### PR TITLE
🐛 fix(dashboard): budget partial save zeroed untouched fields; persist error toasts

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3585,30 +3585,52 @@ func (s *Server) handleGovernorLabels(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGovernorBudget(w http.ResponseWriter, r *http.Request) {
+	// Pointer fields distinguish "field absent from the JSON" (nil) from
+	// "field explicitly set to 0". The dashboard sends only the inputs the
+	// user actually touched, so editing Total Tokens alone POSTs
+	// {"totalTokens":N} with no periodDays/criticalPct. With plain ints
+	// those absent fields decoded to 0 and were rejected by validation as
+	// out-of-range. Nil now means "leave the stored value alone", while an
+	// explicit 0 is still honored (totalTokens: 0 disables budget tracking).
 	var body struct {
-		TotalTokens int64 `json:"totalTokens"`
-		PeriodDays  int   `json:"periodDays"`
-		CriticalPct int   `json:"criticalPct"`
+		TotalTokens *int64 `json:"totalTokens"`
+		PeriodDays  *int   `json:"periodDays"`
+		CriticalPct *int   `json:"criticalPct"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
 		return
 	}
 
-	if err := validateGovernorBudget(body.TotalTokens, body.PeriodDays, body.CriticalPct); err != nil {
+	// Validate against the effective post-update values: supplied fields use
+	// the incoming value, omitted fields keep what is already stored. This
+	// keeps a partial update from being judged against a phantom zero.
+	current := s.deps.Config.Governor.Budget
+	totalTokens, periodDays, criticalPct := current.TotalTokens, current.PeriodDays, current.CriticalPct
+	if body.TotalTokens != nil {
+		totalTokens = *body.TotalTokens
+	}
+	if body.PeriodDays != nil {
+		periodDays = *body.PeriodDays
+	}
+	if body.CriticalPct != nil {
+		criticalPct = *body.CriticalPct
+	}
+
+	if err := validateGovernorBudget(totalTokens, periodDays, criticalPct); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	if body.TotalTokens > 0 {
-		s.deps.Config.Governor.Budget.TotalTokens = body.TotalTokens
-		s.deps.Governor.SetBudgetLimit(body.TotalTokens)
+	if body.TotalTokens != nil {
+		s.deps.Config.Governor.Budget.TotalTokens = totalTokens
+		s.deps.Governor.SetBudgetLimit(totalTokens)
 	}
-	if body.PeriodDays > 0 {
-		s.deps.Config.Governor.Budget.PeriodDays = body.PeriodDays
+	if body.PeriodDays != nil {
+		s.deps.Config.Governor.Budget.PeriodDays = periodDays
 	}
-	if body.CriticalPct > 0 {
-		s.deps.Config.Governor.Budget.CriticalPct = body.CriticalPct
+	if body.CriticalPct != nil {
+		s.deps.Config.Governor.Budget.CriticalPct = criticalPct
 	}
 
 	if err := s.saveConfig(); err != nil {

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -3802,3 +3802,125 @@ func TestHandleRestart_NotRunning(t *testing.T) {
 		t.Log("restart succeeded despite stopped agent (depends on impl)")
 	}
 }
+
+// ── Budget partial-update regression tests ──
+// Reported by Cyril Nestor: editing only "Total Tokens" in the Governor
+// Budget tab failed with "periodDays must be between 1 and 365" even though
+// the UI showed a valid period. The dashboard PUTs only the fields the user
+// touched, so periodDays/criticalPct were absent and decoded to 0.
+
+// budgetTestPeriodDays / budgetTestCriticalPct are the pre-existing stored
+// values these tests seed so they can assert the values survive a partial PUT.
+const (
+	budgetTestPeriodDays  = 7
+	budgetTestCriticalPct = 90
+)
+
+// seedBudget puts a known-good budget into the server config so that a
+// partial update has something meaningful to preserve.
+func seedBudget(deps *Dependencies, totalTokens int64) {
+	deps.Config.Governor.Budget.TotalTokens = totalTokens
+	deps.Config.Governor.Budget.PeriodDays = budgetTestPeriodDays
+	deps.Config.Governor.Budget.CriticalPct = budgetTestCriticalPct
+}
+
+func TestHandleGovernorBudget_PartialUpdatePreservesOtherFields(t *testing.T) {
+	s, deps := apiServer(t)
+	seedBudget(deps, 1000)
+
+	// Exactly what the dashboard sends when only Total Tokens is edited.
+	rec := doPutRaw(s, "/api/config/governor/budget", `{"totalTokens":50}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	b := deps.Config.Governor.Budget
+	if b.TotalTokens != 50 {
+		t.Errorf("TotalTokens = %d, want 50", b.TotalTokens)
+	}
+	if b.PeriodDays != budgetTestPeriodDays {
+		t.Errorf("PeriodDays = %d, want %d preserved", b.PeriodDays, budgetTestPeriodDays)
+	}
+	if b.CriticalPct != budgetTestCriticalPct {
+		t.Errorf("CriticalPct = %d, want %d preserved", b.CriticalPct, budgetTestCriticalPct)
+	}
+}
+
+func TestHandleGovernorBudget_PartialPeriodDaysOnly(t *testing.T) {
+	s, deps := apiServer(t)
+	seedBudget(deps, 1000)
+
+	rec := doPutRaw(s, "/api/config/governor/budget", `{"periodDays":30}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	b := deps.Config.Governor.Budget
+	if b.PeriodDays != 30 {
+		t.Errorf("PeriodDays = %d, want 30", b.PeriodDays)
+	}
+	if b.TotalTokens != 1000 {
+		t.Errorf("TotalTokens = %d, want 1000 preserved", b.TotalTokens)
+	}
+	if b.CriticalPct != budgetTestCriticalPct {
+		t.Errorf("CriticalPct = %d, want %d preserved", b.CriticalPct, budgetTestCriticalPct)
+	}
+}
+
+// An explicit zero for totalTokens disables budget tracking per the UI
+// tooltip, so it must be applied — not mistaken for an absent field.
+func TestHandleGovernorBudget_ExplicitZeroTotalTokensHonored(t *testing.T) {
+	s, deps := apiServer(t)
+	seedBudget(deps, 1000)
+
+	rec := doPutRaw(s, "/api/config/governor/budget", `{"totalTokens":0}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := deps.Config.Governor.Budget.TotalTokens; got != 0 {
+		t.Errorf("TotalTokens = %d, want 0 (explicit zero disables tracking)", got)
+	}
+	if got := deps.Config.Governor.Budget.PeriodDays; got != budgetTestPeriodDays {
+		t.Errorf("PeriodDays = %d, want %d preserved", got, budgetTestPeriodDays)
+	}
+}
+
+// An explicit out-of-range value must still be rejected — the pointer change
+// fixes absence, it does not relax validation.
+func TestHandleGovernorBudget_ExplicitOutOfRangeStillRejected(t *testing.T) {
+	s, deps := apiServer(t)
+	seedBudget(deps, 1000)
+
+	for _, tc := range []struct{ name, payload string }{
+		{"periodDays zero", `{"periodDays":0}`},
+		{"periodDays too high", `{"periodDays":400}`},
+		{"criticalPct zero", `{"criticalPct":0}`},
+		{"criticalPct too high", `{"criticalPct":101}`},
+		{"negative totalTokens", `{"totalTokens":-1}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := doPutRaw(s, "/api/config/governor/budget", tc.payload)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400 for %s", rec.Code, tc.payload)
+			}
+		})
+	}
+	// Nothing should have been mutated by the rejected requests.
+	b := deps.Config.Governor.Budget
+	if b.PeriodDays != budgetTestPeriodDays || b.CriticalPct != budgetTestCriticalPct || b.TotalTokens != 1000 {
+		t.Errorf("config mutated by rejected requests: %+v", b)
+	}
+}
+
+// An empty object touches nothing and must succeed without zeroing anything.
+func TestHandleGovernorBudget_EmptyPayloadPreservesAll(t *testing.T) {
+	s, deps := apiServer(t)
+	seedBudget(deps, 1000)
+
+	rec := doPutRaw(s, "/api/config/governor/budget", `{}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	b := deps.Config.Governor.Budget
+	if b.TotalTokens != 1000 || b.PeriodDays != budgetTestPeriodDays || b.CriticalPct != budgetTestCriticalPct {
+		t.Errorf("empty payload mutated config: %+v", b)
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1268,6 +1268,11 @@
     .toast.error { background: color-mix(in srgb, var(--red) 14%, var(--panel)); border-color: color-mix(in srgb, var(--red) 35%, var(--line)); border-left-color: var(--red); }
     .toast.info { background: color-mix(in srgb, var(--blue) 14%, var(--panel)); border-color: color-mix(in srgb, var(--blue) 35%, var(--line)); border-left-color: var(--blue); }
     .toast-spinner { display: inline-block; width: 12px; height: 12px; border: 2px solid color-mix(in srgb, var(--text) 30%, transparent); border-top-color: var(--text); border-radius: 50%; animation: spin 0.8s linear infinite; margin-right: 8px; vertical-align: middle; }
+    /* Error toasts never auto-dismiss (a failed save must stay readable), so
+       they carry an explicit close affordance and a click-anywhere target. */
+    .toast.sticky { cursor: pointer; padding-right: 30px; position: relative; }
+    .toast-close { position: absolute; top: 4px; right: 8px; font-size: 0.9rem; line-height: 1; color: var(--muted); background: none; border: none; padding: 2px 4px; cursor: pointer; }
+    .toast-close:hover { color: var(--text); }
     @keyframes spin { to { transform: rotate(360deg); } }
     @keyframes toast-in { from { opacity: 0; transform: translateX(40px); } to { opacity: 1; transform: translateX(0); } }
     @keyframes toast-out { from { opacity: 1; } to { opacity: 0; transform: translateY(-10px); } }
@@ -11093,6 +11098,21 @@ function burnAreaChart() {
         overlay.querySelector('.primary').focus();
       });
     }
+    // makeToastSticky turns a toast into one that never auto-dismisses. Used
+    // for errors: a failed save may carry a validation message the user has
+    // not finished reading, so it waits for an explicit click or × instead of
+    // vanishing on a timer. Success/info toasts keep their timeout.
+    function makeToastSticky(el) {
+      if (el._sticky) return;
+      el._sticky = true;
+      el.classList.add('sticky');
+      const close = document.createElement('button');
+      close.className = 'toast-close';
+      close.textContent = '×';
+      close.setAttribute('aria-label', 'Dismiss');
+      el.appendChild(close);
+      el.addEventListener('click', () => dismissToast(el, null, null, true));
+    }
     function showToast(msg, type = 'info', persistent = false) {
       const container = document.getElementById('toast-container');
       const el = document.createElement('div');
@@ -11107,16 +11127,28 @@ function burnAreaChart() {
         setTimeout(() => { if (el.parentNode) dismissToast(el); }, TOAST_PROGRESS_MAX_MS);
         return el;
       }
+      if (type === 'error') {
+        makeToastSticky(el);
+        return el;
+      }
       setTimeout(() => dismissToast(el), TOAST_DURATION_MS);
       return el;
     }
-    function dismissToast(el, newMsg, newType) {
+    // dismissToast removes a toast, or (with newMsg) rewrites an in-flight
+    // toast into its result. `force` bypasses stickiness for the user-initiated
+    // click/× path, so a sticky error can still be dismissed on demand.
+    function dismissToast(el, newMsg, newType, force) {
       if (!el || !el.parentNode) return;
       if (newMsg) {
         el.textContent = newMsg;
         el.className = `toast ${newType || 'success'}`;
+        el._sticky = false;
+        // A resolved in-flight toast that resolved to an error stays put for
+        // the same reason a direct error toast does.
+        if (newType === 'error') { makeToastSticky(el); return; }
         setTimeout(() => { el.style.animation = 'toast-out 0.3s ease-in forwards'; setTimeout(() => el.remove(), 300); }, TOAST_DURATION_MS);
       } else {
+        if (el._sticky && !force) return;
         el.style.animation = 'toast-out 0.3s ease-in forwards';
         setTimeout(() => el.remove(), 300);
       }


### PR DESCRIPTION
Reported by **Cyril Nestor** in Slack:

> There is a bug when setting up the Total tokens.
> `Failed to save budget: PeriodDays must be between 1 and 365`
> The error message should also be persistent instead of the 5s timeout.

## Root cause

The Governor Budget tab wires each input to its own `onchange="markDirty('budget', ...)"`, and the save loop PUTs `JSON.stringify(values)` — **only the fields the user actually touched**. Editing Total Tokens alone therefore POSTs `{"totalTokens":50}` with no `periodDays`.

`handleGovernorBudget` decoded into plain `int64`/`int`, so those absent fields became `0`, and `validateGovernorBudget` rejected `periodDays: 0` as out of range. The UI still displayed `7` because the user never touched that input — the server simply never received it. That is exactly the reported symptom.

## Fix

`handleGovernorBudget` now decodes into pointer fields (`*int64`, `*int`) so **absent (nil) is distinguishable from an explicit 0**. Validation runs against the *effective post-update* values — supplied fields use the incoming value, omitted fields keep what is already stored — so a partial update is no longer judged against a phantom zero. Explicit out-of-range values are still rejected exactly as before.

I fixed this **server-side** rather than making the client send the full object. A server that zeroes unsent fields is a latent bug regardless of what any one client happens to send, and the pointer approach is what actually distinguishes the two cases.

This also fixes a **second latent bug** in the same handler: the old apply block guarded on `> 0`, silently dropping an explicit `totalTokens: 0` — which the UI tooltip documents as the way to disable budget tracking. Pointers fix that too; plain ints could not.

### Persistent error toasts

Error toasts no longer auto-dismiss. A failed save can carry a validation message the user has not finished reading, so error toasts stay until dismissed by click or ×. **Success and info toasts keep their existing timeout** — this does not make every toast sticky. In-flight toasts that resolve to an error (the `dismissToast(toast, msg, 'error')` pattern used throughout) become sticky as well, so the behavior is consistent.

## On the capitalization mismatch

Cyril's error reads `PeriodDays` (capital P), but the validator emits lowercase `periodDays`. I grepped all four branches (`v2`, `mk`, `dd`, `v3`) for `eriodDays must be between` and found **exactly one** producer — `v2/pkg/dashboard/validation.go:267` — on every branch, all lowercase. There is **no second/reflective validator**. Cyril's hive is running an older image whose message was capitalized; the underlying bug is the same one fixed here.

## Tests

Four regression tests added, all of which **fail without the fix and pass with it** (verified by stashing the handler change):

- `TestHandleGovernorBudget_PartialUpdatePreservesOtherFields` — the exact reported payload `{"totalTokens":50}` succeeds and preserves `periodDays`/`criticalPct`
- `TestHandleGovernorBudget_PartialPeriodDaysOnly` — the mirror case
- `TestHandleGovernorBudget_ExplicitZeroTotalTokensHonored` — explicit `0` is applied, not mistaken for absent
- `TestHandleGovernorBudget_EmptyPayloadPreservesAll` — `{}` mutates nothing
- `TestHandleGovernorBudget_ExplicitOutOfRangeStillRejected` — out-of-range values still 400, and reject cleanly without mutating config

`go build ./...`, `go vet ./pkg/dashboard/` clean; `gofmt` clean on touched files only. The 18 pre-existing failures in `pkg/dashboard` (GitHub-auth / network-dependent tests) are **identical in count on clean `origin/v2`** and unrelated to this change.

## Adjacent bug found, NOT fixed here

While auditing sibling handlers for the same shape, `handleGovernorHub` has an **on-apply** variant: `cfg.Hub.SnapshotURL = body.SnapshotURL` is assigned unconditionally while `URL` and `DashboardURL` immediately above it are guarded `if body.URL != ""`. Any PUT to the hub section omitting `snapshot_url` wipes the stored value. Left out of scope to keep this PR focused — worth a follow-up.

`handleGovernorThresholds`, `handleGovernorHealth`, `handleGovernorLogging`, and `handleGovernorNotifications` are all clean; Health and Logging are in fact the correct reference pattern.

## Porting

**Needs porting to `mk`, `dd`, and `v3`** — all three carry the identical handler and validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)