### PR TITLE
docs(contribute): name the contributor relay ClankeR

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,4 @@
-# Justfile — KubeStellar Hive contributor commands
+# Justfile — KubeStellar Hive contributor commands, for ClankeR (the contributor relay)
 #
 # Install just: brew install just (macOS) or cargo install just
 # Usage: just contribute-setup claude && just contribute-hive
@@ -91,7 +91,7 @@ contribute-setup backend="claude": check-version
       echo ""
     fi
     mkdir -p "{{config_dir}}"
-    echo "=== Hive Contributor Setup ==="
+    echo "=== Hive Contributor Setup (ClankeR) ==="
     echo ""
 
     # ── Step 1: GitHub authentication ──
@@ -318,7 +318,7 @@ contribute-hive backend="" mode="docker": check-version
       BACKEND="${AGENT_BACKEND:-claude}"
     fi
     export AGENT_BACKEND="$BACKEND"
-    echo "=== Hive Contributor Agent ==="
+    echo "=== Hive Contributor Agent (ClankeR) ==="
     echo "Backend:  ${BACKEND}"
     echo "Hub:      {{hive_hub}}"
     echo "GitHub:   $(gh api user --jq '.login' 2>/dev/null || echo 'authenticated')"

--- a/README.md
+++ b/README.md
@@ -278,7 +278,9 @@ flowchart LR
 
 ## Contribute to a Hive
 
-Community members can contribute compute to any hive:
+Community members can contribute compute to any hive through **ClankeR**, the
+contributor relay — it hands tasks from a hive's backlog to the CLI agent
+running on your own machine:
 
 ```bash
 brew install just gh

--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -2,7 +2,7 @@
 # contributor-agent.sh — Entrypoint for the contributor container.
 #
 # 1. Detects which CLI backend is authenticated
-# 2. Starts the contributor-relay (WebSocket client) in the background
+# 2. Starts contributor-relay.sh — ClankeR, the contributor relay (WebSocket client) — in the background
 # 3. Launches the CLI agent in a tmux session
 # 4. The relay feeds tasks into the tmux session and reports results
 #
@@ -105,7 +105,7 @@ detect_cli() {
   esac
 }
 
-echo "=== Hive Contributor Agent ==="
+echo "=== Hive Contributor Agent (ClankeR) ==="
 echo "Hub:     $HIVE_HUB"
 echo "Backend: $AGENT_BACKEND"
 echo ""
@@ -244,7 +244,7 @@ tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
 tmux new-session -d -s "$TMUX_SESSION" -x 200 -y 50
 
 # Start the relay in the background
-echo "Starting relay connection to hub..."
+echo "Starting ClankeR relay connection to hub..."
 node "${SCRIPT_DIR}/contributor-relay.sh" &
 RELAY_PID=$!
 
@@ -335,9 +335,9 @@ AUTO_DISMISS_INTERVAL=3
 echo ""
 CONTAINER_NAME="${HIVE_CONTAINER_NAME:-hive-contributor}"
 echo "Contributor agent is running."
-echo "  CLI:   $CMD"
-echo "  Relay: PID $RELAY_PID"
-echo "  Tmux:  docker exec -it $CONTAINER_NAME tmux attach -t $TMUX_SESSION"
+echo "  CLI:     $CMD"
+echo "  ClankeR: PID $RELAY_PID"
+echo "  Tmux:    docker exec -it $CONTAINER_NAME tmux attach -t $TMUX_SESSION"
 echo ""
 
 # Keep running until interrupted

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-// contributor-relay.sh — WebSocket client that connects a contributor agent to the Hive hub.
+// contributor-relay.sh — ClankeR, the contributor relay: the WebSocket client
+// that connects a contributor agent to the Hive hub.
 //
 // Handles: authentication, task receipt, GitHub token injection, result reporting,
 // heartbeat, and reconnection with exponential backoff.

--- a/docs/federation-design.md
+++ b/docs/federation-design.md
@@ -5,7 +5,9 @@
 Hive Federation allows any open source project to run their own Hive instance
 and join a network where contributors can discover and join any participating
 project's swarm. A contributor runs `just contribute-browse` to find projects
-that need help, then `just contribute-hive` pointed at that project's hub.
+that need help, then `just contribute-hive` pointed at that project's hub —
+**ClankeR**, the contributor relay, carries that project's tasks to the agent on
+their machine.
 
 ## How a New Project Signs Up
 
@@ -131,7 +133,7 @@ connections and token minting.
 
 - **Dashboard** at port 3001 with agent status, queue, sparklines
 - **Agent fleet** (scanner, supervisor, + whatever they enable)
-- **Contributor WebSocket** at `/contribute`
+- **Contributor WebSocket** (ClankeR) at `/contribute`
 - **Scoped GitHub tokens** via the shared Hive GitHub App
 - **Governor** that adapts agent cadence to queue depth
 - **Nous Strategy Lab** for automated experimentation (optional)

--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -1,3 +1,5 @@
+# Contributor image for ClankeR, the contributor relay: a CLI agent plus the
+# WebSocket client that pulls tasks from a Hive hub.
 FROM debian:bookworm-slim
 
 ARG NODE_MAJOR=24

--- a/v2/compose-contributor.yaml
+++ b/v2/compose-contributor.yaml
@@ -1,3 +1,5 @@
+# ClankeR — the contributor relay. Runs a contributor's CLI agent locally and
+# connects it to a Hive hub over WebSocket.
 services:
   contributor:
     build:

--- a/v2/docs/architecture.md
+++ b/v2/docs/architecture.md
@@ -36,7 +36,7 @@ flowchart LR
     notify["Notifications<br/>(ntfy · Slack · Discord)"]
 
     maintainer -->|HTTPS dashboard| hive
-    contributor -->|contribute relay| hive
+    contributor -->|ClankeR contributor relay| hive
     hive <-->|"REST · git (via MITM proxy)"| github
     hive <-->|inference| models
     hive -->|"heartbeat every 2 min"| hub
@@ -298,9 +298,9 @@ sequenceDiagram
 ```
 
 The hub also serves the public **registry**, cross-hive **leaderboard**, and the
-**contributor** flow: community members donate compute to a spoke via a relay,
-starting rate-limited and auto-promoting through trust tiers as tasks complete —
-their credentials never leave their machine.
+**contributor** flow: community members donate compute to a spoke via **ClankeR**,
+the contributor relay — starting rate-limited and auto-promoting through trust
+tiers as tasks complete — their credentials never leave their machine.
 
 ---
 

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -236,6 +236,9 @@ func findContributor(id string) *ContributorProfile {
 
 // ── Landing page ───────────────────────────────────────────────────────────
 
+// handleContributeLanding renders the public sign-up page for ClankeR, the
+// contributor relay: it explains the deal, offers per-CLI copy-paste setup
+// commands, and shows a live feed of contributor activity.
 func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request) {
 	profiles := listContributorProfiles()
 	projectName := ""
@@ -345,6 +348,7 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 <div class="main">
 <h1>🐝 Contribute to %s</h1>
 <p class="subtitle">Donate your CLI + API tokens to help this project's AI agent swarm.</p>
+<p class="subtitle" style="font-size:.95rem;margin-top:-24px;margin-bottom:32px">Powered by <strong style="color:#e6edf3">ClankeR</strong>, the contributor relay &mdash; it hands tasks from this hive's backlog to the agent running on your machine. Your compute, their backlog.</p>
 <div class="stat-row">
 <div class="stat"><div class="stat-num" style="color:#58a6ff">%d</div><div class="stat-label">Total</div></div>
 %s
@@ -470,7 +474,7 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 <div class="how">
 <h3>What you bring vs. what the hive provides</h3>
 <p><strong>You bring:</strong> Your GitHub account + CLI API tokens. With LiteLLM you bring your own proxy instead — Claude Code on your machine talks directly to your endpoint, and the hive never sees your endpoint or key. Issues and PRs are created under YOUR name.</p>
-<p><strong>The hive provides:</strong> Work queue, task assignment, and coordination. Your credentials never leave your machine.</p>
+<p><strong>The hive provides:</strong> Work queue, task assignment, and coordination &mdash; ClankeR carries each task to your agent over a secure WebSocket. Your credentials never leave your machine.</p>
 </div>
 <div class="how">
 <h3>Trust tiers</h3>
@@ -1468,7 +1472,7 @@ font-size:.875rem;font-weight:500;text-decoration:none;transition:opacity .2s}
     <div style="margin-top:24px;display:flex;justify-content:center">
       <a href="/contribute" class="contribute-link">
         <span>&#x1F41D;</span>
-        <span><strong>Join the swarm</strong> &mdash; donate your CLI to help autonomous agents maintain repos</span>
+        <span><strong>Join the swarm</strong> &mdash; donate your CLI to help autonomous agents maintain repos, over ClankeR (the contributor relay)</span>
       </a>
     </div>
   </section>
@@ -1511,7 +1515,7 @@ font-size:.875rem;font-weight:500;text-decoration:none;transition:opacity .2s}
   <section class="invite-section">
     <div class="invite-card">
       <h3>Want to contribute?</h3>
-      <p>Connect to the %s hive and let your CLI agent help maintain open-source repos.</p>
+      <p>Connect to the %s hive over ClankeR and let your CLI agent help maintain open-source repos.</p>
       <code>%s</code>
     </div>
   </section>

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -1,3 +1,11 @@
+// ClankeR — the contributor relay. This file is the hive-side half: the
+// WebSocket endpoint that authenticates contributor agents, dispatches tasks
+// (issue fixes, reviews, docs) to whichever machine is connected, and keeps
+// GitHub tokens fresh for the duration of a task. The contributor-side half
+// lives in bin/contributor-relay.sh.
+//
+// Names on the wire (message types, JSON fields, the /contribute route) are
+// deliberately unchanged: ClankeR is the presentation name, not the protocol.
 package dashboard
 
 import (

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -9475,9 +9475,9 @@ function burnAreaChart() {
         const contributeUrl = window.location.origin + '/contribute';
         setIfChanged(panel,
           '<div style="color:var(--text);padding:24px;background:var(--card-bg);border:1px solid var(--border);border-radius:var(--radius-lg);max-width:760px">' +
-            '<div style="font-weight:600;font-size:var(--fs-md);margin-bottom:8px">\ud83e\udd1d Grow your hive with Contributor Relay</div>' +
+            '<div style="font-weight:600;font-size:var(--fs-md);margin-bottom:8px">\ud83e\udd1d Grow your hive with ClankeR</div>' +
             '<div style="color:var(--muted);font-size:var(--fs-base);line-height:1.6;margin-bottom:12px">' +
-              'Contributor Relay lets anyone lend their own machine and AI subscription to this hive. ' +
+              'ClankeR \u2014 the contributor relay \u2014 lets anyone lend their own machine and AI subscription to this hive. ' +
               'Contributors register with their GitHub account, run a lightweight worker locally, and the hive ' +
               'relays tasks (issue fixes, reviews, docs) to their agents over a secure WebSocket \u2014 their compute, your backlog. ' +
               'Completed tasks build trust: contributors are promoted automatically from <strong>Newcomer</strong> to <strong>Contributor</strong>, <strong>Trusted</strong>, and <strong>Advisor</strong> tiers.' +
@@ -17202,7 +17202,7 @@ function burnAreaChart() {
       { id: 'budget', label: 'Budget', desc: 'set a weekly token budget and watch the burn rate (Governor Config → Budget).', onclick: "welcomeShowConfigTab('Budget')" },
       { id: 'notifications', label: 'Notifications', desc: 'route alerts to your channels (Governor Config → Notifications).', onclick: "welcomeShowConfigTab('Notifications')" },
       { id: 'knowledge', label: 'Knowledge Base', desc: 'seed facts and patterns the agents reuse across passes.', onclick: "welcomeShowSection('knowledge-section')" },
-      { id: 'contributors', label: 'Contributor Relay', desc: 'let outside contributors drive agents, with a leaderboard.', onclick: "welcomeShowSection('contributors-section')" },
+      { id: 'contributors', label: 'ClankeR (Contributor Relay)', desc: 'let outside contributors drive agents, with a leaderboard.', onclick: "welcomeShowSection('contributors-section')" },
       { id: 'hub', label: 'Hub visibility', desc: 'make this hive public or private on the hub (Governor Config → Hub).', onclick: "welcomeShowConfigTab('Hub')" },
       { id: 'theme', label: 'Light / Dark mode', desc: 'switch layouts any time from the toggle in the top bar.', onclick: 'toggleLayout()' }
     ];

--- a/v2/pkg/hub/journey.go
+++ b/v2/pkg/hub/journey.go
@@ -30,7 +30,7 @@ import (
 //	4. GH / GHE App   — install the GitHub App. github.com App for a github.com
 //	                    primary repo, GitHub Enterprise App for a github.ibm.com
 //	                    primary repo. THIS IS THE WRITE GATE (below).
-//	5. Setup agents   — assign methods + models (or run the contributor relay),
+//	5. Setup agents   — assign methods + models (or run ClankeR, the contributor relay),
 //	                    then raise the ACMM level.
 //
 // The stall-detection stages below track the SPOKE-side steps (3-5): a
@@ -397,7 +397,7 @@ func methodModelAssigned(h *RegistryEntry) (assigned bool, known bool) {
 	return *h.AgentsWithModel > 0, true
 }
 
-// relayInUse reports whether the contributor relay is carrying this hive's
+// relayInUse reports whether ClankeR, the contributor relay, is carrying this hive's
 // work, which the product accepts as a full substitute for a method/model.
 //
 // Two signals, strongest first:
@@ -543,7 +543,7 @@ func nextNudge(h *RegistryEntry, now time.Time) nudge {
 		return n
 	}
 
-	// ── Stage 2: method/model, or the contributor relay ────────────────────
+	// ── Stage 2: method/model, or ClankeR (the contributor relay) ──────────
 	//
 	// The relay is a first-class substitute: a hive whose humans are picking up
 	// tasks through /contribute has satisfied this stage as completely as one
@@ -562,7 +562,7 @@ func nextNudge(h *RegistryEntry, now time.Time) nudge {
 		case age >= stage2WarnAfter:
 			n.Severity = SeverityDeprovisionWarning
 			n.Message = fmt.Sprintf(
-				"Action required: after %s, none of your agents has a method or model assigned, and no one is picking up tasks through your contributor relay. "+
+				"Action required: after %s, none of your agents has a method or model assigned, and no one is picking up tasks through ClankeR, your contributor relay. "+
 					"Assign a backend and model to at least one agent (Agents → pick an agent → Model), or open your hive's /contribute page to your community — "+
 					"either one counts. Spokes that stay idle past this point are candidates for de-provisioning by an administrator.",
 				humanDuration(age))
@@ -571,7 +571,7 @@ func nextNudge(h *RegistryEntry, now time.Time) nudge {
 			n.Message = fmt.Sprintf(
 				"Your hive has been up for %s but no agent has a method or model assigned yet, so nothing is running. "+
 					"Pick a backend and model for an agent under Agents → Model. Prefer humans in the loop? "+
-					"Running the contributor relay from your hive's /contribute page satisfies this step just as well.",
+					"Running ClankeR, the contributor relay, from your hive's /contribute page satisfies this step just as well.",
 				humanDuration(age))
 		default:
 			return nudge{}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -6586,7 +6586,7 @@ const dashboardHTML = `<!DOCTYPE html>
     var JOURNEY_STAGE_TIPS = {
       'none': 'No outstanding adoption steps.',
       'github-app': 'Stage 1 — the GitHub App is not installed, so no agent can open issues or PRs.',
-      'method-model': 'Stage 2 — no agent has a method/model assigned and the contributor relay is not in use.',
+      'method-model': 'Stage 2 — no agent has a method/model assigned and ClankeR (the contributor relay) is not in use.',
       'acmm-level': 'Stage 3 — running steadily; due a gentle suggestion to consider the next ACMM level. Never a de-provision risk.',
     };
     /* Rank a journey status for sorting. Snoozed hives rank lowest — an admin
@@ -6621,9 +6621,9 @@ const dashboardHTML = `<!DOCTYPE html>
         if (sev === 'deprovision-warning') text = label + ' ⚠';
       }
       var html = '<span class="journey-badge ' + cls + '" title="' + esc(tip) + '">' + esc(text) + '</span>';
-      /* Stage 2 satisfied via the contributor relay gets its own visible badge. */
+      /* Stage 2 satisfied via ClankeR gets its own visible badge. */
       if (j.viaRelay) {
-        html += '<span class="journey-relay" title="' + esc('Stage 2 is satisfied through the contributor relay (human contributors picking up tasks), not by an assigned method/model.') + '">relay</span>';
+        html += '<span class="journey-relay" title="' + esc('Stage 2 is satisfied through ClankeR, the contributor relay (human contributors picking up tasks), not by an assigned method/model.') + '">relay</span>';
       }
       return html;
     }
@@ -6909,7 +6909,7 @@ const dashboardHTML = `<!DOCTYPE html>
         esc(label) + '</span>';
     }
 
-    /* ---- Contributor relay (hover panel) ------------------------------
+    /* ---- ClankeR, the contributor relay (hover panel) ------------------
        The relay is a first-class SUBSTITUTE for assigning a method/model:
        when humans are picking up this hive's tasks through /contribute, the
        "tokens for an agent" requirement is satisfied. The product rule is
@@ -6949,7 +6949,7 @@ const dashboardHTML = `<!DOCTYPE html>
         who = 'task in progress';
       }
       return '<div style="padding:1px 0;color:' + RELAY_COLOR + '">' +
-        esc('◆ Contributor relay · ' + who) + '</div>' +
+        esc('◆ ClankeR · ' + who) + '</div>' +
         '<div style="padding:0 0 1px 12px;color:var(--muted);font-size:0.65rem">' +
         esc('satisfies the method/model requirement') + '</div>';
     }
@@ -7071,7 +7071,7 @@ const dashboardHTML = `<!DOCTYPE html>
       if (!access.length) {
         var plainLines = lines.slice();
         if ((h.journey || {}).viaRelay) {
-          plainLines.push('◆ Contributor relay in use — satisfies the method/model requirement');
+          plainLines.push('◆ ClankeR (contributor relay) in use — satisfies the method/model requirement');
         }
         return '<span title="' + esc(plainLines.join('\n')) + '" style="display:inline-flex;align-items:center;gap:4px;cursor:help;white-space:pre-line">' + dotMarkup + '</span>';
       }
@@ -10049,7 +10049,7 @@ const dashboardHTML = `<!DOCTYPE html>
         /* Non-admin lists have no section headers, so the flat list's
            select-all lives in the table head instead. */
         '<th style="width:26px;text-align:center">' + (_isAdmin ? '' : bulkSectionCheckbox('all')) + '</th>' +
-        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer" title="Where this hive runs, and whether it is listed publicly">Location / Public ⇅</th><th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'aiAuthor\')" style="cursor:pointer" title="The GitHub identity this hive\'s agents open PRs as — the configured ai_author, or the App bot (&lt;slug&gt;[bot]) in App-authored mode">AI Author ⇅</th><th onclick="sortDashHives(\'journey\')" style="cursor:pointer" title="Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run the contributor relay), then raise the ACMM level">Journey ⇅</th><th title="Configuration drift from the fleet norm — hover a value for the specific signals">Drift</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
+        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer" title="Where this hive runs, and whether it is listed publicly">Location / Public ⇅</th><th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'aiAuthor\')" style="cursor:pointer" title="The GitHub identity this hive\'s agents open PRs as — the configured ai_author, or the App bot (&lt;slug&gt;[bot]) in App-authored mode">AI Author ⇅</th><th onclick="sortDashHives(\'journey\')" style="cursor:pointer" title="Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run ClankeR, the contributor relay), then raise the ACMM level">Journey ⇅</th><th title="Configuration drift from the fleet norm — hover a value for the specific signals">Drift</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table></div>';
       /* Delegated, so binding once is enough no matter how often the table is
          re-rendered. The guard keeps repeated renders from stacking listeners. */

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -142,7 +142,7 @@ type RegistryEntry struct {
 	AgentsWithModel *int `json:"agentsWithModel,omitempty"`
 	// Journey is the computed user-journey status (which adoption stage this
 	// hive is stalled on, how hard it is being nudged, and whether stage 2 is
-	// satisfied via the contributor relay). Computed on read from the journey
+	// satisfied via ClankeR, the contributor relay). Computed on read from the journey
 	// state store — never persisted on the registry entry itself.
 	Journey *JourneyStatus `json:"journey,omitempty"`
 }


### PR DESCRIPTION
Gives the Contributor Relay an affectionate vanity name — **ClankeR** (for **C**ontributor **R**elay) — across the places users actually read it.

## What changed

Prose, labels, banners, and docs only. First mention in each context reads "ClankeR (the contributor relay)" or similar, so the name adds warmth without obscuring what the thing *is*.

| File | Why |
|---|---|
| `v2/pkg/dashboard/api_contribute.go` | `/contribute` landing page — new sub-tagline naming ClankeR; "what the hive provides" and leaderboard invite copy; handler doc comment |
| `v2/pkg/dashboard/contribute_ws.go` | File-level doc comment naming the hive-side half |
| `v2/pkg/dashboard/static/index.html` | Spoke dashboard contributor panel heading/body + welcome "More to explore" label |
| `v2/pkg/hub/saas.go` | Hub dashboard journey stage tooltip, `.journey-relay` badge tooltip, hover panel line, Journey column header tooltip |
| `v2/pkg/hub/journey.go` | Stage-2 nudge messages users receive, plus doc comments |
| `v2/pkg/hub/server.go` | `RegistryEntry.Journey` doc comment |
| `bin/contributor-agent.sh` | Startup banner, relay-start line, running-status block (labels realigned) |
| `bin/contributor-relay.sh` | Header comment |
| `Justfile` | Header + the two `=== Hive Contributor … ===` banners |
| `v2/Dockerfile.contributor`, `v2/compose-contributor.yaml` | Header comments |
| `README.md`, `v2/docs/architecture.md`, `docs/federation-design.md` | Contributor sections and the system-context diagram edge |

## Explicitly NOT renamed

This is branding in presentation only — nothing on the wire or on disk moved:

- WebSocket message types, JSON fields, the `/contribute` and `/api/contribute/*` routes
- `HIVE_CONTRIBUTOR_*` env vars, config keys
- `.journey-relay` CSS class, and the badge text itself stays `relay` so it keeps matching its class and the Journey column semantics
- File names (`contribute_ws.go`, `contributor-relay.sh`), container name `hive-contributor`, image names
- Generic uses of "relay" elsewhere (e.g. the proxy relaying upstream responses) are unrelated and untouched

## Verification

- `go build ./...` and `go vet ./pkg/dashboard/ ./pkg/hub/` pass (vet's printf analyzer covers the `fmt.Fprintf` template edits)
- `bash -n bin/contributor-agent.sh` and `node --check` on `bin/contributor-relay.sh` pass
- Relay/journey tests all pass: `TestRelayInUse`, `TestRelaySubstitutesForMethodModel`, `TestRelayRenderingIsConsistentWithJourneyColumn`, `TestRelayInUseDrivesHoverSignal`, `TestRelayHiveIsNotReportedAsAssigned`, plus the `Journey*` suite
- `saas.go`: no backticks introduced (would terminate the `dashboardHTML` raw string); extracted embedded JS is brace-balanced, and its paren delta of `-1` is **pre-existing** — identical on untouched `origin/v2`
- Pre-existing and unrelated to this PR: `pkg/dashboard` gofmt drift in `api_contribute.go` const/struct alignment, and failures in `TestCovV1_*`/`TestCovDF_GHUserAuth*`, `TestHandleHubSelfUpgrade_Edge`, `TestLoadAppPrivateKeyKubectlFails` — all reproduce on clean `origin/v2`. Deliberately not reformatted, to avoid sweeping unrelated drift into this PR.

## Notes

- Rebased on fresh `origin/v2`, on top of #2266 (bob backend support) — that PR's functional changes to `bin/contributor-*.sh`, `v2/Dockerfile.contributor` and the bob `<option>` are preserved intact.
- **Needs porting to `mk`, `dd`, and `v3`.**