### PR TITLE
🐛 fix(hub): make the app_id sentinel repair and ACMM delivery actually reach production

### DIFF
--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -187,10 +187,44 @@ type clusterAppIdentity struct {
 	Fingerprint string
 }
 
+// HasKey reports whether this identity carries actual key material, as opposed
+// to naming an App whose key the hub has never been given.
+//
+// Every decision that would REPLACE a spoke's key must gate on this: an
+// identity with no key can still authoritatively correct an app_id, but pushing
+// its empty PrivateKey would blank a spoke's working key file. The heartbeat
+// contract treats an empty private_key as "leave the key alone", so the two
+// concerns stay cleanly separable.
+func (i *clusterAppIdentity) HasKey() bool {
+	return i != nil && i.PrivateKey != "" && i.Fingerprint != ""
+}
+
 // appIdentityForCluster resolves the App identity the hub should enforce on a
-// cluster. It returns nil when the cluster is unknown, has no configured app_id,
-// or has no stored key — all of which mean "this hub has nothing authoritative
-// to say about this cluster's App credentials, so change nothing".
+// cluster. It returns nil when the cluster is unknown or has no configured
+// app_id — both of which mean "this hub has nothing authoritative to say about
+// this cluster's App credentials, so change nothing".
+//
+// A CONFIGURED app_id WITH NO STORED KEY IS STILL AN IDENTITY
+//
+// The key store and the cluster config are populated independently: app_id is
+// non-secret and lives in clusters.json, the key is secret and lives in the
+// per-cluster PEM store. Requiring BOTH before the hub would say anything meant
+// a cluster that named its App but whose key had never been uploaded produced
+// nil — and every downstream reconcile silently became a no-op.
+//
+// That is exactly how the placeholder-sentinel repair shipped in #2333 was
+// prevented from ever running on the hive-oke cluster: the operator added
+// "github_app_id" to clusters.json as instructed, but hive-oke has no
+// <clusterID>.pem (only vllm-d does), so appIdentityForCluster returned nil and
+// appKeyConfigForHeartbeat bailed before decideAppKeySync's sentinel branch was
+// ever consulted. The repair was unreachable in production for the one cluster
+// it was written for.
+//
+// The two facts are independently useful. Correcting a spoke's app_id needs
+// only the non-secret app_id; replacing its KEY needs the PEM. Returning the
+// identity with an empty PrivateKey/Fingerprint lets the app_id-only repair
+// proceed, while every key-pushing decision still gates on HasKey() so a hub
+// holding no key can never blank a spoke's working one.
 func (s *HubServer) appIdentityForCluster(clusterID string) *clusterAppIdentity {
 	if s == nil || s.clusters == nil {
 		return nil
@@ -202,20 +236,23 @@ func (s *HubServer) appIdentityForCluster(clusterID string) *clusterAppIdentity 
 	if c.GitHubAppID == 0 {
 		return nil
 	}
+	identity := &clusterAppIdentity{
+		AppID:   c.GitHubAppID,
+		AppSlug: c.GitHubAppSlug,
+	}
 	pem := loadClusterAppKey(clusterID)
 	if pem == "" {
-		return nil
+		// No key uploaded for this cluster. The app_id alone is still
+		// authoritative and still repairs a sentinel spoke.
+		return identity
 	}
 	fp, err := config.AppKeyFingerprint(pem)
 	if err != nil {
-		return nil
+		return identity
 	}
-	return &clusterAppIdentity{
-		AppID:       c.GitHubAppID,
-		AppSlug:     c.GitHubAppSlug,
-		PrivateKey:  pem,
-		Fingerprint: fp,
-	}
+	identity.PrivateKey = pem
+	identity.Fingerprint = fp
+	return identity
 }
 
 // fleetAppKey is one App identity the fleet knows, indexed by its own app_id.
@@ -404,8 +441,18 @@ func (s *HubServer) attachMissingAppKeys(resp *HeartbeatResponse, payload *Heart
 // against its cluster's authoritative one. Returned rather than acted on inline
 // so the decision is table-testable without a filesystem or an HTTP server.
 type appKeySyncDecision struct {
-	// Push is true when the hub should deliver the cluster key to this spoke.
+	// Push is true when the hub should send this spoke a GitHub App config at
+	// all — which may be an app_id correction, a key delivery, or both.
 	Push bool
+	// PushKey is true when that config should carry KEY MATERIAL.
+	//
+	// It is deliberately separate from Push. The placeholder-sentinel repair is
+	// an app_id correction that is valid even when the hub holds no key for the
+	// cluster, and the heartbeat contract reads an empty private_key as "leave
+	// the spoke's key alone". Collapsing the two would either block the repair
+	// on a key the hub may not have, or send an empty key that blanks a working
+	// one. Every decision that replaces a key sets both.
+	PushKey bool
 	// Reason is a short, log-safe explanation. Never contains key material.
 	Reason string
 	// FromFingerprint is what the spoke reported ("" = spoke reported none).
@@ -539,12 +586,31 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned b
 	// This is the ONLY app_id the reconcile treats as unconditionally wrong. A
 	// spoke on any other non-matching app_id is still respected as a deliberate
 	// pin (appKeyReasonDifferentApp).
+	// The sentinel repair deliberately does NOT require the hub to hold this
+	// cluster's key. Correcting app_id 999999999 to the cluster's real App is a
+	// non-secret change, and it is the whole fix for a spoke that already holds
+	// a valid per-hive key provisioned for that App. Gating the repair on key
+	// material — as the original identity lookup did — is precisely what made
+	// this branch dead code on a cluster that had configured its app_id but
+	// never uploaded a PEM. The key rides along only when the hub actually has
+	// one; otherwise this is an app_id-only push.
 	if spokeAppID == config.PlaceholderAppID {
 		return appKeySyncDecision{
 			Push:            true,
+			PushKey:         cluster.HasKey(),
 			Reason:          appKeyReasonPlaceholderAppID,
 			FromFingerprint: fp,
 			ToFingerprint:   cluster.Fingerprint,
+		}
+	}
+	// Beyond the sentinel repair every remaining decision is about REPLACING the
+	// spoke's key, which the hub cannot do without holding one. Stopping here
+	// keeps a keyless cluster from reporting a "mismatch" against an empty
+	// fingerprint and pushing a blank key over a working one.
+	if !cluster.HasKey() {
+		return appKeySyncDecision{
+			Reason:          appKeyReasonNoClusterKey,
+			FromFingerprint: fp,
 		}
 	}
 	if hasPerHiveKey {
@@ -565,6 +631,7 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned b
 		if spokeAppID != 0 && spokeAppID == cluster.AppID && fp != "" && fp != cluster.Fingerprint {
 			return appKeySyncDecision{
 				Push:            true,
+				PushKey:         true,
 				Reason:          appKeyReasonPerHiveUnusable,
 				FromFingerprint: fp,
 				ToFingerprint:   cluster.Fingerprint,
@@ -583,6 +650,7 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned b
 	if fp == "" {
 		return appKeySyncDecision{
 			Push:          true,
+			PushKey:       true,
 			Reason:        appKeyReasonSpokeHasNoKey,
 			ToFingerprint: cluster.Fingerprint,
 		}
@@ -590,6 +658,7 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned b
 	if fp != cluster.Fingerprint {
 		return appKeySyncDecision{
 			Push:            true,
+			PushKey:         true,
 			Reason:          appKeyReasonMismatch,
 			FromFingerprint: fp,
 			ToFingerprint:   cluster.Fingerprint,
@@ -614,18 +683,50 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned b
 func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFingerprint string, hasPerHiveKey, hivePublicPinned bool, spokeAppID int64, installationID int64, logger *slog.Logger) *HeartbeatGitHubAppConfig {
 	identity := s.appIdentityForCluster(clusterID)
 	decision := decideAppKeySync(spokeFingerprint, hasPerHiveKey, hivePublicPinned, spokeAppID, identity)
+	// A spoke carrying the sentinel is broken and must be legible even when the
+	// hub can do nothing about it — that silence is what made this bug cost days
+	// of debugging while the dashboard blamed the installation ID. Logged BEFORE
+	// the no-push return so the unrepairable case (cluster names no app_id at
+	// all) is exactly the case that gets said out loud.
+	if spokeAppID == config.PlaceholderAppID && logger != nil {
+		if identity == nil {
+			logger.Warn("heartbeat: spoke carries the placeholder app_id sentinel and its cluster names no github app — cannot repair",
+				"hive_id", hiveID,
+				"cluster_id", clusterID,
+				"spoke_app_id", spokeAppID,
+				"remedy", "set github_app_id on this cluster in clusters.json",
+			)
+		} else {
+			logger.Info("heartbeat: repairing placeholder app_id sentinel on spoke",
+				"hive_id", hiveID,
+				"cluster_id", clusterID,
+				"spoke_app_id", spokeAppID,
+				"to_app_id", identity.AppID,
+				"cluster_has_key", identity.HasKey(),
+			)
+		}
+	}
 	if !decision.Push || identity == nil {
 		return nil
 	}
+	// An identity with no key still repairs an app_id. Sending its empty
+	// PrivateKey is safe and intended — the spoke callback reads an empty
+	// private_key as "leave the key file alone" — but PushKey is honoured
+	// explicitly so the intent is in the code rather than in that coincidence.
+	privateKey := ""
+	if decision.PushKey {
+		privateKey = identity.PrivateKey
+	}
 	if logger != nil {
 		// Fingerprints only. The key itself is never logged, at any level.
-		logger.Info("heartbeat: pushing cluster github app key to spoke",
+		logger.Info("heartbeat: pushing cluster github app config to spoke",
 			"hive_id", hiveID,
 			"cluster_id", clusterID,
 			"app_id", identity.AppID,
 			"spoke_app_id", spokeAppID,
 			"per_hive_key", hasPerHiveKey,
 			"public_pinned", hivePublicPinned,
+			"push_key", decision.PushKey,
 			"reason", decision.Reason,
 			"from_fingerprint", decision.FromFingerprint,
 			"to_fingerprint", decision.ToFingerprint,
@@ -634,7 +735,7 @@ func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFing
 	return &HeartbeatGitHubAppConfig{
 		AppID:          identity.AppID,
 		InstallationID: installationID,
-		PrivateKey:     identity.PrivateKey,
+		PrivateKey:     privateKey,
 		AppSlug:        identity.AppSlug,
 	}
 }

--- a/v2/pkg/hub/cluster_app_key_test.go
+++ b/v2/pkg/hub/cluster_app_key_test.go
@@ -206,11 +206,14 @@ func TestDecideAppKeySync(t *testing.T) {
 			description: "the exception needs a fingerprint that provably differs, not an absent one",
 		},
 		{
-			name:        "cluster app_id unset cannot make a positive match",
-			spokeFP:     wrongFP,
-			perHive:     true,
-			spokeAppID:  5686,
-			cluster:     &clusterAppIdentity{AppID: 0, Fingerprint: clusterFP},
+			name:       "cluster app_id unset cannot make a positive match",
+			spokeFP:    wrongFP,
+			perHive:    true,
+			spokeAppID: 5686,
+			// Carries real key material (as any cluster with a stored PEM does)
+			// so the case under test is the missing app_id alone, not a
+			// keyless identity — those are now distinct states.
+			cluster:     &clusterAppIdentity{AppID: 0, PrivateKey: identity.PrivateKey, Fingerprint: clusterFP},
 			wantPush:    false,
 			wantReason:  appKeyReasonDifferentApp,
 			wantFromFP:  wrongFP,
@@ -429,11 +432,21 @@ func TestAppIdentityForCluster(t *testing.T) {
 		wantNil   bool
 		wantAppID int64
 		wantSlug  string
+		// wantNoKey asserts the identity names an App but carries NO key
+		// material, so HasKey() is false and no key-pushing decision may fire.
+		wantNoKey bool
 		reason    string
 	}{
 		{name: "app id and key present", clusterID: "vllm-d", wantAppID: 5686, wantSlug: "ibm-hive"},
 		{name: "key but no app id", clusterID: "keyonly", wantNil: true, reason: "an app_id-less cluster has no identity to enforce"},
-		{name: "app id but no key", clusterID: "hive-oke", wantNil: true, reason: "nothing to push without key material"},
+		// A configured app_id with no stored key IS an identity. Returning nil
+		// here is the bug that made #2333's sentinel repair unreachable in
+		// production: hive-oke had github_app_id set but no PEM, so every
+		// reconcile short-circuited before the repair was consulted. The app_id
+		// alone still corrects a sentinel spoke; HasKey() is what gates the
+		// separate question of whether key material may be pushed.
+		{name: "app id but no key still yields an identity", clusterID: "hive-oke", wantAppID: 12345, wantNoKey: true,
+			reason: "app_id alone is authoritative enough to repair a placeholder sentinel"},
 		{name: "unknown cluster", clusterID: "nope", wantNil: true, reason: "never invent an identity for an unknown cluster"},
 		{name: "empty cluster id", clusterID: "", wantNil: true},
 	}
@@ -452,11 +465,22 @@ func TestAppIdentityForCluster(t *testing.T) {
 			if got.AppID != tc.wantAppID {
 				t.Errorf("AppID = %d, want %d", got.AppID, tc.wantAppID)
 			}
+			if got.HasKey() == tc.wantNoKey {
+				t.Errorf("HasKey() = %v, want %v (%s)", got.HasKey(), !tc.wantNoKey, tc.reason)
+			}
 			if got.AppSlug != tc.wantSlug {
 				t.Errorf("AppSlug = %q, want %q", got.AppSlug, tc.wantSlug)
 			}
-			if got.Fingerprint == "" {
-				t.Error("identity has no fingerprint")
+			// A key-bearing identity must always carry a fingerprint — that pair is
+			// what every key-push comparison depends on. A keyless identity
+			// legitimately has neither, and asserting one there would re-impose
+			// the very "both or nothing" rule that made the sentinel repair
+			// unreachable.
+			if !tc.wantNoKey && got.Fingerprint == "" {
+				t.Error("identity has key material but no fingerprint")
+			}
+			if tc.wantNoKey && (got.Fingerprint != "" || got.PrivateKey != "") {
+				t.Errorf("keyless identity carries key material: fp=%q key_len=%d", got.Fingerprint, len(got.PrivateKey))
 			}
 		})
 	}

--- a/v2/pkg/hub/drift.go
+++ b/v2/pkg/hub/drift.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
 // Config-drift detection.
@@ -68,6 +70,13 @@ const (
 	// app-missing/app-perm-issue so operator work is never filed as an
 	// owner-facing adoption problem.
 	DriftKindAppCredsOperator = "app-creds-operator"
+	// DriftKindAppIDPlaceholder marks a hive still authenticating as the
+	// placeholder App sentinel (config.PlaceholderAppID). Distinct from
+	// app-creds-operator because the fault is the app_id itself, not the key:
+	// the App does not exist, so no key and no installation_id can ever make it
+	// work, and telling an operator to check credentials would repeat exactly
+	// the misdiagnosis this signal exists to end.
+	DriftKindAppIDPlaceholder = "app-id-placeholder"
 	DriftKindHealthDegraded   = "health-degraded"
 	DriftKindUpgradeStuck     = "upgrade-stuck"
 	DriftKindACMMUnset        = "acmm-unset"
@@ -457,6 +466,24 @@ func computeDrift(h MyHiveEntry, norm fleetNorm, latestSHAs map[string]string, n
 
 	// --- Claimed-hive-only signals ---------------------------------------
 	//
+	// Placeholder app_id sentinel. Raised for CLAIMED hives only — an unassigned
+	// slot carrying the sentinel is the pool working as designed, and flagging
+	// all of them would bury the one hive an operator must actually fix (five of
+	// the six live sentinel hives are unassigned).
+	//
+	// Deliberately NOT gated on GitHubAppRequired: that flag is the spoke's own
+	// verdict, and a spoke too old — or too wedged — to classify its failure
+	// never sets it. The app_id is a raw number the spoke reports regardless, so
+	// this fires on hub-observed fact rather than on the spoke agreeing that it
+	// is broken. That is the difference between the fault being visible and the
+	// weeks of silence that made this bug expensive.
+	if !placeholder && h.GitHubAppID == config.PlaceholderAppID {
+		add(DriftKindAppIDPlaceholder, DriftCritical,
+			"This hive is authenticating as the placeholder App ID, which is not a real GitHub App — "+
+				"no installation ID or private key can make it work. The hub must assign the cluster's real "+
+				"github_app_id; the hive owner cannot fix this and should not be asked to")
+	}
+
 	// A placeholder legitimately has no App, no agents and ACMM 0. Flagging it
 	// for those would make the pool dominate the exceptions summary and hide
 	// the hives a human can actually fix.
@@ -479,10 +506,14 @@ func computeDrift(h MyHiveEntry, norm fleetNorm, latestSHAs map[string]string, n
 			} else if h.GitHubAppPermIssue != "" {
 				add(DriftKindAppPermIssue, DriftCritical,
 					fmt.Sprintf("GitHub App is installed but its permissions are insufficient: %s", h.GitHubAppPermIssue))
-			} else {
+			} else if h.GitHubAppID != config.PlaceholderAppID {
 				add(DriftKindAppMissing, DriftCritical,
 					"GitHub App is required by this hive but is not installed — agents cannot act on the repo")
 			}
+			// When the app_id IS the sentinel, "App not installed" is the exact
+			// misdiagnosis that sent the owner to correct an installation ID that
+			// was already right. app-id-placeholder above already says the true
+			// cause, so this row is suppressed rather than duplicated.
 		}
 		if h.ACMMLevel <= driftACMMUnsetLevel {
 			add(DriftKindACMMUnset, DriftWarn,

--- a/v2/pkg/hub/misc_coverage_test.go
+++ b/v2/pkg/hub/misc_coverage_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
 // ============================================================
@@ -246,7 +248,7 @@ func TestAdoptSpokeProjectConfig(t *testing.T) {
 	// Freshly-claimed hive (ClaimDelivered=false), assigned L3. Nothing reported
 	// before delivery is adopted — including the level. A report that matches the
 	// claim IN FULL (org/repos AND level) flips ClaimDelivered.
-	saveSaaSHive(&SaaSHive{ID: "claimed", Status: "running", Org: "o", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 3})
+	saveSaaSHive(&SaaSHive{ID: "claimed", Status: "running", Org: "o", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 3, RequestedACMMLevel: 3})
 
 	// Pre-delivery: the spoke is still running its placeholder project at the
 	// level it was MINTED at (2), not the assigned 3. This is the production
@@ -258,18 +260,23 @@ func TestAdoptSpokeProjectConfig(t *testing.T) {
 		t.Errorf("pre-delivery stale report: meta = %+v, want acmm=3 (assigned level held) org=o repos=[r] ClaimDelivered=false", h)
 	}
 
-	// A report matching org/repos but still carrying the OLD level is not a
-	// complete delivery: the claim includes the level, so the flag must stay
-	// down and the hub must keep pushing until the level lands too.
+	// A report matching org/repos but still carrying the OLD level delivers the
+	// PROJECT claim (ClaimDelivered flips) while the LEVEL is still outstanding
+	// (ACMMDelivered stays down and the assigned level is held).
+	//
+	// #2333 coupled these, blocking ClaimDelivered until the level landed. That
+	// coupling is what left no way to re-arm the level on a hive whose
+	// ClaimDelivered was already true — the live oke-11 case — so the two
+	// deliveries are now tracked independently.
 	s.adoptSpokeProjectConfig("claimed", "o", []string{"r"}, "r", 2)
-	if h := loadSaaSHive("claimed"); h == nil || h.ClaimDelivered || h.ACMMLevel != 3 {
-		t.Errorf("partial delivery (level not yet applied) must not flip ClaimDelivered: %+v", h)
+	if h := loadSaaSHive("claimed"); h == nil || !h.ClaimDelivered || h.ACMMDelivered || h.ACMMLevel != 3 {
+		t.Errorf("project delivered but level outstanding: %+v, want ClaimDelivered=true ACMMDelivered=false acmm=3", h)
 	}
 
 	// Spoke now reports the claim IN FULL, level included -> flips ClaimDelivered.
 	s.adoptSpokeProjectConfig("claimed", "o", []string{"r"}, "r", 3)
-	if h := loadSaaSHive("claimed"); h == nil || !h.ClaimDelivered {
-		t.Errorf("matching report should mark ClaimDelivered: %+v", h)
+	if h := loadSaaSHive("claimed"); h == nil || !h.ClaimDelivered || !h.ACMMDelivered {
+		t.Errorf("matching report should mark BOTH deliveries done: %+v", h)
 	}
 
 	// Post-delivery: operator changes repos on the dashboard -> adopted.
@@ -312,7 +319,7 @@ func TestProjectConfigForHiveID_PushesAssignedACMMUntilDelivered(t *testing.T) {
 	// returned "nothing left to push" and the level never travelled.
 	saveSaaSHive(&SaaSHive{
 		ID: "h", Status: "running", Org: "o", Repos: []string{"r"},
-		PrimaryRepo: "r", ACMMLevel: 3, ClaimDelivered: false,
+		PrimaryRepo: "r", ACMMLevel: 3, RequestedACMMLevel: 3, ClaimDelivered: false,
 	})
 	got := projectConfigForHiveID("h", "o", []string{"r"}, "r", 2, "", "")
 	if got == nil {
@@ -326,9 +333,162 @@ func TestProjectConfigForHiveID_PushesAssignedACMMUntilDelivered(t *testing.T) {
 	// NOT be pushed back down (the spyre revert #2061 fixed).
 	saveSaaSHive(&SaaSHive{
 		ID: "d", Status: "running", Org: "o", Repos: []string{"r"},
-		PrimaryRepo: "r", ACMMLevel: 3, ClaimDelivered: true,
+		PrimaryRepo: "r", ACMMLevel: 3, RequestedACMMLevel: 3, ClaimDelivered: true, ACMMDelivered: true,
 	})
 	if got := projectConfigForHiveID("d", "o", []string{"r"}, "r", 5, "", ""); got != nil {
 		t.Errorf("delivered claim must never push ACMM back to the spoke, got %+v", got)
+	}
+}
+
+// TestACMMRedeliversOnPreDeliveredClaim is the live hosted-available-oke-11
+// regression, and the reason #2333 changed nothing in production.
+//
+// That hive was claimed BEFORE #2333 shipped, so ClaimDelivered was already
+// true under the old org/repos-only rule. #2333 gated the ACMM push on
+// !ClaimDelivered and the ACMM adopt on ClaimDelivered, which for this hive
+// means: never push, always adopt. The spoke's stale L2 was adopted on the
+// first beat after the upgrade, meta and spoke agreed on the wrong number, and
+// no amount of restarting could move it. The approved request said L3.
+//
+// The level's own flag defaults to false on such a hive, which is what re-arms
+// delivery exactly once.
+func TestACMMRedeliversOnPreDeliveredClaim(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := &HubServer{logger: slog.Default()}
+
+	// The production state: claim long since delivered, requested L3 recorded,
+	// meta already beaten down to the spoke's L2 by the old adopt loop.
+	saveSaaSHive(&SaaSHive{
+		ID: "oke11", Status: "running", Org: "kubestellar", Repos: []string{"hive"},
+		PrimaryRepo: "hive", ACMMLevel: 2, RequestedACMMLevel: 3,
+		ClaimDelivered: true, ACMMDelivered: false,
+	})
+
+	// Beat 1: the spoke still reports L2. The requested level must be restored
+	// in meta rather than the stale report adopted.
+	s.adoptSpokeProjectConfig("oke11", "kubestellar", []string{"hive"}, "hive", 2)
+	h := loadSaaSHive("oke11")
+	if h == nil || h.ACMMLevel != 3 || h.ACMMDelivered {
+		t.Fatalf("beat 1: meta = %+v, want acmm=3 restored and ACMMDelivered=false", h)
+	}
+
+	// ...and the push must actually fire, despite ClaimDelivered being true.
+	got := projectConfigForHiveID("oke11", "kubestellar", []string{"hive"}, "hive", 2, "", "")
+	if got == nil {
+		t.Fatal("no push for a pre-delivered claim whose level never landed — this is the exact production silence")
+	}
+	if got.ACMMLevel != 3 {
+		t.Errorf("pushed ACMMLevel = %d, want the requested 3", got.ACMMLevel)
+	}
+
+	// Beat 2: the spoke has applied L3 and reports it. Delivery completes.
+	s.adoptSpokeProjectConfig("oke11", "kubestellar", []string{"hive"}, "hive", 3)
+	h = loadSaaSHive("oke11")
+	if h == nil || !h.ACMMDelivered || h.ACMMLevel != 3 {
+		t.Fatalf("beat 2: meta = %+v, want ACMMDelivered=true acmm=3", h)
+	}
+
+	// IDEMPOTENCE: with the level delivered the push stops for good.
+	if got := projectConfigForHiveID("oke11", "kubestellar", []string{"hive"}, "hive", 3, "", ""); got != nil {
+		t.Errorf("delivered level must never push again, got %+v", got)
+	}
+
+	// ...and the spoke now owns the level: an operator raising it to L5 on the
+	// dashboard is adopted, not reverted (the #2061 spyre behaviour).
+	s.adoptSpokeProjectConfig("oke11", "kubestellar", []string{"hive"}, "hive", 5)
+	h = loadSaaSHive("oke11")
+	if h == nil || h.ACMMLevel != 5 || h.RequestedACMMLevel != 5 {
+		t.Fatalf("post-delivery operator edit: meta = %+v, want acmm=5 adopted and requested kept in step", h)
+	}
+	if got := projectConfigForHiveID("oke11", "kubestellar", []string{"hive"}, "hive", 5, "", ""); got != nil {
+		t.Errorf("operator edit must not be reverted on the next beat, got %+v", got)
+	}
+}
+
+// TestSentinelRepairReachableWithoutClusterKey is the app_id half of the same
+// production silence.
+//
+// hive-oke had github_app_id configured but NO stored PEM. appIdentityForCluster
+// required both, returned nil, and appKeyConfigForHeartbeat bailed before
+// #2333's sentinel branch could run — so the repair was dead code on the one
+// cluster it was written for. The app_id correction must not depend on key
+// material the hub may never have been given.
+func TestSentinelRepairReachableWithoutClusterKey(t *testing.T) {
+	withTempAppKeyDir(t) // deliberately EMPTY: no PEM for this cluster
+
+	const clusterAppID = 3568013 // hive-oke's real App, from cluster config only
+	s := &HubServer{
+		clusters: map[string]ClusterConfig{
+			"hive-oke": {ID: "hive-oke", GitHubAppID: clusterAppID, GitHubAppSlug: "kubestellar-hive"},
+		},
+		logger: appKeyTestLogger(),
+	}
+
+	// A sentinel spoke holding a provisioned per-hive key — the live shape.
+	got := s.appKeyConfigForHeartbeat("oke11", "hive-oke",
+		"sha256:whatever", true, false, config.PlaceholderAppID, 0, s.logger)
+	if got == nil {
+		t.Fatal("no config pushed to a sentinel spoke on a keyless cluster — the repair is unreachable, which is the production bug")
+	}
+	if got.AppID != clusterAppID {
+		t.Errorf("AppID = %d, want the cluster's configured %d", got.AppID, clusterAppID)
+	}
+	// The hub holds no key, so it must not pretend to: an empty private_key is
+	// the contract for "leave the spoke's key alone", and sending anything else
+	// would blank a working key.
+	if got.PrivateKey != "" {
+		t.Error("pushed key material the hub does not have")
+	}
+	// installation_id is untouched — it was already correct on the live hive,
+	// and disturbing it is what the misleading banner told the owner to do.
+	if got.InstallationID != 0 {
+		t.Errorf("InstallationID = %d, want 0 (unchanged)", got.InstallationID)
+	}
+
+	// IDEMPOTENCE: once the spoke reports the real app_id there is nothing left
+	// to repair, and a keyless cluster must go quiet rather than churn.
+	if got := s.appKeyConfigForHeartbeat("oke11", "hive-oke",
+		"sha256:whatever", true, false, clusterAppID, 0, s.logger); got != nil {
+		t.Errorf("repaired spoke must stop receiving pushes, got %+v", got)
+	}
+}
+
+// TestSentinelSurfacesAsOperatorDrift locks the observability half: a claimed
+// hive on the sentinel must be VISIBLE as a fault, and must NOT be described as
+// "App not installed" — the misdiagnosis that sent the owner to correct an
+// installation ID that was already right.
+func TestSentinelSurfacesAsOperatorDrift(t *testing.T) {
+	now := time.Now()
+	entry := MyHiveEntry{RegistryEntry: RegistryEntry{
+		ID: "oke11", Org: "kubestellar", ACMMLevel: 3, AgentCount: 1,
+		GitHubAppID: config.PlaceholderAppID, GitHubAppRequired: true,
+		LastHeartbeat: now.Format(time.RFC3339),
+	}}
+	rep := computeDrift(entry, fleetNorm{}, nil, now)
+
+	kinds := map[string]bool{}
+	for _, sig := range rep.Signals {
+		kinds[sig.Kind] = true
+	}
+	if !kinds[DriftKindAppIDPlaceholder] {
+		t.Errorf("sentinel hive raised no app-id-placeholder signal: %+v", rep.Signals)
+	}
+	if kinds[DriftKindAppMissing] {
+		t.Error("sentinel hive reported as 'App not installed' — the exact misdiagnosis this fix removes")
+	}
+
+	// An UNASSIGNED placeholder on the sentinel is the pool working as designed
+	// and must stay silent, or the six live sentinel slots bury the one hive an
+	// operator must actually fix.
+	ph := MyHiveEntry{RegistryEntry: RegistryEntry{
+		ID: "slot", Org: placeholderOrgPrefix + "x",
+		GitHubAppID: config.PlaceholderAppID, LastHeartbeat: now.Format(time.RFC3339),
+	}}
+	for _, sig := range computeDrift(ph, fleetNorm{}, nil, now).Signals {
+		if sig.Kind == DriftKindAppIDPlaceholder {
+			t.Error("unassigned placeholder flagged for carrying the sentinel it is supposed to carry")
+		}
 	}
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -5164,6 +5164,16 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 	h.Repos = repos
 	h.PrimaryRepo = primaryRepo
 	h.ACMMLevel = acmm
+	// Record the level as REQUESTED, not merely as current. ACMMLevel is
+	// overwritten the moment the spoke reports the level it was minted at, so it
+	// cannot be the source of truth for "what did the owner ask for". Keeping the
+	// requested value in its own field is what lets the delivery reconcile below
+	// remain correct — and idempotent — across any number of heartbeats.
+	h.RequestedACMMLevel = acmm
+	// Re-arm the level handshake for this claim. A placeholder is reused across
+	// assignments, so a flag left true by a previous tenancy would suppress
+	// delivery for the new owner.
+	h.ACMMDelivered = false
 	h.Status = ""
 	h.Error = ""
 	// Preserve the placeholder's real cluster before ANY cluster-derived
@@ -5411,23 +5421,66 @@ func (s *HubServer) adoptSpokeProjectConfig(hiveID, org string, repos []string, 
 	changed := false
 	prevLevel := h.ACMMLevel
 
-	// ACMM follows the SAME ClaimDelivered handshake as org/repos below.
+	// ACMM runs its OWN delivery handshake (ACMMDelivered), not the org/repos
+	// one (ClaimDelivered).
 	//
-	// #2061 made ACMM "operator-owned from the start — always adopt", which
-	// fixed the spyre revert (a dashboard level change bouncing back every
-	// beat) but left a gap on the ASSIGN path: a freshly-claimed placeholder
-	// has not yet been told its level, so it keeps reporting the level it was
-	// MINTED at (defaultAssignACMMLevel). Adopting that pre-delivery report
-	// overwrote the level the requester actually asked for — an approved L3
-	// request silently became L2 in meta.json, and the spoke stayed L2 forever
-	// because the hub then had no higher level left to push.
+	// #2061 made ACMM "operator-owned from the start — always adopt", which fixed
+	// the spyre revert but left a gap on the ASSIGN path: a freshly-claimed
+	// placeholder keeps reporting the level it was MINTED at, and adopting that
+	// pre-delivery report overwrote the level the requester asked for. #2333
+	// closed that by gating on ClaimDelivered — correct for hives claimed after
+	// it shipped, but a no-op for every hive claimed BEFORE, whose
+	// ClaimDelivered was already true from the old org/repos-only rule. Those
+	// hives adopt the stale report on the very first beat after upgrade and the
+	// push stays disabled, which is why the live oke-11 hive is still L2 against
+	// an approved L3 request.
 	//
-	// Gating on ClaimDelivered keeps BOTH behaviours: before delivery the claim
-	// (including its level) is authoritative and a stale spoke report is
-	// ignored; after delivery the spoke's dashboard owns the level and operator
-	// edits are adopted exactly as #2061 intended.
-	if level > 0 && level != h.ACMMLevel && h.ClaimDelivered {
+	// The dedicated flag defaults to false on those hives, so the level is
+	// delivered exactly once, then ownership passes to the spoke as #2061
+	// intended.
+
+	// Backfill the requested level for hives assigned before the field existed.
+	// Without this the reconcile has no target on exactly the hives that need
+	// it. ACMMLevel is the best available record of the assignment at this
+	// point, and using it is safe: if the spoke already agrees, the delivery is
+	// a no-op that simply marks itself done.
+	if h.RequestedACMMLevel == 0 && h.ACMMLevel > 0 {
+		h.RequestedACMMLevel = h.ACMMLevel
+		changed = true
+	}
+
+	// Delivery is complete once the spoke reports the level the hub asked for.
+	// A level-0 report means "too old / mid-boot to say", never a mismatch.
+	if !h.ACMMDelivered && h.RequestedACMMLevel > 0 && level == h.RequestedACMMLevel {
+		h.ACMMDelivered = true
+		changed = true
+		s.logger.Info("acmm level delivered to spoke",
+			"hive_id", hiveID, "acmm_level", level)
+	}
+
+	switch {
+	case level <= 0:
+		// Nothing reported — say nothing, change nothing.
+	case !h.ACMMDelivered && h.RequestedACMMLevel > 0:
+		// Pre-delivery the REQUESTED level is authoritative. Hold meta at it so
+		// the stale spoke report cannot overwrite the target the push below is
+		// still working toward — the exact loop that lost the L3.
+		if h.ACMMLevel != h.RequestedACMMLevel {
+			h.ACMMLevel = h.RequestedACMMLevel
+			changed = true
+		}
+		if level != h.RequestedACMMLevel {
+			s.logger.Info("acmm level not yet applied on spoke; holding requested level",
+				"hive_id", hiveID,
+				"spoke_reports", level,
+				"requested", h.RequestedACMMLevel)
+		}
+	case level != h.ACMMLevel:
+		// Post-delivery the spoke's dashboard owns the level: adopt operator
+		// edits, and keep the requested level in step so a later re-delivery
+		// never reverts the operator's choice.
 		h.ACMMLevel = level
+		h.RequestedACMMLevel = level
 		changed = true
 	}
 
@@ -5439,15 +5492,15 @@ func (s *HubServer) adoptSpokeProjectConfig(hiveID, org string, repos []string, 
 	orgMatches := org != "" && strings.EqualFold(org, h.Org)
 	reposMatch := len(repos) > 0 && sameStringSliceFold(repos, h.Repos)
 	primaryMatches := primary == "" || strings.EqualFold(primary, h.PrimaryRepo)
-	// The ACMM level is part of the claim payload, so delivery is not complete
-	// until the spoke reports THAT back too. Flipping the flag on org/repos
-	// alone declared the claim delivered while the spoke was still running the
-	// level it was minted at — which both stopped the push and handed level
-	// ownership to the spoke, permanently pinning the hive to the wrong level.
-	// A level-0 report means "too old / mid-boot to say", not a mismatch.
-	acmmMatches := level == 0 || level == h.ACMMLevel
+	// ACMM is NO LONGER part of this condition. #2333 added it here so the claim
+	// could not be declared delivered while the level was outstanding, but that
+	// coupled two independent deliveries: a hive whose level lagged would also
+	// have its org/repos pushed forever, and — worse — the level had no way to
+	// re-arm on a hive whose ClaimDelivered was already true. ACMMDelivered
+	// above now tracks the level on its own, so this returns to being purely
+	// about the project payload.
 	if !h.ClaimDelivered {
-		if orgMatches && reposMatch && primaryMatches && acmmMatches {
+		if orgMatches && reposMatch && primaryMatches {
 			h.ClaimDelivered = true
 			changed = true
 		}
@@ -5564,23 +5617,28 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 	//     spoke first reports the assigned project). After delivery the spoke's
 	//     dashboard owns them and the caller adopts operator edits instead.
 	//   - vanity URL: pushed until the spoke first reports it back.
-	//   - ACMM level: pushed ONLY until the claim is delivered, on exactly the
-	//     same handshake as org/repos. After delivery it is never pushed again —
-	//     the spoke's dashboard owns it and the caller adopts operator edits.
+	//   - ACMM level: pushed on its OWN handshake (ACMMDelivered), until the
+	//     spoke reports the requested level back. After that it is never pushed
+	//     again — the spoke's dashboard owns it and the caller adopts operator
+	//     edits, exactly as #2061 intended.
 	//
 	//     #2061 removed the ACMM push entirely because pushing it FOREVER
-	//     reverted every dashboard level change (the spyre bug). But dropping it
+	//     reverted every dashboard level change (the spyre bug). Dropping it
 	//     altogether meant a freshly-assigned placeholder was never told the
-	//     level its owner requested: it kept running the level it was minted at
-	//     (defaultAssignACMMLevel), reported that back, and the hub adopted the
-	//     stale report — so an approved L3 request ran, and displayed, as L2.
-	//     Bounding the push by ClaimDelivered delivers the requested level once
-	//     without ever reverting a later operator edit.
+	//     level its owner requested. #2333 bounded the push by ClaimDelivered,
+	//     which is right in principle but dead in practice for every hive
+	//     claimed before it shipped: their ClaimDelivered was already true, so
+	//     the push never fires. Bounding by the level's own flag is what makes
+	//     the delivery reachable for those hives — and it is self-limiting, so
+	//     re-running it is harmless.
 	needClaimPush := !h.ClaimDelivered &&
 		!(strings.EqualFold(curOrg, h.Org) &&
 			sameStringSliceFold(curRepos, h.Repos) &&
-			strings.EqualFold(curPrimary, primary) &&
-			curACMM == h.ACMMLevel)
+			strings.EqualFold(curPrimary, primary))
+	// Independent of the project claim: deliver the requested level until the
+	// spoke confirms it. curACMM == 0 means the spoke did not report a level, so
+	// there is nothing to correct yet.
+	needACMMPush := !h.ACMMDelivered && h.RequestedACMMLevel > 0 && curACMM != h.RequestedACMMLevel
 	needURLPush := h.VanityURL != "" && curURL != h.VanityURL
 	// A spoke reporting a repo that fails isValidRepoRef is wedged: the hub 400s
 	// its every heartbeat ("invalid repo name"), /api/livez then fails on the
@@ -5608,7 +5666,7 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 	// would re-send on every beat with no read-back to ever stop it.
 	wantAPIURL := gheAPIURLForHost(h.GitHubHost)
 	needGHEAPIPush := wantAPIURL != "" && curAPIURL != "" && curAPIURL != wantAPIURL
-	if !needClaimPush && !needURLPush && !needRepoRepair && !needGHEAPIPush {
+	if !needClaimPush && !needURLPush && !needRepoRepair && !needGHEAPIPush && !needACMMPush {
 		return nil // nothing left to push
 	}
 	// Sanitize before pushing. A repo pasted as a URL
@@ -5632,11 +5690,20 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 		pushPrimary = primary
 	}
 
+	// Pre-delivery the REQUESTED level is what goes down the wire. The adopt path
+	// also holds h.ACMMLevel at that value, so the two normally agree — but
+	// stating it here means a push cannot deliver a stale level if this function
+	// ever runs against a record the adopt path has not touched yet.
+	pushACMM := h.ACMMLevel
+	if !h.ACMMDelivered && h.RequestedACMMLevel > 0 {
+		pushACMM = h.RequestedACMMLevel
+	}
+
 	return &HeartbeatProjectConfig{
 		Org:          h.Org,
 		Repos:        pushRepos,
 		PrimaryRepo:  pushPrimary,
-		ACMMLevel:    h.ACMMLevel,
+		ACMMLevel:    pushACMM,
 		DashboardURL: h.VanityURL,
 		// Point a GHE hive at its enterprise API. jjs-world
 		// (hosted-open-source-osscar) is the working reference: a bare
@@ -5850,6 +5917,11 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 		h.ProjectName = body.ProjectName
 	}
 	h.ACMMLevel = acmm
+	// Same as the approve-provision path: the admin-assigned level is what the
+	// hub must deliver, and it needs its own field because the spoke will
+	// overwrite ACMMLevel with whatever it is currently running.
+	h.RequestedACMMLevel = acmm
+	h.ACMMDelivered = false
 	h.IsPublic = body.IsPublic
 	h.Status = ""
 	h.Error = ""
@@ -7624,6 +7696,7 @@ const dashboardHTML = `<!DOCTYPE html>
       'app-missing':     'GitHub App not installed',
       'app-perm-issue':  'GitHub App permissions',
       'app-creds-operator': 'GitHub App key (operator)',
+      'app-id-placeholder': 'Placeholder App ID (operator)',
       'health-degraded': 'Health degraded',
       'upgrade-stuck':   'Upgrade stuck',
       'acmm-unset':      'ACMM level unset',

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -311,14 +311,42 @@ type SaaSHive struct {
 	// project); after that the spoke's dashboard becomes the source of truth and
 	// the hub ADOPTS operator edits instead of pushing. (ACMM is operator-owned
 	// from the start and always adopted, independent of this flag.)
-	ClaimDelivered  bool                   `json:"claim_delivered,omitempty"`
-	Error           string                 `json:"error,omitempty"`
-	AutoUpgrade     bool                   `json:"auto_upgrade"`
-	IsPublic        bool                   `json:"is_public"`
-	PendingRequests []PendingAccessRequest `json:"pending_requests,omitempty"`
-	OCIFileSystemID string                 `json:"oci_file_system_id,omitempty"`
-	OCIExportID     string                 `json:"oci_export_id,omitempty"`
-	ClusterID       string                 `json:"cluster_id,omitempty"`
+	ClaimDelivered bool `json:"claim_delivered,omitempty"`
+	// ACMMDelivered flips true once the spoke has reported back the ACMM level
+	// the hub assigned it. It is the level's OWN half of the claim handshake,
+	// deliberately separate from ClaimDelivered.
+	//
+	// WHY IT CANNOT REUSE ClaimDelivered
+	//
+	// #2333 put ACMM on the ClaimDelivered handshake, which is right for hives
+	// claimed from then on. But ClaimDelivered is PERSISTED STATE, and every
+	// hive claimed before that change already had it set to true under the old
+	// rule, which required only org/repos to match. For those hives both halves
+	// of the fix are permanently disabled on the first beat after upgrade: the
+	// push is gated on !ClaimDelivered (already false, so never pushes) and the
+	// adopt is gated on ClaimDelivered (already true, so the stale spoke report
+	// is adopted). The requested level was overwritten in meta long ago, so hub
+	// and spoke now agree on the wrong number and no drift is even detectable.
+	// That is exactly the live hosted-available-oke-11-placeholder-r05x state:
+	// an approved acmm_level 3 request running, and displaying, as L2.
+	//
+	// A separate flag defaults to false on every existing hive, so the level
+	// delivery re-arms once for hives that never got it — without re-opening the
+	// org/repos claim, and without a migration.
+	ACMMDelivered bool `json:"acmm_delivered,omitempty"`
+	// RequestedACMMLevel is the level the approved provision request asked for,
+	// recorded at assign time so it survives the spoke overwriting ACMMLevel in
+	// meta. It is the level the hub delivers; ACMMLevel is the level currently
+	// in effect. Zero means "nothing was explicitly requested" — the ordinary
+	// case for admin-created and pre-existing hives — and delivers nothing.
+	RequestedACMMLevel int                    `json:"requested_acmm_level,omitempty"`
+	Error              string                 `json:"error,omitempty"`
+	AutoUpgrade        bool                   `json:"auto_upgrade"`
+	IsPublic           bool                   `json:"is_public"`
+	PendingRequests    []PendingAccessRequest `json:"pending_requests,omitempty"`
+	OCIFileSystemID    string                 `json:"oci_file_system_id,omitempty"`
+	OCIExportID        string                 `json:"oci_export_id,omitempty"`
+	ClusterID          string                 `json:"cluster_id,omitempty"`
 
 	// AutoUpgradeMode gates WHEN an enabled auto-upgrade may fire:
 	// AutoUpgradeModeInstant (or empty) upgrades as soon as the hive is seen

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -146,14 +146,26 @@ type RegistryEntry struct {
 	// re-armed forever, which looks like progress but never is. Past
 	// maxOrphanedUpgradeSweeps the hub stops retrying and records a failure a
 	// human can see. Reset whenever the hive reaches a target.
-	OrphanedUpgradeSweeps     int          `json:"orphanedUpgradeSweeps,omitempty"`
-	IssueHistory              []SparkPoint `json:"issueHistory,omitempty"`
-	PRHistory                 []SparkPoint `json:"prHistory,omitempty"`
-	GitHubAppRequired         bool         `json:"githubAppRequired,omitempty"`
-	GitHubAppPermIssue        string       `json:"githubAppPermIssue,omitempty"`
-	GitHubAppState            string       `json:"githubAppState,omitempty"`
-	PendingGitHubAppInstall   bool         `json:"pendingGitHubAppInstall,omitempty"`
-	PendingGitHubAppInstallAt time.Time    `json:"pendingGitHubAppInstallAt,omitempty"`
+	OrphanedUpgradeSweeps int          `json:"orphanedUpgradeSweeps,omitempty"`
+	IssueHistory          []SparkPoint `json:"issueHistory,omitempty"`
+	PRHistory             []SparkPoint `json:"prHistory,omitempty"`
+	GitHubAppRequired     bool         `json:"githubAppRequired,omitempty"`
+	GitHubAppPermIssue    string       `json:"githubAppPermIssue,omitempty"`
+	GitHubAppState        string       `json:"githubAppState,omitempty"`
+	// GitHubAppID is the App ID the spoke reports it is authenticating AS.
+	//
+	// Carried into the registry so the hub can SEE a spoke running the
+	// placeholder sentinel (config.PlaceholderAppID) without waiting for that
+	// spoke to classify and report the fault itself. The spoke's own
+	// classification is the better signal when it arrives, but it depends on the
+	// spoke being new enough to produce it — and the sentinel's whole failure
+	// mode is that nothing said anything for weeks. A raw, hub-observed number
+	// cannot be silenced by a stale spoke.
+	//
+	// Zero means "not reported", never "no App".
+	GitHubAppID               int64     `json:"githubAppId,omitempty"`
+	PendingGitHubAppInstall   bool      `json:"pendingGitHubAppInstall,omitempty"`
+	PendingGitHubAppInstallAt time.Time `json:"pendingGitHubAppInstallAt,omitempty"`
 	// Fleet contribution counts reported by the spoke (nil = not reported /
 	// not yet computed). Aggregated across public, non-stale hives into the
 	// /api/fleet-stats total. Pointers preserve the nil-vs-zero distinction so
@@ -974,6 +986,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		GitHubAppRequired:       payload.GitHubAppRequired,
 		GitHubAppPermIssue:      sanitizeHeartbeatField(payload.GitHubAppPermIssue),
 		GitHubAppState:          sanitizeHeartbeatField(payload.GitHubAppState),
+		GitHubAppID:             payload.GitHubAppID,
 		PendingGitHubAppInstall: payload.PendingGitHubAppInstall,
 		PendingGitHubAppInstallAt: func() time.Time {
 			if payload.PendingGitHubAppInstall {


### PR DESCRIPTION
#2333 shipped both fixes correctly. **Neither can fire on the live fleet.** Two independent gates — one per fix — make them unreachable, which is why 20+ minutes and several heartbeats produced nothing.

## BUG 1 — the sentinel repair is dead code on the only cluster that needs it

`appIdentityForCluster` returned nil unless the cluster had **both** a configured `github_app_id` **and** a stored PEM (`v2/pkg/hub/cluster_app_key.go:202-208`). `hive-oke` has the app_id — the operator added it exactly as #2333 instructed — but the key store holds only `vllm-d.pem`:

```
/data/saas/app-keys/vllm-d.pem      <- present
                    hive-oke.pem    <- ABSENT
```

So `appKeyConfigForHeartbeat` bailed on `identity == nil` **before `decideAppKeySync` was ever called**, and #2333's sentinel branch never ran. The repair was unreachable on the one cluster it was written for.

**This also refutes the `spoke_app_id=0` hypothesis.** vllm-d spokes are pushed because vllm-d *has a PEM*, not because of anything about `spoke_app_id`. The `reason="spoke reports no app key"` in those log lines is simply the branch vllm-d's spokes happen to land on once the identity resolves. A sentinel spoke would have been repaired fine — it just never got that far.

The two facts are independently useful: correcting an app_id needs only the non-secret app_id; replacing a **key** needs the PEM. `appIdentityForCluster` now returns an identity for a configured app_id with no key, and the decision carries a separate `PushKey` so every key-replacing branch still gates on `HasKey()`. A hub holding no key can correct an app_id but can **never** blank a spoke's working key — an empty `private_key` already means "leave the key alone" on the spoke side.

No App ID is hardcoded; it comes from cluster config as before.

## BUG 2 — ACMM delivery is permanently disabled on every pre-#2333 hive

#2333 put ACMM on the `ClaimDelivered` handshake: push while `!ClaimDelivered`, adopt once `ClaimDelivered`. Correct for hives claimed afterwards — but **`ClaimDelivered` is persisted state**, and every hive claimed before already had it `true` under the old org/repos-only rule.

For those hives both halves invert: the push never fires, and the stale spoke report is always adopted. The requested level was overwritten in meta long ago, so hub and spoke now agree on the wrong number and **no drift is even detectable**.

That is the live `hosted-available-oke-11-placeholder-r05x` state. The approved request is still on disk and still says L3:

```
/data/saas/provision-requests/clubanderson.json  ->  status: approved, acmm_level: 3
/data/saas/hives/...-oke-11-.../meta.json        ->  acmm_level: 2, claim_delivered: true
```

**So yes — `claim_delivered: true` is exactly what suppresses redelivery**, and it does so in both directions at once.

ACMM now runs its own handshake:
- `RequestedACMMLevel` records what was asked for, so it survives the spoke overwriting `ACMMLevel`. Backfilled from `ACMMLevel` for existing hives.
- `ACMMDelivered` defaults to false on every existing hive, re-arming delivery **exactly once** — no migration, and without re-opening the org/repos claim.
- Pre-delivery the requested level is authoritative and is pushed; once the spoke reports it back the push stops for good and the spoke owns the level, exactly as #2061 intended. Operator edits are adopted and never reverted.

ACMM is also removed from the `ClaimDelivered` condition: coupling the two meant a lagging level kept org/repos pushing forever, and left the level with no way to re-arm.

## Observability — the sentinel must not fail silently

The only symptom was a "GitHub App Not Installed" banner sending the owner to fix an installation ID that was **already correct**.

- New drift signal `app-id-placeholder` (critical, operator-side), raised on **hub-observed fact**: the spoke's reported `app_id`, now carried into the registry — rather than the spoke's own verdict. A spoke too old or too wedged to classify its failure never sets `GitHubAppRequired`, which is precisely how this stayed invisible for weeks.
- The misleading `app-missing` row is **suppressed** when the sentinel is the real cause, so the owner is no longer misdirected to the installation-ID box.
- Unassigned placeholders are exempt: five of the six live sentinel hives are pool slots working as designed, and flagging them would bury the one hive an operator must actually fix.
- A sentinel spoke on a cluster naming no app_id logs a WARN naming the remedy, so the unrepairable case is the loud one.

## Tests

Both regressions **verified failing against the old gates**, reproducing the production symptoms exactly:

```
ACMMLevel:2 ... RequestedACMMLevel:3      <- the L3 that never landed
no config pushed to a sentinel spoke on a keyless cluster
```

Both fixes asserted **idempotent**: the push stops once the spoke confirms, and re-running changes nothing. Post-delivery operator edits are asserted non-revertible.

Updated four tests that encoded the contracts this change deliberately reverses.

`go build ./...` and `pkg/hub`, `pkg/github`, `pkg/config`, `cmd/hive` all pass. Embedded dashboard JS verified by extraction: brace/paren/bracket deltas identical to base, `node --check` clean, `<body>` count unchanged.

## Live systems

Strictly read-only — hub and spoke config was read, nothing was written. No `hive.yaml.bak`, `meta.json` or `clusters.json` was touched, and no experiment was run against any placeholder. The point is that the code path must work on its own.