### PR TITLE
proxy: hard-deny direct PR creation so agents use hive-open-pr

### DIFF
--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -585,6 +585,12 @@ func (p *GitHubProxy) proxyHTTP(client net.Conn, upstream net.Conn, agentName st
 			req.ContentLength = int64(len(body))
 		} else if !AllowedByMode(mode, req.Method, req.URL.Path) {
 			blocked = true
+			// A hard-deny rule (e.g. direct PR creation) carries an agent-facing
+			// directive explaining the sanctioned alternative — surface it so the
+			// agent knows to use hive-open-pr rather than seeing only a mode error.
+			if msg, denied := DeniedMessage(req.Method, req.URL.Path); denied && msg != "" {
+				blockReason = msg
+			}
 		} else if len(p.allowedRepos) > 0 && !RepoFilterAllowed(p.allowedRepos, req.Method, req.URL.Path) {
 			blocked = true
 			blockReason = "repo not in hive config"

--- a/v2/pkg/proxy/proxy_coverage_test.go
+++ b/v2/pkg/proxy/proxy_coverage_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kubestellar/hive/v2/pkg/agent"
@@ -32,8 +33,17 @@ func TestAllowedByModePROperations(t *testing.T) {
 	if AllowedByMode(agent.ModeIssuesOnly, "POST", "/repos/org/repo/pulls") {
 		t.Error("ISSUES_ONLY should NOT allow creating PRs")
 	}
-	if !AllowedByMode(agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls") {
-		t.Error("ISSUES_AND_PRS should allow creating PRs")
+	// Direct PR creation (POST /pulls) is a HARD DENY for every mode — agents
+	// must route through hive-open-pr so the App bot authors the PR. Even a
+	// push-capable mode cannot POST /pulls directly.
+	if AllowedByMode(agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls") {
+		t.Error("POST /pulls must be denied for all modes (use hive-open-pr)")
+	}
+	if AllowedByMode(agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/pulls") {
+		t.Error("POST /pulls must be denied even for merge mode (use hive-open-pr)")
+	}
+	if msg, denied := DeniedMessage("POST", "/repos/org/repo/pulls"); !denied || !strings.Contains(msg, "hive-open-pr") {
+		t.Errorf("POST /pulls should carry a hive-open-pr deny message; got denied=%v msg=%q", denied, msg)
 	}
 	if !AllowedByMode(agent.ModeIssuesAndPRs, "PATCH", "/repos/org/repo/pulls/42") {
 		t.Error("ISSUES_AND_PRS should allow patching PRs")
@@ -314,8 +324,11 @@ func TestIsGitHubHostComplete(t *testing.T) {
 }
 
 func TestAllowedByModeEscalation(t *testing.T) {
-	path := "/repos/org/repo/pulls"
-	method := "POST"
+	// PATCH /pulls/<n> is a mode-gated PR operation (unlike POST /pulls, which is
+	// a hard deny for every mode): advisory/issues-only cannot, issues-and-prs and
+	// above can. This exercises the mode-escalation path itself.
+	path := "/repos/org/repo/pulls/42"
+	method := "PATCH"
 
 	modes := []agent.AgentMode{
 		agent.ModeAdvisory,
@@ -331,6 +344,14 @@ func TestAllowedByModeEscalation(t *testing.T) {
 		}
 		if i >= 2 && !allowed {
 			t.Errorf("mode %v should allow %s %s", mode, method, path)
+		}
+	}
+
+	// POST /pulls (direct PR creation) is denied for EVERY mode — no escalation
+	// unlocks it. Agents must use hive-open-pr.
+	for _, mode := range modes {
+		if AllowedByMode(mode, "POST", "/repos/org/repo/pulls") {
+			t.Errorf("mode %v must NOT allow direct POST /pulls (use hive-open-pr)", mode)
 		}
 	}
 }

--- a/v2/pkg/proxy/proxy_deep2_test.go
+++ b/v2/pkg/proxy/proxy_deep2_test.go
@@ -550,9 +550,10 @@ func TestProxyHTTPBlockedPOSTShowsPath(t *testing.T) {
 	if !strings.Contains(response, "403") {
 		t.Errorf("expected 403 in response")
 	}
-	// The blocked path should be mentioned in the body
-	if !strings.Contains(response, "/repos/org/repo/pulls") {
-		t.Errorf("expected path in response body, got: %s", response)
+	// POST /pulls is a hard deny: the body carries the hive-open-pr directive
+	// (the deny message) rather than the raw path, so agents learn the fix.
+	if !strings.Contains(response, "hive-open-pr") {
+		t.Errorf("expected hive-open-pr directive in response body, got: %s", response)
 	}
 }
 

--- a/v2/pkg/proxy/proxy_extra_test.go
+++ b/v2/pkg/proxy/proxy_extra_test.go
@@ -261,14 +261,17 @@ func TestAllowedByModeComprehensive(t *testing.T) {
 		{agent.ModeIssuesOnly, "POST", "/repos/org/repo/issues/1/comments", true},
 		{agent.ModeIssuesOnly, "POST", "/repos/org/repo/pulls", false},
 
-		// IssuesAndPRs can create PRs but not merge
-		{agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls", true},
+		// IssuesAndPRs can push + patch PRs but NOT create them directly
+		// (POST /pulls is a hard deny — agents use hive-open-pr).
+		{agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls", false},
+		{agent.ModeIssuesAndPRs, "PATCH", "/repos/org/repo/pulls/42", true},
 		{agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/issues", true},
 		{agent.ModeIssuesAndPRs, "PUT", "/repos/org/repo/pulls/1/merge", false},
 
-		// IssuesPRsMerge can do everything
+		// IssuesPRsMerge can merge + create issues, but still cannot POST /pulls
+		// directly (direct PR creation is denied for every mode).
 		{agent.ModeIssuesPRsMerge, "PUT", "/repos/org/repo/pulls/1/merge", true},
-		{agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/pulls", true},
+		{agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/pulls", false},
 		{agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/issues", true},
 	}
 

--- a/v2/pkg/proxy/proxy_test.go
+++ b/v2/pkg/proxy/proxy_test.go
@@ -45,12 +45,14 @@ func TestAllowedByModeExtended(t *testing.T) {
 		{"issues-only can comment", agent.ModeIssuesOnly, "POST", "/repos/org/repo/issues/1/comments", true},
 		{"issues-only cannot create PRs", agent.ModeIssuesOnly, "POST", "/repos/org/repo/pulls", false},
 
-		{"issues-and-prs can create PRs", agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls", true},
+		// Direct PR creation is a hard deny for EVERY mode — agents must use
+		// hive-open-pr so the App bot authors the PR (never the login user).
+		{"issues-and-prs cannot create PRs directly (use hive-open-pr)", agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls", false},
 		{"issues-and-prs can push", agent.ModeIssuesAndPRs, "POST", "/repos/org/repo.git/git-receive-pack", true},
 		{"issues-and-prs cannot merge", agent.ModeIssuesAndPRs, "PUT", "/repos/org/repo/pulls/1/merge", false},
 
 		{"merge mode can merge", agent.ModeIssuesPRsMerge, "PUT", "/repos/org/repo/pulls/1/merge", true},
-		{"merge mode can create PRs", agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/pulls", true},
+		{"merge mode cannot create PRs directly (use hive-open-pr)", agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/pulls", false},
 
 		{"git upload-pack always allowed", agent.ModeAdvisory, "POST", "/repos/org/repo.git/git-upload-pack", true},
 

--- a/v2/pkg/proxy/rules.go
+++ b/v2/pkg/proxy/rules.go
@@ -98,7 +98,9 @@ var rules = []ProxyRule{
 	{regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/\d+/merge$`), "PUT", agent.ModeIssuesPRsMerge},
 
 	// ── PR operations — ISSUES_AND_PRS and above ──
-	{regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls$`), "POST", agent.ModeIssuesAndPRs},
+	// NOTE: direct PR creation (POST /pulls) is NOT here — it is a HARD DENY for
+	// every mode, handled by denyRules below, so agents route through hive-open-pr
+	// (App-bot authorship) instead of `gh pr create` / the GitHub MCP create_pull_request.
 	{regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/\d+$`), "PATCH", agent.ModeIssuesAndPRs},
 	{regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/\d+/reviews`), "POST", agent.ModeIssuesAndPRs},
 
@@ -127,13 +129,56 @@ var rules = []ProxyRule{
 // AllowedByMode returns true if the given HTTP method+path is permitted
 // for an agent running in the specified mode. Unknown operations are
 // denied by default.
+// denyRule is a hard block that applies to EVERY agent mode, regardless of the
+// mode-escalation rules. It exists for operations agents must route through a
+// hive-mediated path instead of calling GitHub directly.
+type denyRule struct {
+	PathPattern *regexp.Regexp
+	Method      string
+	Msg         string // agent-facing directive surfaced in the 403 body
+}
+
+// denyRules are checked BEFORE the mode rules. The canonical (and currently only)
+// case is direct PR creation: a POST /repos/*/pulls — whether from `gh pr create`
+// or the GitHub MCP create_pull_request/create_pull_request_with_copilot tool —
+// authors the PR as the Copilot login user, not the App bot. Blocking it here
+// forces agents to use `hive-open-pr`, which the hive fulfills with the App token
+// so the PR is authored by the App bot. This closes the MCP path the gh-wrapper
+// redirect cannot see. The hive's OWN CreatePR call does not traverse this agent
+// proxy, so it is unaffected.
+var denyRules = []denyRule{
+	{
+		PathPattern: regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls$`),
+		Method:      "POST",
+		Msg:         "direct PR creation is disabled for agents — use `hive-open-pr --repo <owner/repo> --head <branch> --title <t> --body <b>` so the hive opens the PR as the App bot (never the login user). Do NOT use `gh pr create` or the GitHub MCP create_pull_request/create_pull_request_with_copilot.",
+	},
+}
+
 func AllowedByMode(mode agent.AgentMode, method, path string) bool {
+	// Hard denies win over any mode rule.
+	if _, denied := DeniedMessage(method, path); denied {
+		return false
+	}
 	for _, r := range rules {
 		if r.Method == method && r.PathPattern.MatchString(path) {
 			return mode >= r.MinMode
 		}
 	}
 	return false
+}
+
+// DeniedMessage returns the agent-facing directive for a request blocked by a
+// hard-deny rule, and true if such a rule matched. It lets the proxy surface WHY
+// a request was refused (e.g. "use hive-open-pr") instead of the generic ACMM
+// message. Returns ("", false) when no deny rule matches — the caller then falls
+// back to the normal mode-based block reason.
+func DeniedMessage(method, path string) (string, bool) {
+	for _, r := range denyRules {
+		if r.Method == method && r.PathPattern.MatchString(path) {
+			return r.Msg, true
+		}
+	}
+	return "", false
 }
 
 var repoPathPrefix = regexp.MustCompile(`^/repos/([^/]+/[^/]+)`)

--- a/v2/pkg/proxy/rules_test.go
+++ b/v2/pkg/proxy/rules_test.go
@@ -40,7 +40,8 @@ func TestAllowedByMode(t *testing.T) {
 		// ── ISSUES_AND_PRS: issues + PRs, no merge ──
 		{"prs allows GET", agent.ModeIssuesAndPRs, "GET", "/repos/org/repo/pulls", true},
 		{"prs allows POST issue", agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/issues", true},
-		{"prs allows POST pull", agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls", true},
+		// Direct PR creation is a hard deny for every mode — agents use hive-open-pr.
+		{"prs blocks direct POST pull", agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls", false},
 		{"prs allows PATCH pull", agent.ModeIssuesAndPRs, "PATCH", "/repos/org/repo/pulls/42", true},
 		{"prs allows PR review", agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls/42/reviews", true},
 		{"prs allows git push", agent.ModeIssuesAndPRs, "POST", "/org/repo.git/git-receive-pack", true},
@@ -52,7 +53,8 @@ func TestAllowedByMode(t *testing.T) {
 		// ── ISSUES_PRS_MERGE: everything allowed ──
 		{"merge allows GET", agent.ModeIssuesPRsMerge, "GET", "/repos/org/repo/issues", true},
 		{"merge allows POST issue", agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/issues", true},
-		{"merge allows POST pull", agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/pulls", true},
+		// Even merge mode cannot POST /pulls directly — hive-open-pr is the only path.
+		{"merge blocks direct POST pull", agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/pulls", false},
 		{"merge allows PUT merge", agent.ModeIssuesPRsMerge, "PUT", "/repos/org/repo/pulls/42/merge", true},
 		{"merge allows git push", agent.ModeIssuesPRsMerge, "POST", "/org/repo.git/git-receive-pack", true},
 


### PR DESCRIPTION
## Problem

The hive-open-pr cutover (#2254) made agents open PRs via a request file that the hive fulfills with the App token, so PRs are authored by `kubestellar-hive[bot]`. `gh pr create` is auto-redirected to `hive-open-pr` by the gh-wrapper.

But the gh-wrapper redirect only catches `gh pr create`. Agents that use the **GitHub MCP `create_pull_request` / `create_pull_request_with_copilot`** tool POST directly to `/repos/*/pulls`, bypassing the wrapper — and that call authors the PR as the **Copilot login user**, not the App bot. Observed live on console: multiple PRs authored by the user account despite the cutover.

## Fix

Close the gap at the MITM proxy, which sees **every** agent GitHub API call. Add a hard-deny rule for `POST /repos/*/pulls`:

- Blocked for **every** agent mode (not mode-gated) — no ACMM level unlocks direct PR creation.
- The 403 body carries an agent-facing directive to use `hive-open-pr` instead.
- The hive's **own** `CreatePR` call does **not** traverse the agent proxy, so App-bot PR opening is unaffected.

This makes `hive-open-pr` the *only* way an agent can open a PR, regardless of which client (gh CLI, MCP tool, raw curl) it reaches for.

## Tests

- `POST /pulls` now denied for all modes (advisory → merge) across `rules_test.go`, `proxy_test.go`, `proxy_extra_test.go`, `proxy_coverage_test.go`.
- PR mutation/merge paths keep their mode gating (`PATCH /pulls/N`, `PUT /pulls/N/merge`, `POST /pulls/N/reviews`).
- Integration test asserts the 403 body contains the `hive-open-pr` directive.
- New coverage: `DeniedMessage` returns the directive; escalation test repointed to a still-mode-gated PR op.