### PR TITLE
🐛 fix(proxy): identify agents from the connection, not the parsed request

### DIFF
--- a/v2/pkg/proxy/agent_identification_test.go
+++ b/v2/pkg/proxy/agent_identification_test.go
@@ -1,0 +1,143 @@
+package proxy
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/agent"
+)
+
+// agentUIDFixture is the UID the fake /proc/net/tcp table attributes the
+// agent's socket to, and the UID the fake uid map resolves to "scanner".
+const agentUIDFixture = 2007
+
+// writeProcNetFixture points the procnet parser at a synthetic socket table in
+// which localPort is owned by agentUIDFixture, mirroring the real loopback
+// layout: the agent's socket (ephemeral local port -> proxy port) alongside the
+// proxy's own accepted socket for the same pair, owned by a different UID.
+func writeProcNetFixture(t *testing.T, localPort, proxyPort int) {
+	t.Helper()
+	header := "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n"
+	// Row 0: the proxy's accepted socket, owned by the proxy UID (1001).
+	// Row 1: the agent's socket, owned by the agent UID — the one to find.
+	rows := fmt.Sprintf(
+		"   0: 0100007F:%04X 0100007F:%04X 01 00000000:00000000 00:00000000 00000000  1001        0 1 1\n"+
+			"   1: 0100007F:%04X 0100007F:%04X 01 00000000:00000000 00:00000000 00000000  %d        0 2 1\n",
+		proxyPort, localPort, localPort, proxyPort, agentUIDFixture)
+
+	dir := t.TempDir()
+	tcp4 := filepath.Join(dir, "tcp")
+	tcp6 := filepath.Join(dir, "tcp6")
+	if err := os.WriteFile(tcp4, []byte(header+rows), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tcp6, []byte(header), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	oldTCP, oldTCP6 := procNetTCPPath, procNetTCP6Path
+	procNetTCPPath, procNetTCP6Path = tcp4, tcp6
+	t.Cleanup(func() { procNetTCPPath, procNetTCP6Path = oldTCP, oldTCP6 })
+}
+
+// TestIdentifyAgentOnReadRequestConnection is the regression test for the
+// auto-merge outage: the CONNECT path parses its request with http.ReadRequest,
+// which — unlike http.Server — leaves Request.RemoteAddr EMPTY. Identifying the
+// agent from the request therefore found no UID, returned "", and every
+// write-capable agent was silently downgraded to ADVISORY and blocked.
+//
+// The test drives a real loopback connection so the peer address is real, then
+// asserts the agent is identified from a request whose RemoteAddr is empty
+// exactly as http.ReadRequest leaves it. Identifying from r.RemoteAddr fails
+// this test; identifying from the connection passes it.
+func TestIdentifyAgentOnReadRequestConnection(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	client, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	server, err := ln.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+
+	// From the proxy's side, the peer is the client's ephemeral port — the port
+	// the socket table attributes to the agent UID.
+	_, peerPortStr, err := net.SplitHostPort(server.RemoteAddr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var peerPort int
+	if _, err := fmt.Sscanf(peerPortStr, "%d", &peerPort); err != nil {
+		t.Fatal(err)
+	}
+	_, proxyPortStr, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var proxyPort int
+	if _, err := fmt.Sscanf(proxyPortStr, "%d", &proxyPort); err != nil {
+		t.Fatal(err)
+	}
+	writeProcNetFixture(t, peerPort, proxyPort)
+
+	p := &GitHubProxy{
+		uidMap: &agent.UIDMap{Agents: map[string]int{"scanner": agentUIDFixture}},
+		logger: slog.Default(),
+	}
+
+	// A request shaped exactly as http.ReadRequest produces it: no RemoteAddr,
+	// and no Proxy-Authorization header (agents do not send one).
+	req, err := http.NewRequest(http.MethodConnect, "https://api.github.com:443", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.RemoteAddr = ""
+
+	if got := p.identifyAgentFromConn(server, req); got != "scanner" {
+		t.Fatalf("agent not identified on the ReadRequest path: got %q, want %q. "+
+			"http.ReadRequest leaves RemoteAddr empty, so identification must come "+
+			"from the connection — otherwise every agent silently degrades to ADVISORY.", got, "scanner")
+	}
+
+	// Guard the trap itself: prove RemoteAddr really is unusable here, so a
+	// future refactor back to identifyAgentFromReq cannot look correct.
+	if got := p.identifyAgentFromReq(req); got != "" {
+		t.Fatalf("expected request-based identification to yield nothing with an empty RemoteAddr, got %q", got)
+	}
+}
+
+// TestUpdateBranchRequiresMergeMode covers the second half of the outage:
+// PUT .../update-branch matched no rule at all, so AllowedByMode fell through
+// to its deny-by-default and refused it at EVERY mode — including the trusted
+// ISSUES_PRS_MERGE tier that is supposed to land PRs.
+func TestUpdateBranchRequiresMergeMode(t *testing.T) {
+	const path = "/repos/kubestellar/console/pulls/22110/update-branch"
+
+	if !AllowedByMode(agent.ModeIssuesPRsMerge, "PUT", path) {
+		t.Error("ISSUES_PRS_MERGE must be allowed to update a PR branch — it is part of landing a PR")
+	}
+
+	// Anything below merge authority must still be refused.
+	for _, mode := range []agent.AgentMode{
+		agent.ModeAdvisory,
+		agent.ModeIssuesOnly,
+		agent.ModeIssuesAndPRs,
+	} {
+		if AllowedByMode(mode, "PUT", path) {
+			t.Errorf("mode %v must NOT be allowed to update a PR branch", mode)
+		}
+	}
+}

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -447,6 +447,22 @@ func (p *GitHubProxy) identifyAgentFromReq(r *http.Request) string {
 	return extractAgentName(r)
 }
 
+// identifyAgentFromConn identifies the calling agent for a request read off a
+// raw connection. It MUST be used instead of identifyAgentFromReq on any path
+// where the request came from http.ReadRequest rather than http.Server:
+// ReadRequest does not populate Request.RemoteAddr (only http.Server does), so
+// the UID lookup silently gets an empty address, finds no agent, and the caller
+// falls back to ADVISORY — downgrading every write-capable agent to read-only.
+// Taking the peer address from the connection itself removes that trap.
+func (p *GitHubProxy) identifyAgentFromConn(conn net.Conn, r *http.Request) string {
+	if p.uidMap != nil && conn != nil {
+		if name := p.identifyAgentByUID(conn.RemoteAddr().String()); name != "" {
+			return name
+		}
+	}
+	return extractAgentName(r)
+}
+
 // identifyAgentByUID reads /proc/net/tcp to find the UID of the process
 // that owns the socket connected to the proxy, then looks up the agent name.
 func (p *GitHubProxy) identifyAgentByUID(remoteAddr string) string {
@@ -479,7 +495,9 @@ func (p *GitHubProxy) handleConnectDirect(conn net.Conn, r *http.Request) {
 		host = r.Host
 	}
 
-	agentName := p.identifyAgentFromReq(r)
+	// Identify from the connection, NOT from r.RemoteAddr: this request came
+	// from http.ReadRequest, which leaves RemoteAddr empty.
+	agentName := p.identifyAgentFromConn(conn, r)
 
 	// Anthropic hosts with an inference route: reroute to self-hosted backend.
 	if IsAnthropicHost(host) {
@@ -585,6 +603,14 @@ func (p *GitHubProxy) proxyHTTP(client net.Conn, upstream net.Conn, agentName st
 			req.ContentLength = int64(len(body))
 		} else if !AllowedByMode(mode, req.Method, req.URL.Path) {
 			blocked = true
+			// An unidentified agent is silently treated as ADVISORY, which turns
+			// a permissions bug into an indistinguishable "policy denial". Say so
+			// loudly on writes: a write from an unknown caller means UID
+			// attribution failed, not that the agent lacks the mode.
+			if agentName == "" && writeMethods[req.Method] {
+				p.logger.Warn("proxy: agent could not be identified — defaulting to ADVISORY and blocking a write; UID attribution failed (check the uid map and /proc/net/tcp visibility), this is NOT an agent-mode misconfiguration",
+					"method", req.Method, "path", req.URL.Path)
+			}
 			// A hard-deny rule (e.g. direct PR creation) carries an agent-facing
 			// directive explaining the sanctioned alternative — surface it so the
 			// agent knows to use hive-open-pr rather than seeing only a mode error.

--- a/v2/pkg/proxy/rules.go
+++ b/v2/pkg/proxy/rules.go
@@ -97,6 +97,13 @@ var rules = []ProxyRule{
 	// Must come before the generic pulls PATCH/PUT rules.
 	{regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/\d+/merge$`), "PUT", agent.ModeIssuesPRsMerge},
 
+	// Updating a PR branch from its base is part of landing a PR: an
+	// auto-merging agent hits it whenever the base has moved on. Without a rule
+	// it matches nothing and AllowedByMode falls through to its deny-by-default,
+	// so it was refused even at ISSUES_PRS_MERGE. It is gated at the same level
+	// as the merge itself — it writes to the PR's head branch, nothing more.
+	{regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/\d+/update-branch$`), "PUT", agent.ModeIssuesPRsMerge},
+
 	// ── PR operations — ISSUES_AND_PRS and above ──
 	// NOTE: direct PR creation (POST /pulls) is NOT here — it is a HARD DENY for
 	// every mode, handled by denyRules below, so agents route through hive-open-pr


### PR DESCRIPTION
## Summary

Auto-merge was completely broken on hives at ACMM levels that grant it: **every write from every agent got a 403**, so zero PRs merged. On the console hive there were ~32 open PRs, nearly all `MERGEABLE`, and none landed.

**The 403 came from the hive's own proxy, not from GitHub.** Two plausible explanations were investigated first and both disproven — the GitHub App installation genuinely permits merging (`contents=write`, `pull_requests=write`, `repository_selection=all`), and `main` has no required reviews, no push restrictions, and no app allowlist.

## Root cause

`handleConnectDirect` identified the calling agent with `identifyAgentFromReq(r)` → `identifyAgentByUID(r.RemoteAddr)`. That request comes from `http.ReadRequest`, which — unlike `http.Server` — **does not populate `Request.RemoteAddr`**. So:

`RemoteAddr == ""` → `net.SplitHostPort` errors → no UID → `identifyAgentByUID` returns `""` → the `Proxy-Authorization` fallback also returns `""` (agents send no such header) → `readAgentMode("")` hits its empty-name guard → **`ModeAdvisory`**.

Every agent was silently downgraded to read-only regardless of its configured mode, and `AllowedByMode(ADVISORY, "PUT", ".../merge")` is false.

## Evidence (verified on a live hive, read-only)

The decisive discrimination was **409 vs 403**. Using the scanner's own scoped token, with a deliberately stale sha:

- **Direct to GitHub:** `PUT /repos/.../pulls/22110/merge` → **409** `"Head branch was modified"`. A token lacking merge permission returns 403 *before* sha validation, so this proves the token can merge.
- **Through the proxy, same token, same request:** → **403**
  ```
  ⛔ ACMM proxy:  (ADVISORY) blocked PUT /repos/.../pulls/22110/merge
  ```
  Note the **empty agent name** — the identification failure, visible directly. Reproduced three times identically.

Everything downstream was healthy, which is exactly why this presented as a permissions problem: the `trusted` tier is scoped correctly (`app.go` mints `issues/contents/pull_requests: write`), token delivery is correct (`dev:hive-scanner 0640`, pre-created), the uid map is correct, `/tmp/.hive-mode-scanner` reads `ISSUES_PRS_MERGE`, `/proc` has no `hidepid`, the agent's socket **is** visible to the proxy under its own UID, and the IPv6 attribution fix (#2127) is present and working. The UID lookup would have succeeded — it was simply never given a port.

The transparent-TLS path already did this correctly via `conn.RemoteAddr()`. Only the explicit-CONNECT path was affected — and it carries **all** agent traffic wherever iptables redirection is inactive (`iptables_active: false`).

## Second fix, same symptom

`PUT /repos/{o}/{r}/pulls/{n}/update-branch` matched **no rule at all**, so `AllowedByMode` fell through to its deny-by-default and refused it at **every** mode, including `ISSUES_PRS_MERGE`:

```
PUT .../merge          trusted=true   advisory=false
PUT .../update-branch  trusted=false  advisory=false   <- blocked even at trusted
```

An auto-merging agent hits this whenever the base branch has moved on, so it would still have failed after the identification fix. It is now gated at the same level as the merge itself — it writes to the PR's head branch, nothing more.

## The silent-downgrade question — a deliberate recommendation

Added a `WARN` naming the method and path when an unidentified agent is blocked on a write. The silent fallback to ADVISORY is precisely what disguised an attribution bug as a policy denial.

**Should an unidentifiable agent fail closed instead of masquerading as advisory?** My recommendation: **it already effectively fails closed for writes, and that is the right behaviour — but the masquerade should end.** Concretely:

- Treating an unknown caller as ADVISORY is *safe* (it denies writes), so there is no security argument for changing the enforcement outcome.
- The real defect is **diagnostic**, not permissive: ADVISORY is a legitimate configured mode, so a genuine advisory agent and a completely unidentifiable one produced byte-identical 403s. That ambiguity is what cost the investigation time and sent it down two dead ends.
- I therefore chose a loud WARN over a distinct status code or a hard failure. Returning something other than 403 would change the agent-visible contract and risk breaking retry logic for a condition that should simply never occur; failing the connection outright would turn a transient attribution miss into an agent crash.

If you'd prefer stronger action, the natural next step is surfacing unidentified-write-blocks on the dashboard as a health signal rather than only in logs — happy to add that. Worth flagging a related **observability gap**: violation counts are in-memory only (`recordViolation`, `github_proxy.go`), so a restart erases the evidence of exactly this class of bug. I could not recover the scanner's original 403s because the pod had restarted; the reproduction above used the scanner's own UID, own token, and the live proxy instead.

## Affected branches

Confirmed by inspecting each branch directly — **all five carry both bugs** (`identifyAgentFromReq(r)` on the CONNECT path, and zero `update-branch` rules):

| Branch | `identifyAgentFromReq` | `update-branch` rule |
|---|---|---|
| `v2` | line 482 | absent |
| `dd` | line 482 | absent |
| `mk` | line 482 | absent |
| `v3-dynamic-models` | line 425 | absent |
| `v4` | line 482 | absent |

Ports can follow as syncs once this lands on `v2`.

## Tests — mutation-verified

New `v2/pkg/proxy/agent_identification_test.go`:

- `TestIdentifyAgentOnReadRequestConnection` — drives a **real loopback connection** against a synthetic `/proc/net/tcp` and asserts the agent is identified from a request whose `RemoteAddr` is empty exactly as `http.ReadRequest` leaves it. It also asserts the request-based path yields nothing, so a future refactor back to `identifyAgentFromReq` cannot look correct.
- `TestUpdateBranchRequiresMergeMode` — permitted at `ISSUES_PRS_MERGE`, denied below it.

Each was mutation-verified by breaking the production code and confirming the failure:

| Mutation | Result |
|---|---|
| Revert identification to `identifyAgentByUID(r.RemoteAddr)` | ❌ `got "", want "scanner"` |
| Downgrade `update-branch` to `ModeIssuesAndPRs` | ❌ `ISSUES_AND_PRS must NOT be allowed` |
| Remove the `update-branch` rule entirely (original bug) | ❌ `ISSUES_PRS_MERGE must be allowed` |

Restored, then the full `pkg/proxy` suite passes (45s, no regressions). The two `gofmt` hits in `proxy_deep3_test.go` / `proxy_deep5_test.go` are pre-existing and untouched by this PR.

## Verification once deployed

The proof is that the automation merges on its own — no PR was merged by hand during this investigation, deliberately.
