### PR TITLE
🐛 fix(fleet-stats): start the collector on App-authored hives and cache the last good total

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1137,7 +1137,16 @@ func main() {
 	// the agents open PRs as, so it is the correct author to count. Never fall
 	// back to an org-wide search with no author filter — that would sweep in
 	// human PRs and overstate what the fleet's agents actually did.
-	fleetStatsAuthor := cfg.Project.AIAuthor
+	//
+	// Use EffectiveAIAuthor(), not the raw Project.AIAuthor field. App-authored
+	// hives deliberately leave ai_author EMPTY and derive their identity from
+	// the installed App ("<slug>[bot]") — that is what keeps App-bot mode
+	// durable across restarts. Reading the raw field saw "" for every one of
+	// them and disabled the collector fleet-wide, while the PAT fallback below
+	// could not rescue it either: those hives authenticate as a GitHub App and
+	// have github.token empty, so there was no token to identify. The result
+	// was a fleet where essentially no spoke ever attempted a collect.
+	fleetStatsAuthor := cfg.EffectiveAIAuthor()
 	fleetStatsToken := cfg.GitHub.Token
 	if fleetStatsToken == "" {
 		fleetStatsToken = os.Getenv("HIVE_GITHUB_TOKEN")

--- a/v2/pkg/config/fleet_stats_author_test.go
+++ b/v2/pkg/config/fleet_stats_author_test.go
@@ -1,0 +1,60 @@
+package config
+
+import "testing"
+
+// Regression test for the fleet-stats collector never starting fleet-wide.
+//
+// Observed live: every hosted spoke logged
+//
+//	"fleet stats collector disabled: author or org is empty" author=""
+//
+// even though the hub registry showed a populated aiAuthorEffective of
+// "kubestellar-hive[bot]". The collector was reading the RAW Project.AIAuthor
+// field, which App-authored hives deliberately leave empty (they derive the
+// bot login from the installed App so App-bot mode survives restarts). With
+// author empty, Start() returned before making a single GitHub call — so this
+// was never a rate limit, a 403, or a retry problem. Nothing was ever tried.
+//
+// The PAT fallback could not rescue it either: those hives authenticate as a
+// GitHub App and carry github.token == "".
+//
+// This pins EffectiveAIAuthor() as the identity the collector must use.
+func TestEffectiveAIAuthor_AppBotHiveWithEmptyAIAuthor(t *testing.T) {
+	// Exactly the shape of the live kubestellar/console spoke: App installed,
+	// no PAT, ai_author left empty.
+	cfg := &Config{}
+	cfg.Project.Org = "kubestellar"
+	cfg.Project.AIAuthor = ""
+	cfg.GitHub.Token = ""
+	cfg.GitHub.AppID = 3568013
+	cfg.GitHub.InstallationID = 128685788
+	cfg.GitHub.AppSlug = "kubestellar-hive"
+
+	got := cfg.EffectiveAIAuthor()
+	if got == "" {
+		t.Fatal("EffectiveAIAuthor() = \"\" for an App-authored hive; the fleet-stats " +
+			"collector would be disabled and this hive would never contribute")
+	}
+	if want := "kubestellar-hive[bot]"; got != want {
+		t.Errorf("EffectiveAIAuthor() = %q, want %q", got, want)
+	}
+	// The raw field is what the buggy code read — assert it really is empty, so
+	// this test would have failed against the old implementation.
+	if cfg.Project.AIAuthor != "" {
+		t.Fatal("test setup wrong: Project.AIAuthor must be empty to reproduce")
+	}
+}
+
+// An App-less hive must still resolve to no author, so we never fabricate a
+// phantom "<slug>[bot]" that authored nothing.
+func TestEffectiveAIAuthor_AppLessHiveStaysEmpty(t *testing.T) {
+	cfg := &Config{}
+	cfg.Project.Org = "someorg"
+	cfg.GitHub.AppID = 3568013
+	cfg.GitHub.InstallationID = 0 // never installed
+	cfg.GitHub.AppSlug = "kubestellar-hive"
+
+	if got := cfg.EffectiveAIAuthor(); got != "" {
+		t.Errorf("EffectiveAIAuthor() = %q, want \"\" for an uninstalled App", got)
+	}
+}

--- a/v2/pkg/hub/fleet_stats_test.go
+++ b/v2/pkg/hub/fleet_stats_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 )
@@ -227,5 +228,155 @@ func TestComputeFleetStatsSkipsRepolessHives(t *testing.T) {
 	}
 	if !got.FleetStatsTrustworthy() {
 		t.Error("a fully-reporting fleet of one must be trustworthy")
+	}
+}
+
+// fleetStatsLKGTestServer builds a hub whose registry save path is redirected
+// into a temp dir, so recordFleetStatsLKG's requestSave cannot touch /data.
+func fleetStatsLKGTestServer(t *testing.T) *HubServer {
+	t.Helper()
+	old := registryPath
+	registryPath = t.TempDir() + "/reg.json"
+	t.Cleanup(func() { registryPath = old })
+	return &HubServer{logger: slog.Default()}
+}
+
+func decodeFleetStats(t *testing.T, s *HubServer) FleetStats {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	s.handleFleetStats(rec, httptest.NewRequest(http.MethodGet, "/api/fleet-stats", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var fs FleetStats
+	if err := json.Unmarshal(rec.Body.Bytes(), &fs); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return fs
+}
+
+// A collection that clears the coverage bar must be recorded as last-known-good
+// and served as fresh (not stale).
+func TestHandleFleetStats_TrustworthyRecordsLKG(t *testing.T) {
+	s := fleetStatsLKGTestServer(t)
+	s.registry.Hives = []RegistryEntry{
+		{ID: "h1", IsPublic: true, Online: true, LastHeartbeat: freshHeartbeat(),
+			Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(20)},
+		{ID: "h2", IsPublic: true, Online: true, LastHeartbeat: freshHeartbeat(),
+			Org: "a", Repos: []string{"r2"}, PRsMerged90d: ptrInt(6)},
+	}
+
+	fs := decodeFleetStats(t, s)
+	if !fs.Trustworthy {
+		t.Fatalf("Trustworthy = false, want true (2 of 2 reporting)")
+	}
+	if fs.StaleData {
+		t.Error("StaleData = true, want false for a fresh trustworthy aggregate")
+	}
+	if fs.PRsMerged != 26 {
+		t.Errorf("PRsMerged = %d, want 26", fs.PRsMerged)
+	}
+	if fs.AsOf != fs.UpdatedAt {
+		t.Errorf("AsOf = %q, want it to equal UpdatedAt %q when fresh", fs.AsOf, fs.UpdatedAt)
+	}
+	lkg := s.fleetStatsLKG()
+	if lkg == nil {
+		t.Fatal("fleetStatsLKG() = nil, want the trustworthy aggregate recorded")
+	}
+	if lkg.PRsMerged != 26 || lkg.Reporting != 2 || lkg.Eligible != 2 {
+		t.Errorf("LKG = %+v, want PRsMerged 26 / Reporting 2 / Eligible 2", *lkg)
+	}
+}
+
+// The regression this whole change exists for: once coverage collapses, the
+// page must still get NUMBERS (from the cache) plus an honest stale label —
+// not a blank strip.
+func TestHandleFleetStats_DegradedServesLabelledLKG(t *testing.T) {
+	s := fleetStatsLKGTestServer(t)
+	collectedAt := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+	s.registry.FleetStatsLKG = &FleetStatsSnapshot{
+		ReposManaged: 42, PRsMerged: 26, PRsRejected: 3, CVEsClosed: 1,
+		Hives: 18, Reporting: 12, Eligible: 18, CollectedAt: collectedAt,
+	}
+	// Live fleet: only 1 of 4 eligible hives reporting → 25%, below the bar.
+	s.registry.Hives = []RegistryEntry{
+		{ID: "h1", IsPublic: true, Online: true, LastHeartbeat: freshHeartbeat(),
+			Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(2)},
+		{ID: "h2", IsPublic: true, Online: true, LastHeartbeat: freshHeartbeat(), Org: "a", Repos: []string{"r2"}},
+		{ID: "h3", IsPublic: true, Online: true, LastHeartbeat: freshHeartbeat(), Org: "a", Repos: []string{"r3"}},
+		{ID: "h4", IsPublic: true, Online: true, LastHeartbeat: freshHeartbeat(), Org: "a", Repos: []string{"r4"}},
+	}
+
+	fs := decodeFleetStats(t, s)
+	if fs.Trustworthy {
+		t.Fatal("Trustworthy = true, want false (1 of 4 reporting)")
+	}
+	if !fs.StaleData {
+		t.Error("StaleData = false, want true when serving the cache")
+	}
+	// Counts come from the cache, NOT from the 1 live hive (which would be 2).
+	if fs.PRsMerged != 26 {
+		t.Errorf("PRsMerged = %d, want 26 from LKG (not the degraded live 2)", fs.PRsMerged)
+	}
+	if fs.ReposManaged != 42 {
+		t.Errorf("ReposManaged = %d, want 42 from LKG", fs.ReposManaged)
+	}
+	// Coverage figures stay LIVE so the page can show recollection progress.
+	if fs.Reporting != 1 || fs.Eligible != 4 {
+		t.Errorf("Reporting/Eligible = %d/%d, want live 1/4", fs.Reporting, fs.Eligible)
+	}
+	if fs.AsOf != collectedAt.Format(time.RFC3339) {
+		t.Errorf("AsOf = %q, want the LKG collection time %q", fs.AsOf, collectedAt.Format(time.RFC3339))
+	}
+	// A degraded aggregate must never overwrite the cache.
+	if lkg := s.fleetStatsLKG(); lkg == nil || lkg.PRsMerged != 26 {
+		t.Errorf("degraded aggregate overwrote the LKG: %+v", lkg)
+	}
+}
+
+// Genuine first boot — never collected, nothing cached — is the only state
+// that legitimately shows no total.
+func TestHandleFleetStats_NoLKGShowsNothing(t *testing.T) {
+	s := fleetStatsLKGTestServer(t)
+	s.registry.Hives = []RegistryEntry{
+		{ID: "h1", IsPublic: true, Online: true, LastHeartbeat: freshHeartbeat(), Org: "a", Repos: []string{"r1"}},
+		{ID: "h2", IsPublic: true, Online: true, LastHeartbeat: freshHeartbeat(), Org: "a", Repos: []string{"r2"}},
+	}
+	fs := decodeFleetStats(t, s)
+	if fs.Trustworthy || fs.StaleData {
+		t.Errorf("Trustworthy=%v StaleData=%v, want both false on first boot", fs.Trustworthy, fs.StaleData)
+	}
+	if fs.PRsMerged != 0 || fs.AsOf != "" {
+		t.Errorf("PRsMerged=%d AsOf=%q, want 0 and empty with no cache", fs.PRsMerged, fs.AsOf)
+	}
+}
+
+// The LKG must round-trip through the registry file, or a hub restart would
+// blank the strip again — the durability half of the fix.
+func TestFleetStatsLKG_PersistsAcrossReload(t *testing.T) {
+	s := fleetStatsLKGTestServer(t)
+	collectedAt := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	s.registry.FleetStatsLKG = &FleetStatsSnapshot{
+		PRsMerged: 26, Reporting: 12, Eligible: 18, CollectedAt: collectedAt,
+	}
+	if err := s.saveRegistryNow(); err != nil {
+		t.Fatalf("saveRegistryNow: %v", err)
+	}
+	var reloaded Registry
+	data, err := os.ReadFile(registryPath)
+	if err != nil {
+		t.Fatalf("read registry: %v", err)
+	}
+	if err := json.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if reloaded.FleetStatsLKG == nil {
+		t.Fatal("FleetStatsLKG did not survive the registry round-trip")
+	}
+	if reloaded.FleetStatsLKG.PRsMerged != 26 {
+		t.Errorf("PRsMerged = %d, want 26", reloaded.FleetStatsLKG.PRsMerged)
+	}
+	if !reloaded.FleetStatsLKG.CollectedAt.Equal(collectedAt) {
+		t.Errorf("CollectedAt = %v, want %v", reloaded.FleetStatsLKG.CollectedAt, collectedAt)
 	}
 }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -55,6 +55,32 @@ const (
 type Registry struct {
 	Hives     []RegistryEntry `json:"hives"`
 	UpdatedAt string          `json:"updatedAt"`
+	// FleetStatsLKG is the last fleet-stats aggregate that met the coverage
+	// bar, persisted with the registry so it survives a hub restart. It is what
+	// the landing page falls back to when coverage dips: a figure that is
+	// honestly labelled stale beats a blank strip, because "no number" reads to
+	// a visitor as "this fleet did nothing" rather than "we are recollecting".
+	// Nil until the fleet has ever reported well enough to produce one — that
+	// genuine first-boot state is the only case where the page shows no total.
+	FleetStatsLKG *FleetStatsSnapshot `json:"fleetStatsLastKnownGood,omitempty"`
+}
+
+// FleetStatsSnapshot is a point-in-time fleet aggregate retained as the
+// last-known-good figure. It stores the counts together with the coverage they
+// were computed from, so the UI can say not just "as of 14:20" but "based on
+// 12 of 18 hives" — staleness that describes itself rather than a bare number
+// the viewer has to trust blindly.
+type FleetStatsSnapshot struct {
+	ReposManaged int `json:"repos_managed"`
+	PRsMerged    int `json:"prs_merged"`
+	PRsRejected  int `json:"prs_rejected"`
+	CVEsClosed   int `json:"cves_closed"`
+	Hives        int `json:"hives"`
+	Reporting    int `json:"reporting"`
+	Eligible     int `json:"eligible"`
+	// CollectedAt is when this aggregate was computed, i.e. what "as of" means
+	// on the public page.
+	CollectedAt time.Time `json:"collected_at"`
 }
 
 type RegistryEntry struct {
@@ -1640,6 +1666,16 @@ type FleetStats struct {
 	// totals to stand as a fleet-wide figure. The landing page shows a
 	// "collecting" state instead of the numbers when this is false.
 	Trustworthy bool `json:"trustworthy"`
+	// Stale is true when the counts above did NOT come from the current
+	// collection but from the persisted last-known-good aggregate. The page
+	// still shows the numbers — hiding them entirely is what made a
+	// recollecting fleet look like a dead one — but it must label them, so
+	// this flag and AsOf travel with the payload. Stale-and-says-so is the
+	// goal; wrong-and-silent is the thing to avoid.
+	StaleData bool `json:"stale_data,omitempty"`
+	// AsOf is the RFC3339 time the returned counts were actually collected.
+	// Equal to UpdatedAt for a fresh aggregate; older when StaleData is true.
+	AsOf string `json:"as_of,omitempty"`
 }
 
 // fleetStatsMaxAge is how old a spoke's last successful collect may be and
@@ -1732,6 +1768,40 @@ func (fs FleetStats) FleetStatsTrustworthy() bool {
 	return float64(fs.Reporting)/float64(fs.Eligible) >= fleetStatsMinReportingFraction
 }
 
+// fleetStatsLKG returns a copy of the persisted last-known-good aggregate, or
+// nil if the fleet has never produced one. A copy (not the pointer) so callers
+// cannot mutate registry state they do not hold the write lock for.
+func (s *HubServer) fleetStatsLKG() *FleetStatsSnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.registry.FleetStatsLKG == nil {
+		return nil
+	}
+	snapshot := *s.registry.FleetStatsLKG
+	return &snapshot
+}
+
+// recordFleetStatsLKG stores fs as the new last-known-good aggregate and asks
+// for a registry flush, so the figure survives a hub restart. Only ever called
+// with an aggregate that already cleared the coverage bar — a degraded total
+// must never become the fallback, or the cache would launder exactly the
+// unbacked number the coverage gate exists to suppress.
+func (s *HubServer) recordFleetStatsLKG(fs FleetStats, collectedAt time.Time) {
+	s.mu.Lock()
+	s.registry.FleetStatsLKG = &FleetStatsSnapshot{
+		ReposManaged: fs.ReposManaged,
+		PRsMerged:    fs.PRsMerged,
+		PRsRejected:  fs.PRsRejected,
+		CVEsClosed:   fs.CVEsClosed,
+		Hives:        fs.Hives,
+		Reporting:    fs.Reporting,
+		Eligible:     fs.Eligible,
+		CollectedAt:  collectedAt.UTC(),
+	}
+	s.mu.Unlock()
+	s.requestSave()
+}
+
 func (s *HubServer) handleFleetStats(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 	offlineEvents := s.markStaleHives()
@@ -1741,8 +1811,35 @@ func (s *HubServer) handleFleetStats(w http.ResponseWriter, r *http.Request) {
 	s.mu.RLock()
 	fs := s.computeFleetStats()
 	s.mu.RUnlock()
-	fs.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	now := time.Now().UTC()
+	fs.UpdatedAt = now.Format(time.RFC3339)
 	fs.Trustworthy = fs.FleetStatsTrustworthy()
+
+	// Last-known-good handling. A fleet total does not have to be current to be
+	// useful, but it does have to say how current it is. When this collection
+	// clears the coverage bar we record it as the new LKG; when it does not, we
+	// serve the stored LKG and mark it stale so the page can label it. Only a
+	// fleet that has never once reported well enough shows no number at all.
+	if fs.Trustworthy {
+		fs.AsOf = fs.UpdatedAt
+		s.recordFleetStatsLKG(fs, now)
+	} else if lkg := s.fleetStatsLKG(); lkg != nil {
+		// Keep the LIVE coverage figures (Reporting/Eligible/Stale) so the page
+		// can still show recollection progress, but serve the cached counts.
+		fs.ReposManaged = lkg.ReposManaged
+		fs.PRsMerged = lkg.PRsMerged
+		fs.PRsRejected = lkg.PRsRejected
+		fs.CVEsClosed = lkg.CVEsClosed
+		fs.StaleData = true
+		fs.AsOf = lkg.CollectedAt.UTC().Format(time.RFC3339)
+		s.logger.Warn("fleet stats: serving last-known-good totals; live coverage is below the publish threshold",
+			"reporting", fs.Reporting,
+			"eligible", fs.Eligible,
+			"lkg_collected_at", fs.AsOf,
+			"lkg_based_on_reporting", lkg.Reporting,
+			"lkg_based_on_eligible", lkg.Eligible,
+		)
+	}
 
 	// Make the degraded case loud on the server too. The landing page hides the
 	// numbers, but a silent hide is how this regressed unnoticed before: with

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -1327,20 +1327,40 @@
         { key: 'cves_closed', box: 'proof-cves' }
       ];
       function fmt(n) { return n.toLocaleString('en-US'); }
+      // Render "as of" for a stale figure. Same-day collections show a clock
+      // time (the common case — a fleet recollecting for an hour or two);
+      // anything older shows a date, since "as of 14:20" is actively
+      // misleading when 14:20 was last week.
+      function asOfLabel(iso) {
+        if (!iso) return '';
+        var d = new Date(iso);
+        if (isNaN(d.getTime())) return '';
+        var sameDay = d.toDateString() === new Date().toDateString();
+        return sameDay
+          ? d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+          : d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+      }
       function apply(data) {
         // The hub tells us whether enough of the fleet reported for these
-        // totals to mean anything. When it says no, show NOTHING rather than a
-        // number assembled from a handful of hives — a precise-looking total
-        // built from 2 of 50 spokes is the exact failure this guards against.
+        // totals to be presented as CURRENT. When it says no, it now also
+        // serves the last-known-good figure (stale_data + as_of) instead of
+        // nothing: a total that is honestly labelled stale is far more useful
+        // to a visitor than a blank strip, which reads as "this fleet did
+        // nothing" rather than "we are recollecting". What we must never do is
+        // present stale numbers AS current — hence the caveat line below.
         // Treat a response without the field (older hub) as trustworthy so an
         // upgrade skew never blanks a strip that is actually fine.
         var trustworthy = !data || typeof data.trustworthy !== 'boolean' ? true : data.trustworthy;
+        var stale = !!(data && data.stale_data);
+        // Show the numbers when the live aggregate is trustworthy OR when the
+        // hub handed us a labelled last-known-good one.
+        var showValues = trustworthy || stale;
         var anyLive = false;
         (LIVE_STATS || []).forEach(function(s) {
           var box = document.getElementById(s.box);
           if (!box) return;
           var val = data && typeof data[s.key] === 'number' ? data[s.key] : 0;
-          if (trustworthy && val > 0) {
+          if (showValues && val > 0) {
             box.querySelector('[data-stat]').textContent = fmt(val);
             box.hidden = false;
             anyLive = true;
@@ -1348,14 +1368,29 @@
             box.hidden = true;
           }
         });
+        // Staleness has to be visible in the UI, not just in a server log.
+        // When values came from the cache, caption the strip so the reader
+        // knows these are last-known-good rather than live.
+        if (anyLive && stale) {
+          var when = asOfLabel(data && data.as_of);
+          var note2 = document.getElementById('hero-proof-note');
+          if (note2) {
+            note2.innerHTML = 'The <strong>90% coverage gate</strong> is enforced on Hive\'s own build. Fleet totals above are <strong>last known good</strong>' +
+              (when ? ' (as of ' + esc(when) + ')' : '') +
+              ' while the fleet recollects &mdash; ' + fmt((data && data.reporting) || 0) + ' of ' +
+              fmt((data && data.eligible) || 0) + ' hives reporting right now. ' +
+              '<a href="/learn" target="_blank" rel="noopener">Learn how earned autonomy works</a>.';
+          }
+        }
         var note = document.getElementById('hero-proof-note');
         if (!anyLive && note) {
           if (!trustworthy && data && data.eligible > 0) {
-            // Data IS degraded and we know it. Say so plainly instead of
-            // letting a blank strip read as "the fleet did nothing".
-            note.innerHTML = 'The <strong>90% coverage gate</strong> is enforced on Hive\'s own build. Fleet contribution totals are <strong>currently being recollected</strong> (' +
+            // Degraded AND no last-known-good figure to fall back on (a true
+            // first-boot fleet). Say so plainly instead of letting a blank
+            // strip read as "the fleet did nothing".
+            note.innerHTML = 'The <strong>90% coverage gate</strong> is enforced on Hive\'s own build. Fleet contribution totals are <strong>currently being collected</strong> (' +
               fmt(data.reporting || 0) + ' of ' + fmt(data.eligible || 0) +
-              ' hives reporting) and are hidden until enough of the fleet has reported. <a href="/learn" target="_blank" rel="noopener">Learn how earned autonomy works</a>.';
+              ' hives reporting) and appear once the fleet has reported. <a href="/learn" target="_blank" rel="noopener">Learn how earned autonomy works</a>.';
           } else {
             // No fleet data yet: don't imply live numbers exist. Swap to a
             // qualitative line alongside the (always-true) 90% coverage stat.


### PR DESCRIPTION
## Symptom

`hive.kubestellar.io` has been stuck for hours on:

> Fleet contribution totals are **currently being recollected (2 of 18 hives reporting)** and are hidden until enough of the fleet has reported.

#2328 was working correctly — it suppressed an unbackable figure. The bug is that collection never recovered.

## Root cause (VERIFIED live, not inferred)

**Not the rate limit. Not a 403. Not retry backoff. Collection was never attempted.**

`gh api rate_limit` showed `search: 30/30 remaining` — the quota was untouched, which is itself the tell: nobody was searching.

Checking all 16 hosted spoke namespaces on `hive-oke`, **16 of 16** logged:

```
"fleet stats collector disabled: author or org is empty" author="" org="kubestellar"
"fleet stats collector not started; this hive will never contribute to the public fleet total"
```

Meanwhile the hub registry showed a populated `aiAuthorEffective` of `kubestellar-hive[bot]`, and `/data/hive.yaml` on the console spoke's PVC carried a real `ai_author`.

The collector read the **raw `cfg.Project.AIAuthor`** field. App-authored hives deliberately leave `ai_author` **empty** and derive their identity from the installed App (`<slug>[bot]`) — that is exactly what keeps App-bot mode durable across restarts. With `author == ""`, `Start()` returned at its guard on line 86 before issuing a single GitHub call.

The PAT fallback could not rescue it either: these hives authenticate as a GitHub App and carry `github.token == ""`, so there was no token to identify. Where a token did exist it returned `token invalid: status 401`.

**Fix:** use `cfg.EffectiveAIAuthor()`, which already resolves the App-bot login.

### Not the same root cause as the App-permission 403

The merge-endpoint `403 Resource not accessible by integration` is a *permission* problem on a call that is being made. This is a call that was **never made**. Retry logic and permissions were both irrelevant here.

### Is 50% of 18 reachable?

Yes — eligibility is `IsPublic && Online && len(Repos) > 0`, which I reproduced exactly against the live registry (18 eligible, 2 reporting, matching `/api/fleet-stats`). The 32 excluded of 50 are private or repo-less placeholders, correctly excluded. Nothing is structurally unreachable; the 16 non-reporting eligible hives were all simply disabled by the author bug.

## Second fix: graceful degradation (owner's ask)

> "the info for stats can be cached so there is always info - it may not be current, but it shows something"

The 50% gate was **binary** — below the bar, the page showed nothing, so a recollecting fleet looked identical to a dead one.

The hub now persists the last aggregate that **cleared** the bar into `Registry.FleetStatsLKG` (in `hub-registry.json`, so it survives a hub restart) and serves it when live coverage drops, flagged `stale_data` with an `as_of` timestamp. The page renders the numbers with an explicit **"last known good (as of HH:MM)"** caption alongside live recollection progress.

Preserving #2328's honesty:

- Staleness is visible **in the UI**, not just a log line — stale-and-says-so, never wrong-and-silent.
- A degraded aggregate is **never promoted** into the cache, so the fallback cannot launder an unbacked number as current.
- Per-hive counts remain cached at hive granularity (already carried forward on the registry entry), so a partially-recovered fleet improves the figure rather than being stuck on a whole-fleet snapshot.
- Only a fleet that has **never once** reported well enough shows no total — a first-boot state, not a steady state.

### On #2329 (durability)

The hub side was already durable: per-hive counts persist in the registry and are carried forward when a heartbeat arrives with `nil`. The missing durability was the **aggregate**, which this PR adds. Restarts were not the thing wiping the figure here — the collector was never producing one to wipe.

### Threshold recommendation

With a labelled cache in place, I recommend **keeping** the 50% gate as the bar for what counts as *current*, rather than lowering it. It now controls a caption rather than a blackout, which is the right amount of power for an arbitrary threshold — the visitor always sees a number, and the number always says how current it is.

## Operator visibility

Previously the only symptom was a number that never appeared. Now:

- `fleet stats: serving last-known-good totals; live coverage is below the publish threshold` — with live `reporting`/`eligible`, the cache's `as_of`, and the coverage it was based on, so a permanently-broken collector cannot hide behind the cache.
- The existing per-spoke `collector disabled` warning is what actually diagnosed this; the author fix means it now fires only when genuinely misconfigured.

## Testing

- `go build ./...`, `go vet`, and `pkg/hub` + `pkg/config` + `pkg/dashboard` suites all pass.
- Landing-page JS extracted, `node --check` clean, brace/paren delta identical to base (0/0), change confirmed present in the extraction.
- **Mutation-verified** — each of these fails the suite: reverting the LKG fallback, promoting a degraded aggregate into the cache, dropping the persistence json tag, and neutering the App-bot branch of `EffectiveAIAuthor`.

## Read-only

No hive or hub was restarted and no config changed; live systems were only read.