### PR TITLE
🐛 fix(hub): stop GitHub Enterprise hives emitting a 404 GitHub App install link

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2656,6 +2656,25 @@ func main() {
 				cfg.GitHub.AppSlug = ghCfg.AppSlug
 			}
 
+			// Persist the adopted App IDENTITY to the PVC overlay, exactly as the
+			// claimed-project-config callback persists what it adopts.
+			//
+			// Without this the adoption lived only in memory. The key files are
+			// written to /data (durable), but app_id/app_slug/installation_id were
+			// not, so on every pod restart the entrypoint re-merged the ConfigMap
+			// seed and the spoke reverted to whatever App it was provisioned with —
+			// silently undoing a completed repair and making the hub's push look
+			// like it had never happened. That is how a GHE hive kept re-appearing
+			// with the github.com app_id and an empty slug across restarts.
+			//
+			// Saved even when the App is not yet usable (installation_id still 0):
+			// the corrected app_id and slug are precisely what the owner needs on
+			// disk so the dashboard renders a working install link BEFORE they have
+			// installed anything.
+			if err := cfg.Save(); err != nil {
+				logger.Error("failed to persist github app config from heartbeat", "error", err)
+			}
+
 			// Resolve the key file the same way startup does, so a hive whose
 			// only correct key arrived as an ADDITIONAL per-app-id key (no
 			// primary key_file configured — the exact vllm-d state) still finds

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1456,13 +1456,35 @@ func (g GitHubConfig) AppAuthoredPRsEnabled() bool {
 // AppInstallURL returns the full URL to install the GitHub App.
 // For GHE: {base_url}/github-apps/{slug}/installations/new
 // For github.com: https://github.com/apps/{slug}/installations/new
+//
+// It returns "" for a GitHub Enterprise host whose App slug is not configured.
+//
+// WHY EMPTY RATHER THAN A BEST-EFFORT URL
+//
+// DefaultGitHubAppSlug ("kubestellar-hive") names the App registered on PUBLIC
+// github.com. GitHub Enterprise hosts a SEPARATE App registry, and an enterprise
+// registration is rarely given the same slug — so falling back to the default on
+// a GHE host emits a link to an App that provably does not exist there, and the
+// user lands on a GitHub 404. That is strictly worse than no link: a dead link
+// reads as "this product is broken", and it sent a real user to
+// github.ibm.com/github-apps/kubestellar-hive/installations/new.
+//
+// The empty string is the honest answer — "this host's App slug was never
+// recorded" — and callers render it as a legible message naming the missing
+// config instead of a button that 404s. Public github.com keeps the default,
+// where it is correct by construction.
 func (g GitHubConfig) AppInstallURL() string {
 	base := strings.TrimRight(g.ResolvedBaseURL(), "/")
-	slug := g.ResolvedAppSlug()
 	if g.IsGHE() {
+		// No default is admissible here: only an explicitly configured slug can
+		// name an App on this enterprise host.
+		slug := strings.TrimSpace(g.AppSlug)
+		if slug == "" {
+			return ""
+		}
 		return base + "/github-apps/" + slug + "/installations/new"
 	}
-	return base + "/apps/" + slug + "/installations/new"
+	return base + "/apps/" + g.ResolvedAppSlug() + "/installations/new"
 }
 
 type NotificationsConfig struct {

--- a/v2/pkg/config/config_uncovered_coverage_test.go
+++ b/v2/pkg/config/config_uncovered_coverage_test.go
@@ -350,19 +350,31 @@ func TestGitHubConfig_AppInstallURL_Table(t *testing.T) {
 			want:    "https://github.com/apps/acme-hive/installations/new",
 		},
 		{
-			name:    "GHE host uses the enterprise /github-apps/ path",
+			// The public default names an App that exists ONLY on github.com. On a
+			// GHE host it produced github.ibm.com/github-apps/kubestellar-hive/...,
+			// a live 404 a real user hit. Empty is the honest answer and callers
+			// render it as "install link unavailable" plus the missing config.
+			name:    "GHE host with no configured slug yields no link, not a 404",
 			baseURL: "https://github.ibm.com",
-			want:    "https://github.ibm.com/github-apps/" + DefaultGitHubAppSlug + "/installations/new",
+			want:    "",
 		},
 		{
 			name:    "GHE host with a trailing slash does not double up",
 			baseURL: "https://github.cisco.com/",
-			want:    "https://github.cisco.com/github-apps/" + DefaultGitHubAppSlug + "/installations/new",
+			appSlug: "acme-ghe",
+			want:    "https://github.cisco.com/github-apps/acme-ghe/installations/new",
 		},
 		{
 			name:    "GHE host with multiple trailing slashes",
 			baseURL: "https://github.cisco.com///",
-			want:    "https://github.cisco.com/github-apps/" + DefaultGitHubAppSlug + "/installations/new",
+			appSlug: "acme-ghe",
+			want:    "https://github.cisco.com/github-apps/acme-ghe/installations/new",
+		},
+		{
+			name:    "GHE slug that is only whitespace is treated as unset",
+			baseURL: "https://github.ibm.com",
+			appSlug: "   ",
+			want:    "",
 		},
 		{
 			name:    "GHE host honours a per-instance app slug",
@@ -383,7 +395,8 @@ func TestGitHubConfig_AppInstallURL_Table(t *testing.T) {
 			// broken link is the safer outcome than a plausible wrong one.
 			name:    "malformed base url is not rewritten to github.com",
 			baseURL: "not a url",
-			want:    "not a url/github-apps/" + DefaultGitHubAppSlug + "/installations/new",
+			appSlug: "acme-ghe",
+			want:    "not a url/github-apps/acme-ghe/installations/new",
 		},
 	}
 	for _, tt := range tests {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5220,7 +5220,29 @@
           if (desc) desc.textContent = isGHE
             ? 'This hive cannot post advisory reports. Install the GitHub App on your GHE org to enable full functionality.'
             : 'This hive cannot create issues or advisory reports. Install the Hive Hub GitHub App on your repository to enable full functionality.';
-          if (link) { link.textContent = 'Install GitHub App'; link.href = data.githubAppInstallURL; }
+          /* A GitHub Enterprise host whose App slug was never configured yields
+             an EMPTY install URL from the server, deliberately: the public
+             "kubestellar-hive" slug names no App on an enterprise host, so a
+             best-effort link would 404 and read as a broken product. Say what is
+             missing instead of offering a dead button. */
+          if (link) {
+            if (data.githubAppInstallURL) {
+              link.textContent = 'Install GitHub App';
+              link.href = data.githubAppInstallURL;
+              link.removeAttribute('aria-disabled');
+            } else {
+              link.removeAttribute('href');
+              link.setAttribute('aria-disabled', 'true');
+              link.textContent = isGHE ? 'Install link unavailable for this GitHub host' : 'Install URL unavailable';
+              if (desc) {
+                desc.textContent = isGHE
+                  ? 'This hive cannot post advisory reports. The GitHub App slug for '
+                    + String(data.githubBaseURL).replace(/^https?:\/\//, '')
+                    + ' is not configured, so an install link cannot be built. Ask your hub operator to set github_app_slug for this cluster.'
+                  : desc.textContent;
+              }
+            }
+          }
         }
         banner.removeAttribute('hidden');
         banner.style.cssText = 'display:flex !important';

--- a/v2/pkg/hub/app_host_follows_repo_test.go
+++ b/v2/pkg/hub/app_host_follows_repo_test.go
@@ -78,7 +78,7 @@ func TestDecideAppKeySync_RepairsPlaceholderSentinel(t *testing.T) {
 		{"no key at all", "", false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := decideAppKeySync(tc.fingerprint, tc.hasPerHive, false, config.PlaceholderAppID, cluster)
+			got := decideAppKeySync(tc.fingerprint, tc.hasPerHive, false, false, config.PlaceholderAppID, cluster)
 			if !got.Push {
 				t.Errorf("sentinel app_id not repaired (%s): %+v", tc.name, got)
 			}
@@ -91,7 +91,7 @@ func TestDecideAppKeySync_RepairsPlaceholderSentinel(t *testing.T) {
 	// A spoke on a genuinely different (real) App is still protected — the
 	// sentinel is the ONLY app_id treated as unconditionally wrong.
 	const someOtherRealApp = 4240368
-	if got := decideAppKeySync("other-fp", true, false, someOtherRealApp, cluster); got.Push {
+	if got := decideAppKeySync("other-fp", true, false, false, someOtherRealApp, cluster); got.Push {
 		t.Errorf("a real non-matching app_id must stay protected as a deliberate pin: %+v", got)
 	}
 }

--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -497,6 +497,29 @@ const (
 	// key on disk. This mirrors resolveProvisionAppID, which likewise honours the
 	// public pin instead of forcing the cluster GHE app_id.
 	appKeyReasonPublicHiveOnGHECluster = "hive is pinned to public github.com on a GHE-default cluster"
+	// appKeyReasonWrongForgeApp repairs a spoke carrying an App registered on a
+	// DIFFERENT GitHub host than the one the hive actually talks to.
+	//
+	// appKeyReasonDifferentApp protects a deliberate pin, and that protection is
+	// right whenever both Apps live on the same forge — an operator may genuinely
+	// want a hive on its own App. But an App ID is only meaningful ON the host that
+	// issued it: GitHub Enterprise and github.com maintain entirely separate App
+	// registries, so a github.com app_id names NOTHING on github.ibm.com. Such a
+	// pairing is not a configuration choice, it is provably broken in the same way
+	// the placeholder sentinel is — every JWT is signed for an App the host has
+	// never heard of, and no installation_id the owner enters can rescue it.
+	//
+	// It is also the state a forge migration leaves behind: moving a hive's host
+	// without swapping its App identity strands the old forge's app_id on the new
+	// host. That is exactly how a live GHE hive ended up emitting an install link
+	// for the github.com App slug and 404ing on GitHub Enterprise.
+	//
+	// The discriminator is narrow and evidence-based: the hive is NOT public-pinned
+	// (that case is already handled above and must keep its github.com App), its
+	// cluster declares a GHE base URL, and the spoke's app_id differs from the
+	// cluster's. Under those three conditions the spoke's App cannot be the
+	// cluster's forge's App, so the cluster identity is the only workable one.
+	appKeyReasonWrongForgeApp = "hive carries an app_id registered on a different github host"
 )
 
 // decideAppKeySync decides whether the hub should push its cluster App key to a
@@ -559,7 +582,14 @@ const (
 // key rides only as an ADDITIONAL key (attachMissingAppKeys). This is the app-KEY
 // reconcile finally honouring the same public pin that resolveProvisionAppID and
 // effectiveGitHubBaseURL already honour on the provisioning path.
-func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned bool, spokeAppID int64, cluster *clusterAppIdentity) appKeySyncDecision {
+//
+// WRONG-FORGE APP — clusterIsGHE carries the one fact this function cannot see
+// for itself: whether the cluster's App lives on a GitHub Enterprise host rather
+// than public github.com. Combined with a non-public-pinned hive whose app_id
+// differs from the cluster's, that proves the spoke's App was issued by a
+// different forge and therefore names nothing on the host this hive uses. See
+// appKeyReasonWrongForgeApp.
+func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned, clusterIsGHE bool, spokeAppID int64, cluster *clusterAppIdentity) appKeySyncDecision {
 	if cluster == nil {
 		return appKeySyncDecision{Reason: appKeyReasonNoClusterKey, FromFingerprint: spokeFingerprint}
 	}
@@ -599,6 +629,29 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned b
 			Push:            true,
 			PushKey:         cluster.HasKey(),
 			Reason:          appKeyReasonPlaceholderAppID,
+			FromFingerprint: fp,
+			ToFingerprint:   cluster.Fingerprint,
+		}
+	}
+	// A spoke holding an App from ANOTHER forge is broken for the same reason the
+	// sentinel is: the app_id names no App on the host this hive actually uses.
+	// Decided here — after the sentinel and the public pin, but BEFORE the
+	// per-hive-key shield — because a stranded hive typically does hold a per-hive
+	// key (for the other forge's App) and would otherwise be protected as
+	// appKeyReasonDifferentApp and never repaired.
+	//
+	// Requires a POSITIVE, non-zero app_id disagreement: zero means "too old to
+	// report", and silence is never evidence of a fault (same contract as the
+	// per-hive exception above).
+	//
+	// Like the sentinel repair this does NOT require the hub to hold the cluster's
+	// key — correcting a cross-forge app_id/app_slug is a non-secret change and is
+	// the whole fix for a hive whose owner has yet to install the App at all.
+	if clusterIsGHE && spokeAppID != 0 && spokeAppID != cluster.AppID {
+		return appKeySyncDecision{
+			Push:            true,
+			PushKey:         cluster.HasKey(),
+			Reason:          appKeyReasonWrongForgeApp,
 			FromFingerprint: fp,
 			ToFingerprint:   cluster.Fingerprint,
 		}
@@ -682,7 +735,14 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned b
 // so a key delivered ahead of an installation ID lands on disk and waits.
 func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFingerprint string, hasPerHiveKey, hivePublicPinned bool, spokeAppID int64, installationID int64, logger *slog.Logger) *HeartbeatGitHubAppConfig {
 	identity := s.appIdentityForCluster(clusterID)
-	decision := decideAppKeySync(spokeFingerprint, hasPerHiveKey, hivePublicPinned, spokeAppID, identity)
+	// Does this cluster's App live on a GitHub Enterprise host? Read from cluster
+	// config, never inferred from the App ID — an App ID is an opaque number and
+	// carries no forge information. Empty github_base_url means public github.com.
+	clusterIsGHE := false
+	if c, ok := s.clusters[clusterID]; ok {
+		clusterIsGHE = strings.TrimSpace(c.GitHubBaseURL) != ""
+	}
+	decision := decideAppKeySync(spokeFingerprint, hasPerHiveKey, hivePublicPinned, clusterIsGHE, spokeAppID, identity)
 	// A spoke carrying the sentinel is broken and must be legible even when the
 	// hub can do nothing about it — that silence is what made this bug cost days
 	// of debugging while the dashboard blamed the installation ID. Logged BEFORE

--- a/v2/pkg/hub/cluster_app_key_test.go
+++ b/v2/pkg/hub/cluster_app_key_test.go
@@ -71,6 +71,7 @@ func TestDecideAppKeySync(t *testing.T) {
 		spokeFP      string
 		perHive      bool
 		publicPinned bool
+		clusterIsGHE bool
 		spokeAppID   int64
 		cluster      *clusterAppIdentity
 		wantPush     bool
@@ -182,6 +183,73 @@ func TestDecideAppKeySync(t *testing.T) {
 			wantToFP:    clusterFP,
 			description: "a hive pinned to its own App keeps its own key; the cluster key would break it",
 		},
+		// --- WRONG-FORGE APP: a cross-forge app_id is a fault, not a pin ---
+		{
+			name:         "GHE cluster, spoke carries the github.com app - PUSH",
+			spokeFP:      wrongFP,
+			perHive:      true,
+			clusterIsGHE: true,
+			spokeAppID:   3568013, // the public github.com App
+			cluster:      identity,
+			wantPush:     true,
+			wantReason:   appKeyReasonWrongForgeApp,
+			wantFromFP:   wrongFP,
+			wantToFP:     clusterFP,
+			description:  "vllmd-03 (Enrico): app_id 3568013 names no App on github.ibm.com, so the per-hive shield must not protect it",
+		},
+		{
+			name:         "GHE cluster, spoke app_id unknown (0) - no push",
+			spokeFP:      wrongFP,
+			perHive:      true,
+			clusterIsGHE: true,
+			spokeAppID:   0,
+			cluster:      identity,
+			wantPush:     false,
+			wantReason:   appKeyReasonPerHiveOverride,
+			wantFromFP:   wrongFP,
+			wantToFP:     clusterFP,
+			description:  "a spoke too old to report its app_id is silent, and silence is never evidence of a cross-forge fault",
+		},
+		{
+			name:         "GHE cluster, spoke already on the cluster app - no wrong-forge push",
+			spokeFP:      clusterFP,
+			perHive:      true,
+			clusterIsGHE: true,
+			spokeAppID:   5686,
+			cluster:      identity,
+			wantPush:     false,
+			wantReason:   appKeyReasonMatch,
+			wantFromFP:   clusterFP,
+			wantToFP:     clusterFP,
+			description:  "idempotence: once the spoke carries the GHE App the repair stops firing",
+		},
+		{
+			name:         "public cluster keeps protecting a deliberate different app",
+			spokeFP:      wrongFP,
+			perHive:      true,
+			clusterIsGHE: false,
+			spokeAppID:   99999,
+			cluster:      identity,
+			wantPush:     false,
+			wantReason:   appKeyReasonDifferentApp,
+			wantFromFP:   wrongFP,
+			wantToFP:     clusterFP,
+			description:  "same-forge pins stay protected; the repair is scoped to cross-forge clusters only",
+		},
+		{
+			name:         "public-pinned hive on a GHE cluster is never wrong-forge repaired",
+			spokeFP:      wrongFP,
+			perHive:      true,
+			publicPinned: true,
+			clusterIsGHE: true,
+			spokeAppID:   3568013,
+			cluster:      identity,
+			wantPush:     false,
+			wantReason:   appKeyReasonPublicHiveOnGHECluster,
+			wantFromFP:   wrongFP,
+			wantToFP:     clusterFP,
+			description:  "a hive deliberately pinned to public github.com must keep its github.com App even on a GHE cluster",
+		},
 		{
 			name:        "per-hive key already matches the cluster key - no push",
 			spokeFP:     clusterFP,
@@ -260,7 +328,7 @@ func TestDecideAppKeySync(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := decideAppKeySync(tc.spokeFP, tc.perHive, tc.publicPinned, tc.spokeAppID, tc.cluster)
+			got := decideAppKeySync(tc.spokeFP, tc.perHive, tc.publicPinned, tc.clusterIsGHE, tc.spokeAppID, tc.cluster)
 			if got.Push != tc.wantPush {
 				t.Errorf("Push = %v, want %v (%s)", got.Push, tc.wantPush, tc.description)
 			}
@@ -295,7 +363,7 @@ func TestDecideAppKeySyncIsIdempotent(t *testing.T) {
 	identity := &clusterAppIdentity{AppID: 5686, PrivateKey: keyPEM, Fingerprint: fp}
 
 	// Beat 1: spoke has nothing → push.
-	first := decideAppKeySync("", false, false, 0, identity)
+	first := decideAppKeySync("", false, false, false, 0, identity)
 	if !first.Push {
 		t.Fatal("first beat should push to a spoke with no key")
 	}
@@ -307,7 +375,7 @@ func TestDecideAppKeySyncIsIdempotent(t *testing.T) {
 	}
 	// Beat 2: spoke now reports the delivered key → no push, forever after.
 	for beat := 2; beat <= 5; beat++ {
-		d := decideAppKeySync(delivered, false, false, 0, identity)
+		d := decideAppKeySync(delivered, false, false, false, 0, identity)
 		if d.Push {
 			t.Fatalf("beat %d re-pushed a key the spoke already holds", beat)
 		}
@@ -746,7 +814,7 @@ func TestClusterKeyNeverSerializedIntoAPIPayload(t *testing.T) {
 			Fingerprint: identity.Fingerprint,
 		},
 		// The decision record that feeds every log line.
-		"appKeySyncDecision": decideAppKeySync("sha256:00000000000000000000000000000000", false, false, 0, identity),
+		"appKeySyncDecision": decideAppKeySync("sha256:00000000000000000000000000000000", false, false, false, 0, identity),
 	}
 
 	for name, payload := range payloads {


### PR DESCRIPTION
> A GHE hive's **Install GitHub App** button led to `github.ibm.com/github-apps/kubestellar-hive/installations/new` — a GitHub **404**. The user concluded the product was broken.

`kubestellar-hive` is the **github.com** App slug. GitHub Enterprise hosts a *separate* App registry (ID `5686` on `github.ibm.com`), so that URL names an app that does not exist on that host.

## Three defects had to line up

**1. `AppInstallURL()` fell back to the public default on a GHE host** — `config.go`

`DefaultGitHubAppSlug` names the App registered on github.com. Falling back to it on an enterprise host emits a link to an App that provably does not exist there. It now returns `""` for a GHE host with no configured slug, and the dashboard says *"Install link unavailable for this GitHub host"* naming the missing config.

A dead link is worse than no link — it reads as "this product is broken". Public github.com keeps the default, where it is correct by construction.

**2. The hub refused to repair a cross-forge `app_id`** — `cluster_app_key.go`

`decideAppKeySync` treats a spoke whose `app_id` differs from its cluster's as a deliberate pin (`appKeyReasonDifferentApp`). That is right when both Apps live on the **same forge** — but an App ID is only meaningful on the host that issued it. A github.com `app_id` names **nothing** on `github.ibm.com`. That pairing is not a configuration choice; it is broken in exactly the way the placeholder sentinel is, and it is the state a forge migration leaves behind.

`appKeyReasonWrongForgeApp` repairs it, decided *before* the per-hive-key shield (a stranded hive typically holds a per-hive key for the other forge's App and would otherwise never be reached). Gated narrowly on three facts: the cluster declares a GHE base URL, the hive is **not** public-pinned, and the spoke reports a **positive, differing** `app_id`. Zero — too old to report — stays conservative; silence is not evidence of a fault.

**3. The spoke never persisted the identity it adopted** — `cmd/hive/main.go`

The heartbeat callback set `app_id`/`app_slug` on the in-memory config but, unlike the claimed-project-config callback *directly beside it*, never called `cfg.Save()`. Key files land on the PVC; these fields did not. Every pod restart re-merged the ConfigMap seed and silently reverted a completed repair — making the hub's push look like it had never happened, which is why this looked unfixable from the hub side.

## No App ID or slug is hardcoded in Go

`ClusterConfig.GitHubAppSlug` already existed (`saas_provision.go:165`) carrying a comment warning that a GHE registration *"is rarely named kubestellar-hive"*. The mechanism was built and simply never populated. The value belongs in `/data/saas/clusters.json` and is set there for the `vllm-d` cluster — which fixes **every** GHE hive on it, present and future, not one.

## Tests

Cross-forge repair fires for a stranded hive; is **idempotent** once adopted (the push stops); and does **not** fire on an unknown `app_id`, on a same-forge deliberate pin, or for a hive pinned to public github.com on a GHE cluster. The install-URL table now locks *"no slug on GHE means no link"*, including a whitespace-only slug.

`pkg/hub` and `pkg/config` suites pass. `pkg/dashboard` shows 18 failures **both with and without** this change — pre-existing and unrelated (verified by stashing).

`saas.go` is **not touched**, so its inline raw-string `dashboardHTML` is unaffected. The edited dashboard JS extracts and passes `node --check`.

## Relationship to the forge switcher (#2360)

**Complementary, not duplicated.** #2360 builds the operator-facing switch and swaps App **ID** + base/api URL, resolving identity from `clusters.json` only. It deliberately does **not** address the **slug**, and the slug is what produces the 404.

This PR is the other half:
- it makes the **install link** correct per forge, and legible when it cannot be;
- it lets the hub **repair** a hive already stranded on the wrong forge's App (#2360 governs deliberate switches going forward; this recovers the ones that already drifted);
- it makes any adopted identity **survive a pod restart** — without which #2360's delivery would also revert on the next restart.

The two touch `cluster_app_key.go` / `saas_provision.go` from different angles; **#2360 should merge first** and I will rebase. Also adjacent: **#2358** (install-ID hover hint deriving host per forge) — no overlapping lines.

## Live systems

Applied to **one** hive only, `hosted-available-vllmd-03`, via the **real heartbeat code path** — no spoke state was hand-edited. Adding `github_app_slug` to the `vllm-d` cluster entry was sufficient for the existing push to deliver it:

```
app_id:          3568013  ->  5686
app_slug:        ""       ->  kubestellar-hive-ghe
```

`installation_id` left at `0` deliberately — the owner installs the App and supplies it. No key material left the cluster; fingerprints only.

**Fleet scope:** 10 GHE hives carry a wrong or empty slug and several carry the github.com `app_id`. That blast radius is reported in-thread for the owner to approve before anything else is touched.