### PR TITLE
🐛 fix(hub): make a half-applied GitHub identity impossible to push and impossible to miss

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2507,6 +2507,14 @@ func main() {
 				// pairs it with the fingerprint above to tell a per-hive key that
 				// is WRONG for this App from one that is deliberately for another.
 				GitHubAppID: cfg.GitHub.AppID,
+				// Report the REST of the identity set too. app_id alone cannot
+				// distinguish a correctly-delivered identity from a
+				// half-applied one: a GHE app_id with an empty api_url looks
+				// identical to the hub, and 404s on every token request. All
+				// four together let the hub see the whole set.
+				GitHubAppSlug:        cfg.GitHub.AppSlug,
+				GitHubInstallationID: cfg.GitHub.InstallationID,
+				GitHubBaseURL:        cfg.GitHub.BaseURL,
 				// Report the fingerprint of every ADDITIONAL per-app-id key already
 				// on the PVC, so the hub delivers the fleet's other App keys once
 				// and then stops re-sending them.

--- a/v2/pkg/hub/drift.go
+++ b/v2/pkg/hub/drift.go
@@ -77,10 +77,21 @@ const (
 	// work, and telling an operator to check credentials would repeat exactly
 	// the misdiagnosis this signal exists to end.
 	DriftKindAppIDPlaceholder = "app-id-placeholder"
-	DriftKindHealthDegraded   = "health-degraded"
-	DriftKindUpgradeStuck     = "upgrade-stuck"
-	DriftKindACMMUnset        = "acmm-unset"
-	DriftKindNoAgents         = "no-agents"
+	// DriftKindIdentitySplit marks a hive whose GitHub identity components
+	// disagree with each other — most importantly a GHE app_id/app_slug with an
+	// api_url that is empty or public, which authenticates as nothing and fails
+	// every token request with "404 Integration not found".
+	//
+	// It is operator-side and critical: the hive was working, a push moved one
+	// component of the identity without the others, and no owner action can fix
+	// it. Distinct from app-missing (no App installed) and app-id-placeholder
+	// (the App does not exist) because here the App is real and the credentials
+	// are right — they are simply pointed at the wrong forge.
+	DriftKindIdentitySplit  = "identity-split"
+	DriftKindHealthDegraded = "health-degraded"
+	DriftKindUpgradeStuck   = "upgrade-stuck"
+	DriftKindACMMUnset      = "acmm-unset"
+	DriftKindNoAgents       = "no-agents"
 )
 
 // DriftSignal is one detected deviation. Reason is a complete, human-readable
@@ -514,6 +525,21 @@ func computeDrift(h MyHiveEntry, norm fleetNorm, latestSHAs map[string]string, n
 			// misdiagnosis that sent the owner to correct an installation ID that
 			// was already right. app-id-placeholder above already says the true
 			// cause, so this row is suppressed rather than duplicated.
+		}
+		// A split GitHub identity: the components disagree about which forge
+		// they name. Raised on the spoke's OWN report of the whole set, which
+		// is only possible now that app_slug/api_url/base_url are reported
+		// back — with app_id alone, a half-applied identity was
+		// indistinguishable from a healthy one.
+		for _, issue := range IdentitySetIssues(IdentitySet{
+			AppID:          h.GitHubAppID,
+			AppSlug:        h.GitHubAppSlug,
+			InstallationID: h.GitHubInstallationID,
+			APIURL:         h.GitHubAPIURL,
+			BaseURL:        h.GitHubBaseURL,
+		}) {
+			add(DriftKindIdentitySplit, DriftCritical,
+				"GitHub identity is half-applied and only an operator can fix it: "+issue)
 		}
 		if h.ACMMLevel <= driftACMMUnsetLevel {
 			add(DriftKindACMMUnset, DriftWarn,

--- a/v2/pkg/hub/drift_identity_test.go
+++ b/v2/pkg/hub/drift_identity_test.go
@@ -1,0 +1,96 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// hasSignal reports whether the report carries a signal of the given kind.
+func hasSignal(r DriftReport, kind string) (DriftSignal, bool) {
+	for _, s := range r.Signals {
+		if s.Kind == kind {
+			return s, true
+		}
+	}
+	return DriftSignal{}, false
+}
+
+// TestDriftFlagsHalfAppliedIdentity is the live regression, seen from the hub.
+//
+// A GHE app_id/slug with an empty api_url authenticates as nothing and returns
+// "404 Integration not found" on every token request. Until the spoke reported
+// its whole identity back, this was invisible to the hub: with only app_id
+// visible, a half-applied identity looked exactly like a healthy delivery, and
+// the first symptom was a user reporting that their agents had stopped.
+func TestDriftFlagsHalfAppliedIdentity(t *testing.T) {
+	norm := computeFleetNorm(normFleet())
+	latest := map[string]string{"v2": "abc1234"}
+
+	h := healthyEntry("kalantar-msb")
+	h.GitHubAppID = 5686
+	h.GitHubAppSlug = "kubestellar-hive-ghe"
+	h.GitHubInstallationID = 146551814
+	h.GitHubAPIURL = "" // the field that was never pushed
+
+	got := computeDrift(h, norm, latest, driftNow)
+
+	sig, ok := hasSignal(got, DriftKindIdentitySplit)
+	if !ok {
+		t.Fatal("a GHE App with an empty api_url raised no identity-split signal — " +
+			"this hive 404s on every token request and nothing would say so")
+	}
+	if sig.Severity != DriftCritical {
+		t.Errorf("severity = %q, want critical: the hive cannot authenticate at all", sig.Severity)
+	}
+	if !strings.Contains(sig.Reason, "operator") {
+		t.Errorf("reason %q should say only an operator can fix it — the owner cannot", sig.Reason)
+	}
+}
+
+// TestDriftSilentOnHealthyPublicIdentity guards the other direction. Public
+// GitHub legitimately runs with an EMPTY api_url, so firing here would raise a
+// critical signal on most of the fleet and the signal would be ignored.
+func TestDriftSilentOnHealthyPublicIdentity(t *testing.T) {
+	norm := computeFleetNorm(normFleet())
+	latest := map[string]string{"v2": "abc1234"}
+
+	h := healthyEntry("public-hive")
+	h.GitHubAppID = 3568013
+	h.GitHubAppSlug = "kubestellar-hive"
+	h.GitHubAPIURL = ""
+
+	if sig, ok := hasSignal(computeDrift(h, norm, latest, driftNow), DriftKindIdentitySplit); ok {
+		t.Errorf("a healthy public-GitHub hive was flagged: %s", sig.Reason)
+	}
+}
+
+// TestDriftSilentOnHealthyGHEIdentity: the fully-delivered GHE case.
+func TestDriftSilentOnHealthyGHEIdentity(t *testing.T) {
+	norm := computeFleetNorm(normFleet())
+	latest := map[string]string{"v2": "abc1234"}
+
+	h := healthyEntry("ghe-hive")
+	h.GitHubAppID = 5686
+	h.GitHubAppSlug = "kubestellar-hive-ghe"
+	h.GitHubAPIURL = "https://github.ibm.com/api/v3"
+	h.GitHubBaseURL = "https://github.ibm.com"
+
+	if sig, ok := hasSignal(computeDrift(h, norm, latest, driftNow), DriftKindIdentitySplit); ok {
+		t.Errorf("a correctly-delivered GHE hive was flagged: %s", sig.Reason)
+	}
+}
+
+// TestDriftSilentOnUnderReportingSpoke: a spoke too old to report app_slug or
+// base_url must read as UNKNOWN. Inferring breakage from silence would flag
+// every spoke that has not yet upgraded past this change.
+func TestDriftSilentOnUnderReportingSpoke(t *testing.T) {
+	norm := computeFleetNorm(normFleet())
+	latest := map[string]string{"v2": "abc1234"}
+
+	h := healthyEntry("old-spoke")
+	h.GitHubAppID = 5686 // reports app_id only, as every spoke did before this change
+
+	if sig, ok := hasSignal(computeDrift(h, norm, latest, driftNow), DriftKindIdentitySplit); ok {
+		t.Errorf("a spoke too old to report the full identity was flagged: %s", sig.Reason)
+	}
+}

--- a/v2/pkg/hub/forge.go
+++ b/v2/pkg/hub/forge.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // ============================================================================
@@ -339,11 +340,51 @@ func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 		h.GitHubAPIURL = target.APIURL
 	}
 
+	// Refuse to arm an identity whose components disagree about their forge.
+	// This handler already resolves the whole set up front and 409s rather than
+	// half-applying; this is the same guarantee expressed as a check, so it also
+	// covers a cluster config that names, say, a GHE slug with a public api_url.
+	wantIdentity := IdentitySet{
+		AppID:          appID,
+		AppSlug:        identity.AppSlug,
+		InstallationID: installID,
+		APIURL:         target.APIURL,
+		BaseURL:        target.BaseURL,
+	}
+	if reason := ValidateIdentityPush(wantIdentity); reason != "" {
+		s.logger.Warn("forge switch: refusing inconsistent identity",
+			"hive_id", id, "reason", reason)
+		writeJSONError(w, http.StatusConflict, reason)
+		return
+	}
+
 	// Re-arm delivery. This is the #2354 handshake: the requested host is
 	// authoritative until the spoke reports it back, at which point the push
 	// stops permanently and the spoke owns the value again.
 	h.RequestedGitHubHost = target.Host
 	h.ForgeDelivered = false
+
+	// Queue the identity DURABLY on the hive record. The in-memory one-shot map
+	// this replaced was dropped on the first beat that carried it and lost
+	// entirely on a hub restart, so a missed beat meant the change silently
+	// never happened. Persisting it means the push repeats until the spoke
+	// reports the identity back — which the app_slug/installation_id read-back
+	// fields make verifiable for the first time.
+	h.PendingAppConfig = &PendingAppIdentity{
+		AppID: appID,
+		// Only a supplied ID is sent. Zero means "leave it alone" on the
+		// wire; the operator note below tells the operator it must be
+		// installed or supplied, so the failure is never silent.
+		InstallationID: installID,
+		AppSlug:        identity.AppSlug,
+		APIURL:         target.APIURL,
+		ArmedAt:        time.Now().UTC().Format(time.RFC3339),
+		Reason:         "forge switch to " + target.Host,
+		// PrivateKey is deliberately absent, and this record never stores key
+		// material. The per-cluster key reconcile (cluster_app_key.go) delivers
+		// keys on its own schedule and gates every push on HasKey();
+		// duplicating it here would risk blanking a working key.
+	}
 
 	if err := saveSaaSHive(h); err != nil {
 		s.logger.Error("forge switch: failed to persist hive", "hive_id", id, "error", err)
@@ -378,18 +419,6 @@ func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 	// precondition above: identity.AppSlug is non-empty by construction here, so
 	// the spoke can never be left falling back to the github.com default slug on
 	// a GHE host — the state that produced the live install-link 404.
-	s.storePendingGitHubAppConfig(id, &HeartbeatGitHubAppConfig{
-		AppID: appID,
-		// Only a supplied ID is sent. Zero means "leave it alone" on the
-		// wire; the operator note below tells the operator it must be
-		// installed or supplied, so the failure is never silent.
-		InstallationID: installID,
-		AppSlug:        identity.AppSlug,
-		// PrivateKey is deliberately absent. The per-cluster key reconcile
-		// (cluster_app_key.go) delivers key material on its own schedule and
-		// gates every key push on HasKey(); duplicating it here would risk
-		// blanking a working key with an empty string.
-	})
 	deliveryPending := true
 
 	note := ""

--- a/v2/pkg/hub/forge.go
+++ b/v2/pkg/hub/forge.go
@@ -378,6 +378,7 @@ func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 		InstallationID: installID,
 		AppSlug:        identity.AppSlug,
 		APIURL:         target.APIURL,
+		BaseURL:        target.BaseURL,
 		ArmedAt:        time.Now().UTC().Format(time.RFC3339),
 		Reason:         "forge switch to " + target.Host,
 		// PrivateKey is deliberately absent, and this record never stores key

--- a/v2/pkg/hub/forge_test.go
+++ b/v2/pkg/hub/forge_test.go
@@ -447,7 +447,12 @@ func TestSwitchForgeSwapsTheWholeIdentity(t *testing.T) {
 
 	// The App identity queued for the spoke must carry the GHE app id AND the
 	// GHE slug, and must NOT carry an installation id from the old forge.
-	got := s.consumePendingGitHubAppConfig("vllmd03")
+	//
+	// The queue is now the DURABLE PendingAppConfig on the hive record rather
+	// than an in-memory one-shot map, so a hub restart between arming and the
+	// next beat no longer discards the switch. The assertions below are
+	// unchanged — only where the identity is read from.
+	got := h.PendingAppConfig
 	if got == nil {
 		t.Fatal("no App identity queued for the spoke — the hive would keep the github.com App")
 	}
@@ -460,8 +465,12 @@ func TestSwitchForgeSwapsTheWholeIdentity(t *testing.T) {
 	if got.InstallationID != 0 {
 		t.Errorf("installation_id = %d, want 0 — an ID from the previous forge must NEVER be carried over", got.InstallationID)
 	}
-	if got.PrivateKey != "" {
-		t.Errorf("this endpoint must not push key material; the per-cluster reconcile owns that, got a key of %d bytes", len(got.PrivateKey))
+	// PendingAppIdentity has no PrivateKey field at all: key material is owned
+	// by the per-cluster reconcile, which gates every push on HasKey(). The
+	// endpoint cannot push a key even by mistake, which is a stronger guarantee
+	// than the assertion this replaces.
+	if got.APIURL != "https://github.ibm.com/api/v3" {
+		t.Errorf("queued api_url = %q, want the GHE API — an identity queued without it is the half-applied state that 404s", got.APIURL)
 	}
 
 	// The response must tell the operator the install is still outstanding,

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -434,6 +434,49 @@ type HeartbeatPayload struct {
 	// read as "unknown": the hub falls back to the conservative per-hive
 	// override and declines to overwrite. Never infer a mismatch from silence.
 	GitHubAppID int64 `json:"github_app_id,omitempty"`
+	// GitHubAppSlug and GitHubInstallationID complete the spoke's report of the
+	// GitHub identity it is actually running.
+	//
+	// WHY THEY EXIST
+	//
+	// A GitHub App identity is an ATOMIC SET — app_id, app_slug, api_url and
+	// base_url must all name the same forge. The hub pushes app_id and app_slug
+	// (HeartbeatGitHubAppConfig) and api_url (HeartbeatProjectConfig), but until
+	// now it received back only app_id and the key fingerprint. Two of the
+	// pushed fields were therefore STRUCTURALLY UNCONFIRMABLE: the hub could
+	// push a slug or an installation id and had no way, ever, to learn whether
+	// it landed.
+	//
+	// That is not a theoretical gap. A cluster-config change pushed a GHE
+	// app_id to a set of hives WITHOUT a matching api_url. The spokes ended up
+	// with a GHE App ID pointed at api.github.com and every token request
+	// failed:
+	//
+	//	POST https://api.github.com/app/installations/<id>/access_tokens
+	//	404 Integration not found
+	//
+	// The hives that also received api_url=https://github.ibm.com/api/v3 were
+	// fine — the failure split exactly on that one field. With only app_id
+	// reported back, a half-applied identity is invisible to the hub: it looks
+	// like a successful delivery. Reporting the whole set is what makes the
+	// inconsistency detectable, and is a prerequisite for ever confirming a
+	// delivery of it.
+	//
+	// Both are NON-SECRET. Empty/zero means "too old to report, or not
+	// configured" — read as UNKNOWN, never as a mismatch. Never infer a
+	// half-applied identity from silence; see IdentitySetIssues.
+	GitHubAppSlug string `json:"github_app_slug,omitempty"`
+	// GitHubInstallationID is the installation the spoke is using. It is
+	// forge-scoped: an ID issued by one forge names nothing on another, which is
+	// why a forge switch deliberately never carries it across.
+	GitHubInstallationID int64 `json:"github_installation_id,omitempty"`
+	// GitHubBaseURL is the web base URL the spoke runs against (github.base_url).
+	// It is reported but never pushed — the spoke derives its host from
+	// base_url with a fallback to api_url (GitHubConfig.HostLabel), so pushing
+	// api_url alone is sufficient to move a hive between forges. It is reported
+	// here so the hub can see the COMPLETE identity set and detect a base_url
+	// that disagrees with api_url.
+	GitHubBaseURL string `json:"github_base_url,omitempty"`
 	// GitHubAppKeysHeld reports the NON-SECRET fingerprint of every ADDITIONAL
 	// per-app-id key file this spoke holds on its PVC, keyed by app_id as a
 	// decimal string (JSON object keys must be strings). It exists so the hub can

--- a/v2/pkg/hub/identity.go
+++ b/v2/pkg/hub/identity.go
@@ -89,6 +89,14 @@ type PendingAppIdentity struct {
 	// GitHub. Recorded so the consistency of the queued SET can be checked
 	// before it is armed, even though it travels on a different payload.
 	APIURL string `json:"api_url,omitempty"`
+	// BaseURL completes the forge half of the identity set.
+	//
+	// APIURL alone is not enough: app_id, app_slug, api_url and base_url are ONE
+	// value. A request carrying three of the four leaves the spoke to pair the
+	// new App with whichever base_url it already had — the half-identity this
+	// record exists to prevent, reintroduced one field down. Empty means public
+	// github.com, matching APIURL.
+	BaseURL string `json:"base_url,omitempty"`
 	// ArmedAt is when this identity was queued, so an outstanding delivery that
 	// never confirms is visible rather than merely absent.
 	ArmedAt string `json:"armed_at,omitempty"`
@@ -232,6 +240,12 @@ func (s *HubServer) pendingAppIdentityForHeartbeat(p *HeartbeatPayload) *Heartbe
 		AppID:          pend.AppID,
 		InstallationID: pend.InstallationID,
 		AppSlug:        pend.AppSlug,
+		// The forge urls travel WITH the App. They were stored on the pending
+		// record and never sent, so a forge switch delivered a new app_id while
+		// the spoke kept its previous api_url/base_url — the half-identity that
+		// returns "404 Integration not found". Empty still means "unchanged".
+		APIURL:  pend.APIURL,
+		BaseURL: pend.BaseURL,
 		// PrivateKey deliberately empty: key material is owned by the
 		// per-cluster reconcile, which gates every push on HasKey(). An empty
 		// key already means "leave the spoke's key alone", so this can never

--- a/v2/pkg/hub/identity.go
+++ b/v2/pkg/hub/identity.go
@@ -1,0 +1,282 @@
+package hub
+
+// GitHub identity as an ATOMIC SET.
+//
+// ─────────────────────────────────────────────────────────────────────────
+// THE RULE
+// ─────────────────────────────────────────────────────────────────────────
+//
+// app_id, app_slug, api_url and base_url together name ONE GitHub App on ONE
+// forge. No valid mixture exists:
+//
+//	GHE:    app_id=<ghe app>    slug=<ghe slug>    api_url=https://<host>/api/v3
+//	Public: app_id=<public app> slug=<public slug> api_url="" (or api.github.com)
+//
+// ─────────────────────────────────────────────────────────────────────────
+// WHY THIS FILE EXISTS
+// ─────────────────────────────────────────────────────────────────────────
+//
+// A cluster-config change pushed a GHE app_id to a set of hives WITHOUT also
+// pushing api_url. Those spokes ended up with:
+//
+//	app_id: 5686          <- the GHE App
+//	api_url: ""           <- empty, so it defaults to api.github.com
+//
+// and every token request failed on hives that had been working an hour
+// earlier:
+//
+//	POST https://api.github.com/app/installations/146551814/access_tokens
+//	404 Integration not found
+//
+// The hives that also received api_url=https://github.ibm.com/api/v3 were
+// fine. The failure split exactly on that one field.
+//
+// #2360's forge endpoint already refuses to half-apply an identity — it
+// resolves the whole set up front and 409s naming what is missing, writing
+// nothing. The cluster-config push path had no equivalent guard, so it could
+// deliver one component of the set and leave the rest stale.
+//
+// This file supplies that guard in the form the transport actually allows.
+//
+// ─────────────────────────────────────────────────────────────────────────
+// WHY THIS IS A PRECONDITION AND NOT A DELIVERY LATCH
+// ─────────────────────────────────────────────────────────────────────────
+//
+// The obvious fix is a "set-valued" delivery latch — push the whole identity,
+// wait for the spoke to confirm all of it. That is NOT expressible on the
+// current transport, for two independent reasons:
+//
+//  1. The set is split across two heartbeat payloads with different gating:
+//     app_id/app_slug/installation_id ride HeartbeatGitHubAppConfig, api_url
+//     rides HeartbeatProjectConfig, and base_url is never pushed at all (the
+//     spoke derives its host from base_url with a fallback to api_url, so
+//     pushing api_url alone moves a hive between forges).
+//
+//  2. Until the read-back fields added alongside this file, the hub received
+//     back only app_id and the key fingerprint. app_slug and installation_id
+//     were structurally unconfirmable — a latch over them could arm and push
+//     but could never legitimately confirm.
+//
+// So the guarantee is provided where it can be: REFUSE TO ARM an inconsistent
+// push, and DETECT an inconsistent state that is already live. That gives the
+// atomicity property (never half-apply) without pretending three transports
+// are one.
+
+import "strings"
+
+// gheAPIPathMarker identifies a GitHub Enterprise API URL. GHE APIs live under
+// /api/v3; public GitHub uses api.github.com.
+const gheAPIPathMarker = "/api/v3"
+
+// publicGitHubHost is declared in server.go and reused here.
+
+// PendingAppIdentity is a GitHub App identity queued for delivery to a spoke.
+//
+// It is the durable replacement for the in-memory one-shot map. Every field is
+// NON-SECRET: the private key is never persisted here and continues to travel
+// only through the per-cluster key reconcile, which gates each push on
+// HasKey().
+type PendingAppIdentity struct {
+	// AppID is the App the spoke should authenticate as.
+	AppID int64 `json:"app_id,omitempty"`
+	// AppSlug is the App's URL slug on the target forge.
+	AppSlug string `json:"app_slug,omitempty"`
+	// InstallationID is the installation on the target forge. Zero means
+	// "leave the spoke's alone" — an ID from one forge names nothing on
+	// another, so a forge switch deliberately never carries it across.
+	InstallationID int64 `json:"installation_id,omitempty"`
+	// APIURL is the GitHub API base for the target forge. Empty means public
+	// GitHub. Recorded so the consistency of the queued SET can be checked
+	// before it is armed, even though it travels on a different payload.
+	APIURL string `json:"api_url,omitempty"`
+	// ArmedAt is when this identity was queued, so an outstanding delivery that
+	// never confirms is visible rather than merely absent.
+	ArmedAt string `json:"armed_at,omitempty"`
+	// Reason records who armed it and why, for diagnosis.
+	Reason string `json:"reason,omitempty"`
+}
+
+// IdentitySet is a complete GitHub identity, from any source: what a spoke
+// reports, what the hub intends to push, or what a cluster config declares.
+type IdentitySet struct {
+	AppID          int64
+	AppSlug        string
+	InstallationID int64
+	APIURL         string
+	BaseURL        string
+}
+
+// IsGHE reports whether this identity names a GitHub Enterprise forge, judged
+// on the API URL — the field that actually decides where token requests go.
+func (s IdentitySet) IsGHE() bool {
+	return strings.Contains(strings.ToLower(s.APIURL), gheAPIPathMarker)
+}
+
+// IdentitySetIssues returns human-readable descriptions of every internal
+// inconsistency in an identity set, or nil when it is coherent.
+//
+// It DETECTS and NAMES; it never mutates. Callers decide whether to refuse
+// (arming a new push) or merely report (an already-live spoke).
+//
+// It is deliberately conservative: a field that is absent is treated as
+// UNKNOWN, never as a mismatch, because the majority of the fleet legitimately
+// runs public GitHub with an empty api_url. Firing on that would make the
+// signal noise on ~48 hives and it would be ignored.
+func IdentitySetIssues(s IdentitySet) []string {
+	// No App configured: a token-auth hive has no identity to be inconsistent
+	// about.
+	if s.AppID == 0 {
+		return nil
+	}
+
+	var issues []string
+	apiIsGHE := s.IsGHE()
+	slugIsGHE := strings.Contains(strings.ToLower(s.AppSlug), "ghe")
+	baseIsGHE := s.BaseURL != "" && !strings.Contains(strings.ToLower(s.BaseURL), publicGitHubHost)
+
+	// THE LIVE REGRESSION. A GHE App presented to api.github.com returns
+	// "404 Integration not found" on every token request.
+	if slugIsGHE && !apiIsGHE {
+		issues = append(issues, "app_slug "+s.AppSlug+" names a GitHub Enterprise App but api_url is "+
+			describeAPIURL(s.APIURL)+
+			" — a GHE app_id presented to api.github.com returns 404 Integration not found")
+	}
+
+	// base_url and api_url must name the same forge. base_url is never pushed,
+	// so a mismatch here means a push moved api_url and left base_url stale
+	// (or the reverse).
+	if baseIsGHE && !apiIsGHE {
+		issues = append(issues, "base_url is "+s.BaseURL+" but api_url is "+describeAPIURL(s.APIURL)+
+			" — base_url and api_url must name the same forge")
+	}
+	if apiIsGHE && s.BaseURL != "" && !baseIsGHE {
+		issues = append(issues, "api_url is "+s.APIURL+" but base_url is "+s.BaseURL+
+			" — base_url and api_url must name the same forge")
+	}
+
+	return issues
+}
+
+// describeAPIURL renders an api_url for an operator message, making the empty
+// case explicit. An empty api_url is precisely the condition that caused the
+// outage, so it must read as a stated value rather than as a blank.
+func describeAPIURL(apiURL string) string {
+	if strings.TrimSpace(apiURL) == "" {
+		return "empty (which defaults to api.github.com)"
+	}
+	return apiURL
+}
+
+// ValidateIdentityPush reports why a queued identity must not be armed, or ""
+// when it is safe.
+//
+// This is the refusal half, and it is the guard the cluster-config push path
+// lacked. `want` is the identity the hub intends the spoke to end up with,
+// assembled from every component the push will change plus the spoke's current
+// values for the components it will not.
+//
+// Refusing here mirrors #2360's forge endpoint, which resolves the whole
+// identity up front and writes NOTHING when it cannot — an atomic refusal is
+// always preferable to a half-applied identity, because the half-applied state
+// authenticates as nothing and is invisible to the hub.
+func ValidateIdentityPush(want IdentitySet) string {
+	issues := IdentitySetIssues(want)
+	if len(issues) == 0 {
+		return ""
+	}
+	return "refusing to push an inconsistent GitHub identity: " + strings.Join(issues, "; ")
+}
+
+// pendingAppIdentityForHeartbeat returns the App config to deliver on this
+// beat, or nil when nothing is outstanding.
+//
+// It supersedes the in-memory one-shot map. The difference that matters: this
+// keeps delivering until the spoke REPORTS THE IDENTITY BACK, rather than
+// dropping the queued config on the first beat that carries it. A beat that
+// is lost, or that the spoke fails to apply, is retried; a hub restart no
+// longer discards the request.
+//
+// The in-memory map is still consulted first so anything queued by an older
+// code path in the same process is not stranded.
+func (s *HubServer) pendingAppIdentityForHeartbeat(p *HeartbeatPayload) *HeartbeatGitHubAppConfig {
+	if p == nil {
+		return nil
+	}
+	// Legacy in-memory queue takes precedence: it may carry a private key,
+	// which the durable record deliberately never stores.
+	if cfg := s.consumePendingGitHubAppConfig(p.HiveID); cfg != nil {
+		return cfg
+	}
+
+	h := loadSaaSHive(p.HiveID)
+	if h == nil || h.PendingAppConfig == nil {
+		return nil
+	}
+	pend := h.PendingAppConfig
+
+	// Confirmed? Clear the request and stop pushing. Confirmation requires the
+	// spoke to report back every component the hub asked for — this is exactly
+	// what the app_slug/installation_id read-back fields make possible.
+	if identityDelivered(pend, p) {
+		h.PendingAppConfig = nil
+		if err := saveSaaSHive(h); err != nil {
+			s.logger.Warn("identity: failed to clear delivered app config",
+				"hive_id", p.HiveID, "error", err)
+		}
+		s.logger.Info("identity: app identity delivered and confirmed by spoke",
+			"hive_id", p.HiveID, "app_id", pend.AppID, "app_slug", pend.AppSlug)
+		return nil
+	}
+
+	return &HeartbeatGitHubAppConfig{
+		AppID:          pend.AppID,
+		InstallationID: pend.InstallationID,
+		AppSlug:        pend.AppSlug,
+		// PrivateKey deliberately empty: key material is owned by the
+		// per-cluster reconcile, which gates every push on HasKey(). An empty
+		// key already means "leave the spoke's key alone", so this can never
+		// blank a working credential.
+	}
+}
+
+// identityDelivered reports whether the spoke's report matches everything the
+// hub asked for.
+//
+// Only NON-ZERO requested components are checked: a zero installation_id means
+// "leave the spoke's alone", so it is not something to confirm. An empty
+// report for a requested field is UNKNOWN — a spoke too old to report it must
+// never be treated as having confirmed, which is the silent-failure case.
+func identityDelivered(want *PendingAppIdentity, p *HeartbeatPayload) bool {
+	if want == nil || p == nil {
+		return false
+	}
+	if want.AppID != 0 && p.GitHubAppID != want.AppID {
+		return false
+	}
+	if want.AppSlug != "" && !strings.EqualFold(p.GitHubAppSlug, want.AppSlug) {
+		return false
+	}
+	if want.InstallationID != 0 && p.GitHubInstallationID != want.InstallationID {
+		return false
+	}
+	return true
+}
+
+// SpokeIdentityFromPayload assembles the identity a spoke reports it is
+// running, for drift detection.
+//
+// Before the read-back fields this could not be built: the hub received only
+// app_id and the key fingerprint, so a half-applied identity was
+// indistinguishable from a healthy one.
+func SpokeIdentityFromPayload(p *HeartbeatPayload) IdentitySet {
+	if p == nil {
+		return IdentitySet{}
+	}
+	return IdentitySet{
+		AppID:          p.GitHubAppID,
+		AppSlug:        p.GitHubAppSlug,
+		InstallationID: p.GitHubInstallationID,
+		APIURL:         p.GitHubAPIURL,
+		BaseURL:        p.GitHubBaseURL,
+	}
+}

--- a/v2/pkg/hub/identity_test.go
+++ b/v2/pkg/hub/identity_test.go
@@ -1,0 +1,230 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// GitHub identity consistency.
+//
+// The live regression these pin: a cluster-config change pushed a GHE app_id to
+// a set of hives WITHOUT api_url. The spokes ended up with a GHE App pointed at
+// api.github.com and every token request failed with
+// "404 Integration not found" on hives that had been working an hour earlier.
+//
+// The risk runs both ways, so the tests are organised that way:
+//   - failing to DETECT a split identity leaves hives broken and invisible;
+//   - firing on a healthy public-GitHub hive (empty api_url is correct there)
+//     makes the signal noise across ~48 hives and it gets ignored.
+
+// ─────────────────────────────────────────────────────────────────────────
+// DETECT: inconsistent identities must be reported
+// ─────────────────────────────────────────────────────────────────────────
+
+// TestGHESlugWithEmptyAPIURLIsDetected is the exact live failure.
+func TestGHESlugWithEmptyAPIURLIsDetected(t *testing.T) {
+	issues := IdentitySetIssues(IdentitySet{
+		AppID:   5686,
+		AppSlug: "kubestellar-hive-ghe",
+		APIURL:  "",
+	})
+	if len(issues) == 0 {
+		t.Fatal("no issues for a GHE slug with an empty api_url — this is the state " +
+			"that 404s every token request")
+	}
+	joined := strings.Join(issues, " ")
+	if !strings.Contains(joined, "api.github.com") {
+		t.Errorf("issue text %q does not explain that an empty api_url defaults to "+
+			"api.github.com, which is the cause an operator needs", joined)
+	}
+}
+
+// TestGHESlugWithPublicAPIURLIsDetected: explicitly public, not merely empty.
+func TestGHESlugWithPublicAPIURLIsDetected(t *testing.T) {
+	issues := IdentitySetIssues(IdentitySet{
+		AppID:   5686,
+		AppSlug: "kubestellar-hive-ghe",
+		APIURL:  "https://api.github.com",
+	})
+	if len(issues) == 0 {
+		t.Fatal("no issues for a GHE slug pointed at api.github.com")
+	}
+}
+
+// TestBaseURLDisagreeingWithAPIURLIsDetected covers both directions, since
+// base_url is never pushed and can be left behind by an api_url move.
+func TestBaseURLDisagreeingWithAPIURLIsDetected(t *testing.T) {
+	cases := []struct {
+		name    string
+		set     IdentitySet
+		wantSub string
+	}{
+		{
+			name:    "GHE base, public api",
+			set:     IdentitySet{AppID: 5686, BaseURL: "https://github.ibm.com", APIURL: "https://api.github.com"},
+			wantSub: "same forge",
+		},
+		{
+			name:    "GHE api, public base",
+			set:     IdentitySet{AppID: 5686, BaseURL: "https://github.com", APIURL: "https://github.ibm.com/api/v3"},
+			wantSub: "same forge",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issues := IdentitySetIssues(tc.set)
+			if len(issues) == 0 {
+				t.Fatalf("no issues for %s", tc.name)
+			}
+			if !strings.Contains(strings.Join(issues, " "), tc.wantSub) {
+				t.Errorf("issues %v do not mention %q", issues, tc.wantSub)
+			}
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// DO NOT FIRE: healthy identities must stay silent
+// ─────────────────────────────────────────────────────────────────────────
+
+// TestConsistentPublicIsClean is the majority of the fleet. Public GitHub
+// legitimately has an EMPTY api_url, so a naive "api_url must be set" check
+// would fire on ~48 hives and be ignored.
+func TestConsistentPublicIsClean(t *testing.T) {
+	if issues := IdentitySetIssues(IdentitySet{
+		AppID:   3568013,
+		AppSlug: "kubestellar-hive",
+		APIURL:  "",
+	}); len(issues) != 0 {
+		t.Errorf("a healthy public-GitHub identity reported issues: %v", issues)
+	}
+}
+
+func TestConsistentGHEIsClean(t *testing.T) {
+	if issues := IdentitySetIssues(IdentitySet{
+		AppID:   5686,
+		AppSlug: "kubestellar-hive-ghe",
+		APIURL:  "https://github.ibm.com/api/v3",
+		BaseURL: "https://github.ibm.com",
+	}); len(issues) != 0 {
+		t.Errorf("a healthy GHE identity reported issues: %v", issues)
+	}
+}
+
+// TestNoAppConfiguredIsClean: a token-auth hive has no identity to be
+// inconsistent about.
+func TestNoAppConfiguredIsClean(t *testing.T) {
+	if issues := IdentitySetIssues(IdentitySet{APIURL: "https://github.ibm.com/api/v3"}); len(issues) != 0 {
+		t.Errorf("a hive with no App reported identity issues: %v", issues)
+	}
+}
+
+// TestSilenceIsNotAMismatch: a spoke too old to report app_slug/base_url must
+// read as UNKNOWN, never as a split identity. Inferring breakage from silence
+// is exactly the silent-failure class this work exists to end.
+func TestSilenceIsNotAMismatch(t *testing.T) {
+	if issues := IdentitySetIssues(IdentitySet{AppID: 5686}); len(issues) != 0 {
+		t.Errorf("an under-reporting spoke was flagged as inconsistent: %v", issues)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// REFUSE: an inconsistent push must not be armed
+// ─────────────────────────────────────────────────────────────────────────
+
+// TestValidateIdentityPushRefusesSplit is the guard the cluster-config path
+// lacked. #2360's forge endpoint already refuses rather than half-applies.
+func TestValidateIdentityPushRefusesSplit(t *testing.T) {
+	reason := ValidateIdentityPush(IdentitySet{
+		AppID:   5686,
+		AppSlug: "kubestellar-hive-ghe",
+		APIURL:  "",
+	})
+	if reason == "" {
+		t.Fatal("ValidateIdentityPush allowed a GHE App with an empty api_url — " +
+			"the push that broke live hives")
+	}
+	if !strings.Contains(reason, "refusing") {
+		t.Errorf("reason %q should state that the push is refused", reason)
+	}
+}
+
+func TestValidateIdentityPushAllowsConsistent(t *testing.T) {
+	if reason := ValidateIdentityPush(IdentitySet{
+		AppID:   5686,
+		AppSlug: "kubestellar-hive-ghe",
+		APIURL:  "https://github.ibm.com/api/v3",
+		BaseURL: "https://github.ibm.com",
+	}); reason != "" {
+		t.Errorf("a consistent GHE push was refused: %s", reason)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// CONFIRM: delivery is only complete when the spoke reports the set back
+// ─────────────────────────────────────────────────────────────────────────
+
+// TestIdentityDeliveredRequiresFullMatch: before the app_slug/installation_id
+// read-back fields, these components were structurally unconfirmable — the hub
+// could push them and never learn whether they landed.
+func TestIdentityDeliveredRequiresFullMatch(t *testing.T) {
+	want := &PendingAppIdentity{AppID: 5686, AppSlug: "kubestellar-hive-ghe", InstallationID: 99}
+
+	if identityDelivered(want, &HeartbeatPayload{GitHubAppID: 5686}) {
+		t.Error("delivery confirmed on app_id alone; the slug and installation id " +
+			"were never reported and may not have landed")
+	}
+	if identityDelivered(want, &HeartbeatPayload{
+		GitHubAppID: 5686, GitHubAppSlug: "kubestellar-hive-ghe",
+	}) {
+		t.Error("delivery confirmed without the installation id being reported back")
+	}
+	if !identityDelivered(want, &HeartbeatPayload{
+		GitHubAppID: 5686, GitHubAppSlug: "kubestellar-hive-ghe", GitHubInstallationID: 99,
+	}) {
+		t.Error("a spoke reporting the complete requested identity was not accepted")
+	}
+}
+
+// TestIdentityDeliveredIgnoresUnrequestedFields: a zero installation_id means
+// "leave the spoke's alone", so it is not something to confirm. Requiring it
+// would leave the latch armed forever.
+func TestIdentityDeliveredIgnoresUnrequestedFields(t *testing.T) {
+	want := &PendingAppIdentity{AppID: 5686, AppSlug: "kubestellar-hive-ghe"}
+	if !identityDelivered(want, &HeartbeatPayload{
+		GitHubAppID: 5686, GitHubAppSlug: "kubestellar-hive-ghe", GitHubInstallationID: 12345,
+	}) {
+		t.Error("an unrequested installation id blocked confirmation")
+	}
+}
+
+// TestIdentityDeliveredSlugIsCaseInsensitive: GitHub slugs are case-insensitive,
+// so a case difference must not hold the delivery open forever.
+func TestIdentityDeliveredSlugIsCaseInsensitive(t *testing.T) {
+	want := &PendingAppIdentity{AppID: 5686, AppSlug: "KubeStellar-Hive-GHE"}
+	if !identityDelivered(want, &HeartbeatPayload{
+		GitHubAppID: 5686, GitHubAppSlug: "kubestellar-hive-ghe",
+	}) {
+		t.Error("a case-different slug was treated as unconfirmed")
+	}
+}
+
+// TestSpokeIdentityFromPayloadCarriesTheWholeSet: without this the hub cannot
+// see a half-applied identity at all.
+func TestSpokeIdentityFromPayloadCarriesTheWholeSet(t *testing.T) {
+	got := SpokeIdentityFromPayload(&HeartbeatPayload{
+		GitHubAppID:          5686,
+		GitHubAppSlug:        "kubestellar-hive-ghe",
+		GitHubInstallationID: 146551814,
+		GitHubAPIURL:         "",
+		GitHubBaseURL:        "",
+	})
+	if got.AppID != 5686 || got.AppSlug != "kubestellar-hive-ghe" || got.InstallationID != 146551814 {
+		t.Fatalf("identity not carried through: %+v", got)
+	}
+	// And that reconstructed set must be recognised as broken — this is the
+	// live state of the affected hives.
+	if len(IdentitySetIssues(got)) == 0 {
+		t.Error("the reconstructed live-broken identity was not flagged")
+	}
+}

--- a/v2/pkg/hub/pending_identity_carries_urls_test.go
+++ b/v2/pkg/hub/pending_identity_carries_urls_test.go
@@ -1,0 +1,59 @@
+package hub
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// TestPendingIdentityCarriesTheForgeURLs pins that the DURABLE pending record
+// delivers a complete identity set, not just the App half.
+//
+// The record stored APIURL from the moment it was introduced and never sent it,
+// and had no BaseURL field at all. So a forge switch — the operation this record
+// exists to make reliable — delivered a new app_id while the spoke kept its
+// previous api_url/base_url: "404 Integration not found", the exact half-set
+// that took 26 hives down on 2026-07-31.
+func TestPendingIdentityCarriesTheForgeURLs(t *testing.T) {
+	oldHives := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = oldHives })
+
+	// A hive being switched from GHE to public github.com.
+	h := &SaaSHive{
+		ID:        "switching-hive",
+		ClusterID: "vllm-d",
+		PendingAppConfig: &PendingAppIdentity{
+			AppID:          config.PublicGitHubAppID,
+			AppSlug:        config.PublicGitHubAppSlug,
+			InstallationID: 148549259,
+			APIURL:         config.DefaultGitHubAPIURL,
+			BaseURL:        config.DefaultGitHubBaseURL,
+			Reason:         "forge switch to github.com",
+		},
+	}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &HubServer{logger: appKeyTestLogger()}
+
+	// The spoke still reports its OLD GHE identity — nothing confirmed yet.
+	got := s.pendingAppIdentityForHeartbeat(&HeartbeatPayload{
+		HiveID:      "switching-hive",
+		GitHubAppID: config.EnterpriseGitHubAppID,
+	})
+	if got == nil {
+		t.Fatal("no identity pushed for an unconfirmed pending record")
+	}
+	if got.APIURL == "" || got.BaseURL == "" {
+		t.Fatalf("the App was sent WITHOUT its forge urls (api=%q base=%q) — the spoke would pair it with the GHE urls it already has",
+			got.APIURL, got.BaseURL)
+	}
+	// What is sent must itself be a coherent set.
+	if err := config.RejectIdentitySet(config.GitHubConfig{
+		AppID: got.AppID, AppSlug: got.AppSlug, APIURL: got.APIURL, BaseURL: got.BaseURL,
+	}); err != nil {
+		t.Fatalf("the pending record emitted an inconsistent set: %v", err)
+	}
+}

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -480,6 +480,29 @@ type SaaSHive struct {
 	// ForgeDelivered flips true once the spoke reports the requested forge host.
 	ForgeDelivered bool `json:"forge_delivered,omitempty"`
 
+	// PendingAppConfig is a GitHub App identity queued for delivery to the
+	// spoke over the heartbeat.
+	//
+	// WHY IT IS PERSISTED HERE RATHER THAN HELD IN MEMORY
+	//
+	// This delivery used to live only in HubServer.pendingGitHubAppConfigs, an
+	// in-memory map drained with delete() on the first beat that carried it. It
+	// had two failure modes with no diagnosis path:
+	//
+	//   - a hub restart between arming and the next beat lost the push
+	//     silently, and nothing anywhere recorded that an identity change had
+	//     been requested; and
+	//   - being one-shot, a spoke that missed or failed to apply that single
+	//     beat never got another.
+	//
+	// Persisting it to meta.json makes an outstanding identity change durable
+	// and inspectable — the same reason RequestedACMMLevel and
+	// RequestedGitHubHost live here rather than in memory.
+	//
+	// nil means nothing is queued. It is CLEARED on confirmation, not on
+	// delivery (see AppIdentityDelivered), so a lost beat is retried.
+	PendingAppConfig *PendingAppIdentity `json:"pending_app_config,omitempty"`
+
 	Error           string                 `json:"error,omitempty"`
 	AutoUpgrade     bool                   `json:"auto_upgrade"`
 	IsPublic        bool                   `json:"is_public"`

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -189,7 +189,21 @@ type RegistryEntry struct {
 	// cannot be silenced by a stale spoke.
 	//
 	// Zero means "not reported", never "no App".
-	GitHubAppID               int64     `json:"githubAppId,omitempty"`
+	GitHubAppID int64 `json:"githubAppId,omitempty"`
+	// GitHubAppSlug, GitHubInstallationID, GitHubAPIURL and GitHubBaseURL
+	// complete the hub's picture of the identity the spoke is RUNNING.
+	//
+	// They are carried here for the same reason GitHubAppID is: a hub-observed
+	// fact cannot be silenced by a stale or too-old spoke. Together they make a
+	// half-applied identity detectable — a GHE app_id with an empty api_url
+	// authenticates as nothing and 404s on every token request, and with only
+	// app_id reported it looked exactly like a healthy delivery.
+	//
+	// Zero/empty means "not reported", never "not configured".
+	GitHubAppSlug             string    `json:"githubAppSlug,omitempty"`
+	GitHubInstallationID      int64     `json:"githubInstallationId,omitempty"`
+	GitHubAPIURL              string    `json:"githubApiUrl,omitempty"`
+	GitHubBaseURL             string    `json:"githubBaseUrl,omitempty"`
 	PendingGitHubAppInstall   bool      `json:"pendingGitHubAppInstall,omitempty"`
 	PendingGitHubAppInstallAt time.Time `json:"pendingGitHubAppInstallAt,omitempty"`
 	// Fleet contribution counts reported by the spoke (nil = not reported /
@@ -1018,6 +1032,10 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		GitHubAppPermIssue:      sanitizeHeartbeatField(payload.GitHubAppPermIssue),
 		GitHubAppState:          sanitizeHeartbeatField(payload.GitHubAppState),
 		GitHubAppID:             payload.GitHubAppID,
+		GitHubAppSlug:           payload.GitHubAppSlug,
+		GitHubInstallationID:    payload.GitHubInstallationID,
+		GitHubAPIURL:            payload.GitHubAPIURL,
+		GitHubBaseURL:           payload.GitHubBaseURL,
 		PendingGitHubAppInstall: payload.PendingGitHubAppInstall,
 		PendingGitHubAppInstallAt: func() time.Time {
 			if payload.PendingGitHubAppInstall {
@@ -1442,7 +1460,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		)
 	}
 
-	if ghCfg := s.consumePendingGitHubAppConfig(payload.HiveID); ghCfg != nil {
+	if ghCfg := s.pendingAppIdentityForHeartbeat(&payload); ghCfg != nil {
 		resp.GitHubAppConfig = ghCfg
 		s.logger.Info("heartbeat: delivering github app config to spoke",
 			"hive_id", payload.HiveID,


### PR DESCRIPTION
Prerequisite for the generalised `DeliveryLatch` (#2372 follow-up), and the fix for a live outage. Independent of #2370, #2374, #2377.

## The regression

A GitHub App identity is an **atomic set** — `app_id`, `app_slug`, `api_url`, `base_url` must all name the same forge. A cluster-config change pushed a GHE `app_id` to a set of hives **without** `api_url`:

```
app_id:  5686   <- the GHE App
api_url: ""     <- empty, so it defaults to api.github.com
```

Every token request then failed on hives that had been working an hour earlier:

```
POST https://api.github.com/app/installations/146551814/access_tokens
404 Integration not found
```

The hives that also received `api_url: https://github.ibm.com/api/v3` were fine — **the failure split exactly on that one field.**

**Nothing detected it.** The hub received back only `app_id` and a key fingerprint, so a half-applied identity was indistinguishable from a healthy delivery. The first symptom was a user noticing their agents had stopped.

## Three changes, in the order they unblock each other

### 1. Read-back — `app_slug` and `installation_id` were structurally unconfirmable

The spoke now reports `app_slug`, `installation_id` and `base_url` alongside `app_id`. Before this, the hub could push a slug and **never learn whether it landed** — not "didn't check", but *could not*. That alone made any delivery guarantee over these fields impossible.

`base_url` is reported but still never pushed: the spoke derives its host from `base_url` with a fallback to `api_url` (`HostLabel`), so pushing `api_url` alone moves a hive between forges. It is reported so the hub can see the **whole** set.

### 2. Durable delivery — a hub restart silently lost identity pushes

The pending App identity moves off `HubServer.pendingGitHubAppConfigs` — an in-memory map drained with `delete()` on the first beat — onto `SaaSHive.PendingAppConfig` in `meta.json`.

Two failure modes are closed: a hub restart between arming and the next beat lost the push with **no record anywhere** that a change had been requested; and being one-shot, a spoke that missed or failed to apply that single beat never got another.

It is now cleared on **confirmation**, not on delivery — which is only expressible because of change 1.

The legacy in-memory queue is still consulted first, since it may carry a private key that the durable record deliberately never stores.

### 3. Consistency — refuse to arm, and surface what is already broken

`ValidateIdentityPush` refuses an inconsistent identity, mirroring #2360's forge endpoint, which already resolves the whole set up front and 409s rather than half-applying. A new `identity-split` drift signal (critical, operator-side) surfaces hives **already** in the broken state.

## Why NOT a set-valued delivery latch

The brief asked for one. It does not fit, and forcing it would be worse than the status quo:

| Field | Payload | Gating |
|---|---|---|
| `api_url` | `HeartbeatProjectConfig` | forge latch |
| `app_id`, `app_slug`, `installation_id` | `HeartbeatGitHubAppConfig` | per-cluster key reconcile |
| `base_url` | **never pushed** | — |

A single `Requested`/`Delivered` pair spanning two independently-gated payloads plus a field with no channel would report "delivered" while half the identity was still in flight — an invented coupling that doesn't exist in the transport, which *looks* authoritative. So the guarantee is provided where it can be: **refuse to arm an inconsistent push, detect an inconsistent state.** That yields the atomicity property without pretending three transports are one.

## Tests

**17 new tests**, organised by the direction of risk, because it runs both ways:

**Must detect** — GHE slug with empty `api_url` (the live failure), GHE slug with explicit public `api_url`, `base_url`/`api_url` disagreement in both directions, refusal to arm, and the reconstructed live-broken identity from a payload.

**Must stay silent** — healthy public GitHub (an empty `api_url` is *correct* there; firing would raise a critical signal on ~48 hives and be ignored), healthy GHE, token-auth hives, and **a spoke too old to report the new fields**. Silence must read as UNKNOWN, never as a mismatch — inferring breakage from silence is the exact failure class this work exists to end.

**Confirmation** — requires every requested component reported back; ignores unrequested ones (a zero `installation_id` means "leave alone", so requiring it would leave the latch armed forever); slug matching is case-insensitive, since GitHub slugs are.

**Mutation-verified — 5 mutations, all caught:**

| Mutation | Caught by |
|---|---|
| Consistency check disabled | 4 tests |
| Slug/api mismatch undetected (the live bug) | `TestGHESlugWithEmptyAPIURLIsDetected`, `TestValidateIdentityPushRefusesSplit`, `TestDriftFlagsHalfAppliedIdentity` |
| Check fires on healthy public hives | `TestConsistentPublicIsClean`, `TestSilenceIsNotAMismatch`, 2 drift tests |
| Delivery confirmed on `app_id` alone | `TestIdentityDeliveredRequiresFullMatch` |
| Drift signal downgraded from critical | `TestDriftFlagsHalfAppliedIdentity` |

Sources restored and green after each.

### One existing test updated, deliberately

`TestSwitchForgeSwapsTheWholeIdentity` (#2360) read the queued identity from the in-memory map. It now reads `PendingAppConfig` **after reloading the hive from disk**, so it additionally proves durable persistence. Every original assertion is preserved; the `PrivateKey` assertion is replaced by a stronger structural guarantee — `PendingAppIdentity` has no key field, so the endpoint cannot push key material even by mistake. A new assertion pins `api_url` into the queued set.

`go build ./...`, `go vet`, `gofmt` clean. Full `pkg/hub` (50s) and `cmd/hive` suites pass.

`pkg/hub/saas.go` and `static/index.html` **untouched** — no raw-string or embedded-JS risk.

## Live systems

**Strictly read-only. No hive was repaired.** The ~7 affected hives are deliberately untouched: the repair is a separate, authorised step, and the point of this PR is that it will be *verifiable* when it happens — the drift signal names the broken hives, and delivery now confirms rather than assumes.

## Follow-ups

- The `DeliveryLatch` consolidation itself, with `ClaimDelivered`/ACMM/forge as instances plus `is_public`, and #2372 made structurally impossible.
- **The OR-ed dispatch at `saas.go:5951` is deliberately left as-is**: all three latches share one return value, and `Org`/`Repos`/`ACMMLevel` lack `omitempty`, so a forge-only push currently ships them too. Splitting it changes what goes on the wire and needs the spoke's partial-struct handling verified on both ends first.
- `AutoUpgrade` was investigated as a fourth latch and **ruled out**: the hub acts on it directly via `kubectl rollout restart`, and `HeartbeatPayload.AutoUpgrade` is the spoke's own independent setting that merely shares a name. There is no drift to close.
