### PR TITLE
✨ feat(dashboard): move Trajectory Review from the top banner into Getting Started

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2762,8 +2762,9 @@ func main() {
 				"on_divergence", cfg.Governor.Trajectory.OnDivergence)
 		}
 	}
-	// Reconcile the not-configured alert from actual state (raises only when
-	// enabled AND no reviewer resolves; clears when off or configured).
+	// Clear any legacy "not configured" banner alert persisted by an older
+	// build. The half-configured state is shown inline in Governor Config →
+	// General, not in the top banner.
 	dashSrv.ReconcileTrajectoryAlert(&cfg.Governor)
 
 	logger.Info("entering governor loop", "interval_seconds", cfg.Governor.EvalIntervalS)

--- a/v2/pkg/dashboard/api_trajectory.go
+++ b/v2/pkg/dashboard/api_trajectory.go
@@ -49,29 +49,45 @@ func (s *Server) handleGovernorTrajectory(w http.ResponseWriter, r *http.Request
 	if err := s.saveConfig(); err != nil {
 		s.logger.Error("failed to persist config after trajectory update", "error", err)
 	}
-	// Reconcile the "enabled but no reviewer endpoint" alert against the new
-	// state: it must clear when the lane is turned off or an endpoint is set,
-	// not linger from a stale startup evaluation.
+	// Clear any legacy "not configured" banner alert. The half-configured
+	// state is surfaced inline in Governor Config → General instead of the
+	// top banner (see ReconcileTrajectoryAlert).
 	s.ReconcileTrajectoryAlert(&s.deps.Config.Governor)
 	s.auditFromRequest(r, "config_governor_trajectory", auditDetail("section", "trajectory"), "")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
 }
 
-// TrajectoryNotConfiguredAlertID is the dashboard system-alert id for
-// "trajectory review is enabled but has no reviewer endpoint."
+// TrajectoryNotConfiguredAlertID is the dashboard system-alert id formerly
+// used for "trajectory review is enabled but has no reviewer endpoint."
+// The alert is no longer raised; the id is retained so ReconcileTrajectoryAlert
+// can clear one persisted by an older build.
 const TrajectoryNotConfiguredAlertID = "trajectory-not-configured"
 
-// ReconcileTrajectoryAlert raises the "enabled but no reviewer endpoint" alert
-// only when the lane is BOTH enabled AND not runnable, and clears it in every
-// other case (disabled, or an endpoint now resolves). Safe to call from
-// startup and from the config PUT handler.
-func (s *Server) ReconcileTrajectoryAlert(g *config.GovernorConfig) {
-	if g.Trajectory.IsEnabled() && !g.ReviewerReady() {
-		s.AddSystemAlert(TrajectoryNotConfiguredAlertID, "warning",
-			"Trajectory review is ON but has no reviewer endpoint configured — no agents are being reviewed. Set a reviewer endpoint (LiteLLM, vLLM, or llm-d) in Governor Config.")
-		return
-	}
+// ReconcileTrajectoryAlert clears the legacy "enabled but no reviewer
+// endpoint" system alert. It no longer raises it.
+//
+// Why the banner went away: the lane defaults to ON (TrajectoryConfig.IsEnabled
+// returns true when Enabled is nil), so on a hive that has never configured a
+// LiteLLM endpoint the alert fired on first boot for everyone — it flagged the
+// untouched default, not an operator who opted in and then misconfigured it.
+// That made it a "you have not set up an optional feature" nag occupying the
+// top banner, which is reserved for conditions demanding action. The lane also
+// fails open (an unreachable reviewer returns "not divergent"), so the inert
+// state never pauses or breaks a working agent.
+//
+// The half-configured state is still surfaced, just not as a top-of-page
+// warning: Governor Config → General shows an amber "On — no reviewer endpoint
+// (not running)" status chip plus a "Resolved: none — reviewer will not run"
+// hint next to the endpoint field, and Getting Started → More to explore
+// mentions the feature as an advanced capability.
+//
+// This is still called from startup and the config PUT handler so that an
+// alert persisted by an older build is cleared rather than left stuck in the
+// banner forever.
+// The config argument is retained (unused) so both call sites and any future
+// re-introduction of a narrower, opt-in-only alert keep a stable signature.
+func (s *Server) ReconcileTrajectoryAlert(_ *config.GovernorConfig) {
 	s.ClearSystemAlert(TrajectoryNotConfiguredAlertID)
 }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2196,6 +2196,9 @@
     .welcome-more-item { font-size: var(--fs-sm); color: var(--muted); padding: 3px 0 3px 8px; line-height: 1.5; }
     .welcome-more-link { color: var(--blue); cursor: pointer; font-weight: 600; }
     .welcome-more-link:hover { text-decoration: underline; }
+    /* Marks a "More to explore" entry as an advanced/optional capability, so a
+       new operator does not read it as part of the required setup path. */
+    .welcome-more-tag { display: inline-block; margin-left: 6px; padding: 1px 6px; border-radius: 999px; font-size: var(--fs-xs); font-weight: 600; text-transform: uppercase; letter-spacing: 0.4px; color: var(--amber); background: color-mix(in srgb, var(--amber) 14%, transparent); border: 1px solid color-mix(in srgb, var(--amber) 45%, transparent); }
     .welcome-footer { justify-content: space-between; }
     @media (max-width: 480px) {
       .welcome-step-body { padding-left: 12px; }
@@ -15266,7 +15269,7 @@ function burnAreaChart() {
             <div style="grid-column:1 / -1">
               <label style="font-size:0.7rem;color:var(--muted);display:block;margin-bottom:3px">Reviewer endpoint <span class="config-info">i<span class="config-tooltip">OpenAI-compatible base URL for the reviewer (LiteLLM / vLLM / llm-d). Empty = inherit the Governor's LiteLLM endpoint. The API key is inherited from LiteLLM or set in hive.yaml (governor.trajectory.api_key_env/api_key_file); a bare vLLM server needs none.</span></span></label>
               <input type="text" value="${esc(traj.endpoint || '')}" placeholder="${trajEndpoint ? esc(trajEndpoint) + '  (inherited from LiteLLM)' : 'https://litellm-or-vllm-or-llmd:port'}" onchange="saveTrajectoryField('endpoint', this.value)" style="width:100%">
-              <span style="font-size:0.62rem;color:var(--muted);margin-top:3px;display:block">Resolved: ${trajEndpoint ? esc(trajEndpoint) + ' (' + esc(traj.endpointSource || '') + (traj.hasKey ? ', key set' : ', no key') + ')' : 'none — reviewer will not run'}</span>
+              <span style="font-size:0.62rem;margin-top:3px;display:block;color:${trajOn && !trajEndpoint ? 'var(--amber)' : 'var(--muted)'}">Resolved: ${trajEndpoint ? esc(trajEndpoint) + ' (' + esc(traj.endpointSource || '') + (traj.hasKey ? ', key set' : ', no key') + ')' : (trajOn ? 'none — Trajectory Review is ON but no agents are being reviewed. Set an endpoint above (or a Governor LiteLLM endpoint) to activate it.' : 'none — reviewer will not run')}</span>
             </div>
             <div style="grid-column:1 / -1">
               <label style="font-size:0.7rem;color:var(--muted);display:block;margin-bottom:3px">On divergence</label>
@@ -17321,13 +17324,23 @@ function burnAreaChart() {
       }
     ];
 
-    // Collapsed "More to explore" one-liners under the core steps.
+    // Governor Config tab hosting the Trajectory Review controls (toggle,
+    // reviewer endpoint/model, on-divergence mode) — see renderGovGeneral().
+    // Named so the Getting Started deep link cannot drift from the tab list
+    // in GOVERNOR_CONFIG_TABS.
+    const TRAJECTORY_CONFIG_TAB = 'General';
+
+    // Collapsed "More to explore" one-liners under the core steps. These are
+    // OPTIONAL/advanced capabilities, deliberately kept out of WELCOME_STEPS:
+    // updateWelcomeProgress() counts only WELCOME_STEPS, so nothing listed
+    // here can inflate the "N of M done" counter or read as a required step.
     const WELCOME_MORE_ITEMS = [
       { id: 'budget', label: 'Budget', desc: 'set a weekly token budget and watch the burn rate (Governor Config → Budget).', onclick: "welcomeShowConfigTab('Budget')" },
       { id: 'notifications', label: 'Notifications', desc: 'route alerts to your channels (Governor Config → Notifications).', onclick: "welcomeShowConfigTab('Notifications')" },
       { id: 'knowledge', label: 'Knowledge Base', desc: 'seed facts and patterns the agents reuse across passes.', onclick: "welcomeShowSection('knowledge-section')" },
       { id: 'contributors', label: 'ClankeR (Contributor Relay)', desc: 'let outside contributors drive agents, with a leaderboard.', onclick: "welcomeShowSection('contributors-section')" },
       { id: 'hub', label: 'Hub visibility', desc: 'make this hive public or private on the hub (Governor Config → Hub).', onclick: "welcomeShowConfigTab('Hub')" },
+      { id: 'trajectory', label: 'Trajectory Review <span class="welcome-more-tag">advanced</span>', desc: 'an LLM reviewer periodically reads each running agent’s transcript and pauses or alerts you if the agent drifts from the task it was given. Needs one OpenAI-compatible reviewer endpoint (LiteLLM, vLLM, or llm-d) — without it the lane stays inert (Governor Config → General).', onclick: `welcomeShowConfigTab('${TRAJECTORY_CONFIG_TAB}')` },
       { id: 'theme', label: 'Light / Dark mode', desc: 'switch layouts any time from the toggle in the top bar.', onclick: 'toggleLayout()' }
     ];
 

--- a/v2/pkg/dashboard/trajectory_coverage_test.go
+++ b/v2/pkg/dashboard/trajectory_coverage_test.go
@@ -110,7 +110,12 @@ func TestCov_ReconcileTrajectoryAlert(t *testing.T) {
 	s, deps := covServer(t)
 	g := &deps.Config.Governor
 
-	// Enabled + no reviewer endpoint/model → alert raised.
+	// The banner alert is no longer raised in ANY state — the half-configured
+	// case is surfaced inline in Governor Config → General instead. The lane
+	// defaults to ON, so raising it here fired on every unconfigured hive.
+
+	// Enabled + no reviewer endpoint/model → still no alert (the case that
+	// used to raise it; this is the behaviour change under test).
 	enabled := true
 	g.Trajectory.Enabled = &enabled
 	g.Trajectory.Endpoint = ""
@@ -118,25 +123,36 @@ func TestCov_ReconcileTrajectoryAlert(t *testing.T) {
 	g.LiteLLM.Endpoint = ""
 	g.LiteLLM.DefaultModel = ""
 	s.ReconcileTrajectoryAlert(g)
-	if !covHasAlert(s, TrajectoryNotConfiguredAlertID) {
-		t.Error("expected trajectory-not-configured alert to be raised")
+	if covHasAlert(s, TrajectoryNotConfiguredAlertID) {
+		t.Error("expected no banner alert when enabled but unconfigured")
 	}
 
-	// Disabled → alert cleared.
+	// Disabled → no alert.
 	disabled := false
 	g.Trajectory.Enabled = &disabled
 	s.ReconcileTrajectoryAlert(g)
 	if covHasAlert(s, TrajectoryNotConfiguredAlertID) {
-		t.Error("expected alert cleared when disabled")
+		t.Error("expected no alert when disabled")
 	}
 
-	// Enabled + reviewer ready → alert cleared.
+	// Enabled + reviewer ready → no alert.
 	g.Trajectory.Enabled = &enabled
 	g.Trajectory.Endpoint = "https://reviewer.local"
 	g.Trajectory.Model = "cheap-model"
 	s.ReconcileTrajectoryAlert(g)
 	if covHasAlert(s, TrajectoryNotConfiguredAlertID) {
-		t.Error("expected alert cleared when reviewer ready")
+		t.Error("expected no alert when reviewer ready")
+	}
+
+	// A stale alert persisted by an older build must be cleared, since that is
+	// now the function's only job.
+	s.AddSystemAlert(TrajectoryNotConfiguredAlertID, "warning", "stale alert from an older build")
+	g.Trajectory.Enabled = &enabled
+	g.Trajectory.Endpoint = ""
+	g.Trajectory.Model = ""
+	s.ReconcileTrajectoryAlert(g)
+	if covHasAlert(s, TrajectoryNotConfiguredAlertID) {
+		t.Error("expected a stale legacy alert to be cleared")
 	}
 }
 


### PR DESCRIPTION
Moves **Trajectory Review** out of the spoke dashboard's top banner and into the **Getting Started / Welcome dialog** as an advanced feature to mention, per the project owner's request.

## The judgment call: I removed the banner alert

The task correctly flagged the tension — the alert fired only when trajectory review was **ON but not runnable**, which looks like a genuine silent-failure warning. Deleting a real warning would overshoot.

**But it wasn't discriminating that case.** The lane **defaults to ON**:

```go
func (t TrajectoryConfig) IsEnabled() bool {
	return t.Enabled == nil || *t.Enabled   // nil => true
}
```

So on any hive that never configured a LiteLLM endpoint, `IsEnabled() && !ReviewerReady()` was true **on first boot, for everyone**. The alert flagged the *untouched default*, not an operator who opted in and then misconfigured it. That makes it a "you have not set up an optional feature" nag holding prime real estate reserved for things demanding action — exactly what the owner objected to.

Two further facts made removal safe rather than lossy:

1. **The lane fails open.** An unreachable reviewer returns "not divergent," so the inert state never pauses or breaks a working agent. Nothing is silently degraded — the feature simply isn't running.
2. **The inline indicator already exists and is prominent**: an amber `On — no reviewer endpoint (not running)` status chip sits directly beside the toggle, plus a `Resolved:` hint under the endpoint field.

I did **not** rely on that inline state as-is, though — since it's now the only signal, I strengthened it (below). Had the alert fired only on genuine opt-in misconfiguration, I'd have kept a narrowed version instead.

## Changes

**Banner removed (`v2/pkg/dashboard/api_trajectory.go`)**
`ReconcileTrajectoryAlert` no longer raises the alert. It is **retained and still called** from both sites (`cmd/hive/main.go` startup + the config PUT handler) so an alert **persisted by an older build gets cleared** rather than left stuck in the banner forever. `TrajectoryNotConfiguredAlertID` is kept for that reason.

**Inline indicator strengthened (`index.html`)**
When the lane is on and nothing resolves, the hint now turns **amber** and reads:
> `none — Trajectory Review is ON but no agents are being reviewed. Set an endpoint above (or a Governor LiteLLM endpoint) to activate it.`

instead of the flat, easily-missed `none — reviewer will not run`. The operator who opts in and misconfigures still gets told, at the place they configure it.

**Getting Started entry (`index.html`)**
Added to `WELCOME_MORE_ITEMS` ("More to explore"), tagged **advanced**:
> **Trajectory Review** `advanced` — an LLM reviewer periodically reads each running agent's transcript and pauses or alerts you if the agent drifts from the task it was given. Needs one OpenAI-compatible reviewer endpoint (LiteLLM, vLLM, or llm-d) — without it the lane stays inert (Governor Config → General).

### Progress counter is explicitly not inflated

`updateWelcomeProgress()` counts **only `WELCOME_STEPS`**:

```js
const done = WELCOME_STEPS.filter(s => welcomeStepDone(s, data)).length;
el.textContent = done + ' of ' + WELCOME_STEPS.length + ' done';
```

`WELCOME_MORE_ITEMS` is a separate array rendered below the numbered steps and is **not counted**, so this optional capability cannot turn "9 of 10 done" into "9 of 11". That was the correct existing slot for optional items — I used it rather than inventing anything. Documented with a comment so a future edit doesn't move it into `WELCOME_STEPS` by accident.

Deep-link uses the **existing** `welcomeShowConfigTab()` entry point (no new navigation mechanism), via a named constant `TRAJECTORY_CONFIG_TAB = 'General'` so the link can't drift from `GOVERNOR_CONFIG_TABS`. The controls themselves are unmoved.

**Tests updated, not deleted (`trajectory_coverage_test.go`)**
`TestCov_ReconcileTrajectoryAlert` now asserts the new contract across all three states, **plus a new case** proving a stale legacy alert is cleared.

## Verification

Verified by running:
- `go build ./...`, `go vet ./pkg/dashboard/ ./pkg/config/ ./cmd/hive/` — clean
- `go test ./pkg/dashboard/ -run Trajectory` — all 4 pass; `./pkg/config/` — pass
- `gofmt -l` on the 3 touched Go files only — clean (no wildcard sweep)
- **Brace-delta parity on the extracted JS**: base `{}`=0 `()`=-4 `[]`=0 → current **identical**; extraction confirmed fresh (872619 vs 871421 chars) and **grepped to contain my markers** (`TRAJECTORY_CONFIG_TAB`, `id: 'trajectory'`, `welcome-more-tag`, `no agents are being reviewed`). `node --check` also passes.
- Rebased on fresh `origin/v2`: 0 behind, `origin/v2` confirmed ancestor of HEAD.

**Pre-existing failures (NOT from this change):** `TestCovV1_*`, `TestCovDF_GHUserAuth*`, `TestHandleGHUserAuthStart*` fail identically on a clean detached `origin/v2` worktree — environment-dependent (SSO handoff loop + `/data` PVC paths). Confirmed by running them on unmodified `origin/v2`.

**Not verified:** rendered appearance in a live browser (no running hive); the markup follows existing `WELCOME_MORE_ITEMS` patterns and `item.label` is interpolated raw like the sibling `desc` fields, which already contain markup.

## Porting

⚠️ **mk, dd, and v3 need this ported** — v2 only.