### PR TITLE
🐛 fix(upgrade): unlatch the self-upgrade guard and make failed upgrades visible

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -513,9 +513,23 @@ func main() {
 	// previous version.
 	const upgradeMarkerStartupPath = "/data/upgrade-requested"
 	if markerData, err := os.ReadFile(upgradeMarkerStartupPath); err == nil {
-		if !strings.Contains(string(markerData), fmt.Sprintf(`"current_sha":"%s"`, gitShort)) {
+		m := parseUpgradeMarker(markerData)
+		if m.CurrentSHA != gitShort {
+			// We booted on a different SHA than the one that requested the
+			// upgrade: it landed. Drop the marker so the attempt budget resets.
 			os.Remove(upgradeMarkerStartupPath)
-			logger.Info("cleared stale upgrade marker (SHA changed)", "current", gitShort)
+			logger.Info("upgrade landed, cleared marker",
+				"current", gitShort, "previous", m.CurrentSHA, "target", m.TargetSHA)
+		} else {
+			// Same SHA as the attempt that ran before this boot: the image never
+			// changed, so that attempt FAILED. Say so at startup — previously
+			// this restart looked completely routine in the logs.
+			logger.Error("previous self-upgrade attempt did not land (still on the same image)",
+				"current", gitShort,
+				"target", m.TargetSHA,
+				"attempts", m.Attempts,
+				"last_error", m.LastError,
+			)
 		}
 	}
 
@@ -2336,6 +2350,10 @@ func main() {
 		}, heartbeatSendInterval, logger, hub.UpgradeCallback(func(targetSHA string) {
 			const upgradeMarkerPath = "/data/upgrade-requested"
 
+			// attemptCount carries the number of PREVIOUS failed attempts for this
+			// (current_sha → target_sha) pair, read from the marker below.
+			attemptCount := 0
+
 			// Never self-upgrade to the commit we are already running. The hub
 			// may instruct an upgrade to a short SHA that is a prefix of our
 			// full gitShort (or vice-versa); treating that as "behind" caused a
@@ -2353,17 +2371,59 @@ func main() {
 				}
 			}
 
-			// If a previous process already attempted an upgrade and we booted
-			// with the same git hash, the image tag didn't actually change.
-			// Skip to avoid an infinite restart loop.
+			// A previous process attempted an upgrade and we booted with the same
+			// git hash, so the image did not actually change: the attempt FAILED.
+			// Back off rather than retrying instantly (that was a crash-loop), but
+			// do NOT latch forever — "image unchanged" is the signature of a failed
+			// upgrade, not a reason to stop trying. The latch is keyed on
+			// (current_sha → target_sha) and bounded to selfUpgradeMaxAttempts, so a
+			// NEW target always gets a fresh budget and a transient failure (an RBAC
+			// Role that showed up late, a registry blip) still converges.
 			if markerData, err := os.ReadFile(upgradeMarkerPath); err == nil {
-				if strings.Contains(string(markerData), fmt.Sprintf(`"current_sha":"%s"`, gitShort)) {
-					logger.Info("self-upgrade skipped: already attempted from this SHA (image unchanged)",
+				m := parseUpgradeMarker(markerData)
+				if m.CurrentSHA == gitShort && sameUpgradeTarget(m.TargetSHA, targetSHA) {
+					if m.Attempts >= selfUpgradeMaxAttempts {
+						// Terminal: report it LOUDLY and tell the hub, so the UI stops
+						// claiming "Upgrading" forever and a human sees the real cause.
+						logger.Error("self-upgrade FAILED: giving up after repeated attempts (image never changed)",
+							"target", targetSHA,
+							"current", gitShort,
+							"attempts", m.Attempts,
+							"max_attempts", selfUpgradeMaxAttempts,
+							"last_error", m.LastError,
+							"hint", "the spoke must be able to get/patch its own Deployment; check the hive-self-upgrade Role/RoleBinding in this namespace",
+						)
+						hub.ReportUpgradeFailure(hubURL, cfg.HiveID, targetSHA, gitShort,
+							fmt.Sprintf("self-upgrade failed after %d attempts: %s", m.Attempts, m.LastError), logger)
+						return
+					}
+					// Exponential backoff between attempts so a hard failure does not
+					// spin every heartbeat while a recoverable one still retries.
+					backoff := selfUpgradeBaseBackoff << (m.Attempts - 1)
+					if backoff > selfUpgradeMaxBackoff {
+						backoff = selfUpgradeMaxBackoff
+					}
+					if since := time.Since(m.RequestedAt); since < backoff {
+						logger.Warn("self-upgrade retry deferred: backing off after a failed attempt",
+							"target", targetSHA,
+							"current", gitShort,
+							"attempts", m.Attempts,
+							"retry_in", (backoff - since).Round(time.Second),
+							"last_error", m.LastError,
+						)
+						return
+					}
+					logger.Warn("self-upgrade retrying after a failed attempt (image unchanged)",
 						"target", targetSHA,
 						"current", gitShort,
+						"attempt", m.Attempts+1,
+						"max_attempts", selfUpgradeMaxAttempts,
+						"last_error", m.LastError,
 					)
+					attemptCount = m.Attempts
+				} else {
+					// Different SHA or a different target — the old marker is stale.
 					os.Remove(upgradeMarkerPath)
-					return
 				}
 			}
 
@@ -2380,11 +2440,15 @@ func main() {
 				return
 			}
 
-			marker := fmt.Sprintf(`{"target_sha":"%s","current_sha":"%s","requested_at":"%s"}`,
-				targetSHA, gitShort, time.Now().UTC().Format(time.RFC3339))
-			if err := os.WriteFile(upgradeMarkerPath, []byte(marker), 0o644); err != nil {
-				logger.Warn("failed to write upgrade marker", "path", upgradeMarkerPath, "error", err)
-			}
+			// Record the attempt BEFORE acting: if the process dies mid-upgrade the
+			// next boot must still see an incremented count, otherwise a crash loop
+			// would retry without ever exhausting the budget.
+			writeUpgradeMarker(upgradeMarkerPath, upgradeMarker{
+				TargetSHA:   targetSHA,
+				CurrentSHA:  gitShort,
+				RequestedAt: time.Now().UTC(),
+				Attempts:    attemptCount + 1,
+			}, logger)
 
 			logger.Info("self-upgrade triggered: sending upgrading heartbeat then exiting",
 				"current", gitShort,
@@ -2431,14 +2495,32 @@ func main() {
 			if err != nil {
 				logger.Warn("pinned-image upgrade failed, falling back to rolling restart",
 					"target", targetSHA, "error", err)
+				recordUpgradeError(upgradeMarkerPath, err, logger)
 				needsRestart = true
 			}
 			if needsRestart {
 				if err := hub.RolloutRestartSelf(logger); err != nil {
-					logger.Warn("rolling restart failed, falling back to os.Exit",
+					// This is the wedge. os.Exit here restarts the pod onto the
+					// SAME image, so the upgrade silently never lands. It is an
+					// ERROR, not a Warn, and the cause (typically a 403 because
+					// the spoke lacks patch on its own Deployment) must be both
+					// persisted for the next attempt and reported to the hub so
+					// the UI stops showing a permanent "Upgrading".
+					logger.Error("self-upgrade FAILED: could not patch own Deployment, restarting onto the same image",
+						"target", targetSHA,
+						"current", gitShort,
 						"error", err,
+						"hint", "grant get/patch on deployments/hive in this namespace (hive-self-upgrade Role/RoleBinding)",
 					)
-					os.Exit(0)
+					recordUpgradeError(upgradeMarkerPath, err, logger)
+					hub.ReportUpgradeFailure(hubURL, cfg.HiveID, targetSHA, gitShort, err.Error(), logger)
+					// Exit NON-ZERO. Exiting 0 on a failed upgrade told Kubernetes
+					// the process had completed successfully, so the restart looked
+					// routine and nothing — not the pod's exit code, not an event,
+					// not a probe — recorded that an upgrade had just failed. A
+					// non-zero code makes the failure visible in the pod's
+					// lastState.terminated and in `kubectl describe`.
+					os.Exit(selfUpgradeFailureExitCode)
 				}
 			}
 			// Rolling restart initiated — K8s will start a new pod and
@@ -3581,6 +3663,88 @@ func convertKnowledgeLayers(cfgLayers []config.KnowledgeLayer) []knowledge.Layer
 const hiveIDFilePath = "/data/hive-id"
 
 // loadOrGenerateHiveID reads the Hive ID from disk, or generates and persists a new one.
+const (
+	// selfUpgradeMaxAttempts bounds how many times a spoke retries an upgrade
+	// that keeps leaving the image unchanged. Bounded rather than unlimited so a
+	// genuinely broken hive (e.g. missing RBAC) stops thrashing its pod, and
+	// bounded rather than "never again" so a transient failure still converges.
+	selfUpgradeMaxAttempts = 5
+	// selfUpgradeBaseBackoff is the delay before retry #2; it doubles per
+	// attempt up to selfUpgradeMaxBackoff.
+	selfUpgradeBaseBackoff = 2 * time.Minute
+	// selfUpgradeMaxBackoff caps the exponential backoff between retries.
+	selfUpgradeMaxBackoff = 30 * time.Minute
+	// selfUpgradeFailureExitCode marks a process exit caused by a FAILED
+	// self-upgrade. Distinct from 0 so the failure is visible in the container's
+	// termination state instead of looking like a clean shutdown.
+	selfUpgradeFailureExitCode = 17
+)
+
+// upgradeMarker is the on-PVC record at /data/upgrade-requested. It survives
+// pod restarts (that is the whole point: the process exits as part of an
+// upgrade), so it is the only place attempt bookkeeping can live.
+type upgradeMarker struct {
+	TargetSHA   string    `json:"target_sha"`
+	CurrentSHA  string    `json:"current_sha"`
+	RequestedAt time.Time `json:"requested_at"`
+	Attempts    int       `json:"attempts"`
+	LastError   string    `json:"last_error,omitempty"`
+}
+
+// parseUpgradeMarker decodes a marker, tolerating the legacy format that had no
+// attempts/last_error fields. A legacy marker counts as one prior attempt so an
+// already-wedged hive gets retries under the new budget instead of being
+// treated as fresh.
+func parseUpgradeMarker(data []byte) upgradeMarker {
+	var m upgradeMarker
+	if err := json.Unmarshal(data, &m); err != nil {
+		return upgradeMarker{}
+	}
+	if m.Attempts < 1 {
+		m.Attempts = 1
+	}
+	return m
+}
+
+// sameUpgradeTarget reports whether two target SHAs refer to the same commit,
+// tolerating short/full SHA length mismatch the way the hub's sameCommit does.
+// A DIFFERENT target must reset the attempt budget, so this comparison is what
+// keeps the latch from outliving the upgrade it was created for.
+func sameUpgradeTarget(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	return strings.EqualFold(a[:n], b[:n])
+}
+
+func writeUpgradeMarker(path string, m upgradeMarker, logger *slog.Logger) {
+	data, err := json.Marshal(m)
+	if err != nil {
+		logger.Warn("failed to encode upgrade marker", "error", err)
+		return
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		logger.Warn("failed to write upgrade marker", "path", path, "error", err)
+	}
+}
+
+// recordUpgradeError annotates the existing marker with the cause of the failed
+// attempt so the NEXT boot can log why the previous one did not land — without
+// it the reason dies with the process and the failure is invisible.
+func recordUpgradeError(path string, upgradeErr error, logger *slog.Logger) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	m := parseUpgradeMarker(data)
+	m.LastError = upgradeErr.Error()
+	writeUpgradeMarker(path, m, logger)
+}
+
 func loadOrGenerateHiveID(logger *slog.Logger) string {
 	if envID := os.Getenv("HIVE_ID"); envID != "" {
 		if err := os.WriteFile(hiveIDFilePath, []byte(envID+"\n"), 0o644); err == nil {

--- a/v2/cmd/hive/upgrade_marker_test.go
+++ b/v2/cmd/hive/upgrade_marker_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// testLogger discards output: these tests assert on the marker file, not logs.
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// The wedge this guards against: a spoke whose upgrade failed (image never
+// changed) used to latch PERMANENTLY on the current SHA and silently discard
+// every later instruction. These tests pin the replacement semantics —
+// (fromSHA -> targetSHA) keying, a bounded attempt budget, and backoff.
+
+func TestParseUpgradeMarker_LegacyMarkerCountsAsOneAttempt(t *testing.T) {
+	// Markers written by the previous version have no "attempts" field. An
+	// already-wedged hive must get retries under the new budget rather than be
+	// read as zero attempts (which would mis-order the backoff).
+	legacy := []byte(`{"target_sha":"fc32ae4","current_sha":"c11643a","requested_at":"2026-07-31T13:52:23Z"}`)
+	m := parseUpgradeMarker(legacy)
+	if m.TargetSHA != "fc32ae4" || m.CurrentSHA != "c11643a" {
+		t.Fatalf("legacy fields not parsed: %+v", m)
+	}
+	if m.Attempts != 1 {
+		t.Errorf("legacy marker attempts = %d, want 1", m.Attempts)
+	}
+}
+
+func TestParseUpgradeMarker_GarbageIsNotALatch(t *testing.T) {
+	// A corrupt marker must never be able to wedge an upgrade: it decodes to a
+	// zero marker whose empty CurrentSHA cannot match any real gitShort.
+	m := parseUpgradeMarker([]byte("not json"))
+	if m.CurrentSHA != "" || m.TargetSHA != "" {
+		t.Errorf("garbage marker should decode empty, got %+v", m)
+	}
+}
+
+func TestSameUpgradeTarget(t *testing.T) {
+	cases := []struct {
+		name, a, b string
+		want       bool
+	}{
+		{"identical", "fc32ae4", "fc32ae4", true},
+		{"short vs full prefix", "fc32ae4", "fc32ae4d9c1b2a3", true},
+		{"case insensitive", "FC32AE4", "fc32ae4", true},
+		// The whole point of keying on the target: a NEW target must reset the
+		// attempt budget instead of inheriting the old target's exhausted one.
+		{"different target", "fc32ae4", "c11643a", false},
+		{"empty never matches", "", "fc32ae4", false},
+		{"both empty never matches", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sameUpgradeTarget(tc.a, tc.b); got != tc.want {
+				t.Errorf("sameUpgradeTarget(%q,%q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWriteAndRecordUpgradeError_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "upgrade-requested")
+	logger := testLogger()
+
+	writeUpgradeMarker(path, upgradeMarker{
+		TargetSHA:   "fc32ae4",
+		CurrentSHA:  "c11643a",
+		RequestedAt: time.Now().UTC(),
+		Attempts:    2,
+	}, logger)
+
+	// The cause of a failed attempt must survive into the next boot — without
+	// it the reason dies with the process and the failure stays invisible.
+	recordUpgradeError(path, os.ErrPermission, logger)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading marker: %v", err)
+	}
+	m := parseUpgradeMarker(data)
+	if m.Attempts != 2 {
+		t.Errorf("attempts = %d, want 2 (recordUpgradeError must not reset it)", m.Attempts)
+	}
+	if m.LastError != os.ErrPermission.Error() {
+		t.Errorf("last_error = %q, want %q", m.LastError, os.ErrPermission.Error())
+	}
+	if m.TargetSHA != "fc32ae4" {
+		t.Errorf("target_sha = %q, want fc32ae4", m.TargetSHA)
+	}
+}
+
+func TestRecordUpgradeError_NoMarkerIsNoOp(t *testing.T) {
+	// No marker means no attempt is in flight; annotating one must not create
+	// a marker that would later be mistaken for a real attempt.
+	path := filepath.Join(t.TempDir(), "absent")
+	recordUpgradeError(path, os.ErrPermission, testLogger())
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("recordUpgradeError created a marker where none existed")
+	}
+}
+
+func TestUpgradeMarker_EncodesAttemptsAndError(t *testing.T) {
+	// The marker is the only cross-restart state, so its JSON shape is load
+	// bearing: the fields must actually serialize.
+	data, err := json.Marshal(upgradeMarker{
+		TargetSHA: "fc32ae4", CurrentSHA: "c11643a", Attempts: 3, LastError: "HTTP 403",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m := parseUpgradeMarker(data)
+	if m.Attempts != 3 || m.LastError != "HTTP 403" {
+		t.Errorf("round trip lost data: %+v", m)
+	}
+}
+
+func TestSelfUpgradeBudgetConstants(t *testing.T) {
+	// The latch must be bounded but not instant, and must never be "never
+	// again" (the original bug) nor unlimited (a retry storm).
+	if selfUpgradeMaxAttempts < 2 {
+		t.Errorf("selfUpgradeMaxAttempts = %d; a latch that allows <2 attempts cannot recover from a transient failure", selfUpgradeMaxAttempts)
+	}
+	if selfUpgradeBaseBackoff <= 0 || selfUpgradeMaxBackoff < selfUpgradeBaseBackoff {
+		t.Errorf("backoff bounds invalid: base=%v max=%v", selfUpgradeBaseBackoff, selfUpgradeMaxBackoff)
+	}
+	// Exiting 0 on a failed upgrade is what made the failure invisible to K8s.
+	if selfUpgradeFailureExitCode == 0 {
+		t.Error("selfUpgradeFailureExitCode must be non-zero so a failed upgrade is visible in the container termination state")
+	}
+}

--- a/v2/pkg/hub/alerts.go
+++ b/v2/pkg/hub/alerts.go
@@ -77,6 +77,10 @@ const (
 	AlertTypeOffline = "offline"
 	// AlertTypeStuckUpgrade — Upgrading has been true past staleUpgradeTimeout.
 	AlertTypeStuckUpgrade = "stuck-upgrade"
+	// AlertTypeFailedUpgrade — the spoke explicitly reported an upgrade it could
+	// not complete. Distinct from stuck-upgrade: this one has a known cause the
+	// spoke told us, so it is Critical and carries the underlying error.
+	AlertTypeFailedUpgrade = "failed-upgrade"
 	// AlertTypeHealthCheckFailing — a named check inside Health reports "fail".
 	AlertTypeHealthCheckFailing = "health-check-failing"
 	// AlertTypeTokenBurn — token consumption is anomalous versus the fleet
@@ -432,6 +436,8 @@ type alertHive struct {
 	Upgrading        bool
 	UpgradeStartedAt time.Time
 	UpgradeTarget    string
+	UpgradeFailed    bool
+	UpgradeError     string
 	TotalTokens24h   int64
 	Health           map[string]any
 	ProvStatus       string
@@ -451,6 +457,8 @@ func alertHiveFromEntry(h MyHiveEntry) alertHive {
 		Upgrading:        h.Upgrading,
 		UpgradeStartedAt: h.UpgradeStartedAt,
 		UpgradeTarget:    h.UpgradeTarget,
+		UpgradeFailed:    h.UpgradeFailed,
+		UpgradeError:     h.UpgradeError,
 		TotalTokens24h:   h.TotalTokens24h,
 		Health:           h.Health,
 		ProvStatus:       h.ProvStatus,
@@ -684,6 +692,20 @@ func evaluateAlerts(state *alertState, hives []alertHive, driftAlerts []Alert, n
 		// --- Rule: upgrade in flight past staleUpgradeTimeout. Reuses the
 		// EXISTING constant rather than introducing a second, divergent notion
 		// of "stuck upgrade". ---
+		// --- Rule: the spoke told us the upgrade FAILED. Reported ahead of the
+		// stuck-upgrade rule below because a known cause beats a timeout guess,
+		// and Critical because it never resolves on its own. ---
+		if h.UpgradeFailed {
+			reason := "Upgrade failed"
+			if t := strings.TrimSpace(h.UpgradeTarget); t != "" {
+				reason += " (target " + t + ")"
+			}
+			if e := strings.TrimSpace(h.UpgradeError); e != "" {
+				reason += ": " + e
+			}
+			add(h.ID, h.Name, AlertTypeFailedUpgrade, AlertSeverityCritical, reason)
+		}
+
 		if h.Upgrading && !h.UpgradeStartedAt.IsZero() {
 			if age := now.Sub(h.UpgradeStartedAt); age > staleUpgradeTimeout {
 				reason := "Upgrade in flight for " + roundedDuration(age) +

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -291,10 +291,16 @@ type HeartbeatPayload struct {
 	// The hub uses it to avoid nudging — let alone threatening de-provisioning
 	// — a hive whose credentials the OPERATOR has not delivered. Empty from a
 	// spoke too old to report it, which must be read as "cannot tell".
-	GitHubAppState          string                        `json:"github_app_state,omitempty"`
-	AutoUpgrade             bool                          `json:"auto_upgrade,omitempty"`
-	Upgrading               bool                          `json:"upgrading,omitempty"`
-	UpgradeTargetSHA        string                        `json:"upgrade_target_sha,omitempty"`
+	GitHubAppState   string `json:"github_app_state,omitempty"`
+	AutoUpgrade      bool   `json:"auto_upgrade,omitempty"`
+	Upgrading        bool   `json:"upgrading,omitempty"`
+	UpgradeTargetSHA string `json:"upgrade_target_sha,omitempty"`
+	// UpgradeFailed / UpgradeError let a spoke tell the hub that an instructed
+	// upgrade did NOT land. Without them a failed upgrade is indistinguishable
+	// from a slow one: the hub keeps re-instructing and the UI shows a permanent
+	// "Upgrading" spinner that is simply a lie.
+	UpgradeFailed           bool                          `json:"upgrade_failed,omitempty"`
+	UpgradeError            string                        `json:"upgrade_error,omitempty"`
 	PendingGitHubAppInstall bool                          `json:"pending_github_app_install,omitempty"`
 	ClusterHealth           *HeartbeatClusterHealthReport `json:"cluster_health,omitempty"`
 	// Fleet contribution counts — the spoke's AI-author PR activity across its
@@ -629,6 +635,52 @@ func SendUpgradingHeartbeat(hubURL string, collect StatusCollector, targetSHA st
 		recordHeartbeatSuccess()
 	}
 	logger.Info("upgrading heartbeat sent to hub", "target", targetSHA)
+}
+
+// ReportUpgradeFailure tells the hub that an instructed upgrade failed, with
+// the underlying cause. This is the counterpart to SendUpgradingHeartbeat: that
+// one says "I am upgrading", this one says "I could not". Without it the hub
+// only ever learns about upgrades that succeed, so a wedged spoke stays
+// "Upgrading" forever while the hub silently re-instructs it every heartbeat.
+//
+// Best-effort and non-fatal: the caller is usually seconds from exiting, and a
+// failure to report must never mask the upgrade failure itself.
+func ReportUpgradeFailure(hubURL, hiveID, targetSHA, currentSHA, cause string, logger *slog.Logger) {
+	if hubURL == "" || hiveID == "" {
+		return
+	}
+	payload := HeartbeatPayload{
+		HiveID:           hiveID,
+		GitHash:          currentSHA,
+		UpgradeTargetSHA: targetSHA,
+		UpgradeFailed:    true,
+		UpgradeError:     cause,
+		Timestamp:        time.Now().UTC().Format(time.RFC3339),
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), heartbeatTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, hubURL+"/api/heartbeat", bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if secret := os.Getenv("HIVE_HUB_SECRET"); secret != "" {
+		req.Header.Set("Authorization", "Bearer "+secret)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		logger.Warn("could not report upgrade failure to hub", "error", err)
+		return
+	}
+	defer resp.Body.Close()
+	logger.Info("reported upgrade failure to hub", "target", targetSHA, "cause", cause)
 }
 
 // HeartbeatGitHubAppConfig carries GitHub App credentials from the hub to

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -126,20 +126,26 @@ type RegistryEntry struct {
 	//      spokes too old to report it;
 	//   3. "github.com" at render time, so a chip is never blank.
 	// Empty here means "not reported" — resolved on read, never guessed.
-	GitHubHost                string             `json:"githubHost,omitempty"`
-	Agents                    []AgentSummary     `json:"agents,omitempty"`
-	Leaderboard               []LeaderboardEntry `json:"leaderboard,omitempty"`
-	Online                    bool               `json:"online"`
-	Upgrading                 bool               `json:"upgrading,omitempty"`
-	UpgradeTarget             string             `json:"upgradeTarget,omitempty"`
-	UpgradeStartedAt          time.Time          `json:"upgradeStartedAt,omitempty"`
-	IssueHistory              []SparkPoint       `json:"issueHistory,omitempty"`
-	PRHistory                 []SparkPoint       `json:"prHistory,omitempty"`
-	GitHubAppRequired         bool               `json:"githubAppRequired,omitempty"`
-	GitHubAppPermIssue        string             `json:"githubAppPermIssue,omitempty"`
-	GitHubAppState            string             `json:"githubAppState,omitempty"`
-	PendingGitHubAppInstall   bool               `json:"pendingGitHubAppInstall,omitempty"`
-	PendingGitHubAppInstallAt time.Time          `json:"pendingGitHubAppInstallAt,omitempty"`
+	GitHubHost       string             `json:"githubHost,omitempty"`
+	Agents           []AgentSummary     `json:"agents,omitempty"`
+	Leaderboard      []LeaderboardEntry `json:"leaderboard,omitempty"`
+	Online           bool               `json:"online"`
+	Upgrading        bool               `json:"upgrading,omitempty"`
+	UpgradeTarget    string             `json:"upgradeTarget,omitempty"`
+	UpgradeStartedAt time.Time          `json:"upgradeStartedAt,omitempty"`
+	// UpgradeFailed records that the spoke reported an upgrade it could not
+	// complete, with the cause. Distinct from Upgrading: "failed" is a terminal
+	// state a human must see, not an in-flight one.
+	UpgradeFailed             bool         `json:"upgradeFailed,omitempty"`
+	UpgradeError              string       `json:"upgradeError,omitempty"`
+	UpgradeFailedAt           time.Time    `json:"upgradeFailedAt,omitempty"`
+	IssueHistory              []SparkPoint `json:"issueHistory,omitempty"`
+	PRHistory                 []SparkPoint `json:"prHistory,omitempty"`
+	GitHubAppRequired         bool         `json:"githubAppRequired,omitempty"`
+	GitHubAppPermIssue        string       `json:"githubAppPermIssue,omitempty"`
+	GitHubAppState            string       `json:"githubAppState,omitempty"`
+	PendingGitHubAppInstall   bool         `json:"pendingGitHubAppInstall,omitempty"`
+	PendingGitHubAppInstallAt time.Time    `json:"pendingGitHubAppInstallAt,omitempty"`
 	// Fleet contribution counts reported by the spoke (nil = not reported /
 	// not yet computed). Aggregated across public, non-stale hives into the
 	// /api/fleet-stats total. Pointers preserve the nil-vs-zero distinction so
@@ -979,6 +985,27 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		entry.Upgrading = true
 	}
 
+	// A spoke that explicitly reports a FAILED upgrade must not be left showing
+	// the "Upgrading" spinner, and must not be re-instructed on a loop. Record
+	// the cause so operators can see WHY, and drop the pending instruction: the
+	// spoke has already exhausted its own retry budget, so re-sending the same
+	// target every heartbeat only reproduces the failure.
+	if payload.UpgradeFailed {
+		entry.Upgrading = false
+		entry.UpgradeFailed = true
+		entry.UpgradeError = sanitizeHeartbeatField(payload.UpgradeError)
+		entry.UpgradeFailedAt = time.Now()
+		s.mu.Lock()
+		delete(s.heartbeatUpgrade, payload.HiveID)
+		s.mu.Unlock()
+		s.logger.Error("heartbeat: spoke reported a FAILED upgrade",
+			"hive_id", payload.HiveID,
+			"from", payload.GitHash,
+			"to", payload.UpgradeTargetSHA,
+			"error", payload.UpgradeError,
+		)
+	}
+
 	// Timeline: capture the pre-heartbeat entry inside the lock (it is the only
 	// place old and new coexist), but diff and persist AFTER unlocking —
 	// s.mu is a write lock held across the whole registry scan, so a file
@@ -1008,6 +1035,22 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				branchForLatest = "v2"
 			}
 			registryLatestSHA := getLatestSHAForBranch(branchForLatest)
+			// Carry a previously-reported upgrade failure forward across ordinary
+			// heartbeats (which do not repeat it), but clear it the moment the
+			// spoke actually reports a NEW git hash — that means it finally moved.
+			if h.UpgradeFailed && !payload.UpgradeFailed {
+				if entry.GitHash != "" && h.GitHash != "" && entry.GitHash != h.GitHash {
+					entry.UpgradeFailed = false
+					entry.UpgradeError = ""
+					entry.UpgradeFailedAt = time.Time{}
+					s.logger.Info("heartbeat: previously failed upgrade has landed",
+						"hive_id", payload.HiveID, "git_hash", entry.GitHash)
+				} else {
+					entry.UpgradeFailed = true
+					entry.UpgradeError = h.UpgradeError
+					entry.UpgradeFailedAt = h.UpgradeFailedAt
+				}
+			}
 			if h.Upgrading && !payload.Upgrading && (sameCommit(payload.GitHash, h.UpgradeTarget) || (registryLatestSHA != "" && sameCommit(payload.GitHash, registryLatestSHA))) {
 				// Non-upgrading heartbeat at the target SHA or at latest —
 				// upgrade completed (image may have advanced past the
@@ -1019,6 +1062,14 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				entry.UpgradeTarget = ""
 			} else if h.Upgrading && !payload.Upgrading && h.UpgradeTarget == "" {
 				// Upgrading with no target (stale flag from config-only restart).
+				entry.Upgrading = false
+				entry.UpgradeTarget = ""
+			} else if payload.UpgradeFailed {
+				// The spoke just told us the upgrade FAILED. That is direct
+				// evidence and must beat the inference below, which would
+				// otherwise re-assert the stale Upgrading flag (same GitHash as
+				// before is exactly what a failed upgrade looks like) and put the
+				// permanent spinner straight back.
 				entry.Upgrading = false
 				entry.UpgradeTarget = ""
 			} else if h.Upgrading && h.UpgradeTarget != "" {

--- a/v2/pkg/hub/upgrade_failure_test.go
+++ b/v2/pkg/hub/upgrade_failure_test.go
@@ -1,0 +1,127 @@
+package hub
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+// Before this change the hub only ever learned about upgrades that SUCCEEDED.
+// A spoke that could not upgrade (e.g. HTTP 403 patching its own Deployment)
+// looked identical to one still working on it, so the registry kept
+// Upgrading=true forever and the hub re-instructed the same target every beat.
+
+func TestHandleHeartbeat_UpgradeFailedClearsUpgradingAndRecordsCause(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	s.registry.Hives = []RegistryEntry{{
+		ID: "h1", Upgrading: true, UpgradeTarget: "fc32ae4", GitHash: "c11643a",
+	}}
+	// Arm the fallback instruction so we can prove it gets dropped.
+	s.heartbeatUpgrade = map[string]string{"h1": "fc32ae4"}
+
+	rec := postHeartbeat(t, s, `{"hive_id":"h1","git_hash":"c11643a",`+
+		`"upgrade_target_sha":"fc32ae4","upgrade_failed":true,`+
+		`"upgrade_error":"HTTP 403: cannot patch resource deployments"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	s.mu.RLock()
+	h := s.registry.Hives[0]
+	_, stillArmed := s.heartbeatUpgrade["h1"]
+	s.mu.RUnlock()
+
+	if h.Upgrading {
+		t.Error("Upgrading must be cleared on a reported failure — the UI showing a permanent spinner is the bug")
+	}
+	if !h.UpgradeFailed {
+		t.Error("UpgradeFailed not recorded")
+	}
+	if h.UpgradeError == "" {
+		t.Error("UpgradeError must carry the underlying cause so the failure is diagnosable")
+	}
+	if h.UpgradeFailedAt.IsZero() {
+		t.Error("UpgradeFailedAt not stamped")
+	}
+	if stillArmed {
+		t.Error("a refused instruction must be dropped, otherwise the hub re-sends the same failing target forever")
+	}
+}
+
+func TestHandleHeartbeat_UpgradeFailurePersistsUntilTheHiveActuallyMoves(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	// Ordinary heartbeats do not repeat the failure flag; the hub must not
+	// forget the failure just because the next beat was silent about it.
+	s.registry.Hives = []RegistryEntry{{
+		ID: "h1", GitHash: "c11643a", UpgradeFailed: true,
+		UpgradeError: "HTTP 403", UpgradeFailedAt: time.Now(),
+	}}
+
+	rec := postHeartbeat(t, s, `{"hive_id":"h1","git_hash":"c11643a"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	s.mu.RLock()
+	h := s.registry.Hives[0]
+	s.mu.RUnlock()
+	if !h.UpgradeFailed || h.UpgradeError != "HTTP 403" {
+		t.Errorf("failure state lost on a plain heartbeat: %+v", h)
+	}
+}
+
+func TestHandleHeartbeat_UpgradeFailureClearsOnceTheHiveReportsANewSHA(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	s.registry.Hives = []RegistryEntry{{
+		ID: "h1", GitHash: "c11643a", UpgradeFailed: true,
+		UpgradeError: "HTTP 403", UpgradeFailedAt: time.Now(),
+	}}
+
+	// The hive finally moved — the failure is history and must not stick.
+	rec := postHeartbeat(t, s, `{"hive_id":"h1","git_hash":"fc32ae4"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	s.mu.RLock()
+	h := s.registry.Hives[0]
+	s.mu.RUnlock()
+	if h.UpgradeFailed || h.UpgradeError != "" {
+		t.Errorf("failure state must clear once the spoke reports a new SHA: %+v", h)
+	}
+}
+
+func TestEvaluateAlerts_FailedUpgradeIsCritical(t *testing.T) {
+	// A failed upgrade never resolves itself, so it must surface as an alert
+	// rather than hiding behind an "Upgrading" badge.
+	hives := []alertHive{{
+		ID: "h1", Name: "hive-1", Online: true,
+		UpgradeFailed: true, UpgradeTarget: "fc32ae4",
+		UpgradeError: "HTTP 403: cannot patch resource deployments",
+	}}
+	got := evaluateAlerts(newAlertState(), hives, nil, time.Now())
+
+	var found *Alert
+	for i := range got.Alerts {
+		if got.Alerts[i].Type == AlertTypeFailedUpgrade {
+			found = &got.Alerts[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("no %s alert raised; alerts=%+v", AlertTypeFailedUpgrade, got.Alerts)
+	}
+	if found.Severity != AlertSeverityCritical {
+		t.Errorf("severity = %q, want %q", found.Severity, AlertSeverityCritical)
+	}
+	if found.Reason == "" {
+		t.Error("alert reason must include the cause")
+	}
+}


### PR DESCRIPTION
## Problem

15 hives sat at `upgrading: true`, target `fc32ae4`, current `c11643a`, for 20+ minutes and counting. The Deployments were fully settled and **never touched** — `observedGeneration == generation`, `readyReplicas 1/1`, image still `ghcr.io/kubestellar/hive:c11643a`. The upgrade wasn't slow; it never started.

The failure was **completely silent on both sides**:

- **Hub**, forever, every few seconds: `INFO "heartbeat: instructing hub-managed hive to upgrade (kubectl fallback)"` — it logged issuing the instruction, never the outcome.
- **Spoke**: `INFO "self-upgrade skipped: already attempted from this SHA (image unchanged)"`.

Both INFO. No error anywhere. The UI showed "Upgrading" indefinitely, which was simply a lie.

## Why attempt #1 failed

Captured verbatim from a wedged spoke's **previous** container (`hive-hosted-hosted-available-oke-01-placeholder-bb95`):

```
WARN "rolling restart failed, falling back to os.Exit"
error="patching deployment .../hive: k8s API PATCH ...: HTTP 403:
  deployments.apps \"hive\" is forbidden: User
  \"system:serviceaccount:hive-hosted-hosted-available-oke-01-placeholder-bb95:default\"
  cannot patch resource \"deployments\" in API group \"apps\""
```

The spoke patches its **own** Deployment (`UpgradeSelfToSHA` / `RolloutRestartSelf`), but the `hive-self-upgrade` Role/RoleBinding is nested inside a `{{if .RequiresSCC}}` block in the provisioning template, so it is only created on OpenShift. `hive-oke` is not OpenShift — confirmed zero Role/RoleBinding objects in every wedged namespace.

**That RBAC scoping fix is #2307, not this PR.** This PR deliberately does not touch `saas_provision.go`, so the two do not conflict.

## Why this PR is still needed

#2307 stops *this particular* attempt #1 from failing. It does not stop a hive from wedging permanently and invisibly the next time an upgrade fails for **any other reason** — bad tag, registry outage, quota, network. Three independent bugs remain:

### 1. The latch was permanent

`v2/cmd/hive/main.go` — the guard keyed only on `current_sha` and returned forever. But **"image unchanged" is the signature of a FAILED upgrade, not a reason to stop retrying.** The first attempt failed, the guard latched, and every subsequent hub instruction was silently discarded.

Now the marker is keyed on `(current_sha → target_sha)` so a **new target always gets a fresh budget**, and retries are bounded to `selfUpgradeMaxAttempts` with exponential backoff — a hard failure stops thrashing the pod, a transient one still converges. Legacy markers (no `attempts` field) count as one prior attempt, so hives wedged *today* recover under the new budget rather than being read as fresh.

### 2. `os.Exit(0)` on failure

Exiting **zero** told Kubernetes the process had completed cleanly. That is precisely why nothing — not the exit code, not an event, not a probe — recorded that an upgrade had just failed. Now exits non-zero, so the failure is visible in `lastState.terminated` and `kubectl describe`.

The underlying error (which already carries the HTTP status) is logged at **ERROR** with a hint naming the RBAC it needs, the cause is persisted in the marker so the **next boot** can report why the previous attempt didn't land, and the startup path logs it instead of treating the restart as routine.

### 3. The hub never learned, and the UI lied

New `ReportUpgradeFailure` tells the hub the instruction was **refused**. The hub clears `Upgrading`, records the cause, and **drops the pending instruction** rather than re-sending a target the spoke has already given up on. A reported failure takes precedence over the stale-flag inference, which would otherwise re-assert the spinner on the very next heartbeat (a real bug the new tests caught).

A new **`failed-upgrade`** alert (Critical, carries the cause) surfaces the fault, so a hive that cannot upgrade shows as failed instead of spinning forever.

## Testing

`go build ./...`, `go vet`, and the full `./pkg/hub/...` + `./cmd/hive/...` suites pass. New tests cover marker semantics, the legacy-marker path, target-change reset, backoff bounds, the non-zero exit code, and the hub state machine (clear on failure, persist across quiet heartbeats, clear once the spoke reports a new SHA).

## Note

Investigation on live hives was strictly read-only (`logs`, `get`, `auth can-i`). **No running hive was restarted, patched, or otherwise unstuck** — the wedged hives are still wedged and will need #2307's RBAC plus a roll to recover.