### PR TITLE
🐛 fix(hub): ungate hive-self-upgrade RBAC from RequiresSCC and verify spoke image exists

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2806,6 +2806,19 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"branch does not map to a valid image tag"}`, http.StatusBadRequest)
 		return
 	}
+	// Shape is not existence. A DEPRECATED branch (v3 was retired while hives
+	// were still pointed at it) keeps a perfectly well-formed "<branch>-latest"
+	// tag that CI no longer publishes, so validateImageTag passes and the pull
+	// then fails with an opaque "manifest unknown". Kubernetes keeps the old
+	// ReplicaSet serving, so the hive looks alive while silently running stale
+	// code. Verify the tag is actually pullable before writing it.
+	if !spokeImageExists(imageTag, s.logger) {
+		s.logger.Error("branch switch REFUSED: image tag not published on GHCR",
+			"hive", id, "branch", body.Branch, "tag", imageTag,
+			"hint", "branch may be deprecated or its CI image build never completed")
+		http.Error(w, `{"error":"no published image for that branch (deprecated branch, or its image build has not completed)"}`, http.StatusBadRequest)
+		return
+	}
 	// "*=" updates every container including init containers (copy-config,
 	// init-permissions) — pinning only "hive" left inits on the old branch tag.
 	cmd := kubectlForCluster(cluster, "set", "image", "deployment/hive", "*="+image, "-n", ns)
@@ -3152,6 +3165,16 @@ const (
 var hubImageExists = func(sha string, logger *slog.Logger) bool {
 	client := &http.Client{Timeout: 10 * time.Second}
 	return ghcrTagExists(client, ghcrRepoHub, sha, logger)
+}
+
+// spokeImageExists is the ghcrRepoSpoke counterpart of hubImageExists: it
+// reports whether a SPOKE tag (a "<branch>-latest" channel tag or a SHA) is
+// actually published. Separate from hubImageExists because the two repos are
+// independent build jobs — the hub image for a SHA can exist while the spoke
+// image for that same SHA does not. A var so tests can stub the GHCR round-trip.
+var spokeImageExists = func(tag string, logger *slog.Logger) bool {
+	client := &http.Client{Timeout: 10 * time.Second}
+	return ghcrTagExists(client, ghcrRepoSpoke, tag, logger)
 }
 
 var (

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1327,6 +1327,17 @@ subjects:
   name: hive-sa
   namespace: {{.Namespace}}
 ---
+{{- end}}
+# hive-self-upgrade must NOT be gated on RequiresSCC. The spoke patches its own
+# Deployment (UpgradeSelfToSHA / SwitchImageSelf in pkg/hub/self_upgrade.go) on
+# EVERY cluster, not just OpenShift ones. While this Role was inside the
+# RequiresSCC conditional block, non-OpenShift spokes ran as the "default"
+# ServiceAccount with no patch permission, so every hub-instructed upgrade hit
+# HTTP 403, fell through to os.Exit(0), and the pod restarted onto the SAME
+# image — a crash-loop that re-ran on each heartbeat and never advanced. It also
+# froze the init containers on whatever tag they were provisioned with, since
+# the only code path that rewrites init-container images is the very patch that
+# was being denied.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -1349,10 +1360,13 @@ roleRef:
   name: hive-self-upgrade
 subjects:
 - kind: ServiceAccount
+{{- if .RequiresSCC}}
   name: hive-sa
+{{- else}}
+  name: default
+{{- end}}
   namespace: {{.Namespace}}
 ---
-{{- end}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:


### PR DESCRIPTION
## Summary

The hosted console spoke sat in `Init:ImagePullBackOff` on an init container pinned to `ghcr.io/kubestellar/hive:v3-latest` — a tag that does not exist on GHCR (verified: `HTTP 404`, while `c11643a` and `v2-latest` return `200`) — while its main container ran `c11643a`. This PR fixes the two defects that produced and sustained that state.

## Root cause 1 — `hive-self-upgrade` RBAC was OpenShift-only

`v2/pkg/hub/saas_provision.go:1309` opened a `{{if .RequiresSCC}}` block that closed at line 1355, enclosing the **entire** `hive-self-upgrade` Role and RoleBinding (and `hive-sa`). Those objects were therefore created **only on OpenShift clusters**.

But the spoke patches its own Deployment on **every** cluster — `UpgradeSelfToSHA` / `SwitchImageSelf` in `v2/pkg/hub/self_upgrade.go`. On a non-OpenShift cluster the pod runs as the `default` ServiceAccount with no patch permission, so every upgrade was denied:

```
deployments.apps "hive" is forbidden: User "system:serviceaccount:...:default"
cannot patch resource "deployments" in API group "apps"
```

`UpgradeSelfToSHA` then logged `could not read own deployment image, defaulting to rollout restart`, `RolloutRestartSelf` hit the same 403, and the code fell through to `os.Exit(0)`. The pod restarted onto the *same* image, reported the same git hash, and the hub re-sent the identical target on the next heartbeat — a genuine crash loop (the affected pod had 9 restarts and was in `CrashLoopBackOff`, not healthy).

**This also explains the init/main asymmetry.** The provisioning template uses `{{.ImageTag}}` for both init and main containers, so they start out identical — the skew is not created at provision time. The only code path that rewrites **init-container** images is the self-patch that was being denied. Init containers therefore froze on whatever tag the hive was provisioned with while the main container advanced through other paths. Every one of the 12 ReplicaSets in the namespace shows `INIT v3-latest` while `MAIN` moved `v2-latest` → `c11643a`, which is exactly this signature.

Fix: render the Role/RoleBinding unconditionally, binding `hive-sa` on OpenShift and `default` elsewhere — the same conditional-subject pattern `hive-secrets-writer` already uses directly below it.

## Root cause 2 — shape was validated, existence was not

`handleSwitchBranch` called `validateImageTag`, which is deliberately a **shape** check (its own doc comment says so: *"Existence is verified separately and over the network (hubImageExists)"*). For the spoke path that separate verification did not exist.

A deprecated branch still sanitizes to a perfectly well-formed `<branch>-latest` tag that CI no longer publishes. The write succeeded, the pull failed with an opaque `manifest unknown`, and Kubernetes kept the old ReplicaSet serving — so the hive looked alive while running stale code. This is precisely the silent-staleness failure mode `image_tag_validation.go` was written to prevent.

Fix: add `spokeImageExists` (the `ghcrRepoSpoke` counterpart of the existing `hubImageExists`, sharing `ghcrTagExists`) and refuse the switch with an actionable error naming the likely cause.

## Verification

- `go build ./...` clean; `gofmt` clean.
- `go test ./pkg/hub/` passes (43.9s, no regressions).
- Template rendered for both `RequiresSCC=true/false`: the `hive-self-upgrade` Role is present in both, with the RoleBinding subject resolving to `hive-sa` and `default` respectively.
- `saas.go` raw-string hazards checked: no backtick added inside `dashboardHTML` (the one added backtick is an ordinary Go string literal in handler code), and no literal body tag introduced.

## Note on the deprecated `v3` branch

`trackedBranches` in `v2/pkg/hub/saas.go` still lists `v3`, and GHCR currently publishes `v2-latest`, `dd-latest`, `mk-latest`, and `v4-latest` — but no `v3-latest`. Retiring `v3` from that list is deliberately **not** included here, since it changes which branches the fleet tracks and warrants a separate decision. With this PR, a switch to such a branch is refused loudly instead of silently stranding a spoke.