### PR TITLE
⏰ feat(upgrade): move the daily auto-upgrade window from 5pm ET to 1pm ET

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3059,7 +3059,8 @@ func (s *HubServer) handleToggleAutoUpgrade(w http.ResponseWriter, r *http.Reque
 	// is delivered via the heartbeat response.
 	// Daily mode deliberately does NOT kick an upgrade here: the whole point of
 	// choosing it is that turning auto-upgrade on should not immediately
-	// restart a working hive. It will roll at the next 17:00 ET window. The
+	// restart a working hive. It will roll at the next daily ET window
+	// (autoUpgradeDailyHour, currently 13:00 / 1pm ET). The
 	// operator who wants it now still has the explicit Upgrade button, which
 	// goes through handleUpgradeHive and is never gated by mode.
 	if body.AutoUpgrade && normalizeAutoUpgradeMode(body.Mode) == AutoUpgradeModeInstant {
@@ -9951,7 +9952,7 @@ const dashboardHTML = `<!DOCTYPE html>
         '<button type="button" onclick="runBulkAction(\'restart\')" style="' + btn + '">Restart</button>' +
         '<button type="button" onclick="runBulkAction(\'upgrade\')" style="' + btn + '">Upgrade to latest</button>' +
         '<button type="button" onclick="runBulkAction(\'enable-auto-upgrade\')" style="' + btn + '">Auto: instant</button>' +
-        '<button type="button" onclick="runBulkAction(\'daily-auto-upgrade\')" style="' + btn + '" title="Upgrade at most once a day, after hours — keeps a stable hive from being restarted mid-work">Auto: daily 5pm ET</button>' +
+        '<button type="button" onclick="runBulkAction(\'daily-auto-upgrade\')" style="' + btn + '" title="Upgrade at most once a day, midday — keeps a stable hive from being restarted mid-work, and puts a bad roll in staffed hours">Auto: daily 1pm ET</button>' +
         '<button type="button" onclick="runBulkAction(\'disable-auto-upgrade\')" style="' + btn + '">Auto-upgrade off</button>' +
         branchPicker +
         '<button type="button" onclick="clearBulkSelection()" style="' + btn + ';color:var(--muted)">Clear</button>' +
@@ -9971,7 +9972,7 @@ const dashboardHTML = `<!DOCTYPE html>
       'restart': 'Restart',
       'upgrade': 'Upgrade to latest',
       'enable-auto-upgrade': 'Enable instant auto-upgrade on',
-      'daily-auto-upgrade': 'Enable daily 5pm ET auto-upgrade on',
+      'daily-auto-upgrade': 'Enable daily 1pm ET auto-upgrade on',
       'disable-auto-upgrade': 'Disable auto-upgrade on',
       'switch-branch': 'Switch branch for'
     };
@@ -10250,9 +10251,9 @@ const dashboardHTML = `<!DOCTYPE html>
                keep the click-to-upgrade-now escape hatch, which is the manual
                path and is never gated by the schedule. */
             var queuedDaily = h.autoUpgradeMode === AUTO_UPGRADE_DAILY;
-            var queuedLabel = queuedDaily ? 'queued · 5pm ET' : 'queued';
+            var queuedLabel = queuedDaily ? 'queued · 1pm ET' : 'queued';
             var queuedTitle = queuedDaily
-              ? 'Auto-upgrade will apply ' + esc(branchLatest) + ' at the next 5pm ET window — click to upgrade now' + esc(buildingHint)
+              ? 'Auto-upgrade will apply ' + esc(branchLatest) + ' at the next 1pm ET window — click to upgrade now' + esc(buildingHint)
               : 'Auto-upgrade will apply ' + esc(branchLatest) + ' shortly — click to upgrade now' + esc(buildingHint);
             /* escAttr, not esc, for the title: esc() leaves quotes intact and a
                branch name or commit subject carrying one would break out of the
@@ -10310,7 +10311,7 @@ const dashboardHTML = `<!DOCTYPE html>
              its widest LINE, so as long as no two controls share a line the
              width collapses to the widest single element — which, now that the
              select is icon-only, is the 56px select rather than the ~150px
-             "[queued · 5pm ET] [Auto: daily 5pm ET]" pair that used to set it.
+             "[queued · 1pm ET] [Auto: daily 1pm ET]" pair that used to set it.
                1. the branch pill, which the owner can CHANGE (it is a switcher,
                   so it owns a line and stays a full tap target);
                2. the SHA and its current/behind glyph — two views of the same
@@ -10669,7 +10670,7 @@ const dashboardHTML = `<!DOCTYPE html>
     var AUTO_UPGRADE_OPTIONS = [
       {value: AUTO_UPGRADE_OFF, label: '⦸ off', ariaLabel: 'Auto-upgrade: off'},
       {value: AUTO_UPGRADE_INSTANT, label: '⚡ instant', ariaLabel: 'Auto-upgrade: instantly when a new version lands'},
-      {value: AUTO_UPGRADE_DAILY, label: '🕔 5p', ariaLabel: 'Auto-upgrade: daily at 5pm ET'}
+      {value: AUTO_UPGRADE_DAILY, label: '🕐 1p', ariaLabel: 'Auto-upgrade: daily at 1pm ET'}
     ];
     /* Accessible name for the select itself, resolved from the CURRENT mode so
        the control announces what it is set to rather than only what it does. */
@@ -10708,7 +10709,7 @@ const dashboardHTML = `<!DOCTYPE html>
         });
         if (!resp.ok) { hiveToast('Failed to update auto-upgrade', 'error'); loadHives(); return; }
         var label = !enabled ? 'off'
-          : (mode === AUTO_UPGRADE_DAILY ? 'daily at 5pm ET' : 'instant');
+          : (mode === AUTO_UPGRADE_DAILY ? 'daily at 1pm ET' : 'instant');
         hiveToast(id + ' auto-upgrade: ' + label, 'success');
         loadHives();
       } catch(e) {
@@ -10905,8 +10906,8 @@ const dashboardHTML = `<!DOCTYPE html>
        control height, which is taller.
 
        What actually sets the width now is the LONGEST upgrade label,
-       "queued · 5pm ET" at 90.4px — not the select, which measures 77px. The
-       old width was set by that label and the "Auto: daily 5pm ET" select
+       "queued · 1pm ET" at 90.4px — not the select, which measures 77px. The
+       old width was set by that label and the "Auto: daily 1pm ET" select
        sitting on ONE line together.
 
        Non-owner rows are UNCHANGED: they still get at most two lines (28.9px),
@@ -10937,7 +10938,7 @@ const dashboardHTML = `<!DOCTYPE html>
        to a glyph: 20px tall and at least 56px wide keeps it a comfortable
        pointer and touch target (the row is 63.8px tall, so 20px is roughly a
        third of it — visibly a control, not a decoration) while still being far
-       narrower than the "Auto: daily 5pm ET" string it replaces. Widening it
+       narrower than the "Auto: daily 1pm ET" string it replaces. Widening it
        would give back the column width this change exists to reclaim; making it
        smaller would make it fiddly to hit. */
     var AUTO_SELECT_H_PX = 20;

--- a/v2/pkg/hub/upgrade_schedule.go
+++ b/v2/pkg/hub/upgrade_schedule.go
@@ -18,7 +18,8 @@ import (
 //
 // The product intent is disruption minimisation: a stable, working hive should
 // not be restarted at an arbitrary moment just because a new commit landed.
-// "daily" confines the restart to one predictable after-hours moment per day.
+// "daily" confines the restart to one predictable moment per day, placed
+// inside working hours so a bad roll is caught while someone is around.
 const (
 	// AutoUpgradeModeInstant upgrades as soon as the hive is seen behind latest.
 	// This is the historical behaviour and the meaning of an EMPTY mode, so the
@@ -33,9 +34,25 @@ const (
 )
 
 // autoUpgradeDailyHour is the hour (24h clock, in autoUpgradeTimezone) at or
-// after which a "daily" hive becomes eligible to upgrade. 17 = 5pm ET, chosen
-// as an after-hours moment for the maintainers this hub serves.
-const autoUpgradeDailyHour = 17
+// after which a "daily" hive becomes eligible to upgrade. 13 = 1pm ET.
+//
+// This was 17 (5pm ET), picked as an "after hours" moment so an upgrade would
+// not restart a hive mid-work. That reasoning had it backwards. The restart
+// itself is not the expensive event — a FAILED restart is, and a failure at 5pm
+// surfaces as the maintainer is stopping for the day, turning a bad upgrade
+// into evening or overnight work. 1pm ET puts the window in the middle of the
+// working day: the same once-a-day cadence and the same protection against
+// arbitrary mid-work restarts, but with several staffed hours behind it in
+// which to notice and fix a bad roll.
+//
+// Deliberately a SINGLE daily hour rather than an operator-selectable one. The
+// hour is not persisted per hive (only the generic AutoUpgradeModeDaily string
+// is — see AutoUpgradeMode in saas_provision.go), so every hive already on the
+// daily schedule follows this constant and moves with it, no data migration
+// required. Making the hour selectable would mean persisting it per hive, and
+// would let hives drift back onto a late window and recreate the after-hours
+// failure this constant exists to avoid.
+const autoUpgradeDailyHour = 13
 
 // autoUpgradeTimezone is the IANA zone the daily window is expressed in. It is
 // deliberately a ZONE NAME and not a fixed UTC offset: America/New_York is
@@ -98,7 +115,7 @@ func autoUpgradeLocation() (*time.Location, error) {
 type autoUpgradeDecision struct {
 	Allowed bool
 	// FireDate is the ET calendar day the upgrade is being attributed to.
-	// Persisting it is what makes a 17:02 cycle and a 17:04 cycle collapse
+	// Persisting it is what makes a 13:02 cycle and a 13:04 cycle collapse
 	// into a single upgrade for the day.
 	FireDate string
 	// Reason is a short, log-friendly explanation. Always populated.
@@ -114,10 +131,10 @@ type autoUpgradeDecision struct {
 // now is injected so the behaviour is testable without touching the wall clock.
 //
 // Missed windows deliberately do NOT accumulate. If the hub is down across
-// 17:00 and comes back at 21:30, the hive upgrades on the next cycle it sees
+// 13:00 and comes back at 21:30, the hive upgrades on the next cycle it sees
 // (it is still behind, and the day's window has passed) and then resumes the
 // normal daily cadence. The alternative — waiting a further ~20 hours for the
-// next 17:00 — would leave a hive knowingly behind for a full extra day, which
+// next 13:00 — would leave a hive knowingly behind for a full extra day, which
 // defeats the point of having auto-upgrade enabled at all. Only ONE upgrade is
 // ever owed, because the gate is "have we fired today", not a queue of windows.
 func shouldAutoUpgradeNow(mode, lastFiredDate string, now time.Time) autoUpgradeDecision {

--- a/v2/pkg/hub/upgrade_schedule_test.go
+++ b/v2/pkg/hub/upgrade_schedule_test.go
@@ -65,11 +65,11 @@ func TestShouldAutoUpgradeNow(t *testing.T) {
 		{
 			name:        "daily before the window does not fire",
 			mode:        AutoUpgradeModeDaily,
-			now:         mustET(t, 2026, time.July, 15, 16, 59),
+			now:         mustET(t, 2026, time.July, 15, autoUpgradeDailyHour-1, 59),
 			wantAllowed: false,
 		},
 		{
-			name:        "daily exactly at 17:00 fires",
+			name:        "daily exactly at the window hour fires",
 			mode:        AutoUpgradeModeDaily,
 			now:         mustET(t, 2026, time.July, 15, autoUpgradeDailyHour, 0),
 			wantAllowed: true,
@@ -78,15 +78,15 @@ func TestShouldAutoUpgradeNow(t *testing.T) {
 		{
 			name:        "daily after the window fires",
 			mode:        AutoUpgradeModeDaily,
-			now:         mustET(t, 2026, time.July, 15, 17, 2),
+			now:         mustET(t, 2026, time.July, 15, autoUpgradeDailyHour, 2),
 			wantAllowed: true,
 			wantFire:    "2026-07-15",
 		},
 		{
-			name:        "daily already fired today does not fire again at 17:04",
+			name:        "daily already fired today does not fire again minutes later",
 			mode:        AutoUpgradeModeDaily,
 			lastFired:   "2026-07-15",
-			now:         mustET(t, 2026, time.July, 15, 17, 4),
+			now:         mustET(t, 2026, time.July, 15, autoUpgradeDailyHour, 4),
 			wantAllowed: false,
 		},
 		{
@@ -100,7 +100,7 @@ func TestShouldAutoUpgradeNow(t *testing.T) {
 			name:        "daily fires again the next day",
 			mode:        AutoUpgradeModeDaily,
 			lastFired:   "2026-07-15",
-			now:         mustET(t, 2026, time.July, 16, 17, 0),
+			now:         mustET(t, 2026, time.July, 16, autoUpgradeDailyHour, 0),
 			wantAllowed: true,
 			wantFire:    "2026-07-16",
 		},
@@ -139,7 +139,7 @@ func TestShouldAutoUpgradeNow(t *testing.T) {
 
 // TestShouldAutoUpgradeNowDST is the reason autoUpgradeTimezone is a ZONE NAME
 // and not a fixed offset. On these dates a hardcoded UTC-5 or UTC-4 would put
-// the 17:00 boundary an hour off, firing early or holding a hive an extra day.
+// the daily boundary an hour off, firing early or holding a hive an extra day.
 // Each case asserts on a wall-clock ET time that is only correct if the offset
 // is resolved from tzdata.
 func TestShouldAutoUpgradeNowDST(t *testing.T) {
@@ -152,50 +152,50 @@ func TestShouldAutoUpgradeNowDST(t *testing.T) {
 		{
 			// Spring forward 2026: DST begins Sunday March 8. The day before is
 			// still EST (UTC-5).
-			name:        "day before spring forward is EST, 16:59 holds",
-			now:         mustET(t, 2026, time.March, 7, 16, 59),
+			name:        "day before spring forward is EST, the minute before holds",
+			now:         mustET(t, 2026, time.March, 7, autoUpgradeDailyHour-1, 59),
 			wantOffset:  -5 * 60 * 60,
 			wantAllowed: false,
 		},
 		{
-			name:        "day before spring forward is EST, 17:00 fires",
+			name:        "day before spring forward is EST, the window fires",
 			now:         mustET(t, 2026, time.March, 7, autoUpgradeDailyHour, 0),
 			wantOffset:  -5 * 60 * 60,
 			wantAllowed: true,
 		},
 		{
-			// After the transition the same wall-clock 17:00 is EDT (UTC-4).
+			// After the transition the same wall-clock hour is EDT (UTC-4).
 			// A hardcoded -5 offset would treat this instant as 16:00 and hold.
-			name:        "day after spring forward is EDT, 17:00 still fires",
+			name:        "day after spring forward is EDT, the window still fires",
 			now:         mustET(t, 2026, time.March, 9, autoUpgradeDailyHour, 0),
 			wantOffset:  -4 * 60 * 60,
 			wantAllowed: true,
 		},
 		{
-			name:        "day after spring forward is EDT, 16:59 still holds",
-			now:         mustET(t, 2026, time.March, 9, 16, 59),
+			name:        "day after spring forward is EDT, the minute before still holds",
+			now:         mustET(t, 2026, time.March, 9, autoUpgradeDailyHour-1, 59),
 			wantOffset:  -4 * 60 * 60,
 			wantAllowed: false,
 		},
 		{
 			// Fall back 2026: DST ends Sunday November 1. The day before is EDT.
-			name:        "day before fall back is EDT, 17:00 fires",
+			name:        "day before fall back is EDT, the window fires",
 			now:         mustET(t, 2026, time.October, 31, autoUpgradeDailyHour, 0),
 			wantOffset:  -4 * 60 * 60,
 			wantAllowed: true,
 		},
 		{
-			// After the transition 17:00 is EST again. A hardcoded -4 offset
-			// would treat this as 18:00 — still firing, but the 16:59 case
+			// After the transition the window hour is EST again. A hardcoded -4 offset
+			// would treat this as an hour later — still firing, but the minute-before case
 			// below is what a wrong offset actually breaks.
-			name:        "day after fall back is EST, 17:00 fires",
+			name:        "day after fall back is EST, the window fires",
 			now:         mustET(t, 2026, time.November, 2, autoUpgradeDailyHour, 0),
 			wantOffset:  -5 * 60 * 60,
 			wantAllowed: true,
 		},
 		{
-			name:        "day after fall back is EST, 16:59 holds",
-			now:         mustET(t, 2026, time.November, 2, 16, 59),
+			name:        "day after fall back is EST, the minute before holds",
+			now:         mustET(t, 2026, time.November, 2, autoUpgradeDailyHour-1, 59),
 			wantOffset:  -5 * 60 * 60,
 			wantAllowed: false,
 		},

--- a/v2/pkg/hub/version_column_stack_test.go
+++ b/v2/pkg/hub/version_column_stack_test.go
@@ -84,14 +84,14 @@ func TestAutoUpgradeSelectIsIconOnlyButStillLabelled(t *testing.T) {
 	html := dashboardHTML
 
 	// Icon-only labels, with the short values the product owner specified.
-	for _, want := range []string{"'⦸ off'", "'⚡ instant'", "'🕔 5p'"} {
+	for _, want := range []string{"'⦸ off'", "'⚡ instant'", "'🕐 1p'"} {
 		if !strings.Contains(html, want) {
 			t.Errorf("auto-upgrade option label %s is missing; the control is not icon-only", want)
 		}
 	}
 	// The verbose inline label must be gone from the OPTIONS. Its words now live
 	// in the tooltip and the accessible name instead.
-	for _, gone := range []string{"'Auto: off'", "'Auto: instant'", "'Auto: daily 5pm ET'"} {
+	for _, gone := range []string{"'Auto: off'", "'Auto: instant'", "'Auto: daily 1pm ET'"} {
 		if strings.Contains(html, gone) {
 			t.Errorf("auto-upgrade option still carries the verbose label %s; that string "+
 				"was the widest single element in the Version column", gone)
@@ -101,7 +101,7 @@ func TestAutoUpgradeSelectIsIconOnlyButStillLabelled(t *testing.T) {
 	for _, want := range []string{
 		"ariaLabel: 'Auto-upgrade: off'",
 		"ariaLabel: 'Auto-upgrade: instantly when a new version lands'",
-		"ariaLabel: 'Auto-upgrade: daily at 5pm ET'",
+		"ariaLabel: 'Auto-upgrade: daily at 1pm ET'",
 	} {
 		if !strings.Contains(html, want) {
 			t.Errorf("an auto-upgrade option has no full-meaning label (%s); icon-only "+


### PR DESCRIPTION
## Why

The daily auto-upgrade window fired at **17:00 ET**, chosen as an "after hours" moment so a rolling upgrade would not restart a hive mid-work.

That reasoning had the risk backwards. The restart is not the expensive event — a **failed** restart is. A failure at 5pm surfaces exactly as the maintainer is stopping for the day, converting a bad roll into evening or overnight work.

This moves the window to **13:00 ET (1pm)**. Same once-a-day cadence and the same protection against arbitrary mid-work restarts, but with several staffed hours behind it in which to notice and fix a bad upgrade.

## The load-bearing change

`v2/pkg/hub/upgrade_schedule.go` — `autoUpgradeDailyHour`, `17` → `13`. This is the constant `shouldAutoUpgradeNow()` gates on (`local.Hour() < autoUpgradeDailyHour`). Everything else in this PR is cosmetic labels and tests that follow it.

The hour was already a named constant, so there was no magic number to extract. The three tests that hardcoded `17` / `16:59` as the window boundary **are** now rewritten relative to `autoUpgradeDailyHour`, so they track the constant instead of rotting against the next change to it.

## No data migration required

The hour is **not persisted per hive**. A hive on the daily schedule stores only the generic `AutoUpgradeModeDaily` string (`\"daily\"`) in its `meta.json` under `/data/saas/hives/<id>/`; the hour lives solely in the constant.

Every hive already on the daily schedule therefore moves to 1pm on deploy, with **no rewrite of any PVC record** and nothing to run idempotently. `auto_upgrade_last_fired` keeps working unchanged — it stores an ET calendar day, not a time.

## Replacing 5pm rather than offering both — deliberate

The ask was to add 1pm and migrate everyone off 5pm, leaving open whether 5pm stays selectable. **It does not**, for two reasons:

1. **Offering both is not cheap here.** The mode is a single opaque string. A second daily mode means a new enum value, a new allowlist entry, a new branch in `normalizeAutoUpgradeMode`, an hour-resolution function replacing the constant, a fourth select option, and a second bulk button — *and* a real data migration, because existing records store `\"daily\"` and would have to be rewritten to one variant or the other. Keeping one mode is what makes this a zero-migration change.
2. **A selectable 5pm recreates the problem.** The goal is no night work; leaving the late window on the menu lets hives drift straight back onto it.

If a per-hive custom hour is ever genuinely wanted, that is a different feature (persist the hour, migrate the existing records) and should be built as one.

## Unchanged

Timezone handling is untouched: still the `America/New_York` **zone name**, never a fixed UTC offset, so the DST transitions in March and November are still handled correctly. The DST regression tests still pass, now anchored to the constant.

## Surfaces updated

Both the per-row `auto-upgrade-select` and the bulk-action buttons:

- bulk button label `Auto: daily 5pm ET` → `Auto: daily 1pm ET`, and its tooltip ("after hours" → "midday … puts a bad roll in staffed hours")
- bulk confirm string `Enable daily 5pm ET auto-upgrade on`
- per-row select option `🕔 5p` → `🕐 1p`, plus its `ariaLabel`
- `queuedLabel` (`queued · 5pm ET`) and the queued tooltip (`next 5pm ET window`)
- the `setAutoUpgradeMode` toast label
- stale `17:00` / `5pm` references in comments, including the daily-mode note in `saas.go`

`grep -c 5pm` over the extracted dashboard JS is now **0**.

## Overlap with #2309

#2309 (upgrade-state facet filters + elapsed-time counters) touches the same `queuedLabel` / queued-tooltip lines. It **landed while this was in progress**; this branch is rebased on top of it and builds on its version rather than reverting it. I re-verified after the rebase that it reintroduced no `5pm` strings.

## Verification

Verified by running:
- `go build ./...` — clean
- `go test ./pkg/hub/` — **ok** (re-run after the rebase onto #2309). Two DST cases legitimately failed first, having hardcoded `16:59` as "just before the window"; fixed to be hour-relative.
- `gofmt -l` on all four changed files — clean
- **`dashboardHTML` JS brace/paren delta, base-vs-current: zero on every class** against the post-#2309 base — `{`1219/`}`1219, `(`4604/`)`4605, `[`552/`]`553 in both. (The asymmetric paren/bracket counts are the known regex-literal artifact and are identical in base and current, which is the condition that matters.)
- Grepped the extracted JS to confirm all 12 label sites are present and 0 `5pm` remain.
- No backtick introduced inside the raw string; `<body>` occurrence count unchanged from base (3, pre-existing).

Assumed, not verified: that no hive currently relies on the 5pm timing for an external reason (a maintenance window coordinated elsewhere). No live hive settings were mutated — this is a code change to be applied by deploying.