### PR TITLE
🔀 sync: v2 → dd (top-up #2317, #2310)

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2505,7 +2505,7 @@
       <a class="oc-nav-item" data-section="contributors-section" onclick="ocNavigate('contributors-section')"><span class="oc-nav-emoji">👥</span><span class="oc-nav-text">Contributors</span><span id="contributors-sidebar-badge" class="oc-nav-count" style="display:none"></span></a>
       <a class="oc-nav-item" data-section="audit-section" onclick="ocNavigate('audit-section')"><span class="oc-nav-emoji">📋</span><span class="oc-nav-text">Audit Log</span></a>
       <a class="oc-nav-item" data-section="nous-section" onclick="ocNavigate('nous-section')"><span class="oc-nav-emoji">🧪</span><span class="oc-nav-text">Strategy Lab</span></a>
-      <a class="oc-nav-item" data-section="faq-section" onclick="ocNavigate('faq-section')" title="Answers to common first-time questions: the Advisory Digest, ACMM levels, and how to advance"><span class="oc-nav-emoji">❓</span><span class="oc-nav-text">FAQ</span></a>
+      <a class="oc-nav-item" data-section="faq-section" onclick="ocNavigate('faq-section')" title="Answers to common first-time questions: the Advisory Digest, ACMM levels, how to advance, and managing cost"><span class="oc-nav-emoji">❓</span><span class="oc-nav-text">FAQ</span></a>
       <a class="oc-nav-item" id="welcome-nav-item" style="display:none" onclick="openWelcomeDialog()" title="Open the Getting Started checklist — one-time setup steps for a new hive"><span class="oc-nav-emoji">🚀</span><span class="oc-nav-text">Getting Started</span></a>
       <a class="oc-nav-item" href="/api/docs" target="_blank"><span class="oc-nav-emoji">📘</span><span class="oc-nav-text">API Spec (Redoc)</span></a>
     </div>
@@ -2782,6 +2782,147 @@
           <li><strong>L6 Autonomous</strong> — auto-merge once CI is green.</li>
         </ul>
         <p style="margin:0 0 16px;color:var(--muted)">L4 and above become available after provisioning; newly created hives start in the L1–L3 range.</p>
+
+        <h3 style="font-size:0.95rem;margin:0 0 6px">My spend jumped after I raised my ACMM level. How do I manage cost?</h3>
+        <p style="margin:0 0 8px"><strong>First, the honest framing: higher levels increase throughput <em>and</em> spend, and that is the design, not a
+        malfunction.</strong> A hive that merges ~60 PRs in an afternoon burned tokens roughly in proportion to the work it did. If
+        the PRs were good, that spend bought something. The lever you want is usually not "spend less per unit of work" but
+        <strong>"do less work per day"</strong> — and that lever is cadence.</p>
+        <p style="margin:0 0 8px">Seven things you can actually turn, roughly in order of effect:</p>
+        <ol style="margin:0 0 8px;padding-left:20px">
+          <li><strong>Widen your agent cadences — the primary lever.</strong> Cadence is the interval between governor kicks, set
+              per agent <em>per governor mode</em>. The Governor panel shows this as a grid — agents down the side, the four modes
+              (<strong>idle / quiet / busy / surge</strong>) across the top, plus <strong>method</strong> and <strong>model</strong> columns.
+              <strong>Click any row</strong> (or the config gear on that agent's dashboard card) to adjust its cadences. Going from
+              <code>1h</code> to <code>6h</code> is roughly a 6× cut in that agent's kick count, and <code>12h</code> or <code>24h</code> cuts
+              further. Because the value is per mode, the highest-value edit is usually widening <strong>busy</strong> and
+              <strong>surge</strong> — those are the modes a high ACMM level spends most of its time in.
+              <br><span style="color:var(--muted)">Units are <code>m</code> and <code>h</code>. <strong>Write one day as <code>24h</code>, not <code>1D</code>.</strong>
+              A day suffix is <em>not</em> valid in <code>hive.yaml</code> — the governor parses cadences with Go's duration parser, which
+              rejects <code>1d</code>/<code>1D</code> outright, and an unparseable cadence is <em>skipped with a log warning</em>, leaving that
+              agent with no schedule at all rather than a slow one. <code>0</code> disables the agent in that mode.</span></li>
+          <li><strong>Pause agents you are not using.</strong> Each agent card on the Agents page has a <strong>⏸ pause</strong> button
+              — a paused agent is never kicked by the governor until you resume it. You can also set a mode's cadence to
+              <code>0</code> to switch an agent off in just that mode, which is a scalpel where pausing is a hammer.</li>
+          <li><strong>Set a real budget.</strong> <em>Governor Config → Budget</em> → <strong>Total Tokens</strong> is the cap
+              (<code>0</code> disables budget tracking entirely). The enforcement that actually bites is kick suppression: a soft
+              warning fires at 90% of the limit, and at 100% the governor <strong>stops kicking agents</strong> until the window rolls.
+              <strong>Per-Agent Exemptions</strong> lets chosen agents keep running through an exhausted budget.
+              <br><span style="color:var(--muted)">Three caveats before you lean on this. The budget is denominated in
+              <strong>tokens, not dollars</strong>, so it will not line up one-to-one with a provider's billing page. The accounting
+              window is a fixed 7 days and the warning fires at a fixed 90% — the <em>Period (days)</em> and <em>Critical Percent</em>
+              fields are stored but do not currently change that behaviour, so treat the window as weekly regardless of what they say.
+              And the governor panel's <strong>ignore budget</strong> checkbox disables enforcement entirely, so check that it is
+              unticked.</span></li>
+          <li><strong>Move work onto cheaper agents.</strong> Two independent dials on each agent card: the <strong>model</strong>
+              picker (higher tiers such as Opus cost more per token than Sonnet or Haiku) and the <strong>method</strong> picker
+              (the CLI or inference backend). Notably <strong>copilot</strong> and <strong>goose</strong> are treated as free backends and
+              <em>do not count toward the token budget</em> at all. Routine, high-frequency agents are the best candidates to move
+              down; leave the agents whose judgement you actually depend on where they are. Both columns also appear in the Governor
+              panel's grid, with a 📌 pin next to each to lock in a method or model you deliberately chose.</li>
+          <li><strong>Re-check the level itself.</strong> If the spend is not buying PRs you actually merge, the level — not the
+              cadence — is the wrong setting. Dropping from L5 to L4 or L3 is a legitimate cost control, and the ACMM dialog moves
+              in both directions.</li>
+          <li><strong>Move inference off metered APIs entirely.</strong> Two options change the cost model rather than trimming it.
+              <em>Self-hosted models</em> — point agents at <strong>vLLM</strong> or <strong>llm-d</strong> via the <strong>method</strong>
+              picker, and per-token API charges become fixed infrastructure you already run. <em>Donated compute</em> — <strong>ClankeR</strong>,
+              the contributor relay, hands tasks from your hive's backlog to CLI agents running on <em>contributors'</em> machines, on
+              their credentials, which never leave their machine. Contributors start rate-limited and auto-promote as tasks complete.
+              <br><span style="color:var(--muted)">If you move to vLLM or llm-d, revisit the next item: self-hosted models are exactly the
+              case where the supervisor earns its keep.</span></li>
+        </ol>
+        <p style="margin:0 0 8px">And one more that is easy to miss, because it is on by default and you did not choose it:</p>
+        <ol start="7" style="margin:0 0 8px;padding-left:20px">
+          <li><strong>Turn the supervisor off if you are on <code>claude</code>, <code>copilot</code>, <code>bob</code>, or
+              <code>litellm</code>.</strong> The supervisor's core job is watching the other agents' tmux panes for ones
+              <em>stuck at a prompt</em> — waiting on a human instead of running to completion. That failure mode is now
+              predominantly a <strong>self-hosted inference</strong> problem: open-source models served via <strong>vLLM</strong> or
+              <strong>llm-d</strong> need an injected preamble telling them to never ask for permission and never stop, precisely
+              because they otherwise stop and ask. Frontier CLI agents are explicitly unaffected by that preamble, and
+              <code>litellm</code> opts out of it too, on the grounds that it usually fronts frontier models. CLI agents used to
+              stall this way; in practice they no longer do. <strong>If you are running only CLI backends or litellm, the supervisor
+              is mostly watching for a condition that no longer occurs</strong> — and it is not free: the shipped packs kick it every
+              <code>5m</code> in most modes (every <code>1m</code> at L6), which is the tightest cadence of any agent.
+              <br><span style="color:var(--muted)"><strong>Keep it if you run vLLM or llm-d agents</strong> — that is the case it was built
+              for, and it is the direct trade-off against the self-hosted option above: moving inference in-house cuts your token bill
+              but reintroduces the stalling behaviour the supervisor exists to catch. It is also doing secondary work — spotting idle,
+              crashed, and rate-limited agents — so on a mixed fleet, widening its cadence is the safer move than switching it off
+              outright.</span></li>
+        </ol>
+        <p style="margin:0 0 8px;color:var(--muted)"><strong>Why it is on in the first place, and how to turn it off.</strong> The supervisor ships <em>enabled</em> in every
+        default pack from L2 to L6 (on <code>copilot</code>), so you will find it running even though you never asked for it. That
+        default dates from when CLI agents genuinely did stall; it has outlived the problem. Turning it off is therefore a
+        deliberate act.</p>
+        <p style="margin:0 0 16px;color:var(--muted)">Note that the supervisor's agent card has <strong>no ⏸ pause button</strong> — it is suppressed for this one agent, so the
+        usual route does not work and it can look undisableable. It is not. Use the <strong>Governor panel's cadence grid</strong>: click
+        the supervisor row to open its <em>Cadences</em> tab and set the modes you want silenced to <code>pause</code> (or
+        <code>0</code>). This is a supported, first-class value — the shipped L3 and L4 packs already use
+        <code>supervisor: pause</code> for idle mode — and the governor applies it to the supervisor with no special-casing. The
+        equivalent edit in <code>hive.yaml</code> is the same key under each mode's <code>cadences:</code> block.</p>
+        <p style="margin:0 0 16px;color:var(--muted)">Finally, some perspective: model pricing has been falling steadily, and cheap models keep getting more capable. Other
+        hives are already running successfully on low-cost models, so today's bill for a given amount of work is not a fixed
+        property of the system.</p>
+
+        <h3 style="font-size:0.95rem;margin:0 0 6px">How does cadence impact cost? My scanner seems to run non-stop.</h3>
+        <p style="margin:0 0 8px"><strong>Cadence is the wait <em>between</em> runs, not a limit on how long a run lasts.</strong> This is the
+        single most common misunderstanding about cost, so it is worth stating plainly. An agent session does not go on forever:
+        the agent works until it runs out of work, then stops. Cadence is how long Hive waits after that before kicking it again.</p>
+        <p style="margin:0 0 8px">Which means a busy agent can look like it is running continuously, and effectively be running continuously —
+        without anything being wrong. If your scanner faces a large queue (say, issues that <em>other</em> agents have been opening),
+        each session has plenty to chew on, so it runs long, finishes, and gets kicked again shortly after. Shortening cadence does
+        not make an agent work harder; <strong>widening cadence spreads the same work over more wall-clock time</strong>, which is exactly
+        what lowers the burn rate.</p>
+        <p style="margin:0 0 8px">There is a second, less obvious effect worth knowing. The governor picks its mode from the
+        <strong>count of actionable open issues</strong> — cross a threshold and it escalates idle → quiet → busy → surge, and every agent
+        switches to that mode's (shorter) cadence column. So a growing backlog raises spend on its own, without you changing any
+        setting. <strong>Working the backlog down lowers the mode, and the mode drives the pace.</strong> The thresholds themselves are
+        editable under <em>Governor Config → Thresholds</em>.</p>
+        <p style="margin:0 0 16px">Two cadence values in the grid are not durations. <strong>paused</strong> means the governor never kicks
+        that agent until you resume it. <strong>on demand</strong> means the agent is only ever kicked manually — it has no automatic
+        schedule at all.</p>
+
+        <h3 style="font-size:0.95rem;margin:0 0 6px">Is the first day supposed to cost this much?</h3>
+        <p style="margin:0 0 8px"><strong>Yes, and it is the least representative day you will have. Budget for a day-one spike, then expect
+        it to fall.</strong> Pointing a hive at an existing repo for the first time is the single most expensive thing you will ask it to
+        do, because a mature codebase carries years of accumulated technical debt that nobody has triaged — and the scanner finds
+        essentially all of it at once.</p>
+        <p style="margin:0 0 8px">That produces enough queued work to keep agents busy continuously, which is exactly what
+        "running non-stop" looks like. It is not a runaway loop; it is a real backlog being worked. One early adopter saw ~60 PRs in
+        an afternoon — small, targeted ones — at roughly five minutes of agent work apiece, which is about five hours of genuine
+        output. The bill tracked the work.</p>
+        <p style="margin:0 0 8px"><strong>Two things compound on day one</strong>, and both unwind on their own:</p>
+        <ul style="margin:0 0 8px;padding-left:20px">
+          <li>The backlog is at its deepest, so agents rarely run out of work and stop early — sessions run long.</li>
+          <li>A deep backlog of actionable issues pushes the governor into <strong>busy</strong> or <strong>surge</strong>, which is the
+              mode column with the <em>shortest</em> cadences. So the pace goes up at precisely the moment there is most to do.</li>
+        </ul>
+        <p style="margin:0 0 8px">As the backlog drains, both effects reverse: agents finish their queue and sit idle until the next
+        kick, and the governor settles back toward quiet or idle with its longer intervals. <strong>Steady-state cost is materially lower
+        than onboarding cost</strong>, so extrapolating your first day into a monthly figure will overestimate — usually by a lot.</p>
+        <p style="margin:0 0 16px;color:var(--muted)">If you would rather not absorb the spike all at once, the levers above still apply on day one — start at a lower ACMM
+        level, widen cadences before the first run, or set a <em>Total Tokens</em> budget so the spike is capped. Draining the initial
+        backlog is a one-time cost, and paying it more slowly is a legitimate choice.</p>
+
+        <h3 style="font-size:0.95rem;margin:0 0 6px">Where did the money actually go?</h3>
+        <p style="margin:0 0 8px">The <strong>💵 Cost</strong> section is the place to look. It reports an <strong>estimated</strong> total —
+        token counts multiplied by a dated list-price table — with a timeframe selector offering <strong>hourly</strong>,
+        <strong>daily</strong>, <strong>weekly</strong>, <strong>monthly</strong>, and <strong>custom</strong> ranges, so you can line a
+        spike up against what the fleet was doing at the time. Each agent card also shows a <strong>spend</strong> figure attributed to
+        that agent over whichever timeframe the Cost section is set to, which is how you find the one agent responsible for a jump.</p>
+        <p style="margin:0 0 8px;color:var(--muted)">Treat it as an estimate, not a bill. It is derived from token counts and list prices, so a subscription plan, a
+        discounted rate, or self-hosted inference will all diverge from it — and models without an exact price entry fall back to a
+        coarse tier estimate (shown with a <code>~</code>). It is the right tool for <em>attribution</em> — which agent, which model, which
+        day — rather than for reconciling against an invoice. The per-agent figure is also derived from a cumulative counter, so it
+        can read blank for a window that spans a restart.</p>
+        <p style="margin:0 0 8px">To see <em>what</em> an agent was asked to do, open that agent's <strong>Prior Prompts</strong> tab —
+        each kick is recorded with its timestamp and the fully expanded prompt text, with a <em>Window</em> selector offering
+        <strong>Last hour</strong>, <strong>Last day</strong>, and <strong>Last week</strong>. The <strong>📋 Audit Log</strong> is the
+        other half: it records that a kick, start, or restart happened and what triggered it.</p>
+        <p style="margin:0 0 16px;color:var(--muted)"><strong>What you cannot currently see is time.</strong> Nothing records how long a past session ran, so there is no
+        way to confirm "it ran flat out for four hours" from the UI — and no per-run cost figure either, since spend is bucketed by
+        time rather than attributed to individual kicks. The nearest proxy is <em>Last Run</em> on an agent card, which is when the
+        governor last kicked it, not how long it worked. Agent output is a live 500-line tmux buffer that is lost on restart, so it
+        cannot be used to reconstruct older activity.</p>
 
         <h3 style="font-size:0.95rem;margin:0 0 6px">Why couldn't the Guide agent answer my questions?</h3>
         <p style="margin:0 0 16px">Because the guide agent documents <em>your</em> project, not Hive itself. Its job is to audit your

--- a/v2/pkg/hub/hive_access_avatars_test.go
+++ b/v2/pkg/hub/hive_access_avatars_test.go
@@ -178,15 +178,17 @@ func TestHoverPanelReusesSharedRoleColor(t *testing.T) {
 // section-header colspan and the pending-expand colspan all stay correct; a
 // stale count leaves the table visibly ragged.
 //
-// 17 = the 16 columns left after the standalone Public column was folded into
+// 18 = the 16 columns left after the standalone Public column was folded into
 // Location (visibility stacks beneath the location badge), plus the AI Author
-// column added with App-bot PR authorship. TestHiveTableColumnCountsAgree is
-// the authority on this number: it counts the emitted <th> and <td> cells
-// rather than trusting a literal, so update it first and follow it here.
+// column added with App-bot PR authorship, plus the Provisioned column that
+// exposes each hive's first-seen time as a sort option.
+// TestHiveTableColumnCountsAgree is the authority on this number: it counts the
+// emitted <th> and <td> cells rather than trusting a literal, so update it
+// first and follow it here.
 func TestHiveTableColumnCountUnchanged(t *testing.T) {
 	for _, snippet := range []string{
-		"var TOTAL_COLUMNS = 17;",
-		"var TOTAL_COLUMNS_HEADER = 17;",
+		"var TOTAL_COLUMNS = 18;",
+		"var TOTAL_COLUMNS_HEADER = 18;",
 	} {
 		if !strings.Contains(dashboardHTML, snippet) {
 			t.Errorf("dashboardHTML is missing %q — did the hive table gain or lose a column?", snippet)

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -7713,7 +7713,12 @@ const dashboardHTML = `<!DOCTYPE html>
     var _clusterList = [];
     var _commitMessages = {};
     var _allDashHives = [];
-    var _dashSortKey = '', _dashSortAsc = true;
+    /* Seeded to the A-Z default rather than '' (registry/arrival order) so the
+       very first paint — including paintCachedHives, which runs before any
+       network call — is already alphabetical. loadHiveSortPrefs overwrites both
+       from localStorage when the operator has a stored choice; see
+       HIVE_SORT_DEFAULT_KEY for why a stored choice wins over this default. */
+    var _dashSortKey = 'name', _dashSortAsc = true;
     var _hivesLoading = false;
     var _lastHivesJSON = '';
     var _lastUsersJSON = '';
@@ -7934,6 +7939,35 @@ const dashboardHTML = `<!DOCTYPE html>
     var LS_HIVE_GROUP_COLLAPSED = 'hive-group-collapsed';
     var LS_HIVE_SAVED_VIEWS = 'hive-saved-views';
     var LS_HIVE_DEFAULT_VIEW = 'hive-default-view';
+    var LS_HIVE_SORT = 'hive-sort';
+    var LS_HIVE_SCROLL = 'hive-scroll';
+
+    /* HIVE_SORT_DEFAULT_KEY is the sort a FIRST-TIME visitor gets: the Hive
+       column, ascending — i.e. plain A-Z over the label the name cell actually
+       displays (see hiveNameSortValue / hiveLabel). Before this the table
+       rendered in registry order, which is arrival order and looks arbitrary.
+
+       This is a DEFAULT, not an override: loadHiveSortPrefs applies it only
+       when there is no usable stored choice, so an operator who sorted by
+       Tokens still returns to Tokens. */
+    var HIVE_SORT_DEFAULT_KEY = 'name';
+    var HIVE_SORT_DEFAULT_ASC = true;
+
+    /* HIVE_SORT_KEYS is every key a header can sort by — the allowlist that a
+       persisted value is validated against. A stored key that is no longer a
+       column (a renamed field, a hand-edited value, a downgrade) degrades to
+       the A-Z default instead of silently sorting on an absent property, which
+       reads as "sorting is broken" because every row compares equal. */
+    var HIVE_SORT_KEYS = ['name', 'clusterId', 'startedAt', 'acmmLevel', 'aiAuthor',
+      'journey', 'agentCount', 'totalTokens24h', 'governorMode', 'actionableIssues',
+      'actionablePRs', 'activeContributors', 'registeredAt'];
+
+    function isHiveSortKey(key) {
+      for (var i = 0; i < (HIVE_SORT_KEYS || []).length; i++) {
+        if (HIVE_SORT_KEYS[i] === key) return true;
+      }
+      return false;
+    }
 
     /* Cap on stored saved views. localStorage is a small shared budget and an
        unbounded list would let one runaway page fill it for every other
@@ -9294,6 +9328,30 @@ const dashboardHTML = `<!DOCTYPE html>
       bar.innerHTML = '<div class="view-ctls">' + groupCtl + '</div><div class="view-ctls">' + viewCtl + '</div>';
     }
 
+    /* hiveProvisionTime returns when this hive came into existence, as epoch
+       ms, or null when that is genuinely unknown.
+
+       Why registeredAt and NOT the per-hive meta.json created_at: created_at is
+       declared on SaaSHive and written on exactly one provisioning path, so
+       every hive that predates it — or that was created any other way — carries
+       the empty string. On the live fleet at the time of writing, 26 of 50
+       meta.json files have "created_at": "", including long-running assigned
+       hives, while registeredAt was populated on 50 of 50 registry entries.
+       registeredAt is also preserved across heartbeats (server.go copies it
+       from the previous entry rather than restamping it), so it stays the
+       first-seen time instead of drifting to "now" on every beat.
+
+       Returns null — never NaN and never a rendered 'Invalid Date' — for a
+       missing or unparseable value, so the caller can order those rows
+       explicitly instead of comparing against NaN, which is false in both
+       directions and would make the sort non-deterministic. */
+    function hiveProvisionTime(h) {
+      var raw = h && h.registeredAt;
+      if (typeof raw !== 'string' || !raw) return null;
+      var t = Date.parse(raw);
+      return isNaN(t) ? null : t;
+    }
+
     /* sortedDashHives applies the CURRENT sort key/direction to the unfiltered
        cache. Split out of sortDashHives so restoring a saved view (which sets
        the key/direction directly rather than by clicking a header) reproduces
@@ -9310,6 +9368,23 @@ const dashboardHTML = `<!DOCTYPE html>
           var ja = journeySortValue(a && a.journey);
           var jb = journeySortValue(b && b.journey);
           return _dashSortAsc ? ja - jb : jb - ja;
+        }
+        if (key === 'registeredAt') {
+          /* Provision time. Compared as epoch ms, not as text: registeredAt is
+             RFC3339 so it happens to sort lexically today, but a value that
+             ever arrives with an offset ('...+02:00') or without the 'Z' would
+             collate wrong, and a string compare cannot express "unknown last".
+
+             Hives with no parseable timestamp sort LAST in both directions
+             rather than clumping at whichever end '' collates to — they are
+             the least informative rows, so they stay out of the way whether
+             the operator asked for oldest-first or newest-first. */
+          var ra = hiveProvisionTime(a);
+          var rb2 = hiveProvisionTime(b);
+          if (ra === null && rb2 === null) return 0;
+          if (ra === null) return 1;
+          if (rb2 === null) return -1;
+          return _dashSortAsc ? ra - rb2 : rb2 - ra;
         }
         var va = key === 'name' ? hiveNameSortValue(a) : ((a && a[key]) || '');
         var vb = key === 'name' ? hiveNameSortValue(b) : ((b && b[key]) || '');
@@ -9375,7 +9450,118 @@ const dashboardHTML = `<!DOCTYPE html>
 
     function sortDashHives(key) {
       if (_dashSortKey === key) { _dashSortAsc = !_dashSortAsc; } else { _dashSortKey = key; _dashSortAsc = true; }
+      persistHiveSort();
       renderHives(sortedDashHives(), true);
+    }
+
+    /* persistHiveSort records the operator's EXPLICIT sort choice. Written only
+       from sortDashHives (a header click), never from loadHiveSortPrefs, so
+       restoring a preference can't rewrite it and a first visit leaves the key
+       absent rather than storing the default — which is what lets
+       loadHiveSortPrefs tell "never chose" apart from "chose the default". */
+    function persistHiveSort() {
+      lsSetJSON(LS_HIVE_SORT, {key: _dashSortKey, asc: _dashSortAsc});
+    }
+
+    /* ---- Scroll position across refresh --------------------------------
+       "Location on page" is the WINDOW's scroll offset, not a container's:
+       .table-wrap is overflow:visible at desktop widths (it only becomes an
+       overflow-x scroller in the narrow media query, and that axis is
+       horizontal), so the hive list scrolls the document itself.
+
+       Writes are throttled through requestAnimationFrame because scroll fires
+       at input rate and localStorage.setItem is synchronous — persisting on
+       every event would jank the scroll it is trying to record. */
+    var HIVE_SCROLL_MAX_AGE_MS = 30 * 60 * 1000; /* 30 min — see readHiveScroll */
+    var HIVE_SCROLL_RESTORE_FRAMES = 3;          /* see restoreHiveScroll */
+    var _hiveScrollWritePending = false;
+    var _hiveScrollRestored = false;
+
+    function persistHiveScroll() {
+      if (_hiveScrollWritePending) return;
+      _hiveScrollWritePending = true;
+      window.requestAnimationFrame(function() {
+        _hiveScrollWritePending = false;
+        var y = window.pageYOffset || document.documentElement.scrollTop || 0;
+        lsSetJSON(LS_HIVE_SCROLL, {y: y, t: Date.now()});
+      });
+    }
+
+    /* readHiveScroll returns the stored offset, or 0 when there is nothing
+       usable. Stale entries are discarded: coming back to the dashboard after
+       hours, the fleet has changed underneath and the old offset points at
+       unrelated rows, so landing at the top is the honest result. Guards the
+       shape too — a hand-edited or truncated value must not yield NaN, which
+       window.scrollTo would silently treat as 0 anyway but which would also
+       poison the comparison below. */
+    function readHiveScroll() {
+      var s = lsGetJSON(LS_HIVE_SCROLL, null);
+      if (!s || typeof s !== 'object') return 0;
+      var y = Number(s.y), t = Number(s.t);
+      if (!isFinite(y) || y <= 0) return 0;
+      if (!isFinite(t) || (Date.now() - t) > HIVE_SCROLL_MAX_AGE_MS) return 0;
+      return y;
+    }
+
+    /* restoreHiveScroll re-applies the saved offset ONCE per page load.
+
+       Why not a single scrollTo at init: the rows are painted asynchronously
+       (paintCachedHives, then loadHives' await, then renderHives), and the
+       document is only as tall as what has been painted so far. Scrolling to
+       y before the table exists clamps to the current maximum — silently
+       landing at the top, which is exactly the bug this is meant to fix.
+
+       So it retries across a few animation frames and stops as soon as the
+       document is actually tall enough for the offset to survive, which is the
+       observable definition of "the rows have rendered". The frame budget is
+       small and bounded so a genuinely shorter list (hives removed since) costs
+       three frames and then gives up rather than fighting the user forever. */
+    function restoreHiveScroll() {
+      if (_hiveScrollRestored) return;
+      var y = readHiveScroll();
+      if (!y) { _hiveScrollRestored = true; return; }
+      var attempts = 0;
+      var tryScroll = function() {
+        var maxY = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+        if (maxY >= y) {
+          window.scrollTo(0, y);
+          _hiveScrollRestored = true;
+          return;
+        }
+        if (++attempts >= HIVE_SCROLL_RESTORE_FRAMES) {
+          /* Never tall enough — go as far as the page allows so the operator
+             at least lands near where they were. */
+          window.scrollTo(0, maxY);
+          _hiveScrollRestored = true;
+          return;
+        }
+        window.requestAnimationFrame(tryScroll);
+      };
+      window.requestAnimationFrame(tryScroll);
+    }
+
+    /* loadHiveSortPrefs resolves the stored sort against the A-Z default.
+
+       Precedence: a PERSISTED choice wins, the default applies only when there
+       is nothing usable stored — first visit, cleared storage, or a value that
+       no longer validates. Applying A-Z unconditionally would undo the operator's
+       choice on every refresh, which is the exact complaint this fixes.
+
+       Every failure mode degrades to the default rather than throwing: lsGetJSON
+       already swallows disabled storage and malformed JSON, and isHiveSortKey
+       rejects a stale key so a removed column cannot leave the table sorting on
+       a property no row has. */
+    function loadHiveSortPrefs() {
+      var stored = lsGetJSON(LS_HIVE_SORT, null);
+      if (stored && typeof stored === 'object' && isHiveSortKey(stored.key)) {
+        _dashSortKey = stored.key;
+        /* Only an explicit false flips direction — a stored object missing
+           'asc' still means ascending. */
+        _dashSortAsc = stored.asc !== false;
+        return;
+      }
+      _dashSortKey = HIVE_SORT_DEFAULT_KEY;
+      _dashSortAsc = HIVE_SORT_DEFAULT_ASC;
     }
 
     /* ---- Usage attribution panel ----------------------------------------
@@ -10339,11 +10525,11 @@ const dashboardHTML = `<!DOCTYPE html>
           pendingPill = '<a href="#" onclick="togglePendingRow(\'' + esc(h.id) + '\');return false" style="display:inline-flex;align-items:center;gap:4px;padding:3px 10px;background:rgba(59,130,246,0.12);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);border-radius:4px;font-size:0.7rem;text-decoration:none;cursor:pointer;white-space:nowrap">&#x1F514; ' + h.pendingRequestCount + ' pending</a>';
         }
         // 16 = the 13 original columns, plus Uptime, plus Drift, plus the
-        // bulk-select column, plus Journey, MINUS Public — visibility now
-        // stacks under Location instead of owning a column. Counted against
-        // the <th> cells in the header and the <td> cells emitted below
-        // (bulkCheckboxCell contributes one).
-        var TOTAL_COLUMNS = 17;
+        // bulk-select column, plus Journey, plus Provisioned, MINUS Public —
+        // visibility now stacks under Location instead of owning a column.
+        // Counted against the <th> cells in the header and the <td> cells
+        // emitted below (bulkCheckboxCell contributes one).
+        var TOTAL_COLUMNS = 18;
         /* Visibility moved OUT of its own column and under Location: "where
            does this hive run" and "who can see it" are both facts about the
            hive's placement, so they read as one cell, and folding them saves a
@@ -10461,6 +10647,13 @@ const dashboardHTML = `<!DOCTYPE html>
           '<td>' + sparkline(h.issueHistory, '#f59e0b', 50, 14) + (h.actionableIssues || 0) + '</td>' +
           '<td>' + sparkline(h.prHistory, '#3b82f6', 50, 14) + (h.actionablePRs || 0) + '</td>' +
           '<td>' + (h.activeContributors || 0) + '</td>' +
+          /* Provisioned. hiveProvisionTime is the single source of truth for
+             "is this timestamp usable" — reusing it here keeps the cell and the
+             comparator from ever disagreeing (a row showing a date but sorting
+             as unknown, or the reverse). An em dash, never 'Invalid Date', for
+             a hive whose registeredAt is missing or unparseable. */
+          '<td style="font-size:0.75rem;color:var(--muted);white-space:nowrap">' +
+            (hiveProvisionTime(h) === null ? '—' : esc(fmtUserTS(h.registeredAt))) + '</td>' +
           '</tr>' + pendingExpandRow;
       };
       /* Section-header row: a labeled separator spanning all columns, styled to
@@ -10468,9 +10661,10 @@ const dashboardHTML = `<!DOCTYPE html>
       /* Count of <th> cells in the hive table header below. The section-header
          row spans all of them; a stale value would leave the separator short
          and the table visibly ragged. 15 with the Drift column, plus the
-         bulk-select column, plus the Journey column, minus Public (visibility
-         is stacked under Location). Must stay equal to TOTAL_COLUMNS. */
-      var TOTAL_COLUMNS_HEADER = 17;
+         bulk-select column, plus the Journey column, plus the Provisioned
+         column, minus Public (visibility is stacked under Location). Must stay
+         equal to TOTAL_COLUMNS. */
+      var TOTAL_COLUMNS_HEADER = 18;
       /* The header is a click target that expands/collapses its section. The
          caret mirrors aria-expanded so the affordance and the a11y state can
          never disagree. sectionKey also scopes the select-all checkbox to THIS
@@ -10605,7 +10799,7 @@ const dashboardHTML = `<!DOCTYPE html>
         /* Non-admin lists have no section headers, so the flat list's
            select-all lives in the table head instead. */
         '<th style="width:26px;text-align:center">' + (_isAdmin ? '' : bulkSectionCheckbox('all')) + '</th>' +
-        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer" title="Where this hive runs, and whether it is listed publicly">Location / Public ⇅</th><th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'aiAuthor\')" style="cursor:pointer" title="The GitHub identity this hive\'s agents open PRs as — the configured ai_author, or the App bot (&lt;slug&gt;[bot]) in App-authored mode">AI Author ⇅</th><th onclick="sortDashHives(\'journey\')" style="cursor:pointer" title="Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run ClankeR, the contributor relay), then raise the ACMM level">Journey ⇅</th><th title="Configuration drift from the fleet norm — hover a value for the specific signals">Drift</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
+        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer" title="Where this hive runs, and whether it is listed publicly">Location / Public ⇅</th><th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'aiAuthor\')" style="cursor:pointer" title="The GitHub identity this hive\'s agents open PRs as — the configured ai_author, or the App bot (&lt;slug&gt;[bot]) in App-authored mode">AI Author ⇅</th><th onclick="sortDashHives(\'journey\')" style="cursor:pointer" title="Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run ClankeR, the contributor relay), then raise the ACMM level">Journey ⇅</th><th title="Configuration drift from the fleet norm — hover a value for the specific signals">Drift</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th><th onclick="sortDashHives(\'registeredAt\')" style="cursor:pointer" title="When this hive was first provisioned — the hub&apos;s first-seen time, preserved across restarts and heartbeats">Provisioned ⇅</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table></div>';
       /* Delegated, so binding once is enough no matter how often the table is
          re-rendered. The guard keeps repeated renders from stacking listeners. */
@@ -12278,15 +12472,29 @@ const dashboardHTML = `<!DOCTYPE html>
          already reflects the operator's view rather than flashing the ungrouped
          list and then rearranging. */
       loadDashViewPrefs();
+      /* Sort is resolved AFTER loadDashViewPrefs because applying a default
+         saved view sets a key/direction of its own: the operator's explicitly
+         stored sort is the more specific signal and must have the last word.
+         Both run before the first paint so no render happens in the wrong
+         order. */
+      loadHiveSortPrefs();
       /* Progressive paint: put the last known fleet on screen immediately so a
          returning operator sees their hives instead of a spinner. The network
          path below still runs unconditionally and reconciles the list; this
          only changes what fills the gap while it is in flight. Must come after
          loadDashViewPrefs() so the cached rows honour the active view. */
       paintCachedHives();
+      /* Record the offset from here on. Attached before the awaits below so a
+         scroll during a slow load is still captured. */
+      window.addEventListener('scroll', persistHiveScroll, {passive: true});
       await loadUser();
       await autoRequestAccessFromUrl();
       await loadHives();
+      /* Restore AFTER the real rows are in the DOM — loadHives' renderHives is
+         what gives the document its full height, and restoreHiveScroll still
+         waits for that height before it commits (see its frame loop). Calling
+         it any earlier clamps the offset to a short page and lands at the top. */
+      restoreHiveScroll();
       await loadAdminUsers();
       if (!_adminLoaded) setTimeout(loadAdminUsers, 2000);
       loadClusterHealth();

--- a/v2/pkg/hub/saas_dashboard_facet_tray_test.go
+++ b/v2/pkg/hub/saas_dashboard_facet_tray_test.go
@@ -114,8 +114,8 @@ func TestStatusFiltersMovedIntoTray(t *testing.T) {
 	}
 	// Semantics unchanged: same state, same predicate, same handlers.
 	for _, want := range []string{
-		"_dashStatusFilters",       // health chips still OR among themselves
-		"_dashFailingCheckFilter",  // failing check still single-select, ANDed
+		"_dashStatusFilters",      // health chips still OR among themselves
+		"_dashFailingCheckFilter", // failing check still single-select, ANDed
 		"toggleStatusFilter(",
 		"setFailingCheckFilter(",
 	} {
@@ -340,19 +340,20 @@ func TestHiveTableColumnCountsAgree(t *testing.T) {
 		t.Errorf("header emits %d <th> cells but a row emits %d cells — "+
 			"every column right of the mismatch is shifted", thCount, tdCount)
 	}
-	// 17: the Public column was folded into Location (visibility stacks beneath
-	// the location badge) leaving 16 — see the Location cell in buildRow — and
-	// the AI Author column was then added alongside ACMM to show the GitHub
-	// identity a hive's agents open PRs as.
-	const wantColumns = 17
+	// 18: the Public column was folded into Location (visibility stacks beneath
+	// the location badge) leaving 16 — see the Location cell in buildRow — the
+	// AI Author column was then added alongside ACMM to show the GitHub
+	// identity a hive's agents open PRs as, and Provisioned was added at the
+	// end so the fleet can be ordered by when each hive was first seen.
+	const wantColumns = 18
 	if thCount != wantColumns {
 		t.Errorf("hive table has %d columns, want %d", thCount, wantColumns)
 	}
 	// The colspan constants span the whole table; a stale value leaves the
 	// section separators and the pending-requests row visibly short.
 	for _, decl := range []string{
-		"var TOTAL_COLUMNS = 17;",
-		"var TOTAL_COLUMNS_HEADER = 17;",
+		"var TOTAL_COLUMNS = 18;",
+		"var TOTAL_COLUMNS_HEADER = 18;",
 	} {
 		if !strings.Contains(html, decl) {
 			t.Errorf("missing or stale colspan constant: %s", decl)

--- a/v2/pkg/hub/saas_dashboard_hive_sort_test.go
+++ b/v2/pkg/hub/saas_dashboard_hive_sort_test.go
@@ -1,0 +1,145 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// The hive-table sort and the scroll/sort persistence live inside the
+// dashboardHTML raw string, so there is no Go function to call. These tests
+// guard the wiring the same way the neighbouring dashboard tests do: every
+// handler the markup references must exist, and the invariants that are silent
+// when broken must stay asserted somewhere CI runs.
+//
+// "Silent when broken" is the whole point here. If the default sort key stops
+// being 'name', or a persisted choice starts being overwritten by the default,
+// or the scroll restore moves back ahead of the render that gives the document
+// its height, nothing throws — the table just quietly ignores the operator.
+
+// TestHiveSortDefaultsToAlphabetical pins the first-visit ordering to the Hive
+// column, ascending. Before this the table rendered in registry order, which is
+// arrival order and reads as arbitrary.
+func TestHiveSortDefaultsToAlphabetical(t *testing.T) {
+	html := dashScript(t)
+	for _, snippet := range []string{
+		"var HIVE_SORT_DEFAULT_KEY = 'name';",
+		"var HIVE_SORT_DEFAULT_ASC = true;",
+		// The state seed must match the default so the very first paint —
+		// paintCachedHives, which runs before any network call — is already A-Z.
+		"var _dashSortKey = 'name', _dashSortAsc = true;",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("dashboardHTML is missing %q — the default hive sort is no longer A-Z", snippet)
+		}
+	}
+}
+
+// TestHiveSortPersistenceWiring asserts the persisted choice survives a reload
+// and, critically, that the A-Z default does NOT clobber it.
+func TestHiveSortPersistenceWiring(t *testing.T) {
+	html := dashScript(t)
+	for _, snippet := range []string{
+		"var LS_HIVE_SORT = 'hive-sort';",
+		"function persistHiveSort()",
+		"function loadHiveSortPrefs()",
+		// A header click must record the choice, otherwise nothing is ever
+		// persisted and the reload silently falls back to the default.
+		"persistHiveSort();",
+		// The stored value is validated before use, so a stale key degrades to
+		// the default instead of sorting on a property no row has.
+		"function isHiveSortKey(key)",
+		"isHiveSortKey(stored.key)",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("dashboardHTML is missing %q — hive sort persistence is not wired", snippet)
+		}
+	}
+
+	// loadHiveSortPrefs must run at init, AFTER loadDashViewPrefs: applying a
+	// default saved view sets a sort of its own, and the operator's explicit
+	// stored sort is the more specific signal, so it has to have the last word.
+	viewIdx := strings.Index(html, "loadDashViewPrefs();")
+	sortIdx := strings.Index(html, "loadHiveSortPrefs();")
+	if viewIdx < 0 || sortIdx < 0 {
+		t.Fatal("init no longer calls loadDashViewPrefs()/loadHiveSortPrefs()")
+	}
+	if sortIdx < viewIdx {
+		t.Error("loadHiveSortPrefs() runs before loadDashViewPrefs() — a default saved view would override the operator's explicit sort")
+	}
+}
+
+// TestHiveScrollRestoreRunsAfterRender is the ordering guard. The rows paint
+// asynchronously, and the document is only as tall as what has been painted, so
+// scrolling before the table exists clamps to the current maximum and silently
+// lands at the top — the exact bug the feature is meant to fix.
+func TestHiveScrollRestoreRunsAfterRender(t *testing.T) {
+	html := dashScript(t)
+	for _, snippet := range []string{
+		"var LS_HIVE_SCROLL = 'hive-scroll';",
+		"function persistHiveScroll()",
+		"function readHiveScroll()",
+		"function restoreHiveScroll()",
+		// Throttled through rAF: scroll fires at input rate and setItem is
+		// synchronous, so an unthrottled write janks the scroll it records.
+		"window.requestAnimationFrame(",
+		"window.addEventListener('scroll', persistHiveScroll, {passive: true});",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("dashboardHTML is missing %q — scroll persistence is not wired", snippet)
+		}
+	}
+
+	loadIdx := strings.Index(html, "await loadHives();")
+	restoreIdx := strings.Index(html, "restoreHiveScroll();")
+	if loadIdx < 0 || restoreIdx < 0 {
+		t.Fatal("init no longer calls loadHives()/restoreHiveScroll()")
+	}
+	if restoreIdx < loadIdx {
+		t.Error("restoreHiveScroll() runs before await loadHives() — the rows have not rendered yet, so the offset clamps to a short page and the restore silently does nothing")
+	}
+}
+
+// TestHiveProvisionSortUsesRegisteredAt pins the timestamp field.
+//
+// registeredAt, NOT the per-hive meta.json created_at: created_at is written on
+// exactly one provisioning path, so hives created any other way — or before the
+// field existed — carry the empty string. On the live fleet 26 of 50 meta.json
+// files have "created_at": "" while registeredAt was populated on 50 of 50
+// registry entries. registeredAt is also carried forward across heartbeats
+// (see the RegisteredAt copy in handleHeartbeat) rather than restamped, so it
+// stays first-seen time instead of drifting to "now" on every beat.
+func TestHiveProvisionSortUsesRegisteredAt(t *testing.T) {
+	html := dashScript(t)
+	for _, snippet := range []string{
+		"function hiveProvisionTime(h)",
+		"var raw = h && h.registeredAt;",
+		"sortDashHives(\\'registeredAt\\')",
+		"Provisioned ⇅",
+		// registeredAt must be a recognised sort key, otherwise a persisted
+		// choice of it would be rejected on the next load.
+		"'registeredAt'",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("dashboardHTML is missing %q — provision-date sort is not wired to registeredAt", snippet)
+		}
+	}
+
+	// created_at must NOT be what the hive table sorts on. It is still legitimately
+	// used by the admin USERS table (fmtUserTS / sortUsers), so assert on the
+	// hive-side accessor specifically rather than banning the string outright.
+	if strings.Contains(html, "h.created_at") {
+		t.Error("the hive table reads h.created_at — it is empty on over half the live fleet; use registeredAt")
+	}
+}
+
+// TestHiveProvisionCellHandlesMissingTimestamp guards the render path: a hive
+// with no usable timestamp must show an em dash, never the string
+// "Invalid Date" that new Date(”) stringifies to.
+func TestHiveProvisionCellHandlesMissingTimestamp(t *testing.T) {
+	html := dashScript(t)
+	// The cell and the comparator must agree on "is this usable", so the cell
+	// asks hiveProvisionTime rather than testing the raw field itself.
+	if !strings.Contains(html, "hiveProvisionTime(h) === null ? '—'") {
+		t.Error("the Provisioned cell does not fall back to an em dash via hiveProvisionTime — a hive with an empty registeredAt would render 'Invalid Date'")
+	}
+}


### PR DESCRIPTION
Top-up. #2317 and #2310 landed on `v2` during CI for #2320.

Brings `dd` to `origin/v2` @ `626a50c7`:
- #2317 — default hives A-Z, provision-date sort, persist sort + scroll
- #2310 — cost management FAQ entries in Resources

Merged with **no conflicts**. `go build ./...` clean; `pkg/hub` sort/facet/avatar tests pass; `saas.go` byte-identical to `origin/v2`.

> [!IMPORTANT]
> Merge with `--merge`, **not** `--squash`.