### PR TITLE
📝 docs(config): state the spoke config precedence in code, and expose it over an API

### DIFF
--- a/v2/docs/config-layering.md
+++ b/v2/docs/config-layering.md
@@ -1,0 +1,153 @@
+# Spoke configuration layering
+
+**Which layer sets this field, and where do I write to change it?**
+
+Until this document existed, that question was answerable only by reading a
+single line of pod boot logs. It cost real time: a GitHub Enterprise hive was
+repaired on the **fourth** attempt, after patching the hub's `meta.json`, then
+`clusters.json`, then the spoke's ConfigMap — three layers that are *inert* for
+`github.app_id` — before patching the dashboard overlay, the layer that
+actually wins.
+
+Ask the hive instead:
+
+```bash
+curl -s localhost:3002/api/config/provenance | jq .
+```
+
+## Precedence order — highest to lowest
+
+| Rank | Layer | Path | Writable by |
+|---|---|---|---|
+| 1 (wins) | `config-env` | `/etc/hive/config.env` | cluster admin (pod spec) |
+| 2 | `agent-overlay` | `/data/agent-configs/<agent>.yaml` | spoke (dashboard agent edits) |
+| 3 | `dashboard-overlay` | `/data/hive.yaml.dashboard` | **spoke (`Config.Save`) and hub (heartbeat)** |
+| 4 (loses) | `configmap-seed` | ConfigMap `hive-config`, key `hive.yaml` | **nobody** |
+
+Three documented exceptions where a lower layer affects the result:
+
+| # | Field | Behaviour |
+|---|---|---|
+| A | `hub.is_public` | The seed's value is applied over the overlay's. The **only** unconditional seed-wins assignment in the merge. |
+| B | `acmm_level` | The seed is a **fallback only**, used when the overlay has no level at all (issue #1856). |
+| C | `github.*` | The seed wins only as an **anti-wipe ratchet**: when the seed holds real App credentials and the overlay's look like a placeholder. A safety catch, not precedence. |
+
+Everything else: the highest layer that sets the field wins.
+
+## The ConfigMap decides almost nothing, and nothing can write it
+
+This is the most important and least obvious fact about the system.
+
+Measured on the live fleet — ConfigMap seed vs running config:
+
+| Hive | Seed | Running | Seed share |
+|---|---|---|---|
+| `hosted-aslom-hive-agent` | 559 B | 12,380 B | 4.5% |
+| `hosted-projectbluefin-knuckle` | 1,661 B | 14,609 B | 11% |
+| `hosted-kubestellar-console` | 1,051 B | 17,564 B | 6% |
+
+The seed omits whole top-level blocks (`policies`, `data`, `knowledge`,
+`notifications`, `hive_id`) that the running config carries.
+
+Its one exclusive field, `hub.is_public`, is owned by a component that
+**cannot write this layer**:
+
+- **hub → ConfigMap**: one reference in `pkg/hub`
+  (`saas_provision.go:1282`), and it is a `get`. There is no write path.
+- **spoke → ConfigMap**: the spoke Role (`saas_provision.go:1478-1518`) grants
+  `deployments` and `secrets`. `configmaps` appears in no rule.
+
+The hub also re-asserts `is_public` over the heartbeat
+(`server.go:1271` pushes on disagreement; `server.go:1077` keeps a hub-set
+public flag from being reverted), so the seed's win survives at most one beat.
+
+**Consequence:** editing the ConfigMap and restarting usually changes nothing.
+It looks authoritative — it is the only layer visible to `kubectl` without
+`exec`ing into a pod — and it is not. This is the trap the GHE incident fell
+into.
+
+It also explains why every config fix this week travelled by heartbeat into the
+PVC overlay: #2354 (ACMM), #2360 (forge), #2363 (GHE App IDs). The overlay is
+the only writable channel. The bespoke per-field delivery latches are a
+rational response to having one road, not duplicated effort.
+
+## Where to write to change a field
+
+| Field | Winning layer | Write here |
+|---|---|---|
+| `acmm_level` | dashboard-overlay | overlay, or hub `RequestedACMMLevel` |
+| `github.app_id` | dashboard-overlay | overlay (hub source is `clusters.json`) |
+| `github.installation_id` | dashboard-overlay | overlay |
+| `github.key_file` / PEM | hub (cluster PEM) | `/data/saas/app-keys/<cluster>.pem` |
+| `github.app_slug` | hub push | cluster config |
+| `github.api_url` / `base_url` | spoke; hub pushes via forge latch | `handleSwitchForge` |
+| `github_host` | spoke reports, hub adopts | `handleSwitchForge` |
+| agent list | union of seed + overlay + agent-configs | see caveat below |
+| agent `model` / `backend` | dashboard-overlay | dashboard (ownership-guarded, #2340) |
+| governor thresholds | dashboard-overlay | dashboard |
+| `hub.is_public` | **configmap-seed** | hub (the seed is not writable) |
+
+> **Caveat — agent deletion.** `MergeAgentOverrides` unions its three sources
+> and only ever *adds*, so a deleted agent reappears on the next config reload.
+> Tracked in #2361.
+
+## `hive.yaml.bak` is a backup, not an input
+
+Despite the name suggesting otherwise, and despite what some code comments and
+the DR runbook currently say, `/data/hive.yaml.bak` is **written** by the
+entrypoint after the merge (`entrypoint.sh:150`) and is **read only** when the
+ConfigMap is missing or empty (`entrypoint.sh:152-161`), or in Docker mode.
+
+Three older hives run a `copy-config` init container variant that *does*
+restore from `.bak` first. That variant is not what new hives get. The DR
+documentation is being corrected separately.
+
+## Reading the provenance report
+
+```jsonc
+{
+  "fields": [
+    {
+      "field": "github.app_id",
+      "layer": "dashboard-overlay",
+      "path": "/data/hive.yaml.dashboard",
+      "writer": "spoke (Config.Save) and hub (via heartbeat delivery)",
+      "writable": true,
+      "value": "5686",
+      "also_set_by": ["configmap-seed"]   // a losing, stale value
+    }
+  ],
+  "overlay_rejected": false,
+  "identity_issues": []
+}
+```
+
+- **`also_set_by`** names lower layers that set the field and lost. A
+  `configmap-seed` entry here means the ConfigMap holds a stale value that
+  looks authoritative and is not.
+- **`overlay_rejected`** is the alarming one. It means the overlay failed the
+  plausibility guard and was discarded, so the hive is running on the bare
+  seed — which, per the table above, can be a small fraction of the real
+  config, including a fraction of the agent roster.
+- **`identity_issues`** names inconsistencies in the GitHub identity set.
+
+## The GitHub identity set is atomic
+
+`app_id`, `app_slug`, `api_url` and `base_url` are **one identity**. No valid
+mixture exists.
+
+| Forge | `app_id` | `app_slug` | `api_url` |
+|---|---|---|---|
+| GHE | `5686` | `kubestellar-hive-ghe` | `https://github.ibm.com/api/v3` |
+| Public | `3568013` | `kubestellar-hive` | empty (defaults to `api.github.com`) |
+
+Delivering a GHE `app_id` **without** `api_url` leaves `api_url` empty, which
+defaults to public GitHub, and every token request fails:
+
+```
+POST https://api.github.com/app/installations/<id>/access_tokens
+404 Integration not found
+```
+
+This happened on live hives. `identity_issues` in the provenance report names
+the condition directly.

--- a/v2/pkg/config/layers.go
+++ b/v2/pkg/config/layers.go
@@ -1,0 +1,346 @@
+// Package config — spoke configuration layering.
+//
+// ─────────────────────────────────────────────────────────────────────────
+// PRECEDENCE ORDER — HIGHEST TO LOWEST
+// ─────────────────────────────────────────────────────────────────────────
+//
+//  1. config.env              /etc/hive/config.env            env overrides
+//  2. Per-agent overlays      /data/agent-configs/*.yaml       agents only
+//  3. Dashboard overlay       /data/hive.yaml.dashboard        PVC
+//  4. ConfigMap seed          /etc/hive-seed → /etc/hive/hive.yaml
+//
+// with exactly THREE places a lower layer affects the result:
+//
+//	A. hub.is_public   — the seed's value is applied over the overlay's. This
+//	                     is the ONLY unconditional seed-wins assignment in the
+//	                     whole merge.
+//	B. acmm_level      — the seed is a FALLBACK, used only when the overlay
+//	                     has no level at all (issue #1856).
+//	C. github.*        — the seed wins only as an anti-wipe RATCHET, when the
+//	                     seed holds real App credentials and the overlay's look
+//	                     like a placeholder. A safety catch, not precedence.
+//
+// Everything else: the highest layer that sets the field wins.
+//
+// ─────────────────────────────────────────────────────────────────────────
+// WHY THIS FILE EXISTS
+// ─────────────────────────────────────────────────────────────────────────
+//
+// Until now this order lived in one place only: a Python heredoc inside
+// v2/deploy/entrypoint.sh, run once at pod boot, whose sole externally visible
+// trace was a log line:
+//
+//	[entrypoint] K8s mode — dashboard overlay merged over ConfigMap seed
+//	(overlay wins for acmm_level and github app creds; ConfigMap wins for
+//	hub.is_public)
+//
+// An operator could not answer "which layer sets this field?" without reading
+// pod logs. That cost real hours: a GitHub Enterprise hive was repaired only on
+// the fourth attempt, after patching the hub's meta.json, then clusters.json,
+// then the spoke's ConfigMap — three layers INERT for that field — before
+// patching the dashboard overlay, the one that actually wins.
+//
+// MergeLayers is a behaviour-preserving transcription of that heredoc into Go,
+// so the rule is stated once, in code, and is testable. It deliberately does
+// NOT change which value wins for any field: ~50 live hives depend on current
+// behaviour, and a precedence change is a migration, not a refactor.
+//
+// ─────────────────────────────────────────────────────────────────────────
+// THE SEED DECIDES ALMOST NOTHING, AND NOTHING CAN WRITE IT
+// ─────────────────────────────────────────────────────────────────────────
+//
+// Measured read-only on the live fleet — ConfigMap seed vs running config:
+//
+//	hosted-aslom-hive-agent          559 B of 12,380 B   (4.5%)
+//	hosted-projectbluefin-knuckle  1,661 B of 14,609 B   (11%)
+//	hosted-kubestellar-console     1,051 B of 17,564 B   (6%)
+//
+// The seed omits whole top-level blocks (policies, data, knowledge,
+// notifications, hive_id) that the running config carries.
+//
+// Its one exclusive win, hub.is_public, is owned by a component that CANNOT
+// WRITE THIS LAYER:
+//
+//   - hub → ConfigMap: a single reference in pkg/hub, saas_provision.go:1282,
+//     and it is a "get". There is no write path.
+//   - spoke → ConfigMap: the spoke Role (saas_provision.go:1478-1518) grants
+//     deployments and secrets. "configmaps" appears in no rule, so the spoke
+//     cannot write it even if it tried.
+//
+// And the hub re-asserts is_public over the heartbeat anyway (server.go:1271
+// pushes whenever it disagrees with the spoke; server.go:1077 keeps a hub-set
+// public flag from being reverted), so the seed's win survives at most one
+// beat.
+//
+// This is why every config fix this week travelled by heartbeat into the PVC
+// overlay rather than through the ConfigMap — #2354 (ACMM), #2360 (forge),
+// #2363 (GHE App IDs). The overlay is the only writable channel. The
+// proliferation of bespoke delivery latches is a rational response to having
+// one road, not duplicated effort.
+package config
+
+import "os"
+
+// Layer identifies a configuration source. Ordered lowest → highest, so a
+// numerically greater Layer wins under the default rule.
+type Layer int
+
+const (
+	// LayerUnset means no layer supplied a value for the field.
+	LayerUnset Layer = iota
+	// LayerSeed is the ConfigMap seed, copied to /etc/hive/hive.yaml by the
+	// copy-config init container on every pod boot.
+	LayerSeed
+	// LayerDashboardOverlay is /data/hive.yaml.dashboard on the PVC, written by
+	// Config.Save() on every dashboard edit. This is the layer that decides
+	// nearly everything, and the only one the running system can write.
+	LayerDashboardOverlay
+	// LayerAgentOverlay is /data/agent-configs/<name>.yaml. Contributes agents
+	// only, never top-level fields.
+	LayerAgentOverlay
+	// LayerConfigEnv is config.env, applied last by LoadWithOverrides.
+	LayerConfigEnv
+)
+
+// String names the layer. These strings are part of the
+// /api/config/provenance contract — keep them stable.
+func (l Layer) String() string {
+	switch l {
+	case LayerSeed:
+		return "configmap-seed"
+	case LayerDashboardOverlay:
+		return "dashboard-overlay"
+	case LayerAgentOverlay:
+		return "agent-overlay"
+	case LayerConfigEnv:
+		return "config-env"
+	default:
+		return "unset"
+	}
+}
+
+// Path returns where an operator must write to change a field won by this
+// layer. This is the answer to the question that took four attempts during the
+// GitHub Enterprise incident.
+func (l Layer) Path() string {
+	switch l {
+	case LayerSeed:
+		return "ConfigMap hive-config (key hive.yaml)"
+	case LayerDashboardOverlay:
+		return DashboardOverlayFile
+	case LayerAgentOverlay:
+		return "/data/agent-configs/<agent>.yaml"
+	case LayerConfigEnv:
+		return "/etc/hive/config.env"
+	default:
+		return ""
+	}
+}
+
+// Writer describes who, if anyone, can write a layer at runtime. Reported by
+// the provenance API so an operator can see not just which layer won but
+// whether editing it is even possible.
+//
+// The ConfigMap's answer — "nobody" — is the single most useful fact this
+// package exposes. Nothing in the system writes it: the hub only reads it, and
+// the spoke's RBAC omits configmaps entirely. An operator who edits it and
+// restarts will observe no change, which is exactly what happened four times
+// in a row during the GHE incident.
+func (l Layer) Writer() string {
+	switch l {
+	case LayerSeed:
+		return "nobody (hub has read-only access; spoke RBAC omits configmaps)"
+	case LayerDashboardOverlay:
+		return "spoke (Config.Save) and hub (via heartbeat delivery)"
+	case LayerAgentOverlay:
+		return "spoke (dashboard agent edits)"
+	case LayerConfigEnv:
+		return "cluster admin (pod spec / mounted file)"
+	default:
+		return "n/a"
+	}
+}
+
+// Writable reports whether any running component can write this layer.
+func (l Layer) Writable() bool { return l != LayerSeed && l != LayerUnset }
+
+// seedKeys carries key-presence facts that survive only in raw YAML, so the
+// merge can be exactly faithful to the heredoc. See MergeLayersYAML.
+type seedKeys struct {
+	isPublicPresent bool
+}
+
+// MergeLayers applies the dashboard overlay over the ConfigMap seed and
+// returns the merged config plus provenance naming the winning layer per
+// field.
+//
+// It transcribes the entrypoint's boot-time merge. overlay may be nil (no
+// overlay on disk), in which case the seed is returned untouched, exactly as
+// at boot.
+//
+// FIDELITY: prefer MergeLayersYAML on the boot path. The heredoc gates
+// hub.is_public on the KEY BEING PRESENT in the seed YAML, a distinction lost
+// once YAML is parsed into HubConfig.IsPublic (a plain bool, where absent and
+// explicit-false are both false). MergeLayersYAML preserves it; this function
+// assumes the key is present, which holds for every provisioned seed on the
+// fleet. See TestIsPublicKeyPresenceFidelity.
+//
+// Agent overlays and config.env are applied by LoadWithOverrides AFTER this
+// function, which is why they outrank the dashboard overlay.
+func MergeLayers(seed, overlay *Config) (*Config, *Provenance) {
+	return mergeLayers(seed, overlay, seedKeys{isPublicPresent: true})
+}
+
+func mergeLayers(seed, overlay *Config, keys seedKeys) (*Config, *Provenance) {
+	prov := NewProvenance()
+	if seed == nil {
+		if overlay != nil {
+			prov.recordAll(overlay, LayerDashboardOverlay)
+		}
+		return overlay, prov
+	}
+
+	// A missing or implausible overlay means the seed is used as-is. This is
+	// the dangerous path: seeds on the live fleet are 4–11% of the running
+	// config, so booting on a bare seed can bring a hive up with a fraction of
+	// its agent roster. Callers MUST surface OverlayRejected loudly.
+	if overlay == nil || !OverlayIsPlausible(overlay) {
+		prov.recordAll(seed, LayerSeed)
+		if overlay != nil {
+			prov.OverlayRejected = true
+			prov.OverlayRejectReason = overlayRejectReason(overlay)
+		}
+		return seed, prov
+	}
+
+	// Start from the overlay: the default rule is "highest layer wins". This
+	// mirrors the heredoc, which mutates the overlay dict and writes it back
+	// over the seed path.
+	merged := *overlay
+	prov.recordAll(seed, LayerSeed)
+	prov.recordAll(overlay, LayerDashboardOverlay)
+
+	// ── A: hub.is_public — the seed wins (the only unconditional one) ─────
+	// entrypoint.sh:131-133. Hub-managed and re-asserted every heartbeat, so
+	// the seed merely mirrors hub intent; editing the ConfigMap to change it
+	// is ineffective (see Layer.Writer).
+	if keys.isPublicPresent {
+		merged.Hub.IsPublic = seed.Hub.IsPublic
+		prov.Set("hub.is_public", LayerSeed)
+	}
+
+	// ── B: acmm_level — the seed is only a FALLBACK ───────────────────────
+	// The seed carries the provision-time level and is never updated on a
+	// level change, so letting it win reverted a hive to its provisioned level
+	// on every restart (issue #1856).
+	if overlay.ACMMLevel == nil && seed.ACMMLevel != nil {
+		merged.ACMMLevel = seed.ACMMLevel
+		prov.Set("acmm_level", LayerSeed)
+	} else if overlay.ACMMLevel != nil {
+		prov.Set("acmm_level", LayerDashboardOverlay)
+	}
+
+	// ── C: the GitHub App anti-wipe ratchet ───────────────────────────────
+	// Dashboard- or hub-installed App credentials live ONLY in the overlay;
+	// the seed keeps whatever placeholder it was provisioned with, so the
+	// overlay normally wins. But a missing/truncated/reverted overlay must
+	// never silently downgrade a hive with a live App back to placeholder
+	// creds — observed in production as a 401 loop after a pod restart.
+	if SeedWinsGitHubApp(seed, overlay) {
+		merged.GitHub = seed.GitHub
+		prov.SetPrefix("github.", LayerSeed)
+		prov.GitHubRatchetFired = true
+	}
+
+	return &merged, prov
+}
+
+// OverlayIsPlausible reports whether an overlay looks like a full hive config,
+// mirroring the guard in the entrypoint heredoc and validateSaveGuard.
+//
+// This guard is load-bearing and sharp: an overlay failing it is DISCARDED and
+// the hive boots on the bare ConfigMap seed. Because live seeds are 4–11% of
+// the running config and omit whole blocks, a trip can bring a hive up with a
+// fraction of its agents. Treat any change here as fleet-affecting, and never
+// let a trip be silent — see Provenance.OverlayRejected.
+func OverlayIsPlausible(overlay *Config) bool {
+	return overlayRejectReason(overlay) == ""
+}
+
+// overlayRejectReason returns why an overlay is implausible, or "" if it is
+// fine. Returning the reason (rather than a bare bool) is what lets the boot
+// path log ERROR with a cause and lets provenance show it.
+func overlayRejectReason(overlay *Config) string {
+	if overlay == nil {
+		return "overlay absent"
+	}
+	if overlay.Project.Org == "" {
+		return "overlay has no project.org"
+	}
+	if len(overlay.Agents) == 0 {
+		return "overlay has no agents"
+	}
+	return ""
+}
+
+// SeedWinsGitHubApp reports whether the seed's github block must be preserved
+// over the overlay's — ratchet C. True only when the seed holds real App
+// credentials and the overlay's look like a placeholder.
+func SeedWinsGitHubApp(seed, overlay *Config) bool {
+	if seed == nil || overlay == nil {
+		return false
+	}
+	return !gitHubLooksPlaceholder(seed.GitHub) && gitHubLooksPlaceholder(overlay.GitHub)
+}
+
+// gitHubLooksPlaceholder mirrors _looks_placeholder() in the heredoc: an App
+// is a placeholder when either identifier is absent, or the key file path is
+// literally marked as a placeholder.
+func gitHubLooksPlaceholder(gh GitHubConfig) bool {
+	if gh.AppID == 0 || gh.InstallationID == 0 {
+		return true
+	}
+	return containsFold(gh.KeyFile, "PLACEHOLDER")
+}
+
+// DanglingKeyFile reports whether gh names a PVC key file that does not exist.
+// The entrypoint warns rather than fails here, because the alternative is a
+// silent 401 loop against GitHub. Surfaced through provenance so the condition
+// is visible without reading pod logs.
+func DanglingKeyFile(gh GitHubConfig) bool {
+	const pvcPrefix = "/data/"
+	if len(gh.KeyFile) < len(pvcPrefix) || gh.KeyFile[:len(pvcPrefix)] != pvcPrefix {
+		return false
+	}
+	_, err := os.Stat(gh.KeyFile)
+	return os.IsNotExist(err)
+}
+
+// containsFold reports whether s contains substr, ASCII case-insensitively.
+func containsFold(s, substr string) bool {
+	if len(substr) == 0 {
+		return true
+	}
+	if len(s) < len(substr) {
+		return false
+	}
+	lower := func(b byte) byte {
+		if b >= 'A' && b <= 'Z' {
+			return b + ('a' - 'A')
+		}
+		return b
+	}
+	for i := 0; i+len(substr) <= len(s); i++ {
+		match := true
+		for j := 0; j < len(substr); j++ {
+			if lower(s[i+j]) != lower(substr[j]) {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}

--- a/v2/pkg/config/layers_test.go
+++ b/v2/pkg/config/layers_test.go
@@ -1,0 +1,348 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// intPtr is a local helper so these tests do not depend on helpers elsewhere.
+func intPtr(i int) *int { return &i }
+
+// baseOverlay returns an overlay that passes the plausibility guard. Tests
+// mutate the specific field under test so a failure names one behaviour.
+func baseOverlay() *Config {
+	return &Config{
+		Project: ProjectConfig{Org: "acme"},
+		Agents:  map[string]AgentConfig{"scanner": {}},
+	}
+}
+
+func baseSeed() *Config {
+	return &Config{
+		Project: ProjectConfig{Org: "acme"},
+		Agents:  map[string]AgentConfig{"scanner": {}, "guide": {}},
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// GOLDEN TABLE — one test per row of the documented layering table.
+//
+// These pin CURRENT behaviour. PR 1 is a codification with no behaviour
+// change, so a failure here means either the transcription is wrong or
+// somebody changed which layer wins — the latter being a fleet migration, not
+// a refactor. Treat a diff as a stop-and-report.
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestGoldenTable_OverlayWinsByDefault(t *testing.T) {
+	seed := baseSeed()
+	seed.Project.PrimaryRepo = "seed-repo"
+	overlay := baseOverlay()
+	overlay.Project.PrimaryRepo = "overlay-repo"
+
+	merged, prov := MergeLayers(seed, overlay)
+
+	if merged.Project.PrimaryRepo != "overlay-repo" {
+		t.Errorf("project.primary_repo = %q, want overlay to win with %q",
+			merged.Project.PrimaryRepo, "overlay-repo")
+	}
+	if got := prov.LayerOf("project.primary_repo"); got != LayerDashboardOverlay {
+		t.Errorf("provenance = %v, want %v", got, LayerDashboardOverlay)
+	}
+}
+
+func TestGoldenTable_ACMMLevelOverlayWins(t *testing.T) {
+	// Issue #1856: the seed carries only the provision-time level and goes
+	// stale on any level change. A hive raised to L5 must not drop back to its
+	// provisioned L3 on restart.
+	seed := baseSeed()
+	seed.ACMMLevel = intPtr(3)
+	overlay := baseOverlay()
+	overlay.ACMMLevel = intPtr(5)
+
+	merged, prov := MergeLayers(seed, overlay)
+
+	if merged.ACMMLevel == nil || *merged.ACMMLevel != 5 {
+		t.Fatalf("acmm_level = %v, want overlay's 5 (issue #1856 regression)", merged.ACMMLevel)
+	}
+	if got := prov.LayerOf("acmm_level"); got != LayerDashboardOverlay {
+		t.Errorf("provenance = %v, want %v", got, LayerDashboardOverlay)
+	}
+}
+
+func TestGoldenTable_ACMMLevelSeedIsFallbackOnly(t *testing.T) {
+	// The seed supplies the level ONLY when the overlay has none at all.
+	seed := baseSeed()
+	seed.ACMMLevel = intPtr(3)
+	overlay := baseOverlay() // no ACMMLevel
+
+	merged, prov := MergeLayers(seed, overlay)
+
+	if merged.ACMMLevel == nil || *merged.ACMMLevel != 3 {
+		t.Fatalf("acmm_level = %v, want seed fallback 3", merged.ACMMLevel)
+	}
+	if got := prov.LayerOf("acmm_level"); got != LayerSeed {
+		t.Errorf("provenance = %v, want %v", got, LayerSeed)
+	}
+}
+
+func TestGoldenTable_IsPublicSeedWins(t *testing.T) {
+	// The ONLY unconditional seed-wins assignment in the whole merge.
+	seed := baseSeed()
+	seed.Hub.IsPublic = true
+	overlay := baseOverlay()
+	overlay.Hub.IsPublic = false
+
+	merged, prov := MergeLayers(seed, overlay)
+
+	if !merged.Hub.IsPublic {
+		t.Error("hub.is_public = false, want seed's true to win")
+	}
+	if got := prov.LayerOf("hub.is_public"); got != LayerSeed {
+		t.Errorf("provenance = %v, want %v", got, LayerSeed)
+	}
+}
+
+func TestGoldenTable_GitHubOverlayWinsNormally(t *testing.T) {
+	// Dashboard/hub-installed App creds live only in the overlay; the seed
+	// keeps its provision-time placeholder. The overlay must win.
+	seed := baseSeed()
+	seed.GitHub = GitHubConfig{AppID: 1, InstallationID: 1, KeyFile: "/secrets/PLACEHOLDER.pem"}
+	overlay := baseOverlay()
+	overlay.GitHub = GitHubConfig{AppID: 3568013, InstallationID: 135058248, KeyFile: "/data/gh-app-key.pem"}
+
+	merged, _ := MergeLayers(seed, overlay)
+
+	if merged.GitHub.AppID != 3568013 {
+		t.Errorf("github.app_id = %d, want overlay's real App 3568013", merged.GitHub.AppID)
+	}
+}
+
+func TestGoldenTable_GitHubRatchetPreventsWipe(t *testing.T) {
+	// Ratchet C: a placeholder-looking overlay must never downgrade a hive
+	// that has a real App installed. Observed in production as a 401 loop
+	// after a pod restart.
+	seed := baseSeed()
+	seed.GitHub = GitHubConfig{AppID: 3568013, InstallationID: 135058248, KeyFile: "/data/real.pem"}
+	overlay := baseOverlay()
+	overlay.GitHub = GitHubConfig{} // wiped / placeholder
+
+	merged, prov := MergeLayers(seed, overlay)
+
+	if merged.GitHub.AppID != 3568013 {
+		t.Errorf("github.app_id = %d, want seed's real App preserved by the ratchet",
+			merged.GitHub.AppID)
+	}
+	if !prov.GitHubRatchetFired {
+		t.Error("GitHubRatchetFired = false, want the ratchet to be reported")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Plausibility guard — a trip means booting on the bare seed.
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestOverlayRejected_NoAgentsIsLoud(t *testing.T) {
+	seed := baseSeed()
+	overlay := &Config{Project: ProjectConfig{Org: "acme"}} // no agents
+
+	merged, prov := MergeLayers(seed, overlay)
+
+	if !prov.OverlayRejected {
+		t.Fatal("OverlayRejected = false, want a rejected overlay to be reported")
+	}
+	if !strings.Contains(prov.OverlayRejectReason, "agents") {
+		t.Errorf("reason = %q, want it to name the missing agents", prov.OverlayRejectReason)
+	}
+	// The seed must be used as-is, exactly as at boot.
+	if len(merged.Agents) != len(seed.Agents) {
+		t.Errorf("merged agents = %d, want the seed's %d", len(merged.Agents), len(seed.Agents))
+	}
+}
+
+func TestOverlayRejected_NoOrgIsLoud(t *testing.T) {
+	seed := baseSeed()
+	overlay := &Config{Agents: map[string]AgentConfig{"scanner": {}}} // no project.org
+
+	_, prov := MergeLayers(seed, overlay)
+
+	if !prov.OverlayRejected {
+		t.Fatal("OverlayRejected = false, want a rejected overlay to be reported")
+	}
+	if !strings.Contains(prov.OverlayRejectReason, "project.org") {
+		t.Errorf("reason = %q, want it to name project.org", prov.OverlayRejectReason)
+	}
+}
+
+func TestAbsentOverlayIsNotARejection(t *testing.T) {
+	// No overlay on disk is the ordinary first-boot state, not an anomaly.
+	// Reporting it as a rejection would cry wolf on every fresh hive.
+	_, prov := MergeLayers(baseSeed(), nil)
+
+	if prov.OverlayRejected {
+		t.Error("OverlayRejected = true for an absent overlay, want false")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// is_public key-presence fidelity — the one case where a naive Go
+// transcription would silently diverge from the shell.
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestIsPublicKeyPresenceFidelity(t *testing.T) {
+	// Seed OMITS hub.is_public; overlay sets it true.
+	//
+	// The heredoc gates on `'is_public' in seed['hub']`, so it leaves the
+	// overlay's true alone. A Go transcription over parsed structs cannot see
+	// the difference between "absent" and "false" and would apply the seed's
+	// zero value, silently flipping the hive to private.
+	seedYAML := []byte("project:\n  org: acme\nagents:\n  scanner: {}\nhub:\n  url: https://hub\n")
+	overlayYAML := []byte("project:\n  org: acme\nagents:\n  scanner: {}\nhub:\n  is_public: true\n")
+
+	merged, prov, err := MergeLayersYAML(seedYAML, overlayYAML)
+	if err != nil {
+		t.Fatalf("MergeLayersYAML: %v", err)
+	}
+
+	if !merged.Hub.IsPublic {
+		t.Error("hub.is_public = false, want the overlay's true preserved " +
+			"because the seed omits the key entirely (heredoc fidelity)")
+	}
+	if got := prov.LayerOf("hub.is_public"); got == LayerSeed {
+		t.Error("provenance credits the seed for a key the seed does not set")
+	}
+}
+
+func TestIsPublicExplicitFalseInSeedStillWins(t *testing.T) {
+	// Present-and-false is a real assertion and must beat the overlay, which
+	// is what distinguishes this from the absent case above.
+	seedYAML := []byte("project:\n  org: acme\nagents:\n  scanner: {}\nhub:\n  is_public: false\n")
+	overlayYAML := []byte("project:\n  org: acme\nagents:\n  scanner: {}\nhub:\n  is_public: true\n")
+
+	merged, prov, err := MergeLayersYAML(seedYAML, overlayYAML)
+	if err != nil {
+		t.Fatalf("MergeLayersYAML: %v", err)
+	}
+
+	if merged.Hub.IsPublic {
+		t.Error("hub.is_public = true, want the seed's explicit false to win")
+	}
+	if got := prov.LayerOf("hub.is_public"); got != LayerSeed {
+		t.Errorf("provenance = %v, want %v", got, LayerSeed)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Layer metadata — the operator-facing answers.
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestSeedIsWritableByNobody(t *testing.T) {
+	// The single most useful fact this package exposes. The hub has only a
+	// "get" against configmaps and the spoke's RBAC omits them entirely, so
+	// editing the ConfigMap and restarting changes nothing — which is what
+	// happened four times during the GHE incident.
+	if LayerSeed.Writable() {
+		t.Error("LayerSeed.Writable() = true, want false")
+	}
+	if w := LayerSeed.Writer(); !strings.Contains(w, "nobody") {
+		t.Errorf("LayerSeed.Writer() = %q, want it to say nobody", w)
+	}
+	if !LayerDashboardOverlay.Writable() {
+		t.Error("LayerDashboardOverlay.Writable() = false, want true")
+	}
+}
+
+func TestReportNamesWhereToWrite(t *testing.T) {
+	seed := baseSeed()
+	overlay := baseOverlay()
+	overlay.GitHub = GitHubConfig{AppID: 3568013, InstallationID: 1, KeyFile: "/data/k.pem"}
+
+	merged, prov := MergeLayers(seed, overlay)
+	report := prov.Report(merged)
+
+	var found bool
+	for _, f := range report {
+		if f.Field == "github.app_id" {
+			found = true
+			if f.Path != DashboardOverlayFile {
+				t.Errorf("github.app_id path = %q, want %q", f.Path, DashboardOverlayFile)
+			}
+			if !f.Writable {
+				t.Error("github.app_id reported as not writable, want writable")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("report omits github.app_id")
+	}
+}
+
+func TestReportRedactsToken(t *testing.T) {
+	overlay := baseOverlay()
+	overlay.GitHub = GitHubConfig{Token: "ghp_supersecret"}
+
+	merged, prov := MergeLayers(baseSeed(), overlay)
+	for _, f := range prov.Report(merged) {
+		if strings.Contains(f.Value, "supersecret") {
+			t.Fatalf("report leaked the token in field %s", f.Field)
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// GitHub identity-set invariant — detection only, no behaviour change.
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestIdentitySet_GHESlugWithEmptyAPIURLIsDetected(t *testing.T) {
+	// The live regression: a GHE app_id/slug pushed WITHOUT api_url, so
+	// api_url stayed empty and defaulted to api.github.com, producing
+	// "404 Integration not found" on hives that worked an hour earlier.
+	gh := GitHubConfig{AppID: 5686, AppSlug: "kubestellar-hive-ghe", APIURL: ""}
+
+	issues := IdentitySetIssues(gh)
+	if len(issues) == 0 {
+		t.Fatal("no issues reported for a GHE slug with an empty api_url")
+	}
+	joined := strings.Join(issues, " ")
+	if !strings.Contains(joined, "api.github.com") {
+		t.Errorf("issue text %q does not explain the 404 cause", joined)
+	}
+}
+
+func TestIdentitySet_ConsistentGHEIsClean(t *testing.T) {
+	gh := GitHubConfig{
+		AppID:   5686,
+		AppSlug: "kubestellar-hive-ghe",
+		APIURL:  "https://github.ibm.com/api/v3",
+		BaseURL: "https://github.ibm.com",
+	}
+	if issues := IdentitySetIssues(gh); len(issues) != 0 {
+		t.Errorf("consistent GHE identity reported issues: %v", issues)
+	}
+}
+
+func TestIdentitySet_ConsistentPublicIsClean(t *testing.T) {
+	// Public GitHub legitimately has an empty api_url, so the check must not
+	// fire on the ordinary case — otherwise it is noise on ~48 hives.
+	gh := GitHubConfig{AppID: 3568013, AppSlug: "kubestellar-hive", APIURL: ""}
+	if issues := IdentitySetIssues(gh); len(issues) != 0 {
+		t.Errorf("consistent public identity reported issues: %v", issues)
+	}
+}
+
+func TestIdentitySet_MismatchedBaseAndAPIIsDetected(t *testing.T) {
+	gh := GitHubConfig{
+		AppID:   5686,
+		BaseURL: "https://github.ibm.com",
+		APIURL:  "https://api.github.com",
+	}
+	if issues := IdentitySetIssues(gh); len(issues) == 0 {
+		t.Fatal("no issues reported for base_url/api_url naming different forges")
+	}
+}
+
+func TestIdentitySet_NoAppConfiguredIsClean(t *testing.T) {
+	// A token-auth hive has no App identity to be inconsistent about.
+	if issues := IdentitySetIssues(GitHubConfig{Token: "x"}); len(issues) != 0 {
+		t.Errorf("token-only hive reported identity issues: %v", issues)
+	}
+}

--- a/v2/pkg/config/layers_yaml.go
+++ b/v2/pkg/config/layers_yaml.go
@@ -1,0 +1,81 @@
+package config
+
+// Exact-fidelity merge entry points.
+//
+// MergeLayers operates on parsed *Config values, which is convenient but loses
+// one distinction the entrypoint heredoc depends on: whether a KEY WAS PRESENT
+// in the YAML at all.
+//
+// The heredoc gates the hub.is_public inversion on key presence:
+//
+//	if isinstance(seed.get('hub'), dict) and 'is_public' in seed['hub']:
+//	    overlay.setdefault('hub', {})['is_public'] = seed['hub']['is_public']
+//
+// HubConfig.IsPublic is a plain bool, so after parsing, "key absent" and
+// "is_public: false" are both false and indistinguishable. A Go transcription
+// that ignores this differs from the shell in exactly one case:
+//
+//	seed omits hub.is_public  AND  overlay sets it true
+//	  → heredoc keeps the overlay's true
+//	  → naive Go applies the seed's false
+//
+// That is a silent visibility flip on whichever hives happen to hit it. This
+// PR exists to END divergence between the documented rule and the running
+// behaviour, so shipping a known divergence inside it would be
+// self-defeating. MergeLayersYAML parses the raw seed YAML to recover
+// key-presence and reproduces the heredoc exactly.
+
+import "gopkg.in/yaml.v3"
+
+// MergeLayersYAML merges raw seed and overlay YAML with exact fidelity to the
+// entrypoint heredoc, returning the merged config and its provenance.
+//
+// overlayYAML may be empty, meaning no overlay on disk: the seed is used as-is,
+// exactly as at boot.
+//
+// This is the entry point the boot path should use. MergeLayers remains for
+// callers that already hold parsed configs and accept the documented
+// is_public caveat.
+func MergeLayersYAML(seedYAML, overlayYAML []byte) (*Config, *Provenance, error) {
+	var seed Config
+	if err := yaml.Unmarshal([]byte(expandEnvVars(string(seedYAML))), &seed); err != nil {
+		return nil, nil, err
+	}
+
+	keys := seedKeys{isPublicPresent: seedHasIsPublic(seedYAML)}
+
+	if len(overlayYAML) == 0 {
+		cfg, prov := mergeLayers(&seed, nil, keys)
+		return cfg, prov, nil
+	}
+
+	var overlay Config
+	if err := yaml.Unmarshal([]byte(expandEnvVars(string(overlayYAML))), &overlay); err != nil {
+		// A malformed overlay is treated as absent, matching the entrypoint's
+		// behaviour of falling back to the seed rather than failing the boot.
+		cfg, prov := mergeLayers(&seed, nil, keys)
+		prov.OverlayRejected = true
+		prov.OverlayRejectReason = "overlay is not valid YAML: " + err.Error()
+		return cfg, prov, nil
+	}
+
+	cfg, prov := mergeLayers(&seed, &overlay, keys)
+	return cfg, prov, nil
+}
+
+// seedHasIsPublic reports whether the raw seed YAML contains the hub.is_public
+// key, regardless of its value. This is the fact that parsing into a bool
+// destroys.
+func seedHasIsPublic(seedYAML []byte) bool {
+	var probe struct {
+		Hub map[string]yaml.Node `yaml:"hub"`
+	}
+	if err := yaml.Unmarshal(seedYAML, &probe); err != nil {
+		// Unparsable seed: assume present, which is the behaviour every
+		// provisioned seed on the fleet exhibits (the provisioning template
+		// always emits hub.is_public).
+		return true
+	}
+	_, ok := probe.Hub["is_public"]
+	return ok
+}

--- a/v2/pkg/config/provenance.go
+++ b/v2/pkg/config/provenance.go
@@ -1,0 +1,283 @@
+package config
+
+// Field provenance — "which layer set this field, and can I even edit it?"
+//
+// This exists because that question previously had no answer short of reading
+// pod boot logs. The cost was concrete and repeated:
+//
+//   - A GitHub Enterprise hive was repaired on the FOURTH attempt, after
+//     patching the hub's meta.json, then clusters.json, then the spoke's
+//     ConfigMap — three layers that are INERT for github.app_id — before
+//     patching the dashboard overlay, the layer that actually wins.
+//
+//   - A half-applied GHE identity (app_id switched to the GHE App, api_url
+//     left empty so it defaulted to api.github.com) produced
+//     "404 Integration not found" on live hives. The two fields live in the
+//     same layer, and seeing them side by side with their sources would have
+//     made the split obvious immediately. See IdentitySetIssues.
+//
+// Provenance is derived, never authoritative: it records what MergeLayers did.
+// It changes no behaviour.
+
+import (
+	"sort"
+	"strconv"
+)
+
+// FieldOrigin records where one field's effective value came from.
+type FieldOrigin struct {
+	// Field is the dotted config path, e.g. "github.app_id".
+	Field string `json:"field"`
+	// Layer is the layer that supplied the winning value.
+	Layer string `json:"layer"`
+	// Path is where to write to change it.
+	Path string `json:"path"`
+	// Writer names who can write that layer at runtime. For the ConfigMap
+	// seed this is "nobody" — the fact that ends most misdirected repairs.
+	Writer string `json:"writer"`
+	// Writable is false when no running component can write the layer.
+	Writable bool `json:"writable"`
+	// Value is the effective value, rendered for display. Secrets are
+	// redacted; see redactField.
+	Value string `json:"value,omitempty"`
+	// AlsoSetBy lists lower layers that set this field but lost. This is what
+	// reveals a stale ConfigMap value that looks authoritative and is not.
+	AlsoSetBy []string `json:"also_set_by,omitempty"`
+}
+
+// Provenance is the per-field origin map for one merge.
+type Provenance struct {
+	// Fields maps dotted field path → winning layer.
+	Fields map[string]Layer `json:"-"`
+	// alsoSet tracks every layer that supplied a value, winner included.
+	alsoSet map[string][]Layer
+
+	// OverlayRejected is true when a dashboard overlay existed but failed the
+	// plausibility guard and was DISCARDED, so the hive is running on the bare
+	// ConfigMap seed.
+	//
+	// On the live fleet seeds are 4–11% of the running config, so this state
+	// can mean a hive booted with a fraction of its agent roster. It must
+	// never be silent.
+	OverlayRejected bool `json:"overlay_rejected"`
+	// OverlayRejectReason names why, e.g. "overlay has no agents".
+	OverlayRejectReason string `json:"overlay_reject_reason,omitempty"`
+	// GitHubRatchetFired is true when the seed's github block was kept because
+	// the overlay's looked like a placeholder (ratchet C in layers.go).
+	GitHubRatchetFired bool `json:"github_ratchet_fired"`
+}
+
+// NewProvenance returns an empty Provenance.
+func NewProvenance() *Provenance {
+	return &Provenance{
+		Fields:  make(map[string]Layer),
+		alsoSet: make(map[string][]Layer),
+	}
+}
+
+// Set records that layer supplied the winning value for field.
+func (p *Provenance) Set(field string, layer Layer) {
+	if p == nil {
+		return
+	}
+	p.Fields[field] = layer
+}
+
+// SetPrefix re-points every already-recorded field under prefix at layer. Used
+// when a whole block changes owner at once, as the github ratchet does.
+func (p *Provenance) SetPrefix(prefix string, layer Layer) {
+	if p == nil {
+		return
+	}
+	for f := range p.Fields {
+		if len(f) >= len(prefix) && f[:len(prefix)] == prefix {
+			p.Fields[f] = layer
+		}
+	}
+}
+
+// LayerOf returns the layer that set field, or LayerUnset.
+func (p *Provenance) LayerOf(field string) Layer {
+	if p == nil {
+		return LayerUnset
+	}
+	return p.Fields[field]
+}
+
+// note records that layer supplied a value for field, winner or not.
+func (p *Provenance) note(field string, layer Layer) {
+	if p == nil {
+		return
+	}
+	for _, l := range p.alsoSet[field] {
+		if l == layer {
+			return
+		}
+	}
+	p.alsoSet[field] = append(p.alsoSet[field], layer)
+}
+
+// recordAll walks cfg and records layer as a source for every field it sets,
+// overwriting any previously recorded winner. Callers apply layers lowest →
+// highest so the last write wins, matching the merge order.
+func (p *Provenance) recordAll(cfg *Config, layer Layer) {
+	if p == nil || cfg == nil {
+		return
+	}
+	for _, f := range enumerateFields(cfg) {
+		p.Fields[f.Field] = layer
+		p.note(f.Field, layer)
+	}
+}
+
+// enumerateFields lists the config fields provenance tracks, with their
+// rendered values.
+//
+// This is a deliberately CURATED list, not reflection over the whole struct.
+// It covers the fields an operator actually changes — the rows of the layering
+// table — because an exhaustive dump of every nested field would bury the
+// handful that matter. Fields absent from a config are skipped, so "not
+// listed" means "no layer set it".
+func enumerateFields(cfg *Config) []FieldOrigin {
+	if cfg == nil {
+		return nil
+	}
+	var out []FieldOrigin
+	add := func(field, value string) {
+		if value == "" {
+			return
+		}
+		out = append(out, FieldOrigin{Field: field, Value: value})
+	}
+
+	add("project.org", cfg.Project.Org)
+	add("project.primary_repo", cfg.Project.PrimaryRepo)
+	if len(cfg.Project.Repos) > 0 {
+		add("project.repos", strconv.Itoa(len(cfg.Project.Repos))+" repo(s)")
+	}
+
+	if cfg.ACMMLevel != nil {
+		add("acmm_level", strconv.Itoa(*cfg.ACMMLevel))
+	}
+
+	// The GitHub identity set. These four fields must be internally
+	// consistent; see IdentitySetIssues.
+	if cfg.GitHub.AppID != 0 {
+		add("github.app_id", strconv.FormatInt(cfg.GitHub.AppID, 10))
+	}
+	if cfg.GitHub.InstallationID != 0 {
+		add("github.installation_id", strconv.FormatInt(cfg.GitHub.InstallationID, 10))
+	}
+	add("github.app_slug", cfg.GitHub.AppSlug)
+	add("github.api_url", cfg.GitHub.APIURL)
+	add("github.base_url", cfg.GitHub.BaseURL)
+	add("github.key_file", cfg.GitHub.KeyFile)
+	if cfg.GitHub.Token != "" {
+		add("github.token", redacted)
+	}
+
+	add("hub.url", cfg.Hub.URL)
+	add("hub.is_public", strconv.FormatBool(cfg.Hub.IsPublic))
+	add("hive_id", cfg.HiveID)
+
+	for name := range cfg.Agents {
+		add("agents."+name, "configured")
+	}
+	return out
+}
+
+// redacted is the placeholder shown instead of secret values. Provenance is
+// exposed over the dashboard API, so it must never carry credentials.
+const redacted = "<redacted>"
+
+// Report renders the provenance of cfg as a stable, sorted list suitable for
+// the /api/config/provenance response.
+func (p *Provenance) Report(cfg *Config) []FieldOrigin {
+	fields := enumerateFields(cfg)
+	out := make([]FieldOrigin, 0, len(fields))
+	for _, f := range fields {
+		layer := p.LayerOf(f.Field)
+		f.Layer = layer.String()
+		f.Path = layer.Path()
+		f.Writer = layer.Writer()
+		f.Writable = layer.Writable()
+		if p != nil {
+			for _, l := range p.alsoSet[f.Field] {
+				if l != layer {
+					f.AlsoSetBy = append(f.AlsoSetBy, l.String())
+				}
+			}
+			sort.Strings(f.AlsoSetBy)
+		}
+		out = append(out, f)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Field < out[j].Field })
+	return out
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// GitHub identity-set invariant
+// ─────────────────────────────────────────────────────────────────────────
+
+// gheAPIURLMarker identifies a GitHub Enterprise API URL. Public GitHub uses
+// api.github.com (or an empty api_url, which defaults to it).
+const gheAPIURLMarker = "/api/v3"
+
+// IdentitySetIssues reports inconsistencies within the GitHub identity set:
+// app_id, app_slug, api_url and base_url are ONE atomic identity and no valid
+// mixture of forges exists.
+//
+//	GHE:    app_id=<ghe app>    slug=<ghe slug>    api_url=https://<host>/api/v3
+//	Public: app_id=<public app> slug=<public slug> api_url="" (or api.github.com)
+//
+// WHY THIS EXISTS. A cluster-config change pushed a GHE app_id to a set of
+// hives WITHOUT also pushing api_url. The spokes ended up with a GHE App ID
+// and an empty api_url, which defaults to public GitHub, and every token
+// request failed:
+//
+//	POST https://api.github.com/app/installations/<id>/access_tokens
+//	404 Integration not found
+//
+// The hives that also received api_url=https://github.ibm.com/api/v3 were
+// fine — the failure split exactly on that one field. #2360's forge endpoint
+// refuses half-applied identities by construction; the cluster-config push
+// path has no such guard.
+//
+// This function only DETECTS and NAMES the invalid state — it changes no
+// behaviour and rejects nothing. Surfacing it in provenance is what makes the
+// split visible at a glance instead of via a 404 in agent logs.
+func IdentitySetIssues(gh GitHubConfig) []string {
+	var issues []string
+	apiIsGHE := containsFold(gh.APIURL, gheAPIURLMarker)
+	baseIsGHE := gh.BaseURL != "" && !containsFold(gh.BaseURL, "github.com")
+	slugIsGHE := containsFold(gh.AppSlug, "ghe")
+
+	// The live regression: an App is configured and the forge markers
+	// disagree with each other.
+	if gh.AppID != 0 {
+		if slugIsGHE && !apiIsGHE {
+			issues = append(issues, "app_slug looks like a GitHub Enterprise slug ("+gh.AppSlug+
+				") but api_url is not a GHE API URL ("+displayOrEmpty(gh.APIURL)+
+				") — a GHE App ID presented to api.github.com returns 404 Integration not found")
+		}
+		if baseIsGHE && !apiIsGHE {
+			issues = append(issues, "base_url is "+gh.BaseURL+" but api_url is "+
+				displayOrEmpty(gh.APIURL)+" — base_url and api_url must name the same forge")
+		}
+		if apiIsGHE && gh.BaseURL != "" && !baseIsGHE {
+			issues = append(issues, "api_url is a GHE API URL but base_url is "+gh.BaseURL+
+				" — base_url and api_url must name the same forge")
+		}
+	}
+	return issues
+}
+
+// displayOrEmpty renders an empty string as an explicit marker, so a report
+// never shows a blank where a value is expected. An empty api_url is exactly
+// the condition that caused the outage, so it must be visible, not invisible.
+func displayOrEmpty(s string) string {
+	if s == "" {
+		return "<empty — defaults to api.github.com>"
+	}
+	return s
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -37,6 +37,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/version", s.handleVersion)
 	s.mux.HandleFunc("GET /api/config", s.handleConfig)
 	s.mux.HandleFunc("GET /api/config/download", s.handleConfigDownload)
+	s.mux.HandleFunc("GET /api/config/provenance", s.handleConfigProvenance)
 	s.mux.HandleFunc("GET /api/config/variables", s.handleVariablesList)
 	s.mux.HandleFunc("GET /api/config/authorized-users", s.handleAuthorizedUsersList)
 	s.mux.HandleFunc("PUT /api/config/variables/{name}", s.handleVariableUpsert)

--- a/v2/pkg/dashboard/api_provenance.go
+++ b/v2/pkg/dashboard/api_provenance.go
@@ -1,0 +1,150 @@
+package dashboard
+
+// GET /api/config/provenance — "which layer set this field, and can I edit it?"
+//
+// Before this endpoint, that question was answerable only by reading pod boot
+// logs for a single entrypoint line. The cost was concrete: a GitHub
+// Enterprise hive was repaired on the FOURTH attempt, after patching the hub's
+// meta.json, then clusters.json, then the spoke's ConfigMap — three layers
+// INERT for github.app_id — before patching the dashboard overlay, the layer
+// that actually wins.
+//
+// The response answers, per field: which layer won, where to write to change
+// it, and whether that layer is writable AT ALL. The ConfigMap seed's answer
+// is "nobody" — nothing in the system can write it (the hub holds only a
+// read-only get; the spoke's RBAC omits configmaps), which is why editing it
+// and restarting appears to do nothing.
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// provenanceResponse is the JSON body of GET /api/config/provenance.
+type provenanceResponse struct {
+	// Fields lists every tracked field with its winning layer and writability.
+	Fields []config.FieldOrigin `json:"fields"`
+	// Layers describes each layer once, so a client can render a legend
+	// without hardcoding the precedence order.
+	Layers []layerInfo `json:"layers"`
+	// OverlayRejected is true when a dashboard overlay exists but failed the
+	// plausibility guard and was DISCARDED, meaning this hive is running on
+	// the bare ConfigMap seed. On the live fleet seeds are 4–11% of the
+	// running config, so this can mean a hive booted with a fraction of its
+	// agent roster. It is surfaced here so the condition is visible without
+	// reading pod logs.
+	OverlayRejected bool `json:"overlay_rejected"`
+	// OverlayRejectReason names why the overlay was rejected.
+	OverlayRejectReason string `json:"overlay_reject_reason,omitempty"`
+	// GitHubRatchetFired is true when the seed's github block was preserved
+	// because the overlay's looked like a placeholder.
+	GitHubRatchetFired bool `json:"github_ratchet_fired"`
+	// IdentityIssues names inconsistencies in the GitHub identity set
+	// (app_id/app_slug/api_url/base_url are one atomic identity). Empty is the
+	// healthy case. A GHE app_id with an empty api_url produces
+	// "404 Integration not found" on every token request.
+	IdentityIssues []string `json:"identity_issues,omitempty"`
+	// SeedPath and OverlayPath name the files this report was derived from.
+	SeedPath    string `json:"seed_path"`
+	OverlayPath string `json:"overlay_path"`
+	// OverlayPresent is false when no overlay exists on disk — the ordinary
+	// first-boot state, not an error.
+	OverlayPresent bool `json:"overlay_present"`
+}
+
+// layerInfo describes one configuration layer for the response legend.
+type layerInfo struct {
+	// Rank is the precedence rank; higher wins.
+	Rank int `json:"rank"`
+	// Name is the stable layer identifier, e.g. "dashboard-overlay".
+	Name string `json:"name"`
+	// Path is where the layer lives.
+	Path string `json:"path"`
+	// Writer names who can write it at runtime.
+	Writer string `json:"writer"`
+	// Writable is false when no running component can write it.
+	Writable bool `json:"writable"`
+}
+
+// handleConfigProvenance serves GET /api/config/provenance.
+//
+// Owner-gated, matching handleConfigDownload: the report names config paths
+// and effective values, so it is operator information rather than public
+// status. Secret values are redacted regardless.
+func (s *Server) handleConfigProvenance(w http.ResponseWriter, r *http.Request) {
+	role := r.Header.Get("X-Hive-Role")
+	if role == "" {
+		role = "owner"
+	}
+	if role != "owner" {
+		http.Error(w, "owner access required", http.StatusForbidden)
+		return
+	}
+
+	seedPath := "/etc/hive/hive.yaml"
+	if envCfg := os.Getenv("HIVE_CONFIG"); envCfg != "" {
+		seedPath = envCfg
+	}
+	overlayPath := config.DashboardOverlayFile
+
+	seedYAML, err := os.ReadFile(seedPath)
+	if err != nil {
+		http.Error(w, "config file not found", http.StatusNotFound)
+		return
+	}
+	// A missing overlay is normal on first boot, so a read error here is not
+	// an error condition — it means "seed only", which MergeLayersYAML
+	// represents as an empty overlay.
+	overlayYAML, overlayErr := os.ReadFile(overlayPath)
+	if overlayErr != nil {
+		overlayYAML = nil
+	}
+
+	merged, prov, err := config.MergeLayersYAML(seedYAML, overlayYAML)
+	if err != nil {
+		http.Error(w, "config is not parsable: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resp := provenanceResponse{
+		Fields:              prov.Report(merged),
+		Layers:              describeLayers(),
+		OverlayRejected:     prov.OverlayRejected,
+		OverlayRejectReason: prov.OverlayRejectReason,
+		GitHubRatchetFired:  prov.GitHubRatchetFired,
+		SeedPath:            seedPath,
+		OverlayPath:         overlayPath,
+		OverlayPresent:      len(overlayYAML) > 0,
+	}
+	if merged != nil {
+		resp.IdentityIssues = config.IdentitySetIssues(merged.GitHub)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// describeLayers returns the layer legend, highest precedence last so the
+// order in the response matches the documented precedence order.
+func describeLayers() []layerInfo {
+	layers := []config.Layer{
+		config.LayerSeed,
+		config.LayerDashboardOverlay,
+		config.LayerAgentOverlay,
+		config.LayerConfigEnv,
+	}
+	out := make([]layerInfo, 0, len(layers))
+	for _, l := range layers {
+		out = append(out, layerInfo{
+			Rank:     int(l),
+			Name:     l.String(),
+			Path:     l.Path(),
+			Writer:   l.Writer(),
+			Writable: l.Writable(),
+		})
+	}
+	return out
+}

--- a/v2/pkg/dashboard/api_provenance_test.go
+++ b/v2/pkg/dashboard/api_provenance_test.go
@@ -1,0 +1,203 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// writeProvenanceFixture points the handler at temp seed/overlay files and
+// restores the globals afterwards.
+func writeProvenanceFixture(t *testing.T, seedYAML, overlayYAML string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	seedPath := filepath.Join(dir, "hive.yaml")
+	if err := os.WriteFile(seedPath, []byte(seedYAML), 0o644); err != nil {
+		t.Fatalf("writing seed: %v", err)
+	}
+	t.Setenv("HIVE_CONFIG", seedPath)
+
+	prevOverlay := config.DashboardOverlayFile
+	t.Cleanup(func() { config.DashboardOverlayFile = prevOverlay })
+	overlayPath := filepath.Join(dir, "hive.yaml.dashboard")
+	if overlayYAML != "" {
+		if err := os.WriteFile(overlayPath, []byte(overlayYAML), 0o644); err != nil {
+			t.Fatalf("writing overlay: %v", err)
+		}
+	}
+	config.DashboardOverlayFile = overlayPath
+}
+
+func getProvenance(t *testing.T, role string) (*httptest.ResponseRecorder, provenanceResponse) {
+	t.Helper()
+	s := &Server{}
+	req := httptest.NewRequest(http.MethodGet, "/api/config/provenance", nil)
+	if role != "" {
+		req.Header.Set("X-Hive-Role", role)
+	}
+	rec := httptest.NewRecorder()
+	s.handleConfigProvenance(rec, req)
+
+	var body provenanceResponse
+	if rec.Code == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decoding response: %v (body=%s)", err, rec.Body.String())
+		}
+	}
+	return rec, body
+}
+
+func fieldByName(fields []config.FieldOrigin, name string) (config.FieldOrigin, bool) {
+	for _, f := range fields {
+		if f.Field == name {
+			return f, true
+		}
+	}
+	return config.FieldOrigin{}, false
+}
+
+// TestProvenanceAnswersTheGHEQuestion is the regression this endpoint exists
+// for. During the GitHub Enterprise incident an operator patched meta.json,
+// clusters.json and the ConfigMap — all inert for github.app_id — before
+// finding that the dashboard overlay is the layer that wins. The report must
+// name the overlay, and name its path, so the first attempt is the right one.
+func TestProvenanceAnswersTheGHEQuestion(t *testing.T) {
+	writeProvenanceFixture(t,
+		"project:\n  org: acme\nagents:\n  scanner: {}\ngithub:\n  app_id: 1\n  installation_id: 1\n  key_file: /secrets/PLACEHOLDER.pem\n",
+		"project:\n  org: acme\nagents:\n  scanner: {}\ngithub:\n  app_id: 5686\n  installation_id: 146551814\n  key_file: /data/gh-app-key.pem\n")
+
+	rec, body := getProvenance(t, "owner")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	f, ok := fieldByName(body.Fields, "github.app_id")
+	if !ok {
+		t.Fatal("report omits github.app_id")
+	}
+	if f.Layer != "dashboard-overlay" {
+		t.Errorf("github.app_id layer = %q, want dashboard-overlay", f.Layer)
+	}
+	if !strings.Contains(f.Path, "hive.yaml.dashboard") {
+		t.Errorf("github.app_id path = %q, want it to name the overlay file", f.Path)
+	}
+	if !f.Writable {
+		t.Error("github.app_id reported as not writable; the overlay is writable")
+	}
+	// The seed also sets app_id (with a placeholder) and lost. Saying so is
+	// what stops an operator from trusting the ConfigMap's value.
+	if len(f.AlsoSetBy) == 0 {
+		t.Error("AlsoSetBy is empty; the losing seed value should be disclosed")
+	}
+}
+
+// TestProvenanceReportsSeedUnwritable pins the single most valuable line in
+// the report: nothing can write the ConfigMap.
+func TestProvenanceReportsSeedUnwritable(t *testing.T) {
+	writeProvenanceFixture(t,
+		"project:\n  org: acme\nagents:\n  scanner: {}\nhub:\n  is_public: true\n",
+		"project:\n  org: acme\nagents:\n  scanner: {}\n")
+
+	_, body := getProvenance(t, "owner")
+
+	var seedLayer *layerInfo
+	for i := range body.Layers {
+		if body.Layers[i].Name == "configmap-seed" {
+			seedLayer = &body.Layers[i]
+		}
+	}
+	if seedLayer == nil {
+		t.Fatal("layer legend omits configmap-seed")
+	}
+	if seedLayer.Writable {
+		t.Error("configmap-seed reported writable, want false")
+	}
+	if !strings.Contains(seedLayer.Writer, "nobody") {
+		t.Errorf("configmap-seed writer = %q, want it to say nobody", seedLayer.Writer)
+	}
+}
+
+// TestProvenanceSurfacesHalfAppliedGHEIdentity covers the live regression: a
+// GHE app_id/slug delivered WITHOUT api_url, so api_url stayed empty and
+// defaulted to api.github.com, producing 404 Integration not found.
+func TestProvenanceSurfacesHalfAppliedGHEIdentity(t *testing.T) {
+	writeProvenanceFixture(t,
+		"project:\n  org: acme\nagents:\n  scanner: {}\n",
+		"project:\n  org: acme\nagents:\n  scanner: {}\ngithub:\n  app_id: 5686\n  installation_id: 146551814\n  app_slug: kubestellar-hive-ghe\n")
+
+	_, body := getProvenance(t, "owner")
+
+	if len(body.IdentityIssues) == 0 {
+		t.Fatal("no identity issues reported for a GHE slug with an empty api_url")
+	}
+	joined := strings.Join(body.IdentityIssues, " ")
+	if !strings.Contains(joined, "api.github.com") {
+		t.Errorf("issue text %q does not explain the 404 cause", joined)
+	}
+}
+
+// TestProvenanceFlagsRejectedOverlay: a discarded overlay means the hive is
+// running on the bare seed, which on the live fleet can be 4–11% of the real
+// config. It must never be silent.
+func TestProvenanceFlagsRejectedOverlay(t *testing.T) {
+	writeProvenanceFixture(t,
+		"project:\n  org: acme\nagents:\n  scanner: {}\n",
+		"project:\n  org: acme\n") // no agents — fails the guard
+
+	_, body := getProvenance(t, "owner")
+
+	if !body.OverlayRejected {
+		t.Fatal("overlay_rejected = false, want true for an overlay with no agents")
+	}
+	if !strings.Contains(body.OverlayRejectReason, "agents") {
+		t.Errorf("reason = %q, want it to name the missing agents", body.OverlayRejectReason)
+	}
+}
+
+// TestProvenanceAbsentOverlayIsNotAnError: first boot has no overlay. That is
+// normal and must not be reported as a rejection, or the signal is noise.
+func TestProvenanceAbsentOverlayIsNotAnError(t *testing.T) {
+	writeProvenanceFixture(t, "project:\n  org: acme\nagents:\n  scanner: {}\n", "")
+
+	rec, body := getProvenance(t, "owner")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if body.OverlayRejected {
+		t.Error("overlay_rejected = true with no overlay on disk, want false")
+	}
+	if body.OverlayPresent {
+		t.Error("overlay_present = true with no overlay on disk, want false")
+	}
+}
+
+// TestProvenanceRequiresOwner matches handleConfigDownload's gating: the
+// report names config paths and effective values.
+func TestProvenanceRequiresOwner(t *testing.T) {
+	writeProvenanceFixture(t, "project:\n  org: acme\nagents:\n  scanner: {}\n", "")
+
+	rec, _ := getProvenance(t, "viewer")
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d for a non-owner, want 403", rec.Code)
+	}
+}
+
+// TestProvenanceRedactsSecrets: the report is served over the dashboard API
+// and must never carry credentials.
+func TestProvenanceRedactsSecrets(t *testing.T) {
+	writeProvenanceFixture(t,
+		"project:\n  org: acme\nagents:\n  scanner: {}\n",
+		"project:\n  org: acme\nagents:\n  scanner: {}\ngithub:\n  token: ghp_supersecret\n")
+
+	rec, _ := getProvenance(t, "owner")
+	if strings.Contains(rec.Body.String(), "supersecret") {
+		t.Fatal("response leaked the github token")
+	}
+}


### PR DESCRIPTION
## What an operator can now answer

```bash
curl -s localhost:3002/api/config/provenance | jq .
```

Per field: **which layer won, where to write to change it, and whether that layer is writable at all.** Previously that fact existed in exactly one place — a line of pod boot logs.

This is codification, **not a behaviour change**. `MergeLayers` is a transcription of the entrypoint heredoc; the golden tests pin every row of the table. Nothing about which value wins for any field changes on any of the ~50 live hives.

## The finding that matters most: nothing can write the ConfigMap

- **hub → ConfigMap**: one reference in all of `pkg/hub` (`saas_provision.go:1282`) and it is a `get`. There is no write path.
- **spoke → ConfigMap**: the spoke Role (`saas_provision.go:1478-1518`) grants `deployments` and `secrets`. `configmaps` appears in no rule — the spoke could not write it if it tried.
- **33 of 51 hives** are on `vllm-d`, which the hub cannot reach for API calls at all.

And it is authoritative for **exactly one field** — `hub.is_public`, the only unconditional seed-wins assignment in the entire merge — which the hub re-asserts every heartbeat anyway (`server.go:1271`), so its win survives at most one beat.

Measured live, seed vs running config: `aslom` 559 B / 12,380 B (4.5%), `bluefin` 1,661 B / 14,609 B (11%), `console` 1,051 B / 17,564 B (6%). The seed omits whole top-level blocks (`policies`, `data`, `knowledge`, `notifications`, `hive_id`).

So the ConfigMap **looks** authoritative — it is the only layer visible to `kubectl` without exec'ing into a pod — and decides essentially nothing. `Layer.Writer()` now returns, for the seed, literally:

> `nobody (hub has read-only access; spoke RBAC omits configmaps)`

That one line would have ended the GitHub Enterprise incident at attempt one instead of attempt four, where `meta.json`, `clusters.json` and the ConfigMap were each patched in turn — all three inert for `github.app_id` — before the dashboard overlay, which is the layer that wins.

It also explains the delivery-latch proliferation. Every config fix this week travelled by heartbeat into the PVC overlay — #2354 (ACMM), #2360 (forge), #2363 (GHE App IDs) — because the overlay is the only writable channel. Three bespoke latches in a week is a rational response to having one road, not duplicated effort.

## Precedence order, now stated once

| Rank | Layer | Path | Writable by |
|---|---|---|---|
| 1 (wins) | `config-env` | `/etc/hive/config.env` | cluster admin |
| 2 | `agent-overlay` | `/data/agent-configs/<agent>.yaml` | spoke |
| 3 | `dashboard-overlay` | `/data/hive.yaml.dashboard` | **spoke + hub (heartbeat)** |
| 4 (loses) | `configmap-seed` | ConfigMap `hive-config` | **nobody** |

Three documented exceptions where a lower layer affects the result: **A** `hub.is_public` (seed wins — the only unconditional one); **B** `acmm_level` (seed is a *fallback only*, issue #1856); **C** `github.*` (seed wins only as an anti-wipe **ratchet** when the overlay looks like a placeholder — a safety catch, not precedence).

## Exact fidelity on `hub.is_public`

The heredoc gates this on the **key being present** in the seed YAML. `HubConfig.IsPublic` is a plain `bool`, so after parsing, "absent" and "explicit false" are indistinguishable. A naive Go transcription would diverge in exactly one case — seed omits the key, overlay sets it true — silently flipping a hive to private.

`MergeLayersYAML` parses the raw seed to recover key-presence. Shipping a known divergence inside the PR that claims to end divergence would undercut the whole thing. `TestIsPublicKeyPresenceFidelity` pins it, and mutation M4 confirms the naive version fails it.

## The GitHub identity set is atomic

`app_id`, `app_slug`, `api_url`, `base_url` are **one identity**; no valid mixture exists. Delivering a GHE `app_id` without `api_url` leaves `api_url` empty, defaulting to public GitHub:

```
POST https://api.github.com/app/installations/<id>/access_tokens
404 Integration not found
```

That happened on live hives today. `IdentitySetIssues` **detects and names** the state — it rejects nothing and changes no behaviour — and it surfaces in `identity_issues`. `TestIdentitySet_ConsistentPublicIsClean` guards against firing on the ordinary empty-`api_url` case, so it is not noise on the ~48 public hives.

## Also surfaced: a discarded overlay is no longer silent

The plausibility guard (`entrypoint.sh:63-66`) discards an overlay lacking `project.org` or agents, and the hive boots on the bare seed. Given seeds are 4–11% of the running config, that can mean booting with a fraction of the agent roster. `overlay_rejected` + `overlay_reject_reason` now report it. Hardening the guard itself is deliberately left to a follow-up.

## Tests

19 golden/unit tests in `pkg/config`, 7 endpoint tests in `pkg/dashboard`.

**Mutation-verified non-vacuous — 11 mutations, all caught:** acmm_level precedence inverted (fails with the #1856 symptom); ratchet disabled; `is_public` seed-win removed; key-presence fidelity dropped; guard neutered (×2); identity check disabled (×2); seed reported writable; token redaction removed; owner gate removed; rejection not propagated. Sources restored and green after each.

`go build ./...` clean, `go vet` clean, `pkg/config` and `pkg/dashboard` both fully pass.

`pkg/hub/saas.go` and `pkg/dashboard/static/index.html` are **untouched** — no embedded-JS or raw-string risk in this PR.

## Live systems

**Strictly read-only.** `kubectl get` / `exec … wc -l` against three ConfigMaps and three pods to measure seed-vs-running sizes. No hive, hub, ConfigMap or PVC was modified, and no placeholder experiment was run.

## Follow-ups (deliberately not in this PR)

1. Harden the plausibility guard so a valid overlay can never be discarded.
2. Correct the DR docs/code — `hubbackup/collect.go:39-45`, `spokebackup/backup.go:62` and the runbook assert `.bak`-restore semantics that are false for 48 of 51 hives.
3. Generalise the three bespoke latches into one `DeliveryLatch`, with `hub.is_public` and `AutoUpgrade` as instances.
4. Make the Go reload path merge the full overlay: `LoadWithDashboardOverlay` merges only `Agents`, not `github`, which is why the GHE hives needed a **restart** for their fix to take effect.
5. `saas.go:5328` re-arms `ACMMDelivered` on approve-provision but never resets `ClaimDelivered` — a recycled placeholder will suppress the org/repos push and adopt a stale spoke report.
