### PR TITLE
🐛 fix(ui): offer bob only "auto" in the agent-card model dropdown

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -5094,6 +5094,20 @@ func toolRulesToLaunchCmd(binary, model, backend string, tools *config.ToolsConf
 			cmd += fmt.Sprintf(" --deny-tool='%s'", copilotPattern)
 		}
 		return cmd
+	case bobBackend:
+		// bob must never receive --model. It auto-selects its own model and a
+		// concrete id breaks inference outright: normalizeModelName rewrites a
+		// trailing -<digits> to .<digits> for every non-claude backend, so a
+		// configured claude-sonnet-4-6 reaches bob as claude-sonnet-4.6 — an id
+		// bob's backend does not know — and every prompt dies with "Cannot read
+		// properties of undefined (reading 'maxTokens')". The dashboard offers
+		// bob only the "auto" sentinel, and even that is a display/stored
+		// placeholder: `bob --model auto` is untested and must not be emitted.
+		//
+		// This branch exists because agents with Config.Tools set bypass
+		// bobLaunchCmd entirely and would otherwise land in the default case
+		// below, reintroducing the crash for exactly those agents.
+		return binary
 	default:
 		cmd := binary
 		if model != "" {

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -5094,20 +5094,6 @@ func toolRulesToLaunchCmd(binary, model, backend string, tools *config.ToolsConf
 			cmd += fmt.Sprintf(" --deny-tool='%s'", copilotPattern)
 		}
 		return cmd
-	case bobBackend:
-		// bob must never receive --model. It auto-selects its own model and a
-		// concrete id breaks inference outright: normalizeModelName rewrites a
-		// trailing -<digits> to .<digits> for every non-claude backend, so a
-		// configured claude-sonnet-4-6 reaches bob as claude-sonnet-4.6 — an id
-		// bob's backend does not know — and every prompt dies with "Cannot read
-		// properties of undefined (reading 'maxTokens')". The dashboard offers
-		// bob only the "auto" sentinel, and even that is a display/stored
-		// placeholder: `bob --model auto` is untested and must not be emitted.
-		//
-		// This branch exists because agents with Config.Tools set bypass
-		// bobLaunchCmd entirely and would otherwise land in the default case
-		// below, reintroducing the crash for exactly those agents.
-		return binary
 	default:
 		cmd := binary
 		if model != "" {

--- a/v2/pkg/agent/routing_coverage_test.go
+++ b/v2/pkg/agent/routing_coverage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
@@ -486,6 +487,43 @@ func TestAgentModeTokenTier(t *testing.T) {
 	for mode, want := range cases {
 		if got := mode.TokenTier(); got != want {
 			t.Errorf("mode %d TokenTier=%q want %q", mode, got, want)
+		}
+	}
+}
+
+// TestToolRulesToLaunchCmd_BobNeverGetsModel verifies bob's launch command
+// carries no --model even when a concrete model is configured.
+//
+// Agents with Config.Tools set bypass bobLaunchCmd and build their command
+// here, so without an explicit bob branch they fell into the default case and
+// got `bob --model <id>`. That is the crash: normalizeModelName rewrites a
+// trailing -<digits> to .<digits> for every non-claude backend, so a stored
+// claude-sonnet-4-6 reaches bob as claude-sonnet-4.6 — an id bob's backend
+// does not know — and every prompt dies with "Cannot read properties of
+// undefined (reading 'maxTokens')". bob auto-selects its own model.
+func TestToolRulesToLaunchCmd_BobNeverGetsModel(t *testing.T) {
+	tools := &config.ToolsConfig{}
+	// Includes "auto": the dashboard's only bob option is a display/stored
+	// placeholder, and `bob --model auto` is untested and must not be emitted.
+	for _, model := range []string{"", "auto", "claude-sonnet-4.6", "claude-sonnet-4-6", "granite-3"} {
+		cmd := toolRulesToLaunchCmd("bob", model, bobBackend, tools, false)
+		if strings.Contains(cmd, "--model") {
+			t.Errorf("bob launch cmd with model %q must not contain --model: %q", model, cmd)
+		}
+		if cmd != "bob" {
+			t.Errorf("bob launch cmd with model %q = %q, want %q", model, cmd, "bob")
+		}
+	}
+}
+
+// TestToolRulesToLaunchCmd_OtherBackendsStillGetModel guards the bob branch
+// against swallowing the default case for everything else.
+func TestToolRulesToLaunchCmd_OtherBackendsStillGetModel(t *testing.T) {
+	tools := &config.ToolsConfig{}
+	for _, backend := range []string{"gemini", "goose", "codex"} {
+		cmd := toolRulesToLaunchCmd(backend, "some-model", backend, tools, false)
+		if !strings.Contains(cmd, "--model some-model") {
+			t.Errorf("%s must still receive --model: %q", backend, cmd)
 		}
 	}
 }

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4657,10 +4657,15 @@ func (s *Server) handleBackends(w http.ResponseWriter, r *http.Request) {
 	copilotCLI := s.queryCLIModels("copilot")
 	geminiCLI := s.queryCLIModels("gemini")
 	gooseCLI := s.queryCLIModels("goose")
+	// bob has no discovery source and no usable --model flag: it selects its
+	// own model. Served explicitly so the client never falls through to the
+	// copilot catalog and offers models bob cannot honor (see bobStaticModels).
+	bobCLI := s.queryCLIModels(bobBackendID)
 
 	jsonResponse(w, []map[string]interface{}{
 		{"id": "claude", "name": "Claude Code", "models": claudeCLI.models, "fallback": claudeCLI.fallback},
 		{"id": "copilot", "name": "GitHub Copilot", "models": copilotCLI.models, "fallback": copilotCLI.fallback},
+		{"id": bobBackendID, "name": "bob (IBM bobshell)", "models": bobCLI.models, "fallback": bobCLI.fallback},
 		{"id": "gemini", "name": "Gemini", "models": geminiCLI.models, "fallback": geminiCLI.fallback},
 		{"id": "goose", "name": "Goose", "models": gooseCLI.models, "fallback": gooseCLI.fallback},
 		{"id": "vllm", "name": "vLLM (self-hosted)", "models": vllmModels, "inference": true},

--- a/v2/pkg/dashboard/cli_models.go
+++ b/v2/pkg/dashboard/cli_models.go
@@ -93,6 +93,25 @@ const (
 	// offered (copilotAlwaysIncludeModels) and exempt from model auto-heal.
 	copilotAutoModel = "auto"
 
+	// --- bob (IBM bobshell) ---
+
+	// bobBackendID is the backend id for the IBM bobshell ("bob") CLI. Mirrors
+	// the agent package's unexported bobBackend constant; keep the two in sync.
+	bobBackendID = "bob"
+
+	// bobAutoModel is the ONLY model option offered for bob, and it is a UI
+	// placeholder rather than a flag value: bob selects its own model and has
+	// no working --model flag. Passing one is actively harmful — a concrete id
+	// (e.g. claude-sonnet-4.6) makes every prompt die with "Cannot read
+	// properties of undefined (reading 'maxTokens')", verified live on a spoke,
+	// while the same bob with no --model runs inference fine.
+	//
+	// Unlike copilotAutoModel, this value must NEVER reach a command line:
+	// `bob --model auto` is UNTESTED and presumed unsafe. The launch path
+	// (agent.bobLaunchCmd) omits --model entirely, so "auto" only ever exists
+	// as the stored/displayed selection.
+	bobAutoModel = "auto"
+
 	// --- Gemini ---
 
 	// geminiModelsURL lists models available to a Gemini API key.
@@ -160,6 +179,12 @@ var copilotAlwaysIncludeModels = []string{
 	// launch value, so it must always be offered and must survive auto-heal.
 	copilotAutoModel,
 }
+
+// bobStaticModels is bob's complete model list: exactly one entry, the auto
+// sentinel. bob has no model catalog to discover and no usable --model flag
+// (see bobAutoModel), so offering anything else would invite a selection that
+// either does nothing or breaks inference.
+var bobStaticModels = []string{bobAutoModel}
 
 // codexStaticModels is the maintained list for the OpenAI Codex CLI. Codex only
 // accepts OpenAI models — Claude ids are rejected with a ChatGPT account
@@ -316,6 +341,12 @@ func (s *Server) queryCLIModels(backend string) cliModelResult {
 		// No probe wired yet; the maintained static list is authoritative and
 		// OpenAI-only (Claude ids are rejected by Codex with a ChatGPT account).
 		r = cliModelResult{models: dedupeModels(codexStaticModels), fallback: false}
+	case bobBackendID:
+		// bob picks its own model and exposes no catalog, so there is nothing
+		// to discover. The single auto sentinel is authoritative (not a
+		// fallback) — marking it fallback=true would label it "(common alias,
+		// unverified)" in the dropdown and make it eligible for auto-heal.
+		r = cliModelResult{models: dedupeModels(bobStaticModels), fallback: false}
 	default:
 		r = cliModelResult{models: nil, fallback: true}
 	}
@@ -352,6 +383,8 @@ func cliStaticFallback(backend string) []string {
 		return claudeStaticModels
 	case "codex":
 		return codexStaticModels
+	case bobBackendID:
+		return bobStaticModels
 	case "goose":
 		return []string{"default"}
 	default:

--- a/v2/pkg/dashboard/cli_models_test.go
+++ b/v2/pkg/dashboard/cli_models_test.go
@@ -290,3 +290,48 @@ func TestCLIModelCacheStabilize_PerBackendIsolation(t *testing.T) {
 		t.Fatalf("copilot retention lost, got %v", got)
 	}
 }
+
+// TestQueryCLIModels_BobAutoOnly verifies bob is served EXACTLY one model, the
+// auto sentinel, and that it is authoritative rather than a fallback. bob has
+// no model catalog and no usable --model flag, so any additional option would
+// invite a selection it cannot honor; marking it fallback would label it
+// "(common alias, unverified)" in the dropdown and expose it to auto-heal.
+func TestQueryCLIModels_BobAutoOnly(t *testing.T) {
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.queryCLIModels(bobBackendID)
+	if len(r.models) != 1 {
+		t.Fatalf("bob must be served exactly one model, got %v", r.models)
+	}
+	if r.models[0] != bobAutoModel {
+		t.Fatalf("bob's only model must be %q, got %q", bobAutoModel, r.models[0])
+	}
+	if r.fallback {
+		t.Fatal("bob's single-option list is authoritative, not a fallback")
+	}
+}
+
+// TestCliStaticFallback_BobAutoOnly verifies the static fallback path (used if
+// the discovery switch is ever bypassed) also yields only the auto sentinel,
+// so bob can never be handed the copilot catalog.
+func TestCliStaticFallback_BobAutoOnly(t *testing.T) {
+	got := cliStaticFallback(bobBackendID)
+	if len(got) != 1 || got[0] != bobAutoModel {
+		t.Fatalf("bob static fallback must be exactly [%q], got %v", bobAutoModel, got)
+	}
+}
+
+// TestQueryCLIModels_BobDoesNotAffectOtherBackends guards against a regression
+// where adding bob narrows or empties another CLI backend's catalog.
+func TestQueryCLIModels_BobDoesNotAffectOtherBackends(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	for _, backend := range []string{"claude", "copilot", "gemini", "goose", "codex"} {
+		r := s.queryCLIModels(backend)
+		if len(r.models) == 0 {
+			t.Errorf("%s models must not be empty", backend)
+		}
+		if len(r.models) == 1 && r.models[0] == bobAutoModel {
+			t.Errorf("%s must not inherit bob's single auto option: %v", backend, r.models)
+		}
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5533,8 +5533,22 @@
       { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
       { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' },
     ];
+    // bob (IBM bobshell) selects its own model and has NO usable --model flag:
+    // launching `bob --model <concrete-id>` makes every prompt die with
+    // "Cannot read properties of undefined (reading 'maxTokens')" (verified
+    // live on a spoke), while the same bob with no --model runs inference fine.
+    // So bob gets exactly ONE option — the auto sentinel — and the launch path
+    // (bobLaunchCmd) passes no --model at all. This value is a display/stored
+    // placeholder, never a command-line argument.
+    const BOB_CLI_MODELS = [
+      { value: 'auto', label: 'Auto (bob picks)' },
+    ];
     const KNOWN_MODELS = COPILOT_CLI_MODELS;
-    const CLI_BACKENDS = ['claude', 'copilot', 'gemini', 'goose', 'codex'];
+    // CLI_BACKENDS gates which /api/config/backends entries populate
+    // BACKEND_MODELS. bob is included so its server-served single-option list
+    // is honored; without it bob's entry would be dropped and modelsForBackend
+    // would fall through to the copilot catalog.
+    const CLI_BACKENDS = ['claude', 'copilot', 'bob', 'gemini', 'goose', 'codex'];
     // BACKEND_MODELS holds the live-discovered model list for every backend
     // (inference AND cli), keyed by backend id. INFERENCE_MODELS is kept as
     // an alias to the same object for backward compatibility with existing
@@ -5548,6 +5562,7 @@
     const CLI_FALLBACK_MODELS = {
       claude: CLAUDE_CLI_MODELS,
       copilot: COPILOT_CLI_MODELS,
+      bob: BOB_CLI_MODELS,
       gemini: COPILOT_CLI_MODELS,
       goose: COPILOT_CLI_MODELS,
       codex: CODEX_CLI_MODELS,
@@ -5558,18 +5573,43 @@
       if (INFERENCE_BACKENDS.includes(b) || _configuredGateways.includes(b)) return b + ' ⚡';
       return b;
     }
-    // Auto-select sentinels: special --model VALUES that tell a CLI to pick the
-    // model itself rather than pin a concrete id. They flow verbatim through the
-    // launch path's `--model <value>` but are never in a discovered model
-    // catalog, so they must be exempted from model auto-heal. Copilot: `auto`.
-    const AUTO_MODEL_SENTINELS = { copilot: ['auto'] };
+    // Auto-select sentinels: values meaning "let the CLI pick its own model"
+    // rather than pinning a concrete id. They are never in a discovered model
+    // catalog, so they must be exempted from model auto-heal — otherwise
+    // reconcileModelsAfterDiscovery rewrites them to a concrete discovered id.
+    //
+    // How each reaches the CLI differs, and the difference is load-bearing:
+    //   - copilot: `auto` flows VERBATIM through the launch path as
+    //     `--model auto`. It is a real, supported Copilot CLI flag value.
+    //   - bob: `auto` is NEVER passed on the command line. bob has no working
+    //     --model flag (a concrete id breaks inference with "Cannot read
+    //     properties of undefined (reading 'maxTokens')"), and `bob --model
+    //     auto` is untested/presumed unsafe. bobLaunchCmd omits --model
+    //     entirely; `auto` exists only as the stored/displayed selection.
+    const AUTO_MODEL_SENTINELS = { copilot: ['auto'], bob: ['auto'] };
     function isAutoModelSentinel(backend, model) {
       return (AUTO_MODEL_SENTINELS[backend] || []).includes(model);
     }
+    // Backends whose model list is a single fixed option, so there is nothing
+    // for a user to choose and nothing meaningful to store per agent.
+    const SINGLE_OPTION_BACKENDS = ['bob'];
     function modelsForBackend(backend) {
+      // Single-option backends are authoritative and never overridden by
+      // discovery: even if the server (or a stale cached response) offered a
+      // longer list, bob cannot honor a model choice, so the local one-option
+      // list wins. This also guarantees bob never reaches the copilot fallback.
+      if (SINGLE_OPTION_BACKENDS.includes(backend)) {
+        return CLI_FALLBACK_MODELS[backend] || [];
+      }
       const discovered = BACKEND_MODELS[backend];
       if (discovered && discovered.length) return discovered;
       if (INFERENCE_BACKENDS.includes(backend)) return [];
+      // NOTE (latent trap): any UNKNOWN backend still falls through to the
+      // copilot catalog and is offered models it may not support — the exact
+      // bug this change fixes for bob. Left as-is deliberately: gateway
+      // backends rely on a non-empty first paint, so narrowing it needs its
+      // own change. Every known CLI backend is now explicit in
+      // CLI_FALLBACK_MODELS, so nothing shipped reaches this line by accident.
       return CLI_FALLBACK_MODELS[backend] || COPILOT_CLI_MODELS;
     }
     // _modelIdMatches: an agent's stored model may lack (or carry) the
@@ -5592,7 +5632,17 @@
     // the dropdown never silently drops an agent's active selection.
     function modelOptionsHtml(backend, currentModel) {
       const models = modelsForBackend(backend);
-      const cur = currentModel || '';
+      // SINGLE_OPTION_BACKENDS offer exactly one valid selection, so an agent's
+      // stored model carries no information — and bob agents created before
+      // this change hold a stale concrete id (e.g. "claude-sonnet-4.6") that
+      // bob cannot honor. Substituting the sole option as the "current" value
+      // both preselects it (with the usual " ▾" caret) and starves the
+      // "(current)" branch below, which would otherwise resurrect the stale id
+      // as a pinned, preselected option.
+      const soleOption = SINGLE_OPTION_BACKENDS.includes(backend) && models.length === 1
+        ? models[0].value
+        : '';
+      const cur = soleOption || currentModel || '';
       let matched = false;
       const opts = models.map(m => {
         const sel = !matched && _modelIdMatches(m.value, cur);


### PR DESCRIPTION
## Problem

bob (IBM bobshell) **auto-selects its own model and has no usable `--model` flag**, but the spoke dashboard still invited users to pick one — from Copilot's catalog.

Root cause: `bob` was absent from `CLI_FALLBACK_MODELS`, so `modelsForBackend()` hit its trailing `|| COPILOT_CLI_MODELS` and silently served Copilot's model list for bob's agent card.

The resulting selection was not merely inert — it was **harmful**. `normalizeModelName` rewrites a trailing `-<digits>` to `.<digits>` for every non-claude backend, so a stored `claude-sonnet-4-6` reached bob as `claude-sonnet-4.6`, an id bob's backend does not know. Every prompt then died with:

```
🛑 Cannot read properties of undefined (reading 'maxTokens')
```

Verified live on a spoke: the same bob with **no** `--model` runs inference fine.

This is the **UI counterpart** to #2249 (which removes `--model` from `bobLaunchCmd`).

## Changes

### Client — `v2/pkg/dashboard/static/index.html`
- **`BOB_CLI_MODELS`**: exactly one option, the `auto` sentinel.
- `bob` added to **`CLI_FALLBACK_MODELS`** and to **`CLI_BACKENDS`** — the latter matters because `fetchBackendsConfig()` filters on `CLI_BACKENDS`, so without it the server's bob entry would be silently discarded.
- **`SINGLE_OPTION_BACKENDS`** + a `modelsForBackend()` short-circuit: bob's one-option list is authoritative and is never overridden by discovery, so **bob can never reach the copilot fallback** even if a stale/poisoned cached response supplies a longer list.
- **`AUTO_MODEL_SENTINELS`** gains `bob: ['auto']` — load-bearing: it stops model auto-heal from rewriting `auto` back to a concrete discovered id and re-breaking the launch.
- **`modelOptionsHtml()`**: for single-option backends the sole option is substituted as the "current" value, so a pre-existing bob agent's stale concrete model (katamari's scanner logs `"model":"claude-sonnet-4.6"`) renders as `auto` rather than being resurrected by the unmatched-current `"<id> (current) ▾"` branch.

### Server — `v2/pkg/dashboard/cli_models.go`, `api.go`
- `bobStaticModels = ["auto"]`, served **authoritatively** (`fallback=false`) so it is neither labeled `(common alias, unverified)` in the dropdown nor made eligible for auto-heal. Wired into `queryCLIModels` + `cliStaticFallback`, and `bob` added to `handleBackends` so **client and server agree**.

### Launch path — `v2/pkg/agent/manager.go`
`toolRulesToLaunchCmd` gains a `bob` branch returning the bare binary.

**This is a second, separate bug that #2249 does not fix**: agents with `Config.Tools` set bypass `bobLaunchCmd` entirely and were landing in the `default:` case, which appends `--model` — reintroducing the crash for exactly those agents. The edit is at line ~4994, well clear of #2249's hunks (~1018 and ~3686), so the two should not conflict.

`auto` is a **display/stored placeholder only** — `bob --model auto` is untested and is never emitted.

## Consistency note (requirement #3)

The sentinel comment previously claimed these values "flow verbatim through the launch path's `--model <value>`". That is true for copilot but **must not** be true for bob. The comment is corrected, and the code now guarantees bob receives **no `--model` flag at all** on both launch paths.

## Hub dashboard

`v2/pkg/hub/saas.go` renders **no model selector** and contains no bob reference (`grep` for `modelsForBackend` / `modelOptionsHtml` / `*_CLI_MODELS` / `bob` → 0 hits), so no change is needed there. The file was not touched.

## Latent trap (noted, deliberately not changed)

`modelsForBackend()` still ends in `|| COPILOT_CLI_MODELS`, so any **unknown** backend is offered Copilot's catalog — the exact class of bug fixed here for bob. Narrowing it was left out of scope because gateway backends rely on a non-empty list on first paint; a comment now flags it. Every known CLI backend is explicit in `CLI_FALLBACK_MODELS`, so nothing shipped reaches that line by accident.

## Verification

**Ran, not assumed:**
- `go build ./...`, `go vet ./pkg/dashboard/... ./pkg/agent/...` — clean.
- `gofmt` clean on all touched files. (`manager.go` shows pre-existing alignment drift in struct blocks I never touched; left alone per the no-wildcard-sweep rule.)
- New Go tests pass: `TestQueryCLIModels_BobAutoOnly`, `TestCliStaticFallback_BobAutoOnly`, `TestQueryCLIModels_BobDoesNotAffectOtherBackends`, `TestToolRulesToLaunchCmd_BobNeverGetsModel`, `TestToolRulesToLaunchCmd_OtherBackendsStillGetModel`.
- **JS verified against the real extracted source** (not a stale extraction — grepped the extraction to confirm the new symbols are present), 40/40 behavioral assertions pass: `modelsForBackend('bob')` returns exactly one `auto` option; bob resists a poisoned `BACKEND_MODELS['bob']`; `isAutoModelSentinel('bob','auto')` is true; four different stale concrete ids each render exactly one `auto` option with no `(current)` resurrection; claude/copilot/gemini/goose/codex dropdowns byte-identical.
- **Brace/paren/bracket balance identical to clean `origin/v2`** (`{:5, (:19, [:2` both sides) — the diff introduces zero imbalance.
- `pkg/dashboard` suite: 18 failures, **the identical set by name on clean `origin/v2`** — all pre-existing GitHub-auth tests, 0 new.
- `pkg/agent` full suite does not complete within 240s **on clean `origin/v2` too** — pre-existing slowness, not caused by this change; targeted tests pass.

## Porting

**mk / dd / v3 need this ported.**