### PR TITLE
🐛 fix(hub): clear upgrade flags orphaned by departed spoke pods

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3636,6 +3636,11 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 	}
 	// On first poll, check if any auto-upgrade hives are behind
 	s.triggerAutoUpgrades()
+	// Clear Upgrading flags orphaned by spoke pods that vanished mid-upgrade.
+	// Runs alongside — not inside — triggerAutoUpgrades because that function
+	// only ever considers hives with AutoUpgrade enabled, while the flag is set
+	// by the admin and bulk upgrade paths for any hive.
+	s.sweepOrphanedUpgrades()
 	ticker := time.NewTicker(latestSHAPollInterval)
 	defer ticker.Stop()
 	for {
@@ -3655,6 +3660,7 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 		}
 		// Always check for pending auto-upgrades (retries failed/missed hives).
 		s.triggerAutoUpgrades()
+		s.sweepOrphanedUpgrades()
 		changed := false
 		for branch, sha := range newSHAs {
 			if sha != "" && sha != oldSHAs[branch] {

--- a/v2/pkg/hub/stale_upgrade.go
+++ b/v2/pkg/hub/stale_upgrade.go
@@ -1,0 +1,181 @@
+package hub
+
+import (
+	"time"
+)
+
+// orphanedUpgradeGrace is the EXTRA time, beyond staleUpgradeTimeout, that a
+// hive must sit latched-upgrading before the sweep will clear its flag.
+//
+// It is deliberately derived from staleUpgradeTimeout rather than being an
+// independent number, so retuning the one constant that already defines "this
+// upgrade is stuck" (server.go) moves the warning threshold, the dashboard's
+// red elapsed counter, the drift check and this sweep together.
+//
+// The clear threshold is longer than the warn threshold on purpose. At
+// staleUpgradeTimeout the hub only says "this is taking too long" — a slow but
+// real upgrade (cold-node image pull of a large layer) can still be in flight,
+// and clearing there could cancel a legitimate rollout out from under itself.
+// Doubling it means we only ever clear an attempt that has had twice the time
+// the hub itself calls excessive, and only when the evidence below also says
+// the attempt no longer exists.
+const orphanedUpgradeGrace = staleUpgradeTimeout
+
+// orphanedUpgradeClearAfter is the total elapsed time since UpgradeStartedAt
+// after which an upgrade with no live attempt behind it is considered orphaned.
+const orphanedUpgradeClearAfter = staleUpgradeTimeout + orphanedUpgradeGrace
+
+// upgradeAttemptEvidence describes whether a still-latched upgrade has an
+// attempt actually behind it, and if not, why we concluded that.
+type upgradeAttemptEvidence struct {
+	// orphaned is true when the flag should be cleared.
+	orphaned bool
+	// reason is a short human-readable justification, logged and surfaced.
+	reason string
+	// elapsed is the time since the upgrade was instructed.
+	elapsed time.Duration
+}
+
+// evaluateOrphanedUpgrade decides whether entry's Upgrading flag is orphaned:
+// set by a hub instruction whose spoke pod died before it could either complete
+// the upgrade or report the failure, leaving nothing alive to clear it.
+//
+// The reliable signal is a heartbeat NEWER than UpgradeStartedAt that still
+// reports the OLD SHA. During a genuine upgrade the spoke's pod is restarting
+// into the new image, so it is not heartbeating; and the moment it comes back
+// it reports the new GitHash, which the heartbeat path already uses to clear
+// the flag (server.go). So a hive that is demonstrably alive and talking to us
+// long after the upgrade was instructed, while still running the SHA it started
+// on, cannot have an attempt in flight — the attempt is gone.
+//
+// Elapsed time alone is NOT sufficient and is not used alone here: a slow image
+// pull looks identical to an orphan if you only look at the clock. Both
+// conditions must hold.
+func evaluateOrphanedUpgrade(entry *RegistryEntry, now time.Time) upgradeAttemptEvidence {
+	var ev upgradeAttemptEvidence
+
+	if !entry.Upgrading {
+		return ev
+	}
+	// A spoke that explicitly reported failure is already handled by the
+	// heartbeat path, which clears Upgrading and records the cause. Leave that
+	// terminal state alone — it carries a known reason this sweep would erase.
+	if entry.UpgradeFailed {
+		return ev
+	}
+	// Without a start timestamp there is no elapsed time to reason about. The
+	// auto-upgrade recovery path treats a zero timestamp as stale, but that path
+	// re-arms delivery rather than clearing state; clearing on no evidence at
+	// all would risk dropping a genuinely fresh upgrade, so we decline.
+	if entry.UpgradeStartedAt.IsZero() {
+		return ev
+	}
+
+	ev.elapsed = now.Sub(entry.UpgradeStartedAt)
+	if ev.elapsed < orphanedUpgradeClearAfter {
+		return ev
+	}
+
+	// Evidence: has the spoke checked in since we instructed the upgrade?
+	lastBeat, err := time.Parse(time.RFC3339, entry.LastHeartbeat)
+	if err != nil {
+		// Never heartbeated, or an unparseable timestamp. We cannot prove the
+		// attempt is gone, so we do not clear — an offline hive is reported by
+		// the offline alert instead.
+		return ev
+	}
+	if !lastBeat.After(entry.UpgradeStartedAt) {
+		// Silent since the upgrade was instructed. That is what a restart in
+		// progress looks like, so it must not be cleared here.
+		return ev
+	}
+
+	// The spoke is alive and post-dates the instruction. If it is already on the
+	// target, the flag is merely lagging and the heartbeat path clears it; only
+	// a spoke still on a DIFFERENT SHA is genuinely un-upgraded.
+	if entry.UpgradeTarget != "" && sameCommit(entry.GitHash, entry.UpgradeTarget) {
+		return ev
+	}
+
+	ev.orphaned = true
+	ev.reason = "spoke heartbeated " + roundedDuration(now.Sub(lastBeat)) +
+		" ago still running " + orDash(entry.GitHash) +
+		", no upgrade attempt in flight"
+	return ev
+}
+
+// sweepOrphanedUpgrades clears Upgrading flags left behind by spoke pods that
+// vanished mid-upgrade. It runs on the hub, unconditioned on AutoUpgrade,
+// because the flag is set by admin and bulk upgrade paths too — the existing
+// recovery inside triggerAutoUpgrades() is gated on a hive having AutoUpgrade
+// enabled and so never sees those hives at all.
+//
+// Clearing does NOT lose the fact that the upgrade never happened. The hive is
+// still on its old SHA, and the sweep re-arms the heartbeat instruction so the
+// next check-in carries the target again — the false "in flight" claim was
+// SUPPRESSING delivery, since every upgrade path skips a hive it believes is
+// mid-upgrade. UpgradeTarget is preserved for observability, and the event is
+// logged and written to the hive's timeline.
+func (s *HubServer) sweepOrphanedUpgrades() {
+	now := time.Now()
+
+	type cleared struct {
+		id       string
+		from, to string
+		elapsed  time.Duration
+		reason   string
+	}
+	var swept []cleared
+
+	s.mu.Lock()
+	for i := range s.registry.Hives {
+		h := &s.registry.Hives[i]
+		ev := evaluateOrphanedUpgrade(h, now)
+		if !ev.orphaned {
+			continue
+		}
+		swept = append(swept, cleared{
+			id:      h.ID,
+			from:    h.GitHash,
+			to:      h.UpgradeTarget,
+			elapsed: ev.elapsed,
+			reason:  ev.reason,
+		})
+		h.Upgrading = false
+
+		// Re-arm delivery rather than dropping it. Clearing the flag alone is
+		// NOT enough to make the hive upgrade again: heartbeatUpgrade is an
+		// in-memory map (server.go), so a hub restart — the very event that
+		// orphans these upgrades — wipes the armed target while the registry's
+		// Upgrading=true survives on disk. The hive is left on the old SHA with
+		// nothing instructing it.
+		//
+		// The two heartbeat re-instruct branches (server.go) fire only for a
+		// spoke-managed hive or one with an armed hbTarget. A hub-managed hive
+		// with AutoUpgrade off matches neither, so without this it would
+		// silently stop receiving the upgrade. Re-arming the existing target
+		// keeps the instruction alive; it is idempotent, and the heartbeat path
+		// clears it as soon as the spoke reports the target SHA.
+		if h.UpgradeTarget != "" {
+			s.heartbeatUpgrade[h.ID] = h.UpgradeTarget
+		}
+	}
+	s.mu.Unlock()
+
+	for _, c := range swept {
+		s.logger.Warn("cleared orphaned upgrade flag — no attempt in flight",
+			"hive_id", c.id,
+			"elapsed", roundedDuration(c.elapsed),
+			"from", orDash(c.from),
+			"to", orDash(c.to),
+			"reason", c.reason,
+		)
+		s.recordTimeline(c.id, TimelineUpgradeStale,
+			"upgrade never completed after "+roundedDuration(c.elapsed)+
+				" — cleared stale in-flight state (still on "+orDash(c.from)+
+				", target was "+orDash(c.to)+")", "stale-upgrade-sweep")
+	}
+	if len(swept) > 0 {
+		s.requestSave()
+	}
+}

--- a/v2/pkg/hub/stale_upgrade_test.go
+++ b/v2/pkg/hub/stale_upgrade_test.go
@@ -1,0 +1,179 @@
+package hub
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// fixedSweepNow is an arbitrary but stable clock for these tests.
+var fixedSweepNow = time.Date(2026, 7, 31, 14, 40, 0, 0, time.UTC)
+
+// TestEvaluateOrphanedUpgrade covers the decision that separates an upgrade
+// whose attempt has vanished from one that may still be in flight.
+func TestEvaluateOrphanedUpgrade(t *testing.T) {
+	// The production incident this fix exists for: hive
+	// hosted-available-oke-05-placeholder-6q84 sat Upgrading for 68 minutes
+	// while heartbeating normally on the OLD SHA, because its pod died between
+	// the instruction and any completion/failure report.
+	started := fixedSweepNow.Add(-68 * time.Minute)
+
+	cases := []struct {
+		name     string
+		entry    RegistryEntry
+		orphaned bool
+	}{
+		{
+			name: "orphaned: alive and heartbeating past the threshold on the old SHA",
+			entry: RegistryEntry{
+				Upgrading:        true,
+				UpgradeStartedAt: started,
+				GitHash:          "c11643a",
+				UpgradeTarget:    "fc32ae4",
+				LastHeartbeat:    rfc3339(fixedSweepNow.Add(-30 * time.Second)),
+			},
+			orphaned: true,
+		},
+		{
+			name: "in flight: silent since the upgrade was instructed (pod restarting)",
+			entry: RegistryEntry{
+				Upgrading:        true,
+				UpgradeStartedAt: started,
+				GitHash:          "c11643a",
+				UpgradeTarget:    "fc32ae4",
+				LastHeartbeat:    rfc3339(started.Add(-time.Minute)),
+			},
+			orphaned: false,
+		},
+		{
+			name: "in flight: a slow but recent upgrade is never cleared on elapsed time alone",
+			entry: RegistryEntry{
+				Upgrading:        true,
+				UpgradeStartedAt: fixedSweepNow.Add(-staleUpgradeTimeout - time.Minute),
+				GitHash:          "c11643a",
+				UpgradeTarget:    "fc32ae4",
+				LastHeartbeat:    rfc3339(fixedSweepNow.Add(-10 * time.Second)),
+			},
+			orphaned: false,
+		},
+		{
+			name: "not orphaned: spoke already reports the target, heartbeat path clears it",
+			entry: RegistryEntry{
+				Upgrading:        true,
+				UpgradeStartedAt: started,
+				GitHash:          "fc32ae4",
+				UpgradeTarget:    "fc32ae4",
+				LastHeartbeat:    rfc3339(fixedSweepNow.Add(-30 * time.Second)),
+			},
+			orphaned: false,
+		},
+		{
+			name: "not orphaned: an explicitly reported failure keeps its known cause",
+			entry: RegistryEntry{
+				Upgrading:        true,
+				UpgradeFailed:    true,
+				UpgradeStartedAt: started,
+				GitHash:          "c11643a",
+				UpgradeTarget:    "fc32ae4",
+				LastHeartbeat:    rfc3339(fixedSweepNow.Add(-30 * time.Second)),
+			},
+			orphaned: false,
+		},
+		{
+			name: "not orphaned: never heartbeated, so we cannot prove the attempt is gone",
+			entry: RegistryEntry{
+				Upgrading:        true,
+				UpgradeStartedAt: started,
+				GitHash:          "c11643a",
+				UpgradeTarget:    "fc32ae4",
+			},
+			orphaned: false,
+		},
+		{
+			name: "not orphaned: no start timestamp means no elapsed time to judge",
+			entry: RegistryEntry{
+				Upgrading:     true,
+				GitHash:       "c11643a",
+				UpgradeTarget: "fc32ae4",
+				LastHeartbeat: rfc3339(fixedSweepNow.Add(-30 * time.Second)),
+			},
+			orphaned: false,
+		},
+		{
+			name:     "not upgrading at all",
+			entry:    RegistryEntry{GitHash: "c11643a"},
+			orphaned: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := evaluateOrphanedUpgrade(&tc.entry, fixedSweepNow)
+			if got.orphaned != tc.orphaned {
+				t.Fatalf("orphaned = %v, want %v (reason %q)", got.orphaned, tc.orphaned, got.reason)
+			}
+			if got.orphaned && got.reason == "" {
+				t.Fatal("an orphaned verdict must carry a reason for the log")
+			}
+		})
+	}
+}
+
+// TestSweepOrphanedUpgradesClearsAndReArms asserts the two halves of the fix:
+// the false in-flight flag goes away, AND the upgrade is still delivered. The
+// second half is the one that matters — clearing alone would leave a
+// hub-managed hive silently stranded on the old SHA.
+func TestSweepOrphanedUpgradesClearsAndReArms(t *testing.T) {
+	s := &HubServer{
+		logger:           slog.Default(),
+		heartbeatUpgrade: make(map[string]string),
+	}
+	s.registry.Hives = []RegistryEntry{
+		{
+			ID:               "orphaned-hive",
+			Upgrading:        true,
+			UpgradeStartedAt: time.Now().Add(-68 * time.Minute),
+			GitHash:          "c11643a",
+			UpgradeTarget:    "fc32ae4",
+			LastHeartbeat:    rfc3339(time.Now().Add(-30 * time.Second)),
+		},
+		{
+			ID:               "healthy-in-flight",
+			Upgrading:        true,
+			UpgradeStartedAt: time.Now().Add(-2 * time.Minute),
+			GitHash:          "c11643a",
+			UpgradeTarget:    "fc32ae4",
+			LastHeartbeat:    rfc3339(time.Now().Add(-10 * time.Second)),
+		},
+	}
+
+	s.sweepOrphanedUpgrades()
+
+	if s.registry.Hives[0].Upgrading {
+		t.Error("orphaned hive should have had Upgrading cleared")
+	}
+	if got := s.heartbeatUpgrade["orphaned-hive"]; got != "fc32ae4" {
+		t.Errorf("orphaned hive must be re-armed for delivery, heartbeatUpgrade = %q, want %q", got, "fc32ae4")
+	}
+	if s.registry.Hives[0].UpgradeTarget != "fc32ae4" {
+		t.Error("UpgradeTarget must be preserved for observability")
+	}
+	if !s.registry.Hives[1].Upgrading {
+		t.Error("a genuinely in-flight upgrade must not be cleared")
+	}
+}
+
+// TestOrphanedUpgradeThresholdDerivesFromStaleUpgradeTimeout guards the
+// constant relationship: the clear threshold must stay tied to — and strictly
+// later than — the threshold at which the hub merely WARNS, so a slow upgrade
+// is never cancelled at the moment it is first called stuck.
+func TestOrphanedUpgradeThresholdDerivesFromStaleUpgradeTimeout(t *testing.T) {
+	if orphanedUpgradeClearAfter <= staleUpgradeTimeout {
+		t.Fatalf("clear threshold %v must be later than the warn threshold %v",
+			orphanedUpgradeClearAfter, staleUpgradeTimeout)
+	}
+	if want := staleUpgradeTimeout + orphanedUpgradeGrace; orphanedUpgradeClearAfter != want {
+		t.Fatalf("clear threshold %v must be derived from staleUpgradeTimeout, want %v",
+			orphanedUpgradeClearAfter, want)
+	}
+}


### PR DESCRIPTION
## The bug

A hive whose spoke pod dies between the hub instructing an upgrade and the spoke reporting success or failure is left latched at `Upgrading=true` **forever**. Nothing clears it:

- the completion path (`server.go`) needs a heartbeat reporting the new SHA;
- #2308's `ReportUpgradeFailure` path needs a **live spoke** to report its own failure.

When the pod is simply gone, there is no spoke left to do either.

The consequence is worse than a stuck spinner. Every upgrade path skips a hive it believes is mid-upgrade, so the false in-flight claim **suppresses delivery** — the hive silently stops receiving upgrades while sitting on the old SHA.

## Live reproduction

`hosted-available-oke-05-placeholder-6q84` on `hive-oke`, verified read-only against the running hub's registry:

```
upgrading        = true
upgradeStartedAt = 2026-07-31T13:32:37Z
gitHash          = c11643a      (old)
upgradeTarget    = fc32ae4
lastHeartbeat    = 2026-07-31T14:40:28Z   <-- 68 min AFTER the upgrade started
```

The pod is 69 minutes old with **0 restarts**, so the current pod post-dates `upgradeStartedAt` and its log contains no upgrade lines — the attempt belonged to a pod that no longer exists. The hive is otherwise fully healthy and doing real work.

## Why the existing recovery never fired

There **is** a stale-upgrade recovery, in `triggerAutoUpgrades()` (`saas.go`). It is unreachable for this class of hive:

1. It is gated behind `if !h.AutoUpgrade { continue }`, but `Upgrading` is also set by the admin and bulk upgrade paths (`saas_bulk.go`, `saas.go`), which do not require `AutoUpgrade`. **Verified: 0 of 50 hives in the live fleet have `autoUpgrade=true`** — the block is effectively dead code in production.
2. Even when reached, it only re-arms the target; it **never clears the flag**.

So this adds the missing sweep rather than a second competing mechanism.

## The fix

A hub-side sweep on the existing SHA-poller cycle, unconditioned on `AutoUpgrade`.

**Signal used** — the flag is cleared only on positive evidence that no attempt is in flight: a heartbeat **newer than `UpgradeStartedAt`** that still reports the **old** SHA. This is reliable because during a genuine upgrade the pod is restarting and therefore silent, and the moment it returns it reports the new `GitHash` (which the existing heartbeat path already uses to clear the flag). A hive demonstrably alive and talking to us long after the instruction, still on its starting SHA, cannot have an attempt running.

Elapsed time alone is deliberately **not** sufficient — a slow image pull on a cold node is indistinguishable on the clock. Both conditions must hold. Also skipped: `UpgradeFailed` entries (terminal, with a known cause worth keeping), zero `UpgradeStartedAt`, never-heartbeated hives, and hives already at the target.

**Nothing is silently lost.** Clearing **re-arms** the heartbeat instruction rather than dropping it. `heartbeatUpgrade` is an in-memory map, so a hub restart — the very event that orphans these upgrades — wipes the armed target while `Upgrading=true` survives on disk. The two re-instruct branches in `server.go` fire only for a spoke-managed hive or one with an armed target, so a hub-managed hive with `AutoUpgrade` off matches neither; clearing alone would strand it. `UpgradeTarget` is preserved for observability.

**Constants.** `orphanedUpgradeClearAfter = staleUpgradeTimeout + orphanedUpgradeGrace`, with `orphanedUpgradeGrace = staleUpgradeTimeout` — derived from the existing constant rather than introducing a competing number, so retuning `staleUpgradeTimeout` moves the warning threshold, the dashboard's red counter, the drift check and this sweep together. The clear threshold is deliberately **later** than the warn threshold so an upgrade is never cancelled at the moment it is first merely called slow. A test guards that relationship.

**Observability.** WARN log with hive id, elapsed, both SHAs and the reason, plus a `TimelineUpgradeStale` entry. No new alert type — the existing `AlertTypeStuckUpgrade` (#2308/#2309) already surfaces the condition and is what this sweep resolves.

## Testing

- `go build ./...` clean; `go test ./pkg/hub/` fully green (post-rebase).
- New table test covers the orphaned case and every must-not-clear case (restarting pod, slow-but-recent upgrade, reported failure, already-at-target, never-heartbeated, no timestamp).
- Sweep test asserts both halves: flag cleared **and** delivery re-armed, while a genuinely in-flight upgrade is untouched.
- `saas.go` change is 6 lines of plain Go in `StartLatestSHAPoller`, far from `dashboardHTML`; backtick count verified identical to HEAD (354).

Rebased on fresh `origin/v2` (includes #2310, #2317).

🤖 Generated with [Claude Code](https://claude.com/claude-code)