### PR TITLE
🐛 fix(hub): drop the App-install step, the repo listing, and the OAuth scope

### DIFF
--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -172,7 +172,22 @@ func (s *HubServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	state := url.QueryEscape(redirect)
-	authURL := fmt.Sprintf("%s?client_id=%s&scope=read:user&redirect_uri=%s&state=%s",
+	// An EMPTY scope is deliberate, not an omission. The hub only needs to know
+	// WHO is logging in: the callback reads GET /user for the login name and
+	// signs it into the session cookie. GitHub serves /user's public profile —
+	// including "login" — for a token with no scopes at all, so identity works
+	// unscoped.
+	//
+	// The hub used to ask for read:user because the request wizard listed the
+	// user's repositories for them to pick from. That listing is gone: it could
+	// only ever see public github.com, and it could never generalize to GitLab
+	// or Gitea. Requesters now type a repository URL instead, which needs no
+	// permission on the requester's account whatsoever.
+	//
+	// Do NOT restore a scope here without also restoring a feature that needs
+	// it — asking for access the product does not use is a consent prompt users
+	// are right to refuse.
+	authURL := fmt.Sprintf("%s?client_id=%s&scope=&redirect_uri=%s&state=%s",
 		defaultGHAuthorizeURL, clientID, "https://hive.kubestellar.io/api/auth/callback", state)
 	http.Redirect(w, r, authURL, http.StatusTemporaryRedirect)
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -211,7 +211,13 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("PUT /api/saas/hives/{id}/approve-access/{username}", s.requireAuth(s.handleApproveAccess))
 	s.mux.HandleFunc("DELETE /api/saas/hives/{id}/deny-access/{username}", s.requireAuth(s.handleDenyAccess))
 	s.mux.HandleFunc("GET /api/saas/access-status", s.handleAccessStatus)
-	s.mux.HandleFunc("GET /api/saas/repos", s.requireAuth(s.handleSaaSRepos))
+	// GET /api/saas/repos is deliberately gone. Repo discovery ran on the
+	// requester's github.com OAuth token, so it could only ever see public
+	// GitHub — invisible to GitHub Enterprise, and structurally unable to list
+	// a GitLab or Gitea repo when those forges arrive. The request flow now
+	// takes a typed repository URL, which works for every forge without new
+	// code, and that is what let the login drop to an empty OAuth scope.
+	// Restoring this endpoint would also require restoring that scope.
 	s.mux.HandleFunc("POST /api/saas/request-provision", s.requireAuth(s.handleRequestProvision))
 	s.mux.HandleFunc("PUT /api/saas/approve-provision/{username}", s.requireAdmin(s.handleApproveProvision))
 	s.mux.HandleFunc("DELETE /api/saas/deny-provision/{username}", s.requireAdmin(s.handleDenyProvision))
@@ -6711,6 +6717,21 @@ const dashboardHTML = `<!DOCTYPE html>
     });
 
     var ACMM_LABELS = {1:'L1 Assisted',2:'L2 Instructed',3:'L3 Measured',4:'L4 Adaptive',5:'L5 Semi-Automated',6:'L6 Autonomous'};
+    /* One-line "what this level actually does" per ACMM level, hoisted out of
+       acmmBadge so the badge tooltip and the Request-a-Hive level picker read
+       from the SAME strings. They used to be a local inside acmmBadge, and the
+       request modal carried its own hand-written copy that had drifted into
+       plain wrong ("L3 CI/CD", "L4 Auto PR", "L6 Fully Autonomous") — L4 in
+       particular is NOT fully autonomous, it opens hold-gated PRs for human
+       review. Anything describing a level must use this object. */
+    var ACMM_TIPS = {1:'L1 Assisted — Advisory only.',2:'L2 Instructed — Advisory beads, no GitHub writes.',3:'L3 Measured — Hold-gated PRs, CI gates.',4:'L4 Adaptive — Agents open issues, sec-check.',5:'L5 Semi-Automated — PRs with hold label, batch review.',6:'L6 Autonomous — Auto-merge on green CI.'};
+    /* The tip strings above lead with the level label; the picker renders the
+       label separately, so strip the redundant "Lx Name — " prefix there. */
+    function acmmTipDetail(level) {
+      var tip = ACMM_TIPS[level] || '';
+      var dash = tip.indexOf('—');
+      return dash >= 0 ? tip.slice(dash + 1).trim() : tip;
+    }
     function sparkline(points, color, w, h) {
       if (!points || points.length < 2) return '';
       var vals = points.map(function(p) { return p.v; });
@@ -6728,8 +6749,7 @@ const dashboardHTML = `<!DOCTYPE html>
 
     function acmmBadge(level) {
       var l = level || 0;
-      var tips = {1:'L1 Assisted — Advisory only.',2:'L2 Instructed — Advisory beads, no GitHub writes.',3:'L3 Measured — Hold-gated PRs, CI gates.',4:'L4 Adaptive — Agents open issues, sec-check.',5:'L5 Semi-Automated — PRs with hold label, batch review.',6:'L6 Autonomous — Auto-merge on green CI.'};
-      return '<span class="acmm-badge acmm-' + l + '" title="' + esc(tips[l] || '') + '">' + (ACMM_LABELS[l] || 'L' + l) + '</span>';
+      return '<span class="acmm-badge acmm-' + l + '" title="' + esc(ACMM_TIPS[l] || '') + '">' + (ACMM_LABELS[l] || 'L' + l) + '</span>';
     }
     /* Classified GitHub App auth states, matching github.AppAuthState.String()
        on the spoke and operatorSideAppStates in journey.go. The two OPERATOR
@@ -11296,11 +11316,56 @@ const dashboardHTML = `<!DOCTYPE html>
       out.style.color = host !== PUBLIC_GITHUB_HOST ? 'var(--accent, #58a6ff)' : 'var(--muted)';
     }
 
+    /* REQUEST_DEFAULT_ACMM_LEVEL is where a new hive starts. L3 Measured is the
+       first level that produces useful output (hold-gated PRs that raise test
+       coverage) while still requiring a human on every merge, which is the
+       right default for someone who has not run a hive before. */
+    var REQUEST_DEFAULT_ACMM_LEVEL = 3;
+    /* ACMM levels offered on the request form, lowest to highest. All six are
+       offered — L5 and L6 are real, selectable levels, not hidden ones. */
+    var REQUEST_ACMM_LEVELS = [1, 2, 3, 4, 5, 6];
+
+    /* renderRequestLevelOptions builds the level picker from ACMM_LABELS and
+       ACMM_TIPS. Rendering rather than hardcoding is the point: the previous
+       hardcoded <option> list had drifted to names that appear nowhere else in
+       the product and described the wrong behaviour. */
+    function renderRequestLevelOptions() {
+      var sel = document.getElementById('rq-level');
+      if (!sel) return;
+      var prev = sel.value;
+      sel.innerHTML = (REQUEST_ACMM_LEVELS || []).map(function(l) {
+        var label = ACMM_LABELS[l] || ('L' + l);
+        var detail = acmmTipDetail(l);
+        /* Label and one-line description live in the option text itself: a
+           <select> shows only the selected option when closed, so a requester
+           browsing the list needs the description inline to compare levels. */
+        return '<option value="' + l + '">' + esc(label) + (detail ? ' &#x2014; ' + esc(detail) : '') + '</option>';
+      }).join('');
+      sel.value = prev || String(REQUEST_DEFAULT_ACMM_LEVEL);
+      if (!sel.value) sel.value = String(REQUEST_DEFAULT_ACMM_LEVEL);
+      if (!sel._rqLevelWired) {
+        sel._rqLevelWired = true;
+        sel.addEventListener('change', syncRequestLevelDesc);
+      }
+      syncRequestLevelDesc();
+    }
+
+    /* syncRequestLevelDesc restates the selected level's description under the
+       picker, so it stays readable once the dropdown is closed. */
+    function syncRequestLevelDesc() {
+      var sel = document.getElementById('rq-level');
+      var out = document.getElementById('rq-level-desc');
+      if (!sel || !out) return;
+      var lvl = parseInt(sel.value, 10) || REQUEST_DEFAULT_ACMM_LEVEL;
+      out.textContent = ACMM_TIPS[lvl] || '';
+    }
+
     /* openRequestHiveModal shows the modal with a freshly populated forge
        picker, so a cluster list that loaded after page render is reflected. */
     function openRequestHiveModal() {
       renderRequestForgeOptions();
       syncRequestForgePreview();
+      renderRequestLevelOptions();
       document.getElementById('request-modal').style.display = 'flex';
     }
 
@@ -12991,14 +13056,11 @@ const dashboardHTML = `<!DOCTYPE html>
         </div>
         <div style="margin-bottom:12px">
           <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">ACMM Level</label>
-          <select id="rq-level" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
-            <option value="1">L1 &#x2014; Assisted</option>
-            <option value="2">L2 &#x2014; Instructed</option>
-            <option value="3" selected>L3 &#x2014; CI/CD</option>
-            <option value="4">L4 &#x2014; Auto PR</option>
-            <option value="5">L5 &#x2014; Self-Governing</option>
-            <option value="6">L6 &#x2014; Fully Autonomous</option>
-          </select>
+          <!-- Options are rendered by renderRequestLevelOptions() from
+               ACMM_LABELS/ACMM_TIPS so this picker can never drift from the
+               names the rest of the hub shows. Do not hardcode them here. -->
+          <select id="rq-level" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem"></select>
+          <div id="rq-level-desc" style="font-size:0.72rem;color:var(--muted);margin-top:6px"></div>
         </div>
       </div>
       <div style="display:flex;gap:12px;justify-content:flex-end;padding:16px 32px;border-top:1px solid var(--border);flex-shrink:0">
@@ -13573,116 +13635,4 @@ func (s *HubServer) handleGetHubBanner(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"banners": banners})
-}
-
-// handleSaaSRepos lists the repositories the requester can pick from in the
-// "Get a hosted hive" flow (step 3).
-//
-// The frontend has always called GET /api/saas/repos, but no handler was ever
-// registered — the fetch 404'd and the page fell through to "No repositories
-// found. Make sure the Hive GitHub App is installed on your org", which blamed
-// the user's App installation for a missing backend route. It failed for every
-// requester regardless of whether the App was installed.
-//
-// Repos come from the App installations the user's OAuth token can see, which
-// covers BOTH org installations and personal-account installations (the
-// original error text assumed orgs only — the first real report was a repo
-// under a personal account).
-//
-// Note this can only ever see public github.com. A GitHub Enterprise repo
-// (github.ibm.com, …) is invisible to a github.com OAuth token, so the UI also
-// lets the requester type a repo URL by hand; that path does not depend on this
-// endpoint.
-func (s *HubServer) handleSaaSRepos(w http.ResponseWriter, r *http.Request) {
-	username := s.getAuthUser(r)
-	if username == "" {
-		http.Error(w, `{"error":"not authenticated"}`, http.StatusUnauthorized)
-		return
-	}
-	user := loadSaaSUser(username)
-	if user == nil || user.EncryptedToken == "" {
-		// No stored token — return an empty list rather than an error so the UI
-		// shows its "install the App / paste a URL" guidance instead of a crash.
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"repos": []any{}})
-		return
-	}
-	token, err := decryptToken(user.EncryptedToken)
-	if err != nil {
-		s.logger.Warn("repos: failed to decrypt user token", "user", username, "error", err)
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"repos": []any{}})
-		return
-	}
-
-	type repoOut struct {
-		FullName    string `json:"full_name"`
-		Name        string `json:"name"`
-		Description string `json:"description,omitempty"`
-	}
-	ghGet := func(url string, out any) error {
-		req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, url, nil)
-		if err != nil {
-			return err
-		}
-		req.Header.Set("Authorization", "token "+token)
-		req.Header.Set("Accept", "application/vnd.github+json")
-		resp, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("github %s: status %d", url, resp.StatusCode)
-		}
-		return json.NewDecoder(resp.Body).Decode(out)
-	}
-
-	// 1. Which App installations can this user see? (orgs AND their own account)
-	var insts struct {
-		Installations []struct {
-			ID int64 `json:"id"`
-		} `json:"installations"`
-	}
-	if err := ghGet("https://api.github.com/user/installations?per_page=100", &insts); err != nil {
-		s.logger.Warn("repos: listing installations failed", "user", username, "error", err)
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"repos": []any{}})
-		return
-	}
-
-	// 2. Repositories per installation, deduped by full_name.
-	seen := map[string]struct{}{}
-	repos := []repoOut{}
-	for _, inst := range insts.Installations {
-		for page := 1; page <= 5; page++ { // cap paging; 500 repos is plenty for a picker
-			var rr struct {
-				Repositories []struct {
-					FullName    string `json:"full_name"`
-					Name        string `json:"name"`
-					Description string `json:"description"`
-				} `json:"repositories"`
-			}
-			url := fmt.Sprintf("https://api.github.com/user/installations/%d/repositories?per_page=100&page=%d", inst.ID, page)
-			if err := ghGet(url, &rr); err != nil {
-				s.logger.Warn("repos: listing installation repos failed",
-					"user", username, "installation", inst.ID, "error", err)
-				break
-			}
-			for _, rp := range rr.Repositories {
-				if _, dup := seen[rp.FullName]; dup {
-					continue
-				}
-				seen[rp.FullName] = struct{}{}
-				repos = append(repos, repoOut{FullName: rp.FullName, Name: rp.Name, Description: rp.Description})
-			}
-			if len(rr.Repositories) < 100 {
-				break
-			}
-		}
-	}
-	sort.Slice(repos, func(i, j int) bool { return repos[i].FullName < repos[j].FullName })
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"repos": repos})
 }

--- a/v2/pkg/hub/static/get-started.html
+++ b/v2/pkg/hub/static/get-started.html
@@ -6,10 +6,10 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🍯</text></svg>">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta property="og:title" content="Get started — put your repo on autopilot">
-  <meta property="og:description" content="Request a hosted hive in four steps, self-host with Docker Compose, or contribute compute to a public hive. No Kubernetes, no setup.">
+  <meta property="og:description" content="Request a hosted hive in three steps, self-host with Docker Compose, or contribute compute to a public hive. No Kubernetes, no setup.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://hive.kubestellar.io/get-started">
-  <meta name="description" content="Get started with Hive — request a hosted hive in four steps, self-host with Docker Compose, or contribute compute to a public hive.">
+  <meta name="description" content="Get started with Hive — request a hosted hive in three steps, self-host with Docker Compose, or contribute compute to a public hive.">
   <title>Get started — put your repo on autopilot</title>
   <style>
     :root {
@@ -290,23 +290,24 @@
   <section class="section-pad">
     <p class="section-label">Get started</p>
     <h1>Get a hosted hive</h1>
-    <p class="lede">Request a hive for your project in four steps. We provision it on our infrastructure &mdash; no Kubernetes, no setup, no compute needed.</p>
+    <p class="lede">Request a hive for your project in three steps. We provision it on our infrastructure &mdash; no Kubernetes, no setup, no compute needed.</p>
 
     <div class="wizard">
       <div class="wizard-steps" id="wizard-steps">
         <div class="wizard-step active" data-step="1"><span class="step-dot">1</span> Login</div>
         <span class="step-arrow">→</span>
-        <div class="wizard-step" data-step="2"><span class="step-dot">2</span> Install App</div>
+        <div class="wizard-step" data-step="2"><span class="step-dot">2</span> Add Repos</div>
         <span class="step-arrow">→</span>
-        <div class="wizard-step" data-step="3"><span class="step-dot">3</span> Select Repos</div>
-        <span class="step-arrow">→</span>
-        <div class="wizard-step" data-step="4"><span class="step-dot">4</span> Request</div>
+        <div class="wizard-step" data-step="3"><span class="step-dot">3</span> Request</div>
       </div>
 
       <!-- Step 1: Login -->
       <div class="wizard-panel active" id="panel-1">
         <h2>Login with GitHub</h2>
-        <p>We use your GitHub identity to verify org membership and to install the Hive GitHub App on your repositories. No passwords are stored.</p>
+        <!-- Identity only. The login requests an EMPTY OAuth scope (see
+             handleLogin in oauth.go) because nothing in this flow reads your
+             account: you tell us the repository URL yourself. -->
+        <p>We use your GitHub identity to know who is asking &mdash; nothing more. We request <strong>no permissions</strong> on your account, and no passwords are stored.</p>
         <div id="login-area">
           <a href="/login?redirect=/get-started" class="btn-github">
             <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
@@ -325,118 +326,65 @@
         </div>
       </div>
 
-      <!-- Step 2: Install GitHub App -->
+      <!-- Step 2: Add repositories by URL.
+           The typed URL is the ONLY input here, by design. The old picker
+           listed repos from the requester's github.com OAuth token, which
+           could never see a GitHub Enterprise repo and could never generalize
+           to another forge. A URL needs no permission on the requester's
+           account and describes any forge. -->
       <div class="wizard-panel" id="panel-2">
-        <h2>Install the Hive GitHub App</h2>
-        <p>The Hive GitHub App lets our agents read issues, open PRs, and respond to CI on your repos. Install it on the org or repos you want to manage.</p>
-        <!-- This button is correct ONLY for public github.com. This page signs
-             you in with the public github.com OAuth app and no hive exists yet,
-             so we genuinely do not know which GitHub instance your repos live
-             on — we must not fake a per-user link here. GitHub Enterprise users
-             get the explicit note below instead of a link that would send their
-             install request to the wrong GitHub entirely. -->
-        <div style="margin:20px 0">
-          <a href="https://github.com/apps/kubestellar-hive" target="_blank" rel="noopener" class="btn-github" id="install-app-btn">
-            <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-            Install Hive GitHub App
-          </a>
-        </div>
-        <p style="font-size:0.82rem;color:var(--muted)">Already installed? Click continue.</p>
-        <div style="margin-top:18px;padding:12px 14px;background:var(--bg-soft);border:1px solid var(--line);border-radius:.7rem">
-          <p style="margin:0 0 6px;font-size:0.86rem;font-weight:700">Using GitHub Enterprise?</p>
-          <p style="margin:0;font-size:0.82rem;color:var(--muted);line-height:1.55">
-            The button above installs on <strong>public github.com</strong>. If your repos live on a
-            GitHub Enterprise instance (<code>github.example.com</code>, and similar), that link will
-            not work &mdash; the install request lands on public GitHub and your Enterprise org admin
-            will never see it.
-            <br><br>
-            Instead: continue to step&nbsp;3 and add your repository by <strong>URL</strong>. We record
-            which Enterprise instance it lives on, and provision your hive against a GitHub App
-            registered on <em>that</em> instance. Your org admin approves the installation from your own
-            Enterprise host &mdash; your hive's dashboard will show the correct install link once it is
-            provisioned. If no App is registered on your Enterprise instance yet, we will set that up
-            with your admin as part of provisioning.
-          </p>
-        </div>
-        <div style="display:flex;gap:12px;margin-top:16px">
-          <button class="btn-secondary" onclick="goToStep(1)">← Back</button>
-          <button class="btn-primary" onclick="goToStep(3)">Continue →</button>
-        </div>
-      </div>
-
-      <!-- Step 3: Select repos -->
-      <div class="wizard-panel" id="panel-3">
-        <h2>Select repositories</h2>
-        <p>Choose which repos the hive should manage. You can add more later from your dashboard.</p>
-        <div id="repo-loading" style="color:var(--muted);padding:24px;text-align:center">Loading your repositories...</div>
-        <div id="repo-list" class="repo-list" style="display:none"></div>
-        <div id="repo-none" style="display:none;padding:24px;text-align:center;color:var(--muted)">
-          <p>No repositories found. Install the <a href="https://github.com/apps/kubestellar-hive" target="_blank" rel="noopener" style="color:var(--blue)">Hive GitHub App</a> on the account or org that owns them &mdash; or add a repo URL below.</p>
-          <p style="font-size:0.82rem">That link is public github.com. <strong>GitHub Enterprise repos will never appear in this list</strong> and cannot be installed from there &mdash; add the repo by URL below and we will provision against your Enterprise instance.</p>
-        </div>
-        <!-- Manual entry. Repo discovery uses the github.com OAuth token, so a
-             GitHub Enterprise repo (github.ibm.com, github.cisco.com, …) can
-             never appear in the list above. Typing the URL is the only way to
-             request one, and it also covers a repo the App has not been
-             installed on yet. -->
-        <div style="margin-top:18px;padding-top:16px;border-top:1px solid var(--line)">
+        <h2>Add your repositories</h2>
+        <p>Paste the URL of each repository the hive should manage. You can add more later from your dashboard.</p>
+        <div>
           <label for="repo-manual" style="display:block;font-size:0.86rem;color:var(--muted);margin-bottom:6px">
-            Or add a repository by URL &mdash; required for GitHub Enterprise (github.ibm.com and similar), which cannot be listed above
+            Repository URL
           </label>
           <div style="display:flex;gap:8px">
-            <input type="text" id="repo-manual" placeholder="https://github.ibm.com/my-org/my-repo"
+            <input type="text" id="repo-manual" placeholder="github.com/my-org/my-repo"
+              onkeydown="if(event.key==='Enter'){event.preventDefault();addManualRepo()}"
               style="flex:1;padding:9px 12px;background:var(--bg-soft);border:1px solid var(--line);border-radius:6px;color:var(--text);font-size:0.88rem">
             <button class="btn-secondary" type="button" onclick="addManualRepo()">Add</button>
           </div>
           <div id="repo-manual-err" style="display:none;margin-top:6px;font-size:0.8rem;color:var(--red)"></div>
+          <p style="font-size:0.8rem;margin-top:8px;margin-bottom:0">
+            With or without <code>https://</code>. Works for public GitHub and for GitHub Enterprise
+            (<code>github.ibm.com</code> and similar) &mdash; we record which instance the repo lives on
+            and provision against it. Examples: <code>github.com/my-org/my-repo</code>,
+            <code>https://github.ibm.com/my-org/my-repo</code>.
+          </p>
         </div>
         <div style="display:flex;gap:12px;margin-top:16px">
-          <button class="btn-secondary" onclick="goToStep(2)">← Back</button>
-          <button class="btn-primary" id="repos-continue" onclick="goToStep(4)" disabled>Continue →</button>
+          <button class="btn-secondary" onclick="goToStep(1)">← Back</button>
+          <button class="btn-primary" id="repos-continue" onclick="goToStep(3)" disabled>Continue →</button>
         </div>
       </div>
 
-      <!-- Step 4: ACMM level + submit -->
-      <div class="wizard-panel" id="panel-4">
+      <!-- Step 3: ACMM level + submit.
+           Options are rendered by renderAcmmOptions() from ACMM_LEVELS so the
+           names match the hub dashboard and the spoke. They previously read
+           "L1 Advisory / L2 Measured / L4 Auto PR", which named the levels
+           wrongly AND described L4 as auto-merging — it does not. -->
+      <div class="wizard-panel" id="panel-3">
         <h2>Choose autonomy level</h2>
         <p>How much should the agents do on their own? Start low and increase as you build confidence. This only controls the mundane work &mdash; security patches, dependency updates, issue triage, test fixes &mdash; so your team can focus on what matters: innovation, outreach, and strategy.</p>
-        <div class="acmm-options" id="acmm-options">
-          <label class="acmm-option selected" onclick="selectAcmm(this, 1)">
-            <input type="radio" name="acmm" value="1" checked>
-            <div>
-              <div class="acmm-label">L1 &mdash; Advisory <span class="acmm-rec">Recommended to start</span></div>
-              <div class="acmm-desc">Agents scan issues and suggest fixes but take no action. You review everything. A safe way to see what the hive would do before granting more autonomy.</div>
-            </div>
-          </label>
-          <label class="acmm-option" onclick="selectAcmm(this, 2)">
-            <input type="radio" name="acmm" value="2">
-            <div>
-              <div class="acmm-label">L2 &mdash; Measured</div>
-              <div class="acmm-desc">Agents open issues to track findings. No PRs, no merges.</div>
-            </div>
-          </label>
-          <label class="acmm-option" onclick="selectAcmm(this, 3)">
-            <input type="radio" name="acmm" value="3">
-            <div>
-              <div class="acmm-label">L3 &mdash; CI-Gated PRs</div>
-              <div class="acmm-desc">Agents open hold-gated pull requests. CI must pass, and a human approves each merge.</div>
-            </div>
-          </label>
-          <label class="acmm-option" onclick="selectAcmm(this, 4)">
-            <input type="radio" name="acmm" value="4">
-            <div>
-              <div class="acmm-label">L4 &mdash; Auto PR</div>
-              <div class="acmm-desc">Agents open and merge PRs on green CI. Human review optional. Best for repos with strong CI coverage.</div>
-            </div>
-          </label>
-        </div>
+        <div class="acmm-options" id="acmm-options"></div>
         <div id="request-summary" style="margin:20px 0;padding:16px;background:#080b0f85;border:1px solid var(--line);border-radius:.7rem;font-size:0.85rem">
           <div style="margin-bottom:8px"><strong>Summary</strong></div>
           <div style="color:var(--muted)">Repos: <span id="summary-repos" style="color:var(--text)">none selected</span></div>
-          <div style="color:var(--muted)">ACMM Level: <span id="summary-acmm" style="color:var(--text)">L1 Advisory</span></div>
+          <div style="color:var(--muted)">ACMM Level: <span id="summary-acmm" style="color:var(--text)"></span></div>
         </div>
+        <!-- The wizard no longer asks anyone to install the GitHub App. This
+             note is the handoff to where that now happens: after provisioning,
+             the hive's own dashboard knows its forge and renders a correct
+             per-instance install link (githubAppInstallURL, from
+             config.GitHubConfig.AppInstallURL). -->
+        <p style="font-size:0.8rem;margin-top:4px">
+          <strong>What happens next:</strong> an admin reviews your request. Once your hive is provisioned,
+          its dashboard will prompt you to install the Hive GitHub App &mdash; with a link pointing at the
+          right GitHub instance for your repos. Nothing to install before then.
+        </p>
         <div style="display:flex;gap:12px;margin-top:16px">
-          <button class="btn-secondary" onclick="goToStep(3)">← Back</button>
+          <button class="btn-secondary" onclick="goToStep(2)">← Back</button>
           <button class="btn-primary" id="submit-request" onclick="submitRequest()">Request a Hive</button>
         </div>
       </div>
@@ -506,11 +454,55 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
     var _step = 1;
     var _user = null;
     var _selectedRepos = [];
-    var _selectedAcmm = 1;
+
+    /* WIZARD_STEP_* name the panels so a renumber is a one-line change instead
+       of a hunt for bare integers. The wizard lost its old "Install the GitHub
+       App" step: the App is installed AFTER provisioning, from the hive's own
+       dashboard, where the hive knows its forge and can build a correct
+       per-instance install link. */
+    var WIZARD_STEP_LOGIN = 1;
+    var WIZARD_STEP_REPOS = 2;
+    var WIZARD_STEP_LEVEL = 3;
+
+    /* ACMM levels, mirroring ACMM_LABELS/ACMM_TIPS on the hub dashboard
+       (pkg/hub/saas.go) and acmmLevelLabel() on the spoke. Keep all three in
+       step — a requester must not be shown one name here and another one on
+       the dashboard of the hive they receive. */
+    var ACMM_LEVELS = [
+      {level: 1, label: 'L1 Assisted',       desc: 'Advisory only. Agents look and report; they never write to your repo.'},
+      {level: 2, label: 'L2 Instructed',     desc: 'Advisory beads, no GitHub writes. Agents follow your CLAUDE.md and house rules.'},
+      {level: 3, label: 'L3 Measured',       desc: 'Hold-gated PRs, CI gates. Agents raise test coverage to earn later automation; every PR waits for a human.'},
+      {level: 4, label: 'L4 Adaptive',       desc: 'Agents open issues and hold-gated PRs, plus security checks. Still a human on every merge.'},
+      {level: 5, label: 'L5 Semi-Automated', desc: 'PRs carry a hold label for batch review, so you approve in groups rather than one at a time.'},
+      {level: 6, label: 'L6 Autonomous',     desc: 'Auto-merge on green CI. Only for repos with CI you already trust.'}
+    ];
+    /* L3 Measured is the recommended entry point: it is the first level that
+       produces useful work (test-coverage PRs) while still gating every merge
+       on a human. */
+    var DEFAULT_ACMM_LEVEL = 3;
+    var _selectedAcmm = DEFAULT_ACMM_LEVEL;
+
+    function acmmEntry(level) {
+      return (ACMM_LEVELS || []).filter(function(a) { return a.level === level; })[0] || null;
+    }
+
+    /* renderAcmmOptions builds the level radios from ACMM_LEVELS. */
+    function renderAcmmOptions() {
+      var host = document.getElementById('acmm-options');
+      if (!host) return;
+      host.innerHTML = (ACMM_LEVELS || []).map(function(a) {
+        var sel = a.level === _selectedAcmm;
+        return '<label class="acmm-option' + (sel ? ' selected' : '') + '" onclick="selectAcmm(this, ' + a.level + ')">' +
+          '<input type="radio" name="acmm" value="' + a.level + '"' + (sel ? ' checked' : '') + '>' +
+          '<div><div class="acmm-label">' + esc(a.label) +
+          (a.level === DEFAULT_ACMM_LEVEL ? ' <span class="acmm-rec">Recommended to start</span>' : '') +
+          '</div>' +
+          '<div class="acmm-desc">' + esc(a.desc) + '</div></div></label>';
+      }).join('');
+    }
 
     function goToStep(n) {
-      if (n === 3) loadRepos();
-      if (n === 4) updateSummary();
+      if (n === WIZARD_STEP_LEVEL) { renderAcmmOptions(); updateSummary(); }
       _step = n;
       var steps = document.querySelectorAll('.wizard-step');
       steps.forEach(function(s) {
@@ -530,65 +522,92 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
     }
 
     function updateSummary() {
-      var names = _selectedRepos.map(function(r) { return r.name || r; });
-      document.getElementById('summary-repos').textContent = names.length ? names.join(', ') : 'none selected';
-      var acmmNames = {1: 'L1 Advisory', 2: 'L2 Measured', 3: 'L3 CI-Gated PRs', 4: 'L4 Auto PR'};
-      document.getElementById('summary-acmm').textContent = acmmNames[_selectedAcmm] || 'L1 Advisory';
+      var names = (_selectedRepos || []).map(function(r) { return r.full_name || r.name || r; });
+      document.getElementById('summary-repos').textContent = names.length ? names.join(', ') : 'none added';
+      var entry = acmmEntry(_selectedAcmm);
+      document.getElementById('summary-acmm').textContent = entry ? entry.label : ('L' + _selectedAcmm);
     }
 
-    async function loadRepos() {
-      var loading = document.getElementById('repo-loading');
-      var list = document.getElementById('repo-list');
-      var none = document.getElementById('repo-none');
-      loading.style.display = 'block';
-      list.style.display = 'none';
-      none.style.display = 'none';
+    /* parseRepoRef turns whatever a user pastes into {host, org, name}.
+       It mirrors the server's normalizeForgeHost (pkg/hub/server.go): strip the
+       scheme, drop a trailing slash, lowercase the HOST only. It is a separate
+       JS function rather than a call into that Go helper for the obvious reason
+       — this runs in the browser — but the accepted forms are kept identical so
+       what the page accepts is what the server will store.
 
-      try {
-        var resp = await fetch('/api/saas/repos');
-        var data = await resp.json();
-        var repos = data.repos || [];
-        loading.style.display = 'none';
+       Accepts:  github.com/org/repo   https://github.ibm.com/org/repo
+                 host/org/repo/        org/repo         (bare -> public GitHub)
 
-        if (!repos.length) {
-          none.style.display = 'block';
-          return;
-        }
-
-        list.style.display = 'flex';
-        list.innerHTML = repos.map(function(r) {
-          var checked = _selectedRepos.some(function(s) { return s.full_name === r.full_name; });
-          return '<label class="repo-item' + (checked ? ' selected' : '') + '" onclick="toggleRepo(this, \'' + esc(r.full_name) + '\', \'' + esc(r.name) + '\')">' +
-            '<input type="checkbox" ' + (checked ? 'checked' : '') + '>' +
-            '<div><div class="repo-name">' + esc(r.full_name) + '</div>' +
-            (r.description ? '<div class="repo-desc">' + esc(r.description) + '</div>' : '') +
-            '</div></label>';
-        }).join('');
-      } catch(e) {
-        loading.style.display = 'none';
-        none.style.display = 'block';
+       Parsing is deliberately separate from forge policy: this function will
+       happily split gitlab.com/org/repo, and isSupportedForgeHost then rejects
+       it. Keeping the two apart means supporting a new forge later is a change
+       to the predicate alone, not to URL handling. */
+    function parseRepoRef(raw) {
+      var v = (raw || '').trim().replace(/^[a-z][a-z0-9+.-]*:\/\//i, '');
+      v = v.replace(/[?#].*$/, '').replace(/\/+$/, '');
+      var parts = v.split('/').filter(function(p) { return p.length; });
+      // Strip a leading hostname (anything with a dot) but KEEP it: an
+      // Enterprise repo is only reachable if the request records its instance.
+      var host = '';
+      if (parts.length > 2 && parts[0].indexOf('.') !== -1) {
+        host = parts[0].toLowerCase();
+        parts = parts.slice(1);
       }
+      if (parts.length < 2) return null;
+      // ".git" is part of a clone URL, not the repo name. Strip it AFTER the
+      // trailing slash is gone so "…/repo.git/" is handled too.
+      var name = parts[1].replace(/\.git$/i, '');
+      if (!parts[0] || !name) return null;
+      return {host: host, org: parts[0], name: name};
     }
 
-    function toggleRepo(el, fullName, name) {
-      var cb = el.querySelector('input[type=checkbox]');
-      var idx = _selectedRepos.findIndex(function(r) { return r.full_name === fullName; });
-      if (idx >= 0) {
-        _selectedRepos.splice(idx, 1);
-        el.classList.remove('selected');
-        cb.checked = false;
-      } else {
-        _selectedRepos.push({full_name: fullName, name: name});
-        el.classList.add('selected');
-        cb.checked = true;
-      }
-      document.getElementById('repos-continue').disabled = _selectedRepos.length === 0;
-    }
+    /* Only GitHub can be provisioned today: App auth, AppInstallURL, and the
+       write gate are all GitHub-specific, so a GitLab or Gitea URL would be
+       accepted here and then fail after the request was already filed. This is
+       an ALLOW-list, not a deny-list — a deny-list of known forges would let
+       "gitlab.mycorp.com" through simply by not having heard of it.
 
-    // Add a repo the picker cannot show. Repo discovery runs on the github.com
-    // OAuth token, so GitHub Enterprise repos (github.ibm.com and friends) never
-    // appear in the list — typing the URL is the only way to request one.
-    // Accepts a full URL, "host/org/repo", or "org/repo".
+       Accepts:  github.com                (public GitHub)
+                 github.<org>.<tld>        (GitHub Enterprise: github.ibm.com,
+                                            github.cisco.com)
+                 github.<org>.<sub>.<tld>  (github.corp.example.com)
+       Rejects:  gitlab.com, gitea.example.com, codeberg.org, bitbucket.org.
+
+       The pattern is anchored at BOTH ends and bounded in length, so the
+       lookalikes "mygithub.com" and "notgithub.com" fail at the front.
+
+       "github.com.evil.net" needs a SEPARATE rule, and it is worth being honest
+       about why: it is structurally identical to the legitimate
+       "github.corp.example.com" (github + label + label + tld). No pattern can
+       tell them apart, so the second label is checked against public GitHub's
+       own name instead — "github.com.<anything>" is the classic prefix-spoof
+       and never a real Enterprise host. */
+    var PUBLIC_GITHUB_HOST = 'github.com';
+    /* Labels permitted AFTER the leading "github." and before the TLD. Real GHE
+       hosts are github.<org>.<tld>, occasionally with one extra internal label
+       (github.corp.example.com). Two is the ceiling; more is a spoofing shape,
+       not a deployment anyone runs. */
+    var GITHUB_ENTERPRISE_HOST_RE = /^github\.[a-z0-9-]+(\.[a-z0-9-]+)?\.[a-z]{2,}$/;
+    /* Rejects github.com.evil.net and github.com.co — a host whose first two
+       labels spell public GitHub, with anything appended after it. */
+    var GITHUB_SPOOF_PREFIX_RE = /^github\.com\./;
+    function isSupportedForgeHost(host) {
+      // No host means a bare "org/repo", which we read as public GitHub.
+      if (!host) return true;
+      var h = host.toLowerCase();
+      if (h === PUBLIC_GITHUB_HOST) return true;
+      if (GITHUB_SPOOF_PREFIX_RE.test(h)) return false;
+      return GITHUB_ENTERPRISE_HOST_RE.test(h);
+    }
+    /* One message, used wherever a forge is rejected. It states the limit, names
+       the accepted forms, and says other forges are coming — a GitLab user
+       should read this as a roadmap gap, not a refusal. */
+    var UNSUPPORTED_FORGE_MSG = ' is not supported yet. Hives can currently be provisioned on GitHub only' +
+      ' — github.com or a GitHub Enterprise host such as github.ibm.com.' +
+      ' Support for GitLab, Gitea, and other forges is planned.';
+
+    // Add a repository the user typed. This is the ONLY way repos enter the
+    // request — see the panel comment for why the picker is gone.
     function addManualRepo() {
       var input = document.getElementById('repo-manual');
       var err = document.getElementById('repo-manual-err');
@@ -596,31 +615,30 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
       err.style.display = 'none';
       if (!raw) return;
 
-      var v = raw.replace(/^https?:\/\//, '').replace(/\/+$/, '').replace(/\.git$/, '');
-      var parts = v.split('/').filter(function(p) { return p.length; });
-      // Split off a leading hostname (anything with a dot) so host/org/repo ->
-      // org/repo, but KEEP the host: a GitHub Enterprise repo is only reachable
-      // if the request records which instance it lives on.
-      var ghHost = '';
-      if (parts.length > 2 && parts[0].indexOf('.') !== -1) { ghHost = parts[0]; parts = parts.slice(1); }
-      if (parts.length < 2) {
-        err.textContent = 'Enter a repository URL or org/repo — for example https://github.ibm.com/my-org/my-repo';
+      var ref = parseRepoRef(raw);
+      if (!ref) {
+        err.textContent = 'Enter a repository URL — for example github.com/my-org/my-repo or https://github.ibm.com/my-org/my-repo';
         err.style.display = 'block';
         return;
       }
-      var org = parts[0], name = parts[1], fullName = org + '/' + name;
-      if (_selectedRepos.some(function(r) { return r.full_name === fullName; })) {
-        err.textContent = fullName + ' is already selected';
+      if (!isSupportedForgeHost(ref.host)) {
+        err.textContent = ref.host + UNSUPPORTED_FORGE_MSG;
         err.style.display = 'block';
         return;
       }
-      _selectedRepos.push({full_name: fullName, name: name, github_host: ghHost});
+      var fullName = ref.org + '/' + ref.name;
+      if ((_selectedRepos || []).some(function(r) { return r.full_name === fullName; })) {
+        err.textContent = fullName + ' is already added';
+        err.style.display = 'block';
+        return;
+      }
+      _selectedRepos.push({full_name: fullName, name: ref.name, github_host: ref.host});
       input.value = '';
       renderManualRepos();
       document.getElementById('repos-continue').disabled = _selectedRepos.length === 0;
     }
 
-    // Show manually added repos (they have no checkbox row in the picker list).
+    // Show the repositories added so far as removable chips.
     function renderManualRepos() {
       var host = document.getElementById('repo-manual-added');
       if (!host) {
@@ -629,15 +647,12 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
         host.style.cssText = 'margin-top:10px;display:flex;flex-wrap:wrap;gap:6px';
         document.getElementById('repo-manual').parentNode.parentNode.appendChild(host);
       }
-      var listed = {};
-      document.querySelectorAll('#repo-list .repo-item').forEach(function(el) {
-        var n = el.querySelector('.repo-name');
-        if (n) listed[n.textContent] = true;
-      });
-      var manual = _selectedRepos.filter(function(r) { return !listed[r.full_name]; });
-      host.innerHTML = manual.map(function(r) {
+      host.innerHTML = (_selectedRepos || []).map(function(r) {
+        // Show the Enterprise host when there is one, so the user can see which
+        // instance we recorded before they submit.
+        var shown = (r.github_host ? r.github_host + '/' : '') + r.full_name;
         return '<span style="display:inline-flex;align-items:center;gap:6px;padding:3px 10px;border:1px solid var(--line);border-radius:999px;font-size:0.8rem">' +
-          esc(r.full_name) +
+          esc(shown) +
           '<a href="#" onclick="removeManualRepo(\'' + esc(r.full_name) + '\');return false" style="color:var(--muted);text-decoration:none" title="Remove">&times;</a></span>';
       }).join('');
     }


### PR DESCRIPTION
Requesting a hosted hive required installing a GitHub App and granting `read:user` so the wizard could list repositories. Neither was necessary, and both blocked GitHub Enterprise users outright.

## The four changes

**1. Remove wizard Step 2 (Install the GitHub App)** — `get-started.html`

The step's own comment already conceded the button was correct only for public github.com: *"we genuinely do not know which GitHub instance your repos live on — we must not fake a per-user link here."* So for every GHE user it was a dead end, and for everyone else an adoption barrier.

**The App still gets installed — after provisioning, which is the only place it can be done correctly.** I verified the post-provision path covers it before removing anything:
- `dashboard/static/index.html:2593-2600` — the "GitHub App Not Installed" banner, with `#gh-app-install-link`
- `:4915-4919` — GHE-aware: retitles to "GitHub App Not Installed on \<host\>" and sets `href` from `data.githubAppInstallURL`
- `:17244-17257` — the welcome journey's own "Install the GitHub App" step
- fed by `config.GitHubConfig.AppInstallURL()` (`config.go:1417`) via `dashboard/server.go:1013,1150`

That link is per-instance and correct, which the wizard's could never be.

**2. Remove repo discovery** — `GET /api/saas/repos` + `handleSaaSRepos` + the picker UI

The handler's own doc comment: *"this can only ever see public github.com. A GitHub Enterprise repo is invisible to a github.com OAuth token."* It was a partial feature that failed silently for every GHE user.

The stronger reason is forward-compatibility: repo discovery via a GitHub OAuth token **cannot generalize to GitLab or Gitea**. A URL field handles any forge with no new code. The typed URL is now the primary and only control in step 2 — not a fallback under a "no repos found" message. The old blame-the-user empty state is gone entirely.

**3. OAuth scope → empty** — `oauth.go:175`

The hub only needs to know *who* is logging in. `GET /user` returns the public profile including `login` for a token with no scopes, and `mintHubUserCookieValue` signs that name into the cookie.

**4. Fix the ACMM levels in the Request a Hive modal** — `saas.go`

The modal read `L3 — CI/CD`, `L4 — Auto PR`, `L5 — Self-Governing`, `L6 — Fully Autonomous`. Those names appear nowhere else in the product, and **L4 does not auto-merge** — it opens hold-gated PRs for human review.

**Canonical source: the hub's own `ACMM_LABELS` + `ACMM_TIPS`.** They are self-consistent, live in the same file, and match the described behaviour (L3 hold-gated PRs raising coverage; L4 agents opening issues + hold-gated PRs). The spoke disagrees on two names (`L1 Foundational`/`L5 Automated` at `index.html:11475` vs `L1 Assisted`/`L5 Semi-Automated` at `:12612`) — note the spoke **contradicts itself**, and its `:12612` selector already matches the hub. So the hub labels are canonical and the spoke's `:11475` map is the outlier. I did not touch it: it drives the ACMM evaluation dialog, not this picker, and reconciling it is a separate change.

Rather than adding a fourth copy, the picker now renders from `ACMM_LABELS`/`ACMM_TIPS` (hoisted out of `acmmBadge`). L5 and L6 remain visible. Each option carries its short description inline, since a closed `<select>` shows only the selected row. The wizard's step 3 had a *fourth* divergent copy (`L1 Advisory`/`L2 Measured`/`L4 Auto PR`) — also now rendered from one table.

## Step 3 instructions (the "should it look like /contribute?" question)

**I concluded it should not, and made a focused change instead.** `/contribute` needs a CLI picker, a copy-paste block, and per-option `data-env` because it configures a runtime with many valid combinations. Entering a repo URL has one input and one correct answer; that machinery would be ceremony. What it *did* need was promotion from afterthought to primary control, plus honest inline guidance on accepted forms — that is what it got.

## URL parsing and forge validation

Parsing is `parseRepoRef()`, mirroring the server's `normalizeForgeHost` (`server.go:229`) in accepted forms. Note `normalizeForgeHost` is **Go**, not reachable from this static page; the existing JS mirror `normalizeForgeInput` (`saas.go:11201`) is host-only and does not split org/repo, so it could not be reused as-is. Forms are kept identical deliberately.

Fixed a real ordering bug carried over from the old parser: `.git` was stripped *before* the trailing slash, so `…/repo.git/` parsed as repo name `repo.git`.

**Validation accepts GitHub only, today:**

| Accepted | Rejected |
|---|---|
| `github.com` | `gitlab.com`, `gitea.example.com`, `codeberg.org`, `bitbucket.org` |
| `github.<org>.<tld>` (`github.ibm.com`) | `mygithub.com`, `notgithub.com` (anchored at front) |
| `github.<org>.<sub>.<tld>` (`github.corp.example.com`) | `github.com.evil.net` (explicit spoof rule) |

An **allow-list**, not a deny-list — a deny-list would let `gitlab.mycorp.com` through simply by not having heard of it.

One honest caveat: `github.com.evil.net` is *structurally identical* to the legitimate `github.corp.example.com` (github + label + label + tld), so no regex separates them. It needs the separate `GITHUB_SPOOF_PREFIX_RE` rule, which is commented as such.

Rejection message states the limit, names accepted forms, and signals the roadmap: *"…Support for GitLab, Gitea, and other forges is planned."* Field copy is forge-neutral where cheap; examples stay GitHub since that is what works. No Go identifiers, JSON fields, config keys, or routes renamed.

## Ordering dependency — please do not undo this piecemeal

**(2) and (3) are only safe because of (1).** The empty OAuth scope works *because* nothing lists repos; the listing removal is acceptable *because* no App install is required at request time. Restoring `/api/saas/repos` without restoring the `read:user` scope would yield an endpoint that silently returns nothing. Both the route site and `handleLogin` carry comments saying so.

## Verified by running

- `go build ./...`, `go vet ./pkg/hub/...` — clean
- `gofmt` on the three touched files only — clean
- `go test ./pkg/hub/ -run 'Forge|Request|OAuth|Login'` — pass
- JS extracted from **both** `saas.go` (4 blocks) and `get-started.html`, `node --check` OK on each, **and the extraction grepped to confirm my changes were present** (not a stale file)
- `parseRepoRef`/`isSupportedForgeHost` executed under node against **21 cases** — all forms in the table above, plus `HTTPS://GitHub.IBM.com/Org/Repo`, `?tab=` query strings, `.git` and `.git/`, bare `org/repo`, and malformed input. All pass.
- Confirmed zero backticks added to `saas.go` (raw-string hazard) and no stale `panel-4` / `loadRepos` / `handleSaaSRepos` references remain

**Pre-existing failure, not mine:** `TestLoadAppPrivateKeyKubectlFails` fails identically on clean `origin/v2` (verified by stashing). Environment-dependent — it picks up a real key where it expects none.

**Assumed, not executed:** that GitHub returns `login` from `GET /user` for a zero-scope token. This is documented behaviour for public profile data and the load-bearing assumption of change (3), but I could not exercise a live OAuth round-trip from here. Worth a smoke-test login on staging before this reaches users.

## Action required by a maintainer

Please confirm whether the OAuth **App registration** needs a matching change. Scope here is a per-request `?scope=` parameter, so the code change stands alone — but if the registered app pins default scopes, that must be adjusted or this silently does nothing. Only one authorize URL exists in the codebase (`oauth.go:175`); there is no second spoke-SSO path, so nothing else was touched.

## Porting

Needs porting to **mk**, **dd**, and **v3**. The console's hive runs v3, so a v2-only merge will not reach it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)