### PR TITLE
🐛 fix(agent): stop pinning bob's launch cmd to the bare binary name

### DIFF
--- a/v2/pkg/agent/routing_coverage_test.go
+++ b/v2/pkg/agent/routing_coverage_test.go
@@ -501,17 +501,36 @@ func TestAgentModeTokenTier(t *testing.T) {
 // claude-sonnet-4-6 reaches bob as claude-sonnet-4.6 — an id bob's backend
 // does not know — and every prompt dies with "Cannot read properties of
 // undefined (reading 'maxTokens')". bob auto-selects its own model.
+//
+// The assertion is deliberately about the ABSENCE of --model and the INVARIANCE
+// of the command across models, not equality against a fixed string. bob's
+// launch command legitimately carries required flags (--accept-license,
+// --auth-method api-key, --approval-mode yolo, --trust) that this test must not
+// re-litigate; bobLaunchCmd's own doc comment and
+// TestToolRulesToLaunchCmdBobHasNoModel in bob_test.go own that contract and
+// assert those flags are present. An earlier `cmd != "bob"` check here duplicated
+// that ownership badly: it pinned the whole command to the bare binary name and
+// so contradicted the sibling test the moment a required flag was added.
 func TestToolRulesToLaunchCmd_BobNeverGetsModel(t *testing.T) {
 	tools := &config.ToolsConfig{}
 	// Includes "auto": the dashboard's only bob option is a display/stored
 	// placeholder, and `bob --model auto` is untested and must not be emitted.
-	for _, model := range []string{"", "auto", "claude-sonnet-4.6", "claude-sonnet-4-6", "granite-3"} {
+	models := []string{"", "auto", "claude-sonnet-4.6", "claude-sonnet-4-6", "granite-3"}
+
+	// The command bob gets must not vary with the configured model at all, so
+	// every iteration is compared against the first one rather than a literal.
+	want := toolRulesToLaunchCmd("bob", models[0], bobBackend, tools, false)
+	for _, model := range models {
 		cmd := toolRulesToLaunchCmd("bob", model, bobBackend, tools, false)
 		if strings.Contains(cmd, "--model") {
 			t.Errorf("bob launch cmd with model %q must not contain --model: %q", model, cmd)
 		}
-		if cmd != "bob" {
-			t.Errorf("bob launch cmd with model %q = %q, want %q", model, cmd, "bob")
+		// Catches a model leaking in under any spelling, not just as --model.
+		if model != "" && strings.Contains(cmd, model) {
+			t.Errorf("bob launch cmd with model %q leaked the model id: %q", model, cmd)
+		}
+		if cmd != want {
+			t.Errorf("bob launch cmd with model %q = %q, want it identical to the no-model command %q", model, cmd, want)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #2186

## What was actually failing

Issue #2186 is an auto-filed CI report with no diagnosis, and it has been re-firing hourly ever since (latest: `c11643a`). The failure it reports **changed identity** over its lifetime, so both halves needed checking:

| | Test(s) | Status |
|---|---|---|
| **Original** (`b19c3d2`) | `TestFailingCheckSummaryEscapes/filter_chip_label_escaped`, `TestFilterComposition/clear_button_accounts_for_check_filter` (`pkg/hub`) | **Already fixed** by #2231 |
| **Current** (`c11643a`, still red) | `TestToolRulesToLaunchCmd_BobNeverGetsModel` (`pkg/agent`) | Fixed here |

The original `pkg/hub` failure no longer reproduces — verified with 3 consecutive `-count=1` runs on current `origin/v2`, all `ok`. `git log -S` confirms #2231 ("realign four stale dashboard tests") is the commit that fixed it. That half of the issue is genuinely stale.

The nightly stayed red because of a **different, real** failure in `pkg/agent`.

## The bug in the test

`TestToolRulesToLaunchCmd_BobNeverGetsModel` asserted:

```go
if cmd != "bob" {
```

pinning bob's *entire* launch command to the bare binary name. That equality was only ever incidentally true, and it is provably wrong rather than merely stale:

- `bobLaunchCmd` **must** emit `--accept-license`, `--auth-method api-key`, `--approval-mode yolo` and `--trust`. Each is required and extensively documented at its definition in `manager.go` — without them bob hard-errors on the license gate, stalls forever on its first tool call, or runs with the workdir untrusted.
- `pkg/agent/bob_test.go`'s `TestToolRulesToLaunchCmdBobHasNoModel` **positively asserts those same flags are present**.

So the two tests directly contradicted each other: no correct implementation could satisfy both, and the suite could not be green. The flags were added by the legitimate bob fixes #2235 / #2249; the equality assertion (from #2252) simply had no business owning that contract.

## The fix

The test's own doc comment states its purpose: bob "carries no `--model`". bob auto-selects its model, and `normalizeModelName` rewrites a trailing `-<digits>` to `.<digits>` for non-claude backends, so a configured `claude-sonnet-4-6` reached bob as `claude-sonnet-4.6` and every prompt died with `Cannot read properties of undefined (reading 'maxTokens')`.

This asserts that purpose **directly** instead of by proxy:

- the command is compared against the **no-model command** rather than a string literal, so it must be **invariant across every model** tested;
- plus an explicit check that the model id never leaks in **under any spelling**, not just as `--model`.

No assertion was weakened or deleted — this is **strictly stronger** than the old check for the regression it guards, while no longer breaking when a required bob flag is added. Flag ownership now sits solely with `bob_test.go`, which is where it belongs.

## Verification

- **Mutation-tested**: reintroducing `bobLaunchCmd(binary) + " --model " + model` in `toolRulesToLaunchCmd` fails the new test on **both** the leak check and the invariance check. The old `cmd != "bob"` check would also have caught it — but it additionally failed on correct code, which is the bug.
- `go build ./...`, `go vet ./pkg/agent/` clean; `gofmt` clean on the single touched file (no unrelated files swept).
- Full `pkg/agent` and `pkg/hub` runs compared against a **clean unmodified `origin/v2` worktree** to separate this from the known environment-dependent failures (`TestLoadAppPrivateKeyKubectlFails`, `TestConcurrentPauseResume_NoPanic`, tmux-session `cxa`/`DismissInferencePrompts` tests, and the ~18 `pkg/dashboard` `/data`-dependent tests) — none of which this touches.

One file changed, test-only. No production behavior change.

## Porting

Test-only, but the same contradiction exists wherever both bob tests were ported. **mk / dd / v3 need this ported.**