### PR TITLE
🔑 fix: deliver every fleet GitHub App key at provision time, selected by app_id

### DIFF
--- a/v2/cmd/hive/appkeyfile_test.go
+++ b/v2/cmd/hive/appkeyfile_test.go
@@ -43,13 +43,22 @@ func redirectSpokeKeyPaths(t *testing.T) (dataPath, secretsPath string) {
 	t.Helper()
 	dir := t.TempDir()
 	origData, origSecrets, origDir := spokeAppKeyPath, spokeProvisionedAppKeyPath, spokeAppKeyDir
+	origProvDir := spokeProvisionedAppKeyDir
 	spokeAppKeyPath = filepath.Join(dir, "data-gh-app-key.pem")
 	spokeProvisionedAppKeyPath = filepath.Join(dir, "secrets-gh-app-key.pem")
 	// Per-app-id keys land in this same temp dir, so perAppIDKeyPath and
 	// heldPerAppIDKeyFingerprints never touch the real /data.
 	spokeAppKeyDir = dir
+	// The provisioning mount gets a SEPARATE dir: the PVC and the read-only
+	// Secret hold per-app-id files under identical names, so pointing both at one
+	// dir would make it impossible to tell which source a resolution came from.
+	spokeProvisionedAppKeyDir = filepath.Join(dir, "secrets")
+	if err := os.MkdirAll(spokeProvisionedAppKeyDir, 0o700); err != nil {
+		t.Fatalf("mkdir provisioned key dir: %v", err)
+	}
 	t.Cleanup(func() {
 		spokeAppKeyPath, spokeProvisionedAppKeyPath, spokeAppKeyDir = origData, origSecrets, origDir
+		spokeProvisionedAppKeyDir = origProvDir
 	})
 	return spokeAppKeyPath, spokeProvisionedAppKeyPath
 }
@@ -281,5 +290,70 @@ func TestWritePerAppIDKeyAndReport(t *testing.T) {
 	// A non-positive app_id is refused rather than writing an ambiguous file.
 	if _, err := writePerAppIDKey(0, pemData); err == nil {
 		t.Error("writePerAppIDKey(0, ...) succeeded; a non-positive app_id must be refused")
+	}
+}
+
+// TestResolveAppKeyFileUsesProvisionedPerAppIDKey covers the birth of a hive:
+// provisioning has written the fleet's keys into the read-only Secret, and no
+// heartbeat has run yet, so the PVC holds nothing. The spoke must still sign as
+// the App it is configured as rather than falling through to the generic
+// single-file paths — which on a GHE cluster hold the OTHER forge's key and
+// produce "404 Integration not found".
+func TestResolveAppKeyFileUsesProvisionedPerAppIDKey(t *testing.T) {
+	redirectSpokeKeyPaths(t)
+	const publicAppID = 3568013
+
+	provisioned := perAppIDProvisionedKeyPath(publicAppID)
+	writeTestKey(t, provisioned)
+
+	if got := resolveAppKeyFile("", "", publicAppID); got != provisioned {
+		t.Fatalf("want provisioned per-app-id key %s, got %s", provisioned, got)
+	}
+}
+
+// A heartbeat-delivered key on the PVC must outrank the copy frozen into the
+// Secret at provision time: that is what makes key ROTATION possible, since the
+// Secret cannot be rewritten in place by the spoke.
+func TestResolveAppKeyFilePrefersPVCOverProvisionedPerAppID(t *testing.T) {
+	redirectSpokeKeyPaths(t)
+	const publicAppID = 3568013
+
+	writeTestKey(t, perAppIDProvisionedKeyPath(publicAppID))
+	pvc := perAppIDKeyPath(publicAppID)
+	writeTestKey(t, pvc)
+
+	if got := resolveAppKeyFile("", "", publicAppID); got != pvc {
+		t.Fatalf("rotated PVC key must win, want %s, got %s", pvc, got)
+	}
+}
+
+// An explicit operator override still beats both per-app-id sources.
+func TestResolveAppKeyFileExplicitOverrideBeatsProvisionedPerAppID(t *testing.T) {
+	redirectSpokeKeyPaths(t)
+	const publicAppID = 3568013
+
+	writeTestKey(t, perAppIDProvisionedKeyPath(publicAppID))
+	named := filepath.Join(t.TempDir(), "operator-named.pem")
+	writeTestKey(t, named)
+
+	if got := resolveAppKeyFile(named, "", publicAppID); got != named {
+		t.Fatalf("explicit key_file must win, want %s, got %s", named, got)
+	}
+}
+
+// A truncated per-app-id file in the Secret must not shadow a usable generic
+// key: existence is not enough, it has to be a parseable key.
+func TestResolveAppKeyFileIgnoresUnusableProvisionedPerAppIDKey(t *testing.T) {
+	dataPath, _ := redirectSpokeKeyPaths(t)
+	const publicAppID = 3568013
+
+	if err := os.WriteFile(perAppIDProvisionedKeyPath(publicAppID),
+		[]byte("PLACEHOLDER-awaiting-github-app-key"), 0o600); err != nil {
+		t.Fatalf("write placeholder: %v", err)
+	}
+	writeTestKey(t, dataPath)
+
+	if got := resolveAppKeyFile("", "", publicAppID); got != dataPath {
+		t.Fatalf("unusable per-app-id key must be skipped, want %s, got %s", dataPath, got)
 	}
 }

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -77,6 +77,13 @@ var (
 	// already holds spokeAppKeyPath, so both survive restarts. A var so tests can
 	// redirect it; production never reassigns it.
 	spokeAppKeyDir = "/data"
+	// spokeProvisionedAppKeyDir is the read-only projected-Secret mount where
+	// PROVISIONING places per-app-id keys (gh-app-key-<appid>.pem), mirroring
+	// spokeAppKeyDir on the PVC. A hive provisioned with the fleet's full key set
+	// holds them here from its very first boot — before any heartbeat has run — so
+	// a forge switch never has to wait a beat for the target forge's key. The
+	// mount is readOnly, so nothing ever writes here; it is a lookup source only.
+	spokeProvisionedAppKeyDir = "/secrets"
 )
 
 // spokeAppKeyFileMode is rw------- : signing material must never be readable by
@@ -96,6 +103,17 @@ func perAppIDKeyPath(appID int64) string {
 		return ""
 	}
 	return filepath.Join(spokeAppKeyDir, fmt.Sprintf("gh-app-key-%d.pem", appID))
+}
+
+// perAppIDProvisionedKeyPath is perAppIDKeyPath's read-only twin: the same
+// per-app-id filename under the provisioning Secret mount. It is consulted only
+// when the PVC has no usable key for the app_id, so a heartbeat-delivered key
+// (which can be rotated) always wins over the one baked in at provision time.
+func perAppIDProvisionedKeyPath(appID int64) string {
+	if appID <= 0 {
+		return ""
+	}
+	return filepath.Join(spokeProvisionedAppKeyDir, fmt.Sprintf("gh-app-key-%d.pem", appID))
 }
 
 // perAppIDKeyFilePrefix / Suffix bracket the per-app-id key filename so a scan
@@ -291,6 +309,16 @@ func resolveAppKeyFile(configured, envOverride string, appID int64) string {
 			return p
 		}
 	}
+	// Same idea, but from the read-only provisioning mount: a hive provisioned
+	// with the fleet's full key set can sign as its configured App on its very
+	// first boot, before any heartbeat has delivered anything to the PVC. Ranked
+	// BELOW the PVC copy so a rotated key delivered by heartbeat always wins over
+	// the one frozen into the Secret at provision time.
+	if p := perAppIDProvisionedKeyPath(appID); p != "" {
+		if fp, err := config.AppKeyFingerprintFromFile(p); err == nil && fp != "" {
+			return p
+		}
+	}
 	// Prefer a usable hub-delivered key on the PVC; fall back to the provisioning
 	// mount only when /data has no parseable key.
 	if fp, err := config.AppKeyFingerprintFromFile(spokeAppKeyPath); err == nil && fp != "" {
@@ -312,6 +340,8 @@ func describeAppKeyFailure(configured, envOverride, resolved string, err error) 
 	order := []string{
 		fmt.Sprintf("$GH_APP_KEY_FILE=%s", describeKeySource(envOverride)),
 		fmt.Sprintf("github.key_file=%s", describeKeySource(configured)),
+		fmt.Sprintf("per-app-id PVC key %s/gh-app-key-<app_id>.pem", spokeAppKeyDir),
+		fmt.Sprintf("per-app-id provisioning key %s/gh-app-key-<app_id>.pem", spokeProvisionedAppKeyDir),
 		fmt.Sprintf("PVC fallback %s", spokeAppKeyPath),
 		fmt.Sprintf("provisioning mount %s", spokeProvisionedAppKeyPath),
 	}

--- a/v2/pkg/hub/final_gaps_coverage_test.go
+++ b/v2/pkg/hub/final_gaps_coverage_test.go
@@ -33,7 +33,7 @@ func TestProvisionHiveNFSWithOCI(t *testing.T) {
 	// NFS storage triggers the OCI create branch.
 	cluster := &ClusterConfig{ID: "hive-oke", InCluster: true, StorageType: storageTypeNFS, Domain: "hive.kubestellar.io"}
 
-	if err := provisionHive(h, req, cluster, slog.Default()); err != nil {
+	if err := provisionHive(h, req, cluster, nil, slog.Default()); err != nil {
 		t.Fatalf("provisionHive NFS+OCI: %v", err)
 	}
 	if h.OCIFileSystemID == "" || h.OCIExportID == "" {

--- a/v2/pkg/hub/provision_app_keys_test.go
+++ b/v2/pkg/hub/provision_app_keys_test.go
@@ -1,0 +1,124 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// The provisioning-time both-keys delivery. These tests pin the property that
+// matters operationally: a spoke is born holding EVERY App key the fleet knows,
+// each named by the app_id it belongs to, and never a second copy of its own
+// primary key under a different name.
+
+// appIDsOf reduces the rendered result to the app_ids it names, which is the
+// only part a caller reasons about. Key material is never compared or logged.
+func appIDsOf(keys []provisionAppKey) []int64 {
+	out := make([]int64, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, k.AppID)
+	}
+	return out
+}
+
+func testFleetKeys(t *testing.T) map[int64]fleetAppKey {
+	t.Helper()
+	return map[int64]fleetAppKey{
+		3568013: {AppID: 3568013, AppSlug: "kubestellar-hive", PrivateKey: testAppKeyPEM(t)},
+		5686:    {AppID: 5686, AppSlug: "kubestellar-hive-ghe", PrivateKey: testAppKeyPEM(t)},
+	}
+}
+
+// A public-GitHub hive must be provisioned holding the GHE key as an additional
+// key — that is what makes a later forge switch instant — but never a duplicate
+// of its own primary.
+func TestProvisionAdditionalAppKeysExcludesPrimary(t *testing.T) {
+	got := provisionAdditionalAppKeys(testFleetKeys(t), "3568013")
+
+	ids := appIDsOf(got)
+	if len(ids) != 1 || ids[0] != 5686 {
+		t.Fatalf("public hive should receive only the GHE key as additional, got %v", ids)
+	}
+}
+
+// The mirror case: a GHE hive receives the github.com key, not its own.
+func TestProvisionAdditionalAppKeysGHEPrimary(t *testing.T) {
+	got := provisionAdditionalAppKeys(testFleetKeys(t), "5686")
+
+	ids := appIDsOf(got)
+	if len(ids) != 1 || ids[0] != 3568013 {
+		t.Fatalf("GHE hive should receive only the public key as additional, got %v", ids)
+	}
+}
+
+// A hive with no App configured (token auth, or a placeholder awaiting a key)
+// has no primary to exclude, so it receives the whole fleet set.
+func TestProvisionAdditionalAppKeysNoPrimary(t *testing.T) {
+	for _, primary := range []string{"", "0", "not-a-number"} {
+		got := provisionAdditionalAppKeys(testFleetKeys(t), primary)
+		if len(got) != 2 {
+			t.Fatalf("primary %q: want both fleet keys, got %d", primary, len(got))
+		}
+	}
+}
+
+// Ordering must be deterministic or every reconcile renders a different manifest
+// and looks like a change.
+func TestProvisionAdditionalAppKeysDeterministicOrder(t *testing.T) {
+	fleet := testFleetKeys(t)
+	first := appIDsOf(provisionAdditionalAppKeys(fleet, ""))
+
+	for i := 0; i < 10; i++ {
+		got := appIDsOf(provisionAdditionalAppKeys(fleet, ""))
+		if len(got) != len(first) {
+			t.Fatalf("length changed between runs: %v vs %v", first, got)
+		}
+		for j := range got {
+			if got[j] != first[j] {
+				t.Fatalf("order changed between runs: %v vs %v", first, got)
+			}
+		}
+	}
+	if first[0] >= first[1] {
+		t.Fatalf("want ascending app_id order, got %v", first)
+	}
+}
+
+// A truncated or garbage key must never be rendered: written into the Secret it
+// would shadow a good key of the same app_id and break signing.
+func TestProvisionAdditionalAppKeysSkipsNonPEM(t *testing.T) {
+	fleet := map[int64]fleetAppKey{
+		3568013: {AppID: 3568013, PrivateKey: testAppKeyPEM(t)},
+		5686:    {AppID: 5686, PrivateKey: "PLACEHOLDER-awaiting-github-app-key"},
+	}
+
+	got := provisionAdditionalAppKeys(fleet, "")
+
+	ids := appIDsOf(got)
+	if len(ids) != 1 || ids[0] != 3568013 {
+		t.Fatalf("non-PEM key must be skipped, got %v", ids)
+	}
+}
+
+func TestProvisionAdditionalAppKeysEmptyFleet(t *testing.T) {
+	if got := provisionAdditionalAppKeys(nil, "3568013"); got != nil {
+		t.Fatalf("nil fleet should yield nil, got %v", appIDsOf(got))
+	}
+}
+
+// The PEM is rendered as a YAML block scalar, so every line must carry the
+// block's indentation. An unindented line silently truncates the key.
+func TestProvisionAdditionalAppKeysIndentsForYAMLBlock(t *testing.T) {
+	got := provisionAdditionalAppKeys(testFleetKeys(t), "3568013")
+	if len(got) != 1 {
+		t.Fatalf("want 1 additional key, got %d", len(got))
+	}
+
+	for i, line := range strings.Split(got[0].PEM, "\n") {
+		if !strings.HasPrefix(line, "    ") {
+			t.Fatalf("line %d is not indented for the YAML block: %q", i, line)
+		}
+		if strings.TrimSpace(line) == "" {
+			t.Fatalf("line %d is blank, which would terminate the block scalar", i)
+		}
+	}
+}

--- a/v2/pkg/hub/provision_coverage_test.go
+++ b/v2/pkg/hub/provision_coverage_test.go
@@ -35,7 +35,7 @@ func TestProvisionHiveSuccess(t *testing.T) {
 	h := &SaaSHive{ID: "hosted-acme-repo-abcd", Owner: "alice", Org: "acme", Repos: []string{"repo"}, PrimaryRepo: "repo", ACMMLevel: 2}
 	req := &CreateHiveRequest{Org: "acme", Repos: "repo", PrimaryRepo: "repo", ACMMLevel: 2, ClusterID: "hive-oke"}
 
-	if err := provisionHive(h, req, dynamicCluster(), slog.Default()); err != nil {
+	if err := provisionHive(h, req, dynamicCluster(), nil, slog.Default()); err != nil {
 		t.Fatalf("provisionHive: %v", err)
 	}
 }
@@ -51,7 +51,7 @@ func TestProvisionHiveWithAppAuth(t *testing.T) {
 		AuthMethod: "app", AppID: "123", InstallationID: "456",
 		AppPrivateKey: "-----BEGIN RSA PRIVATE KEY-----\nabc\n-----END RSA PRIVATE KEY-----",
 	}
-	if err := provisionHive(h, req, dynamicCluster(), slog.Default()); err != nil {
+	if err := provisionHive(h, req, dynamicCluster(), nil, slog.Default()); err != nil {
 		t.Fatalf("provisionHive app auth: %v", err)
 	}
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2306,7 +2306,7 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 			s.logger.Error("no cluster config for provisioning", "hive_id", hiveID, "cluster_id", h.ClusterID)
 			return
 		}
-		if err := provisionHive(h, &req, cluster, s.logger); err != nil {
+		if err := provisionHive(h, &req, cluster, s.appKeysByAppID(), s.logger); err != nil {
 			h.Status = "error"
 			h.Error = err.Error()
 			saveSaaSHive(h)

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -960,7 +961,68 @@ func authorizedUsersForHive(h *SaaSHive) string {
 	return strings.Join(entries, ",")
 }
 
-func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, logger *slog.Logger) error {
+// provisionAppKey is one additional App key rendered into the provisioning
+// Secret: the app_id that names its file and the PEM body, pre-indented for the
+// YAML block scalar it is written into.
+type provisionAppKey struct {
+	AppID int64
+	PEM   string
+}
+
+// provisionAdditionalAppKeys turns the fleet's key set into the ADDITIONAL keys a
+// newly provisioned spoke should hold — every fleet key except the primary the
+// spoke is already getting as gh-app-key.pem.
+//
+// This is the provisioning-time twin of attachMissingAppKeys: the heartbeat gets
+// a spoke to the both-keys state eventually, this gets it there at birth, so a
+// forge switch never has to wait a beat for the target forge's key to arrive.
+//
+// Excluding primaryAppID is what keeps key selection identity-safe. A hive's
+// GitHub identity is the atomic set (app_id, app_slug, api_url, base_url); the
+// key it signs with must match the app_id it claims. Writing the primary only
+// under its canonical gh-app-key.pem name — never also as a per-app-id file —
+// means there is exactly one copy of it and no chance of two diverging.
+//
+// Results are sorted by app_id so the rendered manifest is deterministic: an
+// unstable order would make every reconcile look like a change.
+func provisionAdditionalAppKeys(fleetKeys map[int64]fleetAppKey, primaryAppID string) []provisionAppKey {
+	if len(fleetKeys) == 0 {
+		return nil
+	}
+	var primary int64
+	if v, err := strconv.ParseInt(strings.TrimSpace(primaryAppID), 10, 64); err == nil {
+		primary = v
+	}
+	ids := make([]int64, 0, len(fleetKeys))
+	for id := range fleetKeys {
+		if id == primary {
+			continue // already delivered as gh-app-key.pem
+		}
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+
+	out := make([]provisionAppKey, 0, len(ids))
+	for _, id := range ids {
+		pem := strings.TrimSpace(fleetKeys[id].PrivateKey)
+		if !strings.HasPrefix(pem, "-----BEGIN") {
+			// Never render a truncated or garbage key: it would shadow a good one.
+			continue
+		}
+		lines := strings.Split(pem, "\n")
+		for i := range lines {
+			lines[i] = "    " + strings.TrimSpace(lines[i])
+		}
+		out = append(out, provisionAppKey{AppID: id, PEM: strings.Join(lines, "\n")})
+	}
+	return out
+}
+
+// fleetKeys carries every GitHub App private key the fleet knows, keyed by
+// app_id, so a freshly provisioned spoke starts life holding ALL of them rather
+// than waiting for the heartbeat's additional-key delivery to catch up. Pass nil
+// to provision with only the primary key (the pre-existing behaviour).
+func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, fleetKeys map[int64]fleetAppKey, logger *slog.Logger) error {
 	dir := filepath.Join(saasHivesDir, h.ID, "manifests")
 	os.MkdirAll(dir, 0o755)
 
@@ -1027,6 +1089,17 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 			}
 			return strings.Join(lines, "\n")
 		}(),
+		// AdditionalAppKeys delivers the fleet's OTHER App keys at provision time,
+		// each in its own per-app-id Secret entry. Naming is by APP ID, not by
+		// cluster: a key's identity is the App it belongs to, and the spoke selects
+		// by matching its configured app_id (resolveAppKeyFile). Per-cluster naming
+		// would be a lie here — the same PEM is valid on every cluster whose hives
+		// authenticate as that App, and a spoke has no way to know which cluster a
+		// file named for one was meant to serve. The primary key is excluded: it is
+		// already written as gh-app-key.pem above, and duplicating it would let the
+		// two copies drift.
+		"AdditionalAppKeys": provisionAdditionalAppKeys(
+			fleetKeys, resolveProvisionAppID(req.AppID, h, cluster)),
 		"CPURequest":            cpuRequest,
 		"CPULimit":              cpuLimit,
 		"MemRequest":            memRequest,
@@ -1307,7 +1380,7 @@ func (s *HubServer) migrateHive(h *SaaSHive, fromCluster, toCluster *ClusterConf
 
 	// Step 2: Provision on target cluster.
 	logger.Info("migration: provisioning on target cluster")
-	if provErr := provisionHive(h, req, toCluster, logger); provErr != nil {
+	if provErr := provisionHive(h, req, toCluster, s.appKeysByAppID(), logger); provErr != nil {
 		logger.Error("migration: provisioning on target failed", "error", provErr)
 		h.MigrationStatus = "failed"
 		h.Error = fmt.Sprintf("migration failed during provisioning on %s: %s", toCluster.ID, provErr.Error())
@@ -1638,6 +1711,10 @@ stringData:
 {{.AppPrivateKey}}
 {{- else if not .UseApp}}
   github-token: {{.Token}}
+{{- end}}
+{{- range .AdditionalAppKeys}}
+  gh-app-key-{{.AppID}}.pem: |
+{{.PEM}}
 {{- end}}
 ---
 {{- if .IsNFSStorage}}


### PR DESCRIPTION
## Problem

A spoke's GitHub identity is an **atomic set** of four fields — `app_id`, `app_slug`, `api_url`, `base_url`. There is no valid mixture: an `app_id` of `5686` (GHE) pointed at `api.github.com` yields `404 Integration not found`. The key a spoke signs with must match the `app_id` it claims, which must match its `api_url`.

The **runtime** half of this is already solved on `v2`: `attachMissingAppKeys` converges a running spoke onto the fleet's full key set over the heartbeat, and `resolveAppKeyFile` selects the key whose `app_id` matches the configured one.

The **provisioning** half was not. A newly provisioned hive received only its cluster's default key and had to wait for a heartbeat to acquire the rest. During that window a forge switch had no key for the target forge — the exact gap this closes.

## Change

- Provisioning writes the fleet's *other* App keys into `hive-secrets` as `gh-app-key-<appid>.pem`, alongside the primary `gh-app-key.pem`.
- The spoke resolver consults the read-only provisioning mount for per-app-id keys, so a hive can sign as its configured App on its **first boot**, before any heartbeat.

## Naming: per-forge (app_id), not per-cluster

The hub's per-cluster `app-keys/<cluster>.pem` naming is right for the hub, which stores one key per cluster. It is the wrong shape for a spoke that must hold **both**.

A key's identity is the **App** it belongs to, not the cluster it happened to arrive from. The same PEM is valid on every cluster whose hives authenticate as that App, and a spoke has no way to map a cluster-named file onto the `app_id` it claims. Per-app-id naming makes selection correct-by-construction rather than by convention, and it matches the filename contract the heartbeat path already established.

## Safety properties

- **No duplication.** The primary is written only as `gh-app-key.pem` and excluded from the additional set — exactly one copy, so the two cannot drift.
- **Rotation still works.** PVC keys outrank provisioned ones; the Secret copy is frozen at provision time and must never shadow a rotated key.
- **Operator override preserved.** An explicit `key_file` / `$GH_APP_KEY_FILE` still wins outright.
- **Placeholders can't shadow.** Non-PEM values are skipped rather than written.
- **Deterministic.** Keys render in ascending `app_id` order, so a reconcile doesn't look like a change.

## DR

No new Kubernetes Secret is introduced. The hub's keys live on the PVC at `/data/saas/app-keys` and are already captured by hub backup step 1, so the PR #2315 captured set needs no addition.

## Tests

New coverage for primary exclusion (both forge directions), no-primary/unparseable-primary, deterministic ordering, non-PEM skipping, YAML block-scalar indentation, and all four spoke resolution-precedence cases. `go build`, `go vet`, and `./cmd/hive ./pkg/hub ./pkg/hubbackup` all pass.

No key material appears in this diff, in test fixtures (freshly generated throwaway RSA keys), or in any log line — fingerprints only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)