### PR TITLE
🐛 fix(dashboard): close the GitHub App banner's unterminated <div> start tag

### DIFF
--- a/v2/pkg/dashboard/gh_app_banner_test.go
+++ b/v2/pkg/dashboard/gh_app_banner_test.go
@@ -117,3 +117,54 @@ func TestSetGitHubAppStateRoundTrips(t *testing.T) {
 		t.Errorf("GetGitHubAppState() = %q after clearing the requirement, want empty", got)
 	}
 }
+
+// TestGitHubAppBannerStartTagIsClosed guards a whole class of silent HTML
+// corruption that no JS syntax check can catch.
+//
+// The banner's opening <div> shipped for seven weeks with no ">" at all:
+//
+//	<div id="gh-app-install-banner" class="gh-app-install-banner" hidden
+//	  <span style="font-size:1.5rem">&#9888;&#65039;</span>
+//
+// Per the HTML5 tokenizer, "<" is a legal attribute-name character, so the
+// parser stayed in the div's start tag and consumed "<span" as an attribute
+// NAME and "font-size:1.5rem" as the value of a "style" attribute it then
+// hung on the DIV. The ">" that was meant to close the <span> closed the
+// <div> instead. Net effect: the ⚠️ glyph was swallowed into the tag and
+// never rendered, and the banner div acquired a bogus inline
+// style="font-size:1.5rem" that fights the cssText the show/hide code
+// assigns. node --check sees none of this — the script bodies are untouched.
+//
+// Assert on the parsed shape rather than the literal text so a future
+// reformat of the attribute list cannot silently retire the guard.
+func TestGitHubAppBannerStartTagIsClosed(t *testing.T) {
+	html := spokeIndexHTML(t)
+
+	const bannerID = `id="gh-app-install-banner"`
+	start := strings.Index(html, bannerID)
+	if start < 0 {
+		t.Fatalf("static/index.html no longer contains %s", bannerID)
+	}
+	// Walk back to the "<" that opens this element, then forward to the first
+	// ">" — everything between them is the start tag as the browser sees it.
+	open := strings.LastIndex(html[:start], "<")
+	if open < 0 {
+		t.Fatalf("could not find the opening < for the banner div")
+	}
+	end := strings.Index(html[open:], ">")
+	if end < 0 {
+		t.Fatalf("banner div start tag is never terminated by >")
+	}
+	tag := html[open : open+end+1]
+
+	// A well-formed start tag cannot contain another "<": if it does, the
+	// tokenizer has swallowed the next element into this tag's attributes.
+	if strings.Contains(tag[1:], "<") {
+		t.Errorf("banner div start tag swallowed a following element — missing '>':\n%s", tag)
+	}
+	// The warning glyph must be real text content, not tag innards.
+	afterTag := html[open+end+1:]
+	if !strings.HasPrefix(strings.TrimSpace(afterTag), "<span") {
+		t.Errorf("expected the warning <span> to follow the banner div start tag, got: %.80s", strings.TrimSpace(afterTag))
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2590,7 +2590,7 @@
     <a href="/api/widget" class="widget-dl" title="Download Übersicht widget">⬇ Widget</a>
   </h1>
 
-  <div id="gh-app-install-banner" class="gh-app-install-banner" hidden
+  <div id="gh-app-install-banner" class="gh-app-install-banner" hidden>
     <span style="font-size:1.5rem">&#9888;&#65039;</span>
     <div style="flex:1">
       <div class="gh-app-title">GitHub App Not Installed</div>


### PR DESCRIPTION
## Context

Investigating a report that **Set ID** (GitHub App installation ID entry) "fails" on the `kubestellar/console` hive whose App is demonstrably working. The investigation cleared Set ID itself and turned up a separate, real markup bug in the same banner.

## The bug

The banner's opening tag has shipped without a `>` since #1524 (2026-06-11):

```html
<div id="gh-app-install-banner" class="gh-app-install-banner" hidden
  <span style="font-size:1.5rem">&#9888;&#65039;</span>
```

Per the HTML5 tokenizer, `<` is a legal attribute-name character, so the parser never left the div's start tag: it consumed `<span` as an attribute **name** and `font-size:1.5rem` as the value of a `style` attribute it then hung on the **div**. The `>` intended to close the `<span>` closed the `<div>` instead.

Two consequences, both silent:

- The ⚠️ glyph is swallowed into the tag and **never renders** — the banner shows with no warning icon.
- The banner div acquires a bogus inline `style="font-size:1.5rem"`. The show/hide code assigns `banner.style.cssText` wholesale, so the two fight over the same attribute depending on which path ran last.

No JS syntax check could catch this — the `<script>` bodies are byte-identical before and after.

## Verification

- Extracted both `<script>` blocks: **byte-identical** before and after; brace delta **0 == 0** (base == new).
- `node --check` on the extracted script: OK.
- Parsed the corrected fragment: the ⚠️ is real text content again and `#gh-app-install-id-input` / `#gh-app-set-id-btn` are proper children.
- `go build ./...`, `go vet ./pkg/dashboard/` clean.
- `TestGitHubAppBannerStartTagIsClosed` **fails** against the unfixed markup and passes against the fix (checked both directions).
- Remaining `pkg/dashboard` failures (`TestCovV1_*`, `TestCovDF_*`) are **pre-existing** and network-dependent (they call real github.com and get 404); confirmed failing on a clean stash of this branch.

## Test

`TestGitHubAppBannerStartTagIsClosed` parses the start tag the way a browser would — asserting no second `<` appears inside the tag and that the warning `<span>` follows it as content — rather than matching literal text, so a future reformat of the attribute list cannot silently retire the guard.

## Not fixed here (separate finding)

The reported **Set ID** failure is **not** a defect in `handleConfigGitHub`. On the affected hive, `/data/audit.jsonl` (unbroken since 2026-06-09) contains **zero** `config_github` entries, so the PUT never reached the handler's audit line. Live status on that pod reports `githubAppRequired` absent (false) — the banner is not currently raised — and the pod runs `ghcr.io/kubestellar/hive:c11643a`, which predates #2301's cold-start banner fix. That points at a stale pre-#2301 banner rather than a Set ID code bug. Details in the investigation report.

## Porting

**Needs porting to `mk`, `dd` and `v3`.**