### PR TITLE
🐛 fix(app-keys): deliver both App keys to every spoke, select by app_id

### DIFF
--- a/v2/cmd/hive/appkeyfile_test.go
+++ b/v2/cmd/hive/appkeyfile_test.go
@@ -42,11 +42,14 @@ func writeTestKey(t *testing.T, path string) string {
 func redirectSpokeKeyPaths(t *testing.T) (dataPath, secretsPath string) {
 	t.Helper()
 	dir := t.TempDir()
-	origData, origSecrets := spokeAppKeyPath, spokeProvisionedAppKeyPath
+	origData, origSecrets, origDir := spokeAppKeyPath, spokeProvisionedAppKeyPath, spokeAppKeyDir
 	spokeAppKeyPath = filepath.Join(dir, "data-gh-app-key.pem")
 	spokeProvisionedAppKeyPath = filepath.Join(dir, "secrets-gh-app-key.pem")
+	// Per-app-id keys land in this same temp dir, so perAppIDKeyPath and
+	// heldPerAppIDKeyFingerprints never touch the real /data.
+	spokeAppKeyDir = dir
 	t.Cleanup(func() {
-		spokeAppKeyPath, spokeProvisionedAppKeyPath = origData, origSecrets
+		spokeAppKeyPath, spokeProvisionedAppKeyPath, spokeAppKeyDir = origData, origSecrets, origDir
 	})
 	return spokeAppKeyPath, spokeProvisionedAppKeyPath
 }
@@ -72,7 +75,7 @@ func TestResolveAppKeyFilePrefersDeliveredKey(t *testing.T) {
 		}
 
 		// key_file unset — the vllmd-01..03 state.
-		got := resolveAppKeyFile("", "")
+		got := resolveAppKeyFile("", "", 0)
 		if got != dataPath {
 			t.Fatalf("resolveAppKeyFile = %q, want the delivered key at %q", got, dataPath)
 		}
@@ -88,13 +91,13 @@ func TestResolveAppKeyFilePrefersDeliveredKey(t *testing.T) {
 
 		// The heartbeat must report that same key, or the hub compares against a
 		// key that is not signing anything.
-		if reported := reportedAppKeyFingerprint(""); reported != goodFP {
+		if reported := reportedAppKeyFingerprint("", 0); reported != goodFP {
 			t.Fatalf("reportedAppKeyFingerprint = %q, want %q", reported, goodFP)
 		}
 
 		// And it must stop claiming a per-hive override, so the hub's idempotence
 		// check sees a plain match and stops pushing.
-		if hasPerHiveAppKey("") {
+		if hasPerHiveAppKey("", 0) {
 			t.Error("hasPerHiveAppKey = true after taking delivery; the /secrets key is no longer in effect")
 		}
 	})
@@ -104,16 +107,16 @@ func TestResolveAppKeyFilePrefersDeliveredKey(t *testing.T) {
 		provisionedFP := writeTestKey(t, secretsPath)
 		_ = dataPath // deliberately absent
 
-		got := resolveAppKeyFile("", "")
+		got := resolveAppKeyFile("", "", 0)
 		if got != secretsPath {
 			t.Fatalf("resolveAppKeyFile = %q, want the provisioned key at %q", got, secretsPath)
 		}
-		if reported := reportedAppKeyFingerprint(""); reported != provisionedFP {
+		if reported := reportedAppKeyFingerprint("", 0); reported != provisionedFP {
 			t.Fatalf("reportedAppKeyFingerprint = %q, want %q", reported, provisionedFP)
 		}
 		// A genuine per-hive credential must still be reported as such, so the
 		// hub's protective precedence keeps working.
-		if !hasPerHiveAppKey("") {
+		if !hasPerHiveAppKey("", 0) {
 			t.Error("hasPerHiveAppKey = false; a provisioned key in effect is a per-hive override")
 		}
 	})
@@ -127,10 +130,10 @@ func TestResolveAppKeyFilePrefersDeliveredKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if got := resolveAppKeyFile("", ""); got != secretsPath {
+		if got := resolveAppKeyFile("", "", 0); got != secretsPath {
 			t.Fatalf("resolveAppKeyFile = %q, want %q; an empty file is not a key", got, secretsPath)
 		}
-		if reported := reportedAppKeyFingerprint(""); reported != provisionedFP {
+		if reported := reportedAppKeyFingerprint("", 0); reported != provisionedFP {
 			t.Fatalf("reportedAppKeyFingerprint = %q, want %q", reported, provisionedFP)
 		}
 	})
@@ -140,20 +143,143 @@ func TestResolveAppKeyFilePrefersDeliveredKey(t *testing.T) {
 		writeTestKey(t, dataPath)
 		explicit := filepath.Join(t.TempDir(), "operator-chosen.pem")
 
-		if got := resolveAppKeyFile(explicit, ""); got != explicit {
+		if got := resolveAppKeyFile(explicit, "", 0); got != explicit {
 			t.Errorf("configured key_file = %q, want %q; an explicit path must not be redirected", got, explicit)
 		}
-		if got := resolveAppKeyFile("", explicit); got != explicit {
+		if got := resolveAppKeyFile("", explicit, 0); got != explicit {
 			t.Errorf("env override = %q, want %q", got, explicit)
 		}
 		// Env beats config, matching the original precedence.
 		other := filepath.Join(t.TempDir(), "from-config.pem")
-		if got := resolveAppKeyFile(other, explicit); got != explicit {
+		if got := resolveAppKeyFile(other, explicit, 0); got != explicit {
 			t.Errorf("env override = %q, want it to beat key_file %q", got, explicit)
 		}
 		// Whitespace is not a path.
-		if got := resolveAppKeyFile("  ", "  "); got != dataPath {
+		if got := resolveAppKeyFile("  ", "  ", 0); got != dataPath {
 			t.Errorf("blank inputs = %q, want the delivered key at %q", got, dataPath)
 		}
 	})
+}
+
+// TestResolveAppKeyFilePrefersPerAppIDKey is the both-keys fix's central
+// guarantee on the spoke: a hive configured for a specific app_id signs with the
+// per-app-id key delivered for THAT app, even when a different (cluster-default)
+// key sits at the generic /data path.
+//
+// This is exactly the github.com-hive-on-a-GHE-cluster case: /data/gh-app-key.pem
+// holds the cluster's GHE key, but the hive claims the github.com app_id, and
+// /data/gh-app-key-<githubAppID>.pem holds the github.com key. Resolution must
+// pick the per-app-id file.
+func TestResolveAppKeyFilePrefersPerAppIDKey(t *testing.T) {
+	const githubAppID int64 = 3568013
+
+	t.Run("per-app-id key wins over the generic data key", func(t *testing.T) {
+		redirectSpokeKeyPaths(t)
+		clusterKeyFP := writeTestKey(t, spokeAppKeyPath) // GHE cluster default at /data
+		perAppPath := perAppIDKeyPath(githubAppID)
+		githubKeyFP := writeTestKey(t, perAppPath) // github.com key, per-app-id file
+		if clusterKeyFP == githubKeyFP {
+			t.Fatal("test keys collided; the two paths must hold different keys")
+		}
+
+		got := resolveAppKeyFile("", "", githubAppID)
+		if got != perAppPath {
+			t.Fatalf("resolveAppKeyFile = %q, want the per-app-id key at %q", got, perAppPath)
+		}
+		// The key actually in effect — and the fingerprint the heartbeat reports —
+		// must be the github.com one, not the cluster default.
+		if reported := reportedAppKeyFingerprint("", githubAppID); reported != githubKeyFP {
+			t.Fatalf("reportedAppKeyFingerprint = %q, want the github.com key %q", reported, githubKeyFP)
+		}
+	})
+
+	t.Run("a different app_id still gets the generic data key", func(t *testing.T) {
+		redirectSpokeKeyPaths(t)
+		clusterKeyFP := writeTestKey(t, spokeAppKeyPath)
+		// A per-app-id key exists for github.com, but this hive claims the GHE app.
+		writeTestKey(t, perAppIDKeyPath(githubAppID))
+
+		const gheAppID int64 = 5686
+		got := resolveAppKeyFile("", "", gheAppID)
+		if got != spokeAppKeyPath {
+			t.Fatalf("resolveAppKeyFile = %q, want the generic data key at %q (no per-app file for this app_id)", got, spokeAppKeyPath)
+		}
+		if reported := reportedAppKeyFingerprint("", gheAppID); reported != clusterKeyFP {
+			t.Fatalf("reportedAppKeyFingerprint = %q, want the cluster key %q", reported, clusterKeyFP)
+		}
+	})
+
+	t.Run("empty per-app-id file does not shadow the generic key", func(t *testing.T) {
+		redirectSpokeKeyPaths(t)
+		clusterKeyFP := writeTestKey(t, spokeAppKeyPath)
+		// A truncated per-app file must never win — only a parseable key may.
+		if err := os.WriteFile(perAppIDKeyPath(githubAppID), nil, spokeAppKeyFileMode); err != nil {
+			t.Fatal(err)
+		}
+		if got := resolveAppKeyFile("", "", githubAppID); got != spokeAppKeyPath {
+			t.Fatalf("resolveAppKeyFile = %q, want the generic key at %q; an empty per-app file is not a key", got, spokeAppKeyPath)
+		}
+		if reported := reportedAppKeyFingerprint("", githubAppID); reported != clusterKeyFP {
+			t.Fatalf("reportedAppKeyFingerprint = %q, want %q", reported, clusterKeyFP)
+		}
+	})
+
+	t.Run("explicit key_file still beats a per-app-id key", func(t *testing.T) {
+		redirectSpokeKeyPaths(t)
+		writeTestKey(t, perAppIDKeyPath(githubAppID))
+		explicit := filepath.Join(t.TempDir(), "operator-chosen.pem")
+		if got := resolveAppKeyFile(explicit, "", githubAppID); got != explicit {
+			t.Errorf("configured key_file = %q, want %q; an explicit path must not be redirected", got, explicit)
+		}
+	})
+}
+
+// TestWritePerAppIDKeyAndReport exercises the spoke's storage of a hub-delivered
+// additional key and the held-fingerprints report the hub uses for idempotence.
+func TestWritePerAppIDKeyAndReport(t *testing.T) {
+	redirectSpokeKeyPaths(t)
+	const appID int64 = 3568013
+
+	// Generate a key PEM the way the hub would deliver it.
+	k, err := rsa.GenerateKey(rand.Reader, testRSAKeyBits)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pemData := string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(k),
+	}))
+	wantFP, err := config.AppKeyFingerprint(pemData)
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+
+	fp, err := writePerAppIDKey(appID, pemData)
+	if err != nil {
+		t.Fatalf("writePerAppIDKey: %v", err)
+	}
+	if fp != wantFP {
+		t.Fatalf("writePerAppIDKey fingerprint = %q, want %q", fp, wantFP)
+	}
+
+	// The file must be 0600 — signing material is never group/other readable.
+	info, err := os.Stat(perAppIDKeyPath(appID))
+	if err != nil {
+		t.Fatalf("stat per-app key: %v", err)
+	}
+	if info.Mode().Perm() != spokeAppKeyFileMode {
+		t.Fatalf("per-app key mode = %o, want %o", info.Mode().Perm(), spokeAppKeyFileMode)
+	}
+
+	// heldPerAppIDKeyFingerprints must surface exactly this app_id → fingerprint,
+	// which is what the hub diffs against to stop re-delivering.
+	held := heldPerAppIDKeyFingerprints()
+	if got := held["3568013"]; got != wantFP {
+		t.Fatalf("heldPerAppIDKeyFingerprints[3568013] = %q, want %q (full map: %v)", got, wantFP, held)
+	}
+
+	// A non-positive app_id is refused rather than writing an ambiguous file.
+	if _, err := writePerAppIDKey(0, pemData); err == nil {
+		t.Error("writePerAppIDKey(0, ...) succeeded; a non-positive app_id must be refused")
+	}
 }

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -66,16 +66,132 @@ var (
 //   - spokeAppKeyPath is on the PVC and is where a hub-delivered (cluster
 //     default) key lands. It is also what cfg.GitHub.KeyFile is repointed at
 //     once the hub delivers one, so it takes effect over the provisioned mount.
+//
 // Vars rather than consts so tests can point them at a temp dir and exercise
 // the real resolution order; production never reassigns them.
 var (
 	spokeProvisionedAppKeyPath = "/secrets/gh-app-key.pem"
 	spokeAppKeyPath            = "/data/gh-app-key.pem"
+	// spokeAppKeyDir is where per-app-id keys the hub delivers land, one file per
+	// App the fleet knows: gh-app-key-<appid>.pem. It is the PVC directory that
+	// already holds spokeAppKeyPath, so both survive restarts. A var so tests can
+	// redirect it; production never reassigns it.
+	spokeAppKeyDir = "/data"
 )
 
 // spokeAppKeyFileMode is rw------- : signing material must never be readable by
 // anything else sharing the PVC or the pod.
 const spokeAppKeyFileMode = 0o600
+
+// perAppIDKeyPath returns the on-disk path of the key file a spoke uses for a
+// specific app_id — /data/gh-app-key-<appid>.pem. This is what lets one spoke
+// hold BOTH the github.com App key AND its cluster's GitHub Enterprise App key
+// at once and sign with whichever matches its configured app_id.
+//
+// Returns "" for a non-positive app_id (0 = unknown/unset, the placeholder
+// sentinel, or a hand-corrupted value): there is no meaningful per-app file for
+// those, and the caller falls back to the existing single-file behaviour.
+func perAppIDKeyPath(appID int64) string {
+	if appID <= 0 {
+		return ""
+	}
+	return filepath.Join(spokeAppKeyDir, fmt.Sprintf("gh-app-key-%d.pem", appID))
+}
+
+// perAppIDKeyFilePrefix / Suffix bracket the per-app-id key filename so a scan
+// can recover the app_id from the name. Named so the format lives in exactly one
+// place alongside perAppIDKeyPath.
+const (
+	perAppIDKeyFilePrefix = "gh-app-key-"
+	perAppIDKeyFileSuffix = ".pem"
+)
+
+// heldPerAppIDKeyFingerprints scans the PVC for per-app-id key files
+// (gh-app-key-<appid>.pem) and returns app_id (decimal string) → fingerprint for
+// every one that holds a usable key. It is what the spoke reports so the hub
+// delivers the fleet's additional keys idempotently: a key already present with
+// the right fingerprint is not re-sent.
+//
+// It never returns key material — only fingerprints. A missing directory,
+// unreadable file, or unparseable key is silently skipped: the worst case is the
+// hub re-delivers a key the spoke already writes idempotently, never a crash.
+func heldPerAppIDKeyFingerprints() map[string]string {
+	entries, err := os.ReadDir(spokeAppKeyDir)
+	if err != nil {
+		return nil
+	}
+	var held map[string]string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, perAppIDKeyFilePrefix) || !strings.HasSuffix(name, perAppIDKeyFileSuffix) {
+			continue
+		}
+		idStr := strings.TrimSuffix(strings.TrimPrefix(name, perAppIDKeyFilePrefix), perAppIDKeyFileSuffix)
+		id, convErr := strconv.ParseInt(idStr, 10, 64)
+		if convErr != nil || id <= 0 {
+			continue
+		}
+		fp, fpErr := config.AppKeyFingerprintFromFile(filepath.Join(spokeAppKeyDir, name))
+		if fpErr != nil || fp == "" {
+			continue
+		}
+		if held == nil {
+			held = make(map[string]string)
+		}
+		held[idStr] = fp
+	}
+	return held
+}
+
+// writePerAppIDKey persists a hub-delivered per-app-id key to its PVC file
+// atomically (temp file in the same dir, then rename) with a restrictive 0600
+// mode from creation, so a spoke can never sign with a half-written key. Returns
+// the resulting fingerprint (never the key) for auditable logging, or an error.
+func writePerAppIDKey(appID int64, pemData string) (string, error) {
+	path := perAppIDKeyPath(appID)
+	if path == "" {
+		return "", fmt.Errorf("refusing to write key for non-positive app_id %d", appID)
+	}
+	trimmed := strings.TrimSpace(pemData)
+	if !strings.HasPrefix(trimmed, "-----BEGIN") {
+		return "", fmt.Errorf("app key for app_id %d is not PEM", appID)
+	}
+	fp, err := config.AppKeyFingerprint(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("app key for app_id %d is unusable: %w", appID, err)
+	}
+	if err := os.MkdirAll(spokeAppKeyDir, 0o700); err != nil {
+		return "", fmt.Errorf("create app key dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(spokeAppKeyDir, "."+filepath.Base(path)+".tmp*")
+	if err != nil {
+		return "", fmt.Errorf("create temp app key file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op once the rename below succeeds
+	if err := tmp.Chmod(spokeAppKeyFileMode); err != nil {
+		tmp.Close()
+		return "", fmt.Errorf("chmod temp app key file: %w", err)
+	}
+	if _, err := tmp.WriteString(trimmed + "\n"); err != nil {
+		tmp.Close()
+		return "", fmt.Errorf("write temp app key file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return "", fmt.Errorf("sync temp app key file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("close temp app key file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return "", fmt.Errorf("rename app key into place: %w", err)
+	}
+	return fp, nil
+}
 
 // reportedAppKeyFingerprint returns the non-secret fingerprint of the App key
 // this spoke is ACTUALLY using, for the heartbeat payload. It fingerprints the
@@ -86,11 +202,12 @@ const spokeAppKeyFileMode = 0o600
 // unparseable contents. All three mean the same thing to the hub ("this spoke
 // cannot authenticate") and are repaired identically. The private key itself is
 // never returned, and never enters the payload.
-func reportedAppKeyFingerprint(keyFile string) string {
+func reportedAppKeyFingerprint(keyFile string, appID int64) string {
 	// Lead with the same path resolveAppKeyFile would sign with, so the hub is
 	// told about the key actually in effect and never about a shadowed one.
 	candidates := []string{
-		resolveAppKeyFile(keyFile, os.Getenv("GH_APP_KEY_FILE")),
+		resolveAppKeyFile(keyFile, os.Getenv("GH_APP_KEY_FILE"), appID),
+		perAppIDKeyPath(appID),
 		keyFile, spokeAppKeyPath, spokeProvisionedAppKeyPath,
 	}
 	for _, p := range candidates {
@@ -112,7 +229,7 @@ func reportedAppKeyFingerprint(keyFile string) string {
 // When BOTH exist the hub-delivered PVC key is the one in effect (the callback
 // repoints cfg.GitHub.KeyFile at it), so this only claims an override while the
 // provisioned key is genuinely the one being used.
-func hasPerHiveAppKey(keyFile string) bool {
+func hasPerHiveAppKey(keyFile string, appID int64) bool {
 	fp, err := config.AppKeyFingerprintFromFile(spokeProvisionedAppKeyPath)
 	if err != nil || fp == "" {
 		return false
@@ -120,8 +237,9 @@ func hasPerHiveAppKey(keyFile string) bool {
 	// The provisioned key exists. It is the effective credential only if the
 	// resolved key file still points at it — resolveAppKeyFile is the single
 	// authority on that, so an unconfigured hive that has already taken delivery
-	// of a /data key correctly stops claiming a per-hive override.
-	return resolveAppKeyFile(keyFile, os.Getenv("GH_APP_KEY_FILE")) == spokeProvisionedAppKeyPath
+	// of a /data key (or a per-app-id key) correctly stops claiming a per-hive
+	// override.
+	return resolveAppKeyFile(keyFile, os.Getenv("GH_APP_KEY_FILE"), appID) == spokeProvisionedAppKeyPath
 }
 
 // resolveAppKeyFile picks which App private key this process will actually sign
@@ -143,17 +261,38 @@ func hasPerHiveAppKey(keyFile string) bool {
 // preferred over the provisioning mount. An EXPLICIT key_file or env override
 // still wins outright: those are deliberate, and this must not silently redirect
 // an operator who named a path.
-func resolveAppKeyFile(configured, envOverride string) string {
+//
+// PER-APP-ID SELECTION (the both-keys fix)
+//
+// appID is the App this process is configured to authenticate AS
+// (cfg.GitHub.AppID). When the hub has delivered a per-app-id key for exactly
+// that App — /data/gh-app-key-<appID>.pem — it is preferred over the generic
+// single-file paths, because it is provably the RIGHT key for the app_id we
+// claim. This is what lets a github.com hive on a GitHub-Enterprise cluster sign
+// with the github.com key even though its cluster default (and its single
+// /data/gh-app-key.pem) is the GHE key. It sits just below an explicit
+// key_file/env override — an operator who named a path still wins — and above
+// the generic fallbacks. appID <= 0 disables it entirely, so nothing changes for
+// a hive that reports no app_id.
+func resolveAppKeyFile(configured, envOverride string, appID int64) string {
 	if v := strings.TrimSpace(envOverride); v != "" {
 		return v
 	}
 	if v := strings.TrimSpace(configured); v != "" {
 		return v
 	}
-	// Nothing configured. Prefer a usable hub-delivered key on the PVC; fall
-	// back to the provisioning mount only when /data has no parseable key. The
-	// fingerprint check (not mere existence) keeps an empty or truncated /data
-	// file from shadowing a good provisioned key.
+	// Nothing explicitly configured. Prefer a per-app-id key matching the App we
+	// claim — the only key that is CORRECT-by-construction for this app_id — over
+	// the generic cluster/provisioned files. The fingerprint check (not mere
+	// existence) keeps an empty or truncated per-app file from shadowing a good
+	// generic key.
+	if p := perAppIDKeyPath(appID); p != "" {
+		if fp, err := config.AppKeyFingerprintFromFile(p); err == nil && fp != "" {
+			return p
+		}
+	}
+	// Prefer a usable hub-delivered key on the PVC; fall back to the provisioning
+	// mount only when /data has no parseable key.
 	if fp, err := config.AppKeyFingerprintFromFile(spokeAppKeyPath); err == nil && fp != "" {
 		return spokeAppKeyPath
 	}
@@ -227,7 +366,7 @@ type githubAuth struct {
 // config.PlaceholderAppID.
 func initGitHubAuth(ctx context.Context, cfg *config.Config, logger *slog.Logger) githubAuth {
 	var out githubAuth
-	appKeyFile := resolveAppKeyFile(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"))
+	appKeyFile := resolveAppKeyFile(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), cfg.GitHub.AppID)
 
 	// HasUsableApp() rejects config.PlaceholderAppID. A placeholder paired with
 	// a real installation_id — exactly what happens the instant an owner
@@ -2105,12 +2244,16 @@ func main() {
 				// this against its per-cluster key and pushes a correction only
 				// on a mismatch, so a spoke already holding the right key costs
 				// nothing and a spoke holding the wrong one self-heals.
-				GitHubAppKeyFingerprint: reportedAppKeyFingerprint(cfg.GitHub.KeyFile),
-				GitHubAppKeyPerHive:     hasPerHiveAppKey(cfg.GitHub.KeyFile),
+				GitHubAppKeyFingerprint: reportedAppKeyFingerprint(cfg.GitHub.KeyFile, cfg.GitHub.AppID),
+				GitHubAppKeyPerHive:     hasPerHiveAppKey(cfg.GitHub.KeyFile, cfg.GitHub.AppID),
 				// Report the App this hive believes it authenticates as. The hub
 				// pairs it with the fingerprint above to tell a per-hive key that
 				// is WRONG for this App from one that is deliberately for another.
 				GitHubAppID: cfg.GitHub.AppID,
+				// Report the fingerprint of every ADDITIONAL per-app-id key already
+				// on the PVC, so the hub delivers the fleet's other App keys once
+				// and then stops re-sending them.
+				GitHubAppKeysHeld: heldPerAppIDKeyFingerprints(),
 			}
 		}, heartbeatSendInterval, logger, hub.UpgradeCallback(func(targetSHA string) {
 			const upgradeMarkerPath = "/data/upgrade-requested"
@@ -2270,6 +2413,46 @@ func main() {
 				}
 			}
 
+			// Persist the fleet's ADDITIONAL App keys — every OTHER App's key,
+			// keyed by app_id — so this spoke can sign for the App it is actually
+			// configured as even when that is NOT its cluster's default. This is
+			// the both-keys fix: a github.com hive on a GHE cluster now receives
+			// and stores the github.com key here, and resolveAppKeyFile selects it
+			// by matching cfg.GitHub.AppID.
+			//
+			// Written to distinct /data/gh-app-key-<appid>.pem files, so they never
+			// collide with the primary /data/gh-app-key.pem above. Writing one that
+			// matches our OWN app_id must take effect immediately: flip keyChanged
+			// so the client is rebuilt below, exactly as a primary-key change does.
+			for _, ak := range ghCfg.AdditionalKeys {
+				if ak.PrivateKey == "" || ak.AppID <= 0 {
+					continue
+				}
+				perAppPath := perAppIDKeyPath(ak.AppID)
+				beforeFP, _ := config.AppKeyFingerprintFromFile(perAppPath)
+				fp, err := writePerAppIDKey(ak.AppID, ak.PrivateKey)
+				if err != nil {
+					logger.Error("failed to write additional github app key from heartbeat",
+						"app_id", ak.AppID, "error", err)
+					continue
+				}
+				changed := fp != "" && fp != beforeFP
+				logger.Info("additional github app private key written via heartbeat",
+					"app_id", ak.AppID,
+					"path", perAppPath,
+					"from_fingerprint", beforeFP,
+					"to_fingerprint", fp,
+					"key_changed", changed,
+				)
+				// If this additional key is for the App we ourselves authenticate
+				// as, it is now the key resolveAppKeyFile will pick — treat it like
+				// a primary-key rotation so the client rebuild below uses it.
+				if changed && ak.AppID == cfg.GitHub.AppID {
+					keyChanged = true
+					appAuth.DropCachedToken()
+				}
+			}
+
 			// Adopt a hub-delivered app_id only when it names a REAL App. Zero
 			// means "not speaking to this field"; the placeholder sentinel is
 			// what a pre-provisioned hive already carries, so re-adopting it
@@ -2297,12 +2480,22 @@ func main() {
 				cfg.GitHub.AppSlug = ghCfg.AppSlug
 			}
 
-			if cfg.GitHub.HasUsableApp() && cfg.GitHub.KeyFile != "" {
-				newAppAuth, err := github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, cfg.GitHub.KeyFile, logger, cfg.GitHub.ResolvedAPIURL())
+			// Resolve the key file the same way startup does, so a hive whose
+			// only correct key arrived as an ADDITIONAL per-app-id key (no
+			// primary key_file configured — the exact vllm-d state) still finds
+			// it: resolveAppKeyFile prefers /data/gh-app-key-<appid>.pem for the
+			// app_id we now claim. An explicit key_file still wins outright.
+			rebuildKeyFile := resolveAppKeyFile(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), cfg.GitHub.AppID)
+			if cfg.GitHub.HasUsableApp() && rebuildKeyFile != "" {
+				newAppAuth, err := github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, rebuildKeyFile, logger, cfg.GitHub.ResolvedAPIURL())
 				if err != nil {
 					logger.Error("github app auth init via heartbeat failed", "error", err)
 					return
 				}
+				// Record the key file actually in effect so subsequent config
+				// reads and heartbeat fingerprint reports reflect the resolved
+				// per-app-id key rather than an empty configured value.
+				cfg.GitHub.KeyFile = rebuildKeyFile
 				// Hub-delivered creds can carry a wrong installation_id just as
 				// easily as a hand-edited config; correct (and persist) it
 				// before building a client that would 403 on every write.

--- a/v2/pkg/hub/both_app_keys_test.go
+++ b/v2/pkg/hub/both_app_keys_test.go
@@ -1,0 +1,248 @@
+package hub
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// App IDs from the live incident: the public github.com Hive App and the GHE App
+// registered on the vllm-d cluster's github.ibm.com host.
+const (
+	testGitHubComAppID int64 = 3568013
+	testGHEAppID       int64 = 5686
+)
+
+// storeKeyFor stores a freshly generated key for a cluster and returns its
+// fingerprint. Uses the same temp-dir redirection every store test uses.
+func storeKeyFor(t *testing.T, clusterID string) string {
+	t.Helper()
+	pemData := testAppKeyPEM(t)
+	if err := storeClusterAppKey(clusterID, pemData); err != nil {
+		t.Fatalf("store key for %s: %v", clusterID, err)
+	}
+	fp, err := config.AppKeyFingerprint(pemData)
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	return fp
+}
+
+// twoClusterHub builds a hub with a github.com cluster and a GHE (vllm-d)
+// cluster, each with its own App key stored, mirroring the live fleet.
+func twoClusterHub(t *testing.T) (*HubServer, map[int64]string) {
+	t.Helper()
+	withTempAppKeyDir(t)
+	// The github.com App key lives on the public cluster; the GHE key on vllm-d.
+	publicFP := storeKeyFor(t, "hive-oke")
+	gheFP := storeKeyFor(t, "vllm-d")
+	s := &HubServer{
+		logger: appKeyTestLogger(),
+		clusters: map[string]ClusterConfig{
+			"hive-oke": {ID: "hive-oke", GitHubAppID: testGitHubComAppID, GitHubAppSlug: "kubestellar-hive"},
+			"vllm-d":   {ID: "vllm-d", GitHubAppID: testGHEAppID, GitHubAppSlug: "ibm-hive"},
+		},
+	}
+	return s, map[int64]string{testGitHubComAppID: publicFP, testGHEAppID: gheFP}
+}
+
+// TestAppKeysByAppID indexes the per-cluster store by app_id and de-duplicates.
+func TestAppKeysByAppID(t *testing.T) {
+	s, fps := twoClusterHub(t)
+
+	byID := s.appKeysByAppID()
+	if len(byID) != 2 {
+		t.Fatalf("appKeysByAppID returned %d keys, want 2", len(byID))
+	}
+	for appID, wantFP := range fps {
+		got, ok := byID[appID]
+		if !ok {
+			t.Fatalf("appKeysByAppID missing app_id %d", appID)
+		}
+		if got.Fingerprint != wantFP {
+			t.Errorf("app_id %d fingerprint = %q, want %q", appID, got.Fingerprint, wantFP)
+		}
+		if got.PrivateKey == "" {
+			t.Errorf("app_id %d has no private key", appID)
+		}
+	}
+
+	t.Run("cluster with no app_id contributes nothing", func(t *testing.T) {
+		s.clusters["nokey"] = ClusterConfig{ID: "nokey"} // GitHubAppID == 0
+		if got := len(s.appKeysByAppID()); got != 2 {
+			t.Fatalf("appKeysByAppID = %d keys after adding a keyless cluster, want 2", got)
+		}
+	})
+
+	t.Run("two clusters sharing an app_id de-duplicate", func(t *testing.T) {
+		// A second cluster fronting the SAME github.com App.
+		storeKeyFor(t, "hive-oke-2")
+		s.clusters["hive-oke-2"] = ClusterConfig{ID: "hive-oke-2", GitHubAppID: testGitHubComAppID}
+		byID := s.appKeysByAppID()
+		if _, ok := byID[testGitHubComAppID]; !ok {
+			t.Fatal("shared app_id vanished after adding a second cluster for it")
+		}
+		// Still exactly two distinct app_ids.
+		if len(byID) != 2 {
+			t.Fatalf("appKeysByAppID = %d distinct app_ids, want 2", len(byID))
+		}
+	})
+}
+
+// TestAdditionalAppKeysForSpoke returns every key except the spoke's primary.
+func TestAdditionalAppKeysForSpoke(t *testing.T) {
+	s, fps := twoClusterHub(t)
+
+	t.Run("github.com hive on GHE cluster gets the GHE key as additional", func(t *testing.T) {
+		// Primary is the github.com app the hive claims; the OTHER key (GHE) must
+		// be offered as additional.
+		add := s.additionalAppKeysForSpoke(testGitHubComAppID)
+		if len(add) != 1 {
+			t.Fatalf("additional keys = %d, want 1", len(add))
+		}
+		if add[0].AppID != testGHEAppID {
+			t.Fatalf("additional key app_id = %d, want %d", add[0].AppID, testGHEAppID)
+		}
+		if add[0].Fingerprint != fps[testGHEAppID] {
+			t.Errorf("additional key fingerprint = %q, want %q", add[0].Fingerprint, fps[testGHEAppID])
+		}
+		if add[0].PrivateKey == "" {
+			t.Error("additional key carries no private key value")
+		}
+	})
+
+	t.Run("primary is never duplicated as additional", func(t *testing.T) {
+		for _, k := range s.additionalAppKeysForSpoke(testGHEAppID) {
+			if k.AppID == testGHEAppID {
+				t.Errorf("primary app_id %d appeared in additional keys", testGHEAppID)
+			}
+		}
+	})
+
+	t.Run("primary 0 returns every fleet key", func(t *testing.T) {
+		if got := len(s.additionalAppKeysForSpoke(0)); got != 2 {
+			t.Fatalf("additional keys for primary 0 = %d, want 2 (all fleet keys)", got)
+		}
+	})
+}
+
+// TestAttachMissingAppKeys is the end-to-end delivery decision on the hub: a
+// github.com hive on the GHE cluster must receive the github.com key it lacks,
+// delivered idempotently.
+func TestAttachMissingAppKeys(t *testing.T) {
+	s, fps := twoClusterHub(t)
+
+	t.Run("github.com hive on GHE cluster receives the github.com key", func(t *testing.T) {
+		// The live bug: a github.com hive parked on vllm-d has inherited the GHE
+		// cluster default (app_id 5686) and holds only the GHE key. It must be
+		// handed the github.com key (3568013) so that once its app_id is corrected
+		// to github.com, the matching key is already on disk. Its PRIMARY (the GHE
+		// key) is delivered by the cluster reconcile; the github.com key rides here
+		// as additional.
+		payload := &HeartbeatPayload{
+			HiveID:      "katamari-hive",
+			ClusterID:   "vllm-d",
+			GitHubAppID: testGHEAppID, // currently mis-inheriting the cluster app_id
+		}
+		var resp HeartbeatResponse
+		s.attachMissingAppKeys(&resp, payload)
+
+		if resp.GitHubAppConfig == nil {
+			t.Fatal("no GitHubAppConfig attached; the github.com hive got no additional key")
+		}
+		add := resp.GitHubAppConfig.AdditionalKeys
+		if len(add) != 1 || add[0].AppID != testGitHubComAppID {
+			t.Fatalf("additional keys = %+v, want exactly the github.com key %d", add, testGitHubComAppID)
+		}
+		if add[0].Fingerprint != fps[testGitHubComAppID] {
+			t.Errorf("delivered github.com key fingerprint = %q, want %q", add[0].Fingerprint, fps[testGitHubComAppID])
+		}
+	})
+
+	t.Run("idempotent: a spoke already holding every additional key gets nothing", func(t *testing.T) {
+		// A github.com hive's ONE additional key is the GHE key. Once it reports
+		// holding that with the right fingerprint, nothing further rides the wire.
+		payload := &HeartbeatPayload{
+			HiveID:      "katamari-hive",
+			ClusterID:   "vllm-d",
+			GitHubAppID: testGitHubComAppID,
+			GitHubAppKeysHeld: map[string]string{
+				strconv.FormatInt(testGHEAppID, 10): fps[testGHEAppID],
+			},
+		}
+		var resp HeartbeatResponse
+		s.attachMissingAppKeys(&resp, payload)
+		if resp.GitHubAppConfig != nil && len(resp.GitHubAppConfig.AdditionalKeys) != 0 {
+			t.Fatalf("re-delivered a key the spoke already holds: %+v", resp.GitHubAppConfig.AdditionalKeys)
+		}
+	})
+
+	t.Run("stale held fingerprint is corrected", func(t *testing.T) {
+		payload := &HeartbeatPayload{
+			HiveID:      "katamari-hive",
+			ClusterID:   "vllm-d",
+			GitHubAppID: testGitHubComAppID,
+			GitHubAppKeysHeld: map[string]string{
+				strconv.FormatInt(testGHEAppID, 10): "sha256:stalestalestalestale",
+			},
+		}
+		var resp HeartbeatResponse
+		s.attachMissingAppKeys(&resp, payload)
+		if resp.GitHubAppConfig == nil || len(resp.GitHubAppConfig.AdditionalKeys) != 1 {
+			t.Fatal("a spoke holding a STALE fingerprint must be re-delivered the current key")
+		}
+		if resp.GitHubAppConfig.AdditionalKeys[0].AppID != testGHEAppID {
+			t.Fatalf("re-delivered app_id = %d, want the stale GHE key %d", resp.GitHubAppConfig.AdditionalKeys[0].AppID, testGHEAppID)
+		}
+	})
+
+	t.Run("does not duplicate a key already attached as the primary this beat", func(t *testing.T) {
+		// The cluster reconcile already attached the GHE key as the primary; the
+		// additional pass must not attach it again.
+		resp := HeartbeatResponse{GitHubAppConfig: &HeartbeatGitHubAppConfig{AppID: testGHEAppID}}
+		payload := &HeartbeatPayload{HiveID: "vllmd-06", ClusterID: "vllm-d", GitHubAppID: testGHEAppID}
+		s.attachMissingAppKeys(&resp, payload)
+		for _, k := range resp.GitHubAppConfig.AdditionalKeys {
+			if k.AppID == testGHEAppID {
+				t.Errorf("GHE key %d attached as additional despite being the primary this beat", testGHEAppID)
+			}
+		}
+		// It SHOULD still get the github.com key, since it lacks it.
+		if len(resp.GitHubAppConfig.AdditionalKeys) != 1 || resp.GitHubAppConfig.AdditionalKeys[0].AppID != testGitHubComAppID {
+			t.Fatalf("additional keys = %+v, want just the github.com key", resp.GitHubAppConfig.AdditionalKeys)
+		}
+	})
+
+	t.Run("no fleet keys means nothing attached", func(t *testing.T) {
+		empty := &HubServer{logger: appKeyTestLogger(), clusters: map[string]ClusterConfig{}}
+		var resp HeartbeatResponse
+		empty.attachMissingAppKeys(&resp, &HeartbeatPayload{HiveID: "h", GitHubAppID: 1})
+		if resp.GitHubAppConfig != nil {
+			t.Fatalf("attached a config with no fleet keys: %+v", resp.GitHubAppConfig)
+		}
+	})
+}
+
+// TestAdditionalKeysNeverLoggedOrInClustersJSON guards the security posture: the
+// additional-keys mechanism must not leak key material into the cluster config
+// surface that flows to operator-facing paths.
+func TestAdditionalKeysCarryFingerprintNotInConfig(t *testing.T) {
+	s, _ := twoClusterHub(t)
+	add := s.additionalAppKeysForSpoke(0)
+	if len(add) == 0 {
+		t.Fatal("expected fleet keys")
+	}
+	// The ClusterConfig values must never carry a private key field (this is the
+	// same invariant TestClusterConfigHasNoPrivateKeyField enforces structurally);
+	// here we assert the delivery struct carries the key only in its dedicated
+	// PrivateKey field and a fingerprint alongside.
+	for _, k := range add {
+		if k.PrivateKey == "" {
+			t.Errorf("app_id %d additional key missing its private key value", k.AppID)
+		}
+		if k.Fingerprint == "" {
+			t.Errorf("app_id %d additional key missing its non-secret fingerprint", k.AppID)
+		}
+	}
+}

--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
@@ -214,6 +215,188 @@ func (s *HubServer) appIdentityForCluster(clusterID string) *clusterAppIdentity 
 		AppSlug:     c.GitHubAppSlug,
 		PrivateKey:  pem,
 		Fingerprint: fp,
+	}
+}
+
+// fleetAppKey is one App identity the fleet knows, indexed by its own app_id.
+// It is assembled the same way appIdentityForCluster assembles a cluster's
+// identity — the non-secret app_id/slug from cluster config, the secret key from
+// the per-cluster key store — but keyed by APP rather than by cluster, so a
+// spoke can be handed the key of an App that is not its own cluster's.
+type fleetAppKey struct {
+	AppID       int64
+	AppSlug     string
+	PrivateKey  string
+	Fingerprint string
+}
+
+// appKeysByAppID returns the fleet's App keys de-duplicated by app_id.
+//
+// WHY app_id AND NOT clusterID
+//
+// The store on disk is keyed by cluster (one <clusterID>.pem per cluster), but
+// two clusters can front the SAME GitHub host and therefore the same App — and,
+// more importantly, a spoke needs to be handed the key for an App that is NOT its
+// cluster's default (a github.com hive parked on a GitHub-Enterprise cluster).
+// Re-indexing the existing per-cluster keys by their app_id gives exactly that
+// lookup without a second on-disk store or any migration: every key already on
+// disk simply becomes discoverable by the App it belongs to.
+//
+// It is read-only over the cluster map and the key files; it invents nothing and
+// stores nothing. A cluster with no configured app_id, or no usable key on disk,
+// contributes nothing. When two clusters resolve to the same app_id the first
+// usable key wins deterministically (clusters are visited in sorted ID order) —
+// they are the same App, so any of its valid keys is correct.
+func (s *HubServer) appKeysByAppID() map[int64]fleetAppKey {
+	out := make(map[int64]fleetAppKey)
+	if s == nil || s.clusters == nil {
+		return out
+	}
+	ids := make([]string, 0, len(s.clusters))
+	for id := range s.clusters {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids) // deterministic winner when two clusters share an app_id
+	for _, id := range ids {
+		c := s.clusters[id]
+		if c.GitHubAppID == 0 {
+			continue
+		}
+		if _, seen := out[c.GitHubAppID]; seen {
+			continue
+		}
+		pem := loadClusterAppKey(id)
+		if pem == "" {
+			continue
+		}
+		fp, err := config.AppKeyFingerprint(pem)
+		if err != nil {
+			continue
+		}
+		out[c.GitHubAppID] = fleetAppKey{
+			AppID:       c.GitHubAppID,
+			AppSlug:     c.GitHubAppSlug,
+			PrivateKey:  pem,
+			Fingerprint: fp,
+		}
+	}
+	return out
+}
+
+// additionalAppKeysForSpoke returns every fleet App key EXCEPT the one a given
+// spoke would already receive as its primary (cluster) key, so a spoke ends up
+// holding all keys the fleet knows and can select by its own app_id.
+//
+// primaryAppID is the app_id of the key already carried in the heartbeat's
+// AppID/PrivateKey pair (the spoke's cluster key). Passing 0 means "no primary
+// carried" and every fleet key is returned. The result is sorted by app_id so
+// delivery — and any test asserting on it — is deterministic, and never contains
+// the primary again (that would be pure duplication on the wire).
+func (s *HubServer) additionalAppKeysForSpoke(primaryAppID int64) []HeartbeatAppKey {
+	keys := s.appKeysByAppID()
+	if len(keys) == 0 {
+		return nil
+	}
+	appIDs := make([]int64, 0, len(keys))
+	for id := range keys {
+		if id == primaryAppID {
+			continue // already delivered as the primary key
+		}
+		appIDs = append(appIDs, id)
+	}
+	if len(appIDs) == 0 {
+		return nil
+	}
+	sort.Slice(appIDs, func(i, j int) bool { return appIDs[i] < appIDs[j] })
+	out := make([]HeartbeatAppKey, 0, len(appIDs))
+	for _, id := range appIDs {
+		k := keys[id]
+		out = append(out, HeartbeatAppKey{
+			AppID:       k.AppID,
+			PrivateKey:  k.PrivateKey,
+			Fingerprint: k.Fingerprint,
+		})
+	}
+	return out
+}
+
+// attachMissingAppKeys adds the fleet's OTHER App keys to a heartbeat response
+// so a spoke ends up holding every App key the fleet knows, and can pick the one
+// matching its own app_id. It is the fix for a github.com hive on a
+// GitHub-Enterprise cluster (vllm-d): that hive inherits only the GHE cluster
+// key, holds no github.com key, and cannot authenticate github.com repos.
+//
+// IDEMPOTENCE: it delivers only the keys the spoke does NOT already hold with a
+// matching fingerprint (payload.GitHubAppKeysHeld). Once the spoke reports it
+// holds them all, nothing further rides the wire — the same "compare by
+// fingerprint, never re-send a key already in place" contract the per-cluster
+// reconcile uses.
+//
+// EXCLUSIONS: the spoke's PRIMARY key is never sent as an "additional" key.
+// Primary = whatever app_id the spoke is already configured as
+// (payload.GitHubAppID) AND whatever app_id the response's own
+// GitHubAppConfig.AppID carries this beat (the cluster key just decided above).
+// Sending either again would be pure duplication.
+//
+// It attaches to resp.GitHubAppConfig, creating a bare one (no primary key, no
+// app_id change) when the branches above left it nil — the additional keys must
+// reach the spoke even when its cluster key needs no correction. The private key
+// values are secret and travel only on this TLS response; only fingerprints are
+// logged.
+func (s *HubServer) attachMissingAppKeys(resp *HeartbeatResponse, payload *HeartbeatPayload) {
+	if s == nil || resp == nil || payload == nil {
+		return
+	}
+	// The spoke's primary app_id is its own configured one; also exclude the
+	// app_id of any cluster key attached this beat so we never duplicate it.
+	primaryAppID := payload.GitHubAppID
+	var alsoExclude int64
+	if resp.GitHubAppConfig != nil {
+		alsoExclude = resp.GitHubAppConfig.AppID
+	}
+
+	additional := s.additionalAppKeysForSpoke(primaryAppID)
+	if len(additional) == 0 {
+		return
+	}
+
+	missing := make([]HeartbeatAppKey, 0, len(additional))
+	for _, k := range additional {
+		if alsoExclude != 0 && k.AppID == alsoExclude {
+			continue // already delivered as the primary/cluster key this beat
+		}
+		// Idempotence: skip a key the spoke already holds with this fingerprint.
+		if held, ok := payload.GitHubAppKeysHeld[strconv.FormatInt(k.AppID, 10)]; ok {
+			if held != "" && k.Fingerprint != "" && held == k.Fingerprint {
+				continue
+			}
+		}
+		missing = append(missing, k)
+	}
+	if len(missing) == 0 {
+		return
+	}
+
+	if resp.GitHubAppConfig == nil {
+		// No primary key change this beat — attach a bare carrier. AppID 0 and an
+		// empty PrivateKey both mean "leave the spoke's primary alone"; only the
+		// additional keys travel.
+		resp.GitHubAppConfig = &HeartbeatGitHubAppConfig{}
+	}
+	resp.GitHubAppConfig.AdditionalKeys = missing
+
+	if s.logger != nil {
+		fps := make([]string, 0, len(missing))
+		for _, k := range missing {
+			// Fingerprints only — the key material is never logged.
+			fps = append(fps, strconv.FormatInt(k.AppID, 10)+"="+k.Fingerprint)
+		}
+		s.logger.Info("heartbeat: delivering additional github app keys to spoke",
+			"hive_id", payload.HiveID,
+			"cluster_id", payload.ClusterID,
+			"primary_app_id", primaryAppID,
+			"delivered", strings.Join(fps, ","),
+		)
 	}
 }
 

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -331,6 +331,18 @@ type HeartbeatPayload struct {
 	// read as "unknown": the hub falls back to the conservative per-hive
 	// override and declines to overwrite. Never infer a mismatch from silence.
 	GitHubAppID int64 `json:"github_app_id,omitempty"`
+	// GitHubAppKeysHeld reports the NON-SECRET fingerprint of every ADDITIONAL
+	// per-app-id key file this spoke holds on its PVC, keyed by app_id as a
+	// decimal string (JSON object keys must be strings). It exists so the hub can
+	// deliver the fleet's OTHER App keys (see HeartbeatGitHubAppConfig.
+	// AdditionalKeys) exactly once and then stop: a key already present with the
+	// right fingerprint is not re-sent every beat.
+	//
+	// It carries fingerprints ONLY — never key material — exactly like
+	// GitHubAppKeyFingerprint above. Empty/nil means the spoke holds no per-app-id
+	// keys, or is too old to report; either way the hub falls back to delivering
+	// any additional keys it has, which the spoke writes idempotently.
+	GitHubAppKeysHeld map[string]string `json:"github_app_keys_held,omitempty"`
 }
 
 type StatusCollector func() *HeartbeatPayload
@@ -615,6 +627,45 @@ type HeartbeatGitHubAppConfig struct {
 	// Empty means "leave the spoke's slug unchanged" — never a way to blank a
 	// working value.
 	AppSlug string `json:"app_slug,omitempty"`
+	// AdditionalKeys carries EVERY OTHER GitHub App private key the fleet knows,
+	// keyed by its own app_id, so a spoke can hold both the github.com App key
+	// AND its cluster's GitHub Enterprise App key at once — and pick whichever
+	// one matches the app_id it is actually configured to authenticate as.
+	//
+	// WHY THIS EXISTS
+	//
+	// The AppID/PrivateKey pair above is the spoke's CLUSTER key: the key of the
+	// App registered on the cluster's GitHub host. That is wrong for a github.com
+	// hive that happens to land on a GitHub-Enterprise-default cluster (the live
+	// vllm-d case): it inherits the GHE app_id and GHE key, holds no github.com
+	// key at all, and every github.com repo call dies with "github auth token
+	// error". Delivering the OTHER app's key too — written to a distinct
+	// per-app-id file on the spoke — lets that hive authenticate as the App it is
+	// really pinned to, regardless of which cluster it runs on.
+	//
+	// It is purely additive: a spoke that only understands the single AppID/
+	// PrivateKey pair (an older build) ignores this field and behaves exactly as
+	// before. Each entry's PrivateKey is a SECRET value and travels only over the
+	// TLS heartbeat channel; it is never logged. nil/empty means "nothing extra
+	// to deliver".
+	AdditionalKeys []HeartbeatAppKey `json:"additional_keys,omitempty"`
+}
+
+// HeartbeatAppKey is one (app_id, private key) pair the hub delivers alongside
+// the spoke's primary cluster key so the spoke can authenticate as an App other
+// than its cluster's default. The spoke writes it to a per-app-id key file and
+// selects it when its own configured app_id matches AppID.
+type HeartbeatAppKey struct {
+	// AppID is the numeric GitHub App ID this key signs for. The spoke uses it
+	// both to name the on-disk key file and to decide which key to sign with.
+	AppID int64 `json:"app_id"`
+	// PrivateKey is the PEM private key VALUE for AppID. Secret — TLS-channel
+	// only, never logged, written to a 0600 file on the spoke.
+	PrivateKey string `json:"private_key"`
+	// Fingerprint is the NON-SECRET fingerprint of PrivateKey
+	// (config.AppKeyFingerprint). It rides along so the delivery is auditable
+	// from fingerprints alone, without the key ever appearing in a log line.
+	Fingerprint string `json:"fingerprint,omitempty"`
 }
 
 // HeartbeatProjectConfig carries a claimed project's real org/repos/ACMM from

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1194,6 +1194,17 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		resp.GitHubAppConfig = keyCfg
 	}
 
+	// Deliver the fleet's OTHER App keys so a spoke can authenticate as an App
+	// that is NOT its cluster's default — the github.com hive parked on a
+	// GitHub-Enterprise cluster (vllm-d) that inherits only the GHE key and can
+	// never sign for github.com. This runs on EVERY heartbeat, independent of the
+	// branches above: those decide the spoke's PRIMARY (cluster) key; this makes
+	// sure it also carries every other key it is missing. Delivering only the
+	// missing/stale ones (attachMissingAppKeys diffs against what the spoke
+	// reports it holds) keeps it idempotent — once the spoke has them all, nothing
+	// rides the wire.
+	s.attachMissingAppKeys(&resp, &payload)
+
 	s.hubBannersMu.RLock()
 	if banner, ok := s.hubBanners[payload.HiveID]; ok {
 		resp.HubBanner = &HubBanner{


### PR DESCRIPTION
## Problem

A **github.com hive that lands on a GitHub-Enterprise-default cluster** (the live vllm-d case) cannot authenticate to github.com.

Every spoke gets exactly **one** App private key, tied to its **cluster**. The hub stores keys per-cluster at `/data/saas/app-keys/<clusterID>.pem`, and pushes that cluster's key to all its spokes. So a github.com hive on the vllm-d cluster inherits the GHE App key (app id `5686`) and holds **no github.com App key** (app id `3568013`) at all. Every github.com repo call dies with a "github auth token error" — the hive can never sign a JWT for the App it is really pinned to.

## Fix

**Every spoke now carries BOTH App keys, and selects the one matching its configured `app_id` — not its cluster.**

### Hub (`pkg/hub/cluster_app_key.go`, `server.go`, `heartbeat.go`)
- `appKeysByAppID()` re-indexes the **existing** per-cluster key store by `app_id`. No second on-disk store, no migration: every key already on disk simply becomes discoverable by the App it belongs to. Two clusters sharing an app_id de-duplicate deterministically.
- `additionalAppKeysForSpoke(primaryAppID)` returns every fleet key **except** the spoke's primary (cluster) key.
- `attachMissingAppKeys()` rides those on the heartbeat response's new `HeartbeatGitHubAppConfig.AdditionalKeys` field. Delivered **idempotently** — diffed against the per-app-id fingerprints the spoke reports it holds (`GitHubAppKeysHeld`) — and never duplicating the primary key attached the same beat. Runs on every heartbeat, independent of the existing per-cluster key reconcile.

### Spoke (`cmd/hive/main.go`)
- Additional keys land in distinct `/data/gh-app-key-<appid>.pem` files (atomic temp-file+rename, `0600`), leaving the existing `/data/gh-app-key.pem` and `/secrets/gh-app-key.pem` paths untouched.
- `resolveAppKeyFile` now prefers the **per-app-id file matching `cfg.GitHub.AppID`**, positioned below an explicit `key_file`/`GH_APP_KEY_FILE` override and above the generic PVC/provisioning fallbacks.
- The spoke reports held per-app-id fingerprints so the hub stops re-sending once a key is in place. When a delivered additional key matches the hive's own app_id, the client is rebuilt immediately (same path as a primary-key rotation).

## Back-compat & safety
- **Purely additive.** A single-key hive receives no additional keys, writes no new files, and resolves its key exactly as before. Older spokes ignore the new field entirely.
- No key material is **ever logged** (fingerprints only). Keys stay out of `clusters.json` and out of every HTTP response, preserving the existing security posture. Atomic writes; restrictive `0600` modes.

## Tests
- **Hub** (`pkg/hub/both_app_keys_test.go`): app-id indexing + de-dup, additional-keys selection, end-to-end delivery for the github.com-hive-on-GHE-cluster case, idempotence, stale-fingerprint correction, no-primary-duplication, empty-fleet no-op.
- **Spoke** (`cmd/hive/appkeyfile_test.go`): per-app-id key preferred over the generic key; a different app_id still gets the generic key; empty per-app file does not shadow a good key; explicit `key_file` still wins; atomic write + `0600` + held-fingerprint reporting.

`go build ./...` clean; `go vet` clean; `cmd/hive`, `pkg/config`, and the new `pkg/hub` tests green. (Two unrelated `pkg/hub` tests — `TestHandleHubSelfUpgrade_Edge`, `TestLoadAppPrivateKeyKubectlFails` — fail identically on the clean base branch because they depend on `kubectl`/`gh` being absent from PATH; not touched by this change.)

## Reviewer notes / risks
- The hub treats each cluster's stored key as authoritative for that cluster's app_id. If two clusters legitimately register **different** keys under the **same** app_id, the sorted-cluster-ID first-usable-key wins — acceptable because they are the same App, but worth an operator's awareness.
- Delivery is gated on the spoke reporting `GitHubAppKeysHeld`; an older spoke that never reports it will receive the additional keys every beat (still written idempotently, no harm) until it upgrades.