### PR TITLE
✨ feat(hub): show vanity URL in status bar on hive-name hover

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -7463,6 +7463,56 @@ const dashboardHTML = `<!DOCTYPE html>
       return '';
     }
 
+    /* SSO_NAV_ATTR marks an anchor whose href is a DISPLAY url (the friendly
+       vanity host) but whose click must actually go through the hub's /open
+       handoff. The real navigation target is carried here rather than in href
+       because browsers show the raw href in the status bar on hover, and the
+       placeholder-id /open path is exactly what we do not want a user to read
+       there. Named so the delegated click listener below and the builder agree
+       on one string. */
+    var SSO_NAV_ATTR = 'data-sso-open';
+
+    /* ssoDisplayLink builds the hive-name anchor.
+
+       href      = displayUrl (vanity) when we have one, so the status bar, the
+                   context menu's "Copy link address" and middle-click all show
+                   and use the friendly host.
+       data attr = openUrl, the hub /open endpoint that mints the 90s HMAC SSO
+                   handoff token. A plain left-click is intercepted and sent
+                   there instead, so the normal path still lands authenticated.
+
+       The cmd-click / middle-click divergence is DELIBERATE and safe: the spoke
+       serves a real "Sign in with GitHub" device-flow page at its root, so a
+       token-less arrival on the vanity host is an ordinary login, not a dead
+       end. Trading a rare extra sign-in for a readable URL on every hover is
+       the intended bargain.
+
+       When displayUrl is empty (unclaimed placeholder, or vanity adoption
+       skipped) there is nothing friendlier to show, so href stays the /open
+       url and behavior is byte-for-byte what it was before. */
+    function ssoDisplayLink(openUrl, displayUrl, text, cls) {
+      var shown = displayUrl || openUrl;
+      var navAttr = displayUrl ? ' ' + SSO_NAV_ATTR + '="' + esc(openUrl) + '"' : '';
+      return '<a href="' + esc(shown) + '" target="_blank"' + navAttr +
+        ' class="' + cls + '" title="Open dashboard">' + esc(text) + '</a>';
+    }
+
+    /* One delegated listener rather than per-row handlers: the table is
+       re-rendered wholesale on every refresh, so inline handlers would be
+       re-attached constantly. Only a plain primary-button click is taken over;
+       cmd/ctrl/shift/alt-click and middle-click fall through to the browser so
+       "open in new tab" keeps its native meaning (landing on the vanity login
+       page, per the note above). */
+    document.addEventListener('click', function(ev) {
+      var a = ev.target && ev.target.closest ? ev.target.closest('[' + SSO_NAV_ATTR + ']') : null;
+      if (!a) return;
+      if (ev.button !== 0 || ev.metaKey || ev.ctrlKey || ev.shiftKey || ev.altKey) return;
+      var target = a.getAttribute(SSO_NAV_ATTR);
+      if (!target) return;
+      ev.preventDefault();
+      window.open(target, '_blank');
+    });
+
     async function loadUser() {
       try {
         var resp = await fetch('/api/auth/user');
@@ -10077,7 +10127,7 @@ const dashboardHTML = `<!DOCTYPE html>
         return '<tr>' +
           bulkCheckboxCell(h, section || 'all') +
           '<td class="hive-menu-cell" style="position:relative;width:30px;text-align:center;overflow:visible">' + (h.migrationStatus === 'migrating' ? '<span style="font-size:1.1rem;color:var(--border);user-select:none;cursor:not-allowed" title="Disabled during migration">⋮</span>' : '<span style="cursor:pointer;font-size:1.1rem;color:var(--muted);user-select:none">⋮</span>' + pendingBadge + '<div class="hive-menu-dropdown" style="display:none;position:absolute;left:0;bottom:auto;background:#1c2128;border:1px solid #30363d;border-radius:8px;min-width:160px;padding:4px 0;z-index:1000;box-shadow:0 8px 24px rgba(0,0,0,0.5)">' + menuItems.join('') + '</div>') + '</td>' +
-          '<td style="text-align:left;line-height:1.4">' + (function() { var isHostedRow = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'))); var dh = isHostedRow && h.id ? ('/api/saas/hives/' + encodeURIComponent(h.id) + '/open') : (rb ? esc(rb) : ''); /* Label derived from the PROJECT (org + primary repo), not by splitting h.name — see hiveLabel. */ var label = hiveLabel(h); var orgName = label.line1; var repoName = label.line2; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var ghIcon = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : ''; var link = function(text, bold) { if (dh) { return '<a href="' + dh + '" target="_blank" class="' + (bold ? 'hive-name-link' : 'hive-sub-link') + '" title="Open dashboard">' + esc(text) + '</a>'; } var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName, true); var fcPill = h.online ? failingCheckSummary(h) : ''; /* Advisory-staleness pill sits right beside the failing-check pill: both are "something is quietly wrong with this working hive" signals, and advisoryStaleSummary already self-suppresses (empty string) unless the hub flagged the digest stale, so unaffected rows are pixel-identical. */ var advPill = h.online ? advisoryStaleSummary(h) : ''; /* Inline access faces sit on the name cell's second line, immediately after this row's own role badge: the badge already answers "what am I on this hive", so the co-members read as the natural continuation of the same thought, in the one cell that is left-aligned and has room to grow. It also keeps them out of the 16 dense metric columns, none of which is about people. Empty string when the viewer is the only member, so those rows are pixel-identical to today. */ var accessFaces = hiveAccessAvatars(h); /* Keyed off repoName, not orgName: line 1 now always carries SOME identity, so the presence of a second line is decided purely by whether there is a repo to put on it. Without a repo the row still shows the GitHub icon, role badge, faces and failing-check pill on the compact variant. */ var line2 = repoName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + '</div>'; var line3 = pendingPill ? '<div style="margin-top:4px;padding-left:18px">' + pendingPill + '</div>' : ''; return line1 + line2 + line3; })() + '</td>' +
+          '<td style="text-align:left;line-height:1.4">' + (function() { var isHostedRow = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'))); var dh = isHostedRow && h.id ? ('/api/saas/hives/' + encodeURIComponent(h.id) + '/open') : (rb ? esc(rb) : ''); /* Label derived from the PROJECT (org + primary repo), not by splitting h.name — see hiveLabel. */ var label = hiveLabel(h); var orgName = label.line1; var repoName = label.line2; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var ghIcon = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : ''; /* vanityDisplay is the friendly host shown in the status bar on hover. rb is resolvedBase(h), which the hub has already overlaid with the claimed vanity_url; it is only a DISPLAY url here, never the click target — see ssoDisplayLink. Empty for a row with no vanity host, which falls back to today's /open href. Only meaningful on hosted rows: a non-hosted row's dh IS rb already. */ var vanityDisplay = isHostedRow && rb ? rb : ''; var link = function(text, bold) { if (dh) { return ssoDisplayLink(dh, vanityDisplay, text, bold ? 'hive-name-link' : 'hive-sub-link'); } var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName, true); var fcPill = h.online ? failingCheckSummary(h) : ''; /* Advisory-staleness pill sits right beside the failing-check pill: both are "something is quietly wrong with this working hive" signals, and advisoryStaleSummary already self-suppresses (empty string) unless the hub flagged the digest stale, so unaffected rows are pixel-identical. */ var advPill = h.online ? advisoryStaleSummary(h) : ''; /* Inline access faces sit on the name cell's second line, immediately after this row's own role badge: the badge already answers "what am I on this hive", so the co-members read as the natural continuation of the same thought, in the one cell that is left-aligned and has room to grow. It also keeps them out of the 16 dense metric columns, none of which is about people. Empty string when the viewer is the only member, so those rows are pixel-identical to today. */ var accessFaces = hiveAccessAvatars(h); /* Keyed off repoName, not orgName: line 1 now always carries SOME identity, so the presence of a second line is decided purely by whether there is a repo to put on it. Without a repo the row still shows the GitHub icon, role badge, faces and failing-check pill on the compact variant. */ var line2 = repoName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + '</div>'; var line3 = pendingPill ? '<div style="margin-top:4px;padding-left:18px">' + pendingPill + '</div>' : ''; return line1 + line2 + line3; })() + '</td>' +
           '<td>' + locationCell + '</td>' +
           '<td style="white-space:nowrap">' + uptimeCell(h) + '</td>' +
           /* No white-space:nowrap on the cell itself: the stacked lines each


### PR DESCRIPTION
## Problem

> when i hover over a hive's name in the hub, i see the placeholder url and not the vanity url in the bottom of the browser - can that be changed to show the vanity url?

The hive-name anchor in My Hives has `href="/api/saas/hives/<placeholder-id>/open"`. Browsers show the raw href in the status bar, so hovering surfaces the placeholder id rather than the friendly vanity host.

This is purely a **display/affordance** problem. The `/open` endpoint is correct and unchanged: it mints a short-lived (90s) HMAC-signed, hive-scoped SSO handoff token and 303s to the spoke's `/sso` on the vanity host, so the user lands authenticated.

## Approach

`href` now carries the **vanity URL**, and a delegated click listener sends a plain left-click through `/open` instead. The status bar reads the friendly host; the click still authenticates.

The obvious objection is the modified-click path — cmd/middle-click and "Copy link address" now use the vanity URL, which carries no handoff token. I verified where that actually lands before choosing this option:

- `GET /` on the spoke is `http.FileServer` over the embedded SPA (`pkg/dashboard/server.go`), and `pkg/dashboard/static/index.html` renders a real **"Sign in with GitHub"** device-flow login page when unauthenticated.
- So a token-less arrival on the vanity host is an **ordinary login**, not a login wall dead end.

Trading a rare extra sign-in on modified-click for a readable URL on *every* hover is the right bargain. Modified-clicks deliberately fall through to native browser behavior, so "open in new tab" keeps its meaning.

## No payload change needed

The task assumed a new `vanityUrl` field was required. It is not — and `RegistryEntry` has no `VanityURL` field at all. `enrichFromSaaSMeta` already overlays the claimed `vanity_url` onto `entry.DashboardURL` hub-side, so the existing client-side `resolvedBase(h)` already returns the vanity host. The change is display-only.

## Empty-vanity case

When there is no vanity URL (unclaimed placeholder, or adoption legitimately skipped on OpenShift), `ssoDisplayLink` falls back to the `/open` href with no data attribute and no listener involvement — behavior is byte-for-byte what it is today. No broken link, no `undefined`.

## Scope decisions

- **Hive-name cell (~10060)** — changed. This is what the report is about.
- **Past Requests `/open` (~10972)** — left alone. It renders `pr.assigned_hive` (a bare hive id) as monospace text; there is no vanity URL in scope on that object, and the id *is* the intended label there.
- **`ssoHref` (~7414)** — left alone. Different surface, not the hover the owner described; keeping the hunk tight.

## Verified by running

- `go build ./...`, `go vet ./pkg/hub/` — clean
- `gofmt -l pkg/hub/saas.go` — clean (touched file only, no sweep)
- `TestHiveTableColumnCount*` passes; no column added, `TOTAL_COLUMNS` undisturbed
- `pkg/dashboard` SSO handoff tests pass
- Raw-string safety: extracted `dashboardHTML`, confirmed brace/paren/bracket deltas are **identical to the pre-change baseline** (`{}` 0, `()` -1, `[]` -1), no backtick introduced, and grepped the extraction to confirm the new code is actually present (not a stale extraction)

**Pre-existing failures, not from this change** (confirmed by testing the parent commit): `TestHandleHubSelfUpgrade_Edge` and `TestLoadAppPrivateKeyKubectlFails` in `pkg/hub`, plus 18 device-flow failures in `pkg/dashboard`.

## Not verified

The hover behavior was not exercised in a live browser against a real hosted hive; the reasoning rests on reading the anchor construction and the spoke's root/SSO handlers.

## Porting

**mk, dd and v3 need this ported.** ks/console's hive runs v3, so a v2-only merge will not reach it.