### PR TITLE
🐛 fix(ui): don't offer "View App Settings" when no App is installed

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4782,6 +4782,11 @@
        states must not tell the user to install anything or edit config. */
     var GH_APP_STATE_KEY_MISSING = 'key-missing';
     var GH_APP_STATE_KEY_INVALID = 'key-invalid';
+    /* User-actionable, but distinct from a permission problem: the App is not
+       installed at all, so there are no settings to view — only an install to
+       perform. Kept out of GH_APP_OPERATOR_STATES: installing is the user's
+       job, not the operator's. */
+    var GH_APP_STATE_NOT_INSTALLED = 'not-installed';
     var GH_APP_OPERATOR_STATES = {};
     GH_APP_OPERATOR_STATES[GH_APP_STATE_KEY_MISSING] = true;
     GH_APP_OPERATOR_STATES[GH_APP_STATE_KEY_INVALID] = true;
@@ -4839,7 +4844,18 @@
       if (resetLink) resetLink.style.display = '';
       banner.classList.remove('operator-issue');
 
-      var isPermIssue = data.githubAppRequired && data.githubAppPermIssue;
+      /* githubAppPermIssue carries the diagnostic string for EVERY
+         user-actionable App failure, including "not installed at all", so it
+         cannot decide between "installed but under-permissioned" and "never
+         installed". Using it alone told a hive carrying a placeholder app_id
+         that "the app is installed but cannot write" and offered
+         "View App Settings" — settings for an App that does not exist — while
+         the banner's own body text said it was not yet linked to any App.
+         githubAppState (added with the operator/user classification) is the
+         authoritative signal, so an explicitly not-installed state is never
+         treated as a permission problem. */
+      var isNotInstalled = appState === GH_APP_STATE_NOT_INSTALLED;
+      var isPermIssue = data.githubAppRequired && data.githubAppPermIssue && !isNotInstalled;
       if (data.githubAppRequired && (data.githubAppInstallURL || isPermIssue)) {
         var link = document.getElementById('gh-app-install-link');
         var title = document.querySelector('#gh-app-install-banner .gh-app-title');


### PR DESCRIPTION
A hive with a **placeholder** `github.app_id` showed:

> **GitHub App — Insufficient Permissions**
> The app is installed but cannot write to this repository.
> *This hive carries a placeholder github.app_id and is not yet linked to a GitHub App. Install the GitHub App on your org to enable agents.*
>
> `[ View App Settings ]`

The banner contradicts itself — the headline says the App *is* installed, the body says it is *not* — and the button offers settings for an App that does not exist.

## Cause

```js
var isPermIssue = data.githubAppRequired && data.githubAppPermIssue;
```

`githubAppPermIssue` carries the diagnostic string for **every** user-actionable App failure, including "not installed at all" (its own field comment says *"non-empty when app is installed but lacks required permissions"* — but the not-installed path sets it too). So it cannot distinguish the two cases, and a never-installed hive took the permissions branch.

## Fix

`githubAppState` already classifies this exactly — `AppStateNotInstalled` → `"not-installed"` — and the client **already reads it** for `ghAppIsOperatorSide`. It simply was not consulted here.

An explicitly not-installed state now falls through to the existing branch, which already renders **"GitHub App Not Installed"** and an **"Install GitHub App"** button using the GHE-aware install URL. No new copy or layout — the correct branch already existed.

Deliberately narrow: only an *explicit* `not-installed` is excluded. An unreported or unrecognised state keeps today's behavior, so a spoke too old to classify is unaffected.

## Verified

Against the live hive in the report (`hosted-available-oke-10-placeholder-ncnd`):
```
app_id: 999999999      <- placeholder sentinel
installation_id: 0
app_slug: ""
```
No App installed, yet the permissions banner rendered.

- Extracted the dashboard JS: brace delta **0**, `node --check` passes, and all three edits confirmed present in the **extraction** (not a stale read). The `-4` paren delta is pre-existing on clean `origin/v2`.
- CSS/JS branch selection only; no server change.

## Ports

Needs porting to `mk`, `dd`, and `v3`.