### PR TITLE
🐛 fix(hub): preserve cluster_id when a placeholder hive is claimed

### DIFF
--- a/v2/pkg/hub/claim_preserves_cluster_id_test.go
+++ b/v2/pkg/hub/claim_preserves_cluster_id_test.go
@@ -1,0 +1,173 @@
+package hub
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// newMultiClusterTestHub returns a hub with both the public (hive-oke) pool and
+// the GPU (vllm-d) pool configured, plus a discard logger. This mirrors the
+// live multi-cluster hub where the cluster_id-drop bug mis-routed vllm-d hives
+// to hive-oke's App/host defaults.
+func newMultiClusterTestHub() *HubServer {
+	return &HubServer{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		clusters: map[string]ClusterConfig{
+			defaultClusterID: {
+				ID:   defaultClusterID,
+				Name: "hive-oke",
+			},
+			gpuClusterID: {
+				ID:            gpuClusterID,
+				Name:          "vllm-d",
+				GitHubBaseURL: gheTestBaseURL,
+				GitHubAPIURL:  gheTestAPIURL,
+			},
+		},
+	}
+}
+
+// TestEnsureClusterIDForClaim covers the guard directly: a hive's own non-blank
+// cluster is never overridden, a blank one falls back to the caller's pool when
+// that pool is real, and otherwise to the default. It must never leave a blank.
+func TestEnsureClusterIDForClaim(t *testing.T) {
+	s := newMultiClusterTestHub()
+
+	tests := []struct {
+		name         string
+		startCluster string
+		poolFallback string
+		want         string
+	}{
+		{
+			name:         "own vllm-d cluster is preserved, pool is ignored",
+			startCluster: gpuClusterID,
+			poolFallback: defaultClusterID, // even a mismatching pool must not win
+			want:         gpuClusterID,
+		},
+		{
+			name:         "own hive-oke cluster is preserved",
+			startCluster: defaultClusterID,
+			poolFallback: gpuClusterID,
+			want:         defaultClusterID,
+		},
+		{
+			name:         "blank falls back to the vllm-d pool it was drawn from",
+			startCluster: "",
+			poolFallback: gpuClusterID,
+			want:         gpuClusterID,
+		},
+		{
+			name:         "blank with an unknown pool falls back to the default",
+			startCluster: "",
+			poolFallback: "cluster-that-does-not-exist",
+			want:         defaultClusterID,
+		},
+		{
+			name:         "blank with no pool falls back to the default",
+			startCluster: "",
+			poolFallback: "",
+			want:         defaultClusterID,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &SaaSHive{ID: "hosted-x", ClusterID: tc.startCluster}
+			s.ensureClusterIDForClaim(h, tc.poolFallback)
+			if h.ClusterID != tc.want {
+				t.Errorf("ClusterID = %q, want %q", h.ClusterID, tc.want)
+			}
+			if h.ClusterID == "" {
+				t.Error("ClusterID is blank after the claim guard — clusterForHive would mis-route to hive-oke")
+			}
+		})
+	}
+}
+
+// TestAssignPreservesVllmdClusterID is the regression test for the reported bug:
+// claiming/assigning a vllm-d placeholder must keep it on vllm-d in meta.json —
+// it must NOT become hive-oke or blank. We exercise the exact ClusterID
+// preservation the assign handler performs, then round-trip through
+// saveSaaSHive/loadSaaSHive (which is where the field actually vanished on the
+// live PVC via omitempty) and assert clusterForHive still resolves to vllm-d.
+func TestAssignPreservesVllmdClusterID(t *testing.T) {
+	useTempHiveDir(t)
+	s := newMultiClusterTestHub()
+
+	// A vllm-d placeholder as it sits before a claim.
+	placeholder := &SaaSHive{
+		ID:        "hosted-available-vllmd-01",
+		Owner:     hubAdminUsername,
+		Status:    statusAvailable,
+		ClusterID: gpuClusterID,
+	}
+	if err := saveSaaSHive(placeholder); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mirror the assign handler: load the placeholder, rewrite its project, and
+	// apply the ClusterID guard before saving.
+	h := loadSaaSHive(placeholder.ID)
+	if h == nil {
+		t.Fatal("placeholder disappeared")
+	}
+	h.Owner = "taylormgeorge91"
+	h.Org = "katamari"
+	h.Repos = []string{"ibm-aiops-orchestrator"}
+	h.PrimaryRepo = "ibm-aiops-orchestrator"
+	h.Status = ""
+	s.ensureClusterIDForClaim(h, "")
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+
+	// The whole point: after the claim round-trips through disk, cluster_id must
+	// still be vllm-d, not hive-oke and not blank.
+	reloaded := loadSaaSHive(placeholder.ID)
+	if reloaded == nil {
+		t.Fatal("claimed hive disappeared")
+	}
+	if reloaded.ClusterID != gpuClusterID {
+		t.Fatalf("claimed vllm-d hive lost its cluster: ClusterID = %q, want %q", reloaded.ClusterID, gpuClusterID)
+	}
+	if got := s.clusterForHive(reloaded); got == nil || got.ID != gpuClusterID {
+		t.Fatalf("clusterForHive resolved a claimed vllm-d hive to the wrong cluster: %+v (want %s)", got, gpuClusterID)
+	}
+	// And it must carry vllm-d's GHE host defaults, not hive-oke's public github.com.
+	if got := s.clusterForHive(reloaded); got.GitHubBaseURL != gheTestBaseURL {
+		t.Errorf("claimed vllm-d hive got the wrong cluster's GitHub base URL: %q, want %q", got.GitHubBaseURL, gheTestBaseURL)
+	}
+}
+
+// TestApprovePreservesPoolClusterID proves the approve path stamps the pool it
+// drew from: a placeholder that somehow lost its cluster_id, when approved into
+// the vllm-d pool, is stamped vllm-d — NOT left blank to resolve to hive-oke.
+func TestApprovePreservesPoolClusterID(t *testing.T) {
+	useTempHiveDir(t)
+	s := newMultiClusterTestHub()
+
+	// Simulate the degraded on-disk state: a placeholder with NO cluster_id.
+	// findAvailablePlaceholder treats blank as hive-oke, but the approve path
+	// pulled it from the vllm-d pool (private auth_method) and must record that.
+	h := &SaaSHive{
+		ID:     "hosted-approve-blank",
+		Owner:  "taylormgeorge91",
+		Org:    "katamari",
+		Status: "",
+	}
+	pool := poolClusterForAuthMethod(authMethodPrivate) // vllm-d
+	s.ensureClusterIDForClaim(h, pool)
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded := loadSaaSHive(h.ID)
+	if reloaded == nil {
+		t.Fatal("approved hive disappeared")
+	}
+	if reloaded.ClusterID != gpuClusterID {
+		t.Errorf("approved private hive did not inherit the vllm-d pool: ClusterID = %q, want %q", reloaded.ClusterID, gpuClusterID)
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -602,6 +602,35 @@ func clusterIDForSaaSHive(sh SaaSHive) string {
 	return defaultClusterID
 }
 
+// ensureClusterIDForClaim stamps a non-blank cluster_id onto a hive that is
+// about to be persisted by a claim/assign. This is the data-integrity guard
+// for the observed bug where CLAIMED hives lost cluster_id in their meta.json
+// and then fell back to defaultClusterID (hive-oke) in clusterForHive — which
+// mis-routed App/host resolution for hives that actually run on vllm-d.
+//
+// Precedence, most-trusted first:
+//  1. The hive's OWN non-blank ClusterID (the placeholder already belongs to a
+//     cluster — always the most authoritative source; never override it).
+//  2. poolFallback — the pool the claim was drawn from, when the caller knows
+//     it (e.g. handleApproveProvision picks a pool by auth_method), but only
+//     when it names a cluster the hub actually has.
+//  3. defaultClusterID — last resort, matching clusterForHive's own fallback.
+//
+// The result is always non-blank, so with omitempty on the json tag it still
+// serializes to a concrete "cluster_id" value rather than vanishing.
+func (s *HubServer) ensureClusterIDForClaim(h *SaaSHive, poolFallback string) {
+	if h.ClusterID != "" {
+		return
+	}
+	if poolFallback != "" {
+		if _, ok := s.clusters[poolFallback]; ok {
+			h.ClusterID = poolFallback
+			return
+		}
+	}
+	h.ClusterID = defaultClusterID
+}
+
 // clusterNameForID returns the human-readable name for a cluster ID.
 // Returns empty string when the cluster is not found.
 func (s *HubServer) clusterNameForID(clusterID string) string {
@@ -4857,6 +4886,13 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 	h.ACMMLevel = acmm
 	h.Status = ""
 	h.Error = ""
+	// Preserve the placeholder's real cluster before ANY cluster-derived
+	// resolution below (host backfill uses s.clusterForHive(h), which silently
+	// returns hive-oke when ClusterID is blank). The placeholder was picked
+	// from `pool`, so a blank cluster_id here can only mean the placeholder was
+	// created without one — stamp the pool it came from rather than leaving a
+	// blank that later resolves to the wrong (default) cluster's App/host.
+	s.ensureClusterIDForClaim(h, pool)
 	// The requester already told us which GitHub their org lives on (parsed
 	// from the org URL they pasted, or picked explicitly), so honour it. Before
 	// this, approve dropped github_host entirely — only the manual assign path
@@ -5424,6 +5460,12 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	// (and any stale error) alone makes it show under the new owner in My Hives.
 	h.Owner = body.Owner
 	h.Org = body.Org
+	// Preserve the placeholder's real cluster before the host backfill below,
+	// which resolves via s.clusterForHive(h) and would fall back to hive-oke on
+	// a blank cluster_id. The admin assigns a specific placeholder, so its own
+	// ClusterID is authoritative; only a placeholder created without one lands
+	// on the default here (never a silent blank that mis-routes to hive-oke).
+	s.ensureClusterIDForClaim(h, "")
 	// Record the GHE host (if any) so the heartbeat can point this spoke at the
 	// right GitHub API. Never blank an existing value with an empty one.
 	//


### PR DESCRIPTION
## Problem

Every CLAIMED/ASSIGNED hive's `meta.json` was ending up with **no** `cluster_id`, while UNCLAIMED placeholders correctly carried it. With a blank `cluster_id`, `clusterForHive()` (pkg/hub/saas_provision.go) falls back to `defaultClusterID = "hive-oke"` — a legacy pre-multi-cluster default.

For a hive that actually runs on the **vllm-d** cluster this is a data-integrity bug: it silently resolves to hive-oke, so `backfillGitHubHostFromCluster` / `resolveProvisionAppID` inherit hive-oke's **public github.com** defaults instead of vllm-d's **GHE** defaults (or vice-versa), and the App/host resolution mis-routes.

## Where the value was being dropped

Both claim paths — `handleApproveProvision` and `handleAssignHive` in `pkg/hub/saas.go` — `loadSaaSHive(hiveID)`, rewrite owner/org/repos/host/status, then `saveSaaSHive(h)`. The `SaaSHive.ClusterID` json tag is `cluster_id,omitempty` (saas_provision.go), so the moment `h.ClusterID` is empty at save time it is **omitted entirely** from the marshalled `meta.json` — which is exactly how it "disappears". Any placeholder that reached a claim with a blank `ClusterID` was then persisted with the field silently absent, and every subsequent read resolved it to hive-oke.

Critically, the host backfill in both handlers runs `s.clusterForHive(h)` **before** the save — so a blank `ClusterID` also corrupts host resolution *during* the claim, not just afterward.

## Fix

New guard `ensureClusterIDForClaim(h, poolFallback)` (saas.go), called in both handlers **before any cluster-derived resolution**:

1. Keep the hive's own non-blank `ClusterID` — the placeholder already belongs to a cluster; this is authoritative and is never overridden.
2. Only when blank, fall back to `poolFallback` — the pool the claim was drawn from — when it names a real cluster. `handleApproveProvision` passes the `pool` it selected via `poolClusterForAuthMethod` (private → vllm-d); `handleAssignHive` passes `""` because the admin picks a specific placeholder.
3. Else `defaultClusterID`, matching `clusterForHive`'s own fallback.

The result is **always non-blank**, so a claimed hive can never again be written with an absent `cluster_id`. This mirrors how the migration path already does it correctly (`h.ClusterID = toCluster.ID`, saas_provision.go).

### `omitempty` tag decision

**Kept `cluster_id,omitempty`.** The real fix is to never leave `ClusterID` blank on a claimed hive, which this guard guarantees — so with the field always populated, `omitempty` still serialises a concrete `"cluster_id":"vllm-d"`. Removing `omitempty` would only make a *blank* visible as `"cluster_id":""` (a symptom, not a fix) and would rewrite the byte layout of existing on-disk records for no behavioural gain. Preserving the real value is strictly better than making the blank visible.

## Tests

New `pkg/hub/claim_preserves_cluster_id_test.go`:

- `TestEnsureClusterIDForClaim` — precedence table: own cluster wins over a mismatching pool; blank inherits a real pool; blank with an unknown/absent pool falls to default; never blank.
- `TestAssignPreservesVllmdClusterID` — regression: a **vllm-d** placeholder claimed via the assign flow stays vllm-d through a `saveSaaSHive`/`loadSaaSHive` round-trip (the exact place the field vanished), and `clusterForHive` still resolves it to vllm-d with vllm-d's GHE base URL — **not** hive-oke/blank.
- `TestApprovePreservesPoolClusterID` — a placeholder that lost its `cluster_id`, approved into the private (vllm-d) pool, is stamped vllm-d rather than left blank.

`go build ./...` clean. `go test ./pkg/hub/` — all claim/assign/cluster tests pass, including the three new ones. Two unrelated failures (`TestHandleHubSelfUpgrade_Edge`, `TestLoadAppPrivateKeyKubectlFails`) are **pre-existing on the clean v2 base** (verified by stashing this change) — they depend on real self-upgrade/kubectl tooling and are untouched by this PR. gofmt applied to the two edited files only.
