### PR TITLE
🔥 refactor(hub): retire the dashboard Request-a-Hive modal, leaving the wizard as the only path

### DIFF
--- a/v2/pkg/hub/hub_coverage_deep_test.go
+++ b/v2/pkg/hub/hub_coverage_deep_test.go
@@ -624,15 +624,26 @@ func TestHandleRequestProvisionACMMLevelDefault(t *testing.T) {
 
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
-	body := `{"org":"validorg","repos":"repo1","acmm_level":0}`
+	// Carries github_host AND full_name on purpose: both are required, and
+	// omitting either makes the handler 400 long before the ACMM clamp this
+	// test exists to cover. This fixture used to omit full_name and discard the
+	// status with `_ = w.Code`, so after #2369 made the name required it passed
+	// while silently exercising the 400 branch instead of the clamp.
+	body := `{"org":"validorg","github_host":"github.com","repos":"repo1","acmm_level":0,"full_name":"Ada Lovelace"}`
 	req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer ghp_prov_acmm")
 	w := httptest.NewRecorder()
 	srv.handleRequestProvision(w, req)
 
-	// ACMM 0 → clamped to 1
-	_ = w.Code
+	// ACMM 0 → clamped to minRequestACMMLevel. Assert we got PAST validation:
+	// a 400 here means a required field regressed, which is exactly the failure
+	// the old `_ = w.Code` hid. Persisting needs /data, absent in unit tests, so
+	// the success path legitimately ends in 500 — anything but 400 proves the
+	// clamp was reached.
+	if w.Code == http.StatusBadRequest {
+		t.Errorf("ACMM clamp path should not 400 — a required field likely regressed; body: %s", w.Body.String())
+	}
 }
 
 func TestHandleRequestProvisionACMMLevelHigh(t *testing.T) {
@@ -641,15 +652,20 @@ func TestHandleRequestProvisionACMMLevelHigh(t *testing.T) {
 
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
-	body := `{"org":"validorg","repos":"repo1","acmm_level":99}`
+	// See TestHandleRequestProvisionACMMLevelDefault: github_host and full_name
+	// are required, so a fixture missing them never reaches the clamp.
+	body := `{"org":"validorg","github_host":"github.com","repos":"repo1","acmm_level":99,"full_name":"Ada Lovelace"}`
 	req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer ghp_prov_high")
 	w := httptest.NewRecorder()
 	srv.handleRequestProvision(w, req)
 
-	// ACMM 99 → clamped to 1
-	_ = w.Code
+	// ACMM 99 (above maxRequestACMMLevel) → clamped to minRequestACMMLevel.
+	// As above, 400 means validation rejected us before the clamp ran.
+	if w.Code == http.StatusBadRequest {
+		t.Errorf("ACMM clamp path should not 400 — a required field likely regressed; body: %s", w.Body.String())
+	}
 }
 
 // ============================================================

--- a/v2/pkg/hub/request_provision_callers_test.go
+++ b/v2/pkg/hub/request_provision_callers_test.go
@@ -1,0 +1,180 @@
+package hub
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// This file exists because of a live regression, and the shape of that
+// regression is the reason the test below is static analysis rather than a
+// behavioural HTTP test.
+//
+// #2369 made full_name required on POST /api/saas/request-provision and updated
+// the get-started wizard, which was believed to be the only in-tree caller. It
+// was not. The hub dashboard had its own "Request a Hive" modal posting to the
+// same endpoint, added AFTER the wizard and reachable by every logged-in user.
+// It was never updated, so it began returning
+// 400 "your name is required" with no field on screen that could satisfy it.
+//
+// Nothing caught it. The modal was inline JavaScript inside the dashboardHTML
+// Go raw string, and no test named a single one of its symbols — so neither the
+// compiler, `go vet`, nor any handler test could see it. The modal has since
+// been removed (the wizard is the single supported request path), but the gap
+// that hid it is generic: the next inline-JS caller of a tightened endpoint
+// would be just as invisible.
+//
+// A behavioural test cannot close that gap. There is no Go call graph reaching
+// this code — the callers are string literals compiled into a Go constant and a
+// file in an embedded FS. Executing them would mean a headless browser and a
+// logged-in session, which is far outside a unit test and would not have run in
+// CI on the PR that broke it. Grepping the JS is what actually observes the
+// thing that broke: whether every in-tree fetch() to this endpoint sends the
+// fields the handler now demands.
+
+// requestProvisionPath is the endpoint whose in-tree callers this file audits.
+const requestProvisionPath = "/api/saas/request-provision"
+
+// requestProvisionRequiredJSONKeys are the JSON keys handleRequestProvision
+// rejects a request for omitting. Keep in step with the validation in
+// handleRequestProvision: adding a required field there without adding it here
+// means the next caller can silently regress exactly as the dashboard modal
+// did.
+//
+// full_name is checked with an explicit `body.FullName == ""` guard; org,
+// github_host and repos are each validated above it. acmm_level is NOT listed:
+// it is clamped rather than rejected, so omitting it is legal.
+var requestProvisionRequiredJSONKeys = []string{"org", "github_host", "repos", "full_name"}
+
+// jsBodyWindow is how many bytes after a fetch() call site we scan for the
+// request body. The body is built inline in the same call expression in every
+// caller here; this window comfortably spans the longest of them while stopping
+// well short of the following function, so an unrelated later fetch() cannot
+// lend its keys to this one.
+const jsBodyWindow = 900
+
+// inTreeJSSource is a JavaScript-bearing source file audited by this test.
+type inTreeJSSource struct {
+	name string
+	body string
+}
+
+// collectInTreeJSSources returns every in-tree source that can originate a
+// browser request to the hub API: the dashboard's embedded JS and the static
+// files under static/ (which includes the get-started wizard).
+//
+// Both halves matter. The dashboard raw string is where the missed caller
+// lived, and static/ is where the surviving one lives. Reading the wizard from
+// staticFS rather than from disk means this asserts against the bytes actually
+// shipped in the binary.
+func collectInTreeJSSources(t *testing.T) []inTreeJSSource {
+	t.Helper()
+
+	srcs := []inTreeJSSource{{name: "pkg/hub/saas.go:dashboardHTML", body: dashboardHTML}}
+
+	entries, err := staticFS.ReadDir("static")
+	if err != nil {
+		t.Fatalf("read embedded static dir: %v", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".html") && !strings.HasSuffix(name, ".js") {
+			continue
+		}
+		b, err := staticFS.ReadFile("static/" + name)
+		if err != nil {
+			t.Fatalf("read embedded static/%s: %v", name, err)
+		}
+		srcs = append(srcs, inTreeJSSource{name: "pkg/hub/static/" + name, body: string(b)})
+	}
+
+	// A guard on the guard: if the embed ever stops delivering files, every
+	// scan below would vacuously pass. Require the wizard specifically, since
+	// it is the caller we expect to find.
+	var sawWizard bool
+	for _, s := range srcs {
+		if strings.HasSuffix(s.name, "get-started.html") {
+			sawWizard = true
+		}
+	}
+	if !sawWizard {
+		t.Fatal("get-started.html not found in embedded static FS — the audit below would scan nothing")
+	}
+	return srcs
+}
+
+// TestRequestProvisionInTreeCallersSendRequiredFields is the regression test
+// for the dashboard-modal breakage: it fails if any in-tree JS caller of
+// request-provision omits a field the handler requires.
+//
+// Had this existed, #2369 would have failed CI — the dashboard modal's body
+// carried no full_name — instead of shipping a dead button to production.
+func TestRequestProvisionInTreeCallersSendRequiredFields(t *testing.T) {
+	fetchRe := regexp.MustCompile(`fetch\(\s*['"` + "`" + `][^'"` + "`" + `]*` + regexp.QuoteMeta(requestProvisionPath))
+
+	var callers int
+	for _, src := range collectInTreeJSSources(t) {
+		for _, loc := range fetchRe.FindAllStringIndex(src.body, -1) {
+			callers++
+			end := loc[1] + jsBodyWindow
+			if end > len(src.body) {
+				end = len(src.body)
+			}
+			window := src.body[loc[1]:end]
+
+			for _, key := range requestProvisionRequiredJSONKeys {
+				// Match the key as a JS object property, the form every caller
+				// uses to build the body (`full_name: name` / `"full_name":`).
+				keyRe := regexp.MustCompile(`['"` + "`" + `]?` + regexp.QuoteMeta(key) + `['"` + "`" + `]?\s*:`)
+				if !keyRe.MatchString(window) {
+					t.Errorf("%s: caller of POST %s does not send required field %q.\n"+
+						"handleRequestProvision rejects requests missing it, so this caller "+
+						"gets a 400 the user cannot fix from the UI.\n"+
+						"Either send the field or, if this caller is being retired, remove it.\n"+
+						"body scanned:\n%s",
+						src.name, requestProvisionPath, key, window)
+				}
+			}
+		}
+	}
+
+	// Without this the test would pass if every caller vanished or the regex
+	// silently stopped matching — the same class of false green as the
+	// `_ = w.Code` assertions this PR also repairs.
+	if callers == 0 {
+		t.Fatalf("found no in-tree JS caller of POST %s; the scan is not matching anything and would never catch a regression", requestProvisionPath)
+	}
+	t.Logf("audited %d in-tree JS caller(s) of POST %s", callers, requestProvisionPath)
+}
+
+// TestRequestProvisionDashboardModalRemoved pins the removal itself.
+//
+// The dashboard's Request-a-Hive modal was deliberately retired so the
+// 3-step get-started wizard is the single supported request path. This asserts
+// none of its symbols creep back into the dashboard: a reintroduced modal would
+// be a second request path, and — being inline JS — invisible to everything
+// except the audit above.
+func TestRequestProvisionDashboardModalRemoved(t *testing.T) {
+	removed := []string{
+		"btn-request-hive",
+		"request-modal",
+		"btn-request-go",
+		"openRequestHiveModal",
+		"submitProvisionRequest",
+		"renderRequestHiveButton",
+		"renderRequestForgeOptions",
+		"requestForgeValue",
+		"syncRequestForgePreview",
+		"renderRequestLevelOptions",
+	}
+	for _, sym := range removed {
+		if strings.Contains(dashboardHTML, sym) {
+			t.Errorf("dashboardHTML still references %q — the Request-a-Hive modal was removed on purpose "+
+				"so the get-started wizard is the only request path; re-adding it reintroduces a second, "+
+				"untested caller of POST %s", sym, requestProvisionPath)
+		}
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -5258,8 +5258,24 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 	//
 	// This does tighten an existing endpoint: a caller that posted no full_name
 	// now gets a 400 where it used to get a 200. That is intended — the whole
-	// point is that the field is reliably present — and the wizard is the only
-	// caller in-tree. Called out in the PR body rather than hidden here.
+	// point is that the field is reliably present.
+	//
+	// The get-started wizard (static/get-started.html) is now the only in-tree
+	// caller, but do not read that as "it always was". When this check landed
+	// (#2369) this comment claimed the wizard was the only caller and it was
+	// simply wrong: the hub dashboard had its own Request-a-Hive modal posting
+	// here, added later than the wizard, reachable by every logged-in user, and
+	// it went un-updated — so the button 400'd with no field on screen that
+	// could satisfy it. The modal has since been removed deliberately (the
+	// wizard is the single supported request path), which is what makes this
+	// sentence true today rather than aspirational.
+	//
+	// The modal was invisible to CI because it was inline JS inside the
+	// dashboardHTML raw string with no test naming any of its symbols. Before
+	// adding another required field here, re-run the caller audit rather than
+	// trusting this comment: TestRequestProvisionInTreeCallersSendRequiredFields
+	// greps the embedded JS and the static wizard for callers of this endpoint
+	// and fails on one that omits a required field.
 	if body.FullName == "" {
 		http.Error(w, `{"error":"your name is required — we use it to know who the request is from"}`, http.StatusBadRequest)
 		return
@@ -7029,7 +7045,6 @@ const dashboardHTML = `<!DOCTYPE html>
       <div style="display:flex;gap:8px;align-items:center">
         <button class="btn-primary" id="btn-send-banner-top" style="display:none;background:#d97706" onclick="_bannerTargetHive=null;document.getElementById('banner-modal').style.display='flex';loadBannerHiveList()">Send Banner</button>
         <button class="btn-primary" id="btn-add-hive" disabled onclick="document.getElementById('create-modal').style.display='flex'">+ Add Hosted Hive</button>
-        <button class="btn-primary" id="btn-request-hive" style="display:none;background:var(--blue)" onclick="openRequestHiveModal()">Request a Hive</button>
       </div>
     </div>
 
@@ -7297,8 +7312,6 @@ const dashboardHTML = `<!DOCTYPE html>
       if (e.key !== 'Escape') return;
       var createModal = document.getElementById('create-modal');
       if (createModal && createModal.style.display === 'flex') { createModal.style.display = 'none'; return; }
-      var requestModal = document.getElementById('request-modal');
-      if (requestModal && requestModal.style.display === 'flex') { requestModal.style.display = 'none'; return; }
       var accessOverlay = document.querySelector('.hive-confirm-overlay');
       if (accessOverlay) { accessOverlay.remove(); return; }
       var timelineModal = document.getElementById('timeline-modal');
@@ -10483,7 +10496,6 @@ const dashboardHTML = `<!DOCTYPE html>
         renderUserAccessBanner();
         renderProvisionRequestBanner(data.my_provision_request || null);
         renderAdminProvisionRequests(data.provision_requests || []);
-        renderRequestHiveButton(data);
         loadPublicHives(data.hives || []);
         loadUsage();
       } catch(e) {
@@ -12088,12 +12100,6 @@ const dashboardHTML = `<!DOCTYPE html>
       } catch(e) {}
     }
 
-    function renderRequestHiveButton(data) {
-      var btn = document.getElementById('btn-request-hive');
-      if (!btn) return;
-      btn.style.display = '';
-    }
-
     function renderProvisionRequestBanner(req) {
       var el = document.getElementById('provision-request-banner');
       if (!el) return;
@@ -12573,208 +12579,6 @@ const dashboardHTML = `<!DOCTYPE html>
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); btn.disabled = false; btn.textContent = 'Deny'; }
     }
 
-    /* REQUEST_FORGE_CUSTOM is the sentinel option value that reveals the
-       free-text forge box. It is not a hostname and is never submitted. */
-    var REQUEST_FORGE_CUSTOM = '__custom__';
-
-    /* normalizeForgeInput mirrors the server's normalizeForgeHost: strip the
-       scheme, drop any pasted path, drop a trailing slash, lowercase. Keeping
-       the two in step means the live preview shows exactly the host the server
-       will store, instead of a spelling that changes on submit. */
-    function normalizeForgeInput(raw) {
-      var h = (raw || '').trim().toLowerCase();
-      h = h.replace(/^https?:\/\//, '');
-      var slash = h.indexOf('/');
-      if (slash >= 0) h = h.slice(0, slash);
-      return h;
-    }
-
-    /* renderRequestForgeOptions fills the Request-a-Hive forge picker from the
-       forges the hub's own clusters actually run on, plus public github.com and
-       an "other" escape hatch.
-
-       Hybrid rather than pure free-text: the listed forges are the ones the hub
-       can actually place a hive on, so the common path is a click that cannot
-       be typo'd, and the list self-documents what is supported. Pure free-text
-       invites "gihub.ibm.com"; a pure select would block a brand-new GHE
-       instance the hub has no cluster for yet, which is a real onboarding case
-       — hence "Other". */
-    function renderRequestForgeOptions() {
-      var sel = document.getElementById('rq-forge');
-      if (!sel) return;
-      var seen = {};
-      var hosts = [];
-      (_clusterList || []).forEach(function(c) {
-        var h = normalizeForgeInput((c && c.github_host) || '');
-        if (!h || seen[h]) return;
-        seen[h] = true;
-        hosts.push(h);
-      });
-      /* Public GitHub is always offered even when no cluster reports it, so the
-         picker is never empty before the cluster list loads. */
-      if (!seen[PUBLIC_GITHUB_HOST]) hosts.unshift(PUBLIC_GITHUB_HOST);
-      hosts.sort();
-      var prev = sel.value;
-      var opts = hosts.map(function(h) {
-        return '<option value="' + esc(h) + '">' + esc(h) + '</option>';
-      });
-      opts.push('<option value="' + esc(REQUEST_FORGE_CUSTOM) + '">Other GitHub Enterprise host&#x2026;</option>');
-      sel.innerHTML = opts.join('');
-      if (prev) sel.value = prev;
-      if (!sel.value) sel.value = PUBLIC_GITHUB_HOST;
-      /* Bind once. renderRequestForgeOptions re-runs whenever the cluster list
-         reloads, and re-adding these listeners each time would fire the
-         preview N times per keystroke. */
-      if (!sel._rqForgeWired) {
-        sel._rqForgeWired = true;
-        sel.addEventListener('change', syncRequestForgePreview);
-        var customEl = document.getElementById('rq-forge-custom');
-        if (customEl) customEl.addEventListener('input', syncRequestForgePreview);
-        var orgEl = document.getElementById('rq-org');
-        if (orgEl) orgEl.addEventListener('input', syncRequestForgePreview);
-      }
-      syncRequestForgePreview();
-    }
-
-    /* requestForgeValue returns the normalized forge host the modal will
-       submit, or '' when "Other" is selected and nothing has been typed. */
-    function requestForgeValue() {
-      var sel = document.getElementById('rq-forge');
-      if (!sel) return '';
-      if (sel.value !== REQUEST_FORGE_CUSTOM) return normalizeForgeInput(sel.value);
-      var custom = document.getElementById('rq-forge-custom');
-      return normalizeForgeInput(custom && custom.value);
-    }
-
-    /* syncRequestForgePreview shows the forge with the org affixed to it —
-       "github.ibm.com/z-innersource" — so the requester sees the exact target
-       they are asking for before they submit, rather than discovering after
-       provisioning that the org was resolved against the wrong GitHub. */
-    function syncRequestForgePreview() {
-      var sel = document.getElementById('rq-forge');
-      var custom = document.getElementById('rq-forge-custom');
-      var out = document.getElementById('rq-target-preview');
-      if (sel && custom) custom.style.display = sel.value === REQUEST_FORGE_CUSTOM ? 'block' : 'none';
-      if (!out) return;
-      var host = requestForgeValue();
-      var orgEl = document.getElementById('rq-org');
-      var org = orgEl ? orgEl.value.trim() : '';
-      /* The org field accepts a pasted URL too; show only its last segment so
-         the preview never renders "github.com/https://github.ibm.com/x". */
-      if (org) {
-        var parts = org.replace(/^https?:\/\//, '').replace(/\/+$/, '').split('/');
-        org = parts[parts.length - 1];
-      }
-      if (!host) {
-        out.textContent = 'Enter the GitHub forge your org lives on.';
-        out.style.color = 'var(--muted)';
-        return;
-      }
-      out.textContent = 'This hive will target ' + host + '/' + (org || '<org>') +
-        (host !== PUBLIC_GITHUB_HOST ? ' — the GitHub App must be installed on that org on ' + host + '.' : '');
-      out.style.color = host !== PUBLIC_GITHUB_HOST ? 'var(--accent, #58a6ff)' : 'var(--muted)';
-    }
-
-    /* REQUEST_DEFAULT_ACMM_LEVEL is where a new hive starts. L3 Measured is the
-       first level that produces useful output (hold-gated PRs that raise test
-       coverage) while still requiring a human on every merge, which is the
-       right default for someone who has not run a hive before. */
-    var REQUEST_DEFAULT_ACMM_LEVEL = 3;
-    /* ACMM levels offered on the request form, lowest to highest. Capped at L3
-       Measured, matching maxRequestACMMLevel on POST /api/saas/request-provision
-       and the get-started wizard: a hive is never REQUESTED above L3. L4-L6 are
-       real levels, reached after provisioning from the hive's own dashboard
-       once coverage and CI history have earned them. This form posts to the
-       same clamped endpoint as the wizard, so offering L4-L6 here would not
-       grant them — it would silently record L1 instead. */
-    var REQUEST_ACMM_LEVELS = [1, 2, 3];
-    /* Restated under the picker so the cap reads as "later", not "denied". */
-    var REQUEST_LEVELS_LATER_NOTE = 'L4 Adaptive, L5 Semi-Automated and L6 Autonomous become available after provisioning, from your hive dashboard.';
-
-    /* renderRequestLevelOptions builds the level picker from ACMM_LABELS and
-       ACMM_TIPS. Rendering rather than hardcoding is the point: the previous
-       hardcoded <option> list had drifted to names that appear nowhere else in
-       the product and described the wrong behaviour. */
-    function renderRequestLevelOptions() {
-      var sel = document.getElementById('rq-level');
-      if (!sel) return;
-      var prev = sel.value;
-      sel.innerHTML = (REQUEST_ACMM_LEVELS || []).map(function(l) {
-        var label = ACMM_LABELS[l] || ('L' + l);
-        var detail = acmmTipDetail(l);
-        /* Label and one-line description live in the option text itself: a
-           <select> shows only the selected option when closed, so a requester
-           browsing the list needs the description inline to compare levels. */
-        return '<option value="' + l + '">' + esc(label) + (detail ? ' &#x2014; ' + esc(detail) : '') + '</option>';
-      }).join('');
-      sel.value = prev || String(REQUEST_DEFAULT_ACMM_LEVEL);
-      if (!sel.value) sel.value = String(REQUEST_DEFAULT_ACMM_LEVEL);
-      if (!sel._rqLevelWired) {
-        sel._rqLevelWired = true;
-        sel.addEventListener('change', syncRequestLevelDesc);
-      }
-      syncRequestLevelDesc();
-    }
-
-    /* syncRequestLevelDesc restates the selected level's description under the
-       picker, so it stays readable once the dropdown is closed. */
-    function syncRequestLevelDesc() {
-      var sel = document.getElementById('rq-level');
-      var out = document.getElementById('rq-level-desc');
-      if (!sel || !out) return;
-      var lvl = parseInt(sel.value, 10) || REQUEST_DEFAULT_ACMM_LEVEL;
-      var tip = ACMM_TIPS[lvl] || '';
-      out.textContent = tip ? (tip + ' ' + REQUEST_LEVELS_LATER_NOTE) : REQUEST_LEVELS_LATER_NOTE;
-    }
-
-    /* openRequestHiveModal shows the modal with a freshly populated forge
-       picker, so a cluster list that loaded after page render is reflected. */
-    function openRequestHiveModal() {
-      renderRequestForgeOptions();
-      syncRequestForgePreview();
-      renderRequestLevelOptions();
-      document.getElementById('request-modal').style.display = 'flex';
-    }
-
-    var _requestInProgress = false;
-    async function submitProvisionRequest() {
-      if (_requestInProgress) return;
-      _requestInProgress = true;
-      var btn = document.getElementById('btn-request-go');
-      btn.disabled = true;
-      btn.textContent = 'Submitting...';
-      var org = document.getElementById('rq-org').value.trim();
-      var repos = document.getElementById('rq-repos').value.trim();
-      var primary = document.getElementById('rq-primary').value.trim();
-      var level = parseInt(document.getElementById('rq-level').value) || 1;
-      var forge = requestForgeValue();
-
-      function abort(msg) {
-        hiveToast(msg, 'error');
-        _requestInProgress = false;
-        btn.disabled = false;
-        btn.textContent = 'Submit Request';
-      }
-
-      if (!org || !repos) { abort('Org and repos are required'); return; }
-      /* The forge is required client-side for a fast, in-context error; the
-         server enforces it independently — this check is UX, not security. */
-      if (!forge) { abort('A GitHub forge is required — pick one or enter the host your org lives on'); return; }
-
-      try {
-        var resp = await fetch('/api/saas/request-provision', {
-          method: 'POST',
-          headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({org: org, github_host: forge, repos: repos, primary_repo: primary || repos.split(',')[0].trim(), acmm_level: level})
-        });
-        var data = await resp.json();
-        if (!resp.ok) { hiveToast(data.error || 'Request failed', 'error'); return; }
-        document.getElementById('request-modal').style.display = 'none';
-        hiveToast('Provision request submitted — awaiting admin approval', 'success');
-        loadHives();
-      } catch(e) { hiveToast('Error: ' + e.message, 'error'); }
-      finally { _requestInProgress = false; btn.disabled = false; btn.textContent = 'Submit Request'; }
-    }
 
     // --- Cluster Health Panel ---
     var CLUSTER_HEALTH_POLL_MS = 30000;
@@ -13012,10 +12816,6 @@ const dashboardHTML = `<!DOCTYPE html>
         if (!resp.ok) return;
         var clusters = await resp.json();
         _clusterList = clusters || [];
-        /* Refresh the Request-a-Hive forge picker: the cluster list usually
-           lands after first render, and the picker's whole value is listing the
-           forges the hub can actually place a hive on. */
-        renderRequestForgeOptions();
         var sel = document.getElementById('f-cluster');
         if (!sel || !clusters || !clusters.length) return;
         sel.innerHTML = clusters.map(function(c) {
@@ -14824,45 +14624,6 @@ const dashboardHTML = `<!DOCTYPE html>
     </div>
   </div>
 
-  <div id="request-modal" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:100;align-items:center;justify-content:center">
-    <div style="background:var(--surface);border:1px solid var(--border);border-radius:12px;max-width:540px;width:90%;max-height:90vh;display:flex;flex-direction:column">
-      <h2 style="font-size:1.3rem;padding:32px 32px 16px;margin:0;color:var(--accent);flex-shrink:0">Request a Hive</h2>
-      <div style="flex:1;overflow-y:auto;padding:0 32px">
-        <p style="font-size:0.8rem;color:var(--muted);margin-bottom:16px">Submit a request for a hosted hive. An admin will review and approve it.</p>
-        <div style="margin-bottom:12px">
-          <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">GitHub Forge *</label>
-          <select id="rq-forge" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem"></select>
-          <input id="rq-forge-custom" type="text" placeholder="github.example.com" style="width:100%;margin-top:6px;display:none;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
-          <div style="font-size:0.72rem;color:var(--muted);margin-top:4px">Which GitHub your org lives on. Required &#x2014; a bare org name does not say whether it is on github.com or a GitHub Enterprise instance.</div>
-        </div>
-        <div style="margin-bottom:12px">
-          <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">GitHub Organization *</label>
-          <input id="rq-org" type="text" placeholder="my-org" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
-          <div id="rq-target-preview" style="font-size:0.75rem;color:var(--muted);margin-top:6px"></div>
-        </div>
-        <div style="margin-bottom:12px">
-          <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">Repositories * <span style="font-size:0.7rem">(comma-separated)</span></label>
-          <input id="rq-repos" type="text" placeholder="repo1, repo2" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
-        </div>
-        <div style="margin-bottom:12px">
-          <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">Primary Repository</label>
-          <input id="rq-primary" type="text" placeholder="defaults to first repo" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
-        </div>
-        <div style="margin-bottom:12px">
-          <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">ACMM Level</label>
-          <!-- Options are rendered by renderRequestLevelOptions() from
-               ACMM_LABELS/ACMM_TIPS so this picker can never drift from the
-               names the rest of the hub shows. Do not hardcode them here. -->
-          <select id="rq-level" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem"></select>
-          <div id="rq-level-desc" style="font-size:0.72rem;color:var(--muted);margin-top:6px"></div>
-        </div>
-      </div>
-      <div style="display:flex;gap:12px;justify-content:flex-end;padding:16px 32px;border-top:1px solid var(--border);flex-shrink:0">
-        <button onclick="document.getElementById('request-modal').style.display='none'" style="padding:8px 20px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--muted);cursor:pointer">Cancel</button>
-        <button id="btn-request-go" onclick="submitProvisionRequest()" class="btn-primary" style="background:var(--blue)">Submit Request</button>
-      </div>
-    </div>
-  </div>
 
   <script>
     var _accessHiveId = '';


### PR DESCRIPTION
## What this is

The hub dashboard had a **second** way to request a hive — a modal posting to `POST /api/saas/request-provision` — alongside the 3-step get-started wizard (Login → Your Repo → Request). This removes it so the wizard is the single supported path.

**This is a deliberate product decision, not dead-code cleanup.** Please do not read this diff later and conclude the modal was unused.

## The modal was live

It rendered for every logged-in user:

- `renderRequestHiveButton(data)` was called **unconditionally** from the main `loadHives()` render path (`saas.go:10486`) — no `_isAdmin` gate, no feature flag.
- Its entire body was `btn.style.display = ''` — it existed solely to *un-hide* the button. The `display:none` in the markup was initial state, not a kill switch.
- The button sat in the ordinary dashboard header `<div>` beside `btn-add-hive`, which all users see.

History rules out "superseded legacy": the wizard first appeared **2026-06-03**; the modal was added **nine days later, 2026-06-12**, in #1528 — *"add provision request workflow and show My Hives for all logged-in users"* — and was never modified, gated, or deprecated since. The modal was the **newer** path, added deliberately for all logged-in users.

## Consequence, stated up front

After this, a logged-in user who wants another hive **leaves the dashboard and goes to the public wizard**. That is the intended behaviour, written down here rather than discovered later.

## Caller audit

Exactly **two** in-tree callers of `POST /api/saas/request-provision` existed; there is now one.

| Caller | Status |
|---|---|
| `static/get-started.html:827` (wizard) | kept — the supported path |
| `saas.go` dashboard modal | **removed** |

Other matches are non-callers: route registration (`saas.go:225`), the ACMM clamp comment, `forge.go:18` prose, and test files. Root-level `dash.js` is a committed `extract.go` artifact of `dashboardHTML` — not a served file and not a separate caller. **Left untouched** (`extract.go` writes to a `/tmp` scratch path, so it is not build-regenerated).

## Removed

`#request-modal` markup, `btn-request-hive`, `openRequestHiveModal`, `submitProvisionRequest`, `renderRequestHiveButton`, the modal-only helpers (`renderRequestForgeOptions`, `requestForgeValue`, `syncRequestForgePreview`, `renderRequestLevelOptions`), constants only they used (`REQUEST_FORGE_CUSTOM`, `normalizeForgeInput`, `REQUEST_ACMM_LEVELS`, `REQUEST_DEFAULT_ACMM_LEVEL`, `REQUEST_LEVELS_LATER_NOTE`), the Escape-key branch for the modal, and the `loadClusters()` call that existed only to refresh the modal's forge picker.

**Retained** because they have other users: `PUBLIC_GITHUB_HOST`, `_clusterList`, `ACMM_LABELS`, `ACMM_TIPS`.

All 22 removed symbols verified at **zero** remaining references.

## The false comment (`saas.go:5261-5262`)

It claimed *"the wizard is the only caller in-tree."* **That was false when written in #2369**, and it is why that PR shipped believing it had updated every caller — the dashboard modal began returning `400 "your name is required"` with no field on screen that could satisfy it. The path was completely blocked.

The comment now explains *why* the wizard is the only caller (because the modal was deliberately retired), records that the original claim was wrong, and points at the regression test instead of asking the next reader to trust prose.

## Regression test — the important part

The modal had **zero test coverage**: no test named a single one of its symbols. It was inline JS inside the `dashboardHTML` Go raw string, so the compiler, `go vet`, and every handler test were all blind to it. That is exactly why CI could not catch #2369.

`TestRequestProvisionInTreeCallersSendRequiredFields` greps the embedded dashboard JS **and** the embedded static wizard (read from `staticFS`, i.e. the bytes actually shipped) for `fetch()` calls to the endpoint, and fails on any caller omitting a required field.

**Why static analysis rather than a behavioural test:** there is no Go call graph reaching this code — the callers are string literals compiled into a Go constant and a file in an embedded FS. Executing them needs a headless browser and a logged-in session, which would not have run in CI on the PR that broke it. Grepping the JS observes the thing that actually broke. The test also fails if it finds *zero* callers, so it cannot silently stop matching.

`TestRequestProvisionDashboardModalRemoved` pins the removal, so a reintroduced modal is caught as a second untested caller.

### Mutation-verified

| Mutation | Result |
|---|---|
| Strip `full_name` from the wizard body (the exact #2369 bug) | **FAILS** with the offending body |
| Re-add a modal-style caller with no `full_name` | **FAILS both** tests — names the missing field and the resurrected symbol |
| Revert the ACMM fixtures to their `_ = w.Code` state | **FAILS**, surfacing the real 400 |

## Secondary: `hub_coverage_deep_test.go:626` / `:643`

Both omitted `full_name` (and `github_host`) and discarded the status with `_ = w.Code`. After #2369 they passed while silently exercising the new 400 branch instead of the ACMM clamp they were written to cover — green while testing nothing. They now carry the required fields and assert the clamp was reached.

## Verification

- `node --check` on the extracted JS: **OK** (base and current)
- Brace/paren delta base→current: `{` −28, `}` −28, `(` −132, `)` −132 — symmetric; balance unchanged (brace 0, paren −1 in both, a pre-existing literal)
- Extraction still yields 4 script blocks; grep confirms removed symbols absent and the wizard caller intact
- Backticks inside `dashboardHTML`: **0**
- `gofmt` clean, `go build ./...` OK, `go vet` OK, full `pkg/hub` suite green