### PR TITLE
🐛 fix(dashboard): cost chart renders empty because spend is billed to observation time

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1147,6 +1147,11 @@
     .cost-bar { flex: 1 1 0; min-width: 2px; background: var(--green); border-radius: 2px 2px 0 0; opacity: 0.8; transition: opacity 0.1s; align-self: flex-end; }
     .cost-bar:hover { opacity: 1; }
     .cost-bar.zero { background: rgba(128,128,128,0.25); }
+    .cost-bars-wrap { position: relative; }
+    /* Centered over the flat bars when a covered window really did spend $0, so
+       empty axes never read as a failed render. */
+    .cost-bars-note { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+      font-size: 0.62rem; color: var(--muted); font-style: italic; pointer-events: none; }
     .cost-bars-axis { display: flex; justify-content: space-between; font-size: 0.58rem; color: var(--muted); font-family: var(--font-mono); margin-top: 3px; }
     .cost-trend-empty { font-size: 0.66rem; color: var(--muted); font-style: italic; padding: 8px 0; }
 
@@ -4359,9 +4364,21 @@
       // one-time re-seed jump against the same baseline (a bucket holding only
       // the spike has no local typical of its own).
       const ceiling = costDiscontinuityCeiling(hist, rate);
+      // Spread each increment across the interval it accrued over rather than
+      // billing it to the instant it was observed — otherwise a bucket narrower
+      // than the observation cadence (notably every hourly bucket) reads $0 even
+      // while agents were working. See COST_ACCRUAL_* above.
+      const spans = costAccrualSpans(hist, rate);
       for (const b of buckets) {
-        const s = costSpendBetween(hist, rate, b.start, b.end, ceiling);
-        if (s != null) { b.spend = s; b.hasData = true; }
+        // Coverage, not spend, decides hasData: a bucket the history actually
+        // spans is a real $0 (nothing ran), whereas a bucket outside the
+        // recorded range is genuinely unknown. Keeping these distinct is what
+        // lets the empty state say which one it is.
+        const covered = costSpendBetween(hist, rate, b.start, b.end, ceiling) != null
+          || spans.some(s => s.to > b.start && s.from < b.end);
+        if (!covered) continue;
+        b.spend = costSpreadSpendBetween(spans, b.start, b.end, ceiling);
+        b.hasData = true;
       }
       return buckets;
     }
@@ -4430,6 +4447,46 @@
     // spend never trips it, while a ~$18k all-time restore obviously does.
     const COST_DISCONTINUITY_FLOOR_USD = 500;
 
+    // ── Accrual spreading ──────────────────────────────────────────────────
+    // The cumulative token counter does NOT rise smoothly as agents work: the
+    // scanner only observes a session's tokens once that session's transcript
+    // is flushed, so the counter sits flat for hours and then jumps by the whole
+    // session at once. Observed on a live spoke: 285 snapshots over 6.5 days
+    // produced just 4 increases, spaced a median of ~8.5h apart.
+    //
+    // Attributing a jump to the single instant it was OBSERVED is wrong twice
+    // over: the one bucket containing that instant gets the entire session's
+    // spend, and every other bucket reads $0 even though agents were busy. For
+    // an hourly view (24 one-hour buckets) that means the chart is blank unless
+    // the viewer happens to load it within an hour of an observation — which is
+    // exactly the reported "I see data there once in a while".
+    //
+    // Fix: treat an increment as spend that accrued EVENLY across the interval
+    // between the previous observation and this one, and bill each bucket the
+    // overlapping fraction. Totals are unchanged (every dollar is still counted
+    // exactly once); they are simply placed where the work happened rather than
+    // where it was noticed.
+    //
+    // How far back an increment may be spread is bounded by RECORDED LIVENESS,
+    // not by a fixed wall-clock limit. Spreading should follow the interval the
+    // hive was actually up and sampling: if snapshots kept arriving every ~5 min
+    // while the counter sat flat, the hive was alive and agents plausibly
+    // working the whole time, so the spend belongs across all of it. If instead
+    // the snapshots themselves stop, the hive was down — no work happened, and
+    // smearing spend across that dead air would invent activity.
+    //
+    // A gap between consecutive SNAPSHOTS longer than this means the sampler
+    // wasn't running (it records every ~5 min, so a few missed cycles is normal
+    // jitter but a long silence is an outage/restart). Spreading is cut at the
+    // most recent such silence.
+    const COST_ACCRUAL_LIVENESS_GAP_MS = 30 * 60e3; // 30 minutes
+    // Absolute backstop so a hive that sampled continuously for weeks while the
+    // counter never moved still can't smear one jump across the entire chart.
+    const COST_ACCRUAL_MAX_SPREAD_MS = 24 * 3600e3; // 24 hours
+    // An interval shorter than this is treated as instantaneous — no meaningful
+    // spreading to do, and it keeps back-to-back snapshots cheap to compute.
+    const COST_ACCRUAL_MIN_SPREAD_MS = 60e3; // 1 minute
+
     // costPositiveIncrements: the list of POSITIVE step-to-step increments over
     // [t0, t1], differenced only within a like measure (see costSpendBetween).
     // Shared by the spend sum and the discontinuity ceiling so both judge the
@@ -4452,6 +4509,73 @@
         prev = cur; prevKind = kind;
       }
       return { incs, sawWindow };
+    }
+
+    // costAccrualSpans: every POSITIVE increment in the WHOLE history, each
+    // tagged with the interval [from, to] it is presumed to have accrued over —
+    // i.e. from the previous observation to the one that revealed it. See the
+    // COST_ACCRUAL_* notes above for why observation time ≠ spend time.
+    //
+    // Deliberately walks the entire series rather than a window: an increment
+    // observed just AFTER a bucket ends may still have accrued largely INSIDE
+    // it, and one observed inside a bucket may have started well before it.
+    // Windowing first would drop exactly the spans that need splitting.
+    function costAccrualSpans(hist, rate) {
+      const pricedTok = (models) => {
+        let s = 0;
+        for (const k in models) { const m = models[k]; s += ((m.i || 0) + (m.o || 0)) * (rate[k] || 0); }
+        return s;
+      };
+      const spans = [];
+      // Timestamps of every usable snapshot, in order, so an increment can walk
+      // back over the stretch the sampler was demonstrably alive.
+      const stamps = [];
+      let prev = null, prevKind = null;
+      for (const e of (hist || [])) {
+        const kind = e.models ? 'm' : (typeof e.usd === 'number' ? 'u' : null);
+        if (kind == null) continue;
+        const cur = kind === 'm' ? pricedTok(e.models) : e.usd;
+        if (prev != null && kind === prevKind && cur > prev) {
+          // Walk back while snapshots stayed dense: that is the stretch the hive
+          // was up and this spend could have been accruing. Stop at the first
+          // long silence (outage/restart) so spend never smears across dead air.
+          let from = e.timestamp;
+          for (let i = stamps.length - 1; i > 0; i--) {
+            if (stamps[i] - stamps[i - 1] > COST_ACCRUAL_LIVENESS_GAP_MS) break;
+            from = stamps[i - 1];
+            if (e.timestamp - from >= COST_ACCRUAL_MAX_SPREAD_MS) break;
+          }
+          from = Math.max(from, e.timestamp - COST_ACCRUAL_MAX_SPREAD_MS);
+          spans.push({ amount: cur - prev, from, to: e.timestamp });
+        }
+        prev = cur; prevKind = kind;
+        stamps.push(e.timestamp);
+      }
+      return spans;
+    }
+
+    // costSpreadSpendBetween: estimated $ that accrued inside [t0, t1], billing
+    // each increment the fraction of its accrual interval that overlaps the
+    // bucket. An increment whose interval is shorter than
+    // COST_ACCRUAL_MIN_SPREAD_MS is treated as a point event at its observation
+    // time. Increments above `cap` are dropped as data corrections, exactly as
+    // in costSpendBetween.
+    function costSpreadSpendBetween(spans, t0, t1, cap) {
+      const ceil = (typeof cap === 'number') ? cap : Infinity;
+      let spend = 0;
+      for (const s of (spans || [])) {
+        if (s.amount > ceil) continue;
+        const span = s.to - s.from;
+        if (span < COST_ACCRUAL_MIN_SPREAD_MS) {
+          // Point event: bill it entirely to the bucket containing it.
+          if (s.to > t0 && s.to <= t1) spend += s.amount;
+          continue;
+        }
+        const lo = Math.max(s.from, t0), hi = Math.min(s.to, t1);
+        if (hi <= lo) continue;
+        spend += s.amount * ((hi - lo) / span);
+      }
+      return spend;
     }
 
     // costDiscontinuityCeiling: the $ threshold above which a single positive
@@ -4542,7 +4666,9 @@
 
       let body;
       if (!_costHistory || _costHistory.length < 2 || withData.length === 0) {
-        body = `<div class="cost-trend-empty">No cost history yet for this range — data accrues as agents run.</div>`;
+        // Nothing recorded anywhere in this window — distinct from "recorded and
+        // it was $0", which is handled by the overlay below.
+        body = `<div class="cost-trend-empty">No cost history recorded for this range — data accrues as agents run.</div>`;
       } else {
         const bars = buckets.map(b => {
           // All-zero windows still draw a 2% baseline so the chart reads as
@@ -4552,9 +4678,17 @@
           const tip = `${new Date(b.start).toLocaleString()} → ${new Date(b.end).toLocaleString()}: ${fmtUSD(b.spend)}`;
           return `<div class="${cls}" style="height:${h.toFixed(1)}%" title="${esc(tip)}"></div>`;
         }).join('');
+        // Bare axes with no visible series are indistinguishable from a broken
+        // chart. When the range IS covered by history but every bucket is $0,
+        // say so on top of the (flat) bars instead of leaving the reader to
+        // guess whether the panel failed to render.
+        const allZero = max <= 0;
+        const overlay = allZero
+          ? `<div class="cost-bars-note">no spend recorded in this window</div>`
+          : '';
         // Show first, middle, and last axis labels to avoid crowding.
         const first = buckets[0], mid = buckets[Math.floor(buckets.length / 2)], last = buckets[buckets.length - 1];
-        body = `<div class="cost-bars">${bars}</div>
+        body = `<div class="cost-bars-wrap"><div class="cost-bars">${bars}</div>${overlay}</div>
           <div class="cost-bars-axis"><span>${esc(costBucketAxisLabel(first))}</span><span>${esc(costBucketAxisLabel(mid))}</span><span>${esc(costBucketAxisLabel(last))}</span></div>`;
       }
 


### PR DESCRIPTION
## The report

> i know that the cost graph is not working properly. I see data there once in a while.

The Cost panel header was fully populated ($22,383 total, a working sparkline, a run-rate) while the **main chart below the Hourly/Daily/Weekly/Monthly tabs showed only axis labels and gridlines** — no bars.

## Root cause

The cumulative token counter **does not rise smoothly as agents work**. The scanner only observes a session's tokens once that session's transcript is flushed, so the counter sits flat for hours and then jumps by the whole session at once.

Measured against a live spoke (`hive-hosted-hosted-projectbluefin-knuckle-gjvq`, read-only): **285 snapshots over 6.5 days produced just 4 increases**, spaced a median of **~8.5h** apart.

`costBuckets()` billed each increase to the single instant it was **observed**. With 24 one-hour buckets in the hourly view, at most one bucket could ever be non-zero and the other 23 read `$0`.

### Why "once in a while"

The hourly chart could only show anything if the viewer loaded it within an hour of one of those 4 observations. Replayed against the real history across 168 hypothetical viewing times: **the chart was non-empty only 29% of the time**. That is precisely the reported intermittency.

The header total and sparkline were unaffected because `costSparkSvg()` plots the **raw cumulative** `e.usd` — a rising staircase that always renders. Only the per-bucket **delta** path was broken. The estimate and actual (OpenRouter) series are separate code paths; only the estimate feeds this chart.

## The fix

Spread each increment across the interval it **accrued** over rather than the instant it surfaced.

How far back an increment may spread is bounded by **recorded liveness**, not a fixed wall-clock limit:
- walk back while snapshots stayed dense — the hive was up and sampling, so agents were plausibly working the whole time;
- stop at the first long silence (`COST_ACCRUAL_LIVENESS_GAP_MS`, 30 min) — the sampler wasn't running, so spend must not smear across dead air;
- `COST_ACCRUAL_MAX_SPREAD_MS` (24h) as an absolute backstop.

This distinction matters on the real data: one gap had 27 snapshots recorded through it (hive alive, counter flat → spread), another had **zero** (hive down → not spread).

**Dollars are conserved exactly** — $78.3956 gross increments vs $78.3956 re-summed across 20,000 fine slices.

## Results against live data

| tab | buckets with spend, before | after | total (unchanged) |
|---|---|---|---|
| hourly | **0** | **11** | — |
| daily | 3 | 3 | $78.40 |
| weekly | 1 | 1 | $78.40 |
| monthly | 1 | 1 | $78.40 |

Hourly was the broken tab; longer buckets were wide enough to contain an observation, so they already worked. Totals are untouched.

## Legible empty state

`hasData` was true whenever a snapshot merely *existed* in a bucket, so an all-zero window rendered **bare axes indistinguishable from a broken chart**. `hasData` now tracks coverage, and a covered-but-zero window renders **"no spend recorded in this window"** over the flat bars. Every viewing time is now legible: either bars, or a stated reason.

## Verification

- `node --check` on all extracted inline JS: **PASS**
- brace/paren/bracket delta vs `origin/v2`: **0 / 0 / 0**
- `go test ./pkg/dashboard/ -run Cost`: **ok**
- new `for...of` loops guarded with `(arr || [])`
- named constants with comments; no magic numbers
- single file changed; `saas.go` untouched

## Note for #2329 / #2324

Cost history **is persisted**, not memory-only — written to `/data/cost-history.json` on the PVC (`v2/cmd/hive/main.go:3986`) and restored via `SeedCostHistory` on startup (`main.go:1054`). So today's restarts are not the cause here, and this bug is independent of the volatile-counter class of issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)