### PR TITLE
🔀 sync: v2 → dd (top-up #2306)

### DIFF
--- a/v2/pkg/hub/alerts.go
+++ b/v2/pkg/hub/alerts.go
@@ -88,6 +88,12 @@ const (
 	AlertTypeTokenBurn = "token-burn"
 	// AlertTypeProvisionError — the SaaS provisioning record is in "error".
 	AlertTypeProvisionError = "provision-error"
+	// AlertTypeAdvisoryStale — the hive should be posting advisory digests but
+	// its digest has quietly gone stale. The condition is NOT re-derived here:
+	// it is the AdvisoryStale flag advisoryStale() already computed on read,
+	// so the panel, the facet and the row pill can never disagree about which
+	// hives are affected.
+	AlertTypeAdvisoryStale = "advisory-stale"
 )
 
 // --- Thresholds. Every one is a named constant with a rationale. ---
@@ -442,6 +448,12 @@ type alertHive struct {
 	Health           map[string]any
 	ProvStatus       string
 	ProvError        string
+	// AdvisoryStale / AdvisoryStaleReason are carried through verbatim from
+	// the entry rather than recomputed. advisoryStale() owns the threshold and
+	// the advisory-mode + app-can-write gating; duplicating either here is
+	// exactly how the panel and the row pill would start disagreeing.
+	AdvisoryStale       bool
+	AdvisoryStaleReason string
 }
 
 // alertHiveFromEntry projects a MyHiveEntry into the evaluator's view.
@@ -463,6 +475,9 @@ func alertHiveFromEntry(h MyHiveEntry) alertHive {
 		Health:           h.Health,
 		ProvStatus:       h.ProvStatus,
 		ProvError:        h.ProvError,
+
+		AdvisoryStale:       h.AdvisoryStale,
+		AdvisoryStaleReason: h.AdvisoryStaleReason,
 	}
 }
 
@@ -733,6 +748,23 @@ func evaluateAlerts(state *alertState, hives []alertHive, driftAlerts []Alert, n
 				itoa(len(failing))+" health "+noun+" failing: "+strings.Join(shown, ", ")+suffix)
 		}
 
+		// --- Rule: the advisory digest has gone stale. ---
+		// The flag is precomputed by advisoryStale(), which already gates on
+		// advisory-mode participation AND app-can-write, and already excludes
+		// unknown timestamps — so there is nothing to re-check here beyond the
+		// placeholder guard every claimed-hive rule applies. Severity is
+		// warning, not critical: the hive is still running and doing work, but
+		// the digest path a human relies on has quietly wedged.
+		if !h.IsPlaceholder && h.AdvisoryStale {
+			reason := h.AdvisoryStaleReason
+			if reason == "" {
+				// Only reached if a spoke reports the flag without a reason.
+				// The server-supplied reason is preferred wherever it exists.
+				reason = "Advisory digest has gone stale"
+			}
+			add(h.ID, h.Name, AlertTypeAdvisoryStale, AlertSeverityWarning, reason)
+		}
+
 		// --- Rule: token burn anomaly. Claimed hives only — an unassigned
 		// placeholder has no agents and therefore legitimately spends nothing. ---
 		if !h.IsPlaceholder {
@@ -997,6 +1029,7 @@ var knownAlertTypes = map[string]bool{
 	AlertTypeHealthCheckFailing: true,
 	AlertTypeTokenBurn:          true,
 	AlertTypeProvisionError:     true,
+	AlertTypeAdvisoryStale:      true,
 }
 
 func isKnownAlertType(t string) bool { return knownAlertTypes[t] }

--- a/v2/pkg/hub/alerts_test.go
+++ b/v2/pkg/hub/alerts_test.go
@@ -1426,3 +1426,97 @@ func indexOf(h, n string) int {
 	}
 	return -1
 }
+
+func TestEvaluateAlerts_AdvisoryStaleRule(t *testing.T) {
+	h := baseHive("h1")
+	h.AdvisoryStale = true
+	h.AdvisoryStaleReason = "No advisory digest posted for 3h20m"
+
+	got := evaluateAlerts(newAlertState(), []alertHive{h}, nil, fixedNow)
+	a, ok := findAlert(got.Alerts, "h1", AlertTypeAdvisoryStale)
+	if !ok {
+		t.Fatalf("expected a stale-advisory alert, got %+v", got.Alerts)
+	}
+	if a.Severity != AlertSeverityWarning {
+		t.Fatalf("severity = %q, want %q", a.Severity, AlertSeverityWarning)
+	}
+	// The SERVER-supplied reason must be surfaced verbatim rather than replaced
+	// by generic wording — advisoryStale() owns the explanation.
+	if a.Reason != h.AdvisoryStaleReason {
+		t.Fatalf("reason = %q, want the server-supplied %q", a.Reason, h.AdvisoryStaleReason)
+	}
+}
+
+func TestEvaluateAlerts_AdvisoryStaleNotRaisedWhenFlagUnset(t *testing.T) {
+	// The gating (advisory-mode participation, app-can-write, unknown
+	// timestamps) lives entirely in advisoryStale(). The evaluator must trust
+	// the flag and never re-derive it, so a cleared flag means no alert even
+	// though a reason string is present.
+	h := baseHive("h1")
+	h.AdvisoryStale = false
+	h.AdvisoryStaleReason = "stale-looking but not flagged"
+
+	got := evaluateAlerts(newAlertState(), []alertHive{h}, nil, fixedNow)
+	if hasAlert(got.Alerts, "h1", AlertTypeAdvisoryStale) {
+		t.Fatal("a hive the hub did not flag stale must not raise a stale-advisory alert")
+	}
+}
+
+func TestEvaluateAlerts_AdvisoryStaleFallsBackWhenReasonEmpty(t *testing.T) {
+	h := baseHive("h1")
+	h.AdvisoryStale = true
+	h.AdvisoryStaleReason = ""
+
+	got := evaluateAlerts(newAlertState(), []alertHive{h}, nil, fixedNow)
+	a, ok := findAlert(got.Alerts, "h1", AlertTypeAdvisoryStale)
+	if !ok {
+		t.Fatalf("expected a stale-advisory alert, got %+v", got.Alerts)
+	}
+	if a.Reason == "" {
+		t.Fatal("reason must never be empty — the panel renders it as the detail line")
+	}
+}
+
+func TestEvaluateAlerts_AdvisoryStalePlaceholderExclusion(t *testing.T) {
+	// An unassigned pool slot posts no advisory digests by definition, so it
+	// must never be flagged, matching every other claimed-hive rule.
+	ph := baseHive("placeholder-1")
+	ph.IsPlaceholder = true
+	ph.AdvisoryStale = true
+	ph.AdvisoryStaleReason = "stale"
+
+	claimed := baseHive("claimed-1")
+	claimed.AdvisoryStale = true
+	claimed.AdvisoryStaleReason = "stale"
+
+	got := evaluateAlerts(newAlertState(), []alertHive{ph, claimed}, nil, fixedNow)
+	if hasAlert(got.Alerts, "placeholder-1", AlertTypeAdvisoryStale) {
+		t.Fatal("an unassigned placeholder must not raise a stale-advisory alert")
+	}
+	if !hasAlert(got.Alerts, "claimed-1", AlertTypeAdvisoryStale) {
+		t.Fatal("the claimed control hive should raise the alert; " +
+			"if not, the placeholder exclusion is not what is being tested")
+	}
+}
+
+func TestAdvisoryStaleIsAKnownAlertType(t *testing.T) {
+	// The ack endpoint rejects unknown types, so omitting this would leave the
+	// new alert permanently un-acknowledgeable from the panel.
+	if !isKnownAlertType(AlertTypeAdvisoryStale) {
+		t.Fatal("AlertTypeAdvisoryStale must be ack-able via the alert ack endpoint")
+	}
+}
+
+func TestAlertHiveFromEntry_CarriesAdvisoryStaleness(t *testing.T) {
+	// The projection is the only path from MyHiveEntry into the evaluator; if
+	// it drops these fields the rule can never fire in production even though
+	// every unit test above passes.
+	got := alertHiveFromEntry(MyHiveEntry{
+		RegistryEntry:       RegistryEntry{ID: "h1"},
+		AdvisoryStale:       true,
+		AdvisoryStaleReason: "why",
+	})
+	if !got.AdvisoryStale || got.AdvisoryStaleReason != "why" {
+		t.Fatalf("advisory staleness not projected: %+v", got)
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -7911,6 +7911,24 @@ const dashboardHTML = `<!DOCTYPE html>
       return hiveUpgradeState(h) === _dashUpgradeFilter;
     }
 
+    /* ── Stale-advisory filter ──
+       When true, the list is narrowed to hives whose advisory digest the hub
+       has flagged stale. A single boolean, not a value set: the underlying
+       signal is itself boolean, so there is no second value to OR against.
+       Composes by AND with the status chips and the facets, like the drift
+       filter above. */
+    var _dashAdvisoryStaleFilter = false;
+
+    /* hiveMatchesAdvisoryStaleFilter answers whether a hive survives the
+       stale-advisory filter. Reads the SERVER-computed h.advisoryStale flag —
+       the browser must never re-derive the threshold or the advisory-mode /
+       app-can-write gating, or the filter and the row pill would drift apart
+       (see advisoryStale() in advisory_staleness.go). */
+    function hiveMatchesAdvisoryStaleFilter(h) {
+      if (!_dashAdvisoryStaleFilter) return true;
+      return !!(h && h.advisoryStale);
+    }
+
     /* ────────────────────────────────────────────────────────────────────────
        Grouping and saved views for My Hives.
 
@@ -8307,6 +8325,7 @@ const dashboardHTML = `<!DOCTYPE html>
       }
       if (!hiveMatchesDriftFilter(h)) return false;
       if (!hiveMatchesUpgradeFilter(h)) return false;
+      if (!hiveMatchesAdvisoryStaleFilter(h)) return false;
       var active = Object.keys(_dashStatusFilters || {}).filter(function(k) { return _dashStatusFilters[k]; });
       if (!active.length) return true;
       var f = hiveStatusFlags(h);
@@ -8357,7 +8376,8 @@ const dashboardHTML = `<!DOCTYPE html>
       'provision-error': 'Provision error',
       /* Added by the hub in #2308. Without a label here the chip for a
          genuinely failed upgrade would render as the raw key 'failed-upgrade'. */
-      'failed-upgrade': 'Failed upgrade'
+      'failed-upgrade': 'Failed upgrade',
+      'advisory-stale': 'Stale advisory'
     };
 
     /* How many alert rows are listed before the panel collapses the remainder
@@ -8410,6 +8430,7 @@ const dashboardHTML = `<!DOCTYPE html>
       _dashFailingCheckFilter = '';
       _dashDriftFilter = '';
       _dashUpgradeFilter = '';
+      _dashAdvisoryStaleFilter = false;
       _alertTypeFilter = '';
       _dashFacets = {};
       _dashSearchQuery = '';
@@ -8740,6 +8761,13 @@ const dashboardHTML = `<!DOCTYPE html>
        (_dashUpgradeFilter), not a dimension enumerated from the data like
        cluster or branch, so it stays OUT of HIVE_FACET_GROUPS. */
     var FACET_GROUP_UPGRADE = 'upgrade-state';
+    /* Stale-advisory group. Follows the HEALTH/FAILING_CHECK pattern rather
+       than the derived-facet one: "is this hive's advisory digest stale" is a
+       boolean health signal read off a server-computed flag, not an enumerated
+       dimension of the hive like cluster or branch, so it keeps its own state
+       (_dashAdvisoryStaleFilter) and its own matching rule and stays OUT of
+       HIVE_FACET_GROUPS. */
+    var FACET_GROUP_ADVISORY_STALE = 'advisory-stale';
 
     var HIVE_FACET_GROUPS = [
       {key: FACET_CLUSTER, label: 'Location'},
@@ -8801,6 +8829,7 @@ const dashboardHTML = `<!DOCTYPE html>
       if (_dashFailingCheckFilter) n++;
       if (_dashDriftFilter) n++;
       if (_dashUpgradeFilter) n++;
+      if (_dashAdvisoryStaleFilter) n++;
       if (_alertTypeFilter) n++;
       if (_dashSearchQuery) n++;
       var groups = Object.keys(_dashFacets || {});
@@ -8945,8 +8974,8 @@ const dashboardHTML = `<!DOCTYPE html>
       }).join('') +
       /* Group-scoped reset for the health + failing-check pair, so a user can
          undo just these without also dropping their search term and facets. */
-      (Object.keys(_dashStatusFilters || {}).length || _dashFailingCheckFilter || _dashDriftFilter || _dashUpgradeFilter
-        ? '<button type="button" class="facet-value" onclick="clearStatusFilters()" title="Clear the health, failing-check, drift and upgrade-state filters">' +
+      (Object.keys(_dashStatusFilters || {}).length || _dashFailingCheckFilter || _dashDriftFilter || _dashUpgradeFilter || _dashAdvisoryStaleFilter
+        ? '<button type="button" class="facet-value" onclick="clearStatusFilters()" title="Clear the health, failing-check, drift, upgrade-state and stale-advisory filters">' +
           '<span class="facet-value-label">Clear health filters</span></button>'
         : '') + '</div>';
       return facetGroupShell(FACET_GROUP_HEALTH, 'Health',
@@ -9058,6 +9087,34 @@ const dashboardHTML = `<!DOCTYPE html>
         !!_dashFacetCollapsed[FACET_GROUP_UPGRADE], body);
     }
 
+    /* renderAdvisoryStaleFacetGroup renders the stale-advisory toggle as a
+       facet group. One value, because the signal is boolean: picking it means
+       "only hives whose advisory digest has gone stale".
+
+       Returns '' when no hive is affected AND the filter is off, so a fleet
+       with healthy digests sees no new chrome at all — the same self-
+       suppressing contract advisoryStaleSummary() uses for the row pill. When
+       the filter IS on the group always renders, even at count 0, so it can
+       always be clicked back off (the failing-check group does the same). */
+    function renderAdvisoryStaleFacetGroup(assignedNoPlaceholders) {
+      var n = (assignedNoPlaceholders || []).filter(function(h) {
+        return !!(h && h.advisoryStale);
+      }).length;
+      if (!n && !_dashAdvisoryStaleFilter) return '';
+      var on = _dashAdvisoryStaleFilter;
+      var tip = n === 1
+        ? '1 hive should be posting advisory digests but its digest has gone stale'
+        : n + ' hives should be posting advisory digests but their digests have gone stale';
+      var body = '<div class="facet-values">' +
+        '<button type="button" class="facet-value' + (on ? ' on' : '') +
+        '" aria-pressed="' + (on ? 'true' : 'false') + '" title="' + esc(tip) + '"' +
+        ' onclick="toggleAdvisoryStaleFilter()">' +
+        '<span class="facet-value-label">Stale advisory</span>' +
+        '<span class="facet-value-count">' + n + '</span></button></div>';
+      return facetGroupShell(FACET_GROUP_ADVISORY_STALE, 'Advisory digest',
+        !!_dashFacetCollapsed[FACET_GROUP_ADVISORY_STALE], body);
+    }
+
     /* renderFacetRail draws the tray's body: the health chips and failing-check
        picker moved in from the old standalone bar, then the derived facet
        groups. Derived-group counts are computed over the assigned hives after
@@ -9076,7 +9133,7 @@ const dashboardHTML = `<!DOCTYPE html>
       var assignedReal = (assignedAll || []).filter(function(h) { return !isPlaceholderHive(h); });
       var base = (assignedAll || []).filter(hiveMatchesFilters).filter(hiveMatchesSearch);
       var head = renderStatusFacetGroup(assignedReal) + renderFailingCheckFacetGroup(assignedReal) +
-        renderUpgradeFacetGroup(assignedReal);
+        renderUpgradeFacetGroup(assignedReal) + renderAdvisoryStaleFacetGroup(assignedReal);
       if (!base.length && !Object.keys(_dashFacets || {}).length) {
         rail.innerHTML = head + clearFacetsButton();
         return;
@@ -9158,6 +9215,7 @@ const dashboardHTML = `<!DOCTYPE html>
       _dashFailingCheckFilter = '';
       _dashDriftFilter = '';
       _dashUpgradeFilter = '';
+      _dashAdvisoryStaleFilter = false;
       renderHives(_allDashHives, true);
     }
 
@@ -9166,6 +9224,12 @@ const dashboardHTML = `<!DOCTYPE html>
        filter). */
     function toggleUpgradeFilter(state) {
       _dashUpgradeFilter = (_dashUpgradeFilter === state) ? '' : (state || '');
+      renderHives(_allDashHives, true);
+    }
+
+    /* toggleAdvisoryStaleFilter flips the stale-advisory narrowing on or off. */
+    function toggleAdvisoryStaleFilter() {
+      _dashAdvisoryStaleFilter = !_dashAdvisoryStaleFilter;
       renderHives(_allDashHives, true);
     }
 
@@ -10242,6 +10306,7 @@ const dashboardHTML = `<!DOCTYPE html>
          applying a saved view would all appear to do nothing. */
       var sig = JSON.stringify(allHives) + '|' + JSON.stringify(_dashStatusFilters) +
         '|' + _dashFailingCheckFilter + '|' + _dashDriftFilter + '|' + _dashUpgradeFilter +
+        '|' + _dashAdvisoryStaleFilter +
         '|' + _alertTypeFilter + '|' + _alertShowAcked + '|' + JSON.stringify(_fleetAlerts) +
         '|' + _dashSearchQuery + '|' + JSON.stringify(_dashFacets) +
         '|' + JSON.stringify(_dashFacetCollapsed) + '|' + JSON.stringify(_dashSectionCollapsed) +
@@ -11452,9 +11517,33 @@ const dashboardHTML = `<!DOCTYPE html>
         bg = 'rgba(245,158,11,0.12)'; border = 'rgba(245,158,11,0.3)';
         msg = 'Your hive request for <strong>' + project + '</strong> is pending admin approval.';
       }
+      /* Dismissal is offered for the INFORMATIONAL states only. An 'approved'
+         banner carries the Provision button — it is the only place that action
+         is offered, and dismissals never expire (see dismissBanner: the stored
+         timestamp is written but no reader ever compares it), so a single
+         stray click would strand the user with an approved request and no way
+         to act on it. Pending and denied carry no action and are safe to hide.
+
+         The key embeds the request identity AND its status, so it is scoped to
+         exactly the state the user chose to dismiss: when a pending request is
+         later approved or denied the key changes and the banner re-raises on
+         its own. That is the same content-derived keying the access banner
+         uses ('pending:' + ids). */
+      var dismissable = status === 'pending' || status === 'denied';
+      var dismissBtn = '';
+      if (dismissable) {
+        var reqKey = ('provision:' + (req.id || project) + ':' + status).replace(/'/g, '');
+        var dismissedReqs = {};
+        try {
+          dismissedReqs = JSON.parse(localStorage.getItem('hive-dismissed-banners') || '{}') || {};
+        } catch (e) { dismissedReqs = {}; } /* corrupted value — show the banner */
+        if (dismissedReqs[reqKey]) { el.style.display = 'none'; return; }
+        dismissBtn = '<button onclick="dismissBanner(\'' + esc(reqKey) + '\',this)" style="margin-left:auto;background:none;border:none;color:var(--muted);cursor:pointer;font-size:1rem;padding:0 4px" title="Dismiss">&times;</button>';
+      }
       el.innerHTML = '<div style="background:' + bg + ';border:1px solid ' + border + ';border-radius:8px;padding:12px 16px;margin-bottom:16px;display:flex;align-items:center;gap:10px">' +
         '<span style="font-size:1.1rem">' + icon + '</span>' +
         '<span style="flex:1;font-size:0.85rem;color:var(--text)">' + msg + '</span>' +
+        dismissBtn +
         '</div>';
     }
 


### PR DESCRIPTION
Top-up. #2306 landed on `v2` during CI for #2326.

Brings `dd` to `origin/v2` @ `839c85e6`:
- #2306 — stale-advisory filter and dismissable provision banner

Merged with **no conflicts**. `go build ./...` clean; `pkg/hub` alert/advisory tests pass; `saas.go` byte-identical to `origin/v2`.

> [!IMPORTANT]
> Merge with `--merge`, **not** `--squash`.