### PR TITLE
🐛 fix(config): reject half-applied GitHub identity sets on the write path

### DIFF
--- a/v2/cmd/hive/identity_guard_test.go
+++ b/v2/cmd/hive/identity_guard_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/hub"
+)
+
+// prospectiveGitHubIdentity must mirror the adoption rules in
+// GitHubAppConfigCallback exactly. If it drifts, the guard validates an
+// identity the spoke will never hold and the real write goes unchecked.
+
+func TestProspectiveIdentity_IncidentPushIsRejected(t *testing.T) {
+	// A healthy public spoke: app_id 3568013, empty URLs — the shape ~41 of the
+	// fleet runs today.
+	cur := config.GitHubConfig{
+		AppID:          config.PublicGitHubAppID,
+		AppSlug:        config.PublicGitHubAppSlug,
+		InstallationID: 149922991,
+	}
+	// The 2026-07-31 push: the GHE App, with no api_url (this channel has no
+	// field for one).
+	push := &hub.HeartbeatGitHubAppConfig{
+		AppID:   config.EnterpriseGitHubAppID,
+		AppSlug: config.EnterpriseGitHubAppSlug,
+	}
+
+	prospective := prospectiveGitHubIdentity(cur, push)
+	if prospective == nil {
+		t.Fatal("a push that changes app_id and app_slug must produce a prospective identity to validate")
+	}
+	// The pushed app_id MUST appear in the prospective identity. Without this
+	// assertion the test passes even if app_id is dropped entirely, because the
+	// slug alone trips the legacy slugIsGHE rule — a rejection for the wrong
+	// reason, on a marker that is empty on most of the real fleet.
+	if prospective.AppID != config.EnterpriseGitHubAppID {
+		t.Fatalf("prospective app_id = %d, want the PUSHED %d — the guard must validate the app_id the spoke would actually adopt",
+			prospective.AppID, config.EnterpriseGitHubAppID)
+	}
+	if prospective.AppSlug != config.EnterpriseGitHubAppSlug {
+		t.Fatalf("prospective app_slug = %q, want the pushed %q", prospective.AppSlug, config.EnterpriseGitHubAppSlug)
+	}
+	if prospective.APIURL != "" {
+		t.Fatalf("prospective api_url = %q, want empty — the channel cannot deliver one, which is the whole defect", prospective.APIURL)
+	}
+	if err := config.RejectIdentitySet(*prospective); err == nil {
+		t.Fatal("the incident push was ACCEPTED at the spoke write path")
+	}
+}
+
+// TestProspectiveIdentity_AppIDAloneIsEnoughToReject is the reachability half at
+// the spoke boundary. The hub can push an app_id with NO slug (the cluster's
+// github_app_slug is empty on several records), leaving every string marker
+// blank — so only an app_id-keyed rule can catch it. If this passes while
+// app_id is dropped from the prospective identity, the guard is decorative.
+func TestProspectiveIdentity_AppIDAloneIsEnoughToReject(t *testing.T) {
+	cur := config.GitHubConfig{AppID: config.PublicGitHubAppID} // healthy public spoke, all URLs empty
+	push := &hub.HeartbeatGitHubAppConfig{AppID: config.EnterpriseGitHubAppID}
+
+	prospective := prospectiveGitHubIdentity(cur, push)
+	if prospective == nil {
+		t.Fatal("an app_id-only push must still be validated")
+	}
+	if prospective.AppSlug != "" || prospective.APIURL != "" || prospective.BaseURL != "" {
+		t.Fatalf("premise broken: expected every string marker empty, got %+v", prospective)
+	}
+	if err := config.RejectIdentitySet(*prospective); err == nil {
+		t.Fatal("a GHE app_id pushed onto a public spoke with no other identity field was ACCEPTED — the spoke guard is unreachable on real fleet data")
+	}
+}
+
+func TestProspectiveIdentity_HealthyPushIsAccepted(t *testing.T) {
+	cur := config.GitHubConfig{AppID: config.PlaceholderAppID}
+	push := &hub.HeartbeatGitHubAppConfig{
+		AppID:   config.PublicGitHubAppID,
+		AppSlug: config.PublicGitHubAppSlug,
+	}
+	prospective := prospectiveGitHubIdentity(cur, push)
+	if prospective == nil {
+		t.Fatal("a real app_id replacing the placeholder must be validated, not skipped")
+	}
+	if err := config.RejectIdentitySet(*prospective); err != nil {
+		t.Fatalf("a healthy public App push was refused: %v", err)
+	}
+}
+
+func TestProspectiveIdentity_GHEPushOntoAGHESpokeIsAccepted(t *testing.T) {
+	// A GHE spoke already carrying its api_url. Receiving its own cluster's App
+	// is consistent and must apply.
+	cur := config.GitHubConfig{APIURL: config.EnterpriseGitHubAPIURL}
+	push := &hub.HeartbeatGitHubAppConfig{
+		AppID:   config.EnterpriseGitHubAppID,
+		AppSlug: config.EnterpriseGitHubAppSlug,
+	}
+	prospective := prospectiveGitHubIdentity(cur, push)
+	if prospective == nil {
+		t.Fatal("want a prospective identity")
+	}
+	if err := config.RejectIdentitySet(*prospective); err != nil {
+		t.Fatalf("a GHE App delivered to a GHE spoke was refused: %v", err)
+	}
+}
+
+func TestProspectiveIdentity_NoIdentityFieldsMeansNothingToValidate(t *testing.T) {
+	cur := config.GitHubConfig{AppID: config.PublicGitHubAppID, AppSlug: config.PublicGitHubAppSlug}
+	// A key-only delivery: the common case, and it must not be gated.
+	if got := prospectiveGitHubIdentity(cur, &hub.HeartbeatGitHubAppConfig{PrivateKey: "pem"}); got != nil {
+		t.Errorf("a key-only push produced a prospective identity %+v, want nil", got)
+	}
+	// An echo of the values we already hold.
+	if got := prospectiveGitHubIdentity(cur, &hub.HeartbeatGitHubAppConfig{AppSlug: config.PublicGitHubAppSlug}); got != nil {
+		t.Errorf("a no-op slug echo produced a prospective identity %+v, want nil", got)
+	}
+	if got := prospectiveGitHubIdentity(cur, nil); got != nil {
+		t.Errorf("a nil push produced %+v, want nil", got)
+	}
+}
+
+func TestProspectiveIdentity_PlaceholderIsNeverAdopted(t *testing.T) {
+	// Mirrors the callback: the placeholder sentinel must not overwrite a real
+	// app_id, so it must not appear in the prospective identity either.
+	cur := config.GitHubConfig{AppID: config.EnterpriseGitHubAppID, APIURL: config.EnterpriseGitHubAPIURL}
+	got := prospectiveGitHubIdentity(cur, &hub.HeartbeatGitHubAppConfig{AppID: config.PlaceholderAppID})
+	if got != nil {
+		t.Fatalf("the placeholder sentinel was treated as an adoption: %+v", got)
+	}
+}

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -117,6 +117,37 @@ func agentActivityFor(mgr *agent.Manager, name string, proc *agent.AgentProcess)
 	return act
 }
 
+// prospectiveGitHubIdentity returns the GitHub identity the spoke WOULD hold
+// after adopting ghCfg, or nil when the push speaks to no identity field and
+// there is nothing to validate.
+//
+// It mirrors the adoption rules in the GitHubAppConfigCallback exactly — a
+// zero app_id and an empty app_slug both mean "not speaking to this field", and
+// the placeholder sentinel is never adopted over a real App. Mirroring rather
+// than validating ghCfg alone is what makes the check correct: the damaging
+// state is a combination of PUSHED and EXISTING fields (a GHE app_id landing
+// beside the spoke's own empty api_url), and validating the push in isolation
+// cannot see it.
+func prospectiveGitHubIdentity(cur config.GitHubConfig, ghCfg *hub.HeartbeatGitHubAppConfig) *config.GitHubConfig {
+	if ghCfg == nil {
+		return nil
+	}
+	touched := false
+	next := cur
+	if ghCfg.AppID != 0 && ghCfg.AppID != config.PlaceholderAppID {
+		next.AppID = ghCfg.AppID
+		touched = true
+	}
+	if ghCfg.AppSlug != "" && ghCfg.AppSlug != cur.AppSlug {
+		next.AppSlug = ghCfg.AppSlug
+		touched = true
+	}
+	if !touched {
+		return nil
+	}
+	return &next
+}
+
 func perAppIDKeyPath(appID int64) string {
 	if appID <= 0 {
 		return ""
@@ -2611,6 +2642,36 @@ func main() {
 				"has_key", ghCfg.PrivateKey != "",
 			)
 
+			// WRITE-PATH GUARD. Compute the identity this push WOULD produce and
+			// refuse the whole delivery if it is internally inconsistent.
+			//
+			// This is the guard the 2026-07-31 incident needed. That push carried
+			// the GHE app_id and slug with no api_url; the adoption below applies
+			// each field independently under an "empty means unchanged" contract,
+			// so seven public-GitHub hives took the GHE App ID, kept api_url: "",
+			// and every token request 404'd. Refusing the whole delivery leaves
+			// those hives on their previous, working identity instead of a half of
+			// two identities.
+			//
+			// Rejection is loud and repeats on every beat: the hub keeps pushing
+			// until the spoke reports back, so a silent skip would be an invisible
+			// permanent stall. There is no auto-repair here — the fix is on the
+			// hub, in clusters.json.
+			if prospective := prospectiveGitHubIdentity(cfg.GitHub, ghCfg); prospective != nil {
+				if err := config.RejectIdentitySet(*prospective); err != nil {
+					logger.Error("REFUSING hub github app config: the pushed identity set is inconsistent and would half-apply — nothing was changed",
+						"error", err,
+						"pushed_app_id", ghCfg.AppID,
+						"pushed_app_slug", ghCfg.AppSlug,
+						"current_app_id", cfg.GitHub.AppID,
+						"current_api_url", cfg.GitHub.APIURL,
+						"current_base_url", cfg.GitHub.BaseURL,
+						"remedy", "correct github_app_id/github_app_slug/github_api_url/github_base_url for this cluster on the hub",
+					)
+					return
+				}
+			}
+
 			keyPath := spokeAppKeyPath
 			// keyChanged gates dropping the cached installation token below: a
 			// token minted under the previous key is invalid the moment the key
@@ -2877,9 +2938,26 @@ func main() {
 			// means "leave mine alone" — the spoke's own default is already
 			// api.github.com, so this never clobbers a working config.
 			if pc.GitHubAPIURL != "" && cfg.GitHub.APIURL != pc.GitHubAPIURL {
-				logger.Info("adopting GitHub API URL from hub heartbeat",
-					"was", cfg.GitHub.APIURL, "now", pc.GitHubAPIURL)
-				cfg.GitHub.APIURL = pc.GitHubAPIURL
+				// WRITE-PATH GUARD, mirroring the App-config callback: an api_url
+				// that names a different forge than our app_id is the same
+				// half-applied identity arriving from the other direction. Skip
+				// only this field — the org/repos/ACMM adoption around it is
+				// unrelated and must still land.
+				prospective := cfg.GitHub
+				prospective.APIURL = pc.GitHubAPIURL
+				if err := config.RejectIdentitySet(prospective); err != nil {
+					logger.Error("REFUSING hub GitHub API URL: it does not match this hive's app_id and would half-apply an identity — api_url left unchanged",
+						"error", err,
+						"pushed_api_url", pc.GitHubAPIURL,
+						"current_api_url", cfg.GitHub.APIURL,
+						"current_app_id", cfg.GitHub.AppID,
+						"remedy", "correct github_api_url/github_app_id for this cluster on the hub",
+					)
+				} else {
+					logger.Info("adopting GitHub API URL from hub heartbeat",
+						"was", cfg.GitHub.APIURL, "now", pc.GitHubAPIURL)
+					cfg.GitHub.APIURL = pc.GitHubAPIURL
+				}
 			}
 			level := pc.ACMMLevel
 			cfg.ACMMLevel = &level

--- a/v2/pkg/config/identity_reject_test.go
+++ b/v2/pkg/config/identity_reject_test.go
@@ -1,0 +1,328 @@
+package config
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// These tests exist because a previous version of the identity check passed
+// against fixtures crafted to match it while being UNREACHABLE on real fleet
+// data: all three of its markers (apiIsGHE, baseIsGHE, slugIsGHE) derive from
+// fields that are empty on ~41 of ~51 production spokes. Every test here that
+// asserts a rejection uses a shape that occurs on the real fleet.
+
+// identityCombo names one of the 16 states of the four identity fields, with
+// each field taking either its public value or its enterprise value.
+type identityCombo struct {
+	appID   int64
+	slug    string
+	apiURL  string
+	baseURL string
+}
+
+func (c identityCombo) cfg() GitHubConfig {
+	return GitHubConfig{
+		AppID:   c.appID,
+		AppSlug: c.slug,
+		APIURL:  c.apiURL,
+		BaseURL: c.baseURL,
+	}
+}
+
+// TestIdentitySet_All16Combinations walks every combination of the four fields
+// across their public and enterprise values. Exactly two are valid; the other
+// fourteen are mixed forges and must be rejected.
+//
+// The public "value" for api_url and base_url is the EXPLICIT URL here; the
+// empty-string form (which is what the fleet actually runs) is covered
+// separately in TestIdentitySet_RealFleetShapes so a failure tells you which of
+// the two is broken.
+//
+// ONE EXCEPTION, and it is a deliberate one. app_slug is NOT derivable from
+// app_id: App ID 5686 legitimately appears in this tree under both
+// "kubestellar-hive-ghe" and "ibm-hive" (the vllm-d cluster fixture), because a
+// slug is an operator-chosen App URL name. So the combination
+//
+//	app_id 5686 + slug kubestellar-hive + GHE api_url + GHE base_url
+//
+// is a REAL, VALID production shape wearing a slug that happens not to contain
+// "ghe" — a rule rejecting it would refuse a live cluster. It is enumerated
+// below as wantValid, with the reason attached, rather than quietly skipped.
+// See the note on EnterpriseGitHubAppSlug.
+func TestIdentitySet_All16Combinations(t *testing.T) {
+	appIDs := []int64{PublicGitHubAppID, EnterpriseGitHubAppID}
+	slugs := []string{PublicGitHubAppSlug, EnterpriseGitHubAppSlug}
+	apiURLs := []string{DefaultGitHubAPIURL, EnterpriseGitHubAPIURL}
+	baseURLs := []string{DefaultGitHubBaseURL, EnterpriseGitHubBaseURL}
+
+	// Index 0 = public, 1 = enterprise. The forge of an identity is decided by
+	// app_id, api_url and base_url; those three must agree.
+	seen, rejected := 0, 0
+	for ai, appID := range appIDs {
+		for si, slug := range slugs {
+			for pi, apiURL := range apiURLs {
+				for bi, baseURL := range baseURLs {
+					seen++
+					combo := identityCombo{appID: appID, slug: slug, apiURL: apiURL, baseURL: baseURL}
+					forgeAgrees := ai == pi && pi == bi
+					// The slug may lag the forge only in the direction that is
+					// genuinely ambiguous: a GHE App under a slug without the
+					// "ghe" marker. A public App under a GHE-marked slug is
+					// unambiguously wrong and stays rejected.
+					slugTolerated := si == ai || (ai == 1 && si == 0)
+					wantValid := forgeAgrees && slugTolerated
+
+					err := RejectIdentitySet(combo.cfg())
+					if err != nil {
+						rejected++
+					}
+					if wantValid && err != nil {
+						t.Errorf("valid identity %+v was REJECTED: %v", combo, err)
+					}
+					if !wantValid && err == nil {
+						t.Errorf("mixed identity %+v was ACCEPTED — this is the class of state that took down seven hives", combo)
+					}
+					if !wantValid && err != nil && !errors.Is(err, ErrIdentitySetMismatch) {
+						t.Errorf("rejection of %+v did not wrap ErrIdentitySetMismatch: %v", combo, err)
+					}
+				}
+			}
+		}
+	}
+	if seen != 16 {
+		t.Fatalf("walked %d combinations, want 16", seen)
+	}
+	// 3 valid: public×public, GHE×GHE, and the GHE App under the non-"ghe"
+	// slug. Pinning the count catches a rule that silently stops firing.
+	if want := 13; rejected != want {
+		t.Errorf("rejected %d of 16 combinations, want %d", rejected, want)
+	}
+}
+
+// TestIdentitySet_Incident2026_07_31 pins the EXACT field set of the incident:
+// a GHE app_id and slug pushed onto a public-GitHub hive whose api_url and
+// base_url were never sent and so stayed empty. This is the write that must be
+// refused.
+func TestIdentitySet_Incident2026_07_31(t *testing.T) {
+	incident := GitHubConfig{
+		AppID:   EnterpriseGitHubAppID,   // 5686
+		AppSlug: EnterpriseGitHubAppSlug, // kubestellar-hive-ghe
+		APIURL:  "",                      // EMPTY — resolves to api.github.com
+		BaseURL: "",                      // EMPTY
+	}
+	err := RejectIdentitySet(incident)
+	if err == nil {
+		t.Fatal("the 2026-07-31 incident field set was ACCEPTED — this is the write that produced 404 Integration not found on seven hives")
+	}
+	if !errors.Is(err, ErrIdentitySetMismatch) {
+		t.Errorf("incident rejection did not wrap ErrIdentitySetMismatch: %v", err)
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("rejection text %q does not name the observed failure", err)
+	}
+}
+
+// TestIdentitySet_RealFleetShapes is the REACHABILITY test. It builds configs in
+// the shapes that actually exist on the fleet — empty api_url, empty base_url,
+// often an empty app_slug — and asserts the rule still fires when app_id names
+// the wrong forge.
+//
+// If this test can be made to pass by a rule that keys only on api_url/base_url/
+// app_slug string markers, the rule is unreachable in production. It cannot: on
+// every rejected case below all three of those markers are false or empty.
+func TestIdentitySet_RealFleetShapes(t *testing.T) {
+	tests := []struct {
+		name       string
+		gh         GitHubConfig
+		wantReject bool
+	}{
+		{
+			// ~41 spokes. The single most important negative case: if this is
+			// rejected, the healthy fleet breaks.
+			name:       "healthy public spoke, all URLs empty",
+			gh:         GitHubConfig{AppID: PublicGitHubAppID, AppSlug: PublicGitHubAppSlug},
+			wantReject: false,
+		},
+		{
+			name:       "healthy public spoke, URLs AND slug empty",
+			gh:         GitHubConfig{AppID: PublicGitHubAppID},
+			wantReject: false,
+		},
+		{
+			// The incident, minus the slug — the slug marker is unavailable, so
+			// only an app_id-keyed rule can catch this.
+			name:       "GHE app_id on a public spoke, slug and URLs all empty",
+			gh:         GitHubConfig{AppID: EnterpriseGitHubAppID},
+			wantReject: true,
+		},
+		{
+			// The incident as it landed.
+			name:       "GHE app_id and slug, URLs empty",
+			gh:         GitHubConfig{AppID: EnterpriseGitHubAppID, AppSlug: EnterpriseGitHubAppSlug},
+			wantReject: true,
+		},
+		{
+			// Healthy GHE spokes that carry api_url only (base_url: "") — a real
+			// shape for pooled/placeholder GHE hives.
+			name:       "healthy GHE spoke, base_url empty",
+			gh:         GitHubConfig{AppID: EnterpriseGitHubAppID, AppSlug: EnterpriseGitHubAppSlug, APIURL: EnterpriseGitHubAPIURL},
+			wantReject: false,
+		},
+		{
+			// The mirror image: a public app_id on a hive pointed at GHE.
+			name:       "public app_id with a GHE api_url",
+			gh:         GitHubConfig{AppID: PublicGitHubAppID, APIURL: EnterpriseGitHubAPIURL},
+			wantReject: true,
+		},
+		{
+			// A public App wearing a GHE-marked slug. Caught by the pre-existing
+			// slugIsGHE rule, which is legitimate in THIS direction: no valid
+			// deployment names a public App "*-ghe".
+			name:       "public app_id and URLs, enterprise slug",
+			gh:         GitHubConfig{AppID: PublicGitHubAppID, AppSlug: EnterpriseGitHubAppSlug},
+			wantReject: true,
+		},
+		{
+			// The vllm-d cluster's real shape: the GHE App under the operator-
+			// chosen slug "ibm-hive", which carries no "ghe" marker. This MUST
+			// be accepted — a rule tying app_id to a specific slug refuses a
+			// live production cluster. See pkg/hub/cluster_app_key_test.go.
+			name: "GHE app_id under the operator-chosen ibm-hive slug",
+			gh: GitHubConfig{
+				AppID:   EnterpriseGitHubAppID,
+				AppSlug: "ibm-hive",
+				APIURL:  EnterpriseGitHubAPIURL,
+				BaseURL: EnterpriseGitHubBaseURL,
+			},
+			wantReject: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := RejectIdentitySet(tc.gh)
+			if tc.wantReject && err == nil {
+				t.Fatalf("%+v was ACCEPTED, want rejected", tc.gh)
+			}
+			if !tc.wantReject && err != nil {
+				t.Fatalf("%+v was REJECTED, want accepted: %v", tc.gh, err)
+			}
+		})
+	}
+}
+
+// TestIdentitySet_RuleIsReachableWithoutStringMarkers proves the new rule does
+// not depend on any of the three legacy markers. The fixture has an empty
+// api_url, an empty base_url and an empty app_slug — so apiIsGHE, baseIsGHE and
+// slugIsGHE are ALL false — yet it is the damaged state and must be rejected.
+//
+// This is the assertion the previous check could not have made.
+func TestIdentitySet_RuleIsReachableWithoutStringMarkers(t *testing.T) {
+	gh := GitHubConfig{AppID: EnterpriseGitHubAppID} // app_id only; every string field empty
+
+	if containsFold(gh.APIURL, gheAPIURLMarker) {
+		t.Fatal("fixture has a GHE api_url — the reachability premise is broken")
+	}
+	if gh.BaseURL != "" {
+		t.Fatal("fixture has a base_url — the reachability premise is broken")
+	}
+	if containsFold(gh.AppSlug, "ghe") {
+		t.Fatal("fixture has a GHE slug — the reachability premise is broken")
+	}
+
+	if err := RejectIdentitySet(gh); err == nil {
+		t.Fatal("a GHE app_id with every string marker empty was ACCEPTED — the rule is unreachable on real fleet data, which is exactly the defect this replaces")
+	}
+}
+
+// TestIdentitySet_OneEmptyURLIsNotAContradiction pins the semantics the legacy
+// base/api rules got wrong: an EMPTY url is "unset", not "public github.com".
+//
+// ResolvedBaseURL and HostLabel are explicit that a GHE hive legitimately
+// carries only one of the two. While IdentitySetIssues merely rendered a
+// dashboard panel, reading a blank as a contradiction was noise; wired to
+// RejectIdentitySet it would refuse a GHE App push to every GHE hive that has
+// not backfilled both URLs. The rules now require both to be populated before
+// comparing them.
+func TestIdentitySet_OneEmptyURLIsNotAContradiction(t *testing.T) {
+	valid := []GitHubConfig{
+		// The vllm-d cluster record: GHE base_url declared, api_url unset.
+		{AppID: EnterpriseGitHubAppID, AppSlug: "ibm-hive", BaseURL: EnterpriseGitHubBaseURL},
+		// Pooled/placeholder GHE hives: GHE api_url declared, base_url unset.
+		{AppID: EnterpriseGitHubAppID, AppSlug: EnterpriseGitHubAppSlug, APIURL: EnterpriseGitHubAPIURL},
+	}
+	for _, gh := range valid {
+		if err := RejectIdentitySet(gh); err != nil {
+			t.Errorf("%+v was rejected, but one unset URL defers to the other — it is not a forge disagreement: %v", gh, err)
+		}
+	}
+
+	// Both populated and disagreeing IS a contradiction and must still fire.
+	both := GitHubConfig{
+		AppID:   EnterpriseGitHubAppID,
+		BaseURL: EnterpriseGitHubBaseURL,
+		APIURL:  DefaultGitHubAPIURL,
+	}
+	if err := RejectIdentitySet(both); err == nil {
+		t.Error("two populated URLs naming different forges were accepted")
+	}
+}
+
+// TestIdentitySet_UnknownAppIDIsNotJudged guards against the rule becoming a
+// gate on deployments this build does not know about. An App ID from a third
+// forge, or a self-hosted deployment, carries no forge information and must not
+// be treated as a mismatch.
+func TestIdentitySet_UnknownAppIDIsNotJudged(t *testing.T) {
+	for _, gh := range []GitHubConfig{
+		{AppID: 4242424},
+		{AppID: 4242424, APIURL: "https://git.example.com/api/v3", BaseURL: "https://git.example.com"},
+		{AppID: PlaceholderAppID},
+		{AppID: PlaceholderAppID, AppSlug: PublicGitHubAppSlug},
+		{Token: "x"}, // token-auth hive, no App at all
+	} {
+		if err := RejectIdentitySet(gh); err != nil {
+			t.Errorf("%+v was rejected, but this build knows nothing about that App: %v", gh, err)
+		}
+	}
+}
+
+// TestIdentitySet_ByteExactDefaults pins the identity constants against the
+// resolver defaults they must agree with. A drift here silently un-reaches the
+// rule: forgeOfAppID compares against DefaultGitHubBaseURL's host.
+func TestIdentitySet_ByteExactDefaults(t *testing.T) {
+	if got := (GitHubConfig{AppID: PublicGitHubAppID}).ResolvedAPIURL(); got != DefaultGitHubAPIURL {
+		t.Errorf("ResolvedAPIURL on an empty api_url = %q, want %q", got, DefaultGitHubAPIURL)
+	}
+	if got := (GitHubConfig{AppID: PublicGitHubAppID}).ResolvedBaseURL(); got != DefaultGitHubBaseURL {
+		t.Errorf("ResolvedBaseURL on an empty base_url = %q, want %q", got, DefaultGitHubBaseURL)
+	}
+	if got := (GitHubConfig{AppID: PublicGitHubAppID}).ResolvedAppSlug(); got != PublicGitHubAppSlug {
+		t.Errorf("ResolvedAppSlug on an empty app_slug = %q, want %q", got, PublicGitHubAppSlug)
+	}
+	if forgeOfAppID(PublicGitHubAppID) != "github.com" {
+		t.Errorf("forgeOfAppID(public) = %q, want github.com", forgeOfAppID(PublicGitHubAppID))
+	}
+	if forgeOfAppID(EnterpriseGitHubAppID) != "github.ibm.com" {
+		t.Errorf("forgeOfAppID(enterprise) = %q, want github.ibm.com", forgeOfAppID(EnterpriseGitHubAppID))
+	}
+	if forgeOfAppID(0) != "" || forgeOfAppID(PlaceholderAppID) != "" {
+		t.Error("forgeOfAppID must claim nothing for zero or the placeholder sentinel")
+	}
+}
+
+// TestRejectIdentitySet_CleanConfigReturnsNil is the contract the write-path
+// callers depend on: no issues means no error, so a healthy push applies.
+func TestRejectIdentitySet_CleanConfigReturnsNil(t *testing.T) {
+	if err := RejectIdentitySet(GitHubConfig{AppID: PublicGitHubAppID, AppSlug: PublicGitHubAppSlug}); err != nil {
+		t.Fatalf("healthy public identity rejected: %v", err)
+	}
+	if err := RejectIdentitySet(GitHubConfig{
+		AppID:   EnterpriseGitHubAppID,
+		AppSlug: EnterpriseGitHubAppSlug,
+		APIURL:  EnterpriseGitHubAPIURL,
+		BaseURL: EnterpriseGitHubBaseURL,
+	}); err != nil {
+		t.Fatalf("healthy enterprise identity rejected: %v", err)
+	}
+}

--- a/v2/pkg/config/provenance.go
+++ b/v2/pkg/config/provenance.go
@@ -20,8 +20,11 @@ package config
 // It changes no behaviour.
 
 import (
+	"errors"
+	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 )
 
 // FieldOrigin records where one field's effective value came from.
@@ -223,6 +226,59 @@ func (p *Provenance) Report(cfg *Config) []FieldOrigin {
 // api.github.com (or an empty api_url, which defaults to it).
 const gheAPIURLMarker = "/api/v3"
 
+// The two valid GitHub identity sets, as named constants. Every one of these
+// values appears somewhere in the tree as a bare literal today; the rules below
+// must never grow one.
+const (
+	// PublicGitHubAppID is the numeric App ID of the public github.com
+	// kubestellar-hive GitHub App.
+	PublicGitHubAppID int64 = 3568013
+	// PublicGitHubAppSlug is that App's URL slug (== DefaultGitHubAppSlug).
+	PublicGitHubAppSlug = DefaultGitHubAppSlug
+
+	// EnterpriseGitHubAppID is the numeric App ID of the github.ibm.com
+	// kubestellar-hive-ghe GitHub App. This is the value that was pushed onto
+	// seven public-GitHub hives on 2026-07-31.
+	EnterpriseGitHubAppID int64 = 5686
+	// EnterpriseGitHubAppSlug is the slug the config/dashboard paths use for
+	// that App.
+	//
+	// NOTE: app_slug is NOT derivable from app_id, and no rule here treats it
+	// as such. App ID 5686 appears in this tree under TWO slugs — this one and
+	// "ibm-hive", which is what the vllm-d cluster fixture carries (see
+	// pkg/hub/cluster_app_key_test.go). Both are legitimate: the slug is an
+	// operator-chosen App URL name, so a rule asserting "app_id 5686 implies
+	// slug kubestellar-hive-ghe" refuses a real production cluster. Only the
+	// app_id → FORGE mapping below is safe to assert.
+	EnterpriseGitHubAppSlug = "kubestellar-hive-ghe"
+	// EnterpriseGitHubAPIURL and EnterpriseGitHubBaseURL are the forge URLs the
+	// enterprise App lives on.
+	EnterpriseGitHubAPIURL  = "https://github.ibm.com/api/v3"
+	EnterpriseGitHubBaseURL = "https://github.ibm.com"
+)
+
+// forgeOfAppID classifies an app_id as belonging to a KNOWN forge.
+//
+// This is the only identity marker that is reliably populated on the real
+// fleet. api_url and base_url are empty on ~41 of ~51 spokes (empty is the
+// public default and nothing ever backfilled it), and app_slug is empty on many
+// more — so every rule keyed on those three strings is unreachable in
+// production for exactly the hives that need checking. app_id is required by
+// config validation and is therefore always present.
+//
+// Returns "" for an App ID this build does not recognise (a third forge, a
+// self-hosted deployment, the placeholder sentinel): unknown must never be
+// treated as a mismatch, or a legitimate deployment is refused.
+func forgeOfAppID(appID int64) string {
+	switch appID {
+	case PublicGitHubAppID:
+		return DefaultGitHubBaseURL[len("https://"):] // "github.com"
+	case EnterpriseGitHubAppID:
+		return EnterpriseGitHubBaseURL[len("https://"):] // "github.ibm.com"
+	}
+	return ""
+}
+
 // IdentitySetIssues reports inconsistencies within the GitHub identity set:
 // app_id, app_slug, api_url and base_url are ONE atomic identity and no valid
 // mixture of forges exists.
@@ -243,14 +299,42 @@ const gheAPIURLMarker = "/api/v3"
 // refuses half-applied identities by construction; the cluster-config push
 // path has no such guard.
 //
-// This function only DETECTS and NAMES the invalid state — it changes no
-// behaviour and rejects nothing. Surfacing it in provenance is what makes the
-// split visible at a glance instead of via a 404 in agent logs.
+// This function DETECTS and NAMES the invalid state. Callers on the WRITE path
+// (see RejectIdentitySet) refuse a config carrying any of these issues rather
+// than applying it partially; the provenance API renders the same list for
+// display.
 func IdentitySetIssues(gh GitHubConfig) []string {
 	var issues []string
 	apiIsGHE := containsFold(gh.APIURL, gheAPIURLMarker)
 	baseIsGHE := gh.BaseURL != "" && !containsFold(gh.BaseURL, "github.com")
 	slugIsGHE := containsFold(gh.AppSlug, "ghe")
+
+	// RULE 0 — the app_id rule. Keyed on the ONE identity field that is always
+	// populated on the real fleet, so unlike the three string-marker rules below
+	// it actually fires on the shape the incident produced:
+	//
+	//	app_id:   5686                  <- GHE App
+	//	app_slug: kubestellar-hive-ghe
+	//	api_url:  ""                    <- EMPTY, resolves to api.github.com
+	//	base_url: ""
+	//
+	// HostLabel() resolves an empty api_url/base_url to "github.com", which is
+	// what makes this comparison meaningful: it asks "does the forge this App
+	// belongs to match the forge this hive will actually talk to?", where the
+	// second half already accounts for empty-means-public. A healthy public hive
+	// (app_id 3568013, both URLs empty) compares github.com against github.com
+	// and passes — which it must, because ~41 spokes run exactly that way.
+	//
+	// Unknown App IDs (a third forge, self-hosted, the placeholder sentinel) are
+	// skipped: forgeOfAppID returns "" and no claim is made.
+	if appForge := forgeOfAppID(gh.AppID); appForge != "" {
+		if host := gh.HostLabel(); !strings.EqualFold(host, appForge) {
+			issues = append(issues, "app_id "+strconv.FormatInt(gh.AppID, 10)+
+				" is the GitHub App on "+appForge+", but api_url ("+displayOrEmpty(gh.APIURL)+
+				") and base_url ("+displayOrEmpty(gh.BaseURL)+") resolve to "+host+
+				" — an App ID presented to the wrong forge returns 404 Integration not found")
+		}
+	}
 
 	// The live regression: an App is configured and the forge markers
 	// disagree with each other.
@@ -260,16 +344,59 @@ func IdentitySetIssues(gh GitHubConfig) []string {
 				") but api_url is not a GHE API URL ("+displayOrEmpty(gh.APIURL)+
 				") — a GHE App ID presented to api.github.com returns 404 Integration not found")
 		}
-		if baseIsGHE && !apiIsGHE {
-			issues = append(issues, "base_url is "+gh.BaseURL+" but api_url is "+
-				displayOrEmpty(gh.APIURL)+" — base_url and api_url must name the same forge")
-		}
-		if apiIsGHE && gh.BaseURL != "" && !baseIsGHE {
-			issues = append(issues, "api_url is a GHE API URL but base_url is "+gh.BaseURL+
-				" — base_url and api_url must name the same forge")
+		// base_url and api_url must name the same forge — but ONLY when both are
+		// actually set.
+		//
+		// An empty one is not a public one. ResolvedBaseURL and HostLabel are
+		// explicit that a GHE hive legitimately carries
+		// api_url: https://github.ibm.com/api/v3 with base_url: "" (pooled and
+		// placeholder GHE hives all do), and the symmetric case — a declared GHE
+		// base_url with api_url unset — is the shape of the vllm-d cluster
+		// record. Treating either silence as "public github.com" makes these two
+		// rules fire on VALID configs.
+		//
+		// That was harmless while this function only rendered a dashboard panel.
+		// It is not harmless now that RejectIdentitySet refuses writes: reading
+		// an empty api_url as a contradiction would refuse the GHE App push to
+		// every GHE hive that has not backfilled both URLs. Requiring both to be
+		// populated before comparing them is what keeps the rule true rather
+		// than merely loud. The app_id rule above still catches the incident,
+		// which is the case where BOTH are empty.
+		if gh.APIURL != "" && gh.BaseURL != "" {
+			if baseIsGHE && !apiIsGHE {
+				issues = append(issues, "base_url is "+gh.BaseURL+" but api_url is "+
+					gh.APIURL+" — base_url and api_url must name the same forge")
+			}
+			if apiIsGHE && !baseIsGHE {
+				issues = append(issues, "api_url is a GHE API URL but base_url is "+gh.BaseURL+
+					" — base_url and api_url must name the same forge")
+			}
 		}
 	}
 	return issues
+}
+
+// ErrIdentitySetMismatch is the sentinel returned by RejectIdentitySet. Callers
+// on the write path test for it with errors.Is to distinguish "this push is
+// internally inconsistent" from any other failure.
+var ErrIdentitySetMismatch = errors.New("github identity set is internally inconsistent")
+
+// RejectIdentitySet is the WRITE-PATH guard. It returns a non-nil error when
+// applying gh would leave a hive with a half-applied GitHub identity.
+//
+// It is the caller IdentitySetIssues never had. Detection alone is what let the
+// 2026-07-31 push land: the mismatch was rendered on a dashboard panel while
+// every spoke applied it field by field, adopting the GHE app_id and leaving
+// api_url empty because "empty means unchanged".
+//
+// Callers must apply NOTHING when this returns an error. Applying the
+// consistent subset is the failure mode, not the remedy.
+func RejectIdentitySet(gh GitHubConfig) error {
+	issues := IdentitySetIssues(gh)
+	if len(issues) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%w: %s", ErrIdentitySetMismatch, strings.Join(issues, "; "))
 }
 
 // displayOrEmpty renders an empty string as an explicit marker, so a report

--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -792,12 +792,77 @@ func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFing
 			"to_fingerprint", decision.ToFingerprint,
 		)
 	}
+	// WRITE-PATH GUARD, hub side. This struct is the exact channel that carried
+	// the 2026-07-31 breakage: it delivers app_id and app_slug and has no field
+	// for api_url, so a cluster whose github_app_id names one forge while its
+	// URLs name another pushes a half identity the spoke cannot reassemble.
+	// Refuse to construct it.
+	//
+	// Validated against the identity the CLUSTER declares — app_id and app_slug
+	// from the App identity, api_url and base_url from the cluster record — so a
+	// clusters.json entry naming a GHE App beside public-GitHub URLs is caught
+	// at the source. The spoke re-validates against its own current values,
+	// which is the half this side cannot see.
+	//
+	// GATED ON THE CLUSTER DECLARING A FORGE AT ALL. A cluster record with both
+	// URLs empty is UNDER-SPECIFIED, not public: several real records carry only
+	// github_app_id and github_app_slug, and clusterIsGHE above already treats
+	// empty github_base_url as "no forge information". Reading that silence as
+	// "public github.com" here would refuse every GHE cluster that has not
+	// backfilled its URLs and stop the key/app_id repair path fleet-wide — the
+	// same class of outage this guard exists to prevent, in the other direction.
+	// Silence is never evidence. When the cluster does declare a forge, the full
+	// set is checked.
+	clusterAPIURL := clusterAPIURLForIdentity(s, clusterID)
+	clusterBaseURL := clusterBaseURLForIdentity(s, clusterID)
+	clusterDeclaresForge := clusterAPIURL != "" || clusterBaseURL != ""
+
+	if err := config.RejectIdentitySet(config.GitHubConfig{
+		AppID:   identity.AppID,
+		AppSlug: identity.AppSlug,
+		APIURL:  clusterAPIURL,
+		BaseURL: clusterBaseURL,
+	}); err != nil && clusterDeclaresForge {
+		if logger != nil {
+			logger.Error("REFUSING to push cluster github app config: the cluster's identity set is inconsistent and would half-apply on the spoke — nothing was sent",
+				"error", err,
+				"hive_id", hiveID,
+				"cluster_id", clusterID,
+				"app_id", identity.AppID,
+				"app_slug", identity.AppSlug,
+				"remedy", "correct github_app_id/github_app_slug/github_api_url/github_base_url for this cluster in clusters.json",
+			)
+		}
+		return nil
+	}
+
 	return &HeartbeatGitHubAppConfig{
 		AppID:          identity.AppID,
 		InstallationID: installationID,
 		PrivateKey:     privateKey,
 		AppSlug:        identity.AppSlug,
 	}
+}
+
+// clusterAPIURLForIdentity and clusterBaseURLForIdentity read the cluster's
+// declared forge URLs so the hub-side guard validates the FULL identity set the
+// cluster declares, not just the two fields the heartbeat channel can carry.
+//
+// An unknown cluster, or one that declares neither URL, yields empty strings.
+// The caller reads that as "no forge declared" and skips the check entirely
+// rather than assuming public github.com — see clusterDeclaresForge.
+func clusterAPIURLForIdentity(s *HubServer, clusterID string) string {
+	if c, ok := s.clusters[clusterID]; ok {
+		return strings.TrimSpace(c.GitHubAPIURL)
+	}
+	return ""
+}
+
+func clusterBaseURLForIdentity(s *HubServer, clusterID string) string {
+	if c, ok := s.clusters[clusterID]; ok {
+		return strings.TrimSpace(c.GitHubBaseURL)
+	}
+	return ""
 }
 
 // --- Operator API ---

--- a/v2/pkg/hub/identity_push_guard_test.go
+++ b/v2/pkg/hub/identity_push_guard_test.go
@@ -1,0 +1,159 @@
+package hub
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// The hub-side half of the write-path guard: appKeyConfigForHeartbeat must
+// refuse to CONSTRUCT a push whose identity set is internally inconsistent.
+//
+// HeartbeatGitHubAppConfig carries app_id and app_slug and has no api_url
+// field, so a clusters.json entry naming one forge's App beside another forge's
+// URLs is not something the spoke can reassemble — it is exactly the delivery
+// that half-applied onto seven hives on 2026-07-31.
+
+// TestPushGuard_RefusesCrossForgeClusterIdentity pins the incident's clusters.json
+// shape: a GHE app_id and slug on a cluster whose GitHub URLs are public
+// (empty == api.github.com). Nothing may be pushed.
+func TestPushGuard_RefusesCrossForgeClusterIdentity(t *testing.T) {
+	withTempAppKeyDir(t)
+
+	s := &HubServer{
+		clusters: map[string]ClusterConfig{
+			// The bad edit: the GHE App ID pasted onto a cluster that DECLARES
+			// public github.com. Declaring the forge is what makes the two
+			// halves comparable — see the gate in appKeyConfigForHeartbeat.
+			"hive-oke": {
+				ID:            "hive-oke",
+				GitHubAppID:   config.EnterpriseGitHubAppID,
+				GitHubAppSlug: config.EnterpriseGitHubAppSlug,
+				GitHubAPIURL:  config.DefaultGitHubAPIURL,
+				GitHubBaseURL: config.DefaultGitHubBaseURL,
+			},
+		},
+		logger: appKeyTestLogger(),
+	}
+
+	got := s.appKeyConfigForHeartbeat("oke11", "hive-oke",
+		"sha256:whatever", true, false, config.PlaceholderAppID, 0, s.logger)
+	if got != nil {
+		t.Fatalf("the hub CONSTRUCTED a cross-forge identity push %+v — this is the delivery that produced 404 Integration not found on seven hives", got)
+	}
+}
+
+// TestPushGuard_HealthyClusterStillPushes is the negative control. The guard
+// must not break the ordinary repair path: a consistent public cluster still
+// delivers its App to a sentinel spoke.
+func TestPushGuard_HealthyClusterStillPushes(t *testing.T) {
+	withTempAppKeyDir(t)
+
+	s := &HubServer{
+		clusters: map[string]ClusterConfig{
+			// Consistent public identity with EMPTY URLs — the live shape of
+			// most clusters. If the guard rejects this, the fleet stops
+			// self-repairing.
+			"hive-oke": {
+				ID:            "hive-oke",
+				GitHubAppID:   config.PublicGitHubAppID,
+				GitHubAppSlug: config.PublicGitHubAppSlug,
+			},
+		},
+		logger: appKeyTestLogger(),
+	}
+
+	got := s.appKeyConfigForHeartbeat("oke11", "hive-oke",
+		"sha256:whatever", true, false, config.PlaceholderAppID, 0, s.logger)
+	if got == nil {
+		t.Fatal("a consistent public cluster was refused — the guard broke the sentinel repair path")
+	}
+	if got.AppID != config.PublicGitHubAppID {
+		t.Errorf("AppID = %d, want %d", got.AppID, config.PublicGitHubAppID)
+	}
+}
+
+// TestPushGuard_HealthyGHEClusterStillPushes covers the other valid set: a GHE
+// cluster that declares its URLs consistently.
+func TestPushGuard_HealthyGHEClusterStillPushes(t *testing.T) {
+	withTempAppKeyDir(t)
+
+	s := &HubServer{
+		clusters: map[string]ClusterConfig{
+			"vllm-d": {
+				ID:            "vllm-d",
+				GitHubAppID:   config.EnterpriseGitHubAppID,
+				GitHubAppSlug: config.EnterpriseGitHubAppSlug,
+				GitHubAPIURL:  config.EnterpriseGitHubAPIURL,
+				GitHubBaseURL: config.EnterpriseGitHubBaseURL,
+			},
+		},
+		logger: appKeyTestLogger(),
+	}
+
+	got := s.appKeyConfigForHeartbeat("vd01", "vllm-d",
+		"sha256:whatever", true, false, config.PlaceholderAppID, 0, s.logger)
+	if got == nil {
+		t.Fatal("a consistent GHE cluster was refused")
+	}
+	if got.AppID != config.EnterpriseGitHubAppID {
+		t.Errorf("AppID = %d, want %d", got.AppID, config.EnterpriseGitHubAppID)
+	}
+}
+
+// TestPushGuard_UnderSpecifiedClusterIsNotGated pins the fail-safe gate. Several
+// real cluster records carry github_app_id and github_app_slug with NO forge
+// URLs — vllm-d is one. Reading that silence as "public github.com" would refuse
+// every such GHE cluster and stop the key/app_id repair path fleet-wide, which
+// is the same outage this guard exists to prevent, pointed the other way.
+func TestPushGuard_UnderSpecifiedClusterIsNotGated(t *testing.T) {
+	withTempAppKeyDir(t)
+
+	s := &HubServer{
+		clusters: map[string]ClusterConfig{
+			// The real vllm-d fixture shape: the GHE App, no declared URLs.
+			"vllm-d": {
+				ID:            "vllm-d",
+				GitHubAppID:   config.EnterpriseGitHubAppID,
+				GitHubAppSlug: "ibm-hive",
+			},
+		},
+		logger: appKeyTestLogger(),
+	}
+
+	got := s.appKeyConfigForHeartbeat("vd01", "vllm-d",
+		"sha256:whatever", true, false, config.PlaceholderAppID, 0, s.logger)
+	if got == nil {
+		t.Fatal("a cluster that declares no forge URLs was refused — silence is not evidence of public GitHub, and this stops the repair path on every un-backfilled GHE cluster")
+	}
+	if got.AppID != config.EnterpriseGitHubAppID {
+		t.Errorf("AppID = %d, want %d", got.AppID, config.EnterpriseGitHubAppID)
+	}
+}
+
+// TestPushGuard_UnknownAppIDIsNotGated keeps the guard from becoming a gate on
+// deployments this build knows nothing about — a third forge, or a self-hosted
+// App. Silence about an unknown App ID is the correct behaviour.
+func TestPushGuard_UnknownAppIDIsNotGated(t *testing.T) {
+	withTempAppKeyDir(t)
+
+	const unknownAppID = 4242424
+	s := &HubServer{
+		clusters: map[string]ClusterConfig{
+			"byo": {
+				ID:            "byo",
+				GitHubAppID:   unknownAppID,
+				GitHubAppSlug: "someones-own-app",
+				GitHubAPIURL:  "https://git.example.com/api/v3",
+				GitHubBaseURL: "https://git.example.com",
+			},
+		},
+		logger: appKeyTestLogger(),
+	}
+
+	got := s.appKeyConfigForHeartbeat("byo01", "byo",
+		"sha256:whatever", true, false, config.PlaceholderAppID, 0, s.logger)
+	if got == nil {
+		t.Fatal("a self-hosted App was refused — the guard must claim nothing about App IDs it does not recognise")
+	}
+}


### PR DESCRIPTION
## The gap

`IdentitySetIssues` already detected mismatched GitHub identity sets. Its only non-test caller was `pkg/dashboard/api_provenance.go`, which **rendered** the list. Nothing rejected the write.

On 2026-07-31 a `clusters.json` edit pushed `app_id: 5686` (GHE) onto seven public-GitHub hives with `api_url: ""`. Every token request returned `404 Integration not found`, and agents authored as `kubestellar-hive-ghe[bot]` on public repos. The validator that could have caught it ran only on a dashboard panel nobody was looking at.

## 1. The untested rule is now written

`provenance.go` carried a comment describing this exact failure mode — `AppID != 0 && APIURL == ""` — and **no rule tested it**.

The new rule keys on **`app_id`**, mapping a known App ID to its forge and comparing that against `HostLabel()`.

**Why this is reachable on real data.** The three existing markers — `apiIsGHE`, `baseIsGHE`, `slugIsGHE` — all derive from fields that are empty fleet-wide: `api_url`/`base_url` are empty on ~41 of ~51 spokes, and `app_slug` is empty on many. They are false in production for exactly the hives that need checking. `app_id` is required by config validation and is always populated, so the rule fires on the shape the incident actually produced:

```
app_id:   5686                  <- GHE App
app_slug: kubestellar-hive-ghe
api_url:  ""                    <- EMPTY, resolves to api.github.com
base_url: ""
```

Unknown App IDs (a third forge, self-hosted, the placeholder sentinel) are never judged.

## 2. The validator now has callers on the write path

`RejectIdentitySet` returns an error wrapping `ErrIdentitySetMismatch`. Three call sites:

| Site | Behaviour |
|---|---|
| `cmd/hive/main.go` `GitHubAppConfigCallback` | Computes the identity the push **would** produce (mirroring the field-by-field adoption rules) and refuses the **whole** delivery. Partial application is what let seven hives take half of two identities. |
| `cmd/hive/main.go` project-config callback | Same guard on the `pc.GitHubAPIURL` adoption — the other direction of the same split. Skips only that field; org/repos/ACMM still land. |
| `pkg/hub/cluster_app_key.go` `appKeyConfigForHeartbeat` | Refuses to **construct** the push, so a bad `clusters.json` never reaches the wire. |

Every refusal logs at ERROR with the pushed values, the current values, and a remedy.

## Two corrections found while wiring this up

Both came from real fixtures, and both contradict assumptions I started with:

**`app_slug` is NOT derivable from `app_id`.** App ID `5686` appears in this tree under **two** slugs: `kubestellar-hive-ghe` (config/dashboard) and `ibm-hive` (the vllm-d cluster, `pkg/hub/cluster_app_key_test.go`). A slug is an operator-chosen App URL name. A rule asserting `app_id 5686 ⇒ slug kubestellar-hive-ghe` refuses a live production cluster — so only the `app_id → forge` mapping is asserted. I wrote that rule, watched it break `TestAppKeySyncForHeartbeat`, and removed it.

**The pre-existing `base_url`/`api_url` rules treated an EMPTY url as "public github.com".** `ResolvedBaseURL` and `HostLabel` are explicit that a GHE hive legitimately carries only one of the two (pooled/placeholder GHE hives carry `api_url` with `base_url: ""`; the vllm-d cluster record is the mirror). This was harmless while `IdentitySetIssues` only rendered a panel. Wired to a write path it would have **refused the GHE App push to every GHE hive that has not backfilled both URLs** — the same class of outage this guard exists to prevent, pointed the other way. The rules now require both to be populated before comparing them. The `app_id` rule still catches the incident, which is the case where both are empty.

The hub-side guard is gated on the same principle: a cluster record declaring neither URL is **under-specified, not public**, so it is not checked. Silence is never evidence.

## Verification

- **All 16 combinations** of the four identity fields walked; 13 rejected, 3 valid (the third being the GHE App under a non-`ghe` slug, enumerated with its reason rather than skipped).
- **Regression test** pinning the exact 2026-07-31 field set → rejected.
- **Reachability test** asserting the rule fires with `api_url`, `base_url` and `app_slug` all empty — the assertion the previous check could not have made.
- **Healthy fleet negative tests**: public (`3568013` + empty URLs, the ~41-spoke shape) and GHE (`5686` + both URLs) both pass, plus the one-empty-URL shapes and the `ibm-hive` slug.
- **Mutation testing — 8 of 8 killed.** Each rule and each call site was broken in turn and the suite confirmed to fail. One mutation (dropping the pushed `app_id` from the spoke's prospective identity) initially **survived** — the test passed for the wrong reason, via the legacy slug marker. Test strengthened; it now dies.

No schema change, no `forge` field, no migration, no live config touched.