### PR TITLE
🔀 sync: v2 → dd (top-up #2337, #2333)

### DIFF
--- a/v2/cmd/hive/githubauth_test.go
+++ b/v2/cmd/hive/githubauth_test.go
@@ -62,6 +62,9 @@ func isolateAppKeyLookup(t *testing.T) string {
 // the new pod could never go Ready.
 //
 // Booting is the assertion. Nine more hives were carrying this exact config.
+//
+// It also locks the CLASSIFICATION: a sentinel hive is operator-actionable
+// (AppStateNoAppAssigned), never AppStateNotInstalled.
 func TestInitGitHubAuthPlaceholderAppIDBoots(t *testing.T) {
 	dir := isolateAppKeyLookup(t)
 
@@ -91,15 +94,25 @@ func TestInitGitHubAuthPlaceholderAppIDBoots(t *testing.T) {
 	if !strings.Contains(got.Failure, "placeholder") {
 		t.Errorf("failure reason does not identify the placeholder as the cause: %q", got.Failure)
 	}
-	// A placeholder hive genuinely has no App installed, and installing one is
-	// what the owner must do — so this must classify as user-actionable, not as
-	// an operator-side key fault.
-	if got.State != github.AppStateNotInstalled {
-		t.Errorf("State = %v, want AppStateNotInstalled", got.State)
+	// A placeholder hive is OPERATOR-actionable, not user-actionable.
+	//
+	// This assertion was inverted until the placeholder-assignment fix. The
+	// premise "the owner can fix this by installing the App" is false: the
+	// sentinel app_id names no GitHub App, so the JWT fails before any
+	// installation is consulted. The App is typically already installed and the
+	// installation_id already correct (the reporting owner's was the very same
+	// installation another working hive uses) — only the hub can supply the real
+	// app_id. Classifying it as "not installed" pointed the owner at the
+	// install link and the Set-ID box, i.e. at the one field already right.
+	if got.State != github.AppStateNoAppAssigned {
+		t.Errorf("State = %v, want AppStateNoAppAssigned", got.State)
 	}
-	if !got.State.UserActionable() {
-		t.Error("a placeholder hive's owner can fix this by installing the App; " +
-			"the state must be user-actionable or the banner will not tell them to")
+	if got.State.UserActionable() {
+		t.Error("placeholder app_id is not user-actionable: no installation_id the owner " +
+			"enters can make a nonexistent app_id authenticate")
+	}
+	if !got.State.OperatorActionable() {
+		t.Error("only the hub operator can assign a real app_id; the banner must say so")
 	}
 }
 

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -421,10 +421,17 @@ func initGitHubAuth(ctx context.Context, cfg *config.Config, logger *slog.Logger
 		// Real App, unusable key. Already logged; leave Client nil so nothing
 		// tries to act on GitHub with credentials that do not work.
 	case cfg.GitHub.IsPlaceholderApp():
-		// User-actionable: this hive was provisioned ahead of its App, and
-		// installing the App is exactly what resolves it.
-		out.Failure = "This hive carries a placeholder github.app_id and is not yet linked to a GitHub App. Install the GitHub App on your org to enable agents."
-		out.State = github.AppStateNotInstalled
+		// OPERATOR-actionable, not user-actionable. This hive was provisioned as
+		// a placeholder and never assigned a real app_id, so the JWT it signs
+		// names no App and fails before any installation is consulted. Nothing
+		// the owner enters in the installation-ID box can fix it — reporting this
+		// as AppStateNotInstalled sent owners to re-install an App that was
+		// already installed and to re-enter an installation_id that was already
+		// correct.
+		out.Failure = "This hive was never assigned a GitHub App ID: it still carries the placeholder github.app_id, " +
+			"which does not name a real GitHub App. Setting an installation ID cannot resolve this — " +
+			"the hub operator must assign the real App ID."
+		out.State = github.AppStateNoAppAssigned
 		logger.Warn("placeholder github.app_id — hive starting in dashboard-only mode",
 			"placeholder_app_id", config.PlaceholderAppID,
 			"installation_id", cfg.GitHub.InstallationID,

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5082,9 +5082,17 @@
        perform. Kept out of GH_APP_OPERATOR_STATES: installing is the user's
        job, not the operator's. */
     var GH_APP_STATE_NOT_INSTALLED = 'not-installed';
+    /* Operator-side: this hive still carries the placeholder app_id and was
+       never assigned a real App. It is NOT 'not-installed' — the App may well be
+       installed and the installation ID correct (it usually is), but an app_id
+       that names no App can never authenticate. Treating it as user-actionable
+       sent owners to the install link and the Set-ID box, i.e. to fix the one
+       field that was already right. */
+    var GH_APP_STATE_NO_APP_ASSIGNED = 'no-app-assigned';
     var GH_APP_OPERATOR_STATES = {};
     GH_APP_OPERATOR_STATES[GH_APP_STATE_KEY_MISSING] = true;
     GH_APP_OPERATOR_STATES[GH_APP_STATE_KEY_INVALID] = true;
+    GH_APP_OPERATOR_STATES[GH_APP_STATE_NO_APP_ASSIGNED] = true;
 
     /* True when the App failure is the operator's to fix. An unreported or
        unrecognised state is deliberately NOT operator-side: a spoke too old to
@@ -5110,14 +5118,20 @@
         var oTitle = document.querySelector('#gh-app-install-banner .gh-app-title');
         var oDesc = document.querySelector('#gh-app-install-banner .gh-app-desc');
         var oLink = document.getElementById('gh-app-install-link');
-        if (oTitle) oTitle.textContent = 'GitHub App credentials pending — no action needed from you';
+        if (oTitle) {
+          oTitle.textContent = appState === GH_APP_STATE_NO_APP_ASSIGNED
+            ? 'This hive was never assigned a GitHub App ID'
+            : 'GitHub App credentials pending — no action needed from you';
+        }
         if (oDesc) {
           /* Prefer the server-composed diagnosis; it already carries the
              accurate, non-blaming copy. textContent keeps any org name or API
              text safe to render verbatim. */
           oDesc.textContent = (typeof data.githubAppPermIssue === 'string' && data.githubAppPermIssue)
             ? data.githubAppPermIssue
-            : (appState === GH_APP_STATE_KEY_INVALID
+            : (appState === GH_APP_STATE_NO_APP_ASSIGNED
+                ? 'This hive was provisioned as a placeholder and still carries the placeholder github.app_id, which does not name a real GitHub App. It cannot authenticate no matter which installation ID is set — your App installation and installation ID are not at fault. Only the hub operator can assign the real App ID. Please contact your hub administrator.'
+                : appState === GH_APP_STATE_KEY_INVALID
                 ? 'This hive’s GitHub App private key does not match the App it authenticates as, so GitHub rejects its token. The key is supplied by the hub operator and cannot be corrected by you — your App installation and installation ID are not at fault. Please contact your hub administrator.'
                 : 'This hive’s GitHub App credentials have not been provisioned yet. The private key is supplied by the hub operator, not by you. Agents will start working automatically once it arrives; contact your hub administrator if this persists.');
         }

--- a/v2/pkg/github/app_state.go
+++ b/v2/pkg/github/app_state.go
@@ -55,6 +55,20 @@ const (
 	// classic symptom of a public github.com key on a GitHub Enterprise hive).
 	// OPERATOR-ACTIONABLE: the hub must push the correct key.
 	AppStateKeyInvalid
+
+	// AppStateNoAppAssigned means the hive is still running
+	// config.PlaceholderAppID — it was provisioned as a placeholder and never
+	// assigned a real GitHub App ID. OPERATOR-ACTIONABLE: only the hub can
+	// supply the App ID.
+	//
+	// This is deliberately NOT AppStateNotInstalled. Both leave the hive without
+	// working App auth, but they point at opposite fixes, and reporting this one
+	// as "not installed" actively misleads: it tells the owner to install the App
+	// and set an installation_id, when their installation_id is already correct
+	// and no value they can enter will help — the app_id names no App, so the
+	// JWT fails before the installation is ever consulted. That misdiagnosis is
+	// what cost the owner of the first hive to hit this real debugging time.
+	AppStateNoAppAssigned
 )
 
 // String returns the stable wire token for a state. These tokens cross the
@@ -74,6 +88,8 @@ func (s AppAuthState) String() string {
 		return "key-missing"
 	case AppStateKeyInvalid:
 		return "key-invalid"
+	case AppStateNoAppAssigned:
+		return "no-app-assigned"
 	default:
 		return "unknown"
 	}
@@ -84,7 +100,7 @@ func (s AppAuthState) String() string {
 // not instruct the user to install anything or edit config, and the journey
 // nudges must never escalate against them.
 func (s AppAuthState) OperatorActionable() bool {
-	return s == AppStateKeyMissing || s == AppStateKeyInvalid
+	return s == AppStateKeyMissing || s == AppStateKeyInvalid || s == AppStateNoAppAssigned
 }
 
 // UserActionable reports whether the hive's owner (or their org owner) can fix
@@ -115,6 +131,8 @@ func ParseAppAuthState(s string) AppAuthState {
 		return AppStateKeyMissing
 	case "key-invalid":
 		return AppStateKeyInvalid
+	case "no-app-assigned":
+		return AppStateNoAppAssigned
 	default:
 		return AppStateUnknown
 	}
@@ -337,6 +355,13 @@ func (d AppAuthDiagnosis) Message() string {
 			"the private key it holds does not match the App it authenticates as, so GitHub rejects its signed token. " +
 			"This key is distributed by the hub operator and cannot be supplied or corrected by you — " +
 			"your App installation and installation ID are not at fault. Please contact your hub administrator to have the correct key pushed to this hive."
+
+	case AppStateNoAppAssigned:
+		return "This hive was never assigned a GitHub App ID. It was provisioned as a placeholder and still carries the " +
+			"placeholder app_id, which does not name a real GitHub App — so it cannot authenticate no matter which " +
+			"installation ID is set here. Your App installation and installation ID are NOT at fault, and setting an " +
+			"installation ID will not resolve this. Only the hub operator can assign the real App ID. " +
+			"Please contact your hub administrator."
 
 	case AppStateNotInstalled:
 		return fmt.Sprintf("The KubeStellar Hive GitHub App is not installed on %s. "+

--- a/v2/pkg/hub/advisory_staleness.go
+++ b/v2/pkg/hub/advisory_staleness.go
@@ -32,7 +32,7 @@ func appCanWriteForAdvisory(e RegistryEntry) bool {
 		return false
 	}
 	switch e.GitHubAppState {
-	case "not-installed", "key-missing", "key-invalid",
+	case "not-installed", "key-missing", "key-invalid", "no-app-assigned",
 		"wrong-installation", "insufficient-permissions":
 		return false
 	default:

--- a/v2/pkg/hub/app_host_follows_repo_test.go
+++ b/v2/pkg/hub/app_host_follows_repo_test.go
@@ -1,6 +1,10 @@
 package hub
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
 
 // The App ID provisioned for a hive must follow the hive's GitHub HOST:
 // a GHE hive gets the cluster's GitHub Enterprise App, never the public
@@ -24,6 +28,15 @@ func TestResolveProvisionAppID_GHEUsesClusterApp(t *testing.T) {
 	if got := resolveProvisionAppID("3568013", publicOnGHECluster, gheCluster); got != "3568013" {
 		t.Errorf("public-override hive on GHE cluster app_id = %q, want request value 3568013", got)
 	}
+
+	// A PUBLIC github.com cluster that names its own App ID must hand it to its
+	// hives. This is the placeholder-sentinel fix: the public cluster carried no
+	// github_app_id, so every hive it provisioned kept config.PlaceholderAppID
+	// and could never authenticate. The rule is per-HOST, not GHE-only.
+	publicCluster := &ClusterConfig{GitHubAppID: 3568013}
+	if got := resolveProvisionAppID("", &SaaSHive{}, publicCluster); got != "3568013" {
+		t.Errorf("public cluster app_id = %q, want the cluster's configured App 3568013", got)
+	}
 }
 
 // Public-GitHub hives (and clusters with no GHE App) keep the request's app_id
@@ -39,5 +52,46 @@ func TestResolveProvisionAppID_PublicUnchanged(t *testing.T) {
 	gheClusterNoApp := &ClusterConfig{GitHubBaseURL: "https://github.ibm.com", GitHubAPIURL: "https://github.ibm.com/api/v3"}
 	if got := resolveProvisionAppID("3568013", &SaaSHive{}, gheClusterNoApp); got != "3568013" {
 		t.Errorf("GHE cluster w/o App app_id = %q, want request value 3568013 (no cluster App to use)", got)
+	}
+}
+
+// TestDecideAppKeySync_RepairsPlaceholderSentinel locks the fleet-repair half of
+// the placeholder-app_id fix.
+//
+// A spoke provisioned as a placeholder carries config.PlaceholderAppID plus its
+// own per-hive key. Before this, the per-hive key acted as an override and the
+// reconcile refused to touch it (appKeyReasonPerHiveOverride), so the sentinel
+// survived every heartbeat forever — the hive could never authenticate no matter
+// what its owner did. The sentinel is never a deliberate pin, so it must be
+// repaired even against a per-hive key, and even when that key's fingerprint
+// happens to match (a correct key cannot rescue a nonexistent app_id).
+func TestDecideAppKeySync_RepairsPlaceholderSentinel(t *testing.T) {
+	cluster := &clusterAppIdentity{AppID: 3568013, Fingerprint: "cluster-fp"}
+
+	for _, tc := range []struct {
+		name        string
+		fingerprint string
+		hasPerHive  bool
+	}{
+		{"per-hive key, different fingerprint", "other-fp", true},
+		{"per-hive key, matching fingerprint", "cluster-fp", true},
+		{"no key at all", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decideAppKeySync(tc.fingerprint, tc.hasPerHive, false, config.PlaceholderAppID, cluster)
+			if !got.Push {
+				t.Errorf("sentinel app_id not repaired (%s): %+v", tc.name, got)
+			}
+			if got.Reason != appKeyReasonPlaceholderAppID {
+				t.Errorf("Reason = %q, want %q", got.Reason, appKeyReasonPlaceholderAppID)
+			}
+		})
+	}
+
+	// A spoke on a genuinely different (real) App is still protected — the
+	// sentinel is the ONLY app_id treated as unconditionally wrong.
+	const someOtherRealApp = 4240368
+	if got := decideAppKeySync("other-fp", true, false, someOtherRealApp, cluster); got.Push {
+		t.Errorf("a real non-matching app_id must stay protected as a deliberate pin: %+v", got)
 	}
 }

--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -431,6 +431,14 @@ const (
 	// is pinned to an App other than the cluster's, so its key is presumed
 	// correct for that App and the cluster key would break it.
 	appKeyReasonDifferentApp = "hive is deliberately pinned to a different app_id"
+	// appKeyReasonPlaceholderAppID repairs a spoke still running the
+	// config.PlaceholderAppID sentinel. The sentinel is NOT a real App and is
+	// never a deliberate pin — it is what provisioning writes when no App ID was
+	// known yet — so the per-hive-override protection must not shield it. Such a
+	// spoke signs a JWT for a nonexistent App and can never authenticate, no
+	// matter what installation_id its owner enters, so pushing the cluster's real
+	// App identity is the only thing that can fix it.
+	appKeyReasonPlaceholderAppID = "spoke still carries the placeholder app_id sentinel"
 	// appKeyReasonPublicHiveOnGHECluster is the class fix for a github.com hive
 	// parked on a GitHub-Enterprise-default cluster (vllm-d). The hive's meta
 	// pins it to public github.com (github_base_url:"public" / "https://github.com")
@@ -454,7 +462,7 @@ const (
 // for the operator to make it stick. The cluster key is a FLOOR for hives nobody
 // has spoken for, not a ceiling over hives somebody has.
 //
-// THE ONE EXCEPTION — A WRONG PER-HIVE KEY IS NOT A CHOICE
+// # THE ONE EXCEPTION — A WRONG PER-HIVE KEY IS NOT A CHOICE
 //
 // That precedence protects a DECISION. It must not protect a FAULT, and the two
 // are distinguishable without heuristics. A GitHub App JWT is signed by the
@@ -519,6 +527,26 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned b
 		}
 	}
 	fp := strings.TrimSpace(spokeFingerprint)
+	// A spoke still running the placeholder sentinel is broken regardless of
+	// which key it holds: app_id 999999999 names no App, so every JWT it signs
+	// is for a nonexistent App and auth fails no matter how correct its
+	// installation_id and key are. Decided BEFORE the per-hive branch because a
+	// sentinel hive typically holds a provisioned per-hive key and would
+	// otherwise be shielded by appKeyReasonPerHiveOverride and never repaired —
+	// and before the fingerprint-match test, since holding the right key does
+	// not make a nonexistent app_id work.
+	//
+	// This is the ONLY app_id the reconcile treats as unconditionally wrong. A
+	// spoke on any other non-matching app_id is still respected as a deliberate
+	// pin (appKeyReasonDifferentApp).
+	if spokeAppID == config.PlaceholderAppID {
+		return appKeySyncDecision{
+			Push:            true,
+			Reason:          appKeyReasonPlaceholderAppID,
+			FromFingerprint: fp,
+			ToFingerprint:   cluster.Fingerprint,
+		}
+	}
 	if hasPerHiveKey {
 		// Idempotence first: if the per-hive key already IS the cluster key
 		// there is nothing to decide and nothing to send. Checking this ahead of

--- a/v2/pkg/hub/journey.go
+++ b/v2/pkg/hub/journey.go
@@ -371,9 +371,13 @@ func appStateIsOperatorSide(state string) bool {
 //   - "key-missing" — no App private key reached this spoke at all.
 //   - "key-invalid" — a key is present but GitHub rejects the JWT it signs,
 //     i.e. it belongs to a different App than the hive claims to be.
+//   - "no-app-assigned" — the hive still carries the placeholder app_id and was
+//     never assigned a real App. The owner cannot fix this at all, so the
+//     journey must never nudge (or threaten de-provisioning) over it.
 var operatorSideAppStates = map[string]bool{
-	appStateKeyMissingToken: true,
-	appStateKeyInvalidToken: true,
+	appStateKeyMissingToken:    true,
+	appStateKeyInvalidToken:    true,
+	appStateNoAppAssignedToken: true,
 }
 
 const (
@@ -381,6 +385,8 @@ const (
 	// github.AppStateKeyMissing.String() and github.AppStateKeyInvalid.String().
 	appStateKeyMissingToken = "key-missing"
 	appStateKeyInvalidToken = "key-invalid"
+	// appStateNoAppAssignedToken mirrors github.AppStateNoAppAssigned.String().
+	appStateNoAppAssignedToken = "no-app-assigned"
 )
 
 // methodModelAssigned reports whether any agent on this hive has a method

--- a/v2/pkg/hub/journey_operator_block_test.go
+++ b/v2/pkg/hub/journey_operator_block_test.go
@@ -128,10 +128,15 @@ func TestNextNudge_OperatorBlockedDoesNotSuppressOtherStages(t *testing.T) {
 // pkg/hub deliberately does not import pkg/github, so these literals must stay
 // in sync with github.AppAuthState.String() by test, not by compiler.
 func TestOperatorSideAppStateTokensMatchSpoke(t *testing.T) {
-	// These are exactly the tokens github.AppStateKeyMissing.String() and
-	// github.AppStateKeyInvalid.String() produce; pkg/github's
+	// These are exactly the tokens github.AppStateKeyMissing.String(),
+	// github.AppStateKeyInvalid.String() and
+	// github.AppStateNoAppAssigned.String() produce; pkg/github's
 	// TestAppAuthState_WireRoundTrip locks the other side.
-	want := map[string]bool{"key-missing": true, "key-invalid": true}
+	//
+	// "no-app-assigned" is operator-side: a hive still on the placeholder
+	// app_id cannot be fixed by its owner at all, so the journey must never
+	// nudge — let alone threaten de-provisioning — over it.
+	want := map[string]bool{"key-missing": true, "key-invalid": true, "no-app-assigned": true}
 	if len(operatorSideAppStates) != len(want) {
 		t.Fatalf("operatorSideAppStates = %v, want exactly %v", operatorSideAppStates, want)
 	}

--- a/v2/pkg/hub/misc_coverage_test.go
+++ b/v2/pkg/hub/misc_coverage_test.go
@@ -225,8 +225,11 @@ func TestHandleClusterHealth(t *testing.T) {
 }
 
 // TestAdoptSpokeProjectConfig verifies the hub's adopt path:
-//   - ACMM level is operator-owned from the start and always adopted (the Joe
-//     Runde / spyre revert bug);
+//   - ACMM level follows the SAME ClaimDelivered handshake as org/repos: before
+//     delivery the assigned level is authoritative and a stale spoke report is
+//     ignored (an approved L3 request was silently downgraded to the level the
+//     placeholder was minted at); after delivery a dashboard level change is
+//     adopted and never reverted (the Joe Runde / spyre revert bug);
 //   - org/repos/primary follow the ClaimDelivered handshake: before the spoke
 //     first reports the claimed project, hub-pushed values are authoritative and
 //     spoke reports do NOT adopt (a stale placeholder must not win); the first
@@ -240,20 +243,30 @@ func TestAdoptSpokeProjectConfig(t *testing.T) {
 
 	s := &HubServer{logger: slog.Default()}
 
-	// Freshly-claimed hive (ClaimDelivered=false). ACMM is adopted immediately,
-	// but org/repos edits reported before delivery are IGNORED (could be a stale
-	// placeholder still reporting old values). A report that MATCHES the claim
-	// flips ClaimDelivered.
-	saveSaaSHive(&SaaSHive{ID: "claimed", Status: "running", Org: "o", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 2})
+	// Freshly-claimed hive (ClaimDelivered=false), assigned L3. Nothing reported
+	// before delivery is adopted — including the level. A report that matches the
+	// claim IN FULL (org/repos AND level) flips ClaimDelivered.
+	saveSaaSHive(&SaaSHive{ID: "claimed", Status: "running", Org: "o", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 3})
 
-	// Pre-delivery: spoke reports a DIFFERENT org/repos (stale) but a new level.
-	// -> adopt the level (3) only; org/repos stay as the claim; not yet delivered.
-	s.adoptSpokeProjectConfig("claimed", "stale", []string{"old"}, "old", 3)
+	// Pre-delivery: the spoke is still running its placeholder project at the
+	// level it was MINTED at (2), not the assigned 3. This is the production
+	// bug: adopting that report rewrote meta from the requested L3 down to L2,
+	// and since the hub then had nothing higher to push, the hive stayed L2
+	// forever. The assigned level must survive.
+	s.adoptSpokeProjectConfig("claimed", "stale", []string{"old"}, "old", 2)
 	if h := loadSaaSHive("claimed"); h == nil || h.ACMMLevel != 3 || h.Org != "o" || len(h.Repos) != 1 || h.ClaimDelivered {
-		t.Errorf("pre-delivery stale report: meta = %+v, want acmm=3 org=o repos=[r] ClaimDelivered=false", h)
+		t.Errorf("pre-delivery stale report: meta = %+v, want acmm=3 (assigned level held) org=o repos=[r] ClaimDelivered=false", h)
 	}
 
-	// Spoke now reports the actual claimed project -> flips ClaimDelivered.
+	// A report matching org/repos but still carrying the OLD level is not a
+	// complete delivery: the claim includes the level, so the flag must stay
+	// down and the hub must keep pushing until the level lands too.
+	s.adoptSpokeProjectConfig("claimed", "o", []string{"r"}, "r", 2)
+	if h := loadSaaSHive("claimed"); h == nil || h.ClaimDelivered || h.ACMMLevel != 3 {
+		t.Errorf("partial delivery (level not yet applied) must not flip ClaimDelivered: %+v", h)
+	}
+
+	// Spoke now reports the claim IN FULL, level included -> flips ClaimDelivered.
 	s.adoptSpokeProjectConfig("claimed", "o", []string{"r"}, "r", 3)
 	if h := loadSaaSHive("claimed"); h == nil || !h.ClaimDelivered {
 		t.Errorf("matching report should mark ClaimDelivered: %+v", h)
@@ -280,4 +293,42 @@ func TestAdoptSpokeProjectConfig(t *testing.T) {
 
 	// No record -> no panic, no-op.
 	s.adoptSpokeProjectConfig("missing", "o", []string{"r"}, "r", 4)
+}
+
+// TestProjectConfigForHiveID_PushesAssignedACMMUntilDelivered locks the push
+// half of the assigned-ACMM fix.
+//
+// #2061 removed the ACMM push entirely to stop a dashboard level change being
+// reverted every beat. That fixed the revert but meant a freshly-assigned
+// placeholder was never TOLD the level its owner requested: it kept running the
+// level it was minted at and reported it back. Bounding the push by
+// ClaimDelivered delivers the requested level exactly once, then stops forever.
+func TestProjectConfigForHiveID_PushesAssignedACMMUntilDelivered(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	// Assigned at L3; the spoke still reports the minted L2 with matching
+	// org/repos. Before the fix every non-ACMM field matched, so the reconcile
+	// returned "nothing left to push" and the level never travelled.
+	saveSaaSHive(&SaaSHive{
+		ID: "h", Status: "running", Org: "o", Repos: []string{"r"},
+		PrimaryRepo: "r", ACMMLevel: 3, ClaimDelivered: false,
+	})
+	got := projectConfigForHiveID("h", "o", []string{"r"}, "r", 2, "", "")
+	if got == nil {
+		t.Fatal("no push for an undelivered claim whose level has not landed; the hive stays at the wrong level forever")
+	}
+	if got.ACMMLevel != 3 {
+		t.Errorf("pushed ACMMLevel = %d, want the assigned 3", got.ACMMLevel)
+	}
+
+	// Once delivered, ACMM is the spoke's to own: a dashboard change to L5 must
+	// NOT be pushed back down (the spyre revert #2061 fixed).
+	saveSaaSHive(&SaaSHive{
+		ID: "d", Status: "running", Org: "o", Repos: []string{"r"},
+		PrimaryRepo: "r", ACMMLevel: 3, ClaimDelivered: true,
+	})
+	if got := projectConfigForHiveID("d", "o", []string{"r"}, "r", 5, "", ""); got != nil {
+		t.Errorf("delivered claim must never push ACMM back to the spoke, got %+v", got)
+	}
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -5382,8 +5382,22 @@ func (s *HubServer) adoptSpokeProjectConfig(hiveID, org string, repos []string, 
 	changed := false
 	prevLevel := h.ACMMLevel
 
-	// ACMM is operator-owned from the start — always adopt a non-zero level.
-	if level > 0 && level != h.ACMMLevel {
+	// ACMM follows the SAME ClaimDelivered handshake as org/repos below.
+	//
+	// #2061 made ACMM "operator-owned from the start — always adopt", which
+	// fixed the spyre revert (a dashboard level change bouncing back every
+	// beat) but left a gap on the ASSIGN path: a freshly-claimed placeholder
+	// has not yet been told its level, so it keeps reporting the level it was
+	// MINTED at (defaultAssignACMMLevel). Adopting that pre-delivery report
+	// overwrote the level the requester actually asked for — an approved L3
+	// request silently became L2 in meta.json, and the spoke stayed L2 forever
+	// because the hub then had no higher level left to push.
+	//
+	// Gating on ClaimDelivered keeps BOTH behaviours: before delivery the claim
+	// (including its level) is authoritative and a stale spoke report is
+	// ignored; after delivery the spoke's dashboard owns the level and operator
+	// edits are adopted exactly as #2061 intended.
+	if level > 0 && level != h.ACMMLevel && h.ClaimDelivered {
 		h.ACMMLevel = level
 		changed = true
 	}
@@ -5396,8 +5410,15 @@ func (s *HubServer) adoptSpokeProjectConfig(hiveID, org string, repos []string, 
 	orgMatches := org != "" && strings.EqualFold(org, h.Org)
 	reposMatch := len(repos) > 0 && sameStringSliceFold(repos, h.Repos)
 	primaryMatches := primary == "" || strings.EqualFold(primary, h.PrimaryRepo)
+	// The ACMM level is part of the claim payload, so delivery is not complete
+	// until the spoke reports THAT back too. Flipping the flag on org/repos
+	// alone declared the claim delivered while the spoke was still running the
+	// level it was minted at — which both stopped the push and handed level
+	// ownership to the spoke, permanently pinning the hive to the wrong level.
+	// A level-0 report means "too old / mid-boot to say", not a mismatch.
+	acmmMatches := level == 0 || level == h.ACMMLevel
 	if !h.ClaimDelivered {
-		if orgMatches && reposMatch && primaryMatches {
+		if orgMatches && reposMatch && primaryMatches && acmmMatches {
 			h.ClaimDelivered = true
 			changed = true
 		}
@@ -5514,15 +5535,23 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 	//     spoke first reports the assigned project). After delivery the spoke's
 	//     dashboard owns them and the caller adopts operator edits instead.
 	//   - vanity URL: pushed until the spoke first reports it back.
-	//   - ACMM level: NEVER pushed — operator-owned from the start, always
-	//     adopted by the caller. Including it here (as the old code did) made any
-	//     dashboard level change get reverted every beat (the spyre bug).
-	// curACMM is unused for the push decision (kept for signature/back-compat).
-	_ = curACMM
+	//   - ACMM level: pushed ONLY until the claim is delivered, on exactly the
+	//     same handshake as org/repos. After delivery it is never pushed again —
+	//     the spoke's dashboard owns it and the caller adopts operator edits.
+	//
+	//     #2061 removed the ACMM push entirely because pushing it FOREVER
+	//     reverted every dashboard level change (the spyre bug). But dropping it
+	//     altogether meant a freshly-assigned placeholder was never told the
+	//     level its owner requested: it kept running the level it was minted at
+	//     (defaultAssignACMMLevel), reported that back, and the hub adopted the
+	//     stale report — so an approved L3 request ran, and displayed, as L2.
+	//     Bounding the push by ClaimDelivered delivers the requested level once
+	//     without ever reverting a later operator edit.
 	needClaimPush := !h.ClaimDelivered &&
 		!(strings.EqualFold(curOrg, h.Org) &&
 			sameStringSliceFold(curRepos, h.Repos) &&
-			strings.EqualFold(curPrimary, primary))
+			strings.EqualFold(curPrimary, primary) &&
+			curACMM == h.ACMMLevel)
 	needURLPush := h.VanityURL != "" && curURL != h.VanityURL
 	// A spoke reporting a repo that fails isValidRepoRef is wedged: the hub 400s
 	// its every heartbeat ("invalid repo name"), /api/livez then fails on the

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -424,21 +424,46 @@ func effectiveGitHubAPIURL(h *SaaSHive, cluster *ClusterConfig) string {
 // cannot mint installation tokens against a github.ibm.com repo.
 //
 // Rule:
-//   - GHE hive (effectiveGitHubBaseURL != "") → the cluster's GitHubAppID (the
-//     GHE App registered on that enterprise), when the cluster names one. This
-//     overrides a public app_id that a placeholder was seeded with — the exact
-//     bug where GHE hives carried app_id 3568013 and could never write.
-//   - Otherwise (public hive, or a GHE cluster with no GHE App configured) →
-//     the request's app_id verbatim, so public hives and explicit overrides are
-//     unchanged.
+//   - The hive is explicitly pinned to PUBLIC github.com on a cluster whose App
+//     is a GitHub Enterprise one → keep the request's app_id. The cluster's App
+//     belongs to the wrong host for this hive; forcing it would break exactly
+//     the case the public pin exists to protect.
+//   - Otherwise the cluster names a GitHubAppID → use it. This now covers a
+//     public-github.com CLUSTER as well as a GHE one: the App ID is a
+//     per-GitHub-HOST constant, not per-hive state, and this field is the one
+//     place the fleet records it.
+//   - Otherwise → the request's app_id verbatim, so explicit overrides and
+//     clusters with no hub-managed App identity are unchanged.
+//
+// The public-github.com case was previously excluded (the rule required
+// effectiveGitHubBaseURL != ""), which is why every hive on the public cluster
+// provisioned with the config.PlaceholderAppID sentinel and NOTHING ever
+// replaced it: there was no configured App ID to look up, and assignment does
+// not mint one. Such a hive builds a JWT for a nonexistent App, so App auth can
+// never succeed no matter which installation_id the owner enters.
+//
+// Widening the rule rather than adding a github.com-specific branch is what
+// generalizes: a third forge (gitlab/gitea) needs only its own cluster entry
+// with a github_app_id, not another special case here.
+//
+// This does NOT hardcode an App ID. A cluster that names none still falls
+// through to the request value exactly as before.
 //
 // Returns a string (the template field is a string); sanitize() is applied to
 // any request-sourced value exactly as before.
 func resolveProvisionAppID(reqAppID string, h *SaaSHive, cluster *ClusterConfig) string {
-	if cluster != nil && cluster.GitHubAppID != 0 && effectiveGitHubBaseURL(h, cluster) != "" {
-		return strconv.FormatInt(cluster.GitHubAppID, 10)
+	if cluster == nil || cluster.GitHubAppID == 0 {
+		return sanitize(reqAppID)
 	}
-	return sanitize(reqAppID)
+	// A hive pinned to public github.com on a cluster whose own App is a GHE
+	// App: the cluster App is registered on the wrong host for this hive, so the
+	// request's public app_id stands. Detected as "the hive resolves to no GHE
+	// base URL while the cluster has one" — the same public-pin semantics
+	// effectiveGitHubBaseURL already implements.
+	if cluster.GitHubBaseURL != "" && effectiveGitHubBaseURL(h, cluster) == "" {
+		return sanitize(reqAppID)
+	}
+	return strconv.FormatInt(cluster.GitHubAppID, 10)
 }
 
 // backfillGitHubHostFromCluster returns the GitHub host a hive should inherit

--- a/v2/pkg/hub/self_upgrade.go
+++ b/v2/pkg/hub/self_upgrade.go
@@ -148,6 +148,13 @@ func imageTagIsMutable(image string) bool {
 //
 // So: patch the image when pinned, restart when mutable. Returns needsRestart
 // false when the image patch itself rolls the deployment.
+//
+// The mutable case is NOT simply "restart and hope". A restart re-pulls the
+// tag and therefore lands on whatever digest CI last published under it —
+// which is only the requested target by coincidence. Verified on the live
+// fleet: v2-latest resolved to fb37afe while the hub was targeting 07ccca1, so
+// every restart delivered the wrong build, the spoke reported fb37afe, and the
+// hub re-instructed the same upgrade forever. See upgradeSelfMutableToSHA.
 func UpgradeSelfToSHA(logger *slog.Logger, targetSHA string) (needsRestart bool, err error) {
 	current, err := selfDeploymentImage()
 	if err != nil {
@@ -159,7 +166,7 @@ func UpgradeSelfToSHA(logger *slog.Logger, targetSHA string) (needsRestart bool,
 		return true, nil
 	}
 	if imageTagIsMutable(current) {
-		return true, nil
+		return upgradeSelfMutableToSHA(logger, current, targetSHA)
 	}
 	// Pinned. Rewrite the tag in place so the registry/repo (which may be a
 	// mirror or a private registry) is preserved — only the tag changes.
@@ -178,6 +185,92 @@ func UpgradeSelfToSHA(logger *slog.Logger, targetSHA string) (needsRestart bool,
 	}
 	// SwitchImageSelf's patch changes the pod template, which rolls the
 	// deployment on its own — a restart on top would be redundant.
+	return false, nil
+}
+
+// selfUpgradeTargetAnnotation records, on the pod template, which SHA the hub
+// asked this deployment to run. It exists to make the pod template DIFFER
+// between two upgrades that both leave the image string untouched — a mutable
+// tag never changes, so without this the strategic-merge patch is a semantic
+// no-op, Kubernetes sees no change to the template, and no rollout happens at
+// all. Carrying the target (rather than a timestamp) also makes the intent
+// readable with `kubectl get deploy -o yaml` when diagnosing a stuck upgrade.
+const selfUpgradeTargetAnnotation = "hive.kubestellar.io/upgrade-target-sha"
+
+// upgradeSelfMutableToSHA advances a deployment that tracks a MUTABLE tag
+// (v2-latest and friends) onto targetSHA.
+//
+// The naive action here — a plain rollout restart — is wrong, and was the
+// systemic bug this function exists to fix. Restarting re-pulls the tag, so the
+// pod lands on the tag's CURRENT digest. That is the hub's target only if CI
+// happens not to have published since the target was chosen. When it has, the
+// spoke comes back reporting a SHA that is neither the old one nor the
+// requested one, the hub's completion check (which compares the reported
+// gitHash against upgradeTarget) never matches, and the hive sits "Upgrading"
+// forever while the hub re-instructs on every heartbeat.
+//
+// The fix keeps the floating tag — the platform's deliberate preference, which
+// came out of a self-upgrade CrashLoop incident — and makes the rollout
+// deterministic anyway, by writing the target SHA into a pod-template
+// annotation. That changes the template even though the image string does not,
+// which is what actually forces Kubernetes to roll. Combined with the
+// fleet-wide imagePullPolicy: Always, the new pod re-pulls the tag.
+//
+// This narrows but does not eliminate the race: if CI republishes the tag
+// between the hub choosing a target and the kubelet pulling, the pod still
+// lands on the newer build. That is benign and self-correcting — the hub
+// accepts "at target OR at registry-latest" as success (server.go), so an
+// overshoot completes the upgrade rather than wedging it. What it must never do
+// again is silently land on the WRONG build with no record of what was asked
+// for; the annotation is that record.
+func upgradeSelfMutableToSHA(logger *slog.Logger, current, targetSHA string) (needsRestart bool, err error) {
+	if targetSHA == "" {
+		// No target to record. Fall back to the historical behaviour rather
+		// than writing an empty annotation that would defeat the diff.
+		return true, nil
+	}
+	ns, err := os.ReadFile(k8sNamespacePath)
+	if err != nil {
+		// Not in-cluster, or the SA projection is missing. A plain restart is
+		// the safe fallback: it is what this path did before, and the caller
+		// already handles a failed restart loudly.
+		logger.Warn("could not read namespace for mutable-tag upgrade, falling back to rollout restart",
+			"error", err)
+		return true, nil
+	}
+	namespace := strings.TrimSpace(string(ns))
+	if namespace == "" {
+		logger.Warn("empty namespace for mutable-tag upgrade, falling back to rollout restart",
+			"path", k8sNamespacePath)
+		return true, nil
+	}
+
+	// Annotate the POD TEMPLATE (not the Deployment) — only template changes
+	// roll the pods. restart-at is set alongside the target so two consecutive
+	// upgrades to the SAME target still produce distinct templates; without it
+	// a retry of an identical target would itself be a no-op.
+	patch := fmt.Sprintf(
+		`{"spec":{"template":{"metadata":{"annotations":{%q:%q,"hive.kubestellar.io/restart-at":%q}}}}}`,
+		selfUpgradeTargetAnnotation, targetSHA,
+		time.Now().UTC().Format(time.RFC3339),
+	)
+	path := fmt.Sprintf("/apis/apps/v1/namespaces/%s/deployments/%s", namespace, selfUpgradeDeployName)
+	if err := k8sAPIPatch(path, []byte(patch)); err != nil {
+		// Report the failure rather than swallowing it: the caller turns a
+		// non-nil error into a recorded, hub-visible upgrade failure instead of
+		// a permanent spinner.
+		return false, fmt.Errorf("annotating mutable-tag deployment for rollout to %s: %w", targetSHA, err)
+	}
+
+	logger.Info("upgrading a mutable-tag deployment by pod-template annotation, not a bare restart",
+		"image", current,
+		"target", targetSHA,
+		"annotation", selfUpgradeTargetAnnotation,
+		"namespace", namespace,
+		"deployment", selfUpgradeDeployName,
+	)
+	// The annotation patch changes the pod template, which rolls the deployment
+	// on its own — a restart on top would be redundant.
 	return false, nil
 }
 

--- a/v2/pkg/hub/self_upgrade_coverage_test.go
+++ b/v2/pkg/hub/self_upgrade_coverage_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -197,5 +198,110 @@ func TestSwitchImageSelfNoNamespace(t *testing.T) {
 	defer func() { k8sNamespacePath = oldNS }()
 	if err := SwitchImageSelf(slog.Default(), "img"); err == nil {
 		t.Error("expected error when namespace file missing")
+	}
+}
+
+// TestUpgradeSelfMutableTagForcesRollout is the regression test for the
+// floating-tag no-op. A deployment on v2-latest used to take a bare rollout
+// restart, which re-pulls the tag and lands on whatever CI last published —
+// verified on the live fleet as fb37afe while the hub targeted 07ccca1. The
+// upgrade must instead patch the pod template with the target SHA, so the
+// rollout is forced AND the requested target is recorded on the deployment.
+func TestUpgradeSelfMutableTagForcesRollout(t *testing.T) {
+	const (
+		currentImage = "ghcr.io/kubestellar/hive:v2-latest"
+		targetSHA    = "07ccca1"
+	)
+	var patchBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			b, _ := io.ReadAll(r.Body)
+			patchBody = string(b)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"spec":{"template":{"spec":{"containers":[{"name":"hive","image":"` + currentImage + `"}]}}}}`))
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+
+	needsRestart, err := UpgradeSelfToSHA(slog.Default(), targetSHA)
+	if err != nil {
+		t.Fatalf("UpgradeSelfToSHA on a mutable tag: %v", err)
+	}
+	// The annotation patch rolls the deployment by itself; a bare restart on
+	// top would be the very no-op this fix removes.
+	if needsRestart {
+		t.Error("a mutable-tag upgrade must roll via the template patch, not a bare restart")
+	}
+	if patchBody == "" {
+		t.Fatal("expected the deployment to be patched, but no PATCH was issued")
+	}
+	if !strings.Contains(patchBody, selfUpgradeTargetAnnotation) {
+		t.Errorf("patch must carry the target annotation %q, got: %s", selfUpgradeTargetAnnotation, patchBody)
+	}
+	if !strings.Contains(patchBody, targetSHA) {
+		t.Errorf("patch must record the target SHA %q, got: %s", targetSHA, patchBody)
+	}
+	// The template, not the Deployment, must be annotated — only template
+	// changes roll pods.
+	if !strings.Contains(patchBody, `"template"`) {
+		t.Errorf("annotation must land on the POD TEMPLATE, got: %s", patchBody)
+	}
+	// The floating tag must survive: pinning the image would defeat the
+	// platform's deliberate preference for mutable tags.
+	if strings.Contains(patchBody, `"image"`) {
+		t.Errorf("a mutable-tag upgrade must NOT rewrite the image, got: %s", patchBody)
+	}
+}
+
+// TestUpgradeSelfMutableTagPatchFailureIsReported guards that a failed patch
+// surfaces as an error. Swallowing it would return needsRestart and reproduce
+// the original silent no-op.
+func TestUpgradeSelfMutableTagPatchFailureIsReported(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"forbidden"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"spec":{"template":{"spec":{"containers":[{"name":"hive","image":"ghcr.io/kubestellar/hive:v2-latest"}]}}}}`))
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+
+	if _, err := UpgradeSelfToSHA(slog.Default(), "07ccca1"); err == nil {
+		t.Fatal("a rejected patch must be reported as an error, not swallowed")
+	}
+}
+
+// TestUpgradeSelfPinnedStillPatchesImage guards that the pinned path (#2308) is
+// unchanged by the mutable-tag fix: a SHA-pinned deployment must still have its
+// image rewritten, since no annotation can move it onto new code.
+func TestUpgradeSelfPinnedStillPatchesImage(t *testing.T) {
+	var patchBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			b, _ := io.ReadAll(r.Body)
+			patchBody = string(b)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"spec":{"template":{"spec":{"containers":[{"name":"hive","image":"ghcr.io/kubestellar/hive:c11643a"}]}}}}`))
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+
+	needsRestart, err := UpgradeSelfToSHA(slog.Default(), "07ccca1")
+	if err != nil {
+		t.Fatalf("UpgradeSelfToSHA on a pinned tag: %v", err)
+	}
+	if needsRestart {
+		t.Error("a pinned upgrade rolls via the image patch")
+	}
+	if !strings.Contains(patchBody, "ghcr.io/kubestellar/hive:07ccca1") {
+		t.Errorf("pinned upgrade must rewrite the image to the target, got: %s", patchBody)
 	}
 }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -136,9 +136,17 @@ type RegistryEntry struct {
 	// UpgradeFailed records that the spoke reported an upgrade it could not
 	// complete, with the cause. Distinct from Upgrading: "failed" is a terminal
 	// state a human must see, not an in-flight one.
-	UpgradeFailed             bool         `json:"upgradeFailed,omitempty"`
-	UpgradeError              string       `json:"upgradeError,omitempty"`
-	UpgradeFailedAt           time.Time    `json:"upgradeFailedAt,omitempty"`
+	UpgradeFailed   bool      `json:"upgradeFailed,omitempty"`
+	UpgradeError    string    `json:"upgradeError,omitempty"`
+	UpgradeFailedAt time.Time `json:"upgradeFailedAt,omitempty"`
+	// OrphanedUpgradeSweeps counts how many times the orphan sweep has cleared
+	// and re-armed an upgrade for this hive without it ever landing. A spoke
+	// that cannot advance (it restarts, comes back on a SHA that is neither the
+	// old one nor the target, and goes quiet again) would otherwise be swept and
+	// re-armed forever, which looks like progress but never is. Past
+	// maxOrphanedUpgradeSweeps the hub stops retrying and records a failure a
+	// human can see. Reset whenever the hive reaches a target.
+	OrphanedUpgradeSweeps     int          `json:"orphanedUpgradeSweeps,omitempty"`
 	IssueHistory              []SparkPoint `json:"issueHistory,omitempty"`
 	PRHistory                 []SparkPoint `json:"prHistory,omitempty"`
 	GitHubAppRequired         bool         `json:"githubAppRequired,omitempty"`
@@ -1099,6 +1107,11 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				// full SHA and the target/latest was the 7-char short form.
 				entry.Upgrading = false
 				entry.UpgradeTarget = ""
+				// The upgrade landed, so any orphan-sweep retry budget spent
+				// getting here is no longer relevant. Reset it, or a hive that
+				// needed one sweep on each of three separate upgrades would be
+				// declared permanently faulty on the third.
+				entry.OrphanedUpgradeSweeps = 0
 			} else if h.Upgrading && !payload.Upgrading && h.UpgradeTarget == "" {
 				// Upgrading with no target (stale flag from config-only restart).
 				entry.Upgrading = false

--- a/v2/pkg/hub/stale_upgrade.go
+++ b/v2/pkg/hub/stale_upgrade.go
@@ -25,6 +25,25 @@ const orphanedUpgradeGrace = staleUpgradeTimeout
 // after which an upgrade with no live attempt behind it is considered orphaned.
 const orphanedUpgradeClearAfter = staleUpgradeTimeout + orphanedUpgradeGrace
 
+// maxOrphanedUpgradeSweeps bounds how many times the sweep will clear and
+// re-arm the same hive's upgrade before treating it as a genuine fault instead
+// of a transient orphan.
+//
+// #2327's sweep assumes the attempt merely went missing, so re-arming lets the
+// next heartbeat carry it again. That is right for a departed pod, but it is
+// an infinite loop for a hive that is structurally unable to advance — the
+// floating-tag case being the motivating example: the spoke restarts, re-pulls
+// its mutable tag, lands on a build that is neither its old SHA nor the target,
+// and reports in. The sweep sees "alive, not at target", clears, re-arms, and
+// the cycle repeats indefinitely with nothing ever surfacing to a human.
+//
+// Three is deliberately small. Each sweep costs at least
+// orphanedUpgradeClearAfter, so this is ~1 hour of real elapsed time at the
+// default staleUpgradeTimeout before the hub gives up — long enough to absorb a
+// genuinely slow or twice-unlucky rollout, short enough that a broken upgrade
+// path is reported the same working day rather than never.
+const maxOrphanedUpgradeSweeps = 3
+
 // upgradeAttemptEvidence describes whether a still-latched upgrade has an
 // attempt actually behind it, and if not, why we concluded that.
 type upgradeAttemptEvidence struct {
@@ -124,6 +143,10 @@ func (s *HubServer) sweepOrphanedUpgrades() {
 		from, to string
 		elapsed  time.Duration
 		reason   string
+		// exhausted marks a hive that has been swept too many times to keep
+		// retrying — reported as a fault rather than re-armed.
+		exhausted bool
+		sweeps    int
 	}
 	var swept []cleared
 
@@ -134,14 +157,35 @@ func (s *HubServer) sweepOrphanedUpgrades() {
 		if !ev.orphaned {
 			continue
 		}
+		h.OrphanedUpgradeSweeps++
+		exhausted := h.OrphanedUpgradeSweeps >= maxOrphanedUpgradeSweeps
 		swept = append(swept, cleared{
-			id:      h.ID,
-			from:    h.GitHash,
-			to:      h.UpgradeTarget,
-			elapsed: ev.elapsed,
-			reason:  ev.reason,
+			id:        h.ID,
+			from:      h.GitHash,
+			to:        h.UpgradeTarget,
+			elapsed:   ev.elapsed,
+			reason:    ev.reason,
+			exhausted: exhausted,
+			sweeps:    h.OrphanedUpgradeSweeps,
 		})
 		h.Upgrading = false
+
+		if exhausted {
+			// Stop retrying. Re-arming again would just reproduce the same
+			// no-op on the next cycle; record a terminal, human-visible failure
+			// instead, which the existing UpgradeFailed surfaces in the UI and
+			// which AlertTypeStuckUpgrade already alerts on.
+			h.UpgradeFailed = true
+			h.UpgradeError = "upgrade to " + orDash(h.UpgradeTarget) +
+				" never landed after " + itoa(h.OrphanedUpgradeSweeps) +
+				" attempts — hive is still on " + orDash(h.GitHash) +
+				". If its Deployment tracks a floating tag, the pod may be " +
+				"re-pulling that tag and landing on a build other than the target."
+			h.UpgradeFailedAt = now
+			// Drop any armed instruction so no path keeps re-delivering it.
+			delete(s.heartbeatUpgrade, h.ID)
+			continue
+		}
 
 		// Re-arm delivery rather than dropping it. Clearing the flag alone is
 		// NOT enough to make the hive upgrade again: heartbeatUpgrade is an
@@ -163,8 +207,25 @@ func (s *HubServer) sweepOrphanedUpgrades() {
 	s.mu.Unlock()
 
 	for _, c := range swept {
+		if c.exhausted {
+			s.logger.Error("upgrade repeatedly failed to land — giving up and reporting a fault",
+				"hive_id", c.id,
+				"attempts", c.sweeps,
+				"elapsed", roundedDuration(c.elapsed),
+				"from", orDash(c.from),
+				"to", orDash(c.to),
+				"reason", c.reason,
+				"hint", "check whether the spoke Deployment tracks a floating tag whose digest differs from the target SHA",
+			)
+			s.recordTimeline(c.id, TimelineUpgradeStale,
+				"upgrade to "+orDash(c.to)+" abandoned after "+itoa(c.sweeps)+
+					" attempts — hive is still on "+orDash(c.from)+
+					" and is no longer being retried", "stale-upgrade-sweep")
+			continue
+		}
 		s.logger.Warn("cleared orphaned upgrade flag — no attempt in flight",
 			"hive_id", c.id,
+			"attempt", c.sweeps,
 			"elapsed", roundedDuration(c.elapsed),
 			"from", orDash(c.from),
 			"to", orDash(c.to),

--- a/v2/pkg/hub/stale_upgrade_test.go
+++ b/v2/pkg/hub/stale_upgrade_test.go
@@ -177,3 +177,79 @@ func TestOrphanedUpgradeThresholdDerivesFromStaleUpgradeTimeout(t *testing.T) {
 			orphanedUpgradeClearAfter, want)
 	}
 }
+
+// TestSweepEscalatesAfterRepeatedFailures asserts the bounded-retry behaviour
+// that complements #2327. A hive that is structurally unable to advance — the
+// floating-tag case, where the pod re-pulls its mutable tag and lands on a
+// build that is neither the old SHA nor the target — must eventually be
+// reported as a fault instead of being cleared and re-armed forever.
+func TestSweepEscalatesAfterRepeatedFailures(t *testing.T) {
+	s := &HubServer{
+		logger:           slog.Default(),
+		heartbeatUpgrade: make(map[string]string),
+	}
+	s.registry.Hives = []RegistryEntry{{
+		ID:            "never-lands",
+		GitHash:       "c11643a",
+		UpgradeTarget: "fc32ae4",
+	}}
+
+	// Each cycle re-latches the flag exactly as a re-armed upgrade would, so
+	// the hive presents to the sweep as orphaned again every time.
+	for i := 1; i <= maxOrphanedUpgradeSweeps; i++ {
+		h := &s.registry.Hives[0]
+		h.Upgrading = true
+		h.UpgradeStartedAt = time.Now().Add(-68 * time.Minute)
+		h.LastHeartbeat = rfc3339(time.Now().Add(-30 * time.Second))
+		s.sweepOrphanedUpgrades()
+
+		if got := s.registry.Hives[0].OrphanedUpgradeSweeps; got != i {
+			t.Fatalf("after cycle %d, OrphanedUpgradeSweeps = %d, want %d", i, got, i)
+		}
+	}
+
+	h := s.registry.Hives[0]
+	if !h.UpgradeFailed {
+		t.Errorf("after %d sweeps the hive must be marked UpgradeFailed", maxOrphanedUpgradeSweeps)
+	}
+	if h.UpgradeError == "" {
+		t.Error("an exhausted upgrade must carry a human-readable cause")
+	}
+	if h.UpgradeFailedAt.IsZero() {
+		t.Error("an exhausted upgrade must record when it was abandoned")
+	}
+	if _, armed := s.heartbeatUpgrade["never-lands"]; armed {
+		t.Error("an exhausted upgrade must NOT stay armed for delivery")
+	}
+	if h.Upgrading {
+		t.Error("an exhausted upgrade must not still claim to be in flight")
+	}
+}
+
+// TestSweepBelowBudgetStillReArms guards that escalation does not fire early:
+// under the budget the #2327 behaviour (clear AND re-arm) must be preserved
+// unchanged, with no failure recorded.
+func TestSweepBelowBudgetStillReArms(t *testing.T) {
+	s := &HubServer{
+		logger:           slog.Default(),
+		heartbeatUpgrade: make(map[string]string),
+	}
+	s.registry.Hives = []RegistryEntry{{
+		ID:               "first-orphan",
+		Upgrading:        true,
+		UpgradeStartedAt: time.Now().Add(-68 * time.Minute),
+		GitHash:          "c11643a",
+		UpgradeTarget:    "fc32ae4",
+		LastHeartbeat:    rfc3339(time.Now().Add(-30 * time.Second)),
+	}}
+
+	s.sweepOrphanedUpgrades()
+
+	h := s.registry.Hives[0]
+	if h.UpgradeFailed {
+		t.Error("a single orphan sweep must not mark the hive failed")
+	}
+	if got := s.heartbeatUpgrade["first-orphan"]; got != "fc32ae4" {
+		t.Errorf("below the budget the upgrade must still be re-armed, got %q", got)
+	}
+}


### PR DESCRIPTION
Top-up. Two commits landed on `v2` during CI for #2339.

Brings `dd` to `origin/v2` @ `681a8fd6`:
- #2337 — roll floating-tag spokes onto the requested SHA
- #2333 — apply requested ACMM level and a real app_id on placeholder assignment

Merged with **no conflicts**. `go build ./...` clean; `pkg/hub` stale/upgrade/ACMM tests pass.

> [!IMPORTANT]
> Merge with `--merge`, **not** `--squash`.