### PR TITLE
🔀 sync: v2 → mk (top-up #2315)

### DIFF
--- a/docs/HUB_DISASTER_RECOVERY.md
+++ b/docs/HUB_DISASTER_RECOVERY.md
@@ -1,0 +1,297 @@
+# Hive Hub — Backup & Disaster Recovery
+
+How to back up the Hive hub and its spoke fleet, and how to rebuild everything
+from zero after a catastrophic loss.
+
+---
+
+## ⚠️ Read this first
+
+### 1. `HIVE_BACKUP_KEY` must be escrowed OUTSIDE the cluster
+
+Backups are encrypted with AES-256-GCM using `HIVE_BACKUP_KEY`. **If that key
+exists only inside the cluster, the backup is worthless the moment the cluster
+is gone.** Store it in a password manager and/or an offline copy, today.
+
+There is no key-recovery mechanism. A lost key means an unreadable archive.
+
+```bash
+openssl rand -hex 32     # generate; store the output OUT OF BAND
+```
+
+The key is deliberately **independent of `/data/saas/hmac.key`**. `hmac.key` is
+itself backup *payload*; deriving the backup key from it would make the archive
+undecryptable in exactly the disaster it exists for.
+
+### 2. `hmac.key` is a single point of failure for all user tokens
+
+`/data/saas/hmac.key` (32 bytes) is the AES key for **every** user's
+`encrypted_token` (see `encryptToken`/`decryptToken` in `pkg/hub/saas.go`).
+There is no KMS, no escrow, no second copy anywhere.
+
+**If `hmac.key` is lost, all ~88 users' stored GitHub tokens become permanently
+undecryptable ciphertext and every user must re-authorize via OAuth.** No
+restore procedure recovers it. This backup is the only thing standing between
+you and that outcome.
+
+### 3. The authoritative spoke config is `hive.yaml.bak` — NOT `hive.yaml`
+
+Each spoke's running config is **`/data/hive.yaml.bak`** on its own PVC. The
+ConfigMap is only a fallback seed read at startup. The spoke's `copy-config`
+init container does:
+
+```sh
+if [ -f /data/hive.yaml.bak ]; then cp /data/hive.yaml.bak /etc/hive/hive.yaml
+else cp /etc/hive-seed/hive.yaml /etc/hive/hive.yaml; fi
+```
+
+**A restore that omits `hive.yaml.bak` silently falls back to the stale
+ConfigMap seed with no error**, losing every customization the user made. There
+is no warning — the spoke just comes up wrong. Always restore `hive.yaml.bak`.
+
+### 4. A PVC-only backup is NOT restorable
+
+Four Kubernetes Secrets live **outside** the hub PVC and are required:
+
+| Secret | Without it |
+|---|---|
+| `hive-hub-secrets` | OAuth login broken for all users |
+| `oci-api-key` | Hub cannot provision spoke storage or write backups |
+| `hive-hub-kubeconfigs` | Hub cannot reach remote spoke clusters (vllm-d) |
+| `hive-hub-tls` | Cert-manager reissues automatically (not fatal) |
+
+`hive-backup` captures these automatically and **fails the backup** if any of
+the first three is missing.
+
+---
+
+## What is backed up
+
+| Included | Why |
+|---|---|
+| `/data/saas/**` | users, hives, keys, timeline, provisioning state |
+| `/data/hub-registry.json` | the 50-hive fleet registry |
+| 4 Kubernetes Secrets | credentials outside the PVC |
+| per-spoke `hive.yaml.bak`, `gh-app-key*.pem`, `hive-id` | rebuild each spoke |
+
+**Deliberately excluded** as regenerable agent scratch: `nous/`, `home/`,
+`beads/`, `logs/`. These are ~110MB of the hub's ~125MB and ~796MB per spoke.
+Excluding them keeps an archive at roughly **300–400KB**, small enough to retain
+30 daily copies and restore in minutes.
+
+Losing the excluded data costs agent history and learned context — not the
+ability to run.
+
+### What is NOT recoverable by any backup
+
+- **GitHub App installation consent** — if the App registration is recreated,
+  each org owner must re-approve the installation.
+- **In-flight agent work** at the moment of loss.
+- **`hmac.key` if it was never backed up** — see above.
+
+---
+
+## Backup
+
+Runs as a CronJob in `hive-hub`. Each run builds the archive, encrypts it,
+uploads it to OCI Object Storage, **downloads it again and verifies checksums**,
+then prunes beyond the retention count. A run that cannot self-verify fails
+rather than reporting a good backup.
+
+```bash
+hive-backup run                    # to object storage
+hive-backup run -local out.enc     # to a local file
+hive-backup verify                 # verify newest stored archive
+hive-backup list                   # list stored archives
+hive-backup extract -file f.enc -dest ./restore
+```
+
+Environment:
+
+| Variable | Meaning |
+|---|---|
+| `HIVE_BACKUP_KEY` | **required** 64-hex AES-256 key. No default; unset aborts. |
+| `HIVE_BACKUP_BUCKET` | OCI Object Storage bucket |
+| `HIVE_BACKUP_RETENTION` | archives to keep (default 30) |
+| `HIVE_BACKUP_DATA_DIR` | hub data dir (default `/data`) |
+| `OCI_*` | credentials, from the existing `oci-api-key` Secret |
+
+### Spoke gaps are recorded, not hidden
+
+A spoke scaled to zero, or with no Running pod, cannot be read. Those hives are
+listed in the archive's `MANIFEST.json` under `spoke_errors`, and printed by
+`run` and `verify`. **Check this output** — a "successful" backup can still be
+missing spokes, and the manifest is where you find out before you need it.
+
+---
+
+## Restore runbook — rebuilding from zero
+
+Assumes: total loss of the hub cluster. You have the escrowed
+`HIVE_BACKUP_KEY` and access to the OCI bucket.
+
+### Step 0 — Get the archive
+
+```bash
+export HIVE_BACKUP_KEY=<from your password manager>
+export HIVE_BACKUP_BUCKET=<bucket>
+hive-backup list
+hive-backup verify                      # confirm it is intact BEFORE relying on it
+hive-backup extract -file <archive> -dest ./restore
+```
+
+`./restore` now contains `hub/`, `secrets/`, `spokes/`, `MANIFEST.json`.
+Read `MANIFEST.json` → `spoke_errors` to learn which spokes were not captured.
+
+### Step 1 — Provision a cluster
+
+Create a Kubernetes cluster and the `hive-hub` namespace. Recreate the hub PVC
+(RWX; on OKE this is an NFS/FSS-backed PV).
+
+```bash
+kubectl create namespace hive-hub
+kubectl apply -f <your hub PVC manifest>
+```
+
+### Step 2 — Restore the Kubernetes Secrets
+
+```bash
+for f in restore/secrets/*.json; do
+  kubectl apply -n hive-hub -f "$f"
+done
+```
+
+`hive-hub-tls` may be omitted; cert-manager reissues it.
+
+### Step 3 — Restore the hub PVC data
+
+Start a helper pod mounting the hub PVC, then stream the data in:
+
+```bash
+kubectl apply -n hive-hub -f - <<'YAML'
+apiVersion: v1
+kind: Pod
+metadata: {name: restore-helper}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: shell
+    image: busybox:1.36
+    command: ["sh","-c","sleep 3600"]
+    volumeMounts: [{name: data, mountPath: /data}]
+  volumes:
+  - name: data
+    persistentVolumeClaim: {claimName: hive-hub-data-rwx}
+YAML
+
+kubectl wait --for=condition=Ready pod/restore-helper -n hive-hub --timeout=120s
+tar cf - -C restore/hub saas hub-registry.json \
+  | kubectl exec -i -n hive-hub restore-helper -- sh -c 'cd /data && tar xf -'
+```
+
+Verify before continuing — especially `hmac.key`:
+
+```bash
+kubectl exec -n hive-hub restore-helper -- sh -c \
+  'ls /data/saas/users | wc -l; sha256sum /data/saas/hmac.key'
+kubectl delete pod restore-helper -n hive-hub
+```
+
+### Step 4 — Start the hub
+
+Deploy the hub. On boot it reads `/data/saas` and `/data/hub-registry.json`.
+
+Because `hmac.key`, `hub-secret.key` and `webhook-secret.key` were restored
+rather than regenerated:
+
+- existing user tokens still decrypt — **no mass re-OAuth**
+- spokes still authenticate with their existing `hub-secret`
+- GitHub webhooks still validate
+
+**Hive IDs and vanity URLs stay stable** because they come from
+`hub-registry.json` and `saas/hives/<id>/meta.json`, both restored verbatim.
+
+### Step 5 — Rebuild spokes
+
+For each hive in the registry, provision the namespace, PVC and Deployment as
+normal, then restore its config **before first start** (or restart after):
+
+```bash
+HIVE=hosted-example-abcd
+NS=hive-hosted-$HIVE
+POD=$(kubectl get pods -n $NS --field-selector=status.phase=Running \
+        -o jsonpath='{.items[0].metadata.name}')
+
+# hive.yaml.bak is authoritative — without it the spoke silently uses the
+# stale ConfigMap seed.
+kubectl cp restore/spokes/$HIVE/hive.yaml.bak $NS/$POD:/data/hive.yaml.bak -c hive
+kubectl cp restore/spokes/$HIVE/hive-id       $NS/$POD:/data/hive-id       -c hive
+for k in restore/spokes/$HIVE/gh-app-key*.pem; do
+  kubectl cp "$k" $NS/$POD:/data/$(basename "$k") -c hive
+done
+
+kubectl rollout restart deploy/hive -n $NS
+```
+
+Confirm the spoke used the restored config, not the seed:
+
+```bash
+kubectl logs -n $NS -c copy-config $POD    # expect "override-used", not "seed-copied"
+```
+
+### Step 6 — Re-link GitHub
+
+Manual, and unavoidable:
+
+- If the **OAuth App** still exists, restoring `hive-hub-secrets` is enough.
+- If the **GitHub App** was recreated, every org owner must re-approve the
+  installation. Its private keys are in `restore/hub/saas/app-keys/` and
+  `restore/spokes/*/gh-app-key*.pem` — reuse them if the App survived.
+- Re-point DNS / ingress for `hive.kubestellar.io`.
+
+### Step 7 — Verify
+
+- [ ] user count matches (`ls /data/saas/users | wc -l`)
+- [ ] users can log in without re-authorizing (proves `hmac.key` restored)
+- [ ] hive count and vanity URLs unchanged
+- [ ] spokes appear online and heartbeat to the hub
+- [ ] `copy-config` logged `override-used` on each spoke
+- [ ] a fresh `hive-backup run` succeeds against the rebuilt hub
+
+---
+
+## Automated vs manual
+
+| Automated | Manual |
+|---|---|
+| Archive creation, encryption, upload | Escrowing `HIVE_BACKUP_KEY` |
+| Integrity self-verification, retention | Cluster/PVC provisioning |
+| Hub state + Secrets + spoke config capture | Applying Secrets and PVC data |
+| Gap reporting via manifest | GitHub App re-consent, DNS |
+
+---
+
+## Testing status
+
+Verified end-to-end against production data (read-only against live systems;
+writes confined to a throwaway namespace that was deleted afterwards):
+
+- Backup of the real hub: **423 files, all 50 spokes, all 4 Secrets**
+- Archive is opaque ciphertext — no plaintext leakage
+- Wrong key and bit-flips are rejected (GCM auth tag)
+- Restored `hmac.key` byte-identical to production
+- **All 88 restored user tokens decrypt successfully**
+- Restored `hive.yaml.bak` byte-identical to the live spoke
+- Secrets restored into a throwaway namespace matched live values
+- Hub PVC data restored into a live pod: 88 users, 50 hives
+
+**UNTESTED** — no production meltdown was simulated:
+
+- Restoring onto a genuinely fresh/empty cluster
+- Starting the hub server against restored data (Step 4)
+- Spoke re-adoption and heartbeat after restore (Step 5)
+- GitHub App/OAuth re-linkage (Step 6)
+- The CronJob running in-cluster on its schedule
+- Upload to OCI Object Storage from *inside* the cluster (write permission was
+  verified out-of-band with the hub's own credentials; the in-cluster upload
+  path itself has not been exercised)

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -16,7 +16,8 @@ RUN GIT_HASH=$(git -C /repo rev-parse HEAD 2>/dev/null || echo "unknown") && \
     GIT_SHORT=$(git -C /repo rev-parse --short=7 HEAD 2>/dev/null || echo "unknown") && \
     if [ "$GIT_BRANCH" = "unknown" ] || [ -z "$GIT_BRANCH" ]; then GIT_BRANCH=$(git -C /repo rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown"); fi && \
     GOCACHE=/tmp/gobuild CGO_ENABLED=0 go build -ldflags "-X main.gitHash=${GIT_HASH} -X main.gitShort=${GIT_SHORT} -X main.gitBranch=${GIT_BRANCH}" -o /hive ./cmd/hive && \
-    GOCACHE=/tmp/gobuild CGO_ENABLED=0 go build -o /bd ./cmd/bd
+    GOCACHE=/tmp/gobuild CGO_ENABLED=0 go build -o /bd ./cmd/bd && \
+    GOCACHE=/tmp/gobuild CGO_ENABLED=0 go build -o /hive-backup ./cmd/hive-backup
 
 
 # --- tmux from source (cached until TMUX_VERSION changes) ---
@@ -143,6 +144,7 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 
 COPY --from=builder /hive /usr/local/bin/hive
 COPY --from=builder /bd /usr/local/bin/bd
+COPY --from=builder /hive-backup /usr/local/bin/hive-backup
 
 COPY v2/proxy/ /opt/hive/proxy/
 

--- a/v2/cmd/hive-backup/main.go
+++ b/v2/cmd/hive-backup/main.go
@@ -1,0 +1,183 @@
+// Command hive-backup creates, verifies and restores encrypted disaster-recovery
+// backups of the Hive hub and its spoke fleet.
+//
+// It is a standalone binary so the backup path can run as a CronJob without
+// starting a hub server, and so a restore can be performed from any machine
+// with kubectl access and the escrowed HIVE_BACKUP_KEY.
+//
+// Usage:
+//
+//	hive-backup run                 # back up to OCI Object Storage
+//	hive-backup run -local out.enc  # back up to a local file
+//	hive-backup verify              # verify the newest stored archive
+//	hive-backup verify -file f.enc  # verify a local archive
+//	hive-backup extract -file f.enc -dest ./restore
+//	hive-backup list                # list stored archives
+//
+// HIVE_BACKUP_KEY must be set to a 64-character hex AES-256 key. It has no
+// default: an unset key aborts rather than writing plaintext.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/kubestellar/hive/v2/pkg/hubbackup"
+	"github.com/kubestellar/hive/v2/pkg/logscrub"
+)
+
+// exitCodeError is returned for any operational failure so a CronJob shows
+// as failed and alerting fires.
+const exitCodeError = 1
+
+func main() {
+	logger := slog.New(logscrub.NewHandler(
+		slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(exitCodeError)
+	}
+
+	switch os.Args[1] {
+	case "run":
+		cmdRun(os.Args[2:], logger)
+	case "verify":
+		cmdVerify(os.Args[2:], logger)
+	case "extract":
+		cmdExtract(os.Args[2:], logger)
+	case "list":
+		cmdList(logger)
+	default:
+		usage()
+		os.Exit(exitCodeError)
+	}
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `hive-backup — Hive hub disaster-recovery backup
+
+Commands:
+  run [-local FILE] [-skip-spokes]   create an encrypted backup
+  verify [-file FILE]                verify newest stored, or a local archive
+  extract -file FILE -dest DIR       decrypt an archive to a directory
+  list                               list stored archives
+
+Environment:
+  %s   (required) 64-char hex AES-256 key; escrow this OUTSIDE the cluster
+  %s        OCI Object Storage bucket name
+  %s      hub data directory (default %s)
+  %s     archives to retain (default %d)
+`, hubbackup.EnvBackupKey, hubbackup.EnvBucket, hubbackup.EnvDataDir,
+		hubbackup.DefaultDataDir, hubbackup.EnvRetention, hubbackup.DefaultRetention)
+}
+
+func cmdRun(args []string, logger *slog.Logger) {
+	fs := flag.NewFlagSet("run", flag.ExitOnError)
+	local := fs.String("local", "", "write archive to this local path instead of object storage")
+	skipSpokes := fs.String("skip-spokes", "", "set to 'true' for a hub-only backup")
+	_ = fs.Parse(args)
+
+	opts := hubbackup.Options{
+		LocalOnly:  *local != "",
+		LocalPath:  *local,
+		SkipSpokes: *skipSpokes == "true",
+	}
+	man, dest, err := hubbackup.Run(opts, logger)
+	if err != nil {
+		logger.Error("backup failed", "err", err)
+		os.Exit(exitCodeError)
+	}
+	fmt.Printf("backup complete: %s\n", dest)
+	fmt.Printf("  files:        %d\n", len(man.Files))
+	fmt.Printf("  spokes:       %d\n", len(man.SpokeIDs))
+	fmt.Printf("  secrets:      %d\n", len(man.SecretNames))
+	if len(man.SpokeErrors) > 0 {
+		fmt.Printf("  SPOKE GAPS:   %d (see manifest)\n", len(man.SpokeErrors))
+		for id, e := range man.SpokeErrors {
+			fmt.Printf("    - %s: %s\n", id, e)
+		}
+	}
+}
+
+func cmdVerify(args []string, logger *slog.Logger) {
+	fs := flag.NewFlagSet("verify", flag.ExitOnError)
+	file := fs.String("file", "", "verify this local archive instead of the newest stored one")
+	_ = fs.Parse(args)
+
+	var man *hubbackup.Manifest
+	var err error
+	if *file != "" {
+		key, kerr := hubbackup.LoadKey()
+		if kerr != nil {
+			logger.Error("verify failed", "err", kerr)
+			os.Exit(exitCodeError)
+		}
+		data, rerr := os.ReadFile(*file)
+		if rerr != nil {
+			logger.Error("verify failed", "err", rerr)
+			os.Exit(exitCodeError)
+		}
+		man, err = hubbackup.Verify(key, data)
+	} else {
+		man, err = hubbackup.VerifyLatest(logger)
+	}
+	if err != nil {
+		logger.Error("verify failed", "err", err)
+		os.Exit(exitCodeError)
+	}
+	fmt.Printf("archive OK: %d files, %d spokes, created %s\n",
+		len(man.Files), len(man.SpokeIDs), man.CreatedAt.Format("2006-01-02T15:04:05Z"))
+	if len(man.SpokeErrors) > 0 {
+		fmt.Printf("WARNING: %d spokes were NOT captured:\n", len(man.SpokeErrors))
+		for id, e := range man.SpokeErrors {
+			fmt.Printf("  - %s: %s\n", id, e)
+		}
+	}
+}
+
+func cmdExtract(args []string, logger *slog.Logger) {
+	fs := flag.NewFlagSet("extract", flag.ExitOnError)
+	file := fs.String("file", "", "archive to extract (required)")
+	dest := fs.String("dest", "", "destination directory (required)")
+	_ = fs.Parse(args)
+
+	if *file == "" || *dest == "" {
+		fmt.Fprintln(os.Stderr, "extract requires -file and -dest")
+		os.Exit(exitCodeError)
+	}
+	key, err := hubbackup.LoadKey()
+	if err != nil {
+		logger.Error("extract failed", "err", err)
+		os.Exit(exitCodeError)
+	}
+	data, err := os.ReadFile(*file)
+	if err != nil {
+		logger.Error("extract failed", "err", err)
+		os.Exit(exitCodeError)
+	}
+	man, err := hubbackup.Extract(key, data, *dest)
+	if err != nil {
+		logger.Error("extract failed", "err", err)
+		os.Exit(exitCodeError)
+	}
+	fmt.Printf("extracted %d files to %s\n", len(man.Files), *dest)
+}
+
+func cmdList(logger *slog.Logger) {
+	store, err := hubbackup.NewObjectStore(os.Getenv(hubbackup.EnvBucket))
+	if err != nil {
+		logger.Error("list failed", "err", err)
+		os.Exit(exitCodeError)
+	}
+	names, err := store.List()
+	if err != nil {
+		logger.Error("list failed", "err", err)
+		os.Exit(exitCodeError)
+	}
+	for _, n := range names {
+		fmt.Println(n)
+	}
+}

--- a/v2/deploy/k8s/backup-cronjob.yaml
+++ b/v2/deploy/k8s/backup-cronjob.yaml
@@ -1,0 +1,135 @@
+# Hive hub disaster-recovery backup.
+#
+# Captures hub state, the four out-of-PVC Kubernetes Secrets, and every spoke's
+# authoritative config (hive.yaml.bak, gh-app-key*.pem, hive-id), encrypts the
+# result with AES-256-GCM and uploads it to OCI Object Storage.
+#
+# See docs/HUB_DISASTER_RECOVERY.md before deploying. In particular:
+#   HIVE_BACKUP_KEY MUST be escrowed OUTSIDE the cluster (password manager /
+#   offline). A backup encrypted with a key that only exists inside the hub is
+#   worthless after the hub is destroyed.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hive-hub-backup
+  namespace: hive-hub
+---
+# The backup reads Secrets in its own namespace and execs into spoke pods on
+# this cluster. Read-only apart from pod/exec, which is required to read
+# per-spoke PVC state the hub cannot mount.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hive-hub-backup
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hive-hub-backup
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hive-hub-backup
+subjects:
+  - kind: ServiceAccount
+    name: hive-hub-backup
+    namespace: hive-hub
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: hive-hub-backup
+  namespace: hive-hub
+  labels:
+    app.kubernetes.io/name: hive-hub-backup
+    app.kubernetes.io/component: backup
+spec:
+  # 03:17 UTC daily — off the hour to avoid contending with other cron traffic.
+  schedule: "17 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 7
+  jobTemplate:
+    spec:
+      # A hung spoke exec must not leave the job running until the next fire.
+      activeDeadlineSeconds: 3600
+      backoffLimit: 2
+      template:
+        spec:
+          serviceAccountName: hive-hub-backup
+          restartPolicy: Never
+          containers:
+            - name: backup
+              image: ghcr.io/kubestellar/hive:v2-latest
+              command: ["/usr/local/bin/hive-backup", "run"]
+              env:
+                # AES-256 key for the archive. MUST be escrowed outside the
+                # cluster. No default: an unset key aborts the backup rather
+                # than writing plaintext.
+                - name: HIVE_BACKUP_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: hive-hub-backup-key
+                      key: backup-key
+                - name: HIVE_BACKUP_BUCKET
+                  valueFrom:
+                    configMapKeyRef:
+                      name: hive-hub-backup-config
+                      key: bucket
+                - name: HIVE_BACKUP_RETENTION
+                  valueFrom:
+                    configMapKeyRef:
+                      name: hive-hub-backup-config
+                      key: retention
+              # OCI credentials for Object Storage, reusing the Secret the hub
+              # already uses for File Storage provisioning.
+              envFrom:
+                - secretRef:
+                    name: oci-api-key
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+                  readOnly: true
+                - name: kubeconfigs
+                  mountPath: /etc/hive/kubeconfigs
+                  readOnly: true
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            # The hub PVC, mounted read-only: the backup never writes to it.
+            - name: data
+              persistentVolumeClaim:
+                claimName: hive-hub-data-rwx
+                readOnly: true
+            # Kubeconfigs for remote spoke clusters (e.g. vllm-d). Without
+            # this, spokes on remote clusters cannot be captured.
+            - name: kubeconfigs
+              secret:
+                secretName: hive-hub-kubeconfigs
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hive-hub-backup-config
+  namespace: hive-hub
+data:
+  bucket: "hive-hub-backups"
+  retention: "30"

--- a/v2/pkg/hubbackup/backup.go
+++ b/v2/pkg/hubbackup/backup.go
@@ -1,0 +1,507 @@
+// Package hubbackup implements disaster-recovery backup for the Hive hub.
+//
+// It captures the minimum set of state required to reconstruct the hub and
+// every registered spoke after total loss of the hub cluster:
+//
+//   - /data/saas/**            hub SaaS state (users, hives, keys, timeline)
+//   - /data/hub-registry.json  the fleet registry
+//   - Kubernetes Secrets       credentials that live OUTSIDE the PVC
+//   - per-spoke config         hive.yaml.bak, gh-app-key*.pem, hive-id
+//
+// Deliberately EXCLUDED as regenerable agent scratch: nous/, home/, beads/,
+// logs/. Including them would grow a ~5MB archive into gigabytes.
+//
+// # Encryption
+//
+// The archive is a tar.gz sealed with AES-256-GCM. The key comes from the
+// HIVE_BACKUP_KEY environment variable and has NO default — an unset key is a
+// hard error, never a silent plaintext write.
+//
+// HIVE_BACKUP_KEY is deliberately INDEPENDENT of /data/saas/hmac.key. hmac.key
+// is itself part of the backup payload; deriving the backup key from it would
+// make the archive undecryptable in exactly the scenario the backup exists for
+// (the hub is gone). The operator MUST escrow HIVE_BACKUP_KEY outside the
+// cluster. See docs/HUB_DISASTER_RECOVERY.md.
+package hubbackup
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Environment variable names. No secret has a default value.
+const (
+	// EnvBackupKey holds the hex- or base64-encoded AES-256 key used to seal
+	// the archive. Unset is a fatal error.
+	EnvBackupKey = "HIVE_BACKUP_KEY"
+
+	// EnvDataDir overrides the hub data directory (test seam).
+	EnvDataDir = "HIVE_BACKUP_DATA_DIR"
+
+	// EnvBucket names the OCI Object Storage bucket receiving archives.
+	EnvBucket = "HIVE_BACKUP_BUCKET"
+
+	// EnvRetention overrides how many archives to retain.
+	EnvRetention = "HIVE_BACKUP_RETENTION"
+)
+
+// Filesystem layout of hub state.
+const (
+	// DefaultDataDir is the hub PVC mount point.
+	DefaultDataDir = "/data"
+
+	// saasSubdir is the hub SaaS state directory, relative to the data dir.
+	saasSubdir = "saas"
+
+	// registryFile is the fleet registry filename, relative to the data dir.
+	registryFile = "hub-registry.json"
+
+	// manifestName is the integrity manifest stored inside every archive.
+	manifestName = "MANIFEST.json"
+)
+
+// Archive layout: top-level directories inside the tarball.
+const (
+	// hubPrefix holds files copied from the hub PVC.
+	hubPrefix = "hub"
+
+	// secretsPrefix holds Kubernetes Secrets serialized as JSON.
+	secretsPrefix = "secrets"
+
+	// spokesPrefix holds per-spoke config, one subdirectory per hive ID.
+	spokesPrefix = "spokes"
+)
+
+// Crypto parameters.
+const (
+	// aesKeySize is the AES-256 key length in bytes.
+	aesKeySize = 32
+
+	// backupFormatVersion is bumped when the archive layout changes so a
+	// restore can refuse an archive it does not understand.
+	backupFormatVersion = 1
+)
+
+// Retention.
+const (
+	// DefaultRetention is how many archives to keep before pruning oldest.
+	DefaultRetention = 30
+)
+
+// excludedDirs are regenerable agent working directories skipped from the
+// hub PVC copy. They dominate disk usage but carry no unrecoverable state.
+var excludedDirs = map[string]bool{
+	"nous":  true,
+	"home":  true,
+	"beads": true,
+	"logs":  true,
+}
+
+// FileEntry records one archived file for integrity verification.
+type FileEntry struct {
+	Path   string `json:"path"`
+	Size   int64  `json:"size"`
+	SHA256 string `json:"sha256"`
+}
+
+// Manifest is the integrity and provenance record embedded in each archive.
+type Manifest struct {
+	FormatVersion int         `json:"format_version"`
+	CreatedAt     time.Time   `json:"created_at"`
+	HubDataDir    string      `json:"hub_data_dir"`
+	Files         []FileEntry `json:"files"`
+
+	// SpokeIDs lists every hive whose config was captured.
+	SpokeIDs []string `json:"spoke_ids"`
+
+	// SpokeErrors records hives that could NOT be captured, so a restore
+	// operator learns about gaps from the archive itself rather than by
+	// discovering missing spokes mid-recovery.
+	SpokeErrors map[string]string `json:"spoke_errors,omitempty"`
+
+	// SecretNames lists the Kubernetes Secrets captured.
+	SecretNames []string `json:"secret_names,omitempty"`
+}
+
+// LoadKey reads and validates the AES-256 backup key from the environment.
+// It returns an error when unset so callers fail loudly rather than writing
+// an unencrypted archive.
+func LoadKey() ([]byte, error) {
+	raw := strings.TrimSpace(os.Getenv(EnvBackupKey))
+	if raw == "" {
+		return nil, fmt.Errorf(
+			"%s is not set: refusing to write an unencrypted backup "+
+				"(generate one with: openssl rand -hex 32)", EnvBackupKey)
+	}
+	key, err := hex.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%s must be %d hex characters (%d-byte AES-256 key): %w",
+			EnvBackupKey, aesKeySize*2, aesKeySize, err)
+	}
+	if len(key) != aesKeySize {
+		return nil, fmt.Errorf("%s decoded to %d bytes, want %d (AES-256)",
+			EnvBackupKey, len(key), aesKeySize)
+	}
+	return key, nil
+}
+
+// Seal encrypts plaintext with AES-256-GCM, returning nonce||ciphertext.
+func Seal(key, plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+	return gcm.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+// Open decrypts data produced by Seal. A wrong key or any tampering fails the
+// GCM authentication tag, so this doubles as an integrity check.
+func Open(key, data []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) < gcm.NonceSize() {
+		return nil, fmt.Errorf("ciphertext too short: %d bytes", len(data))
+	}
+	plaintext, err := gcm.Open(nil, data[:gcm.NonceSize()], data[gcm.NonceSize():], nil)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt failed (wrong %s, or archive corrupted): %w",
+			EnvBackupKey, err)
+	}
+	return plaintext, nil
+}
+
+// DataDir returns the hub data directory, honouring the test-seam override.
+func DataDir() string {
+	if v := strings.TrimSpace(os.Getenv(EnvDataDir)); v != "" {
+		return v
+	}
+	return DefaultDataDir
+}
+
+// Retention returns the configured archive retention count.
+func Retention() int {
+	if v := strings.TrimSpace(os.Getenv(EnvRetention)); v != "" {
+		var n int
+		if _, err := fmt.Sscanf(v, "%d", &n); err == nil && n > 0 {
+			return n
+		}
+	}
+	return DefaultRetention
+}
+
+// ArchiveName returns the object name for a backup taken at t.
+func ArchiveName(t time.Time) string {
+	return fmt.Sprintf("hive-hub-backup-%s.tar.gz.enc", t.UTC().Format("20060102T150405Z"))
+}
+
+// builder accumulates files into a gzipped tar and records their digests.
+type builder struct {
+	tw    *tar.Writer
+	gz    *gzip.Writer
+	buf   *strings.Builder
+	files []FileEntry
+}
+
+// addBytes writes one in-memory file into the archive and records its digest.
+func (b *builder) addBytes(name string, mode int64, content []byte) error {
+	sum := sha256.Sum256(content)
+	hdr := &tar.Header{
+		Name:    name,
+		Mode:    mode,
+		Size:    int64(len(content)),
+		ModTime: time.Now(),
+	}
+	if err := b.tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+	if _, err := b.tw.Write(content); err != nil {
+		return err
+	}
+	b.files = append(b.files, FileEntry{
+		Path:   name,
+		Size:   int64(len(content)),
+		SHA256: hex.EncodeToString(sum[:]),
+	})
+	return nil
+}
+
+// addTree recursively copies srcDir into the archive under dstPrefix,
+// skipping excluded directories and unreadable files.
+func (b *builder) addTree(srcDir, dstPrefix string, skipExcluded bool, logger *slog.Logger) error {
+	return filepath.WalkDir(srcDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			// A single unreadable path must not abort the whole backup.
+			logger.Warn("backup: skipping unreadable path", "path", path, "err", err)
+			return nil
+		}
+		rel, relErr := filepath.Rel(srcDir, path)
+		if relErr != nil {
+			return nil
+		}
+		if rel == "." {
+			return nil
+		}
+		if d.IsDir() {
+			if skipExcluded && excludedDirs[rel] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			logger.Warn("backup: skipping unreadable file", "path", path, "err", readErr)
+			return nil
+		}
+		info, infoErr := d.Info()
+		mode := int64(0o600)
+		if infoErr == nil {
+			mode = int64(info.Mode().Perm())
+		}
+		return b.addBytes(filepath.Join(dstPrefix, rel), mode, content)
+	})
+}
+
+// Build assembles the complete encrypted archive and returns the sealed bytes
+// along with the manifest describing its contents.
+func Build(key []byte, collector SpokeCollector, secrets SecretCollector, logger *slog.Logger) ([]byte, *Manifest, error) {
+	dataDir := DataDir()
+
+	var raw strings.Builder
+	gz := gzip.NewWriter(&raw)
+	tw := tar.NewWriter(gz)
+	b := &builder{tw: tw, gz: gz, buf: &raw}
+
+	man := &Manifest{
+		FormatVersion: backupFormatVersion,
+		CreatedAt:     time.Now().UTC(),
+		HubDataDir:    dataDir,
+		SpokeErrors:   map[string]string{},
+	}
+
+	// 1. Hub SaaS state — users, hives, hmac.key, hub-secret.key, app-keys.
+	saasDir := filepath.Join(dataDir, saasSubdir)
+	if _, err := os.Stat(saasDir); err == nil {
+		if err := b.addTree(saasDir, filepath.Join(hubPrefix, saasSubdir), false, logger); err != nil {
+			return nil, nil, fmt.Errorf("archive saas dir: %w", err)
+		}
+	} else {
+		logger.Warn("backup: saas dir missing", "dir", saasDir)
+	}
+
+	// 2. Fleet registry.
+	regPath := filepath.Join(dataDir, registryFile)
+	if content, err := os.ReadFile(regPath); err == nil {
+		if err := b.addBytes(filepath.Join(hubPrefix, registryFile), 0o644, content); err != nil {
+			return nil, nil, fmt.Errorf("archive registry: %w", err)
+		}
+	} else {
+		logger.Warn("backup: registry missing", "path", regPath, "err", err)
+	}
+
+	// 3. Kubernetes Secrets that live outside the PVC. Without these the
+	//    archive is NOT restorable, so a failure here is fatal, not a warning.
+	if secrets != nil {
+		items, err := secrets.Collect(logger)
+		if err != nil {
+			return nil, nil, fmt.Errorf("collect kubernetes secrets: %w", err)
+		}
+		for _, it := range items {
+			if err := b.addBytes(filepath.Join(secretsPrefix, it.Name+".json"), 0o600, it.JSON); err != nil {
+				return nil, nil, fmt.Errorf("archive secret %s: %w", it.Name, err)
+			}
+			man.SecretNames = append(man.SecretNames, it.Name)
+		}
+	}
+
+	// 4. Per-spoke config. Individual spoke failures are recorded in the
+	//    manifest rather than aborting the fleet-wide backup.
+	if collector != nil {
+		spokes, err := collector.Collect(logger)
+		if err != nil {
+			logger.Error("backup: spoke collection failed", "err", err)
+			man.SpokeErrors["_collector"] = err.Error()
+		}
+		for _, sp := range spokes {
+			if sp.Err != "" {
+				man.SpokeErrors[sp.ID] = sp.Err
+				continue
+			}
+			for name, content := range sp.Files {
+				if err := b.addBytes(filepath.Join(spokesPrefix, sp.ID, name), 0o600, content); err != nil {
+					return nil, nil, fmt.Errorf("archive spoke %s/%s: %w", sp.ID, name, err)
+				}
+			}
+			man.SpokeIDs = append(man.SpokeIDs, sp.ID)
+		}
+	}
+
+	// 5. Manifest last, so it covers every preceding file. Copying the
+	//    accumulated digests in is what makes Verify meaningful — an empty
+	//    Files list would make verification silently vacuous.
+	man.Files = b.files
+
+	manJSON, err := json.MarshalIndent(man, "", "  ")
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal manifest: %w", err)
+	}
+	manHdr := &tar.Header{Name: manifestName, Mode: 0o644, Size: int64(len(manJSON)), ModTime: time.Now()}
+	if err := tw.WriteHeader(manHdr); err != nil {
+		return nil, nil, err
+	}
+	if _, err := tw.Write(manJSON); err != nil {
+		return nil, nil, err
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, nil, fmt.Errorf("close tar: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return nil, nil, fmt.Errorf("close gzip: %w", err)
+	}
+
+	sealed, err := Seal(key, []byte(raw.String()))
+	if err != nil {
+		return nil, nil, fmt.Errorf("seal archive: %w", err)
+	}
+	return sealed, man, nil
+}
+
+// Verify decrypts an archive, re-hashes every file and compares against the
+// embedded manifest. It is the proof that a stored archive is restorable.
+func Verify(key, sealed []byte) (*Manifest, error) {
+	plain, err := Open(key, sealed)
+	if err != nil {
+		return nil, err
+	}
+	gz, err := gzip.NewReader(strings.NewReader(string(plain)))
+	if err != nil {
+		return nil, fmt.Errorf("gunzip: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	digests := map[string]string{}
+	var man *Manifest
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read tar: %w", err)
+		}
+		content, err := io.ReadAll(tr)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", hdr.Name, err)
+		}
+		if hdr.Name == manifestName {
+			man = &Manifest{}
+			if err := json.Unmarshal(content, man); err != nil {
+				return nil, fmt.Errorf("parse manifest: %w", err)
+			}
+			continue
+		}
+		sum := sha256.Sum256(content)
+		digests[hdr.Name] = hex.EncodeToString(sum[:])
+	}
+
+	if man == nil {
+		return nil, fmt.Errorf("archive has no %s", manifestName)
+	}
+	if man.FormatVersion != backupFormatVersion {
+		return nil, fmt.Errorf("archive format version %d, this build understands %d",
+			man.FormatVersion, backupFormatVersion)
+	}
+	for _, f := range man.Files {
+		got, ok := digests[f.Path]
+		if !ok {
+			return nil, fmt.Errorf("manifest lists %s but archive does not contain it", f.Path)
+		}
+		if got != f.SHA256 {
+			return nil, fmt.Errorf("checksum mismatch for %s", f.Path)
+		}
+	}
+	return man, nil
+}
+
+// Extract decrypts an archive and writes its contents under destDir.
+func Extract(key, sealed []byte, destDir string) (*Manifest, error) {
+	if _, err := Verify(key, sealed); err != nil {
+		return nil, err
+	}
+	plain, err := Open(key, sealed)
+	if err != nil {
+		return nil, err
+	}
+	gz, err := gzip.NewReader(strings.NewReader(string(plain)))
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	var man *Manifest
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		content, err := io.ReadAll(tr)
+		if err != nil {
+			return nil, err
+		}
+		// Reject path traversal before touching the filesystem.
+		clean := filepath.Clean(hdr.Name)
+		if strings.HasPrefix(clean, "..") || filepath.IsAbs(clean) {
+			return nil, fmt.Errorf("refusing unsafe archive path %q", hdr.Name)
+		}
+		out := filepath.Join(destDir, clean)
+		if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+			return nil, err
+		}
+		if err := os.WriteFile(out, content, os.FileMode(hdr.Mode)); err != nil {
+			return nil, err
+		}
+		if hdr.Name == manifestName {
+			man = &Manifest{}
+			if err := json.Unmarshal(content, man); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return man, nil
+}

--- a/v2/pkg/hubbackup/backup_test.go
+++ b/v2/pkg/hubbackup/backup_test.go
@@ -1,0 +1,433 @@
+package hubbackup
+
+import (
+	"encoding/hex"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// testKey is a deterministic non-secret AES-256 key used only by tests.
+const testKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// seedHubData builds a fake hub PVC layout mirroring the real one, including
+// the excluded scratch directories, and returns its path.
+func seedHubData(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	saas := filepath.Join(dir, "saas")
+
+	mustWrite(t, filepath.Join(saas, "hmac.key"), strings.Repeat("k", 32))
+	mustWrite(t, filepath.Join(saas, "hub-secret.key"), strings.Repeat("s", 64))
+	mustWrite(t, filepath.Join(saas, "webhook-secret.key"), "webhooksecret")
+	mustWrite(t, filepath.Join(saas, "app-keys", "vllm-d.pem"), "-----BEGIN RSA PRIVATE KEY-----\nfake\n")
+	mustWrite(t, filepath.Join(saas, "users", "alice.json"),
+		`{"github_username":"alice","encrypted_token":"ZmFrZQ==","hives":{"hosted-x":"owner"}}`)
+	mustWrite(t, filepath.Join(saas, "hives", "hosted-x", "meta.json"),
+		`{"id":"hosted-x","org":"acme","acmm_level":3}`)
+	mustWrite(t, filepath.Join(saas, "clusters.json"),
+		`[{"id":"hive-oke","in_cluster":true},{"id":"vllm-d","in_cluster":false,`+
+			`"kubeconfig_path":"/etc/hive/kubeconfigs/vllm-d.yaml","context":"vllm-d"}]`)
+	mustWrite(t, filepath.Join(dir, "hub-registry.json"),
+		`{"hives":[{"id":"hosted-x","clusterId":"hive-oke"}],"updatedAt":"now"}`)
+
+	// Excluded scratch directories — these must NOT appear in the archive.
+	mustWrite(t, filepath.Join(dir, "nous", "big.bin"), strings.Repeat("N", 4096))
+	mustWrite(t, filepath.Join(dir, "home", "agent", "cache.bin"), strings.Repeat("H", 4096))
+	mustWrite(t, filepath.Join(dir, "beads", "b.db"), strings.Repeat("B", 4096))
+	mustWrite(t, filepath.Join(dir, "logs", "hive.log"), strings.Repeat("L", 4096))
+	return dir
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func decodeTestKey(t *testing.T) []byte {
+	t.Helper()
+	k, err := hex.DecodeString(testKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return k
+}
+
+// TestLoadKeyRejectsUnset is the guard against silently writing plaintext.
+func TestLoadKeyRejectsUnset(t *testing.T) {
+	t.Setenv(EnvBackupKey, "")
+	if _, err := LoadKey(); err == nil {
+		t.Fatal("expected error when HIVE_BACKUP_KEY is unset, got nil")
+	}
+}
+
+func TestLoadKeyRejectsWrongLength(t *testing.T) {
+	t.Setenv(EnvBackupKey, "abcd")
+	if _, err := LoadKey(); err == nil {
+		t.Fatal("expected error for short key")
+	}
+}
+
+func TestLoadKeyAccceptsValid(t *testing.T) {
+	t.Setenv(EnvBackupKey, testKey)
+	k, err := LoadKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(k) != aesKeySize {
+		t.Fatalf("key len = %d, want %d", len(k), aesKeySize)
+	}
+}
+
+func TestSealOpenRoundTrip(t *testing.T) {
+	key := decodeTestKey(t)
+	plain := []byte("sensitive hub state")
+	sealed, err := Seal(key, plain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(sealed), "sensitive") {
+		t.Fatal("plaintext leaked into sealed output")
+	}
+	got, err := Open(key, sealed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(plain) {
+		t.Fatalf("round trip mismatch: %q", got)
+	}
+}
+
+// TestOpenWithWrongKeyFails proves the archive is useless without the escrowed key.
+func TestOpenWithWrongKeyFails(t *testing.T) {
+	key := decodeTestKey(t)
+	sealed, err := Seal(key, []byte("secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrong := make([]byte, aesKeySize)
+	if _, err := Open(wrong, sealed); err == nil {
+		t.Fatal("expected decryption failure with wrong key")
+	}
+}
+
+// TestTamperDetected proves GCM catches modification of a stored archive.
+func TestTamperDetected(t *testing.T) {
+	key := decodeTestKey(t)
+	sealed, err := Seal(key, []byte("important"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sealed[len(sealed)-1] ^= 0xFF
+	if _, err := Open(key, sealed); err == nil {
+		t.Fatal("expected tamper detection")
+	}
+}
+
+// TestBuildCapturesHubStateAndExcludesScratch is the core scope assertion.
+func TestBuildCapturesHubStateAndExcludesScratch(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	key := decodeTestKey(t)
+
+	sealed, man, err := Build(key, nil, nil, quietLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	paths := map[string]bool{}
+	for _, f := range man.Files {
+		paths[f.Path] = true
+	}
+
+	// Must include the unrecoverable secrets and state.
+	for _, want := range []string{
+		"hub/saas/hmac.key",
+		"hub/saas/hub-secret.key",
+		"hub/saas/webhook-secret.key",
+		"hub/saas/app-keys/vllm-d.pem",
+		"hub/saas/users/alice.json",
+		"hub/saas/hives/hosted-x/meta.json",
+		"hub/hub-registry.json",
+	} {
+		if !paths[want] {
+			t.Errorf("archive missing required file %q", want)
+		}
+	}
+
+	// Must exclude regenerable scratch.
+	for p := range paths {
+		for _, bad := range []string{"hub/nous/", "hub/home/", "hub/beads/", "hub/logs/"} {
+			if strings.HasPrefix(p, bad) {
+				t.Errorf("archive should not contain scratch path %q", p)
+			}
+		}
+	}
+
+	if _, err := Verify(key, sealed); err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+}
+
+// TestManifestListsEveryArchivedFile is a regression guard: an earlier version
+// serialized the manifest without copying the accumulated digests, so Files was
+// empty and Verify passed vacuously — a backup that verified but checked nothing.
+func TestManifestIsNotEmpty(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	key := decodeTestKey(t)
+
+	_, man, err := Build(key, nil, nil, quietLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(man.Files) == 0 {
+		t.Fatal("manifest Files is empty: verification would be vacuous")
+	}
+	for _, f := range man.Files {
+		if f.SHA256 == "" {
+			t.Fatalf("manifest entry %q has no checksum", f.Path)
+		}
+	}
+}
+
+// TestVerifyDetectsCorruption proves integrity checking actually works.
+func TestVerifyDetectsCorruption(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	key := decodeTestKey(t)
+
+	sealed, _, err := Build(key, nil, nil, quietLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sealed[len(sealed)/2] ^= 0x01
+	if _, err := Verify(key, sealed); err == nil {
+		t.Fatal("expected verification failure on corrupted archive")
+	}
+}
+
+// fakeSpokes returns a collector producing deterministic spoke data.
+type fakeSpokes struct{ spokes []SpokeConfig }
+
+func (f fakeSpokes) Collect(_ *slog.Logger) ([]SpokeConfig, error) { return f.spokes, nil }
+
+type fakeSecrets struct{ items []SecretItem }
+
+func (f fakeSecrets) Collect(_ *slog.Logger) ([]SecretItem, error) { return f.items, nil }
+
+// TestBuildIncludesSpokesAndSecrets covers the full-fleet archive shape.
+func TestBuildIncludesSpokesAndSecrets(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	key := decodeTestKey(t)
+
+	spokes := fakeSpokes{spokes: []SpokeConfig{
+		{ID: "hosted-x", Files: map[string][]byte{
+			"hive.yaml.bak":       []byte("project:\n  org: acme\n"),
+			"hive-id":             []byte("hosted-x"),
+			"gh-app-key-5686.pem": []byte("-----BEGIN RSA PRIVATE KEY-----\n"),
+		}},
+		{ID: "hosted-broken", Err: "no running pod (scaled to zero?)"},
+	}}
+	secrets := fakeSecrets{items: []SecretItem{
+		{Name: "hive-hub-secrets", JSON: []byte(`{"kind":"Secret"}`)},
+		{Name: "oci-api-key", JSON: []byte(`{"kind":"Secret"}`)},
+	}}
+
+	sealed, man, err := Build(key, spokes, secrets, quietLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(man.SpokeIDs) != 1 || man.SpokeIDs[0] != "hosted-x" {
+		t.Fatalf("SpokeIDs = %v, want [hosted-x]", man.SpokeIDs)
+	}
+	// A failed spoke must be recorded, not silently dropped.
+	if _, ok := man.SpokeErrors["hosted-broken"]; !ok {
+		t.Fatal("expected hosted-broken recorded in SpokeErrors")
+	}
+	if len(man.SecretNames) != 2 {
+		t.Fatalf("SecretNames = %v", man.SecretNames)
+	}
+
+	paths := map[string]bool{}
+	for _, f := range man.Files {
+		paths[f.Path] = true
+	}
+	for _, want := range []string{
+		"spokes/hosted-x/hive.yaml.bak",
+		"spokes/hosted-x/hive-id",
+		"spokes/hosted-x/gh-app-key-5686.pem",
+		"secrets/hive-hub-secrets.json",
+		"secrets/oci-api-key.json",
+	} {
+		if !paths[want] {
+			t.Errorf("archive missing %q", want)
+		}
+	}
+	if _, err := Verify(key, sealed); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestExtractRestoresContent is the restore-path proof: bytes written into the
+// archive come back out byte-identical.
+func TestExtractRestoresContent(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	key := decodeTestKey(t)
+
+	spokeYAML := []byte("project:\n  org: acme\n  repos:\n  - thing\n")
+	spokes := fakeSpokes{spokes: []SpokeConfig{
+		{ID: "hosted-x", Files: map[string][]byte{
+			"hive.yaml.bak": spokeYAML,
+			"hive-id":       []byte("hosted-x"),
+		}},
+	}}
+	sealed, _, err := Build(key, spokes, nil, quietLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dest := t.TempDir()
+	if _, err := Extract(key, sealed, dest); err != nil {
+		t.Fatal(err)
+	}
+
+	// The hmac.key must survive byte-for-byte: it is the only thing that can
+	// decrypt every user's GitHub token.
+	gotHMAC, err := os.ReadFile(filepath.Join(dest, "hub", "saas", "hmac.key"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotHMAC) != strings.Repeat("k", 32) {
+		t.Fatalf("hmac.key corrupted through backup/restore: %q", gotHMAC)
+	}
+
+	// The authoritative spoke config must round-trip exactly.
+	gotYAML, err := os.ReadFile(filepath.Join(dest, "spokes", "hosted-x", "hive.yaml.bak"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotYAML) != string(spokeYAML) {
+		t.Fatalf("hive.yaml.bak corrupted: %q", gotYAML)
+	}
+}
+
+// TestExtractRejectsPathTraversal guards restore against a malicious archive.
+func TestExtractRejectsPathTraversal(t *testing.T) {
+	key := decodeTestKey(t)
+	evil := buildEvilArchive(t, key)
+	if _, err := Extract(key, evil, t.TempDir()); err == nil {
+		t.Fatal("expected path traversal to be rejected")
+	}
+}
+
+func TestParseSpokeStream(t *testing.T) {
+	// base64 of "hello" is aGVsbG8=
+	raw := spokeStreamPrefix + "hive-id" + spokeStreamDelim + "\naGVsbG8=\n"
+	files, err := parseSpokeStream([]byte(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(files["hive-id"]) != "hello" {
+		t.Fatalf("got %q", files["hive-id"])
+	}
+}
+
+// TestSpokeReadScriptTargetsAuthoritativeConfig locks in the single most
+// dangerous detail: the backup must read hive.yaml.bak, not hive.yaml.
+// Reading the wrong file makes restore silently fall back to the stale
+// ConfigMap seed with no error.
+func TestSpokeReadScriptTargetsAuthoritativeConfig(t *testing.T) {
+	script := buildSpokeReadScript()
+	if !strings.Contains(script, "/data/hive.yaml.bak") {
+		t.Fatal("spoke read script must capture /data/hive.yaml.bak")
+	}
+	if !strings.Contains(script, "gh-app-key*.pem") {
+		t.Fatal("spoke read script must capture GitHub App keys")
+	}
+	if !strings.Contains(script, "/data/hive-id") {
+		t.Fatal("spoke read script must capture hive-id")
+	}
+}
+
+func TestRetentionDefaultAndOverride(t *testing.T) {
+	t.Setenv(EnvRetention, "")
+	if got := Retention(); got != DefaultRetention {
+		t.Fatalf("Retention() = %d, want %d", got, DefaultRetention)
+	}
+	t.Setenv(EnvRetention, "7")
+	if got := Retention(); got != 7 {
+		t.Fatalf("Retention() = %d, want 7", got)
+	}
+}
+
+func TestLoadTargets(t *testing.T) {
+	dir := seedHubData(t)
+	clusters, hives, err := LoadTargets(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(clusters) != 2 {
+		t.Fatalf("clusters = %d, want 2", len(clusters))
+	}
+	if clusters["vllm-d"].InCluster {
+		t.Fatal("vllm-d should not be in-cluster")
+	}
+	if clusters["vllm-d"].KubeconfigPath == "" {
+		t.Fatal("vllm-d needs a kubeconfig path to be reachable")
+	}
+	if hives["hosted-x"] != "hive-oke" {
+		t.Fatalf("hives[hosted-x] = %q", hives["hosted-x"])
+	}
+}
+
+func TestKubectlArgsForRemoteCluster(t *testing.T) {
+	remote := ClusterTarget{ID: "vllm-d", InCluster: false,
+		KubeconfigPath: "/etc/hive/kubeconfigs/vllm-d.yaml", Context: "vllm-d"}
+	args := remote.kubectlArgs("get", "pods")
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--kubeconfig /etc/hive/kubeconfigs/vllm-d.yaml") {
+		t.Fatalf("missing kubeconfig flag: %v", args)
+	}
+	if !strings.Contains(joined, "--context vllm-d") {
+		t.Fatalf("missing context flag: %v", args)
+	}
+
+	inCluster := ClusterTarget{ID: "hive-oke", InCluster: true}
+	if got := strings.Join(inCluster.kubectlArgs("get", "pods"), " "); got != "get pods" {
+		t.Fatalf("in-cluster args = %q, want %q", got, "get pods")
+	}
+}
+
+func TestStripSecretNoise(t *testing.T) {
+	raw := []byte(`{"kind":"Secret","metadata":{"name":"x","uid":"u1',","resourceVersion":"9","creationTimestamp":"t"},"data":{"a":"b"}}`)
+	// Use a well-formed input.
+	raw = []byte(`{"kind":"Secret","metadata":{"name":"x","uid":"u1","resourceVersion":"9","creationTimestamp":"t"},"data":{"a":"b"}}`)
+	out, err := stripSecretNoise(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	for _, bad := range []string{"resourceVersion", "uid", "creationTimestamp"} {
+		if strings.Contains(s, bad) {
+			t.Errorf("stripped output still contains %q", bad)
+		}
+	}
+	if !strings.Contains(s, `"data"`) || !strings.Contains(s, `"name": "x"`) {
+		t.Errorf("stripped output lost required fields: %s", s)
+	}
+}

--- a/v2/pkg/hubbackup/collect.go
+++ b/v2/pkg/hubbackup/collect.go
@@ -1,0 +1,332 @@
+package hubbackup
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Timeouts for external kubectl calls. Spoke collection touches ~50 pods
+// across two clusters, so a single hung exec must not stall the backup.
+const (
+	// kubectlTimeout bounds one kubectl invocation.
+	kubectlTimeout = 60 * time.Second
+
+	// spokeExecTimeout bounds a single per-spoke file read.
+	spokeExecTimeout = 45 * time.Second
+)
+
+// Spoke namespace and container naming on the hosting clusters.
+const (
+	// spokeNamespacePrefix is prepended to a hive ID to form its namespace.
+	spokeNamespacePrefix = "hive-hosted-"
+
+	// spokeContainer is the container inside a spoke pod holding /data.
+	// Spoke pods also run a copy-config init container, so the container
+	// must be named explicitly or kubectl exec is ambiguous.
+	spokeContainer = "hive"
+)
+
+// Spoke files captured. This set is the minimum required to rebuild a working
+// spoke; everything else on a spoke PVC is regenerable agent scratch.
+//
+// hive.yaml.bak is THE authoritative running config. The spoke's copy-config
+// init container does:
+//
+//	if [ -f /data/hive.yaml.bak ]; then cp /data/hive.yaml.bak /etc/hive/hive.yaml
+//	else cp /etc/hive-seed/hive.yaml /etc/hive/hive.yaml; fi
+//
+// so a restore that omits hive.yaml.bak silently falls back to the stale
+// ConfigMap seed with NO error, losing every user customization. The plain
+// /data/hive.yaml is NOT authoritative and is not what must be restored.
+var spokeFiles = []string{
+	"hive.yaml.bak",
+	"hive-id",
+}
+
+// spokeKeyGlob matches the per-spoke GitHub App private keys, whose exact
+// filenames vary by cluster (gh-app-key.pem, gh-app-key-<appid>.pem).
+const spokeKeyGlob = "gh-app-key*.pem"
+
+// SpokeConfig is one spoke's captured configuration.
+type SpokeConfig struct {
+	ID      string
+	Cluster string
+	Files   map[string][]byte
+	// Err is non-empty when this spoke could not be captured. The backup
+	// continues and records the gap in the manifest.
+	Err string
+}
+
+// SpokeCollector gathers per-spoke configuration.
+type SpokeCollector interface {
+	Collect(logger *slog.Logger) ([]SpokeConfig, error)
+}
+
+// SecretItem is one Kubernetes Secret serialized for the archive.
+type SecretItem struct {
+	Name string
+	JSON []byte
+}
+
+// SecretCollector gathers Kubernetes Secrets that live outside the PVC.
+type SecretCollector interface {
+	Collect(logger *slog.Logger) ([]SecretItem, error)
+}
+
+// ClusterTarget describes how to reach one hosting cluster with kubectl.
+type ClusterTarget struct {
+	ID             string
+	InCluster      bool
+	KubeconfigPath string
+	Context        string
+}
+
+// kubectlArgs prefixes cluster-selection flags, mirroring the hub's existing
+// kubectlArgsForCluster helper so remote clusters are addressed identically.
+func (c ClusterTarget) kubectlArgs(args ...string) []string {
+	out := []string{}
+	if !c.InCluster {
+		if c.KubeconfigPath != "" {
+			out = append(out, "--kubeconfig", c.KubeconfigPath)
+		}
+		if c.Context != "" {
+			out = append(out, "--context", c.Context)
+		}
+	}
+	return append(out, args...)
+}
+
+// run executes kubectl against this cluster and returns stdout.
+func (c ClusterTarget) run(args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), kubectlTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "kubectl", c.kubectlArgs(args...)...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("kubectl %s: %w: %s",
+			strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}
+
+// KubectlSecretCollector captures named Secrets from the hub namespace.
+//
+// These four Secrets live OUTSIDE the hub PVC. A PVC-only backup restores to a
+// hub that cannot authenticate users (oauth-client-secret), cannot provision
+// storage (oci-api-key) and cannot reach remote clusters (kubeconfigs) — that
+// is why they are collected here and why a failure is fatal.
+type KubectlSecretCollector struct {
+	Cluster   ClusterTarget
+	Namespace string
+	Names     []string
+}
+
+// DefaultHubSecrets are the Secrets required for a restorable hub.
+var DefaultHubSecrets = []string{
+	"hive-hub-secrets",     // GitHub OAuth client secret
+	"oci-api-key",          // OCI credentials for FSS + Object Storage
+	"hive-hub-kubeconfigs", // kubeconfig for remote spoke clusters
+	"hive-hub-tls",         // TLS cert (cert-manager can reissue, kept for speed)
+}
+
+// Collect fetches each Secret as JSON with server-side noise stripped.
+func (k KubectlSecretCollector) Collect(logger *slog.Logger) ([]SecretItem, error) {
+	names := k.Names
+	if len(names) == 0 {
+		names = DefaultHubSecrets
+	}
+	var out []SecretItem
+	for _, name := range names {
+		raw, err := k.Cluster.run("get", "secret", name, "-n", k.Namespace, "-o", "json")
+		if err != nil {
+			// cert-manager can reissue TLS, so a missing TLS secret is not
+			// fatal. Any other missing secret breaks restore.
+			if name == "hive-hub-tls" {
+				logger.Warn("backup: TLS secret missing, cert-manager will reissue", "name", name)
+				continue
+			}
+			return nil, fmt.Errorf("secret %q is required for a restorable backup: %w", name, err)
+		}
+		cleaned, err := stripSecretNoise(raw)
+		if err != nil {
+			return nil, fmt.Errorf("clean secret %q: %w", name, err)
+		}
+		out = append(out, SecretItem{Name: name, JSON: cleaned})
+		logger.Info("backup: captured secret", "name", name)
+	}
+	return out, nil
+}
+
+// stripSecretNoise removes cluster-instance metadata so the Secret can be
+// re-applied to a brand-new cluster without conflict.
+func stripSecretNoise(raw []byte) ([]byte, error) {
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, err
+	}
+	if md, ok := obj["metadata"].(map[string]any); ok {
+		for _, f := range []string{"resourceVersion", "uid", "creationTimestamp",
+			"managedFields", "selfLink", "generation"} {
+			delete(md, f)
+		}
+	}
+	return json.MarshalIndent(obj, "", "  ")
+}
+
+// KubectlSpokeCollector reads each spoke's config out of its running pod.
+//
+// Spoke state lives on per-spoke PVCs that the hub cannot mount, so the only
+// read path is kubectl exec into the spoke pod. A spoke that is scaled to zero
+// therefore cannot be captured; that gap is recorded in the manifest.
+type KubectlSpokeCollector struct {
+	// Clusters maps cluster ID to how kubectl reaches it.
+	Clusters map[string]ClusterTarget
+
+	// Hives maps hive ID to the cluster ID hosting it.
+	Hives map[string]string
+}
+
+// Collect gathers config for every known hive.
+func (k KubectlSpokeCollector) Collect(logger *slog.Logger) ([]SpokeConfig, error) {
+	ids := make([]string, 0, len(k.Hives))
+	for id := range k.Hives {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	out := make([]SpokeConfig, 0, len(ids))
+	for _, id := range ids {
+		clusterID := k.Hives[id]
+		target, ok := k.Clusters[clusterID]
+		if !ok {
+			out = append(out, SpokeConfig{ID: id, Cluster: clusterID,
+				Err: fmt.Sprintf("unknown cluster %q", clusterID)})
+			continue
+		}
+		sc := k.collectOne(target, id, logger)
+		out = append(out, sc)
+	}
+	return out, nil
+}
+
+// collectOne captures a single spoke, tolerating failure.
+func (k KubectlSpokeCollector) collectOne(target ClusterTarget, id string, logger *slog.Logger) SpokeConfig {
+	sc := SpokeConfig{ID: id, Cluster: target.ID, Files: map[string][]byte{}}
+	ns := spokeNamespacePrefix + id
+
+	// Select only Running pods. Namespaces frequently retain Evicted/Failed
+	// pods alongside a healthy one, and an unfiltered .items[0] can select a
+	// dead pod — which silently loses that hive's config from the backup.
+	podRaw, err := target.run("get", "pods", "-n", ns,
+		"--field-selector=status.phase=Running",
+		"-o", "jsonpath={.items[0].metadata.name}")
+	if err != nil || len(bytes.TrimSpace(podRaw)) == 0 {
+		sc.Err = fmt.Sprintf("no running pod in %s (scaled to zero?): %v", ns, err)
+		logger.Warn("backup: spoke unreachable", "hive", id, "err", sc.Err)
+		return sc
+	}
+	pod := string(bytes.TrimSpace(podRaw))
+
+	// One exec emits every wanted file as a base64 stream with name markers,
+	// so a spoke costs a single round trip rather than one per file.
+	script := buildSpokeReadScript()
+	ctx, cancel := context.WithTimeout(context.Background(), spokeExecTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "kubectl",
+		target.kubectlArgs("exec", "-n", ns, "-c", spokeContainer, pod, "--", "sh", "-c", script)...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		sc.Err = fmt.Sprintf("exec into %s/%s: %v: %s", ns, pod, err, strings.TrimSpace(stderr.String()))
+		logger.Warn("backup: spoke exec failed", "hive", id, "err", sc.Err)
+		return sc
+	}
+
+	files, err := parseSpokeStream(stdout.Bytes())
+	if err != nil {
+		sc.Err = fmt.Sprintf("parse spoke stream: %v", err)
+		return sc
+	}
+	sc.Files = files
+
+	// hive.yaml.bak is the authoritative config; without it the spoke cannot
+	// be faithfully rebuilt, so surface that as an explicit error.
+	if _, ok := sc.Files["hive.yaml.bak"]; !ok {
+		sc.Err = "hive.yaml.bak absent — spoke config not recoverable from this backup"
+		logger.Warn("backup: spoke missing authoritative config", "hive", id)
+		return sc
+	}
+	logger.Info("backup: captured spoke", "hive", id, "files", len(sc.Files))
+	return sc
+}
+
+// spokeStreamDelim separates the filename marker from its base64 payload.
+const spokeStreamDelim = "::"
+
+// spokeStreamPrefix marks the start of a file record in the exec output.
+const spokeStreamPrefix = "@@FILE@@"
+
+// buildSpokeReadScript emits a shell script that base64-encodes each wanted
+// file. Encoding avoids binary/newline corruption over the exec stream.
+func buildSpokeReadScript() string {
+	var sb strings.Builder
+	for _, f := range spokeFiles {
+		fmt.Fprintf(&sb,
+			"if [ -f /data/%s ]; then echo '%s%s%s'; base64 /data/%s; fi; ",
+			f, spokeStreamPrefix, f, spokeStreamDelim, f)
+	}
+	// GitHub App keys use varying filenames across clusters.
+	fmt.Fprintf(&sb,
+		"for p in /data/%s; do if [ -f \"$p\" ]; then echo \"%s$(basename $p)%s\"; base64 \"$p\"; fi; done",
+		spokeKeyGlob, spokeStreamPrefix, spokeStreamDelim)
+	return sb.String()
+}
+
+// parseSpokeStream decodes the marker-delimited base64 stream.
+func parseSpokeStream(data []byte) (map[string][]byte, error) {
+	out := map[string][]byte{}
+	var current string
+	var b64 strings.Builder
+
+	flush := func() error {
+		if current == "" {
+			return nil
+		}
+		decoded, err := decodeBase64(b64.String())
+		if err != nil {
+			return fmt.Errorf("decode %s: %w", current, err)
+		}
+		out[current] = decoded
+		b64.Reset()
+		return nil
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.HasPrefix(line, spokeStreamPrefix) {
+			if err := flush(); err != nil {
+				return nil, err
+			}
+			name := strings.TrimSuffix(strings.TrimPrefix(line, spokeStreamPrefix), spokeStreamDelim)
+			current = strings.TrimSpace(name)
+			continue
+		}
+		if current != "" && strings.TrimSpace(line) != "" {
+			b64.WriteString(strings.TrimSpace(line))
+		}
+	}
+	if err := flush(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/v2/pkg/hubbackup/evil_archive_test.go
+++ b/v2/pkg/hubbackup/evil_archive_test.go
@@ -1,0 +1,60 @@
+package hubbackup
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// buildEvilArchive constructs a valid, correctly-signed archive whose manifest
+// and entries reference a path-traversal filename. It exists to prove Extract
+// refuses to write outside the destination directory.
+func buildEvilArchive(t *testing.T, key []byte) []byte {
+	t.Helper()
+
+	const evilPath = "../../etc/passwd"
+	payload := []byte("pwned")
+
+	var raw strings.Builder
+	gz := gzip.NewWriter(&raw)
+	tw := tar.NewWriter(gz)
+
+	if err := tw.WriteHeader(&tar.Header{
+		Name: evilPath, Mode: 0o600, Size: int64(len(payload)), ModTime: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+
+	man := Manifest{FormatVersion: backupFormatVersion, CreatedAt: time.Now().UTC()}
+	manJSON, err := json.MarshalIndent(&man, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.WriteHeader(&tar.Header{
+		Name: manifestName, Mode: 0o644, Size: int64(len(manJSON)), ModTime: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(manJSON); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	sealed, err := Seal(key, []byte(raw.String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sealed
+}

--- a/v2/pkg/hubbackup/objectstore.go
+++ b/v2/pkg/hubbackup/objectstore.go
@@ -1,0 +1,295 @@
+package hubbackup
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// decodeBase64 decodes standard base64, tolerating embedded whitespace from
+// shell `base64` output.
+func decodeBase64(s string) ([]byte, error) {
+	clean := strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\r' || r == ' ' || r == '\t' {
+			return -1
+		}
+		return r
+	}, s)
+	return base64.StdEncoding.DecodeString(clean)
+}
+
+// OCI Object Storage API and signing constants. These mirror the signing
+// scheme already proven in pkg/hub/oci_fss.go.
+const (
+	// ociObjectStorageHost is the Object Storage endpoint template.
+	ociObjectStorageHost = "objectstorage.%s.oraclecloud.com"
+
+	// ociObjectPathTemplate is the REST path for a single object.
+	ociObjectPathTemplate = "/n/%s/b/%s/o/%s"
+
+	// ociListPathTemplate is the REST path for listing a bucket's objects.
+	ociListPathTemplate = "/n/%s/b/%s/o"
+
+	// ociNamespacePath resolves the tenancy's Object Storage namespace.
+	ociNamespacePath = "/n/"
+
+	// ociSignatureVersion is the version field in the Authorization header.
+	ociSignatureVersion = "1"
+
+	// ociSigningAlgorithm is the signature algorithm identifier.
+	ociSigningAlgorithm = "rsa-sha256"
+
+	// ociGetSignedHeaders lists headers signed for GET/DELETE.
+	ociGetSignedHeaders = "date (request-target) host"
+
+	// ociPutSignedHeaders lists headers signed for PUT.
+	ociPutSignedHeaders = "date (request-target) host content-length content-type x-content-sha256"
+
+	// ociUploadContentType is the Content-Type for archive uploads.
+	ociUploadContentType = "application/octet-stream"
+
+	// ociHTTPTimeout bounds a single Object Storage request. Archives are a
+	// few MB, so this is generous.
+	ociHTTPTimeout = 180 * time.Second
+)
+
+// OCI credential environment variables. Values come from the existing
+// oci-api-key Secret; none has a default.
+const (
+	envOCITenancy     = "OCI_TENANCY_OCID"
+	envOCIUser        = "OCI_USER_OCID"
+	envOCIFingerprint = "OCI_FINGERPRINT"
+	envOCIPrivateKey  = "OCI_PRIVATE_KEY"
+	envOCIRegion      = "OCI_REGION"
+)
+
+// defaultOCIRegion is the region hosting the hub's tenancy. Non-secret.
+const defaultOCIRegion = "us-ashburn-1"
+
+// ObjectStore uploads and lists encrypted archives in OCI Object Storage.
+type ObjectStore struct {
+	tenancy     string
+	user        string
+	fingerprint string
+	privateKey  *rsa.PrivateKey
+	region      string
+	namespace   string
+	bucket      string
+	client      *http.Client
+}
+
+// NewObjectStore builds a client from environment credentials.
+func NewObjectStore(bucket string) (*ObjectStore, error) {
+	tenancy := os.Getenv(envOCITenancy)
+	user := os.Getenv(envOCIUser)
+	fingerprint := os.Getenv(envOCIFingerprint)
+	keyPEM := os.Getenv(envOCIPrivateKey)
+	if tenancy == "" || user == "" || fingerprint == "" || keyPEM == "" {
+		return nil, fmt.Errorf("OCI credentials incomplete: need %s, %s, %s, %s",
+			envOCITenancy, envOCIUser, envOCIFingerprint, envOCIPrivateKey)
+	}
+	if bucket == "" {
+		return nil, fmt.Errorf("%s is not set: no backup destination", EnvBucket)
+	}
+
+	block, _ := pem.Decode([]byte(keyPEM))
+	if block == nil {
+		return nil, fmt.Errorf("%s is not valid PEM", envOCIPrivateKey)
+	}
+	var key *rsa.PrivateKey
+	if k, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		key = k
+	} else {
+		parsed, err2 := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err2 != nil {
+			return nil, fmt.Errorf("parse OCI private key: %w", err2)
+		}
+		rsaKey, ok := parsed.(*rsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("OCI private key is not RSA")
+		}
+		key = rsaKey
+	}
+
+	region := os.Getenv(envOCIRegion)
+	if region == "" {
+		region = defaultOCIRegion
+	}
+
+	os_ := &ObjectStore{
+		tenancy: tenancy, user: user, fingerprint: fingerprint,
+		privateKey: key, region: region, bucket: bucket,
+		client: &http.Client{Timeout: ociHTTPTimeout},
+	}
+	ns, err := os_.resolveNamespace()
+	if err != nil {
+		return nil, fmt.Errorf("resolve Object Storage namespace: %w", err)
+	}
+	os_.namespace = ns
+	return os_, nil
+}
+
+func (o *ObjectStore) host() string {
+	return fmt.Sprintf(ociObjectStorageHost, o.region)
+}
+
+// sign applies the OCI HTTP Signature to a request.
+func (o *ObjectStore) sign(req *http.Request, body []byte) error {
+	req.Header.Set("date", time.Now().UTC().Format(http.TimeFormat))
+	signedHeaders := ociGetSignedHeaders
+
+	if req.Method == http.MethodPut || req.Method == http.MethodPost {
+		sum := sha256.Sum256(body)
+		req.Header.Set("x-content-sha256", base64.StdEncoding.EncodeToString(sum[:]))
+		req.Header.Set("content-type", ociUploadContentType)
+		req.Header.Set("content-length", fmt.Sprintf("%d", len(body)))
+		signedHeaders = ociPutSignedHeaders
+	}
+
+	requestTarget := strings.ToLower(req.Method) + " " + req.URL.RequestURI()
+	var parts []string
+	for _, h := range strings.Split(signedHeaders, " ") {
+		switch h {
+		case "(request-target)":
+			parts = append(parts, "(request-target): "+requestTarget)
+		case "host":
+			parts = append(parts, "host: "+req.Host)
+		default:
+			parts = append(parts, h+": "+req.Header.Get(h))
+		}
+	}
+	hash := sha256.Sum256([]byte(strings.Join(parts, "\n")))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, o.privateKey, crypto.SHA256, hash[:])
+	if err != nil {
+		return fmt.Errorf("RSA sign: %w", err)
+	}
+	keyID := o.tenancy + "/" + o.user + "/" + o.fingerprint
+	req.Header.Set("Authorization", fmt.Sprintf(
+		`Signature version="%s",keyId="%s",algorithm="%s",headers="%s",signature="%s"`,
+		ociSignatureVersion, keyID, ociSigningAlgorithm, signedHeaders,
+		base64.StdEncoding.EncodeToString(sig)))
+	return nil
+}
+
+// do signs and executes a request, returning the response body.
+func (o *ObjectStore) do(method, path string, body []byte) ([]byte, error) {
+	url := "https://" + o.host() + path
+	var rdr io.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, rdr)
+	if err != nil {
+		return nil, err
+	}
+	req.Host = o.host()
+	if err := o.sign(req, body); err != nil {
+		return nil, err
+	}
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("OCI %s %s: HTTP %d: %s",
+			method, path, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return respBody, nil
+}
+
+// resolveNamespace looks up the tenancy's Object Storage namespace.
+func (o *ObjectStore) resolveNamespace() (string, error) {
+	body, err := o.do(http.MethodGet, ociNamespacePath, nil)
+	if err != nil {
+		return "", err
+	}
+	var ns string
+	if err := json.Unmarshal(body, &ns); err != nil {
+		return "", fmt.Errorf("parse namespace response: %w", err)
+	}
+	return ns, nil
+}
+
+// Put uploads an object.
+func (o *ObjectStore) Put(name string, data []byte) error {
+	path := fmt.Sprintf(ociObjectPathTemplate, o.namespace, o.bucket, name)
+	_, err := o.do(http.MethodPut, path, data)
+	return err
+}
+
+// Get downloads an object.
+func (o *ObjectStore) Get(name string) ([]byte, error) {
+	path := fmt.Sprintf(ociObjectPathTemplate, o.namespace, o.bucket, name)
+	return o.do(http.MethodGet, path, nil)
+}
+
+// Delete removes an object.
+func (o *ObjectStore) Delete(name string) error {
+	path := fmt.Sprintf(ociObjectPathTemplate, o.namespace, o.bucket, name)
+	_, err := o.do(http.MethodDelete, path, nil)
+	return err
+}
+
+// listResponse models the Object Storage list payload.
+type listResponse struct {
+	Objects []struct {
+		Name string `json:"name"`
+	} `json:"objects"`
+}
+
+// List returns archive object names, newest first (names sort lexically by
+// their UTC timestamp, so reverse-sorting yields newest-first).
+func (o *ObjectStore) List() ([]string, error) {
+	path := fmt.Sprintf(ociListPathTemplate, o.namespace, o.bucket)
+	body, err := o.do(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var lr listResponse
+	if err := json.Unmarshal(body, &lr); err != nil {
+		return nil, fmt.Errorf("parse list response: %w", err)
+	}
+	names := make([]string, 0, len(lr.Objects))
+	for _, ob := range lr.Objects {
+		if strings.HasPrefix(ob.Name, "hive-hub-backup-") {
+			names = append(names, ob.Name)
+		}
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(names)))
+	return names, nil
+}
+
+// Prune deletes archives beyond the retention count, oldest first.
+func (o *ObjectStore) Prune(keep int, logger *slog.Logger) error {
+	names, err := o.List()
+	if err != nil {
+		return err
+	}
+	if len(names) <= keep {
+		return nil
+	}
+	for _, name := range names[keep:] {
+		if err := o.Delete(name); err != nil {
+			logger.Warn("backup: prune failed", "object", name, "err", err)
+			continue
+		}
+		logger.Info("backup: pruned old archive", "object", name)
+	}
+	return nil
+}

--- a/v2/pkg/hubbackup/run.go
+++ b/v2/pkg/hubbackup/run.go
@@ -1,0 +1,206 @@
+package hubbackup
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+// Hub namespace defaults.
+const (
+	// DefaultHubNamespace is the namespace hosting the hub deployment.
+	DefaultHubNamespace = "hive-hub"
+
+	// EnvHubNamespace overrides the hub namespace.
+	EnvHubNamespace = "HIVE_HUB_NAMESPACE"
+
+	// EnvKubeconfigDir is where per-cluster kubeconfigs are mounted.
+	EnvKubeconfigDir = "HIVE_KUBECONFIG_DIR"
+
+	// DefaultKubeconfigDir matches the hub deployment's mount path.
+	DefaultKubeconfigDir = "/etc/hive/kubeconfigs"
+)
+
+// registryDoc models the parts of hub-registry.json the backup needs.
+type registryDoc struct {
+	Hives []struct {
+		ID        string `json:"id"`
+		ClusterID string `json:"clusterId"`
+	} `json:"hives"`
+}
+
+// clusterDoc models the parts of clusters.json the backup needs.
+type clusterDoc struct {
+	ID             string `json:"id"`
+	InCluster      bool   `json:"in_cluster"`
+	KubeconfigPath string `json:"kubeconfig_path"`
+	Context        string `json:"context"`
+}
+
+// LoadTargets reads clusters.json and hub-registry.json to determine which
+// spokes exist and how to reach each hosting cluster.
+func LoadTargets(dataDir string) (map[string]ClusterTarget, map[string]string, error) {
+	clustersRaw, err := os.ReadFile(filepath.Join(dataDir, saasSubdir, "clusters.json"))
+	if err != nil {
+		return nil, nil, fmt.Errorf("read clusters.json: %w", err)
+	}
+	var cds []clusterDoc
+	if err := json.Unmarshal(clustersRaw, &cds); err != nil {
+		return nil, nil, fmt.Errorf("parse clusters.json: %w", err)
+	}
+	clusters := map[string]ClusterTarget{}
+	for _, c := range cds {
+		clusters[c.ID] = ClusterTarget{
+			ID:             c.ID,
+			InCluster:      c.InCluster,
+			KubeconfigPath: c.KubeconfigPath,
+			Context:        c.Context,
+		}
+	}
+
+	regRaw, err := os.ReadFile(filepath.Join(dataDir, registryFile))
+	if err != nil {
+		return nil, nil, fmt.Errorf("read hub-registry.json: %w", err)
+	}
+	var rd registryDoc
+	if err := json.Unmarshal(regRaw, &rd); err != nil {
+		return nil, nil, fmt.Errorf("parse hub-registry.json: %w", err)
+	}
+	hives := map[string]string{}
+	for _, h := range rd.Hives {
+		if h.ID != "" && h.ClusterID != "" {
+			hives[h.ID] = h.ClusterID
+		}
+	}
+	return clusters, hives, nil
+}
+
+// Options controls one backup run.
+type Options struct {
+	// LocalOnly writes the archive to LocalPath instead of object storage.
+	LocalOnly bool
+	LocalPath string
+
+	// SkipSpokes disables per-spoke collection (hub-only backup).
+	SkipSpokes bool
+
+	// SkipSecrets disables Kubernetes Secret collection. Only safe in tests —
+	// a real backup without Secrets is not restorable.
+	SkipSecrets bool
+}
+
+// Run performs a full backup: build, encrypt, upload, verify, prune.
+func Run(opts Options, logger *slog.Logger) (*Manifest, string, error) {
+	key, err := LoadKey()
+	if err != nil {
+		return nil, "", err
+	}
+	dataDir := DataDir()
+
+	hubNS := os.Getenv(EnvHubNamespace)
+	if hubNS == "" {
+		hubNS = DefaultHubNamespace
+	}
+
+	var spokeCollector SpokeCollector
+	var secretCollector SecretCollector
+
+	// The hub runs in-cluster, so its own kubectl needs no flags.
+	hubCluster := ClusterTarget{ID: "hub", InCluster: true}
+
+	if !opts.SkipSecrets {
+		secretCollector = KubectlSecretCollector{Cluster: hubCluster, Namespace: hubNS}
+	}
+	if !opts.SkipSpokes {
+		clusters, hives, err := LoadTargets(dataDir)
+		if err != nil {
+			logger.Error("backup: cannot enumerate spokes", "err", err)
+			return nil, "", fmt.Errorf("enumerate spokes: %w", err)
+		}
+		logger.Info("backup: enumerated fleet", "clusters", len(clusters), "hives", len(hives))
+		spokeCollector = KubectlSpokeCollector{Clusters: clusters, Hives: hives}
+	}
+
+	sealed, man, err := Build(key, spokeCollector, secretCollector, logger)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Verify before storing: an archive that cannot be verified must never be
+	// counted as a good backup.
+	if _, err := Verify(key, sealed); err != nil {
+		return nil, "", fmt.Errorf("self-verify failed, refusing to store: %w", err)
+	}
+
+	name := ArchiveName(man.CreatedAt)
+
+	if opts.LocalOnly {
+		path := opts.LocalPath
+		if path == "" {
+			path = name
+		}
+		if err := os.WriteFile(path, sealed, 0o600); err != nil {
+			return nil, "", fmt.Errorf("write local archive: %w", err)
+		}
+		logger.Info("backup: wrote local archive", "path", path,
+			"bytes", len(sealed), "spokes", len(man.SpokeIDs))
+		return man, path, nil
+	}
+
+	store, err := NewObjectStore(os.Getenv(EnvBucket))
+	if err != nil {
+		return nil, "", err
+	}
+	if err := store.Put(name, sealed); err != nil {
+		return nil, "", fmt.Errorf("upload archive: %w", err)
+	}
+	logger.Info("backup: uploaded", "object", name, "bytes", len(sealed),
+		"spokes", len(man.SpokeIDs), "spoke_errors", len(man.SpokeErrors))
+
+	// Read back and verify what actually landed in object storage.
+	fetched, err := store.Get(name)
+	if err != nil {
+		return nil, "", fmt.Errorf("read-back failed: %w", err)
+	}
+	if _, err := Verify(key, fetched); err != nil {
+		return nil, "", fmt.Errorf("stored archive failed verification: %w", err)
+	}
+	logger.Info("backup: verified stored archive", "object", name)
+
+	if err := store.Prune(Retention(), logger); err != nil {
+		logger.Warn("backup: prune failed", "err", err)
+	}
+	return man, name, nil
+}
+
+// VerifyLatest downloads the newest archive and verifies it end to end.
+func VerifyLatest(logger *slog.Logger) (*Manifest, error) {
+	key, err := LoadKey()
+	if err != nil {
+		return nil, err
+	}
+	store, err := NewObjectStore(os.Getenv(EnvBucket))
+	if err != nil {
+		return nil, err
+	}
+	names, err := store.List()
+	if err != nil {
+		return nil, err
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("no archives found in bucket")
+	}
+	data, err := store.Get(names[0])
+	if err != nil {
+		return nil, err
+	}
+	man, err := Verify(key, data)
+	if err != nil {
+		return nil, err
+	}
+	logger.Info("backup: latest archive verified", "object", names[0],
+		"files", len(man.Files), "spokes", len(man.SpokeIDs))
+	return man, nil
+}


### PR DESCRIPTION
Final top-up. #2315 landed on `v2` during CI for #2316.

Brings `mk` to `origin/v2` @ `fb37afe7`:
- #2315 — encrypted disaster-recovery backup for hub and spoke fleet

Merged with **no conflicts** (all new files). `go build ./...` clean; new `pkg/hubbackup` tests pass.

> [!IMPORTANT]
> Merge with `--merge`, **not** `--squash`.