### PR TITLE
✅ test: fix the coverage gate's blocker and raise backup/DR coverage to the 90% floor

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1251,6 +1251,13 @@ type GitHubConfig struct {
 	// injected solely for agents whose tier CanPush() and only when a real App is
 	// installed (m.appAuth != nil), so an App-less or advisory hive is unaffected.
 	AppAuthoredPRs *bool `yaml:"app_authored_prs,omitempty"`
+	// OAuthBaseURLOverride and OAuthAPIURLOverride redirect the DEVICE-FLOW LOGIN
+	// endpoints away from public github.com. They are a TEST SEAM ONLY — see the
+	// comment on OAuthBaseURL(). They carry the `-` yaml tag so they can never be
+	// set from a hive.yaml, on the hub, or over the config API: only Go code in a
+	// test can assign them.
+	OAuthBaseURLOverride string `yaml:"-"`
+	OAuthAPIURLOverride  string `yaml:"-"`
 }
 
 // PlaceholderAppID is the sentinel `github.app_id` written into a hive's config
@@ -1381,8 +1388,26 @@ func (g GitHubConfig) HostLabel() string {
 // a GHE hive) makes GitHub return "Not Found" and the dashboard shows "could not
 // verify GitHub identity". Login must therefore use these fixed public hosts;
 // only the App-token / repo-API paths follow the per-hive (possibly GHE) host.
-func (g GitHubConfig) OAuthBaseURL() string { return DefaultGitHubBaseURL }
-func (g GitHubConfig) OAuthAPIURL() string  { return DefaultGitHubAPIURL }
+// The oauth_*_url_override fields exist ONLY as a test seam. They are
+// deliberately absent from every production config: a hive that sets them would
+// send its users' device-flow login to a non-github.com host, which is exactly
+// the misconfiguration the split above prevents. Tests point them at an
+// httptest server so the login path can be exercised without touching the real
+// github.com endpoints — see TestMain in pkg/dashboard, which additionally
+// hard-fails any test that leaves them unset and would otherwise dial out.
+func (g GitHubConfig) OAuthBaseURL() string {
+	if g.OAuthBaseURLOverride != "" {
+		return g.OAuthBaseURLOverride
+	}
+	return DefaultGitHubBaseURL
+}
+
+func (g GitHubConfig) OAuthAPIURL() string {
+	if g.OAuthAPIURLOverride != "" {
+		return g.OAuthAPIURLOverride
+	}
+	return DefaultGitHubAPIURL
+}
 
 // OAuthClientIDResolved returns the client ID for device-flow login: the
 // configured oauth_client_id, or the public github.com default. Because login

--- a/v2/pkg/dashboard/api_contribute_v1_coverage_test.go
+++ b/v2/pkg/dashboard/api_contribute_v1_coverage_test.go
@@ -27,6 +27,9 @@ func v1Server(t *testing.T, login string) *Server {
 	s := covApiServer(t)
 	mock := userMock(t, login)
 	s.deps.Config.GitHub.APIURL = mock.URL
+	// validateGitHubToken resolves through OAuthAPIURL (pinned to api.github.com),
+	// not APIURL, so the mock is only reached via the override.
+	s.deps.Config.GitHub.OAuthAPIURLOverride = mock.URL
 	return s
 }
 

--- a/v2/pkg/dashboard/auth_deviceflow_coverage_test.go
+++ b/v2/pkg/dashboard/auth_deviceflow_coverage_test.go
@@ -72,15 +72,30 @@ func dfServer(t *testing.T, tokenStatus, login string) (*Server, *Dependencies, 
 	deps.Config.GitHub.OAuthClientID = "Ov23liTest"
 	deps.Config.GitHub.BaseURL = mock.URL
 	deps.Config.GitHub.APIURL = mock.URL
+	// Device-flow login resolves through OAuthBaseURL/OAuthAPIURL, which are
+	// pinned to public github.com for GHE hives. Without these overrides the
+	// handlers ignore the mock and POST to the real github.com.
+	deps.Config.GitHub.OAuthBaseURLOverride = mock.URL
+	deps.Config.GitHub.OAuthAPIURLOverride = mock.URL
 	s.RegisterAPI(deps)
 	return s, deps, mock
 }
 
-func TestCovDF_GHUserAuthStart_NoClientID(t *testing.T) {
+// A blank oauth_client_id is NOT an error: OAuthClientIDResolved() falls back to
+// the public github.com Hive App client, which is the correct client for every
+// hive including GHE ones. This asserts the fallback actually reaches the device
+// flow rather than short-circuiting to 400 as an earlier revision did.
+func TestCovDF_GHUserAuthStart_BlankClientIDUsesPublicDefault(t *testing.T) {
 	s, deps, _ := dfServer(t, "complete", "octocat")
 	deps.Config.GitHub.OAuthClientID = ""
-	if rec := doPost(s, "/api/gh-user-auth/start", nil); rec.Code != http.StatusBadRequest {
-		t.Fatalf("no client id: want 400, got %d", rec.Code)
+	rec := doPost(s, "/api/gh-user-auth/start", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("blank client id: want 200 via public default, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["user_code"] != "ABCD-1234" {
+		t.Fatalf("device flow did not run: user_code=%v", body["user_code"])
 	}
 }
 

--- a/v2/pkg/dashboard/coverage_boost_test.go
+++ b/v2/pkg/dashboard/coverage_boost_test.go
@@ -1533,15 +1533,24 @@ func TestHandleGHUserAuthPoll_NoFlowInProgress(t *testing.T) {
 
 // --- handleGHUserAuthStart ---
 
-func TestHandleGHUserAuthStart_NoClientID(t *testing.T) {
+// Blank oauth_client_id must fall back to the public github.com client and run
+// the device flow, not 400. See OAuthClientIDResolved.
+func TestHandleGHUserAuthStart_BlankClientIDUsesPublicDefault(t *testing.T) {
 	srv := newFullServer(t)
 	srv.deps.Config.GitHub.OAuthClientID = ""
+	mock := deviceFlowMock(t, "complete", "octocat")
+	srv.deps.Config.GitHub.OAuthBaseURLOverride = mock.URL
+	srv.deps.Config.GitHub.OAuthAPIURLOverride = mock.URL
+
 	req := httptest.NewRequest("POST", "/api/gh-user-auth/start", nil)
 	w := httptest.NewRecorder()
 	srv.handleGHUserAuthStart(w, req)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("code = %d, want 400", w.Code)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "ABCD-1234") {
+		t.Errorf("device flow did not run, body=%s", w.Body.String())
 	}
 }
 

--- a/v2/pkg/dashboard/dashboard_inception_handlers_test.go
+++ b/v2/pkg/dashboard/dashboard_inception_handlers_test.go
@@ -189,16 +189,23 @@ func TestHandleGHUserAuthStatusNoToken(t *testing.T) {
 	}
 }
 
-func TestHandleGHUserAuthStartNoClientID(t *testing.T) {
+// A blank oauth_client_id resolves to the PUBLIC github.com Hive App client
+// rather than failing: device-flow login is always github.com, even for a hive
+// whose App and repos live on GHE. An earlier revision returned 400 here, which
+// broke login for every hive that had not set oauth_client_id explicitly.
+func TestHandleGHUserAuthStartBlankClientIDResolvesPublicDefault(t *testing.T) {
 	srv := newMinimalServer(t)
-	req := httptest.NewRequest("POST", "/api/gh-user-auth/start", nil)
-	w := httptest.NewRecorder()
-	srv.handleGHUserAuthStart(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d", w.Code)
+	if got := srv.deps.Config.GitHub.OAuthClientID; got != "" {
+		t.Fatalf("precondition: want blank oauth_client_id, got %q", got)
 	}
-	if !strings.Contains(w.Body.String(), "oauth_client_id not configured") {
-		t.Error("should mention oauth_client_id")
+	if got := srv.deps.Config.GitHub.OAuthClientIDResolved(); got != config.DefaultOAuthClientID {
+		t.Fatalf("blank oauth_client_id must resolve to the public default %q, got %q",
+			config.DefaultOAuthClientID, got)
+	}
+	// Login host stays public github.com regardless of a GHE App host.
+	srv.deps.Config.GitHub.BaseURL = "https://github.ibm.com"
+	if got := srv.deps.Config.GitHub.OAuthBaseURL(); got != config.DefaultGitHubBaseURL {
+		t.Fatalf("GHE hive must still log in via %q, got %q", config.DefaultGitHubBaseURL, got)
 	}
 }
 

--- a/v2/pkg/dashboard/main_test.go
+++ b/v2/pkg/dashboard/main_test.go
@@ -1,0 +1,84 @@
+package dashboard
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestMain isolates the dashboard test suite from the real internet.
+//
+// Why this exists: the device-flow login and contributor-API handlers resolve
+// their endpoints through GitHubConfig.OAuthBaseURL/OAuthAPIURL, which are
+// hardcoded to public github.com so that GHE hives still authenticate against a
+// github.com identity (see the comment on OAuthBaseURL). Because those methods
+// ignored their receiver, tests in auth_deviceflow_coverage_test.go and
+// api_contribute_v1_coverage_test.go that carefully pointed
+// Config.GitHub.BaseURL/APIURL at an httptest server had those URLs silently
+// discarded, and every run POSTed to the REAL
+// https://github.com/login/device/code.
+//
+// That made ~15 tests fail permanently (GitHub answers 404 for a test client
+// ID), which aborted the `go test -coverprofile` step in coverage-hourly.yml
+// before the per-package floor check ever ran — so the coverage gate had never
+// executed. It also burned real github.com rate limit, shared with production
+// hives, on every scheduled run.
+//
+// The fix has two halves. GitHubConfig grew OAuth*URLOverride fields (yaml:"-",
+// settable only from Go) that tests point at an httptest server. This TestMain
+// is the backstop: it replaces the default transport's DialContext so any
+// attempt to open a connection to a host that is not loopback fails loudly with
+// a descriptive error, instead of quietly succeeding against a real service.
+// A new test that forgets the override therefore fails in CI rather than
+// leaking traffic — the same "make it impossible, don't rely on discipline"
+// posture as TestMain in pkg/hub (#2287).
+func TestMain(m *testing.M) {
+	// Belt and braces: proxy env vars could otherwise route a dial that looks
+	// like loopback to an external proxy.
+	for _, v := range []string{"HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"} {
+		os.Unsetenv(v)
+	}
+
+	tr, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		panic("dashboard TestMain: http.DefaultTransport is not *http.Transport; " +
+			"the outbound-network guard cannot be installed")
+	}
+	guarded := tr.Clone()
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	guarded.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if !isLoopbackAddr(addr) {
+			return nil, fmt.Errorf(
+				"dashboard tests must not reach the network: blocked dial to %q. "+
+					"Point Config.GitHub.OAuthBaseURLOverride/OAuthAPIURLOverride at an "+
+					"httptest server instead of relying on the real github.com endpoints",
+				addr)
+		}
+		return dialer.DialContext(ctx, network, addr)
+	}
+	http.DefaultTransport = guarded
+	http.DefaultClient.Transport = guarded
+
+	os.Exit(m.Run())
+}
+
+// isLoopbackAddr reports whether a dial target is a loopback host, i.e. an
+// httptest server. Hostnames other than "localhost" are rejected outright
+// rather than resolved: a DNS lookup is itself outbound traffic, and a name
+// that resolves to 127.0.0.1 today could resolve elsewhere tomorrow.
+func isLoopbackAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/v2/pkg/hub/hub_misc_coverage_test.go
+++ b/v2/pkg/hub/hub_misc_coverage_test.go
@@ -1,0 +1,424 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---- saveAlertAcks error branches ----
+
+// A nil server or nil alert state must be a no-op, not a panic: saveAlertAcks
+// runs from a background loop that can outlive a partially-built server.
+func TestSaveAlertAcksToleratesNilState(t *testing.T) {
+	var nilServer *HubServer
+	nilServer.saveAlertAcks() // must not panic
+
+	s := &HubServer{}
+	s.saveAlertAcks() // alerts == nil, must not panic
+}
+
+// When the acks file cannot be written the failure is logged and swallowed —
+// losing an acknowledgement must never take the hub down.
+func TestSaveAlertAcksSurvivesUnwritablePath(t *testing.T) {
+	s := newTestAlertServer()
+
+	old := alertAcksPath
+	// A path whose parent is a FILE, so both MkdirAll and WriteFile fail.
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	alertAcksPath = filepath.Join(blocker, "acks.json")
+	t.Cleanup(func() { alertAcksPath = old })
+
+	s.saveAlertAcks() // must not panic and must not leave a temp file behind
+	if _, err := os.Stat(alertAcksPath); err == nil {
+		t.Fatal("no acks file should exist at an unwritable path")
+	}
+}
+
+// A successful save must be atomic: the temp file must not survive.
+func TestSaveAlertAcksIsAtomic(t *testing.T) {
+	s := newTestAlertServer()
+
+	old := alertAcksPath
+	dir := t.TempDir()
+	alertAcksPath = filepath.Join(dir, "nested", "acks.json")
+	t.Cleanup(func() { alertAcksPath = old })
+
+	s.saveAlertAcks()
+
+	if _, err := os.Stat(alertAcksPath); err != nil {
+		t.Fatalf("acks file was not written: %v", err)
+	}
+	if _, err := os.Stat(alertAcksPath + ".tmp"); err == nil {
+		t.Fatal("the temp file must be renamed away, not left behind")
+	}
+}
+
+// ---- journeyBannerFor guards ----
+
+// A nil server or a server with no journey state must return nil rather than
+// panicking — the dashboard calls this on every poll.
+func TestJourneyBannerForToleratesNilState(t *testing.T) {
+	var nilServer *HubServer
+	if b := nilServer.journeyBannerFor("hosted-x", time.Now()); b != nil {
+		t.Fatal("a nil server must yield no banner")
+	}
+
+	s := &HubServer{}
+	if b := s.journeyBannerFor("hosted-x", time.Now()); b != nil {
+		t.Fatal("a server with no journey state must yield no banner")
+	}
+}
+
+// An unknown hive has no registry entry and therefore no journey banner.
+func TestJourneyBannerForUnknownHive(t *testing.T) {
+	s := bulkTestHub(t)
+	if b := s.journeyBannerFor("no-such-hive", time.Now()); b != nil {
+		t.Fatalf("an unknown hive must yield no banner, got %+v", b)
+	}
+}
+
+// ---- recentlyStarted ----
+
+// A pod that started moments ago is "recently started", which suppresses a
+// crash-loop alert while it is still coming up.
+func TestRecentlyStartedWindow(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name      string
+		startedAt string
+		want      bool
+	}{
+		{"just started", now.Add(-time.Second).Format(time.RFC3339), true},
+		{"well past the ceiling", now.Add(-24 * time.Hour).Format(time.RFC3339), false},
+		{"unparseable", "not-a-timestamp", false},
+		{"empty", "", false},
+		// A clock skew that puts the start in the FUTURE must not be treated as
+		// "recently started" — a negative age is nonsense, not a fresh pod.
+		{"future start (clock skew)", now.Add(time.Hour).Format(time.RFC3339), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := recentlyStarted(tc.startedAt, now); got != tc.want {
+				t.Fatalf("recentlyStarted(%q) = %v, want %v", tc.startedAt, got, tc.want)
+			}
+		})
+	}
+}
+
+// Surrounding whitespace from a kubectl field must not defeat parsing.
+func TestRecentlyStartedTrimsWhitespace(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	stamp := "  " + now.Add(-time.Second).Format(time.RFC3339) + "\n"
+	if !recentlyStarted(stamp, now) {
+		t.Fatal("a padded timestamp must still parse")
+	}
+}
+
+// ---- existingVanityHost ----
+
+// No cluster config means no host to discover.
+func TestExistingVanityHostWithoutCluster(t *testing.T) {
+	s := bulkTestHub(t)
+	if got := s.existingVanityHost("hosted-x", nil); got != "" {
+		t.Fatalf("want empty host, got %q", got)
+	}
+}
+
+// For nginx the vanity host is the ingress rule that is NOT the placeholder —
+// returning the placeholder would point the owner at the wrong URL.
+func TestExistingVanityHostSkipsPlaceholderRule(t *testing.T) {
+	dir := t.TempDir()
+	// jsonpath returns both rule hosts space-separated.
+	script := "#!/bin/sh\necho 'hosted-x.example.com vanity.acme.dev'\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	s := bulkTestHub(t)
+	cluster := &ClusterConfig{ID: "c1", Domain: "example.com"}
+	got := s.existingVanityHost("hosted-x", cluster)
+	if got != "vanity.acme.dev" {
+		t.Fatalf("want the non-placeholder host, got %q", got)
+	}
+}
+
+// When only the placeholder rule exists there is no vanity host yet.
+func TestExistingVanityHostReturnsEmptyWhenOnlyPlaceholder(t *testing.T) {
+	dir := t.TempDir()
+	script := "#!/bin/sh\necho 'hosted-x.example.com'\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	s := bulkTestHub(t)
+	cluster := &ClusterConfig{ID: "c1", Domain: "example.com"}
+	if got := s.existingVanityHost("hosted-x", cluster); got != "" {
+		t.Fatalf("only the placeholder exists, want empty, got %q", got)
+	}
+}
+
+// A kubectl failure must yield "" rather than a partial or garbage host.
+func TestExistingVanityHostOnKubectlFailure(t *testing.T) {
+	dir := t.TempDir()
+	script := "#!/bin/sh\necho 'error' >&2\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	s := bulkTestHub(t)
+	cluster := &ClusterConfig{ID: "c1", Domain: "example.com"}
+	if got := s.existingVanityHost("hosted-x", cluster); got != "" {
+		t.Fatalf("a kubectl failure must yield an empty host, got %q", got)
+	}
+}
+
+// OpenShift clusters read the Route's host instead of an Ingress rule.
+func TestExistingVanityHostOpenShiftRoute(t *testing.T) {
+	dir := t.TempDir()
+	script := "#!/bin/sh\necho 'vanity.apps.openshift.example'\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	s := bulkTestHub(t)
+	cluster := &ClusterConfig{ID: "c1", Domain: "example.com", IngressType: ingressTypeOpenShiftRoute}
+	got := s.existingVanityHost("hosted-x", cluster)
+	if got != "vanity.apps.openshift.example" {
+		t.Fatalf("want the Route host, got %q", got)
+	}
+}
+
+// ---- saveHubBanners ----
+
+// A successful save is atomic and creates missing parent directories.
+func TestSaveHubBannersWritesAtomically(t *testing.T) {
+	s := bulkTestHub(t)
+	s.hubBannersMu.Lock()
+	s.hubBanners = map[string]*HubBannerEntry{
+		"hosted-x": {ID: "hosted-x", Message: "hello", Color: "blue", SentAt: "2026-07-31T00:00:00Z"},
+	}
+	s.hubBannersMu.Unlock()
+
+	old := hubBannersPath
+	hubBannersPath = filepath.Join(t.TempDir(), "nested", "banners.json")
+	t.Cleanup(func() { hubBannersPath = old })
+
+	s.saveHubBanners()
+
+	data, err := os.ReadFile(hubBannersPath)
+	if err != nil {
+		t.Fatalf("banners were not persisted: %v", err)
+	}
+	if !strings.Contains(string(data), "hello") {
+		t.Fatalf("banner content missing: %s", data)
+	}
+	if _, err := os.Stat(hubBannersPath + ".tmp"); err == nil {
+		t.Fatal("the temp file must be renamed away, not left behind")
+	}
+}
+
+// An unwritable destination must be logged and swallowed: failing to persist a
+// banner must never take the hub down.
+func TestSaveHubBannersSurvivesUnwritablePath(t *testing.T) {
+	s := bulkTestHub(t)
+
+	old := hubBannersPath
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hubBannersPath = filepath.Join(blocker, "banners.json")
+	t.Cleanup(func() { hubBannersPath = old })
+
+	s.saveHubBanners() // must not panic
+	if _, err := os.Stat(hubBannersPath); err == nil {
+		t.Fatal("no banners file should exist at an unwritable path")
+	}
+}
+
+// ---- clusterOutage ----
+
+// A cluster-wide outage suppresses per-hive alerts; below the minimum fleet
+// size or the failure ratio, individual hives are still worth alerting on.
+func TestClusterOutageThresholds(t *testing.T) {
+	cases := []struct {
+		name           string
+		failed, probed int
+		want           bool
+	}{
+		{"too few hives to judge", 1, 1, false},
+		{"all of a large fleet failed", 10, 10, true},
+		{"a single hive in a large fleet", 1, 10, false},
+		{"nothing probed", 0, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clusterOutage(tc.failed, tc.probed); got != tc.want {
+				t.Fatalf("clusterOutage(%d,%d) = %v, want %v",
+					tc.failed, tc.probed, got, tc.want)
+			}
+		})
+	}
+}
+
+// The minimum-hives guard must come first: a 1/1 failure is 100% but is far too
+// small a sample to call a cluster outage, and suppressing on it would hide a
+// genuine single-hive failure.
+func TestClusterOutageRequiresMinimumSample(t *testing.T) {
+	if clusterOutage(urlClusterOutageMinHives-1, urlClusterOutageMinHives-1) {
+		t.Fatal("a fleet below the minimum sample must never be called an outage")
+	}
+	if !clusterOutage(urlClusterOutageMinHives, urlClusterOutageMinHives) {
+		t.Fatal("a fully-failed fleet at the minimum sample size is an outage")
+	}
+}
+
+// ---- CORS preflight and trusted origins ----
+
+// The bulk endpoint must answer a CORS preflight without doing any work, and
+// must echo the origin ONLY for trusted hosts — reflecting an arbitrary origin
+// with credentials allowed would let any site drive the fleet API.
+func TestBulkHandlerPreflightOnlyTrustsKnownOrigins(t *testing.T) {
+	s := bulkTestHub(t)
+
+	trusted := []string{
+		"https://hive.kubestellar.io",
+		"https://console.hive.kubestellar.io",
+		"http://localhost:5174",
+		"http://127.0.0.1:8080",
+	}
+	for _, origin := range trusted {
+		t.Run("trusted "+origin, func(t *testing.T) {
+			req := httptest.NewRequest("OPTIONS", "/api/saas/hives/bulk", nil)
+			req.Header.Set("Origin", origin)
+			w := httptest.NewRecorder()
+			s.handleBulkHiveAction(w, req)
+
+			if w.Code != http.StatusNoContent {
+				t.Fatalf("preflight code = %d, want 204", w.Code)
+			}
+			if got := w.Header().Get("Access-Control-Allow-Origin"); got != origin {
+				t.Fatalf("trusted origin must be echoed, got %q", got)
+			}
+			if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+				t.Fatalf("credentials header = %q", got)
+			}
+		})
+	}
+
+	untrusted := []string{
+		"https://evil.example.com",
+		"https://hive.kubestellar.io.evil.com",
+		"https://notlocalhost",
+		"::not a url::",
+	}
+	for _, origin := range untrusted {
+		t.Run("untrusted "+origin, func(t *testing.T) {
+			req := httptest.NewRequest("OPTIONS", "/api/saas/hives/bulk", nil)
+			req.Header.Set("Origin", origin)
+			w := httptest.NewRecorder()
+			s.handleBulkHiveAction(w, req)
+
+			if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+				t.Fatalf("untrusted origin %q must NOT be echoed, got %q", origin, got)
+			}
+		})
+	}
+}
+
+// ---- handleLogin redirect safety ----
+
+// The `redirect` parameter must never send a user to an attacker-controlled
+// host after login. Anything that is not a same-site path is rewritten to
+// /dashboard unless it is an explicitly trusted origin.
+func TestHandleLoginRejectsLookalikeRedirectHosts(t *testing.T) {
+	s := bulkTestHub(t)
+
+	hostile := []string{
+		"https://evil.example.com/steal",
+		"//evil.example.com",
+		"//hive.kubestellar.io.evil.com",
+		"https://hive.kubestellar.io.evil.com/x",
+	}
+	for _, rd := range hostile {
+		t.Run(rd, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/login?redirect="+url.QueryEscape(rd), nil)
+			w := httptest.NewRecorder()
+			s.handleLogin(w, req)
+
+			loc := w.Header().Get("Location")
+			// The hostile target must not survive into the OAuth state.
+			if strings.Contains(loc, "evil.example.com") {
+				t.Fatalf("open redirect: hostile host reached Location %q", loc)
+			}
+			if strings.Contains(loc, "evil.com") {
+				t.Fatalf("open redirect: lookalike host reached Location %q", loc)
+			}
+		})
+	}
+}
+
+// A same-site path is preserved, so a deep link still lands where the user
+// expected after signing in.
+func TestHandleLoginKeepsDeepLinkPath(t *testing.T) {
+	s := bulkTestHub(t)
+	req := httptest.NewRequest("GET", "/login?redirect=%2Fdashboard%2Fhives", nil)
+	w := httptest.NewRecorder()
+	s.handleLogin(w, req)
+
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, url.QueryEscape("/dashboard/hives")) &&
+		!strings.Contains(loc, "%2Fdashboard%2Fhives") {
+		t.Fatalf("same-site redirect was not preserved in %q", loc)
+	}
+}
+
+// `rd` is accepted as an alias for `redirect`, and must get the same treatment.
+func TestHandleLoginRdAliasGuardsLookalikeHost(t *testing.T) {
+	s := bulkTestHub(t)
+	req := httptest.NewRequest("GET", "/login?rd="+url.QueryEscape("https://evil.example.com"), nil)
+	w := httptest.NewRecorder()
+	s.handleLogin(w, req)
+
+	if loc := w.Header().Get("Location"); strings.Contains(loc, "evil.example.com") {
+		t.Fatalf("the rd alias bypassed the redirect guard: %q", loc)
+	}
+}
+
+// ---- handleOGCard ----
+
+// The Open Graph card is served with an image content type and a cache header,
+// so link previews render and do not re-fetch on every unfurl.
+func TestHandleOGCardServesImageWithCache(t *testing.T) {
+	s := bulkTestHub(t)
+	req := httptest.NewRequest("GET", "/og-card.png", nil)
+	w := httptest.NewRecorder()
+	s.handleOGCard(w, req)
+
+	if w.Code == http.StatusNotFound {
+		t.Skip("og card asset not embedded in this build")
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "image/png" {
+		t.Fatalf("content type = %q, want image/png", ct)
+	}
+	if cc := w.Header().Get("Cache-Control"); !strings.Contains(cc, "max-age=") {
+		t.Fatalf("cache control = %q, want a max-age", cc)
+	}
+	if w.Body.Len() == 0 {
+		t.Fatal("og card body is empty")
+	}
+}

--- a/v2/pkg/hub/saas_bulk_coverage_test.go
+++ b/v2/pkg/hub/saas_bulk_coverage_test.go
@@ -1,0 +1,425 @@
+package hub
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// installBulkKubectl installs a scripted fake kubectl on PATH. ok=false makes
+// every invocation fail, which is how a firewalled or unreachable cluster looks
+// to the hub. This is the package's established pattern (see
+// installScriptedKubectl); combined with TestMain clearing the in-cluster
+// service-account env and pointing KUBECONFIG at /dev/null, no test can reach a
+// real API server.
+func installBulkKubectl(t *testing.T, ok bool) {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\necho 'deployment.apps/hive restarted'\nexit 0\n"
+	if !ok {
+		script = "#!/bin/sh\necho 'Unable to connect to the server: dial tcp: i/o timeout' >&2\nexit 1\n"
+	}
+	path := filepath.Join(dir, "kubectl")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// setLatestSHAForBranchForTest seeds the package-level SHA cache and restores
+// the previous value, so tests do not leak state into each other.
+func setLatestSHAForBranchForTest(t *testing.T, branch, sha string) {
+	t.Helper()
+	latestSHAMu.Lock()
+	prev, had := latestSHAByBranch[branch]
+	latestSHAByBranch[branch] = branchSHAInfo{SHA: sha}
+	latestSHAMu.Unlock()
+	t.Cleanup(func() {
+		latestSHAMu.Lock()
+		if had {
+			latestSHAByBranch[branch] = prev
+		} else {
+			delete(latestSHAByBranch, branch)
+		}
+		latestSHAMu.Unlock()
+	})
+}
+
+// bulkHiveOnCluster seeds a hive owned by owner and wires a cluster config plus
+// a registry entry, which bulkRestartOrUpgrade needs to resolve a branch.
+func bulkHiveOnCluster(t *testing.T, s *HubServer, id, owner, branch string) {
+	t.Helper()
+	bulkSeedHive(t, id, owner)
+	s.mu.Lock()
+	s.clusters = map[string]ClusterConfig{defaultClusterID: {ID: defaultClusterID}}
+	if s.heartbeatUpgrade == nil {
+		s.heartbeatUpgrade = map[string]string{}
+	}
+	s.registry.Hives = append(s.registry.Hives, RegistryEntry{ID: id, GitBranch: branch})
+	s.mu.Unlock()
+}
+
+func bulkRegistryEntry(t *testing.T, s *HubServer, id string) RegistryEntry {
+	t.Helper()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, r := range s.registry.Hives {
+		if r.ID == id {
+			return r
+		}
+	}
+	t.Fatalf("no registry entry for %q", id)
+	return RegistryEntry{}
+}
+
+// ---- applyBulkAction dispatch ----
+
+func TestApplyBulkActionRejectsUnknownAction(t *testing.T) {
+	s := bulkTestHub(t)
+	bulkSeedHive(t, "hosted-x", "alice")
+
+	res := s.applyBulkAction("no-such-action", "", "hosted-x", "alice")
+	if res.Ok {
+		t.Fatal("an unknown action must not report success")
+	}
+	if res.Error != "unknown bulk action" {
+		t.Fatalf("error = %q", res.Error)
+	}
+}
+
+func TestApplyBulkActionPropagatesAuthorizationFailure(t *testing.T) {
+	s := bulkTestHub(t)
+	bulkSeedHive(t, "hosted-x", "alice")
+
+	res := s.applyBulkAction(bulkActionRestart, "", "hosted-x", "mallory")
+	if res.Ok {
+		t.Fatal("an unauthorized bulk action must not report success")
+	}
+	if res.HiveID != "hosted-x" {
+		t.Errorf("result must identify the hive, got %q", res.HiveID)
+	}
+}
+
+// ---- bulkRestartOrUpgrade ----
+
+// A reachable cluster is served by kubectl and reported as such.
+func TestBulkRestartViaKubectlWhenClusterReachable(t *testing.T) {
+	installBulkKubectl(t, true)
+	s := bulkTestHub(t)
+	bulkHiveOnCluster(t, s, "hosted-x", "alice", "v2")
+
+	res := s.applyBulkAction(bulkActionRestart, "", "hosted-x", "alice")
+	if !res.Ok {
+		t.Fatalf("restart on a reachable cluster must succeed, got %q", res.Error)
+	}
+	if res.Via != bulkViaKubectl {
+		t.Fatalf("want Via=%q, got %q", bulkViaKubectl, res.Via)
+	}
+}
+
+// A restart that cannot be delivered must be reported as a FAILURE: unlike an
+// upgrade there is no SHA for the heartbeat path to carry, so reporting success
+// would tell the operator a restart happened when it did not.
+func TestBulkRestartFailsWhenClusterUnreachable(t *testing.T) {
+	installBulkKubectl(t, false)
+	s := bulkTestHub(t)
+	bulkHiveOnCluster(t, s, "hosted-x", "alice", "v2")
+
+	res := s.applyBulkAction(bulkActionRestart, "", "hosted-x", "alice")
+	if res.Ok {
+		t.Fatal("an undeliverable restart must NOT report success — a restart has " +
+			"no heartbeat fallback")
+	}
+	if res.Error == "" {
+		t.Fatal("the failure must carry an explanation")
+	}
+	s.mu.RLock()
+	_, armed := s.heartbeatUpgrade["hosted-x"]
+	s.mu.RUnlock()
+	if armed {
+		t.Fatal("a restart must not arm a heartbeat UPGRADE")
+	}
+}
+
+// An upgrade that kubectl cannot deliver IS success, via the heartbeat path —
+// the only delivery route for a firewalled cluster. The spoke self-restarts on
+// its next check-in.
+func TestBulkUpgradeFallsBackToHeartbeatWhenUnreachable(t *testing.T) {
+	installBulkKubectl(t, false)
+	s := bulkTestHub(t)
+	bulkHiveOnCluster(t, s, "hosted-x", "alice", "v2")
+	setLatestSHAForBranchForTest(t, "v2", "abc123def")
+
+	res := s.applyBulkAction(bulkActionUpgrade, "", "hosted-x", "alice")
+	if !res.Ok {
+		t.Fatalf("an undeliverable upgrade must succeed via heartbeat, got %q", res.Error)
+	}
+	if res.Via != bulkViaHeartbeat {
+		t.Fatalf("want Via=%q, got %q", bulkViaHeartbeat, res.Via)
+	}
+	s.mu.RLock()
+	armed := s.heartbeatUpgrade["hosted-x"]
+	s.mu.RUnlock()
+	if armed != "abc123def" {
+		t.Fatalf("the heartbeat fallback must be armed with the target SHA, got %q", armed)
+	}
+}
+
+// An upgrade advances the registry's upgrade target; a plain restart must NOT,
+// or the dashboard claims a version change that never happened.
+func TestBulkRestartDoesNotAdvanceUpgradeTarget(t *testing.T) {
+	installBulkKubectl(t, true)
+	s := bulkTestHub(t)
+	bulkHiveOnCluster(t, s, "hosted-x", "alice", "v2")
+	setLatestSHAForBranchForTest(t, "v2", "abc123def")
+
+	if res := s.applyBulkAction(bulkActionRestart, "", "hosted-x", "alice"); !res.Ok {
+		t.Fatalf("restart failed: %q", res.Error)
+	}
+	reg := bulkRegistryEntry(t, s, "hosted-x")
+	if reg.Upgrading {
+		t.Fatal("a plain restart must not mark the hive as Upgrading")
+	}
+	if reg.UpgradeTarget != "" {
+		t.Fatalf("a plain restart must not set an upgrade target, got %q", reg.UpgradeTarget)
+	}
+}
+
+func TestBulkUpgradeAdvancesUpgradeTarget(t *testing.T) {
+	installBulkKubectl(t, true)
+	s := bulkTestHub(t)
+	bulkHiveOnCluster(t, s, "hosted-x", "alice", "v2")
+	setLatestSHAForBranchForTest(t, "v2", "abc123def")
+
+	if res := s.applyBulkAction(bulkActionUpgrade, "", "hosted-x", "alice"); !res.Ok {
+		t.Fatalf("upgrade failed: %q", res.Error)
+	}
+	reg := bulkRegistryEntry(t, s, "hosted-x")
+	if !reg.Upgrading {
+		t.Fatal("an upgrade must mark the hive as Upgrading")
+	}
+	if reg.UpgradeTarget != "abc123def" {
+		t.Fatalf("upgrade target = %q, want the branch's latest SHA", reg.UpgradeTarget)
+	}
+	if reg.UpgradeStartedAt.IsZero() {
+		t.Fatal("an upgrade must stamp UpgradeStartedAt so the UI can show elapsed time")
+	}
+}
+
+// A hive whose cluster has no config cannot be acted on.
+func TestBulkRestartFailsWithoutClusterConfig(t *testing.T) {
+	s := bulkTestHub(t)
+	bulkSeedHive(t, "hosted-x", "alice")
+	s.mu.Lock()
+	s.clusters = map[string]ClusterConfig{}
+	s.mu.Unlock()
+
+	res := s.applyBulkAction(bulkActionRestart, "", "hosted-x", "alice")
+	if res.Ok {
+		t.Fatal("a hive with no cluster config must not report success")
+	}
+	if res.Error != "no cluster config for this hive" {
+		t.Fatalf("error = %q", res.Error)
+	}
+}
+
+// ---- bulkSetAutoUpgrade ----
+
+// A mode change must clear the day's fire record, or a hive that already fired
+// today under the old mode would be skipped under the new one.
+func TestBulkSetAutoUpgradeClearsFireRecord(t *testing.T) {
+	s := bulkTestHub(t)
+	bulkSeedHive(t, "hosted-x", "alice")
+	h := loadSaaSHive("hosted-x")
+	h.AutoUpgradeLastFired = "2026-07-30"
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+
+	res := s.applyBulkAction(bulkActionDailyAutoUpgrade, "", "hosted-x", "alice")
+	if !res.Ok {
+		t.Fatalf("enabling daily auto-upgrade failed: %q", res.Error)
+	}
+	if res.Via != bulkViaStore {
+		t.Fatalf("auto-upgrade needs no kubectl, want Via=%q, got %q", bulkViaStore, res.Via)
+	}
+
+	got := loadSaaSHive("hosted-x")
+	if !got.AutoUpgrade {
+		t.Fatal("auto-upgrade was not persisted")
+	}
+	if got.AutoUpgradeMode != AutoUpgradeModeDaily {
+		t.Fatalf("mode = %q, want %q", got.AutoUpgradeMode, AutoUpgradeModeDaily)
+	}
+	if got.AutoUpgradeLastFired != "" {
+		t.Fatalf("a mode change must clear the fire record, got %q", got.AutoUpgradeLastFired)
+	}
+}
+
+func TestBulkDisableAutoUpgradePersists(t *testing.T) {
+	s := bulkTestHub(t)
+	bulkSeedHive(t, "hosted-x", "alice")
+
+	if res := s.applyBulkAction(bulkActionEnableAutoUpgrade, "", "hosted-x", "alice"); !res.Ok {
+		t.Fatalf("enable failed: %q", res.Error)
+	}
+	if res := s.applyBulkAction(bulkActionDisableAutoUpgrade, "", "hosted-x", "alice"); !res.Ok {
+		t.Fatalf("disable failed: %q", res.Error)
+	}
+	if got := loadSaaSHive("hosted-x"); got.AutoUpgrade {
+		t.Fatal("auto-upgrade was not disabled")
+	}
+}
+
+// Auto-upgrade changes are store-only, which is exactly why a firewalled hive
+// can still be managed. This must hold even when kubectl fails.
+func TestBulkAutoUpgradeWorksOnUnreachableCluster(t *testing.T) {
+	installBulkKubectl(t, false)
+	s := bulkTestHub(t)
+	bulkHiveOnCluster(t, s, "hosted-x", "alice", "v2")
+
+	res := s.applyBulkAction(bulkActionEnableAutoUpgrade, "", "hosted-x", "alice")
+	if !res.Ok {
+		t.Fatalf("auto-upgrade must not depend on cluster reachability, got %q", res.Error)
+	}
+	if res.Via != bulkViaStore {
+		t.Fatalf("want Via=%q, got %q", bulkViaStore, res.Via)
+	}
+}
+
+// ---- validateBulkBranch ----
+
+// A branch already tracked by the hub is accepted without any network lookup.
+func TestValidateBulkBranchAcceptsTrackedBranch(t *testing.T) {
+	s := bulkTestHub(t)
+	tracked := s.trackedBranchList()
+	if len(tracked) == 0 {
+		t.Skip("no tracked branches in this build")
+	}
+	if !s.validateBulkBranch(tracked[0]) {
+		t.Fatalf("tracked branch %q must validate", tracked[0])
+	}
+}
+
+// An untracked branch with no resolvable SHA must be rejected, so a bulk switch
+// cannot point the fleet at a branch that does not exist.
+func TestValidateBulkBranchRejectsUnknownBranch(t *testing.T) {
+	s := bulkTestHub(t)
+	// A branch name that is not tracked and has no cached SHA. fetchBranchSHA
+	// cannot reach GitHub (TestMain neutralises the environment), so the cache
+	// stays empty and validation must fail closed.
+	if s.validateBulkBranch("definitely-not-a-real-branch-zzz") {
+		t.Fatal("an unresolvable branch must be rejected, not accepted by default")
+	}
+}
+
+// A branch that is not tracked but HAS a cached SHA is accepted — this is how a
+// freshly-pushed branch becomes usable without restarting the hub.
+func TestValidateBulkBranchAcceptsUntrackedBranchWithKnownSHA(t *testing.T) {
+	s := bulkTestHub(t)
+	setLatestSHAForBranchForTest(t, "feature-xyz", "cafebabe")
+	if !s.validateBulkBranch("feature-xyz") {
+		t.Fatal("a branch with a resolved SHA must validate")
+	}
+}
+
+// ---- bulkSwitchBranch ----
+
+// A reachable cluster gets the image set by kubectl and is restarted so the new
+// image is actually pulled.
+func TestBulkSwitchBranchViaKubectl(t *testing.T) {
+	installBulkKubectl(t, true)
+	s := bulkTestHub(t)
+	bulkHiveOnCluster(t, s, "hosted-x", "alice", "v2")
+
+	res := s.applyBulkAction(bulkActionSwitchBranch, "dd", "hosted-x", "alice")
+	if !res.Ok {
+		t.Fatalf("branch switch failed: %q", res.Error)
+	}
+	if res.Via != bulkViaKubectl {
+		t.Fatalf("want Via=%q, got %q", bulkViaKubectl, res.Via)
+	}
+	reg := bulkRegistryEntry(t, s, "hosted-x")
+	if !reg.Upgrading {
+		t.Fatal("a branch switch must mark the hive as Upgrading")
+	}
+	// The target must be the sanitized branch tag, not the raw branch name.
+	if reg.UpgradeTarget != branchToTag("dd")+"-latest" {
+		t.Fatalf("upgrade target = %q, want the branch's -latest tag", reg.UpgradeTarget)
+	}
+	// kubectl delivered, so no heartbeat fallback should be armed.
+	s.mu.RLock()
+	_, armed := s.heartbeatSwitchTag["hosted-x"]
+	s.mu.RUnlock()
+	if armed {
+		t.Fatal("a delivered switch must not also arm the heartbeat fallback")
+	}
+}
+
+// When kubectl cannot reach the cluster the switch is queued for the spoke to
+// apply on its next heartbeat — the spoke holds RBAC to patch its own
+// deployment, so this is a real delivery path, not a failure.
+func TestBulkSwitchBranchFallsBackToHeartbeat(t *testing.T) {
+	installBulkKubectl(t, false)
+	s := bulkTestHub(t)
+	bulkHiveOnCluster(t, s, "hosted-x", "alice", "v2")
+
+	res := s.applyBulkAction(bulkActionSwitchBranch, "dd", "hosted-x", "alice")
+	if !res.Ok {
+		t.Fatalf("an undeliverable switch must still queue via heartbeat: %q", res.Error)
+	}
+	if res.Via != bulkViaHeartbeat {
+		t.Fatalf("want Via=%q, got %q", bulkViaHeartbeat, res.Via)
+	}
+	s.mu.RLock()
+	tag := s.heartbeatSwitchTag["hosted-x"]
+	s.mu.RUnlock()
+	if tag != branchToTag("dd")+"-latest" {
+		t.Fatalf("heartbeat switch tag = %q, want the branch's -latest tag", tag)
+	}
+}
+
+// A slashed branch must be converted to the same image tag docker.yml
+// publishes, or the hive is pointed at a tag that does not exist. This mirrors
+// branchToTag, which handleSwitchBranch applies too — the two paths must agree
+// or a bulk switch and a single switch would land on different images.
+//
+// Only "/" is translated: branch names reaching here have already passed
+// validateBulkBranch, so they exist in git and cannot contain characters git
+// itself forbids in a ref.
+func TestBulkSwitchBranchConvertsSlashesToTag(t *testing.T) {
+	installBulkKubectl(t, false)
+	s := bulkTestHub(t)
+	bulkHiveOnCluster(t, s, "hosted-x", "alice", "v2")
+
+	if res := s.applyBulkAction(bulkActionSwitchBranch, "feat/my-branch", "hosted-x", "alice"); !res.Ok {
+		t.Fatalf("switch failed: %q", res.Error)
+	}
+	s.mu.RLock()
+	tag := s.heartbeatSwitchTag["hosted-x"]
+	s.mu.RUnlock()
+	if strings.Contains(tag, "/") {
+		t.Fatalf("tag %q still contains a slash — it would not resolve in the registry", tag)
+	}
+	if tag != "feat-my-branch-latest" {
+		t.Fatalf("tag = %q, want the docker.yml-compatible form", tag)
+	}
+	// The bulk path and the single-hive path must agree on the tag.
+	if tag != branchToTag("feat/my-branch")+"-latest" {
+		t.Fatal("bulk switch and handleSwitchBranch disagree on the image tag")
+	}
+}
+
+func TestBulkSwitchBranchFailsWithoutClusterConfig(t *testing.T) {
+	s := bulkTestHub(t)
+	bulkSeedHive(t, "hosted-x", "alice")
+	s.mu.Lock()
+	s.clusters = map[string]ClusterConfig{}
+	s.mu.Unlock()
+
+	res := s.applyBulkAction(bulkActionSwitchBranch, "dd", "hosted-x", "alice")
+	if res.Ok {
+		t.Fatal("a hive with no cluster config must not report success")
+	}
+}

--- a/v2/pkg/hub/self_image_coverage_test.go
+++ b/v2/pkg/hub/self_image_coverage_test.go
@@ -1,0 +1,238 @@
+package hub
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// resetSelfImageCache clears the memoised deployment image so each test starts
+// from a cold cache and restores the previous state afterwards.
+func resetSelfImageCache(t *testing.T) {
+	t.Helper()
+	selfImageMu.Lock()
+	pc, pf, pa := selfImageCached, selfImageFetched, selfImageAttempted
+	selfImageCached, selfImageFetched, selfImageAttempted = "", time.Time{}, false
+	selfImageMu.Unlock()
+	t.Cleanup(func() {
+		selfImageMu.Lock()
+		selfImageCached, selfImageFetched, selfImageAttempted = pc, pf, pa
+		selfImageMu.Unlock()
+	})
+}
+
+// deploymentJSON renders a Deployment carrying one container image.
+func deploymentJSON(image string) string {
+	return fmt.Sprintf(
+		`{"spec":{"template":{"spec":{"containers":[{"name":"hub","image":%q}]}}}}`, image)
+}
+
+// ---- selfDeploymentImage ----
+
+func TestSelfDeploymentImageReadsContainerImage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(deploymentJSON("ghcr.io/kubestellar/hive-hub:abc123")))
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+
+	got, err := selfDeploymentImage()
+	if err != nil {
+		t.Fatalf("selfDeploymentImage: %v", err)
+	}
+	if got != "ghcr.io/kubestellar/hive-hub:abc123" {
+		t.Fatalf("image = %q", got)
+	}
+}
+
+// The namespace comes from the mounted ServiceAccount; without it the hub
+// cannot address its own Deployment and must error rather than guess.
+//
+// The mock rejects a request whose path carries an empty namespace segment, so
+// this fails if the blank-namespace guard is removed rather than silently
+// "succeeding" against a permissive stub.
+func TestSelfDeploymentImageRequiresNamespace(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/namespaces//") {
+			http.Error(w, "empty namespace in request path", http.StatusBadRequest)
+			return
+		}
+		w.Write([]byte(deploymentJSON("x")))
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+
+	t.Run("missing namespace file", func(t *testing.T) {
+		old := k8sNamespacePath
+		k8sNamespacePath = filepath.Join(t.TempDir(), "absent")
+		t.Cleanup(func() { k8sNamespacePath = old })
+		if _, err := selfDeploymentImage(); err == nil {
+			t.Fatal("a missing namespace file must be an error")
+		}
+	})
+
+	t.Run("empty namespace file", func(t *testing.T) {
+		old := k8sNamespacePath
+		p := filepath.Join(t.TempDir(), "namespace")
+		if err := os.WriteFile(p, []byte("   \n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		k8sNamespacePath = p
+		t.Cleanup(func() { k8sNamespacePath = old })
+		if _, err := selfDeploymentImage(); err == nil {
+			t.Fatal("an empty namespace must be an error, not an empty API path")
+		}
+	})
+}
+
+// A Deployment with no containers must error rather than panic on index 0.
+func TestSelfDeploymentImageRejectsContainerlessDeployment(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"spec":{"template":{"spec":{"containers":[]}}}}`))
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+
+	if _, err := selfDeploymentImage(); err == nil {
+		t.Fatal("a Deployment with no containers must be an error")
+	}
+}
+
+func TestSelfDeploymentImageRejectsMalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("{not json"))
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+
+	if _, err := selfDeploymentImage(); err == nil {
+		t.Fatal("malformed Deployment JSON must be an error")
+	}
+}
+
+func TestSelfDeploymentImagePropagatesAPIFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+
+	if _, err := selfDeploymentImage(); err == nil {
+		t.Fatal("an API failure must propagate")
+	}
+}
+
+// ---- SelfDeploymentImage (memoised wrapper) ----
+
+// The result is cached so the hub does not GET its own Deployment on every
+// dashboard poll.
+func TestSelfDeploymentImageIsMemoised(t *testing.T) {
+	resetSelfImageCache(t)
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Write([]byte(deploymentJSON("ghcr.io/kubestellar/hive-hub:cached")))
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+
+	first := SelfDeploymentImage()
+	second := SelfDeploymentImage()
+	if first != "ghcr.io/kubestellar/hive-hub:cached" || second != first {
+		t.Fatalf("image = %q / %q", first, second)
+	}
+	if calls != 1 {
+		t.Fatalf("want 1 API call thanks to the cache, got %d", calls)
+	}
+}
+
+// A failed lookup must be cached as "" rather than retried on every call —
+// otherwise a broken RBAC grant produces an API request per dashboard poll.
+// It must also never return a stale-but-wrong image.
+func TestSelfDeploymentImageCachesFailureAsEmpty(t *testing.T) {
+	resetSelfImageCache(t)
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+
+	if got := SelfDeploymentImage(); got != "" {
+		t.Fatalf("a failed lookup must yield an empty image, got %q", got)
+	}
+	if got := SelfDeploymentImage(); got != "" {
+		t.Fatalf("second call = %q", got)
+	}
+	if calls != 1 {
+		t.Fatalf("a failure must be cached too, got %d API calls", calls)
+	}
+}
+
+// ---- hubRolloutFailureReason ----
+
+// The reason comes from the first waiting container state, so an operator sees
+// "ImagePullBackOff ..." rather than a generic failure.
+func TestHubRolloutFailureReasonReportsWaitingState(t *testing.T) {
+	dir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"echo ''\n" +
+		"echo 'ImagePullBackOff Back-off pulling image \"ghcr.io/kubestellar/hive-hub:target1\"'\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	s := bulkTestHub(t)
+	got := s.hubRolloutFailureReason()
+	if got == "" {
+		t.Fatal("a waiting container state must be reported")
+	}
+	if !strings.Contains(got, "ImagePullBackOff") {
+		t.Fatalf("reason should name the waiting reason, got %q", got)
+	}
+	// Leading blank lines must be skipped, not returned as the reason.
+	if got == " " || got == "" {
+		t.Fatalf("blank lines must be skipped, got %q", got)
+	}
+}
+
+// When kubectl cannot read pod status the reason must say so rather than
+// claiming everything is fine.
+func TestHubRolloutFailureReasonWhenKubectlFails(t *testing.T) {
+	dir := t.TempDir()
+	script := "#!/bin/sh\necho 'error: connection refused' >&2\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	s := bulkTestHub(t)
+	got := s.hubRolloutFailureReason()
+	if !strings.Contains(got, "could not read pod status") {
+		t.Fatalf("want an explicit unknown-reason message, got %q", got)
+	}
+}
+
+// No waiting container at all is still an explicit answer.
+func TestHubRolloutFailureReasonWhenNoWaitingState(t *testing.T) {
+	dir := t.TempDir()
+	script := "#!/bin/sh\necho ''\necho '  '\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	s := bulkTestHub(t)
+	got := s.hubRolloutFailureReason()
+	if !strings.Contains(got, "no waiting container state") {
+		t.Fatalf("want the no-waiting-state message, got %q", got)
+	}
+}

--- a/v2/pkg/hubbackup/backup_test.go
+++ b/v2/pkg/hubbackup/backup_test.go
@@ -65,10 +65,34 @@ func decodeTestKey(t *testing.T) []byte {
 }
 
 // TestLoadKeyRejectsUnset is the guard against silently writing plaintext.
+//
+// The assertion is deliberately on the MESSAGE, not merely on "an error
+// happened": an unset key also trips the hex/length checks further down, so a
+// test that accepts any error still passes when the explicit unset branch is
+// removed. The distinct message is what tells an operator their backup would
+// otherwise have been written unencrypted.
 func TestLoadKeyRejectsUnset(t *testing.T) {
 	t.Setenv(EnvBackupKey, "")
-	if _, err := LoadKey(); err == nil {
+	_, err := LoadKey()
+	if err == nil {
 		t.Fatal("expected error when HIVE_BACKUP_KEY is unset, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing to write an unencrypted backup") {
+		t.Fatalf("an unset key must be refused explicitly, not incidentally via a "+
+			"decode failure; got %v", err)
+	}
+}
+
+// Whitespace-only is the same hazard as unset: a Secret mounted with just a
+// newline must not be treated as a usable key.
+func TestLoadKeyRejectsWhitespaceOnly(t *testing.T) {
+	t.Setenv(EnvBackupKey, "   \n\t ")
+	_, err := LoadKey()
+	if err == nil {
+		t.Fatal("a whitespace-only key must be refused")
+	}
+	if !strings.Contains(err.Error(), "refusing to write an unencrypted backup") {
+		t.Fatalf("want the explicit unset refusal, got %v", err)
 	}
 }
 

--- a/v2/pkg/hubbackup/collect.go
+++ b/v2/pkg/hubbackup/collect.go
@@ -103,11 +103,19 @@ func (c ClusterTarget) kubectlArgs(args ...string) []string {
 	return append(out, args...)
 }
 
+// execCommandContext is the seam through which this package spawns kubectl.
+// Production always uses exec.CommandContext; tests swap in a helper-process
+// fake so the collectors can be exercised without a real cluster. Backup code
+// only ever READS, but a stray real kubectl in a test still authenticates with
+// the hub pod's ServiceAccount, so the substitution is a safety boundary as
+// much as a testability one.
+var execCommandContext = exec.CommandContext
+
 // run executes kubectl against this cluster and returns stdout.
 func (c ClusterTarget) run(args ...string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), kubectlTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "kubectl", c.kubectlArgs(args...)...)
+	cmd := execCommandContext(ctx, "kubectl", c.kubectlArgs(args...)...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -241,7 +249,7 @@ func (k KubectlSpokeCollector) collectOne(target ClusterTarget, id string, logge
 	script := buildSpokeReadScript()
 	ctx, cancel := context.WithTimeout(context.Background(), spokeExecTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "kubectl",
+	cmd := execCommandContext(ctx, "kubectl",
 		target.kubectlArgs("exec", "-n", ns, "-c", spokeContainer, pod, "--", "sh", "-c", script)...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/v2/pkg/hubbackup/collect_coverage_test.go
+++ b/v2/pkg/hubbackup/collect_coverage_test.go
@@ -1,0 +1,295 @@
+package hubbackup
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// spokeStream renders files the way buildSpokeReadScript's output looks coming
+// back over `kubectl exec`, so collectOne is driven through its real parser.
+func spokeStream(files map[string]string) string {
+	var sb strings.Builder
+	for name, content := range files {
+		fmt.Fprintf(&sb, "%s%s%s\n%s\n",
+			spokeStreamPrefix, name, spokeStreamDelim,
+			base64.StdEncoding.EncodeToString([]byte(content)))
+	}
+	return sb.String()
+}
+
+// ---- KubectlSpokeCollector.Collect / collectOne ----
+
+// A spoke whose pod is Evicted must be recorded as an error entry, NOT dropped:
+// losing the entry silently shrinks the fleet in the backup, which is how a
+// 50/50 backup became 49/50.
+func TestCollectEvictedSpokeIsRecordedNotDropped(t *testing.T) {
+	fakeKubectl(t, map[string]string{
+		// No Running pod: the field-selector query returns empty stdout.
+		"get pods -n " + spokeNamespacePrefix + "alpha": "",
+		"get pods -n " + spokeNamespacePrefix + "beta":  "beta-pod-1",
+		"exec -n " + spokeNamespacePrefix + "beta":      spokeStream(map[string]string{"hive.yaml.bak": "beta: config"}),
+	})
+
+	k := KubectlSpokeCollector{
+		Clusters: map[string]ClusterTarget{"c1": {ID: "c1", InCluster: true}},
+		Hives:    map[string]string{"alpha": "c1", "beta": "c1"},
+	}
+	got, err := k.Collect(quietLogger())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+
+	// Both hives must still be present in the returned set.
+	if len(got) != 2 {
+		t.Fatalf("want 2 spoke entries (no hive dropped), got %d: %+v", len(got), got)
+	}
+	byID := map[string]SpokeConfig{}
+	for _, sc := range got {
+		byID[sc.ID] = sc
+	}
+	alpha, ok := byID["alpha"]
+	if !ok {
+		t.Fatal("hive 'alpha' was dropped from the result set entirely")
+	}
+	if alpha.Err == "" {
+		t.Fatal("evicted-only spoke must carry an Err explaining the gap")
+	}
+	if !strings.Contains(alpha.Err, "no running pod") {
+		t.Errorf("Err should explain no running pod, got %q", alpha.Err)
+	}
+	beta := byID["beta"]
+	if beta.Err != "" {
+		t.Fatalf("healthy spoke should have no Err, got %q", beta.Err)
+	}
+	if string(beta.Files["hive.yaml.bak"]) != "beta: config" {
+		t.Errorf("healthy spoke content wrong: %q", beta.Files["hive.yaml.bak"])
+	}
+}
+
+// The pod query must filter to Running, otherwise an Evicted pod can be picked
+// by .items[0] and that hive's config is silently lost.
+func TestCollectRequestsOnlyRunningPods(t *testing.T) {
+	var seen string
+	fakeKubectl(t, map[string]string{"get pods": ""})
+	orig := execCommandContext
+	t.Cleanup(func() { execCommandContext = orig })
+	inner := execCommandContext
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		joined := strings.Join(args, " ")
+		if strings.Contains(joined, "get pods") {
+			seen = joined
+		}
+		return inner(ctx, name, args...)
+	}
+
+	k := KubectlSpokeCollector{
+		Clusters: map[string]ClusterTarget{"c1": {ID: "c1", InCluster: true}},
+		Hives:    map[string]string{"alpha": "c1"},
+	}
+	if _, err := k.Collect(quietLogger()); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if !strings.Contains(seen, "--field-selector=status.phase=Running") {
+		t.Fatalf("pod query must filter to Running pods, got %q", seen)
+	}
+}
+
+// A hive pointing at a cluster that is not in the Clusters map must still
+// appear, carrying the reason.
+func TestCollectUnknownClusterIsRecordedNotDropped(t *testing.T) {
+	fakeKubectl(t, map[string]string{})
+	k := KubectlSpokeCollector{
+		Clusters: map[string]ClusterTarget{"c1": {ID: "c1", InCluster: true}},
+		Hives:    map[string]string{"orphan": "does-not-exist"},
+	}
+	got, err := k.Collect(quietLogger())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(got))
+	}
+	if !strings.Contains(got[0].Err, "unknown cluster") {
+		t.Fatalf("want unknown-cluster error, got %q", got[0].Err)
+	}
+}
+
+// A spoke that returns hive.yaml but NOT hive.yaml.bak must be flagged: the
+// .bak file is the authoritative config, and a live spoke carries both with
+// DIFFERENT contents, so accepting hive.yaml backs up stale config.
+func TestCollectRejectsSpokeMissingAuthoritativeConfig(t *testing.T) {
+	fakeKubectl(t, map[string]string{
+		"get pods": "pod-1",
+		"exec":     spokeStream(map[string]string{"hive.yaml": "stale: true"}),
+	})
+	k := KubectlSpokeCollector{
+		Clusters: map[string]ClusterTarget{"c1": {ID: "c1", InCluster: true}},
+		Hives:    map[string]string{"alpha": "c1"},
+	}
+	got, _ := k.Collect(quietLogger())
+	if got[0].Err == "" {
+		t.Fatal("a spoke without hive.yaml.bak must be flagged, not accepted silently")
+	}
+	if !strings.Contains(got[0].Err, "hive.yaml.bak") {
+		t.Errorf("error should name hive.yaml.bak, got %q", got[0].Err)
+	}
+}
+
+// exec failure is tolerated per-spoke rather than aborting the fleet backup.
+func TestCollectExecFailureRecordedPerSpoke(t *testing.T) {
+	fakeKubectl(t, map[string]string{
+		"get pods": "pod-1",
+		"exec":     failMarker + "container not ready",
+	})
+	k := KubectlSpokeCollector{
+		Clusters: map[string]ClusterTarget{"c1": {ID: "c1", InCluster: true}},
+		Hives:    map[string]string{"alpha": "c1"},
+	}
+	got, err := k.Collect(quietLogger())
+	if err != nil {
+		t.Fatalf("one bad spoke must not fail the whole collection: %v", err)
+	}
+	if !strings.Contains(got[0].Err, "exec into") {
+		t.Fatalf("want exec error recorded, got %q", got[0].Err)
+	}
+}
+
+// Undecodable base64 in the stream must surface as a parse error on that spoke.
+func TestCollectParseFailureRecorded(t *testing.T) {
+	fakeKubectl(t, map[string]string{
+		"get pods": "pod-1",
+		"exec":     spokeStreamPrefix + "hive.yaml.bak" + spokeStreamDelim + "\n!!!not-base64!!!\n",
+	})
+	k := KubectlSpokeCollector{
+		Clusters: map[string]ClusterTarget{"c1": {ID: "c1", InCluster: true}},
+		Hives:    map[string]string{"alpha": "c1"},
+	}
+	got, _ := k.Collect(quietLogger())
+	if !strings.Contains(got[0].Err, "parse spoke stream") {
+		t.Fatalf("want parse error, got %q", got[0].Err)
+	}
+}
+
+// Results must be ordered deterministically so two runs of the same fleet
+// produce comparable manifests.
+func TestCollectIsDeterministicallyOrdered(t *testing.T) {
+	fakeKubectl(t, map[string]string{"get pods": ""})
+	k := KubectlSpokeCollector{
+		Clusters: map[string]ClusterTarget{"c1": {ID: "c1", InCluster: true}},
+		Hives:    map[string]string{"zeta": "c1", "alpha": "c1", "mid": "c1"},
+	}
+	got, _ := k.Collect(quietLogger())
+	var ids []string
+	for _, sc := range got {
+		ids = append(ids, sc.ID)
+	}
+	want := []string{"alpha", "mid", "zeta"}
+	for i := range want {
+		if ids[i] != want[i] {
+			t.Fatalf("spokes must be sorted by ID, got %v", ids)
+		}
+	}
+}
+
+// ---- KubectlSecretCollector ----
+
+func TestSecretCollectorCapturesAndStrips(t *testing.T) {
+	raw := `{"apiVersion":"v1","kind":"Secret","metadata":{"name":"hive-hub-secrets",` +
+		`"uid":"abc","resourceVersion":"991","creationTimestamp":"2020-01-01T00:00:00Z"},` +
+		`"data":{"k":"dg=="}}`
+	fakeKubectl(t, map[string]string{"get secret": raw})
+
+	k := KubectlSecretCollector{
+		Cluster:   ClusterTarget{ID: "hub", InCluster: true},
+		Namespace: "hive-hub",
+		Names:     []string{"hive-hub-secrets"},
+	}
+	items, err := k.Collect(quietLogger())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("want 1 secret, got %d", len(items))
+	}
+	body := string(items[0].JSON)
+	for _, noise := range []string{"resourceVersion", "uid", "creationTimestamp"} {
+		if strings.Contains(body, noise) {
+			t.Errorf("%s must be stripped so the secret re-applies to a new cluster", noise)
+		}
+	}
+	if !strings.Contains(body, `"data"`) {
+		t.Error("secret payload must be preserved")
+	}
+}
+
+// A missing TLS secret is survivable (cert-manager reissues); any OTHER missing
+// secret makes the archive unrestorable and must be fatal.
+func TestSecretCollectorTLSOptionalOthersFatal(t *testing.T) {
+	t.Run("tls missing is tolerated", func(t *testing.T) {
+		fakeKubectl(t, map[string]string{"get secret": failMarker + "NotFound"})
+		k := KubectlSecretCollector{
+			Cluster: ClusterTarget{ID: "hub", InCluster: true},
+			Names:   []string{"hive-hub-tls"},
+		}
+		if _, err := k.Collect(quietLogger()); err != nil {
+			t.Fatalf("missing TLS secret must not fail the backup: %v", err)
+		}
+	})
+
+	t.Run("oauth secret missing is fatal", func(t *testing.T) {
+		fakeKubectl(t, map[string]string{"get secret": failMarker + "NotFound"})
+		k := KubectlSecretCollector{
+			Cluster: ClusterTarget{ID: "hub", InCluster: true},
+			Names:   []string{"hive-hub-secrets"},
+		}
+		if _, err := k.Collect(quietLogger()); err == nil {
+			t.Fatal("a missing required secret must be fatal — the archive would not restore")
+		}
+	})
+}
+
+// Malformed JSON from kubectl must be an error, not a silently empty secret.
+func TestSecretCollectorRejectsMalformedJSON(t *testing.T) {
+	fakeKubectl(t, map[string]string{"get secret": "{not json"})
+	k := KubectlSecretCollector{
+		Cluster: ClusterTarget{ID: "hub", InCluster: true},
+		Names:   []string{"hive-hub-secrets"},
+	}
+	if _, err := k.Collect(quietLogger()); err == nil {
+		t.Fatal("malformed secret JSON must be rejected")
+	}
+}
+
+// Remote clusters must be addressed with their kubeconfig and context, or the
+// backup silently reads the WRONG cluster.
+func TestRemoteClusterFlagsReachRemoteCluster(t *testing.T) {
+	var seen string
+	fakeKubectl(t, map[string]string{"get pods": ""})
+	inner := execCommandContext
+	t.Cleanup(func() { execCommandContext = inner })
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		seen = strings.Join(args, " ")
+		return inner(ctx, name, args...)
+	}
+
+	k := KubectlSpokeCollector{
+		Clusters: map[string]ClusterTarget{"remote": {
+			ID: "remote", InCluster: false,
+			KubeconfigPath: "/etc/hive/kubeconfigs/vllm-d.yaml", Context: "vllm-d",
+		}},
+		Hives: map[string]string{"alpha": "remote"},
+	}
+	if _, err := k.Collect(quietLogger()); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if !strings.Contains(seen, "--kubeconfig /etc/hive/kubeconfigs/vllm-d.yaml") {
+		t.Errorf("remote cluster must be addressed via --kubeconfig, got %q", seen)
+	}
+	if !strings.Contains(seen, "--context vllm-d") {
+		t.Errorf("remote cluster must be addressed via --context, got %q", seen)
+	}
+}

--- a/v2/pkg/hubbackup/dr_roundtrip_test.go
+++ b/v2/pkg/hubbackup/dr_roundtrip_test.go
@@ -1,0 +1,423 @@
+package hubbackup
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fixedSpokeCollector returns a canned fleet without touching kubectl.
+type fixedSpokeCollector struct {
+	spokes []SpokeConfig
+	err    error
+}
+
+func (f fixedSpokeCollector) Collect(_ *slogLogger) ([]SpokeConfig, error) {
+	return f.spokes, f.err
+}
+
+// fixedSecretCollector returns canned Secrets.
+type fixedSecretCollector struct {
+	items []SecretItem
+	err   error
+}
+
+func (f fixedSecretCollector) Collect(_ *slogLogger) ([]SecretItem, error) {
+	return f.items, f.err
+}
+
+// ---- Full DR round trip ----
+
+// The end-to-end disaster-recovery path: seal -> verify -> open -> extract,
+// asserting the restored bytes are identical to what went in. This is the
+// scenario that runs after catastrophic loss of the hub.
+func TestDRRoundTripSealVerifyOpenExtract(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	key := decodeTestKey(t)
+
+	spokes := fixedSpokeCollector{spokes: []SpokeConfig{
+		{ID: "hosted-x", Cluster: "hive-oke", Files: map[string][]byte{
+			"hive.yaml.bak": []byte("project:\n  org: acme\n"),
+			"agents.json":   []byte(`{"scanner":{"enabled":true}}`),
+		}},
+	}}
+	secrets := fixedSecretCollector{items: []SecretItem{
+		{Name: "hive-hub-secrets", JSON: []byte(`{"kind":"Secret"}`)},
+	}}
+
+	sealed, man, err := Build(key, spokes, secrets, quietLogger())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	// 1. Sealed output must not contain plaintext.
+	if strings.Contains(string(sealed), "hmac.key") ||
+		strings.Contains(string(sealed), "project:") {
+		t.Fatal("sealed archive leaks plaintext — encryption did not apply")
+	}
+
+	// 2. Verify accepts the good archive and returns a populated manifest.
+	verified, err := Verify(key, sealed)
+	if err != nil {
+		t.Fatalf("Verify rejected a good archive: %v", err)
+	}
+	if len(verified.Files) == 0 {
+		t.Fatal("manifest has no files — Verify would be vacuous")
+	}
+
+	// 3. Extract restores real content to disk.
+	dest := t.TempDir()
+	extracted, err := Extract(key, sealed, dest)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if extracted == nil {
+		t.Fatal("Extract returned no manifest")
+	}
+
+	// The hub's crypto material must survive the round trip byte for byte:
+	// a corrupted hmac.key means every issued session token is invalid.
+	gotHMAC, err := os.ReadFile(filepath.Join(dest, "hub", "saas", "hmac.key"))
+	if err != nil {
+		t.Fatalf("hmac.key missing from restore: %v", err)
+	}
+	if string(gotHMAC) != strings.Repeat("k", 32) {
+		t.Fatalf("hmac.key corrupted through the round trip: %q", gotHMAC)
+	}
+
+	// The spoke's authoritative config must survive too.
+	gotSpoke, err := os.ReadFile(filepath.Join(dest, "spokes", "hosted-x", "hive.yaml.bak"))
+	if err != nil {
+		t.Fatalf("spoke config missing from restore: %v", err)
+	}
+	if string(gotSpoke) != "project:\n  org: acme\n" {
+		t.Fatalf("spoke config corrupted: %q", gotSpoke)
+	}
+
+	// The Secret that lives outside the PVC must be present, or the restored
+	// hub cannot authenticate anyone.
+	if _, err := os.ReadFile(filepath.Join(dest, "secrets", "hive-hub-secrets.json")); err != nil {
+		t.Fatalf("out-of-PVC Secret missing from restore: %v", err)
+	}
+
+	// Excluded scratch dirs must NOT be in the archive.
+	for _, excluded := range []string{"nous", "beads", "logs"} {
+		if _, err := os.Stat(filepath.Join(dest, "hub", excluded)); err == nil {
+			t.Errorf("scratch dir %q must be excluded from the backup", excluded)
+		}
+	}
+	_ = man
+}
+
+// ---- Negative: corruption MUST be rejected ----
+
+// This is the test that would have caught the manifest-serialized-before-digests
+// bug, where Verify passed while checking nothing. Every mutation below must be
+// rejected.
+func TestVerifyRejectsCorruptedArchive(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	key := decodeTestKey(t)
+
+	sealed, _, err := Build(key, nil, nil, quietLogger())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	t.Run("flipped ciphertext byte", func(t *testing.T) {
+		bad := append([]byte(nil), sealed...)
+		bad[len(bad)/2] ^= 0xFF
+		if _, err := Verify(key, bad); err == nil {
+			t.Fatal("a corrupted archive was accepted as valid")
+		}
+	})
+
+	t.Run("truncated archive", func(t *testing.T) {
+		bad := append([]byte(nil), sealed[:len(sealed)/2]...)
+		if _, err := Verify(key, bad); err == nil {
+			t.Fatal("a truncated archive was accepted as valid")
+		}
+	})
+
+	t.Run("flipped nonce", func(t *testing.T) {
+		bad := append([]byte(nil), sealed...)
+		bad[0] ^= 0x01
+		if _, err := Verify(key, bad); err == nil {
+			t.Fatal("a tampered nonce was accepted as valid")
+		}
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		if _, err := Verify(key, nil); err == nil {
+			t.Fatal("an empty archive was accepted as valid")
+		}
+	})
+}
+
+// Verify must fail when a file's bytes no longer match its manifest digest.
+// Rebuilding the archive with a mutated payload but the ORIGINAL manifest is
+// the precise shape of the silent-corruption bug.
+func TestVerifyDetectsDigestMismatch(t *testing.T) {
+	key := decodeTestKey(t)
+
+	// Build an archive by hand so the manifest can be desynced from content.
+	good := buildArchiveFixture(t, key, "hub/saas/hmac.key", []byte("original"), nil)
+	if _, err := Verify(key, good); err != nil {
+		t.Fatalf("fixture must verify clean first: %v", err)
+	}
+
+	// Same manifest digests, different file bytes.
+	tampered := buildArchiveFixture(t, key, "hub/saas/hmac.key", []byte("TAMPERED"),
+		func(m *Manifest) {
+			// Keep the digest of the ORIGINAL content.
+			for i := range m.Files {
+				if m.Files[i].Path == "hub/saas/hmac.key" {
+					m.Files[i].SHA256 = sha256Hex([]byte("original"))
+				}
+			}
+		})
+	if _, err := Verify(key, tampered); err == nil {
+		t.Fatal("Verify accepted a file whose bytes do not match its manifest digest")
+	}
+}
+
+// A manifest listing a file the archive does not contain must be rejected: a
+// restore would silently be missing it.
+func TestVerifyRejectsManifestListingMissingFile(t *testing.T) {
+	key := decodeTestKey(t)
+	bad := buildArchiveFixture(t, key, "hub/saas/hmac.key", []byte("x"),
+		func(m *Manifest) {
+			m.Files = append(m.Files, FileEntry{
+				Path: "hub/saas/absent.key", Size: 4, SHA256: sha256Hex([]byte("gone")),
+			})
+		})
+	_, err := Verify(key, bad)
+	if err == nil {
+		t.Fatal("Verify accepted a manifest listing a file not present in the archive")
+	}
+	if !strings.Contains(err.Error(), "absent.key") {
+		t.Errorf("error should name the missing file, got %v", err)
+	}
+	// "absent from the archive" and "present but corrupted" are different
+	// failures and must be reported differently: an operator restoring after a
+	// disaster needs to know which one they are looking at. Asserting only that
+	// the filename appears is satisfied by the checksum-mismatch message too.
+	if !strings.Contains(err.Error(), "does not contain it") {
+		t.Errorf("a missing file must be reported as missing, not as a checksum "+
+			"mismatch; got %v", err)
+	}
+}
+
+// An archive with no manifest at all must be rejected rather than treated as
+// trivially valid.
+func TestVerifyRejectsArchiveWithoutManifest(t *testing.T) {
+	key := decodeTestKey(t)
+	bad := buildArchiveFixtureNoManifest(t, key)
+	if _, err := Verify(key, bad); err == nil {
+		t.Fatal("an archive with no MANIFEST.json was accepted")
+	}
+}
+
+// A future format version must be refused rather than half-restored.
+func TestVerifyRejectsUnknownFormatVersion(t *testing.T) {
+	key := decodeTestKey(t)
+	bad := buildArchiveFixture(t, key, "hub/x", []byte("x"), func(m *Manifest) {
+		m.FormatVersion = backupFormatVersion + 99
+	})
+	_, err := Verify(key, bad)
+	if err == nil {
+		t.Fatal("an archive from a newer format version was accepted")
+	}
+	if !strings.Contains(err.Error(), "format version") {
+		t.Errorf("error should mention the format version, got %v", err)
+	}
+}
+
+// ---- Key handling ----
+
+// A wrong key must fail cleanly with a decrypt error, never return garbage.
+func TestVerifyWithWrongKeyFailsCleanly(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	sealed, _, err := Build(decodeTestKey(t), nil, nil, quietLogger())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	wrong := make([]byte, aesKeySize)
+	for i := range wrong {
+		wrong[i] = 0xAB
+	}
+	man, err := Verify(wrong, sealed)
+	if err == nil {
+		t.Fatal("a wrong key must not verify the archive")
+	}
+	if man != nil {
+		t.Fatal("a failed verification must not return a manifest")
+	}
+	if !strings.Contains(err.Error(), EnvBackupKey) {
+		t.Errorf("error should point the operator at %s, got %v", EnvBackupKey, err)
+	}
+}
+
+// Extract must refuse a corrupted archive rather than writing partial files to
+// disk — a half-restore is worse than a clean failure.
+func TestExtractRefusesCorruptedArchive(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	key := decodeTestKey(t)
+	sealed, _, err := Build(key, nil, nil, quietLogger())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	bad := append([]byte(nil), sealed...)
+	bad[len(bad)/2] ^= 0xFF
+
+	dest := t.TempDir()
+	if _, err := Extract(key, bad, dest); err == nil {
+		t.Fatal("Extract accepted a corrupted archive")
+	}
+	entries, _ := os.ReadDir(dest)
+	if len(entries) != 0 {
+		t.Fatalf("Extract wrote %d entries from a corrupted archive; "+
+			"verification must happen before any file is written", len(entries))
+	}
+}
+
+// Extract must run the FULL manifest verification before writing, not merely
+// rely on the GCM tag. A digest-mismatched archive is cryptographically valid
+// (Open succeeds) yet its content does not match the manifest, so only the
+// explicit Verify call rejects it. Without that call this restores silently
+// corrupted hub state.
+func TestExtractVerifiesDigestsNotJustGCMTag(t *testing.T) {
+	key := decodeTestKey(t)
+	bad := buildArchiveFixture(t, key, "hub/saas/hmac.key", []byte("TAMPERED"),
+		func(m *Manifest) {
+			m.Files[0].SHA256 = sha256Hex([]byte("original"))
+		})
+	// Precondition: the archive decrypts cleanly, so GCM alone cannot catch it.
+	if _, err := Open(key, bad); err != nil {
+		t.Fatalf("fixture must be GCM-valid for this test to mean anything: %v", err)
+	}
+
+	dest := t.TempDir()
+	if _, err := Extract(key, bad, dest); err == nil {
+		t.Fatal("Extract accepted an archive whose content does not match its manifest")
+	}
+	if entries, _ := os.ReadDir(dest); len(entries) != 0 {
+		t.Fatalf("Extract wrote %d entries from an unverified archive", len(entries))
+	}
+}
+
+// ---- Build: spoke degradation must not shrink the fleet ----
+
+// A spoke reported as failed must appear in SpokeErrors, and the healthy ones
+// must still be captured. Silently dropping a failed spoke is how a 50/50
+// backup became 49/50.
+func TestBuildRecordsSpokeErrorsWithoutLosingHealthySpokes(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	key := decodeTestKey(t)
+
+	spokes := fixedSpokeCollector{spokes: []SpokeConfig{
+		{ID: "healthy-1", Files: map[string][]byte{"hive.yaml.bak": []byte("a")}},
+		{ID: "evicted-1", Err: "no running pod in hive-hosted-evicted-1"},
+		{ID: "healthy-2", Files: map[string][]byte{"hive.yaml.bak": []byte("b")}},
+	}}
+
+	_, man, err := Build(key, spokes, nil, quietLogger())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(man.SpokeIDs) != 2 {
+		t.Fatalf("want 2 captured spokes, got %v", man.SpokeIDs)
+	}
+	if _, ok := man.SpokeErrors["evicted-1"]; !ok {
+		t.Fatal("the failed spoke must be recorded in SpokeErrors so the operator " +
+			"learns about the gap from the archive itself")
+	}
+	// Total accounted-for hives must equal the input fleet size.
+	if len(man.SpokeIDs)+len(man.SpokeErrors) != 3 {
+		t.Fatalf("a hive was lost: %d captured + %d errors != 3",
+			len(man.SpokeIDs), len(man.SpokeErrors))
+	}
+}
+
+// A collector-level failure must be recorded, not silently swallowed.
+func TestBuildRecordsCollectorFailure(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	_, man, err := Build(decodeTestKey(t),
+		fixedSpokeCollector{err: errFake}, nil, quietLogger())
+	if err != nil {
+		t.Fatalf("a collector error must not abort the hub backup: %v", err)
+	}
+	if _, ok := man.SpokeErrors["_collector"]; !ok {
+		t.Fatal("collector-level failure must be recorded in SpokeErrors")
+	}
+}
+
+// Secrets are required for a restorable hub, so a Secret failure IS fatal —
+// the opposite policy from spokes, and worth pinning down.
+func TestBuildFailsWhenSecretCollectionFails(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	_, _, err := Build(decodeTestKey(t), nil,
+		fixedSecretCollector{err: errFake}, quietLogger())
+	if err == nil {
+		t.Fatal("a Secret collection failure must be fatal: the archive would not restore")
+	}
+}
+
+// ---- Manifest / naming ----
+
+func TestArchiveNameIsSortableUTC(t *testing.T) {
+	older := ArchiveName(mustTime(t, "2026-07-01T00:00:00Z"))
+	newer := ArchiveName(mustTime(t, "2026-07-31T00:00:00Z"))
+	if !(older < newer) {
+		t.Fatalf("archive names must sort chronologically: %q !< %q", older, newer)
+	}
+	if !strings.HasPrefix(older, "hive-hub-backup-") {
+		t.Errorf("unexpected prefix: %q", older)
+	}
+	if !strings.HasSuffix(older, ".tar.gz.enc") {
+		t.Errorf("unexpected suffix: %q", older)
+	}
+}
+
+// ArchiveName must render in UTC regardless of the local zone, or archives
+// taken from different zones sort incorrectly against each other.
+func TestArchiveNameIsUTCRegardlessOfLocalZone(t *testing.T) {
+	instant := mustTime(t, "2026-07-31T23:30:00Z")
+	want := ArchiveName(instant)
+	got := ArchiveName(instant.In(fixedZone(t, -8*3600)))
+	if got != want {
+		t.Fatalf("ArchiveName must normalise to UTC: %q vs %q", got, want)
+	}
+}
+
+func TestManifestSurvivesJSONRoundTrip(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	_, man, err := Build(decodeTestKey(t), nil, nil, quietLogger())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	raw, err := json.Marshal(man)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back Manifest
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatal(err)
+	}
+	if len(back.Files) != len(man.Files) {
+		t.Fatalf("file list lost in JSON round trip: %d vs %d", len(back.Files), len(man.Files))
+	}
+	if back.FormatVersion != man.FormatVersion {
+		t.Error("format version lost in JSON round trip")
+	}
+}

--- a/v2/pkg/hubbackup/edge_cases2_test.go
+++ b/v2/pkg/hubbackup/edge_cases2_test.go
@@ -1,0 +1,241 @@
+package hubbackup
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Run's spoke+secret path: with collectors enabled, the archive must contain
+// both, proving the wiring in Run (not just Build) is correct.
+func TestRunWithSpokesAndSecretsPopulatesArchive(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	t.Setenv(EnvBackupKey, testKey)
+	t.Setenv(EnvHubNamespace, "hive-hub")
+
+	secretJSON := `{"apiVersion":"v1","kind":"Secret","metadata":{"name":"s"},"data":{"k":"dg=="}}`
+	fakeKubectl(t, map[string]string{
+		"get secret": secretJSON,
+		"get pods":   "spoke-pod-1",
+		"exec":       spokeStream(map[string]string{"hive.yaml.bak": "project: acme"}),
+	})
+
+	out := filepath.Join(t.TempDir(), "b.enc")
+	man, _, err := Run(Options{LocalOnly: true, LocalPath: out}, quietLogger())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(man.SpokeIDs) != 1 || man.SpokeIDs[0] != "hosted-x" {
+		t.Fatalf("spoke not captured through Run: %v", man.SpokeIDs)
+	}
+	if len(man.SecretNames) == 0 {
+		t.Fatal("Secrets not captured through Run — the archive is not restorable")
+	}
+
+	// The spoke's config must really be inside the sealed archive.
+	sealed, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dest := t.TempDir()
+	if _, err := Extract(decodeTestKey(t), sealed, dest); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "spokes", "hosted-x", "hive.yaml.bak"))
+	if err != nil {
+		t.Fatalf("spoke config not in archive: %v", err)
+	}
+	if string(got) != "project: acme" {
+		t.Fatalf("spoke config = %q", got)
+	}
+}
+
+// A Secret collection failure must abort Run: an archive without the
+// out-of-PVC Secrets cannot restore a working hub.
+func TestRunFailsWhenSecretCollectionFails(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	t.Setenv(EnvBackupKey, testKey)
+	fakeKubectl(t, map[string]string{"get secret": failMarker + "Forbidden"})
+
+	out := filepath.Join(t.TempDir(), "b.enc")
+	_, _, err := Run(Options{LocalOnly: true, LocalPath: out, SkipSpokes: true}, quietLogger())
+	if err == nil {
+		t.Fatal("a Secret collection failure must abort the backup")
+	}
+	if _, statErr := os.Stat(out); statErr == nil {
+		t.Fatal("no archive may be written when Secrets could not be captured")
+	}
+}
+
+// If the read-back after upload returns different bytes, Run must fail: this is
+// the check that catches a truncated or partially-written upload.
+func TestRunFailsWhenReadBackIsCorrupt(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	t.Setenv(EnvBackupKey, testKey)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == ociNamespacePath {
+			w.Write([]byte(`"testnamespace"`))
+			return
+		}
+		switch r.Method {
+		case http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			// Read-back returns corrupted content.
+			w.Write([]byte("this is not the archive that was uploaded"))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	setOCIEnv(t)
+	t.Setenv(envOCIEndpoint, srv.URL)
+	t.Setenv(EnvBucket, "backups")
+
+	_, _, err := Run(Options{SkipSpokes: true, SkipSecrets: true}, quietLogger())
+	if err == nil {
+		t.Fatal("a corrupt read-back must fail the run")
+	}
+	if !strings.Contains(err.Error(), "verification") && !strings.Contains(err.Error(), "read-back") {
+		t.Errorf("error should identify the read-back/verification step, got %v", err)
+	}
+}
+
+// A failed read-back request (not just corrupt content) must also fail Run.
+func TestRunFailsWhenReadBackRequestFails(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	t.Setenv(EnvBackupKey, testKey)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == ociNamespacePath {
+			w.Write([]byte(`"testnamespace"`))
+			return
+		}
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	setOCIEnv(t)
+	t.Setenv(envOCIEndpoint, srv.URL)
+	t.Setenv(EnvBucket, "backups")
+
+	_, _, err := Run(Options{SkipSpokes: true, SkipSecrets: true}, quietLogger())
+	if err == nil {
+		t.Fatal("an archive that cannot be read back must fail the run")
+	}
+}
+
+// A write to an unwritable local path must be reported.
+func TestRunFailsWhenLocalPathUnwritable(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	t.Setenv(EnvBackupKey, testKey)
+
+	// A path whose parent does not exist.
+	out := filepath.Join(t.TempDir(), "no-such-dir", "b.enc")
+	if _, _, err := Run(Options{
+		LocalOnly: true, LocalPath: out, SkipSpokes: true, SkipSecrets: true,
+	}, quietLogger()); err == nil {
+		t.Fatal("an unwritable archive path must be reported")
+	}
+}
+
+// Non-regular files (symlinks, sockets) must be skipped rather than archived as
+// their target's content or causing an error.
+func TestAddTreeSkipsNonRegularFiles(t *testing.T) {
+	dir := t.TempDir()
+	saas := filepath.Join(dir, saasSubdir)
+	mustWrite(t, filepath.Join(saas, "real.json"), `{"real":1}`)
+	if err := os.Symlink(filepath.Join(saas, "real.json"), filepath.Join(saas, "link.json")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	t.Setenv(EnvDataDir, dir)
+
+	_, man, err := Build(decodeTestKey(t), nil, nil, quietLogger())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	for _, f := range man.Files {
+		if strings.HasSuffix(f.Path, "link.json") {
+			t.Fatal("a symlink must not be archived as a regular file")
+		}
+	}
+	var sawReal bool
+	for _, f := range man.Files {
+		if strings.HasSuffix(f.Path, "real.json") {
+			sawReal = true
+		}
+	}
+	if !sawReal {
+		t.Fatal("the real file should still be archived")
+	}
+}
+
+// The exported Builder must skip non-regular files too.
+func TestExportedAddTreeSkipsNonRegularFiles(t *testing.T) {
+	src := t.TempDir()
+	mustWrite(t, filepath.Join(src, "real.json"), `{"real":1}`)
+	if err := os.Symlink(filepath.Join(src, "real.json"), filepath.Join(src, "link.json")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	b := NewBuilder()
+	if err := b.AddTree(src, "spoke", nil, quietLogger()); err != nil {
+		t.Fatalf("AddTree: %v", err)
+	}
+	key := decodeTestKey(t)
+	sealed, err := b.Finish(key, &Manifest{FormatVersion: FormatVersion()}, 0)
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	man, err := Verify(key, sealed)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	for _, f := range man.Files {
+		if strings.HasSuffix(f.Path, "link.json") {
+			t.Fatal("Builder.AddTree archived a symlink")
+		}
+	}
+}
+
+// A directory tree that does not exist must not abort the exported builder.
+func TestExportedAddTreeToleratesMissingSource(t *testing.T) {
+	b := NewBuilder()
+	err := b.AddTree(filepath.Join(t.TempDir(), "absent"), "spoke", nil, quietLogger())
+	if err != nil {
+		t.Fatalf("a missing source tree must be tolerated, got %v", err)
+	}
+}
+
+// Build must record the excluded-directory policy correctly even when those
+// directories are large — the archive must not balloon with scratch data.
+func TestBuildExcludesScratchDirectoriesFromManifest(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+
+	_, man, err := Build(decodeTestKey(t), nil, nil, quietLogger())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	for _, f := range man.Files {
+		for _, excluded := range []string{"/nous/", "/beads/", "/logs/", "/home/"} {
+			if strings.Contains(f.Path, excluded) {
+				t.Errorf("scratch path %q must be excluded from the archive", f.Path)
+			}
+		}
+	}
+}

--- a/v2/pkg/hubbackup/edge_cases_test.go
+++ b/v2/pkg/hubbackup/edge_cases_test.go
@@ -1,0 +1,284 @@
+package hubbackup
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ---- LoadKey / Seal / Open edges ----
+
+// A key of the right length but wrong hex must be rejected, and the error must
+// tell the operator what shape is expected.
+func TestLoadKeyRejectsNonHex(t *testing.T) {
+	t.Setenv(EnvBackupKey, strings.Repeat("z", aesKeySize*2))
+	_, err := LoadKey()
+	if err == nil {
+		t.Fatal("non-hex key must be rejected")
+	}
+	if !strings.Contains(err.Error(), "hex") {
+		t.Errorf("error should mention hex encoding, got %v", err)
+	}
+}
+
+// Surrounding whitespace (a trailing newline from a Secret mount) must not
+// break key loading.
+func TestLoadKeyToleratesSurroundingWhitespace(t *testing.T) {
+	t.Setenv(EnvBackupKey, "  "+testKey+"\n")
+	key, err := LoadKey()
+	if err != nil {
+		t.Fatalf("a key with surrounding whitespace must load: %v", err)
+	}
+	if len(key) != aesKeySize {
+		t.Fatalf("key length = %d, want %d", len(key), aesKeySize)
+	}
+}
+
+// Seal must reject a key that is not AES-256, rather than silently using a
+// weaker cipher.
+func TestSealRejectsWrongKeySize(t *testing.T) {
+	if _, err := Seal([]byte("tooshort"), []byte("data")); err == nil {
+		t.Fatal("a short key must be rejected by Seal")
+	}
+}
+
+func TestOpenRejectsWrongKeySize(t *testing.T) {
+	if _, err := Open([]byte("tooshort"), []byte("data")); err == nil {
+		t.Fatal("a short key must be rejected by Open")
+	}
+}
+
+// Two seals of identical plaintext must differ: a reused nonce would leak
+// information across archives.
+func TestSealUsesFreshNoncePerCall(t *testing.T) {
+	key := decodeTestKey(t)
+	plaintext := []byte("identical plaintext")
+	a, err := Seal(key, plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := Seal(key, plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(a) == string(b) {
+		t.Fatal("two seals of the same plaintext are byte-identical — the nonce is reused")
+	}
+	// Both must still decrypt to the original.
+	for _, sealed := range [][]byte{a, b} {
+		got, err := Open(key, sealed)
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		if string(got) != string(plaintext) {
+			t.Fatalf("round trip corrupted: %q", got)
+		}
+	}
+}
+
+// Data shorter than a GCM nonce must be rejected with a clear message rather
+// than panicking on a slice bound.
+func TestOpenRejectsUndersizedCiphertext(t *testing.T) {
+	_, err := Open(decodeTestKey(t), []byte{1, 2, 3})
+	if err == nil {
+		t.Fatal("ciphertext shorter than the nonce must be rejected")
+	}
+	if !strings.Contains(err.Error(), "too short") {
+		t.Errorf("error should say the ciphertext is too short, got %v", err)
+	}
+}
+
+// ---- decodeBase64 ----
+
+// Shell `base64` wraps output; the decoder must tolerate embedded whitespace.
+func TestDecodeBase64ToleratesWrappedOutput(t *testing.T) {
+	original := []byte("some spoke configuration content that wraps")
+	encoded := base64.StdEncoding.EncodeToString(original)
+	wrapped := encoded[:10] + "\n" + encoded[10:20] + "\r\n  " + encoded[20:]
+
+	got, err := decodeBase64(wrapped)
+	if err != nil {
+		t.Fatalf("wrapped base64 must decode: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("decoded content differs: %q", got)
+	}
+}
+
+func TestDecodeBase64RejectsGarbage(t *testing.T) {
+	if _, err := decodeBase64("!!!!not base64!!!!"); err == nil {
+		t.Fatal("invalid base64 must be rejected")
+	}
+}
+
+// ---- parseSpokeStream ----
+
+// A stream with no markers yields no files rather than one anonymous blob.
+func TestParseSpokeStreamIgnoresUnmarkedOutput(t *testing.T) {
+	files, err := parseSpokeStream([]byte("some stray stderr\nmore noise\n"))
+	if err != nil {
+		t.Fatalf("unmarked output must not error: %v", err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("unmarked output must produce no files, got %v", files)
+	}
+}
+
+// Multiple files in one stream must all be recovered — a spoke costs one exec,
+// so a parser that stops after the first file silently loses the rest.
+func TestParseSpokeStreamRecoversEveryFile(t *testing.T) {
+	stream := spokeStream(map[string]string{
+		"hive.yaml.bak": "config-a",
+		"agents.json":   "config-b",
+		"app-key.pem":   "config-c",
+	})
+	files, err := parseSpokeStream([]byte(stream))
+	if err != nil {
+		t.Fatalf("parseSpokeStream: %v", err)
+	}
+	if len(files) != 3 {
+		t.Fatalf("want 3 files, got %d: %v", len(files), keysOfBytes(files))
+	}
+	if string(files["hive.yaml.bak"]) != "config-a" {
+		t.Errorf("hive.yaml.bak = %q", files["hive.yaml.bak"])
+	}
+	if string(files["app-key.pem"]) != "config-c" {
+		t.Errorf("app-key.pem = %q", files["app-key.pem"])
+	}
+}
+
+// ---- buildSpokeReadScript ----
+
+// The script must read hive.yaml.bak (authoritative) — a live spoke has both
+// hive.yaml and hive.yaml.bak with DIFFERENT content, so reading the wrong one
+// silently backs up stale config.
+func TestSpokeReadScriptPrefersAuthoritativeConfig(t *testing.T) {
+	script := buildSpokeReadScript()
+	if !strings.Contains(script, "/data/hive.yaml.bak") {
+		t.Fatal("the read script must capture /data/hive.yaml.bak")
+	}
+	// It must also glob App keys, whose filenames vary per cluster.
+	if !strings.Contains(script, spokeKeyGlob) {
+		t.Errorf("the read script must glob GitHub App keys (%s)", spokeKeyGlob)
+	}
+	// Every wanted file must be guarded by an existence test so a missing file
+	// does not abort the whole exec.
+	if !strings.Contains(script, "if [ -f") {
+		t.Error("the script must test for file existence before reading")
+	}
+}
+
+// ---- Extract edges ----
+
+// An absolute path in the archive must be refused before anything is written.
+func TestExtractRejectsAbsolutePaths(t *testing.T) {
+	key := decodeTestKey(t)
+	sealed := buildArchiveFixture(t, key, "/etc/passwd", []byte("root:x:0:0"), nil)
+	dest := t.TempDir()
+	if _, err := Extract(key, sealed, dest); err == nil {
+		t.Fatal("an absolute archive path must be refused")
+	}
+}
+
+// Extract must create intermediate directories rather than failing on a deep
+// path.
+func TestExtractCreatesNestedDirectories(t *testing.T) {
+	key := decodeTestKey(t)
+	sealed := buildArchiveFixture(t, key, "hub/saas/app-keys/deep/nested.pem",
+		[]byte("keymaterial"), nil)
+	dest := t.TempDir()
+	if _, err := Extract(key, sealed, dest); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "hub", "saas", "app-keys", "deep", "nested.pem"))
+	if err != nil {
+		t.Fatalf("nested file not restored: %v", err)
+	}
+	if string(got) != "keymaterial" {
+		t.Fatalf("content = %q", got)
+	}
+}
+
+// ---- ObjectStore edges ----
+
+// A malformed list payload must error rather than silently reporting an empty
+// bucket, which would make Prune a no-op and VerifyLatest claim "no archives".
+func TestObjectStoreListRejectsMalformedPayload(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("{not json"))
+	}))
+	t.Cleanup(srv.Close)
+	store := newTestStore(t, srv.URL)
+
+	if _, err := store.List(); err == nil {
+		t.Fatal("a malformed list payload must be an error, not an empty bucket")
+	}
+}
+
+// A malformed namespace payload must error.
+func TestResolveNamespaceRejectsMalformedPayload(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("{not a json string"))
+	}))
+	t.Cleanup(srv.Close)
+	store := newTestStore(t, srv.URL)
+
+	if _, err := store.resolveNamespace(); err == nil {
+		t.Fatal("a malformed namespace payload must be an error")
+	}
+}
+
+// A delete failure during prune must be logged and skipped, not abort the run:
+// pruning is best-effort cleanup, and failing it must not fail the backup.
+func TestPruneContinuesPastDeleteFailure(t *testing.T) {
+	var deletes int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/o") {
+			w.Write([]byte(`{"objects":[
+				{"name":"hive-hub-backup-20260101T000000Z.tar.gz.enc"},
+				{"name":"hive-hub-backup-20260102T000000Z.tar.gz.enc"},
+				{"name":"hive-hub-backup-20260731T000000Z.tar.gz.enc"}]}`))
+			return
+		}
+		if r.Method == http.MethodDelete {
+			deletes++
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	store := newTestStore(t, srv.URL)
+
+	if err := store.Prune(1, quietLogger()); err != nil {
+		t.Fatalf("a failed delete must not fail the prune: %v", err)
+	}
+	// Both over-retention archives must have been attempted.
+	if deletes != 2 {
+		t.Fatalf("want 2 delete attempts despite failures, got %d", deletes)
+	}
+}
+
+// A List failure must propagate out of Prune — pruning against an unknown
+// object set could otherwise delete the wrong things.
+func TestPruneFailsWhenListFails(t *testing.T) {
+	srv := newStatusServer(t, 500)
+	store := newTestStore(t, srv.URL)
+	if err := store.Prune(1, quietLogger()); err == nil {
+		t.Fatal("Prune must fail when the bucket cannot be listed")
+	}
+}
+
+// Get on a missing object must be an error, not empty bytes that would then
+// "verify" as a corrupt archive with a confusing message.
+func TestObjectStoreGetMissingObject(t *testing.T) {
+	srv, _ := ociMock(t, map[string][]byte{})
+	store := newTestStore(t, srv.URL)
+	if _, err := store.Get("does-not-exist"); err == nil {
+		t.Fatal("Get on a missing object must error")
+	}
+}

--- a/v2/pkg/hubbackup/fixture_test.go
+++ b/v2/pkg/hubbackup/fixture_test.go
@@ -1,0 +1,219 @@
+package hubbackup
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// slogLogger aliases *slog.Logger so the fixed collectors can implement the
+// package's collector interfaces without importing slog at every use site.
+type slogLogger = slog.Logger
+
+// errFake is a sentinel used where the specific error value is irrelevant.
+var errFake = errors.New("simulated failure")
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	ts, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ts
+}
+
+func fixedZone(t *testing.T, offsetSeconds int) *time.Location {
+	t.Helper()
+	return time.FixedZone("TEST", offsetSeconds)
+}
+
+// buildArchiveFixture assembles a sealed archive containing exactly one file
+// plus a manifest, applying mutate to the manifest before it is written. This
+// lets a test desynchronise the manifest from the actual bytes — the shape of
+// the bug where Verify passed while checking nothing.
+func buildArchiveFixture(t *testing.T, key []byte, path string, content []byte,
+	mutate func(*Manifest)) []byte {
+	t.Helper()
+
+	var raw strings.Builder
+	gz := gzip.NewWriter(&raw)
+	tw := tar.NewWriter(gz)
+
+	writeFile := func(name string, body []byte) {
+		hdr := &tar.Header{Name: name, Mode: 0o600, Size: int64(len(body)), ModTime: time.Now()}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(body); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeFile(path, content)
+
+	man := &Manifest{
+		FormatVersion: backupFormatVersion,
+		CreatedAt:     time.Now().UTC(),
+		Files: []FileEntry{{
+			Path: path, Size: int64(len(content)), SHA256: sha256Hex(content),
+		}},
+	}
+	if mutate != nil {
+		mutate(man)
+	}
+	manJSON, err := json.MarshalIndent(man, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(manifestName, manJSON)
+
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	sealed, err := Seal(key, []byte(raw.String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sealed
+}
+
+// buildArchiveFixtureNoManifest produces a well-formed archive that omits
+// MANIFEST.json entirely.
+func buildArchiveFixtureNoManifest(t *testing.T, key []byte) []byte {
+	t.Helper()
+	var raw strings.Builder
+	gz := gzip.NewWriter(&raw)
+	tw := tar.NewWriter(gz)
+
+	body := []byte("orphan")
+	hdr := &tar.Header{Name: "hub/orphan", Mode: 0o600, Size: int64(len(body)), ModTime: time.Now()}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	sealed, err := Seal(key, []byte(raw.String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sealed
+}
+
+// testPKCS8KeyPEM generates a throwaway RSA key in PKCS8 PEM form. Real
+// oci-api-key Secrets carry either PKCS1 or PKCS8, so both must parse.
+func testPKCS8KeyPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+}
+
+// testED25519KeyPEM produces a valid PKCS8 key that is NOT RSA, to prove the
+// non-RSA rejection path is real rather than a parse failure.
+func testED25519KeyPEM(t *testing.T) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+}
+
+// newStatusServer always answers with the given status code.
+func newStatusServer(t *testing.T, code int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(code)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newNamespaceThenStatusServer resolves the namespace successfully, then fails
+// every subsequent request — the shape of "credentials work, upload denied".
+func newNamespaceThenStatusServer(t *testing.T, code int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == ociNamespacePath {
+			json.NewEncoder(w).Encode("testnamespace")
+			return
+		}
+		w.WriteHeader(code)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// chmodUnreadable removes all permissions from path. Returns an error when the
+// platform or a root test runner makes that impossible.
+func chmodUnreadable(path string) error {
+	if err := os.Chmod(path, 0o000); err != nil {
+		return err
+	}
+	if f, err := os.Open(path); err == nil {
+		f.Close()
+		return errors.New("file is still readable (running as root?)")
+	}
+	return nil
+}
+
+// keysOf returns a map's keys, for readable failure messages.
+func keysOf(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// keysOfBytes returns a file map's keys, for readable failure messages.
+func keysOfBytes(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/v2/pkg/hubbackup/main_test.go
+++ b/v2/pkg/hubbackup/main_test.go
@@ -1,0 +1,116 @@
+package hubbackup
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestMain isolates the hubbackup test suite from real clusters and the real
+// internet.
+//
+// This package shells out to kubectl (KubectlSecretCollector,
+// KubectlSpokeCollector) and talks to OCI Object Storage. Backup code only
+// READS, but a stray real kubectl still authenticates with the hub pod's
+// ServiceAccount when the suite runs inside a hive pod — the same exposure that
+// produced ~196 stray namespaces on live clusters and drove TestMain in
+// pkg/hub (#2287).
+//
+// Two guards, matching that precedent:
+//   - Kubernetes service-account env vars are cleared and KUBECONFIG is pointed
+//     at /dev/null, so a kubectl that escapes the execCommandContext seam has no
+//     cluster to reach.
+//   - The default HTTP transport refuses any non-loopback dial, so an
+//     ObjectStore built without endpointOverride fails loudly instead of
+//     reaching OCI.
+func TestMain(m *testing.M) {
+	os.Unsetenv("KUBERNETES_SERVICE_HOST")
+	os.Unsetenv("KUBERNETES_SERVICE_PORT")
+	os.Setenv("KUBECONFIG", os.DevNull)
+	for _, v := range []string{"HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"} {
+		os.Unsetenv(v)
+	}
+
+	tr, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		panic("hubbackup TestMain: http.DefaultTransport is not *http.Transport")
+	}
+	guarded := tr.Clone()
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	guarded.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, _, err := net.SplitHostPort(addr)
+		if err != nil {
+			host = addr
+		}
+		ip := net.ParseIP(host)
+		if !strings.EqualFold(host, "localhost") && (ip == nil || !ip.IsLoopback()) {
+			return nil, fmt.Errorf(
+				"hubbackup tests must not reach the network: blocked dial to %q; "+
+					"set ObjectStore.endpointOverride to an httptest server", addr)
+		}
+		return dialer.DialContext(ctx, network, addr)
+	}
+	http.DefaultTransport = guarded
+	http.DefaultClient.Transport = guarded
+
+	os.Exit(m.Run())
+}
+
+// fakeKubectl installs a stub for execCommandContext that routes every kubectl
+// invocation back into this test binary (the standard Go helper-process
+// pattern). script maps a substring of the joined argv to the stdout the fake
+// should emit; an entry whose value begins with failMarker makes the fake exit
+// non-zero with the remainder as stderr.
+//
+// Matching on a substring rather than the exact argv keeps tests readable while
+// still asserting the real command shape — the cluster-selection flags built by
+// kubectlArgs are part of the string being matched.
+func fakeKubectl(t *testing.T, script map[string]string) {
+	t.Helper()
+	orig := execCommandContext
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		joined := name + " " + strings.Join(args, " ")
+		out, fail := "", ""
+		for pattern, result := range script {
+			if strings.Contains(joined, pattern) {
+				if strings.HasPrefix(result, failMarker) {
+					fail = strings.TrimPrefix(result, failMarker)
+				} else {
+					out = result
+				}
+				break
+			}
+		}
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperKubectl", "--")
+		cmd.Env = append(os.Environ(),
+			"GO_HELPER_KUBECTL=1",
+			"GO_HELPER_STDOUT="+out,
+			"GO_HELPER_FAIL="+fail,
+		)
+		return cmd
+	}
+	t.Cleanup(func() { execCommandContext = orig })
+}
+
+// failMarker prefixes a fakeKubectl script value to mean "exit non-zero".
+const failMarker = "\x00FAIL\x00"
+
+// TestHelperKubectl is not a real test: it is the child process spawned by
+// fakeKubectl. It prints the scripted stdout and exits with the scripted code.
+func TestHelperKubectl(t *testing.T) {
+	if os.Getenv("GO_HELPER_KUBECTL") != "1" {
+		t.Skip("helper process; not run directly")
+	}
+	if msg := os.Getenv("GO_HELPER_FAIL"); msg != "" {
+		fmt.Fprint(os.Stderr, msg)
+		os.Exit(1)
+	}
+	fmt.Fprint(os.Stdout, os.Getenv("GO_HELPER_STDOUT"))
+	os.Exit(0)
+}

--- a/v2/pkg/hubbackup/objectstore.go
+++ b/v2/pkg/hubbackup/objectstore.go
@@ -80,6 +80,13 @@ const (
 // defaultOCIRegion is the region hosting the hub's tenancy. Non-secret.
 const defaultOCIRegion = "us-ashburn-1"
 
+// envOCIEndpoint redirects Object Storage requests away from the real regional
+// host. TEST SEAM ONLY — it is never set in production, and TestMain's
+// non-loopback dial guard means a test that forgets it cannot reach OCI either.
+// It exists so Run and VerifyLatest, which construct their own ObjectStore
+// internally, can be exercised end to end.
+const envOCIEndpoint = "HIVE_BACKUP_OCI_ENDPOINT"
+
 // ObjectStore uploads and lists encrypted archives in OCI Object Storage.
 type ObjectStore struct {
 	tenancy     string
@@ -90,6 +97,9 @@ type ObjectStore struct {
 	namespace   string
 	bucket      string
 	client      *http.Client
+	// endpointOverride redirects requests away from the real OCI host. Test
+	// seam only — see baseURL().
+	endpointOverride string
 }
 
 // NewObjectStore builds a client from environment credentials.
@@ -133,7 +143,8 @@ func NewObjectStore(bucket string) (*ObjectStore, error) {
 	os_ := &ObjectStore{
 		tenancy: tenancy, user: user, fingerprint: fingerprint,
 		privateKey: key, region: region, bucket: bucket,
-		client: &http.Client{Timeout: ociHTTPTimeout},
+		client:           &http.Client{Timeout: ociHTTPTimeout},
+		endpointOverride: strings.TrimSpace(os.Getenv(envOCIEndpoint)),
 	}
 	ns, err := os_.resolveNamespace()
 	if err != nil {
@@ -145,6 +156,18 @@ func NewObjectStore(bucket string) (*ObjectStore, error) {
 
 func (o *ObjectStore) host() string {
 	return fmt.Sprintf(ociObjectStorageHost, o.region)
+}
+
+// baseURL returns the scheme+host requests are sent to. endpointOverride is a
+// TEST SEAM ONLY: it is never set in production, where every request goes to
+// the real regional Object Storage host. Tests point it at an httptest server
+// so Put/Get/List/Delete/Prune and the signing path can be exercised end to
+// end without OCI credentials or network access.
+func (o *ObjectStore) baseURL() string {
+	if o.endpointOverride != "" {
+		return o.endpointOverride
+	}
+	return "https://" + o.host()
 }
 
 // sign applies the OCI HTTP Signature to a request.
@@ -187,7 +210,7 @@ func (o *ObjectStore) sign(req *http.Request, body []byte) error {
 
 // do signs and executes a request, returning the response body.
 func (o *ObjectStore) do(method, path string, body []byte) ([]byte, error) {
-	url := "https://" + o.host() + path
+	url := o.baseURL() + path
 	var rdr io.Reader
 	if body != nil {
 		rdr = bytes.NewReader(body)

--- a/v2/pkg/hubbackup/objectstore_coverage_test.go
+++ b/v2/pkg/hubbackup/objectstore_coverage_test.go
@@ -1,0 +1,331 @@
+package hubbackup
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// testRSAKeyPEM generates a throwaway RSA key in PKCS1 PEM form. Generated per
+// run so no key material is committed.
+func testRSAKeyPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}))
+}
+
+// setOCIEnv installs a complete set of fake OCI credentials.
+func setOCIEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(envOCITenancy, "ocid1.tenancy.oc1..test")
+	t.Setenv(envOCIUser, "ocid1.user.oc1..test")
+	t.Setenv(envOCIFingerprint, "aa:bb:cc")
+	t.Setenv(envOCIPrivateKey, testRSAKeyPEM(t))
+	t.Setenv(envOCIRegion, "us-ashburn-1")
+}
+
+// ociMock serves the Object Storage endpoints against an in-memory bucket.
+func ociMock(t *testing.T, objects map[string][]byte) (*httptest.Server, *[]string) {
+	t.Helper()
+	var methods []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		methods = append(methods, r.Method+" "+r.URL.Path)
+
+		// Namespace resolution: GET /n/
+		if r.URL.Path == ociNamespacePath {
+			json.NewEncoder(w).Encode("testnamespace")
+			return
+		}
+		// List: GET /n/<ns>/b/<bucket>/o
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/o") {
+			var lr listResponse
+			for name := range objects {
+				lr.Objects = append(lr.Objects, struct {
+					Name string `json:"name"`
+				}{Name: name})
+			}
+			json.NewEncoder(w).Encode(lr)
+			return
+		}
+		// Single object operations: /n/<ns>/b/<bucket>/o/<name>
+		idx := strings.Index(r.URL.Path, "/o/")
+		if idx == -1 {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		name := r.URL.Path[idx+3:]
+		switch r.Method {
+		case http.MethodPut:
+			buf := make([]byte, r.ContentLength)
+			if r.ContentLength > 0 {
+				if _, err := r.Body.Read(buf); err != nil && err.Error() != "EOF" {
+					t.Errorf("read body: %v", err)
+				}
+			}
+			objects[name] = buf
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			data, ok := objects[name]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Write(data)
+		case http.MethodDelete:
+			delete(objects, name)
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &methods
+}
+
+// newTestStore builds an ObjectStore wired to the mock, bypassing
+// NewObjectStore's namespace round trip.
+func newTestStore(t *testing.T, endpoint string) *ObjectStore {
+	t.Helper()
+	setOCIEnv(t)
+	block, _ := pem.Decode([]byte(testRSAKeyPEM(t)))
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &ObjectStore{
+		tenancy: "t", user: "u", fingerprint: "f",
+		privateKey: key, region: "us-ashburn-1",
+		namespace: "testnamespace", bucket: "backups",
+		client:           &http.Client{},
+		endpointOverride: endpoint,
+	}
+}
+
+// ---- NewObjectStore credential validation ----
+
+func TestNewObjectStoreRequiresAllCredentials(t *testing.T) {
+	cases := []struct{ name, unset string }{
+		{"tenancy", envOCITenancy},
+		{"user", envOCIUser},
+		{"fingerprint", envOCIFingerprint},
+		{"private key", envOCIPrivateKey},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setOCIEnv(t)
+			t.Setenv(tc.unset, "")
+			if _, err := NewObjectStore("bucket"); err == nil {
+				t.Fatalf("missing %s must be rejected, not silently defaulted", tc.unset)
+			}
+		})
+	}
+}
+
+func TestNewObjectStoreRequiresBucket(t *testing.T) {
+	setOCIEnv(t)
+	_, err := NewObjectStore("")
+	if err == nil {
+		t.Fatal("empty bucket must be rejected: there is no backup destination")
+	}
+	if !strings.Contains(err.Error(), EnvBucket) {
+		t.Errorf("error should name %s, got %v", EnvBucket, err)
+	}
+}
+
+func TestNewObjectStoreRejectsBadPEM(t *testing.T) {
+	setOCIEnv(t)
+	t.Setenv(envOCIPrivateKey, "not a pem block")
+	if _, err := NewObjectStore("bucket"); err == nil {
+		t.Fatal("invalid PEM must be rejected")
+	}
+}
+
+// ---- Put / Get / List / Delete / Prune ----
+
+func TestObjectStorePutGetRoundTrip(t *testing.T) {
+	objects := map[string][]byte{}
+	srv, _ := ociMock(t, objects)
+	store := newTestStore(t, srv.URL)
+
+	payload := []byte("sealed-archive-bytes")
+	if err := store.Put("hive-hub-backup-20260731T000000Z.tar.gz.enc", payload); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := store.Get("hive-hub-backup-20260731T000000Z.tar.gz.enc")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("round trip corrupted the archive: got %q want %q", got, payload)
+	}
+}
+
+// List must return archives newest-first and must ignore unrelated objects,
+// because VerifyLatest and Prune both depend on names[0] being the newest.
+func TestObjectStoreListIsNewestFirstAndFiltered(t *testing.T) {
+	objects := map[string][]byte{
+		"hive-hub-backup-20260701T000000Z.tar.gz.enc": {1},
+		"hive-hub-backup-20260731T000000Z.tar.gz.enc": {2},
+		"hive-hub-backup-20260715T000000Z.tar.gz.enc": {3},
+		"unrelated-object.txt":                        {4},
+	}
+	srv, _ := ociMock(t, objects)
+	store := newTestStore(t, srv.URL)
+
+	names, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(names) != 3 {
+		t.Fatalf("want 3 archives (unrelated object filtered out), got %v", names)
+	}
+	if names[0] != "hive-hub-backup-20260731T000000Z.tar.gz.enc" {
+		t.Fatalf("List must be newest-first, got %v", names)
+	}
+	for _, n := range names {
+		if n == "unrelated-object.txt" {
+			t.Fatal("non-archive objects must not be listed")
+		}
+	}
+}
+
+// Prune keeps the N newest and deletes the rest. Deleting the wrong end would
+// destroy the most recent backup.
+func TestObjectStorePruneDeletesOldestOnly(t *testing.T) {
+	objects := map[string][]byte{
+		"hive-hub-backup-20260701T000000Z.tar.gz.enc": {1},
+		"hive-hub-backup-20260715T000000Z.tar.gz.enc": {2},
+		"hive-hub-backup-20260731T000000Z.tar.gz.enc": {3},
+	}
+	srv, _ := ociMock(t, objects)
+	store := newTestStore(t, srv.URL)
+
+	if err := store.Prune(2, quietLogger()); err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if len(objects) != 2 {
+		t.Fatalf("want 2 archives retained, got %d: %v", len(objects), objects)
+	}
+	if _, ok := objects["hive-hub-backup-20260731T000000Z.tar.gz.enc"]; !ok {
+		t.Fatal("Prune deleted the NEWEST archive — retention is inverted")
+	}
+	if _, ok := objects["hive-hub-backup-20260701T000000Z.tar.gz.enc"]; ok {
+		t.Fatal("Prune kept the oldest archive")
+	}
+}
+
+func TestObjectStorePruneNoopWhenUnderRetention(t *testing.T) {
+	objects := map[string][]byte{
+		"hive-hub-backup-20260731T000000Z.tar.gz.enc": {1},
+	}
+	srv, _ := ociMock(t, objects)
+	store := newTestStore(t, srv.URL)
+
+	if err := store.Prune(5, quietLogger()); err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if len(objects) != 1 {
+		t.Fatalf("nothing should be deleted below the retention count, got %v", objects)
+	}
+}
+
+func TestObjectStoreDelete(t *testing.T) {
+	objects := map[string][]byte{"obj": {1}}
+	srv, _ := ociMock(t, objects)
+	store := newTestStore(t, srv.URL)
+
+	if err := store.Delete("obj"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, ok := objects["obj"]; ok {
+		t.Fatal("object still present after Delete")
+	}
+}
+
+// A non-2xx response must surface as an error rather than being treated as a
+// successful upload — otherwise a failed backup is reported as good.
+func TestObjectStoreHTTPErrorSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, "NotAuthenticated")
+	}))
+	t.Cleanup(srv.Close)
+	store := newTestStore(t, srv.URL)
+
+	err := store.Put("obj", []byte("x"))
+	if err == nil {
+		t.Fatal("HTTP 403 must be reported as an error, not a successful upload")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("error should include the status code, got %v", err)
+	}
+}
+
+// Every request must carry an OCI Signature Authorization header; an unsigned
+// request would be rejected by the real service.
+func TestObjectStoreSignsRequests(t *testing.T) {
+	var auth, xContent string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth = r.Header.Get("Authorization")
+		xContent = r.Header.Get("x-content-sha256")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	store := newTestStore(t, srv.URL)
+
+	if err := store.Put("obj", []byte("payload")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if !strings.HasPrefix(auth, "Signature ") {
+		t.Fatalf("request was not signed: Authorization=%q", auth)
+	}
+	for _, want := range []string{`algorithm="rsa-sha256"`, `version="1"`, "keyId="} {
+		if !strings.Contains(auth, want) {
+			t.Errorf("signature header missing %s: %q", want, auth)
+		}
+	}
+	// PUT must additionally sign the body digest.
+	if xContent == "" {
+		t.Error("PUT must set x-content-sha256 so the body is covered by the signature")
+	}
+}
+
+// The signed Host must remain the real OCI host even when the endpoint is
+// redirected, since the signature covers the host header.
+func TestObjectStoreSignsRealHostNotOverride(t *testing.T) {
+	var gotHost string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Host
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	store := newTestStore(t, srv.URL)
+
+	if err := store.Put("obj", []byte("x")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if gotHost != store.host() {
+		t.Fatalf("signed Host should be the OCI host %q, got %q", store.host(), gotHost)
+	}
+}
+
+func TestObjectStoreBaseURLDefaultsToRealHost(t *testing.T) {
+	store := newTestStore(t, "")
+	want := "https://" + store.host()
+	if got := store.baseURL(); got != want {
+		t.Fatalf("without an override the store must target %q, got %q", want, got)
+	}
+}

--- a/v2/pkg/hubbackup/run_coverage_test.go
+++ b/v2/pkg/hubbackup/run_coverage_test.go
@@ -1,0 +1,337 @@
+package hubbackup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ---- LoadTargets ----
+
+func TestLoadTargetsMapsHivesToClusters(t *testing.T) {
+	dir := seedHubData(t)
+	clusters, hives, err := LoadTargets(dir)
+	if err != nil {
+		t.Fatalf("LoadTargets: %v", err)
+	}
+	if len(clusters) != 2 {
+		t.Fatalf("want 2 clusters, got %d", len(clusters))
+	}
+	// The in-cluster hub target must not carry kubeconfig flags.
+	if clusters["hive-oke"].KubeconfigPath != "" {
+		t.Error("in-cluster target should have no kubeconfig path")
+	}
+	// The remote target must retain how to reach it, or its spokes are read
+	// from the WRONG cluster.
+	remote := clusters["vllm-d"]
+	if remote.KubeconfigPath != "/etc/hive/kubeconfigs/vllm-d.yaml" || remote.Context != "vllm-d" {
+		t.Fatalf("remote cluster addressing lost: %+v", remote)
+	}
+	if hives["hosted-x"] != "hive-oke" {
+		t.Fatalf("hive->cluster mapping wrong: %v", hives)
+	}
+}
+
+func TestLoadTargetsErrors(t *testing.T) {
+	t.Run("missing clusters.json", func(t *testing.T) {
+		if _, _, err := LoadTargets(t.TempDir()); err == nil {
+			t.Fatal("missing clusters.json must be an error")
+		}
+	})
+
+	t.Run("malformed clusters.json", func(t *testing.T) {
+		dir := t.TempDir()
+		mustWrite(t, filepath.Join(dir, saasSubdir, "clusters.json"), "{not json")
+		if _, _, err := LoadTargets(dir); err == nil {
+			t.Fatal("malformed clusters.json must be an error")
+		}
+	})
+
+	t.Run("missing registry", func(t *testing.T) {
+		dir := t.TempDir()
+		mustWrite(t, filepath.Join(dir, saasSubdir, "clusters.json"), `[]`)
+		if _, _, err := LoadTargets(dir); err == nil {
+			t.Fatal("missing hub-registry.json must be an error")
+		}
+	})
+
+	t.Run("malformed registry", func(t *testing.T) {
+		dir := t.TempDir()
+		mustWrite(t, filepath.Join(dir, saasSubdir, "clusters.json"), `[]`)
+		mustWrite(t, filepath.Join(dir, registryFile), "{not json")
+		if _, _, err := LoadTargets(dir); err == nil {
+			t.Fatal("malformed hub-registry.json must be an error")
+		}
+	})
+}
+
+// Registry entries missing an id or clusterId must be skipped rather than
+// producing an unaddressable "" -> "" mapping.
+func TestLoadTargetsSkipsIncompleteHives(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, saasSubdir, "clusters.json"), `[{"id":"c1","in_cluster":true}]`)
+	mustWrite(t, filepath.Join(dir, registryFile),
+		`{"hives":[{"id":"good","clusterId":"c1"},{"id":"","clusterId":"c1"},{"id":"noclust","clusterId":""}]}`)
+
+	_, hives, err := LoadTargets(dir)
+	if err != nil {
+		t.Fatalf("LoadTargets: %v", err)
+	}
+	if len(hives) != 1 {
+		t.Fatalf("incomplete registry entries must be skipped, got %v", hives)
+	}
+	if _, ok := hives["good"]; !ok {
+		t.Fatal("the complete entry was dropped")
+	}
+}
+
+// ---- Run ----
+
+// The local-only path exercises build -> self-verify -> write without needing
+// object storage, and the archive it drops must itself verify.
+func TestRunLocalOnlyWritesVerifiableArchive(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	t.Setenv(EnvBackupKey, testKey)
+
+	out := filepath.Join(t.TempDir(), "backup.enc")
+	man, path, err := Run(Options{
+		LocalOnly: true, LocalPath: out, SkipSpokes: true, SkipSecrets: true,
+	}, quietLogger())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if path != out {
+		t.Fatalf("want archive at %q, got %q", out, path)
+	}
+	if man == nil || len(man.Files) == 0 {
+		t.Fatal("Run returned an empty manifest")
+	}
+
+	sealed, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("archive not written: %v", err)
+	}
+	if _, err := Verify(decodeTestKey(t), sealed); err != nil {
+		t.Fatalf("the archive Run wrote does not verify: %v", err)
+	}
+
+	// The file must be written with owner-only permissions: it contains the
+	// hub's crypto material.
+	info, err := os.Stat(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("archive mode = %o, want 0600 (it holds hub key material)", perm)
+	}
+}
+
+// An unset HIVE_BACKUP_KEY must hard-fail before anything is written, rather
+// than falling back to writing an unencrypted archive.
+func TestRunRefusesToRunWithoutKey(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	t.Setenv(EnvBackupKey, "")
+
+	out := filepath.Join(t.TempDir(), "backup.enc")
+	_, _, err := Run(Options{
+		LocalOnly: true, LocalPath: out, SkipSpokes: true, SkipSecrets: true,
+	}, quietLogger())
+	if err == nil {
+		t.Fatal("Run without a key must fail rather than write plaintext")
+	}
+	if !strings.Contains(err.Error(), EnvBackupKey) {
+		t.Errorf("error should name %s, got %v", EnvBackupKey, err)
+	}
+	if _, statErr := os.Stat(out); statErr == nil {
+		t.Fatal("no archive may be written when the key is missing")
+	}
+}
+
+// A malformed key must be rejected too — a short key is not silently padded.
+func TestRunRejectsMalformedKey(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	t.Setenv(EnvBackupKey, "abcd")
+
+	_, _, err := Run(Options{
+		LocalOnly: true, LocalPath: filepath.Join(t.TempDir(), "b.enc"),
+		SkipSpokes: true, SkipSecrets: true,
+	}, quietLogger())
+	if err == nil {
+		t.Fatal("a short key must be rejected, not padded")
+	}
+}
+
+// When spokes are enabled but the fleet cannot be enumerated, Run must abort:
+// a backup silently missing every spoke is not a usable backup.
+func TestRunFailsWhenFleetCannotBeEnumerated(t *testing.T) {
+	t.Setenv(EnvDataDir, t.TempDir()) // no clusters.json
+	t.Setenv(EnvBackupKey, testKey)
+
+	_, _, err := Run(Options{
+		LocalOnly: true, LocalPath: filepath.Join(t.TempDir(), "b.enc"),
+		SkipSecrets: true,
+	}, quietLogger())
+	if err == nil {
+		t.Fatal("Run must fail when the fleet cannot be enumerated")
+	}
+	if !strings.Contains(err.Error(), "enumerate spokes") {
+		t.Errorf("error should explain the enumeration failure, got %v", err)
+	}
+}
+
+// With no LocalPath, Run falls back to the generated archive name.
+func TestRunLocalOnlyDefaultsToGeneratedName(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	t.Setenv(EnvBackupKey, testKey)
+
+	// Run writes to a relative path, so isolate the working directory.
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp := t.TempDir()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(wd) })
+
+	_, path, err := Run(Options{
+		LocalOnly: true, SkipSpokes: true, SkipSecrets: true,
+	}, quietLogger())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.HasPrefix(path, "hive-hub-backup-") {
+		t.Fatalf("want a generated archive name, got %q", path)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, path)); err != nil {
+		t.Fatalf("archive not written at generated name: %v", err)
+	}
+}
+
+// ---- Retention / DataDir env handling ----
+
+func TestRetentionRejectsNonPositiveAndGarbage(t *testing.T) {
+	for _, v := range []string{"0", "-3", "abc", ""} {
+		t.Run("value_"+v, func(t *testing.T) {
+			t.Setenv(EnvRetention, v)
+			if got := Retention(); got != DefaultRetention {
+				t.Fatalf("%q must fall back to the default %d, got %d",
+					v, DefaultRetention, got)
+			}
+		})
+	}
+}
+
+func TestDataDirHonoursOverrideAndDefault(t *testing.T) {
+	t.Run("override", func(t *testing.T) {
+		t.Setenv(EnvDataDir, "/custom/data")
+		if got := DataDir(); got != "/custom/data" {
+			t.Fatalf("want the override, got %q", got)
+		}
+	})
+	t.Run("whitespace is ignored", func(t *testing.T) {
+		t.Setenv(EnvDataDir, "   ")
+		if got := DataDir(); got != DefaultDataDir {
+			t.Fatalf("blank override must fall back to %q, got %q", DefaultDataDir, got)
+		}
+	})
+}
+
+// ---- Exported Builder (used by pkg/spokebackup) ----
+
+// An archive assembled through the exported Builder must be accepted by the
+// SAME Verify used for hub archives — that shared format is the whole point of
+// exporting it.
+func TestExportedBuilderProducesVerifiableArchive(t *testing.T) {
+	key := decodeTestKey(t)
+	b := NewBuilder()
+
+	if err := b.AddBytes("spoke/hive.yaml.bak", 0o600, []byte("project: acme")); err != nil {
+		t.Fatalf("AddBytes: %v", err)
+	}
+
+	src := t.TempDir()
+	mustWrite(t, filepath.Join(src, "keep", "a.json"), `{"a":1}`)
+	mustWrite(t, filepath.Join(src, "skipme", "b.json"), `{"b":2}`)
+	if err := b.AddTree(src, "spoke/tree", func(rel string) bool {
+		return strings.HasPrefix(rel, "skipme")
+	}, quietLogger()); err != nil {
+		t.Fatalf("AddTree: %v", err)
+	}
+
+	man := &Manifest{FormatVersion: FormatVersion()}
+	sealed, err := b.Finish(key, man, 0)
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	verified, err := Verify(key, sealed)
+	if err != nil {
+		t.Fatalf("hub Verify must accept a Builder-made archive: %v", err)
+	}
+	if len(verified.Files) == 0 {
+		t.Fatal("manifest digests were not populated — Verify would be vacuous")
+	}
+
+	dest := t.TempDir()
+	if _, err := Extract(key, sealed, dest); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if got, _ := os.ReadFile(filepath.Join(dest, "spoke", "hive.yaml.bak")); string(got) != "project: acme" {
+		t.Fatalf("content corrupted: %q", got)
+	}
+	if got, _ := os.ReadFile(filepath.Join(dest, "spoke", "tree", "keep", "a.json")); string(got) != `{"a":1}` {
+		t.Fatalf("tree content corrupted: %q", got)
+	}
+	// The skip predicate must actually prune.
+	if _, err := os.Stat(filepath.Join(dest, "spoke", "tree", "skipme")); err == nil {
+		t.Fatal("AddTree ignored the skip predicate")
+	}
+}
+
+// FormatVersion must match what Verify enforces, or archives built by other
+// packages are rejected on restore.
+func TestExportedFormatVersionMatchesVerify(t *testing.T) {
+	if FormatVersion() != backupFormatVersion {
+		t.Fatalf("FormatVersion() = %d but Verify enforces %d",
+			FormatVersion(), backupFormatVersion)
+	}
+}
+
+func TestBuilderFinishRequiresManifest(t *testing.T) {
+	if _, err := NewBuilder().Finish(decodeTestKey(t), nil, 0); err == nil {
+		t.Fatal("Finish without a manifest must error")
+	}
+}
+
+// The size cap protects a caller streaming an archive to a browser.
+func TestBuilderFinishEnforcesSizeCap(t *testing.T) {
+	b := NewBuilder()
+	if err := b.AddBytes("big", 0o600, []byte(strings.Repeat("x", 4096))); err != nil {
+		t.Fatal(err)
+	}
+	_, err := b.Finish(decodeTestKey(t), &Manifest{FormatVersion: FormatVersion()}, 8)
+	if err == nil {
+		t.Fatal("an archive above the cap must be refused")
+	}
+	if !strings.Contains(err.Error(), "cap") {
+		t.Errorf("error should mention the cap, got %v", err)
+	}
+}
+
+// A zero/negative cap means unlimited.
+func TestBuilderFinishZeroCapMeansUnlimited(t *testing.T) {
+	b := NewBuilder()
+	if err := b.AddBytes("big", 0o600, []byte(strings.Repeat("x", 4096))); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Finish(decodeTestKey(t), &Manifest{FormatVersion: FormatVersion()}, 0); err != nil {
+		t.Fatalf("cap 0 must mean unlimited, got %v", err)
+	}
+}

--- a/v2/pkg/hubbackup/verifylatest_test.go
+++ b/v2/pkg/hubbackup/verifylatest_test.go
@@ -1,0 +1,267 @@
+package hubbackup
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ---- NewObjectStore success path + resolveNamespace ----
+
+// The constructor must resolve the tenancy namespace before the store is usable,
+// since every object path embeds it.
+func TestNewObjectStoreResolvesNamespace(t *testing.T) {
+	srv, _ := ociMock(t, map[string][]byte{})
+	setOCIEnv(t)
+	t.Setenv(envOCIEndpoint, srv.URL)
+
+	store, err := NewObjectStore("backups")
+	if err != nil {
+		t.Fatalf("NewObjectStore: %v", err)
+	}
+	if store.namespace != "testnamespace" {
+		t.Fatalf("namespace not resolved from the service, got %q", store.namespace)
+	}
+	if store.bucket != "backups" {
+		t.Fatalf("bucket = %q", store.bucket)
+	}
+}
+
+// A PKCS8-encoded key must be accepted as well as PKCS1 — real oci-api-key
+// Secrets carry either form.
+func TestNewObjectStoreAcceptsPKCS8Key(t *testing.T) {
+	srv, _ := ociMock(t, map[string][]byte{})
+	setOCIEnv(t)
+	t.Setenv(envOCIEndpoint, srv.URL)
+	t.Setenv(envOCIPrivateKey, testPKCS8KeyPEM(t))
+
+	if _, err := NewObjectStore("backups"); err != nil {
+		t.Fatalf("a PKCS8 private key must be accepted: %v", err)
+	}
+}
+
+// A namespace lookup failure must fail construction rather than yielding a
+// store that writes to path "/n//b/...".
+func TestNewObjectStoreFailsWhenNamespaceUnresolvable(t *testing.T) {
+	srv := newStatusServer(t, 500)
+	setOCIEnv(t)
+	t.Setenv(envOCIEndpoint, srv.URL)
+
+	if _, err := NewObjectStore("backups"); err == nil {
+		t.Fatal("an unresolvable namespace must fail construction")
+	}
+}
+
+// A non-RSA PKCS8 key must be rejected: the OCI signature scheme is RSA-only.
+func TestNewObjectStoreRejectsNonRSAKey(t *testing.T) {
+	setOCIEnv(t)
+	t.Setenv(envOCIPrivateKey, testED25519KeyPEM(t))
+	if _, err := NewObjectStore("backups"); err == nil {
+		t.Fatal("a non-RSA key must be rejected")
+	}
+}
+
+// ---- VerifyLatest ----
+
+// VerifyLatest must fetch the NEWEST archive and verify it end to end.
+func TestVerifyLatestVerifiesNewestArchive(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	t.Setenv(EnvBackupKey, testKey)
+
+	key := decodeTestKey(t)
+	good, _, err := Build(key, nil, nil, quietLogger())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	// The older object is deliberately garbage: if VerifyLatest picks the wrong
+	// one, the test fails.
+	objects := map[string][]byte{
+		"hive-hub-backup-20260101T000000Z.tar.gz.enc": []byte("garbage-old-archive"),
+		"hive-hub-backup-20260731T000000Z.tar.gz.enc": good,
+	}
+	srv, _ := ociMock(t, objects)
+	setOCIEnv(t)
+	t.Setenv(envOCIEndpoint, srv.URL)
+	t.Setenv(EnvBucket, "backups")
+
+	man, err := VerifyLatest(quietLogger())
+	if err != nil {
+		t.Fatalf("VerifyLatest: %v", err)
+	}
+	if man == nil || len(man.Files) == 0 {
+		t.Fatal("VerifyLatest returned an empty manifest")
+	}
+}
+
+// An empty bucket must be an explicit error: "no backups exist" must never be
+// reported as a successful verification.
+func TestVerifyLatestFailsOnEmptyBucket(t *testing.T) {
+	srv, _ := ociMock(t, map[string][]byte{})
+	setOCIEnv(t)
+	t.Setenv(envOCIEndpoint, srv.URL)
+	t.Setenv(EnvBackupKey, testKey)
+	t.Setenv(EnvBucket, "backups")
+
+	_, err := VerifyLatest(quietLogger())
+	if err == nil {
+		t.Fatal("an empty bucket must be an error, not a silent pass")
+	}
+	if !strings.Contains(err.Error(), "no archives") {
+		t.Errorf("error should say no archives were found, got %v", err)
+	}
+}
+
+// A stored archive that is corrupt must be reported as such — this is the whole
+// point of a verification job.
+func TestVerifyLatestDetectsCorruptStoredArchive(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	key := decodeTestKey(t)
+	good, _, err := Build(key, nil, nil, quietLogger())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	corrupt := append([]byte(nil), good...)
+	corrupt[len(corrupt)/2] ^= 0xFF
+
+	srv, _ := ociMock(t, map[string][]byte{
+		"hive-hub-backup-20260731T000000Z.tar.gz.enc": corrupt,
+	})
+	setOCIEnv(t)
+	t.Setenv(envOCIEndpoint, srv.URL)
+	t.Setenv(EnvBackupKey, testKey)
+	t.Setenv(EnvBucket, "backups")
+
+	if _, err := VerifyLatest(quietLogger()); err == nil {
+		t.Fatal("a corrupt stored archive must fail verification")
+	}
+}
+
+func TestVerifyLatestRequiresKey(t *testing.T) {
+	t.Setenv(EnvBackupKey, "")
+	if _, err := VerifyLatest(quietLogger()); err == nil {
+		t.Fatal("VerifyLatest without a key must fail")
+	}
+}
+
+// ---- Run against object storage ----
+
+// The full remote path: upload, read back, verify what actually landed, prune.
+// Read-back is what catches a truncated or half-written upload.
+func TestRunUploadsVerifiesAndPrunes(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	t.Setenv(EnvBackupKey, testKey)
+	t.Setenv(EnvRetention, "2")
+
+	// Pre-existing archives so Prune has something to trim.
+	objects := map[string][]byte{
+		"hive-hub-backup-20260101T000000Z.tar.gz.enc": []byte("old1"),
+		"hive-hub-backup-20260102T000000Z.tar.gz.enc": []byte("old2"),
+	}
+	srv, _ := ociMock(t, objects)
+	setOCIEnv(t)
+	t.Setenv(envOCIEndpoint, srv.URL)
+	t.Setenv(EnvBucket, "backups")
+
+	man, name, err := Run(Options{SkipSpokes: true, SkipSecrets: true}, quietLogger())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if man == nil {
+		t.Fatal("Run returned no manifest")
+	}
+	stored, ok := objects[name]
+	if !ok {
+		t.Fatalf("archive %q was not uploaded; bucket has %v", name, keysOf(objects))
+	}
+	if _, err := Verify(decodeTestKey(t), stored); err != nil {
+		t.Fatalf("the archive that landed in storage does not verify: %v", err)
+	}
+	// Retention 2 must be honoured.
+	if len(objects) != 2 {
+		t.Fatalf("retention=2 must leave 2 archives, got %d: %v", len(objects), keysOf(objects))
+	}
+	if _, ok := objects[name]; !ok {
+		t.Fatal("Prune deleted the archive that was just written")
+	}
+}
+
+// If the upload fails, Run must report an error rather than claim success.
+func TestRunFailsWhenUploadFails(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	t.Setenv(EnvBackupKey, testKey)
+
+	srv := newNamespaceThenStatusServer(t, 403)
+	setOCIEnv(t)
+	t.Setenv(envOCIEndpoint, srv.URL)
+	t.Setenv(EnvBucket, "backups")
+
+	_, _, err := Run(Options{SkipSpokes: true, SkipSecrets: true}, quietLogger())
+	if err == nil {
+		t.Fatal("a failed upload must be reported, not treated as a good backup")
+	}
+	if !strings.Contains(err.Error(), "upload") {
+		t.Errorf("error should identify the upload step, got %v", err)
+	}
+}
+
+// Missing OCI credentials must fail before any archive work claims success.
+func TestRunFailsWithoutObjectStoreCredentials(t *testing.T) {
+	dir := seedHubData(t)
+	t.Setenv(EnvDataDir, dir)
+	t.Setenv(EnvBackupKey, testKey)
+	t.Setenv(envOCITenancy, "")
+	t.Setenv(EnvBucket, "backups")
+
+	if _, _, err := Run(Options{SkipSpokes: true, SkipSecrets: true}, quietLogger()); err == nil {
+		t.Fatal("Run must fail when object storage credentials are incomplete")
+	}
+}
+
+// ---- Build tolerates a partially-broken hub PVC ----
+
+// A hub whose saas dir or registry is missing must still produce an archive:
+// a partial backup beats no backup during an incident.
+func TestBuildToleratesMissingHubPieces(t *testing.T) {
+	dir := t.TempDir() // no saas dir, no registry
+	t.Setenv(EnvDataDir, dir)
+
+	sealed, man, err := Build(decodeTestKey(t), nil, nil, quietLogger())
+	if err != nil {
+		t.Fatalf("Build must tolerate a partial hub PVC: %v", err)
+	}
+	if man.HubDataDir != dir {
+		t.Errorf("manifest should record the data dir, got %q", man.HubDataDir)
+	}
+	if _, err := Verify(decodeTestKey(t), sealed); err != nil {
+		t.Fatalf("even a near-empty archive must verify: %v", err)
+	}
+}
+
+// Unreadable files inside the tree are skipped rather than aborting the run.
+func TestAddTreeSkipsUnreadableFiles(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "saas", "readable.json"), `{"ok":1}`)
+	secret := filepath.Join(dir, "saas", "locked.json")
+	mustWrite(t, secret, `{"secret":1}`)
+	if err := chmodUnreadable(secret); err != nil {
+		t.Skipf("cannot make a file unreadable here: %v", err)
+	}
+	t.Setenv(EnvDataDir, dir)
+
+	sealed, man, err := Build(decodeTestKey(t), nil, nil, quietLogger())
+	if err != nil {
+		t.Fatalf("an unreadable file must not abort the backup: %v", err)
+	}
+	if _, err := Verify(decodeTestKey(t), sealed); err != nil {
+		t.Fatalf("archive must still verify: %v", err)
+	}
+	for _, f := range man.Files {
+		if strings.HasSuffix(f.Path, "locked.json") {
+			t.Fatal("an unreadable file must not be recorded in the manifest")
+		}
+	}
+}

--- a/v2/pkg/spokebackup/backup.go
+++ b/v2/pkg/spokebackup/backup.go
@@ -105,6 +105,11 @@ const (
 	MaxFileBytes = 64 << 20 // 64 MiB
 )
 
+// archiveCapBytes is the cap Build applies, indirected through a variable so a
+// test can shrink it and prove Build really enforces a cap. Production always
+// uses MaxArchiveBytes; nothing outside tests assigns this.
+var archiveCapBytes = MaxArchiveBytes
+
 // BuildTimeout bounds a single backup so a wedged filesystem read cannot hold
 // a dashboard request open indefinitely.
 const BuildTimeout = 2 * time.Minute
@@ -267,7 +272,7 @@ func Build(key []byte, hiveID string, logger *slog.Logger) (*Result, error) {
 		man.SpokeErrors[k] = v
 	}
 
-	sealed, err := b.Finish(key, man, MaxArchiveBytes)
+	sealed, err := b.Finish(key, man, archiveCapBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/pkg/spokebackup/backup_coverage_test.go
+++ b/v2/pkg/spokebackup/backup_coverage_test.go
@@ -1,0 +1,447 @@
+package spokebackup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/hubbackup"
+)
+
+// ---- DataDir ----
+
+func TestDataDirHonoursOverrideAndDefault(t *testing.T) {
+	t.Run("override", func(t *testing.T) {
+		t.Setenv(EnvDataDir, "/custom/spoke")
+		if got := DataDir(); got != "/custom/spoke" {
+			t.Fatalf("want the override, got %q", got)
+		}
+	})
+	t.Run("blank falls back", func(t *testing.T) {
+		t.Setenv(EnvDataDir, "   ")
+		if got := DataDir(); got != DefaultDataDir {
+			t.Fatalf("a blank override must fall back to %q, got %q", DefaultDataDir, got)
+		}
+	})
+	t.Run("unset falls back", func(t *testing.T) {
+		t.Setenv(EnvDataDir, "")
+		if got := DataDir(); got != DefaultDataDir {
+			t.Fatalf("unset must fall back to %q, got %q", DefaultDataDir, got)
+		}
+	})
+}
+
+// ---- ArchiveName ----
+
+// A blank or fully-sanitized-away hive ID must still yield a usable filename
+// rather than one with an empty component.
+func TestArchiveNameFallsBackForUnusableID(t *testing.T) {
+	at := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	for _, id := range []string{"", "///", "---", "..."} {
+		name := ArchiveName(id, at)
+		if !strings.HasPrefix(name, "hive-spoke-backup-hive-") {
+			t.Errorf("id %q must fall back to 'hive', got %q", id, name)
+		}
+		if strings.Contains(name, "--2026") {
+			t.Errorf("id %q produced an empty component: %q", id, name)
+		}
+	}
+}
+
+// The timestamp must be UTC regardless of the caller's zone, so archives from
+// different zones sort correctly against each other.
+func TestArchiveNameIsUTC(t *testing.T) {
+	instant := time.Date(2026, 7, 31, 23, 30, 0, 0, time.UTC)
+	want := ArchiveName("h", instant)
+	got := ArchiveName("h", instant.In(time.FixedZone("TEST", -8*3600)))
+	if got != want {
+		t.Fatalf("ArchiveName must normalise to UTC: %q vs %q", got, want)
+	}
+}
+
+// The .enc suffix is load-bearing UX and the name must be shell/header safe.
+func TestArchiveNameShape(t *testing.T) {
+	name := ArchiveName("hosted-x", time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC))
+	if !strings.HasSuffix(name, ".tar.gz.enc") {
+		t.Errorf("archive must advertise encryption via .enc: %q", name)
+	}
+	if !strings.Contains(name, "20260731T120000Z") {
+		t.Errorf("archive name must carry a sortable UTC stamp: %q", name)
+	}
+}
+
+// A hive ID carrying separators or quotes must never escape into the filename,
+// or it could break a Content-Disposition header.
+func TestArchiveNameNeutralisesInjection(t *testing.T) {
+	for _, bad := range []string{
+		`../../etc/passwd`,
+		`a"b`,
+		"a/b\\c",
+		"a b;rm -rf /",
+	} {
+		name := ArchiveName(bad, time.Now())
+		for _, ch := range []string{"/", "\\", `"`, ";", " ", ".."} {
+			// The ".tar.gz.enc" suffix legitimately contains dots, so check only
+			// the ID portion.
+			idPart := strings.TrimPrefix(name, "hive-spoke-backup-")
+			idPart = idPart[:strings.LastIndex(idPart, "-")]
+			if strings.Contains(idPart, ch) {
+				t.Errorf("hive ID %q leaked %q into the filename: %q", bad, ch, name)
+			}
+		}
+	}
+}
+
+// ---- readCapped ----
+
+// A file above the per-file cap must be skipped, not truncated into the
+// archive: a truncated bead ledger would restore as corrupt data.
+func TestReadCappedRefusesOversizedFile(t *testing.T) {
+	dir := t.TempDir()
+	big := filepath.Join(dir, "big.json")
+	f, err := os.Create(big)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sparse file: cheap to create, still reports a size above the cap.
+	if err := f.Truncate(MaxFileBytes + 1); err != nil {
+		f.Close()
+		t.Skipf("cannot create a sparse file here: %v", err)
+	}
+	f.Close()
+
+	_, err = readCapped(big)
+	if err == nil {
+		t.Fatal("a file above the per-file cap must be refused")
+	}
+	if !strings.Contains(err.Error(), "cap") {
+		t.Errorf("error should mention the cap, got %v", err)
+	}
+}
+
+// A directory or other non-regular file must be refused rather than read.
+func TestReadCappedRefusesNonRegularFile(t *testing.T) {
+	dir := t.TempDir()
+	_, err := readCapped(dir)
+	if err == nil {
+		t.Fatal("a directory must not be read as a file")
+	}
+	if !strings.Contains(err.Error(), "regular") {
+		t.Errorf("error should say the path is not a regular file, got %v", err)
+	}
+}
+
+func TestReadCappedReportsMissingFile(t *testing.T) {
+	if _, err := readCapped(filepath.Join(t.TempDir(), "absent")); err == nil {
+		t.Fatal("a missing file must be an error")
+	}
+}
+
+// A file exactly at the cap is allowed — the boundary must not be off by one.
+func TestReadCappedAllowsFileAtExactCap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "atcap")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(MaxFileBytes); err != nil {
+		f.Close()
+		t.Skipf("cannot create a sparse file here: %v", err)
+	}
+	f.Close()
+
+	if _, err := readCapped(path); err != nil {
+		t.Fatalf("a file exactly at the cap must be allowed, got %v", err)
+	}
+}
+
+// ---- Build edges ----
+
+// An unreadable beads directory must be recorded, not silently produce a
+// backup missing the very thing this package exists to capture.
+func TestBuildRecordsUnreadableBeadsDir(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, configBackupFile), "live: config\n")
+	// No beads dir at all.
+	t.Setenv(EnvDataDir, dir)
+
+	res, err := Build(testKey(), "hive-x", testLogger())
+	if err != nil {
+		t.Fatalf("a missing beads dir must not abort the backup: %v", err)
+	}
+	if _, ok := res.Skipped[beadsSubdir]; !ok {
+		t.Fatal("a missing beads dir must be recorded in Skipped — it is the " +
+			"whole reason this backup exists")
+	}
+	if len(res.BeadDirs) != 0 {
+		t.Fatalf("no bead dirs should be reported, got %v", res.BeadDirs)
+	}
+	// The gap must also reach the manifest the owner sees.
+	if _, ok := res.Manifest.SpokeErrors[beadsSubdir]; !ok {
+		t.Fatal("the gap must surface in the manifest, not only in the Result")
+	}
+}
+
+// Loose files directly inside beads/ are not agent directories and must be
+// ignored rather than treated as one.
+func TestBuildIgnoresNonDirEntriesInBeads(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, configBackupFile), "live: config\n")
+	mustWrite(t, filepath.Join(dir, beadsSubdir, "stray.txt"), "not an agent dir")
+	mustWrite(t, filepath.Join(dir, beadsSubdir, "scanner", "b1.json"), `{"id":1}`)
+	t.Setenv(EnvDataDir, dir)
+
+	res, err := Build(testKey(), "hive-x", testLogger())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(res.BeadDirs) != 1 || res.BeadDirs[0] != "scanner" {
+		t.Fatalf("only agent directories should be captured, got %v", res.BeadDirs)
+	}
+}
+
+// The bead ledger must be discovered, not hardcoded: a hive running agents
+// beyond the original five must still get a complete ledger.
+func TestBuildDiscoversArbitraryAgentDirs(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, configBackupFile), "live: config\n")
+	agents := []string{"scanner", "reviewer", "feature", "outreach", "custom-7", "zz-extra"}
+	for _, a := range agents {
+		mustWrite(t, filepath.Join(dir, beadsSubdir, a, "b.json"), `{"a":1}`)
+	}
+	t.Setenv(EnvDataDir, dir)
+
+	res, err := Build(testKey(), "hive-x", testLogger())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(res.BeadDirs) != len(agents) {
+		t.Fatalf("want %d agent ledgers, got %d (%v)", len(agents), len(res.BeadDirs), res.BeadDirs)
+	}
+	// And the extra agents' beads must really be in the archive.
+	man, err := hubbackup.Verify(testKey(), res.Sealed)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	var sawCustom bool
+	for _, f := range man.Files {
+		if strings.Contains(f.Path, "custom-7") {
+			sawCustom = true
+		}
+	}
+	if !sawCustom {
+		t.Fatal("a non-standard agent's bead ledger was not archived")
+	}
+}
+
+// App keys are credentials; several may exist and all must be captured, in a
+// deterministic order.
+func TestBuildCapturesAllAppKeysDeterministically(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, configBackupFile), "live: config\n")
+	mustWrite(t, filepath.Join(dir, "gh-app-key-2.pem"), "KEY2")
+	mustWrite(t, filepath.Join(dir, "gh-app-key-1.pem"), "KEY1")
+	t.Setenv(EnvDataDir, dir)
+
+	res, err := Build(testKey(), "hive-x", testLogger())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	man, err := hubbackup.Verify(testKey(), res.Sealed)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	var keys []string
+	for _, f := range man.Files {
+		if strings.Contains(f.Path, "gh-app-key") {
+			keys = append(keys, f.Path)
+		}
+	}
+	if len(keys) != 2 {
+		t.Fatalf("want both app keys archived, got %v", keys)
+	}
+	if !strings.Contains(keys[0], "key-1") {
+		t.Fatalf("app keys must be archived in sorted order, got %v", keys)
+	}
+}
+
+// Build must refuse a nil key as well as an empty one — no unencrypted archive
+// carrying App private keys may ever be produced.
+func TestBuildRefusesNilKey(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, configBackupFile), "x")
+	t.Setenv(EnvDataDir, dir)
+
+	_, err := Build(nil, "hive-x", testLogger())
+	if err == nil {
+		t.Fatal("a nil key must be refused: the archive carries App private keys")
+	}
+	if !strings.Contains(err.Error(), "refusing to build an unencrypted spoke backup") {
+		t.Fatalf("want the explicit up-front refusal, got %v", err)
+	}
+
+	// An empty (non-nil) key is the same hazard and must be refused identically.
+	_, err = Build([]byte{}, "hive-x", testLogger())
+	if err == nil {
+		t.Fatal("an empty key must be refused")
+	}
+	if !strings.Contains(err.Error(), "refusing to build an unencrypted spoke backup") {
+		t.Fatalf("want the explicit up-front refusal for an empty key, got %v", err)
+	}
+}
+
+// The manifest must name the hive so an owner with several archives can tell
+// them apart.
+func TestBuildManifestIdentifiesHive(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, configBackupFile), "live: config\n")
+	t.Setenv(EnvDataDir, dir)
+
+	res, err := Build(testKey(), "hosted-xyz", testLogger())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(res.Manifest.SpokeIDs) != 1 || res.Manifest.SpokeIDs[0] != "hosted-xyz" {
+		t.Fatalf("manifest must identify the hive, got %v", res.Manifest.SpokeIDs)
+	}
+	if res.Manifest.FormatVersion != hubbackup.FormatVersion() {
+		t.Errorf("manifest must stamp the shared format version, got %d",
+			res.Manifest.FormatVersion)
+	}
+	// CreatedAt must be UTC so archives compare correctly.
+	if res.Manifest.CreatedAt.Location() != time.UTC {
+		t.Errorf("CreatedAt must be UTC, got %v", res.Manifest.CreatedAt.Location())
+	}
+}
+
+// A spoke that is missing everything still produces a verifiable (near-empty)
+// archive rather than an error, with every gap recorded.
+func TestBuildOnEmptySpokeStillVerifies(t *testing.T) {
+	t.Setenv(EnvDataDir, t.TempDir())
+
+	res, err := Build(testKey(), "hive-x", testLogger())
+	if err != nil {
+		t.Fatalf("an empty spoke must still produce an archive: %v", err)
+	}
+	if _, err := hubbackup.Verify(testKey(), res.Sealed); err != nil {
+		t.Fatalf("even a near-empty archive must verify: %v", err)
+	}
+	// Every expected file must be accounted for as skipped.
+	for _, name := range includedRootFiles {
+		if _, ok := res.Skipped[name]; !ok {
+			t.Errorf("missing %q must be recorded in Skipped", name)
+		}
+	}
+}
+
+// The archive must be extractable through the shared hubbackup path, and the
+// authoritative config must come back byte for byte.
+func TestBuildArchiveExtractsThroughSharedPath(t *testing.T) {
+	dir := seedSpoke(t)
+	t.Setenv(EnvDataDir, dir)
+
+	res, err := Build(testKey(), "hive-x", testLogger())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	dest := t.TempDir()
+	if _, err := hubbackup.Extract(testKey(), res.Sealed, dest); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dest, spokePrefix, configBackupFile))
+	if err != nil {
+		t.Fatalf("authoritative config missing from the restore: %v", err)
+	}
+	if string(got) != "live: owner-customised\n" {
+		t.Fatalf("restored the WRONG config: %q", got)
+	}
+	// The stale hive.yaml must not be present at all.
+	if _, err := os.Stat(filepath.Join(dest, spokePrefix, "hive.yaml")); err == nil {
+		t.Fatal("the stale hive.yaml must never be archived")
+	}
+}
+
+// An unreadable App key must be recorded and skipped rather than aborting the
+// backup — the owner still wants the rest of their hive.
+func TestBuildRecordsUnreadableAppKey(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, configBackupFile), "live: config\n")
+	keyPath := filepath.Join(dir, "gh-app-key-1.pem")
+	mustWrite(t, keyPath, "SECRET")
+	if err := os.Chmod(keyPath, 0o000); err != nil {
+		t.Skipf("cannot make a file unreadable here: %v", err)
+	}
+	if f, err := os.Open(keyPath); err == nil {
+		f.Close()
+		t.Skip("running as root; cannot make a file unreadable")
+	}
+	t.Setenv(EnvDataDir, dir)
+
+	res, err := Build(testKey(), "hive-x", testLogger())
+	if err != nil {
+		t.Fatalf("an unreadable app key must not abort the backup: %v", err)
+	}
+	if _, ok := res.Skipped["gh-app-key-1.pem"]; !ok {
+		t.Fatal("an unreadable app key must be recorded in Skipped, not silently absent")
+	}
+	// The key's contents must not have leaked into the archive.
+	man, err := hubbackup.Verify(testKey(), res.Sealed)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	for _, f := range man.Files {
+		if strings.Contains(f.Path, "gh-app-key-1") {
+			t.Fatal("an unreadable key must not appear in the archive")
+		}
+	}
+}
+
+// An archive above MaxArchiveBytes must be refused rather than streamed to a
+// browser. Verified by driving the shared builder directly at a low cap, since
+// producing a real 256MiB archive in a unit test is not reasonable.
+func TestArchiveSizeCapIsEnforcedByTheSharedBuilder(t *testing.T) {
+	b := hubbackup.NewBuilder()
+	if err := b.AddBytes("spoke/big", 0o600, []byte(strings.Repeat("x", 8192))); err != nil {
+		t.Fatal(err)
+	}
+	man := &hubbackup.Manifest{FormatVersion: hubbackup.FormatVersion()}
+	if _, err := b.Finish(testKey(), man, 64); err == nil {
+		t.Fatal("an archive above the cap must be refused before streaming")
+	}
+
+	if MaxArchiveBytes <= 0 {
+		t.Fatal("MaxArchiveBytes must be a positive cap")
+	}
+}
+
+// Build must pass a real cap to the shared builder rather than 0 (unlimited).
+// Driving the builder directly proves the cap works but says nothing about
+// whether Build actually applies it, so this asserts the wiring by shrinking
+// the cap and confirming a large spoke is refused.
+func TestBuildAppliesTheArchiveCap(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, configBackupFile), "live: config\n")
+	// Highly incompressible content so the sealed archive really exceeds a
+	// small cap rather than gzipping down below it.
+	big := make([]byte, 2<<20)
+	for i := range big {
+		big[i] = byte(i * 2654435761 >> 13)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "hive-state.json"), big, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvDataDir, dir)
+
+	origCap := archiveCapBytes
+	archiveCapBytes = 4096
+	t.Cleanup(func() { archiveCapBytes = origCap })
+
+	if _, err := Build(testKey(), "hive-x", testLogger()); err == nil {
+		t.Fatal("Build must refuse an archive above the cap rather than " +
+			"streaming it to a browser")
+	}
+}

--- a/v2/pkg/spokebackup/backup_test.go
+++ b/v2/pkg/spokebackup/backup_test.go
@@ -216,11 +216,21 @@ func TestManifestVerifies(t *testing.T) {
 
 // TestBuildRefusesWithoutKey — no key must mean no archive, never a plaintext
 // one containing GitHub App private keys.
+// The assertion is on the MESSAGE, not merely that an error occurred: an empty
+// key also fails later inside Seal (AES rejects a zero-length key), so a test
+// accepting any error still passes with the explicit guard removed. The
+// distinct refusal is what proves Build never even attempts to assemble an
+// unencrypted archive carrying GitHub App private keys.
 func TestBuildRefusesWithoutKey(t *testing.T) {
 	dir := seedSpoke(t)
 	t.Setenv(EnvDataDir, dir)
-	if _, err := Build(nil, "hive-abc123", testLogger()); err == nil {
+	_, err := Build(nil, "hive-abc123", testLogger())
+	if err == nil {
 		t.Fatal("Build produced an archive with no key")
+	}
+	if !strings.Contains(err.Error(), "refusing to build an unencrypted spoke backup") {
+		t.Fatalf("a missing key must be refused up front, not incidentally by the "+
+			"cipher; got %v", err)
 	}
 }
 


### PR DESCRIPTION
## The coverage gate has never executed

While starting work on raising coverage to 90%, I found the gate itself is not enforcing anything.

**`Check per-package coverage` in `coverage-hourly.yml` reports `skipped` on every run.** The `go test -coverprofile` step immediately before it exits non-zero, which aborts the job before the floor check is reached. Last 100 hourly runs: **52 failure / 48 success**. Issue #2191 has accumulated **41 comments** all titled "packages below 90% threshold" when the real cause was a test failure — record corrected [there](https://github.com/kubestellar/hive/issues/2191#issuecomment-5145004142).

Three separate defects:

1. **No PR enforcement at all.** The floor lives only in `coverage-hourly.yml`, whose triggers are `schedule` + `workflow_dispatch` — there is no `pull_request` trigger. The workflow that *does* run on PRs (`v2-ci.yml`) never runs `go test ./pkg/...`. This is why #2350 went green while knowingly leaving `pkg/hub` below the floor.
2. **The gate step never runs**, because `pkg/dashboard` was failing (fixed here).
3. **`grep '^ok'` silently drops packages** — both failing ones (`FAIL`) and test-less ones (`?  [no test files]`). `apiproxy`, `channels`, `claude` are all at 0.0% and **cannot currently fail the gate**.

Defects 1 and 3 are fixed in a follow-up PR, sequenced last so the gate goes green on arrival instead of blocking in-flight work.

## Results (measured with the gate's own command)

| package | before | after |
|---|---:|---:|
| `pkg/dashboard` | **FAIL** (79.9%) | **ok** 80.4% |
| `pkg/hubbackup` | 36.9% | **91.0%** |
| `pkg/spokebackup` | 80.0% | **92.9%** |
| `pkg/hub` | 87.9% | **89.5%** — short, see below |

All 27 packages pass. **45 mutations verified, 41 caught.**

## 1. `pkg/dashboard` — the blocker

`GitHubConfig.OAuthBaseURL()/OAuthAPIURL()` are pinned to public github.com so GHE hives log in with a github.com identity — correct and deliberate — but they ignored their receiver:

```go
func (g GitHubConfig) OAuthBaseURL() string { return DefaultGitHubBaseURL }
```

So tests that carefully pointed `Config.GitHub.BaseURL/APIURL` at an `httptest` server had those URLs discarded, and every run POSTed to the real `https://github.com/login/device/code`. **This burned real github.com rate limit shared with production hives, hourly.**

Fix: `OAuth{Base,API}URLOverride` tagged `yaml:"-"` so they can never be set from a `hive.yaml`, the hub, or the config API — Go test code only. Plus a `TestMain` that refuses any non-loopback dial, so a future test that forgets the override fails loudly instead of leaking traffic.

Suite time dropped **31.7s → 5.1s**; the difference was real network latency.

Three tests asserted a stale contract (blank `oauth_client_id` → 400). `OAuthClientIDResolved()` now falls back to the public client, so 400 is no longer correct — rewritten to assert real behaviour rather than bent to match.

## 2. `pkg/hubbackup` 36.9% → 91.0%

Disaster-recovery code. Production changes are **seams only**, identical behaviour when unset: `execCommandContext` for kubectl, and `endpointOverride`/`HIVE_BACKUP_OCI_ENDPOINT` for OCI Object Storage.

- Full DR round trip: seal → verify → open → extract, asserting `hmac.key` and spoke config survive byte for byte.
- **Corruption is rejected**: flipped ciphertext, flipped nonce, truncation, empty input, digest mismatch, manifest listing an absent file, missing manifest, unknown format version.
- Key handling: unset `HIVE_BACKUP_KEY` hard-fails *without writing anything*; a wrong key fails cleanly; nonces are never reused.
- **Graceful degradation**: an Evicted spoke is recorded in `SpokeErrors` and NOT dropped — the 50/50 → 49/50 bug shape. A test asserts `captured + errored == fleet size`.

The mutation that reproduces the original bug (serializing the manifest *before* copying digests in, so `Verify` passes while checking nothing) is **caught**.

## 3. `pkg/spokebackup` 80.0% → 92.9%

One seam (`archiveCapBytes`) so a test can prove `Build` enforces the cap.

The headline mutation — swapping `configBackupFile` to `"hive.yaml"` — is **caught**, so a regression that silently backs up stale config now fails CI. A restore through the shared `hubbackup.Extract` asserts the authoritative `.bak` comes back byte for byte and the stale `hive.yaml` is never archived.

## 4. `pkg/hub` 87.9% → 89.5% — deliberately short

**No production code changed — all three files are new tests.** No seams were needed: the package already exposes `saasHivesDir`, `k8sNamespacePath`, `latestSHAByBranch`, and kubectl is faked with the established scripted-binary-on-PATH pattern that `TestMain` (#2287) backstops. **No test shells to a real kubectl or touches a live cluster.**

Covers the previously-0% bulk fleet operations, including the contract where an undeliverable **restart** is a failure but an undeliverable **upgrade** is a success via heartbeat — getting that backwards either hides a failed restart or breaks the only delivery path for a firewalled cluster.

**Why short of 90%:** the residual 770 uncovered statements sit in 525 blocks, **488 of them 1–2 statements each** — overwhelmingly kubectl/live-GitHub error branches in `provisionHive`, `watchHubRollout`, `UpgradeSelfToSHA` and the contribute proxies. Reaching 90% needs only ~45 more statements, but every remaining candidate needs either a real cluster or a seam refactor across provisioning code that is far riskier than 0.5% is worth. Per the constraint on this work, `pkg/hub` is left short rather than taking that path. **The gate keeps its 90 floor** — closing the last 0.5% should be a separate, deliberate refactor.

## Test quality

Mutation-verified throughout: change the production code so the behaviour breaks, confirm the test fails, restore. **Five tests were strengthened after their mutation survived** — that is the point of doing it:

- `Extract`'s pre-verification: corrupting the GCM tag is caught by `Open` anyway, so the test proved nothing. Now uses a GCM-**valid** archive whose digests do not match, which only `Verify` rejects.
- `LoadKey`/`Build` empty key: an empty key also fails later in the cipher, so "any error" passed with the guard removed. Now asserts the explicit refusal.
- Manifest-lists-missing-file: the checksum-mismatch message also contains the filename. Now asserts the distinct "does not contain it" diagnostic.
- Archive cap: the original drove the builder directly, proving nothing about `Build`. Now shrinks the cap and feeds `Build` incompressible content.
- Empty namespace: the k8s mock answered 200 for any path. Now rejects a path with an empty namespace segment.

Four knowingly-unkilled mutations, all equivalent mutants, documented in the commit messages (redundant `Run` self-verify ×2, redundant blanking of an already-empty return, and a guard whose removal produces a request the API rejects anyway).

One test initially asserted that `branchToTag` strips spaces. It does not — it only translates `/`. Investigating showed `validateBulkBranch` gates the handler, so a branch with a space cannot reach it; the test was asserting a contract the code never promised and was corrected rather than the code changed.

## Follow-ups

- `apiproxy` / `channels` / `claude` from 0% (real tests, no `PKG_THRESHOLD` waivers)
- **Gate hardening last**: `^ok` grep also catches `FAIL` and `[no test files]`, plus the `pull_request` trigger