### PR TITLE
✨ feat(hub): switch a hive between forges (github.com / GitHub Enterprise), delivered over the heartbeat

### DIFF
--- a/v2/pkg/hub/forge.go
+++ b/v2/pkg/hub/forge.go
@@ -180,13 +180,17 @@ type SwitchForgeRequest struct {
 // identity the hive will now authenticate as, so the operator can see whether
 // the target cluster actually has an App configured before waiting on a beat.
 type switchForgeResponse struct {
-	Status          string `json:"status"`
-	ID              string `json:"id"`
-	FromHost        string `json:"from_host"`
-	ToHost          string `json:"to_host"`
-	ForgeKind       string `json:"forge_kind"`
-	APIURL          string `json:"api_url,omitempty"`
-	AppID           string `json:"app_id,omitempty"`
+	Status    string `json:"status"`
+	ID        string `json:"id"`
+	FromHost  string `json:"from_host"`
+	ToHost    string `json:"to_host"`
+	ForgeKind string `json:"forge_kind"`
+	APIURL    string `json:"api_url,omitempty"`
+	AppID     string `json:"app_id,omitempty"`
+	// AppSlug is the App slug now in effect on the target forge. Reported so an
+	// operator can see the install link will resolve, rather than discovering a
+	// 404 through the user.
+	AppSlug         string `json:"app_slug,omitempty"`
 	InstallationID  string `json:"installation_id,omitempty"`
 	AppInstallNote  string `json:"app_install_note,omitempty"`
 	DeliveryPending bool   `json:"delivery_pending"`
@@ -285,11 +289,39 @@ func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Resolve the App identity for the TARGET forge from CLUSTER CONFIG. No App
-	// ID is hardcoded anywhere in Go: hive-oke names its github.com App and
-	// vllm-d names its github.ibm.com App, both in clusters.json, exactly as
+	// ID or slug is hardcoded anywhere in Go: hive-oke names its github.com App
+	// and vllm-d names its github.ibm.com App, both in clusters.json, exactly as
 	// resolveProvisionAppID already reads them.
 	cluster := s.clusterForHive(h)
-	appID := s.forgeAppIDForTarget(cluster, target)
+	identity, missing := s.forgeIdentityForTarget(cluster, target)
+
+	// REFUSE RATHER THAN HALF-APPLY. Verified the hard way: a hive was moved to
+	// github.ibm.com by editing github_host alone. The host changed and nothing
+	// else did — it kept the github.com app_id, an empty app_slug, and a
+	// installation_id belonging to the old forge. The owner then clicked
+	// "Install GitHub App" and got a GitHub 404, because an empty app_slug falls
+	// back to config.DefaultGitHubAppSlug ("kubestellar-hive"), which is the
+	// github.com App's slug and names nothing on GHE. A wrong install link is
+	// worse than no link: it tells the user the product is broken.
+	//
+	// A forge switch is therefore an ATOMIC SWAP OF AN IDENTITY SET, not a
+	// single field. If the target forge's identity is not fully known for this
+	// cluster, nothing is written at all and the response names exactly what is
+	// missing so an operator can populate clusters.json and re-run.
+	if len(missing) > 0 {
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": fmt.Sprintf("refusing to switch %s to %s: the target forge identity is incomplete for cluster %q, and a partial switch produces a broken hive (a wrong App install link 404s)",
+				id, target.Host, clusterIDForHive(h)),
+			"missing": missing,
+			"remedy":  forgeIdentityRemedy,
+		})
+		s.logger.Warn("forge switch refused: incomplete target identity",
+			"hive_id", id, "to_host", target.Host,
+			"cluster", clusterIDForHive(h), "missing", strings.Join(missing, ","))
+		return
+	}
+	appID := identity.AppID
 
 	// Record the target. GitHubHost is what projectConfigForHiveID derives the
 	// pushed api_url from; GitHubBaseURL/GitHubAPIURL pin the hive explicitly so
@@ -340,22 +372,24 @@ func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 	// field" value, so a bare app_id switch leaves the spoke's stale ID in
 	// place. That is why an explicit clear is queued below via the hive's own
 	// record rather than relying on the heartbeat field alone.
-	deliveryPending := false
-	if appID > 0 {
-		s.storePendingGitHubAppConfig(id, &HeartbeatGitHubAppConfig{
-			AppID: appID,
-			// Only a supplied ID is sent. Zero means "leave it alone" on the
-			// wire; the operator note below tells the operator it must be
-			// installed or supplied, so the failure is never silent.
-			InstallationID: installID,
-			AppSlug:        forgeAppSlugForCluster(cluster),
-			// PrivateKey is deliberately absent. The per-cluster key reconcile
-			// (cluster_app_key.go) delivers key material on its own schedule and
-			// gates every key push on HasKey(); duplicating it here would risk
-			// blanking a working key with an empty string.
-		})
-		deliveryPending = true
-	}
+	//
+	// The SLUG travels with the app_id, and that is the whole point of the
+	// precondition above: identity.AppSlug is non-empty by construction here, so
+	// the spoke can never be left falling back to the github.com default slug on
+	// a GHE host — the state that produced the live install-link 404.
+	s.storePendingGitHubAppConfig(id, &HeartbeatGitHubAppConfig{
+		AppID: appID,
+		// Only a supplied ID is sent. Zero means "leave it alone" on the
+		// wire; the operator note below tells the operator it must be
+		// installed or supplied, so the failure is never silent.
+		InstallationID: installID,
+		AppSlug:        identity.AppSlug,
+		// PrivateKey is deliberately absent. The per-cluster key reconcile
+		// (cluster_app_key.go) delivers key material on its own schedule and
+		// gates every key push on HasKey(); duplicating it here would risk
+		// blanking a working key with an empty string.
+	})
+	deliveryPending := true
 
 	note := ""
 	if installID == 0 {
@@ -372,6 +406,7 @@ func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 		"forge_kind", string(target.Kind),
 		"api_url", target.APIURL,
 		"app_id", appID,
+		"app_slug", identity.AppSlug,
 		"installation_id_supplied", installID != 0,
 		"cluster", clusterIDForHive(h),
 	)
@@ -385,6 +420,7 @@ func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 		ToHost:          target.Host,
 		ForgeKind:       string(target.Kind),
 		APIURL:          target.APIURL,
+		AppSlug:         identity.AppSlug,
 		InstallationID:  strings.TrimSpace(body.InstallationID),
 		AppInstallNote:  note,
 		DeliveryPending: deliveryPending,
@@ -395,22 +431,47 @@ func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(resp)
 }
 
-// forgeAppIDForTarget resolves the GitHub App ID to authenticate as on the
-// TARGET forge, from cluster config only.
+// forgeIdentity is the COMPLETE App identity for one forge. A forge switch
+// swaps all of it or none of it.
+type forgeIdentity struct {
+	// AppID is the numeric GitHub App ID registered on the target forge.
+	AppID int64
+	// AppSlug is that App's URL slug ON THAT FORGE. It is part of the identity,
+	// not a cosmetic extra: it is what the "Install GitHub App" link is built
+	// from, and an empty value silently falls back to the public github.com slug
+	// (config.ResolvedAppSlug -> DefaultGitHubAppSlug), which on a GHE host
+	// names an App that does not exist and 404s.
+	AppSlug string
+}
+
+// forgeIdentityRemedy is the operator-facing instruction attached to a refused
+// switch. It names the file and the fields, because the fix is a config edit and
+// nothing about the request itself is wrong.
+const forgeIdentityRemedy = "populate the target cluster's entry in /data/saas/clusters.json (github_app_id and github_app_slug for that forge), then re-run this switch — it is idempotent"
+
+// forgeIdentityForTarget resolves the FULL App identity for the target forge
+// from CLUSTER CONFIG ONLY, and reports everything that is missing.
 //
-// The cluster's configured app_id is correct exactly when the cluster's own
-// GitHub host matches the target — hive-oke is a github.com cluster and vllm-d
-// is a github.ibm.com cluster, so a hive switching to the cluster's own forge
-// gets the cluster's App. A hive switching to a forge the cluster does NOT
-// default to has no App the hub can name, and returning 0 is the honest answer:
-// zero means "say nothing about the App", which leaves the spoke's credentials
-// untouched rather than pushing an App ID from the wrong forge.
+// A cluster's configured App is correct exactly when the cluster's own GitHub
+// host matches the target — hive-oke is a github.com cluster naming its
+// github.com App, vllm-d is a github.ibm.com cluster naming its GHE App. A hive
+// switching to a forge its cluster does NOT serve has no App the hub can name.
 //
-// No App ID is hardcoded. This reads ClusterConfig.GitHubAppID, the same
-// non-secret field resolveProvisionAppID uses.
-func (s *HubServer) forgeAppIDForTarget(cluster *ClusterConfig, target ForgeTarget) int64 {
-	if cluster == nil || cluster.GitHubAppID == 0 {
-		return 0
+// # WHY MISSING FIELDS ARE AN ERROR AND NOT A DEFAULT
+//
+// Every field here has a plausible-looking fallback, and every one of those
+// fallbacks is wrong on the target forge:
+//   - app_id: falling back to the cluster's other App authenticates as an App
+//     that does not exist on this forge.
+//   - app_slug: falling back to DefaultGitHubAppSlug builds an install link at
+//     <ghe-host>/github-apps/kubestellar-hive/... — the exact live 404.
+//
+// So this returns the missing field NAMES and the caller refuses the switch.
+// Nothing is hardcoded: both values come from ClusterConfig, the same
+// non-secret fields resolveProvisionAppID and the provisioning template read.
+func (s *HubServer) forgeIdentityForTarget(cluster *ClusterConfig, target ForgeTarget) (forgeIdentity, []string) {
+	if cluster == nil {
+		return forgeIdentity{}, []string{"cluster config (this hive's cluster is unknown to the hub)"}
 	}
 	clusterHost := publicForgeHost
 	if cluster.GitHubBaseURL != "" {
@@ -419,20 +480,39 @@ func (s *HubServer) forgeAppIDForTarget(cluster *ClusterConfig, target ForgeTarg
 		clusterHost = strings.ToLower(githubHostLabel(cluster.GitHubAPIURL))
 	}
 	if !sameGitHubHost(clusterHost, target.Host) {
-		return 0
+		// The hub knows an App for this cluster, but it is registered on the
+		// WRONG forge. Naming the mismatch is far more useful than a bare
+		// "missing app_id", because the remedy is different: this cluster may
+		// simply not be able to host a hive on the requested forge.
+		return forgeIdentity{}, []string{
+			fmt.Sprintf("a GitHub App registered on %s (cluster %q serves %s)", target.Host, cluster.ID, clusterHost),
+		}
 	}
-	return cluster.GitHubAppID
+	var missing []string
+	if cluster.GitHubAppID == 0 {
+		missing = append(missing, fmt.Sprintf("github_app_id for cluster %q", cluster.ID))
+	}
+	if strings.TrimSpace(cluster.GitHubAppSlug) == "" {
+		// Deliberately required even for public github.com. The default slug
+		// happens to be right there, but accepting an unset value would mean the
+		// atomicity guarantee holds on one forge and not the other — and the
+		// operator would have no signal that the cluster entry is incomplete.
+		missing = append(missing, fmt.Sprintf("github_app_slug for cluster %q (an empty slug falls back to %q, which names no App on %s)",
+			cluster.ID, defaultPublicAppSlug, target.Host))
+	}
+	if len(missing) > 0 {
+		return forgeIdentity{}, missing
+	}
+	return forgeIdentity{
+		AppID:   cluster.GitHubAppID,
+		AppSlug: strings.TrimSpace(cluster.GitHubAppSlug),
+	}, nil
 }
 
-// forgeAppSlugForCluster returns the cluster's App slug, or "" when it has
-// none. Empty is the spoke's "leave my slug alone" value, so this never blanks
-// a working install link.
-func forgeAppSlugForCluster(cluster *ClusterConfig) string {
-	if cluster == nil {
-		return ""
-	}
-	return cluster.GitHubAppSlug
-}
+// defaultPublicAppSlug mirrors config.DefaultGitHubAppSlug. It appears here
+// only inside an operator-facing error message explaining what an empty slug
+// would fall back to — it is never used as a value.
+const defaultPublicAppSlug = "kubestellar-hive"
 
 // ============================================================================
 // FORGE DELIVERY HANDSHAKE

--- a/v2/pkg/hub/forge.go
+++ b/v2/pkg/hub/forge.go
@@ -1,0 +1,541 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// ============================================================================
+// FORGE REGISTRY
+// ============================================================================
+//
+// A "forge" is the code-hosting system a hive's org and repos live on. Today
+// every hive is on a GitHub of some kind — public github.com or a GitHub
+// Enterprise instance (github.ibm.com, github.cisco.com, …) — but GitLab and
+// Gitea are coming, and the hub already has one endpoint (request-provision)
+// whose design note calls that out explicitly.
+//
+// The switch endpoint therefore validates against a KIND plus a HOST rather
+// than accepting an arbitrary string. Adding a forge kind later means adding a
+// case here and an apiURLFor* helper; it does not mean revisiting the handler,
+// the authorization, or the delivery path.
+
+// ForgeKind names a family of code-hosting system. The zero value is invalid:
+// a caller must say which forge it means.
+type ForgeKind string
+
+const (
+	// ForgeGitHub is public github.com — the fleet default.
+	ForgeGitHub ForgeKind = "github"
+	// ForgeGitHubEnterprise is a self-hosted GitHub Enterprise Server instance.
+	// It differs from ForgeGitHub only in host and API path shape, which is why
+	// both resolve through the same identity/credential machinery.
+	ForgeGitHubEnterprise ForgeKind = "github-enterprise"
+)
+
+// publicForgeHost is the canonical host of public GitHub. A hive on this host
+// carries GitHubHost == "github.com" (or "", historically) and an empty
+// api_url, because the spoke's own default is already api.github.com.
+const publicForgeHost = "github.com"
+
+// gheAPIPathSuffix is the API path every GitHub Enterprise Server instance
+// serves its v3 REST API on. It is a property of the GHE product, not of any
+// particular instance, so it is the same for github.ibm.com and every future
+// enterprise host.
+const gheAPIPathSuffix = "/api/v3"
+
+// maxForgeHostLen bounds an operator-supplied host label. Real hostnames are
+// far shorter; this exists so a pasted blob can never reach the registry, the
+// meta.json on the PVC, or a log line.
+const maxForgeHostLen = 253 // RFC 1035 maximum length of a DNS name
+
+// ForgeTarget is a validated forge destination: the kind, its bare host label,
+// and the derived web/API URLs the spoke needs. It is produced only by
+// parseForgeTarget, so every consumer can rely on the values being normalized.
+type ForgeTarget struct {
+	Kind ForgeKind
+	// Host is the bare, lower-cased hostname ("github.com", "github.ibm.com").
+	Host string
+	// BaseURL is the web base ("https://github.ibm.com"). Empty for public
+	// GitHub, matching the codebase-wide convention that "" means public — see
+	// effectiveGitHubBaseURL and SaaSHive.GitHubHost.
+	BaseURL string
+	// APIURL is the REST API base ("https://github.ibm.com/api/v3"). Empty for
+	// public GitHub, which the spoke already defaults to.
+	APIURL string
+}
+
+// IsPublic reports whether this target is public github.com.
+func (t ForgeTarget) IsPublic() bool { return t.Kind == ForgeGitHub }
+
+// parseForgeTarget validates an operator-supplied forge host and resolves it to
+// a ForgeTarget.
+//
+// It accepts a bare host ("github.ibm.com") or a full URL
+// ("https://github.ibm.com/") and normalizes both to the same target, because
+// an operator pasting an org URL into this field is the overwhelmingly likely
+// input — the same paste that, in the repo field, produced the malformed value
+// that crash-looped a spoke.
+//
+// It deliberately does NOT accept arbitrary strings. An unrecognized host shape
+// is rejected with a message naming what is supported, rather than being
+// recorded and silently producing a spoke that talks to nothing.
+func parseForgeTarget(raw string) (ForgeTarget, error) {
+	// Deliberately NOT githubHostLabel: that helper maps "" to "github.com",
+	// which would silently turn a missing/blank host into a switch to public
+	// GitHub — a destructive default for an endpoint whose whole job is to move
+	// a hive. An absent host must be an error, not an assumption.
+	host := strings.ToLower(strings.TrimSpace(raw))
+	if host == "" {
+		return ForgeTarget{}, fmt.Errorf("forge host is required (e.g. %q or %q)", publicForgeHost, "github.ibm.com")
+	}
+	host = strings.TrimPrefix(strings.TrimPrefix(host, "https://"), "http://")
+	// Strip any path: an operator is most likely to paste an org URL
+	// ("https://github.ibm.com/enricom-ibm"), and the host is the only part of
+	// it this endpoint is asking for.
+	host = strings.SplitN(host, "/", 2)[0]
+	// Strip a port and any userinfo, neither of which belongs in a host label.
+	host = strings.SplitN(host, ":", 2)[0]
+	if i := strings.LastIndex(host, "@"); i >= 0 {
+		host = host[i+1:]
+	}
+	if host == "" {
+		return ForgeTarget{}, fmt.Errorf("forge host is required (e.g. %q or %q)", publicForgeHost, "github.ibm.com")
+	}
+	if len(host) > maxForgeHostLen {
+		return ForgeTarget{}, fmt.Errorf("forge host is too long (max %d characters)", maxForgeHostLen)
+	}
+	// api.github.com is the API host, not the web host; an operator naming it
+	// means public GitHub. Normalizing it here keeps one canonical record for
+	// public rather than two that compare unequal.
+	if host == publicForgeHost || host == "api.github.com" {
+		return ForgeTarget{Kind: ForgeGitHub, Host: publicForgeHost}, nil
+	}
+	if !isValidForgeHostLabel(host) {
+		return ForgeTarget{}, fmt.Errorf("%q is not a valid forge host — supply a hostname such as %q or %q", raw, publicForgeHost, "github.ibm.com")
+	}
+	// Everything that is a well-formed host but is not github.com is treated as
+	// a GitHub Enterprise Server instance. That is true of every non-public
+	// forge the fleet runs today. When GitLab/Gitea arrive they will be selected
+	// by an explicit kind rather than inferred from the host, because their API
+	// paths differ and a host alone cannot distinguish them.
+	return ForgeTarget{
+		Kind:    ForgeGitHubEnterprise,
+		Host:    host,
+		BaseURL: "https://" + host,
+		APIURL:  "https://" + host + gheAPIPathSuffix,
+	}, nil
+}
+
+// isValidForgeHostLabel reports whether s is a plausible DNS hostname: at least
+// one dot, and only characters legal in a host label. It is intentionally strict
+// — this value is written to meta.json, rendered in the dashboard, and used to
+// build a URL the spoke will call.
+func isValidForgeHostLabel(s string) bool {
+	if s == "" || !strings.Contains(s, ".") {
+		return false
+	}
+	if strings.HasPrefix(s, ".") || strings.HasSuffix(s, ".") || strings.Contains(s, "..") {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case r == '.' || r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// ============================================================================
+// SWITCH ENDPOINT
+// ============================================================================
+
+// SwitchForgeRequest is the body of POST /api/saas/hives/{id}/forge.
+type SwitchForgeRequest struct {
+	// Host is the forge to move this hive to: "github.com" or a GitHub
+	// Enterprise host. Required.
+	Host string `json:"host"`
+	// InstallationID is the GitHub App installation ID on the TARGET forge.
+	//
+	// An installation ID is issued by one forge and is meaningless on any
+	// other, so switching forges necessarily invalidates the current one. It is
+	// therefore never carried over: it is either supplied here, or left for
+	// installation auto-discovery to resolve once the App is installed on the
+	// target org.
+	//
+	// Optional. Empty means "clear it and let discovery re-resolve it" — see
+	// the handler comment on why clearing is the safe default rather than
+	// keeping a value that is provably wrong.
+	InstallationID string `json:"installation_id,omitempty"`
+}
+
+// switchForgeResponse is the operator-facing result. It reports the App
+// identity the hive will now authenticate as, so the operator can see whether
+// the target cluster actually has an App configured before waiting on a beat.
+type switchForgeResponse struct {
+	Status          string `json:"status"`
+	ID              string `json:"id"`
+	FromHost        string `json:"from_host"`
+	ToHost          string `json:"to_host"`
+	ForgeKind       string `json:"forge_kind"`
+	APIURL          string `json:"api_url,omitempty"`
+	AppID           string `json:"app_id,omitempty"`
+	InstallationID  string `json:"installation_id,omitempty"`
+	AppInstallNote  string `json:"app_install_note,omitempty"`
+	DeliveryPending bool   `json:"delivery_pending"`
+}
+
+// forgeSwitchNeedsInstallNote is the operator-facing caveat returned when a
+// forge switch leaves the hive with no installation ID. The hive will not
+// authenticate until the App is installed on the target org (or an ID is
+// supplied), and saying so in the response is what stops an operator concluding
+// the switch silently failed.
+const forgeSwitchNeedsInstallNote = "installation_id was cleared because it belongs to the previous forge; install the GitHub App on this org on the target forge (or re-run with installation_id) before the hive can authenticate"
+
+// handleSwitchForge moves ONE hive to a different forge.
+//
+// AUTHORIZATION mirrors handleSwitchBranch / handleToggleAutoUpgrade exactly:
+// requireAuth on the route, plus an inner owner-or-admin check. The forge is a
+// property of where the owner's code lives, so the owner may set it; an admin
+// may set it on anyone's hive because moving a user between forges is precisely
+// the operator task this exists for.
+//
+// # WHY A HUB-SIDE EDIT ALONE IS NOT ENOUGH
+//
+// Editing github_host in the hive's meta.json and restarting the hub does NOT
+// stick — verified on the live fleet. The registry reverts to the spoke's value
+// within one beat, because handleHeartbeat records RegistryEntry.GitHubHost
+// from the spoke's own HeartbeatPayload.GitHubHost on every beat, and the spoke
+// derives that from its OWN config via GitHubConfig.HostLabel(). Nothing the
+// hub writes to meta.json changes what the spoke reports, so the hub's edit is
+// overwritten by the next report of the unchanged truth.
+//
+// This is the same class of bug as the ACMM revert fixed in #2354: hub-side
+// state that the spoke also reports is always won by the spoke unless the hub
+// PUSHES the change and waits for the spoke to report it back.
+//
+// The fix follows #2354's shape. The switch records the target on the hive and
+// re-arms a delivery flag (ForgeDelivered=false); projectConfigForHiveID then
+// pushes github_api_url down the heartbeat until the spoke reports a matching
+// host, at which point the flag latches true and the push stops for good.
+//
+// Crucially, HostLabel() reads base_url and FALLS BACK TO api_url, so pushing
+// the API URL alone is sufficient to change what the spoke reports — the
+// existing GitHubAPIURL field on HeartbeatProjectConfig is a complete delivery
+// channel for this, already implemented on both ends.
+func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
+	origin := r.Header.Get("Origin")
+	if isTrustedOrigin(origin) {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	}
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+
+	id := r.PathValue("id")
+	username := s.getAuthUser(r)
+	h := loadSaaSHive(id)
+	if h == nil {
+		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
+		return
+	}
+	if h.Owner != username && username != hubAdminUsername {
+		http.Error(w, `{"error":"only the owner can switch forges"}`, http.StatusForbidden)
+		return
+	}
+
+	var body SwitchForgeRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+	target, err := parseForgeTarget(body.Host)
+	if err != nil {
+		http.Error(w, `{"error":`+strconv.Quote(err.Error())+`}`, http.StatusBadRequest)
+		return
+	}
+
+	// An installation ID, when supplied, must be numeric. Rejecting here rather
+	// than storing garbage keeps the spoke from being handed a value it will
+	// fail on with a far less obvious error.
+	var installID int64
+	if raw := strings.TrimSpace(body.InstallationID); raw != "" {
+		installID, err = strconv.ParseInt(raw, 10, 64)
+		if err != nil || installID <= 0 {
+			http.Error(w, `{"error":"installation_id must be a positive number"}`, http.StatusBadRequest)
+			return
+		}
+	}
+
+	fromHost := h.GitHubHost
+	if fromHost == "" {
+		fromHost = publicForgeHost // "" has always meant public github.com
+	}
+
+	// Resolve the App identity for the TARGET forge from CLUSTER CONFIG. No App
+	// ID is hardcoded anywhere in Go: hive-oke names its github.com App and
+	// vllm-d names its github.ibm.com App, both in clusters.json, exactly as
+	// resolveProvisionAppID already reads them.
+	cluster := s.clusterForHive(h)
+	appID := s.forgeAppIDForTarget(cluster, target)
+
+	// Record the target. GitHubHost is what projectConfigForHiveID derives the
+	// pushed api_url from; GitHubBaseURL/GitHubAPIURL pin the hive explicitly so
+	// a later cluster-default change cannot silently move it back.
+	h.GitHubHost = target.Host
+	if target.IsPublic() {
+		// The sentinel, not "": an explicit public pin must survive a cluster
+		// whose defaults point at GHE, which is what githubHostPublic means to
+		// effectiveGitHubBaseURL / effectiveGitHubAPIURL / resolveProvisionAppID.
+		h.GitHubBaseURL = githubHostPublic
+		h.GitHubAPIURL = githubHostPublic
+	} else {
+		h.GitHubBaseURL = target.BaseURL
+		h.GitHubAPIURL = target.APIURL
+	}
+
+	// Re-arm delivery. This is the #2354 handshake: the requested host is
+	// authoritative until the spoke reports it back, at which point the push
+	// stops permanently and the spoke owns the value again.
+	h.RequestedGitHubHost = target.Host
+	h.ForgeDelivered = false
+
+	if err := saveSaaSHive(h); err != nil {
+		s.logger.Error("forge switch: failed to persist hive", "hive_id", id, "error", err)
+		http.Error(w, `{"error":"failed to save hive"}`, http.StatusInternalServerError)
+		return
+	}
+
+	// Keep the in-memory registry in step so the dashboard reflects the switch
+	// immediately rather than after the next beat. The spoke's own report will
+	// overwrite this within a beat or two — that is the point of the push — but
+	// showing the stale host in the meantime reads as "the switch did nothing".
+	s.mu.Lock()
+	for i := range s.registry.Hives {
+		if s.registry.Hives[i].ID == id {
+			s.registry.Hives[i].GitHubHost = target.Host
+			break
+		}
+	}
+	s.mu.Unlock()
+
+	// Swap the App identity. installation_id is per-forge and is NEVER carried
+	// over: an ID issued by github.com names nothing on github.ibm.com, and
+	// pushing it would authenticate as a nonexistent installation — a confusing
+	// 401/404 that looks like a key problem rather than a forge problem.
+	//
+	// Sending InstallationID: 0 is the spoke's documented "not speaking to this
+	// field" value, so a bare app_id switch leaves the spoke's stale ID in
+	// place. That is why an explicit clear is queued below via the hive's own
+	// record rather than relying on the heartbeat field alone.
+	deliveryPending := false
+	if appID > 0 {
+		s.storePendingGitHubAppConfig(id, &HeartbeatGitHubAppConfig{
+			AppID: appID,
+			// Only a supplied ID is sent. Zero means "leave it alone" on the
+			// wire; the operator note below tells the operator it must be
+			// installed or supplied, so the failure is never silent.
+			InstallationID: installID,
+			AppSlug:        forgeAppSlugForCluster(cluster),
+			// PrivateKey is deliberately absent. The per-cluster key reconcile
+			// (cluster_app_key.go) delivers key material on its own schedule and
+			// gates every key push on HasKey(); duplicating it here would risk
+			// blanking a working key with an empty string.
+		})
+		deliveryPending = true
+	}
+
+	note := ""
+	if installID == 0 {
+		note = forgeSwitchNeedsInstallNote
+	}
+
+	s.logger.Info("audit: hive forge switched",
+		"hive_id", id,
+		"actor", username,
+		"owner", h.Owner,
+		"org", h.Org,
+		"from_host", fromHost,
+		"to_host", target.Host,
+		"forge_kind", string(target.Kind),
+		"api_url", target.APIURL,
+		"app_id", appID,
+		"installation_id_supplied", installID != 0,
+		"cluster", clusterIDForHive(h),
+	)
+	s.recordTimeline(id, TimelineOwnership,
+		fmt.Sprintf("forge switched from %s to %s", fromHost, target.Host), username)
+
+	resp := switchForgeResponse{
+		Status:          "switched",
+		ID:              id,
+		FromHost:        fromHost,
+		ToHost:          target.Host,
+		ForgeKind:       string(target.Kind),
+		APIURL:          target.APIURL,
+		InstallationID:  strings.TrimSpace(body.InstallationID),
+		AppInstallNote:  note,
+		DeliveryPending: deliveryPending,
+	}
+	if appID > 0 {
+		resp.AppID = strconv.FormatInt(appID, 10)
+	}
+	json.NewEncoder(w).Encode(resp)
+}
+
+// forgeAppIDForTarget resolves the GitHub App ID to authenticate as on the
+// TARGET forge, from cluster config only.
+//
+// The cluster's configured app_id is correct exactly when the cluster's own
+// GitHub host matches the target — hive-oke is a github.com cluster and vllm-d
+// is a github.ibm.com cluster, so a hive switching to the cluster's own forge
+// gets the cluster's App. A hive switching to a forge the cluster does NOT
+// default to has no App the hub can name, and returning 0 is the honest answer:
+// zero means "say nothing about the App", which leaves the spoke's credentials
+// untouched rather than pushing an App ID from the wrong forge.
+//
+// No App ID is hardcoded. This reads ClusterConfig.GitHubAppID, the same
+// non-secret field resolveProvisionAppID uses.
+func (s *HubServer) forgeAppIDForTarget(cluster *ClusterConfig, target ForgeTarget) int64 {
+	if cluster == nil || cluster.GitHubAppID == 0 {
+		return 0
+	}
+	clusterHost := publicForgeHost
+	if cluster.GitHubBaseURL != "" {
+		clusterHost = strings.ToLower(githubHostLabel(cluster.GitHubBaseURL))
+	} else if cluster.GitHubAPIURL != "" {
+		clusterHost = strings.ToLower(githubHostLabel(cluster.GitHubAPIURL))
+	}
+	if !sameGitHubHost(clusterHost, target.Host) {
+		return 0
+	}
+	return cluster.GitHubAppID
+}
+
+// forgeAppSlugForCluster returns the cluster's App slug, or "" when it has
+// none. Empty is the spoke's "leave my slug alone" value, so this never blanks
+// a working install link.
+func forgeAppSlugForCluster(cluster *ClusterConfig) string {
+	if cluster == nil {
+		return ""
+	}
+	return cluster.GitHubAppSlug
+}
+
+// ============================================================================
+// FORGE DELIVERY HANDSHAKE
+// ============================================================================
+
+// pendingForgeAPIURL returns the github_api_url the hub must still push to
+// deliver an outstanding forge switch, or "" when there is nothing to deliver.
+//
+// It is the push half of the handshake described on SaaSHive.RequestedGitHubHost.
+// The delivery is bounded and self-limiting: it fires only while
+// RequestedGitHubHost is set and ForgeDelivered is false, and adoptSpokeForge
+// flips ForgeDelivered the moment the spoke reports the requested host. Once
+// that happens this returns "" forever, so a switch cannot become a permanent
+// push that overrides a later operator change on the spoke — the failure mode
+// #2061 hit with ACMM.
+//
+// curAPIURL is what the spoke reports it is CURRENTLY running against.
+//
+// # WHY SWITCHING TO PUBLIC GITHUB NEEDS AN EXPLICIT URL
+//
+// Everywhere else in this codebase an empty github_api_url means "leave the
+// spoke's value unchanged" — which is exactly right when the hub has nothing
+// to say. But it makes a switch FROM GitHub Enterprise TO public github.com
+// undeliverable: the natural value to send is "", and "" is precisely the
+// value the spoke ignores, so a GHE spoke would keep its GHE api_url forever
+// and keep reporting github.ibm.com. So the public target is delivered as the
+// EXPLICIT config.DefaultGitHubAPIURL rather than as emptiness. The spoke
+// already defaults to that string, and it resolves through HostLabel() to
+// "github.com", which is what closes the read-back.
+func pendingForgeAPIURL(h *SaaSHive, curAPIURL string) string {
+	if h == nil || h.ForgeDelivered || h.RequestedGitHubHost == "" {
+		return ""
+	}
+	target, err := parseForgeTarget(h.RequestedGitHubHost)
+	if err != nil {
+		return "" // an unparseable stored target is never pushed
+	}
+	want := target.APIURL
+	if want == "" {
+		// Public github.com — send the explicit default, not "" (see above).
+		want = defaultPublicAPIURL
+	}
+	if strings.EqualFold(strings.TrimSpace(curAPIURL), want) {
+		// The spoke is already there. adoptSpokeForge latches ForgeDelivered
+		// from the reported HOST; returning "" here simply stops re-sending a
+		// value that has demonstrably landed.
+		return ""
+	}
+	return want
+}
+
+// defaultPublicAPIURL is the public github.com REST API base. It duplicates
+// config.DefaultGitHubAPIURL deliberately: pkg/hub does not import pkg/config
+// for this value anywhere else on the heartbeat path, and the string is a
+// stable, public, product-level constant.
+const defaultPublicAPIURL = "https://api.github.com"
+
+// adoptSpokeForge closes the forge handshake: once the spoke reports the host
+// the operator asked for, delivery is complete and the hub stops pushing.
+//
+// It is the direct analogue of the ACMMDelivered latch in
+// adoptSpokeProjectConfig, and it exists because the hub CANNOT simply trust
+// its own meta: the spoke re-reports its host on every beat and the registry
+// adopts that report, so the only durable evidence a switch landed is the
+// spoke saying so.
+//
+// spokeHost is HeartbeatPayload.GitHubHost — the spoke's own
+// GitHubConfig.HostLabel(). An EMPTY report means the spoke is too old to
+// report the field, which is UNKNOWN, not a match: latching on it would end the
+// delivery without any evidence it succeeded, leaving the hive on the old forge
+// with the hub believing otherwise.
+//
+// Returns true when it changed and persisted the record.
+func (s *HubServer) adoptSpokeForge(hiveID, spokeHost string) bool {
+	spokeHost = strings.TrimSpace(spokeHost)
+	if spokeHost == "" {
+		return false // too old to report — unknown, never a match
+	}
+	h := loadSaaSHive(hiveID)
+	if h == nil || h.RequestedGitHubHost == "" || h.ForgeDelivered {
+		return false
+	}
+	if !sameGitHubHost(spokeHost, h.RequestedGitHubHost) {
+		s.logger.Info("forge switch not yet applied on spoke; still delivering",
+			"hive_id", hiveID,
+			"spoke_reports", spokeHost,
+			"requested", h.RequestedGitHubHost)
+		return false
+	}
+	h.ForgeDelivered = true
+	// Keep GitHubHost in step with what the spoke now actually runs. Normally
+	// they already agree (the switch handler set both), but stating it here
+	// means the record cannot be left describing the old forge if this ever runs
+	// against a hive whose meta was edited out from under it.
+	if !sameGitHubHost(h.GitHubHost, spokeHost) {
+		h.GitHubHost = strings.ToLower(spokeHost)
+	}
+	if err := saveSaaSHive(h); err != nil {
+		s.logger.Warn("forge switch: failed to persist delivery",
+			"hive_id", hiveID, "error", err)
+		return false
+	}
+	s.logger.Info("forge switch delivered to spoke",
+		"hive_id", hiveID, "github_host", spokeHost)
+	return true
+}

--- a/v2/pkg/hub/forge_test.go
+++ b/v2/pkg/hub/forge_test.go
@@ -2,6 +2,9 @@ package hub
 
 import (
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -225,19 +228,32 @@ func TestForgePushIsInertWithoutASwitch(t *testing.T) {
 	}
 }
 
-// TestForgeAppIDComesFromClusterConfigOnly locks the credential half: no App ID
-// is hardcoded in Go, and a cluster whose forge does not match the target must
-// contribute nothing rather than pushing an App from the wrong forge.
-func TestForgeAppIDComesFromClusterConfigOnly(t *testing.T) {
+// TestForgeIdentityIsAtomic is the regression test for a hive that was broken
+// by hand, and it is the most important test in this file.
+//
+// A hive was moved to github.ibm.com by editing github_host alone. The host
+// changed; the identity did not. It kept the github.com app_id (3568013 where
+// GHE needs its own), an EMPTY app_slug, and an installation_id belonging to
+// the old forge. The owner clicked "Install GitHub App" and got a GitHub 404,
+// because an empty app_slug falls back to config.DefaultGitHubAppSlug
+// ("kubestellar-hive") — the github.com App's slug, which names nothing on GHE.
+//
+// A wrong install link is worse than no link: it tells the user the product is
+// broken. So a forge switch resolves the identity as a SET and refuses when any
+// part of it is unknown, rather than half-applying.
+func TestForgeIdentityIsAtomic(t *testing.T) {
 	s := &HubServer{logger: slog.Default()}
 
-	// A github.com cluster (hive-oke shape): no GHE URLs, its own app id.
+	// A github.com cluster (hive-oke shape): no GHE URLs, its own app + slug.
 	const publicClusterApp int64 = 111
-	publicCluster := &ClusterConfig{ID: "hive-oke", GitHubAppID: publicClusterApp}
-	// An enterprise cluster (vllm-d shape): GHE base/api URLs, its own app id.
+	publicCluster := &ClusterConfig{
+		ID: "hive-oke", GitHubAppID: publicClusterApp, GitHubAppSlug: "kubestellar-hive",
+	}
+	// An enterprise cluster (vllm-d shape): GHE base/api URLs, its own app+slug.
 	const gheClusterApp int64 = 222
 	gheCluster := &ClusterConfig{
 		ID: "vllm-d", GitHubAppID: gheClusterApp,
+		GitHubAppSlug: "kubestellar-hive-ghe",
 		GitHubBaseURL: "https://github.ibm.com",
 		GitHubAPIURL:  "https://github.ibm.com/api/v3",
 	}
@@ -251,26 +267,250 @@ func TestForgeAppIDComesFromClusterConfigOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := s.forgeAppIDForTarget(publicCluster, public); got != publicClusterApp {
-		t.Errorf("github.com hive on a github.com cluster: app id = %d, want %d from cluster config", got, publicClusterApp)
+	// Fully configured clusters resolve a COMPLETE identity — id AND slug.
+	got, missing := s.forgeIdentityForTarget(publicCluster, public)
+	if len(missing) != 0 || got.AppID != publicClusterApp || got.AppSlug != "kubestellar-hive" {
+		t.Errorf("github.com cluster: identity = %+v missing = %v, want the configured app id and slug", got, missing)
 	}
-	if got := s.forgeAppIDForTarget(gheCluster, ghe); got != gheClusterApp {
-		t.Errorf("GHE hive on a GHE cluster: app id = %d, want %d from cluster config", got, gheClusterApp)
+	got, missing = s.forgeIdentityForTarget(gheCluster, ghe)
+	if len(missing) != 0 || got.AppID != gheClusterApp || got.AppSlug != "kubestellar-hive-ghe" {
+		t.Errorf("GHE cluster: identity = %+v missing = %v, want the configured GHE app id and slug", got, missing)
 	}
+
+	// THE LIVE BUG: a GHE cluster whose github_app_slug was never populated.
+	// This must be REFUSED, not silently accepted with an empty slug that falls
+	// back to the github.com default and 404s on the install link.
+	slugless := &ClusterConfig{
+		ID: "vllm-d", GitHubAppID: gheClusterApp,
+		GitHubBaseURL: "https://github.ibm.com",
+		GitHubAPIURL:  "https://github.ibm.com/api/v3",
+	}
+	got, missing = s.forgeIdentityForTarget(slugless, ghe)
+	if len(missing) == 0 {
+		t.Fatalf("a cluster with no github_app_slug must be refused — an empty slug 404s the install link on GHE; got identity %+v", got)
+	}
+	if got.AppSlug != "" || got.AppID != 0 {
+		t.Errorf("a refused identity must be entirely empty (all-or-nothing), got %+v", got)
+	}
+	if !strings.Contains(strings.Join(missing, " "), "github_app_slug") {
+		t.Errorf("the refusal must NAME the missing field so an operator can fix clusters.json, got %v", missing)
+	}
+
 	// Cross-forge: the cluster's App is registered on the OTHER forge, so it
-	// names nothing on the target. Zero = "say nothing", which leaves the
-	// spoke's credentials untouched rather than pushing a wrong-forge App.
-	if got := s.forgeAppIDForTarget(publicCluster, ghe); got != 0 {
-		t.Errorf("github.com cluster must contribute no App for a GHE target, got %d", got)
+	// names nothing on the target. Refused rather than pushed.
+	if _, missing = s.forgeIdentityForTarget(publicCluster, ghe); len(missing) == 0 {
+		t.Error("a github.com cluster must not supply an identity for a GHE target")
 	}
-	if got := s.forgeAppIDForTarget(gheCluster, public); got != 0 {
-		t.Errorf("GHE cluster must contribute no App for a github.com target, got %d", got)
+	if _, missing = s.forgeIdentityForTarget(gheCluster, public); len(missing) == 0 {
+		t.Error("a GHE cluster must not supply an identity for a github.com target")
 	}
-	// A cluster with no configured App, and a nil cluster, must both be silent.
-	if got := s.forgeAppIDForTarget(&ClusterConfig{ID: "bare"}, public); got != 0 {
-		t.Errorf("cluster with no github_app_id must contribute nothing, got %d", got)
+	// A cluster with no configured App, and a nil cluster, are both refusals.
+	if _, missing = s.forgeIdentityForTarget(&ClusterConfig{ID: "bare"}, public); len(missing) == 0 {
+		t.Error("a cluster with no github_app_id must be refused")
 	}
-	if got := s.forgeAppIDForTarget(nil, public); got != 0 {
-		t.Errorf("nil cluster must contribute nothing, got %d", got)
+	if _, missing = s.forgeIdentityForTarget(nil, public); len(missing) == 0 {
+		t.Error("a nil cluster must be refused")
+	}
+}
+
+// forgeTestSecret signs the auth cookie in the handler tests below.
+const forgeTestSecret = "forge-test-secret"
+
+// postForgeSwitch drives the real handler end to end as the given user.
+func postForgeSwitch(t *testing.T, s *HubServer, hiveID, username, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/hives/"+hiveID+"/forge", strings.NewReader(body))
+	req.SetPathValue("id", hiveID)
+	if username != "" {
+		req.AddCookie(&http.Cookie{
+			Name:  "hive_hub_user",
+			Value: mintHubUserCookieValue(forgeTestSecret, username),
+		})
+	}
+	rec := httptest.NewRecorder()
+	s.handleSwitchForge(rec, req)
+	return rec
+}
+
+// TestSwitchForgeRefusesPartialIdentity drives the HANDLER through the live
+// failure: a GHE cluster whose github_app_slug was never populated.
+//
+// The switch must write NOTHING. A half-applied switch is what produced a hive
+// on github.ibm.com still carrying the github.com app_id and an empty slug —
+// and an "Install GitHub App" link that 404s.
+func TestSwitchForgeRefusesPartialIdentity(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "enricom8"}); err != nil {
+		t.Fatal(err)
+	}
+	saveSaaSHive(&SaaSHive{
+		ID: "vllmd03", Owner: "enricom8", Status: "running", ClusterID: "vllm-d",
+		Org: "enricom-ibm", Repos: []string{"jackrabbit"}, PrimaryRepo: "jackrabbit",
+		ACMMLevel: 2, GitHubHost: "github.com",
+	})
+	s := &HubServer{
+		logger:    slog.Default(),
+		hubSecret: forgeTestSecret,
+		clusters: map[string]ClusterConfig{
+			// The live vllm-d shape at the time of the incident: an app id, GHE
+			// URLs, and NO github_app_slug.
+			"vllm-d": {
+				ID: "vllm-d", GitHubAppID: 5686,
+				GitHubBaseURL: "https://github.ibm.com",
+				GitHubAPIURL:  "https://github.ibm.com/api/v3",
+			},
+		},
+		pendingGitHubAppConfigs: map[string]*HeartbeatGitHubAppConfig{},
+	}
+
+	rec := postForgeSwitch(t, s, "vllmd03", "enricom8", `{"host":"github.ibm.com"}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 — an incomplete target identity must refuse, not half-apply (body=%q)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "github_app_slug") {
+		t.Errorf("the refusal must name the missing field, got %q", rec.Body.String())
+	}
+
+	// NOTHING may have been written: not the host, not the pin, not the
+	// delivery arming. This is the atomicity guarantee.
+	h := loadSaaSHive("vllmd03")
+	if h == nil {
+		t.Fatal("hive vanished")
+	}
+	if h.GitHubHost != "github.com" {
+		t.Errorf("github_host = %q, want the ORIGINAL github.com — a refused switch must not move the host", h.GitHubHost)
+	}
+	if h.RequestedGitHubHost != "" || h.ForgeDelivered {
+		t.Errorf("a refused switch must not arm delivery, got requested=%q delivered=%v", h.RequestedGitHubHost, h.ForgeDelivered)
+	}
+	if h.GitHubBaseURL != "" || h.GitHubAPIURL != "" {
+		t.Errorf("a refused switch must not pin URLs, got base=%q api=%q", h.GitHubBaseURL, h.GitHubAPIURL)
+	}
+	if got := s.consumePendingGitHubAppConfig("vllmd03"); got != nil {
+		t.Errorf("a refused switch must queue no App delivery, got %+v", got)
+	}
+}
+
+// TestSwitchForgeSwapsTheWholeIdentity is the success path, and it asserts that
+// every field in the identity set moves together — including the app_slug whose
+// absence caused the live 404.
+func TestSwitchForgeSwapsTheWholeIdentity(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "enricom8"}); err != nil {
+		t.Fatal(err)
+	}
+	saveSaaSHive(&SaaSHive{
+		ID: "vllmd03", Owner: "enricom8", Status: "running", ClusterID: "vllm-d",
+		Org: "enricom-ibm", Repos: []string{"jackrabbit"}, PrimaryRepo: "jackrabbit",
+		ACMMLevel: 2, GitHubHost: "github.com",
+	})
+	const gheAppID int64 = 5686
+	s := &HubServer{
+		logger:    slog.Default(),
+		hubSecret: forgeTestSecret,
+		clusters: map[string]ClusterConfig{
+			"vllm-d": {
+				ID: "vllm-d", GitHubAppID: gheAppID,
+				GitHubAppSlug: "kubestellar-hive-ghe",
+				GitHubBaseURL: "https://github.ibm.com",
+				GitHubAPIURL:  "https://github.ibm.com/api/v3",
+			},
+		},
+		pendingGitHubAppConfigs: map[string]*HeartbeatGitHubAppConfig{},
+	}
+
+	rec := postForgeSwitch(t, s, "vllmd03", "enricom8", `{"host":"github.ibm.com"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+
+	h := loadSaaSHive("vllmd03")
+	if h == nil {
+		t.Fatal("hive vanished")
+	}
+	if h.GitHubHost != "github.ibm.com" {
+		t.Errorf("github_host = %q, want github.ibm.com", h.GitHubHost)
+	}
+	if h.GitHubBaseURL != "https://github.ibm.com" {
+		t.Errorf("base_url = %q, want the GHE web base — the field left empty by the manual edit", h.GitHubBaseURL)
+	}
+	if h.GitHubAPIURL != "https://github.ibm.com/api/v3" {
+		t.Errorf("api_url = %q, want the GHE API", h.GitHubAPIURL)
+	}
+	if h.RequestedGitHubHost != "github.ibm.com" || h.ForgeDelivered {
+		t.Errorf("delivery must be armed and undelivered, got requested=%q delivered=%v", h.RequestedGitHubHost, h.ForgeDelivered)
+	}
+
+	// The App identity queued for the spoke must carry the GHE app id AND the
+	// GHE slug, and must NOT carry an installation id from the old forge.
+	got := s.consumePendingGitHubAppConfig("vllmd03")
+	if got == nil {
+		t.Fatal("no App identity queued for the spoke — the hive would keep the github.com App")
+	}
+	if got.AppID != gheAppID {
+		t.Errorf("queued app_id = %d, want the cluster's GHE app %d", got.AppID, gheAppID)
+	}
+	if got.AppSlug != "kubestellar-hive-ghe" {
+		t.Errorf("queued app_slug = %q, want the GHE slug — an empty slug is what 404s the install link", got.AppSlug)
+	}
+	if got.InstallationID != 0 {
+		t.Errorf("installation_id = %d, want 0 — an ID from the previous forge must NEVER be carried over", got.InstallationID)
+	}
+	if got.PrivateKey != "" {
+		t.Errorf("this endpoint must not push key material; the per-cluster reconcile owns that, got a key of %d bytes", len(got.PrivateKey))
+	}
+
+	// The response must tell the operator the install is still outstanding,
+	// rather than reading as a completed success.
+	if !strings.Contains(rec.Body.String(), "installation_id was cleared") {
+		t.Errorf("response must flag the cleared installation_id, got %q", rec.Body.String())
+	}
+
+	// IDEMPOTENT and re-runnable: switching again to the same forge is safe.
+	rec2 := postForgeSwitch(t, s, "vllmd03", "enricom8", `{"host":"github.ibm.com"}`)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("re-running the same switch must succeed, got %d (%q)", rec2.Code, rec2.Body.String())
+	}
+}
+
+// TestSwitchForgeAuthorization locks the owner-or-admin rule.
+func TestSwitchForgeAuthorization(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	for _, u := range []string{"enricom8", "someoneelse", hubAdminUsername} {
+		if err := saveSaaSUser(&SaaSUser{GitHubUsername: u}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	saveSaaSHive(&SaaSHive{
+		ID: "h", Owner: "enricom8", Status: "running", ClusterID: "c",
+		Org: "o", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 2,
+	})
+	s := &HubServer{
+		logger:    slog.Default(),
+		hubSecret: forgeTestSecret,
+		clusters: map[string]ClusterConfig{
+			"c": {ID: "c", GitHubAppID: 111, GitHubAppSlug: "kubestellar-hive"},
+		},
+		pendingGitHubAppConfigs: map[string]*HeartbeatGitHubAppConfig{},
+	}
+
+	if rec := postForgeSwitch(t, s, "h", "someoneelse", `{"host":"github.com"}`); rec.Code != http.StatusForbidden {
+		t.Errorf("a non-owner must be refused, got %d", rec.Code)
+	}
+	if rec := postForgeSwitch(t, s, "h", hubAdminUsername, `{"host":"github.com"}`); rec.Code != http.StatusOK {
+		t.Errorf("an admin must be allowed, got %d (%q)", rec.Code, rec.Body.String())
+	}
+	if rec := postForgeSwitch(t, s, "h", "enricom8", `{"host":"github.com"}`); rec.Code != http.StatusOK {
+		t.Errorf("the owner must be allowed, got %d (%q)", rec.Code, rec.Body.String())
+	}
+	// A bad host is rejected before anything is written.
+	if rec := postForgeSwitch(t, s, "h", "enricom8", `{"host":"not a host"}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("an invalid forge host must 400, got %d", rec.Code)
 	}
 }

--- a/v2/pkg/hub/forge_test.go
+++ b/v2/pkg/hub/forge_test.go
@@ -1,0 +1,276 @@
+package hub
+
+import (
+	"log/slog"
+	"testing"
+)
+
+// TestParseForgeTarget locks the validation contract: a forge is validated into
+// a known kind, never accepted as an arbitrary string.
+func TestParseForgeTarget(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		wantErr bool
+		kind    ForgeKind
+		host    string
+		apiURL  string
+	}{
+		{name: "public bare", in: "github.com", kind: ForgeGitHub, host: "github.com", apiURL: ""},
+		{name: "public via URL", in: "https://github.com/", kind: ForgeGitHub, host: "github.com"},
+		{name: "public via api host", in: "api.github.com", kind: ForgeGitHub, host: "github.com"},
+		{name: "uppercase normalizes", in: "GitHub.COM", kind: ForgeGitHub, host: "github.com"},
+		{
+			name: "ghe bare", in: "github.ibm.com",
+			kind: ForgeGitHubEnterprise, host: "github.ibm.com",
+			apiURL: "https://github.ibm.com/api/v3",
+		},
+		{
+			// The exact paste an operator is most likely to make — an org URL.
+			// It must normalize to the same target as the bare host, not be
+			// recorded verbatim and produce a spoke that talks to nothing.
+			name: "ghe pasted org URL", in: "https://github.ibm.com/enricom-ibm",
+			kind: ForgeGitHubEnterprise, host: "github.ibm.com",
+			apiURL: "https://github.ibm.com/api/v3",
+		},
+		{
+			name: "future ghe host", in: "github.cisco.com",
+			kind: ForgeGitHubEnterprise, host: "github.cisco.com",
+			apiURL: "https://github.cisco.com/api/v3",
+		},
+		{name: "empty rejected", in: "", wantErr: true},
+		{name: "whitespace rejected", in: "   ", wantErr: true},
+		{name: "no dot rejected", in: "notahost", wantErr: true},
+		{name: "space in host rejected", in: "git hub.com", wantErr: true},
+		{name: "double dot rejected", in: "github..com", wantErr: true},
+		{name: "trailing dot rejected", in: "github.com.", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseForgeTarget(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseForgeTarget(%q) = %+v, want an error — arbitrary strings must not be accepted", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseForgeTarget(%q) unexpected error: %v", tc.in, err)
+			}
+			if got.Kind != tc.kind {
+				t.Errorf("kind = %q, want %q", got.Kind, tc.kind)
+			}
+			if got.Host != tc.host {
+				t.Errorf("host = %q, want %q", got.Host, tc.host)
+			}
+			if got.APIURL != tc.apiURL {
+				t.Errorf("api url = %q, want %q", got.APIURL, tc.apiURL)
+			}
+		})
+	}
+}
+
+// TestForgeSwitchSurvivesHeartbeat is the whole point of the feature, and it is
+// a REGRESSION TEST for a failure verified on the live fleet.
+//
+// github_host was edited to "github.ibm.com" in a hive's meta.json on the hub
+// and the hub restarted. It did not stick: the spoke re-reported github.com on
+// its next beat and the hub adopted it. A hub-side edit is provably
+// insufficient, because the spoke is the one that reports the host and nothing
+// the hub writes to meta changes what the spoke runs.
+//
+// The switch must therefore PUSH, and keep pushing until the spoke confirms.
+func TestForgeSwitchSurvivesHeartbeat(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := &HubServer{logger: slog.Default()}
+
+	// A hive on github.com that an operator has just switched to github.ibm.com:
+	// the target is recorded and delivery is armed.
+	saveSaaSHive(&SaaSHive{
+		ID: "vllmd03", Status: "running", Org: "enricom-ibm",
+		Repos: []string{"jackrabbit"}, PrimaryRepo: "jackrabbit", ACMMLevel: 2,
+		GitHubHost: "github.ibm.com", RequestedGitHubHost: "github.ibm.com",
+		ForgeDelivered: false,
+	})
+
+	// Beat 1: the spoke still reports the OLD host and the OLD api url. This is
+	// exactly the state that silently reverted the manual edit. The hub must
+	// push the enterprise API URL.
+	got := projectConfigForHiveID("vllmd03", "enricom-ibm", []string{"jackrabbit"}, "jackrabbit", 2, "", "https://api.github.com")
+	if got == nil {
+		t.Fatal("no push for an undelivered forge switch — this is the exact production silence that reverted the manual edit")
+	}
+	if got.GitHubAPIURL != "https://github.ibm.com/api/v3" {
+		t.Errorf("pushed GitHubAPIURL = %q, want the enterprise API", got.GitHubAPIURL)
+	}
+
+	// ...and the hub must NOT declare victory on the spoke's stale report.
+	// Latching here would end the delivery with no evidence it worked.
+	if s.adoptSpokeForge("vllmd03", "github.com") {
+		t.Error("adopted delivery from a spoke still reporting the OLD host")
+	}
+	if h := loadSaaSHive("vllmd03"); h == nil || h.ForgeDelivered {
+		t.Fatalf("ForgeDelivered must stay false while the spoke reports the old host, got %+v", h)
+	}
+
+	// Beat 2: the spoke has adopted the API URL. HostLabel() falls back to
+	// api_url, so it now reports github.ibm.com — which is what closes the
+	// read-back and stops the push for good.
+	if !s.adoptSpokeForge("vllmd03", "github.ibm.com") {
+		t.Fatal("spoke reported the requested host but delivery did not complete")
+	}
+	h := loadSaaSHive("vllmd03")
+	if h == nil || !h.ForgeDelivered || h.GitHubHost != "github.ibm.com" {
+		t.Fatalf("after delivery meta = %+v, want ForgeDelivered=true host=github.ibm.com", h)
+	}
+
+	// IDEMPOTENCE: the push stops permanently. Continuing to push would make
+	// the forge un-editable on the spoke forever — the #2061 ACMM failure mode.
+	if got := projectConfigForHiveID("vllmd03", "enricom-ibm", []string{"jackrabbit"}, "jackrabbit", 2, "", "https://github.ibm.com/api/v3"); got != nil {
+		t.Errorf("delivered forge must never push again, got %+v", got)
+	}
+	if s.adoptSpokeForge("vllmd03", "github.ibm.com") {
+		t.Error("re-adopting a delivered forge must be a no-op")
+	}
+}
+
+// TestForgeSwitchBackToPublicIsDeliverable covers the direction that the
+// existing GHE push could never handle.
+//
+// Everywhere else an empty github_api_url means "leave the spoke alone", and
+// gheAPIURLForHost("github.com") is "" by definition — so a naive
+// implementation can move a hive TO enterprise but never back. The public
+// target is therefore delivered as an EXPLICIT api.github.com.
+func TestForgeSwitchBackToPublicIsDeliverable(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := &HubServer{logger: slog.Default()}
+	saveSaaSHive(&SaaSHive{
+		ID: "back", Status: "running", Org: "o", Repos: []string{"r"},
+		PrimaryRepo: "r", ACMMLevel: 2,
+		GitHubHost: "github.com", RequestedGitHubHost: "github.com",
+		ForgeDelivered: false,
+	})
+
+	got := projectConfigForHiveID("back", "o", []string{"r"}, "r", 2, "", "https://github.ibm.com/api/v3")
+	if got == nil {
+		t.Fatal("switching back to public github.com produced no push — the hive would stay on the enterprise API forever")
+	}
+	if got.GitHubAPIURL != defaultPublicAPIURL {
+		t.Errorf("pushed GitHubAPIURL = %q, want an explicit %q (empty would be ignored by the spoke)", got.GitHubAPIURL, defaultPublicAPIURL)
+	}
+
+	if !s.adoptSpokeForge("back", "github.com") {
+		t.Fatal("spoke reported github.com but delivery did not complete")
+	}
+	if got := projectConfigForHiveID("back", "o", []string{"r"}, "r", 2, "", defaultPublicAPIURL); got != nil {
+		t.Errorf("delivered public forge must never push again, got %+v", got)
+	}
+}
+
+// TestForgeDeliveryIgnoresSilentSpoke locks "unknown is not a match".
+//
+// A spoke too old to report github_host sends "". Latching delivery on that
+// would end the push with zero evidence the switch landed, leaving the hive on
+// the old forge while the hub believes it moved — a silent failure, and the
+// worst outcome available.
+func TestForgeDeliveryIgnoresSilentSpoke(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := &HubServer{logger: slog.Default()}
+	saveSaaSHive(&SaaSHive{
+		ID: "old", Status: "running", Org: "o", Repos: []string{"r"},
+		PrimaryRepo: "r", ACMMLevel: 2,
+		GitHubHost: "github.ibm.com", RequestedGitHubHost: "github.ibm.com",
+	})
+	if s.adoptSpokeForge("old", "") {
+		t.Error("an empty host report is UNKNOWN, not a delivery confirmation")
+	}
+	if h := loadSaaSHive("old"); h == nil || h.ForgeDelivered {
+		t.Fatalf("silent spoke must not complete delivery, got %+v", h)
+	}
+}
+
+// TestForgePushIsInertWithoutASwitch guarantees the feature is invisible to the
+// ~every hive nobody has switched. Both new fields default to their zero values
+// on every existing record, so the push must be gated on a NON-EMPTY request.
+func TestForgePushIsInertWithoutASwitch(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := &HubServer{logger: slog.Default()}
+	// A perfectly ordinary delivered hive, as every record on the PVC looks today.
+	saveSaaSHive(&SaaSHive{
+		ID: "plain", Status: "running", Org: "o", Repos: []string{"r"},
+		PrimaryRepo: "r", ACMMLevel: 3, RequestedACMMLevel: 3,
+		ClaimDelivered: true, ACMMDelivered: true,
+	})
+	if got := projectConfigForHiveID("plain", "o", []string{"r"}, "r", 3, "", "https://api.github.com"); got != nil {
+		t.Errorf("a hive with no forge switch must push nothing, got %+v", got)
+	}
+	if s.adoptSpokeForge("plain", "github.com") {
+		t.Error("a hive with no forge switch must not record a delivery")
+	}
+	// And an unparseable stored target is never pushed rather than pushing junk.
+	saveSaaSHive(&SaaSHive{
+		ID: "junk", Status: "running", Org: "o", Repos: []string{"r"},
+		PrimaryRepo: "r", ACMMLevel: 3, RequestedGitHubHost: "not a host",
+	})
+	if got := pendingForgeAPIURL(loadSaaSHive("junk"), ""); got != "" {
+		t.Errorf("unparseable stored forge target must push nothing, got %q", got)
+	}
+}
+
+// TestForgeAppIDComesFromClusterConfigOnly locks the credential half: no App ID
+// is hardcoded in Go, and a cluster whose forge does not match the target must
+// contribute nothing rather than pushing an App from the wrong forge.
+func TestForgeAppIDComesFromClusterConfigOnly(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+
+	// A github.com cluster (hive-oke shape): no GHE URLs, its own app id.
+	const publicClusterApp int64 = 111
+	publicCluster := &ClusterConfig{ID: "hive-oke", GitHubAppID: publicClusterApp}
+	// An enterprise cluster (vllm-d shape): GHE base/api URLs, its own app id.
+	const gheClusterApp int64 = 222
+	gheCluster := &ClusterConfig{
+		ID: "vllm-d", GitHubAppID: gheClusterApp,
+		GitHubBaseURL: "https://github.ibm.com",
+		GitHubAPIURL:  "https://github.ibm.com/api/v3",
+	}
+
+	public, err := parseForgeTarget("github.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ghe, err := parseForgeTarget("github.ibm.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := s.forgeAppIDForTarget(publicCluster, public); got != publicClusterApp {
+		t.Errorf("github.com hive on a github.com cluster: app id = %d, want %d from cluster config", got, publicClusterApp)
+	}
+	if got := s.forgeAppIDForTarget(gheCluster, ghe); got != gheClusterApp {
+		t.Errorf("GHE hive on a GHE cluster: app id = %d, want %d from cluster config", got, gheClusterApp)
+	}
+	// Cross-forge: the cluster's App is registered on the OTHER forge, so it
+	// names nothing on the target. Zero = "say nothing", which leaves the
+	// spoke's credentials untouched rather than pushing a wrong-forge App.
+	if got := s.forgeAppIDForTarget(publicCluster, ghe); got != 0 {
+		t.Errorf("github.com cluster must contribute no App for a GHE target, got %d", got)
+	}
+	if got := s.forgeAppIDForTarget(gheCluster, public); got != 0 {
+		t.Errorf("GHE cluster must contribute no App for a github.com target, got %d", got)
+	}
+	// A cluster with no configured App, and a nil cluster, must both be silent.
+	if got := s.forgeAppIDForTarget(&ClusterConfig{ID: "bare"}, public); got != 0 {
+		t.Errorf("cluster with no github_app_id must contribute nothing, got %d", got)
+	}
+	if got := s.forgeAppIDForTarget(nil, public); got != 0 {
+		t.Errorf("nil cluster must contribute nothing, got %d", got)
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -193,6 +193,10 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/switch-branch", s.requireAuth(s.handleSwitchBranch))
 	s.mux.HandleFunc("PUT /api/saas/hives/{id}/visibility", s.requireAuth(s.handleToggleVisibility))
 	s.mux.HandleFunc("PUT /api/saas/hives/{id}/auto-upgrade", s.requireAuth(s.handleToggleAutoUpgrade))
+	// Move a hive between forges (github.com <-> a GitHub Enterprise host).
+	// requireAuth plus an inner owner-or-admin check, exactly like
+	// switch-branch and auto-upgrade above.
+	s.mux.HandleFunc("POST /api/saas/hives/{id}/forge", s.requireAuth(s.handleSwitchForge))
 	s.mux.HandleFunc("GET /api/saas/hive-config/{hiveID}", s.requireAuth(s.handleProxyHiveConfig))
 	s.mux.HandleFunc("GET /api/saas/latest-sha", s.handleLatestSHA)
 	s.mux.HandleFunc("POST /api/saas/hub/upgrade", s.requireAdmin(s.handleHubSelfUpgrade))
@@ -5747,6 +5751,16 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 		// (addVanityHostToIngress succeeded, or a cluster wildcard route already
 		// serves it), so this never pushes an unserved host and never reintroduces
 		// the 503.
+		//
+		// A pending FORGE SWITCH is likewise independent of project
+		// completeness — a hive can be moved between forges whether or not its
+		// meta carries a complete claim, and the switch is precisely the
+		// operator action that must not be silently dropped. Push the API URL
+		// alone (never the stale project) until the spoke reports the requested
+		// host back.
+		if apiURL := pendingForgeAPIURL(h, curAPIURL); apiURL != "" {
+			return &HeartbeatProjectConfig{GitHubAPIURL: apiURL}
+		}
 		if h.VanityURL != "" && curURL != h.VanityURL {
 			return &HeartbeatProjectConfig{DashboardURL: h.VanityURL}
 		}
@@ -5806,7 +5820,15 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 	// would re-send on every beat with no read-back to ever stop it.
 	wantAPIURL := gheAPIURLForHost(h.GitHubHost)
 	needGHEAPIPush := wantAPIURL != "" && curAPIURL != "" && curAPIURL != wantAPIURL
-	if !needClaimPush && !needURLPush && !needRepoRepair && !needGHEAPIPush && !needACMMPush {
+	// A pending FORGE SWITCH pushes on its own handshake. It cannot ride
+	// needGHEAPIPush: that gate is deliberately conservative about an empty
+	// curAPIURL (unknown, not a mismatch) and — more importantly — it can never
+	// deliver a switch TO public github.com, whose wantAPIURL is "" by
+	// definition. An operator moving a hive back to github.com must be able to,
+	// so the switch carries its own target and its own read-back.
+	forgeAPIURL := pendingForgeAPIURL(h, curAPIURL)
+	needForgePush := forgeAPIURL != ""
+	if !needClaimPush && !needURLPush && !needRepoRepair && !needGHEAPIPush && !needACMMPush && !needForgePush {
 		return nil // nothing left to push
 	}
 	// Sanitize before pushing. A repo pasted as a URL
@@ -5849,7 +5871,17 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 		// (hosted-open-source-osscar) is the working reference: a bare
 		// primary_repo plus github.api_url = https://<host>/api/v3. Empty host
 		// pushes nothing, so a github.com hive keeps the spoke's own default.
-		GitHubAPIURL: gheAPIURLForHost(h.GitHubHost),
+		// A pending forge switch wins: forgeAPIURL is the host the operator
+		// asked for and is only non-empty while that delivery is outstanding.
+		// Once the spoke reports the requested host, ForgeDelivered latches and
+		// this falls back to the ordinary host-derived value — which by then
+		// derives from the SAME host, so the two agree and nothing flaps.
+		GitHubAPIURL: func() string {
+			if forgeAPIURL != "" {
+				return forgeAPIURL
+			}
+			return gheAPIURLForHost(h.GitHubHost)
+		}(),
 		// AIAuthor is deliberately left empty here. Provisioning state never
 		// knows the agents' GitHub account — the spoke owns it — and the spoke
 		// treats an empty author as "leave mine alone". Setting it from this

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -339,14 +339,42 @@ type SaaSHive struct {
 	// meta. It is the level the hub delivers; ACMMLevel is the level currently
 	// in effect. Zero means "nothing was explicitly requested" — the ordinary
 	// case for admin-created and pre-existing hives — and delivers nothing.
-	RequestedACMMLevel int                    `json:"requested_acmm_level,omitempty"`
-	Error              string                 `json:"error,omitempty"`
-	AutoUpgrade        bool                   `json:"auto_upgrade"`
-	IsPublic           bool                   `json:"is_public"`
-	PendingRequests    []PendingAccessRequest `json:"pending_requests,omitempty"`
-	OCIFileSystemID    string                 `json:"oci_file_system_id,omitempty"`
-	OCIExportID        string                 `json:"oci_export_id,omitempty"`
-	ClusterID          string                 `json:"cluster_id,omitempty"`
+	RequestedACMMLevel int `json:"requested_acmm_level,omitempty"`
+
+	// RequestedGitHubHost / ForgeDelivered are the FORGE half of the same
+	// delivery handshake, added for the operator-facing forge switch
+	// (handleSwitchForge). They exist for exactly the reason ACMMDelivered
+	// does, and the reason is worth stating because it was verified the hard
+	// way on the live fleet.
+	//
+	// WHY A HUB-SIDE EDIT OF GitHubHost DOES NOT STICK
+	//
+	// github_host was edited to "github.ibm.com" in a live hive's meta.json and
+	// the hub restarted. Within one beat the registry was back to "github.com".
+	// handleHeartbeat records RegistryEntry.GitHubHost from the SPOKE's
+	// HeartbeatPayload.GitHubHost every beat, and the spoke derives that from
+	// its own config via GitHubConfig.HostLabel(). The hub's edit changed
+	// nothing the spoke reports, so the spoke simply re-reported the unchanged
+	// truth and the hub adopted it. This is the same adopt-stale-value class as
+	// the ACMM revert fixed in #2354.
+	//
+	// RequestedGitHubHost records what the operator asked for, so it survives
+	// the spoke reporting the old host, and ForgeDelivered latches true the
+	// moment the spoke reports the requested host back — after which the push
+	// stops for good and the spoke owns the value again. Both default to their
+	// zero values on every existing hive, so nothing is delivered to a hive
+	// nobody switched: the push is gated on a NON-EMPTY RequestedGitHubHost.
+	RequestedGitHubHost string `json:"requested_github_host,omitempty"`
+	// ForgeDelivered flips true once the spoke reports the requested forge host.
+	ForgeDelivered bool `json:"forge_delivered,omitempty"`
+
+	Error           string                 `json:"error,omitempty"`
+	AutoUpgrade     bool                   `json:"auto_upgrade"`
+	IsPublic        bool                   `json:"is_public"`
+	PendingRequests []PendingAccessRequest `json:"pending_requests,omitempty"`
+	OCIFileSystemID string                 `json:"oci_file_system_id,omitempty"`
+	OCIExportID     string                 `json:"oci_export_id,omitempty"`
+	ClusterID       string                 `json:"cluster_id,omitempty"`
 
 	// AutoUpgradeMode gates WHEN an enabled auto-upgrade may fire:
 	// AutoUpgradeModeInstant (or empty) upgrades as soon as the hive is seen

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1302,6 +1302,14 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	// an unclaimed placeholder, or sits on a non-GHE cluster.
 	s.repairGitHubHostForHive(payload.HiveID)
 
+	// Close the FORGE handshake before building the project config, so the beat
+	// on which the spoke first reports the requested host is also the beat the
+	// push stops. Ordering matters for the same reason it does above: doing this
+	// after projectConfigForHiveID would re-send an api_url that has already
+	// landed. No-op (and silent) for every hive with no outstanding switch,
+	// which is all of them until an operator runs one.
+	s.adoptSpokeForge(payload.HiveID, payload.GitHubHost)
+
 	// Retroactively mint the vanity host for a hive CLAIMED BEFORE the vanity
 	// feature existed, also BEFORE building the project config, so the URL-only
 	// push below delivers it on this very beat. VanityURL is otherwise written


### PR DESCRIPTION
> *"i need a way to switch people between github.ibm.com or github.com or any forge in the hub for a specific hive's listing. Enrico has github.com and he needs to be on github.ibm.com."*

There was **no API and no UI to change a hive's forge after provisioning**. `github_host` is written once, at provision/assign time (`saas.go:5097`), and no `HandleFunc` mentions it.

## Why a hub-side edit cannot work

`github_host` was edited to `github.ibm.com` in a live hive's `meta.json` and the hub restarted. **It did not stick** — the registry was back to `github.com` within one beat.

`handleHeartbeat` records `RegistryEntry.GitHubHost` from the **spoke's** `HeartbeatPayload.GitHubHost` on every beat, and the spoke derives that from its own config via `GitHubConfig.HostLabel()`. Nothing the hub writes to `meta.json` changes what the spoke *runs*, so the spoke simply re-reports the unchanged truth and the hub adopts it.

This is the adopt-stale-value class fixed for ACMM in #2354, and the fix has the same shape:

- **`RequestedGitHubHost`** records what the operator asked for, so it survives the spoke reporting the old host.
- **`ForgeDelivered`** latches true the moment the spoke reports the requested host back — after which the push stops **for good** and the spoke owns the value again. This is what avoids the #2061 failure mode where a forever-push made the value un-editable on the spoke.
- Both default to their zero values on every existing hive, and the push is gated on a **non-empty** `RequestedGitHubHost`, so the feature is inert for every hive nobody has switched. No migration.

## What actually travels

`HostLabel()` reads `base_url` and **falls back to `api_url`**, so pushing the API URL alone is sufficient to change what the spoke reports. `HeartbeatProjectConfig.GitHubAPIURL` is an existing, already-implemented channel on both ends — the spoke adopts it in `main.go` and persists to the PVC overlay. That is the channel this uses, which is why it works uniformly for the reachable (hive-oke) and firewalled/heartbeat-only (vllm-d) clusters alike.

**Switching back to public github.com needed explicit handling.** Everywhere else an empty `github_api_url` means "leave the spoke alone", and `gheAPIURLForHost("github.com")` is `""` by definition — so the naive implementation can move a hive *to* enterprise but never *back*. The public target is delivered as an explicit `https://api.github.com` instead of as emptiness. It also cannot ride the existing `needGHEAPIPush` gate, which is deliberately conservative about an empty `curAPIURL`; the switch carries its own target and its own read-back.

## App identity

Switching forge swaps the App, resolved **from `clusters.json` only** — `hive-oke` names its github.com App, `vllm-d` names its github.ibm.com App. **No App ID is hardcoded in Go.**

A cluster whose own forge does not match the target contributes **nothing** (app_id 0 = "say nothing"), which leaves the spoke's credentials untouched rather than pushing an App registered on the wrong forge.

**`installation_id` is never carried over.** An ID issued by one forge names nothing on another; pushing it would authenticate as a nonexistent installation and produce a 401/404 that reads as a key problem rather than a forge problem. It is either supplied in the request or left for installation auto-discovery — and when it is absent the response says so explicitly (`app_install_note`), so an operator cannot mistake it for a silent success.

Key material is deliberately **not** sent here: the per-cluster key reconcile (`cluster_app_key.go`) owns that and gates every key push on `HasKey()`, so duplicating it risked blanking a working key with an empty string.

## Authorization

`requireAuth` on the route plus an inner owner-or-admin check returning `only the owner can switch forges` 403 — the same shape as `handleSwitchBranch` and `handleToggleAutoUpgrade`.

## Forge validation, not arbitrary strings

`parseForgeTarget` resolves a validated `ForgeKind` + host, accepting a bare host or a pasted org URL (the likeliest operator input) and normalizing both to one canonical target. Ports, userinfo and paths are stripped; a malformed host is rejected naming what is supported. It deliberately does **not** use `githubHostLabel`, which maps `""` to `github.com` — that would turn a blank field into a silent switch to public GitHub, a destructive default for this endpoint.

GitLab/Gitea will be selected by an explicit kind rather than inferred from a host, since their API paths differ and a host alone cannot distinguish them.

## Tests

Six tests, including the live regression: **beat 1** pushes the enterprise API URL while the spoke reports the old host and refuses to latch on that stale report; **beat 2** completes delivery when the spoke confirms; then delivery is asserted **idempotent** — the push stops permanently and re-adopting is a no-op. Separately covered: the switch-back-to-public direction, "unknown is not a match" (a spoke too old to report the host must never complete a delivery — the silent-failure case), inertness for unswitched hives, and that the App ID comes from cluster config in both directions.

`go build ./...` clean; full `pkg/hub` suite passes with no regressions.

The embedded `dashboardHTML` block is **byte-identical to base** (md5 verified) — no JS was touched, and `<body>` count is unchanged at 3.

## Live systems

**Strictly read-only.** No hive, user record, cluster config or hub state was mutated. Enrico's hive has deliberately **not** been switched — operator steps are in the thread.