### PR TITLE
🐛 fix(hub): use claimed hive's vanity URL everywhere (heartbeat + hub), not the placeholder

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2607,7 +2607,25 @@ func main() {
 			// possible. The hub keeps sending this every beat until we report the
 			// matching project back, so an idempotent no-op when already matched
 			// is expected and cheap.
-			if pc == nil || pc.Org == "" {
+			if pc == nil {
+				return
+			}
+			// A URL-only push (org empty, dashboard_url set) delivers the vanity
+			// dashboard URL to an already-claimed hive whose meta project is stale/
+			// empty on the hub — we must still adopt+report it, or the hub keeps
+			// showing the raw placeholder host forever. Handle it BEFORE the
+			// org-empty bail below, which exists so an empty project never blanks a
+			// working config: with no org there is nothing to reconcile except the
+			// URL, so adopt it, persist, and return without touching the project.
+			if pc.Org == "" {
+				if pc.DashboardURL != "" && cfg.Hub.DashboardURL != pc.DashboardURL {
+					logger.Info("adopting vanity dashboard URL from hub heartbeat (url-only push)",
+						"was", cfg.Hub.DashboardURL, "now", pc.DashboardURL)
+					cfg.Hub.DashboardURL = pc.DashboardURL
+					if err := cfg.Save(); err != nil {
+						logger.Error("failed to save adopted vanity dashboard URL", "error", err)
+					}
+				}
 				return
 			}
 			curACMM := 0

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1592,6 +1592,15 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		if sh.Status == statusAvailable || (entry.ACMMLevel == 0 && sh.ACMMLevel > 0) {
 			entry.ACMMLevel = sh.ACMMLevel
 		}
+		// Show the friendly vanity host for a claimed hive the instant it is
+		// claimed, rather than waiting for the spoke to adopt+report it back over
+		// the heartbeat. Until then entry.DashboardURL (spoke-reported) is still the
+		// raw placeholder host, which is the placeholder-URL-persists bug in My
+		// Hives / the row's Open link. Only overlays a validated meta vanity_url;
+		// an unclaimed placeholder or a hive with no vanity keeps its own URL.
+		if v := claimedVanityURL(sh); v != "" {
+			entry.DashboardURL = v
+		}
 		switch sh.Status {
 		case "provisioning":
 			entry.GovernorMode = "PROVISIONING"
@@ -2193,6 +2202,14 @@ func (s *HubServer) handleOpenHive(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	s.mu.RUnlock()
+	// For a claimed hive, hand the SSO handoff off to its vanity host rather than
+	// the raw placeholder host the spoke may still be reporting — the vanity URL
+	// is the validated, user-facing host (and the one the spoke will settle on).
+	// Only a validated meta vanity_url is used; unclaimed placeholders are left on
+	// their working placeholder host.
+	if v := claimedVanityURL(loadSaaSHive(id)); v != "" {
+		base = v
+	}
 	if base == "" && (strings.HasPrefix(id, "hosted-") || strings.HasPrefix(id, "saas-")) {
 		base = "https://" + id + ".hive.kubestellar.io"
 	}
@@ -5208,6 +5225,28 @@ func (s *HubServer) adoptSpokeProjectConfig(hiveID, org string, repos []string, 
 		"acmm_was", prevLevel, "acmm_now", h.ACMMLevel)
 }
 
+// claimedVanityURL returns the vanity dashboard URL the hub should SHOW and LINK
+// for a hive (My Hives, the SSO /open handoff, config proxy), or "" to fall back
+// to the spoke-reported placeholder host.
+//
+// The rule is deliberately narrow so it never resurrects the 503 bug:
+//   - Unclaimed placeholder (statusAvailable): "" — it has no project yet, so its
+//     placeholder host is the only correct URL. Leave it.
+//   - Claimed hive with a non-empty meta VanityURL: return it. A vanity URL is
+//     only non-empty because it was VALIDATED as servable at provision/assign
+//     time (addVanityHostToIngress succeeded, or a cluster wildcard/OpenShift
+//     route already serves it, e.g. vllm-d's hosted-...apps.fmaas-vllm-d... host).
+//     Trusting it here means the hub shows/links the friendly host the instant a
+//     hive is claimed, instead of waiting for the spoke to adopt+report it back.
+//   - Claimed hive with an empty VanityURL: "" — never mint an unvalidated host
+//     here; the placeholder still works.
+func claimedVanityURL(h *SaaSHive) string {
+	if h == nil || h.Status == statusAvailable {
+		return ""
+	}
+	return h.VanityURL
+}
+
 // curAPIURL is the GitHub API base URL the spoke reports it is CURRENTLY using
 // (HeartbeatPayload.GitHubAPIURL). Empty means the spoke is too old to report
 // it — treated as UNKNOWN, never as a mismatch.
@@ -5234,7 +5273,24 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 	}
 	claimComplete := h.Org != "" && len(h.Repos) > 0 && primary != "" && h.ACMMLevel > 0
 	if !claimComplete {
-		// Incomplete/stale record (a pre-claim hive) — leave the spoke alone.
+		// Incomplete/stale record (a pre-claim hive) — leave the spoke's PROJECT
+		// (org/repos/ACMM) alone; reconciling from a stale record wiped/downgraded
+		// live hives. BUT the vanity URL is independent of project completeness: a
+		// claimed hive can carry a validated meta vanity_url (set at provision,
+		// e.g. vllmd-10's hosted-...apps.fmaas-vllm-d... route) while its meta's
+		// org/repos/ACMM are still stale/empty. Without pushing it, the spoke never
+		// adopts the vanity URL and the hub keeps showing the raw placeholder host
+		// forever (the placeholder-URL-persists bug). Push the URL alone — never
+		// the stale project — until the spoke reports the vanity back.
+		//
+		// Safety: only a NON-EMPTY VanityURL is ever pushed. A vanity URL is only
+		// non-empty because it was validated/served at provision or assign time
+		// (addVanityHostToIngress succeeded, or a cluster wildcard route already
+		// serves it), so this never pushes an unserved host and never reintroduces
+		// the 503.
+		if h.VanityURL != "" && curURL != h.VanityURL {
+			return &HeartbeatProjectConfig{DashboardURL: h.VanityURL}
+		}
 		return nil
 	}
 	// What the hub still PUSHES to the spoke, and until when:
@@ -5536,20 +5592,31 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	if h.VanityURL == "" {
 		if cluster := s.clusterForHive(h); cluster != nil && cluster.Domain != "" {
 			vanityHost := generateHiveID(body.Org, primaryRepo) + "." + cluster.Domain
-			// Only adopt the vanity hostname once the spoke's Ingress actually
-			// serves it. Nothing else creates a route for this host: provisioning
-			// templates a single DashboardHost, so a vanity URL minted here
-			// resolves to no backend and every hub link to it — including the SSO
-			// handoff — returns 503, while the raw placeholder host works fine.
-			// Create the route FIRST, then adopt the URL. VanityURL doubles as
-			// the "placeholder is claimed" marker (projectConfigForHiveID keeps
-			// pushing until the spoke reports it back), so it is always set —
-			// but a failed route is logged at Warn rather than swallowed, since
-			// the symptom is a 503 on every hub link to this hive.
+			// Make the vanity host servable, then adopt it. Nothing else creates a
+			// route for this host: provisioning templates a single DashboardHost, so
+			// a vanity URL minted here resolves to no backend and every hub link to
+			// it — including the SSO handoff — returns 503, while the raw placeholder
+			// host works fine. Create the route FIRST, then adopt the URL.
+			//
+			// VanityURL doubles as the "placeholder is claimed" marker
+			// (projectConfigForHiveID keeps pushing until the spoke reports it
+			// back), so it is always set once we have a domain to derive it from —
+			// but a failed create is logged at Warn rather than swallowed, since the
+			// symptom is a 503 on every hub link to this hive until the route is
+			// reconciled (cert-manager on nginx, or the cluster wildcard on the
+			// heartbeat-only OpenShift pool where the hub cannot kubectl to create
+			// it, so the create "fails" yet the *.apps.<domain> wildcard still
+			// serves the host — the vllm-d case).
 			if err := s.addVanityHostToIngress(hiveID, vanityHost, cluster); err != nil {
-				s.logger.Warn("vanity host is not served: could not add it to the spoke ingress/route — "+
-					"hub links to this hive will 503 until it is added by hand",
-					"hive", hiveID, "host", vanityHost, "error", err)
+				if cluster.IngressType == ingressTypeOpenShiftRoute {
+					s.logger.Info("vanity host: hub could not create a route (heartbeat-only OpenShift cluster) "+
+						"— relying on the cluster wildcard route to serve it",
+						"hive", hiveID, "host", vanityHost, "cluster", cluster.ID, "error", err)
+				} else {
+					s.logger.Warn("vanity host is not served: could not add it to the spoke ingress/route — "+
+						"hub links to this hive will 503 until it is added by hand",
+						"hive", hiveID, "host", vanityHost, "error", err)
+				}
 			}
 			h.VanityURL = "https://" + vanityHost
 		}

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1058,12 +1058,22 @@ func (s *HubServer) migrateHive(h *SaaSHive, fromCluster, toCluster *ClusterConf
 	}
 
 	// Update the registry entry's ClusterID and ClusterName in-memory.
+	// A migration re-provisions the hive under a fresh placeholder Subdomain on
+	// the target cluster, but a CLAIMED hive must keep showing its vanity host —
+	// resetting DashboardURL to the placeholder subdomain here is exactly what
+	// left claimed, migrated hives back on the placeholder URL in the hub. Prefer
+	// the validated meta vanity_url for a claimed hive; only an unclaimed
+	// placeholder falls back to its new placeholder subdomain.
+	migratedURL := "https://" + h.Subdomain
+	if v := claimedVanityURL(h); v != "" {
+		migratedURL = v
+	}
 	s.mu.Lock()
 	for i := range s.registry.Hives {
 		if s.registry.Hives[i].ID == h.ID {
 			s.registry.Hives[i].ClusterID = toCluster.ID
 			s.registry.Hives[i].ClusterName = toCluster.Name
-			s.registry.Hives[i].DashboardURL = "https://" + h.Subdomain
+			s.registry.Hives[i].DashboardURL = migratedURL
 			break
 		}
 	}

--- a/v2/pkg/hub/vanity_url_test.go
+++ b/v2/pkg/hub/vanity_url_test.go
@@ -1,0 +1,125 @@
+package hub
+
+import "testing"
+
+// A claimed hive whose meta carries a validated vanity_url must have that URL
+// pushed to the spoke as DashboardURL — even when its project record is stale/
+// incomplete (the common placeholder-URL-persists case: vanity_url exists in
+// meta but was never delivered because the reconcile bailed on an incomplete
+// claim). The push must be URL-only (no stale org/repos/ACMM).
+func TestVanityURLPushedForClaimedHiveWithStaleProject(t *testing.T) {
+	dir := t.TempDir()
+	oldDir := saasHivesDir
+	saasHivesDir = dir
+	defer func() { saasHivesDir = oldDir }()
+
+	vanity := "https://hosted-zacburns-vllm-abcd.apps.fmaas-vllm-d.fmaas.res.ibm.com"
+	h := &SaaSHive{
+		ID:     "hosted-available-vllmd-10",
+		Status: "running", // claimed (not "available")
+		// Deliberately incomplete/stale project (no ACMM, no primary) — mirrors a
+		// real pre-claim record that still carries a populated vanity_url.
+		VanityURL: vanity,
+	}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+
+	// Spoke still reports the raw placeholder host.
+	pc := projectConfigForHiveID(h.ID, "", nil, "", 0,
+		"https://hosted-available-vllmd-10.apps.fmaas-vllm-d.fmaas.res.ibm.com", "")
+	if pc == nil {
+		t.Fatal("expected a vanity URL push for a claimed hive with a meta vanity_url, got nil")
+	}
+	if pc.DashboardURL != vanity {
+		t.Errorf("expected DashboardURL %q, got %q", vanity, pc.DashboardURL)
+	}
+	// A URL-only push must NOT carry the stale project (that would blank/downgrade
+	// the spoke's working config).
+	if pc.Org != "" || len(pc.Repos) != 0 || pc.PrimaryRepo != "" || pc.ACMMLevel != 0 {
+		t.Errorf("URL-only push must not carry project fields, got %+v", pc)
+	}
+
+	// Once the spoke reports the vanity host back, the reconcile goes quiet.
+	if pc2 := projectConfigForHiveID(h.ID, "", nil, "", 0, vanity, ""); pc2 != nil {
+		t.Errorf("expected nil once the spoke reports the vanity URL, got %+v", pc2)
+	}
+}
+
+// A hive on a heartbeat-only cluster adopts the vanity URL the hub shows/links
+// for it (My Hives, SSO /open) purely from its meta vanity_url, without the hub
+// ever creating an ingress/route — claimedVanityURL is the single source.
+func TestVanityURLAdoptedWithoutHubCreatedIngress(t *testing.T) {
+	vanity := "https://hosted-zacburns-vllm-abcd.apps.fmaas-vllm-d.fmaas.res.ibm.com"
+	h := &SaaSHive{ID: "hosted-vllmd-hb", Status: "running", VanityURL: vanity}
+	if got := claimedVanityURL(h); got != vanity {
+		t.Errorf("claimed heartbeat-only hive should surface its meta vanity_url %q, got %q", vanity, got)
+	}
+}
+
+// An UNASSIGNED placeholder (status "available") keeps its placeholder URL: the
+// hub must neither push a vanity URL nor override its shown DashboardURL.
+func TestUnassignedPlaceholderKeepsPlaceholderURL(t *testing.T) {
+	dir := t.TempDir()
+	oldDir := saasHivesDir
+	saasHivesDir = dir
+	defer func() { saasHivesDir = oldDir }()
+
+	// Even if a stray vanity_url were present, an available placeholder must be
+	// left alone.
+	h := &SaaSHive{
+		ID:        "hosted-available-slot-01",
+		Status:    statusAvailable,
+		VanityURL: "https://should-not-be-used.example.com",
+	}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := claimedVanityURL(h); got != "" {
+		t.Errorf("available placeholder must not surface a vanity URL, got %q", got)
+	}
+	placeholder := "https://hosted-available-slot-01.apps.fmaas-vllm-d.fmaas.res.ibm.com"
+	if pc := projectConfigForHiveID(h.ID, "", nil, "", 0, placeholder, ""); pc != nil {
+		t.Errorf("available placeholder must not be pushed a vanity URL, got %+v", pc)
+	}
+}
+
+// The don't-503-on-unserved-host safety: a claimed hive with NO vanity URL in
+// meta must never have one invented — the hub keeps the placeholder rather than
+// pushing/linking a host that has no backend.
+func TestNoVanityPushWhenUnserved(t *testing.T) {
+	dir := t.TempDir()
+	oldDir := saasHivesDir
+	saasHivesDir = dir
+	defer func() { saasHivesDir = oldDir }()
+
+	h := &SaaSHive{
+		ID:          "hosted-claimed-no-vanity",
+		Status:      "running",
+		Org:         "acme",
+		Repos:       []string{"acme/widget"},
+		PrimaryRepo: "acme/widget",
+		ACMMLevel:   2,
+		// VanityURL deliberately empty: no validated host exists.
+	}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+
+	// claimedVanityURL yields nothing to link/show, so the placeholder stands.
+	if got := claimedVanityURL(h); got != "" {
+		t.Errorf("no meta vanity_url means nothing to surface, got %q", got)
+	}
+	// The reconcile, once the claim is delivered and matched, must be quiet — it
+	// must NOT invent a vanity URL to push.
+	h.ClaimDelivered = true
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+	pc := projectConfigForHiveID(h.ID, "acme", []string{"acme/widget"}, "acme/widget", 2,
+		"https://hosted-claimed-no-vanity.hive.kubestellar.io", "")
+	if pc != nil {
+		t.Errorf("must not invent/push a vanity URL for a hive with none, got %+v", pc)
+	}
+}


### PR DESCRIPTION
## The bug

Some **claimed** hives keep showing the raw **PLACEHOLDER** host in the hub — My Hives, the SSO `/open` handoff, and the row's Open link — instead of the friendly **vanity URL** the hive was claimed with (`https://hosted-<org>-<repo>-*.<domain>`).

The plumbing to push the vanity URL to the spoke and adopt it back already existed, but it had gaps that let the placeholder host persist:

1. **`projectConfigForHiveID` bailed before the URL push.** For a claimed hive whose meta carries a validated `vanity_url` but whose project record (org/repos/ACMM) is stale or incomplete, the function returned `nil` at the `claimComplete` gate *before* it ever reached the vanity-URL push. So the very common case observed on vllm-d — `vanity_url` **is** populated in meta (e.g. `vllmd-10`'s `hosted-…apps.fmaas-vllm-d…` route) but was **never delivered to the spoke** — left the placeholder host in place forever.
2. **The spoke dropped a URL-only push.** The spoke's heartbeat `ProjectConfig` callback returned early on `pc.Org == ""`, so even if the hub sent a URL-only push, the spoke ignored it and never adopted `hub.dashboard_url`.
3. **The hub-side reads showed the spoke-reported placeholder.** My Hives and the SSO `/open` handoff resolve their URL from `RegistryEntry.DashboardURL`, which is whatever the spoke last reported — the placeholder host until the spoke adopts the vanity. Nothing overlaid the known meta vanity_url in the meantime.
4. **Migration reset the URL to the placeholder.** `migrateHive` rewrote the registry `DashboardURL` to `https://<new-placeholder-subdomain>`, dropping a claimed hive's vanity host.
5. **Heartbeat-only clusters logged a misleading Warn.** On the vllm-d pool the hub can't `kubectl`-create the vanity route, so `addVanityHostToIngress` "fails" — but the host is served by the cluster's `*.apps.<domain>` **wildcard** route. The old code logged a scary Warn ("hub links will 503 … add it by hand") even though the host is already reachable.

## The fix

A single narrow helper, `claimedVanityURL(h)`, is the source of truth: return `h.VanityURL` for a **claimed** hive (`status != available`) that has one, else `""`. It never invents a host.

Changes, per claim/display path:

- **`projectConfigForHiveID`** — when the record is claimed but the project is incomplete/stale, push a **URL-only** `HeartbeatProjectConfig{DashboardURL: vanity}` (never the stale org/repos/ACMM) until the spoke reports the vanity back. Complete-claim records still push the URL via the existing `needURLPush` path.
- **Spoke callback (`cmd/hive/main.go`)** — handle a URL-only push (org empty, dashboard_url set) *before* the org-empty bail: adopt `cfg.Hub.DashboardURL`, persist, and return without touching the project (so an empty project still never blanks a working config).
- **My Hives (`enrichFromSaaSMeta`)** — overlay the validated meta `vanity_url` onto the row's `DashboardURL` immediately, so the friendly host shows the instant a hive is claimed.
- **SSO `/open` (`handleOpenHive`)** — hand the handoff off to the vanity host for a claimed hive.
- **`migrateHive`** — keep the vanity host for a claimed hive instead of resetting to the new placeholder subdomain.
- **`handleAssignHive`** — on a heartbeat-only OpenShift cluster, log Info (the wildcard route serves the host) instead of a misleading Warn, while still adopting the vanity URL.

## Which claim/assign paths now set/push vanity

- **`handleAssignHive`** — already set `VanityURL` at claim (unchanged; now with clearer heartbeat-only logging). `projectConfigForHiveID` pushes it every beat until the spoke reports it back.
- **Any claimed hive with a meta `vanity_url`** (including those claimed before the feature, or via re-provision/migration) — `projectConfigForHiveID` now pushes it even when the project record is stale, and the hub overlays it in My Hives / `/open` immediately.
- **`migrateHive`** — preserves the vanity host across a cluster move.

## Heartbeat-only clusters (vllm-d)

The vanity host on vllm-d is served by the cluster's `*.apps.<domain>` OpenShift wildcard route — which is why those hives already carry a populated `vanity_url` in meta. The hub does **not** try (and fail) to create an ingress and then hide it: it trusts the validated meta `vanity_url`, pushes it over the heartbeat (the only channel that reaches a firewalled spoke), and shows/links it — no hub-created ingress required.

## Safety (don't-503-on-unserved-host — preserved)

Only a **non-empty** meta `vanity_url` is ever pushed or linked. A vanity URL is only non-empty because it was validated as servable at provision/assign time (route created, or covered by a cluster wildcard). The hub never mints an unvalidated host on the read paths, unclaimed placeholders always keep their working placeholder host, and a claimed hive with no vanity_url keeps the placeholder rather than getting an invented one.

## Tests

New `pkg/hub/vanity_url_test.go`:
- a claimed hive with a meta `vanity_url` (and stale project) gets a **URL-only** push as DashboardURL, and the reconcile goes quiet once the spoke reports it back;
- a heartbeat-only-cluster hive surfaces its vanity URL with no hub-created ingress;
- an **unassigned** placeholder keeps its placeholder URL (no push, no override);
- the don't-push-an-unserved-host safety holds (a claimed hive with no vanity_url is never given an invented one).

`go build ./...` clean. `pkg/hub` suite green except two **pre-existing, environment-dependent** failures unrelated to this change (`TestLoadAppPrivateKeyKubectlFails`, `TestHandleHubSelfUpgrade_Edge`) — both assert `kubectl` is absent/failing and only fail on a dev box that has a working `kubectl`; they pass on the clean base too.
