### PR TITLE
✅ test(agent,hub): raise coverage toward the 90% floor with mutation-verified tests

### DIFF
--- a/v2/pkg/agent/config_has_tokens_test.go
+++ b/v2/pkg/agent/config_has_tokens_test.go
@@ -1,0 +1,113 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestConfigHasTokensChecksBothSources pins the two-source contract that
+// decides whether an agent stuck on a login prompt can be auto-restarted: a
+// valid token in EITHER the Claude credentials file or the Copilot config
+// counts, and only the absence of both reads as "no credentials".
+//
+// Getting this wrong in either direction is costly: a false negative leaves a
+// working agent parked on a login prompt, and a false positive restarts it into
+// the same prompt forever.
+func TestConfigHasTokensChecksBothSources(t *testing.T) {
+	// A Claude credentials file with a far-future expiry, so HasValidToken
+	// treats it as usable rather than expired.
+	const validClaudeCreds = `{"claudeAiOauth":{"accessToken":"sk-ant-test","expiresAt":99999999999999}}`
+	// A Copilot config with one token entry, including the // comment line the
+	// Copilot CLI writes.
+	const copilotWithTokens = "// managed file\n{\n  \"copilotTokens\": {\"user\": \"gho_abc\"}\n}\n"
+	const copilotNoTokens = `{"copilotTokens":{}}`
+
+	tests := []struct {
+		name string
+		// claude and copilot are file contents; an empty string means the file
+		// is not created at all.
+		claude  string
+		copilot string
+		want    bool
+	}{
+		{
+			name:   "claude credentials alone are enough",
+			claude: validClaudeCreds,
+			want:   true,
+		},
+		{
+			name:    "copilot tokens alone are enough",
+			copilot: copilotWithTokens,
+			want:    true,
+		},
+		{
+			name:    "either source suffices when both are present",
+			claude:  validClaudeCreds,
+			copilot: copilotWithTokens,
+			want:    true,
+		},
+		{
+			name:    "claude valid, copilot empty still counts",
+			claude:  validClaudeCreds,
+			copilot: copilotNoTokens,
+			want:    true,
+		},
+		{
+			name:    "neither source has a token",
+			copilot: copilotNoTokens,
+			want:    false,
+		},
+		{
+			name: "both files missing",
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			claudePath := filepath.Join(dir, "credentials.json")
+			copilotPath := filepath.Join(dir, "config.json")
+
+			if tc.claude != "" {
+				if err := os.WriteFile(claudePath, []byte(tc.claude), 0o600); err != nil {
+					t.Fatalf("write claude creds: %v", err)
+				}
+			}
+			if tc.copilot != "" {
+				if err := os.WriteFile(copilotPath, []byte(tc.copilot), 0o600); err != nil {
+					t.Fatalf("write copilot config: %v", err)
+				}
+			}
+			withSharedPaths(t, copilotPath, claudePath)
+
+			if got := configHasTokens(); got != tc.want {
+				t.Errorf("configHasTokens() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestConfigHasTokensFallsThroughToCopilot is the specific ordering check: an
+// unusable Claude credentials file must not short-circuit the result, it must
+// fall through to the Copilot config.
+func TestConfigHasTokensFallsThroughToCopilot(t *testing.T) {
+	dir := t.TempDir()
+	claudePath := filepath.Join(dir, "credentials.json")
+	copilotPath := filepath.Join(dir, "config.json")
+
+	// Present but unparseable, so HasValidToken cannot succeed.
+	if err := os.WriteFile(claudePath, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write claude creds: %v", err)
+	}
+	if err := os.WriteFile(copilotPath,
+		[]byte("{\"copilotTokens\": {\"user\": \"gho_abc\"}}"), 0o600); err != nil {
+		t.Fatalf("write copilot config: %v", err)
+	}
+	withSharedPaths(t, copilotPath, claudePath)
+
+	if !configHasTokens() {
+		t.Error("configHasTokens() = false, want true: a broken Claude file must fall through to Copilot")
+	}
+}

--- a/v2/pkg/agent/manager_authz_count_test.go
+++ b/v2/pkg/agent/manager_authz_count_test.go
@@ -1,0 +1,265 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// acmmLevelPushCapable is an ACMM level at which the "quality" agent defaults
+// to ModeIssuesAndPRs (push-capable). See DefaultAgentMode.
+const acmmLevelPushCapable = 3
+
+// acmmLevelAdvisoryOnly is an ACMM level at which every agent defaults to
+// ModeAdvisory, so no agent may open a PR.
+const acmmLevelAdvisoryOnly = 1
+
+// testUIDBase is an arbitrary non-root base UID for the synthetic UID maps in
+// these tests; the exact value is irrelevant as long as it is > 0.
+const testUIDBase = 5000
+
+// ── CountAgentsWithModel ────────────────────────────────────────────────────
+
+// TestCountAgentsWithModel pins the documented contract: an agent counts when
+// EITHER a backend or a model is set, from the config or from any of the three
+// override fields. Only a wholly empty backend AND model reads as unassigned.
+func TestCountAgentsWithModel(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent *AgentProcess
+		want  bool
+	}{
+		{
+			name:  "backend from config counts",
+			agent: &AgentProcess{Name: "a", Config: config.AgentConfig{Backend: "claude"}},
+			want:  true,
+		},
+		{
+			name:  "model from config counts",
+			agent: &AgentProcess{Name: "a", Config: config.AgentConfig{Model: "opus"}},
+			want:  true,
+		},
+		{
+			name:  "backend override counts when config is empty",
+			agent: &AgentProcess{Name: "a", BackendOverride: "copilot"},
+			want:  true,
+		},
+		{
+			name:  "model override counts when config is empty",
+			agent: &AgentProcess{Name: "a", ModelOverride: "sonnet"},
+			want:  true,
+		},
+		{
+			name:  "pinned model counts when config is empty",
+			agent: &AgentProcess{Name: "a", PinnedModel: "haiku"},
+			want:  true,
+		},
+		{
+			name:  `"auto" is a deliberate routing selection, not an absence`,
+			agent: &AgentProcess{Name: "a", Config: config.AgentConfig{Model: "auto"}},
+			want:  true,
+		},
+		{
+			name:  `"default" is a deliberate routing selection, not an absence`,
+			agent: &AgentProcess{Name: "a", Config: config.AgentConfig{Backend: "default"}},
+			want:  true,
+		},
+		{
+			name:  "wholly empty does not count",
+			agent: &AgentProcess{Name: "a"},
+			want:  false,
+		},
+		{
+			name:  "whitespace-only backend and model do not count",
+			agent: &AgentProcess{Name: "a", Config: config.AgentConfig{Backend: "  ", Model: "\t"}},
+			want:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := testManager(acmmLevelPushCapable)
+			m.agents["a"] = tc.agent
+
+			got := m.CountAgentsWithModel()
+			want := 0
+			if tc.want {
+				want = 1
+			}
+			if got != want {
+				t.Errorf("CountAgentsWithModel() = %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+// TestCountAgentsWithModelSkipsNil guards the nil-entry skip: a nil map value
+// must not be counted and must not panic.
+func TestCountAgentsWithModelSkipsNil(t *testing.T) {
+	m := testManager(acmmLevelPushCapable)
+	m.agents["assigned"] = &AgentProcess{Name: "assigned", Config: config.AgentConfig{Backend: "claude"}}
+	m.agents["nil-entry"] = nil
+	m.agents["unassigned"] = &AgentProcess{Name: "unassigned"}
+
+	if got := m.CountAgentsWithModel(); got != 1 {
+		t.Errorf("CountAgentsWithModel() = %d, want 1 (only the assigned agent)", got)
+	}
+}
+
+// TestCountAgentsWithModelOverrideBeatsEmptyConfig checks that an override on a
+// config-less agent is what makes it count — i.e. the override fields are
+// really consulted rather than the config alone.
+func TestCountAgentsWithModelOverrideBeatsEmptyConfig(t *testing.T) {
+	m := testManager(acmmLevelPushCapable)
+	a := &AgentProcess{Name: "a"}
+	m.agents["a"] = a
+
+	if got := m.CountAgentsWithModel(); got != 0 {
+		t.Fatalf("precondition: unassigned agent counted %d, want 0", got)
+	}
+	a.ModelOverride = "opus"
+	if got := m.CountAgentsWithModel(); got != 1 {
+		t.Errorf("after setting ModelOverride: got %d, want 1", got)
+	}
+}
+
+// ── AuthorizePROpen ─────────────────────────────────────────────────────────
+
+// TestAuthorizePROpenAllowsPushCapableAgent is the happy path: a push-capable
+// agent, with a UID map that confirms it owns the request file, is authorized.
+func TestAuthorizePROpenAllowsPushCapableAgent(t *testing.T) {
+	m := testManager(acmmLevelPushCapable)
+	m.agents["quality"] = &AgentProcess{Name: "quality"}
+	m.uidMap = &UIDMap{BaseUID: testUIDBase, Agents: map[string]int{"quality": testUIDBase}}
+
+	if err := m.AuthorizePROpen("quality", testUIDBase); err != nil {
+		t.Errorf("AuthorizePROpen() = %v, want nil (quality is push-capable at ACMM %d)", err, acmmLevelPushCapable)
+	}
+}
+
+// TestAuthorizePROpenRejectsEmptyAgentName covers the first guard: a request
+// naming no agent is never authorized.
+func TestAuthorizePROpenRejectsEmptyAgentName(t *testing.T) {
+	m := testManager(acmmLevelPushCapable)
+
+	for _, name := range []string{"", "   "} {
+		err := m.AuthorizePROpen(name, testUIDBase)
+		if err == nil {
+			t.Fatalf("AuthorizePROpen(%q) = nil, want an error", name)
+		}
+		if !strings.Contains(err.Error(), "no agent named") {
+			t.Errorf("AuthorizePROpen(%q) error = %q, want it to mention the missing agent name", name, err)
+		}
+	}
+}
+
+// TestAuthorizePROpenRejectsForgedAgentName is the core forge check: agent A
+// may not open a PR using a request file owned by agent B.
+func TestAuthorizePROpenRejectsForgedAgentName(t *testing.T) {
+	m := testManager(acmmLevelPushCapable)
+	m.agents["quality"] = &AgentProcess{Name: "quality"}
+	m.agents["scanner"] = &AgentProcess{Name: "scanner"}
+	m.uidMap = &UIDMap{BaseUID: testUIDBase, Agents: map[string]int{
+		"quality": testUIDBase,
+		"scanner": testUIDBase + 1,
+	}}
+
+	// "quality" claims the request, but the file is owned by "scanner"'s UID.
+	err := m.AuthorizePROpen("quality", testUIDBase+1)
+	if err == nil {
+		t.Fatal("AuthorizePROpen() = nil, want a denial: the file is owned by a different agent")
+	}
+	if !strings.Contains(err.Error(), "scanner") {
+		t.Errorf("error = %q, want it to name the real owning agent", err)
+	}
+}
+
+// TestAuthorizePROpenRejectsUnknownUID covers a UID present on the file but
+// absent from the map — an unregistered process, not an agent.
+func TestAuthorizePROpenRejectsUnknownUID(t *testing.T) {
+	m := testManager(acmmLevelPushCapable)
+	m.agents["quality"] = &AgentProcess{Name: "quality"}
+	m.uidMap = &UIDMap{BaseUID: testUIDBase, Agents: map[string]int{"quality": testUIDBase}}
+
+	err := m.AuthorizePROpen("quality", testUIDBase+99)
+	if err == nil {
+		t.Fatal("AuthorizePROpen() = nil, want a denial for an unregistered uid")
+	}
+	if !strings.Contains(err.Error(), "unknown uid") {
+		t.Errorf("error = %q, want it to report an unknown uid", err)
+	}
+}
+
+// TestAuthorizePROpenSkipsForgeCheckWithoutUIDs documents the deliberate
+// fallback: with no UID map, or a non-positive file UID, ownership is
+// unverifiable and only the ACMM gate applies. It must NOT hard-fail.
+func TestAuthorizePROpenSkipsForgeCheckWithoutUIDs(t *testing.T) {
+	t.Run("no uid map", func(t *testing.T) {
+		m := testManager(acmmLevelPushCapable)
+		m.agents["quality"] = &AgentProcess{Name: "quality"}
+		// uidMap intentionally nil.
+		if err := m.AuthorizePROpen("quality", testUIDBase); err != nil {
+			t.Errorf("AuthorizePROpen() = %v, want nil (no uid map → ACMM check alone)", err)
+		}
+	})
+
+	t.Run("non-positive file uid", func(t *testing.T) {
+		m := testManager(acmmLevelPushCapable)
+		m.agents["quality"] = &AgentProcess{Name: "quality"}
+		m.uidMap = &UIDMap{BaseUID: testUIDBase, Agents: map[string]int{"quality": testUIDBase}}
+		if err := m.AuthorizePROpen("quality", 0); err != nil {
+			t.Errorf("AuthorizePROpen() = %v, want nil (fileUID <= 0 → ACMM check alone)", err)
+		}
+	})
+}
+
+// TestAuthorizePROpenRejectsUnknownAgent covers a well-formed request naming an
+// agent this manager does not run.
+func TestAuthorizePROpenRejectsUnknownAgent(t *testing.T) {
+	m := testManager(acmmLevelPushCapable)
+
+	err := m.AuthorizePROpen("ghost", 0)
+	if err == nil {
+		t.Fatal("AuthorizePROpen() = nil, want a denial for an unknown agent")
+	}
+	if !strings.Contains(err.Error(), "unknown agent") {
+		t.Errorf("error = %q, want it to report an unknown agent", err)
+	}
+}
+
+// TestAuthorizePROpenEnforcesACMMWriteGate is the policy check that matters
+// most: an advisory-only agent may not open a PR even when the forge check
+// passes cleanly. This mirrors the `gh pr create` CanPush() gate.
+func TestAuthorizePROpenEnforcesACMMWriteGate(t *testing.T) {
+	m := testManager(acmmLevelAdvisoryOnly)
+	m.agents["quality"] = &AgentProcess{Name: "quality"}
+	m.uidMap = &UIDMap{BaseUID: testUIDBase, Agents: map[string]int{"quality": testUIDBase}}
+
+	err := m.AuthorizePROpen("quality", testUIDBase)
+	if err == nil {
+		t.Fatalf("AuthorizePROpen() = nil, want a denial: no agent is push-capable at ACMM %d", acmmLevelAdvisoryOnly)
+	}
+	if !strings.Contains(err.Error(), "not push-capable") {
+		t.Errorf("error = %q, want it to report the agent is not push-capable", err)
+	}
+}
+
+// TestAuthorizePROpenHonoursExplicitAdvisoryMode checks that an explicit
+// per-agent Mode override in config also closes the gate, not just the ACMM
+// level default — the override is what an operator sets to demote one agent.
+func TestAuthorizePROpenHonoursExplicitAdvisoryMode(t *testing.T) {
+	m := testManager(acmmLevelPushCapable)
+	m.agents["quality"] = &AgentProcess{
+		Name:   "quality",
+		Config: config.AgentConfig{Mode: ModeAdvisory.String()},
+	}
+
+	err := m.AuthorizePROpen("quality", 0)
+	if err == nil {
+		t.Fatal("AuthorizePROpen() = nil, want a denial: config Mode pins this agent to advisory")
+	}
+	if !strings.Contains(err.Error(), "not push-capable") {
+		t.Errorf("error = %q, want it to report the agent is not push-capable", err)
+	}
+}

--- a/v2/pkg/agent/permissions_fixentry_test.go
+++ b/v2/pkg/agent/permissions_fixentry_test.go
@@ -1,0 +1,271 @@
+package agent
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Deliberately restrictive starting modes: neither grants the group access
+// that agents sharing the node group require.
+const (
+	// tooTightDirMode lacks every group bit (needs g+rwx to be traversable).
+	tooTightDirMode os.FileMode = 0o700
+	// tooTightFileMode lacks every group bit (needs g+rw to be shared).
+	tooTightFileMode os.FileMode = 0o600
+	// alreadyOpenDirMode already satisfies DirPerms.
+	alreadyOpenDirMode os.FileMode = 0o775
+	// alreadyOpenFileMode already satisfies FilePerms.
+	alreadyOpenFileMode os.FileMode = 0o664
+)
+
+// quietLogger discards output so an expected chown failure (these tests run
+// unprivileged) does not spam the test log.
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// statMode returns the current permission bits of path.
+func statMode(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return fi.Mode().Perm()
+}
+
+// runningAsDevUID reports whether this test process is the uid the watcher
+// treats as "ours". The chmod arm of fixEntry is deliberately reachable only
+// for entries owned by DevUID (or ones it just chowned to DevUID), so the
+// mode-widening assertions only apply when that precondition genuinely holds.
+func runningAsDevUID() bool { return os.Getuid() == DevUID }
+
+// mkTightDir creates a directory with no group bits set.
+func mkTightDir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.Mkdir(path, tooTightDirMode); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	// Mkdir is umask-filtered, so pin the mode explicitly.
+	if err := os.Chmod(path, tooTightDirMode); err != nil {
+		t.Fatalf("chmod %s: %v", path, err)
+	}
+}
+
+// mkTightFile creates a file with no group bits set.
+func mkTightFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("x"), tooTightFileMode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	if err := os.Chmod(path, tooTightFileMode); err != nil {
+		t.Fatalf("chmod %s: %v", path, err)
+	}
+}
+
+// TestFixEntrySkipsEntriesOwnedByOtherUsers pins the guard that keeps the
+// watcher quiet in production: an entry owned by neither DevUID nor root is
+// left completely alone, because chmod-ing another user's file would only
+// produce "operation not permitted" spam on every tick.
+//
+// Unprivileged test processes are exactly this case, so this is the arm that
+// actually executes here.
+func TestFixEntrySkipsEntriesOwnedByOtherUsers(t *testing.T) {
+	if runningAsDevUID() {
+		t.Skip("this process IS DevUID, so the skip arm is unreachable")
+	}
+	root := t.TempDir()
+
+	dir := filepath.Join(root, "other-owner-dir")
+	mkTightDir(t, dir)
+	file := filepath.Join(root, "other-owner-file")
+	mkTightFile(t, file)
+
+	for _, tc := range []struct {
+		path string
+		want os.FileMode
+	}{
+		{dir, tooTightDirMode},
+		{file, tooTightFileMode},
+	} {
+		fi, err := os.Stat(tc.path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", tc.path, err)
+		}
+		fixEntry(tc.path, fi, quietLogger())
+
+		if got := statMode(t, tc.path); got != tc.want {
+			t.Errorf("%s mode = %v, want it left at %v: entries owned by another user must be skipped",
+				filepath.Base(tc.path), got, tc.want)
+		}
+	}
+}
+
+// TestFixEntryWidensOwnedEntries covers the corrective arm: for entries the
+// watcher may touch, a directory gains DirPerms and a file gains FilePerms so
+// agents sharing the node group can use them.
+func TestFixEntryWidensOwnedEntries(t *testing.T) {
+	if !runningAsDevUID() {
+		t.Skipf("chmod arm requires the process to run as DevUID (%d); running as %d", DevUID, os.Getuid())
+	}
+	root := t.TempDir()
+
+	dir := filepath.Join(root, "tight-dir")
+	mkTightDir(t, dir)
+	file := filepath.Join(root, "tight-file")
+	mkTightFile(t, file)
+
+	for _, tc := range []struct {
+		path string
+		want os.FileMode
+	}{
+		{dir, DirPerms},
+		{file, FilePerms},
+	} {
+		fi, err := os.Stat(tc.path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", tc.path, err)
+		}
+		fixEntry(tc.path, fi, quietLogger())
+
+		if got := statMode(t, tc.path); got&tc.want != tc.want {
+			t.Errorf("%s mode = %v, want it to include %v", filepath.Base(tc.path), got, tc.want)
+		}
+	}
+}
+
+// TestFixEntryLeavesSufficientModesAlone checks the watcher is non-destructive
+// and idempotent: an entry that already satisfies the required bits must come
+// back byte-identical, never narrowed to exactly DirPerms/FilePerms. This holds
+// regardless of ownership, so it runs everywhere.
+func TestFixEntryLeavesSufficientModesAlone(t *testing.T) {
+	root := t.TempDir()
+
+	dir := filepath.Join(root, "open-dir")
+	if err := os.Mkdir(dir, alreadyOpenDirMode); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(dir, alreadyOpenDirMode); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	file := filepath.Join(root, "open-file")
+	if err := os.WriteFile(file, []byte("x"), alreadyOpenFileMode); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.Chmod(file, alreadyOpenFileMode); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	for _, tc := range []struct {
+		path string
+		want os.FileMode
+	}{
+		{dir, alreadyOpenDirMode},
+		{file, alreadyOpenFileMode},
+	} {
+		fi, err := os.Stat(tc.path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", tc.path, err)
+		}
+		fixEntry(tc.path, fi, quietLogger())
+
+		if got := statMode(t, tc.path); got != tc.want {
+			t.Errorf("%s mode = %v, want it unchanged at %v", filepath.Base(tc.path), got, tc.want)
+		}
+	}
+}
+
+// TestFixPermissionsWalksNestedEntries checks the walk really descends: bob
+// creates its chat tree several levels below the watched root, so a shallow
+// scan would leave it unfixed. Ownership decides whether each entry is then
+// modified, but every entry must at least be visited — asserted here by the
+// walk completing over a deep tree without error and leaving a
+// sufficiently-permissive nested entry untouched.
+func TestFixPermissionsWalksNestedEntries(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "watched")
+	nested := filepath.Join(root, "tmp", "some-uuid", "chats")
+	if err := os.MkdirAll(nested, alreadyOpenDirMode); err != nil {
+		t.Fatalf("mkdirall: %v", err)
+	}
+	if err := os.Chmod(nested, alreadyOpenDirMode); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	deepFile := filepath.Join(nested, "session.jsonl")
+	if err := os.WriteFile(deepFile, []byte("{}"), alreadyOpenFileMode); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.Chmod(deepFile, alreadyOpenFileMode); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	origWatched, origGoose := WatchedHomeDirs, GooseLogsDir
+	WatchedHomeDirs = []string{root}
+	GooseLogsDir = filepath.Join(root, "goose-logs")
+	t.Cleanup(func() { WatchedHomeDirs = origWatched; GooseLogsDir = origGoose })
+
+	fixPermissions(quietLogger())
+
+	// Already-sufficient modes must survive the walk unchanged.
+	if got := statMode(t, nested); got != alreadyOpenDirMode {
+		t.Errorf("nested dir mode = %v, want it unchanged at %v", got, alreadyOpenDirMode)
+	}
+	if got := statMode(t, deepFile); got != alreadyOpenFileMode {
+		t.Errorf("nested file mode = %v, want it unchanged at %v", got, alreadyOpenFileMode)
+	}
+}
+
+// TestFixPermissionsRecreatesMissingRoot covers the self-healing arm: a watched
+// root that does not exist yet must be created by the scan, not skipped
+// forever. Without this, a volume mounted empty would never get its
+// agent-writable directories.
+func TestFixPermissionsRecreatesMissingRoot(t *testing.T) {
+	base := t.TempDir()
+	missing := filepath.Join(base, "not-yet-created")
+
+	origWatched, origGoose := WatchedHomeDirs, GooseLogsDir
+	WatchedHomeDirs = []string{missing}
+	GooseLogsDir = filepath.Join(base, "goose-logs")
+	t.Cleanup(func() { WatchedHomeDirs = origWatched; GooseLogsDir = origGoose })
+
+	if _, err := os.Stat(missing); !os.IsNotExist(err) {
+		t.Fatalf("precondition: %s already exists", missing)
+	}
+
+	fixPermissions(quietLogger())
+
+	fi, err := os.Stat(missing)
+	if err != nil {
+		t.Fatalf("watched root was not created: %v", err)
+	}
+	if !fi.IsDir() {
+		t.Errorf("%s is not a directory", missing)
+	}
+	// ensureWatchedDirs also creates the goose log dir, which goose panics
+	// without.
+	if _, err := os.Stat(GooseLogsDir); err != nil {
+		t.Errorf("goose logs dir was not created: %v", err)
+	}
+}
+
+// TestFixPermissionsSkipsNonDirectoryRoot covers the guard for a watched path
+// that exists but is a regular file: it must be skipped rather than walked.
+func TestFixPermissionsSkipsNonDirectoryRoot(t *testing.T) {
+	root := t.TempDir()
+	notADir := filepath.Join(root, "regular-file")
+	mkTightFile(t, notADir)
+
+	origWatched, origGoose := WatchedHomeDirs, GooseLogsDir
+	WatchedHomeDirs = []string{notADir}
+	GooseLogsDir = filepath.Join(root, "goose-logs")
+	t.Cleanup(func() { WatchedHomeDirs = origWatched; GooseLogsDir = origGoose })
+
+	fixPermissions(quietLogger())
+
+	if got := statMode(t, notADir); got != tooTightFileMode {
+		t.Errorf("mode = %v, want it left at %v: a non-directory root must be skipped", got, tooTightFileMode)
+	}
+}

--- a/v2/pkg/agent/record_prompt_test.go
+++ b/v2/pkg/agent/record_prompt_test.go
@@ -1,0 +1,143 @@
+package agent
+
+import (
+	"sync"
+	"testing"
+)
+
+// recordedPrompt is one invocation captured by the test callback.
+type recordedPrompt struct {
+	agent   string
+	trigger string
+	prompt  string
+}
+
+// TestRecordPromptCallbackRoundTrip pins the wiring contract: once a callback
+// is set, recordPrompt forwards the agent, trigger and full prompt text to it
+// verbatim.
+func TestRecordPromptCallbackRoundTrip(t *testing.T) {
+	m := testManager(acmmLevelPushCapable)
+
+	var got []recordedPrompt
+	m.SetRecordPromptCallback(func(agent, trigger, prompt string) {
+		got = append(got, recordedPrompt{agent, trigger, prompt})
+	})
+
+	m.recordPrompt("quality", "kick", "review the open PRs")
+
+	if len(got) != 1 {
+		t.Fatalf("callback fired %d times, want 1", len(got))
+	}
+	want := recordedPrompt{"quality", "kick", "review the open PRs"}
+	if got[0] != want {
+		t.Errorf("callback received %+v, want %+v", got[0], want)
+	}
+}
+
+// TestRecordPromptWithoutCallbackIsNoOp checks the unwired case: a manager that
+// never had a callback set must swallow the call rather than panic on a nil
+// dereference. Every kick path calls recordPrompt unconditionally.
+func TestRecordPromptWithoutCallbackIsNoOp(t *testing.T) {
+	m := testManager(acmmLevelPushCapable)
+
+	// Must not panic.
+	m.recordPrompt("quality", "kick", "some prompt")
+}
+
+// TestSetRecordPromptCallbackNilClears covers the documented "a nil fn clears
+// it" rule: after clearing, a previously wired callback must stop firing.
+func TestSetRecordPromptCallbackNilClears(t *testing.T) {
+	m := testManager(acmmLevelPushCapable)
+
+	calls := 0
+	m.SetRecordPromptCallback(func(agent, trigger, prompt string) { calls++ })
+	m.recordPrompt("quality", "kick", "first")
+	if calls != 1 {
+		t.Fatalf("precondition: callback fired %d times, want 1", calls)
+	}
+
+	m.SetRecordPromptCallback(nil)
+	m.recordPrompt("quality", "kick", "second")
+
+	if calls != 1 {
+		t.Errorf("callback fired %d times after being cleared, want it to stay at 1", calls)
+	}
+}
+
+// TestSetRecordPromptCallbackReplaces checks a second Set replaces rather than
+// chains: only the most recently wired callback receives the prompt.
+func TestSetRecordPromptCallbackReplaces(t *testing.T) {
+	m := testManager(acmmLevelPushCapable)
+
+	firstCalls, secondCalls := 0, 0
+	m.SetRecordPromptCallback(func(agent, trigger, prompt string) { firstCalls++ })
+	m.SetRecordPromptCallback(func(agent, trigger, prompt string) { secondCalls++ })
+
+	m.recordPrompt("quality", "kick", "prompt")
+
+	if firstCalls != 0 {
+		t.Errorf("the replaced callback fired %d times, want 0", firstCalls)
+	}
+	if secondCalls != 1 {
+		t.Errorf("the current callback fired %d times, want 1", secondCalls)
+	}
+}
+
+// TestRecordPromptSafeUnderManagerLock is the reason the callback lives in an
+// atomic rather than behind m.mu: recordPrompt is documented as safe to call
+// with m.mu already held, so it must not re-acquire it. If it did, this would
+// deadlock rather than fail.
+func TestRecordPromptSafeUnderManagerLock(t *testing.T) {
+	m := testManager(acmmLevelPushCapable)
+
+	fired := false
+	m.SetRecordPromptCallback(func(agent, trigger, prompt string) { fired = true })
+
+	m.mu.Lock()
+	m.recordPrompt("quality", "kick", "prompt while holding the lock")
+	m.mu.Unlock()
+
+	if !fired {
+		t.Error("callback did not fire when recordPrompt was called under m.mu")
+	}
+}
+
+// TestRecordPromptConcurrent exercises the atomic under the race detector:
+// concurrent Set and recordPrompt calls must not race. Run with -race in CI.
+func TestRecordPromptConcurrent(t *testing.T) {
+	// concurrentIterations is enough to interleave setters and firers without
+	// making the test slow.
+	const concurrentIterations = 100
+
+	m := testManager(acmmLevelPushCapable)
+	var mu sync.Mutex
+	calls := 0
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < concurrentIterations; i++ {
+			m.SetRecordPromptCallback(func(agent, trigger, prompt string) {
+				mu.Lock()
+				calls++
+				mu.Unlock()
+			})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < concurrentIterations; i++ {
+			m.recordPrompt("quality", "kick", "prompt")
+		}
+	}()
+	wg.Wait()
+
+	// The exact count depends on interleaving; the contract under test is that
+	// neither goroutine panics or races.
+	mu.Lock()
+	defer mu.Unlock()
+	if calls > concurrentIterations {
+		t.Errorf("callback fired %d times, want at most %d", calls, concurrentIterations)
+	}
+}

--- a/v2/pkg/agent/uidmap_persist_test.go
+++ b/v2/pkg/agent/uidmap_persist_test.go
@@ -1,0 +1,168 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// unwritableDirMode denies write and traverse to everyone but the owner's read
+// bit, so creating anything beneath it fails with EACCES.
+const unwritableDirMode os.FileMode = 0o500
+
+// TestUIDMapSaveLoadRoundTrip pins the persistence contract: a saved map reads
+// back with the same agent→UID assignments, so agent identities survive a
+// restart. A UID that changed across a restart would break every
+// file-ownership check that keys off it.
+func TestUIDMapSaveLoadRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "uid-map.json")
+	u := &UIDMap{BaseUID: testUIDBase, Agents: map[string]int{
+		"quality": testUIDBase,
+		"scanner": testUIDBase + 1,
+	}}
+
+	if err := u.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := LoadUIDMap(path)
+	if err != nil {
+		t.Fatalf("LoadUIDMap: %v", err)
+	}
+	if loaded.BaseUID != u.BaseUID {
+		t.Errorf("BaseUID = %d, want %d", loaded.BaseUID, u.BaseUID)
+	}
+	for name, want := range u.Agents {
+		if got := loaded.LookupByName(name); got != want {
+			t.Errorf("LookupByName(%q) = %d, want %d", name, got, want)
+		}
+	}
+	if got := loaded.LookupByUID(testUIDBase + 1); got != "scanner" {
+		t.Errorf("LookupByUID(%d) = %q, want %q", testUIDBase+1, got, "scanner")
+	}
+}
+
+// TestUIDMapSaveCreatesParentDir checks Save creates the intermediate directory
+// rather than failing when the map is written before its directory exists.
+func TestUIDMapSaveCreatesParentDir(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "a", "b", "c", "uid-map.json")
+	u := &UIDMap{BaseUID: testUIDBase, Agents: map[string]int{"quality": testUIDBase}}
+
+	if err := u.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("uid map was not written: %v", err)
+	}
+}
+
+// TestUIDMapSaveLeavesNoTempFile checks the atomic tmp+rename really renames:
+// a leftover .tmp beside the map would accumulate on every save.
+func TestUIDMapSaveLeavesNoTempFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "uid-map.json")
+	u := &UIDMap{BaseUID: testUIDBase, Agents: map[string]int{"quality": testUIDBase}}
+
+	if err := u.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("a .tmp file survived the save (err=%v), want it renamed away", err)
+	}
+}
+
+// TestUIDMapSaveReportsWriteFailure checks an unwritable destination surfaces
+// as an error rather than silently losing the map — a dropped UID map would
+// re-assign every agent a new UID on the next boot.
+func TestUIDMapSaveReportsWriteFailure(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root ignores directory permissions")
+	}
+	dir := filepath.Join(t.TempDir(), "locked")
+	if err := os.Mkdir(dir, unwritableDirMode); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(dir, unwritableDirMode); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	u := &UIDMap{BaseUID: testUIDBase, Agents: map[string]int{"quality": testUIDBase}}
+	err := u.Save(filepath.Join(dir, "uid-map.json"))
+
+	if err == nil {
+		t.Fatal("Save() = nil, want an error when the destination is unwritable")
+	}
+}
+
+// TestLoadUIDMapErrors covers the two failure modes callers must distinguish
+// from an empty map: a missing file and unparseable contents.
+func TestLoadUIDMapErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("missing file", func(t *testing.T) {
+		if _, err := LoadUIDMap(filepath.Join(dir, "absent.json")); err == nil {
+			t.Error("LoadUIDMap() = nil error for a missing file, want an error")
+		}
+	})
+
+	t.Run("malformed json", func(t *testing.T) {
+		path := filepath.Join(dir, "bad.json")
+		if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if _, err := LoadUIDMap(path); err == nil {
+			t.Error("LoadUIDMap() = nil error for malformed json, want an error")
+		}
+	})
+}
+
+// TestLoadUIDMapInitialisesNilAgents checks a map persisted without any agents
+// comes back with a usable (non-nil) map, so the first assignment does not
+// panic on a nil-map write.
+func TestLoadUIDMapInitialisesNilAgents(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "uid-map.json")
+	if err := os.WriteFile(path, []byte(`{"BaseUID":5000}`), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	loaded, err := LoadUIDMap(path)
+	if err != nil {
+		t.Fatalf("LoadUIDMap: %v", err)
+	}
+	if loaded.Agents == nil {
+		t.Fatal("Agents map is nil, want it initialised")
+	}
+	// Must be usable immediately.
+	if got := loaded.LookupByName("nobody"); got != 0 {
+		t.Errorf("LookupByName on an empty map = %d, want 0", got)
+	}
+}
+
+// TestNearestExistingDir pins the helper that locates which directory's
+// permissions actually govern a recursive mkdir: it must walk up past every
+// not-yet-created segment and stop at the first ancestor that exists.
+func TestNearestExistingDir(t *testing.T) {
+	root := t.TempDir()
+
+	t.Run("path itself exists", func(t *testing.T) {
+		if got := nearestExistingDir(root); got != root {
+			t.Errorf("nearestExistingDir(%q) = %q, want the path itself", root, got)
+		}
+	})
+
+	t.Run("walks up past missing segments", func(t *testing.T) {
+		missing := filepath.Join(root, "not", "yet", "created")
+		if got := nearestExistingDir(missing); got != root {
+			t.Errorf("nearestExistingDir(%q) = %q, want %q", missing, got, root)
+		}
+	})
+
+	t.Run("one missing segment", func(t *testing.T) {
+		missing := filepath.Join(root, "child")
+		if got := nearestExistingDir(missing); got != root {
+			t.Errorf("nearestExistingDir(%q) = %q, want %q", missing, got, root)
+		}
+	})
+}

--- a/v2/pkg/hub/cluster_app_id_test.go
+++ b/v2/pkg/hub/cluster_app_id_test.go
@@ -1,0 +1,227 @@
+package hub
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// testAppID and testOtherAppID are arbitrary non-zero GitHub App IDs. Only
+// their distinctness matters to these tests.
+const (
+	testAppID      = int64(123456)
+	testOtherAppID = int64(999888)
+)
+
+// withTempClustersConfig redirects clustersConfigPath at a temp file seeded
+// with the given cluster configs, so setClusterAppID never touches the real
+// /data PVC.
+func withTempClustersConfig(t *testing.T, configs []ClusterConfig) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "clusters.json")
+	data, err := json.MarshalIndent(configs, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal fixture clusters: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write fixture clusters: %v", err)
+	}
+	orig := clustersConfigPath
+	clustersConfigPath = path
+	t.Cleanup(func() { clustersConfigPath = orig })
+	return path
+}
+
+// readClustersFixture reads the on-disk clusters.json back as raw configs.
+func readClustersFixture(t *testing.T, path string) []ClusterConfig {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read clusters config: %v", err)
+	}
+	var got []ClusterConfig
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse clusters config: %v (data=%q)", err, data)
+	}
+	return got
+}
+
+// TestSetClusterAppIDPersists is the core contract: the App ID must be written
+// to BOTH the in-memory map (so the running hub uses it immediately) and
+// clusters.json (so it survives a restart).
+func TestSetClusterAppIDPersists(t *testing.T) {
+	path := withTempClustersConfig(t, []ClusterConfig{
+		{ID: "pok-prod", Name: "pok"},
+		{ID: "vllm-d", Name: "vllm"},
+	})
+	s := &HubServer{clusters: map[string]ClusterConfig{
+		"pok-prod": {ID: "pok-prod", Name: "pok"},
+		"vllm-d":   {ID: "vllm-d", Name: "vllm"},
+	}}
+
+	if err := s.setClusterAppID("pok-prod", testAppID); err != nil {
+		t.Fatalf("setClusterAppID: %v", err)
+	}
+
+	if got := s.clusters["pok-prod"].GitHubAppID; got != testAppID {
+		t.Errorf("in-memory GitHubAppID = %d, want %d", got, testAppID)
+	}
+
+	onDisk := readClustersFixture(t, path)
+	var found bool
+	for _, c := range onDisk {
+		if c.ID == "pok-prod" {
+			found = true
+			if c.GitHubAppID != testAppID {
+				t.Errorf("on-disk GitHubAppID = %d, want %d", c.GitHubAppID, testAppID)
+			}
+		}
+	}
+	if !found {
+		t.Error("pok-prod is missing from the rewritten clusters.json")
+	}
+}
+
+// TestSetClusterAppIDLeavesOtherClustersUntouched guards the documented
+// data-loss rule: the rewrite reads the file fresh and edits one entry, so
+// every other cluster — including one the in-memory map does not know about,
+// which loadClusters would have silently dropped — must survive verbatim.
+func TestSetClusterAppIDLeavesOtherClustersUntouched(t *testing.T) {
+	path := withTempClustersConfig(t, []ClusterConfig{
+		{ID: "pok-prod", Name: "pok"},
+		{ID: "vllm-d", Name: "vllm", GitHubAppID: testOtherAppID},
+		// Present on disk but absent from the in-memory map, standing in for an
+		// entry loadClusters rejected. Re-serializing the map would delete it.
+		{ID: "dropped-by-validation", Name: "ghost"},
+	})
+	s := &HubServer{clusters: map[string]ClusterConfig{
+		"pok-prod": {ID: "pok-prod", Name: "pok"},
+		"vllm-d":   {ID: "vllm-d", Name: "vllm", GitHubAppID: testOtherAppID},
+	}}
+
+	if err := s.setClusterAppID("pok-prod", testAppID); err != nil {
+		t.Fatalf("setClusterAppID: %v", err)
+	}
+
+	onDisk := readClustersFixture(t, path)
+	byID := make(map[string]ClusterConfig, len(onDisk))
+	for _, c := range onDisk {
+		byID[c.ID] = c
+	}
+	if len(onDisk) != 3 {
+		t.Fatalf("clusters.json now has %d entries, want 3 (ids=%v)", len(onDisk), keysOf(byID))
+	}
+	if _, ok := byID["dropped-by-validation"]; !ok {
+		t.Error("an entry absent from the in-memory map was deleted from clusters.json")
+	}
+	if got := byID["vllm-d"].GitHubAppID; got != testOtherAppID {
+		t.Errorf("vllm-d GitHubAppID = %d, want %d (an unrelated cluster was modified)", got, testOtherAppID)
+	}
+	if got := byID["vllm-d"].Name; got != "vllm" {
+		t.Errorf("vllm-d Name = %q, want %q", got, "vllm")
+	}
+}
+
+// keysOf returns map keys for readable failure messages.
+func keysOf(m map[string]ClusterConfig) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestSetClusterAppIDUnknownCluster checks an ID the hub does not run is
+// refused before any file is touched.
+func TestSetClusterAppIDUnknownCluster(t *testing.T) {
+	path := withTempClustersConfig(t, []ClusterConfig{{ID: "pok-prod"}})
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	s := &HubServer{clusters: map[string]ClusterConfig{"pok-prod": {ID: "pok-prod"}}}
+	err = s.setClusterAppID("no-such-cluster", testAppID)
+
+	if err == nil {
+		t.Fatal("setClusterAppID() = nil, want an error for an unknown cluster")
+	}
+	if !strings.Contains(err.Error(), "unknown cluster") {
+		t.Errorf("error = %q, want it to report an unknown cluster", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Error("clusters.json was rewritten despite the cluster being unknown")
+	}
+}
+
+// TestSetClusterAppIDMissingFromConfigFile covers the in-memory/on-disk skew
+// case: the hub knows the cluster but clusters.json does not list it, so the
+// write cannot be persisted and must be reported rather than silently lost.
+func TestSetClusterAppIDMissingFromConfigFile(t *testing.T) {
+	withTempClustersConfig(t, []ClusterConfig{{ID: "some-other-cluster"}})
+	s := &HubServer{clusters: map[string]ClusterConfig{"pok-prod": {ID: "pok-prod"}}}
+
+	err := s.setClusterAppID("pok-prod", testAppID)
+
+	if err == nil {
+		t.Fatal("setClusterAppID() = nil, want an error when the cluster is absent from clusters.json")
+	}
+	if !strings.Contains(err.Error(), "not present") {
+		t.Errorf("error = %q, want it to report the cluster is not present in the config file", err)
+	}
+}
+
+// TestSetClusterAppIDUnreadableConfig checks a missing clusters.json surfaces
+// as an error rather than a panic or a silent no-op.
+func TestSetClusterAppIDUnreadableConfig(t *testing.T) {
+	orig := clustersConfigPath
+	clustersConfigPath = filepath.Join(t.TempDir(), "does-not-exist.json")
+	t.Cleanup(func() { clustersConfigPath = orig })
+
+	s := &HubServer{clusters: map[string]ClusterConfig{"pok-prod": {ID: "pok-prod"}}}
+	err := s.setClusterAppID("pok-prod", testAppID)
+
+	if err == nil {
+		t.Fatal("setClusterAppID() = nil, want an error when clusters.json cannot be read")
+	}
+	if !strings.Contains(err.Error(), "read clusters config") {
+		t.Errorf("error = %q, want it to report the read failure", err)
+	}
+}
+
+// TestSetClusterAppIDMalformedConfig checks unparseable JSON is reported
+// instead of being overwritten — clobbering a hand-edited clusters.json the
+// hub merely failed to parse would strand every cluster.
+func TestSetClusterAppIDMalformedConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "clusters.json")
+	const malformed = `{not valid json`
+	if err := os.WriteFile(path, []byte(malformed), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	orig := clustersConfigPath
+	clustersConfigPath = path
+	t.Cleanup(func() { clustersConfigPath = orig })
+
+	s := &HubServer{clusters: map[string]ClusterConfig{"pok-prod": {ID: "pok-prod"}}}
+	err := s.setClusterAppID("pok-prod", testAppID)
+
+	if err == nil {
+		t.Fatal("setClusterAppID() = nil, want an error for malformed clusters.json")
+	}
+	if !strings.Contains(err.Error(), "parse clusters config") {
+		t.Errorf("error = %q, want it to report the parse failure", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != malformed {
+		t.Error("an unparseable clusters.json was overwritten, want it left intact")
+	}
+}

--- a/v2/pkg/hub/grantable_users_test.go
+++ b/v2/pkg/hub/grantable_users_test.go
@@ -1,0 +1,196 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+// grantableTestSecret signs the session cookies these tests present.
+const grantableTestSecret = "grantable-test-secret"
+
+// withTempSaaSDirs redirects both the users and hives directories at temp
+// trees so the roster handler reads fixtures instead of the real /data PVC.
+func withTempSaaSDirs(t *testing.T) {
+	t.Helper()
+	origUsers, origHives := saasUsersDir, saasHivesDir
+	dir := t.TempDir()
+	saasUsersDir = dir + "/users"
+	saasHivesDir = dir + "/hives"
+	t.Cleanup(func() { saasUsersDir = origUsers; saasHivesDir = origHives })
+}
+
+// grantableTestServer builds a HubServer whose cookie secret matches the one
+// these tests sign with.
+func grantableTestServer() *HubServer {
+	return &HubServer{logger: slog.Default(), hubSecret: grantableTestSecret}
+}
+
+// putUser persists a SaaSUser fixture.
+func putUser(t *testing.T, username string) {
+	t.Helper()
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: username}); err != nil {
+		t.Fatalf("saveSaaSUser(%q): %v", username, err)
+	}
+}
+
+// putHiveOwnedBy persists a SaaSHive fixture with the given owner.
+func putHiveOwnedBy(t *testing.T, id, owner string) {
+	t.Helper()
+	if err := saveSaaSHive(&SaaSHive{ID: id, Owner: owner}); err != nil {
+		t.Fatalf("saveSaaSHive(%q): %v", id, err)
+	}
+}
+
+// getGrantableUsers calls the handler as username (empty means logged out).
+func getGrantableUsers(t *testing.T, s *HubServer, username string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/saas/grantable-users", nil)
+	if username != "" {
+		req.AddCookie(&http.Cookie{
+			Name:  "hive_hub_user",
+			Value: mintHubUserCookieValue(grantableTestSecret, username),
+		})
+	}
+	rec := httptest.NewRecorder()
+	s.handleGrantableUsers(rec, req)
+	return rec
+}
+
+// decodeUsers pulls the roster out of a successful response.
+func decodeUsers(t *testing.T, rec *httptest.ResponseRecorder) []string {
+	t.Helper()
+	var resp struct {
+		Users []string `json:"users"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (body=%q)", err, rec.Body.String())
+	}
+	return resp.Users
+}
+
+// TestHandleGrantableUsersRequiresHiveOwnership pins the access bar stated in
+// the handler: the roster is visible to anyone who owns at least one hive —
+// the same bar as being able to open Manage Access at all — and to nobody
+// else. A logged-out or hive-less caller must be refused, not shown the full
+// user list.
+func TestHandleGrantableUsersRequiresHiveOwnership(t *testing.T) {
+	tests := []struct {
+		name     string
+		username string
+		// ownsHive seeds a hive owned by username.
+		ownsHive bool
+		wantCode int
+	}{
+		{name: "owner of a hive may list", username: "alice", ownsHive: true, wantCode: http.StatusOK},
+		{name: "admin may list without owning anything", username: hubAdminUsername, wantCode: http.StatusOK},
+		{name: "user owning no hive is refused", username: "mallory", wantCode: http.StatusForbidden},
+		{name: "logged out is refused", username: "", wantCode: http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withTempSaaSDirs(t)
+			putUser(t, "alice")
+			putUser(t, "bob")
+			if tc.username != "" {
+				putUser(t, tc.username)
+			}
+			if tc.ownsHive {
+				putHiveOwnedBy(t, "hive-1", tc.username)
+			} else {
+				// A hive owned by someone else must not grant access.
+				putHiveOwnedBy(t, "hive-1", "someone-else")
+			}
+
+			rec := getGrantableUsers(t, grantableTestServer(), tc.username)
+
+			if rec.Code != tc.wantCode {
+				t.Errorf("status = %d, want %d (body=%q)", rec.Code, tc.wantCode, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestHandleGrantableUsersReturnsSortedRoster checks the successful response:
+// every registered username, sorted for a stable UI, as a JSON array.
+func TestHandleGrantableUsersReturnsSortedRoster(t *testing.T) {
+	withTempSaaSDirs(t)
+	// Deliberately created out of order.
+	for _, u := range []string{"carol", "alice", "bob"} {
+		putUser(t, u)
+	}
+	putHiveOwnedBy(t, "hive-1", "alice")
+
+	rec := getGrantableUsers(t, grantableTestServer(), "alice")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	got := decodeUsers(t, rec)
+	want := []string{"alice", "bob", "carol"}
+	if len(got) != len(want) {
+		t.Fatalf("roster = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("roster = %v, want %v (sorted)", got, want)
+			break
+		}
+	}
+}
+
+// TestHandleGrantableUsersRosterIsNeverNull checks the users field always
+// serialises as a JSON array, never null, since the UI iterates it directly.
+// The roster is built with make([]string, 0) precisely for this reason, and a
+// hub whose only record is the caller's own is the case that would otherwise
+// expose a nil slice.
+func TestHandleGrantableUsersRosterIsNeverNull(t *testing.T) {
+	withTempSaaSDirs(t)
+	// getAuthUser requires the caller's own record to exist.
+	putUser(t, hubAdminUsername)
+	putHiveOwnedBy(t, "hive-1", hubAdminUsername)
+
+	rec := getGrantableUsers(t, grantableTestServer(), hubAdminUsername)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+	if got := decodeUsers(t, rec); got == nil {
+		t.Errorf("users = null (body=%q), want a JSON array", rec.Body.String())
+	}
+}
+
+// TestHandleGrantableUsersSkipsRecordsWithoutUsername checks the filter: a
+// user record on the PVC that carries no GitHub username is not emitted as an
+// empty entry, which would render as a blank row in the Manage Access picker.
+func TestHandleGrantableUsersSkipsRecordsWithoutUsername(t *testing.T) {
+	withTempSaaSDirs(t)
+	putUser(t, "alice")
+	putHiveOwnedBy(t, "hive-1", "alice")
+	// A record whose file exists but whose GitHubUsername field is empty.
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "blank-record"}); err != nil {
+		t.Fatalf("saveSaaSUser: %v", err)
+	}
+	blankPath := saasUsersDir + "/blank-record.json"
+	if err := os.WriteFile(blankPath, []byte(`{"github_username":""}`), 0o644); err != nil {
+		t.Fatalf("write blank record: %v", err)
+	}
+
+	rec := getGrantableUsers(t, grantableTestServer(), "alice")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+	for _, u := range decodeUsers(t, rec) {
+		if u == "" {
+			t.Errorf("roster contains an empty username: %v", decodeUsers(t, rec))
+		}
+	}
+}

--- a/v2/pkg/hub/heartbeat_liveness_test.go
+++ b/v2/pkg/hub/heartbeat_liveness_test.go
@@ -1,0 +1,152 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// TestHeartbeatLivenessAccessors pins the distinction the liveness check relies
+// on: LastHeartbeatAttempt advances even while the hub is unreachable, so a
+// wedged goroutine (no attempts) is distinguishable from a network partition
+// (attempts, no successes).
+func TestHeartbeatLivenessAccessors(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+
+	// Truncated to a second because the atomics store unix seconds; a
+	// sub-second component could not survive the round trip.
+	attempt := time.Now().Add(-1 * time.Minute).Truncate(time.Second)
+	success := time.Now().Add(-5 * time.Minute).Truncate(time.Second)
+
+	t.Run("never attempted reads as not-ok", func(t *testing.T) {
+		ResetHeartbeatStateForTest()
+
+		if got, ok := LastHeartbeatAttempt(); ok {
+			t.Errorf("LastHeartbeatAttempt() = (%v, true), want ok=false before any attempt", got)
+		}
+		if got, ok := LastHeartbeatSuccess(); ok {
+			t.Errorf("LastHeartbeatSuccess() = (%v, true), want ok=false before any success", got)
+		}
+		if HeartbeatEnabled() {
+			t.Error("HeartbeatEnabled() = true, want false when no loop was started")
+		}
+	})
+
+	t.Run("attempts without successes: partitioned network", func(t *testing.T) {
+		SetHeartbeatStateForTest(true, attempt, time.Time{})
+
+		got, ok := LastHeartbeatAttempt()
+		if !ok {
+			t.Fatal("LastHeartbeatAttempt() ok = false after recording an attempt")
+		}
+		if !got.Equal(attempt) {
+			t.Errorf("LastHeartbeatAttempt() = %v, want %v", got, attempt)
+		}
+		if _, ok := LastHeartbeatSuccess(); ok {
+			t.Error("LastHeartbeatSuccess() ok = true, want false: no beat has succeeded")
+		}
+		if !HeartbeatEnabled() {
+			t.Error("HeartbeatEnabled() = false, want true when the loop is running")
+		}
+	})
+
+	t.Run("both recorded: healthy loop", func(t *testing.T) {
+		SetHeartbeatStateForTest(true, attempt, success)
+
+		gotAttempt, ok := LastHeartbeatAttempt()
+		if !ok || !gotAttempt.Equal(attempt) {
+			t.Errorf("LastHeartbeatAttempt() = (%v, %v), want (%v, true)", gotAttempt, ok, attempt)
+		}
+		gotSuccess, ok := LastHeartbeatSuccess()
+		if !ok || !gotSuccess.Equal(success) {
+			t.Errorf("LastHeartbeatSuccess() = (%v, %v), want (%v, true)", gotSuccess, ok, success)
+		}
+	})
+}
+
+// TestResetHeartbeatStateForTest checks the reset hook really clears all three
+// pieces of global state — tests that rely on it to avoid leaking into their
+// neighbours depend on this.
+func TestResetHeartbeatStateForTest(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+
+	SetHeartbeatStateForTest(true, time.Now(), time.Now())
+	if _, ok := LastHeartbeatAttempt(); !ok {
+		t.Fatal("precondition: state was not set")
+	}
+
+	ResetHeartbeatStateForTest()
+
+	if _, ok := LastHeartbeatAttempt(); ok {
+		t.Error("LastHeartbeatAttempt() still ok after reset")
+	}
+	if _, ok := LastHeartbeatSuccess(); ok {
+		t.Error("LastHeartbeatSuccess() still ok after reset")
+	}
+	if HeartbeatEnabled() {
+		t.Error("HeartbeatEnabled() still true after reset")
+	}
+}
+
+// TestRecordHeartbeatAttemptAdvances checks the recorder the loop calls on each
+// send actually moves the timestamp forward from "never".
+func TestRecordHeartbeatAttemptAdvances(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
+
+	before := time.Now().Truncate(time.Second)
+	recordHeartbeatAttempt()
+
+	got, ok := LastHeartbeatAttempt()
+	if !ok {
+		t.Fatal("LastHeartbeatAttempt() ok = false after recordHeartbeatAttempt()")
+	}
+	if got.Before(before) {
+		t.Errorf("LastHeartbeatAttempt() = %v, want at or after %v", got, before)
+	}
+	if _, ok := LastHeartbeatSuccess(); ok {
+		t.Error("recordHeartbeatAttempt() also marked a success, want attempts and successes independent")
+	}
+}
+
+// TestRecordHeartbeatSuccessAdvances is the mirror of the above for the success
+// timestamp.
+func TestRecordHeartbeatSuccessAdvances(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
+
+	before := time.Now().Truncate(time.Second)
+	recordHeartbeatSuccess()
+
+	got, ok := LastHeartbeatSuccess()
+	if !ok {
+		t.Fatal("LastHeartbeatSuccess() ok = false after recordHeartbeatSuccess()")
+	}
+	if got.Before(before) {
+		t.Errorf("LastHeartbeatSuccess() = %v, want at or after %v", got, before)
+	}
+	if _, ok := LastHeartbeatAttempt(); ok {
+		t.Error("recordHeartbeatSuccess() also marked an attempt, want attempts and successes independent")
+	}
+}
+
+// TestStoreUnixOrZero pins the zero-time convention the accessors depend on:
+// the zero time stores as 0 so it reads back as "never happened", rather than
+// as a 1970 timestamp that would look like a very stale but real beat.
+func TestStoreUnixOrZero(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+
+	real := time.Now().Add(-time.Hour).Truncate(time.Second)
+
+	storeUnixOrZero(&lastHeartbeatAttemptUnix, real)
+	if got := lastHeartbeatAttemptUnix.Load(); got != real.Unix() {
+		t.Errorf("stored %d, want %d", got, real.Unix())
+	}
+
+	storeUnixOrZero(&lastHeartbeatAttemptUnix, time.Time{})
+	if got := lastHeartbeatAttemptUnix.Load(); got != 0 {
+		t.Errorf("zero time stored as %d, want 0", got)
+	}
+	if _, ok := LastHeartbeatAttempt(); ok {
+		t.Error("LastHeartbeatAttempt() ok = true after storing the zero time, want never-happened")
+	}
+}

--- a/v2/pkg/hub/hub_helpers_test.go
+++ b/v2/pkg/hub/hub_helpers_test.go
@@ -1,0 +1,331 @@
+package hub
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// cookieTestSecret is an arbitrary non-empty HMAC secret for the cookie tests.
+const cookieTestSecret = "cookie-test-secret"
+
+// ── githubHostLabel / GitHubHostLabel ───────────────────────────────────────
+
+// TestGitHubHostLabel pins the normalization the hub and the spoke must agree
+// on. Both sides call this one implementation precisely so the value the spoke
+// reports over the heartbeat and the value the hub renders cannot drift into
+// two different spellings for the same host.
+func TestGitHubHostLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty means public github.com", in: "", want: "github.com"},
+		{name: "whitespace only means public github.com", in: "   ", want: "github.com"},
+		{name: "https scheme is stripped", in: "https://github.ibm.com", want: "github.ibm.com"},
+		{name: "http scheme is stripped", in: "http://github.cisco.com", want: "github.cisco.com"},
+		{name: "trailing slash is stripped", in: "https://github.ibm.com/", want: "github.ibm.com"},
+		{name: "multiple trailing slashes are stripped", in: "https://github.ibm.com///", want: "github.ibm.com"},
+		{name: "surrounding whitespace is trimmed", in: "  https://github.ibm.com/  ", want: "github.ibm.com"},
+		{name: "a bare host passes through", in: "github.ibm.com", want: "github.ibm.com"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := githubHostLabel(tc.in); got != tc.want {
+				t.Errorf("githubHostLabel(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			// The exported form must not diverge from the internal one; that
+			// is the entire reason it exists.
+			if got := GitHubHostLabel(tc.in); got != tc.want {
+				t.Errorf("GitHubHostLabel(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGitHubHostLabelAgreesAcrossSpellings is the anti-drift check stated in
+// the doc comment: every spelling of the same host must collapse to one label,
+// or the hub renders a hive as belonging to a different GitHub instance than
+// the spoke reports.
+func TestGitHubHostLabelAgreesAcrossSpellings(t *testing.T) {
+	spellings := []string{
+		"github.ibm.com",
+		"https://github.ibm.com",
+		"http://github.ibm.com",
+		"https://github.ibm.com/",
+		"  https://github.ibm.com/ ",
+	}
+
+	want := githubHostLabel(spellings[0])
+	for _, s := range spellings[1:] {
+		if got := githubHostLabel(s); got != want {
+			t.Errorf("githubHostLabel(%q) = %q, want %q — spellings must not drift", s, got, want)
+		}
+	}
+}
+
+// ── hub user cookie ─────────────────────────────────────────────────────────
+
+// TestHubUserCookieRoundTrip checks a minted cookie verifies back to the same
+// username.
+func TestHubUserCookieRoundTrip(t *testing.T) {
+	const username = "alice"
+
+	value := mintHubUserCookieValue(cookieTestSecret, username)
+	if value == "" {
+		t.Fatal("mintHubUserCookieValue returned empty for a valid secret and username")
+	}
+
+	got, ok := verifyHubUserCookieValue(cookieTestSecret, value)
+	if !ok {
+		t.Fatalf("verifyHubUserCookieValue(%q) ok = false, want true", value)
+	}
+	if got != username {
+		t.Errorf("verified username = %q, want %q", got, username)
+	}
+}
+
+// TestMintHubUserCookieRefusesWithoutInputs pins the documented refusal: with
+// no secret or no username the mint must return "" so callers treat it as
+// "cannot establish a session", never emitting an unsigned cookie that later
+// code would trust by default.
+func TestMintHubUserCookieRefusesWithoutInputs(t *testing.T) {
+	tests := []struct {
+		name     string
+		secret   string
+		username string
+	}{
+		{name: "no secret", secret: "", username: "alice"},
+		{name: "no username", secret: cookieTestSecret, username: ""},
+		{name: "neither", secret: "", username: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mintHubUserCookieValue(tc.secret, tc.username); got != "" {
+				t.Errorf("mintHubUserCookieValue(%q, %q) = %q, want an empty string",
+					tc.secret, tc.username, got)
+			}
+		})
+	}
+}
+
+// TestVerifyHubUserCookieRejectsTampering is the security contract: a forged or
+// altered cookie must never authenticate. Each case below is a realistic
+// forgery attempt against a signed value.
+func TestVerifyHubUserCookieRejectsTampering(t *testing.T) {
+	valid := mintHubUserCookieValue(cookieTestSecret, "alice")
+	if valid == "" {
+		t.Fatal("precondition: could not mint a valid cookie")
+	}
+	idx := strings.LastIndex(valid, ".")
+	signature := valid[idx+1:]
+
+	tests := []struct {
+		name   string
+		secret string
+		value  string
+	}{
+		{
+			name:   "username swapped, signature kept",
+			secret: cookieTestSecret,
+			value:  "mallory." + signature,
+		},
+		{
+			name:   "signature altered",
+			secret: cookieTestSecret,
+			value:  "alice." + signature + "x",
+		},
+		{
+			name:   "legacy unsigned cookie",
+			secret: cookieTestSecret,
+			value:  "alice",
+		},
+		{
+			name:   "empty signature",
+			secret: cookieTestSecret,
+			value:  "alice.",
+		},
+		{
+			name:   "empty username",
+			secret: cookieTestSecret,
+			value:  "." + signature,
+		},
+		{
+			name:   "signed with a different secret",
+			secret: "a-different-secret",
+			value:  valid,
+		},
+		{
+			name:   "no secret configured",
+			secret: "",
+			value:  valid,
+		},
+		{
+			name:   "empty value",
+			secret: cookieTestSecret,
+			value:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := verifyHubUserCookieValue(tc.secret, tc.value)
+			if ok {
+				t.Errorf("verifyHubUserCookieValue(%q) authenticated as %q, want a rejection",
+					tc.value, got)
+			}
+			if got != "" {
+				t.Errorf("rejected cookie still returned username %q, want an empty string", got)
+			}
+		})
+	}
+}
+
+// TestHubUserCookieIsPerUsername checks two users never share a signature, so
+// one user's cookie cannot be replayed as another's.
+func TestHubUserCookieIsPerUsername(t *testing.T) {
+	a := mintHubUserCookieValue(cookieTestSecret, "alice")
+	b := mintHubUserCookieValue(cookieTestSecret, "bob")
+
+	if a == b {
+		t.Fatalf("two usernames minted the same cookie value %q", a)
+	}
+	if got, ok := verifyHubUserCookieValue(cookieTestSecret, b); !ok || got != "bob" {
+		t.Errorf("verify(bob cookie) = (%q, %v), want (\"bob\", true)", got, ok)
+	}
+}
+
+// ── timeline formatting helpers ─────────────────────────────────────────────
+
+// TestAbsInt covers the sign handling, including the zero boundary.
+func TestAbsInt(t *testing.T) {
+	tests := []struct {
+		in   int
+		want int
+	}{
+		{in: 5, want: 5},
+		{in: -5, want: 5},
+		{in: 0, want: 0},
+		{in: -1, want: 1},
+	}
+	for _, tc := range tests {
+		if got := absInt(tc.in); got != tc.want {
+			t.Errorf("absInt(%d) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestOrDash checks the empty-string placeholder used across the timeline UI.
+func TestOrDash(t *testing.T) {
+	const emDash = "—"
+
+	if got := orDash(""); got != emDash {
+		t.Errorf("orDash(\"\") = %q, want %q", got, emDash)
+	}
+	if got := orDash("value"); got != "value" {
+		t.Errorf("orDash(%q) = %q, want it unchanged", "value", got)
+	}
+	// A whitespace string is not empty and must pass through untouched.
+	if got := orDash(" "); got != " " {
+		t.Errorf("orDash(%q) = %q, want it unchanged", " ", got)
+	}
+}
+
+// ── ReportUpgradeFailure ────────────────────────────────────────────────────
+
+// TestReportUpgradeFailurePostsPayload checks the spoke's failure report
+// reaches the hub with the fields an operator needs to diagnose a failed
+// upgrade: which hive, which target SHA, what it is currently running, and why
+// it failed — with UpgradeFailed set so the hub does not read it as a normal
+// beat.
+func TestReportUpgradeFailurePostsPayload(t *testing.T) {
+	const (
+		hiveID     = "hive-1"
+		targetSHA  = "abc123"
+		currentSHA = "def456"
+		cause      = "image pull backoff"
+	)
+
+	type captured struct {
+		path        string
+		contentType string
+		payload     HeartbeatPayload
+	}
+	got := make(chan captured, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var p HeartbeatPayload
+		_ = json.Unmarshal(body, &p)
+		got <- captured{path: r.URL.Path, contentType: r.Header.Get("Content-Type"), payload: p}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ReportUpgradeFailure(srv.URL, hiveID, targetSHA, currentSHA, cause, slog.Default())
+
+	select {
+	case c := <-got:
+		if c.path != "/api/heartbeat" {
+			t.Errorf("posted to %q, want %q", c.path, "/api/heartbeat")
+		}
+		if c.contentType != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", c.contentType)
+		}
+		if !c.payload.UpgradeFailed {
+			t.Error("UpgradeFailed = false, want true: the hub must not read this as a normal beat")
+		}
+		if c.payload.HiveID != hiveID {
+			t.Errorf("HiveID = %q, want %q", c.payload.HiveID, hiveID)
+		}
+		if c.payload.UpgradeTargetSHA != targetSHA {
+			t.Errorf("UpgradeTargetSHA = %q, want %q", c.payload.UpgradeTargetSHA, targetSHA)
+		}
+		if c.payload.GitHash != currentSHA {
+			t.Errorf("GitHash = %q, want %q", c.payload.GitHash, currentSHA)
+		}
+		if c.payload.UpgradeError != cause {
+			t.Errorf("UpgradeError = %q, want %q", c.payload.UpgradeError, cause)
+		}
+	default:
+		t.Fatal("no request reached the hub")
+	}
+}
+
+// TestReportUpgradeFailureNoOpWithoutTarget checks the guard that keeps an
+// unconfigured spoke from posting: with no hub URL or no hive ID there is
+// nothing to report to, and the call must return without touching the network.
+func TestReportUpgradeFailureNoOpWithoutTarget(t *testing.T) {
+	reached := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ReportUpgradeFailure("", "hive-1", "abc", "def", "cause", slog.Default())
+	ReportUpgradeFailure(srv.URL, "", "abc", "def", "cause", slog.Default())
+
+	if reached {
+		t.Error("a request was sent despite a missing hub URL or hive ID")
+	}
+}
+
+// TestReportUpgradeFailureSurvivesUnreachableHub checks the report is
+// best-effort: an unreachable hub is logged, not fatal, because the spoke is
+// already in a failed-upgrade state and must not compound it by crashing.
+func TestReportUpgradeFailureSurvivesUnreachableHub(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	unreachable := srv.URL
+	srv.Close() // nothing is listening now
+
+	// Must not panic.
+	ReportUpgradeFailure(unreachable, "hive-1", "abc", "def", "cause", slog.Default())
+}

--- a/v2/pkg/hub/journey_dispatch_test.go
+++ b/v2/pkg/hub/journey_dispatch_test.go
@@ -1,0 +1,348 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// snoozeTestDuration is a legitimate, well under-the-cap snooze window used by
+// the dispatch tests ("a vendor pilot lasting a day").
+const snoozeTestDuration = 24 * time.Hour
+
+// dispatchTestServer builds a HubServer wired only with the in-memory pieces
+// the journey dispatch handlers touch: a registry, a journey store, and a
+// logger. Journey state is redirected to a temp file so save() never writes to
+// the real /data PVC.
+func dispatchTestServer(t *testing.T, hives ...RegistryEntry) *HubServer {
+	t.Helper()
+	withTempStatePath(t)
+	s := &HubServer{
+		logger:  slog.Default(),
+		journey: newJourneyStore(),
+	}
+	s.registry.Hives = hives
+	return s
+}
+
+// postSnoozeJSON issues a POST with a JSON body to the given handler and returns the
+// recorder.
+func postSnoozeJSON(t *testing.T, h http.HandlerFunc, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/admin/journey-snooze", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h(rec, req)
+	return rec
+}
+
+// ── writeJSONError ──────────────────────────────────────────────────────────
+
+// TestWriteJSONError pins the error envelope shape the dashboard parses: a JSON
+// object with an "error" key, the requested status code, and a JSON content
+// type. A plain-text body here would break every client error path.
+func TestWriteJSONError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeJSONError(rec, http.StatusTeapot, "kettle offline")
+
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusTeapot)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body is not JSON: %v (body=%q)", err, rec.Body.String())
+	}
+	if got["error"] != "kettle offline" {
+		t.Errorf(`body["error"] = %q, want "kettle offline"`, got["error"])
+	}
+}
+
+// ── attachJourneyStatus ─────────────────────────────────────────────────────
+
+// TestAttachJourneyStatusFillsEveryHive checks the derived-data contract: every
+// entry in the slice comes back with a non-nil Journey, and the status reflects
+// that hive's own state rather than a shared or last-wins value.
+func TestAttachJourneyStatusFillsEveryHive(t *testing.T) {
+	// One hive stalled at stage 1 (no GitHub App), one fully satisfied.
+	stalled := *hive(30 * 24 * time.Hour)
+	stalled.ID = "stalled"
+	stalled.PendingGitHubAppInstall = true
+
+	healthy := *hive(30 * 24 * time.Hour)
+	healthy.ID = "healthy"
+	healthy.PendingGitHubAppInstall = false
+
+	s := dispatchTestServer(t)
+	hives := []RegistryEntry{stalled, healthy}
+	s.attachJourneyStatus(hives, baseTime)
+
+	for i := range hives {
+		if hives[i].Journey == nil {
+			t.Fatalf("hive %q has nil Journey, want a computed status", hives[i].ID)
+		}
+	}
+	if hives[0].Journey.Stage != StageGitHubApp.String() {
+		t.Errorf("stalled hive stage = %q, want %q", hives[0].Journey.Stage, StageGitHubApp.String())
+	}
+	if hives[0].Journey.Stage == hives[1].Journey.Stage {
+		t.Errorf("both hives reported stage %q; status is not per-hive", hives[0].Journey.Stage)
+	}
+}
+
+// TestAttachJourneyStatusNilStoreIsNoOp covers the nil-store guard: a HubServer
+// without a journey store must leave the slice untouched, not panic.
+func TestAttachJourneyStatusNilStoreIsNoOp(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+	hives := []RegistryEntry{*hive(30 * 24 * time.Hour)}
+
+	s.attachJourneyStatus(hives, baseTime)
+
+	if hives[0].Journey != nil {
+		t.Errorf("Journey = %+v, want nil when the server has no journey store", hives[0].Journey)
+	}
+}
+
+// ── handleJourneyStatus ─────────────────────────────────────────────────────
+
+// TestHandleJourneyStatusReturnsEveryHive checks the admin status endpoint
+// returns one row per registered hive, carrying identity plus a computed
+// status.
+func TestHandleJourneyStatusReturnsEveryHive(t *testing.T) {
+	h1 := *hive(30 * 24 * time.Hour)
+	h1.ID = "hive-a"
+	h1.Name = "acme/alpha"
+	h1.Owner = "alice"
+	h1.PendingGitHubAppInstall = true
+
+	h2 := *hive(30 * 24 * time.Hour)
+	h2.ID = "hive-b"
+	h2.Name = "acme/beta"
+	h2.Owner = "bob"
+
+	s := dispatchTestServer(t, h1, h2)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/saas/admin/journey-status", nil)
+	rec := httptest.NewRecorder()
+	s.handleJourneyStatus(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var resp struct {
+		Hives []struct {
+			HiveID string         `json:"hive_id"`
+			Name   string         `json:"name"`
+			Owner  string         `json:"owner"`
+			Status *JourneyStatus `json:"status"`
+		} `json:"hives"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (body=%q)", err, rec.Body.String())
+	}
+	if len(resp.Hives) != 2 {
+		t.Fatalf("got %d rows, want 2", len(resp.Hives))
+	}
+	byID := map[string]string{}
+	for _, r := range resp.Hives {
+		if r.Status == nil {
+			t.Errorf("hive %q has a null status", r.HiveID)
+			continue
+		}
+		byID[r.HiveID] = r.Owner
+	}
+	if byID["hive-a"] != "alice" || byID["hive-b"] != "bob" {
+		t.Errorf("owners = %v, want hive-a=alice hive-b=bob", byID)
+	}
+}
+
+// TestHandleJourneyStatusEmptyRegistry checks an empty registry serialises as
+// an empty array, not JSON null — the UI iterates this field directly.
+func TestHandleJourneyStatusEmptyRegistry(t *testing.T) {
+	s := dispatchTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/saas/admin/journey-status", nil)
+	rec := httptest.NewRecorder()
+	s.handleJourneyStatus(rec, req)
+
+	if !strings.Contains(rec.Body.String(), `"hives":[]`) {
+		t.Errorf("body = %q, want an empty hives array", rec.Body.String())
+	}
+}
+
+// ── handleJourneySnooze ─────────────────────────────────────────────────────
+
+// TestHandleJourneySnoozeSetsExemption is the primary contract: a valid request
+// records a snooze that actually suppresses journey nudges for that hive.
+func TestHandleJourneySnoozeSetsExemption(t *testing.T) {
+	s := dispatchTestServer(t)
+
+	rec := postSnoozeJSON(t, s.handleJourneySnooze, `{"hive_id":"hive-1","duration":"24h","reason":"vendor pilot"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Ok           bool   `json:"ok"`
+		HiveID       string `json:"hive_id"`
+		Snoozed      bool   `json:"snoozed"`
+		SnoozedUntil string `json:"snoozed_until"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.Ok || resp.HiveID != "hive-1" || !resp.Snoozed {
+		t.Errorf("resp = %+v, want ok+snoozed for hive-1", resp)
+	}
+	if resp.SnoozedUntil == "" {
+		t.Error("snoozed_until is empty, want an RFC3339 expiry")
+	}
+
+	// The stored state must actually suppress nudges.
+	st := s.journey.get("hive-1")
+	if st == nil {
+		t.Fatal("no journey state recorded for hive-1")
+	}
+	if st.SnoozeReason != "vendor pilot" {
+		t.Errorf("SnoozeReason = %q, want %q", st.SnoozeReason, "vendor pilot")
+	}
+	if !st.snoozeActive(time.Now()) {
+		t.Error("snoozeActive = false immediately after setting a 24h snooze")
+	}
+}
+
+// TestHandleJourneySnoozeClearsOnEmptyDuration covers the documented "empty or
+// zero duration clears the snooze" rule, including the round trip: set, then
+// clear, then confirm the exemption is gone.
+func TestHandleJourneySnoozeClearsOnEmptyDuration(t *testing.T) {
+	for _, dur := range []string{"", "0"} {
+		t.Run("duration="+dur, func(t *testing.T) {
+			s := dispatchTestServer(t)
+			s.journey.setSnooze("hive-1", time.Now().Add(snoozeTestDuration), "admin", "pilot")
+			if !s.journey.get("hive-1").snoozeActive(time.Now()) {
+				t.Fatal("precondition: snooze was not active before clearing")
+			}
+
+			rec := postSnoozeJSON(t, s.handleJourneySnooze, `{"hive_id":"hive-1","duration":"`+dur+`"}`)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+			}
+			var resp struct {
+				Snoozed      bool   `json:"snoozed"`
+				SnoozedUntil string `json:"snoozed_until"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if resp.Snoozed {
+				t.Error(`resp["snoozed"] = true, want false after clearing`)
+			}
+			if resp.SnoozedUntil != "" {
+				t.Errorf("snoozed_until = %q, want it omitted when cleared", resp.SnoozedUntil)
+			}
+			if s.journey.get("hive-1").snoozeActive(time.Now()) {
+				t.Error("snooze is still active after a clear request")
+			}
+		})
+	}
+}
+
+// TestHandleJourneySnoozeRejectsBadInput covers the three rejection paths:
+// unparseable body, missing hive_id, and a duration past the cap. Each must be
+// a 400, and none may record any state.
+func TestHandleJourneySnoozeRejectsBadInput(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "malformed json", body: `{not json`},
+		{name: "missing hive_id", body: `{"duration":"24h"}`},
+		{name: "blank hive_id", body: `{"hive_id":"   ","duration":"24h"}`},
+		{name: "unparseable duration", body: `{"hive_id":"hive-1","duration":"forever"}`},
+		{name: "duration beyond the cap", body: `{"hive_id":"hive-1","duration":"9000h"}`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := dispatchTestServer(t)
+			rec := postSnoozeJSON(t, s.handleJourneySnooze, tc.body)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400 (body=%q)", rec.Code, rec.Body.String())
+			}
+			if st := s.journey.get("hive-1"); st != nil && st.snoozeActive(time.Now()) {
+				t.Error("a rejected request still recorded an active snooze")
+			}
+		})
+	}
+}
+
+// TestHandleJourneySnoozeTruncatesLongReason checks the PVC-bound guard: an
+// over-long operator note is truncated to maxSnoozeReasonLen runes rather than
+// stored whole or rejected.
+func TestHandleJourneySnoozeTruncatesLongReason(t *testing.T) {
+	// Mirrors the maxSnoozeReasonLen constant inside handleJourneySnooze.
+	const wantMaxReasonLen = 200
+	// Multi-byte runes ensure the truncation is rune-based, not byte-based:
+	// a byte-slice truncation would both cut at the wrong place and risk
+	// splitting a rune into invalid UTF-8.
+	longReason := strings.Repeat("é", wantMaxReasonLen+50)
+
+	s := dispatchTestServer(t)
+	body, err := json.Marshal(map[string]string{
+		"hive_id":  "hive-1",
+		"duration": "24h",
+		"reason":   longReason,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	rec := postSnoozeJSON(t, s.handleJourneySnooze, string(body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+
+	st := s.journey.get("hive-1")
+	if st == nil {
+		t.Fatal("no journey state recorded")
+	}
+	if got := len([]rune(st.SnoozeReason)); got != wantMaxReasonLen {
+		t.Errorf("stored reason length = %d runes, want %d", got, wantMaxReasonLen)
+	}
+	if !strings.HasPrefix(longReason, st.SnoozeReason) {
+		t.Error("stored reason is not a prefix of the submitted reason")
+	}
+}
+
+// TestHandleJourneySnoozeSuppressesNudge is the end-to-end reason the endpoint
+// exists: after an admin snoozes a hive, journeyBannerFor must return nothing
+// for it, even though the same hive is nudged without the snooze.
+func TestHandleJourneySnoozeSuppressesNudge(t *testing.T) {
+	// A long-registered hive with no GitHub App is squarely due a stage-1 nudge.
+	stalled := *hive(60 * 24 * time.Hour)
+	stalled.ID = "hive-1"
+	stalled.PendingGitHubAppInstall = true
+
+	now := time.Now()
+	s := dispatchTestServer(t, stalled)
+
+	if banner := s.journeyBannerFor("hive-1", now); banner == nil {
+		t.Fatal("precondition: expected a nudge for an un-snoozed stalled hive")
+	}
+
+	// Fresh server so the just-recorded "sent" state does not confound the
+	// second half of the check.
+	s = dispatchTestServer(t, stalled)
+	rec := postSnoozeJSON(t, s.handleJourneySnooze, `{"hive_id":"hive-1","duration":"24h","reason":"vendor pilot"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("snooze status = %d, want 200", rec.Code)
+	}
+	if banner := s.journeyBannerFor("hive-1", now); banner != nil {
+		t.Errorf("journeyBannerFor returned %+v for a snoozed hive, want nil", banner)
+	}
+}


### PR DESCRIPTION
## What

Raises per-package test coverage for the two packages named by the hourly coverage gate, with behaviour tests rather than line-chasing.

**`pkg/agent` now clears the 90% floor.** `pkg/hub` improves substantially but does not reach 90 — see the honest accounting below.

| package | before | after | gate floor |
|---|---|---|---|
| `pkg/agent` | 88.1% | **90.0%** | 90% ✅ |
| `pkg/hub` | 85.9% | **87.9%** | 90% ❌ |

Baselines are from the hourly run the issue points at, re-measured on `origin/v2` before starting; the "after" numbers are from CI's own gate command (`go test -cover ./pkg/... -short -count=1`) on this branch.

## Which packages were actually below threshold

The issue body names none, so I read the run logs. The gate only inspects lines starting with `^ok`, so `0.0%` no-test packages (`apiproxy`, `channels`, `claude`) are **not** gated, and `dashboard` has a documented per-package floor of 78 which it meets. That leaves exactly two real failures — `agent` and `hub` — confirmed against current `v2`, not the stale commit.

## What is covered

**`pkg/agent`**
- `AuthorizePROpen` — the forge check (agent A may not open a PR from a request file owned by agent B), the deliberate no-UID-map fallback, and the ACMM write-gate including an explicit per-agent `Mode` override.
- `CountAgentsWithModel` — the "backend OR model, from config or any override field" rule; `"auto"`/`"default"` count as deliberate selections, whitespace does not.
- `fixEntry` / `fixPermissions` — the ownership guard that stops the watcher chmod-ing other users' files, non-destructive OR-ing of mode bits, the recursive walk bob's nested chat tree needs, self-healing of a missing watched root.
- `UIDMap.Save` / `LoadUIDMap` — round trip, atomic tmp+rename, write-failure reporting, nil-`Agents` initialisation. A silently lost UID map would re-assign every agent a new UID on the next boot.
- `configHasTokens` — the two-source rule (Claude credentials OR Copilot config) and fall-through when the Claude file is unreadable.
- `SetRecordPromptCallback` / `recordPrompt` — set/clear/replace, plus the documented "safe to call with `m.mu` held" contract (exercised under `-race`).

**`pkg/hub`**
- `handleJourneySnooze` — set/clear round trip, five rejection paths, rune-based reason truncation, and end-to-end proof a snooze really suppresses `journeyBannerFor`.
- `handleJourneyStatus` / `attachJourneyStatus` / `writeJSONError`.
- `setClusterAppID` — persistence to both the in-memory map and `clusters.json`, including the documented data-loss invariant that entries `loadClusters` would drop must survive the rewrite verbatim.
- Heartbeat liveness accessors — the attempt-vs-success distinction separating a wedged goroutine from a partitioned network.
- `mintHubUserCookieValue` / `verifyHubUserCookieValue` — session security: eight forgery attempts (username swapped under a kept signature, altered signature, legacy unsigned cookie, wrong secret, no secret) that must all fail closed.
- `githubHostLabel` / `GitHubHostLabel` — normalization plus an anti-drift check that hub and spoke cannot spell the same host two ways.
- `ReportUpgradeFailure` — the failed-upgrade payload, driven against an `httptest` server.
- `handleGrantableUsers` — the roster access gate (hive owner or admin only).

## Every test was mutation-verified

Not a claim — a procedure. For each new test I broke the code it covers, confirmed the test failed, and restored the source. Mutations applied: forge check inverted; ACMM gate disabled; `OR` flipped to `AND`; reason truncation removed; `hive_id` validation dropped; snooze ignored; `clusters.json` re-serialized from the in-memory map (the documented data-loss bug); zero-time guard removed; ownership guard removed; missing-root recreation dropped; `os.Rename` skipped; nil-`Agents` init dropped; `nearestExistingDir` stopped walking up; the Claude token source removed; nil-clears disabled; the cookie HMAC comparison made to always succeed; scheme-stripping disabled; the grantable-users ownership gate removed.

The last two are the ones worth noting: they represent a forged-session hole and a user-enumeration hole, and the tests catch both.

## Why `pkg/hub` does not reach 90

`pkg/hub` needs ~180 more covered statements. Essentially all of the remainder sits in code that shells out to a real `kubectl` or calls the live GitHub API — `UpgradeSelfToSHA`, `SelfDeploymentImage`, `watchHubRollout`, `hubRolloutFailureReason`, `bulkRestartOrUpgrade`, `bulkSwitchBranch`, `StartLatestSHAPoller`, `provisionHive`, `addVanityHostToIngress`, and the provisioning handlers.

I deliberately did **not** cover these. `v2/pkg/hub` has a `TestMain` (#2287) that neutralizes `KUBECONFIG` precisely because hub tests shelling out to a real `kubectl` had been mutating the production cluster. Reaching 90 here means either adding real seams to that code or writing tests that touch a live cluster — the latter is exactly the failure mode this repo has already been burned by, and I would rather leave the number short than reintroduce it. `TestHandleHubSelfUpgrade` (which patched the production hub Deployment to a bogus tag three times) is the cautionary example.

Nothing here lowers the threshold, and no production code is modified.

## Note on the coverage issue

`pkg/agent` clears the floor, but the gate will stay red on `pkg/hub`, so **I have not used a `Fixes` keyword** — #2191 should not auto-close. Two further packages, `pkg/hubbackup` (36.9%) and `pkg/spokebackup` (80.0%), landed on `v2` while this work was in flight and are now also below threshold; they are out of scope here and need their own follow-up.

## Verification

- `go build ./...`, `go vet ./pkg/hub/ ./pkg/agent/` — clean
- `go test ./pkg/hub/ ./pkg/agent/ -short` — both pass on this branch
- Compared against a throwaway worktree on unmodified `origin/v2`: the clean base passes too, so nothing here is a regression. One transient `pkg/agent` failure was observed and did not reproduce across three subsequent runs (the known fixed-tmux-session-name flake); it does not reproduce on clean base either.
- `gofmt` on touched files only — several untouched files have pre-existing drift and were left alone.

## Porting

Test-only and additive. `mk`, `dd` and `v3` need the same tests ported; note that `ks/console`'s hive runs **v3**, so a v2-only merge will not reach it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
