### PR TITLE
🐛 fix(github): never read PR mergeability from the list endpoint

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -3981,6 +3981,22 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 const mergeEligiblePath = "/var/run/hive-metrics/merge-eligible.json"
 const ciFailingPath = "/var/run/hive-metrics/ci-failing.json"
 
+// mergeableJSONUnknown is the explicit wire value for "mergeability was never
+// determined". It is spelled out rather than left as "" so a consumer reading
+// merge-eligible.json cannot mistake an unpopulated field for a definitive
+// "no" — the failure mode that made every PR read as unmergeable.
+const mergeableJSONUnknown = "unknown"
+
+// mergeableJSON renders a tri-state mergeability verdict for the
+// merge-eligible.json marker, mapping the unknown zero value to an explicit
+// "unknown" rather than an empty string.
+func mergeableJSON(m github.Mergeable) string {
+	if m == github.MergeableUnknown {
+		return mergeableJSONUnknown
+	}
+	return string(m)
+}
+
 // claimLedger holds the duplicate-PR guard's persisted issue→PR claim mapping
 // across eval cycles. It is loaded lazily on first use (and retried on a load
 // failure) rather than at startup, so a missing or corrupt /data ledger can
@@ -4037,13 +4053,16 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 	}
 
 	type eligiblePR struct {
-		Number    int      `json:"number"`
-		Repo      string   `json:"repo"`
-		Title     string   `json:"title"`
-		Author    string   `json:"author"`
-		Labels    []string `json:"labels,omitempty"`
-		Mergeable bool     `json:"mergeable"`
-		DCO       string   `json:"dco"`
+		Number int      `json:"number"`
+		Repo   string   `json:"repo"`
+		Title  string   `json:"title"`
+		Author string   `json:"author"`
+		Labels []string `json:"labels,omitempty"`
+		// Mergeable is a tri-state string ("yes"/"no"/"unknown"), not a bool.
+		// A bool here defaulted to false for every PR, because the value was
+		// read from a list endpoint that never returns it.
+		Mergeable string `json:"mergeable"`
+		DCO       string `json:"dco"`
 	}
 
 	type failingPR struct {
@@ -4094,7 +4113,7 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 			Title:     pr.Title,
 			Author:    pr.Author,
 			Labels:    pr.Labels,
-			Mergeable: pr.Mergeable,
+			Mergeable: mergeableJSON(pr.Mergeable),
 			DCO:       dco,
 		})
 	}

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -80,18 +80,66 @@ type PullRequest struct {
 	Draft     bool      `json:"draft"`
 	CreatedAt time.Time `json:"created_at"`
 	URL       string    `json:"url"`
-	Mergeable bool      `json:"mergeable"`
+	// Mergeable is a tri-state: MergeableYes, MergeableNo, or MergeableUnknown.
+	// It is intentionally NOT a bool: a bool zero-values to false, which is
+	// indistinguishable from "GitHub says this PR cannot be merged" and would
+	// silently gate every PR shut whenever the value was never populated.
+	// The zero value is MergeableUnknown ("") so an unfilled field reads as
+	// "we do not know" rather than a false negative.
+	Mergeable Mergeable `json:"mergeable"`
 	CIStatus  string    `json:"ci_status"`
 	HeadSHA   string    `json:"head_sha,omitempty"`
 }
 
+// Mergeable is a tri-state mergeability verdict for a pull request.
+type Mergeable string
+
+const (
+	// MergeableUnknown is the zero value: mergeability has not been determined.
+	// Consumers gating a merge MUST treat this as "do not know", never as "no".
+	MergeableUnknown Mergeable = ""
+	// MergeableYes means GitHub reports the PR can be merged.
+	MergeableYes Mergeable = "yes"
+	// MergeableNo means GitHub reports the PR cannot be merged (conflicts, etc).
+	MergeableNo Mergeable = "no"
+)
+
+// mergeableFromState maps a GitHub mergeable_state to a tri-state verdict.
+//
+// mergeable_state is used in preference to the raw "mergeable" bool because
+// this project's standing policy ignores non-required checks (Playwright,
+// tide). GitHub reports "unstable" when the PR is cleanly mergeable but some
+// non-required check is pending or failing — that still counts as mergeable.
+//
+// Reference: "clean" and "has_hooks" are fully green; "unstable" is mergeable
+// with non-required checks outstanding; "blocked" means a required review or
+// status is missing; "dirty" means conflicts; "unknown" means GitHub is still
+// computing the merge commit in the background.
+func mergeableFromState(state string, mergeable *bool) Mergeable {
+	switch state {
+	case "clean", "has_hooks", "unstable":
+		return MergeableYes
+	case "dirty", "blocked", "behind", "draft":
+		return MergeableNo
+	}
+	// "unknown" (or an unrecognised state): GitHub is still computing.
+	// Fall back to the raw bool only when it was actually present.
+	if mergeable != nil {
+		if *mergeable {
+			return MergeableYes
+		}
+		return MergeableNo
+	}
+	return MergeableUnknown
+}
+
 type ActionableResult struct {
-	GeneratedAt   time.Time          `json:"generated_at"`
-	Issues        IssueResult        `json:"issues"`
-	PRs           PRResult           `json:"prs"`
-	Hold          HoldResult         `json:"hold"`
-	Clusters      []IssueCluster     `json:"clusters,omitempty"`
-	TotalByRepo   map[string]RepoCounts `json:"total_by_repo,omitempty"`
+	GeneratedAt time.Time             `json:"generated_at"`
+	Issues      IssueResult           `json:"issues"`
+	PRs         PRResult              `json:"prs"`
+	Hold        HoldResult            `json:"hold"`
+	Clusters    []IssueCluster        `json:"clusters,omitempty"`
+	TotalByRepo map[string]RepoCounts `json:"total_by_repo,omitempty"`
 }
 
 type RepoCounts struct {
@@ -111,10 +159,10 @@ type PRResult struct {
 }
 
 type HoldResult struct {
-	Issues int         `json:"issues"`
-	PRs    int         `json:"prs"`
-	Total  int         `json:"total"`
-	Items  []HoldItem  `json:"items"`
+	Issues int        `json:"issues"`
+	PRs    int        `json:"prs"`
+	Total  int        `json:"total"`
+	Items  []HoldItem `json:"items"`
 }
 
 type HoldItem struct {
@@ -420,8 +468,12 @@ func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRe
 			Draft:     pr.GetDraft(),
 			CreatedAt: pr.GetCreatedAt().Time,
 			URL:       pr.GetHTMLURL(),
-			Mergeable: pr.GetMergeable(),
-			HeadSHA:   headSHA,
+			// Mergeable is deliberately NOT set here. The PullRequests.List
+			// endpoint never populates "mergeable" — GitHub computes it
+			// per-PR and returns it only from the single-PR GET. Reading it
+			// here would yield false for every PR. EnrichCIStatus fills it in
+			// from a per-PR fetch; until then it stays MergeableUnknown.
+			HeadSHA: headSHA,
 		})
 	}
 
@@ -445,6 +497,18 @@ func (c *Client) EnrichCIStatus(ctx context.Context, prs []PullRequest) {
 			continue
 		}
 		owner, repoName := c.splitRepo(prs[i].Repo)
+
+		// Fetch the PR individually to learn its mergeability. The list
+		// endpoint that produced these PullRequests never populates
+		// "mergeable"/"mergeable_state" — GitHub computes them per-PR and
+		// returns them only from this single-PR GET. On error we leave the
+		// field as MergeableUnknown rather than guessing.
+		if full, _, err := c.client.PullRequests.Get(ctx, owner, repoName, prs[i].Number); err != nil {
+			c.logger.Warn("failed to fetch PR mergeability", "repo", prs[i].Repo, "pr", prs[i].Number, "error", err)
+		} else {
+			prs[i].Mergeable = mergeableFromState(full.GetMergeableState(), full.Mergeable)
+		}
+
 		checkRuns, _, err := c.client.Checks.ListCheckRunsForRef(ctx, owner, repoName, prs[i].HeadSHA, &gh.ListCheckRunsOptions{
 			ListOptions: gh.ListOptions{PerPage: 100},
 		})

--- a/v2/pkg/github/client_test.go
+++ b/v2/pkg/github/client_test.go
@@ -488,8 +488,12 @@ func TestFetchPRs_PRFields(t *testing.T) {
 	if pr.Repo != repo {
 		t.Errorf("PR Repo = %q, want %q", pr.Repo, repo)
 	}
-	if !pr.Mergeable {
-		t.Error("PR Mergeable should be true")
+	// Mergeability is NOT read from the list endpoint: GitHub never populates
+	// "mergeable" there. It stays MergeableUnknown until EnrichCIStatus fills
+	// it in from a per-PR GET. (This assertion previously expected true, which
+	// only held because the fixture supplied a field the real API omits.)
+	if pr.Mergeable != MergeableUnknown {
+		t.Errorf("PR Mergeable = %q, want MergeableUnknown from a list response", pr.Mergeable)
 	}
 }
 

--- a/v2/pkg/github/mergeable_test.go
+++ b/v2/pkg/github/mergeable_test.go
@@ -1,0 +1,183 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The bug these tests pin down:
+//
+// listActionablePRs used to set Mergeable from pr.GetMergeable() on a
+// PullRequests.List response. GitHub never populates "mergeable" on the list
+// endpoint — it is computed per-PR and returned only by the single-PR GET —
+// so GetMergeable() read a nil pointer and returned false for every PR. The
+// field was a bool, so "never populated" and "GitHub says no" were the same
+// value, and merge-eligible.json reported every PR as unmergeable forever.
+
+// TestMergeableZeroValueIsUnknown is the guard that makes the failure loud.
+// If Mergeable is ever reverted to a bool, its zero value becomes false —
+// a definitive "not mergeable" — and this test fails.
+func TestMergeableZeroValueIsUnknown(t *testing.T) {
+	var pr PullRequest
+	if pr.Mergeable != MergeableUnknown {
+		t.Fatalf("zero-value Mergeable = %q, want MergeableUnknown", pr.Mergeable)
+	}
+	if pr.Mergeable == MergeableNo {
+		t.Fatal("zero-value Mergeable must never equal MergeableNo: an unpopulated field would silently gate every PR shut")
+	}
+}
+
+// TestMergeableFromState covers the mapping, most importantly that UNSTABLE
+// counts as mergeable — this project ignores non-required checks (Playwright,
+// tide), and GitHub reports "unstable" exactly when the PR is cleanly
+// mergeable but such a check is outstanding.
+func TestMergeableFromState(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+
+	tests := []struct {
+		name  string
+		state string
+		raw   *bool
+		want  Mergeable
+	}{
+		{"unstable counts as mergeable", "unstable", boolPtr(true), MergeableYes},
+		{"unstable mergeable even if raw bool absent", "unstable", nil, MergeableYes},
+		{"clean is mergeable", "clean", boolPtr(true), MergeableYes},
+		{"has_hooks is mergeable", "has_hooks", boolPtr(true), MergeableYes},
+		{"dirty is not mergeable", "dirty", boolPtr(false), MergeableNo},
+		{"blocked is not mergeable", "blocked", boolPtr(false), MergeableNo},
+		{"behind is not mergeable", "behind", nil, MergeableNo},
+		{"unknown state with no raw bool is unknown", "unknown", nil, MergeableUnknown},
+		{"empty state with no raw bool is unknown", "", nil, MergeableUnknown},
+		{"unknown state falls back to raw true", "unknown", boolPtr(true), MergeableYes},
+		{"unknown state falls back to raw false", "unknown", boolPtr(false), MergeableNo},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mergeableFromState(tt.state, tt.raw); got != tt.want {
+				t.Errorf("mergeableFromState(%q, %v) = %q, want %q", tt.state, tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEnrichCIStatus_PopulatesMergeableFromSinglePRGet is the regression test
+// that would have caught the original bug. The fake list endpoint omits
+// "mergeable" exactly as GitHub does; only the single-PR GET supplies it. A
+// build that reads mergeability from the list response leaves this at
+// MergeableUnknown and the test fails.
+func TestEnrichCIStatus_PopulatesMergeableFromSinglePRGet(t *testing.T) {
+	var singleGetCalls int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		// Single-PR GET: the ONLY endpoint that returns mergeable state.
+		case strings.HasSuffix(r.URL.Path, "/pulls/1"):
+			singleGetCalls++
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"number":          1,
+				"mergeable":       true,
+				"mergeable_state": "unstable",
+			})
+		case strings.Contains(r.URL.Path, "/check-runs"):
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"total_count": 1,
+				"check_runs": []map[string]interface{}{
+					{"name": "build", "status": "completed", "conclusion": "success"},
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server, "org", []string{"repo"})
+	prs := []PullRequest{{Repo: "org/repo", Number: 1, HeadSHA: "abc123"}}
+	c.EnrichCIStatus(context.Background(), prs)
+
+	if singleGetCalls == 0 {
+		t.Fatal("EnrichCIStatus never issued the single-PR GET; mergeability cannot come from the list endpoint")
+	}
+	if prs[0].Mergeable != MergeableYes {
+		t.Errorf("Mergeable = %q, want %q (mergeable_state=unstable must count as mergeable)", prs[0].Mergeable, MergeableYes)
+	}
+	if prs[0].CIStatus != "success" {
+		t.Errorf("CIStatus = %q, want success", prs[0].CIStatus)
+	}
+}
+
+// A dirty PR must come back as a definitive "no".
+func TestEnrichCIStatus_MergeableDirtyIsNo(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/pulls/1"):
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"number": 1, "mergeable": false, "mergeable_state": "dirty",
+			})
+		case strings.Contains(r.URL.Path, "/check-runs"):
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"total_count": 1,
+				"check_runs": []map[string]interface{}{
+					{"name": "build", "status": "completed", "conclusion": "success"},
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server, "org", []string{"repo"})
+	prs := []PullRequest{{Repo: "org/repo", Number: 1, HeadSHA: "abc123"}}
+	c.EnrichCIStatus(context.Background(), prs)
+
+	if prs[0].Mergeable != MergeableNo {
+		t.Errorf("Mergeable = %q, want %q for a dirty PR", prs[0].Mergeable, MergeableNo)
+	}
+}
+
+// When the single-PR GET fails we must stay at Unknown, never fabricate "no".
+func TestEnrichCIStatus_MergeableUnknownOnFetchError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/check-runs") {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"total_count": 1,
+				"check_runs": []map[string]interface{}{
+					{"name": "build", "status": "completed", "conclusion": "success"},
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server, "org", []string{"repo"})
+	prs := []PullRequest{{Repo: "org/repo", Number: 1, HeadSHA: "abc123"}}
+	c.EnrichCIStatus(context.Background(), prs)
+
+	if prs[0].Mergeable != MergeableUnknown {
+		t.Errorf("Mergeable = %q, want %q when the mergeability fetch fails", prs[0].Mergeable, MergeableUnknown)
+	}
+}
+
+// The JSON wire form must round-trip as a string, not a bool. This pins the
+// marker contract so a consumer can distinguish "unknown" from "no".
+func TestMergeableJSONWireFormat(t *testing.T) {
+	data, err := json.Marshal(PullRequest{Number: 1, Mergeable: MergeableYes})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"mergeable":"yes"`) {
+		t.Errorf("marshalled PR = %s, want mergeable as the string \"yes\"", data)
+	}
+	if strings.Contains(string(data), `"mergeable":false`) {
+		t.Error("mergeable serialised as a bool: unknown and no are indistinguishable again")
+	}
+}


### PR DESCRIPTION
## Problem

`v2/pkg/github/client.go:423` set `Mergeable: pr.GetMergeable()` from a `PullRequests.List` response. **GitHub's list endpoint never populates `mergeable`** — it is computed per-PR and returned only by the single-PR GET. `GetMergeable()` on the resulting nil pointer returns `false`, so every entry in `/var/run/hive-metrics/merge-eligible.json` read `"mergeable": false`, including PRs GitHub reports as cleanly mergeable.

Verified against the live API:

```
GET /repos/kubestellar/console/pulls?state=open  → mergeable=null for all
GET /repos/kubestellar/console/pulls/22110       → mergeable=true, mergeable_state=unstable
```

…while the live marker on the running hive said:

```json
{"number":22110, ... ,"mergeable":false,"dco":"yes"}
```

Nothing reads the field today (`scheduler.go` unmarshals only `number`/`repo`/`title`), so this is **latent, not the current blocker**. But the marker's documented contract is "CI green, AI-authored, mergeable", and any consumer that started honoring it would see zero eligible PRs forever.

## Fix — populate it correctly, and make the failure loud

I chose to populate rather than drop the field: the marker's contract advertises mergeability, and `EnrichCIStatus` already does a per-PR pass, so the correct value costs no extra round trip beyond one GET.

The deeper problem was the **type**. A `bool` zero-values to `false`, so "never populated" and "GitHub says no" were literally the same value — a boolean that gates merging and is wrong-by-default, failing silently. So:

- `Mergeable` becomes a tri-state (`yes`/`no`/`unknown`) whose zero value is `MergeableUnknown`. An unpopulated field can no longer masquerade as a definitive "not mergeable", and the type change surfaces every consumer at **compile time**.
- Populated in `EnrichCIStatus` via the single-PR GET that actually returns the field. On fetch error it stays `unknown` rather than guessing.
- Decided from **`mergeable_state`**, not the raw bool: `UNSTABLE` counts as mergeable, because this project's standing policy ignores non-required checks (Playwright, `tide`). GitHub reports `unstable` exactly when a PR is cleanly mergeable but such a check is outstanding — the raw bool would have been correct-but-useless.
- `merge-eligible.json` emits an explicit `"unknown"` rather than `""`, so a consumer cannot mistake absence for a "no".

## Tests

New `v2/pkg/github/mergeable_test.go`, **mutation-verified** — each of these fails the suite:

| Mutation | Caught by |
|---|---|
| Revert to reading mergeability from the list endpoint (the original bug) | `never issued the single-PR GET` / dirty PR reads `""` |
| Treat `UNSTABLE` as not-mergeable | `mergeableFromState("unstable") = "no", want "yes"` |
| Fabricate `no` on fetch error | `Mergeable = "no", want ""` |

`TestMergeableZeroValueIsUnknown` guards the type itself: revert `Mergeable` to a `bool` and it fails.

One existing assertion in `client_test.go` expected `Mergeable == true` from a list response. It passed only because its fixture supplied a field the real API omits — it asserted the buggy behavior — so it is corrected to encode the true contract.

`go build ./...` and `pkg/github`, `pkg/scheduler`, `pkg/governor` tests pass locally; CI is the gate.