### PR TITLE
🐛 fix(hub): delete left ghost hives in the registry

### DIFF
--- a/v2/pkg/hub/delete_hive_registry_test.go
+++ b/v2/pkg/hub/delete_hive_registry_test.go
@@ -1,0 +1,322 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// These tests cover the "ghost hive" bug: deleting a hosted hive tore down the
+// Kubernetes resources but left the entry in the hub registry, so the hive kept
+// rendering in "My Hives" forever and could never be removed from the UI.
+
+// helperDeleteHiveEnv points the SaaS hive dir and the registry file at temp
+// paths and returns a mux wired to handleDeleteHive.
+func helperDeleteHiveEnv(t *testing.T) (*HubServer, *http.ServeMux) {
+	t.Helper()
+	provisionWG.Wait()
+
+	dir := t.TempDir()
+	oldHives := saasHivesDir
+	oldUsers := saasUsersDir
+	oldRegistry := registryPath
+
+	saasHivesDir = filepath.Join(dir, "hives")
+	saasUsersDir = filepath.Join(dir, "users")
+	registryPath = filepath.Join(dir, "hub-registry.json")
+	if err := os.MkdirAll(saasHivesDir, 0o755); err != nil {
+		t.Fatalf("mkdir hives: %v", err)
+	}
+	if err := os.MkdirAll(saasUsersDir, 0o755); err != nil {
+		t.Fatalf("mkdir users: %v", err)
+	}
+
+	t.Cleanup(func() {
+		provisionWG.Wait()
+		saasHivesDir = oldHives
+		saasUsersDir = oldUsers
+		registryPath = oldRegistry
+	})
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /api/saas/hives/{id}", srv.handleDeleteHive)
+	return srv, mux
+}
+
+// helperRegistryHasHive reports whether the in-memory registry holds an entry.
+func helperRegistryHasHive(s *HubServer, id string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, h := range s.registry.Hives {
+		if h.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// helperPersistedRegistryHasHive reads the registry back off disk. This is the
+// representation that survives a hub restart, so it is what actually determines
+// whether a deleted hive stays deleted.
+func helperPersistedRegistryHasHive(t *testing.T, id string) bool {
+	t.Helper()
+	data, err := os.ReadFile(registryPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+		t.Fatalf("read registry: %v", err)
+	}
+	var reg Registry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		t.Fatalf("parse registry: %v", err)
+	}
+	for _, h := range reg.Hives {
+		if h.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDeleteHiveRemovesRegistryEntryFromMemoryAndDisk is the core regression:
+// after a successful delete the hive must be absent from both the in-memory
+// registry (what the listing renders) and the on-disk registry (what a restart
+// reloads). Removing it from only one leaves the hive reappearing.
+func TestDeleteHiveRemovesRegistryEntryFromMemoryAndDisk(t *testing.T) {
+	cleanup := helperSetupAuthUser(t, "ghp_del_reg", "del-reg-owner")
+	defer cleanup()
+
+	srv, mux := helperDeleteHiveEnv(t)
+
+	const hiveID = "hosted-del-reg-hive"
+	if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: "del-reg-owner", ClusterID: defaultClusterID}); err != nil {
+		t.Fatalf("seed hive: %v", err)
+	}
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: "del-reg-owner", Online: true}}
+	srv.mu.Unlock()
+	if err := srv.saveRegistryNow(); err != nil {
+		t.Fatalf("seed registry: %v", err)
+	}
+
+	req := httptest.NewRequest("DELETE", "/api/saas/hives/"+hiveID, nil)
+	req.Header.Set("Authorization", "Bearer ghp_del_reg")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if helperRegistryHasHive(srv, hiveID) {
+		t.Error("hive still present in the in-memory registry after delete")
+	}
+	if helperPersistedRegistryHasHive(t, hiveID) {
+		t.Error("hive still present in the persisted registry after delete (would resurrect on hub restart)")
+	}
+}
+
+// TestDeleteHiveWithMissingNamespaceStillRemovesRegistryEntry reproduces the
+// exact stuck state the user hit: the namespace and pods were already gone, but
+// the registry row survived and the UI kept showing the hive. Deleting a hive
+// whose cluster-side resources no longer exist must still clear the row.
+func TestDeleteHiveWithMissingNamespaceStillRemovesRegistryEntry(t *testing.T) {
+	cleanup := helperSetupAuthUser(t, "ghp_del_gone", "del-gone-owner")
+	defer cleanup()
+
+	srv, mux := helperDeleteHiveEnv(t)
+
+	const hiveID = "hosted-del-gone-hive"
+	// No namespace exists for this hive; kubectl delete --ignore-not-found is a
+	// no-op / failure depending on cluster reachability. Either way the registry
+	// entry must go.
+	if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: "del-gone-owner", ClusterID: defaultClusterID}); err != nil {
+		t.Fatalf("seed hive: %v", err)
+	}
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: "del-gone-owner", Online: false}}
+	srv.mu.Unlock()
+
+	req := httptest.NewRequest("DELETE", "/api/saas/hives/"+hiveID, nil)
+	req.Header.Set("Authorization", "Bearer ghp_del_gone")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 even with the namespace already gone, got %d body=%s", w.Code, w.Body.String())
+	}
+	if helperRegistryHasHive(srv, hiveID) {
+		t.Error("ghost entry: hive whose namespace was already gone remained in the registry")
+	}
+	if helperPersistedRegistryHasHive(t, hiveID) {
+		t.Error("ghost entry persisted to disk for a hive whose namespace was already gone")
+	}
+}
+
+// TestDeleteHiveWithNoClusterConfigStillRemovesEntryAndWarns covers the branch
+// that caused the production ghost: clusterForHive returned nil, the handler
+// returned 500 and never reached removeRegistryEntry, so the row was stranded
+// permanently. Now the entry is removed and the partial outcome is reported.
+func TestDeleteHiveWithNoClusterConfigStillRemovesEntryAndWarns(t *testing.T) {
+	cleanup := helperSetupAuthUser(t, "ghp_del_nocluster", "del-nocluster-owner")
+	defer cleanup()
+
+	srv, mux := helperDeleteHiveEnv(t)
+	// Drop every cluster config so clusterForHive cannot resolve one.
+	srv.clusters = map[string]ClusterConfig{}
+
+	const hiveID = "hosted-del-nocluster-hive"
+	if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: "del-nocluster-owner", ClusterID: "cluster-that-was-removed"}); err != nil {
+		t.Fatalf("seed hive: %v", err)
+	}
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: "del-nocluster-owner", Online: false}}
+	srv.mu.Unlock()
+
+	req := httptest.NewRequest("DELETE", "/api/saas/hives/"+hiveID, nil)
+	req.Header.Set("Authorization", "Bearer ghp_del_nocluster")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 with a partial-delete body, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("parse response: %v (body=%s)", err, w.Body.String())
+	}
+	if body["status"] != deleteStatusPartial {
+		t.Errorf("expected status %q so the user learns cleanup was incomplete, got %q", deleteStatusPartial, body["status"])
+	}
+	if body["warning"] == "" {
+		t.Error("partial delete must carry a warning explaining what was left behind")
+	}
+
+	// The critical assertion: a teardown that could not run must NOT leave a ghost.
+	if helperRegistryHasHive(srv, hiveID) {
+		t.Error("ghost entry: registry row survived a delete whose teardown could not run")
+	}
+	if helperPersistedRegistryHasHive(t, hiveID) {
+		t.Error("ghost entry persisted to disk after a delete whose teardown could not run")
+	}
+}
+
+// TestDeleteHiveIsIdempotentWhenSaaSRecordAlreadyGone covers repeated Delete
+// clicks and the case where the on-disk hive record was cleaned up but the
+// registry row was not — the state the user had to fix by hand.
+func TestDeleteHiveIsIdempotentWhenSaaSRecordAlreadyGone(t *testing.T) {
+	cleanup := helperSetupAuthUser(t, "ghp_del_idem", "del-idem-owner")
+	defer cleanup()
+
+	srv, mux := helperDeleteHiveEnv(t)
+
+	const hiveID = "hosted-del-idem-hive"
+	// Deliberately no saveSaaSHive: the meta.json is already gone, only the
+	// registry row remains.
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: "del-idem-owner", Online: false}}
+	srv.mu.Unlock()
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest("DELETE", "/api/saas/hives/"+hiveID, nil)
+		req.Header.Set("Authorization", "Bearer ghp_del_idem")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("delete attempt %d: expected 200, got %d body=%s", i+1, w.Code, w.Body.String())
+		}
+	}
+
+	if helperRegistryHasHive(srv, hiveID) {
+		t.Error("orphaned registry row was not cleared when the SaaS record was already gone")
+	}
+	if helperPersistedRegistryHasHive(t, hiveID) {
+		t.Error("orphaned registry row still on disk after delete")
+	}
+}
+
+// TestRemoveRegistryEntryPersistsSynchronously guards the durability fix
+// directly. requestSave defers the write by registrySaveDelay; a hub restart in
+// that window reloaded the pre-delete registry and the hive came back. The
+// removal must be on disk by the time removeRegistryEntry returns.
+func TestRemoveRegistryEntryPersistsSynchronously(t *testing.T) {
+	_, _ = helperDeleteHiveEnv(t)
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	const keepID = "keep-me-hive"
+	const dropID = "drop-me-hive"
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{{ID: keepID}, {ID: dropID}}
+	srv.mu.Unlock()
+	if err := srv.saveRegistryNow(); err != nil {
+		t.Fatalf("seed registry: %v", err)
+	}
+
+	srv.removeRegistryEntry(dropID, "tester")
+
+	// No sleep: the write must already have happened.
+	if helperPersistedRegistryHasHive(t, dropID) {
+		t.Error("removeRegistryEntry did not flush the removal to disk before returning")
+	}
+	if !helperPersistedRegistryHasHive(t, keepID) {
+		t.Error("removeRegistryEntry dropped an unrelated hive from the persisted registry")
+	}
+
+	// A second removal of an absent ID must be a harmless no-op.
+	srv.removeRegistryEntry(dropID, "tester")
+	if !helperPersistedRegistryHasHive(t, keepID) {
+		t.Error("no-op removal corrupted the registry")
+	}
+}
+
+// TestKubectlUnreachableHiveIsNotReaped pins the deliberate decision NOT to add
+// a namespace-existence garbage collector.
+//
+// Hives on firewalled spokes are heartbeat-only and are NOT kubectl-reachable
+// from the hub, so "the hub cannot see the namespace" does not imply "the hive
+// is gone" — it is equally consistent with a transient API outage or a spoke
+// the hub was never able to reach. Reaping on that signal would delete live
+// hives. The hub's only automatic eviction stays heartbeat-based
+// (staleRemoveAge), because a heartbeat is positive evidence of liveness that
+// the hive itself supplies; its absence for a full day is a far safer signal
+// than the hub's inability to run kubectl.
+//
+// This test asserts that a hive which is offline and whose namespace does not
+// exist is still retained, as long as it is heartbeating within staleRemoveAge.
+func TestKubectlUnreachableHiveIsNotReaped(t *testing.T) {
+	_, _ = helperDeleteHiveEnv(t)
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	const unreachableID = "hosted-unreachable-spoke-hive"
+	// Beat recently enough to be well inside staleRemoveAge, but old enough to
+	// be marked offline: exactly what an unreachable-but-alive hive looks like.
+	recentButStale := time.Now().Add(-2 * maxHeartbeatAge).UTC().Format(time.RFC3339)
+
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{{
+		ID:            unreachableID,
+		Owner:         "spoke-owner",
+		Online:        true,
+		LastHeartbeat: recentButStale,
+	}}
+	srv.markStaleHives()
+	srv.mu.Unlock()
+
+	if !helperRegistryHasHive(srv, unreachableID) {
+		t.Fatal("an unreachable hive was reaped from the registry without an explicit delete")
+	}
+
+	srv.mu.RLock()
+	stillOnline := srv.registry.Hives[0].Online
+	srv.mu.RUnlock()
+	if stillOnline {
+		t.Error("expected the hive to be marked offline (but retained), not left online")
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2266,7 +2266,7 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 		// so the hive disappears from the listing immediately.
 		s.removeRegistryEntry(id, username)
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"status":"deleted"}`))
+		json.NewEncoder(w).Encode(map[string]string{"status": deleteStatusDeleted})
 		return
 	}
 	if h.Owner != username && username != hubAdminUsername {
@@ -2275,19 +2275,49 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Full de-provisioning: namespace, PV, OCI export, OCI file system, disk record, user cleanup.
+	//
+	// The registry entry is removed unconditionally, even when the cluster
+	// teardown cannot run or only partially succeeds. A hive whose namespace is
+	// already gone (or whose cluster config has been removed) would otherwise be
+	// permanently un-deletable: the handler used to return 500 before reaching
+	// removeRegistryEntry, stranding a ghost row in "My Hives" that no amount of
+	// re-clicking Delete could clear. Leaving a stranded row is strictly worse
+	// than leaving cloud resources behind, because the row is what the user sees
+	// and it is the only thing they can act on. Partial failures are reported in
+	// the response so the user knows manual cleanup may still be needed.
 	cluster := s.clusterForHive(h)
-	if cluster == nil {
-		s.logger.Error("no cluster config for deprovision", "hive_id", id, "cluster_id", h.ClusterID)
-		http.Error(w, `{"error":"no cluster config — cannot deprovision"}`, http.StatusInternalServerError)
-		return
+	if cluster != nil {
+		deprovisionHive(h, cluster, s.logger)
+	} else {
+		s.logger.Error("no cluster config for deprovision; removing registry entry anyway",
+			"hive_id", id, "cluster_id", h.ClusterID)
 	}
-	deprovisionHive(h, cluster, s.logger)
 	s.removeRegistryEntry(id, username)
 
-	s.logger.Info("audit: hosted hive deleted", "hive_id", id, "by", username)
+	s.logger.Info("audit: hosted hive deleted", "hive_id", id, "by", username,
+		"deprovisioned", cluster != nil)
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"status":"deleted"}`))
+	if cluster == nil {
+		// deleteStatusPartial tells the UI the registry row is gone but cloud
+		// resources may survive and need manual cleanup.
+		json.NewEncoder(w).Encode(map[string]string{
+			"status":  deleteStatusPartial,
+			"warning": "removed from the hub registry, but no cluster config was available to delete the namespace, PV, or OCI storage — these may need manual cleanup",
+		})
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]string{"status": deleteStatusDeleted})
 }
+
+// Delete outcome statuses returned by handleDeleteHive.
+const (
+	// deleteStatusDeleted means the registry entry was removed and the cluster
+	// teardown ran.
+	deleteStatusDeleted = "deleted"
+	// deleteStatusPartial means the registry entry was removed but the cluster
+	// teardown could not run; cloud resources may need manual cleanup.
+	deleteStatusPartial = "partially_deleted"
+)
 
 // MigrateRequest is the JSON body for POST /api/saas/hives/{id}/migrate.
 type MigrateRequest struct {
@@ -12087,8 +12117,20 @@ const dashboardHTML = `<!DOCTYPE html>
         gtag('event','hive_deleted',{hive_id:id});
         hiveToast('Deleting ' + id + '...', 'info');
         var resp = await fetch('/api/saas/hives/' + encodeURIComponent(id), {method: 'DELETE'});
-        if (!resp.ok) { var d = await resp.json(); hiveToast(d.error || 'Delete failed', 'error'); return; }
-        hiveToast('Deleted ' + id, 'success');
+        if (!resp.ok) {
+          var d = await resp.json().catch(function(){ return {}; });
+          hiveToast(d.error || 'Delete failed', 'error');
+          // Refresh regardless: the hub removes the registry entry even when
+          // teardown fails, so the listing may already be correct.
+          loadHives();
+          return;
+        }
+        var ok = await resp.json().catch(function(){ return {}; });
+        if (ok.status === 'partially_deleted') {
+          hiveToast('Removed ' + id + ' from the hub, but cleanup was incomplete: ' + (ok.warning || 'cloud resources may need manual removal'), 'error');
+        } else {
+          hiveToast('Deleted ' + id, 'success');
+        }
         loadHives();
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); }
       finally { btns.forEach(function(b) { b.disabled = false; b.textContent = 'Delete'; b.style.opacity = '1'; }); }

--- a/v2/pkg/hub/saas_edge_coverage_test.go
+++ b/v2/pkg/hub/saas_edge_coverage_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -68,18 +69,40 @@ func TestHandleUpgradeHiveRegistryUpdate(t *testing.T) {
 	}
 }
 
+// TestHandleDeleteHiveNoCluster: a missing cluster config must NOT block the
+// delete. This previously returned 500 before removing the registry entry,
+// which stranded a ghost row in "My Hives" that the user could never clear.
+// The delete now succeeds and reports the partial outcome instead.
 func TestHandleDeleteHiveNoCluster(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 	mkUser(t, "alice")
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", ClusterID: "gone"})
 	s := noClusterHub()
+	s.mu.Lock()
+	s.registry.Hives = []RegistryEntry{{ID: "h1", Owner: "alice"}}
+	s.mu.Unlock()
 
 	rec := httptest.NewRecorder()
 	req := setPathValue(reqWithUser(http.MethodDelete, "/del", "", "alice"), "id", "h1")
 	s.handleDeleteHive(rec, req)
-	if rec.Code != http.StatusInternalServerError {
-		t.Errorf("no-cluster delete status = %d, want 500", rec.Code)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("no-cluster delete status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("parse response: %v (body=%s)", err, rec.Body.String())
+	}
+	if body["status"] != deleteStatusPartial {
+		t.Errorf("no-cluster delete status field = %q, want %q", body["status"], deleteStatusPartial)
+	}
+
+	s.mu.RLock()
+	remaining := len(s.registry.Hives)
+	s.mu.RUnlock()
+	if remaining != 0 {
+		t.Errorf("registry entry survived a no-cluster delete (ghost hive), %d remaining", remaining)
 	}
 }
 

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1466,19 +1466,55 @@ func (s *HubServer) handleFleetStats(w http.ResponseWriter, r *http.Request) {
 	w.Write(data)
 }
 
-// removeRegistryEntry removes a hive from the in-memory registry by ID.
+// removeRegistryEntry removes a hive from the in-memory registry by ID and
+// flushes the registry to disk before returning.
+//
+// The flush is synchronous rather than going through requestSave because
+// requestSave defers the write by registrySaveDelay. A hub restart inside that
+// window would reload the pre-delete registry from disk and the deleted hive
+// would reappear in "My Hives" — the in-memory removal alone is not durable.
+// Deletion is rare and user-initiated, so paying the write cost inline is fine.
 func (s *HubServer) removeRegistryEntry(id, by string) {
 	s.mu.Lock()
+	removed := false
 	for i, h := range s.registry.Hives {
 		if h.ID == id {
 			s.registry.Hives = append(s.registry.Hives[:i], s.registry.Hives[i+1:]...)
-			s.mu.Unlock()
-			s.requestSave()
-			s.logger.Info("audit: registry entry removed", "id", id, "by", by)
-			return
+			removed = true
+			break
 		}
 	}
 	s.mu.Unlock()
+	if !removed {
+		return
+	}
+	if err := s.saveRegistryNow(); err != nil {
+		// The in-memory removal already happened, so the listing is correct for
+		// this process. Log loudly: only a restart before the next periodic save
+		// would resurrect the entry.
+		s.logger.Error("registry entry removed in memory but persist failed", "id", id, "error", err)
+		s.requestSave()
+	}
+	s.logger.Info("audit: registry entry removed", "id", id, "by", by)
+}
+
+// saveRegistryNow marshals and writes the registry to disk immediately, via a
+// temp file plus atomic rename so a crash mid-write cannot truncate it.
+func (s *HubServer) saveRegistryNow() error {
+	s.mu.RLock()
+	data, err := json.MarshalIndent(s.registry, "", "  ")
+	s.mu.RUnlock()
+	if err != nil {
+		return fmt.Errorf("marshal hub registry: %w", err)
+	}
+	tmpPath := registryPath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("write hub registry: %w", err)
+	}
+	if err := os.Rename(tmpPath, registryPath); err != nil {
+		return fmt.Errorf("rename hub registry: %w", err)
+	}
+	return nil
 }
 
 func (s *HubServer) handleRegistryDelete(w http.ResponseWriter, r *http.Request) {
@@ -1498,7 +1534,11 @@ func (s *HubServer) handleRegistryDelete(w http.ResponseWriter, r *http.Request)
 	}
 	s.mu.Unlock()
 	if removed {
-		s.requestSave()
+		// Synchronous flush for the same durability reason as removeRegistryEntry.
+		if err := s.saveRegistryNow(); err != nil {
+			s.logger.Error("admin registry removal persist failed", "id", id, "error", err)
+			s.requestSave()
+		}
 		s.logger.Info("audit: admin removed registry entry", "id", id, "admin", hubAdminUsername)
 	}
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Problem

Deleting a hosted hive from the hub UI tore down the Kubernetes resources but left the entry in the hub registry. The hive kept rendering in **My Hives** as a live-looking row forever, and re-clicking Delete never cleared it — each occurrence needed manual cleanup via `DELETE /api/saas/hives/{id}`.

Observed in production: namespace `hive-hosted-hosted-available-oke-10-placeholder-ncnd` gone (`NotFound`), no pods, but `/data/hub-registry.json` still held the entry with `online:false`. Two earlier orphans the same night (`open-horizon-core`, `open-horizon-services`) had the identical signature, so it recurs.

## Root cause

`handleDeleteHive` returned HTTP 500 when `clusterForHive` returned `nil`, and **that early return happened before `removeRegistryEntry`**:

```go
cluster := s.clusterForHive(h)
if cluster == nil {
    http.Error(w, `...`, http.StatusInternalServerError)
    return   // <-- registry entry never removed
}
deprovisionHive(h, cluster, s.logger)
s.removeRegistryEntry(id, username)
```

Once a hive's cluster config was gone — or its namespace had already been torn down by an earlier partial attempt — the row became permanently un-deletable. Leaving a stranded row is strictly worse than leaving cloud resources behind: the row is what the user sees, and it is the only thing they can act on.

Ruled out by reading the code:
- **Wrong endpoint** — no. The per-hive menu item calls `deleteHive(id)`, which does `fetch('/api/saas/hives/' + encodeURIComponent(id), {method:'DELETE'})`. Correct endpoint.
- **Heartbeat resurrection** — no. The heartbeat re-add path already rejects `hosted-`/`saas-` IDs with no on-disk record.

A secondary durability gap was also fixed: `requestSave` defers the write by `registrySaveDelay` (5s), so a hub restart inside that window reloaded the pre-delete registry and the hive came back. The hub did restart around the time of the incident, so this was a live contributing factor.

## Changes

- Remove the registry entry **unconditionally**, whether or not the cluster teardown could run. A hive whose namespace is already gone must still be removable — that is precisely the stuck state hit in production.
- Report a `partially_deleted` status with a warning when teardown was skipped, so incomplete cleanup is **visible instead of silent**. The dashboard toast surfaces it, and the listing refreshes even on a failed delete since the row may already be gone.
- Flush the registry **synchronously** on removal via temp-file + atomic rename, so in-memory and on-disk agree before the handler returns. Same fix applied to the admin registry-delete path.
- Status strings are named constants (`deleteStatusDeleted`, `deleteStatusPartial`).

## Deliberately NOT added: namespace-based reaping

No namespace-existence garbage collector. Hives on firewalled spokes (e.g. `vllm-d`) are heartbeat-only and are **not kubectl-reachable from the hub**, so "the hub cannot see the namespace" does not imply "the hive is gone" — it is equally consistent with a transient API outage. Reaping on that signal would delete live hives.

The existing heartbeat-based eviction (`staleRemoveAge`, 24h) stays the only automatic removal, because a heartbeat is *positive evidence of liveness that the hive itself supplies*; its absence for a full day is a far safer signal than the hub's inability to run kubectl. `TestKubectlUnreachableHiveIsNotReaped` pins this so a future change cannot quietly introduce reaping.

## Tests

New `v2/pkg/hub/delete_hive_registry_test.go`:
- registry entry cleared from **both** memory and disk
- delete succeeds when the namespace is already gone
- a teardown that cannot run still clears the row and reports `partially_deleted`
- repeated deletes are idempotent when the SaaS record is already gone
- `removeRegistryEntry` persists before returning (no sleep in the assertion)
- an unreachable hive is not reaped

`TestHandleDeleteHiveNoCluster` asserted the old 500 behavior and was updated to the corrected contract.

Verified the new tests actually catch the bug: reverting the handler fix makes `TestDeleteHiveWithNoClusterConfigStillRemovesEntryAndWarns` fail.

## Verification

- `go build ./...`, `go vet ./pkg/hub/` — clean
- `go test ./pkg/hub/` — only `TestHandleHubSelfUpgrade_Edge` and `TestLoadAppPrivateKeyKubectlFails` fail, and **both fail identically on clean `origin/v2`** (pre-existing, unrelated)
- `gofmt -l` clean on the four touched files only
- `dashboardHTML` raw string: **zero backticks added**; JS extracted and compared against the `origin/v2` baseline — brace delta unchanged at 0, paren delta unchanged; extraction grepped to confirm the new `partially_deleted` handling is present (not a stale extraction). `TestDashboardScriptBracesAreBalanced` passes.

## Porting

Needs porting to **mk**, **dd**, and **v3**.