### PR TITLE
✨ feat(hub): send Slack messages to a user, a hive's owner, or all users

### DIFF
--- a/docs/HUB_DISASTER_RECOVERY.md
+++ b/docs/HUB_DISASTER_RECOVERY.md
@@ -55,13 +55,22 @@ Four Kubernetes Secrets live **outside** the hub PVC and are required:
 
 | Secret | Without it |
 |---|---|
-| `hive-hub-secrets` | OAuth login broken for all users |
+| `hive-hub-secrets` | OAuth login broken for all users; Slack messaging disabled |
 | `oci-api-key` | Hub cannot provision spoke storage or write backups |
 | `hive-hub-kubeconfigs` | Hub cannot reach remote spoke clusters (vllm-d) |
 | `hive-hub-tls` | Cert-manager reissues automatically (not fatal) |
 
 `hive-backup` captures these automatically and **fails the backup** if any of
 the first three is missing.
+
+> **Adding a new hub credential?** Put it in the **existing `hive-hub-secrets`**
+> Secret rather than creating a new one. That Secret is already in
+> `hubbackup.DefaultHubSecrets`, so a key added to it is captured — and restored
+> — for free. A brand-new Secret is **silently lost in a restore** unless it is
+> also added to `DefaultHubSecrets`.
+>
+> This is why the Slack bot token (`HIVE_HUB_SLACK_BOT_TOKEN`, see
+> [Slack messaging](#slack-messaging)) is a key on `hive-hub-secrets`.
 
 ---
 
@@ -477,3 +486,82 @@ ownership to match the surrounding directories rather than loosening the mode.
   only against temporary directories in tests.
 - Browser download of a multi-MB archive was not exercised end-to-end in a
   real browser.
+
+---
+
+## Slack messaging
+
+The hub can send Slack DMs to a single user, to the owner of a hive, or to every
+user. Recipients are resolved from the **existing** `slack_id` contact field on
+each user record (`/data/saas/users/<GitHubUsername>.json`), which admins edit
+from the Users panel.
+
+### Credential
+
+The bot token is read from the environment with **no default**:
+
+| Variable | Source |
+|---|---|
+| `HIVE_HUB_SLACK_BOT_TOKEN` | key on the existing `hive-hub-secrets` Secret |
+
+It is deliberately a key on `hive-hub-secrets` rather than a new Secret, so it is
+already inside the DR-captured set (`hubbackup.DefaultHubSecrets`) and survives a
+restore. **The token must never be committed to this repository** — a previous
+leak required scrubbing the git history.
+
+Add it without disturbing the other keys:
+
+```bash
+kubectl -n <hub-namespace> patch secret hive-hub-secrets \
+  --type merge \
+  -p "{\"stringData\":{\"slack-bot-token\":\"$SLACK_BOT_TOKEN\"}}"
+```
+
+...and reference it from the hub Deployment:
+
+```yaml
+- name: HIVE_HUB_SLACK_BOT_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: hive-hub-secrets
+      key: slack-bot-token
+      optional: true   # unset simply disables Slack messaging
+```
+
+The token needs the `chat:write` scope. A webhook will **not** work: a webhook is
+bound to one channel at creation time and cannot DM a user.
+
+If the variable is unset, the send endpoints return **503** naming the variable.
+They never report a successful send that did not happen.
+
+### Endpoints
+
+| Endpoint | Auth | Notes |
+|---|---|---|
+| `POST /api/saas/slack/user/{username}` | admin, or the user themselves | |
+| `POST /api/saas/hives/{id}/slack` | hive owner or admin | messages the hive's owner |
+| `POST /api/saas/admin/slack/broadcast` | **admin only** | requires confirmation |
+
+Body: `{"message": "...", "dry_run": false, "confirm": "..."}`.
+
+### Broadcast safety
+
+Broadcast reaches every user with a `slack_id` and cannot be recalled, so:
+
+1. **Dry-run first.** `{"dry_run": true}` sends nothing and returns the recipient
+   count, the **names** of users who will be skipped, a message preview, and an
+   estimated duration.
+2. **Confirm explicitly.** A real broadcast requires `"confirm": "SEND TO ALL
+   USERS"` — a typed string, not a boolean, so no client can set it by accident.
+   Without it the request returns **409** and reports the blast radius.
+3. **Sending is paced and backgrounded.** Slack throttles `chat.postMessage` at
+   roughly 1/sec, so sends are spaced one second apart and run in a goroutine;
+   ~88 users takes about a minute and a half. The HTTP response returns
+   immediately with the estimate.
+
+### Users without a Slack ID are skipped VISIBLY
+
+A user with no `slack_id` cannot be reached. Every response reports how many were
+skipped **and names them**, and the full skipped list is written to the hub log on
+a broadcast. Silent drops are not acceptable: "sent to 61" while 27 people never
+heard anything is worse than a clear failure.

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -240,6 +240,14 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("DELETE /api/saas/admin/hub-banner", s.requireAdmin(s.handleClearHubBanner))
 	s.mux.HandleFunc("GET /api/saas/admin/hub-banner", s.requireAdmin(s.handleGetHubBanner))
 	s.registerBulkRoutes()
+	// Slack messaging. The single-user and hive-owner routes are admin-or-owner
+	// (checked inside each handler, like switch-branch); the BROADCAST is
+	// admin-only, because it reaches every user with a slack_id and cannot be
+	// recalled. It additionally requires a typed confirmation and offers a dry
+	// run — see slack.go.
+	s.mux.HandleFunc("POST /api/saas/slack/user/{username}", s.requireAuth(s.handleSlackMessageUser))
+	s.mux.HandleFunc("POST /api/saas/hives/{id}/slack", s.requireAuth(s.handleSlackMessageHiveOwner))
+	s.mux.HandleFunc("POST /api/saas/admin/slack/broadcast", s.requireAdmin(s.handleSlackBroadcast))
 	s.mux.HandleFunc("POST /api/saas/admin/journey-snooze", s.requireAdmin(s.handleJourneySnooze))
 	s.mux.HandleFunc("GET /api/saas/admin/journey-status", s.requireAdmin(s.handleJourneyStatus))
 

--- a/v2/pkg/hub/slack.go
+++ b/v2/pkg/hub/slack.go
@@ -1,0 +1,548 @@
+package hub
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ============================================================================
+// SLACK MESSAGING
+// ============================================================================
+//
+// Operator-initiated Slack messages to hub users: one user, the owner of a
+// hive, or every user.
+//
+// The practical driver is that today these messages are hand-copied. The GitHub
+// App permission notice (#2353) and the node-capacity problem (#2349) were both
+// pasted one org owner at a time, out of the hub's own user list, which already
+// carries the Slack IDs.
+//
+// REUSES THE EXISTING slack_id FIELD. SaaSUser.SlackID is already there — an
+// admin-maintained CRM contact field with a length cap (maxContactSlackIDLen),
+// an edit path (handleAdminUpdateUser), and a rendered dashboard input. Adding a
+// second "slack_handle" field would have split the same fact across two keys on
+// ~88 user records with nothing to keep them in step. Nothing about the user
+// record changes in this PR.
+
+const (
+	// slackPostMessageURL is Slack's chat.postMessage endpoint. A bot token
+	// posting here can DM a user by member ID, which a webhook cannot do — a
+	// webhook is bound to one channel at creation time.
+	slackPostMessageURL = "https://slack.com/api/chat.postMessage"
+
+	// slackTokenEnvVar names the environment variable holding the Slack bot
+	// token (xoxb-...). It is read with NO DEFAULT: an unset variable disables
+	// Slack messaging entirely rather than falling back to anything. The token
+	// must never appear in this repository — a previous leak required scrubbing
+	// this repo's git history, and that must not be recreated.
+	//
+	// Sourced from the EXISTING "hive-hub-secrets" Kubernetes Secret, which is
+	// already captured by the DR backup (hubbackup.DefaultHubSecrets, #2315).
+	// Putting the token there rather than in a new Secret is what keeps it in
+	// the restorable set without touching the backup's collected-secret list —
+	// a new Secret would be silently lost in a restore.
+	slackTokenEnvVar = "HIVE_HUB_SLACK_BOT_TOKEN"
+
+	// slackHTTPTimeout bounds a single chat.postMessage call. Slack's API is
+	// normally sub-second; this is generous enough to ride out a slow response
+	// without letting one recipient stall a broadcast.
+	slackHTTPTimeout = 10 * time.Second
+
+	// slackSendInterval paces sending. Slack rate-limits chat.postMessage at
+	// roughly one message per second per workspace (its "Tier"/special limit for
+	// this method), and bursting past it earns HTTP 429s that drop messages.
+	// One second between sends is the documented sustainable rate.
+	slackSendInterval = 1 * time.Second
+
+	// slackMaxMessageLen bounds an operator-supplied message body. Slack itself
+	// truncates around 40000 characters; this is the last point before the text
+	// leaves the hub, and it stops a pasted blob becoming 88 enormous requests.
+	slackMaxMessageLen = 4000
+
+	// slackMaxBodyBytes bounds the request body for the send endpoints. The
+	// message is the only large field, so this is slackMaxMessageLen plus room
+	// for the surrounding JSON and the target fields.
+	slackMaxBodyBytes = 16 * 1024
+
+	// slackPreviewLen is how much of the message a dry run echoes back. Enough
+	// to confirm the right text is about to go out without reproducing a long
+	// body in a JSON response and a log line.
+	slackPreviewLen = 280
+
+	// slackBroadcastConfirm is the exact value a broadcast request must send in
+	// its `confirm` field. Broadcast is the one irreversible action here — it
+	// reaches every user with a Slack ID and cannot be recalled — so it requires
+	// a deliberate, typed acknowledgement rather than a boolean an errant client
+	// could set by accident.
+	slackBroadcastConfirm = "SEND TO ALL USERS"
+)
+
+// SlackRecipient is one resolved target of a send.
+type SlackRecipient struct {
+	// Username is the GitHub username (the hub's user key).
+	Username string `json:"username"`
+	// SlackID is the user's Slack member ID or handle. Empty means this user
+	// CANNOT be reached — see Skipped on slackSendResult.
+	SlackID string `json:"slack_id,omitempty"`
+}
+
+// Reachable reports whether this user has somewhere to send to.
+func (r SlackRecipient) Reachable() bool { return strings.TrimSpace(r.SlackID) != "" }
+
+// slackSendResult is the operator-facing outcome of a send or dry run.
+//
+// Skipped and SkippedUsers are NOT optional detail. A user with no slack_id is
+// silently unreachable, and reporting only "sent to 61" while 27 people never
+// heard anything is exactly the silent drop this must not do. The count AND the
+// names are returned, and logged.
+type slackSendResult struct {
+	Status string `json:"status"`
+	Target string `json:"target"`
+	// DryRun is true when nothing was sent.
+	DryRun bool `json:"dry_run"`
+	// Recipients is how many users will actually be messaged.
+	Recipients int `json:"recipients"`
+	// Skipped is how many matched users have no slack_id and were skipped.
+	Skipped int `json:"skipped"`
+	// SkippedUsers names them. Capped in the response, never in the log.
+	SkippedUsers []string `json:"skipped_users,omitempty"`
+	// Preview is the leading slackPreviewLen characters of the message.
+	Preview string `json:"preview,omitempty"`
+	// EstimatedSeconds is roughly how long a paced broadcast will take, so an
+	// operator is not surprised that a send to ~88 users is still going a minute
+	// and a half later.
+	EstimatedSeconds int `json:"estimated_seconds,omitempty"`
+	// Note carries any operator-facing caveat (e.g. the confirmation
+	// requirement) without needing an error status.
+	Note string `json:"note,omitempty"`
+}
+
+// maxSkippedUsersReported caps how many skipped usernames the JSON response
+// lists. The full set always reaches the log; this only stops one response
+// growing without bound as the fleet grows.
+const maxSkippedUsersReported = 50
+
+// ============================================================================
+// SENDING
+// ============================================================================
+
+// slackClient is the shared HTTP client for Slack calls. One client (and so one
+// connection pool) rather than one per send, which matters for a paced
+// broadcast making ~88 sequential calls.
+var slackClient = &http.Client{Timeout: slackHTTPTimeout}
+
+// sendSlackDM posts one message to one Slack user via chat.postMessage.
+//
+// Slack answers 200 OK with {"ok": false, "error": "..."} for application-level
+// failures — an invalid user, a missing scope, a revoked token. Checking only
+// the HTTP status would report every one of those as a successful send, so the
+// body is decoded and ok is checked. The token is never logged; the returned
+// error carries only Slack's error code.
+func sendSlackDM(token, slackID, message string) error {
+	payload, err := json.Marshal(map[string]string{
+		"channel": slackID,
+		"text":    message,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal slack payload: %w", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, slackPostMessageURL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("build slack request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := slackClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("slack request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		// Surfaced explicitly rather than folded into a generic status error:
+		// a 429 means the pacing is wrong, which is a different fix from a bad
+		// token or a bad user ID.
+		return fmt.Errorf("slack rate limited (HTTP 429) — sends are being paced faster than slack allows")
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("slack returned HTTP %d", resp.StatusCode)
+	}
+	var body struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return fmt.Errorf("decode slack response: %w", err)
+	}
+	if !body.OK {
+		return fmt.Errorf("slack rejected the message: %s", body.Error)
+	}
+	return nil
+}
+
+// slackBroadcastMu serializes background sends. Two concurrent broadcasts would
+// each pace themselves correctly and still collectively exceed Slack's limit,
+// so only one runs at a time.
+var slackBroadcastMu sync.Mutex
+
+// deliverSlackMessages sends to every recipient, paced at slackSendInterval.
+//
+// It runs in a GOROUTINE, never inline in the HTTP handler: at one message per
+// second a broadcast to ~88 users takes about a minute and a half, which would
+// hold a request open long past any sane proxy timeout and leave the operator
+// staring at a hung page.
+//
+// Every failure is logged per-recipient with the username and Slack's own error
+// string. A send that partly fails must be visible in the log, since the HTTP
+// response was returned long before.
+func (s *HubServer) deliverSlackMessages(token, target, message string, recipients []SlackRecipient, actor string) {
+	slackBroadcastMu.Lock()
+	defer slackBroadcastMu.Unlock()
+
+	sent, failed := 0, 0
+	// A nil slice ranges as empty in Go, so this is a no-op rather than a panic
+	// on a background goroutine where nothing would catch it.
+	for i, rcpt := range recipients {
+		if i > 0 {
+			// Pace BETWEEN sends, not before the first — a single-user message
+			// should not sit idle for a second before going out.
+			time.Sleep(slackSendInterval)
+		}
+		if err := sendSlackDM(token, rcpt.SlackID, message); err != nil {
+			failed++
+			// The Slack ID is logged (it is not a secret and it is what an
+			// operator needs to fix a bad entry); the token and the message body
+			// are not.
+			s.logger.Warn("slack message failed",
+				"target", target, "user", rcpt.Username, "slack_id", rcpt.SlackID, "error", err)
+			continue
+		}
+		sent++
+	}
+	s.logger.Info("audit: slack messages delivered",
+		"target", target, "actor", actor, "sent", sent, "failed", failed, "total", len(recipients))
+}
+
+// ============================================================================
+// RECIPIENT RESOLUTION
+// ============================================================================
+
+// resolveSlackRecipients partitions a set of users into those that can be
+// reached and those that cannot, preserving the skipped usernames.
+//
+// Skipping is never silent: the caller reports both the count and the names.
+func resolveSlackRecipients(users []SaaSUser) (reachable []SlackRecipient, skipped []string) {
+	// listAllSaaSUsers returns nil on a read error rather than an empty slice;
+	// a nil slice ranges as empty, so that case resolves to zero recipients and
+	// zero skipped rather than panicking.
+	for _, u := range users {
+		r := SlackRecipient{Username: u.GitHubUsername, SlackID: strings.TrimSpace(u.SlackID)}
+		if !r.Reachable() {
+			skipped = append(skipped, u.GitHubUsername)
+			continue
+		}
+		reachable = append(reachable, r)
+	}
+	return reachable, skipped
+}
+
+// slackPreview returns the leading slackPreviewLen characters of a message,
+// rune-safe, with an ellipsis when it was cut.
+func slackPreview(message string) string {
+	runes := []rune(message)
+	if len(runes) <= slackPreviewLen {
+		return message
+	}
+	return string(runes[:slackPreviewLen]) + "…"
+}
+
+// buildSlackResult assembles the operator-facing result for a resolved set.
+func buildSlackResult(target, message string, recipients []SlackRecipient, skipped []string, dryRun bool) slackSendResult {
+	reported := skipped
+	if len(reported) > maxSkippedUsersReported {
+		reported = reported[:maxSkippedUsersReported]
+	}
+	res := slackSendResult{
+		Target:       target,
+		DryRun:       dryRun,
+		Recipients:   len(recipients),
+		Skipped:      len(skipped),
+		SkippedUsers: reported,
+		Preview:      slackPreview(message),
+	}
+	if len(recipients) > 1 {
+		// The first send is immediate, so the wait is one interval per
+		// subsequent recipient.
+		res.EstimatedSeconds = int((time.Duration(len(recipients)-1) * slackSendInterval).Seconds())
+	}
+	if dryRun {
+		res.Status = "dry-run"
+	} else {
+		res.Status = "sending"
+	}
+	return res
+}
+
+// ============================================================================
+// HANDLERS
+// ============================================================================
+
+// slackSendRequest is the body of the send endpoints.
+type slackSendRequest struct {
+	// Message is the text to send. Required.
+	Message string `json:"message"`
+	// DryRun reports what WOULD be sent — recipient count, skipped users and a
+	// message preview — and sends nothing.
+	DryRun bool `json:"dry_run,omitempty"`
+	// Confirm must equal slackBroadcastConfirm for a broadcast. Ignored for the
+	// single-user and hive-owner endpoints, which are individually addressed and
+	// trivially recoverable.
+	Confirm string `json:"confirm,omitempty"`
+}
+
+// decodeSlackRequest reads and validates the shared request body, writing the
+// error response itself. Returns ok=false when the caller should stop.
+func decodeSlackRequest(w http.ResponseWriter, r *http.Request) (slackSendRequest, bool) {
+	r.Body = http.MaxBytesReader(w, r.Body, slackMaxBodyBytes)
+	var body slackSendRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return body, false
+	}
+	body.Message = strings.TrimSpace(body.Message)
+	if body.Message == "" {
+		http.Error(w, `{"error":"message is required"}`, http.StatusBadRequest)
+		return body, false
+	}
+	if len([]rune(body.Message)) > slackMaxMessageLen {
+		http.Error(w, fmt.Sprintf(`{"error":"message is too long (max %d characters)"}`, slackMaxMessageLen), http.StatusBadRequest)
+		return body, false
+	}
+	return body, true
+}
+
+// slackPreflight writes the standard CORS/OPTIONS preamble, matching the other
+// hub POST endpoints. Returns true when the request was an OPTIONS preflight and
+// the caller should return.
+func slackPreflight(w http.ResponseWriter, r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if isTrustedOrigin(origin) {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	}
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return true
+	}
+	w.Header().Set("Content-Type", "application/json")
+	return false
+}
+
+// requireSlackToken returns the bot token, or writes a 503 and returns "".
+//
+// A hub with no token must FAIL LOUDLY. Returning a cheerful "sending" for a
+// send that can never happen is the worst available outcome — the operator
+// would believe the fleet had been notified.
+func requireSlackToken(w http.ResponseWriter) string {
+	token := strings.TrimSpace(os.Getenv(slackTokenEnvVar))
+	if token == "" {
+		http.Error(w, fmt.Sprintf(`{"error":"slack messaging is not configured on this hub (%s is unset)"}`, slackTokenEnvVar), http.StatusServiceUnavailable)
+		return ""
+	}
+	return token
+}
+
+// handleSlackMessageUser sends to ONE user.
+//
+// AUTHORIZATION: admin-or-owner. Registered behind requireAuth; an admin may
+// message anyone, and a non-admin may message only themselves. Letting an
+// arbitrary signed-in user DM any other user would make the hub a spam relay,
+// so the self-only rule is the floor for non-admins.
+func (s *HubServer) handleSlackMessageUser(w http.ResponseWriter, r *http.Request) {
+	if slackPreflight(w, r) {
+		return
+	}
+	actor := s.getAuthUser(r)
+	username := r.PathValue("username")
+	if actor != hubAdminUsername && !strings.EqualFold(actor, username) {
+		http.Error(w, `{"error":"only an admin can message another user"}`, http.StatusForbidden)
+		return
+	}
+	body, ok := decodeSlackRequest(w, r)
+	if !ok {
+		return
+	}
+	u := loadSaaSUser(username)
+	if u == nil {
+		http.Error(w, `{"error":"user not found"}`, http.StatusNotFound)
+		return
+	}
+	recipients, skipped := resolveSlackRecipients([]SaaSUser{*u})
+	res := buildSlackResult("user", body.Message, recipients, skipped, body.DryRun)
+
+	if len(recipients) == 0 {
+		// Not an error — the user exists, they just have no Slack ID on file.
+		// Saying so explicitly is the whole point; a 200 "sent" here would be a
+		// silent drop.
+		res.Status = "skipped"
+		res.Note = fmt.Sprintf("%s has no slack_id on file — set one on the admin users panel before messaging them", username)
+		s.logger.Info("slack message skipped: no slack_id", "target", "user", "user", username, "actor", actor)
+		json.NewEncoder(w).Encode(res)
+		return
+	}
+	if body.DryRun {
+		json.NewEncoder(w).Encode(res)
+		return
+	}
+	token := requireSlackToken(w)
+	if token == "" {
+		return
+	}
+	s.logger.Info("audit: slack message queued", "target", "user", "user", username, "actor", actor)
+	go s.deliverSlackMessages(token, "user", body.Message, recipients, actor)
+	json.NewEncoder(w).Encode(res)
+}
+
+// handleSlackMessageHiveOwner sends to the OWNER of a given hive.
+//
+// AUTHORIZATION: admin-or-owner, the same shape as handleSwitchBranch — the
+// owner may message themselves through this route, and an admin may reach any
+// hive's owner. This is the route for "tell whoever runs this hive that their
+// node is full", which is exactly what #2349 required by hand.
+func (s *HubServer) handleSlackMessageHiveOwner(w http.ResponseWriter, r *http.Request) {
+	if slackPreflight(w, r) {
+		return
+	}
+	actor := s.getAuthUser(r)
+	id := r.PathValue("id")
+	h := loadSaaSHive(id)
+	if h == nil {
+		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
+		return
+	}
+	if h.Owner != actor && actor != hubAdminUsername {
+		http.Error(w, `{"error":"only the owner can message this hive's owner"}`, http.StatusForbidden)
+		return
+	}
+	body, ok := decodeSlackRequest(w, r)
+	if !ok {
+		return
+	}
+	if strings.TrimSpace(h.Owner) == "" {
+		// An unclaimed placeholder has no owner to message.
+		http.Error(w, `{"error":"this hive has no owner"}`, http.StatusBadRequest)
+		return
+	}
+	u := loadSaaSUser(h.Owner)
+	if u == nil {
+		http.Error(w, `{"error":"this hive's owner has no user record"}`, http.StatusNotFound)
+		return
+	}
+	recipients, skipped := resolveSlackRecipients([]SaaSUser{*u})
+	res := buildSlackResult("hive-owner", body.Message, recipients, skipped, body.DryRun)
+
+	if len(recipients) == 0 {
+		res.Status = "skipped"
+		res.Note = fmt.Sprintf("%s (owner of %s) has no slack_id on file", h.Owner, id)
+		s.logger.Info("slack message skipped: no slack_id",
+			"target", "hive-owner", "hive_id", id, "owner", h.Owner, "actor", actor)
+		json.NewEncoder(w).Encode(res)
+		return
+	}
+	if body.DryRun {
+		json.NewEncoder(w).Encode(res)
+		return
+	}
+	token := requireSlackToken(w)
+	if token == "" {
+		return
+	}
+	s.logger.Info("audit: slack message queued",
+		"target", "hive-owner", "hive_id", id, "owner", h.Owner, "actor", actor)
+	go s.deliverSlackMessages(token, "hive-owner", body.Message, recipients, actor)
+	json.NewEncoder(w).Encode(res)
+}
+
+// handleSlackBroadcast sends to EVERY user with a slack_id.
+//
+// AUTHORIZATION: admin-only (registered behind requireAdmin). Broadcast is the
+// one action here that cannot be taken back.
+//
+// It is a footgun, and it is guarded as one:
+//   - dry_run reports the recipient count, the skipped users and a message
+//     preview, and sends nothing.
+//   - a real send additionally requires confirm == slackBroadcastConfirm. A
+//     typed acknowledgement rather than a boolean, so no client can set it by
+//     accident and no dry-run request can turn into a live send by dropping one
+//     field.
+//   - the send is paced and runs in the background; the response returns
+//     immediately with an estimate of how long it will take.
+func (s *HubServer) handleSlackBroadcast(w http.ResponseWriter, r *http.Request) {
+	if slackPreflight(w, r) {
+		return
+	}
+	actor := s.getAuthUser(r)
+	body, ok := decodeSlackRequest(w, r)
+	if !ok {
+		return
+	}
+	users := listAllSaaSUsers()
+	recipients, skipped := resolveSlackRecipients(users)
+	res := buildSlackResult("all-users", body.Message, recipients, skipped, body.DryRun)
+
+	if body.DryRun {
+		res.Note = fmt.Sprintf("dry run — nothing was sent. Re-send with %q: %q to deliver to %d users.",
+			"confirm", slackBroadcastConfirm, len(recipients))
+		s.logger.Info("slack broadcast dry run",
+			"actor", actor, "recipients", len(recipients), "skipped", len(skipped))
+		json.NewEncoder(w).Encode(res)
+		return
+	}
+	if body.Confirm != slackBroadcastConfirm {
+		// 409, not 400: the request is well-formed, it just has not been
+		// confirmed. Reporting the recipient count in the refusal means the
+		// operator sees the blast radius before they retype the confirmation.
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error":        fmt.Sprintf("broadcast requires confirm: %q", slackBroadcastConfirm),
+			"recipients":   len(recipients),
+			"skipped":      len(skipped),
+			"preview":      slackPreview(body.Message),
+			"skipped_note": "users without a slack_id are skipped and named in skipped_users on a dry run",
+		})
+		return
+	}
+	if len(recipients) == 0 {
+		res.Status = "skipped"
+		res.Note = "no user on this hub has a slack_id on file — nothing to send"
+		s.logger.Warn("slack broadcast had no reachable recipients",
+			"actor", actor, "users", len(users), "skipped", len(skipped))
+		json.NewEncoder(w).Encode(res)
+		return
+	}
+	token := requireSlackToken(w)
+	if token == "" {
+		return
+	}
+	// The full skipped list goes to the LOG even though the response caps it:
+	// "who did not get told" is the fact an operator needs after a fleet-wide
+	// notice, and truncating it out of existence would be the silent drop this
+	// endpoint exists to avoid.
+	s.logger.Info("audit: slack broadcast queued",
+		"actor", actor,
+		"recipients", len(recipients),
+		"skipped", len(skipped),
+		"skipped_users", strings.Join(skipped, ","),
+		"estimated_seconds", res.EstimatedSeconds)
+	go s.deliverSlackMessages(token, "all-users", body.Message, recipients, actor)
+	json.NewEncoder(w).Encode(res)
+}

--- a/v2/pkg/hub/slack_test.go
+++ b/v2/pkg/hub/slack_test.go
@@ -1,0 +1,420 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const slackTestSecret = "slack-test-secret"
+
+// postSlack drives a Slack handler as the given user.
+func postSlack(t *testing.T, username, body string, path string, pathVals map[string]string, h http.HandlerFunc) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	for k, v := range pathVals {
+		req.SetPathValue(k, v)
+	}
+	if username != "" {
+		req.AddCookie(&http.Cookie{
+			Name:  "hive_hub_user",
+			Value: mintHubUserCookieValue(slackTestSecret, username),
+		})
+	}
+	rec := httptest.NewRecorder()
+	h(rec, req)
+	return rec
+}
+
+func decodeSlackResult(t *testing.T, rec *httptest.ResponseRecorder) slackSendResult {
+	t.Helper()
+	var res slackSendResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &res); err != nil {
+		t.Fatalf("decode: %v (body=%q)", err, rec.Body.String())
+	}
+	return res
+}
+
+// TestSlackSkipsAreVisible is the central contract: a user with no slack_id is
+// unreachable, and that must be REPORTED — count and names — not silently
+// dropped. "Sent to 61" while 27 people never heard anything is the failure
+// this endpoint exists to avoid.
+func TestSlackSkipsAreVisible(t *testing.T) {
+	users := []SaaSUser{
+		{GitHubUsername: "alice", SlackID: "U01ALICE"},
+		{GitHubUsername: "bob"},                   // no slack_id
+		{GitHubUsername: "carol", SlackID: "   "}, // whitespace only == unreachable
+		{GitHubUsername: "dave", SlackID: "U04DAVE"},
+	}
+	reachable, skipped := resolveSlackRecipients(users)
+	if len(reachable) != 2 {
+		t.Errorf("reachable = %d, want 2", len(reachable))
+	}
+	if len(skipped) != 2 {
+		t.Fatalf("skipped = %d, want 2 (bob and carol)", len(skipped))
+	}
+	got := strings.Join(skipped, ",")
+	if !strings.Contains(got, "bob") || !strings.Contains(got, "carol") {
+		t.Errorf("skipped users = %q, want bob and carol NAMED — a count alone does not say who to chase", got)
+	}
+	// A whitespace-only Slack ID must not be treated as reachable: it would
+	// produce a Slack API error per send rather than an honest skip.
+	for _, r := range reachable {
+		if strings.TrimSpace(r.SlackID) == "" {
+			t.Errorf("recipient %q has a blank slack id but was counted reachable", r.Username)
+		}
+	}
+	// A nil slice must resolve to nothing rather than panicking.
+	if r, s := resolveSlackRecipients(nil); len(r) != 0 || len(s) != 0 {
+		t.Errorf("nil users = (%d,%d), want (0,0)", len(r), len(s))
+	}
+}
+
+// TestSlackBroadcastRequiresConfirmation locks the footgun guard. Broadcast is
+// the one irreversible action here, so a well-formed request that has not been
+// confirmed must be refused — and the refusal must show the blast radius.
+func TestSlackBroadcastRequiresConfirmation(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	for _, u := range []SaaSUser{
+		{GitHubUsername: hubAdminUsername, SlackID: "U00ADMIN"},
+		{GitHubUsername: "alice", SlackID: "U01ALICE"},
+		{GitHubUsername: "bob"},
+	} {
+		user := u
+		if err := saveSaaSUser(&user); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s := &HubServer{logger: slog.Default(), hubSecret: slackTestSecret}
+
+	// No confirmation -> refused, with the recipient count so the operator sees
+	// what they are about to do before they retype it.
+	rec := postSlack(t, hubAdminUsername, `{"message":"node capacity problem"}`,
+		"/api/saas/admin/slack/broadcast", nil, s.handleSlackBroadcast)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 — an unconfirmed broadcast must not send (body=%q)", rec.Code, rec.Body.String())
+	}
+	var refusal map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &refusal); err != nil {
+		t.Fatal(err)
+	}
+	if refusal["recipients"] == nil {
+		t.Error("the refusal must report the recipient count — the blast radius is the thing being confirmed")
+	}
+	if !strings.Contains(rec.Body.String(), slackBroadcastConfirm) {
+		t.Errorf("the refusal must state the exact confirmation string, got %q", rec.Body.String())
+	}
+
+	// A WRONG confirmation is still a refusal. The value is typed, not a
+	// boolean, precisely so a client cannot set it by accident.
+	rec = postSlack(t, hubAdminUsername, `{"message":"hi","confirm":"yes"}`,
+		"/api/saas/admin/slack/broadcast", nil, s.handleSlackBroadcast)
+	if rec.Code != http.StatusConflict {
+		t.Errorf("a wrong confirmation must still refuse, got %d", rec.Code)
+	}
+}
+
+// TestSlackBroadcastDryRunSendsNothing locks the dry run: it must report the
+// recipient count, the skipped users and a preview, and send nothing — and it
+// must work with NO token configured, since it is the thing an operator runs
+// before a token is even in place.
+func TestSlackBroadcastDryRunSendsNothing(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	t.Setenv(slackTokenEnvVar, "") // explicitly unconfigured
+
+	for _, u := range []SaaSUser{
+		{GitHubUsername: hubAdminUsername, SlackID: "U00ADMIN"},
+		{GitHubUsername: "alice", SlackID: "U01ALICE"},
+		{GitHubUsername: "bob"},
+		{GitHubUsername: "carol"},
+	} {
+		user := u
+		if err := saveSaaSUser(&user); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s := &HubServer{logger: slog.Default(), hubSecret: slackTestSecret}
+
+	rec := postSlack(t, hubAdminUsername, `{"message":"please update your GitHub App permissions","dry_run":true}`,
+		"/api/saas/admin/slack/broadcast", nil, s.handleSlackBroadcast)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("dry run status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+	res := decodeSlackResult(t, rec)
+	if !res.DryRun || res.Status != "dry-run" {
+		t.Errorf("result = %+v, want a dry run", res)
+	}
+	if res.Recipients != 2 {
+		t.Errorf("recipients = %d, want 2 (admin + alice)", res.Recipients)
+	}
+	if res.Skipped != 2 {
+		t.Errorf("skipped = %d, want 2 (bob + carol)", res.Skipped)
+	}
+	if len(res.SkippedUsers) != 2 {
+		t.Errorf("skipped users = %v, want both named", res.SkippedUsers)
+	}
+	if !strings.Contains(res.Preview, "GitHub App permissions") {
+		t.Errorf("preview = %q, want the message text so the operator can confirm it", res.Preview)
+	}
+}
+
+// TestSlackBroadcastIsAdminOnlyAtTheRoute documents that broadcast carries no
+// in-handler owner check because it is registered behind requireAdmin.
+//
+// The route registration is the authorization for this endpoint, so the test
+// asserts the wiring rather than re-checking inside the handler.
+func TestSlackBroadcastIsAdminOnlyAtTheRoute(t *testing.T) {
+	s := &HubServer{logger: slog.Default(), mux: http.NewServeMux(), hubSecret: slackTestSecret}
+	s.registerSaaSRoutes()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/admin/slack/broadcast",
+		strings.NewReader(`{"message":"hi","dry_run":true}`))
+	// No auth cookie at all: requireAdmin must reject before the handler runs.
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("unauthenticated broadcast = %d, want 403 from requireAdmin", rec.Code)
+	}
+}
+
+// TestSlackMessageUserAuthorization locks the single-user rule: an admin may
+// message anyone, a user may message only themselves. Without the self-only
+// floor the hub becomes a spam relay between its own users.
+func TestSlackMessageUserAuthorization(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	for _, u := range []SaaSUser{
+		{GitHubUsername: hubAdminUsername, SlackID: "U00ADMIN"},
+		{GitHubUsername: "alice", SlackID: "U01ALICE"},
+		{GitHubUsername: "mallory", SlackID: "U09MAL"},
+	} {
+		user := u
+		if err := saveSaaSUser(&user); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s := &HubServer{logger: slog.Default(), hubSecret: slackTestSecret}
+	const body = `{"message":"hello","dry_run":true}`
+
+	rec := postSlack(t, "mallory", body, "/api/saas/slack/user/alice",
+		map[string]string{"username": "alice"}, s.handleSlackMessageUser)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("a non-admin messaging ANOTHER user = %d, want 403 (the hub is not a spam relay)", rec.Code)
+	}
+	rec = postSlack(t, "alice", body, "/api/saas/slack/user/alice",
+		map[string]string{"username": "alice"}, s.handleSlackMessageUser)
+	if rec.Code != http.StatusOK {
+		t.Errorf("a user messaging THEMSELVES = %d, want 200 (%q)", rec.Code, rec.Body.String())
+	}
+	rec = postSlack(t, hubAdminUsername, body, "/api/saas/slack/user/alice",
+		map[string]string{"username": "alice"}, s.handleSlackMessageUser)
+	if rec.Code != http.StatusOK {
+		t.Errorf("an admin messaging any user = %d, want 200 (%q)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestSlackMessageUserWithoutHandleIsNotSilent covers the single-user skip. The
+// user exists and the request is valid — they simply cannot be reached. That
+// must come back as an explicit "skipped" naming the reason, never as a 200
+// that reads like a delivered message.
+func TestSlackMessageUserWithoutHandleIsNotSilent(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	for _, u := range []SaaSUser{
+		{GitHubUsername: hubAdminUsername, SlackID: "U00ADMIN"},
+		{GitHubUsername: "bob"}, // no slack_id
+	} {
+		user := u
+		if err := saveSaaSUser(&user); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s := &HubServer{logger: slog.Default(), hubSecret: slackTestSecret}
+
+	rec := postSlack(t, hubAdminUsername, `{"message":"hello"}`,
+		"/api/saas/slack/user/bob", map[string]string{"username": "bob"}, s.handleSlackMessageUser)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+	res := decodeSlackResult(t, rec)
+	if res.Status != "skipped" {
+		t.Errorf("status = %q, want \"skipped\" — a user with no slack_id must never look delivered", res.Status)
+	}
+	if res.Recipients != 0 || res.Skipped != 1 {
+		t.Errorf("result = %+v, want 0 recipients and 1 skipped", res)
+	}
+	if !strings.Contains(res.Note, "slack_id") {
+		t.Errorf("note = %q, want an explanation naming slack_id", res.Note)
+	}
+}
+
+// TestSlackHiveOwnerAuthorization locks the hive route's owner-or-admin rule,
+// matching handleSwitchBranch.
+func TestSlackHiveOwnerAuthorization(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	for _, u := range []SaaSUser{
+		{GitHubUsername: hubAdminUsername, SlackID: "U00ADMIN"},
+		{GitHubUsername: "owner", SlackID: "U01OWNER"},
+		{GitHubUsername: "stranger", SlackID: "U02STR"},
+	} {
+		user := u
+		if err := saveSaaSUser(&user); err != nil {
+			t.Fatal(err)
+		}
+	}
+	saveSaaSHive(&SaaSHive{ID: "h", Owner: "owner", Status: "running"})
+	s := &HubServer{logger: slog.Default(), hubSecret: slackTestSecret}
+	const body = `{"message":"your node is full","dry_run":true}`
+
+	rec := postSlack(t, "stranger", body, "/api/saas/hives/h/slack",
+		map[string]string{"id": "h"}, s.handleSlackMessageHiveOwner)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("a stranger = %d, want 403", rec.Code)
+	}
+	rec = postSlack(t, "owner", body, "/api/saas/hives/h/slack",
+		map[string]string{"id": "h"}, s.handleSlackMessageHiveOwner)
+	if rec.Code != http.StatusOK {
+		t.Errorf("the owner = %d, want 200 (%q)", rec.Code, rec.Body.String())
+	}
+	rec = postSlack(t, hubAdminUsername, body, "/api/saas/hives/h/slack",
+		map[string]string{"id": "h"}, s.handleSlackMessageHiveOwner)
+	if rec.Code != http.StatusOK {
+		t.Errorf("an admin = %d, want 200 (%q)", rec.Code, rec.Body.String())
+	}
+	// The dry run must resolve the OWNER, not the caller.
+	res := decodeSlackResult(t, rec)
+	if res.Recipients != 1 || res.Target != "hive-owner" {
+		t.Errorf("result = %+v, want 1 recipient targeted at the hive owner", res)
+	}
+}
+
+// TestSlackRequiresAMessage locks input validation: an empty or oversized
+// message never reaches Slack.
+func TestSlackRequiresAMessage(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: hubAdminUsername, SlackID: "U00ADMIN"}); err != nil {
+		t.Fatal(err)
+	}
+	s := &HubServer{logger: slog.Default(), hubSecret: slackTestSecret}
+
+	for _, body := range []string{`{}`, `{"message":""}`, `{"message":"   "}`, `not json`} {
+		rec := postSlack(t, hubAdminUsername, body,
+			"/api/saas/admin/slack/broadcast", nil, s.handleSlackBroadcast)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("body %q = %d, want 400", body, rec.Code)
+		}
+	}
+	// Over the cap.
+	long := `{"message":"` + strings.Repeat("x", slackMaxMessageLen+1) + `"}`
+	if rec := postSlack(t, hubAdminUsername, long,
+		"/api/saas/admin/slack/broadcast", nil, s.handleSlackBroadcast); rec.Code != http.StatusBadRequest {
+		t.Errorf("an oversized message = %d, want 400", rec.Code)
+	}
+}
+
+// TestSlackWithoutATokenFailsLoudly is the anti-silent-failure test.
+//
+// A confirmed broadcast on a hub with no token must return 503, NOT a cheerful
+// "sending" for a send that can never happen — the operator would otherwise
+// believe the fleet had been notified.
+func TestSlackWithoutATokenFailsLoudly(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	t.Setenv(slackTokenEnvVar, "")
+
+	for _, u := range []SaaSUser{
+		{GitHubUsername: hubAdminUsername, SlackID: "U00ADMIN"},
+		{GitHubUsername: "alice", SlackID: "U01ALICE"},
+	} {
+		user := u
+		if err := saveSaaSUser(&user); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s := &HubServer{logger: slog.Default(), hubSecret: slackTestSecret}
+
+	rec := postSlack(t, hubAdminUsername,
+		`{"message":"hi","confirm":"`+slackBroadcastConfirm+`"}`,
+		"/api/saas/admin/slack/broadcast", nil, s.handleSlackBroadcast)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 — an unconfigured hub must not report a send it cannot make (body=%q)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), slackTokenEnvVar) {
+		t.Errorf("the error must name the env var an operator has to set, got %q", rec.Body.String())
+	}
+}
+
+// TestSlackPacingIsDocumentedAndBounded guards the rate constants. Slack
+// throttles chat.postMessage at roughly 1/sec; a broadcast to ~88 users must be
+// paced, and the estimate shown to the operator must reflect that.
+func TestSlackPacingIsDocumentedAndBounded(t *testing.T) {
+	if slackSendInterval < 1_000_000_000 { // 1s in nanoseconds
+		t.Errorf("slackSendInterval = %v, want at least 1s — Slack rate-limits chat.postMessage at ~1/sec", slackSendInterval)
+	}
+	// ~88 users is the live fleet size; the estimate must be reported so the
+	// operator is not surprised the send is still running 90 seconds later.
+	recipients := make([]SlackRecipient, 88)
+	for i := range recipients {
+		recipients[i] = SlackRecipient{Username: "u", SlackID: "U1"}
+	}
+	res := buildSlackResult("all-users", "hello", recipients, nil, true)
+	if res.EstimatedSeconds < 80 {
+		t.Errorf("estimated seconds = %d, want ~87 for 88 paced recipients", res.EstimatedSeconds)
+	}
+	// A single recipient is sent immediately, with no artificial delay.
+	if got := buildSlackResult("user", "hello", recipients[:1], nil, true); got.EstimatedSeconds != 0 {
+		t.Errorf("a single recipient must not be paced, got %d seconds", got.EstimatedSeconds)
+	}
+}
+
+// TestSlackPreviewIsRuneSafe guards the preview against splitting a multi-byte
+// character, which would render as a replacement glyph in the operator's
+// confirmation step.
+func TestSlackPreviewIsRuneSafe(t *testing.T) {
+	if got := slackPreview("short"); got != "short" {
+		t.Errorf("a short message must pass through unchanged, got %q", got)
+	}
+	long := strings.Repeat("é", slackPreviewLen+50)
+	got := slackPreview(long)
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("a truncated preview must be marked as truncated, got %q", got)
+	}
+	if strings.Contains(got, "�") {
+		t.Error("preview split a multi-byte rune")
+	}
+	if n := len([]rune(strings.TrimSuffix(got, "…"))); n != slackPreviewLen {
+		t.Errorf("preview kept %d runes, want %d", n, slackPreviewLen)
+	}
+}
+
+// TestSlackTokenIsNeverHardcoded is a guard against the failure that once
+// required scrubbing this repository's git history: the token must come from
+// the environment with NO default and NO fallback value in source.
+func TestSlackTokenIsNeverHardcoded(t *testing.T) {
+	t.Setenv(slackTokenEnvVar, "")
+	rec := httptest.NewRecorder()
+	if got := requireSlackToken(rec); got != "" {
+		t.Errorf("an unset env var must yield NO token, got a non-empty value of %d bytes", len(got))
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rec.Code)
+	}
+	// And a set value is used verbatim, so the Secret is the single source.
+	t.Setenv(slackTokenEnvVar, "xoxb-not-a-real-token")
+	rec2 := httptest.NewRecorder()
+	if got := requireSlackToken(rec2); got != "xoxb-not-a-real-token" {
+		t.Errorf("token = %q, want the env value", got)
+	}
+}


### PR DESCRIPTION
> *"i need a way to send a slack message to a user (if there slack handle is defined). By extension, i need to be able to send a slack message to all users, or just the owner of a hive."*

Today these messages are hand-copied. The GitHub App permission notice (#2353) and the node-capacity problem (#2349) were both pasted one org owner at a time, out of the hub's own user list — which already carries the Slack IDs.

## Storage: the existing field, not a new one

`SaaSUser.SlackID` (`slack_id`) **already exists** — an admin-maintained CRM contact field with a length cap (`maxContactSlackIDLen`), an edit path (`handleAdminUpdateUser`), and a rendered input on the admin Users panel.

So this PR **changes nothing about the user record**. Adding a second `slack_handle` field would have split one fact across two keys on ~88 records with nothing to keep them in step, and left the existing dashboard input writing to the wrong one.

## Endpoints and authorization

| Endpoint | Auth | Notes |
|---|---|---|
| `POST /api/saas/slack/user/{username}` | `requireAuth` + admin, **or the user themselves** | |
| `POST /api/saas/hives/{id}/slack` | `requireAuth` + owner-or-admin | messages the hive's owner |
| `POST /api/saas/admin/slack/broadcast` | **`requireAdmin`** | |

The single-user route's self-only floor for non-admins is deliberate: letting any signed-in user DM any other user would make the hub a spam relay. The hive route mirrors `handleSwitchBranch`'s owner-or-admin shape exactly.

## The token is never in this repo

Read via `os.Getenv` with **no default and no fallback**. Unset simply disables the feature.

It is a key on the **existing `hive-hub-secrets`** Secret rather than a new one — that Secret is already in `hubbackup.DefaultHubSecrets`, so the token is captured by the DR backup (#2315) and survives a restore **without touching the collected-secret list**. A brand-new Secret would have been silently lost in a restore. The DR doc now states this rule generally, so the next credential lands in the right place.

A webhook would not work here regardless: a webhook is bound to one channel at creation time and cannot DM a user. This uses `chat.postMessage` with a bot token.

## Broadcast is treated as the footgun it is

1. **Dry run** (`"dry_run": true`) sends nothing and returns the recipient count, the **names** of users who will be skipped, a message preview, and an estimated duration. It works with no token configured — it is the thing you run *before* the token is in place.
2. **Typed confirmation.** A real broadcast requires `"confirm": "SEND TO ALL USERS"`. A string, not a boolean, so no client can set it by accident and a dry-run request cannot become a live send by dropping one field. Without it: **409**, reporting the blast radius so the operator sees it before retyping.
3. **Paced and backgrounded.** Slack throttles `chat.postMessage` at ~1/sec, so sends are spaced by a named constant and run in a goroutine — ~88 users takes about 90 seconds, which would otherwise hold the request past any proxy timeout. A mutex serializes concurrent broadcasts, since two correctly-paced sends still collectively exceed the limit.

## Skips are visible, and failures are loud

- A user with **no `slack_id`** is skipped and **named** — in the response and, for a broadcast, the full list in the log. "Sent to 61" while 27 people never heard anything is exactly the silent drop this must not do. A single-user send to someone with no ID returns `status: "skipped"` with a note, never a 200 that reads as delivered.
- A hub with **no token** returns **503** naming the variable, rather than a cheerful `"sending"` for a send that can never happen.
- Slack answers `200 OK` with `{"ok": false, "error": "..."}` for application-level failures (bad user, missing scope, revoked token). The body is decoded and `ok` checked — checking only the HTTP status would report every one of those as a success. HTTP 429 is surfaced distinctly, because it means the pacing is wrong rather than the credentials.
- Whitespace-only Slack IDs count as unreachable, so they produce an honest skip instead of a per-send API error.

The token is never logged. Message bodies are not logged.

## Tests

11 tests covering: skips are named (not just counted); broadcast refuses without confirmation and with a *wrong* confirmation; dry run sends nothing and reports count/skips/preview; broadcast is admin-only **at the route**; single-user self-only rule for non-admins; a user with no `slack_id` returns `skipped` and not a fake success; hive-owner owner-or-admin and that it targets the *owner* rather than the caller; message validation (empty/blank/malformed/oversized); **no token → 503 naming the env var**; pacing constants are ≥1s and the estimate reflects ~88 recipients; the preview is rune-safe; and the token is never hardcoded.

Full `pkg/hub` suite passes. `dashboardHTML` is **byte-identical to base** (md5 verified) — no embedded JS was touched.

## Live systems

**Strictly read-only.** No user record, hive or hub state was mutated, and no Slack message was sent to anyone.