### PR TITLE
🐛 fix(github): stop github_auth health check flapping on a working App

### DIFF
--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -2023,7 +2023,13 @@ func (s *Server) HealthSummary() map[string]any {
 	// 2. GitHub auth
 	if s.deps != nil && s.deps.GHAppAuth != nil {
 		if _, err := s.deps.GHAppAuth.Token(s.deps.Ctx); err != nil {
-			checks = append(checks, check{Name: "github_auth", Status: "fail", Detail: "token error"})
+			// Surface the underlying error, not a bare "token error": this
+			// detail travels to the hub and into the dashboard tooltip, and a
+			// swallowed error string is exactly what left past github_auth flaps
+			// undiagnosable. Token() now serves a still-valid cached token
+			// through a transient mint blip, so reaching here means no usable
+			// token remains — a genuine, sustained auth failure worth showing.
+			checks = append(checks, check{Name: "github_auth", Status: "fail", Detail: "token error: " + err.Error()})
 			fails++
 		} else {
 			checks = append(checks, check{Name: "github_auth", Status: "pass"})

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -120,20 +120,32 @@ func (a *AppAuth) Token(ctx context.Context) (string, error) {
 		return a.cachedToken, nil
 	}
 
-	jwtToken, err := a.generateJWT()
+	// We are inside the tokenRefreshBuffer window (or have no token yet): try to
+	// PROACTIVELY mint a fresh token. A GitHub installation token is minted with
+	// a live network call to CreateInstallationToken, and on GHE-adjacent /
+	// firewalled clusters that call intermittently fails (transient 5xx, TLS
+	// blip, network hiccup). Crucially, a proactive-refresh failure is NOT an
+	// auth failure while the currently-cached token is still valid: the buffer
+	// only exists to refresh EARLY, so a blip here must fall back to the good
+	// cached token rather than surface an error. Erroring here is exactly what
+	// made the dashboard's github_auth health check flap red↔green on a hive
+	// whose App is genuinely working. We only hard-fail once no usable token
+	// remains — i.e. the cache is empty or the cached token has truly expired.
+	newToken, expiry, err := a.mintInstallationToken(ctx)
 	if err != nil {
-		return "", fmt.Errorf("generating JWT: %w", err)
+		if a.cachedToken != "" && time.Now().Before(a.tokenExpiry) {
+			a.logger.Warn("github app token proactive refresh failed; serving still-valid cached token",
+				"expires_at", a.tokenExpiry.Format(time.RFC3339),
+				"installation_id", a.installationID,
+				"error", err,
+			)
+			return a.cachedToken, nil
+		}
+		return "", err
 	}
 
-	jwtClient := gh.NewClient(nil).WithAuthToken(jwtToken)
-	setBaseURL(jwtClient, a.apiURL)
-	installToken, _, err := jwtClient.Apps.CreateInstallationToken(ctx, a.installationID, nil)
-	if err != nil {
-		return "", fmt.Errorf("creating installation token: %w", err)
-	}
-
-	a.cachedToken = installToken.GetToken()
-	a.tokenExpiry = installToken.GetExpiresAt().Time
+	a.cachedToken = newToken
+	a.tokenExpiry = expiry
 	a.logger.Info("github app token refreshed",
 		"expires_at", a.tokenExpiry.Format(time.RFC3339),
 		"installation_id", a.installationID,
@@ -147,6 +159,27 @@ func (a *AppAuth) Token(ctx context.Context) (string, error) {
 	}
 
 	return a.cachedToken, nil
+}
+
+// mintInstallationToken performs the live GitHub call that exchanges an
+// App JWT for an installation token. It is the network step shared by the
+// cache-refresh path in Token(); it does NOT touch the cache or take the
+// mutex (callers already hold a.mu). It is the only failure-prone step in
+// Token(), so isolating it lets Token() distinguish "mint blipped" (fall back
+// to a still-valid cached token) from a genuine expiry.
+func (a *AppAuth) mintInstallationToken(ctx context.Context) (token string, expiry time.Time, err error) {
+	jwtToken, err := a.generateJWT()
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("generating JWT: %w", err)
+	}
+
+	jwtClient := gh.NewClient(nil).WithAuthToken(jwtToken)
+	setBaseURL(jwtClient, a.apiURL)
+	installToken, _, err := jwtClient.Apps.CreateInstallationToken(ctx, a.installationID, nil)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("creating installation token: %w", err)
+	}
+	return installToken.GetToken(), installToken.GetExpiresAt().Time, nil
 }
 
 // ScopedToken creates a short-lived installation token with permissions

--- a/v2/pkg/github/app_token_flap_test.go
+++ b/v2/pkg/github/app_token_flap_test.go
@@ -1,0 +1,170 @@
+package github
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// These tests lock in the fix for the dashboard's github_auth health check
+// flapping red↔green on a hive whose GitHub App is genuinely working.
+//
+// Root cause: Token() serves the cached installation token only while
+// now < tokenExpiry-tokenRefreshBuffer. Once inside the final buffer window it
+// makes a live CreateInstallationToken network call on EVERY call. On
+// GHE-adjacent / firewalled clusters that call intermittently blips (transient
+// 5xx / TLS / network). The old code returned that error even though the
+// cached token was still valid, so the once-per-heartbeat health check flipped
+// github_auth to fail and back — Degraded rabbiting on a working hive.
+//
+// The fix: a proactive-refresh blip falls back to the still-valid cached token.
+// A genuine failure (no cached token, or the cached token has truly expired)
+// must still error so a real outage still shows Degraded.
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// TestToken_TransientMintErrorServesValidCache is the core false-flap case:
+// we are inside the refresh buffer (so Token() attempts a re-mint), the mint
+// blips (500), but the cached token is still valid — Token() must return the
+// cached token, NOT an error.
+func TestToken_TransientMintErrorServesValidCache(t *testing.T) {
+	key, _ := generateTestKey(t)
+
+	// GitHub mint endpoint always fails (simulates a transient blip).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream hiccup", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         quietLogger(),
+		apiURL:         server.URL,
+		cachePath:      t.TempDir() + "/token-cache",
+		cachedToken:    "still-valid-cached-token",
+		// Inside the refresh buffer window (< tokenRefreshBuffer to expiry) but
+		// NOT yet expired: the token is still perfectly usable.
+		tokenExpiry: time.Now().Add(tokenRefreshBuffer / 2),
+	}
+
+	token, err := auth.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token returned error on a transient mint blip while cache is still valid: %v", err)
+	}
+	if token != "still-valid-cached-token" {
+		t.Errorf("token = %q, want still-valid-cached-token (should serve cache through the blip)", token)
+	}
+}
+
+// TestToken_SustainedFailureNoCacheStillErrors proves the fix does not mask a
+// real failure: with no cached token, a failing mint must error.
+func TestToken_SustainedFailureNoCacheStillErrors(t *testing.T) {
+	key, _ := generateTestKey(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "app not installed", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         quietLogger(),
+		apiURL:         server.URL,
+		cachePath:      t.TempDir() + "/token-cache",
+		// No cached token at all.
+	}
+
+	if _, err := auth.Token(context.Background()); err == nil {
+		t.Fatal("expected an error when the App is genuinely broken and there is no cached token")
+	}
+}
+
+// TestToken_ExpiredCacheFailingMintStillErrors proves that once the cached
+// token has TRULY expired, a failing mint still errors — an expired token is
+// not a usable credential, so falling back to it would hide a real outage.
+func TestToken_ExpiredCacheFailingMintStillErrors(t *testing.T) {
+	key, _ := generateTestKey(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream hiccup", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         quietLogger(),
+		apiURL:         server.URL,
+		cachePath:      t.TempDir() + "/token-cache",
+		cachedToken:    "long-expired-token",
+		tokenExpiry:    time.Now().Add(-time.Minute), // already expired
+	}
+
+	if _, err := auth.Token(context.Background()); err == nil {
+		t.Fatal("expected an error when the cached token has expired and the mint keeps failing")
+	}
+}
+
+// TestToken_TransientThenRecoveryDoesNotFlap simulates the live sequence: a
+// heartbeat mints, the next hits a blip (must not error), and the following one
+// recovers with a fresh token. The health check would see pass→pass→pass, never
+// flipping to fail — i.e. no rabbiting on a working hive.
+func TestToken_TransientThenRecoveryDoesNotFlap(t *testing.T) {
+	key, _ := generateTestKey(t)
+
+	var fail atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fail.Load() {
+			http.Error(w, "blip", http.StatusBadGateway)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token":"fresh-token","expires_at":"` +
+			time.Now().Add(time.Hour).Format(time.RFC3339) + `"}`))
+	}))
+	defer server.Close()
+
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         quietLogger(),
+		apiURL:         server.URL,
+		cachePath:      t.TempDir() + "/token-cache",
+		cachedToken:    "boot-token",
+		// Inside the buffer window so every call attempts a re-mint.
+		tokenExpiry: time.Now().Add(tokenRefreshBuffer / 2),
+	}
+
+	// 1) Blip: must serve the still-valid cached token, no error.
+	fail.Store(true)
+	tok, err := auth.Token(context.Background())
+	if err != nil {
+		t.Fatalf("blip poll errored instead of serving cache: %v", err)
+	}
+	if tok != "boot-token" {
+		t.Errorf("blip poll token = %q, want boot-token", tok)
+	}
+
+	// 2) Recovery: mint succeeds, cache advances to the fresh token.
+	fail.Store(false)
+	tok, err = auth.Token(context.Background())
+	if err != nil {
+		t.Fatalf("recovery poll errored: %v", err)
+	}
+	if tok != "fresh-token" {
+		t.Errorf("recovery poll token = %q, want fresh-token", tok)
+	}
+}


### PR DESCRIPTION
## Root cause

The dashboard's `github_auth` health check (`v2/pkg/dashboard/server.go` `HealthSummary()` ~L1968, sent in every heartbeat to the hub) calls `GHAppAuth.Token(ctx)` and hard-fails on **any** error.

`Token()` (`v2/pkg/github/app.go`) serves the cached installation token only while `now < tokenExpiry - tokenRefreshBuffer` (buffer = 20 min). Once inside the final 20-minute window it makes a **live** `CreateInstallationToken` network call on **every** call to proactively refresh. On GHE-adjacent / firewalled clusters (e.g. **vllm-d**) that call intermittently blips (transient 5xx / TLS / network hiccup).

The old code returned that error even though the cached token was **still valid** — so the once-per-heartbeat health check flipped `github_auth` pass→fail→pass and the hub tooltip rabbited between healthy and **Degraded** on a hive whose App is genuinely working (agents commit/push as the App, PRs opened as the App bot, 5h-TTL token minted at boot, `installation_id` correct/stable).

### Live evidence (vllmd-10, kalantar / inference-sim / sim2real)
- Token minted once at boot: `github app token refreshed expires_at=…18:14:47Z installation_id=149933127` — **5-hour TTL**, correct install id (not the docs id 0).
- App demonstrably working during the flap window: `CreatePR: opened PR as the App bot repo=sim2real number=744`, scoped tokens minting, 268M tokens consumed.
- The health detail was a hardcoded `"token error"` — the real `err.Error()` was **swallowed**, which is why the flaps left no log evidence.
- Reproduced the failing path in test: the old behavior returns `creating installation token: POST …/access_tokens: 500` while the cached token is still valid.

## The fix

1. **`Token()` falls back to the still-valid cached token on a proactive-refresh blip.** The buffer window only exists to refresh *early*; a mint failure while the cached token is not yet expired is not an auth failure. We only hard-fail once there is no usable credential — cache empty, or the cached token has truly passed `tokenExpiry`. So a **real** sustained failure (App broken) still shows Degraded; a **transient** blip on a working App no longer flaps. The network mint is factored into `mintInstallationToken()` so `Token()` can cleanly distinguish the two.
2. **Surface the underlying error** in the `github_auth` health detail (`token error: <err>`) so the next real failure is diagnosable instead of a bare string.

## Tests (`v2/pkg/github/app_token_flap_test.go`)
- `TestToken_TransientMintErrorServesValidCache` — mint 500 inside the buffer window with a valid cache → serves cache, no error.
- `TestToken_TransientThenRecoveryDoesNotFlap` — blip then recovery → pass, pass (never flips to fail).
- `TestToken_SustainedFailureNoCacheStillErrors` — no cache + failing mint → still errors (real failure not hidden).
- `TestToken_ExpiredCacheFailingMintStillErrors` — expired cache + failing mint → still errors.

Verified the tests fail against the pre-fix behavior (non-vacuous) and pass with the fix; `-race` clean. Pre-existing `TestCovV1_*` / `TestHandleGHUserAuth*` dashboard failures are unrelated (fail on the base without this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)