### PR TITLE
✨ feat(hub): default hives A-Z, add provision-date sort, persist sort + scroll

### DIFF
--- a/v2/pkg/hub/hive_access_avatars_test.go
+++ b/v2/pkg/hub/hive_access_avatars_test.go
@@ -178,15 +178,17 @@ func TestHoverPanelReusesSharedRoleColor(t *testing.T) {
 // section-header colspan and the pending-expand colspan all stay correct; a
 // stale count leaves the table visibly ragged.
 //
-// 17 = the 16 columns left after the standalone Public column was folded into
+// 18 = the 16 columns left after the standalone Public column was folded into
 // Location (visibility stacks beneath the location badge), plus the AI Author
-// column added with App-bot PR authorship. TestHiveTableColumnCountsAgree is
-// the authority on this number: it counts the emitted <th> and <td> cells
-// rather than trusting a literal, so update it first and follow it here.
+// column added with App-bot PR authorship, plus the Provisioned column that
+// exposes each hive's first-seen time as a sort option.
+// TestHiveTableColumnCountsAgree is the authority on this number: it counts the
+// emitted <th> and <td> cells rather than trusting a literal, so update it
+// first and follow it here.
 func TestHiveTableColumnCountUnchanged(t *testing.T) {
 	for _, snippet := range []string{
-		"var TOTAL_COLUMNS = 17;",
-		"var TOTAL_COLUMNS_HEADER = 17;",
+		"var TOTAL_COLUMNS = 18;",
+		"var TOTAL_COLUMNS_HEADER = 18;",
 	} {
 		if !strings.Contains(dashboardHTML, snippet) {
 			t.Errorf("dashboardHTML is missing %q — did the hive table gain or lose a column?", snippet)

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -7713,7 +7713,12 @@ const dashboardHTML = `<!DOCTYPE html>
     var _clusterList = [];
     var _commitMessages = {};
     var _allDashHives = [];
-    var _dashSortKey = '', _dashSortAsc = true;
+    /* Seeded to the A-Z default rather than '' (registry/arrival order) so the
+       very first paint — including paintCachedHives, which runs before any
+       network call — is already alphabetical. loadHiveSortPrefs overwrites both
+       from localStorage when the operator has a stored choice; see
+       HIVE_SORT_DEFAULT_KEY for why a stored choice wins over this default. */
+    var _dashSortKey = 'name', _dashSortAsc = true;
     var _hivesLoading = false;
     var _lastHivesJSON = '';
     var _lastUsersJSON = '';
@@ -7934,6 +7939,35 @@ const dashboardHTML = `<!DOCTYPE html>
     var LS_HIVE_GROUP_COLLAPSED = 'hive-group-collapsed';
     var LS_HIVE_SAVED_VIEWS = 'hive-saved-views';
     var LS_HIVE_DEFAULT_VIEW = 'hive-default-view';
+    var LS_HIVE_SORT = 'hive-sort';
+    var LS_HIVE_SCROLL = 'hive-scroll';
+
+    /* HIVE_SORT_DEFAULT_KEY is the sort a FIRST-TIME visitor gets: the Hive
+       column, ascending — i.e. plain A-Z over the label the name cell actually
+       displays (see hiveNameSortValue / hiveLabel). Before this the table
+       rendered in registry order, which is arrival order and looks arbitrary.
+
+       This is a DEFAULT, not an override: loadHiveSortPrefs applies it only
+       when there is no usable stored choice, so an operator who sorted by
+       Tokens still returns to Tokens. */
+    var HIVE_SORT_DEFAULT_KEY = 'name';
+    var HIVE_SORT_DEFAULT_ASC = true;
+
+    /* HIVE_SORT_KEYS is every key a header can sort by — the allowlist that a
+       persisted value is validated against. A stored key that is no longer a
+       column (a renamed field, a hand-edited value, a downgrade) degrades to
+       the A-Z default instead of silently sorting on an absent property, which
+       reads as "sorting is broken" because every row compares equal. */
+    var HIVE_SORT_KEYS = ['name', 'clusterId', 'startedAt', 'acmmLevel', 'aiAuthor',
+      'journey', 'agentCount', 'totalTokens24h', 'governorMode', 'actionableIssues',
+      'actionablePRs', 'activeContributors', 'registeredAt'];
+
+    function isHiveSortKey(key) {
+      for (var i = 0; i < (HIVE_SORT_KEYS || []).length; i++) {
+        if (HIVE_SORT_KEYS[i] === key) return true;
+      }
+      return false;
+    }
 
     /* Cap on stored saved views. localStorage is a small shared budget and an
        unbounded list would let one runaway page fill it for every other
@@ -9294,6 +9328,30 @@ const dashboardHTML = `<!DOCTYPE html>
       bar.innerHTML = '<div class="view-ctls">' + groupCtl + '</div><div class="view-ctls">' + viewCtl + '</div>';
     }
 
+    /* hiveProvisionTime returns when this hive came into existence, as epoch
+       ms, or null when that is genuinely unknown.
+
+       Why registeredAt and NOT the per-hive meta.json created_at: created_at is
+       declared on SaaSHive and written on exactly one provisioning path, so
+       every hive that predates it — or that was created any other way — carries
+       the empty string. On the live fleet at the time of writing, 26 of 50
+       meta.json files have "created_at": "", including long-running assigned
+       hives, while registeredAt was populated on 50 of 50 registry entries.
+       registeredAt is also preserved across heartbeats (server.go copies it
+       from the previous entry rather than restamping it), so it stays the
+       first-seen time instead of drifting to "now" on every beat.
+
+       Returns null — never NaN and never a rendered 'Invalid Date' — for a
+       missing or unparseable value, so the caller can order those rows
+       explicitly instead of comparing against NaN, which is false in both
+       directions and would make the sort non-deterministic. */
+    function hiveProvisionTime(h) {
+      var raw = h && h.registeredAt;
+      if (typeof raw !== 'string' || !raw) return null;
+      var t = Date.parse(raw);
+      return isNaN(t) ? null : t;
+    }
+
     /* sortedDashHives applies the CURRENT sort key/direction to the unfiltered
        cache. Split out of sortDashHives so restoring a saved view (which sets
        the key/direction directly rather than by clicking a header) reproduces
@@ -9310,6 +9368,23 @@ const dashboardHTML = `<!DOCTYPE html>
           var ja = journeySortValue(a && a.journey);
           var jb = journeySortValue(b && b.journey);
           return _dashSortAsc ? ja - jb : jb - ja;
+        }
+        if (key === 'registeredAt') {
+          /* Provision time. Compared as epoch ms, not as text: registeredAt is
+             RFC3339 so it happens to sort lexically today, but a value that
+             ever arrives with an offset ('...+02:00') or without the 'Z' would
+             collate wrong, and a string compare cannot express "unknown last".
+
+             Hives with no parseable timestamp sort LAST in both directions
+             rather than clumping at whichever end '' collates to — they are
+             the least informative rows, so they stay out of the way whether
+             the operator asked for oldest-first or newest-first. */
+          var ra = hiveProvisionTime(a);
+          var rb2 = hiveProvisionTime(b);
+          if (ra === null && rb2 === null) return 0;
+          if (ra === null) return 1;
+          if (rb2 === null) return -1;
+          return _dashSortAsc ? ra - rb2 : rb2 - ra;
         }
         var va = key === 'name' ? hiveNameSortValue(a) : ((a && a[key]) || '');
         var vb = key === 'name' ? hiveNameSortValue(b) : ((b && b[key]) || '');
@@ -9375,7 +9450,118 @@ const dashboardHTML = `<!DOCTYPE html>
 
     function sortDashHives(key) {
       if (_dashSortKey === key) { _dashSortAsc = !_dashSortAsc; } else { _dashSortKey = key; _dashSortAsc = true; }
+      persistHiveSort();
       renderHives(sortedDashHives(), true);
+    }
+
+    /* persistHiveSort records the operator's EXPLICIT sort choice. Written only
+       from sortDashHives (a header click), never from loadHiveSortPrefs, so
+       restoring a preference can't rewrite it and a first visit leaves the key
+       absent rather than storing the default — which is what lets
+       loadHiveSortPrefs tell "never chose" apart from "chose the default". */
+    function persistHiveSort() {
+      lsSetJSON(LS_HIVE_SORT, {key: _dashSortKey, asc: _dashSortAsc});
+    }
+
+    /* ---- Scroll position across refresh --------------------------------
+       "Location on page" is the WINDOW's scroll offset, not a container's:
+       .table-wrap is overflow:visible at desktop widths (it only becomes an
+       overflow-x scroller in the narrow media query, and that axis is
+       horizontal), so the hive list scrolls the document itself.
+
+       Writes are throttled through requestAnimationFrame because scroll fires
+       at input rate and localStorage.setItem is synchronous — persisting on
+       every event would jank the scroll it is trying to record. */
+    var HIVE_SCROLL_MAX_AGE_MS = 30 * 60 * 1000; /* 30 min — see readHiveScroll */
+    var HIVE_SCROLL_RESTORE_FRAMES = 3;          /* see restoreHiveScroll */
+    var _hiveScrollWritePending = false;
+    var _hiveScrollRestored = false;
+
+    function persistHiveScroll() {
+      if (_hiveScrollWritePending) return;
+      _hiveScrollWritePending = true;
+      window.requestAnimationFrame(function() {
+        _hiveScrollWritePending = false;
+        var y = window.pageYOffset || document.documentElement.scrollTop || 0;
+        lsSetJSON(LS_HIVE_SCROLL, {y: y, t: Date.now()});
+      });
+    }
+
+    /* readHiveScroll returns the stored offset, or 0 when there is nothing
+       usable. Stale entries are discarded: coming back to the dashboard after
+       hours, the fleet has changed underneath and the old offset points at
+       unrelated rows, so landing at the top is the honest result. Guards the
+       shape too — a hand-edited or truncated value must not yield NaN, which
+       window.scrollTo would silently treat as 0 anyway but which would also
+       poison the comparison below. */
+    function readHiveScroll() {
+      var s = lsGetJSON(LS_HIVE_SCROLL, null);
+      if (!s || typeof s !== 'object') return 0;
+      var y = Number(s.y), t = Number(s.t);
+      if (!isFinite(y) || y <= 0) return 0;
+      if (!isFinite(t) || (Date.now() - t) > HIVE_SCROLL_MAX_AGE_MS) return 0;
+      return y;
+    }
+
+    /* restoreHiveScroll re-applies the saved offset ONCE per page load.
+
+       Why not a single scrollTo at init: the rows are painted asynchronously
+       (paintCachedHives, then loadHives' await, then renderHives), and the
+       document is only as tall as what has been painted so far. Scrolling to
+       y before the table exists clamps to the current maximum — silently
+       landing at the top, which is exactly the bug this is meant to fix.
+
+       So it retries across a few animation frames and stops as soon as the
+       document is actually tall enough for the offset to survive, which is the
+       observable definition of "the rows have rendered". The frame budget is
+       small and bounded so a genuinely shorter list (hives removed since) costs
+       three frames and then gives up rather than fighting the user forever. */
+    function restoreHiveScroll() {
+      if (_hiveScrollRestored) return;
+      var y = readHiveScroll();
+      if (!y) { _hiveScrollRestored = true; return; }
+      var attempts = 0;
+      var tryScroll = function() {
+        var maxY = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+        if (maxY >= y) {
+          window.scrollTo(0, y);
+          _hiveScrollRestored = true;
+          return;
+        }
+        if (++attempts >= HIVE_SCROLL_RESTORE_FRAMES) {
+          /* Never tall enough — go as far as the page allows so the operator
+             at least lands near where they were. */
+          window.scrollTo(0, maxY);
+          _hiveScrollRestored = true;
+          return;
+        }
+        window.requestAnimationFrame(tryScroll);
+      };
+      window.requestAnimationFrame(tryScroll);
+    }
+
+    /* loadHiveSortPrefs resolves the stored sort against the A-Z default.
+
+       Precedence: a PERSISTED choice wins, the default applies only when there
+       is nothing usable stored — first visit, cleared storage, or a value that
+       no longer validates. Applying A-Z unconditionally would undo the operator's
+       choice on every refresh, which is the exact complaint this fixes.
+
+       Every failure mode degrades to the default rather than throwing: lsGetJSON
+       already swallows disabled storage and malformed JSON, and isHiveSortKey
+       rejects a stale key so a removed column cannot leave the table sorting on
+       a property no row has. */
+    function loadHiveSortPrefs() {
+      var stored = lsGetJSON(LS_HIVE_SORT, null);
+      if (stored && typeof stored === 'object' && isHiveSortKey(stored.key)) {
+        _dashSortKey = stored.key;
+        /* Only an explicit false flips direction — a stored object missing
+           'asc' still means ascending. */
+        _dashSortAsc = stored.asc !== false;
+        return;
+      }
+      _dashSortKey = HIVE_SORT_DEFAULT_KEY;
+      _dashSortAsc = HIVE_SORT_DEFAULT_ASC;
     }
 
     /* ---- Usage attribution panel ----------------------------------------
@@ -10339,11 +10525,11 @@ const dashboardHTML = `<!DOCTYPE html>
           pendingPill = '<a href="#" onclick="togglePendingRow(\'' + esc(h.id) + '\');return false" style="display:inline-flex;align-items:center;gap:4px;padding:3px 10px;background:rgba(59,130,246,0.12);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);border-radius:4px;font-size:0.7rem;text-decoration:none;cursor:pointer;white-space:nowrap">&#x1F514; ' + h.pendingRequestCount + ' pending</a>';
         }
         // 16 = the 13 original columns, plus Uptime, plus Drift, plus the
-        // bulk-select column, plus Journey, MINUS Public — visibility now
-        // stacks under Location instead of owning a column. Counted against
-        // the <th> cells in the header and the <td> cells emitted below
-        // (bulkCheckboxCell contributes one).
-        var TOTAL_COLUMNS = 17;
+        // bulk-select column, plus Journey, plus Provisioned, MINUS Public —
+        // visibility now stacks under Location instead of owning a column.
+        // Counted against the <th> cells in the header and the <td> cells
+        // emitted below (bulkCheckboxCell contributes one).
+        var TOTAL_COLUMNS = 18;
         /* Visibility moved OUT of its own column and under Location: "where
            does this hive run" and "who can see it" are both facts about the
            hive's placement, so they read as one cell, and folding them saves a
@@ -10461,6 +10647,13 @@ const dashboardHTML = `<!DOCTYPE html>
           '<td>' + sparkline(h.issueHistory, '#f59e0b', 50, 14) + (h.actionableIssues || 0) + '</td>' +
           '<td>' + sparkline(h.prHistory, '#3b82f6', 50, 14) + (h.actionablePRs || 0) + '</td>' +
           '<td>' + (h.activeContributors || 0) + '</td>' +
+          /* Provisioned. hiveProvisionTime is the single source of truth for
+             "is this timestamp usable" — reusing it here keeps the cell and the
+             comparator from ever disagreeing (a row showing a date but sorting
+             as unknown, or the reverse). An em dash, never 'Invalid Date', for
+             a hive whose registeredAt is missing or unparseable. */
+          '<td style="font-size:0.75rem;color:var(--muted);white-space:nowrap">' +
+            (hiveProvisionTime(h) === null ? '—' : esc(fmtUserTS(h.registeredAt))) + '</td>' +
           '</tr>' + pendingExpandRow;
       };
       /* Section-header row: a labeled separator spanning all columns, styled to
@@ -10468,9 +10661,10 @@ const dashboardHTML = `<!DOCTYPE html>
       /* Count of <th> cells in the hive table header below. The section-header
          row spans all of them; a stale value would leave the separator short
          and the table visibly ragged. 15 with the Drift column, plus the
-         bulk-select column, plus the Journey column, minus Public (visibility
-         is stacked under Location). Must stay equal to TOTAL_COLUMNS. */
-      var TOTAL_COLUMNS_HEADER = 17;
+         bulk-select column, plus the Journey column, plus the Provisioned
+         column, minus Public (visibility is stacked under Location). Must stay
+         equal to TOTAL_COLUMNS. */
+      var TOTAL_COLUMNS_HEADER = 18;
       /* The header is a click target that expands/collapses its section. The
          caret mirrors aria-expanded so the affordance and the a11y state can
          never disagree. sectionKey also scopes the select-all checkbox to THIS
@@ -10605,7 +10799,7 @@ const dashboardHTML = `<!DOCTYPE html>
         /* Non-admin lists have no section headers, so the flat list's
            select-all lives in the table head instead. */
         '<th style="width:26px;text-align:center">' + (_isAdmin ? '' : bulkSectionCheckbox('all')) + '</th>' +
-        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer" title="Where this hive runs, and whether it is listed publicly">Location / Public ⇅</th><th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'aiAuthor\')" style="cursor:pointer" title="The GitHub identity this hive\'s agents open PRs as — the configured ai_author, or the App bot (&lt;slug&gt;[bot]) in App-authored mode">AI Author ⇅</th><th onclick="sortDashHives(\'journey\')" style="cursor:pointer" title="Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run ClankeR, the contributor relay), then raise the ACMM level">Journey ⇅</th><th title="Configuration drift from the fleet norm — hover a value for the specific signals">Drift</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
+        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer" title="Where this hive runs, and whether it is listed publicly">Location / Public ⇅</th><th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'aiAuthor\')" style="cursor:pointer" title="The GitHub identity this hive\'s agents open PRs as — the configured ai_author, or the App bot (&lt;slug&gt;[bot]) in App-authored mode">AI Author ⇅</th><th onclick="sortDashHives(\'journey\')" style="cursor:pointer" title="Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run ClankeR, the contributor relay), then raise the ACMM level">Journey ⇅</th><th title="Configuration drift from the fleet norm — hover a value for the specific signals">Drift</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th><th onclick="sortDashHives(\'registeredAt\')" style="cursor:pointer" title="When this hive was first provisioned — the hub&apos;s first-seen time, preserved across restarts and heartbeats">Provisioned ⇅</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table></div>';
       /* Delegated, so binding once is enough no matter how often the table is
          re-rendered. The guard keeps repeated renders from stacking listeners. */
@@ -12278,15 +12472,29 @@ const dashboardHTML = `<!DOCTYPE html>
          already reflects the operator's view rather than flashing the ungrouped
          list and then rearranging. */
       loadDashViewPrefs();
+      /* Sort is resolved AFTER loadDashViewPrefs because applying a default
+         saved view sets a key/direction of its own: the operator's explicitly
+         stored sort is the more specific signal and must have the last word.
+         Both run before the first paint so no render happens in the wrong
+         order. */
+      loadHiveSortPrefs();
       /* Progressive paint: put the last known fleet on screen immediately so a
          returning operator sees their hives instead of a spinner. The network
          path below still runs unconditionally and reconciles the list; this
          only changes what fills the gap while it is in flight. Must come after
          loadDashViewPrefs() so the cached rows honour the active view. */
       paintCachedHives();
+      /* Record the offset from here on. Attached before the awaits below so a
+         scroll during a slow load is still captured. */
+      window.addEventListener('scroll', persistHiveScroll, {passive: true});
       await loadUser();
       await autoRequestAccessFromUrl();
       await loadHives();
+      /* Restore AFTER the real rows are in the DOM — loadHives' renderHives is
+         what gives the document its full height, and restoreHiveScroll still
+         waits for that height before it commits (see its frame loop). Calling
+         it any earlier clamps the offset to a short page and lands at the top. */
+      restoreHiveScroll();
       await loadAdminUsers();
       if (!_adminLoaded) setTimeout(loadAdminUsers, 2000);
       loadClusterHealth();

--- a/v2/pkg/hub/saas_dashboard_facet_tray_test.go
+++ b/v2/pkg/hub/saas_dashboard_facet_tray_test.go
@@ -114,8 +114,8 @@ func TestStatusFiltersMovedIntoTray(t *testing.T) {
 	}
 	// Semantics unchanged: same state, same predicate, same handlers.
 	for _, want := range []string{
-		"_dashStatusFilters",       // health chips still OR among themselves
-		"_dashFailingCheckFilter",  // failing check still single-select, ANDed
+		"_dashStatusFilters",      // health chips still OR among themselves
+		"_dashFailingCheckFilter", // failing check still single-select, ANDed
 		"toggleStatusFilter(",
 		"setFailingCheckFilter(",
 	} {
@@ -340,19 +340,20 @@ func TestHiveTableColumnCountsAgree(t *testing.T) {
 		t.Errorf("header emits %d <th> cells but a row emits %d cells — "+
 			"every column right of the mismatch is shifted", thCount, tdCount)
 	}
-	// 17: the Public column was folded into Location (visibility stacks beneath
-	// the location badge) leaving 16 — see the Location cell in buildRow — and
-	// the AI Author column was then added alongside ACMM to show the GitHub
-	// identity a hive's agents open PRs as.
-	const wantColumns = 17
+	// 18: the Public column was folded into Location (visibility stacks beneath
+	// the location badge) leaving 16 — see the Location cell in buildRow — the
+	// AI Author column was then added alongside ACMM to show the GitHub
+	// identity a hive's agents open PRs as, and Provisioned was added at the
+	// end so the fleet can be ordered by when each hive was first seen.
+	const wantColumns = 18
 	if thCount != wantColumns {
 		t.Errorf("hive table has %d columns, want %d", thCount, wantColumns)
 	}
 	// The colspan constants span the whole table; a stale value leaves the
 	// section separators and the pending-requests row visibly short.
 	for _, decl := range []string{
-		"var TOTAL_COLUMNS = 17;",
-		"var TOTAL_COLUMNS_HEADER = 17;",
+		"var TOTAL_COLUMNS = 18;",
+		"var TOTAL_COLUMNS_HEADER = 18;",
 	} {
 		if !strings.Contains(html, decl) {
 			t.Errorf("missing or stale colspan constant: %s", decl)

--- a/v2/pkg/hub/saas_dashboard_hive_sort_test.go
+++ b/v2/pkg/hub/saas_dashboard_hive_sort_test.go
@@ -1,0 +1,145 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// The hive-table sort and the scroll/sort persistence live inside the
+// dashboardHTML raw string, so there is no Go function to call. These tests
+// guard the wiring the same way the neighbouring dashboard tests do: every
+// handler the markup references must exist, and the invariants that are silent
+// when broken must stay asserted somewhere CI runs.
+//
+// "Silent when broken" is the whole point here. If the default sort key stops
+// being 'name', or a persisted choice starts being overwritten by the default,
+// or the scroll restore moves back ahead of the render that gives the document
+// its height, nothing throws — the table just quietly ignores the operator.
+
+// TestHiveSortDefaultsToAlphabetical pins the first-visit ordering to the Hive
+// column, ascending. Before this the table rendered in registry order, which is
+// arrival order and reads as arbitrary.
+func TestHiveSortDefaultsToAlphabetical(t *testing.T) {
+	html := dashScript(t)
+	for _, snippet := range []string{
+		"var HIVE_SORT_DEFAULT_KEY = 'name';",
+		"var HIVE_SORT_DEFAULT_ASC = true;",
+		// The state seed must match the default so the very first paint —
+		// paintCachedHives, which runs before any network call — is already A-Z.
+		"var _dashSortKey = 'name', _dashSortAsc = true;",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("dashboardHTML is missing %q — the default hive sort is no longer A-Z", snippet)
+		}
+	}
+}
+
+// TestHiveSortPersistenceWiring asserts the persisted choice survives a reload
+// and, critically, that the A-Z default does NOT clobber it.
+func TestHiveSortPersistenceWiring(t *testing.T) {
+	html := dashScript(t)
+	for _, snippet := range []string{
+		"var LS_HIVE_SORT = 'hive-sort';",
+		"function persistHiveSort()",
+		"function loadHiveSortPrefs()",
+		// A header click must record the choice, otherwise nothing is ever
+		// persisted and the reload silently falls back to the default.
+		"persistHiveSort();",
+		// The stored value is validated before use, so a stale key degrades to
+		// the default instead of sorting on a property no row has.
+		"function isHiveSortKey(key)",
+		"isHiveSortKey(stored.key)",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("dashboardHTML is missing %q — hive sort persistence is not wired", snippet)
+		}
+	}
+
+	// loadHiveSortPrefs must run at init, AFTER loadDashViewPrefs: applying a
+	// default saved view sets a sort of its own, and the operator's explicit
+	// stored sort is the more specific signal, so it has to have the last word.
+	viewIdx := strings.Index(html, "loadDashViewPrefs();")
+	sortIdx := strings.Index(html, "loadHiveSortPrefs();")
+	if viewIdx < 0 || sortIdx < 0 {
+		t.Fatal("init no longer calls loadDashViewPrefs()/loadHiveSortPrefs()")
+	}
+	if sortIdx < viewIdx {
+		t.Error("loadHiveSortPrefs() runs before loadDashViewPrefs() — a default saved view would override the operator's explicit sort")
+	}
+}
+
+// TestHiveScrollRestoreRunsAfterRender is the ordering guard. The rows paint
+// asynchronously, and the document is only as tall as what has been painted, so
+// scrolling before the table exists clamps to the current maximum and silently
+// lands at the top — the exact bug the feature is meant to fix.
+func TestHiveScrollRestoreRunsAfterRender(t *testing.T) {
+	html := dashScript(t)
+	for _, snippet := range []string{
+		"var LS_HIVE_SCROLL = 'hive-scroll';",
+		"function persistHiveScroll()",
+		"function readHiveScroll()",
+		"function restoreHiveScroll()",
+		// Throttled through rAF: scroll fires at input rate and setItem is
+		// synchronous, so an unthrottled write janks the scroll it records.
+		"window.requestAnimationFrame(",
+		"window.addEventListener('scroll', persistHiveScroll, {passive: true});",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("dashboardHTML is missing %q — scroll persistence is not wired", snippet)
+		}
+	}
+
+	loadIdx := strings.Index(html, "await loadHives();")
+	restoreIdx := strings.Index(html, "restoreHiveScroll();")
+	if loadIdx < 0 || restoreIdx < 0 {
+		t.Fatal("init no longer calls loadHives()/restoreHiveScroll()")
+	}
+	if restoreIdx < loadIdx {
+		t.Error("restoreHiveScroll() runs before await loadHives() — the rows have not rendered yet, so the offset clamps to a short page and the restore silently does nothing")
+	}
+}
+
+// TestHiveProvisionSortUsesRegisteredAt pins the timestamp field.
+//
+// registeredAt, NOT the per-hive meta.json created_at: created_at is written on
+// exactly one provisioning path, so hives created any other way — or before the
+// field existed — carry the empty string. On the live fleet 26 of 50 meta.json
+// files have "created_at": "" while registeredAt was populated on 50 of 50
+// registry entries. registeredAt is also carried forward across heartbeats
+// (see the RegisteredAt copy in handleHeartbeat) rather than restamped, so it
+// stays first-seen time instead of drifting to "now" on every beat.
+func TestHiveProvisionSortUsesRegisteredAt(t *testing.T) {
+	html := dashScript(t)
+	for _, snippet := range []string{
+		"function hiveProvisionTime(h)",
+		"var raw = h && h.registeredAt;",
+		"sortDashHives(\\'registeredAt\\')",
+		"Provisioned ⇅",
+		// registeredAt must be a recognised sort key, otherwise a persisted
+		// choice of it would be rejected on the next load.
+		"'registeredAt'",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("dashboardHTML is missing %q — provision-date sort is not wired to registeredAt", snippet)
+		}
+	}
+
+	// created_at must NOT be what the hive table sorts on. It is still legitimately
+	// used by the admin USERS table (fmtUserTS / sortUsers), so assert on the
+	// hive-side accessor specifically rather than banning the string outright.
+	if strings.Contains(html, "h.created_at") {
+		t.Error("the hive table reads h.created_at — it is empty on over half the live fleet; use registeredAt")
+	}
+}
+
+// TestHiveProvisionCellHandlesMissingTimestamp guards the render path: a hive
+// with no usable timestamp must show an em dash, never the string
+// "Invalid Date" that new Date(”) stringifies to.
+func TestHiveProvisionCellHandlesMissingTimestamp(t *testing.T) {
+	html := dashScript(t)
+	// The cell and the comparator must agree on "is this usable", so the cell
+	// asks hiveProvisionTime rather than testing the raw field itself.
+	if !strings.Contains(html, "hiveProvisionTime(h) === null ? '—'") {
+		t.Error("the Provisioned cell does not fall back to an em dash via hiveProvisionTime — a hive with an empty registeredAt would render 'Invalid Date'")
+	}
+}


### PR DESCRIPTION
Closes the three sort/persistence asks on the hub's My Hives table:

> "sort order(s) and location on page are not preserved when i refresh the dashboard."

> "default sort order for hives is a-z please. date/time of provision should be another sort option for hives"

## 1. Default sort is A-Z

The table previously rendered in registry order — arrival order, which reads as arbitrary. It now defaults to the Hive column ascending.

It sorts on the existing `hiveNameSortValue`, which delegates to `hiveLabel` — the org + primary-repo label the name cell actually **displays**. That matters: `h.name` is synthesised by the hub as `org + "/" + primaryRepo`, so sorting on it puts a hive with no org under `/repo` (leading slash collates before every letter) while the row visibly shows an ordinary word. Sorting on the label keeps the order matching what is on screen.

Verified against the live 50-hive fleet: the resulting order is exactly `localeCompare` order, and `localeCompare` (already used by the existing comparator) gives human A-Z — `apple, TradingAsBuddies, zacburns` rather than the uppercase-first order a raw `<` compare would produce.

## 2. Provision date as a sort option — using `registeredAt`, not `created_at`

New **Provisioned** column, sortable, showing when each hive was first seen.

I checked both candidate fields against live data before wiring either:

| field | populated on the live fleet |
|---|---|
| `registeredAt` (registry) | **50 / 50** |
| `created_at` (per-hive `meta.json`) | 24 / 50 — **26 are `""`** |

`created_at` is declared on `SaaSHive` but written on exactly one provisioning path, so hives created any other way — or predating the field — carry the empty string. The empties are not just placeholders; they include long-running assigned hives (`kubestellar/console`, `llm-d`, `aslom/hive-agent`, …). Had the column used `created_at`, over half the fleet would have sorted as unknown.

`registeredAt` is also *preserved* across heartbeats (`server.go` copies it from the previous entry rather than restamping), so it stays first-seen time instead of drifting to "now" on every beat.

Missing/unparseable timestamps are handled explicitly: `hiveProvisionTime` returns `null` (never `NaN`), those rows sort **last in both directions**, and the cell renders an em dash — never `Invalid Date`. Comparison is on epoch ms rather than string order, so a value arriving with an offset (`+02:00`) or without the `Z` cannot collate wrong.

## 3. Sort + scroll persist across refresh

Both stored under the existing `hive-*` convention (`hive-sort`, `hive-scroll`), alongside `hive-group-by` / `hive-saved-views`.

**Resolving req 1 vs req 3.** A persisted choice **wins**; A-Z is the default only for a first visit or cleared/corrupt state. `persistHiveSort` is written *only* from a header click, never from the loader, so restoring a preference cannot rewrite it — that is what lets the loader tell "never chose" apart from "chose the default". A stored key is validated against an allowlist, so a stale or hand-edited value (a column that no longer exists) degrades to A-Z rather than silently sorting on an absent property, which would make every row compare equal and read as "sorting is broken". Malformed JSON and disabled storage degrade the same way, no throw.

`loadHiveSortPrefs()` runs *after* `loadDashViewPrefs()`, since applying a default saved view sets a sort of its own and the explicit stored sort is the more specific signal.

**Scroll restore vs async render.** "Location on page" is the window offset — `.table-wrap` is `overflow: visible` at desktop widths. Restoring naively at init does nothing: the rows paint asynchronously and the document is only as tall as what has painted, so an early `scrollTo` clamps to the current maximum and silently lands at the top. So the restore runs after `await loadHives()` **and** then waits across a bounded few animation frames until `scrollHeight` is actually large enough for the offset to survive — the observable definition of "the rows have rendered" — before committing. It gives up after 3 frames and scrolls as far as the page allows, so a genuinely shorter list doesn't fight the user. Writes are throttled through `requestAnimationFrame` because `scroll` fires at input rate and `setItem` is synchronous. Offsets older than 30 min are discarded, since the fleet has changed underneath by then.

## Column count

The table gains one column, so `TOTAL_COLUMNS` / `TOTAL_COLUMNS_HEADER` and the two ratchet tests move 17 → 18. `TestHiveTableColumnCountsAgree` independently counts the emitted `<th>` and `<td>` cells and confirms they still agree at 18 — that check is what caught the constants, and it passes rather than being loosened.

## Coordination

Rebased onto fresh `origin/v2` immediately before opening this. Both overlapping PRs had landed and this is built **on top of** them, not reverting either:
- **#2309** (upgrading/queued facets + elapsed counters) — merged as `07ccca19`; its filter state and elapsed counters are intact.
- **#2314** (1pm ET auto-upgrade) — merged as `df1caf75`.

Both touch the same hive-table rendering; the rebase was clean and the full `pkg/hub` suite passes on the result.

## Verification

- `go build ./...` and the full `go test ./pkg/hub/` suite pass **after** the rebase.
- `saas.go` hazards: **0 backticks** inside `dashboardHTML`; no literal body tag added (the one occurrence is pre-existing and untouched).
- JS delimiter delta, base-vs-current, re-run against the **post-rebase** base: `{}` `+18/+18`, `()` `+70/+70`, `[]` `+3/+3` — imbalance identical to base on all three pairs (base is itself `-1` on parens/brackets, the known regex-literal artifact, which is why only base-vs-current is meaningful). The extraction was then grepped to confirm each new symbol is actually present.
- The extracted dashboard JS parses under `node --check`.
- 22 behavioral assertions run against the extracted functions with a `localStorage` shim, covering: first visit → A-Z; persisted choice wins; stale key / malformed JSON → A-Z without throwing; Z-A preserved; save/reload round-trip; and the scroll guards (stale discarded, non-numeric → 0, never NaN).
- The two sorts were run over the real 50-hive registry: A-Z order matches `localeCompare` exactly, and provision-date is correctly ordered in both directions with unknowns last (confirmed with synthetic empty/absent/garbage timestamps).

New Go tests pin the parts that are silent when broken — the default key, that persistence isn't clobbered by the default, that the scroll restore stays *after* `loadHives()`, that the provision sort reads `registeredAt` and not `created_at`, and the em-dash fallback.

Not verified in a browser — no live dashboard was exercised, and no hive was mutated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)