### PR TITLE
🐛 fix(hub): stop adopting an unservable vanity URL on OpenShift clusters

### DIFF
--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -57,6 +57,13 @@ const (
 	// ingressTypeOpenShiftRoute selects OpenShift Route generation.
 	ingressTypeOpenShiftRoute = "openshift-route"
 
+	// routeBaseDashboard and routeBaseTerminal name the Routes that provisioning
+	// creates on an OpenShift spoke. addVanityHostToIngress mirrors each one into
+	// a parallel "<name>-vanity" Route, because a Route carries a single host and
+	// so cannot simply gain the vanity hostname the way an nginx Ingress rule can.
+	routeBaseDashboard = "hive-dashboard"
+	routeBaseTerminal  = "hive-terminal"
+
 	// storageTypeDynamic selects dynamic PVC provisioning (no NFS PV).
 	storageTypeDynamic = "dynamic"
 
@@ -632,6 +639,17 @@ func (s *HubServer) makeVanityHostServable(hiveID, vanityHost string, cluster *C
 // repairVanityURLsForClaimedHives applies the retroactive vanity-URL repair to
 // every hive, returning the number changed. Safe to run repeatedly: each hive is
 // gated by repairVanityURLForHive, which no-ops once a vanity URL exists.
+//
+// DELIBERATELY NOT CALLED IN PRODUCTION, for the same reason as its sibling
+// repairGitHubHostsFromClusters: the repair runs LAZILY, per hive, from the
+// heartbeat path, and a startup sweep would walk the hive directory
+// concurrently with the first heartbeats already writing to it for no benefit —
+// a hive that never beats needs no repair, and one that does gets repaired on
+// its very next beat. It is retained as the fleet-level entry point (and is
+// covered by a test asserting sweep-level idempotency) so an operator-triggered
+// backfill has one correct implementation to call rather than an ad-hoc loop.
+// This is NOT dead code left behind by accident; do not read its absence from
+// the heartbeat path as missing coverage.
 func (s *HubServer) repairVanityURLsForClaimedHives() int {
 	repaired := 0
 	for _, h := range listSaaSHives() {
@@ -1842,7 +1860,15 @@ func (s *HubServer) addVanityHostToIngress(hiveID, vanityHost string, cluster *C
 	placeholderHost := hiveID + "." + cluster.Domain
 
 	if cluster.IngressType == ingressTypeOpenShiftRoute {
-		for _, base := range []string{"hive-dashboard", "hive-terminal"} {
+		// Mirror the nginx branch's accounting: count what was actually applied,
+		// so "every source Route was unreachable" reports failure instead of
+		// success. Without this the loop `continue`s past every missing/
+		// unreachable Route and still returns nil, telling the caller the host is
+		// servable when no Route was created — the retroactive repair then adopts
+		// an unservable vanity host and replaces a working placeholder link with
+		// a 503.
+		applied := 0
+		for _, base := range []string{routeBaseDashboard, routeBaseTerminal} {
 			out, err := kubectlForCluster(cluster, "-n", ns, "get", "route", base,
 				"-o", "jsonpath={.spec.port.targetPort}|{.spec.path}").Output()
 			if err != nil {
@@ -1870,6 +1896,11 @@ spec:
 			if err := cmd.Run(); err != nil {
 				return fmt.Errorf("applying %s-vanity route: %w", base, err)
 			}
+			applied++
+		}
+		if applied == 0 {
+			return fmt.Errorf("no route found in %s to mirror %s onto (cluster unreachable or spoke has no %s/%s route)",
+				ns, vanityHost, routeBaseDashboard, routeBaseTerminal)
 		}
 		return nil
 	}

--- a/v2/pkg/hub/vanity_url_repair_test.go
+++ b/v2/pkg/hub/vanity_url_repair_test.go
@@ -258,3 +258,127 @@ func TestRepairedVanityURLReachesSpokeViaHeartbeat(t *testing.T) {
 		t.Errorf("still pushing after the spoke adopted the vanity URL: %+v", pc2)
 	}
 }
+
+// openShiftVanityTestDomain mirrors the live vllm-d apps wildcard domain.
+const openShiftVanityTestDomain = "apps.fmaas-vllm-d.example.com"
+
+// newOpenShiftVanityTestHub builds a hub with one OpenShift-Route cluster whose
+// spokes the hub cannot reach (no kubectl under test), standing in for the
+// firewalled heartbeat-only vllm-d pool.
+func newOpenShiftVanityTestHub() *HubServer {
+	return &HubServer{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		clusters: map[string]ClusterConfig{
+			defaultClusterID: {
+				ID:          defaultClusterID,
+				Name:        "vllm-d",
+				Domain:      openShiftVanityTestDomain,
+				IngressType: ingressTypeOpenShiftRoute,
+			},
+		},
+	}
+}
+
+// On an OpenShift cluster whose Routes the hub cannot read, addVanityHostToIngress
+// must report FAILURE. It previously `continue`d past every unreachable source
+// Route and still returned nil, so the retroactive repair believed the host was
+// servable, adopted it, and replaced a working placeholder link with a 503 — the
+// live vllm-d regression across 11 claimed hives.
+func TestAddVanityHostToIngressFailsWhenNoRouteCanBeMirrored(t *testing.T) {
+	s := newOpenShiftVanityTestHub()
+	cluster := s.clusters[defaultClusterID]
+
+	err := s.addVanityHostToIngress("hosted-available-vllmd-01", "hosted-x-y-ab12."+openShiftVanityTestDomain, &cluster)
+	if err == nil {
+		t.Fatal("addVanityHostToIngress reported success with no route mirrored — " +
+			"the caller would adopt an unservable vanity host and 503 every hub link")
+	}
+	if !strings.Contains(err.Error(), "no route found") {
+		t.Errorf("error %q does not name the missing-route cause", err)
+	}
+}
+
+// The guard must actually hold end to end: on an unreachable OpenShift cluster the
+// hive keeps its EMPTY VanityURL, so every read path falls back to the working
+// placeholder host rather than an adopted-but-unservable vanity host.
+func TestVanityRepairKeepsPlaceholderOnUnreachableOpenShiftCluster(t *testing.T) {
+	useTempHiveDir(t)
+	s := newOpenShiftVanityTestHub()
+
+	const id = "hosted-available-vllmd-01"
+	if err := saveSaaSHive(&SaaSHive{
+		ID: id, Status: "running", Owner: "someone", Org: "ibm-aiops",
+		Repos: []string{"katamari"}, PrimaryRepo: "katamari", ACMMLevel: 3,
+		ClusterID: defaultClusterID, ClaimDelivered: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.repairVanityURLForHive(id) {
+		t.Error("repair adopted a vanity URL on a cluster where it could not create a route")
+	}
+	if got := loadSaaSHive(id).VanityURL; got != "" {
+		t.Errorf("VanityURL = %q, want empty so the working placeholder host stands", got)
+	}
+	if got := claimedVanityURL(loadSaaSHive(id)); got != "" {
+		t.Errorf("claimedVanityURL = %q, want empty (placeholder fallback)", got)
+	}
+}
+
+// A repair that CANNOT succeed must not churn a new random host per heartbeat.
+// generateHiveID mints a fresh 4-char suffix per call, so an unguarded retry
+// produced a different host every beat (observed live: three hosts in four
+// minutes). Repeated failing repairs must leave the record untouched.
+func TestVanityRepairDoesNotChurnHostWhenItCannotSucceed(t *testing.T) {
+	useTempHiveDir(t)
+	s := newOpenShiftVanityTestHub()
+
+	const id = "hosted-available-vllmd-12"
+	if err := saveSaaSHive(&SaaSHive{
+		ID: id, Status: "running", Owner: "someone", Org: "ibm-aiops",
+		Repos: []string{"katamari"}, PrimaryRepo: "katamari", ACMMLevel: 3,
+		ClusterID: defaultClusterID, ClaimDelivered: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate several heartbeats against a cluster that stays unreachable.
+	for beat := range 5 {
+		if s.repairVanityURLForHive(id) {
+			t.Fatalf("beat %d: repair reported a change it could not make servable", beat)
+		}
+		if got := loadSaaSHive(id).VanityURL; got != "" {
+			t.Fatalf("beat %d: adopted %q despite an unservable host", beat, got)
+		}
+	}
+}
+
+// The nginx path must be unaffected by the OpenShift accounting fix: a reachable
+// nginx cluster still adopts its vanity host exactly once and keeps it stable.
+func TestVanityRepairNginxBehaviorUnchanged(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityRepairTestHub()
+
+	const id = "hosted-available-oke-42-placeholder-zz01"
+	if err := saveSaaSHive(&SaaSHive{
+		ID: id, Status: "running", Owner: "someone", Org: "kubestellar",
+		Repos: []string{"console"}, PrimaryRepo: "console", ACMMLevel: 3,
+		ClusterID: defaultClusterID, ClaimDelivered: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !s.repairVanityURLForHive(id) {
+		t.Fatal("nginx repair reported no change — existing behavior regressed")
+	}
+	first := loadSaaSHive(id).VanityURL
+	if first == "" {
+		t.Fatal("nginx repair left the vanity URL empty")
+	}
+	if s.repairVanityURLForHive(id) {
+		t.Error("nginx repair was not idempotent")
+	}
+	if second := loadSaaSHive(id).VanityURL; second != first {
+		t.Errorf("nginx vanity host churned: %q then %q", first, second)
+	}
+}


### PR DESCRIPTION
## The bug

PR #2286 added `repairVanityURLForHive` with the right design: adopt the vanity host **only after** `addVanityHostToIngress` has actually made it servable, otherwise log and leave `VanityURL` empty so the working placeholder link stands.

**That guard did not hold on OpenShift.** All 11 claimed `vllm-d` hives ended up pointing at a host that resolves to nothing:

```
vanity host  hosted-…-ibm-aiops-…apps.fmaas-vllm-d…   → HTTP 503   ← hub redirected here
placeholder  hosted-available-vllmd-01.apps.fmaas-…   → HTTP 401   ← still worked
```

A working link was replaced by a broken one — the exact outcome the guard exists to prevent.

## Why the guard passed

Not a swallowed error, and not a path that skips the guard. **`addVanityHostToIngress` returns `nil` when it mirrors nothing.**

Its **nginx** branch counts successful patches and returns an error when `patched == 0`. The **OpenShift** branch — added in #2128, *before* the guard existed, when the only caller adopted optimistically — has no such accounting:

```go
out, err := kubectlForCluster(cluster, "-n", ns, "get", "route", base, …).Output()
if err != nil {
    continue // route absent on this spoke — nothing to mirror
}
…
return nil   // ← unconditional, even if the loop mirrored zero routes
```

On a firewalled heartbeat-only cluster the `kubectl get route` *itself* fails, so **every** iteration `continue`s, the loop falls through, and `return nil` reports success. "Nothing to do" was reported as "done", so the caller believed the host was servable and adopted it.

## The fix

Mirror the nginx branch's accounting: count applied Routes, and return an error naming the cause when none could be mirrored. A cluster the hub cannot reach now **fails closed** and the hive keeps its working placeholder host.

**This is the refuse-to-adopt fix (option 3), not new Route creation.** The real `vllm-d` Routes already exist and are mirrored correctly whenever the hub *can* reach the cluster — the observed failure is purely reachability, which creating more Routes cannot fix.

Ingress-technology detection needed no API probing or caching: `ClusterConfig.IngressType` already carries it, and the branch keyed on it was correct. The bug was the accounting inside that branch.

## Idempotency

`generateHiveID` mints a fresh random 4-char suffix per call, so a repair that kept failing *open* churned a different host every heartbeat (observed live: three hosts in four minutes on `hosted-available-vllmd-12`). Failing closed leaves `VanityURL` empty and the record untouched, so nothing is re-minted. A test drives five consecutive beats and asserts no adoption and no churn.

## `repairVanityURLsForClaimedHives`

Confirmed zero production call sites — but this is **deliberate**, matching its sibling `repairGitHubHostsFromClusters`, whose comment explains a startup sweep would walk the hive directory concurrently with the first heartbeats for no benefit. It only *looked* like a dead-code trap because that rationale was never written down. Documented rather than deleted, so the one correct fleet-level implementation stays available to an operator-triggered backfill.

## Tests

- Unreachable OpenShift cluster → `addVanityHostToIngress` reports failure
- Unreachable OpenShift cluster → hive keeps its placeholder, `VanityURL` stays empty
- Repeated failing repairs across 5 beats → no adoption, no host churn
- nginx → existing adopt-once-and-stay-stable behavior unchanged

All three new failure tests were **verified to fail against the unfixed code** (the pre-fix run adopted `https://hosted-ibm-aiops-katamari-e1k4.apps.fmaas-vllm-d…`, reproducing the live 503 host shape).

`go build ./...`, `go vet ./pkg/hub/`, and `go test ./pkg/hub/ -run Vanity` all pass. (`TestLoadAppPrivateKeyKubectlFails` fails identically on clean `origin/v2` — pre-existing and unrelated.)

## Notes

- No live cluster state was touched; the 11 hand-created Routes are left as-is.
- **Needs porting to `mk`, `dd` and `v3`.**
