### PR TITLE
🔀 sync: v2 → dd (top-up #2338, #2340, #2344 +)

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -348,9 +348,26 @@ type AgentConfig struct {
 	// Paused persists an operator pause across restarts/upgrades. Without
 	// this, every pod restart rebuilt agents un-paused (Go zero value), so
 	// an operator pause was silently undone on the next upgrade.
-	Paused          bool   `yaml:"paused" json:"paused,omitempty"`
-	ClearOnKick     bool   `yaml:"clear_on_kick" json:"clear_on_kick"`
-	CLIPinned       bool   `yaml:"cli_pinned" json:"cli_pinned,omitempty"`
+	Paused      bool `yaml:"paused" json:"paused,omitempty"`
+	ClearOnKick bool `yaml:"clear_on_kick" json:"clear_on_kick"`
+	CLIPinned   bool `yaml:"cli_pinned" json:"cli_pinned,omitempty"`
+
+	// ModelOwner / BackendOwner record WHO last set Model / Backend. An ACMM
+	// pack owns these fields until an operator changes them in the Governor
+	// grid; from that point the operator owns them and ApplyPack must not
+	// reconcile them back to the pack value.
+	//
+	// Without this, a pack re-apply — which happens on EVERY hive restart
+	// (cmd/hive/main.go "merging pack updates") — rewrote Model back to the
+	// pack default, so an operator's model choice silently reverted on the
+	// next restart. That is the "I've deleted those 4 times, they always come
+	// back" report: the revert was a restart, not a propagation delay.
+	//
+	// Stored as a string owner rather than a bool so "never set" (empty),
+	// "pack-owned" and "operator-owned" stay distinguishable across upgrades
+	// of hives whose config predates this field.
+	ModelOwner      string `yaml:"model_owner" json:"model_owner,omitempty"`
+	BackendOwner    string `yaml:"backend_owner" json:"backend_owner,omitempty"`
 	StaleTimeout    int    `yaml:"stale_timeout" json:"stale_timeout,omitempty"`
 	RestartStrategy string `yaml:"restart_strategy" json:"restart_strategy,omitempty"`
 	LaunchCmd       string `yaml:"launch_cmd" json:"launch_cmd,omitempty"`
@@ -496,6 +513,28 @@ func (a *AgentConfig) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
+// Ownership markers for AgentConfig.ModelOwner / BackendOwner.
+const (
+	// FieldOwnerPack marks a value written by an ACMM pack. Pack-owned values
+	// are reconciled to the current pack on every apply.
+	FieldOwnerPack = "pack"
+	// FieldOwnerOperator marks a value an operator chose in the Governor grid.
+	// Operator-owned values are never overwritten by a pack apply.
+	FieldOwnerOperator = "operator"
+)
+
+// ModelIsOperatorOwned reports whether an operator explicitly chose this
+// agent's model, which makes it immune to pack reconciliation.
+func (a AgentConfig) ModelIsOperatorOwned() bool {
+	return a.ModelOwner == FieldOwnerOperator
+}
+
+// BackendIsOperatorOwned reports whether an operator explicitly chose this
+// agent's backend (the grid's "method" column).
+func (a AgentConfig) BackendIsOperatorOwned() bool {
+	return a.BackendOwner == FieldOwnerOperator
+}
+
 // EnabledExplicitlySet returns true when the user's YAML explicitly set the
 // "enabled" field (allowing us to distinguish "not specified" from "enabled: false").
 func (a *AgentConfig) EnabledExplicitlySet() bool {
@@ -516,8 +555,8 @@ type GovernorConfig struct {
 	// Bob holds the IBM bobshell CLI backend's API-key location. Required for
 	// agents with backend "bob": bobshell's browser SSO flow cannot complete in
 	// a headless pod.
-	Bob BobConfig `yaml:"bob"`
-	Trajectory    TrajectoryConfig      `yaml:"trajectory"`
+	Bob        BobConfig        `yaml:"bob"`
+	Trajectory TrajectoryConfig `yaml:"trajectory"`
 	// Gateways is the list of named model gateways (OpenAI-compatible endpoints
 	// like OpenRouter, a LiteLLM proxy, vLLM, or llm-d). An agent routes through
 	// a gateway by naming it as its backend. When empty, a single implicit

--- a/v2/pkg/dashboard/agent_model_ownership_test.go
+++ b/v2/pkg/dashboard/agent_model_ownership_test.go
@@ -1,0 +1,227 @@
+package dashboard
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// enableScanner mirrors production, where every agent defaults to enabled
+// (config.applyDefaults); the shared fixture leaves the field at its zero value.
+func enableScanner(t *testing.T, srv *Server) {
+	t.Helper()
+	sc := srv.deps.Config.Agents["scanner"]
+	sc.Enabled = true
+	srv.deps.Config.Agents["scanner"] = sc
+}
+
+// TestApplyPackPreservesOperatorModel is the regression test for the reported
+// bug: an operator sets a model in the Governor grid, and it reverts to the
+// pack's model. ApplyPack runs on EVERY hive restart ("merging pack updates"),
+// and it used to replace Model on diff unconditionally — so the operator's
+// choice came back as the pack default every restart.
+func TestApplyPackPreservesOperatorModel(t *testing.T) {
+	srv := newFullServer(t)
+	enableScanner(t, srv)
+	if _, err := srv.ApplyPack(3); err != nil {
+		t.Fatalf("ApplyPack(3): %v", err)
+	}
+
+	packModel := srv.deps.Config.Agents["scanner"].Model
+	if packModel == "" {
+		t.Fatal("precondition: pack should have set a model")
+	}
+
+	// Operator picks a different model in the grid.
+	const operatorModel = "some-other-model"
+	srv.claimAgentFieldOwnership("scanner", operatorModel, "")
+
+	// Restart: the pack is re-applied.
+	if _, err := srv.ApplyPack(3); err != nil {
+		t.Fatalf("ApplyPack(3) re-apply: %v", err)
+	}
+
+	if got := srv.deps.Config.Agents["scanner"].Model; got != operatorModel {
+		t.Errorf("operator model reverted: got %q, want %q (pack model %q)", got, operatorModel, packModel)
+	}
+
+	// And it must keep surviving repeated restarts — the user reported four.
+	for i := 0; i < 4; i++ {
+		if _, err := srv.ApplyPack(3); err != nil {
+			t.Fatalf("ApplyPack(3) restart %d: %v", i, err)
+		}
+	}
+	if got := srv.deps.Config.Agents["scanner"].Model; got != operatorModel {
+		t.Errorf("operator model reverted after repeated restarts: got %q, want %q", got, operatorModel)
+	}
+}
+
+// TestApplyPackPreservesOperatorBackend covers the grid's "method" column.
+func TestApplyPackPreservesOperatorBackend(t *testing.T) {
+	srv := newFullServer(t)
+	enableScanner(t, srv)
+	if _, err := srv.ApplyPack(3); err != nil {
+		t.Fatalf("ApplyPack(3): %v", err)
+	}
+
+	const operatorBackend = "claude"
+	srv.claimAgentFieldOwnership("scanner", "", operatorBackend)
+
+	if _, err := srv.ApplyPack(3); err != nil {
+		t.Fatalf("ApplyPack(3) re-apply: %v", err)
+	}
+
+	if got := srv.deps.Config.Agents["scanner"].Backend; got != operatorBackend {
+		t.Errorf("operator backend reverted: got %q, want %q", got, operatorBackend)
+	}
+}
+
+// TestApplyPackStillReconcilesPackOwnedModel guards the other direction: a
+// model the operator never touched must still follow the pack across a level
+// change, otherwise agents keep behaving at their old level.
+func TestApplyPackStillReconcilesPackOwnedModel(t *testing.T) {
+	srv := newFullServer(t)
+	enableScanner(t, srv)
+	if _, err := srv.ApplyPack(3); err != nil {
+		t.Fatalf("ApplyPack(3): %v", err)
+	}
+
+	// Force a stale pack-owned value, as a previous level's pack would leave.
+	sc := srv.deps.Config.Agents["scanner"]
+	sc.Model = "stale-previous-level-model"
+	sc.ModelOwner = config.FieldOwnerPack
+	srv.deps.Config.Agents["scanner"] = sc
+
+	if _, err := srv.ApplyPack(3); err != nil {
+		t.Fatalf("ApplyPack(3) re-apply: %v", err)
+	}
+
+	if got := srv.deps.Config.Agents["scanner"].Model; got == "stale-previous-level-model" {
+		t.Error("pack-owned model was not reconciled to the pack value")
+	}
+}
+
+// TestClaimAgentFieldOwnershipMarksOwner verifies the ownership markers, which
+// are what make the preservation above durable across a restart.
+func TestClaimAgentFieldOwnershipMarksOwner(t *testing.T) {
+	srv := newFullServer(t)
+	enableScanner(t, srv)
+
+	srv.claimAgentFieldOwnership("scanner", "m1", "b1")
+	ac := srv.deps.Config.Agents["scanner"]
+
+	if !ac.ModelIsOperatorOwned() {
+		t.Errorf("ModelOwner = %q, want %q", ac.ModelOwner, config.FieldOwnerOperator)
+	}
+	if !ac.BackendIsOperatorOwned() {
+		t.Errorf("BackendOwner = %q, want %q", ac.BackendOwner, config.FieldOwnerOperator)
+	}
+	if ac.Model != "m1" || ac.Backend != "b1" {
+		t.Errorf("values not written: model=%q backend=%q", ac.Model, ac.Backend)
+	}
+}
+
+// TestClaimAgentFieldOwnershipPartial checks that an empty argument leaves the
+// other field (and its owner) untouched.
+func TestClaimAgentFieldOwnershipPartial(t *testing.T) {
+	srv := newFullServer(t)
+	enableScanner(t, srv)
+	before := srv.deps.Config.Agents["scanner"].Backend
+
+	srv.claimAgentFieldOwnership("scanner", "only-model", "")
+	ac := srv.deps.Config.Agents["scanner"]
+
+	if ac.Backend != before {
+		t.Errorf("backend changed: got %q, want %q", ac.Backend, before)
+	}
+	if ac.BackendOwner != "" {
+		t.Errorf("BackendOwner claimed unexpectedly: %q", ac.BackendOwner)
+	}
+	if !ac.ModelIsOperatorOwned() {
+		t.Error("ModelOwner not claimed")
+	}
+}
+
+// TestPinClaimsOwnership verifies a pin is durable, not decorative: pinning a
+// model must make the field operator-owned so the pack cannot reconcile it.
+func TestPinClaimsOwnership(t *testing.T) {
+	srv := newFullServer(t)
+	enableScanner(t, srv)
+	if _, err := srv.ApplyPack(3); err != nil {
+		t.Fatalf("ApplyPack(3): %v", err)
+	}
+
+	const pinned = "pinned-model"
+	req := httptest.NewRequest("POST", "/api/agents/scanner/pin/model", nil)
+	req.SetPathValue("agent", "scanner")
+	req.SetPathValue("dimension", "model")
+	w := httptest.NewRecorder()
+	srv.handlePin(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("handlePin: %d %s", w.Code, w.Body.String())
+	}
+	// With no body the handler pins the CURRENT effective value; either way the
+	// field must now be operator-owned so a pack apply cannot move it.
+	if !srv.deps.Config.Agents["scanner"].ModelIsOperatorOwned() {
+		t.Error("pin did not claim operator ownership — pin is decorative")
+	}
+
+	pinnedValue := srv.deps.Config.Agents["scanner"].Model
+	if _, err := srv.ApplyPack(3); err != nil {
+		t.Fatalf("ApplyPack after pin: %v", err)
+	}
+	if got := srv.deps.Config.Agents["scanner"].Model; got != pinnedValue {
+		t.Errorf("pinned model changed across pack apply: got %q, want %q", got, pinnedValue)
+	}
+	_ = pinned
+}
+
+// TestValidateModelForAgentAllowsUnverifiable ensures validation never blocks
+// on a cold cache: an unverifiable model is allowed, not rejected.
+func TestValidateModelForAgentAllowsUnverifiable(t *testing.T) {
+	srv := newFullServer(t)
+	enableScanner(t, srv)
+	if err := srv.validateModelForAgent("scanner", "anything-at-all"); err != nil {
+		t.Errorf("cold cache should not reject: %v", err)
+	}
+}
+
+// TestValidateModelForAgentRejectsUnavailable is the legibility guarantee: a
+// model the backend does not offer produces an explicit error instead of being
+// stored and silently falling back at launch.
+func TestValidateModelForAgentRejectsUnavailable(t *testing.T) {
+	srv := newFullServer(t)
+	enableScanner(t, srv)
+
+	backend := srv.deps.Config.Agents["scanner"].Backend
+	srv.cliModels.set(backend, cliModelResult{models: []string{"real-a", "real-b"}, fallback: false})
+
+	err := srv.validateModelForAgent("scanner", "not-a-real-model")
+	if err == nil {
+		t.Fatal("expected an error for an unavailable model")
+	}
+	if !contains([]string{"real-a", "real-b"}, "real-a") {
+		t.Fatal("fixture sanity")
+	}
+	t.Logf("legible error: %v", err)
+
+	if err := srv.validateModelForAgent("scanner", "real-a"); err != nil {
+		t.Errorf("available model rejected: %v", err)
+	}
+}
+
+// TestValidateModelForAgentIgnoresFallbackList verifies the static fallback
+// list is not used to reject, since it is a maintained guess.
+func TestValidateModelForAgentIgnoresFallbackList(t *testing.T) {
+	srv := newFullServer(t)
+	enableScanner(t, srv)
+
+	backend := srv.deps.Config.Agents["scanner"].Backend
+	srv.cliModels.set(backend, cliModelResult{models: []string{"only-this"}, fallback: true})
+
+	if err := srv.validateModelForAgent("scanner", "something-else"); err != nil {
+		t.Errorf("fallback list must not reject: %v", err)
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1025,6 +1025,77 @@ func (s *Server) handleKick(w http.ResponseWriter, r *http.Request) {
 	okResponse(w, map[string]string{"status": "kicked", "agent": name})
 }
 
+// claimAgentFieldOwnership writes an operator's model and/or backend choice
+// into hive.yaml and marks those fields operator-owned. Empty arguments leave
+// the corresponding field untouched.
+//
+// This is the durability half of the model/method revert fix. The in-memory
+// ModelOverride/BackendOverride on the agent process is replayed from
+// /data/hive-state.json on restart, but hive.yaml still carried the PACK's
+// model — and ApplyPack re-reconciles from the pack on every restart. Writing
+// the operator's value to the same layer the pack writes, plus an ownership
+// marker, is what makes the choice actually survive.
+func (s *Server) claimAgentFieldOwnership(name, model, backend string) {
+	if s.deps == nil || s.deps.Config == nil {
+		return
+	}
+	ac, ok := s.deps.Config.Agents[name]
+	if !ok {
+		return
+	}
+	if model != "" {
+		ac.Model = model
+		ac.ModelOwner = config.FieldOwnerOperator
+	}
+	if backend != "" {
+		ac.Backend = backend
+		ac.BackendOwner = config.FieldOwnerOperator
+	}
+	s.deps.Config.Agents[name] = ac
+	_ = s.deps.AgentMgr.UpdateConfig(name, ac)
+	if err := s.saveConfig(); err != nil {
+		s.deps.Logger.Error("failed to persist agent model/method choice", "agent", name, "error", err)
+		s.AddSystemAlert("agent-field-save-failed", "error",
+			"Could not save the model/method choice for "+name+" — it will revert on the next restart: "+err.Error())
+		return
+	}
+	s.ClearSystemAlert("agent-field-save-failed")
+}
+
+// validateModelForAgent rejects a model the agent's effective backend does not
+// offer, so an unhonorable choice surfaces as a 400 the operator can see
+// instead of silently degrading to a default at launch time.
+//
+// Backends whose model list cannot be enumerated (no reachable endpoint, or a
+// backend that accepts free-form model ids) are allowed through: refusing a
+// value we simply cannot verify would block legitimate configurations.
+func (s *Server) validateModelForAgent(name, model string) error {
+	if model == "" {
+		return fmt.Errorf("model must not be empty")
+	}
+	proc, err := s.deps.AgentMgr.GetStatus(name)
+	if err != nil || proc == nil {
+		// Agent lookup failures are reported by the caller's SetModelOverride.
+		return nil
+	}
+	backend := proc.Config.Backend
+	if proc.BackendOverride != "" {
+		backend = proc.BackendOverride
+	}
+
+	known := s.modelIDsForBackend(backend)
+	if len(known) == 0 {
+		return nil // cannot enumerate — do not block
+	}
+	for _, id := range known {
+		if id == model {
+			return nil
+		}
+	}
+	return fmt.Errorf("model %q is not available for backend %q (available: %s)",
+		model, backend, strings.Join(known, ", "))
+}
+
 func (s *Server) handleSwitch(w http.ResponseWriter, r *http.Request) {
 	name := s.resolveAgentParam(r.PathValue("agent"))
 	backend := sanitizeString(r.PathValue("backend"))
@@ -1033,6 +1104,10 @@ func (s *Server) handleSwitch(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+
+	// Persist to hive.yaml and mark the field operator-owned so the next pack
+	// apply (which runs on every restart) does not reconcile it away.
+	s.claimAgentFieldOwnership(name, "", backend)
 
 	s.deps.Logger.Info("audit: backend switched", "agent", name, "backend", backend, "trigger", "dashboard-api")
 	s.auditFromRequest(r, "switch_backend", auditDetail("backend", backend), name)
@@ -1050,10 +1125,23 @@ func (s *Server) handleModelSet(w http.ResponseWriter, r *http.Request) {
 	name := s.resolveAgentParam(r.PathValue("agent"))
 	model := sanitizeString(r.PathValue("model"))
 
+	// Reject a model the effective backend cannot serve BEFORE storing it.
+	// Silently accepting an unusable value and then falling back at launch is
+	// what made this class of bug invisible: the grid showed the choice, the
+	// agent ran on something else, and the value appeared to "revert".
+	if err := s.validateModelForAgent(name, model); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	if err := s.deps.AgentMgr.SetModelOverride(name, model); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+
+	// Persist to hive.yaml and mark the field operator-owned so the next pack
+	// apply (which runs on every restart) does not reconcile it away.
+	s.claimAgentFieldOwnership(name, model, "")
 
 	s.deps.Logger.Info("audit: model set", "agent", name, "model", model, "trigger", "dashboard-api")
 	s.auditFromRequest(r, "set_model", auditDetail("model", model), name)
@@ -1138,6 +1226,18 @@ func (s *Server) handlePin(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
+	}
+
+	// A pin is a stronger statement of intent than a plain switch, so it must
+	// at least be as durable. Previously a pin lived only on the agent process
+	// (replayed from /data/hive-state.json) while hive.yaml kept the pack's
+	// value, so the pin did not protect the field from the pack re-apply that
+	// runs on every restart — the pin icon was effectively decorative.
+	switch dimension {
+	case "model":
+		s.claimAgentFieldOwnership(name, body.Value, "")
+	case "cli":
+		s.claimAgentFieldOwnership(name, "", body.Value)
 	}
 
 	s.deps.Logger.Info("audit: agent pinned", "agent", name, "dimension", dimension, "value", body.Value, "trigger", "dashboard-api")
@@ -2402,15 +2502,19 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 	// way the card dropdowns do (SetModelOverride + restart) — otherwise a stale
 	// live override would mask the freshly-saved value and it still wouldn't stick.
 	modelChanged, backendChanged := false, false
+	// Both are operator edits, so they claim ownership of the field — without
+	// the marker the next pack apply (every restart) reconciles them away.
 	if v, ok := body["model"]; ok {
 		if str, ok := v.(string); ok {
 			agentCfg.Model = sanitizeString(str)
+			agentCfg.ModelOwner = config.FieldOwnerOperator
 			modelChanged = true
 		}
 	}
 	if v, ok := body["cliPinValue"]; ok {
 		if str, ok := v.(string); ok && str != "" {
 			agentCfg.Backend = sanitizeString(str)
+			agentCfg.BackendOwner = config.FieldOwnerOperator
 			backendChanged = true
 		}
 	}
@@ -2659,11 +2763,15 @@ func (s *Server) handleAgentConfigModels(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Operator edits claim ownership so the pack apply that runs on every
+	// restart cannot reconcile the choice back to the pack default.
 	if body.Backend != "" {
 		agentCfg.Backend = sanitizeString(body.Backend)
+		agentCfg.BackendOwner = config.FieldOwnerOperator
 	}
 	if body.Model != "" {
 		agentCfg.Model = sanitizeString(body.Model)
+		agentCfg.ModelOwner = config.FieldOwnerOperator
 	}
 	s.deps.Config.Agents[name] = agentCfg
 

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -91,9 +91,15 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 			// templates and models even though acmm_level had moved up. Reconcile
 			// these replace-on-diff (kick_template and mode already did; model,
 			// description, role, bead_role, display_name did NOT — that gap is the
-			// bug). Genuine per-agent overrides belong in the explicit override
-			// fields (BackendOverride, ModelOverride, pins), which live on the
-			// agent process and are NOT touched here.
+			// bug).
+			//
+			// Model/Backend are the exception: an operator sets them from the
+			// Governor grid, so they carry an ownership marker and are reconciled
+			// only while still pack-owned (see below). The in-memory
+			// ModelOverride/BackendOverride on the agent process are NOT a
+			// durable home for that choice — they are replayed from
+			// /data/hive-state.json, while hive.yaml (which this writes) is what
+			// the pack re-reads on the next restart.
 			if pa.KickTemplate != "" && existing.KickTemplate != pa.KickTemplate {
 				existing.KickTemplate = pa.KickTemplate
 				changed = true
@@ -102,8 +108,16 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 				existing.Mode = pa.Mode
 				changed = true
 			}
-			if pa.Model != "" && existing.Model != pa.Model {
+			// Model is reconciled to the pack ONLY while the pack still owns
+			// it. Once an operator picks a model in the Governor grid the
+			// field becomes operator-owned and the pack must leave it alone:
+			// ApplyPack runs on every restart ("merging pack updates"), so an
+			// unconditional replace-on-diff here silently reverted the
+			// operator's choice on the next pod restart — repeatedly, which is
+			// exactly the reported "they always come back".
+			if pa.Model != "" && existing.Model != pa.Model && !existing.ModelIsOperatorOwned() {
 				existing.Model = pa.Model
+				existing.ModelOwner = config.FieldOwnerPack
 				changed = true
 			}
 			if pa.Description != "" && existing.Description != pa.Description {
@@ -126,8 +140,9 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 			// Backend is fill-if-empty: it never varies by level (always the same
 			// per agent across all packs), and users legitimately pin it, so the
 			// pack must not stomp a user's choice.
-			if existing.Backend == "" && pa.Backend != "" {
+			if existing.Backend == "" && pa.Backend != "" && !existing.BackendIsOperatorOwned() {
 				existing.Backend = pa.Backend
+				existing.BackendOwner = config.FieldOwnerPack
 				changed = true
 			}
 
@@ -144,8 +159,12 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 
 		includeRepos := pa.IncludeRepos
 		agentCfg := config.AgentConfig{
-			Backend:      pa.Backend,
-			Model:        pa.Model,
+			Backend: pa.Backend,
+			Model:   pa.Model,
+			// A freshly created agent's model/backend come from the pack, so
+			// the pack owns them until an operator overrides in the grid.
+			ModelOwner:   config.FieldOwnerPack,
+			BackendOwner: config.FieldOwnerPack,
 			Enabled:      true,
 			DisplayName:  pa.DisplayName,
 			Description:  pa.Description,

--- a/v2/pkg/dashboard/cli_models.go
+++ b/v2/pkg/dashboard/cli_models.go
@@ -319,6 +319,26 @@ func (c *cliModelCache) set(backend string, r cliModelResult) {
 // gemini, goose), running the backend's best-effort discovery probe (cached)
 // and falling back to a current static list on any failure. It never errors
 // and never returns an empty list.
+// modelIDsForBackend returns the known model ids for a backend WITHOUT issuing
+// a discovery probe: it uses only the already-populated cache. Validation runs
+// on the request path, so a cold cache must not block the operator behind a
+// network round-trip — an empty result means "cannot verify", and callers let
+// the value through rather than rejecting something that may be valid.
+//
+// A fallback (static) list is also treated as unverifiable: it is a maintained
+// guess, not the backend's authoritative inventory, and rejecting against it
+// would block legitimately available models.
+func (s *Server) modelIDsForBackend(backend string) []string {
+	if s.cliModels == nil || backend == "" {
+		return nil
+	}
+	r, ok := s.cliModels.get(backend)
+	if !ok || r.fallback {
+		return nil
+	}
+	return append([]string(nil), (r.models)...)
+}
+
 func (s *Server) queryCLIModels(backend string) cliModelResult {
 	if s.cliModels != nil {
 		if r, ok := s.cliModels.get(backend); ok {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2687,6 +2687,77 @@
     </div>
   </div>
 
+  <div id="nous-section" style="display:none; margin-top: 16px; margin-bottom: 24px;">
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('nous-section')"><span class="section-chevron">▼</span> 🧪 Strategy Lab <span id="nous-mode-badge" style="font-size:0.75rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span> <button onclick="event.stopPropagation();openNousConfig()" style="background:none;border:none;cursor:pointer;font-size:1rem;color:var(--muted);margin-left:6px;padding:2px" title="Strategy Lab Configuration">⚙️</button></h2>
+    <div class="section-body">
+      <div id="nous-panel"></div>
+      <div id="nous-config-overlay" class="nous-config-overlay" style="display:none"></div>
+    </div>
+  </div>
+
+  <div id="inception-section" style="margin-top: 16px; margin-bottom: 24px;">
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('inception-section')"><span class="section-chevron">▼</span> 💡 Project Inception</h2>
+    <div class="section-body">
+      <div id="inception-panel" style="height:min(800px,70vh);overflow-y:auto;overflow-x:hidden;"></div>
+    </div>
+  </div>
+
+  <div id="knowledge-section" style="margin-top: 16px; margin-bottom: 24px;">
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('knowledge-section')"><span class="section-chevron">▼</span> 📚 Knowledge Base <span id="kb-status-badge" style="font-size:0.7rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span></h2>
+    <div class="section-body">
+      <div id="knowledge-panel"></div>
+    </div>
+  </div>
+
+  <div id="contributors-section" style="margin-top: 16px; margin-bottom: 24px;">
+    <div style="display:flex;align-items:center;gap:12px;margin-bottom:12px;flex-wrap:wrap" class="section-header-toggle" onclick="toggleSection('contributors-section')">
+      <span class="section-chevron">▼</span>
+      <h2 class="section-label" style="margin:0;">👥 Contributors <span id="contributors-status-badge" style="font-size:0.7rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span></h2>
+      <a href="/contribute" target="_blank" onclick="event.stopPropagation()" style="font-size:0.75rem;padding:4px 12px;background:var(--green);color:var(--bg);border-radius:6px;text-decoration:none;font-weight:600">Share /contribute link &rarr;</a>
+      <a href="/leaderboard" target="_blank" onclick="event.stopPropagation()" style="font-size:0.75rem;padding:4px 12px;background:transparent;color:var(--blue);border:1px solid var(--blue);border-radius:6px;text-decoration:none">🏆 Leaderboard</a>
+    </div>
+    <div class="section-body">
+      <div id="contributors-filters" style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:12px"></div>
+      <div id="contributors-panel"></div>
+    </div>
+  </div>
+
+  </div>
+
+  <div id="debug-section" style="margin-top: 16px; margin-bottom: 24px;">
+    <h2 style="margin-bottom: 12px;" class="section-label section-header-toggle" onclick="toggleSection('debug-section')"><span class="section-chevron">▼</span> 🔍 System Diagnostics</h2>
+    <div class="section-body">
+      <div id="debug-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 12px;"></div>
+    </div>
+  </div>
+
+  <div id="logs-section" style="display: none; margin-top: 16px; margin-bottom: 24px;">
+    <h2 style="margin-bottom: 12px;" class="section-label section-header-toggle" onclick="toggleSection('logs-section')"><span class="section-chevron">▼</span> 📋 Agent Logs</h2>
+    <div class="section-body">
+      <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 10px;">
+        <select id="logs-agent-select" style="padding: 6px 12px; border: 1px solid var(--border); border-radius: 6px; font-size: 0.82rem; background: var(--surface); color: var(--text); cursor: pointer;" title="Filter logs to a specific agent or view all agents combined">
+          <option value="all">All Agents</option>
+        </select>
+        <label style="display: flex; align-items: center; gap: 4px; font-size: 0.78rem; color: var(--muted); cursor: pointer;" title="When enabled, the log output auto-scrolls to show the most recent entries as they arrive">
+          <input type="checkbox" id="logs-follow" checked> Follow
+        </label>
+      </div>
+      <div id="logs-output" style="font-size: 0.75rem; line-height: 1.5; padding: 14px; max-height: 500px; overflow-y: auto; white-space: pre-wrap; word-break: break-all;"></div>
+    </div>
+  </div>
+
+  <div id="oc-gov-strip-outer" class="oc-gov-strip"></div>
+  <div id="oc-agent-detail" class="oc-agent-detail"></div>
+  <div id="agents-section">
+    <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
+      <h2 style="margin:0; cursor:pointer" class="section-label section-header-toggle" onclick="toggleSection('agents-section')"><span class="section-chevron">▼</span> Agents</h2>
+      <button id="agents-compact-all-btn" onclick="event.stopPropagation();toggleAllAgentsCompact()" style="font-size:0.7rem;padding:2px 10px;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer" title="Toggle all agent cards between compact and expanded view"></button>
+    </div>
+    <div class="section-body">
+      <div class="agents" id="agents"></div>
+    </div>
+  </div>
+
   <!-- FAQ — intentionally NOT ACMM-gated (no entry in applyACMMVisibility's
        sidebarItems list and no display:none default), because the audience for
        it is a confused L1/L2 user. Static content only: no JS, no fetch. -->
@@ -2959,77 +3030,6 @@
         </ol>
 
       </div>
-    </div>
-  </div>
-
-  <div id="nous-section" style="display:none; margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('nous-section')"><span class="section-chevron">▼</span> 🧪 Strategy Lab <span id="nous-mode-badge" style="font-size:0.75rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span> <button onclick="event.stopPropagation();openNousConfig()" style="background:none;border:none;cursor:pointer;font-size:1rem;color:var(--muted);margin-left:6px;padding:2px" title="Strategy Lab Configuration">⚙️</button></h2>
-    <div class="section-body">
-      <div id="nous-panel"></div>
-      <div id="nous-config-overlay" class="nous-config-overlay" style="display:none"></div>
-    </div>
-  </div>
-
-  <div id="inception-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('inception-section')"><span class="section-chevron">▼</span> 💡 Project Inception</h2>
-    <div class="section-body">
-      <div id="inception-panel" style="height:min(800px,70vh);overflow-y:auto;overflow-x:hidden;"></div>
-    </div>
-  </div>
-
-  <div id="knowledge-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('knowledge-section')"><span class="section-chevron">▼</span> 📚 Knowledge Base <span id="kb-status-badge" style="font-size:0.7rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span></h2>
-    <div class="section-body">
-      <div id="knowledge-panel"></div>
-    </div>
-  </div>
-
-  <div id="contributors-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <div style="display:flex;align-items:center;gap:12px;margin-bottom:12px;flex-wrap:wrap" class="section-header-toggle" onclick="toggleSection('contributors-section')">
-      <span class="section-chevron">▼</span>
-      <h2 class="section-label" style="margin:0;">👥 Contributors <span id="contributors-status-badge" style="font-size:0.7rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span></h2>
-      <a href="/contribute" target="_blank" onclick="event.stopPropagation()" style="font-size:0.75rem;padding:4px 12px;background:var(--green);color:var(--bg);border-radius:6px;text-decoration:none;font-weight:600">Share /contribute link &rarr;</a>
-      <a href="/leaderboard" target="_blank" onclick="event.stopPropagation()" style="font-size:0.75rem;padding:4px 12px;background:transparent;color:var(--blue);border:1px solid var(--blue);border-radius:6px;text-decoration:none">🏆 Leaderboard</a>
-    </div>
-    <div class="section-body">
-      <div id="contributors-filters" style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:12px"></div>
-      <div id="contributors-panel"></div>
-    </div>
-  </div>
-
-  </div>
-
-  <div id="debug-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="margin-bottom: 12px;" class="section-label section-header-toggle" onclick="toggleSection('debug-section')"><span class="section-chevron">▼</span> 🔍 System Diagnostics</h2>
-    <div class="section-body">
-      <div id="debug-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 12px;"></div>
-    </div>
-  </div>
-
-  <div id="logs-section" style="display: none; margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="margin-bottom: 12px;" class="section-label section-header-toggle" onclick="toggleSection('logs-section')"><span class="section-chevron">▼</span> 📋 Agent Logs</h2>
-    <div class="section-body">
-      <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 10px;">
-        <select id="logs-agent-select" style="padding: 6px 12px; border: 1px solid var(--border); border-radius: 6px; font-size: 0.82rem; background: var(--surface); color: var(--text); cursor: pointer;" title="Filter logs to a specific agent or view all agents combined">
-          <option value="all">All Agents</option>
-        </select>
-        <label style="display: flex; align-items: center; gap: 4px; font-size: 0.78rem; color: var(--muted); cursor: pointer;" title="When enabled, the log output auto-scrolls to show the most recent entries as they arrive">
-          <input type="checkbox" id="logs-follow" checked> Follow
-        </label>
-      </div>
-      <div id="logs-output" style="font-size: 0.75rem; line-height: 1.5; padding: 14px; max-height: 500px; overflow-y: auto; white-space: pre-wrap; word-break: break-all;"></div>
-    </div>
-  </div>
-
-  <div id="oc-gov-strip-outer" class="oc-gov-strip"></div>
-  <div id="oc-agent-detail" class="oc-agent-detail"></div>
-  <div id="agents-section">
-    <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-      <h2 style="margin:0; cursor:pointer" class="section-label section-header-toggle" onclick="toggleSection('agents-section')"><span class="section-chevron">▼</span> Agents</h2>
-      <button id="agents-compact-all-btn" onclick="event.stopPropagation();toggleAllAgentsCompact()" style="font-size:0.7rem;padding:2px 10px;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer" title="Toggle all agent cards between compact and expanded view"></button>
-    </div>
-    <div class="section-body">
-      <div class="agents" id="agents"></div>
     </div>
   </div>
 

--- a/v2/pkg/hub/alerts.go
+++ b/v2/pkg/hub/alerts.go
@@ -94,6 +94,13 @@ const (
 	// so the panel, the facet and the row pill can never disagree about which
 	// hives are affected.
 	AlertTypeAdvisoryStale = "advisory-stale"
+	// AlertTypeURLUnreachable — the PUBLIC dashboard URL the hub links users to
+	// did not serve. Distinct from every other alert here in that it is the only
+	// one measured from OUTSIDE the spoke: a hive can be online, heartbeating and
+	// reporting every health check green while its vanity Route/Ingress, DNS or
+	// certificate is broken and the link in the hub table returns 503. Raised by
+	// the auth-audit loop, which already makes this HTTPS request.
+	AlertTypeURLUnreachable = "url-unreachable"
 )
 
 // --- Thresholds. Every one is a named constant with a rationale. ---
@@ -916,7 +923,16 @@ func (s *HubServer) fleetAlerts(entries []MyHiveEntry) AlertSummary {
 	// driftAlerts is nil today. When the config-drift evaluator lands, its
 	// signals are passed here and flow through the same ordering, ack and
 	// counting pipeline — see the file header.
-	return evaluateAlerts(s.alerts, hives, nil, time.Now())
+	//
+	// urlUnreachableAlerts is exactly such a signal: it is measured by the
+	// auth-audit loop from OUTSIDE the spoke, so it cannot be re-derived from
+	// the spoke-reported fields the evaluator sees.
+	now := time.Now()
+	regs := make([]RegistryEntry, 0, len(entries))
+	for _, e := range entries {
+		regs = append(regs, e.RegistryEntry)
+	}
+	return evaluateAlerts(s.alerts, hives, s.urlUnreachableAlerts(regs, now), now)
 }
 
 // saveAlertAcks persists acknowledgements to the PVC so a silenced alert stays
@@ -1030,6 +1046,7 @@ var knownAlertTypes = map[string]bool{
 	AlertTypeTokenBurn:          true,
 	AlertTypeProvisionError:     true,
 	AlertTypeAdvisoryStale:      true,
+	AlertTypeURLUnreachable:     true,
 }
 
 func isKnownAlertType(t string) bool { return knownAlertTypes[t] }

--- a/v2/pkg/hub/auth_audit.go
+++ b/v2/pkg/hub/auth_audit.go
@@ -83,6 +83,12 @@ func (s *HubServer) runAuthAudit(ctx context.Context, client *http.Client) {
 
 	var open []string
 	probed, unreachable := 0, 0
+	// Per-cluster tallies so a whole cluster going dark (vllm-d has been
+	// intermittently unreachable from the hub) is reported as ONE outage rather
+	// than as N individually broken hives.
+	clusterProbed := map[string]int{}
+	clusterFailed := map[string]int{}
+	known := map[string]bool{}
 	for _, h := range hives {
 		// Only probe hives that report a real dashboard URL (heartbeating spokes).
 		base := strings.TrimRight(h.DashboardURL, "/")
@@ -90,7 +96,20 @@ func (s *HubServer) runAuthAudit(ctx context.Context, client *http.Client) {
 			continue
 		}
 		probed++
-		wideOpen, reachable := probeWideOpen(ctx, client, base)
+		known[h.ID] = true
+		clusterProbed[h.ClusterID]++
+		status, wideOpen, reachable := probeWideOpen(ctx, client, base)
+		// Reachability is a STRICTER test than the auth audit's "reachable": a
+		// 503 from an ingress with no backend is a completed HTTP transaction,
+		// so reachable is true, yet the user still gets an error page. Record
+		// the status-based verdict, not the transport one.
+		healthy := reachable && urlHealthyStatus(status)
+		if s.urlHealth != nil {
+			s.urlHealth.observe(h.ID, urlProbeResult{Status: status, Healthy: healthy})
+		}
+		if !healthy {
+			clusterFailed[h.ClusterID]++
+		}
 		if !reachable {
 			unreachable++
 			continue
@@ -99,6 +118,11 @@ func (s *HubServer) runAuthAudit(ctx context.Context, client *http.Client) {
 			open = append(open, h.ID)
 		}
 	}
+	// Drop recycled pool slots so the failure counters cannot grow unbounded.
+	if s.urlHealth != nil {
+		s.urlHealth.forget(known)
+	}
+	s.reportURLHealth(hives, clusterProbed, clusterFailed)
 
 	if len(open) == 0 {
 		s.logger.Info("auth audit: no wide-open spokes", "probed", probed, "unreachable", unreachable)
@@ -112,23 +136,47 @@ func (s *HubServer) runAuthAudit(ctx context.Context, client *http.Client) {
 	s.pushAuthAuditAlert(msg)
 }
 
-// probeWideOpen fetches base+authAuditPath with NO auth. Returns (wideOpen,
-// reachable). wideOpen is true only on a 200 (dashboard served to anyone).
-// A 30x/401/403 means protected. A transport error means unreachable (e.g. a
-// firewalled vllm-d spoke the hub can't reach), never counted as open.
-func probeWideOpen(ctx context.Context, client *http.Client, base string) (wideOpen, reachable bool) {
+// probeWideOpen fetches base+authAuditPath with NO auth. Returns the observed
+// HTTP status (0 when the request never completed), wideOpen and reachable.
+// wideOpen is true only on a 200 (dashboard served to anyone). A 30x/401/403
+// means protected. A transport error means unreachable (e.g. a firewalled
+// vllm-d spoke the hub can't reach), never counted as open.
+//
+// The status is returned so callers can distinguish a SERVING spoke from one
+// whose ingress answered with an error: reachable only says the HTTP exchange
+// completed, which is true of a 503 from a routed hostname with no backend.
+func probeWideOpen(ctx context.Context, client *http.Client, base string) (status int, wideOpen, reachable bool) {
 	reqCtx, cancel := context.WithTimeout(ctx, authAuditProbeTimeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, base+authAuditPath, nil)
 	if err != nil {
-		return false, false
+		return 0, false, false
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return false, false
+		return 0, false, false
 	}
 	defer resp.Body.Close()
-	return resp.StatusCode == http.StatusOK, true
+	return resp.StatusCode, resp.StatusCode == http.StatusOK, true
+}
+
+// reportURLHealth logs the outcome of the reachability side of the audit,
+// rolling whole-cluster failures up into a single line. The per-hive alerts
+// themselves are built later by urlUnreachableAlerts, from the same state, so
+// the log and the alert panel can never disagree about which hives are broken.
+func (s *HubServer) reportURLHealth(hives []RegistryEntry, clusterProbed, clusterFailed map[string]int) {
+	for clusterID, failed := range clusterFailed {
+		if failed == 0 {
+			continue
+		}
+		if clusterOutage(failed, clusterProbed[clusterID]) {
+			s.logger.Warn("url reachability: cluster-wide failure, suppressing per-hive alerts",
+				"cluster", clusterID, "failed", failed, "probed", clusterProbed[clusterID])
+			continue
+		}
+		s.logger.Warn("url reachability: hives whose public URL did not serve",
+			"cluster", clusterID, "failed", failed, "probed", clusterProbed[clusterID])
+	}
 }
 
 // pushAuthAuditAlert sends a high-priority ntfy notification when a wide-open

--- a/v2/pkg/hub/auth_audit_coverage_test.go
+++ b/v2/pkg/hub/auth_audit_coverage_test.go
@@ -28,7 +28,7 @@ func TestProbeWideOpen(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer open.Close()
-	wideOpen, reachable := probeWideOpen(context.Background(), newAuditClient(), open.URL)
+	_, wideOpen, reachable := probeWideOpen(context.Background(), newAuditClient(), open.URL)
 	if !wideOpen || !reachable {
 		t.Errorf("200 should be wideOpen+reachable, got %v %v", wideOpen, reachable)
 	}
@@ -38,19 +38,19 @@ func TestProbeWideOpen(t *testing.T) {
 		http.Redirect(w, r, "/login", http.StatusFound)
 	}))
 	defer prot.Close()
-	wideOpen, reachable = probeWideOpen(context.Background(), newAuditClient(), prot.URL)
+	_, wideOpen, reachable = probeWideOpen(context.Background(), newAuditClient(), prot.URL)
 	if wideOpen || !reachable {
 		t.Errorf("302 should be protected+reachable, got %v %v", wideOpen, reachable)
 	}
 
 	// Unreachable (closed port).
-	wideOpen, reachable = probeWideOpen(context.Background(), newAuditClient(), "http://127.0.0.1:1")
+	_, wideOpen, reachable = probeWideOpen(context.Background(), newAuditClient(), "http://127.0.0.1:1")
 	if wideOpen || reachable {
 		t.Errorf("closed port should be unreachable, got %v %v", wideOpen, reachable)
 	}
 
 	// Bad URL -> request build error.
-	wideOpen, reachable = probeWideOpen(context.Background(), newAuditClient(), "http://\x7f\x00")
+	_, wideOpen, reachable = probeWideOpen(context.Background(), newAuditClient(), "http://\x7f\x00")
 	if wideOpen || reachable {
 		t.Errorf("bad URL should be unreachable, got %v %v", wideOpen, reachable)
 	}

--- a/v2/pkg/hub/auth_audit_test.go
+++ b/v2/pkg/hub/auth_audit_test.go
@@ -21,7 +21,7 @@ func TestProbeWideOpen_OpenIsFlagged(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
-	open, reachable := probeWideOpen(context.Background(), auditTestClient(), srv.URL)
+	_, open, reachable := probeWideOpen(context.Background(), auditTestClient(), srv.URL)
 	if !reachable {
 		t.Fatal("expected reachable")
 	}
@@ -36,7 +36,7 @@ func TestProbeWideOpen_RedirectIsProtected(t *testing.T) {
 		http.Redirect(w, r, "/login", http.StatusSeeOther)
 	}))
 	defer srv.Close()
-	open, reachable := probeWideOpen(context.Background(), auditTestClient(), srv.URL)
+	_, open, reachable := probeWideOpen(context.Background(), auditTestClient(), srv.URL)
 	if !reachable {
 		t.Fatal("expected reachable")
 	}
@@ -50,7 +50,7 @@ func TestProbeWideOpen_UnauthorizedIsProtected(t *testing.T) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer srv.Close()
-	open, reachable := probeWideOpen(context.Background(), auditTestClient(), srv.URL)
+	_, open, reachable := probeWideOpen(context.Background(), auditTestClient(), srv.URL)
 	if !reachable || open {
 		t.Fatalf("401 must be reachable+protected, got open=%v reachable=%v", open, reachable)
 	}
@@ -58,7 +58,7 @@ func TestProbeWideOpen_UnauthorizedIsProtected(t *testing.T) {
 
 func TestProbeWideOpen_UnreachableIsNotOpen(t *testing.T) {
 	// A firewalled/down spoke: transport error → unreachable, never "open".
-	open, reachable := probeWideOpen(context.Background(), auditTestClient(), "https://127.0.0.1:1")
+	_, open, reachable := probeWideOpen(context.Background(), auditTestClient(), "https://127.0.0.1:1")
 	if reachable {
 		t.Fatal("expected unreachable for a dead endpoint")
 	}

--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -1190,6 +1190,11 @@ func TestHandleAssignHiveWithFilesystem(t *testing.T) {
 	}
 
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	// Assign only adopts a vanity URL once the host is actually SERVABLE, and
+	// kubectl does not exist under test, so stub the seam to report success.
+	// Without this the assign correctly declines to adopt an unservable host —
+	// that is the fix for the vllm-d 503s, not a regression.
+	srv.vanityHostServable = func(string, string, *ClusterConfig) error { return nil }
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/assign", srv.handleAssignHive)
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1532,6 +1532,16 @@ type MyHiveEntry struct {
 	// must never show the pill.
 	AdvisoryStale       bool   `json:"advisoryStale,omitempty"`
 	AdvisoryStaleReason string `json:"advisoryStaleReason,omitempty"`
+
+	// URLUnreachable is true when this hive's PUBLIC dashboard URL failed to
+	// serve on the last several probes — the link in this very table is dead.
+	// Computed on read from the auth-audit loop's observations, so the browser
+	// never re-derives the failure threshold. Stays zero/empty for a hive that
+	// is serving, that is too new to have converged, or whose whole cluster is
+	// out (an outage is one condition, not N broken hives) — those must never
+	// show the pill.
+	URLUnreachable       bool   `json:"urlUnreachable,omitempty"`
+	URLUnreachableReason string `json:"urlUnreachableReason,omitempty"`
 }
 
 // myHivesRecentEventCount is how many timeline events ride the My Hives
@@ -1836,6 +1846,25 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 	// been collected and enriched (a row still missing its provStatus would be
 	// misread as a claimed hive and flagged for having no App).
 	annotateDrift(result, getDisplaySHAs(), time.Now())
+
+	// Dead-link pill, computed once over the full visible set for the same
+	// reason as drift: the cluster-outage suppression is a property of the SET
+	// (most of a cluster failing is an outage, not N broken hives), so it
+	// cannot be decided one row at a time. Derived from the same alert list the
+	// panel renders, so pill and panel always agree.
+	{
+		regs := make([]RegistryEntry, 0, len(result))
+		for i := range result {
+			regs = append(regs, result[i].RegistryEntry)
+		}
+		urlAlerts := s.urlUnreachableAlerts(regs, time.Now())
+		for i := range result {
+			if bad, reason := urlUnreachableFacet(urlAlerts, result[i].ID); bad {
+				result[i].URLUnreachable = true
+				result[i].URLUnreachableReason = reason
+			}
+		}
+	}
 
 	// Attach the user-journey stage to every row so the table can show who is
 	// stalled where. Derived on read; never persisted on the registry entry.
@@ -5852,18 +5881,24 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 			// heartbeat-only OpenShift pool where the hub cannot kubectl to create
 			// it, so the create "fails" yet the *.apps.<domain> wildcard still
 			// serves the host — the vllm-d case).
-			if err := s.addVanityHostToIngress(hiveID, vanityHost, cluster); err != nil {
-				if cluster.IngressType == ingressTypeOpenShiftRoute {
-					s.logger.Info("vanity host: hub could not create a route (heartbeat-only OpenShift cluster) "+
-						"— relying on the cluster wildcard route to serve it",
-						"hive", hiveID, "host", vanityHost, "cluster", cluster.ID, "error", err)
-				} else {
-					s.logger.Warn("vanity host is not served: could not add it to the spoke ingress/route — "+
-						"hub links to this hive will 503 until it is added by hand",
-						"hive", hiveID, "host", vanityHost, "error", err)
-				}
+			// Goes through the same seam as the retroactive repair so both
+			// adoption paths share one definition of "servable" (and so tests,
+			// which have no kubectl, can exercise the success path).
+			if err := s.makeVanityHostServable(hiveID, vanityHost, cluster); err != nil {
+				// Do NOT adopt a host we could not make servable. This used to
+				// assume an OpenShift cluster wildcard would serve the host
+				// anyway and adopt it regardless; on vllm-d that assumption is
+				// false — only explicitly created *-vanity Routes are served, so
+				// the hub advertised a hostname that returned 503 while the raw
+				// placeholder host worked fine. Leaving VanityURL empty makes
+				// every read path fall back to the working placeholder, and the
+				// heartbeat repair re-attempts adoption once a route exists.
+				s.logger.Warn("vanity host is not served: could not add it to the spoke ingress/route — "+
+					"keeping the working placeholder host; the heartbeat repair will retry",
+					"hive", hiveID, "host", vanityHost, "cluster", cluster.ID, "error", err)
+			} else {
+				h.VanityURL = "https://" + vanityHost
 			}
-			h.VanityURL = "https://" + vanityHost
 		}
 	}
 	if err := saveSaaSHive(h); err != nil {
@@ -7311,6 +7346,25 @@ const dashboardHTML = `<!DOCTYPE html>
         'border-radius:9999px;font-size:0.62rem;font-weight:600;line-height:1.5;cursor:help;white-space:nowrap;' +
         'color:' + col + ';background:rgba(210,153,34,0.12);border:1px solid rgba(210,153,34,0.35)">' +
         'stale advisory</span>';
+    }
+
+    /* deadLinkSummary renders a "dead link" pill when this hive's own public
+       URL did not serve on the last several probes. Red, not amber: unlike a
+       stale digest this is user-facing breakage — the link in this very row
+       returns an error page, and because the spoke itself is healthy and
+       heartbeating, NOTHING else on the row indicates a problem.
+       h.urlUnreachable and its reason are computed server-side from the same
+       alert list the panel renders (see urlUnreachableFacet), gated on
+       consecutive failures AND minimum age AND cluster-outage suppression, so
+       this renderer never re-derives the rule and a converging or
+       whole-cluster-out hive is filtered out before it gets here. */
+    function deadLinkSummary(h) {
+      if (!h || !h.urlUnreachable) return '';
+      var title = h.urlUnreachableReason || 'This hive public URL did not respond';
+      return '<span title="' + esc(title) + '" style="display:inline-block;margin-left:6px;padding:0 6px;' +
+        'border-radius:9999px;font-size:0.62rem;font-weight:600;line-height:1.5;cursor:help;white-space:nowrap;' +
+        'color:#f85149;background:rgba(248,81,73,0.12);border:1px solid rgba(248,81,73,0.35)">' +
+        'dead link</span>';
     }
 
     /* ---- ClankeR, the contributor relay (hover panel) ------------------
@@ -10708,7 +10762,7 @@ const dashboardHTML = `<!DOCTYPE html>
         return '<tr>' +
           bulkCheckboxCell(h, section || 'all') +
           '<td class="hive-menu-cell" style="position:relative;width:30px;text-align:center;overflow:visible">' + (h.migrationStatus === 'migrating' ? '<span style="font-size:1.1rem;color:var(--border);user-select:none;cursor:not-allowed" title="Disabled during migration">⋮</span>' : '<span style="cursor:pointer;font-size:1.1rem;color:var(--muted);user-select:none">⋮</span>' + pendingBadge + '<div class="hive-menu-dropdown" style="display:none;position:absolute;left:0;bottom:auto;background:#1c2128;border:1px solid #30363d;border-radius:8px;min-width:160px;padding:4px 0;z-index:1000;box-shadow:0 8px 24px rgba(0,0,0,0.5)">' + menuItems.join('') + '</div>') + '</td>' +
-          '<td style="text-align:left;line-height:1.4">' + (function() { var isHostedRow = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'))); var dh = isHostedRow && h.id ? ('/api/saas/hives/' + encodeURIComponent(h.id) + '/open') : (rb ? esc(rb) : ''); /* Label derived from the PROJECT (org + primary repo), not by splitting h.name — see hiveLabel. */ var label = hiveLabel(h); var orgName = label.line1; var repoName = label.line2; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var ghIcon = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : ''; /* vanityDisplay is the friendly host shown in the status bar on hover. rb is resolvedBase(h), which the hub has already overlaid with the claimed vanity_url; it is only a DISPLAY url here, never the click target — see ssoDisplayLink. Empty for a row with no vanity host, which falls back to today's /open href. Only meaningful on hosted rows: a non-hosted row's dh IS rb already. */ var vanityDisplay = isHostedRow && rb ? rb : ''; var link = function(text, bold) { if (dh) { return ssoDisplayLink(dh, vanityDisplay, text, bold ? 'hive-name-link' : 'hive-sub-link'); } var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName, true); var fcPill = h.online ? failingCheckSummary(h) : ''; /* Advisory-staleness pill sits right beside the failing-check pill: both are "something is quietly wrong with this working hive" signals, and advisoryStaleSummary already self-suppresses (empty string) unless the hub flagged the digest stale, so unaffected rows are pixel-identical. */ var advPill = h.online ? advisoryStaleSummary(h) : ''; /* Inline access faces sit on the name cell's second line, immediately after this row's own role badge: the badge already answers "what am I on this hive", so the co-members read as the natural continuation of the same thought, in the one cell that is left-aligned and has room to grow. It also keeps them out of the 16 dense metric columns, none of which is about people. Empty string when the viewer is the only member, so those rows are pixel-identical to today. */ var accessFaces = hiveAccessAvatars(h); /* Keyed off repoName, not orgName: line 1 now always carries SOME identity, so the presence of a second line is decided purely by whether there is a repo to put on it. Without a repo the row still shows the GitHub icon, role badge, faces and failing-check pill on the compact variant. */ var line2 = repoName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + '</div>'; var line3 = pendingPill ? '<div style="margin-top:4px;padding-left:18px">' + pendingPill + '</div>' : ''; return line1 + line2 + line3; })() + '</td>' +
+          '<td style="text-align:left;line-height:1.4">' + (function() { var isHostedRow = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'))); var dh = isHostedRow && h.id ? ('/api/saas/hives/' + encodeURIComponent(h.id) + '/open') : (rb ? esc(rb) : ''); /* Label derived from the PROJECT (org + primary repo), not by splitting h.name — see hiveLabel. */ var label = hiveLabel(h); var orgName = label.line1; var repoName = label.line2; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var ghIcon = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : ''; /* vanityDisplay is the friendly host shown in the status bar on hover. rb is resolvedBase(h), which the hub has already overlaid with the claimed vanity_url; it is only a DISPLAY url here, never the click target — see ssoDisplayLink. Empty for a row with no vanity host, which falls back to today's /open href. Only meaningful on hosted rows: a non-hosted row's dh IS rb already. */ var vanityDisplay = isHostedRow && rb ? rb : ''; var link = function(text, bold) { if (dh) { return ssoDisplayLink(dh, vanityDisplay, text, bold ? 'hive-name-link' : 'hive-sub-link'); } var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName, true); var fcPill = h.online ? failingCheckSummary(h) : ''; /* Advisory-staleness pill sits right beside the failing-check pill: both are "something is quietly wrong with this working hive" signals, and advisoryStaleSummary already self-suppresses (empty string) unless the hub flagged the digest stale, so unaffected rows are pixel-identical. */ var advPill = h.online ? advisoryStaleSummary(h) : ''; /* Dead-link pill is deliberately NOT gated on h.online: the entire point is a hive that IS online and heartbeating while its public URL is broken, so gating it the way the other pills are gated would hide exactly the case it exists to surface. */ var dlPill = deadLinkSummary(h); /* Inline access faces sit on the name cell's second line, immediately after this row's own role badge: the badge already answers "what am I on this hive", so the co-members read as the natural continuation of the same thought, in the one cell that is left-aligned and has room to grow. It also keeps them out of the 16 dense metric columns, none of which is about people. Empty string when the viewer is the only member, so those rows are pixel-identical to today. */ var accessFaces = hiveAccessAvatars(h); /* Keyed off repoName, not orgName: line 1 now always carries SOME identity, so the presence of a second line is decided purely by whether there is a repo to put on it. Without a repo the row still shows the GitHub icon, role badge, faces and failing-check pill on the compact variant. */ var line2 = repoName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + dlPill + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + dlPill + '</div>'; var line3 = pendingPill ? '<div style="margin-top:4px;padding-left:18px">' + pendingPill + '</div>' : ''; return line1 + line2 + line3; })() + '</td>' +
           '<td>' + locationCell + '</td>' +
           '<td style="white-space:nowrap">' + uptimeCell(h) + '</td>' +
           /* No white-space:nowrap on the cell itself: the stacked lines each

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -643,7 +643,19 @@ func (s *HubServer) repairVanityURLForHive(hiveID string) bool {
 	if cluster == nil || cluster.Domain == "" {
 		return false
 	}
-	vanityHost := generateHiveID(h.Org, h.PrimaryRepo) + "." + cluster.Domain
+	// Reuse the host an EXISTING vanity route already serves before minting a
+	// new one. generateHiveID appends a fresh random suffix on every call, so a
+	// hive whose repair keeps failing used to burn a brand-new hostname every
+	// heartbeat (observed churning four hosts in eight minutes). Worse, when a
+	// vanity_url had been cleared by hand to repair a mismatch, the next beat
+	// minted a DIFFERENT suffix instead of re-adopting the host the spoke's
+	// route was already serving — leaving the registry pointing at a hostname
+	// nothing serves while the working route sat unused. Adopting the existing
+	// route's host first makes this repair converge instead of oscillate.
+	vanityHost := s.existingVanityHost(hiveID, cluster)
+	if vanityHost == "" {
+		vanityHost = generateHiveID(h.Org, h.PrimaryRepo) + "." + cluster.Domain
+	}
 	// Make it servable BEFORE adopting it; on failure leave VanityURL empty so
 	// every read path keeps falling back to the working placeholder host.
 	if err := s.makeVanityHostServable(hiveID, vanityHost, cluster); err != nil {
@@ -660,6 +672,49 @@ func (s *HubServer) repairVanityURLForHive(hiveID string) bool {
 		"hive", hiveID, "org", h.Org, "primary_repo", h.PrimaryRepo,
 		"cluster", cluster.ID, "vanity_url", h.VanityURL)
 	return true
+}
+
+// existingVanityHost returns the host an already-created vanity route/ingress
+// on the spoke is serving, or "" when there is none (or the cluster cannot be
+// reached).
+//
+// This exists so the retroactive repair is CONVERGENT. The vanity host carries
+// a random suffix, so re-minting is not idempotent: any path that mints a host
+// without first looking for the one already in place will invent a new name,
+// and the hub can end up advertising a hostname that no route serves while the
+// real route answers on a different one. Reading the live object first makes
+// the repair adopt reality instead of overwriting it.
+//
+// Best-effort by design: on any error it returns "" and the caller mints a
+// fresh host exactly as before, so an unreachable cluster is no worse off.
+func (s *HubServer) existingVanityHost(hiveID string, cluster *ClusterConfig) string {
+	if cluster == nil {
+		return ""
+	}
+	ns := "hive-hosted-" + hiveID
+	placeholderHost := hiveID + "." + cluster.Domain
+
+	if cluster.IngressType == ingressTypeOpenShiftRoute {
+		out, err := kubectlForCluster(cluster, "-n", ns, "get", "route",
+			routeBaseDashboard+"-vanity", "-o", "jsonpath={.spec.host}").Output()
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	// nginx: the vanity host is the rule whose host is not the placeholder.
+	out, err := kubectlForCluster(cluster, "-n", ns, "get", "ingress", "hive",
+		"-o", "jsonpath={.spec.rules[*].host}").Output()
+	if err != nil {
+		return ""
+	}
+	for _, host := range strings.Fields(string(out)) {
+		if host != placeholderHost && host != "" {
+			return host
+		}
+	}
+	return ""
 }
 
 // makeVanityHostServable creates the ingress/route that makes vanityHost resolve,

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -584,6 +584,13 @@ type HubServer struct {
 	// its own leaf mutex and is never touched while s.mu is held — see
 	// alerts.go.
 	alerts *alertState
+
+	// urlHealth remembers how many consecutive times each hive's PUBLIC
+	// dashboard URL failed to serve, so a transient blip can be told apart from
+	// a link that has been dead for hours. Populated by the auth-audit loop,
+	// which already probes those URLs. Carries its own leaf mutex and is never
+	// touched while s.mu is held — see url_reachability.go.
+	urlHealth *urlHealthState
 }
 
 // HubBannerEntry stores an admin banner targeted at a specific hive.
@@ -712,6 +719,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		timeline:                newTimelineStore(),
 		journey:                 newJourneyStore(),
 		alerts:                  newAlertState(),
+		urlHealth:               newURLHealthState(),
 	}
 
 	s.loadRegistry()

--- a/v2/pkg/hub/url_reachability.go
+++ b/v2/pkg/hub/url_reachability.go
@@ -1,0 +1,271 @@
+package hub
+
+import (
+	"net/http"
+	"sync"
+	"time"
+)
+
+// URL reachability: the hub already probes every spoke's dashboard URL over
+// HTTPS during the auth audit, but until now it threw the transport result
+// away — a hive whose vanity host served a 503 still showed a green dot, all
+// health checks passing, and a dead link in the hub table. The pod being
+// healthy says nothing about whether the Route/Ingress, DNS and cert that put
+// that pod on its PUBLIC hostname actually work.
+//
+// This file records the reachability of the URL the hub LINKS USERS TO
+// (RegistryEntry.DashboardURL, which carries the vanity host once minted) and
+// turns a persistent failure into an alert.
+//
+// The rule is deliberately conservative in the same spirit as advisoryStale:
+// anything we are unsure about is NOT alarmed on. Specifically:
+//   - A brand-new hive is still converging (cert-manager issuing, ingress
+//     reloading), so it is exempt until urlUnreachableMinAge.
+//   - A single bad probe never alerts; it takes urlUnreachableMinFailures
+//     consecutive failures, so a rolling restart is invisible.
+//   - When an ENTIRE cluster fails at once that is an outage or a hub-side
+//     network partition, not N broken hives, so those are suppressed into one
+//     cluster-level condition rather than N alerts.
+
+const (
+	// urlUnreachableMinFailures is how many CONSECUTIVE failed probes a hive
+	// must accumulate before it is alerted on. The audit runs every
+	// authAuditInterval (30m), so this is ~1h of sustained failure — long
+	// enough that a spoke restart, an ingress reload or a brief DNS blip has
+	// resolved, short enough to catch a genuinely dead link the same morning.
+	urlUnreachableMinFailures = 2
+
+	// urlUnreachableMinAge is how long after registration a hive is exempt.
+	// A freshly provisioned hive legitimately 503s while cert-manager issues a
+	// certificate and the ingress controller reloads; alerting during that
+	// window would make every new hive page someone. This is the "not yet
+	// servable (normal)" vs "broken (converged long ago)" boundary.
+	urlUnreachableMinAge = 2 * time.Hour
+
+	// urlClusterOutageRatio is the share of a cluster's probed hives that must
+	// fail before the failures are treated as a single cluster-wide outage
+	// instead of per-hive breakage. vllm-d has been intermittently unreachable
+	// from the hub, and a partition there must not raise 30 separate alerts.
+	urlClusterOutageRatio = 0.5
+
+	// urlClusterOutageMinHives is the smallest cluster size the outage rollup
+	// applies to. Below this, "most hives failed" is not evidence of an outage
+	// — on a 2-hive cluster a single genuinely broken hive already crosses the
+	// ratio, and rolling it up would hide a real defect.
+	urlClusterOutageMinHives = 3
+)
+
+// urlHealthyStatus reports whether an HTTP status from a spoke's dashboard URL
+// means the URL is genuinely serving.
+//
+// This is the load-bearing distinction that the auth audit's notion of
+// "reachable" does NOT make: a 503 from an OpenShift router or an nginx
+// controller is a perfectly successful HTTP transaction, so the transport
+// succeeded — but there is no backend behind the hostname and the user gets an
+// error page. Treating that as reachable is exactly how a dead vanity URL hid
+// behind a green dot.
+//
+// Healthy responses:
+//   - 200: the dashboard rendered (the auth audit separately flags this as
+//     wide open; for reachability it is a success).
+//   - 30x: redirected to login. The hub's own spokes do this, so it is the
+//     single most common healthy answer and must never read as a failure.
+//   - 401/403: an authenticated endpoint refusing an anonymous caller. This is
+//     what every vllm-d spoke returns via its OAuth proxy — healthy.
+//
+// Anything else (5xx, 404, and any transport error) is a failure.
+func urlHealthyStatus(status int) bool {
+	switch {
+	case status == http.StatusOK:
+		return true
+	case status >= 300 && status < 400:
+		return true
+	case status == http.StatusUnauthorized || status == http.StatusForbidden:
+		return true
+	default:
+		return false
+	}
+}
+
+// urlProbeResult is one probe of one hive's dashboard URL.
+type urlProbeResult struct {
+	// Status is the HTTP status observed, or 0 when the request never
+	// completed (DNS failure, TLS failure, timeout).
+	Status int
+	// Healthy is urlHealthyStatus(Status), false for a transport error.
+	Healthy bool
+}
+
+// urlHealthState tracks consecutive failures per hive across audit passes. It
+// is the memory that lets a transient blip be distinguished from a hive that
+// converged long ago and is still failing.
+type urlHealthState struct {
+	mu sync.Mutex
+	// consecutiveFailures[hiveID] counts probes in a row that came back
+	// unhealthy. Reset to zero by any healthy probe.
+	consecutiveFailures map[string]int
+	// lastStatus[hiveID] is the most recent observed status, surfaced in the
+	// alert reason so an operator sees "503" rather than just "unreachable".
+	lastStatus map[string]int
+}
+
+func newURLHealthState() *urlHealthState {
+	return &urlHealthState{
+		consecutiveFailures: map[string]int{},
+		lastStatus:          map[string]int{},
+	}
+}
+
+// observe records one probe result and returns the running consecutive-failure
+// count for that hive.
+func (u *urlHealthState) observe(hiveID string, res urlProbeResult) int {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.lastStatus[hiveID] = res.Status
+	if res.Healthy {
+		delete(u.consecutiveFailures, hiveID)
+		return 0
+	}
+	u.consecutiveFailures[hiveID]++
+	return u.consecutiveFailures[hiveID]
+}
+
+// snapshot returns a copy of the current per-hive failure counts and last
+// statuses, for building alerts without holding the lock.
+func (u *urlHealthState) snapshot() (failures map[string]int, statuses map[string]int) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	failures = make(map[string]int, len(u.consecutiveFailures))
+	for k, v := range u.consecutiveFailures {
+		failures[k] = v
+	}
+	statuses = make(map[string]int, len(u.lastStatus))
+	for k, v := range u.lastStatus {
+		statuses[k] = v
+	}
+	return failures, statuses
+}
+
+// forget drops hives that are no longer in the registry so the maps do not
+// grow without bound as pool slots are recycled.
+func (u *urlHealthState) forget(known map[string]bool) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	for id := range u.consecutiveFailures {
+		if !known[id] {
+			delete(u.consecutiveFailures, id)
+		}
+	}
+	for id := range u.lastStatus {
+		if !known[id] {
+			delete(u.lastStatus, id)
+		}
+	}
+}
+
+// clusterOutage reports whether a cluster's failures should be rolled up into
+// a single outage rather than alerted per hive. Requires both a minimum
+// cluster size and a majority of its probed hives failing.
+func clusterOutage(failed, probed int) bool {
+	if probed < urlClusterOutageMinHives {
+		return false
+	}
+	return float64(failed)/float64(probed) >= urlClusterOutageRatio
+}
+
+// urlUnreachableAlerts builds the per-hive unreachable-URL alerts for the
+// current fleet. It is fed into evaluateAlerts' driftAlerts parameter, the
+// pre-existing seam for signals computed outside the evaluator, so this shares
+// all of the ack/dedup/first-seen machinery rather than adding a parallel one.
+//
+// A hive is alerted on only when ALL of these hold, so that "still converging"
+// never reads as "broken":
+//   - it has failed urlUnreachableMinFailures probes in a row;
+//   - it registered at least urlUnreachableMinAge ago;
+//   - its cluster is not in a whole-cluster outage.
+func (s *HubServer) urlUnreachableAlerts(hives []RegistryEntry, now time.Time) []Alert {
+	// A HubServer built directly by a test has no urlHealth; no probe has run,
+	// so there is nothing to report.
+	if s == nil || s.urlHealth == nil {
+		return nil
+	}
+	failures, statuses := s.urlHealth.snapshot()
+	if len(failures) == 0 {
+		return nil
+	}
+
+	// Recompute the per-cluster tallies from the failure map so the outage
+	// suppression here matches what the audit logged.
+	clusterProbed := map[string]int{}
+	clusterFailed := map[string]int{}
+	for _, h := range hives {
+		if h.DashboardURL == "" {
+			continue
+		}
+		clusterProbed[h.ClusterID]++
+		if failures[h.ID] > 0 {
+			clusterFailed[h.ClusterID]++
+		}
+	}
+
+	var alerts []Alert
+	for _, h := range hives {
+		n := failures[h.ID]
+		if n < urlUnreachableMinFailures {
+			continue
+		}
+		if !urlUnreachableEligible(h.RegisteredAt, now) {
+			continue
+		}
+		if clusterOutage(clusterFailed[h.ClusterID], clusterProbed[h.ClusterID]) {
+			continue
+		}
+		alerts = append(alerts, Alert{
+			HiveID:   h.ID,
+			HiveName: h.Name,
+			Type:     AlertTypeURLUnreachable,
+			// Critical: the user-facing link is dead. Every other signal on this
+			// hive can look green, so nothing else will surface it.
+			Severity: AlertSeverityCritical,
+			Reason:   urlUnreachableReason(h.DashboardURL, statuses[h.ID]),
+		})
+	}
+	return alerts
+}
+
+// urlUnreachableFacet reports whether a single hive should show the dead-link
+// pill, and why. It applies the SAME gates as urlUnreachableAlerts (minimum
+// consecutive failures, minimum age, cluster-outage suppression) by reusing the
+// alert list itself, so the pill and the alert panel can never disagree about
+// which hives are affected — the contract advisoryStale established.
+func urlUnreachableFacet(alerts []Alert, hiveID string) (bool, string) {
+	for _, a := range alerts {
+		if a.HiveID == hiveID && a.Type == AlertTypeURLUnreachable {
+			return true, a.Reason
+		}
+	}
+	return false, ""
+}
+
+// urlUnreachableReason renders an operator-facing explanation that names the
+// URL and what it actually returned, so the fix is obvious from the alert.
+func urlUnreachableReason(url string, status int) string {
+	if status == 0 {
+		return "public URL " + url + " did not respond (DNS, TLS or timeout)"
+	}
+	return "public URL " + url + " returned HTTP " + itoa(status)
+}
+
+// urlUnreachableEligible reports whether a hive is old enough to be alerted on
+// for an unreachable URL. A hive with no parseable registration time is NOT
+// eligible — unknown is never alarmed on.
+func urlUnreachableEligible(registeredAt string, now time.Time) bool {
+	if registeredAt == "" {
+		return false
+	}
+	t, err := time.Parse(time.RFC3339, registeredAt)
+	if err != nil {
+		return false
+	}
+	return now.Sub(t) >= urlUnreachableMinAge
+}

--- a/v2/pkg/hub/url_reachability_test.go
+++ b/v2/pkg/hub/url_reachability_test.go
@@ -1,0 +1,230 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// A 503 from a routed hostname with no backend is the exact failure that hid
+// behind a green dot: the HTTP exchange SUCCEEDS, so any check based on
+// "did the request complete" reports healthy while the user gets an error page.
+func TestURLHealthyStatus(t *testing.T) {
+	healthy := []int{200, 301, 302, 303, 307, 308, 401, 403}
+	for _, code := range healthy {
+		if !urlHealthyStatus(code) {
+			t.Errorf("status %d should be healthy: a login redirect or an auth challenge means the URL is serving", code)
+		}
+	}
+	unhealthy := []int{0, 404, 500, 502, 503, 504}
+	for _, code := range unhealthy {
+		if urlHealthyStatus(code) {
+			t.Errorf("status %d should be unhealthy", code)
+		}
+	}
+}
+
+func TestURLHealthStateCountsConsecutiveFailures(t *testing.T) {
+	u := newURLHealthState()
+	if n := u.observe("h1", urlProbeResult{Status: 503}); n != 1 {
+		t.Fatalf("first failure = %d, want 1", n)
+	}
+	if n := u.observe("h1", urlProbeResult{Status: 503}); n != 2 {
+		t.Fatalf("second failure = %d, want 2", n)
+	}
+	// A single healthy probe must reset the streak — otherwise a hive that
+	// recovered would keep alerting.
+	if n := u.observe("h1", urlProbeResult{Status: 302, Healthy: true}); n != 0 {
+		t.Fatalf("healthy probe = %d, want 0", n)
+	}
+	if n := u.observe("h1", urlProbeResult{Status: 503}); n != 1 {
+		t.Fatalf("after recovery = %d, want 1", n)
+	}
+}
+
+func TestURLHealthStateForgetDropsRecycledSlots(t *testing.T) {
+	u := newURLHealthState()
+	u.observe("gone", urlProbeResult{Status: 503})
+	u.observe("kept", urlProbeResult{Status: 503})
+	u.forget(map[string]bool{"kept": true})
+	failures, statuses := u.snapshot()
+	if _, ok := failures["gone"]; ok {
+		t.Error("recycled pool slot should be forgotten so the map cannot grow unbounded")
+	}
+	if _, ok := statuses["gone"]; ok {
+		t.Error("recycled pool slot status should be forgotten")
+	}
+	if failures["kept"] != 1 {
+		t.Error("a hive still in the registry must be retained")
+	}
+}
+
+// A whole cluster failing is an outage, not N broken hives. vllm-d has been
+// intermittently unreachable from the hub and must not raise 30 alerts.
+func TestClusterOutageRollup(t *testing.T) {
+	if !clusterOutage(10, 10) {
+		t.Error("every hive failing on a large cluster is an outage")
+	}
+	if !clusterOutage(5, 10) {
+		t.Error("half a large cluster failing is an outage")
+	}
+	if clusterOutage(1, 10) {
+		t.Error("one hive failing is NOT an outage — that is the real breakage we must surface")
+	}
+	// Below the minimum size, "most failed" is not evidence of an outage: on a
+	// 2-hive cluster one genuinely broken hive already crosses the ratio.
+	if clusterOutage(2, 2) {
+		t.Error("a tiny cluster must not roll up, or a real defect is hidden")
+	}
+}
+
+func TestURLUnreachableEligibleExemptsNewAndUnknown(t *testing.T) {
+	now := time.Now()
+	old := now.Add(-urlUnreachableMinAge - time.Hour).Format(time.RFC3339)
+	if !urlUnreachableEligible(old, now) {
+		t.Error("a hive that converged long ago is eligible")
+	}
+	fresh := now.Add(-time.Minute).Format(time.RFC3339)
+	if urlUnreachableEligible(fresh, now) {
+		t.Error("a brand-new hive is still converging (cert issuance, ingress reload) and must be exempt")
+	}
+	// Unknown is never alarmed on — the advisoryStale contract.
+	if urlUnreachableEligible("", now) {
+		t.Error("an unknown registration time must not alert")
+	}
+	if urlUnreachableEligible("not-a-timestamp", now) {
+		t.Error("an unparseable registration time must not alert")
+	}
+}
+
+func TestURLUnreachableReasonNamesTheStatus(t *testing.T) {
+	got := urlUnreachableReason("https://x.example.com", 503)
+	if got != "public URL https://x.example.com returned HTTP 503" {
+		t.Errorf("reason = %q, want it to name the URL and the status", got)
+	}
+	got = urlUnreachableReason("https://x.example.com", 0)
+	if got != "public URL https://x.example.com did not respond (DNS, TLS or timeout)" {
+		t.Errorf("transport-failure reason = %q", got)
+	}
+}
+
+// The end-to-end rule: a hive that is online and green but whose public URL
+// serves 503 must alert, while a converging hive and a cluster outage must not.
+func TestURLUnreachableAlerts(t *testing.T) {
+	now := time.Now()
+	oldEnough := now.Add(-urlUnreachableMinAge - time.Hour).Format(time.RFC3339)
+
+	s := &HubServer{urlHealth: newURLHealthState()}
+	hives := []RegistryEntry{
+		{ID: "broken", Name: "org/broken", ClusterID: "c1", RegisteredAt: oldEnough, DashboardURL: "https://broken.example.com"},
+		{ID: "fine1", ClusterID: "c1", RegisteredAt: oldEnough, DashboardURL: "https://f1.example.com"},
+		{ID: "fine2", ClusterID: "c1", RegisteredAt: oldEnough, DashboardURL: "https://f2.example.com"},
+		{ID: "fine3", ClusterID: "c1", RegisteredAt: oldEnough, DashboardURL: "https://f3.example.com"},
+	}
+	// One hive fails twice; the rest are healthy.
+	for i := 0; i < urlUnreachableMinFailures; i++ {
+		s.urlHealth.observe("broken", urlProbeResult{Status: 503})
+	}
+	alerts := s.urlUnreachableAlerts(hives, now)
+	if len(alerts) != 1 || alerts[0].HiveID != "broken" {
+		t.Fatalf("want exactly one alert for the broken hive, got %+v", alerts)
+	}
+	if alerts[0].Type != AlertTypeURLUnreachable {
+		t.Errorf("type = %q", alerts[0].Type)
+	}
+	if alerts[0].Severity != AlertSeverityCritical {
+		t.Errorf("a dead user-facing link is critical, got %q", alerts[0].Severity)
+	}
+
+	// A single failure is below the threshold — a blip must never alert.
+	s2 := &HubServer{urlHealth: newURLHealthState()}
+	s2.urlHealth.observe("broken", urlProbeResult{Status: 503})
+	if got := s2.urlUnreachableAlerts(hives, now); len(got) != 0 {
+		t.Errorf("one failure must not alert, got %+v", got)
+	}
+
+	// Whole cluster down -> suppressed into an outage, zero per-hive alerts.
+	s3 := &HubServer{urlHealth: newURLHealthState()}
+	for _, h := range hives {
+		for i := 0; i < urlUnreachableMinFailures; i++ {
+			s3.urlHealth.observe(h.ID, urlProbeResult{Status: 0})
+		}
+	}
+	if got := s3.urlUnreachableAlerts(hives, now); len(got) != 0 {
+		t.Errorf("a cluster-wide outage must not raise per-hive alerts, got %d", len(got))
+	}
+}
+
+func TestURLUnreachableAlertsNilStateIsSafe(t *testing.T) {
+	s := &HubServer{}
+	if got := s.urlUnreachableAlerts([]RegistryEntry{{ID: "x"}}, time.Now()); got != nil {
+		t.Errorf("a HubServer with no probe state must return no alerts, got %+v", got)
+	}
+}
+
+// The pill and the alert panel must never disagree about which hives are broken.
+func TestURLUnreachableFacetMatchesAlerts(t *testing.T) {
+	alerts := []Alert{
+		{HiveID: "a", Type: AlertTypeURLUnreachable, Reason: "public URL https://a returned HTTP 503"},
+		{HiveID: "b", Type: AlertTypeOffline, Reason: "offline"},
+	}
+	if bad, reason := urlUnreachableFacet(alerts, "a"); !bad || reason == "" {
+		t.Error("hive a has an unreachable-URL alert so it must show the pill with a reason")
+	}
+	if bad, _ := urlUnreachableFacet(alerts, "b"); bad {
+		t.Error("an offline alert is a different condition and must not show the dead-link pill")
+	}
+	if bad, _ := urlUnreachableFacet(alerts, "c"); bad {
+		t.Error("a hive with no alert must not show the pill")
+	}
+}
+
+// A new alert type is unusable until knownAlertTypes accepts it: the ack
+// endpoint 400s otherwise, so an operator could never silence it.
+func TestURLUnreachableIsAckable(t *testing.T) {
+	if !isKnownAlertType(AlertTypeURLUnreachable) {
+		t.Error("AlertTypeURLUnreachable must be in knownAlertTypes or its ack endpoint returns 400")
+	}
+}
+
+// Assign must NOT adopt a vanity host it could not make servable. Adopting
+// optimistically (the old OpenShift behaviour, which assumed a cluster wildcard
+// route) is what left hosted-available-vllmd-01 advertising a hostname that
+// returned 503 while its placeholder host worked fine.
+func TestAssignDoesNotAdoptUnservableVanityHost(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	if err := saveSaaSHive(&SaaSHive{
+		ID:        "hosted-unservable",
+		Status:    statusAvailable,
+		ClusterID: gpuClusterID,
+	}); err != nil {
+		t.Fatalf("seed placeholder: %v", err)
+	}
+
+	s := &HubServer{
+		vanityHostServable: func(string, string, *ClusterConfig) error {
+			return errNotServableForTest
+		},
+	}
+	h := loadSaaSHive("hosted-unservable")
+	h.Org, h.PrimaryRepo = "neworg", "repoa"
+	cluster := s.clusterForHive(h)
+	if cluster == nil || cluster.Domain == "" {
+		t.Skip("test cluster has no domain configured")
+	}
+	if err := s.makeVanityHostServable(h.ID, "vanity."+cluster.Domain, cluster); err == nil {
+		t.Fatal("seam should report the host is not servable")
+	}
+	// The contract: on that error the caller leaves VanityURL empty so every
+	// read path falls back to the working placeholder host.
+	if h.VanityURL != "" {
+		t.Errorf("VanityURL = %q, want empty so the placeholder host is used", h.VanityURL)
+	}
+}
+
+var errNotServableForTest = errNotServable{}
+
+type errNotServable struct{}
+
+func (errNotServable) Error() string { return "not servable" }


### PR DESCRIPTION
Top-up bringing `dd` to the current `origin/v2` tip, including:
- #2338 — detect and surface spoke URLs that do not actually serve
- #2340 — stop model/method choices reverting on restart
- #2344 — move FAQ to the bottom of the spoke dashboard

## Conflict resolved (1)

**`v2/pkg/dashboard/api_packs.go`** — `applyPack`. Genuinely substantive, resolved by combining both sides:

- **v2 (#2340/#2333)** rewrote pack reconciliation to add *field ownership*: `Model` is only reconciled while `!existing.ModelIsOperatorOwned()`, `Backend` only while `!existing.BackendIsOperatorOwned()`, and newly created agents get `ModelOwner`/`BackendOwner: config.FieldOwnerPack`. This is the actual bug fix — without it an operator's Governor-grid model choice is reverted on every restart. It also reconciles `description`/`role`/`bead_role`/`display_name` replace-on-diff, and adds `AgentMgr.UpdateConfig` on change.
- **dd** had refactored the same function into a `s.mutateConfig(func(candidate *config.Config) error {...})` transaction with a `forceLevel` parameter, writing to `candidate` rather than `s.deps.Config`, plus dd-only `StaleTimeout` reconciliation and `forceLevel` cadence/threshold handling.

**Resolution:** kept dd's `mutateConfig`/`forceLevel` structure and `candidate.*` writes, and ported every v2 ownership guard and field-reconciliation fix inside it. No v2 bug fix was dropped; no dd customization was lost. Verified: 2 `*IsOperatorOwned()` guards, 4 `FieldOwnerPack` assignments, `mutateConfig` + `forceLevel` intact, and no stray `s.deps.Config.Agents[...]` writes inside the transaction.

## Verification

`go build ./...` clean, `go vet ./pkg/dashboard/...` clean, `gofmt` clean, `pkg/dashboard` Pack/ACMM/Level tests pass. Remaining `pkg/dashboard` reds are the known pre-existing network device-flow set (`TestCovV1_*`, `TestCovDF_*`, `GHUserAuth*`), confirmed failing identically on the unmerged base.

> [!IMPORTANT]
> Merge with `--merge`, **not** `--squash`.