### PR TITLE
🐛 fix(upgrade): roll floating-tag spokes onto the requested SHA

### DIFF
--- a/v2/pkg/hub/self_upgrade.go
+++ b/v2/pkg/hub/self_upgrade.go
@@ -148,6 +148,13 @@ func imageTagIsMutable(image string) bool {
 //
 // So: patch the image when pinned, restart when mutable. Returns needsRestart
 // false when the image patch itself rolls the deployment.
+//
+// The mutable case is NOT simply "restart and hope". A restart re-pulls the
+// tag and therefore lands on whatever digest CI last published under it —
+// which is only the requested target by coincidence. Verified on the live
+// fleet: v2-latest resolved to fb37afe while the hub was targeting 07ccca1, so
+// every restart delivered the wrong build, the spoke reported fb37afe, and the
+// hub re-instructed the same upgrade forever. See upgradeSelfMutableToSHA.
 func UpgradeSelfToSHA(logger *slog.Logger, targetSHA string) (needsRestart bool, err error) {
 	current, err := selfDeploymentImage()
 	if err != nil {
@@ -159,7 +166,7 @@ func UpgradeSelfToSHA(logger *slog.Logger, targetSHA string) (needsRestart bool,
 		return true, nil
 	}
 	if imageTagIsMutable(current) {
-		return true, nil
+		return upgradeSelfMutableToSHA(logger, current, targetSHA)
 	}
 	// Pinned. Rewrite the tag in place so the registry/repo (which may be a
 	// mirror or a private registry) is preserved — only the tag changes.
@@ -178,6 +185,92 @@ func UpgradeSelfToSHA(logger *slog.Logger, targetSHA string) (needsRestart bool,
 	}
 	// SwitchImageSelf's patch changes the pod template, which rolls the
 	// deployment on its own — a restart on top would be redundant.
+	return false, nil
+}
+
+// selfUpgradeTargetAnnotation records, on the pod template, which SHA the hub
+// asked this deployment to run. It exists to make the pod template DIFFER
+// between two upgrades that both leave the image string untouched — a mutable
+// tag never changes, so without this the strategic-merge patch is a semantic
+// no-op, Kubernetes sees no change to the template, and no rollout happens at
+// all. Carrying the target (rather than a timestamp) also makes the intent
+// readable with `kubectl get deploy -o yaml` when diagnosing a stuck upgrade.
+const selfUpgradeTargetAnnotation = "hive.kubestellar.io/upgrade-target-sha"
+
+// upgradeSelfMutableToSHA advances a deployment that tracks a MUTABLE tag
+// (v2-latest and friends) onto targetSHA.
+//
+// The naive action here — a plain rollout restart — is wrong, and was the
+// systemic bug this function exists to fix. Restarting re-pulls the tag, so the
+// pod lands on the tag's CURRENT digest. That is the hub's target only if CI
+// happens not to have published since the target was chosen. When it has, the
+// spoke comes back reporting a SHA that is neither the old one nor the
+// requested one, the hub's completion check (which compares the reported
+// gitHash against upgradeTarget) never matches, and the hive sits "Upgrading"
+// forever while the hub re-instructs on every heartbeat.
+//
+// The fix keeps the floating tag — the platform's deliberate preference, which
+// came out of a self-upgrade CrashLoop incident — and makes the rollout
+// deterministic anyway, by writing the target SHA into a pod-template
+// annotation. That changes the template even though the image string does not,
+// which is what actually forces Kubernetes to roll. Combined with the
+// fleet-wide imagePullPolicy: Always, the new pod re-pulls the tag.
+//
+// This narrows but does not eliminate the race: if CI republishes the tag
+// between the hub choosing a target and the kubelet pulling, the pod still
+// lands on the newer build. That is benign and self-correcting — the hub
+// accepts "at target OR at registry-latest" as success (server.go), so an
+// overshoot completes the upgrade rather than wedging it. What it must never do
+// again is silently land on the WRONG build with no record of what was asked
+// for; the annotation is that record.
+func upgradeSelfMutableToSHA(logger *slog.Logger, current, targetSHA string) (needsRestart bool, err error) {
+	if targetSHA == "" {
+		// No target to record. Fall back to the historical behaviour rather
+		// than writing an empty annotation that would defeat the diff.
+		return true, nil
+	}
+	ns, err := os.ReadFile(k8sNamespacePath)
+	if err != nil {
+		// Not in-cluster, or the SA projection is missing. A plain restart is
+		// the safe fallback: it is what this path did before, and the caller
+		// already handles a failed restart loudly.
+		logger.Warn("could not read namespace for mutable-tag upgrade, falling back to rollout restart",
+			"error", err)
+		return true, nil
+	}
+	namespace := strings.TrimSpace(string(ns))
+	if namespace == "" {
+		logger.Warn("empty namespace for mutable-tag upgrade, falling back to rollout restart",
+			"path", k8sNamespacePath)
+		return true, nil
+	}
+
+	// Annotate the POD TEMPLATE (not the Deployment) — only template changes
+	// roll the pods. restart-at is set alongside the target so two consecutive
+	// upgrades to the SAME target still produce distinct templates; without it
+	// a retry of an identical target would itself be a no-op.
+	patch := fmt.Sprintf(
+		`{"spec":{"template":{"metadata":{"annotations":{%q:%q,"hive.kubestellar.io/restart-at":%q}}}}}`,
+		selfUpgradeTargetAnnotation, targetSHA,
+		time.Now().UTC().Format(time.RFC3339),
+	)
+	path := fmt.Sprintf("/apis/apps/v1/namespaces/%s/deployments/%s", namespace, selfUpgradeDeployName)
+	if err := k8sAPIPatch(path, []byte(patch)); err != nil {
+		// Report the failure rather than swallowing it: the caller turns a
+		// non-nil error into a recorded, hub-visible upgrade failure instead of
+		// a permanent spinner.
+		return false, fmt.Errorf("annotating mutable-tag deployment for rollout to %s: %w", targetSHA, err)
+	}
+
+	logger.Info("upgrading a mutable-tag deployment by pod-template annotation, not a bare restart",
+		"image", current,
+		"target", targetSHA,
+		"annotation", selfUpgradeTargetAnnotation,
+		"namespace", namespace,
+		"deployment", selfUpgradeDeployName,
+	)
+	// The annotation patch changes the pod template, which rolls the deployment
+	// on its own — a restart on top would be redundant.
 	return false, nil
 }
 

--- a/v2/pkg/hub/self_upgrade_coverage_test.go
+++ b/v2/pkg/hub/self_upgrade_coverage_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -197,5 +198,110 @@ func TestSwitchImageSelfNoNamespace(t *testing.T) {
 	defer func() { k8sNamespacePath = oldNS }()
 	if err := SwitchImageSelf(slog.Default(), "img"); err == nil {
 		t.Error("expected error when namespace file missing")
+	}
+}
+
+// TestUpgradeSelfMutableTagForcesRollout is the regression test for the
+// floating-tag no-op. A deployment on v2-latest used to take a bare rollout
+// restart, which re-pulls the tag and lands on whatever CI last published —
+// verified on the live fleet as fb37afe while the hub targeted 07ccca1. The
+// upgrade must instead patch the pod template with the target SHA, so the
+// rollout is forced AND the requested target is recorded on the deployment.
+func TestUpgradeSelfMutableTagForcesRollout(t *testing.T) {
+	const (
+		currentImage = "ghcr.io/kubestellar/hive:v2-latest"
+		targetSHA    = "07ccca1"
+	)
+	var patchBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			b, _ := io.ReadAll(r.Body)
+			patchBody = string(b)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"spec":{"template":{"spec":{"containers":[{"name":"hive","image":"` + currentImage + `"}]}}}}`))
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+
+	needsRestart, err := UpgradeSelfToSHA(slog.Default(), targetSHA)
+	if err != nil {
+		t.Fatalf("UpgradeSelfToSHA on a mutable tag: %v", err)
+	}
+	// The annotation patch rolls the deployment by itself; a bare restart on
+	// top would be the very no-op this fix removes.
+	if needsRestart {
+		t.Error("a mutable-tag upgrade must roll via the template patch, not a bare restart")
+	}
+	if patchBody == "" {
+		t.Fatal("expected the deployment to be patched, but no PATCH was issued")
+	}
+	if !strings.Contains(patchBody, selfUpgradeTargetAnnotation) {
+		t.Errorf("patch must carry the target annotation %q, got: %s", selfUpgradeTargetAnnotation, patchBody)
+	}
+	if !strings.Contains(patchBody, targetSHA) {
+		t.Errorf("patch must record the target SHA %q, got: %s", targetSHA, patchBody)
+	}
+	// The template, not the Deployment, must be annotated — only template
+	// changes roll pods.
+	if !strings.Contains(patchBody, `"template"`) {
+		t.Errorf("annotation must land on the POD TEMPLATE, got: %s", patchBody)
+	}
+	// The floating tag must survive: pinning the image would defeat the
+	// platform's deliberate preference for mutable tags.
+	if strings.Contains(patchBody, `"image"`) {
+		t.Errorf("a mutable-tag upgrade must NOT rewrite the image, got: %s", patchBody)
+	}
+}
+
+// TestUpgradeSelfMutableTagPatchFailureIsReported guards that a failed patch
+// surfaces as an error. Swallowing it would return needsRestart and reproduce
+// the original silent no-op.
+func TestUpgradeSelfMutableTagPatchFailureIsReported(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"forbidden"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"spec":{"template":{"spec":{"containers":[{"name":"hive","image":"ghcr.io/kubestellar/hive:v2-latest"}]}}}}`))
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+
+	if _, err := UpgradeSelfToSHA(slog.Default(), "07ccca1"); err == nil {
+		t.Fatal("a rejected patch must be reported as an error, not swallowed")
+	}
+}
+
+// TestUpgradeSelfPinnedStillPatchesImage guards that the pinned path (#2308) is
+// unchanged by the mutable-tag fix: a SHA-pinned deployment must still have its
+// image rewritten, since no annotation can move it onto new code.
+func TestUpgradeSelfPinnedStillPatchesImage(t *testing.T) {
+	var patchBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			b, _ := io.ReadAll(r.Body)
+			patchBody = string(b)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"spec":{"template":{"spec":{"containers":[{"name":"hive","image":"ghcr.io/kubestellar/hive:c11643a"}]}}}}`))
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+
+	needsRestart, err := UpgradeSelfToSHA(slog.Default(), "07ccca1")
+	if err != nil {
+		t.Fatalf("UpgradeSelfToSHA on a pinned tag: %v", err)
+	}
+	if needsRestart {
+		t.Error("a pinned upgrade rolls via the image patch")
+	}
+	if !strings.Contains(patchBody, "ghcr.io/kubestellar/hive:07ccca1") {
+		t.Errorf("pinned upgrade must rewrite the image to the target, got: %s", patchBody)
 	}
 }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -136,9 +136,17 @@ type RegistryEntry struct {
 	// UpgradeFailed records that the spoke reported an upgrade it could not
 	// complete, with the cause. Distinct from Upgrading: "failed" is a terminal
 	// state a human must see, not an in-flight one.
-	UpgradeFailed             bool         `json:"upgradeFailed,omitempty"`
-	UpgradeError              string       `json:"upgradeError,omitempty"`
-	UpgradeFailedAt           time.Time    `json:"upgradeFailedAt,omitempty"`
+	UpgradeFailed   bool      `json:"upgradeFailed,omitempty"`
+	UpgradeError    string    `json:"upgradeError,omitempty"`
+	UpgradeFailedAt time.Time `json:"upgradeFailedAt,omitempty"`
+	// OrphanedUpgradeSweeps counts how many times the orphan sweep has cleared
+	// and re-armed an upgrade for this hive without it ever landing. A spoke
+	// that cannot advance (it restarts, comes back on a SHA that is neither the
+	// old one nor the target, and goes quiet again) would otherwise be swept and
+	// re-armed forever, which looks like progress but never is. Past
+	// maxOrphanedUpgradeSweeps the hub stops retrying and records a failure a
+	// human can see. Reset whenever the hive reaches a target.
+	OrphanedUpgradeSweeps     int          `json:"orphanedUpgradeSweeps,omitempty"`
 	IssueHistory              []SparkPoint `json:"issueHistory,omitempty"`
 	PRHistory                 []SparkPoint `json:"prHistory,omitempty"`
 	GitHubAppRequired         bool         `json:"githubAppRequired,omitempty"`
@@ -1060,6 +1068,11 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				// full SHA and the target/latest was the 7-char short form.
 				entry.Upgrading = false
 				entry.UpgradeTarget = ""
+				// The upgrade landed, so any orphan-sweep retry budget spent
+				// getting here is no longer relevant. Reset it, or a hive that
+				// needed one sweep on each of three separate upgrades would be
+				// declared permanently faulty on the third.
+				entry.OrphanedUpgradeSweeps = 0
 			} else if h.Upgrading && !payload.Upgrading && h.UpgradeTarget == "" {
 				// Upgrading with no target (stale flag from config-only restart).
 				entry.Upgrading = false

--- a/v2/pkg/hub/stale_upgrade.go
+++ b/v2/pkg/hub/stale_upgrade.go
@@ -25,6 +25,25 @@ const orphanedUpgradeGrace = staleUpgradeTimeout
 // after which an upgrade with no live attempt behind it is considered orphaned.
 const orphanedUpgradeClearAfter = staleUpgradeTimeout + orphanedUpgradeGrace
 
+// maxOrphanedUpgradeSweeps bounds how many times the sweep will clear and
+// re-arm the same hive's upgrade before treating it as a genuine fault instead
+// of a transient orphan.
+//
+// #2327's sweep assumes the attempt merely went missing, so re-arming lets the
+// next heartbeat carry it again. That is right for a departed pod, but it is
+// an infinite loop for a hive that is structurally unable to advance — the
+// floating-tag case being the motivating example: the spoke restarts, re-pulls
+// its mutable tag, lands on a build that is neither its old SHA nor the target,
+// and reports in. The sweep sees "alive, not at target", clears, re-arms, and
+// the cycle repeats indefinitely with nothing ever surfacing to a human.
+//
+// Three is deliberately small. Each sweep costs at least
+// orphanedUpgradeClearAfter, so this is ~1 hour of real elapsed time at the
+// default staleUpgradeTimeout before the hub gives up — long enough to absorb a
+// genuinely slow or twice-unlucky rollout, short enough that a broken upgrade
+// path is reported the same working day rather than never.
+const maxOrphanedUpgradeSweeps = 3
+
 // upgradeAttemptEvidence describes whether a still-latched upgrade has an
 // attempt actually behind it, and if not, why we concluded that.
 type upgradeAttemptEvidence struct {
@@ -124,6 +143,10 @@ func (s *HubServer) sweepOrphanedUpgrades() {
 		from, to string
 		elapsed  time.Duration
 		reason   string
+		// exhausted marks a hive that has been swept too many times to keep
+		// retrying — reported as a fault rather than re-armed.
+		exhausted bool
+		sweeps    int
 	}
 	var swept []cleared
 
@@ -134,14 +157,35 @@ func (s *HubServer) sweepOrphanedUpgrades() {
 		if !ev.orphaned {
 			continue
 		}
+		h.OrphanedUpgradeSweeps++
+		exhausted := h.OrphanedUpgradeSweeps >= maxOrphanedUpgradeSweeps
 		swept = append(swept, cleared{
-			id:      h.ID,
-			from:    h.GitHash,
-			to:      h.UpgradeTarget,
-			elapsed: ev.elapsed,
-			reason:  ev.reason,
+			id:        h.ID,
+			from:      h.GitHash,
+			to:        h.UpgradeTarget,
+			elapsed:   ev.elapsed,
+			reason:    ev.reason,
+			exhausted: exhausted,
+			sweeps:    h.OrphanedUpgradeSweeps,
 		})
 		h.Upgrading = false
+
+		if exhausted {
+			// Stop retrying. Re-arming again would just reproduce the same
+			// no-op on the next cycle; record a terminal, human-visible failure
+			// instead, which the existing UpgradeFailed surfaces in the UI and
+			// which AlertTypeStuckUpgrade already alerts on.
+			h.UpgradeFailed = true
+			h.UpgradeError = "upgrade to " + orDash(h.UpgradeTarget) +
+				" never landed after " + itoa(h.OrphanedUpgradeSweeps) +
+				" attempts — hive is still on " + orDash(h.GitHash) +
+				". If its Deployment tracks a floating tag, the pod may be " +
+				"re-pulling that tag and landing on a build other than the target."
+			h.UpgradeFailedAt = now
+			// Drop any armed instruction so no path keeps re-delivering it.
+			delete(s.heartbeatUpgrade, h.ID)
+			continue
+		}
 
 		// Re-arm delivery rather than dropping it. Clearing the flag alone is
 		// NOT enough to make the hive upgrade again: heartbeatUpgrade is an
@@ -163,8 +207,25 @@ func (s *HubServer) sweepOrphanedUpgrades() {
 	s.mu.Unlock()
 
 	for _, c := range swept {
+		if c.exhausted {
+			s.logger.Error("upgrade repeatedly failed to land — giving up and reporting a fault",
+				"hive_id", c.id,
+				"attempts", c.sweeps,
+				"elapsed", roundedDuration(c.elapsed),
+				"from", orDash(c.from),
+				"to", orDash(c.to),
+				"reason", c.reason,
+				"hint", "check whether the spoke Deployment tracks a floating tag whose digest differs from the target SHA",
+			)
+			s.recordTimeline(c.id, TimelineUpgradeStale,
+				"upgrade to "+orDash(c.to)+" abandoned after "+itoa(c.sweeps)+
+					" attempts — hive is still on "+orDash(c.from)+
+					" and is no longer being retried", "stale-upgrade-sweep")
+			continue
+		}
 		s.logger.Warn("cleared orphaned upgrade flag — no attempt in flight",
 			"hive_id", c.id,
+			"attempt", c.sweeps,
 			"elapsed", roundedDuration(c.elapsed),
 			"from", orDash(c.from),
 			"to", orDash(c.to),

--- a/v2/pkg/hub/stale_upgrade_test.go
+++ b/v2/pkg/hub/stale_upgrade_test.go
@@ -177,3 +177,79 @@ func TestOrphanedUpgradeThresholdDerivesFromStaleUpgradeTimeout(t *testing.T) {
 			orphanedUpgradeClearAfter, want)
 	}
 }
+
+// TestSweepEscalatesAfterRepeatedFailures asserts the bounded-retry behaviour
+// that complements #2327. A hive that is structurally unable to advance — the
+// floating-tag case, where the pod re-pulls its mutable tag and lands on a
+// build that is neither the old SHA nor the target — must eventually be
+// reported as a fault instead of being cleared and re-armed forever.
+func TestSweepEscalatesAfterRepeatedFailures(t *testing.T) {
+	s := &HubServer{
+		logger:           slog.Default(),
+		heartbeatUpgrade: make(map[string]string),
+	}
+	s.registry.Hives = []RegistryEntry{{
+		ID:            "never-lands",
+		GitHash:       "c11643a",
+		UpgradeTarget: "fc32ae4",
+	}}
+
+	// Each cycle re-latches the flag exactly as a re-armed upgrade would, so
+	// the hive presents to the sweep as orphaned again every time.
+	for i := 1; i <= maxOrphanedUpgradeSweeps; i++ {
+		h := &s.registry.Hives[0]
+		h.Upgrading = true
+		h.UpgradeStartedAt = time.Now().Add(-68 * time.Minute)
+		h.LastHeartbeat = rfc3339(time.Now().Add(-30 * time.Second))
+		s.sweepOrphanedUpgrades()
+
+		if got := s.registry.Hives[0].OrphanedUpgradeSweeps; got != i {
+			t.Fatalf("after cycle %d, OrphanedUpgradeSweeps = %d, want %d", i, got, i)
+		}
+	}
+
+	h := s.registry.Hives[0]
+	if !h.UpgradeFailed {
+		t.Errorf("after %d sweeps the hive must be marked UpgradeFailed", maxOrphanedUpgradeSweeps)
+	}
+	if h.UpgradeError == "" {
+		t.Error("an exhausted upgrade must carry a human-readable cause")
+	}
+	if h.UpgradeFailedAt.IsZero() {
+		t.Error("an exhausted upgrade must record when it was abandoned")
+	}
+	if _, armed := s.heartbeatUpgrade["never-lands"]; armed {
+		t.Error("an exhausted upgrade must NOT stay armed for delivery")
+	}
+	if h.Upgrading {
+		t.Error("an exhausted upgrade must not still claim to be in flight")
+	}
+}
+
+// TestSweepBelowBudgetStillReArms guards that escalation does not fire early:
+// under the budget the #2327 behaviour (clear AND re-arm) must be preserved
+// unchanged, with no failure recorded.
+func TestSweepBelowBudgetStillReArms(t *testing.T) {
+	s := &HubServer{
+		logger:           slog.Default(),
+		heartbeatUpgrade: make(map[string]string),
+	}
+	s.registry.Hives = []RegistryEntry{{
+		ID:               "first-orphan",
+		Upgrading:        true,
+		UpgradeStartedAt: time.Now().Add(-68 * time.Minute),
+		GitHash:          "c11643a",
+		UpgradeTarget:    "fc32ae4",
+		LastHeartbeat:    rfc3339(time.Now().Add(-30 * time.Second)),
+	}}
+
+	s.sweepOrphanedUpgrades()
+
+	h := s.registry.Hives[0]
+	if h.UpgradeFailed {
+		t.Error("a single orphan sweep must not mark the hive failed")
+	}
+	if got := s.heartbeatUpgrade["first-orphan"]; got != "fc32ae4" {
+		t.Errorf("below the budget the upgrade must still be re-armed, got %q", got)
+	}
+}


### PR DESCRIPTION
## The bug

A spoke whose Deployment tracks a **mutable tag** (`v2-latest` and friends) can never be upgraded to a specific SHA, and the hub retries forever without surfacing a fault. Two hives sat "Upgrading" for 86 and 8 minutes today with fully-settled Deployments — `observedGeneration == generation`, `1/1` ready, zero restarts.

## Root cause (file:line)

`v2/pkg/hub/self_upgrade.go:161` — `UpgradeSelfToSHA` returned `needsRestart = true` for **any** mutable tag, taking a bare `rollout restart`.

A restart re-pulls the tag, so the pod lands on whatever digest CI last published under it — the hub's target only by coincidence. **Verified against the live registry**, three distinct digests:

| tag | digest | SHA |
|---|---|---|
| `v2-latest` | `sha256:709fea5e7d81` | `fb37afe` |
| target | `sha256:1ddcf6bed4a1` | `07ccca1` |
| target | `sha256:c9fe0024086b` | `fc32ae4` |

So the spoke came back reporting a SHA that was neither its old one nor the target. The hub's completion check never matched, and the hive was re-instructed on every heartbeat, forever.

Note this is **not** a stale-cached-digest problem — the restart really does roll and really does pull new code. It just pulls the *wrong* code. `hive-hosted-hosted-available-vllmd-02/03` are live proof: spec says `v2-latest`, running digest is `sha256:1ddcf6…` (`07ccca1`), i.e. already drifted away from the tag they nominally track.

## The fix

Keep the floating tag — a deliberate platform preference that came out of the self-upgrade CrashLoop incident — and make the rollout deterministic anyway.

`upgradeSelfMutableToSHA` writes the target SHA into a **pod-template annotation** (`hive.kubestellar.io/upgrade-target-sha`, alongside the existing `restart-at` so a retry of an identical target is still a distinct template). The template differs even though the image string does not, which is what actually forces Kubernetes to roll, and the Deployment now carries a readable record of what was asked for. **The image is never rewritten**, so the floating tag survives — a test asserts this.

A rejected patch is now returned as an **error** instead of degrading to the silent no-op; the caller already turns that into a recorded, hub-visible failure (#2308) rather than a permanent spinner.

This narrows but does not eliminate the race — if CI republishes between target selection and the pull, the pod lands on a newer build. That is benign and self-correcting: the hub accepts "at target **or** at registry-latest" as success, so an overshoot completes rather than wedges. What it must never do again is silently land on the wrong build with no record of the request.

## What did NOT need changing

- **`imagePullPolicy`** — already defaults to `Always` at provision time (`saas_provision.go:855`) and is `Always` on **all 51** hive Deployments across `vllm-d` (33) and `hive-oke` (18). No exceptions, so no change.
- **Completion detection** — `server.go:1062` already compares the spoke's self-reported `gitHash` against the target, never the image string, so it works unmodified when the image string cannot change. The `|| registryLatestSHA` fallback is what makes the overshoot case above benign.

## Detection gap / interaction with #2327

#2327's sweep clears and re-arms an orphaned upgrade. That is correct for a departed pod, but it is an **infinite loop** for a spoke structurally unable to advance — exactly the floating-tag case: restart, land on the wrong build, report in, get swept, get re-armed, repeat. Nothing ever reaches a human.

This bounds it. After `maxOrphanedUpgradeSweeps` (3, ≈1 hour at the default `staleUpgradeTimeout`, since each sweep costs at least `orphanedUpgradeClearAfter`) the hub stops retrying, drops the armed instruction, and records a terminal `UpgradeFailed` with the cause — surfaced by the existing UI and `AlertTypeStuckUpgrade`, so no new alert type. Below the budget #2327's behaviour is **unchanged**, guarded by a test. The counter resets when an upgrade lands, so the budget is per-upgrade, not per-hive-lifetime.

## Testing

- `go build ./...` clean, `go vet ./pkg/hub/` clean, `go test ./pkg/hub/` fully green.
- New: forced rollout on a mutable tag (asserting the image is *not* rewritten and the annotation lands on the **template**), reported patch failure, unchanged pinned path (#2308 regression guard), escalation at the budget, preserved re-arm below it.
- `saas.go` / `dashboardHTML` untouched.

## Blast radius

Deployments on floating tags, re-verified read-only:

| cluster | floating | pinned | total |
|---|---|---|---|
| `vllm-d` | 30 (29 `v2-latest`, 1 `mk-latest`) | 3 | 33 |
| `hive-oke` | 2 (1 `v2-latest`, 1 `dd-latest`) | 16 | 18 |

Every floating-tag hive would exhibit this the next time its hub targets a SHA.

**No live systems were modified.** The two hives repaired by hand earlier are already on the target. No mass-patch was performed; with this fix the next upgrade cycle rolls them correctly on its own, so a one-off repair looks unnecessary — happy to do one if you'd rather not wait.
