### PR TITLE
🐛 fix(agent): make tmux pane inherit session env so bob can authenticate

### DIFF
--- a/v2/pkg/agent/bob_settings.go
+++ b/v2/pkg/agent/bob_settings.go
@@ -21,6 +21,9 @@ const (
 	// bobKeyOtherReadBit is `o+r`. Also sufficient for the agent to read, but
 	// it means the secret is world-readable, which is worth flagging.
 	bobKeyOtherReadBit fs.FileMode = 0o004
+	// bobStateGroupWriteBit is `g+w` — the bit that lets an agent UID create
+	// or replace files inside a dev:node-owned bob state directory.
+	bobStateGroupWriteBit fs.FileMode = 0o020
 )
 
 // verifyBobKeyReadable checks that the resolved bob key file is readable BY
@@ -88,6 +91,81 @@ const bobSharedHome = "/data/home"
 // bobSettingsPath returns the shared bob settings file for a given HOME.
 func bobSettingsPath(home string) string {
 	return filepath.Join(home, config.BobSettingsRelPath)
+}
+
+// verifyBobStateDirsWritable probes, AS THE AGENT UID, every directory bob
+// writes to during startup, and logs an actionable error for each one that is
+// not writable.
+//
+// This exists because bob reports these failures only inside its own TUI —
+// "There was an error saving your latest settings changes." and "Failed to
+// initialize logger:" — which nobody sees unless they are attached to that
+// pane. Nothing reaches the hive log, so a genuinely unwritable directory is
+// invisible to an operator reading `kubectl logs` and gets misdiagnosed as a
+// read-only filesystem. The same false-positive trap as verifyBobKeyReadable
+// applies: the hive process runs as dev and OWNS these directories, so any
+// check it performs on its own behalf succeeds while the agent UID still gets
+// EACCES. The probe therefore tests the agent's group access explicitly rather
+// than calling os.Access as dev.
+//
+// Advisory only — it never blocks a launch. bob degrades rather than dying
+// when these writes fail (ephemeral installation ID, no chat recording), so a
+// probe failure is a reason to log loudly, not to refuse to start the agent.
+// Logs paths, modes and UIDs only — never any file contents.
+//
+// Returns the directories found unwritable, so callers and tests can assert on
+// the outcome rather than scraping log output. A nil result means every
+// existing state dir is writable by the agent UID.
+func (m *Manager) verifyBobStateDirsWritable(agentName, home, workDir string, uid int) []string {
+	if uid <= 0 {
+		return nil
+	}
+	var unwritable []string
+
+	// The directories bob creates or writes during startup:
+	//   - $HOME/.bob            settings.json, trustedFolders.json,
+	//                           installation_id, tmp/ (chat recordings)
+	//   - <workdir>/.bob        per-agent .bob-errors/ logger target, which is
+	//                           what "Failed to initialize logger:" refers to
+	probeDirs := []string{
+		filepath.Dir(bobSettingsPath(home)),
+		filepath.Join(workDir, config.BobStateDirName),
+	}
+
+	for _, dir := range probeDirs {
+		info, err := os.Stat(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// Not an error on its own: bob creates these with
+				// mkdirSync({recursive:true}) on first use. It only matters
+				// whether the PARENT is writable, which the next launch's
+				// probe reports once the dir exists.
+				continue
+			}
+			m.logger.Warn("bob state dir not statable; bob may fail to persist settings or initialize its logger",
+				"agent", agentName, "dir", dir, "uid", uid, "error", err)
+			continue
+		}
+		if !info.IsDir() {
+			m.logger.Warn("bob state path exists but is not a directory",
+				"agent", agentName, "path", dir, "uid", uid)
+			continue
+		}
+
+		// The agent UID reaches these dev-owned dirs through group `node`, so
+		// group write+execute is what actually decides whether bob can create
+		// or replace a file inside. Write alone is not enough — without
+		// execute the path cannot be traversed to open the file by name.
+		mode := info.Mode().Perm()
+		if mode&bobStateGroupWriteBit == 0 || mode&bobKeyGroupExecBit == 0 {
+			m.logger.Error("bob state dir is not writable by the agent UID; bob will report \"error saving your latest settings changes\" and \"Failed to initialize logger\"",
+				"agent", agentName, "dir", dir,
+				"mode", fs.FileMode(mode).String(), "uid", uid,
+				"remedy", "chmod 770 "+dir+" and ensure it is group-owned by node")
+			unwritable = append(unwritable, dir)
+		}
+	}
+	return unwritable
 }
 
 // ensureBobAuthSettings makes hive the owner of the `security.auth` block in

--- a/v2/pkg/agent/bob_settings_test.go
+++ b/v2/pkg/agent/bob_settings_test.go
@@ -366,3 +366,96 @@ func TestBobKeyFilePathNoResolver(t *testing.T) {
 		t.Errorf("bobKeyFilePath() = %q with no resolver, want empty", got)
 	}
 }
+
+// TestVerifyBobStateDirsWritable pins the probe behind issue #2253: bob
+// reports "error saving your latest settings changes" and "Failed to
+// initialize logger:" only inside its own TUI, so hive must detect the
+// underlying permission problem itself.
+//
+// The modes are the real ones: 0770 is what /data/home/.bob actually carries
+// in production (drwxrwx--- dev:node), and 0700 is the failure mode where the
+// dir is owned by dev but carries no group bits, which is exactly what locks
+// out an agent UID that reaches it through group `node`.
+func TestVerifyBobStateDirsWritable(t *testing.T) {
+	tests := []struct {
+		name           string
+		mode           os.FileMode
+		uid            int
+		wantUnwritable bool
+	}{
+		{"production-correct 0770 is writable", 0o770, 2004, false},
+		{"0700 locks out the agent UID", 0o700, 2004, true},
+		{"0750 is readable but not writable", 0o750, 2004, true},
+		{"0760 lacks group traverse", 0o760, 2004, true},
+		{"root agent bypasses the check", 0o700, 0, false},
+		{"unset uid bypasses the check", 0o700, -1, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			bobDir := filepath.Dir(bobSettingsPath(home))
+			if err := os.MkdirAll(bobDir, 0o770); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.Chmod(bobDir, tc.mode); err != nil {
+				t.Fatalf("chmod: %v", err)
+			}
+			// Restore traversal so t.TempDir cleanup can remove the tree.
+			t.Cleanup(func() { _ = os.Chmod(bobDir, 0o770) })
+
+			m := &Manager{logger: discardLogger()}
+			// workDir points at a non-existent path on purpose: a state dir
+			// bob has not created yet must NOT be reported, since bob creates
+			// it recursively on first use.
+			got := m.verifyBobStateDirsWritable("tester", home,
+				filepath.Join(t.TempDir(), "agents", "tester"), tc.uid)
+
+			if gotUnwritable := len(got) > 0; gotUnwritable != tc.wantUnwritable {
+				t.Errorf("verifyBobStateDirsWritable() unwritable=%v (%v), want %v",
+					gotUnwritable, got, tc.wantUnwritable)
+			}
+		})
+	}
+}
+
+// TestVerifyBobStateDirsWritableIgnoresMissingDirs covers the fresh-PVC case:
+// neither state dir exists yet. bob creates them with mkdirSync recursive on
+// first use, so a missing dir is not a fault and must not be reported.
+func TestVerifyBobStateDirsWritableIgnoresMissingDirs(t *testing.T) {
+	m := &Manager{logger: discardLogger()}
+	got := m.verifyBobStateDirsWritable("tester", t.TempDir(),
+		filepath.Join(t.TempDir(), "nope"), 2004)
+	if len(got) != 0 {
+		t.Errorf("verifyBobStateDirsWritable() = %v for missing dirs, want none", got)
+	}
+}
+
+// TestVerifyBobStateDirsWritableFlagsWorkspaceDir pins that the per-agent
+// workspace .bob (the "Failed to initialize logger:" target, seen in
+// production at /data/agents/<name>/.bob/.bob-errors/) is probed too, not just
+// the shared $HOME/.bob.
+func TestVerifyBobStateDirsWritableFlagsWorkspaceDir(t *testing.T) {
+	home := t.TempDir()
+	homeBob := filepath.Dir(bobSettingsPath(home))
+	if err := os.MkdirAll(homeBob, 0o770); err != nil {
+		t.Fatalf("mkdir home .bob: %v", err)
+	}
+	// MkdirAll's mode is masked by umask, so set the production mode
+	// explicitly — this dir must be the WRITABLE one for the assertion below
+	// to prove the workspace dir is probed independently.
+	if err := os.Chmod(homeBob, 0o770); err != nil {
+		t.Fatalf("chmod home .bob: %v", err)
+	}
+	workDir := t.TempDir()
+	stateDir := filepath.Join(workDir, config.BobStateDirName)
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir workspace .bob: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(stateDir, 0o770) })
+
+	m := &Manager{logger: discardLogger()}
+	got := m.verifyBobStateDirsWritable("tester", home, workDir, 2004)
+	if len(got) != 1 || got[0] != stateDir {
+		t.Errorf("verifyBobStateDirsWritable() = %v, want [%s]", got, stateDir)
+	}
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -681,6 +681,39 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 		_ = m.tmuxCmd(agent, "set-environment", "-t", agent.tmuxSession, "-u", "GITHUB_TOKEN").Run()
 	}
 
+	// Every set-environment above updated the SESSION environment, which tmux
+	// only copies into processes it forks AFTERWARDS. `new-session -d` already
+	// forked this session's pane shell, so that bash predates all of it and
+	// will never see a single one of those variables — including the Secret
+	// pairs (BOBSHELL_API_KEY, CLAUDE_CODE_OAUTH_TOKEN) that buildEnvPrefix
+	// deliberately keeps off the command line. Every CLI launched by send-keys
+	// into this pane therefore inherits an environment missing exactly the
+	// credentials that are only delivered this way, which is why bob still
+	// prompted for an API key with the key demonstrably present in the session
+	// env (`show-environment` listed it; no bob /proc/<pid>/environ had it).
+	//
+	// Respawning the pane replaces that stale shell with a fresh one forked by
+	// the server after the environment was populated, so it inherits the full
+	// set. This is the only ordering that works in all three states the launch
+	// path actually hits: cold server, warm server with other sessions, and a
+	// session recreated by killSessionForRelaunch. Passing the vars in the
+	// environment of the `tmux new-session` client process does NOT work once
+	// the server is already running (the server, not the client, forks the
+	// pane), and `set-environment -g` before `new-session` cannot run at all on
+	// a cold server ("error connecting to <socket>") — both verified.
+	//
+	// Secrets stay off the command line: respawn-pane takes no arguments here,
+	// so nothing is typed into the pane or visible in `ps`.
+	respawnArgs := []string{"respawn-pane", "-k", "-t", agent.tmuxSession}
+	if err := m.tmuxCmd(agent, respawnArgs...).Run(); err != nil {
+		// Non-fatal: the pane still exists with the pre-env shell. Log it so a
+		// later "CLI cannot see its credentials" report has a breadcrumb
+		// instead of being silent, then continue — a degraded session is still
+		// better than refusing to launch the agent at all.
+		m.logger.Warn("tmux pane respawn failed; pane shell will not inherit session env (CLI may prompt for credentials)",
+			"name", agent.Name, "session", agent.tmuxSession, "error", err)
+	}
+
 	m.logger.Info("tmux session created", "name", agent.Name, "session", agent.tmuxSession, "uid", agent.UID, "socket", agent.tmuxSocket)
 
 	// Attach pluk publisher if available — streams structured events
@@ -918,6 +951,10 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		// Advisory only: the Secret-mounted copy may still be readable, so this
 		// never blocks a launch that might succeed.
 		m.verifyBobKeyReadable(agent.Name, m.bobKeyFilePath(), agent.UID)
+		// bob reports unwritable state dirs only inside its own TUI, so probe
+		// them here as the agent UID and surface any failure in the hive log.
+		// Advisory, like the key probe above — never blocks a launch.
+		_ = m.verifyBobStateDirsWritable(agent.Name, bobSharedHome, m.workDir+"/"+agent.Name, agent.UID)
 	}
 
 	launchCmd := binary

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -948,6 +948,13 @@ const (
 
 	// BobSettingsDirMode matches the observed /data/home/.bob (drwxrwx---).
 	BobSettingsDirMode = 0o770
+
+	// BobStateDirName is the per-workspace state directory bob creates inside
+	// the directory it is launched in (in addition to the shared $HOME/.bob).
+	// Its .bob-errors/ subdirectory is the logger target behind bob's
+	// "Failed to initialize logger:" message, observed in production at
+	// /data/agents/<name>/.bob/.bob-errors/errors-YYYY-MM-DD.log.
+	BobStateDirName = ".bob"
 )
 
 // BobConfig configures the IBM bobshell ("bob") CLI backend. Only the


### PR DESCRIPTION
## Summary

Investigated #2253. The reported symptoms are real, but the diagnosis in the issue is **not** what the container shows. The actual defect is a tmux environment-ordering bug that prevents bob from ever authenticating; the "read-only folder" framing does not hold up.

`Refs #2253` rather than `Fixes` — see *What remains* below.

## What the reporter hypothesized vs. what is actually true

| Hypothesis in the issue | Verdict | Evidence |
|---|---|---|
| Bob's config dir is on a read-only volume | **Wrong** | `/data/home/.bob` is `drwxrwx--- dev:node`. The agent user can write it: `su -s /bin/sh -c "test -w /data/home/.bob/settings.json" hive-scanner` succeeds. bob actively rewrites `settings.json` at runtime. |
| The workspace mount is `readOnly` to the bob user | **Wrong** | Agent workspaces are `/data/agents/<name>`, owned by the agent UID. `.bob/.bob-errors/errors-*.log` is actively being written there (708 KB in a day), owned `hive-scanner:node`. |
| Container runs as a user that mismatches volume ownership | **Wrong** | Per-agent UIDs (2001+) all share group `node` (gid 1000); the dirs are group-writable. `StartPermissionsWatcher` already reconciles ownership on a 10s tick. |
| Needs `securityContext` / `fsGroup` / initContainer `chown` | **Not needed** | Nothing is unwritable, so there is nothing to chown. These are also non-starters on OpenShift here: `NET_ADMIN` and `CAP_CHOWN` are both denied. No deployment change is required by this PR. |
| Needs a `BOB_CONFIG_DIR`-style env var | **Not needed** | bob derives its state dir from `os.homedir()`; `$HOME=/data/home` already points at a writable volume. |
| "Do you trust this folder?" banner | **Already fixed** | #2249 added `--trust`; the banner no longer appears. Not re-fixed here. |

## The actual root cause

`ensureTmuxSession` creates the session and only *then* applies the environment:

```
new-session -d   ->   set-environment (xN)   ->   send-keys
```

tmux copies the session environment only into processes it forks **afterwards**. `new-session -d` has already forked the pane's shell, so that shell predates every `set-environment` and never receives any of them.

This silently drops exactly the `Secret: true` pairs — `BOBSHELL_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN` — because `buildEnvPrefix` deliberately keeps those off the command line so credentials never land in `ps` or pane scrollback. Non-secret vars survive only because they are re-typed on every launch by `buildEnvPrefix`.

Net effect: the session environment genuinely holds the key (`show-environment` lists it) while no bob process does, so bob falls back to the W3ID SSO flow that cannot complete in a pod and parks at the auth prompt — with every precondition green (settings `api-key`, key readable by the agent UID, token delivered). A bob that cannot authenticate also cannot complete the startup writes behind "There was an error saving your latest settings changes."

The codebase already documented this tmux behavior (comment at `manager.go` ~line 377, and the `RelaunchBobAgentsAwaitingKey` comment), but the launch path still depended on the broken ordering.

## Verification (run against real tmux, not reasoned about)

```
new-session -> set-environment -> send-keys        => pane env EMPTY   (reproduces the bug)
new-session -> set-environment -> respawn-pane     => pane env FULL    (the fix)
```

Two obvious alternatives were tested and **rejected**:

- **Env on the `tmux new-session` client process** — works on a cold server, fails once the server is already running, because the *server* forks the pane, not the client. That is precisely the relaunch case (`killSessionForRelaunch` kills the session, not the server), so it would have regressed silently.
- **`set-environment -g` before `new-session`** — cannot run at all on a cold server: `error connecting to <socket>`.

Also verified: pluk's `pipe-pane` still captures correctly, since it attaches after the respawn; and the container's shells are `/bin/bash` (`Dockerfile:52`, `entrypoint.sh:501`), matching the tested case.

## Changes

- **`ensureTmuxSession`** — respawn the pane after the environment is populated so the shell inherits it. Failure is logged and non-fatal (a degraded session beats refusing to launch). Secrets stay off the command line: `respawn-pane` takes no arguments.
- **`verifyBobStateDirsWritable`** — new advisory probe. bob surfaces "error saving your latest settings changes" and "Failed to initialize logger:" only inside its own TUI, so a genuinely unwritable dir is invisible to anyone reading `kubectl logs` — that silence is what made this issue hard to diagnose. Probes both `$HOME/.bob` and `<workdir>/.bob` for the agent UID's group access and logs a remedy. Mirrors `verifyBobKeyReadable`, including its false-positive trap: hive runs as `dev` and *owns* these dirs, so any check on its own behalf passes while the agent UID still gets EACCES. Never blocks a launch. Missing dirs are not faults — bob creates them recursively on first use.
- Named constants only (`bobStateGroupWriteBit`, `config.BobStateDirName`); no magic numbers. No credential values logged — paths, modes and UIDs only.

## Safety

`ensureTmuxSession` takes no locks in the added code — no new `m.mu` acquisition, so the non-reentrant-RWMutex deadlock class from #1980→#1988 is not reintroduced.

## Testing

9 new table-driven cases covering the production-correct `0770`, the `0700` lockout, `0750`/`0760` partial-permission cases, root/unset-UID bypass, missing dirs, and workspace-dir-only failure. `go build ./...`, `go vet`, and the `pkg/agent` + `pkg/config` suites pass. gofmt clean on touched files — the pre-existing drift in `manager.go` and `config.go` was deliberately left alone (verified my hunks add none).

## What remains

Marked `Refs` rather than `Fixes` because I could not re-attach to the reporter's Supervisor pane to confirm their *specific* instance was the same failure. The probe added here will now say so definitively in the hive log if any state dir really is unwritable in their environment. If #2253 was solely the trust banner, that was already resolved by #2249.

## Porting

**mk / dd / v3 still need this.** ks/console's hive runs v3, so a v2-only merge will not reach it.
