### PR TITLE
🐛 fix(hub): apply the requested ACMM level and a real app_id on placeholder assignment

### DIFF
--- a/v2/cmd/hive/githubauth_test.go
+++ b/v2/cmd/hive/githubauth_test.go
@@ -62,6 +62,9 @@ func isolateAppKeyLookup(t *testing.T) string {
 // the new pod could never go Ready.
 //
 // Booting is the assertion. Nine more hives were carrying this exact config.
+//
+// It also locks the CLASSIFICATION: a sentinel hive is operator-actionable
+// (AppStateNoAppAssigned), never AppStateNotInstalled.
 func TestInitGitHubAuthPlaceholderAppIDBoots(t *testing.T) {
 	dir := isolateAppKeyLookup(t)
 
@@ -91,15 +94,25 @@ func TestInitGitHubAuthPlaceholderAppIDBoots(t *testing.T) {
 	if !strings.Contains(got.Failure, "placeholder") {
 		t.Errorf("failure reason does not identify the placeholder as the cause: %q", got.Failure)
 	}
-	// A placeholder hive genuinely has no App installed, and installing one is
-	// what the owner must do — so this must classify as user-actionable, not as
-	// an operator-side key fault.
-	if got.State != github.AppStateNotInstalled {
-		t.Errorf("State = %v, want AppStateNotInstalled", got.State)
+	// A placeholder hive is OPERATOR-actionable, not user-actionable.
+	//
+	// This assertion was inverted until the placeholder-assignment fix. The
+	// premise "the owner can fix this by installing the App" is false: the
+	// sentinel app_id names no GitHub App, so the JWT fails before any
+	// installation is consulted. The App is typically already installed and the
+	// installation_id already correct (the reporting owner's was the very same
+	// installation another working hive uses) — only the hub can supply the real
+	// app_id. Classifying it as "not installed" pointed the owner at the
+	// install link and the Set-ID box, i.e. at the one field already right.
+	if got.State != github.AppStateNoAppAssigned {
+		t.Errorf("State = %v, want AppStateNoAppAssigned", got.State)
 	}
-	if !got.State.UserActionable() {
-		t.Error("a placeholder hive's owner can fix this by installing the App; " +
-			"the state must be user-actionable or the banner will not tell them to")
+	if got.State.UserActionable() {
+		t.Error("placeholder app_id is not user-actionable: no installation_id the owner " +
+			"enters can make a nonexistent app_id authenticate")
+	}
+	if !got.State.OperatorActionable() {
+		t.Error("only the hub operator can assign a real app_id; the banner must say so")
 	}
 }
 

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -421,10 +421,17 @@ func initGitHubAuth(ctx context.Context, cfg *config.Config, logger *slog.Logger
 		// Real App, unusable key. Already logged; leave Client nil so nothing
 		// tries to act on GitHub with credentials that do not work.
 	case cfg.GitHub.IsPlaceholderApp():
-		// User-actionable: this hive was provisioned ahead of its App, and
-		// installing the App is exactly what resolves it.
-		out.Failure = "This hive carries a placeholder github.app_id and is not yet linked to a GitHub App. Install the GitHub App on your org to enable agents."
-		out.State = github.AppStateNotInstalled
+		// OPERATOR-actionable, not user-actionable. This hive was provisioned as
+		// a placeholder and never assigned a real app_id, so the JWT it signs
+		// names no App and fails before any installation is consulted. Nothing
+		// the owner enters in the installation-ID box can fix it — reporting this
+		// as AppStateNotInstalled sent owners to re-install an App that was
+		// already installed and to re-enter an installation_id that was already
+		// correct.
+		out.Failure = "This hive was never assigned a GitHub App ID: it still carries the placeholder github.app_id, " +
+			"which does not name a real GitHub App. Setting an installation ID cannot resolve this — " +
+			"the hub operator must assign the real App ID."
+		out.State = github.AppStateNoAppAssigned
 		logger.Warn("placeholder github.app_id — hive starting in dashboard-only mode",
 			"placeholder_app_id", config.PlaceholderAppID,
 			"installation_id", cfg.GitHub.InstallationID,

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5071,9 +5071,17 @@
        perform. Kept out of GH_APP_OPERATOR_STATES: installing is the user's
        job, not the operator's. */
     var GH_APP_STATE_NOT_INSTALLED = 'not-installed';
+    /* Operator-side: this hive still carries the placeholder app_id and was
+       never assigned a real App. It is NOT 'not-installed' — the App may well be
+       installed and the installation ID correct (it usually is), but an app_id
+       that names no App can never authenticate. Treating it as user-actionable
+       sent owners to the install link and the Set-ID box, i.e. to fix the one
+       field that was already right. */
+    var GH_APP_STATE_NO_APP_ASSIGNED = 'no-app-assigned';
     var GH_APP_OPERATOR_STATES = {};
     GH_APP_OPERATOR_STATES[GH_APP_STATE_KEY_MISSING] = true;
     GH_APP_OPERATOR_STATES[GH_APP_STATE_KEY_INVALID] = true;
+    GH_APP_OPERATOR_STATES[GH_APP_STATE_NO_APP_ASSIGNED] = true;
 
     /* True when the App failure is the operator's to fix. An unreported or
        unrecognised state is deliberately NOT operator-side: a spoke too old to
@@ -5099,14 +5107,20 @@
         var oTitle = document.querySelector('#gh-app-install-banner .gh-app-title');
         var oDesc = document.querySelector('#gh-app-install-banner .gh-app-desc');
         var oLink = document.getElementById('gh-app-install-link');
-        if (oTitle) oTitle.textContent = 'GitHub App credentials pending — no action needed from you';
+        if (oTitle) {
+          oTitle.textContent = appState === GH_APP_STATE_NO_APP_ASSIGNED
+            ? 'This hive was never assigned a GitHub App ID'
+            : 'GitHub App credentials pending — no action needed from you';
+        }
         if (oDesc) {
           /* Prefer the server-composed diagnosis; it already carries the
              accurate, non-blaming copy. textContent keeps any org name or API
              text safe to render verbatim. */
           oDesc.textContent = (typeof data.githubAppPermIssue === 'string' && data.githubAppPermIssue)
             ? data.githubAppPermIssue
-            : (appState === GH_APP_STATE_KEY_INVALID
+            : (appState === GH_APP_STATE_NO_APP_ASSIGNED
+                ? 'This hive was provisioned as a placeholder and still carries the placeholder github.app_id, which does not name a real GitHub App. It cannot authenticate no matter which installation ID is set — your App installation and installation ID are not at fault. Only the hub operator can assign the real App ID. Please contact your hub administrator.'
+                : appState === GH_APP_STATE_KEY_INVALID
                 ? 'This hive’s GitHub App private key does not match the App it authenticates as, so GitHub rejects its token. The key is supplied by the hub operator and cannot be corrected by you — your App installation and installation ID are not at fault. Please contact your hub administrator.'
                 : 'This hive’s GitHub App credentials have not been provisioned yet. The private key is supplied by the hub operator, not by you. Agents will start working automatically once it arrives; contact your hub administrator if this persists.');
         }

--- a/v2/pkg/github/app_state.go
+++ b/v2/pkg/github/app_state.go
@@ -55,6 +55,20 @@ const (
 	// classic symptom of a public github.com key on a GitHub Enterprise hive).
 	// OPERATOR-ACTIONABLE: the hub must push the correct key.
 	AppStateKeyInvalid
+
+	// AppStateNoAppAssigned means the hive is still running
+	// config.PlaceholderAppID — it was provisioned as a placeholder and never
+	// assigned a real GitHub App ID. OPERATOR-ACTIONABLE: only the hub can
+	// supply the App ID.
+	//
+	// This is deliberately NOT AppStateNotInstalled. Both leave the hive without
+	// working App auth, but they point at opposite fixes, and reporting this one
+	// as "not installed" actively misleads: it tells the owner to install the App
+	// and set an installation_id, when their installation_id is already correct
+	// and no value they can enter will help — the app_id names no App, so the
+	// JWT fails before the installation is ever consulted. That misdiagnosis is
+	// what cost the owner of the first hive to hit this real debugging time.
+	AppStateNoAppAssigned
 )
 
 // String returns the stable wire token for a state. These tokens cross the
@@ -74,6 +88,8 @@ func (s AppAuthState) String() string {
 		return "key-missing"
 	case AppStateKeyInvalid:
 		return "key-invalid"
+	case AppStateNoAppAssigned:
+		return "no-app-assigned"
 	default:
 		return "unknown"
 	}
@@ -84,7 +100,7 @@ func (s AppAuthState) String() string {
 // not instruct the user to install anything or edit config, and the journey
 // nudges must never escalate against them.
 func (s AppAuthState) OperatorActionable() bool {
-	return s == AppStateKeyMissing || s == AppStateKeyInvalid
+	return s == AppStateKeyMissing || s == AppStateKeyInvalid || s == AppStateNoAppAssigned
 }
 
 // UserActionable reports whether the hive's owner (or their org owner) can fix
@@ -115,6 +131,8 @@ func ParseAppAuthState(s string) AppAuthState {
 		return AppStateKeyMissing
 	case "key-invalid":
 		return AppStateKeyInvalid
+	case "no-app-assigned":
+		return AppStateNoAppAssigned
 	default:
 		return AppStateUnknown
 	}
@@ -337,6 +355,13 @@ func (d AppAuthDiagnosis) Message() string {
 			"the private key it holds does not match the App it authenticates as, so GitHub rejects its signed token. " +
 			"This key is distributed by the hub operator and cannot be supplied or corrected by you — " +
 			"your App installation and installation ID are not at fault. Please contact your hub administrator to have the correct key pushed to this hive."
+
+	case AppStateNoAppAssigned:
+		return "This hive was never assigned a GitHub App ID. It was provisioned as a placeholder and still carries the " +
+			"placeholder app_id, which does not name a real GitHub App — so it cannot authenticate no matter which " +
+			"installation ID is set here. Your App installation and installation ID are NOT at fault, and setting an " +
+			"installation ID will not resolve this. Only the hub operator can assign the real App ID. " +
+			"Please contact your hub administrator."
 
 	case AppStateNotInstalled:
 		return fmt.Sprintf("The KubeStellar Hive GitHub App is not installed on %s. "+

--- a/v2/pkg/hub/advisory_staleness.go
+++ b/v2/pkg/hub/advisory_staleness.go
@@ -32,7 +32,7 @@ func appCanWriteForAdvisory(e RegistryEntry) bool {
 		return false
 	}
 	switch e.GitHubAppState {
-	case "not-installed", "key-missing", "key-invalid",
+	case "not-installed", "key-missing", "key-invalid", "no-app-assigned",
 		"wrong-installation", "insufficient-permissions":
 		return false
 	default:

--- a/v2/pkg/hub/app_host_follows_repo_test.go
+++ b/v2/pkg/hub/app_host_follows_repo_test.go
@@ -1,6 +1,10 @@
 package hub
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
 
 // The App ID provisioned for a hive must follow the hive's GitHub HOST:
 // a GHE hive gets the cluster's GitHub Enterprise App, never the public
@@ -24,6 +28,15 @@ func TestResolveProvisionAppID_GHEUsesClusterApp(t *testing.T) {
 	if got := resolveProvisionAppID("3568013", publicOnGHECluster, gheCluster); got != "3568013" {
 		t.Errorf("public-override hive on GHE cluster app_id = %q, want request value 3568013", got)
 	}
+
+	// A PUBLIC github.com cluster that names its own App ID must hand it to its
+	// hives. This is the placeholder-sentinel fix: the public cluster carried no
+	// github_app_id, so every hive it provisioned kept config.PlaceholderAppID
+	// and could never authenticate. The rule is per-HOST, not GHE-only.
+	publicCluster := &ClusterConfig{GitHubAppID: 3568013}
+	if got := resolveProvisionAppID("", &SaaSHive{}, publicCluster); got != "3568013" {
+		t.Errorf("public cluster app_id = %q, want the cluster's configured App 3568013", got)
+	}
 }
 
 // Public-GitHub hives (and clusters with no GHE App) keep the request's app_id
@@ -39,5 +52,46 @@ func TestResolveProvisionAppID_PublicUnchanged(t *testing.T) {
 	gheClusterNoApp := &ClusterConfig{GitHubBaseURL: "https://github.ibm.com", GitHubAPIURL: "https://github.ibm.com/api/v3"}
 	if got := resolveProvisionAppID("3568013", &SaaSHive{}, gheClusterNoApp); got != "3568013" {
 		t.Errorf("GHE cluster w/o App app_id = %q, want request value 3568013 (no cluster App to use)", got)
+	}
+}
+
+// TestDecideAppKeySync_RepairsPlaceholderSentinel locks the fleet-repair half of
+// the placeholder-app_id fix.
+//
+// A spoke provisioned as a placeholder carries config.PlaceholderAppID plus its
+// own per-hive key. Before this, the per-hive key acted as an override and the
+// reconcile refused to touch it (appKeyReasonPerHiveOverride), so the sentinel
+// survived every heartbeat forever — the hive could never authenticate no matter
+// what its owner did. The sentinel is never a deliberate pin, so it must be
+// repaired even against a per-hive key, and even when that key's fingerprint
+// happens to match (a correct key cannot rescue a nonexistent app_id).
+func TestDecideAppKeySync_RepairsPlaceholderSentinel(t *testing.T) {
+	cluster := &clusterAppIdentity{AppID: 3568013, Fingerprint: "cluster-fp"}
+
+	for _, tc := range []struct {
+		name        string
+		fingerprint string
+		hasPerHive  bool
+	}{
+		{"per-hive key, different fingerprint", "other-fp", true},
+		{"per-hive key, matching fingerprint", "cluster-fp", true},
+		{"no key at all", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decideAppKeySync(tc.fingerprint, tc.hasPerHive, false, config.PlaceholderAppID, cluster)
+			if !got.Push {
+				t.Errorf("sentinel app_id not repaired (%s): %+v", tc.name, got)
+			}
+			if got.Reason != appKeyReasonPlaceholderAppID {
+				t.Errorf("Reason = %q, want %q", got.Reason, appKeyReasonPlaceholderAppID)
+			}
+		})
+	}
+
+	// A spoke on a genuinely different (real) App is still protected — the
+	// sentinel is the ONLY app_id treated as unconditionally wrong.
+	const someOtherRealApp = 4240368
+	if got := decideAppKeySync("other-fp", true, false, someOtherRealApp, cluster); got.Push {
+		t.Errorf("a real non-matching app_id must stay protected as a deliberate pin: %+v", got)
 	}
 }

--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -431,6 +431,14 @@ const (
 	// is pinned to an App other than the cluster's, so its key is presumed
 	// correct for that App and the cluster key would break it.
 	appKeyReasonDifferentApp = "hive is deliberately pinned to a different app_id"
+	// appKeyReasonPlaceholderAppID repairs a spoke still running the
+	// config.PlaceholderAppID sentinel. The sentinel is NOT a real App and is
+	// never a deliberate pin — it is what provisioning writes when no App ID was
+	// known yet — so the per-hive-override protection must not shield it. Such a
+	// spoke signs a JWT for a nonexistent App and can never authenticate, no
+	// matter what installation_id its owner enters, so pushing the cluster's real
+	// App identity is the only thing that can fix it.
+	appKeyReasonPlaceholderAppID = "spoke still carries the placeholder app_id sentinel"
 	// appKeyReasonPublicHiveOnGHECluster is the class fix for a github.com hive
 	// parked on a GitHub-Enterprise-default cluster (vllm-d). The hive's meta
 	// pins it to public github.com (github_base_url:"public" / "https://github.com")
@@ -454,7 +462,7 @@ const (
 // for the operator to make it stick. The cluster key is a FLOOR for hives nobody
 // has spoken for, not a ceiling over hives somebody has.
 //
-// THE ONE EXCEPTION — A WRONG PER-HIVE KEY IS NOT A CHOICE
+// # THE ONE EXCEPTION — A WRONG PER-HIVE KEY IS NOT A CHOICE
 //
 // That precedence protects a DECISION. It must not protect a FAULT, and the two
 // are distinguishable without heuristics. A GitHub App JWT is signed by the
@@ -519,6 +527,26 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned b
 		}
 	}
 	fp := strings.TrimSpace(spokeFingerprint)
+	// A spoke still running the placeholder sentinel is broken regardless of
+	// which key it holds: app_id 999999999 names no App, so every JWT it signs
+	// is for a nonexistent App and auth fails no matter how correct its
+	// installation_id and key are. Decided BEFORE the per-hive branch because a
+	// sentinel hive typically holds a provisioned per-hive key and would
+	// otherwise be shielded by appKeyReasonPerHiveOverride and never repaired —
+	// and before the fingerprint-match test, since holding the right key does
+	// not make a nonexistent app_id work.
+	//
+	// This is the ONLY app_id the reconcile treats as unconditionally wrong. A
+	// spoke on any other non-matching app_id is still respected as a deliberate
+	// pin (appKeyReasonDifferentApp).
+	if spokeAppID == config.PlaceholderAppID {
+		return appKeySyncDecision{
+			Push:            true,
+			Reason:          appKeyReasonPlaceholderAppID,
+			FromFingerprint: fp,
+			ToFingerprint:   cluster.Fingerprint,
+		}
+	}
 	if hasPerHiveKey {
 		// Idempotence first: if the per-hive key already IS the cluster key
 		// there is nothing to decide and nothing to send. Checking this ahead of

--- a/v2/pkg/hub/journey.go
+++ b/v2/pkg/hub/journey.go
@@ -371,9 +371,13 @@ func appStateIsOperatorSide(state string) bool {
 //   - "key-missing" — no App private key reached this spoke at all.
 //   - "key-invalid" — a key is present but GitHub rejects the JWT it signs,
 //     i.e. it belongs to a different App than the hive claims to be.
+//   - "no-app-assigned" — the hive still carries the placeholder app_id and was
+//     never assigned a real App. The owner cannot fix this at all, so the
+//     journey must never nudge (or threaten de-provisioning) over it.
 var operatorSideAppStates = map[string]bool{
-	appStateKeyMissingToken: true,
-	appStateKeyInvalidToken: true,
+	appStateKeyMissingToken:    true,
+	appStateKeyInvalidToken:    true,
+	appStateNoAppAssignedToken: true,
 }
 
 const (
@@ -381,6 +385,8 @@ const (
 	// github.AppStateKeyMissing.String() and github.AppStateKeyInvalid.String().
 	appStateKeyMissingToken = "key-missing"
 	appStateKeyInvalidToken = "key-invalid"
+	// appStateNoAppAssignedToken mirrors github.AppStateNoAppAssigned.String().
+	appStateNoAppAssignedToken = "no-app-assigned"
 )
 
 // methodModelAssigned reports whether any agent on this hive has a method

--- a/v2/pkg/hub/journey_operator_block_test.go
+++ b/v2/pkg/hub/journey_operator_block_test.go
@@ -128,10 +128,15 @@ func TestNextNudge_OperatorBlockedDoesNotSuppressOtherStages(t *testing.T) {
 // pkg/hub deliberately does not import pkg/github, so these literals must stay
 // in sync with github.AppAuthState.String() by test, not by compiler.
 func TestOperatorSideAppStateTokensMatchSpoke(t *testing.T) {
-	// These are exactly the tokens github.AppStateKeyMissing.String() and
-	// github.AppStateKeyInvalid.String() produce; pkg/github's
+	// These are exactly the tokens github.AppStateKeyMissing.String(),
+	// github.AppStateKeyInvalid.String() and
+	// github.AppStateNoAppAssigned.String() produce; pkg/github's
 	// TestAppAuthState_WireRoundTrip locks the other side.
-	want := map[string]bool{"key-missing": true, "key-invalid": true}
+	//
+	// "no-app-assigned" is operator-side: a hive still on the placeholder
+	// app_id cannot be fixed by its owner at all, so the journey must never
+	// nudge — let alone threaten de-provisioning — over it.
+	want := map[string]bool{"key-missing": true, "key-invalid": true, "no-app-assigned": true}
 	if len(operatorSideAppStates) != len(want) {
 		t.Fatalf("operatorSideAppStates = %v, want exactly %v", operatorSideAppStates, want)
 	}

--- a/v2/pkg/hub/misc_coverage_test.go
+++ b/v2/pkg/hub/misc_coverage_test.go
@@ -225,8 +225,11 @@ func TestHandleClusterHealth(t *testing.T) {
 }
 
 // TestAdoptSpokeProjectConfig verifies the hub's adopt path:
-//   - ACMM level is operator-owned from the start and always adopted (the Joe
-//     Runde / spyre revert bug);
+//   - ACMM level follows the SAME ClaimDelivered handshake as org/repos: before
+//     delivery the assigned level is authoritative and a stale spoke report is
+//     ignored (an approved L3 request was silently downgraded to the level the
+//     placeholder was minted at); after delivery a dashboard level change is
+//     adopted and never reverted (the Joe Runde / spyre revert bug);
 //   - org/repos/primary follow the ClaimDelivered handshake: before the spoke
 //     first reports the claimed project, hub-pushed values are authoritative and
 //     spoke reports do NOT adopt (a stale placeholder must not win); the first
@@ -240,20 +243,30 @@ func TestAdoptSpokeProjectConfig(t *testing.T) {
 
 	s := &HubServer{logger: slog.Default()}
 
-	// Freshly-claimed hive (ClaimDelivered=false). ACMM is adopted immediately,
-	// but org/repos edits reported before delivery are IGNORED (could be a stale
-	// placeholder still reporting old values). A report that MATCHES the claim
-	// flips ClaimDelivered.
-	saveSaaSHive(&SaaSHive{ID: "claimed", Status: "running", Org: "o", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 2})
+	// Freshly-claimed hive (ClaimDelivered=false), assigned L3. Nothing reported
+	// before delivery is adopted — including the level. A report that matches the
+	// claim IN FULL (org/repos AND level) flips ClaimDelivered.
+	saveSaaSHive(&SaaSHive{ID: "claimed", Status: "running", Org: "o", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 3})
 
-	// Pre-delivery: spoke reports a DIFFERENT org/repos (stale) but a new level.
-	// -> adopt the level (3) only; org/repos stay as the claim; not yet delivered.
-	s.adoptSpokeProjectConfig("claimed", "stale", []string{"old"}, "old", 3)
+	// Pre-delivery: the spoke is still running its placeholder project at the
+	// level it was MINTED at (2), not the assigned 3. This is the production
+	// bug: adopting that report rewrote meta from the requested L3 down to L2,
+	// and since the hub then had nothing higher to push, the hive stayed L2
+	// forever. The assigned level must survive.
+	s.adoptSpokeProjectConfig("claimed", "stale", []string{"old"}, "old", 2)
 	if h := loadSaaSHive("claimed"); h == nil || h.ACMMLevel != 3 || h.Org != "o" || len(h.Repos) != 1 || h.ClaimDelivered {
-		t.Errorf("pre-delivery stale report: meta = %+v, want acmm=3 org=o repos=[r] ClaimDelivered=false", h)
+		t.Errorf("pre-delivery stale report: meta = %+v, want acmm=3 (assigned level held) org=o repos=[r] ClaimDelivered=false", h)
 	}
 
-	// Spoke now reports the actual claimed project -> flips ClaimDelivered.
+	// A report matching org/repos but still carrying the OLD level is not a
+	// complete delivery: the claim includes the level, so the flag must stay
+	// down and the hub must keep pushing until the level lands too.
+	s.adoptSpokeProjectConfig("claimed", "o", []string{"r"}, "r", 2)
+	if h := loadSaaSHive("claimed"); h == nil || h.ClaimDelivered || h.ACMMLevel != 3 {
+		t.Errorf("partial delivery (level not yet applied) must not flip ClaimDelivered: %+v", h)
+	}
+
+	// Spoke now reports the claim IN FULL, level included -> flips ClaimDelivered.
 	s.adoptSpokeProjectConfig("claimed", "o", []string{"r"}, "r", 3)
 	if h := loadSaaSHive("claimed"); h == nil || !h.ClaimDelivered {
 		t.Errorf("matching report should mark ClaimDelivered: %+v", h)
@@ -280,4 +293,42 @@ func TestAdoptSpokeProjectConfig(t *testing.T) {
 
 	// No record -> no panic, no-op.
 	s.adoptSpokeProjectConfig("missing", "o", []string{"r"}, "r", 4)
+}
+
+// TestProjectConfigForHiveID_PushesAssignedACMMUntilDelivered locks the push
+// half of the assigned-ACMM fix.
+//
+// #2061 removed the ACMM push entirely to stop a dashboard level change being
+// reverted every beat. That fixed the revert but meant a freshly-assigned
+// placeholder was never TOLD the level its owner requested: it kept running the
+// level it was minted at and reported it back. Bounding the push by
+// ClaimDelivered delivers the requested level exactly once, then stops forever.
+func TestProjectConfigForHiveID_PushesAssignedACMMUntilDelivered(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	// Assigned at L3; the spoke still reports the minted L2 with matching
+	// org/repos. Before the fix every non-ACMM field matched, so the reconcile
+	// returned "nothing left to push" and the level never travelled.
+	saveSaaSHive(&SaaSHive{
+		ID: "h", Status: "running", Org: "o", Repos: []string{"r"},
+		PrimaryRepo: "r", ACMMLevel: 3, ClaimDelivered: false,
+	})
+	got := projectConfigForHiveID("h", "o", []string{"r"}, "r", 2, "", "")
+	if got == nil {
+		t.Fatal("no push for an undelivered claim whose level has not landed; the hive stays at the wrong level forever")
+	}
+	if got.ACMMLevel != 3 {
+		t.Errorf("pushed ACMMLevel = %d, want the assigned 3", got.ACMMLevel)
+	}
+
+	// Once delivered, ACMM is the spoke's to own: a dashboard change to L5 must
+	// NOT be pushed back down (the spyre revert #2061 fixed).
+	saveSaaSHive(&SaaSHive{
+		ID: "d", Status: "running", Org: "o", Repos: []string{"r"},
+		PrimaryRepo: "r", ACMMLevel: 3, ClaimDelivered: true,
+	})
+	if got := projectConfigForHiveID("d", "o", []string{"r"}, "r", 5, "", ""); got != nil {
+		t.Errorf("delivered claim must never push ACMM back to the spoke, got %+v", got)
+	}
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -5382,8 +5382,22 @@ func (s *HubServer) adoptSpokeProjectConfig(hiveID, org string, repos []string, 
 	changed := false
 	prevLevel := h.ACMMLevel
 
-	// ACMM is operator-owned from the start — always adopt a non-zero level.
-	if level > 0 && level != h.ACMMLevel {
+	// ACMM follows the SAME ClaimDelivered handshake as org/repos below.
+	//
+	// #2061 made ACMM "operator-owned from the start — always adopt", which
+	// fixed the spyre revert (a dashboard level change bouncing back every
+	// beat) but left a gap on the ASSIGN path: a freshly-claimed placeholder
+	// has not yet been told its level, so it keeps reporting the level it was
+	// MINTED at (defaultAssignACMMLevel). Adopting that pre-delivery report
+	// overwrote the level the requester actually asked for — an approved L3
+	// request silently became L2 in meta.json, and the spoke stayed L2 forever
+	// because the hub then had no higher level left to push.
+	//
+	// Gating on ClaimDelivered keeps BOTH behaviours: before delivery the claim
+	// (including its level) is authoritative and a stale spoke report is
+	// ignored; after delivery the spoke's dashboard owns the level and operator
+	// edits are adopted exactly as #2061 intended.
+	if level > 0 && level != h.ACMMLevel && h.ClaimDelivered {
 		h.ACMMLevel = level
 		changed = true
 	}
@@ -5396,8 +5410,15 @@ func (s *HubServer) adoptSpokeProjectConfig(hiveID, org string, repos []string, 
 	orgMatches := org != "" && strings.EqualFold(org, h.Org)
 	reposMatch := len(repos) > 0 && sameStringSliceFold(repos, h.Repos)
 	primaryMatches := primary == "" || strings.EqualFold(primary, h.PrimaryRepo)
+	// The ACMM level is part of the claim payload, so delivery is not complete
+	// until the spoke reports THAT back too. Flipping the flag on org/repos
+	// alone declared the claim delivered while the spoke was still running the
+	// level it was minted at — which both stopped the push and handed level
+	// ownership to the spoke, permanently pinning the hive to the wrong level.
+	// A level-0 report means "too old / mid-boot to say", not a mismatch.
+	acmmMatches := level == 0 || level == h.ACMMLevel
 	if !h.ClaimDelivered {
-		if orgMatches && reposMatch && primaryMatches {
+		if orgMatches && reposMatch && primaryMatches && acmmMatches {
 			h.ClaimDelivered = true
 			changed = true
 		}
@@ -5514,15 +5535,23 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 	//     spoke first reports the assigned project). After delivery the spoke's
 	//     dashboard owns them and the caller adopts operator edits instead.
 	//   - vanity URL: pushed until the spoke first reports it back.
-	//   - ACMM level: NEVER pushed — operator-owned from the start, always
-	//     adopted by the caller. Including it here (as the old code did) made any
-	//     dashboard level change get reverted every beat (the spyre bug).
-	// curACMM is unused for the push decision (kept for signature/back-compat).
-	_ = curACMM
+	//   - ACMM level: pushed ONLY until the claim is delivered, on exactly the
+	//     same handshake as org/repos. After delivery it is never pushed again —
+	//     the spoke's dashboard owns it and the caller adopts operator edits.
+	//
+	//     #2061 removed the ACMM push entirely because pushing it FOREVER
+	//     reverted every dashboard level change (the spyre bug). But dropping it
+	//     altogether meant a freshly-assigned placeholder was never told the
+	//     level its owner requested: it kept running the level it was minted at
+	//     (defaultAssignACMMLevel), reported that back, and the hub adopted the
+	//     stale report — so an approved L3 request ran, and displayed, as L2.
+	//     Bounding the push by ClaimDelivered delivers the requested level once
+	//     without ever reverting a later operator edit.
 	needClaimPush := !h.ClaimDelivered &&
 		!(strings.EqualFold(curOrg, h.Org) &&
 			sameStringSliceFold(curRepos, h.Repos) &&
-			strings.EqualFold(curPrimary, primary))
+			strings.EqualFold(curPrimary, primary) &&
+			curACMM == h.ACMMLevel)
 	needURLPush := h.VanityURL != "" && curURL != h.VanityURL
 	// A spoke reporting a repo that fails isValidRepoRef is wedged: the hub 400s
 	// its every heartbeat ("invalid repo name"), /api/livez then fails on the

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -424,21 +424,46 @@ func effectiveGitHubAPIURL(h *SaaSHive, cluster *ClusterConfig) string {
 // cannot mint installation tokens against a github.ibm.com repo.
 //
 // Rule:
-//   - GHE hive (effectiveGitHubBaseURL != "") → the cluster's GitHubAppID (the
-//     GHE App registered on that enterprise), when the cluster names one. This
-//     overrides a public app_id that a placeholder was seeded with — the exact
-//     bug where GHE hives carried app_id 3568013 and could never write.
-//   - Otherwise (public hive, or a GHE cluster with no GHE App configured) →
-//     the request's app_id verbatim, so public hives and explicit overrides are
-//     unchanged.
+//   - The hive is explicitly pinned to PUBLIC github.com on a cluster whose App
+//     is a GitHub Enterprise one → keep the request's app_id. The cluster's App
+//     belongs to the wrong host for this hive; forcing it would break exactly
+//     the case the public pin exists to protect.
+//   - Otherwise the cluster names a GitHubAppID → use it. This now covers a
+//     public-github.com CLUSTER as well as a GHE one: the App ID is a
+//     per-GitHub-HOST constant, not per-hive state, and this field is the one
+//     place the fleet records it.
+//   - Otherwise → the request's app_id verbatim, so explicit overrides and
+//     clusters with no hub-managed App identity are unchanged.
+//
+// The public-github.com case was previously excluded (the rule required
+// effectiveGitHubBaseURL != ""), which is why every hive on the public cluster
+// provisioned with the config.PlaceholderAppID sentinel and NOTHING ever
+// replaced it: there was no configured App ID to look up, and assignment does
+// not mint one. Such a hive builds a JWT for a nonexistent App, so App auth can
+// never succeed no matter which installation_id the owner enters.
+//
+// Widening the rule rather than adding a github.com-specific branch is what
+// generalizes: a third forge (gitlab/gitea) needs only its own cluster entry
+// with a github_app_id, not another special case here.
+//
+// This does NOT hardcode an App ID. A cluster that names none still falls
+// through to the request value exactly as before.
 //
 // Returns a string (the template field is a string); sanitize() is applied to
 // any request-sourced value exactly as before.
 func resolveProvisionAppID(reqAppID string, h *SaaSHive, cluster *ClusterConfig) string {
-	if cluster != nil && cluster.GitHubAppID != 0 && effectiveGitHubBaseURL(h, cluster) != "" {
-		return strconv.FormatInt(cluster.GitHubAppID, 10)
+	if cluster == nil || cluster.GitHubAppID == 0 {
+		return sanitize(reqAppID)
 	}
-	return sanitize(reqAppID)
+	// A hive pinned to public github.com on a cluster whose own App is a GHE
+	// App: the cluster App is registered on the wrong host for this hive, so the
+	// request's public app_id stands. Detected as "the hive resolves to no GHE
+	// base URL while the cluster has one" — the same public-pin semantics
+	// effectiveGitHubBaseURL already implements.
+	if cluster.GitHubBaseURL != "" && effectiveGitHubBaseURL(h, cluster) == "" {
+		return sanitize(reqAppID)
+	}
+	return strconv.FormatInt(cluster.GitHubAppID, 10)
 }
 
 // backfillGitHubHostFromCluster returns the GitHub host a hive should inherit


### PR DESCRIPTION
Two production bugs on the **placeholder-assignment** path, both reproduced against a live hive (`kubestellar/hive`, assigned to `hosted-available-oke-11-placeholder-r05x`).

## BUG 1 — the requested ACMM level was silently downgraded

An approved **L3** provision request landed as `acmm_level: 2` in meta.json, and the spoke ran and displayed **"ACMM L2 Instructed"**.

Assignment is **not** where the level was lost. `handleApproveProvision` copies `pr.ACMMLevel` onto the placeholder correctly (`v2/pkg/hub/saas.go:5117-5131`). It was lost **afterwards, on the heartbeat**:

- #2061 made ACMM *"operator-owned from the start — always adopt"* to stop a dashboard level change bouncing back every beat (the spyre bug), and removed the ACMM push from `projectConfigForHiveID` entirely.
- A freshly-assigned placeholder is therefore **never told its assigned level**. It keeps running the level it was minted at (`defaultAssignACMMLevel = 2`), reports that back, and the hub **adopts the stale report** — overwriting the requested L3 in meta. Meta now agrees with the spoke, so there is nothing left to push and the hive stays L2 **permanently**.

The gap is an **asymmetry**: org/repos are protected before delivery by the `ClaimDelivered` handshake; ACMM had no equivalent. Not a regression in #1891/#1892/#1897 (those are pack/agent-field reconciliation) — it is an adjacent gap opened by #2061's correct fix.

**Fix — put ACMM on the same handshake:**
- Pre-delivery the assigned level is authoritative: a spoke report is not adopted, and the level **is** pushed as part of the claim.
- `ClaimDelivered` now also requires the level to be reported back, so the claim is not declared delivered while the level is still outstanding.
- Post-delivery behaviour is exactly as #2061 intended: the spoke owns the level, operator edits are adopted, ACMM is never pushed again.

**Ceiling:** unchanged and not bypassable. `handleRequestProvision` already clamps a self-service request to `maxRequestACMMLevel` (L3) at the point of entry, so `pr.ACMMLevel` is pre-clamped before assignment ever reads it. Admin paths keep the full 0–6 range, as before.

## BUG 2 — the placeholder `app_id` sentinel was never replaced

Assigned placeholders ran `app_id: 999999999` (`config.PlaceholderAppID`) with a **real** `installation_id`, so the spoke signed a GitHub App JWT for an App that does not exist. Auth could never succeed **no matter what installation ID the owner entered**.

This is a **missing static configuration** problem, not per-hive state. The App ID is a **per-GitHub-host constant**; only `installation_id` is per-hive. `resolveProvisionAppID` consulted the cluster's `github_app_id` **only for GHE hives**, so github.ibm.com got its App (`5686`) while public github.com had **no configured App ID at all** — provisioning wrote the sentinel and nothing ever replaced it.

- `resolveProvisionAppID` now uses the cluster's configured `github_app_id` for **public-github.com clusters as well as GHE ones**, still honouring an explicit public pin on a GHE cluster. Widening the existing per-cluster field (rather than adding a github.com special case) is what **generalizes to gitlab/gitea**: a new forge needs only its own cluster entry.
- **No App ID is hardcoded.** A cluster naming none behaves exactly as before.
- `decideAppKeySync` now **repairs** a spoke still carrying the sentinel. It was previously shielded by the per-hive-key override and survived forever. The sentinel is never a deliberate pin; any *other* non-matching app_id is still protected as one.

### Required operator follow-up (config, not code)

This code cannot invent an App ID. The `hive-oke` cluster entry in `/data/saas/clusters.json` must gain the field the GHE cluster already has:

```json
{ "id": "hive-oke", "github_app_id": 3568013 }
```

Once set, the reconcile repairs the affected spokes over the heartbeat. **Not done here — read-only on live systems.**

## Making the failure legible

A sentinel hive reported `AppStateNotInstalled` → **"GitHub App Not Installed"**, telling the owner to install an App that *was already installed* and to fix an installation ID that *was already correct*. (The reporting owner's `installation_id: 128685788` is the very same installation the working `kubestellar/console` hive uses.) That misdiagnosis is exactly why the **Set-ID box appeared to do nothing**, and it cost real debugging time.

Adds `github.AppStateNoAppAssigned` (`"no-app-assigned"`), classified **operator-actionable**, saying plainly: *"This hive was never assigned a GitHub App ID."* The spoke dashboard renders it through the existing operator-side branch, which shows **no install link and no config instruction** — so the user is no longer misdirected to the installation-ID box. The journey nudges treat it as operator-side, so a hive is never chased (or threatened with de-provisioning) over a fault only the hub can fix.

## Blast radius — verified across all running `hive-oke` spokes

| app_id | count | meaning |
|---|---|---|
| `3568013` | 10 | working github.com hives |
| `999999999` | **6** | **sentinel — broken** |
| `4240368` | 1 | `daviddiaz0317-visual-hive` — a *different real* App with its own installation (`145050760`). Legitimate; **left alone** by this fix. |

All 6 sentinel hives are `available-oke-*-placeholder-*`, confirming the defect is confined to the placeholder path. Five are unassigned; only `oke-11` is assigned and in use.

## Tests

- Assigned ACMM held pre-delivery, pushed until it lands, never pushed after. **Verified failing without the fix** (`acmm_was=3 acmm_now=2` — the exact production bug).
- Sentinel repaired even against a per-hive key *and* a matching fingerprint; a real non-matching app_id stays protected.
- Public cluster hands its configured App ID to its hives.
- Placeholder boot now asserts **operator**-actionable, not "not installed" (this assertion was previously inverted).

`go build ./...` and `pkg/hub` / `pkg/github` / `pkg/config` / `cmd/hive` pass. The `pkg/dashboard` `TestCovV1_*` failures are **pre-existing on clean `origin/v2`** and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
