### PR TITLE
🐛 fix(contribute): forward BOBSHELL_API_KEY into the contributor container

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -197,7 +197,9 @@ contribute-setup backend="claude": check-version
         ;;
       bob)
         if command -v bob &>/dev/null; then
-          echo "Bob CLI detected — authentication handled on first run."
+          # Bob's browser SSO flow cannot complete in a container, so the
+          # containerized path needs BOBSHELL_API_KEY exported in your shell.
+          echo "Bob CLI detected — export BOBSHELL_API_KEY for containerized runs."
         else
           echo "ERROR: Bob CLI not found."
           exit 1
@@ -318,6 +320,14 @@ contribute-hive backend="" mode="docker": check-version
       BACKEND="${AGENT_BACKEND:-claude}"
     fi
     export AGENT_BACKEND="$BACKEND"
+    # Bob has no headless credential other than its API key — without it the
+    # agent would launch and sit at Bob's key prompt forever. Fail fast.
+    if [[ "$BACKEND" == "bob" && -z "${BOBSHELL_API_KEY:-}" ]]; then
+      echo "ERROR: BOBSHELL_API_KEY not set — Bob cannot authenticate."
+      echo "  export BOBSHELL_API_KEY=your-bob-api-key"
+      echo "  then re-run: just contribute-hive bob"
+      exit 1
+    fi
     echo "=== Hive Contributor Agent (ClankeR) ==="
     echo "Backend:  ${BACKEND}"
     echo "Hub:      {{hive_hub}}"
@@ -481,6 +491,7 @@ contribute-hive backend="" mode="docker": check-version
         ${GOOSE_PROVIDER:+-e GOOSE_PROVIDER="${GOOSE_PROVIDER}"} \
         ${GOOSE_MODEL:+-e GOOSE_MODEL="${GOOSE_MODEL}"} \
         ${OPENAI_API_KEY:+-e OPENAI_API_KEY="${OPENAI_API_KEY}"} \
+        ${BOBSHELL_API_KEY:+-e BOBSHELL_API_KEY="${BOBSHELL_API_KEY}"} \
         ${HIVE_LITELLM_ENDPOINT:+-e HIVE_LITELLM_ENDPOINT="${HIVE_LITELLM_ENDPOINT}"} \
         ${HIVE_LITELLM_API_KEY:+-e HIVE_LITELLM_API_KEY="${HIVE_LITELLM_API_KEY}"} \
         ${AGENT_MODEL:+-e AGENT_MODEL="${AGENT_MODEL}"} \


### PR DESCRIPTION
## Problem

`just contribute-hive` never passed `BOBSHELL_API_KEY` into the ClankeR contributor container, so a contributor running the `bob` backend could never authenticate.

The break is one-sided. The `/contribute` page **already ships the correct guidance** — the bob `<option>` in `v2/pkg/dashboard/api_contribute.go` renders a copy-paste block telling the user to `export BOBSHELL_API_KEY=...`. The user exports it, and then `contribute-hive` silently drops it.

```
$ grep -c BOBSHELL_API_KEY v2/pkg/dashboard/api_contribute.go   # 1
$ grep -c BOBSHELL_API_KEY Justfile                             # 0
```

Every other backend's credential was forwarded (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `GOOSE_API_KEY`, `HIVE_LITELLM_API_KEY`). Bob's was not.

Confirmed independently: a contributor manually ran the same container with `-e BOBSHELL_API_KEY="${BOBSHELL_API_KEY}"` added, and bob started fine.

## Changes

Three small hunks in `Justfile`:

1. **Forward the key** — added `${BOBSHELL_API_KEY:+-e BOBSHELL_API_KEY="${BOBSHELL_API_KEY}"}` to the `run` block, matching the existing conditional-forward style. The `:+` guard is load-bearing: the recipe runs under `set -euo pipefail`, so a bare `${BOBSHELL_API_KEY}` would be an unbound-variable hard exit for **every non-bob contributor**.

2. **Fail fast** — if the backend is `bob` and no key is set, `contribute-hive` now exits with an actionable message pointing at the same `export` line the page shows, instead of launching a container that sits at bob's key prompt forever. Placed after `BACKEND` resolution so it covers both container and local mode.

3. **Fix the misleading setup message** — the `bob)` branch of `contribute-setup` said "authentication handled on first run", which is untrue for the container path: bob's browser SSO flow cannot complete in a container (no browser, and the callback resolves to the container).

## Design note

The key stays **env-only** and is never written to `contributor.env`. That is deliberate: the `/contribute` page explicitly promises "Exported locally, never sent to the hive", and `contributor.env` is sourced under `set -a`, so an exported shell var is already inherited — no extra plumbing is needed. Persisting it would put a credential on disk for no functional gain.

## Verification

- `just --summary` parses the Justfile cleanly.
- `bash -n` passes on both the `contribute-setup` and `contribute-hive` recipe bodies (extracted and placeholder-substituted).
- Verified the `:+` guard under `set -euo pipefail`: expands to empty when unset (no crash), to `-e BOBSHELL_API_KEY=<value>` when set.

Not run: an end-to-end `just contribute-hive bob` with a real Bob key — no IBM Bob subscription available in this environment.

## Porting

**`mk`, `dd`, and `v3` need this ported.** This lands on `v2` only.