### PR TITLE
✨ feat(hub): surface running-but-inactive agents in Attention needed

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -91,6 +91,25 @@ const spokeAppKeyFileMode = 0o600
 // Returns "" for a non-positive app_id (0 = unknown/unset, the placeholder
 // sentinel, or a hand-corrupted value): there is no meaningful per-app file for
 // those, and the caller falls back to the existing single-file behaviour.
+// agentActivityFor gathers the per-agent liveness evidence the hub needs to
+// tell a deliberately-paused agent from one that is running but unable to
+// work. Shared by both heartbeat build sites so the ordinary beat and the
+// upgrade beat can never report different pictures of the same agent.
+func agentActivityFor(mgr *agent.Manager, name string, proc *agent.AgentProcess) hub.AgentActivity {
+	act := hub.AgentActivity{
+		Paused:         proc.Paused,
+		NeedsLogin:     proc.NeedsLogin,
+		LastActivityAt: proc.LastPaneChange,
+		// A missing tmux session is only meaningful for an agent the manager
+		// believes is running; SessionMissing enforces that itself.
+		SessionMissing: mgr.SessionMissing(name),
+	}
+	if proc.StartedAt != nil {
+		act.StartedAt = *proc.StartedAt
+	}
+	return act
+}
+
 func perAppIDKeyPath(appID int64) string {
 	if appID <= 0 {
 		return ""
@@ -2185,11 +2204,12 @@ func main() {
 			govState := gov.GetState()
 			agents := make([]hub.AgentSummary, 0, len(statuses))
 			for name, proc := range statuses {
-				as := hub.AgentSummary{Name: name, State: string(proc.State)}
+				mode := ""
 				if ac, ok := cfg.Agents[name]; (ok && ac.OnDemand) || onDemandFromPack[name] {
-					as.Mode = "on_demand"
+					mode = "on_demand"
 				}
-				agents = append(agents, as)
+				agents = append(agents, hub.NewAgentSummary(name, string(proc.State), mode,
+					agentActivityFor(agentMgr, name, proc)))
 			}
 			acmmLvl := 0
 			if cfg.ACMMLevel != nil {
@@ -2479,11 +2499,12 @@ func main() {
 				statuses := agentMgr.AllStatuses()
 				agents := make([]hub.AgentSummary, 0, len(statuses))
 				for name, proc := range statuses {
-					as := hub.AgentSummary{Name: name, State: string(proc.State)}
+					mode := ""
 					if ac, ok := cfg.Agents[name]; (ok && ac.OnDemand) || onDemandFromPack[name] {
-						as.Mode = "on_demand"
+						mode = "on_demand"
 					}
-					agents = append(agents, as)
+					agents = append(agents, hub.NewAgentSummary(name, string(proc.State), mode,
+						agentActivityFor(agentMgr, name, proc)))
 				}
 				acmmLvl := 0
 				if cfg.ACMMLevel != nil {

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -83,6 +83,15 @@ type AgentProcess struct {
 	LastError           string // captured from bare copilot diagnostic launch
 	lastTokenRestart    time.Time // cooldown for auto-restart after token detection
 	NeedsLogin          bool   // true when pane shows a login prompt
+	// LastPaneChange is when the agent's tmux pane content last CHANGED, as
+	// observed by the 3s pane poller. It is the spoke's only evidence of an
+	// agent actually doing something: State says what the manager intends,
+	// StartedAt says when the CLI launched, and LastKick says when the
+	// governor last spoke to it — none of them move when a running,
+	// authenticated CLI sits there producing nothing. Written under paneMu by
+	// pollTmuxOutputForAgent alongside lastPaneCapture; zero until the poller
+	// has seen two differing captures, which reads as "unknown", never "idle".
+	LastPaneChange      time.Time
 	consentSeenAt       time.Time // watcher: when a consent screen was first seen in the pane
 	lastConsentDismiss  time.Time // watcher: cooldown for re-running dismissInferencePrompts
 	lastInferKickAt     time.Time // stall watchdog: when the last kick was delivered to an inference agent
@@ -1325,6 +1334,22 @@ func (m *Manager) installCavemanForAgent(agent *AgentProcess, backend string) {
 	}
 }
 
+// samePaneCapture reports whether two pane captures are identical line for
+// line. Used to decide whether the agent produced anything since the last
+// poll; equality means the pane is static, which is the observable signature
+// of an agent that is running but not working.
+func samePaneCapture(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // pollTmuxOutputForAgent is pollTmuxOutput using the agent's tmux socket.
 func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Context) {
 	const pollInterval = 3 * time.Second
@@ -1356,6 +1381,15 @@ func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Contex
 			showsLogin := paneShowsLoginPrompt(filtered)
 
 			agent.paneMu.Lock()
+			// Advance the activity clock only when the pane actually changed.
+			// Comparing against the PREVIOUS capture (not prevLines, which the
+			// ring-buffer diff below consumes and rewrites) is what separates
+			// "the CLI is producing output" from "the CLI is sitting at an idle
+			// prompt": a static pane re-captured every 3s is byte-identical, so
+			// an agent that renders nothing new never moves this timestamp.
+			if !samePaneCapture(agent.lastPaneCapture, filtered) {
+				agent.LastPaneChange = time.Now()
+			}
 			agent.lastPaneCapture = filtered
 			agent.NeedsLogin = showsLogin
 			agent.paneMu.Unlock()
@@ -2409,6 +2443,44 @@ func (m *Manager) bobAgentsAwaitingKey() []string {
 	return candidates
 }
 
+// notRunningReason explains WHY an agent is not in StateRunning, in terms an
+// operator can act on.
+//
+// The old wording — "agent <name> not running" — came from this same
+// State != StateRunning check and conflated three unrelated situations: an
+// agent the operator deliberately paused, one that failed to launch, and one
+// that was stopped or never started. During a live incident it read as a
+// launch failure on agents that were paused exactly as intended, and sent the
+// investigation after a tmux problem that did not exist. Naming the state, and
+// the pause trigger where there is one, is the whole fix.
+//
+// Caller holds m.mu.
+func notRunningReason(agent *AgentProcess) string {
+	switch {
+	case agent.Paused || agent.State == StatePaused:
+		reason := "it is paused"
+		if t := strings.TrimSpace(agent.PausedTrigger); t != "" {
+			reason += " (by " + t + ")"
+		}
+		if r := strings.TrimSpace(agent.PausedReason); r != "" {
+			reason += ": " + r
+		}
+		return reason
+	case agent.State == StateFailed:
+		reason := "it failed to start"
+		if e := strings.TrimSpace(agent.LastError); e != "" {
+			reason += ": " + e
+		}
+		return reason
+	case agent.State == StateStopped:
+		return "it is stopped"
+	case agent.State == StateIdle:
+		return "it has not been started yet"
+	default:
+		return "it is in state " + string(agent.State)
+	}
+}
+
 func (m *Manager) SendKick(name string, message string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -2419,7 +2491,7 @@ func (m *Manager) SendKick(name string, message string) error {
 	}
 
 	if agent.State != StateRunning {
-		return fmt.Errorf("agent %s not running", name)
+		return fmt.Errorf("agent %s cannot be kicked: %s", name, notRunningReason(agent))
 	}
 
 	if !m.tmuxSessionExistsForAgent(agent) {
@@ -3168,8 +3240,9 @@ func (a *AgentProcess) snapshot() AgentProcess {
 	a.paneMu.RLock()
 	pane := make([]string, len(a.lastPaneCapture))
 	copy(pane, a.lastPaneCapture)
-	// NeedsLogin is written by the pane poller under paneMu.
+	// NeedsLogin and LastPaneChange are written by the pane poller under paneMu.
 	needsLogin := a.NeedsLogin
+	lastPaneChange := a.LastPaneChange
 	a.paneMu.RUnlock()
 	return AgentProcess{
 		Name:            a.Name,
@@ -3192,6 +3265,7 @@ func (a *AgentProcess) snapshot() AgentProcess {
 		KickHistory:     history,
 		LastKickMessage: a.LastKickMessage,
 		NeedsLogin:      needsLogin,
+		LastPaneChange:  lastPaneChange,
 		StallNudges:     a.StallNudges,
 		ActionNudges:    a.ActionNudges,
 		HasLaunched:     a.HasLaunched,
@@ -5141,6 +5215,33 @@ func (m *Manager) IsPaused(name string) bool {
 		return false
 	}
 	return agent.Paused
+}
+
+// SessionMissing reports whether an agent the manager believes is RUNNING has
+// no live tmux session — the zombie case, where in-memory state and reality
+// have diverged.
+//
+// It is deliberately false for any agent that is not StateRunning: a paused,
+// stopped or never-started agent legitimately has no session, and reporting
+// those as missing would turn every deliberate pause into a fault.
+//
+// The session check must go through the agent's OWN tmux socket. Each agent
+// runs under its own UID on its own socket (e.g. /tmp/tmux-2007/hive-scanner),
+// so a query against the default socket answers "no server running" even when
+// every session is alive — the exact false reading that has sent live
+// diagnosis down the wrong path.
+func (m *Manager) SessionMissing(name string) bool {
+	m.mu.RLock()
+	agent, ok := m.agents[name]
+	if !ok || agent.State != StateRunning || agent.Paused {
+		m.mu.RUnlock()
+		return false
+	}
+	m.mu.RUnlock()
+	// The exec runs outside the lock: it shells out to tmux, and holding a
+	// manager lock across a subprocess is how the startup path has deadlocked
+	// before.
+	return !m.tmuxSessionExistsForAgent(agent)
 }
 
 func (m *Manager) TmuxSession(name string) string {

--- a/v2/pkg/agent/manager_test.go
+++ b/v2/pkg/agent/manager_test.go
@@ -571,8 +571,22 @@ func TestSendKick_NonRunningAgentReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error kicking non-running agent, got nil")
 	}
-	if !strings.Contains(err.Error(), "not running") {
-		t.Errorf("error %q should say 'not running'", err.Error())
+	// The message must name the SPECIFIC state. It used to read "agent idle
+	// not running", which was identical for a deliberately paused agent, a
+	// crashed one and a never-started one — and was read as a launch failure
+	// during a live incident on agents that were paused exactly as intended.
+	if !strings.Contains(err.Error(), "cannot be kicked") {
+		t.Errorf("error %q should explain that the kick was refused", err.Error())
+	}
+	if !strings.Contains(err.Error(), "stopped") {
+		t.Errorf("error %q should name the state that blocked the kick", err.Error())
+	}
+	if !strings.Contains(err.Error(), "idle") {
+		t.Errorf("error %q should mention the agent name", err.Error())
+	}
+	// Never the old ambiguous phrasing.
+	if strings.Contains(err.Error(), "not running") {
+		t.Errorf("error %q reverted to the ambiguous wording", err.Error())
 	}
 }
 

--- a/v2/pkg/agent/not_running_reason_test.go
+++ b/v2/pkg/agent/not_running_reason_test.go
@@ -1,0 +1,131 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNotRunningReasonNamesTheState guards the wording fix. The old message,
+// "agent <name> not running", came from a single State != StateRunning check
+// and read identically for an agent the operator had deliberately paused, one
+// that failed to launch, and one that was never started. During a live incident
+// it was read as a launch failure on agents that were paused exactly as
+// intended.
+func TestNotRunningReasonNamesTheState(t *testing.T) {
+	cases := []struct {
+		name  string
+		agent *AgentProcess
+		want  []string
+		// deny lists substrings that would reintroduce the ambiguity.
+		deny []string
+	}{
+		{
+			name: "operator paused via dashboard",
+			agent: &AgentProcess{
+				State: StatePaused, Paused: true,
+				PausedTrigger: "dashboard-api",
+				PausedReason:  "operator request",
+			},
+			want: []string{"paused", "dashboard-api", "operator request"},
+		},
+		{
+			name:  "paused with no trigger recorded",
+			agent: &AgentProcess{State: StatePaused, Paused: true},
+			want:  []string{"paused"},
+		},
+		{
+			// Paused before Start() ran, so State still holds the old value.
+			// The message must still say "paused", not "stopped".
+			name:  "paused flag set while state lags",
+			agent: &AgentProcess{State: StateStopped, Paused: true},
+			want:  []string{"paused"},
+			deny:  []string{"stopped"},
+		},
+		{
+			name:  "failed to launch, with cause",
+			agent: &AgentProcess{State: StateFailed, LastError: "missing API key"},
+			want:  []string{"failed to start", "missing API key"},
+			deny:  []string{"paused"},
+		},
+		{
+			name:  "stopped",
+			agent: &AgentProcess{State: StateStopped},
+			want:  []string{"stopped"},
+			deny:  []string{"paused"},
+		},
+		{
+			name:  "never started",
+			agent: &AgentProcess{State: StateIdle},
+			want:  []string{"not been started"},
+			deny:  []string{"paused"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := notRunningReason(tc.agent)
+			for _, w := range tc.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("reason %q does not mention %q", got, w)
+				}
+			}
+			for _, d := range tc.deny {
+				if strings.Contains(got, d) {
+					t.Errorf("reason %q wrongly mentions %q", got, d)
+				}
+			}
+			// The whole point of the change: never the bare old phrasing.
+			if got == "not running" {
+				t.Errorf("reason fell back to the ambiguous original wording")
+			}
+		})
+	}
+}
+
+// TestSamePaneCapture covers the comparison that drives the activity clock: an
+// agent producing nothing re-captures a byte-identical pane, and that is what
+// must NOT advance the timestamp.
+func TestSamePaneCapture(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b []string
+		want bool
+	}{
+		{"identical", []string{"one", "two"}, []string{"one", "two"}, true},
+		{"both empty", nil, nil, true},
+		{"content differs", []string{"one", "two"}, []string{"one", "three"}, false},
+		{"length differs", []string{"one"}, []string{"one", "two"}, false},
+		{"empty vs populated", nil, []string{"one"}, false},
+		{"order differs", []string{"a", "b"}, []string{"b", "a"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := samePaneCapture(tc.a, tc.b); got != tc.want {
+				t.Errorf("samePaneCapture(%v, %v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSnapshotCarriesLastPaneChange checks the field survives the snapshot that
+// feeds both the dashboard and the heartbeat — the same hop where StartedAt was
+// being dropped (#2324).
+func TestSnapshotCarriesLastPaneChange(t *testing.T) {
+	when := time.Now().Add(-5 * time.Minute).Truncate(time.Second)
+	started := time.Now().Add(-time.Hour).Truncate(time.Second)
+	a := &AgentProcess{
+		Name:           "scanner",
+		State:          StateRunning,
+		StartedAt:      &started,
+		LastPaneChange: when,
+		OutputBuffer:   NewRingBuffer(outputBufferCapacity),
+	}
+	snap := a.snapshot()
+	if !snap.LastPaneChange.Equal(when) {
+		t.Errorf("LastPaneChange = %v, want %v", snap.LastPaneChange, when)
+	}
+	if snap.StartedAt == nil || !snap.StartedAt.Equal(started) {
+		t.Errorf("StartedAt = %v, want %v", snap.StartedAt, started)
+	}
+}

--- a/v2/pkg/hub/agent_inactivity.go
+++ b/v2/pkg/hub/agent_inactivity.go
@@ -1,0 +1,243 @@
+package hub
+
+import (
+	"strings"
+	"time"
+)
+
+// Running-but-inactive agent detection.
+//
+// An agent process being "up" says almost nothing about whether it is doing
+// the job it exists to do. Five situations are visually identical in a status
+// table that only shows State, and diagnosing them by hand has repeatedly cost
+// real time:
+//
+//  1. Session exists, CLI never launched — the operator PAUSED it. Not a
+//     fault. Must never alarm.
+//  2. Session exists, CLI running, but sitting on a login / device-code
+//     prompt. State reads "running" throughout; the agent can do nothing.
+//  3. Session exists, CLI running and authenticated, but producing no output.
+//     A fault only when there is work waiting.
+//  4. Session exists, CLI running and working. Healthy.
+//  5. The manager believes the agent is running but its tmux session is gone —
+//     a zombie.
+//
+// This file decides which of those the hub raises. The governing constraint is
+// that a facet which lights up constantly gets ignored, which is worse than
+// not having the facet at all — so the bar for each rule is "an operator would
+// agree something is wrong" rather than "an agent is not currently busy".
+//
+// The evidence all arrives in the heartbeat's AgentSummary; nothing here
+// re-derives a spoke-side condition, and no second channel exists.
+
+const (
+	// inactiveAgentNeedsLoginGrace is how long an agent may show a login
+	// prompt before it is reported. A CLI briefly renders its auth screen
+	// during a normal restart, and an operator part-way through a device-code
+	// flow is mid-fix, not broken. Comfortably longer than a restart, short
+	// enough that a genuinely unauthenticated agent surfaces within one shift.
+	inactiveAgentNeedsLoginGrace = 20 * time.Minute
+
+	// inactiveAgentIdleThreshold is how long a running, authenticated agent
+	// may produce NO pane output before it counts as idle. Agents legitimately
+	// think, wait on CI, and sit between kicks for long stretches, so this is
+	// deliberately far above any single operation: it marks "this agent has
+	// produced nothing for most of an hour", not "this agent is between
+	// tasks".
+	//
+	// Idleness ALONE is never reported — see queuedWorkForInactivity.
+	inactiveAgentIdleThreshold = 45 * time.Minute
+
+	// inactiveAgentMinQueued is how much actionable work must be waiting
+	// before an idle agent is called a problem. A hive with an empty queue is
+	// SUPPOSED to have idle agents; reporting those would light the facet on
+	// every healthy quiet hive and train operators to ignore it. One waiting
+	// item is enough to make "and nothing is happening" wrong.
+	inactiveAgentMinQueued = 1
+
+	// inactiveAgentStartupGrace is how long after an agent's own launch its
+	// signals are ignored. A freshly launched CLI has not yet painted a pane,
+	// so its activity clock is legitimately unset; without this, every restart
+	// would raise a burst of alerts that clear themselves a minute later.
+	inactiveAgentStartupGrace = 10 * time.Minute
+
+	// inactiveAgentsNamedInReason caps how many agent names are listed in the
+	// alert text before it summarises the remainder, so one badly-wedged hive
+	// cannot push a paragraph into the panel.
+	inactiveAgentsNamedInReason = 3
+)
+
+// agentInactivityKind classifies why one agent is not working. Ordered by how
+// firmly it is a fault: a dead session and a login prompt are unambiguous,
+// while idleness depends on there being work to do.
+type agentInactivityKind int
+
+const (
+	agentInactiveNone agentInactivityKind = iota
+	// agentInactiveSessionMissing — state 5. The spoke expected a live tmux
+	// session for a running agent and found none.
+	agentInactiveSessionMissing
+	// agentInactiveNeedsLogin — state 2. Running and unauthenticated.
+	agentInactiveNeedsLogin
+	// agentInactiveIdleWithWork — state 3, and only while work is queued.
+	agentInactiveIdleWithWork
+)
+
+// label describes the kind in the words the alert row uses.
+func (k agentInactivityKind) label() string {
+	switch k {
+	case agentInactiveSessionMissing:
+		return "session gone"
+	case agentInactiveNeedsLogin:
+		return "not logged in"
+	case agentInactiveIdleWithWork:
+		return "idle with work queued"
+	default:
+		return ""
+	}
+}
+
+// classifyInactiveAgent decides whether ONE agent is running-but-not-working,
+// and why.
+//
+// queuedWork is the hive's actionable issue+PR backlog; it gates the idle rule
+// only. now is passed in so the whole evaluation is deterministic under test.
+//
+// Returns agentInactiveNone for every agent that is fine — including every
+// paused one, which is checked first and unconditionally.
+func classifyInactiveAgent(a AgentSummary, queuedWork int, now time.Time) agentInactivityKind {
+	// --- Paused is never a fault. The operator chose it. ---
+	//
+	// Checked before anything else and against BOTH signals: State carries
+	// "paused" once Start() has run, but an agent parked before that reports
+	// its earlier state with Paused set. Either one means hands off.
+	if a.Paused || strings.EqualFold(a.State, agentStatePaused) {
+		return agentInactiveNone
+	}
+
+	// Only agents the spoke believes are RUNNING can be "running but
+	// inactive". A stopped or failed agent is a different condition, already
+	// visible as a zero agent count and not this facet's job.
+	if !strings.EqualFold(a.State, agentStateRunning) {
+		return agentInactiveNone
+	}
+
+	// On-demand agents are meant to sit still until called. Idleness is their
+	// designed behaviour, so they are exempt from the idle rule — but NOT from
+	// the two unambiguous faults below, which are wrong for any agent.
+	onDemand := strings.EqualFold(a.Mode, agentModeOnDemand)
+
+	// --- A running agent with no session is a zombie. Unambiguous. ---
+	if a.SessionMissing {
+		return agentInactiveSessionMissing
+	}
+
+	startedAt, startedOK := parseAgentTime(a.StartedAt)
+
+	// Everything below is about an agent that has had time to settle. Within
+	// the startup grace its signals are still converging.
+	if startedOK && now.Sub(startedAt) < inactiveAgentStartupGrace {
+		return agentInactiveNone
+	}
+
+	// --- Running, but sitting on a login prompt. ---
+	if a.NeedsLogin {
+		// Without a start time there is no way to tell a momentary auth screen
+		// from a wedged one, so require the grace to have demonstrably passed
+		// rather than assuming it has.
+		if startedOK && now.Sub(startedAt) >= inactiveAgentNeedsLoginGrace {
+			return agentInactiveNeedsLogin
+		}
+		return agentInactiveNone
+	}
+
+	// --- Idle. Reported ONLY when the hive has work waiting. ---
+	//
+	// This is the rule most likely to produce noise, so it carries the most
+	// gating: an empty queue means idleness is correct, an on-demand agent is
+	// supposed to be idle, and an unknown activity time is not evidence.
+	if onDemand || queuedWork < inactiveAgentMinQueued {
+		return agentInactiveNone
+	}
+	lastActivity, activityOK := parseAgentTime(a.LastActivityAt)
+	if !activityOK {
+		// The spoke has never observed a pane change for this agent. That is
+		// the normal state of a spoke too old to report the field, so it must
+		// read as UNKNOWN — inferring idleness here would light the facet for
+		// every agent on every hive that has not upgraded yet.
+		return agentInactiveNone
+	}
+	if now.Sub(lastActivity) >= inactiveAgentIdleThreshold {
+		return agentInactiveIdleWithWork
+	}
+	return agentInactiveNone
+}
+
+// Wire values for the agent fields the classifier reads. Named so a typo
+// cannot silently turn a rule off — a misspelled literal here would simply
+// never match, and the facet would go quiet without failing anything.
+const (
+	agentStateRunning = "running"
+	agentStatePaused  = "paused"
+	agentModeOnDemand = "on_demand"
+)
+
+// parseAgentTime parses a spoke-reported RFC3339 timestamp. An empty,
+// unparseable or future value returns ok=false so every caller treats it as
+// UNKNOWN. A future timestamp is clock skew, not activity, and must not be
+// read as either fresh or stale.
+func parseAgentTime(s string) (time.Time, bool) {
+	t, err := time.Parse(time.RFC3339, strings.TrimSpace(s))
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// inactiveAgentReport is the per-hive result: which agents are running but not
+// working, and a sentence naming them.
+type inactiveAgentReport struct {
+	// Count is how many agents are affected. Zero means the hive is fine and
+	// nothing is rendered.
+	Count int
+	// Reason is the human sentence for the alert row and the row pill.
+	Reason string
+}
+
+// evaluateInactiveAgents classifies every agent on one hive.
+//
+// queuedWork gates the idle rule; pass the hive's actionable issue+PR total.
+// A hive whose spoke reports no agents at all yields an empty report — that is
+// a different condition (zero agents configured) with its own signal.
+func evaluateInactiveAgents(agents []AgentSummary, queuedWork int, now time.Time) inactiveAgentReport {
+	var affected []string
+	for _, a := range agents {
+		name := strings.TrimSpace(a.Name)
+		if name == "" {
+			continue
+		}
+		kind := classifyInactiveAgent(a, queuedWork, now)
+		if kind == agentInactiveNone {
+			continue
+		}
+		affected = append(affected, name+" ("+kind.label()+")")
+	}
+	if len(affected) == 0 {
+		return inactiveAgentReport{}
+	}
+
+	shown := affected
+	suffix := ""
+	if len(shown) > inactiveAgentsNamedInReason {
+		shown = shown[:inactiveAgentsNamedInReason]
+		suffix = " (+" + itoa(len(affected)-inactiveAgentsNamedInReason) + " more)"
+	}
+	noun := "agent is"
+	if len(affected) != 1 {
+		noun = "agents are"
+	}
+	return inactiveAgentReport{
+		Count:  len(affected),
+		Reason: itoa(len(affected)) + " " + noun + " running but not working: " + strings.Join(shown, ", ") + suffix,
+	}
+}

--- a/v2/pkg/hub/agent_inactivity_test.go
+++ b/v2/pkg/hub/agent_inactivity_test.go
@@ -1,0 +1,293 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// settled is a start time far enough in the past that inactiveAgentStartupGrace
+// has passed, so an agent's signals are eligible for evaluation.
+func settled(now time.Time) string {
+	return now.Add(-24 * time.Hour).UTC().Format(time.RFC3339)
+}
+
+// activeAt formats a last-activity timestamp d ago.
+func activeAt(now time.Time, d time.Duration) string {
+	return now.Add(-d).UTC().Format(time.RFC3339)
+}
+
+// TestPausedAgentIsNeverInactive is the rule that matters most: on a real
+// hosted hive four agents (architect, outreach, strategist, supervisor) sit
+// deliberately paused with trigger "dashboard-api". Reporting an operator's own
+// choice as a fault is exactly the false positive that makes a facet useless.
+func TestPausedAgentIsNeverInactive(t *testing.T) {
+	now := time.Now()
+	// Every fault signal at once — and it must STILL be silent, because paused
+	// wins over all of them.
+	cases := []AgentSummary{
+		{Name: "architect", State: "paused", Paused: true},
+		// Parked before Start() ran, so State still reads "running" and only
+		// the Paused bool marks the operator's choice. A paused agent has no
+		// live tmux session BY DESIGN, so this case also carries
+		// SessionMissing — without the Paused check it would be reported as a
+		// zombie, which is the exact false alarm this facet must never raise.
+		{Name: "outreach", State: "running", Paused: true, SessionMissing: true, StartedAt: settled(now)},
+		// Paused, session gone, unauthenticated, idle forever.
+		{
+			Name: "strategist", State: "paused", Paused: true,
+			SessionMissing: true, NeedsLogin: true,
+			StartedAt: settled(now), LastActivityAt: activeAt(now, 30*24*time.Hour),
+		},
+		// State says paused even though the bool was not set.
+		{Name: "supervisor", State: "paused"},
+	}
+	for _, a := range cases {
+		if got := classifyInactiveAgent(a, 500, now); got != agentInactiveNone {
+			t.Errorf("paused agent %q classified as %v; paused must never alarm", a.Name, got.label())
+		}
+	}
+
+	rep := evaluateInactiveAgents(cases, 500, now)
+	if rep.Count != 0 {
+		t.Fatalf("report counted %d paused agents (%q); want 0", rep.Count, rep.Reason)
+	}
+}
+
+func TestSessionMissingIsReported(t *testing.T) {
+	now := time.Now()
+	a := AgentSummary{Name: "scanner", State: "running", SessionMissing: true, StartedAt: settled(now)}
+	// A zombie is a fault even with an empty queue — there is no work to do,
+	// but the agent is also not there to do any.
+	if got := classifyInactiveAgent(a, 0, now); got != agentInactiveSessionMissing {
+		t.Fatalf("got %v, want session-missing", got.label())
+	}
+}
+
+func TestNeedsLoginReportedOnlyAfterGrace(t *testing.T) {
+	now := time.Now()
+	base := AgentSummary{Name: "quality", State: "running", NeedsLogin: true}
+
+	// Within the login grace (but past startup grace): still settling.
+	within := base
+	within.StartedAt = now.Add(-(inactiveAgentStartupGrace + time.Minute)).UTC().Format(time.RFC3339)
+	if got := classifyInactiveAgent(within, 0, now); got != agentInactiveNone {
+		t.Errorf("agent inside login grace classified %v; want none", got.label())
+	}
+
+	// Past the grace: a genuinely unauthenticated agent.
+	past := base
+	past.StartedAt = now.Add(-(inactiveAgentNeedsLoginGrace + time.Minute)).UTC().Format(time.RFC3339)
+	if got := classifyInactiveAgent(past, 0, now); got != agentInactiveNeedsLogin {
+		t.Errorf("got %v, want needs-login", got.label())
+	}
+
+	// No start time at all: unknown uptime is not evidence of a wedged login.
+	unknown := base
+	if got := classifyInactiveAgent(unknown, 0, now); got != agentInactiveNone {
+		t.Errorf("agent with unknown start classified %v; want none", got.label())
+	}
+}
+
+// TestIdleAgentNotReportedWithoutQueuedWork is the anti-noise guarantee: a hive
+// with nothing to do SHOULD have idle agents, and lighting the facet on those
+// would train operators to ignore it.
+func TestIdleAgentNotReportedWithoutQueuedWork(t *testing.T) {
+	now := time.Now()
+	a := AgentSummary{
+		Name: "guide", State: "running",
+		StartedAt:      settled(now),
+		LastActivityAt: activeAt(now, inactiveAgentIdleThreshold+time.Hour),
+	}
+	if got := classifyInactiveAgent(a, 0, now); got != agentInactiveNone {
+		t.Fatalf("idle agent on an empty queue classified %v; want none", got.label())
+	}
+	// The same agent, with work waiting, IS the signal we want.
+	if got := classifyInactiveAgent(a, inactiveAgentMinQueued, now); got != agentInactiveIdleWithWork {
+		t.Fatalf("idle agent with queued work classified %v; want idle-with-work", got.label())
+	}
+}
+
+func TestIdleRuleRespectsThresholdAndOnDemand(t *testing.T) {
+	now := time.Now()
+	base := AgentSummary{Name: "sec-check", State: "running", StartedAt: settled(now)}
+
+	// Recently active: working, not idle.
+	busy := base
+	busy.LastActivityAt = activeAt(now, inactiveAgentIdleThreshold-time.Minute)
+	if got := classifyInactiveAgent(busy, 50, now); got != agentInactiveNone {
+		t.Errorf("recently-active agent classified %v; want none", got.label())
+	}
+
+	// On-demand agents are SUPPOSED to sit idle until called.
+	onDemand := base
+	onDemand.Mode = "on_demand"
+	onDemand.LastActivityAt = activeAt(now, 30*24*time.Hour)
+	if got := classifyInactiveAgent(onDemand, 50, now); got != agentInactiveNone {
+		t.Errorf("on-demand agent classified %v; want none", got.label())
+	}
+	// But an on-demand agent whose session died is still a fault.
+	onDemand.SessionMissing = true
+	if got := classifyInactiveAgent(onDemand, 0, now); got != agentInactiveSessionMissing {
+		t.Errorf("on-demand zombie classified %v; want session-missing", got.label())
+	}
+}
+
+// TestUnknownActivityIsNotIdle guards the upgrade path: a spoke too old to
+// report lastActivityAt must not make every one of its agents alarm.
+func TestUnknownActivityIsNotIdle(t *testing.T) {
+	now := time.Now()
+	old := AgentSummary{Name: "legacy", State: "running", StartedAt: settled(now)}
+	if got := classifyInactiveAgent(old, 999, now); got != agentInactiveNone {
+		t.Fatalf("agent with unknown activity classified %v; want none", got.label())
+	}
+	// A future timestamp is clock skew, not freshness — and not idleness.
+	skewed := old
+	skewed.LastActivityAt = now.Add(2 * time.Hour).UTC().Format(time.RFC3339)
+	if got := classifyInactiveAgent(skewed, 999, now); got != agentInactiveNone {
+		t.Fatalf("future activity classified %v; want none", got.label())
+	}
+}
+
+func TestNonRunningStatesAreNotThisFacet(t *testing.T) {
+	now := time.Now()
+	for _, st := range []string{"stopped", "failed", "idle", ""} {
+		a := AgentSummary{Name: "x", State: st, StartedAt: settled(now)}
+		if got := classifyInactiveAgent(a, 100, now); got != agentInactiveNone {
+			t.Errorf("state %q classified %v; want none", st, got.label())
+		}
+	}
+}
+
+// TestStartupGraceSuppressesFreshLaunch stops a restart raising a burst of
+// alerts that clear a minute later.
+func TestStartupGraceSuppressesFreshLaunch(t *testing.T) {
+	now := time.Now()
+	fresh := now.Add(-time.Minute).UTC().Format(time.RFC3339)
+
+	// A CLI showing its auth screen seconds after launch is booting, not
+	// wedged.
+	login := AgentSummary{Name: "ci-maintainer", State: "running", NeedsLogin: true, StartedAt: fresh}
+	if got := classifyInactiveAgent(login, 100, now); got != agentInactiveNone {
+		t.Fatalf("freshly launched agent on a login prompt classified %v; want none", got.label())
+	}
+
+	// The case only the STARTUP grace can suppress: an agent restarted moments
+	// ago whose activity clock still carries a stale timestamp from before the
+	// relaunch. Without the grace this reads as "idle for hours" and every
+	// restart raises a burst of alerts that clear themselves a minute later.
+	staleClock := AgentSummary{
+		Name: "ci-maintainer", State: "running",
+		StartedAt:      fresh,
+		LastActivityAt: activeAt(now, inactiveAgentIdleThreshold+3*time.Hour),
+	}
+	if got := classifyInactiveAgent(staleClock, 100, now); got != agentInactiveNone {
+		t.Fatalf("freshly relaunched agent with a stale activity clock classified %v; want none", got.label())
+	}
+}
+
+func TestEvaluateInactiveAgentsReasonNamesAgents(t *testing.T) {
+	now := time.Now()
+	agents := []AgentSummary{
+		{Name: "scanner", State: "running", SessionMissing: true, StartedAt: settled(now)},
+		{Name: "quality", State: "running", NeedsLogin: true, StartedAt: settled(now)},
+		// Paused: must not appear anywhere in the output.
+		{Name: "architect", State: "paused", Paused: true},
+		// Healthy.
+		{Name: "guide", State: "running", StartedAt: settled(now), LastActivityAt: activeAt(now, time.Minute)},
+	}
+	rep := evaluateInactiveAgents(agents, 10, now)
+	if rep.Count != 2 {
+		t.Fatalf("count = %d, want 2 (reason %q)", rep.Count, rep.Reason)
+	}
+	for _, want := range []string{"scanner", "session gone", "quality", "not logged in"} {
+		if !strings.Contains(rep.Reason, want) {
+			t.Errorf("reason %q missing %q", rep.Reason, want)
+		}
+	}
+	if strings.Contains(rep.Reason, "architect") {
+		t.Errorf("reason %q names a PAUSED agent", rep.Reason)
+	}
+	if strings.Contains(rep.Reason, "guide") {
+		t.Errorf("reason %q names a healthy agent", rep.Reason)
+	}
+}
+
+func TestEvaluateInactiveAgentsTruncatesLongLists(t *testing.T) {
+	now := time.Now()
+	var agents []AgentSummary
+	for _, n := range []string{"a", "b", "c", "d", "e"} {
+		agents = append(agents, AgentSummary{
+			Name: n, State: "running", SessionMissing: true, StartedAt: settled(now),
+		})
+	}
+	rep := evaluateInactiveAgents(agents, 0, now)
+	if rep.Count != 5 {
+		t.Fatalf("count = %d, want 5", rep.Count)
+	}
+	if !strings.Contains(rep.Reason, "+2 more") {
+		t.Errorf("reason %q should summarise the remainder past %d named", rep.Reason, inactiveAgentsNamedInReason)
+	}
+}
+
+func TestEvaluateInactiveAgentsEmptyAndUnnamed(t *testing.T) {
+	now := time.Now()
+	if rep := evaluateInactiveAgents(nil, 100, now); rep.Count != 0 || rep.Reason != "" {
+		t.Errorf("nil agents produced %+v; want empty", rep)
+	}
+	// A nameless agent cannot be actioned, so it is skipped rather than
+	// rendering a blank entry in the panel.
+	unnamed := []AgentSummary{{Name: "  ", State: "running", SessionMissing: true, StartedAt: settled(now)}}
+	if rep := evaluateInactiveAgents(unnamed, 0, now); rep.Count != 0 {
+		t.Errorf("unnamed agent counted: %+v", rep)
+	}
+}
+
+// TestInactiveAgentsAlertRaisedFromPrecomputedFlag checks the wiring into the
+// fleet-alert pipeline, including that placeholders are excluded.
+func TestInactiveAgentsAlertRaisedFromPrecomputedFlag(t *testing.T) {
+	now := time.Now()
+	state := newAlertState()
+	hives := []alertHive{
+		{
+			ID: "h1", Name: "org/one", Online: true,
+			InactiveAgents: 2, InactiveAgentsReason: "2 agents are running but not working: scanner (session gone), quality (not logged in)",
+		},
+		{
+			// A placeholder pool slot has no agents to be inactive.
+			ID: "h2", Name: "available-x", IsPlaceholder: true,
+			InactiveAgents: 3, InactiveAgentsReason: "should not be reported",
+		},
+	}
+	summary := evaluateAlerts(state, hives, nil, now)
+
+	var found *Alert
+	for i := range summary.Alerts {
+		if summary.Alerts[i].Type == AlertTypeAgentsInactive {
+			if summary.Alerts[i].HiveID == "h2" {
+				t.Fatalf("placeholder hive raised an inactive-agents alert")
+			}
+			found = &summary.Alerts[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("no agents-inactive alert raised for h1")
+	}
+	if found.Severity != AlertSeverityWarning {
+		t.Errorf("severity = %q, want %q", found.Severity, AlertSeverityWarning)
+	}
+	if !strings.Contains(found.Reason, "scanner") {
+		t.Errorf("reason %q lost the spoke-supplied detail", found.Reason)
+	}
+	if summary.CountsByType[AlertTypeAgentsInactive] != 1 {
+		t.Errorf("countsByType = %v, want one agents-inactive", summary.CountsByType)
+	}
+}
+
+// TestInactiveAgentsAlertIsAckable pairs with the #2348 known-types guard: an
+// alert the operator cannot silence is a bug.
+func TestInactiveAgentsAlertIsAckable(t *testing.T) {
+	if !isKnownAlertType(AlertTypeAgentsInactive) {
+		t.Fatal("agents-inactive is not a known alert type, so it cannot be acknowledged")
+	}
+}

--- a/v2/pkg/hub/alerts.go
+++ b/v2/pkg/hub/alerts.go
@@ -101,6 +101,11 @@ const (
 	// certificate is broken and the link in the hub table returns 503. Raised by
 	// the auth-audit loop, which already makes this HTTPS request.
 	AlertTypeURLUnreachable = "url-unreachable"
+	// AlertTypeAgentsInactive — one or more agents are RUNNING but not doing
+	// any work: their tmux session has gone, they are sitting on a login
+	// prompt, or they have produced nothing while work is queued. Deliberately
+	// paused agents are excluded by the rule itself, never reported here.
+	AlertTypeAgentsInactive = "agents-inactive"
 )
 
 // --- Thresholds. Every one is a named constant with a rationale. ---
@@ -461,6 +466,14 @@ type alertHive struct {
 	// exactly how the panel and the row pill would start disagreeing.
 	AdvisoryStale       bool
 	AdvisoryStaleReason string
+
+	// InactiveAgents / InactiveAgentsReason are carried through verbatim from
+	// the entry rather than recomputed, exactly as the advisory pair above is:
+	// evaluateInactiveAgents owns the thresholds and the paused/on-demand
+	// gating, and duplicating either here is how the facet and the row pill
+	// would start disagreeing about which hives are affected.
+	InactiveAgents       int
+	InactiveAgentsReason string
 }
 
 // alertHiveFromEntry projects a MyHiveEntry into the evaluator's view.
@@ -485,6 +498,9 @@ func alertHiveFromEntry(h MyHiveEntry) alertHive {
 
 		AdvisoryStale:       h.AdvisoryStale,
 		AdvisoryStaleReason: h.AdvisoryStaleReason,
+
+		InactiveAgents:       h.InactiveAgents,
+		InactiveAgentsReason: h.InactiveAgentsReason,
 	}
 }
 
@@ -770,6 +786,26 @@ func evaluateAlerts(state *alertState, hives []alertHive, driftAlerts []Alert, n
 				reason = "Advisory digest has gone stale"
 			}
 			add(h.ID, h.Name, AlertTypeAdvisoryStale, AlertSeverityWarning, reason)
+		}
+
+		// --- Rule: agents are running but not working. ---
+		// The condition is NOT re-derived here: it is precomputed by
+		// evaluateInactiveAgents(), which already excludes paused and
+		// on-demand agents, already requires queued work before calling an
+		// agent idle, and already treats unknown timestamps as unknown. There
+		// is nothing to re-check beyond the placeholder guard every
+		// claimed-hive rule applies — an unclaimed pool slot has no agents.
+		//
+		// Warning, not critical: the hive is up and its other agents may be
+		// working, but capacity the operator believes they have is doing
+		// nothing.
+		if !h.IsPlaceholder && h.InactiveAgents > 0 {
+			reason := h.InactiveAgentsReason
+			if reason == "" {
+				// Only reached if the count arrives without a sentence.
+				reason = "Agents are running but not working"
+			}
+			add(h.ID, h.Name, AlertTypeAgentsInactive, AlertSeverityWarning, reason)
 		}
 
 		// --- Rule: token burn anomaly. Claimed hives only — an unassigned
@@ -1058,6 +1094,7 @@ var knownAlertTypes = map[string]bool{
 	AlertTypeTokenBurn:          true,
 	AlertTypeProvisionError:     true,
 	AlertTypeAdvisoryStale:      true,
+	AlertTypeAgentsInactive:     true,
 	AlertTypeURLUnreachable:     true,
 }
 

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -117,6 +117,68 @@ type AgentSummary struct {
 	Name  string `json:"name"`
 	State string `json:"state"`
 	Mode  string `json:"mode,omitempty"`
+	// Paused distinguishes an agent the OPERATOR deliberately parked from one
+	// that is merely not running. State already carries "paused", but a paused
+	// agent that has not yet been through Start() reports its prior state with
+	// Paused set, so the two are not interchangeable. The hub's inactive-agent
+	// rule keys off this to guarantee a deliberate pause is never alerted on.
+	Paused bool `json:"paused,omitempty"`
+	// NeedsLogin is true when the agent's CLI is sitting on a login /
+	// device-code prompt. This is the "running but not logged in" state: the
+	// session is alive, the CLI process is alive, and the agent still cannot do
+	// any work. It is invisible in State, which reads "running" throughout.
+	NeedsLogin bool `json:"needsLogin,omitempty"`
+	// SessionMissing is true when the manager expected a live tmux session for
+	// a running agent and did not find one — the zombie case. Reported
+	// explicitly rather than inferred hub-side, because only the spoke can see
+	// the per-UID tmux socket (each agent runs on its own,
+	// e.g. /tmp/tmux-2007/hive-scanner; a default-socket check reports "no
+	// server running" even when every session is alive).
+	SessionMissing bool `json:"sessionMissing,omitempty"`
+	// StartedAt is when this agent's CLI was last launched (RFC3339), empty if
+	// it has never launched. Wiring it through closes #2324: AgentProcess has
+	// carried it all along, but both the dashboard and the heartbeat dropped
+	// it, so no persisted per-agent session duration existed anywhere.
+	StartedAt string `json:"startedAt,omitempty"`
+	// LastActivityAt is when the agent's pane content last changed (RFC3339),
+	// empty when the spoke has not yet observed a change. It is what separates
+	// "running and working" from "running and producing nothing" — State,
+	// StartedAt and the kick log all keep their values while a CLI sits idle.
+	LastActivityAt string `json:"lastActivityAt,omitempty"`
+}
+
+// AgentActivity is the per-agent liveness evidence the spoke has and the hub
+// does not. It exists so the two heartbeat build sites in cmd/hive (the
+// ordinary loop and the upgrade beat) fill AgentSummary identically — they
+// were already duplicated line for line, and a signal that is only reported on
+// one of the two paths is a signal that quietly disappears mid-upgrade.
+type AgentActivity struct {
+	Paused         bool
+	NeedsLogin     bool
+	SessionMissing bool
+	StartedAt      time.Time
+	LastActivityAt time.Time
+}
+
+// NewAgentSummary builds one AgentSummary from an agent's name, state, mode and
+// activity evidence. Zero timestamps serialise as empty (not as a bogus
+// year-1 string), which the hub reads as "unknown" — never as "idle".
+func NewAgentSummary(name, state, mode string, act AgentActivity) AgentSummary {
+	as := AgentSummary{
+		Name:           name,
+		State:          state,
+		Mode:           mode,
+		Paused:         act.Paused,
+		NeedsLogin:     act.NeedsLogin,
+		SessionMissing: act.SessionMissing,
+	}
+	if !act.StartedAt.IsZero() {
+		as.StartedAt = act.StartedAt.UTC().Format(time.RFC3339)
+	}
+	if !act.LastActivityAt.IsZero() {
+		as.LastActivityAt = act.LastActivityAt.UTC().Format(time.RFC3339)
+	}
+	return as
 }
 
 type GovernorSummary struct {

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1692,6 +1692,20 @@ type MyHiveEntry struct {
 	AdvisoryStale       bool   `json:"advisoryStale,omitempty"`
 	AdvisoryStaleReason string `json:"advisoryStaleReason,omitempty"`
 
+	// InactiveAgents is how many of this hive's agents are RUNNING but not
+	// doing any work — session gone, sitting on a login prompt, or producing
+	// nothing while work is queued. Computed on read by
+	// evaluateInactiveAgents() so the browser never re-derives the thresholds
+	// or the paused/on-demand gating and cannot drift from the Go rule.
+	//
+	// Agents the operator deliberately PAUSED are excluded by that rule and
+	// never counted here: a pause is a choice, not a fault, and a facet that
+	// alarms on it would be wrong on every hive with a parked agent.
+	// InactiveAgentsReason is the tooltip cause. Both stay zero/empty for
+	// hives with nothing wrong, so the pill and the facet self-suppress.
+	InactiveAgents       int    `json:"inactiveAgents,omitempty"`
+	InactiveAgentsReason string `json:"inactiveAgentsReason,omitempty"`
+
 	// URLUnreachable is true when this hive's PUBLIC dashboard URL failed to
 	// serve on the last several probes — the link in this very table is dead.
 	// Computed on read from the auth-audit loop's observations, so the browser
@@ -2039,6 +2053,20 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		if stale, reason := advisoryStale(result[i].RegistryEntry, journeyNow); stale {
 			result[i].AdvisoryStale = true
 			result[i].AdvisoryStaleReason = reason
+		}
+
+		// Running-but-inactive agents, computed on read for the same reason:
+		// the thresholds and the paused/on-demand exclusions live ONLY in Go.
+		//
+		// The queue gate is the governor's own actionable backlog, which is
+		// what makes the idle rule safe on a genuinely quiet hive: with no
+		// issues and no PRs waiting, idle agents are CORRECT and nothing is
+		// reported. The two unambiguous faults (dead session, login prompt)
+		// are independent of it.
+		queuedWork := result[i].ActionableIssues + result[i].ActionablePRs
+		if rep := evaluateInactiveAgents(result[i].Agents, queuedWork, journeyNow); rep.Count > 0 {
+			result[i].InactiveAgents = rep.Count
+			result[i].InactiveAgentsReason = rep.Reason
 		}
 
 		// Sparkline history dominated this payload: at 42 hives the two series
@@ -8749,7 +8777,14 @@ const dashboardHTML = `<!DOCTYPE html>
       /* Added by the hub in #2308. Without a label here the chip for a
          genuinely failed upgrade would render as the raw key 'failed-upgrade'. */
       'failed-upgrade': 'Failed upgrade',
-      'advisory-stale': 'Stale advisory'
+      'advisory-stale': 'Stale advisory',
+      /* Agents that are up but doing nothing — a session that has gone, a
+         login prompt, or no output while work is queued. Deliberately paused
+         agents are excluded server-side and never counted here. */
+      'agents-inactive': 'Idle agents',
+      /* Raised by the auth-audit loop since #2306 but never labelled, so its
+         chip rendered the raw key. */
+      'url-unreachable': 'Dashboard URL unreachable'
     };
 
     /* How many alert rows are listed before the panel collapses the remainder

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -966,6 +966,11 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				payload.Agents[i].Name = sanitizeHeartbeatField(payload.Agents[i].Name)
 				payload.Agents[i].State = sanitizeHeartbeatField(payload.Agents[i].State)
 				payload.Agents[i].Mode = sanitizeHeartbeatField(payload.Agents[i].Mode)
+				// Timestamps are spoke-reported strings like every other field
+				// here. An unparseable value is later read as "unknown" by the
+				// inactive-agent rule, never as evidence of idleness.
+				payload.Agents[i].StartedAt = sanitizeHeartbeatField(payload.Agents[i].StartedAt)
+				payload.Agents[i].LastActivityAt = sanitizeHeartbeatField(payload.Agents[i].LastActivityAt)
 			}
 			const maxAgents = 50
 			if len(payload.Agents) > maxAgents {


### PR DESCRIPTION
## The problem

An agent process being "up" says almost nothing about whether it is doing the job it exists to do. Five situations were indistinguishable in the hub, and telling them apart by hand has repeatedly cost real diagnosis time:

| # | State | Evidence | Alarm? |
|---|---|---|---|
| 1 | Session exists, CLI never launched — **deliberately paused** | `Paused` bool / `state=="paused"` | **Never** |
| 2 | Session exists, CLI running, **not logged in** | `NeedsLogin` (pane shows a login/device-code prompt) | Yes |
| 3 | Session exists, running + authenticated, **producing nothing** | `LastActivityAt` (new pane-change clock) | Only while work is queued |
| 4 | Session exists, running and **working** | recent `LastActivityAt` | No — healthy |
| 5 | Manager believes it is running, **session is gone** | `SessionMissing` (per-UID tmux socket) | Yes |

Today's incident is the motivation: `tmux ls` reported "no server running" while all nine sessions were alive (each agent runs on its own per-UID socket, e.g. `/tmp/tmux-2007/hive-scanner`), four agents sat deliberately paused, and `"agent scanner not running"` — an in-memory state check, not a tmux one — fired for the paused ones and read as a launch failure.

## What this adds

A warning-severity **`agents-inactive`** alert type, rendered as an **"Idle agents"** chip in the existing *Attention needed* panel. It follows the stale-advisory facet (#2306) exactly: the condition is precomputed server-side on read, so the browser never re-derives a threshold and the panel, chip and row pill cannot disagree. Rows are clickable and jump to the hive via the #2348 machinery for free.

The spoke reports the evidence in its **heartbeat** — the only write path to the hub — through new `AgentSummary` fields (`paused`, `needsLogin`, `sessionMissing`, `startedAt`, `lastActivityAt`). No second channel. Both heartbeat build sites go through one shared `NewAgentSummary`/`agentActivityFor` helper, so the ordinary beat and the upgrade beat can never report different pictures.

## Paused is never a fault

Checked first, and against **both** the `Paused` bool and the state string — an agent parked before `Start()` runs still reports its earlier state. This matters concretely: a paused agent has no live tmux session *by design*, so without the bool check it would be reported as a **zombie**. Mutation-testing caught exactly this, and the guard test now carries `SessionMissing: true` to pin it.

## Avoiding false positives

A facet that lights up constantly gets ignored, which is worse than not having it. So:

- **The idle rule is gated on queued work** — the governor's own `ActionableIssues + ActionablePRs`. A hive with an empty queue is *supposed* to have idle agents and reports nothing.
- **On-demand agents** are exempt from the idle rule (sitting still is their design) but not from the two unambiguous faults.
- **Unknown and future timestamps read as UNKNOWN**, never as idleness — so a spoke too old to report `lastActivityAt` stays silent rather than alarming on every agent.
- **Startup grace** suppresses a freshly relaunched agent whose activity clock still holds a pre-restart timestamp.
- **Placeholders** are excluded; an unclaimed pool slot has no agents.

Every threshold is a named constant with a rationale — `inactiveAgentIdleThreshold` (45m), `inactiveAgentNeedsLoginGrace` (20m), `inactiveAgentStartupGrace` (10m), `inactiveAgentMinQueued` (1).

## Closes #2324

`AgentProcess.StartedAt` existed but was dropped **twice** — by `buildAgents` and by the heartbeat collector — so no persisted per-agent session duration existed anywhere. It is now wired through, alongside a new `LastPaneChange` activity clock updated by the existing 3s pane poller only when pane content actually *changes*. That clock is the only evidence separating "running and working" from "running and producing nothing": state, uptime and the kick log all keep their values while a CLI sits idle.

## Misleading wording fixed

- `"agent <name> not running"` conflated paused, failed, stopped and never-started. Now: `"agent scanner cannot be kicked: it is paused (by dashboard-api): operator request"`.
- The `url-unreachable` chip rendered its raw key — it was never given a label when the type was added. Fixed in passing.

## Verification

- `go build ./...`, `go vet` clean; **full `pkg/hub` and `pkg/agent` suites pass**.
- **13 mutations, all killed** — including removing the paused guard, the queue gate, the on-demand exemption, the unknown-timestamp guard, the startup grace and the placeholder guard. Two tests were strengthened after mutations initially survived.
- Embedded dashboard JS extracted and `node --check`ed: **exit 0**, **zero backticks**, and a **zero brace/paren/bracket delta** vs `origin/v2` (the pre-existing `-1` parens/brackets is unchanged).
- Live evidence gathered **read-only** from `hosted-kubestellar-console-4vkt`: nine per-UID sockets all alive, five panes showing CLI chrome and four showing a bare shell. The deliberately paused agents were left exactly as they were.

`gofmt` reports `pkg/agent/manager.go` unformatted — pre-existing alignment drift on `origin/v2` in declarations this PR does not touch, so it is left alone.