### PR TITLE
✨ feat(hub): filter hives by upgrade state and show how long they have been upgrading

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -7865,6 +7865,46 @@ const dashboardHTML = `<!DOCTYPE html>
       return false;
     }
 
+    /* ── Upgrade-state filter ──
+       Which upgrade state the list is narrowed to, or '' for none. Single-
+       select like the drift filter, not multi-select: "upgrading" and "queued"
+       are successive stages of one lifecycle, so a hive is in exactly one of
+       them and an OR across both would just mean "any pending upgrade" — which
+       is what clearing the filter already shows.
+
+       This exists so an operator can WATCH an upgrade roll across the fleet,
+       and — the reason it was asked for — pull up every wedged hive at once
+       when a rollout stalls. */
+    var UPGRADE_FILTER_UPGRADING = 'upgrading';
+    var UPGRADE_FILTER_QUEUED = 'queued';
+    var _dashUpgradeFilter = '';
+
+    /* hiveUpgradeState classifies a hive as 'upgrading', 'queued' or '' (in
+       neither state).
+
+       The definitions mirror the Version cell's render conditions on purpose,
+       so the facet count and the rows can never disagree:
+         upgrading — the hub says an upgrade is in flight (h.upgrading).
+         queued    — auto-upgrade is on and the hive is BEHIND latest, but the
+                     hub has not instructed the upgrade yet. This is the state
+                     with no upgradeStartedAt, which is precisely why the
+                     elapsed counter must not claim to know one.
+       'upgrading' is tested FIRST because an in-flight upgrade outranks a
+       queued one; without that ordering a hive would be double-counted. */
+    function hiveUpgradeState(h) {
+      if (!h) return '';
+      if (h.upgrading) return UPGRADE_FILTER_UPGRADING;
+      if (h.autoUpgrade && h.upgradeTarget) return UPGRADE_FILTER_QUEUED;
+      return '';
+    }
+
+    /* hiveMatchesUpgradeFilter answers whether a hive survives the upgrade-
+       state filter. Composes by AND with the status chips and facets. */
+    function hiveMatchesUpgradeFilter(h) {
+      if (!_dashUpgradeFilter) return true;
+      return hiveUpgradeState(h) === _dashUpgradeFilter;
+    }
+
     /* ────────────────────────────────────────────────────────────────────────
        Grouping and saved views for My Hives.
 
@@ -8231,6 +8271,7 @@ const dashboardHTML = `<!DOCTYPE html>
         if (!hit) return false;
       }
       if (!hiveMatchesDriftFilter(h)) return false;
+      if (!hiveMatchesUpgradeFilter(h)) return false;
       var active = Object.keys(_dashStatusFilters || {}).filter(function(k) { return _dashStatusFilters[k]; });
       if (!active.length) return true;
       var f = hiveStatusFlags(h);
@@ -8278,7 +8319,10 @@ const dashboardHTML = `<!DOCTYPE html>
       'stuck-upgrade': 'Stuck upgrade',
       'health-check-failing': 'Health check failing',
       'token-burn': 'Token burn',
-      'provision-error': 'Provision error'
+      'provision-error': 'Provision error',
+      /* Added by the hub in #2308. Without a label here the chip for a
+         genuinely failed upgrade would render as the raw key 'failed-upgrade'. */
+      'failed-upgrade': 'Failed upgrade'
     };
 
     /* How many alert rows are listed before the panel collapses the remainder
@@ -8330,6 +8374,7 @@ const dashboardHTML = `<!DOCTYPE html>
       _dashStatusFilters = {};
       _dashFailingCheckFilter = '';
       _dashDriftFilter = '';
+      _dashUpgradeFilter = '';
       _alertTypeFilter = '';
       _dashFacets = {};
       _dashSearchQuery = '';
@@ -8654,6 +8699,12 @@ const dashboardHTML = `<!DOCTYPE html>
        They share _dashFacetCollapsed only for the collapse chrome. */
     var FACET_GROUP_HEALTH = 'health';
     var FACET_GROUP_FAILING_CHECK = 'failing-check';
+    /* Upgrade-state group. Follows the HEALTH/FAILING_CHECK pattern rather than
+       the derived-facet one: the values are a fixed, hand-written lifecycle
+       ('upgrading', 'queued') with their own matching rule and their own state
+       (_dashUpgradeFilter), not a dimension enumerated from the data like
+       cluster or branch, so it stays OUT of HIVE_FACET_GROUPS. */
+    var FACET_GROUP_UPGRADE = 'upgrade-state';
 
     var HIVE_FACET_GROUPS = [
       {key: FACET_CLUSTER, label: 'Location'},
@@ -8714,6 +8765,7 @@ const dashboardHTML = `<!DOCTYPE html>
       n += Object.keys(_dashStatusFilters || {}).length;
       if (_dashFailingCheckFilter) n++;
       if (_dashDriftFilter) n++;
+      if (_dashUpgradeFilter) n++;
       if (_alertTypeFilter) n++;
       if (_dashSearchQuery) n++;
       var groups = Object.keys(_dashFacets || {});
@@ -8858,8 +8910,8 @@ const dashboardHTML = `<!DOCTYPE html>
       }).join('') +
       /* Group-scoped reset for the health + failing-check pair, so a user can
          undo just these without also dropping their search term and facets. */
-      (Object.keys(_dashStatusFilters || {}).length || _dashFailingCheckFilter || _dashDriftFilter
-        ? '<button type="button" class="facet-value" onclick="clearStatusFilters()" title="Clear the health, failing-check and drift filters">' +
+      (Object.keys(_dashStatusFilters || {}).length || _dashFailingCheckFilter || _dashDriftFilter || _dashUpgradeFilter
+        ? '<button type="button" class="facet-value" onclick="clearStatusFilters()" title="Clear the health, failing-check, drift and upgrade-state filters">' +
           '<span class="facet-value-label">Clear health filters</span></button>'
         : '') + '</div>';
       return facetGroupShell(FACET_GROUP_HEALTH, 'Health',
@@ -8900,6 +8952,77 @@ const dashboardHTML = `<!DOCTYPE html>
         !!_dashFacetCollapsed[FACET_GROUP_FAILING_CHECK], body);
     }
 
+    /* How long a hive must have been upgrading before the facet's tooltip
+       calls the fleet out as wedged rather than busy. Same limit the counter
+       and the hub's stuck-upgrade alert use — one definition of "too long",
+       reused, so the rail, the row and the alert panel cannot disagree. */
+    var UPGRADE_FACET_STUCK_MS = UPGRADE_ELAPSED_RED_MS;
+
+    /* renderUpgradeFacetGroup renders the upgrade-state picker. Single-select,
+       ANDed against the health chips like the failing-check group.
+
+       The 'upgrading' value additionally reports how many of those hives are
+       past the stuck limit, because the whole point of this filter is catching
+       a rollout that has stopped moving — a bare count of 15 upgrading hives
+       looks identical whether they are 10 seconds or 40 minutes in.
+
+       Returns '' when nothing is upgrading or queued AND no filter is on, so a
+       settled fleet sees no extra chrome; renders while the filter is on even
+       at count 0 so it can always be clicked back off. */
+    function renderUpgradeFacetGroup(assignedNoPlaceholders) {
+      var hives = assignedNoPlaceholders || [];
+      var counts = {};
+      counts[UPGRADE_FILTER_UPGRADING] = 0;
+      counts[UPGRADE_FILTER_QUEUED] = 0;
+      var stuck = 0;
+      var now = Date.now();
+      for (var i = 0; i < hives.length; i++) {
+        var st = hiveUpgradeState(hives[i]);
+        if (!st) continue;
+        counts[st]++;
+        if (st === UPGRADE_FILTER_UPGRADING) {
+          var ms = upgradeElapsedMs(hives[i], now);
+          /* null (unknown start time) is NOT counted as stuck — an unknown
+             elapsed is not evidence of a fault, and inflating this number
+             would make the warning untrustworthy. */
+          if (ms !== null && ms >= UPGRADE_FACET_STUCK_MS) stuck++;
+        }
+      }
+      var total = counts[UPGRADE_FILTER_UPGRADING] + counts[UPGRADE_FILTER_QUEUED];
+      if (!total && !_dashUpgradeFilter) return '';
+
+      var values = [
+        {key: UPGRADE_FILTER_UPGRADING, label: 'Upgrading'},
+        {key: UPGRADE_FILTER_QUEUED, label: 'Queued'}
+      ];
+      var body = '<div class="facet-values">' + (values || []).map(function(v) {
+        var on = _dashUpgradeFilter === v.key;
+        var n = counts[v.key] || 0;
+        var tip;
+        if (v.key === UPGRADE_FILTER_UPGRADING) {
+          tip = n + (n === 1 ? ' hive is' : ' hives are') + ' upgrading now';
+          if (stuck) {
+            tip += ' — ' + stuck + ' past ' + Math.round(UPGRADE_FACET_STUCK_MS / 60000) +
+              ' minutes and likely wedged rather than slow';
+          }
+        } else {
+          tip = n + (n === 1 ? ' hive is' : ' hives are') +
+            ' behind latest with auto-upgrade on, waiting to be instructed';
+        }
+        /* The count turns red when any upgrade is past the stuck limit, so the
+           fault is visible in the rail without opening the filter. */
+        var countStyle = (v.key === UPGRADE_FILTER_UPGRADING && stuck)
+          ? ' style="color:var(--red);font-weight:600"' : '';
+        return '<button type="button" class="facet-value' + (on ? ' on' : '') +
+          '" aria-pressed="' + (on ? 'true' : 'false') + '" title="' + escAttr(tip) + '"' +
+          ' onclick="toggleUpgradeFilter(' + jsArg(v.key) + ')">' +
+          '<span class="facet-value-label">' + esc(v.label) + '</span>' +
+          '<span class="facet-value-count"' + countStyle + '>' + n + '</span></button>';
+      }).join('') + '</div>';
+      return facetGroupShell(FACET_GROUP_UPGRADE, 'Upgrade state (one at a time)',
+        !!_dashFacetCollapsed[FACET_GROUP_UPGRADE], body);
+    }
+
     /* renderFacetRail draws the tray's body: the health chips and failing-check
        picker moved in from the old standalone bar, then the derived facet
        groups. Derived-group counts are computed over the assigned hives after
@@ -8917,7 +9040,8 @@ const dashboardHTML = `<!DOCTYPE html>
          strip any placeholder defensively so the counts match the old bar. */
       var assignedReal = (assignedAll || []).filter(function(h) { return !isPlaceholderHive(h); });
       var base = (assignedAll || []).filter(hiveMatchesFilters).filter(hiveMatchesSearch);
-      var head = renderStatusFacetGroup(assignedReal) + renderFailingCheckFacetGroup(assignedReal);
+      var head = renderStatusFacetGroup(assignedReal) + renderFailingCheckFacetGroup(assignedReal) +
+        renderUpgradeFacetGroup(assignedReal);
       if (!base.length && !Object.keys(_dashFacets || {}).length) {
         rail.innerHTML = head + clearFacetsButton();
         return;
@@ -8998,6 +9122,15 @@ const dashboardHTML = `<!DOCTYPE html>
          button look broken. */
       _dashFailingCheckFilter = '';
       _dashDriftFilter = '';
+      _dashUpgradeFilter = '';
+      renderHives(_allDashHives, true);
+    }
+
+    /* toggleUpgradeFilter selects an upgrade state, or clears it when the
+       already-selected value is clicked again (single-select, like the drift
+       filter). */
+    function toggleUpgradeFilter(state) {
+      _dashUpgradeFilter = (_dashUpgradeFilter === state) ? '' : (state || '');
       renderHives(_allDashHives, true);
     }
 
@@ -9921,7 +10054,7 @@ const dashboardHTML = `<!DOCTYPE html>
          collapsing a section, switching group-by, collapsing a group or
          applying a saved view would all appear to do nothing. */
       var sig = JSON.stringify(allHives) + '|' + JSON.stringify(_dashStatusFilters) +
-        '|' + _dashFailingCheckFilter + '|' + _dashDriftFilter +
+        '|' + _dashFailingCheckFilter + '|' + _dashDriftFilter + '|' + _dashUpgradeFilter +
         '|' + _alertTypeFilter + '|' + _alertShowAcked + '|' + JSON.stringify(_fleetAlerts) +
         '|' + _dashSearchQuery + '|' + JSON.stringify(_dashFacets) +
         '|' + JSON.stringify(_dashFacetCollapsed) + '|' + JSON.stringify(_dashSectionCollapsed) +
@@ -10106,7 +10239,11 @@ const dashboardHTML = `<!DOCTYPE html>
             /* In-flight state is not clickable, so it loses the box entirely:
                a border around a non-target was the padding that made this the
                tall line. The spinner is the affordance-free progress signal. */
-            upgradeIcon = '<span title="' + progressTitle + '" style="font-size:0.7rem;white-space:nowrap;opacity:0.8;color:var(--muted)"><span style="display:inline-block;width:10px;height:10px;border:2px solid rgba(255,255,255,0.3);border-top-color:currentColor;border-radius:50%;animation:spin 1s linear infinite;vertical-align:middle;margin-right:4px"></span>' + progressLabel + '</span>';
+            /* The elapsed counter rides INSIDE the pill so a long-running
+               upgrade cannot be read as progress. It self-suppresses when the
+               start time is unknown or the rollout is still fast (see
+               renderUpgradeElapsed), so a healthy fleet looks unchanged. */
+            upgradeIcon = '<span title="' + progressTitle + '" style="font-size:0.7rem;white-space:nowrap;opacity:0.8;color:var(--muted)"><span style="display:inline-block;width:10px;height:10px;border:2px solid rgba(255,255,255,0.3);border-top-color:currentColor;border-radius:50%;animation:spin 1s linear infinite;vertical-align:middle;margin-right:4px"></span>' + progressLabel + '</span>' + renderUpgradeElapsed(h);
           } else if (!isCurrent && !latestUnknown && isHosted && h.role === 'owner' && h.autoUpgrade) {
             /* A daily-mode hive is NOT upgrading "shortly" — saying so would be
                a lie the operator would notice hours later. Name the window and
@@ -10626,6 +10763,113 @@ const dashboardHTML = `<!DOCTYPE html>
     var _upgradingHives = {};
     var _switchStartedAt = {}; // hiveId → ms timestamp the switch was initiated
     var SWITCH_STALE_MS = 8 * 60 * 1000; // warn if a switch hasn't landed in 8 min
+
+    /* ── Upgrade elapsed-time counter ──
+       A hive that has been "Upgrading" for a long time is a FAULT SIGNAL, not
+       progress: the incident this exists to prevent had 15 hives pinned at
+       upgrading:true for 20+ minutes while their spokes exited 0 in a restart
+       loop, and a static spinner made a permanently-wedged fleet look
+       identical to a merely slow one.
+
+       The thresholds below escalate the counter's colour so that state is
+       obvious at a glance instead of requiring the operator to notice a
+       number. UPGRADE_ELAPSED_RED_MS deliberately equals staleUpgradeTimeout
+       in server.go (10m) — the same instant the hub raises its stuck-upgrade
+       alert. Turning red EARLIER would accuse a hive the hub still considers
+       healthy; turning red LATER would leave a window where the alert panel
+       says stuck and the row still looks fine. The amber step sits at half of
+       that, an early warning while the upgrade is still plausibly in flight. */
+    var UPGRADE_ELAPSED_RED_MS = 10 * 60 * 1000;  // == staleUpgradeTimeout (server.go): hub calls this stuck
+    var UPGRADE_ELAPSED_AMBER_MS = 5 * 60 * 1000; // half the stuck limit: early warning, still plausible
+
+    /* Below this the counter is suppressed entirely. Every upgrade begins at
+       0s, and a counter that flickers "1s, 2s…" on every healthy rollout would
+       train the operator to ignore it — which is exactly the habit that let the
+       incident go unnoticed. It only appears once an upgrade is slow enough to
+       be worth a human's attention. */
+    var UPGRADE_ELAPSED_MIN_SHOW_MS = 30 * 1000; // don't nag during a normal fast rollout
+
+    /* Clocks are not synchronised. The browser's Date.now() and the hub's
+       upgradeStartedAt can disagree by seconds, which yields a small NEGATIVE
+       elapsed on a freshly-started upgrade. Tolerate that as "just started"
+       rather than rendering a negative duration; anything more negative than
+       this is real clock skew and the counter is suppressed instead of shown
+       as a lie. */
+    var UPGRADE_ELAPSED_SKEW_TOLERANCE_MS = 60 * 1000; // treat small negatives as 0
+
+    /* upgradeElapsedMs returns how long a hive has been upgrading, in ms, or
+       null when that cannot be known — a MISSING, EMPTY or UNPARSEABLE
+       upgradeStartedAt, or a negative elapsed beyond the skew tolerance.
+       Callers must render nothing on null; they must never render NaN, a
+       negative duration, or a fabricated "0s" that implies the upgrade just
+       started when in truth the timestamp was lost.
+
+       Note a real server behaviour this relies on: upgradeStartedAt is stamped
+       ONLY where Upgrading is set true, so a hive that is merely QUEUED has no
+       timestamp and correctly gets null here rather than a bogus counter. */
+    function upgradeElapsedMs(h, nowMs) {
+      if (!h) return null;
+      var started = h.upgradeStartedAt;
+      if (!started || typeof started !== 'string') return null;
+      var t = Date.parse(started);
+      if (isNaN(t)) return null; /* unparseable timestamp — show nothing, never NaN */
+      var elapsed = (typeof nowMs === 'number' ? nowMs : Date.now()) - t;
+      if (elapsed < 0) {
+        /* Clock skew. A small negative is the browser being marginally behind
+           the hub on an upgrade that genuinely just started; clamp it to zero.
+           A large negative means the timestamp is not trustworthy at all. */
+        if (elapsed > -UPGRADE_ELAPSED_SKEW_TOLERANCE_MS) return 0;
+        return null;
+      }
+      return elapsed;
+    }
+
+    /* formatUpgradeElapsed renders a compact duration: "45s", "3m", "1h12m".
+       Minutes are the operator's working unit here, so past an hour it keeps
+       the minutes rather than collapsing to a bare "1h" that would hide a
+       72-minute wedge behind the same string as a 61-minute one. */
+    function formatUpgradeElapsed(ms) {
+      if (typeof ms !== 'number' || isNaN(ms) || ms < 0) return '';
+      var totalSec = Math.floor(ms / 1000);
+      if (totalSec < 60) return totalSec + 's';
+      var totalMin = Math.floor(totalSec / 60);
+      if (totalMin < 60) return totalMin + 'm';
+      var hours = Math.floor(totalMin / 60);
+      return hours + 'h' + (totalMin % 60) + 'm';
+    }
+
+    /* upgradeElapsedColor escalates the counter past the thresholds above.
+       Muted while the rollout is plausibly healthy, amber as an early warning,
+       red once the hub itself would call the upgrade stuck. */
+    function upgradeElapsedColor(ms) {
+      if (typeof ms !== 'number' || isNaN(ms)) return 'var(--muted)';
+      if (ms >= UPGRADE_ELAPSED_RED_MS) return 'var(--red)';
+      if (ms >= UPGRADE_ELAPSED_AMBER_MS) return 'var(--amber, #f59e0b)';
+      return 'var(--muted)';
+    }
+
+    /* renderUpgradeElapsed builds the counter fragment appended to the
+       "Upgrading" pill. Returns '' whenever the elapsed time is unknown or
+       still below the nag threshold, so the common healthy case renders
+       exactly what it renders today. */
+    function renderUpgradeElapsed(h, nowMs) {
+      var ms = upgradeElapsedMs(h, nowMs);
+      if (ms === null) return '';
+      if (ms < UPGRADE_ELAPSED_MIN_SHOW_MS) return '';
+      var label = formatUpgradeElapsed(ms);
+      if (!label) return '';
+      var stuck = ms >= UPGRADE_ELAPSED_RED_MS;
+      /* Past the red line the wording stops describing progress and names the
+         fault, because at that point the hub has raised its stuck-upgrade
+         alert and "still upgrading" would be the same misleading reassurance
+         the incident turned on. */
+      var tip = stuck
+        ? 'Upgrading for ' + label + ' — past the ' + Math.round(UPGRADE_ELAPSED_RED_MS / 60000) +
+          ' minute limit. This upgrade is almost certainly wedged, not slow; check the hive for a failed self-upgrade.'
+        : 'Upgrading for ' + label;
+      return '<span title="' + escAttr(tip) + '" style="margin-left:4px;font-variant-numeric:tabular-nums;color:' +
+        upgradeElapsedColor(ms) + (stuck ? ';font-weight:600' : '') + '">' + esc(label) + '</span>';
+    }
 
     /* Version and Location cells stack their contents vertically so neither
        column is forced as wide as the sum of its parts. The Version cell used

--- a/v2/pkg/hub/upgrade_elapsed_ui_test.go
+++ b/v2/pkg/hub/upgrade_elapsed_ui_test.go
@@ -1,0 +1,168 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// The dashboard's upgrade counter and its two facet filters live inside the
+// inline dashboardHTML JavaScript, which no Go test can execute. These tests
+// therefore lock down the STRUCTURAL invariants that would silently break the
+// feature — the wiring that has no other guard, and the two thresholds that
+// must stay pinned to their server-side counterparts.
+
+// TestUpgradeElapsedThresholdMatchesStuckUpgradeAlert is the important one.
+//
+// The red escalation exists to mark a hive the hub ALREADY considers stuck, so
+// the row and the stuck-upgrade alert raised in alerts.go must flip at the same
+// instant. If someone retunes staleUpgradeTimeout without retuning the UI
+// constant, the row would go red before or after the alert fires and the two
+// would tell the operator different stories about the same hive.
+func TestUpgradeElapsedThresholdMatchesStuckUpgradeAlert(t *testing.T) {
+	wantMs := int64(staleUpgradeTimeout / time.Millisecond)
+	// 10 * 60 * 1000 — written as the product so the JS reads as a duration.
+	const decl = "var UPGRADE_ELAPSED_RED_MS = 10 * 60 * 1000;"
+	if !strings.Contains(dashboardHTML, decl) {
+		t.Fatalf("UPGRADE_ELAPSED_RED_MS declaration not found as %q", decl)
+	}
+	if wantMs != 10*60*1000 {
+		t.Fatalf("staleUpgradeTimeout is %v (%d ms), but the dashboard's "+
+			"UPGRADE_ELAPSED_RED_MS is hardcoded to 10*60*1000 ms. Update the JS "+
+			"constant so the red counter and the stuck-upgrade alert still agree.",
+			staleUpgradeTimeout, wantMs)
+	}
+}
+
+// TestUpgradeElapsedUsesNamedConstants guards the repo's no-magic-numbers rule
+// for every threshold this feature introduced.
+func TestUpgradeElapsedUsesNamedConstants(t *testing.T) {
+	for _, decl := range []string{
+		"var UPGRADE_ELAPSED_RED_MS =",
+		"var UPGRADE_ELAPSED_AMBER_MS =",
+		"var UPGRADE_ELAPSED_MIN_SHOW_MS =",
+		"var UPGRADE_ELAPSED_SKEW_TOLERANCE_MS =",
+		"var UPGRADE_FACET_STUCK_MS =",
+	} {
+		if !strings.Contains(dashboardHTML, decl) {
+			t.Errorf("missing named constant %q — thresholds must never be inline literals", decl)
+		}
+	}
+}
+
+// TestUpgradeElapsedHandlesUnknownStartTime pins the guards that keep the
+// counter from rendering "NaN" or a negative duration. Each of these is a
+// distinct edge case: absent, empty, unparseable, and clock skew.
+func TestUpgradeElapsedHandlesUnknownStartTime(t *testing.T) {
+	for _, guard := range []string{
+		// Missing / empty / non-string upgradeStartedAt.
+		"if (!started || typeof started !== 'string') return null;",
+		// Unparseable timestamp — Date.parse yields NaN.
+		"if (isNaN(t)) return null;",
+		// Negative elapsed from clock skew.
+		"if (elapsed < 0) {",
+		"if (elapsed > -UPGRADE_ELAPSED_SKEW_TOLERANCE_MS) return 0;",
+		// Callers must render nothing when the elapsed time is unknown.
+		"if (ms === null) return '';",
+	} {
+		if !strings.Contains(dashboardHTML, guard) {
+			t.Errorf("missing edge-case guard: %q", guard)
+		}
+	}
+	// formatUpgradeElapsed must refuse NaN and negatives outright rather than
+	// letting them reach the DOM as "NaNm" or "-3m".
+	if !strings.Contains(dashboardHTML,
+		"if (typeof ms !== 'number' || isNaN(ms) || ms < 0) return '';") {
+		t.Error("formatUpgradeElapsed must reject NaN and negative durations")
+	}
+}
+
+// TestUpgradeCounterIsWiredIntoTheUpgradingPill catches the failure mode where
+// every helper exists and is perfectly correct but nothing ever calls them, so
+// the counter is invisible in production while all other tests pass.
+func TestUpgradeCounterIsWiredIntoTheUpgradingPill(t *testing.T) {
+	if !strings.Contains(dashboardHTML, "+ renderUpgradeElapsed(h);") {
+		t.Error("renderUpgradeElapsed is never appended to the Upgrading pill — " +
+			"the counter would never appear")
+	}
+}
+
+// TestUpgradeFacetFilterWiring covers every call site a new filter must be
+// registered in. Omitting the render-cache key is the classic miss: the filter
+// toggles its state but the table never re-renders, so clicking it appears to
+// do nothing at all.
+func TestUpgradeFacetFilterWiring(t *testing.T) {
+	for name, snippet := range map[string]string{
+		"state variable":      "var _dashUpgradeFilter = '';",
+		"match rule applied":  "if (!hiveMatchesUpgradeFilter(h)) return false;",
+		"render cache key":    "'|' + _dashUpgradeFilter",
+		"active filter count": "if (_dashUpgradeFilter) n++;",
+		"clearAllHiveFilters / clearStatusFilters reset": "_dashUpgradeFilter = '';",
+		"facet group rendered":                           "renderUpgradeFacetGroup(assignedReal)",
+		"toggle handler":                                 "function toggleUpgradeFilter(state)",
+	} {
+		if !strings.Contains(dashboardHTML, snippet) {
+			t.Errorf("%s: missing %q", name, snippet)
+		}
+	}
+}
+
+// TestUpgradeStateClassificationOrdering pins the precedence between the two
+// facets. They are successive stages of one lifecycle, so an in-flight upgrade
+// must win over a queued one; otherwise a hive counts in both facets and the
+// two chips sum to more than the fleet.
+func TestUpgradeStateClassificationOrdering(t *testing.T) {
+	i := strings.Index(dashboardHTML, "function hiveUpgradeState(")
+	if i < 0 {
+		t.Fatal("hiveUpgradeState not found")
+	}
+	body := dashboardHTML[i : i+600]
+	up := strings.Index(body, "return UPGRADE_FILTER_UPGRADING;")
+	q := strings.Index(body, "return UPGRADE_FILTER_QUEUED;")
+	if up < 0 || q < 0 {
+		t.Fatalf("both upgrade states must be returned; got up=%d queued=%d", up, q)
+	}
+	if up > q {
+		t.Error("h.upgrading must be tested BEFORE the queued condition, " +
+			"or an upgrading hive would also be counted as queued")
+	}
+}
+
+// TestQueuedHivesGetNoFabricatedCounter documents the server behaviour the UI
+// depends on: UpgradeStartedAt is stamped only where Upgrading is set true, so
+// a queued hive genuinely has no start time. If a future change started
+// stamping it at queue time, the counter would begin reporting queue wait as
+// upgrade duration and this test should be revisited deliberately.
+func TestQueuedHivesGetNoFabricatedCounter(t *testing.T) {
+	queued := RegistryEntry{
+		ID: "queued-1", Upgrading: false, UpgradeTarget: "abc1234",
+	}
+	if !queued.UpgradeStartedAt.IsZero() {
+		t.Fatal("a queued (not yet upgrading) hive must carry no UpgradeStartedAt")
+	}
+	// The JS mirrors that: the queued branch of the facet never reads a
+	// timestamp, and upgradeElapsedMs returns null for an absent one.
+	if !strings.Contains(dashboardHTML, "if (h.autoUpgrade && h.upgradeTarget) return UPGRADE_FILTER_QUEUED;") {
+		t.Error("queued classification must not depend on upgradeStartedAt")
+	}
+}
+
+// TestFailedUpgradeAlertHasADashboardLabel closes a gap left by #2308: the hub
+// can raise AlertTypeFailedUpgrade, but the alert-type chip falls back to the
+// raw key when ALERT_TYPE_LABELS has no entry, so the panel would read
+// "failed-upgrade" instead of "Failed upgrade".
+func TestFailedUpgradeAlertHasADashboardLabel(t *testing.T) {
+	if !strings.Contains(dashboardHTML, "'"+AlertTypeFailedUpgrade+"': 'Failed upgrade'") {
+		t.Errorf("ALERT_TYPE_LABELS has no entry for %q", AlertTypeFailedUpgrade)
+	}
+}
+
+// TestUpgradeElapsedStuckWordingNamesTheFault is the anti-regression test for
+// the incident itself. Past the red line the tooltip must stop describing
+// progress and name the fault: a spinner that still reads as "in progress"
+// after 20 minutes is precisely what made a wedged fleet look healthy.
+func TestUpgradeElapsedStuckWordingNamesTheFault(t *testing.T) {
+	if !strings.Contains(dashboardHTML, "almost certainly wedged, not slow") {
+		t.Error("the past-threshold tooltip must name the fault rather than imply progress")
+	}
+}


### PR DESCRIPTION
Two related hub-dashboard (My Hives) changes: an upgrade-state facet filter, and an elapsed-time counter on the Upgrading pill.

## Why

15 hives sat at `upgrading: true` for 20+ minutes while nothing happened — the spoke's self-upgrade took an HTTP 403 on missing RBAC, exited 0, and restarted onto the same image forever. The UI showed a static "Upgrading" spinner with **no elapsed time**, so a permanently-wedged fleet was visually indistinguishable from a merely slow one.

The design premise here is that **a long-running "Upgrading" is a fault signal, not progress.**

## 1. Upgrade-state facet filters

New `FACET_GROUP_UPGRADE` group with two values, `Upgrading` and `Queued`. Follows the `FACET_GROUP_HEALTH` / `FACET_GROUP_FAILING_CHECK` pattern established by #2306 rather than inventing a parallel mechanism: the values are a fixed, hand-written lifecycle with their own matching rule and their own state, not a dimension enumerated from the data like cluster or branch, so it stays **out** of `HIVE_FACET_GROUPS`.

Single-select, ANDed against the health chips, like the drift filter. "Upgrading" and "queued" are successive stages of one lifecycle, so an OR across both would just mean "any pending upgrade" — which is what clearing the filter already shows.

`hiveUpgradeState()` tests `h.upgrading` **before** the queued condition. Without that ordering a hive in flight would be counted in both chips and the two would sum to more than the fleet. There is a test for it.

Wired into `hiveMatchesFilters`, `activeFilterCount`, `clearStatusFilters`, `clearAllHiveFilters`, and **the render cache key** — without that last one the filter would toggle its state and the table would never re-render, so clicking it would appear to do nothing.

The `Upgrading` chip additionally counts how many of those hives are **past the stuck limit** and turns its count red when any are, because a bare count of 15 upgrading hives looks identical whether they are 10 seconds or 40 minutes in.

## 2. Elapsed-time counter

`renderUpgradeElapsed()` appends a compact duration (`45s`, `3m`, `1h12m`) to the Upgrading pill, escalating muted → amber → red.

**The red threshold is pinned to `staleUpgradeTimeout` (10m) — the exact instant the hub raises its stuck-upgrade alert.** Turning red earlier would accuse a hive the hub still considers healthy; turning red later would leave a window where the alert panel says stuck and the row still looks fine. `TestUpgradeElapsedThresholdMatchesStuckUpgradeAlert` fails with an explanatory message if someone retunes the server constant without retuning the UI one. Amber sits at half that as an early warning.

Past the red line the tooltip **stops describing progress and names the fault** ("almost certainly wedged, not slow"), because a spinner that still reads as in-progress after 20 minutes is exactly what made the wedged fleet look healthy.

Under `UPGRADE_ELAPSED_MIN_SHOW_MS` (30s) the counter renders nothing at all. Every upgrade starts at 0s, and a counter that flickers "1s, 2s…" on every healthy rollout would train the operator to ignore it — the same habit that let the incident go unnoticed.

### Relationship to #2308

**Complementary, not duplicative.** #2308 handles the case where the spoke *reports* a failure: it clears `Upgrading`, records the cause, and raises a Critical `failed-upgrade` alert. Once that report arrives the pill is gone and this counter no longer applies.

This counter covers the gap #2308 cannot: the spoke that never reports anything — wedged, offline, or killed before it could call `ReportUpgradeFailure`. There `Upgrading` stays true indefinitely and the elapsed time is the *only* available signal. The two agree on what "stuck" means because both derive from `staleUpgradeTimeout`.

Also closes a small gap left by #2308: `AlertTypeFailedUpgrade` had no entry in `ALERT_TYPE_LABELS`, so the alert chip rendered the raw key `failed-upgrade` instead of "Failed upgrade".

### Edge cases

`upgradeElapsedMs()` returns `null` — and every caller renders nothing — for a **missing, empty, non-string or unparseable** `upgradeStartedAt`. Never `NaN`, never a negative duration.

**Clock skew:** browser and hub clocks disagree by seconds, which yields a small negative elapsed on a freshly-started upgrade. Negatives within `UPGRADE_ELAPSED_SKEW_TOLERANCE_MS` (60s) clamp to 0; anything more negative is real skew and the counter is suppressed rather than shown as a lie.

**Queued hives get no counter.** Verified against the server: `UpgradeStartedAt` is stamped *only* where `Upgrading` is set true, so a queued hive genuinely has no start time. Rather than fabricate one, the queued state is classified without reference to any timestamp. A test documents this coupling so that if a future change starts stamping at queue time, the decision is revisited deliberately instead of silently reporting queue wait as upgrade duration.

Hives with an unknown start time are **not** counted toward the facet's "stuck" number — an unknown elapsed is not evidence of a fault, and inflating that number would make the warning untrustworthy.

## Verification

- **No backend change needed** — confirmed by running, not assumed: `MyHiveEntry` embeds `RegistryEntry`, and a marshal probe showed `"upgradeStartedAt":"2026-07-31T12:00:00Z"` already reaching the browser as RFC3339.
- `go build ./...`, `go vet ./pkg/hub/`, and the **full `./pkg/hub/` suite** pass.
- `gofmt -l` clean on the two touched files only.
- **Raw-string hazards:** zero backticks introduced inside `dashboardHTML`; no literal body tag.
- **JS brace/paren/bracket delta identical to the `origin/v2` baseline** — `{}` 0/0, `()` -1/-1, `[]` -1/-1 — with the change confirmed present in the extraction so the check is not measuring stale output. (The -1s are the known validator artifact from regex literals like `/'/g`; base-vs-current is what matters and it is unchanged.)
- `TestHiveTableColumnCount*` passes — no column added.
- The counter logic was additionally **executed** under node against 28 cases (missing/empty/unparseable/non-string timestamps, both skew directions, NaN and negative formatting, all three escalation bands, suppression thresholds, and the queued-vs-upgrading precedence). All pass, including the incident scenario: 20 minutes renders `20m`, red, wording that names the fault, and no `NaN`.

## Porting

**mk, dd and v3 still need this ported.**