### PR TITLE
✨ feat(agent): route PR creation through hive-open-pr (App-bot authorship, hard switch)

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -132,6 +132,26 @@ fi
 ACMM_LEVEL="${HIVE_ACMM_LEVEL:-0}"
 ADVISORY_ISSUE="${HIVE_ADVISORY_ISSUE:-}"
 
+# ── Route `gh pr create` through the hive so the PR is App-bot-authored ──
+# An agent running `gh pr create` would author the PR as whatever identity the gh
+# token / Copilot login resolves to (the login USER, not the App bot). Redirect
+# to hive-open-pr, which drops a request file the hive's watcher opens with the
+# App installation token → authored by "<slug>[bot]". The watcher enforces the
+# SAME ACMM write-gate + forge-resistance, so this changes WHO opens the PR, not
+# WHAT an agent is allowed to do. Contributors are EXEMPT: they fork and PR under
+# their OWN identity by design, so their gh pr create must pass through unchanged.
+if [ "$subcmd" = "pr" ] && [ "$action" = "create" ] && [ "${HIVE_CONTRIBUTOR_MODE:-}" != "true" ]; then
+  if command -v hive-open-pr >/dev/null 2>&1; then
+    # Pass the original gh-pr-create flags straight through — hive-open-pr accepts
+    # the same --repo/--head/--base/--title/--body shape and ignores the rest.
+    exec hive-open-pr "$@"
+  fi
+  # If the wrapper somehow isn't installed, fail loud rather than silently
+  # opening the PR as the wrong identity (hard switch: no gh-pr-create fallback).
+  echo "⛔ hive-open-pr not found — cannot open a PR as the App bot. Do NOT fall back to gh pr create (would author as the login user). Report this to the operator." >&2
+  exit 1
+fi
+
 # Helper: capture advisory finding to JSONL for governor digest
 _capture_advisory_finding() {
   local _adv_title="" _adv_body="" _next_is_title=false _next_is_body=false

--- a/bin/hive-open-pr.sh
+++ b/bin/hive-open-pr.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# hive-open-pr.sh — open a PR via the HIVE (App bot), not `gh pr create`.
+#
+# Agents call this INSTEAD of `gh pr create`. It writes a request file that the
+# hive's PR-request watcher picks up and opens the PR with the App installation
+# token — so the PR is authored by the App bot ("<slug>[bot]"), never the
+# Copilot login user. The watcher enforces the SAME per-agent ACMM write-gate +
+# forge-resistance as the direct path (see AuthorizePROpen); this wrapper adds
+# no privilege, it only changes WHO opens the PR.
+#
+# It runs AS THE AGENT (in the agent's tmux session, under the agent's UID), so
+# the request file it writes is owned by that agent's UID — the forge-resistance
+# anchor. It accepts the gh-pr-create flags agents already use.
+#
+# Usage (drop-in for the common gh pr create shape):
+#   hive-open-pr --repo <owner/repo> --head <branch> [--base <branch>] \
+#                --title "<title>" --body "<body>"
+#   # --head defaults to the current git branch; --base defaults to main.
+#
+# On success it prints the request path and returns 0. The PR opens
+# asynchronously (within one watcher tick); poll the .result.json next to the
+# request, or just look for the PR — this is intentional: the agent's job is to
+# REQUEST the PR, the hive owns opening it.
+
+set -euo pipefail
+
+REQ_DIR="/var/run/hive-metrics/pr-requests"
+
+REPO=""; HEAD=""; BASE="main"; TITLE=""; BODY=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)  REPO="$2"; shift 2;;
+    --head)  HEAD="$2"; shift 2;;
+    --base)  BASE="$2"; shift 2;;
+    --title) TITLE="$2"; shift 2;;
+    --body)  BODY="$2"; shift 2;;
+    --repo=*)  REPO="${1#*=}"; shift;;
+    --head=*)  HEAD="${1#*=}"; shift;;
+    --base=*)  BASE="${1#*=}"; shift;;
+    --title=*) TITLE="${1#*=}"; shift;;
+    --body=*)  BODY="${1#*=}"; shift;;
+    # Tolerate flags gh accepts but we don't need; ignore their value if present.
+    --draft|--fill|--web|--no-maintainer-edit) shift;;
+    *) shift;;
+  esac
+done
+
+# Default head to the current branch if not given.
+if [ -z "$HEAD" ]; then
+  HEAD="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+fi
+if [ -z "$REPO" ] || [ -z "$HEAD" ] || [ -z "$TITLE" ]; then
+  echo "hive-open-pr: --repo, --head (or a current branch), and --title are required" >&2
+  exit 2
+fi
+
+# Identify the requesting agent. Prefer the UID map (the watcher re-derives the
+# owner from the FILE's UID anyway, so this is informational + a nicer log line);
+# fall back to HIVE_AGENT.
+AGENT="${HIVE_AGENT:-agent}"
+UID_NOW="$(id -u 2>/dev/null || echo 0)"
+UID_MAP="/var/run/hive/uid-map.json"
+if [ "$UID_NOW" -ge 2001 ] && [ -f "$UID_MAP" ] && command -v python3 >/dev/null 2>&1; then
+  MAPPED="$(python3 -c "
+import json,sys
+try:
+    m=json.load(open('$UID_MAP')).get('agents',{})
+    for n,u in m.items():
+        if u==$UID_NOW: print(n); break
+except Exception: pass
+" 2>/dev/null || true)"
+  [ -n "$MAPPED" ] && AGENT="$MAPPED"
+fi
+
+mkdir -p "$REQ_DIR" 2>/dev/null || true
+
+# Write the request as valid JSON. Use python for correct escaping of title/body.
+REQ_FILE="$REQ_DIR/${AGENT}-$(date +%s%N).json"
+if command -v python3 >/dev/null 2>&1; then
+  python3 - "$REQ_FILE" "$REPO" "$HEAD" "$BASE" "$TITLE" "$BODY" "$AGENT" <<'PY'
+import json, sys
+path, repo, head, base, title, body, agent = sys.argv[1:8]
+json.dump({"repo":repo,"head":head,"base":base,"title":title,"body":body,"agent":agent},
+          open(path,"w"))
+PY
+else
+  # Minimal fallback escaper (no python): escape backslash and double-quote.
+  esc() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+  printf '{"repo":"%s","head":"%s","base":"%s","title":"%s","body":"%s","agent":"%s"}\n' \
+    "$(esc "$REPO")" "$(esc "$HEAD")" "$(esc "$BASE")" "$(esc "$TITLE")" "$(esc "$BODY")" "$(esc "$AGENT")" \
+    > "$REQ_FILE"
+fi
+
+echo "hive-open-pr: requested PR on $REPO ($HEAD -> $BASE) as the App bot"
+echo "hive-open-pr: request $REQ_FILE (the hive opens the PR within ~10s; result appears at ${REQ_FILE%.json}.result.json)"

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -159,11 +159,12 @@ COPY v2/deploy/data/ /opt/hive/seed-data/
 COPY v2/deploy/ttyd-tmux.sh /usr/local/bin/ttyd-tmux.sh
 COPY v2/deploy/hive-panes.sh /usr/local/bin/hive-panes
 COPY bin/gh-app-token.sh bin/hive-config.sh bin/agent-launch.sh bin/git-credential-hive.sh /usr/local/bin/
+COPY bin/hive-open-pr.sh /usr/local/bin/hive-open-pr
 COPY bin/gh-wrapper.sh /usr/local/bin/gh
 COPY config/backends.conf /usr/local/etc/hive/backends.conf
 RUN chmod +x /usr/local/bin/ttyd-tmux.sh /usr/local/bin/hive-panes /usr/local/bin/gh-app-token.sh \
     /usr/local/bin/hive-config.sh /usr/local/bin/agent-launch.sh /usr/local/bin/gh \
-    /usr/local/bin/git-credential-hive.sh
+    /usr/local/bin/git-credential-hive.sh /usr/local/bin/hive-open-pr
 
 # --- Nous framework (strategist experiment engine) ---
 RUN (apt-get update && apt-get install -y --no-install-recommends \

--- a/v2/pkg/policies/defaults/scanner-automerge.md
+++ b/v2/pkg/policies/defaults/scanner-automerge.md
@@ -70,7 +70,9 @@ Steps:
 7. git add the changed files
 8. git commit -s -m "[scanner] fix: <short description covering all issues>"
 9. git push -u origin scanner/fix-<lowest-number>
-10. gh pr create --repo <org>/<repo> --title "[scanner] fix: <short description>" --body "Fixes #<n1>, Fixes #<n2>, Fixes #<n3>" (repeat Fixes keyword for each issue)
+10. Open the PR with **`hive-open-pr`** (the hive opens it as the App bot):
+    `hive-open-pr --repo <org>/<repo> --head scanner/fix-<lowest-number> --title "[scanner] fix: <short description>" --body "Fixes #<n1>, Fixes #<n2>, Fixes #<n3>"` (repeat Fixes keyword for each issue).
+    Do NOT use the GitHub MCP `create_pull_request` / `create_pull_request_with_copilot`, and do NOT run raw `gh pr create` — both author the PR as the login user. `hive-open-pr` is the only sanctioned way to open a PR; the hive opens it with the App token so it is authored by the App bot. `gh pr create` is auto-redirected to `hive-open-pr` for you, but call `hive-open-pr` directly.
 11. git worktree remove /tmp/scanner-fix-<lowest-number>
 12. Return immediately — do NOT wait for CI, do NOT merge, do NOT run build or lint
 ```

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -617,6 +617,13 @@ func (s *Scheduler) ghAuthInstructions(agentName string) string {
 - Writes are authored by the App bot identity, not a personal account. Do not
   set git user.name/user.email to a human, and do not pass 'gh pr create' or
   'git commit' an explicit --author: let the App identity stand.
+- To OPEN A PULL REQUEST, use ` + "`hive-open-pr`" + ` — the hive opens it with the
+  App token so it is authored by the App bot ("<slug>[bot]"), never the login user:
+    hive-open-pr --repo <org>/<repo> --head <your-branch> --title "<title>" --body "<body with Fixes #N>"
+  Do NOT open PRs with the GitHub MCP (create_pull_request / create_pull_request_with_copilot)
+  or raw 'gh pr create' — those author the PR as the Copilot login user. 'gh pr create'
+  is auto-redirected to hive-open-pr, but prefer calling hive-open-pr directly.
+  (Push your branch first; hive-open-pr requests the PR, the hive opens it within ~10s.)
 - git push / git fetch: run them normally. A credential helper supplies the
   App-scoped push token automatically. Do NOT export GH_TOKEN for git and do
   NOT use HIVE_GITHUB_TOKEN (it is read-only; overriding breaks pushes).


### PR DESCRIPTION
## Summary

Final cutover so **agent PRs are authored by the App bot**, not the Copilot login user. Builds on the proven, secure watcher (#2247 mechanism, #2250 ACMM authz).

## Changes
- **`hive-open-pr`** (`bin/hive-open-pr.sh` → `/usr/local/bin/hive-open-pr`): a `gh pr create`-shaped wrapper that runs **as the agent** and drops a request file (owned by the agent's UID — the forge-resistance anchor) into the watcher dir. The hive opens the PR with the **App token** → `<slug>[bot]`.
- **`gh-wrapper.sh`**: `gh pr create` is redirected to `hive-open-pr` for agents. **Contributors are exempt** (they fork+PR under their own identity by design). **Hard switch** — if `hive-open-pr` is missing it fails loud rather than falling back to `gh pr create` (which would author as the login user).
- **Policy**: the shared `${GH_AUTH}` block (every agent) + `scanner-automerge` instruct `hive-open-pr` and explicitly forbid the GitHub MCP `create_pull_request` / `create_pull_request_with_copilot` and raw `gh pr create`.

## Security / policy
No added privilege — the watcher enforces the same **ACMM write-gate + forge-resistance** as the direct path (#2250). Only **who opens the PR** changes.

## Verified
The watcher path is proven end-to-end on console: PR #21988 was opened by `kubestellar-hive[bot]` via exactly this mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)