### PR TITLE
✨ feat(hub): show live disk usage on Cluster Health cards and rollups

### DIFF
--- a/v2/pkg/hub/cluster_health_disk_test.go
+++ b/v2/pkg/hub/cluster_health_disk_test.go
@@ -1,0 +1,109 @@
+package hub
+
+import "testing"
+
+// The disk metric exists because a node at 81% used gave the operator no
+// warning before kubelet began evicting pods. These tests pin the two
+// behaviours that make the metric trustworthy: real usage is reported from
+// the kubelet stats endpoint, and *missing* usage stays missing rather than
+// collapsing into a healthy-looking 0%.
+
+func TestParseNodeStatsSummaryDisk(t *testing.T) {
+	// Shape mirrors a real /stats/summary response (extra fields ignored).
+	raw := []byte(`{"node":{"nodeName":"n1","fs":{"availableBytes":7086080,"capacityBytes":100,"usedBytes":81}}}`)
+	usage, ok := parseNodeStatsSummaryDisk(raw)
+	if !ok {
+		t.Fatal("expected disk usage to parse")
+	}
+	if usage.usedBytes != 81 || usage.capacityBytes != 100 {
+		t.Fatalf("got used=%d cap=%d, want 81/100", usage.usedBytes, usage.capacityBytes)
+	}
+}
+
+func TestParseNodeStatsSummaryDiskRejectsUnusable(t *testing.T) {
+	cases := map[string]string{
+		"malformed json":   `{`,
+		"no node":          `{}`,
+		"missing usage":    `{"node":{"fs":{"capacityBytes":100}}}`,
+		"missing capacity": `{"node":{"fs":{"usedBytes":81}}}`,
+		// Zero capacity would make the percentage a divide-by-zero.
+		"zero capacity": `{"node":{"fs":{"usedBytes":81,"capacityBytes":0}}}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, ok := parseNodeStatsSummaryDisk([]byte(body)); ok {
+				t.Fatal("expected unusable stats to be rejected, not defaulted to zero")
+			}
+		})
+	}
+}
+
+func TestApplyNodeDiskUsageComputesPercent(t *testing.T) {
+	var n ClusterHealthNode
+	const gib = int64(giToBytes)
+	// 81 GiB used of 100 GiB: the danger zone that triggered the incident.
+	applyNodeDiskUsage(&n, nodeDiskUsage{usedBytes: 81 * gib, capacityBytes: 100 * gib})
+	if n.DiskPercent == nil || *n.DiskPercent != 81 {
+		t.Fatalf("DiskPercent = %v, want 81", n.DiskPercent)
+	}
+	if n.DiskTotalMB == nil || *n.DiskTotalMB != 100*1024 {
+		t.Fatalf("DiskTotalMB = %v, want 102400", n.DiskTotalMB)
+	}
+	if n.DiskUsedMB == nil || *n.DiskUsedMB != 81*1024 {
+		t.Fatalf("DiskUsedMB = %v, want 82944", n.DiskUsedMB)
+	}
+}
+
+func TestSummarizeDiskIgnoresNodesWithoutData(t *testing.T) {
+	mb := func(v int64) *int64 { return &v }
+	nodes := []ClusterHealthNode{
+		// 90 GiB used of 100 GiB.
+		{DiskTotalMB: mb(100 * 1024), DiskUsedMB: mb(90 * 1024)},
+		// Unreachable node: must not dilute the percentage toward healthy.
+		{},
+	}
+	gb, pct := summarizeDisk(nodes)
+	if gb == nil || pct == nil {
+		t.Fatal("expected a summary from the one reporting node")
+	}
+	if *gb != 100 {
+		t.Fatalf("total GB = %d, want 100 (unknown node excluded)", *gb)
+	}
+	if *pct != 90 {
+		t.Fatalf("percent = %d, want 90 (unknown node must not dilute)", *pct)
+	}
+}
+
+func TestSummarizeDiskUnknownWhenNoNodeReports(t *testing.T) {
+	// The critical case: an unreachable cluster must yield nil, so the UI
+	// renders a dash. Returning 0 would paint a full disk as healthy.
+	gb, pct := summarizeDisk([]ClusterHealthNode{{}, {}})
+	if gb != nil || pct != nil {
+		t.Fatalf("got %v/%v, want nil/nil so the UI renders unknown, not 0%%", gb, pct)
+	}
+	if gb, pct := summarizeDisk(nil); gb != nil || pct != nil {
+		t.Fatalf("nil nodes: got %v/%v, want nil/nil", gb, pct)
+	}
+}
+
+func TestNodeStatsSummaryPath(t *testing.T) {
+	got := nodeStatsSummaryPath("10.0.10.52")
+	want := "/api/v1/nodes/10.0.10.52/proxy/stats/summary"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestDiskThresholdsMatchKubeletBehaviour(t *testing.T) {
+	// Thresholds are meaningful only if they track kubelet: image GC starts
+	// at 85% used and hard eviction fires at 90% used (nodefs.available<10%).
+	if clusterHealthDiskWarnPct != 85 {
+		t.Fatalf("warn = %d, want 85 (imageGCHighThresholdPercent)", clusterHealthDiskWarnPct)
+	}
+	if clusterHealthDiskDangerPct != 90 {
+		t.Fatalf("danger = %d, want 90 (evictionHard nodefs.available<10%%)", clusterHealthDiskDangerPct)
+	}
+	if clusterHealthDiskWarnPct >= clusterHealthDiskDangerPct {
+		t.Fatal("warn must fire before danger to leave time to act")
+	}
+}

--- a/v2/pkg/hub/cluster_metrics.go
+++ b/v2/pkg/hub/cluster_metrics.go
@@ -203,6 +203,20 @@ func collectClusterHealthUncached(logger *slog.Logger) *HeartbeatClusterHealthRe
 			node.GPUs = ni.gpuCapacity
 			node.GPUType = ni.gpuType
 		}
+		// LIVE node filesystem usage from the kubelet stats/summary endpoint.
+		// The node object's ephemeral-storage capacity is only the declared
+		// size and cannot tell us how full the disk is. Best-effort per node:
+		// a failure leaves the disk fields nil (rendered as unknown).
+		if rawStats, statsErr := k8sAPIGet(nodeStatsSummaryPath(name)); statsErr != nil {
+			logger.Debug("spoke metrics: node disk stats unavailable", "node", name, "error", statsErr)
+		} else if usage, ok := parseNodeStatsSummaryDisk(rawStats); ok {
+			totalMB := usage.capacityBytes / bytesPerMB
+			usedMB := usage.usedBytes / bytesPerMB
+			diskPct := int(usage.usedBytes * percentMultiplier / usage.capacityBytes)
+			node.DiskTotalMB = &totalMB
+			node.DiskUsedMB = &usedMB
+			node.DiskPercent = &diskPct
+		}
 		nodes = append(nodes, node)
 	}
 
@@ -285,6 +299,9 @@ func collectClusterHealthUncached(logger *slog.Logger) *HeartbeatClusterHealthRe
 	var totalMemAlloc int64
 	var totalMemUsed int64
 	var totalPods int
+	// Disk totals accumulate only over nodes that actually reported usage, so
+	// partial coverage stays honest instead of averaging in phantom zeros.
+	var totalDiskBytes, totalDiskUsedBytes int64
 	readyNodes := 0
 
 	for _, n := range nodes {
@@ -293,6 +310,10 @@ func collectClusterHealthUncached(logger *slog.Logger) *HeartbeatClusterHealthRe
 		totalPods += n.Pods
 		if n.Ready {
 			readyNodes++
+		}
+		if n.DiskTotalMB != nil && n.DiskUsedMB != nil {
+			totalDiskBytes += *n.DiskTotalMB * bytesPerMB
+			totalDiskUsedBytes += *n.DiskUsedMB * bytesPerMB
 		}
 		if ni, ok := nodeMap[n.Name]; ok {
 			totalCPUAlloc += ni.cpuAllocatable
@@ -311,6 +332,16 @@ func collectClusterHealthUncached(logger *slog.Logger) *HeartbeatClusterHealthRe
 	}
 	totalMemGB := int(totalMemAlloc / giToBytes)
 
+	// nil when no node reported disk usage, so the hub omits disk for this
+	// cluster rather than displaying a misleading 0%.
+	var totalDiskGB, totalDiskPct *int
+	if totalDiskBytes > 0 {
+		gb := int(totalDiskBytes / giToBytes)
+		pct := int(totalDiskUsedBytes * percentMultiplier / totalDiskBytes)
+		totalDiskGB = &gb
+		totalDiskPct = &pct
+	}
+
 	report := &HeartbeatClusterHealthReport{
 		Nodes: nodes,
 		Summary: HeartbeatClusterSummary{
@@ -320,6 +351,8 @@ func collectClusterHealthUncached(logger *slog.Logger) *HeartbeatClusterHealthRe
 			TotalCPUPct:           totalCPUPct,
 			TotalMemGB:            totalMemGB,
 			TotalMemPct:           totalMemPct,
+			TotalDiskGB:           totalDiskGB,
+			TotalDiskPct:          totalDiskPct,
 			TotalPods:             totalPods,
 			HiveCapacityRemaining: hiveCapacityRemaining,
 		},

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -161,8 +161,14 @@ type HeartbeatNodeMetric struct {
 	MemTotalMB    int64  `json:"mem_total_mb"`
 	MemUsedMB     int64  `json:"mem_used_mb"`
 	MemPercent    int    `json:"mem_percent"`
-	Pods          int    `json:"pods"`
-	PodCapacity   int    `json:"pod_capacity"`
+	// Disk fields are pointers so a spoke that could not read kubelet stats
+	// (or an older spoke build that does not report them at all) leaves them
+	// absent, and the hub renders unknown rather than a misleading 0%.
+	DiskTotalMB *int64 `json:"disk_total_mb,omitempty"`
+	DiskUsedMB  *int64 `json:"disk_used_mb,omitempty"`
+	DiskPercent *int   `json:"disk_percent,omitempty"`
+	Pods        int    `json:"pods"`
+	PodCapacity int    `json:"pod_capacity"`
 	// HiveCount is the number of distinct hive-hosted-* namespaces with a
 	// running pod on this node (namespaces, not pods, so a hive briefly
 	// running two pods during a rollout is counted once).
@@ -182,7 +188,11 @@ type HeartbeatClusterSummary struct {
 	TotalCPUPct   int `json:"total_cpu_percent"`
 	TotalMemGB    int `json:"total_mem_gb"`
 	TotalMemPct   int `json:"total_mem_percent"`
-	TotalPods     int `json:"total_pods"`
+	// Disk totals cover only the nodes that reported live usage; nil when no
+	// node did, so the hub omits disk instead of showing a false 0%.
+	TotalDiskGB  *int `json:"total_disk_gb,omitempty"`
+	TotalDiskPct *int `json:"total_disk_percent,omitempty"`
+	TotalPods    int  `json:"total_pods"`
 	// HiveCapacityRemaining estimates how many MORE hives the cluster can
 	// hold (see hive_capacity.go). Pointer so old spokes that do not report
 	// it are distinguishable from a genuinely full cluster (nil vs 0).

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -732,6 +732,27 @@ const clusterHealthMemWarnPct = 60
 // clusterHealthMemDangerPct is the memory usage percentage threshold for danger state.
 const clusterHealthMemDangerPct = 80
 
+// Disk thresholds are anchored to kubelet's own behaviour rather than to
+// round numbers, so a coloured bar means something concrete is about to
+// happen on the node:
+//
+//	evictionHard: nodefs.available<10%  -> kubelet starts evicting pods at
+//	                                       90% used, so that is the danger line.
+//	imageGCHighThresholdPercent: 85     -> kubelet begins garbage-collecting
+//	                                       images at 85% used. That is the
+//	                                       first automatic reaction to disk
+//	                                       filling up, which makes it the
+//	                                       right moment to warn an operator
+//	                                       while there is still headroom.
+//
+// clusterHealthDiskWarnPct is the disk usage percentage at which kubelet's
+// image garbage collection kicks in (imageGCHighThresholdPercent).
+const clusterHealthDiskWarnPct = 85
+
+// clusterHealthDiskDangerPct is the disk usage percentage at which kubelet's
+// hard eviction threshold fires (nodefs.available<10%).
+const clusterHealthDiskDangerPct = 90
+
 // kubectlTopTimeoutSec is the timeout for kubectl top nodes commands.
 const kubectlTopTimeoutSec = 10
 
@@ -768,8 +789,16 @@ type ClusterHealthNode struct {
 	MemUsedMB     int64  `json:"mem_used_mb"`
 	MemPercent    int    `json:"mem_percent"`
 	DiskPressure  bool   `json:"disk_pressure"`
-	Pods          int    `json:"pods"`
-	PodCapacity   int    `json:"pod_capacity"`
+	// Disk fields describe the node filesystem (nodefs) that kubelet applies
+	// its eviction thresholds to. They are pointers because live disk usage
+	// comes from the kubelet stats/summary endpoint, which a hub may not be
+	// able to reach; nil means "unknown" and must render as dashes rather
+	// than as 0 (which would read as healthy).
+	DiskTotalMB *int64 `json:"disk_total_mb,omitempty"`
+	DiskUsedMB  *int64 `json:"disk_used_mb,omitempty"`
+	DiskPercent *int   `json:"disk_percent,omitempty"`
+	Pods        int    `json:"pods"`
+	PodCapacity int    `json:"pod_capacity"`
 	// HiveCount is the number of distinct hive-hosted-* namespaces with a
 	// running pod on this node (namespaces, not pods, so a hive briefly
 	// running two pods during a rollout is counted once).
@@ -787,7 +816,12 @@ type ClusterHealthSummary struct {
 	TotalCPUPct   int `json:"total_cpu_percent"`
 	TotalMemGB    int `json:"total_mem_gb"`
 	TotalMemPct   int `json:"total_mem_percent"`
-	HiveCount     int `json:"hive_count"`
+	// Disk totals cover only the nodes that reported live disk usage. They
+	// are pointers so a cluster with no reachable kubelet stats endpoint
+	// omits them entirely instead of reporting a misleading 0%.
+	TotalDiskGB  *int `json:"total_disk_gb,omitempty"`
+	TotalDiskPct *int `json:"total_disk_percent,omitempty"`
+	HiveCount    int  `json:"hive_count"`
 	// HiveCapacityRemaining estimates how many MORE hives the cluster can
 	// hold: per Ready, schedulable node, the per-hive request footprint
 	// (see hive_capacity.go) bin-packed into allocatable-minus-requested
@@ -1037,6 +1071,12 @@ func buildClusterHealth(s *HubServer) (*ClusterHealthResponse, error) {
 		return perCluster[i].ID < perCluster[j].ID
 	})
 
+	// Every collection path above appends its nodes to allNodes, so the fleet
+	// disk total is derived from them directly. Nodes with no disk data are
+	// skipped, so an unreachable cluster lowers coverage without skewing the
+	// percentage; if no node anywhere reported, disk is omitted entirely.
+	aggDiskGB, aggDiskPct := summarizeDisk(allNodes)
+
 	return &ClusterHealthResponse{
 		Nodes: allNodes,
 		Summary: ClusterHealthSummary{
@@ -1045,6 +1085,8 @@ func buildClusterHealth(s *HubServer) (*ClusterHealthResponse, error) {
 			TotalCPUPct:   aggCPUPct,
 			TotalMemGB:    aggMemGB,
 			TotalMemPct:   aggMemPct,
+			TotalDiskGB:   aggDiskGB,
+			TotalDiskPct:  aggDiskPct,
 			HiveCount:     totalHiveCount,
 		},
 		Clusters: perCluster,
@@ -1194,6 +1236,26 @@ func buildSingleClusterHealth(cluster *ClusterConfig, hiveCount int, logger *slo
 		})
 	}
 
+	// Collect LIVE node filesystem usage from each kubelet's stats/summary
+	// endpoint. This is best-effort per node: a node whose kubelet proxy is
+	// unreachable simply keeps nil disk fields and renders as unknown, which
+	// must never degrade the rest of this cluster's health data.
+	for i := range nodes {
+		rawStats, statsErr := kubectlForClusterContext(ctx, cluster,
+			"--request-timeout", timeout.String(),
+			"get", "--raw", nodeStatsSummaryPath(nodes[i].Name)).Output()
+		if statsErr != nil {
+			if logger != nil {
+				logger.Debug("cluster health: node disk stats unavailable",
+					"cluster", cluster.ID, "node", nodes[i].Name, "error", statsErr)
+			}
+			continue
+		}
+		if usage, ok := parseNodeStatsSummaryDisk(rawStats); ok {
+			applyNodeDiskUsage(&nodes[i], usage)
+		}
+	}
+
 	// Count running pods per node and sum their container resource REQUESTS
 	// (requests, not usage — that is what the scheduler bin-packs against).
 	// Listing only Running pods slightly undercounts requests (Pending pods
@@ -1284,6 +1346,7 @@ func buildSingleClusterHealth(cluster *ClusterConfig, hiveCount int, logger *slo
 		totalMemPct = int(totalMemUsed * percentMultiplier / totalMemAlloc)
 	}
 	totalMemGB := int(totalMemAlloc / giToBytes)
+	totalDiskGB, totalDiskPct := summarizeDisk(nodes)
 
 	result := PerClusterHealth{
 		Nodes: nodes,
@@ -1293,6 +1356,8 @@ func buildSingleClusterHealth(cluster *ClusterConfig, hiveCount int, logger *slo
 			TotalCPUPct:           totalCPUPct,
 			TotalMemGB:            totalMemGB,
 			TotalMemPct:           totalMemPct,
+			TotalDiskGB:           totalDiskGB,
+			TotalDiskPct:          totalDiskPct,
 			HiveCount:             hiveCount,
 			HiveCapacityRemaining: hiveCapacityRemaining,
 		},
@@ -1340,6 +1405,9 @@ func convertHeartbeatToPerClusterHealth(clusterID, clusterName string, entry *He
 			MemUsedMB:     n.MemUsedMB,
 			MemPercent:    n.MemPercent,
 			DiskPressure:  n.DiskPressure,
+			DiskTotalMB:   n.DiskTotalMB,
+			DiskUsedMB:    n.DiskUsedMB,
+			DiskPercent:   n.DiskPercent,
 			Pods:          n.Pods,
 			PodCapacity:   n.PodCapacity,
 			HiveCount:     n.HiveCount,
@@ -1357,7 +1425,10 @@ func convertHeartbeatToPerClusterHealth(clusterID, clusterName string, entry *He
 			TotalCPUPct:   report.Summary.TotalCPUPct,
 			TotalMemGB:    report.Summary.TotalMemGB,
 			TotalMemPct:   report.Summary.TotalMemPct,
-			HiveCount:     hiveCount,
+			// nil for spokes that could not read kubelet disk stats.
+			TotalDiskGB:  report.Summary.TotalDiskGB,
+			TotalDiskPct: report.Summary.TotalDiskPct,
+			HiveCount:    hiveCount,
 			// nil for spokes running older builds that do not report it.
 			HiveCapacityRemaining: report.Summary.HiveCapacityRemaining,
 		},
@@ -1383,6 +1454,75 @@ func convertHeartbeatToPerClusterHealth(clusterID, clusterName string, entry *He
 	}
 
 	return pch
+}
+
+// nodeDiskUsage holds live node filesystem usage for one node.
+type nodeDiskUsage struct {
+	usedBytes     int64
+	capacityBytes int64
+}
+
+// nodeStatsSummaryPath builds the kubelet stats/summary proxy path for a node.
+// This endpoint is the only source of LIVE disk usage: the node object's
+// capacity/allocatable["ephemeral-storage"] reports the declared size only and
+// says nothing about how full the filesystem actually is.
+func nodeStatsSummaryPath(nodeName string) string {
+	return "/api/v1/nodes/" + nodeName + "/proxy/stats/summary"
+}
+
+// parseNodeStatsSummaryDisk extracts node filesystem usage from a kubelet
+// stats/summary response. node.fs is the nodefs that kubelet's
+// evictionHard nodefs.available threshold applies to.
+func parseNodeStatsSummaryDisk(raw []byte) (nodeDiskUsage, bool) {
+	var summary struct {
+		Node struct {
+			FS struct {
+				UsedBytes     *int64 `json:"usedBytes"`
+				CapacityBytes *int64 `json:"capacityBytes"`
+			} `json:"fs"`
+		} `json:"node"`
+	}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		return nodeDiskUsage{}, false
+	}
+	fs := summary.Node.FS
+	// Both values are required: without capacity there is no percentage, and
+	// a missing usedBytes must not be treated as zero usage.
+	if fs.UsedBytes == nil || fs.CapacityBytes == nil || *fs.CapacityBytes <= 0 {
+		return nodeDiskUsage{}, false
+	}
+	return nodeDiskUsage{usedBytes: *fs.UsedBytes, capacityBytes: *fs.CapacityBytes}, true
+}
+
+// applyNodeDiskUsage fills the disk fields on a health node from live usage.
+// Nodes with no usable stats keep nil disk fields and render as unknown.
+func applyNodeDiskUsage(n *ClusterHealthNode, d nodeDiskUsage) {
+	totalMB := d.capacityBytes / bytesPerMB
+	usedMB := d.usedBytes / bytesPerMB
+	pct := int(d.usedBytes * percentMultiplier / d.capacityBytes)
+	n.DiskTotalMB = &totalMB
+	n.DiskUsedMB = &usedMB
+	n.DiskPercent = &pct
+}
+
+// summarizeDisk aggregates per-node disk usage into cluster totals, counting
+// only nodes that actually reported usage. Returns nil,nil when no node did,
+// so the UI omits disk for that cluster rather than showing a false 0%.
+func summarizeDisk(nodes []ClusterHealthNode) (*int, *int) {
+	var totalBytes, usedBytes int64
+	for _, n := range nodes {
+		if n.DiskTotalMB == nil || n.DiskUsedMB == nil {
+			continue
+		}
+		totalBytes += *n.DiskTotalMB * bytesPerMB
+		usedBytes += *n.DiskUsedMB * bytesPerMB
+	}
+	if totalBytes <= 0 {
+		return nil, nil
+	}
+	totalGB := int(totalBytes / giToBytes)
+	pct := int(usedBytes * percentMultiplier / totalBytes)
+	return &totalGB, &pct
 }
 
 // parseK8sCPU parses Kubernetes CPU resource strings (e.g. "4", "4000m", "5866711668n").
@@ -12408,6 +12548,15 @@ const dashboardHTML = `<!DOCTYPE html>
     var CLUSTER_CPU_DANGER_PCT = 80;
     var CLUSTER_MEM_WARN_PCT = 60;
     var CLUSTER_MEM_DANGER_PCT = 80;
+    // Disk thresholds mirror kubelet's own behaviour on these nodes rather
+    // than round numbers: image garbage collection starts at
+    // imageGCHighThresholdPercent (85% used) and hard eviction fires at
+    // evictionHard nodefs.available<10% (90% used). Amber therefore means
+    // "kubelet is already reclaiming disk", red means "pods are being evicted".
+    var CLUSTER_DISK_WARN_PCT = 85;
+    var CLUSTER_DISK_DANGER_PCT = 90;
+    // MiB per GiB, for rendering disk_*_mb values as GiB.
+    var MB_PER_GB = 1024;
     var _clusterHealthCollapsed = localStorage.getItem('hive-cluster-health-collapsed') !== 'false';
 
     function toggleClusterHealth() {
@@ -12463,6 +12612,29 @@ const dashboardHTML = `<!DOCTYPE html>
         '</span></div>';
     }
 
+    // Renders a metric row whose value could not be collected. Deliberately
+    // dashed rather than 0%, so an unreachable node never reads as healthy.
+    function renderHealthMetricUnknown(label, reason) {
+      return '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:4px" title="' + esc(reason || 'No data') + '">' +
+        '<span style="font-size:0.7rem;color:var(--muted)">' + label + '</span>' +
+        '<span style="display:flex;align-items:center;gap:6px">' +
+        '<span style="font-family:monospace;font-size:0.75rem;color:var(--muted)">— / — GiB</span>' +
+        '<span style="font-size:0.7rem;min-width:28px;text-align:right;color:var(--muted)">—</span>' +
+        '</span></div>';
+    }
+
+    // Disk usage is optional: the collector omits it when the kubelet
+    // stats endpoint was unreachable, so absent means unknown, not zero.
+    function renderNodeDiskMetric(n, nk) {
+      if (n.disk_percent == null || n.disk_total_mb == null || n.disk_used_mb == null) {
+        return renderHealthMetricUnknown('DISK', 'Disk usage unavailable for this node');
+      }
+      var diskUsedGB = (n.disk_used_mb / MB_PER_GB).toFixed(1);
+      var diskTotalGB = Math.round(n.disk_total_mb / MB_PER_GB);
+      return renderHealthMetric('DISK', diskUsedGB, diskTotalGB, 'GiB', n.disk_percent,
+        CLUSTER_DISK_WARN_PCT, CLUSTER_DISK_DANGER_PCT, nk, 'disk');
+    }
+
     function renderNodeCard(n) {
       var nk = n.name;
       var readyBadge = (n.conditions || []).indexOf('Ready') >= 0
@@ -12485,6 +12657,7 @@ const dashboardHTML = `<!DOCTYPE html>
         '</span></div>' +
         renderHealthMetric('CPU', cpuUsed, n.cpu_cores, 'cores', n.cpu_percent, CLUSTER_CPU_WARN_PCT, CLUSTER_CPU_DANGER_PCT, nk, 'cpu') +
         renderHealthMetric('MEM', memUsedGB, memTotalGB, 'GB', n.mem_percent, CLUSTER_MEM_WARN_PCT, CLUSTER_MEM_DANGER_PCT, nk, 'mem') +
+        renderNodeDiskMetric(n, nk) +
         diskWarn +
         '</div>';
     }
@@ -12509,10 +12682,22 @@ const dashboardHTML = `<!DOCTYPE html>
           var cpuColor = healthBarColor(s.total_cpu_percent || 0, CLUSTER_CPU_WARN_PCT, CLUSTER_CPU_DANGER_PCT);
           var memColor = healthBarColor(s.total_mem_percent || 0, CLUSTER_MEM_WARN_PCT, CLUSTER_MEM_DANGER_PCT);
           var clusterCount = (data.clusters || []).length;
+          // Disk is omitted when no node reported usage; showing 0% there
+          // would claim the fleet is healthy on no evidence at all.
+          var diskSegment = '';
+          if (s.total_disk_percent != null) {
+            pushSparkPoint('_cluster', 'disk', s.total_disk_percent);
+            var diskColor = healthBarColor(s.total_disk_percent, CLUSTER_DISK_WARN_PCT, CLUSTER_DISK_DANGER_PCT);
+            diskSegment = renderUnicodeSparkline('_cluster', 'disk', diskColor) +
+              ' <span style="color:' + diskColor + '">' + s.total_disk_percent + '% disk</span> · ';
+          } else {
+            diskSegment = '<span style="color:var(--muted)" title="No node reported live disk usage">— disk</span> · ';
+          }
           summaryBar.innerHTML = clusterCount + ' cluster' + (clusterCount !== 1 ? 's' : '') + ' · ' +
             (s.total_nodes || 0) + ' nodes · ' + (s.total_cpu_cores || 0) + ' vCPU · ' +
             renderUnicodeSparkline('_cluster', 'cpu', cpuColor) + ' <span style="color:' + cpuColor + '">' + (s.total_cpu_percent || 0) + '% cpu</span> · ' +
             renderUnicodeSparkline('_cluster', 'mem', memColor) + ' <span style="color:' + memColor + '">' + (s.total_mem_percent || 0) + '% mem</span> · ' +
+            diskSegment +
             (s.hive_count || 0) + ' hives';
         }
 
@@ -12535,6 +12720,15 @@ const dashboardHTML = `<!DOCTYPE html>
             var cs = c.summary || {};
             var cCpuColor = healthBarColor(cs.total_cpu_percent || 0, CLUSTER_CPU_WARN_PCT, CLUSTER_CPU_DANGER_PCT);
             var cMemColor = healthBarColor(cs.total_mem_percent || 0, CLUSTER_MEM_WARN_PCT, CLUSTER_MEM_DANGER_PCT);
+            // Absent disk data (e.g. an unreachable cluster) renders dashed,
+            // never as 0% — a full disk and an unknown disk must not look alike.
+            var cDiskSegment;
+            if (cs.total_disk_percent != null) {
+              var cDiskColor = healthBarColor(cs.total_disk_percent, CLUSTER_DISK_WARN_PCT, CLUSTER_DISK_DANGER_PCT);
+              cDiskSegment = '<span style="color:' + cDiskColor + '">' + cs.total_disk_percent + '% disk</span> · ';
+            } else {
+              cDiskSegment = '<span style="color:var(--muted)" title="No node in this cluster reported live disk usage">— disk</span> · ';
+            }
             var gpuLine = '';
             if (c.gpu_summary) {
               gpuLine = ' · <span style="color:var(--green)">' + c.gpu_summary.allocatable_gpus + '/' + c.gpu_summary.total_gpus + ' GPUs</span>';
@@ -12554,6 +12748,7 @@ const dashboardHTML = `<!DOCTYPE html>
               (cs.total_nodes || 0) + ' nodes · ' + (cs.total_cpu_cores || 0) + ' vCPU · ' +
               '<span style="color:' + cCpuColor + '">' + (cs.total_cpu_percent || 0) + '% cpu</span> · ' +
               '<span style="color:' + cMemColor + '">' + (cs.total_mem_percent || 0) + '% mem</span> · ' +
+              cDiskSegment +
               (c.hive_count || 0) + ' hives' + capacityLine + gpuLine +
               '</span></div>';
             var nodesHtml = (c.nodes || []).length > 0


### PR DESCRIPTION
## Why

Cluster Health showed **CPU and MEM only**. Disk appeared solely as a red "⚠ Disk Pressure" banner driven by the node's `DiskPressure` condition — which kubelet sets only once it is *already evicting pods*.

Today all four `hive-oke` nodes sat at **66–81%** ephemeral storage with nothing on the dashboard to show it. By the time the banner appeared, **13 pods had been evicted** and one hive (`available-oke-04-placeholder-dlyb`) had no running pod at all and could not schedule anywhere. A DISK bar reading 81% would have surfaced this hours earlier.

## What

- **Per-node card** — a third `DISK` row beside CPU and MEM, same bar/sparkline treatment, `used / capacity` in GiB plus a percentage.
- **Fleet rollup** — `… 6% cpu · 6% mem · 71% disk · 50 hives`
- **Per-cluster rollup** — `… 11% cpu · 10% mem · 66% disk · 17 hives · room for ~50 more hives`

## Data source

`/api/v1/nodes/<node>/proxy/stats/summary` → `node.fs.{usedBytes,capacityBytes}`.

The alternative, `node.status.capacity/allocatable["ephemeral-storage"]`, reports the **declared size only** and says nothing about how full the filesystem is — insufficient on its own. `kubectl top` does not report disk at all.

`node.fs` is specifically the *nodefs* that kubelet applies its `evictionHard` threshold to, so the number shown is the number kubelet acts on.

Collection **follows each existing path** rather than adding a parallel one:
- **Hub** → `kubectl get --raw <stats path>` via the existing `kubectlForClusterContext`, reusing the same cluster context, timeout, and `--request-timeout`.
- **Spoke heartbeat** → the in-cluster `k8sAPIGet` already used for the metrics and nodes APIs.

## Thresholds — anchored to kubelet, not round numbers

Verified kubelet config on this cluster:

```
evictionHard: nodefs.available<10%   imagefs.available<15%
imageGCHighThresholdPercent: 85      imageGCLowThresholdPercent: 80
```

| Constant | Value | Justification |
|---|---|---|
| `clusterHealthDiskWarnPct` / `CLUSTER_DISK_WARN_PCT` | **85** | `imageGCHighThresholdPercent` — kubelet begins garbage-collecting images. The first automatic reaction to a filling disk, and the last comfortable moment to intervene. |
| `clusterHealthDiskDangerPct` / `CLUSTER_DISK_DANGER_PCT` | **90** | `evictionHard: nodefs.available<10%` — the exact point pods start being evicted. |

Named constants with comments on both the Go and JS sides; no bare literals. A test asserts the values still track kubelet's semantics and that warn fires strictly before danger.

## Unknown is never 0%

The central safety property: a disk we cannot measure must not look like an empty one. `vllm-d` is intermittently unreachable from the hub (`i/o timeout` to :6443 appears regularly in hub logs), so this is the common case, not the edge case.

- Disk fields are **pointers** (`*int64` / `*int`, `omitempty`) on `ClusterHealthNode`, `ClusterHealthSummary`, `HeartbeatNodeMetric`, and `HeartbeatClusterSummary` — absent means unknown, distinct from zero.
- Per-node collection is **best-effort**: a node whose kubelet proxy fails is logged at debug and keeps nil disk fields. CPU, MEM, pods, and hive counts for that node and cluster are unaffected.
- Aggregates count **only nodes that actually reported**, so partial coverage stays honest instead of averaging in phantom zeros.
- An unreachable node renders `— / — GiB   —`; an unreachable cluster renders `— disk` in muted grey with an explanatory tooltip.
- Older spokes that do not report disk degrade to the same unknown rendering.

## Verification

- `node --check` on the extracted dashboard JS: **passes** (baseline also verified clean first).
- Base-vs-current JS delta: braces **+7/+7**, parens **+24/+24**, brackets **0/0** — symmetric.
- Grepped the extraction to confirm the new code is actually present in `dashboardHTML`.
- Every added backtick confirmed to be a Go struct tag, none inside the raw string.
- All `.map()` / `.join()` call sites guarded with `(arr || [])`; new optional fields checked with `!= null` rather than falsiness, so a genuine `0%` still renders as `0%`.
- `go build ./...`, `go vet ./pkg/hub/`, `gofmt` clean; full `go test ./pkg/hub/` passes.
- 7 new unit tests covering stats parsing, rejection of unusable payloads (malformed, missing usage, missing capacity, zero capacity), percentage math, aggregate exclusion of unknown nodes, and the nil-not-zero guarantee.
- The `stats/summary` endpoint and `node.fs` shape were confirmed against live `hive-oke` nodes read-only (`10.0.10.52` → used 28.8 GiB / cap 35.4 GiB / avail 6.6 GiB). No node, hive, or hub was mutated.