### PR TITLE
✨ feat(hub): ask for the requester's name and Slack ID on the request form

### DIFF
--- a/v2/pkg/hub/hub_coverage_deep_test.go
+++ b/v2/pkg/hub/hub_coverage_deep_test.go
@@ -604,7 +604,7 @@ func TestHandleRequestProvisionValidBody(t *testing.T) {
 
 	// github_host is required: a request must name the GitHub forge its org
 	// lives on, so a "valid body" fixture has to carry one.
-	body := `{"org":"validorg","github_host":"github.com","repos":"repo1,repo2","primary_repo":"repo1","acmm_level":3,"auth_method":"token"}`
+	body := `{"org":"validorg","github_host":"github.com","repos":"repo1,repo2","primary_repo":"repo1","acmm_level":3,"auth_method":"token","full_name":"Ada Lovelace"}`
 	req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer ghp_prov_valid")

--- a/v2/pkg/hub/hub_coverage_extra_test.go
+++ b/v2/pkg/hub/hub_coverage_extra_test.go
@@ -1004,7 +1004,7 @@ func TestHandleRequestProvisionDefaultPrimaryRepo(t *testing.T) {
 
 	// primary_repo not provided — should default to first repo. github_host is
 	// required and must be present for the request to reach that defaulting.
-	body := `{"org":"validorg","github_host":"github.com","repos":"repo1,repo2","acmm_level":2}`
+	body := `{"org":"validorg","github_host":"github.com","repos":"repo1,repo2","acmm_level":2,"full_name":"Ada Lovelace"}`
 	req := httptest.NewRequest("POST", "/provision-test", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer ghp_prov_default")

--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -980,7 +980,7 @@ func TestHandleRequestProvisionWithFilesystem(t *testing.T) {
 
 	// github_host is required — the forge the org lives on must be captured at
 	// request time, so this end-to-end save fixture carries one.
-	body := `{"org":"validorg","github_host":"github.com","repos":"repo1,repo2","primary_repo":"repo1","acmm_level":3}`
+	body := `{"org":"validorg","github_host":"github.com","repos":"repo1,repo2","primary_repo":"repo1","acmm_level":3,"full_name":"Ada Lovelace"}`
 	req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer ghp_reqprov_fs")
@@ -1022,7 +1022,7 @@ func TestHandleRequestProvisionClampsAboveOnboardingCeiling(t *testing.T) {
 
 			srv := NewHubServer(0, slog.Default(), "test", "v2")
 
-			body := fmt.Sprintf(`{"org":"validorg","github_host":"github.com","repos":"repo1","primary_repo":"repo1","acmm_level":%d}`, requested)
+			body := fmt.Sprintf(`{"org":"validorg","github_host":"github.com","repos":"repo1","primary_repo":"repo1","acmm_level":%d,"full_name":"Ada Lovelace"}`, requested)
 			req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
 			req.Header.Set("Authorization", "Bearer "+token)
@@ -1058,7 +1058,7 @@ func TestHandleRequestProvisionAcceptsOnboardingLevels(t *testing.T) {
 
 			srv := NewHubServer(0, slog.Default(), "test", "v2")
 
-			body := fmt.Sprintf(`{"org":"validorg","github_host":"github.com","repos":"repo1","primary_repo":"repo1","acmm_level":%d}`, requested)
+			body := fmt.Sprintf(`{"org":"validorg","github_host":"github.com","repos":"repo1","primary_repo":"repo1","acmm_level":%d,"full_name":"Ada Lovelace"}`, requested)
 			req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
 			req.Header.Set("Authorization", "Bearer "+token)

--- a/v2/pkg/hub/request_contact_fields_test.go
+++ b/v2/pkg/hub/request_contact_fields_test.go
@@ -1,0 +1,266 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// The "Request a Hive" wizard captures WHO is asking, not just which repo they
+// want: a first/last name so an operator can map a GitHub login to a person,
+// and an optional Slack ID so the hub can reach them.
+//
+// Both REUSE the existing SaaSUser contact fields (FullName / SlackID) rather
+// than introducing a parallel key. That is the property most worth pinning: a
+// second Slack key would split one fact across two names, with this form
+// writing one and the admin users panel plus the Slack sender reading the
+// other. The tests below assert the reuse end-to-end — captured on the request,
+// then carried onto the user record at approval, where those readers look.
+
+// helperContactRequestBody builds a request body that is valid apart from the
+// contact fields under test.
+func helperContactRequestBody(t *testing.T, fullName, slackID string) string {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"org":         "z-innersource",
+		"repos":       "repo1",
+		"github_host": "github.com",
+		"acmm_level":  3,
+		"full_name":   fullName,
+		"slack_id":    slackID,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(body)
+}
+
+// TestRequestProvisionRequiresName pins the required half. Client-side
+// validation is not enforcement: a curl or a stale page bypasses it, and a name
+// that is usually absent is one nobody can rely on.
+func TestRequestProvisionRequiresName(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	authAsForgeTester(t, "ghp_contact_noname", "contact-noname-user")
+
+	for _, name := range []string{"", "   ", "\t\n"} {
+		w := postProvisionRequest(t, srv, "ghp_contact_noname", helperContactRequestBody(t, name, ""))
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("name %q: expected 400, got %d (body %s)", name, w.Code, w.Body.String())
+		}
+		if !strings.Contains(strings.ToLower(w.Body.String()), "name") {
+			t.Errorf("name %q: rejection should say which field is missing, got %s", name, w.Body.String())
+		}
+	}
+}
+
+// TestRequestProvisionSlackIDIsOptional pins the optional half. The owner asked
+// for the Slack ID explicitly as optional, so a request without one must be a
+// clean 200 — not a 400, and not a stored placeholder string.
+func TestRequestProvisionSlackIDIsOptional(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	const user = "contact-noslack-user"
+	authAsForgeTester(t, "ghp_contact_noslack", user)
+
+	w := postProvisionRequest(t, srv, "ghp_contact_noslack", helperContactRequestBody(t, "Ada Lovelace", ""))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 with no slack_id, got %d (body %s)", w.Code, w.Body.String())
+	}
+	pr := loadProvisionRequest(user)
+	if pr == nil {
+		t.Fatal("request was not persisted")
+	}
+	if pr.FullName != "Ada Lovelace" {
+		t.Errorf("full_name = %q, want %q", pr.FullName, "Ada Lovelace")
+	}
+	if pr.SlackID != "" {
+		t.Errorf("slack_id should stay empty when not supplied, got %q", pr.SlackID)
+	}
+}
+
+// TestRequestProvisionPersistsContactFields — the values must land on the
+// stored request, trimmed. Captured-then-dropped would be worse than not
+// asking at all.
+func TestRequestProvisionPersistsContactFields(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	const user = "contact-persist-user"
+	authAsForgeTester(t, "ghp_contact_persist", user)
+
+	w := postProvisionRequest(t, srv, "ghp_contact_persist",
+		helperContactRequestBody(t, "  Ada Lovelace  ", "  U01ABCDEF23  "))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body %s)", w.Code, w.Body.String())
+	}
+	pr := loadProvisionRequest(user)
+	if pr == nil {
+		t.Fatal("request was not persisted")
+	}
+	if pr.FullName != "Ada Lovelace" {
+		t.Errorf("full_name = %q, want it trimmed to %q", pr.FullName, "Ada Lovelace")
+	}
+	if pr.SlackID != "U01ABCDEF23" {
+		t.Errorf("slack_id = %q, want it trimmed to %q", pr.SlackID, "U01ABCDEF23")
+	}
+}
+
+// TestRequestProvisionCapsContactFields pins the length bounds to the SAME
+// constants the admin contact editor uses. Truncation, not rejection, matches
+// handleAdminUpdateUser's existing treatment of these two fields.
+func TestRequestProvisionCapsContactFields(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	const user = "contact-cap-user"
+	authAsForgeTester(t, "ghp_contact_cap", user)
+
+	longName := strings.Repeat("a", maxContactNameLen*2)
+	longSlack := strings.Repeat("b", maxContactSlackIDLen*2)
+	w := postProvisionRequest(t, srv, "ghp_contact_cap", helperContactRequestBody(t, longName, longSlack))
+	if w.Code != http.StatusOK {
+		t.Fatalf("over-long values should truncate, not reject; got %d (%s)", w.Code, w.Body.String())
+	}
+	pr := loadProvisionRequest(user)
+	if pr == nil {
+		t.Fatal("request was not persisted")
+	}
+	if len([]rune(pr.FullName)) != maxContactNameLen {
+		t.Errorf("full_name kept %d runes, want the maxContactNameLen cap of %d",
+			len([]rune(pr.FullName)), maxContactNameLen)
+	}
+	if len([]rune(pr.SlackID)) != maxContactSlackIDLen {
+		t.Errorf("slack_id kept %d runes, want the maxContactSlackIDLen cap of %d",
+			len([]rune(pr.SlackID)), maxContactSlackIDLen)
+	}
+}
+
+// TestRequestProvisionStoresHostileNameVerbatim — these are display strings,
+// so they are stored as typed and escaped at every RENDER site. Storing a
+// pre-escaped or stripped value would corrupt the legitimate half of this set:
+// "O'Brien" is a real name, and mangling it to serve an escaping concern is the
+// bug, not the fix.
+func TestRequestProvisionStoresHostileNameVerbatim(t *testing.T) {
+	cases := []struct {
+		user  string
+		token string
+		name  string
+	}{
+		{"contact-apos-user", "ghp_contact_apos", "Máire O'Brien"},
+		{"contact-html-user", "ghp_contact_html", `<script>alert(1)</script>`},
+		{"contact-quote-user", "ghp_contact_quote", `Ada "Countess" Lovelace`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.user, func(t *testing.T) {
+			cleanup := helperSetupTempDirs(t)
+			defer cleanup()
+			srv := NewHubServer(0, slog.Default(), "test", "v2")
+			authAsForgeTester(t, tc.token, tc.user)
+
+			w := postProvisionRequest(t, srv, tc.token, helperContactRequestBody(t, tc.name, ""))
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d (body %s)", w.Code, w.Body.String())
+			}
+			pr := loadProvisionRequest(tc.user)
+			if pr == nil {
+				t.Fatal("request was not persisted")
+			}
+			if pr.FullName != tc.name {
+				t.Errorf("full_name = %q, want it stored verbatim as %q", pr.FullName, tc.name)
+			}
+		})
+	}
+}
+
+// TestApprovalCarriesContactFieldsOntoUser is the reason this feature is worth
+// anything. The admin users panel and the Slack sender read SaaSUser, NOT
+// ProvisionRequest — so a value that stops at the request file is invisible to
+// every consumer of it. Slack messaging shipped with no user having a slack_id;
+// this is the path that finally populates one.
+func TestApprovalCarriesContactFieldsOntoUser(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	const user = "contact-approve-user"
+	pr := &ProvisionRequest{
+		Username:    user,
+		Org:         "z-innersource",
+		Repos:       "repo1",
+		PrimaryRepo: "repo1",
+		GitHubHost:  "github.com",
+		ACMMLevel:   3,
+		Status:      provisionStatusPending,
+		FullName:    "Ada Lovelace",
+		SlackID:     "U01ABCDEF23",
+	}
+	if err := saveProvisionRequest(pr); err != nil {
+		t.Fatalf("seed request: %v", err)
+	}
+
+	u := ensureSaaSUser(user)
+	if u.FullName != "" || u.SlackID != "" {
+		t.Fatalf("precondition: a fresh user must have no contact details, got %q/%q", u.FullName, u.SlackID)
+	}
+	applyRequestContactToUser(u, pr)
+	if err := saveSaaSUser(u); err != nil {
+		t.Fatalf("save user: %v", err)
+	}
+
+	got := loadSaaSUser(user)
+	if got == nil {
+		t.Fatal("user was not persisted")
+	}
+	if got.FullName != "Ada Lovelace" {
+		t.Errorf("user.FullName = %q, want the requested %q", got.FullName, "Ada Lovelace")
+	}
+	if got.SlackID != "U01ABCDEF23" {
+		t.Errorf("user.SlackID = %q, want the requested %q — this is the field the "+
+			"Slack sender reads", got.SlackID, "U01ABCDEF23")
+	}
+}
+
+// TestApprovalNeverOverwritesCuratedContactFields — an admin who has already
+// curated a user's contact details (or a user who corrected them) outranks
+// whatever was typed into a request form, and a re-approval must not silently
+// revert that. The carry-over fills a blank; it does not overwrite.
+func TestApprovalNeverOverwritesCuratedContactFields(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	const user = "contact-curated-user"
+	u := ensureSaaSUser(user)
+	u.FullName = "Augusta Ada King"
+	u.SlackID = "U99CURATED"
+	if err := saveSaaSUser(u); err != nil {
+		t.Fatalf("seed curated user: %v", err)
+	}
+
+	pr := &ProvisionRequest{
+		Username: user,
+		Status:   provisionStatusPending,
+		FullName: "typo mcTypoface",
+		SlackID:  "U00WRONG",
+	}
+	applyRequestContactToUser(u, pr)
+
+	if u.FullName != "Augusta Ada King" {
+		t.Errorf("curated FullName was overwritten to %q", u.FullName)
+	}
+	if u.SlackID != "U99CURATED" {
+		t.Errorf("curated SlackID was overwritten to %q", u.SlackID)
+	}
+}
+
+// TestApprovalContactCarryIsNilSafe — the carry-over runs on the approval path
+// next to other work that can legitimately leave either side absent. Neither a
+// nil user nor a nil request may panic there.
+func TestApprovalContactCarryIsNilSafe(t *testing.T) {
+	applyRequestContactToUser(nil, &ProvisionRequest{FullName: "Ada"})
+	applyRequestContactToUser(&SaaSUser{}, nil)
+	applyRequestContactToUser(nil, nil)
+}

--- a/v2/pkg/hub/request_forge_required_test.go
+++ b/v2/pkg/hub/request_forge_required_test.go
@@ -173,6 +173,7 @@ func TestRequestProvisionAcceptsAllForgeForms(t *testing.T) {
 			"repos":       "repo1",
 			"github_host": tc.forge,
 			"acmm_level":  3,
+			"full_name":   "Ada Lovelace",
 		})
 		if err != nil {
 			t.Fatalf("marshal: %v", err)

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4918,6 +4918,19 @@ type ProvisionRequest struct {
 	RequestedAt string `json:"requested_at"`
 	Status      string `json:"status"`
 
+	// Who is asking, as a person rather than as a GitHub login. Both reuse the
+	// SaaSUser contact fields of the same name and the same caps
+	// (maxContactNameLen / maxContactSlackIDLen) — deliberately NOT new keys.
+	// A second Slack key would split one fact across two names, with the
+	// request form writing one and the admin users panel reading the other.
+	//
+	// These are captured here and copied onto the SaaSUser record on approval
+	// (handleApproveProvision); asking and then dropping the answer would be
+	// worse than not asking. Both are omitempty so requests filed before these
+	// fields existed round-trip unchanged.
+	FullName string `json:"full_name,omitempty"`
+	SlackID  string `json:"slack_id,omitempty"`
+
 	// Decision audit. Previously a request only carried its final Status, so
 	// once it left "pending" there was no record of WHO decided, WHEN, or —
 	// for an approval — which hive the requester actually got. That made the
@@ -5037,6 +5050,33 @@ func enrichProvisionRequests(requests []ProvisionRequest) []ProvisionRequest {
 	return requests
 }
 
+// applyRequestContactToUser carries the requester's contact details from an
+// approved provision request onto their SaaSUser record.
+//
+// This is what makes asking for them worth anything. The admin users panel and
+// the Slack sender both read SaaSUser, NOT ProvisionRequest — a value that
+// stops at the request file is invisible to every consumer of it. Slack
+// messaging shipped with no user having a slack_id, settable only by hand one
+// user at a time; approval is the natural point of capture.
+//
+// It only ever FILLS A BLANK. An admin who has already curated these fields (or
+// a user who corrected them later) outranks whatever was typed into a request
+// form, and a re-approval must not silently revert that.
+//
+// Nil-safe on both sides: it runs on the approval path beside other work that
+// can legitimately leave either side absent, and must not panic there.
+func applyRequestContactToUser(user *SaaSUser, pr *ProvisionRequest) {
+	if user == nil || pr == nil {
+		return
+	}
+	if user.FullName == "" && pr.FullName != "" {
+		user.FullName = truncateRunes(strings.TrimSpace(pr.FullName), maxContactNameLen)
+	}
+	if user.SlackID == "" && pr.SlackID != "" {
+		user.SlackID = truncateRunes(strings.TrimSpace(pr.SlackID), maxContactSlackIDLen)
+	}
+}
+
 func loadProvisionRequest(username string) *ProvisionRequest {
 	if strings.Contains(username, "..") || strings.Contains(username, "/") || strings.Contains(username, "\\") {
 		return nil
@@ -5118,6 +5158,8 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 		PrimaryRepo string `json:"primary_repo"`
 		ACMMLevel   int    `json:"acmm_level"`
 		AuthMethod  string `json:"auth_method"`
+		FullName    string `json:"full_name"`
+		SlackID     string `json:"slack_id"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
@@ -5127,6 +5169,19 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 		http.Error(w, `{"error":"org and repos are required"}`, http.StatusBadRequest)
 		return
 	}
+	// Contact details for the person asking.
+	//
+	// No charset validation on purpose: isValidName() is for identifiers
+	// (org/repo/host names) and would reject spaces, apostrophes and every
+	// non-ASCII script. These are display strings — trimmed, rune-capped and
+	// escaped at every render site, exactly as the admin contact editor
+	// (handleAdminUpdateUser) already treats these same two fields. We also do
+	// NOT try to detect a "real" name: any pattern for that (two words,
+	// capitalised, Latin script) is wrong for a large fraction of the world's
+	// names, and a determined user types junk regardless. Human review is the
+	// check, not a regex.
+	body.FullName = truncateRunes(strings.TrimSpace(body.FullName), maxContactNameLen)
+	body.SlackID = truncateRunes(strings.TrimSpace(body.SlackID), maxContactSlackIDLen)
 	// Accept a pasted org/repo URL, not just a bare name. Users read
 	// "GitHub Organization" and paste the org's URL; the old validator rejected
 	// ":" and "/" and returned a bare "invalid org name" that explained nothing.
@@ -5187,6 +5242,29 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
+	// Name is REQUIRED; Slack ID is optional.
+	//
+	// The name exists to map a GitHub login to a person an operator can talk
+	// to, which only works if it is actually populated — a field that is
+	// usually blank cannot be relied on and stops being read. Requesting a hive
+	// is a deliberate, one-per-user action already reviewed by a human, so one
+	// short field is negligible friction at the moment the requester is most
+	// motivated to answer.
+	//
+	// Checked AFTER the org/forge/repo validation above so the more specific
+	// "which GitHub is this org on?" errors keep their precedence — a request
+	// missing both should be told about the forge, not sent round the loop one
+	// field at a time.
+	//
+	// This does tighten an existing endpoint: a caller that posted no full_name
+	// now gets a 400 where it used to get a 200. That is intended — the whole
+	// point is that the field is reliably present — and the wizard is the only
+	// caller in-tree. Called out in the PR body rather than hidden here.
+	if body.FullName == "" {
+		http.Error(w, `{"error":"your name is required — we use it to know who the request is from"}`, http.StatusBadRequest)
+		return
+	}
+
 	// A hive is never REQUESTED above L3 Measured. L4-L6 are real levels, but
 	// they are reached after provisioning, from the hive's own dashboard, once
 	// the project has the coverage and CI history to justify them. The
@@ -5215,6 +5293,8 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 		PrimaryRepo: primaryRepo,
 		ACMMLevel:   acmm,
 		AuthMethod:  body.AuthMethod,
+		FullName:    body.FullName,
+		SlackID:     body.SlackID,
 		RequestedAt: time.Now().UTC().Format(time.RFC3339),
 		Status:      provisionStatusPending,
 	}
@@ -5398,6 +5478,7 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 	}
 	user.Hives[hiveID] = "owner"
 	user.SaaSQuota++
+	applyRequestContactToUser(user, pr)
 	if err := saveSaaSUser(user); err != nil {
 		s.logger.Warn("assigned placeholder but failed to grant owner access", "user", targetUsername, "hive", hiveID, "error", err)
 	}
@@ -12167,6 +12248,28 @@ const dashboardHTML = `<!DOCTYPE html>
     // github.ibm.com means GitHub Enterprise — hardcoding github.com would send
     // an admin to a 404 (or worse, an unrelated public repo of the same name).
     // Requests with no repo recorded fall back to plain escaped text.
+    /* provisionRequesterLabel renders the requester's real name and Slack ID
+       beside their GitHub login on the review card. Mapping a login to a person
+       is the reason the wizard asks for a name at all, and this is where the
+       operator deciding the request needs it.
+
+       Both are free text a user typed. esc() everywhere, and the whole label is
+       built as a text node's escaped HTML rather than interpolated into an
+       attribute — nothing here is ever placed inside an inline handler, where
+       esc() alone would leave an apostrophe live. Older requests predate these
+       fields and simply render nothing. */
+    function provisionRequesterLabel(pr) {
+      if (!pr) return '';
+      var name = (pr.full_name || '').trim();
+      var slack = (pr.slack_id || '').trim();
+      if (!name && !slack) return '';
+      var bits = [];
+      if (name) bits.push(esc(name));
+      if (slack) bits.push('slack: ' + esc(slack));
+      return '<span style="font-size:0.75rem;color:var(--muted);margin-left:8px">' +
+        bits.join(' &middot; ') + '</span>';
+    }
+
     function provisionRepoLabel(pr) {
       if (!pr) return '';
       var org = pr.org || '';
@@ -12310,6 +12413,10 @@ const dashboardHTML = `<!DOCTYPE html>
           avatar +
           '<div>' +
           '<span style="font-size:0.85rem;font-weight:600">' + esc(pr.username) + '</span>' +
+          // Who the requester actually IS. Mapping a login to a person is the
+          // reason the wizard asks for a name, and this review card is where an
+          // operator needs it. esc() only — free text, never markup.
+          provisionRequesterLabel(pr) +
           // org/repo links to the repo on the instance the request targets.
           '<span style="font-size:0.75rem;color:var(--muted);margin-left:8px">' + provisionRepoLabel(pr) + '</span>' +
           // Show which GitHub instance the request targets — same pill the Past

--- a/v2/pkg/hub/static/get-started.html
+++ b/v2/pkg/hub/static/get-started.html
@@ -380,10 +380,47 @@
         <h2>Choose autonomy level</h2>
         <p>How much should the agents do on their own? Start low and increase as you build confidence. This only controls the mundane work &mdash; security patches, dependency updates, issue triage, test fixes &mdash; so your team can focus on what matters: innovation, outreach, and strategy.</p>
         <div class="acmm-options" id="acmm-options"></div>
+
+        <!-- Who is asking. These live on step 3 rather than step 2 because
+             step 2 is "Your repository" — it asks about the project, and its
+             one input is parsed as a repo URL. These describe the PERSON, and
+             they sit directly above the summary and the submit button, which
+             is where a requester expects to identify themselves before sending.
+             Both map onto the SaaSUser contact fields of the same name; they
+             are not new keys. -->
+        <div style="margin-top:1.4rem">
+          <label for="req-full-name" style="display:block;font-size:0.86rem;color:var(--muted);margin-bottom:6px">
+            Your name <span style="color:var(--red)">*</span>
+          </label>
+          <input type="text" id="req-full-name" placeholder="Ada Lovelace" maxlength="128"
+            oninput="clearContactError();updateSummary()"
+            style="width:100%;padding:9px 12px;background:var(--bg-soft);border:1px solid var(--line);border-radius:6px;color:var(--text);font-size:0.88rem">
+          <p style="font-size:0.8rem;margin-top:6px;margin-bottom:0">
+            First and last name, so we know who the request is from &mdash; a GitHub username on its own
+            often does not say who a person is.
+          </p>
+        </div>
+
+        <div style="margin-top:1rem">
+          <label for="req-slack-id" style="display:block;font-size:0.86rem;color:var(--muted);margin-bottom:6px">
+            Slack ID <span style="color:var(--muted);font-weight:400">(optional)</span>
+          </label>
+          <input type="text" id="req-slack-id" placeholder="U01ABCDEF23 or @ada" maxlength="64"
+            oninput="clearContactError();updateSummary()"
+            style="width:100%;padding:9px 12px;background:var(--bg-soft);border:1px solid var(--line);border-radius:6px;color:var(--text);font-size:0.88rem">
+          <p style="font-size:0.8rem;margin-top:6px;margin-bottom:0">
+            Your Slack member ID or handle, if you have one. We use it to reach you about your hive
+            &mdash; leave it blank and we will use GitHub instead.
+          </p>
+        </div>
+        <div id="contact-err" style="display:none;margin-top:8px;font-size:0.8rem;color:var(--red)"></div>
+
         <div id="request-summary" style="margin:20px 0;padding:16px;background:#080b0f85;border:1px solid var(--line);border-radius:.7rem;font-size:0.85rem">
           <div style="margin-bottom:8px"><strong>Summary</strong></div>
           <div style="color:var(--muted)">Repo: <span id="summary-repos" style="color:var(--text)">none added</span></div>
           <div style="color:var(--muted)">ACMM Level: <span id="summary-acmm" style="color:var(--text)"></span></div>
+          <div style="color:var(--muted)">Name: <span id="summary-name" style="color:var(--text)">&mdash;</span></div>
+          <div style="color:var(--muted)">Slack ID: <span id="summary-slack" style="color:var(--text)">&mdash;</span></div>
         </div>
         <!-- The wizard no longer asks anyone to install the GitHub App. This
              note is the handoff to where that now happens: after provisioning,
@@ -566,6 +603,14 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
       document.getElementById('summary-repos').textContent = names.length ? names.join(', ') : 'none added';
       var entry = acmmEntry(_selectedAcmm);
       document.getElementById('summary-acmm').textContent = entry ? entry.label : ('L' + _selectedAcmm);
+      /* textContent, not innerHTML: these are the only free-text values in the
+         wizard, so a name containing an apostrophe or a <script> tag renders as
+         the literal characters the user typed and nothing is parsed as markup. */
+      var em = '—';
+      var nm = contactValue('req-full-name', CONTACT_MAX_NAME);
+      var sl = contactValue('req-slack-id', CONTACT_MAX_SLACK);
+      document.getElementById('summary-name').textContent = nm || em;
+      document.getElementById('summary-slack').textContent = sl || em;
     }
 
     /* parseRepoRef turns whatever a user pastes into {host, org, name}.
@@ -654,6 +699,39 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
     /* Shown when the field holds something that is not a repository reference. */
     var REPO_UNPARSEABLE_MSG = 'Enter a repository URL — for example github.com/my-org/my-repo or https://github.ibm.com/my-org/my-repo';
 
+    /* Contact-field caps, mirroring maxContactNameLen / maxContactSlackIDLen in
+       pkg/hub/saas.go. They are also the maxlength on the two inputs; the
+       server truncates to the same bounds, so these only stop a user typing
+       past a limit that would be silently applied anyway. */
+    var CONTACT_MAX_NAME = 128;
+    var CONTACT_MAX_SLACK = 64;
+    /* Shown when Request is pressed with no name. The server rejects the same
+       case, so refusing here reports it where it can be fixed rather than
+       after a round trip. */
+    var NAME_REQUIRED_MSG = 'Enter your name so we know who the request is from.';
+
+    function clearContactError() {
+      var err = document.getElementById('contact-err');
+      if (err) err.style.display = 'none';
+    }
+
+    function showContactError(msg) {
+      var err = document.getElementById('contact-err');
+      if (!err) return;
+      err.textContent = msg;
+      err.style.display = 'block';
+    }
+
+    /* Read a contact input, trimmed and clipped to its cap. Clipping with
+       .slice() counts UTF-16 code units where the server counts runes, so an
+       astral-plane name could still be trimmed further server-side — the cap is
+       generous enough that this is not a case a real name reaches, and the
+       server truncates rather than rejecting. */
+    function contactValue(id, cap) {
+      var el = document.getElementById(id);
+      return ((el && el.value) || '').trim().slice(0, cap);
+    }
+
     function clearRepoError() {
       var err = document.getElementById('repo-manual-err');
       if (err) err.style.display = 'none';
@@ -716,6 +794,17 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
 
     async function submitRequest() {
       var btn = document.getElementById('submit-request');
+      /* Check the required name BEFORE disabling the button: bailing out after
+         btn.disabled = true would leave the user staring at a dead control. */
+      clearContactError();
+      var fullName = contactValue('req-full-name', CONTACT_MAX_NAME);
+      var slackID = contactValue('req-slack-id', CONTACT_MAX_SLACK);
+      if (!fullName) {
+        showContactError(NAME_REQUIRED_MSG);
+        var nameEl = document.getElementById('req-full-name');
+        if (nameEl) nameEl.focus();
+        return;
+      }
       btn.disabled = true;
       btn.textContent = 'Submitting...';
       try {
@@ -746,7 +835,12 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
             github_host: (_selectedRepos.find(function(r) { return r.github_host; }) || {}).github_host || '',
             repos: reqRepos,
             primary_repo: reqRepos.split(',')[0],
-            acmm_level: _selectedAcmm
+            acmm_level: _selectedAcmm,
+            // Reuses the SaaSUser contact fields of the same names. On approval
+            // the hub copies these onto the user record, which is what the
+            // admin users panel and the Slack sender read.
+            full_name: fullName,
+            slack_id: slackID
           })
         });
         var data = await resp.json();


### PR DESCRIPTION
## Problem

The "Request a Hive" wizard captured which repo someone wanted but never who they were. An operator reviewing a request saw a GitHub login and had no way to map it to a person.

There is a second, more concrete cost. Slack messaging (#2362) is merged, but **no user has a `slack_id` set**, so a broadcast today skips all ~88 users. The only way to populate one is the admin user editor, by hand, one user at a time. Asking at request time is the natural point of capture and stops the backlog growing.

## Where the fields went, and why

Both are on **step 3 ("Request")**, directly above the summary and the submit button.

Step 2 is "Your repository" — it asks about the *project*, and its single input is parsed as a repo URL (`parseRepoRef`). These two fields describe the *person*. Step 3 is where the requester reviews and sends, which is where identifying yourself belongs. The summary block now echoes both back before submit.

## Reusing `SlackID` — no second field

`SaaSUser` **already had both fields**, so this adds no new keys anywhere:

| Go field | JSON | Cap |
|---|---|---|
| `SaaSUser.FullName` | `full_name` | `maxContactNameLen` = 128 |
| `SaaSUser.SlackID` | `slack_id` | `maxContactSlackIDLen` = 64 |

The same names and the same constants are used on `ProvisionRequest`, in the POST body, and in the wizard's `maxlength`. A second Slack key would have split one fact across two names, with this form writing one and the admin users panel (#2359) plus the Slack sender (#2362) reading the other.

## Surviving approval

Capturing these and then dropping them would be worse than not asking. The admin users panel and the Slack sender read `SaaSUser`, **not** `ProvisionRequest` — a value that stops at the request file is invisible to every consumer of it.

`handleApproveProvision` now calls `applyRequestContactToUser(user, pr)`, which copies both onto the user record. It is extracted as a named helper so the behaviour is directly testable, and it is deliberately conservative:

- **Only ever fills a blank.** An admin who has curated a user's contact details (or a user who corrected them) outranks whatever was typed into a request form; a re-approval must not silently revert that.
- **Nil-safe on both sides** — it runs beside other approval work that can legitimately leave either side absent.

The requester's name and Slack ID also now render on the **admin approval card**, which is the moment the login-to-person mapping is actually needed.

## Required vs optional — recommendation

**Slack ID: optional**, as requested. Blank is a normal answer; we fall back to GitHub.

**Name: required — recommended, and implemented that way.** The reasoning, since this was flagged as a judgement call:

- The stated purpose is mapping a login to a person. A field that is usually blank cannot be relied on, and a field nobody can rely on stops being read — it decays into noise.
- Requesting a hive is a deliberate, one-per-user action already reviewed by a human. One short field is negligible friction at the one moment the requester is most motivated to answer.
- The junk-input objection is real but does not argue for optional: a determined user types junk either way. What it argues against is *validating* the name, which we do not do.

Concretely, we do **not** try to detect a "real" name. Any pattern for that (two words, capitalised, Latin script) is wrong for a large fraction of the world's names. Human review is the check, not a regex.

**This does tighten an existing endpoint**: a caller posting no `full_name` now gets a 400 where it previously got a 200. That is the intended behaviour, and the wizard is the only in-tree caller. The check runs *after* org/forge/repo validation so the more specific "which GitHub is this org on?" errors keep their precedence.

## Validation and escaping

Both fields are user-supplied and end up in the admin UI.

- Server: trimmed, then rune-capped via the existing `truncateRunes` — matching how `handleAdminUpdateUser` already treats these same two fields. No charset validation on purpose: `isValidName()` is for identifiers and would reject spaces, apostrophes, and every non-ASCII script.
- Stored **verbatim**. Storing a pre-escaped or stripped value would corrupt the legitimate half of the set — `O'Brien` is a real name, and mangling it to serve an escaping concern is the bug, not the fix. Escaping happens at each render site.
- Wizard summary uses `textContent`, so a name is never parsed as markup.
- Admin card uses `esc()` and is **not** interpolated into an inline handler attribute — the case where `esc()` alone would leave an apostrophe live.
- `omitempty` on both, so requests filed before these fields existed round-trip unchanged.

## Tests

New `request_contact_fields_test.go` covers: name required (empty/whitespace), Slack ID optional, persistence with trimming, both caps pinned to the shared constants, hostile input (`O'Brien`, `<script>`, embedded quotes) stored verbatim, carry-over onto `SaaSUser` at approval, curated values never overwritten, and nil-safety.

Existing happy-path provision tests were updated to send a `full_name`, since the field is now genuinely required.

## Verification

- `go build ./...` — OK; `gofmt` clean
- Full `pkg/hub` suite green (`go test ./pkg/hub/`)
- Embedded `dashboardHTML` JS extracted and `node --check`'d — **PASS**, brace delta **0**, paren delta unchanged from base (`-1`, pre-existing)
- Wizard JS `node --check` — **PASS**, brace delta **0**, paren delta **0**
- Zero backticks and zero literal `<body>` tags added inside the Go raw string (the 5 backticks in the diff are Go struct tags and one error literal, all outside `dashboardHTML`)

CI is the gate.