### PR TITLE
🐛 fix(clanker): unblock the bob contributor relay round-trip

### DIFF
--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -147,6 +147,15 @@ mkdir -p /var/run/hive-metrics 2>/dev/null || true
 
 # Configure git credentials so push works (fork + PR model).
 # GH_TOKEN is the contributor's personal token — enough to fork and push.
+#
+# It is expanded with a ":-" default because this script runs under `set -u`:
+# an unset GH_TOKEN would otherwise abort the entrypoint here with
+# "GH_TOKEN: unbound variable", before the CLI or the relay ever start.
+# An absent token is a normal, supported state — `just contribute-run` passes
+# -e GH_TOKEN="${GH_TOKEN}" and sets it to "" whenever `gh auth token` fails,
+# and the hub also injects a per-task token over the WebSocket at dispatch
+# time (task_assign.github_token -> injectGhToken). Only git push needs this
+# helper, so an empty value must degrade rather than kill the container.
 CRED_HELPER="${HOME}/.git-credential-hive"
 cat > "$CRED_HELPER" <<CRED
 #!/bin/sh
@@ -156,7 +165,7 @@ case "\$1" in
     echo "protocol=https"
     echo "host=github.com"
     echo "username=x-access-token"
-    echo "password=${GH_TOKEN}"
+    echo "password=${GH_TOKEN:-}"
     ;;
 esac
 CRED

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -312,6 +312,17 @@ function bobIsRunning() {
   }
 }
 
+// Relaunch the backend CLI in the tmux session using the flags from
+// backends.conf, the same way contributor-agent.sh first launched it.
+function relaunchCLI() {
+  const confPaths = ['/usr/local/etc/hive/backends.conf', path.join(process.cwd(), 'config/backends.conf')];
+  const confPath = confPaths.find(p => fs.existsSync(p)) || confPaths[0];
+  const CMD = execSync(`bash -c 'source ${confPath} 2>/dev/null; backend_binary ${BACKEND}'`, { encoding: 'utf8', timeout: 15000 }).trim() || BACKEND;
+  const PERM = execSync(`bash -c 'source ${confPath} 2>/dev/null; backend_perm_flag ${BACKEND}'`, { encoding: 'utf8', timeout: 15000 }).trim();
+  execSync(`tmux send-keys -t ${TMUX_SESSION} '${CMD} ${PERM}' Enter`, { timeout: 15000 });
+  return `${CMD} ${PERM}`;
+}
+
 function checkTmuxIdle() {
   try {
     const output = execSync(
@@ -450,7 +461,13 @@ function startProgressReporting() {
         }
       } catch (_) { procs = BACKEND; }
       const cliAlive = procs.includes(BACKEND) || procs.includes('claude') || procs.includes('copilot') || procs.includes('bob') || procs.includes('codex') || procs.includes('goose') || procs.includes('pi');
-      if (!cliAlive) {
+      // bob is not a persistent REPL: it exits at the end of every turn ("Bob
+      // goes to sleep 💤"). For bob an exited process is the normal completion
+      // signal, not a crash, so it must fall through to the checkTmuxIdle()
+      // path below and be reported as task_complete. Treating it as a death
+      // here reported finished work as task_failed on every single task.
+      const cliExitIsNormal = BACKEND === 'bob';
+      if (!cliAlive && !cliExitIsNormal) {
         console.error(`CLI process (${BACKEND}) died — restarting and reporting task as failed`);
         try {
           const confPaths = ['/usr/local/etc/hive/backends.conf', path.join(process.cwd(), 'config/backends.conf')];
@@ -474,6 +491,21 @@ function startProgressReporting() {
     if (idle) {
       console.log(`Task ${currentTask.task_id} completed — agent idle`);
       send({ type: 'task_complete', seq: nextSeq(), task_id: currentTask.task_id, result: 'completed', summary: 'Agent returned to idle', tmux_output: tmuxLines });
+      // bob exits after each turn, so the pane is now a bare shell. Bring it
+      // back up before the next task, or the prompt would be typed into bash
+      // ("-bash: <prompt>: command not found") and silently lost.
+      if (BACKEND === 'bob' && !bobIsRunning()) {
+        try {
+          console.log(`Relaunching bob for the next task: ${relaunchCLI()}`);
+          cliReady = false;
+          waitForCLI().then(() => {
+            cliReady = true;
+            if (pendingTask) { const t = pendingTask; pendingTask = null; tmuxSendKeys(t); }
+          }).catch(e => console.error(e.message));
+        } catch (e) {
+          console.error('Failed to relaunch bob:', e.message);
+        }
+      }
       const completedRepo = currentTask.repo;
       currentTask = null;
       taskAssignedAt = 0;

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -287,6 +287,31 @@ function captureTmuxLines(n) {
   }
 }
 
+// True while a bob CLI process is alive. bob exits at the end of every turn,
+// so "process gone" means the turn finished — see the bob branch of
+// checkTmuxIdle(). Matches the launch command rather than the bare name so a
+// stray "bob" substring elsewhere in the process table cannot mask an exit.
+const BOB_PROCESS_PATTERN = 'bob --accept-license';
+
+function bobIsRunning() {
+  try {
+    let procs;
+    if (fs.existsSync('/proc')) {
+      procs = execSync(
+        `for p in /proc/[0-9]*/cmdline; do tr "\\0" " " < "$p" 2>/dev/null; echo; done`,
+        { encoding: 'utf8', timeout: 15000 }
+      );
+    } else {
+      procs = execSync('ps -eo command 2>/dev/null', { encoding: 'utf8', timeout: 15000 });
+    }
+    return procs.includes(BOB_PROCESS_PATTERN);
+  } catch (_) {
+    // Unknown -> assume still running, so a probe failure cannot fabricate a
+    // completion for a task that is actually still in flight.
+    return true;
+  }
+}
+
 function checkTmuxIdle() {
   try {
     const output = execSync(
@@ -345,16 +370,20 @@ function checkTmuxIdle() {
       // (same convention as the copilot/goose branches above).
       const BOB_IDLE_CHROME = /Enter your prompt, \/ for commands|Auto-approve:|Tokens left:/;
       const BOB_SPINNER = /\(esc to cancel/;
-      // bob exits after finishing a turn ("Bob goes to sleep 💤"), dropping the
-      // pane back to a shell prompt. That is a completed turn, not a hung one,
-      // so treat it as idle rather than waiting for chrome that is now gone.
-      const BOB_EXITED = /goes to sleep/;
-      const lastLines = text.split('\n').slice(-TMUX_TAIL_LINES).join('\n');
-      hasIdlePrompt = BOB_IDLE_CHROME.test(text) || BOB_EXITED.test(text);
+      // bob exits after finishing a turn ("Bob goes to sleep 💤"). Process
+      // liveness is the only reliable completion signal: bob does not repaint
+      // over its last frame on the way out, so a finished pane keeps a frozen
+      // spinner line ("◡ <title> (esc to cancel, 5s)") and the "goes to sleep"
+      // notice often scrolls out of the visible pane entirely. Screen-scraping
+      // alone therefore reports a completed turn as still working. Conversely
+      // the trailing shell prompt cannot stand in for "exited" either — it is
+      // also present mid-turn, left over from before bob was launched.
+      // Once bob has exited its chrome scrolls away, so an exited bob counts
+      // as idle on its own: there is no prompt left to look for.
+      const bobRunning = bobIsRunning();
+      hasIdlePrompt = BOB_IDLE_CHROME.test(text) || !bobRunning;
       hasCompletionMarker = true;
-      // Scope the spinner probe to the tail: a stale spinner line scrolled up
-      // in the backlog would otherwise pin isWorking true forever.
-      isWorking = BOB_SPINNER.test(lastLines) && !BOB_EXITED.test(lastLines);
+      isWorking = bobRunning && BOB_SPINNER.test(text);
     } else if (BACKEND === 'codex') {
       hasIdlePrompt = /codex>|>\s*$/.test(text);
       hasCompletionMarker = /completed|done|finished/i.test(text);

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -322,9 +322,39 @@ function checkTmuxIdle() {
       hasCompletionMarker = true;
       isWorking = /working|running|executing|calling/i.test(text);
     } else if (BACKEND === 'bob') {
-      hasIdlePrompt = /bob>|>\s*$/.test(text);
-      hasCompletionMarker = /completed|done|finished|✓/i.test(text);
-      isWorking = /running|executing|thinking/i.test(text);
+      // Matched against real bobshell 1.0.6 panes. Every part of the previous
+      // classifier was wrong on real output, and each was independently fatal:
+      //
+      //   hasIdlePrompt /bob>|>\s*$/ NEVER matched. bob's idle prompt is drawn
+      //     inside a box ("│ >   Enter your prompt, / for commands, …  │"), so
+      //     the '>' is never at end-of-line and there is no "bob>" anywhere.
+      //     Since idle is ANDed in, task_complete could never fire for bob:
+      //     a finished task stayed "in progress" until the 30-min timeout, and
+      //     the hub then heard task_failed for work bob had actually done.
+      //
+      //   isWorking /running|executing|thinking/i was permanently TRUE. bob
+      //     prints a static banner "You are running Bob Shell in your home
+      //     directory" and echoes its <thinking> block; both stay in the pane
+      //     forever, so this never cleared even on a fully idle bob.
+      //
+      // Instead: reuse the same prompt chrome getCLIState() already verifies
+      // for 'ready', and detect work via bob's live spinner line, which reads
+      // "◡ <task title> (esc to cancel, 5s)" only while a turn is running.
+      // hasCompletionMarker is true because bob has no completion token —
+      // returning to the idle prompt with no spinner IS the completion signal
+      // (same convention as the copilot/goose branches above).
+      const BOB_IDLE_CHROME = /Enter your prompt, \/ for commands|Auto-approve:|Tokens left:/;
+      const BOB_SPINNER = /\(esc to cancel/;
+      // bob exits after finishing a turn ("Bob goes to sleep 💤"), dropping the
+      // pane back to a shell prompt. That is a completed turn, not a hung one,
+      // so treat it as idle rather than waiting for chrome that is now gone.
+      const BOB_EXITED = /goes to sleep/;
+      const lastLines = text.split('\n').slice(-TMUX_TAIL_LINES).join('\n');
+      hasIdlePrompt = BOB_IDLE_CHROME.test(text) || BOB_EXITED.test(text);
+      hasCompletionMarker = true;
+      // Scope the spinner probe to the tail: a stale spinner line scrolled up
+      // in the backlog would otherwise pin isWorking true forever.
+      isWorking = BOB_SPINNER.test(lastLines) && !BOB_EXITED.test(lastLines);
     } else if (BACKEND === 'codex') {
       hasIdlePrompt = /codex>|>\s*$/.test(text);
       hasCompletionMarker = /completed|done|finished/i.test(text);


### PR DESCRIPTION
## What

Four independent, individually-fatal bugs on the ClankeR contributor dispatch path with `AGENT_BACKEND=bob`. Each was found by running a real bob 1.0.6 agent in the contributor image against a local stand-in hub and watching the WebSocket traffic; each one hid behind the previous.

### 1. `contributor-agent.sh` died before starting anything when `GH_TOKEN` was unset

The git credential-helper heredoc expands `${GH_TOKEN}` and the script runs under `set -euo pipefail`, so an unset value aborted the entrypoint with `GH_TOKEN: unbound variable` — no CLI, no relay, no hub connection. Backend-independent.

An absent token is a normal, supported state: `just contribute-run` passes `-e GH_TOKEN="${GH_TOKEN}"` and sets it to `""` whenever `gh auth token` fails, and the hub separately injects a per-task token at dispatch (`task_assign.github_token` → `injectGhToken`). Only `git push` needs the helper, so it now expands with a `:-` default.

### 2. `checkTmuxIdle()`'s bob classifier could never match

- `hasIdlePrompt` `/bob>|>\s*$/` **never matched**. bob draws its prompt inside a box (`│ >   Enter your prompt, / for commands, … │`), so `>` is never at end-of-line and `bob>` appears nowhere. Being ANDed in, this pinned every task "in progress" until the 30-minute timeout.
- `isWorking` `/running|executing|thinking/i` was **permanently true**. bob prints a static banner `You are running Bob Shell in your home directory` and echoes its `<thinking>` block; both persist in the pane forever.

### 3. Screen-scraping alone cannot detect a finished turn

bob does not repaint over its last frame on exit, so a completed pane keeps a frozen spinner (`◡ <title> (esc to cancel, 5s)`), and `Bob goes to sleep 💤` scrolls out of the visible pane — later the prompt chrome scrolls away too. The trailing shell prompt cannot stand in for "exited" either, since it is also present mid-turn, left over from before bob launched.

bob exits at the end of every turn, so process liveness is the unambiguous signal: the spinner is gated on a live bob, and an exited bob counts as idle on its own. A failed process probe returns "running" so it can never fabricate a completion.

### 4. The CLI-liveness probe failed the task on normal completion

With the classifier fixed the round-trip *still* reported `task_failed`. The liveness probe in `startProgressReporting()` runs **before** `checkTmuxIdle()` and calls `failCurrentTask()` as soon as the backend process is gone — which for bob is normal completion. bob is now exempt from that death check, and is relaunched after `task_complete`; without the relaunch the pane is left at a bare shell and the next prompt is typed into bash (`-bash: <prompt>: command not found`) and silently lost — observed directly while testing.

## Verification

Run against the contributor image with a real bob 1.0.6 and a live API key, over the documented WebSocket protocol:

- **Before:** entrypoint died on `GH_TOKEN: unbound variable`. With `GH_TOKEN=""` supplied, bob connected, authenticated, received the task and **wrote the requested file** — but the hub received `task_failed`, never `task_complete`.
- **After**, with `GH_TOKEN` entirely unset:
  ```
  connect -> auth_ok -> task_assign -> bob writes /tmp/ws/relay-proof.txt
  *** TASK_COMPLETE task=ct-test-1 result=completed
  Relaunching bob for the next task: bob --accept-license --auth-method api-key --approval-mode yolo --trust
  CLI ready — accepting tasks
  ```
  `CLANKER_RELAY_OK` confirmed on disk in the container.

The classifier was checked against four real captured panes: mid-work with bob alive (working), live idle with bob alive (complete), and two completed panes after bob exited — one still showing chrome, one scrolled past it — all correct.

Also confirmed while testing, no change needed: the relay **does** send Enter after typing (`tmuxSendEnters`, 3×), a 6,183-char prompt survives the send path (6,218-char command, far under the 128 KB single-arg limit), and `shellQuote` escaping is correct.

## Notes

- Needs porting to `mk`/`dd`/`v3`.
- `go build ./...`, `go vet ./pkg/dashboard/`, `go test ./pkg/dashboard/ -run 'Contribute|WS'` pass; `bash -n` and `node --check` clean. No local `npm run build`/`lint` per repo convention — CI is the gate.
- Hub-side dispatch was exercised against a local stand-in hub implementing the same protocol as `v2/pkg/dashboard/contribute_ws.go`. No production hub state was created or modified.