### PR TITLE
🐛 fix(startup): MarkReady before staggered agent launch (Ready in seconds, not minutes)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2048,32 +2048,65 @@ func main() {
 	dashSrv.AuditLog("system", "hive_restart",
 		fmt.Sprintf("build=%s version=%s; restoring %d paused agent(s)", gitShort, "3.0.0", pausedCount), "")
 
-	const agentLaunchDelaySec = 15
-	agentIndex := 0
-	for name, ac := range cfg.EnabledAgents() {
-		isOnDemand := ac.OnDemand || onDemandFromPack[name]
-		if isOnDemand {
-			logger.Info("skipping on-demand agent at startup", "name", name)
-			continue
-		}
-		if agentIndex > 0 {
-			logger.Info("staggering agent launch", "name", name, "delay_sec", agentLaunchDelaySec)
-			time.Sleep(time.Duration(agentLaunchDelaySec) * time.Second)
-		}
-		logger.Info("audit: starting agent", "name", name, "trigger", "startup")
-		if err := agentMgr.Start(ctx, name); err != nil {
-			logger.Warn("failed to start agent", "name", name, "error", err)
-		} else {
-			// Surface whether a persisted operator pause was honored on this
-			// restart, so the audit log shows pause state survived (or didn't).
-			detail := "trigger=startup"
-			if ac.Paused {
-				detail = "trigger=startup; restored paused (persisted)"
+	// Mark the dashboard READY as soon as the HTTP server can serve requests —
+	// which is NOW: config is loaded, GitHub client/App auth are wired, the
+	// dashboard deps are set, and the listener (go dashSrv.Start() above) is up.
+	// None of /api/*, /sso, /open, /api/livez or /api/health depend on the agent
+	// fleet being up; the frontend already handles agents appearing over time.
+	//
+	// This MUST precede the staggered agent-launch loop below. That loop sleeps
+	// ~15s per agent (× the whole fleet = several minutes) and previously ran
+	// BEFORE MarkReady, so /api/livez returned 503 "starting" for the entire
+	// launch window. The liveness probe (period 30s × failureThreshold 3 ≈ 90s)
+	// then SIGKILLed the container (exit 137) before readiness was ever reached
+	// on cold start, and rolling upgrades left the Service with no Ready endpoint
+	// for minutes → 503s on /open and /sso. Flipping ready here makes the pod
+	// Ready in seconds and moves the fleet spin-up entirely off the critical path.
+	dashSrv.MarkReady()
+
+	// Launch the persistent (non-on-demand) agents in the BACKGROUND so the
+	// staggered start no longer gates pod readiness. The loop honors ctx: on
+	// shutdown the ctx-aware stagger returns immediately instead of leaking a
+	// goroutine parked in a bare time.Sleep.
+	go func() {
+		const agentLaunchDelaySec = 15
+		agentIndex := 0
+		for name, ac := range cfg.EnabledAgents() {
+			isOnDemand := ac.OnDemand || onDemandFromPack[name]
+			if isOnDemand {
+				logger.Info("skipping on-demand agent at startup", "name", name)
+				continue
 			}
-			dashSrv.AuditLog("system", "agent_start", detail, name)
+			if agentIndex > 0 {
+				logger.Info("staggering agent launch", "name", name, "delay_sec", agentLaunchDelaySec)
+				select {
+				case <-time.After(time.Duration(agentLaunchDelaySec) * time.Second):
+				case <-ctx.Done():
+					logger.Info("aborting staggered agent launch: shutting down")
+					return
+				}
+			}
+			// Bail before starting another agent if we are already shutting down,
+			// so a SIGTERM during the launch window doesn't spawn fresh processes.
+			if ctx.Err() != nil {
+				logger.Info("aborting staggered agent launch: shutting down")
+				return
+			}
+			logger.Info("audit: starting agent", "name", name, "trigger", "startup")
+			if err := agentMgr.Start(ctx, name); err != nil {
+				logger.Warn("failed to start agent", "name", name, "error", err)
+			} else {
+				// Surface whether a persisted operator pause was honored on this
+				// restart, so the audit log shows pause state survived (or didn't).
+				detail := "trigger=startup"
+				if ac.Paused {
+					detail = "trigger=startup; restored paused (persisted)"
+				}
+				dashSrv.AuditLog("system", "agent_start", detail, name)
+			}
+			agentIndex++
 		}
-		agentIndex++
-	}
+	}()
 
 	// Start hub heartbeat push if configured (env var or config)
 	hubURL := cfg.Hub.URL
@@ -2727,7 +2760,11 @@ func main() {
 		logger.Info("fast agent status enabled", "interval_seconds", cfg.Dashboard.AgentPollIntervalS)
 	}
 
-	dashSrv.MarkReady()
+	// NOTE: dashSrv.MarkReady() was previously HERE, after the staggered agent
+	// launch and the heartbeat/trajectory/ticker setup. It has been moved to
+	// immediately after the HTTP listener starts (before the agent-launch loop),
+	// so the pod becomes Ready in seconds instead of minutes. See the MarkReady
+	// call and comment above the agent-launch goroutine.
 
 	const cliStartupDelay = 10 * time.Second
 	logger.Info("waiting for CLI startup before first eval", "delay", cliStartupDelay)

--- a/v2/pkg/dashboard/server_health_coverage_test.go
+++ b/v2/pkg/dashboard/server_health_coverage_test.go
@@ -39,6 +39,41 @@ func TestCovHealth_Livez_Ready(t *testing.T) {
 	}
 }
 
+// TestReadinessIsAgentIndependent locks in the startup-ordering fix: the
+// dashboard becomes Ready purely from MarkReady() with its deps wired, WITHOUT
+// any agent having been launched. healthServer wires the API deps (testDeps)
+// but starts zero agents — the exact state that exists right after the HTTP
+// listener comes up and BEFORE the (now-backgrounded) staggered agent-launch
+// loop in cmd/hive/main.go. Both /api/livez and /api/health must flip to 200 as
+// soon as MarkReady() is called, proving the readiness gate does not depend on
+// the agent fleet being up. This is what lets a pod become Ready in seconds
+// instead of waiting out the multi-minute staggered launch.
+func TestReadinessIsAgentIndependent(t *testing.T) {
+	s := healthServer(t) // deps wired, NO agents started
+
+	// Before MarkReady: readiness gate closed → 503 on both probes.
+	for _, path := range []string{"/api/livez", "/api/health"} {
+		rec := httptest.NewRecorder()
+		s.mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("%s before MarkReady: want 503, got %d", path, rec.Code)
+		}
+	}
+
+	// MarkReady with no agents launched — the reorder makes this reachable in
+	// seconds on the real startup path.
+	s.MarkReady()
+
+	// After MarkReady: both probes are 200 despite zero agents running.
+	for _, path := range []string{"/api/livez", "/api/health"} {
+		rec := httptest.NewRecorder()
+		s.mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s after MarkReady (no agents): want 200, got %d", path, rec.Code)
+		}
+	}
+}
+
 func TestCovHealth_HealthDeep_NotReady(t *testing.T) {
 	s := healthServer(t)
 	rec := httptest.NewRecorder()


### PR DESCRIPTION
## The bug

`cmd/hive/main.go` called `dashSrv.MarkReady()` only **after** the staggered agent-launch loop. That loop sleeps ~15s per agent (`agentLaunchDelaySec` × the whole fleet ≈ several minutes). Until `MarkReady`, the readiness gate (`s.ready`) is closed, so `/api/livez` and `/api/health` return **503 "starting"**. The pod therefore stayed **UNREADY for the entire multi-minute agent-launch window**.

Root-caused on live vllm-d hives:

1. **Crashloop.** The liveness probe (period 30s × failureThreshold 3 ≈ 90s) SIGKILLed the container (**exit 137**) before `MarkReady` was ever reached on cold start. (Band-aided today by a manually-added `startupProbe` on some deployments.)
2. **Non-zero-downtime rollouts → 503s.** Deployments use `maxUnavailable=0`/`maxSurge=1` + an RWX PVC (both pods can mount `/data`), which *should* be zero-downtime. But because the new pod took minutes to become Ready, during rapid stacked `v2-latest` republishes the rolls stack and the Service is left with **no Ready endpoint** → users get **503 on `/open` and `/sso`**.

## The fix

The HTTP server serves `/api/*`, `/sso`, `/open`, `/api/livez` and `/api/health` as soon as its deps are wired and the listener is up (`go dashSrv.Start()` → `ListenAndServe`). It does **not** need the agent fleet running to serve any of those.

So:

- **Moved `dashSrv.MarkReady()`** from after the agent loop + heartbeat/trajectory/ticker setup up to **immediately after the HTTP listener starts**, right after the `hive_restart` audit marker — before the agent-launch loop. `MarkReady()` is just a bool flip; nothing on the readiness/health path depends on agents.
- **Moved the staggered agent-launch loop into a background goroutine.** It no longer gates readiness. The stagger is now **ctx-aware** (`select { <-time.After(...); <-ctx.Done() }`) and bails if `ctx.Err() != nil` before starting each agent, so a SIGTERM during the launch window returns immediately instead of leaking a goroutine parked in a bare `time.Sleep` or spawning fresh processes during shutdown.

### Exact reorder

| Before | After |
|---|---|
| `go dashSrv.Start()` (listener up) | `go dashSrv.Start()` (listener up) — unchanged |
| heartbeat / trajectory / ticker setup | `dashSrv.MarkReady()`  ← **moved up here** |
| **staggered agent-launch loop (blocks minutes)** | **agent-launch loop in `go func(){…}()`** (ctx-aware, non-blocking) |
| `dashSrv.MarkReady()` | heartbeat / trajectory / ticker setup (unchanged, non-blocking) |

## Why it's safe

- The listener is already accepting connections (`go dashSrv.Start()`) **before** `MarkReady` — `MarkReady` does not precede the listener.
- Everything the `/api` handlers require (config, GitHub client + App auth, dashboard deps) is wired **before** `go dashSrv.Start()` and is unchanged.
- The heartbeat/trajectory/ticker setup that used to sit before `MarkReady` is fast, non-blocking background-loop setup and is **not** required to serve HTTP — leaving it after `MarkReady` cannot make the server unable to serve.
- Agents still **all** launch (just in the background); the frontend already handles agents appearing over time, so the agent list populating late is cosmetic and never gates liveness.
- The background goroutine honors the same `ctx` and cannot leak or spawn on shutdown.

Deployment probes are intentionally **not** changed here (per-hive live config, not repo manifests). The repo `deploy/k8s/deployment.yaml` already carries a `startupProbe` — it stays as harmless defense-in-depth and now simply passes within seconds.

## Tests

- New `TestReadinessIsAgentIndependent` (`pkg/dashboard/server_health_coverage_test.go`): with deps wired and **zero agents started**, `/api/livez` and `/api/health` are 503 before `MarkReady()` and 200 after — proving the readiness gate does not depend on the agent fleet. Passes.
- `go build ./...` clean.
- `go test ./cmd/hive/` passes. The pre-existing `pkg/dashboard` `TestCovV1_*` / `TestCovDF_GHUserAuth*` failures reproduce on a clean `origin/v2` checkout and are unrelated to this change.
- gofmt-clean on both edited files.