### PR TITLE
🐛 fix(agent): TLS-error detector must honour the backend override

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1380,7 +1380,16 @@ func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Contex
 			// "ready" (the Copilot chrome shows ❯ and / commands) but actually
 			// dead. These errors are transient — a restart will succeed once
 			// the network recovers.
-			if agent.Config.Backend == "copilot" && paneShowsFatalNetworkError(filtered) {
+			// effectiveBackend, not Config.Backend: an agent configured for
+			// copilot but overridden to another CLI at runtime still reported
+			// "copilot" here, so this copilot-only detector ran against a
+			// different TUI's output. Observed in production on a bob agent
+			// whose config said copilot — bob printed one of the generic
+			// patterns below ("fetch failed"), the agent was restarted as if
+			// its TLS had died, and the governor kick delivered seconds
+			// earlier died with the session. It looped every ~60s, so no kick
+			// ever survived long enough to run.
+			if effectiveBackend(agent) == "copilot" && paneShowsFatalNetworkError(filtered) {
 				sinceLastRestart := time.Since(agent.lastTokenRestart).Seconds()
 				if sinceLastRestart >= float64(tlsErrorRestartCooldownSec) {
 					m.logger.Warn("fatal network/TLS error detected, restarting agent",


### PR DESCRIPTION
A copilot-only guard ran against a **bob** agent's pane and restarted it every ~60s, so **every governor kick was destroyed seconds after delivery** and no advisory work ever ran.

## Root cause

```go
if agent.Config.Backend == "copilot" && paneShowsFatalNetworkError(filtered) {
```

`Config.Backend` still reads `copilot` for an agent configured as copilot but **overridden to another CLI at runtime**. katamari's scanner is exactly that shape — `backend: copilot` in `hive.yaml`, bob at runtime.

The patterns it matches are generic (`fetch failed`, `invalid peer certificate`, `BadSignature`), so bob printing `fetch failed` was read as a dead TLS stack and the supervisor restarted a perfectly healthy agent.

## Observed live on katamari

```
10:44:58  audit: agent kicked          name=scanner message_len=6183
10:45:39  fatal network/TLS error detected, restarting agent  agent=scanner
10:45:42  audit: agent restarting      name=scanner restart_count=66
```

After the restart the pane held **zero** trace of the kick text across 500 lines of scrollback — the 6,183-character advisory prompt was delivered and then discarded with the session. `restart_count=66` shows how long this had been looping.

This is why bob could be fully authenticated (`Auto-approve: Full`, live token balance) and still never do any work.

## Fix

Use the existing `effectiveBackend()` helper — the same one every other backend check on the launch path already uses. One line, plus a comment recording the failure mode.

## Verification

- `go build ./...` and `go vet ./pkg/agent/` clean.
- `go test ./pkg/agent/ -run 'FatalNetwork|Backend|Restart'` → **ok**.

## Ports

Needs porting to `mk`, `dd`, and `v3`.