### PR TITLE
✨ fix(hub): nobody starts a hive above L3 in onboarding

### DIFF
--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -1000,6 +1001,81 @@ func TestHandleRequestProvisionWithFilesystem(t *testing.T) {
 	}
 	if pr.GitHubHost != "github.com" {
 		t.Errorf("github_host = %q, want it persisted as github.com", pr.GitHubHost)
+	}
+}
+
+// TestHandleRequestProvisionClampsAboveOnboardingCeiling pins the rule that a
+// self-service request can never provision a hive above L3 Measured. The
+// get-started wizard and the Request-a-Hive modal both only offer L1-L3, but
+// they are clients: this asserts the SERVER refuses to record L4-L6 from a
+// crafted body, so the UI is not the only gate.
+func TestHandleRequestProvisionClampsAboveOnboardingCeiling(t *testing.T) {
+	for _, requested := range []int{maxRequestACMMLevel + 1, 5, 6, 99} {
+		t.Run(fmt.Sprintf("level%d", requested), func(t *testing.T) {
+			cleanup := helperSetupTempDirs(t)
+			defer cleanup()
+
+			token := fmt.Sprintf("ghp_clamp_%d", requested)
+			username := fmt.Sprintf("clamp-user-%d", requested)
+			authCleanup := helperSetupAuthUser(t, token, username)
+			defer authCleanup()
+
+			srv := NewHubServer(0, slog.Default(), "test", "v2")
+
+			body := fmt.Sprintf(`{"org":"validorg","github_host":"github.com","repos":"repo1","primary_repo":"repo1","acmm_level":%d}`, requested)
+			req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+token)
+			w := httptest.NewRecorder()
+			srv.handleRequestProvision(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+			}
+			pr := loadProvisionRequest(username)
+			if pr == nil {
+				t.Fatal("provision request should be saved")
+			}
+			if pr.ACMMLevel > maxRequestACMMLevel {
+				t.Errorf("acmm_level = %d, want it clamped to at most %d — nobody starts a hive above L3", pr.ACMMLevel, maxRequestACMMLevel)
+			}
+		})
+	}
+}
+
+// TestHandleRequestProvisionAcceptsOnboardingLevels is the other half: the
+// levels the wizard DOES offer must survive the clamp unchanged.
+func TestHandleRequestProvisionAcceptsOnboardingLevels(t *testing.T) {
+	for requested := minRequestACMMLevel; requested <= maxRequestACMMLevel; requested++ {
+		t.Run(fmt.Sprintf("level%d", requested), func(t *testing.T) {
+			cleanup := helperSetupTempDirs(t)
+			defer cleanup()
+
+			token := fmt.Sprintf("ghp_ok_%d", requested)
+			username := fmt.Sprintf("ok-user-%d", requested)
+			authCleanup := helperSetupAuthUser(t, token, username)
+			defer authCleanup()
+
+			srv := NewHubServer(0, slog.Default(), "test", "v2")
+
+			body := fmt.Sprintf(`{"org":"validorg","github_host":"github.com","repos":"repo1","primary_repo":"repo1","acmm_level":%d}`, requested)
+			req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+token)
+			w := httptest.NewRecorder()
+			srv.handleRequestProvision(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+			}
+			pr := loadProvisionRequest(username)
+			if pr == nil {
+				t.Fatal("provision request should be saved")
+			}
+			if pr.ACMMLevel != requested {
+				t.Errorf("acmm_level = %d, want %d preserved", pr.ACMMLevel, requested)
+			}
+		})
 	}
 }
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4969,11 +4969,16 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	const minACMMLevel = 1
-	const maxACMMLevel = 6
+	// A hive is never REQUESTED above L3 Measured. L4-L6 are real levels, but
+	// they are reached after provisioning, from the hive's own dashboard, once
+	// the project has the coverage and CI history to justify them. The
+	// get-started wizard only offers L1-L3, but the wizard is one client: clamp
+	// here so a crafted request cannot provision straight into auto-merge.
+	// Admin paths (assign/provision) keep the full 0..6 range on purpose — an
+	// operator setting a level deliberately is not the case being guarded.
 	acmm := body.ACMMLevel
-	if acmm < minACMMLevel || acmm > maxACMMLevel {
-		acmm = minACMMLevel
+	if acmm < minRequestACMMLevel || acmm > maxRequestACMMLevel {
+		acmm = minRequestACMMLevel
 	}
 
 	primaryRepo := body.PrimaryRepo
@@ -11500,9 +11505,16 @@ const dashboardHTML = `<!DOCTYPE html>
        coverage) while still requiring a human on every merge, which is the
        right default for someone who has not run a hive before. */
     var REQUEST_DEFAULT_ACMM_LEVEL = 3;
-    /* ACMM levels offered on the request form, lowest to highest. All six are
-       offered — L5 and L6 are real, selectable levels, not hidden ones. */
-    var REQUEST_ACMM_LEVELS = [1, 2, 3, 4, 5, 6];
+    /* ACMM levels offered on the request form, lowest to highest. Capped at L3
+       Measured, matching maxRequestACMMLevel on POST /api/saas/request-provision
+       and the get-started wizard: a hive is never REQUESTED above L3. L4-L6 are
+       real levels, reached after provisioning from the hive's own dashboard
+       once coverage and CI history have earned them. This form posts to the
+       same clamped endpoint as the wizard, so offering L4-L6 here would not
+       grant them — it would silently record L1 instead. */
+    var REQUEST_ACMM_LEVELS = [1, 2, 3];
+    /* Restated under the picker so the cap reads as "later", not "denied". */
+    var REQUEST_LEVELS_LATER_NOTE = 'L4 Adaptive, L5 Semi-Automated and L6 Autonomous become available after provisioning, from your hive dashboard.';
 
     /* renderRequestLevelOptions builds the level picker from ACMM_LABELS and
        ACMM_TIPS. Rendering rather than hardcoding is the point: the previous
@@ -11536,7 +11548,8 @@ const dashboardHTML = `<!DOCTYPE html>
       var out = document.getElementById('rq-level-desc');
       if (!sel || !out) return;
       var lvl = parseInt(sel.value, 10) || REQUEST_DEFAULT_ACMM_LEVEL;
-      out.textContent = ACMM_TIPS[lvl] || '';
+      var tip = ACMM_TIPS[lvl] || '';
+      out.textContent = tip ? (tip + ' ' + REQUEST_LEVELS_LATER_NOTE) : REQUEST_LEVELS_LATER_NOTE;
     }
 
     /* openRequestHiveModal shows the modal with a freshly populated forge

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -112,6 +112,19 @@ const (
 	defaultAssignACMMLevel = 2
 )
 
+// ACMM level bounds for a SELF-SERVICE provision request (the get-started
+// wizard). Narrower than the assign bounds above on purpose: nobody starts a
+// hive above L3 Measured. L4 Adaptive and higher are reached after
+// provisioning, from the hive's own dashboard, once the project's test
+// coverage and CI history have earned the extra automation. The wizard renders
+// levels up to maxRequestACMMLevel as radios and lists the rest as "available
+// after provisioning"; this pair is the enforcement behind that copy, since the
+// wizard is only one possible client of the endpoint.
+const (
+	minRequestACMMLevel = 1
+	maxRequestACMMLevel = 3
+)
+
 // clustersConfigPath is the on-disk location where the hub reads cluster
 // definitions. It is a JSON array of ClusterConfig objects. A var (not a const)
 // so tests can point it at a temp file; production never reassigns it.

--- a/v2/pkg/hub/static/get-started.html
+++ b/v2/pkg/hub/static/get-started.html
@@ -216,6 +216,12 @@
     .acmm-option input[type=radio] { accent-color: var(--amber); margin-top: 2px; flex-shrink: 0; }
     .acmm-option .acmm-label { font-weight: 700; font-size: .9rem; color: var(--text); margin-bottom: 2px; }
     .acmm-option .acmm-desc { font-size: .78rem; color: var(--muted); line-height: 1.5; }
+    /* Levels above the onboarding ceiling: a quiet informational note, not a
+       disabled choice. Deliberately not styled like .acmm-option so it never
+       reads as a radio the requester failed to earn. */
+    .acmm-later { margin-top: .35rem; padding: .7rem .85rem; border-left: 2px solid var(--border); }
+    .acmm-later-title { font-size: .74rem; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; color: var(--muted); margin-bottom: 4px; }
+    .acmm-later-body { font-size: .78rem; color: var(--muted); line-height: 1.55; }
     .acmm-rec {
       display: inline-block; padding: 2px 10px; border-radius: 9999px;
       font-size: .65rem; font-weight: 900; letter-spacing: .04em; text-transform: uppercase;
@@ -475,9 +481,9 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
        step — a requester must not be shown one name here and another one on
        the dashboard of the hive they receive. */
     var ACMM_LEVELS = [
-      {level: 1, label: 'L1 Assisted',       desc: 'Advisory only. Agents look and report; they never write to your repo.'},
-      {level: 2, label: 'L2 Instructed',     desc: 'Advisory beads, no GitHub writes. Agents follow your CLAUDE.md and house rules.'},
-      {level: 3, label: 'L3 Measured',       desc: 'Hold-gated PRs, CI gates. Agents raise test coverage to earn later automation; every PR waits for a human.'},
+      {level: 1, label: 'L1 Assisted',       desc: 'Start a new feature with spec-driven tooling. Agents look, plan and report; they never write to your repo.'},
+      {level: 2, label: 'L2 Instructed',     desc: 'Advisory beads, no GitHub writes. Agents follow the house rules you set for the project.'},
+      {level: 3, label: 'L3 Measured',       desc: 'Improve quality through better test coverage. Agents open hold-gated PRs that raise coverage behind CI gates; every PR waits for a human.'},
       {level: 4, label: 'L4 Adaptive',       desc: 'Agents open issues and hold-gated PRs, plus security checks. Still a human on every merge.'},
       {level: 5, label: 'L5 Semi-Automated', desc: 'PRs carry a hold label for batch review, so you approve in groups rather than one at a time.'},
       {level: 6, label: 'L6 Autonomous',     desc: 'Auto-merge on green CI. Only for repos with CI you already trust.'}
@@ -486,17 +492,33 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
        produces useful work (test-coverage PRs) while still gating every merge
        on a human. */
     var DEFAULT_ACMM_LEVEL = 3;
+    /* Highest level a hive can be REQUESTED at. Levels above this are real and
+       reachable, but only after provisioning, from the hive's own dashboard —
+       nobody starts a hive at L4+. The wizard therefore offers 1..3 as radios
+       and lists the rest as "available later". The hub enforces the same
+       ceiling on POST /api/saas/request-provision; this constant is the copy
+       of that rule the UI renders from, not the rule itself. */
+    var ONBOARDING_MAX_ACMM_LEVEL = 3;
     var _selectedAcmm = DEFAULT_ACMM_LEVEL;
 
     function acmmEntry(level) {
       return (ACMM_LEVELS || []).filter(function(a) { return a.level === level; })[0] || null;
     }
 
-    /* renderAcmmOptions builds the level radios from ACMM_LEVELS. */
+    /* renderAcmmOptions builds the level radios from ACMM_LEVELS.
+
+       Only levels up to ONBOARDING_MAX_ACMM_LEVEL are selectable. The higher
+       levels are rendered as a short "what comes next" note rather than as
+       disabled radios: a greyed-out radio reads as a choice being refused,
+       which is the wrong message. They are not forbidden, they are simply
+       earned later — a hive advances to them from its own dashboard once it
+       has the coverage and CI history to justify them. */
     function renderAcmmOptions() {
       var host = document.getElementById('acmm-options');
       if (!host) return;
-      host.innerHTML = (ACMM_LEVELS || []).map(function(a) {
+      var startable = (ACMM_LEVELS || []).filter(function(a) { return a.level <= ONBOARDING_MAX_ACMM_LEVEL; });
+      var later = (ACMM_LEVELS || []).filter(function(a) { return a.level > ONBOARDING_MAX_ACMM_LEVEL; });
+      var html = (startable || []).map(function(a) {
         var sel = a.level === _selectedAcmm;
         return '<label class="acmm-option' + (sel ? ' selected' : '') + '" onclick="selectAcmm(this, ' + a.level + ')">' +
           '<input type="radio" name="acmm" value="' + a.level + '"' + (sel ? ' checked' : '') + '>' +
@@ -505,6 +527,14 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
           '</div>' +
           '<div class="acmm-desc">' + esc(a.desc) + '</div></div></label>';
       }).join('');
+      if ((later || []).length) {
+        html += '<div class="acmm-later">' +
+          '<div class="acmm-later-title">Available after provisioning</div>' +
+          '<div class="acmm-later-body">Once your hive is running you can advance it from its own dashboard, as its test coverage and CI history earn more automation: ' +
+          (later || []).map(function(a) { return esc(a.label); }).join(', ') + '.</div>' +
+          '</div>';
+      }
+      host.innerHTML = html;
     }
 
     function goToStep(n) {
@@ -522,6 +552,10 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
     }
 
     function selectAcmm(el, level) {
+      /* Clamp rather than trust the caller: renderAcmmOptions only emits
+         startable levels, but this is the one place _selectedAcmm is written
+         and it is what the submit body carries. */
+      if (level > ONBOARDING_MAX_ACMM_LEVEL) { level = ONBOARDING_MAX_ACMM_LEVEL; }
       _selectedAcmm = level;
       document.querySelectorAll('.acmm-option').forEach(function(o) { o.classList.remove('selected'); });
       el.classList.add('selected');


### PR DESCRIPTION
Three copy/selection corrections to the ACMM step of the get-started wizard, plus the server-side rule behind them.

## The corrections

**L2 must not mention CLAUDE.md.** The level is about agents following the house rules of the project, which is true whatever the rules file is called. Naming one agent's convention was both narrower and more brittle than the level itself.

**L1 now says what it is FOR.** The old copy stated only the permission ("advisory only. Agents look and report"). It now leads with the use case — starting a new feature with spec-driven tooling — and keeps the permission second. That is the half a requester is actually choosing between.

**L3 leads with its purpose.** "Improve quality through better test coverage" was previously buried behind the hold-gate mechanics. The mechanics are still there, second.

**L4–L6 are no longer selectable at onboarding.** They render as a short "Available after provisioning" note listing the three levels.

### Why a note and not disabled radios

A greyed-out radio reads as a choice being *refused*. The actual rule is that those levels are *earned later*, from the hive's own dashboard, once coverage and CI history justify them. The note carries that meaning, and is less markup. It is deliberately not styled like `.acmm-option` so it never reads as a radio the requester failed to qualify for.

## The UI was the only gate

`POST /api/saas/request-provision` previously accepted **any** level 1–6 and clamped only out-of-range values to 1. A crafted request could have provisioned a hive straight into **L6 auto-merge**, entirely bypassing the wizard. Client-side hiding alone was not enforcement.

It now clamps to `minRequestACMMLevel..maxRequestACMMLevel` (1..3), with tests asserting both halves:

- `TestHandleRequestProvisionClampsAboveOnboardingCeiling` — L4/L5/L6/99 are clamped and the *persisted* level is checked, not just the status code.
- `TestHandleRequestProvisionAcceptsOnboardingLevels` — L1/L2/L3 survive unchanged.

The admin **assign/provision** paths keep the full 0..6 range on purpose: an operator setting a level deliberately is not the case being guarded.

## The Request-a-Hive modal is capped too

The modal posts to that **same** clamped endpoint. The owner's phrasing was about onboarding, so this needed a decision rather than an assumption — and here the two surfaces are not actually separable: leaving the modal offering L4–L6 would not have granted them, it would have **silently recorded L1**. A picker that lies about its outcome is worse than a capped one, so `REQUEST_ACMM_LEVELS` is now `[1, 2, 3]` with the same "available after provisioning" note under the picker.

## No fifth copy of the levels

#2294 consolidated ACMM copy so it renders from one table. Labels still come from the single `ACMM_LABELS`/`ACMM_TIPS` in `saas.go` — **unchanged and shared**. The wizard keeps its own longer descriptions, which is deliberate: they serve a different audience (onboarding prose vs. a hover tip). The *labels*, which are what drifted last time, are untouched.

## Verification

- `go build ./...`, `go vet ./pkg/hub/...` — clean
- `go test ./pkg/hub/` — pass (full suite, not just the new tests)
- JS extracted from both the raw-string `dashboardHTML` and the static file, grepped to confirm the changes are present in the extraction (not a stale one), brace delta `0` == base delta `0`, `node --check` clean on both
- `gofmt -l` clean on the touched files only

`v2/test` times out at 604s making real outbound TCP connections in this sandbox; it contains zero ACMM references and is unrelated.

## Porting

**mk, dd and v3 still need this.** v3 in particular is what the ks/console hive runs, so a v2-only merge does not reach it.

Rebased on fresh `origin/v2`; hunks are confined to the ACMM section so they do not collide with the concurrent repository-step change to the same file.
