### PR TITLE
🐛 fix(agents): make agent deletion durable so deleted agents stay deleted

### DIFF
--- a/v2/pkg/config/agent_overlay.go
+++ b/v2/pkg/config/agent_overlay.go
@@ -48,14 +48,72 @@ func LoadAgentOverrides(dir string) (map[string]AgentConfig, error) {
 
 // MergeAgentOverrides merges overlay agents into the config's agent map.
 // Overlay agents override base config agents with the same name.
+//
+// Tombstoned agents (Config.RemovedAgents) are skipped AND evicted from the
+// base map. Both halves matter: skipping stops a stale
+// /data/agent-configs/<name>.yaml from resurrecting a deleted agent, and the
+// eviction stops the ConfigMap seed — which the dashboard cannot rewrite —
+// from doing the same. Before this, either source alone brought the agent
+// back on the very next config reload.
 func (c *Config) MergeAgentOverrides(overlays map[string]AgentConfig) {
 	if c.Agents == nil {
 		c.Agents = make(map[string]AgentConfig)
 	}
 	for name, agent := range overlays {
+		if c.IsAgentRemoved(name) {
+			continue
+		}
 		agent.Managed = true
 		c.Agents[name] = agent
 	}
+	c.PruneRemovedAgents()
+}
+
+// PruneRemovedAgents drops every tombstoned agent from the in-memory agent
+// map. Safe to call repeatedly; a no-op when nothing is tombstoned.
+func (c *Config) PruneRemovedAgents() {
+	for _, name := range c.RemovedAgents {
+		delete(c.Agents, name)
+	}
+}
+
+// IsAgentRemoved reports whether an operator deliberately deleted this agent.
+func (c *Config) IsAgentRemoved(name string) bool {
+	for _, removed := range c.RemovedAgents {
+		if removed == name {
+			return true
+		}
+	}
+	return false
+}
+
+// MarkAgentRemoved records a deliberate deletion so no later merge, reload, or
+// ACMM pack apply brings the agent back. Returns true when the tombstone was
+// newly added (a repeat delete of the same agent is a no-op).
+func (c *Config) MarkAgentRemoved(name string) bool {
+	if name == "" || c.IsAgentRemoved(name) {
+		return false
+	}
+	c.RemovedAgents = append(c.RemovedAgents, name)
+	return true
+}
+
+// ClearAgentRemoved lifts a tombstone. This is the operator explicitly
+// re-adding an agent they had previously deleted — the one unambiguous signal
+// that the deletion no longer reflects their intent. Returns true when a
+// tombstone was actually lifted.
+func (c *Config) ClearAgentRemoved(name string) bool {
+	kept := make([]string, 0, len(c.RemovedAgents))
+	for _, removed := range c.RemovedAgents {
+		if removed != name {
+			kept = append(kept, removed)
+		}
+	}
+	if len(kept) == len(c.RemovedAgents) {
+		return false
+	}
+	c.RemovedAgents = kept
+	return true
 }
 
 // SaveAgentFile writes a single agent config to dir/<name>.yaml.

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -42,6 +42,30 @@ type Config struct {
 	ACMMLevel     *int                   `yaml:"acmm_level,omitempty" json:"acmm_level"`
 	Variables     VariablesConfig        `yaml:"variables,omitempty"`
 
+	// RemovedAgents are agent names an operator deliberately deleted. It is a
+	// TOMBSTONE list, and it exists because deletion had no durable record
+	// anywhere: the delete handlers dropped the agent from the in-memory map
+	// and re-saved the overlay, but an agent lives in THREE places — the
+	// ConfigMap seed, /data/agent-configs/<name>.yaml, and the dashboard
+	// overlay — and Load() UNIONS all three via MergeAgentOverrides, which
+	// only ever adds. So the next config reload (fsnotify, observed ~36s after
+	// the delete on a live hive) re-materialized the agent, and even after
+	// that the next ApplyPack re-created it from the ACMM pack. That is the
+	// reported "I deleted brainstorm and guide and they always come back".
+	//
+	// A tombstone is scoped to the agent NAME and persists indefinitely,
+	// including across ACMM level changes. The alternative — clearing
+	// tombstones on a level change so a higher pack can reintroduce the agent
+	// — was rejected: an operator who deletes `guide` is expressing "I do not
+	// want this agent", not "I do not want it at this level", and silently
+	// resurrecting it during an unrelated level bump is the same class of
+	// silent revert as the bug itself. Re-adding the agent explicitly (the
+	// Governor grid's add, the agent CRUD create, or an import) clears the
+	// tombstone, which is the one unambiguous signal that the operator changed
+	// their mind. A genuinely NEW pack agent — one never deleted here — is
+	// unaffected and is still added on a level increase.
+	RemovedAgents []string `yaml:"removed_agents,omitempty" json:"removed_agents,omitempty"`
+
 	SourcePath string `yaml:"-" json:"-"`
 }
 
@@ -1741,6 +1765,10 @@ func LoadWithDashboardOverlay(path string) (*Config, error) {
 	if overlay.Project.Org == "" || len(overlay.Agents) == 0 {
 		return cfg, nil
 	}
+	// Tombstones live in the dashboard overlay because that is the only agent
+	// source the dashboard can write. Adopt them BEFORE merging so a deleted
+	// agent is neither re-merged from the overlay nor left behind by the seed.
+	cfg.RemovedAgents = overlay.RemovedAgents
 	// Overlay agents win — they carry the reconciled pack-behavior fields.
 	cfg.MergeAgentOverrides(overlay.Agents)
 	for name := range overlay.Agents {

--- a/v2/pkg/dashboard/agent_delete_tombstone_test.go
+++ b/v2/pkg/dashboard/agent_delete_tombstone_test.go
@@ -1,0 +1,231 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// bluefinLevel is the ACMM level of the hive that produced the report. Its
+// level-3 pack defines both agents the operator deleted.
+const bluefinLevel = 3
+
+// TestApplyPackDoesNotResurrectDeletedAgent is the regression test for the
+// reported bug: "I deleted brainstorm and guide agents and they always come
+// back". ApplyPack runs on every hive restart, and it re-created any pack
+// agent missing from the roster — so a deletion never survived a restart.
+func TestApplyPackDoesNotResurrectDeletedAgent(t *testing.T) {
+	srv := newFullServer(t)
+	if _, err := srv.ApplyPack(bluefinLevel); err != nil {
+		t.Fatalf("ApplyPack(%d): %v", bluefinLevel, err)
+	}
+	for _, name := range []string{"brainstorm", "guide"} {
+		if _, ok := srv.deps.Config.Agents[name]; !ok {
+			t.Fatalf("precondition: L%d pack should define %q", bluefinLevel, name)
+		}
+	}
+
+	// Operator deletes both, exactly as the audit log on the live hive shows.
+	for _, name := range []string{"guide", "brainstorm"} {
+		rec := doDelete(srv, "/api/config/governor/agents/"+name, nil)
+		if rec.Code != 200 {
+			t.Fatalf("delete %s: status %d", name, rec.Code)
+		}
+	}
+
+	// Restart. The pack is re-applied ("merging pack updates").
+	result, err := srv.ApplyPack(bluefinLevel)
+	if err != nil {
+		t.Fatalf("ApplyPack(%d) re-apply: %v", bluefinLevel, err)
+	}
+
+	for _, name := range []string{"brainstorm", "guide"} {
+		if _, ok := srv.deps.Config.Agents[name]; ok {
+			t.Errorf("deleted agent %q was re-created by ApplyPack", name)
+		}
+	}
+	if len(result.Tombstoned) != 2 {
+		t.Errorf("ApplyPack should report both deleted agents as tombstoned, got %v", result.Tombstoned)
+	}
+
+	// The user reported deleting them repeatedly. Four more restarts.
+	for i := 0; i < 4; i++ {
+		if _, err := srv.ApplyPack(bluefinLevel); err != nil {
+			t.Fatalf("ApplyPack restart %d: %v", i, err)
+		}
+	}
+	for _, name := range []string{"brainstorm", "guide"} {
+		if _, ok := srv.deps.Config.Agents[name]; ok {
+			t.Errorf("deleted agent %q came back after repeated restarts", name)
+		}
+	}
+}
+
+// TestMergeAgentOverridesSkipsTombstoned covers the FASTER of the two
+// resurrection paths, and the one that matches the user's "a minute or so
+// later": a leftover /data/agent-configs/<name>.yaml is re-merged by every
+// config reload, because MergeAgentOverrides only ever adds.
+func TestMergeAgentOverridesSkipsTombstoned(t *testing.T) {
+	cfg := &config.Config{
+		Agents:        map[string]config.AgentConfig{},
+		RemovedAgents: []string{"guide"},
+	}
+	cfg.MergeAgentOverrides(map[string]config.AgentConfig{
+		"guide":   {Model: "claude-sonnet-4-6"},
+		"scanner": {Model: "claude-sonnet-4-6"},
+	})
+	if _, ok := cfg.Agents["guide"]; ok {
+		t.Error("tombstoned agent was re-merged from its overlay file")
+	}
+	if _, ok := cfg.Agents["scanner"]; !ok {
+		t.Error("a non-deleted overlay agent must still merge")
+	}
+}
+
+// TestMergeAgentOverridesPrunesSeedAgent covers the OTHER source: the
+// ConfigMap seed, which the dashboard cannot rewrite. Skipping the overlay is
+// not enough on its own — a tombstoned agent already present in the base map
+// must be evicted too.
+func TestMergeAgentOverridesPrunesSeedAgent(t *testing.T) {
+	cfg := &config.Config{
+		Agents: map[string]config.AgentConfig{
+			"guide": {Model: "from-seed"},
+		},
+		RemovedAgents: []string{"guide"},
+	}
+	cfg.MergeAgentOverrides(nil)
+	if _, ok := cfg.Agents["guide"]; ok {
+		t.Error("tombstoned agent survived from the ConfigMap seed")
+	}
+}
+
+// TestTombstoneSurvivesACMMLevelChange pins the design decision: a tombstone is
+// scoped to the agent NAME and is NOT cleared by a level change. An operator
+// who deletes `guide` at L3 does not get it back by moving to L5.
+func TestTombstoneSurvivesACMMLevelChange(t *testing.T) {
+	srv := newFullServer(t)
+	if _, err := srv.ApplyPack(bluefinLevel); err != nil {
+		t.Fatalf("ApplyPack(%d): %v", bluefinLevel, err)
+	}
+	if rec := doDelete(srv, "/api/config/governor/agents/guide", nil); rec.Code != 200 {
+		t.Fatalf("delete guide: status %d", rec.Code)
+	}
+
+	const higherLevel = 5
+	if _, err := srv.ApplyPack(higherLevel); err != nil {
+		t.Fatalf("ApplyPack(%d): %v", higherLevel, err)
+	}
+	if _, ok := srv.deps.Config.Agents["guide"]; ok {
+		t.Error("a deleted agent must not return on an ACMM level increase")
+	}
+	// A genuinely NEW agent the higher pack introduces — one never deleted
+	// here — must still be added. Without this the tombstone would be
+	// indistinguishable from a broken level upgrade.
+	pack, err := config.ACMMPackByLevel(higherLevel)
+	if err != nil {
+		t.Fatalf("ACMMPackByLevel(%d): %v", higherLevel, err)
+	}
+	added := 0
+	for _, pa := range pack.Agents {
+		if pa.Name == "guide" {
+			continue
+		}
+		if _, ok := srv.deps.Config.Agents[pa.Name]; ok {
+			added++
+		}
+	}
+	if added == 0 {
+		t.Error("the level increase added no agents at all — tombstone over-applied")
+	}
+}
+
+// TestExplicitReAddLiftsTombstone: adding the agent back from the Governor grid
+// is the one unambiguous signal that the operator changed their mind.
+func TestExplicitReAddLiftsTombstone(t *testing.T) {
+	srv := newFullServer(t)
+	if _, err := srv.ApplyPack(bluefinLevel); err != nil {
+		t.Fatalf("ApplyPack(%d): %v", bluefinLevel, err)
+	}
+	if rec := doDelete(srv, "/api/config/governor/agents/guide", nil); rec.Code != 200 {
+		t.Fatalf("delete guide: status %d", rec.Code)
+	}
+	if !srv.deps.Config.IsAgentRemoved("guide") {
+		t.Fatal("precondition: guide should be tombstoned")
+	}
+
+	rec := doPost(srv, "/api/config/governor/agents", map[string]string{
+		"name":    "guide",
+		"backend": "copilot",
+	})
+	if rec.Code != 200 {
+		t.Fatalf("re-add guide: status %d body %s", rec.Code, rec.Body.String())
+	}
+	if srv.deps.Config.IsAgentRemoved("guide") {
+		t.Error("an explicit re-add must lift the tombstone")
+	}
+
+	// And the re-added agent must now survive a pack apply rather than being
+	// pruned straight back out.
+	if _, err := srv.ApplyPack(bluefinLevel); err != nil {
+		t.Fatalf("ApplyPack after re-add: %v", err)
+	}
+	if _, ok := srv.deps.Config.Agents["guide"]; !ok {
+		t.Error("re-added agent was pruned again")
+	}
+}
+
+// TestDeleteResponseNamesThePack covers legibility. Silently undoing the
+// operator's action a minute later is what turned this into a bug report; the
+// delete response now says up front that the agent belongs to an ACMM pack and
+// that the deletion has been recorded.
+func TestDeleteResponseNamesThePack(t *testing.T) {
+	srv := newFullServer(t)
+	if _, err := srv.ApplyPack(bluefinLevel); err != nil {
+		t.Fatalf("ApplyPack(%d): %v", bluefinLevel, err)
+	}
+
+	rec := doDelete(srv, "/api/config/governor/agents/guide", nil)
+	if rec.Code != 200 {
+		t.Fatalf("delete guide: status %d", rec.Code)
+	}
+	var resp struct {
+		OK         bool   `json:"ok"`
+		Tombstoned bool   `json:"tombstoned"`
+		Note       string `json:"note"`
+		PackLevels []int  `json:"packLevels"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode delete response: %v", err)
+	}
+	if !resp.OK || !resp.Tombstoned {
+		t.Errorf("delete response must report ok+tombstoned, got %+v", resp)
+	}
+	if resp.Note == "" {
+		t.Error("delete response must explain what happens next")
+	}
+	if len(resp.PackLevels) == 0 {
+		t.Error("guide is defined by ACMM packs; the response must say which levels")
+	}
+}
+
+// TestRepeatDeleteIsIdempotent: a second delete of the same name must not
+// append a duplicate tombstone.
+func TestRepeatDeleteIsIdempotent(t *testing.T) {
+	cfg := &config.Config{Agents: map[string]config.AgentConfig{}}
+	if !cfg.MarkAgentRemoved("guide") {
+		t.Fatal("first mark should report a new tombstone")
+	}
+	if cfg.MarkAgentRemoved("guide") {
+		t.Error("second mark should be a no-op")
+	}
+	if len(cfg.RemovedAgents) != 1 {
+		t.Errorf("expected 1 tombstone, got %v", cfg.RemovedAgents)
+	}
+	if !cfg.ClearAgentRemoved("guide") {
+		t.Error("clear should report a lifted tombstone")
+	}
+	if cfg.ClearAgentRemoved("guide") {
+		t.Error("clearing an absent tombstone should be a no-op")
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4525,6 +4525,12 @@ func (s *Server) handleGovernorAddAgent(w http.ResponseWriter, r *http.Request) 
 		Model:   body.Model,
 		Enabled: true,
 	}
+	// An explicit re-add is the operator changing their mind, and it is the
+	// only signal that lifts a deletion tombstone. Without this the agent
+	// would be added now and pruned again by the next config reload.
+	if s.deps.Config.ClearAgentRemoved(body.Name) {
+		s.logger.Info("agent deletion tombstone lifted by explicit re-add", "agent", body.Name)
+	}
 	s.deps.Config.Agents[body.Name] = agentCfg
 	s.deps.AgentMgr.AddAgent(body.Name, agentCfg)
 	if err := s.saveConfig(); err != nil {
@@ -4545,12 +4551,85 @@ func (s *Server) handleGovernorRemoveAgent(w http.ResponseWriter, r *http.Reques
 
 	delete(s.deps.Config.Agents, name)
 	s.deps.AgentMgr.RemoveAgent(name)
+
+	// Tombstone the name BEFORE saving. Deleting from the in-memory map and
+	// re-saving the overlay was all this handler used to do, and it did not
+	// stick for two independent reasons:
+	//
+	//  1. /data/agent-configs/<name>.yaml was left on disk, and Load()'s
+	//     MergeAgentOverrides UNIONS that directory over the config — so the
+	//     next config reload (fsnotify; measured at ~36s after the delete on a
+	//     live hive) re-materialized the agent. That is the reported
+	//     "readded themselves a minute or so later".
+	//  2. Even with the file gone, ApplyPack — which runs on every restart —
+	//     re-created any pack agent missing from the roster.
+	//
+	// The tombstone closes both: MergeAgentOverrides skips and prunes it, and
+	// ApplyPack refuses to re-create it.
+	s.deps.Config.MarkAgentRemoved(name)
+	s.removeAgentOverlayFile(name)
+
 	if err := s.saveConfig(); err != nil {
 		s.logger.Error("failed to persist config after agent removal", "error", err)
 	}
 	s.auditFromRequest(r, "remove_agent", "", name)
 	s.refreshAndPersist()
-	okResponse(w, map[string]string{"status": "removed", "agent": name})
+	s.logger.Info("agent removed and tombstoned", "agent", name,
+		"note", "will not be re-created by an ACMM pack apply until explicitly re-added")
+	jsonResponse(w, agentDeletionResponse("removed", name, packLevelsDefining(name)))
+}
+
+// removeAgentOverlayFile deletes /data/agent-configs/<name>.yaml. A leftover
+// overlay file is re-merged by every config load, which is one of the two ways
+// a deleted agent used to come back.
+func (s *Server) removeAgentOverlayFile(name string) {
+	agentsDir := s.deps.Config.Data.AgentsDir
+	if agentsDir == "" {
+		return
+	}
+	if err := config.RemoveAgentFile(agentsDir, name); err != nil {
+		// Not fatal: the tombstone already prevents the merge from
+		// resurrecting the agent. Log it so a stale file is still visible.
+		s.logger.Error("failed to remove agent overlay file after delete (tombstone still applies)",
+			"agent", name, "error", err)
+	}
+}
+
+// packLevelsDefining returns the ACMM levels whose pack defines this agent, so
+// the delete response can tell the operator up front that the level's pack
+// would otherwise have re-added it. Legibility is the point: silently undoing
+// the operator's action a minute later is what turned this into a bug report
+// instead of a question.
+func packLevelsDefining(name string) []int {
+	var levels []int
+	for _, pack := range config.ACMMPacks() {
+		for _, pa := range pack.Agents {
+			if pa.Name == name {
+				levels = append(levels, pack.Level)
+				break
+			}
+		}
+	}
+	return levels
+}
+
+// agentDeletionResponse builds the delete response, including an explicit
+// human-readable note when the agent is part of an ACMM pack.
+func agentDeletionResponse(status, name string, packLevels []int) map[string]any {
+	resp := map[string]any{"ok": true, "status": status, "agent": name, "tombstoned": true}
+	if len(packLevels) == 0 {
+		resp["note"] = "This agent is not part of any ACMM pack; it will stay deleted."
+		return resp
+	}
+	parts := make([]string, 0, len(packLevels))
+	for _, level := range packLevels {
+		parts = append(parts, strconv.Itoa(level))
+	}
+	resp["packLevels"] = packLevels
+	resp["note"] = fmt.Sprintf(
+		"%s is defined by the ACMM pack for level %s. It has been recorded as deliberately deleted, so no restart or level change will bring it back. Re-add it from the Governor grid if you change your mind.",
+		name, strings.Join(parts, ", "))
+	return resp
 }
 
 func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/api_agents.go
+++ b/v2/pkg/dashboard/api_agents.go
@@ -98,6 +98,11 @@ func (s *Server) handleAgentCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Creating an agent under a previously-deleted name is an explicit
+	// re-add — lift the tombstone, or the next config reload prunes it again.
+	if s.deps.Config.ClearAgentRemoved(body.Name) {
+		s.logger.Info("agent deletion tombstone lifted by explicit create", "agent", body.Name)
+	}
 	s.deps.Config.Agents[body.Name] = body.Agent
 	s.deps.Config.ApplyAgentDefaults(body.Name)
 
@@ -136,11 +141,21 @@ func (s *Server) handleAgentDelete(w http.ResponseWriter, r *http.Request) {
 	s.deps.AgentMgr.RemoveAgent(name)
 	delete(s.deps.Config.Agents, name)
 
+	// Record the deletion durably. Removing the overlay file above is not
+	// enough on its own: ApplyPack runs on every restart and re-creates any
+	// pack agent missing from the roster, so a pack agent deleted here came
+	// straight back. See handleGovernorRemoveAgent for the full chain.
+	s.deps.Config.MarkAgentRemoved(name)
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist agent tombstone", "agent", name, "error", err)
+	}
+
 	s.reInitSubsystems()
 	s.refreshAndPersist()
 
-	s.logger.Info("agent deleted via API", "name", name)
-	okResponse(w, map[string]string{"status": "deleted", "agent": name})
+	s.logger.Info("agent deleted via API and tombstoned", "name", name,
+		"note", "will not be re-created by an ACMM pack apply until explicitly re-added")
+	jsonResponse(w, agentDeletionResponse("deleted", name, packLevelsDefining(name)))
 }
 
 // agentDefinition is the portable YAML format for importing/exporting agents.
@@ -335,6 +350,11 @@ func (s *Server) handleAgentImport(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Importing an agent under a previously-deleted name is an explicit
+	// re-add — lift the tombstone so the import is not pruned on reload.
+	if s.deps.Config.ClearAgentRemoved(name) {
+		s.logger.Info("agent deletion tombstone lifted by import", "agent", name)
+	}
 	s.deps.Config.Agents[name] = agentCfg
 	s.deps.Config.ApplyAgentDefaults(name)
 

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -48,6 +48,10 @@ type ApplyPackResult struct {
 	Skipped []string `json:"skipped"`
 	Paused  []string `json:"paused"`
 	Resumed []string `json:"resumed"`
+	// Tombstoned lists pack agents deliberately deleted by the operator and
+	// therefore NOT re-created. Surfaced so an under-full roster reads as an
+	// honored choice rather than an apply that quietly dropped agents.
+	Tombstoned []string `json:"tombstoned,omitempty"`
 }
 
 // ApplyPack applies the ACMM pack for the given level. It creates agents,
@@ -76,7 +80,19 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 	// are fixing. We reconcile every agent we can, then surface a combined
 	// error so the caller does NOT record the level as cleanly applied.
 	var createErrs []string
+	// tombstoned collects pack agents skipped because the operator deleted
+	// them. Reported back so the caller (and the apply-pack response) can say
+	// so out loud instead of silently under-delivering the level's roster.
+	var tombstoned []string
 	for _, pa := range pack.Agents {
+		// A deliberately deleted agent is NOT re-created, at any level. The
+		// pack listing it is exactly why deletion did not stick: ApplyPack
+		// runs on every restart, so the pack re-added `brainstorm`/`guide` to
+		// a hive whose operator had removed them, four times over.
+		if s.deps.Config.IsAgentRemoved(pa.Name) {
+			tombstoned = append(tombstoned, pa.Name)
+			continue
+		}
 		if existing, exists := s.deps.Config.Agents[pa.Name]; exists {
 			changed := false
 
@@ -275,15 +291,23 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 
 	s.persistOnly()
 	go s.refreshAsync()
-	s.logger.Info("ACMM pack applied", "level", level, "name", pack.Name, "created", len(created), "updated", len(updated), "skipped", len(skipped), "paused", len(paused), "resumed", len(resumed))
+	s.logger.Info("ACMM pack applied", "level", level, "name", pack.Name, "created", len(created), "updated", len(updated), "skipped", len(skipped), "paused", len(paused), "resumed", len(resumed), "tombstoned", len(tombstoned))
+	if len(tombstoned) > 0 {
+		// Say it plainly in the log too: an operator reading "this level has 6
+		// agents but I see 4" needs the reason, not a silent gap.
+		s.logger.Info("ACMM pack: agents NOT re-created because the operator deleted them",
+			"agents", strings.Join(tombstoned, ", "),
+			"hint", "re-add the agent from the Governor grid to undo the deletion")
+	}
 
 	result := &ApplyPackResult{
-		Name:    pack.Name,
-		Created: created,
-		Updated: updated,
-		Skipped: skipped,
-		Paused:  paused,
-		Resumed: resumed,
+		Name:       pack.Name,
+		Created:    created,
+		Updated:    updated,
+		Skipped:    skipped,
+		Paused:     paused,
+		Resumed:    resumed,
+		Tombstoned: tombstoned,
 	}
 	if len(createErrs) > 0 {
 		// Return the result alongside the error so callers can still see what
@@ -322,6 +346,8 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 		"skipped": result.Skipped,
 		"paused":  result.Paused,
 		"resumed": result.Resumed,
+		// Empty unless the operator deleted one of this level's agents.
+		"tombstoned": result.Tombstoned,
 	})
 }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -16330,12 +16330,25 @@ function burnAreaChart() {
         .catch(err => showToast(`Failed: ${err.message}`, 'error'));
     }
 
+    // _packAgentNote returns an extra confirm-dialog line when the agent is part
+    // of the active ACMM pack. Deleting a pack agent used to look like it had
+    // silently failed — the pack re-added it on the next config reload — so the
+    // dialog now states up front that the deletion is recorded and permanent.
+    function _packAgentNote(name) {
+      const packAgents = (window._lastStatus && window._lastStatus.acmmPackAgents) || [];
+      if (!packAgents.includes(name)) return '';
+      return `\n\n"${name}" is part of this hive's ACMM pack. The deletion will be recorded, so no restart or ACMM level change will bring it back. Add it again from the Agents tab if you change your mind.`;
+    }
+
     async function deleteAgentFromConfig(name) {
-      if (!(await hiveConfirm(`Delete agent "${name}"?\n\nThis will remove its env file, governor config, and sidebar entry. The tmux session (if running) will NOT be killed.`))) return;
+      if (!(await hiveConfirm(`Delete agent "${name}"?\n\nThis will remove its env file, governor config, and sidebar entry. The tmux session (if running) will NOT be killed.${_packAgentNote(name)}`))) return;
       fetch(`/api/config/governor/agents/${name}`, { method: 'DELETE' })
         .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
-        .then(() => {
-          showToast(`Agent "${name}" deleted`, 'success');
+        .then(d => {
+          // Say out loud when the agent belongs to an ACMM pack. The pack used
+          // to re-add it on the next reload/restart with no explanation, which
+          // is why this was reported as a bug rather than asked about.
+          showToast(((d || {}).note) || `Agent "${name}" deleted`, 'success');
           closeConfigDialog();
           // Remove from cached agents so cards disappear immediately
           window._lastAgents = (window._lastAgents || []).filter(a => a.name !== name);
@@ -16353,11 +16366,11 @@ function burnAreaChart() {
     }
 
     async function removeAgent(name) {
-      if (!(await hiveConfirm(`Remove agent "${name}"? This will delete its configuration.`))) return;
+      if (!(await hiveConfirm(`Remove agent "${name}"? This will delete its configuration.${_packAgentNote(name)}`))) return;
       fetch(`/api/config/governor/agents/${name}`, { method: 'DELETE' })
         .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
-        .then(() => {
-          showToast(`Agent "${name}" removed`, 'success');
+        .then(d => {
+          showToast(((d || {}).note) || `Agent "${name}" removed`, 'success');
           _configState.data.agents = (_configState.data.agents || []).filter(a => a !== name);
           renderConfigTab('Agents');
         })


### PR DESCRIPTION
## Problem (Bluefin / jOrge)

> "I deleted brainstorm and guide agents and they always come back"
> "readded themselves a minute or so later"

## Root cause — reproduced live, and it is NOT a restart

The one-minute timing is the tell. This is a **config reload**, not a pod restart.

The live Bluefin hive's own logs, from today:

```
12:01:34  audit: agent removed  name=guide
12:01:37  audit: agent removed  name=brainstorm
12:02:10  config reloaded from file  path=/etc/hive/hive.yaml
```

**36 seconds.** The pod did not restart (it was already 6 minutes old at the delete and never bounced). Its `audit.jsonl` shows this loop running since 2026-07-28 — 13 `remove_agent` entries for these two names, the last pair by `castrojo` at 16:01Z today.

An agent lives in **three** places: the ConfigMap seed, `/data/agent-configs/<name>.yaml`, and the dashboard overlay. `Load()` **unions** all three via `MergeAgentOverrides`, which only ever *adds*. The delete handlers dropped the agent from the in-memory map and re-saved the overlay, but `handleGovernorRemoveAgent` — the endpoint the grid actually calls — never removed the per-agent overlay file. So the next reload re-materialized it.

`ApplyPack` was the *second*, slower path: it re-created any pack agent missing from the roster, on every restart. Bluefin is L3 and `packs/level-3.yaml` defines both `brainstorm` and `guide`. Even a delete that survived the reload would not have survived the next boot.

### Live reproduction

On the unassigned placeholder `hosted-available-oke-08-placeholder-xf07`, against the current production build:

```
DELETE /api/config/governor/agents/brainstorm  → {"ok":true,"status":"removed"}
/data/agent-configs/brainstorm.yaml            → still on disk
GET /api/agents                                → brainstorm absent
(config reload fires)
GET /api/agents                                → brainstorm BACK
```

The delete reports success and is undone seconds later. The placeholder was restored to its original state afterwards; Bluefin was only ever read.

### Every `ApplyPack` call site

| Site | Trigger |
|---|---|
| `v2/cmd/hive/main.go:1725` | first start only (`saved == nil`) |
| `v2/cmd/hive/main.go:1762` | every restart ("merging pack updates") |
| `v2/pkg/dashboard/api_packs.go:308` | `POST /api/packs/{level}/apply` |
| `v2/pkg/dashboard/api_packs.go:374` | `PUT /api/packs/level` |

No periodic or governor-driven call site exists. The hub's heartbeat writes `cfg.ACMMLevel` but never calls `ApplyPack`. So `ApplyPack` alone cannot explain the one-minute return — the reload does.

## Fix

`Config.RemovedAgents` (`removed_agents`), a tombstone list persisted in the dashboard overlay:

- `MergeAgentOverrides` **skips** tombstoned overlay agents **and prunes** them from the base map. Both halves are needed: skipping stops the stale `agent-configs` file, pruning stops the ConfigMap seed, which the dashboard cannot rewrite.
- `ApplyPack` will not re-create a tombstoned agent, and reports them in a new `tombstoned` field so an under-full roster reads as an honored choice rather than a silent drop.
- Both delete handlers mark the tombstone; `handleGovernorRemoveAgent` now also removes the leftover overlay file.
- An **explicit re-add** — grid add, agent create, or import — lifts the tombstone. That is the one unambiguous signal the operator changed their mind.

### ACMM level-change decision

**A tombstone is scoped to the agent name and survives a level change.** Delete `guide` at L3, move to L5, and `guide` stays gone.

An operator who deletes an agent is saying "I don't want this agent", not "not at this level". Resurrecting it during an unrelated level bump would be the same class of silent revert as the bug itself. Genuinely new pack agents are unaffected — `TestTombstoneSurvivesACMMLevelChange` asserts the L5 pack still adds its other agents, so the tombstone cannot be confused with a broken upgrade.

## Legibility

Silently reverting a user action four times is what made this a bug report instead of a question.

- The confirm dialog now warns **before** the click that the agent is part of the ACMM pack and that the deletion is permanent.
- The delete response carries a `note` naming the pack levels that define the agent; the toast shows it.
- `ApplyPack` logs skipped agents by name with the reason and how to undo it.

## Relationship to #2340

#2340 (merged today, same user) fixed model/method **values** reverting via `ModelIsOperatorOwned` / `FieldOwnerPack`. It did not cover agent **existence** — `ApplyPack` still unconditionally re-created missing pack agents, and the reload path was untouched. This extends that ownership model to the roster rather than inventing a parallel mechanism, and does not alter any of #2340's field-ownership logic.

## Tests

`pkg/dashboard/agent_delete_tombstone_test.go`:

- `TestApplyPackDoesNotResurrectDeletedAgent` — delete both reported agents, then survive five pack re-applies.
- `TestMergeAgentOverridesSkipsTombstoned` — the fast path, the leftover overlay file.
- `TestMergeAgentOverridesPrunesSeedAgent` — the ConfigMap seed.
- `TestTombstoneSurvivesACMMLevelChange` — pins the L3→L5 decision, and that other agents still arrive.
- `TestExplicitReAddLiftsTombstone` — re-added agents are not pruned back out.
- `TestDeleteResponseNamesThePack` — legibility.
- `TestRepeatDeleteIsIdempotent` — no duplicate tombstones.

Mutation-verified non-vacuous. Disabling the `ApplyPack` guard fails `TestApplyPackDoesNotResurrectDeletedAgent` with `deleted agent "brainstorm" was re-created by ApplyPack`; removing the merge guard fails both merge tests. Restored after each.

`pkg/config` passes clean. The `TestCovV1_*` / `TestCovDF_*` / `TestHandleGHUserAuth*` failures in `pkg/dashboard` reproduce identically on unmodified `v2` and are unrelated.

Embedded JS verified: extracted the modified region, `node --check` passes, and brace/paren/backtick deltas against base are balanced (+6/+6, +8/+8, +2).
