### PR TITLE
🐛 fix(hub): backfill vanity URL for hives claimed before the vanity feature

### DIFF
--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -540,6 +540,111 @@ func (s *HubServer) repairGitHubHostForHive(hiveID string) bool {
 // Until a human does that, the hive authenticates as nothing on its GHE host.
 const gitHubAppStillRequiredNote = "github_host repaired; a hive still carrying the public app_id also needs the GitHub Enterprise App installed on its org before its installation can be auto-discovered"
 
+// repairVanityURLForHive retroactively mints the friendly vanity host for a hive
+// that was CLAIMED BEFORE the vanity feature existed, reporting whether it
+// changed anything.
+//
+// h.VanityURL is written in exactly ONE place — handleAssignHive, at claim time.
+// Every read path (claimedVanityURL, and through it My Hives, the SSO /open
+// handoff, and migrateHive) treats an empty VanityURL as "no validated host, keep
+// the placeholder". So a hive claimed before that code shipped keeps
+// VanityURL == "" forever and displays/opens its raw placeholder host no matter
+// how many times it heartbeats — nothing else ever fills it in. That is the
+// 14-claimed-hives-still-on-placeholder-IDs report: those records have a real org
+// but a placeholder id, and a placeholder id is NOT evidence the fix is missing,
+// only that the vanity URL was never minted for them.
+//
+// This deliberately does NOT touch the hive's id. The id is a k8s namespace
+// suffix (hive-hosted-<id>), an ingress hostname, a per-agent socket path and the
+// SSO token's "h" claim; renaming it is a different and far larger migration. The
+// goal is only that the DISPLAYED name and the OPENED URL are the vanity ones.
+//
+// It is conservative and idempotent, mirroring repairGitHubHostForHive:
+//   - Unclaimed placeholders are skipped: assign owns those and mints the vanity
+//     URL itself at claim time.
+//   - A hive that already has a VanityURL is never touched, so re-running is a
+//     no-op and a hive keeps one stable vanity host (the id's random suffix is
+//     regenerated per call, so re-minting would churn the host every beat).
+//   - A hive with no resolvable cluster domain, or an incomplete claim (no org or
+//     no primary repo), is skipped — there is nothing to derive a host from.
+//   - The host is adopted ONLY once it is actually servable. Unlike the claim
+//     path, which adopts optimistically because provisioning is creating the
+//     spoke's routes anyway, a retroactive repair has no such guarantee: the
+//     vanity host is a NEW name that resolves to no backend until an
+//     ingress/route exists for it. Adopting it before then would replace an
+//     ugly-but-working placeholder link with a 503, so addVanityHostToIngress
+//     must succeed first. On a heartbeat-only cluster the hub cannot kubectl to
+//     the spoke, so that call fails and the hive correctly keeps its working
+//     placeholder host.
+//
+// Called on each heartbeat, so it must be cheap and silent in the overwhelmingly
+// common no-op case — every guard below returns before any network call or write.
+func (s *HubServer) repairVanityURLForHive(hiveID string) bool {
+	h := loadSaaSHive(hiveID)
+	if h == nil {
+		return false
+	}
+	if h.Status == statusAvailable {
+		return false // unclaimed placeholder — assign mints it at claim time
+	}
+	if h.VanityURL != "" {
+		return false // already has one — never re-mint (idempotency + stable host)
+	}
+	// An incomplete claim has nothing to derive a friendly host from.
+	if h.Org == "" || h.PrimaryRepo == "" {
+		return false
+	}
+	cluster := s.clusterForHive(h)
+	if cluster == nil || cluster.Domain == "" {
+		return false
+	}
+	vanityHost := generateHiveID(h.Org, h.PrimaryRepo) + "." + cluster.Domain
+	// Make it servable BEFORE adopting it; on failure leave VanityURL empty so
+	// every read path keeps falling back to the working placeholder host.
+	if err := s.makeVanityHostServable(hiveID, vanityHost, cluster); err != nil {
+		s.logger.Info("vanity url repair: host is not servable yet, keeping the placeholder host",
+			"hive", hiveID, "host", vanityHost, "cluster", cluster.ID, "error", err)
+		return false
+	}
+	h.VanityURL = "https://" + vanityHost
+	if err := saveSaaSHive(h); err != nil {
+		s.logger.Error("vanity url repair: failed to save hive", "hive", hiveID, "error", err)
+		return false
+	}
+	s.logger.Info("vanity url repair: minted a vanity host for a hive claimed before the vanity feature",
+		"hive", hiveID, "org", h.Org, "primary_repo", h.PrimaryRepo,
+		"cluster", cluster.ID, "vanity_url", h.VanityURL)
+	return true
+}
+
+// makeVanityHostServable creates the ingress/route that makes vanityHost resolve,
+// returning an error when it could not be made servable. It is the one seam the
+// retroactive repair goes through: production uses addVanityHostToIngress, while
+// tests substitute it to exercise the adopt path without a live cluster (kubectl
+// is unavailable under test, so the real call always fails there).
+func (s *HubServer) makeVanityHostServable(hiveID, vanityHost string, cluster *ClusterConfig) error {
+	if s.vanityHostServable != nil {
+		return s.vanityHostServable(hiveID, vanityHost, cluster)
+	}
+	return s.addVanityHostToIngress(hiveID, vanityHost, cluster)
+}
+
+// repairVanityURLsForClaimedHives applies the retroactive vanity-URL repair to
+// every hive, returning the number changed. Safe to run repeatedly: each hive is
+// gated by repairVanityURLForHive, which no-ops once a vanity URL exists.
+func (s *HubServer) repairVanityURLsForClaimedHives() int {
+	repaired := 0
+	for _, h := range listSaaSHives() {
+		if s.repairVanityURLForHive(h.ID) {
+			repaired++
+		}
+	}
+	if repaired > 0 {
+		s.logger.Info("vanity url repair: complete", "hives_repaired", repaired)
+	}
+	return repaired
+}
+
 func generateHiveID(org, repo string) string {
 	short := repo
 	if len(short) > 12 {

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -402,8 +402,14 @@ type HubServer struct {
 	httpServer            *http.Server
 	httpMu                sync.Mutex // guards httpServer (Start runs in a goroutine; Shutdown races it)
 	clusters              map[string]ClusterConfig
-	heartbeatHealth       map[string]*HeartbeatHealthEntry // cluster ID → latest health from spoke heartbeat
-	heartbeatHealthMu     sync.RWMutex
+
+	// vanityHostServable overrides how the retroactive vanity-URL repair makes a
+	// vanity host servable (see makeVanityHostServable). nil in production, where
+	// the real addVanityHostToIngress runs; set by tests, which have no cluster to
+	// kubectl to.
+	vanityHostServable func(hiveID, vanityHost string, cluster *ClusterConfig) error
+	heartbeatHealth    map[string]*HeartbeatHealthEntry // cluster ID → latest health from spoke heartbeat
+	heartbeatHealthMu  sync.RWMutex
 
 	// usageHistory is the sampled fleet-total token trend, appended on
 	// heartbeat at usageSnapshotInterval and bounded to
@@ -1100,6 +1106,15 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	// very beat. No-op (and silent) for every hive that already has a host, is
 	// an unclaimed placeholder, or sits on a non-GHE cluster.
 	s.repairGitHubHostForHive(payload.HiveID)
+
+	// Retroactively mint the vanity host for a hive CLAIMED BEFORE the vanity
+	// feature existed, also BEFORE building the project config, so the URL-only
+	// push below delivers it on this very beat. VanityURL is otherwise written
+	// only at assign time, so those hives would display and open their raw
+	// placeholder host forever. No-op (and silent) for unclaimed placeholders,
+	// hives that already have a vanity URL, and hives whose vanity host the hub
+	// cannot make servable (heartbeat-only clusters keep their placeholder).
+	s.repairVanityURLForHive(payload.HiveID)
 
 	if projCfg := projectConfigForHiveID(payload.HiveID, payload.Org, payload.Repos, payload.PrimaryRepo, payload.ACMMLevel, payload.DashboardURL, payload.GitHubAPIURL); projCfg != nil {
 		resp.ProjectConfig = projCfg

--- a/v2/pkg/hub/vanity_url_repair_test.go
+++ b/v2/pkg/hub/vanity_url_repair_test.go
@@ -1,0 +1,260 @@
+package hub
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// vanityRepairTestDomain is the cluster domain the repair derives vanity hosts
+// from in these tests, mirroring the live hive-oke cluster.
+const vanityRepairTestDomain = "hive.kubestellar.io"
+
+// newVanityRepairTestHub builds a hub with one nginx cluster that has a domain
+// (so a vanity host can be derived) and a servability seam that succeeds,
+// standing in for a reachable cluster whose ingress the hub can patch.
+func newVanityRepairTestHub() *HubServer {
+	s := &HubServer{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		clusters: map[string]ClusterConfig{
+			defaultClusterID: {
+				ID:          defaultClusterID,
+				Name:        "oke",
+				Domain:      vanityRepairTestDomain,
+				IngressType: "nginx",
+			},
+		},
+	}
+	s.vanityHostServable = func(_, _ string, _ *ClusterConfig) error { return nil }
+	return s
+}
+
+// A hive claimed BEFORE the vanity feature existed (real org, placeholder id,
+// empty vanity_url) must get a vanity URL — and its id must NOT change, since
+// the id is a k8s namespace suffix, an ingress host, a socket path and the SSO
+// token's "h" claim.
+func TestVanityRepairBackfillsClaimedHiveWithoutChangingID(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityRepairTestHub()
+
+	const id = "hosted-available-oke-07-placeholder-wlj4"
+	h := &SaaSHive{
+		ID: id, Status: "running", Owner: "MattSweetIBM", Org: "MattSweetIBM",
+		Repos: []string{"s1netops"}, PrimaryRepo: "s1netops", ACMMLevel: 3,
+		ClusterID: defaultClusterID, ClaimDelivered: true,
+	}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+
+	// Before the repair every read path falls back to the placeholder host.
+	if got := claimedVanityURL(loadSaaSHive(id)); got != "" {
+		t.Fatalf("precondition: expected no vanity URL, got %q", got)
+	}
+
+	if !s.repairVanityURLForHive(id) {
+		t.Fatal("repair reported no change for a pre-vanity claimed hive")
+	}
+
+	got := loadSaaSHive(id)
+	if got.ID != id {
+		t.Errorf("repair changed the hive id: %q, want %q (ids are namespaces/SSO claims)", got.ID, id)
+	}
+	if got.VanityURL == "" {
+		t.Fatal("repair left the vanity URL empty")
+	}
+	// Derived from the claimed PROJECT, on the cluster domain — not the placeholder.
+	if !strings.HasPrefix(got.VanityURL, "https://hosted-mattsweetibm-s1netops-") {
+		t.Errorf("vanity URL %q is not derived from org/primary repo", got.VanityURL)
+	}
+	if !strings.HasSuffix(got.VanityURL, "."+vanityRepairTestDomain) {
+		t.Errorf("vanity URL %q is not on the cluster domain", got.VanityURL)
+	}
+	if strings.Contains(got.VanityURL, "placeholder") {
+		t.Errorf("vanity URL %q still carries the placeholder host", got.VanityURL)
+	}
+	// The whole point: the read paths now surface the vanity URL.
+	if v := claimedVanityURL(got); v != got.VanityURL {
+		t.Errorf("claimedVanityURL = %q, want %q", v, got.VanityURL)
+	}
+}
+
+// The repair must be idempotent: the heartbeat calls it on EVERY beat, and
+// generateHiveID mints a fresh random suffix per call, so a second run must not
+// change anything (otherwise the vanity host would churn every heartbeat).
+func TestVanityRepairIsIdempotent(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityRepairTestHub()
+
+	const id = "hosted-available-oke-01-placeholder-bb95"
+	if err := saveSaaSHive(&SaaSHive{
+		ID: id, Status: "running", Org: "TradingAsBuddies",
+		Repos: []string{"app"}, PrimaryRepo: "app", ACMMLevel: 2,
+		ClusterID: defaultClusterID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !s.repairVanityURLForHive(id) {
+		t.Fatal("first repair reported no change")
+	}
+	first := loadSaaSHive(id).VanityURL
+
+	if s.repairVanityURLForHive(id) {
+		t.Error("second repair changed an already-repaired hive")
+	}
+	if second := loadSaaSHive(id).VanityURL; second != first {
+		t.Errorf("vanity URL churned across beats: %q then %q", first, second)
+	}
+
+	// The same holds for the fleet sweep.
+	if n := s.repairVanityURLsForClaimedHives(); n != 0 {
+		t.Errorf("sweep over an already-repaired fleet changed %d hives, want 0", n)
+	}
+}
+
+// An UNCLAIMED placeholder must be left completely alone: assign owns it and
+// mints its vanity URL at claim time.
+func TestVanityRepairSkipsUnclaimedPlaceholder(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityRepairTestHub()
+
+	const id = "hosted-available-oke-09"
+	if err := saveSaaSHive(&SaaSHive{
+		ID: id, Status: statusAvailable, Owner: hubAdminUsername, ClusterID: defaultClusterID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.repairVanityURLForHive(id) {
+		t.Error("repair touched an unclaimed placeholder")
+	}
+	if v := loadSaaSHive(id).VanityURL; v != "" {
+		t.Errorf("unclaimed placeholder gained a vanity URL %q", v)
+	}
+}
+
+// A hive whose cluster the hub cannot reach (the firewalled vllm-d case: the hub
+// cannot kubectl to create a route) must keep its working placeholder host
+// rather than adopt an unserved vanity host that would 503 every hub link.
+func TestVanityRepairKeepsPlaceholderWhenHostNotServable(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityRepairTestHub()
+	s.vanityHostServable = func(_, _ string, _ *ClusterConfig) error {
+		return fmt.Errorf("cluster unreachable")
+	}
+
+	const id = "hosted-available-vllmd-10"
+	if err := saveSaaSHive(&SaaSHive{
+		ID: id, Status: "running", Org: "katamari",
+		Repos: []string{"ibm-aiops-orchestrator"}, PrimaryRepo: "ibm-aiops-orchestrator",
+		ACMMLevel: 2, ClusterID: defaultClusterID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.repairVanityURLForHive(id) {
+		t.Error("repair adopted a vanity host it could not make servable")
+	}
+	if v := loadSaaSHive(id).VanityURL; v != "" {
+		t.Errorf("unservable vanity host was adopted: %q — hub links would 503", v)
+	}
+	// claimedVanityURL therefore still yields nothing, so the placeholder stands.
+	if v := claimedVanityURL(loadSaaSHive(id)); v != "" {
+		t.Errorf("claimedVanityURL = %q, want \"\" so the working placeholder is used", v)
+	}
+}
+
+// A hive with an incomplete claim (no org, or no primary repo) has nothing to
+// derive a friendly host from, and a hive on a cluster with no domain likewise.
+func TestVanityRepairSkipsUnderivableHives(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityRepairTestHub()
+	s.clusters["no-domain"] = ClusterConfig{ID: "no-domain", Name: "nodomain"}
+
+	seed := []*SaaSHive{
+		{ID: "hosted-no-org", Status: "running", Repos: []string{"r"}, PrimaryRepo: "r", ClusterID: defaultClusterID},
+		{ID: "hosted-no-repo", Status: "running", Org: "o", ClusterID: defaultClusterID},
+		{ID: "hosted-no-domain", Status: "running", Org: "o", Repos: []string{"r"}, PrimaryRepo: "r", ClusterID: "no-domain"},
+	}
+	for _, h := range seed {
+		if err := saveSaaSHive(h); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, h := range seed {
+		if s.repairVanityURLForHive(h.ID) {
+			t.Errorf("%s: repair changed a hive with nothing to derive a host from", h.ID)
+		}
+		if v := loadSaaSHive(h.ID).VanityURL; v != "" {
+			t.Errorf("%s: gained a vanity URL %q", h.ID, v)
+		}
+	}
+}
+
+// An existing vanity URL is never re-minted or clobbered.
+func TestVanityRepairNeverClobbersExistingVanityURL(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityRepairTestHub()
+
+	const id = "hosted-has-vanity"
+	const existing = "https://hosted-acme-app-abcd.hive.kubestellar.io"
+	if err := saveSaaSHive(&SaaSHive{
+		ID: id, Status: "running", Org: "acme", Repos: []string{"app"}, PrimaryRepo: "app",
+		ClusterID: defaultClusterID, VanityURL: existing,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.repairVanityURLForHive(id) {
+		t.Error("repair changed a hive that already had a vanity URL")
+	}
+	if v := loadSaaSHive(id).VanityURL; v != existing {
+		t.Errorf("vanity URL = %q, want the untouched %q", v, existing)
+	}
+}
+
+// End-to-end: once repaired, the very next heartbeat must PUSH the vanity URL to
+// the spoke, so the spoke adopts it and the registry's dashboardUrl follows.
+// Without this the repair would only fix the hub's display and leave the spoke
+// reporting the placeholder forever.
+func TestRepairedVanityURLReachesSpokeViaHeartbeat(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityRepairTestHub()
+
+	const id = "hosted-available-oke-03-placeholder-y99x"
+	const placeholderURL = "https://hosted-available-oke-03-placeholder-y99x.hive.kubestellar.io"
+	if err := saveSaaSHive(&SaaSHive{
+		ID: id, Status: "running", Org: "IBM", Repos: []string{"s1netops"},
+		PrimaryRepo: "s1netops", ACMMLevel: 3, ClusterID: defaultClusterID,
+		ClaimDelivered: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Before the repair the hub has no vanity URL to push.
+	if pc := projectConfigForHiveID(id, "IBM", []string{"s1netops"}, "s1netops", 3, placeholderURL, ""); pc != nil && pc.DashboardURL != "" {
+		t.Fatalf("expected no vanity push before repair, got %+v", pc)
+	}
+
+	if !s.repairVanityURLForHive(id) {
+		t.Fatal("repair reported no change")
+	}
+	want := loadSaaSHive(id).VanityURL
+
+	pc := projectConfigForHiveID(id, "IBM", []string{"s1netops"}, "s1netops", 3, placeholderURL, "")
+	if pc == nil {
+		t.Fatal("repaired hive produced no heartbeat push — the spoke would keep the placeholder")
+	}
+	if pc.DashboardURL != want {
+		t.Errorf("pushed dashboard URL = %q, want %q", pc.DashboardURL, want)
+	}
+
+	// Once the spoke reports the vanity URL back, the reconcile goes quiet.
+	if pc2 := projectConfigForHiveID(id, "IBM", []string{"s1netops"}, "s1netops", 3, want, ""); pc2 != nil && pc2.DashboardURL != "" {
+		t.Errorf("still pushing after the spoke adopted the vanity URL: %+v", pc2)
+	}
+}


### PR DESCRIPTION
## The finding

**#2280 works as designed — but it can never fix an already-claimed hive.** The "only applies to new claims" hypothesis is **correct**.

`#2280` is a **read-time overlay**: `claimedVanityURL(h)` returns `h.VanityURL`, and My Hives / the SSO `/open` handoff / `migrateHive` all consult it. But `h.VanityURL` is **written in exactly one place** — `handleAssignHive`, at claim time (`saas.go:5621`). Verified by grep: no other non-test writer exists.

So a hive claimed *before* that code shipped keeps `VanityURL == ""` forever. `claimedVanityURL()` returns `""`, every read path falls back to the raw placeholder host, and **no number of heartbeats changes that** — the heartbeat push in `projectConfigForHiveID` is itself gated on `h.VanityURL != ""`. Nothing else ever fills it in. That is precisely the 14 hives with a real org and a placeholder id. The struct comment already admits the gap: *"Empty = unclaimed placeholder (or a **pre-vanity hive**)."*

Reproduced with a test on clean `origin/v2`: a hive with `Org: "MattSweetIBM"` and empty `VanityURL` yields `claimedVanityURL() == ""`.

**Also worth recording:** the hover URL `/api/saas/hives/{id}/open` is **not** a bug. `saas.go:10014` builds every hosted row's link that way unconditionally — it is a hub-side redirect endpoint, and it is keyed by `id` by design. The vanity URL matters as the *redirect target* and the *displayed* URL, not as the href.

## The fix

`repairVanityURLForHive`, called from the heartbeat path right after `repairGitHubHostForHive` — the same "only ran at assign time" bug class, deliberately mirroring its lazy-per-beat shape — and *before* the project config is built, so the URL-only push delivers it on that very beat.

The hive **`id` is not changed**, as specified: it is a k8s namespace suffix (`hive-hosted-<id>`), an ingress hostname, a per-agent socket path, and the SSO token's `h` claim. Only the displayed name and the opened URL become vanity.

### On the correctness trap (the unserved-host risk)

The vanity host is a genuinely **new DNS name** that resolves to nothing until an ingress/route exists. The claim path adopts it optimistically because provisioning is creating the spoke's routes anyway; a *retroactive* repair has no such guarantee. So this adopts the host **only after `addVanityHostToIngress` succeeds**. On failure it logs and leaves `VanityURL` empty, so the ugly-but-working placeholder stands. Firewalled heartbeat-only spokes (`vllm-d`) fail that call and correctly keep their placeholder — no link is ever swapped for a 503.

The 14 affected hives are on `hive-oke` (nginx, `InCluster: true`), which the hub *can* patch, so they are repairable.

### Other guards

- Unclaimed placeholders skipped — assign still owns those.
- An existing `VanityURL` is never re-minted. Important: `generateHiveID` mints a **fresh random suffix per call**, so re-minting would churn the host on every heartbeat. This is what makes it idempotent.
- Incomplete claims (no org / no primary repo) and domainless clusters are skipped.

## Tests

`v2/pkg/hub/vanity_url_repair_test.go` — claimed hive gets a vanity URL with `id` unchanged; unclaimed placeholder untouched; idempotent (per-hive and fleet sweep); unreachable cluster keeps the placeholder (registry-only path); underivable hives skipped; existing vanity URL never clobbered; and an end-to-end check that the repaired URL actually reaches the spoke on the next heartbeat.

## Verification

- `go build ./...`, `go vet ./...` — clean.
- `go test ./pkg/hub/ -run 'Vanity|RepairedVanity|GitHubHost'` — pass, including #2280's own tests.
- `gofmt` clean on the three touched files only.
- `v2/pkg/hub/saas.go` is **not touched**, so the inline-JS raw-string invariant is unaffected. Zero backticks added anywhere.
- `TestLoadAppPrivateKeyKubectlFails` fails **identically on clean `origin/v2`** (local-env artifact: a real kubeconfig is present) — pre-existing, unrelated.

## Porting

Needs porting to **mk, dd and v3**.