### PR TITLE
🐛 fix(justfile): preserve contributor container logs and fix iTerm detection

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -463,7 +463,16 @@ contribute-hive backend="" mode="docker": check-version
           ;;
       esac
       CONTAINER_NAME="hive-contributor-${BACKEND}-$(head -c 4 /dev/urandom | od -An -tx1 | tr -d ' ')"
-      "$RUNTIME" run -d --rm \
+      # NOTE: deliberately NOT --rm. With --rm the runtime deletes the
+      # container the instant it exits, taking its logs with it — so a
+      # container that dies during startup leaves nothing to diagnose
+      # (the user just sees "no such container"). We remove it ourselves
+      # in the cleanup trap below, after the logs have been read.
+      cleanup_container() {
+        "$RUNTIME" rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+      }
+      trap cleanup_container EXIT
+      "$RUNTIME" run -d \
         --name "${CONTAINER_NAME}" \
         ${RUNTIME_FLAGS} \
         ${NET_FLAGS} \
@@ -472,7 +481,7 @@ contribute-hive backend="" mode="docker": check-version
         -v "${HOME}/.config/gh:/home/dev/.config/gh${ROSUF}" \
         -e HIVE_HUB="{{hive_hub}}" \
         -e AGENT_BACKEND="${BACKEND}" \
-        -e GH_TOKEN="${GH_TOKEN}" \
+        -e GH_TOKEN="${GH_TOKEN:-}" \
         -e HIVE_USE_CONTRIBUTOR_GH=true \
         -e HIVE_CONTAINER_NAME="${CONTAINER_NAME}" \
         ${ANTHROPIC_API_KEY:+-e ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}"} \
@@ -488,18 +497,77 @@ contribute-hive backend="" mode="docker": check-version
 
       echo "Container: ${CONTAINER_NAME}"
       echo "Waiting for CLI session to start..."
-      sleep 3
+      # Grace period for the container entrypoint to bring up the tmux
+      # session before we try to attach to it.
+      readonly STARTUP_GRACE_SECONDS=3
+      sleep "${STARTUP_GRACE_SECONDS}"
+
+      # The container may have died during the grace period (bad flag, OOM,
+      # unreadable mount, failed entrypoint). Detect that BEFORE attaching or
+      # tailing, and surface the exit code plus the captured logs — otherwise
+      # the user only sees an opaque runtime error.
+      CONTAINER_STATE=$("$RUNTIME" inspect -f '{{ "{{" }}.State.Running{{ "}}" }}' "${CONTAINER_NAME}" 2>/dev/null || echo "missing")
+      if [[ "$CONTAINER_STATE" != "true" ]]; then
+        CONTAINER_EXIT=$("$RUNTIME" inspect -f '{{ "{{" }}.State.ExitCode{{ "}}" }}' "${CONTAINER_NAME}" 2>/dev/null || echo "unknown")
+        echo ""
+        echo "ERROR: the contributor container exited during startup."
+        echo "  Container: ${CONTAINER_NAME}"
+        echo "  Runtime:   ${RUNTIME}"
+        echo "  Exit code: ${CONTAINER_EXIT}"
+        echo ""
+        echo "── Container logs ──"
+        "$RUNTIME" logs "${CONTAINER_NAME}" 2>&1 || echo "(no logs captured)"
+        echo "────────────────────"
+        echo ""
+        echo "Common causes:"
+        echo "  * GH_TOKEN empty/expired  — re-run: just contribute-setup {{backend}}"
+        echo "  * config mounts unreadable (rootless podman UID mapping)"
+        echo "  * missing HIVE_REGISTRATION_TOKEN"
+        echo ""
+        echo "Re-run with HIVE_KEEP_CONTAINER=true to keep the container for inspection."
+        if [[ "${HIVE_KEEP_CONTAINER:-}" == "true" ]]; then
+          trap - EXIT
+          echo "Container kept: ${RUNTIME} logs ${CONTAINER_NAME}"
+        fi
+        exit 1
+      fi
 
       # Open the CLI session in a new terminal window
       ATTACH_CMD="${RUNTIME} exec -it ${CONTAINER_NAME} tmux attach -t contributor"
       if [[ "$OSTYPE" == "darwin"* ]]; then
-        if pgrep -x "iTerm2" > /dev/null 2>&1; then
-          osascript -e "tell application \"iTerm2\" to tell current window to create tab with default profile command \"${ATTACH_CMD}\""
+        # Detect iTerm via System Events rather than pgrep. On macOS the
+        # iTerm process's comm is the full bundle path
+        # (/Applications/iTerm.app/Contents/MacOS/iTerm2), so `pgrep -x iTerm2`
+        # anchors against that path and NEVER matches — every iTerm user
+        # silently fell through to Terminal.app. System Events reports the
+        # application name ("iTerm2"), which is what we actually want.
+        TAB_OPENED=true
+        RUNNING_APPS=$(osascript -e 'tell application "System Events" to get name of every application process whose background only is false' 2>/dev/null || echo "")
+        if [[ "$RUNNING_APPS" == *"iTerm"* ]]; then
+          # iTerm may be running with no open window, in which case
+          # `tell current window` errors — fall back to creating a window.
+          osascript -e "tell application \"iTerm2\"
+            if (count of windows) = 0 then
+              create window with default profile command \"${ATTACH_CMD}\"
+            else
+              tell current window to create tab with default profile command \"${ATTACH_CMD}\"
+            end if
+          end tell" >/dev/null 2>&1 || {
+            TAB_OPENED=false
+            echo "WARNING: could not open an iTerm tab; attach manually with:"
+            echo "  ${ATTACH_CMD}"
+          }
         else
-          osascript -e "tell application \"Terminal\" to do script \"${ATTACH_CMD}\""
+          osascript -e "tell application \"Terminal\" to do script \"${ATTACH_CMD}\"" >/dev/null 2>&1 || {
+            TAB_OPENED=false
+            echo "WARNING: could not open a Terminal window; attach manually with:"
+            echo "  ${ATTACH_CMD}"
+          }
         fi
-        echo ""
-        echo "✓ CLI session opened in a new terminal tab."
+        if [[ "$TAB_OPENED" == "true" ]]; then
+          echo ""
+          echo "✓ CLI session opened in a new terminal tab."
+        fi
       else
         echo ""
         echo "Attach to the CLI session with:"
@@ -508,7 +576,15 @@ contribute-hive backend="" mode="docker": check-version
 
       echo ""
       echo "Relay logs:"
-      "$RUNTIME" logs -f "${CONTAINER_NAME}"
+      # `logs -f` returns when the container stops. Don't let a non-zero
+      # status from it kill the recipe under `set -e` — we want to report the
+      # container's own exit code, which is the useful signal.
+      "$RUNTIME" logs -f "${CONTAINER_NAME}" 2>&1 || true
+      FINAL_EXIT=$("$RUNTIME" inspect -f '{{ "{{" }}.State.ExitCode{{ "}}" }}' "${CONTAINER_NAME}" 2>/dev/null || echo "unknown")
+      if [[ "$FINAL_EXIT" != "0" && "$FINAL_EXIT" != "unknown" ]]; then
+        echo ""
+        echo "Container ${CONTAINER_NAME} exited with code ${FINAL_EXIT}."
+      fi
     fi
 
 # Check hub status and your contributor profile


### PR DESCRIPTION
Fixes two `just contribute-hive` bugs reported by **Joe Pearson** (macOS M2, rootless podman) on `438a9f2b`.

## Problem 1 — container logs destroyed before anyone can read them

Joe's output:
```
Container: hive-contributor-bob-6d639907
Waiting for CLI session to start...
✓ CLI session opened in a new terminal tab.
Relay logs:
Error: no container with name or ID "hive-contributor-bob-6d639907" found: no such container
error: recipe `contribute-hive` failed with exit code 125
```

`--rm` was the trap: the container started, exited during the 3-second sleep, and the runtime deleted it **along with its logs**. The actual startup error was unrecoverable by design.

**Fix — the diagnostics, not just the symptom:**
- **Drop `--rm`**, remove the container in an explicit `EXIT` trap after logs are read. Chosen over "start `logs -f` early" because it also preserves `inspect` state (the exit code), which streaming alone cannot recover; the trap keeps cleanup automatic so nothing leaks.
- **Detect the dead container before attaching/tailing** and print the **exit code** + captured logs + likely causes, instead of a raw runtime error and exit 125. The exit code is what distinguishes "entrypoint failed" from OOM from a bad flag.
- `HIVE_KEEP_CONTAINER=true` keeps the container for manual inspection.
- Report a non-zero exit code after `logs -f` returns; guarded with `|| true` so it cannot hard-exit under `set -euo pipefail`.
- **`${GH_TOKEN}` → `${GH_TOKEN:-}`.** Same `set -u` exposure fixed in `contributor-agent.sh`: `gh-auth.env` is only written when `gh auth token` is non-empty, but the precondition only checks the file *exists* — so an unset `GH_TOKEN` crashed the recipe. (Confirmed reproducible; note this fails *before* `run`, so it is not Joe's exact symptom, but it is the same latent class.)

No root cause is guessed at in the fix — the point is to make whatever it is **visible**.

## Problem 2 — iTerm users got Terminal.app

> "I'm using iTerm on my macOS M2 and it keeps trying to open the native terminal application."

Root cause is **not** the `iTerm` vs `iTerm2` naming theory. On macOS the iTerm process's `comm` is the **full bundle path** `/Applications/iTerm.app/Contents/MacOS/iTerm2`, and `pgrep -x` anchors against that whole string — so `pgrep -x "iTerm2"` can **never** match. Verified on a real iTerm install: `pgrep -x` misses for *both* `iTerm` and `iTerm2` (plain `pgrep` misses too). Every iTerm user silently fell through to Terminal.app.

The AppleScript **target** was correct all along (`iTerm2` resolves as an alias of `iTerm`), which is why Joe still saw the iTerm-style `tab 1 of window id 2932` — detection was the broken half.

**Fix:** detect via System Events (`name of every application process whose background only is false`), which reports the application name. Also handles **iTerm running with no open window**, where `tell current window` errors — falls back to creating a window. Both AppleScript branches now fall back to printing the attach command rather than failing, and the "✓ opened" message is suppressed when that fallback fires.

## Verification

Run on **docker** (podman not available locally; I am not on Joe's machine).

**VERIFIED**
- Reproduced Joe's exact defect: with `--rm`, a container exiting 3 gives `No such container` and its stderr is gone permanently.
- With the fix, the same container yields the recovered message and exit code:
  ```
  ERROR: the contributor container exited during startup.
    Exit code: 3
  ── Container logs ──
  STARTUP ERROR: cannot read /home/dev/.config/hive
  ```
- Happy path: liveness check passes on a long-running container, exit 0 prints no spurious warning, and the trap removes the container (no leak from dropping `--rm`).
- `pgrep -x "iTerm2"` MISSES and System Events detection HITS on a live iTerm install.
- Both AppleScript branches compile (`osacompile`); zero-window branch confirmed reachable.
- `${GH_TOKEN}` unbound-variable crash reproduced under `set -euo pipefail`.
- `just --list` parses; `bash -n` clean on the fully rendered recipe body; `{{ "{{" }}`-escaping confirmed to emit valid Go templates (`{{.State.Running}}`) for `inspect -f`.

**ASSUMED (not verified)**
- Behaviour under **rootless podman on macOS** — including whether `--userns=keep-id` or the `:Z` relabel is Joe's actual root cause. Unchanged by this PR; the new output should now reveal it.
- iTerm detection on Joe's specific machine/iTerm build.
- `docker` and `podman` agree on `inspect -f '{{ "{{" }}.State.Running{{ "}}" }}'` / `.State.ExitCode` (both support these fields; only docker exercised).

## Notes
- **Needs porting to `mk`, `dd`, and `v3`.**
- Thanks to **Joe Pearson** for both reports.