### PR TITLE
🐛 fix(backup): capture the PVC overlay, not just the post-merge snapshot

### DIFF
--- a/docs/HUB_DISASTER_RECOVERY.md
+++ b/docs/HUB_DISASTER_RECOVERY.md
@@ -34,20 +34,76 @@ undecryptable ciphertext and every user must re-authorize via OAuth.** No
 restore procedure recovers it. This backup is the only thing standing between
 you and that outcome.
 
-### 3. The authoritative spoke config is `hive.yaml.bak` — NOT `hive.yaml`
+### 3. The authoritative spoke config is the PVC overlay — usually NOT `hive.yaml.bak`
 
-Each spoke's running config is **`/data/hive.yaml.bak`** on its own PVC. The
-ConfigMap is only a fallback seed read at startup. The spoke's `copy-config`
-init container does:
+> **Corrected.** This section previously stated that `copy-config` restores from
+> `/data/hive.yaml.bak`, and that restoring that file is what brings a spoke
+> back. **That is true on only 3 of 51 live hives.** Following it on the other
+> 48 produces a differently-configured spoke with no error — the worst kind of
+> DR bug, because it fails only when you are already in an emergency.
+
+The fleet runs **two different `copy-config` variants**, baked into each
+spoke's Deployment at provision time and never migrated.
+
+| Variant | Init-container behaviour | Hives |
+|---|---|---|
+| **A/B — `.bak` wins** | restores `/data/hive.yaml.bak` over the seed | **3**: `kubestellar-console`, `projectbluefin-knuckle`, `aslom-hive-agent` |
+| **C — seed wins** | copies the ConfigMap seed; merely *echoes* whether `.bak` exists | **48**: everything else (15 on hive-oke, 33 on vllm-d) |
+
+Variant C, which is what new hives get:
 
 ```sh
-if [ -f /data/hive.yaml.bak ]; then cp /data/hive.yaml.bak /etc/hive/hive.yaml
-else cp /etc/hive-seed/hive.yaml /etc/hive/hive.yaml; fi
+cp /etc/hive-seed/hive.yaml /etc/hive/hive.yaml && echo configmap-copied
+if [ -f /data/hive.yaml.bak ]; then echo backup-exists-for-recovery; fi
 ```
 
-**A restore that omits `hive.yaml.bak` silently falls back to the stale
-ConfigMap seed with no error**, losing every customization the user made. There
-is no warning — the spoke just comes up wrong. Always restore `hive.yaml.bak`.
+Note it only *reports* `.bak`. It never restores from it.
+
+**How to tell which variant a hive runs** — this is the only way to know:
+
+```sh
+kubectl -n hive-hosted-<id> get deploy -o jsonpath\
+='{.items[*].spec.template.spec.initContainers[?(@.name=="copy-config")].command}'
+```
+
+#### What actually holds the running config
+
+On **every** hive, the config in effect is dominated by the PVC overlay
+`/data/hive.yaml.dashboard`, which the entrypoint merges over the seed at boot.
+The ConfigMap seed is 4–11% of the running config on sampled hives and omits
+whole top-level blocks (`policies`, `data`, `knowledge`, `notifications`,
+`hive_id`).
+
+**So the file to restore is `/data/hive.yaml.dashboard`.** It is the only
+writable layer and the one that wins. See `v2/docs/config-layering.md` for the
+full precedence order, and `GET /api/config/provenance` on a running spoke to
+ask which layer set any given field.
+
+#### `hive.yaml.bak` is a snapshot, not a restore source
+
+The name misleads. `.bak` is written by the entrypoint **after** the merge
+(`v2/deploy/entrypoint.sh:150`) — it is a snapshot of the *result*, not an
+input. On variant-C hives nothing reads it during a normal boot.
+
+It has exactly one non-redundant role: the **disaster fallback** at
+`entrypoint.sh:152-161`, which restores from `.bak` when the ConfigMap is
+missing or empty. That is a genuinely different scenario from the overlay path,
+which is why the file is still worth capturing.
+
+`.bak` and the overlay are **near-copies but not interchangeable**. The overlay
+is written secret-free on purpose (`dashboardOverlayBytes` collapses
+`HIVE_GITHUB_TOKEN` back to `${HIVE_GITHUB_TOKEN}` and blanks a
+pod-env-derived `dashboard.auth_token`), while `.bak` is a verbatim copy of the
+merged config **including** those secrets. Observed live on
+`projectbluefin-knuckle`:
+
+```
+/data/hive.yaml.bak        14609 B   auth_token: 55c076f9…
+/data/hive.yaml.dashboard  14547 B   auth_token: ""
+```
+
+On a hive with no such env vars set the two files are byte-identical — but that
+is incidental, not structural. **Capture both.**
 
 ### 4. A PVC-only backup is NOT restorable
 
@@ -81,7 +137,7 @@ the first three is missing.
 | `/data/saas/**` | users, hives, keys, timeline, provisioning state |
 | `/data/hub-registry.json` | the 50-hive fleet registry |
 | 4 Kubernetes Secrets | credentials outside the PVC |
-| per-spoke `hive.yaml.bak`, `gh-app-key*.pem`, `hive-id` | rebuild each spoke |
+| per-spoke `hive.yaml.dashboard`, `hive.yaml.bak`, `gh-app-key*.pem`, `hive-id` | rebuild each spoke |
 
 **Deliberately excluded** as regenerable agent scratch: `nous/`, `home/`,
 `beads/`, `logs/`. These are ~110MB of the hub's ~125MB and ~796MB per spoke.
@@ -231,8 +287,10 @@ NS=hive-hosted-$HIVE
 POD=$(kubectl get pods -n $NS --field-selector=status.phase=Running \
         -o jsonpath='{.items[0].metadata.name}')
 
-# hive.yaml.bak is authoritative — without it the spoke silently uses the
-# stale ConfigMap seed.
+# Restore BOTH config files. The overlay is what wins on a normal boot
+# (all 51 hives); .bak is what the disaster fallback reads when the
+# ConfigMap is missing/empty, and what variant-A/B hives boot from.
+kubectl cp restore/spokes/$HIVE/hive.yaml.dashboard $NS/$POD:/data/hive.yaml.dashboard -c hive
 kubectl cp restore/spokes/$HIVE/hive.yaml.bak $NS/$POD:/data/hive.yaml.bak -c hive
 kubectl cp restore/spokes/$HIVE/hive-id       $NS/$POD:/data/hive-id       -c hive
 for k in restore/spokes/$HIVE/gh-app-key*.pem; do
@@ -242,10 +300,26 @@ done
 kubectl rollout restart deploy/hive -n $NS
 ```
 
-Confirm the spoke used the restored config, not the seed:
+Confirm the spoke used the restored config. **Which log line to expect depends
+on the variant** (see §3):
 
 ```bash
-kubectl logs -n $NS -c copy-config $POD    # expect "override-used", not "seed-copied"
+kubectl logs -n $NS -c copy-config $POD
+#   variant A/B  -> "override-used"     (.bak restored)
+#   variant C    -> "configmap-copied"  (seed copied; .bak NOT read)
+
+# On variant C the overlay is what matters, and the merge happens in the
+# main container, not copy-config:
+kubectl logs -n $NS -c hive $POD | grep '\[entrypoint\]'
+#   expect: "dashboard overlay merged over ConfigMap seed"
+#   NOT:    "dashboard overlay invalid, using ConfigMap seed as-is"
+```
+
+The best confirmation is to ask the spoke directly:
+
+```bash
+kubectl -n $NS exec $POD -c hive -- \
+  curl -s localhost:3002/api/config/provenance | jq '.overlay_rejected, .fields'
 ```
 
 ### Step 6 — Re-link GitHub
@@ -264,7 +338,7 @@ Manual, and unavoidable:
 - [ ] users can log in without re-authorizing (proves `hmac.key` restored)
 - [ ] hive count and vanity URLs unchanged
 - [ ] spokes appear online and heartbeat to the hub
-- [ ] `copy-config` logged `override-used` on each spoke
+- [ ] `copy-config` logged the expected line for the spoke's variant (`override-used` on A/B, `configmap-copied` on C), and the hive container logged "dashboard overlay merged over ConfigMap seed"
 - [ ] a fresh `hive-backup run` succeeds against the rebuilt hub
 
 ---
@@ -290,7 +364,7 @@ writes confined to a throwaway namespace that was deleted afterwards):
 - Wrong key and bit-flips are rejected (GCM auth tag)
 - Restored `hmac.key` byte-identical to production
 - **All 88 restored user tokens decrypt successfully**
-- Restored `hive.yaml.bak` byte-identical to the live spoke
+- Restored `hive.yaml.dashboard` and `hive.yaml.bak` byte-identical to the live spoke
 - Secrets restored into a throwaway namespace matched live values
 - Hub PVC data restored into a live pod: 88 users, 50 hives
 
@@ -331,7 +405,8 @@ they had already found, claimed, deferred or closed. This backup preserves that.
 
 | Path | Why |
 |---|---|
-| `hive.yaml.bak` | The **authoritative** spoke config (see below) |
+| `hive.yaml.dashboard` | The **overlay** — the layer that wins the boot merge (see below) |
+| `hive.yaml.bak` | Post-merge snapshot; disaster fallback + variant-A/B boot source |
 | `hive-id` | Hive identity as known to the hub |
 | `hive-state.json` | Agent runtime state |
 | `gh-app-key*.pem` | GitHub App private keys — **credentials** |
@@ -358,15 +433,25 @@ Bead directories are **discovered, not hardcoded**. A production spoke had ten
 production spoke (beads 2.6MB dominating), versus ~796MB for the whole PVC.
 Small enough to stream to a browser and stay responsive.
 
-## `hive.yaml.bak`, not `hive.yaml`
+## Capture the overlay and `.bak`, not `hive.yaml`
 
-The same trap as the hub backup, and worth repeating because it is silent. The
-`copy-config` init container restores from `hive.yaml.bak` and falls back to the
-stale ConfigMap seed only when it is absent. On a sampled production spoke the
-two files had **different content and different timestamps** — `hive.yaml` was a
-root-owned copy days older than the live, user-customised `hive.yaml.bak`.
-Backing up the wrong one produces no error at backup time and no symptom until a
-restore quietly reverts the owner's settings. A test locks this in.
+The same trap as the hub backup, and worth repeating because it is silent.
+
+`/etc/hive/hive.yaml` is **not** the file to back up. On a sampled production
+spoke it was a root-owned copy days older than the live config. It is
+regenerated from the seed plus the overlay on every boot.
+
+The two files worth capturing are:
+
+| File | Why |
+|---|---|
+| `/data/hive.yaml.dashboard` | The **overlay** — the only writable layer, and the one that wins the boot-time merge on all 51 hives. This is the real running config. |
+| `/data/hive.yaml.bak` | The post-merge snapshot. Read by the disaster fallback when the ConfigMap is missing/empty, and by variant-A/B hives on every boot. Also the only copy that retains env-derived secrets. |
+
+They are near-copies but **not interchangeable** — the overlay is deliberately
+secret-free. Backing up the wrong one produces no error at backup time and no
+symptom until a restore quietly reverts the owner's settings. Tests lock this
+in.
 
 ## Encryption is mandatory
 
@@ -407,7 +492,7 @@ hive-backup extract --archive hive-spoke-backup-<id>-<ts>.tar.gz.enc --dest ./re
 
 # Layout:
 #   ./restore/MANIFEST.json
-#   ./restore/spoke/{hive.yaml.bak,hive-id,hive-state.json,gh-app-key*.pem}
+#   ./restore/spoke/{hive.yaml.dashboard,hive.yaml.bak,hive-id,hive-state.json,gh-app-key*.pem}
 #   ./restore/beads/<agent>/**
 
 # 1. Identify the target spoke pod.
@@ -427,7 +512,9 @@ kubectl -n $NS scale deploy/hive --replicas=1
 POD=$(kubectl -n $NS get pods --field-selector=status.phase=Running \
         -o jsonpath='{.items[0].metadata.name}')
 
-# 3. Config FIRST — .bak is what copy-config actually restores from.
+# 3. Config FIRST. Restore BOTH: the overlay is what wins the boot merge on
+#    every hive; .bak covers the disaster fallback and variant-A/B hives.
+kubectl -n $NS cp ./restore/spoke/hive.yaml.dashboard $POD:/data/hive.yaml.dashboard -c hive
 kubectl -n $NS cp ./restore/spoke/hive.yaml.bak   $POD:/data/hive.yaml.bak -c hive
 kubectl -n $NS cp ./restore/spoke/hive-id         $POD:/data/hive-id       -c hive
 kubectl -n $NS cp ./restore/spoke/hive-state.json $POD:/data/hive-state.json -c hive
@@ -445,7 +532,7 @@ for d in ./restore/beads/*/; do
   kubectl -n $NS cp "$d" $POD:/data/beads/$agent -c hive
 done
 
-# 6. Restart so copy-config picks up hive.yaml.bak.
+# 6. Restart so the boot-time merge picks up the restored config.
 kubectl -n $NS rollout restart deploy/hive
 kubectl -n $NS rollout status  deploy/hive --timeout=300s
 ```
@@ -464,7 +551,7 @@ ownership to match the surrounding directories rather than loosening the mode.
 
 **Verified:**
 
-- Unit tests cover: `hive.yaml.bak` captured and `hive.yaml` excluded; beads
+- Unit tests cover: `hive.yaml.dashboard` and `hive.yaml.bak` captured and `hive.yaml` excluded; beads
   captured for every discovered agent; `nous`/`logs`/`home`/`audit.jsonl`/
   `dashboard-sessions.json` excluded; App keys captured; sealed archive is
   opaque ciphertext with no plaintext key/config leakage; wrong key and

--- a/v2/pkg/hubbackup/collect.go
+++ b/v2/pkg/hubbackup/collect.go
@@ -36,16 +36,42 @@ const (
 // Spoke files captured. This set is the minimum required to rebuild a working
 // spoke; everything else on a spoke PVC is regenerable agent scratch.
 //
-// hive.yaml.bak is THE authoritative running config. The spoke's copy-config
-// init container does:
+// TWO config files are captured, because neither alone restores a spoke.
 //
-//	if [ -f /data/hive.yaml.bak ]; then cp /data/hive.yaml.bak /etc/hive/hive.yaml
-//	else cp /etc/hive-seed/hive.yaml /etc/hive/hive.yaml; fi
+// hive.yaml.dashboard is the PVC OVERLAY, and it is what the boot-time merge
+// applies over the ConfigMap seed on every hive. It dominates the resulting
+// config: sampled seeds are 4–11% of the running config and omit whole
+// top-level blocks (policies, data, knowledge, notifications, hive_id). This
+// is the file that actually carries a hive's configuration.
 //
-// so a restore that omits hive.yaml.bak silently falls back to the stale
-// ConfigMap seed with NO error, losing every user customization. The plain
-// /data/hive.yaml is NOT authoritative and is not what must be restored.
+// hive.yaml.bak is a POST-MERGE SNAPSHOT written by the entrypoint after the
+// merge (deploy/entrypoint.sh:150) — not an input on most hives. It is read in
+// two cases: the disaster fallback when the ConfigMap is missing or empty
+// (entrypoint.sh:152-161), and on every boot by the minority of spokes running
+// the older ".bak wins" copy-config variant.
+//
+// A PREVIOUS VERSION OF THIS COMMENT ASSERTED that copy-config always restores
+// from .bak and falls back to the seed. That is true on only 3 of 51 live
+// hives. The variant new hives get merely REPORTS whether .bak exists:
+//
+//	cp /etc/hive-seed/hive.yaml /etc/hive/hive.yaml && echo configmap-copied
+//	if [ -f /data/hive.yaml.bak ]; then echo backup-exists-for-recovery; fi
+//
+// Capturing only .bak was therefore capturing the snapshot while omitting the
+// file that wins the merge — a restore would produce a differently-configured
+// spoke with no error at backup time and no symptom until the owner noticed
+// their settings had reverted.
+//
+// The two files are near-copies but NOT interchangeable: the overlay is
+// written secret-free on purpose (config.dashboardOverlayBytes collapses
+// HIVE_GITHUB_TOKEN back to ${HIVE_GITHUB_TOKEN} and blanks a pod-env-derived
+// dashboard.auth_token), while .bak retains those values. Observed live on one
+// spoke: .bak 14609 B with a real auth_token, overlay 14547 B with "".
+//
+// The plain /data/hive.yaml is NOT authoritative — it is regenerated from seed
+// + overlay on every boot — and is deliberately excluded.
 var spokeFiles = []string{
+	"hive.yaml.dashboard",
 	"hive.yaml.bak",
 	"hive-id",
 }
@@ -267,15 +293,33 @@ func (k KubectlSpokeCollector) collectOne(target ClusterTarget, id string, logge
 	}
 	sc.Files = files
 
-	// hive.yaml.bak is the authoritative config; without it the spoke cannot
-	// be faithfully rebuilt, so surface that as an explicit error.
-	if _, ok := sc.Files["hive.yaml.bak"]; !ok {
-		sc.Err = "hive.yaml.bak absent — spoke config not recoverable from this backup"
+	if reason := spokeConfigUnrecoverable(sc.Files); reason != "" {
+		sc.Err = reason
 		logger.Warn("backup: spoke missing authoritative config", "hive", id)
 		return sc
 	}
 	logger.Info("backup: captured spoke", "hive", id, "files", len(sc.Files))
 	return sc
+}
+
+// spokeConfigUnrecoverable returns why a captured spoke cannot be rebuilt from
+// its config files, or "" if it can.
+//
+// EITHER config file is sufficient. The overlay carries the configuration that
+// wins the boot merge; .bak is a post-merge snapshot of the same config that
+// additionally serves the disaster fallback. Missing both means the spoke
+// cannot be faithfully rebuilt.
+//
+// This deliberately does not require the overlay specifically: a spoke that has
+// never had a dashboard save legitimately has no overlay yet, and failing its
+// backup would be a false alarm.
+func spokeConfigUnrecoverable(files map[string][]byte) string {
+	_, haveOverlay := files["hive.yaml.dashboard"]
+	_, haveBak := files["hive.yaml.bak"]
+	if !haveOverlay && !haveBak {
+		return "hive.yaml.dashboard and hive.yaml.bak both absent — spoke config not recoverable from this backup"
+	}
+	return ""
 }
 
 // spokeStreamDelim separates the filename marker from its base64 payload.

--- a/v2/pkg/hubbackup/spoke_config_files_test.go
+++ b/v2/pkg/hubbackup/spoke_config_files_test.go
@@ -1,0 +1,80 @@
+package hubbackup
+
+import (
+	"strings"
+	"testing"
+)
+
+// The hub-side spoke capture must take BOTH config files.
+//
+// hive.yaml.dashboard is the PVC overlay and wins the boot-time merge, so it
+// carries the hive's real configuration. hive.yaml.bak is the post-merge
+// snapshot, read by the disaster fallback and by the minority of spokes still
+// running the ".bak wins" copy-config variant.
+//
+// Capturing only .bak — the previous behaviour — meant archiving the snapshot
+// while omitting the file that wins, producing a restore that silently differs
+// from the original.
+
+// TestSpokeFilesIncludesOverlay pins the overlay into the captured set.
+func TestSpokeFilesIncludesOverlay(t *testing.T) {
+	var haveOverlay, haveBak bool
+	for _, f := range spokeFiles {
+		switch f {
+		case "hive.yaml.dashboard":
+			haveOverlay = true
+		case "hive.yaml.bak":
+			haveBak = true
+		}
+	}
+	if !haveOverlay {
+		t.Error("spokeFiles omits hive.yaml.dashboard — the overlay wins the boot " +
+			"merge, so a restore without it reverts the owner's configuration")
+	}
+	if !haveBak {
+		t.Error("spokeFiles omits hive.yaml.bak — it is the disaster-fallback source")
+	}
+}
+
+// TestSpokeFilesExcludesPlainHiveYaml: the PVC's hive.yaml is regenerated from
+// seed + overlay on every boot and was observed stale on a live spoke.
+func TestSpokeFilesExcludesPlainHiveYaml(t *testing.T) {
+	for _, f := range spokeFiles {
+		if f == "hive.yaml" {
+			t.Fatal("spokeFiles includes hive.yaml, which is regenerated every boot " +
+				"and was observed stale on a live spoke")
+		}
+	}
+}
+
+// TestSpokeRecoverableWithOverlayOnly: a spoke whose capture yielded the
+// overlay but no .bak is still restorable, so it must not be flagged as
+// unrecoverable. Requiring .bak specifically would fail backups for no reason.
+func TestSpokeRecoverableWithOverlayOnly(t *testing.T) {
+	files := map[string][]byte{"hive.yaml.dashboard": []byte("project:\n  org: acme\n")}
+	if reason := spokeConfigUnrecoverable(files); reason != "" {
+		t.Errorf("spoke with an overlay was marked unrecoverable: %q", reason)
+	}
+}
+
+// TestSpokeRecoverableWithBakOnly: the converse. A spoke that has never had a
+// dashboard save legitimately has no overlay yet, and its .bak is sufficient.
+func TestSpokeRecoverableWithBakOnly(t *testing.T) {
+	files := map[string][]byte{"hive.yaml.bak": []byte("project:\n  org: acme\n")}
+	if reason := spokeConfigUnrecoverable(files); reason != "" {
+		t.Errorf("spoke with a .bak was marked unrecoverable: %q", reason)
+	}
+}
+
+// TestSpokeUnrecoverableWithNeitherConfig: missing both is a genuine failure
+// and must still be surfaced, or an unrestorable archive reports success.
+func TestSpokeUnrecoverableWithNeitherConfig(t *testing.T) {
+	files := map[string][]byte{"hive-id": []byte("hosted-x")}
+	reason := spokeConfigUnrecoverable(files)
+	if reason == "" {
+		t.Fatal("a spoke with neither config file was not flagged as unrecoverable")
+	}
+	if !strings.Contains(reason, "hive.yaml.dashboard") || !strings.Contains(reason, "hive.yaml.bak") {
+		t.Errorf("error should name both missing files, got %q", reason)
+	}
+}

--- a/v2/pkg/spokebackup/backup.go
+++ b/v2/pkg/spokebackup/backup.go
@@ -57,16 +57,30 @@ const (
 	// agent roster rather than being a fixed set of five.
 	beadsSubdir = "beads"
 
-	// configBackupFile is the AUTHORITATIVE spoke config.
+	// configOverlayFile is the PVC overlay — the layer that wins the boot-time
+	// merge over the ConfigMap seed, and therefore the file that actually
+	// carries a hive's configuration. Sampled seeds are 4–11% of the running
+	// config and omit whole top-level blocks (policies, data, knowledge,
+	// notifications, hive_id).
+	configOverlayFile = "hive.yaml.dashboard"
+
+	// configBackupFile is the POST-MERGE SNAPSHOT, written by the entrypoint
+	// after the merge (deploy/entrypoint.sh:150).
 	//
-	// It is hive.yaml.bak, NOT hive.yaml. The copy-config init container
-	// restores from .bak and falls back to the ConfigMap seed only when .bak is
-	// absent, so .bak is what actually comes back after a restart. On a sampled
-	// production spoke the two files had DIFFERENT content and different
-	// timestamps — hive.yaml was a stale root-owned copy while hive.yaml.bak
-	// carried the live user customizations. Backing up hive.yaml instead would
-	// silently capture the wrong config with no error at backup time and no
-	// symptom until a restore quietly reverted the owner's settings.
+	// An earlier comment here stated that copy-config restores from .bak and
+	// falls back to the seed only when .bak is absent. That is true on only 3
+	// of 51 live hives; the variant new hives get merely reports whether .bak
+	// exists and never restores from it. So .bak is not, in general, "what
+	// comes back after a restart" — the overlay is.
+	//
+	// It is still captured, for two reasons: it is what the disaster fallback
+	// reads when the ConfigMap is missing or empty (entrypoint.sh:152-161),
+	// and it is the only copy retaining env-derived secrets, since the overlay
+	// is written secret-free on purpose (config.dashboardOverlayBytes).
+	//
+	// hive.yaml itself remains excluded: it is regenerated from seed + overlay
+	// on every boot, and on a sampled production spoke was a stale root-owned
+	// copy days older than the live config.
 	configBackupFile = "hive.yaml.bak"
 
 	// hiveIDFile identifies this hive to the hub.
@@ -132,8 +146,10 @@ const BuildTimeout = 2 * time.Minute
 //   - dashboard-sessions.json  live browser session tokens. Excluded on
 //     purpose: these are credentials with no restore value, and restoring
 //     them would resurrect sessions that should have expired.
-//   - hive.yaml  the stale ConfigMap-seeded copy; see configBackupFile.
+//   - hive.yaml  regenerated from seed + overlay on every boot; see
+//     configOverlayFile and configBackupFile.
 var includedRootFiles = []string{
+	configOverlayFile,
 	configBackupFile,
 	hiveIDFile,
 	stateFile,

--- a/v2/pkg/spokebackup/backup_coverage_test.go
+++ b/v2/pkg/spokebackup/backup_coverage_test.go
@@ -352,12 +352,24 @@ func TestBuildArchiveExtractsThroughSharedPath(t *testing.T) {
 		t.Fatalf("Extract: %v", err)
 	}
 
-	got, err := os.ReadFile(filepath.Join(dest, spokePrefix, configBackupFile))
+	// Both config files must survive the round trip: the overlay because it
+	// wins the boot merge, .bak because it serves the disaster fallback and
+	// the variant-A/B hives. The fixture gives them a shared marker plus a
+	// distinguishing line, so this asserts the owner's config came back AND
+	// that the two files were not conflated.
+	gotBak, err := os.ReadFile(filepath.Join(dest, spokePrefix, configBackupFile))
 	if err != nil {
-		t.Fatalf("authoritative config missing from the restore: %v", err)
+		t.Fatalf("post-merge snapshot missing from the restore: %v", err)
 	}
-	if string(got) != "live: owner-customised\n" {
-		t.Fatalf("restored the WRONG config: %q", got)
+	if !strings.Contains(string(gotBak), "owner-customised") {
+		t.Fatalf("restored the WRONG config for %s: %q", configBackupFile, gotBak)
+	}
+	gotOverlay, err := os.ReadFile(filepath.Join(dest, spokePrefix, configOverlayFile))
+	if err != nil {
+		t.Fatalf("overlay missing from the restore: %v", err)
+	}
+	if !strings.Contains(string(gotOverlay), "owner-customised") {
+		t.Fatalf("restored the WRONG config for %s: %q", configOverlayFile, gotOverlay)
 	}
 	// The stale hive.yaml must not be present at all.
 	if _, err := os.Stat(filepath.Join(dest, spokePrefix, "hive.yaml")); err == nil {

--- a/v2/pkg/spokebackup/backup_test.go
+++ b/v2/pkg/spokebackup/backup_test.go
@@ -32,10 +32,14 @@ func seedSpoke(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 
-	// hive.yaml and hive.yaml.bak deliberately DIFFER, as they did on the
-	// sampled production spoke.
+	// The three config files deliberately DIFFER, as they do on a live spoke:
+	// hive.yaml is regenerated each boot, the overlay wins the boot merge and
+	// is written secret-free, and .bak is the post-merge snapshot that retains
+	// env-derived secrets. Distinct content is what proves which file the
+	// archive captured.
 	mustWrite(t, filepath.Join(dir, "hive.yaml"), "stale: configmap-seed\n")
-	mustWrite(t, filepath.Join(dir, "hive.yaml.bak"), "live: owner-customised\n")
+	mustWrite(t, filepath.Join(dir, "hive.yaml.dashboard"), "live: owner-customised\noverlay: wins-the-merge\n")
+	mustWrite(t, filepath.Join(dir, "hive.yaml.bak"), "live: owner-customised\nbak: post-merge-snapshot\n")
 	mustWrite(t, filepath.Join(dir, "hive-id"), "hive-abc123")
 	mustWrite(t, filepath.Join(dir, "hive-state.json"), `{"agents":[]}`)
 	mustWrite(t, filepath.Join(dir, "gh-app-key.pem"), "-----BEGIN PRIVATE KEY-----\nAAA\n")

--- a/v2/pkg/spokebackup/overlay_capture_test.go
+++ b/v2/pkg/spokebackup/overlay_capture_test.go
@@ -1,0 +1,75 @@
+package spokebackup
+
+import (
+	"strings"
+	"testing"
+)
+
+// The overlay (/data/hive.yaml.dashboard) is the layer that wins the boot-time
+// merge, so a backup omitting it captures a post-merge snapshot while missing
+// the file that actually carries the hive's configuration. A restore from such
+// an archive produces a differently-configured spoke, with no error at backup
+// time and no symptom until the owner notices their settings reverted.
+//
+// Pre-existing tests cover .bak. These cover the overlay, and the relationship
+// between the two.
+
+// TestOverlayIsCaptured is the regression. Before this change, spokeFiles and
+// includedRootFiles listed only hive.yaml.bak.
+func TestOverlayIsCaptured(t *testing.T) {
+	files, _, _ := buildTestBackup(t)
+
+	got, ok := files["spoke/hive.yaml.dashboard"]
+	if !ok {
+		t.Fatal("hive.yaml.dashboard missing from archive — the overlay wins the " +
+			"boot merge, so omitting it makes the backup unrestorable")
+	}
+	if !strings.Contains(got, "wins-the-merge") {
+		t.Errorf("overlay content wrong: %q", got)
+	}
+}
+
+// TestBakStillCapturedAlongsideOverlay guards the other direction: .bak serves
+// the disaster fallback (ConfigMap missing/empty) and is the boot source on
+// the variant-A/B hives, so adding the overlay must not displace it.
+func TestBakStillCapturedAlongsideOverlay(t *testing.T) {
+	files, _, _ := buildTestBackup(t)
+
+	bak, ok := files["spoke/hive.yaml.bak"]
+	if !ok {
+		t.Fatal("hive.yaml.bak missing from archive — it is the disaster-fallback " +
+			"source and the boot source on variant-A/B hives")
+	}
+	if !strings.Contains(bak, "post-merge-snapshot") {
+		t.Errorf(".bak content wrong: %q", bak)
+	}
+}
+
+// TestOverlayAndBakAreBothCapturedWhenTheyDiffer reflects the live case: on
+// projectbluefin-knuckle the two files differ (14609 B vs 14547 B) because the
+// overlay is written secret-free while .bak retains the merged auth_token.
+// Capturing only one loses information the other holds.
+func TestOverlayAndBakAreBothCapturedWhenTheyDiffer(t *testing.T) {
+	files, _, _ := buildTestBackup(t)
+
+	overlay, okOverlay := files["spoke/hive.yaml.dashboard"]
+	bak, okBak := files["spoke/hive.yaml.bak"]
+	if !okOverlay || !okBak {
+		t.Fatalf("both config files must be captured; overlay=%v bak=%v", okOverlay, okBak)
+	}
+	if overlay == bak {
+		t.Fatal("fixture is not exercising the divergent case; the two files are equal")
+	}
+}
+
+// TestPlainHiveYamlStillExcluded: the PVC's hive.yaml is regenerated from seed
+// + overlay on every boot and was observed stale on a production spoke.
+// Capturing it would invite restoring the wrong file.
+func TestPlainHiveYamlStillExcluded(t *testing.T) {
+	files, _, _ := buildTestBackup(t)
+
+	if _, ok := files["spoke/hive.yaml"]; ok {
+		t.Error("hive.yaml was captured; it is regenerated on every boot and was " +
+			"observed stale on a live spoke")
+	}
+}


### PR DESCRIPTION
## This is a correctness bug, not a docs fix

The spoke backup captured **only `hive.yaml.bak`**. That file is a post-merge *snapshot*. The file that actually carries a hive's configuration is the PVC overlay `/data/hive.yaml.dashboard`, which wins the boot-time merge on **every** hive.

So an existing archive restores a **differently-configured spoke**: no error at backup time, no symptom until the owner notices their settings reverted. That is the worst failure mode in DR code — it only bites when you are already in an emergency.

Sampled live seeds are **4–11% of the running config** and omit `policies`, `data`, `knowledge`, `notifications` and `hive_id` entirely, so falling back to the seed is not a near-miss.

Both files are now captured, and `spokeConfigUnrecoverable` accepts **either** — a spoke that has never had a dashboard save legitimately has no overlay, and failing its backup would be a false alarm.

## The docs asserted the opposite of what 48 of 51 hives do

Three sites stated as fact that `copy-config` restores from `.bak` and falls back to the seed:

- `v2/pkg/hubbackup/collect.go:39-45`
- `v2/pkg/spokebackup/backup.go:62`
- `docs/HUB_DISASTER_RECOVERY.md:361`

**True on 3 hives. False on 48.** The fleet runs two `copy-config` variants, baked into each Deployment at provision time and never migrated:

| Variant | Behaviour | Hives |
|---|---|---|
| A/B — `.bak` wins | restores `/data/hive.yaml.bak` over the seed | **3**: `kubestellar-console`, `projectbluefin-knuckle`, `aslom-hive-agent` |
| C — seed wins | copies the seed; merely *echoes* whether `.bak` exists | **48**: 15 on hive-oke, 33 on vllm-d |

The runbook now documents both, gives the `kubectl get deploy -o jsonpath` that reveals which one a hive runs (the only way to know), and cross-references `v2/docs/config-layering.md` and `GET /api/config/provenance` from #2370 rather than restating precedence and drifting again.

## Answering "are `.bak` and the overlay redundant?"

**Redundant in content on some hives, never in role — and the equality is incidental, not structural.**

They diverge **by construction**. `config.dashboardOverlayBytes` writes the overlay secret-free: it collapses `HIVE_GITHUB_TOKEN` back to `${HIVE_GITHUB_TOKEN}` and blanks a pod-env-derived `dashboard.auth_token`. `.bak` is a verbatim copy of the merged config, secrets included.

Confirmed live, read-only:

| Hive | `.bak` | overlay | equal? |
|---|---|---|---|
| `hosted-available-vllmd-03` | 12538 B | 12538 B | **yes** — no secret env vars set |
| `projectbluefin-knuckle` | 14609 B, `auth_token: 55c076f9…` | 14547 B, `auth_token: ""` | **no** |

So byte-equality holds only where the divergence-causing env vars happen to be unset. **Capture both.**

`.bak`'s one non-redundant role is the disaster fallback (`entrypoint.sh:152-161`), read when the ConfigMap is missing or empty — a genuinely different scenario from the overlay path.

**Could the overlay serve that role instead?** Mechanically yes, but not safely: the overlay is secret-free by design, so recovering from it loses the env-derived `auth_token`. `.bak` is the only copy that retains it.

**Recommendation: keep both, and rename `.bak`.** The name is the actual problem — `hive.yaml.bak` reads like *the* restorable backup when on 48 hives nothing reads it during a normal boot. `hive.yaml.merged` or `hive.yaml.snapshot` would state what it is. **Not renamed here** — that touches the entrypoint and both backup packages, and belongs in its own PR.

## Interaction with PR 6 (seed shrink)

Once everything converges on seed-wins, the `.bak` assertions become false for **all 51** hives rather than 48, so this correction is a prerequisite for the shrink not re-introducing stale docs.

More importantly: the shrink **narrows the disaster fallback**. That branch fires only when the seed is *missing or empty*, so a shrunken-but-non-empty seed silently bypasses it and the hive boots on the shrunken seed instead of recovering from `.bak`. Worth deciding deliberately when PR 6 lands.

## Tests

**hubbackup** (4): overlay is in `spokeFiles`; `hive.yaml` still excluded; recoverable with overlay-only; recoverable with `.bak`-only; unrecoverable with neither, naming both files.

**spokebackup** (4): overlay captured; `.bak` still captured alongside it; both captured when they differ; `hive.yaml` still excluded.

The shared `seedSpoke` fixture now writes all three config files with **distinct** content, so a test cannot pass by conflating them. One existing assertion that hardcoded the old fixture string was updated to assert intent instead.

**Mutation-verified — 3 mutations, all caught:**

| Mutation | Caught by |
|---|---|
| Drop overlay from `spokeFiles` | `TestSpokeFilesIncludesOverlay` |
| Guard requires `.bak` specifically | `TestSpokeRecoverableWithOverlayOnly` |
| Drop overlay from `includedRootFiles` | `TestOverlayIsCaptured` + 2 others |

Sources restored and green after each. `go build ./...`, `go vet`, `gofmt` clean; `pkg/hubbackup` and `pkg/spokebackup` fully pass.

`pkg/hub/saas.go` and `static/index.html` **untouched** — no raw-string risk.

## Live systems

**Strictly read-only.** `kubectl exec … wc -c` / `md5sum` / `diff` against spoke config files on three hives to establish the divergence. No hive, hub, ConfigMap or PVC modified; no restarts.
