### PR TITLE
🐛 fix(contributor): stop infinite crash loop after periodic CLI restart

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -3,10 +3,10 @@ name: v2 CI
 on:
   push:
     branches: [v2]
-    paths: ['v2/**']
+    paths: ['v2/**', 'bin/contributor-relay*']
   pull_request:
     branches: [v2]
-    paths: ['v2/**']
+    paths: ['v2/**', 'bin/contributor-relay*']
 
 permissions:
   contents: read
@@ -37,6 +37,15 @@ jobs:
 
       - name: Proxy Tests
         run: cd proxy && npm ci && npm test
+
+      # bin/contributor-relay.sh is JavaScript run by node despite the .sh
+      # extension; node --check needs a .js path, so check a copy.
+      - name: Contributor Relay Syntax + Tests
+        working-directory: .
+        run: |
+          cp bin/contributor-relay.sh "${RUNNER_TEMP}/contributor-relay.js"
+          node --check "${RUNNER_TEMP}/contributor-relay.js"
+          node bin/contributor-relay.test.js
   create-issue-on-failure:
     if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/v2'
     runs-on: ubuntu-latest

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -40,6 +40,20 @@ const TOKEN_REFRESH_MARGIN_MS = 300000;
 const MAX_TASK_DURATION_MS = 1800000;
 const NETWORK_ERROR_RETRY_DELAY_MS = 5000;
 
+// Per-task CLI-crash retry budget. Issue #2203: a task whose CLI kept dying was
+// reassigned by the hub and failed identically forever (5+ times in ~20min),
+// starving that hub task slot. After MAX_TASK_CLI_RESTARTS crash-restarts for
+// the SAME repo#number, the relay gives up on that task permanently and tells
+// the hub so it can be reassigned elsewhere.
+const MAX_TASK_CLI_RESTARTS = 3;
+// Backoff before each successive restart of the same task: 5s, 10s, 20s.
+const TASK_RESTART_BASE_BACKOFF_MS = 5000;
+const TASK_RESTART_MAX_BACKOFF_MS = 60000;
+// How long a permanently-given-up task stays on the deny list. Long enough
+// that the hub does not immediately hand the same poison task back, short
+// enough that a transient environment fault eventually clears.
+const GIVE_UP_MEMORY_MS = 3600000;
+
 if (!REG_TOKEN) {
   console.error('FATAL: HIVE_REGISTRATION_TOKEN not set. Run `just contribute-register` first.');
   process.exit(1);
@@ -71,6 +85,50 @@ function injectGhToken(token) {
 const CLI_READY_POLL_MS = 2000;
 const CLI_READY_TIMEOUT_MS = 600000;
 const CONTAINER_NAME = process.env.HIVE_CONTAINER_NAME || 'hive-contributor';
+
+// Backends that must NOT be given --model, mirroring contributor-agent.sh.
+// amazonq/goose take their model from config/env. bob is excluded because
+// --model is actively FATAL for it: bob auto-selects its own model and passing
+// one leaves its model config undefined, so every prompt dies with
+// "Cannot read properties of undefined (reading 'maxTokens')" (bobshell 1.0.6).
+const NO_MODEL_FLAG_BACKENDS = ['amazonq', 'goose', 'bob'];
+
+// Single source of truth for the CLI launch command (issue #2203, bug 1).
+// contributor-agent.sh builds "$CMD $PERM_FLAG $MODEL_FLAG" for the FIRST
+// launch; every restart path in this file previously rebuilt only "$CMD $PERM"
+// inline, silently dropping the resolved model for the rest of the container's
+// life. Build it once here and reuse it everywhere so the paths cannot drift.
+let cachedLaunchCommand = null;
+
+function buildLaunchCommand() {
+  if (cachedLaunchCommand) return cachedLaunchCommand;
+  const confPaths = ['/usr/local/etc/hive/backends.conf', path.join(process.cwd(), 'config/backends.conf')];
+  const confPath = confPaths.find(p => fs.existsSync(p)) || confPaths[0];
+  let cmd = BACKEND;
+  let perm = '';
+  try {
+    cmd = execSync(`bash -c 'source ${confPath} 2>/dev/null; backend_binary ${BACKEND}'`, { encoding: 'utf8', timeout: 15000 }).trim() || BACKEND;
+    perm = execSync(`bash -c 'source ${confPath} 2>/dev/null; backend_perm_flag ${BACKEND}'`, { encoding: 'utf8', timeout: 15000 }).trim();
+  } catch (e) {
+    console.error(`Could not resolve backend flags from ${confPath}: ${e.message}`);
+  }
+  const modelFlag = MODEL && !NO_MODEL_FLAG_BACKENDS.includes(BACKEND) ? `--model ${MODEL}` : '';
+  cachedLaunchCommand = [cmd, perm, modelFlag].filter(Boolean).join(' ');
+  return cachedLaunchCommand;
+}
+
+// A tmux pane can be left in bash's PS2 continuation state ("> ") when task
+// text is typed into a bare shell — the prompt contains literal apostrophes
+// (e.g. 'gh repo fork ... --clone=false'), so bash's readline sees an
+// unbalanced quote and swallows everything typed afterwards, including the
+// relaunch command (issue #2203). Clear the line before relaunching.
+function recoverWedgedShell() {
+  try {
+    execSync(`tmux send-keys -t ${TMUX_SESSION} C-c`, { timeout: 15000 });
+    execSync(`tmux send-keys -t ${TMUX_SESSION} C-u`, { timeout: 15000 });
+    execSync(`tmux send-keys -t ${TMUX_SESSION} Enter`, { timeout: 15000 });
+  } catch (_) {}
+}
 
 function getCLIState() {
   try {
@@ -159,17 +217,16 @@ let pendingTask = null;
 
 waitForCLI().then(() => {
   cliReady = true;
-  if (pendingTask) {
-    const task = pendingTask;
-    pendingTask = null;
-    tmuxSendKeys(task);
-  }
+  flushPendingTask();
 }).catch(e => console.error(e.message));
 
 const ENTER_COUNT = 3;
 const ENTER_DELAY_MS = 300;
 
 function sleepMs(ms) {
+  // Tests drive the restart/backoff paths synchronously; a real busy-wait
+  // would make the suite take minutes of wall clock for no added coverage.
+  if (process.env.HIVE_RELAY_TEST_MODE === '1') return;
   const end = Date.now() + ms;
   while (Date.now() < end) {
     try { execSync(`sleep 0.1`, { timeout: 5000 }); } catch (_) {}
@@ -199,6 +256,16 @@ function checkContextUsage() {
 }
 
 function tmuxSendKeys(text) {
+  // Hard gate (issue #2203, bug 2): `send-keys -l` types literal keystrokes
+  // into whatever owns the pane. If the CLI is not confirmed ready, those
+  // keystrokes land on bash, whose readline chokes on the apostrophes in the
+  // prompt and drops the pane into PS2 continuation, wedging it permanently.
+  // Queue instead; flushPendingTask() delivers it once readiness is confirmed.
+  if (!cliReady) {
+    console.log('CLI not ready — queuing task prompt instead of typing into the pane');
+    pendingTask = text;
+    return;
+  }
   try {
     try {
       execSync(`find /tmp -maxdepth 1 -type d -user dev -not -name 'tmux-*' -not -name 'claude-*' -not -name 'node-*' -not -name '.' -mmin +60 -exec rm -rf {} + 2>/dev/null; find /tmp -maxdepth 1 -type f -user dev -name '*.out' -o -name '*.html' -mmin +60 -exec rm -f {} + 2>/dev/null`, { timeout: 15000 });
@@ -224,16 +291,18 @@ function tmuxSendKeys(text) {
       sleepMs(1000);
       execSync(`tmux send-keys -t ${TMUX_SESSION} C-c`, { timeout: 15000 });
       sleepMs(2000);
+      // Queue this prompt and hand delivery to the readiness callback.
+      // Previously the restart set cliReady=false and then FELL THROUGH to the
+      // send loop below, typing the prompt into a pane where the CLI had just
+      // been Ctrl-C'd and had not come back — the exact sequence in #2203.
+      pendingTask = text;
+      cliReady = false;
       try {
-        const confPaths2 = ['/usr/local/etc/hive/backends.conf', path.join(process.cwd(), 'config/backends.conf')];
-        const confPath2 = confPaths2.find(p => fs.existsSync(p)) || confPaths2[0];
-        const CMD = execSync(`bash -c 'source ${confPath2} 2>/dev/null; backend_binary ${BACKEND}'`, { encoding: 'utf8', timeout: 15000 }).trim() || BACKEND;
-        const PERM = execSync(`bash -c 'source ${confPath2} 2>/dev/null; backend_perm_flag ${BACKEND}'`, { encoding: 'utf8', timeout: 15000 }).trim();
-        execSync(`tmux send-keys -t ${TMUX_SESSION} '${CMD} ${PERM}' Enter`, { timeout: 15000 });
-        cliReady = false;
-        waitForCLI().then(() => { cliReady = true; if (pendingTask) { const t = pendingTask; pendingTask = null; tmuxSendKeys(t); } }).catch(() => {});
-        sleepMs(10000);
-      } catch (e) { console.error('CLI restart failed:', e.message); }
+        console.log(`CLI restarted: ${relaunchCLI()}`);
+      } catch (e) {
+        console.error('CLI restart failed:', e.message);
+      }
+      return;
     }
     const MAX_SEND_RETRIES = 3;
     const RETRY_DELAY_MS = 10000;
@@ -315,12 +384,27 @@ function bobIsRunning() {
 // Relaunch the backend CLI in the tmux session using the flags from
 // backends.conf, the same way contributor-agent.sh first launched it.
 function relaunchCLI() {
-  const confPaths = ['/usr/local/etc/hive/backends.conf', path.join(process.cwd(), 'config/backends.conf')];
-  const confPath = confPaths.find(p => fs.existsSync(p)) || confPaths[0];
-  const CMD = execSync(`bash -c 'source ${confPath} 2>/dev/null; backend_binary ${BACKEND}'`, { encoding: 'utf8', timeout: 15000 }).trim() || BACKEND;
-  const PERM = execSync(`bash -c 'source ${confPath} 2>/dev/null; backend_perm_flag ${BACKEND}'`, { encoding: 'utf8', timeout: 15000 }).trim();
-  execSync(`tmux send-keys -t ${TMUX_SESSION} '${CMD} ${PERM}' Enter`, { timeout: 15000 });
-  return `${CMD} ${PERM}`;
+  const launchCmd = buildLaunchCommand();
+  // The pane may be wedged in bash PS2 continuation; clear it or the relaunch
+  // command is swallowed as more continuation text and never runs.
+  recoverWedgedShell();
+  execSync(`tmux send-keys -t ${TMUX_SESSION} ${shellQuote(launchCmd)} Enter`, { timeout: 15000 });
+  // The CLI is NOT up yet. cliReady must stay false until the readiness
+  // classifier positively confirms it, or a task prompt sent in the meantime
+  // is typed as literal keystrokes into a bare shell (issue #2203, bug 2).
+  cliReady = false;
+  waitForCLI().then(() => {
+    cliReady = true;
+    flushPendingTask();
+  }).catch(e => console.error(`CLI did not become ready after relaunch: ${e.message}`));
+  return launchCmd;
+}
+
+function flushPendingTask() {
+  if (!pendingTask) return;
+  const t = pendingTask;
+  pendingTask = null;
+  tmuxSendKeys(t);
 }
 
 function checkTmuxIdle() {
@@ -421,12 +505,38 @@ const PR_REVIEW_EVERY_N = 5;
 let taskTimeoutHandle = null;
 let lastProgressTick = 0;
 
-function failCurrentTask(reason) {
+// Crash-restart bookkeeping, keyed by the underlying work item (repo#number)
+// rather than task_id — the hub mints a NEW task_id on every reassignment of
+// the same issue, so a task_id-keyed counter would reset each round and never
+// reach the cap (issue #2203, bug 3).
+const cliRestartCounts = new Map();
+const givenUpTasks = new Map();
+
+function taskKey(task) {
+  return task && task.repo ? `${task.repo}#${task.number}` : (task && task.task_id) || 'unknown';
+}
+
+function isGivenUp(key) {
+  const at = givenUpTasks.get(key);
+  if (at === undefined) return false;
+  if (Date.now() - at > GIVE_UP_MEMORY_MS) {
+    givenUpTasks.delete(key);
+    return false;
+  }
+  return true;
+}
+
+function restartBackoffMs(attempt) {
+  return Math.min(TASK_RESTART_BASE_BACKOFF_MS * Math.pow(2, attempt - 1), TASK_RESTART_MAX_BACKOFF_MS);
+}
+
+function failCurrentTask(reason, opts) {
   if (!currentTask) return;
+  const permanent = !!(opts && opts.permanent);
   const taskId = currentTask.task_id;
   const tmuxLines = captureTmuxLines(TMUX_TAIL_LINES);
-  console.error(`Task ${taskId} failed: ${reason}`);
-  send({ type: 'task_failed', seq: nextSeq(), task_id: taskId, reason, tmux_output: tmuxLines });
+  console.error(`Task ${taskId} failed${permanent ? ' permanently' : ''}: ${reason}`);
+  send({ type: 'task_failed', seq: nextSeq(), task_id: taskId, reason, permanent, tmux_output: tmuxLines });
   currentTask = null;
   taskAssignedAt = 0;
   if (progressInterval) { clearInterval(progressInterval); progressInterval = null; }
@@ -446,90 +556,110 @@ function startProgressReporting() {
     }
   }, MAX_TASK_DURATION_MS);
 
-  progressInterval = setInterval(() => {
-    lastProgressTick = Date.now();
-    if (!currentTask) return;
-    if (Date.now() - taskAssignedAt < TASK_GRACE_PERIOD_MS) return;
+  progressInterval = setInterval(progressTick, PROGRESS_REPORT_INTERVAL_MS);
+}
 
+// One iteration of the progress/completion/crash-detection loop. Extracted from
+// the setInterval body so it can be driven deterministically from tests.
+function progressTick() {
+  lastProgressTick = Date.now();
+  if (!currentTask) return;
+  if (Date.now() - taskAssignedAt < TASK_GRACE_PERIOD_MS) return;
+
+  try {
+    let procs = '';
     try {
-      let procs = '';
-      try {
-        if (fs.existsSync('/proc')) {
-          procs = execSync(`for p in /proc/[0-9]*/cmdline; do tr "\\0" " " < "$p" 2>/dev/null; done`, { encoding: 'utf8', timeout: 15000 });
-        } else {
-          procs = execSync(`ps -eo command 2>/dev/null`, { encoding: 'utf8', timeout: 15000 });
-        }
-      } catch (_) { procs = BACKEND; }
-      const cliAlive = procs.includes(BACKEND) || procs.includes('claude') || procs.includes('copilot') || procs.includes('bob') || procs.includes('codex') || procs.includes('goose') || procs.includes('pi');
-      // bob is not a persistent REPL: it exits at the end of every turn ("Bob
-      // goes to sleep 💤"). For bob an exited process is the normal completion
-      // signal, not a crash, so it must fall through to the checkTmuxIdle()
-      // path below and be reported as task_complete. Treating it as a death
-      // here reported finished work as task_failed on every single task.
-      const cliExitIsNormal = BACKEND === 'bob';
-      if (!cliAlive && !cliExitIsNormal) {
-        console.error(`CLI process (${BACKEND}) died — restarting and reporting task as failed`);
-        try {
-          const confPaths = ['/usr/local/etc/hive/backends.conf', path.join(process.cwd(), 'config/backends.conf')];
-          const confPath = confPaths.find(p => fs.existsSync(p)) || confPaths[0];
-          const CMD = execSync(`bash -c 'source ${confPath} 2>/dev/null; backend_binary ${BACKEND}'`, { encoding: 'utf8', timeout: 15000 }).trim() || BACKEND;
-          const PERM = execSync(`bash -c 'source ${confPath} 2>/dev/null; backend_perm_flag ${BACKEND}'`, { encoding: 'utf8', timeout: 15000 }).trim();
-          execSync(`tmux send-keys -t ${TMUX_SESSION} '${CMD} ${PERM}' Enter`, { timeout: 15000 });
-          console.log(`CLI restarted: ${CMD} ${PERM}`);
-          cliReady = false;
-          waitForCLI().then(() => { cliReady = true; }).catch(() => {});
-        } catch (e) {
-          console.error('Failed to restart CLI:', e.message);
-        }
-        failCurrentTask('CLI process exited — restarted');
+      if (fs.existsSync('/proc')) {
+        procs = execSync(`for p in /proc/[0-9]*/cmdline; do tr "\\0" " " < "$p" 2>/dev/null; done`, { encoding: 'utf8', timeout: 15000 });
+      } else {
+        procs = execSync(`ps -eo command 2>/dev/null`, { encoding: 'utf8', timeout: 15000 });
+      }
+    } catch (_) { procs = BACKEND; }
+    const cliAlive = procs.includes(BACKEND) || procs.includes('claude') || procs.includes('copilot') || procs.includes('bob') || procs.includes('codex') || procs.includes('goose') || procs.includes('pi');
+    // bob is not a persistent REPL: it exits at the end of every turn ("Bob
+    // goes to sleep 💤"). For bob an exited process is the normal completion
+    // signal, not a crash, so it must fall through to the checkTmuxIdle()
+    // path below and be reported as task_complete. Treating it as a death
+    // here reported finished work as task_failed on every single task.
+    const cliExitIsNormal = BACKEND === 'bob';
+    if (!cliAlive && !cliExitIsNormal) {
+      const key = taskKey(currentTask);
+      const attempt = (cliRestartCounts.get(key) || 0) + 1;
+      cliRestartCounts.set(key, attempt);
+
+      if (attempt > MAX_TASK_CLI_RESTARTS) {
+        // Terminal give-up (issue #2203, bug 3). Do NOT relaunch on this
+        // task's behalf again; report a permanent failure so the hub can
+        // hand the work to a different contributor instead of looping.
+        // The relay itself stays healthy and keeps accepting NEW tasks —
+        // only this one work item is poisoned — so a single bad task can
+        // never wedge the whole contributor.
+        givenUpTasks.set(key, Date.now());
+        cliRestartCounts.delete(key);
+        failCurrentTask(
+          `CLI process exited ${MAX_TASK_CLI_RESTARTS} times for ${key} — giving up on this task (relay still accepting other work)`,
+          { permanent: true }
+        );
+        // Bring the CLI back so the next, different task can run.
+        try { console.log(`CLI restarted: ${relaunchCLI()}`); } catch (e) { console.error('Failed to restart CLI:', e.message); }
         return;
       }
-    } catch (_) {}
 
-    const idle = checkTmuxIdle();
-    const tmuxLines = captureTmuxLines(TMUX_TAIL_LINES);
-    if (idle) {
-      console.log(`Task ${currentTask.task_id} completed — agent idle`);
-      send({ type: 'task_complete', seq: nextSeq(), task_id: currentTask.task_id, result: 'completed', summary: 'Agent returned to idle', tmux_output: tmuxLines });
-      // bob exits after each turn, so the pane is now a bare shell. Bring it
-      // back up before the next task, or the prompt would be typed into bash
-      // ("-bash: <prompt>: command not found") and silently lost.
-      if (BACKEND === 'bob' && !bobIsRunning()) {
-        try {
-          console.log(`Relaunching bob for the next task: ${relaunchCLI()}`);
-          cliReady = false;
-          waitForCLI().then(() => {
-            cliReady = true;
-            if (pendingTask) { const t = pendingTask; pendingTask = null; tmuxSendKeys(t); }
-          }).catch(e => console.error(e.message));
-        } catch (e) {
-          console.error('Failed to relaunch bob:', e.message);
-        }
+      const backoff = restartBackoffMs(attempt);
+      console.error(`CLI process (${BACKEND}) died — restart ${attempt}/${MAX_TASK_CLI_RESTARTS} for ${key} after ${backoff / 1000}s backoff`);
+      sleepMs(backoff);
+      try {
+        console.log(`CLI restarted: ${relaunchCLI()}`);
+      } catch (e) {
+        console.error('Failed to restart CLI:', e.message);
       }
-      const completedRepo = currentTask.repo;
-      currentTask = null;
-      taskAssignedAt = 0;
-      clearInterval(progressInterval);
-      progressInterval = null;
-      if (taskTimeoutHandle) { clearTimeout(taskTimeoutHandle); taskTimeoutHandle = null; }
-      tasksCompletedCount++;
-      if (tasksCompletedCount % PR_REVIEW_EVERY_N === 0) {
-        console.log(`PR review cycle (${tasksCompletedCount} tasks completed) — checking open PRs`);
-        currentTask = { task_id: `pr-review-${Date.now()}`, kind: 'review', repo: completedRepo, number: 0, title: 'Review open PRs for comments' };
-        taskAssignedAt = Date.now();
-        const reviewPrompt = `Check your open PRs on ${completedRepo} for review comments. ` +
-          `Run 'GH_TOKEN=$GH_TOKEN gh pr list --repo ${completedRepo} --author @me --state open' to find them. ` +
-          `For each PR with review comments, read the comments, address the feedback, push fixes, and respond. ` +
-          `If no PRs have comments, just say "No PR comments to address."`;
-        tmuxSendKeys(reviewPrompt);
-        startProgressReporting();
-      } else {
-        send({ type: 'ready', seq: nextSeq() });
-      }
-    } else {
-      send({ type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, status: 'working', tmux_output: tmuxLines });
+      failCurrentTask('CLI process exited — restarted');
+      return;
     }
-  }, PROGRESS_REPORT_INTERVAL_MS);
+  } catch (_) {}
+
+  const idle = checkTmuxIdle();
+  const tmuxLines = captureTmuxLines(TMUX_TAIL_LINES);
+  if (idle) {
+    console.log(`Task ${currentTask.task_id} completed — agent idle`);
+    // Successful completion clears this work item's crash-retry budget.
+    cliRestartCounts.delete(taskKey(currentTask));
+    send({ type: 'task_complete', seq: nextSeq(), task_id: currentTask.task_id, result: 'completed', summary: 'Agent returned to idle', tmux_output: tmuxLines });
+    // bob exits after each turn, so the pane is now a bare shell. Bring it
+    // back up before the next task, or the prompt would be typed into bash
+    // ("-bash: <prompt>: command not found") and silently lost.
+    if (BACKEND === 'bob' && !bobIsRunning()) {
+      try {
+        // relaunchCLI() clears cliReady and re-arms the readiness callback,
+        // which flushes any queued prompt once the CLI is confirmed up.
+        console.log(`Relaunching bob for the next task: ${relaunchCLI()}`);
+      } catch (e) {
+        console.error('Failed to relaunch bob:', e.message);
+      }
+    }
+    const completedRepo = currentTask.repo;
+    currentTask = null;
+    taskAssignedAt = 0;
+    clearInterval(progressInterval);
+    progressInterval = null;
+    if (taskTimeoutHandle) { clearTimeout(taskTimeoutHandle); taskTimeoutHandle = null; }
+    tasksCompletedCount++;
+    if (tasksCompletedCount % PR_REVIEW_EVERY_N === 0) {
+      console.log(`PR review cycle (${tasksCompletedCount} tasks completed) — checking open PRs`);
+      currentTask = { task_id: `pr-review-${Date.now()}`, kind: 'review', repo: completedRepo, number: 0, title: 'Review open PRs for comments' };
+      taskAssignedAt = Date.now();
+      const reviewPrompt = `Check your open PRs on ${completedRepo} for review comments. ` +
+        `Run 'GH_TOKEN=$GH_TOKEN gh pr list --repo ${completedRepo} --author @me --state open' to find them. ` +
+        `For each PR with review comments, read the comments, address the feedback, push fixes, and respond. ` +
+        `If no PRs have comments, just say "No PR comments to address."`;
+      tmuxSendKeys(reviewPrompt);
+      startProgressReporting();
+    } else {
+      send({ type: 'ready', seq: nextSeq() });
+    }
+  } else {
+    send({ type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, status: 'working', tmux_output: tmuxLines });
+  }
 }
 
 function handleMessage(data) {
@@ -576,6 +706,15 @@ function handleMessage(data) {
         send({ type: 'task_failed', seq: nextSeq(), task_id: msg.task_id, reason: 'Already has active task' });
         break;
       }
+      // A task we already gave up on permanently must not restart the loop if
+      // the hub reassigns it anyway (issue #2203, bug 3). Reject it up front
+      // and stay available for other work.
+      if (isGivenUp(taskKey(msg))) {
+        console.log(`Rejecting ${taskKey(msg)} — previously given up on after ${MAX_TASK_CLI_RESTARTS} CLI crashes`);
+        send({ type: 'task_failed', seq: nextSeq(), task_id: msg.task_id, reason: `previously given up on after ${MAX_TASK_CLI_RESTARTS} CLI crashes`, permanent: true });
+        send({ type: 'ready', seq: nextSeq() });
+        break;
+      }
       currentTask = msg;
       console.log(`Task assigned: ${msg.kind} ${msg.repo}#${msg.number} — ${msg.title}`);
       if (msg.github_token) {
@@ -585,12 +724,9 @@ function handleMessage(data) {
       fs.writeFileSync(TASK_FILE, JSON.stringify(msg, null, 2));
       send({ type: 'task_accepted', seq: nextSeq(), task_id: msg.task_id });
       const taskPrompt = msg.prompt || `Work on ${msg.kind} ${msg.repo}#${msg.number}: ${msg.title}`;
-      if (cliReady) {
-        tmuxSendKeys(taskPrompt);
-      } else {
-        console.log('CLI not ready yet — queuing task prompt');
-        pendingTask = taskPrompt;
-      }
+      // tmuxSendKeys() itself queues when the CLI is not confirmed ready, so
+      // there is a single gate rather than two that can disagree.
+      tmuxSendKeys(taskPrompt);
       startProgressReporting();
       break;
 
@@ -678,4 +814,32 @@ function cleanup() {
 process.on('SIGTERM', () => { cleanup(); process.exit(0); });
 process.on('SIGINT', () => { cleanup(); process.exit(0); });
 
-connect();
+// Test hook: when HIVE_RELAY_TEST_MODE=1 the relay exposes its internals and
+// does NOT open a hub connection, so contributor-relay.test.js can drive the
+// restart/queueing/give-up logic directly. Production runs never set this.
+if (process.env.HIVE_RELAY_TEST_MODE === '1') {
+  module.exports = {
+    buildLaunchCommand,
+    handleMessage,
+    tmuxSendKeys,
+    flushPendingTask,
+    relaunchCLI,
+    failCurrentTask,
+    startProgressReporting,
+    progressTick,
+    // Run one progress tick with the grace period already elapsed.
+    __crashTick: () => { taskAssignedAt = Date.now() - TASK_GRACE_PERIOD_MS - 1; progressTick(); },
+    cleanup,
+    restartBackoffMs,
+    NO_MODEL_FLAG_BACKENDS,
+    MAX_TASK_CLI_RESTARTS,
+    setCliReady: (v) => { cliReady = v; },
+    getCliReady: () => cliReady,
+    getPendingTask: () => pendingTask,
+    setPendingTask: (v) => { pendingTask = v; },
+    getCurrentTask: () => currentTask,
+    setWs: (w) => { ws = w; },
+  };
+} else {
+  connect();
+}

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -1,0 +1,386 @@
+// Tests for bin/contributor-relay.sh (JavaScript despite the .sh extension).
+//
+// Regression coverage for kubestellar/hive#2203 — "Contributor agent stuck in
+// infinite crash loop after periodic CLI restart". Reported with a full source
+// root-cause analysis by @castrojo.
+//
+// Run: node bin/contributor-relay.test.js
+
+'use strict';
+
+const assert = require('assert');
+const Module = require('module');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+// Set for the whole run, not just during module load: the relay checks it at
+// CALL time in sleepMs() to skip its busy-wait, and the restart paths sleep for
+// seconds at a time.
+process.env.HIVE_RELAY_TEST_MODE = '1';
+
+const RELAY_PATH = path.join(__dirname, 'contributor-relay.sh');
+
+// ---------------------------------------------------------------------------
+// Harness: load the relay with child_process/ws stubbed out, so no tmux, no
+// bash and no WebSocket are ever touched.
+// ---------------------------------------------------------------------------
+
+function loadRelay({ backend = 'copilot', model = '', cliStates = ['ready'], procAlive = true } = {}) {
+  const commands = [];
+  const sent = [];
+  let stateIdx = 0;
+  // Guard against a runaway loop in the code under test eating all memory.
+  const MAX_RECORDED_COMMANDS = 10000;
+
+  const fakeExecSync = (cmd) => {
+    if (commands.length < MAX_RECORDED_COMMANDS) commands.push(cmd);
+    if (/backend_binary/.test(cmd)) return `${backend}\n`;
+    if (/backend_perm_flag/.test(cmd)) return '--allow-all\n';
+    if (/capture-pane/.test(cmd)) {
+      const state = cliStates[Math.min(stateIdx++, cliStates.length - 1)];
+      // Panes that getCLIState()/checkTmuxIdle() classify per backend.
+      if (state === 'ready') return '/ commands for help\n';
+      if (state === 'working') return '/ commands for help\nesc cancel\n';
+      return 'dev@host:~$ \n';
+    }
+    if (/cmdline|ps -eo/.test(cmd)) {
+      // The relay's liveness probe greps this for the backend name. When the
+      // CLI is "dead" the pane is a bare shell — and crucially the string must
+      // not contain any known backend name.
+      return procAlive ? `${backend} --allow-all\n` : '/usr/bin/sh\n';
+    }
+    return '';
+  };
+
+  const stubs = {
+    child_process: {
+      execSync: fakeExecSync,
+      execFile: () => {},
+    },
+    ws: class FakeWebSocket {
+      static get OPEN() { return 1; }
+      constructor() { this.readyState = 1; }
+      on() {}
+      send(payload) { sent.push(JSON.parse(payload)); }
+      close() {}
+      ping() {}
+    },
+  };
+
+  const origResolve = Module._resolveFilename;
+  const origLoad = Module._load;
+  Module._load = function (request, parent, isMain) {
+    if (Object.prototype.hasOwnProperty.call(stubs, request)) return stubs[request];
+    return origLoad.apply(this, arguments);
+  };
+
+  const prevEnv = { ...process.env };
+  process.env.HIVE_REGISTRATION_TOKEN = 'test-token';
+  process.env.AGENT_BACKEND = backend;
+  process.env.AGENT_MODEL = model;
+  process.env.GOOSE_MODEL = '';
+  process.env.HIVE_AGENT_SESSION = 'contributor';
+
+  // Keep the relay's task-file write out of the real /tmp path used in prod.
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-test-'));
+
+  // node refuses to require a .sh file with the default extension handlers;
+  // register .sh as JavaScript. This must happen BEFORE require.resolve(), and
+  // the cache must be cleared on every load so each test gets a fresh module
+  // wired to its own execSync stub.
+  Module._extensions['.sh'] = Module._extensions['.js'];
+  for (const key of Object.keys(require.cache)) {
+    if (key.includes('contributor-relay.sh')) delete require.cache[key];
+  }
+  let relay;
+  try {
+    relay = require(RELAY_PATH);
+  } finally {
+    Module._load = origLoad;
+    Module._resolveFilename = origResolve;
+    process.env = prevEnv;
+    process.env.HIVE_RELAY_TEST_MODE = '1';
+  }
+
+  const ws = new stubs.ws();
+  relay.setWs(ws);
+  relay.__commands = commands;
+  relay.__sent = sent;
+  relay.__tmpDir = tmpDir;
+  relay.__tmuxSends = () => commands.filter(c => /send-keys/.test(c));
+  return relay;
+}
+
+function teardown(relay) {
+  try { relay.cleanup(); } catch (_) {}
+}
+
+const tests = [];
+function test(name, fn) { tests.push([name, fn]); }
+
+// ---------------------------------------------------------------------------
+// Bug 1 — the relaunch command must keep the model flag, and must never pass
+// --model to bob.
+// ---------------------------------------------------------------------------
+
+test('relaunch command includes --model for a model-taking backend', () => {
+  const relay = loadRelay({ backend: 'copilot', model: 'gpt-5.6-luna' });
+  try {
+    const cmd = relay.buildLaunchCommand();
+    assert.match(cmd, /--model gpt-5\.6-luna/, `expected model flag in launch command, got: ${cmd}`);
+    assert.match(cmd, /copilot/);
+    assert.match(cmd, /--allow-all/);
+  } finally { teardown(relay); }
+});
+
+test('relaunchCLI() sends the model flag to tmux, not just the bare binary', () => {
+  const relay = loadRelay({ backend: 'copilot', model: 'gpt-5.6-luna' });
+  try {
+    relay.relaunchCLI();
+    const launch = relay.__tmuxSends().find(c => /copilot/.test(c));
+    assert.ok(launch, 'no launch command was sent to tmux');
+    assert.match(launch, /--model gpt-5\.6-luna/,
+      `restart path dropped the model flag (issue #2203 bug 1): ${launch}`);
+  } finally { teardown(relay); }
+});
+
+test('bob never receives --model even when AGENT_MODEL is set', () => {
+  const relay = loadRelay({ backend: 'bob', model: 'some-model' });
+  try {
+    const cmd = relay.buildLaunchCommand();
+    assert.ok(!/--model/.test(cmd),
+      `--model is fatal for bob ("Cannot read properties of undefined (reading 'maxTokens')"), got: ${cmd}`);
+  } finally { teardown(relay); }
+});
+
+test('amazonq and goose are also excluded from --model', () => {
+  for (const backend of ['amazonq', 'goose']) {
+    const relay = loadRelay({ backend, model: 'some-model' });
+    try {
+      assert.ok(!/--model/.test(relay.buildLaunchCommand()), `${backend} should not get --model`);
+    } finally { teardown(relay); }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Bug 2 — a task prompt must never be typed into a pane that is not confirmed
+// ready, or the literal keystrokes land on bash and wedge it in PS2.
+// ---------------------------------------------------------------------------
+
+const PROMPT_WITH_APOSTROPHES =
+  "Work on issue foo/bar#421. Fork it with 'gh repo fork foo/bar --clone=false' first.";
+
+test('task prompt is queued, not typed, while cliReady is false', () => {
+  const relay = loadRelay({ backend: 'copilot' });
+  try {
+    relay.setCliReady(false);
+    relay.setPendingTask(null);
+    relay.tmuxSendKeys(PROMPT_WITH_APOSTROPHES);
+
+    assert.strictEqual(relay.getPendingTask(), PROMPT_WITH_APOSTROPHES,
+      'prompt should have been queued while the CLI was not ready');
+    const literalSends = relay.__tmuxSends().filter(c => / -l /.test(c));
+    assert.deepStrictEqual(literalSends, [],
+      `no literal keystrokes may be sent to an unready pane (issue #2203 bug 2): ${literalSends}`);
+  } finally { teardown(relay); }
+});
+
+test('queued prompt flushes once the CLI is confirmed ready', () => {
+  const relay = loadRelay({ backend: 'copilot' });
+  try {
+    relay.setCliReady(false);
+    relay.setPendingTask(null);
+    relay.tmuxSendKeys(PROMPT_WITH_APOSTROPHES);
+    const queued = relay.getPendingTask();
+    assert.strictEqual(queued, PROMPT_WITH_APOSTROPHES, 'precondition: prompt is queued');
+
+    const before = relay.__tmuxSends().length;
+    relay.setCliReady(true);
+    relay.setPendingTask(queued);
+    relay.flushPendingTask();
+
+    const literalSends = relay.__tmuxSends().slice(before).filter(c => / -l /.test(c));
+    assert.ok(literalSends.some(c => c.includes('gh repo fork')),
+      `prompt should be delivered once the CLI is ready; literal sends: ${JSON.stringify(literalSends)}`);
+    assert.strictEqual(relay.getPendingTask(), null, 'queue should be drained after delivery');
+  } finally { teardown(relay); }
+});
+
+test('task_assign queues rather than typing when the CLI is not ready', () => {
+  const relay = loadRelay({ backend: 'copilot' });
+  try {
+    relay.setCliReady(false);
+    relay.setPendingTask(null);
+    relay.handleMessage(JSON.stringify({
+      type: 'task_assign',
+      task_id: 'ct-1',
+      kind: 'issue',
+      repo: 'foo/bar',
+      number: 421,
+      title: 'something',
+      prompt: PROMPT_WITH_APOSTROPHES,
+    }));
+
+    assert.strictEqual(relay.getPendingTask(), PROMPT_WITH_APOSTROPHES);
+    const literalSends = relay.__tmuxSends().filter(c => / -l /.test(c));
+    assert.deepStrictEqual(literalSends, [], 'task_assign must not type into an unready pane');
+  } finally { teardown(relay); }
+});
+
+test('relaunchCLI() leaves cliReady false until readiness is confirmed', () => {
+  const relay = loadRelay({ backend: 'copilot', cliStates: ['starting'] });
+  try {
+    relay.setCliReady(true);
+    relay.relaunchCLI();
+    assert.strictEqual(relay.getCliReady(), false,
+      'a restart must clear cliReady; it may only be set by the readiness classifier');
+  } finally { teardown(relay); }
+});
+
+test('relaunch clears a wedged bash PS2 line before sending the command', () => {
+  const relay = loadRelay({ backend: 'copilot' });
+  try {
+    relay.relaunchCLI();
+    const sends = relay.__tmuxSends();
+    const cIdx = sends.findIndex(c => /\bC-u\b/.test(c));
+    const launchIdx = sends.findIndex(c => /copilot/.test(c));
+    assert.ok(cIdx >= 0, 'expected a C-u to clear a possibly-wedged shell line');
+    assert.ok(cIdx < launchIdx, 'the wedge recovery must run before the launch command');
+  } finally { teardown(relay); }
+});
+
+// ---------------------------------------------------------------------------
+// Bug 3 — bounded retries, permanent give-up, and the relay staying available.
+// ---------------------------------------------------------------------------
+
+function assignTask(relay, taskId, number = 421) {
+  relay.handleMessage(JSON.stringify({
+    type: 'task_assign',
+    task_id: taskId,
+    kind: 'issue',
+    repo: 'foo/bar',
+    number,
+    title: 'crashy task',
+    prompt: 'do the thing',
+  }));
+}
+
+// Drive the crash path directly: assign, then let the progress tick observe a
+// dead CLI. startProgressReporting() uses a long interval, so instead of
+// waiting we re-enter via repeated assign/crash cycles using fake timers.
+// Independent of the configured value: the cap must be a small finite number.
+// Without this a regression that sets it to Infinity/MAX_SAFE_INTEGER would
+// still satisfy every cap-relative assertion below while restoring the exact
+// infinite loop #2203 reports.
+const CAP_SANITY_LIMIT = 10;
+
+test('the CLI-restart cap is a small finite number', () => {
+  const relay = loadRelay({ backend: 'copilot' });
+  try {
+    const cap = relay.MAX_TASK_CLI_RESTARTS;
+    assert.ok(Number.isInteger(cap) && cap >= 1 && cap <= CAP_SANITY_LIMIT,
+      `MAX_TASK_CLI_RESTARTS must be a small finite integer to bound the retry loop, got: ${cap}`);
+  } finally { teardown(relay); }
+});
+
+test('crash restarts are capped and end in a permanent failure', () => {
+  const relay = loadRelay({ backend: 'copilot', procAlive: false });
+  try {
+    relay.setCliReady(true);
+    const cap = relay.MAX_TASK_CLI_RESTARTS;
+    assert.ok(cap <= CAP_SANITY_LIMIT, 'cap must be small enough to drive here');
+
+    // Simulate the hub reassigning the same work item after each failure.
+    for (let i = 0; i <= cap; i++) {
+      assignTask(relay, `ct-421-${i}`);
+      relay.__crashTick();
+    }
+
+    const failures = relay.__sent.filter(m => m.type === 'task_failed');
+    assert.ok(failures.length >= cap + 1, `expected at least ${cap + 1} failures, got ${failures.length}`);
+
+    const permanent = failures.filter(m => m.permanent === true);
+    assert.ok(permanent.length >= 1,
+      'after the retry cap the relay must report a PERMANENT failure so the hub reassigns elsewhere');
+    assert.match(permanent[0].reason, /giving up/i);
+
+    // And the non-permanent ones stop: no unbounded retrying.
+    const transient = failures.filter(m => !m.permanent);
+    assert.ok(transient.length <= cap,
+      `retries must be bounded by MAX_TASK_CLI_RESTARTS=${cap}, saw ${transient.length}`);
+  } finally { teardown(relay); }
+});
+
+test('a reassignment of a given-up task is rejected, not retried', () => {
+  const relay = loadRelay({ backend: 'copilot', procAlive: false });
+  try {
+    relay.setCliReady(true);
+    assert.ok(relay.MAX_TASK_CLI_RESTARTS <= CAP_SANITY_LIMIT, 'cap must be small enough to drive here');
+    for (let i = 0; i <= relay.MAX_TASK_CLI_RESTARTS; i++) {
+      assignTask(relay, `ct-421-${i}`);
+      relay.__crashTick();
+    }
+    const before = relay.__sent.length;
+    assignTask(relay, 'ct-421-again');
+
+    assert.strictEqual(relay.getCurrentTask(), null,
+      'a given-up work item must not be accepted again');
+    const after = relay.__sent.slice(before);
+    assert.ok(after.some(m => m.type === 'task_failed' && m.permanent),
+      'reassignment of a given-up task should be refused with a permanent failure');
+    assert.ok(after.some(m => m.type === 'ready'),
+      'the relay must announce it is still ready for other work');
+  } finally { teardown(relay); }
+});
+
+test('after give-up a DIFFERENT task is still accepted', () => {
+  const relay = loadRelay({ backend: 'copilot', procAlive: false });
+  try {
+    relay.setCliReady(true);
+    assert.ok(relay.MAX_TASK_CLI_RESTARTS <= CAP_SANITY_LIMIT, 'cap must be small enough to drive here');
+    for (let i = 0; i <= relay.MAX_TASK_CLI_RESTARTS; i++) {
+      assignTask(relay, `ct-421-${i}`);
+      relay.__crashTick();
+    }
+    assert.strictEqual(relay.getCurrentTask(), null, 'precondition: no active task after give-up');
+
+    relay.setCliReady(true);
+    assignTask(relay, 'ct-999-0', 999);
+    const task = relay.getCurrentTask();
+    assert.ok(task, 'a poisoned task must not wedge the whole contributor');
+    assert.strictEqual(task.number, 999);
+  } finally { teardown(relay); }
+});
+
+test('restart backoff grows and is capped', () => {
+  const relay = loadRelay({ backend: 'copilot' });
+  try {
+    const b1 = relay.restartBackoffMs(1);
+    const b2 = relay.restartBackoffMs(2);
+    const b3 = relay.restartBackoffMs(3);
+    assert.ok(b2 > b1 && b3 > b2, `backoff must grow: ${b1}, ${b2}, ${b3}`);
+    assert.strictEqual(relay.restartBackoffMs(50), relay.restartBackoffMs(60),
+      'backoff must saturate at the cap');
+  } finally { teardown(relay); }
+});
+
+// ---------------------------------------------------------------------------
+
+let failed = 0;
+// RELAY_TEST_ONLY=<substring> runs a single test, for debugging in isolation.
+const only = process.env.RELAY_TEST_ONLY;
+for (const [name, fn] of only ? tests.filter(([n]) => n.includes(only)) : tests) {
+  try {
+    fn();
+    console.log(`ok   ${name}`);
+  } catch (e) {
+    failed++;
+    console.error(`FAIL ${name}`);
+    console.error(`     ${e.message}`);
+  }
+}
+console.log(`\n${tests.length - failed}/${tests.length} passed`);
+// waitForCLI() schedules polling timers that would otherwise keep the event
+// loop alive well past the last assertion; exit explicitly.
+process.exit(failed ? 1 : 0);

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -90,6 +90,12 @@ type WSMessage struct {
 	Summary           string          `json:"summary,omitempty"`
 	TmuxOutput        []string        `json:"tmux_output,omitempty"`
 	AcceptedModels    []string        `json:"accepted_models,omitempty"`
+	// Permanent marks a task_failed the relay will not retry: it exhausted its
+	// per-task CLI-restart budget and gave up (see MAX_TASK_CLI_RESTARTS in
+	// bin/contributor-relay.sh). Reassigning the same work item to the same
+	// contributor will be rejected outright, so the hub should prefer a
+	// different contributor. See kubestellar/hive#2203.
+	Permanent bool `json:"permanent,omitempty"`
 }
 
 type WSTaskAssign struct {
@@ -684,6 +690,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 						"username", contributor.profile.GitHubUsername,
 						"task", msg.TaskID,
 						"reason", msg.Reason,
+						"permanent", msg.Permanent,
 					)
 					contributor.mu.Lock()
 					contributor.profile.TasksFailed++


### PR DESCRIPTION
Fixes #2203

## The report

@castrojo filed an unusually good issue: source-level root cause, container logs, and a `tmux capture-pane` dump showing the pane wedged in bash PS2 continuation. The analysis below is theirs; this PR implements and tests it. All three reported bugs were confirmed still present on current `v2`.

## What was broken

A contributor would complete 3 tasks, hit the periodic "restart CLI for memory cleanup", and then fail the 4th issue every ~4 minutes forever — same issue, reassigned indefinitely, starving that hub task slot.

**1. The model flag was dropped on every relaunch.** Only the first launch (`bin/contributor-agent.sh`) built `$CMD $PERM_FLAG $MODEL_FLAG`. All three restart paths in `bin/contributor-relay.sh` rebuilt `$CMD $PERM` inline, permanently losing the resolved model. Visible in the reporter's pane dump:

```
dev@…:~$ copilot --allow-all --model gpt-5.6-luna     ← first launch
dev@…:~$ copilot --allow-all                          ← every restart after
```

**2. The task prompt could be typed into a bare shell.** The memory-cleanup restart set `cliReady = false` and then **fell through** to the send loop, so `tmux send-keys -l` delivered the prompt as literal keystrokes into a pane where the CLI had just been `Ctrl-C`'d and had not come back. The prompt contains literal apostrophes (`'gh repo fork … --clone=false'`), so bash's readline saw an unbalanced quote, dropped into PS2 (`>`), and swallowed everything typed afterwards — including the next relaunch command. That is why the pane shows a stack of `> copilot --allow-all` lines that never ran.

Worth noting: a `cliReady`/`pendingTask` queue already existed in `task_assign`, but it was a *second* gate that the restart path bypassed entirely. Two gates that could disagree.

**3. No retry cap, backoff, or give-up.** Nothing would ever stop the loop.

## What this changes

**Single source of truth for the launch command.** `buildLaunchCommand()` builds `binary + perm flag + model flag` once; first launch and both restart paths use it, so they cannot drift again. It preserves the `bob`/`amazonq`/`goose` exclusion from `--model` — for bob this is not cosmetic, `--model` is fatal (`Cannot read properties of undefined (reading 'maxTokens')`).

**One gate, not two.** `tmuxSendKeys()` now refuses to type into an unconfirmed pane and queues via `pendingTask`; the `task_assign` branch just calls it. `relaunchCLI()` owns clearing `cliReady` and re-arming the readiness callback (the existing `getCLIState()` classifier path), and flushes the queue only once readiness is positively confirmed. It also clears a possibly-wedged PS2 line (`C-c` / `C-u`) before sending the launch command — a pane already in continuation would otherwise swallow the relaunch too.

**Bounded retries.** Crash-restarts are capped at `MAX_TASK_CLI_RESTARTS = 3` with exponential backoff (5s / 10s / 20s, capped at 60s), then a terminal give-up.

Counting is keyed on **`repo#number`, not `task_id`** — the hub mints a new `task_id` on every reassignment, so a `task_id`-keyed counter would reset each round and never reach the cap. This is the detail that makes the fix actually work against the reported failure mode.

**Judgment call, stated explicitly:** after give-up the relay keeps accepting *new* tasks and only refuses *this* work item (for `GIVE_UP_MEMORY_MS`, 1h). A poisoned task must never wedge the whole contributor. There is a test for exactly this.

**Making the failure visible.** The reporter notes nothing surfaces except container stdout. `task_failed` now carries a `permanent` flag; `WSMessage` gains the field and the hub logs it, so a give-up is distinguishable from an ordinary failure hub-side rather than looking like more of the same.

## Tests

New `bin/contributor-relay.test.js` — 14 tests, no tmux, no `ws`, no network (`child_process`/`ws` are stubbed; the relay exposes internals only under `HIVE_RELAY_TEST_MODE=1` and skips `connect()`).

Covers exactly the four behaviours asked for, plus the inverse cases:

- relaunch command includes `--model` for a model-taking backend; `bob`/`amazonq`/`goose` never get `--model`
- a prompt is never sent while `cliReady` is false — it queues and flushes on ready; `relaunchCLI()` leaves `cliReady` false; the PS2 recovery runs *before* the launch command
- retries stop at the cap and report a **permanent** failure
- after give-up, a reassignment of the same item is refused but a **different** task is still accepted

Each fix was mutation-verified — reverting it makes the corresponding tests fail:

| mutation | result |
|---|---|
| drop the model flag from `buildLaunchCommand()` | 2 tests fail |
| remove the `cliReady` gate in `tmuxSendKeys()` | 3 tests fail |
| set the cap to `100` or `MAX_SAFE_INTEGER` | 4 tests fail |

The cap test asserts the value is a *small finite integer* independently of the configured number, so a regression to `Infinity` cannot satisfy cap-relative assertions while restoring the infinite loop.

Wired into `v2-ci.yml` (`node --check` on a `.js` copy, since the file is JavaScript despite the `.sh` extension, plus the suite). The workflow's path filter was `v2/**` only, so `bin/**` changes would never have triggered it — widened to include `bin/contributor-relay*`.

## Verification

Run locally: `node bin/contributor-relay.test.js` (14/14), `node --check` on the relay, `bash -n bin/contributor-agent.sh`, `go build ./...`, `go vet ./pkg/dashboard/`, `gofmt` clean on the touched Go file.

`go test ./pkg/dashboard/` has pre-existing failures on stock `v2` (`TestCovV1_*`, `TestCovDF_*` — they need `/data`); confirmed unchanged by this PR by running them on a clean tree.

Not verified by running: behaviour against a real container/tmux/hub. The restart paths are exercised through stubs, not live tmux.

## Porting

**`mk`, `dd` and `v3` need this ported.** `bin/contributor-relay.sh` is shared across branches and `v3` is what the ks/console hive runs.