### PR TITLE
✨ feat(heartbeat): detect stale advisory digests on working hives

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2127,17 +2127,34 @@ func main() {
 			// "genuinely zero agents configured" from "old spoke, unknown".
 			agentsWithModel := agentMgr.CountAgentsWithModel()
 			return &hub.HeartbeatPayload{
-				AgentsWithModel: &agentsWithModel,
-				HiveID:          cfg.HiveID,
-				Org:             cfg.Project.Org,
+				AgentsWithModel:   &agentsWithModel,
+				HiveID:            cfg.HiveID,
+				Org:               cfg.Project.Org,
 				AIAuthor:          cfg.Project.AIAuthor,
 				AIAuthorEffective: cfg.EffectiveAIAuthor(),
 				StartedAt:         processStartedAt.UTC().Format(time.RFC3339),
-				Repos:           cfg.Project.Repos,
-				PrimaryRepo:     cfg.Project.PrimaryRepo,
-				ACMMLevel:       acmmLvl,
-				Agents:          agents,
-				Governor:        hub.GovernorSummary{Mode: string(govState.Mode), Issues: govState.QueueIssues, PRs: govState.QueuePRs},
+				// Advisory-staleness signal (mirrors StartedAt/uptime). Report the
+				// last successful digest-post time only if the spoke has actually
+				// posted one — a zero time is left as an empty string so the hub
+				// reads it as UNKNOWN (not-advisory-mode / old spoke), never a
+				// false stale alarm. The last post error rides alongside so a
+				// working-App-but-failing-post hive can be flagged with its cause.
+				AdvisoryLastPostedAt: func() string {
+					postedAt, _, _ := dashSrv.AdvisoryState()
+					if postedAt.IsZero() {
+						return ""
+					}
+					return postedAt.UTC().Format(time.RFC3339)
+				}(),
+				AdvisoryError: func() string {
+					_, _, errMsg := dashSrv.AdvisoryState()
+					return errMsg
+				}(),
+				Repos:       cfg.Project.Repos,
+				PrimaryRepo: cfg.Project.PrimaryRepo,
+				ACMMLevel:   acmmLvl,
+				Agents:      agents,
+				Governor:    hub.GovernorSummary{Mode: string(govState.Mode), Issues: govState.QueueIssues, PRs: govState.QueuePRs},
 				// Tokens carries the spoke's authoritative cumulative token
 				// total (same store the dashboard token panel and governor
 				// budget read). It flows to the hub's My Hives token column so
@@ -2217,7 +2234,7 @@ func main() {
 				// is the only way to distinguish a hive pinned to an immutable
 				// SHA tag (which can never receive a rolling upgrade) from one
 				// riding <branch>-latest. Empty off-cluster — never guessed.
-				ImageRef:                hub.SelfDeploymentImage(),
+				ImageRef: hub.SelfDeploymentImage(),
 				// The GitHub instance this spoke actually runs against. Only
 				// the spoke knows this for certain: a hive's GitHub can differ
 				// from its cluster's default, so the hub cannot infer it.
@@ -3190,10 +3207,23 @@ func runEvalCycle(
 						// the digest still gets posted. A user-fallback success
 						// does NOT clear the App banner — the App error below is
 						// what decides the banner state.
+						postedViaFallback := false
 						if uc := userGHClient.Load(); uc != nil {
 							if uerr := uc.PostAdvisoryDigest(ctx, primaryRepo, issueNum, md); uerr == nil {
 								logger.Info("posted advisory digest", "repo", primaryRepo, "issue", issueNum, "findings", digest.TotalCount, "via", "user-fallback")
+								postedViaFallback = true
 							}
+						}
+						// Record the outcome for the heartbeat's advisory-staleness
+						// signal. A user-fallback success still counts as a fresh
+						// digest post (the issue DID get updated); otherwise record the
+						// App error so the hub can flag the digest as stale with its
+						// specific cause. err.Error() is the same string logged just
+						// below — log-safe, never key material.
+						if postedViaFallback {
+							dashSrv.RecordAdvisoryPost(digest.TotalCount)
+						} else {
+							dashSrv.RecordAdvisoryError(err.Error())
 						}
 						logger.Warn("failed to post advisory digest via app", "repo", primaryRepo, "issue", issueNum, "error", err)
 						if strings.Contains(err.Error(), "403") && strings.Contains(err.Error(), "Resource not accessible by integration") {
@@ -3230,6 +3260,9 @@ func runEvalCycle(
 						}
 					} else {
 						logger.Info("posted advisory digest", "repo", primaryRepo, "issue", issueNum, "findings", digest.TotalCount, "via", "app")
+						// Record the fresh, successful digest post so the hub's
+						// advisory-staleness gate stays satisfied for this hive.
+						dashSrv.RecordAdvisoryPost(digest.TotalCount)
 						// A successful write proves the app is installed AND has
 						// write access — clear BOTH the perm issue and the
 						// app-required banner flag. Previously only the perm

--- a/v2/pkg/dashboard/advisory_state_test.go
+++ b/v2/pkg/dashboard/advisory_state_test.go
@@ -1,0 +1,73 @@
+package dashboard
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func newAdvisoryTestServer() *Server {
+	return NewServer(0, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+// A fresh server has never posted a digest: the last-posted time is zero and
+// the error is empty, which the heartbeat builder reports as an empty string —
+// UNKNOWN to the hub, never a false stale alarm.
+func TestAdvisoryState_ZeroBeforeAnyPost(t *testing.T) {
+	s := newAdvisoryTestServer()
+	postedAt, findings, errMsg := s.AdvisoryState()
+	if !postedAt.IsZero() {
+		t.Fatalf("expected zero lastPostedAt before any post, got %v", postedAt)
+	}
+	if findings != 0 {
+		t.Fatalf("expected 0 findings before any post, got %d", findings)
+	}
+	if errMsg != "" {
+		t.Fatalf("expected empty error before any post, got %q", errMsg)
+	}
+}
+
+// RecordAdvisoryPost stamps the current time and the finding count, and clears
+// any prior error — a fresh success means the advisory path is healthy again.
+func TestRecordAdvisoryPost_StampsTimeAndFindings(t *testing.T) {
+	s := newAdvisoryTestServer()
+	s.RecordAdvisoryError("boom") // prior failure that a success must clear
+
+	before := time.Now()
+	s.RecordAdvisoryPost(7)
+	after := time.Now()
+
+	postedAt, findings, errMsg := s.AdvisoryState()
+	if postedAt.Before(before) || postedAt.After(after) {
+		t.Fatalf("lastPostedAt %v not within [%v,%v]", postedAt, before, after)
+	}
+	if findings != 7 {
+		t.Fatalf("expected 7 findings, got %d", findings)
+	}
+	if errMsg != "" {
+		t.Fatalf("a successful post must clear the prior error, got %q", errMsg)
+	}
+}
+
+// RecordAdvisoryError records the cause but must NOT advance the last-successful
+// post time — the digest's age has to keep growing so the hub still sees it go
+// stale, while the error names the specific cause.
+func TestRecordAdvisoryError_KeepsLastPostTime(t *testing.T) {
+	s := newAdvisoryTestServer()
+	s.RecordAdvisoryPost(3)
+	postedAt1, _, _ := s.AdvisoryState()
+
+	s.RecordAdvisoryError("403 Resource not accessible by integration")
+
+	postedAt2, findings, errMsg := s.AdvisoryState()
+	if !postedAt2.Equal(postedAt1) {
+		t.Fatalf("error must not move lastPostedAt: was %v, now %v", postedAt1, postedAt2)
+	}
+	if findings != 3 {
+		t.Fatalf("error must not change last findings count, got %d", findings)
+	}
+	if errMsg != "403 Resource not accessible by integration" {
+		t.Fatalf("expected recorded error, got %q", errMsg)
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -95,6 +95,27 @@ type Server struct {
 
 	advisoryMu     sync.RWMutex
 	advisoryDigest any
+	// advisoryLastPostedAt / advisoryLastFindings / advisoryLastError record the
+	// outcome of the most recent advisory-digest post ATTEMPT, so the heartbeat
+	// builder can report it to the hub and a hive whose digest has quietly gone
+	// stale (working App, advisory agents, but the digest stopped updating)
+	// becomes visible in My Hives instead of needing a per-hive log sweep.
+	//
+	// advisoryLastPostedAt stays zero until the spoke SUCCESSFULLY posts a
+	// digest at least once. That zero is what makes "this hive is not in the
+	// advisory-posting business" (pure PR/merge mode, no advisory agents — it
+	// never reaches the post path) indistinguishable on the wire from "old
+	// spoke": both report an empty timestamp, which the hub must read as UNKNOWN
+	// and never as a stale alarm. Only a hive that HAS posted at least once, and
+	// then stopped, can trip the hub's staleness gate.
+	//
+	// advisoryLastError holds the log-safe error string from the most recent
+	// FAILED post attempt (403 issues:write, rate limit, auth failure), or "" on
+	// success. It is set from the same error the spoke already logs, so it never
+	// carries key material.
+	advisoryLastPostedAt time.Time
+	advisoryLastFindings int
+	advisoryLastError    string
 
 	deviceFlowMu    sync.Mutex
 	deviceFlowState *github.DeviceFlowState
@@ -1940,6 +1961,41 @@ func (s *Server) GetAdvisoryDigest() any {
 	s.advisoryMu.RLock()
 	defer s.advisoryMu.RUnlock()
 	return s.advisoryDigest
+}
+
+// RecordAdvisoryPost marks that the spoke SUCCESSFULLY posted/updated the
+// advisory digest just now, carrying the finding count that went out. It clears
+// any prior error, since a fresh success means the advisory path is healthy
+// again. Called only from the digest-posting path — a hive with no advisory
+// agents never reaches it, so its advisoryLastPostedAt stays zero and the hub
+// reads it as UNKNOWN (never a false stale alarm).
+func (s *Server) RecordAdvisoryPost(findings int) {
+	s.advisoryMu.Lock()
+	defer s.advisoryMu.Unlock()
+	s.advisoryLastPostedAt = time.Now()
+	s.advisoryLastFindings = findings
+	s.advisoryLastError = ""
+}
+
+// RecordAdvisoryError records that a digest post ATTEMPT failed, with a
+// log-safe error string (the same one the spoke logs — never key material). It
+// does NOT advance advisoryLastPostedAt: the last SUCCESSFUL post time must
+// keep ageing so the hub still sees the digest going stale, while the error
+// gives the operator the specific cause (403 issues:write, rate limit, …).
+func (s *Server) RecordAdvisoryError(errMsg string) {
+	s.advisoryMu.Lock()
+	defer s.advisoryMu.Unlock()
+	s.advisoryLastError = errMsg
+}
+
+// AdvisoryState returns the last successful advisory-post time (zero if the
+// spoke has never posted one), the finding count that went out then, and the
+// most recent post error ("" when the last attempt succeeded). The heartbeat
+// builder reports these so the hub can flag a stale advisory digest.
+func (s *Server) AdvisoryState() (lastPostedAt time.Time, lastFindings int, lastError string) {
+	s.advisoryMu.RLock()
+	defer s.advisoryMu.RUnlock()
+	return s.advisoryLastPostedAt, s.advisoryLastFindings, s.advisoryLastError
 }
 
 // HealthSummary returns a deep-health summary with individual check results for heartbeats.

--- a/v2/pkg/hub/advisory_staleness.go
+++ b/v2/pkg/hub/advisory_staleness.go
@@ -1,0 +1,97 @@
+package hub
+
+import "time"
+
+// advisoryStaleThreshold is how long a hive's advisory digest may go without a
+// successful update before the hub flags it as stale. Advisory digests are
+// posted once per governor eval cycle; even a low-ACMM hive (which evaluates
+// infrequently by design — on the order of every ~10 min) posts far more often
+// than this. 90 minutes is therefore comfortably longer than any realistic
+// posting interval, so the pill only lights up on a digest path that has
+// GENUINELY wedged (a working App that has quietly stopped posting), never on a
+// hive that is merely slow. Kept a named constant with this reasoning so the
+// threshold is not a bare magic number.
+const advisoryStaleThreshold = 90 * time.Minute
+
+// appCanWriteForAdvisory reports whether a hive's GitHub App is in a state that
+// COULD post an advisory digest right now. It is the "app can write" gate on
+// the staleness alarm: a hive that legitimately cannot post — the App is not
+// installed, its installation is minting no tokens, or the operator never
+// delivered its key — must NEVER be flagged stale, because its silence is
+// expected, not a failure.
+//
+// The rule mirrors how the spoke and both dashboards already branch on these
+// signals: a raised GitHubAppRequired banner, a pending install, or any
+// non-"ok" classified app-auth state all mean the App cannot currently write.
+// An empty state is treated as writable-unless-proven-otherwise, since a hive
+// that is genuinely posting digests reports no app error — the digest post is
+// itself the proof it can write, and the AdvisoryLastPostedAt gate handles the
+// rest.
+func appCanWriteForAdvisory(e RegistryEntry) bool {
+	if e.GitHubAppRequired || e.PendingGitHubAppInstall {
+		return false
+	}
+	switch e.GitHubAppState {
+	case "not-installed", "key-missing", "key-invalid",
+		"wrong-installation", "insufficient-permissions":
+		return false
+	default:
+		// "ok", "unknown", or empty (spoke too old to classify) — the App is
+		// not KNOWN to be broken, so writability is not the thing blocking a
+		// stale flag here.
+		return true
+	}
+}
+
+// advisoryStale reports whether a hive's advisory digest should be flagged as
+// stale as of now, together with a short human-readable reason for the pill's
+// tooltip. It is THE discriminator between "genuinely broken" (the signal an
+// operator wants) and "expected quiet" (which must never alarm), and every gate
+// below is required — the alarm fires only when ALL of them hold:
+//
+//  1. The hive is actually IN the advisory-posting business. The spoke reports
+//     AdvisoryLastPostedAt only after it has successfully posted at least once,
+//     and AdvisoryError only from a real post attempt — so a pure PR/merge-mode
+//     hive (no advisory agents, never reaches the post path) reports NEITHER and
+//     is skipped here. This is why the gate needs no separate "is advisory mode"
+//     flag from the hub: participation is proven by the spoke having reported
+//     one of these fields at all.
+//  2. The hive's App can WRITE (appCanWriteForAdvisory). A not-installed hive,
+//     one running without credentials, or one whose key was never delivered
+//     legitimately cannot post and must not alarm.
+//  3. Either the last successful post is older than advisoryStaleThreshold, OR
+//     the most recent post attempt errored (AdvisoryError set).
+//
+// An empty/unparseable AdvisoryLastPostedAt with no AdvisoryError is UNKNOWN and
+// returns false — never a false alarm — matching the rule the codebase already
+// applies to StartedAt and GitHubAPIURL.
+func advisoryStale(e RegistryEntry, now time.Time) (stale bool, reason string) {
+	// Gate 1: the hive must participate in advisory posting at all. No reported
+	// post time AND no reported error means "not advisory mode / old spoke" —
+	// UNKNOWN, never stale.
+	if e.AdvisoryLastPostedAt == "" && e.AdvisoryError == "" {
+		return false, ""
+	}
+
+	// Gate 2: an App that cannot write is expected to be quiet, not broken.
+	if !appCanWriteForAdvisory(e) {
+		return false, ""
+	}
+
+	// Gate 3a: a failed post attempt is a stale signal on its own, and the most
+	// specific one — surface the reported cause.
+	if e.AdvisoryError != "" {
+		return true, "last advisory post failed: " + e.AdvisoryError
+	}
+
+	// Gate 3b: no error, so decide on age. An unparseable timestamp is treated
+	// as UNKNOWN (not stale) so a malformed spoke value never false-alarms.
+	postedAt, err := time.Parse(time.RFC3339, e.AdvisoryLastPostedAt)
+	if err != nil {
+		return false, ""
+	}
+	if now.Sub(postedAt) > advisoryStaleThreshold {
+		return true, "advisory digest has not updated since " + postedAt.UTC().Format(time.RFC3339)
+	}
+	return false, ""
+}

--- a/v2/pkg/hub/advisory_staleness_test.go
+++ b/v2/pkg/hub/advisory_staleness_test.go
@@ -1,0 +1,175 @@
+package hub
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// baseNow is a fixed reference time so age-based cases are deterministic.
+var advNow = time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+// rfc3339Ago formats a time `d` before advNow, as the spoke would report it.
+func rfc3339Ago(d time.Duration) string {
+	return advNow.Add(-d).UTC().Format(time.RFC3339)
+}
+
+// advisoryModeEntry is a hive that IS in advisory mode (has posted a digest)
+// with an App that can write — the only shape that is ever eligible to be
+// flagged stale. Individual cases override fields to exercise each gate.
+func advisoryModeEntry() RegistryEntry {
+	return RegistryEntry{
+		ID:                   "hosted-adv",
+		AdvisoryLastPostedAt: rfc3339Ago(5 * time.Minute), // fresh by default
+		// App can write: no banner, no pending install, state OK.
+		GitHubAppRequired:       false,
+		PendingGitHubAppInstall: false,
+		GitHubAppState:          "ok",
+	}
+}
+
+func TestAdvisoryStale_FreshDigestNotStale(t *testing.T) {
+	e := advisoryModeEntry() // posted 5 min ago, well within threshold
+	if stale, reason := advisoryStale(e, advNow); stale {
+		t.Fatalf("a freshly-posted digest must not be stale, got reason %q", reason)
+	}
+}
+
+func TestAdvisoryStale_PastThresholdIsStale(t *testing.T) {
+	e := advisoryModeEntry()
+	e.AdvisoryLastPostedAt = rfc3339Ago(advisoryStaleThreshold + time.Minute)
+	stale, reason := advisoryStale(e, advNow)
+	if !stale {
+		t.Fatalf("a digest older than the threshold must be stale")
+	}
+	if reason == "" {
+		t.Fatalf("a stale flag must carry a reason for the tooltip")
+	}
+}
+
+func TestAdvisoryStale_ErrorIsStaleWithCause(t *testing.T) {
+	e := advisoryModeEntry() // fresh timestamp, but the last attempt errored
+	e.AdvisoryError = "403 Resource not accessible by integration"
+	stale, reason := advisoryStale(e, advNow)
+	if !stale {
+		t.Fatalf("a reported post error must flag the digest stale even if the timestamp is fresh")
+	}
+	if reason == "" || reason == "advisory digest has gone stale" {
+		t.Fatalf("the error cause must appear in the reason, got %q", reason)
+	}
+}
+
+// GATE 1 — not in advisory mode: a hive that has never posted a digest and
+// reports no error (pure PR/merge mode, or an old spoke) is UNKNOWN, never stale.
+func TestAdvisoryStale_NotAdvisoryModeNeverStale(t *testing.T) {
+	e := RegistryEntry{
+		ID:                   "hosted-prmode",
+		AdvisoryLastPostedAt: "", // never posted
+		AdvisoryError:        "",
+		GitHubAppState:       "ok", // App is perfectly healthy — irrelevant here
+	}
+	if stale, _ := advisoryStale(e, advNow); stale {
+		t.Fatalf("a hive that never posts advisories must never be flagged stale")
+	}
+}
+
+// GATE 2 — App cannot write: a not-installed hive (or one running without
+// credentials / with an undelivered key / a raised install banner) legitimately
+// cannot post, so an aged timestamp must NOT alarm.
+func TestAdvisoryStale_AppCannotWriteNeverStale(t *testing.T) {
+	old := rfc3339Ago(advisoryStaleThreshold + time.Hour) // very stale timestamp
+
+	cases := []struct {
+		name  string
+		mutfn func(*RegistryEntry)
+	}{
+		{"not-installed state", func(e *RegistryEntry) { e.GitHubAppState = "not-installed" }},
+		{"key-missing state", func(e *RegistryEntry) { e.GitHubAppState = "key-missing" }},
+		{"key-invalid state", func(e *RegistryEntry) { e.GitHubAppState = "key-invalid" }},
+		{"wrong-installation state", func(e *RegistryEntry) { e.GitHubAppState = "wrong-installation" }},
+		{"insufficient-permissions state", func(e *RegistryEntry) { e.GitHubAppState = "insufficient-permissions" }},
+		{"app-required banner raised", func(e *RegistryEntry) { e.GitHubAppRequired = true }},
+		{"pending install", func(e *RegistryEntry) { e.PendingGitHubAppInstall = true }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := advisoryModeEntry()
+			e.AdvisoryLastPostedAt = old
+			tc.mutfn(&e)
+			if stale, reason := advisoryStale(e, advNow); stale {
+				t.Fatalf("app-cannot-write hive must not alarm, got stale=%v reason=%q", stale, reason)
+			}
+		})
+	}
+}
+
+// GATE 2 (error variant) — even a reported post ERROR must not alarm when the
+// App cannot write: the error is the EXPECTED symptom of the missing
+// credential, not a broken digest path.
+func TestAdvisoryStale_AppCannotWriteSuppressesError(t *testing.T) {
+	e := advisoryModeEntry()
+	e.GitHubAppState = "not-installed"
+	e.AdvisoryError = "403 Resource not accessible by integration"
+	if stale, _ := advisoryStale(e, advNow); stale {
+		t.Fatalf("a not-installed hive's post error must not alarm — it is expected")
+	}
+}
+
+// Unknown/empty timestamp with no error is UNKNOWN, never a false alarm — even
+// on an app-can-write hive. (Distinct from gate 1: here a malformed value could
+// arrive; it must be treated the same as absence.)
+func TestAdvisoryStale_UnparseableTimestampNeverStale(t *testing.T) {
+	e := advisoryModeEntry()
+	e.AdvisoryLastPostedAt = "not-a-timestamp"
+	if stale, _ := advisoryStale(e, advNow); stale {
+		t.Fatalf("an unparseable timestamp must be treated as UNKNOWN, not stale")
+	}
+}
+
+// appCanWriteForAdvisory: empty/unknown state on a hive with no banner is
+// writable-unless-proven-otherwise (a genuinely posting hive reports no error).
+func TestAppCanWriteForAdvisory_EmptyStateIsWritable(t *testing.T) {
+	if !appCanWriteForAdvisory(RegistryEntry{GitHubAppState: ""}) {
+		t.Fatalf("empty app state with no banner should be treated as writable")
+	}
+	if !appCanWriteForAdvisory(RegistryEntry{GitHubAppState: "unknown"}) {
+		t.Fatalf("unknown app state with no banner should be treated as writable")
+	}
+}
+
+// TestHeartbeatPayload_CarriesAdvisoryFields proves the new fields survive the
+// JSON round-trip the heartbeat actually uses (spoke marshals, hub unmarshals),
+// and that empty values omit cleanly so an old spoke's payload is unchanged.
+func TestHeartbeatPayload_CarriesAdvisoryFields(t *testing.T) {
+	posted := advNow.Format(time.RFC3339)
+	in := HeartbeatPayload{
+		HiveID:               "hosted-adv",
+		AdvisoryLastPostedAt: posted,
+		AdvisoryError:        "rate limit",
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out HeartbeatPayload
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.AdvisoryLastPostedAt != posted {
+		t.Fatalf("advisory_last_posted_at lost in round-trip: got %q", out.AdvisoryLastPostedAt)
+	}
+	if out.AdvisoryError != "rate limit" {
+		t.Fatalf("advisory_error lost in round-trip: got %q", out.AdvisoryError)
+	}
+
+	// Empty fields must be omitted so an old spoke's wire format is untouched.
+	empty, _ := json.Marshal(HeartbeatPayload{HiveID: "x"})
+	var m map[string]any
+	json.Unmarshal(empty, &m)
+	if _, ok := m["advisory_last_posted_at"]; ok {
+		t.Fatalf("advisory_last_posted_at must be omitted when empty")
+	}
+	if _, ok := m["advisory_error"]; ok {
+		t.Fatalf("advisory_error must be omitted when empty")
+	}
+}

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -235,17 +235,37 @@ type HeartbeatPayload struct {
 	// as an uptime pill so a hive that is quietly crash-looping — 1/1 Running
 	// but restarted 35 times — is visible in My Hives instead of looking
 	// healthy. A short uptime that keeps resetting is the tell.
-	StartedAt    string         `json:"started_at,omitempty"`
-	Health       map[string]any `json:"health"`
-	DashboardURL string         `json:"dashboard_url"`
-	SnapshotURL  string         `json:"snapshot_url"`
-	Owner        string         `json:"owner,omitempty"`
-	HiveType     string         `json:"hive_type,omitempty"`
-	ClusterID    string         `json:"cluster_id,omitempty"`
-	IsPublic     bool           `json:"is_public"`
-	Version      string         `json:"version"`
-	GitHash      string         `json:"git_hash"`
-	GitBranch    string         `json:"git_branch,omitempty"`
+	StartedAt string `json:"started_at,omitempty"`
+	// AdvisoryLastPostedAt is when this spoke last SUCCESSFULLY posted/updated
+	// its advisory-digest issue (RFC3339). It is the mirror of StartedAt for the
+	// advisory path: the hub renders a "stale advisory" pill so a hive that
+	// SHOULD be posting advisory digests but has quietly stopped (working App,
+	// advisory agents, but the digest went stale) becomes visible in My Hives
+	// instead of needing a per-hive log sweep.
+	//
+	// Empty means the spoke has NEVER posted a digest — either it is not in the
+	// advisory-posting business at all (pure PR/merge mode, no advisory agents,
+	// so it never reaches the post path) or it is too old to report this field.
+	// BOTH must be read by the hub as UNKNOWN and NEVER as a stale alarm — the
+	// same rule the codebase already applies to StartedAt/GitHubAPIURL. Only a
+	// hive that HAS posted at least once, and then stopped, can trip staleness.
+	AdvisoryLastPostedAt string `json:"advisory_last_posted_at,omitempty"`
+	// AdvisoryError is the log-safe error string from the spoke's most recent
+	// FAILED advisory-post attempt (403 issues:write, rate limit, auth failure),
+	// or empty when the last attempt succeeded. It is the same string the spoke
+	// already logs, so it never carries key material. Set = the hub flags the
+	// digest as stale (gated on advisory-mode + app-can-write) with this cause.
+	AdvisoryError string         `json:"advisory_error,omitempty"`
+	Health        map[string]any `json:"health"`
+	DashboardURL  string         `json:"dashboard_url"`
+	SnapshotURL   string         `json:"snapshot_url"`
+	Owner         string         `json:"owner,omitempty"`
+	HiveType      string         `json:"hive_type,omitempty"`
+	ClusterID     string         `json:"cluster_id,omitempty"`
+	IsPublic      bool           `json:"is_public"`
+	Version       string         `json:"version"`
+	GitHash       string         `json:"git_hash"`
+	GitBranch     string         `json:"git_branch,omitempty"`
 	// ImageRef is the container image this spoke's own Deployment runs, read
 	// in-cluster from the Deployment spec. GitHash says which commit the
 	// BINARY was built from; ImageRef says which TAG the deployment tracks —

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1516,6 +1516,16 @@ type MyHiveEntry struct {
 	// guards. The full 200-event history stays behind that endpoint and its
 	// modal; this is only the hover preview.
 	RecentEvents []TimelineEvent `json:"recentEvents,omitempty"`
+
+	// AdvisoryStale is true when this hive SHOULD be posting advisory digests
+	// but its digest has quietly gone stale — computed on read by advisoryStale()
+	// so the browser never re-derives the threshold or the gating (advisory-mode
+	// + app-can-write) and cannot drift from the Go rule. AdvisoryStaleReason is
+	// the tooltip cause. Both stay zero/empty for hives that are not in advisory
+	// mode, whose App cannot write, or that report an unknown timestamp — those
+	// must never show the pill.
+	AdvisoryStale       bool   `json:"advisoryStale,omitempty"`
+	AdvisoryStaleReason string `json:"advisoryStaleReason,omitempty"`
 }
 
 // myHivesRecentEventCount is how many timeline events ride the My Hives
@@ -1819,6 +1829,14 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		st := s.journey.get(result[i].ID)
 		status := JourneyStatusFor(&result[i].RegistryEntry, st, journeyNow)
 		result[i].Journey = &status
+
+		// Advisory-staleness pill, computed on read (same as Journey) so the
+		// gating — advisory-mode participation, app-can-write, past-threshold —
+		// lives ONLY in Go and the browser just renders the flag.
+		if stale, reason := advisoryStale(result[i].RegistryEntry, journeyNow); stale {
+			result[i].AdvisoryStale = true
+			result[i].AdvisoryStaleReason = reason
+		}
 
 		// Sparkline history dominated this payload: at 42 hives the two series
 		// were ~755 KB of an 818 KB response (92%), yet they are drawn into a
@@ -6951,6 +6969,24 @@ const dashboardHTML = `<!DOCTYPE html>
         esc(label) + '</span>';
     }
 
+    /* advisoryStaleSummary renders a small "stale advisory" pill next to the
+       failing-check pill when the hub has flagged this hive's advisory digest as
+       stale. The flag (h.advisoryStale) and its reason are computed server-side
+       by advisoryStale() — gated on advisory-mode participation AND app-can-write
+       AND past-threshold — so this renderer never re-derives the rule and a
+       not-installed or PR-mode hive is already filtered out before it gets here.
+       Amber, matching the "worth noticing" band of the uptime pill: a stale
+       digest is an operator nudge, not a hard row failure. */
+    function advisoryStaleSummary(h) {
+      if (!h || !h.advisoryStale) return '';
+      var col = '#d29922';
+      var title = h.advisoryStaleReason || 'Advisory digest has gone stale';
+      return '<span title="' + esc(title) + '" style="display:inline-block;margin-left:6px;padding:0 6px;' +
+        'border-radius:9999px;font-size:0.62rem;font-weight:600;line-height:1.5;cursor:help;white-space:nowrap;' +
+        'color:' + col + ';background:rgba(210,153,34,0.12);border:1px solid rgba(210,153,34,0.35)">' +
+        'stale advisory</span>';
+    }
+
     /* ---- ClankeR, the contributor relay (hover panel) ------------------
        The relay is a first-class SUBSTITUTE for assigning a method/model:
        when humans are picking up this hive's tasks through /contribute, the
@@ -9908,7 +9944,7 @@ const dashboardHTML = `<!DOCTYPE html>
         return '<tr>' +
           bulkCheckboxCell(h, section || 'all') +
           '<td class="hive-menu-cell" style="position:relative;width:30px;text-align:center;overflow:visible">' + (h.migrationStatus === 'migrating' ? '<span style="font-size:1.1rem;color:var(--border);user-select:none;cursor:not-allowed" title="Disabled during migration">⋮</span>' : '<span style="cursor:pointer;font-size:1.1rem;color:var(--muted);user-select:none">⋮</span>' + pendingBadge + '<div class="hive-menu-dropdown" style="display:none;position:absolute;left:0;bottom:auto;background:#1c2128;border:1px solid #30363d;border-radius:8px;min-width:160px;padding:4px 0;z-index:1000;box-shadow:0 8px 24px rgba(0,0,0,0.5)">' + menuItems.join('') + '</div>') + '</td>' +
-          '<td style="text-align:left;line-height:1.4">' + (function() { var isHostedRow = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'))); var dh = isHostedRow && h.id ? ('/api/saas/hives/' + encodeURIComponent(h.id) + '/open') : (rb ? esc(rb) : ''); /* Label derived from the PROJECT (org + primary repo), not by splitting h.name — see hiveLabel. */ var label = hiveLabel(h); var orgName = label.line1; var repoName = label.line2; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var ghIcon = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : ''; var link = function(text, bold) { if (dh) { return '<a href="' + dh + '" target="_blank" class="' + (bold ? 'hive-name-link' : 'hive-sub-link') + '" title="Open dashboard">' + esc(text) + '</a>'; } var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName, true); var fcPill = h.online ? failingCheckSummary(h) : ''; /* Inline access faces sit on the name cell's second line, immediately after this row's own role badge: the badge already answers "what am I on this hive", so the co-members read as the natural continuation of the same thought, in the one cell that is left-aligned and has room to grow. It also keeps them out of the 16 dense metric columns, none of which is about people. Empty string when the viewer is the only member, so those rows are pixel-identical to today. */ var accessFaces = hiveAccessAvatars(h); /* Keyed off repoName, not orgName: line 1 now always carries SOME identity, so the presence of a second line is decided purely by whether there is a repo to put on it. Without a repo the row still shows the GitHub icon, role badge, faces and failing-check pill on the compact variant. */ var line2 = repoName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + '</div>'; var line3 = pendingPill ? '<div style="margin-top:4px;padding-left:18px">' + pendingPill + '</div>' : ''; return line1 + line2 + line3; })() + '</td>' +
+          '<td style="text-align:left;line-height:1.4">' + (function() { var isHostedRow = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'))); var dh = isHostedRow && h.id ? ('/api/saas/hives/' + encodeURIComponent(h.id) + '/open') : (rb ? esc(rb) : ''); /* Label derived from the PROJECT (org + primary repo), not by splitting h.name — see hiveLabel. */ var label = hiveLabel(h); var orgName = label.line1; var repoName = label.line2; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var ghIcon = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : ''; var link = function(text, bold) { if (dh) { return '<a href="' + dh + '" target="_blank" class="' + (bold ? 'hive-name-link' : 'hive-sub-link') + '" title="Open dashboard">' + esc(text) + '</a>'; } var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName, true); var fcPill = h.online ? failingCheckSummary(h) : ''; /* Advisory-staleness pill sits right beside the failing-check pill: both are "something is quietly wrong with this working hive" signals, and advisoryStaleSummary already self-suppresses (empty string) unless the hub flagged the digest stale, so unaffected rows are pixel-identical. */ var advPill = h.online ? advisoryStaleSummary(h) : ''; /* Inline access faces sit on the name cell's second line, immediately after this row's own role badge: the badge already answers "what am I on this hive", so the co-members read as the natural continuation of the same thought, in the one cell that is left-aligned and has room to grow. It also keeps them out of the 16 dense metric columns, none of which is about people. Empty string when the viewer is the only member, so those rows are pixel-identical to today. */ var accessFaces = hiveAccessAvatars(h); /* Keyed off repoName, not orgName: line 1 now always carries SOME identity, so the presence of a second line is decided purely by whether there is a repo to put on it. Without a repo the row still shows the GitHub icon, role badge, faces and failing-check pill on the compact variant. */ var line2 = repoName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + '</div>'; var line3 = pendingPill ? '<div style="margin-top:4px;padding-left:18px">' + pendingPill + '</div>' : ''; return line1 + line2 + line3; })() + '</td>' +
           '<td>' + locationCell + '</td>' +
           '<td style="white-space:nowrap">' + uptimeCell(h) + '</td>' +
           /* No white-space:nowrap on the cell itself: the stacked lines each

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -73,7 +73,18 @@ type RegistryEntry struct {
 	AIAuthorEffective string `json:"aiAuthorEffective,omitempty"`
 	// StartedAt is the spoke process start time, reported over the heartbeat.
 	// Rendered as an uptime pill in My Hives so a crash-looping hive is visible.
-	StartedAt          string         `json:"startedAt,omitempty"`
+	StartedAt string `json:"startedAt,omitempty"`
+	// AdvisoryLastPostedAt is when the spoke last SUCCESSFULLY posted its
+	// advisory digest (RFC3339), reported over the heartbeat. Empty means the
+	// hive has never posted one — not-advisory-mode or an old spoke — which the
+	// staleness gate reads as UNKNOWN, never as an alarm. My Hives renders a
+	// "stale advisory" pill (advisoryStaleSummary) when this ages past
+	// advisoryStaleThreshold on a hive whose App can write.
+	AdvisoryLastPostedAt string `json:"advisoryLastPostedAt,omitempty"`
+	// AdvisoryError is the log-safe error from the spoke's most recent failed
+	// advisory-post attempt ("" on success). When set on an app-can-write hive
+	// it trips the stale pill directly, carrying the specific cause.
+	AdvisoryError      string         `json:"advisoryError,omitempty"`
 	PrimaryRepo        string         `json:"primaryRepo"`
 	DashboardURL       string         `json:"dashboardUrl"`
 	SnapshotURL        string         `json:"snapshotUrl,omitempty"`
@@ -780,9 +791,14 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		AIAuthor:          sanitizeField(payload.AIAuthor),
 		AIAuthorEffective: sanitizeField(payload.AIAuthorEffective),
 		StartedAt:         sanitizeField(payload.StartedAt),
-		DashboardURL:      payload.DashboardURL,
-		SnapshotURL:       payload.SnapshotURL,
-		ACMMLevel:         clampInt(payload.ACMMLevel, 0, 6),
+		// Advisory-staleness signal. Both are sanitized like every other
+		// spoke-reported string; an empty AdvisoryLastPostedAt is preserved as
+		// empty so the render/gate reads it as UNKNOWN rather than stale.
+		AdvisoryLastPostedAt: sanitizeField(payload.AdvisoryLastPostedAt),
+		AdvisoryError:        sanitizeField(payload.AdvisoryError),
+		DashboardURL:         payload.DashboardURL,
+		SnapshotURL:          payload.SnapshotURL,
+		ACMMLevel:            clampInt(payload.ACMMLevel, 0, 6),
 		AgentCount: func() int {
 			count := 0
 			for _, a := range payload.Agents {


### PR DESCRIPTION
## Problem

A hive running in **advisory mode** with a **working GitHub App** is supposed to post a periodic advisory digest to its tracking issue. When that digest quietly stops updating — the App still works, the agents still run, but the digest went stale — **nothing surfaced it**. Finding the affected hives required a manual, per-hive log sweep. Four hives were found stale exactly this way.

This is the same class of "looks healthy, quietly broken" problem the heartbeat already solves for crash-loops (the uptime pill: 1/1 Running but restarting). This PR gives the advisory path the same treatment.

## Design (mirrors the crashloop uptime-pill)

- **Spoke records last-advisory state.** On a successful digest post/update the spoke stamps `lastAdvisoryPostedAt` + finding count (`RecordAdvisoryPost`); on a failed post attempt it records the log-safe error (`RecordAdvisoryError`). Stored on the dashboard `Server` (the same place `GitHubAppState` etc. live), read back via `AdvisoryState()`. A hive that never reaches the post path (pure PR/merge mode, no advisory agents) records nothing.
- **Heartbeat carries it.** New typed fields on `HeartbeatPayload`: `AdvisoryLastPostedAt string` (RFC3339, `omitempty`) and `AdvisoryError string` (`omitempty`). Typed rather than folded into the existing `Health map[string]any` — self-documenting, `omitempty`-clean for old spokes, and directly testable, matching the `StartedAt` precedent.
- **Hub flags staleness — GATED.** `advisoryStale(entry, now)` returns stale **only when ALL** of:
  1. the hive **participates in advisory posting** — it reported a post time OR an error (a pure PR/merge-mode hive reports neither and is skipped; no separate "is advisory mode" flag is needed because participation is proven by the spoke reporting the field at all);
  2. the hive's **App can write** (`appCanWriteForAdvisory`) — not `not-installed` / `key-missing` / `key-invalid` / `wrong-installation` / `insufficient-permissions`, no App-required banner, no pending install;
  3. the last post is older than `advisoryStaleThreshold` **OR** the last attempt errored.
- **Surfaced** as a small amber "stale advisory" pill next to the failing-check pill in My Hives, computed server-side (`MyHiveEntry.AdvisoryStale` / `AdvisoryStaleReason`) so the browser never re-derives the gate.

## Gating rationale (the important part)

The gating is the discriminator between **genuinely broken** (the real signal) and **expected quiet** (must never alarm):

- A **not-installed** hive (installation_id 0, "running without credentials") legitimately can't post → no alarm.
- A **PR/merge-mode** hive doesn't post advisories at all → no alarm.
- An **empty/unknown timestamp** (old spoke, or never posted) is treated as **UNKNOWN**, never stale — the same rule the codebase already applies to `StartedAt` / `GitHubAPIURL`.

Without this gating the pill would false-alarm on every not-installed hive.

## Threshold

`advisoryStaleThreshold = 90 * time.Minute` — a named constant with a comment. Advisory digests are posted once per governor eval cycle; even a slow low-ACMM hive (~10 min) posts far more often, so 90 minutes only trips on a genuinely wedged digest path, never on a merely slow hive.

## Tests

- **Spoke:** records the timestamp + findings on a post, clears the prior error on success, and keeps the last-successful time on an error (so the digest keeps ageing while the cause is captured).
- **Heartbeat:** the fields survive the JSON round-trip (spoke marshal → hub unmarshal) and are omitted when empty (old-spoke wire format unchanged).
- **Hub gating:** stale only for advisory-mode + app-can-write + past-threshold (or error); NOT stale for a not-installed / key-missing / pending-install / banner-raised hive, a PR-mode hive (never posted), or an unparseable/empty timestamp. App-cannot-write suppresses even a reported error.

`go build ./...` clean; new tests green. (Pre-existing, unrelated `pkg/hub` / `pkg/dashboard` failures — `TestHandleHubSelfUpgrade_Edge`, `TestLoadAppPrivateKeyKubectlFails`, the device-flow/SSO coverage tests — fail identically on a clean `origin/v2` in this sandbox: they shell out to `kubectl` / require GitHub OAuth creds. This PR does not touch those paths.)
