### PR TITLE
🔀 sync: v2 → mk

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -3,10 +3,10 @@ name: v2 CI
 on:
   push:
     branches: [v2]
-    paths: ['v2/**']
+    paths: ['v2/**', 'bin/contributor-relay*']
   pull_request:
     branches: [v2]
-    paths: ['v2/**']
+    paths: ['v2/**', 'bin/contributor-relay*']
 
 permissions:
   contents: read
@@ -37,6 +37,15 @@ jobs:
 
       - name: Proxy Tests
         run: cd proxy && npm ci && npm test
+
+      # bin/contributor-relay.sh is JavaScript run by node despite the .sh
+      # extension; node --check needs a .js path, so check a copy.
+      - name: Contributor Relay Syntax + Tests
+        working-directory: .
+        run: |
+          cp bin/contributor-relay.sh "${RUNNER_TEMP}/contributor-relay.js"
+          node --check "${RUNNER_TEMP}/contributor-relay.js"
+          node bin/contributor-relay.test.js
   create-issue-on-failure:
     if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/v2'
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -197,7 +197,9 @@ contribute-setup backend="claude": check-version
         ;;
       bob)
         if command -v bob &>/dev/null; then
-          echo "Bob CLI detected — authentication handled on first run."
+          # Bob's browser SSO flow cannot complete in a container, so the
+          # containerized path needs BOBSHELL_API_KEY exported in your shell.
+          echo "Bob CLI detected — export BOBSHELL_API_KEY for containerized runs."
         else
           echo "ERROR: Bob CLI not found."
           exit 1
@@ -318,6 +320,14 @@ contribute-hive backend="" mode="docker": check-version
       BACKEND="${AGENT_BACKEND:-claude}"
     fi
     export AGENT_BACKEND="$BACKEND"
+    # Bob has no headless credential other than its API key — without it the
+    # agent would launch and sit at Bob's key prompt forever. Fail fast.
+    if [[ "$BACKEND" == "bob" && -z "${BOBSHELL_API_KEY:-}" ]]; then
+      echo "ERROR: BOBSHELL_API_KEY not set — Bob cannot authenticate."
+      echo "  export BOBSHELL_API_KEY=your-bob-api-key"
+      echo "  then re-run: just contribute-hive bob"
+      exit 1
+    fi
     echo "=== Hive Contributor Agent (ClankeR) ==="
     echo "Backend:  ${BACKEND}"
     echo "Hub:      {{hive_hub}}"
@@ -481,6 +491,7 @@ contribute-hive backend="" mode="docker": check-version
         ${GOOSE_PROVIDER:+-e GOOSE_PROVIDER="${GOOSE_PROVIDER}"} \
         ${GOOSE_MODEL:+-e GOOSE_MODEL="${GOOSE_MODEL}"} \
         ${OPENAI_API_KEY:+-e OPENAI_API_KEY="${OPENAI_API_KEY}"} \
+        ${BOBSHELL_API_KEY:+-e BOBSHELL_API_KEY="${BOBSHELL_API_KEY}"} \
         ${HIVE_LITELLM_ENDPOINT:+-e HIVE_LITELLM_ENDPOINT="${HIVE_LITELLM_ENDPOINT}"} \
         ${HIVE_LITELLM_API_KEY:+-e HIVE_LITELLM_API_KEY="${HIVE_LITELLM_API_KEY}"} \
         ${AGENT_MODEL:+-e AGENT_MODEL="${AGENT_MODEL}"} \

--- a/Justfile
+++ b/Justfile
@@ -473,7 +473,16 @@ contribute-hive backend="" mode="docker": check-version
           ;;
       esac
       CONTAINER_NAME="hive-contributor-${BACKEND}-$(head -c 4 /dev/urandom | od -An -tx1 | tr -d ' ')"
-      "$RUNTIME" run -d --rm \
+      # NOTE: deliberately NOT --rm. With --rm the runtime deletes the
+      # container the instant it exits, taking its logs with it — so a
+      # container that dies during startup leaves nothing to diagnose
+      # (the user just sees "no such container"). We remove it ourselves
+      # in the cleanup trap below, after the logs have been read.
+      cleanup_container() {
+        "$RUNTIME" rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+      }
+      trap cleanup_container EXIT
+      "$RUNTIME" run -d \
         --name "${CONTAINER_NAME}" \
         ${RUNTIME_FLAGS} \
         ${NET_FLAGS} \
@@ -482,7 +491,7 @@ contribute-hive backend="" mode="docker": check-version
         -v "${HOME}/.config/gh:/home/dev/.config/gh${ROSUF}" \
         -e HIVE_HUB="{{hive_hub}}" \
         -e AGENT_BACKEND="${BACKEND}" \
-        -e GH_TOKEN="${GH_TOKEN}" \
+        -e GH_TOKEN="${GH_TOKEN:-}" \
         -e HIVE_USE_CONTRIBUTOR_GH=true \
         -e HIVE_CONTAINER_NAME="${CONTAINER_NAME}" \
         ${ANTHROPIC_API_KEY:+-e ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}"} \
@@ -499,18 +508,77 @@ contribute-hive backend="" mode="docker": check-version
 
       echo "Container: ${CONTAINER_NAME}"
       echo "Waiting for CLI session to start..."
-      sleep 3
+      # Grace period for the container entrypoint to bring up the tmux
+      # session before we try to attach to it.
+      readonly STARTUP_GRACE_SECONDS=3
+      sleep "${STARTUP_GRACE_SECONDS}"
+
+      # The container may have died during the grace period (bad flag, OOM,
+      # unreadable mount, failed entrypoint). Detect that BEFORE attaching or
+      # tailing, and surface the exit code plus the captured logs — otherwise
+      # the user only sees an opaque runtime error.
+      CONTAINER_STATE=$("$RUNTIME" inspect -f '{{ "{{" }}.State.Running{{ "}}" }}' "${CONTAINER_NAME}" 2>/dev/null || echo "missing")
+      if [[ "$CONTAINER_STATE" != "true" ]]; then
+        CONTAINER_EXIT=$("$RUNTIME" inspect -f '{{ "{{" }}.State.ExitCode{{ "}}" }}' "${CONTAINER_NAME}" 2>/dev/null || echo "unknown")
+        echo ""
+        echo "ERROR: the contributor container exited during startup."
+        echo "  Container: ${CONTAINER_NAME}"
+        echo "  Runtime:   ${RUNTIME}"
+        echo "  Exit code: ${CONTAINER_EXIT}"
+        echo ""
+        echo "── Container logs ──"
+        "$RUNTIME" logs "${CONTAINER_NAME}" 2>&1 || echo "(no logs captured)"
+        echo "────────────────────"
+        echo ""
+        echo "Common causes:"
+        echo "  * GH_TOKEN empty/expired  — re-run: just contribute-setup {{backend}}"
+        echo "  * config mounts unreadable (rootless podman UID mapping)"
+        echo "  * missing HIVE_REGISTRATION_TOKEN"
+        echo ""
+        echo "Re-run with HIVE_KEEP_CONTAINER=true to keep the container for inspection."
+        if [[ "${HIVE_KEEP_CONTAINER:-}" == "true" ]]; then
+          trap - EXIT
+          echo "Container kept: ${RUNTIME} logs ${CONTAINER_NAME}"
+        fi
+        exit 1
+      fi
 
       # Open the CLI session in a new terminal window
       ATTACH_CMD="${RUNTIME} exec -it ${CONTAINER_NAME} tmux attach -t contributor"
       if [[ "$OSTYPE" == "darwin"* ]]; then
-        if pgrep -x "iTerm2" > /dev/null 2>&1; then
-          osascript -e "tell application \"iTerm2\" to tell current window to create tab with default profile command \"${ATTACH_CMD}\""
+        # Detect iTerm via System Events rather than pgrep. On macOS the
+        # iTerm process's comm is the full bundle path
+        # (/Applications/iTerm.app/Contents/MacOS/iTerm2), so `pgrep -x iTerm2`
+        # anchors against that path and NEVER matches — every iTerm user
+        # silently fell through to Terminal.app. System Events reports the
+        # application name ("iTerm2"), which is what we actually want.
+        TAB_OPENED=true
+        RUNNING_APPS=$(osascript -e 'tell application "System Events" to get name of every application process whose background only is false' 2>/dev/null || echo "")
+        if [[ "$RUNNING_APPS" == *"iTerm"* ]]; then
+          # iTerm may be running with no open window, in which case
+          # `tell current window` errors — fall back to creating a window.
+          osascript -e "tell application \"iTerm2\"
+            if (count of windows) = 0 then
+              create window with default profile command \"${ATTACH_CMD}\"
+            else
+              tell current window to create tab with default profile command \"${ATTACH_CMD}\"
+            end if
+          end tell" >/dev/null 2>&1 || {
+            TAB_OPENED=false
+            echo "WARNING: could not open an iTerm tab; attach manually with:"
+            echo "  ${ATTACH_CMD}"
+          }
         else
-          osascript -e "tell application \"Terminal\" to do script \"${ATTACH_CMD}\""
+          osascript -e "tell application \"Terminal\" to do script \"${ATTACH_CMD}\"" >/dev/null 2>&1 || {
+            TAB_OPENED=false
+            echo "WARNING: could not open a Terminal window; attach manually with:"
+            echo "  ${ATTACH_CMD}"
+          }
         fi
-        echo ""
-        echo "✓ CLI session opened in a new terminal tab."
+        if [[ "$TAB_OPENED" == "true" ]]; then
+          echo ""
+          echo "✓ CLI session opened in a new terminal tab."
+        fi
       else
         echo ""
         echo "Attach to the CLI session with:"
@@ -519,7 +587,15 @@ contribute-hive backend="" mode="docker": check-version
 
       echo ""
       echo "Relay logs:"
-      "$RUNTIME" logs -f "${CONTAINER_NAME}"
+      # `logs -f` returns when the container stops. Don't let a non-zero
+      # status from it kill the recipe under `set -e` — we want to report the
+      # container's own exit code, which is the useful signal.
+      "$RUNTIME" logs -f "${CONTAINER_NAME}" 2>&1 || true
+      FINAL_EXIT=$("$RUNTIME" inspect -f '{{ "{{" }}.State.ExitCode{{ "}}" }}' "${CONTAINER_NAME}" 2>/dev/null || echo "unknown")
+      if [[ "$FINAL_EXIT" != "0" && "$FINAL_EXIT" != "unknown" ]]; then
+        echo ""
+        echo "Container ${CONTAINER_NAME} exited with code ${FINAL_EXIT}."
+      fi
     fi
 
 # Check hub status and your contributor profile

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -40,6 +40,20 @@ const TOKEN_REFRESH_MARGIN_MS = 300000;
 const MAX_TASK_DURATION_MS = 1800000;
 const NETWORK_ERROR_RETRY_DELAY_MS = 5000;
 
+// Per-task CLI-crash retry budget. Issue #2203: a task whose CLI kept dying was
+// reassigned by the hub and failed identically forever (5+ times in ~20min),
+// starving that hub task slot. After MAX_TASK_CLI_RESTARTS crash-restarts for
+// the SAME repo#number, the relay gives up on that task permanently and tells
+// the hub so it can be reassigned elsewhere.
+const MAX_TASK_CLI_RESTARTS = 3;
+// Backoff before each successive restart of the same task: 5s, 10s, 20s.
+const TASK_RESTART_BASE_BACKOFF_MS = 5000;
+const TASK_RESTART_MAX_BACKOFF_MS = 60000;
+// How long a permanently-given-up task stays on the deny list. Long enough
+// that the hub does not immediately hand the same poison task back, short
+// enough that a transient environment fault eventually clears.
+const GIVE_UP_MEMORY_MS = 3600000;
+
 if (!REG_TOKEN) {
   console.error('FATAL: HIVE_REGISTRATION_TOKEN not set. Run `just contribute-register` first.');
   process.exit(1);
@@ -71,6 +85,50 @@ function injectGhToken(token) {
 const CLI_READY_POLL_MS = 2000;
 const CLI_READY_TIMEOUT_MS = 600000;
 const CONTAINER_NAME = process.env.HIVE_CONTAINER_NAME || 'hive-contributor';
+
+// Backends that must NOT be given --model, mirroring contributor-agent.sh.
+// amazonq/goose take their model from config/env. bob is excluded because
+// --model is actively FATAL for it: bob auto-selects its own model and passing
+// one leaves its model config undefined, so every prompt dies with
+// "Cannot read properties of undefined (reading 'maxTokens')" (bobshell 1.0.6).
+const NO_MODEL_FLAG_BACKENDS = ['amazonq', 'goose', 'bob'];
+
+// Single source of truth for the CLI launch command (issue #2203, bug 1).
+// contributor-agent.sh builds "$CMD $PERM_FLAG $MODEL_FLAG" for the FIRST
+// launch; every restart path in this file previously rebuilt only "$CMD $PERM"
+// inline, silently dropping the resolved model for the rest of the container's
+// life. Build it once here and reuse it everywhere so the paths cannot drift.
+let cachedLaunchCommand = null;
+
+function buildLaunchCommand() {
+  if (cachedLaunchCommand) return cachedLaunchCommand;
+  const confPaths = ['/usr/local/etc/hive/backends.conf', path.join(process.cwd(), 'config/backends.conf')];
+  const confPath = confPaths.find(p => fs.existsSync(p)) || confPaths[0];
+  let cmd = BACKEND;
+  let perm = '';
+  try {
+    cmd = execSync(`bash -c 'source ${confPath} 2>/dev/null; backend_binary ${BACKEND}'`, { encoding: 'utf8', timeout: 15000 }).trim() || BACKEND;
+    perm = execSync(`bash -c 'source ${confPath} 2>/dev/null; backend_perm_flag ${BACKEND}'`, { encoding: 'utf8', timeout: 15000 }).trim();
+  } catch (e) {
+    console.error(`Could not resolve backend flags from ${confPath}: ${e.message}`);
+  }
+  const modelFlag = MODEL && !NO_MODEL_FLAG_BACKENDS.includes(BACKEND) ? `--model ${MODEL}` : '';
+  cachedLaunchCommand = [cmd, perm, modelFlag].filter(Boolean).join(' ');
+  return cachedLaunchCommand;
+}
+
+// A tmux pane can be left in bash's PS2 continuation state ("> ") when task
+// text is typed into a bare shell — the prompt contains literal apostrophes
+// (e.g. 'gh repo fork ... --clone=false'), so bash's readline sees an
+// unbalanced quote and swallows everything typed afterwards, including the
+// relaunch command (issue #2203). Clear the line before relaunching.
+function recoverWedgedShell() {
+  try {
+    execSync(`tmux send-keys -t ${TMUX_SESSION} C-c`, { timeout: 15000 });
+    execSync(`tmux send-keys -t ${TMUX_SESSION} C-u`, { timeout: 15000 });
+    execSync(`tmux send-keys -t ${TMUX_SESSION} Enter`, { timeout: 15000 });
+  } catch (_) {}
+}
 
 function getCLIState() {
   try {
@@ -159,17 +217,16 @@ let pendingTask = null;
 
 waitForCLI().then(() => {
   cliReady = true;
-  if (pendingTask) {
-    const task = pendingTask;
-    pendingTask = null;
-    tmuxSendKeys(task);
-  }
+  flushPendingTask();
 }).catch(e => console.error(e.message));
 
 const ENTER_COUNT = 3;
 const ENTER_DELAY_MS = 300;
 
 function sleepMs(ms) {
+  // Tests drive the restart/backoff paths synchronously; a real busy-wait
+  // would make the suite take minutes of wall clock for no added coverage.
+  if (process.env.HIVE_RELAY_TEST_MODE === '1') return;
   const end = Date.now() + ms;
   while (Date.now() < end) {
     try { execSync(`sleep 0.1`, { timeout: 5000 }); } catch (_) {}
@@ -199,6 +256,16 @@ function checkContextUsage() {
 }
 
 function tmuxSendKeys(text) {
+  // Hard gate (issue #2203, bug 2): `send-keys -l` types literal keystrokes
+  // into whatever owns the pane. If the CLI is not confirmed ready, those
+  // keystrokes land on bash, whose readline chokes on the apostrophes in the
+  // prompt and drops the pane into PS2 continuation, wedging it permanently.
+  // Queue instead; flushPendingTask() delivers it once readiness is confirmed.
+  if (!cliReady) {
+    console.log('CLI not ready — queuing task prompt instead of typing into the pane');
+    pendingTask = text;
+    return;
+  }
   try {
     try {
       execSync(`find /tmp -maxdepth 1 -type d -user dev -not -name 'tmux-*' -not -name 'claude-*' -not -name 'node-*' -not -name '.' -mmin +60 -exec rm -rf {} + 2>/dev/null; find /tmp -maxdepth 1 -type f -user dev -name '*.out' -o -name '*.html' -mmin +60 -exec rm -f {} + 2>/dev/null`, { timeout: 15000 });
@@ -224,16 +291,18 @@ function tmuxSendKeys(text) {
       sleepMs(1000);
       execSync(`tmux send-keys -t ${TMUX_SESSION} C-c`, { timeout: 15000 });
       sleepMs(2000);
+      // Queue this prompt and hand delivery to the readiness callback.
+      // Previously the restart set cliReady=false and then FELL THROUGH to the
+      // send loop below, typing the prompt into a pane where the CLI had just
+      // been Ctrl-C'd and had not come back — the exact sequence in #2203.
+      pendingTask = text;
+      cliReady = false;
       try {
-        const confPaths2 = ['/usr/local/etc/hive/backends.conf', path.join(process.cwd(), 'config/backends.conf')];
-        const confPath2 = confPaths2.find(p => fs.existsSync(p)) || confPaths2[0];
-        const CMD = execSync(`bash -c 'source ${confPath2} 2>/dev/null; backend_binary ${BACKEND}'`, { encoding: 'utf8', timeout: 15000 }).trim() || BACKEND;
-        const PERM = execSync(`bash -c 'source ${confPath2} 2>/dev/null; backend_perm_flag ${BACKEND}'`, { encoding: 'utf8', timeout: 15000 }).trim();
-        execSync(`tmux send-keys -t ${TMUX_SESSION} '${CMD} ${PERM}' Enter`, { timeout: 15000 });
-        cliReady = false;
-        waitForCLI().then(() => { cliReady = true; if (pendingTask) { const t = pendingTask; pendingTask = null; tmuxSendKeys(t); } }).catch(() => {});
-        sleepMs(10000);
-      } catch (e) { console.error('CLI restart failed:', e.message); }
+        console.log(`CLI restarted: ${relaunchCLI()}`);
+      } catch (e) {
+        console.error('CLI restart failed:', e.message);
+      }
+      return;
     }
     const MAX_SEND_RETRIES = 3;
     const RETRY_DELAY_MS = 10000;
@@ -315,12 +384,27 @@ function bobIsRunning() {
 // Relaunch the backend CLI in the tmux session using the flags from
 // backends.conf, the same way contributor-agent.sh first launched it.
 function relaunchCLI() {
-  const confPaths = ['/usr/local/etc/hive/backends.conf', path.join(process.cwd(), 'config/backends.conf')];
-  const confPath = confPaths.find(p => fs.existsSync(p)) || confPaths[0];
-  const CMD = execSync(`bash -c 'source ${confPath} 2>/dev/null; backend_binary ${BACKEND}'`, { encoding: 'utf8', timeout: 15000 }).trim() || BACKEND;
-  const PERM = execSync(`bash -c 'source ${confPath} 2>/dev/null; backend_perm_flag ${BACKEND}'`, { encoding: 'utf8', timeout: 15000 }).trim();
-  execSync(`tmux send-keys -t ${TMUX_SESSION} '${CMD} ${PERM}' Enter`, { timeout: 15000 });
-  return `${CMD} ${PERM}`;
+  const launchCmd = buildLaunchCommand();
+  // The pane may be wedged in bash PS2 continuation; clear it or the relaunch
+  // command is swallowed as more continuation text and never runs.
+  recoverWedgedShell();
+  execSync(`tmux send-keys -t ${TMUX_SESSION} ${shellQuote(launchCmd)} Enter`, { timeout: 15000 });
+  // The CLI is NOT up yet. cliReady must stay false until the readiness
+  // classifier positively confirms it, or a task prompt sent in the meantime
+  // is typed as literal keystrokes into a bare shell (issue #2203, bug 2).
+  cliReady = false;
+  waitForCLI().then(() => {
+    cliReady = true;
+    flushPendingTask();
+  }).catch(e => console.error(`CLI did not become ready after relaunch: ${e.message}`));
+  return launchCmd;
+}
+
+function flushPendingTask() {
+  if (!pendingTask) return;
+  const t = pendingTask;
+  pendingTask = null;
+  tmuxSendKeys(t);
 }
 
 function checkTmuxIdle() {
@@ -421,12 +505,38 @@ const PR_REVIEW_EVERY_N = 5;
 let taskTimeoutHandle = null;
 let lastProgressTick = 0;
 
-function failCurrentTask(reason) {
+// Crash-restart bookkeeping, keyed by the underlying work item (repo#number)
+// rather than task_id — the hub mints a NEW task_id on every reassignment of
+// the same issue, so a task_id-keyed counter would reset each round and never
+// reach the cap (issue #2203, bug 3).
+const cliRestartCounts = new Map();
+const givenUpTasks = new Map();
+
+function taskKey(task) {
+  return task && task.repo ? `${task.repo}#${task.number}` : (task && task.task_id) || 'unknown';
+}
+
+function isGivenUp(key) {
+  const at = givenUpTasks.get(key);
+  if (at === undefined) return false;
+  if (Date.now() - at > GIVE_UP_MEMORY_MS) {
+    givenUpTasks.delete(key);
+    return false;
+  }
+  return true;
+}
+
+function restartBackoffMs(attempt) {
+  return Math.min(TASK_RESTART_BASE_BACKOFF_MS * Math.pow(2, attempt - 1), TASK_RESTART_MAX_BACKOFF_MS);
+}
+
+function failCurrentTask(reason, opts) {
   if (!currentTask) return;
+  const permanent = !!(opts && opts.permanent);
   const taskId = currentTask.task_id;
   const tmuxLines = captureTmuxLines(TMUX_TAIL_LINES);
-  console.error(`Task ${taskId} failed: ${reason}`);
-  send({ type: 'task_failed', seq: nextSeq(), task_id: taskId, reason, tmux_output: tmuxLines });
+  console.error(`Task ${taskId} failed${permanent ? ' permanently' : ''}: ${reason}`);
+  send({ type: 'task_failed', seq: nextSeq(), task_id: taskId, reason, permanent, tmux_output: tmuxLines });
   currentTask = null;
   taskAssignedAt = 0;
   if (progressInterval) { clearInterval(progressInterval); progressInterval = null; }
@@ -446,90 +556,110 @@ function startProgressReporting() {
     }
   }, MAX_TASK_DURATION_MS);
 
-  progressInterval = setInterval(() => {
-    lastProgressTick = Date.now();
-    if (!currentTask) return;
-    if (Date.now() - taskAssignedAt < TASK_GRACE_PERIOD_MS) return;
+  progressInterval = setInterval(progressTick, PROGRESS_REPORT_INTERVAL_MS);
+}
 
+// One iteration of the progress/completion/crash-detection loop. Extracted from
+// the setInterval body so it can be driven deterministically from tests.
+function progressTick() {
+  lastProgressTick = Date.now();
+  if (!currentTask) return;
+  if (Date.now() - taskAssignedAt < TASK_GRACE_PERIOD_MS) return;
+
+  try {
+    let procs = '';
     try {
-      let procs = '';
-      try {
-        if (fs.existsSync('/proc')) {
-          procs = execSync(`for p in /proc/[0-9]*/cmdline; do tr "\\0" " " < "$p" 2>/dev/null; done`, { encoding: 'utf8', timeout: 15000 });
-        } else {
-          procs = execSync(`ps -eo command 2>/dev/null`, { encoding: 'utf8', timeout: 15000 });
-        }
-      } catch (_) { procs = BACKEND; }
-      const cliAlive = procs.includes(BACKEND) || procs.includes('claude') || procs.includes('copilot') || procs.includes('bob') || procs.includes('codex') || procs.includes('goose') || procs.includes('pi');
-      // bob is not a persistent REPL: it exits at the end of every turn ("Bob
-      // goes to sleep 💤"). For bob an exited process is the normal completion
-      // signal, not a crash, so it must fall through to the checkTmuxIdle()
-      // path below and be reported as task_complete. Treating it as a death
-      // here reported finished work as task_failed on every single task.
-      const cliExitIsNormal = BACKEND === 'bob';
-      if (!cliAlive && !cliExitIsNormal) {
-        console.error(`CLI process (${BACKEND}) died — restarting and reporting task as failed`);
-        try {
-          const confPaths = ['/usr/local/etc/hive/backends.conf', path.join(process.cwd(), 'config/backends.conf')];
-          const confPath = confPaths.find(p => fs.existsSync(p)) || confPaths[0];
-          const CMD = execSync(`bash -c 'source ${confPath} 2>/dev/null; backend_binary ${BACKEND}'`, { encoding: 'utf8', timeout: 15000 }).trim() || BACKEND;
-          const PERM = execSync(`bash -c 'source ${confPath} 2>/dev/null; backend_perm_flag ${BACKEND}'`, { encoding: 'utf8', timeout: 15000 }).trim();
-          execSync(`tmux send-keys -t ${TMUX_SESSION} '${CMD} ${PERM}' Enter`, { timeout: 15000 });
-          console.log(`CLI restarted: ${CMD} ${PERM}`);
-          cliReady = false;
-          waitForCLI().then(() => { cliReady = true; }).catch(() => {});
-        } catch (e) {
-          console.error('Failed to restart CLI:', e.message);
-        }
-        failCurrentTask('CLI process exited — restarted');
+      if (fs.existsSync('/proc')) {
+        procs = execSync(`for p in /proc/[0-9]*/cmdline; do tr "\\0" " " < "$p" 2>/dev/null; done`, { encoding: 'utf8', timeout: 15000 });
+      } else {
+        procs = execSync(`ps -eo command 2>/dev/null`, { encoding: 'utf8', timeout: 15000 });
+      }
+    } catch (_) { procs = BACKEND; }
+    const cliAlive = procs.includes(BACKEND) || procs.includes('claude') || procs.includes('copilot') || procs.includes('bob') || procs.includes('codex') || procs.includes('goose') || procs.includes('pi');
+    // bob is not a persistent REPL: it exits at the end of every turn ("Bob
+    // goes to sleep 💤"). For bob an exited process is the normal completion
+    // signal, not a crash, so it must fall through to the checkTmuxIdle()
+    // path below and be reported as task_complete. Treating it as a death
+    // here reported finished work as task_failed on every single task.
+    const cliExitIsNormal = BACKEND === 'bob';
+    if (!cliAlive && !cliExitIsNormal) {
+      const key = taskKey(currentTask);
+      const attempt = (cliRestartCounts.get(key) || 0) + 1;
+      cliRestartCounts.set(key, attempt);
+
+      if (attempt > MAX_TASK_CLI_RESTARTS) {
+        // Terminal give-up (issue #2203, bug 3). Do NOT relaunch on this
+        // task's behalf again; report a permanent failure so the hub can
+        // hand the work to a different contributor instead of looping.
+        // The relay itself stays healthy and keeps accepting NEW tasks —
+        // only this one work item is poisoned — so a single bad task can
+        // never wedge the whole contributor.
+        givenUpTasks.set(key, Date.now());
+        cliRestartCounts.delete(key);
+        failCurrentTask(
+          `CLI process exited ${MAX_TASK_CLI_RESTARTS} times for ${key} — giving up on this task (relay still accepting other work)`,
+          { permanent: true }
+        );
+        // Bring the CLI back so the next, different task can run.
+        try { console.log(`CLI restarted: ${relaunchCLI()}`); } catch (e) { console.error('Failed to restart CLI:', e.message); }
         return;
       }
-    } catch (_) {}
 
-    const idle = checkTmuxIdle();
-    const tmuxLines = captureTmuxLines(TMUX_TAIL_LINES);
-    if (idle) {
-      console.log(`Task ${currentTask.task_id} completed — agent idle`);
-      send({ type: 'task_complete', seq: nextSeq(), task_id: currentTask.task_id, result: 'completed', summary: 'Agent returned to idle', tmux_output: tmuxLines });
-      // bob exits after each turn, so the pane is now a bare shell. Bring it
-      // back up before the next task, or the prompt would be typed into bash
-      // ("-bash: <prompt>: command not found") and silently lost.
-      if (BACKEND === 'bob' && !bobIsRunning()) {
-        try {
-          console.log(`Relaunching bob for the next task: ${relaunchCLI()}`);
-          cliReady = false;
-          waitForCLI().then(() => {
-            cliReady = true;
-            if (pendingTask) { const t = pendingTask; pendingTask = null; tmuxSendKeys(t); }
-          }).catch(e => console.error(e.message));
-        } catch (e) {
-          console.error('Failed to relaunch bob:', e.message);
-        }
+      const backoff = restartBackoffMs(attempt);
+      console.error(`CLI process (${BACKEND}) died — restart ${attempt}/${MAX_TASK_CLI_RESTARTS} for ${key} after ${backoff / 1000}s backoff`);
+      sleepMs(backoff);
+      try {
+        console.log(`CLI restarted: ${relaunchCLI()}`);
+      } catch (e) {
+        console.error('Failed to restart CLI:', e.message);
       }
-      const completedRepo = currentTask.repo;
-      currentTask = null;
-      taskAssignedAt = 0;
-      clearInterval(progressInterval);
-      progressInterval = null;
-      if (taskTimeoutHandle) { clearTimeout(taskTimeoutHandle); taskTimeoutHandle = null; }
-      tasksCompletedCount++;
-      if (tasksCompletedCount % PR_REVIEW_EVERY_N === 0) {
-        console.log(`PR review cycle (${tasksCompletedCount} tasks completed) — checking open PRs`);
-        currentTask = { task_id: `pr-review-${Date.now()}`, kind: 'review', repo: completedRepo, number: 0, title: 'Review open PRs for comments' };
-        taskAssignedAt = Date.now();
-        const reviewPrompt = `Check your open PRs on ${completedRepo} for review comments. ` +
-          `Run 'GH_TOKEN=$GH_TOKEN gh pr list --repo ${completedRepo} --author @me --state open' to find them. ` +
-          `For each PR with review comments, read the comments, address the feedback, push fixes, and respond. ` +
-          `If no PRs have comments, just say "No PR comments to address."`;
-        tmuxSendKeys(reviewPrompt);
-        startProgressReporting();
-      } else {
-        send({ type: 'ready', seq: nextSeq() });
-      }
-    } else {
-      send({ type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, status: 'working', tmux_output: tmuxLines });
+      failCurrentTask('CLI process exited — restarted');
+      return;
     }
-  }, PROGRESS_REPORT_INTERVAL_MS);
+  } catch (_) {}
+
+  const idle = checkTmuxIdle();
+  const tmuxLines = captureTmuxLines(TMUX_TAIL_LINES);
+  if (idle) {
+    console.log(`Task ${currentTask.task_id} completed — agent idle`);
+    // Successful completion clears this work item's crash-retry budget.
+    cliRestartCounts.delete(taskKey(currentTask));
+    send({ type: 'task_complete', seq: nextSeq(), task_id: currentTask.task_id, result: 'completed', summary: 'Agent returned to idle', tmux_output: tmuxLines });
+    // bob exits after each turn, so the pane is now a bare shell. Bring it
+    // back up before the next task, or the prompt would be typed into bash
+    // ("-bash: <prompt>: command not found") and silently lost.
+    if (BACKEND === 'bob' && !bobIsRunning()) {
+      try {
+        // relaunchCLI() clears cliReady and re-arms the readiness callback,
+        // which flushes any queued prompt once the CLI is confirmed up.
+        console.log(`Relaunching bob for the next task: ${relaunchCLI()}`);
+      } catch (e) {
+        console.error('Failed to relaunch bob:', e.message);
+      }
+    }
+    const completedRepo = currentTask.repo;
+    currentTask = null;
+    taskAssignedAt = 0;
+    clearInterval(progressInterval);
+    progressInterval = null;
+    if (taskTimeoutHandle) { clearTimeout(taskTimeoutHandle); taskTimeoutHandle = null; }
+    tasksCompletedCount++;
+    if (tasksCompletedCount % PR_REVIEW_EVERY_N === 0) {
+      console.log(`PR review cycle (${tasksCompletedCount} tasks completed) — checking open PRs`);
+      currentTask = { task_id: `pr-review-${Date.now()}`, kind: 'review', repo: completedRepo, number: 0, title: 'Review open PRs for comments' };
+      taskAssignedAt = Date.now();
+      const reviewPrompt = `Check your open PRs on ${completedRepo} for review comments. ` +
+        `Run 'GH_TOKEN=$GH_TOKEN gh pr list --repo ${completedRepo} --author @me --state open' to find them. ` +
+        `For each PR with review comments, read the comments, address the feedback, push fixes, and respond. ` +
+        `If no PRs have comments, just say "No PR comments to address."`;
+      tmuxSendKeys(reviewPrompt);
+      startProgressReporting();
+    } else {
+      send({ type: 'ready', seq: nextSeq() });
+    }
+  } else {
+    send({ type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, status: 'working', tmux_output: tmuxLines });
+  }
 }
 
 function handleMessage(data) {
@@ -576,6 +706,15 @@ function handleMessage(data) {
         send({ type: 'task_failed', seq: nextSeq(), task_id: msg.task_id, reason: 'Already has active task' });
         break;
       }
+      // A task we already gave up on permanently must not restart the loop if
+      // the hub reassigns it anyway (issue #2203, bug 3). Reject it up front
+      // and stay available for other work.
+      if (isGivenUp(taskKey(msg))) {
+        console.log(`Rejecting ${taskKey(msg)} — previously given up on after ${MAX_TASK_CLI_RESTARTS} CLI crashes`);
+        send({ type: 'task_failed', seq: nextSeq(), task_id: msg.task_id, reason: `previously given up on after ${MAX_TASK_CLI_RESTARTS} CLI crashes`, permanent: true });
+        send({ type: 'ready', seq: nextSeq() });
+        break;
+      }
       currentTask = msg;
       console.log(`Task assigned: ${msg.kind} ${msg.repo}#${msg.number} — ${msg.title}`);
       if (msg.github_token) {
@@ -585,12 +724,9 @@ function handleMessage(data) {
       fs.writeFileSync(TASK_FILE, JSON.stringify(msg, null, 2));
       send({ type: 'task_accepted', seq: nextSeq(), task_id: msg.task_id });
       const taskPrompt = msg.prompt || `Work on ${msg.kind} ${msg.repo}#${msg.number}: ${msg.title}`;
-      if (cliReady) {
-        tmuxSendKeys(taskPrompt);
-      } else {
-        console.log('CLI not ready yet — queuing task prompt');
-        pendingTask = taskPrompt;
-      }
+      // tmuxSendKeys() itself queues when the CLI is not confirmed ready, so
+      // there is a single gate rather than two that can disagree.
+      tmuxSendKeys(taskPrompt);
       startProgressReporting();
       break;
 
@@ -678,4 +814,32 @@ function cleanup() {
 process.on('SIGTERM', () => { cleanup(); process.exit(0); });
 process.on('SIGINT', () => { cleanup(); process.exit(0); });
 
-connect();
+// Test hook: when HIVE_RELAY_TEST_MODE=1 the relay exposes its internals and
+// does NOT open a hub connection, so contributor-relay.test.js can drive the
+// restart/queueing/give-up logic directly. Production runs never set this.
+if (process.env.HIVE_RELAY_TEST_MODE === '1') {
+  module.exports = {
+    buildLaunchCommand,
+    handleMessage,
+    tmuxSendKeys,
+    flushPendingTask,
+    relaunchCLI,
+    failCurrentTask,
+    startProgressReporting,
+    progressTick,
+    // Run one progress tick with the grace period already elapsed.
+    __crashTick: () => { taskAssignedAt = Date.now() - TASK_GRACE_PERIOD_MS - 1; progressTick(); },
+    cleanup,
+    restartBackoffMs,
+    NO_MODEL_FLAG_BACKENDS,
+    MAX_TASK_CLI_RESTARTS,
+    setCliReady: (v) => { cliReady = v; },
+    getCliReady: () => cliReady,
+    getPendingTask: () => pendingTask,
+    setPendingTask: (v) => { pendingTask = v; },
+    getCurrentTask: () => currentTask,
+    setWs: (w) => { ws = w; },
+  };
+} else {
+  connect();
+}

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -1,0 +1,386 @@
+// Tests for bin/contributor-relay.sh (JavaScript despite the .sh extension).
+//
+// Regression coverage for kubestellar/hive#2203 — "Contributor agent stuck in
+// infinite crash loop after periodic CLI restart". Reported with a full source
+// root-cause analysis by @castrojo.
+//
+// Run: node bin/contributor-relay.test.js
+
+'use strict';
+
+const assert = require('assert');
+const Module = require('module');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+// Set for the whole run, not just during module load: the relay checks it at
+// CALL time in sleepMs() to skip its busy-wait, and the restart paths sleep for
+// seconds at a time.
+process.env.HIVE_RELAY_TEST_MODE = '1';
+
+const RELAY_PATH = path.join(__dirname, 'contributor-relay.sh');
+
+// ---------------------------------------------------------------------------
+// Harness: load the relay with child_process/ws stubbed out, so no tmux, no
+// bash and no WebSocket are ever touched.
+// ---------------------------------------------------------------------------
+
+function loadRelay({ backend = 'copilot', model = '', cliStates = ['ready'], procAlive = true } = {}) {
+  const commands = [];
+  const sent = [];
+  let stateIdx = 0;
+  // Guard against a runaway loop in the code under test eating all memory.
+  const MAX_RECORDED_COMMANDS = 10000;
+
+  const fakeExecSync = (cmd) => {
+    if (commands.length < MAX_RECORDED_COMMANDS) commands.push(cmd);
+    if (/backend_binary/.test(cmd)) return `${backend}\n`;
+    if (/backend_perm_flag/.test(cmd)) return '--allow-all\n';
+    if (/capture-pane/.test(cmd)) {
+      const state = cliStates[Math.min(stateIdx++, cliStates.length - 1)];
+      // Panes that getCLIState()/checkTmuxIdle() classify per backend.
+      if (state === 'ready') return '/ commands for help\n';
+      if (state === 'working') return '/ commands for help\nesc cancel\n';
+      return 'dev@host:~$ \n';
+    }
+    if (/cmdline|ps -eo/.test(cmd)) {
+      // The relay's liveness probe greps this for the backend name. When the
+      // CLI is "dead" the pane is a bare shell — and crucially the string must
+      // not contain any known backend name.
+      return procAlive ? `${backend} --allow-all\n` : '/usr/bin/sh\n';
+    }
+    return '';
+  };
+
+  const stubs = {
+    child_process: {
+      execSync: fakeExecSync,
+      execFile: () => {},
+    },
+    ws: class FakeWebSocket {
+      static get OPEN() { return 1; }
+      constructor() { this.readyState = 1; }
+      on() {}
+      send(payload) { sent.push(JSON.parse(payload)); }
+      close() {}
+      ping() {}
+    },
+  };
+
+  const origResolve = Module._resolveFilename;
+  const origLoad = Module._load;
+  Module._load = function (request, parent, isMain) {
+    if (Object.prototype.hasOwnProperty.call(stubs, request)) return stubs[request];
+    return origLoad.apply(this, arguments);
+  };
+
+  const prevEnv = { ...process.env };
+  process.env.HIVE_REGISTRATION_TOKEN = 'test-token';
+  process.env.AGENT_BACKEND = backend;
+  process.env.AGENT_MODEL = model;
+  process.env.GOOSE_MODEL = '';
+  process.env.HIVE_AGENT_SESSION = 'contributor';
+
+  // Keep the relay's task-file write out of the real /tmp path used in prod.
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-test-'));
+
+  // node refuses to require a .sh file with the default extension handlers;
+  // register .sh as JavaScript. This must happen BEFORE require.resolve(), and
+  // the cache must be cleared on every load so each test gets a fresh module
+  // wired to its own execSync stub.
+  Module._extensions['.sh'] = Module._extensions['.js'];
+  for (const key of Object.keys(require.cache)) {
+    if (key.includes('contributor-relay.sh')) delete require.cache[key];
+  }
+  let relay;
+  try {
+    relay = require(RELAY_PATH);
+  } finally {
+    Module._load = origLoad;
+    Module._resolveFilename = origResolve;
+    process.env = prevEnv;
+    process.env.HIVE_RELAY_TEST_MODE = '1';
+  }
+
+  const ws = new stubs.ws();
+  relay.setWs(ws);
+  relay.__commands = commands;
+  relay.__sent = sent;
+  relay.__tmpDir = tmpDir;
+  relay.__tmuxSends = () => commands.filter(c => /send-keys/.test(c));
+  return relay;
+}
+
+function teardown(relay) {
+  try { relay.cleanup(); } catch (_) {}
+}
+
+const tests = [];
+function test(name, fn) { tests.push([name, fn]); }
+
+// ---------------------------------------------------------------------------
+// Bug 1 — the relaunch command must keep the model flag, and must never pass
+// --model to bob.
+// ---------------------------------------------------------------------------
+
+test('relaunch command includes --model for a model-taking backend', () => {
+  const relay = loadRelay({ backend: 'copilot', model: 'gpt-5.6-luna' });
+  try {
+    const cmd = relay.buildLaunchCommand();
+    assert.match(cmd, /--model gpt-5\.6-luna/, `expected model flag in launch command, got: ${cmd}`);
+    assert.match(cmd, /copilot/);
+    assert.match(cmd, /--allow-all/);
+  } finally { teardown(relay); }
+});
+
+test('relaunchCLI() sends the model flag to tmux, not just the bare binary', () => {
+  const relay = loadRelay({ backend: 'copilot', model: 'gpt-5.6-luna' });
+  try {
+    relay.relaunchCLI();
+    const launch = relay.__tmuxSends().find(c => /copilot/.test(c));
+    assert.ok(launch, 'no launch command was sent to tmux');
+    assert.match(launch, /--model gpt-5\.6-luna/,
+      `restart path dropped the model flag (issue #2203 bug 1): ${launch}`);
+  } finally { teardown(relay); }
+});
+
+test('bob never receives --model even when AGENT_MODEL is set', () => {
+  const relay = loadRelay({ backend: 'bob', model: 'some-model' });
+  try {
+    const cmd = relay.buildLaunchCommand();
+    assert.ok(!/--model/.test(cmd),
+      `--model is fatal for bob ("Cannot read properties of undefined (reading 'maxTokens')"), got: ${cmd}`);
+  } finally { teardown(relay); }
+});
+
+test('amazonq and goose are also excluded from --model', () => {
+  for (const backend of ['amazonq', 'goose']) {
+    const relay = loadRelay({ backend, model: 'some-model' });
+    try {
+      assert.ok(!/--model/.test(relay.buildLaunchCommand()), `${backend} should not get --model`);
+    } finally { teardown(relay); }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Bug 2 — a task prompt must never be typed into a pane that is not confirmed
+// ready, or the literal keystrokes land on bash and wedge it in PS2.
+// ---------------------------------------------------------------------------
+
+const PROMPT_WITH_APOSTROPHES =
+  "Work on issue foo/bar#421. Fork it with 'gh repo fork foo/bar --clone=false' first.";
+
+test('task prompt is queued, not typed, while cliReady is false', () => {
+  const relay = loadRelay({ backend: 'copilot' });
+  try {
+    relay.setCliReady(false);
+    relay.setPendingTask(null);
+    relay.tmuxSendKeys(PROMPT_WITH_APOSTROPHES);
+
+    assert.strictEqual(relay.getPendingTask(), PROMPT_WITH_APOSTROPHES,
+      'prompt should have been queued while the CLI was not ready');
+    const literalSends = relay.__tmuxSends().filter(c => / -l /.test(c));
+    assert.deepStrictEqual(literalSends, [],
+      `no literal keystrokes may be sent to an unready pane (issue #2203 bug 2): ${literalSends}`);
+  } finally { teardown(relay); }
+});
+
+test('queued prompt flushes once the CLI is confirmed ready', () => {
+  const relay = loadRelay({ backend: 'copilot' });
+  try {
+    relay.setCliReady(false);
+    relay.setPendingTask(null);
+    relay.tmuxSendKeys(PROMPT_WITH_APOSTROPHES);
+    const queued = relay.getPendingTask();
+    assert.strictEqual(queued, PROMPT_WITH_APOSTROPHES, 'precondition: prompt is queued');
+
+    const before = relay.__tmuxSends().length;
+    relay.setCliReady(true);
+    relay.setPendingTask(queued);
+    relay.flushPendingTask();
+
+    const literalSends = relay.__tmuxSends().slice(before).filter(c => / -l /.test(c));
+    assert.ok(literalSends.some(c => c.includes('gh repo fork')),
+      `prompt should be delivered once the CLI is ready; literal sends: ${JSON.stringify(literalSends)}`);
+    assert.strictEqual(relay.getPendingTask(), null, 'queue should be drained after delivery');
+  } finally { teardown(relay); }
+});
+
+test('task_assign queues rather than typing when the CLI is not ready', () => {
+  const relay = loadRelay({ backend: 'copilot' });
+  try {
+    relay.setCliReady(false);
+    relay.setPendingTask(null);
+    relay.handleMessage(JSON.stringify({
+      type: 'task_assign',
+      task_id: 'ct-1',
+      kind: 'issue',
+      repo: 'foo/bar',
+      number: 421,
+      title: 'something',
+      prompt: PROMPT_WITH_APOSTROPHES,
+    }));
+
+    assert.strictEqual(relay.getPendingTask(), PROMPT_WITH_APOSTROPHES);
+    const literalSends = relay.__tmuxSends().filter(c => / -l /.test(c));
+    assert.deepStrictEqual(literalSends, [], 'task_assign must not type into an unready pane');
+  } finally { teardown(relay); }
+});
+
+test('relaunchCLI() leaves cliReady false until readiness is confirmed', () => {
+  const relay = loadRelay({ backend: 'copilot', cliStates: ['starting'] });
+  try {
+    relay.setCliReady(true);
+    relay.relaunchCLI();
+    assert.strictEqual(relay.getCliReady(), false,
+      'a restart must clear cliReady; it may only be set by the readiness classifier');
+  } finally { teardown(relay); }
+});
+
+test('relaunch clears a wedged bash PS2 line before sending the command', () => {
+  const relay = loadRelay({ backend: 'copilot' });
+  try {
+    relay.relaunchCLI();
+    const sends = relay.__tmuxSends();
+    const cIdx = sends.findIndex(c => /\bC-u\b/.test(c));
+    const launchIdx = sends.findIndex(c => /copilot/.test(c));
+    assert.ok(cIdx >= 0, 'expected a C-u to clear a possibly-wedged shell line');
+    assert.ok(cIdx < launchIdx, 'the wedge recovery must run before the launch command');
+  } finally { teardown(relay); }
+});
+
+// ---------------------------------------------------------------------------
+// Bug 3 — bounded retries, permanent give-up, and the relay staying available.
+// ---------------------------------------------------------------------------
+
+function assignTask(relay, taskId, number = 421) {
+  relay.handleMessage(JSON.stringify({
+    type: 'task_assign',
+    task_id: taskId,
+    kind: 'issue',
+    repo: 'foo/bar',
+    number,
+    title: 'crashy task',
+    prompt: 'do the thing',
+  }));
+}
+
+// Drive the crash path directly: assign, then let the progress tick observe a
+// dead CLI. startProgressReporting() uses a long interval, so instead of
+// waiting we re-enter via repeated assign/crash cycles using fake timers.
+// Independent of the configured value: the cap must be a small finite number.
+// Without this a regression that sets it to Infinity/MAX_SAFE_INTEGER would
+// still satisfy every cap-relative assertion below while restoring the exact
+// infinite loop #2203 reports.
+const CAP_SANITY_LIMIT = 10;
+
+test('the CLI-restart cap is a small finite number', () => {
+  const relay = loadRelay({ backend: 'copilot' });
+  try {
+    const cap = relay.MAX_TASK_CLI_RESTARTS;
+    assert.ok(Number.isInteger(cap) && cap >= 1 && cap <= CAP_SANITY_LIMIT,
+      `MAX_TASK_CLI_RESTARTS must be a small finite integer to bound the retry loop, got: ${cap}`);
+  } finally { teardown(relay); }
+});
+
+test('crash restarts are capped and end in a permanent failure', () => {
+  const relay = loadRelay({ backend: 'copilot', procAlive: false });
+  try {
+    relay.setCliReady(true);
+    const cap = relay.MAX_TASK_CLI_RESTARTS;
+    assert.ok(cap <= CAP_SANITY_LIMIT, 'cap must be small enough to drive here');
+
+    // Simulate the hub reassigning the same work item after each failure.
+    for (let i = 0; i <= cap; i++) {
+      assignTask(relay, `ct-421-${i}`);
+      relay.__crashTick();
+    }
+
+    const failures = relay.__sent.filter(m => m.type === 'task_failed');
+    assert.ok(failures.length >= cap + 1, `expected at least ${cap + 1} failures, got ${failures.length}`);
+
+    const permanent = failures.filter(m => m.permanent === true);
+    assert.ok(permanent.length >= 1,
+      'after the retry cap the relay must report a PERMANENT failure so the hub reassigns elsewhere');
+    assert.match(permanent[0].reason, /giving up/i);
+
+    // And the non-permanent ones stop: no unbounded retrying.
+    const transient = failures.filter(m => !m.permanent);
+    assert.ok(transient.length <= cap,
+      `retries must be bounded by MAX_TASK_CLI_RESTARTS=${cap}, saw ${transient.length}`);
+  } finally { teardown(relay); }
+});
+
+test('a reassignment of a given-up task is rejected, not retried', () => {
+  const relay = loadRelay({ backend: 'copilot', procAlive: false });
+  try {
+    relay.setCliReady(true);
+    assert.ok(relay.MAX_TASK_CLI_RESTARTS <= CAP_SANITY_LIMIT, 'cap must be small enough to drive here');
+    for (let i = 0; i <= relay.MAX_TASK_CLI_RESTARTS; i++) {
+      assignTask(relay, `ct-421-${i}`);
+      relay.__crashTick();
+    }
+    const before = relay.__sent.length;
+    assignTask(relay, 'ct-421-again');
+
+    assert.strictEqual(relay.getCurrentTask(), null,
+      'a given-up work item must not be accepted again');
+    const after = relay.__sent.slice(before);
+    assert.ok(after.some(m => m.type === 'task_failed' && m.permanent),
+      'reassignment of a given-up task should be refused with a permanent failure');
+    assert.ok(after.some(m => m.type === 'ready'),
+      'the relay must announce it is still ready for other work');
+  } finally { teardown(relay); }
+});
+
+test('after give-up a DIFFERENT task is still accepted', () => {
+  const relay = loadRelay({ backend: 'copilot', procAlive: false });
+  try {
+    relay.setCliReady(true);
+    assert.ok(relay.MAX_TASK_CLI_RESTARTS <= CAP_SANITY_LIMIT, 'cap must be small enough to drive here');
+    for (let i = 0; i <= relay.MAX_TASK_CLI_RESTARTS; i++) {
+      assignTask(relay, `ct-421-${i}`);
+      relay.__crashTick();
+    }
+    assert.strictEqual(relay.getCurrentTask(), null, 'precondition: no active task after give-up');
+
+    relay.setCliReady(true);
+    assignTask(relay, 'ct-999-0', 999);
+    const task = relay.getCurrentTask();
+    assert.ok(task, 'a poisoned task must not wedge the whole contributor');
+    assert.strictEqual(task.number, 999);
+  } finally { teardown(relay); }
+});
+
+test('restart backoff grows and is capped', () => {
+  const relay = loadRelay({ backend: 'copilot' });
+  try {
+    const b1 = relay.restartBackoffMs(1);
+    const b2 = relay.restartBackoffMs(2);
+    const b3 = relay.restartBackoffMs(3);
+    assert.ok(b2 > b1 && b3 > b2, `backoff must grow: ${b1}, ${b2}, ${b3}`);
+    assert.strictEqual(relay.restartBackoffMs(50), relay.restartBackoffMs(60),
+      'backoff must saturate at the cap');
+  } finally { teardown(relay); }
+});
+
+// ---------------------------------------------------------------------------
+
+let failed = 0;
+// RELAY_TEST_ONLY=<substring> runs a single test, for debugging in isolation.
+const only = process.env.RELAY_TEST_ONLY;
+for (const [name, fn] of only ? tests.filter(([n]) => n.includes(only)) : tests) {
+  try {
+    fn();
+    console.log(`ok   ${name}`);
+  } catch (e) {
+    failed++;
+    console.error(`FAIL ${name}`);
+    console.error(`     ${e.message}`);
+  }
+}
+console.log(`\n${tests.length - failed}/${tests.length} passed`);
+// waitForCLI() schedules polling timers that would otherwise keep the event
+// loop alive well past the last assertion; exit explicitly.
+process.exit(failed ? 1 : 0);

--- a/v2/cmd/hive/ghapp_banner_verdict_test.go
+++ b/v2/cmd/hive/ghapp_banner_verdict_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// verdictTestKeyBits keeps key generation fast; these keys never leave the test.
+const verdictTestKeyBits = 2048
+
+// verdictTestAppID / verdictTestInstallationID are arbitrary non-placeholder
+// identifiers — they only need to be non-zero for NewAppAuth to accept them.
+const (
+	verdictTestAppID          = 5686
+	verdictTestInstallationID = 42980
+)
+
+func verdictTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// verdictTestAuth builds a real AppAuth backed by a freshly generated key on
+// disk and pointed at a stub API, so classifyGitHubAppFailure exercises the
+// same code path production does.
+func verdictTestAuth(t *testing.T, apiURL string) *github.AppAuth {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, verdictTestKeyBits)
+	if err != nil {
+		t.Fatalf("generating test key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	keyPath := filepath.Join(t.TempDir(), "app.pem")
+	if err := os.WriteFile(keyPath, pemBytes, 0o600); err != nil {
+		t.Fatalf("writing test key: %v", err)
+	}
+	// diagnoseGitHubApp pre-flights the well-known spoke key paths and reports
+	// key-missing without any API call when none holds content. Point one of
+	// them at the real key so these tests exercise the API classification the
+	// verdict actually depends on. Restored via t.Cleanup.
+	origProvisioned, origPVC := spokeProvisionedAppKeyPath, spokeAppKeyPath
+	spokeProvisionedAppKeyPath, spokeAppKeyPath = keyPath, keyPath
+	t.Cleanup(func() {
+		spokeProvisionedAppKeyPath, spokeAppKeyPath = origProvisioned, origPVC
+	})
+	auth, err := github.NewAppAuth(verdictTestAppID, verdictTestInstallationID, keyPath, verdictTestLogger(), apiURL)
+	if err != nil {
+		t.Fatalf("NewAppAuth: %v", err)
+	}
+	return auth
+}
+
+// TestClassifyGitHubAppFailure_UnknownDoesNotRaiseBanner is the regression test
+// for the false banner: a hive whose first App probe fails for a reason we
+// cannot classify (the API never answered) must NOT be told its App is broken.
+// The boot path used to raise the banner unconditionally in this situation and
+// then never lower it, while the Re-check button — running the identical probe
+// — treated the same evidence as success and cleared it. That asymmetry is the
+// entire "shows on load, disappears on Re-check" report.
+func TestClassifyGitHubAppFailure_UnknownDoesNotRaiseBanner(t *testing.T) {
+	// Port 1 is reserved and refuses connections, so no status is ever
+	// returned and classification is genuinely inconclusive.
+	auth := verdictTestAuth(t, "http://127.0.0.1:1")
+
+	raise, msg, state := classifyGitHubAppFailure(context.Background(), auth, "katamari", verdictTestLogger())
+	if raise {
+		t.Error("an unreachable GitHub API must not raise the App banner")
+	}
+	if state != github.AppStateUnknown {
+		t.Errorf("state = %s, want unknown when GitHub never answered", state)
+	}
+	if msg != "" {
+		t.Errorf("msg = %q, want empty — we must not accuse anyone without a verdict", msg)
+	}
+	if state.OperatorActionable() || state.UserActionable() {
+		t.Error("an unclassifiable failure must not be reported as anyone's fault")
+	}
+}
+
+// TestClassifyGitHubAppFailure_RateLimitDoesNotRaiseBanner — GitHub answers a
+// rate limit with 403, the same status a wrong installation returns. It is
+// transient and must never latch a credential banner.
+func TestClassifyGitHubAppFailure_RateLimitDoesNotRaiseBanner(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Limit", "60")
+		w.Header().Set("X-RateLimit-Reset", "9999999999")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "API rate limit exceeded"})
+	}))
+	defer srv.Close()
+
+	raise, _, state := classifyGitHubAppFailure(context.Background(), verdictTestAuth(t, srv.URL), "katamari", verdictTestLogger())
+	if raise {
+		t.Error("a rate-limited probe must not raise the App banner")
+	}
+	if state != github.AppStateUnknown {
+		t.Errorf("state = %s, want unknown for a rate-limited 403", state)
+	}
+}
+
+// TestClassifyGitHubAppFailure_HealthyAppDoesNotRaiseBanner — the case the boot
+// path got wrong. EnsureAdvisoryIssue can fail for repo-scoped reasons (the
+// repo is archived, missing, or the issue write raced a permission refresh)
+// while App auth itself is perfectly fine. Boot raised the banner on the error
+// string alone; the verdict must come from the App probe.
+func TestClassifyGitHubAppFailure_HealthyAppDoesNotRaiseBanner(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":          verdictTestInstallationID,
+			"account":     map[string]any{"login": "katamari"},
+			"permissions": map[string]any{"issues": "write"},
+		})
+	}))
+	defer srv.Close()
+
+	raise, msg, state := classifyGitHubAppFailure(context.Background(), verdictTestAuth(t, srv.URL), "katamari", verdictTestLogger())
+	if raise {
+		t.Errorf("a healthy App must not raise the banner (state=%s, msg=%q)", state, msg)
+	}
+	if state != github.AppStateOK {
+		t.Errorf("state = %s, want ok", state)
+	}
+}
+
+// TestClassifyGitHubAppFailure_GenuineFailureStillRaises guards against the fix
+// silencing real problems: a 404 means the App truly is not installed, and that
+// banner must still appear.
+func TestClassifyGitHubAppFailure_GenuineFailureStillRaises(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "Not Found"})
+	}))
+	defer srv.Close()
+
+	raise, msg, state := classifyGitHubAppFailure(context.Background(), verdictTestAuth(t, srv.URL), "katamari", verdictTestLogger())
+	if !raise {
+		t.Error("a genuinely uninstalled App must still raise the banner")
+	}
+	if state != github.AppStateNotInstalled {
+		t.Errorf("state = %s, want not-installed", state)
+	}
+	if msg == "" {
+		t.Error("a raised banner must carry copy explaining what to fix")
+	}
+	if !state.UserActionable() {
+		t.Error("not-installed is the user's to fix")
+	}
+}
+
+// TestClassifyGitHubAppFailure_OperatorFaultIsNotBlamedOnUser — a 401 means the
+// key does not belong to the App. Only the operator can fix that, and #2224
+// exists so the user is never told to reinstall in this case.
+func TestClassifyGitHubAppFailure_OperatorFaultIsNotBlamedOnUser(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "A JSON web token could not be decoded"})
+	}))
+	defer srv.Close()
+
+	raise, _, state := classifyGitHubAppFailure(context.Background(), verdictTestAuth(t, srv.URL), "katamari", verdictTestLogger())
+	if !raise {
+		t.Error("an invalid key is a real fault and must raise the banner")
+	}
+	if state != github.AppStateKeyInvalid {
+		t.Errorf("state = %s, want key-invalid", state)
+	}
+	if !state.OperatorActionable() || state.UserActionable() {
+		t.Error("key-invalid is the operator's fault and must never be blamed on the user")
+	}
+}
+
+// TestIsGitHubRateLimitText covers the one place error-string matching survives
+// — where it can only ever cause an extra correct classification, never an
+// accusation.
+func TestIsGitHubRateLimitText(t *testing.T) {
+	if isGitHubRateLimitText(nil) {
+		t.Error("nil is not a rate limit")
+	}
+	for _, s := range []string{"API rate limit exceeded", "secondary RATE LIMIT hit"} {
+		if !isGitHubRateLimitText(errString(s)) {
+			t.Errorf("%q should be detected as a rate limit", s)
+		}
+	}
+	if isGitHubRateLimitText(errString("403 Resource not accessible by integration")) {
+		t.Error("a plain 403 is not a rate limit")
+	}
+}
+
+// errString is a minimal error carrying exactly the message given.
+type errString string
+
+func (e errString) Error() string { return string(e) }

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2607,7 +2607,25 @@ func main() {
 			// possible. The hub keeps sending this every beat until we report the
 			// matching project back, so an idempotent no-op when already matched
 			// is expected and cheap.
-			if pc == nil || pc.Org == "" {
+			if pc == nil {
+				return
+			}
+			// A URL-only push (org empty, dashboard_url set) delivers the vanity
+			// dashboard URL to an already-claimed hive whose meta project is stale/
+			// empty on the hub — we must still adopt+report it, or the hub keeps
+			// showing the raw placeholder host forever. Handle it BEFORE the
+			// org-empty bail below, which exists so an empty project never blanks a
+			// working config: with no org there is nothing to reconcile except the
+			// URL, so adopt it, persist, and return without touching the project.
+			if pc.Org == "" {
+				if pc.DashboardURL != "" && cfg.Hub.DashboardURL != pc.DashboardURL {
+					logger.Info("adopting vanity dashboard URL from hub heartbeat (url-only push)",
+						"was", cfg.Hub.DashboardURL, "now", pc.DashboardURL)
+					cfg.Hub.DashboardURL = pc.DashboardURL
+					if err := cfg.Save(); err != nil {
+						logger.Error("failed to save adopted vanity dashboard URL", "error", err)
+					}
+				}
 				return
 			}
 			curACMM := 0

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2048,32 +2048,65 @@ func main() {
 	dashSrv.AuditLog("system", "hive_restart",
 		fmt.Sprintf("build=%s version=%s; restoring %d paused agent(s)", gitShort, "3.0.0", pausedCount), "")
 
-	const agentLaunchDelaySec = 15
-	agentIndex := 0
-	for name, ac := range cfg.EnabledAgents() {
-		isOnDemand := ac.OnDemand || onDemandFromPack[name]
-		if isOnDemand {
-			logger.Info("skipping on-demand agent at startup", "name", name)
-			continue
-		}
-		if agentIndex > 0 {
-			logger.Info("staggering agent launch", "name", name, "delay_sec", agentLaunchDelaySec)
-			time.Sleep(time.Duration(agentLaunchDelaySec) * time.Second)
-		}
-		logger.Info("audit: starting agent", "name", name, "trigger", "startup")
-		if err := agentMgr.Start(ctx, name); err != nil {
-			logger.Warn("failed to start agent", "name", name, "error", err)
-		} else {
-			// Surface whether a persisted operator pause was honored on this
-			// restart, so the audit log shows pause state survived (or didn't).
-			detail := "trigger=startup"
-			if ac.Paused {
-				detail = "trigger=startup; restored paused (persisted)"
+	// Mark the dashboard READY as soon as the HTTP server can serve requests —
+	// which is NOW: config is loaded, GitHub client/App auth are wired, the
+	// dashboard deps are set, and the listener (go dashSrv.Start() above) is up.
+	// None of /api/*, /sso, /open, /api/livez or /api/health depend on the agent
+	// fleet being up; the frontend already handles agents appearing over time.
+	//
+	// This MUST precede the staggered agent-launch loop below. That loop sleeps
+	// ~15s per agent (× the whole fleet = several minutes) and previously ran
+	// BEFORE MarkReady, so /api/livez returned 503 "starting" for the entire
+	// launch window. The liveness probe (period 30s × failureThreshold 3 ≈ 90s)
+	// then SIGKILLed the container (exit 137) before readiness was ever reached
+	// on cold start, and rolling upgrades left the Service with no Ready endpoint
+	// for minutes → 503s on /open and /sso. Flipping ready here makes the pod
+	// Ready in seconds and moves the fleet spin-up entirely off the critical path.
+	dashSrv.MarkReady()
+
+	// Launch the persistent (non-on-demand) agents in the BACKGROUND so the
+	// staggered start no longer gates pod readiness. The loop honors ctx: on
+	// shutdown the ctx-aware stagger returns immediately instead of leaking a
+	// goroutine parked in a bare time.Sleep.
+	go func() {
+		const agentLaunchDelaySec = 15
+		agentIndex := 0
+		for name, ac := range cfg.EnabledAgents() {
+			isOnDemand := ac.OnDemand || onDemandFromPack[name]
+			if isOnDemand {
+				logger.Info("skipping on-demand agent at startup", "name", name)
+				continue
 			}
-			dashSrv.AuditLog("system", "agent_start", detail, name)
+			if agentIndex > 0 {
+				logger.Info("staggering agent launch", "name", name, "delay_sec", agentLaunchDelaySec)
+				select {
+				case <-time.After(time.Duration(agentLaunchDelaySec) * time.Second):
+				case <-ctx.Done():
+					logger.Info("aborting staggered agent launch: shutting down")
+					return
+				}
+			}
+			// Bail before starting another agent if we are already shutting down,
+			// so a SIGTERM during the launch window doesn't spawn fresh processes.
+			if ctx.Err() != nil {
+				logger.Info("aborting staggered agent launch: shutting down")
+				return
+			}
+			logger.Info("audit: starting agent", "name", name, "trigger", "startup")
+			if err := agentMgr.Start(ctx, name); err != nil {
+				logger.Warn("failed to start agent", "name", name, "error", err)
+			} else {
+				// Surface whether a persisted operator pause was honored on this
+				// restart, so the audit log shows pause state survived (or didn't).
+				detail := "trigger=startup"
+				if ac.Paused {
+					detail = "trigger=startup; restored paused (persisted)"
+				}
+				dashSrv.AuditLog("system", "agent_start", detail, name)
+			}
+			agentIndex++
 		}
-		agentIndex++
-	}
+	}()
 
 	// Start hub heartbeat push if configured (env var or config)
 	hubURL := cfg.Hub.URL
@@ -2727,7 +2760,11 @@ func main() {
 		logger.Info("fast agent status enabled", "interval_seconds", cfg.Dashboard.AgentPollIntervalS)
 	}
 
-	dashSrv.MarkReady()
+	// NOTE: dashSrv.MarkReady() was previously HERE, after the staggered agent
+	// launch and the heartbeat/trajectory/ticker setup. It has been moved to
+	// immediately after the HTTP listener starts (before the agent-launch loop),
+	// so the pod becomes Ready in seconds instead of minutes. See the MarkReady
+	// call and comment above the agent-launch goroutine.
 
 	const cliStartupDelay = 10 * time.Second
 	logger.Info("waiting for CLI startup before first eval", "delay", cliStartupDelay)

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -513,9 +513,23 @@ func main() {
 	// previous version.
 	const upgradeMarkerStartupPath = "/data/upgrade-requested"
 	if markerData, err := os.ReadFile(upgradeMarkerStartupPath); err == nil {
-		if !strings.Contains(string(markerData), fmt.Sprintf(`"current_sha":"%s"`, gitShort)) {
+		m := parseUpgradeMarker(markerData)
+		if m.CurrentSHA != gitShort {
+			// We booted on a different SHA than the one that requested the
+			// upgrade: it landed. Drop the marker so the attempt budget resets.
 			os.Remove(upgradeMarkerStartupPath)
-			logger.Info("cleared stale upgrade marker (SHA changed)", "current", gitShort)
+			logger.Info("upgrade landed, cleared marker",
+				"current", gitShort, "previous", m.CurrentSHA, "target", m.TargetSHA)
+		} else {
+			// Same SHA as the attempt that ran before this boot: the image never
+			// changed, so that attempt FAILED. Say so at startup — previously
+			// this restart looked completely routine in the logs.
+			logger.Error("previous self-upgrade attempt did not land (still on the same image)",
+				"current", gitShort,
+				"target", m.TargetSHA,
+				"attempts", m.Attempts,
+				"last_error", m.LastError,
+			)
 		}
 	}
 
@@ -2336,6 +2350,10 @@ func main() {
 		}, heartbeatSendInterval, logger, hub.UpgradeCallback(func(targetSHA string) {
 			const upgradeMarkerPath = "/data/upgrade-requested"
 
+			// attemptCount carries the number of PREVIOUS failed attempts for this
+			// (current_sha → target_sha) pair, read from the marker below.
+			attemptCount := 0
+
 			// Never self-upgrade to the commit we are already running. The hub
 			// may instruct an upgrade to a short SHA that is a prefix of our
 			// full gitShort (or vice-versa); treating that as "behind" caused a
@@ -2353,17 +2371,59 @@ func main() {
 				}
 			}
 
-			// If a previous process already attempted an upgrade and we booted
-			// with the same git hash, the image tag didn't actually change.
-			// Skip to avoid an infinite restart loop.
+			// A previous process attempted an upgrade and we booted with the same
+			// git hash, so the image did not actually change: the attempt FAILED.
+			// Back off rather than retrying instantly (that was a crash-loop), but
+			// do NOT latch forever — "image unchanged" is the signature of a failed
+			// upgrade, not a reason to stop trying. The latch is keyed on
+			// (current_sha → target_sha) and bounded to selfUpgradeMaxAttempts, so a
+			// NEW target always gets a fresh budget and a transient failure (an RBAC
+			// Role that showed up late, a registry blip) still converges.
 			if markerData, err := os.ReadFile(upgradeMarkerPath); err == nil {
-				if strings.Contains(string(markerData), fmt.Sprintf(`"current_sha":"%s"`, gitShort)) {
-					logger.Info("self-upgrade skipped: already attempted from this SHA (image unchanged)",
+				m := parseUpgradeMarker(markerData)
+				if m.CurrentSHA == gitShort && sameUpgradeTarget(m.TargetSHA, targetSHA) {
+					if m.Attempts >= selfUpgradeMaxAttempts {
+						// Terminal: report it LOUDLY and tell the hub, so the UI stops
+						// claiming "Upgrading" forever and a human sees the real cause.
+						logger.Error("self-upgrade FAILED: giving up after repeated attempts (image never changed)",
+							"target", targetSHA,
+							"current", gitShort,
+							"attempts", m.Attempts,
+							"max_attempts", selfUpgradeMaxAttempts,
+							"last_error", m.LastError,
+							"hint", "the spoke must be able to get/patch its own Deployment; check the hive-self-upgrade Role/RoleBinding in this namespace",
+						)
+						hub.ReportUpgradeFailure(hubURL, cfg.HiveID, targetSHA, gitShort,
+							fmt.Sprintf("self-upgrade failed after %d attempts: %s", m.Attempts, m.LastError), logger)
+						return
+					}
+					// Exponential backoff between attempts so a hard failure does not
+					// spin every heartbeat while a recoverable one still retries.
+					backoff := selfUpgradeBaseBackoff << (m.Attempts - 1)
+					if backoff > selfUpgradeMaxBackoff {
+						backoff = selfUpgradeMaxBackoff
+					}
+					if since := time.Since(m.RequestedAt); since < backoff {
+						logger.Warn("self-upgrade retry deferred: backing off after a failed attempt",
+							"target", targetSHA,
+							"current", gitShort,
+							"attempts", m.Attempts,
+							"retry_in", (backoff - since).Round(time.Second),
+							"last_error", m.LastError,
+						)
+						return
+					}
+					logger.Warn("self-upgrade retrying after a failed attempt (image unchanged)",
 						"target", targetSHA,
 						"current", gitShort,
+						"attempt", m.Attempts+1,
+						"max_attempts", selfUpgradeMaxAttempts,
+						"last_error", m.LastError,
 					)
+					attemptCount = m.Attempts
+				} else {
+					// Different SHA or a different target — the old marker is stale.
 					os.Remove(upgradeMarkerPath)
-					return
 				}
 			}
 
@@ -2380,11 +2440,15 @@ func main() {
 				return
 			}
 
-			marker := fmt.Sprintf(`{"target_sha":"%s","current_sha":"%s","requested_at":"%s"}`,
-				targetSHA, gitShort, time.Now().UTC().Format(time.RFC3339))
-			if err := os.WriteFile(upgradeMarkerPath, []byte(marker), 0o644); err != nil {
-				logger.Warn("failed to write upgrade marker", "path", upgradeMarkerPath, "error", err)
-			}
+			// Record the attempt BEFORE acting: if the process dies mid-upgrade the
+			// next boot must still see an incremented count, otherwise a crash loop
+			// would retry without ever exhausting the budget.
+			writeUpgradeMarker(upgradeMarkerPath, upgradeMarker{
+				TargetSHA:   targetSHA,
+				CurrentSHA:  gitShort,
+				RequestedAt: time.Now().UTC(),
+				Attempts:    attemptCount + 1,
+			}, logger)
 
 			logger.Info("self-upgrade triggered: sending upgrading heartbeat then exiting",
 				"current", gitShort,
@@ -2431,14 +2495,32 @@ func main() {
 			if err != nil {
 				logger.Warn("pinned-image upgrade failed, falling back to rolling restart",
 					"target", targetSHA, "error", err)
+				recordUpgradeError(upgradeMarkerPath, err, logger)
 				needsRestart = true
 			}
 			if needsRestart {
 				if err := hub.RolloutRestartSelf(logger); err != nil {
-					logger.Warn("rolling restart failed, falling back to os.Exit",
+					// This is the wedge. os.Exit here restarts the pod onto the
+					// SAME image, so the upgrade silently never lands. It is an
+					// ERROR, not a Warn, and the cause (typically a 403 because
+					// the spoke lacks patch on its own Deployment) must be both
+					// persisted for the next attempt and reported to the hub so
+					// the UI stops showing a permanent "Upgrading".
+					logger.Error("self-upgrade FAILED: could not patch own Deployment, restarting onto the same image",
+						"target", targetSHA,
+						"current", gitShort,
 						"error", err,
+						"hint", "grant get/patch on deployments/hive in this namespace (hive-self-upgrade Role/RoleBinding)",
 					)
-					os.Exit(0)
+					recordUpgradeError(upgradeMarkerPath, err, logger)
+					hub.ReportUpgradeFailure(hubURL, cfg.HiveID, targetSHA, gitShort, err.Error(), logger)
+					// Exit NON-ZERO. Exiting 0 on a failed upgrade told Kubernetes
+					// the process had completed successfully, so the restart looked
+					// routine and nothing — not the pod's exit code, not an event,
+					// not a probe — recorded that an upgrade had just failed. A
+					// non-zero code makes the failure visible in the pod's
+					// lastState.terminated and in `kubectl describe`.
+					os.Exit(selfUpgradeFailureExitCode)
 				}
 			}
 			// Rolling restart initiated — K8s will start a new pod and
@@ -3581,6 +3663,88 @@ func convertKnowledgeLayers(cfgLayers []config.KnowledgeLayer) []knowledge.Layer
 const hiveIDFilePath = "/data/hive-id"
 
 // loadOrGenerateHiveID reads the Hive ID from disk, or generates and persists a new one.
+const (
+	// selfUpgradeMaxAttempts bounds how many times a spoke retries an upgrade
+	// that keeps leaving the image unchanged. Bounded rather than unlimited so a
+	// genuinely broken hive (e.g. missing RBAC) stops thrashing its pod, and
+	// bounded rather than "never again" so a transient failure still converges.
+	selfUpgradeMaxAttempts = 5
+	// selfUpgradeBaseBackoff is the delay before retry #2; it doubles per
+	// attempt up to selfUpgradeMaxBackoff.
+	selfUpgradeBaseBackoff = 2 * time.Minute
+	// selfUpgradeMaxBackoff caps the exponential backoff between retries.
+	selfUpgradeMaxBackoff = 30 * time.Minute
+	// selfUpgradeFailureExitCode marks a process exit caused by a FAILED
+	// self-upgrade. Distinct from 0 so the failure is visible in the container's
+	// termination state instead of looking like a clean shutdown.
+	selfUpgradeFailureExitCode = 17
+)
+
+// upgradeMarker is the on-PVC record at /data/upgrade-requested. It survives
+// pod restarts (that is the whole point: the process exits as part of an
+// upgrade), so it is the only place attempt bookkeeping can live.
+type upgradeMarker struct {
+	TargetSHA   string    `json:"target_sha"`
+	CurrentSHA  string    `json:"current_sha"`
+	RequestedAt time.Time `json:"requested_at"`
+	Attempts    int       `json:"attempts"`
+	LastError   string    `json:"last_error,omitempty"`
+}
+
+// parseUpgradeMarker decodes a marker, tolerating the legacy format that had no
+// attempts/last_error fields. A legacy marker counts as one prior attempt so an
+// already-wedged hive gets retries under the new budget instead of being
+// treated as fresh.
+func parseUpgradeMarker(data []byte) upgradeMarker {
+	var m upgradeMarker
+	if err := json.Unmarshal(data, &m); err != nil {
+		return upgradeMarker{}
+	}
+	if m.Attempts < 1 {
+		m.Attempts = 1
+	}
+	return m
+}
+
+// sameUpgradeTarget reports whether two target SHAs refer to the same commit,
+// tolerating short/full SHA length mismatch the way the hub's sameCommit does.
+// A DIFFERENT target must reset the attempt budget, so this comparison is what
+// keeps the latch from outliving the upgrade it was created for.
+func sameUpgradeTarget(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	return strings.EqualFold(a[:n], b[:n])
+}
+
+func writeUpgradeMarker(path string, m upgradeMarker, logger *slog.Logger) {
+	data, err := json.Marshal(m)
+	if err != nil {
+		logger.Warn("failed to encode upgrade marker", "error", err)
+		return
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		logger.Warn("failed to write upgrade marker", "path", path, "error", err)
+	}
+}
+
+// recordUpgradeError annotates the existing marker with the cause of the failed
+// attempt so the NEXT boot can log why the previous one did not land — without
+// it the reason dies with the process and the failure is invisible.
+func recordUpgradeError(path string, upgradeErr error, logger *slog.Logger) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	m := parseUpgradeMarker(data)
+	m.LastError = upgradeErr.Error()
+	writeUpgradeMarker(path, m, logger)
+}
+
 func loadOrGenerateHiveID(logger *slog.Logger) string {
 	if envID := os.Getenv("HIVE_ID"); envID != "" {
 		if err := os.WriteFile(hiveIDFilePath, []byte(envID+"\n"), 0o644); err == nil {

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2762,8 +2762,9 @@ func main() {
 				"on_divergence", cfg.Governor.Trajectory.OnDivergence)
 		}
 	}
-	// Reconcile the not-configured alert from actual state (raises only when
-	// enabled AND no reviewer resolves; clears when off or configured).
+	// Clear any legacy "not configured" banner alert persisted by an older
+	// build. The half-configured state is shown inline in Governor Config →
+	// General, not in the top banner.
 	dashSrv.ReconcileTrajectoryAlert(&cfg.Governor)
 
 	logger.Info("entering governor loop", "interval_seconds", cfg.Governor.EvalIntervalS)

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -737,21 +737,29 @@ func main() {
 				// GitHub returns 403 for rate limiting too — a transient
 				// condition that must not raise the "App Not Installed"
 				// banner (matches the guard on the repo-change path).
-				if strings.Contains(err.Error(), "rate limit") {
+				if isGitHubRateLimitText(err) {
 					logger.Warn("GitHub API rate limit hit during advisory issue ensure", "repo", primaryRepo)
-				} else if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "401") {
-					githubAppRequired = true
-					// Classify WHY before the banner renders. A bare 401/403
-					// here used to become "GitHub App Not Installed", which is
-					// wrong — and actively misleading — when the real cause is
-					// a key the operator has not delivered. Classification is
-					// on the live API response, and a missing key file
-					// short-circuits without any API call.
-					githubAppDiag, githubAppState = diagnoseGitHubApp(ctx, ghClient.AppAuth(), cfg.Project.Org)
-					logger.Warn("GitHub App authentication failed at startup",
-						"state", githubAppState.String(),
-						"operator_actionable", githubAppState.OperatorActionable(),
-						"error", err)
+				} else {
+					// Do NOT decide from the error string. This call site used
+					// to raise the banner on a substring match for "403"/"401"
+					// and set githubAppRequired=true BEFORE classifying, then
+					// never lower it again when classification came back OK or
+					// inconclusive — which is why the banner showed on boot and
+					// vanished on the first Re-check with nothing fixed.
+					// classifyGitHubAppFailure is the same verdict Re-check
+					// uses, and it declines to raise on AppStateUnknown.
+					raise, diag, state := classifyGitHubAppFailure(ctx, ghClient.AppAuth(), cfg.Project.Org, logger)
+					if raise {
+						githubAppRequired = true
+						githubAppDiag, githubAppState = diag, state
+						logger.Warn("GitHub App authentication failed at startup",
+							"state", state.String(),
+							"operator_actionable", state.OperatorActionable(),
+							"error", err)
+					} else {
+						logger.Warn("advisory issue ensure failed but GitHub App auth verified healthy — not raising the App banner",
+							"repo", primaryRepo, "state", state.String(), "error", err)
+					}
 				}
 			} else {
 				advisoryIssues[primaryRepo] = num
@@ -1493,10 +1501,25 @@ func main() {
 				num, err := ghClient.EnsureAdvisoryIssue(ctx, newPrimaryRepo)
 				if err != nil {
 					logger.Error("failed to create advisory issue on new primary repo", "repo", newPrimaryRepo, "error", err)
-					if strings.Contains(err.Error(), "rate limit") {
+					if isGitHubRateLimitText(err) {
 						logger.Warn("GitHub API rate limit hit during advisory issue creation", "repo", newPrimaryRepo)
-					} else if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "401") {
-						dashSrv.SetGitHubAppRequired(true)
+					} else {
+						// #2224 replaced error-string classification everywhere
+						// else but missed this site, which raised the banner on
+						// a bare "403"/"401" substring and recorded no state at
+						// all — so the UI fell back to "App Not Installed" even
+						// for an operator-side key fault. Classify properly.
+						raise, diag, state := classifyGitHubAppFailure(ctx, ghClient.AppAuth(), cfg.Project.Org, logger)
+						if raise {
+							dashSrv.SetGitHubAppRequired(true)
+							dashSrv.SetGitHubAppState(state.String())
+							if diag != "" {
+								dashSrv.SetGitHubAppPermIssue(diag)
+							}
+							logger.Warn("GitHub App authentication failed creating advisory issue",
+								"repo", newPrimaryRepo, "state", state.String(),
+								"operator_actionable", state.OperatorActionable())
+						}
 					}
 				} else {
 					advisoryIssues[newPrimaryRepo] = num
@@ -1586,7 +1609,12 @@ func main() {
 				// this is the exact case rediscovery exists for. Cached by TTL,
 				// so a repeated re-check does not re-hit the API.
 				healGitHubAppInstallation(ctx, ghClient.AppAuth(), cfg, logger)
-				if diag, state := diagnoseGitHubApp(ctx, ghClient.AppAuth(), cfg.Project.Org); diag != "" {
+				// Shared verdict with the boot and advisory-digest paths. Re-check
+				// previously branched on `diag != ""` while boot branched on the
+				// error string, which is how the two came to disagree about the
+				// same hive; routing both through classifyGitHubAppFailure means
+				// they cannot drift again.
+				if raise, diag, state := classifyGitHubAppFailure(ctx, ghClient.AppAuth(), cfg.Project.Org, logger); raise {
 					dashSrv.SetGitHubAppPermIssue(diag)
 					dashSrv.SetGitHubAppState(state.String())
 					logger.Warn("github app recheck: app detected but write not verified",
@@ -2973,6 +3001,87 @@ func diagnoseGitHubAppWrite(ctx context.Context, appAuth *github.AppAuth, expect
 	return msg
 }
 
+// githubRateLimitErrText is the substring GitHub's client surfaces on a rate or
+// abuse limit. Matching text is acceptable ONLY here: a rate limit is a reason
+// to skip classification entirely, never a reason to accuse anyone of anything,
+// so a false negative costs one extra (correct) classification round-trip.
+const githubRateLimitErrText = "rate limit"
+
+// isGitHubRateLimitText reports whether an error looks like a GitHub rate limit.
+func isGitHubRateLimitText(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), githubRateLimitErrText)
+}
+
+// githubAppBannerAttempts is how many times classifyGitHubAppFailure probes
+// before accepting an unclassifiable (AppStateUnknown) verdict. A cold start
+// races the cluster's DNS/egress-proxy readiness, so the FIRST App call a pod
+// makes is the one most likely to fail for reasons that have nothing to do
+// with the App. One retry converts that transient into a correct verdict.
+const githubAppBannerAttempts = 2
+
+// githubAppBannerRetryDelay spaces those attempts. Short enough not to stall
+// boot, long enough for an egress proxy or DNS cache to come up.
+const githubAppBannerRetryDelay = 3 * time.Second
+
+// classifyGitHubAppFailure is the SINGLE decision point for "should the GitHub
+// App banner be raised?" — used by the boot path, the advisory-digest path and
+// the manual Re-check button alike, so those three can never again disagree
+// about the same hive.
+//
+// It exists because they DID disagree. The boot path used to raise the banner
+// on a substring match for "403"/"401" in a formatted error string (the exact
+// pattern #2224 replaced), set githubAppRequired=true UNCONDITIONALLY, and
+// then classify — never lowering the flag again when classification came back
+// healthy or inconclusive. Re-check ran the very same diagnoseGitHubApp probe
+// but treated an empty diagnosis as success and cleared the banner. Same
+// evidence, opposite conclusion: the banner appeared on every cold start whose
+// first advisory-issue call blipped, and vanished the moment the user clicked
+// Re-check without anything having been fixed.
+//
+// Two rules make the verdict trustworthy:
+//
+//  1. Only a state that is genuinely actionable raises the banner. AppStateOK
+//     obviously does not, and neither does AppStateUnknown — #2224 defines it
+//     as "we could not reach a conclusion", and escalating on it is precisely
+//     the false accusation that design was meant to prevent.
+//  2. An unknown verdict is retried before it is accepted, so a transient
+//     startup network failure is not mistaken for a definitive one.
+//
+// Returns raise=false with an empty message when the App is fine or when we
+// simply cannot tell.
+func classifyGitHubAppFailure(ctx context.Context, appAuth *github.AppAuth, expectedOwner string, logger *slog.Logger) (raise bool, msg string, state github.AppAuthState) {
+	for attempt := 1; attempt <= githubAppBannerAttempts; attempt++ {
+		msg, state = diagnoseGitHubApp(ctx, appAuth, expectedOwner)
+		if state != github.AppStateUnknown {
+			break
+		}
+		if attempt < githubAppBannerAttempts {
+			logger.Debug("github app classification inconclusive — retrying before accepting a verdict",
+				"attempt", attempt, "owner", expectedOwner)
+			select {
+			case <-ctx.Done():
+				return false, "", github.AppStateUnknown
+			case <-time.After(githubAppBannerRetryDelay):
+			}
+		}
+	}
+
+	// AppStateUnknown must never raise the banner: we did not get an answer
+	// from GitHub, and a hive whose App is perfectly healthy would otherwise
+	// be told to reinstall it because of a momentary network fault. The
+	// self-heal loop and the next eval cycle both re-probe, so deferring the
+	// verdict costs nothing but a delay on a hive that IS genuinely broken.
+	if state == github.AppStateUnknown {
+		logger.Warn("github app state could not be determined — leaving the banner down rather than guessing",
+			"owner", expectedOwner)
+		return false, "", github.AppStateUnknown
+	}
+	if state == github.AppStateOK {
+		return false, "", github.AppStateOK
+	}
+	return true, msg, state
+}
+
 func runEvalCycle(
 	ctx context.Context,
 	cfg *config.Config,
@@ -3298,21 +3407,23 @@ func runEvalCycle(
 							logger.Warn("GitHub App write failed — cannot write issue comments",
 								"repo", primaryRepo, "state", state.String(),
 								"operator_actionable", state.OperatorActionable(), "detail", msg)
-						} else if strings.Contains(err.Error(), "rate limit") {
+						} else if isGitHubRateLimitText(err) {
 							logger.Warn("GitHub API rate limit hit, skipping advisory digest post", "repo", primaryRepo)
-						} else if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "401") {
-							// Same reasoning as the startup path: classify
-							// before raising a banner, so an operator-side key
-							// failure is never rendered as "not installed".
-							msg, state := diagnoseGitHubApp(ctx, ghClient.AppAuth(), cfg.Project.Org)
-							dashSrv.SetGitHubAppRequired(true)
-							if msg != "" {
-								dashSrv.SetGitHubAppPermIssue(msg)
+						} else {
+							// Same verdict function as boot and Re-check, so a
+							// healthy or unclassifiable probe cannot raise the
+							// banner here either.
+							raise, msg, state := classifyGitHubAppFailure(ctx, ghClient.AppAuth(), cfg.Project.Org, logger)
+							if raise {
+								dashSrv.SetGitHubAppRequired(true)
+								if msg != "" {
+									dashSrv.SetGitHubAppPermIssue(msg)
+								}
+								dashSrv.SetGitHubAppState(state.String())
+								logger.Warn("GitHub App authentication failed posting advisory digest",
+									"repo", primaryRepo, "state", state.String(),
+									"operator_actionable", state.OperatorActionable())
 							}
-							dashSrv.SetGitHubAppState(state.String())
-							logger.Warn("GitHub App authentication failed posting advisory digest",
-								"repo", primaryRepo, "state", state.String(),
-								"operator_actionable", state.OperatorActionable())
 						}
 					} else {
 						logger.Info("posted advisory digest", "repo", primaryRepo, "issue", issueNum, "findings", digest.TotalCount, "via", "app")

--- a/v2/cmd/hive/upgrade_marker_test.go
+++ b/v2/cmd/hive/upgrade_marker_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// testLogger discards output: these tests assert on the marker file, not logs.
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// The wedge this guards against: a spoke whose upgrade failed (image never
+// changed) used to latch PERMANENTLY on the current SHA and silently discard
+// every later instruction. These tests pin the replacement semantics —
+// (fromSHA -> targetSHA) keying, a bounded attempt budget, and backoff.
+
+func TestParseUpgradeMarker_LegacyMarkerCountsAsOneAttempt(t *testing.T) {
+	// Markers written by the previous version have no "attempts" field. An
+	// already-wedged hive must get retries under the new budget rather than be
+	// read as zero attempts (which would mis-order the backoff).
+	legacy := []byte(`{"target_sha":"fc32ae4","current_sha":"c11643a","requested_at":"2026-07-31T13:52:23Z"}`)
+	m := parseUpgradeMarker(legacy)
+	if m.TargetSHA != "fc32ae4" || m.CurrentSHA != "c11643a" {
+		t.Fatalf("legacy fields not parsed: %+v", m)
+	}
+	if m.Attempts != 1 {
+		t.Errorf("legacy marker attempts = %d, want 1", m.Attempts)
+	}
+}
+
+func TestParseUpgradeMarker_GarbageIsNotALatch(t *testing.T) {
+	// A corrupt marker must never be able to wedge an upgrade: it decodes to a
+	// zero marker whose empty CurrentSHA cannot match any real gitShort.
+	m := parseUpgradeMarker([]byte("not json"))
+	if m.CurrentSHA != "" || m.TargetSHA != "" {
+		t.Errorf("garbage marker should decode empty, got %+v", m)
+	}
+}
+
+func TestSameUpgradeTarget(t *testing.T) {
+	cases := []struct {
+		name, a, b string
+		want       bool
+	}{
+		{"identical", "fc32ae4", "fc32ae4", true},
+		{"short vs full prefix", "fc32ae4", "fc32ae4d9c1b2a3", true},
+		{"case insensitive", "FC32AE4", "fc32ae4", true},
+		// The whole point of keying on the target: a NEW target must reset the
+		// attempt budget instead of inheriting the old target's exhausted one.
+		{"different target", "fc32ae4", "c11643a", false},
+		{"empty never matches", "", "fc32ae4", false},
+		{"both empty never matches", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sameUpgradeTarget(tc.a, tc.b); got != tc.want {
+				t.Errorf("sameUpgradeTarget(%q,%q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWriteAndRecordUpgradeError_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "upgrade-requested")
+	logger := testLogger()
+
+	writeUpgradeMarker(path, upgradeMarker{
+		TargetSHA:   "fc32ae4",
+		CurrentSHA:  "c11643a",
+		RequestedAt: time.Now().UTC(),
+		Attempts:    2,
+	}, logger)
+
+	// The cause of a failed attempt must survive into the next boot — without
+	// it the reason dies with the process and the failure stays invisible.
+	recordUpgradeError(path, os.ErrPermission, logger)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading marker: %v", err)
+	}
+	m := parseUpgradeMarker(data)
+	if m.Attempts != 2 {
+		t.Errorf("attempts = %d, want 2 (recordUpgradeError must not reset it)", m.Attempts)
+	}
+	if m.LastError != os.ErrPermission.Error() {
+		t.Errorf("last_error = %q, want %q", m.LastError, os.ErrPermission.Error())
+	}
+	if m.TargetSHA != "fc32ae4" {
+		t.Errorf("target_sha = %q, want fc32ae4", m.TargetSHA)
+	}
+}
+
+func TestRecordUpgradeError_NoMarkerIsNoOp(t *testing.T) {
+	// No marker means no attempt is in flight; annotating one must not create
+	// a marker that would later be mistaken for a real attempt.
+	path := filepath.Join(t.TempDir(), "absent")
+	recordUpgradeError(path, os.ErrPermission, testLogger())
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("recordUpgradeError created a marker where none existed")
+	}
+}
+
+func TestUpgradeMarker_EncodesAttemptsAndError(t *testing.T) {
+	// The marker is the only cross-restart state, so its JSON shape is load
+	// bearing: the fields must actually serialize.
+	data, err := json.Marshal(upgradeMarker{
+		TargetSHA: "fc32ae4", CurrentSHA: "c11643a", Attempts: 3, LastError: "HTTP 403",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m := parseUpgradeMarker(data)
+	if m.Attempts != 3 || m.LastError != "HTTP 403" {
+		t.Errorf("round trip lost data: %+v", m)
+	}
+}
+
+func TestSelfUpgradeBudgetConstants(t *testing.T) {
+	// The latch must be bounded but not instant, and must never be "never
+	// again" (the original bug) nor unlimited (a retry storm).
+	if selfUpgradeMaxAttempts < 2 {
+		t.Errorf("selfUpgradeMaxAttempts = %d; a latch that allows <2 attempts cannot recover from a transient failure", selfUpgradeMaxAttempts)
+	}
+	if selfUpgradeBaseBackoff <= 0 || selfUpgradeMaxBackoff < selfUpgradeBaseBackoff {
+		t.Errorf("backoff bounds invalid: base=%v max=%v", selfUpgradeBaseBackoff, selfUpgradeMaxBackoff)
+	}
+	// Exiting 0 on a failed upgrade is what made the failure invisible to K8s.
+	if selfUpgradeFailureExitCode == 0 {
+		t.Error("selfUpgradeFailureExitCode must be non-zero so a failed upgrade is visible in the container termination state")
+	}
+}

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -308,7 +308,13 @@ if [ "$(id -u)" = "0" ]; then
   # Shared CLI auth/cache lives in /data/home (persistent volume).
   # Make it group-writable so all agent UIDs (node group) can use it.
   # The manager sets HOME=/data/home for agent tmux sessions.
-  mkdir -p /data/home/.config /data/home/.copilot /data/home/.claude/session-env /data/home/.codex /data/config/github-copilot /home/dev/.config
+  mkdir -p /data/home/.config /data/home/.copilot /data/home/.claude/session-env /data/home/.codex /data/home/.bob/settings /data/config/github-copilot /home/dev/.config
+  # $HOME itself must be group-writable, not just its children. bob calls
+  # mkdirSync('$HOME/.bob') on first run, which needs write on /data/home — a
+  # 0755 root-owned $HOME makes that EACCES even though every child dir below
+  # is perfectly writable. 2775 = rwxrwxr-x + setgid (new entries inherit node).
+  chmod 2775 /data/home 2>/dev/null || true
+  chown dev:node /data/home 2>/dev/null || true
   chmod 2770 /data/home/.copilot 2>/dev/null || true
   chown dev:node /data/home/.copilot 2>/dev/null || true
   chmod 2775 /data/home/.claude /data/home/.claude/session-env 2>/dev/null || true
@@ -319,23 +325,35 @@ if [ "$(id -u)" = "0" ]; then
   # codex backend fails with "Permission denied" initializing state_N.sqlite.
   chmod 2775 /data/home/.codex 2>/dev/null || true
   chown -R dev:node /data/home/.codex 2>/dev/null || true
+  # bob writes installation_id, settings.json, trustedFolders.json and tmp/ under
+  # $HOME/.bob, plus custom modes under $HOME/.bob/settings. Pre-create both
+  # group-writable + setgid so the FIRST agent to launch (a 2001+ UID in group
+  # node) never has to mkdir them itself — that mkdir is what failed with EACCES
+  # in #2284/#2253. Pre-creating also removes the ordering dependency on which
+  # process touches .bob first. 2770: no world access, these hold auth settings.
+  chmod 2770 /data/home/.bob /data/home/.bob/settings 2>/dev/null || true
+  chown -R dev:node /data/home/.bob 2>/dev/null || true
   ln -sfn /data/config/github-copilot /home/dev/.config/github-copilot
   ln -sfn /data/config/github-copilot /data/home/.config/github-copilot
   ln -sfn /data/home/.copilot /home/dev/.copilot
   # Set group-write + setgid on shared dirs — skip if already done (saves 100s+ on NFS).
   # The polling perm guard handles ongoing config.json fixes regardless.
+  # The sampled set MUST include every dir the repair below is relied on to fix.
+  # It previously sampled only .copilot and .claude, so a hive whose those two
+  # were already correct skipped the whole-tree repair forever — leaving
+  # /data/home itself at its original root-owned 0755 and making bob's
+  # mkdir('$HOME/.bob') fail with EACCES (#2284). /data/home and .bob are sampled
+  # too so that gap cannot reopen.
   NEED_PERM_FIX=false
   if [ -d "/data/home/.copilot" ] && [ -d "/data/home/.claude" ]; then
-    COPILOT_PERMS=$(stat -c '%a' "/data/home/.copilot" 2>/dev/null || echo "755")
-    CLAUDE_PERMS=$(stat -c '%a' "/data/home/.claude" 2>/dev/null || echo "755")
-    case "$COPILOT_PERMS" in
-      27[0-9][0-9]|37[0-9][0-9]) ;; # already has group-write + setgid
-      *) NEED_PERM_FIX=true ;;
-    esac
-    case "$CLAUDE_PERMS" in
-      27[0-9][0-9]|37[0-9][0-9]) ;; # already has group-write + setgid
-      *) NEED_PERM_FIX=true ;;
-    esac
+    for perm_dir in /data/home /data/home/.copilot /data/home/.claude /data/home/.bob; do
+      # Missing dir → repair. Default 755 → repair (no group-write/setgid).
+      DIR_PERMS=$(stat -c '%a' "$perm_dir" 2>/dev/null || echo "755")
+      case "$DIR_PERMS" in
+        27[0-9][0-9]|37[0-9][0-9]) ;; # already has group-write + setgid
+        *) NEED_PERM_FIX=true ;;
+      esac
+    done
   else
     NEED_PERM_FIX=true
   fi
@@ -390,8 +408,8 @@ if [ "$(id -u)" = "0" ]; then
       # Slow cycle: fix entire /data/home tree every 5 min (new dirs from agents)
       CYCLE=$((CYCLE + 1))
       if [ "$CYCLE" -ge 60 ]; then
-        chmod -R g+rwX /data/home/.cache /data/home/.copilot /data/home/.claude /data/home/.codex 2>/dev/null
-        find /data/home/.cache /data/home/.claude /data/home/.codex -type d -exec chmod g+s {} + 2>/dev/null
+        chmod -R g+rwX /data/home/.cache /data/home/.copilot /data/home/.claude /data/home/.codex /data/home/.bob 2>/dev/null
+        find /data/home/.cache /data/home/.claude /data/home/.codex /data/home/.bob -type d -exec chmod g+s {} + 2>/dev/null
         CYCLE=0
       fi
       sleep 5

--- a/v2/pkg/agent/bob_settings.go
+++ b/v2/pkg/agent/bob_settings.go
@@ -93,6 +93,24 @@ func bobSettingsPath(home string) string {
 	return filepath.Join(home, config.BobSettingsRelPath)
 }
 
+// nearestExistingDir walks up from dir and returns the first ancestor that
+// exists, or "" if none does. Used to locate the directory whose permissions
+// actually govern a recursive mkdir of a not-yet-existing path.
+func nearestExistingDir(dir string) string {
+	for {
+		if _, err := os.Stat(dir); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		// filepath.Dir is its own fixed point at the root ("/" or "."), which
+		// is the loop's only termination condition.
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
 // verifyBobStateDirsWritable probes, AS THE AGENT UID, every directory bob
 // writes to during startup, and logs an actionable error for each one that is
 // not writable.
@@ -136,10 +154,26 @@ func (m *Manager) verifyBobStateDirsWritable(agentName, home, workDir string, ui
 		info, err := os.Stat(dir)
 		if err != nil {
 			if os.IsNotExist(err) {
-				// Not an error on its own: bob creates these with
-				// mkdirSync({recursive:true}) on first use. It only matters
-				// whether the PARENT is writable, which the next launch's
-				// probe reports once the dir exists.
+				// A missing dir is not itself a failure — bob creates these
+				// with mkdirSync({recursive:true}) on first use. But that
+				// mkdir runs as the AGENT UID, so it succeeds only if the
+				// PARENT is group-writable. Probing the parent here is the
+				// whole point on a fresh hive: this is precisely the
+				// first-run EACCES in #2284, and the original probe returned
+				// "all clear" for it because it skipped missing dirs
+				// entirely. Check the nearest existing ancestor instead.
+				if parent := nearestExistingDir(filepath.Dir(dir)); parent != "" {
+					if pInfo, pErr := os.Stat(parent); pErr == nil {
+						pMode := pInfo.Mode().Perm()
+						if pMode&bobStateGroupWriteBit == 0 || pMode&bobKeyGroupExecBit == 0 {
+							m.logger.Error("bob state dir does not exist and its parent is not writable by the agent UID; bob's first-run mkdir will fail with EACCES",
+								"agent", agentName, "dir", dir, "parent", parent,
+								"parent_mode", fs.FileMode(pMode).String(), "uid", uid,
+								"remedy", "chmod 2775 "+parent+" and ensure it is group-owned by node")
+							unwritable = append(unwritable, dir)
+						}
+					}
+				}
 				continue
 			}
 			m.logger.Warn("bob state dir not statable; bob may fail to persist settings or initialize its logger",

--- a/v2/pkg/agent/bob_settings_test.go
+++ b/v2/pkg/agent/bob_settings_test.go
@@ -405,10 +405,17 @@ func TestVerifyBobStateDirsWritable(t *testing.T) {
 
 			m := &Manager{logger: discardLogger()}
 			// workDir points at a non-existent path on purpose: a state dir
-			// bob has not created yet must NOT be reported, since bob creates
-			// it recursively on first use.
+			// bob has not created yet must NOT be reported, PROVIDED its
+			// parent is group-writable so bob's recursive mkdir can succeed.
+			// The parent is made 0770 explicitly (t.TempDir is 0700) to keep
+			// this case isolating the $HOME/.bob mode under test — otherwise
+			// the unwritable-parent check would fire on every row.
+			workRoot := t.TempDir()
+			if err := os.Chmod(workRoot, 0o770); err != nil {
+				t.Fatalf("chmod workRoot: %v", err)
+			}
 			got := m.verifyBobStateDirsWritable("tester", home,
-				filepath.Join(t.TempDir(), "agents", "tester"), tc.uid)
+				filepath.Join(workRoot, "agents", "tester"), tc.uid)
 
 			if gotUnwritable := len(got) > 0; gotUnwritable != tc.wantUnwritable {
 				t.Errorf("verifyBobStateDirsWritable() unwritable=%v (%v), want %v",
@@ -418,15 +425,48 @@ func TestVerifyBobStateDirsWritable(t *testing.T) {
 	}
 }
 
-// TestVerifyBobStateDirsWritableIgnoresMissingDirs covers the fresh-PVC case:
-// neither state dir exists yet. bob creates them with mkdirSync recursive on
-// first use, so a missing dir is not a fault and must not be reported.
-func TestVerifyBobStateDirsWritableIgnoresMissingDirs(t *testing.T) {
+// TestVerifyBobStateDirsWritableIgnoresMissingDirsWithWritableParent covers the
+// fresh-PVC case where the state dirs do not exist yet but their parents ARE
+// group-writable. bob creates them with mkdirSync recursive on first use, so a
+// missing dir with a writable parent is not a fault and must not be reported.
+func TestVerifyBobStateDirsWritableIgnoresMissingDirsWithWritableParent(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	// t.TempDir() is 0700; production parents are group-writable (2775).
+	for _, d := range []string{home, workDir} {
+		if err := os.Chmod(d, 0o770); err != nil {
+			t.Fatalf("chmod %s: %v", d, err)
+		}
+	}
 	m := &Manager{logger: discardLogger()}
-	got := m.verifyBobStateDirsWritable("tester", t.TempDir(),
-		filepath.Join(t.TempDir(), "nope"), 2004)
+	got := m.verifyBobStateDirsWritable("tester", home, workDir, 2004)
 	if len(got) != 0 {
-		t.Errorf("verifyBobStateDirsWritable() = %v for missing dirs, want none", got)
+		t.Errorf("verifyBobStateDirsWritable() = %v for missing dirs with writable parents, want none", got)
+	}
+}
+
+// TestVerifyBobStateDirsWritableFlagsMissingDirWithUnwritableParent is the
+// regression test for #2284. On the reporting hive $HOME/.bob did not exist and
+// $HOME itself was root-owned 0755, so bob's first-run mkdir failed with EACCES.
+// The original probe skipped missing dirs outright and therefore reported "all
+// clear" for exactly the failure it was added to catch.
+func TestVerifyBobStateDirsWritableFlagsMissingDirWithUnwritableParent(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	// 0755: world-readable, NOT group-writable — the production $HOME mode.
+	if err := os.Chmod(home, 0o755); err != nil {
+		t.Fatalf("chmod home: %v", err)
+	}
+	if err := os.Chmod(workDir, 0o770); err != nil {
+		t.Fatalf("chmod workDir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(home, 0o770) })
+
+	m := &Manager{logger: discardLogger()}
+	got := m.verifyBobStateDirsWritable("tester", home, workDir, 2004)
+	wantDir := filepath.Dir(bobSettingsPath(home))
+	if len(got) != 1 || got[0] != wantDir {
+		t.Errorf("verifyBobStateDirsWritable() = %v, want [%s]", got, wantDir)
 	}
 }
 

--- a/v2/pkg/agent/routing_coverage_test.go
+++ b/v2/pkg/agent/routing_coverage_test.go
@@ -501,17 +501,36 @@ func TestAgentModeTokenTier(t *testing.T) {
 // claude-sonnet-4-6 reaches bob as claude-sonnet-4.6 — an id bob's backend
 // does not know — and every prompt dies with "Cannot read properties of
 // undefined (reading 'maxTokens')". bob auto-selects its own model.
+//
+// The assertion is deliberately about the ABSENCE of --model and the INVARIANCE
+// of the command across models, not equality against a fixed string. bob's
+// launch command legitimately carries required flags (--accept-license,
+// --auth-method api-key, --approval-mode yolo, --trust) that this test must not
+// re-litigate; bobLaunchCmd's own doc comment and
+// TestToolRulesToLaunchCmdBobHasNoModel in bob_test.go own that contract and
+// assert those flags are present. An earlier `cmd != "bob"` check here duplicated
+// that ownership badly: it pinned the whole command to the bare binary name and
+// so contradicted the sibling test the moment a required flag was added.
 func TestToolRulesToLaunchCmd_BobNeverGetsModel(t *testing.T) {
 	tools := &config.ToolsConfig{}
 	// Includes "auto": the dashboard's only bob option is a display/stored
 	// placeholder, and `bob --model auto` is untested and must not be emitted.
-	for _, model := range []string{"", "auto", "claude-sonnet-4.6", "claude-sonnet-4-6", "granite-3"} {
+	models := []string{"", "auto", "claude-sonnet-4.6", "claude-sonnet-4-6", "granite-3"}
+
+	// The command bob gets must not vary with the configured model at all, so
+	// every iteration is compared against the first one rather than a literal.
+	want := toolRulesToLaunchCmd("bob", models[0], bobBackend, tools, false)
+	for _, model := range models {
 		cmd := toolRulesToLaunchCmd("bob", model, bobBackend, tools, false)
 		if strings.Contains(cmd, "--model") {
 			t.Errorf("bob launch cmd with model %q must not contain --model: %q", model, cmd)
 		}
-		if cmd != "bob" {
-			t.Errorf("bob launch cmd with model %q = %q, want %q", model, cmd, "bob")
+		// Catches a model leaking in under any spelling, not just as --model.
+		if model != "" && strings.Contains(cmd, model) {
+			t.Errorf("bob launch cmd with model %q leaked the model id: %q", model, cmd)
+		}
+		if cmd != want {
+			t.Errorf("bob launch cmd with model %q = %q, want it identical to the no-model command %q", model, cmd, want)
 		}
 	}
 }

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -571,10 +571,13 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 	if primaryRepo != "" && cfg.Project.Org != "" && !strings.Contains(primaryRepo, "/") {
 		primaryRepo = cfg.Project.Org + "/" + primaryRepo
 	}
-	githubBaseURL := cfg.GitHub.BaseURL
-	if githubBaseURL == "" {
-		githubBaseURL = "https://github.com"
-	}
+	// ResolvedBaseURL (not the raw BaseURL) so pooled/placeholder GHE hives —
+	// which legitimately carry base_url: "" but api_url: https://github.ibm.com/api/v3
+	// — report github.ibm.com, not github.com. Reading BaseURL alone made the
+	// Repos config show bare org/repo with no GHE hint, so operators mistook a
+	// github.ibm.com hive for github.com. ResolvedBaseURL falls back to the api_url
+	// host in exactly that case (mirrors HostLabel).
+	githubBaseURL := cfg.GitHub.ResolvedBaseURL()
 	jsonResponse(w, map[string]interface{}{
 		"org":       cfg.Project.Org,
 		"repos":     cfg.Project.Repos,

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3588,30 +3588,52 @@ func (s *Server) handleGovernorLabels(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGovernorBudget(w http.ResponseWriter, r *http.Request) {
+	// Pointer fields distinguish "field absent from the JSON" (nil) from
+	// "field explicitly set to 0". The dashboard sends only the inputs the
+	// user actually touched, so editing Total Tokens alone POSTs
+	// {"totalTokens":N} with no periodDays/criticalPct. With plain ints
+	// those absent fields decoded to 0 and were rejected by validation as
+	// out-of-range. Nil now means "leave the stored value alone", while an
+	// explicit 0 is still honored (totalTokens: 0 disables budget tracking).
 	var body struct {
-		TotalTokens int64 `json:"totalTokens"`
-		PeriodDays  int   `json:"periodDays"`
-		CriticalPct int   `json:"criticalPct"`
+		TotalTokens *int64 `json:"totalTokens"`
+		PeriodDays  *int   `json:"periodDays"`
+		CriticalPct *int   `json:"criticalPct"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
 		return
 	}
 
-	if err := validateGovernorBudget(body.TotalTokens, body.PeriodDays, body.CriticalPct); err != nil {
+	// Validate against the effective post-update values: supplied fields use
+	// the incoming value, omitted fields keep what is already stored. This
+	// keeps a partial update from being judged against a phantom zero.
+	current := s.deps.Config.Governor.Budget
+	totalTokens, periodDays, criticalPct := current.TotalTokens, current.PeriodDays, current.CriticalPct
+	if body.TotalTokens != nil {
+		totalTokens = *body.TotalTokens
+	}
+	if body.PeriodDays != nil {
+		periodDays = *body.PeriodDays
+	}
+	if body.CriticalPct != nil {
+		criticalPct = *body.CriticalPct
+	}
+
+	if err := validateGovernorBudget(totalTokens, periodDays, criticalPct); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	if body.TotalTokens > 0 {
-		s.deps.Config.Governor.Budget.TotalTokens = body.TotalTokens
-		s.deps.Governor.SetBudgetLimit(body.TotalTokens)
+	if body.TotalTokens != nil {
+		s.deps.Config.Governor.Budget.TotalTokens = totalTokens
+		s.deps.Governor.SetBudgetLimit(totalTokens)
 	}
-	if body.PeriodDays > 0 {
-		s.deps.Config.Governor.Budget.PeriodDays = body.PeriodDays
+	if body.PeriodDays != nil {
+		s.deps.Config.Governor.Budget.PeriodDays = periodDays
 	}
-	if body.CriticalPct > 0 {
-		s.deps.Config.Governor.Budget.CriticalPct = body.CriticalPct
+	if body.CriticalPct != nil {
+		s.deps.Config.Governor.Budget.CriticalPct = criticalPct
 	}
 
 	if err := s.saveConfig(); err != nil {

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -1935,6 +1935,41 @@ func TestHandleConfig_WithPrimaryRepo(t *testing.T) {
 	}
 }
 
+// handleConfig must report the RESOLVED GitHub host so the dashboard's
+// forge indicators (Repositories section pill, per-repo cards, Repos config
+// modal) show the real host. A pooled/placeholder GHE hive legitimately
+// carries base_url: "" with a GHE api_url — reading base_url alone rendered
+// those as github.com, so operators mistook a github.ibm.com hive for
+// github.com (the vllmd-06 case). ResolvedBaseURL falls back to the api_url
+// host in exactly that case.
+func TestHandleConfig_GitHubBaseURL_BlankBaseGHEApi(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.GitHub.BaseURL = ""
+	deps.Config.GitHub.APIURL = "https://github.ibm.com/api/v3"
+	rec := doGet(s, "/api/config")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	result := decodeJSON(t, rec)
+	if got := result["github_base_url"]; got != "https://github.ibm.com" {
+		t.Errorf("github_base_url = %v, want https://github.ibm.com", got)
+	}
+}
+
+func TestHandleConfig_GitHubBaseURL_PublicDefault(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.GitHub.BaseURL = ""
+	deps.Config.GitHub.APIURL = ""
+	rec := doGet(s, "/api/config")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	result := decodeJSON(t, rec)
+	if got := result["github_base_url"]; got != "https://github.com" {
+		t.Errorf("github_base_url = %v, want https://github.com", got)
+	}
+}
+
 // ---- handleKnowledgeToggle enable with layers ----
 
 func TestHandleKnowledgeToggle_EnableWithLayers(t *testing.T) {

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -3837,3 +3837,125 @@ func TestHandleRestart_NotRunning(t *testing.T) {
 		t.Log("restart succeeded despite stopped agent (depends on impl)")
 	}
 }
+
+// ── Budget partial-update regression tests ──
+// Reported by Cyril Nestor: editing only "Total Tokens" in the Governor
+// Budget tab failed with "periodDays must be between 1 and 365" even though
+// the UI showed a valid period. The dashboard PUTs only the fields the user
+// touched, so periodDays/criticalPct were absent and decoded to 0.
+
+// budgetTestPeriodDays / budgetTestCriticalPct are the pre-existing stored
+// values these tests seed so they can assert the values survive a partial PUT.
+const (
+	budgetTestPeriodDays  = 7
+	budgetTestCriticalPct = 90
+)
+
+// seedBudget puts a known-good budget into the server config so that a
+// partial update has something meaningful to preserve.
+func seedBudget(deps *Dependencies, totalTokens int64) {
+	deps.Config.Governor.Budget.TotalTokens = totalTokens
+	deps.Config.Governor.Budget.PeriodDays = budgetTestPeriodDays
+	deps.Config.Governor.Budget.CriticalPct = budgetTestCriticalPct
+}
+
+func TestHandleGovernorBudget_PartialUpdatePreservesOtherFields(t *testing.T) {
+	s, deps := apiServer(t)
+	seedBudget(deps, 1000)
+
+	// Exactly what the dashboard sends when only Total Tokens is edited.
+	rec := doPutRaw(s, "/api/config/governor/budget", `{"totalTokens":50}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	b := deps.Config.Governor.Budget
+	if b.TotalTokens != 50 {
+		t.Errorf("TotalTokens = %d, want 50", b.TotalTokens)
+	}
+	if b.PeriodDays != budgetTestPeriodDays {
+		t.Errorf("PeriodDays = %d, want %d preserved", b.PeriodDays, budgetTestPeriodDays)
+	}
+	if b.CriticalPct != budgetTestCriticalPct {
+		t.Errorf("CriticalPct = %d, want %d preserved", b.CriticalPct, budgetTestCriticalPct)
+	}
+}
+
+func TestHandleGovernorBudget_PartialPeriodDaysOnly(t *testing.T) {
+	s, deps := apiServer(t)
+	seedBudget(deps, 1000)
+
+	rec := doPutRaw(s, "/api/config/governor/budget", `{"periodDays":30}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	b := deps.Config.Governor.Budget
+	if b.PeriodDays != 30 {
+		t.Errorf("PeriodDays = %d, want 30", b.PeriodDays)
+	}
+	if b.TotalTokens != 1000 {
+		t.Errorf("TotalTokens = %d, want 1000 preserved", b.TotalTokens)
+	}
+	if b.CriticalPct != budgetTestCriticalPct {
+		t.Errorf("CriticalPct = %d, want %d preserved", b.CriticalPct, budgetTestCriticalPct)
+	}
+}
+
+// An explicit zero for totalTokens disables budget tracking per the UI
+// tooltip, so it must be applied — not mistaken for an absent field.
+func TestHandleGovernorBudget_ExplicitZeroTotalTokensHonored(t *testing.T) {
+	s, deps := apiServer(t)
+	seedBudget(deps, 1000)
+
+	rec := doPutRaw(s, "/api/config/governor/budget", `{"totalTokens":0}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := deps.Config.Governor.Budget.TotalTokens; got != 0 {
+		t.Errorf("TotalTokens = %d, want 0 (explicit zero disables tracking)", got)
+	}
+	if got := deps.Config.Governor.Budget.PeriodDays; got != budgetTestPeriodDays {
+		t.Errorf("PeriodDays = %d, want %d preserved", got, budgetTestPeriodDays)
+	}
+}
+
+// An explicit out-of-range value must still be rejected — the pointer change
+// fixes absence, it does not relax validation.
+func TestHandleGovernorBudget_ExplicitOutOfRangeStillRejected(t *testing.T) {
+	s, deps := apiServer(t)
+	seedBudget(deps, 1000)
+
+	for _, tc := range []struct{ name, payload string }{
+		{"periodDays zero", `{"periodDays":0}`},
+		{"periodDays too high", `{"periodDays":400}`},
+		{"criticalPct zero", `{"criticalPct":0}`},
+		{"criticalPct too high", `{"criticalPct":101}`},
+		{"negative totalTokens", `{"totalTokens":-1}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := doPutRaw(s, "/api/config/governor/budget", tc.payload)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400 for %s", rec.Code, tc.payload)
+			}
+		})
+	}
+	// Nothing should have been mutated by the rejected requests.
+	b := deps.Config.Governor.Budget
+	if b.PeriodDays != budgetTestPeriodDays || b.CriticalPct != budgetTestCriticalPct || b.TotalTokens != 1000 {
+		t.Errorf("config mutated by rejected requests: %+v", b)
+	}
+}
+
+// An empty object touches nothing and must succeed without zeroing anything.
+func TestHandleGovernorBudget_EmptyPayloadPreservesAll(t *testing.T) {
+	s, deps := apiServer(t)
+	seedBudget(deps, 1000)
+
+	rec := doPutRaw(s, "/api/config/governor/budget", `{}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	b := deps.Config.Governor.Budget
+	if b.TotalTokens != 1000 || b.PeriodDays != budgetTestPeriodDays || b.CriticalPct != budgetTestCriticalPct {
+		t.Errorf("empty payload mutated config: %+v", b)
+	}
+}

--- a/v2/pkg/dashboard/api_trajectory.go
+++ b/v2/pkg/dashboard/api_trajectory.go
@@ -49,29 +49,45 @@ func (s *Server) handleGovernorTrajectory(w http.ResponseWriter, r *http.Request
 	if err := s.saveConfig(); err != nil {
 		s.logger.Error("failed to persist config after trajectory update", "error", err)
 	}
-	// Reconcile the "enabled but no reviewer endpoint" alert against the new
-	// state: it must clear when the lane is turned off or an endpoint is set,
-	// not linger from a stale startup evaluation.
+	// Clear any legacy "not configured" banner alert. The half-configured
+	// state is surfaced inline in Governor Config → General instead of the
+	// top banner (see ReconcileTrajectoryAlert).
 	s.ReconcileTrajectoryAlert(&s.deps.Config.Governor)
 	s.auditFromRequest(r, "config_governor_trajectory", auditDetail("section", "trajectory"), "")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
 }
 
-// TrajectoryNotConfiguredAlertID is the dashboard system-alert id for
-// "trajectory review is enabled but has no reviewer endpoint."
+// TrajectoryNotConfiguredAlertID is the dashboard system-alert id formerly
+// used for "trajectory review is enabled but has no reviewer endpoint."
+// The alert is no longer raised; the id is retained so ReconcileTrajectoryAlert
+// can clear one persisted by an older build.
 const TrajectoryNotConfiguredAlertID = "trajectory-not-configured"
 
-// ReconcileTrajectoryAlert raises the "enabled but no reviewer endpoint" alert
-// only when the lane is BOTH enabled AND not runnable, and clears it in every
-// other case (disabled, or an endpoint now resolves). Safe to call from
-// startup and from the config PUT handler.
-func (s *Server) ReconcileTrajectoryAlert(g *config.GovernorConfig) {
-	if g.Trajectory.IsEnabled() && !g.ReviewerReady() {
-		s.AddSystemAlert(TrajectoryNotConfiguredAlertID, "warning",
-			"Trajectory review is ON but has no reviewer endpoint configured — no agents are being reviewed. Set a reviewer endpoint (LiteLLM, vLLM, or llm-d) in Governor Config.")
-		return
-	}
+// ReconcileTrajectoryAlert clears the legacy "enabled but no reviewer
+// endpoint" system alert. It no longer raises it.
+//
+// Why the banner went away: the lane defaults to ON (TrajectoryConfig.IsEnabled
+// returns true when Enabled is nil), so on a hive that has never configured a
+// LiteLLM endpoint the alert fired on first boot for everyone — it flagged the
+// untouched default, not an operator who opted in and then misconfigured it.
+// That made it a "you have not set up an optional feature" nag occupying the
+// top banner, which is reserved for conditions demanding action. The lane also
+// fails open (an unreachable reviewer returns "not divergent"), so the inert
+// state never pauses or breaks a working agent.
+//
+// The half-configured state is still surfaced, just not as a top-of-page
+// warning: Governor Config → General shows an amber "On — no reviewer endpoint
+// (not running)" status chip plus a "Resolved: none — reviewer will not run"
+// hint next to the endpoint field, and Getting Started → More to explore
+// mentions the feature as an advanced capability.
+//
+// This is still called from startup and the config PUT handler so that an
+// alert persisted by an older build is cleared rather than left stuck in the
+// banner forever.
+// The config argument is retained (unused) so both call sites and any future
+// re-introduction of a narrower, opt-in-only alert keep a stable signature.
+func (s *Server) ReconcileTrajectoryAlert(_ *config.GovernorConfig) {
 	s.ClearSystemAlert(TrajectoryNotConfiguredAlertID)
 }
 

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -90,6 +90,12 @@ type WSMessage struct {
 	Summary           string          `json:"summary,omitempty"`
 	TmuxOutput        []string        `json:"tmux_output,omitempty"`
 	AcceptedModels    []string        `json:"accepted_models,omitempty"`
+	// Permanent marks a task_failed the relay will not retry: it exhausted its
+	// per-task CLI-restart budget and gave up (see MAX_TASK_CLI_RESTARTS in
+	// bin/contributor-relay.sh). Reassigning the same work item to the same
+	// contributor will be rejected outright, so the hub should prefer a
+	// different contributor. See kubestellar/hive#2203.
+	Permanent bool `json:"permanent,omitempty"`
 }
 
 type WSTaskAssign struct {
@@ -684,6 +690,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 						"username", contributor.profile.GitHubUsername,
 						"task", msg.TaskID,
 						"reason", msg.Reason,
+						"permanent", msg.Permanent,
 					)
 					contributor.mu.Lock()
 					contributor.profile.TasksFailed++

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -2023,7 +2023,13 @@ func (s *Server) HealthSummary() map[string]any {
 	// 2. GitHub auth
 	if s.deps != nil && s.deps.GHAppAuth != nil {
 		if _, err := s.deps.GHAppAuth.Token(s.deps.Ctx); err != nil {
-			checks = append(checks, check{Name: "github_auth", Status: "fail", Detail: "token error"})
+			// Surface the underlying error, not a bare "token error": this
+			// detail travels to the hub and into the dashboard tooltip, and a
+			// swallowed error string is exactly what left past github_auth flaps
+			// undiagnosable. Token() now serves a still-valid cached token
+			// through a transient mint blip, so reaching here means no usable
+			// token remains — a genuine, sustained auth failure worth showing.
+			checks = append(checks, check{Name: "github_auth", Status: "fail", Detail: "token error: " + err.Error()})
 			fails++
 		} else {
 			checks = append(checks, check{Name: "github_auth", Status: "pass"})

--- a/v2/pkg/dashboard/server_health_coverage_test.go
+++ b/v2/pkg/dashboard/server_health_coverage_test.go
@@ -39,6 +39,41 @@ func TestCovHealth_Livez_Ready(t *testing.T) {
 	}
 }
 
+// TestReadinessIsAgentIndependent locks in the startup-ordering fix: the
+// dashboard becomes Ready purely from MarkReady() with its deps wired, WITHOUT
+// any agent having been launched. healthServer wires the API deps (testDeps)
+// but starts zero agents — the exact state that exists right after the HTTP
+// listener comes up and BEFORE the (now-backgrounded) staggered agent-launch
+// loop in cmd/hive/main.go. Both /api/livez and /api/health must flip to 200 as
+// soon as MarkReady() is called, proving the readiness gate does not depend on
+// the agent fleet being up. This is what lets a pod become Ready in seconds
+// instead of waiting out the multi-minute staggered launch.
+func TestReadinessIsAgentIndependent(t *testing.T) {
+	s := healthServer(t) // deps wired, NO agents started
+
+	// Before MarkReady: readiness gate closed → 503 on both probes.
+	for _, path := range []string{"/api/livez", "/api/health"} {
+		rec := httptest.NewRecorder()
+		s.mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("%s before MarkReady: want 503, got %d", path, rec.Code)
+		}
+	}
+
+	// MarkReady with no agents launched — the reorder makes this reachable in
+	// seconds on the real startup path.
+	s.MarkReady()
+
+	// After MarkReady: both probes are 200 despite zero agents running.
+	for _, path := range []string{"/api/livez", "/api/health"} {
+		rec := httptest.NewRecorder()
+		s.mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s after MarkReady (no agents): want 200, got %d", path, rec.Code)
+		}
+	}
+}
+
 func TestCovHealth_HealthDeep_NotReady(t *testing.T) {
 	s := healthServer(t)
 	rec := httptest.NewRecorder()

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5341,14 +5341,22 @@
       // Definitive single-host badge in the section header: every repo in this
       // hive is on ONE GitHub host (github.com or a GHE instance). Green =
       // github.com, blue = GitHub Enterprise — matches the hub spokes-table pill.
+      // hostLabel is the hive's forge. window._githubBaseUrl now comes from the
+      // backend's ResolvedBaseURL() (base_url, else the api_url host), so a
+      // pooled GHE hive carrying base_url: "" + api_url github.ibm.com resolves
+      // to github.ibm.com here — not github.com. This is the fix for the pill
+      // that read "GITHUB.COM" on a github.ibm.com hive.
+      const hostLabel = (window._githubBaseUrl || 'https://github.com').replace(/^https?:\/\//, '').replace(/\/$/, '') || 'github.com';
+      const isPublic = hostLabel === 'github.com';
       const badge = document.getElementById('repos-host-badge');
       if (badge) {
-        const base = (window._githubBaseUrl || 'https://github.com').replace(/^https?:\/\//, '').replace(/\/$/, '');
-        const isPublic = (base === 'github.com' || base === '');
-        badge.textContent = isPublic ? 'github.com' : base;
-        badge.style.background = isPublic ? 'rgba(34,197,94,0.15)' : 'rgba(59,130,246,0.15)';
-        badge.style.color = isPublic ? 'var(--green, #16a34a)' : 'var(--blue, #2563eb)';
-        badge.title = 'Every repo in this hive is on ' + (isPublic ? 'github.com' : base) + ' — this hive is single-host';
+        // Definitive single-host badge in the section header: every repo in this
+        // hive is on ONE GitHub host. Green = github.com, indigo = GHE — GHE also
+        // gets an "Enterprise" tag so an operator instantly sees it is not public.
+        badge.textContent = isPublic ? 'github.com' : hostLabel + ' · Enterprise';
+        badge.style.background = isPublic ? 'color-mix(in srgb, var(--green) 15%, transparent)' : 'color-mix(in srgb, var(--indigo) 15%, transparent)';
+        badge.style.color = isPublic ? 'var(--green)' : 'var(--indigo)';
+        badge.title = 'Every repo in this hive is on ' + hostLabel + (isPublic ? '' : ' (GitHub Enterprise)') + ' — this hive is single-host';
       }
       setIfChanged(el, repos.map(r => {
         const iSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.issues ?? 0), 'var(--blue)');
@@ -5373,6 +5381,7 @@
         const pillsHtml = allPills ? `<div class="repo-issues">${allPills}</div>` : '';
         return `
         <div class="repo-card">
+          <div style="font-size:0.62rem;font-weight:600;letter-spacing:0.02em;color:${isPublic ? 'var(--muted)' : 'var(--indigo)'};margin-bottom:2px" title="This repo lives on ${esc(hostLabel)}${isPublic ? '' : ' (GitHub Enterprise), not public github.com'}">${esc(hostLabel)}${isPublic ? '' : ' · Enterprise'}</div>
           <div class="repo-name"><a href="${esc(repoUrl)}" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">${esc(r.full || r.name)}</a></div>
           <div class="repo-stats">
             <div class="repo-stat"><a href="${esc(repoUrl)}/issues" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.issues >= 0 ? r.issues : '?'}</span>${iSpark}</div><div class="label">issues</div></a></div>
@@ -15445,9 +15454,30 @@ function burnAreaChart() {
 
     function renderGovRepos(repos) {
       const primary = _configState.data.primaryRepo || '';
+      // ghHost is the hive's forge, derived server-side by ResolvedBaseURL()
+      // (base_url, or the api_url host for pooled GHE hives that carry
+      // base_url: ""). A hive is single-forge — validateSingleRepoHost rejects
+      // off-host repos — so every repo below lives on THIS host. We surface it
+      // both in the header and as a per-row pill so an org/repo can never be
+      // mistaken for github.com when it actually lives on github.ibm.com.
       const ghBase = window._githubBaseUrl || 'https://github.com';
-      const ghHost = ghBase.replace(/^https?:\/\//, '');
+      const ghHost = ghBase.replace(/^https?:\/\//, '').replace(/\/$/, '');
       const isGHE = ghHost !== 'github.com';
+      // GHE hosts get an indigo "Enterprise" pill so an operator instantly sees
+      // this is an Enterprise hive; public github.com gets a muted host pill.
+      // Inline styles mirror the pill recipe (--pill-c tint + border) and the
+      // ACMM badge pattern — self-contained, no external resources (CSP-safe).
+      const pillColor = isGHE ? 'var(--indigo)' : 'var(--muted)';
+      const pillBase = 'display:inline-flex;align-items:center;gap:4px;flex-shrink:0;'
+        + 'font-size:0.62rem;font-weight:700;letter-spacing:0.02em;padding:1px 7px;'
+        + 'border-radius:999px;white-space:nowrap;'
+        + 'background:color-mix(in srgb, ' + pillColor + ' 12%, transparent);'
+        + 'border:1px solid color-mix(in srgb, ' + pillColor + ' 40%, transparent);'
+        + 'color:' + pillColor;
+      const pillLabel = isGHE ? esc(ghHost) + ' · Enterprise' : esc(ghHost);
+      const pillTitle = isGHE
+        ? 'This repo lives on the GitHub Enterprise host ' + esc(ghHost) + ' — NOT public github.com'
+        : 'This repo lives on public github.com';
       const list = repos.map((r, i) => {
         const isDefault = r === primary;
         const starStyle = isDefault
@@ -15456,15 +15486,19 @@ function burnAreaChart() {
         const starTitle = isDefault
           ? 'Default repo (advisory issue lives here)'
           : 'Set as default repo for advisory issue';
-        const displayName = isGHE ? ghHost + '/' + r : r;
-        return `<div class="config-list-item" style="align-items:center"><span onclick="setDefaultRepo('${esc(r)}')" style="${starStyle}" title="${starTitle}">${isDefault ? '★' : '☆'}</span><span style="flex:1">${esc(displayName)}</span><button class="remove-item" onclick="removeListItem('repos','list',${i})">&#x2715;</button></div>`;
+        // Fully forge-qualified so the row is unambiguous: github.ibm.com/org/repo.
+        const displayName = ghHost + '/' + r;
+        return `<div class="config-list-item" style="align-items:center;gap:6px"><span onclick="setDefaultRepo('${esc(r)}')" style="${starStyle}" title="${starTitle}">${isDefault ? '★' : '☆'}</span><span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${esc(displayName)}">${esc(displayName)}</span><span style="${pillBase}" title="${pillTitle}">${pillLabel}</span><button class="remove-item" onclick="removeListItem('repos','list',${i})">&#x2715;</button></div>`;
       }).join('');
+      const hostNote = isGHE
+        ? ` on <strong style="color:var(--indigo)">${esc(ghHost)}</strong> (GitHub Enterprise)`
+        : ` on <strong>${esc(ghHost)}</strong>`;
       return `
-        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">GitHub repositories monitored by this hive. Click the star to set the default repo where the advisory issue is maintained.</p>
+        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">GitHub repositories monitored by this hive${hostNote}. Click the star to set the default repo where the advisory issue is maintained.</p>
         <div class="config-list">
           ${list || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No repos configured</div>'}
           <div class="config-list-add">
-            <input type="text" id="cfg-repo-input" placeholder="org/repo" title="GitHub repository in org/repo format (e.g. kubestellar/console). The governor will monitor this repo for issues, PRs, and CI status.">
+            <input type="text" id="cfg-repo-input" placeholder="org/repo (on ${esc(ghHost)})" title="GitHub repository in org/repo format (e.g. kubestellar/console). It must live on this hive's forge, ${esc(ghHost)} — the governor rejects repos on other GitHub hosts. It will be monitored for issues, PRs, and CI status.">
             <button onclick="addListItem('repos','list','cfg-repo-input')" title="Add this repository to the monitored list">+ Add</button>
           </div>
         </div>`;

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2196,6 +2196,9 @@
     .welcome-more-item { font-size: var(--fs-sm); color: var(--muted); padding: 3px 0 3px 8px; line-height: 1.5; }
     .welcome-more-link { color: var(--blue); cursor: pointer; font-weight: 600; }
     .welcome-more-link:hover { text-decoration: underline; }
+    /* Marks a "More to explore" entry as an advanced/optional capability, so a
+       new operator does not read it as part of the required setup path. */
+    .welcome-more-tag { display: inline-block; margin-left: 6px; padding: 1px 6px; border-radius: 999px; font-size: var(--fs-xs); font-weight: 600; text-transform: uppercase; letter-spacing: 0.4px; color: var(--amber); background: color-mix(in srgb, var(--amber) 14%, transparent); border: 1px solid color-mix(in srgb, var(--amber) 45%, transparent); }
     .welcome-footer { justify-content: space-between; }
     @media (max-width: 480px) {
       .welcome-step-body { padding-left: 12px; }
@@ -15266,7 +15269,7 @@ function burnAreaChart() {
             <div style="grid-column:1 / -1">
               <label style="font-size:0.7rem;color:var(--muted);display:block;margin-bottom:3px">Reviewer endpoint <span class="config-info">i<span class="config-tooltip">OpenAI-compatible base URL for the reviewer (LiteLLM / vLLM / llm-d). Empty = inherit the Governor's LiteLLM endpoint. The API key is inherited from LiteLLM or set in hive.yaml (governor.trajectory.api_key_env/api_key_file); a bare vLLM server needs none.</span></span></label>
               <input type="text" value="${esc(traj.endpoint || '')}" placeholder="${trajEndpoint ? esc(trajEndpoint) + '  (inherited from LiteLLM)' : 'https://litellm-or-vllm-or-llmd:port'}" onchange="saveTrajectoryField('endpoint', this.value)" style="width:100%">
-              <span style="font-size:0.62rem;color:var(--muted);margin-top:3px;display:block">Resolved: ${trajEndpoint ? esc(trajEndpoint) + ' (' + esc(traj.endpointSource || '') + (traj.hasKey ? ', key set' : ', no key') + ')' : 'none — reviewer will not run'}</span>
+              <span style="font-size:0.62rem;margin-top:3px;display:block;color:${trajOn && !trajEndpoint ? 'var(--amber)' : 'var(--muted)'}">Resolved: ${trajEndpoint ? esc(trajEndpoint) + ' (' + esc(traj.endpointSource || '') + (traj.hasKey ? ', key set' : ', no key') + ')' : (trajOn ? 'none — Trajectory Review is ON but no agents are being reviewed. Set an endpoint above (or a Governor LiteLLM endpoint) to activate it.' : 'none — reviewer will not run')}</span>
             </div>
             <div style="grid-column:1 / -1">
               <label style="font-size:0.7rem;color:var(--muted);display:block;margin-bottom:3px">On divergence</label>
@@ -17321,13 +17324,23 @@ function burnAreaChart() {
       }
     ];
 
-    // Collapsed "More to explore" one-liners under the core steps.
+    // Governor Config tab hosting the Trajectory Review controls (toggle,
+    // reviewer endpoint/model, on-divergence mode) — see renderGovGeneral().
+    // Named so the Getting Started deep link cannot drift from the tab list
+    // in GOVERNOR_CONFIG_TABS.
+    const TRAJECTORY_CONFIG_TAB = 'General';
+
+    // Collapsed "More to explore" one-liners under the core steps. These are
+    // OPTIONAL/advanced capabilities, deliberately kept out of WELCOME_STEPS:
+    // updateWelcomeProgress() counts only WELCOME_STEPS, so nothing listed
+    // here can inflate the "N of M done" counter or read as a required step.
     const WELCOME_MORE_ITEMS = [
       { id: 'budget', label: 'Budget', desc: 'set a weekly token budget and watch the burn rate (Governor Config → Budget).', onclick: "welcomeShowConfigTab('Budget')" },
       { id: 'notifications', label: 'Notifications', desc: 'route alerts to your channels (Governor Config → Notifications).', onclick: "welcomeShowConfigTab('Notifications')" },
       { id: 'knowledge', label: 'Knowledge Base', desc: 'seed facts and patterns the agents reuse across passes.', onclick: "welcomeShowSection('knowledge-section')" },
       { id: 'contributors', label: 'ClankeR (Contributor Relay)', desc: 'let outside contributors drive agents, with a leaderboard.', onclick: "welcomeShowSection('contributors-section')" },
       { id: 'hub', label: 'Hub visibility', desc: 'make this hive public or private on the hub (Governor Config → Hub).', onclick: "welcomeShowConfigTab('Hub')" },
+      { id: 'trajectory', label: 'Trajectory Review <span class="welcome-more-tag">advanced</span>', desc: 'an LLM reviewer periodically reads each running agent’s transcript and pauses or alerts you if the agent drifts from the task it was given. Needs one OpenAI-compatible reviewer endpoint (LiteLLM, vLLM, or llm-d) — without it the lane stays inert (Governor Config → General).', onclick: `welcomeShowConfigTab('${TRAJECTORY_CONFIG_TAB}')` },
       { id: 'theme', label: 'Light / Dark mode', desc: 'switch layouts any time from the toggle in the top bar.', onclick: 'toggleLayout()' }
     ];
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4782,6 +4782,11 @@
        states must not tell the user to install anything or edit config. */
     var GH_APP_STATE_KEY_MISSING = 'key-missing';
     var GH_APP_STATE_KEY_INVALID = 'key-invalid';
+    /* User-actionable, but distinct from a permission problem: the App is not
+       installed at all, so there are no settings to view — only an install to
+       perform. Kept out of GH_APP_OPERATOR_STATES: installing is the user's
+       job, not the operator's. */
+    var GH_APP_STATE_NOT_INSTALLED = 'not-installed';
     var GH_APP_OPERATOR_STATES = {};
     GH_APP_OPERATOR_STATES[GH_APP_STATE_KEY_MISSING] = true;
     GH_APP_OPERATOR_STATES[GH_APP_STATE_KEY_INVALID] = true;
@@ -4839,7 +4844,18 @@
       if (resetLink) resetLink.style.display = '';
       banner.classList.remove('operator-issue');
 
-      var isPermIssue = data.githubAppRequired && data.githubAppPermIssue;
+      /* githubAppPermIssue carries the diagnostic string for EVERY
+         user-actionable App failure, including "not installed at all", so it
+         cannot decide between "installed but under-permissioned" and "never
+         installed". Using it alone told a hive carrying a placeholder app_id
+         that "the app is installed but cannot write" and offered
+         "View App Settings" — settings for an App that does not exist — while
+         the banner's own body text said it was not yet linked to any App.
+         githubAppState (added with the operator/user classification) is the
+         authoritative signal, so an explicitly not-installed state is never
+         treated as a permission problem. */
+      var isNotInstalled = appState === GH_APP_STATE_NOT_INSTALLED;
+      var isPermIssue = data.githubAppRequired && data.githubAppPermIssue && !isNotInstalled;
       if (data.githubAppRequired && (data.githubAppInstallURL || isPermIssue)) {
         var link = document.getElementById('gh-app-install-link');
         var title = document.querySelector('#gh-app-install-banner .gh-app-title');

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1268,6 +1268,11 @@
     .toast.error { background: color-mix(in srgb, var(--red) 14%, var(--panel)); border-color: color-mix(in srgb, var(--red) 35%, var(--line)); border-left-color: var(--red); }
     .toast.info { background: color-mix(in srgb, var(--blue) 14%, var(--panel)); border-color: color-mix(in srgb, var(--blue) 35%, var(--line)); border-left-color: var(--blue); }
     .toast-spinner { display: inline-block; width: 12px; height: 12px; border: 2px solid color-mix(in srgb, var(--text) 30%, transparent); border-top-color: var(--text); border-radius: 50%; animation: spin 0.8s linear infinite; margin-right: 8px; vertical-align: middle; }
+    /* Error toasts never auto-dismiss (a failed save must stay readable), so
+       they carry an explicit close affordance and a click-anywhere target. */
+    .toast.sticky { cursor: pointer; padding-right: 30px; position: relative; }
+    .toast-close { position: absolute; top: 4px; right: 8px; font-size: 0.9rem; line-height: 1; color: var(--muted); background: none; border: none; padding: 2px 4px; cursor: pointer; }
+    .toast-close:hover { color: var(--text); }
     @keyframes spin { to { transform: rotate(360deg); } }
     @keyframes toast-in { from { opacity: 0; transform: translateX(40px); } to { opacity: 1; transform: translateX(0); } }
     @keyframes toast-out { from { opacity: 1; } to { opacity: 0; transform: translateY(-10px); } }
@@ -11102,6 +11107,21 @@ function burnAreaChart() {
         overlay.querySelector('.primary').focus();
       });
     }
+    // makeToastSticky turns a toast into one that never auto-dismisses. Used
+    // for errors: a failed save may carry a validation message the user has
+    // not finished reading, so it waits for an explicit click or × instead of
+    // vanishing on a timer. Success/info toasts keep their timeout.
+    function makeToastSticky(el) {
+      if (el._sticky) return;
+      el._sticky = true;
+      el.classList.add('sticky');
+      const close = document.createElement('button');
+      close.className = 'toast-close';
+      close.textContent = '×';
+      close.setAttribute('aria-label', 'Dismiss');
+      el.appendChild(close);
+      el.addEventListener('click', () => dismissToast(el, null, null, true));
+    }
     function showToast(msg, type = 'info', persistent = false) {
       const container = document.getElementById('toast-container');
       const el = document.createElement('div');
@@ -11116,16 +11136,28 @@ function burnAreaChart() {
         setTimeout(() => { if (el.parentNode) dismissToast(el); }, TOAST_PROGRESS_MAX_MS);
         return el;
       }
+      if (type === 'error') {
+        makeToastSticky(el);
+        return el;
+      }
       setTimeout(() => dismissToast(el), TOAST_DURATION_MS);
       return el;
     }
-    function dismissToast(el, newMsg, newType) {
+    // dismissToast removes a toast, or (with newMsg) rewrites an in-flight
+    // toast into its result. `force` bypasses stickiness for the user-initiated
+    // click/× path, so a sticky error can still be dismissed on demand.
+    function dismissToast(el, newMsg, newType, force) {
       if (!el || !el.parentNode) return;
       if (newMsg) {
         el.textContent = newMsg;
         el.className = `toast ${newType || 'success'}`;
+        el._sticky = false;
+        // A resolved in-flight toast that resolved to an error stays put for
+        // the same reason a direct error toast does.
+        if (newType === 'error') { makeToastSticky(el); return; }
         setTimeout(() => { el.style.animation = 'toast-out 0.3s ease-in forwards'; setTimeout(() => el.remove(), 300); }, TOAST_DURATION_MS);
       } else {
+        if (el._sticky && !force) return;
         el.style.animation = 'toast-out 0.3s ease-in forwards';
         setTimeout(() => el.remove(), 300);
       }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2505,6 +2505,7 @@
       <a class="oc-nav-item" data-section="contributors-section" onclick="ocNavigate('contributors-section')"><span class="oc-nav-emoji">👥</span><span class="oc-nav-text">Contributors</span><span id="contributors-sidebar-badge" class="oc-nav-count" style="display:none"></span></a>
       <a class="oc-nav-item" data-section="audit-section" onclick="ocNavigate('audit-section')"><span class="oc-nav-emoji">📋</span><span class="oc-nav-text">Audit Log</span></a>
       <a class="oc-nav-item" data-section="nous-section" onclick="ocNavigate('nous-section')"><span class="oc-nav-emoji">🧪</span><span class="oc-nav-text">Strategy Lab</span></a>
+      <a class="oc-nav-item" data-section="faq-section" onclick="ocNavigate('faq-section')" title="Answers to common first-time questions: the Advisory Digest, ACMM levels, and how to advance"><span class="oc-nav-emoji">❓</span><span class="oc-nav-text">FAQ</span></a>
       <a class="oc-nav-item" id="welcome-nav-item" style="display:none" onclick="openWelcomeDialog()" title="Open the Getting Started checklist — one-time setup steps for a new hive"><span class="oc-nav-emoji">🚀</span><span class="oc-nav-text">Getting Started</span></a>
       <a class="oc-nav-item" href="/api/docs" target="_blank"><span class="oc-nav-emoji">📘</span><span class="oc-nav-text">API Spec (Redoc)</span></a>
     </div>
@@ -2671,6 +2672,140 @@
       </div>
       <div id="audit-panel" style="padding:12px;max-height:320px;overflow-y:auto">
         <div class="loading">Loading audit log...</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- FAQ — intentionally NOT ACMM-gated (no entry in applyACMMVisibility's
+       sidebarItems list and no display:none default), because the audience for
+       it is a confused L1/L2 user. Static content only: no JS, no fetch. -->
+  <div id="faq-section" style="margin-top: 16px; margin-bottom: 24px;">
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('faq-section')"><span class="section-chevron">▼</span> ❓ FAQ</h2>
+    <div class="section-body">
+      <div id="faq-panel" style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:16px;font-size:0.85rem;line-height:1.6;max-width:900px">
+
+        <p style="color:var(--muted);margin:0 0 18px">Common questions from first-time users. Everything below describes what this hive
+        actually does today — where behaviour is surprising, it is called out rather than smoothed over.</p>
+
+        <h3 style="font-size:0.95rem;margin:0 0 6px">What is the Advisory Digest for?</h3>
+        <p style="margin:0 0 8px"><strong>The Advisory Digest is the work ledger.</strong> It is the collection of
+        <strong>beads</strong> your agents open — the running record of what the hive has found and what it would act on,
+        if you let it. Agents create each bead with <code>bd create</code>; the digest rolls up every open bead of type
+        <code>advisory</code>, <code>bug</code>, or <code>feature</code>, grouped by the agent that filed it. Internal agent
+        work items (<code>task</code>, <code>decision</code>) are deliberately excluded so the ledger stays readable.</p>
+        <p style="margin:0 0 16px">You can read the same ledger in two places. Here in the dashboard, and in GitHub: the hive
+        opens a single issue titled <strong>🐝 Hive Advisory Report</strong> in your default repo and keeps a digest comment on
+        it up to date each cycle. That issue is the whole of the hive's GitHub footprint at Level 2 — reading it in GitHub
+        means the ledger lands where your normal workflow already lives.</p>
+
+        <h3 style="font-size:0.95rem;margin:0 0 6px">What do the colors mean?</h3>
+        <p style="margin:0 0 8px">The colored bar on the left of each finding, and its dot, encode <strong>severity</strong>, which is
+        derived directly from the priority the agent set on the bead (<code>--priority 0</code> through <code>3</code>):</p>
+        <ul style="margin:0 0 8px;padding-left:20px">
+          <li>🔴 <strong>critical</strong> (priority 0) — red bar</li>
+          <li>🟠 <strong>high</strong> (priority 1) — orange bar</li>
+          <li>🟡 <strong>medium</strong> (priority 2) — yellow bar</li>
+          <li>🔵 <strong>low</strong> (priority 3) — grey bar</li>
+          <li>⚪ <strong>info</strong> — anything else; grey bar</li>
+        </ul>
+        <p style="margin:0 0 16px;color:var(--muted)">Note the icon and the bar disagree slightly at the bottom end: <em>low</em> shows a blue dot but a
+        grey bar, since only critical/high/medium have dedicated bar colors. Severity is set by the agent that filed the
+        bead, using the priority rubric in that agent's policy — it is a judgement call, not a measurement.</p>
+
+        <h3 style="font-size:0.95rem;margin:0 0 6px">How are digest items selected and ordered?</h3>
+        <p style="margin:0 0 16px"><strong>They are not ranked by severity.</strong> This is the single most common misreading of the digest.
+        Findings are grouped by agent (agents sorted alphabetically), and within each agent they appear in the order the
+        beads were created — <strong>oldest first, chronologically</strong>. Severity is a label you can scan for; it has no
+        effect on position. A critical finding filed this morning sits <em>below</em> a low-severity one filed last week.
+        So: read the whole of an agent's group, or scan for 🔴/🟠, but do not assume the top of the list is the most
+        important thing. Selection is simply "every open advisory/bug/feature bead" — there is no cutoff or scoring.
+        Beads closed in the last 48 hours appear separately as recently resolved.</p>
+
+        <h3 style="font-size:0.95rem;margin:0 0 6px">What am I supposed to do with it?</h3>
+        <p style="margin:0 0 8px"><strong>Level 2 is a trust level.</strong> It exists to show you how Hive works, what it
+        would find, and how it might fix it — <em>if you let it</em>. So the job at L2 is not to fix everything in the ledger.
+        It is to decide whether you believe the ledger.</p>
+        <p style="margin:0 0 8px">The intended way to do that: point <strong>your own</strong> agent — <code>claude</code> CLI,
+        <code>bob</code> shell, <code>copilot</code> CLI, running on your own laptop — at the 🐝 Hive Advisory Report issue, and
+        have it read the findings and suss out whether they make sense. You are reviewing the hive's judgement using a tool
+        you already control, on a repo the hive cannot write to. That is the whole point of the level.</p>
+        <p style="margin:0 0 8px">Alongside that:</p>
+        <ol style="margin:0 0 16px;padding-left:20px">
+          <li>Skim for 🔴 and 🟠 first, since ordering will not surface them for you (see below).</li>
+          <li>For anything you agree with and want tracked, open a real GitHub issue yourself — at L2 the agents cannot.</li>
+          <li>A large ledger on a first run is normal. It is the accumulated backlog of a codebase nobody has audited
+              before, not a list of new problems, and not a queue you are expected to burn down.</li>
+        </ol>
+
+        <h3 style="font-size:0.95rem;margin:0 0 6px">How do I move from L2 to L3?</h3>
+        <p style="margin:0 0 8px"><strong>Change to L3 whenever you like — there is no gate.</strong> No quota, no checklist,
+        no criteria that must go green first. The only criterion is your own judgement: <em>do you trust the advisory findings
+        you have been reading?</em> That is what L2 is for. Once you believe the beads, you are ready.</p>
+        <p style="margin:0 0 8px"><strong>What changes:</strong> at L2 (<em>Instructed</em>) the only thing the hive touches in
+        GitHub is its own 🐝 Hive Advisory Report issue. L3 (<em>Measured</em>) introduces the <strong>quality agent</strong>, and
+        its job is building test cases — making your repo resilient to code changes from <em>any</em> contributor that would
+        destabilise it, break it, or violate patterns you prefer. That is the next step in gaining trust: not more findings,
+        but a safety net. Concretely, the quality agent may open GitHub issues
+        and <strong>hold-gated pull requests</strong> that add test coverage. "Hold-gated" means every PR is opened with a
+        <code>hold</code> label, and the agent is forbidden from merging it or removing that label — so a human merges every
+        change, always. L3 is deliberately scoped to <em>tests only</em>: no production code, no refactors, no features.
+        The point of L3 is to build the test coverage that makes the more automated levels above it safe.</p>
+        <p style="margin:0 0 8px"><strong>Why this is the pivotal level.</strong> Test coverage is the critical safeguard that
+        makes every later level defensible. Agents opening issues and PRs on their own (L4–L5), and eventually auto-merging
+        them (L6), are only safe once there are tests that can catch a bad change. So the ACMM ladder is not a feature ladder
+        you climb for more capability — each level earns the trust that makes the next one safe. L3 is where you build the
+        net that the automation above it falls into.</p>
+        <p style="margin:0 0 8px"><strong>Optional aid, not a gate:</strong> the <strong>ACMM Eval</strong> page scores your repo
+        against per-level criteria and reports a <em>Codebase Readiness</em> level. It is useful for seeing where your test and
+        CI scaffolding currently stands, and <em>Criteria Passed</em> will show you which checks fail. But nothing there blocks
+        or licenses a level change — you can move to L3 with readiness reading L1. Treat it as information, not permission.</p>
+        <p style="margin:0 0 16px"><strong>How to actually change it:</strong> use the ACMM badge in the sidebar, or the
+        <em>Change level ▾</em> button on the ACMM Eval section. Both open the same dialog. It offers two distinct actions,
+        and the difference matters: <strong>Preview</strong> only changes what this dashboard displays and leaves running
+        agents untouched, while <strong>Apply</strong> is the real move — it creates the agents in that level's pack, resumes
+        them, and pauses agents not in the pack. Do not edit <code>hive.yaml</code> by hand to change level; the dialog is
+        the supported path.</p>
+
+        <h3 style="font-size:0.95rem;margin:0 0 6px">What about L4, L5, L6?</h3>
+        <p style="margin:0 0 8px">Each level hands over more of the <em>acting</em>, and each is only safe because of the level
+        below it. The end-to-end journey: <strong>L2 shows you what Hive would find; L3 builds the safety net that makes acting
+        on those findings safe; L4–L6 progressively hand over more of the acting.</strong> Nothing is fully autonomous until L6:</p>
+        <ul style="margin:0 0 16px;padding-left:20px">
+          <li><strong>L1 Assisted</strong> — advisory only; typically used to start a new feature with tools like speckit.</li>
+          <li><strong>L2 Instructed</strong> — the trust level. Advisory beads only; the sole GitHub write is the
+              🐝 Hive Advisory Report issue and its digest comment.</li>
+          <li><strong>L3 Measured</strong> — introduces the quality agent: hold-gated test-coverage PRs, CI gates. The
+              safeguard everything above depends on.</li>
+          <li><strong>L4 Adaptive</strong> — agents open issues, plus a security-check agent. Still <em>not</em> autonomous:
+              issues and PRs remain hold-gated for human review.</li>
+          <li><strong>L5 Semi-Automated</strong> — PRs carry a hold label, reviewed in batches.</li>
+          <li><strong>L6 Autonomous</strong> — auto-merge once CI is green.</li>
+        </ul>
+        <p style="margin:0 0 16px;color:var(--muted)">L4 and above become available after provisioning; newly created hives start in the L1–L3 range.</p>
+
+        <h3 style="font-size:0.95rem;margin:0 0 6px">Why couldn't the Guide agent answer my questions?</h3>
+        <p style="margin:0 0 16px">Because the guide agent documents <em>your</em> project, not Hive itself. Its job is to audit your
+        repo's README, getting-started, architecture and contributing docs and report the gaps — at L1–L2 as beads and an
+        issue, at L3+ as doc PRs. It is explicitly barred from writing code, filing triage issues, or reviewing PRs, and it
+        has no special knowledge of Hive's own workflow or ACMM levels. Questions about how to <em>operate</em> your hive
+        belong here, not to an agent.</p>
+
+        <h3 style="font-size:0.95rem;margin:0 0 6px">A first week, end to end</h3>
+        <ol style="margin:0;padding-left:20px">
+          <li><strong>Start at L1–L2.</strong> Let the agents run a full cycle against your repos and populate the ledger.</li>
+          <li><strong>Read the ledger</strong> on the Advisory page, or on the 🐝 Hive Advisory Report issue in your default
+              repo. Expect it to be long. Scan for 🔴/🟠 rather than reading top-down.</li>
+          <li><strong>Audit it with your own agent.</strong> Point <code>claude</code>, <code>bob</code>, or
+              <code>copilot</code> on your laptop at that issue and ask whether the findings hold up. This is the core L2
+              activity — you are calibrating whether the hive's judgement matches yours.</li>
+          <li><strong>Act on a handful.</strong> File real issues for the findings you agree with; ignore the rest.</li>
+          <li><strong>Advance to L3 when you trust the findings</strong> — that judgement is the only prerequisite. Use the
+              ACMM dialog and choose <em>Apply</em> (not Preview). Optionally glance at ACMM Eval first for context on where
+              your test and CI scaffolding stands.</li>
+          <li><strong>Review the first hold-gated PRs.</strong> They will be test-coverage PRs from the quality agent.
+              Merging them is a manual step, by design — and the coverage they add is what makes L4+ safe to turn on.</li>
+        </ol>
+
       </div>
     </div>
   </div>
@@ -9994,7 +10129,8 @@ function burnAreaChart() {
       const COLLAPSIBLE_SECTION_IDS = [
         'advisory-section', 'repos-section', 'beads-section', 'acmm-eval-section',
         'audit-section', 'nous-section', 'inception-section', 'knowledge-section',
-        'contributors-section', 'debug-section', 'logs-section', 'agents-section'
+        'contributors-section', 'debug-section', 'logs-section', 'agents-section',
+        'faq-section'
       ];
       COLLAPSIBLE_SECTION_IDS.forEach(applySectionCollapse);
       // Update compact-all button text

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -694,6 +694,16 @@
     /* .gh-auth-overlay/.gh-auth-modal — modal overlay/panel recipes (end of style block).
        z-index encodes stacking intent — do not change. */
     .gh-auth-overlay { z-index: 9999; }
+    /* Credential dialogs opened FROM Governor config must stack above it.
+       .config-overlay is 10000 and .gh-auth-overlay is 9999, so a bob /
+       Copilot / Claude key dialog launched from the config modal rendered
+       BEHIND it — visible only as a dimmed backdrop, with the key field
+       unreachable. These are always launched on top of another modal, never
+       beneath one, so they sit above .config-overlay (10000) and below
+       .hive-dialog-overlay (20000), which is a full-page takeover. The shared
+       9999 stays untouched: the other .gh-auth-overlay users (sign-in,
+       setup) open from the page itself and their stacking intent is correct. */
+    .cred-dialog-overlay { z-index: 10001; }
     .gh-auth-modal { padding: 32px; max-width: 420px; width: 90%; text-align: center; }
     .gh-auth-modal h3 { margin: 0 0 8px; font-size: var(--fs-lg); font-weight: 700; color: var(--text); }
     .gh-auth-modal p { color: var(--muted); font-size: 0.85rem; margin: 4px 0; }
@@ -1985,7 +1995,7 @@
        encode stacking intent). The acmm JS-built overlay keeps its inline
        styles until the Phase 4 template sweep. */
     body.modal-open { overflow: hidden; }
-    .gh-auth-overlay, .config-overlay, .hive-dialog-overlay, .nous-config-overlay, .acmm-dialog-overlay {
+    .gh-auth-overlay, .cred-dialog-overlay, .config-overlay, .hive-dialog-overlay, .nous-config-overlay, .acmm-dialog-overlay {
       position: fixed; inset: 0;
       background: rgba(0, 0, 0, 0.55);
       -webkit-backdrop-filter: blur(4px); backdrop-filter: blur(4px);
@@ -2927,7 +2937,7 @@
     // hive-dialog, nous) and any added later; per-modal open/close handlers
     // no longer need to touch body.style.overflow.
     (function installModalScrollLock() {
-      var OVERLAY_SELECTOR = '.config-overlay, .gh-auth-overlay, .hive-dialog-overlay, .nous-config-overlay, .acmm-dialog-overlay, #oc-drawer-backdrop';
+      var OVERLAY_SELECTOR = '.config-overlay, .gh-auth-overlay, .cred-dialog-overlay, .hive-dialog-overlay, .nous-config-overlay, .acmm-dialog-overlay, #oc-drawer-backdrop';
       function anyOverlayOpen() {
         var overlays = document.querySelectorAll(OVERLAY_SELECTOR);
         for (var i = 0; i < overlays.length; i++) {
@@ -11186,7 +11196,7 @@ function burnAreaChart() {
         // Compact first-selection prompt on the gh-auth-modal pattern (the
         // Claude login modal): centered amber title, tight labeled inputs,
         // centered buttons, 480px max width (#1787).
-        overlay.className = 'gh-auth-overlay';
+        overlay.className = 'gh-auth-overlay cred-dialog-overlay';
         overlay.innerHTML = `<div class="gh-auth-modal" style="max-width:480px;text-align:left">
           <h3 style="color:var(--amber);text-align:center">Configure LiteLLM</h3>
           <p style="margin:0 0 14px;line-height:1.5">No LiteLLM gateway is configured yet. Enter the gateway URL and your API key (editable later under Governor Config → LiteLLM).</p>
@@ -16625,7 +16635,7 @@ function burnAreaChart() {
       if (overlay) { overlay.remove(); }
       overlay = document.createElement('div');
       overlay.id = 'copilot-auth-overlay';
-      overlay.className = 'gh-auth-overlay';
+      overlay.className = 'gh-auth-overlay cred-dialog-overlay';
       overlay.innerHTML = '<div class="gh-auth-modal" style="max-width:480px;text-align:center">' +
         '<h3 style="color:var(--green)">Login GitHub Copilot</h3>' +
         '<p style="color:var(--muted);font-size:0.85rem;margin:12px 0">Enter this one-time code at github.com/login/device:</p>' +
@@ -16691,12 +16701,24 @@ function burnAreaChart() {
     //
     // `configured` / `source` are passed in by the caller (the Bob tab already
     // fetched them) so opening the dialog does not re-round-trip.
+    // Where an operator obtains a bob API key. Named constants rather than
+    // inline literals so the three links stay in one place if IBM moves them.
+    //
+    // NOTE ON SCOPE: IBM's own docs disagree. The API-keys page describes
+    // General as usable across services, while the bob Shell setup page says
+    // "Create an API key with Scope set to Inference". The Shell page is the
+    // authoritative one for this CLI, so the dialog says Inference and links
+    // BOTH pages so the operator can check if a key is rejected.
+    var BOB_PORTAL_URL = 'https://bob.ibm.com';
+    var BOB_API_KEY_DOCS_URL = 'https://bob.ibm.com/docs/ide/account/api-keys';
+    var BOB_SHELL_SETUP_DOCS_URL = 'https://bob.ibm.com/docs/shell/getting-started/install-and-setup';
+
     function openBobKeyDialog(configured, source) {
       var overlay = document.getElementById('bob-key-overlay');
       if (overlay) { overlay.remove(); }
       overlay = document.createElement('div');
       overlay.id = 'bob-key-overlay';
-      overlay.className = 'gh-auth-overlay';
+      overlay.className = 'gh-auth-overlay cred-dialog-overlay';
       overlay.innerHTML = '<div class="gh-auth-modal" style="max-width:520px;text-align:left">' +
         '<h3 style="color:#4589ff;text-align:center">bob API key</h3>' +
         '<p style="color:var(--muted);font-size:0.85rem;margin:12px 0">' +
@@ -16707,6 +16729,26 @@ function burnAreaChart() {
           ? '<div style="color:var(--green);font-size:0.8rem;margin:8px 0">✓ A key is currently set' +
               (source ? ' (' + esc(source) + ')' : '') + '. Entering a new one replaces it.</div>'
           : '<div style="color:var(--muted);font-size:0.8rem;margin:8px 0">No key is set — agents using bob cannot start.</div>') +
+        /* Where to get a key. Without this the dialog assumes the operator
+           already knows the portal flow, and the scope choice is easy to get
+           wrong: an Inference-scoped key is what bob Shell documents, and a
+           key is shown exactly once, so a mis-scoped key means starting over. */
+        '<div style="background:rgba(69,137,255,0.08);border:1px solid rgba(69,137,255,0.25);' +
+          'border-radius:6px;padding:10px 12px;margin:12px 0;font-size:0.8rem;color:var(--muted)">' +
+          '<div style="color:var(--text);font-weight:600;margin-bottom:6px">How to get a key</div>' +
+          '<ol style="margin:0;padding-left:18px;line-height:1.6">' +
+            '<li>Sign in at <a href="' + BOB_PORTAL_URL + '" target="_blank" rel="noopener noreferrer" ' +
+              'style="color:#4589ff">bob.ibm.com</a> and open your subscription instance.</li>' +
+            '<li>Go to API key management and create a key with <strong>Scope: Inference</strong>.</li>' +
+            '<li>Copy it immediately — IBM shows the value only once.</li>' +
+          '</ol>' +
+          '<div style="margin-top:8px">' +
+            '<a href="' + BOB_API_KEY_DOCS_URL + '" target="_blank" rel="noopener noreferrer" ' +
+              'style="color:#4589ff">API key docs</a> · ' +
+            '<a href="' + BOB_SHELL_SETUP_DOCS_URL + '" target="_blank" rel="noopener noreferrer" ' +
+              'style="color:#4589ff">bob Shell setup</a>' +
+          '</div>' +
+        '</div>' +
         '<input id="bob-key-input" type="password" autocomplete="off" spellcheck="false" ' +
           'placeholder="Paste the bob API key" ' +
           'style="width:100%;box-sizing:border-box;padding:8px;border-radius:6px;border:1px solid var(--border);' +
@@ -16839,7 +16881,7 @@ function burnAreaChart() {
       if (overlay) { overlay.remove(); }
       overlay = document.createElement('div');
       overlay.id = 'claude-auth-overlay';
-      overlay.className = 'gh-auth-overlay';
+      overlay.className = 'gh-auth-overlay cred-dialog-overlay';
       var countdownSec = CLAUDE_AUTH_TAB_DELAY_MS / 1000;
       overlay.innerHTML = '<div class="gh-auth-modal" style="max-width:560px;text-align:left">' +
         '<h3 style="color:#d97706;text-align:center">Login Claude Code</h3>' +

--- a/v2/pkg/dashboard/trajectory_coverage_test.go
+++ b/v2/pkg/dashboard/trajectory_coverage_test.go
@@ -110,7 +110,12 @@ func TestCov_ReconcileTrajectoryAlert(t *testing.T) {
 	s, deps := covServer(t)
 	g := &deps.Config.Governor
 
-	// Enabled + no reviewer endpoint/model → alert raised.
+	// The banner alert is no longer raised in ANY state — the half-configured
+	// case is surfaced inline in Governor Config → General instead. The lane
+	// defaults to ON, so raising it here fired on every unconfigured hive.
+
+	// Enabled + no reviewer endpoint/model → still no alert (the case that
+	// used to raise it; this is the behaviour change under test).
 	enabled := true
 	g.Trajectory.Enabled = &enabled
 	g.Trajectory.Endpoint = ""
@@ -118,25 +123,36 @@ func TestCov_ReconcileTrajectoryAlert(t *testing.T) {
 	g.LiteLLM.Endpoint = ""
 	g.LiteLLM.DefaultModel = ""
 	s.ReconcileTrajectoryAlert(g)
-	if !covHasAlert(s, TrajectoryNotConfiguredAlertID) {
-		t.Error("expected trajectory-not-configured alert to be raised")
+	if covHasAlert(s, TrajectoryNotConfiguredAlertID) {
+		t.Error("expected no banner alert when enabled but unconfigured")
 	}
 
-	// Disabled → alert cleared.
+	// Disabled → no alert.
 	disabled := false
 	g.Trajectory.Enabled = &disabled
 	s.ReconcileTrajectoryAlert(g)
 	if covHasAlert(s, TrajectoryNotConfiguredAlertID) {
-		t.Error("expected alert cleared when disabled")
+		t.Error("expected no alert when disabled")
 	}
 
-	// Enabled + reviewer ready → alert cleared.
+	// Enabled + reviewer ready → no alert.
 	g.Trajectory.Enabled = &enabled
 	g.Trajectory.Endpoint = "https://reviewer.local"
 	g.Trajectory.Model = "cheap-model"
 	s.ReconcileTrajectoryAlert(g)
 	if covHasAlert(s, TrajectoryNotConfiguredAlertID) {
-		t.Error("expected alert cleared when reviewer ready")
+		t.Error("expected no alert when reviewer ready")
+	}
+
+	// A stale alert persisted by an older build must be cleared, since that is
+	// now the function's only job.
+	s.AddSystemAlert(TrajectoryNotConfiguredAlertID, "warning", "stale alert from an older build")
+	g.Trajectory.Enabled = &enabled
+	g.Trajectory.Endpoint = ""
+	g.Trajectory.Model = ""
+	s.ReconcileTrajectoryAlert(g)
+	if covHasAlert(s, TrajectoryNotConfiguredAlertID) {
+		t.Error("expected a stale legacy alert to be cleared")
 	}
 }
 

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -120,20 +120,32 @@ func (a *AppAuth) Token(ctx context.Context) (string, error) {
 		return a.cachedToken, nil
 	}
 
-	jwtToken, err := a.generateJWT()
+	// We are inside the tokenRefreshBuffer window (or have no token yet): try to
+	// PROACTIVELY mint a fresh token. A GitHub installation token is minted with
+	// a live network call to CreateInstallationToken, and on GHE-adjacent /
+	// firewalled clusters that call intermittently fails (transient 5xx, TLS
+	// blip, network hiccup). Crucially, a proactive-refresh failure is NOT an
+	// auth failure while the currently-cached token is still valid: the buffer
+	// only exists to refresh EARLY, so a blip here must fall back to the good
+	// cached token rather than surface an error. Erroring here is exactly what
+	// made the dashboard's github_auth health check flap red↔green on a hive
+	// whose App is genuinely working. We only hard-fail once no usable token
+	// remains — i.e. the cache is empty or the cached token has truly expired.
+	newToken, expiry, err := a.mintInstallationToken(ctx)
 	if err != nil {
-		return "", fmt.Errorf("generating JWT: %w", err)
+		if a.cachedToken != "" && time.Now().Before(a.tokenExpiry) {
+			a.logger.Warn("github app token proactive refresh failed; serving still-valid cached token",
+				"expires_at", a.tokenExpiry.Format(time.RFC3339),
+				"installation_id", a.installationID,
+				"error", err,
+			)
+			return a.cachedToken, nil
+		}
+		return "", err
 	}
 
-	jwtClient := gh.NewClient(nil).WithAuthToken(jwtToken)
-	setBaseURL(jwtClient, a.apiURL)
-	installToken, _, err := jwtClient.Apps.CreateInstallationToken(ctx, a.installationID, nil)
-	if err != nil {
-		return "", fmt.Errorf("creating installation token: %w", err)
-	}
-
-	a.cachedToken = installToken.GetToken()
-	a.tokenExpiry = installToken.GetExpiresAt().Time
+	a.cachedToken = newToken
+	a.tokenExpiry = expiry
 	a.logger.Info("github app token refreshed",
 		"expires_at", a.tokenExpiry.Format(time.RFC3339),
 		"installation_id", a.installationID,
@@ -147,6 +159,27 @@ func (a *AppAuth) Token(ctx context.Context) (string, error) {
 	}
 
 	return a.cachedToken, nil
+}
+
+// mintInstallationToken performs the live GitHub call that exchanges an
+// App JWT for an installation token. It is the network step shared by the
+// cache-refresh path in Token(); it does NOT touch the cache or take the
+// mutex (callers already hold a.mu). It is the only failure-prone step in
+// Token(), so isolating it lets Token() distinguish "mint blipped" (fall back
+// to a still-valid cached token) from a genuine expiry.
+func (a *AppAuth) mintInstallationToken(ctx context.Context) (token string, expiry time.Time, err error) {
+	jwtToken, err := a.generateJWT()
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("generating JWT: %w", err)
+	}
+
+	jwtClient := gh.NewClient(nil).WithAuthToken(jwtToken)
+	setBaseURL(jwtClient, a.apiURL)
+	installToken, _, err := jwtClient.Apps.CreateInstallationToken(ctx, a.installationID, nil)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("creating installation token: %w", err)
+	}
+	return installToken.GetToken(), installToken.GetExpiresAt().Time, nil
 }
 
 // ScopedToken creates a short-lived installation token with permissions

--- a/v2/pkg/github/app_token_flap_test.go
+++ b/v2/pkg/github/app_token_flap_test.go
@@ -1,0 +1,170 @@
+package github
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// These tests lock in the fix for the dashboard's github_auth health check
+// flapping red↔green on a hive whose GitHub App is genuinely working.
+//
+// Root cause: Token() serves the cached installation token only while
+// now < tokenExpiry-tokenRefreshBuffer. Once inside the final buffer window it
+// makes a live CreateInstallationToken network call on EVERY call. On
+// GHE-adjacent / firewalled clusters that call intermittently blips (transient
+// 5xx / TLS / network). The old code returned that error even though the
+// cached token was still valid, so the once-per-heartbeat health check flipped
+// github_auth to fail and back — Degraded rabbiting on a working hive.
+//
+// The fix: a proactive-refresh blip falls back to the still-valid cached token.
+// A genuine failure (no cached token, or the cached token has truly expired)
+// must still error so a real outage still shows Degraded.
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// TestToken_TransientMintErrorServesValidCache is the core false-flap case:
+// we are inside the refresh buffer (so Token() attempts a re-mint), the mint
+// blips (500), but the cached token is still valid — Token() must return the
+// cached token, NOT an error.
+func TestToken_TransientMintErrorServesValidCache(t *testing.T) {
+	key, _ := generateTestKey(t)
+
+	// GitHub mint endpoint always fails (simulates a transient blip).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream hiccup", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         quietLogger(),
+		apiURL:         server.URL,
+		cachePath:      t.TempDir() + "/token-cache",
+		cachedToken:    "still-valid-cached-token",
+		// Inside the refresh buffer window (< tokenRefreshBuffer to expiry) but
+		// NOT yet expired: the token is still perfectly usable.
+		tokenExpiry: time.Now().Add(tokenRefreshBuffer / 2),
+	}
+
+	token, err := auth.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token returned error on a transient mint blip while cache is still valid: %v", err)
+	}
+	if token != "still-valid-cached-token" {
+		t.Errorf("token = %q, want still-valid-cached-token (should serve cache through the blip)", token)
+	}
+}
+
+// TestToken_SustainedFailureNoCacheStillErrors proves the fix does not mask a
+// real failure: with no cached token, a failing mint must error.
+func TestToken_SustainedFailureNoCacheStillErrors(t *testing.T) {
+	key, _ := generateTestKey(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "app not installed", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         quietLogger(),
+		apiURL:         server.URL,
+		cachePath:      t.TempDir() + "/token-cache",
+		// No cached token at all.
+	}
+
+	if _, err := auth.Token(context.Background()); err == nil {
+		t.Fatal("expected an error when the App is genuinely broken and there is no cached token")
+	}
+}
+
+// TestToken_ExpiredCacheFailingMintStillErrors proves that once the cached
+// token has TRULY expired, a failing mint still errors — an expired token is
+// not a usable credential, so falling back to it would hide a real outage.
+func TestToken_ExpiredCacheFailingMintStillErrors(t *testing.T) {
+	key, _ := generateTestKey(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream hiccup", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         quietLogger(),
+		apiURL:         server.URL,
+		cachePath:      t.TempDir() + "/token-cache",
+		cachedToken:    "long-expired-token",
+		tokenExpiry:    time.Now().Add(-time.Minute), // already expired
+	}
+
+	if _, err := auth.Token(context.Background()); err == nil {
+		t.Fatal("expected an error when the cached token has expired and the mint keeps failing")
+	}
+}
+
+// TestToken_TransientThenRecoveryDoesNotFlap simulates the live sequence: a
+// heartbeat mints, the next hits a blip (must not error), and the following one
+// recovers with a fresh token. The health check would see pass→pass→pass, never
+// flipping to fail — i.e. no rabbiting on a working hive.
+func TestToken_TransientThenRecoveryDoesNotFlap(t *testing.T) {
+	key, _ := generateTestKey(t)
+
+	var fail atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fail.Load() {
+			http.Error(w, "blip", http.StatusBadGateway)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token":"fresh-token","expires_at":"` +
+			time.Now().Add(time.Hour).Format(time.RFC3339) + `"}`))
+	}))
+	defer server.Close()
+
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         quietLogger(),
+		apiURL:         server.URL,
+		cachePath:      t.TempDir() + "/token-cache",
+		cachedToken:    "boot-token",
+		// Inside the buffer window so every call attempts a re-mint.
+		tokenExpiry: time.Now().Add(tokenRefreshBuffer / 2),
+	}
+
+	// 1) Blip: must serve the still-valid cached token, no error.
+	fail.Store(true)
+	tok, err := auth.Token(context.Background())
+	if err != nil {
+		t.Fatalf("blip poll errored instead of serving cache: %v", err)
+	}
+	if tok != "boot-token" {
+		t.Errorf("blip poll token = %q, want boot-token", tok)
+	}
+
+	// 2) Recovery: mint succeeds, cache advances to the fresh token.
+	fail.Store(false)
+	tok, err = auth.Token(context.Background())
+	if err != nil {
+		t.Fatalf("recovery poll errored: %v", err)
+	}
+	if tok != "fresh-token" {
+		t.Errorf("recovery poll token = %q, want fresh-token", tok)
+	}
+}

--- a/v2/pkg/hub/alerts.go
+++ b/v2/pkg/hub/alerts.go
@@ -77,6 +77,10 @@ const (
 	AlertTypeOffline = "offline"
 	// AlertTypeStuckUpgrade — Upgrading has been true past staleUpgradeTimeout.
 	AlertTypeStuckUpgrade = "stuck-upgrade"
+	// AlertTypeFailedUpgrade — the spoke explicitly reported an upgrade it could
+	// not complete. Distinct from stuck-upgrade: this one has a known cause the
+	// spoke told us, so it is Critical and carries the underlying error.
+	AlertTypeFailedUpgrade = "failed-upgrade"
 	// AlertTypeHealthCheckFailing — a named check inside Health reports "fail".
 	AlertTypeHealthCheckFailing = "health-check-failing"
 	// AlertTypeTokenBurn — token consumption is anomalous versus the fleet
@@ -432,6 +436,8 @@ type alertHive struct {
 	Upgrading        bool
 	UpgradeStartedAt time.Time
 	UpgradeTarget    string
+	UpgradeFailed    bool
+	UpgradeError     string
 	TotalTokens24h   int64
 	Health           map[string]any
 	ProvStatus       string
@@ -451,6 +457,8 @@ func alertHiveFromEntry(h MyHiveEntry) alertHive {
 		Upgrading:        h.Upgrading,
 		UpgradeStartedAt: h.UpgradeStartedAt,
 		UpgradeTarget:    h.UpgradeTarget,
+		UpgradeFailed:    h.UpgradeFailed,
+		UpgradeError:     h.UpgradeError,
 		TotalTokens24h:   h.TotalTokens24h,
 		Health:           h.Health,
 		ProvStatus:       h.ProvStatus,
@@ -684,6 +692,20 @@ func evaluateAlerts(state *alertState, hives []alertHive, driftAlerts []Alert, n
 		// --- Rule: upgrade in flight past staleUpgradeTimeout. Reuses the
 		// EXISTING constant rather than introducing a second, divergent notion
 		// of "stuck upgrade". ---
+		// --- Rule: the spoke told us the upgrade FAILED. Reported ahead of the
+		// stuck-upgrade rule below because a known cause beats a timeout guess,
+		// and Critical because it never resolves on its own. ---
+		if h.UpgradeFailed {
+			reason := "Upgrade failed"
+			if t := strings.TrimSpace(h.UpgradeTarget); t != "" {
+				reason += " (target " + t + ")"
+			}
+			if e := strings.TrimSpace(h.UpgradeError); e != "" {
+				reason += ": " + e
+			}
+			add(h.ID, h.Name, AlertTypeFailedUpgrade, AlertSeverityCritical, reason)
+		}
+
 		if h.Upgrading && !h.UpgradeStartedAt.IsZero() {
 			if age := now.Sub(h.UpgradeStartedAt); age > staleUpgradeTimeout {
 				reason := "Upgrade in flight for " + roundedDuration(age) +

--- a/v2/pkg/hub/delete_hive_registry_test.go
+++ b/v2/pkg/hub/delete_hive_registry_test.go
@@ -1,0 +1,322 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// These tests cover the "ghost hive" bug: deleting a hosted hive tore down the
+// Kubernetes resources but left the entry in the hub registry, so the hive kept
+// rendering in "My Hives" forever and could never be removed from the UI.
+
+// helperDeleteHiveEnv points the SaaS hive dir and the registry file at temp
+// paths and returns a mux wired to handleDeleteHive.
+func helperDeleteHiveEnv(t *testing.T) (*HubServer, *http.ServeMux) {
+	t.Helper()
+	provisionWG.Wait()
+
+	dir := t.TempDir()
+	oldHives := saasHivesDir
+	oldUsers := saasUsersDir
+	oldRegistry := registryPath
+
+	saasHivesDir = filepath.Join(dir, "hives")
+	saasUsersDir = filepath.Join(dir, "users")
+	registryPath = filepath.Join(dir, "hub-registry.json")
+	if err := os.MkdirAll(saasHivesDir, 0o755); err != nil {
+		t.Fatalf("mkdir hives: %v", err)
+	}
+	if err := os.MkdirAll(saasUsersDir, 0o755); err != nil {
+		t.Fatalf("mkdir users: %v", err)
+	}
+
+	t.Cleanup(func() {
+		provisionWG.Wait()
+		saasHivesDir = oldHives
+		saasUsersDir = oldUsers
+		registryPath = oldRegistry
+	})
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /api/saas/hives/{id}", srv.handleDeleteHive)
+	return srv, mux
+}
+
+// helperRegistryHasHive reports whether the in-memory registry holds an entry.
+func helperRegistryHasHive(s *HubServer, id string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, h := range s.registry.Hives {
+		if h.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// helperPersistedRegistryHasHive reads the registry back off disk. This is the
+// representation that survives a hub restart, so it is what actually determines
+// whether a deleted hive stays deleted.
+func helperPersistedRegistryHasHive(t *testing.T, id string) bool {
+	t.Helper()
+	data, err := os.ReadFile(registryPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+		t.Fatalf("read registry: %v", err)
+	}
+	var reg Registry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		t.Fatalf("parse registry: %v", err)
+	}
+	for _, h := range reg.Hives {
+		if h.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDeleteHiveRemovesRegistryEntryFromMemoryAndDisk is the core regression:
+// after a successful delete the hive must be absent from both the in-memory
+// registry (what the listing renders) and the on-disk registry (what a restart
+// reloads). Removing it from only one leaves the hive reappearing.
+func TestDeleteHiveRemovesRegistryEntryFromMemoryAndDisk(t *testing.T) {
+	cleanup := helperSetupAuthUser(t, "ghp_del_reg", "del-reg-owner")
+	defer cleanup()
+
+	srv, mux := helperDeleteHiveEnv(t)
+
+	const hiveID = "hosted-del-reg-hive"
+	if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: "del-reg-owner", ClusterID: defaultClusterID}); err != nil {
+		t.Fatalf("seed hive: %v", err)
+	}
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: "del-reg-owner", Online: true}}
+	srv.mu.Unlock()
+	if err := srv.saveRegistryNow(); err != nil {
+		t.Fatalf("seed registry: %v", err)
+	}
+
+	req := httptest.NewRequest("DELETE", "/api/saas/hives/"+hiveID, nil)
+	req.Header.Set("Authorization", "Bearer ghp_del_reg")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if helperRegistryHasHive(srv, hiveID) {
+		t.Error("hive still present in the in-memory registry after delete")
+	}
+	if helperPersistedRegistryHasHive(t, hiveID) {
+		t.Error("hive still present in the persisted registry after delete (would resurrect on hub restart)")
+	}
+}
+
+// TestDeleteHiveWithMissingNamespaceStillRemovesRegistryEntry reproduces the
+// exact stuck state the user hit: the namespace and pods were already gone, but
+// the registry row survived and the UI kept showing the hive. Deleting a hive
+// whose cluster-side resources no longer exist must still clear the row.
+func TestDeleteHiveWithMissingNamespaceStillRemovesRegistryEntry(t *testing.T) {
+	cleanup := helperSetupAuthUser(t, "ghp_del_gone", "del-gone-owner")
+	defer cleanup()
+
+	srv, mux := helperDeleteHiveEnv(t)
+
+	const hiveID = "hosted-del-gone-hive"
+	// No namespace exists for this hive; kubectl delete --ignore-not-found is a
+	// no-op / failure depending on cluster reachability. Either way the registry
+	// entry must go.
+	if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: "del-gone-owner", ClusterID: defaultClusterID}); err != nil {
+		t.Fatalf("seed hive: %v", err)
+	}
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: "del-gone-owner", Online: false}}
+	srv.mu.Unlock()
+
+	req := httptest.NewRequest("DELETE", "/api/saas/hives/"+hiveID, nil)
+	req.Header.Set("Authorization", "Bearer ghp_del_gone")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 even with the namespace already gone, got %d body=%s", w.Code, w.Body.String())
+	}
+	if helperRegistryHasHive(srv, hiveID) {
+		t.Error("ghost entry: hive whose namespace was already gone remained in the registry")
+	}
+	if helperPersistedRegistryHasHive(t, hiveID) {
+		t.Error("ghost entry persisted to disk for a hive whose namespace was already gone")
+	}
+}
+
+// TestDeleteHiveWithNoClusterConfigStillRemovesEntryAndWarns covers the branch
+// that caused the production ghost: clusterForHive returned nil, the handler
+// returned 500 and never reached removeRegistryEntry, so the row was stranded
+// permanently. Now the entry is removed and the partial outcome is reported.
+func TestDeleteHiveWithNoClusterConfigStillRemovesEntryAndWarns(t *testing.T) {
+	cleanup := helperSetupAuthUser(t, "ghp_del_nocluster", "del-nocluster-owner")
+	defer cleanup()
+
+	srv, mux := helperDeleteHiveEnv(t)
+	// Drop every cluster config so clusterForHive cannot resolve one.
+	srv.clusters = map[string]ClusterConfig{}
+
+	const hiveID = "hosted-del-nocluster-hive"
+	if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: "del-nocluster-owner", ClusterID: "cluster-that-was-removed"}); err != nil {
+		t.Fatalf("seed hive: %v", err)
+	}
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: "del-nocluster-owner", Online: false}}
+	srv.mu.Unlock()
+
+	req := httptest.NewRequest("DELETE", "/api/saas/hives/"+hiveID, nil)
+	req.Header.Set("Authorization", "Bearer ghp_del_nocluster")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 with a partial-delete body, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("parse response: %v (body=%s)", err, w.Body.String())
+	}
+	if body["status"] != deleteStatusPartial {
+		t.Errorf("expected status %q so the user learns cleanup was incomplete, got %q", deleteStatusPartial, body["status"])
+	}
+	if body["warning"] == "" {
+		t.Error("partial delete must carry a warning explaining what was left behind")
+	}
+
+	// The critical assertion: a teardown that could not run must NOT leave a ghost.
+	if helperRegistryHasHive(srv, hiveID) {
+		t.Error("ghost entry: registry row survived a delete whose teardown could not run")
+	}
+	if helperPersistedRegistryHasHive(t, hiveID) {
+		t.Error("ghost entry persisted to disk after a delete whose teardown could not run")
+	}
+}
+
+// TestDeleteHiveIsIdempotentWhenSaaSRecordAlreadyGone covers repeated Delete
+// clicks and the case where the on-disk hive record was cleaned up but the
+// registry row was not — the state the user had to fix by hand.
+func TestDeleteHiveIsIdempotentWhenSaaSRecordAlreadyGone(t *testing.T) {
+	cleanup := helperSetupAuthUser(t, "ghp_del_idem", "del-idem-owner")
+	defer cleanup()
+
+	srv, mux := helperDeleteHiveEnv(t)
+
+	const hiveID = "hosted-del-idem-hive"
+	// Deliberately no saveSaaSHive: the meta.json is already gone, only the
+	// registry row remains.
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: "del-idem-owner", Online: false}}
+	srv.mu.Unlock()
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest("DELETE", "/api/saas/hives/"+hiveID, nil)
+		req.Header.Set("Authorization", "Bearer ghp_del_idem")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("delete attempt %d: expected 200, got %d body=%s", i+1, w.Code, w.Body.String())
+		}
+	}
+
+	if helperRegistryHasHive(srv, hiveID) {
+		t.Error("orphaned registry row was not cleared when the SaaS record was already gone")
+	}
+	if helperPersistedRegistryHasHive(t, hiveID) {
+		t.Error("orphaned registry row still on disk after delete")
+	}
+}
+
+// TestRemoveRegistryEntryPersistsSynchronously guards the durability fix
+// directly. requestSave defers the write by registrySaveDelay; a hub restart in
+// that window reloaded the pre-delete registry and the hive came back. The
+// removal must be on disk by the time removeRegistryEntry returns.
+func TestRemoveRegistryEntryPersistsSynchronously(t *testing.T) {
+	_, _ = helperDeleteHiveEnv(t)
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	const keepID = "keep-me-hive"
+	const dropID = "drop-me-hive"
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{{ID: keepID}, {ID: dropID}}
+	srv.mu.Unlock()
+	if err := srv.saveRegistryNow(); err != nil {
+		t.Fatalf("seed registry: %v", err)
+	}
+
+	srv.removeRegistryEntry(dropID, "tester")
+
+	// No sleep: the write must already have happened.
+	if helperPersistedRegistryHasHive(t, dropID) {
+		t.Error("removeRegistryEntry did not flush the removal to disk before returning")
+	}
+	if !helperPersistedRegistryHasHive(t, keepID) {
+		t.Error("removeRegistryEntry dropped an unrelated hive from the persisted registry")
+	}
+
+	// A second removal of an absent ID must be a harmless no-op.
+	srv.removeRegistryEntry(dropID, "tester")
+	if !helperPersistedRegistryHasHive(t, keepID) {
+		t.Error("no-op removal corrupted the registry")
+	}
+}
+
+// TestKubectlUnreachableHiveIsNotReaped pins the deliberate decision NOT to add
+// a namespace-existence garbage collector.
+//
+// Hives on firewalled spokes are heartbeat-only and are NOT kubectl-reachable
+// from the hub, so "the hub cannot see the namespace" does not imply "the hive
+// is gone" — it is equally consistent with a transient API outage or a spoke
+// the hub was never able to reach. Reaping on that signal would delete live
+// hives. The hub's only automatic eviction stays heartbeat-based
+// (staleRemoveAge), because a heartbeat is positive evidence of liveness that
+// the hive itself supplies; its absence for a full day is a far safer signal
+// than the hub's inability to run kubectl.
+//
+// This test asserts that a hive which is offline and whose namespace does not
+// exist is still retained, as long as it is heartbeating within staleRemoveAge.
+func TestKubectlUnreachableHiveIsNotReaped(t *testing.T) {
+	_, _ = helperDeleteHiveEnv(t)
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	const unreachableID = "hosted-unreachable-spoke-hive"
+	// Beat recently enough to be well inside staleRemoveAge, but old enough to
+	// be marked offline: exactly what an unreachable-but-alive hive looks like.
+	recentButStale := time.Now().Add(-2 * maxHeartbeatAge).UTC().Format(time.RFC3339)
+
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{{
+		ID:            unreachableID,
+		Owner:         "spoke-owner",
+		Online:        true,
+		LastHeartbeat: recentButStale,
+	}}
+	srv.markStaleHives()
+	srv.mu.Unlock()
+
+	if !helperRegistryHasHive(srv, unreachableID) {
+		t.Fatal("an unreachable hive was reaped from the registry without an explicit delete")
+	}
+
+	srv.mu.RLock()
+	stillOnline := srv.registry.Hives[0].Online
+	srv.mu.RUnlock()
+	if stillOnline {
+		t.Error("expected the hive to be marked offline (but retained), not left online")
+	}
+}

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -291,10 +291,16 @@ type HeartbeatPayload struct {
 	// The hub uses it to avoid nudging — let alone threatening de-provisioning
 	// — a hive whose credentials the OPERATOR has not delivered. Empty from a
 	// spoke too old to report it, which must be read as "cannot tell".
-	GitHubAppState          string                        `json:"github_app_state,omitempty"`
-	AutoUpgrade             bool                          `json:"auto_upgrade,omitempty"`
-	Upgrading               bool                          `json:"upgrading,omitempty"`
-	UpgradeTargetSHA        string                        `json:"upgrade_target_sha,omitempty"`
+	GitHubAppState   string `json:"github_app_state,omitempty"`
+	AutoUpgrade      bool   `json:"auto_upgrade,omitempty"`
+	Upgrading        bool   `json:"upgrading,omitempty"`
+	UpgradeTargetSHA string `json:"upgrade_target_sha,omitempty"`
+	// UpgradeFailed / UpgradeError let a spoke tell the hub that an instructed
+	// upgrade did NOT land. Without them a failed upgrade is indistinguishable
+	// from a slow one: the hub keeps re-instructing and the UI shows a permanent
+	// "Upgrading" spinner that is simply a lie.
+	UpgradeFailed           bool                          `json:"upgrade_failed,omitempty"`
+	UpgradeError            string                        `json:"upgrade_error,omitempty"`
 	PendingGitHubAppInstall bool                          `json:"pending_github_app_install,omitempty"`
 	ClusterHealth           *HeartbeatClusterHealthReport `json:"cluster_health,omitempty"`
 	// Fleet contribution counts — the spoke's AI-author PR activity across its
@@ -629,6 +635,52 @@ func SendUpgradingHeartbeat(hubURL string, collect StatusCollector, targetSHA st
 		recordHeartbeatSuccess()
 	}
 	logger.Info("upgrading heartbeat sent to hub", "target", targetSHA)
+}
+
+// ReportUpgradeFailure tells the hub that an instructed upgrade failed, with
+// the underlying cause. This is the counterpart to SendUpgradingHeartbeat: that
+// one says "I am upgrading", this one says "I could not". Without it the hub
+// only ever learns about upgrades that succeed, so a wedged spoke stays
+// "Upgrading" forever while the hub silently re-instructs it every heartbeat.
+//
+// Best-effort and non-fatal: the caller is usually seconds from exiting, and a
+// failure to report must never mask the upgrade failure itself.
+func ReportUpgradeFailure(hubURL, hiveID, targetSHA, currentSHA, cause string, logger *slog.Logger) {
+	if hubURL == "" || hiveID == "" {
+		return
+	}
+	payload := HeartbeatPayload{
+		HiveID:           hiveID,
+		GitHash:          currentSHA,
+		UpgradeTargetSHA: targetSHA,
+		UpgradeFailed:    true,
+		UpgradeError:     cause,
+		Timestamp:        time.Now().UTC().Format(time.RFC3339),
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), heartbeatTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, hubURL+"/api/heartbeat", bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if secret := os.Getenv("HIVE_HUB_SECRET"); secret != "" {
+		req.Header.Set("Authorization", "Bearer "+secret)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		logger.Warn("could not report upgrade failure to hub", "error", err)
+		return
+	}
+	defer resp.Body.Close()
+	logger.Info("reported upgrade failure to hub", "target", targetSHA, "cause", cause)
 }
 
 // HeartbeatGitHubAppConfig carries GitHub App credentials from the hub to

--- a/v2/pkg/hub/hub_coverage_deep_test.go
+++ b/v2/pkg/hub/hub_coverage_deep_test.go
@@ -777,7 +777,7 @@ func TestHandleHeartbeatAutoUpgradeSpokeRequest(t *testing.T) {
 
 	// Set latest SHA
 	latestSHAMu.Lock()
-	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "target1", Message: "latest"}
+	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "7a41e01", Message: "latest"}
 	latestSHAMu.Unlock()
 	defer func() {
 		latestSHAMu.Lock()
@@ -797,8 +797,8 @@ func TestHandleHeartbeatAutoUpgradeSpokeRequest(t *testing.T) {
 
 	var resp HeartbeatResponse
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp.UpgradeTo != "target1" {
-		t.Errorf("upgrade_to = %q, want target1", resp.UpgradeTo)
+	if resp.UpgradeTo != "7a41e01" {
+		t.Errorf("upgrade_to = %q, want 7a41e01", resp.UpgradeTo)
 	}
 }
 

--- a/v2/pkg/hub/hub_coverage_deep_test.go
+++ b/v2/pkg/hub/hub_coverage_deep_test.go
@@ -602,7 +602,9 @@ func TestHandleRequestProvisionValidBody(t *testing.T) {
 
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
-	body := `{"org":"validorg","repos":"repo1,repo2","primary_repo":"repo1","acmm_level":3,"auth_method":"token"}`
+	// github_host is required: a request must name the GitHub forge its org
+	// lives on, so a "valid body" fixture has to carry one.
+	body := `{"org":"validorg","github_host":"github.com","repos":"repo1,repo2","primary_repo":"repo1","acmm_level":3,"auth_method":"token"}`
 	req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer ghp_prov_valid")

--- a/v2/pkg/hub/hub_coverage_extra_test.go
+++ b/v2/pkg/hub/hub_coverage_extra_test.go
@@ -968,8 +968,9 @@ func TestHandleRequestProvisionDefaultPrimaryRepo(t *testing.T) {
 		ghTokenCacheMu.Unlock()
 	}()
 
-	// primary_repo not provided — should default to first repo
-	body := `{"org":"validorg","repos":"repo1,repo2","acmm_level":2}`
+	// primary_repo not provided — should default to first repo. github_host is
+	// required and must be present for the request to reach that defaulting.
+	body := `{"org":"validorg","github_host":"github.com","repos":"repo1,repo2","acmm_level":2}`
 	req := httptest.NewRequest("POST", "/provision-test", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer ghp_prov_default")

--- a/v2/pkg/hub/hub_coverage_extra_test.go
+++ b/v2/pkg/hub/hub_coverage_extra_test.go
@@ -398,17 +398,51 @@ func TestHandleHubAutoUpgradeEnable(t *testing.T) {
 // handleHubSelfUpgrade
 // ============================================================
 
+// TestHandleHubSelfUpgrade asserts the handler REFUSES to upgrade when no
+// target SHA is known, and does so without touching a cluster.
+//
+// The previous version of this test asserted nothing: it accepted both 200 and
+// 500 and merely t.Logf'd anything else, so it could not fail. Worse, its
+// premise was wrong. It reasoned "will fail because kubectl doesn't exist or
+// cluster not accessible" — untrue inside a hive pod, where kubectl exists and
+// the pod's ServiceAccount holds patch on the hub Deployment. Combined with a
+// sibling test seeding latestSHAByBranch["v2"] = "target1", it issued a real
+//
+//	kubectl set image deployment/hive-hub hub=ghcr.io/kubestellar/hive-hub:target1
+//
+// against production, leaving the hub serving stale code behind an
+// ImagePullBackOff. See TestMain, which removes the in-cluster credentials
+// that made it reachable.
+//
+// The SHA cache is a package-level global shared across the suite, so this
+// clears it and restores it rather than assuming a starting state.
 func TestHandleHubSelfUpgrade(t *testing.T) {
+	latestSHAMu.Lock()
+	saved, had := latestSHAByBranch["v2"]
+	delete(latestSHAByBranch, "v2")
+	latestSHAMu.Unlock()
+	t.Cleanup(func() {
+		latestSHAMu.Lock()
+		if had {
+			latestSHAByBranch["v2"] = saved
+		} else {
+			delete(latestSHAByBranch, "v2")
+		}
+		latestSHAMu.Unlock()
+	})
+
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("POST", "/hub-self-upgrade", nil)
 	w := httptest.NewRecorder()
 	srv.handleHubSelfUpgrade(w, req)
 
-	// Will fail because kubectl doesn't exist or cluster not accessible
-	// but exercises the code path
-	if w.Code != http.StatusInternalServerError && w.Code != http.StatusOK {
-		t.Logf("hub self-upgrade: %d", w.Code)
+	// No cached SHA means an empty target, which rolloutHubToSHA must reject
+	// before it ever builds a kubectl command. This is deterministic: it does
+	// not depend on whether a cluster happens to be reachable.
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("hub self-upgrade with no target SHA: got %d, want %d",
+			w.Code, http.StatusInternalServerError)
 	}
 }
 
@@ -1195,7 +1229,7 @@ func TestHandleHeartbeatUpgradingFlag(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
-	payload := `{"hive_id":"upgrading-flag-test","upgrading":true,"upgrade_target_sha":"target1"}`
+	payload := `{"hive_id":"upgrading-flag-test","upgrading":true,"upgrade_target_sha":"7a41e01"}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -977,7 +977,9 @@ func TestHandleRequestProvisionWithFilesystem(t *testing.T) {
 
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
-	body := `{"org":"validorg","repos":"repo1,repo2","primary_repo":"repo1","acmm_level":3}`
+	// github_host is required — the forge the org lives on must be captured at
+	// request time, so this end-to-end save fixture carries one.
+	body := `{"org":"validorg","github_host":"github.com","repos":"repo1,repo2","primary_repo":"repo1","acmm_level":3}`
 	req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer ghp_reqprov_fs")
@@ -995,6 +997,9 @@ func TestHandleRequestProvisionWithFilesystem(t *testing.T) {
 	}
 	if pr.Org != "validorg" {
 		t.Errorf("org = %q", pr.Org)
+	}
+	if pr.GitHubHost != "github.com" {
+		t.Errorf("github_host = %q, want it persisted as github.com", pr.GitHubHost)
 	}
 }
 

--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -1000,6 +1001,81 @@ func TestHandleRequestProvisionWithFilesystem(t *testing.T) {
 	}
 	if pr.GitHubHost != "github.com" {
 		t.Errorf("github_host = %q, want it persisted as github.com", pr.GitHubHost)
+	}
+}
+
+// TestHandleRequestProvisionClampsAboveOnboardingCeiling pins the rule that a
+// self-service request can never provision a hive above L3 Measured. The
+// get-started wizard and the Request-a-Hive modal both only offer L1-L3, but
+// they are clients: this asserts the SERVER refuses to record L4-L6 from a
+// crafted body, so the UI is not the only gate.
+func TestHandleRequestProvisionClampsAboveOnboardingCeiling(t *testing.T) {
+	for _, requested := range []int{maxRequestACMMLevel + 1, 5, 6, 99} {
+		t.Run(fmt.Sprintf("level%d", requested), func(t *testing.T) {
+			cleanup := helperSetupTempDirs(t)
+			defer cleanup()
+
+			token := fmt.Sprintf("ghp_clamp_%d", requested)
+			username := fmt.Sprintf("clamp-user-%d", requested)
+			authCleanup := helperSetupAuthUser(t, token, username)
+			defer authCleanup()
+
+			srv := NewHubServer(0, slog.Default(), "test", "v2")
+
+			body := fmt.Sprintf(`{"org":"validorg","github_host":"github.com","repos":"repo1","primary_repo":"repo1","acmm_level":%d}`, requested)
+			req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+token)
+			w := httptest.NewRecorder()
+			srv.handleRequestProvision(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+			}
+			pr := loadProvisionRequest(username)
+			if pr == nil {
+				t.Fatal("provision request should be saved")
+			}
+			if pr.ACMMLevel > maxRequestACMMLevel {
+				t.Errorf("acmm_level = %d, want it clamped to at most %d — nobody starts a hive above L3", pr.ACMMLevel, maxRequestACMMLevel)
+			}
+		})
+	}
+}
+
+// TestHandleRequestProvisionAcceptsOnboardingLevels is the other half: the
+// levels the wizard DOES offer must survive the clamp unchanged.
+func TestHandleRequestProvisionAcceptsOnboardingLevels(t *testing.T) {
+	for requested := minRequestACMMLevel; requested <= maxRequestACMMLevel; requested++ {
+		t.Run(fmt.Sprintf("level%d", requested), func(t *testing.T) {
+			cleanup := helperSetupTempDirs(t)
+			defer cleanup()
+
+			token := fmt.Sprintf("ghp_ok_%d", requested)
+			username := fmt.Sprintf("ok-user-%d", requested)
+			authCleanup := helperSetupAuthUser(t, token, username)
+			defer authCleanup()
+
+			srv := NewHubServer(0, slog.Default(), "test", "v2")
+
+			body := fmt.Sprintf(`{"org":"validorg","github_host":"github.com","repos":"repo1","primary_repo":"repo1","acmm_level":%d}`, requested)
+			req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+token)
+			w := httptest.NewRecorder()
+			srv.handleRequestProvision(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+			}
+			pr := loadProvisionRequest(username)
+			if pr == nil {
+				t.Fatal("provision request should be saved")
+			}
+			if pr.ACMMLevel != requested {
+				t.Errorf("acmm_level = %d, want %d preserved", pr.ACMMLevel, requested)
+			}
+		})
 	}
 }
 

--- a/v2/pkg/hub/image_tag_validation.go
+++ b/v2/pkg/hub/image_tag_validation.go
@@ -1,0 +1,133 @@
+package hub
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Image-tag validation for every path that writes a container image onto a
+// running Deployment (hub self-upgrade and spoke upgrade/branch-switch).
+//
+// Why this exists: on 2026-07-27 the hub's own Deployment was patched to
+// `ghcr.io/kubestellar/hive-hub:target1`. `target1` is not a tag that has ever
+// been published — it is a TEST FIXTURE SHA (see setV2Latest(t, "target1") in
+// saas_edge_coverage_test.go) that reached a real cluster because the hub's
+// unit tests shell out to a real `kubectl` while KUBERNETES_SERVICE_HOST is
+// still set in the pod environment. The new ReplicaSet went
+// ImagePullBackOff, the OLD ReplicaSet kept serving, and the hub therefore
+// looked healthy for ~20 minutes while silently running stale code. Nothing
+// alerted; it was found only because an expected UI fix was missing.
+//
+// The lesson generalizes past that one fixture: writing an unresolvable tag
+// takes a component down SILENTLY, because Kubernetes keeps the old ReplicaSet
+// up. Refusing to patch is strictly safer — the component keeps running its
+// last good image and the refusal is loud and actionable. So every writer now
+// validates the tag first and refuses anything that is not a recognizable
+// build artifact.
+
+const (
+	// minImageTagSHALen / maxImageTagSHALen bound a git SHA tag. The hub
+	// normalizes branch SHAs to StandardSHALen (7) via shortSHA, but a spoke or
+	// an admin may legitimately supply a longer prefix or the full 40-character
+	// SHA, so accept the whole abbreviation range git itself allows.
+	minImageTagSHALen = StandardSHALen
+	maxImageTagSHALen = 40
+
+	// mutableChannelTagSuffix is the suffix CI (.github/workflows/docker.yml)
+	// appends when it republishes a floating per-branch tag in place, e.g.
+	// v2-latest / v3-latest / mk-latest / dd-latest. The branch part is
+	// branchToTag(branch), so it may contain '-' from a slashed branch name
+	// (feat/x -> feat-x-latest) — which is why the channel form is matched by
+	// pattern rather than against a fixed allowlist of branch names.
+	mutableChannelTagSuffix = mutableTagSuffix
+
+	// maxImageTagLen is the OCI limit on a tag: 128 characters total. A value
+	// longer than this could never resolve on any registry.
+	maxImageTagLen = 128
+)
+
+// imageTagSHAPattern matches an immutable git-SHA tag: lowercase hex only, of a
+// length git accepts as an abbreviation. Anchored, so an identifier that merely
+// CONTAINS hex characters (the `target1` class of bug — a bare identifier, or a
+// leaked `$target`/`${target}1` template variable) cannot slip through.
+var imageTagSHAPattern = regexp.MustCompile(
+	fmt.Sprintf(`^[0-9a-f]{%d,%d}$`, minImageTagSHALen, maxImageTagSHALen),
+)
+
+// imageTagChannelPattern matches a mutable channel tag: a branchToTag-sanitized
+// branch name followed by "-latest". The branch part allows the characters a
+// git branch can carry once '/' has been replaced by '-' (alphanumerics, '-',
+// '_', '.') and must start alphanumeric so a stray leading dash cannot pass.
+var imageTagChannelPattern = regexp.MustCompile(
+	`^[0-9A-Za-z][0-9A-Za-z._-]*` + regexp.QuoteMeta(mutableChannelTagSuffix) + `$`,
+)
+
+// validateImageTag reports whether tag is a shape we are willing to write onto
+// a live Deployment: either an immutable git-SHA tag or a mutable
+// "<branch>-latest" channel tag. Anything else — empty, an identifier like
+// `target1`, an unsubstituted `$target`, or a value over the OCI length limit —
+// is refused with an error naming the exact offending value.
+//
+// This is deliberately a shape check, not an existence check. Existence is
+// verified separately and over the network (hubImageExists); shape is free,
+// deterministic, and catches the class of bug that produced `target1` — a value
+// that was never a tag at all.
+func validateImageTag(tag string) error {
+	if tag == "" {
+		return fmt.Errorf("refusing to patch deployment image: tag is empty")
+	}
+	if strings.TrimSpace(tag) != tag {
+		return fmt.Errorf("refusing to patch deployment image: tag %q has leading/trailing whitespace", tag)
+	}
+	if len(tag) > maxImageTagLen {
+		return fmt.Errorf("refusing to patch deployment image: tag %q is %d chars, over the %d-char OCI limit",
+			tag, len(tag), maxImageTagLen)
+	}
+	if imageTagSHAPattern.MatchString(tag) {
+		return nil
+	}
+	if imageTagChannelPattern.MatchString(tag) {
+		return nil
+	}
+	return fmt.Errorf(
+		"refusing to patch deployment image: tag %q is neither a %d-%d char hex git SHA nor a %q channel tag "+
+			"(an unresolvable tag silently strands the component on its old ReplicaSet)",
+		tag, minImageTagSHALen, maxImageTagSHALen, mutableChannelTagSuffix)
+}
+
+// imageRefTag returns the tag portion of a full image reference
+// (ghcr.io/org/repo:tag). It mirrors imageTagIsMutable's parsing: only the part
+// after the LAST colon is a tag, and only when no '/' follows it — otherwise
+// that colon introduces a registry port (host:5000/repo). A digest pin
+// (repo@sha256:...) has no tag to validate.
+func imageRefTag(image string) (string, bool) {
+	if strings.Contains(image, "@") {
+		return "", false // digest pin — immutable by construction
+	}
+	idx := strings.LastIndex(image, ":")
+	if idx < 0 || strings.Contains(image[idx+1:], "/") {
+		return "", false
+	}
+	return image[idx+1:], true
+}
+
+// validateImageRef validates the tag embedded in a full image reference. A
+// reference with no parseable tag is refused too: an untagged image resolves to
+// :latest, which is never what an upgrade path means to write.
+func validateImageRef(image string) error {
+	if image == "" {
+		return fmt.Errorf("refusing to patch deployment image: image reference is empty")
+	}
+	tag, ok := imageRefTag(image)
+	if !ok {
+		if strings.Contains(image, "@") {
+			return nil // digest pin is a valid, fully-resolved reference
+		}
+		return fmt.Errorf("refusing to patch deployment image: image %q has no tag", image)
+	}
+	if err := validateImageTag(tag); err != nil {
+		return fmt.Errorf("%w (image %q)", err, image)
+	}
+	return nil
+}

--- a/v2/pkg/hub/image_tag_validation_test.go
+++ b/v2/pkg/hub/image_tag_validation_test.go
@@ -1,0 +1,212 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateImageTagRefusesMalformed(t *testing.T) {
+	// Every one of these would have been written straight onto a live
+	// Deployment before this change, stranding the component on
+	// ImagePullBackOff behind a still-serving old ReplicaSet.
+	bad := []struct {
+		tag string
+		why string
+	}{
+		{"target1", "the literal value from the 2026-07-27 hub outage: a test fixture SHA, not a tag"},
+		{"", "empty"},
+		{"$target", "unsubstituted shell variable"},
+		{"${target}", "unsubstituted shell variable with braces"},
+		{"$target1", "unsubstituted shell variable with index"},
+		{"target", "bare identifier"},
+		{"latest", "not a channel tag we publish per-branch"},
+		{"abc", "hex but too short to be a git SHA"},
+		{"g45d2e9", "'g' is not a hex digit"},
+		{"F45D2E9", "uppercase hex is not how git prints short SHAs"},
+		{"  f45d2e9", "leading whitespace"},
+		{"f45d2e9\n", "trailing newline"},
+		{"-latest", "channel tag with no branch part"},
+		{strings.Repeat("a", maxImageTagLen+1), "over the OCI tag length limit"},
+	}
+	for _, tc := range bad {
+		if err := validateImageTag(tc.tag); err == nil {
+			t.Errorf("validateImageTag(%q) = nil, want error (%s)", tc.tag, tc.why)
+		} else if !strings.Contains(err.Error(), "refusing to patch") {
+			t.Errorf("validateImageTag(%q) error = %q, want an actionable 'refusing to patch' message", tc.tag, err)
+		}
+	}
+}
+
+func TestValidateImageTagAcceptsValid(t *testing.T) {
+	good := []string{
+		"f45d2e9",  // canonical 7-char short SHA (the manual recovery tag)
+		"438a9f2b", // 8-char abbreviation
+		"f45d2e9b1c3a4e5f6789012345678901234567ab", // full 40-char SHA
+		"v2-latest",
+		"v3-latest",
+		"mk-latest",
+		"dd-latest",
+		"feat-vanity-url-latest", // branchToTag("feat/vanity-url") + "-latest"
+	}
+	for _, tag := range good {
+		if err := validateImageTag(tag); err != nil {
+			t.Errorf("validateImageTag(%q) = %v, want nil", tag, err)
+		}
+	}
+}
+
+func TestValidateImageRef(t *testing.T) {
+	if err := validateImageRef("ghcr.io/kubestellar/hive-hub:target1"); err == nil {
+		t.Error("validateImageRef accepted the outage image reference, want refusal")
+	}
+	if err := validateImageRef("ghcr.io/kubestellar/hive-hub:f45d2e9"); err != nil {
+		t.Errorf("validateImageRef(valid SHA ref) = %v, want nil", err)
+	}
+	if err := validateImageRef("ghcr.io/kubestellar/hive:v2-latest"); err != nil {
+		t.Errorf("validateImageRef(valid channel ref) = %v, want nil", err)
+	}
+	// A registry port must not be mistaken for a tag.
+	if err := validateImageRef("registry.local:5000/kubestellar/hive"); err == nil {
+		t.Error("validateImageRef accepted an untagged image, want refusal")
+	}
+	// Digest pins are already fully resolved.
+	if err := validateImageRef("ghcr.io/kubestellar/hive-hub@sha256:" + strings.Repeat("a", 64)); err != nil {
+		t.Errorf("validateImageRef(digest pin) = %v, want nil", err)
+	}
+	if err := validateImageRef(""); err == nil {
+		t.Error("validateImageRef(\"\") = nil, want error")
+	}
+}
+
+// TestRolloutHubToSHARefusesBogusTagWithoutPatching is the regression test for
+// the outage: a malformed target must be refused BEFORE kubectl runs, and must
+// leave the deployment untouched.
+func TestRolloutHubToSHARefusesBogusTagWithoutPatching(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	// Record every kubectl invocation so we can assert none happened.
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "calls.log")
+	script := "#!/bin/sh\necho \"$*\" >> " + logPath + "\nexit 0\n"
+	kubectlPath := filepath.Join(dir, "kubectl")
+	if err := os.WriteFile(kubectlPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// If validation were bypassed, hubImageExists would be consulted next —
+	// make it loudly fail the test rather than silently allow the patch.
+	oldImgCheck := hubImageExists
+	hubImageExists = func(sha string, _ *slog.Logger) bool {
+		t.Errorf("hubImageExists called for %q — validation should have refused first", sha)
+		return true
+	}
+	t.Cleanup(func() { hubImageExists = oldImgCheck })
+
+	s := &HubServer{
+		logger:       slog.Default(),
+		hubSecret:    testHubSecret,
+		hubGitBranch: "v2",
+		clusters:     map[string]ClusterConfig{defaultClusterID: {ID: defaultClusterID, InCluster: true}},
+	}
+
+	for _, bogus := range []string{"target1", "$target", "target"} {
+		err := s.rolloutHubToSHA(bogus)
+		if err == nil {
+			t.Fatalf("rolloutHubToSHA(%q) = nil, want refusal", bogus)
+		}
+		if !strings.Contains(err.Error(), "refusing to patch") {
+			t.Errorf("rolloutHubToSHA(%q) error = %q, want an actionable refusal", bogus, err)
+		}
+		// The refusal must be visible in hub status, not just in logs.
+		if fault := s.HubUpgradeFault(); !strings.Contains(fault, bogus) {
+			t.Errorf("HubUpgradeFault() = %q, want it to name the refused tag %q", fault, bogus)
+		}
+	}
+
+	// Nothing may have reached kubectl.
+	if data, err := os.ReadFile(logPath); err == nil && len(strings.TrimSpace(string(data))) > 0 {
+		t.Errorf("kubectl was invoked during a refused rollout:\n%s", data)
+	}
+}
+
+// TestHubUpgradeStateSurfacesFault asserts a refused/stuck upgrade shows as
+// "failed" rather than a reassuring "queued".
+func TestHubUpgradeStateSurfacesFault(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	setV2Latest(t, "f45d2e9")
+
+	s := &HubServer{
+		logger:       slog.Default(),
+		hubSecret:    testHubSecret,
+		hubGitBranch: "v2",
+		hubGitHash:   "0000000", // behind latest
+		clusters:     map[string]ClusterConfig{defaultClusterID: {ID: defaultClusterID, InCluster: true}},
+	}
+	if got := s.hubUpgradeState(); got == hubUpgradeStateFailed {
+		t.Fatalf("hubUpgradeState() = %q before any fault, want a non-failed state", got)
+	}
+	s.setHubUpgradeFault("refused invalid image tag \"target1\"")
+	if got := s.hubUpgradeState(); got != hubUpgradeStateFailed {
+		t.Errorf("hubUpgradeState() = %q after a fault, want %q", got, hubUpgradeStateFailed)
+	}
+}
+
+// TestSwitchImageSelfRefusesBogusTag covers the SHARED spoke helper. This is the
+// path that would strand spokes, which is worse than the hub outage: a spoke
+// stuck on an old ReplicaSet keeps reporting its OLD git hash, so the hub
+// re-sends the same doomed target on every heartbeat, forever.
+func TestSwitchImageSelfRefusesBogusTag(t *testing.T) {
+	for _, image := range []string{
+		"ghcr.io/kubestellar/hive:target1",
+		"ghcr.io/kubestellar/hive:$target",
+		"ghcr.io/kubestellar/hive:",
+		"",
+	} {
+		err := SwitchImageSelf(slog.Default(), image)
+		if err == nil {
+			t.Errorf("SwitchImageSelf(%q) = nil, want refusal", image)
+			continue
+		}
+		if !strings.Contains(err.Error(), "refusing to patch") {
+			t.Errorf("SwitchImageSelf(%q) error = %q, want an actionable refusal", image, err)
+		}
+	}
+}
+
+// TestHandleSwitchBranchRefusesBogusTag asserts the hub-side spoke writer
+// refuses a branch that does not sanitize into a valid channel tag.
+func TestHandleSwitchBranchRefusesBogusTag(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, "alice")
+
+	h := &SaaSHive{ID: "h1", Owner: "alice"}
+	saveSaaSHive(h)
+
+	s := &HubServer{
+		logger:             slog.Default(),
+		hubSecret:          testHubSecret,
+		saveCh:             make(chan struct{}, 1),
+		heartbeatUpgrade:   make(map[string]string),
+		heartbeatSwitchTag: make(map[string]string),
+		clusters:           map[string]ClusterConfig{defaultClusterID: {ID: defaultClusterID, InCluster: true}},
+	}
+
+	// A branch whose sanitized tag starts with '-' cannot form a valid channel
+	// tag. It must be rejected, not written to the spoke's Deployment.
+	rec := httptest.NewRecorder()
+	req := reqWithUser(http.MethodPost, "/api/saas/hives/h1/switch-branch", `{"branch":"-bad"}`, "alice")
+	req.SetPathValue("id", "h1")
+	s.handleSwitchBranch(rec, req)
+	if rec.Code == http.StatusOK {
+		t.Errorf("handleSwitchBranch accepted a branch that maps to an invalid tag: %s", rec.Body.String())
+	}
+}

--- a/v2/pkg/hub/main_test.go
+++ b/v2/pkg/hub/main_test.go
@@ -1,0 +1,42 @@
+package hub
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain isolates the hub test suite from any real Kubernetes cluster.
+//
+// Why this exists: many hub tests exercise handlers that shell out to `kubectl`
+// (rolloutHubToSHA, handleSwitchBranch, triggerAutoUpgrades, ...). Those tests
+// usually install a scripted fake kubectl on PATH, but several deliberately run
+// a "kubectl fails" branch FIRST, with the real binary still on PATH.
+//
+// kubectlArgsForCluster builds in-cluster credentials from KUBERNETES_SERVICE_HOST
+// and KUBERNETES_SERVICE_PORT. When the suite runs anywhere those are set — most
+// importantly inside a hive pod, where agents run the tests — a real kubectl
+// reaches the REAL API server using the pod's ServiceAccount, which holds patch
+// on the hub Deployment.
+//
+// That is exactly how the 2026-07-27 outage happened: TestHandleHubSelfUpgrade_Edge
+// seeds the SHA cache with the fixture value "target1" and calls
+// handleHubSelfUpgrade, producing a literal
+//
+//	kubectl set image deployment/hive-hub hub=ghcr.io/kubestellar/hive-hub:target1 -n hive-hub
+//
+// against the live cluster. `target1` was never a published tag, so the new
+// ReplicaSet went ImagePullBackOff while the old one kept serving — the hub
+// looked healthy for ~20 minutes while silently running stale code.
+//
+// Clearing these two variables makes kubectlArgsForCluster omit --server/--token,
+// so a stray real kubectl has no cluster to talk to and fails locally instead of
+// mutating production. Tests that WANT kubectl behavior still get it from their
+// scripted fake on PATH, which ignores these flags entirely.
+func TestMain(m *testing.M) {
+	os.Unsetenv("KUBERNETES_SERVICE_HOST")
+	os.Unsetenv("KUBERNETES_SERVICE_PORT")
+	// KUBECONFIG could equally point a real kubectl at a real cluster for the
+	// non-InCluster branch, so neutralize it to a path that cannot exist.
+	os.Setenv("KUBECONFIG", os.DevNull)
+	os.Exit(m.Run())
+}

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -172,7 +172,22 @@ func (s *HubServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	state := url.QueryEscape(redirect)
-	authURL := fmt.Sprintf("%s?client_id=%s&scope=read:user&redirect_uri=%s&state=%s",
+	// An EMPTY scope is deliberate, not an omission. The hub only needs to know
+	// WHO is logging in: the callback reads GET /user for the login name and
+	// signs it into the session cookie. GitHub serves /user's public profile —
+	// including "login" — for a token with no scopes at all, so identity works
+	// unscoped.
+	//
+	// The hub used to ask for read:user because the request wizard listed the
+	// user's repositories for them to pick from. That listing is gone: it could
+	// only ever see public github.com, and it could never generalize to GitLab
+	// or Gitea. Requesters now type a repository URL instead, which needs no
+	// permission on the requester's account whatsoever.
+	//
+	// Do NOT restore a scope here without also restoring a feature that needs
+	// it — asking for access the product does not use is a consent prompt users
+	// are right to refuse.
+	authURL := fmt.Sprintf("%s?client_id=%s&scope=&redirect_uri=%s&state=%s",
 		defaultGHAuthorizeURL, clientID, "https://hive.kubestellar.io/api/auth/callback", state)
 	http.Redirect(w, r, authURL, http.StatusTemporaryRedirect)
 }

--- a/v2/pkg/hub/request_forge_required_test.go
+++ b/v2/pkg/hub/request_forge_required_test.go
@@ -1,0 +1,262 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The "Request a Hive" form must capture the GitHub forge the org lives on.
+// Without it the hub cannot tell whether "z-innersource" is on github.com or
+// on a GitHub Enterprise instance, and it provisions the hive against the wrong
+// GitHub — App-install links point at a forge the org admin never sees.
+//
+// These tests pin the three halves of that guarantee: the normalizer accepts
+// every form the form advertises, the endpoint REJECTS a request that omits the
+// forge, and the captured host survives all the way to the created hive.
+
+// TestNormalizeForgeHostAcceptedForms pins the exact spellings the request
+// modal tells users they may enter. All must collapse to the same bare host.
+func TestNormalizeForgeHostAcceptedForms(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"github.com", "github.com"},
+		{"https://github.com", "github.com"},
+		{"http://github.com", "github.com"},
+		{"https://github.com/", "github.com"},
+		{"github.ibm.com", "github.ibm.com"},
+		{"https://github.ibm.com", "github.ibm.com"},
+		{"https://github.ibm.com/", "github.ibm.com"},
+		{"  https://github.ibm.com/  ", "github.ibm.com"},
+		{"GitHub.IBM.com", "github.ibm.com"},
+		// A pasted org URL carries a path; only the host is the forge.
+		{"https://github.ibm.com/z-innersource", "github.ibm.com"},
+	}
+	for _, tc := range cases {
+		got, ok := normalizeForgeHost(tc.in)
+		if !ok {
+			t.Errorf("normalizeForgeHost(%q) rejected a form the request form advertises", tc.in)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("normalizeForgeHost(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestNormalizeForgeHostRejectsGarbage guards the other direction: a value that
+// is not a hostname must not be accepted just because it is non-empty.
+func TestNormalizeForgeHostRejectsGarbage(t *testing.T) {
+	bad := []string{
+		"",
+		"   ",
+		"https://",
+		"not a host",
+		"github",          // single label — a typo, not a forge
+		"gi thub.ibm.com", // embedded space
+		"github.ibm.com;rm -rf /",
+		"../../etc/passwd",
+	}
+	for _, in := range bad {
+		if got, ok := normalizeForgeHost(in); ok {
+			t.Errorf("normalizeForgeHost(%q) accepted garbage as %q", in, got)
+		}
+	}
+}
+
+// TestNormalizeForgeHostAgreesWithGithubHostLabel proves the request-time
+// normalizer and the display-time normalizer produce the same spelling, so a
+// captured host and a rendered host can never drift.
+func TestNormalizeForgeHostAgreesWithGithubHostLabel(t *testing.T) {
+	for _, in := range []string{"github.com", "https://github.com/", "github.ibm.com", "https://github.ibm.com/"} {
+		got, ok := normalizeForgeHost(in)
+		if !ok {
+			t.Fatalf("normalizeForgeHost(%q) unexpectedly rejected", in)
+		}
+		if want := githubHostLabel(in); got != want {
+			t.Errorf("normalizeForgeHost(%q) = %q but githubHostLabel = %q", in, got, want)
+		}
+	}
+}
+
+// authAsForgeTester registers a token so handleRequestProvision sees a caller,
+// and returns the username plus a cleanup func.
+func authAsForgeTester(t *testing.T, token, username string) {
+	t.Helper()
+	ghTokenCacheMu.Lock()
+	ghTokenCache[token] = ghTokenCacheEntry{username: username, expiresAt: time.Now().Add(5 * time.Minute)}
+	ghTokenCacheMu.Unlock()
+	t.Cleanup(func() {
+		ghTokenCacheMu.Lock()
+		delete(ghTokenCache, token)
+		ghTokenCacheMu.Unlock()
+	})
+}
+
+func postProvisionRequest(t *testing.T, srv *HubServer, token, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/saas/request-provision", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	srv.handleRequestProvision(w, req)
+	return w
+}
+
+// TestRequestProvisionRejectsMissingForge is the core of the feature: an
+// otherwise perfectly valid request with no forge must be refused server-side.
+// Client-side validation is not enforcement — a curl or a stale page bypasses
+// it entirely.
+func TestRequestProvisionRejectsMissingForge(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	authAsForgeTester(t, "ghp_forge_missing", "forge-missing-user")
+
+	w := postProvisionRequest(t, srv, "ghp_forge_missing", `{"org":"z-innersource","repos":"repo1,repo2"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("request with no forge: expected 400, got %d (body %s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(strings.ToLower(w.Body.String()), "forge") {
+		t.Errorf("rejection should name the missing forge, got %s", w.Body.String())
+	}
+}
+
+// TestRequestProvisionRejectsGarbageForge — a non-empty but nonsensical forge
+// is no better than a missing one.
+func TestRequestProvisionRejectsGarbageForge(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	authAsForgeTester(t, "ghp_forge_garbage", "forge-garbage-user")
+
+	w := postProvisionRequest(t, srv, "ghp_forge_garbage",
+		`{"org":"z-innersource","repos":"repo1","github_host":"not a host"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("garbage forge: expected 400, got %d (body %s)", w.Code, w.Body.String())
+	}
+}
+
+// TestRequestProvisionAcceptsAllForgeForms drives the real endpoint with every
+// spelling the modal offers and asserts each is accepted AND stored as the same
+// normalized bare host — the "https://" form in particular, which the old
+// isValidName-on-raw-input check would have rejected.
+func TestRequestProvisionAcceptsAllForgeForms(t *testing.T) {
+	dir := t.TempDir()
+	origDir := provisionRequestsDir
+	provisionRequestsDir = dir
+	t.Cleanup(func() { provisionRequestsDir = origDir })
+
+	cases := []struct {
+		forge string
+		want  string
+	}{
+		{"github.com", "github.com"},
+		{"https://github.com", "github.com"},
+		{"github.ibm.com", "github.ibm.com"},
+		{"https://github.ibm.com/", "github.ibm.com"},
+	}
+
+	for i, tc := range cases {
+		srv := NewHubServer(0, slog.Default(), "test", "v2")
+		// A fresh username per case: the handler refuses a second pending
+		// request from the same user.
+		user := "forge-form-user-" + string(rune('a'+i))
+		token := "ghp_forge_form_" + string(rune('a'+i))
+		authAsForgeTester(t, token, user)
+
+		body, err := json.Marshal(map[string]any{
+			"org":         "z-innersource",
+			"repos":       "repo1",
+			"github_host": tc.forge,
+			"acmm_level":  3,
+		})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		w := postProvisionRequest(t, srv, token, string(body))
+		if w.Code != http.StatusOK {
+			t.Fatalf("forge %q: expected 200, got %d (body %s)", tc.forge, w.Code, w.Body.String())
+		}
+
+		pr := loadProvisionRequest(user)
+		if pr == nil {
+			t.Fatalf("forge %q: request was not persisted", tc.forge)
+		}
+		if pr.GitHubHost != tc.want {
+			t.Errorf("forge %q stored as %q, want normalized %q", tc.forge, pr.GitHubHost, tc.want)
+		}
+	}
+}
+
+// TestLegacyProvisionRequestWithEmptyHostStillLoads is the backward-compat
+// guarantee: requests written before the forge was required have no
+// github_host, and must still round-trip rather than failing to render. The
+// requirement is on NEW submissions only.
+func TestLegacyProvisionRequestWithEmptyHostStillLoads(t *testing.T) {
+	dir := t.TempDir()
+	origDir := provisionRequestsDir
+	provisionRequestsDir = dir
+	t.Cleanup(func() { provisionRequestsDir = origDir })
+
+	const legacyUser = "legacy-forge-user"
+	legacy := `{"username":"` + legacyUser + `","org":"old-org","repos":"repo1","primary_repo":"repo1","acmm_level":3,"status":"pending","requested_at":"2026-01-01T00:00:00Z"}`
+	if err := os.WriteFile(dir+"/"+legacyUser+".json", []byte(legacy), 0o600); err != nil {
+		t.Fatalf("seed legacy request: %v", err)
+	}
+
+	pr := loadProvisionRequest(legacyUser)
+	if pr == nil {
+		t.Fatal("a legacy request with no github_host must still load")
+	}
+	if pr.GitHubHost != "" {
+		t.Errorf("legacy GitHubHost = %q, want empty", pr.GitHubHost)
+	}
+	// Empty reads as public github.com, matching the convention used
+	// everywhere else in the hub.
+	if got := githubHostLabel(pr.GitHubHost); got != publicGitHubHost {
+		t.Errorf("empty host should read as %q, got %q", publicGitHubHost, got)
+	}
+}
+
+// TestRequestForgeSurvivesToApprovedHive traces the captured host end to end:
+// request -> approve -> the hive record that provisioning reads. Capturing a
+// field that approve drops would be worse than useless.
+func TestRequestForgeSurvivesToApprovedHive(t *testing.T) {
+	const wantHost = "github.ibm.com"
+
+	pr := &ProvisionRequest{
+		Username:   "e2e-forge-user",
+		GitHubHost: wantHost,
+		Org:        "z-innersource",
+		Repos:      "repo1",
+		Status:     provisionStatusPending,
+	}
+
+	// The approve path's host resolution, in the same precedence order the
+	// handler applies it: an explicit admin override wins, otherwise the
+	// request's captured host is adopted onto the hive.
+	h := &SaaSHive{}
+	adminOverride := "" // no override — the requester's forge should be used
+	if host := strings.TrimSpace(adminOverride); host != "" {
+		h.GitHubHost = host
+	} else if pr.GitHubHost != "" {
+		h.GitHubHost = pr.GitHubHost
+	}
+
+	if h.GitHubHost != wantHost {
+		t.Fatalf("approve dropped the requested forge: hive host = %q, want %q", h.GitHubHost, wantHost)
+	}
+
+	// And the host must actually change downstream behavior — that is the whole
+	// reason it has to be captured.
+	if api := gheAPIURLForHost(h.GitHubHost); api == "" {
+		t.Errorf("a GHE host must yield a GHE API URL, got empty for %q", h.GitHubHost)
+	}
+	if gheAPIURLForHost("") != "" {
+		t.Error("an empty host must yield no GHE API URL (public github.com default)")
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4784,6 +4784,19 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 	if ghHost != "" {
 		body.GitHubHost = ghHost
 	}
+	// The forge is REQUIRED. A bare org name ("z-innersource") does not say
+	// whether the org lives on github.com or on a GitHub Enterprise instance,
+	// and the hub cannot guess: the wrong choice provisions the hive against
+	// the wrong GitHub and points the App-install link at a forge the org
+	// admin never sees. Normalize FIRST — the field accepts
+	// "https://github.ibm.com/" and isValidName rejects ":" and "/", so
+	// validating the raw value would reject a form the form itself advertises.
+	forgeHost, ok := normalizeForgeHost(body.GitHubHost)
+	if !ok {
+		http.Error(w, `{"error":"a GitHub forge is required — enter the host your org lives on (e.g. github.com or github.ibm.com); without it we cannot tell which GitHub to provision against"}`, http.StatusBadRequest)
+		return
+	}
+	body.GitHubHost = forgeHost
 	// Single-host-per-spoke: every repo (and the primary) must be on the same
 	// GitHub host as the org. Check BEFORE normalizeRepoRef strips the host off
 	// each pasted repo. Reject a mixed request up front with a clear message —
@@ -4807,7 +4820,10 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 		http.Error(w, fmt.Sprintf(`{"error":"invalid org name %q — use the org name or its URL (e.g. github.ibm.com/my-org)"}`, body.Org), http.StatusBadRequest)
 		return
 	}
-	if body.GitHubHost != "" && !isValidName(body.GitHubHost) {
+	// Defence in depth: normalizeForgeHost above already guaranteed this, but
+	// keep the check so a future edit that reorders the handler cannot let an
+	// unvalidated host reach the stored request.
+	if !isValidName(body.GitHubHost) {
 		http.Error(w, `{"error":"invalid github host"}`, http.StatusBadRequest)
 		return
 	}
@@ -6423,7 +6439,7 @@ const dashboardHTML = `<!DOCTYPE html>
       <div style="display:flex;gap:8px;align-items:center">
         <button class="btn-primary" id="btn-send-banner-top" style="display:none;background:#d97706" onclick="_bannerTargetHive=null;document.getElementById('banner-modal').style.display='flex';loadBannerHiveList()">Send Banner</button>
         <button class="btn-primary" id="btn-add-hive" disabled onclick="document.getElementById('create-modal').style.display='flex'">+ Add Hosted Hive</button>
-        <button class="btn-primary" id="btn-request-hive" style="display:none;background:var(--blue)" onclick="document.getElementById('request-modal').style.display='flex'">Request a Hive</button>
+        <button class="btn-primary" id="btn-request-hive" style="display:none;background:var(--blue)" onclick="openRequestHiveModal()">Request a Hive</button>
       </div>
     </div>
 
@@ -11178,6 +11194,116 @@ const dashboardHTML = `<!DOCTYPE html>
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); btn.disabled = false; btn.textContent = 'Deny'; }
     }
 
+    /* REQUEST_FORGE_CUSTOM is the sentinel option value that reveals the
+       free-text forge box. It is not a hostname and is never submitted. */
+    var REQUEST_FORGE_CUSTOM = '__custom__';
+
+    /* normalizeForgeInput mirrors the server's normalizeForgeHost: strip the
+       scheme, drop any pasted path, drop a trailing slash, lowercase. Keeping
+       the two in step means the live preview shows exactly the host the server
+       will store, instead of a spelling that changes on submit. */
+    function normalizeForgeInput(raw) {
+      var h = (raw || '').trim().toLowerCase();
+      h = h.replace(/^https?:\/\//, '');
+      var slash = h.indexOf('/');
+      if (slash >= 0) h = h.slice(0, slash);
+      return h;
+    }
+
+    /* renderRequestForgeOptions fills the Request-a-Hive forge picker from the
+       forges the hub's own clusters actually run on, plus public github.com and
+       an "other" escape hatch.
+
+       Hybrid rather than pure free-text: the listed forges are the ones the hub
+       can actually place a hive on, so the common path is a click that cannot
+       be typo'd, and the list self-documents what is supported. Pure free-text
+       invites "gihub.ibm.com"; a pure select would block a brand-new GHE
+       instance the hub has no cluster for yet, which is a real onboarding case
+       — hence "Other". */
+    function renderRequestForgeOptions() {
+      var sel = document.getElementById('rq-forge');
+      if (!sel) return;
+      var seen = {};
+      var hosts = [];
+      (_clusterList || []).forEach(function(c) {
+        var h = normalizeForgeInput((c && c.github_host) || '');
+        if (!h || seen[h]) return;
+        seen[h] = true;
+        hosts.push(h);
+      });
+      /* Public GitHub is always offered even when no cluster reports it, so the
+         picker is never empty before the cluster list loads. */
+      if (!seen[PUBLIC_GITHUB_HOST]) hosts.unshift(PUBLIC_GITHUB_HOST);
+      hosts.sort();
+      var prev = sel.value;
+      var opts = hosts.map(function(h) {
+        return '<option value="' + esc(h) + '">' + esc(h) + '</option>';
+      });
+      opts.push('<option value="' + esc(REQUEST_FORGE_CUSTOM) + '">Other GitHub Enterprise host&#x2026;</option>');
+      sel.innerHTML = opts.join('');
+      if (prev) sel.value = prev;
+      if (!sel.value) sel.value = PUBLIC_GITHUB_HOST;
+      /* Bind once. renderRequestForgeOptions re-runs whenever the cluster list
+         reloads, and re-adding these listeners each time would fire the
+         preview N times per keystroke. */
+      if (!sel._rqForgeWired) {
+        sel._rqForgeWired = true;
+        sel.addEventListener('change', syncRequestForgePreview);
+        var customEl = document.getElementById('rq-forge-custom');
+        if (customEl) customEl.addEventListener('input', syncRequestForgePreview);
+        var orgEl = document.getElementById('rq-org');
+        if (orgEl) orgEl.addEventListener('input', syncRequestForgePreview);
+      }
+      syncRequestForgePreview();
+    }
+
+    /* requestForgeValue returns the normalized forge host the modal will
+       submit, or '' when "Other" is selected and nothing has been typed. */
+    function requestForgeValue() {
+      var sel = document.getElementById('rq-forge');
+      if (!sel) return '';
+      if (sel.value !== REQUEST_FORGE_CUSTOM) return normalizeForgeInput(sel.value);
+      var custom = document.getElementById('rq-forge-custom');
+      return normalizeForgeInput(custom && custom.value);
+    }
+
+    /* syncRequestForgePreview shows the forge with the org affixed to it —
+       "github.ibm.com/z-innersource" — so the requester sees the exact target
+       they are asking for before they submit, rather than discovering after
+       provisioning that the org was resolved against the wrong GitHub. */
+    function syncRequestForgePreview() {
+      var sel = document.getElementById('rq-forge');
+      var custom = document.getElementById('rq-forge-custom');
+      var out = document.getElementById('rq-target-preview');
+      if (sel && custom) custom.style.display = sel.value === REQUEST_FORGE_CUSTOM ? 'block' : 'none';
+      if (!out) return;
+      var host = requestForgeValue();
+      var orgEl = document.getElementById('rq-org');
+      var org = orgEl ? orgEl.value.trim() : '';
+      /* The org field accepts a pasted URL too; show only its last segment so
+         the preview never renders "github.com/https://github.ibm.com/x". */
+      if (org) {
+        var parts = org.replace(/^https?:\/\//, '').replace(/\/+$/, '').split('/');
+        org = parts[parts.length - 1];
+      }
+      if (!host) {
+        out.textContent = 'Enter the GitHub forge your org lives on.';
+        out.style.color = 'var(--muted)';
+        return;
+      }
+      out.textContent = 'This hive will target ' + host + '/' + (org || '<org>') +
+        (host !== PUBLIC_GITHUB_HOST ? ' — the GitHub App must be installed on that org on ' + host + '.' : '');
+      out.style.color = host !== PUBLIC_GITHUB_HOST ? 'var(--accent, #58a6ff)' : 'var(--muted)';
+    }
+
+    /* openRequestHiveModal shows the modal with a freshly populated forge
+       picker, so a cluster list that loaded after page render is reflected. */
+    function openRequestHiveModal() {
+      renderRequestForgeOptions();
+      syncRequestForgePreview();
+      document.getElementById('request-modal').style.display = 'flex';
+    }
+
     var _requestInProgress = false;
     async function submitProvisionRequest() {
       if (_requestInProgress) return;
@@ -11189,14 +11315,25 @@ const dashboardHTML = `<!DOCTYPE html>
       var repos = document.getElementById('rq-repos').value.trim();
       var primary = document.getElementById('rq-primary').value.trim();
       var level = parseInt(document.getElementById('rq-level').value) || 1;
+      var forge = requestForgeValue();
 
-      if (!org || !repos) { hiveToast('Org and repos are required', 'error'); _requestInProgress = false; btn.disabled = false; btn.textContent = 'Submit Request'; return; }
+      function abort(msg) {
+        hiveToast(msg, 'error');
+        _requestInProgress = false;
+        btn.disabled = false;
+        btn.textContent = 'Submit Request';
+      }
+
+      if (!org || !repos) { abort('Org and repos are required'); return; }
+      /* The forge is required client-side for a fast, in-context error; the
+         server enforces it independently — this check is UX, not security. */
+      if (!forge) { abort('A GitHub forge is required — pick one or enter the host your org lives on'); return; }
 
       try {
         var resp = await fetch('/api/saas/request-provision', {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({org: org, repos: repos, primary_repo: primary || repos.split(',')[0].trim(), acmm_level: level})
+          body: JSON.stringify({org: org, github_host: forge, repos: repos, primary_repo: primary || repos.split(',')[0].trim(), acmm_level: level})
         });
         var data = await resp.json();
         if (!resp.ok) { hiveToast(data.error || 'Request failed', 'error'); return; }
@@ -11388,6 +11525,10 @@ const dashboardHTML = `<!DOCTYPE html>
         if (!resp.ok) return;
         var clusters = await resp.json();
         _clusterList = clusters || [];
+        /* Refresh the Request-a-Hive forge picker: the cluster list usually
+           lands after first render, and the picker's whole value is listing the
+           forges the hub can actually place a hive on. */
+        renderRequestForgeOptions();
         var sel = document.getElementById('f-cluster');
         if (!sel || !clusters || !clusters.length) return;
         sel.innerHTML = clusters.map(function(c) {
@@ -12830,8 +12971,15 @@ const dashboardHTML = `<!DOCTYPE html>
       <div style="flex:1;overflow-y:auto;padding:0 32px">
         <p style="font-size:0.8rem;color:var(--muted);margin-bottom:16px">Submit a request for a hosted hive. An admin will review and approve it.</p>
         <div style="margin-bottom:12px">
+          <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">GitHub Forge *</label>
+          <select id="rq-forge" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem"></select>
+          <input id="rq-forge-custom" type="text" placeholder="github.example.com" style="width:100%;margin-top:6px;display:none;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
+          <div style="font-size:0.72rem;color:var(--muted);margin-top:4px">Which GitHub your org lives on. Required &#x2014; a bare org name does not say whether it is on github.com or a GitHub Enterprise instance.</div>
+        </div>
+        <div style="margin-bottom:12px">
           <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">GitHub Organization *</label>
           <input id="rq-org" type="text" placeholder="my-org" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
+          <div id="rq-target-preview" style="font-size:0.75rem;color:var(--muted);margin-top:6px"></div>
         </div>
         <div style="margin-bottom:12px">
           <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">Repositories * <span style="font-size:0.7rem">(comma-separated)</span></label>

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1592,6 +1592,15 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		if sh.Status == statusAvailable || (entry.ACMMLevel == 0 && sh.ACMMLevel > 0) {
 			entry.ACMMLevel = sh.ACMMLevel
 		}
+		// Show the friendly vanity host for a claimed hive the instant it is
+		// claimed, rather than waiting for the spoke to adopt+report it back over
+		// the heartbeat. Until then entry.DashboardURL (spoke-reported) is still the
+		// raw placeholder host, which is the placeholder-URL-persists bug in My
+		// Hives / the row's Open link. Only overlays a validated meta vanity_url;
+		// an unclaimed placeholder or a hive with no vanity keeps its own URL.
+		if v := claimedVanityURL(sh); v != "" {
+			entry.DashboardURL = v
+		}
 		switch sh.Status {
 		case "provisioning":
 			entry.GovernorMode = "PROVISIONING"
@@ -2193,6 +2202,14 @@ func (s *HubServer) handleOpenHive(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	s.mu.RUnlock()
+	// For a claimed hive, hand the SSO handoff off to its vanity host rather than
+	// the raw placeholder host the spoke may still be reporting — the vanity URL
+	// is the validated, user-facing host (and the one the spoke will settle on).
+	// Only a validated meta vanity_url is used; unclaimed placeholders are left on
+	// their working placeholder host.
+	if v := claimedVanityURL(loadSaaSHive(id)); v != "" {
+		base = v
+	}
 	if base == "" && (strings.HasPrefix(id, "hosted-") || strings.HasPrefix(id, "saas-")) {
 		base = "https://" + id + ".hive.kubestellar.io"
 	}
@@ -5208,6 +5225,28 @@ func (s *HubServer) adoptSpokeProjectConfig(hiveID, org string, repos []string, 
 		"acmm_was", prevLevel, "acmm_now", h.ACMMLevel)
 }
 
+// claimedVanityURL returns the vanity dashboard URL the hub should SHOW and LINK
+// for a hive (My Hives, the SSO /open handoff, config proxy), or "" to fall back
+// to the spoke-reported placeholder host.
+//
+// The rule is deliberately narrow so it never resurrects the 503 bug:
+//   - Unclaimed placeholder (statusAvailable): "" — it has no project yet, so its
+//     placeholder host is the only correct URL. Leave it.
+//   - Claimed hive with a non-empty meta VanityURL: return it. A vanity URL is
+//     only non-empty because it was VALIDATED as servable at provision/assign
+//     time (addVanityHostToIngress succeeded, or a cluster wildcard/OpenShift
+//     route already serves it, e.g. vllm-d's hosted-...apps.fmaas-vllm-d... host).
+//     Trusting it here means the hub shows/links the friendly host the instant a
+//     hive is claimed, instead of waiting for the spoke to adopt+report it back.
+//   - Claimed hive with an empty VanityURL: "" — never mint an unvalidated host
+//     here; the placeholder still works.
+func claimedVanityURL(h *SaaSHive) string {
+	if h == nil || h.Status == statusAvailable {
+		return ""
+	}
+	return h.VanityURL
+}
+
 // curAPIURL is the GitHub API base URL the spoke reports it is CURRENTLY using
 // (HeartbeatPayload.GitHubAPIURL). Empty means the spoke is too old to report
 // it — treated as UNKNOWN, never as a mismatch.
@@ -5234,7 +5273,24 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 	}
 	claimComplete := h.Org != "" && len(h.Repos) > 0 && primary != "" && h.ACMMLevel > 0
 	if !claimComplete {
-		// Incomplete/stale record (a pre-claim hive) — leave the spoke alone.
+		// Incomplete/stale record (a pre-claim hive) — leave the spoke's PROJECT
+		// (org/repos/ACMM) alone; reconciling from a stale record wiped/downgraded
+		// live hives. BUT the vanity URL is independent of project completeness: a
+		// claimed hive can carry a validated meta vanity_url (set at provision,
+		// e.g. vllmd-10's hosted-...apps.fmaas-vllm-d... route) while its meta's
+		// org/repos/ACMM are still stale/empty. Without pushing it, the spoke never
+		// adopts the vanity URL and the hub keeps showing the raw placeholder host
+		// forever (the placeholder-URL-persists bug). Push the URL alone — never
+		// the stale project — until the spoke reports the vanity back.
+		//
+		// Safety: only a NON-EMPTY VanityURL is ever pushed. A vanity URL is only
+		// non-empty because it was validated/served at provision or assign time
+		// (addVanityHostToIngress succeeded, or a cluster wildcard route already
+		// serves it), so this never pushes an unserved host and never reintroduces
+		// the 503.
+		if h.VanityURL != "" && curURL != h.VanityURL {
+			return &HeartbeatProjectConfig{DashboardURL: h.VanityURL}
+		}
 		return nil
 	}
 	// What the hub still PUSHES to the spoke, and until when:
@@ -5536,20 +5592,31 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	if h.VanityURL == "" {
 		if cluster := s.clusterForHive(h); cluster != nil && cluster.Domain != "" {
 			vanityHost := generateHiveID(body.Org, primaryRepo) + "." + cluster.Domain
-			// Only adopt the vanity hostname once the spoke's Ingress actually
-			// serves it. Nothing else creates a route for this host: provisioning
-			// templates a single DashboardHost, so a vanity URL minted here
-			// resolves to no backend and every hub link to it — including the SSO
-			// handoff — returns 503, while the raw placeholder host works fine.
-			// Create the route FIRST, then adopt the URL. VanityURL doubles as
-			// the "placeholder is claimed" marker (projectConfigForHiveID keeps
-			// pushing until the spoke reports it back), so it is always set —
-			// but a failed route is logged at Warn rather than swallowed, since
-			// the symptom is a 503 on every hub link to this hive.
+			// Make the vanity host servable, then adopt it. Nothing else creates a
+			// route for this host: provisioning templates a single DashboardHost, so
+			// a vanity URL minted here resolves to no backend and every hub link to
+			// it — including the SSO handoff — returns 503, while the raw placeholder
+			// host works fine. Create the route FIRST, then adopt the URL.
+			//
+			// VanityURL doubles as the "placeholder is claimed" marker
+			// (projectConfigForHiveID keeps pushing until the spoke reports it
+			// back), so it is always set once we have a domain to derive it from —
+			// but a failed create is logged at Warn rather than swallowed, since the
+			// symptom is a 503 on every hub link to this hive until the route is
+			// reconciled (cert-manager on nginx, or the cluster wildcard on the
+			// heartbeat-only OpenShift pool where the hub cannot kubectl to create
+			// it, so the create "fails" yet the *.apps.<domain> wildcard still
+			// serves the host — the vllm-d case).
 			if err := s.addVanityHostToIngress(hiveID, vanityHost, cluster); err != nil {
-				s.logger.Warn("vanity host is not served: could not add it to the spoke ingress/route — "+
-					"hub links to this hive will 503 until it is added by hand",
-					"hive", hiveID, "host", vanityHost, "error", err)
+				if cluster.IngressType == ingressTypeOpenShiftRoute {
+					s.logger.Info("vanity host: hub could not create a route (heartbeat-only OpenShift cluster) "+
+						"— relying on the cluster wildcard route to serve it",
+						"hive", hiveID, "host", vanityHost, "cluster", cluster.ID, "error", err)
+				} else {
+					s.logger.Warn("vanity host is not served: could not add it to the spoke ingress/route — "+
+						"hub links to this hive will 503 until it is added by hand",
+						"hive", hiveID, "host", vanityHost, "error", err)
+				}
 			}
 			h.VanityURL = "https://" + vanityHost
 		}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -211,7 +211,13 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("PUT /api/saas/hives/{id}/approve-access/{username}", s.requireAuth(s.handleApproveAccess))
 	s.mux.HandleFunc("DELETE /api/saas/hives/{id}/deny-access/{username}", s.requireAuth(s.handleDenyAccess))
 	s.mux.HandleFunc("GET /api/saas/access-status", s.handleAccessStatus)
-	s.mux.HandleFunc("GET /api/saas/repos", s.requireAuth(s.handleSaaSRepos))
+	// GET /api/saas/repos is deliberately gone. Repo discovery ran on the
+	// requester's github.com OAuth token, so it could only ever see public
+	// GitHub — invisible to GitHub Enterprise, and structurally unable to list
+	// a GitLab or Gitea repo when those forges arrive. The request flow now
+	// takes a typed repository URL, which works for every forge without new
+	// code, and that is what let the login drop to an empty OAuth scope.
+	// Restoring this endpoint would also require restoring that scope.
 	s.mux.HandleFunc("POST /api/saas/request-provision", s.requireAuth(s.handleRequestProvision))
 	s.mux.HandleFunc("PUT /api/saas/approve-provision/{username}", s.requireAdmin(s.handleApproveProvision))
 	s.mux.HandleFunc("DELETE /api/saas/deny-provision/{username}", s.requireAdmin(s.handleDenyProvision))
@@ -6711,6 +6717,21 @@ const dashboardHTML = `<!DOCTYPE html>
     });
 
     var ACMM_LABELS = {1:'L1 Assisted',2:'L2 Instructed',3:'L3 Measured',4:'L4 Adaptive',5:'L5 Semi-Automated',6:'L6 Autonomous'};
+    /* One-line "what this level actually does" per ACMM level, hoisted out of
+       acmmBadge so the badge tooltip and the Request-a-Hive level picker read
+       from the SAME strings. They used to be a local inside acmmBadge, and the
+       request modal carried its own hand-written copy that had drifted into
+       plain wrong ("L3 CI/CD", "L4 Auto PR", "L6 Fully Autonomous") — L4 in
+       particular is NOT fully autonomous, it opens hold-gated PRs for human
+       review. Anything describing a level must use this object. */
+    var ACMM_TIPS = {1:'L1 Assisted — Advisory only.',2:'L2 Instructed — Advisory beads, no GitHub writes.',3:'L3 Measured — Hold-gated PRs, CI gates.',4:'L4 Adaptive — Agents open issues, sec-check.',5:'L5 Semi-Automated — PRs with hold label, batch review.',6:'L6 Autonomous — Auto-merge on green CI.'};
+    /* The tip strings above lead with the level label; the picker renders the
+       label separately, so strip the redundant "Lx Name — " prefix there. */
+    function acmmTipDetail(level) {
+      var tip = ACMM_TIPS[level] || '';
+      var dash = tip.indexOf('—');
+      return dash >= 0 ? tip.slice(dash + 1).trim() : tip;
+    }
     function sparkline(points, color, w, h) {
       if (!points || points.length < 2) return '';
       var vals = points.map(function(p) { return p.v; });
@@ -6728,8 +6749,7 @@ const dashboardHTML = `<!DOCTYPE html>
 
     function acmmBadge(level) {
       var l = level || 0;
-      var tips = {1:'L1 Assisted — Advisory only.',2:'L2 Instructed — Advisory beads, no GitHub writes.',3:'L3 Measured — Hold-gated PRs, CI gates.',4:'L4 Adaptive — Agents open issues, sec-check.',5:'L5 Semi-Automated — PRs with hold label, batch review.',6:'L6 Autonomous — Auto-merge on green CI.'};
-      return '<span class="acmm-badge acmm-' + l + '" title="' + esc(tips[l] || '') + '">' + (ACMM_LABELS[l] || 'L' + l) + '</span>';
+      return '<span class="acmm-badge acmm-' + l + '" title="' + esc(ACMM_TIPS[l] || '') + '">' + (ACMM_LABELS[l] || 'L' + l) + '</span>';
     }
     /* Classified GitHub App auth states, matching github.AppAuthState.String()
        on the spoke and operatorSideAppStates in journey.go. The two OPERATOR
@@ -11296,11 +11316,56 @@ const dashboardHTML = `<!DOCTYPE html>
       out.style.color = host !== PUBLIC_GITHUB_HOST ? 'var(--accent, #58a6ff)' : 'var(--muted)';
     }
 
+    /* REQUEST_DEFAULT_ACMM_LEVEL is where a new hive starts. L3 Measured is the
+       first level that produces useful output (hold-gated PRs that raise test
+       coverage) while still requiring a human on every merge, which is the
+       right default for someone who has not run a hive before. */
+    var REQUEST_DEFAULT_ACMM_LEVEL = 3;
+    /* ACMM levels offered on the request form, lowest to highest. All six are
+       offered — L5 and L6 are real, selectable levels, not hidden ones. */
+    var REQUEST_ACMM_LEVELS = [1, 2, 3, 4, 5, 6];
+
+    /* renderRequestLevelOptions builds the level picker from ACMM_LABELS and
+       ACMM_TIPS. Rendering rather than hardcoding is the point: the previous
+       hardcoded <option> list had drifted to names that appear nowhere else in
+       the product and described the wrong behaviour. */
+    function renderRequestLevelOptions() {
+      var sel = document.getElementById('rq-level');
+      if (!sel) return;
+      var prev = sel.value;
+      sel.innerHTML = (REQUEST_ACMM_LEVELS || []).map(function(l) {
+        var label = ACMM_LABELS[l] || ('L' + l);
+        var detail = acmmTipDetail(l);
+        /* Label and one-line description live in the option text itself: a
+           <select> shows only the selected option when closed, so a requester
+           browsing the list needs the description inline to compare levels. */
+        return '<option value="' + l + '">' + esc(label) + (detail ? ' &#x2014; ' + esc(detail) : '') + '</option>';
+      }).join('');
+      sel.value = prev || String(REQUEST_DEFAULT_ACMM_LEVEL);
+      if (!sel.value) sel.value = String(REQUEST_DEFAULT_ACMM_LEVEL);
+      if (!sel._rqLevelWired) {
+        sel._rqLevelWired = true;
+        sel.addEventListener('change', syncRequestLevelDesc);
+      }
+      syncRequestLevelDesc();
+    }
+
+    /* syncRequestLevelDesc restates the selected level's description under the
+       picker, so it stays readable once the dropdown is closed. */
+    function syncRequestLevelDesc() {
+      var sel = document.getElementById('rq-level');
+      var out = document.getElementById('rq-level-desc');
+      if (!sel || !out) return;
+      var lvl = parseInt(sel.value, 10) || REQUEST_DEFAULT_ACMM_LEVEL;
+      out.textContent = ACMM_TIPS[lvl] || '';
+    }
+
     /* openRequestHiveModal shows the modal with a freshly populated forge
        picker, so a cluster list that loaded after page render is reflected. */
     function openRequestHiveModal() {
       renderRequestForgeOptions();
       syncRequestForgePreview();
+      renderRequestLevelOptions();
       document.getElementById('request-modal').style.display = 'flex';
     }
 
@@ -12991,14 +13056,11 @@ const dashboardHTML = `<!DOCTYPE html>
         </div>
         <div style="margin-bottom:12px">
           <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">ACMM Level</label>
-          <select id="rq-level" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
-            <option value="1">L1 &#x2014; Assisted</option>
-            <option value="2">L2 &#x2014; Instructed</option>
-            <option value="3" selected>L3 &#x2014; CI/CD</option>
-            <option value="4">L4 &#x2014; Auto PR</option>
-            <option value="5">L5 &#x2014; Self-Governing</option>
-            <option value="6">L6 &#x2014; Fully Autonomous</option>
-          </select>
+          <!-- Options are rendered by renderRequestLevelOptions() from
+               ACMM_LABELS/ACMM_TIPS so this picker can never drift from the
+               names the rest of the hub shows. Do not hardcode them here. -->
+          <select id="rq-level" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem"></select>
+          <div id="rq-level-desc" style="font-size:0.72rem;color:var(--muted);margin-top:6px"></div>
         </div>
       </div>
       <div style="display:flex;gap:12px;justify-content:flex-end;padding:16px 32px;border-top:1px solid var(--border);flex-shrink:0">
@@ -13573,116 +13635,4 @@ func (s *HubServer) handleGetHubBanner(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"banners": banners})
-}
-
-// handleSaaSRepos lists the repositories the requester can pick from in the
-// "Get a hosted hive" flow (step 3).
-//
-// The frontend has always called GET /api/saas/repos, but no handler was ever
-// registered — the fetch 404'd and the page fell through to "No repositories
-// found. Make sure the Hive GitHub App is installed on your org", which blamed
-// the user's App installation for a missing backend route. It failed for every
-// requester regardless of whether the App was installed.
-//
-// Repos come from the App installations the user's OAuth token can see, which
-// covers BOTH org installations and personal-account installations (the
-// original error text assumed orgs only — the first real report was a repo
-// under a personal account).
-//
-// Note this can only ever see public github.com. A GitHub Enterprise repo
-// (github.ibm.com, …) is invisible to a github.com OAuth token, so the UI also
-// lets the requester type a repo URL by hand; that path does not depend on this
-// endpoint.
-func (s *HubServer) handleSaaSRepos(w http.ResponseWriter, r *http.Request) {
-	username := s.getAuthUser(r)
-	if username == "" {
-		http.Error(w, `{"error":"not authenticated"}`, http.StatusUnauthorized)
-		return
-	}
-	user := loadSaaSUser(username)
-	if user == nil || user.EncryptedToken == "" {
-		// No stored token — return an empty list rather than an error so the UI
-		// shows its "install the App / paste a URL" guidance instead of a crash.
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"repos": []any{}})
-		return
-	}
-	token, err := decryptToken(user.EncryptedToken)
-	if err != nil {
-		s.logger.Warn("repos: failed to decrypt user token", "user", username, "error", err)
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"repos": []any{}})
-		return
-	}
-
-	type repoOut struct {
-		FullName    string `json:"full_name"`
-		Name        string `json:"name"`
-		Description string `json:"description,omitempty"`
-	}
-	ghGet := func(url string, out any) error {
-		req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, url, nil)
-		if err != nil {
-			return err
-		}
-		req.Header.Set("Authorization", "token "+token)
-		req.Header.Set("Accept", "application/vnd.github+json")
-		resp, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("github %s: status %d", url, resp.StatusCode)
-		}
-		return json.NewDecoder(resp.Body).Decode(out)
-	}
-
-	// 1. Which App installations can this user see? (orgs AND their own account)
-	var insts struct {
-		Installations []struct {
-			ID int64 `json:"id"`
-		} `json:"installations"`
-	}
-	if err := ghGet("https://api.github.com/user/installations?per_page=100", &insts); err != nil {
-		s.logger.Warn("repos: listing installations failed", "user", username, "error", err)
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"repos": []any{}})
-		return
-	}
-
-	// 2. Repositories per installation, deduped by full_name.
-	seen := map[string]struct{}{}
-	repos := []repoOut{}
-	for _, inst := range insts.Installations {
-		for page := 1; page <= 5; page++ { // cap paging; 500 repos is plenty for a picker
-			var rr struct {
-				Repositories []struct {
-					FullName    string `json:"full_name"`
-					Name        string `json:"name"`
-					Description string `json:"description"`
-				} `json:"repositories"`
-			}
-			url := fmt.Sprintf("https://api.github.com/user/installations/%d/repositories?per_page=100&page=%d", inst.ID, page)
-			if err := ghGet(url, &rr); err != nil {
-				s.logger.Warn("repos: listing installation repos failed",
-					"user", username, "installation", inst.ID, "error", err)
-				break
-			}
-			for _, rp := range rr.Repositories {
-				if _, dup := seen[rp.FullName]; dup {
-					continue
-				}
-				seen[rp.FullName] = struct{}{}
-				repos = append(repos, repoOut{FullName: rp.FullName, Name: rp.Name, Description: rp.Description})
-			}
-			if len(rr.Repositories) < 100 {
-				break
-			}
-		}
-	}
-	sort.Slice(repos, func(i, j int) bool { return repos[i].FullName < repos[j].FullName })
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"repos": repos})
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2806,6 +2806,19 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"branch does not map to a valid image tag"}`, http.StatusBadRequest)
 		return
 	}
+	// Shape is not existence. A DEPRECATED branch (v3 was retired while hives
+	// were still pointed at it) keeps a perfectly well-formed "<branch>-latest"
+	// tag that CI no longer publishes, so validateImageTag passes and the pull
+	// then fails with an opaque "manifest unknown". Kubernetes keeps the old
+	// ReplicaSet serving, so the hive looks alive while silently running stale
+	// code. Verify the tag is actually pullable before writing it.
+	if !spokeImageExists(imageTag, s.logger) {
+		s.logger.Error("branch switch REFUSED: image tag not published on GHCR",
+			"hive", id, "branch", body.Branch, "tag", imageTag,
+			"hint", "branch may be deprecated or its CI image build never completed")
+		http.Error(w, `{"error":"no published image for that branch (deprecated branch, or its image build has not completed)"}`, http.StatusBadRequest)
+		return
+	}
 	// "*=" updates every container including init containers (copy-config,
 	// init-permissions) — pinning only "hive" left inits on the old branch tag.
 	cmd := kubectlForCluster(cluster, "set", "image", "deployment/hive", "*="+image, "-n", ns)
@@ -3152,6 +3165,16 @@ const (
 var hubImageExists = func(sha string, logger *slog.Logger) bool {
 	client := &http.Client{Timeout: 10 * time.Second}
 	return ghcrTagExists(client, ghcrRepoHub, sha, logger)
+}
+
+// spokeImageExists is the ghcrRepoSpoke counterpart of hubImageExists: it
+// reports whether a SPOKE tag (a "<branch>-latest" channel tag or a SHA) is
+// actually published. Separate from hubImageExists because the two repos are
+// independent build jobs — the hub image for a SHA can exist while the spoke
+// image for that same SHA does not. A var so tests can stub the GHCR round-trip.
+var spokeImageExists = func(tag string, logger *slog.Logger) bool {
+	client := &http.Client{Timeout: 10 * time.Second}
+	return ghcrTagExists(client, ghcrRepoSpoke, tag, logger)
 }
 
 var (

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2266,7 +2266,7 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 		// so the hive disappears from the listing immediately.
 		s.removeRegistryEntry(id, username)
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"status":"deleted"}`))
+		json.NewEncoder(w).Encode(map[string]string{"status": deleteStatusDeleted})
 		return
 	}
 	if h.Owner != username && username != hubAdminUsername {
@@ -2275,19 +2275,49 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Full de-provisioning: namespace, PV, OCI export, OCI file system, disk record, user cleanup.
+	//
+	// The registry entry is removed unconditionally, even when the cluster
+	// teardown cannot run or only partially succeeds. A hive whose namespace is
+	// already gone (or whose cluster config has been removed) would otherwise be
+	// permanently un-deletable: the handler used to return 500 before reaching
+	// removeRegistryEntry, stranding a ghost row in "My Hives" that no amount of
+	// re-clicking Delete could clear. Leaving a stranded row is strictly worse
+	// than leaving cloud resources behind, because the row is what the user sees
+	// and it is the only thing they can act on. Partial failures are reported in
+	// the response so the user knows manual cleanup may still be needed.
 	cluster := s.clusterForHive(h)
-	if cluster == nil {
-		s.logger.Error("no cluster config for deprovision", "hive_id", id, "cluster_id", h.ClusterID)
-		http.Error(w, `{"error":"no cluster config — cannot deprovision"}`, http.StatusInternalServerError)
-		return
+	if cluster != nil {
+		deprovisionHive(h, cluster, s.logger)
+	} else {
+		s.logger.Error("no cluster config for deprovision; removing registry entry anyway",
+			"hive_id", id, "cluster_id", h.ClusterID)
 	}
-	deprovisionHive(h, cluster, s.logger)
 	s.removeRegistryEntry(id, username)
 
-	s.logger.Info("audit: hosted hive deleted", "hive_id", id, "by", username)
+	s.logger.Info("audit: hosted hive deleted", "hive_id", id, "by", username,
+		"deprovisioned", cluster != nil)
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"status":"deleted"}`))
+	if cluster == nil {
+		// deleteStatusPartial tells the UI the registry row is gone but cloud
+		// resources may survive and need manual cleanup.
+		json.NewEncoder(w).Encode(map[string]string{
+			"status":  deleteStatusPartial,
+			"warning": "removed from the hub registry, but no cluster config was available to delete the namespace, PV, or OCI storage — these may need manual cleanup",
+		})
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]string{"status": deleteStatusDeleted})
 }
+
+// Delete outcome statuses returned by handleDeleteHive.
+const (
+	// deleteStatusDeleted means the registry entry was removed and the cluster
+	// teardown ran.
+	deleteStatusDeleted = "deleted"
+	// deleteStatusPartial means the registry entry was removed but the cluster
+	// teardown could not run; cloud resources may need manual cleanup.
+	deleteStatusPartial = "partially_deleted"
+)
 
 // MigrateRequest is the JSON body for POST /api/saas/hives/{id}/migrate.
 type MigrateRequest struct {
@@ -12087,8 +12117,20 @@ const dashboardHTML = `<!DOCTYPE html>
         gtag('event','hive_deleted',{hive_id:id});
         hiveToast('Deleting ' + id + '...', 'info');
         var resp = await fetch('/api/saas/hives/' + encodeURIComponent(id), {method: 'DELETE'});
-        if (!resp.ok) { var d = await resp.json(); hiveToast(d.error || 'Delete failed', 'error'); return; }
-        hiveToast('Deleted ' + id, 'success');
+        if (!resp.ok) {
+          var d = await resp.json().catch(function(){ return {}; });
+          hiveToast(d.error || 'Delete failed', 'error');
+          // Refresh regardless: the hub removes the registry entry even when
+          // teardown fails, so the listing may already be correct.
+          loadHives();
+          return;
+        }
+        var ok = await resp.json().catch(function(){ return {}; });
+        if (ok.status === 'partially_deleted') {
+          hiveToast('Removed ' + id + ' from the hub, but cleanup was incomplete: ' + (ok.warning || 'cloud resources may need manual removal'), 'error');
+        } else {
+          hiveToast('Deleted ' + id, 'success');
+        }
         loadHives();
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); }
       finally { btns.forEach(function(b) { b.disabled = false; b.textContent = 'Delete'; b.style.opacity = '1'; }); }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4969,11 +4969,16 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	const minACMMLevel = 1
-	const maxACMMLevel = 6
+	// A hive is never REQUESTED above L3 Measured. L4-L6 are real levels, but
+	// they are reached after provisioning, from the hive's own dashboard, once
+	// the project has the coverage and CI history to justify them. The
+	// get-started wizard only offers L1-L3, but the wizard is one client: clamp
+	// here so a crafted request cannot provision straight into auto-merge.
+	// Admin paths (assign/provision) keep the full 0..6 range on purpose — an
+	// operator setting a level deliberately is not the case being guarded.
 	acmm := body.ACMMLevel
-	if acmm < minACMMLevel || acmm > maxACMMLevel {
-		acmm = minACMMLevel
+	if acmm < minRequestACMMLevel || acmm > maxRequestACMMLevel {
+		acmm = minRequestACMMLevel
 	}
 
 	primaryRepo := body.PrimaryRepo
@@ -11500,9 +11505,16 @@ const dashboardHTML = `<!DOCTYPE html>
        coverage) while still requiring a human on every merge, which is the
        right default for someone who has not run a hive before. */
     var REQUEST_DEFAULT_ACMM_LEVEL = 3;
-    /* ACMM levels offered on the request form, lowest to highest. All six are
-       offered — L5 and L6 are real, selectable levels, not hidden ones. */
-    var REQUEST_ACMM_LEVELS = [1, 2, 3, 4, 5, 6];
+    /* ACMM levels offered on the request form, lowest to highest. Capped at L3
+       Measured, matching maxRequestACMMLevel on POST /api/saas/request-provision
+       and the get-started wizard: a hive is never REQUESTED above L3. L4-L6 are
+       real levels, reached after provisioning from the hive's own dashboard
+       once coverage and CI history have earned them. This form posts to the
+       same clamped endpoint as the wizard, so offering L4-L6 here would not
+       grant them — it would silently record L1 instead. */
+    var REQUEST_ACMM_LEVELS = [1, 2, 3];
+    /* Restated under the picker so the cap reads as "later", not "denied". */
+    var REQUEST_LEVELS_LATER_NOTE = 'L4 Adaptive, L5 Semi-Automated and L6 Autonomous become available after provisioning, from your hive dashboard.';
 
     /* renderRequestLevelOptions builds the level picker from ACMM_LABELS and
        ACMM_TIPS. Rendering rather than hardcoding is the point: the previous
@@ -11536,7 +11548,8 @@ const dashboardHTML = `<!DOCTYPE html>
       var out = document.getElementById('rq-level-desc');
       if (!sel || !out) return;
       var lvl = parseInt(sel.value, 10) || REQUEST_DEFAULT_ACMM_LEVEL;
-      out.textContent = ACMM_TIPS[lvl] || '';
+      var tip = ACMM_TIPS[lvl] || '';
+      out.textContent = tip ? (tip + ' ' + REQUEST_LEVELS_LATER_NOTE) : REQUEST_LEVELS_LATER_NOTE;
     }
 
     /* openRequestHiveModal shows the modal with a freshly populated forge

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -7592,6 +7592,56 @@ const dashboardHTML = `<!DOCTYPE html>
       return '';
     }
 
+    /* SSO_NAV_ATTR marks an anchor whose href is a DISPLAY url (the friendly
+       vanity host) but whose click must actually go through the hub's /open
+       handoff. The real navigation target is carried here rather than in href
+       because browsers show the raw href in the status bar on hover, and the
+       placeholder-id /open path is exactly what we do not want a user to read
+       there. Named so the delegated click listener below and the builder agree
+       on one string. */
+    var SSO_NAV_ATTR = 'data-sso-open';
+
+    /* ssoDisplayLink builds the hive-name anchor.
+
+       href      = displayUrl (vanity) when we have one, so the status bar, the
+                   context menu's "Copy link address" and middle-click all show
+                   and use the friendly host.
+       data attr = openUrl, the hub /open endpoint that mints the 90s HMAC SSO
+                   handoff token. A plain left-click is intercepted and sent
+                   there instead, so the normal path still lands authenticated.
+
+       The cmd-click / middle-click divergence is DELIBERATE and safe: the spoke
+       serves a real "Sign in with GitHub" device-flow page at its root, so a
+       token-less arrival on the vanity host is an ordinary login, not a dead
+       end. Trading a rare extra sign-in for a readable URL on every hover is
+       the intended bargain.
+
+       When displayUrl is empty (unclaimed placeholder, or vanity adoption
+       skipped) there is nothing friendlier to show, so href stays the /open
+       url and behavior is byte-for-byte what it was before. */
+    function ssoDisplayLink(openUrl, displayUrl, text, cls) {
+      var shown = displayUrl || openUrl;
+      var navAttr = displayUrl ? ' ' + SSO_NAV_ATTR + '="' + esc(openUrl) + '"' : '';
+      return '<a href="' + esc(shown) + '" target="_blank"' + navAttr +
+        ' class="' + cls + '" title="Open dashboard">' + esc(text) + '</a>';
+    }
+
+    /* One delegated listener rather than per-row handlers: the table is
+       re-rendered wholesale on every refresh, so inline handlers would be
+       re-attached constantly. Only a plain primary-button click is taken over;
+       cmd/ctrl/shift/alt-click and middle-click fall through to the browser so
+       "open in new tab" keeps its native meaning (landing on the vanity login
+       page, per the note above). */
+    document.addEventListener('click', function(ev) {
+      var a = ev.target && ev.target.closest ? ev.target.closest('[' + SSO_NAV_ATTR + ']') : null;
+      if (!a) return;
+      if (ev.button !== 0 || ev.metaKey || ev.ctrlKey || ev.shiftKey || ev.altKey) return;
+      var target = a.getAttribute(SSO_NAV_ATTR);
+      if (!target) return;
+      ev.preventDefault();
+      window.open(target, '_blank');
+    });
+
     async function loadUser() {
       try {
         var resp = await fetch('/api/auth/user');
@@ -10206,7 +10256,7 @@ const dashboardHTML = `<!DOCTYPE html>
         return '<tr>' +
           bulkCheckboxCell(h, section || 'all') +
           '<td class="hive-menu-cell" style="position:relative;width:30px;text-align:center;overflow:visible">' + (h.migrationStatus === 'migrating' ? '<span style="font-size:1.1rem;color:var(--border);user-select:none;cursor:not-allowed" title="Disabled during migration">⋮</span>' : '<span style="cursor:pointer;font-size:1.1rem;color:var(--muted);user-select:none">⋮</span>' + pendingBadge + '<div class="hive-menu-dropdown" style="display:none;position:absolute;left:0;bottom:auto;background:#1c2128;border:1px solid #30363d;border-radius:8px;min-width:160px;padding:4px 0;z-index:1000;box-shadow:0 8px 24px rgba(0,0,0,0.5)">' + menuItems.join('') + '</div>') + '</td>' +
-          '<td style="text-align:left;line-height:1.4">' + (function() { var isHostedRow = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'))); var dh = isHostedRow && h.id ? ('/api/saas/hives/' + encodeURIComponent(h.id) + '/open') : (rb ? esc(rb) : ''); /* Label derived from the PROJECT (org + primary repo), not by splitting h.name — see hiveLabel. */ var label = hiveLabel(h); var orgName = label.line1; var repoName = label.line2; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var ghIcon = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : ''; var link = function(text, bold) { if (dh) { return '<a href="' + dh + '" target="_blank" class="' + (bold ? 'hive-name-link' : 'hive-sub-link') + '" title="Open dashboard">' + esc(text) + '</a>'; } var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName, true); var fcPill = h.online ? failingCheckSummary(h) : ''; /* Advisory-staleness pill sits right beside the failing-check pill: both are "something is quietly wrong with this working hive" signals, and advisoryStaleSummary already self-suppresses (empty string) unless the hub flagged the digest stale, so unaffected rows are pixel-identical. */ var advPill = h.online ? advisoryStaleSummary(h) : ''; /* Inline access faces sit on the name cell's second line, immediately after this row's own role badge: the badge already answers "what am I on this hive", so the co-members read as the natural continuation of the same thought, in the one cell that is left-aligned and has room to grow. It also keeps them out of the 16 dense metric columns, none of which is about people. Empty string when the viewer is the only member, so those rows are pixel-identical to today. */ var accessFaces = hiveAccessAvatars(h); /* Keyed off repoName, not orgName: line 1 now always carries SOME identity, so the presence of a second line is decided purely by whether there is a repo to put on it. Without a repo the row still shows the GitHub icon, role badge, faces and failing-check pill on the compact variant. */ var line2 = repoName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + '</div>'; var line3 = pendingPill ? '<div style="margin-top:4px;padding-left:18px">' + pendingPill + '</div>' : ''; return line1 + line2 + line3; })() + '</td>' +
+          '<td style="text-align:left;line-height:1.4">' + (function() { var isHostedRow = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'))); var dh = isHostedRow && h.id ? ('/api/saas/hives/' + encodeURIComponent(h.id) + '/open') : (rb ? esc(rb) : ''); /* Label derived from the PROJECT (org + primary repo), not by splitting h.name — see hiveLabel. */ var label = hiveLabel(h); var orgName = label.line1; var repoName = label.line2; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var ghIcon = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : ''; /* vanityDisplay is the friendly host shown in the status bar on hover. rb is resolvedBase(h), which the hub has already overlaid with the claimed vanity_url; it is only a DISPLAY url here, never the click target — see ssoDisplayLink. Empty for a row with no vanity host, which falls back to today's /open href. Only meaningful on hosted rows: a non-hosted row's dh IS rb already. */ var vanityDisplay = isHostedRow && rb ? rb : ''; var link = function(text, bold) { if (dh) { return ssoDisplayLink(dh, vanityDisplay, text, bold ? 'hive-name-link' : 'hive-sub-link'); } var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName, true); var fcPill = h.online ? failingCheckSummary(h) : ''; /* Advisory-staleness pill sits right beside the failing-check pill: both are "something is quietly wrong with this working hive" signals, and advisoryStaleSummary already self-suppresses (empty string) unless the hub flagged the digest stale, so unaffected rows are pixel-identical. */ var advPill = h.online ? advisoryStaleSummary(h) : ''; /* Inline access faces sit on the name cell's second line, immediately after this row's own role badge: the badge already answers "what am I on this hive", so the co-members read as the natural continuation of the same thought, in the one cell that is left-aligned and has room to grow. It also keeps them out of the 16 dense metric columns, none of which is about people. Empty string when the viewer is the only member, so those rows are pixel-identical to today. */ var accessFaces = hiveAccessAvatars(h); /* Keyed off repoName, not orgName: line 1 now always carries SOME identity, so the presence of a second line is decided purely by whether there is a repo to put on it. Without a repo the row still shows the GitHub icon, role badge, faces and failing-check pill on the compact variant. */ var line2 = repoName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + '</div>'; var line3 = pendingPill ? '<div style="margin-top:4px;padding-left:18px">' + pendingPill + '</div>' : ''; return line1 + line2 + line3; })() + '</td>' +
           '<td>' + locationCell + '</td>' +
           '<td style="white-space:nowrap">' + uptimeCell(h) + '</td>' +
           /* No white-space:nowrap on the cell itself: the stacked lines each

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2492,6 +2492,21 @@ func (s *HubServer) rolloutHubToSHA(sha string) error {
 	if sha == "" {
 		return fmt.Errorf("empty target SHA")
 	}
+	// Shape-check the tag BEFORE it can reach a live Deployment. Writing an
+	// unresolvable tag (the `target1` incident — a test fixture SHA that escaped
+	// to the real cluster) leaves the new ReplicaSet in ImagePullBackOff while
+	// the old one keeps serving: the hub stays "up" but silently runs stale
+	// code. Refusing here leaves the last good image running and makes the
+	// failure loud instead of invisible.
+	if err := validateImageTag(sha); err != nil {
+		s.logger.Error("hub self-upgrade REFUSED: invalid image tag",
+			"tag", sha,
+			"deployment", hubDeploymentName,
+			"namespace", hubNamespace,
+			"error", err)
+		s.setHubUpgradeFault(fmt.Sprintf("refused invalid image tag %q: %v", sha, err))
+		return err
+	}
 	if !hubImageExists(sha, s.logger) {
 		return fmt.Errorf("hub image %s:%s not published yet", ghcrRepoHub, sha)
 	}
@@ -2504,8 +2519,98 @@ func (s *HubServer) rolloutHubToSHA(sha string) error {
 	s.hubUpgradeMu.Lock()
 	s.lastHubUpgradeTrigger = time.Now()
 	s.hubUpgradeTarget = sha
+	s.hubUpgradeFault = "" // a fresh, validated rollout clears any prior refusal
 	s.hubUpgradeMu.Unlock()
+	// Watch the rollout land. Detect-and-report only: an auto-rollback would
+	// race the upgrade poller (which re-triggers the same target every cycle),
+	// so a rollback could fight the upgrade loop and flap the deployment. See
+	// watchHubRollout.
+	go s.watchHubRollout(sha, image)
 	return nil
+}
+
+// hubRolloutWatchTimeout bounds how long we wait for a self-upgrade we just
+// triggered to become Ready before flagging it as stuck. The hub's own image is
+// a few hundred MB and a cold node has to pull it, so this is generous enough
+// to avoid false alarms while still catching an ImagePullBackOff — which
+// back-off-retries indefinitely and would otherwise never surface.
+const hubRolloutWatchTimeout = 5 * time.Minute
+
+// hubRolloutPollInterval is how often watchHubRollout re-checks rollout status.
+const hubRolloutPollInterval = 15 * time.Second
+
+// watchHubRollout confirms a self-upgrade actually became Ready, and records a
+// loud, user-visible fault if it did not.
+//
+// It deliberately does NOT roll back. The auto-upgrade poller re-evaluates the
+// same target every cycle, so an automatic rollback would immediately be undone
+// and re-applied, flapping the deployment during an already-degraded window.
+// Detect and report is the safe half of the loop: the operator sees the stuck
+// upgrade in the UI and in the logs, and decides.
+func (s *HubServer) watchHubRollout(sha, image string) {
+	deadline := time.Now().Add(hubRolloutWatchTimeout)
+	for time.Now().Before(deadline) {
+		time.Sleep(hubRolloutPollInterval)
+		// `rollout status --timeout=0s` returns non-zero while a rollout is
+		// still progressing and zero once it has fully succeeded.
+		cmd := kubectlForCluster(s.hubCluster(), "rollout", "status",
+			"deployment/"+hubDeploymentName, "-n", hubNamespace, "--timeout=0s")
+		if err := cmd.Run(); err == nil {
+			s.hubUpgradeMu.Lock()
+			s.hubUpgradeFault = ""
+			s.hubUpgradeMu.Unlock()
+			s.logger.Info("hub self-upgrade rollout completed", "sha", sha, "image", image)
+			return
+		}
+	}
+	// Still not Ready. Pull the pod-level reason so the log names the actual
+	// cause (ImagePullBackOff / ErrImagePull / CrashLoopBackOff) rather than
+	// just "timed out".
+	reason := s.hubRolloutFailureReason()
+	s.logger.Error("hub self-upgrade STUCK: new ReplicaSet not Ready — hub is still serving the OLD image",
+		"sha", sha,
+		"image", image,
+		"deployment", hubDeploymentName,
+		"namespace", hubNamespace,
+		"waited", hubRolloutWatchTimeout.String(),
+		"reason", reason)
+	s.setHubUpgradeFault(fmt.Sprintf("upgrade to %s stuck after %s: %s (still serving the previous image)",
+		image, hubRolloutWatchTimeout, reason))
+}
+
+// hubRolloutFailureReason best-effort extracts why the hub's pods are not
+// Ready, so the stuck-rollout log/status names the real cause.
+func (s *HubServer) hubRolloutFailureReason() string {
+	const reasonJSONPath = `{range .items[*].status.containerStatuses[*]}{.state.waiting.reason}{" "}{.state.waiting.message}{"\n"}{end}`
+	cmd := kubectlForCluster(s.hubCluster(), "get", "pods",
+		"-n", hubNamespace, "-l", "app="+hubDeploymentName,
+		"-o", "jsonpath="+reasonJSONPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "unknown (could not read pod status)"
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			return line
+		}
+	}
+	return "unknown (no waiting container state reported)"
+}
+
+// setHubUpgradeFault records a self-upgrade failure for the dashboard so a
+// stuck or refused upgrade is visible in the UI, not only in `kubectl describe`.
+func (s *HubServer) setHubUpgradeFault(msg string) {
+	s.hubUpgradeMu.Lock()
+	s.hubUpgradeFault = msg
+	s.hubUpgradeMu.Unlock()
+}
+
+// HubUpgradeFault returns the current self-upgrade fault message, or "" when
+// the last upgrade attempt was healthy.
+func (s *HubServer) HubUpgradeFault() string {
+	s.hubUpgradeMu.Lock()
+	defer s.hubUpgradeMu.Unlock()
+	return s.hubUpgradeFault
 }
 
 // hubUpgradeState reports the hub's own upgrade status for the dashboard badge:
@@ -2515,6 +2620,9 @@ func (s *HubServer) rolloutHubToSHA(sha string) error {
 //   - "queued"    — behind latest, auto-upgrade ON, no rollout in flight yet
 //     (the poller will trigger one shortly)
 //   - "behind"    — behind latest, auto-upgrade OFF (admin must click Upgrade)
+//   - "failed"    — an upgrade was REFUSED (malformed image tag) or its rollout
+//     never became Ready. The hub is behind and cannot self-heal;
+//     an operator must look. HubUpgradeFault() carries the reason.
 //   - "unknown"   — latest SHA not resolved yet
 //
 // This is the field the badge needs: previously the frontend could only tell an
@@ -2534,7 +2642,14 @@ func (s *HubServer) hubUpgradeState() string {
 	s.hubUpgradeMu.Lock()
 	inFlight := s.hubUpgradeTarget != "" &&
 		time.Since(s.lastHubUpgradeTrigger) < hubUpgradeDebounce
+	fault := s.hubUpgradeFault
 	s.hubUpgradeMu.Unlock()
+	// A refused or stuck upgrade outranks "upgrading"/"queued": the hub is
+	// behind AND cannot get there on its own, which needs an operator. Without
+	// this the badge showed a reassuring "queued" while the rollout was wedged.
+	if fault != "" {
+		return hubUpgradeStateFailed
+	}
 	if inFlight {
 		return "upgrading"
 	}
@@ -2682,6 +2797,15 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 	ns := "hive-hosted-" + id
 	imageTag := branchToTag(body.Branch) + "-latest"
 	image := "ghcr.io/kubestellar/hive:" + imageTag
+	// Refuse a branch name that sanitizes into something that is not a valid
+	// channel tag, rather than stranding the spoke on ImagePullBackOff behind a
+	// still-serving old ReplicaSet.
+	if err := validateImageTag(imageTag); err != nil {
+		s.logger.Error("branch switch REFUSED: invalid image tag",
+			"hive", id, "branch", body.Branch, "tag", imageTag, "error", err)
+		http.Error(w, `{"error":"branch does not map to a valid image tag"}`, http.StatusBadRequest)
+		return
+	}
 	// "*=" updates every container including init containers (copy-config,
 	// init-permissions) — pinning only "hive" left inits on the old branch tag.
 	cmd := kubectlForCluster(cluster, "set", "image", "deployment/hive", "*="+image, "-n", ns)
@@ -3015,6 +3139,11 @@ const (
 	hubDeploymentName = "hive-hub"
 	hubContainerName  = "hub"
 	hubNamespace      = "hive-hub"
+
+	// hubUpgradeStateFailed is the hubUpgradeState() value meaning the hub is
+	// behind latest AND its last upgrade attempt was refused or wedged, so it
+	// cannot reach latest without operator action.
+	hubUpgradeStateFailed = "failed"
 )
 
 // hubImageExists reports whether the hub's own container image is published on

--- a/v2/pkg/hub/saas_edge_coverage_test.go
+++ b/v2/pkg/hub/saas_edge_coverage_test.go
@@ -144,7 +144,7 @@ func TestHandleHubSelfUpgrade_Edge(t *testing.T) {
 	defer cleanup()
 
 	// A latest v2 SHA must be resolved for the handler to have a target.
-	setV2Latest(t, "target1")
+	setV2Latest(t, "7a41e01")
 	// Stub the GHCR hub-image check so tests don't hit the network; assume the
 	// hub image exists for the success path.
 	oldImgCheck := hubImageExists

--- a/v2/pkg/hub/saas_edge_coverage_test.go
+++ b/v2/pkg/hub/saas_edge_coverage_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -68,18 +69,40 @@ func TestHandleUpgradeHiveRegistryUpdate(t *testing.T) {
 	}
 }
 
+// TestHandleDeleteHiveNoCluster: a missing cluster config must NOT block the
+// delete. This previously returned 500 before removing the registry entry,
+// which stranded a ghost row in "My Hives" that the user could never clear.
+// The delete now succeeds and reports the partial outcome instead.
 func TestHandleDeleteHiveNoCluster(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 	mkUser(t, "alice")
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", ClusterID: "gone"})
 	s := noClusterHub()
+	s.mu.Lock()
+	s.registry.Hives = []RegistryEntry{{ID: "h1", Owner: "alice"}}
+	s.mu.Unlock()
 
 	rec := httptest.NewRecorder()
 	req := setPathValue(reqWithUser(http.MethodDelete, "/del", "", "alice"), "id", "h1")
 	s.handleDeleteHive(rec, req)
-	if rec.Code != http.StatusInternalServerError {
-		t.Errorf("no-cluster delete status = %d, want 500", rec.Code)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("no-cluster delete status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("parse response: %v (body=%s)", err, rec.Body.String())
+	}
+	if body["status"] != deleteStatusPartial {
+		t.Errorf("no-cluster delete status field = %q, want %q", body["status"], deleteStatusPartial)
+	}
+
+	s.mu.RLock()
+	remaining := len(s.registry.Hives)
+	s.mu.RUnlock()
+	if remaining != 0 {
+		t.Errorf("registry entry survived a no-cluster delete (ghost hive), %d remaining", remaining)
 	}
 }
 

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1058,12 +1058,22 @@ func (s *HubServer) migrateHive(h *SaaSHive, fromCluster, toCluster *ClusterConf
 	}
 
 	// Update the registry entry's ClusterID and ClusterName in-memory.
+	// A migration re-provisions the hive under a fresh placeholder Subdomain on
+	// the target cluster, but a CLAIMED hive must keep showing its vanity host —
+	// resetting DashboardURL to the placeholder subdomain here is exactly what
+	// left claimed, migrated hives back on the placeholder URL in the hub. Prefer
+	// the validated meta vanity_url for a claimed hive; only an unclaimed
+	// placeholder falls back to its new placeholder subdomain.
+	migratedURL := "https://" + h.Subdomain
+	if v := claimedVanityURL(h); v != "" {
+		migratedURL = v
+	}
 	s.mu.Lock()
 	for i := range s.registry.Hives {
 		if s.registry.Hives[i].ID == h.ID {
 			s.registry.Hives[i].ClusterID = toCluster.ID
 			s.registry.Hives[i].ClusterName = toCluster.Name
-			s.registry.Hives[i].DashboardURL = "https://" + h.Subdomain
+			s.registry.Hives[i].DashboardURL = migratedURL
 			break
 		}
 	}

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -57,6 +57,13 @@ const (
 	// ingressTypeOpenShiftRoute selects OpenShift Route generation.
 	ingressTypeOpenShiftRoute = "openshift-route"
 
+	// routeBaseDashboard and routeBaseTerminal name the Routes that provisioning
+	// creates on an OpenShift spoke. addVanityHostToIngress mirrors each one into
+	// a parallel "<name>-vanity" Route, because a Route carries a single host and
+	// so cannot simply gain the vanity hostname the way an nginx Ingress rule can.
+	routeBaseDashboard = "hive-dashboard"
+	routeBaseTerminal  = "hive-terminal"
+
 	// storageTypeDynamic selects dynamic PVC provisioning (no NFS PV).
 	storageTypeDynamic = "dynamic"
 
@@ -632,6 +639,17 @@ func (s *HubServer) makeVanityHostServable(hiveID, vanityHost string, cluster *C
 // repairVanityURLsForClaimedHives applies the retroactive vanity-URL repair to
 // every hive, returning the number changed. Safe to run repeatedly: each hive is
 // gated by repairVanityURLForHive, which no-ops once a vanity URL exists.
+//
+// DELIBERATELY NOT CALLED IN PRODUCTION, for the same reason as its sibling
+// repairGitHubHostsFromClusters: the repair runs LAZILY, per hive, from the
+// heartbeat path, and a startup sweep would walk the hive directory
+// concurrently with the first heartbeats already writing to it for no benefit —
+// a hive that never beats needs no repair, and one that does gets repaired on
+// its very next beat. It is retained as the fleet-level entry point (and is
+// covered by a test asserting sweep-level idempotency) so an operator-triggered
+// backfill has one correct implementation to call rather than an ad-hoc loop.
+// This is NOT dead code left behind by accident; do not read its absence from
+// the heartbeat path as missing coverage.
 func (s *HubServer) repairVanityURLsForClaimedHives() int {
 	repaired := 0
 	for _, h := range listSaaSHives() {
@@ -1842,7 +1860,15 @@ func (s *HubServer) addVanityHostToIngress(hiveID, vanityHost string, cluster *C
 	placeholderHost := hiveID + "." + cluster.Domain
 
 	if cluster.IngressType == ingressTypeOpenShiftRoute {
-		for _, base := range []string{"hive-dashboard", "hive-terminal"} {
+		// Mirror the nginx branch's accounting: count what was actually applied,
+		// so "every source Route was unreachable" reports failure instead of
+		// success. Without this the loop `continue`s past every missing/
+		// unreachable Route and still returns nil, telling the caller the host is
+		// servable when no Route was created — the retroactive repair then adopts
+		// an unservable vanity host and replaces a working placeholder link with
+		// a 503.
+		applied := 0
+		for _, base := range []string{routeBaseDashboard, routeBaseTerminal} {
 			out, err := kubectlForCluster(cluster, "-n", ns, "get", "route", base,
 				"-o", "jsonpath={.spec.port.targetPort}|{.spec.path}").Output()
 			if err != nil {
@@ -1870,6 +1896,11 @@ spec:
 			if err := cmd.Run(); err != nil {
 				return fmt.Errorf("applying %s-vanity route: %w", base, err)
 			}
+			applied++
+		}
+		if applied == 0 {
+			return fmt.Errorf("no route found in %s to mirror %s onto (cluster unreachable or spoke has no %s/%s route)",
+				ns, vanityHost, routeBaseDashboard, routeBaseTerminal)
 		}
 		return nil
 	}

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -540,6 +540,111 @@ func (s *HubServer) repairGitHubHostForHive(hiveID string) bool {
 // Until a human does that, the hive authenticates as nothing on its GHE host.
 const gitHubAppStillRequiredNote = "github_host repaired; a hive still carrying the public app_id also needs the GitHub Enterprise App installed on its org before its installation can be auto-discovered"
 
+// repairVanityURLForHive retroactively mints the friendly vanity host for a hive
+// that was CLAIMED BEFORE the vanity feature existed, reporting whether it
+// changed anything.
+//
+// h.VanityURL is written in exactly ONE place — handleAssignHive, at claim time.
+// Every read path (claimedVanityURL, and through it My Hives, the SSO /open
+// handoff, and migrateHive) treats an empty VanityURL as "no validated host, keep
+// the placeholder". So a hive claimed before that code shipped keeps
+// VanityURL == "" forever and displays/opens its raw placeholder host no matter
+// how many times it heartbeats — nothing else ever fills it in. That is the
+// 14-claimed-hives-still-on-placeholder-IDs report: those records have a real org
+// but a placeholder id, and a placeholder id is NOT evidence the fix is missing,
+// only that the vanity URL was never minted for them.
+//
+// This deliberately does NOT touch the hive's id. The id is a k8s namespace
+// suffix (hive-hosted-<id>), an ingress hostname, a per-agent socket path and the
+// SSO token's "h" claim; renaming it is a different and far larger migration. The
+// goal is only that the DISPLAYED name and the OPENED URL are the vanity ones.
+//
+// It is conservative and idempotent, mirroring repairGitHubHostForHive:
+//   - Unclaimed placeholders are skipped: assign owns those and mints the vanity
+//     URL itself at claim time.
+//   - A hive that already has a VanityURL is never touched, so re-running is a
+//     no-op and a hive keeps one stable vanity host (the id's random suffix is
+//     regenerated per call, so re-minting would churn the host every beat).
+//   - A hive with no resolvable cluster domain, or an incomplete claim (no org or
+//     no primary repo), is skipped — there is nothing to derive a host from.
+//   - The host is adopted ONLY once it is actually servable. Unlike the claim
+//     path, which adopts optimistically because provisioning is creating the
+//     spoke's routes anyway, a retroactive repair has no such guarantee: the
+//     vanity host is a NEW name that resolves to no backend until an
+//     ingress/route exists for it. Adopting it before then would replace an
+//     ugly-but-working placeholder link with a 503, so addVanityHostToIngress
+//     must succeed first. On a heartbeat-only cluster the hub cannot kubectl to
+//     the spoke, so that call fails and the hive correctly keeps its working
+//     placeholder host.
+//
+// Called on each heartbeat, so it must be cheap and silent in the overwhelmingly
+// common no-op case — every guard below returns before any network call or write.
+func (s *HubServer) repairVanityURLForHive(hiveID string) bool {
+	h := loadSaaSHive(hiveID)
+	if h == nil {
+		return false
+	}
+	if h.Status == statusAvailable {
+		return false // unclaimed placeholder — assign mints it at claim time
+	}
+	if h.VanityURL != "" {
+		return false // already has one — never re-mint (idempotency + stable host)
+	}
+	// An incomplete claim has nothing to derive a friendly host from.
+	if h.Org == "" || h.PrimaryRepo == "" {
+		return false
+	}
+	cluster := s.clusterForHive(h)
+	if cluster == nil || cluster.Domain == "" {
+		return false
+	}
+	vanityHost := generateHiveID(h.Org, h.PrimaryRepo) + "." + cluster.Domain
+	// Make it servable BEFORE adopting it; on failure leave VanityURL empty so
+	// every read path keeps falling back to the working placeholder host.
+	if err := s.makeVanityHostServable(hiveID, vanityHost, cluster); err != nil {
+		s.logger.Info("vanity url repair: host is not servable yet, keeping the placeholder host",
+			"hive", hiveID, "host", vanityHost, "cluster", cluster.ID, "error", err)
+		return false
+	}
+	h.VanityURL = "https://" + vanityHost
+	if err := saveSaaSHive(h); err != nil {
+		s.logger.Error("vanity url repair: failed to save hive", "hive", hiveID, "error", err)
+		return false
+	}
+	s.logger.Info("vanity url repair: minted a vanity host for a hive claimed before the vanity feature",
+		"hive", hiveID, "org", h.Org, "primary_repo", h.PrimaryRepo,
+		"cluster", cluster.ID, "vanity_url", h.VanityURL)
+	return true
+}
+
+// makeVanityHostServable creates the ingress/route that makes vanityHost resolve,
+// returning an error when it could not be made servable. It is the one seam the
+// retroactive repair goes through: production uses addVanityHostToIngress, while
+// tests substitute it to exercise the adopt path without a live cluster (kubectl
+// is unavailable under test, so the real call always fails there).
+func (s *HubServer) makeVanityHostServable(hiveID, vanityHost string, cluster *ClusterConfig) error {
+	if s.vanityHostServable != nil {
+		return s.vanityHostServable(hiveID, vanityHost, cluster)
+	}
+	return s.addVanityHostToIngress(hiveID, vanityHost, cluster)
+}
+
+// repairVanityURLsForClaimedHives applies the retroactive vanity-URL repair to
+// every hive, returning the number changed. Safe to run repeatedly: each hive is
+// gated by repairVanityURLForHive, which no-ops once a vanity URL exists.
+func (s *HubServer) repairVanityURLsForClaimedHives() int {
+	repaired := 0
+	for _, h := range listSaaSHives() {
+		if s.repairVanityURLForHive(h.ID) {
+			repaired++
+		}
+	}
+	if repaired > 0 {
+		s.logger.Info("vanity url repair: complete", "hives_repaired", repaired)
+	}
+	return repaired
+}
+
 func generateHiveID(org, repo string) string {
 	short := repo
 	if len(short) > 12 {

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -112,6 +112,19 @@ const (
 	defaultAssignACMMLevel = 2
 )
 
+// ACMM level bounds for a SELF-SERVICE provision request (the get-started
+// wizard). Narrower than the assign bounds above on purpose: nobody starts a
+// hive above L3 Measured. L4 Adaptive and higher are reached after
+// provisioning, from the hive's own dashboard, once the project's test
+// coverage and CI history have earned the extra automation. The wizard renders
+// levels up to maxRequestACMMLevel as radios and lists the rest as "available
+// after provisioning"; this pair is the enforcement behind that copy, since the
+// wizard is only one possible client of the endpoint.
+const (
+	minRequestACMMLevel = 1
+	maxRequestACMMLevel = 3
+)
+
 // clustersConfigPath is the on-disk location where the hub reads cluster
 // definitions. It is a JSON array of ClusterConfig objects. A var (not a const)
 // so tests can point it at a temp file; production never reassigns it.

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1327,6 +1327,17 @@ subjects:
   name: hive-sa
   namespace: {{.Namespace}}
 ---
+{{- end}}
+# hive-self-upgrade must NOT be gated on RequiresSCC. The spoke patches its own
+# Deployment (UpgradeSelfToSHA / SwitchImageSelf in pkg/hub/self_upgrade.go) on
+# EVERY cluster, not just OpenShift ones. While this Role was inside the
+# RequiresSCC conditional block, non-OpenShift spokes ran as the "default"
+# ServiceAccount with no patch permission, so every hub-instructed upgrade hit
+# HTTP 403, fell through to os.Exit(0), and the pod restarted onto the SAME
+# image — a crash-loop that re-ran on each heartbeat and never advanced. It also
+# froze the init containers on whatever tag they were provisioned with, since
+# the only code path that rewrites init-container images is the very patch that
+# was being denied.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -1349,10 +1360,13 @@ roleRef:
   name: hive-self-upgrade
 subjects:
 - kind: ServiceAccount
+{{- if .RequiresSCC}}
   name: hive-sa
+{{- else}}
+  name: default
+{{- end}}
   namespace: {{.Namespace}}
 ---
-{{- end}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/v2/pkg/hub/self_upgrade.go
+++ b/v2/pkg/hub/self_upgrade.go
@@ -67,6 +67,18 @@ func RolloutRestartSelf(logger *slog.Logger) error {
 // deployment/hive). A strategic-merge patch merges containers by name, so we
 // enumerate the deployment's containers first and set each image.
 func SwitchImageSelf(logger *slog.Logger, image string) error {
+	// Same contract as the hub self-upgrade: never write a tag that cannot
+	// resolve. A spoke that patches itself to a bogus tag goes
+	// ImagePullBackOff while its old ReplicaSet keeps serving — it looks alive,
+	// silently runs stale code, and keeps reporting the OLD git hash, so the
+	// hub re-sends the same doomed target every heartbeat forever.
+	if err := validateImageRef(image); err != nil {
+		logger.Error("self image switch REFUSED: invalid image reference",
+			"image", image,
+			"deployment", selfUpgradeDeployName,
+			"error", err)
+		return err
+	}
 	ns, err := os.ReadFile(k8sNamespacePath)
 	if err != nil {
 		return fmt.Errorf("reading namespace: %w", err)

--- a/v2/pkg/hub/self_upgrade_coverage_test.go
+++ b/v2/pkg/hub/self_upgrade_coverage_test.go
@@ -174,7 +174,7 @@ func TestSwitchImageSelfSuccess(t *testing.T) {
 	defer srv.Close()
 	withFakeK8sAPI(t, srv)
 
-	if err := SwitchImageSelf(slog.Default(), "ghcr.io/kubestellar/hive:dev-abc"); err != nil {
+	if err := SwitchImageSelf(slog.Default(), "ghcr.io/kubestellar/hive:dev-latest"); err != nil {
 		t.Fatalf("SwitchImageSelf: %v", err)
 	}
 }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -402,8 +402,14 @@ type HubServer struct {
 	httpServer            *http.Server
 	httpMu                sync.Mutex // guards httpServer (Start runs in a goroutine; Shutdown races it)
 	clusters              map[string]ClusterConfig
-	heartbeatHealth       map[string]*HeartbeatHealthEntry // cluster ID → latest health from spoke heartbeat
-	heartbeatHealthMu     sync.RWMutex
+
+	// vanityHostServable overrides how the retroactive vanity-URL repair makes a
+	// vanity host servable (see makeVanityHostServable). nil in production, where
+	// the real addVanityHostToIngress runs; set by tests, which have no cluster to
+	// kubectl to.
+	vanityHostServable func(hiveID, vanityHost string, cluster *ClusterConfig) error
+	heartbeatHealth    map[string]*HeartbeatHealthEntry // cluster ID → latest health from spoke heartbeat
+	heartbeatHealthMu  sync.RWMutex
 
 	// usageHistory is the sampled fleet-total token trend, appended on
 	// heartbeat at usageSnapshotInterval and bounded to
@@ -1100,6 +1106,15 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	// very beat. No-op (and silent) for every hive that already has a host, is
 	// an unclaimed placeholder, or sits on a non-GHE cluster.
 	s.repairGitHubHostForHive(payload.HiveID)
+
+	// Retroactively mint the vanity host for a hive CLAIMED BEFORE the vanity
+	// feature existed, also BEFORE building the project config, so the URL-only
+	// push below delivers it on this very beat. VanityURL is otherwise written
+	// only at assign time, so those hives would display and open their raw
+	// placeholder host forever. No-op (and silent) for unclaimed placeholders,
+	// hives that already have a vanity URL, and hives whose vanity host the hub
+	// cannot make servable (heartbeat-only clusters keep their placeholder).
+	s.repairVanityURLForHive(payload.HiveID)
 
 	if projCfg := projectConfigForHiveID(payload.HiveID, payload.Org, payload.Repos, payload.PrimaryRepo, payload.ACMMLevel, payload.DashboardURL, payload.GitHubAPIURL); projCfg != nil {
 		resp.ProjectConfig = projCfg

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -126,20 +126,26 @@ type RegistryEntry struct {
 	//      spokes too old to report it;
 	//   3. "github.com" at render time, so a chip is never blank.
 	// Empty here means "not reported" — resolved on read, never guessed.
-	GitHubHost                string             `json:"githubHost,omitempty"`
-	Agents                    []AgentSummary     `json:"agents,omitempty"`
-	Leaderboard               []LeaderboardEntry `json:"leaderboard,omitempty"`
-	Online                    bool               `json:"online"`
-	Upgrading                 bool               `json:"upgrading,omitempty"`
-	UpgradeTarget             string             `json:"upgradeTarget,omitempty"`
-	UpgradeStartedAt          time.Time          `json:"upgradeStartedAt,omitempty"`
-	IssueHistory              []SparkPoint       `json:"issueHistory,omitempty"`
-	PRHistory                 []SparkPoint       `json:"prHistory,omitempty"`
-	GitHubAppRequired         bool               `json:"githubAppRequired,omitempty"`
-	GitHubAppPermIssue        string             `json:"githubAppPermIssue,omitempty"`
-	GitHubAppState            string             `json:"githubAppState,omitempty"`
-	PendingGitHubAppInstall   bool               `json:"pendingGitHubAppInstall,omitempty"`
-	PendingGitHubAppInstallAt time.Time          `json:"pendingGitHubAppInstallAt,omitempty"`
+	GitHubHost       string             `json:"githubHost,omitempty"`
+	Agents           []AgentSummary     `json:"agents,omitempty"`
+	Leaderboard      []LeaderboardEntry `json:"leaderboard,omitempty"`
+	Online           bool               `json:"online"`
+	Upgrading        bool               `json:"upgrading,omitempty"`
+	UpgradeTarget    string             `json:"upgradeTarget,omitempty"`
+	UpgradeStartedAt time.Time          `json:"upgradeStartedAt,omitempty"`
+	// UpgradeFailed records that the spoke reported an upgrade it could not
+	// complete, with the cause. Distinct from Upgrading: "failed" is a terminal
+	// state a human must see, not an in-flight one.
+	UpgradeFailed             bool         `json:"upgradeFailed,omitempty"`
+	UpgradeError              string       `json:"upgradeError,omitempty"`
+	UpgradeFailedAt           time.Time    `json:"upgradeFailedAt,omitempty"`
+	IssueHistory              []SparkPoint `json:"issueHistory,omitempty"`
+	PRHistory                 []SparkPoint `json:"prHistory,omitempty"`
+	GitHubAppRequired         bool         `json:"githubAppRequired,omitempty"`
+	GitHubAppPermIssue        string       `json:"githubAppPermIssue,omitempty"`
+	GitHubAppState            string       `json:"githubAppState,omitempty"`
+	PendingGitHubAppInstall   bool         `json:"pendingGitHubAppInstall,omitempty"`
+	PendingGitHubAppInstallAt time.Time    `json:"pendingGitHubAppInstallAt,omitempty"`
 	// Fleet contribution counts reported by the spoke (nil = not reported /
 	// not yet computed). Aggregated across public, non-stale hives into the
 	// /api/fleet-stats total. Pointers preserve the nil-vs-zero distinction so
@@ -979,6 +985,27 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		entry.Upgrading = true
 	}
 
+	// A spoke that explicitly reports a FAILED upgrade must not be left showing
+	// the "Upgrading" spinner, and must not be re-instructed on a loop. Record
+	// the cause so operators can see WHY, and drop the pending instruction: the
+	// spoke has already exhausted its own retry budget, so re-sending the same
+	// target every heartbeat only reproduces the failure.
+	if payload.UpgradeFailed {
+		entry.Upgrading = false
+		entry.UpgradeFailed = true
+		entry.UpgradeError = sanitizeHeartbeatField(payload.UpgradeError)
+		entry.UpgradeFailedAt = time.Now()
+		s.mu.Lock()
+		delete(s.heartbeatUpgrade, payload.HiveID)
+		s.mu.Unlock()
+		s.logger.Error("heartbeat: spoke reported a FAILED upgrade",
+			"hive_id", payload.HiveID,
+			"from", payload.GitHash,
+			"to", payload.UpgradeTargetSHA,
+			"error", payload.UpgradeError,
+		)
+	}
+
 	// Timeline: capture the pre-heartbeat entry inside the lock (it is the only
 	// place old and new coexist), but diff and persist AFTER unlocking —
 	// s.mu is a write lock held across the whole registry scan, so a file
@@ -1008,6 +1035,22 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				branchForLatest = "v2"
 			}
 			registryLatestSHA := getLatestSHAForBranch(branchForLatest)
+			// Carry a previously-reported upgrade failure forward across ordinary
+			// heartbeats (which do not repeat it), but clear it the moment the
+			// spoke actually reports a NEW git hash — that means it finally moved.
+			if h.UpgradeFailed && !payload.UpgradeFailed {
+				if entry.GitHash != "" && h.GitHash != "" && entry.GitHash != h.GitHash {
+					entry.UpgradeFailed = false
+					entry.UpgradeError = ""
+					entry.UpgradeFailedAt = time.Time{}
+					s.logger.Info("heartbeat: previously failed upgrade has landed",
+						"hive_id", payload.HiveID, "git_hash", entry.GitHash)
+				} else {
+					entry.UpgradeFailed = true
+					entry.UpgradeError = h.UpgradeError
+					entry.UpgradeFailedAt = h.UpgradeFailedAt
+				}
+			}
 			if h.Upgrading && !payload.Upgrading && (sameCommit(payload.GitHash, h.UpgradeTarget) || (registryLatestSHA != "" && sameCommit(payload.GitHash, registryLatestSHA))) {
 				// Non-upgrading heartbeat at the target SHA or at latest —
 				// upgrade completed (image may have advanced past the
@@ -1019,6 +1062,14 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				entry.UpgradeTarget = ""
 			} else if h.Upgrading && !payload.Upgrading && h.UpgradeTarget == "" {
 				// Upgrading with no target (stale flag from config-only restart).
+				entry.Upgrading = false
+				entry.UpgradeTarget = ""
+			} else if payload.UpgradeFailed {
+				// The spoke just told us the upgrade FAILED. That is direct
+				// evidence and must beat the inference below, which would
+				// otherwise re-assert the stale Upgrading flag (same GitHash as
+				// before is exactly what a failed upgrade looks like) and put the
+				// permanent spinner straight back.
 				entry.Upgrading = false
 				entry.UpgradeTarget = ""
 			} else if h.Upgrading && h.UpgradeTarget != "" {

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -215,6 +215,71 @@ func isValidName(s string) bool {
 	return safeNamePattern.MatchString(s) && len(s) <= 100
 }
 
+// publicGitHubHost is the bare hostname of public GitHub. A hive record stores
+// "" for public GitHub, but a REQUEST must name its forge explicitly, and this
+// is the label a requester types (or the picker submits) to mean "public".
+const publicGitHubHost = "github.com"
+
+// minForgeHostLabels is the fewest dot-separated labels a forge hostname can
+// have. A GitHub forge is always at least "host.tld" (github.com,
+// github.ibm.com); a single bare label like "github" is a typo, not a forge,
+// and accepting it would provision a hive against a host that resolves nowhere.
+const minForgeHostLabels = 2
+
+// normalizeForgeHost turns whatever a user typed into a "GitHub forge" field
+// into a bare hostname, and reports whether the result is a usable forge.
+//
+// It accepts every form the request modal advertises — with or without a
+// scheme, with or without a trailing slash — because those are what people
+// actually paste out of a browser address bar:
+//
+//	github.com            -> ("github.com",     true)
+//	https://github.com    -> ("github.com",     true)
+//	github.ibm.com        -> ("github.ibm.com", true)
+//	https://github.ibm.com/ -> ("github.ibm.com", true)
+//	""                    -> ("",               false)
+//	"not a host"          -> ("not a host",     false)
+//
+// Normalization runs BEFORE validation deliberately. isValidName rejects ":"
+// and "/", so validating the raw input would reject "https://github.ibm.com" —
+// a form the request form explicitly tells users to use. Callers must
+// normalize first and validate the result.
+//
+// githubHostLabel does the scheme/slash stripping and is reused here rather
+// than duplicated, so the hostname a request records and the hostname the
+// dashboard renders can never drift into two spellings.
+func normalizeForgeHost(s string) (string, bool) {
+	host := strings.ToLower(githubHostLabel(strings.TrimSpace(s)))
+	// githubHostLabel maps empty -> "github.com". For a REQUEST that default is
+	// wrong: an omitted forge must fail, not silently become public GitHub.
+	if strings.TrimSpace(s) == "" {
+		return "", false
+	}
+	// A pasted org URL ("github.ibm.com/my-org") carries a path; keep only the
+	// host so the forge field tolerates the same paste the org field does.
+	if i := strings.Index(host, "/"); i >= 0 {
+		host = host[:i]
+	}
+	if !isValidName(host) {
+		return host, false
+	}
+	// Every label must be non-empty and contain something other than dots, so
+	// "..", "../..", and ".github.com" are rejected. isValidName permits dots
+	// (legitimately — hostnames need them), which on its own would let a
+	// path-traversal prefix like "../../etc/passwd" survive truncation at the
+	// first slash and be stored as the forge "..".
+	labels := strings.Split(host, ".")
+	if len(labels) < minForgeHostLabels {
+		return host, false
+	}
+	for _, label := range labels {
+		if label == "" {
+			return host, false
+		}
+	}
+	return host, true
+}
+
 // normalizeOrgRef accepts what a user actually pastes into an "org" field and
 // splits it into a GitHub host and a bare org name.
 //

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -463,10 +463,16 @@ type HubServer struct {
 	// the admin-triggered path. hubUpgradeTarget is the SHA being rolled to.
 	lastHubUpgradeTrigger time.Time
 	hubUpgradeTarget      string
-	hubUpgradeMu          sync.Mutex // guards lastHubUpgradeTrigger + hubUpgradeTarget
-	httpServer            *http.Server
-	httpMu                sync.Mutex // guards httpServer (Start runs in a goroutine; Shutdown races it)
-	clusters              map[string]ClusterConfig
+	// hubUpgradeFault holds a human-readable reason the last self-upgrade did
+	// not land: a refused (malformed) image tag, or a rollout that never became
+	// Ready. Empty means healthy. It exists so a stuck upgrade is visible in the
+	// dashboard instead of only in `kubectl describe` — the `target1` incident
+	// left the hub serving stale code for ~20 minutes with nothing surfaced.
+	hubUpgradeFault string
+	hubUpgradeMu    sync.Mutex // guards lastHubUpgradeTrigger + hubUpgradeTarget + hubUpgradeFault
+	httpServer      *http.Server
+	httpMu          sync.Mutex // guards httpServer (Start runs in a goroutine; Shutdown races it)
+	clusters        map[string]ClusterConfig
 
 	// vanityHostServable overrides how the retroactive vanity-URL repair makes a
 	// vanity host servable (see makeVanityHostServable). nil in production, where

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1481,19 +1481,55 @@ func (s *HubServer) handleFleetStats(w http.ResponseWriter, r *http.Request) {
 	w.Write(data)
 }
 
-// removeRegistryEntry removes a hive from the in-memory registry by ID.
+// removeRegistryEntry removes a hive from the in-memory registry by ID and
+// flushes the registry to disk before returning.
+//
+// The flush is synchronous rather than going through requestSave because
+// requestSave defers the write by registrySaveDelay. A hub restart inside that
+// window would reload the pre-delete registry from disk and the deleted hive
+// would reappear in "My Hives" — the in-memory removal alone is not durable.
+// Deletion is rare and user-initiated, so paying the write cost inline is fine.
 func (s *HubServer) removeRegistryEntry(id, by string) {
 	s.mu.Lock()
+	removed := false
 	for i, h := range s.registry.Hives {
 		if h.ID == id {
 			s.registry.Hives = append(s.registry.Hives[:i], s.registry.Hives[i+1:]...)
-			s.mu.Unlock()
-			s.requestSave()
-			s.logger.Info("audit: registry entry removed", "id", id, "by", by)
-			return
+			removed = true
+			break
 		}
 	}
 	s.mu.Unlock()
+	if !removed {
+		return
+	}
+	if err := s.saveRegistryNow(); err != nil {
+		// The in-memory removal already happened, so the listing is correct for
+		// this process. Log loudly: only a restart before the next periodic save
+		// would resurrect the entry.
+		s.logger.Error("registry entry removed in memory but persist failed", "id", id, "error", err)
+		s.requestSave()
+	}
+	s.logger.Info("audit: registry entry removed", "id", id, "by", by)
+}
+
+// saveRegistryNow marshals and writes the registry to disk immediately, via a
+// temp file plus atomic rename so a crash mid-write cannot truncate it.
+func (s *HubServer) saveRegistryNow() error {
+	s.mu.RLock()
+	data, err := json.MarshalIndent(s.registry, "", "  ")
+	s.mu.RUnlock()
+	if err != nil {
+		return fmt.Errorf("marshal hub registry: %w", err)
+	}
+	tmpPath := registryPath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("write hub registry: %w", err)
+	}
+	if err := os.Rename(tmpPath, registryPath); err != nil {
+		return fmt.Errorf("rename hub registry: %w", err)
+	}
+	return nil
 }
 
 func (s *HubServer) handleRegistryDelete(w http.ResponseWriter, r *http.Request) {
@@ -1513,7 +1549,11 @@ func (s *HubServer) handleRegistryDelete(w http.ResponseWriter, r *http.Request)
 	}
 	s.mu.Unlock()
 	if removed {
-		s.requestSave()
+		// Synchronous flush for the same durability reason as removeRegistryEntry.
+		if err := s.saveRegistryNow(); err != nil {
+			s.logger.Error("admin registry removal persist failed", "id", id, "error", err)
+			s.requestSave()
+		}
 		s.logger.Info("audit: admin removed registry entry", "id", id, "admin", hubAdminUsername)
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/v2/pkg/hub/static/get-started.html
+++ b/v2/pkg/hub/static/get-started.html
@@ -296,7 +296,7 @@
       <div class="wizard-steps" id="wizard-steps">
         <div class="wizard-step active" data-step="1"><span class="step-dot">1</span> Login</div>
         <span class="step-arrow">→</span>
-        <div class="wizard-step" data-step="2"><span class="step-dot">2</span> Add Repos</div>
+        <div class="wizard-step" data-step="2"><span class="step-dot">2</span> Your Repo</div>
         <span class="step-arrow">→</span>
         <div class="wizard-step" data-step="3"><span class="step-dot">3</span> Request</div>
       </div>
@@ -333,18 +333,21 @@
            to another forge. A URL needs no permission on the requester's
            account and describes any forge. -->
       <div class="wizard-panel" id="panel-2">
-        <h2>Add your repositories</h2>
-        <p>Paste the URL of each repository the hive should manage. You can add more later from your dashboard.</p>
+        <h2>Your repository</h2>
+        <p>Paste the URL of the repository the hive should manage. You can add more later from your dashboard.</p>
         <div>
           <label for="repo-manual" style="display:block;font-size:0.86rem;color:var(--muted);margin-bottom:6px">
             Repository URL
           </label>
-          <div style="display:flex;gap:8px">
-            <input type="text" id="repo-manual" placeholder="github.com/my-org/my-repo"
-              onkeydown="if(event.key==='Enter'){event.preventDefault();addManualRepo()}"
-              style="flex:1;padding:9px 12px;background:var(--bg-soft);border:1px solid var(--line);border-radius:6px;color:var(--text);font-size:0.88rem">
-            <button class="btn-secondary" type="button" onclick="addManualRepo()">Add</button>
-          </div>
+          <!-- No "Add" button: onboarding expects ONE repo, so Continue commits
+               the typed URL and advances (commitManualRepo). The input is not
+               inside a <form>, so Enter has no default submit to suppress — the
+               preventDefault is kept anyway so a future wrapping form cannot
+               turn Enter into a page reload. -->
+          <input type="text" id="repo-manual" placeholder="github.com/my-org/my-repo"
+            onkeydown="if(event.key==='Enter'){event.preventDefault();continueFromRepos()}"
+            onblur="validateRepoInput()" oninput="clearRepoError()"
+            style="width:100%;padding:9px 12px;background:var(--bg-soft);border:1px solid var(--line);border-radius:6px;color:var(--text);font-size:0.88rem">
           <div id="repo-manual-err" style="display:none;margin-top:6px;font-size:0.8rem;color:var(--red)"></div>
           <p style="font-size:0.8rem;margin-top:8px;margin-bottom:0">
             With or without <code>https://</code>. Works for public GitHub and for GitHub Enterprise
@@ -355,7 +358,10 @@
         </div>
         <div style="display:flex;gap:12px;margin-top:16px">
           <button class="btn-secondary" onclick="goToStep(1)">← Back</button>
-          <button class="btn-primary" id="repos-continue" onclick="goToStep(3)" disabled>Continue →</button>
+          <!-- Enabled unconditionally: validation now happens ON click, so a
+               disabled button would give the user no way to learn WHY it is
+               disabled. continueFromRepos() refuses to advance on bad input. -->
+          <button class="btn-primary" id="repos-continue" onclick="continueFromRepos()">Continue →</button>
         </div>
       </div>
 
@@ -370,7 +376,7 @@
         <div class="acmm-options" id="acmm-options"></div>
         <div id="request-summary" style="margin:20px 0;padding:16px;background:#080b0f85;border:1px solid var(--line);border-radius:.7rem;font-size:0.85rem">
           <div style="margin-bottom:8px"><strong>Summary</strong></div>
-          <div style="color:var(--muted)">Repos: <span id="summary-repos" style="color:var(--text)">none selected</span></div>
+          <div style="color:var(--muted)">Repo: <span id="summary-repos" style="color:var(--text)">none added</span></div>
           <div style="color:var(--muted)">ACMM Level: <span id="summary-acmm" style="color:var(--text)"></span></div>
         </div>
         <!-- The wizard no longer asks anyone to install the GitHub App. This
@@ -606,62 +612,72 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
       ' — github.com or a GitHub Enterprise host such as github.ibm.com.' +
       ' Support for GitLab, Gitea, and other forges is planned.';
 
-    // Add a repository the user typed. This is the ONLY way repos enter the
-    // request — see the panel comment for why the picker is gone.
-    function addManualRepo() {
-      var input = document.getElementById('repo-manual');
-      var err = document.getElementById('repo-manual-err');
-      var raw = (input.value || '').trim();
-      err.style.display = 'none';
-      if (!raw) return;
+    /* Shown when Continue is pressed with an empty field. This is NOT cosmetic:
+       handleRequestProvision (pkg/hub/saas.go) rejects a request whose org or
+       repos is empty, so advancing with no repo would walk the user to the final
+       step and fail there. Refusing here reports it where it can be fixed. */
+    var REPO_REQUIRED_MSG = 'Enter the repository your hive should manage — for example github.com/my-org/my-repo';
+    /* Shown when the field holds something that is not a repository reference. */
+    var REPO_UNPARSEABLE_MSG = 'Enter a repository URL — for example github.com/my-org/my-repo or https://github.ibm.com/my-org/my-repo';
 
+    function clearRepoError() {
+      var err = document.getElementById('repo-manual-err');
+      if (err) err.style.display = 'none';
+    }
+
+    function showRepoError(msg) {
+      var err = document.getElementById('repo-manual-err');
+      if (!err) return;
+      err.textContent = msg;
+      err.style.display = 'block';
+    }
+
+    /* Validate the typed repository and return {full_name, name, github_host},
+       or null if it cannot be used. Every check the old Add button ran is kept
+       here and in the same order: parseable, then forge policy.
+
+       `requireValue` separates the two callers. On blur we must NOT nag about an
+       empty field the user simply tabbed through, but on Continue an empty field
+       IS the error. Neither caller validates per keystroke — oninput only CLEARS
+       a stale error, so a half-typed URL never flashes red. */
+    function validateManualRepo(requireValue) {
+      var input = document.getElementById('repo-manual');
+      var raw = ((input && input.value) || '').trim();
+      clearRepoError();
+      if (!raw) {
+        if (requireValue) showRepoError(REPO_REQUIRED_MSG);
+        return null;
+      }
       var ref = parseRepoRef(raw);
       if (!ref) {
-        err.textContent = 'Enter a repository URL — for example github.com/my-org/my-repo or https://github.ibm.com/my-org/my-repo';
-        err.style.display = 'block';
-        return;
+        showRepoError(REPO_UNPARSEABLE_MSG);
+        return null;
       }
       if (!isSupportedForgeHost(ref.host)) {
-        err.textContent = ref.host + UNSUPPORTED_FORGE_MSG;
-        err.style.display = 'block';
-        return;
+        showRepoError(ref.host + UNSUPPORTED_FORGE_MSG);
+        return null;
       }
-      var fullName = ref.org + '/' + ref.name;
-      if ((_selectedRepos || []).some(function(r) { return r.full_name === fullName; })) {
-        err.textContent = fullName + ' is already added';
-        err.style.display = 'block';
-        return;
-      }
-      _selectedRepos.push({full_name: fullName, name: ref.name, github_host: ref.host});
-      input.value = '';
-      renderManualRepos();
-      document.getElementById('repos-continue').disabled = _selectedRepos.length === 0;
+      return {full_name: ref.org + '/' + ref.name, name: ref.name, github_host: ref.host};
     }
 
-    // Show the repositories added so far as removable chips.
-    function renderManualRepos() {
-      var host = document.getElementById('repo-manual-added');
-      if (!host) {
-        host = document.createElement('div');
-        host.id = 'repo-manual-added';
-        host.style.cssText = 'margin-top:10px;display:flex;flex-wrap:wrap;gap:6px';
-        document.getElementById('repo-manual').parentNode.parentNode.appendChild(host);
-      }
-      host.innerHTML = (_selectedRepos || []).map(function(r) {
-        // Show the Enterprise host when there is one, so the user can see which
-        // instance we recorded before they submit.
-        var shown = (r.github_host ? r.github_host + '/' : '') + r.full_name;
-        return '<span style="display:inline-flex;align-items:center;gap:6px;padding:3px 10px;border:1px solid var(--line);border-radius:999px;font-size:0.8rem">' +
-          esc(shown) +
-          '<a href="#" onclick="removeManualRepo(\'' + esc(r.full_name) + '\');return false" style="color:var(--muted);text-decoration:none" title="Remove">&times;</a></span>';
-      }).join('');
-    }
+    /* Surface a bad URL as soon as the user leaves the field, rather than making
+       them press Continue to find out. Empty is not an error here. */
+    function validateRepoInput() { validateManualRepo(false); }
 
-    function removeManualRepo(fullName) {
-      var i = _selectedRepos.findIndex(function(r) { return r.full_name === fullName; });
-      if (i >= 0) _selectedRepos.splice(i, 1);
-      renderManualRepos();
-      document.getElementById('repos-continue').disabled = _selectedRepos.length === 0;
+    /* Continue does what the old "Add" button did, then advances. Onboarding
+       expects a single repo, so the typed value REPLACES _selectedRepos rather
+       than appending — that also makes the old "already added" dedupe branch
+       unreachable, so it is gone rather than left as dead list-building code.
+
+       _selectedRepos stays an ARRAY of one: submitRequest() reads
+       _selectedRepos[0], .map(), and .find() on it, and the server wants a
+       comma-separated repos string, so keeping the shape means the submit path
+       is untouched and can still carry more repos if a later screen adds them. */
+    function continueFromRepos() {
+      var repo = validateManualRepo(true);
+      if (!repo) return;
+      _selectedRepos = [repo];
+      goToStep(WIZARD_STEP_LEVEL);
     }
 
     async function submitRequest() {

--- a/v2/pkg/hub/static/get-started.html
+++ b/v2/pkg/hub/static/get-started.html
@@ -216,6 +216,12 @@
     .acmm-option input[type=radio] { accent-color: var(--amber); margin-top: 2px; flex-shrink: 0; }
     .acmm-option .acmm-label { font-weight: 700; font-size: .9rem; color: var(--text); margin-bottom: 2px; }
     .acmm-option .acmm-desc { font-size: .78rem; color: var(--muted); line-height: 1.5; }
+    /* Levels above the onboarding ceiling: a quiet informational note, not a
+       disabled choice. Deliberately not styled like .acmm-option so it never
+       reads as a radio the requester failed to earn. */
+    .acmm-later { margin-top: .35rem; padding: .7rem .85rem; border-left: 2px solid var(--border); }
+    .acmm-later-title { font-size: .74rem; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; color: var(--muted); margin-bottom: 4px; }
+    .acmm-later-body { font-size: .78rem; color: var(--muted); line-height: 1.55; }
     .acmm-rec {
       display: inline-block; padding: 2px 10px; border-radius: 9999px;
       font-size: .65rem; font-weight: 900; letter-spacing: .04em; text-transform: uppercase;
@@ -475,9 +481,9 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
        step — a requester must not be shown one name here and another one on
        the dashboard of the hive they receive. */
     var ACMM_LEVELS = [
-      {level: 1, label: 'L1 Assisted',       desc: 'Advisory only. Agents look and report; they never write to your repo.'},
-      {level: 2, label: 'L2 Instructed',     desc: 'Advisory beads, no GitHub writes. Agents follow your CLAUDE.md and house rules.'},
-      {level: 3, label: 'L3 Measured',       desc: 'Hold-gated PRs, CI gates. Agents raise test coverage to earn later automation; every PR waits for a human.'},
+      {level: 1, label: 'L1 Assisted',       desc: 'Start a new feature with spec-driven tooling. Agents look, plan and report; they never write to your repo.'},
+      {level: 2, label: 'L2 Instructed',     desc: 'Advisory beads, no GitHub writes. Agents follow the house rules you set for the project.'},
+      {level: 3, label: 'L3 Measured',       desc: 'Improve quality through better test coverage. Agents open hold-gated PRs that raise coverage behind CI gates; every PR waits for a human.'},
       {level: 4, label: 'L4 Adaptive',       desc: 'Agents open issues and hold-gated PRs, plus security checks. Still a human on every merge.'},
       {level: 5, label: 'L5 Semi-Automated', desc: 'PRs carry a hold label for batch review, so you approve in groups rather than one at a time.'},
       {level: 6, label: 'L6 Autonomous',     desc: 'Auto-merge on green CI. Only for repos with CI you already trust.'}
@@ -486,17 +492,33 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
        produces useful work (test-coverage PRs) while still gating every merge
        on a human. */
     var DEFAULT_ACMM_LEVEL = 3;
+    /* Highest level a hive can be REQUESTED at. Levels above this are real and
+       reachable, but only after provisioning, from the hive's own dashboard —
+       nobody starts a hive at L4+. The wizard therefore offers 1..3 as radios
+       and lists the rest as "available later". The hub enforces the same
+       ceiling on POST /api/saas/request-provision; this constant is the copy
+       of that rule the UI renders from, not the rule itself. */
+    var ONBOARDING_MAX_ACMM_LEVEL = 3;
     var _selectedAcmm = DEFAULT_ACMM_LEVEL;
 
     function acmmEntry(level) {
       return (ACMM_LEVELS || []).filter(function(a) { return a.level === level; })[0] || null;
     }
 
-    /* renderAcmmOptions builds the level radios from ACMM_LEVELS. */
+    /* renderAcmmOptions builds the level radios from ACMM_LEVELS.
+
+       Only levels up to ONBOARDING_MAX_ACMM_LEVEL are selectable. The higher
+       levels are rendered as a short "what comes next" note rather than as
+       disabled radios: a greyed-out radio reads as a choice being refused,
+       which is the wrong message. They are not forbidden, they are simply
+       earned later — a hive advances to them from its own dashboard once it
+       has the coverage and CI history to justify them. */
     function renderAcmmOptions() {
       var host = document.getElementById('acmm-options');
       if (!host) return;
-      host.innerHTML = (ACMM_LEVELS || []).map(function(a) {
+      var startable = (ACMM_LEVELS || []).filter(function(a) { return a.level <= ONBOARDING_MAX_ACMM_LEVEL; });
+      var later = (ACMM_LEVELS || []).filter(function(a) { return a.level > ONBOARDING_MAX_ACMM_LEVEL; });
+      var html = (startable || []).map(function(a) {
         var sel = a.level === _selectedAcmm;
         return '<label class="acmm-option' + (sel ? ' selected' : '') + '" onclick="selectAcmm(this, ' + a.level + ')">' +
           '<input type="radio" name="acmm" value="' + a.level + '"' + (sel ? ' checked' : '') + '>' +
@@ -505,6 +527,14 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
           '</div>' +
           '<div class="acmm-desc">' + esc(a.desc) + '</div></div></label>';
       }).join('');
+      if ((later || []).length) {
+        html += '<div class="acmm-later">' +
+          '<div class="acmm-later-title">Available after provisioning</div>' +
+          '<div class="acmm-later-body">Once your hive is running you can advance it from its own dashboard, as its test coverage and CI history earn more automation: ' +
+          (later || []).map(function(a) { return esc(a.label); }).join(', ') + '.</div>' +
+          '</div>';
+      }
+      host.innerHTML = html;
     }
 
     function goToStep(n) {
@@ -522,6 +552,10 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
     }
 
     function selectAcmm(el, level) {
+      /* Clamp rather than trust the caller: renderAcmmOptions only emits
+         startable levels, but this is the one place _selectedAcmm is written
+         and it is what the submit body carries. */
+      if (level > ONBOARDING_MAX_ACMM_LEVEL) { level = ONBOARDING_MAX_ACMM_LEVEL; }
       _selectedAcmm = level;
       document.querySelectorAll('.acmm-option').forEach(function(o) { o.classList.remove('selected'); });
       el.classList.add('selected');

--- a/v2/pkg/hub/static/get-started.html
+++ b/v2/pkg/hub/static/get-started.html
@@ -6,10 +6,10 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🍯</text></svg>">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta property="og:title" content="Get started — put your repo on autopilot">
-  <meta property="og:description" content="Request a hosted hive in four steps, self-host with Docker Compose, or contribute compute to a public hive. No Kubernetes, no setup.">
+  <meta property="og:description" content="Request a hosted hive in three steps, self-host with Docker Compose, or contribute compute to a public hive. No Kubernetes, no setup.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://hive.kubestellar.io/get-started">
-  <meta name="description" content="Get started with Hive — request a hosted hive in four steps, self-host with Docker Compose, or contribute compute to a public hive.">
+  <meta name="description" content="Get started with Hive — request a hosted hive in three steps, self-host with Docker Compose, or contribute compute to a public hive.">
   <title>Get started — put your repo on autopilot</title>
   <style>
     :root {
@@ -290,23 +290,24 @@
   <section class="section-pad">
     <p class="section-label">Get started</p>
     <h1>Get a hosted hive</h1>
-    <p class="lede">Request a hive for your project in four steps. We provision it on our infrastructure &mdash; no Kubernetes, no setup, no compute needed.</p>
+    <p class="lede">Request a hive for your project in three steps. We provision it on our infrastructure &mdash; no Kubernetes, no setup, no compute needed.</p>
 
     <div class="wizard">
       <div class="wizard-steps" id="wizard-steps">
         <div class="wizard-step active" data-step="1"><span class="step-dot">1</span> Login</div>
         <span class="step-arrow">→</span>
-        <div class="wizard-step" data-step="2"><span class="step-dot">2</span> Install App</div>
+        <div class="wizard-step" data-step="2"><span class="step-dot">2</span> Add Repos</div>
         <span class="step-arrow">→</span>
-        <div class="wizard-step" data-step="3"><span class="step-dot">3</span> Select Repos</div>
-        <span class="step-arrow">→</span>
-        <div class="wizard-step" data-step="4"><span class="step-dot">4</span> Request</div>
+        <div class="wizard-step" data-step="3"><span class="step-dot">3</span> Request</div>
       </div>
 
       <!-- Step 1: Login -->
       <div class="wizard-panel active" id="panel-1">
         <h2>Login with GitHub</h2>
-        <p>We use your GitHub identity to verify org membership and to install the Hive GitHub App on your repositories. No passwords are stored.</p>
+        <!-- Identity only. The login requests an EMPTY OAuth scope (see
+             handleLogin in oauth.go) because nothing in this flow reads your
+             account: you tell us the repository URL yourself. -->
+        <p>We use your GitHub identity to know who is asking &mdash; nothing more. We request <strong>no permissions</strong> on your account, and no passwords are stored.</p>
         <div id="login-area">
           <a href="/login?redirect=/get-started" class="btn-github">
             <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
@@ -325,118 +326,65 @@
         </div>
       </div>
 
-      <!-- Step 2: Install GitHub App -->
+      <!-- Step 2: Add repositories by URL.
+           The typed URL is the ONLY input here, by design. The old picker
+           listed repos from the requester's github.com OAuth token, which
+           could never see a GitHub Enterprise repo and could never generalize
+           to another forge. A URL needs no permission on the requester's
+           account and describes any forge. -->
       <div class="wizard-panel" id="panel-2">
-        <h2>Install the Hive GitHub App</h2>
-        <p>The Hive GitHub App lets our agents read issues, open PRs, and respond to CI on your repos. Install it on the org or repos you want to manage.</p>
-        <!-- This button is correct ONLY for public github.com. This page signs
-             you in with the public github.com OAuth app and no hive exists yet,
-             so we genuinely do not know which GitHub instance your repos live
-             on — we must not fake a per-user link here. GitHub Enterprise users
-             get the explicit note below instead of a link that would send their
-             install request to the wrong GitHub entirely. -->
-        <div style="margin:20px 0">
-          <a href="https://github.com/apps/kubestellar-hive" target="_blank" rel="noopener" class="btn-github" id="install-app-btn">
-            <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-            Install Hive GitHub App
-          </a>
-        </div>
-        <p style="font-size:0.82rem;color:var(--muted)">Already installed? Click continue.</p>
-        <div style="margin-top:18px;padding:12px 14px;background:var(--bg-soft);border:1px solid var(--line);border-radius:.7rem">
-          <p style="margin:0 0 6px;font-size:0.86rem;font-weight:700">Using GitHub Enterprise?</p>
-          <p style="margin:0;font-size:0.82rem;color:var(--muted);line-height:1.55">
-            The button above installs on <strong>public github.com</strong>. If your repos live on a
-            GitHub Enterprise instance (<code>github.example.com</code>, and similar), that link will
-            not work &mdash; the install request lands on public GitHub and your Enterprise org admin
-            will never see it.
-            <br><br>
-            Instead: continue to step&nbsp;3 and add your repository by <strong>URL</strong>. We record
-            which Enterprise instance it lives on, and provision your hive against a GitHub App
-            registered on <em>that</em> instance. Your org admin approves the installation from your own
-            Enterprise host &mdash; your hive's dashboard will show the correct install link once it is
-            provisioned. If no App is registered on your Enterprise instance yet, we will set that up
-            with your admin as part of provisioning.
-          </p>
-        </div>
-        <div style="display:flex;gap:12px;margin-top:16px">
-          <button class="btn-secondary" onclick="goToStep(1)">← Back</button>
-          <button class="btn-primary" onclick="goToStep(3)">Continue →</button>
-        </div>
-      </div>
-
-      <!-- Step 3: Select repos -->
-      <div class="wizard-panel" id="panel-3">
-        <h2>Select repositories</h2>
-        <p>Choose which repos the hive should manage. You can add more later from your dashboard.</p>
-        <div id="repo-loading" style="color:var(--muted);padding:24px;text-align:center">Loading your repositories...</div>
-        <div id="repo-list" class="repo-list" style="display:none"></div>
-        <div id="repo-none" style="display:none;padding:24px;text-align:center;color:var(--muted)">
-          <p>No repositories found. Install the <a href="https://github.com/apps/kubestellar-hive" target="_blank" rel="noopener" style="color:var(--blue)">Hive GitHub App</a> on the account or org that owns them &mdash; or add a repo URL below.</p>
-          <p style="font-size:0.82rem">That link is public github.com. <strong>GitHub Enterprise repos will never appear in this list</strong> and cannot be installed from there &mdash; add the repo by URL below and we will provision against your Enterprise instance.</p>
-        </div>
-        <!-- Manual entry. Repo discovery uses the github.com OAuth token, so a
-             GitHub Enterprise repo (github.ibm.com, github.cisco.com, …) can
-             never appear in the list above. Typing the URL is the only way to
-             request one, and it also covers a repo the App has not been
-             installed on yet. -->
-        <div style="margin-top:18px;padding-top:16px;border-top:1px solid var(--line)">
+        <h2>Add your repositories</h2>
+        <p>Paste the URL of each repository the hive should manage. You can add more later from your dashboard.</p>
+        <div>
           <label for="repo-manual" style="display:block;font-size:0.86rem;color:var(--muted);margin-bottom:6px">
-            Or add a repository by URL &mdash; required for GitHub Enterprise (github.ibm.com and similar), which cannot be listed above
+            Repository URL
           </label>
           <div style="display:flex;gap:8px">
-            <input type="text" id="repo-manual" placeholder="https://github.ibm.com/my-org/my-repo"
+            <input type="text" id="repo-manual" placeholder="github.com/my-org/my-repo"
+              onkeydown="if(event.key==='Enter'){event.preventDefault();addManualRepo()}"
               style="flex:1;padding:9px 12px;background:var(--bg-soft);border:1px solid var(--line);border-radius:6px;color:var(--text);font-size:0.88rem">
             <button class="btn-secondary" type="button" onclick="addManualRepo()">Add</button>
           </div>
           <div id="repo-manual-err" style="display:none;margin-top:6px;font-size:0.8rem;color:var(--red)"></div>
+          <p style="font-size:0.8rem;margin-top:8px;margin-bottom:0">
+            With or without <code>https://</code>. Works for public GitHub and for GitHub Enterprise
+            (<code>github.ibm.com</code> and similar) &mdash; we record which instance the repo lives on
+            and provision against it. Examples: <code>github.com/my-org/my-repo</code>,
+            <code>https://github.ibm.com/my-org/my-repo</code>.
+          </p>
         </div>
         <div style="display:flex;gap:12px;margin-top:16px">
-          <button class="btn-secondary" onclick="goToStep(2)">← Back</button>
-          <button class="btn-primary" id="repos-continue" onclick="goToStep(4)" disabled>Continue →</button>
+          <button class="btn-secondary" onclick="goToStep(1)">← Back</button>
+          <button class="btn-primary" id="repos-continue" onclick="goToStep(3)" disabled>Continue →</button>
         </div>
       </div>
 
-      <!-- Step 4: ACMM level + submit -->
-      <div class="wizard-panel" id="panel-4">
+      <!-- Step 3: ACMM level + submit.
+           Options are rendered by renderAcmmOptions() from ACMM_LEVELS so the
+           names match the hub dashboard and the spoke. They previously read
+           "L1 Advisory / L2 Measured / L4 Auto PR", which named the levels
+           wrongly AND described L4 as auto-merging — it does not. -->
+      <div class="wizard-panel" id="panel-3">
         <h2>Choose autonomy level</h2>
         <p>How much should the agents do on their own? Start low and increase as you build confidence. This only controls the mundane work &mdash; security patches, dependency updates, issue triage, test fixes &mdash; so your team can focus on what matters: innovation, outreach, and strategy.</p>
-        <div class="acmm-options" id="acmm-options">
-          <label class="acmm-option selected" onclick="selectAcmm(this, 1)">
-            <input type="radio" name="acmm" value="1" checked>
-            <div>
-              <div class="acmm-label">L1 &mdash; Advisory <span class="acmm-rec">Recommended to start</span></div>
-              <div class="acmm-desc">Agents scan issues and suggest fixes but take no action. You review everything. A safe way to see what the hive would do before granting more autonomy.</div>
-            </div>
-          </label>
-          <label class="acmm-option" onclick="selectAcmm(this, 2)">
-            <input type="radio" name="acmm" value="2">
-            <div>
-              <div class="acmm-label">L2 &mdash; Measured</div>
-              <div class="acmm-desc">Agents open issues to track findings. No PRs, no merges.</div>
-            </div>
-          </label>
-          <label class="acmm-option" onclick="selectAcmm(this, 3)">
-            <input type="radio" name="acmm" value="3">
-            <div>
-              <div class="acmm-label">L3 &mdash; CI-Gated PRs</div>
-              <div class="acmm-desc">Agents open hold-gated pull requests. CI must pass, and a human approves each merge.</div>
-            </div>
-          </label>
-          <label class="acmm-option" onclick="selectAcmm(this, 4)">
-            <input type="radio" name="acmm" value="4">
-            <div>
-              <div class="acmm-label">L4 &mdash; Auto PR</div>
-              <div class="acmm-desc">Agents open and merge PRs on green CI. Human review optional. Best for repos with strong CI coverage.</div>
-            </div>
-          </label>
-        </div>
+        <div class="acmm-options" id="acmm-options"></div>
         <div id="request-summary" style="margin:20px 0;padding:16px;background:#080b0f85;border:1px solid var(--line);border-radius:.7rem;font-size:0.85rem">
           <div style="margin-bottom:8px"><strong>Summary</strong></div>
           <div style="color:var(--muted)">Repos: <span id="summary-repos" style="color:var(--text)">none selected</span></div>
-          <div style="color:var(--muted)">ACMM Level: <span id="summary-acmm" style="color:var(--text)">L1 Advisory</span></div>
+          <div style="color:var(--muted)">ACMM Level: <span id="summary-acmm" style="color:var(--text)"></span></div>
         </div>
+        <!-- The wizard no longer asks anyone to install the GitHub App. This
+             note is the handoff to where that now happens: after provisioning,
+             the hive's own dashboard knows its forge and renders a correct
+             per-instance install link (githubAppInstallURL, from
+             config.GitHubConfig.AppInstallURL). -->
+        <p style="font-size:0.8rem;margin-top:4px">
+          <strong>What happens next:</strong> an admin reviews your request. Once your hive is provisioned,
+          its dashboard will prompt you to install the Hive GitHub App &mdash; with a link pointing at the
+          right GitHub instance for your repos. Nothing to install before then.
+        </p>
         <div style="display:flex;gap:12px;margin-top:16px">
-          <button class="btn-secondary" onclick="goToStep(3)">← Back</button>
+          <button class="btn-secondary" onclick="goToStep(2)">← Back</button>
           <button class="btn-primary" id="submit-request" onclick="submitRequest()">Request a Hive</button>
         </div>
       </div>
@@ -506,11 +454,55 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
     var _step = 1;
     var _user = null;
     var _selectedRepos = [];
-    var _selectedAcmm = 1;
+
+    /* WIZARD_STEP_* name the panels so a renumber is a one-line change instead
+       of a hunt for bare integers. The wizard lost its old "Install the GitHub
+       App" step: the App is installed AFTER provisioning, from the hive's own
+       dashboard, where the hive knows its forge and can build a correct
+       per-instance install link. */
+    var WIZARD_STEP_LOGIN = 1;
+    var WIZARD_STEP_REPOS = 2;
+    var WIZARD_STEP_LEVEL = 3;
+
+    /* ACMM levels, mirroring ACMM_LABELS/ACMM_TIPS on the hub dashboard
+       (pkg/hub/saas.go) and acmmLevelLabel() on the spoke. Keep all three in
+       step — a requester must not be shown one name here and another one on
+       the dashboard of the hive they receive. */
+    var ACMM_LEVELS = [
+      {level: 1, label: 'L1 Assisted',       desc: 'Advisory only. Agents look and report; they never write to your repo.'},
+      {level: 2, label: 'L2 Instructed',     desc: 'Advisory beads, no GitHub writes. Agents follow your CLAUDE.md and house rules.'},
+      {level: 3, label: 'L3 Measured',       desc: 'Hold-gated PRs, CI gates. Agents raise test coverage to earn later automation; every PR waits for a human.'},
+      {level: 4, label: 'L4 Adaptive',       desc: 'Agents open issues and hold-gated PRs, plus security checks. Still a human on every merge.'},
+      {level: 5, label: 'L5 Semi-Automated', desc: 'PRs carry a hold label for batch review, so you approve in groups rather than one at a time.'},
+      {level: 6, label: 'L6 Autonomous',     desc: 'Auto-merge on green CI. Only for repos with CI you already trust.'}
+    ];
+    /* L3 Measured is the recommended entry point: it is the first level that
+       produces useful work (test-coverage PRs) while still gating every merge
+       on a human. */
+    var DEFAULT_ACMM_LEVEL = 3;
+    var _selectedAcmm = DEFAULT_ACMM_LEVEL;
+
+    function acmmEntry(level) {
+      return (ACMM_LEVELS || []).filter(function(a) { return a.level === level; })[0] || null;
+    }
+
+    /* renderAcmmOptions builds the level radios from ACMM_LEVELS. */
+    function renderAcmmOptions() {
+      var host = document.getElementById('acmm-options');
+      if (!host) return;
+      host.innerHTML = (ACMM_LEVELS || []).map(function(a) {
+        var sel = a.level === _selectedAcmm;
+        return '<label class="acmm-option' + (sel ? ' selected' : '') + '" onclick="selectAcmm(this, ' + a.level + ')">' +
+          '<input type="radio" name="acmm" value="' + a.level + '"' + (sel ? ' checked' : '') + '>' +
+          '<div><div class="acmm-label">' + esc(a.label) +
+          (a.level === DEFAULT_ACMM_LEVEL ? ' <span class="acmm-rec">Recommended to start</span>' : '') +
+          '</div>' +
+          '<div class="acmm-desc">' + esc(a.desc) + '</div></div></label>';
+      }).join('');
+    }
 
     function goToStep(n) {
-      if (n === 3) loadRepos();
-      if (n === 4) updateSummary();
+      if (n === WIZARD_STEP_LEVEL) { renderAcmmOptions(); updateSummary(); }
       _step = n;
       var steps = document.querySelectorAll('.wizard-step');
       steps.forEach(function(s) {
@@ -530,65 +522,92 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
     }
 
     function updateSummary() {
-      var names = _selectedRepos.map(function(r) { return r.name || r; });
-      document.getElementById('summary-repos').textContent = names.length ? names.join(', ') : 'none selected';
-      var acmmNames = {1: 'L1 Advisory', 2: 'L2 Measured', 3: 'L3 CI-Gated PRs', 4: 'L4 Auto PR'};
-      document.getElementById('summary-acmm').textContent = acmmNames[_selectedAcmm] || 'L1 Advisory';
+      var names = (_selectedRepos || []).map(function(r) { return r.full_name || r.name || r; });
+      document.getElementById('summary-repos').textContent = names.length ? names.join(', ') : 'none added';
+      var entry = acmmEntry(_selectedAcmm);
+      document.getElementById('summary-acmm').textContent = entry ? entry.label : ('L' + _selectedAcmm);
     }
 
-    async function loadRepos() {
-      var loading = document.getElementById('repo-loading');
-      var list = document.getElementById('repo-list');
-      var none = document.getElementById('repo-none');
-      loading.style.display = 'block';
-      list.style.display = 'none';
-      none.style.display = 'none';
+    /* parseRepoRef turns whatever a user pastes into {host, org, name}.
+       It mirrors the server's normalizeForgeHost (pkg/hub/server.go): strip the
+       scheme, drop a trailing slash, lowercase the HOST only. It is a separate
+       JS function rather than a call into that Go helper for the obvious reason
+       — this runs in the browser — but the accepted forms are kept identical so
+       what the page accepts is what the server will store.
 
-      try {
-        var resp = await fetch('/api/saas/repos');
-        var data = await resp.json();
-        var repos = data.repos || [];
-        loading.style.display = 'none';
+       Accepts:  github.com/org/repo   https://github.ibm.com/org/repo
+                 host/org/repo/        org/repo         (bare -> public GitHub)
 
-        if (!repos.length) {
-          none.style.display = 'block';
-          return;
-        }
-
-        list.style.display = 'flex';
-        list.innerHTML = repos.map(function(r) {
-          var checked = _selectedRepos.some(function(s) { return s.full_name === r.full_name; });
-          return '<label class="repo-item' + (checked ? ' selected' : '') + '" onclick="toggleRepo(this, \'' + esc(r.full_name) + '\', \'' + esc(r.name) + '\')">' +
-            '<input type="checkbox" ' + (checked ? 'checked' : '') + '>' +
-            '<div><div class="repo-name">' + esc(r.full_name) + '</div>' +
-            (r.description ? '<div class="repo-desc">' + esc(r.description) + '</div>' : '') +
-            '</div></label>';
-        }).join('');
-      } catch(e) {
-        loading.style.display = 'none';
-        none.style.display = 'block';
+       Parsing is deliberately separate from forge policy: this function will
+       happily split gitlab.com/org/repo, and isSupportedForgeHost then rejects
+       it. Keeping the two apart means supporting a new forge later is a change
+       to the predicate alone, not to URL handling. */
+    function parseRepoRef(raw) {
+      var v = (raw || '').trim().replace(/^[a-z][a-z0-9+.-]*:\/\//i, '');
+      v = v.replace(/[?#].*$/, '').replace(/\/+$/, '');
+      var parts = v.split('/').filter(function(p) { return p.length; });
+      // Strip a leading hostname (anything with a dot) but KEEP it: an
+      // Enterprise repo is only reachable if the request records its instance.
+      var host = '';
+      if (parts.length > 2 && parts[0].indexOf('.') !== -1) {
+        host = parts[0].toLowerCase();
+        parts = parts.slice(1);
       }
+      if (parts.length < 2) return null;
+      // ".git" is part of a clone URL, not the repo name. Strip it AFTER the
+      // trailing slash is gone so "…/repo.git/" is handled too.
+      var name = parts[1].replace(/\.git$/i, '');
+      if (!parts[0] || !name) return null;
+      return {host: host, org: parts[0], name: name};
     }
 
-    function toggleRepo(el, fullName, name) {
-      var cb = el.querySelector('input[type=checkbox]');
-      var idx = _selectedRepos.findIndex(function(r) { return r.full_name === fullName; });
-      if (idx >= 0) {
-        _selectedRepos.splice(idx, 1);
-        el.classList.remove('selected');
-        cb.checked = false;
-      } else {
-        _selectedRepos.push({full_name: fullName, name: name});
-        el.classList.add('selected');
-        cb.checked = true;
-      }
-      document.getElementById('repos-continue').disabled = _selectedRepos.length === 0;
-    }
+    /* Only GitHub can be provisioned today: App auth, AppInstallURL, and the
+       write gate are all GitHub-specific, so a GitLab or Gitea URL would be
+       accepted here and then fail after the request was already filed. This is
+       an ALLOW-list, not a deny-list — a deny-list of known forges would let
+       "gitlab.mycorp.com" through simply by not having heard of it.
 
-    // Add a repo the picker cannot show. Repo discovery runs on the github.com
-    // OAuth token, so GitHub Enterprise repos (github.ibm.com and friends) never
-    // appear in the list — typing the URL is the only way to request one.
-    // Accepts a full URL, "host/org/repo", or "org/repo".
+       Accepts:  github.com                (public GitHub)
+                 github.<org>.<tld>        (GitHub Enterprise: github.ibm.com,
+                                            github.cisco.com)
+                 github.<org>.<sub>.<tld>  (github.corp.example.com)
+       Rejects:  gitlab.com, gitea.example.com, codeberg.org, bitbucket.org.
+
+       The pattern is anchored at BOTH ends and bounded in length, so the
+       lookalikes "mygithub.com" and "notgithub.com" fail at the front.
+
+       "github.com.evil.net" needs a SEPARATE rule, and it is worth being honest
+       about why: it is structurally identical to the legitimate
+       "github.corp.example.com" (github + label + label + tld). No pattern can
+       tell them apart, so the second label is checked against public GitHub's
+       own name instead — "github.com.<anything>" is the classic prefix-spoof
+       and never a real Enterprise host. */
+    var PUBLIC_GITHUB_HOST = 'github.com';
+    /* Labels permitted AFTER the leading "github." and before the TLD. Real GHE
+       hosts are github.<org>.<tld>, occasionally with one extra internal label
+       (github.corp.example.com). Two is the ceiling; more is a spoofing shape,
+       not a deployment anyone runs. */
+    var GITHUB_ENTERPRISE_HOST_RE = /^github\.[a-z0-9-]+(\.[a-z0-9-]+)?\.[a-z]{2,}$/;
+    /* Rejects github.com.evil.net and github.com.co — a host whose first two
+       labels spell public GitHub, with anything appended after it. */
+    var GITHUB_SPOOF_PREFIX_RE = /^github\.com\./;
+    function isSupportedForgeHost(host) {
+      // No host means a bare "org/repo", which we read as public GitHub.
+      if (!host) return true;
+      var h = host.toLowerCase();
+      if (h === PUBLIC_GITHUB_HOST) return true;
+      if (GITHUB_SPOOF_PREFIX_RE.test(h)) return false;
+      return GITHUB_ENTERPRISE_HOST_RE.test(h);
+    }
+    /* One message, used wherever a forge is rejected. It states the limit, names
+       the accepted forms, and says other forges are coming — a GitLab user
+       should read this as a roadmap gap, not a refusal. */
+    var UNSUPPORTED_FORGE_MSG = ' is not supported yet. Hives can currently be provisioned on GitHub only' +
+      ' — github.com or a GitHub Enterprise host such as github.ibm.com.' +
+      ' Support for GitLab, Gitea, and other forges is planned.';
+
+    // Add a repository the user typed. This is the ONLY way repos enter the
+    // request — see the panel comment for why the picker is gone.
     function addManualRepo() {
       var input = document.getElementById('repo-manual');
       var err = document.getElementById('repo-manual-err');
@@ -596,31 +615,30 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
       err.style.display = 'none';
       if (!raw) return;
 
-      var v = raw.replace(/^https?:\/\//, '').replace(/\/+$/, '').replace(/\.git$/, '');
-      var parts = v.split('/').filter(function(p) { return p.length; });
-      // Split off a leading hostname (anything with a dot) so host/org/repo ->
-      // org/repo, but KEEP the host: a GitHub Enterprise repo is only reachable
-      // if the request records which instance it lives on.
-      var ghHost = '';
-      if (parts.length > 2 && parts[0].indexOf('.') !== -1) { ghHost = parts[0]; parts = parts.slice(1); }
-      if (parts.length < 2) {
-        err.textContent = 'Enter a repository URL or org/repo — for example https://github.ibm.com/my-org/my-repo';
+      var ref = parseRepoRef(raw);
+      if (!ref) {
+        err.textContent = 'Enter a repository URL — for example github.com/my-org/my-repo or https://github.ibm.com/my-org/my-repo';
         err.style.display = 'block';
         return;
       }
-      var org = parts[0], name = parts[1], fullName = org + '/' + name;
-      if (_selectedRepos.some(function(r) { return r.full_name === fullName; })) {
-        err.textContent = fullName + ' is already selected';
+      if (!isSupportedForgeHost(ref.host)) {
+        err.textContent = ref.host + UNSUPPORTED_FORGE_MSG;
         err.style.display = 'block';
         return;
       }
-      _selectedRepos.push({full_name: fullName, name: name, github_host: ghHost});
+      var fullName = ref.org + '/' + ref.name;
+      if ((_selectedRepos || []).some(function(r) { return r.full_name === fullName; })) {
+        err.textContent = fullName + ' is already added';
+        err.style.display = 'block';
+        return;
+      }
+      _selectedRepos.push({full_name: fullName, name: ref.name, github_host: ref.host});
       input.value = '';
       renderManualRepos();
       document.getElementById('repos-continue').disabled = _selectedRepos.length === 0;
     }
 
-    // Show manually added repos (they have no checkbox row in the picker list).
+    // Show the repositories added so far as removable chips.
     function renderManualRepos() {
       var host = document.getElementById('repo-manual-added');
       if (!host) {
@@ -629,15 +647,12 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
         host.style.cssText = 'margin-top:10px;display:flex;flex-wrap:wrap;gap:6px';
         document.getElementById('repo-manual').parentNode.parentNode.appendChild(host);
       }
-      var listed = {};
-      document.querySelectorAll('#repo-list .repo-item').forEach(function(el) {
-        var n = el.querySelector('.repo-name');
-        if (n) listed[n.textContent] = true;
-      });
-      var manual = _selectedRepos.filter(function(r) { return !listed[r.full_name]; });
-      host.innerHTML = manual.map(function(r) {
+      host.innerHTML = (_selectedRepos || []).map(function(r) {
+        // Show the Enterprise host when there is one, so the user can see which
+        // instance we recorded before they submit.
+        var shown = (r.github_host ? r.github_host + '/' : '') + r.full_name;
         return '<span style="display:inline-flex;align-items:center;gap:6px;padding:3px 10px;border:1px solid var(--line);border-radius:999px;font-size:0.8rem">' +
-          esc(r.full_name) +
+          esc(shown) +
           '<a href="#" onclick="removeManualRepo(\'' + esc(r.full_name) + '\');return false" style="color:var(--muted);text-decoration:none" title="Remove">&times;</a></span>';
       }).join('');
     }

--- a/v2/pkg/hub/upgrade_failure_test.go
+++ b/v2/pkg/hub/upgrade_failure_test.go
@@ -1,0 +1,127 @@
+package hub
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+// Before this change the hub only ever learned about upgrades that SUCCEEDED.
+// A spoke that could not upgrade (e.g. HTTP 403 patching its own Deployment)
+// looked identical to one still working on it, so the registry kept
+// Upgrading=true forever and the hub re-instructed the same target every beat.
+
+func TestHandleHeartbeat_UpgradeFailedClearsUpgradingAndRecordsCause(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	s.registry.Hives = []RegistryEntry{{
+		ID: "h1", Upgrading: true, UpgradeTarget: "fc32ae4", GitHash: "c11643a",
+	}}
+	// Arm the fallback instruction so we can prove it gets dropped.
+	s.heartbeatUpgrade = map[string]string{"h1": "fc32ae4"}
+
+	rec := postHeartbeat(t, s, `{"hive_id":"h1","git_hash":"c11643a",`+
+		`"upgrade_target_sha":"fc32ae4","upgrade_failed":true,`+
+		`"upgrade_error":"HTTP 403: cannot patch resource deployments"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	s.mu.RLock()
+	h := s.registry.Hives[0]
+	_, stillArmed := s.heartbeatUpgrade["h1"]
+	s.mu.RUnlock()
+
+	if h.Upgrading {
+		t.Error("Upgrading must be cleared on a reported failure — the UI showing a permanent spinner is the bug")
+	}
+	if !h.UpgradeFailed {
+		t.Error("UpgradeFailed not recorded")
+	}
+	if h.UpgradeError == "" {
+		t.Error("UpgradeError must carry the underlying cause so the failure is diagnosable")
+	}
+	if h.UpgradeFailedAt.IsZero() {
+		t.Error("UpgradeFailedAt not stamped")
+	}
+	if stillArmed {
+		t.Error("a refused instruction must be dropped, otherwise the hub re-sends the same failing target forever")
+	}
+}
+
+func TestHandleHeartbeat_UpgradeFailurePersistsUntilTheHiveActuallyMoves(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	// Ordinary heartbeats do not repeat the failure flag; the hub must not
+	// forget the failure just because the next beat was silent about it.
+	s.registry.Hives = []RegistryEntry{{
+		ID: "h1", GitHash: "c11643a", UpgradeFailed: true,
+		UpgradeError: "HTTP 403", UpgradeFailedAt: time.Now(),
+	}}
+
+	rec := postHeartbeat(t, s, `{"hive_id":"h1","git_hash":"c11643a"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	s.mu.RLock()
+	h := s.registry.Hives[0]
+	s.mu.RUnlock()
+	if !h.UpgradeFailed || h.UpgradeError != "HTTP 403" {
+		t.Errorf("failure state lost on a plain heartbeat: %+v", h)
+	}
+}
+
+func TestHandleHeartbeat_UpgradeFailureClearsOnceTheHiveReportsANewSHA(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	s.registry.Hives = []RegistryEntry{{
+		ID: "h1", GitHash: "c11643a", UpgradeFailed: true,
+		UpgradeError: "HTTP 403", UpgradeFailedAt: time.Now(),
+	}}
+
+	// The hive finally moved — the failure is history and must not stick.
+	rec := postHeartbeat(t, s, `{"hive_id":"h1","git_hash":"fc32ae4"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	s.mu.RLock()
+	h := s.registry.Hives[0]
+	s.mu.RUnlock()
+	if h.UpgradeFailed || h.UpgradeError != "" {
+		t.Errorf("failure state must clear once the spoke reports a new SHA: %+v", h)
+	}
+}
+
+func TestEvaluateAlerts_FailedUpgradeIsCritical(t *testing.T) {
+	// A failed upgrade never resolves itself, so it must surface as an alert
+	// rather than hiding behind an "Upgrading" badge.
+	hives := []alertHive{{
+		ID: "h1", Name: "hive-1", Online: true,
+		UpgradeFailed: true, UpgradeTarget: "fc32ae4",
+		UpgradeError: "HTTP 403: cannot patch resource deployments",
+	}}
+	got := evaluateAlerts(newAlertState(), hives, nil, time.Now())
+
+	var found *Alert
+	for i := range got.Alerts {
+		if got.Alerts[i].Type == AlertTypeFailedUpgrade {
+			found = &got.Alerts[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("no %s alert raised; alerts=%+v", AlertTypeFailedUpgrade, got.Alerts)
+	}
+	if found.Severity != AlertSeverityCritical {
+		t.Errorf("severity = %q, want %q", found.Severity, AlertSeverityCritical)
+	}
+	if found.Reason == "" {
+		t.Error("alert reason must include the cause")
+	}
+}

--- a/v2/pkg/hub/vanity_url_repair_test.go
+++ b/v2/pkg/hub/vanity_url_repair_test.go
@@ -258,3 +258,127 @@ func TestRepairedVanityURLReachesSpokeViaHeartbeat(t *testing.T) {
 		t.Errorf("still pushing after the spoke adopted the vanity URL: %+v", pc2)
 	}
 }
+
+// openShiftVanityTestDomain mirrors the live vllm-d apps wildcard domain.
+const openShiftVanityTestDomain = "apps.fmaas-vllm-d.example.com"
+
+// newOpenShiftVanityTestHub builds a hub with one OpenShift-Route cluster whose
+// spokes the hub cannot reach (no kubectl under test), standing in for the
+// firewalled heartbeat-only vllm-d pool.
+func newOpenShiftVanityTestHub() *HubServer {
+	return &HubServer{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		clusters: map[string]ClusterConfig{
+			defaultClusterID: {
+				ID:          defaultClusterID,
+				Name:        "vllm-d",
+				Domain:      openShiftVanityTestDomain,
+				IngressType: ingressTypeOpenShiftRoute,
+			},
+		},
+	}
+}
+
+// On an OpenShift cluster whose Routes the hub cannot read, addVanityHostToIngress
+// must report FAILURE. It previously `continue`d past every unreachable source
+// Route and still returned nil, so the retroactive repair believed the host was
+// servable, adopted it, and replaced a working placeholder link with a 503 — the
+// live vllm-d regression across 11 claimed hives.
+func TestAddVanityHostToIngressFailsWhenNoRouteCanBeMirrored(t *testing.T) {
+	s := newOpenShiftVanityTestHub()
+	cluster := s.clusters[defaultClusterID]
+
+	err := s.addVanityHostToIngress("hosted-available-vllmd-01", "hosted-x-y-ab12."+openShiftVanityTestDomain, &cluster)
+	if err == nil {
+		t.Fatal("addVanityHostToIngress reported success with no route mirrored — " +
+			"the caller would adopt an unservable vanity host and 503 every hub link")
+	}
+	if !strings.Contains(err.Error(), "no route found") {
+		t.Errorf("error %q does not name the missing-route cause", err)
+	}
+}
+
+// The guard must actually hold end to end: on an unreachable OpenShift cluster the
+// hive keeps its EMPTY VanityURL, so every read path falls back to the working
+// placeholder host rather than an adopted-but-unservable vanity host.
+func TestVanityRepairKeepsPlaceholderOnUnreachableOpenShiftCluster(t *testing.T) {
+	useTempHiveDir(t)
+	s := newOpenShiftVanityTestHub()
+
+	const id = "hosted-available-vllmd-01"
+	if err := saveSaaSHive(&SaaSHive{
+		ID: id, Status: "running", Owner: "someone", Org: "ibm-aiops",
+		Repos: []string{"katamari"}, PrimaryRepo: "katamari", ACMMLevel: 3,
+		ClusterID: defaultClusterID, ClaimDelivered: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.repairVanityURLForHive(id) {
+		t.Error("repair adopted a vanity URL on a cluster where it could not create a route")
+	}
+	if got := loadSaaSHive(id).VanityURL; got != "" {
+		t.Errorf("VanityURL = %q, want empty so the working placeholder host stands", got)
+	}
+	if got := claimedVanityURL(loadSaaSHive(id)); got != "" {
+		t.Errorf("claimedVanityURL = %q, want empty (placeholder fallback)", got)
+	}
+}
+
+// A repair that CANNOT succeed must not churn a new random host per heartbeat.
+// generateHiveID mints a fresh 4-char suffix per call, so an unguarded retry
+// produced a different host every beat (observed live: three hosts in four
+// minutes). Repeated failing repairs must leave the record untouched.
+func TestVanityRepairDoesNotChurnHostWhenItCannotSucceed(t *testing.T) {
+	useTempHiveDir(t)
+	s := newOpenShiftVanityTestHub()
+
+	const id = "hosted-available-vllmd-12"
+	if err := saveSaaSHive(&SaaSHive{
+		ID: id, Status: "running", Owner: "someone", Org: "ibm-aiops",
+		Repos: []string{"katamari"}, PrimaryRepo: "katamari", ACMMLevel: 3,
+		ClusterID: defaultClusterID, ClaimDelivered: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate several heartbeats against a cluster that stays unreachable.
+	for beat := range 5 {
+		if s.repairVanityURLForHive(id) {
+			t.Fatalf("beat %d: repair reported a change it could not make servable", beat)
+		}
+		if got := loadSaaSHive(id).VanityURL; got != "" {
+			t.Fatalf("beat %d: adopted %q despite an unservable host", beat, got)
+		}
+	}
+}
+
+// The nginx path must be unaffected by the OpenShift accounting fix: a reachable
+// nginx cluster still adopts its vanity host exactly once and keeps it stable.
+func TestVanityRepairNginxBehaviorUnchanged(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityRepairTestHub()
+
+	const id = "hosted-available-oke-42-placeholder-zz01"
+	if err := saveSaaSHive(&SaaSHive{
+		ID: id, Status: "running", Owner: "someone", Org: "kubestellar",
+		Repos: []string{"console"}, PrimaryRepo: "console", ACMMLevel: 3,
+		ClusterID: defaultClusterID, ClaimDelivered: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !s.repairVanityURLForHive(id) {
+		t.Fatal("nginx repair reported no change — existing behavior regressed")
+	}
+	first := loadSaaSHive(id).VanityURL
+	if first == "" {
+		t.Fatal("nginx repair left the vanity URL empty")
+	}
+	if s.repairVanityURLForHive(id) {
+		t.Error("nginx repair was not idempotent")
+	}
+	if second := loadSaaSHive(id).VanityURL; second != first {
+		t.Errorf("nginx vanity host churned: %q then %q", first, second)
+	}
+}

--- a/v2/pkg/hub/vanity_url_repair_test.go
+++ b/v2/pkg/hub/vanity_url_repair_test.go
@@ -1,0 +1,260 @@
+package hub
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// vanityRepairTestDomain is the cluster domain the repair derives vanity hosts
+// from in these tests, mirroring the live hive-oke cluster.
+const vanityRepairTestDomain = "hive.kubestellar.io"
+
+// newVanityRepairTestHub builds a hub with one nginx cluster that has a domain
+// (so a vanity host can be derived) and a servability seam that succeeds,
+// standing in for a reachable cluster whose ingress the hub can patch.
+func newVanityRepairTestHub() *HubServer {
+	s := &HubServer{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		clusters: map[string]ClusterConfig{
+			defaultClusterID: {
+				ID:          defaultClusterID,
+				Name:        "oke",
+				Domain:      vanityRepairTestDomain,
+				IngressType: "nginx",
+			},
+		},
+	}
+	s.vanityHostServable = func(_, _ string, _ *ClusterConfig) error { return nil }
+	return s
+}
+
+// A hive claimed BEFORE the vanity feature existed (real org, placeholder id,
+// empty vanity_url) must get a vanity URL — and its id must NOT change, since
+// the id is a k8s namespace suffix, an ingress host, a socket path and the SSO
+// token's "h" claim.
+func TestVanityRepairBackfillsClaimedHiveWithoutChangingID(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityRepairTestHub()
+
+	const id = "hosted-available-oke-07-placeholder-wlj4"
+	h := &SaaSHive{
+		ID: id, Status: "running", Owner: "MattSweetIBM", Org: "MattSweetIBM",
+		Repos: []string{"s1netops"}, PrimaryRepo: "s1netops", ACMMLevel: 3,
+		ClusterID: defaultClusterID, ClaimDelivered: true,
+	}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+
+	// Before the repair every read path falls back to the placeholder host.
+	if got := claimedVanityURL(loadSaaSHive(id)); got != "" {
+		t.Fatalf("precondition: expected no vanity URL, got %q", got)
+	}
+
+	if !s.repairVanityURLForHive(id) {
+		t.Fatal("repair reported no change for a pre-vanity claimed hive")
+	}
+
+	got := loadSaaSHive(id)
+	if got.ID != id {
+		t.Errorf("repair changed the hive id: %q, want %q (ids are namespaces/SSO claims)", got.ID, id)
+	}
+	if got.VanityURL == "" {
+		t.Fatal("repair left the vanity URL empty")
+	}
+	// Derived from the claimed PROJECT, on the cluster domain — not the placeholder.
+	if !strings.HasPrefix(got.VanityURL, "https://hosted-mattsweetibm-s1netops-") {
+		t.Errorf("vanity URL %q is not derived from org/primary repo", got.VanityURL)
+	}
+	if !strings.HasSuffix(got.VanityURL, "."+vanityRepairTestDomain) {
+		t.Errorf("vanity URL %q is not on the cluster domain", got.VanityURL)
+	}
+	if strings.Contains(got.VanityURL, "placeholder") {
+		t.Errorf("vanity URL %q still carries the placeholder host", got.VanityURL)
+	}
+	// The whole point: the read paths now surface the vanity URL.
+	if v := claimedVanityURL(got); v != got.VanityURL {
+		t.Errorf("claimedVanityURL = %q, want %q", v, got.VanityURL)
+	}
+}
+
+// The repair must be idempotent: the heartbeat calls it on EVERY beat, and
+// generateHiveID mints a fresh random suffix per call, so a second run must not
+// change anything (otherwise the vanity host would churn every heartbeat).
+func TestVanityRepairIsIdempotent(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityRepairTestHub()
+
+	const id = "hosted-available-oke-01-placeholder-bb95"
+	if err := saveSaaSHive(&SaaSHive{
+		ID: id, Status: "running", Org: "TradingAsBuddies",
+		Repos: []string{"app"}, PrimaryRepo: "app", ACMMLevel: 2,
+		ClusterID: defaultClusterID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !s.repairVanityURLForHive(id) {
+		t.Fatal("first repair reported no change")
+	}
+	first := loadSaaSHive(id).VanityURL
+
+	if s.repairVanityURLForHive(id) {
+		t.Error("second repair changed an already-repaired hive")
+	}
+	if second := loadSaaSHive(id).VanityURL; second != first {
+		t.Errorf("vanity URL churned across beats: %q then %q", first, second)
+	}
+
+	// The same holds for the fleet sweep.
+	if n := s.repairVanityURLsForClaimedHives(); n != 0 {
+		t.Errorf("sweep over an already-repaired fleet changed %d hives, want 0", n)
+	}
+}
+
+// An UNCLAIMED placeholder must be left completely alone: assign owns it and
+// mints its vanity URL at claim time.
+func TestVanityRepairSkipsUnclaimedPlaceholder(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityRepairTestHub()
+
+	const id = "hosted-available-oke-09"
+	if err := saveSaaSHive(&SaaSHive{
+		ID: id, Status: statusAvailable, Owner: hubAdminUsername, ClusterID: defaultClusterID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.repairVanityURLForHive(id) {
+		t.Error("repair touched an unclaimed placeholder")
+	}
+	if v := loadSaaSHive(id).VanityURL; v != "" {
+		t.Errorf("unclaimed placeholder gained a vanity URL %q", v)
+	}
+}
+
+// A hive whose cluster the hub cannot reach (the firewalled vllm-d case: the hub
+// cannot kubectl to create a route) must keep its working placeholder host
+// rather than adopt an unserved vanity host that would 503 every hub link.
+func TestVanityRepairKeepsPlaceholderWhenHostNotServable(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityRepairTestHub()
+	s.vanityHostServable = func(_, _ string, _ *ClusterConfig) error {
+		return fmt.Errorf("cluster unreachable")
+	}
+
+	const id = "hosted-available-vllmd-10"
+	if err := saveSaaSHive(&SaaSHive{
+		ID: id, Status: "running", Org: "katamari",
+		Repos: []string{"ibm-aiops-orchestrator"}, PrimaryRepo: "ibm-aiops-orchestrator",
+		ACMMLevel: 2, ClusterID: defaultClusterID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.repairVanityURLForHive(id) {
+		t.Error("repair adopted a vanity host it could not make servable")
+	}
+	if v := loadSaaSHive(id).VanityURL; v != "" {
+		t.Errorf("unservable vanity host was adopted: %q — hub links would 503", v)
+	}
+	// claimedVanityURL therefore still yields nothing, so the placeholder stands.
+	if v := claimedVanityURL(loadSaaSHive(id)); v != "" {
+		t.Errorf("claimedVanityURL = %q, want \"\" so the working placeholder is used", v)
+	}
+}
+
+// A hive with an incomplete claim (no org, or no primary repo) has nothing to
+// derive a friendly host from, and a hive on a cluster with no domain likewise.
+func TestVanityRepairSkipsUnderivableHives(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityRepairTestHub()
+	s.clusters["no-domain"] = ClusterConfig{ID: "no-domain", Name: "nodomain"}
+
+	seed := []*SaaSHive{
+		{ID: "hosted-no-org", Status: "running", Repos: []string{"r"}, PrimaryRepo: "r", ClusterID: defaultClusterID},
+		{ID: "hosted-no-repo", Status: "running", Org: "o", ClusterID: defaultClusterID},
+		{ID: "hosted-no-domain", Status: "running", Org: "o", Repos: []string{"r"}, PrimaryRepo: "r", ClusterID: "no-domain"},
+	}
+	for _, h := range seed {
+		if err := saveSaaSHive(h); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, h := range seed {
+		if s.repairVanityURLForHive(h.ID) {
+			t.Errorf("%s: repair changed a hive with nothing to derive a host from", h.ID)
+		}
+		if v := loadSaaSHive(h.ID).VanityURL; v != "" {
+			t.Errorf("%s: gained a vanity URL %q", h.ID, v)
+		}
+	}
+}
+
+// An existing vanity URL is never re-minted or clobbered.
+func TestVanityRepairNeverClobbersExistingVanityURL(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityRepairTestHub()
+
+	const id = "hosted-has-vanity"
+	const existing = "https://hosted-acme-app-abcd.hive.kubestellar.io"
+	if err := saveSaaSHive(&SaaSHive{
+		ID: id, Status: "running", Org: "acme", Repos: []string{"app"}, PrimaryRepo: "app",
+		ClusterID: defaultClusterID, VanityURL: existing,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.repairVanityURLForHive(id) {
+		t.Error("repair changed a hive that already had a vanity URL")
+	}
+	if v := loadSaaSHive(id).VanityURL; v != existing {
+		t.Errorf("vanity URL = %q, want the untouched %q", v, existing)
+	}
+}
+
+// End-to-end: once repaired, the very next heartbeat must PUSH the vanity URL to
+// the spoke, so the spoke adopts it and the registry's dashboardUrl follows.
+// Without this the repair would only fix the hub's display and leave the spoke
+// reporting the placeholder forever.
+func TestRepairedVanityURLReachesSpokeViaHeartbeat(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityRepairTestHub()
+
+	const id = "hosted-available-oke-03-placeholder-y99x"
+	const placeholderURL = "https://hosted-available-oke-03-placeholder-y99x.hive.kubestellar.io"
+	if err := saveSaaSHive(&SaaSHive{
+		ID: id, Status: "running", Org: "IBM", Repos: []string{"s1netops"},
+		PrimaryRepo: "s1netops", ACMMLevel: 3, ClusterID: defaultClusterID,
+		ClaimDelivered: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Before the repair the hub has no vanity URL to push.
+	if pc := projectConfigForHiveID(id, "IBM", []string{"s1netops"}, "s1netops", 3, placeholderURL, ""); pc != nil && pc.DashboardURL != "" {
+		t.Fatalf("expected no vanity push before repair, got %+v", pc)
+	}
+
+	if !s.repairVanityURLForHive(id) {
+		t.Fatal("repair reported no change")
+	}
+	want := loadSaaSHive(id).VanityURL
+
+	pc := projectConfigForHiveID(id, "IBM", []string{"s1netops"}, "s1netops", 3, placeholderURL, "")
+	if pc == nil {
+		t.Fatal("repaired hive produced no heartbeat push — the spoke would keep the placeholder")
+	}
+	if pc.DashboardURL != want {
+		t.Errorf("pushed dashboard URL = %q, want %q", pc.DashboardURL, want)
+	}
+
+	// Once the spoke reports the vanity URL back, the reconcile goes quiet.
+	if pc2 := projectConfigForHiveID(id, "IBM", []string{"s1netops"}, "s1netops", 3, want, ""); pc2 != nil && pc2.DashboardURL != "" {
+		t.Errorf("still pushing after the spoke adopted the vanity URL: %+v", pc2)
+	}
+}

--- a/v2/pkg/hub/vanity_url_test.go
+++ b/v2/pkg/hub/vanity_url_test.go
@@ -1,0 +1,125 @@
+package hub
+
+import "testing"
+
+// A claimed hive whose meta carries a validated vanity_url must have that URL
+// pushed to the spoke as DashboardURL — even when its project record is stale/
+// incomplete (the common placeholder-URL-persists case: vanity_url exists in
+// meta but was never delivered because the reconcile bailed on an incomplete
+// claim). The push must be URL-only (no stale org/repos/ACMM).
+func TestVanityURLPushedForClaimedHiveWithStaleProject(t *testing.T) {
+	dir := t.TempDir()
+	oldDir := saasHivesDir
+	saasHivesDir = dir
+	defer func() { saasHivesDir = oldDir }()
+
+	vanity := "https://hosted-zacburns-vllm-abcd.apps.fmaas-vllm-d.fmaas.res.ibm.com"
+	h := &SaaSHive{
+		ID:     "hosted-available-vllmd-10",
+		Status: "running", // claimed (not "available")
+		// Deliberately incomplete/stale project (no ACMM, no primary) — mirrors a
+		// real pre-claim record that still carries a populated vanity_url.
+		VanityURL: vanity,
+	}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+
+	// Spoke still reports the raw placeholder host.
+	pc := projectConfigForHiveID(h.ID, "", nil, "", 0,
+		"https://hosted-available-vllmd-10.apps.fmaas-vllm-d.fmaas.res.ibm.com", "")
+	if pc == nil {
+		t.Fatal("expected a vanity URL push for a claimed hive with a meta vanity_url, got nil")
+	}
+	if pc.DashboardURL != vanity {
+		t.Errorf("expected DashboardURL %q, got %q", vanity, pc.DashboardURL)
+	}
+	// A URL-only push must NOT carry the stale project (that would blank/downgrade
+	// the spoke's working config).
+	if pc.Org != "" || len(pc.Repos) != 0 || pc.PrimaryRepo != "" || pc.ACMMLevel != 0 {
+		t.Errorf("URL-only push must not carry project fields, got %+v", pc)
+	}
+
+	// Once the spoke reports the vanity host back, the reconcile goes quiet.
+	if pc2 := projectConfigForHiveID(h.ID, "", nil, "", 0, vanity, ""); pc2 != nil {
+		t.Errorf("expected nil once the spoke reports the vanity URL, got %+v", pc2)
+	}
+}
+
+// A hive on a heartbeat-only cluster adopts the vanity URL the hub shows/links
+// for it (My Hives, SSO /open) purely from its meta vanity_url, without the hub
+// ever creating an ingress/route — claimedVanityURL is the single source.
+func TestVanityURLAdoptedWithoutHubCreatedIngress(t *testing.T) {
+	vanity := "https://hosted-zacburns-vllm-abcd.apps.fmaas-vllm-d.fmaas.res.ibm.com"
+	h := &SaaSHive{ID: "hosted-vllmd-hb", Status: "running", VanityURL: vanity}
+	if got := claimedVanityURL(h); got != vanity {
+		t.Errorf("claimed heartbeat-only hive should surface its meta vanity_url %q, got %q", vanity, got)
+	}
+}
+
+// An UNASSIGNED placeholder (status "available") keeps its placeholder URL: the
+// hub must neither push a vanity URL nor override its shown DashboardURL.
+func TestUnassignedPlaceholderKeepsPlaceholderURL(t *testing.T) {
+	dir := t.TempDir()
+	oldDir := saasHivesDir
+	saasHivesDir = dir
+	defer func() { saasHivesDir = oldDir }()
+
+	// Even if a stray vanity_url were present, an available placeholder must be
+	// left alone.
+	h := &SaaSHive{
+		ID:        "hosted-available-slot-01",
+		Status:    statusAvailable,
+		VanityURL: "https://should-not-be-used.example.com",
+	}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := claimedVanityURL(h); got != "" {
+		t.Errorf("available placeholder must not surface a vanity URL, got %q", got)
+	}
+	placeholder := "https://hosted-available-slot-01.apps.fmaas-vllm-d.fmaas.res.ibm.com"
+	if pc := projectConfigForHiveID(h.ID, "", nil, "", 0, placeholder, ""); pc != nil {
+		t.Errorf("available placeholder must not be pushed a vanity URL, got %+v", pc)
+	}
+}
+
+// The don't-503-on-unserved-host safety: a claimed hive with NO vanity URL in
+// meta must never have one invented — the hub keeps the placeholder rather than
+// pushing/linking a host that has no backend.
+func TestNoVanityPushWhenUnserved(t *testing.T) {
+	dir := t.TempDir()
+	oldDir := saasHivesDir
+	saasHivesDir = dir
+	defer func() { saasHivesDir = oldDir }()
+
+	h := &SaaSHive{
+		ID:          "hosted-claimed-no-vanity",
+		Status:      "running",
+		Org:         "acme",
+		Repos:       []string{"acme/widget"},
+		PrimaryRepo: "acme/widget",
+		ACMMLevel:   2,
+		// VanityURL deliberately empty: no validated host exists.
+	}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+
+	// claimedVanityURL yields nothing to link/show, so the placeholder stands.
+	if got := claimedVanityURL(h); got != "" {
+		t.Errorf("no meta vanity_url means nothing to surface, got %q", got)
+	}
+	// The reconcile, once the claim is delivered and matched, must be quiet — it
+	// must NOT invent a vanity URL to push.
+	h.ClaimDelivered = true
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+	pc := projectConfigForHiveID(h.ID, "acme", []string{"acme/widget"}, "acme/widget", 2,
+		"https://hosted-claimed-no-vanity.hive.kubestellar.io", "")
+	if pc != nil {
+		t.Errorf("must not invent/push a vanity URL for a hive with none, got %+v", pc)
+	}
+}


### PR DESCRIPTION
Periodic sync of mainline `v2` into `mk`.

Brings `mk` up to date with `origin/v2` @ `64319198`, including:
- #2307 — ungate hive-self-upgrade RBAC from RequiresSCC, verify spoke image exists
- #2308 — unlatch the self-upgrade guard, make failed upgrades visible
- #2303 — FAQ page in dashboard Resources
- #2302 — writable $HOME for agent UIDs
- #2301 — GitHub App banner no longer fires falsely on cold start
- #2300 / #2299 / #2298 — onboarding level cap, bob launch cmd, wizard Continue

`mk` was **26 commits behind** `origin/v2`.

Merged with **no conflicts**. `go build ./...` passes.

> [!IMPORTANT]
> Merge this with `--merge`, **not** `--squash` — squashing destroys the merge-base and makes every subsequent v2→mk sync conflict.