### PR TITLE
🐛 fix(app-keys): honour a hive's public-github.com pin in the app-key reconcile

### DIFF
--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -431,6 +431,17 @@ const (
 	// is pinned to an App other than the cluster's, so its key is presumed
 	// correct for that App and the cluster key would break it.
 	appKeyReasonDifferentApp = "hive is deliberately pinned to a different app_id"
+	// appKeyReasonPublicHiveOnGHECluster is the class fix for a github.com hive
+	// parked on a GitHub-Enterprise-default cluster (vllm-d). The hive's meta
+	// pins it to public github.com (github_base_url:"public" / "https://github.com")
+	// even though its cluster's default App is the GHE App. Pushing the cluster's
+	// GHE key as the hive's PRIMARY every beat overwrites its github.com app_id and
+	// breaks github.com auth. The hive is github.com: its own public App is
+	// primary, and the cluster GHE key rides only as an ADDITIONAL key
+	// (attachMissingAppKeys) so a future migration onto the GHE App already has the
+	// key on disk. This mirrors resolveProvisionAppID, which likewise honours the
+	// public pin instead of forcing the cluster GHE app_id.
+	appKeyReasonPublicHiveOnGHECluster = "hive is pinned to public github.com on a GHE-default cluster"
 )
 
 // decideAppKeySync decides whether the hub should push its cluster App key to a
@@ -482,9 +493,30 @@ const (
 // that in fact has a good key is harmless — it rewrites the same App identity —
 // whereas withholding leaves a dead hive dead. Once the spoke is new enough to
 // report, the push stops on the following beat.
-func decideAppKeySync(spokeFingerprint string, hasPerHiveKey bool, spokeAppID int64, cluster *clusterAppIdentity) appKeySyncDecision {
+//
+// PUBLIC-PINNED HIVE ON A GHE CLUSTER — never force the cluster GHE app.
+// hivePublicPinned is true when the hive's meta pins it to public github.com
+// (github_base_url:"public" / "https://github.com") while its cluster defaults to
+// a GHE App. The cluster identity resolved above is that GHE App; pushing it as
+// this hive's PRIMARY would overwrite its github.com app_id and break github.com
+// auth on the very next beat. So the reconcile refuses to push the cluster key as
+// primary for such a hive — its own public App stays primary and the cluster GHE
+// key rides only as an ADDITIONAL key (attachMissingAppKeys). This is the app-KEY
+// reconcile finally honouring the same public pin that resolveProvisionAppID and
+// effectiveGitHubBaseURL already honour on the provisioning path.
+func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned bool, spokeAppID int64, cluster *clusterAppIdentity) appKeySyncDecision {
 	if cluster == nil {
 		return appKeySyncDecision{Reason: appKeyReasonNoClusterKey, FromFingerprint: spokeFingerprint}
+	}
+	if hivePublicPinned {
+		// The hive is public github.com on a GHE-default cluster. Never push the
+		// cluster's GHE App as primary; the additional-keys pass still delivers the
+		// GHE key so a later migration onto that App has it on disk.
+		return appKeySyncDecision{
+			Reason:          appKeyReasonPublicHiveOnGHECluster,
+			FromFingerprint: strings.TrimSpace(spokeFingerprint),
+			ToFingerprint:   cluster.Fingerprint,
+		}
 	}
 	fp := strings.TrimSpace(spokeFingerprint)
 	if hasPerHiveKey {
@@ -551,9 +583,9 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey bool, spokeAppID in
 // installation_id. Zero is passed through as zero — the spoke's callback only
 // rebuilds its client once app_id, installation_id and key file are all present,
 // so a key delivered ahead of an installation ID lands on disk and waits.
-func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFingerprint string, hasPerHiveKey bool, spokeAppID int64, installationID int64, logger *slog.Logger) *HeartbeatGitHubAppConfig {
+func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFingerprint string, hasPerHiveKey, hivePublicPinned bool, spokeAppID int64, installationID int64, logger *slog.Logger) *HeartbeatGitHubAppConfig {
 	identity := s.appIdentityForCluster(clusterID)
-	decision := decideAppKeySync(spokeFingerprint, hasPerHiveKey, spokeAppID, identity)
+	decision := decideAppKeySync(spokeFingerprint, hasPerHiveKey, hivePublicPinned, spokeAppID, identity)
 	if !decision.Push || identity == nil {
 		return nil
 	}
@@ -565,6 +597,7 @@ func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFing
 			"app_id", identity.AppID,
 			"spoke_app_id", spokeAppID,
 			"per_hive_key", hasPerHiveKey,
+			"public_pinned", hivePublicPinned,
 			"reason", decision.Reason,
 			"from_fingerprint", decision.FromFingerprint,
 			"to_fingerprint", decision.ToFingerprint,
@@ -755,16 +788,36 @@ func (s *HubServer) appKeySyncForHeartbeat(payload *HeartbeatPayload) *Heartbeat
 		return nil
 	}
 	clusterID := payload.ClusterID
+	// Load the hive's own meta once: it carries the GitHub-host pin
+	// (github_base_url) that decides whether this hive is public github.com, and
+	// it is also the fallback source for the cluster ID when the spoke did not
+	// report one.
+	sh := loadSaaSHive(payload.HiveID)
 	if clusterID == "" {
 		// The spoke did not report a cluster. Fall back to the hub's own record
 		// for this hive rather than guessing the default cluster: guessing would
 		// aim a GitHub Enterprise key at a public-GitHub hive.
-		if sh := loadSaaSHive(payload.HiveID); sh != nil {
+		if sh != nil {
 			clusterID = sh.ClusterID
 		}
 	}
 	if clusterID == "" {
 		return nil
+	}
+	// Is this hive pinned to public github.com while its cluster defaults to a
+	// GHE App? effectiveGitHubBaseURL honours the hive's github_base_url:"public"
+	// / "https://github.com" sentinel and returns "" for public; the cluster
+	// defaulting to GHE is exactly cluster.GitHubBaseURL != "". When both hold, the
+	// cluster's GHE App must NOT be forced onto this hive as its primary key — the
+	// same public pin resolveProvisionAppID already honours on the provisioning
+	// path. The signal is computed here (where the hive meta and cluster config are
+	// both in hand) and threaded into the decision so decideAppKeySync stays a pure,
+	// table-testable function.
+	hivePublicPinned := false
+	if sh != nil {
+		if c, ok := s.clusters[clusterID]; ok {
+			hivePublicPinned = effectiveGitHubBaseURL(sh, &c) == "" && c.GitHubBaseURL != ""
+		}
 	}
 	// The hub does not track installation IDs, and this reconcile is about the
 	// KEY. Sending 0 tells the spoke to leave its (already correct) installation
@@ -775,6 +828,7 @@ func (s *HubServer) appKeySyncForHeartbeat(payload *HeartbeatPayload) *Heartbeat
 		clusterID,
 		payload.GitHubAppKeyFingerprint,
 		payload.GitHubAppKeyPerHive,
+		hivePublicPinned,
 		payload.GitHubAppID,
 		installationIDUnchanged,
 		s.logger,

--- a/v2/pkg/hub/cluster_app_key_test.go
+++ b/v2/pkg/hub/cluster_app_key_test.go
@@ -67,16 +67,17 @@ func TestDecideAppKeySync(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		spokeFP     string
-		perHive     bool
-		spokeAppID  int64
-		cluster     *clusterAppIdentity
-		wantPush    bool
-		wantReason  string
-		wantFromFP  string
-		wantToFP    string
-		description string
+		name         string
+		spokeFP      string
+		perHive      bool
+		publicPinned bool
+		spokeAppID   int64
+		cluster      *clusterAppIdentity
+		wantPush     bool
+		wantReason   string
+		wantFromFP   string
+		wantToFP     string
+		description  string
 	}{
 		{
 			name:        "fingerprint matches - no push",
@@ -227,11 +228,36 @@ func TestDecideAppKeySync(t *testing.T) {
 			wantToFP:    clusterFP,
 			description: "reporting app_id must not change the pre-existing non-per-hive path",
 		},
+
+		// --- THE CLASS FIX: a public github.com hive parked on a GHE cluster ---
+		{
+			name:         "public-pinned hive on GHE cluster - never push the cluster GHE key as primary",
+			spokeFP:      "",
+			publicPinned: true,
+			spokeAppID:   3568013, // the hive's own public github.com App
+			cluster:      identity,
+			wantPush:     false,
+			wantReason:   appKeyReasonPublicHiveOnGHECluster,
+			wantToFP:     clusterFP,
+			description:  "kalantar/vllmd-10 etc: github.com hive on vllm-d — its github.com App stays primary, the GHE key rides only as additional",
+		},
+		{
+			name:         "public-pinned hive with the wrong/empty key is still not forced onto the GHE app",
+			spokeFP:      wrongFP,
+			publicPinned: true,
+			spokeAppID:   3568013,
+			cluster:      identity,
+			wantPush:     false,
+			wantReason:   appKeyReasonPublicHiveOnGHECluster,
+			wantFromFP:   wrongFP,
+			wantToFP:     clusterFP,
+			description:  "the public pin wins even before any per-hive/mismatch reasoning: the cluster GHE app is never this hive's primary",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := decideAppKeySync(tc.spokeFP, tc.perHive, tc.spokeAppID, tc.cluster)
+			got := decideAppKeySync(tc.spokeFP, tc.perHive, tc.publicPinned, tc.spokeAppID, tc.cluster)
 			if got.Push != tc.wantPush {
 				t.Errorf("Push = %v, want %v (%s)", got.Push, tc.wantPush, tc.description)
 			}
@@ -266,7 +292,7 @@ func TestDecideAppKeySyncIsIdempotent(t *testing.T) {
 	identity := &clusterAppIdentity{AppID: 5686, PrivateKey: keyPEM, Fingerprint: fp}
 
 	// Beat 1: spoke has nothing → push.
-	first := decideAppKeySync("", false, 0, identity)
+	first := decideAppKeySync("", false, false, 0, identity)
 	if !first.Push {
 		t.Fatal("first beat should push to a spoke with no key")
 	}
@@ -278,7 +304,7 @@ func TestDecideAppKeySyncIsIdempotent(t *testing.T) {
 	}
 	// Beat 2: spoke now reports the delivered key → no push, forever after.
 	for beat := 2; beat <= 5; beat++ {
-		d := decideAppKeySync(delivered, false, 0, identity)
+		d := decideAppKeySync(delivered, false, false, 0, identity)
 		if d.Push {
 			t.Fatalf("beat %d re-pushed a key the spoke already holds", beat)
 		}
@@ -554,6 +580,91 @@ func TestAppKeySyncForHeartbeatNilServer(t *testing.T) {
 	}
 }
 
+// TestAppKeySyncForHeartbeatPublicPinnedHive is the end-to-end class fix: a
+// github.com hive (github_base_url:"public") parked on the vllm-d GHE cluster
+// must NEVER be handed the cluster's GHE App (5686) as its primary key, while a
+// genuine GHE hive on the same cluster still is. The public hive's GHE key rides
+// only as an additional key via attachMissingAppKeys — asserted separately in
+// both_app_keys_test.go.
+func TestAppKeySyncForHeartbeatPublicPinnedHive(t *testing.T) {
+	withTempAppKeyDir(t)
+	oldHives := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = oldHives })
+
+	keyPEM := testAppKeyPEM(t)
+	if err := storeClusterAppKey("vllm-d", keyPEM); err != nil {
+		t.Fatal(err)
+	}
+
+	// vllm-d defaults to a GHE App: GitHubBaseURL is a GHE host, app_id 5686.
+	s := &HubServer{
+		logger: appKeyTestLogger(),
+		clusters: map[string]ClusterConfig{
+			"vllm-d": {
+				ID:            "vllm-d",
+				GitHubAppID:   5686,
+				GitHubAppSlug: "ibm-hive",
+				GitHubBaseURL: "https://github.ibm.com",
+			},
+		},
+	}
+
+	// A github.com hive pinned public, parked on the GHE cluster (kalantar's case).
+	if err := saveSaaSHive(&SaaSHive{
+		ID:            "kalantar-vllmd-10",
+		ClusterID:     "vllm-d",
+		GitHubBaseURL: githubHostPublic,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// A genuine GHE hive on the same cluster: no public pin, inherits the default.
+	if err := saveSaaSHive(&SaaSHive{
+		ID:        "genuine-ghe-hive",
+		ClusterID: "vllm-d",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("public-pinned hive is NOT forced onto the cluster GHE app", func(t *testing.T) {
+		// Reports no key and app_id 3568013 (its own github.com App) — the exact
+		// state that previously got 5686 pushed as primary every beat.
+		got := s.appKeySyncForHeartbeat(&HeartbeatPayload{
+			HiveID:      "kalantar-vllmd-10",
+			ClusterID:   "vllm-d",
+			GitHubAppID: 3568013,
+		})
+		if got != nil {
+			t.Fatalf("public-pinned hive got a primary key config (app_id %d); the cluster GHE app must never be forced as primary", got.AppID)
+		}
+	})
+
+	t.Run("genuine GHE hive on the same cluster still gets the GHE key", func(t *testing.T) {
+		got := s.appKeySyncForHeartbeat(&HeartbeatPayload{
+			HiveID:    "genuine-ghe-hive",
+			ClusterID: "vllm-d",
+		})
+		if got == nil {
+			t.Fatal("a genuine GHE hive with no key must still receive the cluster GHE key")
+		}
+		if got.AppID != 5686 {
+			t.Errorf("GHE hive primary app_id = %d, want 5686", got.AppID)
+		}
+	})
+
+	t.Run("public pin honoured even when the spoke does not report a cluster", func(t *testing.T) {
+		// Cluster ID falls back to the hive's own meta record; the public pin must
+		// still be read from that same record.
+		got := s.appKeySyncForHeartbeat(&HeartbeatPayload{
+			HiveID:      "kalantar-vllmd-10",
+			GitHubAppID: 3568013,
+		})
+		if got != nil {
+			t.Fatalf("public-pinned hive (cluster from meta) got app_id %d as primary, want none", got.AppID)
+		}
+	})
+}
+
 // --- The key must never leave the hub through an API ---
 
 // TestClusterKeyNeverSerializedIntoAPIPayload is the standing guarantee that a
@@ -611,7 +722,7 @@ func TestClusterKeyNeverSerializedIntoAPIPayload(t *testing.T) {
 			Fingerprint: identity.Fingerprint,
 		},
 		// The decision record that feeds every log line.
-		"appKeySyncDecision": decideAppKeySync("sha256:00000000000000000000000000000000", false, 0, identity),
+		"appKeySyncDecision": decideAppKeySync("sha256:00000000000000000000000000000000", false, false, 0, identity),
 	}
 
 	for name, payload := range payloads {


### PR DESCRIPTION
## The bug

The per-cluster GitHub-App **key** reconcile in `pkg/hub/cluster_app_key.go` (`decideAppKeySync` / `appKeyConfigForHeartbeat` / `appKeySyncForHeartbeat`) decided which App to push to a spoke **purely** from what the spoke reported (per-hive-key flag, spoke app_id, key fingerprint) plus `payload.ClusterID` → the cluster's App. It **never** consulted the hive's `github_base_url:"public"` pin — the marker that says *"this hive is public github.com even though its cluster defaults to GHE."*

Consequence: a github.com-repo hive parked on the GHE-default `vllm-d` cluster (app_id **5686**) that reports `per_hive_key:false` got `HeartbeatGitHubAppConfig{AppID:5686}` pushed as its **primary** every heartbeat. The spoke callback (`cmd/hive/main.go`, `cfg.GitHub.AppID = ghCfg.AppID`) then overwrote its app_id → 5686, breaking github.com auth (`401 A JSON web token could not be decoded`).

The provisioning path already gets this right: `resolveProvisionAppID` + `effectiveGitHubBaseURL` honour the public pin (return `""` → the hive's own app_id, not the cluster GHE app). The app-**key** reconcile had no equivalent check. **That inconsistency is the bug.**

## The fix

`appKeySyncForHeartbeat` now computes whether the hive is pinned to public github.com **on a GHE-default cluster** — reusing the existing helper:

```go
hivePublicPinned = effectiveGitHubBaseURL(sh, &c) == "" && c.GitHubBaseURL != ""
```

and threads that signal into `decideAppKeySync`. When set, the reconcile **refuses to push the cluster's GHE App as primary**. The hive's own public App stays primary and the cluster GHE key rides only as an **additional** key via the already-merged #2271 mechanism (`appKeysByAppID` / `additionalAppKeysForSpoke` / `attachMissingAppKeys`) — so a later migration onto the GHE App already has the key on disk.

`decideAppKeySync` stays a pure, table-testable function: the public-pin signal is computed once in the caller (where both the hive meta and cluster config are in hand) and passed in. New log field `public_pinned` and a new reason constant `appKeyReasonPublicHiveOnGHECluster`.

### Outcome for a public-pinned hive on vllm-d
Hub emits `delivering additional github app keys ... primary_app_id:3568013, delivered:"5686=..."` (the GHE key as additional), **not** `pushing cluster github app key ... app_id:5686`. Exactly what already-working hives get. A **genuine** GHE hive on the same cluster still gets 5686 as its primary — unchanged.

## Decision point changed
`pkg/hub/cluster_app_key.go` — `decideAppKeySync` gains a `hivePublicPinned bool` parameter and an early guard: when true it returns a **no-push** decision (`appKeyReasonPublicHiveOnGHECluster`) before any cluster-key-as-primary reasoning. The signal is produced in `appKeySyncForHeartbeat` from `effectiveGitHubBaseURL(hive, cluster) == "" && cluster.GitHubBaseURL != ""`, plumbed through `appKeyConfigForHeartbeat`.

## Class fix
`kalantar/vllmd-10` was hand-fixed; `enricom8/vllmd-03` and `jmesmarston/vllmd-08` are being hand-fixed in parallel. This makes the correction **automatic** for every public-pinned hive on a GHE-default cluster.

## Tests
- `TestDecideAppKeySync`: two new cases — a public-pinned hive (empty key, and a wrong key) on the GHE cluster resolves to **no-push** with the new reason; all existing cases (including the GHE per-hive-unusable PUSH path) unchanged.
- `TestAppKeySyncForHeartbeatPublicPinnedHive` (new, end-to-end via `loadSaaSHive`): public-pinned hive gets **no** primary config (app_id 5686 never forced); a genuine GHE hive on the same cluster still gets 5686; the pin is honoured even when the spoke omits `cluster_id` (cluster resolved from hive meta).

`go build ./...` clean; `go test ./pkg/hub/` green for all app-key tests. (One unrelated pre-existing failure, `TestLoadAppPrivateKeyKubectlFails`, fails identically on the clean base — it depends on `kubectl` being absent.)

Builds on top of #2270 (cluster_id preservation) and #2271 (both-keys, 5c6eac07), both already on `v2`.
