### PR TITLE
✨ feat(dashboard): owner self-service encrypted spoke backup, including beads

### DIFF
--- a/docs/HUB_DISASTER_RECOVERY.md
+++ b/docs/HUB_DISASTER_RECOVERY.md
@@ -295,3 +295,185 @@ writes confined to a throwaway namespace that was deleted afterwards):
 - Upload to OCI Object Storage from *inside* the cluster (write permission was
   verified out-of-band with the hub's own credentials; the in-cluster upload
   path itself has not been exercised)
+
+---
+
+# Spoke self-service backup (owner-triggered)
+
+This is a **second, complementary** backup, separate from the fleet-wide hub
+backup described above. A spoke owner triggers it themselves from the avatar
+menu on their spoke dashboard (**Back up this hive**), and it downloads an
+encrypted archive to their browser.
+
+## Why it exists — and why it includes beads
+
+The hub backup is deliberately config-only. It excludes `/data/beads`,
+`/data/nous`, `/data/home` and `/data/logs`, because including them across ~50
+spokes would be roughly 40GB — too slow and expensive to run nightly and too
+slow to restore in an emergency. That trade-off is recorded in issue #2318.
+
+The cost profile of a *single owner backing up their own hive on demand* is
+completely different. So this backup **includes `/data/beads`** — the agent
+work ledger that #2318 identifies as the most painful documented loss. After a
+hub-backup-only restore, agents come back configured but with no memory of what
+they had already found, claimed, deferred or closed. This backup preserves that.
+
+## What is captured
+
+| Path | Why |
+|---|---|
+| `hive.yaml.bak` | The **authoritative** spoke config (see below) |
+| `hive-id` | Hive identity as known to the hub |
+| `hive-state.json` | Agent runtime state |
+| `gh-app-key*.pem` | GitHub App private keys — **credentials** |
+| `beads/<agent>/**` | The agent work ledger, one directory per agent |
+
+Bead directories are **discovered, not hardcoded**. A production spoke had ten
+(`architect`, `brainstorm`, `ci-maintainer`, `guide`, `outreach`, `quality`,
+`scanner`, `sec-check`, `strategist`, `supervisor`), not the five named in
+#2318, so a fixed list would silently miss ledgers.
+
+### What is excluded, and why
+
+| Path | Size (measured) | Why excluded |
+|---|---|---|
+| `nous/` | **287MB** | Timestamped learned-context snapshots; regenerable and by far the largest directory |
+| `logs/` | 32MB | Diagnostic, not state |
+| `graph/`, `snapshots/`, `vaults/` | ~19MB | Derived/bulk artifacts |
+| `prompt-history.jsonl` | 3.1MB | Diagnostic transcript |
+| `audit.jsonl` | 860KB | A record *of* actions, not state needed to reconstitute the hive |
+| `dashboard-sessions.json` | 1KB | **Live browser session tokens** — credentials with no restore value; restoring them would resurrect sessions that should have expired |
+| `hive.yaml` | 16KB | The *stale* ConfigMap seed — not authoritative |
+
+**Resulting archive: roughly 3–5MB before compression** on a measured
+production spoke (beads 2.6MB dominating), versus ~796MB for the whole PVC.
+Small enough to stream to a browser and stay responsive.
+
+## `hive.yaml.bak`, not `hive.yaml`
+
+The same trap as the hub backup, and worth repeating because it is silent. The
+`copy-config` init container restores from `hive.yaml.bak` and falls back to the
+stale ConfigMap seed only when it is absent. On a sampled production spoke the
+two files had **different content and different timestamps** — `hive.yaml` was a
+root-owned copy days older than the live, user-customised `hive.yaml.bak`.
+Backing up the wrong one produces no error at backup time and no symptom until a
+restore quietly reverts the owner's settings. A test locks this in.
+
+## Encryption is mandatory
+
+The archive contains GitHub App private keys, so it is **always** sealed with
+AES-256-GCM using the same code path as the hub backup.
+
+- The key comes from **`HIVE_BACKUP_KEY`** on the spoke, with **no default**.
+  If it is unset the endpoint returns `412 Precondition Failed` and refuses —
+  it never streams plaintext credentials to a browser.
+- The key is **not in the archive** and is not derivable from it. An artifact
+  carrying its own decryption key is not encrypted. The owner must have the key
+  escrowed separately, or the backup is unreadable.
+- The response is `Cache-Control: no-store` and is served over `POST` only, so
+  it cannot be pulled by a cross-origin navigation or `<img>` tag.
+
+The UI states plainly that the file is encrypted and that the key is not
+included.
+
+## Authorization
+
+**Owner-only**, enforced server-side on both `POST /api/backup` and
+`GET /api/backup/status`, matching `handleConfigDownload` and
+`handleSelfUpgrade`. Viewers and read-write members get `403`. Hiding the menu
+entry for non-owners is UX; the server check is the boundary.
+
+## Restore procedure
+
+There is **no restore button** — restoring is a deliberate, disruptive act on a
+running hive, so it is a documented operator procedure rather than a one-click
+control. The archive shares the hub format, so the same tooling reads it.
+
+```bash
+# 0. Decrypt and verify. Uses the SAME archive format as the hub backup,
+#    so hive-backup verifies and extracts it unchanged.
+export HIVE_BACKUP_KEY=<the key escrowed for THIS hive>
+hive-backup verify --archive hive-spoke-backup-<id>-<ts>.tar.gz.enc
+hive-backup extract --archive hive-spoke-backup-<id>-<ts>.tar.gz.enc --dest ./restore
+
+# Layout:
+#   ./restore/MANIFEST.json
+#   ./restore/spoke/{hive.yaml.bak,hive-id,hive-state.json,gh-app-key*.pem}
+#   ./restore/beads/<agent>/**
+
+# 1. Identify the target spoke pod.
+NS=hive-hosted-hosted-<org>-<repo>-<suffix>
+POD=$(kubectl -n $NS get pods --field-selector=status.phase=Running \
+        -o jsonpath='{.items[0].metadata.name}')
+
+# 2. Scale down so agents are not writing beads while you restore them.
+kubectl -n $NS scale deploy/hive --replicas=0
+kubectl -n $NS wait --for=delete pod/$POD --timeout=120s
+```
+
+Then bring up a pod with the PVC mounted and copy the files back:
+
+```bash
+kubectl -n $NS scale deploy/hive --replicas=1
+POD=$(kubectl -n $NS get pods --field-selector=status.phase=Running \
+        -o jsonpath='{.items[0].metadata.name}')
+
+# 3. Config FIRST — .bak is what copy-config actually restores from.
+kubectl -n $NS cp ./restore/spoke/hive.yaml.bak   $POD:/data/hive.yaml.bak -c hive
+kubectl -n $NS cp ./restore/spoke/hive-id         $POD:/data/hive-id       -c hive
+kubectl -n $NS cp ./restore/spoke/hive-state.json $POD:/data/hive-state.json -c hive
+
+# 4. GitHub App keys. Mode 0600 — never world-readable.
+for k in ./restore/spoke/gh-app-key*.pem; do
+  kubectl -n $NS cp "$k" $POD:/data/$(basename "$k") -c hive
+  kubectl -n $NS exec $POD -c hive -- chmod 600 /data/$(basename "$k")
+done
+
+# 5. The bead ledger.
+for d in ./restore/beads/*/; do
+  agent=$(basename "$d")
+  kubectl -n $NS exec $POD -c hive -- mkdir -p /data/beads/$agent
+  kubectl -n $NS cp "$d" $POD:/data/beads/$agent -c hive
+done
+
+# 6. Restart so copy-config picks up hive.yaml.bak.
+kubectl -n $NS rollout restart deploy/hive
+kubectl -n $NS rollout status  deploy/hive --timeout=300s
+```
+
+**Verify:** the dashboard loads, the hive ID matches, config changes the owner
+made are present (not the ConfigMap defaults), and agents show their prior bead
+counts rather than starting from an empty ledger.
+
+### Bead ownership
+
+Bead directories are owned per-agent UID on the spoke (`hive-scanner`,
+`hive-quality`, …). If agents cannot write their ledgers after a restore, fix
+ownership to match the surrounding directories rather than loosening the mode.
+
+## Testing status
+
+**Verified:**
+
+- Unit tests cover: `hive.yaml.bak` captured and `hive.yaml` excluded; beads
+  captured for every discovered agent; `nous`/`logs`/`home`/`audit.jsonl`/
+  `dashboard-sessions.json` excluded; App keys captured; sealed archive is
+  opaque ciphertext with no plaintext key/config leakage; wrong key and
+  bit-flips rejected; manifest digests non-empty so `Verify` is not vacuous;
+  build refuses with no key; missing files recorded rather than silently
+  dropped; hostile hive IDs cannot escape the filename.
+- Handler tests cover: `403` for `read`/`read-write`/`write`/`viewer` on both
+  endpoints, `412` with no `HIVE_BACKUP_KEY` and no download offered,
+  `no-store` caching, and an `.enc` attachment.
+- Archives are extracted through `hubbackup.Extract`, proving both backups
+  share one format and one restore path.
+- Spoke layout, `hive.yaml`/`hive.yaml.bak` divergence, bead directory names
+  and all sizes above were read from a live production spoke (read-only).
+
+**UNTESTED:**
+
+- The restore procedure above has **not** been executed against a live spoke.
+- No real backup was run against a user's hive; the endpoint was exercised
+  only against temporary directories in tests.
+- Browser download of a multi-MB archive was not exercised end-to-end in a
+  real browser.

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -44,6 +44,10 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/audit", s.handleAuditLog)
 	s.mux.HandleFunc("GET /api/prompt-history", s.handlePromptHistory)
 	s.mux.HandleFunc("POST /api/self-upgrade", s.handleSelfUpgrade)
+	// Self-service, owner-only spoke backup (encrypted; includes the bead
+	// ledger the fleet-wide hub backup excludes — see issue #2318).
+	s.mux.HandleFunc("GET /api/backup/status", s.handleBackupStatus)
+	s.mux.HandleFunc("POST /api/backup", s.handleBackupDownload)
 	s.mux.HandleFunc("POST /api/banner-dismissed", s.handleBannerDismissed)
 	s.mux.HandleFunc("GET /api/snapshot", s.handleSnapshotAPI)
 	s.mux.HandleFunc("GET /snapshot", s.handleSnapshotPage)

--- a/v2/pkg/dashboard/backup_api.go
+++ b/v2/pkg/dashboard/backup_api.go
@@ -1,0 +1,135 @@
+package dashboard
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/hubbackup"
+	"github.com/kubestellar/hive/v2/pkg/spokebackup"
+)
+
+// Self-service spoke backup.
+//
+// GET  /api/backup/status   — whether backup is available (owner-only)
+// POST /api/backup          — build and stream an encrypted archive (owner-only)
+//
+// The download is a POST rather than a GET on purpose. A GET would be
+// reachable by a plain <a href> or an <img> on another site, and this response
+// body contains GitHub App private keys; keeping it non-idempotent and
+// fetch-only keeps it off the cross-origin-navigation path.
+
+// backupBuildTimeout bounds a single backup request so a wedged filesystem
+// read cannot hold a dashboard connection open indefinitely.
+const backupBuildTimeout = spokebackup.BuildTimeout
+
+// Owner checks below mirror handleConfigDownload and handleSelfUpgrade: an
+// empty role means no per-user identity is in play (an open/dev spoke), which
+// those handlers already treat as owner.
+
+// handleBackupStatus reports whether a self-service backup can run, so the UI
+// can show the menu entry in a disabled state with a real reason instead of
+// failing only after the owner clicks.
+func (s *Server) handleBackupStatus(w http.ResponseWriter, r *http.Request) {
+	role := r.Header.Get("X-Hive-Role")
+	if role == "" {
+		role = "owner"
+	}
+	if role != "owner" {
+		jsonError(w, "owner access required", http.StatusForbidden)
+		return
+	}
+	_, err := hubbackup.LoadKey()
+	if err != nil {
+		jsonResponse(w, map[string]interface{}{
+			"available": false,
+			// The reason is operator-facing configuration state, not a secret:
+			// it names the missing environment variable, never a key value.
+			"reason": "backup encryption key is not configured on this hive",
+		})
+		return
+	}
+	jsonResponse(w, map[string]interface{}{"available": true})
+}
+
+// handleBackupDownload builds an encrypted backup of this spoke and streams it
+// to the owner.
+func (s *Server) handleBackupDownload(w http.ResponseWriter, r *http.Request) {
+	role := r.Header.Get("X-Hive-Role")
+	if role == "" {
+		role = "owner"
+	}
+	if role != "owner" {
+		jsonError(w, "only the owner can back up this hive", http.StatusForbidden)
+		return
+	}
+
+	// No key means no backup. Refusing here is deliberate: the alternative is
+	// streaming GitHub App private keys to a browser in plaintext.
+	key, err := hubbackup.LoadKey()
+	if err != nil {
+		jsonError(w,
+			"backup encryption key is not configured on this hive, so a backup "+
+				"would be unencrypted; refusing", http.StatusPreconditionFailed)
+		return
+	}
+
+	hiveID := ""
+	if s.deps != nil && s.deps.Config != nil {
+		hiveID = s.deps.Config.HiveID
+	}
+
+	// Build with a bound so a stuck read cannot pin the connection.
+	type buildResult struct {
+		res *spokebackup.Result
+		err error
+	}
+	done := make(chan buildResult, 1)
+	go func() {
+		res, err := spokebackup.Build(key, hiveID, s.logger)
+		done <- buildResult{res, err}
+	}()
+
+	var out buildResult
+	select {
+	case out = <-done:
+	case <-time.After(backupBuildTimeout):
+		jsonError(w, "backup timed out while reading hive data", http.StatusGatewayTimeout)
+		return
+	}
+	if out.err != nil {
+		// The error may name paths but never file contents.
+		s.logger.Error("spoke backup failed", "err", out.err)
+		jsonError(w, "backup failed: "+out.err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	res := out.res
+	filename := spokebackup.ArchiveName(hiveID, time.Now())
+
+	// Summarize what was captured in headers so the UI can tell the owner
+	// what they got without the archive being decrypted client-side. These
+	// carry counts and directory names only — no secrets.
+	beadDirs := res.BeadDirs
+	w.Header().Set("X-Hive-Backup-Bead-Dirs", fmt.Sprintf("%d", len(beadDirs)))
+	w.Header().Set("X-Hive-Backup-Files", fmt.Sprintf("%d", len(res.Manifest.Files)))
+	w.Header().Set("X-Hive-Backup-Encrypted", "aes-256-gcm")
+	// Let the browser read the summary headers on a same-origin fetch.
+	w.Header().Set("Access-Control-Expose-Headers",
+		"X-Hive-Backup-Bead-Dirs, X-Hive-Backup-Files, X-Hive-Backup-Encrypted")
+
+	// Never cache a credential-bearing response.
+	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, private")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(res.Sealed)))
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+
+	s.logger.Info("spoke backup created",
+		"hive_id", hiveID,
+		"files", len(res.Manifest.Files),
+		"bead_dirs", len(beadDirs),
+		"bytes", len(res.Sealed))
+
+	w.Write(res.Sealed)
+}

--- a/v2/pkg/dashboard/backup_api_test.go
+++ b/v2/pkg/dashboard/backup_api_test.go
@@ -1,0 +1,146 @@
+package dashboard
+
+import (
+	"encoding/hex"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// backupTestKey is a test-only AES-256 key. Production has no default and
+// reads HIVE_BACKUP_KEY.
+func backupTestKey() string {
+	k := make([]byte, 32)
+	for i := range k {
+		k[i] = byte(i)
+	}
+	return hex.EncodeToString(k)
+}
+
+func backupTestServer() *Server {
+	return &Server{
+		mux:    http.NewServeMux(),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+// TestBackupDeniedForNonOwners is the authorization gate: viewers and
+// read-write members must not be able to pull an archive containing this
+// hive's GitHub App private keys.
+func TestBackupDeniedForNonOwners(t *testing.T) {
+	t.Setenv("HIVE_BACKUP_KEY", backupTestKey())
+	s := backupTestServer()
+
+	for _, role := range []string{"read", "read-write", "write", "viewer"} {
+		t.Run(role, func(t *testing.T) {
+			for _, tc := range []struct {
+				name string
+				fn   func(http.ResponseWriter, *http.Request)
+				verb string
+				path string
+			}{
+				{"download", s.handleBackupDownload, http.MethodPost, "/api/backup"},
+				{"status", s.handleBackupStatus, http.MethodGet, "/api/backup/status"},
+			} {
+				req := httptest.NewRequest(tc.verb, tc.path, nil)
+				req.Header.Set("X-Hive-Role", role)
+				rec := httptest.NewRecorder()
+				tc.fn(rec, req)
+
+				if rec.Code != http.StatusForbidden {
+					t.Errorf("%s as %q: status = %d, want 403", tc.name, role, rec.Code)
+				}
+				if strings.Contains(rec.Body.String(), "PRIVATE KEY") {
+					t.Errorf("%s as %q leaked key material", tc.name, role)
+				}
+			}
+		})
+	}
+}
+
+// TestBackupRefusesWithoutEncryptionKey — with no HIVE_BACKUP_KEY the endpoint
+// must refuse rather than stream unencrypted credentials to a browser.
+func TestBackupRefusesWithoutEncryptionKey(t *testing.T) {
+	t.Setenv("HIVE_BACKUP_KEY", "")
+	s := backupTestServer()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/backup", nil)
+	req.Header.Set("X-Hive-Role", "owner")
+	rec := httptest.NewRecorder()
+	s.handleBackupDownload(rec, req)
+
+	if rec.Code != http.StatusPreconditionFailed {
+		t.Fatalf("status = %d, want 412", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Disposition"); ct != "" {
+		t.Errorf("must not offer a download when refusing: %q", ct)
+	}
+}
+
+// TestBackupStatusReportsUnavailableWithoutKey lets the UI explain itself
+// before the owner clicks, and must never echo a key value.
+func TestBackupStatusReportsUnavailableWithoutKey(t *testing.T) {
+	t.Setenv("HIVE_BACKUP_KEY", "")
+	s := backupTestServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/backup/status", nil)
+	req.Header.Set("X-Hive-Role", "owner")
+	rec := httptest.NewRecorder()
+	s.handleBackupStatus(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"available":false`) {
+		t.Errorf("expected available:false, got %s", body)
+	}
+}
+
+// TestBackupStatusAvailableWithKey — the happy path for the UI probe.
+func TestBackupStatusAvailableWithKey(t *testing.T) {
+	t.Setenv("HIVE_BACKUP_KEY", backupTestKey())
+	s := backupTestServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/backup/status", nil)
+	req.Header.Set("X-Hive-Role", "owner")
+	rec := httptest.NewRecorder()
+	s.handleBackupStatus(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `"available":true`) {
+		t.Errorf("expected available:true, got %s", body)
+	}
+	if strings.Contains(body, backupTestKey()) {
+		t.Fatal("status response echoed the backup key")
+	}
+}
+
+// TestBackupResponseIsNotCacheable — a credential-bearing body must not be
+// stored by the browser cache or an intermediary.
+func TestBackupResponseIsNotCacheable(t *testing.T) {
+	t.Setenv("HIVE_BACKUP_KEY", backupTestKey())
+	t.Setenv("HIVE_SPOKE_BACKUP_DATA_DIR", t.TempDir())
+	s := backupTestServer()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/backup", nil)
+	req.Header.Set("X-Hive-Role", "owner")
+	rec := httptest.NewRecorder()
+	s.handleBackupDownload(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if cc := rec.Header().Get("Cache-Control"); !strings.Contains(cc, "no-store") {
+		t.Errorf("Cache-Control = %q, want no-store", cc)
+	}
+	if cd := rec.Header().Get("Content-Disposition"); !strings.Contains(cd, ".tar.gz.enc") {
+		t.Errorf("Content-Disposition = %q, want an .enc attachment", cd)
+	}
+	if enc := rec.Header().Get("X-Hive-Backup-Encrypted"); enc != "aes-256-gcm" {
+		t.Errorf("X-Hive-Backup-Encrypted = %q", enc)
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2561,7 +2561,11 @@
       <a href="/api/widget" class="widget-dl" title="Download Übersicht widget">⬇ Widget</a>
       <div id="oc-gh-avatar-wrap" style="display:none;position:relative">
         <img id="oc-gh-avatar" src="" alt="" style="width:28px;height:28px;border-radius:50%;cursor:pointer;border:2px solid var(--green);vertical-align:middle" onclick="toggleGHUserMenu()">
-        <div id="oc-gh-user-menu" style="display:none;position:absolute;right:0;top:34px;background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:4px 0;min-width:160px;z-index:9999;box-shadow:0 8px 24px rgba(0,0,0,0.4)">
+        <!-- max-width keeps the longest entry ("Back up this hive") from
+             widening the menu past the right edge of a narrow viewport; the
+             menu is right-anchored, so extra width grows leftward and stays
+             on screen. Long labels wrap rather than overflow. -->
+        <div id="oc-gh-user-menu" style="display:none;position:absolute;right:0;top:34px;background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:4px 0;min-width:160px;max-width:min(280px,calc(100vw - 24px));z-index:9999;box-shadow:0 8px 24px rgba(0,0,0,0.4)">
           <div style="padding:8px 16px;border-bottom:1px solid var(--line);color:var(--text);font-weight:600;font-size:0.85rem" id="oc-gh-menu-user"></div>
           <div id="oc-gh-menu-role" style="display:none;padding:2px 16px 6px;border-bottom:1px solid var(--line);font-size:0.72rem;color:var(--muted)"></div>
           <!-- This nav avatar is NOT a profile link: its click already opens
@@ -2570,6 +2574,13 @@
                once the signed-in login is known. -->
           <a href="#" id="oc-gh-menu-profile" target="_blank" rel="noopener noreferrer" style="display:none;padding:8px 16px;color:var(--text);text-decoration:none;font-size:0.82rem">GitHub profile ↗</a>
           <a href="/api/config/download" id="oc-gh-menu-download" style="display:none;padding:8px 16px;color:var(--text);text-decoration:none;font-size:0.82rem">Download hive.yaml</a>
+          <!-- Owner-only self-service backup. Shown only for role === 'owner',
+               matching the hive.yaml entry above; the server enforces the same
+               check, so hiding this is UX, not the security boundary. -->
+          <button type="button" id="oc-gh-menu-backup" onclick="downloadHiveBackup()" style="display:none;width:100%;text-align:left;padding:8px 16px;background:none;border:none;color:var(--text);cursor:pointer;font-size:0.82rem;line-height:1.35">
+            Back up this hive
+            <span style="display:block;font-size:0.68rem;color:var(--muted)">Encrypted · includes beads</span>
+          </button>
           <a href="/api/docs" target="_blank" style="display:block;padding:8px 16px;color:var(--text);text-decoration:none;font-size:0.82rem">API Docs ↗</a>
           <button onclick="ghLogout()" style="display:block;width:100%;text-align:left;padding:8px 16px;background:none;border:none;color:var(--text);cursor:pointer;font-size:0.82rem">Sign out</button>
         </div>
@@ -16839,6 +16850,8 @@ function burnAreaChart() {
           }
           const dlEl = document.getElementById('oc-gh-menu-download');
           if (dlEl) dlEl.style.display = role === 'owner' ? 'block' : 'none';
+          const bkEl = document.getElementById('oc-gh-menu-backup');
+          if (bkEl) bkEl.style.display = role === 'owner' ? 'block' : 'none';
         }
       } else {
         banner.style.display = 'flex';
@@ -16858,6 +16871,64 @@ function burnAreaChart() {
         document.getElementById('oc-gh-user-menu').style.display = 'none';
       }
     });
+
+    /* Owner-only self-service backup.
+       POSTs (not a plain link) because the response body carries GitHub App
+       private keys: keeping it fetch-only keeps it off the cross-origin
+       navigation path. The archive arrives already encrypted with the hive's
+       HIVE_BACKUP_KEY — the browser never sees that key, and it is NOT in the
+       file, so the owner must have it escrowed to restore. */
+    async function downloadHiveBackup() {
+      const btn = document.getElementById('oc-gh-menu-backup');
+      if (btn && btn.dataset.busy === '1') return;
+      if (btn) {
+        btn.dataset.busy = '1';
+        btn.style.opacity = '0.6';
+        btn.firstChild.textContent = ' Backing up… ';
+      }
+      document.getElementById('oc-gh-user-menu').style.display = 'none';
+      showToast('Building encrypted backup — this can take a moment…', 'info');
+      let url = null;
+      try {
+        const resp = await fetch('/api/backup', { method: 'POST' });
+        if (!resp.ok) {
+          let msg = 'Backup failed (' + resp.status + ')';
+          try { const d = await resp.json(); if (d && d.error) msg = d.error; } catch (e) { /* non-JSON body */ }
+          showToast(msg, 'error');
+          return;
+        }
+        const blob = await resp.blob();
+        /* Prefer the server's filename; fall back to a generic one rather
+           than parsing a header that may be absent. */
+        let name = 'hive-spoke-backup.tar.gz.enc';
+        const cd = resp.headers.get('Content-Disposition') || '';
+        const m = cd.match(/filename="([^"]+)"/);
+        if (m && m[1]) name = m[1];
+        url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = name;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        const beadDirs = resp.headers.get('X-Hive-Backup-Bead-Dirs') || '0';
+        const files = resp.headers.get('X-Hive-Backup-Files') || '0';
+        showToast(
+          'Encrypted backup downloaded — ' + files + ' files, ' + beadDirs +
+          ' bead ledgers. Decrypt with this hive’s HIVE_BACKUP_KEY; the key is not in the file.',
+          'success');
+      } catch (e) {
+        showToast('Backup failed: ' + (e && e.message ? e.message : 'network error'), 'error');
+      } finally {
+        /* Revoke on the next tick so the click has already been dispatched. */
+        if (url) setTimeout(function () { URL.revokeObjectURL(url); }, 60000);
+        if (btn) {
+          btn.dataset.busy = '';
+          btn.style.opacity = '';
+          btn.firstChild.textContent = ' Back up this hive ';
+        }
+      }
+    }
 
     async function ghLogout() {
       document.getElementById('oc-gh-user-menu').style.display = 'none';

--- a/v2/pkg/hubbackup/builder_export.go
+++ b/v2/pkg/hubbackup/builder_export.go
@@ -1,0 +1,133 @@
+package hubbackup
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// This file exposes the archive builder so other packages can produce archives
+// in the SAME sealed format, with the same SHA-256 manifest and the same
+// AES-256-GCM sealing, instead of reimplementing crypto.
+//
+// pkg/spokebackup is the first consumer: an owner-triggered, per-hive backup
+// that includes the bead ledger the fleet-wide hub backup deliberately omits
+// (issue #2318). Sharing this builder means Verify and Extract accept both
+// archive kinds unchanged, so there is exactly one restore path to trust.
+//
+// The unexported builder used by Build is untouched; these are thin wrappers.
+
+// Builder accumulates files into a gzipped tar and records their digests.
+// Create one with NewBuilder, add content, then call Finish to seal it.
+type Builder struct {
+	b   *builder
+	raw *strings.Builder
+}
+
+// NewBuilder returns a Builder ready to accept files.
+func NewBuilder() *Builder {
+	var raw strings.Builder
+	gz := gzip.NewWriter(&raw)
+	tw := tar.NewWriter(gz)
+	return &Builder{
+		b:   &builder{tw: tw, gz: gz, buf: &raw},
+		raw: &raw,
+	}
+}
+
+// FormatVersion reports the archive format version this build understands, so
+// other packages stamp manifests consistently rather than hardcoding a number
+// that could drift from Verify's expectation.
+func FormatVersion() int { return backupFormatVersion }
+
+// AddBytes writes one in-memory file into the archive and records its digest.
+func (x *Builder) AddBytes(name string, mode int64, content []byte) error {
+	return x.b.addBytes(name, mode, content)
+}
+
+// AddTree recursively copies srcDir into the archive under dstPrefix.
+//
+// skip, when non-nil, is called with each path relative to srcDir; returning
+// true omits that file or (for a directory) prunes the whole subtree. This
+// lets a caller apply its own exclusions rather than the hub's fixed set.
+func (x *Builder) AddTree(srcDir, dstPrefix string, skip func(rel string) bool, logger *slog.Logger) error {
+	return filepath.WalkDir(srcDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			// A single unreadable path must not abort the whole backup.
+			logger.Warn("backup: skipping unreadable path", "path", path, "err", err)
+			return nil
+		}
+		rel, relErr := filepath.Rel(srcDir, path)
+		if relErr != nil || rel == "." {
+			return nil
+		}
+		if skip != nil && skip(rel) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() || !d.Type().IsRegular() {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			logger.Warn("backup: skipping unreadable file", "path", path, "err", readErr)
+			return nil
+		}
+		mode := int64(0o600)
+		if info, infoErr := d.Info(); infoErr == nil {
+			mode = int64(info.Mode().Perm())
+		}
+		return x.b.addBytes(filepath.Join(dstPrefix, rel), mode, content)
+	})
+}
+
+// Finish writes the manifest, closes the archive and seals it with key.
+//
+// The manifest is written LAST and its Files list is populated from the
+// digests accumulated so far — copying them in is what makes Verify
+// meaningful, since an empty Files list would make verification vacuous.
+//
+// maxBytes, when positive, caps the assembled plaintext so a caller streaming
+// to a browser cannot be handed an unbounded archive.
+func (x *Builder) Finish(key []byte, man *Manifest, maxBytes int) ([]byte, error) {
+	if man == nil {
+		return nil, fmt.Errorf("manifest is required")
+	}
+	man.Files = x.b.files
+
+	manJSON, err := json.MarshalIndent(man, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal manifest: %w", err)
+	}
+	hdr := &tar.Header{Name: manifestName, Mode: 0o644, Size: int64(len(manJSON)), ModTime: time.Now()}
+	if err := x.b.tw.WriteHeader(hdr); err != nil {
+		return nil, err
+	}
+	if _, err := x.b.tw.Write(manJSON); err != nil {
+		return nil, err
+	}
+	if err := x.b.tw.Close(); err != nil {
+		return nil, fmt.Errorf("close tar: %w", err)
+	}
+	if err := x.b.gz.Close(); err != nil {
+		return nil, fmt.Errorf("close gzip: %w", err)
+	}
+
+	plain := x.raw.String()
+	if maxBytes > 0 && len(plain) > maxBytes {
+		return nil, fmt.Errorf("archive is %d bytes, above the %d-byte cap", len(plain), maxBytes)
+	}
+	sealed, err := Seal(key, []byte(plain))
+	if err != nil {
+		return nil, fmt.Errorf("seal archive: %w", err)
+	}
+	return sealed, nil
+}

--- a/v2/pkg/spokebackup/backup.go
+++ b/v2/pkg/spokebackup/backup.go
@@ -1,0 +1,293 @@
+// Package spokebackup implements a self-service, owner-triggered backup of a
+// single spoke, streamed to the owner's browser as an encrypted archive.
+//
+// # Relationship to the hub backup
+//
+// pkg/hubbackup runs unattended, nightly, across the whole fleet, and is
+// deliberately config-only: including bulk agent state fleet-wide would be
+// roughly 40GB and too slow to run nightly or restore quickly. That exclusion —
+// most importantly of /data/beads, the agent work ledger — is documented in
+// issue #2318.
+//
+// This package has the opposite cost profile. One owner backing up one hive on
+// demand can afford the bead ledger, so beads ARE included here. That makes the
+// two backups complementary rather than redundant: hubbackup answers "the hub
+// cluster is gone", spokebackup answers "I want a copy of my hive that I
+// control, including what my agents have learned and filed".
+//
+// The AES-256-GCM sealing, the SHA-256 manifest and the traversal-safe
+// extraction are reused from pkg/hubbackup rather than reimplemented, so both
+// archives share one audited crypto path and one archive format.
+//
+// # Encryption
+//
+// The archive is ALWAYS encrypted. It carries GitHub App private keys
+// (gh-app-key*.pem), so an unencrypted copy would be a credential leak the
+// moment it reached the owner's Downloads folder. The key comes from
+// HIVE_BACKUP_KEY with no default; unset means the endpoint refuses to run
+// rather than streaming plaintext secrets to a browser.
+//
+// The key is deliberately NOT embedded in, or derivable from, the archive —
+// an artifact that carries its own decryption key is not encrypted at all.
+package spokebackup
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/hubbackup"
+)
+
+// Filesystem layout of spoke state.
+const (
+	// DefaultDataDir is the spoke PVC mount point.
+	DefaultDataDir = "/data"
+
+	// EnvDataDir overrides the spoke data directory (test seam).
+	EnvDataDir = "HIVE_SPOKE_BACKUP_DATA_DIR"
+
+	// beadsSubdir is the agent work ledger, relative to the data dir. This is
+	// the directory hubbackup excludes; including it is this backup's reason
+	// to exist. Its layout is one subdirectory per agent, so it grows with the
+	// agent roster rather than being a fixed set of five.
+	beadsSubdir = "beads"
+
+	// configBackupFile is the AUTHORITATIVE spoke config.
+	//
+	// It is hive.yaml.bak, NOT hive.yaml. The copy-config init container
+	// restores from .bak and falls back to the ConfigMap seed only when .bak is
+	// absent, so .bak is what actually comes back after a restart. On a sampled
+	// production spoke the two files had DIFFERENT content and different
+	// timestamps — hive.yaml was a stale root-owned copy while hive.yaml.bak
+	// carried the live user customizations. Backing up hive.yaml instead would
+	// silently capture the wrong config with no error at backup time and no
+	// symptom until a restore quietly reverted the owner's settings.
+	configBackupFile = "hive.yaml.bak"
+
+	// hiveIDFile identifies this hive to the hub.
+	hiveIDFile = "hive-id"
+
+	// stateFile is the agent runtime state snapshot.
+	stateFile = "hive-state.json"
+
+	// appKeyGlob matches the GitHub App private keys. These are credentials:
+	// they are why the archive must be encrypted, and they must never be
+	// logged or written anywhere world-readable.
+	appKeyGlob = "gh-app-key*.pem"
+)
+
+// Archive layout: top-level directories inside the tarball.
+const (
+	// spokePrefix holds files copied from the spoke PVC root.
+	spokePrefix = "spoke"
+
+	// beadsPrefix holds the agent work ledger.
+	beadsPrefix = "beads"
+)
+
+// Size guards. A backup is streamed through the dashboard to a browser, so it
+// must stay responsive; an unbounded read of a ~796MB PVC would not be.
+const (
+	// MaxArchiveBytes caps the assembled plaintext archive. Measured on a
+	// production spoke the included set is roughly 3-5MB before compression
+	// (beads 2.6MB, hive-state.json ~110KB, config ~14KB, keys ~3KB), so this
+	// leaves ample headroom for a hive with a much larger bead ledger while
+	// still refusing to stream something browser-hostile.
+	MaxArchiveBytes = 256 << 20 // 256 MiB
+
+	// MaxFileBytes skips any single file larger than this. It keeps one
+	// runaway log or state blob from dominating an otherwise small archive.
+	MaxFileBytes = 64 << 20 // 64 MiB
+)
+
+// BuildTimeout bounds a single backup so a wedged filesystem read cannot hold
+// a dashboard request open indefinitely.
+const BuildTimeout = 2 * time.Minute
+
+// includedRootFiles are the individual files copied from the data-dir root.
+//
+// Everything not listed here is excluded deliberately:
+//
+//   - nous/    287MB of timestamped learned-context snapshots. Regenerable,
+//     and the single largest directory on the PVC.
+//   - home/    agent CLI state and credential caches. Bulk, regenerable, and
+//     carries third-party tokens that should not be duplicated into an
+//     archive the owner will store outside the cluster.
+//   - logs/    32MB of rotating logs. Diagnostic, not state.
+//   - graph/, snapshots/, vaults/  derived or bulk artifacts (~19MB combined).
+//   - prompt-history.jsonl  3.1MB append-only transcript; diagnostic.
+//   - audit.jsonl  860KB append-only audit trail. Excluded to keep the
+//     archive small and fast; it is a record OF actions, not state needed to
+//     reconstitute the hive.
+//   - dashboard-sessions.json  live browser session tokens. Excluded on
+//     purpose: these are credentials with no restore value, and restoring
+//     them would resurrect sessions that should have expired.
+//   - hive.yaml  the stale ConfigMap-seeded copy; see configBackupFile.
+var includedRootFiles = []string{
+	configBackupFile,
+	hiveIDFile,
+	stateFile,
+}
+
+// DataDir returns the spoke data directory, honouring the test-seam override.
+func DataDir() string {
+	if v := strings.TrimSpace(os.Getenv(EnvDataDir)); v != "" {
+		return v
+	}
+	return DefaultDataDir
+}
+
+// ArchiveName returns a download filename for a backup of hiveID taken at t.
+// The ".enc" suffix is load-bearing UX: it tells the owner at a glance that
+// the file in their Downloads folder is not directly readable.
+func ArchiveName(hiveID string, t time.Time) string {
+	id := sanitizeComponent(hiveID)
+	if id == "" {
+		id = "hive"
+	}
+	return fmt.Sprintf("hive-spoke-backup-%s-%s.tar.gz.enc", id, t.UTC().Format("20060102T150405Z"))
+}
+
+// sanitizeComponent reduces s to characters safe in a filename, so a hive ID
+// can never inject path separators or quotes into a Content-Disposition header.
+func sanitizeComponent(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// Result reports what a backup captured, for logging and for the manifest the
+// owner sees. It intentionally carries no file CONTENT and no secret values.
+type Result struct {
+	// Sealed is the encrypted archive, ready to stream.
+	Sealed []byte
+
+	// Manifest describes the archive contents and digests.
+	Manifest *hubbackup.Manifest
+
+	// BeadDirs lists the per-agent bead directories captured.
+	BeadDirs []string
+
+	// Skipped records files that could not be read or were too large, so a
+	// gap is visible in the result rather than silently absent.
+	Skipped map[string]string
+}
+
+// Build assembles and seals a backup of this spoke.
+//
+// key must come from hubbackup.LoadKey (HIVE_BACKUP_KEY); Build does not read
+// the environment itself so a caller can never accidentally pass a default.
+func Build(key []byte, hiveID string, logger *slog.Logger) (*Result, error) {
+	if len(key) == 0 {
+		return nil, fmt.Errorf("refusing to build an unencrypted spoke backup: no key supplied")
+	}
+	dataDir := DataDir()
+	res := &Result{Skipped: map[string]string{}}
+
+	b := hubbackup.NewBuilder()
+
+	// 1. Authoritative config, hive identity and agent state.
+	for _, name := range includedRootFiles {
+		path := filepath.Join(dataDir, name)
+		content, err := readCapped(path)
+		if err != nil {
+			// A missing hive-state.json or hive-id is survivable; a missing
+			// config is worth surfacing, but neither should abort the backup
+			// the owner asked for. Record the gap instead.
+			res.Skipped[name] = err.Error()
+			logger.Warn("spoke backup: skipping file", "file", name, "err", err)
+			continue
+		}
+		if err := b.AddBytes(filepath.Join(spokePrefix, name), 0o600, content); err != nil {
+			return nil, fmt.Errorf("archive %s: %w", name, err)
+		}
+	}
+
+	// 2. GitHub App private keys. Credentials — never logged, and the reason
+	//    this archive is unconditionally encrypted.
+	keyPaths, _ := filepath.Glob(filepath.Join(dataDir, appKeyGlob))
+	sort.Strings(keyPaths)
+	for _, path := range keyPaths {
+		name := filepath.Base(path)
+		content, err := readCapped(path)
+		if err != nil {
+			res.Skipped[name] = err.Error()
+			logger.Warn("spoke backup: skipping app key", "file", name, "err", err)
+			continue
+		}
+		if err := b.AddBytes(filepath.Join(spokePrefix, name), 0o600, content); err != nil {
+			return nil, fmt.Errorf("archive app key: %w", err)
+		}
+	}
+
+	// 3. The bead ledger — the whole point of this backup. One subdirectory
+	//    per agent, discovered rather than hardcoded, so a hive running agents
+	//    beyond the original five still gets a complete ledger.
+	beadsDir := filepath.Join(dataDir, beadsSubdir)
+	entries, err := os.ReadDir(beadsDir)
+	if err != nil {
+		res.Skipped[beadsSubdir] = err.Error()
+		logger.Warn("spoke backup: beads dir unreadable", "dir", beadsDir, "err", err)
+	} else {
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			agent := e.Name()
+			src := filepath.Join(beadsDir, agent)
+			if err := b.AddTree(src, filepath.Join(beadsPrefix, agent), nil, logger); err != nil {
+				res.Skipped[filepath.Join(beadsSubdir, agent)] = err.Error()
+				logger.Warn("spoke backup: bead dir failed", "agent", agent, "err", err)
+				continue
+			}
+			res.BeadDirs = append(res.BeadDirs, agent)
+		}
+	}
+
+	man := &hubbackup.Manifest{
+		FormatVersion: hubbackup.FormatVersion(),
+		CreatedAt:     time.Now().UTC(),
+		HubDataDir:    dataDir,
+		SpokeIDs:      []string{hiveID},
+		SpokeErrors:   map[string]string{},
+	}
+	for k, v := range res.Skipped {
+		man.SpokeErrors[k] = v
+	}
+
+	sealed, err := b.Finish(key, man, MaxArchiveBytes)
+	if err != nil {
+		return nil, err
+	}
+	res.Sealed = sealed
+	res.Manifest = man
+	return res, nil
+}
+
+// readCapped reads path, refusing files above MaxFileBytes so a single runaway
+// file cannot blow up an archive that is streamed to a browser.
+func readCapped(path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("not a regular file")
+	}
+	if info.Size() > MaxFileBytes {
+		return nil, fmt.Errorf("file is %d bytes, above the %d-byte per-file cap", info.Size(), MaxFileBytes)
+	}
+	return os.ReadFile(path)
+}

--- a/v2/pkg/spokebackup/backup_test.go
+++ b/v2/pkg/spokebackup/backup_test.go
@@ -1,0 +1,259 @@
+package spokebackup
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/hubbackup"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// testKey is a deterministic AES-256 key for tests only. It is NOT a default
+// and never reaches non-test code — production reads HIVE_BACKUP_KEY.
+func testKey() []byte {
+	k := make([]byte, 32)
+	for i := range k {
+		k[i] = byte(i)
+	}
+	return k
+}
+
+// seedSpoke lays out a realistic spoke data dir, mirroring what was observed
+// on a production spoke.
+func seedSpoke(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	// hive.yaml and hive.yaml.bak deliberately DIFFER, as they did on the
+	// sampled production spoke.
+	mustWrite(t, filepath.Join(dir, "hive.yaml"), "stale: configmap-seed\n")
+	mustWrite(t, filepath.Join(dir, "hive.yaml.bak"), "live: owner-customised\n")
+	mustWrite(t, filepath.Join(dir, "hive-id"), "hive-abc123")
+	mustWrite(t, filepath.Join(dir, "hive-state.json"), `{"agents":[]}`)
+	mustWrite(t, filepath.Join(dir, "gh-app-key.pem"), "-----BEGIN PRIVATE KEY-----\nAAA\n")
+	mustWrite(t, filepath.Join(dir, "gh-app-key-5686.pem"), "-----BEGIN PRIVATE KEY-----\nBBB\n")
+
+	// Things that must NOT be captured.
+	mustWrite(t, filepath.Join(dir, "dashboard-sessions.json"), `{"sess":"secret"}`)
+	mustWrite(t, filepath.Join(dir, "audit.jsonl"), "{}\n")
+	mustWrite(t, filepath.Join(dir, "nous", "snapshots", "1.json"), "bulk")
+	mustWrite(t, filepath.Join(dir, "logs", "hive.log"), "noise")
+	mustWrite(t, filepath.Join(dir, "home", "agent", "creds"), "token")
+
+	// The bead ledger: one dir per agent, more than the original five.
+	for _, agent := range []string{"scanner", "quality", "ci-maintainer", "sec-check", "strategist"} {
+		mustWrite(t, filepath.Join(dir, "beads", agent, "beads.json"), `{"agent":"`+agent+`"}`)
+	}
+	return dir
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func buildTestBackup(t *testing.T) (map[string]string, *hubbackup.Manifest, *Result) {
+	t.Helper()
+	dir := seedSpoke(t)
+	t.Setenv(EnvDataDir, dir)
+
+	res, err := Build(testKey(), "hive-abc123", testLogger())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	// Extract through hubbackup's shared path — proving the two backups share
+	// one archive format and one restore path.
+	dest := t.TempDir()
+	man, err := hubbackup.Extract(testKey(), res.Sealed, dest)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	files := map[string]string{}
+	filepath.WalkDir(dest, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(dest, p)
+		b, _ := os.ReadFile(p)
+		files[filepath.ToSlash(rel)] = string(b)
+		return nil
+	})
+	return files, man, res
+}
+
+// TestBackupCapturesAuthoritativeConfig locks in that the backup takes
+// hive.yaml.bak and NOT hive.yaml. Getting this wrong silently backs up a
+// stale ConfigMap seed instead of the owner's real configuration.
+func TestBackupCapturesAuthoritativeConfig(t *testing.T) {
+	files, _, _ := buildTestBackup(t)
+
+	got, ok := files["spoke/hive.yaml.bak"]
+	if !ok {
+		t.Fatal("hive.yaml.bak missing from archive")
+	}
+	if !strings.Contains(got, "owner-customised") {
+		t.Errorf("hive.yaml.bak content wrong: %q", got)
+	}
+	if _, ok := files["spoke/hive.yaml"]; ok {
+		t.Error("archive must NOT contain the stale hive.yaml")
+	}
+}
+
+// TestBackupIncludesBeads is the reason this package exists: the fleet-wide
+// hub backup excludes the bead ledger (issue #2318) and this one must not.
+func TestBackupIncludesBeads(t *testing.T) {
+	files, _, res := buildTestBackup(t)
+
+	for _, agent := range []string{"scanner", "quality", "ci-maintainer", "sec-check", "strategist"} {
+		key := "beads/" + agent + "/beads.json"
+		if _, ok := files[key]; !ok {
+			t.Errorf("bead ledger for %s missing from archive", agent)
+		}
+	}
+	if len(res.BeadDirs) != 5 {
+		t.Errorf("BeadDirs = %d, want 5 (discovered, not hardcoded)", len(res.BeadDirs))
+	}
+}
+
+// TestBackupExcludesBulkAndLiveCredentials proves the exclusions are real —
+// bulk directories stay out (so the download stays responsive) and live
+// browser sessions stay out (they are credentials with no restore value).
+func TestBackupExcludesBulkAndLiveCredentials(t *testing.T) {
+	files, _, _ := buildTestBackup(t)
+
+	for path := range files {
+		for _, banned := range []string{"nous/", "logs/", "home/", "dashboard-sessions", "audit.jsonl"} {
+			if strings.Contains(path, banned) {
+				t.Errorf("archive must not contain %q (matched %q)", path, banned)
+			}
+		}
+	}
+}
+
+// TestBackupCapturesAppKeys — the App keys must be present (they are needed to
+// restore a working hive) which is precisely why encryption is mandatory.
+func TestBackupCapturesAppKeys(t *testing.T) {
+	files, _, _ := buildTestBackup(t)
+	for _, name := range []string{"spoke/gh-app-key.pem", "spoke/gh-app-key-5686.pem"} {
+		if _, ok := files[name]; !ok {
+			t.Errorf("%s missing from archive", name)
+		}
+	}
+}
+
+// TestArchiveIsOpaqueCiphertext proves the sealed bytes leak neither the
+// private keys nor the config in plaintext.
+func TestArchiveIsOpaqueCiphertext(t *testing.T) {
+	dir := seedSpoke(t)
+	t.Setenv(EnvDataDir, dir)
+	res, err := Build(testKey(), "hive-abc123", testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, secret := range []string{"BEGIN PRIVATE KEY", "owner-customised", "hive-abc123"} {
+		if strings.Contains(string(res.Sealed), secret) {
+			t.Errorf("sealed archive leaks %q in plaintext", secret)
+		}
+	}
+}
+
+// TestWrongKeyIsRejected — the GCM auth tag must make a wrong key fail rather
+// than yielding garbage that a restore might act on.
+func TestWrongKeyIsRejected(t *testing.T) {
+	dir := seedSpoke(t)
+	t.Setenv(EnvDataDir, dir)
+	res, err := Build(testKey(), "hive-abc123", testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrong := make([]byte, 32)
+	if _, err := hubbackup.Verify(wrong, res.Sealed); err == nil {
+		t.Fatal("Verify accepted a wrong key")
+	}
+}
+
+// TestTamperedArchiveIsRejected — a flipped bit must fail verification.
+func TestTamperedArchiveIsRejected(t *testing.T) {
+	dir := seedSpoke(t)
+	t.Setenv(EnvDataDir, dir)
+	res, err := Build(testKey(), "hive-abc123", testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tampered := append([]byte(nil), res.Sealed...)
+	tampered[len(tampered)/2] ^= 0xFF
+	if _, err := hubbackup.Verify(testKey(), tampered); err == nil {
+		t.Fatal("Verify accepted a tampered archive")
+	}
+}
+
+// TestManifestVerifies — digests must actually cover the files, so Verify is
+// not vacuously passing (the exact bug caught during PR #2315).
+func TestManifestVerifies(t *testing.T) {
+	_, man, res := buildTestBackup(t)
+	if len(man.Files) == 0 {
+		t.Fatal("manifest has no files: verification would be vacuous")
+	}
+	if _, err := hubbackup.Verify(testKey(), res.Sealed); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+}
+
+// TestBuildRefusesWithoutKey — no key must mean no archive, never a plaintext
+// one containing GitHub App private keys.
+func TestBuildRefusesWithoutKey(t *testing.T) {
+	dir := seedSpoke(t)
+	t.Setenv(EnvDataDir, dir)
+	if _, err := Build(nil, "hive-abc123", testLogger()); err == nil {
+		t.Fatal("Build produced an archive with no key")
+	}
+}
+
+// TestMissingFilesAreRecordedNotSilent — a gap must be visible in the result
+// rather than discovered during a restore.
+func TestMissingFilesAreRecordedNotSilent(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "hive-id"), "hive-xyz")
+	t.Setenv(EnvDataDir, dir)
+
+	res, err := Build(testKey(), "hive-xyz", testLogger())
+	if err != nil {
+		t.Fatalf("Build should tolerate a sparse spoke: %v", err)
+	}
+	if _, ok := res.Skipped["hive.yaml.bak"]; !ok {
+		t.Error("missing hive.yaml.bak should be recorded in Skipped")
+	}
+	if len(res.Manifest.SpokeErrors) == 0 {
+		t.Error("gaps should surface in the manifest")
+	}
+}
+
+// TestArchiveNameIsFilenameSafe — a hostile hive ID must not escape the
+// Content-Disposition header.
+func TestArchiveNameIsFilenameSafe(t *testing.T) {
+	name := ArchiveName(`../../etc/"passwd`, timeZero())
+	if strings.ContainsAny(name, `/"\`) {
+		t.Errorf("unsafe filename: %q", name)
+	}
+	if !strings.HasSuffix(name, ".tar.gz.enc") {
+		t.Errorf("expected .enc suffix, got %q", name)
+	}
+}
+
+// timeZero is a fixed timestamp so filename tests are deterministic.
+func timeZero() time.Time { return time.Unix(0, 0).UTC() }


### PR DESCRIPTION
Spoke owners can now back up their own hive from the **avatar menu** on the spoke dashboard. The archive downloads to the browser, encrypted, and **includes the bead ledger** that the fleet-wide hub backup deliberately excludes.

> "might be useful for spoke owners to have a backup option that sits under their avatar in their dashboard. that might backup beads as well"

## Why this is not a duplicate of #2315

PR #2315 is config-only **on purpose**: including bulk agent state across ~50 spokes would be roughly 40GB — too slow to run nightly, too slow to restore in an emergency. Issue #2318 records that trade-off and names the **bead ledger** as the most painful documented loss: after a restore, agents come back configured but with no memory of what they had found, claimed, deferred, or closed.

A single owner backing up a single hive **on demand** has the opposite cost profile, so beads belong here. The two are complementary — #2315 answers *"the hub cluster is gone"*; this answers *"I want a copy of my hive that I control."*

## Reused, not reimplemented

AES-256-GCM sealing, the SHA-256 manifest, and traversal-safe extraction all come from `pkg/hubbackup` via a new exported `Builder` seam. Archives verify and extract with `hubbackup.Verify`/`Extract` **unchanged**, so there is exactly one archive format and one restore path to trust. #2315's own code is untouched, as is `pkg/hub/saas.go`.

## What it captures — and the size that justifies it

Captured: `hive.yaml.bak`, `hive-id`, `hive-state.json`, `gh-app-key*.pem`, and `beads/<agent>/**`.

Bead directories are **discovered, not hardcoded** — a production spoke had **ten** agents, not the five named in #2318, so a fixed list would silently miss ledgers.

Excluded, with sizes measured on a live spoke:

| Path | Size | Why excluded |
|---|---|---|
| `nous/` | **287MB** | Regenerable snapshots; largest dir on the PVC |
| `logs/` | 32MB | Diagnostic, not state |
| `graph/`,`snapshots/`,`vaults/` | ~19MB | Derived/bulk |
| `prompt-history.jsonl` | 3.1MB | Diagnostic transcript |
| `audit.jsonl` | 860KB | A record *of* actions, not state |
| `dashboard-sessions.json` | 1KB | **Live session tokens** — credentials with no restore value |

**Result: ~3–5MB** (beads 2.6MB dominating) versus ~796MB for the whole PVC — small enough to stream and stay responsive.

## `hive.yaml.bak`, not `hive.yaml`

`copy-config` restores from `.bak` and *silently* falls back to the stale ConfigMap seed when it is absent. On a sampled production spoke the two files had **different content and different timestamps** — `hive.yaml` was a root-owned copy days older than the live, user-customised `.bak`. Backing up the wrong one fails silently until a restore reverts the owner's settings. A test locks this in.

## Secrets

The archive carries GitHub App private keys, so it is **always** encrypted.

- `HIVE_BACKUP_KEY` read with **no default**; unset returns `412` rather than streaming plaintext credentials to a browser.
- The key is **not in the archive** and not derivable from it — an artifact carrying its own key is not encrypted. The owner must have it escrowed.
- `Cache-Control: no-store`, and **POST-only** so a credential-bearing body stays off the cross-origin navigation path.
- The UI states plainly that the file is encrypted and that the key is not included.

## Authorization

**Owner-only**, enforced server-side on both endpoints, matching `handleConfigDownload`/`handleSelfUpgrade`. `read`, `read-write`, `write`, and `viewer` all get `403`. Hiding the menu entry is UX; the server check is the boundary.

## Restore — documented, not implemented

Restoring is a disruptive act on a running hive, so it is an operator procedure rather than a one-click control. `docs/HUB_DISASTER_RECOVERY.md` gains a full spoke section: extract, scale down, copy back (config first), restore beads, restart, verify — plus a note on per-agent bead ownership.

## UI

Entry sits under the avatar next to the existing owner-only *Download hive.yaml*. The dropdown gains a `max-width` so the new, longer label **cannot widen the right-anchored menu past a narrow viewport edge** — the known overflow bug is not made worse.

## Verified

- **Read-only against a live production spoke**: `/data` layout, the real `hive.yaml`/`hive.yaml.bak` divergence, the ten bead directories, and every size above. No hive was mutated; **no real backup was run against a user's hive**.
- Tests: `.bak` captured / `hive.yaml` excluded; beads captured per discovered agent; bulk + session-token exclusions; App keys captured; sealed archive is opaque ciphertext with no plaintext leakage; wrong key and bit-flips rejected; manifest digests non-empty so `Verify` is not vacuous; refuses with no key; gaps recorded not dropped; hostile hive IDs cannot escape the filename. Handlers: `403` for all non-owner roles, `412` with no key and no download offered, `no-store`, `.enc` attachment.
- Archives extracted via `hubbackup.Extract`, proving the shared format.
- `go build ./...`, `go vet`, `gofmt` clean. The 18 `pkg/dashboard` failures on this branch are **pre-existing** — the clean base fails the same 18 (GitHub device-flow tests needing network); zero new failures.
- Embedded JS verified by extracting `<script>` bodies and comparing brace/paren/bracket **deltas vs base**: all `0`, pre-existing `-4` paren offset unchanged.

## Not tested

The restore procedure has **not** been executed against a live spoke, and the browser download was not exercised end-to-end in a real browser. Both are stated in the doc.

Refs #2318