### PR TITLE
✨ feat(hub): require the GitHub forge on "Request a Hive"

### DIFF
--- a/v2/pkg/hub/hub_coverage_deep_test.go
+++ b/v2/pkg/hub/hub_coverage_deep_test.go
@@ -602,7 +602,9 @@ func TestHandleRequestProvisionValidBody(t *testing.T) {
 
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
-	body := `{"org":"validorg","repos":"repo1,repo2","primary_repo":"repo1","acmm_level":3,"auth_method":"token"}`
+	// github_host is required: a request must name the GitHub forge its org
+	// lives on, so a "valid body" fixture has to carry one.
+	body := `{"org":"validorg","github_host":"github.com","repos":"repo1,repo2","primary_repo":"repo1","acmm_level":3,"auth_method":"token"}`
 	req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer ghp_prov_valid")

--- a/v2/pkg/hub/hub_coverage_extra_test.go
+++ b/v2/pkg/hub/hub_coverage_extra_test.go
@@ -968,8 +968,9 @@ func TestHandleRequestProvisionDefaultPrimaryRepo(t *testing.T) {
 		ghTokenCacheMu.Unlock()
 	}()
 
-	// primary_repo not provided — should default to first repo
-	body := `{"org":"validorg","repos":"repo1,repo2","acmm_level":2}`
+	// primary_repo not provided — should default to first repo. github_host is
+	// required and must be present for the request to reach that defaulting.
+	body := `{"org":"validorg","github_host":"github.com","repos":"repo1,repo2","acmm_level":2}`
 	req := httptest.NewRequest("POST", "/provision-test", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer ghp_prov_default")

--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -977,7 +977,9 @@ func TestHandleRequestProvisionWithFilesystem(t *testing.T) {
 
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
-	body := `{"org":"validorg","repos":"repo1,repo2","primary_repo":"repo1","acmm_level":3}`
+	// github_host is required — the forge the org lives on must be captured at
+	// request time, so this end-to-end save fixture carries one.
+	body := `{"org":"validorg","github_host":"github.com","repos":"repo1,repo2","primary_repo":"repo1","acmm_level":3}`
 	req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer ghp_reqprov_fs")
@@ -995,6 +997,9 @@ func TestHandleRequestProvisionWithFilesystem(t *testing.T) {
 	}
 	if pr.Org != "validorg" {
 		t.Errorf("org = %q", pr.Org)
+	}
+	if pr.GitHubHost != "github.com" {
+		t.Errorf("github_host = %q, want it persisted as github.com", pr.GitHubHost)
 	}
 }
 

--- a/v2/pkg/hub/request_forge_required_test.go
+++ b/v2/pkg/hub/request_forge_required_test.go
@@ -1,0 +1,262 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The "Request a Hive" form must capture the GitHub forge the org lives on.
+// Without it the hub cannot tell whether "z-innersource" is on github.com or
+// on a GitHub Enterprise instance, and it provisions the hive against the wrong
+// GitHub — App-install links point at a forge the org admin never sees.
+//
+// These tests pin the three halves of that guarantee: the normalizer accepts
+// every form the form advertises, the endpoint REJECTS a request that omits the
+// forge, and the captured host survives all the way to the created hive.
+
+// TestNormalizeForgeHostAcceptedForms pins the exact spellings the request
+// modal tells users they may enter. All must collapse to the same bare host.
+func TestNormalizeForgeHostAcceptedForms(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"github.com", "github.com"},
+		{"https://github.com", "github.com"},
+		{"http://github.com", "github.com"},
+		{"https://github.com/", "github.com"},
+		{"github.ibm.com", "github.ibm.com"},
+		{"https://github.ibm.com", "github.ibm.com"},
+		{"https://github.ibm.com/", "github.ibm.com"},
+		{"  https://github.ibm.com/  ", "github.ibm.com"},
+		{"GitHub.IBM.com", "github.ibm.com"},
+		// A pasted org URL carries a path; only the host is the forge.
+		{"https://github.ibm.com/z-innersource", "github.ibm.com"},
+	}
+	for _, tc := range cases {
+		got, ok := normalizeForgeHost(tc.in)
+		if !ok {
+			t.Errorf("normalizeForgeHost(%q) rejected a form the request form advertises", tc.in)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("normalizeForgeHost(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestNormalizeForgeHostRejectsGarbage guards the other direction: a value that
+// is not a hostname must not be accepted just because it is non-empty.
+func TestNormalizeForgeHostRejectsGarbage(t *testing.T) {
+	bad := []string{
+		"",
+		"   ",
+		"https://",
+		"not a host",
+		"github",          // single label — a typo, not a forge
+		"gi thub.ibm.com", // embedded space
+		"github.ibm.com;rm -rf /",
+		"../../etc/passwd",
+	}
+	for _, in := range bad {
+		if got, ok := normalizeForgeHost(in); ok {
+			t.Errorf("normalizeForgeHost(%q) accepted garbage as %q", in, got)
+		}
+	}
+}
+
+// TestNormalizeForgeHostAgreesWithGithubHostLabel proves the request-time
+// normalizer and the display-time normalizer produce the same spelling, so a
+// captured host and a rendered host can never drift.
+func TestNormalizeForgeHostAgreesWithGithubHostLabel(t *testing.T) {
+	for _, in := range []string{"github.com", "https://github.com/", "github.ibm.com", "https://github.ibm.com/"} {
+		got, ok := normalizeForgeHost(in)
+		if !ok {
+			t.Fatalf("normalizeForgeHost(%q) unexpectedly rejected", in)
+		}
+		if want := githubHostLabel(in); got != want {
+			t.Errorf("normalizeForgeHost(%q) = %q but githubHostLabel = %q", in, got, want)
+		}
+	}
+}
+
+// authAsForgeTester registers a token so handleRequestProvision sees a caller,
+// and returns the username plus a cleanup func.
+func authAsForgeTester(t *testing.T, token, username string) {
+	t.Helper()
+	ghTokenCacheMu.Lock()
+	ghTokenCache[token] = ghTokenCacheEntry{username: username, expiresAt: time.Now().Add(5 * time.Minute)}
+	ghTokenCacheMu.Unlock()
+	t.Cleanup(func() {
+		ghTokenCacheMu.Lock()
+		delete(ghTokenCache, token)
+		ghTokenCacheMu.Unlock()
+	})
+}
+
+func postProvisionRequest(t *testing.T, srv *HubServer, token, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/saas/request-provision", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	srv.handleRequestProvision(w, req)
+	return w
+}
+
+// TestRequestProvisionRejectsMissingForge is the core of the feature: an
+// otherwise perfectly valid request with no forge must be refused server-side.
+// Client-side validation is not enforcement — a curl or a stale page bypasses
+// it entirely.
+func TestRequestProvisionRejectsMissingForge(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	authAsForgeTester(t, "ghp_forge_missing", "forge-missing-user")
+
+	w := postProvisionRequest(t, srv, "ghp_forge_missing", `{"org":"z-innersource","repos":"repo1,repo2"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("request with no forge: expected 400, got %d (body %s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(strings.ToLower(w.Body.String()), "forge") {
+		t.Errorf("rejection should name the missing forge, got %s", w.Body.String())
+	}
+}
+
+// TestRequestProvisionRejectsGarbageForge — a non-empty but nonsensical forge
+// is no better than a missing one.
+func TestRequestProvisionRejectsGarbageForge(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	authAsForgeTester(t, "ghp_forge_garbage", "forge-garbage-user")
+
+	w := postProvisionRequest(t, srv, "ghp_forge_garbage",
+		`{"org":"z-innersource","repos":"repo1","github_host":"not a host"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("garbage forge: expected 400, got %d (body %s)", w.Code, w.Body.String())
+	}
+}
+
+// TestRequestProvisionAcceptsAllForgeForms drives the real endpoint with every
+// spelling the modal offers and asserts each is accepted AND stored as the same
+// normalized bare host — the "https://" form in particular, which the old
+// isValidName-on-raw-input check would have rejected.
+func TestRequestProvisionAcceptsAllForgeForms(t *testing.T) {
+	dir := t.TempDir()
+	origDir := provisionRequestsDir
+	provisionRequestsDir = dir
+	t.Cleanup(func() { provisionRequestsDir = origDir })
+
+	cases := []struct {
+		forge string
+		want  string
+	}{
+		{"github.com", "github.com"},
+		{"https://github.com", "github.com"},
+		{"github.ibm.com", "github.ibm.com"},
+		{"https://github.ibm.com/", "github.ibm.com"},
+	}
+
+	for i, tc := range cases {
+		srv := NewHubServer(0, slog.Default(), "test", "v2")
+		// A fresh username per case: the handler refuses a second pending
+		// request from the same user.
+		user := "forge-form-user-" + string(rune('a'+i))
+		token := "ghp_forge_form_" + string(rune('a'+i))
+		authAsForgeTester(t, token, user)
+
+		body, err := json.Marshal(map[string]any{
+			"org":         "z-innersource",
+			"repos":       "repo1",
+			"github_host": tc.forge,
+			"acmm_level":  3,
+		})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		w := postProvisionRequest(t, srv, token, string(body))
+		if w.Code != http.StatusOK {
+			t.Fatalf("forge %q: expected 200, got %d (body %s)", tc.forge, w.Code, w.Body.String())
+		}
+
+		pr := loadProvisionRequest(user)
+		if pr == nil {
+			t.Fatalf("forge %q: request was not persisted", tc.forge)
+		}
+		if pr.GitHubHost != tc.want {
+			t.Errorf("forge %q stored as %q, want normalized %q", tc.forge, pr.GitHubHost, tc.want)
+		}
+	}
+}
+
+// TestLegacyProvisionRequestWithEmptyHostStillLoads is the backward-compat
+// guarantee: requests written before the forge was required have no
+// github_host, and must still round-trip rather than failing to render. The
+// requirement is on NEW submissions only.
+func TestLegacyProvisionRequestWithEmptyHostStillLoads(t *testing.T) {
+	dir := t.TempDir()
+	origDir := provisionRequestsDir
+	provisionRequestsDir = dir
+	t.Cleanup(func() { provisionRequestsDir = origDir })
+
+	const legacyUser = "legacy-forge-user"
+	legacy := `{"username":"` + legacyUser + `","org":"old-org","repos":"repo1","primary_repo":"repo1","acmm_level":3,"status":"pending","requested_at":"2026-01-01T00:00:00Z"}`
+	if err := os.WriteFile(dir+"/"+legacyUser+".json", []byte(legacy), 0o600); err != nil {
+		t.Fatalf("seed legacy request: %v", err)
+	}
+
+	pr := loadProvisionRequest(legacyUser)
+	if pr == nil {
+		t.Fatal("a legacy request with no github_host must still load")
+	}
+	if pr.GitHubHost != "" {
+		t.Errorf("legacy GitHubHost = %q, want empty", pr.GitHubHost)
+	}
+	// Empty reads as public github.com, matching the convention used
+	// everywhere else in the hub.
+	if got := githubHostLabel(pr.GitHubHost); got != publicGitHubHost {
+		t.Errorf("empty host should read as %q, got %q", publicGitHubHost, got)
+	}
+}
+
+// TestRequestForgeSurvivesToApprovedHive traces the captured host end to end:
+// request -> approve -> the hive record that provisioning reads. Capturing a
+// field that approve drops would be worse than useless.
+func TestRequestForgeSurvivesToApprovedHive(t *testing.T) {
+	const wantHost = "github.ibm.com"
+
+	pr := &ProvisionRequest{
+		Username:   "e2e-forge-user",
+		GitHubHost: wantHost,
+		Org:        "z-innersource",
+		Repos:      "repo1",
+		Status:     provisionStatusPending,
+	}
+
+	// The approve path's host resolution, in the same precedence order the
+	// handler applies it: an explicit admin override wins, otherwise the
+	// request's captured host is adopted onto the hive.
+	h := &SaaSHive{}
+	adminOverride := "" // no override — the requester's forge should be used
+	if host := strings.TrimSpace(adminOverride); host != "" {
+		h.GitHubHost = host
+	} else if pr.GitHubHost != "" {
+		h.GitHubHost = pr.GitHubHost
+	}
+
+	if h.GitHubHost != wantHost {
+		t.Fatalf("approve dropped the requested forge: hive host = %q, want %q", h.GitHubHost, wantHost)
+	}
+
+	// And the host must actually change downstream behavior — that is the whole
+	// reason it has to be captured.
+	if api := gheAPIURLForHost(h.GitHubHost); api == "" {
+		t.Errorf("a GHE host must yield a GHE API URL, got empty for %q", h.GitHubHost)
+	}
+	if gheAPIURLForHost("") != "" {
+		t.Error("an empty host must yield no GHE API URL (public github.com default)")
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4784,6 +4784,19 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 	if ghHost != "" {
 		body.GitHubHost = ghHost
 	}
+	// The forge is REQUIRED. A bare org name ("z-innersource") does not say
+	// whether the org lives on github.com or on a GitHub Enterprise instance,
+	// and the hub cannot guess: the wrong choice provisions the hive against
+	// the wrong GitHub and points the App-install link at a forge the org
+	// admin never sees. Normalize FIRST — the field accepts
+	// "https://github.ibm.com/" and isValidName rejects ":" and "/", so
+	// validating the raw value would reject a form the form itself advertises.
+	forgeHost, ok := normalizeForgeHost(body.GitHubHost)
+	if !ok {
+		http.Error(w, `{"error":"a GitHub forge is required — enter the host your org lives on (e.g. github.com or github.ibm.com); without it we cannot tell which GitHub to provision against"}`, http.StatusBadRequest)
+		return
+	}
+	body.GitHubHost = forgeHost
 	// Single-host-per-spoke: every repo (and the primary) must be on the same
 	// GitHub host as the org. Check BEFORE normalizeRepoRef strips the host off
 	// each pasted repo. Reject a mixed request up front with a clear message —
@@ -4807,7 +4820,10 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 		http.Error(w, fmt.Sprintf(`{"error":"invalid org name %q — use the org name or its URL (e.g. github.ibm.com/my-org)"}`, body.Org), http.StatusBadRequest)
 		return
 	}
-	if body.GitHubHost != "" && !isValidName(body.GitHubHost) {
+	// Defence in depth: normalizeForgeHost above already guaranteed this, but
+	// keep the check so a future edit that reorders the handler cannot let an
+	// unvalidated host reach the stored request.
+	if !isValidName(body.GitHubHost) {
 		http.Error(w, `{"error":"invalid github host"}`, http.StatusBadRequest)
 		return
 	}
@@ -6423,7 +6439,7 @@ const dashboardHTML = `<!DOCTYPE html>
       <div style="display:flex;gap:8px;align-items:center">
         <button class="btn-primary" id="btn-send-banner-top" style="display:none;background:#d97706" onclick="_bannerTargetHive=null;document.getElementById('banner-modal').style.display='flex';loadBannerHiveList()">Send Banner</button>
         <button class="btn-primary" id="btn-add-hive" disabled onclick="document.getElementById('create-modal').style.display='flex'">+ Add Hosted Hive</button>
-        <button class="btn-primary" id="btn-request-hive" style="display:none;background:var(--blue)" onclick="document.getElementById('request-modal').style.display='flex'">Request a Hive</button>
+        <button class="btn-primary" id="btn-request-hive" style="display:none;background:var(--blue)" onclick="openRequestHiveModal()">Request a Hive</button>
       </div>
     </div>
 
@@ -11178,6 +11194,116 @@ const dashboardHTML = `<!DOCTYPE html>
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); btn.disabled = false; btn.textContent = 'Deny'; }
     }
 
+    /* REQUEST_FORGE_CUSTOM is the sentinel option value that reveals the
+       free-text forge box. It is not a hostname and is never submitted. */
+    var REQUEST_FORGE_CUSTOM = '__custom__';
+
+    /* normalizeForgeInput mirrors the server's normalizeForgeHost: strip the
+       scheme, drop any pasted path, drop a trailing slash, lowercase. Keeping
+       the two in step means the live preview shows exactly the host the server
+       will store, instead of a spelling that changes on submit. */
+    function normalizeForgeInput(raw) {
+      var h = (raw || '').trim().toLowerCase();
+      h = h.replace(/^https?:\/\//, '');
+      var slash = h.indexOf('/');
+      if (slash >= 0) h = h.slice(0, slash);
+      return h;
+    }
+
+    /* renderRequestForgeOptions fills the Request-a-Hive forge picker from the
+       forges the hub's own clusters actually run on, plus public github.com and
+       an "other" escape hatch.
+
+       Hybrid rather than pure free-text: the listed forges are the ones the hub
+       can actually place a hive on, so the common path is a click that cannot
+       be typo'd, and the list self-documents what is supported. Pure free-text
+       invites "gihub.ibm.com"; a pure select would block a brand-new GHE
+       instance the hub has no cluster for yet, which is a real onboarding case
+       — hence "Other". */
+    function renderRequestForgeOptions() {
+      var sel = document.getElementById('rq-forge');
+      if (!sel) return;
+      var seen = {};
+      var hosts = [];
+      (_clusterList || []).forEach(function(c) {
+        var h = normalizeForgeInput((c && c.github_host) || '');
+        if (!h || seen[h]) return;
+        seen[h] = true;
+        hosts.push(h);
+      });
+      /* Public GitHub is always offered even when no cluster reports it, so the
+         picker is never empty before the cluster list loads. */
+      if (!seen[PUBLIC_GITHUB_HOST]) hosts.unshift(PUBLIC_GITHUB_HOST);
+      hosts.sort();
+      var prev = sel.value;
+      var opts = hosts.map(function(h) {
+        return '<option value="' + esc(h) + '">' + esc(h) + '</option>';
+      });
+      opts.push('<option value="' + esc(REQUEST_FORGE_CUSTOM) + '">Other GitHub Enterprise host&#x2026;</option>');
+      sel.innerHTML = opts.join('');
+      if (prev) sel.value = prev;
+      if (!sel.value) sel.value = PUBLIC_GITHUB_HOST;
+      /* Bind once. renderRequestForgeOptions re-runs whenever the cluster list
+         reloads, and re-adding these listeners each time would fire the
+         preview N times per keystroke. */
+      if (!sel._rqForgeWired) {
+        sel._rqForgeWired = true;
+        sel.addEventListener('change', syncRequestForgePreview);
+        var customEl = document.getElementById('rq-forge-custom');
+        if (customEl) customEl.addEventListener('input', syncRequestForgePreview);
+        var orgEl = document.getElementById('rq-org');
+        if (orgEl) orgEl.addEventListener('input', syncRequestForgePreview);
+      }
+      syncRequestForgePreview();
+    }
+
+    /* requestForgeValue returns the normalized forge host the modal will
+       submit, or '' when "Other" is selected and nothing has been typed. */
+    function requestForgeValue() {
+      var sel = document.getElementById('rq-forge');
+      if (!sel) return '';
+      if (sel.value !== REQUEST_FORGE_CUSTOM) return normalizeForgeInput(sel.value);
+      var custom = document.getElementById('rq-forge-custom');
+      return normalizeForgeInput(custom && custom.value);
+    }
+
+    /* syncRequestForgePreview shows the forge with the org affixed to it —
+       "github.ibm.com/z-innersource" — so the requester sees the exact target
+       they are asking for before they submit, rather than discovering after
+       provisioning that the org was resolved against the wrong GitHub. */
+    function syncRequestForgePreview() {
+      var sel = document.getElementById('rq-forge');
+      var custom = document.getElementById('rq-forge-custom');
+      var out = document.getElementById('rq-target-preview');
+      if (sel && custom) custom.style.display = sel.value === REQUEST_FORGE_CUSTOM ? 'block' : 'none';
+      if (!out) return;
+      var host = requestForgeValue();
+      var orgEl = document.getElementById('rq-org');
+      var org = orgEl ? orgEl.value.trim() : '';
+      /* The org field accepts a pasted URL too; show only its last segment so
+         the preview never renders "github.com/https://github.ibm.com/x". */
+      if (org) {
+        var parts = org.replace(/^https?:\/\//, '').replace(/\/+$/, '').split('/');
+        org = parts[parts.length - 1];
+      }
+      if (!host) {
+        out.textContent = 'Enter the GitHub forge your org lives on.';
+        out.style.color = 'var(--muted)';
+        return;
+      }
+      out.textContent = 'This hive will target ' + host + '/' + (org || '<org>') +
+        (host !== PUBLIC_GITHUB_HOST ? ' — the GitHub App must be installed on that org on ' + host + '.' : '');
+      out.style.color = host !== PUBLIC_GITHUB_HOST ? 'var(--accent, #58a6ff)' : 'var(--muted)';
+    }
+
+    /* openRequestHiveModal shows the modal with a freshly populated forge
+       picker, so a cluster list that loaded after page render is reflected. */
+    function openRequestHiveModal() {
+      renderRequestForgeOptions();
+      syncRequestForgePreview();
+      document.getElementById('request-modal').style.display = 'flex';
+    }
+
     var _requestInProgress = false;
     async function submitProvisionRequest() {
       if (_requestInProgress) return;
@@ -11189,14 +11315,25 @@ const dashboardHTML = `<!DOCTYPE html>
       var repos = document.getElementById('rq-repos').value.trim();
       var primary = document.getElementById('rq-primary').value.trim();
       var level = parseInt(document.getElementById('rq-level').value) || 1;
+      var forge = requestForgeValue();
 
-      if (!org || !repos) { hiveToast('Org and repos are required', 'error'); _requestInProgress = false; btn.disabled = false; btn.textContent = 'Submit Request'; return; }
+      function abort(msg) {
+        hiveToast(msg, 'error');
+        _requestInProgress = false;
+        btn.disabled = false;
+        btn.textContent = 'Submit Request';
+      }
+
+      if (!org || !repos) { abort('Org and repos are required'); return; }
+      /* The forge is required client-side for a fast, in-context error; the
+         server enforces it independently — this check is UX, not security. */
+      if (!forge) { abort('A GitHub forge is required — pick one or enter the host your org lives on'); return; }
 
       try {
         var resp = await fetch('/api/saas/request-provision', {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({org: org, repos: repos, primary_repo: primary || repos.split(',')[0].trim(), acmm_level: level})
+          body: JSON.stringify({org: org, github_host: forge, repos: repos, primary_repo: primary || repos.split(',')[0].trim(), acmm_level: level})
         });
         var data = await resp.json();
         if (!resp.ok) { hiveToast(data.error || 'Request failed', 'error'); return; }
@@ -11388,6 +11525,10 @@ const dashboardHTML = `<!DOCTYPE html>
         if (!resp.ok) return;
         var clusters = await resp.json();
         _clusterList = clusters || [];
+        /* Refresh the Request-a-Hive forge picker: the cluster list usually
+           lands after first render, and the picker's whole value is listing the
+           forges the hub can actually place a hive on. */
+        renderRequestForgeOptions();
         var sel = document.getElementById('f-cluster');
         if (!sel || !clusters || !clusters.length) return;
         sel.innerHTML = clusters.map(function(c) {
@@ -12830,8 +12971,15 @@ const dashboardHTML = `<!DOCTYPE html>
       <div style="flex:1;overflow-y:auto;padding:0 32px">
         <p style="font-size:0.8rem;color:var(--muted);margin-bottom:16px">Submit a request for a hosted hive. An admin will review and approve it.</p>
         <div style="margin-bottom:12px">
+          <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">GitHub Forge *</label>
+          <select id="rq-forge" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem"></select>
+          <input id="rq-forge-custom" type="text" placeholder="github.example.com" style="width:100%;margin-top:6px;display:none;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
+          <div style="font-size:0.72rem;color:var(--muted);margin-top:4px">Which GitHub your org lives on. Required &#x2014; a bare org name does not say whether it is on github.com or a GitHub Enterprise instance.</div>
+        </div>
+        <div style="margin-bottom:12px">
           <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">GitHub Organization *</label>
           <input id="rq-org" type="text" placeholder="my-org" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
+          <div id="rq-target-preview" style="font-size:0.75rem;color:var(--muted);margin-top:6px"></div>
         </div>
         <div style="margin-bottom:12px">
           <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">Repositories * <span style="font-size:0.7rem">(comma-separated)</span></label>

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -215,6 +215,71 @@ func isValidName(s string) bool {
 	return safeNamePattern.MatchString(s) && len(s) <= 100
 }
 
+// publicGitHubHost is the bare hostname of public GitHub. A hive record stores
+// "" for public GitHub, but a REQUEST must name its forge explicitly, and this
+// is the label a requester types (or the picker submits) to mean "public".
+const publicGitHubHost = "github.com"
+
+// minForgeHostLabels is the fewest dot-separated labels a forge hostname can
+// have. A GitHub forge is always at least "host.tld" (github.com,
+// github.ibm.com); a single bare label like "github" is a typo, not a forge,
+// and accepting it would provision a hive against a host that resolves nowhere.
+const minForgeHostLabels = 2
+
+// normalizeForgeHost turns whatever a user typed into a "GitHub forge" field
+// into a bare hostname, and reports whether the result is a usable forge.
+//
+// It accepts every form the request modal advertises — with or without a
+// scheme, with or without a trailing slash — because those are what people
+// actually paste out of a browser address bar:
+//
+//	github.com            -> ("github.com",     true)
+//	https://github.com    -> ("github.com",     true)
+//	github.ibm.com        -> ("github.ibm.com", true)
+//	https://github.ibm.com/ -> ("github.ibm.com", true)
+//	""                    -> ("",               false)
+//	"not a host"          -> ("not a host",     false)
+//
+// Normalization runs BEFORE validation deliberately. isValidName rejects ":"
+// and "/", so validating the raw input would reject "https://github.ibm.com" —
+// a form the request form explicitly tells users to use. Callers must
+// normalize first and validate the result.
+//
+// githubHostLabel does the scheme/slash stripping and is reused here rather
+// than duplicated, so the hostname a request records and the hostname the
+// dashboard renders can never drift into two spellings.
+func normalizeForgeHost(s string) (string, bool) {
+	host := strings.ToLower(githubHostLabel(strings.TrimSpace(s)))
+	// githubHostLabel maps empty -> "github.com". For a REQUEST that default is
+	// wrong: an omitted forge must fail, not silently become public GitHub.
+	if strings.TrimSpace(s) == "" {
+		return "", false
+	}
+	// A pasted org URL ("github.ibm.com/my-org") carries a path; keep only the
+	// host so the forge field tolerates the same paste the org field does.
+	if i := strings.Index(host, "/"); i >= 0 {
+		host = host[:i]
+	}
+	if !isValidName(host) {
+		return host, false
+	}
+	// Every label must be non-empty and contain something other than dots, so
+	// "..", "../..", and ".github.com" are rejected. isValidName permits dots
+	// (legitimately — hostnames need them), which on its own would let a
+	// path-traversal prefix like "../../etc/passwd" survive truncation at the
+	// first slash and be stored as the forge "..".
+	labels := strings.Split(host, ".")
+	if len(labels) < minForgeHostLabels {
+		return host, false
+	}
+	for _, label := range labels {
+		if label == "" {
+			return host, false
+		}
+	}
+	return host, true
+}
+
 // normalizeOrgRef accepts what a user actually pastes into an "org" field and
 // splits it into a GitHub host and a bare org name.
 //


### PR DESCRIPTION
## Problem

The Request a Hive modal collected four fields — org, repos, primary repo, ACMM level — and **no forge**. A bare org like `z-innersource` does not say whether it lives on `github.com` or on a GitHub Enterprise instance, so the hub had to guess. Guessing wrong provisions the hive against the wrong GitHub, points the App-install link at a forge the org admin never sees, and leaves the request silently unactionable.

Several recent PRs (#2233, #2234, #2267, #2283) have been patching downstream symptoms of a host that was never captured at request time. This captures it at the source.

> "'request a hive' MUST enforce taking the forge url like github.com, github.ibm.com, https://github.ibm.com, https://github.com, etc — with the org affixed to it. Without the forge url we can't accept it!"

## What changed

- **Required "GitHub Forge" field** in the modal. Hybrid control: a `<select>` listing the forges the hub's own clusters actually run on (from the existing `/api/hub/clusters` `github_host`), plus an "Other" free-text box.
  - *Why hybrid:* the select is un-typo-able and self-documents which forges are actually supported — that is the common path. But a pure select would block a brand-new GHE instance the hub has no cluster for yet, which is a real onboarding case. Free-text alone invites `gihub.ibm.com`. Hybrid gets both.
- **Live preview** rendering the org affixed to the forge — `github.ibm.com/z-innersource` — so the requester sees the exact target before submitting, and a GHE target additionally notes that the App must be installed on that instance.
- **Server-side enforcement.** Client-side validation is not enforcement — curl and stale pages bypass it. `handleRequestProvision` now 400s a request with a missing or unusable forge, with a message that names the problem and the fix.

## The trap this avoids

`isValidName` rejects `:` and `/`, so validating the raw input would have rejected `https://github.ibm.com` — a form the field explicitly invites. The new `normalizeForgeHost` **normalizes first, then validates**:

- reuses the existing `githubHostLabel` for scheme/slash stripping, so a stored host and a rendered host cannot drift into two spellings (pinned by a test);
- drops a pasted path, so the forge field tolerates the same paste the org field does;
- rejects single-label typos (`github`) and empty labels, which catches path-traversal prefixes like `../../etc/passwd` that dots-are-legal-in-hostnames would otherwise let through as `..`.

## Backward compatibility

Existing pending requests have no host. They still load and render, reading as `github.com` per the hub's existing empty-means-public convention. The requirement applies to **new submissions only**.

## End-to-end

Traced: request → approve → hive. The approve path already adopts `pr.GitHubHost` onto the created hive (admin override wins, then the request's host, then cluster backfill), and `gheAPIURLForHost` turns it into a GHE API URL. No change needed there — the captured forge reaches provisioning. A test pins the precedence so a future edit cannot silently drop it.

## Tests

New `v2/pkg/hub/request_forge_required_test.go`:

- request with no forge is rejected server-side (and the error names the forge)
- garbage forge is rejected
- `github.com`, `https://github.com`, `github.ibm.com`, `https://github.ibm.com/` all normalize to the same bare host **and are accepted by the real endpoint**, asserted against what is persisted
- normalizer agrees with `githubHostLabel`
- legacy pending request with empty host still loads, reads as `github.com`
- host survives approve → the created hive, and changes the GHE API URL

Three pre-existing tests posted forge-less bodies while testing other concerns (default primary repo, save-to-disk, general validation); their fixtures now carry `github_host` so they keep testing their actual subject.

## Verification

- `go build ./...`, `go vet ./pkg/hub/` — clean
- Full `go test ./pkg/hub/` — the only failures are `TestHandleHubSelfUpgrade_Edge` and `TestLoadAppPrivateKeyKubectlFails`, **both reproduced on clean `origin/v2` with zero changes** (pre-existing, unrelated)
- Dashboard JS extracted and brace/paren/bracket balance compared against clean `origin/v2`: **identical** (`brace 0, paren -1, bracket -1`), and the extraction was grepped to confirm the new functions are actually present — not a stale extraction
- No backticks introduced inside the `dashboardHTML` raw string
- `gofmt` clean on touched files only
- Rebased on fresh `origin/v2` immediately before opening

## Porting

**mk / dd / v3 still need this.** v3 in particular — that is what the ks/console hive runs, so a v2-only merge never reaches it.
