### PR TITLE
🐛 fix(config): stop the overlay guard discarding valid configs

### DIFF
--- a/v2/docs/config-layering.md
+++ b/v2/docs/config-layering.md
@@ -153,7 +153,30 @@ after every live hive has written the new name.
 - **`overlay_rejected`** is the alarming one. It means the overlay failed the
   plausibility guard and was discarded, so the hive is running on the bare
   seed — which, per the table above, can be a small fraction of the real
-  config, including a fraction of the agent roster.
+  config, including a fraction of the agent roster. A rejection is also logged
+  at `ERROR` naming the specific cause.
+- **`last_good_used`** means a rejected overlay was replaced by the rolling
+  last-good config (`/data/hive.yaml.bak`) rather than by the sparse seed. The
+  config in effect is then neither the overlay the operator last wrote nor the
+  seed, so it is reported explicitly.
+
+### What makes an overlay valid
+
+The guard catches a **truncated or corrupt** overlay — not an unusual one.
+
+| Overlay | Verdict |
+|---|---|
+| `project.org` + one or more agents | valid |
+| Zero agents **with** `removed_agents` tombstones | **valid** — a deliberate deletion (#2361) |
+| All agents paused | valid |
+| Missing `policies` / `data` / `knowledge` / `hive_id` | valid — all optional |
+| No `project.org` | rejected — truncated write |
+| Zero agents **and** no tombstones | rejected — truncated write |
+
+The tombstone distinction matters: before it existed, deleting your last agent
+produced a zero-agent overlay that the guard called corrupt, so the hive booted
+from a seed that still listed the deleted agents — silently undoing the
+deletion.
 - **`identity_issues`** names inconsistencies in the GitHub identity set.
 
 ## The GitHub identity set is atomic

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -2840,8 +2840,19 @@ func (c *Config) validateSaveGuard() error {
 		log.Printf("WARNING: config.Save() blocked — project.org is empty, would corrupt hive.yaml")
 		return fmt.Errorf("project.org is empty")
 	}
-	if len(c.Agents) == 0 {
-		log.Printf("WARNING: config.Save() blocked — no agents configured, would corrupt hive.yaml")
+	// Zero agents is a legitimate state when the operator deliberately deleted
+	// them all: #2361's tombstones (RemovedAgents) are the durable record of
+	// that intent. Blocking the save here would make the last deletion
+	// unpersistable — the in-memory roster empties, the write is refused, and
+	// the next reload restores the agents from the seed, silently undoing the
+	// operator's action. That is precisely the "they always come back" bug
+	// #2361 fixed, reintroduced through the save path.
+	//
+	// An empty roster with NO tombstones is still refused: that is the
+	// truncated/uninitialised case this guard exists to catch. The two states
+	// are distinguishable, so distinguish them rather than rejecting both.
+	if len(c.Agents) == 0 && len(c.RemovedAgents) == 0 {
+		log.Printf("WARNING: config.Save() blocked — no agents configured and no tombstones, would corrupt hive.yaml")
 		return fmt.Errorf("no agents configured")
 	}
 	return nil

--- a/v2/pkg/config/layers.go
+++ b/v2/pkg/config/layers.go
@@ -79,7 +79,10 @@
 // one road, not duplicated effort.
 package config
 
-import "os"
+import (
+	"log"
+	"os"
+)
 
 // Layer identifies a configuration source. Ordered lowest → highest, so a
 // numerically greater Layer wins under the default rule.
@@ -209,6 +212,15 @@ func mergeLayers(seed, overlay *Config, keys seedKeys) (*Config, *Provenance) {
 		if overlay != nil {
 			prov.OverlayRejected = true
 			prov.OverlayRejectReason = overlayRejectReason(overlay)
+			// A rejection is severe: the hive is about to run on the bare
+			// ConfigMap seed, which omits whole config blocks and can mean a
+			// fraction of the agent roster. Say so at ERROR, naming the cause
+			// and the file, so this is diagnosable from `kubectl logs` alone
+			// rather than by inference from missing agents.
+			log.Printf("ERROR: dashboard overlay REJECTED (%s) — falling back to the "+
+				"ConfigMap seed, which may omit agents, policies, data, knowledge and "+
+				"notifications. Overlay: %s. Inspect with GET /api/config/provenance.",
+				prov.OverlayRejectReason, DashboardOverlayFile)
 		}
 		return seed, prov
 	}
@@ -270,15 +282,59 @@ func OverlayIsPlausible(overlay *Config) bool {
 // overlayRejectReason returns why an overlay is implausible, or "" if it is
 // fine. Returning the reason (rather than a bare bool) is what lets the boot
 // path log ERROR with a cause and lets provenance show it.
+//
+// ─────────────────────────────────────────────────────────────────────────
+// WHAT THIS GUARD IS FOR, AND WHAT IT MUST NOT DO
+// ─────────────────────────────────────────────────────────────────────────
+//
+// The guard exists to catch a TRUNCATED or CORRUPT overlay — a file cut off
+// mid-write when the pod was SIGKILLed, or one that is not a hive config at
+// all. Rejecting such a file is correct.
+//
+// It must NOT reject a structurally sound overlay that merely describes an
+// unusual hive, because the consequence of rejection is severe and silent: the
+// hive boots on the bare ConfigMap seed, which on the live fleet is 4–11% of
+// the running config and omits whole top-level blocks (policies, data,
+// knowledge, notifications, hive_id). A false rejection can bring a hive up
+// with a fraction of its agent roster.
+//
+// The original predicate was "project.org non-empty AND len(agents) > 0". The
+// agent-count half is wrong now, and demonstrably so:
+//
+//	#2361 shipped agent TOMBSTONES (Config.RemovedAgents), which make
+//	deliberate deletion durable. An operator who deletes their last agent
+//	produces a legitimately zero-agent overlay. The old guard classifies that
+//	correct state as corrupt, discards it, and boots from the seed — which
+//	still lists the deleted agents. The deletion silently un-does itself,
+//	which is the exact bug #2361 was written to fix.
+//
+// Verified against the code as merged: an all-tombstoned config is also
+// refused by validateSaveGuard ("no agents configured"), so the deletion
+// cannot even be persisted. See TestZeroAgentOverlayWithTombstonesIsValid.
+//
+// The replacement test is STRUCTURAL AUTHENTICITY, not richness: does this
+// file look like a hive config that was written completely? project.org is
+// kept because Config.Save never writes an overlay without it and it is the
+// cheapest true corruption signal. The agent-count check is replaced by a
+// tombstone-aware one: zero agents is valid when the overlay explains itself
+// with RemovedAgents, and suspicious only when it does not.
 func overlayRejectReason(overlay *Config) string {
 	if overlay == nil {
 		return "overlay absent"
 	}
+	// project.org is the corruption canary. Config.Save() refuses to write an
+	// overlay without it (validateSaveGuard), so an overlay lacking it was
+	// never written by us — it is truncated, hand-edited, or another file.
 	if overlay.Project.Org == "" {
-		return "overlay has no project.org"
+		return "overlay has no project.org — the file is truncated or is not a hive config"
 	}
-	if len(overlay.Agents) == 0 {
-		return "overlay has no agents"
+	// Zero agents is VALID when the overlay records deliberate deletions.
+	// Without that record it is more likely a truncated write than a real
+	// hive, so it is still rejected — but the reason now names the
+	// distinction instead of treating every empty roster as corruption.
+	if len(overlay.Agents) == 0 && len(overlay.RemovedAgents) == 0 {
+		return "overlay has no agents and no removed_agents tombstones — " +
+			"likely a truncated write (a deliberately emptied roster records tombstones)"
 	}
 	return ""
 }

--- a/v2/pkg/config/layers_guard_test.go
+++ b/v2/pkg/config/layers_guard_test.go
@@ -1,0 +1,245 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Plausibility-guard tests.
+//
+// The risk runs in BOTH directions and the tests are organised that way:
+//
+//   - Rejecting a VALID overlay is severe and silent: the hive boots on the
+//     bare ConfigMap seed, which on the live fleet is 4–11% of the running
+//     config and omits whole top-level blocks. A false rejection can bring a
+//     hive up with a fraction of its agent roster.
+//   - Accepting a CORRUPT overlay defeats the guard's reason to exist and
+//     lets a truncated write become the running config.
+//
+// Every test below states which direction it protects.
+
+// ─────────────────────────────────────────────────────────────────────────
+// DIRECTION 1: valid overlays must be ACCEPTED
+// ─────────────────────────────────────────────────────────────────────────
+
+// TestZeroAgentOverlayWithTombstonesIsValid is the case that motivated this
+// change. #2361 made agent deletion durable via RemovedAgents tombstones, so
+// an operator who deletes their last agent produces a legitimately zero-agent
+// overlay. The old guard called that corrupt and discarded it, booting from a
+// seed that still lists the deleted agents — silently undoing the deletion,
+// which is exactly the bug #2361 fixed.
+func TestZeroAgentOverlayWithTombstonesIsValid(t *testing.T) {
+	overlay := &Config{
+		Project:       ProjectConfig{Org: "acme"},
+		Agents:        map[string]AgentConfig{},
+		RemovedAgents: []string{"scanner", "guide"},
+	}
+
+	if !OverlayIsPlausible(overlay) {
+		t.Fatalf("a zero-agent overlay with tombstones was rejected (%q); "+
+			"deleting the last agent is a legitimate operator action since #2361",
+			overlayRejectReason(overlay))
+	}
+
+	seed := &Config{
+		Project: ProjectConfig{Org: "acme"},
+		Agents:  map[string]AgentConfig{"scanner": {}, "guide": {}},
+	}
+	merged, prov := MergeLayers(seed, overlay)
+
+	if prov.OverlayRejected {
+		t.Error("OverlayRejected = true for a valid tombstoned overlay")
+	}
+	// The deletion must survive the merge; resurrecting the agents from the
+	// seed is the regression this guards.
+	if len(merged.Agents) != 0 {
+		t.Errorf("merged roster has %d agents, want 0 — the seed resurrected deleted agents",
+			len(merged.Agents))
+	}
+}
+
+// TestSaveGuardAllowsAllTombstonedConfig covers the same conflict on the WRITE
+// path. If validateSaveGuard refuses an all-tombstoned config, the last
+// deletion cannot be persisted at all: the roster empties in memory, the save
+// is refused, and the next reload restores the agents.
+func TestSaveGuardAllowsAllTombstonedConfig(t *testing.T) {
+	c := &Config{
+		Project:       ProjectConfig{Org: "acme"},
+		Agents:        map[string]AgentConfig{},
+		RemovedAgents: []string{"scanner"},
+	}
+	if err := c.validateSaveGuard(); err != nil {
+		t.Fatalf("validateSaveGuard rejected an all-tombstoned config: %v; "+
+			"the operator's last deletion would be unpersistable", err)
+	}
+}
+
+// TestMinimalButCompleteOverlayIsValid: a hive mid-provision, or a deliberately
+// spare one, carries only project.org and a single agent. Nothing about that is
+// corrupt, and the guard must not demand richness.
+func TestMinimalButCompleteOverlayIsValid(t *testing.T) {
+	overlay := &Config{
+		Project: ProjectConfig{Org: "acme"},
+		Agents:  map[string]AgentConfig{"scanner": {}},
+	}
+	if !OverlayIsPlausible(overlay) {
+		t.Errorf("a minimal but complete overlay was rejected: %q", overlayRejectReason(overlay))
+	}
+}
+
+// TestOverlayWithoutOptionalBlocksIsValid: policies, data, knowledge,
+// notifications and hive_id are all absent from many real overlays. Requiring
+// any of them would reject valid configs fleet-wide.
+func TestOverlayWithoutOptionalBlocksIsValid(t *testing.T) {
+	overlay := &Config{
+		Project: ProjectConfig{Org: "acme"},
+		Agents:  map[string]AgentConfig{"scanner": {}},
+		// No Policies, Data, Knowledge, Notifications, HiveID, GitHub, Hub.
+	}
+	if !OverlayIsPlausible(overlay) {
+		t.Errorf("an overlay lacking optional blocks was rejected: %q",
+			overlayRejectReason(overlay))
+	}
+}
+
+// TestPausedAgentsOverlayIsValid: every agent paused is a normal operator
+// state and leaves a fully populated roster.
+func TestPausedAgentsOverlayIsValid(t *testing.T) {
+	overlay := &Config{
+		Project: ProjectConfig{Org: "acme"},
+		Agents: map[string]AgentConfig{
+			"scanner": {Paused: true},
+			"guide":   {Paused: true},
+		},
+	}
+	if !OverlayIsPlausible(overlay) {
+		t.Errorf("an all-paused overlay was rejected: %q", overlayRejectReason(overlay))
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// DIRECTION 2: corrupt overlays must still be REJECTED
+// ─────────────────────────────────────────────────────────────────────────
+
+// TestTruncatedOverlayIsRejected: the case the guard exists for. A write
+// interrupted by SIGKILL can leave a file with no project.org.
+func TestTruncatedOverlayIsRejected(t *testing.T) {
+	overlay := &Config{Agents: map[string]AgentConfig{"scanner": {}}}
+	if OverlayIsPlausible(overlay) {
+		t.Fatal("an overlay with no project.org was accepted; a truncated write " +
+			"must not become the running config")
+	}
+	if r := overlayRejectReason(overlay); !strings.Contains(r, "project.org") {
+		t.Errorf("reason = %q, want it to name project.org", r)
+	}
+}
+
+// TestEmptyOverlayWithoutTombstonesIsRejected: zero agents AND no tombstones
+// is the truncated case, not a deliberate deletion. The distinction between
+// this and TestZeroAgentOverlayWithTombstonesIsValid is the whole point of the
+// new predicate — if these two ever agree, the guard has lost its meaning.
+func TestEmptyOverlayWithoutTombstonesIsRejected(t *testing.T) {
+	overlay := &Config{Project: ProjectConfig{Org: "acme"}}
+	if OverlayIsPlausible(overlay) {
+		t.Fatal("an overlay with no agents and no tombstones was accepted; " +
+			"that is the truncated-write signature")
+	}
+	if r := overlayRejectReason(overlay); !strings.Contains(r, "removed_agents") {
+		t.Errorf("reason = %q, want it to explain the tombstone distinction", r)
+	}
+}
+
+// TestSaveGuardStillBlocksEmptyConfig: the write-path twin of the above.
+func TestSaveGuardStillBlocksEmptyConfig(t *testing.T) {
+	c := &Config{Project: ProjectConfig{Org: "acme"}}
+	if err := c.validateSaveGuard(); err == nil {
+		t.Fatal("validateSaveGuard accepted a config with no agents and no tombstones")
+	}
+}
+
+// TestRejectionReasonIsSpecific: a generic bail is what made this condition
+// undiagnosable. The reason must name the failing field.
+func TestRejectionReasonIsSpecific(t *testing.T) {
+	cases := []struct {
+		name    string
+		overlay *Config
+		want    string
+	}{
+		{"no org", &Config{Agents: map[string]AgentConfig{"a": {}}}, "project.org"},
+		{"no agents", &Config{Project: ProjectConfig{Org: "acme"}}, "removed_agents"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := overlayRejectReason(tc.overlay)
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("reason = %q, want it to mention %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Fail-safe fallback (opt-in, behaviour change — see MergeLayersWithFallback)
+// ─────────────────────────────────────────────────────────────────────────
+
+// TestFallbackPrefersLastGoodOverSparseSeed: falling back to the seed is
+// failing empty. The rolling backup is much closer to what the hive was
+// actually running.
+func TestFallbackPrefersLastGoodOverSparseSeed(t *testing.T) {
+	seed := []byte("project:\n  org: acme\nagents:\n  scanner: {}\n")
+	badOverlay := []byte("agents:\n  scanner: {}\n") // no project.org
+	lastGood := []byte("project:\n  org: acme\nagents:\n  scanner: {}\n  guide: {}\n  quality: {}\n")
+
+	merged, prov, err := MergeLayersWithFallback(seed, badOverlay, lastGood)
+	if err != nil {
+		t.Fatalf("MergeLayersWithFallback: %v", err)
+	}
+	if !prov.OverlayRejected {
+		t.Error("OverlayRejected = false, want the rejection still reported")
+	}
+	if !prov.LastGoodUsed {
+		t.Fatal("LastGoodUsed = false, want the recovery to be reported")
+	}
+	if len(merged.Agents) != 3 {
+		t.Errorf("merged roster = %d agents, want the last-good 3 rather than the seed's 1",
+			len(merged.Agents))
+	}
+}
+
+// TestFallbackIgnoresCorruptLastGood: never trade a valid seed for a backup
+// that is itself implausible.
+func TestFallbackIgnoresCorruptLastGood(t *testing.T) {
+	seed := []byte("project:\n  org: acme\nagents:\n  scanner: {}\n")
+	badOverlay := []byte("agents:\n  scanner: {}\n")
+	corruptLastGood := []byte("agents:\n  guide: {}\n") // no project.org either
+
+	merged, prov, err := MergeLayersWithFallback(seed, badOverlay, corruptLastGood)
+	if err != nil {
+		t.Fatalf("MergeLayersWithFallback: %v", err)
+	}
+	if prov.LastGoodUsed {
+		t.Error("LastGoodUsed = true for a corrupt backup, want the seed kept")
+	}
+	if len(merged.Agents) != 1 {
+		t.Errorf("merged roster = %d agents, want the seed's 1", len(merged.Agents))
+	}
+}
+
+// TestFallbackInertWhenOverlayIsValid: the fallback must never fire on the
+// healthy path, or it would mask the operator's actual overlay.
+func TestFallbackInertWhenOverlayIsValid(t *testing.T) {
+	seed := []byte("project:\n  org: acme\nagents:\n  scanner: {}\n")
+	goodOverlay := []byte("project:\n  org: acme\nagents:\n  scanner: {}\n  guide: {}\n")
+	lastGood := []byte("project:\n  org: acme\nagents:\n  stale: {}\n")
+
+	merged, prov, err := MergeLayersWithFallback(seed, goodOverlay, lastGood)
+	if err != nil {
+		t.Fatalf("MergeLayersWithFallback: %v", err)
+	}
+	if prov.LastGoodUsed || prov.OverlayRejected {
+		t.Error("fallback fired for a valid overlay")
+	}
+	if _, ok := merged.Agents["stale"]; ok {
+		t.Error("the last-good config leaked into a healthy merge")
+	}
+}

--- a/v2/pkg/config/layers_yaml.go
+++ b/v2/pkg/config/layers_yaml.go
@@ -25,7 +25,11 @@ package config
 // self-defeating. MergeLayersYAML parses the raw seed YAML to recover
 // key-presence and reproduces the heredoc exactly.
 
-import "gopkg.in/yaml.v3"
+import (
+	"log"
+
+	"gopkg.in/yaml.v3"
+)
 
 // MergeLayersYAML merges raw seed and overlay YAML with exact fidelity to the
 // entrypoint heredoc, returning the merged config and its provenance.
@@ -61,6 +65,58 @@ func MergeLayersYAML(seedYAML, overlayYAML []byte) (*Config, *Provenance, error)
 
 	cfg, prov := mergeLayers(&seed, &overlay, keys)
 	return cfg, prov, nil
+}
+
+// MergeLayersWithFallback is MergeLayersYAML plus a last-good fallback: when
+// the overlay is rejected, it prefers lastGoodYAML (normally the rolling
+// backup at /data/hive.yaml.bak) over the bare ConfigMap seed.
+//
+// ─────────────────────────────────────────────────────────────────────────
+// WHY, AND WHY THIS IS OPT-IN
+// ─────────────────────────────────────────────────────────────────────────
+//
+// Falling back to the seed is failing EMPTY, not failing safe. Live seeds are
+// 4–11% of the running config and omit policies, data, knowledge,
+// notifications and hive_id entirely, so a rejected overlay currently costs a
+// hive most of its configuration. The rolling backup is a far closer
+// approximation of what the hive was actually running a moment ago.
+//
+// This CHANGES WHICH CONFIG A HIVE BOOTS WITH in the rejection case, so it is
+// deliberately a separate entry point rather than folded into MergeLayersYAML.
+// Callers opt in explicitly and the change is reviewable on its own. The
+// fallback is used ONLY when the overlay is rejected AND the backup itself
+// passes the guard — a corrupt backup is never preferred to a valid seed.
+//
+// Provenance reports LastGoodUsed so the substitution is never silent.
+func MergeLayersWithFallback(seedYAML, overlayYAML, lastGoodYAML []byte) (*Config, *Provenance, error) {
+	cfg, prov, err := MergeLayersYAML(seedYAML, overlayYAML)
+	if err != nil || prov == nil || !prov.OverlayRejected || len(lastGoodYAML) == 0 {
+		return cfg, prov, err
+	}
+
+	var lastGood Config
+	if err := yaml.Unmarshal([]byte(expandEnvVars(string(lastGoodYAML))), &lastGood); err != nil {
+		// An unparsable backup is no better than the seed; keep the seed.
+		return cfg, prov, nil
+	}
+	if reason := overlayRejectReason(&lastGood); reason != "" {
+		// The backup is itself implausible — do not trade a valid seed for it.
+		return cfg, prov, nil
+	}
+
+	log.Printf("WARNING: dashboard overlay rejected (%s) — recovering from the last-good "+
+		"config instead of the sparse ConfigMap seed", prov.OverlayRejectReason)
+
+	keys := seedKeys{isPublicPresent: seedHasIsPublic(seedYAML)}
+	var seed Config
+	if err := yaml.Unmarshal([]byte(expandEnvVars(string(seedYAML))), &seed); err != nil {
+		return cfg, prov, nil
+	}
+	merged, mergedProv := mergeLayers(&seed, &lastGood, keys)
+	mergedProv.OverlayRejected = true
+	mergedProv.OverlayRejectReason = prov.OverlayRejectReason
+	mergedProv.LastGoodUsed = true
+	return merged, mergedProv, nil
 }
 
 // seedHasIsPublic reports whether the raw seed YAML contains the hub.is_public

--- a/v2/pkg/config/provenance.go
+++ b/v2/pkg/config/provenance.go
@@ -65,6 +65,12 @@ type Provenance struct {
 	OverlayRejected bool `json:"overlay_rejected"`
 	// OverlayRejectReason names why, e.g. "overlay has no agents".
 	OverlayRejectReason string `json:"overlay_reject_reason,omitempty"`
+	// LastGoodUsed is true when a rejected overlay was replaced by the rolling
+	// last-good config (/data/hive.yaml.bak) rather than by the bare ConfigMap
+	// seed. It means the hive recovered rather than degraded, and it must be
+	// visible: the config in effect is then neither the overlay the operator
+	// last wrote nor the seed, and nothing else would say so.
+	LastGoodUsed bool `json:"last_good_used"`
 	// GitHubRatchetFired is true when the seed's github block was kept because
 	// the overlay's looked like a placeholder (ratchet C in layers.go).
 	GitHubRatchetFired bool `json:"github_ratchet_fired"`

--- a/v2/pkg/dashboard/api_provenance.go
+++ b/v2/pkg/dashboard/api_provenance.go
@@ -39,6 +39,9 @@ type provenanceResponse struct {
 	OverlayRejected bool `json:"overlay_rejected"`
 	// OverlayRejectReason names why the overlay was rejected.
 	OverlayRejectReason string `json:"overlay_reject_reason,omitempty"`
+	// LastGoodUsed is true when a rejected overlay was replaced by the rolling
+	// last-good config rather than the bare seed.
+	LastGoodUsed bool `json:"last_good_used"`
 	// GitHubRatchetFired is true when the seed's github block was preserved
 	// because the overlay's looked like a placeholder.
 	GitHubRatchetFired bool `json:"github_ratchet_fired"`
@@ -114,6 +117,7 @@ func (s *Server) handleConfigProvenance(w http.ResponseWriter, r *http.Request) 
 		Layers:              describeLayers(),
 		OverlayRejected:     prov.OverlayRejected,
 		OverlayRejectReason: prov.OverlayRejectReason,
+		LastGoodUsed:        prov.LastGoodUsed,
 		GitHubRatchetFired:  prov.GitHubRatchetFired,
 		SeedPath:            seedPath,
 		OverlayPath:         overlayPath,


### PR DESCRIPTION
Stacked on #2370 (review that first; this PR's diff is the second commit).

## The guard was rejecting correct configs

`OverlayIsPlausible` bailed if the overlay had zero agents. That rule became wrong the moment **#2361** shipped agent tombstones: an operator who deletes their last agent produces a legitimately zero-agent overlay.

The old guard classified that correct state as corrupt, discarded the overlay, and booted from the ConfigMap seed — **which still lists the deleted agents.** The deletion silently undoes itself, which is the exact bug #2361 was written to fix.

`validateSaveGuard` carried the same rule, so the deletion could not even be **persisted**. Verified against the code as merged:

```
WARNING: config.Save() blocked — no agents configured, would corrupt hive.yaml
=> SAVE BLOCKED for an all-tombstoned hive: no agents configured
```

Both halves are fixed. This is why the guard could not simply be left alone.

## The new rule: structural authenticity, not richness

The guard exists to catch a **truncated or corrupt** overlay — a file cut off mid-write by a SIGKILL, or one that is not a hive config at all. It must not reject a sound overlay that merely describes an unusual hive, because rejection is severe and silent: the hive boots on the bare seed, which on the live fleet is **4–11% of the running config** and omits `policies`, `data`, `knowledge`, `notifications` and `hive_id` entirely.

| Overlay | Old | New |
|---|---|---|
| `project.org` + agents | valid | valid |
| Zero agents **with** `removed_agents` tombstones | **rejected** | **valid** |
| All agents paused | valid | valid |
| Missing optional blocks | valid | valid |
| No `project.org` | rejected | rejected |
| Zero agents **and** no tombstones | rejected | rejected |

`project.org` is kept as the corruption canary — `Config.Save` never writes an overlay without it, so a file lacking it was never written by us. The agent-count check is replaced by a tombstone-aware one: an emptied roster that **explains itself** is valid; one that does not is still the truncated-write signature.

## A trip is now loud

Previously a rejection was silent and indistinguishable from "there was no overlay". Now:

```
ERROR: dashboard overlay REJECTED (overlay has no project.org — the file is
truncated or is not a hive config) — falling back to the ConfigMap seed, which
may omit agents, policies, data, knowledge and notifications.
Overlay: /data/hive.yaml.dashboard. Inspect with GET /api/config/provenance.
```

and `/api/config/provenance` reports `overlay_rejected` with the specific reason.

## Fail-safe, not fail-empty — opt-in, flagged as a behaviour change

Falling back to the seed is failing *empty*. `MergeLayersWithFallback` prefers the rolling last-good config (`/data/hive.yaml.bak`) over the sparse seed when an overlay is rejected.

**This changes which config a hive boots with in the rejection case**, so it is a deliberately separate entry point rather than folded into `MergeLayersYAML` — callers opt in, and the change is reviewable on its own. It fires only when the overlay is rejected **and** the backup itself passes the guard; a corrupt backup is never preferred to a valid seed. `last_good_used` reports the substitution so it is never silent.

No caller opts in yet. Wiring the boot path to it is a follow-up.

## Tests

12 tests, organised by the direction of risk, because it runs both ways.

**Valid overlays must be accepted** (a false rejection costs a hive its roster): zero-agent-with-tombstones, the save-path twin, minimal-but-complete, missing optional blocks, all-paused.

**Corrupt overlays must still be rejected** (the guard's reason to exist): truncated write, empty-without-tombstones, the save-path twin, and reason-specificity.

Plus three for the fallback: prefers last-good, ignores a corrupt backup, inert on the healthy path.

**Mutation-verified — 5 mutations, all caught:**

| Mutation | Caught by |
|---|---|
| Revert guard to the agent-count rule | `TestZeroAgentOverlayWithTombstonesIsValid` |
| Revert `validateSaveGuard` | `TestSaveGuardAllowsAllTombstonedConfig` |
| Guard accepts everything | `TestTruncatedOverlayIsRejected` + `TestEmptyOverlayWithoutTombstonesIsRejected` |
| Fallback disabled | `TestFallbackPrefersLastGoodOverSparseSeed` |
| Fallback accepts a corrupt backup | `TestFallbackIgnoresCorruptLastGood` |

Sources restored and green after each. `go build ./...` clean, `gofmt` clean, `pkg/config` and `pkg/dashboard` both fully pass.

`pkg/hub/saas.go` and `static/index.html` are **untouched** — no raw-string or embedded-JS risk.

## Why this replaced the convergence plan

Converging the three variant-A/B hives onto seed-wins would have dropped **7 of 9 agents from the console hive**, because the seed is a small fraction of a running config. Rather than migrate hives, this makes the split stop being dangerous: a valid overlay can no longer be discarded, and a discard is no longer silent.

## Dependency for PR 6 (seed shrink)

The shrink **cannot** land before this. It narrows what a guard trip falls back to, and because the `.bak` disaster fallback fires only when the seed is *missing or empty*, a shrunken-but-non-empty seed silently bypasses it.

## Live systems

**Strictly read-only.** No hive, hub, ConfigMap or PVC was modified; no restarts, no placeholder experiments.
