### PR TITLE
🐛 fix(spoke): stop the GitHub App banner firing falsely on every cold start

### DIFF
--- a/v2/cmd/hive/ghapp_banner_verdict_test.go
+++ b/v2/cmd/hive/ghapp_banner_verdict_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// verdictTestKeyBits keeps key generation fast; these keys never leave the test.
+const verdictTestKeyBits = 2048
+
+// verdictTestAppID / verdictTestInstallationID are arbitrary non-placeholder
+// identifiers — they only need to be non-zero for NewAppAuth to accept them.
+const (
+	verdictTestAppID          = 5686
+	verdictTestInstallationID = 42980
+)
+
+func verdictTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// verdictTestAuth builds a real AppAuth backed by a freshly generated key on
+// disk and pointed at a stub API, so classifyGitHubAppFailure exercises the
+// same code path production does.
+func verdictTestAuth(t *testing.T, apiURL string) *github.AppAuth {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, verdictTestKeyBits)
+	if err != nil {
+		t.Fatalf("generating test key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	keyPath := filepath.Join(t.TempDir(), "app.pem")
+	if err := os.WriteFile(keyPath, pemBytes, 0o600); err != nil {
+		t.Fatalf("writing test key: %v", err)
+	}
+	// diagnoseGitHubApp pre-flights the well-known spoke key paths and reports
+	// key-missing without any API call when none holds content. Point one of
+	// them at the real key so these tests exercise the API classification the
+	// verdict actually depends on. Restored via t.Cleanup.
+	origProvisioned, origPVC := spokeProvisionedAppKeyPath, spokeAppKeyPath
+	spokeProvisionedAppKeyPath, spokeAppKeyPath = keyPath, keyPath
+	t.Cleanup(func() {
+		spokeProvisionedAppKeyPath, spokeAppKeyPath = origProvisioned, origPVC
+	})
+	auth, err := github.NewAppAuth(verdictTestAppID, verdictTestInstallationID, keyPath, verdictTestLogger(), apiURL)
+	if err != nil {
+		t.Fatalf("NewAppAuth: %v", err)
+	}
+	return auth
+}
+
+// TestClassifyGitHubAppFailure_UnknownDoesNotRaiseBanner is the regression test
+// for the false banner: a hive whose first App probe fails for a reason we
+// cannot classify (the API never answered) must NOT be told its App is broken.
+// The boot path used to raise the banner unconditionally in this situation and
+// then never lower it, while the Re-check button — running the identical probe
+// — treated the same evidence as success and cleared it. That asymmetry is the
+// entire "shows on load, disappears on Re-check" report.
+func TestClassifyGitHubAppFailure_UnknownDoesNotRaiseBanner(t *testing.T) {
+	// Port 1 is reserved and refuses connections, so no status is ever
+	// returned and classification is genuinely inconclusive.
+	auth := verdictTestAuth(t, "http://127.0.0.1:1")
+
+	raise, msg, state := classifyGitHubAppFailure(context.Background(), auth, "katamari", verdictTestLogger())
+	if raise {
+		t.Error("an unreachable GitHub API must not raise the App banner")
+	}
+	if state != github.AppStateUnknown {
+		t.Errorf("state = %s, want unknown when GitHub never answered", state)
+	}
+	if msg != "" {
+		t.Errorf("msg = %q, want empty — we must not accuse anyone without a verdict", msg)
+	}
+	if state.OperatorActionable() || state.UserActionable() {
+		t.Error("an unclassifiable failure must not be reported as anyone's fault")
+	}
+}
+
+// TestClassifyGitHubAppFailure_RateLimitDoesNotRaiseBanner — GitHub answers a
+// rate limit with 403, the same status a wrong installation returns. It is
+// transient and must never latch a credential banner.
+func TestClassifyGitHubAppFailure_RateLimitDoesNotRaiseBanner(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Limit", "60")
+		w.Header().Set("X-RateLimit-Reset", "9999999999")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "API rate limit exceeded"})
+	}))
+	defer srv.Close()
+
+	raise, _, state := classifyGitHubAppFailure(context.Background(), verdictTestAuth(t, srv.URL), "katamari", verdictTestLogger())
+	if raise {
+		t.Error("a rate-limited probe must not raise the App banner")
+	}
+	if state != github.AppStateUnknown {
+		t.Errorf("state = %s, want unknown for a rate-limited 403", state)
+	}
+}
+
+// TestClassifyGitHubAppFailure_HealthyAppDoesNotRaiseBanner — the case the boot
+// path got wrong. EnsureAdvisoryIssue can fail for repo-scoped reasons (the
+// repo is archived, missing, or the issue write raced a permission refresh)
+// while App auth itself is perfectly fine. Boot raised the banner on the error
+// string alone; the verdict must come from the App probe.
+func TestClassifyGitHubAppFailure_HealthyAppDoesNotRaiseBanner(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":          verdictTestInstallationID,
+			"account":     map[string]any{"login": "katamari"},
+			"permissions": map[string]any{"issues": "write"},
+		})
+	}))
+	defer srv.Close()
+
+	raise, msg, state := classifyGitHubAppFailure(context.Background(), verdictTestAuth(t, srv.URL), "katamari", verdictTestLogger())
+	if raise {
+		t.Errorf("a healthy App must not raise the banner (state=%s, msg=%q)", state, msg)
+	}
+	if state != github.AppStateOK {
+		t.Errorf("state = %s, want ok", state)
+	}
+}
+
+// TestClassifyGitHubAppFailure_GenuineFailureStillRaises guards against the fix
+// silencing real problems: a 404 means the App truly is not installed, and that
+// banner must still appear.
+func TestClassifyGitHubAppFailure_GenuineFailureStillRaises(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "Not Found"})
+	}))
+	defer srv.Close()
+
+	raise, msg, state := classifyGitHubAppFailure(context.Background(), verdictTestAuth(t, srv.URL), "katamari", verdictTestLogger())
+	if !raise {
+		t.Error("a genuinely uninstalled App must still raise the banner")
+	}
+	if state != github.AppStateNotInstalled {
+		t.Errorf("state = %s, want not-installed", state)
+	}
+	if msg == "" {
+		t.Error("a raised banner must carry copy explaining what to fix")
+	}
+	if !state.UserActionable() {
+		t.Error("not-installed is the user's to fix")
+	}
+}
+
+// TestClassifyGitHubAppFailure_OperatorFaultIsNotBlamedOnUser — a 401 means the
+// key does not belong to the App. Only the operator can fix that, and #2224
+// exists so the user is never told to reinstall in this case.
+func TestClassifyGitHubAppFailure_OperatorFaultIsNotBlamedOnUser(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "A JSON web token could not be decoded"})
+	}))
+	defer srv.Close()
+
+	raise, _, state := classifyGitHubAppFailure(context.Background(), verdictTestAuth(t, srv.URL), "katamari", verdictTestLogger())
+	if !raise {
+		t.Error("an invalid key is a real fault and must raise the banner")
+	}
+	if state != github.AppStateKeyInvalid {
+		t.Errorf("state = %s, want key-invalid", state)
+	}
+	if !state.OperatorActionable() || state.UserActionable() {
+		t.Error("key-invalid is the operator's fault and must never be blamed on the user")
+	}
+}
+
+// TestIsGitHubRateLimitText covers the one place error-string matching survives
+// — where it can only ever cause an extra correct classification, never an
+// accusation.
+func TestIsGitHubRateLimitText(t *testing.T) {
+	if isGitHubRateLimitText(nil) {
+		t.Error("nil is not a rate limit")
+	}
+	for _, s := range []string{"API rate limit exceeded", "secondary RATE LIMIT hit"} {
+		if !isGitHubRateLimitText(errString(s)) {
+			t.Errorf("%q should be detected as a rate limit", s)
+		}
+	}
+	if isGitHubRateLimitText(errString("403 Resource not accessible by integration")) {
+		t.Error("a plain 403 is not a rate limit")
+	}
+}
+
+// errString is a minimal error carrying exactly the message given.
+type errString string
+
+func (e errString) Error() string { return string(e) }

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -737,21 +737,29 @@ func main() {
 				// GitHub returns 403 for rate limiting too — a transient
 				// condition that must not raise the "App Not Installed"
 				// banner (matches the guard on the repo-change path).
-				if strings.Contains(err.Error(), "rate limit") {
+				if isGitHubRateLimitText(err) {
 					logger.Warn("GitHub API rate limit hit during advisory issue ensure", "repo", primaryRepo)
-				} else if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "401") {
-					githubAppRequired = true
-					// Classify WHY before the banner renders. A bare 401/403
-					// here used to become "GitHub App Not Installed", which is
-					// wrong — and actively misleading — when the real cause is
-					// a key the operator has not delivered. Classification is
-					// on the live API response, and a missing key file
-					// short-circuits without any API call.
-					githubAppDiag, githubAppState = diagnoseGitHubApp(ctx, ghClient.AppAuth(), cfg.Project.Org)
-					logger.Warn("GitHub App authentication failed at startup",
-						"state", githubAppState.String(),
-						"operator_actionable", githubAppState.OperatorActionable(),
-						"error", err)
+				} else {
+					// Do NOT decide from the error string. This call site used
+					// to raise the banner on a substring match for "403"/"401"
+					// and set githubAppRequired=true BEFORE classifying, then
+					// never lower it again when classification came back OK or
+					// inconclusive — which is why the banner showed on boot and
+					// vanished on the first Re-check with nothing fixed.
+					// classifyGitHubAppFailure is the same verdict Re-check
+					// uses, and it declines to raise on AppStateUnknown.
+					raise, diag, state := classifyGitHubAppFailure(ctx, ghClient.AppAuth(), cfg.Project.Org, logger)
+					if raise {
+						githubAppRequired = true
+						githubAppDiag, githubAppState = diag, state
+						logger.Warn("GitHub App authentication failed at startup",
+							"state", state.String(),
+							"operator_actionable", state.OperatorActionable(),
+							"error", err)
+					} else {
+						logger.Warn("advisory issue ensure failed but GitHub App auth verified healthy — not raising the App banner",
+							"repo", primaryRepo, "state", state.String(), "error", err)
+					}
 				}
 			} else {
 				advisoryIssues[primaryRepo] = num
@@ -1493,10 +1501,25 @@ func main() {
 				num, err := ghClient.EnsureAdvisoryIssue(ctx, newPrimaryRepo)
 				if err != nil {
 					logger.Error("failed to create advisory issue on new primary repo", "repo", newPrimaryRepo, "error", err)
-					if strings.Contains(err.Error(), "rate limit") {
+					if isGitHubRateLimitText(err) {
 						logger.Warn("GitHub API rate limit hit during advisory issue creation", "repo", newPrimaryRepo)
-					} else if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "401") {
-						dashSrv.SetGitHubAppRequired(true)
+					} else {
+						// #2224 replaced error-string classification everywhere
+						// else but missed this site, which raised the banner on
+						// a bare "403"/"401" substring and recorded no state at
+						// all — so the UI fell back to "App Not Installed" even
+						// for an operator-side key fault. Classify properly.
+						raise, diag, state := classifyGitHubAppFailure(ctx, ghClient.AppAuth(), cfg.Project.Org, logger)
+						if raise {
+							dashSrv.SetGitHubAppRequired(true)
+							dashSrv.SetGitHubAppState(state.String())
+							if diag != "" {
+								dashSrv.SetGitHubAppPermIssue(diag)
+							}
+							logger.Warn("GitHub App authentication failed creating advisory issue",
+								"repo", newPrimaryRepo, "state", state.String(),
+								"operator_actionable", state.OperatorActionable())
+						}
 					}
 				} else {
 					advisoryIssues[newPrimaryRepo] = num
@@ -1586,7 +1609,12 @@ func main() {
 				// this is the exact case rediscovery exists for. Cached by TTL,
 				// so a repeated re-check does not re-hit the API.
 				healGitHubAppInstallation(ctx, ghClient.AppAuth(), cfg, logger)
-				if diag, state := diagnoseGitHubApp(ctx, ghClient.AppAuth(), cfg.Project.Org); diag != "" {
+				// Shared verdict with the boot and advisory-digest paths. Re-check
+				// previously branched on `diag != ""` while boot branched on the
+				// error string, which is how the two came to disagree about the
+				// same hive; routing both through classifyGitHubAppFailure means
+				// they cannot drift again.
+				if raise, diag, state := classifyGitHubAppFailure(ctx, ghClient.AppAuth(), cfg.Project.Org, logger); raise {
 					dashSrv.SetGitHubAppPermIssue(diag)
 					dashSrv.SetGitHubAppState(state.String())
 					logger.Warn("github app recheck: app detected but write not verified",
@@ -2973,6 +3001,87 @@ func diagnoseGitHubAppWrite(ctx context.Context, appAuth *github.AppAuth, expect
 	return msg
 }
 
+// githubRateLimitErrText is the substring GitHub's client surfaces on a rate or
+// abuse limit. Matching text is acceptable ONLY here: a rate limit is a reason
+// to skip classification entirely, never a reason to accuse anyone of anything,
+// so a false negative costs one extra (correct) classification round-trip.
+const githubRateLimitErrText = "rate limit"
+
+// isGitHubRateLimitText reports whether an error looks like a GitHub rate limit.
+func isGitHubRateLimitText(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), githubRateLimitErrText)
+}
+
+// githubAppBannerAttempts is how many times classifyGitHubAppFailure probes
+// before accepting an unclassifiable (AppStateUnknown) verdict. A cold start
+// races the cluster's DNS/egress-proxy readiness, so the FIRST App call a pod
+// makes is the one most likely to fail for reasons that have nothing to do
+// with the App. One retry converts that transient into a correct verdict.
+const githubAppBannerAttempts = 2
+
+// githubAppBannerRetryDelay spaces those attempts. Short enough not to stall
+// boot, long enough for an egress proxy or DNS cache to come up.
+const githubAppBannerRetryDelay = 3 * time.Second
+
+// classifyGitHubAppFailure is the SINGLE decision point for "should the GitHub
+// App banner be raised?" — used by the boot path, the advisory-digest path and
+// the manual Re-check button alike, so those three can never again disagree
+// about the same hive.
+//
+// It exists because they DID disagree. The boot path used to raise the banner
+// on a substring match for "403"/"401" in a formatted error string (the exact
+// pattern #2224 replaced), set githubAppRequired=true UNCONDITIONALLY, and
+// then classify — never lowering the flag again when classification came back
+// healthy or inconclusive. Re-check ran the very same diagnoseGitHubApp probe
+// but treated an empty diagnosis as success and cleared the banner. Same
+// evidence, opposite conclusion: the banner appeared on every cold start whose
+// first advisory-issue call blipped, and vanished the moment the user clicked
+// Re-check without anything having been fixed.
+//
+// Two rules make the verdict trustworthy:
+//
+//  1. Only a state that is genuinely actionable raises the banner. AppStateOK
+//     obviously does not, and neither does AppStateUnknown — #2224 defines it
+//     as "we could not reach a conclusion", and escalating on it is precisely
+//     the false accusation that design was meant to prevent.
+//  2. An unknown verdict is retried before it is accepted, so a transient
+//     startup network failure is not mistaken for a definitive one.
+//
+// Returns raise=false with an empty message when the App is fine or when we
+// simply cannot tell.
+func classifyGitHubAppFailure(ctx context.Context, appAuth *github.AppAuth, expectedOwner string, logger *slog.Logger) (raise bool, msg string, state github.AppAuthState) {
+	for attempt := 1; attempt <= githubAppBannerAttempts; attempt++ {
+		msg, state = diagnoseGitHubApp(ctx, appAuth, expectedOwner)
+		if state != github.AppStateUnknown {
+			break
+		}
+		if attempt < githubAppBannerAttempts {
+			logger.Debug("github app classification inconclusive — retrying before accepting a verdict",
+				"attempt", attempt, "owner", expectedOwner)
+			select {
+			case <-ctx.Done():
+				return false, "", github.AppStateUnknown
+			case <-time.After(githubAppBannerRetryDelay):
+			}
+		}
+	}
+
+	// AppStateUnknown must never raise the banner: we did not get an answer
+	// from GitHub, and a hive whose App is perfectly healthy would otherwise
+	// be told to reinstall it because of a momentary network fault. The
+	// self-heal loop and the next eval cycle both re-probe, so deferring the
+	// verdict costs nothing but a delay on a hive that IS genuinely broken.
+	if state == github.AppStateUnknown {
+		logger.Warn("github app state could not be determined — leaving the banner down rather than guessing",
+			"owner", expectedOwner)
+		return false, "", github.AppStateUnknown
+	}
+	if state == github.AppStateOK {
+		return false, "", github.AppStateOK
+	}
+	return true, msg, state
+}
+
 func runEvalCycle(
 	ctx context.Context,
 	cfg *config.Config,
@@ -3298,21 +3407,23 @@ func runEvalCycle(
 							logger.Warn("GitHub App write failed — cannot write issue comments",
 								"repo", primaryRepo, "state", state.String(),
 								"operator_actionable", state.OperatorActionable(), "detail", msg)
-						} else if strings.Contains(err.Error(), "rate limit") {
+						} else if isGitHubRateLimitText(err) {
 							logger.Warn("GitHub API rate limit hit, skipping advisory digest post", "repo", primaryRepo)
-						} else if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "401") {
-							// Same reasoning as the startup path: classify
-							// before raising a banner, so an operator-side key
-							// failure is never rendered as "not installed".
-							msg, state := diagnoseGitHubApp(ctx, ghClient.AppAuth(), cfg.Project.Org)
-							dashSrv.SetGitHubAppRequired(true)
-							if msg != "" {
-								dashSrv.SetGitHubAppPermIssue(msg)
+						} else {
+							// Same verdict function as boot and Re-check, so a
+							// healthy or unclassifiable probe cannot raise the
+							// banner here either.
+							raise, msg, state := classifyGitHubAppFailure(ctx, ghClient.AppAuth(), cfg.Project.Org, logger)
+							if raise {
+								dashSrv.SetGitHubAppRequired(true)
+								if msg != "" {
+									dashSrv.SetGitHubAppPermIssue(msg)
+								}
+								dashSrv.SetGitHubAppState(state.String())
+								logger.Warn("GitHub App authentication failed posting advisory digest",
+									"repo", primaryRepo, "state", state.String(),
+									"operator_actionable", state.OperatorActionable())
 							}
-							dashSrv.SetGitHubAppState(state.String())
-							logger.Warn("GitHub App authentication failed posting advisory digest",
-								"repo", primaryRepo, "state", state.String(),
-								"operator_actionable", state.OperatorActionable())
 						}
 					} else {
 						logger.Info("posted advisory digest", "repo", primaryRepo, "issue", issueNum, "findings", digest.TotalCount, "via", "app")


### PR DESCRIPTION
## The report

> why is the banner for github showing when i click re-check it goes away. and i do not see a complaint for gh app on the hive hub's status for this spoke either

Two symptoms, and together they are the diagnosis. A banner that clears on Re-check with nothing fixed in between is a false positive at startup.

## Why boot and Re-check disagreed

They reached **opposite conclusions from identical evidence**, because they consumed the same probe differently.

**Boot** (`main.go`, advisory-issue ensure):

```go
} else if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "401") {
    githubAppRequired = true                                   // raised FIRST, unconditionally
    githubAppDiag, githubAppState = diagnoseGitHubApp(...)     // classified SECOND
}
```

Two faults compound here:

1. It decided from a **substring of a formatted error string** — the exact pattern #2224 replaced everywhere else. `EnsureAdvisoryIssue` wraps errors from a repo-scoped search/create, so a "403"/"401" in that text can come from an archived repo, a missing repo, or a permissions refresh race — none of which mean App auth is broken.
2. It set the flag **before** classifying and **never lowered it again** when classification came back `AppStateOK` or `AppStateUnknown`. Classification could only ever refine the banner copy, never withdraw the banner.

**Re-check** ran the *very same* `diagnoseGitHubApp` probe but branched on `diag != ""`, treating an empty diagnosis as success and clearing the banner.

So on any cold start whose first advisory-issue call failed for a reason unrelated to App auth (transient egress/DNS while the pod's network comes up, a rate limit, an archived repo), boot latched a permanent banner that the first Re-check then *correctly* cleared. **`AppStateUnknown` — which #2224 defines as "we could not reach a conclusion, never escalate on it" — was being collapsed into "App required".**

### Why the hub showed no complaint

The heartbeat reports `IsGitHubAppRequired()` / `GetGitHubAppState()` — **the same dashboard fields the banner reads**. Spoke and hub *do* share a source of truth. The hub was silent because by the time anyone looked, the 2-minute self-heal loop (or the user's Re-check) had already cleared the flag. The hub/spoke divergence was a symptom of the flapping, not a second bug. No restructuring needed here.

## The fix

- **`classifyGitHubAppFailure`** — one verdict function now used by boot, the advisory-digest path, **and** the Re-check button, so the three cannot drift apart again. It raises the banner only for a genuinely actionable state; `AppStateOK` and `AppStateUnknown` never raise it.
- **Retry an inconclusive probe once** (2 attempts, 3s apart) before accepting it, so a startup network blip is not mistaken for a definitive verdict. A hive that is genuinely broken still gets its banner — just after one extra probe.
- **Fixed the call site #2224 missed** (`AdvisoryResetFunc`): it classified by `strings.Contains(err, "403"/"401")` and recorded **no state at all**, so the UI fell back to "App Not Installed" even for an operator-side key fault — the precise misdirection #2224 exists to prevent.
- **Confined error-string matching to rate-limit detection**, the one place a false negative merely costs an extra correct classification rather than an accusation.

## Genuine failures still raise the banner

Explicitly covered so this fix cannot silence real problems:

| Probe result | Banner | Actionability |
|---|---|---|
| 404 → `not-installed` | raised | user |
| 401 → `key-invalid` | raised | operator |
| 200 healthy → `ok` | **not** raised | — |
| 403 rate limit → `unknown` | **not** raised | nobody |
| no response → `unknown` | **not** raised | nobody |

## Verification

- `go build ./...`, `go vet ./cmd/hive/` — clean
- `go test ./cmd/hive/ ./pkg/github/` — pass, including 6 new tests
- `pkg/dashboard` has 18 pre-existing failures on untouched `origin/v2` (unrelated package, not touched here)
- Read live spoke logs on `hive-oke`: placeholder hives correctly raise the banner (genuinely no App), real spokes are currently healthy — the transient startup race was not reproducible live at the time of inspection, so the fix rests on code analysis plus the new tests rather than a live repro.

## Porting

**Needs porting to `mk`, `dd` and `v3`.**