### PR TITLE
🐛 fix(hub): pr-requests dir must be group-writable so agents can open PRs (cutover blocker)

### DIFF
--- a/v2/pkg/github/pr_request_watcher.go
+++ b/v2/pkg/github/pr_request_watcher.go
@@ -102,6 +102,18 @@ func (c *Client) StartPRRequestWatcher(ctx context.Context, authz PRRequestAutho
 			slog.String("dir", prRequestDir()), slog.String("error", err.Error()))
 		return
 	}
+	// Agents (UID >= 2001, in the shared "node" group) must be able to DROP request
+	// files here — hive-open-pr runs AS the agent. MkdirAll is masked by umask to
+	// 0755 (not group-writable), so an agent's write gets EACCES and, under the
+	// hard switch, its PR silently fails to open. Force group-write + setgid (like
+	// /data/beads) so agent-written files inherit the node group and the dir is
+	// writable by every agent. The forge-check still holds: the watcher reads each
+	// file's OWNING UID, which is the agent that wrote it — group-writability lets
+	// them write, it does not let one agent forge another's ownership.
+	if err := os.Chmod(prRequestDir(), 0o2775); err != nil {
+		c.logger.Warn("pr-request watcher: could not set group-writable perms on request dir; agents may be unable to open PRs",
+			slog.String("dir", prRequestDir()), slog.String("error", err.Error()))
+	}
 	go func() {
 		t := time.NewTicker(prRequestPollInterval)
 		defer t.Stop()


### PR DESCRIPTION
## Critical follow-up to the PR cutover (#2254)

Agents run `hive-open-pr` **as the agent** (UID ≥ 2001, `node` group) to drop a request file, but the watcher created `/var/run/hive-metrics/pr-requests` via `MkdirAll(0o777)` — which umask masks to **0755, not group-writable**. Every agent write gets **EACCES**, and under the hard switch (no `gh pr create` fallback) the PR **silently fails to open**.

**Found by testing the cutover as the scanner agent on console** — `PermissionError: [Errno 13] Permission denied`.

## Fix
`Chmod(dir, 0o2775)` (group-write + setgid, like `/data/beads`) after creating it, so every agent can drop a request and files inherit the `node` group.

**Forge-resistance unaffected**: the watcher authorizes on each file's **owning UID** (the agent that wrote it). Group-writability lets agents write; it does not let one agent forge another's ownership.

## Verified
With the dir chmod'd on console, `hive-open-pr` as the scanner agent → request opened → **PR #22035 authored by `kubestellar-hive[bot]`** (full ACMM-gated path). Without this fix, a hive on the cutover image opens **no agent PRs at all**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)