### PR TITLE
🐛 fix(hub): make Attention-needed rows clickable and fix un-ackable alerts

### DIFF
--- a/v2/pkg/hub/alerts.go
+++ b/v2/pkg/hub/alerts.go
@@ -981,20 +981,26 @@ type alertAckRequest struct {
 // handleAlertAck acknowledges (or clears) one alert for one hive. Admin-only:
 // silencing a fleet-wide signal is an operator action, not something a hive
 // owner should be able to do to the admin's view.
+//
+// Failures go through writeJSONError, not http.Error. http.Error forces
+// Content-Type: text/plain even when the body is JSON, so the dashboard's
+// `await resp.json()` threw, its .catch() swallowed the reason, and the
+// operator got a generic "Failed to update alert" that never said why. The
+// reason is the whole point of the message when an ack silently does nothing.
 func (s *HubServer) handleAlertAck(w http.ResponseWriter, r *http.Request) {
 	var req alertAckRequest
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxPayloadBytes)).Decode(&req); err != nil {
-		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
 	req.HiveID = strings.TrimSpace(req.HiveID)
 	req.Type = strings.TrimSpace(req.Type)
 	if req.HiveID == "" || req.Type == "" {
-		http.Error(w, `{"error":"hiveId and type are required"}`, http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "hiveId and type are required")
 		return
 	}
 	if !isKnownAlertType(req.Type) {
-		http.Error(w, `{"error":"unknown alert type"}`, http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "unknown alert type: "+req.Type)
 		return
 	}
 
@@ -1008,7 +1014,7 @@ func (s *HubServer) handleAlertAck(w http.ResponseWriter, r *http.Request) {
 	// Acknowledging requires a LIVE condition. Refusing otherwise prevents a
 	// client from pre-silencing an alert that has not fired yet.
 	if !s.alerts.setAck(req.HiveID, req.Type, s.getAuthUser(r), time.Now()) {
-		http.Error(w, `{"error":"no active alert of that type for this hive"}`, http.StatusConflict)
+		writeJSONError(w, http.StatusConflict, "no active alert of that type for this hive")
 		return
 	}
 	s.saveAlertAcks()
@@ -1023,9 +1029,15 @@ func writeAlertAckOK(w http.ResponseWriter, acked bool) {
 // knownAlertTypes is the closed set of types the ack endpoint accepts, so a
 // client cannot wedge arbitrary keys into the persisted ack map.
 var knownAlertTypes = map[string]bool{
-	AlertTypeCrashLoop:          true,
-	AlertTypeOffline:            true,
-	AlertTypeStuckUpgrade:       true,
+	AlertTypeCrashLoop:    true,
+	AlertTypeOffline:      true,
+	AlertTypeStuckUpgrade: true,
+	// AlertTypeFailedUpgrade was omitted when the type was introduced (#2308),
+	// so acking a genuinely failed upgrade returned 400 and the row stayed in
+	// the panel. Every AlertType* constant MUST appear here — see
+	// TestKnownAlertTypesCoversEveryAlertType, which fails if one is added
+	// without being registered.
+	AlertTypeFailedUpgrade:      true,
 	AlertTypeHealthCheckFailing: true,
 	AlertTypeTokenBurn:          true,
 	AlertTypeProvisionError:     true,

--- a/v2/pkg/hub/alerts_known_types_test.go
+++ b/v2/pkg/hub/alerts_known_types_test.go
@@ -1,0 +1,164 @@
+package hub
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// alertsSourceFile is the file declaring both the AlertType* constants and the
+// knownAlertTypes registry. Parsing the source rather than hand-listing the
+// constants is the whole point: a hand-written list is exactly the thing that
+// drifted and produced this bug in the first place.
+const alertsSourceFile = "alerts.go"
+
+// alertTypeConstPrefix is the naming convention every alert type identifier
+// follows. The test discovers types by this prefix, so a newly added one is
+// picked up with no test edit at all.
+const alertTypeConstPrefix = "AlertType"
+
+// TestKnownAlertTypesCoversEveryAlertType is the guard for the ack endpoint.
+//
+// handleAlertAck rejects any type not in knownAlertTypes with HTTP 400. When a
+// type is declared but never registered, the alert renders in the "Attention
+// needed" panel with a working-looking Acknowledge button that can never
+// succeed — the alert simply stays put. AlertTypeFailedUpgrade shipped that way
+// in #2308.
+//
+// This parses alerts.go for every AlertType* constant and asserts each one is
+// ackable, so adding a constant without registering it fails here rather than
+// silently in production.
+func TestKnownAlertTypesCoversEveryAlertType(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, alertsSourceFile, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", alertsSourceFile, err)
+	}
+
+	// declared maps constant name -> its string value, for every AlertType*.
+	declared := map[string]string{}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if !isAlertTypeConstName(name.Name) || i >= len(vs.Values) {
+					continue
+				}
+				lit, ok := vs.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				val, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					t.Fatalf("unquote %s = %s: %v", name.Name, lit.Value, err)
+				}
+				declared[name.Name] = val
+			}
+		}
+	}
+
+	if len(declared) == 0 {
+		t.Fatalf("found no %s* constants in %s — the parser or the naming convention changed", alertTypeConstPrefix, alertsSourceFile)
+	}
+
+	for name, val := range declared {
+		if !isKnownAlertType(val) {
+			t.Errorf("%s (%q) is not in knownAlertTypes: its ack endpoint returns 400 and the alert can never be dismissed", name, val)
+		}
+	}
+
+	// The reverse direction: a registry entry with no constant behind it is a
+	// typo that silently accepts a key nothing ever emits.
+	values := map[string]bool{}
+	for _, v := range declared {
+		values[v] = true
+	}
+	for registered := range knownAlertTypes {
+		if !values[registered] {
+			t.Errorf("knownAlertTypes has %q, which matches no %s* constant", registered, alertTypeConstPrefix)
+		}
+	}
+}
+
+// isAlertTypeConstName reports whether an identifier follows the AlertType*
+// convention. Requires at least one character after the prefix so the bare
+// prefix, if it ever became a real identifier, is not mistaken for a type.
+func isAlertTypeConstName(name string) bool {
+	return len(name) > len(alertTypeConstPrefix) && name[:len(alertTypeConstPrefix)] == alertTypeConstPrefix
+}
+
+// TestAckFailedUpgradeSucceedsAndSurvivesRestart is the end-to-end regression
+// for the reported bug: "acknowledging an alert does not remove it from the
+// alert window."
+//
+// Before AlertTypeFailedUpgrade was registered in knownAlertTypes, this ack
+// returned 400 and the alert stayed in the panel. The second half restarts the
+// hub from the on-disk ack file to prove the ack is not merely in-memory —
+// an ack that evaporates on restart looks like it worked and then regresses.
+func TestAckFailedUpgradeSucceedsAndSurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	orig := alertAcksPath
+	alertAcksPath = filepath.Join(dir, "acks.json")
+	defer func() { alertAcksPath = orig }()
+
+	// A spoke that reported an upgrade it could not complete.
+	var entry MyHiveEntry
+	entry.ID = "hive-failed-upgrade"
+	entry.UpgradeFailed = true
+	entry.UpgradeTarget = "v2.3.0"
+	entry.UpgradeError = "image pull failed"
+
+	s := newTestAlertServer()
+	summary := s.fleetAlerts([]MyHiveEntry{entry})
+	if !hasUnackedAlertOfType(summary.Alerts, AlertTypeFailedUpgrade) {
+		t.Fatalf("expected a live %s alert to acknowledge, got %+v", AlertTypeFailedUpgrade, summary.Alerts)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/admin/alert-ack",
+		strings.NewReader(`{"hiveId":"hive-failed-upgrade","type":"failed-upgrade"}`))
+	s.handleAlertAck(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("acking %s returned %d, want 200 (body: %s)", AlertTypeFailedUpgrade, rec.Code, rec.Body.String())
+	}
+
+	// The alert must now be marked acknowledged, which is what moves it out of
+	// the live rows and behind the "N acknowledged" disclosure in the panel.
+	after := s.fleetAlerts([]MyHiveEntry{entry})
+	if hasUnackedAlertOfType(after.Alerts, AlertTypeFailedUpgrade) {
+		t.Errorf("%s is still listed as unacknowledged after a successful ack", AlertTypeFailedUpgrade)
+	}
+
+	// Restart: a brand-new server reading the same on-disk file must still see
+	// the acknowledgement.
+	restarted := newTestAlertServer()
+	restarted.loadAlertAcks()
+	afterRestart := restarted.fleetAlerts([]MyHiveEntry{entry})
+	if hasUnackedAlertOfType(afterRestart.Alerts, AlertTypeFailedUpgrade) {
+		t.Errorf("the %s acknowledgement did not survive a hub restart", AlertTypeFailedUpgrade)
+	}
+}
+
+// hasUnackedAlertOfType reports whether any alert of the given type is still
+// live and unacknowledged — i.e. whether the panel would still show it.
+func hasUnackedAlertOfType(alerts []Alert, alertType string) bool {
+	for _, a := range alerts {
+		if a.Type == alertType && !a.Acknowledged {
+			return true
+		}
+	}
+	return false
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -6374,6 +6374,22 @@ const dashboardHTML = `<!DOCTYPE html>
     .alert-rows { margin-top: 10px; display: flex; flex-direction: column; gap: 6px; }
     .alert-row { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; font-size: 0.74rem; padding: 5px 8px; border-radius: 6px; background: rgba(255,255,255,0.03); }
     .alert-row.acked { opacity: 0.55; }
+    /* An alert row is a real button: clicking it jumps to that hive's row in the
+       table below. Styled to look clickable (pointer, hover lift, focus ring)
+       because the previous inert <div> gave no hint that anything would happen.
+       width:100%/text-align:left undo the <button> defaults so the row lays out
+       exactly as the old div did. */
+    /* The jump button and the Acknowledge button are siblings (a button cannot
+       nest inside a button), so this wrapper keeps them on one visual line. */
+    .alert-row-wrap { display: flex; align-items: center; gap: 6px; }
+    .alert-row-wrap .alert-ack-btn { flex: 0 0 auto; }
+    button.alert-row { flex: 1 1 auto; min-width: 0; width: 100%; text-align: left; font-family: inherit; color: inherit; border: 1px solid transparent; cursor: pointer; }
+    button.alert-row:hover { background: rgba(255,255,255,0.07); border-color: var(--border); }
+    button.alert-row:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    /* Target highlight: a brief ring on the hive row the operator was sent to,
+       so it is obvious WHICH row answered the click after the scroll settles. */
+    .hive-row-targeted > td { background: rgba(88,166,255,0.16) !important; }
+    .hive-row-targeted > td:first-child { box-shadow: inset 3px 0 0 var(--accent); }
     .alert-row-hive { font-weight: 700; color: var(--text); }
     .alert-row-reason { color: var(--muted); }
     .alert-row-age { color: var(--muted); font-size: 0.68rem; margin-left: auto; white-space: nowrap; }
@@ -8416,9 +8432,22 @@ const dashboardHTML = `<!DOCTYPE html>
     };
 
     /* How many alert rows are listed before the panel collapses the remainder
-       behind a "show all" affordance. Enough to act on, few enough that the
-       panel never pushes the hive list off the screen. */
-    var ALERT_ROWS_SHOWN = 6;
+       behind the "+N more" toggle. Enough to act on, few enough that the panel
+       never pushes the hive list off the screen. */
+    var ALERT_ROWS_SHOWN_MIN = 6;
+
+    /* Which halves of the panel are expanded past ALERT_ROWS_SHOWN_MIN. Keyed
+       'live'/'acked' so the two lists expand independently. Not persisted: an
+       expanded list is a momentary "show me the rest", not a view preference,
+       and a panel that reloads 50 rows deep would bury the hive table. */
+    var _alertRowsExpanded = {live: false, acked: false};
+
+    /* toggleAlertRowsExpanded flips one half of the panel open or closed. */
+    function toggleAlertRowsExpanded(which) {
+      var key = (which === 'acked') ? 'acked' : 'live';
+      _alertRowsExpanded[key] = !_alertRowsExpanded[key];
+      renderHives(_allDashHives, true);
+    }
 
     function alertTypeLabel(t) { return ALERT_TYPE_LABELS[t] || t || 'Unknown'; }
 
@@ -8513,6 +8542,88 @@ const dashboardHTML = `<!DOCTYPE html>
       } catch (e) {
         hiveToast('Error: ' + e.message, 'error');
       }
+    }
+
+    /* ── Jumping from an alert row to the hive's row in the table ──
+
+       hiveRowDomId builds the anchor id renderHives puts on each <tr>. Prefixed
+       so it can never collide with another element id, and encodeURIComponent'd
+       because a hive id is user-influenced and may contain characters that are
+       not valid raw in an id/selector. */
+    var HIVE_ROW_DOM_ID_PREFIX = 'hive-row-';
+    function hiveRowDomId(hiveId) {
+      return HIVE_ROW_DOM_ID_PREFIX + encodeURIComponent(String(hiveId || ''));
+    }
+
+    /* How long the targeted row stays highlighted. Long enough to find the row
+       after the smooth scroll finishes, short enough that a stale highlight does
+       not linger and get mistaken for a status. */
+    var HIVE_ROW_TARGET_HIGHLIGHT_MS = 2600;
+
+    /* Handle of the pending highlight-clear timer, so two jumps in quick
+       succession do not leave the first row highlighted forever. */
+    var _hiveRowTargetTimer = null;
+
+    /* focusHiveRow scrolls one hive's table row into view and highlights it.
+       Returns false when the row is not currently in the DOM. */
+    function focusHiveRow(hiveId) {
+      var row = document.getElementById(hiveRowDomId(hiveId));
+      if (!row) return false;
+      /* Clear any previous target first — only ever one highlighted row. */
+      if (_hiveRowTargetTimer) { clearTimeout(_hiveRowTargetTimer); _hiveRowTargetTimer = null; }
+      var prev = document.querySelectorAll('.hive-row-targeted');
+      (prev || []).forEach(function(el) { el.classList.remove('hive-row-targeted'); });
+
+      row.scrollIntoView({behavior: 'smooth', block: 'center'});
+      row.classList.add('hive-row-targeted');
+      /* Move keyboard focus to the row as well, so a keyboard user lands there
+         rather than being scrolled somewhere their focus ring is not. */
+      if (!row.hasAttribute('tabindex')) row.setAttribute('tabindex', '-1');
+      try { row.focus({preventScroll: true}); } catch (e) { /* focus is best-effort */ }
+
+      _hiveRowTargetTimer = setTimeout(function() {
+        row.classList.remove('hive-row-targeted');
+        _hiveRowTargetTimer = null;
+      }, HIVE_ROW_TARGET_HIGHLIGHT_MS);
+      return true;
+    }
+
+    /* jumpToHiveRow is what an "Attention needed" row does when clicked.
+
+       The hard case is a target the current view is HIDING. The hive list now
+       carries persisted filters, facets, a search box, an alert drill-down and
+       collapsible sections/groups (#2309, #2317), so the alerted hive may well
+       not be on screen. Scrolling to a row that is not in the DOM would look
+       like the click did nothing.
+
+       The choice made here: try the current view FIRST, and only if the row is
+       genuinely absent do we widen the view — clearing every narrowing control
+       and expanding the collapsed sections/groups. Filters are the user's state,
+       so they are never discarded silently: we clear them only when that is the
+       one thing that can satisfy the click, and we say so in a toast that names
+       the hive. The alternative (refusing to navigate and just warning) leaves
+       the operator to work out which of six controls is hiding the row, which is
+       the problem the panel exists to avoid. */
+    function jumpToHiveRow(hiveId, hiveName) {
+      if (!hiveId) return;
+      if (focusHiveRow(hiveId)) return;
+
+      /* Not rendered under the current view. Widen everything that can hide a
+         row, re-render synchronously, then try again. */
+      clearAllHiveFilters();
+      expandAllHiveSections();
+      _dashGroupCollapsed = {};
+      persistGroupCollapsed();
+      renderHives(_allDashHives, true);
+
+      if (focusHiveRow(hiveId)) {
+        hiveToast('Filters cleared to show ' + (hiveName || hiveId), 'info');
+        return;
+      }
+      /* Still absent: the hive is genuinely not in the loaded list (for example
+         it was deleted between the alert being evaluated and now). Say so rather
+         than leaving a click that silently did nothing. */
+      hiveToast('Could not find ' + (hiveName || hiveId) + ' in the hive list', 'error');
     }
 
     /* renderAlertsPanel draws the "Attention needed" panel above the hive list.
@@ -8638,7 +8749,11 @@ const dashboardHTML = `<!DOCTYPE html>
         rows = rows.filter(function(a) { return a.type === _alertTypeFilter; });
       }
       if (!rows.length) return '';
-      var shown = rows.slice(0, ALERT_ROWS_SHOWN);
+      /* Each half of the panel (live vs acknowledged) expands independently, so
+         expanding the acknowledged list does not also dump every live alert. */
+      var expanded = !!_alertRowsExpanded[acked ? 'acked' : 'live'];
+      var limit = expanded ? rows.length : ALERT_ROWS_SHOWN_MIN;
+      var shown = rows.slice(0, limit);
       var html = shown.map(function(a) {
         var color = ALERT_SEVERITY_COLORS[a.severity] || '#8b949e';
         var age = alertAge(a.firstSeen);
@@ -8647,24 +8762,51 @@ const dashboardHTML = `<!DOCTYPE html>
            error text), and the acking username. */
         var ackBtn = '';
         if (_isAdmin) {
+          /* jsArg for the same reason as the jump handler below: esc() leaves an
+             apostrophe intact, which would close the handler's quote early. */
           ackBtn = acked
-            ? '<button type="button" class="alert-ack-btn" onclick="ackAlert(\'' +
-              esc(a.hiveId) + '\',\'' + esc(a.type) + '\',true)">Restore</button>'
-            : '<button type="button" class="alert-ack-btn" onclick="ackAlert(\'' +
-              esc(a.hiveId) + '\',\'' + esc(a.type) + '\',false)">Acknowledge</button>';
+            ? '<button type="button" class="alert-ack-btn" onclick="ackAlert(' +
+              jsArg(a.hiveId) + ',' + jsArg(a.type) + ',true)">Restore</button>'
+            : '<button type="button" class="alert-ack-btn" onclick="ackAlert(' +
+              jsArg(a.hiveId) + ',' + jsArg(a.type) + ',false)">Acknowledge</button>';
         }
         var ackedBy = (acked && a.ackBy) ? '<span class="alert-row-reason">— ack by ' + esc(a.ackBy) + '</span>' : '';
-        return '<div class="alert-row' + (acked ? ' acked' : '') + '">' +
+        /* The row itself is a <button> that jumps to this hive's row in the
+           table below. A real button (not a div with role/tabindex) gets Enter,
+           Space and the focus ring for free.
+
+           The Acknowledge button is a SIBLING, not a child: nesting a button
+           inside a button is invalid HTML and browsers drop the inner one, which
+           would silently break acknowledging. Both sit in a flex wrapper so the
+           row still reads as one line. */
+        var label = a.hiveName || a.hiveId;
+        var jump = '<button type="button" class="alert-row' + (acked ? ' acked' : '') +
+          '" title="Show ' + escAttr(label) + ' in the hive list below"' +
+          /* jsArg, not esc: a hive or org name containing an apostrophe would
+             close the handler's quote early and break the click. */
+          ' onclick="jumpToHiveRow(' + jsArg(a.hiveId) + ',' + jsArg(label) + ')">' +
           '<span class="filter-chip-dot" style="background:' + color + '"></span>' +
-          '<span class="alert-row-hive">' + esc(a.hiveName || a.hiveId) + '</span>' +
+          '<span class="alert-row-hive">' + esc(label) + '</span>' +
           '<span class="alert-row-reason">' + esc(a.reason) + '</span>' + ackedBy +
-          '<span class="alert-row-age">' + esc(age) + '</span>' + ackBtn +
-        '</div>';
+          '<span class="alert-row-age">' + esc(age) + '</span>' +
+        '</button>';
+        return '<div class="alert-row-wrap">' + jump + ackBtn + '</div>';
       }).join('');
-      var more = rows.length > ALERT_ROWS_SHOWN
-        ? '<div class="alert-row-reason" style="font-size:0.7rem;padding-left:8px">+' +
-          (rows.length - ALERT_ROWS_SHOWN) + ' more</div>'
-        : '';
+      /* "+N more" used to be inert text, which was actively misleading once the
+         rows above it became clickable: it looked like the same kind of thing
+         and did nothing. It is now a real toggle that expands the full list in
+         place (and collapses it again), so every alerted hive is reachable —
+         which is the point, since the hive the operator needs is as likely to be
+         #7 as #1. */
+      var more = '';
+      if (rows.length > limit) {
+        more = '<button type="button" class="alert-panel-more" onclick="toggleAlertRowsExpanded(' +
+          jsArg(acked ? 'acked' : 'live') + ')">+' + (rows.length - limit) +
+          ' more</button>';
+      } else if (expanded && rows.length > ALERT_ROWS_SHOWN_MIN) {
+        more = '<button type="button" class="alert-panel-more" onclick="toggleAlertRowsExpanded(' +
+          jsArg(acked ? 'acked' : 'live') + ')">Show fewer</button>';
+      }
       return '<div class="alert-rows">' + html + more + '</div>';
     }
 
@@ -8693,6 +8835,20 @@ const dashboardHTML = `<!DOCTYPE html>
       localStorage.getItem(LS_SECTION_ASSIGNED_COLLAPSED) === 'true';
     _dashSectionCollapsed[HIVE_SECTION_UNASSIGNED] =
       localStorage.getItem(LS_SECTION_UNASSIGNED_COLLAPSED) !== 'false';
+
+    /* expandAllHiveSections opens both sections and PERSISTS that, matching
+       toggleHiveSection. An in-memory-only reset would silently re-collapse on
+       the next reload, so the row the operator was just sent to would vanish
+       again — the collapsed Unassigned pool is the default, so this matters for
+       any alert on an unassigned placeholder. */
+    function expandAllHiveSections() {
+      _dashSectionCollapsed[HIVE_SECTION_ASSIGNED] = false;
+      _dashSectionCollapsed[HIVE_SECTION_UNASSIGNED] = false;
+      try {
+        localStorage.setItem(LS_SECTION_ASSIGNED_COLLAPSED, 'false');
+        localStorage.setItem(LS_SECTION_UNASSIGNED_COLLAPSED, 'false');
+      } catch(e) {} /* private-browsing quota — expansion still works in-session */
+    }
 
     function toggleHiveSection(sectionKey) {
       _dashSectionCollapsed[sectionKey] = !_dashSectionCollapsed[sectionKey];
@@ -10343,6 +10499,9 @@ const dashboardHTML = `<!DOCTYPE html>
         '|' + _dashFailingCheckFilter + '|' + _dashDriftFilter + '|' + _dashUpgradeFilter +
         '|' + _dashAdvisoryStaleFilter +
         '|' + _alertTypeFilter + '|' + _alertShowAcked + '|' + JSON.stringify(_fleetAlerts) +
+        /* Without this, expanding "+N more" changes no hive data and the
+           early-return below would make the click a silent no-op. */
+        '|' + JSON.stringify(_alertRowsExpanded) +
         '|' + _dashSearchQuery + '|' + JSON.stringify(_dashFacets) +
         '|' + JSON.stringify(_dashFacetCollapsed) + '|' + JSON.stringify(_dashSectionCollapsed) +
         '|' + _dashGroupBy + '|' + JSON.stringify(_dashGroupCollapsed) +
@@ -10705,7 +10864,10 @@ const dashboardHTML = `<!DOCTYPE html>
           }).join('');
           pendingExpandRow = '<tr id="pending-row-' + esc(h.id) + '" style="display:none"><td colspan="' + TOTAL_COLUMNS + '"><div style="padding:8px 16px;background:rgba(59,130,246,0.05);border-radius:6px;margin:4px 0">' + prItems + '</div></td></tr>';
         }
-        return '<tr>' +
+        /* Stable per-hive anchor so the "Attention needed" panel can scroll a
+           specific row into view and highlight it. Built from the hive id, which
+           is unique across both the assigned and unassigned sections. */
+        return '<tr id="' + escAttr(hiveRowDomId(h.id)) + '">' +
           bulkCheckboxCell(h, section || 'all') +
           '<td class="hive-menu-cell" style="position:relative;width:30px;text-align:center;overflow:visible">' + (h.migrationStatus === 'migrating' ? '<span style="font-size:1.1rem;color:var(--border);user-select:none;cursor:not-allowed" title="Disabled during migration">⋮</span>' : '<span style="cursor:pointer;font-size:1.1rem;color:var(--muted);user-select:none">⋮</span>' + pendingBadge + '<div class="hive-menu-dropdown" style="display:none;position:absolute;left:0;bottom:auto;background:#1c2128;border:1px solid #30363d;border-radius:8px;min-width:160px;padding:4px 0;z-index:1000;box-shadow:0 8px 24px rgba(0,0,0,0.5)">' + menuItems.join('') + '</div>') + '</td>' +
           '<td style="text-align:left;line-height:1.4">' + (function() { var isHostedRow = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'))); var dh = isHostedRow && h.id ? ('/api/saas/hives/' + encodeURIComponent(h.id) + '/open') : (rb ? esc(rb) : ''); /* Label derived from the PROJECT (org + primary repo), not by splitting h.name — see hiveLabel. */ var label = hiveLabel(h); var orgName = label.line1; var repoName = label.line2; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var ghIcon = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : ''; /* vanityDisplay is the friendly host shown in the status bar on hover. rb is resolvedBase(h), which the hub has already overlaid with the claimed vanity_url; it is only a DISPLAY url here, never the click target — see ssoDisplayLink. Empty for a row with no vanity host, which falls back to today's /open href. Only meaningful on hosted rows: a non-hosted row's dh IS rb already. */ var vanityDisplay = isHostedRow && rb ? rb : ''; var link = function(text, bold) { if (dh) { return ssoDisplayLink(dh, vanityDisplay, text, bold ? 'hive-name-link' : 'hive-sub-link'); } var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName, true); var fcPill = h.online ? failingCheckSummary(h) : ''; /* Advisory-staleness pill sits right beside the failing-check pill: both are "something is quietly wrong with this working hive" signals, and advisoryStaleSummary already self-suppresses (empty string) unless the hub flagged the digest stale, so unaffected rows are pixel-identical. */ var advPill = h.online ? advisoryStaleSummary(h) : ''; /* Inline access faces sit on the name cell's second line, immediately after this row's own role badge: the badge already answers "what am I on this hive", so the co-members read as the natural continuation of the same thought, in the one cell that is left-aligned and has room to grow. It also keeps them out of the 16 dense metric columns, none of which is about people. Empty string when the viewer is the only member, so those rows are pixel-identical to today. */ var accessFaces = hiveAccessAvatars(h); /* Keyed off repoName, not orgName: line 1 now always carries SOME identity, so the presence of a second line is decided purely by whether there is a repo to put on it. Without a repo the row still shows the GitHub icon, role badge, faces and failing-check pill on the compact variant. */ var line2 = repoName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + '</div>'; var line3 = pendingPill ? '<div style="margin-top:4px;padding-left:18px">' + pendingPill + '</div>' : ''; return line1 + line2 + line3; })() + '</td>' +

--- a/v2/pkg/hub/saas_dashboard_facet_tray_test.go
+++ b/v2/pkg/hub/saas_dashboard_facet_tray_test.go
@@ -297,6 +297,15 @@ func TestFacetTrayLayersBelowRowHoverPanels(t *testing.T) {
 // every row must emit the same number of cells, and the colspan constants that
 // span the table must match that number. A past bug moved a <th> without moving
 // its <td>, which silently shifted every column right of it.
+// buildRowReturnAnchor locates the start of buildRow's return expression.
+//
+// Deliberately stops before the '>' of the <tr>: the row now carries an id
+// attribute (the anchor the "Attention needed" panel scrolls to), and matching
+// the bare "return '<tr>' +" broke the moment that attribute was added. These
+// tests are about which CELLS the row emits, so they must not be coupled to the
+// <tr>'s attributes.
+const buildRowReturnAnchor = "return '<tr"
+
 func TestHiveTableColumnCountsAgree(t *testing.T) {
 	html := dashScript(t)
 
@@ -320,7 +329,7 @@ func TestHiveTableColumnCountsAgree(t *testing.T) {
 	if bStart < 0 {
 		t.Fatal("could not find buildRow")
 	}
-	retIdx := strings.Index(html[bStart:], "return '<tr>' +")
+	retIdx := strings.Index(html[bStart:], buildRowReturnAnchor)
 	if retIdx < 0 {
 		t.Fatal("could not find buildRow's return")
 	}
@@ -392,7 +401,7 @@ func TestDriftColumnSitsRightOfJourney(t *testing.T) {
 
 	// --- body order, over the same expression the row is built from.
 	bStart := strings.Index(html, "var buildRow = function(h, i, section) {")
-	retIdx := strings.Index(html[bStart:], "return '<tr>' +")
+	retIdx := strings.Index(html[bStart:], buildRowReturnAnchor)
 	rStart := bStart + retIdx
 	rEnd := strings.Index(html[rStart:], "'</tr>' + pendingExpandRow;")
 	if bStart < 0 || retIdx < 0 || rEnd < 0 {


### PR DESCRIPTION
Two dashboard defects reported against the hub, in one PR because both are about the "Attention needed" panel failing to do what it looks like it does.

## Bug 1 — alert rows were not clickable

> "clicking on one of these items should take me to its entry in the hive hub's spoke table"

Each alert row is now a real `<button>` that scrolls the hive's table row into view and highlights it briefly. Real buttons rather than a `<div>` with `role`/`tabindex`, so Enter, Space and the focus ring come for free.

The Acknowledge button is a **sibling**, not a child — nesting a button inside a button is invalid HTML and browsers drop the inner one, which would have silently broken acknowledging while fixing navigation.

Each `<tr>` now carries a stable per-hive anchor id.

### A target hidden by filters or sort

The hive list now carries persisted filters, facets, a search box, an alert drill-down and collapsible sections/groups (#2309, #2317), so the alerted hive may not be rendered at all. Scrolling to a row that is not in the DOM would look like the click did nothing.

The jump tries the **current view first**, and only if the row is genuinely absent does it widen: clear every narrowing control, expand the collapsed sections/groups, re-render, and **say so in a toast that names the hive**. Filter state is never discarded silently — only when that is the one thing that can satisfy the click, and never without telling the operator.

The alternative (refuse to navigate, just warn) leaves the operator to work out which of six controls is hiding the row — precisely the problem the panel exists to avoid.

There is **no pagination** on this table, so sort only changes a row's position, never its presence. Filters and collapse are the only things that can hide a target.

Section expansion is persisted to `localStorage` to match `toggleHiveSection`. An in-memory-only reset would re-collapse on the next reload and hide the row again — which matters, because the Unassigned pool is collapsed **by default**.

### "+N more"

Was inert text, and became *actively misleading* once the rows above it turned into buttons — it looked like the same kind of thing and did nothing. It is now a real toggle that expands the full list in place (with "Show fewer" to collapse), so every alerted hive is reachable. The live and acknowledged halves expand independently, so expanding one does not dump the other.

Not persisted: an expanded list is a momentary "show me the rest", not a view preference, and a panel reloading 50 rows deep would bury the hive table.

## Bug 2 — acknowledging did not remove the alert

> "acknowledging an alert does not remove it from the alert window"

**Root cause confirmed.** `AlertTypeFailedUpgrade` was missing from `knownAlertTypes` (the type shipped in #2308 without being registered), so `handleAlertAck` rejected it with HTTP 400 and the row stayed in the panel.

### Full audit — all 8 `AlertType*` constants

| Constant | Registered before |
|---|---|
| `AlertTypeCrashLoop` | yes |
| `AlertTypeOffline` | yes |
| `AlertTypeStuckUpgrade` | yes |
| **`AlertTypeFailedUpgrade`** | **NO — the bug** |
| `AlertTypeHealthCheckFailing` | yes |
| `AlertTypeTokenBurn` | yes |
| `AlertTypeProvisionError` | yes |
| `AlertTypeAdvisoryStale` | yes |

`AlertTypeFailedUpgrade` was the **only** one missing.

Rather than fix the one entry and leave the next person to recreate the bug, `TestKnownAlertTypesCoversEveryAlertType` **parses `alerts.go`** for every `AlertType*` constant and asserts each is registered — plus the reverse, that no registry entry lacks a constant behind it. A hand-written list is exactly the thing that drifted here, so the test discovers types by naming convention and needs no edit when one is added.

Verified this fails without the fix:

```
AlertTypeFailedUpgrade ("failed-upgrade") is not in knownAlertTypes:
its ack endpoint returns 400 and the alert can never be dismissed

acking failed-upgrade returned 400, want 200 (body: {"error":"unknown alert type"})
```

### Was the failure silent?

**Nearly.** `ackAlert` does check `!resp.ok` and toast — so it was not completely silent — but the message was useless, and the reason was thrown away by a subtle bug:

`handleAlertAck` used `http.Error`, which forces `Content-Type: text/plain` **even though the body was JSON**. So the dashboard's `await resp.json()` threw, `.catch()` returned `{}`, `data.error` was `undefined`, and the operator got a generic *"Failed to update alert"* that never said why. The reason is the entire point of the message when an ack appears to do nothing.

Now uses the existing `writeJSONError` helper, and the unknown-type message names the offending type.

### Does the ack persist?

**Yes — verified, not assumed.** Acks are written to `/data/saas/hub-alert-acks.json` (on the PVC) via write-tmp-then-atomic-rename, and `loadAlertAcks` reloads them at startup. `TestAckFailedUpgradeSucceedsAndSurvivesRestart` now covers the whole path — ack → new `HubServer` → `loadAlertAcks` → alert still acknowledged — so an ack that silently evaporated on restart would fail CI.

## Overlap with #2338

None. #2338 adds `AlertTypeURLUnreachable` and registers it in `knownAlertTypes`, and its author explicitly left `AlertTypeFailedUpgrade` out to keep that PR's scope honest. This PR takes exactly that remainder. Both edit the same map literal, so a trivial textual conflict is possible depending on merge order — the new invariant test protects whichever lands second.

## Incidental

- The existing ack handlers used `esc()` to build inline `onclick` arguments. `esc()` leaves an apostrophe intact, so a hive or org name containing one would close the handler's quote early and break the button. Switched to the purpose-built `jsArg()` helper, which is what it exists for.
- `TestHiveTableColumnCountsAgree` and `TestDriftColumnSitsRightOfJourney` anchored on the literal `return '<tr>' +`, which the new id attribute broke. Their anchor now stops before the `>`: they assert which **cells** a row emits and must not be coupled to the `<tr>`'s attributes. Confirmed they still catch a real column mismatch (injected a spurious `<td>` → `header emits 18 <th> cells but a row emits 19`).

## Verified by running

- `go build ./...` clean; **full `pkg/hub` suite green**; `go vet` silent; `gofmt` clean on every file touched
- Both new tests confirmed to **fail without the fix** and pass with it
- Column tests confirmed to still detect a genuine column mismatch
- **`node --check` on the extracted `dashboardHTML` JS: OK** (4 script blocks, 435,372 chars)
- **Base-vs-current delta identical**: brace `0`→`0`, paren `-1`→`-1`, bracket `-1`→`-1` (the `-1`s are pre-existing, from literals inside strings — absolute counts are meaningless, the match is what matters)
- Grepped the extraction to confirm every addition is present and that all new declarations are **top-level** (indent 4), not swallowed into an enclosing function — the failure mode `TestDashboardScriptBracesAreBalanced` exists to catch
- No backtick and no literal `<body>` tag introduced into the raw string

Read-only throughout; no hive was mutated.