### PR TITLE
🐛 fix(hub): refuse invalid image tags before patching a Deployment

### DIFF
--- a/v2/pkg/hub/hub_coverage_deep_test.go
+++ b/v2/pkg/hub/hub_coverage_deep_test.go
@@ -777,7 +777,7 @@ func TestHandleHeartbeatAutoUpgradeSpokeRequest(t *testing.T) {
 
 	// Set latest SHA
 	latestSHAMu.Lock()
-	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "target1", Message: "latest"}
+	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "7a41e01", Message: "latest"}
 	latestSHAMu.Unlock()
 	defer func() {
 		latestSHAMu.Lock()
@@ -797,8 +797,8 @@ func TestHandleHeartbeatAutoUpgradeSpokeRequest(t *testing.T) {
 
 	var resp HeartbeatResponse
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp.UpgradeTo != "target1" {
-		t.Errorf("upgrade_to = %q, want target1", resp.UpgradeTo)
+	if resp.UpgradeTo != "7a41e01" {
+		t.Errorf("upgrade_to = %q, want 7a41e01", resp.UpgradeTo)
 	}
 }
 

--- a/v2/pkg/hub/hub_coverage_extra_test.go
+++ b/v2/pkg/hub/hub_coverage_extra_test.go
@@ -1195,7 +1195,7 @@ func TestHandleHeartbeatUpgradingFlag(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
-	payload := `{"hive_id":"upgrading-flag-test","upgrading":true,"upgrade_target_sha":"target1"}`
+	payload := `{"hive_id":"upgrading-flag-test","upgrading":true,"upgrade_target_sha":"7a41e01"}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/v2/pkg/hub/hub_coverage_extra_test.go
+++ b/v2/pkg/hub/hub_coverage_extra_test.go
@@ -398,17 +398,51 @@ func TestHandleHubAutoUpgradeEnable(t *testing.T) {
 // handleHubSelfUpgrade
 // ============================================================
 
+// TestHandleHubSelfUpgrade asserts the handler REFUSES to upgrade when no
+// target SHA is known, and does so without touching a cluster.
+//
+// The previous version of this test asserted nothing: it accepted both 200 and
+// 500 and merely t.Logf'd anything else, so it could not fail. Worse, its
+// premise was wrong. It reasoned "will fail because kubectl doesn't exist or
+// cluster not accessible" — untrue inside a hive pod, where kubectl exists and
+// the pod's ServiceAccount holds patch on the hub Deployment. Combined with a
+// sibling test seeding latestSHAByBranch["v2"] = "target1", it issued a real
+//
+//	kubectl set image deployment/hive-hub hub=ghcr.io/kubestellar/hive-hub:target1
+//
+// against production, leaving the hub serving stale code behind an
+// ImagePullBackOff. See TestMain, which removes the in-cluster credentials
+// that made it reachable.
+//
+// The SHA cache is a package-level global shared across the suite, so this
+// clears it and restores it rather than assuming a starting state.
 func TestHandleHubSelfUpgrade(t *testing.T) {
+	latestSHAMu.Lock()
+	saved, had := latestSHAByBranch["v2"]
+	delete(latestSHAByBranch, "v2")
+	latestSHAMu.Unlock()
+	t.Cleanup(func() {
+		latestSHAMu.Lock()
+		if had {
+			latestSHAByBranch["v2"] = saved
+		} else {
+			delete(latestSHAByBranch, "v2")
+		}
+		latestSHAMu.Unlock()
+	})
+
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("POST", "/hub-self-upgrade", nil)
 	w := httptest.NewRecorder()
 	srv.handleHubSelfUpgrade(w, req)
 
-	// Will fail because kubectl doesn't exist or cluster not accessible
-	// but exercises the code path
-	if w.Code != http.StatusInternalServerError && w.Code != http.StatusOK {
-		t.Logf("hub self-upgrade: %d", w.Code)
+	// No cached SHA means an empty target, which rolloutHubToSHA must reject
+	// before it ever builds a kubectl command. This is deterministic: it does
+	// not depend on whether a cluster happens to be reachable.
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("hub self-upgrade with no target SHA: got %d, want %d",
+			w.Code, http.StatusInternalServerError)
 	}
 }
 

--- a/v2/pkg/hub/image_tag_validation.go
+++ b/v2/pkg/hub/image_tag_validation.go
@@ -1,0 +1,133 @@
+package hub
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Image-tag validation for every path that writes a container image onto a
+// running Deployment (hub self-upgrade and spoke upgrade/branch-switch).
+//
+// Why this exists: on 2026-07-27 the hub's own Deployment was patched to
+// `ghcr.io/kubestellar/hive-hub:target1`. `target1` is not a tag that has ever
+// been published — it is a TEST FIXTURE SHA (see setV2Latest(t, "target1") in
+// saas_edge_coverage_test.go) that reached a real cluster because the hub's
+// unit tests shell out to a real `kubectl` while KUBERNETES_SERVICE_HOST is
+// still set in the pod environment. The new ReplicaSet went
+// ImagePullBackOff, the OLD ReplicaSet kept serving, and the hub therefore
+// looked healthy for ~20 minutes while silently running stale code. Nothing
+// alerted; it was found only because an expected UI fix was missing.
+//
+// The lesson generalizes past that one fixture: writing an unresolvable tag
+// takes a component down SILENTLY, because Kubernetes keeps the old ReplicaSet
+// up. Refusing to patch is strictly safer — the component keeps running its
+// last good image and the refusal is loud and actionable. So every writer now
+// validates the tag first and refuses anything that is not a recognizable
+// build artifact.
+
+const (
+	// minImageTagSHALen / maxImageTagSHALen bound a git SHA tag. The hub
+	// normalizes branch SHAs to StandardSHALen (7) via shortSHA, but a spoke or
+	// an admin may legitimately supply a longer prefix or the full 40-character
+	// SHA, so accept the whole abbreviation range git itself allows.
+	minImageTagSHALen = StandardSHALen
+	maxImageTagSHALen = 40
+
+	// mutableChannelTagSuffix is the suffix CI (.github/workflows/docker.yml)
+	// appends when it republishes a floating per-branch tag in place, e.g.
+	// v2-latest / v3-latest / mk-latest / dd-latest. The branch part is
+	// branchToTag(branch), so it may contain '-' from a slashed branch name
+	// (feat/x -> feat-x-latest) — which is why the channel form is matched by
+	// pattern rather than against a fixed allowlist of branch names.
+	mutableChannelTagSuffix = mutableTagSuffix
+
+	// maxImageTagLen is the OCI limit on a tag: 128 characters total. A value
+	// longer than this could never resolve on any registry.
+	maxImageTagLen = 128
+)
+
+// imageTagSHAPattern matches an immutable git-SHA tag: lowercase hex only, of a
+// length git accepts as an abbreviation. Anchored, so an identifier that merely
+// CONTAINS hex characters (the `target1` class of bug — a bare identifier, or a
+// leaked `$target`/`${target}1` template variable) cannot slip through.
+var imageTagSHAPattern = regexp.MustCompile(
+	fmt.Sprintf(`^[0-9a-f]{%d,%d}$`, minImageTagSHALen, maxImageTagSHALen),
+)
+
+// imageTagChannelPattern matches a mutable channel tag: a branchToTag-sanitized
+// branch name followed by "-latest". The branch part allows the characters a
+// git branch can carry once '/' has been replaced by '-' (alphanumerics, '-',
+// '_', '.') and must start alphanumeric so a stray leading dash cannot pass.
+var imageTagChannelPattern = regexp.MustCompile(
+	`^[0-9A-Za-z][0-9A-Za-z._-]*` + regexp.QuoteMeta(mutableChannelTagSuffix) + `$`,
+)
+
+// validateImageTag reports whether tag is a shape we are willing to write onto
+// a live Deployment: either an immutable git-SHA tag or a mutable
+// "<branch>-latest" channel tag. Anything else — empty, an identifier like
+// `target1`, an unsubstituted `$target`, or a value over the OCI length limit —
+// is refused with an error naming the exact offending value.
+//
+// This is deliberately a shape check, not an existence check. Existence is
+// verified separately and over the network (hubImageExists); shape is free,
+// deterministic, and catches the class of bug that produced `target1` — a value
+// that was never a tag at all.
+func validateImageTag(tag string) error {
+	if tag == "" {
+		return fmt.Errorf("refusing to patch deployment image: tag is empty")
+	}
+	if strings.TrimSpace(tag) != tag {
+		return fmt.Errorf("refusing to patch deployment image: tag %q has leading/trailing whitespace", tag)
+	}
+	if len(tag) > maxImageTagLen {
+		return fmt.Errorf("refusing to patch deployment image: tag %q is %d chars, over the %d-char OCI limit",
+			tag, len(tag), maxImageTagLen)
+	}
+	if imageTagSHAPattern.MatchString(tag) {
+		return nil
+	}
+	if imageTagChannelPattern.MatchString(tag) {
+		return nil
+	}
+	return fmt.Errorf(
+		"refusing to patch deployment image: tag %q is neither a %d-%d char hex git SHA nor a %q channel tag "+
+			"(an unresolvable tag silently strands the component on its old ReplicaSet)",
+		tag, minImageTagSHALen, maxImageTagSHALen, mutableChannelTagSuffix)
+}
+
+// imageRefTag returns the tag portion of a full image reference
+// (ghcr.io/org/repo:tag). It mirrors imageTagIsMutable's parsing: only the part
+// after the LAST colon is a tag, and only when no '/' follows it — otherwise
+// that colon introduces a registry port (host:5000/repo). A digest pin
+// (repo@sha256:...) has no tag to validate.
+func imageRefTag(image string) (string, bool) {
+	if strings.Contains(image, "@") {
+		return "", false // digest pin — immutable by construction
+	}
+	idx := strings.LastIndex(image, ":")
+	if idx < 0 || strings.Contains(image[idx+1:], "/") {
+		return "", false
+	}
+	return image[idx+1:], true
+}
+
+// validateImageRef validates the tag embedded in a full image reference. A
+// reference with no parseable tag is refused too: an untagged image resolves to
+// :latest, which is never what an upgrade path means to write.
+func validateImageRef(image string) error {
+	if image == "" {
+		return fmt.Errorf("refusing to patch deployment image: image reference is empty")
+	}
+	tag, ok := imageRefTag(image)
+	if !ok {
+		if strings.Contains(image, "@") {
+			return nil // digest pin is a valid, fully-resolved reference
+		}
+		return fmt.Errorf("refusing to patch deployment image: image %q has no tag", image)
+	}
+	if err := validateImageTag(tag); err != nil {
+		return fmt.Errorf("%w (image %q)", err, image)
+	}
+	return nil
+}

--- a/v2/pkg/hub/image_tag_validation_test.go
+++ b/v2/pkg/hub/image_tag_validation_test.go
@@ -1,0 +1,212 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateImageTagRefusesMalformed(t *testing.T) {
+	// Every one of these would have been written straight onto a live
+	// Deployment before this change, stranding the component on
+	// ImagePullBackOff behind a still-serving old ReplicaSet.
+	bad := []struct {
+		tag string
+		why string
+	}{
+		{"target1", "the literal value from the 2026-07-27 hub outage: a test fixture SHA, not a tag"},
+		{"", "empty"},
+		{"$target", "unsubstituted shell variable"},
+		{"${target}", "unsubstituted shell variable with braces"},
+		{"$target1", "unsubstituted shell variable with index"},
+		{"target", "bare identifier"},
+		{"latest", "not a channel tag we publish per-branch"},
+		{"abc", "hex but too short to be a git SHA"},
+		{"g45d2e9", "'g' is not a hex digit"},
+		{"F45D2E9", "uppercase hex is not how git prints short SHAs"},
+		{"  f45d2e9", "leading whitespace"},
+		{"f45d2e9\n", "trailing newline"},
+		{"-latest", "channel tag with no branch part"},
+		{strings.Repeat("a", maxImageTagLen+1), "over the OCI tag length limit"},
+	}
+	for _, tc := range bad {
+		if err := validateImageTag(tc.tag); err == nil {
+			t.Errorf("validateImageTag(%q) = nil, want error (%s)", tc.tag, tc.why)
+		} else if !strings.Contains(err.Error(), "refusing to patch") {
+			t.Errorf("validateImageTag(%q) error = %q, want an actionable 'refusing to patch' message", tc.tag, err)
+		}
+	}
+}
+
+func TestValidateImageTagAcceptsValid(t *testing.T) {
+	good := []string{
+		"f45d2e9",  // canonical 7-char short SHA (the manual recovery tag)
+		"438a9f2b", // 8-char abbreviation
+		"f45d2e9b1c3a4e5f6789012345678901234567ab", // full 40-char SHA
+		"v2-latest",
+		"v3-latest",
+		"mk-latest",
+		"dd-latest",
+		"feat-vanity-url-latest", // branchToTag("feat/vanity-url") + "-latest"
+	}
+	for _, tag := range good {
+		if err := validateImageTag(tag); err != nil {
+			t.Errorf("validateImageTag(%q) = %v, want nil", tag, err)
+		}
+	}
+}
+
+func TestValidateImageRef(t *testing.T) {
+	if err := validateImageRef("ghcr.io/kubestellar/hive-hub:target1"); err == nil {
+		t.Error("validateImageRef accepted the outage image reference, want refusal")
+	}
+	if err := validateImageRef("ghcr.io/kubestellar/hive-hub:f45d2e9"); err != nil {
+		t.Errorf("validateImageRef(valid SHA ref) = %v, want nil", err)
+	}
+	if err := validateImageRef("ghcr.io/kubestellar/hive:v2-latest"); err != nil {
+		t.Errorf("validateImageRef(valid channel ref) = %v, want nil", err)
+	}
+	// A registry port must not be mistaken for a tag.
+	if err := validateImageRef("registry.local:5000/kubestellar/hive"); err == nil {
+		t.Error("validateImageRef accepted an untagged image, want refusal")
+	}
+	// Digest pins are already fully resolved.
+	if err := validateImageRef("ghcr.io/kubestellar/hive-hub@sha256:" + strings.Repeat("a", 64)); err != nil {
+		t.Errorf("validateImageRef(digest pin) = %v, want nil", err)
+	}
+	if err := validateImageRef(""); err == nil {
+		t.Error("validateImageRef(\"\") = nil, want error")
+	}
+}
+
+// TestRolloutHubToSHARefusesBogusTagWithoutPatching is the regression test for
+// the outage: a malformed target must be refused BEFORE kubectl runs, and must
+// leave the deployment untouched.
+func TestRolloutHubToSHARefusesBogusTagWithoutPatching(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	// Record every kubectl invocation so we can assert none happened.
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "calls.log")
+	script := "#!/bin/sh\necho \"$*\" >> " + logPath + "\nexit 0\n"
+	kubectlPath := filepath.Join(dir, "kubectl")
+	if err := os.WriteFile(kubectlPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// If validation were bypassed, hubImageExists would be consulted next —
+	// make it loudly fail the test rather than silently allow the patch.
+	oldImgCheck := hubImageExists
+	hubImageExists = func(sha string, _ *slog.Logger) bool {
+		t.Errorf("hubImageExists called for %q — validation should have refused first", sha)
+		return true
+	}
+	t.Cleanup(func() { hubImageExists = oldImgCheck })
+
+	s := &HubServer{
+		logger:       slog.Default(),
+		hubSecret:    testHubSecret,
+		hubGitBranch: "v2",
+		clusters:     map[string]ClusterConfig{defaultClusterID: {ID: defaultClusterID, InCluster: true}},
+	}
+
+	for _, bogus := range []string{"target1", "$target", "target"} {
+		err := s.rolloutHubToSHA(bogus)
+		if err == nil {
+			t.Fatalf("rolloutHubToSHA(%q) = nil, want refusal", bogus)
+		}
+		if !strings.Contains(err.Error(), "refusing to patch") {
+			t.Errorf("rolloutHubToSHA(%q) error = %q, want an actionable refusal", bogus, err)
+		}
+		// The refusal must be visible in hub status, not just in logs.
+		if fault := s.HubUpgradeFault(); !strings.Contains(fault, bogus) {
+			t.Errorf("HubUpgradeFault() = %q, want it to name the refused tag %q", fault, bogus)
+		}
+	}
+
+	// Nothing may have reached kubectl.
+	if data, err := os.ReadFile(logPath); err == nil && len(strings.TrimSpace(string(data))) > 0 {
+		t.Errorf("kubectl was invoked during a refused rollout:\n%s", data)
+	}
+}
+
+// TestHubUpgradeStateSurfacesFault asserts a refused/stuck upgrade shows as
+// "failed" rather than a reassuring "queued".
+func TestHubUpgradeStateSurfacesFault(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	setV2Latest(t, "f45d2e9")
+
+	s := &HubServer{
+		logger:       slog.Default(),
+		hubSecret:    testHubSecret,
+		hubGitBranch: "v2",
+		hubGitHash:   "0000000", // behind latest
+		clusters:     map[string]ClusterConfig{defaultClusterID: {ID: defaultClusterID, InCluster: true}},
+	}
+	if got := s.hubUpgradeState(); got == hubUpgradeStateFailed {
+		t.Fatalf("hubUpgradeState() = %q before any fault, want a non-failed state", got)
+	}
+	s.setHubUpgradeFault("refused invalid image tag \"target1\"")
+	if got := s.hubUpgradeState(); got != hubUpgradeStateFailed {
+		t.Errorf("hubUpgradeState() = %q after a fault, want %q", got, hubUpgradeStateFailed)
+	}
+}
+
+// TestSwitchImageSelfRefusesBogusTag covers the SHARED spoke helper. This is the
+// path that would strand spokes, which is worse than the hub outage: a spoke
+// stuck on an old ReplicaSet keeps reporting its OLD git hash, so the hub
+// re-sends the same doomed target on every heartbeat, forever.
+func TestSwitchImageSelfRefusesBogusTag(t *testing.T) {
+	for _, image := range []string{
+		"ghcr.io/kubestellar/hive:target1",
+		"ghcr.io/kubestellar/hive:$target",
+		"ghcr.io/kubestellar/hive:",
+		"",
+	} {
+		err := SwitchImageSelf(slog.Default(), image)
+		if err == nil {
+			t.Errorf("SwitchImageSelf(%q) = nil, want refusal", image)
+			continue
+		}
+		if !strings.Contains(err.Error(), "refusing to patch") {
+			t.Errorf("SwitchImageSelf(%q) error = %q, want an actionable refusal", image, err)
+		}
+	}
+}
+
+// TestHandleSwitchBranchRefusesBogusTag asserts the hub-side spoke writer
+// refuses a branch that does not sanitize into a valid channel tag.
+func TestHandleSwitchBranchRefusesBogusTag(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, "alice")
+
+	h := &SaaSHive{ID: "h1", Owner: "alice"}
+	saveSaaSHive(h)
+
+	s := &HubServer{
+		logger:             slog.Default(),
+		hubSecret:          testHubSecret,
+		saveCh:             make(chan struct{}, 1),
+		heartbeatUpgrade:   make(map[string]string),
+		heartbeatSwitchTag: make(map[string]string),
+		clusters:           map[string]ClusterConfig{defaultClusterID: {ID: defaultClusterID, InCluster: true}},
+	}
+
+	// A branch whose sanitized tag starts with '-' cannot form a valid channel
+	// tag. It must be rejected, not written to the spoke's Deployment.
+	rec := httptest.NewRecorder()
+	req := reqWithUser(http.MethodPost, "/api/saas/hives/h1/switch-branch", `{"branch":"-bad"}`, "alice")
+	req.SetPathValue("id", "h1")
+	s.handleSwitchBranch(rec, req)
+	if rec.Code == http.StatusOK {
+		t.Errorf("handleSwitchBranch accepted a branch that maps to an invalid tag: %s", rec.Body.String())
+	}
+}

--- a/v2/pkg/hub/main_test.go
+++ b/v2/pkg/hub/main_test.go
@@ -1,0 +1,42 @@
+package hub
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain isolates the hub test suite from any real Kubernetes cluster.
+//
+// Why this exists: many hub tests exercise handlers that shell out to `kubectl`
+// (rolloutHubToSHA, handleSwitchBranch, triggerAutoUpgrades, ...). Those tests
+// usually install a scripted fake kubectl on PATH, but several deliberately run
+// a "kubectl fails" branch FIRST, with the real binary still on PATH.
+//
+// kubectlArgsForCluster builds in-cluster credentials from KUBERNETES_SERVICE_HOST
+// and KUBERNETES_SERVICE_PORT. When the suite runs anywhere those are set — most
+// importantly inside a hive pod, where agents run the tests — a real kubectl
+// reaches the REAL API server using the pod's ServiceAccount, which holds patch
+// on the hub Deployment.
+//
+// That is exactly how the 2026-07-27 outage happened: TestHandleHubSelfUpgrade_Edge
+// seeds the SHA cache with the fixture value "target1" and calls
+// handleHubSelfUpgrade, producing a literal
+//
+//	kubectl set image deployment/hive-hub hub=ghcr.io/kubestellar/hive-hub:target1 -n hive-hub
+//
+// against the live cluster. `target1` was never a published tag, so the new
+// ReplicaSet went ImagePullBackOff while the old one kept serving — the hub
+// looked healthy for ~20 minutes while silently running stale code.
+//
+// Clearing these two variables makes kubectlArgsForCluster omit --server/--token,
+// so a stray real kubectl has no cluster to talk to and fails locally instead of
+// mutating production. Tests that WANT kubectl behavior still get it from their
+// scripted fake on PATH, which ignores these flags entirely.
+func TestMain(m *testing.M) {
+	os.Unsetenv("KUBERNETES_SERVICE_HOST")
+	os.Unsetenv("KUBERNETES_SERVICE_PORT")
+	// KUBECONFIG could equally point a real kubectl at a real cluster for the
+	// non-InCluster branch, so neutralize it to a path that cannot exist.
+	os.Setenv("KUBECONFIG", os.DevNull)
+	os.Exit(m.Run())
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2486,6 +2486,21 @@ func (s *HubServer) rolloutHubToSHA(sha string) error {
 	if sha == "" {
 		return fmt.Errorf("empty target SHA")
 	}
+	// Shape-check the tag BEFORE it can reach a live Deployment. Writing an
+	// unresolvable tag (the `target1` incident — a test fixture SHA that escaped
+	// to the real cluster) leaves the new ReplicaSet in ImagePullBackOff while
+	// the old one keeps serving: the hub stays "up" but silently runs stale
+	// code. Refusing here leaves the last good image running and makes the
+	// failure loud instead of invisible.
+	if err := validateImageTag(sha); err != nil {
+		s.logger.Error("hub self-upgrade REFUSED: invalid image tag",
+			"tag", sha,
+			"deployment", hubDeploymentName,
+			"namespace", hubNamespace,
+			"error", err)
+		s.setHubUpgradeFault(fmt.Sprintf("refused invalid image tag %q: %v", sha, err))
+		return err
+	}
 	if !hubImageExists(sha, s.logger) {
 		return fmt.Errorf("hub image %s:%s not published yet", ghcrRepoHub, sha)
 	}
@@ -2498,8 +2513,98 @@ func (s *HubServer) rolloutHubToSHA(sha string) error {
 	s.hubUpgradeMu.Lock()
 	s.lastHubUpgradeTrigger = time.Now()
 	s.hubUpgradeTarget = sha
+	s.hubUpgradeFault = "" // a fresh, validated rollout clears any prior refusal
 	s.hubUpgradeMu.Unlock()
+	// Watch the rollout land. Detect-and-report only: an auto-rollback would
+	// race the upgrade poller (which re-triggers the same target every cycle),
+	// so a rollback could fight the upgrade loop and flap the deployment. See
+	// watchHubRollout.
+	go s.watchHubRollout(sha, image)
 	return nil
+}
+
+// hubRolloutWatchTimeout bounds how long we wait for a self-upgrade we just
+// triggered to become Ready before flagging it as stuck. The hub's own image is
+// a few hundred MB and a cold node has to pull it, so this is generous enough
+// to avoid false alarms while still catching an ImagePullBackOff — which
+// back-off-retries indefinitely and would otherwise never surface.
+const hubRolloutWatchTimeout = 5 * time.Minute
+
+// hubRolloutPollInterval is how often watchHubRollout re-checks rollout status.
+const hubRolloutPollInterval = 15 * time.Second
+
+// watchHubRollout confirms a self-upgrade actually became Ready, and records a
+// loud, user-visible fault if it did not.
+//
+// It deliberately does NOT roll back. The auto-upgrade poller re-evaluates the
+// same target every cycle, so an automatic rollback would immediately be undone
+// and re-applied, flapping the deployment during an already-degraded window.
+// Detect and report is the safe half of the loop: the operator sees the stuck
+// upgrade in the UI and in the logs, and decides.
+func (s *HubServer) watchHubRollout(sha, image string) {
+	deadline := time.Now().Add(hubRolloutWatchTimeout)
+	for time.Now().Before(deadline) {
+		time.Sleep(hubRolloutPollInterval)
+		// `rollout status --timeout=0s` returns non-zero while a rollout is
+		// still progressing and zero once it has fully succeeded.
+		cmd := kubectlForCluster(s.hubCluster(), "rollout", "status",
+			"deployment/"+hubDeploymentName, "-n", hubNamespace, "--timeout=0s")
+		if err := cmd.Run(); err == nil {
+			s.hubUpgradeMu.Lock()
+			s.hubUpgradeFault = ""
+			s.hubUpgradeMu.Unlock()
+			s.logger.Info("hub self-upgrade rollout completed", "sha", sha, "image", image)
+			return
+		}
+	}
+	// Still not Ready. Pull the pod-level reason so the log names the actual
+	// cause (ImagePullBackOff / ErrImagePull / CrashLoopBackOff) rather than
+	// just "timed out".
+	reason := s.hubRolloutFailureReason()
+	s.logger.Error("hub self-upgrade STUCK: new ReplicaSet not Ready — hub is still serving the OLD image",
+		"sha", sha,
+		"image", image,
+		"deployment", hubDeploymentName,
+		"namespace", hubNamespace,
+		"waited", hubRolloutWatchTimeout.String(),
+		"reason", reason)
+	s.setHubUpgradeFault(fmt.Sprintf("upgrade to %s stuck after %s: %s (still serving the previous image)",
+		image, hubRolloutWatchTimeout, reason))
+}
+
+// hubRolloutFailureReason best-effort extracts why the hub's pods are not
+// Ready, so the stuck-rollout log/status names the real cause.
+func (s *HubServer) hubRolloutFailureReason() string {
+	const reasonJSONPath = `{range .items[*].status.containerStatuses[*]}{.state.waiting.reason}{" "}{.state.waiting.message}{"\n"}{end}`
+	cmd := kubectlForCluster(s.hubCluster(), "get", "pods",
+		"-n", hubNamespace, "-l", "app="+hubDeploymentName,
+		"-o", "jsonpath="+reasonJSONPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "unknown (could not read pod status)"
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			return line
+		}
+	}
+	return "unknown (no waiting container state reported)"
+}
+
+// setHubUpgradeFault records a self-upgrade failure for the dashboard so a
+// stuck or refused upgrade is visible in the UI, not only in `kubectl describe`.
+func (s *HubServer) setHubUpgradeFault(msg string) {
+	s.hubUpgradeMu.Lock()
+	s.hubUpgradeFault = msg
+	s.hubUpgradeMu.Unlock()
+}
+
+// HubUpgradeFault returns the current self-upgrade fault message, or "" when
+// the last upgrade attempt was healthy.
+func (s *HubServer) HubUpgradeFault() string {
+	s.hubUpgradeMu.Lock()
+	defer s.hubUpgradeMu.Unlock()
+	return s.hubUpgradeFault
 }
 
 // hubUpgradeState reports the hub's own upgrade status for the dashboard badge:
@@ -2509,6 +2614,9 @@ func (s *HubServer) rolloutHubToSHA(sha string) error {
 //   - "queued"    — behind latest, auto-upgrade ON, no rollout in flight yet
 //     (the poller will trigger one shortly)
 //   - "behind"    — behind latest, auto-upgrade OFF (admin must click Upgrade)
+//   - "failed"    — an upgrade was REFUSED (malformed image tag) or its rollout
+//     never became Ready. The hub is behind and cannot self-heal;
+//     an operator must look. HubUpgradeFault() carries the reason.
 //   - "unknown"   — latest SHA not resolved yet
 //
 // This is the field the badge needs: previously the frontend could only tell an
@@ -2528,7 +2636,14 @@ func (s *HubServer) hubUpgradeState() string {
 	s.hubUpgradeMu.Lock()
 	inFlight := s.hubUpgradeTarget != "" &&
 		time.Since(s.lastHubUpgradeTrigger) < hubUpgradeDebounce
+	fault := s.hubUpgradeFault
 	s.hubUpgradeMu.Unlock()
+	// A refused or stuck upgrade outranks "upgrading"/"queued": the hub is
+	// behind AND cannot get there on its own, which needs an operator. Without
+	// this the badge showed a reassuring "queued" while the rollout was wedged.
+	if fault != "" {
+		return hubUpgradeStateFailed
+	}
 	if inFlight {
 		return "upgrading"
 	}
@@ -2676,6 +2791,15 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 	ns := "hive-hosted-" + id
 	imageTag := branchToTag(body.Branch) + "-latest"
 	image := "ghcr.io/kubestellar/hive:" + imageTag
+	// Refuse a branch name that sanitizes into something that is not a valid
+	// channel tag, rather than stranding the spoke on ImagePullBackOff behind a
+	// still-serving old ReplicaSet.
+	if err := validateImageTag(imageTag); err != nil {
+		s.logger.Error("branch switch REFUSED: invalid image tag",
+			"hive", id, "branch", body.Branch, "tag", imageTag, "error", err)
+		http.Error(w, `{"error":"branch does not map to a valid image tag"}`, http.StatusBadRequest)
+		return
+	}
 	// "*=" updates every container including init containers (copy-config,
 	// init-permissions) — pinning only "hive" left inits on the old branch tag.
 	cmd := kubectlForCluster(cluster, "set", "image", "deployment/hive", "*="+image, "-n", ns)
@@ -3009,6 +3133,11 @@ const (
 	hubDeploymentName = "hive-hub"
 	hubContainerName  = "hub"
 	hubNamespace      = "hive-hub"
+
+	// hubUpgradeStateFailed is the hubUpgradeState() value meaning the hub is
+	// behind latest AND its last upgrade attempt was refused or wedged, so it
+	// cannot reach latest without operator action.
+	hubUpgradeStateFailed = "failed"
 )
 
 // hubImageExists reports whether the hub's own container image is published on

--- a/v2/pkg/hub/saas_edge_coverage_test.go
+++ b/v2/pkg/hub/saas_edge_coverage_test.go
@@ -144,7 +144,7 @@ func TestHandleHubSelfUpgrade_Edge(t *testing.T) {
 	defer cleanup()
 
 	// A latest v2 SHA must be resolved for the handler to have a target.
-	setV2Latest(t, "target1")
+	setV2Latest(t, "7a41e01")
 	// Stub the GHCR hub-image check so tests don't hit the network; assume the
 	// hub image exists for the success path.
 	oldImgCheck := hubImageExists

--- a/v2/pkg/hub/self_upgrade.go
+++ b/v2/pkg/hub/self_upgrade.go
@@ -67,6 +67,18 @@ func RolloutRestartSelf(logger *slog.Logger) error {
 // deployment/hive). A strategic-merge patch merges containers by name, so we
 // enumerate the deployment's containers first and set each image.
 func SwitchImageSelf(logger *slog.Logger, image string) error {
+	// Same contract as the hub self-upgrade: never write a tag that cannot
+	// resolve. A spoke that patches itself to a bogus tag goes
+	// ImagePullBackOff while its old ReplicaSet keeps serving — it looks alive,
+	// silently runs stale code, and keeps reporting the OLD git hash, so the
+	// hub re-sends the same doomed target every heartbeat forever.
+	if err := validateImageRef(image); err != nil {
+		logger.Error("self image switch REFUSED: invalid image reference",
+			"image", image,
+			"deployment", selfUpgradeDeployName,
+			"error", err)
+		return err
+	}
 	ns, err := os.ReadFile(k8sNamespacePath)
 	if err != nil {
 		return fmt.Errorf("reading namespace: %w", err)

--- a/v2/pkg/hub/self_upgrade_coverage_test.go
+++ b/v2/pkg/hub/self_upgrade_coverage_test.go
@@ -174,7 +174,7 @@ func TestSwitchImageSelfSuccess(t *testing.T) {
 	defer srv.Close()
 	withFakeK8sAPI(t, srv)
 
-	if err := SwitchImageSelf(slog.Default(), "ghcr.io/kubestellar/hive:dev-abc"); err != nil {
+	if err := SwitchImageSelf(slog.Default(), "ghcr.io/kubestellar/hive:dev-latest"); err != nil {
 		t.Fatalf("SwitchImageSelf: %v", err)
 	}
 }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -463,10 +463,16 @@ type HubServer struct {
 	// the admin-triggered path. hubUpgradeTarget is the SHA being rolled to.
 	lastHubUpgradeTrigger time.Time
 	hubUpgradeTarget      string
-	hubUpgradeMu          sync.Mutex // guards lastHubUpgradeTrigger + hubUpgradeTarget
-	httpServer            *http.Server
-	httpMu                sync.Mutex // guards httpServer (Start runs in a goroutine; Shutdown races it)
-	clusters              map[string]ClusterConfig
+	// hubUpgradeFault holds a human-readable reason the last self-upgrade did
+	// not land: a refused (malformed) image tag, or a rollout that never became
+	// Ready. Empty means healthy. It exists so a stuck upgrade is visible in the
+	// dashboard instead of only in `kubectl describe` — the `target1` incident
+	// left the hub serving stale code for ~20 minutes with nothing surfaced.
+	hubUpgradeFault string
+	hubUpgradeMu    sync.Mutex // guards lastHubUpgradeTrigger + hubUpgradeTarget + hubUpgradeFault
+	httpServer      *http.Server
+	httpMu          sync.Mutex // guards httpServer (Start runs in a goroutine; Shutdown races it)
+	clusters        map[string]ClusterConfig
 
 	// vanityHostServable overrides how the retroactive vanity-URL repair makes a
 	// vanity host servable (see makeVanityHostServable). nil in production, where


### PR DESCRIPTION
## Summary

This caused a **silent ~20 minute hub outage** on 2026-07-27. The hub Deployment was patched to `ghcr.io/kubestellar/hive-hub:target1` — a tag that has never existed. The new ReplicaSet went `ImagePullBackOff`, the **old ReplicaSet kept serving**, so the hub stayed *up* and healthy-looking while silently running stale code. PR #2280 had merged but never deployed. Nothing alerted; it was found only because an expected UI fix was missing.

## Root cause (verified, not guessed)

`target1` is a **test fixture SHA**, not a template-substitution bug.

`pkg/hub` tests shell out to a real `kubectl`, and several deliberately exercise a *"kubectl fails"* branch **before** installing their scripted fake. `kubectlArgsForCluster` builds in-cluster credentials from `KUBERNETES_SERVICE_HOST`/`KUBERNETES_SERVICE_PORT` — which **no test ever unset**. So running the suite inside a hive pod (where agents run tests) aims a real `kubectl` at the **real API server** using the pod's ServiceAccount, which holds `patch` on the hub Deployment.

`TestHandleHubSelfUpgrade_Edge` seeds the SHA cache with `setV2Latest(t, "target1")` and calls `handleHubSelfUpgrade`, producing literally:

```
kubectl set image deployment/hive-hub hub=ghcr.io/kubestellar/hive-hub:target1 -n hive-hub
```

**Reproduced**: running that single test with a recording `kubectl` on `PATH` and `KUBERNETES_SERVICE_HOST` set emits that exact command, including the correct container name `hub`.

## Blast radius: the shared helper reaches spokes too

`SwitchImageSelf` is shared by the spoke's heartbeat branch-switch **and** `UpgradeSelfToSHA`. A bogus tag there is **worse** than the hub outage: a stranded spoke keeps reporting its *old* git hash, so the hub re-sends the same doomed target on every heartbeat, forever. Validation is wired into that shared helper, not just the hub path.

## Changes

- **`main_test.go` (containment)** — `TestMain` unsets `KUBERNETES_SERVICE_HOST`/`PORT` and neutralizes `KUBECONFIG`, so a stray real `kubectl` has no cluster to reach. This kills the whole class, not just this instance.
- **`image_tag_validation.go`** — `validateImageTag` / `validateImageRef` accept **only** an immutable hex git SHA (7–40 chars) or a mutable `<branch>-latest` channel tag. Refused: empty, identifier-like (`target1`, `target`), unsubstituted (`$target`, `${target}`), whitespace-padded, over-length. Named constants throughout; regexes anchored so a value merely *containing* hex cannot pass. Registry ports (`host:5000/repo`) and digest pins are handled correctly.
- **Wired into every writer** — `rolloutHubToSHA`, `SwitchImageSelf` (shared spoke helper), `handleSwitchBranch`.
- **Loud failure** — refusals log at `ERROR` naming the exact tag, and set a new `hubUpgradeFault` surfaced as `hubUpgradeState() == "failed"`, so a wedged upgrade appears in the dashboard instead of a reassuring `"queued"`.
- **Post-patch verification** — `watchHubRollout` confirms the new ReplicaSet becomes Ready within 5 min; if not, logs at `ERROR` with the **pod-level reason** (`ImagePullBackOff`/`CrashLoopBackOff`) and records the fault.

### Why no auto-rollback

Deliberately **detect-and-report only**. The auto-upgrade poller re-evaluates the same target every cycle, so an automatic rollback would immediately be undone and re-applied — flapping the deployment during an already-degraded window. The operator sees the stuck upgrade in the UI and in logs, and decides.

## Tests

- `target1`, `""`, `$target`, `${target}`, `target`, `latest`, short/uppercase/non-hex, whitespace-padded, and over-length tags are **refused**.
- Valid SHA tags (7/8/40-char) and channel tags (`v2-latest`, `v3-latest`, `mk-latest`, `dd-latest`, sanitized `feat-x-latest`) **pass**.
- `TestRolloutHubToSHARefusesBogusTagWithoutPatching` asserts the refusal happens **before** `kubectl` runs (recording fake kubectl log must be empty) and before `hubImageExists` is even consulted — the existing image is untouched.
- `TestSwitchImageSelfRefusesBogusTag` covers the shared spoke helper.
- `TestHubUpgradeStateSurfacesFault` asserts `"failed"`, not `"queued"`.

## Verification run

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./pkg/hub/ -count=1` ✅ full package green
- `gofmt` clean on touched files only (pre-existing drift elsewhere untouched)
- `saas.go` raw-string brace/paren balance identical to clean `origin/v2` baseline

## Notes

- **Needs porting to `mk`, `dd`, and `v3`.** Note ks/console's hive runs **v3**, so a v2-only merge does not reach it.
- Footgun worth recording: the hub container is named **`hub`**, not `hive-hub` — `kubectl set image deploy/hive-hub hive-hub=...` fails with `unable to find container named "hive-hub"`. The existing `hubContainerName` constant already documents this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)