### PR TITLE
🐛 fix(bob): recognise bob's default input placeholder as ready

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -768,6 +768,7 @@ var cliPaneMarkers = []string{
 	// waitForCLIReadyForAgent can never see a booted bob, so its startup kick
 	// would be dropped after cliReadyTimeout even though bob is healthy.
 	bobInputPlaceholder,
+	bobInputPlaceholderDefault,
 	bobProductMarker,
 }
 
@@ -779,6 +780,19 @@ const (
 	// `isInputActive`, so seeing it means the input is live, not merely
 	// painted. Copied verbatim from bobshell 1.0.6 — see TestBobPaneMarkers.
 	bobInputPlaceholder = "Type your message or @path/to/file"
+	// bobInputPlaceholderDefault is the OTHER placeholder bob renders in that
+	// same input box. The two are alternatives chosen by editor mode, not
+	// versions: the bundle picks bobInputPlaceholder only when vim-style
+	// modal editing is on, and this string in every other case — which is the
+	// default, so it is what a stock bob actually shows when idle and ready.
+	//
+	// Verified live on bobshell 1.0.6: a healthy authenticated bob pane
+	// contained this string and ZERO occurrences of bobInputPlaceholder, so
+	// waitForCLIReadyForAgent never saw it as ready and every governor kick
+	// was dropped with "CLI did not become ready after restart" while bob sat
+	// perfectly healthy at its prompt. Both strings are present in the 1.0.6
+	// bundle, so match either rather than replacing one with the other.
+	bobInputPlaceholderDefault = "Enter your prompt, / for commands"
 	// bobProductMarker is bob's product name, which appears in its banner and
 	// dialogs. It is a weaker, secondary signal than bobInputPlaceholder — it
 	// also shows on trust/auth/license dialogs, which are NOT ready states —
@@ -1877,7 +1891,8 @@ func paneShowsInputPrompt(output string) bool {
 		strings.Contains(output, "goose is ready") ||
 		strings.Contains(output, "> Enter to send") ||
 		strings.Contains(output, "\n>\n") ||
-		strings.Contains(output, bobInputPlaceholder)
+		strings.Contains(output, bobInputPlaceholder) ||
+		strings.Contains(output, bobInputPlaceholderDefault)
 }
 
 // waitForCLIReady polls the tmux pane until the CLI shows its ready prompt


### PR DESCRIPTION
A healthy, authenticated bob never registered as ready, so **every governor kick was dropped**:

```
WARN  agent CLI crashed or stuck on consent screen, restarting before kick  name=scanner consent_screen=false
WARN  failed to send kick  agent=scanner  error="agent scanner CLI did not become ready after restart"
```

…while bob sat perfectly fine at its prompt with `Auto-approve: Full` and a live token balance.

## Root cause

bob renders one of **two** placeholders in its input box, chosen by **editor mode**, not by version. From the 1.0.6 bundle:

```js
placeholder: s ? "  Press 'i' for INSERT mode and 'Esc' for NORMAL mode."
               : "  Type your message or @path/to/file"
...
" Enter your prompt, / for commands, @ for files, ! for Shell mode"
```

Only `Type your message or @path/to/file` was matched. That one appears when vim-style modal editing is on; the other is the **default**, and it is what a stock bob shows when idle and ready.

## Verified live on bobshell 1.0.6

An authenticated bob pane contained:
- the default placeholder — **1** occurrence
- `Type your message or @path/to/file` — **0** occurrences
- `❯` — **0** occurrences

So `paneShowsInputPrompt` returned false forever and `waitForCLIReadyForAgent` timed out on a completely healthy CLI.

Both strings are present in the 1.0.6 bundle, so this **matches either** rather than swapping one for the other — a contributor running bob in vim mode keeps working.

The new constant is also added to the CLI-presence marker list, so `tmuxPaneHasCLIForAgent` sees a booted bob too.

## Verification

- `go build ./...` and `go vet ./pkg/agent/` clean.
- `go test ./pkg/agent/ -run 'BobPaneMarkers|PaneShowsInputPrompt|CLIReady'` → **ok**.
- gofmt: `manager.go` is flagged, but the drift is **pre-existing** `ProcessState` const alignment in a block I never touched — **zero** of my lines appear in `gofmt -d`. Left alone per the no-wildcard-sweep rule.

## Ports

Needs porting to `mk`, `dd`, and `v3`.