### PR TITLE
🐛 fix(hub): make the admin Users section collapsible and let the user edit form be closed

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -525,7 +525,7 @@ func (s *HubServer) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request
 	username := r.PathValue("username")
 	u := loadSaaSUser(username)
 	if u == nil {
-		http.Error(w, `{"error":"user not found"}`, http.StatusNotFound)
+		writeJSONError(w, http.StatusNotFound, "user not found")
 		return
 	}
 	// Free-text fields land on a PVC, so bound the body before decoding it.
@@ -538,7 +538,7 @@ func (s *HubServer) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request
 		Notes     *string `json:"notes"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	if body.SaaSQuota != nil {
@@ -558,7 +558,14 @@ func (s *HubServer) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request
 	if body.Notes != nil {
 		u.Notes = truncateRunes(strings.TrimSpace(*body.Notes), maxContactNotesLen)
 	}
-	saveSaaSUser(u)
+	// A failed write is the one outcome the admin MUST hear about: the dashboard
+	// closes the editor on a 2xx, so reporting success here after the PVC write
+	// failed would silently discard the edit.
+	if err := saveSaaSUser(u); err != nil {
+		s.logger.Error("admin update user: save failed", "target", username, "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "failed to save user record")
+		return
+	}
 	// Do not log the note bodies — they are free text and may hold anything an
 	// admin jotted down. Log only that contact fields were touched.
 	s.logger.Info("audit: admin updated user", "target", username, "quota", u.SaaSQuota, "blocked", u.Blocked,
@@ -575,16 +582,16 @@ func (s *HubServer) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request
 func (s *HubServer) handleAdminDeleteUser(w http.ResponseWriter, r *http.Request) {
 	username := r.PathValue("username")
 	if username == hubAdminUsername {
-		http.Error(w, `{"error":"cannot delete the hub admin"}`, http.StatusForbidden)
+		writeJSONError(w, http.StatusForbidden, "cannot delete the hub admin")
 		return
 	}
 	if strings.Contains(username, "..") || strings.Contains(username, "/") || strings.Contains(username, "\\") {
-		http.Error(w, `{"error":"invalid username"}`, http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "invalid username")
 		return
 	}
 	u := loadSaaSUser(username)
 	if u == nil {
-		http.Error(w, `{"error":"user not found"}`, http.StatusNotFound)
+		writeJSONError(w, http.StatusNotFound, "user not found")
 		return
 	}
 	var ownedHives []string
@@ -594,14 +601,14 @@ func (s *HubServer) handleAdminDeleteUser(w http.ResponseWriter, r *http.Request
 		}
 	}
 	if len(ownedHives) > 0 {
-		msg, _ := json.Marshal(fmt.Sprintf("user still owns %d hive(s); delete or reassign them first: %s", len(ownedHives), strings.Join(ownedHives, ", ")))
-		http.Error(w, `{"error":`+string(msg)+`}`, http.StatusConflict)
+		writeJSONError(w, http.StatusConflict, fmt.Sprintf("user still owns %d hive(s); delete or reassign them first: %s",
+			len(ownedHives), strings.Join(ownedHives, ", ")))
 		return
 	}
 	path := filepath.Join(saasUsersDir, username+".json")
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		s.logger.Warn("admin delete user: remove failed", "target", username, "error", err)
-		http.Error(w, `{"error":"failed to delete user record"}`, http.StatusInternalServerError)
+		writeJSONError(w, http.StatusInternalServerError, "failed to delete user record")
 		return
 	}
 	s.logger.Info("audit: admin deleted user", "target", username, "by", s.getAuthUser(r))
@@ -2176,7 +2183,7 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxCreateHiveBodyBytes)
 	var req CreateHiveRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 
@@ -2541,7 +2548,7 @@ func (s *HubServer) handleMigrateHive(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, migrateMaxBodyBytes)
 	var req MigrateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 
@@ -4548,7 +4555,7 @@ func (s *HubServer) handleAccessRemove(w http.ResponseWriter, r *http.Request) {
 	}
 	target := loadSaaSUser(targetUsername)
 	if target == nil {
-		http.Error(w, `{"error":"user not found"}`, http.StatusNotFound)
+		writeJSONError(w, http.StatusNotFound, "user not found")
 		return
 	}
 	if target.Hives[hiveID] == "owner" {
@@ -5113,7 +5120,7 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 		AuthMethod  string `json:"auth_method"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	if body.Org == "" || body.Repos == "" {
@@ -5255,7 +5262,7 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 		// An empty body is valid (auto-pick); ignore EOF/empty decode errors and
 		// fall through to auto-pick. Any non-empty malformed body is rejected.
 		if err := json.NewDecoder(r.Body).Decode(&approveBody); err != nil && err != io.EOF {
-			http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
+			writeJSONError(w, http.StatusBadRequest, "invalid JSON")
 			return
 		}
 	}
@@ -5951,7 +5958,7 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxAssignRequestBodyBytes)
 	var body AssignHiveRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 
@@ -6251,7 +6258,7 @@ func (s *HubServer) handleUserToken(w http.ResponseWriter, r *http.Request) {
 
 	user := loadSaaSUser(body.Username)
 	if user == nil {
-		http.Error(w, `{"error":"user not found"}`, http.StatusNotFound)
+		writeJSONError(w, http.StatusNotFound, "user not found")
 		return
 	}
 
@@ -6998,10 +7005,17 @@ const dashboardHTML = `<!DOCTYPE html>
 
     <div id="admin-section" style="display:none;margin-top:48px">
       <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px">
-        <h2 style="font-size:1.3rem;color:var(--accent)">Hub Admin — Users</h2>
+        <h2 id="admin-users-header" role="button" tabindex="0" aria-expanded="false" aria-controls="admin-users-body"
+            onclick="toggleAdminUsers()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleAdminUsers();}"
+            style="font-size:1.3rem;color:var(--accent);margin:0;cursor:pointer;user-select:none;display:flex;align-items:center;gap:8px">
+          <span id="admin-users-toggle" aria-hidden="true" style="font-size:0.7rem">&#9656;</span><span>Hub Admin &mdash; Users</span>
+          <span id="admin-users-count" style="font-size:0.75rem;color:var(--muted);font-weight:400"></span>
+        </h2>
         <input type="text" id="user-search" placeholder="Search users..." oninput="filterUsers()" style="padding:8px 14px;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem;width:250px">
       </div>
-      <div id="users-container"><div class="loading">Loading users...</div></div>
+      <div id="admin-users-body" style="display:none">
+        <div id="users-container"><div class="loading">Loading users...</div></div>
+      </div>
     </div>
 
     <div id="hub-banner-section" style="display:none;margin-top:48px">
@@ -13168,6 +13182,69 @@ const dashboardHTML = `<!DOCTYPE html>
     var _hiveRegistry = [];
     var _userSortKey = 'created_at', _userSortAsc = false;
 
+    /* --- Collapsible "Hub Admin — Users" section ---
+       The roster runs to ~90 records, so an expanded users table pushes the
+       Hub Banner and Cluster Health sections far below the fold. An operator
+       is normally here for hives, not for the roster, so this follows the same
+       convention as the other long admin sections (Past Requests, Cluster
+       Health): collapsed by default, remembered per browser under the same
+       'hive-*-collapsed' localStorage key convention. Absent key means
+       collapsed; only an explicit 'false' expands, so a first visit and a
+       corrupted value behave identically. */
+    var ADMIN_USERS_COLLAPSED_KEY = 'hive-admin-users-collapsed';
+    var _adminUsersCollapsed = localStorage.getItem(ADMIN_USERS_COLLAPSED_KEY) !== 'false';
+
+    /* applyAdminUsersCollapsed pushes _adminUsersCollapsed onto the DOM. Split
+       out from the toggle so the initial render and expandAdminUsersSection()
+       can restore state without duplicating the show/hide + aria bookkeeping. */
+    function applyAdminUsersCollapsed() {
+      var body = document.getElementById('admin-users-body');
+      var toggle = document.getElementById('admin-users-toggle');
+      var header = document.getElementById('admin-users-header');
+      if (body) body.style.display = _adminUsersCollapsed ? 'none' : '';
+      /* ▸ collapsed / ▾ expanded */
+      if (toggle) toggle.innerHTML = _adminUsersCollapsed ? '&#9656;' : '&#9662;';
+      if (header) header.setAttribute('aria-expanded', _adminUsersCollapsed ? 'false' : 'true');
+    }
+
+    /* persistAdminUsersCollapsed writes the current state. localStorage throws
+       under private-browsing quota; collapsing must still work in-session, so
+       the write is best-effort. */
+    function persistAdminUsersCollapsed() {
+      try {
+        localStorage.setItem(ADMIN_USERS_COLLAPSED_KEY, _adminUsersCollapsed ? 'true' : 'false');
+      } catch(e) {}
+    }
+
+    function toggleAdminUsers() {
+      _adminUsersCollapsed = !_adminUsersCollapsed;
+      persistAdminUsersCollapsed();
+      applyAdminUsersCollapsed();
+    }
+
+    /* expandAdminUsersSection opens the section and PERSISTS that, mirroring
+       expandAllHiveSections (#2348). Anything that reveals a row inside this
+       section must go through here rather than flipping display directly: an
+       in-memory-only expand silently re-collapses on the next reload, so the
+       row the operator was just sent to would vanish again. */
+    function expandAdminUsersSection() {
+      if (!_adminUsersCollapsed) return;
+      _adminUsersCollapsed = false;
+      persistAdminUsersCollapsed();
+      applyAdminUsersCollapsed();
+    }
+
+    /* The count beside the header is the only signal of roster size while the
+       section is collapsed, so it is kept current on every render. */
+    function updateAdminUsersCount(shown, total) {
+      var el = document.getElementById('admin-users-count');
+      if (!el) return;
+      var n = Number(total) || 0;
+      el.textContent = (Number(shown) === n)
+        ? '(' + n + ')'
+        : '(' + (Number(shown) || 0) + ' of ' + n + ')';
+    }
+
     function fmtUserTS(ts) {
       if (!ts) return '';
       var d = new Date(ts);
@@ -13211,6 +13288,7 @@ const dashboardHTML = `<!DOCTYPE html>
         if (typeof va === 'number' && typeof vb === 'number') return _userSortAsc ? va - vb : vb - va;
         return _userSortAsc ? String(va).localeCompare(String(vb)) : String(vb).localeCompare(String(va));
       });
+      updateAdminUsersCount(sorted.length, (_allUsers || []).length);
       renderUsers(sorted, true);
     }
 
@@ -13231,6 +13309,10 @@ const dashboardHTML = `<!DOCTYPE html>
         }
         _adminLoaded = true;
         document.getElementById('admin-section').style.display = '';
+        /* The section is display:none until the admin check passes, so this is
+           the first point at which the persisted collapse state can be pushed
+           onto real DOM. Idempotent, so running it on every poll is fine. */
+        applyAdminUsersCollapsed();
         document.getElementById('hub-banner-section').style.display = '';
         document.getElementById('btn-send-banner-top').style.display = '';
         loadActiveBanner();
@@ -13406,7 +13488,8 @@ const dashboardHTML = `<!DOCTYPE html>
       var lbl = 'display:block;font-size:0.66rem;color:var(--muted);margin-bottom:3px;text-transform:uppercase;letter-spacing:0.04em';
       var user = escAttr(u.github_username);
       return '<tr id="' + contactPanelId(u.github_username) + '" style="display:' + (open ? '' : 'none') + '">' +
-        '<td class="contact-panel-cell" colspan="' + USERS_TABLE_COLSPAN + '" style="background:var(--surface)">' +
+        /* position:relative anchors the absolutely-positioned × below. */
+        '<td class="contact-panel-cell" colspan="' + USERS_TABLE_COLSPAN + '" style="background:var(--surface);position:relative">' +
         '<div style="padding:10px 14px 12px 40px;display:flex;gap:14px;flex-wrap:wrap;align-items:flex-start">' +
           '<div style="flex:1 1 ' + CONTACT_W_NAME_BASIS + ';min-width:' + CONTACT_W_NAME_MIN + '">' +
             '<label style="' + lbl + '">Full name</label>' +
@@ -13423,9 +13506,113 @@ const dashboardHTML = `<!DOCTYPE html>
             '<textarea data-contact-user="' + user + '" data-contact-field="notes" rows="' + CONTACT_NOTES_ROWS + '"' +
               ' maxlength="' + CONTACT_MAX_NOTES + '" style="' + fld + ';resize:vertical;font-family:inherit">' + esc(u.notes || '') + '</textarea>' +
           '</div>' +
-          '<div style="align-self:flex-end;font-size:0.65rem;color:var(--muted);padding-bottom:6px">Saves on blur</div>' +
-        '</div></td></tr>';
+          '<div style="align-self:flex-end;display:flex;align-items:center;gap:10px;padding-bottom:4px">' +
+            '<span style="font-size:0.65rem;color:var(--muted)">Saves on blur &middot; Esc to close</span>' +
+            '<button type="button" data-contact-close="' + user + '"' +
+              ' style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;' +
+              'color:var(--muted);cursor:pointer;font-size:0.7rem">Close</button>' +
+          '</div>' +
+        '</div>' +
+        /* The × sits top-right of the panel, the conventional place to look for
+           a dismiss control, and duplicates the Close button so the affordance
+           is visible without reading to the end of a wide row. */
+        '<button type="button" data-contact-close="' + user + '" aria-label="Close editor for ' + user + '"' +
+          ' style="position:absolute;top:6px;right:10px;background:none;border:none;color:var(--muted);' +
+          'cursor:pointer;font-size:1rem;line-height:1;padding:2px 6px">&#10005;</button>' +
+        '</td></tr>';
     }
+
+    /* contactPanelHasUnsavedEdits reports whether anything in this user's panel
+       has been typed but not yet handed to the save path. The fields save on
+       blur, so text that has never been blurred lives ONLY in the DOM node —
+       closing the panel without a warning would be real data loss. */
+    function contactPanelHasUnsavedEdits(username) {
+      if (!username) return false;
+      for (var k in _contactDirty) {
+        if (Object.prototype.hasOwnProperty.call(_contactDirty, k) &&
+            k.indexOf(username + '::') === 0) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    /* closeContactPanel is the single exit for the editor: the ×, the Close
+       button, Escape, and a successful save all funnel through here.
+
+       Unsaved text is committed rather than discarded when the admin confirms:
+       blur normally saves, but Escape and the × can fire while a field still
+       has focus and has never blurred, so the value would otherwise be lost. */
+    async function closeContactPanel(username, opts) {
+      if (!username) return;
+      var force = !!(opts && opts.force);
+      if (!force && contactPanelHasUnsavedEdits(username)) {
+        var keep = await hiveConfirm('You have unsaved changes for ' + username +
+          '. Save them and close?');
+        if (!keep) return;
+        /* Save first, and close only if the save actually landed. A failed
+           save keeps the editor open with the typed text still in the fields
+           so the admin can read the toast, fix the cause and retry — closing
+           here would discard the very edit the server just rejected. */
+        var saved = await commitContactPanelEdits(username);
+        if (!saved) return;
+      }
+      _contactExpandedUsers[username] = false;
+      var row = document.getElementById(contactPanelId(username));
+      if (row) row.style.display = 'none';
+    }
+
+    /* commitContactPanelEdits flushes every dirty field for one user through
+       the normal save path and resolves true only when every one succeeded.
+       saveContactField is a no-op for unchanged values, so this is safe to
+       call broadly. Dirty marks are cleared only for fields that saved, so a
+       rejected field stays dirty and the poll keeps backing off rather than
+       rebuilding the table over text the admin has not managed to store. */
+    async function commitContactPanelEdits(username) {
+      var prefix = username + '::';
+      var keys = Object.keys(_contactDirty || {}).filter(function(k) {
+        return k.indexOf(prefix) === 0;
+      });
+      var allOK = true;
+      for (var i = 0; i < (keys || []).length; i++) {
+        var k = keys[i];
+        var field = k.substring(prefix.length);
+        var ok = await saveContactField(username, field, _contactDirty[k]);
+        if (ok) { delete _contactDirty[k]; } else { allOK = false; }
+      }
+      return allOK;
+    }
+
+    /* openContactPanelUsername returns the username of the contact editor that
+       currently owns focus, or '' when focus is elsewhere. Escape must only
+       close the editor the admin is actually working in — a stray Escape with
+       focus on the page body should fall through to the global handler that
+       closes create-modal and friends (#2321). */
+    function openContactPanelUsername() {
+      var active = document.activeElement;
+      if (!active || !active.closest) return '';
+      var cell = active.closest('.contact-panel-cell');
+      if (!cell) return '';
+      var field = cell.querySelector('[data-contact-user]');
+      return field ? (field.getAttribute('data-contact-user') || '') : '';
+    }
+
+    /* Escape-to-close for the contact editor. Registered in the CAPTURE phase
+       so it can decide before the global Escape handler (#2321) runs, and it
+       stops propagation ONLY when it actually closed an editor — otherwise the
+       global handler keeps its existing behaviour for create-modal, the
+       request modal, the confirm overlay and the timeline/access modals. */
+    document.addEventListener('keydown', function(e) {
+      if (e.key !== 'Escape') return;
+      /* hiveConfirm puts a modal overlay on top and binds its own Escape; while
+         one is up it owns the key, so never steal it. */
+      if (document.querySelector('.hive-confirm-overlay')) return;
+      var username = openContactPanelUsername();
+      if (!username) return;
+      e.stopPropagation();
+      e.preventDefault();
+      closeContactPanel(username);
+    }, true);
 
     // bindContactPanels attaches listeners after renderUsers writes the table.
     // Listeners rather than inline on* attributes: esc() leaves apostrophes
@@ -13439,6 +13626,16 @@ const dashboardHTML = `<!DOCTYPE html>
       Array.prototype.forEach.call(toggles || [], function(btn) {
         btn.addEventListener('click', function() {
           toggleContactPanel(btn.getAttribute('data-contact-toggle'));
+        });
+      });
+      /* The × and the Close button share data-contact-close, so one binding
+         covers both. Bound here rather than as inline on* attributes for the
+         same reason as the toggles: nothing user-controlled is interpolated
+         into executable markup. */
+      var closers = container.querySelectorAll('[data-contact-close]');
+      Array.prototype.forEach.call(closers || [], function(btn) {
+        btn.addEventListener('click', function() {
+          closeContactPanel(btn.getAttribute('data-contact-close'));
         });
       });
       var fields = container.querySelectorAll('[data-contact-field]');
@@ -13476,31 +13673,47 @@ const dashboardHTML = `<!DOCTYPE html>
       });
     }
 
+    /* The Edit button toggles. Closing goes through closeContactPanel so the
+       unsaved-changes warning applies however the panel is dismissed; opening
+       stays a plain display flip, which is what keeps focus and caret intact. */
     function toggleContactPanel(username) {
       if (!username) return;
-      _contactExpandedUsers[username] = !_contactExpandedUsers[username];
+      if (_contactExpandedUsers[username]) { closeContactPanel(username); return; }
+      _contactExpandedUsers[username] = true;
       var row = document.getElementById(contactPanelId(username));
-      if (row) row.style.display = _contactExpandedUsers[username] ? '' : 'none';
+      if (row) row.style.display = '';
     }
 
     // Last value saved per user+field, so a blur that changed nothing (tabbing
     // through, or a re-render restoring focus) does not fire a pointless PUT.
     var _contactLastSaved = {};
 
+    // Always returns a Promise<boolean> so callers can sequence on the outcome;
+    // a no-op resolves true because "nothing to do" is not a failure.
     function saveContactField(username, field, value) {
-      if (!username || !field) return;
+      if (!username || !field) return Promise.resolve(true);
       var key = username + '::' + field;
       var current = _allUsers ? (_allUsers.find(function(x) { return x.github_username === username; }) || {}) : {};
       var previous = (_contactLastSaved[key] !== undefined) ? _contactLastSaved[key] : (current[field] || '');
       var next = (value || '').trim();
-      if (next === previous) return;
+      if (next === previous) return Promise.resolve(true);
       _contactLastSaved[key] = next;
       // Keep the in-memory copy in step so the next poll's signature check does
       // not treat our own edit as an external change and re-render mid-typing.
       if (current) current[field] = next;
       var payload = {};
       payload[field] = next;
-      updateUser(username, payload);
+      // On failure, roll the optimistic bookkeeping back to the previous value.
+      // Without this the cache claims the value was stored, so the
+      // next-equals-previous short-circuit above would skip the retry of the very
+      // same value — the edit could never be saved again without a reload.
+      return updateUser(username, payload).then(function(ok) {
+        if (!ok) {
+          _contactLastSaved[key] = previous;
+          if (current) current[field] = previous;
+        }
+        return ok;
+      });
     }
 
     // scheduleDeferredUsersRender keeps re-checking until editing has stopped
@@ -13601,15 +13814,56 @@ const dashboardHTML = `<!DOCTYPE html>
       bindContactPanels();
     }
 
+    /* updateUser previously ignored the response entirely: a 404/400/500 was
+       indistinguishable from success, so a rejected edit looked like it had
+       been saved until the next poll quietly reverted the field. It now checks
+       resp.ok and reports the server's reason, and returns a boolean so
+       callers can decide whether to close the editor.
+
+       readErrorMessage is used rather than a bare resp.json(): the handler
+       writes errors with writeJSONError so the body IS JSON, but a proxy or
+       middleware fault can still return HTML/plain text, and resp.json() on
+       that throws — which is exactly how #2348's handleAlertAck turned a real
+       cause into a generic "failed". */
+    async function readErrorMessage(resp, fallback) {
+      try {
+        var text = await resp.text();
+        if (text) {
+          try {
+            var parsed = JSON.parse(text);
+            if (parsed && parsed.error) return String(parsed.error);
+          } catch(je) {
+            /* Not JSON — show the raw text, which is still more useful than
+               a bare status code. */
+            return text.trim().substring(0, ERROR_TEXT_MAX_CHARS);
+          }
+        }
+      } catch(e) {}
+      return fallback + ' (HTTP ' + resp.status + ')';
+    }
+
+    /* Longest slice of a non-JSON error body shown in a toast. Long enough for
+       a real proxy/server message, short enough not to fill the screen. */
+    var ERROR_TEXT_MAX_CHARS = 200;
+
     async function updateUser(username, updates) {
       try {
-        await fetch('/api/saas/admin/users/' + encodeURIComponent(username), {
+        var resp = await fetch('/api/saas/admin/users/' + encodeURIComponent(username), {
           method: 'PUT',
           headers: {'Content-Type': 'application/json'},
           body: JSON.stringify(updates)
         });
+        if (!resp.ok) {
+          hiveToast('Could not save ' + username + ': ' +
+            await readErrorMessage(resp, 'update failed'), 'error');
+          return false;
+        }
         loadAdminUsers();
-      } catch(e) { hiveToast('Error: ' + e.message, 'error'); }
+        return true;
+      } catch(e) {
+        hiveToast('Could not save ' + username + ': ' + e.message, 'error');
+        return false;
+      }
     }
 
     async function deleteUser(username, hiveCount) {

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -13473,10 +13473,63 @@ const dashboardHTML = `<!DOCTYPE html>
       var summary = bits.length
         ? '<div style="display:flex;flex-direction:column;align-items:flex-start;text-align:left;gap:1px;max-width:220px;overflow:hidden">' + bits.join('') + '</div>'
         : '<span style="color:var(--muted);font-size:0.72rem">—</span>';
+      var open = !!(_contactExpandedUsers && _contactExpandedUsers[u.github_username]);
       var btn = '<button type="button" data-contact-toggle="' + escAttr(u.github_username) + '"' +
-        ' style="margin-top:2px;padding:1px 7px;background:none;border:1px solid var(--border);border-radius:4px;' +
-        'color:var(--muted);cursor:pointer;font-size:0.65rem">Edit</button>';
+        ' id="' + contactToggleId(u.github_username) + '"' +
+        ' aria-controls="' + contactPanelId(u.github_username) + '"' +
+        ' aria-expanded="' + (open ? 'true' : 'false') + '"' +
+        ' aria-label="' + escAttr(contactToggleAriaLabel(u.github_username, open)) + '"' +
+        ' style="' + contactToggleStyle(open) + '">' + contactToggleLabel(open) + '</button>';
       return summary + btn;
+    }
+
+    /* --- The Edit/Save toggle ---
+       The button in the CONTACT column is the operator's primary affordance:
+       "Edit" while the panel is shut, "Save" while it is open. Clicking Save
+       commits every pending field and closes the panel.
+
+       Save is styled as the primary action (accent border and text) so the eye
+       lands on it; the × and the Close button inside the panel remain the
+       escape hatches, and Escape still works. Making the row button the commit
+       is what gives an explicit save point WITHOUT fighting the per-field blur
+       saves: blur keeps storing silently as the admin tabs around, and this
+       button is the only thing that closes on success. */
+
+    /* Style is derived from state in one place so the initial markup and the
+       live in-place update below can never drift apart. */
+    function contactToggleStyle(open) {
+      var color = open ? 'var(--accent)' : 'var(--muted)';
+      return 'margin-top:2px;padding:1px 7px;background:none;border:1px solid ' + color +
+        ';border-radius:4px;color:' + color + ';cursor:pointer;font-size:0.65rem' +
+        (open ? ';font-weight:600' : '');
+    }
+
+    function contactToggleLabel(open) { return open ? 'Save' : 'Edit'; }
+
+    /* The accessible name carries the username as well as the verb, because a
+       screen-reader user tabbing a table of ~90 identical "Save" buttons needs
+       to know which row they are on. */
+    function contactToggleAriaLabel(username, open) {
+      return (open ? 'Save contact details for ' : 'Edit contact details for ') + String(username || '');
+    }
+
+    function contactToggleId(username) {
+      return 'contact-toggle-' + String(username || '').replace(/[^A-Za-z0-9_-]/g, '_');
+    }
+
+    /* refreshContactToggleLabel re-derives the button from _contactExpandedUsers
+       and writes label, style, aria-expanded and the accessible name TOGETHER.
+       Updating the visible text without the aria state would leave a screen
+       reader announcing "Edit, collapsed" over an open editor. */
+    function refreshContactToggleLabel(username) {
+      if (!username) return;
+      var btn = document.getElementById(contactToggleId(username));
+      if (!btn) return;
+      var open = !!(_contactExpandedUsers && _contactExpandedUsers[username]);
+      btn.textContent = contactToggleLabel(open);
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      btn.setAttribute('aria-label', contactToggleAriaLabel(username, open));
+      btn.setAttribute('style', contactToggleStyle(open));
     }
 
     // renderContactPanelRow is the expandable editor row that follows each user
@@ -13507,10 +13560,10 @@ const dashboardHTML = `<!DOCTYPE html>
               ' maxlength="' + CONTACT_MAX_NOTES + '" style="' + fld + ';resize:vertical;font-family:inherit">' + esc(u.notes || '') + '</textarea>' +
           '</div>' +
           '<div style="align-self:flex-end;display:flex;align-items:center;gap:10px;padding-bottom:4px">' +
-            '<span style="font-size:0.65rem;color:var(--muted)">Saves on blur &middot; Esc to close</span>' +
+            '<span style="font-size:0.65rem;color:var(--muted)">Save closes &middot; Esc cancels</span>' +
             '<button type="button" data-contact-close="' + user + '"' +
               ' style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;' +
-              'color:var(--muted);cursor:pointer;font-size:0.7rem">Close</button>' +
+              'color:var(--muted);cursor:pointer;font-size:0.7rem">Cancel</button>' +
           '</div>' +
         '</div>' +
         /* The × sits top-right of the panel, the conventional place to look for
@@ -13557,9 +13610,7 @@ const dashboardHTML = `<!DOCTYPE html>
         var saved = await commitContactPanelEdits(username);
         if (!saved) return;
       }
-      _contactExpandedUsers[username] = false;
-      var row = document.getElementById(contactPanelId(username));
-      if (row) row.style.display = 'none';
+      setContactPanelOpen(username, false);
     }
 
     /* commitContactPanelEdits flushes every dirty field for one user through
@@ -13573,12 +13624,38 @@ const dashboardHTML = `<!DOCTYPE html>
       var keys = Object.keys(_contactDirty || {}).filter(function(k) {
         return k.indexOf(prefix) === 0;
       });
+      /* Also flush whatever is currently in the panel's inputs. The commit can
+         be triggered by a click on Save while a field still holds focus and has
+         never blurred, so its text may not be in _contactDirty yet. */
+      var panel = document.getElementById(contactPanelId(username));
+      if (panel) {
+        var live = panel.querySelectorAll('[data-contact-field]');
+        Array.prototype.forEach.call(live || [], function(el) {
+          var f = el.getAttribute('data-contact-field');
+          if (!f) return;
+          var k = prefix + f;
+          _contactDirty[k] = el.value;
+          if (keys.indexOf(k) < 0) keys.push(k);
+        });
+      }
+      /* Saves are sequential, not Promise.all: the handler is a read-modify-write
+         over one JSON file per user, so three concurrent PUTs for the same user
+         can interleave and lose a field. */
       var allOK = true;
       for (var i = 0; i < (keys || []).length; i++) {
         var k = keys[i];
         var field = k.substring(prefix.length);
+        /* Not silent: this IS the explicit commit, so a failure here is exactly
+           what the admin needs to see. */
         var ok = await saveContactField(username, field, _contactDirty[k]);
         if (ok) { delete _contactDirty[k]; } else { allOK = false; }
+      }
+      /* A field can be clean here yet still have failed earlier during a silent
+         blur-save. Surface that recorded reason rather than closing on what
+         would look like a no-op success. */
+      if (allOK && _contactLastError[username]) {
+        hiveToast('Could not save ' + username + ': ' + _contactLastError[username], 'error');
+        return false;
       }
       return allOK;
     }
@@ -13662,26 +13739,62 @@ const dashboardHTML = `<!DOCTYPE html>
         el.addEventListener('focus', markContactEditing);
         // Save on blur so an admin can tab between fields and type freely
         // without a request per keystroke.
+        //
+        // Blur-saves are SILENT: no toast on success, and on failure the value
+        // stays dirty so the field keeps the typed text and the Save button
+        // keeps reading "Save". Blur fires constantly (tabbing between the
+        // three fields, clicking the Save button itself), so a toast per blur
+        // would be noise, and a blur-triggered error would fire while the
+        // admin is mid-sentence in the next field. The Save button is the
+        // explicit commit point where failures are reported — see
+        // commitContactPanelEdits.
         el.addEventListener('blur', function() {
           markContactEditing();
-          // Clear dirty only after handing the value to the save path, so
-          // there is no window where the value is neither dirty nor saved.
+          // Clear dirty only once the save has actually landed, so there is no
+          // window where the value is neither dirty nor stored. A rejected
+          // blur-save therefore leaves the panel dirty and Save still armed.
           var pending = el.value;
-          saveContactField(user, field, pending);
-          delete _contactDirty[key];
+          saveContactField(user, field, pending, {silent: true}).then(function(ok) {
+            if (ok && _contactDirty[key] === pending) delete _contactDirty[key];
+            refreshContactToggleLabel(user);
+          });
         });
       });
     }
 
-    /* The Edit button toggles. Closing goes through closeContactPanel so the
-       unsaved-changes warning applies however the panel is dismissed; opening
-       stays a plain display flip, which is what keeps focus and caret intact. */
-    function toggleContactPanel(username) {
+    /* The row button is stateful: "Edit" when shut, "Save" when open.
+
+       Shut  -> open the panel (a plain display flip, which is what keeps focus
+                and caret intact) and relabel to Save.
+       Open  -> this IS the Save action: commit every pending field, and close
+                only if the commit succeeded. A failure keeps the panel open,
+                keeps the label on Save, and lets the error toast stand — with
+                a visible Save button, a false success is the worst outcome, so
+                nothing here closes on an unverified save.
+
+       Note this deliberately does NOT go through closeContactPanel: that path
+       is for the escape hatches (×, Close, Escape), where the right question is
+       "you have unsaved changes, save them?". Pressing Save has already
+       answered that question. */
+    async function toggleContactPanel(username) {
       if (!username) return;
-      if (_contactExpandedUsers[username]) { closeContactPanel(username); return; }
-      _contactExpandedUsers[username] = true;
+      if (_contactExpandedUsers[username]) {
+        var saved = await commitContactPanelEdits(username);
+        if (!saved) return;
+        setContactPanelOpen(username, false);
+        return;
+      }
+      setContactPanelOpen(username, true);
+    }
+
+    /* setContactPanelOpen is the ONLY place panel visibility changes, so the
+       row/panel display and the button's label + aria state can never fall out
+       of step with _contactExpandedUsers. */
+    function setContactPanelOpen(username, open) {
+      _contactExpandedUsers[username] = !!open;
       var row = document.getElementById(contactPanelId(username));
-      if (row) row.style.display = '';
+      if (row) row.style.display = open ? '' : 'none';
+      refreshContactToggleLabel(username);
     }
 
     // Last value saved per user+field, so a blur that changed nothing (tabbing
@@ -13690,7 +13803,9 @@ const dashboardHTML = `<!DOCTYPE html>
 
     // Always returns a Promise<boolean> so callers can sequence on the outcome;
     // a no-op resolves true because "nothing to do" is not a failure.
-    function saveContactField(username, field, value) {
+    // opts.silent suppresses the failure toast, for blur-saves where the Save
+    // button is the reporting point. The boolean result is unaffected.
+    function saveContactField(username, field, value, opts) {
       if (!username || !field) return Promise.resolve(true);
       var key = username + '::' + field;
       var current = _allUsers ? (_allUsers.find(function(x) { return x.github_username === username; }) || {}) : {};
@@ -13707,7 +13822,7 @@ const dashboardHTML = `<!DOCTYPE html>
       // Without this the cache claims the value was stored, so the
       // next-equals-previous short-circuit above would skip the retry of the very
       // same value — the edit could never be saved again without a reload.
-      return updateUser(username, payload).then(function(ok) {
+      return updateUser(username, payload, opts).then(function(ok) {
         if (!ok) {
           _contactLastSaved[key] = previous;
           if (current) current[field] = previous;
@@ -13846,7 +13961,21 @@ const dashboardHTML = `<!DOCTYPE html>
        a real proxy/server message, short enough not to fill the screen. */
     var ERROR_TEXT_MAX_CHARS = 200;
 
-    async function updateUser(username, updates) {
+    /* Reason for the most recent failed save, per user. A silent blur-save
+       records the cause here instead of toasting it, so the Save button can
+       report the REAL reason rather than a generic "failed" when the admin
+       finally commits. Cleared on any success for that user. */
+    var _contactLastError = {};
+
+    /* opts.silent suppresses the toast (blur-saves); the failure is still
+       recorded in _contactLastError and still returns false. */
+    async function updateUser(username, updates, opts) {
+      var silent = !!(opts && opts.silent);
+      function fail(reason) {
+        _contactLastError[username] = reason;
+        if (!silent) hiveToast('Could not save ' + username + ': ' + reason, 'error');
+        return false;
+      }
       try {
         var resp = await fetch('/api/saas/admin/users/' + encodeURIComponent(username), {
           method: 'PUT',
@@ -13854,15 +13983,13 @@ const dashboardHTML = `<!DOCTYPE html>
           body: JSON.stringify(updates)
         });
         if (!resp.ok) {
-          hiveToast('Could not save ' + username + ': ' +
-            await readErrorMessage(resp, 'update failed'), 'error');
-          return false;
+          return fail(await readErrorMessage(resp, 'update failed'));
         }
+        delete _contactLastError[username];
         loadAdminUsers();
         return true;
       } catch(e) {
-        hiveToast('Could not save ' + username + ': ' + e.message, 'error');
-        return false;
+        return fail(e.message);
       }
     }
 

--- a/v2/pkg/hub/saas_dashboard_admin_users_ux_test.go
+++ b/v2/pkg/hub/saas_dashboard_admin_users_ux_test.go
@@ -1,0 +1,288 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The admin Users section's collapse behaviour and the contact editor's close
+// affordances live inside the dashboardHTML raw string, so there is no Go
+// function to exercise directly. These tests guard the wiring: every handler
+// the markup names must exist, and the invariants that are cheap to break in a
+// refactor (an in-memory-only expand, a close that discards typed text, a save
+// error that never reaches the admin) must stay asserted somewhere CI runs.
+
+// TestDashboardAdminUsersCollapseSymbols asserts the collapse markup and its
+// handlers agree. A typo here is invisible to the Go compiler and shows up only
+// as a header that does not respond to clicks.
+func TestDashboardAdminUsersCollapseSymbols(t *testing.T) {
+	html := dashScript(t)
+
+	for _, want := range []string{
+		// Markup: the header is the toggle, and it is reachable by keyboard.
+		`id="admin-users-header"`,
+		`onclick="toggleAdminUsers()"`,
+		`aria-controls="admin-users-body"`,
+		`id="admin-users-body"`,
+		`id="admin-users-toggle"`,
+		`id="admin-users-count"`,
+		// Handlers.
+		"function toggleAdminUsers()",
+		"function applyAdminUsersCollapsed()",
+		"function persistAdminUsersCollapsed()",
+		"function expandAdminUsersSection()",
+		"function updateAdminUsersCount(",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("dashboard is missing admin-users collapse wiring: %s", want)
+		}
+	}
+
+	// Enter/Space must activate the header: it is a <h2 role="button">, which
+	// browsers do not give native keyboard activation.
+	if !strings.Contains(html, "toggleAdminUsers();}") {
+		t.Error("the admin Users header must be activatable from the keyboard")
+	}
+}
+
+// TestDashboardAdminUsersCollapseDefaultsAndPersistence pins the two things a
+// refactor most easily inverts: the default state, and the fact that the choice
+// survives a reload.
+func TestDashboardAdminUsersCollapseDefaultsAndPersistence(t *testing.T) {
+	html := dashScript(t)
+
+	// The key follows the hive-*-collapsed convention shared with the cluster
+	// health and past requests panels.
+	if !strings.Contains(html, `var ADMIN_USERS_COLLAPSED_KEY = 'hive-admin-users-collapsed';`) {
+		t.Error("admin Users collapse must persist under the hive-*-collapsed key convention")
+	}
+
+	// Collapsed by default: only an explicit 'false' expands, so a first visit
+	// and a corrupted value both land on collapsed. The roster runs to dozens of
+	// records and would otherwise push every section below it off the fold.
+	if !strings.Contains(html,
+		`var _adminUsersCollapsed = localStorage.getItem(ADMIN_USERS_COLLAPSED_KEY) !== 'false';`) {
+		t.Error("the admin Users section must default to collapsed (only 'false' expands)")
+	}
+
+	// The persisted state must actually be pushed onto the DOM once the admin
+	// section becomes visible; without this the markup's static display:none
+	// wins and the section can never appear expanded on reload.
+	if !strings.Contains(html, "applyAdminUsersCollapsed();") {
+		t.Error("the persisted collapse state must be applied after the admin check passes")
+	}
+}
+
+// TestDashboardAdminUsersExpandPersists is the #2348 lesson applied to this
+// section: anything that expands the section to reveal a row must ALSO write
+// the new state, or the row is hidden again on the next reload.
+func TestDashboardAdminUsersExpandPersists(t *testing.T) {
+	html := dashScript(t)
+
+	idx := strings.Index(html, "function expandAdminUsersSection()")
+	if idx < 0 {
+		t.Fatal("expandAdminUsersSection is missing")
+	}
+	// Bound the search to the function body so a persist call elsewhere in the
+	// file cannot satisfy this assertion.
+	end := strings.Index(html[idx:], "\n    }")
+	if end < 0 {
+		t.Fatal("could not delimit expandAdminUsersSection")
+	}
+	body := html[idx : idx+end]
+
+	if !strings.Contains(body, "persistAdminUsersCollapsed()") {
+		t.Error("expandAdminUsersSection must persist the expansion; an in-memory-only " +
+			"expand silently re-collapses on reload and re-hides the target row (#2348)")
+	}
+	if !strings.Contains(body, "applyAdminUsersCollapsed()") {
+		t.Error("expandAdminUsersSection must push the new state onto the DOM")
+	}
+}
+
+// TestDashboardContactEditorCloseAffordances asserts the editor can actually be
+// dismissed. Before this it had no close control at all: opening one left it
+// open for the rest of the session.
+func TestDashboardContactEditorCloseAffordances(t *testing.T) {
+	html := dashScript(t)
+
+	for _, want := range []string{
+		"function closeContactPanel(",
+		"function contactPanelHasUnsavedEdits(",
+		"function commitContactPanelEdits(",
+		"function openContactPanelUsername()",
+		// Both the × and the Close button carry the same hook, so one binding
+		// serves both.
+		"data-contact-close=",
+		// Bound as a listener, not an inline on* attribute: esc() leaves
+		// apostrophes alone, so a username in an inline handler would be an
+		// injection vector.
+		"[data-contact-close]",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("the contact editor is missing a close affordance: %s", want)
+		}
+	}
+
+	// Escape must be handled in the CAPTURE phase so it can decide before the
+	// global Escape handler, and it must stop propagation only when it acted —
+	// otherwise it would swallow Escape for create-modal (#2321).
+	if !strings.Contains(html, "closeContactPanel(username);\n    }, true);") {
+		t.Error("Escape-to-close must be registered in the capture phase")
+	}
+	escIdx := strings.Index(html, "function openContactPanelUsername()")
+	if escIdx < 0 {
+		t.Fatal("openContactPanelUsername is missing")
+	}
+	// A stray Escape with focus outside the editor must fall through to the
+	// global handler rather than being consumed here.
+	if !strings.Contains(html, "if (!username) return;\n      e.stopPropagation();") {
+		t.Error("Escape must fall through to the global handler when no contact editor has focus")
+	}
+	// While a confirm overlay is up it owns Escape; stealing the key there would
+	// leave the overlay stranded.
+	if !strings.Contains(html, "if (document.querySelector('.hive-confirm-overlay')) return;") {
+		t.Error("Escape must not be stolen from an open hiveConfirm overlay")
+	}
+}
+
+// TestDashboardContactEditorWarnsBeforeDiscarding asserts closing with typed but
+// unsaved text prompts rather than dropping it. The fields save on blur, so
+// unblurred text exists ONLY in the DOM node the close is about to hide.
+func TestDashboardContactEditorWarnsBeforeDiscarding(t *testing.T) {
+	html := dashScript(t)
+
+	idx := strings.Index(html, "async function closeContactPanel(")
+	if idx < 0 {
+		t.Fatal("closeContactPanel is missing")
+	}
+	end := strings.Index(html[idx:], "\n    }")
+	if end < 0 {
+		t.Fatal("could not delimit closeContactPanel")
+	}
+	body := html[idx : idx+end]
+
+	if !strings.Contains(body, "contactPanelHasUnsavedEdits(username)") {
+		t.Error("closeContactPanel must check for unsaved edits before closing")
+	}
+	if !strings.Contains(body, "hiveConfirm(") {
+		t.Error("closing with unsaved edits must warn rather than silently discard")
+	}
+	// A rejected save must leave the editor open with the text intact, so the
+	// admin can read the reason and retry.
+	if !strings.Contains(body, "if (!saved) return;") {
+		t.Error("a failed save must keep the contact editor open")
+	}
+}
+
+// TestDashboardUpdateUserSurfacesErrors guards the #2348 failure mode: a save
+// whose response is never checked looks identical to a successful one.
+func TestDashboardUpdateUserSurfacesErrors(t *testing.T) {
+	html := dashScript(t)
+
+	idx := strings.Index(html, "async function updateUser(")
+	if idx < 0 {
+		t.Fatal("updateUser is missing")
+	}
+	end := strings.Index(html[idx:], "\n    }")
+	if end < 0 {
+		t.Fatal("could not delimit updateUser")
+	}
+	body := html[idx : idx+end]
+
+	if !strings.Contains(body, "if (!resp.ok)") {
+		t.Error("updateUser must check the response status; an ignored failure " +
+			"is indistinguishable from a successful save")
+	}
+	if !strings.Contains(body, "readErrorMessage(resp") {
+		t.Error("updateUser must surface the server's reason, not a generic failure")
+	}
+
+	// readErrorMessage must read text() and parse defensively. resp.json() on a
+	// non-JSON body throws, which is exactly how #2348 turned a real cause into
+	// a generic "failed".
+	rIdx := strings.Index(html, "async function readErrorMessage(")
+	if rIdx < 0 {
+		t.Fatal("readErrorMessage is missing")
+	}
+	rEnd := strings.Index(html[rIdx:], "\n    }")
+	rBody := html[rIdx : rIdx+rEnd]
+	if !strings.Contains(rBody, "resp.text()") {
+		t.Error("readErrorMessage must use resp.text() so a non-JSON error body does not throw")
+	}
+	if !strings.Contains(rBody, "JSON.parse(") {
+		t.Error("readErrorMessage must parse the JSON body when there is one")
+	}
+}
+
+// TestAdminUpdateUserErrorsAreJSON is the server half of the same defect.
+// http.Error forces Content-Type: text/plain even when the body is JSON, so a
+// browser calling resp.json() on it throws and the real cause is lost.
+func TestAdminUpdateUserErrorsAreJSON(t *testing.T) {
+	dir := t.TempDir()
+	old := saasUsersDir
+	saasUsersDir = filepath.Join(dir, "users")
+	t.Cleanup(func() { saasUsersDir = old })
+	if err := os.MkdirAll(saasUsersDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &HubServer{logger: slog.Default()}
+
+	t.Run("unknown user", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPut, "/api/saas/admin/users/nobody", strings.NewReader(`{}`))
+		req.SetPathValue("username", "nobody")
+		rec := httptest.NewRecorder()
+		s.handleAdminUpdateUser(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+		}
+		assertJSONError(t, rec, "user not found")
+	})
+
+	t.Run("malformed body", func(t *testing.T) {
+		u := &SaaSUser{GitHubUsername: "someone"}
+		if err := saveSaaSUser(u); err != nil {
+			t.Fatal(err)
+		}
+		req := httptest.NewRequest(http.MethodPut, "/api/saas/admin/users/someone", strings.NewReader(`{not json`))
+		req.SetPathValue("username", "someone")
+		rec := httptest.NewRecorder()
+		s.handleAdminUpdateUser(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+		}
+		assertJSONError(t, rec, "invalid JSON")
+	})
+}
+
+// assertJSONError checks a response is a JSON error the browser can actually
+// read: the declared content type must be JSON (http.Error's text/plain is the
+// bug being guarded) and the body must decode with a non-empty "error".
+func assertJSONError(t *testing.T, rec *httptest.ResponseRecorder, wantMsg string) {
+	t.Helper()
+
+	ct := rec.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json — http.Error forces "+
+			"text/plain, which makes resp.json() throw in the dashboard", ct)
+	}
+
+	var body struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("error body is not valid JSON (%v): %s", err, rec.Body.String())
+	}
+	if body.Error != wantMsg {
+		t.Errorf("error = %q, want %q", body.Error, wantMsg)
+	}
+}

--- a/v2/pkg/hub/saas_dashboard_admin_users_ux_test.go
+++ b/v2/pkg/hub/saas_dashboard_admin_users_ux_test.go
@@ -152,6 +152,144 @@ func TestDashboardContactEditorCloseAffordances(t *testing.T) {
 	}
 }
 
+// TestDashboardContactToggleIsStateful asserts the row button reads "Edit" when
+// the panel is shut and "Save" when it is open. Before this it always read
+// "Edit", so an open editor offered no visible commit affordance at all.
+func TestDashboardContactToggleIsStateful(t *testing.T) {
+	html := dashScript(t)
+
+	for _, want := range []string{
+		"function contactToggleLabel(",
+		"function contactToggleStyle(",
+		"function contactToggleAriaLabel(",
+		"function contactToggleId(",
+		"function refreshContactToggleLabel(",
+		"function setContactPanelOpen(",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("the stateful Edit/Save toggle is missing: %s", want)
+		}
+	}
+
+	// The label is derived from state in ONE place, so the initial markup and
+	// the live in-place update cannot drift into showing different verbs.
+	if !strings.Contains(html, `return open ? 'Save' : 'Edit';`) {
+		t.Error("the toggle must read Save when open and Edit when collapsed")
+	}
+}
+
+// TestDashboardContactToggleUpdatesAriaWithLabel is the accessibility half: a
+// screen reader must get the state change too, not just sighted users. Updating
+// the visible text alone would leave it announcing "Edit, collapsed" over an
+// open editor.
+func TestDashboardContactToggleUpdatesAriaWithLabel(t *testing.T) {
+	html := dashScript(t)
+
+	idx := strings.Index(html, "function refreshContactToggleLabel(")
+	if idx < 0 {
+		t.Fatal("refreshContactToggleLabel is missing")
+	}
+	end := strings.Index(html[idx:], "\n    }")
+	if end < 0 {
+		t.Fatal("could not delimit refreshContactToggleLabel")
+	}
+	body := html[idx : idx+end]
+
+	for _, want := range []string{
+		"btn.textContent = contactToggleLabel(open);",
+		`btn.setAttribute('aria-expanded'`,
+		`btn.setAttribute('aria-label', contactToggleAriaLabel(username, open));`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("the toggle must update label and aria state together; missing: %s", want)
+		}
+	}
+
+	// The initial markup must carry the same attributes, or the very first
+	// render is inaccessible until something happens to refresh it.
+	for _, want := range []string{
+		`' aria-controls="' + contactPanelId(u.github_username) + '"'`,
+		`' aria-expanded="' + (open ? 'true' : 'false') + '"'`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("the toggle's initial markup is missing aria wiring: %s", want)
+		}
+	}
+
+	// The accessible name carries the username: a screen-reader user tabbing a
+	// table of ~90 identical "Save" buttons needs to know which row they are on.
+	if !strings.Contains(html, "'Save contact details for '") {
+		t.Error("the accessible name must identify which user the button acts on")
+	}
+}
+
+// TestDashboardContactSaveCommitsAndCloses asserts pressing Save commits and
+// closes, and — critically — does NOT close when the save failed. With a visible
+// Save button a false success is the worst outcome, especially now that
+// handleAdminUpdateUser can legitimately fail on a PVC write.
+func TestDashboardContactSaveCommitsAndCloses(t *testing.T) {
+	html := dashScript(t)
+
+	idx := strings.Index(html, "async function toggleContactPanel(")
+	if idx < 0 {
+		t.Fatal("toggleContactPanel is missing")
+	}
+	end := strings.Index(html[idx:], "\n    }")
+	if end < 0 {
+		t.Fatal("could not delimit toggleContactPanel")
+	}
+	body := html[idx : idx+end]
+
+	if !strings.Contains(body, "commitContactPanelEdits(username)") {
+		t.Error("pressing Save must commit the pending fields")
+	}
+	// The guard clause is the whole point: a failed commit returns before the
+	// panel is closed, so the typed text and the error stay on screen.
+	if !strings.Contains(body, "if (!saved) return;") {
+		t.Error("a failed save must not close the panel or revert the label")
+	}
+	if !strings.Contains(body, "setContactPanelOpen(username, false);") {
+		t.Error("a successful save must close the panel")
+	}
+}
+
+// TestDashboardBlurSavesAreSilent reconciles per-field blur saves with the
+// explicit Save button: blur must keep storing quietly while Save is the thing
+// that reports failures and closes. A toast per blur would fire while the admin
+// is mid-sentence in the next field.
+func TestDashboardBlurSavesAreSilent(t *testing.T) {
+	html := dashScript(t)
+
+	if !strings.Contains(html, "saveContactField(user, field, pending, {silent: true})") {
+		t.Error("blur-saves must be silent; the Save button is the reporting point")
+	}
+
+	// A silent failure must still be RECORDED, or pressing Save afterwards would
+	// close on what looks like a no-op success and lose the real reason.
+	if !strings.Contains(html, "_contactLastError[username] = reason;") {
+		t.Error("a silent save failure must still record its cause")
+	}
+	cIdx := strings.Index(html, "async function commitContactPanelEdits(")
+	if cIdx < 0 {
+		t.Fatal("commitContactPanelEdits is missing")
+	}
+	cEnd := strings.Index(html[cIdx:], "\n    }")
+	cBody := html[cIdx : cIdx+cEnd]
+	if !strings.Contains(cBody, "_contactLastError[username]") {
+		t.Error("Save must surface a reason recorded by an earlier silent blur-save")
+	}
+	// Clicking Save while a field still holds focus means its text may never
+	// have blurred, so the commit must read the live inputs too.
+	if !strings.Contains(cBody, "[data-contact-field]") {
+		t.Error("the commit must flush the panel's live input values")
+	}
+	// Per-user saves are a read-modify-write over one JSON file; concurrent PUTs
+	// for the same user can interleave and lose a field.
+	if !strings.Contains(cBody, "await saveContactField(") {
+		t.Error("field saves must be sequential, not concurrent")
+	}
+}
+
 // TestDashboardContactEditorWarnsBeforeDiscarding asserts closing with typed but
 // unsaved text prompts rather than dropping it. The fields save on blur, so
 // unblurred text exists ONLY in the DOM node the close is about to hide.


### PR DESCRIPTION
Two small hub-dashboard fixes in the same area, reported together.

## 1. The user section needs to be expandable/collapsable

> "user section in hub needs to be expandable/collapsable."

The roster is ~90 records, so an expanded users table pushed Hub Banner and Cluster Health far below the fold. An operator is normally here for hives, not for the roster.

**Matched the existing convention rather than inventing one.** Past Requests and Cluster Health are the two other long admin sections; both are `role="button"` headers with a ▸/▾ caret, `aria-expanded`, Enter/Space activation, an `applyX()` helper split out from the toggle, and state persisted under a `hive-*-collapsed` localStorage key. This section now does the same, under `hive-admin-users-collapsed`.

**Collapsed by default**, matching Past Requests and Cluster Health, and for the same reason they are: absent key means collapsed, only an explicit `'false'` expands, so a first visit and a corrupted value land in the same place. A count beside the header keeps the roster size visible while the section is shut, so collapsing does not hide the fact that there are users.

### On the #2348 trap

`expandAdminUsersSection()` persists the expansion instead of only flipping it in memory, mirroring `expandAllHiveSections`. **These two do not currently interact** — `jumpToHiveRow` → `focusHiveRow` resolves `hive-row-<id>` DOM ids in the My Hives table only, and nothing in the Attention-needed panel targets a user row. The persisting helper is there so the next thing that *does* want to reveal a user row has a correct path to use, rather than reaching past it and flipping `display` directly.

## 2. The user edit form cannot be closed

> "after editing a users info - i want to be able to close the edit some how - right now it just stays open."

The per-user contact editor had no dismiss control at all: opening one left it open for the rest of the session. It now has a × in the corner, a Close button, and Escape.

- **Escape does not conflict with the global handler (#2321).** It is bound in the capture phase and stops propagation *only* when a contact editor actually holds focus; otherwise the event falls through to the existing handler that closes `create-modal`, the request modal, the confirm overlay and the timeline/access modals. It also defers entirely while a `hiveConfirm` overlay is up, since that overlay binds its own Escape.
- **Unsaved changes warn rather than silently discard.** The fields save on blur, so text typed and never blurred lives only in the DOM node the close is about to hide. Closing with unsaved edits prompts, saves on confirm, and stays open if that save fails — closing there would discard the very edit the server just rejected.

### The save-error path had the #2348 defect — confirmed

`updateUser` ignored the response entirely: a 404/400/500 was indistinguishable from a success, so a rejected edit looked saved until the next poll quietly reverted the field. It now checks `resp.ok` and reports the server's reason.

The server half is the same `http.Error` defect: the user handlers built JSON error bodies but shipped them through `http.Error`, which forces `Content-Type: text/plain`, so `resp.json()` throws in the browser and the cause is lost. They now use the existing `writeJSONError` helper. Status codes and body shapes are unchanged — only the content type is corrected.

Two related holes closed while here:

- `handleAdminUpdateUser` ignored `saveSaaSUser`'s error and reported success after a failed PVC write. With the editor now closing on a 2xx, that would silently discard the edit, so it returns a 500 instead.
- `saveContactField` rolls its optimistic cache back on failure. Without that, the next-equals-previous short-circuit would skip a retry of the same value and the edit could never be saved again without a reload.

## 3. The Edit button should change to a Save button when open (follow-up)

> "edit button should change to a save button when open"

With the panel expanded the row button still read **Edit**, so there was no visible commit affordance — the same "it just stays open" complaint seen from the other side. The button is now stateful: **Edit** when collapsed, **Save** when open, styled as the primary action (accent border and text) so the eye lands on it. Pressing Save commits every pending field and closes.

This **composes with** the close affordances above rather than replacing them. The ×, Cancel and Escape remain the escape hatches, and they still ask "you have unsaved changes, save them?" — a question that is only meaningful when the admin did *not* press Save.

### Reconciling Save with the per-field blur saves

I flagged earlier that a literal "auto-close on successful save" would slam the panel shut whenever the admin tabs between fields. A stateful Save button is the better answer to that, but the two have to be reconciled deliberately:

- **Blur-saves are now silent** — no toast, and a rejected value stays dirty so the field keeps the typed text and the button keeps reading Save. Blur fires constantly (tabbing between three fields, clicking Save itself), so a toast per blur would be noise and would fire while the admin is mid-sentence in the next field. Save is the single reporting point.
- **A silent failure is still recorded per user, and the commit surfaces it.** Without this, a blur-save that failed followed by Save would find nothing dirty and close on what looks like a no-op success, losing the real cause.
- **Nothing closes on an unverified save.** A failure keeps the panel open, keeps the label on `Save`, and lets the error stand. This matters more given `handleAdminUpdateUser` was ignoring `saveSaaSUser`'s error (fixed above) — with a visible Save button, a false success is the worst possible outcome.
- The commit **flushes the panel's live inputs**, because clicking Save while a field still holds focus means its text may never have blurred.
- Saves stay **sequential, not `Promise.all`**: the handler is a read-modify-write over one JSON file per user, so concurrent PUTs for the same user can interleave and lose a field.

### Accessibility

`refreshContactToggleLabel` writes the label, `aria-expanded` and the accessible name **together**, so a screen reader is never left announcing "Edit, collapsed" over an open editor. The accessible name carries the username (`"Save contact details for <user>"`) — a table of ~90 identical "Save" buttons is otherwise unnavigable. Label and style are derived from state in one place, so the initial markup and the live in-place update cannot drift.

Context: **SLACK ID is now load-bearing.** PR #2362 added Slack messaging that reads `SaaSUser.SlackID`, and no user has one set yet — this editor is currently the only way to populate ~88 of them, so the commit affordance is about to get heavy use.

## Verification

- `go build ./...`, `go vet ./pkg/hub/`, `gofmt` — clean.
- `go test ./pkg/hub/` — full suite passes; 11 new tests cover the stateful Edit/Save button, its aria/label pairing, commit-and-close, the silent-blur reconciliation, and the collapse wiring, the collapsed-by-default and persistence invariants, the #2348 persist-on-expand lesson, the close affordances, the capture-phase Escape scoping, the unsaved-changes warning, and that the server's error bodies are actually JSON.
- Embedded JS extracted and run through **`node --check` — passes**. Base-vs-current delta matches exactly: braces +45/+45, parens +175/+175. No backticks added, no literal body tag. (An earlier iteration put backticks inside a JS *comment*, which terminated the Go raw string and broke the build 3000 lines away — caught by this check.)
- Iterations added are guarded (`(closers || [])`, `(live || [])`); no magic numbers (`ADMIN_USERS_COLLAPSED_KEY`, `ERROR_TEXT_MAX_CHARS`).
- Rebased onto fresh `origin/v2` (picks up #2362/#2363).
- Read-only against live systems — no hive or hub was mutated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
