### PR TITLE
sync: merge v2 into v3 (backport #2255 perms + #2257 proxy PR-create deny)

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -132,6 +132,26 @@ fi
 ACMM_LEVEL="${HIVE_ACMM_LEVEL:-0}"
 ADVISORY_ISSUE="${HIVE_ADVISORY_ISSUE:-}"
 
+# ── Route `gh pr create` through the hive so the PR is App-bot-authored ──
+# An agent running `gh pr create` would author the PR as whatever identity the gh
+# token / Copilot login resolves to (the login USER, not the App bot). Redirect
+# to hive-open-pr, which drops a request file the hive's watcher opens with the
+# App installation token → authored by "<slug>[bot]". The watcher enforces the
+# SAME ACMM write-gate + forge-resistance, so this changes WHO opens the PR, not
+# WHAT an agent is allowed to do. Contributors are EXEMPT: they fork and PR under
+# their OWN identity by design, so their gh pr create must pass through unchanged.
+if [ "$subcmd" = "pr" ] && [ "$action" = "create" ] && [ "${HIVE_CONTRIBUTOR_MODE:-}" != "true" ]; then
+  if command -v hive-open-pr >/dev/null 2>&1; then
+    # Pass the original gh-pr-create flags straight through — hive-open-pr accepts
+    # the same --repo/--head/--base/--title/--body shape and ignores the rest.
+    exec hive-open-pr "$@"
+  fi
+  # If the wrapper somehow isn't installed, fail loud rather than silently
+  # opening the PR as the wrong identity (hard switch: no gh-pr-create fallback).
+  echo "⛔ hive-open-pr not found — cannot open a PR as the App bot. Do NOT fall back to gh pr create (would author as the login user). Report this to the operator." >&2
+  exit 1
+fi
+
 # Helper: capture advisory finding to JSONL for governor digest
 _capture_advisory_finding() {
   local _adv_title="" _adv_body="" _next_is_title=false _next_is_body=false

--- a/bin/hive-open-pr.sh
+++ b/bin/hive-open-pr.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# hive-open-pr.sh — open a PR via the HIVE (App bot), not `gh pr create`.
+#
+# Agents call this INSTEAD of `gh pr create`. It writes a request file that the
+# hive's PR-request watcher picks up and opens the PR with the App installation
+# token — so the PR is authored by the App bot ("<slug>[bot]"), never the
+# Copilot login user. The watcher enforces the SAME per-agent ACMM write-gate +
+# forge-resistance as the direct path (see AuthorizePROpen); this wrapper adds
+# no privilege, it only changes WHO opens the PR.
+#
+# It runs AS THE AGENT (in the agent's tmux session, under the agent's UID), so
+# the request file it writes is owned by that agent's UID — the forge-resistance
+# anchor. It accepts the gh-pr-create flags agents already use.
+#
+# Usage (drop-in for the common gh pr create shape):
+#   hive-open-pr --repo <owner/repo> --head <branch> [--base <branch>] \
+#                --title "<title>" --body "<body>"
+#   # --head defaults to the current git branch; --base defaults to main.
+#
+# On success it prints the request path and returns 0. The PR opens
+# asynchronously (within one watcher tick); poll the .result.json next to the
+# request, or just look for the PR — this is intentional: the agent's job is to
+# REQUEST the PR, the hive owns opening it.
+
+set -euo pipefail
+
+REQ_DIR="/var/run/hive-metrics/pr-requests"
+
+REPO=""; HEAD=""; BASE="main"; TITLE=""; BODY=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)  REPO="$2"; shift 2;;
+    --head)  HEAD="$2"; shift 2;;
+    --base)  BASE="$2"; shift 2;;
+    --title) TITLE="$2"; shift 2;;
+    --body)  BODY="$2"; shift 2;;
+    --repo=*)  REPO="${1#*=}"; shift;;
+    --head=*)  HEAD="${1#*=}"; shift;;
+    --base=*)  BASE="${1#*=}"; shift;;
+    --title=*) TITLE="${1#*=}"; shift;;
+    --body=*)  BODY="${1#*=}"; shift;;
+    # Tolerate flags gh accepts but we don't need; ignore their value if present.
+    --draft|--fill|--web|--no-maintainer-edit) shift;;
+    *) shift;;
+  esac
+done
+
+# Default head to the current branch if not given.
+if [ -z "$HEAD" ]; then
+  HEAD="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+fi
+if [ -z "$REPO" ] || [ -z "$HEAD" ] || [ -z "$TITLE" ]; then
+  echo "hive-open-pr: --repo, --head (or a current branch), and --title are required" >&2
+  exit 2
+fi
+
+# Identify the requesting agent. Prefer the UID map (the watcher re-derives the
+# owner from the FILE's UID anyway, so this is informational + a nicer log line);
+# fall back to HIVE_AGENT.
+AGENT="${HIVE_AGENT:-agent}"
+UID_NOW="$(id -u 2>/dev/null || echo 0)"
+UID_MAP="/var/run/hive/uid-map.json"
+if [ "$UID_NOW" -ge 2001 ] && [ -f "$UID_MAP" ] && command -v python3 >/dev/null 2>&1; then
+  MAPPED="$(python3 -c "
+import json,sys
+try:
+    m=json.load(open('$UID_MAP')).get('agents',{})
+    for n,u in m.items():
+        if u==$UID_NOW: print(n); break
+except Exception: pass
+" 2>/dev/null || true)"
+  [ -n "$MAPPED" ] && AGENT="$MAPPED"
+fi
+
+mkdir -p "$REQ_DIR" 2>/dev/null || true
+
+# Write the request as valid JSON. Use python for correct escaping of title/body.
+REQ_FILE="$REQ_DIR/${AGENT}-$(date +%s%N).json"
+if command -v python3 >/dev/null 2>&1; then
+  python3 - "$REQ_FILE" "$REPO" "$HEAD" "$BASE" "$TITLE" "$BODY" "$AGENT" <<'PY'
+import json, sys
+path, repo, head, base, title, body, agent = sys.argv[1:8]
+json.dump({"repo":repo,"head":head,"base":base,"title":title,"body":body,"agent":agent},
+          open(path,"w"))
+PY
+else
+  # Minimal fallback escaper (no python): escape backslash and double-quote.
+  esc() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+  printf '{"repo":"%s","head":"%s","base":"%s","title":"%s","body":"%s","agent":"%s"}\n' \
+    "$(esc "$REPO")" "$(esc "$HEAD")" "$(esc "$BASE")" "$(esc "$TITLE")" "$(esc "$BODY")" "$(esc "$AGENT")" \
+    > "$REQ_FILE"
+fi
+
+echo "hive-open-pr: requested PR on $REPO ($HEAD -> $BASE) as the App bot"
+echo "hive-open-pr: request $REQ_FILE (the hive opens the PR within ~10s; result appears at ${REQ_FILE%.json}.result.json)"

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -159,11 +159,12 @@ COPY v2/deploy/data/ /opt/hive/seed-data/
 COPY v2/deploy/ttyd-tmux.sh /usr/local/bin/ttyd-tmux.sh
 COPY v2/deploy/hive-panes.sh /usr/local/bin/hive-panes
 COPY bin/gh-app-token.sh bin/hive-config.sh bin/agent-launch.sh bin/git-credential-hive.sh /usr/local/bin/
+COPY bin/hive-open-pr.sh /usr/local/bin/hive-open-pr
 COPY bin/gh-wrapper.sh /usr/local/bin/gh
 COPY config/backends.conf /usr/local/etc/hive/backends.conf
 RUN chmod +x /usr/local/bin/ttyd-tmux.sh /usr/local/bin/hive-panes /usr/local/bin/gh-app-token.sh \
     /usr/local/bin/hive-config.sh /usr/local/bin/agent-launch.sh /usr/local/bin/gh \
-    /usr/local/bin/git-credential-hive.sh
+    /usr/local/bin/git-credential-hive.sh /usr/local/bin/hive-open-pr
 
 # --- Nous framework (strategist experiment engine) ---
 RUN (apt-get update && apt-get install -y --no-install-recommends \

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -694,7 +694,10 @@ func main() {
 	// as, and requests simply accumulate rather than opening under a wrong
 	// identity. ghClient uses the App installation token (see ghAuth wiring).
 	if ghClient != nil && cfg.GitHub.HasUsableApp() {
-		ghClient.StartPRRequestWatcher(ctx, nil)
+		// authz enforces the SAME per-agent ACMM write-gate + forge-resistance as
+		// the direct `gh pr create` path — the request-file route grants no extra
+		// privilege. A denied request is quarantined, never opened.
+		ghClient.StartPRRequestWatcher(ctx, agentMgr.AuthorizePROpen, nil)
 	}
 
 	go agent.StartPermissionsWatcher(logger)

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -687,6 +687,16 @@ func main() {
 		go agentMgr.StartAgentTokenRefresh(ctx)
 	}
 
+	// PR-open-as-the-App-bot: agents push their branch (App-token credential
+	// helper) then drop a request file; the hive opens the PR here with the App
+	// token so it is authored by "<slug>[bot]", not the Copilot login user.
+	// Gated on a real client + usable App — with no App there is no bot to author
+	// as, and requests simply accumulate rather than opening under a wrong
+	// identity. ghClient uses the App installation token (see ghAuth wiring).
+	if ghClient != nil && cfg.GitHub.HasUsableApp() {
+		ghClient.StartPRRequestWatcher(ctx, nil)
+	}
+
 	go agent.StartPermissionsWatcher(logger)
 
 	const statePath = "/data/hive-state.json"

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -516,6 +516,49 @@ print('\n'.join(sorted(names)))
           chown -R "hive-${agent_name}:node" "/data/beads/${agent_name}" 2>/dev/null || true
         fi
       fi
+      # ── Per-agent GitHub App token cache file ────────────────────────
+      # The hive binary runs as dev (UID 1001) after privilege drop and CANNOT
+      # chown — an unprivileged process cannot give a file away to another UID
+      # without CAP_CHOWN, and capabilities are deliberately restricted here
+      # (the same container already fails NET_ADMIN for iptables above). So the
+      # runtime write path must never call chown. We pre-create the cache file
+      # HERE, as root, with the final ownership and mode:
+      #
+      #   owner = dev  (UID 1001)      -> hive can rewrite it in place, no chown
+      #   group = hive-<agent>         -> ONLY this agent can read it
+      #   mode  = 0640                 -> owner rw, group r, world none
+      #
+      # The group MUST be a per-agent private group. The agent users are all in
+      # the shared "node" group (gid 1000), so group-node would let EVERY agent
+      # read EVERY other agent's scoped token — exactly the cross-agent leak the
+      # per-agent token exists to prevent. groupadd + usermod -aG gives each
+      # agent a private group it is the only member of, while leaving "node" as
+      # its primary group so nothing else about the agent's access changes.
+      #
+      # dev deliberately does NOT join these groups: it writes as the file
+      # OWNER, so it needs no group membership. That keeps dev out of every
+      # agent's private group and avoids N usermod calls.
+      #
+      # gids are auto-allocated by `groupadd --system` rather than derived from
+      # the agent UID. A derived gid (e.g. uid+1000) can collide with an
+      # existing group; letting groupadd pick from the system range cannot.
+      #
+      # Verified in ghcr.io/kubestellar/hive:v2-latest: dev writes in place OK,
+      # the owning agent reads its own token OK, and a second agent gets
+      # EACCES on the first agent's token.
+      AGENT_TOKEN_GROUP="hive-${agent_name}"
+      if ! getent group "$AGENT_TOKEN_GROUP" >/dev/null 2>&1; then
+        groupadd --system "$AGENT_TOKEN_GROUP" 2>/dev/null || true
+      fi
+      usermod -aG "$AGENT_TOKEN_GROUP" "hive-${agent_name}" 2>/dev/null || true
+      AGENT_TOKEN_FILE="/var/run/hive-metrics/agent-tokens/gh-token-${agent_name}.cache"
+      # Create empty (never seeded with a value) — hive fills it at launch.
+      # touch is idempotent across restarts; chown/chmod re-assert the contract
+      # unconditionally in case a previous image left the file mis-owned.
+      touch "$AGENT_TOKEN_FILE" 2>/dev/null || true
+      chown "dev:${AGENT_TOKEN_GROUP}" "$AGENT_TOKEN_FILE" 2>/dev/null || true
+      chmod 640 "$AGENT_TOKEN_FILE" 2>/dev/null || true
+      echo "[entrypoint] Agent token cache: ${AGENT_TOKEN_FILE} (dev:${AGENT_TOKEN_GROUP} 0640)"
       echo "[entrypoint] Agent user: hive-${agent_name} (UID ${AGENT_UID})"
       UID_OFFSET=$((UID_OFFSET + 1))
     done

--- a/v2/pkg/agent/bob_settings.go
+++ b/v2/pkg/agent/bob_settings.go
@@ -21,6 +21,9 @@ const (
 	// bobKeyOtherReadBit is `o+r`. Also sufficient for the agent to read, but
 	// it means the secret is world-readable, which is worth flagging.
 	bobKeyOtherReadBit fs.FileMode = 0o004
+	// bobStateGroupWriteBit is `g+w` — the bit that lets an agent UID create
+	// or replace files inside a dev:node-owned bob state directory.
+	bobStateGroupWriteBit fs.FileMode = 0o020
 )
 
 // verifyBobKeyReadable checks that the resolved bob key file is readable BY
@@ -88,6 +91,81 @@ const bobSharedHome = "/data/home"
 // bobSettingsPath returns the shared bob settings file for a given HOME.
 func bobSettingsPath(home string) string {
 	return filepath.Join(home, config.BobSettingsRelPath)
+}
+
+// verifyBobStateDirsWritable probes, AS THE AGENT UID, every directory bob
+// writes to during startup, and logs an actionable error for each one that is
+// not writable.
+//
+// This exists because bob reports these failures only inside its own TUI —
+// "There was an error saving your latest settings changes." and "Failed to
+// initialize logger:" — which nobody sees unless they are attached to that
+// pane. Nothing reaches the hive log, so a genuinely unwritable directory is
+// invisible to an operator reading `kubectl logs` and gets misdiagnosed as a
+// read-only filesystem. The same false-positive trap as verifyBobKeyReadable
+// applies: the hive process runs as dev and OWNS these directories, so any
+// check it performs on its own behalf succeeds while the agent UID still gets
+// EACCES. The probe therefore tests the agent's group access explicitly rather
+// than calling os.Access as dev.
+//
+// Advisory only — it never blocks a launch. bob degrades rather than dying
+// when these writes fail (ephemeral installation ID, no chat recording), so a
+// probe failure is a reason to log loudly, not to refuse to start the agent.
+// Logs paths, modes and UIDs only — never any file contents.
+//
+// Returns the directories found unwritable, so callers and tests can assert on
+// the outcome rather than scraping log output. A nil result means every
+// existing state dir is writable by the agent UID.
+func (m *Manager) verifyBobStateDirsWritable(agentName, home, workDir string, uid int) []string {
+	if uid <= 0 {
+		return nil
+	}
+	var unwritable []string
+
+	// The directories bob creates or writes during startup:
+	//   - $HOME/.bob            settings.json, trustedFolders.json,
+	//                           installation_id, tmp/ (chat recordings)
+	//   - <workdir>/.bob        per-agent .bob-errors/ logger target, which is
+	//                           what "Failed to initialize logger:" refers to
+	probeDirs := []string{
+		filepath.Dir(bobSettingsPath(home)),
+		filepath.Join(workDir, config.BobStateDirName),
+	}
+
+	for _, dir := range probeDirs {
+		info, err := os.Stat(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// Not an error on its own: bob creates these with
+				// mkdirSync({recursive:true}) on first use. It only matters
+				// whether the PARENT is writable, which the next launch's
+				// probe reports once the dir exists.
+				continue
+			}
+			m.logger.Warn("bob state dir not statable; bob may fail to persist settings or initialize its logger",
+				"agent", agentName, "dir", dir, "uid", uid, "error", err)
+			continue
+		}
+		if !info.IsDir() {
+			m.logger.Warn("bob state path exists but is not a directory",
+				"agent", agentName, "path", dir, "uid", uid)
+			continue
+		}
+
+		// The agent UID reaches these dev-owned dirs through group `node`, so
+		// group write+execute is what actually decides whether bob can create
+		// or replace a file inside. Write alone is not enough — without
+		// execute the path cannot be traversed to open the file by name.
+		mode := info.Mode().Perm()
+		if mode&bobStateGroupWriteBit == 0 || mode&bobKeyGroupExecBit == 0 {
+			m.logger.Error("bob state dir is not writable by the agent UID; bob will report \"error saving your latest settings changes\" and \"Failed to initialize logger\"",
+				"agent", agentName, "dir", dir,
+				"mode", fs.FileMode(mode).String(), "uid", uid,
+				"remedy", "chmod 770 "+dir+" and ensure it is group-owned by node")
+			unwritable = append(unwritable, dir)
+		}
+	}
+	return unwritable
 }
 
 // ensureBobAuthSettings makes hive the owner of the `security.auth` block in

--- a/v2/pkg/agent/bob_settings_test.go
+++ b/v2/pkg/agent/bob_settings_test.go
@@ -366,3 +366,96 @@ func TestBobKeyFilePathNoResolver(t *testing.T) {
 		t.Errorf("bobKeyFilePath() = %q with no resolver, want empty", got)
 	}
 }
+
+// TestVerifyBobStateDirsWritable pins the probe behind issue #2253: bob
+// reports "error saving your latest settings changes" and "Failed to
+// initialize logger:" only inside its own TUI, so hive must detect the
+// underlying permission problem itself.
+//
+// The modes are the real ones: 0770 is what /data/home/.bob actually carries
+// in production (drwxrwx--- dev:node), and 0700 is the failure mode where the
+// dir is owned by dev but carries no group bits, which is exactly what locks
+// out an agent UID that reaches it through group `node`.
+func TestVerifyBobStateDirsWritable(t *testing.T) {
+	tests := []struct {
+		name           string
+		mode           os.FileMode
+		uid            int
+		wantUnwritable bool
+	}{
+		{"production-correct 0770 is writable", 0o770, 2004, false},
+		{"0700 locks out the agent UID", 0o700, 2004, true},
+		{"0750 is readable but not writable", 0o750, 2004, true},
+		{"0760 lacks group traverse", 0o760, 2004, true},
+		{"root agent bypasses the check", 0o700, 0, false},
+		{"unset uid bypasses the check", 0o700, -1, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			bobDir := filepath.Dir(bobSettingsPath(home))
+			if err := os.MkdirAll(bobDir, 0o770); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.Chmod(bobDir, tc.mode); err != nil {
+				t.Fatalf("chmod: %v", err)
+			}
+			// Restore traversal so t.TempDir cleanup can remove the tree.
+			t.Cleanup(func() { _ = os.Chmod(bobDir, 0o770) })
+
+			m := &Manager{logger: discardLogger()}
+			// workDir points at a non-existent path on purpose: a state dir
+			// bob has not created yet must NOT be reported, since bob creates
+			// it recursively on first use.
+			got := m.verifyBobStateDirsWritable("tester", home,
+				filepath.Join(t.TempDir(), "agents", "tester"), tc.uid)
+
+			if gotUnwritable := len(got) > 0; gotUnwritable != tc.wantUnwritable {
+				t.Errorf("verifyBobStateDirsWritable() unwritable=%v (%v), want %v",
+					gotUnwritable, got, tc.wantUnwritable)
+			}
+		})
+	}
+}
+
+// TestVerifyBobStateDirsWritableIgnoresMissingDirs covers the fresh-PVC case:
+// neither state dir exists yet. bob creates them with mkdirSync recursive on
+// first use, so a missing dir is not a fault and must not be reported.
+func TestVerifyBobStateDirsWritableIgnoresMissingDirs(t *testing.T) {
+	m := &Manager{logger: discardLogger()}
+	got := m.verifyBobStateDirsWritable("tester", t.TempDir(),
+		filepath.Join(t.TempDir(), "nope"), 2004)
+	if len(got) != 0 {
+		t.Errorf("verifyBobStateDirsWritable() = %v for missing dirs, want none", got)
+	}
+}
+
+// TestVerifyBobStateDirsWritableFlagsWorkspaceDir pins that the per-agent
+// workspace .bob (the "Failed to initialize logger:" target, seen in
+// production at /data/agents/<name>/.bob/.bob-errors/) is probed too, not just
+// the shared $HOME/.bob.
+func TestVerifyBobStateDirsWritableFlagsWorkspaceDir(t *testing.T) {
+	home := t.TempDir()
+	homeBob := filepath.Dir(bobSettingsPath(home))
+	if err := os.MkdirAll(homeBob, 0o770); err != nil {
+		t.Fatalf("mkdir home .bob: %v", err)
+	}
+	// MkdirAll's mode is masked by umask, so set the production mode
+	// explicitly — this dir must be the WRITABLE one for the assertion below
+	// to prove the workspace dir is probed independently.
+	if err := os.Chmod(homeBob, 0o770); err != nil {
+		t.Fatalf("chmod home .bob: %v", err)
+	}
+	workDir := t.TempDir()
+	stateDir := filepath.Join(workDir, config.BobStateDirName)
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir workspace .bob: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(stateDir, 0o770) })
+
+	m := &Manager{logger: discardLogger()}
+	got := m.verifyBobStateDirsWritable("tester", home, workDir, 2004)
+	if len(got) != 1 || got[0] != stateDir {
+		t.Errorf("verifyBobStateDirsWritable() = %v, want [%s]", got, stateDir)
+	}
+}

--- a/v2/pkg/agent/bob_startup_kick_test.go
+++ b/v2/pkg/agent/bob_startup_kick_test.go
@@ -190,7 +190,7 @@ func TestBobInputHandlerSettleDelay(t *testing.T) {
 // Asserted through the launch-command builder: bob's command must contain no
 // reference to the bootstrap temp file and no embedded prompt argument.
 func TestBobStartupKickNotWrittenToDeadTempFile(t *testing.T) {
-	cmd := bobLaunchCmd("bob", "some-model")
+	cmd := bobLaunchCmd("bob")
 	for _, forbidden := range []string{".hive-bootstrap", "--text", "$(cat", "-p ", "--prompt"} {
 		if strings.Contains(cmd, forbidden) {
 			t.Errorf("bobLaunchCmd() = %q must not contain %q: bob's prompt is delivered "+

--- a/v2/pkg/agent/bob_test.go
+++ b/v2/pkg/agent/bob_test.go
@@ -292,49 +292,106 @@ func TestBobKeyNotInEnvPrefix(t *testing.T) {
 	}
 }
 
-// TestBobLaunchCmd pins the flags that make headless auth work while keeping
-// the session interactive.
+// TestBobLaunchCmd pins the flags that make headless auth work, keep the
+// session interactive, and let an unattended agent actually run tool calls.
 func TestBobLaunchCmd(t *testing.T) {
-	tests := []struct {
-		name        string
-		model       string
-		wantContain []string
-		wantAbsent  []string
-	}{
-		{
-			name:  "no model",
-			model: "",
-			// --accept-license clears the license gate that would otherwise
-			// hard-error with no human to answer it.
-			// --auth-method api-key is the strongest auth control: it is a real
-			// (but --help-hidden) flag in bobshell 1.0.6 and is the only input
-			// that outranks the persisted, fleet-shared settings file.
-			wantContain: []string{"bob", "--accept-license", "--auth-method api-key"},
-			// No -p/--prompt: interactive mode must be preserved.
-			wantAbsent: []string{"--model", " -p ", "--prompt"},
-		},
-		{
-			name:        "with model",
-			model:       "granite-3",
-			wantContain: []string{"--accept-license", "--auth-method api-key", "--model granite-3"},
-			wantAbsent:  []string{" -p ", "--prompt"},
-		},
+	got := bobLaunchCmd("bob")
+
+	wantContain := []string{
+		"bob",
+		// Clears the license gate that would otherwise hard-error with no
+		// human to answer it.
+		"--accept-license",
+		// The strongest auth control: a real (but --help-hidden) flag in
+		// bobshell 1.0.6, and the only input that outranks the persisted,
+		// fleet-shared settings file.
+		"--auth-method api-key",
+		// Without this bob reports `Auto-approve: Off` and blocks forever on
+		// the first tool call. Verified live: with it, bob executed a shell
+		// tool unattended.
+		"--approval-mode yolo",
+		// Clears "This folder is not trusted. Some features may be disabled."
+		"--trust",
+	}
+	for _, want := range wantContain {
+		if !strings.Contains(got, want) {
+			t.Errorf("bobLaunchCmd() = %q, want it to contain %q", got, want)
+		}
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := bobLaunchCmd("bob", tc.model)
-			for _, want := range tc.wantContain {
-				if !strings.Contains(got, want) {
-					t.Errorf("bobLaunchCmd(...) = %q, want it to contain %q", got, want)
-				}
-			}
-			for _, absent := range tc.wantAbsent {
-				if strings.Contains(got, absent) {
-					t.Errorf("bobLaunchCmd(...) = %q, want it NOT to contain %q", got, absent)
-				}
-			}
-		})
+	wantAbsent := []string{
+		// --model is the BUG: normalizeModelName rewrote claude-sonnet-4-6 to
+		// claude-sonnet-4.6, an id bob's backend does not know, and every
+		// prompt died with "Cannot read properties of undefined (reading
+		// 'maxTokens')". bob auto-selects its model; hive must not pass one.
+		"--model",
+		// Interactive mode must be preserved.
+		" -p ",
+		"--prompt",
+	}
+	for _, absent := range wantAbsent {
+		if strings.Contains(got, absent) {
+			t.Errorf("bobLaunchCmd() = %q, want it NOT to contain %q", got, absent)
+		}
+	}
+}
+
+// TestBobLaunchCmdApprovalIsFlat documents the deliberate design decision that
+// bob's approval mode does NOT vary with the agent's ACMM mode.
+//
+// Every other backend already auto-approves tools at every level (claude gets
+// --dangerously-skip-permissions, copilot gets --allow-all, in all three mode
+// branches of launchInTmux). Hive contains low-mode agents by denying GitHub
+// write tools and unsetting GH_TOKEN/GITHUB_TOKEN, not by making them ask
+// permission for local tool calls. bob matches that posture.
+func TestBobLaunchCmdApprovalIsFlat(t *testing.T) {
+	// bobLaunchCmd takes no mode argument at all, so the command is identical
+	// for every agent. Guard against a future signature change reintroducing
+	// per-mode approval without updating this reasoning.
+	if a, b := bobLaunchCmd("bob"), bobLaunchCmd("bob"); a != b {
+		t.Fatalf("bobLaunchCmd() is not deterministic: %q vs %q", a, b)
+	}
+	for _, forbidden := range []string{"--approval-mode default", "--approval-mode auto_edit"} {
+		if strings.Contains(bobLaunchCmd("bob"), forbidden) {
+			t.Errorf("bobLaunchCmd() must not use %q: bob matches the fleet's "+
+				"flat auto-approve posture", forbidden)
+		}
+	}
+}
+
+// TestNormalizeModelNameSkipsBob covers the dot-rewrite that corrupted bob's
+// model id. bob is now excluded alongside claude and the inference backends.
+func TestNormalizeModelNameSkipsBob(t *testing.T) {
+	const configured = "claude-sonnet-4-6"
+	if got := normalizeModelName(configured, bobBackend); got != configured {
+		t.Errorf("normalizeModelName(%q, %q) = %q, want it unchanged: the "+
+			"dot-rewrite produced claude-sonnet-4.6, an id bob does not know",
+			configured, bobBackend, got)
+	}
+	// Non-bob backends must still be normalized.
+	if got := normalizeModelName(configured, "copilot"); got != "claude-sonnet-4.6" {
+		t.Errorf("normalizeModelName(%q, \"copilot\") = %q, want %q: other "+
+			"backends must be unaffected", configured, got, "claude-sonnet-4.6")
+	}
+}
+
+// TestToolRulesToLaunchCmdBobHasNoModel guards the second path that could feed
+// bob a --model: an agent with Config.Tools set bypasses the launchInTmux
+// switch entirely and would otherwise fall to the default branch.
+func TestToolRulesToLaunchCmdBobHasNoModel(t *testing.T) {
+	tools := &config.ToolsConfig{}
+	got := toolRulesToLaunchCmd("bob", "claude-sonnet-4.6", bobBackend, tools, false)
+	if strings.Contains(got, "--model") {
+		t.Errorf("toolRulesToLaunchCmd(bob) = %q must not contain --model", got)
+	}
+	for _, want := range []string{"--accept-license", "--approval-mode yolo", "--trust"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("toolRulesToLaunchCmd(bob) = %q, want it to contain %q", got, want)
+		}
+	}
+	// Non-bob backends must still receive their model.
+	if c := toolRulesToLaunchCmd("copilot", "gpt-5", "copilot", tools, false); !strings.Contains(c, "--model gpt-5") {
+		t.Errorf("toolRulesToLaunchCmd(copilot) = %q, want it to contain --model gpt-5", c)
 	}
 }
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1016,7 +1016,7 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 				launchCmd = fmt.Sprintf("%s --model %s", launchCmd, model)
 			}
 		case bobBackend:
-			launchCmd = bobLaunchCmd(binary, model)
+			launchCmd = bobLaunchCmd(binary)
 		default:
 			launchCmd = binary
 		}
@@ -3680,16 +3680,51 @@ const bobBackend = "bob"
 //     key for unattended use is the act of acceptance; the text stays
 //     reviewable via `bob --show-license`.
 //
+//   - --approval-mode yolo (config.BobApprovalModeFlag/BobApprovalModeYolo):
+//     without it bob runs in its "default" approval mode, the TUI reports
+//     `Auto-approve: Off`, and the agent blocks forever on its FIRST tool call
+//     waiting for a human who is not attached. Verified live on a spoke: with
+//     the flag the TUI reports `Auto-approve: Full` and bob executed a shell
+//     tool unattended.
+//
+//     This is deliberately FLAT — not gated on m.agentMode(agent) — because it
+//     matches the existing fleet posture rather than inventing a new one for
+//     bob. Every other backend already auto-approves tools at EVERY ACMM level:
+//     claude gets --dangerously-skip-permissions and copilot gets --allow-all
+//     in all three mode branches of launchInTmux. Hive does not restrain agents
+//     by making them ask permission for local tool calls; it restrains them by
+//     (a) denying specific GitHub write tools per mode and (b) unsetting
+//     GH_TOKEN/GITHUB_TOKEN for agents whose mode fails CanPush(). Both of
+//     those controls apply to bob unchanged and are where an advisory bob is
+//     actually contained. Giving bob a per-mode approval policy would make it
+//     the only backend that stalls at low ACMM levels — less capable than its
+//     peers, and stalled rather than safely limited.
+//
+//   - --trust (config.BobTrustFlag): bob otherwise treats the agent workdir as
+//     untrusted ("This folder is not trusted. Some features may be disabled.")
+//     and gates tool availability on it. See BobTrustFlag for why the flag is
+//     preferred over seeding the shared $HOME/.bob/trustedFolders.json.
+//
+// No --model is passed, and that is load-bearing. bob auto-selects its own
+// model, and hive's normalizeModelName rewrites a trailing -<digits> to
+// .<digits> for every backend except claude/inference, so a configured
+// `claude-sonnet-4-6` reached bob as `claude-sonnet-4.6` — an id bob's backend
+// does not know. Its model config came back undefined and every prompt died
+// with "🛑 Cannot read properties of undefined (reading 'maxTokens')". Verified
+// live: the same bob with no --model runs inference successfully.
+//
 // The API key itself is NOT a flag — it is delivered out-of-band via
 // tmux set-environment (see agentEnvPairs) so it never lands in the command
 // line, `ps` output, or pane scrollback.
-func bobLaunchCmd(binary, model string) string {
-	cmd := fmt.Sprintf("%s --accept-license %s %s",
-		binary, config.BobAuthMethodFlag, config.BobAuthTypeAPIKey)
-	if model != "" {
-		cmd = fmt.Sprintf("%s --model %s", cmd, model)
-	}
-	return cmd
+//
+// The model parameter is intentionally absent from the signature so no future
+// caller can reintroduce the crash by passing one.
+func bobLaunchCmd(binary string) string {
+	return fmt.Sprintf("%s --accept-license %s %s %s %s %s",
+		binary,
+		config.BobAuthMethodFlag, config.BobAuthTypeAPIKey,
+		config.BobApprovalModeFlag, config.BobApprovalModeYolo,
+		config.BobTrustFlag)
 }
 
 // codexHomePrefix is the per-agent CODEX_HOME directory prefix. Each agent gets
@@ -3966,8 +4001,17 @@ func (m *Manager) ensureWorldWritable(root string) {
 // "gpt-4o-2024-08.06") produces a model the team is not entitled to and the
 // gateway 403s ("team not allowed to access model") even for entitled models.
 // So never normalize inference model names — pass them through untouched.
+//
+// bob is likewise excluded. bobLaunchCmd passes no --model at all (bob
+// auto-selects), so this is defense-in-depth rather than the fix: the value is
+// still computed and logged on the bob launch path, and the dot-rewrite is
+// what turned a configured `claude-sonnet-4-6` into the unknown
+// `claude-sonnet-4.6` that made bob die with "Cannot read properties of
+// undefined (reading 'maxTokens')". Leaving it unrewritten keeps logs honest
+// about what was configured and stops the corrupted id from being handed to a
+// future bob consumer.
 func normalizeModelName(model, backend string) string {
-	if backend == "claude" || IsInferenceBackend(backend) {
+	if backend == "claude" || backend == bobBackend || IsInferenceBackend(backend) {
 		return model
 	}
 	idx := strings.LastIndex(model, "-")
@@ -4961,6 +5005,15 @@ func toolRulesToLaunchCmd(binary, model, backend string, tools *config.ToolsConf
 	denies := tools.DenyPatterns()
 
 	switch backend {
+	case bobBackend:
+		// bob has no deny-tool flag, so ToolsConfig cannot be expressed here.
+		// It must still go through bobLaunchCmd rather than falling to the
+		// default branch below, which would append `--model` and crash bob
+		// with "Cannot read properties of undefined (reading 'maxTokens')".
+		// A bob agent with tools configured therefore launches identically to
+		// one without; the deny patterns are silently inapplicable, exactly as
+		// they already were before this branch existed.
+		return bobLaunchCmd(binary)
 	case "claude":
 		bareFlag := ""
 		if isInference {

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -590,7 +590,14 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 	if m.appAuth != nil && agent.UID > 0 {
 		tier := m.agentMode(agent).TokenTier()
 		if err := m.appAuth.WriteAgentToken(ctx, agent.Name, tier, agent.UID); err != nil {
-			m.logger.Warn("failed to mint per-agent token, agent will use shared cache",
+			// Be precise about the blast radius. A shared-cache fallback does
+			// exist (gh-wrapper.sh / git-credential-hive.sh fall back to
+			// /var/run/hive-metrics/gh-app-token.cache), but it is the FULL
+			// installation token, not this agent's tier-scoped one — so the
+			// failure silently escalates privilege rather than degrading
+			// gracefully, and it only works at all if that shared cache is
+			// present and group-readable. Say that, don't imply it's fine.
+			m.logger.Warn("per-agent scoped token NOT delivered — agent falls back to the shared FULL-privilege App token (tier scoping lost); if the shared cache is also missing, all GitHub writes for this agent will fail",
 				"agent", agent.Name, "tier", tier, "error", err)
 		}
 	}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -681,6 +681,39 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 		_ = m.tmuxCmd(agent, "set-environment", "-t", agent.tmuxSession, "-u", "GITHUB_TOKEN").Run()
 	}
 
+	// Every set-environment above updated the SESSION environment, which tmux
+	// only copies into processes it forks AFTERWARDS. `new-session -d` already
+	// forked this session's pane shell, so that bash predates all of it and
+	// will never see a single one of those variables — including the Secret
+	// pairs (BOBSHELL_API_KEY, CLAUDE_CODE_OAUTH_TOKEN) that buildEnvPrefix
+	// deliberately keeps off the command line. Every CLI launched by send-keys
+	// into this pane therefore inherits an environment missing exactly the
+	// credentials that are only delivered this way, which is why bob still
+	// prompted for an API key with the key demonstrably present in the session
+	// env (`show-environment` listed it; no bob /proc/<pid>/environ had it).
+	//
+	// Respawning the pane replaces that stale shell with a fresh one forked by
+	// the server after the environment was populated, so it inherits the full
+	// set. This is the only ordering that works in all three states the launch
+	// path actually hits: cold server, warm server with other sessions, and a
+	// session recreated by killSessionForRelaunch. Passing the vars in the
+	// environment of the `tmux new-session` client process does NOT work once
+	// the server is already running (the server, not the client, forks the
+	// pane), and `set-environment -g` before `new-session` cannot run at all on
+	// a cold server ("error connecting to <socket>") — both verified.
+	//
+	// Secrets stay off the command line: respawn-pane takes no arguments here,
+	// so nothing is typed into the pane or visible in `ps`.
+	respawnArgs := []string{"respawn-pane", "-k", "-t", agent.tmuxSession}
+	if err := m.tmuxCmd(agent, respawnArgs...).Run(); err != nil {
+		// Non-fatal: the pane still exists with the pre-env shell. Log it so a
+		// later "CLI cannot see its credentials" report has a breadcrumb
+		// instead of being silent, then continue — a degraded session is still
+		// better than refusing to launch the agent at all.
+		m.logger.Warn("tmux pane respawn failed; pane shell will not inherit session env (CLI may prompt for credentials)",
+			"name", agent.Name, "session", agent.tmuxSession, "error", err)
+	}
+
 	m.logger.Info("tmux session created", "name", agent.Name, "session", agent.tmuxSession, "uid", agent.UID, "socket", agent.tmuxSocket)
 
 	// Attach pluk publisher if available — streams structured events
@@ -918,6 +951,10 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		// Advisory only: the Secret-mounted copy may still be readable, so this
 		// never blocks a launch that might succeed.
 		m.verifyBobKeyReadable(agent.Name, m.bobKeyFilePath(), agent.UID)
+		// bob reports unwritable state dirs only inside its own TUI, so probe
+		// them here as the agent UID and surface any failure in the hive log.
+		// Advisory, like the key probe above — never blocks a launch.
+		_ = m.verifyBobStateDirsWritable(agent.Name, bobSharedHome, m.workDir+"/"+agent.Name, agent.UID)
 	}
 
 	launchCmd := binary

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -4125,6 +4125,49 @@ func (m *Manager) agentCanWrite(agent *AgentProcess) bool {
 	return m.agentMode(agent).CanPush()
 }
 
+// AuthorizePROpen enforces the policy for the hive-opens-PR watcher: an agent
+// may open a PR (by dropping a request file) only if BOTH hold:
+//
+//  1. Forge-resistance — the request file's owning UID (fileUID) maps to the
+//     agent it claims to be (via the uid-map). One agent cannot open a PR "as"
+//     another, and a non-agent process (unknown UID) is refused. When per-agent
+//     UIDs are not in play (fileUID <= 0, e.g. shared-dev-UID mode with no map),
+//     ownership is unverifiable, so we fall back to the ACMM check alone rather
+//     than hard-failing — the same posture the credential helper takes.
+//  2. ACMM write-gate — the agent must be push-capable at the hive's current
+//     ACMM level, i.e. exactly the CanPush() check that governs `gh pr create`.
+//
+// Returns nil to authorize, or an error describing the denial. This mirrors the
+// direct PR path's policy so the request-file route grants no extra privilege.
+func (m *Manager) AuthorizePROpen(agentName string, fileUID int) error {
+	if strings.TrimSpace(agentName) == "" {
+		return fmt.Errorf("no agent named in the request")
+	}
+	// Forge check: when we have a UID map and a real owning UID, the file owner
+	// must BE this agent.
+	if m.uidMap != nil && fileUID > 0 {
+		owner := m.uidMap.LookupByUID(fileUID)
+		if owner == "" {
+			return fmt.Errorf("request file owned by unknown uid %d (not a registered agent)", fileUID)
+		}
+		if owner != agentName {
+			return fmt.Errorf("request claims agent %q but file is owned by agent %q (uid %d)", agentName, owner, fileUID)
+		}
+	}
+	// ACMM write-gate: resolve the agent and check CanPush.
+	m.mu.RLock()
+	agent := m.agents[agentName]
+	m.mu.RUnlock()
+	if agent == nil {
+		return fmt.Errorf("unknown agent %q", agentName)
+	}
+	if !m.agentMode(agent).CanPush() {
+		return fmt.Errorf("agent %q is not push-capable at this ACMM level (mode %s) — advisory agents may not open PRs",
+			agentName, m.agentMode(agent).String())
+	}
+	return nil
+}
+
 // filteredEnv returns os.Environ() with write-capable tokens removed for advisory agents.
 // COPILOT_GITHUB_TOKEN is kept for all agents (needed for AI auth); write access is
 // gated by --enable-all-github-mcp-tools flag. GH_TOKEN and GITHUB_TOKEN are stripped

--- a/v2/pkg/agent/routing_coverage_test.go
+++ b/v2/pkg/agent/routing_coverage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
@@ -486,6 +487,43 @@ func TestAgentModeTokenTier(t *testing.T) {
 	for mode, want := range cases {
 		if got := mode.TokenTier(); got != want {
 			t.Errorf("mode %d TokenTier=%q want %q", mode, got, want)
+		}
+	}
+}
+
+// TestToolRulesToLaunchCmd_BobNeverGetsModel verifies bob's launch command
+// carries no --model even when a concrete model is configured.
+//
+// Agents with Config.Tools set bypass bobLaunchCmd and build their command
+// here, so without an explicit bob branch they fell into the default case and
+// got `bob --model <id>`. That is the crash: normalizeModelName rewrites a
+// trailing -<digits> to .<digits> for every non-claude backend, so a stored
+// claude-sonnet-4-6 reaches bob as claude-sonnet-4.6 — an id bob's backend
+// does not know — and every prompt dies with "Cannot read properties of
+// undefined (reading 'maxTokens')". bob auto-selects its own model.
+func TestToolRulesToLaunchCmd_BobNeverGetsModel(t *testing.T) {
+	tools := &config.ToolsConfig{}
+	// Includes "auto": the dashboard's only bob option is a display/stored
+	// placeholder, and `bob --model auto` is untested and must not be emitted.
+	for _, model := range []string{"", "auto", "claude-sonnet-4.6", "claude-sonnet-4-6", "granite-3"} {
+		cmd := toolRulesToLaunchCmd("bob", model, bobBackend, tools, false)
+		if strings.Contains(cmd, "--model") {
+			t.Errorf("bob launch cmd with model %q must not contain --model: %q", model, cmd)
+		}
+		if cmd != "bob" {
+			t.Errorf("bob launch cmd with model %q = %q, want %q", model, cmd, "bob")
+		}
+	}
+}
+
+// TestToolRulesToLaunchCmd_OtherBackendsStillGetModel guards the bob branch
+// against swallowing the default case for everything else.
+func TestToolRulesToLaunchCmd_OtherBackendsStillGetModel(t *testing.T) {
+	tools := &config.ToolsConfig{}
+	for _, backend := range []string{"gemini", "goose", "codex"} {
+		cmd := toolRulesToLaunchCmd(backend, "some-model", backend, tools, false)
+		if !strings.Contains(cmd, "--model some-model") {
+			t.Errorf("%s must still receive --model: %q", backend, cmd)
 		}
 	}
 }

--- a/v2/pkg/agent/routing_coverage_test.go
+++ b/v2/pkg/agent/routing_coverage_test.go
@@ -247,8 +247,13 @@ func TestToolRulesToLaunchCmd_Default(t *testing.T) {
 	if cmd != "gemini --model flash" {
 		t.Errorf("default backend cmd: %q", cmd)
 	}
-	cmd = toolRulesToLaunchCmd("bob", "", "bob", tools, false)
-	if cmd != "bob" {
+	// An UNKNOWN backend with no model gets the bare binary. This used to be
+	// asserted with backend "bob", which meant it pinned bob's broken
+	// fall-through: a bare `bob` has no --accept-license (hard-errors), no
+	// auth flag, and no --approval-mode (stalls on the first tool call). bob
+	// now has its own branch, so use a backend that really is unknown.
+	cmd = toolRulesToLaunchCmd("mystery", "", "mystery", tools, false)
+	if cmd != "mystery" {
 		t.Errorf("default backend with empty model: %q", cmd)
 	}
 }

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -883,6 +883,40 @@ const (
 	// makes hive's choice authoritative without bob rewriting the shared file.
 	BobAuthMethodFlag = "--auth-method"
 
+	// BobApprovalModeFlag / BobApprovalModeYolo set bob's tool-approval policy.
+	// Verified in bobshell 1.0.6 `bob --help`:
+	//   --approval-mode  Set the approval mode: default (prompt for approval),
+	//                    auto_edit (auto-approve edit tools), yolo
+	//                    (auto-approve all tools)
+	//                    [string] [choices: "default", "auto_edit", "yolo"]
+	//
+	// Without it bob defaults to "default" and the TUI shows
+	// `Auto-approve: Off`, so an unattended agent blocks forever on the first
+	// tool call — no human is attached to answer the prompt. With
+	// `--approval-mode yolo` the TUI shows `Auto-approve: Full` and bob
+	// executes shell/edit tools unattended (verified live on a spoke: bob
+	// wrote /tmp/_tool.txt with no approval prompt).
+	//
+	// The named flag is preferred over the equivalent `-y`/`--yolo` boolean
+	// because it states the mode at the call site.
+	BobApprovalModeFlag = "--approval-mode"
+	BobApprovalModeYolo = "yolo"
+
+	// BobTrustFlag marks the agent's workspace as trusted. bobshell 1.0.6
+	// otherwise renders "This folder is not trusted. Some features may be
+	// disabled." and gates tool availability behind that state. Verified in
+	// `bob --help`:
+	//   --trust  specify trust level for the current workspace
+	//
+	// Passing the flag is preferred over seeding $HOME/.bob/trustedFolders.json
+	// because the flag is per-launch and stateless: it needs no knowledge of
+	// bob's on-disk trust schema, cannot drift when that schema changes, and
+	// applies to whatever workdir the agent is launched in. The shared
+	// /data/home is used by EVERY bob agent on a hive, so a seeded trust file
+	// would also be a fleet-wide mutation of the kind that already caused the
+	// selectedType incident (see BobAuthTypeEnvVar).
+	BobTrustFlag = "--trust"
+
 	// BobSettingsRelPath is the persisted settings file, relative to $HOME.
 	// From bundle/bob.js: `as=".bob"` and
 	// `getGlobalSettingsPath(){return fu.join(t.getGlobalGeminiDir(),"settings.json")}`

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -948,6 +948,13 @@ const (
 
 	// BobSettingsDirMode matches the observed /data/home/.bob (drwxrwx---).
 	BobSettingsDirMode = 0o770
+
+	// BobStateDirName is the per-workspace state directory bob creates inside
+	// the directory it is launched in (in addition to the shared $HOME/.bob).
+	// Its .bob-errors/ subdirectory is the logger target behind bob's
+	// "Failed to initialize logger:" message, observed in production at
+	// /data/agents/<name>/.bob/.bob-errors/errors-YYYY-MM-DD.log.
+	BobStateDirName = ".bob"
 )
 
 // BobConfig configures the IBM bobshell ("bob") CLI backend. Only the

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4657,10 +4657,15 @@ func (s *Server) handleBackends(w http.ResponseWriter, r *http.Request) {
 	copilotCLI := s.queryCLIModels("copilot")
 	geminiCLI := s.queryCLIModels("gemini")
 	gooseCLI := s.queryCLIModels("goose")
+	// bob has no discovery source and no usable --model flag: it selects its
+	// own model. Served explicitly so the client never falls through to the
+	// copilot catalog and offers models bob cannot honor (see bobStaticModels).
+	bobCLI := s.queryCLIModels(bobBackendID)
 
 	jsonResponse(w, []map[string]interface{}{
 		{"id": "claude", "name": "Claude Code", "models": claudeCLI.models, "fallback": claudeCLI.fallback},
 		{"id": "copilot", "name": "GitHub Copilot", "models": copilotCLI.models, "fallback": copilotCLI.fallback},
+		{"id": bobBackendID, "name": "bob (IBM bobshell)", "models": bobCLI.models, "fallback": bobCLI.fallback},
 		{"id": "gemini", "name": "Gemini", "models": geminiCLI.models, "fallback": geminiCLI.fallback},
 		{"id": "goose", "name": "Goose", "models": gooseCLI.models, "fallback": gooseCLI.fallback},
 		{"id": "vllm", "name": "vLLM (self-hosted)", "models": vllmModels, "inference": true},

--- a/v2/pkg/dashboard/cli_models.go
+++ b/v2/pkg/dashboard/cli_models.go
@@ -93,6 +93,25 @@ const (
 	// offered (copilotAlwaysIncludeModels) and exempt from model auto-heal.
 	copilotAutoModel = "auto"
 
+	// --- bob (IBM bobshell) ---
+
+	// bobBackendID is the backend id for the IBM bobshell ("bob") CLI. Mirrors
+	// the agent package's unexported bobBackend constant; keep the two in sync.
+	bobBackendID = "bob"
+
+	// bobAutoModel is the ONLY model option offered for bob, and it is a UI
+	// placeholder rather than a flag value: bob selects its own model and has
+	// no working --model flag. Passing one is actively harmful — a concrete id
+	// (e.g. claude-sonnet-4.6) makes every prompt die with "Cannot read
+	// properties of undefined (reading 'maxTokens')", verified live on a spoke,
+	// while the same bob with no --model runs inference fine.
+	//
+	// Unlike copilotAutoModel, this value must NEVER reach a command line:
+	// `bob --model auto` is UNTESTED and presumed unsafe. The launch path
+	// (agent.bobLaunchCmd) omits --model entirely, so "auto" only ever exists
+	// as the stored/displayed selection.
+	bobAutoModel = "auto"
+
 	// --- Gemini ---
 
 	// geminiModelsURL lists models available to a Gemini API key.
@@ -160,6 +179,12 @@ var copilotAlwaysIncludeModels = []string{
 	// launch value, so it must always be offered and must survive auto-heal.
 	copilotAutoModel,
 }
+
+// bobStaticModels is bob's complete model list: exactly one entry, the auto
+// sentinel. bob has no model catalog to discover and no usable --model flag
+// (see bobAutoModel), so offering anything else would invite a selection that
+// either does nothing or breaks inference.
+var bobStaticModels = []string{bobAutoModel}
 
 // codexStaticModels is the maintained list for the OpenAI Codex CLI. Codex only
 // accepts OpenAI models — Claude ids are rejected with a ChatGPT account
@@ -316,6 +341,12 @@ func (s *Server) queryCLIModels(backend string) cliModelResult {
 		// No probe wired yet; the maintained static list is authoritative and
 		// OpenAI-only (Claude ids are rejected by Codex with a ChatGPT account).
 		r = cliModelResult{models: dedupeModels(codexStaticModels), fallback: false}
+	case bobBackendID:
+		// bob picks its own model and exposes no catalog, so there is nothing
+		// to discover. The single auto sentinel is authoritative (not a
+		// fallback) — marking it fallback=true would label it "(common alias,
+		// unverified)" in the dropdown and make it eligible for auto-heal.
+		r = cliModelResult{models: dedupeModels(bobStaticModels), fallback: false}
 	default:
 		r = cliModelResult{models: nil, fallback: true}
 	}
@@ -352,6 +383,8 @@ func cliStaticFallback(backend string) []string {
 		return claudeStaticModels
 	case "codex":
 		return codexStaticModels
+	case bobBackendID:
+		return bobStaticModels
 	case "goose":
 		return []string{"default"}
 	default:

--- a/v2/pkg/dashboard/cli_models_test.go
+++ b/v2/pkg/dashboard/cli_models_test.go
@@ -290,3 +290,48 @@ func TestCLIModelCacheStabilize_PerBackendIsolation(t *testing.T) {
 		t.Fatalf("copilot retention lost, got %v", got)
 	}
 }
+
+// TestQueryCLIModels_BobAutoOnly verifies bob is served EXACTLY one model, the
+// auto sentinel, and that it is authoritative rather than a fallback. bob has
+// no model catalog and no usable --model flag, so any additional option would
+// invite a selection it cannot honor; marking it fallback would label it
+// "(common alias, unverified)" in the dropdown and expose it to auto-heal.
+func TestQueryCLIModels_BobAutoOnly(t *testing.T) {
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.queryCLIModels(bobBackendID)
+	if len(r.models) != 1 {
+		t.Fatalf("bob must be served exactly one model, got %v", r.models)
+	}
+	if r.models[0] != bobAutoModel {
+		t.Fatalf("bob's only model must be %q, got %q", bobAutoModel, r.models[0])
+	}
+	if r.fallback {
+		t.Fatal("bob's single-option list is authoritative, not a fallback")
+	}
+}
+
+// TestCliStaticFallback_BobAutoOnly verifies the static fallback path (used if
+// the discovery switch is ever bypassed) also yields only the auto sentinel,
+// so bob can never be handed the copilot catalog.
+func TestCliStaticFallback_BobAutoOnly(t *testing.T) {
+	got := cliStaticFallback(bobBackendID)
+	if len(got) != 1 || got[0] != bobAutoModel {
+		t.Fatalf("bob static fallback must be exactly [%q], got %v", bobAutoModel, got)
+	}
+}
+
+// TestQueryCLIModels_BobDoesNotAffectOtherBackends guards against a regression
+// where adding bob narrows or empties another CLI backend's catalog.
+func TestQueryCLIModels_BobDoesNotAffectOtherBackends(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	for _, backend := range []string{"claude", "copilot", "gemini", "goose", "codex"} {
+		r := s.queryCLIModels(backend)
+		if len(r.models) == 0 {
+			t.Errorf("%s models must not be empty", backend)
+		}
+		if len(r.models) == 1 && r.models[0] == bobAutoModel {
+			t.Errorf("%s must not inherit bob's single auto option: %v", backend, r.models)
+		}
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5533,8 +5533,22 @@
       { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
       { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' },
     ];
+    // bob (IBM bobshell) selects its own model and has NO usable --model flag:
+    // launching `bob --model <concrete-id>` makes every prompt die with
+    // "Cannot read properties of undefined (reading 'maxTokens')" (verified
+    // live on a spoke), while the same bob with no --model runs inference fine.
+    // So bob gets exactly ONE option — the auto sentinel — and the launch path
+    // (bobLaunchCmd) passes no --model at all. This value is a display/stored
+    // placeholder, never a command-line argument.
+    const BOB_CLI_MODELS = [
+      { value: 'auto', label: 'Auto (bob picks)' },
+    ];
     const KNOWN_MODELS = COPILOT_CLI_MODELS;
-    const CLI_BACKENDS = ['claude', 'copilot', 'gemini', 'goose', 'codex'];
+    // CLI_BACKENDS gates which /api/config/backends entries populate
+    // BACKEND_MODELS. bob is included so its server-served single-option list
+    // is honored; without it bob's entry would be dropped and modelsForBackend
+    // would fall through to the copilot catalog.
+    const CLI_BACKENDS = ['claude', 'copilot', 'bob', 'gemini', 'goose', 'codex'];
     // BACKEND_MODELS holds the live-discovered model list for every backend
     // (inference AND cli), keyed by backend id. INFERENCE_MODELS is kept as
     // an alias to the same object for backward compatibility with existing
@@ -5548,6 +5562,7 @@
     const CLI_FALLBACK_MODELS = {
       claude: CLAUDE_CLI_MODELS,
       copilot: COPILOT_CLI_MODELS,
+      bob: BOB_CLI_MODELS,
       gemini: COPILOT_CLI_MODELS,
       goose: COPILOT_CLI_MODELS,
       codex: CODEX_CLI_MODELS,
@@ -5558,18 +5573,43 @@
       if (INFERENCE_BACKENDS.includes(b) || _configuredGateways.includes(b)) return b + ' ⚡';
       return b;
     }
-    // Auto-select sentinels: special --model VALUES that tell a CLI to pick the
-    // model itself rather than pin a concrete id. They flow verbatim through the
-    // launch path's `--model <value>` but are never in a discovered model
-    // catalog, so they must be exempted from model auto-heal. Copilot: `auto`.
-    const AUTO_MODEL_SENTINELS = { copilot: ['auto'] };
+    // Auto-select sentinels: values meaning "let the CLI pick its own model"
+    // rather than pinning a concrete id. They are never in a discovered model
+    // catalog, so they must be exempted from model auto-heal — otherwise
+    // reconcileModelsAfterDiscovery rewrites them to a concrete discovered id.
+    //
+    // How each reaches the CLI differs, and the difference is load-bearing:
+    //   - copilot: `auto` flows VERBATIM through the launch path as
+    //     `--model auto`. It is a real, supported Copilot CLI flag value.
+    //   - bob: `auto` is NEVER passed on the command line. bob has no working
+    //     --model flag (a concrete id breaks inference with "Cannot read
+    //     properties of undefined (reading 'maxTokens')"), and `bob --model
+    //     auto` is untested/presumed unsafe. bobLaunchCmd omits --model
+    //     entirely; `auto` exists only as the stored/displayed selection.
+    const AUTO_MODEL_SENTINELS = { copilot: ['auto'], bob: ['auto'] };
     function isAutoModelSentinel(backend, model) {
       return (AUTO_MODEL_SENTINELS[backend] || []).includes(model);
     }
+    // Backends whose model list is a single fixed option, so there is nothing
+    // for a user to choose and nothing meaningful to store per agent.
+    const SINGLE_OPTION_BACKENDS = ['bob'];
     function modelsForBackend(backend) {
+      // Single-option backends are authoritative and never overridden by
+      // discovery: even if the server (or a stale cached response) offered a
+      // longer list, bob cannot honor a model choice, so the local one-option
+      // list wins. This also guarantees bob never reaches the copilot fallback.
+      if (SINGLE_OPTION_BACKENDS.includes(backend)) {
+        return CLI_FALLBACK_MODELS[backend] || [];
+      }
       const discovered = BACKEND_MODELS[backend];
       if (discovered && discovered.length) return discovered;
       if (INFERENCE_BACKENDS.includes(backend)) return [];
+      // NOTE (latent trap): any UNKNOWN backend still falls through to the
+      // copilot catalog and is offered models it may not support — the exact
+      // bug this change fixes for bob. Left as-is deliberately: gateway
+      // backends rely on a non-empty first paint, so narrowing it needs its
+      // own change. Every known CLI backend is now explicit in
+      // CLI_FALLBACK_MODELS, so nothing shipped reaches this line by accident.
       return CLI_FALLBACK_MODELS[backend] || COPILOT_CLI_MODELS;
     }
     // _modelIdMatches: an agent's stored model may lack (or carry) the
@@ -5592,7 +5632,17 @@
     // the dropdown never silently drops an agent's active selection.
     function modelOptionsHtml(backend, currentModel) {
       const models = modelsForBackend(backend);
-      const cur = currentModel || '';
+      // SINGLE_OPTION_BACKENDS offer exactly one valid selection, so an agent's
+      // stored model carries no information — and bob agents created before
+      // this change hold a stale concrete id (e.g. "claude-sonnet-4.6") that
+      // bob cannot honor. Substituting the sole option as the "current" value
+      // both preselects it (with the usual " ▾" caret) and starves the
+      // "(current)" branch below, which would otherwise resurrect the stale id
+      // as a pinned, preselected option.
+      const soleOption = SINGLE_OPTION_BACKENDS.includes(backend) && models.length === 1
+        ? models[0].value
+        : '';
+      const cur = soleOption || currentModel || '';
       let matched = false;
       const opts = models.map(m => {
         const sel = !matched && _modelIdMatches(m.value, cur);

--- a/v2/pkg/github/agent_token_delivery_test.go
+++ b/v2/pkg/github/agent_token_delivery_test.go
@@ -1,0 +1,273 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Test constants — no magic numbers in the assertions below.
+const (
+	// testRSABits is the key size for the throwaway App signing key. 2048 is
+	// the minimum GitHub accepts and keeps test key generation fast.
+	testRSABits = 2048
+	// testTokenTTL is how far in the future the fake mint endpoint claims the
+	// token expires; any positive duration works.
+	testTokenTTL = time.Hour
+	// preCreatedMode mirrors what entrypoint.sh applies to a pre-created
+	// per-agent cache file: owner (dev) rw, owning agent's private group r.
+	preCreatedMode os.FileMode = 0o640
+	// otherAgentMode is a deliberately world-readable mode used to prove the
+	// isolation assertion is checking OUR file's mode, not a global umask.
+	otherAgentMode os.FileMode = 0o644
+)
+
+// newFakeAppAuth returns an AppAuth wired to a fake mint endpoint that always
+// returns the given token, plus a buffer capturing everything it logs.
+func newFakeAppAuth(t *testing.T, token string) (*AppAuth, *bytes.Buffer, func()) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token":      token,
+			"expires_at": time.Now().Add(testTokenTTL).Format(time.RFC3339),
+		})
+	}))
+	key, err := rsa.GenerateKey(rand.Reader, testRSABits)
+	if err != nil {
+		t.Fatalf("generating test key: %v", err)
+	}
+	var logBuf bytes.Buffer
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		apiURL:         server.URL,
+	}
+	return auth, &logBuf, server.Close
+}
+
+// useTempCacheDir redirects the package-level agent token cache dir at a temp
+// dir for the duration of the test.
+func useTempCacheDir(t *testing.T) string {
+	t.Helper()
+	orig := agentTokenCacheDir
+	dir := t.TempDir()
+	agentTokenCacheDir = dir
+	t.Cleanup(func() { agentTokenCacheDir = orig })
+	return dir
+}
+
+// TestWriteAgentToken_WritesInPlaceWithoutChown is the core regression test
+// for the fleet-wide delivery bug: WriteAgentToken must write the token into
+// the file entrypoint.sh pre-created, PRESERVING that file's mode, and must
+// never fail (or delete the token) because it cannot chown.
+func TestWriteAgentToken_WritesInPlaceWithoutChown(t *testing.T) {
+	const wantToken = "ghs-scoped-advisor"
+	auth, logBuf, closeFn := newFakeAppAuth(t, wantToken)
+	defer closeFn()
+	dir := useTempCacheDir(t)
+
+	// Simulate entrypoint.sh pre-creating the file as dev:hive-guide 0640.
+	path := AgentTokenCachePath("guide")
+	if err := os.WriteFile(path, nil, preCreatedMode); err != nil {
+		t.Fatalf("pre-creating cache file: %v", err)
+	}
+	if err := os.Chmod(path, preCreatedMode); err != nil {
+		t.Fatalf("chmod pre-created file: %v", err)
+	}
+
+	// A non-zero agent UID is the case that used to trigger the fatal chown.
+	if err := auth.WriteAgentToken(context.Background(), "guide", "advisor", 2001); err != nil {
+		t.Fatalf("WriteAgentToken returned error (must not chown): %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("token file missing after write — the old code deleted it: %v", err)
+	}
+	if string(got) != wantToken {
+		t.Errorf("token = %q, want %q", got, wantToken)
+	}
+
+	// The pre-created inode (and therefore its ownership) must survive: a
+	// write-temp-then-rename would reset the mode to the default.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != preCreatedMode {
+		t.Errorf("mode = %o, want %o (rename would have clobbered the entrypoint ownership)", info.Mode().Perm(), preCreatedMode)
+	}
+
+	// No leftover temp file — the old implementation used a .tmp sidecar.
+	if _, err := os.Stat(path + ".tmp"); err == nil {
+		t.Error("stray .tmp file left behind")
+	}
+
+	// The token value must never be logged.
+	if strings.Contains(logBuf.String(), wantToken) {
+		t.Error("token value leaked into logs")
+	}
+	// Pre-created path must NOT emit the degraded warning.
+	if strings.Contains(logBuf.String(), "not pre-created") {
+		t.Errorf("unexpected degraded warning on the healthy path: %s", logBuf.String())
+	}
+	// Fix the directory in the assertion so a path change is caught.
+	if !strings.HasPrefix(path, dir+"/") {
+		t.Errorf("cache path %q not under cache dir %q", path, dir)
+	}
+}
+
+// TestWriteAgentToken_DoesNotReplaceTheInode is the guard against
+// reintroducing a write-temp-then-rename. Verified in the real hive image: a
+// rename replaces the pre-created inode, the new one is created with the
+// writer's primary group (node, gid 1000) instead of the agent's private
+// group, and a DIFFERENT agent could then read the token. The inode number
+// must therefore be unchanged across a write.
+func TestWriteAgentToken_DoesNotReplaceTheInode(t *testing.T) {
+	auth, _, closeFn := newFakeAppAuth(t, "ghs-inode-check")
+	defer closeFn()
+	useTempCacheDir(t)
+
+	path := AgentTokenCachePath("stable")
+	if err := os.WriteFile(path, nil, preCreatedMode); err != nil {
+		t.Fatalf("pre-create: %v", err)
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
+
+	if err := auth.WriteAgentToken(context.Background(), "stable", "advisor", 2005); err != nil {
+		t.Fatalf("WriteAgentToken: %v", err)
+	}
+
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if !os.SameFile(before, after) {
+		t.Error("cache file inode was replaced — a rename would drop the per-agent group and leak the token to every agent in group node")
+	}
+}
+
+// TestWriteAgentToken_AdvisoryTierIsDelivered proves an ADVISORY agent — whose
+// mode fails CanPush() and is therefore deliberately kept GITHUB_TOKEN-less —
+// still receives its advisor-tier scoped token on disk. That file is the
+// advisory agent's only write path for posting ACMM L2 findings as comments.
+func TestWriteAgentToken_AdvisoryTierIsDelivered(t *testing.T) {
+	const wantToken = "ghs-advisor-comment-token"
+	auth, _, closeFn := newFakeAppAuth(t, wantToken)
+	defer closeFn()
+	useTempCacheDir(t)
+
+	path := AgentTokenCachePath("scanner")
+	if err := os.WriteFile(path, nil, preCreatedMode); err != nil {
+		t.Fatalf("pre-creating cache file: %v", err)
+	}
+
+	if err := auth.WriteAgentToken(context.Background(), "scanner", "advisor", 2002); err != nil {
+		t.Fatalf("advisory token delivery failed: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != wantToken {
+		t.Fatalf("advisor token not delivered: content=%q err=%v", got, err)
+	}
+}
+
+// TestWriteAgentToken_AgentsDoNotShareAFile asserts agent A's token never
+// lands in agent B's cache file, and that each agent's file keeps its own
+// mode. Cross-agent readability is prevented by per-agent GROUP ownership set
+// in entrypoint.sh, which cannot be asserted portably in a unit test without
+// root; what IS asserted here is that the code writes strictly per-agent paths
+// and never widens or reuses another agent's file.
+func TestWriteAgentToken_AgentsDoNotShareAFile(t *testing.T) {
+	const tokenA = "ghs-token-for-a"
+	authA, _, closeA := newFakeAppAuth(t, tokenA)
+	defer closeA()
+	useTempCacheDir(t)
+
+	pathA := AgentTokenCachePath("alpha")
+	pathB := AgentTokenCachePath("bravo")
+	if pathA == pathB {
+		t.Fatal("distinct agents resolved to the same cache path")
+	}
+	if err := os.WriteFile(pathA, nil, preCreatedMode); err != nil {
+		t.Fatalf("pre-create A: %v", err)
+	}
+	// Give B a deliberately different mode so we can prove A's write does not
+	// touch it in any way.
+	if err := os.WriteFile(pathB, []byte("bravo-existing"), otherAgentMode); err != nil {
+		t.Fatalf("pre-create B: %v", err)
+	}
+
+	if err := authA.WriteAgentToken(context.Background(), "alpha", "trusted", 2003); err != nil {
+		t.Fatalf("WriteAgentToken(alpha): %v", err)
+	}
+
+	bContents, err := os.ReadFile(pathB)
+	if err != nil {
+		t.Fatalf("read B: %v", err)
+	}
+	if string(bContents) != "bravo-existing" {
+		t.Errorf("agent alpha's write modified agent bravo's cache: %q", bContents)
+	}
+	if strings.Contains(string(bContents), tokenA) {
+		t.Error("agent alpha's token leaked into agent bravo's cache file")
+	}
+	infoB, err := os.Stat(pathB)
+	if err != nil {
+		t.Fatalf("stat B: %v", err)
+	}
+	if infoB.Mode().Perm() != otherAgentMode {
+		t.Errorf("bravo mode changed to %o", infoB.Mode().Perm())
+	}
+}
+
+// TestWriteAgentToken_MissingPreCreatedFileWarnsAccurately asserts the
+// degraded path produces a LOUD, accurate message. The old message claimed the
+// agent "will use shared cache" while having just DELETED the token; the
+// replacement must name the real consequence (privilege escalation to the
+// shared full token, or total failure) and must not claim things are fine.
+func TestWriteAgentToken_MissingPreCreatedFileWarnsAccurately(t *testing.T) {
+	const wantToken = "ghs-no-precreate"
+	auth, logBuf, closeFn := newFakeAppAuth(t, wantToken)
+	defer closeFn()
+	useTempCacheDir(t)
+
+	// Deliberately do NOT pre-create the file.
+	if err := auth.WriteAgentToken(context.Background(), "orphan", "newcomer", 2004); err != nil {
+		t.Fatalf("write should still succeed (best effort), got: %v", err)
+	}
+
+	logs := logBuf.String()
+	if !strings.Contains(logs, "not pre-created") {
+		t.Errorf("degraded path did not warn; logs: %s", logs)
+	}
+	if !strings.Contains(logs, "CANNOT read") {
+		t.Errorf("warning does not state the consequence; logs: %s", logs)
+	}
+	if strings.Contains(logs, wantToken) {
+		t.Error("token value leaked into logs")
+	}
+
+	// Whatever we did create must stay owner-only, never group-readable —
+	// group "node" contains every agent.
+	info, err := os.Stat(AgentTokenCachePath("orphan"))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Errorf("degraded-path file mode %o is readable beyond the owner", info.Mode().Perm())
+	}
+}

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -23,10 +23,23 @@ const (
 	DocsTokenCachePath = "/var/run/hive-metrics/gh-app-token-docs.cache"
 	tokenCachePerms    = 0o640
 
-	// Per-agent scoped token caches — only the owning agent UID can read.
-	agentTokenCacheDir   = "/var/run/hive-metrics/agent-tokens"
+	// Per-agent scoped token caches. entrypoint.sh pre-creates each file as
+	// dev:hive-<agent> mode 0640 so the hive process (dev) can rewrite it in
+	// place and ONLY the owning agent's private group can read it — no chown
+	// at runtime, which an unprivileged process cannot perform.
+	defaultAgentTokenCacheDir = "/var/run/hive-metrics/agent-tokens"
+	// Applied only when the file was NOT pre-created (degraded path): keep it
+	// owner-only rather than leaking a token to the shared "node" group.
 	agentTokenCachePerms = 0o600
+	// Directory must be traversable by every agent UID so each can open its
+	// own 0640 file; the files themselves carry the per-agent restriction.
+	agentTokenCacheDirPerms = 0o755
 )
+
+// agentTokenCacheDir is the directory holding per-agent token caches. It is a
+// variable rather than a constant solely so tests can redirect it to a temp
+// dir; production code never reassigns it.
+var agentTokenCacheDir = defaultAgentTokenCacheDir
 
 type AppAuth struct {
 	appID          int64
@@ -197,40 +210,72 @@ func AgentTokenCachePath(agentName string) string {
 	return agentTokenCacheDir + "/gh-token-" + agentName + ".cache"
 }
 
-// WriteAgentToken mints a scoped token for the given tier and writes it
-// to a per-agent cache file owned by agentUID with 0600 perms. The hive
-// binary (UID 1001) creates the file then chowns it to the agent UID so
-// only that agent can read it.
+// WriteAgentToken mints a tier-scoped token for the given agent and writes it
+// into that agent's pre-created cache file.
+//
+// Delivery model (no chown at runtime):
+//
+// The hive binary drops privileges to dev (UID 1001) and therefore CANNOT
+// chown — handing a file to a different UID requires CAP_CHOWN, which is not
+// granted in the hardened/OpenShift environments hive targets (the same
+// container already fails NET_ADMIN for iptables). The previous
+// implementation wrote a temp file and chowned it to the agent UID; that
+// chown ALWAYS failed with EPERM, the temp file was deleted, and no agent on
+// any hive ever received a token.
+//
+// Instead, entrypoint.sh pre-creates the cache file as root, before the
+// privilege drop, as dev:hive-<agent> mode 0640 (see the per-agent user loop
+// there). That gives us:
+//
+//   - owner dev  -> this process can rewrite the contents in place
+//   - group hive-<agent>, whose only member is that agent -> only the owning
+//     agent can read it (NOT group "node", which every agent shares)
+//
+// The write must therefore be IN PLACE. A write-temp-then-rename would
+// replace the pre-created inode with a fresh dev:node one and silently
+// destroy both the ownership and the isolation guarantee.
 func (a *AppAuth) WriteAgentToken(ctx context.Context, agentName, tier string, agentUID int) error {
 	token, err := a.ScopedToken(ctx, tier)
 	if err != nil {
 		return fmt.Errorf("minting scoped token for %s: %w", agentName, err)
 	}
 
-	if err := os.MkdirAll(agentTokenCacheDir, 0o755); err != nil {
+	if err := os.MkdirAll(agentTokenCacheDir, agentTokenCacheDirPerms); err != nil {
 		return fmt.Errorf("creating agent token dir: %w", err)
 	}
 
 	cachePath := AgentTokenCachePath(agentName)
-	tmpPath := cachePath + ".tmp"
-	if err := os.WriteFile(tmpPath, []byte(token), agentTokenCachePerms); err != nil {
-		return fmt.Errorf("writing agent token cache: %w", err)
+	preCreated := true
+	if _, statErr := os.Stat(cachePath); statErr != nil {
+		preCreated = false
 	}
 
-	if agentUID > 0 {
-		if err := os.Chown(tmpPath, agentUID, -1); err != nil {
-			a.logger.Warn("chown agent token cache failed — agent will use shared cache",
-				"agent", agentName, "uid", agentUID, "error", err)
-			os.Remove(tmpPath)
-			return fmt.Errorf("chown agent token: %w", err)
-		}
+	// O_TRUNC (not O_APPEND) so a shorter token fully replaces a longer one.
+	// The perm argument only applies if the file does not already exist; when
+	// entrypoint pre-created it, the existing 0640 dev:hive-<agent> mode wins.
+	f, err := os.OpenFile(cachePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, agentTokenCachePerms)
+	if err != nil {
+		return fmt.Errorf("opening agent token cache %s: %w", cachePath, err)
+	}
+	if _, err := f.WriteString(token); err != nil {
+		f.Close()
+		return fmt.Errorf("writing agent token cache %s: %w", cachePath, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("closing agent token cache %s: %w", cachePath, err)
 	}
 
-	if err := os.Rename(tmpPath, cachePath); err != nil {
-		return fmt.Errorf("rename agent token cache: %w", err)
+	if !preCreated && agentUID > 0 {
+		// The file did not exist, so we just created it as dev:node 0600 —
+		// the agent UID cannot read it. This is a real, silent-auth-failure
+		// condition, not a benign fallback: state it plainly and actionably.
+		// Do NOT attempt a chown here; it cannot succeed without CAP_CHOWN
+		// and the failure path is what caused this bug in the first place.
+		a.logger.Warn("agent token cache was not pre-created by entrypoint — the agent CANNOT read it and will fall back to the shared full-privilege token (least-privilege scoping lost); ensure entrypoint.sh created this file as dev:hive-<agent> 0640",
+			"agent", agentName, "uid", agentUID, "path", cachePath)
 	}
 
-	a.logger.Info("per-agent token cached", "agent", agentName, "tier", tier, "uid", agentUID)
+	a.logger.Info("per-agent token cached", "agent", agentName, "tier", tier, "uid", agentUID, "pre_created", preCreated)
 	return nil
 }
 

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -32,6 +32,10 @@ type Client struct {
 	exemptLabels []string
 	logger       *slog.Logger
 	appAuth      *AppAuth // nil for token-authenticated clients
+	// prAuthz gates PR-open requests from the request-file watcher against the
+	// per-agent ACMM write-policy + forge-resistance. nil fails closed. Set by
+	// StartPRRequestWatcher.
+	prAuthz PRRequestAuthorizer
 }
 
 // GoGitHub returns the underlying go-github client for direct API access.

--- a/v2/pkg/github/fileowner_other.go
+++ b/v2/pkg/github/fileowner_other.go
@@ -1,0 +1,10 @@
+//go:build !unix
+
+package github
+
+import "io/fs"
+
+// fileOwnerUID has no meaningful value off unix (dev/Windows builds); return -1
+// so the authorizer treats ownership as unverifiable. The production target is
+// Linux, which uses fileowner_unix.go.
+func fileOwnerUID(_ fs.FileInfo) int { return -1 }

--- a/v2/pkg/github/fileowner_unix.go
+++ b/v2/pkg/github/fileowner_unix.go
@@ -1,0 +1,18 @@
+//go:build unix
+
+package github
+
+import (
+	"io/fs"
+	"syscall"
+)
+
+// fileOwnerUID returns the owning UID of a file from its FileInfo on unix. The
+// container runs on Linux, where this is the agent's real UID — the trust anchor
+// for "an agent can only speak for itself" in the PR-request watcher.
+func fileOwnerUID(fi fs.FileInfo) int {
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		return int(st.Uid)
+	}
+	return -1
+}

--- a/v2/pkg/github/pr_request_watcher.go
+++ b/v2/pkg/github/pr_request_watcher.go
@@ -59,17 +59,41 @@ type PRResponse struct {
 	At             string `json:"at"`
 }
 
+// PRRequestAuthorizer decides whether a PR-open request may proceed. It receives
+// the agent NAME claimed in the request and the UID that OWNS the request file
+// (from the file's stat), and returns nil to authorize or an error explaining
+// the denial. This is where the two policy checks live, implemented by the
+// caller (which has the manager + uid-map):
+//
+//  1. Forge-resistance: the fileUID must map to the claimed agent (an agent can
+//     only speak for ITSELF — one agent, or any non-agent process, cannot drop a
+//     request "as" another agent). The per-agent PR-request subdir is UID-owned,
+//     so this is the same UID trust anchor the git credential helper uses.
+//  2. ACMM write-gate: the agent must be push-capable at the hive's current ACMM
+//     level (the same CanPush()/mode check that governs `gh pr create` today) —
+//     an advisory-only agent must NOT be able to open a PR via this path.
+//
+// A nil authorizer DENIES everything (fail closed) — the watcher never opens a
+// PR without an authorizer, so a wiring mistake cannot silently bypass policy.
+type PRRequestAuthorizer func(agent string, fileUID int) error
+
 // StartPRRequestWatcher runs a loop that opens PRs for request files dropped in
 // PRRequestDir. It returns immediately; the loop runs until ctx is cancelled.
 // A nil client (no GitHub creds) makes this a no-op: requests accumulate rather
 // than being silently dropped, so the feature degrades to "nothing opens" not
 // "opened as the wrong identity".
 //
+// authz enforces the per-agent ACMM write-gate + forge-resistance (see
+// PRRequestAuthorizer). A nil authz fails closed (denies every request) — the
+// watcher must never open a PR that hasn't been authorized against the same
+// policy as the direct `gh pr create` path.
+//
 // nowFn is injectable for tests; pass nil for time.Now.
-func (c *Client) StartPRRequestWatcher(ctx context.Context, nowFn func() time.Time) {
+func (c *Client) StartPRRequestWatcher(ctx context.Context, authz PRRequestAuthorizer, nowFn func() time.Time) {
 	if c == nil {
 		return
 	}
+	c.prAuthz = authz
 	if nowFn == nil {
 		nowFn = time.Now
 	}
@@ -135,6 +159,21 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 		return
 	}
 
+	// AUTHORIZE before opening — the watcher must enforce the SAME policy as the
+	// direct `gh pr create` path: the request's agent must own the file (an agent
+	// can only speak for itself) AND be push-capable at the hive's ACMM level.
+	// The owning UID comes from the file's stat, which the requester cannot forge
+	// without actually running as that UID. A nil authorizer fails closed.
+	fileUID := statUID(data, path)
+	if c.prAuthz == nil {
+		c.denyPRRequest(path, req, "no authorizer configured (fail closed)", nowFn)
+		return
+	}
+	if err := c.prAuthz(req.Agent, fileUID); err != nil {
+		c.denyPRRequest(path, req, err.Error(), nowFn)
+		return
+	}
+
 	res, err := c.CreatePR(ctx, req.Repo, req.Head, req.Base, req.Title, req.Body)
 	resp := PRResponse{At: nowFn().UTC().Format(time.RFC3339)}
 	if err != nil {
@@ -159,6 +198,30 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 		slog.String("repo", req.Repo), slog.String("head", req.Head),
 		slog.Int("number", res.Number), slog.Bool("reused", res.AlreadyExisted),
 		slog.String("agent", req.Agent))
+}
+
+// denyPRRequest records an authorization failure and quarantines the request
+// (renamed .denied) so it is not retried forever. A denied request is a policy
+// event, not a transient error — retrying can never make an advisory agent
+// push-capable or change who owns the file.
+func (c *Client) denyPRRequest(path string, req PRRequest, reason string, nowFn func() time.Time) {
+	c.writePRResult(path, PRResponse{OK: false, Error: "authorization denied: " + reason, At: nowFn().UTC().Format(time.RFC3339)})
+	_ = os.Rename(path, path+".denied")
+	c.logger.Warn("pr-request watcher: DENIED (policy)",
+		slog.String("agent", req.Agent), slog.String("repo", req.Repo),
+		slog.String("head", req.Head), slog.String("reason", reason))
+}
+
+// statUID returns the UID that owns the request file. On the (Linux) container
+// this is a real UID that a forging process cannot fake without running as it.
+// data is unused but kept in the signature so a future non-stat proof (e.g. an
+// embedded signed token) can slot in without touching call sites.
+func statUID(_ []byte, path string) int {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return -1
+	}
+	return fileOwnerUID(fi)
 }
 
 func (c *Client) writePRResult(reqPath string, resp PRResponse) {

--- a/v2/pkg/github/pr_request_watcher.go
+++ b/v2/pkg/github/pr_request_watcher.go
@@ -1,0 +1,203 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// PRRequestDir is where agents drop PR-open requests. An agent pushes its branch
+// (the credential helper uses the App token, so the push is already the App
+// identity) and then writes a request file here INSTEAD of running `gh pr
+// create`. The hive's watcher opens the PR with the App token, so the PR is
+// authored by the App bot — never the Copilot login user. This keeps PR
+// authorship deterministic without touching Copilot's auth/entitlement.
+const PRRequestDir = "/var/run/hive-metrics/pr-requests"
+
+// prRequestDirForTest lets tests point the watcher at a temp dir. Empty means
+// use PRRequestDir. Not for production use.
+var prRequestDirForTest string
+
+func prRequestDir() string {
+	if prRequestDirForTest != "" {
+		return prRequestDirForTest
+	}
+	return PRRequestDir
+}
+
+// prRequestPollInterval is how often the watcher scans PRRequestDir. PR opens
+// are not latency-critical (the agent has already pushed and moved on), so a
+// modest interval keeps the API/log noise low.
+const prRequestPollInterval = 10 * time.Second
+
+// PRRequest is the JSON an agent writes to PRRequestDir to ask the hive to open
+// a PR on its behalf. Repo may be "owner/repo" or a bare repo name; Base
+// defaults to "main".
+type PRRequest struct {
+	Repo   string `json:"repo"`
+	Head   string `json:"head"`
+	Base   string `json:"base,omitempty"`
+	Title  string `json:"title"`
+	Body   string `json:"body,omitempty"`
+	Agent  string `json:"agent,omitempty"`
+	IssueN []int  `json:"issues,omitempty"` // informational; the body already carries "Fixes #N"
+}
+
+// PRResponse is written back next to a consumed request (as <name>.result.json)
+// so the agent — or an operator debugging — can see what happened.
+type PRResponse struct {
+	OK             bool   `json:"ok"`
+	Number         int    `json:"number,omitempty"`
+	URL            string `json:"url,omitempty"`
+	AlreadyExisted bool   `json:"already_existed,omitempty"`
+	Error          string `json:"error,omitempty"`
+	At             string `json:"at"`
+}
+
+// StartPRRequestWatcher runs a loop that opens PRs for request files dropped in
+// PRRequestDir. It returns immediately; the loop runs until ctx is cancelled.
+// A nil client (no GitHub creds) makes this a no-op: requests accumulate rather
+// than being silently dropped, so the feature degrades to "nothing opens" not
+// "opened as the wrong identity".
+//
+// nowFn is injectable for tests; pass nil for time.Now.
+func (c *Client) StartPRRequestWatcher(ctx context.Context, nowFn func() time.Time) {
+	if c == nil {
+		return
+	}
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	if err := os.MkdirAll(prRequestDir(), 0o777); err != nil {
+		c.logger.Warn("pr-request watcher: cannot create request dir; disabled",
+			slog.String("dir", prRequestDir()), slog.String("error", err.Error()))
+		return
+	}
+	go func() {
+		t := time.NewTicker(prRequestPollInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				c.processPRRequests(ctx, nowFn)
+			}
+		}
+	}()
+	c.logger.Info("pr-request watcher started", slog.String("dir", prRequestDir()))
+}
+
+// processPRRequests handles one scan of the request dir. Exported-in-spirit for
+// tests via ProcessPRRequestsOnce.
+func (c *Client) processPRRequests(ctx context.Context, nowFn func() time.Time) {
+	entries, err := os.ReadDir(prRequestDir())
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		name := e.Name()
+		// Only consume request files; skip our own .result.json outputs.
+		if e.IsDir() || !strings.HasSuffix(name, ".json") || strings.HasSuffix(name, ".result.json") {
+			continue
+		}
+		path := filepath.Join(prRequestDir(), name)
+		c.handleOnePRRequest(ctx, path, nowFn)
+	}
+}
+
+// ProcessPRRequestsOnce runs a single scan+process pass. Test/CLI entry point.
+func (c *Client) ProcessPRRequestsOnce(ctx context.Context) {
+	if c == nil {
+		return
+	}
+	c.processPRRequests(ctx, time.Now)
+}
+
+func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func() time.Time) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return // vanished between ReadDir and here — fine
+	}
+	var req PRRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		// A malformed request can never succeed; move it aside so it stops being
+		// retried every tick, and leave a result explaining why.
+		c.writePRResult(path, PRResponse{OK: false, Error: "invalid JSON: " + err.Error(), At: nowFn().UTC().Format(time.RFC3339)})
+		_ = os.Rename(path, path+".bad")
+		c.logger.Warn("pr-request watcher: bad request file quarantined",
+			slog.String("path", path), slog.String("error", err.Error()))
+		return
+	}
+
+	res, err := c.CreatePR(ctx, req.Repo, req.Head, req.Base, req.Title, req.Body)
+	resp := PRResponse{At: nowFn().UTC().Format(time.RFC3339)}
+	if err != nil {
+		// Leave the request in place so the next tick retries (transient API
+		// errors, main not yet pushed, etc.), but record the last error.
+		resp.OK = false
+		resp.Error = err.Error()
+		c.writePRResult(path, resp)
+		c.logger.Warn("pr-request watcher: open failed, will retry",
+			slog.String("repo", req.Repo), slog.String("head", req.Head), slog.String("error", err.Error()))
+		return
+	}
+	resp.OK = true
+	resp.Number = res.Number
+	resp.URL = res.URL
+	resp.AlreadyExisted = res.AlreadyExisted
+	c.writePRResult(path, resp)
+	// Success (or reuse of an existing PR) — consume the request so it isn't
+	// reprocessed.
+	_ = os.Remove(path)
+	c.logger.Info("pr-request watcher: PR opened by App bot",
+		slog.String("repo", req.Repo), slog.String("head", req.Head),
+		slog.Int("number", res.Number), slog.Bool("reused", res.AlreadyExisted),
+		slog.String("agent", req.Agent))
+}
+
+func (c *Client) writePRResult(reqPath string, resp PRResponse) {
+	out := strings.TrimSuffix(reqPath, ".json") + ".result.json"
+	if b, err := json.MarshalIndent(resp, "", "  "); err == nil {
+		_ = os.WriteFile(out, b, 0o644)
+	}
+}
+
+// WritePRRequest is a helper (used by tests and any in-process caller) to drop a
+// well-formed request file into PRRequestDir.
+func WritePRRequest(dir string, req PRRequest) (string, error) {
+	if err := os.MkdirAll(dir, 0o777); err != nil {
+		return "", err
+	}
+	b, err := json.MarshalIndent(req, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	name := fmt.Sprintf("%s-%d.json", sanitizeAgentName(req.Agent), time.Now().UnixNano())
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func sanitizeAgentName(s string) string {
+	if s == "" {
+		return "agent"
+	}
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			b.WriteRune(r)
+		}
+	}
+	if b.Len() == 0 {
+		return "agent"
+	}
+	return b.String()
+}

--- a/v2/pkg/github/pr_request_watcher.go
+++ b/v2/pkg/github/pr_request_watcher.go
@@ -102,6 +102,18 @@ func (c *Client) StartPRRequestWatcher(ctx context.Context, authz PRRequestAutho
 			slog.String("dir", prRequestDir()), slog.String("error", err.Error()))
 		return
 	}
+	// Agents (UID >= 2001, in the shared "node" group) must be able to DROP request
+	// files here — hive-open-pr runs AS the agent. MkdirAll is masked by umask to
+	// 0755 (not group-writable), so an agent's write gets EACCES and, under the
+	// hard switch, its PR silently fails to open. Force group-write + setgid (like
+	// /data/beads) so agent-written files inherit the node group and the dir is
+	// writable by every agent. The forge-check still holds: the watcher reads each
+	// file's OWNING UID, which is the agent that wrote it — group-writability lets
+	// them write, it does not let one agent forge another's ownership.
+	if err := os.Chmod(prRequestDir(), 0o2775); err != nil {
+		c.logger.Warn("pr-request watcher: could not set group-writable perms on request dir; agents may be unable to open PRs",
+			slog.String("dir", prRequestDir()), slog.String("error", err.Error()))
+	}
 	go func() {
 		t := time.NewTicker(prRequestPollInterval)
 		defer t.Stop()

--- a/v2/pkg/github/pr_request_watcher_test.go
+++ b/v2/pkg/github/pr_request_watcher_test.go
@@ -1,0 +1,141 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// mock GitHub API for PR create + list. created counts POST /pulls calls.
+func newPRMockServer(t *testing.T, existingHead string, created *int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pulls"):
+			// dedupe list — return one PR only when the requested head matches.
+			head := r.URL.Query().Get("head") // "owner:branch"
+			if existingHead != "" && strings.HasSuffix(head, ":"+existingHead) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `[{"number":11,"html_url":"https://github.com/o/r/pull/11","head":{"ref":"`+existingHead+`"}}]`)
+				return
+			}
+			_, _ = io.WriteString(w, `[]`)
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pulls"):
+			if created != nil {
+				*created++
+			}
+			body, _ := io.ReadAll(r.Body)
+			var np map[string]any
+			_ = json.Unmarshal(body, &np)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":42,"html_url":"https://github.com/o/r/pull/42","title":"`+
+				strings.ReplaceAll(asString(np["title"]), `"`, `\"`)+`"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func asString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func testClient(t *testing.T, srvURL string) *Client {
+	t.Helper()
+	return NewClientForTest(srvURL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+// End-to-end: a request file is opened into a PR, consumed, and a result written.
+func TestPRRequestWatcher_OpensAndConsumes(t *testing.T) {
+	created := 0
+	srv := newPRMockServer(t, "", &created)
+	defer srv.Close()
+	c := testClient(t, srv.URL)
+
+	dir := t.TempDir()
+	old := prRequestDirForTest
+	prRequestDirForTest = dir
+	defer func() { prRequestDirForTest = old }()
+
+	reqPath, err := WritePRRequest(dir, PRRequest{Repo: "o/r", Head: "scanner/fix-1", Title: "[scanner] fix: thing", Body: "Fixes #1", Agent: "scanner"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if created != 1 {
+		t.Fatalf("expected 1 PR created, got %d", created)
+	}
+	// request consumed
+	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
+		t.Errorf("request file should be removed after success")
+	}
+	// result written with the PR number
+	resBytes, err := os.ReadFile(strings.TrimSuffix(reqPath, ".json") + ".result.json")
+	if err != nil {
+		t.Fatalf("result file missing: %v", err)
+	}
+	var res PRResponse
+	if err := json.Unmarshal(resBytes, &res); err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK || res.Number != 42 || res.AlreadyExisted {
+		t.Errorf("unexpected result: %+v", res)
+	}
+}
+
+// Dedupe: an existing open PR for the head is reused, no second PR created.
+func TestPRRequestWatcher_DedupesExistingPR(t *testing.T) {
+	created := 0
+	srv := newPRMockServer(t, "scanner/dup", &created)
+	defer srv.Close()
+	c := testClient(t, srv.URL)
+
+	dir := t.TempDir()
+	old := prRequestDirForTest
+	prRequestDirForTest = dir
+	defer func() { prRequestDirForTest = old }()
+
+	_, _ = WritePRRequest(dir, PRRequest{Repo: "o/r", Head: "scanner/dup", Title: "dup"})
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if created != 0 {
+		t.Errorf("existing PR should be reused, not re-created; got %d creates", created)
+	}
+}
+
+// A malformed request is quarantined (renamed .bad), not retried forever.
+func TestPRRequestWatcher_QuarantinesBadJSON(t *testing.T) {
+	srv := newPRMockServer(t, "", nil)
+	defer srv.Close()
+	c := testClient(t, srv.URL)
+
+	dir := t.TempDir()
+	old := prRequestDirForTest
+	prRequestDirForTest = dir
+	defer func() { prRequestDirForTest = old }()
+
+	bad := filepath.Join(dir, "broken.json")
+	if err := os.WriteFile(bad, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if _, err := os.Stat(bad); !os.IsNotExist(err) {
+		t.Errorf("bad request should be renamed away")
+	}
+	if _, err := os.Stat(bad + ".bad"); err != nil {
+		t.Errorf("bad request should be quarantined as .bad: %v", err)
+	}
+}

--- a/v2/pkg/github/pr_request_watcher_test.go
+++ b/v2/pkg/github/pr_request_watcher_test.go
@@ -50,9 +50,14 @@ func asString(v any) string {
 	return ""
 }
 
+// testClient returns a client whose PR authorizer ALLOWS everything, so the
+// watcher's open/dedupe/quarantine paths can be exercised. Authorization itself
+// is tested separately in TestPRRequestWatcher_Authz*.
 func testClient(t *testing.T, srvURL string) *Client {
 	t.Helper()
-	return NewClientForTest(srvURL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c := NewClientForTest(srvURL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c.prAuthz = func(agent string, uid int) error { return nil }
+	return c
 }
 
 // End-to-end: a request file is opened into a PR, consumed, and a result written.
@@ -137,5 +142,54 @@ func TestPRRequestWatcher_QuarantinesBadJSON(t *testing.T) {
 	}
 	if _, err := os.Stat(bad + ".bad"); err != nil {
 		t.Errorf("bad request should be quarantined as .bad: %v", err)
+	}
+}
+
+// A denying authorizer (e.g. advisory agent / UID mismatch) must NOT open a PR
+// and must quarantine the request as .denied (not retry it forever).
+func TestPRRequestWatcher_AuthzDenyQuarantines(t *testing.T) {
+	created := 0
+	srv := newPRMockServer(t, "", &created)
+	defer srv.Close()
+	c := NewClientForTest(srv.URL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c.prAuthz = func(agent string, uid int) error { return context.DeadlineExceeded } // stand-in denial
+
+	dir := t.TempDir()
+	old := prRequestDirForTest
+	prRequestDirForTest = dir
+	defer func() { prRequestDirForTest = old }()
+
+	reqPath, _ := WritePRRequest(dir, PRRequest{Repo: "o/r", Head: "brainstorm/x", Title: "advisory tries to PR", Agent: "brainstorm"})
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if created != 0 {
+		t.Errorf("denied request must NOT create a PR; got %d", created)
+	}
+	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
+		t.Errorf("denied request should be renamed away")
+	}
+	if _, err := os.Stat(reqPath + ".denied"); err != nil {
+		t.Errorf("denied request should be quarantined as .denied: %v", err)
+	}
+}
+
+// A nil authorizer fails closed: no PR opened.
+func TestPRRequestWatcher_NilAuthzFailsClosed(t *testing.T) {
+	created := 0
+	srv := newPRMockServer(t, "", &created)
+	defer srv.Close()
+	c := NewClientForTest(srv.URL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	// prAuthz deliberately left nil.
+
+	dir := t.TempDir()
+	old := prRequestDirForTest
+	prRequestDirForTest = dir
+	defer func() { prRequestDirForTest = old }()
+
+	_, _ = WritePRRequest(dir, PRRequest{Repo: "o/r", Head: "scanner/y", Title: "no authorizer", Agent: "scanner"})
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if created != 0 {
+		t.Errorf("nil authorizer must fail closed (no PR); got %d", created)
 	}
 }

--- a/v2/pkg/github/pullrequest.go
+++ b/v2/pkg/github/pullrequest.go
@@ -1,0 +1,102 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// CreatePRResult is what CreatePR returns: the opened (or pre-existing) PR.
+type CreatePRResult struct {
+	Number int
+	URL    string
+	// AlreadyExisted is true when an open PR for this head branch was already
+	// present, so we returned it instead of opening a duplicate.
+	AlreadyExisted bool
+}
+
+// CreatePR opens a pull request on behalf of THIS hive's GitHub App — so the PR
+// is authored by the App bot ("<slug>[bot]"), deterministically, regardless of
+// which agent/CLI produced the branch. This is the hive-opens-the-PR path: an
+// agent pushes its branch (the credential helper already uses the App token for
+// the push), then the hive opens the PR here rather than the agent running
+// `gh pr create` (which would attribute the PR to the Copilot login user).
+//
+// repo may be "owner/repo" or a bare repo name (owner defaults to the hive org).
+// head is the branch the agent pushed; base defaults to "main" when empty.
+//
+// It is idempotent: if an OPEN PR for head already exists, it returns that PR
+// with AlreadyExisted=true instead of erroring or opening a duplicate — this
+// makes the file-watcher safe to retry a request that partially succeeded.
+func (c *Client) CreatePR(ctx context.Context, repo, head, base, title, body string) (CreatePRResult, error) {
+	if c == nil || c.client == nil {
+		return CreatePRResult{}, ErrNoGitHubClient
+	}
+	owner := c.org
+	if parts := strings.SplitN(repo, "/", 2); len(parts) == 2 {
+		owner, repo = parts[0], parts[1]
+	}
+	head = strings.TrimSpace(head)
+	if head == "" {
+		return CreatePRResult{}, fmt.Errorf("CreatePR: head branch is required")
+	}
+	if base = strings.TrimSpace(base); base == "" {
+		base = "main"
+	}
+	if strings.TrimSpace(title) == "" {
+		return CreatePRResult{}, fmt.Errorf("CreatePR: title is required")
+	}
+
+	// Idempotency: don't open a second PR for a branch that already has an open
+	// one. GitHub itself 422s on a duplicate, but checking first lets us return
+	// the existing PR cleanly (the watcher may re-process a request after a
+	// crash between "PR opened" and "request file deleted").
+	if existing, err := c.findOpenPRForHead(ctx, owner, repo, head); err != nil {
+		c.logger.Warn("CreatePR: dedupe lookup failed, proceeding to create",
+			slog.String("repo", repo), slog.String("head", head), slog.String("error", err.Error()))
+	} else if existing != nil {
+		c.logger.Info("CreatePR: open PR already exists for head, reusing",
+			slog.String("repo", repo), slog.String("head", head), slog.Int("number", existing.GetNumber()))
+		return CreatePRResult{Number: existing.GetNumber(), URL: existing.GetHTMLURL(), AlreadyExisted: true}, nil
+	}
+
+	pr, _, err := c.client.PullRequests.Create(ctx, owner, repo, &gh.NewPullRequest{
+		Title: gh.Ptr(title),
+		Head:  gh.Ptr(head),
+		Base:  gh.Ptr(base),
+		Body:  gh.Ptr(body),
+	})
+	if err != nil {
+		// A concurrent creator may have raced us; treat an existing-PR 422 as a
+		// reuse rather than a hard failure.
+		if strings.Contains(err.Error(), "A pull request already exists") {
+			if existing, lookErr := c.findOpenPRForHead(ctx, owner, repo, head); lookErr == nil && existing != nil {
+				return CreatePRResult{Number: existing.GetNumber(), URL: existing.GetHTMLURL(), AlreadyExisted: true}, nil
+			}
+		}
+		return CreatePRResult{}, fmt.Errorf("creating PR %s/%s %s->%s: %w", owner, repo, head, base, err)
+	}
+	c.logger.Info("CreatePR: opened PR as the App bot",
+		slog.String("repo", repo), slog.String("head", head), slog.Int("number", pr.GetNumber()))
+	return CreatePRResult{Number: pr.GetNumber(), URL: pr.GetHTMLURL()}, nil
+}
+
+// findOpenPRForHead returns the open PR whose head branch matches, or nil. The
+// head filter is "owner:branch" per the GitHub API.
+func (c *Client) findOpenPRForHead(ctx context.Context, owner, repo, head string) (*gh.PullRequest, error) {
+	prs, _, err := c.client.PullRequests.List(ctx, owner, repo, &gh.PullRequestListOptions{
+		State:       "open",
+		Head:        owner + ":" + head,
+		ListOptions: gh.ListOptions{PerPage: 5},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(prs) > 0 {
+		return prs[0], nil
+	}
+	return nil, nil
+}

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -152,18 +152,40 @@
        stacked so the block height stays stable while they fade; a spacer sizes
        it to the tallest slide. Auto-rotation is JS-driven and disabled under
        prefers-reduced-motion (handled in JS, not just CSS). ── */
-    .hero-rotator { position: relative; }
+    /* Grid-stack crossfade: every slide (and the spacer) shares the same grid
+       cell, so the rotator auto-sizes to the TALLEST slide at any breakpoint.
+       This is what prevents a long lede from overflowing a fixed-height spacer
+       and colliding with the actions below (the old absolute+spacer approach
+       only reserved one slide's height). */
+    .hero-rotator { display: grid; }
+    .hero-rotator > .hero-slide,
+    .hero-rotator > .hero-slide-spacer { grid-area: 1 / 1; }
     .hero-slide {
-      position: absolute; inset: 0;
       opacity: 0; visibility: hidden;
       transition: opacity .6s ease;
     }
     .hero-slide.is-active { opacity: 1; visibility: visible; }
-    .hero-slide-spacer { visibility: hidden; }
-    /* Slides and the spacer must measure identically or the crossfade jumps —
-       but zeroing the margin let the h1's descenders (line-height .92) collide
-       with the lede below. Keep them equal, just not zero. */
-    .hero-slide h1, .hero-slide-spacer h1 { margin: 0 0 1.15rem; }
+    /* Spacer no longer reserves height (the grid does) — keep it fully hidden. */
+    .hero-slide-spacer { visibility: hidden; pointer-events: none; }
+    /* Pin the hero title's font, weight, and size identically on every slide.
+       Without an explicit weight the browser synthesizes bold from whatever
+       Inter weight is (or isn't) installed, so slides rendered subtly different
+       faces. Fixing font-family + font-weight + font-size here makes all slides
+       visually identical regardless of the viewer's installed fonts. */
+    .hero-slide h1, .hero-slide-spacer h1 {
+      margin: 0 0 1.15rem;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-weight: 800;
+      font-size: clamp(3.2rem, 7vw, 6.5rem);
+      line-height: .92;
+      letter-spacing: 0;
+      max-width: 16ch;
+      font-synthesis: none;
+    }
+    .hero-slide .hero-lede, .hero-slide-spacer .hero-lede {
+      font-weight: 400;
+      font-synthesis: none;
+    }
     @media (prefers-reduced-motion: reduce) {
       .hero-slide { transition: none; }
     }

--- a/v2/pkg/policies/defaults/scanner-automerge.md
+++ b/v2/pkg/policies/defaults/scanner-automerge.md
@@ -70,7 +70,9 @@ Steps:
 7. git add the changed files
 8. git commit -s -m "[scanner] fix: <short description covering all issues>"
 9. git push -u origin scanner/fix-<lowest-number>
-10. gh pr create --repo <org>/<repo> --title "[scanner] fix: <short description>" --body "Fixes #<n1>, Fixes #<n2>, Fixes #<n3>" (repeat Fixes keyword for each issue)
+10. Open the PR with **`hive-open-pr`** (the hive opens it as the App bot):
+    `hive-open-pr --repo <org>/<repo> --head scanner/fix-<lowest-number> --title "[scanner] fix: <short description>" --body "Fixes #<n1>, Fixes #<n2>, Fixes #<n3>"` (repeat Fixes keyword for each issue).
+    Do NOT use the GitHub MCP `create_pull_request` / `create_pull_request_with_copilot`, and do NOT run raw `gh pr create` — both author the PR as the login user. `hive-open-pr` is the only sanctioned way to open a PR; the hive opens it with the App token so it is authored by the App bot. `gh pr create` is auto-redirected to `hive-open-pr` for you, but call `hive-open-pr` directly.
 11. git worktree remove /tmp/scanner-fix-<lowest-number>
 12. Return immediately — do NOT wait for CI, do NOT merge, do NOT run build or lint
 ```

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -585,6 +585,12 @@ func (p *GitHubProxy) proxyHTTP(client net.Conn, upstream net.Conn, agentName st
 			req.ContentLength = int64(len(body))
 		} else if !AllowedByMode(mode, req.Method, req.URL.Path) {
 			blocked = true
+			// A hard-deny rule (e.g. direct PR creation) carries an agent-facing
+			// directive explaining the sanctioned alternative — surface it so the
+			// agent knows to use hive-open-pr rather than seeing only a mode error.
+			if msg, denied := DeniedMessage(req.Method, req.URL.Path); denied && msg != "" {
+				blockReason = msg
+			}
 		} else if len(p.allowedRepos) > 0 && !RepoFilterAllowed(p.allowedRepos, req.Method, req.URL.Path) {
 			blocked = true
 			blockReason = "repo not in hive config"

--- a/v2/pkg/proxy/proxy_coverage_test.go
+++ b/v2/pkg/proxy/proxy_coverage_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kubestellar/hive/v2/pkg/agent"
@@ -32,8 +33,17 @@ func TestAllowedByModePROperations(t *testing.T) {
 	if AllowedByMode(agent.ModeIssuesOnly, "POST", "/repos/org/repo/pulls") {
 		t.Error("ISSUES_ONLY should NOT allow creating PRs")
 	}
-	if !AllowedByMode(agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls") {
-		t.Error("ISSUES_AND_PRS should allow creating PRs")
+	// Direct PR creation (POST /pulls) is a HARD DENY for every mode — agents
+	// must route through hive-open-pr so the App bot authors the PR. Even a
+	// push-capable mode cannot POST /pulls directly.
+	if AllowedByMode(agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls") {
+		t.Error("POST /pulls must be denied for all modes (use hive-open-pr)")
+	}
+	if AllowedByMode(agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/pulls") {
+		t.Error("POST /pulls must be denied even for merge mode (use hive-open-pr)")
+	}
+	if msg, denied := DeniedMessage("POST", "/repos/org/repo/pulls"); !denied || !strings.Contains(msg, "hive-open-pr") {
+		t.Errorf("POST /pulls should carry a hive-open-pr deny message; got denied=%v msg=%q", denied, msg)
 	}
 	if !AllowedByMode(agent.ModeIssuesAndPRs, "PATCH", "/repos/org/repo/pulls/42") {
 		t.Error("ISSUES_AND_PRS should allow patching PRs")
@@ -314,8 +324,11 @@ func TestIsGitHubHostComplete(t *testing.T) {
 }
 
 func TestAllowedByModeEscalation(t *testing.T) {
-	path := "/repos/org/repo/pulls"
-	method := "POST"
+	// PATCH /pulls/<n> is a mode-gated PR operation (unlike POST /pulls, which is
+	// a hard deny for every mode): advisory/issues-only cannot, issues-and-prs and
+	// above can. This exercises the mode-escalation path itself.
+	path := "/repos/org/repo/pulls/42"
+	method := "PATCH"
 
 	modes := []agent.AgentMode{
 		agent.ModeAdvisory,
@@ -331,6 +344,14 @@ func TestAllowedByModeEscalation(t *testing.T) {
 		}
 		if i >= 2 && !allowed {
 			t.Errorf("mode %v should allow %s %s", mode, method, path)
+		}
+	}
+
+	// POST /pulls (direct PR creation) is denied for EVERY mode — no escalation
+	// unlocks it. Agents must use hive-open-pr.
+	for _, mode := range modes {
+		if AllowedByMode(mode, "POST", "/repos/org/repo/pulls") {
+			t.Errorf("mode %v must NOT allow direct POST /pulls (use hive-open-pr)", mode)
 		}
 	}
 }

--- a/v2/pkg/proxy/proxy_deep2_test.go
+++ b/v2/pkg/proxy/proxy_deep2_test.go
@@ -550,9 +550,10 @@ func TestProxyHTTPBlockedPOSTShowsPath(t *testing.T) {
 	if !strings.Contains(response, "403") {
 		t.Errorf("expected 403 in response")
 	}
-	// The blocked path should be mentioned in the body
-	if !strings.Contains(response, "/repos/org/repo/pulls") {
-		t.Errorf("expected path in response body, got: %s", response)
+	// POST /pulls is a hard deny: the body carries the hive-open-pr directive
+	// (the deny message) rather than the raw path, so agents learn the fix.
+	if !strings.Contains(response, "hive-open-pr") {
+		t.Errorf("expected hive-open-pr directive in response body, got: %s", response)
 	}
 }
 

--- a/v2/pkg/proxy/proxy_extra_test.go
+++ b/v2/pkg/proxy/proxy_extra_test.go
@@ -261,14 +261,17 @@ func TestAllowedByModeComprehensive(t *testing.T) {
 		{agent.ModeIssuesOnly, "POST", "/repos/org/repo/issues/1/comments", true},
 		{agent.ModeIssuesOnly, "POST", "/repos/org/repo/pulls", false},
 
-		// IssuesAndPRs can create PRs but not merge
-		{agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls", true},
+		// IssuesAndPRs can push + patch PRs but NOT create them directly
+		// (POST /pulls is a hard deny — agents use hive-open-pr).
+		{agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls", false},
+		{agent.ModeIssuesAndPRs, "PATCH", "/repos/org/repo/pulls/42", true},
 		{agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/issues", true},
 		{agent.ModeIssuesAndPRs, "PUT", "/repos/org/repo/pulls/1/merge", false},
 
-		// IssuesPRsMerge can do everything
+		// IssuesPRsMerge can merge + create issues, but still cannot POST /pulls
+		// directly (direct PR creation is denied for every mode).
 		{agent.ModeIssuesPRsMerge, "PUT", "/repos/org/repo/pulls/1/merge", true},
-		{agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/pulls", true},
+		{agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/pulls", false},
 		{agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/issues", true},
 	}
 

--- a/v2/pkg/proxy/proxy_test.go
+++ b/v2/pkg/proxy/proxy_test.go
@@ -45,12 +45,14 @@ func TestAllowedByModeExtended(t *testing.T) {
 		{"issues-only can comment", agent.ModeIssuesOnly, "POST", "/repos/org/repo/issues/1/comments", true},
 		{"issues-only cannot create PRs", agent.ModeIssuesOnly, "POST", "/repos/org/repo/pulls", false},
 
-		{"issues-and-prs can create PRs", agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls", true},
+		// Direct PR creation is a hard deny for EVERY mode — agents must use
+		// hive-open-pr so the App bot authors the PR (never the login user).
+		{"issues-and-prs cannot create PRs directly (use hive-open-pr)", agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls", false},
 		{"issues-and-prs can push", agent.ModeIssuesAndPRs, "POST", "/repos/org/repo.git/git-receive-pack", true},
 		{"issues-and-prs cannot merge", agent.ModeIssuesAndPRs, "PUT", "/repos/org/repo/pulls/1/merge", false},
 
 		{"merge mode can merge", agent.ModeIssuesPRsMerge, "PUT", "/repos/org/repo/pulls/1/merge", true},
-		{"merge mode can create PRs", agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/pulls", true},
+		{"merge mode cannot create PRs directly (use hive-open-pr)", agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/pulls", false},
 
 		{"git upload-pack always allowed", agent.ModeAdvisory, "POST", "/repos/org/repo.git/git-upload-pack", true},
 

--- a/v2/pkg/proxy/rules.go
+++ b/v2/pkg/proxy/rules.go
@@ -98,7 +98,9 @@ var rules = []ProxyRule{
 	{regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/\d+/merge$`), "PUT", agent.ModeIssuesPRsMerge},
 
 	// ── PR operations — ISSUES_AND_PRS and above ──
-	{regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls$`), "POST", agent.ModeIssuesAndPRs},
+	// NOTE: direct PR creation (POST /pulls) is NOT here — it is a HARD DENY for
+	// every mode, handled by denyRules below, so agents route through hive-open-pr
+	// (App-bot authorship) instead of `gh pr create` / the GitHub MCP create_pull_request.
 	{regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/\d+$`), "PATCH", agent.ModeIssuesAndPRs},
 	{regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/\d+/reviews`), "POST", agent.ModeIssuesAndPRs},
 
@@ -127,13 +129,56 @@ var rules = []ProxyRule{
 // AllowedByMode returns true if the given HTTP method+path is permitted
 // for an agent running in the specified mode. Unknown operations are
 // denied by default.
+// denyRule is a hard block that applies to EVERY agent mode, regardless of the
+// mode-escalation rules. It exists for operations agents must route through a
+// hive-mediated path instead of calling GitHub directly.
+type denyRule struct {
+	PathPattern *regexp.Regexp
+	Method      string
+	Msg         string // agent-facing directive surfaced in the 403 body
+}
+
+// denyRules are checked BEFORE the mode rules. The canonical (and currently only)
+// case is direct PR creation: a POST /repos/*/pulls — whether from `gh pr create`
+// or the GitHub MCP create_pull_request/create_pull_request_with_copilot tool —
+// authors the PR as the Copilot login user, not the App bot. Blocking it here
+// forces agents to use `hive-open-pr`, which the hive fulfills with the App token
+// so the PR is authored by the App bot. This closes the MCP path the gh-wrapper
+// redirect cannot see. The hive's OWN CreatePR call does not traverse this agent
+// proxy, so it is unaffected.
+var denyRules = []denyRule{
+	{
+		PathPattern: regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls$`),
+		Method:      "POST",
+		Msg:         "direct PR creation is disabled for agents — use `hive-open-pr --repo <owner/repo> --head <branch> --title <t> --body <b>` so the hive opens the PR as the App bot (never the login user). Do NOT use `gh pr create` or the GitHub MCP create_pull_request/create_pull_request_with_copilot.",
+	},
+}
+
 func AllowedByMode(mode agent.AgentMode, method, path string) bool {
+	// Hard denies win over any mode rule.
+	if _, denied := DeniedMessage(method, path); denied {
+		return false
+	}
 	for _, r := range rules {
 		if r.Method == method && r.PathPattern.MatchString(path) {
 			return mode >= r.MinMode
 		}
 	}
 	return false
+}
+
+// DeniedMessage returns the agent-facing directive for a request blocked by a
+// hard-deny rule, and true if such a rule matched. It lets the proxy surface WHY
+// a request was refused (e.g. "use hive-open-pr") instead of the generic ACMM
+// message. Returns ("", false) when no deny rule matches — the caller then falls
+// back to the normal mode-based block reason.
+func DeniedMessage(method, path string) (string, bool) {
+	for _, r := range denyRules {
+		if r.Method == method && r.PathPattern.MatchString(path) {
+			return r.Msg, true
+		}
+	}
+	return "", false
 }
 
 var repoPathPrefix = regexp.MustCompile(`^/repos/([^/]+/[^/]+)`)

--- a/v2/pkg/proxy/rules_test.go
+++ b/v2/pkg/proxy/rules_test.go
@@ -40,7 +40,8 @@ func TestAllowedByMode(t *testing.T) {
 		// ── ISSUES_AND_PRS: issues + PRs, no merge ──
 		{"prs allows GET", agent.ModeIssuesAndPRs, "GET", "/repos/org/repo/pulls", true},
 		{"prs allows POST issue", agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/issues", true},
-		{"prs allows POST pull", agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls", true},
+		// Direct PR creation is a hard deny for every mode — agents use hive-open-pr.
+		{"prs blocks direct POST pull", agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls", false},
 		{"prs allows PATCH pull", agent.ModeIssuesAndPRs, "PATCH", "/repos/org/repo/pulls/42", true},
 		{"prs allows PR review", agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls/42/reviews", true},
 		{"prs allows git push", agent.ModeIssuesAndPRs, "POST", "/org/repo.git/git-receive-pack", true},
@@ -52,7 +53,8 @@ func TestAllowedByMode(t *testing.T) {
 		// ── ISSUES_PRS_MERGE: everything allowed ──
 		{"merge allows GET", agent.ModeIssuesPRsMerge, "GET", "/repos/org/repo/issues", true},
 		{"merge allows POST issue", agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/issues", true},
-		{"merge allows POST pull", agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/pulls", true},
+		// Even merge mode cannot POST /pulls directly — hive-open-pr is the only path.
+		{"merge blocks direct POST pull", agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/pulls", false},
 		{"merge allows PUT merge", agent.ModeIssuesPRsMerge, "PUT", "/repos/org/repo/pulls/42/merge", true},
 		{"merge allows git push", agent.ModeIssuesPRsMerge, "POST", "/org/repo.git/git-receive-pack", true},
 

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -617,6 +617,13 @@ func (s *Scheduler) ghAuthInstructions(agentName string) string {
 - Writes are authored by the App bot identity, not a personal account. Do not
   set git user.name/user.email to a human, and do not pass 'gh pr create' or
   'git commit' an explicit --author: let the App identity stand.
+- To OPEN A PULL REQUEST, use ` + "`hive-open-pr`" + ` — the hive opens it with the
+  App token so it is authored by the App bot ("<slug>[bot]"), never the login user:
+    hive-open-pr --repo <org>/<repo> --head <your-branch> --title "<title>" --body "<body with Fixes #N>"
+  Do NOT open PRs with the GitHub MCP (create_pull_request / create_pull_request_with_copilot)
+  or raw 'gh pr create' — those author the PR as the Copilot login user. 'gh pr create'
+  is auto-redirected to hive-open-pr, but prefer calling hive-open-pr directly.
+  (Push your branch first; hive-open-pr requests the PR, the hive opens it within ~10s.)
 - git push / git fetch: run them normally. A credential helper supplies the
   App-scoped push token automatically. Do NOT export GH_TOKEN for git and do
   NOT use HIVE_GITHUB_TOKEN (it is read-only; overriding breaks pushes).


### PR DESCRIPTION
Branch-to-branch sync v2 → v3. Backports pr-request dir perms (#2255) and proxy hard-deny of direct POST /pulls (#2257). MERGE not squash — preserves ancestry. Do not merge until CI incl. docker green.