### PR TITLE
✨ feat(hub): expose head_shas and image_statuses so a lagging SHA is diagnosable

### DIFF
--- a/v2/pkg/hub/hub_version_diagnostics_test.go
+++ b/v2/pkg/hub/hub_version_diagnostics_test.go
@@ -1,0 +1,170 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// hubVersionPayload is the subset of /api/hub/version this test asserts on.
+type hubVersionPayload struct {
+	GitHash       string            `json:"git_hash"`
+	LatestSHAs    map[string]string `json:"latest_shas"`
+	LatestHubSHAs map[string]string `json:"latest_hub_shas"`
+	HeadSHAs      map[string]string `json:"head_shas"`
+	ImageStatuses map[string]string `json:"image_statuses"`
+	UpgradeState  string            `json:"upgrade_state"`
+}
+
+func getHubVersion(t *testing.T, srv *HubServer) hubVersionPayload {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/api/hub/version", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var got hubVersionPayload
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode version payload: %v (body=%s)", err, w.Body.String())
+	}
+	return got
+}
+
+// seedSHACaches populates the three branch caches for branch "v2".
+func seedSHACaches(spokeSHA, hubSHA, headSHA, headStatus string) {
+	latestSHAMu.Lock()
+	defer latestSHAMu.Unlock()
+	if spokeSHA != "" {
+		latestSHAByBranch["v2"] = branchSHAInfo{SHA: spokeSHA}
+	}
+	if hubSHA != "" {
+		latestHubSHAByBranch["v2"] = branchSHAInfo{SHA: hubSHA}
+	}
+	if headSHA != "" {
+		headSHAByBranch["v2"] = branchHeadInfo{SHA: headSHA, ImageStatus: headStatus}
+	}
+}
+
+// TestHubVersionDistinguishesBuildingFromWedgedPoller is the core of this
+// change. Before it, "latest_shas.v2 is behind the branch HEAD" was a bare
+// string with no way to tell a healthy mid-build window from a broken poller —
+// an ambiguity that produced a real false alarm. Each case below is one
+// operator-facing diagnosis; they must not collapse into the same payload.
+func TestHubVersionDistinguishesBuildingFromWedgedPoller(t *testing.T) {
+	cases := []struct {
+		name       string
+		spoke      string
+		hub        string
+		head       string
+		status     string
+		wantStatus string
+		// wantBehind is whether the advertised spoke SHA trails HEAD.
+		wantBehind bool
+	}{
+		{
+			// The real 2026-07-31 race: #2375 (c6ec89d) merged 5 minutes after
+			// f2b4719, and its spoke image was still building. The hub
+			// correctly advertised the older SHA — nothing was wrong.
+			name:  "spoke image still building is transient and healthy",
+			spoke: "f2b4719", hub: "c6ec89d", head: "c6ec89d",
+			status: imageStatusBuilding, wantStatus: imageStatusBuilding, wantBehind: true,
+		},
+		{
+			// Same shape, but the image EXISTS and the advertised SHA still
+			// did not advance. This is the genuine fault the old payload
+			// could not express.
+			name:  "ready image with a stale advertised SHA is a poller fault",
+			spoke: "f2b4719", hub: "c6ec89d", head: "c6ec89d",
+			status: imageStatusReady, wantStatus: imageStatusReady, wantBehind: true,
+		},
+		{
+			name:  "failed build is distinct from building",
+			spoke: "f2b4719", hub: "c6ec89d", head: "c6ec89d",
+			status: imageStatusFailed, wantStatus: imageStatusFailed, wantBehind: true,
+		},
+		{
+			name:  "fully rolled out",
+			spoke: "c6ec89d", hub: "c6ec89d", head: "c6ec89d",
+			status: imageStatusReady, wantStatus: imageStatusReady, wantBehind: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetSHACaches(t)
+			defer resetSHACaches(t)
+			seedSHACaches(tc.spoke, tc.hub, tc.head, tc.status)
+
+			srv := NewHubServer(0, slog.Default(), tc.hub, "v2")
+			got := getHubVersion(t, srv)
+
+			if got.ImageStatuses["v2"] != tc.wantStatus {
+				t.Errorf("image_statuses[v2] = %q, want %q", got.ImageStatuses["v2"], tc.wantStatus)
+			}
+			if got.HeadSHAs["v2"] != tc.head {
+				t.Errorf("head_shas[v2] = %q, want %q", got.HeadSHAs["v2"], tc.head)
+			}
+			if got.LatestSHAs["v2"] != tc.spoke {
+				t.Errorf("latest_shas[v2] = %q, want %q", got.LatestSHAs["v2"], tc.spoke)
+			}
+			if got.LatestHubSHAs["v2"] != tc.hub {
+				t.Errorf("latest_hub_shas[v2] = %q, want %q", got.LatestHubSHAs["v2"], tc.hub)
+			}
+			behind := got.LatestSHAs["v2"] != got.HeadSHAs["v2"]
+			if behind != tc.wantBehind {
+				t.Errorf("advertised-behind-HEAD = %v, want %v", behind, tc.wantBehind)
+			}
+		})
+	}
+}
+
+// TestHubVersionUpgradeStateUsesHubCacheNotSpokeCache pins the property that
+// made the original "self-confirming bug" hypothesis wrong: upgrade_state is
+// computed from the HUB image cache, so "current" alongside an older
+// latest_shas is legitimate, not a contradiction. If someone ever repoints
+// hubUpgradeState() at latestSHAByBranch, this fails.
+func TestHubVersionUpgradeStateUsesHubCacheNotSpokeCache(t *testing.T) {
+	resetSHACaches(t)
+	defer resetSHACaches(t)
+	// Hub image is at c6ec89d (what the hub runs); spoke image lags at f2b4719.
+	seedSHACaches("f2b4719", "c6ec89d", "c6ec89d", imageStatusBuilding)
+
+	srv := NewHubServer(0, slog.Default(), "c6ec89d", "v2")
+	got := getHubVersion(t, srv)
+
+	if got.UpgradeState != "current" {
+		t.Errorf("upgrade_state = %q, want \"current\" — it must track the hub "+
+			"image cache, not the lagging spoke cache", got.UpgradeState)
+	}
+	if got.LatestSHAs["v2"] == got.LatestHubSHAs["v2"] {
+		t.Fatal("test setup is not exercising divergent hub/spoke caches")
+	}
+}
+
+// TestHubVersionEmptyHeadSHAsSignalsPollerNotRunning covers the startup /
+// wedged-poller case: no head fetch has ever succeeded, so head_shas is empty
+// rather than silently mirroring latest_shas.
+func TestHubVersionEmptyHeadSHAsSignalsPollerNotRunning(t *testing.T) {
+	resetSHACaches(t)
+	defer resetSHACaches(t)
+	// Only the persisted spoke cache is warm (as after loadPersistedSHAs).
+	seedSHACaches("f2b4719", "", "", "")
+
+	srv := NewHubServer(0, slog.Default(), "f2b4719", "v2")
+	got := getHubVersion(t, srv)
+
+	if _, ok := got.HeadSHAs["v2"]; ok {
+		t.Errorf("head_shas[v2] should be absent when no head fetch has "+
+			"succeeded, got %q", got.HeadSHAs["v2"])
+	}
+	if got.LatestSHAs["v2"] != "f2b4719" {
+		t.Errorf("latest_shas[v2] = %q, want restored value", got.LatestSHAs["v2"])
+	}
+	// Branches known only from the image-verified cache are ready by definition.
+	if got.ImageStatuses["v2"] != imageStatusReady {
+		t.Errorf("image_statuses[v2] = %q, want %q", got.ImageStatuses["v2"], imageStatusReady)
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3654,6 +3654,37 @@ func getLatestHubSHAForBranch(branch string) string {
 	return latestHubSHAByBranch[branch].SHA
 }
 
+// getLatestHubSHAs returns a branch→SHA map of the newest commit per branch
+// whose HUB image is verified pullable. Exposed alongside getLatestSHAs so an
+// operator can see the two independent build results side by side: the hub and
+// spoke images are separate builds that can succeed in either order (or fail
+// independently) for the same commit, which is why the caches are separate.
+func getLatestHubSHAs() map[string]string {
+	latestSHAMu.RLock()
+	defer latestSHAMu.RUnlock()
+	cp := make(map[string]string, len(latestHubSHAByBranch))
+	for k, v := range latestHubSHAByBranch {
+		cp[k] = v.SHA
+	}
+	return cp
+}
+
+// getHeadSHAs returns a branch→HEAD-SHA map: the newest commit the poller has
+// seen on each branch, regardless of whether its images exist yet. Comparing
+// this against getLatestSHAs tells an operator WHY the advertised SHA is behind
+// HEAD — see getImageStatuses for the distinguishing signal.
+func getHeadSHAs() map[string]string {
+	latestSHAMu.RLock()
+	defer latestSHAMu.RUnlock()
+	cp := make(map[string]string, len(headSHAByBranch))
+	for k, v := range headSHAByBranch {
+		if v.SHA != "" {
+			cp[k] = v.SHA
+		}
+	}
+	return cp
+}
+
 // getLatestSHAs returns a branch→SHA map (backward-compatible string values).
 func getLatestSHAs() map[string]string {
 	latestSHAMu.RLock()

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1947,12 +1947,35 @@ func (s *HubServer) handleRegistryDelete(w http.ResponseWriter, r *http.Request)
 func (s *HubServer) handleHubVersion(w http.ResponseWriter, r *http.Request) {
 	// The hub secret is never returned from this browser-reachable endpoint; the
 	// raw shared secret has no legitimate consumer over HTTP.
+	// latest_shas is the SPOKE-image-verified target actually advertised to
+	// spokes (see the heartbeat response in handleHeartbeat). It legitimately
+	// lags head_shas while a new commit's spoke image builds, so a bare
+	// "latest_shas is behind HEAD" reading cannot distinguish a healthy
+	// mid-build window from a wedged poller. head_shas + image_statuses make
+	// that difference explicit:
+	//
+	//   head == latest                      → fully rolled out
+	//   head > latest, status "building"    → normal, transient, no action
+	//   head > latest, status "failed"      → the image build failed
+	//   head > latest, status "ready"       → poller fault: the image exists
+	//                                         but the advertised SHA never
+	//                                         advanced
+	//   head_shas empty / far behind GitHub → poller not running or erroring
+	//
+	// latest_hub_shas is the HUB image for the same commits, a SEPARATE build
+	// that can land in either order. upgrade_state is computed from it, not
+	// from latest_shas, so "upgrade_state: current" beside an older
+	// latest_shas is a legitimate state (hub image published, spoke image
+	// still building) rather than a contradiction.
 	resp := map[string]any{
-		"git_hash":      s.hubGitHash,
-		"git_branch":    s.hubGitBranch,
-		"latest_sha":    getLatestSHA(),
-		"latest_shas":   getLatestSHAs(),
-		"upgrade_state": s.hubUpgradeState(),
+		"git_hash":        s.hubGitHash,
+		"git_branch":      s.hubGitBranch,
+		"latest_sha":      getLatestSHA(),
+		"latest_shas":     getLatestSHAs(),
+		"latest_hub_shas": getLatestHubSHAs(),
+		"head_shas":       getHeadSHAs(),
+		"image_statuses":  getImageStatuses(),
+		"upgrade_state":   s.hubUpgradeState(),
 	}
 	data, _ := json.Marshal(resp)
 	w.Header().Set("Content-Type", "application/json")

--- a/v2/pkg/hub/sha_fetch_coverage_test.go
+++ b/v2/pkg/hub/sha_fetch_coverage_test.go
@@ -219,6 +219,11 @@ func resetSHACaches(t *testing.T) {
 	for k := range headSHAByBranch {
 		delete(headSHAByBranch, k)
 	}
+	// The hub-image cache is a separate map from latestSHAByBranch; leaving it
+	// populated leaks state into tests that assert on latest_hub_shas.
+	for k := range latestHubSHAByBranch {
+		delete(latestHubSHAByBranch, k)
+	}
 	for k := range commitMsgBySHA {
 		delete(commitMsgBySHA, k)
 	}


### PR DESCRIPTION
## Summary

`/api/hub/version` reported `latest_shas` as a bare branch→SHA string. When that value trailed the branch HEAD, there was **no way to tell apart two completely different situations**:

- the spoke image is **still building** — correct, transient, no action needed
- the poller is **wedged** — a real fault

Both presented identically. That ambiguity is the deliverable this PR removes.

## Why now

An investigation today flagged the hub as "advertising a stale target SHA, blocking ~60 merged PRs from reaching the fleet." **It was a false alarm.** The hub was sampled during a normal mid-build window:

| Time (UTC) | Event |
|---|---|
| 19:22:06 | `f2b4719` merged (#2373) |
| 19:27:09 | `c6ec89d` merged (#2375) — **one commit later**, not "stale" |
| 19:27:12–**19:31:15** | docker build for `c6ec89d` — images did not exist until 19:31:15 |

During that ~4-minute window `latest_shas.v2 = f2b4719` was the **correct, intended value**: `fetchBranchSHA` deliberately only advances the advertised SHA after `ghcrTagExists` confirms the spoke image is pullable, so spokes are never told to pull an image that does not exist. The poller advanced on its own schedule (2 min) once the build landed. Nothing was broken — but the payload could not say so, and that cost real investigation time.

## No functional defect was found

**To be unambiguous for anyone reading this later: the poller was not broken.** The poller, the GHCR gating, and the SHA advertised to spokes are all untouched by this PR. This is purely a diagnosability improvement.

## What changed

Three additive fields on `/api/hub/version`. Every existing key keeps its meaning, so no consumer breaks.

- **`head_shas`** — newest commit the poller has seen per branch, regardless of image existence
- **`image_statuses`** — `building` / `ready` / `failed` per branch
- **`latest_hub_shas`** — the hub-image-verified SHA per branch

How to read them:

| Reading | Diagnosis |
|---|---|
| `head == latest` | fully rolled out |
| `head > latest`, `building` | normal mid-build window — no action |
| `head > latest`, `failed` | the image build failed |
| `head > latest`, `ready` | **poller fault** — image exists but the advertised SHA never advanced |
| `head_shas` empty | no head fetch has ever succeeded — poller not running or erroring |

The signal already existed in `headSHAByBranch` (and `getImageStatuses()` was already written); it simply was never served on this endpoint.

## Why `latest_hub_shas` is included

The hub and spoke images are **separate builds that can land in either order, or fail independently, for the same commit** — which is exactly why `latestSHAByBranch` and `latestHubSHAByBranch` are separate caches (see the comment on `getLatestHubSHAForBranch` in `saas.go`).

This matters for reading the endpoint: `upgrade_state` is computed from the **hub** cache, not from `latest_shas`. So `upgrade_state: current` sitting beside an *older* `latest_shas.v2` is a **legitimate state** — the hub image published, the spoke image is still building. Today that combination looks alarming and reads like a self-contradiction. Serving both caches makes it legible.

## Tests

`TestHubVersionDistinguishesBuildingFromWedgedPoller` is table-driven over the four diagnoses above, using the real `f2b4719`/`c6ec89d` SHAs from today's race. Two further tests pin that `upgrade_state` tracks the hub cache, and that `head_shas` stays empty (rather than mirroring `latest_shas`) when no head fetch has succeeded.

**Mutation-verified** — each mutation applied to the source, confirmed failing, then reverted:

1. repoint `hubUpgradeState()` at the spoke cache → `TestHubVersionUpgradeStateUsesHubCacheNotSpokeCache` fails (`upgrade_state = "behind"`). This is the bug that was *hypothesised* to exist; the test now prevents it being introduced for real.
2. collapse `image_statuses` to always-`ready` → 2 subtests fail
3. make `head_shas` mirror `latest_shas` → 4 subtests fail

Full `pkg/hub` suite passes under `-race`; `go build ./...`, `go vet ./...`, and `gofmt` all clean. `dashboardHTML` was not touched (backtick counts in `saas.go` and `server.go` are byte-identical to base).

Also fixes a latent test-isolation leak: `resetSHACaches` never cleared `latestHubSHAByBranch`.

## Related gap (not addressed here)

Per-spoke convergence is currently hard to verify externally — `/api/hub/fleet-stats` 404s and the real endpoint is behind auth, so confirming "which spokes are on which SHA" needs hub access. Noting it as adjacent; deliberately out of scope for this PR.
