### PR TITLE
🐛 fix(governor): stop model/method choices reverting on restart

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -348,9 +348,26 @@ type AgentConfig struct {
 	// Paused persists an operator pause across restarts/upgrades. Without
 	// this, every pod restart rebuilt agents un-paused (Go zero value), so
 	// an operator pause was silently undone on the next upgrade.
-	Paused          bool   `yaml:"paused" json:"paused,omitempty"`
-	ClearOnKick     bool   `yaml:"clear_on_kick" json:"clear_on_kick"`
-	CLIPinned       bool   `yaml:"cli_pinned" json:"cli_pinned,omitempty"`
+	Paused      bool `yaml:"paused" json:"paused,omitempty"`
+	ClearOnKick bool `yaml:"clear_on_kick" json:"clear_on_kick"`
+	CLIPinned   bool `yaml:"cli_pinned" json:"cli_pinned,omitempty"`
+
+	// ModelOwner / BackendOwner record WHO last set Model / Backend. An ACMM
+	// pack owns these fields until an operator changes them in the Governor
+	// grid; from that point the operator owns them and ApplyPack must not
+	// reconcile them back to the pack value.
+	//
+	// Without this, a pack re-apply — which happens on EVERY hive restart
+	// (cmd/hive/main.go "merging pack updates") — rewrote Model back to the
+	// pack default, so an operator's model choice silently reverted on the
+	// next restart. That is the "I've deleted those 4 times, they always come
+	// back" report: the revert was a restart, not a propagation delay.
+	//
+	// Stored as a string owner rather than a bool so "never set" (empty),
+	// "pack-owned" and "operator-owned" stay distinguishable across upgrades
+	// of hives whose config predates this field.
+	ModelOwner      string `yaml:"model_owner" json:"model_owner,omitempty"`
+	BackendOwner    string `yaml:"backend_owner" json:"backend_owner,omitempty"`
 	StaleTimeout    int    `yaml:"stale_timeout" json:"stale_timeout,omitempty"`
 	RestartStrategy string `yaml:"restart_strategy" json:"restart_strategy,omitempty"`
 	LaunchCmd       string `yaml:"launch_cmd" json:"launch_cmd,omitempty"`
@@ -496,6 +513,28 @@ func (a *AgentConfig) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
+// Ownership markers for AgentConfig.ModelOwner / BackendOwner.
+const (
+	// FieldOwnerPack marks a value written by an ACMM pack. Pack-owned values
+	// are reconciled to the current pack on every apply.
+	FieldOwnerPack = "pack"
+	// FieldOwnerOperator marks a value an operator chose in the Governor grid.
+	// Operator-owned values are never overwritten by a pack apply.
+	FieldOwnerOperator = "operator"
+)
+
+// ModelIsOperatorOwned reports whether an operator explicitly chose this
+// agent's model, which makes it immune to pack reconciliation.
+func (a AgentConfig) ModelIsOperatorOwned() bool {
+	return a.ModelOwner == FieldOwnerOperator
+}
+
+// BackendIsOperatorOwned reports whether an operator explicitly chose this
+// agent's backend (the grid's "method" column).
+func (a AgentConfig) BackendIsOperatorOwned() bool {
+	return a.BackendOwner == FieldOwnerOperator
+}
+
 // EnabledExplicitlySet returns true when the user's YAML explicitly set the
 // "enabled" field (allowing us to distinguish "not specified" from "enabled: false").
 func (a *AgentConfig) EnabledExplicitlySet() bool {
@@ -516,8 +555,8 @@ type GovernorConfig struct {
 	// Bob holds the IBM bobshell CLI backend's API-key location. Required for
 	// agents with backend "bob": bobshell's browser SSO flow cannot complete in
 	// a headless pod.
-	Bob BobConfig `yaml:"bob"`
-	Trajectory    TrajectoryConfig      `yaml:"trajectory"`
+	Bob        BobConfig        `yaml:"bob"`
+	Trajectory TrajectoryConfig `yaml:"trajectory"`
 	// Gateways is the list of named model gateways (OpenAI-compatible endpoints
 	// like OpenRouter, a LiteLLM proxy, vLLM, or llm-d). An agent routes through
 	// a gateway by naming it as its backend. When empty, a single implicit

--- a/v2/pkg/dashboard/agent_model_ownership_test.go
+++ b/v2/pkg/dashboard/agent_model_ownership_test.go
@@ -1,0 +1,227 @@
+package dashboard
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// enableScanner mirrors production, where every agent defaults to enabled
+// (config.applyDefaults); the shared fixture leaves the field at its zero value.
+func enableScanner(t *testing.T, srv *Server) {
+	t.Helper()
+	sc := srv.deps.Config.Agents["scanner"]
+	sc.Enabled = true
+	srv.deps.Config.Agents["scanner"] = sc
+}
+
+// TestApplyPackPreservesOperatorModel is the regression test for the reported
+// bug: an operator sets a model in the Governor grid, and it reverts to the
+// pack's model. ApplyPack runs on EVERY hive restart ("merging pack updates"),
+// and it used to replace Model on diff unconditionally — so the operator's
+// choice came back as the pack default every restart.
+func TestApplyPackPreservesOperatorModel(t *testing.T) {
+	srv := newFullServer(t)
+	enableScanner(t, srv)
+	if _, err := srv.ApplyPack(3); err != nil {
+		t.Fatalf("ApplyPack(3): %v", err)
+	}
+
+	packModel := srv.deps.Config.Agents["scanner"].Model
+	if packModel == "" {
+		t.Fatal("precondition: pack should have set a model")
+	}
+
+	// Operator picks a different model in the grid.
+	const operatorModel = "some-other-model"
+	srv.claimAgentFieldOwnership("scanner", operatorModel, "")
+
+	// Restart: the pack is re-applied.
+	if _, err := srv.ApplyPack(3); err != nil {
+		t.Fatalf("ApplyPack(3) re-apply: %v", err)
+	}
+
+	if got := srv.deps.Config.Agents["scanner"].Model; got != operatorModel {
+		t.Errorf("operator model reverted: got %q, want %q (pack model %q)", got, operatorModel, packModel)
+	}
+
+	// And it must keep surviving repeated restarts — the user reported four.
+	for i := 0; i < 4; i++ {
+		if _, err := srv.ApplyPack(3); err != nil {
+			t.Fatalf("ApplyPack(3) restart %d: %v", i, err)
+		}
+	}
+	if got := srv.deps.Config.Agents["scanner"].Model; got != operatorModel {
+		t.Errorf("operator model reverted after repeated restarts: got %q, want %q", got, operatorModel)
+	}
+}
+
+// TestApplyPackPreservesOperatorBackend covers the grid's "method" column.
+func TestApplyPackPreservesOperatorBackend(t *testing.T) {
+	srv := newFullServer(t)
+	enableScanner(t, srv)
+	if _, err := srv.ApplyPack(3); err != nil {
+		t.Fatalf("ApplyPack(3): %v", err)
+	}
+
+	const operatorBackend = "claude"
+	srv.claimAgentFieldOwnership("scanner", "", operatorBackend)
+
+	if _, err := srv.ApplyPack(3); err != nil {
+		t.Fatalf("ApplyPack(3) re-apply: %v", err)
+	}
+
+	if got := srv.deps.Config.Agents["scanner"].Backend; got != operatorBackend {
+		t.Errorf("operator backend reverted: got %q, want %q", got, operatorBackend)
+	}
+}
+
+// TestApplyPackStillReconcilesPackOwnedModel guards the other direction: a
+// model the operator never touched must still follow the pack across a level
+// change, otherwise agents keep behaving at their old level.
+func TestApplyPackStillReconcilesPackOwnedModel(t *testing.T) {
+	srv := newFullServer(t)
+	enableScanner(t, srv)
+	if _, err := srv.ApplyPack(3); err != nil {
+		t.Fatalf("ApplyPack(3): %v", err)
+	}
+
+	// Force a stale pack-owned value, as a previous level's pack would leave.
+	sc := srv.deps.Config.Agents["scanner"]
+	sc.Model = "stale-previous-level-model"
+	sc.ModelOwner = config.FieldOwnerPack
+	srv.deps.Config.Agents["scanner"] = sc
+
+	if _, err := srv.ApplyPack(3); err != nil {
+		t.Fatalf("ApplyPack(3) re-apply: %v", err)
+	}
+
+	if got := srv.deps.Config.Agents["scanner"].Model; got == "stale-previous-level-model" {
+		t.Error("pack-owned model was not reconciled to the pack value")
+	}
+}
+
+// TestClaimAgentFieldOwnershipMarksOwner verifies the ownership markers, which
+// are what make the preservation above durable across a restart.
+func TestClaimAgentFieldOwnershipMarksOwner(t *testing.T) {
+	srv := newFullServer(t)
+	enableScanner(t, srv)
+
+	srv.claimAgentFieldOwnership("scanner", "m1", "b1")
+	ac := srv.deps.Config.Agents["scanner"]
+
+	if !ac.ModelIsOperatorOwned() {
+		t.Errorf("ModelOwner = %q, want %q", ac.ModelOwner, config.FieldOwnerOperator)
+	}
+	if !ac.BackendIsOperatorOwned() {
+		t.Errorf("BackendOwner = %q, want %q", ac.BackendOwner, config.FieldOwnerOperator)
+	}
+	if ac.Model != "m1" || ac.Backend != "b1" {
+		t.Errorf("values not written: model=%q backend=%q", ac.Model, ac.Backend)
+	}
+}
+
+// TestClaimAgentFieldOwnershipPartial checks that an empty argument leaves the
+// other field (and its owner) untouched.
+func TestClaimAgentFieldOwnershipPartial(t *testing.T) {
+	srv := newFullServer(t)
+	enableScanner(t, srv)
+	before := srv.deps.Config.Agents["scanner"].Backend
+
+	srv.claimAgentFieldOwnership("scanner", "only-model", "")
+	ac := srv.deps.Config.Agents["scanner"]
+
+	if ac.Backend != before {
+		t.Errorf("backend changed: got %q, want %q", ac.Backend, before)
+	}
+	if ac.BackendOwner != "" {
+		t.Errorf("BackendOwner claimed unexpectedly: %q", ac.BackendOwner)
+	}
+	if !ac.ModelIsOperatorOwned() {
+		t.Error("ModelOwner not claimed")
+	}
+}
+
+// TestPinClaimsOwnership verifies a pin is durable, not decorative: pinning a
+// model must make the field operator-owned so the pack cannot reconcile it.
+func TestPinClaimsOwnership(t *testing.T) {
+	srv := newFullServer(t)
+	enableScanner(t, srv)
+	if _, err := srv.ApplyPack(3); err != nil {
+		t.Fatalf("ApplyPack(3): %v", err)
+	}
+
+	const pinned = "pinned-model"
+	req := httptest.NewRequest("POST", "/api/agents/scanner/pin/model", nil)
+	req.SetPathValue("agent", "scanner")
+	req.SetPathValue("dimension", "model")
+	w := httptest.NewRecorder()
+	srv.handlePin(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("handlePin: %d %s", w.Code, w.Body.String())
+	}
+	// With no body the handler pins the CURRENT effective value; either way the
+	// field must now be operator-owned so a pack apply cannot move it.
+	if !srv.deps.Config.Agents["scanner"].ModelIsOperatorOwned() {
+		t.Error("pin did not claim operator ownership — pin is decorative")
+	}
+
+	pinnedValue := srv.deps.Config.Agents["scanner"].Model
+	if _, err := srv.ApplyPack(3); err != nil {
+		t.Fatalf("ApplyPack after pin: %v", err)
+	}
+	if got := srv.deps.Config.Agents["scanner"].Model; got != pinnedValue {
+		t.Errorf("pinned model changed across pack apply: got %q, want %q", got, pinnedValue)
+	}
+	_ = pinned
+}
+
+// TestValidateModelForAgentAllowsUnverifiable ensures validation never blocks
+// on a cold cache: an unverifiable model is allowed, not rejected.
+func TestValidateModelForAgentAllowsUnverifiable(t *testing.T) {
+	srv := newFullServer(t)
+	enableScanner(t, srv)
+	if err := srv.validateModelForAgent("scanner", "anything-at-all"); err != nil {
+		t.Errorf("cold cache should not reject: %v", err)
+	}
+}
+
+// TestValidateModelForAgentRejectsUnavailable is the legibility guarantee: a
+// model the backend does not offer produces an explicit error instead of being
+// stored and silently falling back at launch.
+func TestValidateModelForAgentRejectsUnavailable(t *testing.T) {
+	srv := newFullServer(t)
+	enableScanner(t, srv)
+
+	backend := srv.deps.Config.Agents["scanner"].Backend
+	srv.cliModels.set(backend, cliModelResult{models: []string{"real-a", "real-b"}, fallback: false})
+
+	err := srv.validateModelForAgent("scanner", "not-a-real-model")
+	if err == nil {
+		t.Fatal("expected an error for an unavailable model")
+	}
+	if !contains([]string{"real-a", "real-b"}, "real-a") {
+		t.Fatal("fixture sanity")
+	}
+	t.Logf("legible error: %v", err)
+
+	if err := srv.validateModelForAgent("scanner", "real-a"); err != nil {
+		t.Errorf("available model rejected: %v", err)
+	}
+}
+
+// TestValidateModelForAgentIgnoresFallbackList verifies the static fallback
+// list is not used to reject, since it is a maintained guess.
+func TestValidateModelForAgentIgnoresFallbackList(t *testing.T) {
+	srv := newFullServer(t)
+	enableScanner(t, srv)
+
+	backend := srv.deps.Config.Agents["scanner"].Backend
+	srv.cliModels.set(backend, cliModelResult{models: []string{"only-this"}, fallback: true})
+
+	if err := srv.validateModelForAgent("scanner", "something-else"); err != nil {
+		t.Errorf("fallback list must not reject: %v", err)
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1025,6 +1025,77 @@ func (s *Server) handleKick(w http.ResponseWriter, r *http.Request) {
 	okResponse(w, map[string]string{"status": "kicked", "agent": name})
 }
 
+// claimAgentFieldOwnership writes an operator's model and/or backend choice
+// into hive.yaml and marks those fields operator-owned. Empty arguments leave
+// the corresponding field untouched.
+//
+// This is the durability half of the model/method revert fix. The in-memory
+// ModelOverride/BackendOverride on the agent process is replayed from
+// /data/hive-state.json on restart, but hive.yaml still carried the PACK's
+// model — and ApplyPack re-reconciles from the pack on every restart. Writing
+// the operator's value to the same layer the pack writes, plus an ownership
+// marker, is what makes the choice actually survive.
+func (s *Server) claimAgentFieldOwnership(name, model, backend string) {
+	if s.deps == nil || s.deps.Config == nil {
+		return
+	}
+	ac, ok := s.deps.Config.Agents[name]
+	if !ok {
+		return
+	}
+	if model != "" {
+		ac.Model = model
+		ac.ModelOwner = config.FieldOwnerOperator
+	}
+	if backend != "" {
+		ac.Backend = backend
+		ac.BackendOwner = config.FieldOwnerOperator
+	}
+	s.deps.Config.Agents[name] = ac
+	_ = s.deps.AgentMgr.UpdateConfig(name, ac)
+	if err := s.saveConfig(); err != nil {
+		s.deps.Logger.Error("failed to persist agent model/method choice", "agent", name, "error", err)
+		s.AddSystemAlert("agent-field-save-failed", "error",
+			"Could not save the model/method choice for "+name+" — it will revert on the next restart: "+err.Error())
+		return
+	}
+	s.ClearSystemAlert("agent-field-save-failed")
+}
+
+// validateModelForAgent rejects a model the agent's effective backend does not
+// offer, so an unhonorable choice surfaces as a 400 the operator can see
+// instead of silently degrading to a default at launch time.
+//
+// Backends whose model list cannot be enumerated (no reachable endpoint, or a
+// backend that accepts free-form model ids) are allowed through: refusing a
+// value we simply cannot verify would block legitimate configurations.
+func (s *Server) validateModelForAgent(name, model string) error {
+	if model == "" {
+		return fmt.Errorf("model must not be empty")
+	}
+	proc, err := s.deps.AgentMgr.GetStatus(name)
+	if err != nil || proc == nil {
+		// Agent lookup failures are reported by the caller's SetModelOverride.
+		return nil
+	}
+	backend := proc.Config.Backend
+	if proc.BackendOverride != "" {
+		backend = proc.BackendOverride
+	}
+
+	known := s.modelIDsForBackend(backend)
+	if len(known) == 0 {
+		return nil // cannot enumerate — do not block
+	}
+	for _, id := range known {
+		if id == model {
+			return nil
+		}
+	}
+	return fmt.Errorf("model %q is not available for backend %q (available: %s)",
+		model, backend, strings.Join(known, ", "))
+}
+
 func (s *Server) handleSwitch(w http.ResponseWriter, r *http.Request) {
 	name := s.resolveAgentParam(r.PathValue("agent"))
 	backend := sanitizeString(r.PathValue("backend"))
@@ -1033,6 +1104,10 @@ func (s *Server) handleSwitch(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+
+	// Persist to hive.yaml and mark the field operator-owned so the next pack
+	// apply (which runs on every restart) does not reconcile it away.
+	s.claimAgentFieldOwnership(name, "", backend)
 
 	s.deps.Logger.Info("audit: backend switched", "agent", name, "backend", backend, "trigger", "dashboard-api")
 	s.auditFromRequest(r, "switch_backend", auditDetail("backend", backend), name)
@@ -1050,10 +1125,23 @@ func (s *Server) handleModelSet(w http.ResponseWriter, r *http.Request) {
 	name := s.resolveAgentParam(r.PathValue("agent"))
 	model := sanitizeString(r.PathValue("model"))
 
+	// Reject a model the effective backend cannot serve BEFORE storing it.
+	// Silently accepting an unusable value and then falling back at launch is
+	// what made this class of bug invisible: the grid showed the choice, the
+	// agent ran on something else, and the value appeared to "revert".
+	if err := s.validateModelForAgent(name, model); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	if err := s.deps.AgentMgr.SetModelOverride(name, model); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+
+	// Persist to hive.yaml and mark the field operator-owned so the next pack
+	// apply (which runs on every restart) does not reconcile it away.
+	s.claimAgentFieldOwnership(name, model, "")
 
 	s.deps.Logger.Info("audit: model set", "agent", name, "model", model, "trigger", "dashboard-api")
 	s.auditFromRequest(r, "set_model", auditDetail("model", model), name)
@@ -1138,6 +1226,18 @@ func (s *Server) handlePin(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
+	}
+
+	// A pin is a stronger statement of intent than a plain switch, so it must
+	// at least be as durable. Previously a pin lived only on the agent process
+	// (replayed from /data/hive-state.json) while hive.yaml kept the pack's
+	// value, so the pin did not protect the field from the pack re-apply that
+	// runs on every restart — the pin icon was effectively decorative.
+	switch dimension {
+	case "model":
+		s.claimAgentFieldOwnership(name, body.Value, "")
+	case "cli":
+		s.claimAgentFieldOwnership(name, "", body.Value)
 	}
 
 	s.deps.Logger.Info("audit: agent pinned", "agent", name, "dimension", dimension, "value", body.Value, "trigger", "dashboard-api")
@@ -2402,15 +2502,19 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 	// way the card dropdowns do (SetModelOverride + restart) — otherwise a stale
 	// live override would mask the freshly-saved value and it still wouldn't stick.
 	modelChanged, backendChanged := false, false
+	// Both are operator edits, so they claim ownership of the field — without
+	// the marker the next pack apply (every restart) reconciles them away.
 	if v, ok := body["model"]; ok {
 		if str, ok := v.(string); ok {
 			agentCfg.Model = sanitizeString(str)
+			agentCfg.ModelOwner = config.FieldOwnerOperator
 			modelChanged = true
 		}
 	}
 	if v, ok := body["cliPinValue"]; ok {
 		if str, ok := v.(string); ok && str != "" {
 			agentCfg.Backend = sanitizeString(str)
+			agentCfg.BackendOwner = config.FieldOwnerOperator
 			backendChanged = true
 		}
 	}
@@ -2659,11 +2763,15 @@ func (s *Server) handleAgentConfigModels(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Operator edits claim ownership so the pack apply that runs on every
+	// restart cannot reconcile the choice back to the pack default.
 	if body.Backend != "" {
 		agentCfg.Backend = sanitizeString(body.Backend)
+		agentCfg.BackendOwner = config.FieldOwnerOperator
 	}
 	if body.Model != "" {
 		agentCfg.Model = sanitizeString(body.Model)
+		agentCfg.ModelOwner = config.FieldOwnerOperator
 	}
 	s.deps.Config.Agents[name] = agentCfg
 

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -91,9 +91,15 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 			// templates and models even though acmm_level had moved up. Reconcile
 			// these replace-on-diff (kick_template and mode already did; model,
 			// description, role, bead_role, display_name did NOT — that gap is the
-			// bug). Genuine per-agent overrides belong in the explicit override
-			// fields (BackendOverride, ModelOverride, pins), which live on the
-			// agent process and are NOT touched here.
+			// bug).
+			//
+			// Model/Backend are the exception: an operator sets them from the
+			// Governor grid, so they carry an ownership marker and are reconciled
+			// only while still pack-owned (see below). The in-memory
+			// ModelOverride/BackendOverride on the agent process are NOT a
+			// durable home for that choice — they are replayed from
+			// /data/hive-state.json, while hive.yaml (which this writes) is what
+			// the pack re-reads on the next restart.
 			if pa.KickTemplate != "" && existing.KickTemplate != pa.KickTemplate {
 				existing.KickTemplate = pa.KickTemplate
 				changed = true
@@ -102,8 +108,16 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 				existing.Mode = pa.Mode
 				changed = true
 			}
-			if pa.Model != "" && existing.Model != pa.Model {
+			// Model is reconciled to the pack ONLY while the pack still owns
+			// it. Once an operator picks a model in the Governor grid the
+			// field becomes operator-owned and the pack must leave it alone:
+			// ApplyPack runs on every restart ("merging pack updates"), so an
+			// unconditional replace-on-diff here silently reverted the
+			// operator's choice on the next pod restart — repeatedly, which is
+			// exactly the reported "they always come back".
+			if pa.Model != "" && existing.Model != pa.Model && !existing.ModelIsOperatorOwned() {
 				existing.Model = pa.Model
+				existing.ModelOwner = config.FieldOwnerPack
 				changed = true
 			}
 			if pa.Description != "" && existing.Description != pa.Description {
@@ -126,8 +140,9 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 			// Backend is fill-if-empty: it never varies by level (always the same
 			// per agent across all packs), and users legitimately pin it, so the
 			// pack must not stomp a user's choice.
-			if existing.Backend == "" && pa.Backend != "" {
+			if existing.Backend == "" && pa.Backend != "" && !existing.BackendIsOperatorOwned() {
 				existing.Backend = pa.Backend
+				existing.BackendOwner = config.FieldOwnerPack
 				changed = true
 			}
 
@@ -144,8 +159,12 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 
 		includeRepos := pa.IncludeRepos
 		agentCfg := config.AgentConfig{
-			Backend:      pa.Backend,
-			Model:        pa.Model,
+			Backend: pa.Backend,
+			Model:   pa.Model,
+			// A freshly created agent's model/backend come from the pack, so
+			// the pack owns them until an operator overrides in the grid.
+			ModelOwner:   config.FieldOwnerPack,
+			BackendOwner: config.FieldOwnerPack,
 			Enabled:      true,
 			DisplayName:  pa.DisplayName,
 			Description:  pa.Description,

--- a/v2/pkg/dashboard/cli_models.go
+++ b/v2/pkg/dashboard/cli_models.go
@@ -319,6 +319,26 @@ func (c *cliModelCache) set(backend string, r cliModelResult) {
 // gemini, goose), running the backend's best-effort discovery probe (cached)
 // and falling back to a current static list on any failure. It never errors
 // and never returns an empty list.
+// modelIDsForBackend returns the known model ids for a backend WITHOUT issuing
+// a discovery probe: it uses only the already-populated cache. Validation runs
+// on the request path, so a cold cache must not block the operator behind a
+// network round-trip — an empty result means "cannot verify", and callers let
+// the value through rather than rejecting something that may be valid.
+//
+// A fallback (static) list is also treated as unverifiable: it is a maintained
+// guess, not the backend's authoritative inventory, and rejecting against it
+// would block legitimately available models.
+func (s *Server) modelIDsForBackend(backend string) []string {
+	if s.cliModels == nil || backend == "" {
+		return nil
+	}
+	r, ok := s.cliModels.get(backend)
+	if !ok || r.fallback {
+		return nil
+	}
+	return append([]string(nil), (r.models)...)
+}
+
 func (s *Server) queryCLIModels(backend string) cliModelResult {
 	if s.cliModels != nil {
 		if r, ok := s.cliModels.get(backend); ok {


### PR DESCRIPTION
## Problem (Bluefin / jOrge)

> "see those sonnet 4.6 agents?" — "I've deleted those like 4 times, they always come back"

An operator's **model** or **method (backend)** choice in the Governor grid silently reverts to the ACMM pack's value. Four deletions is a revert, not a propagation delay — something was actively rewriting the config back.

## Root cause (verified)

`ApplyPack` reconciled `Model` replace-on-diff, unconditionally:

```go
if pa.Model != "" && existing.Model != pa.Model {
    existing.Model = pa.Model
}
```

and **`ApplyPack` runs on every hive restart** — `cmd/hive/main.go`, the `saved != nil` branch logged as "merging pack updates" — not only on an ACMM level change. So every pod restart rewrote `hive.yaml` back to the pack default. The fleet restarts frequently for upgrades, which is why the revert looked random to the user.

The code comment above that block asserted per-agent choices "belong in the explicit override fields (BackendOverride, ModelOverride, pins), which live on the agent process and are NOT touched here". That assumption was wrong: those fields live only in memory and are replayed from `/data/hive-state.json`, while `hive.yaml` — what the pack re-reads on the next boot — still held the pack's model. The override was never a durable home for the choice.

Confirmed read-only against the live Bluefin hive (ACMM L3):
- `hive.yaml` carried the pack's `claude-sonnet-4-6` on every agent — the "sonnet 4.6 agents" from the report.
- `hive-state.json` had `pinned_model: null` for **every** agent, despite pins showing as set in the grid.

Ruled out: the hub does not push per-agent model/backend, so a hub→spoke reconcile is not involved.

## Pins were decorative

A pin lived only on the agent process while `hive.yaml` kept the pack value, so it did **not** protect the field from the pack re-apply. Pinning now claims ownership and persists, so the pin icon means what it appears to mean.

## Fix

- Add `model_owner` / `backend_owner` to `AgentConfig` recording whether a **pack** or an **operator** last set the field. This mirrors the existing `Paused` precedent, which was moved into config for exactly this restart-durability reason.
- `ApplyPack` reconciles model/backend only while still **pack-owned** — a stale previous-level value is still corrected (that fix is preserved and tested), but an operator's choice is left alone. Pack-created agents are marked pack-owned.
- Every operator write path claims ownership and persists to `hive.yaml`: the grid dropdowns, the config dialog, and the agent-update endpoint. Previously three of these wrote the value without protecting it.

## Legibility

A model the effective backend does not offer is now rejected with an explicit error naming the available ids, rather than being stored and silently falling back at launch. Silent reversion is what cost this user four attempts.

Validation reads only the already-populated discovery cache and never blocks the request on a probe. An unverifiable or static-fallback list is treated as "cannot verify" and allowed through, so sentinels like `auto` (used by `sec-check` on the live hive) and legitimately available models are never rejected. A failed config save raises a system alert instead of failing silently.

## Relationship to prior art

Same **class** of bug as #2061 (operator edits reverted by a reconcile) but a **different code path and mechanism**: #2061 fixed a per-heartbeat hub reconcile via the `ClaimDelivered` handshake and, in `ApplyPack`, only governor *thresholds*. Model/method were never covered — the pack's `existing.Model` replace was left unconditional. This is not a regression of #2061; that PR's threshold fix and its test still pass.

Independent of today's `acmm_level: 3 → 2` provision drift, which is in the hub provision path. No overlap — scoped strictly to the per-agent model/method fields.

## Tests

- `TestApplyPackPreservesOperatorModel` — survives a re-apply and four further restarts (the user's exact count).
- `TestApplyPackPreservesOperatorBackend` — the grid's method column.
- `TestApplyPackStillReconcilesPackOwnedModel` — guards the other direction; an untouched value still follows the pack.
- `TestPinClaimsOwnership` — a pin is durable, not decorative.
- `TestValidateModelForAgent{RejectsUnavailable,AllowsUnverifiable,IgnoresFallbackList}` — legible error; never blocks on a cold cache or a static list.

Verified non-vacuous: reverting the one-line ownership guard fails `TestApplyPackPreservesOperatorModel` with `got "claude-sonnet-4-6", want "some-other-model"` — reproducing the reported bug exactly.

`pkg/dashboard` and `pkg/config` pass. Some `TestCovV1_*` / `TestCovDF_*` failures and a `pkg/agent` timeout reproduce identically on unmodified `v2` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)