### PR TITLE
🐛 fix(hub): stop the public fleet-stats total collapsing to a wrong small number

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2192,9 +2192,17 @@ func main() {
 			// successful compute — nil pointers until then, so the hub never
 			// aggregates a not-yet-computed zero into the public fleet total.
 			var prsMerged, prsRejected, cvesClosed *int
+			fleetStatsCollectedAt := ""
 			if fc, ok := fleetStatsCollector.Snapshot(); ok {
 				m, rj, cv := fc.PRsMerged, fc.PRsRejected, fc.CVEsClosed
 				prsMerged, prsRejected, cvesClosed = &m, &rj, &cv
+				// Report WHEN these were computed, not when this beat was sent.
+				// The hub carries counts forward across spoke restarts, so this
+				// timestamp is the only way it can tell a fresh contribution
+				// from one frozen by a collector that has started failing.
+				if t := fleetStatsCollector.CollectedAt(); !t.IsZero() {
+					fleetStatsCollectedAt = t.UTC().Format(time.RFC3339)
+				}
 			}
 			// Count agents with a method/model assigned for the hub's
 			// user-journey stage detection. Always a non-nil pointer from a
@@ -2329,9 +2337,10 @@ func main() {
 					}
 					return hub.CollectClusterHealth(logger)
 				}(),
-				PRsMerged90d:   prsMerged,
-				PRsRejected90d: prsRejected,
-				CVEsClosed:     cvesClosed,
+				PRsMerged90d:          prsMerged,
+				PRsRejected90d:        prsRejected,
+				CVEsClosed:            cvesClosed,
+				FleetStatsCollectedAt: fleetStatsCollectedAt,
 				// Report WHICH App key we hold, never the key. The hub compares
 				// this against its per-cluster key and pushes a correction only
 				// on a mismatch, so a spoke already holding the right key costs

--- a/v2/pkg/dashboard/fleet_stats_collector.go
+++ b/v2/pkg/dashboard/fleet_stats_collector.go
@@ -3,6 +3,7 @@ package dashboard
 import (
 	"context"
 	"log/slog"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -16,6 +17,30 @@ import (
 // A var (not a const) so tests can drive the ticker branch quickly; production
 // keeps the default.
 var fleetStatsCollectInterval = 30 * time.Minute
+
+// The GitHub search API allows only 30 requests per minute per token, and that
+// budget is shared by every hive authenticating as the same App installation.
+// A hub-wide rolling restart brings ~50 spokes up within seconds of each other,
+// each firing three searches at once — far over the quota — so the first
+// collect fails on most spokes. Before this jitter+retry existed those spokes
+// simply gave up until the next 30-minute tick, and because a restart also
+// clears the previously reported counts (they live only in memory), the public
+// fleet total collapsed to whatever the handful of survivors reported. That is
+// the "statistics are missing again" regression.
+//
+// fleetStatsStartupJitterMax spreads the initial collect across a window wider
+// than the burst, so spokes queue up against the quota instead of colliding.
+var fleetStatsStartupJitterMax = 5 * time.Minute
+
+// fleetStatsRetryAttempts is the total number of tries for a single collect
+// (one initial attempt plus retries) before giving up until the next tick.
+const fleetStatsRetryAttempts = 4
+
+// fleetStatsRetryBaseDelay is the first retry delay; each subsequent retry
+// doubles it (1m, 2m, 4m). The search quota refills every minute, so a
+// minute-scale backoff is the shortest delay that can actually clear a
+// rate-limit rejection rather than burning an attempt on a still-empty budget.
+var fleetStatsRetryBaseDelay = time.Minute
 
 // FleetStatsCollector periodically computes this hive's AI-author contribution
 // counts (PRs merged, PRs rejected, CVE-referencing PRs) across its org and
@@ -34,6 +59,11 @@ type FleetStatsCollector struct {
 	// omit zero counts that merely mean "not computed yet" rather than "truly
 	// zero" — the hub then hides the stat instead of showing a fake number.
 	ready bool
+	// collectedAt is when counts were last successfully computed. The heartbeat
+	// reports it so the hub can tell a fresh count from one left over from a
+	// collect that has since started failing, and surface the difference rather
+	// than presenting stale numbers as current.
+	collectedAt time.Time
 }
 
 // NewFleetStatsCollector builds a collector for the given AI author and org.
@@ -54,7 +84,21 @@ func NewFleetStatsCollector(ghClient *ghpkg.Client, author, org string, logger *
 // stopped on return, so there is no uncancellable timer leak.
 func (fc *FleetStatsCollector) Start(ctx context.Context) {
 	if fc == nil || fc.ghClient == nil || fc.author == "" || fc.org == "" {
+		if fc != nil && fc.logger != nil {
+			fc.logger.Warn("fleet stats collector not started; this hive will never "+
+				"contribute to the public fleet total",
+				"author", fc.author, "org", fc.org, "has_github_client", fc != nil && fc.ghClient != nil)
+		}
 		return
+	}
+	// Stagger the very first collect. Without this every spoke in a rolling
+	// restart searches at the same instant and most are rate-limited away.
+	if d := fc.startupDelay(); d > 0 {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(d):
+		}
 	}
 	fc.collect(ctx)
 	ticker := time.NewTicker(fleetStatsCollectInterval)
@@ -69,29 +113,61 @@ func (fc *FleetStatsCollector) Start(ctx context.Context) {
 	}
 }
 
-func (fc *FleetStatsCollector) collect(ctx context.Context) {
-	counts, err := fc.ghClient.ComputeFleetContribCounts(ctx, fc.author, fc.org)
-	if err != nil {
-		if fc.logger != nil {
-			// Warn, not Debug: a failure here means this hive silently drops out
-			// of the public fleet-stats total, and the only symptom is a blank
-			// strip on the landing page. That is not something to hide at a log
-			// level nobody enables.
-			fc.logger.Warn("fleet stats collect failed; this hive will not contribute to the fleet total",
-				"error", err, "author", fc.author, "org", fc.org)
-		}
-		return
+// startupDelay returns a random delay in [0, fleetStatsStartupJitterMax) used
+// to spread the fleet's first collect across the search-rate-limit window.
+func (fc *FleetStatsCollector) startupDelay() time.Duration {
+	if fleetStatsStartupJitterMax <= 0 {
+		return 0
 	}
-	fc.mu.Lock()
-	fc.counts = counts
-	fc.ready = true
-	fc.mu.Unlock()
+	return time.Duration(rand.Int63n(int64(fleetStatsStartupJitterMax)))
+}
+
+// collect computes the counts, retrying with exponential backoff. A single
+// GitHub search rejection (rate limit, transient 5xx) must not cost this hive
+// its place in the fleet total until the next 30-minute tick.
+func (fc *FleetStatsCollector) collect(ctx context.Context) {
+	delay := fleetStatsRetryBaseDelay
+	var err error
+	for attempt := 1; attempt <= fleetStatsRetryAttempts; attempt++ {
+		var counts ghpkg.FleetContribCounts
+		counts, err = fc.ghClient.ComputeFleetContribCounts(ctx, fc.author, fc.org)
+		if err == nil {
+			fc.mu.Lock()
+			fc.counts = counts
+			fc.ready = true
+			fc.collectedAt = time.Now()
+			fc.mu.Unlock()
+			if fc.logger != nil {
+				fc.logger.Info("fleet stats collected",
+					"prs_merged", counts.PRsMerged,
+					"prs_rejected", counts.PRsRejected,
+					"cves_closed", counts.CVEsClosed,
+					"attempt", attempt,
+				)
+			}
+			return
+		}
+		if attempt == fleetStatsRetryAttempts {
+			break
+		}
+		if fc.logger != nil {
+			fc.logger.Warn("fleet stats collect failed; retrying",
+				"error", err, "attempt", attempt, "retry_in", delay.String())
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(delay):
+		}
+		delay *= 2
+	}
 	if fc.logger != nil {
-		fc.logger.Info("fleet stats collected",
-			"prs_merged", counts.PRsMerged,
-			"prs_rejected", counts.PRsRejected,
-			"cves_closed", counts.CVEsClosed,
-		)
+		// Warn, not Debug: a failure here means this hive silently drops out
+		// of the public fleet-stats total, and the only symptom is a blank
+		// strip on the landing page. That is not something to hide at a log
+		// level nobody enables.
+		fc.logger.Warn("fleet stats collect failed after all retries; this hive will not contribute to the fleet total",
+			"error", err, "author", fc.author, "org", fc.org, "attempts", fleetStatsRetryAttempts)
 	}
 }
 
@@ -105,4 +181,16 @@ func (fc *FleetStatsCollector) Snapshot() (ghpkg.FleetContribCounts, bool) {
 	fc.mu.RLock()
 	defer fc.mu.RUnlock()
 	return fc.counts, fc.ready
+}
+
+// CollectedAt returns when the cached counts were last successfully computed,
+// or the zero time if no collect has ever succeeded. The heartbeat forwards it
+// so the hub can age out stale contributions instead of summing them forever.
+func (fc *FleetStatsCollector) CollectedAt() time.Time {
+	if fc == nil {
+		return time.Time{}
+	}
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+	return fc.collectedAt
 }

--- a/v2/pkg/dashboard/fleet_stats_collector_test.go
+++ b/v2/pkg/dashboard/fleet_stats_collector_test.go
@@ -87,6 +87,13 @@ func TestFleetStatsCollector_NilAndEmpty(t *testing.T) {
 }
 
 func TestFleetStatsCollector_StartCancels(t *testing.T) {
+	// Disable the startup jitter: it exists to spread a 50-spoke fleet across
+	// the GitHub search rate-limit window, and would otherwise delay this
+	// test's initial collect by up to minutes.
+	origJitter := fleetStatsStartupJitterMax
+	fleetStatsStartupJitterMax = 0
+	defer func() { fleetStatsStartupJitterMax = origJitter }()
+
 	c := newFleetTestClient(t, map[string]int{"is:merged merged:>=": 1})
 	fc := NewFleetStatsCollector(c, "bot", "org", slog.Default())
 	ctx, cancel := context.WithCancel(context.Background())
@@ -117,6 +124,13 @@ func TestFleetStatsCollector_StartCancels(t *testing.T) {
 }
 
 func TestFleetStatsCollector_TickerReCollects(t *testing.T) {
+	// Disable the startup jitter: it exists to spread a 50-spoke fleet across
+	// the GitHub search rate-limit window, and would otherwise delay this
+	// test's initial collect by up to minutes.
+	origJitter := fleetStatsStartupJitterMax
+	fleetStatsStartupJitterMax = 0
+	defer func() { fleetStatsStartupJitterMax = origJitter }()
+
 	// Shrink the interval so the ticker branch fires within the test.
 	orig := fleetStatsCollectInterval
 	fleetStatsCollectInterval = 20 * time.Millisecond
@@ -164,10 +178,74 @@ func TestFleetStatsCollector_CollectError(t *testing.T) {
 	base, _ := url.Parse(srv.URL + "/")
 	c.GoGitHub().BaseURL = base
 
+	// Collapse the retry backoff so the test exercises the full retry ladder
+	// without waiting minutes of real time.
+	restore := fleetStatsRetryBaseDelay
+	fleetStatsRetryBaseDelay = time.Millisecond
+	t.Cleanup(func() { fleetStatsRetryBaseDelay = restore })
+
 	fc := NewFleetStatsCollector(c, "bot", "org", slog.Default())
 	fc.collect(context.Background())
 	// A failed collect must leave the collector not-ready (never a fake zero).
 	if _, ready := fc.Snapshot(); ready {
 		t.Error("collector should stay not-ready after a failed collect")
+	}
+	if !fc.CollectedAt().IsZero() {
+		t.Error("CollectedAt must stay zero when no collect has ever succeeded")
+	}
+}
+
+// TestFleetStatsCollector_RetriesThenSucceeds is the regression guard for the
+// fleet-wide stat collapse: the GitHub search API allows only 30 requests per
+// minute, so a rolling restart rate-limits most spokes on their first attempt.
+// Before retrying, a single rejection dropped that hive out of the public total
+// for a full 30-minute cycle. A transient failure must not cost a hive its
+// contribution.
+func TestFleetStatsCollector_RetriesThenSucceeds(t *testing.T) {
+	var calls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		// Fail every search of the first collect attempt, then succeed.
+		if calls.Add(1) <= 1 {
+			http.Error(w, "rate limited", http.StatusForbidden)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"total_count": 7, "items": []any{}})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	c := ghpkg.NewClient("fake", "org", []string{"repo"}, slog.Default(), "")
+	base, _ := url.Parse(srv.URL + "/")
+	c.GoGitHub().BaseURL = base
+
+	restore := fleetStatsRetryBaseDelay
+	fleetStatsRetryBaseDelay = time.Millisecond
+	t.Cleanup(func() { fleetStatsRetryBaseDelay = restore })
+
+	fc := NewFleetStatsCollector(c, "bot", "org", slog.Default())
+	fc.collect(context.Background())
+
+	counts, ready := fc.Snapshot()
+	if !ready {
+		t.Fatal("collector must be ready after a retry succeeds")
+	}
+	if counts.PRsMerged != 7 {
+		t.Errorf("PRsMerged = %d, want 7", counts.PRsMerged)
+	}
+	if fc.CollectedAt().IsZero() {
+		t.Error("CollectedAt must be set after a successful collect")
+	}
+}
+
+// TestFleetStatsCollector_StartupDelayWithinBound pins the startup jitter to
+// its configured window; it is what spreads the fleet's first collect across
+// the search rate-limit window instead of stampeding it.
+func TestFleetStatsCollector_StartupDelayWithinBound(t *testing.T) {
+	fc := NewFleetStatsCollector(nil, "bot", "org", slog.Default())
+	for i := 0; i < 100; i++ {
+		d := fc.startupDelay()
+		if d < 0 || d >= fleetStatsStartupJitterMax {
+			t.Fatalf("startupDelay() = %v, want within [0, %v)", d, fleetStatsStartupJitterMax)
+		}
 	}
 }

--- a/v2/pkg/hub/fleet_stats_test.go
+++ b/v2/pkg/hub/fleet_stats_test.go
@@ -60,7 +60,7 @@ func TestComputeFleetStats(t *testing.T) {
 					PRsMerged90d: ptrInt(5), PRsRejected90d: ptrInt(1), CVEsClosed: ptrInt(3)},
 			},
 			// repos: a/r1, a/r2, a/r3 = 3 distinct; a/r2 reported twice + as "r2".
-			want: FleetStats{ReposManaged: 3, PRsMerged: 15, PRsRejected: 3, CVEsClosed: 4, Hives: 2},
+			want: FleetStats{ReposManaged: 3, PRsMerged: 15, PRsRejected: 3, CVEsClosed: 4, Hives: 2, Reporting: 2, Eligible: 2},
 		},
 		{
 			name: "skips private and offline hives",
@@ -69,7 +69,7 @@ func TestComputeFleetStats(t *testing.T) {
 				{IsPublic: true, Online: false, Org: "a", Repos: []string{"r2"}, PRsMerged90d: ptrInt(99)},
 				{IsPublic: true, Online: true, Org: "a", Repos: []string{"r3"}, PRsMerged90d: ptrInt(7)},
 			},
-			want: FleetStats{ReposManaged: 1, PRsMerged: 7, Hives: 1},
+			want: FleetStats{ReposManaged: 1, PRsMerged: 7, Hives: 1, Reporting: 1, Eligible: 1},
 		},
 		{
 			name: "nil counts are not aggregated as zero",
@@ -77,7 +77,7 @@ func TestComputeFleetStats(t *testing.T) {
 				{IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}}, // all nil
 				{IsPublic: true, Online: true, Org: "a", Repos: []string{"r2"}, PRsMerged90d: ptrInt(4)},
 			},
-			want: FleetStats{ReposManaged: 2, PRsMerged: 4, Hives: 2},
+			want: FleetStats{ReposManaged: 2, PRsMerged: 4, Hives: 2, Reporting: 1, Eligible: 2},
 		},
 		{
 			name: "empty repo strings are skipped",
@@ -85,7 +85,7 @@ func TestComputeFleetStats(t *testing.T) {
 				{IsPublic: true, Online: true, Org: "a", Repos: []string{"", "r1", ""},
 					PRsMerged90d: ptrInt(2)},
 			},
-			want: FleetStats{ReposManaged: 1, PRsMerged: 2, Hives: 1},
+			want: FleetStats{ReposManaged: 1, PRsMerged: 2, Hives: 1, Reporting: 1, Eligible: 1},
 		},
 		{
 			name:  "no hives yields empty",
@@ -140,5 +140,92 @@ func TestHandleFleetStats(t *testing.T) {
 	}
 	if fs.UpdatedAt == "" {
 		t.Error("UpdatedAt empty")
+	}
+}
+
+// TestComputeFleetStatsAgesOutStaleCollections verifies that a hive whose last
+// successful collect is older than fleetStatsMaxAge is excluded from the totals
+// and counted as stale. Carrying counts forward across restarts keeps a number
+// available, but a frozen number must not masquerade as a current one.
+func TestComputeFleetStatsAgesOutStaleCollections(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+	s.registry.Hives = []RegistryEntry{
+		{IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"},
+			PRsMerged90d: ptrInt(10), FleetStatsCollectedAt: time.Now()},
+		{IsPublic: true, Online: true, Org: "a", Repos: []string{"r2"},
+			PRsMerged90d:          ptrInt(999),
+			FleetStatsCollectedAt: time.Now().Add(-2 * fleetStatsMaxAge)},
+	}
+	got := s.computeFleetStats()
+	if got.PRsMerged != 10 {
+		t.Errorf("PRsMerged = %d, want 10 (stale collect must not be summed)", got.PRsMerged)
+	}
+	if got.Stale != 1 {
+		t.Errorf("Stale = %d, want 1", got.Stale)
+	}
+	if got.Reporting != 1 || got.Eligible != 2 {
+		t.Errorf("Reporting/Eligible = %d/%d, want 1/2", got.Reporting, got.Eligible)
+	}
+}
+
+// TestComputeFleetStatsZeroCollectedAtIsTrusted pins the upgrade-skew guard: a
+// spoke too old to report a collection timestamp must still contribute rather
+// than being aged out on a zero time.
+func TestComputeFleetStatsZeroCollectedAtIsTrusted(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+	s.registry.Hives = []RegistryEntry{
+		{IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(5)},
+	}
+	got := s.computeFleetStats()
+	if got.PRsMerged != 5 || got.Reporting != 1 || got.Stale != 0 {
+		t.Errorf("got %+v, want PRsMerged=5 Reporting=1 Stale=0", got)
+	}
+}
+
+// TestFleetStatsTrustworthy is the regression guard for the reported bug: a
+// total assembled from a small minority of the fleet must NOT be presented as
+// a fleet-wide figure. 2 reporting out of 50 eligible is the live shape of the
+// "statistics are missing again" report.
+func TestFleetStatsTrustworthy(t *testing.T) {
+	tests := []struct {
+		name      string
+		reporting int
+		eligible  int
+		want      bool
+	}{
+		{"the reported regression: 2 of 50", 2, 50, false},
+		{"nothing eligible", 0, 0, false},
+		{"eligible but none reporting", 0, 12, false},
+		{"exactly at the threshold", 5, 10, true},
+		{"just under the threshold", 4, 10, false},
+		{"whole fleet reporting", 50, 50, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := FleetStats{Reporting: tt.reporting, Eligible: tt.eligible}
+			if got := fs.FleetStatsTrustworthy(); got != tt.want {
+				t.Errorf("Trustworthy(%d/%d) = %v, want %v",
+					tt.reporting, tt.eligible, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestComputeFleetStatsSkipsRepolessHives ensures placeholder hives (no repos)
+// are not counted as eligible — they have nothing to contribute and must not
+// drag the reporting fraction down as though data were missing.
+func TestComputeFleetStatsSkipsRepolessHives(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+	s.registry.Hives = []RegistryEntry{
+		{IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(3)},
+		{IsPublic: true, Online: true, Org: "a", Repos: nil},
+		{IsPublic: true, Online: true, Org: "a", Repos: []string{}},
+	}
+	got := s.computeFleetStats()
+	if got.Eligible != 1 || got.Reporting != 1 {
+		t.Errorf("Reporting/Eligible = %d/%d, want 1/1", got.Reporting, got.Eligible)
+	}
+	if !got.FleetStatsTrustworthy() {
+		t.Error("a fully-reporting fleet of one must be trustworthy")
 	}
 }

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -313,6 +313,11 @@ type HeartbeatPayload struct {
 	PRsMerged90d   *int `json:"prs_merged_90d,omitempty"`
 	PRsRejected90d *int `json:"prs_rejected_90d,omitempty"`
 	CVEsClosed     *int `json:"cves_closed,omitempty"`
+	// FleetStatsCollectedAt (RFC3339) is when the counts above were last
+	// successfully computed, so the hub can age out a stale contribution
+	// instead of summing a frozen number forever. Empty from a spoke too old
+	// to report it, which the hub treats as "not stale".
+	FleetStatsCollectedAt string `json:"fleet_stats_collected_at,omitempty"`
 	// AgentsWithModel counts this hive's agents that have an effective method
 	// (backend) or model assigned — override first, then agent config, exactly
 	// as the launcher resolves it. The hub uses it for user-journey stage

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -153,6 +153,14 @@ type RegistryEntry struct {
 	PRsMerged90d   *int `json:"prsMerged90d,omitempty"`
 	PRsRejected90d *int `json:"prsRejected90d,omitempty"`
 	CVEsClosed     *int `json:"cvesClosed,omitempty"`
+	// FleetStatsCollectedAt is when the spoke last SUCCESSFULLY computed the
+	// counts above — not when it last sent a heartbeat. The counts are carried
+	// forward across restarts, so without this the hub cannot tell a count
+	// gathered minutes ago from one frozen since a collector started failing.
+	// The aggregator refuses to count contributions older than
+	// fleetStatsMaxAge. Zero means the spoke is too old to report it, which is
+	// treated as "not stale" so an upgrade does not blank the strip.
+	FleetStatsCollectedAt time.Time `json:"fleetStatsCollectedAt,omitempty"`
 	// AgentsWithModel is the spoke-reported count of agents that have a method
 	// (backend) or model assigned. nil = the spoke is too old to report it, so
 	// journey stage 2 is treated as unknown rather than unsatisfied.
@@ -960,6 +968,16 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		PRsMerged90d:   clampFleetCount(payload.PRsMerged90d),
 		PRsRejected90d: clampFleetCount(payload.PRsRejected90d),
 		CVEsClosed:     clampFleetCount(payload.CVEsClosed),
+		FleetStatsCollectedAt: func() time.Time {
+			if payload.FleetStatsCollectedAt == "" {
+				return time.Time{}
+			}
+			t, err := time.Parse(time.RFC3339, payload.FleetStatsCollectedAt)
+			if err != nil {
+				return time.Time{}
+			}
+			return t
+		}(),
 		// Preserve nil (old spoke, unknown) vs a real count — journey stage
 		// detection depends on telling those two apart.
 		AgentsWithModel: clampFleetCount(payload.AgentsWithModel),
@@ -1029,6 +1047,27 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			// to public, don't let the spoke's heartbeat revert it.
 			if h.IsPublic && !payload.IsPublic {
 				entry.IsPublic = h.IsPublic
+			}
+			// Carry the last known fleet-stat counts forward when this
+			// heartbeat does not carry them. The counts live only in the
+			// spoke's memory, so every restart reports nil until the periodic
+			// collector next succeeds. Overwriting the stored value with nil
+			// dropped the hive out of the public total for that whole gap —
+			// with a fleet-wide restart, that silently collapsed the landing
+			// page's numbers. Preserving the previous value (with its
+			// collection timestamp, which the aggregator ages out) keeps the
+			// total honest instead of quietly shrinking it.
+			if entry.PRsMerged90d == nil && h.PRsMerged90d != nil {
+				entry.PRsMerged90d = h.PRsMerged90d
+			}
+			if entry.PRsRejected90d == nil && h.PRsRejected90d != nil {
+				entry.PRsRejected90d = h.PRsRejected90d
+			}
+			if entry.CVEsClosed == nil && h.CVEsClosed != nil {
+				entry.CVEsClosed = h.CVEsClosed
+			}
+			if entry.FleetStatsCollectedAt.IsZero() {
+				entry.FleetStatsCollectedAt = h.FleetStatsCollectedAt
 			}
 			branchForLatest := payload.GitBranch
 			if branchForLatest == "" {
@@ -1543,7 +1582,40 @@ type FleetStats struct {
 	CVEsClosed   int    `json:"cves_closed"`
 	Hives        int    `json:"hives"`
 	UpdatedAt    string `json:"updated_at"`
+	// Reporting is the number of eligible hives that actually contributed a
+	// fresh count to the totals above; Eligible is how many were considered.
+	// Without this pair the totals are indistinguishable from a healthy fleet:
+	// summing 2 of 50 hives yields a small, confident, WRONG number and the
+	// page has no way to know. The landing page compares the two and refuses
+	// to present a total assembled from too little of the fleet.
+	Reporting int `json:"reporting"`
+	Eligible  int `json:"eligible"`
+	// Stale counts eligible hives whose newest successful collect is older
+	// than fleetStatsMaxAge — surfaced so a fleet quietly failing to collect
+	// is visible as degradation rather than as a shrinking total.
+	Stale int `json:"stale"`
+	// Trustworthy is false when too little of the fleet reported for the
+	// totals to stand as a fleet-wide figure. The landing page shows a
+	// "collecting" state instead of the numbers when this is false.
+	Trustworthy bool `json:"trustworthy"`
 }
+
+// fleetStatsMaxAge is how old a spoke's last successful collect may be and
+// still count toward the public total. The spoke recollects every 30 minutes,
+// so a contribution older than this means that hive's collector has been
+// failing for many consecutive cycles and its number is no longer current.
+// Generous enough to ride out a restart or a transient GitHub outage without
+// blanking the strip, short enough that a genuinely broken collector drops out
+// rather than freezing a stale figure on the public page forever.
+const fleetStatsMaxAge = 6 * time.Hour
+
+// fleetStatsMinReportingFraction is the share of eligible hives that must
+// report fresh counts before the aggregate is considered trustworthy enough to
+// display as a fleet-wide total. Below this the landing page shows a degraded
+// state instead of a confidently wrong number — the regression this guards
+// against is precisely a total silently assembled from a small minority of the
+// fleet (2 of 50) and rendered as though it were complete.
+const fleetStatsMinReportingFraction = 0.5
 
 // computeFleetStats aggregates fleet-wide contribution counts across public,
 // non-stale hives. A hive that never reported a given count (nil pointer) is
@@ -1573,6 +1645,26 @@ func (s *HubServer) computeFleetStats() FleetStats {
 			}
 			repoSet[key] = struct{}{}
 		}
+		// Only hives that could meaningfully report are counted as eligible.
+		// A placeholder with no repos has nothing to contribute and must not
+		// drag the reporting fraction down as though data were missing.
+		if len(h.Repos) == 0 {
+			continue
+		}
+		fs.Eligible++
+
+		hasCount := h.PRsMerged90d != nil || h.PRsRejected90d != nil || h.CVEsClosed != nil
+		if !hasCount {
+			continue
+		}
+		// Age out contributions whose last successful collect is too old. A
+		// zero timestamp means the spoke predates the field, so it is trusted
+		// rather than dropped — an upgrade must not blank the strip.
+		if !h.FleetStatsCollectedAt.IsZero() && time.Since(h.FleetStatsCollectedAt) > fleetStatsMaxAge {
+			fs.Stale++
+			continue
+		}
+		fs.Reporting++
 		if h.PRsMerged90d != nil {
 			fs.PRsMerged += *h.PRsMerged90d
 		}
@@ -1587,6 +1679,17 @@ func (s *HubServer) computeFleetStats() FleetStats {
 	return fs
 }
 
+// FleetStatsTrustworthy reports whether enough of the eligible fleet
+// contributed fresh counts for the totals to be presented as a fleet-wide
+// figure. A total built from a small minority is worse than no total at all:
+// it renders as a confident, precise, badly wrong number.
+func (fs FleetStats) FleetStatsTrustworthy() bool {
+	if fs.Eligible == 0 || fs.Reporting == 0 {
+		return false
+	}
+	return float64(fs.Reporting)/float64(fs.Eligible) >= fleetStatsMinReportingFraction
+}
+
 func (s *HubServer) handleFleetStats(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 	offlineEvents := s.markStaleHives()
@@ -1597,6 +1700,21 @@ func (s *HubServer) handleFleetStats(w http.ResponseWriter, r *http.Request) {
 	fs := s.computeFleetStats()
 	s.mu.RUnlock()
 	fs.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	fs.Trustworthy = fs.FleetStatsTrustworthy()
+
+	// Make the degraded case loud on the server too. The landing page hides the
+	// numbers, but a silent hide is how this regressed unnoticed before: with
+	// no log line, a fleet-wide collector failure looks identical to a quiet
+	// day. This is the operator-visible signal that the data, not the fleet,
+	// is what shrank.
+	if !fs.Trustworthy {
+		s.logger.Warn("fleet stats degraded: too few hives reporting to publish a fleet total",
+			"reporting", fs.Reporting,
+			"eligible", fs.Eligible,
+			"stale", fs.Stale,
+			"min_fraction", fleetStatsMinReportingFraction,
+		)
+	}
 
 	data, _ := json.Marshal(fs)
 	w.Header().Set("Content-Type", "application/json")

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -1328,12 +1328,19 @@
       ];
       function fmt(n) { return n.toLocaleString('en-US'); }
       function apply(data) {
+        // The hub tells us whether enough of the fleet reported for these
+        // totals to mean anything. When it says no, show NOTHING rather than a
+        // number assembled from a handful of hives — a precise-looking total
+        // built from 2 of 50 spokes is the exact failure this guards against.
+        // Treat a response without the field (older hub) as trustworthy so an
+        // upgrade skew never blanks a strip that is actually fine.
+        var trustworthy = !data || typeof data.trustworthy !== 'boolean' ? true : data.trustworthy;
         var anyLive = false;
-        LIVE_STATS.forEach(function(s) {
+        (LIVE_STATS || []).forEach(function(s) {
           var box = document.getElementById(s.box);
           if (!box) return;
           var val = data && typeof data[s.key] === 'number' ? data[s.key] : 0;
-          if (val > 0) {
+          if (trustworthy && val > 0) {
             box.querySelector('[data-stat]').textContent = fmt(val);
             box.hidden = false;
             anyLive = true;
@@ -1343,9 +1350,17 @@
         });
         var note = document.getElementById('hero-proof-note');
         if (!anyLive && note) {
-          // No fleet data yet: don't imply live numbers exist. Swap to a
-          // qualitative line alongside the (always-true) 90% coverage stat.
-          note.innerHTML = 'The <strong>90% coverage gate</strong> is enforced on Hive\'s own build. Spin up a hive and your fleet\'s merged-PR, rejected-PR, and CVE totals appear here, live. <a href="/learn" target="_blank" rel="noopener">Learn how earned autonomy works</a>.';
+          if (!trustworthy && data && data.eligible > 0) {
+            // Data IS degraded and we know it. Say so plainly instead of
+            // letting a blank strip read as "the fleet did nothing".
+            note.innerHTML = 'The <strong>90% coverage gate</strong> is enforced on Hive\'s own build. Fleet contribution totals are <strong>currently being recollected</strong> (' +
+              fmt(data.reporting || 0) + ' of ' + fmt(data.eligible || 0) +
+              ' hives reporting) and are hidden until enough of the fleet has reported. <a href="/learn" target="_blank" rel="noopener">Learn how earned autonomy works</a>.';
+          } else {
+            // No fleet data yet: don't imply live numbers exist. Swap to a
+            // qualitative line alongside the (always-true) 90% coverage stat.
+            note.innerHTML = 'The <strong>90% coverage gate</strong> is enforced on Hive\'s own build. Spin up a hive and your fleet\'s merged-PR, rejected-PR, and CVE totals appear here, live. <a href="/learn" target="_blank" rel="noopener">Learn how earned autonomy works</a>.';
+          }
         }
       }
       function go() {


### PR DESCRIPTION
## The problem

The landing page advertised **"26 PRs merged in the last 90 days, fleet-wide"** and **"3 agent PRs the pipeline rejected"** across a ~50-hive fleet. The `kubestellar` org *alone* has **6,370** merged agent PRs in that window — the figure was wrong by more than two orders of magnitude.

## What the live registry showed

Reading `/data/hub-registry.json` off the running hub settled the question immediately:

| | count |
|---|---|
| hives in registry | 50 |
| hives carrying `prsMerged90d` | **2** (14 + 12 = the 26 on the page) |
| hives carrying `prsRejected90d` | **2** (2 + 1 = 3) |
| hives carrying neither | **48**, including `kubestellar/hive` itself |

So the aggregation arithmetic was correct. This is a **data-collection bug**, not an aggregation bug.

## Root cause — three compounding defects

**1. No retry on collect** (`v2/pkg/dashboard/fleet_stats_collector.go:72`)
The GitHub search API allows **30 requests/minute**, shared by every hive on the same App installation. A hub-wide rolling restart brings ~50 spokes up within seconds, each firing 3 searches — ~150 calls against a 30/min budget. One rejection and the spoke gave up until the next 30-minute tick. There was no retry and no backoff.

**2. Counts destroyed on restart** (`v2/pkg/hub/server.go:960`)
The counts live only in spoke memory. A restarted spoke heartbeats `nil` until its next successful collect, and the hub rebuilt the registry entry wholesale — overwriting good stored counts with that `nil`. A fleet-wide restart zeroed nearly every contribution at once. Registry `startedAt` confirms the fleet had just been restarted.

**3. The failure was silent** (`v2/pkg/hub/server.go:1576`)
Summing 2 of 50 hives yields a small, precise, confident, **wrong** number. Nothing could distinguish that from a healthy fleet having a quiet quarter — which is why this regressed unnoticed before ("statistics are missing *again*").

## The fix

- **Startup jitter + bounded exponential-backoff retry** (4 attempts, 1m/2m/4m). Spokes queue against the quota instead of stampeding it, and a rate-limited spoke recovers in minutes rather than dropping out for half an hour.
- **Carry counts forward across restarts**, stamped with `FleetStatsCollectedAt` — *when they were actually collected*, not when the beat was sent. A frozen number ages out via `fleetStatsMaxAge` (6h) instead of being summed forever.
- **Track reporting-vs-eligible coverage.** The aggregate is published only when at least `fleetStatsMinReportingFraction` (50%) of eligible hives report fresh counts. Repo-less placeholders are not counted as eligible.

## Failing visibly, not silently

This is the part that matters for the "*again*":

- The hub logs `WARN fleet stats degraded: too few hives reporting to publish a fleet total` with the reporting/eligible/stale split.
- The landing page **hides the numbers** and says the totals are *being recollected (N of M hives reporting)* rather than printing a figure it cannot stand behind.
- Spokes log a warning when the collector never starts, and when a collect fails after all retries.

Against the current live registry — **2 of 18 eligible reporting (11%)** — the misleading `26` is suppressed and the degraded note shows instead.

Backward compatible: a spoke too old to send `fleet_stats_collected_at` is trusted rather than aged out, and a landing page talking to an older hub (no `trustworthy` field) still renders. An upgrade skew never blanks a strip that is actually fine.

## Verification

- `go build ./...` clean; `go test ./pkg/hub/ ./pkg/dashboard/ -run Fleet` pass.
- New tests: stale-collect aging, zero-timestamp trust, repo-less exclusion, the retry ladder, jitter bounds, and a `TestFleetStatsTrustworthy` case pinned to the exact live shape (2 of 50 -> false).
- Pre-existing unrelated `TestCov*`/`GHUserAuth` failures in `pkg/dashboard` reproduce on clean `origin/v2` and are untouched by this change.
- Embedded JS in `index.html`: brace/paren deltas `(0,0)` on BASE and `(0,0)` on CURRENT — match confirmed. `saas.go` not touched.