### PR TITLE
config: fix GHE App install URL for hives with a blank base_url

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1277,17 +1277,32 @@ func (g GitHubConfig) ResolvedAPIURL() string {
 	return DefaultGitHubAPIURL
 }
 
-// ResolvedBaseURL returns the configured base URL or the default for github.com.
+// ResolvedBaseURL returns the base URL of the GitHub the hive's App/repos live
+// on, as a full "https://host" URL. It prefers an explicit base_url, but falls
+// back to the host of api_url when base_url is blank — pooled/placeholder GHE
+// hives legitimately carry base_url: "" with api_url: https://github.ibm.com/api/v3,
+// and resolving those to github.com breaks App-host-derived URLs (notably the
+// App install link, which would point at github.com/apps/... instead of the GHE
+// github.ibm.com/github-apps/... path). This mirrors HostLabel()'s base-or-api
+// derivation. Login/device-flow paths deliberately do NOT use this — see
+// OAuthBaseURL, which is always public github.com.
 func (g GitHubConfig) ResolvedBaseURL() string {
 	if g.BaseURL != "" {
 		return g.BaseURL
 	}
+	// base_url blank: derive from api_url's host if it points at a GHE instance.
+	if host := g.HostLabel(); host != DefaultGitHubBaseURL[len("https://"):] {
+		return "https://" + host
+	}
 	return DefaultGitHubBaseURL
 }
 
-// IsGHE returns true if the configured base URL points to a GitHub Enterprise instance.
+// IsGHE returns true if the hive's App/repos live on a GitHub Enterprise instance
+// rather than public github.com. It looks at BOTH base_url and api_url (via
+// HostLabel), so a hive carrying only a GHE api_url (base_url: "") is still
+// correctly recognized as GHE — matching ResolvedBaseURL and HostLabel.
 func (g GitHubConfig) IsGHE() bool {
-	return g.BaseURL != "" && g.BaseURL != DefaultGitHubBaseURL
+	return g.HostLabel() != DefaultGitHubBaseURL[len("https://"):]
 }
 
 // HostLabel returns the bare GitHub hostname this hive's App/repos live on:

--- a/v2/pkg/config/config_uncovered_coverage_test.go
+++ b/v2/pkg/config/config_uncovered_coverage_test.go
@@ -251,19 +251,46 @@ func TestGitHubConfig_IsGHE(t *testing.T) {
 	tests := []struct {
 		name    string
 		baseURL string
+		apiURL  string
 		want    bool
 	}{
-		{"empty base url is not GHE", "", false},
-		{"default github.com is not GHE", DefaultGitHubBaseURL, false},
-		{"custom base url is GHE", "https://github.mycorp.com", true},
+		{"empty base+api url is not GHE", "", "", false},
+		{"default github.com is not GHE", DefaultGitHubBaseURL, "", false},
+		{"custom base url is GHE", "https://github.mycorp.com", "", true},
+		// Pooled/placeholder GHE hives carry base_url:"" with a GHE api_url — they
+		// MUST be recognized as GHE (else the install URL points at github.com).
+		{"blank base url + GHE api url is GHE", "", "https://github.ibm.com/api/v3", true},
+		{"blank base url + github.com api url is not GHE", "", DefaultGitHubAPIURL, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := GitHubConfig{BaseURL: tt.baseURL}
+			g := GitHubConfig{BaseURL: tt.baseURL, APIURL: tt.apiURL}
 			if got := g.IsGHE(); got != tt.want {
 				t.Errorf("IsGHE() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestGitHubConfig_AppInstallURL_BlankBaseGHEApi is the exact zacburns bug: a GHE
+// hive whose overlay carries app_id/app_slug/api_url on github.ibm.com but an
+// empty base_url. The spoke UI must build the GHE /github-apps/ install URL, not
+// the github.com /apps/ one (which returns an empty page on GHE).
+func TestGitHubConfig_AppInstallURL_BlankBaseGHEApi(t *testing.T) {
+	g := GitHubConfig{
+		APIURL:  "https://github.ibm.com/api/v3",
+		BaseURL: "",
+		AppSlug: "kubestellar-hive-ghe",
+	}
+	want := "https://github.ibm.com/github-apps/kubestellar-hive-ghe/installations/new"
+	if got := g.AppInstallURL(); got != want {
+		t.Errorf("AppInstallURL() = %q, want %q", got, want)
+	}
+	if !g.IsGHE() {
+		t.Error("IsGHE() = false, want true for blank base_url + GHE api_url")
+	}
+	if got := g.ResolvedBaseURL(); got != "https://github.ibm.com" {
+		t.Errorf("ResolvedBaseURL() = %q, want https://github.ibm.com", got)
 	}
 }
 


### PR DESCRIPTION
## Problem (observed on zacburns / hosted-available-vllmd-04)

A GHE hive on the vllm-d cluster is correctly configured with the GHE App:
`app_id: 5686`, `app_slug: kubestellar-hive-ghe`, `api_url: https://github.ibm.com/api/v3` — but with **`base_url: ""`** (pooled/placeholder hives carry a blank base_url and rely on api_url for the host).

The spoke UI's "View app settings" link built:
`https://github.com/apps/kubestellar-hive-ghe/installations/new` ← **wrong host**, returns an empty page on GHE.

The correct GHE link is:
`https://github.ibm.com/github-apps/kubestellar-hive-ghe/installations/new` (confirmed working).

Because the install page never loaded, the org owner could never install the App, so the hive logged `github app recheck: hive is running without GitHub credentials` every 2 minutes and agents had no credentials.

## Root cause

`IsGHE()` and `ResolvedBaseURL()` keyed on `base_url` **only**:
```go
func (g GitHubConfig) IsGHE() bool { return g.BaseURL != "" && g.BaseURL != DefaultGitHubBaseURL }
```
With `base_url: ""`, IsGHE()→false and ResolvedBaseURL()→github.com, so `AppInstallURL()` used the github.com `/apps/` path. `HostLabel()` already solved this exact class ("pooled placeholders carry an empty base_url but a GHE api_url") by falling back to the api_url host — but IsGHE/ResolvedBaseURL never got the same treatment.

## Fix

Make `IsGHE()` and `ResolvedBaseURL()` derive the host from base_url **or** api_url (via `HostLabel()`), matching `HostLabel()`. A hive with only a GHE api_url is now recognized as GHE, and its install URL points at `https://github.ibm.com/github-apps/<slug>/installations/new`.

**Scope check:** every `ResolvedBaseURL()`/`IsGHE()` caller wants the real GHE host when the hive is GHE (install URL, agent repo links in scheduler, dashboard `GitHubBaseURL`, proxy host registration). **None are OAuth/device-flow paths** — those use `OAuthBaseURL()`, which stays public github.com. OAuth/App split is preserved.

**No hack downstream:** once zac installs via the correct GHE URL, the existing installation-discovery loop (`app_discovery.go`, JWT client pointed at `api_url` = github.ibm.com) auto-adopts the installation id — no manual entry.

## Tests

- `IsGHE`: added blank-base_url + GHE-api_url → true, and blank + github.com-api_url → false.
- New `TestGitHubConfig_AppInstallURL_BlankBaseGHEApi`: the exact zacburns config → GHE `/github-apps/` URL, IsGHE true, ResolvedBaseURL github.ibm.com.
- Existing AppInstallURL/HostLabel/OAuth tables still green.