### PR TITLE
🐛 fix(entrypoint): make $HOME writable by agent UIDs so bob can create .bob

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -308,7 +308,13 @@ if [ "$(id -u)" = "0" ]; then
   # Shared CLI auth/cache lives in /data/home (persistent volume).
   # Make it group-writable so all agent UIDs (node group) can use it.
   # The manager sets HOME=/data/home for agent tmux sessions.
-  mkdir -p /data/home/.config /data/home/.copilot /data/home/.claude/session-env /data/home/.codex /data/config/github-copilot /home/dev/.config
+  mkdir -p /data/home/.config /data/home/.copilot /data/home/.claude/session-env /data/home/.codex /data/home/.bob/settings /data/config/github-copilot /home/dev/.config
+  # $HOME itself must be group-writable, not just its children. bob calls
+  # mkdirSync('$HOME/.bob') on first run, which needs write on /data/home — a
+  # 0755 root-owned $HOME makes that EACCES even though every child dir below
+  # is perfectly writable. 2775 = rwxrwxr-x + setgid (new entries inherit node).
+  chmod 2775 /data/home 2>/dev/null || true
+  chown dev:node /data/home 2>/dev/null || true
   chmod 2770 /data/home/.copilot 2>/dev/null || true
   chown dev:node /data/home/.copilot 2>/dev/null || true
   chmod 2775 /data/home/.claude /data/home/.claude/session-env 2>/dev/null || true
@@ -319,23 +325,35 @@ if [ "$(id -u)" = "0" ]; then
   # codex backend fails with "Permission denied" initializing state_N.sqlite.
   chmod 2775 /data/home/.codex 2>/dev/null || true
   chown -R dev:node /data/home/.codex 2>/dev/null || true
+  # bob writes installation_id, settings.json, trustedFolders.json and tmp/ under
+  # $HOME/.bob, plus custom modes under $HOME/.bob/settings. Pre-create both
+  # group-writable + setgid so the FIRST agent to launch (a 2001+ UID in group
+  # node) never has to mkdir them itself — that mkdir is what failed with EACCES
+  # in #2284/#2253. Pre-creating also removes the ordering dependency on which
+  # process touches .bob first. 2770: no world access, these hold auth settings.
+  chmod 2770 /data/home/.bob /data/home/.bob/settings 2>/dev/null || true
+  chown -R dev:node /data/home/.bob 2>/dev/null || true
   ln -sfn /data/config/github-copilot /home/dev/.config/github-copilot
   ln -sfn /data/config/github-copilot /data/home/.config/github-copilot
   ln -sfn /data/home/.copilot /home/dev/.copilot
   # Set group-write + setgid on shared dirs — skip if already done (saves 100s+ on NFS).
   # The polling perm guard handles ongoing config.json fixes regardless.
+  # The sampled set MUST include every dir the repair below is relied on to fix.
+  # It previously sampled only .copilot and .claude, so a hive whose those two
+  # were already correct skipped the whole-tree repair forever — leaving
+  # /data/home itself at its original root-owned 0755 and making bob's
+  # mkdir('$HOME/.bob') fail with EACCES (#2284). /data/home and .bob are sampled
+  # too so that gap cannot reopen.
   NEED_PERM_FIX=false
   if [ -d "/data/home/.copilot" ] && [ -d "/data/home/.claude" ]; then
-    COPILOT_PERMS=$(stat -c '%a' "/data/home/.copilot" 2>/dev/null || echo "755")
-    CLAUDE_PERMS=$(stat -c '%a' "/data/home/.claude" 2>/dev/null || echo "755")
-    case "$COPILOT_PERMS" in
-      27[0-9][0-9]|37[0-9][0-9]) ;; # already has group-write + setgid
-      *) NEED_PERM_FIX=true ;;
-    esac
-    case "$CLAUDE_PERMS" in
-      27[0-9][0-9]|37[0-9][0-9]) ;; # already has group-write + setgid
-      *) NEED_PERM_FIX=true ;;
-    esac
+    for perm_dir in /data/home /data/home/.copilot /data/home/.claude /data/home/.bob; do
+      # Missing dir → repair. Default 755 → repair (no group-write/setgid).
+      DIR_PERMS=$(stat -c '%a' "$perm_dir" 2>/dev/null || echo "755")
+      case "$DIR_PERMS" in
+        27[0-9][0-9]|37[0-9][0-9]) ;; # already has group-write + setgid
+        *) NEED_PERM_FIX=true ;;
+      esac
+    done
   else
     NEED_PERM_FIX=true
   fi
@@ -390,8 +408,8 @@ if [ "$(id -u)" = "0" ]; then
       # Slow cycle: fix entire /data/home tree every 5 min (new dirs from agents)
       CYCLE=$((CYCLE + 1))
       if [ "$CYCLE" -ge 60 ]; then
-        chmod -R g+rwX /data/home/.cache /data/home/.copilot /data/home/.claude /data/home/.codex 2>/dev/null
-        find /data/home/.cache /data/home/.claude /data/home/.codex -type d -exec chmod g+s {} + 2>/dev/null
+        chmod -R g+rwX /data/home/.cache /data/home/.copilot /data/home/.claude /data/home/.codex /data/home/.bob 2>/dev/null
+        find /data/home/.cache /data/home/.claude /data/home/.codex /data/home/.bob -type d -exec chmod g+s {} + 2>/dev/null
         CYCLE=0
       fi
       sleep 5

--- a/v2/pkg/agent/bob_settings.go
+++ b/v2/pkg/agent/bob_settings.go
@@ -93,6 +93,24 @@ func bobSettingsPath(home string) string {
 	return filepath.Join(home, config.BobSettingsRelPath)
 }
 
+// nearestExistingDir walks up from dir and returns the first ancestor that
+// exists, or "" if none does. Used to locate the directory whose permissions
+// actually govern a recursive mkdir of a not-yet-existing path.
+func nearestExistingDir(dir string) string {
+	for {
+		if _, err := os.Stat(dir); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		// filepath.Dir is its own fixed point at the root ("/" or "."), which
+		// is the loop's only termination condition.
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
 // verifyBobStateDirsWritable probes, AS THE AGENT UID, every directory bob
 // writes to during startup, and logs an actionable error for each one that is
 // not writable.
@@ -136,10 +154,26 @@ func (m *Manager) verifyBobStateDirsWritable(agentName, home, workDir string, ui
 		info, err := os.Stat(dir)
 		if err != nil {
 			if os.IsNotExist(err) {
-				// Not an error on its own: bob creates these with
-				// mkdirSync({recursive:true}) on first use. It only matters
-				// whether the PARENT is writable, which the next launch's
-				// probe reports once the dir exists.
+				// A missing dir is not itself a failure — bob creates these
+				// with mkdirSync({recursive:true}) on first use. But that
+				// mkdir runs as the AGENT UID, so it succeeds only if the
+				// PARENT is group-writable. Probing the parent here is the
+				// whole point on a fresh hive: this is precisely the
+				// first-run EACCES in #2284, and the original probe returned
+				// "all clear" for it because it skipped missing dirs
+				// entirely. Check the nearest existing ancestor instead.
+				if parent := nearestExistingDir(filepath.Dir(dir)); parent != "" {
+					if pInfo, pErr := os.Stat(parent); pErr == nil {
+						pMode := pInfo.Mode().Perm()
+						if pMode&bobStateGroupWriteBit == 0 || pMode&bobKeyGroupExecBit == 0 {
+							m.logger.Error("bob state dir does not exist and its parent is not writable by the agent UID; bob's first-run mkdir will fail with EACCES",
+								"agent", agentName, "dir", dir, "parent", parent,
+								"parent_mode", fs.FileMode(pMode).String(), "uid", uid,
+								"remedy", "chmod 2775 "+parent+" and ensure it is group-owned by node")
+							unwritable = append(unwritable, dir)
+						}
+					}
+				}
 				continue
 			}
 			m.logger.Warn("bob state dir not statable; bob may fail to persist settings or initialize its logger",

--- a/v2/pkg/agent/bob_settings_test.go
+++ b/v2/pkg/agent/bob_settings_test.go
@@ -405,10 +405,17 @@ func TestVerifyBobStateDirsWritable(t *testing.T) {
 
 			m := &Manager{logger: discardLogger()}
 			// workDir points at a non-existent path on purpose: a state dir
-			// bob has not created yet must NOT be reported, since bob creates
-			// it recursively on first use.
+			// bob has not created yet must NOT be reported, PROVIDED its
+			// parent is group-writable so bob's recursive mkdir can succeed.
+			// The parent is made 0770 explicitly (t.TempDir is 0700) to keep
+			// this case isolating the $HOME/.bob mode under test — otherwise
+			// the unwritable-parent check would fire on every row.
+			workRoot := t.TempDir()
+			if err := os.Chmod(workRoot, 0o770); err != nil {
+				t.Fatalf("chmod workRoot: %v", err)
+			}
 			got := m.verifyBobStateDirsWritable("tester", home,
-				filepath.Join(t.TempDir(), "agents", "tester"), tc.uid)
+				filepath.Join(workRoot, "agents", "tester"), tc.uid)
 
 			if gotUnwritable := len(got) > 0; gotUnwritable != tc.wantUnwritable {
 				t.Errorf("verifyBobStateDirsWritable() unwritable=%v (%v), want %v",
@@ -418,15 +425,48 @@ func TestVerifyBobStateDirsWritable(t *testing.T) {
 	}
 }
 
-// TestVerifyBobStateDirsWritableIgnoresMissingDirs covers the fresh-PVC case:
-// neither state dir exists yet. bob creates them with mkdirSync recursive on
-// first use, so a missing dir is not a fault and must not be reported.
-func TestVerifyBobStateDirsWritableIgnoresMissingDirs(t *testing.T) {
+// TestVerifyBobStateDirsWritableIgnoresMissingDirsWithWritableParent covers the
+// fresh-PVC case where the state dirs do not exist yet but their parents ARE
+// group-writable. bob creates them with mkdirSync recursive on first use, so a
+// missing dir with a writable parent is not a fault and must not be reported.
+func TestVerifyBobStateDirsWritableIgnoresMissingDirsWithWritableParent(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	// t.TempDir() is 0700; production parents are group-writable (2775).
+	for _, d := range []string{home, workDir} {
+		if err := os.Chmod(d, 0o770); err != nil {
+			t.Fatalf("chmod %s: %v", d, err)
+		}
+	}
 	m := &Manager{logger: discardLogger()}
-	got := m.verifyBobStateDirsWritable("tester", t.TempDir(),
-		filepath.Join(t.TempDir(), "nope"), 2004)
+	got := m.verifyBobStateDirsWritable("tester", home, workDir, 2004)
 	if len(got) != 0 {
-		t.Errorf("verifyBobStateDirsWritable() = %v for missing dirs, want none", got)
+		t.Errorf("verifyBobStateDirsWritable() = %v for missing dirs with writable parents, want none", got)
+	}
+}
+
+// TestVerifyBobStateDirsWritableFlagsMissingDirWithUnwritableParent is the
+// regression test for #2284. On the reporting hive $HOME/.bob did not exist and
+// $HOME itself was root-owned 0755, so bob's first-run mkdir failed with EACCES.
+// The original probe skipped missing dirs outright and therefore reported "all
+// clear" for exactly the failure it was added to catch.
+func TestVerifyBobStateDirsWritableFlagsMissingDirWithUnwritableParent(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	// 0755: world-readable, NOT group-writable — the production $HOME mode.
+	if err := os.Chmod(home, 0o755); err != nil {
+		t.Fatalf("chmod home: %v", err)
+	}
+	if err := os.Chmod(workDir, 0o770); err != nil {
+		t.Fatalf("chmod workDir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(home, 0o770) })
+
+	m := &Manager{logger: discardLogger()}
+	got := m.verifyBobStateDirsWritable("tester", home, workDir, 2004)
+	wantDir := filepath.Dir(bobSettingsPath(home))
+	if len(got) != 1 || got[0] != wantDir {
+		t.Errorf("verifyBobStateDirsWritable() = %v, want [%s]", got, wantDir)
 	}
 }
 


### PR DESCRIPTION
## The bug

bob calls `mkdirSync('$HOME/.bob')` on first run, **as the agent UID** (2001+, primary group `node`). On affected hives `/data/home` was root-owned `0755`, so that mkdir failed with `EACCES` and bob died at startup:

```
Error accessing installation ID file, generating ephemeral ID:
  Error: EACCES: permission denied, mkdir '/data/home/.bob'
Failed to load custom modes: EACCES ... mkdir '/data/home/.bob/settings'
An unexpected critical error occurred: EACCES ... mkdir '/data/home/.bob'
```

## Why some hives were broken and others were not

This is the part worth recording. The `NEED_PERM_FIX` short-circuit sampled **only `.copilot` and `.claude`**:

```sh
if [ -d "/data/home/.copilot" ] && [ -d "/data/home/.claude" ]; then
  COPILOT_PERMS=...; CLAUDE_PERMS=...
```

On a hive where those two were already correct, the whole-tree `chmod -R g+rwX /data/home` repair was skipped **forever** — `[entrypoint] /data/home perms OK — skipping` — leaving `/data/home` itself at its original root-owned `0755`. Every *child* dir was fine, so the hive looked healthy. But `$HOME`, the one directory bob's first-run mkdir actually needs, never got group-write. `.bob` was never in the `mkdir -p` list at all (`.config`, `.copilot`, `.claude`, `.codex` all were), so nothing else created it either.

Hives that *did* run the repair — or where a `dev`-UID process happened to create `.bob` first — ended up with the good `drwxrwx--- dev:node` seen on `vllm-d`. **It is not a race**: the ordering hypothesis would require a concurrent first-touch, but the sampling gap is deterministic and fully explains the split on its own. The ordering dependency did exist as a latent second-order risk, and pre-creating `.bob` removes it too.

## The fix

All in `entrypoint.sh` as root **before privileges are dropped** — `CAP_CHOWN` is denied at runtime in this OpenShift environment, so this is the only workable place (same approach as #2235 for `/data/secrets` and #2251 for the token dir):

- `chmod 2775` + `chown dev:node` **`/data/home` itself**, not just its children.
- **Pre-create** `/data/home/.bob` and `.bob/settings` as `2770 dev:node`, so the first agent to launch never has to mkdir them.
- Sample `/data/home` and `.bob` in `NEED_PERM_FIX` so the repair-skip gap cannot reopen, and add `.bob` to the periodic perm guard.

`.bob` stays `2770` — group `node`, **no world access**, since it holds auth settings.

### Probe gap (#2256)

`verifyBobStateDirsWritable` skipped missing dirs outright, so it reported "all clear" for **precisely the first-run case it was added to catch**. It now probes the nearest existing ancestor — the dir that actually governs a recursive mkdir — and logs its mode plus a remedy.

## Should `.bob` be shared at all?

Reviewed, **not restructured here**. `settings.json` is deliberately shared and hive owns its `security.auth` block (#2235/#2228) — that must stay shared or one agent's SSO pick re-breaks the fleet. `trustedFolders.json` is fine shared. `installation_id` is the one arguably-wrong item: all agents report the same installation to bob telemetry. That is cosmetic, not a failure, and splitting it would need a per-agent `$HOME`, which would in turn un-share the auth block. Out of scope.

## Verification

Container repro of the exact observed state (`/data/home` `root:root 0755`, `.bob` absent, `.copilot`/`.claude` already correct):

```
BEFORE: agent CANNOT mkdir .bob          <-- reproduces #2284
OLD sampling would repair? false         <-- repair skipped forever
AFTER:  /data/home       drwxrwsr-x dev:node
        /data/home/.bob  drwxrws--- dev:node
PASS: agent can write $HOME
PASS: agent wrote .bob/installation_id
PASS: agent wrote settings.json + settings/modes
inherited group: .bob/settings/modes -> node
PASS: idempotent on re-run, existing content preserved
PASS: pre-existing good .bob unaffected
```

Go: `go build ./...`, `go vet ./pkg/agent/` clean; `bash -n entrypoint.sh` clean; gofmt on touched files only. Two new tests pin the regression (missing dir + unwritable parent → flagged; missing dir + writable parent → silent).

> `TestToolRulesToLaunchCmd_BobNeverGetsModel` fails **identically on unmodified `origin/v2`** (verified via `git stash`) — pre-existing, about `--trust`/auth launch flags, unrelated to this change.

## Relationship to #2253

`Refs`, not `Fixes`. #2253 was originally diagnosed as the tmux env-ordering bug and fixed in #2256 — but the reporter's [retry on the latest image](https://github.com/kubestellar/hive/issues/2253#issuecomment-5137541822) posted the **identical `mkdir '/data/home/.bob'` EACCES trace** from the supervisor agent on `hosted-available-oke-02`. So the *currently observed* failure in #2253 is this bug, and this PR should resolve it. Leaving it to the reporter to confirm rather than auto-closing, since #2253 also accumulated the separate (already-fixed) trust-prompt and auth-stall symptoms.

## Porting

**`mk`, `dd` and `v3` need this ported** — `entrypoint.sh` is branch-local and `v3` is what ks/console runs.

Fixes #2284
Refs #2253, #2256, #2235, #2251