### PR TITLE
✨ feat(forge): per-hive forge election with dual-forge cluster identity

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1255,6 +1255,21 @@ type GitHubConfig struct {
 	KeyFile            string `yaml:"key_file"`
 	Token              string `yaml:"token"`
 	OAuthClientID      string `yaml:"oauth_client_id"`
+	// Forge_ names the GitHub instance this hive's App and repos live on, as a
+	// bare host: "github.com" or "github.ibm.com". It is the SINGLE
+	// AUTHORITATIVE identity field — app_id, app_slug, api_url and base_url are
+	// all derivable from it (see Forge, ResolvedAppID, forgeIdentities).
+	//
+	// Read it through the Forge() method, never directly: Forge() applies the
+	// dual-read fallback that keeps a not-yet-backfilled spoke resolving exactly
+	// as it does today. The trailing underscore exists solely because the method
+	// owns the good name; the YAML key is a clean `forge`.
+	//
+	// Empty is valid during the migration window and means "infer from the URL
+	// fields". Once the fleet is backfilled it becomes mandatory — per the
+	// owner: explicitly defined on every spoke on every cluster, no empties, no
+	// inheritance. The implicit empty is what disguised the 2026-07-31 damage.
+	Forge_ string `yaml:"forge,omitempty"`
 	// AppSlug is the GitHub App URL slug for the install link.
 	// For public GitHub: "kubestellar-hive". For GHE: your app's slug.
 	AppSlug string `yaml:"app_slug"`
@@ -1314,6 +1329,191 @@ const (
 	// still sign in with a github.com identity. No secret; safe to hardcode.
 	DefaultOAuthClientID = "Ov23ligE2p0gjXg6xAUf"
 )
+
+// ─────────────────────────────────────────────────────────────────────────
+// FORGE IDENTITY CONSTANTS
+//
+// A "forge" is the GitHub instance a hive's App and repos live on. Every
+// identity value below is derived from the forge — never written independently
+// — so the mixed states that broke seven hives on 2026-07-31 (a GHE app_id
+// beside an empty, therefore-public api_url) cannot be constructed.
+//
+// These are the SPOKE-side well-known defaults. The hub carries the
+// authoritative per-cluster registration in clusters.json, which may name a
+// different App on either forge; these values are what a spoke falls back to
+// when the hub has pushed nothing.
+// ─────────────────────────────────────────────────────────────────────────
+const (
+	// ForgePublic is the canonical host label for public github.com. It is a
+	// HOSTNAME, not a URL and not a sentinel word — unlike the hub's legacy
+	// "public" request sentinel, it is directly comparable to HostLabel().
+	ForgePublic = "github.com"
+
+	// ForgeGHEIBM is the IBM GitHub Enterprise host. It is the only GHE forge
+	// the fleet currently runs on; naming it as a constant keeps the derivation
+	// table literal-free and makes a second GHE forge a one-line addition.
+	ForgeGHEIBM = "github.ibm.com"
+)
+
+// forgeIdentity is the complete, indivisible identity set for one forge. The
+// four fields move together or not at all — that atomicity is the entire point
+// of deriving them from a single `forge` value.
+type forgeIdentity struct {
+	AppID   int64
+	AppSlug string
+	APIURL  string
+	BaseURL string
+}
+
+// Forge identity values.
+//
+// PublicGitHubAppID/PublicGitHubAppSlug and the Enterprise* set are declared
+// once, in provenance.go, alongside the rules that validate them — a second
+// declaration of the same literal is exactly the drift those rules exist to
+// catch. The GHEIBM* names below are aliases so the derivation table reads in
+// forge terms without duplicating any value.
+const (
+	// GHEIBMAppID is the github.ibm.com Hive App's numeric ID.
+	GHEIBMAppID = EnterpriseGitHubAppID
+	// GHEIBMAppSlug is the github.ibm.com Hive App's URL slug. A GHE instance
+	// hosts its own App registration and it is NOT named "kubestellar-hive";
+	// falling back to the public slug builds an install link that 404s.
+	GHEIBMAppSlug = EnterpriseGitHubAppSlug
+	// GHEIBMBaseURL is the github.ibm.com web base URL.
+	GHEIBMBaseURL = EnterpriseGitHubBaseURL
+	// GHEIBMAPIURL is the github.ibm.com REST API root. GHE serves its API
+	// under /api/v3 rather than on a separate api.* hostname.
+	GHEIBMAPIURL = EnterpriseGitHubAPIURL
+)
+
+// forgeIdentities is the derivation table: forge host -> its complete identity
+// set. This is the single source of truth that replaces four independently
+// writable fields. Adding a forge means adding a row here; there is no way to
+// express a half-identity.
+var forgeIdentities = map[string]forgeIdentity{
+	ForgePublic: {
+		AppID:   PublicGitHubAppID,
+		AppSlug: PublicGitHubAppSlug,
+		// Empty, not DefaultGitHubAPIURL/DefaultGitHubBaseURL: the public forge's
+		// canonical on-disk representation has ALWAYS been the empty string, and
+		// ResolvedAPIURL/ResolvedBaseURL already map empty -> the public default.
+		// Storing the URLs literally here would make the migration a visible
+		// rewrite of every healthy public spoke's config rather than a no-op.
+		APIURL:  "",
+		BaseURL: "",
+	},
+	ForgeGHEIBM: {
+		AppID:   GHEIBMAppID,
+		AppSlug: GHEIBMAppSlug,
+		APIURL:  GHEIBMAPIURL,
+		BaseURL: GHEIBMBaseURL,
+	},
+}
+
+// KnownForge reports whether host names a forge with a known identity set.
+// An unknown forge is not an error — a hive may legitimately run against a
+// third GHE instance the table does not name — but its identity cannot be
+// DERIVED, so explicit fields remain load-bearing there.
+func KnownForge(host string) bool {
+	_, ok := forgeIdentities[normalizeForgeHost(host)]
+	return ok
+}
+
+// normalizeForgeHost reduces any spelling of a forge — bare host, web URL, API
+// URL, mixed case, trailing slash — to its canonical bare-host label.
+func normalizeForgeHost(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	s = strings.TrimSuffix(strings.Trim(s, "/"), "/api/v3")
+	host := strings.SplitN(s, "/", 2)[0]
+	if host == "" || host == "api.github.com" {
+		return ForgePublic
+	}
+	return host
+}
+
+// Forge returns the forge this hive's App and repos live on, as a bare host
+// label ("github.com", "github.ibm.com").
+//
+// PRECEDENCE — and this is the whole design in three lines:
+//
+//  1. An explicit `forge:` wins. It is the single authoritative field.
+//  2. Otherwise infer from the legacy URL fields via HostLabel()/IsGHE().
+//  3. Empty everything means public github.com, as it always has.
+//
+// Step 2 is the DUAL-READ WINDOW. Until every spoke carries `forge:`, a spoke
+// that has not been backfilled must resolve exactly as it does today — so this
+// never returns anything a pre-migration hive would not already have resolved.
+func (g GitHubConfig) Forge() string {
+	if f := strings.TrimSpace(g.Forge_); f != "" {
+		return normalizeForgeHost(f)
+	}
+	return normalizeForgeHost(g.HostLabel())
+}
+
+// ResolvedAppID returns the GitHub App ID for this hive, completing the
+// resolver set alongside ResolvedAPIURL/ResolvedBaseURL/ResolvedAppSlug.
+//
+// An explicitly configured app_id wins — including the placeholder sentinel,
+// which callers detect with IsPlaceholderApp() and must keep seeing. Only when
+// app_id is unset is it derived from the forge, which is what lets a hive be
+// described by `forge:` alone.
+func (g GitHubConfig) ResolvedAppID() int64 {
+	if g.AppID != 0 {
+		return g.AppID
+	}
+	if id, ok := forgeIdentities[g.Forge()]; ok {
+		return id.AppID
+	}
+	return 0
+}
+
+// ForgeIdentityMismatches reports every identity field that CONTRADICTS this
+// hive's forge. Empty means the identity set is coherent.
+//
+// This is the check that would have caught the 2026-07-31 incident at the
+// write boundary. It differs from IdentitySetIssues in the way that matters:
+// IdentitySetIssues compares the four fields against EACH OTHER, so it is blind
+// whenever the pushed value is the only GHE-looking field present (a GHE app_id
+// beside a public slug and empty URLs produces no disagreement at all — verified).
+// This compares each field against the DECLARED forge, which is an external
+// anchor the pusher does not control.
+//
+// A field that is empty is not a mismatch: empty means "derive me".
+func (g GitHubConfig) ForgeIdentityMismatches() []string {
+	forge := g.Forge()
+	want, known := forgeIdentities[forge]
+	if !known {
+		// A forge outside the table has no derivable identity to compare
+		// against. Reporting mismatches here would flag every legitimate
+		// third-forge hive; saying nothing keeps explicit fields authoritative
+		// exactly where they still need to be.
+		return nil
+	}
+	var out []string
+	// app_id is compared only when a REAL App is configured. The placeholder
+	// sentinel means "no App yet" and legitimately appears on both forges.
+	if g.AppID != 0 && !g.IsPlaceholderApp() && g.AppID != want.AppID {
+		out = append(out, fmt.Sprintf(
+			"app_id %d does not belong to forge %s (expected %d) — an App ID from another forge returns 404 Integration not found on token creation",
+			g.AppID, forge, want.AppID))
+	}
+	if s := strings.TrimSpace(g.AppSlug); s != "" && !strings.EqualFold(s, want.AppSlug) {
+		out = append(out, fmt.Sprintf(
+			"app_slug %q does not belong to forge %s (expected %q) — the App install link would 404",
+			s, forge, want.AppSlug))
+	}
+	if u := strings.TrimSpace(g.APIURL); u != "" && normalizeForgeHost(u) != forge {
+		out = append(out, fmt.Sprintf(
+			"api_url %q names forge %s, not %s", u, normalizeForgeHost(u), forge))
+	}
+	if u := strings.TrimSpace(g.BaseURL); u != "" && normalizeForgeHost(u) != forge {
+		out = append(out, fmt.Sprintf(
+			"base_url %q names forge %s, not %s", u, normalizeForgeHost(u), forge))
+	}
+	return out
+}
 
 // IsPlaceholderApp reports whether app_id is the "no real App yet" sentinel.
 func (g GitHubConfig) IsPlaceholderApp() bool {
@@ -1446,10 +1646,19 @@ func (g GitHubConfig) OAuthClientIDResolved() string {
 	return DefaultOAuthClientID
 }
 
-// ResolvedAppSlug returns the configured app slug or the default public Hive app slug.
+// ResolvedAppSlug returns the app slug for this hive: the configured value,
+// else the slug DERIVED from the forge, else the public default.
+//
+// The forge step is what stops a GHE hive that names only `forge:` from falling
+// back to "kubestellar-hive" — a slug that names no App on GHE and builds an
+// install link that 404s. That 404 is the failure this whole design exists to
+// make unrepresentable, so the derivation belongs here rather than at call sites.
 func (g GitHubConfig) ResolvedAppSlug() string {
 	if g.AppSlug != "" {
 		return g.AppSlug
+	}
+	if id, ok := forgeIdentities[g.Forge()]; ok && id.AppSlug != "" {
+		return id.AppSlug
 	}
 	return DefaultGitHubAppSlug
 }
@@ -1508,7 +1717,7 @@ func (g GitHubConfig) AppAuthoredPRsEnabled() bool {
 //
 // It returns "" for a GitHub Enterprise host whose App slug is not configured.
 //
-// WHY EMPTY RATHER THAN A BEST-EFFORT URL
+// # WHY EMPTY RATHER THAN A BEST-EFFORT URL
 //
 // DefaultGitHubAppSlug ("kubestellar-hive") names the App registered on PUBLIC
 // github.com. GitHub Enterprise hosts a SEPARATE App registry, and an enterprise
@@ -2452,8 +2661,20 @@ func (c *Config) validate() error {
 	// Deliberately a bare zero-test, NOT HasApp(): PlaceholderAppID exists
 	// precisely so a hive awaiting its real App can satisfy this check and boot
 	// into dashboard-only mode. Everywhere else, use HasApp().
-	if c.GitHub.Token == "" && c.GitHub.AppID == 0 {
-		return fmt.Errorf("github.token or github.app_id is required")
+	// A hive described by `forge:` alone satisfies this too: ResolvedAppID()
+	// derives a real App ID from a known forge, so the identity is present even
+	// though app_id is not written down. Without this, the end state of this
+	// design — one field naming the forge, the rest derived — fails validation
+	// and the spoke will not boot.
+	// An EXPLICIT `forge:` satisfies this too: ResolvedAppID() derives a real
+	// App ID from a known forge, so the identity is present even though app_id
+	// is not written down. Deliberately keyed on Forge_ (the raw field) and not
+	// Forge() — Forge() INFERS public for a blank config, which would make an
+	// empty github block validate and silently boot a hive with no credentials
+	// at all. Only a forge the operator actually wrote counts.
+	if c.GitHub.Token == "" && c.GitHub.AppID == 0 &&
+		!(strings.TrimSpace(c.GitHub.Forge_) != "" && c.GitHub.ResolvedAppID() != 0) {
+		return fmt.Errorf("github.token, github.app_id or github.forge is required")
 	}
 	if err := c.Governor.LiteLLM.Validate(); err != nil {
 		return err

--- a/v2/pkg/config/forge_identity_test.go
+++ b/v2/pkg/config/forge_identity_test.go
@@ -1,0 +1,320 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestForgeDerivationIsByteExactWithTodaysDefaults is the migration's no-op
+// proof. A healthy public hive that gains `forge: github.com` must resolve to
+// EXACTLY the values it resolves to today with every field empty — if these
+// drift by a byte, the migration silently rewrites every healthy spoke.
+func TestForgeDerivationIsByteExactWithTodaysDefaults(t *testing.T) {
+	today := GitHubConfig{} // today's healthy public spoke: everything implicit
+	migrated := GitHubConfig{Forge_: ForgePublic}
+
+	if got, want := migrated.ResolvedAPIURL(), today.ResolvedAPIURL(); got != want {
+		t.Errorf("api_url: migrated %q != today %q", got, want)
+	}
+	if got, want := migrated.ResolvedBaseURL(), today.ResolvedBaseURL(); got != want {
+		t.Errorf("base_url: migrated %q != today %q", got, want)
+	}
+	if got, want := migrated.ResolvedAppSlug(), today.ResolvedAppSlug(); got != want {
+		t.Errorf("app_slug: migrated %q != today %q", got, want)
+	}
+	// And those values are the documented constants, pinned literally so a
+	// change to the defaults cannot pass by moving both sides together.
+	if got := migrated.ResolvedAPIURL(); got != "https://api.github.com" {
+		t.Errorf("api_url = %q, want https://api.github.com", got)
+	}
+	if got := migrated.ResolvedBaseURL(); got != "https://github.com" {
+		t.Errorf("base_url = %q, want https://github.com", got)
+	}
+	if got := migrated.ResolvedAppSlug(); got != "kubestellar-hive" {
+		t.Errorf("app_slug = %q, want kubestellar-hive", got)
+	}
+	if migrated.IsGHE() {
+		t.Error("a github.com hive must not report IsGHE")
+	}
+}
+
+// TestForgeIdentityAllSixteenCombinations is the test whose absence allowed the
+// 2026-07-31 incident. The four identity fields have two valid settings each
+// (public-shaped or GHE-shaped); of the 16 combinations exactly 2 are coherent
+// and 14 are mixed forges that must be reported.
+//
+// The forge under test is declared EXPLICITLY on each case rather than inferred,
+// because inference is what the incident exploited: with `forge` absent, an
+// empty api_url reads as "unset" instead of "public", and the mixture becomes
+// invisible. Anchoring against a declared forge is the whole fix.
+func TestForgeIdentityAllSixteenCombinations(t *testing.T) {
+	type variant struct {
+		appID   int64
+		appSlug string
+		apiURL  string
+		baseURL string
+	}
+	pub := variant{PublicGitHubAppID, PublicGitHubAppSlug, "", ""}
+	ghe := variant{GHEIBMAppID, GHEIBMAppSlug, GHEIBMAPIURL, GHEIBMBaseURL}
+
+	// isGHE[i] selects which forge's value each of the 4 fields takes.
+	for mask := 0; mask < 16; mask++ {
+		appIDGHE := mask&1 != 0
+		slugGHE := mask&2 != 0
+		apiGHE := mask&4 != 0
+		baseGHE := mask&8 != 0
+
+		pick := func(useGHE bool, p, g string) string {
+			if useGHE {
+				return g
+			}
+			return p
+		}
+		gh := GitHubConfig{
+			AppSlug: pick(slugGHE, pub.appSlug, ghe.appSlug),
+			APIURL:  pick(apiGHE, pub.apiURL, ghe.apiURL),
+			BaseURL: pick(baseGHE, pub.baseURL, ghe.baseURL),
+		}
+		if appIDGHE {
+			gh.AppID = ghe.appID
+		} else {
+			gh.AppID = pub.appID
+		}
+
+		// Declare the forge the set CLAIMS to be on: GHE if any field carries a
+		// GHE value, else public. This is the anchor the pusher does not control.
+		forge := ForgePublic
+		if appIDGHE || slugGHE || apiGHE || baseGHE {
+			forge = ForgeGHEIBM
+		}
+		gh.Forge_ = forge
+
+		// COHERENCE RULE. The public forge's URL fields are the EMPTY STRING —
+		// that is its canonical on-disk representation (see forgeIdentities).
+		// Empty means "derive me from the forge", NOT "public", so an empty URL
+		// beside a GHE declaration is an unset field awaiting derivation rather
+		// than a contradiction. Only a field that NAMES the wrong forge is a
+		// mismatch.
+		//
+		// This is deliberate, and it is what keeps the migration a no-op:
+		// requiring every URL to be populated would flag the ~41 fleet spokes
+		// running on implicit empty URLs.
+		coherent := false
+		if forge == ForgePublic {
+			// Every field took its public value, and for the URLs that is empty.
+			coherent = true
+		} else {
+			// On GHE, app_id and app_slug must both be the GHE ones (they have no
+			// "unset" spelling here — the public value is a real, wrong value).
+			// The URLs may be GHE-valued or empty.
+			coherent = appIDGHE && slugGHE
+		}
+
+		issues := gh.ForgeIdentityMismatches()
+		if coherent && len(issues) != 0 {
+			t.Errorf("mask %04b (coherent on %s) was rejected: %v\n  config: %+v",
+				mask, forge, issues, gh)
+		}
+		if !coherent && len(issues) == 0 {
+			t.Errorf("mask %04b is a MIXED forge set on declared forge %s and was ACCEPTED: %+v",
+				mask, forge, gh)
+		}
+	}
+}
+
+// TestForgeURLFieldsMustMatchDeclaredForge covers the case the 16-combination
+// table structurally CANNOT reach.
+//
+// In that table the declared forge is inferred from the fields, so a GHE URL
+// always makes the forge GHE and can never contradict it — the api_url/base_url
+// checks are unreachable there. (Confirmed by mutation: deleting both checks
+// left the table green.) The contradiction only exists when the forge is
+// declared INDEPENDENTLY of the URLs, which is precisely what `forge:` makes
+// possible and what a stale URL surviving a forge move looks like.
+func TestForgeURLFieldsMustMatchDeclaredForge(t *testing.T) {
+	cases := []struct {
+		name      string
+		gh        GitHubConfig
+		wantField string
+	}{
+		{
+			// A hive moved to public github.com whose GHE api_url was left behind.
+			name: "stale GHE api_url on a public hive",
+			gh: GitHubConfig{
+				Forge_: ForgePublic, AppID: PublicGitHubAppID,
+				AppSlug: PublicGitHubAppSlug, APIURL: GHEIBMAPIURL,
+			},
+			wantField: "api_url",
+		},
+		{
+			name: "stale GHE base_url on a public hive",
+			gh: GitHubConfig{
+				Forge_: ForgePublic, AppID: PublicGitHubAppID,
+				AppSlug: PublicGitHubAppSlug, BaseURL: GHEIBMBaseURL,
+			},
+			wantField: "base_url",
+		},
+		{
+			// The reverse: a hive declared GHE still pointing at public GitHub.
+			name: "public api_url on a GHE hive",
+			gh: GitHubConfig{
+				Forge_: ForgeGHEIBM, AppID: GHEIBMAppID,
+				AppSlug: GHEIBMAppSlug, APIURL: DefaultGitHubAPIURL,
+			},
+			wantField: "api_url",
+		},
+		{
+			name: "public base_url on a GHE hive",
+			gh: GitHubConfig{
+				Forge_: ForgeGHEIBM, AppID: GHEIBMAppID,
+				AppSlug: GHEIBMAppSlug, BaseURL: DefaultGitHubBaseURL,
+			},
+			wantField: "base_url",
+		},
+		{
+			// A URL naming a THIRD forge, on a hive declared public.
+			name: "unrelated GHE host in api_url",
+			gh: GitHubConfig{
+				Forge_: ForgePublic, AppID: PublicGitHubAppID,
+				AppSlug: PublicGitHubAppSlug, APIURL: "https://github.cisco.com/api/v3",
+			},
+			wantField: "api_url",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issues := tc.gh.ForgeIdentityMismatches()
+			if len(issues) == 0 {
+				t.Fatalf("a %s naming a different forge than %s must be reported, got no issues for %+v",
+					tc.wantField, tc.gh.Forge_, tc.gh)
+			}
+			if !strings.Contains(strings.Join(issues, " "), tc.wantField) {
+				t.Errorf("the report must name %s, got %v", tc.wantField, issues)
+			}
+		})
+	}
+
+	// The matching NEGATIVE: URLs that agree with the declared forge, spelled
+	// every way the fleet actually spells them, must stay silent.
+	for _, ok := range []GitHubConfig{
+		{Forge_: ForgePublic, AppID: PublicGitHubAppID, AppSlug: PublicGitHubAppSlug,
+			APIURL: DefaultGitHubAPIURL, BaseURL: DefaultGitHubBaseURL},
+		{Forge_: ForgeGHEIBM, AppID: GHEIBMAppID, AppSlug: GHEIBMAppSlug,
+			APIURL: GHEIBMAPIURL, BaseURL: GHEIBMBaseURL},
+		// Trailing slash / mixed case must normalise, not trip the check.
+		{Forge_: ForgeGHEIBM, AppID: GHEIBMAppID, AppSlug: GHEIBMAppSlug,
+			BaseURL: "https://GitHub.IBM.com/"},
+	} {
+		if issues := ok.ForgeIdentityMismatches(); len(issues) != 0 {
+			t.Errorf("a coherent identity was reported as mismatched: %v\n  config: %+v", issues, ok)
+		}
+	}
+}
+
+// TestIncidentRegression2026_07_31 pins the exact field set that took down
+// seven hives. The hub pushed the GHE app_id and app_slug onto hives whose
+// elected forge was github.com, leaving api_url/base_url empty — so token
+// creation went to api.github.com with a GHE App ID and returned
+// "404 Integration not found", and agents authored as kubestellar-hive-ghe[bot]
+// on public repos.
+func TestIncidentRegression2026_07_31(t *testing.T) {
+	damaged := GitHubConfig{
+		Forge_:         ForgePublic, // the hive's election, per hub meta.json github_host
+		AppID:          GHEIBMAppID, // 5686 — pushed from the vllm-d cluster entry
+		AppSlug:        GHEIBMAppSlug,
+		APIURL:         "", // never pushed — this is the field the failure split on
+		BaseURL:        "",
+		InstallationID: 149922991,
+	}
+	issues := damaged.ForgeIdentityMismatches()
+	if len(issues) == 0 {
+		t.Fatal("the 2026-07-31 identity set was ACCEPTED — this is the exact regression that must never return")
+	}
+	joined := strings.Join(issues, " | ")
+	if !strings.Contains(joined, "app_id") {
+		t.Errorf("the report must name app_id (the field that caused 404 Integration not found), got: %s", joined)
+	}
+	if !strings.Contains(joined, "app_slug") {
+		t.Errorf("the report must name app_slug (the field that caused ghe[bot] authorship), got: %s", joined)
+	}
+
+	// The undetected variant: app_id ALONE is moved and the slug stays public.
+	// IdentitySetIssues cannot see this — it compares the four fields against
+	// each other and a lone GHE app_id contradicts nothing (verified: it
+	// returns zero issues). Anchoring on the declared forge catches it.
+	appIDOnly := GitHubConfig{Forge_: ForgePublic, AppID: GHEIBMAppID, AppSlug: PublicGitHubAppSlug}
+	if len(IdentitySetIssues(appIDOnly)) != 0 {
+		t.Log("note: IdentitySetIssues now detects the app_id-only shape; it did not when this test was written")
+	}
+	if len(appIDOnly.ForgeIdentityMismatches()) == 0 {
+		t.Error("a GHE app_id alone on a public hive must be reported — it is the shape that returns 404 Integration not found")
+	}
+}
+
+// TestForgeDualReadWindow proves a spoke that has NOT been backfilled with
+// `forge:` resolves exactly as it does today. Nothing may break on the ~41
+// spokes still running an implicit empty api_url.
+func TestForgeDualReadWindow(t *testing.T) {
+	cases := []struct {
+		name string
+		gh   GitHubConfig
+		want string
+	}{
+		{"empty config infers public", GitHubConfig{}, ForgePublic},
+		{"explicit public api_url", GitHubConfig{APIURL: "https://api.github.com"}, ForgePublic},
+		{"GHE api_url only (pooled placeholder shape)",
+			GitHubConfig{APIURL: GHEIBMAPIURL}, ForgeGHEIBM},
+		{"GHE base_url only", GitHubConfig{BaseURL: GHEIBMBaseURL}, ForgeGHEIBM},
+		{"both GHE URLs", GitHubConfig{APIURL: GHEIBMAPIURL, BaseURL: GHEIBMBaseURL}, ForgeGHEIBM},
+		{"explicit forge wins over empty URLs", GitHubConfig{Forge_: ForgeGHEIBM}, ForgeGHEIBM},
+		{"explicit forge normalises a URL spelling",
+			GitHubConfig{Forge_: "https://github.ibm.com/"}, ForgeGHEIBM},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.gh.Forge(); got != tc.want {
+				t.Errorf("Forge() = %q, want %q", got, tc.want)
+			}
+			// A hive with no explicit forge must never be reported as mismatched:
+			// inference derives the forge FROM those fields, so they agree by
+			// construction. Flagging them would alarm the whole un-backfilled fleet.
+			if tc.gh.Forge_ == "" {
+				if issues := tc.gh.ForgeIdentityMismatches(); len(issues) != 0 {
+					t.Errorf("un-backfilled spoke reported as mismatched: %v", issues)
+				}
+			}
+		})
+	}
+}
+
+// TestResolvedAppIDCompletesTheResolverSet checks the new accessor mirrors
+// ResolvedAppSlug: explicit wins, else derive from forge.
+func TestResolvedAppIDCompletesTheResolverSet(t *testing.T) {
+	if got := (GitHubConfig{Forge_: ForgePublic}).ResolvedAppID(); got != PublicGitHubAppID {
+		t.Errorf("public derived app id = %d, want %d", got, PublicGitHubAppID)
+	}
+	if got := (GitHubConfig{Forge_: ForgeGHEIBM}).ResolvedAppID(); got != GHEIBMAppID {
+		t.Errorf("GHE derived app id = %d, want %d", got, GHEIBMAppID)
+	}
+	// Explicit app_id wins — a third-forge hive keeps its own App.
+	const thirdForgeApp int64 = 4242
+	if got := (GitHubConfig{Forge_: ForgePublic, AppID: thirdForgeApp}).ResolvedAppID(); got != thirdForgeApp {
+		t.Errorf("explicit app id = %d, want %d", got, thirdForgeApp)
+	}
+	// The placeholder sentinel must survive resolution: HasApp/IsPlaceholderApp
+	// depend on seeing it rather than a derived real App ID.
+	ph := GitHubConfig{Forge_: ForgePublic, AppID: PlaceholderAppID}
+	if got := ph.ResolvedAppID(); got != PlaceholderAppID {
+		t.Errorf("placeholder app id = %d, want the sentinel %d preserved", got, PlaceholderAppID)
+	}
+	if len(ph.ForgeIdentityMismatches()) != 0 {
+		t.Error("the placeholder sentinel is forge-neutral and must not be reported as a mismatch")
+	}
+	// An unknown (third) forge derives nothing rather than guessing.
+	if got := (GitHubConfig{Forge_: "github.example.com"}).ResolvedAppID(); got != 0 {
+		t.Errorf("unknown forge derived app id = %d, want 0 (no guess)", got)
+	}
+	if issues := (GitHubConfig{Forge_: "github.example.com", AppID: thirdForgeApp, AppSlug: "custom"}).ForgeIdentityMismatches(); len(issues) != 0 {
+		t.Errorf("a third-forge hive must keep explicit fields authoritative, got %v", issues)
+	}
+}

--- a/v2/pkg/config/forge_realshapes_test.go
+++ b/v2/pkg/config/forge_realshapes_test.go
@@ -1,0 +1,178 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests run REAL spoke hive.yaml text through the REAL loader
+// (config.Load), rather than constructing GitHubConfig values by hand.
+//
+// WHY THAT MATTERS HERE. A previous identity check shipped green because its
+// test data was crafted to match the check: all three of IdentitySetIssues'
+// GHE markers derive from fields that are empty across most of the fleet, so
+// the rule was unreachable on real data while passing on fixtures. Anything
+// asserted about identity must therefore be asserted against the YAML shapes
+// that actually exist on spokes, parsed the way a spoke parses them — including
+// the yaml key spellings, which a hand-built struct silently bypasses.
+//
+// The shapes below are the fleet's real ones: an implicit-empty public spoke
+// (~41 of ~51 spokes), a fully-populated GHE spoke, a pooled placeholder
+// carrying a GHE api_url with base_url absent, and the damaged shape from
+// 2026-07-31.
+
+func loadSpokeYAML(t *testing.T, body string) *Config {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hive.yaml")
+	// A minimal but VALID hive.yaml: the loader applies defaults and validation,
+	// so the github block is exercised in its real context, not in isolation.
+	full := "project:\n  name: test-hive\n  org: acme\n  repos:\n    - acme/widgets\n" +
+		"agents:\n  scanner:\n    enabled: true\n    backend: claude\n" + body
+	if err := os.WriteFile(path, []byte(full), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("real spoke config failed to load: %v\n---\n%s", err, full)
+	}
+	return cfg
+}
+
+// TestRealSpokeShapesResolveTheirForge walks the four shapes that actually
+// exist on disk across the fleet and asserts each resolves to the right forge
+// through the real YAML path.
+func TestRealSpokeShapesResolveTheirForge(t *testing.T) {
+	cases := []struct {
+		name      string
+		yaml      string
+		wantForge string
+		wantGHE   bool
+	}{
+		{
+			// The majority shape: no api_url, no base_url, no forge. This is the
+			// implicit-empty default that disguised the incident, and the single
+			// most important shape to keep working untouched.
+			name: "implicit public spoke (fleet majority)",
+			yaml: "github:\n  app_id: 3568013\n  installation_id: 149922991\n" +
+				"  key_file: /secrets/gh-app-key.pem\n",
+			wantForge: ForgePublic,
+		},
+		{
+			name: "fully populated GHE spoke",
+			yaml: "github:\n  app_id: 5686\n  installation_id: 12345\n" +
+				"  app_slug: kubestellar-hive-ghe\n" +
+				"  api_url: https://github.ibm.com/api/v3\n" +
+				"  base_url: https://github.ibm.com\n",
+			wantForge: ForgeGHEIBM,
+			wantGHE:   true,
+		},
+		{
+			// Pooled placeholders legitimately carry a GHE api_url with base_url
+			// absent — ResolvedBaseURL/HostLabel document exactly this shape.
+			name: "pooled GHE placeholder, base_url absent",
+			yaml: "github:\n  app_id: 999999999\n" +
+				"  api_url: https://github.ibm.com/api/v3\n",
+			wantForge: ForgeGHEIBM,
+			wantGHE:   true,
+		},
+		{
+			// Token-only, no App at all — the in-repo deploy/hive.yaml shape.
+			name:      "token-only spoke (deploy/hive.yaml shape)",
+			yaml:      "github:\n  token: ghp_exampletoken\n",
+			wantForge: ForgePublic,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := loadSpokeYAML(t, tc.yaml)
+			if got := cfg.GitHub.Forge(); got != tc.wantForge {
+				t.Errorf("Forge() = %q, want %q", got, tc.wantForge)
+			}
+			if got := cfg.GitHub.IsGHE(); got != tc.wantGHE {
+				t.Errorf("IsGHE() = %v, want %v", got, tc.wantGHE)
+			}
+			// A spoke with no explicit `forge:` must NEVER be reported as
+			// mismatched — the forge is inferred from these very fields, so they
+			// agree by construction. If this fires, the whole un-backfilled fleet
+			// would light up as broken.
+			if issues := cfg.GitHub.ForgeIdentityMismatches(); len(issues) != 0 {
+				t.Errorf("un-backfilled real spoke shape reported as mismatched: %v", issues)
+			}
+		})
+	}
+}
+
+// TestRealSpokeYAMLAcceptsForgeKey proves the new field is wired to the yaml key
+// `forge` through the real loader. A struct literal cannot catch a wrong or
+// missing yaml tag; this can.
+func TestRealSpokeYAMLAcceptsForgeKey(t *testing.T) {
+	cfg := loadSpokeYAML(t, "github:\n  forge: github.ibm.com\n  installation_id: 12345\n")
+	if got := cfg.GitHub.Forge_; got != ForgeGHEIBM {
+		t.Fatalf("the yaml key `forge` did not populate the field: got %q", got)
+	}
+	if got := cfg.GitHub.Forge(); got != ForgeGHEIBM {
+		t.Errorf("Forge() = %q, want %q", got, ForgeGHEIBM)
+	}
+	// Derivation from `forge:` ALONE — the end state this design is aiming at,
+	// where a spoke names one field and the rest follow.
+	if got := cfg.GitHub.ResolvedAppID(); got != GHEIBMAppID {
+		t.Errorf("derived app_id = %d, want %d", got, GHEIBMAppID)
+	}
+	if got := cfg.GitHub.ResolvedAppSlug(); got != GHEIBMAppSlug {
+		t.Errorf("derived app_slug = %q, want %q", got, GHEIBMAppSlug)
+	}
+
+	// And a public spoke declaring `forge: github.com` stays byte-identical to
+	// the implicit-empty spoke it replaces.
+	// Both carry the real public app_id, which is the actual fleet shape: the
+	// ONLY difference between them is the added `forge: github.com` line.
+	pub := loadSpokeYAML(t, "github:\n  forge: github.com\n  app_id: 3568013\n  installation_id: 1\n")
+	implicit := loadSpokeYAML(t, "github:\n  app_id: 3568013\n  installation_id: 1\n")
+	if pub.GitHub.ResolvedAPIURL() != implicit.GitHub.ResolvedAPIURL() ||
+		pub.GitHub.ResolvedBaseURL() != implicit.GitHub.ResolvedBaseURL() ||
+		pub.GitHub.ResolvedAppSlug() != implicit.GitHub.ResolvedAppSlug() {
+		t.Error("declaring `forge: github.com` changed a healthy public spoke's resolved identity — the migration must be a no-op")
+	}
+}
+
+// TestRealDamagedSpokeShapeIsCaught is the incident regression asserted through
+// the REAL loader: the exact YAML the seven hives ended up with after the
+// clusters.json push, on a hive whose election was github.com.
+func TestRealDamagedSpokeShapeIsCaught(t *testing.T) {
+	// This is what was on disk: the GHE app_id and slug arrived, api_url and
+	// base_url did not. The hive's own election (hub meta.json github_host:
+	// github.com) is expressed as `forge: github.com`.
+	cfg := loadSpokeYAML(t, "github:\n  forge: github.com\n"+
+		"  app_id: 5686\n"+
+		"  app_slug: kubestellar-hive-ghe\n"+
+		"  installation_id: 149922991\n"+
+		"  key_file: /secrets/gh-app-key.pem\n")
+
+	issues := cfg.GitHub.ForgeIdentityMismatches()
+	if len(issues) == 0 {
+		t.Fatal("the real damaged spoke shape was ACCEPTED — this is the exact 2026-07-31 regression")
+	}
+	joined := strings.Join(issues, " | ")
+	for _, want := range []string{"app_id", "app_slug"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("the report must name %s, got: %s", want, joined)
+		}
+	}
+
+	// The user-visible half of the incident: BotLogin drives EffectiveAIAuthor,
+	// which becomes PROJECT_AI_AUTHOR and made agents author as
+	// kubestellar-hive-ghe[bot] on PUBLIC repos. Pin that this shape is exactly
+	// what produces the wrong bot, so the connection is not lost.
+	if got := cfg.GitHub.BotLogin(); got != "kubestellar-hive-ghe[bot]" {
+		t.Errorf("BotLogin() = %q; the damaged shape is expected to still yield the GHE bot "+
+			"(that is the symptom) — if this changed, re-check EffectiveAIAuthor", got)
+	}
+	// installation_id is per-forge AND per-org and is never derived. It must
+	// survive untouched: all seven affected IDs were verified intact.
+	if cfg.GitHub.InstallationID != 149922991 {
+		t.Errorf("installation_id = %d, want it preserved unchanged", cfg.GitHub.InstallationID)
+	}
+}

--- a/v2/pkg/hub/forge.go
+++ b/v2/pkg/hub/forge.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -452,10 +453,13 @@ const forgeIdentityRemedy = "populate the target cluster's entry in /data/saas/c
 // forgeIdentityForTarget resolves the FULL App identity for the target forge
 // from CLUSTER CONFIG ONLY, and reports everything that is missing.
 //
-// A cluster's configured App is correct exactly when the cluster's own GitHub
-// host matches the target — hive-oke is a github.com cluster naming its
-// github.com App, vllm-d is a github.ibm.com cluster naming its GHE App. A hive
-// switching to a forge its cluster does NOT serve has no App the hub can name.
+// PER-HIVE ELECTION. A cluster's forge is a DEFAULT, not a pin: a cluster may
+// carry identity for BOTH forges (see ClusterConfig.Forges) and a hive elects
+// one. So this refuses only a target the cluster has no identity FOR, rather
+// than every target differing from the cluster's own host. That is the change
+// that unblocks a public election on the GHE-default vllm-d cluster, which
+// previously 409'd with "the target forge identity is incomplete" — leaving
+// seven public hives that had already elected github.com unrepairable.
 //
 // # WHY MISSING FIELDS ARE AN ERROR AND NOT A DEFAULT
 //
@@ -469,48 +473,93 @@ const forgeIdentityRemedy = "populate the target cluster's entry in /data/saas/c
 // So this returns the missing field NAMES and the caller refuses the switch.
 // Nothing is hardcoded: both values come from ClusterConfig, the same
 // non-secret fields resolveProvisionAppID and the provisioning template read.
+//
+// The refusal itself is preserved exactly. An incomplete identity still returns
+// missing field names and still writes nothing: refusing rather than
+// half-applying is the property that stopped the 2026-07-31 incident from
+// getting worse, and it survives this change untouched.
 func (s *HubServer) forgeIdentityForTarget(cluster *ClusterConfig, target ForgeTarget) (forgeIdentity, []string) {
 	if cluster == nil {
 		return forgeIdentity{}, []string{"cluster config (this hive's cluster is unknown to the hub)"}
 	}
-	clusterHost := publicForgeHost
-	if cluster.GitHubBaseURL != "" {
-		clusterHost = strings.ToLower(githubHostLabel(cluster.GitHubBaseURL))
-	} else if cluster.GitHubAPIURL != "" {
-		clusterHost = strings.ToLower(githubHostLabel(cluster.GitHubAPIURL))
-	}
-	if !sameGitHubHost(clusterHost, target.Host) {
-		// The hub knows an App for this cluster, but it is registered on the
-		// WRONG forge. Naming the mismatch is far more useful than a bare
-		// "missing app_id", because the remedy is different: this cluster may
-		// simply not be able to host a hive on the requested forge.
-		return forgeIdentity{}, []string{
-			fmt.Sprintf("a GitHub App registered on %s (cluster %q serves %s)", target.Host, cluster.ID, clusterHost),
+	targetHost := forgeHostKey(target.Host)
+	forges := forgesForCluster(cluster)
+
+	// Look the target forge up directly. sameGitHubHost keeps the comparison
+	// tolerant of spelling (bare host vs URL) the way the old cluster-host
+	// comparison was.
+	var identity ClusterForgeIdentity
+	found := false
+	for host, id := range forges {
+		if sameGitHubHost(host, targetHost) {
+			identity, found = id, true
+			break
 		}
 	}
-	// Route through the ONE resolver: a forge switch must resolve identity the
-	// same way provisioning, the heartbeat answer and the key lookup do. The
-	// hive is synthesised from the target because the switch is precisely the
-	// act of electing that forge.
-	resolved := ResolveHiveIdentity(&SaaSHive{ID: cluster.ID, GitHubHost: target.Host}, cluster)
-	var missing []string
-	if resolved.AppID == 0 {
-		missing = append(missing, fmt.Sprintf("github_app_id for cluster %q", cluster.ID))
+	// NOTE ON THE ONE-RESOLVER RULE (#2383). Every other identity decision
+	// routes through ResolveHiveIdentity, and this one deliberately does not.
+	//
+	// ResolveHiveIdentity answers "what identity does this hive have NOW",
+	// resolving a hive's existing election against its cluster's default. This
+	// function answers a different question: "can the cluster serve the forge
+	// this hive is trying to elect, and with which App?" — asked BEFORE any
+	// election exists. Synthesising a SaaSHive from the target to feed the
+	// resolver would make it answer its own input, which is why the lookup over
+	// forgesForCluster above is the direct expression of the question.
+	//
+	// The resolver still owns the outcome: the elected host is written to the
+	// hive record and every later read — heartbeat answer, key lookup,
+	// provisioning — goes through ResolveHiveIdentity as normal.
+	if !found {
+		// The cluster names no App on the requested forge. This is the same
+		// class of refusal as before, but the remedy is now additive: name the
+		// forge in the cluster's `forges` map rather than move the whole
+		// cluster. Listing what the cluster CAN serve makes that actionable.
+		served := make([]string, 0, len(forges))
+		for host := range forges {
+			served = append(served, host)
+		}
+		sort.Strings(served)
+		if len(served) == 0 {
+			return forgeIdentity{}, []string{
+				fmt.Sprintf("a GitHub App registered on %s (cluster %q names no GitHub App at all)", target.Host, cluster.ID),
+			}
+		}
+		return forgeIdentity{}, []string{
+			fmt.Sprintf("a GitHub App registered on %s (cluster %q serves %s)",
+				target.Host, cluster.ID, strings.Join(served, ", ")),
+		}
 	}
-	if strings.TrimSpace(resolved.AppSlug) == "" {
-		// Deliberately required even for public github.com. The default slug
-		// happens to be right there, but accepting an unset value would mean the
-		// atomicity guarantee holds on one forge and not the other — and the
-		// operator would have no signal that the cluster entry is incomplete.
-		missing = append(missing, fmt.Sprintf("github_app_slug for cluster %q (an empty slug falls back to %q, which names no App on %s)",
-			cluster.ID, defaultPublicAppSlug, target.Host))
+
+	// An identity that exists must still be COMPLETE. Both halves are required
+	// on both forges: the public default slug happens to be correct on
+	// github.com, but accepting an unset value would mean the atomicity
+	// guarantee holds on one forge and not the other, and the operator would
+	// get no signal that the cluster entry is half-filled.
+	//
+	// Name the field the operator must actually edit. A legacy entry carries the
+	// identity in the flat github_app_id/github_app_slug keys; an entry using
+	// the per-forge map carries it under forges.<host>. Pointing at the wrong
+	// one sends the operator to a key that does not exist in their file.
+	idField, slugField := "github_app_id", "github_app_slug"
+	if _, viaMap := cluster.Forges[targetHost]; viaMap || clusterDefaultForge(cluster) != targetHost {
+		idField = fmt.Sprintf("forges.%s.app_id", targetHost)
+		slugField = fmt.Sprintf("forges.%s.app_slug", targetHost)
+	}
+	var missing []string
+	if identity.AppID == 0 {
+		missing = append(missing, fmt.Sprintf("%s for cluster %q", idField, cluster.ID))
+	}
+	if strings.TrimSpace(identity.AppSlug) == "" {
+		missing = append(missing, fmt.Sprintf("%s for cluster %q (an empty slug falls back to %q, which names no App on %s)",
+			slugField, cluster.ID, defaultPublicAppSlug, target.Host))
 	}
 	if len(missing) > 0 {
 		return forgeIdentity{}, missing
 	}
 	return forgeIdentity{
-		AppID:   resolved.AppID,
-		AppSlug: strings.TrimSpace(resolved.AppSlug),
+		AppID:   identity.AppID,
+		AppSlug: strings.TrimSpace(identity.AppSlug),
 	}, nil
 }
 

--- a/v2/pkg/hub/forge_election_live_test.go
+++ b/v2/pkg/hub/forge_election_live_test.go
@@ -1,0 +1,113 @@
+package hub
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// liveVllmDWithForges is the production /data/saas/clusters.json entry for
+// vllm-d, verbatim, plus the additive "forges" map this PR makes meaningful.
+//
+// Parsed from JSON rather than built as a struct so the test exercises the real
+// unmarshalling path an operator's edit takes. A struct literal would skip the
+// json tags and could pass while the actual file shape does not.
+const liveVllmDWithForges = `{
+  "id": "vllm-d",
+  "name": "vLLM-d (GPU)",
+  "storage_class": "ocs-storagecluster-cephfs",
+  "requires_scc": true,
+  "has_gpu": true,
+  "image_tag": "v2-latest",
+  "github_base_url": "https://github.ibm.com",
+  "github_api_url": "https://github.ibm.com/api/v3",
+  "github_app_id": 5686,
+  "github_app_slug": "kubestellar-hive-ghe",
+  "forges": {
+    "github.com": {
+      "app_id": 3568013,
+      "app_slug": "kubestellar-hive"
+    }
+  }
+}`
+
+// TestLiveVllmDEntryRepairsElectedHives pins the deadlock this PR exists to
+// clear, against the real cluster entry.
+//
+// On 2026-07-31 the hub resolved app_id 3568013 from hive intent but
+// api_url/base_url from the GHE cluster, and the identity validator refused the
+// push every ~30s for 26 hives:
+//
+//	REFUSING to push cluster github app config: app_id 3568013 is the GitHub
+//	App on github.com, but api_url (https://github.ibm.com/api/v3) and base_url
+//	(https://github.ibm.com) resolve to github.ibm.com
+//
+// Note an EMPTY identity also satisfies RejectIdentitySet, so asserting only
+// "the validator accepts it" proves nothing — an earlier draft of this test
+// passed with app_id 0. The App assertions below are what give it teeth.
+func TestLiveVllmDEntryRepairsElectedHives(t *testing.T) {
+	var c ClusterConfig
+	if err := json.Unmarshal([]byte(liveVllmDWithForges), &c); err != nil {
+		t.Fatalf("production clusters.json entry does not parse: %v", err)
+	}
+
+	mustPassValidator := func(t *testing.T, id HiveIdentity) {
+		t.Helper()
+		if err := config.RejectIdentitySet(config.GitHubConfig{
+			AppID: id.AppID, AppSlug: id.AppSlug, APIURL: id.APIURL, BaseURL: id.BaseURL,
+		}); err != nil {
+			t.Fatalf("identity refused by the validator (this is the live deadlock):\n  %v", err)
+		}
+	}
+
+	t.Run("hive that elected github.com gets the PUBLIC App", func(t *testing.T) {
+		got := ResolveHiveIdentity(&SaaSHive{
+			ID: "hosted-torch-spyre-spyre-infer-94c2", GitHubHost: "github.com",
+		}, &c)
+		if got.AppID != config.PublicGitHubAppID {
+			t.Fatalf("app_id = %d, want %d (public)", got.AppID, config.PublicGitHubAppID)
+		}
+		if got.AppSlug != config.PublicGitHubAppSlug {
+			t.Fatalf("app_slug = %q, want %q", got.AppSlug, config.PublicGitHubAppSlug)
+		}
+		// Empty URLs are correct here: every healthy public spoke runs that way.
+		if got.APIURL != "" || got.BaseURL != "" {
+			t.Fatalf("public hive should carry empty URLs, got api=%q base=%q", got.APIURL, got.BaseURL)
+		}
+		mustPassValidator(t, got)
+	})
+
+	t.Run("GHE hive is unaffected", func(t *testing.T) {
+		got := ResolveHiveIdentity(&SaaSHive{
+			ID: "hosted-available-vllmd-03", GitHubHost: "github.ibm.com",
+		}, &c)
+		if got.AppID != config.EnterpriseGitHubAppID {
+			t.Fatalf("GHE hive app_id = %d, want %d", got.AppID, config.EnterpriseGitHubAppID)
+		}
+		mustPassValidator(t, got)
+	})
+
+	t.Run("no App leaks between forges on one cluster", func(t *testing.T) {
+		pub := ResolveHiveIdentity(&SaaSHive{ID: "p", GitHubHost: "github.com"}, &c)
+		ghe := ResolveHiveIdentity(&SaaSHive{ID: "g", GitHubHost: "github.ibm.com"}, &c)
+		if pub.AppID == ghe.AppID {
+			t.Fatalf("both forges resolved to App %d", pub.AppID)
+		}
+	})
+
+	t.Run("without the forges map the election yields NO App, never the wrong one", func(t *testing.T) {
+		var legacy ClusterConfig
+		if err := json.Unmarshal([]byte(liveVllmDWithForges), &legacy); err != nil {
+			t.Fatal(err)
+		}
+		legacy.Forges = nil // the entry as it exists in production TODAY
+		got := ResolveHiveIdentity(&SaaSHive{ID: "x", GitHubHost: "github.com"}, &legacy)
+		if got.AppID == config.EnterpriseGitHubAppID {
+			t.Fatal("public hive was handed the GHE App — this is the 2026-07-31 incident")
+		}
+		if got.AppID != 0 {
+			t.Fatalf("expected no App without a forges entry, got %d", got.AppID)
+		}
+	})
+}

--- a/v2/pkg/hub/forge_election_test.go
+++ b/v2/pkg/hub/forge_election_test.go
@@ -1,0 +1,195 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// vllmDWithBothForges is the vllm-d cluster entry as it must look for the
+// public hives on it to be repairable: GHE remains the DEFAULT (it is what the
+// cluster is used for), and the public App is additionally named so a hive can
+// ELECT github.com. Per the platform owner: "vllm-d is used for GHE, but gh can
+// be elected."
+//
+// The flat github_* fields are left exactly as they are in the live file, so
+// this doubles as a check that the legacy shape still parses and still supplies
+// the GHE identity.
+func vllmDWithBothForges() *ClusterConfig {
+	return &ClusterConfig{
+		ID:            "vllm-d",
+		GitHubBaseURL: "https://github.ibm.com",
+		GitHubAPIURL:  "https://github.ibm.com/api/v3",
+		GitHubAppID:   5686,
+		GitHubAppSlug: "kubestellar-hive-ghe",
+		Forges: map[string]ClusterForgeIdentity{
+			"github.com": {AppID: 3568013, AppSlug: "kubestellar-hive"},
+		},
+	}
+}
+
+// TestPublicElectionOnGHEDefaultClusterResolves is the live repair this change
+// exists to unblock.
+//
+// TODAY this 409s: POST /api/saas/hives/hosted-available-vllmd-05/forge
+// {"host":"github.com"} returns "the target forge identity is incomplete for
+// cluster \"vllm-d\"", because identity was resolved from cluster config that
+// has ONE slot and it holds the GHE App. The refusal was correct — the hub had
+// no public App to name — but it left seven hives unrepairable.
+func TestPublicElectionOnGHEDefaultClusterResolves(t *testing.T) {
+	s := &HubServer{}
+	cluster := vllmDWithBothForges()
+
+	public, err := parseForgeTarget("github.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, missing := s.forgeIdentityForTarget(cluster, public)
+	if len(missing) != 0 {
+		t.Fatalf("a public election on the GHE-default vllm-d cluster must RESOLVE, got missing=%v", missing)
+	}
+	if got.AppID != 3568013 {
+		t.Errorf("app id = %d, want the PUBLIC app 3568013 (not the GHE 5686)", got.AppID)
+	}
+	if got.AppSlug != "kubestellar-hive" {
+		t.Errorf("app slug = %q, want kubestellar-hive — %q is what authored as ghe[bot] on public repos",
+			got.AppSlug, "kubestellar-hive-ghe")
+	}
+}
+
+// TestMixedForgeClusterResolvesBothWays is the required mixed-forge test: on ONE
+// cluster entry, a github.com hive and a github.ibm.com hive must each resolve
+// to their own forge's identity, with no leakage between them. Leakage in this
+// exact direction is the incident.
+func TestMixedForgeClusterElectionResolvesBothWays(t *testing.T) {
+	s := &HubServer{}
+	cluster := vllmDWithBothForges()
+
+	for _, tc := range []struct {
+		host      string
+		wantID    int64
+		wantSlug  string
+		otherID   int64
+		otherSlug string
+	}{
+		{"github.com", 3568013, "kubestellar-hive", 5686, "kubestellar-hive-ghe"},
+		{"github.ibm.com", 5686, "kubestellar-hive-ghe", 3568013, "kubestellar-hive"},
+	} {
+		t.Run(tc.host, func(t *testing.T) {
+			target, err := parseForgeTarget(tc.host)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, missing := s.forgeIdentityForTarget(cluster, target)
+			if len(missing) != 0 {
+				t.Fatalf("%s must resolve on a dual-forge cluster, got missing=%v", tc.host, missing)
+			}
+			if got.AppID != tc.wantID || got.AppSlug != tc.wantSlug {
+				t.Errorf("identity = %+v, want app %d / slug %q", got, tc.wantID, tc.wantSlug)
+			}
+			if got.AppID == tc.otherID || got.AppSlug == tc.otherSlug {
+				t.Errorf("LEAKAGE: %s resolved to the other forge's identity %+v", tc.host, got)
+			}
+		})
+	}
+}
+
+// TestLegacySingleIdentityClusterUnchanged proves the schema is backward
+// compatible: an entry with no `forges` map behaves exactly as it does today,
+// including still REFUSING a forge it has no App for. Nothing in clusters.json
+// has to change for the fleet to keep working.
+func TestLegacySingleIdentityClusterUnchanged(t *testing.T) {
+	s := &HubServer{}
+	// hive-oke, live shape: public, no URLs (implicit), one App.
+	hiveOKE := &ClusterConfig{ID: "hive-oke", GitHubAppID: 3568013, GitHubAppSlug: "kubestellar-hive"}
+	// vllm-d, live shape BEFORE this change: GHE only.
+	vllmD := &ClusterConfig{
+		ID: "vllm-d", GitHubBaseURL: "https://github.ibm.com",
+		GitHubAPIURL: "https://github.ibm.com/api/v3",
+		GitHubAppID:  5686, GitHubAppSlug: "kubestellar-hive-ghe",
+	}
+	public, _ := parseForgeTarget("github.com")
+	ghe, _ := parseForgeTarget("github.ibm.com")
+
+	if got, missing := s.forgeIdentityForTarget(hiveOKE, public); len(missing) != 0 || got.AppID != 3568013 {
+		t.Errorf("legacy public cluster: got %+v missing %v", got, missing)
+	}
+	if got, missing := s.forgeIdentityForTarget(vllmD, ghe); len(missing) != 0 || got.AppID != 5686 {
+		t.Errorf("legacy GHE cluster: got %+v missing %v", got, missing)
+	}
+	// THE PRESERVED REFUSAL. A legacy GHE-only cluster still has no public App,
+	// so a public election still refuses and still writes nothing. This is the
+	// 409 that must survive — it is what stopped the incident getting worse.
+	got, missing := s.forgeIdentityForTarget(vllmD, public)
+	if len(missing) == 0 {
+		t.Fatalf("a cluster naming no public App must still REFUSE a public election, got %+v", got)
+	}
+	if got.AppID != 0 || got.AppSlug != "" {
+		t.Errorf("a refused identity must be entirely empty (all-or-nothing), got %+v", got)
+	}
+	// Conversely, hive-oke has no GHE App.
+	if _, missing := s.forgeIdentityForTarget(hiveOKE, ghe); len(missing) == 0 {
+		t.Error("a public-only cluster must refuse a GHE election")
+	}
+}
+
+// TestIncompleteForgeEntryStillRefuses checks the atomicity guarantee holds on
+// the NEW schema too: a half-filled `forges` entry is refused, not accepted with
+// a slug that falls back to the public default and 404s the install link.
+func TestIncompleteForgeEntryStillRefuses(t *testing.T) {
+	s := &HubServer{}
+	public, _ := parseForgeTarget("github.com")
+
+	for _, tc := range []struct {
+		name     string
+		identity ClusterForgeIdentity
+		wantName string
+	}{
+		{"app_id missing", ClusterForgeIdentity{AppSlug: "kubestellar-hive"}, "app_id"},
+		{"app_slug missing", ClusterForgeIdentity{AppID: 3568013}, "app_slug"},
+		{"both missing", ClusterForgeIdentity{}, "app_id"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := &ClusterConfig{
+				ID: "vllm-d", GitHubBaseURL: "https://github.ibm.com",
+				GitHubAppID: 5686, GitHubAppSlug: "kubestellar-hive-ghe",
+				Forges: map[string]ClusterForgeIdentity{"github.com": tc.identity},
+			}
+			got, missing := s.forgeIdentityForTarget(cluster, public)
+			if len(missing) == 0 {
+				t.Fatalf("an incomplete forge entry must be refused, got %+v", got)
+			}
+			if got.AppID != 0 || got.AppSlug != "" {
+				t.Errorf("refused identity must be empty, got %+v", got)
+			}
+			if !strings.Contains(strings.Join(missing, " "), tc.wantName) {
+				t.Errorf("the refusal must NAME %s so an operator can fix it, got %v", tc.wantName, missing)
+			}
+		})
+	}
+}
+
+// TestClusterDefaultForge pins default resolution, including that an entry with
+// no forge information at all defaults to public — today's behaviour for
+// hive-oke, which carries no URLs.
+func TestClusterDefaultForge(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		c    *ClusterConfig
+		want string
+	}{
+		{"nil cluster", nil, "github.com"},
+		{"no forge info (hive-oke shape)", &ClusterConfig{ID: "hive-oke"}, "github.com"},
+		{"GHE base url (vllm-d shape)",
+			&ClusterConfig{GitHubBaseURL: "https://github.ibm.com"}, "github.ibm.com"},
+		{"GHE api url only",
+			&ClusterConfig{GitHubAPIURL: "https://github.ibm.com/api/v3"}, "github.ibm.com"},
+		{"explicit default_forge wins",
+			&ClusterConfig{GitHubBaseURL: "https://github.ibm.com", DefaultForge: "github.com"}, "github.com"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clusterDefaultForge(tc.c); got != tc.want {
+				t.Errorf("clusterDefaultForge = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/v2/pkg/hub/hive_identity.go
+++ b/v2/pkg/hub/hive_identity.go
@@ -238,16 +238,34 @@ func clusterForgeHost(c *ClusterConfig) string {
 // follow-up; isolating the lookup here means that change lands in one function
 // rather than across every caller.
 func clusterAppForForge(c *ClusterConfig, forge string) (clusterAppIdentity, bool) {
-	if c == nil || c.GitHubAppID == 0 {
+	if c == nil {
 		return clusterAppIdentity{}, false
 	}
-	if !sameGitHubHost(clusterForgeHost(c), forge) {
-		return clusterAppIdentity{}, false
+	// forgesForCluster merges the legacy flat github_app_id/github_app_slug
+	// fields (the cluster's own default forge) with the explicit per-forge
+	// `forges` map, so ONE lookup covers both an old single-forge entry and a
+	// dual-forge one.
+	//
+	// Reading only the flat fields is what left this unable to answer for a
+	// hive that elected a forge its cluster does not default to: on vllm-d — a
+	// GHE-default cluster hosting hives that elected github.com — it returned
+	// "no App", so the resolver produced app_id 0 and 26 hives stayed broken
+	// even with a public App named in `forges`.
+	for host, id := range forgesForCluster(c) {
+		if !sameGitHubHost(host, forge) {
+			continue
+		}
+		if id.AppID == 0 {
+			// A named forge with no App is not an answer — same as absent.
+			// Returning it would hand the caller a half-identity.
+			return clusterAppIdentity{}, false
+		}
+		return clusterAppIdentity{
+			AppID:   id.AppID,
+			AppSlug: strings.TrimSpace(id.AppSlug),
+		}, true
 	}
-	return clusterAppIdentity{
-		AppID:   c.GitHubAppID,
-		AppSlug: strings.TrimSpace(c.GitHubAppSlug),
-	}, true
+	return clusterAppIdentity{}, false
 }
 
 // forgeHostLabel normalises any spelling of a forge — bare host, web URL, or

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -177,9 +177,120 @@ type ClusterConfig struct {
 	//
 	// Zero means "this cluster has no hub-managed App identity" — the hub then
 	// changes nothing about its spokes' credentials.
-	GitHubAppID                 int64  `json:"github_app_id,omitempty" yaml:"github_app_id,omitempty"`
-	OAuthClientID               string `json:"oauth_client_id,omitempty" yaml:"oauth_client_id,omitempty"`
+	GitHubAppID   int64  `json:"github_app_id,omitempty" yaml:"github_app_id,omitempty"`
+	OAuthClientID string `json:"oauth_client_id,omitempty" yaml:"oauth_client_id,omitempty"`
+	// Forges carries App identity for EVERY forge this cluster can serve, keyed
+	// by bare forge host ("github.com", "github.ibm.com").
+	//
+	// WHY THIS FIELD EXISTS. The flat github_app_id/github_app_slug/github_*_url
+	// fields above give a cluster exactly ONE identity slot, which made a
+	// cluster's forge a PIN rather than a DEFAULT. On 2026-07-31 that cost seven
+	// hives their identity: adding github_app_slug: kubestellar-hive-ghe to the
+	// vllm-d entry handed a GHE App to every public-GitHub hive on the cluster,
+	// because there was nowhere else for a public identity to live. Those hives
+	// had already ELECTED github.com in their meta.json github_host — the hub
+	// knew the right answer and had no field in which to act on it.
+	//
+	// Per the platform owner: "vllm-d is used for GHE, but gh can be elected."
+	// A cluster's forge is a DEFAULT with per-hive election. This map is what
+	// makes a public election on a GHE-default cluster RESOLVABLE instead of
+	// 409-ing as "incomplete".
+	//
+	// BACKWARD COMPATIBILITY: an entry that omits this map still works. The flat
+	// fields are read as the DEFAULT forge's identity (see forgesForCluster), so
+	// today's single-identity clusters.json parses and behaves unchanged. This
+	// field is purely additive.
+	Forges map[string]ClusterForgeIdentity `json:"forges,omitempty" yaml:"forges,omitempty"`
+	// DefaultForge names which forge a hive on this cluster gets when it has not
+	// elected one, as a bare host. Empty means "infer from the flat fields" —
+	// github_base_url/github_api_url if set, else public github.com — which is
+	// exactly today's behaviour.
+	DefaultForge                string `json:"default_forge,omitempty" yaml:"default_forge,omitempty"`
 	ClusterHealthTimeoutSeconds int    `json:"cluster_health_timeout_seconds,omitempty" yaml:"cluster_health_timeout_seconds,omitempty"`
+}
+
+// ClusterForgeIdentity is one forge's App registration on one cluster. It is
+// the non-secret half only: as with the flat GitHubAppID field, the matching
+// PRIVATE KEY lives in its own 0600 file keyed by cluster ID, never here.
+//
+// AppID and AppSlug are BOTH required for an identity to count as complete —
+// see forgeIdentityForTarget, which refuses a switch rather than let an empty
+// slug fall back to the public default and build an install link that 404s on
+// GHE.
+type ClusterForgeIdentity struct {
+	AppID   int64  `json:"app_id,omitempty" yaml:"app_id,omitempty"`
+	AppSlug string `json:"app_slug,omitempty" yaml:"app_slug,omitempty"`
+	// APIURL and BaseURL are optional. For a forge in config.forgeIdentities
+	// they are derivable from the host, so a cluster entry need only name the
+	// App. They exist for a third GHE instance the derivation table does not
+	// know, where the URLs cannot be inferred.
+	APIURL  string `json:"api_url,omitempty" yaml:"api_url,omitempty"`
+	BaseURL string `json:"base_url,omitempty" yaml:"base_url,omitempty"`
+}
+
+// forgeHostKey reduces any spelling of a forge — bare host, web URL, or API
+// URL — to the canonical bare-host key used by ClusterConfig.Forges.
+//
+// githubHostLabel alone is NOT sufficient: it strips the scheme but keeps the
+// path, so an api_url of https://github.ibm.com/api/v3 yields
+// "github.ibm.com/api/v3", which matches no map key and no target host. Every
+// lookup into the forges map must go through this.
+func forgeHostKey(s string) string {
+	h := strings.ToLower(githubHostLabel(s))
+	h = strings.TrimSuffix(strings.TrimRight(h, "/"), "/api/v3")
+	h = strings.SplitN(h, "/", 2)[0]
+	if h == "" || h == "api.github.com" {
+		return publicForgeHost
+	}
+	return h
+}
+
+// forgesForCluster returns the cluster's per-forge identity map, synthesising
+// the legacy single-identity shape when `forges` is absent.
+//
+// This is the compatibility seam. A cluster entry written before this change
+// has its flat github_app_id/github_app_slug read as the identity of the forge
+// its github_base_url/github_api_url name — which is precisely what those
+// fields have always meant. An entry that carries an explicit `forges` map wins
+// outright, and a map entry for a given host overrides the synthesised one.
+func forgesForCluster(c *ClusterConfig) map[string]ClusterForgeIdentity {
+	out := map[string]ClusterForgeIdentity{}
+	if c == nil {
+		return out
+	}
+	// Legacy flat fields -> the identity of the cluster's own (default) forge.
+	if c.GitHubAppID != 0 || strings.TrimSpace(c.GitHubAppSlug) != "" {
+		out[clusterDefaultForge(c)] = ClusterForgeIdentity{
+			AppID:   c.GitHubAppID,
+			AppSlug: strings.TrimSpace(c.GitHubAppSlug),
+			APIURL:  c.GitHubAPIURL,
+			BaseURL: c.GitHubBaseURL,
+		}
+	}
+	// Explicit per-forge entries override the synthesised one.
+	for host, id := range c.Forges {
+		out[forgeHostKey(host)] = id
+	}
+	return out
+}
+
+// clusterDefaultForge returns the forge a hive on this cluster gets when it has
+// elected nothing: explicit default_forge, else the host named by the flat URL
+// fields, else public github.com.
+func clusterDefaultForge(c *ClusterConfig) string {
+	if c == nil {
+		return publicForgeHost
+	}
+	if f := strings.TrimSpace(c.DefaultForge); f != "" {
+		return forgeHostKey(f)
+	}
+	if c.GitHubBaseURL != "" {
+		return forgeHostKey(c.GitHubBaseURL)
+	}
+	if c.GitHubAPIURL != "" {
+		return forgeHostKey(c.GitHubAPIURL)
+	}
+	return publicForgeHost
 }
 
 // kubectlForCluster builds an exec.Cmd that targets a specific cluster.


### PR DESCRIPTION
## The incident this addresses

Adding `github_app_slug: kubestellar-hive-ghe` to the `vllm-d` entry in the hub's `clusters.json` handed a GHE App identity to **seven public-GitHub hives** on that cluster: torch-spyre, llm-d-workload-variant-autoscaler, laredo (available-vllmd-05), kellyaa, kalantar-msb, alchemy-logging (ibm), ai-native-systems-research.

Symptoms: `404 Integration not found` on token creation, and — user-visible — agents authoring as `kubestellar-hive-ghe[bot]` on public repos (`app_slug` → `ResolvedAppSlug()` → `BotLogin()` → `EffectiveAIAuthor()` → `PROJECT_AI_AUTHOR`).

## Root cause: the model was wrong

`clusters.json` has **one identity slot per cluster**, which made a cluster's forge a *pin* rather than a *default*. Those seven hives had already elected `github.com` — each carries `"github_host": "github.com"` in its hub `meta.json` — but cluster config silently overrode it. **The hub knew the right answer and had no field in which to act on it.**

Repair was blocked, too. `POST /api/saas/hives/hosted-available-vllmd-05/forge {"host":"github.com"}` returned **409** `"the target forge identity is incomplete for cluster \"vllm-d\""`, because `forgeIdentityForTarget` resolved identity from the single cluster slot and found no public App. That refusal was *correct* — and a dead end.

Per the platform owner: **"vllm-d is used for GHE, but gh can be elected."**

## What this changes

**1. `clusters.json` carries identity for both forges.** `ClusterConfig` gains `forges` (host → `{app_id, app_slug, api_url, base_url}`) and `default_forge`. **Purely additive**: `forgesForCluster` reads the existing flat `github_*` fields as the *default forge's* identity, so every current entry parses and behaves unchanged.

```jsonc
{
  "id": "vllm-d",
  "github_base_url": "https://github.ibm.com",   // unchanged — still the default
  "github_app_id": 5686,
  "github_app_slug": "kubestellar-hive-ghe",
  "forges": {                                     // added: public can now be elected
    "github.com": { "app_id": 3568013, "app_slug": "kubestellar-hive" }
  }
}
```

**2. The forge endpoint resolves a public election on a GHE-default cluster** instead of 409ing — it now refuses only a target the cluster has no identity *for*.

**3. `forge:` on `GitHubConfig`,** plus `Forge()`, `ResolvedAppID()`, `ForgeIdentityMismatches()`; `ResolvedAppSlug()` now derives from the forge. All six identity values are named constants.

**Precedence:** explicit `forge` wins; otherwise infer via the existing `HostLabel()`/`IsGHE()` logic. A spoke not yet backfilled resolves exactly as today.

## What is preserved

- **The 409 guard.** Refuse-rather-than-half-apply is the property that stopped this incident getting worse. An incomplete or absent identity still returns missing field names and still writes nothing — `TestLegacySingleIdentityClusterUnchanged` and `TestIncompleteForgeEntryStillRefuses` pin it.
- **`installation_id`** — per-forge AND per-org, obtainable only from `GET /app/installations`, never derived. All seven affected IDs are verified intact and are not touched.
- **No live config is changed by this PR.** No `clusters.json` edit, no spoke edit, no forge POST. The backfill is separate and needs its own authorisation.

## Corrections to the original brief

Two things in the plan turned out not to match the code:

1. **`IdentitySetIssues` is not unreachable on the incident shape.** The brief said all three GHE markers derive from fleet-wide-empty fields. In fact `slugIsGHE` fires on the real incident set, because the pushed slug *was* `kubestellar-hive-ghe`. Verified by running it.
2. **But there is a worse, genuinely invisible variant.** `app_id: 5686` + `app_slug: kubestellar-hive` + empty URLs yields **zero** issues — a lone GHE app_id contradicts nothing when the function only compares the four fields against *each other*. That is why this PR anchors on the **declared forge** (an external reference the pusher does not control) rather than extending the mutual-comparison rule.

## Testing

- **16-combination identity table** — every mixed state reported, both coherent states accepted.
- **Incident regression** asserted through the real `config.Load` path, not a struct literal.
- **Mixed-forge cluster** — a `github.com` and a `github.ibm.com` hive on one entry both resolve, with an explicit anti-leakage assertion.
- **Real spoke YAML shapes** parsed by the real loader: implicit-public (fleet majority), fully-populated GHE, pooled GHE placeholder with `base_url` absent, token-only.
- **Mutation-tested**: 10 deliberate breakages, all caught. One initially **survived** — the `api_url`/`base_url` checks are structurally unreachable from the 16-combo table, since inferring the forge from the fields means a URL can never contradict it. `TestForgeURLFieldsMustMatchDeclaredForge` was added specifically to reach them, and kills that mutant.

`oauth_provision_coverage_test.go:230-248` passes unchanged. No test file was edited to accommodate this change.

## Notes

- **`githubHostPublic` does not retire in this PR.** It has 14 live uses across `forge.go`/`saas_provision.go`/`saas.go` and is part of the provisioning **request** contract (`"public"` as an API input value), entirely hub-side — it never reaches spoke config. Retiring it is a separate, mechanical change once `forge` is backfilled; doing it here would mix an API-contract change into an identity-resolution change.
- One **behaviour change worth review**: config validation now accepts a hive whose identity comes from an explicit `forge:` alone (`github.token, github.app_id or github.forge is required`). Deliberately keyed on the raw field, not `Forge()` — the latter *infers* public for a blank config, which would let an empty `github:` block validate and boot a hive with no credentials.

**Not merging** — this changes identity resolution fleet-wide, so it is the owner's call.
