### PR TITLE
🐛 fix(ui): show the GitHub forge on Repos config + Repositories section (GHE hives read github.com)

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -571,10 +571,13 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 	if primaryRepo != "" && cfg.Project.Org != "" && !strings.Contains(primaryRepo, "/") {
 		primaryRepo = cfg.Project.Org + "/" + primaryRepo
 	}
-	githubBaseURL := cfg.GitHub.BaseURL
-	if githubBaseURL == "" {
-		githubBaseURL = "https://github.com"
-	}
+	// ResolvedBaseURL (not the raw BaseURL) so pooled/placeholder GHE hives —
+	// which legitimately carry base_url: "" but api_url: https://github.ibm.com/api/v3
+	// — report github.ibm.com, not github.com. Reading BaseURL alone made the
+	// Repos config show bare org/repo with no GHE hint, so operators mistook a
+	// github.ibm.com hive for github.com. ResolvedBaseURL falls back to the api_url
+	// host in exactly that case (mirrors HostLabel).
+	githubBaseURL := cfg.GitHub.ResolvedBaseURL()
 	jsonResponse(w, map[string]interface{}{
 		"org":       cfg.Project.Org,
 		"repos":     cfg.Project.Repos,

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -1935,6 +1935,41 @@ func TestHandleConfig_WithPrimaryRepo(t *testing.T) {
 	}
 }
 
+// handleConfig must report the RESOLVED GitHub host so the dashboard's
+// forge indicators (Repositories section pill, per-repo cards, Repos config
+// modal) show the real host. A pooled/placeholder GHE hive legitimately
+// carries base_url: "" with a GHE api_url — reading base_url alone rendered
+// those as github.com, so operators mistook a github.ibm.com hive for
+// github.com (the vllmd-06 case). ResolvedBaseURL falls back to the api_url
+// host in exactly that case.
+func TestHandleConfig_GitHubBaseURL_BlankBaseGHEApi(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.GitHub.BaseURL = ""
+	deps.Config.GitHub.APIURL = "https://github.ibm.com/api/v3"
+	rec := doGet(s, "/api/config")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	result := decodeJSON(t, rec)
+	if got := result["github_base_url"]; got != "https://github.ibm.com" {
+		t.Errorf("github_base_url = %v, want https://github.ibm.com", got)
+	}
+}
+
+func TestHandleConfig_GitHubBaseURL_PublicDefault(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.GitHub.BaseURL = ""
+	deps.Config.GitHub.APIURL = ""
+	rec := doGet(s, "/api/config")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	result := decodeJSON(t, rec)
+	if got := result["github_base_url"]; got != "https://github.com" {
+		t.Errorf("github_base_url = %v, want https://github.com", got)
+	}
+}
+
 // ---- handleKnowledgeToggle enable with layers ----
 
 func TestHandleKnowledgeToggle_EnableWithLayers(t *testing.T) {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5341,14 +5341,22 @@
       // Definitive single-host badge in the section header: every repo in this
       // hive is on ONE GitHub host (github.com or a GHE instance). Green =
       // github.com, blue = GitHub Enterprise — matches the hub spokes-table pill.
+      // hostLabel is the hive's forge. window._githubBaseUrl now comes from the
+      // backend's ResolvedBaseURL() (base_url, else the api_url host), so a
+      // pooled GHE hive carrying base_url: "" + api_url github.ibm.com resolves
+      // to github.ibm.com here — not github.com. This is the fix for the pill
+      // that read "GITHUB.COM" on a github.ibm.com hive.
+      const hostLabel = (window._githubBaseUrl || 'https://github.com').replace(/^https?:\/\//, '').replace(/\/$/, '') || 'github.com';
+      const isPublic = hostLabel === 'github.com';
       const badge = document.getElementById('repos-host-badge');
       if (badge) {
-        const base = (window._githubBaseUrl || 'https://github.com').replace(/^https?:\/\//, '').replace(/\/$/, '');
-        const isPublic = (base === 'github.com' || base === '');
-        badge.textContent = isPublic ? 'github.com' : base;
-        badge.style.background = isPublic ? 'rgba(34,197,94,0.15)' : 'rgba(59,130,246,0.15)';
-        badge.style.color = isPublic ? 'var(--green, #16a34a)' : 'var(--blue, #2563eb)';
-        badge.title = 'Every repo in this hive is on ' + (isPublic ? 'github.com' : base) + ' — this hive is single-host';
+        // Definitive single-host badge in the section header: every repo in this
+        // hive is on ONE GitHub host. Green = github.com, indigo = GHE — GHE also
+        // gets an "Enterprise" tag so an operator instantly sees it is not public.
+        badge.textContent = isPublic ? 'github.com' : hostLabel + ' · Enterprise';
+        badge.style.background = isPublic ? 'color-mix(in srgb, var(--green) 15%, transparent)' : 'color-mix(in srgb, var(--indigo) 15%, transparent)';
+        badge.style.color = isPublic ? 'var(--green)' : 'var(--indigo)';
+        badge.title = 'Every repo in this hive is on ' + hostLabel + (isPublic ? '' : ' (GitHub Enterprise)') + ' — this hive is single-host';
       }
       setIfChanged(el, repos.map(r => {
         const iSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.issues ?? 0), 'var(--blue)');
@@ -5373,6 +5381,7 @@
         const pillsHtml = allPills ? `<div class="repo-issues">${allPills}</div>` : '';
         return `
         <div class="repo-card">
+          <div style="font-size:0.62rem;font-weight:600;letter-spacing:0.02em;color:${isPublic ? 'var(--muted)' : 'var(--indigo)'};margin-bottom:2px" title="This repo lives on ${esc(hostLabel)}${isPublic ? '' : ' (GitHub Enterprise), not public github.com'}">${esc(hostLabel)}${isPublic ? '' : ' · Enterprise'}</div>
           <div class="repo-name"><a href="${esc(repoUrl)}" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">${esc(r.full || r.name)}</a></div>
           <div class="repo-stats">
             <div class="repo-stat"><a href="${esc(repoUrl)}/issues" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.issues >= 0 ? r.issues : '?'}</span>${iSpark}</div><div class="label">issues</div></a></div>
@@ -15445,9 +15454,30 @@ function burnAreaChart() {
 
     function renderGovRepos(repos) {
       const primary = _configState.data.primaryRepo || '';
+      // ghHost is the hive's forge, derived server-side by ResolvedBaseURL()
+      // (base_url, or the api_url host for pooled GHE hives that carry
+      // base_url: ""). A hive is single-forge — validateSingleRepoHost rejects
+      // off-host repos — so every repo below lives on THIS host. We surface it
+      // both in the header and as a per-row pill so an org/repo can never be
+      // mistaken for github.com when it actually lives on github.ibm.com.
       const ghBase = window._githubBaseUrl || 'https://github.com';
-      const ghHost = ghBase.replace(/^https?:\/\//, '');
+      const ghHost = ghBase.replace(/^https?:\/\//, '').replace(/\/$/, '');
       const isGHE = ghHost !== 'github.com';
+      // GHE hosts get an indigo "Enterprise" pill so an operator instantly sees
+      // this is an Enterprise hive; public github.com gets a muted host pill.
+      // Inline styles mirror the pill recipe (--pill-c tint + border) and the
+      // ACMM badge pattern — self-contained, no external resources (CSP-safe).
+      const pillColor = isGHE ? 'var(--indigo)' : 'var(--muted)';
+      const pillBase = 'display:inline-flex;align-items:center;gap:4px;flex-shrink:0;'
+        + 'font-size:0.62rem;font-weight:700;letter-spacing:0.02em;padding:1px 7px;'
+        + 'border-radius:999px;white-space:nowrap;'
+        + 'background:color-mix(in srgb, ' + pillColor + ' 12%, transparent);'
+        + 'border:1px solid color-mix(in srgb, ' + pillColor + ' 40%, transparent);'
+        + 'color:' + pillColor;
+      const pillLabel = isGHE ? esc(ghHost) + ' · Enterprise' : esc(ghHost);
+      const pillTitle = isGHE
+        ? 'This repo lives on the GitHub Enterprise host ' + esc(ghHost) + ' — NOT public github.com'
+        : 'This repo lives on public github.com';
       const list = repos.map((r, i) => {
         const isDefault = r === primary;
         const starStyle = isDefault
@@ -15456,15 +15486,19 @@ function burnAreaChart() {
         const starTitle = isDefault
           ? 'Default repo (advisory issue lives here)'
           : 'Set as default repo for advisory issue';
-        const displayName = isGHE ? ghHost + '/' + r : r;
-        return `<div class="config-list-item" style="align-items:center"><span onclick="setDefaultRepo('${esc(r)}')" style="${starStyle}" title="${starTitle}">${isDefault ? '★' : '☆'}</span><span style="flex:1">${esc(displayName)}</span><button class="remove-item" onclick="removeListItem('repos','list',${i})">&#x2715;</button></div>`;
+        // Fully forge-qualified so the row is unambiguous: github.ibm.com/org/repo.
+        const displayName = ghHost + '/' + r;
+        return `<div class="config-list-item" style="align-items:center;gap:6px"><span onclick="setDefaultRepo('${esc(r)}')" style="${starStyle}" title="${starTitle}">${isDefault ? '★' : '☆'}</span><span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${esc(displayName)}">${esc(displayName)}</span><span style="${pillBase}" title="${pillTitle}">${pillLabel}</span><button class="remove-item" onclick="removeListItem('repos','list',${i})">&#x2715;</button></div>`;
       }).join('');
+      const hostNote = isGHE
+        ? ` on <strong style="color:var(--indigo)">${esc(ghHost)}</strong> (GitHub Enterprise)`
+        : ` on <strong>${esc(ghHost)}</strong>`;
       return `
-        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">GitHub repositories monitored by this hive. Click the star to set the default repo where the advisory issue is maintained.</p>
+        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">GitHub repositories monitored by this hive${hostNote}. Click the star to set the default repo where the advisory issue is maintained.</p>
         <div class="config-list">
           ${list || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No repos configured</div>'}
           <div class="config-list-add">
-            <input type="text" id="cfg-repo-input" placeholder="org/repo" title="GitHub repository in org/repo format (e.g. kubestellar/console). The governor will monitor this repo for issues, PRs, and CI status.">
+            <input type="text" id="cfg-repo-input" placeholder="org/repo (on ${esc(ghHost)})" title="GitHub repository in org/repo format (e.g. kubestellar/console). It must live on this hive's forge, ${esc(ghHost)} — the governor rejects repos on other GitHub hosts. It will be monitored for issues, PRs, and CI status.">
             <button onclick="addListItem('repos','list','cfg-repo-input')" title="Add this repository to the monitored list">+ Add</button>
           </div>
         </div>`;


### PR DESCRIPTION
## Problem

On a **GitHub Enterprise** hive (e.g. the live `vllmd-06` hive, repo `devx-prod/epx-vscode-ext-poc` on `github.ibm.com`) the spoke governor dashboard gave **no** — and in one place **wrong** — forge information:

- **Repositories** section header pill read **`GITHUB.COM`** even though the hive is on `github.ibm.com`.
- Repo cards and the **Repos** config modal listed bare `org/repo` with no host at all.

Operators mistook the github.ibm.com hive for github.com — a real misconfiguration-confusion incident.

### Root cause
A pooled/placeholder GHE hive legitimately carries:
```yaml
base_url: ""
api_url: https://github.ibm.com/api/v3
```
`GET /api/config` computed `github_base_url` from `cfg.GitHub.BaseURL` **alone**, so a blank `base_url` fell back to `https://github.com`. The frontend reads that value as `window._githubBaseUrl` and drives **every** forge indicator from it — so all of them showed github.com. (The hub side already derived the host with the base-or-api fallback via `githubHostLabel`, which is why the hub *My Hives* hover correctly showed github.ibm.com — the spoke was the outlier.)

## Fix

**One root-cause backend change** aligns the spoke to the same derivation the hub and `HostLabel()` already use:

- `pkg/dashboard/api.go` `handleConfig` now sends `github_base_url` from **`GitHubConfig.ResolvedBaseURL()`** (prefers `base_url`, else the `api_url` host — mirrors `HostLabel()`). A blank-base_url GHE hive now resolves to `https://github.ibm.com` everywhere the frontend reads it.

**UI (`pkg/dashboard/static/index.html`), all fed by the corrected host:**

1. **Repositories section pill** (`renderRepos`) — now shows the real host; **indigo + "· Enterprise"** for GHE (was green `github.com`).
2. **Per-repo cards** — each card gains a small host label (`github.ibm.com · Enterprise`) above the repo name, so every card unambiguously shows its forge.
3. **Repos config modal** (`renderGovRepos`):
   - Header states the hive's forge: *"GitHub repositories monitored by this hive **on github.ibm.com (GitHub Enterprise)**. Click the star…"*
   - Each row is **forge-qualified**: `github.ibm.com/devx-prod/epx-vscode-ext-poc` + an indigo **`github.ibm.com · Enterprise`** pill.
   - Add-repo input placeholder/hint: `org/repo (on github.ibm.com)` — repos must be on the hive's forge (`validateSingleRepoHost` already enforces this server-side).

GHE hosts are styled distinctly (indigo + "Enterprise") from public github.com (muted/green). The hive is single-host, so all repos share the forge. **Hub code is unchanged** — it was already correct.

## How the host is derived
`GitHubConfig.HostLabel()` / `ResolvedBaseURL()` in `pkg/config/config.go` return the bare host from `base_url` **or** the `api_url` host — the canonical, GHE-aware derivation. The API now uses `ResolvedBaseURL()`; the frontend just renders `window._githubBaseUrl`.

## CSP / conventions
Pills use inline styles mirroring the existing pill recipe (`color-mix` tint + border), matching the ACMM badge pattern already in this file — self-contained, no external resources.

## Verification
- `go build ./...` — clean.
- New tests in `api_coverage_test.go`: `TestHandleConfig_GitHubBaseURL_BlankBaseGHEApi` (blank base_url + GHE api_url → `https://github.ibm.com`) and `TestHandleConfig_GitHubBaseURL_PublicDefault` (→ `https://github.com`). Both pass.
- All inline dashboard JS `node --check`s clean; `renderGovRepos`/`renderRepos` rendered in a harness confirm the GHE and public outputs above.
- Confirmed against the **live vllmd-06** hive (read-only): `/etc/hive/hive.yaml` has `base_url: ""`, `api_url: https://github.ibm.com/api/v3`, repo `devx-prod/epx-vscode-ext-poc`. The fixed derivation turns exactly that into a **github.ibm.com** pill, not github.com.

Pre-existing dashboard test failures (device-flow / client-id coverage tests) are unrelated and fail on `origin/v2` without this change.