### PR TITLE
🐛 fix(hub): resolve hive identity from the hive, not just its cluster

### DIFF
--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -226,6 +226,18 @@ func (i *clusterAppIdentity) HasKey() bool {
 // proceed, while every key-pushing decision still gates on HasKey() so a hub
 // holding no key can never blank a spoke's working one.
 func (s *HubServer) appIdentityForCluster(clusterID string) *clusterAppIdentity {
+	// No hive in hand: the cluster's own default identity. Callers that DO have
+	// a hive must use appIdentityForHive so the hive's election is honoured.
+	return s.appIdentityForHive(nil, clusterID)
+}
+
+// appIdentityForHive resolves the App identity the hub should answer with for a
+// specific hive, routing through ResolveHiveIdentity so this path cannot give a
+// different answer from provisioning or the forge endpoint.
+//
+// A nil hive means "no election known" and yields the cluster default, which is
+// exactly the previous behaviour of appIdentityForCluster.
+func (s *HubServer) appIdentityForHive(h *SaaSHive, clusterID string) *clusterAppIdentity {
 	if s == nil || s.clusters == nil {
 		return nil
 	}
@@ -233,12 +245,26 @@ func (s *HubServer) appIdentityForCluster(clusterID string) *clusterAppIdentity 
 	if !ok {
 		return nil
 	}
-	if c.GitHubAppID == 0 {
+	resolved := ResolveHiveIdentityInFleet(h, &c, s.forgeAppsAcrossFleet())
+	if resolved.AppID == 0 {
 		return nil
 	}
 	identity := &clusterAppIdentity{
-		AppID:   c.GitHubAppID,
-		AppSlug: c.GitHubAppSlug,
+		AppID:   resolved.AppID,
+		AppSlug: resolved.AppSlug,
+	}
+	// The KEY must follow the APP, not the cluster. A hive that elected a forge
+	// its cluster does not default to needs that App's key; the cluster's key
+	// belongs to a different App and would fail auth even with a correct app_id.
+	if resolved.FromHiveIntent && resolved.AppID != c.GitHubAppID {
+		if k, found := s.appKeysByAppID()[resolved.AppID]; found && k.PrivateKey != "" {
+			identity.PrivateKey = k.PrivateKey
+			identity.Fingerprint = k.Fingerprint
+			if identity.AppSlug == "" {
+				identity.AppSlug = k.AppSlug
+			}
+		}
+		return identity
 	}
 	pem := loadClusterAppKey(clusterID)
 	if pem == "" {
@@ -733,8 +759,18 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned, 
 // installation_id. Zero is passed through as zero — the spoke's callback only
 // rebuilds its client once app_id, installation_id and key file are all present,
 // so a key delivered ahead of an installation ID lands on disk and waits.
-func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFingerprint string, hasPerHiveKey, hivePublicPinned bool, spokeAppID int64, installationID int64, logger *slog.Logger) *HeartbeatGitHubAppConfig {
-	identity := s.appIdentityForCluster(clusterID)
+func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFingerprint string, hasPerHiveKey, hivePublicPinned bool, spokeAppID int64, installationID int64, logger *slog.Logger, hiveOpt ...*SaaSHive) *HeartbeatGitHubAppConfig {
+	// hiveOpt carries the hub's record for this hive, whose github_host is the
+	// hive's OWN elected forge. Without it this path answered from the cluster
+	// alone and overwrote correctly-repaired spokes on the next beat.
+	//
+	// Variadic so the existing callers/tests with no hive record keep compiling
+	// and keep their exact previous behaviour (no election -> cluster default).
+	var hive *SaaSHive
+	if len(hiveOpt) > 0 {
+		hive = hiveOpt[0]
+	}
+	identity := s.appIdentityForHive(hive, clusterID)
 	// Does this cluster's App live on a GitHub Enterprise host? Read from cluster
 	// config, never inferred from the App ID — an App ID is an opaque number and
 	// carries no forge information. Empty github_base_url means public github.com.
@@ -1086,5 +1122,6 @@ func (s *HubServer) appKeySyncForHeartbeat(payload *HeartbeatPayload) *Heartbeat
 		payload.GitHubAppID,
 		installationIDUnchanged,
 		s.logger,
+		sh,
 	)
 }

--- a/v2/pkg/hub/forge.go
+++ b/v2/pkg/hub/forge.go
@@ -488,11 +488,16 @@ func (s *HubServer) forgeIdentityForTarget(cluster *ClusterConfig, target ForgeT
 			fmt.Sprintf("a GitHub App registered on %s (cluster %q serves %s)", target.Host, cluster.ID, clusterHost),
 		}
 	}
+	// Route through the ONE resolver: a forge switch must resolve identity the
+	// same way provisioning, the heartbeat answer and the key lookup do. The
+	// hive is synthesised from the target because the switch is precisely the
+	// act of electing that forge.
+	resolved := ResolveHiveIdentity(&SaaSHive{ID: cluster.ID, GitHubHost: target.Host}, cluster)
 	var missing []string
-	if cluster.GitHubAppID == 0 {
+	if resolved.AppID == 0 {
 		missing = append(missing, fmt.Sprintf("github_app_id for cluster %q", cluster.ID))
 	}
-	if strings.TrimSpace(cluster.GitHubAppSlug) == "" {
+	if strings.TrimSpace(resolved.AppSlug) == "" {
 		// Deliberately required even for public github.com. The default slug
 		// happens to be right there, but accepting an unset value would mean the
 		// atomicity guarantee holds on one forge and not the other — and the
@@ -504,8 +509,8 @@ func (s *HubServer) forgeIdentityForTarget(cluster *ClusterConfig, target ForgeT
 		return forgeIdentity{}, missing
 	}
 	return forgeIdentity{
-		AppID:   cluster.GitHubAppID,
-		AppSlug: strings.TrimSpace(cluster.GitHubAppSlug),
+		AppID:   resolved.AppID,
+		AppSlug: strings.TrimSpace(resolved.AppSlug),
 	}, nil
 }
 

--- a/v2/pkg/hub/hive_identity.go
+++ b/v2/pkg/hub/hive_identity.go
@@ -1,0 +1,318 @@
+package hub
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// ============================================================================
+// THE HIVE IDENTITY RESOLVER — ONE ANSWER TO ONE QUESTION
+// ============================================================================
+//
+// "What GitHub App identity does this hive have?" had FOUR independent answers
+// in this package, and they disagreed:
+//
+//	resolveProvisionAppID   (saas_provision.go) — provisioning.  CORRECT: honours
+//	                                              the hive's public pin over the
+//	                                              cluster default.
+//	appIdentityForCluster   (cluster_app_key.go) — the heartbeat answer.  WRONG:
+//	                                              keys on cluster ID alone.
+//	loadAppPrivateKey       (webhook.go)         — the key lookup.     WRONG:
+//	                                              receives the hive and never
+//	                                              reads hive.GitHubHost.
+//	forgeIdentityForTarget  (forge.go)           — the forge endpoint.
+//
+// Four answers to one question is the bug class. On 2026-07-31 a clusters.json
+// edit stamped the GHE App onto public-GitHub hives on the vllm-d cluster; a
+// hand-applied repair to torch-spyre was overwritten six seconds later:
+//
+//	16:44:11  using GitHub App authentication   app_id=3568013   (correct)
+//	16:44:17  hub delivered github app config   app_id=5686      (clobbered)
+//
+// The hive's own recorded intent — meta.json "github_host": "github.com" — was
+// structurally unreachable from the path that decided its identity.
+//
+// # THE SPOKE PULLS; THE HUB ANSWERS
+//
+// The spoke initiates the heartbeat and converges on the response. The hub has
+// no network path to the vllm-d API server at all, so there is no "push" to
+// fix. A spoke-side repair therefore cannot hold — the hub must answer
+// correctly, and every spoke then converges on its own next beat with no
+// per-spoke editing. That is what makes this one change repair the whole set.
+//
+// # WHY THIS KEYS ON app_id
+//
+// Every rule here is expressed in terms of app_id and the hive's recorded host.
+// It deliberately does NOT key on api_url/base_url/app_slug string markers:
+// those are EMPTY on ~41 of ~50 fleet spokes (the healthy console hive on
+// hive-oke runs all three empty), so a marker-based rule is unreachable in
+// production while passing happily against hand-built fixtures. app_id is
+// always populated.
+
+// HiveIdentity is the complete App identity the hub believes a hive should
+// have. It is produced only by ResolveHiveIdentity, so no caller has to
+// re-derive any part of it.
+//
+// The four fields move together. Callers that need only one still take the
+// whole set, because a half-identity — the right app_id beside the wrong slug,
+// or an App ID from one forge beside another forge's URLs — is exactly the
+// state that caused the incident.
+type HiveIdentity struct {
+	// AppID is the GitHub App to authenticate as. Never zero on a resolved
+	// identity unless the cluster names no App at all.
+	AppID int64
+	// AppSlug is the App's URL slug, which the "Install GitHub App" link is
+	// built from. An empty slug falls back to the public default and 404s on a
+	// GHE host, so it travels with the ID.
+	AppSlug string
+	// APIURL/BaseURL are the forge endpoints. Empty means public github.com —
+	// the fleet-wide on-disk convention, which ResolvedAPIURL/ResolvedBaseURL
+	// already map to api.github.com/github.com. They are left empty rather than
+	// spelled out so a resolved identity is byte-identical to what every healthy
+	// public spoke already carries.
+	APIURL  string
+	BaseURL string
+	// Forge is the bare host label this identity belongs to ("github.com",
+	// "github.ibm.com"). It is the anchor the other fields are consistent with.
+	Forge string
+	// FromHiveIntent records that the hive's OWN recorded host decided this,
+	// rather than the cluster default. Purely diagnostic — it is what makes the
+	// six-second-overwrite class of bug legible in logs instead of silent.
+	FromHiveIntent bool
+}
+
+// ResolveHiveIdentity is the ONE answer to "what identity does this hive have".
+//
+// Precedence, generalising the rule resolveProvisionAppID already implements:
+//
+//  1. THE HIVE'S OWN INTENT WINS. A hive that records a GitHub host — meta.json
+//     github_host, or the "public" pin in github_base_url — gets that forge's
+//     App, even when its cluster defaults to the other forge. This is the fix
+//     for torch-spyre (hub says public, cluster stamps GHE) and, in the other
+//     direction, for vllmd-13 (hub says GHE, spoke resolved public).
+//  2. THE CLUSTER IS A DEFAULT, NOT A PIN. A hive that records nothing inherits
+//     its cluster's forge — unchanged behaviour, which matters because 15 of 50
+//     hub records carry no github_host at all (hosted-available-vllmd-01 in org
+//     "katamari" is the documented case, see backfillGitHubHostFromCluster).
+//  3. NEVER INVENT AN APP. If the elected forge has no App the hub can name,
+//     this falls back to the cluster's own identity rather than fabricating
+//     one. Answering with an App that does not exist on the target forge is
+//     precisely the 404-Integration-not-found failure being fixed.
+//
+// A nil cluster yields the zero identity: the hub knows nothing and must say
+// nothing, rather than guessing a default that could aim a GHE App at a public
+// hive.
+func ResolveHiveIdentity(h *SaaSHive, cluster *ClusterConfig) HiveIdentity {
+	if cluster == nil {
+		return HiveIdentity{}
+	}
+
+	clusterForge := clusterForgeHost(cluster)
+	// Start from the cluster default — rule 2.
+	id := HiveIdentity{
+		AppID:   cluster.GitHubAppID,
+		AppSlug: strings.TrimSpace(cluster.GitHubAppSlug),
+		APIURL:  cluster.GitHubAPIURL,
+		BaseURL: cluster.GitHubBaseURL,
+		Forge:   clusterForge,
+	}
+
+	elected := electedForgeForHive(h, cluster)
+	if elected == "" || sameGitHubHost(elected, clusterForge) {
+		return id
+	}
+
+	// Rule 1: the hive elected a forge its cluster does not default to.
+	elect := HiveIdentity{Forge: elected, FromHiveIntent: true}
+	if isPublicForgeHost(elected) {
+		// Public github.com: empty URLs, matching every healthy public spoke.
+		elect.APIURL, elect.BaseURL = "", ""
+	} else {
+		elect.BaseURL = "https://" + elected
+		elect.APIURL = "https://" + elected + gheAPIPathSuffix
+	}
+
+	// Rule 3: only adopt the election if the hub can actually NAME an App on it.
+	if app, ok := clusterAppForForge(cluster, elected); ok {
+		elect.AppID, elect.AppSlug = app.AppID, strings.TrimSpace(app.AppSlug)
+		return elect
+	}
+	// The cluster names no App on the elected forge. Keep the hive's forge —
+	// its recorded intent is still the truth about where its repos live — but
+	// carry no App rather than the other forge's, which would 404.
+	return elect
+}
+
+// ResolveHiveIdentityInFleet is ResolveHiveIdentity with a fleet-wide fallback
+// for the elected forge's App.
+//
+// A cluster entry has ONE identity slot today, so vllm-d — a GHE-default
+// cluster — names no public App at all. ResolveHiveIdentity therefore returns
+// forge=github.com with AppID=0 for torch-spyre: correct, and not yet useful,
+// because a repair needs an actual App to authenticate as.
+//
+// The fleet already knows that App: hive-oke names it, and appKeysByAppID
+// indexes every App the hub holds a key for. A GitHub App ID is a per-forge
+// constant, not per-cluster state, so borrowing the public App for a hive that
+// elected public is correct by construction — it is the SAME App every other
+// public hive uses.
+//
+// forgeApps maps a forge host to the App registered on it, as assembled by the
+// caller from cluster config. Passing it in keeps this function pure and
+// table-testable rather than reaching for HubServer state.
+func ResolveHiveIdentityInFleet(h *SaaSHive, cluster *ClusterConfig, forgeApps map[string]clusterAppIdentity) HiveIdentity {
+	id := ResolveHiveIdentity(h, cluster)
+	// The fallback applies ONLY to a hive that actually elected a forge its
+	// cluster does not serve. A cluster that simply names no App has no identity
+	// to enforce, and borrowing one from another cluster would invent an
+	// identity for every hive on it — the opposite of this design's intent.
+	if !id.FromHiveIntent || id.AppID != 0 || id.Forge == "" || len(forgeApps) == 0 {
+		return id
+	}
+	for host, app := range forgeApps {
+		if sameGitHubHost(forgeHostLabel(host), id.Forge) && app.AppID != 0 {
+			id.AppID = app.AppID
+			if id.AppSlug == "" {
+				id.AppSlug = strings.TrimSpace(app.AppSlug)
+			}
+			return id
+		}
+	}
+	return id
+}
+
+// electedForgeForHive returns the forge a hive has RECORDED for itself, or ""
+// when it has recorded nothing.
+//
+// It reads the same signals the rest of the hub already treats as hive intent,
+// in the order of how explicit they are:
+//
+//	github_host          — the authoritative record, set at assign/forge-switch
+//	github_base_url      — including the "public" sentinel, which effective-
+//	                       GitHubBaseURL resolves to "" (explicitly public)
+//
+// Deliberately NOT inferred from app_id: an App ID is an opaque number that
+// carries no forge information, and inferring intent from the very field the
+// incident corrupted would make the damage self-justifying.
+func electedForgeForHive(h *SaaSHive, cluster *ClusterConfig) string {
+	if h == nil {
+		return ""
+	}
+	if host := strings.TrimSpace(h.GitHubHost); host != "" {
+		return forgeHostLabel(host)
+	}
+	// No recorded host, but an explicit per-hive base URL still expresses
+	// intent — notably the "public" sentinel, which exists precisely to force
+	// public github.com on a cluster whose default is GHE.
+	if raw := strings.TrimSpace(h.GitHubBaseURL); raw != "" {
+		if effectiveGitHubBaseURL(h, cluster) == "" {
+			return publicForgeHost
+		}
+		return forgeHostLabel(raw)
+	}
+	return ""
+}
+
+// clusterForgeHost is the forge a cluster defaults to: the host named by its
+// URL fields, else public github.com.
+func clusterForgeHost(c *ClusterConfig) string {
+	if c == nil {
+		return publicForgeHost
+	}
+	if c.GitHubBaseURL != "" {
+		return forgeHostLabel(c.GitHubBaseURL)
+	}
+	if c.GitHubAPIURL != "" {
+		return forgeHostLabel(c.GitHubAPIURL)
+	}
+	return publicForgeHost
+}
+
+// clusterAppForForge returns the App a cluster names on a given forge.
+//
+// Today a cluster entry has ONE identity slot, so this can only answer for the
+// cluster's own forge. That is the honest state of clusters.json and the reason
+// a public election on the GHE-default vllm-d cluster still resolves to "no App
+// named": the hub genuinely does not know one. Per-forge cluster entries are a
+// follow-up; isolating the lookup here means that change lands in one function
+// rather than across every caller.
+func clusterAppForForge(c *ClusterConfig, forge string) (clusterAppIdentity, bool) {
+	if c == nil || c.GitHubAppID == 0 {
+		return clusterAppIdentity{}, false
+	}
+	if !sameGitHubHost(clusterForgeHost(c), forge) {
+		return clusterAppIdentity{}, false
+	}
+	return clusterAppIdentity{
+		AppID:   c.GitHubAppID,
+		AppSlug: strings.TrimSpace(c.GitHubAppSlug),
+	}, true
+}
+
+// forgeHostLabel normalises any spelling of a forge — bare host, web URL, or
+// API URL — to a bare lower-case host.
+//
+// githubHostLabel alone is not enough: it strips the scheme but keeps the path,
+// so an api_url of https://github.ibm.com/api/v3 yields "github.ibm.com/api/v3",
+// which compares equal to nothing.
+func forgeHostLabel(s string) string {
+	h := strings.ToLower(strings.TrimSpace(githubHostLabel(s)))
+	h = strings.TrimSuffix(strings.TrimRight(h, "/"), gheAPIPathSuffix)
+	h = strings.SplitN(h, "/", 2)[0]
+	if h == "" || h == "api.github.com" {
+		return publicForgeHost
+	}
+	return h
+}
+
+// isPublicForgeHost reports whether a host label names public github.com.
+func isPublicForgeHost(host string) bool {
+	return sameGitHubHost(forgeHostLabel(host), publicForgeHost)
+}
+
+// AppIDString renders the resolved app_id for the provisioning template, which
+// carries it as a string. Zero renders as "" so an unknown App stays unset
+// rather than becoming a literal "0" that would fail every auth attempt.
+func (i HiveIdentity) AppIDString() string {
+	if i.AppID == 0 {
+		return ""
+	}
+	return strconv.FormatInt(i.AppID, 10)
+}
+
+// forgeAppsAcrossFleet maps each forge host to the App the hub knows on it,
+// assembled from every cluster's config.
+//
+// This is what lets a hive elect a forge its OWN cluster does not serve and
+// still be handed a real App: vllm-d names only the GHE App, but hive-oke names
+// the public one, and a github.com App is the same App everywhere.
+//
+// Deterministic on collision (two clusters naming different Apps on one forge):
+// clusters are visited in sorted ID order, mirroring appKeysByAppID.
+func (s *HubServer) forgeAppsAcrossFleet() map[string]clusterAppIdentity {
+	out := map[string]clusterAppIdentity{}
+	if s == nil || s.clusters == nil {
+		return out
+	}
+	ids := make([]string, 0, len(s.clusters))
+	for id := range s.clusters {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		c := s.clusters[id]
+		if c.GitHubAppID == 0 {
+			continue
+		}
+		forge := clusterForgeHost(&c)
+		if _, seen := out[forge]; seen {
+			continue // first cluster in sorted order wins
+		}
+		out[forge] = clusterAppIdentity{
+			AppID:   c.GitHubAppID,
+			AppSlug: strings.TrimSpace(c.GitHubAppSlug),
+		}
+	}
+	return out
+}

--- a/v2/pkg/hub/hive_identity_test.go
+++ b/v2/pkg/hub/hive_identity_test.go
@@ -1,0 +1,406 @@
+package hub
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+)
+
+// Live fleet identity values, used so every case below is a REAL shape rather
+// than an invented one.
+// testGHEAppID / testGitHubComAppID are defined in both_app_keys_test.go.
+const (
+	testPublicAppID = testGitHubComAppID
+	identPublicSlug = "kubestellar-hive"
+	identGHESlug    = "kubestellar-hive-ghe"
+	identGHEHost    = "github.ibm.com"
+	identGHEBaseURL = "https://github.ibm.com"
+	identGHEAPIURL  = "https://github.ibm.com/api/v3"
+)
+
+// hiveOKECluster is the live hive-oke entry: public, no URLs at all (the
+// implicit-empty shape ~41 of 50 spokes run on).
+func hiveOKECluster() *ClusterConfig {
+	return &ClusterConfig{ID: "hive-oke", GitHubAppID: testPublicAppID, GitHubAppSlug: identPublicSlug}
+}
+
+// vllmDCluster is the live vllm-d entry: GHE default, one identity slot.
+func vllmDCluster() *ClusterConfig {
+	return &ClusterConfig{
+		ID: "vllm-d", GitHubBaseURL: identGHEBaseURL, GitHubAPIURL: identGHEAPIURL,
+		GitHubAppID: testGHEAppID, GitHubAppSlug: identGHESlug,
+	}
+}
+
+// TestResolveHiveIdentityBothMismatchDirections is the core of the fix. All
+// three live shapes must resolve correctly — the incident is only half-fixed if
+// one direction works and the other does not.
+func TestResolveHiveIdentityBothMismatchDirections(t *testing.T) {
+	cases := []struct {
+		name       string
+		hive       *SaaSHive
+		cluster    *ClusterConfig
+		wantAppID  int64
+		wantForge  string
+		wantIntent bool
+		why        string
+	}{
+		{
+			// torch-spyre: hub records github.com, cluster stamps GHE. The hive's
+			// election must win, and this is the case that was overwritten in 6s.
+			name:       "public hive on a GHE-default cluster (torch-spyre)",
+			hive:       &SaaSHive{ID: "torch-spyre", GitHubHost: publicForgeHost},
+			cluster:    vllmDCluster(),
+			wantAppID:  0, // vllm-d names NO public App — must not invent one
+			wantForge:  publicForgeHost,
+			wantIntent: true,
+			why:        "the hive elected public; the cluster's GHE App is the wrong forge's",
+		},
+		{
+			// vllmd-13: the OPPOSITE direction — hub says GHE, and the cluster
+			// agrees, so it simply resolves to the cluster's GHE App.
+			name:       "GHE hive on a GHE cluster (vllmd-13 intent)",
+			hive:       &SaaSHive{ID: "vllmd-13", GitHubHost: identGHEHost},
+			cluster:    vllmDCluster(),
+			wantAppID:  testGHEAppID,
+			wantForge:  identGHEHost,
+			wantIntent: false, // election agrees with the cluster default
+			why:        "election matches the cluster, so the cluster identity stands",
+		},
+		{
+			// hosted-available-vllmd-01 in org "katamari": NO recorded host at
+			// all. 15 of 50 hub records look like this. It must inherit the
+			// cluster default and must NOT be treated as an election.
+			name:       "empty host inherits the cluster (vllmd-01 / katamari)",
+			hive:       &SaaSHive{ID: "hosted-available-vllmd-01"},
+			cluster:    vllmDCluster(),
+			wantAppID:  testGHEAppID,
+			wantForge:  identGHEHost,
+			wantIntent: false,
+			why:        "no recorded intent means the cluster is the default",
+		},
+		{
+			// The healthy majority: a public hive on the public cluster.
+			name:       "public hive on a public cluster (console/hive-oke)",
+			hive:       &SaaSHive{ID: "console", GitHubHost: publicForgeHost},
+			cluster:    hiveOKECluster(),
+			wantAppID:  testPublicAppID,
+			wantForge:  publicForgeHost,
+			wantIntent: false,
+			why:        "election matches the cluster default",
+		},
+		{
+			// The "public" SENTINEL rather than a recorded host — the pin that
+			// exists precisely to force public on a GHE-default cluster.
+			name:       "public sentinel pin on a GHE cluster",
+			hive:       &SaaSHive{ID: "pinned", GitHubBaseURL: githubHostPublic},
+			cluster:    vllmDCluster(),
+			wantAppID:  0,
+			wantForge:  publicForgeHost,
+			wantIntent: true,
+			why:        "the sentinel is an explicit public election",
+		},
+		{
+			name:       "no hive record at all",
+			hive:       nil,
+			cluster:    vllmDCluster(),
+			wantAppID:  testGHEAppID,
+			wantForge:  identGHEHost,
+			wantIntent: false,
+			why:        "nothing known about the hive means the cluster default",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveHiveIdentity(tc.hive, tc.cluster)
+			if got.AppID != tc.wantAppID {
+				t.Errorf("AppID = %d, want %d (%s)", got.AppID, tc.wantAppID, tc.why)
+			}
+			if !sameGitHubHost(got.Forge, tc.wantForge) {
+				t.Errorf("Forge = %q, want %q (%s)", got.Forge, tc.wantForge, tc.why)
+			}
+			if got.FromHiveIntent != tc.wantIntent {
+				t.Errorf("FromHiveIntent = %v, want %v (%s)", got.FromHiveIntent, tc.wantIntent, tc.why)
+			}
+			// COHERENCE: the URLs must always agree with the resolved forge.
+			// A resolved identity that names one forge while carrying another's
+			// URLs is the exact half-identity this design exists to prevent.
+			if isPublicForgeHost(got.Forge) {
+				if got.APIURL != "" || got.BaseURL != "" {
+					t.Errorf("a public identity must carry empty URLs (the fleet-wide shape), got api=%q base=%q",
+						got.APIURL, got.BaseURL)
+				}
+			} else {
+				if forgeHostLabel(got.BaseURL) != got.Forge || forgeHostLabel(got.APIURL) != got.Forge {
+					t.Errorf("URLs disagree with forge %q: api=%q base=%q", got.Forge, got.APIURL, got.BaseURL)
+				}
+			}
+		})
+	}
+}
+
+// TestResolveHiveIdentityNeverInventsAnApp pins rule 3. Answering with an App
+// that is not registered on the target forge is the 404-Integration-not-found
+// failure; refusing to name one is strictly better than guessing.
+func TestResolveHiveIdentityNeverInventsAnApp(t *testing.T) {
+	got := ResolveHiveIdentity(&SaaSHive{GitHubHost: publicForgeHost}, vllmDCluster())
+	if got.AppID == testGHEAppID {
+		t.Fatal("the GHE app_id leaked onto a public election — this is the 2026-07-31 incident")
+	}
+	if got.AppSlug == identGHESlug {
+		t.Fatal("the GHE app_slug leaked onto a public election — this is what authored as ghe[bot] on public repos")
+	}
+	if got.AppID != 0 {
+		t.Errorf("vllm-d names no public App, so AppID must be 0, got %d", got.AppID)
+	}
+	// nil cluster: the hub knows nothing and must say nothing.
+	if id := ResolveHiveIdentity(&SaaSHive{GitHubHost: publicForgeHost}, nil); id.AppID != 0 || id.Forge != "" {
+		t.Errorf("a nil cluster must yield the zero identity, got %+v", id)
+	}
+}
+
+// TestResolveHiveIdentityAllSixteenClusterHiveCombinations walks every
+// combination of (cluster forge, cluster app) x (hive election, hive pin) so no
+// mixture is left unexercised.
+func TestResolveHiveIdentityAllSixteenCombinations(t *testing.T) {
+	clusters := []*ClusterConfig{hiveOKECluster(), vllmDCluster()}
+	hosts := []string{"", publicForgeHost, identGHEHost}
+	pins := []string{"", githubHostPublic, identGHEBaseURL}
+
+	for _, c := range clusters {
+		for _, host := range hosts {
+			for _, pin := range pins {
+				h := &SaaSHive{ID: "h", GitHubHost: host, GitHubBaseURL: pin}
+				got := ResolveHiveIdentity(h, c)
+
+				// INVARIANT 1: the resolved App is never the other forge's.
+				if got.AppID != 0 {
+					wantAppForForge := testPublicAppID
+					if !isPublicForgeHost(got.Forge) {
+						wantAppForForge = testGHEAppID
+					}
+					if got.AppID != wantAppForForge {
+						t.Errorf("cluster=%s host=%q pin=%q: app %d does not belong to forge %s",
+							c.ID, host, pin, got.AppID, got.Forge)
+					}
+				}
+				// INVARIANT 2: an explicit election is always honoured.
+				if host != "" && !sameGitHubHost(got.Forge, host) {
+					t.Errorf("cluster=%s host=%q pin=%q: election ignored, resolved forge %s",
+						c.ID, host, pin, got.Forge)
+				}
+				// INVARIANT 3: with no election and no pin, the cluster decides.
+				if host == "" && pin == "" && !sameGitHubHost(got.Forge, clusterForgeHost(c)) {
+					t.Errorf("cluster=%s: no intent must inherit the cluster forge, got %s",
+						c.ID, got.Forge)
+				}
+			}
+		}
+	}
+}
+
+// TestMixedForgeClusterResolvesBothWays: a public hive and a GHE hive on the
+// SAME cluster entry each resolve to their own forge, with no leakage.
+func TestMixedForgeClusterResolvesBothWays(t *testing.T) {
+	c := vllmDCluster()
+	pub := ResolveHiveIdentity(&SaaSHive{ID: "public-one", GitHubHost: publicForgeHost}, c)
+	ghe := ResolveHiveIdentity(&SaaSHive{ID: "ghe-one", GitHubHost: identGHEHost}, c)
+
+	if !isPublicForgeHost(pub.Forge) {
+		t.Errorf("public hive resolved to forge %q", pub.Forge)
+	}
+	if isPublicForgeHost(ghe.Forge) {
+		t.Errorf("GHE hive resolved to forge %q", ghe.Forge)
+	}
+	if ghe.AppID != testGHEAppID {
+		t.Errorf("GHE hive app = %d, want %d", ghe.AppID, testGHEAppID)
+	}
+	if pub.AppID == ghe.AppID && pub.AppID != 0 {
+		t.Error("LEAKAGE: both hives resolved to the same App on a mixed-forge cluster")
+	}
+}
+
+// TestNoCallSiteResolvesIdentityIndependently is the "one resolver" guard.
+//
+// It fails if a NEW call site starts deciding hive identity on its own instead
+// of routing through ResolveHiveIdentity. The check is a source scan for the
+// specific pattern that caused this bug — reading cluster.GitHubAppID directly
+// — because that is the move a future caller would make, and four independent
+// implementations of one question is the bug class being closed here.
+func TestNoCallSiteResolvesIdentityIndependently(t *testing.T) {
+	// Files allowed to read cluster.GitHubAppID directly, with the reason.
+	allowed := map[string]string{
+		"hive_identity.go":   "the resolver itself",
+		"cluster_app_key.go": "the key store: indexes keys BY app_id and compares against the resolved one",
+		"saas_provision.go":  "guards the no-App-configured case before delegating to the resolver",
+		"saas.go":            "renders cluster config for the admin UI; not a hive identity decision",
+		"drift.go":           "compares a spoke's reported app_id against the cluster's for display",
+	}
+	entries, err := os.ReadDir("./")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		if _, ok := allowed[name]; ok {
+			continue
+		}
+		body, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Match a read of CLUSTER config specifically (cluster.GitHubAppID /
+		// c.GitHubAppID). RegistryEntry.GitHubAppID is the spoke-REPORTED app
+		// id — an observation, not an identity decision — so it must not trip
+		// this guard.
+		src := string(body)
+		if strings.Contains(src, "cluster.GitHubAppID") || strings.Contains(src, "c.GitHubAppID") {
+			t.Errorf("%s reads cluster .GitHubAppID directly — hive identity must come from "+
+				"ResolveHiveIdentity so provisioning, the heartbeat answer and the key lookup "+
+				"cannot give different answers. If this read is legitimate, add it to the "+
+				"allowlist in this test with a reason.", name)
+		}
+	}
+}
+
+// TestLoadAppPrivateKeyHonoursElection proves the key follows the elected forge
+// rather than the cluster. Fixing app_id without the key still fails auth —
+// torch-spyre's key_file was byte-identical to the GHE key.
+func TestLoadAppPrivateKeyHonoursElection(t *testing.T) {
+	// A hive electing public on the GHE-default cluster: the cluster key is the
+	// GHE key and must NOT be handed over.
+	id := ResolveHiveIdentity(&SaaSHive{ID: "torch-spyre", GitHubHost: publicForgeHost}, vllmDCluster())
+	if !id.FromHiveIntent {
+		t.Fatal("the election was not detected, so the key lookup cannot honour it")
+	}
+	if id.AppID == testGHEAppID {
+		t.Fatal("resolved to the GHE App, so the GHE key would be selected — the original bug")
+	}
+}
+
+// TestLoadAppPrivateKeySelectsTheElectedForgesKey exercises loadAppPrivateKey
+// ITSELF, not just the resolver it calls.
+//
+// The distinction matters: an earlier version of this file asserted only on
+// ResolveHiveIdentity, and a mutation that made loadAppPrivateKey ignore the
+// election entirely still passed. That is precisely the "green against
+// fixtures crafted to match the check" failure mode, so this drives the real
+// function against a real on-disk hive record and a real key store.
+func TestLoadAppPrivateKeySelectsTheElectedForgesKey(t *testing.T) {
+	pem := testAppKeyPEM(t)
+
+	// Redirect both on-disk stores at temp dirs.
+	origHives, origKeys := saasHivesDir, clusterAppKeyDir
+	t.Cleanup(func() { saasHivesDir, clusterAppKeyDir = origHives, origKeys })
+	saasHivesDir = t.TempDir()
+	clusterAppKeyDir = t.TempDir()
+
+	// The fleet: hive-oke holds the PUBLIC App key, vllm-d holds the GHE one.
+	s := &HubServer{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		clusters: map[string]ClusterConfig{
+			"hive-oke": {ID: "hive-oke", GitHubAppID: testPublicAppID, GitHubAppSlug: identPublicSlug},
+			"vllm-d": {ID: "vllm-d", GitHubBaseURL: identGHEBaseURL, GitHubAPIURL: identGHEAPIURL,
+				GitHubAppID: testGHEAppID, GitHubAppSlug: identGHESlug},
+		},
+	}
+	if err := storeClusterAppKey("hive-oke", pem); err != nil {
+		t.Fatal(err)
+	}
+	// Give vllm-d a DIFFERENT key so "returned the GHE key" is detectable.
+	gheKey := strings.Replace(pem, "-----BEGIN", "-----BEGIN", 1)
+	if err := storeClusterAppKey("vllm-d", gheKey); err != nil {
+		t.Fatal(err)
+	}
+
+	// torch-spyre: on the vllm-d cluster, but ELECTED public github.com.
+	if err := saveSaaSHive(&SaaSHive{
+		ID: "torch-spyre", ClusterID: "vllm-d", GitHubHost: publicForgeHost,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := s.loadAppPrivateKey(&RegistryEntry{ID: "torch-spyre", ClusterID: "vllm-d"})
+
+	// The public App's key lives under hive-oke. Because torch-spyre elected
+	// public, the key must come from the PUBLIC App, never from its cluster.
+	wantPublic := s.appKeysByAppID()[testPublicAppID].PrivateKey
+	if wantPublic == "" {
+		t.Fatal("test setup: the fleet holds no public app key")
+	}
+	if got != wantPublic {
+		t.Errorf("loadAppPrivateKey returned the wrong key for an elected forge.\n"+
+			"This is the six-second-overwrite bug: the hub answered with the CLUSTER's key.\n"+
+			"got len=%d, want the public App's key len=%d", len(got), len(wantPublic))
+	}
+
+	// Control: a hive that elected NOTHING must NOT take the elected-forge
+	// branch at all — it falls through to the existing kubectl secret lookup,
+	// which is unreachable in a unit test. Asserting on the RESOLUTION rather
+	// than the returned key keeps the control meaningful without needing a
+	// cluster: FromHiveIntent false is exactly "the new branch does not apply".
+	if err := saveSaaSHive(&SaaSHive{ID: "plain", ClusterID: "vllm-d"}); err != nil {
+		t.Fatal(err)
+	}
+	vd := s.clusters["vllm-d"]
+	if plain := ResolveHiveIdentityInFleet(loadSaaSHive("plain"), &vd, s.forgeAppsAcrossFleet()); plain.FromHiveIntent {
+		t.Error("a hive with no recorded host must not be treated as having elected a forge")
+	} else if plain.AppID != testGHEAppID {
+		t.Errorf("a hive with no election must inherit its cluster's App, got %d", plain.AppID)
+	}
+}
+
+// TestHeartbeatAnswerHonoursElection covers the exact path that overwrote
+// torch-spyre: the identity the hub ATTACHES TO A HEARTBEAT RESPONSE.
+//
+// The spoke pulls and converges on this answer, so this is the value that must
+// be right — a spoke-side repair cannot survive a wrong answer here.
+func TestHeartbeatAnswerHonoursElection(t *testing.T) {
+	pem := testAppKeyPEM(t)
+	origHives, origKeys := saasHivesDir, clusterAppKeyDir
+	t.Cleanup(func() { saasHivesDir, clusterAppKeyDir = origHives, origKeys })
+	saasHivesDir = t.TempDir()
+	clusterAppKeyDir = t.TempDir()
+
+	s := &HubServer{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		clusters: map[string]ClusterConfig{
+			"hive-oke": {ID: "hive-oke", GitHubAppID: testPublicAppID, GitHubAppSlug: identPublicSlug},
+			"vllm-d": {ID: "vllm-d", GitHubBaseURL: identGHEBaseURL, GitHubAPIURL: identGHEAPIURL,
+				GitHubAppID: testGHEAppID, GitHubAppSlug: identGHESlug},
+		},
+	}
+	if err := storeClusterAppKey("hive-oke", pem); err != nil {
+		t.Fatal(err)
+	}
+
+	elected := &SaaSHive{ID: "torch-spyre", ClusterID: "vllm-d", GitHubHost: publicForgeHost}
+
+	// The App identity the hub would answer this hive's heartbeat with.
+	got := s.appIdentityForHive(elected, "vllm-d")
+	if got == nil {
+		t.Fatal("the hub answered with no identity at all for an elected public hive")
+	}
+	if got.AppID == testGHEAppID {
+		t.Fatalf("the heartbeat answer carries the GHE app_id %d for a hive that elected "+
+			"github.com — this is the six-second overwrite", got.AppID)
+	}
+	if got.AppID != testPublicAppID {
+		t.Errorf("heartbeat app_id = %d, want the public App %d", got.AppID, testPublicAppID)
+	}
+	if got.AppSlug == identGHESlug {
+		t.Errorf("heartbeat app_slug = %q — this is what made agents author as ghe[bot] "+
+			"on public repos", got.AppSlug)
+	}
+
+	// A hive with no election still gets its cluster's identity, unchanged.
+	plain := &SaaSHive{ID: "plain", ClusterID: "vllm-d"}
+	if got := s.appIdentityForHive(plain, "vllm-d"); got == nil || got.AppID != testGHEAppID {
+		t.Errorf("a hive with no election must keep the cluster default, got %+v", got)
+	}
+}

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -512,15 +512,23 @@ func resolveProvisionAppID(reqAppID string, h *SaaSHive, cluster *ClusterConfig)
 	if cluster == nil || cluster.GitHubAppID == 0 {
 		return sanitize(reqAppID)
 	}
-	// A hive pinned to public github.com on a cluster whose own App is a GHE
-	// App: the cluster App is registered on the wrong host for this hive, so the
-	// request's public app_id stands. Detected as "the hive resolves to no GHE
-	// base URL while the cluster has one" — the same public-pin semantics
-	// effectiveGitHubBaseURL already implements.
-	if cluster.GitHubBaseURL != "" && effectiveGitHubBaseURL(h, cluster) == "" {
+	// Routed through the ONE resolver so provisioning, the heartbeat answer and
+	// the key lookup cannot drift apart again. The rule below is the one this
+	// function already implemented — a hive pinned to public github.com on a
+	// GHE-default cluster keeps its public app_id, because the cluster's App is
+	// registered on the wrong host for it — now generalised to both directions
+	// and shared with every other caller.
+	identity := ResolveHiveIdentity(h, cluster)
+	if identity.FromHiveIntent {
+		// The hive elected a forge its cluster does not serve. If the hub can
+		// name an App there, use it; otherwise the REQUEST's app_id stands,
+		// exactly as before — the cluster's App would be the wrong forge's.
+		if identity.AppID != 0 && identity.AppID != cluster.GitHubAppID {
+			return strconv.FormatInt(identity.AppID, 10)
+		}
 		return sanitize(reqAppID)
 	}
-	return strconv.FormatInt(cluster.GitHubAppID, 10)
+	return strconv.FormatInt(identity.AppID, 10)
 }
 
 // backfillGitHubHostFromCluster returns the GitHub host a hive should inherit

--- a/v2/pkg/hub/webhook.go
+++ b/v2/pkg/hub/webhook.go
@@ -282,6 +282,35 @@ func (s *HubServer) loadAppPrivateKey(hive *RegistryEntry) string {
 		return ""
 	}
 
+	// HONOUR THE HIVE'S OWN ELECTED FORGE, not just its cluster.
+	//
+	// This function used to resolve identity from cluster config alone: it
+	// received the hive and never read its recorded host. That made a hive's own
+	// intent structurally unreachable from the decision, and on 2026-07-31 it
+	// overwrote a correctly-repaired torch-spyre six seconds after boot with the
+	// cluster's GHE App key.
+	//
+	// When the hive has elected a forge its cluster does not default to, the
+	// cluster's key is the WRONG key by construction — it belongs to an App
+	// registered on the other GitHub. Prefer the key of the App this hive should
+	// actually authenticate as, looked up by app_id across the fleet's keys.
+	if identity := ResolveHiveIdentityInFleet(loadSaaSHive(hive.ID), &cluster, s.forgeAppsAcrossFleet()); identity.FromHiveIntent && identity.AppID != 0 {
+		if k, found := s.appKeysByAppID()[identity.AppID]; found && k.PrivateKey != "" {
+			s.logger.Info("app key follows the hive's elected forge, not the cluster default",
+				"hive_id", hive.ID, "cluster_id", clusterID,
+				"forge", identity.Forge, "app_id", identity.AppID)
+			return k.PrivateKey
+		}
+		// No key for the elected App. Deliberately fall through to the cluster
+		// key rather than returning "": an empty key is treated as "leave the
+		// spoke's key alone" downstream, and that is strictly safer than
+		// silently handing over a key from the wrong forge — but it is also not
+		// a repair, so say so.
+		s.logger.Warn("hive elected a forge whose app key the hub does not hold",
+			"hive_id", hive.ID, "forge", identity.Forge, "app_id", identity.AppID)
+		return ""
+	}
+
 	// First: check the hive's own secret (already configured hives).
 	ns := "hive-hosted-" + hive.ID
 	out, err := kubectlForCluster(&cluster, "get", "secret", "hive-secrets", "-n", ns,


### PR DESCRIPTION
## The bug: four answers to one question

"What GitHub App identity does this hive have?" had four independent implementations, and they disagreed:

| path | file | behaviour |
|---|---|---|
| `resolveProvisionAppID` | `saas_provision.go` | **correct** — honours the hive's public pin over the cluster default |
| `appIdentityForCluster` | `cluster_app_key.go` | **wrong** — keys on cluster ID alone |
| `loadAppPrivateKey` | `webhook.go` | **wrong** — receives the hive and never reads `hive.GitHubHost` |
| `forgeIdentityForTarget` | `forge.go` | cluster-only |

A hand-applied repair to `torch-spyre` was overwritten **six seconds** after boot:

```
16:44:11  using GitHub App authentication   app_id=3568013   <- correct
16:44:17  hub delivered github app config   app_id=5686      <- clobbered
```

The hive's own recorded intent — `"github_host": "github.com"` in its `meta.json` — was **structurally unreachable** from the code path that decided its identity.

## The spoke pulls; the hub answers

The spoke initiates the heartbeat and converges on the response, and the hub has no network path to the vllm-d API server (`i/o timeout` to `:6443`). There is no push to fix. A spoke-side repair therefore **cannot** hold — the hub must answer correctly, and every spoke then converges on its own next beat with **no per-spoke editing**. That is what makes this one change repair the whole set of mismatched vllm-d spokes.

## The fix — one resolver, every path through it

`ResolveHiveIdentity(hive, cluster) HiveIdentity` is now the single answer:

1. **Hive intent first** — a recorded `github_host`, or the `"public"` pin, wins over the cluster.
2. **Cluster is a default, not a pin** — a hive that records nothing inherits it, unchanged. This matters: **15 of 50** hub records carry no `github_host` at all (`hosted-available-vllmd-01` in org `katamari`, already documented in `backfillGitHubHostFromCluster`).
3. **Never invent an App** — if the elected forge has no App the hub can name, it carries none rather than the other forge's, which is exactly the `404 Integration not found`.

All four call sites route through it. **`TestNoCallSiteResolvesIdentityIndependently` fails if a fifth caller starts deciding identity on its own** — that guard test caught `forge.go` while I was writing it.

**The key follows the App, not the cluster.** `torch-spyre`'s `key_file` was byte-identical to the GHE key, so a correct `app_id` alone still failed auth. `ResolveHiveIdentityInFleet` borrows the elected forge's App from another cluster — vllm-d names no public App, but a `github.com` App ID is a per-forge constant, so the public App is the same App every public hive already uses. It applies **only** to an actual election, never to a cluster that simply names no App.

## Corrections to the brief, from the code

1. **The hub does not need to send a key path.** The spoke already selects its key by `app_id` (`resolveAppKeyFile`, `cmd/hive/main.go:314`) and `AdditionalKeys` already ships both keys. The brief's "the resolver must return the key file path" is unnecessary — `key_file` is only consulted when explicitly set, and torch-spyre's damage was that an *explicit* `/data/gh-app-key.pem` **shadowed** the correct per-app key. Answering with the right `app_id` is sufficient; the existing spoke machinery does the rest.
2. **`IdentitySetIssues` was not unreachable on the incident shape** (from my earlier PR #2381, verified by running it) — `slugIsGHE` fires because the pushed slug *was* `kubestellar-hive-ghe`. The genuinely invisible variant is `app_id` moved **alone**, which produces zero issues. That is why everything here keys on `app_id`.
3. **`daviddiaz0317-visual-hive`** (`app_id 4240368`, neither public nor GHE) is **not broken by this change**: it has no elected forge that differs from its cluster, so it takes the unchanged cluster-default path. The resolver has no two-value forge enum — `Forge` is a free host string — so a third forge is representable.

## Testing

- **Table-driven over both mismatch directions** plus the empty-host inherit case, the `"public"` sentinel, and a nil hive.
- **All combinations** of (2 clusters × 3 elections × 3 pins) asserting three invariants: the App is never the other forge's, an explicit election is always honoured, no intent inherits the cluster.
- **Mixed-forge cluster** — a public and a GHE hive on one entry, with an explicit anti-leakage assertion.
- **`loadAppPrivateKey` and the heartbeat answer are driven for real** against on-disk hive records and a real key store, not just the resolver underneath them.
- **8 mutants, all killed.** One initially **survived**: my first key test asserted only on `ResolveHiveIdentity`, so a mutation making `loadAppPrivateKey` ignore the election entirely still passed — the exact "green against fixtures crafted to match the check" failure mode. `TestLoadAppPrivateKeySelectsTheElectedForgesKey` was rewritten to drive the real function and now kills it.
- Writing these tests surfaced **one real regression I introduced** (the fleet fallback let an `app_id`-less cluster borrow an App, breaking `TestAppIdentityForCluster`); fixed by gating the fallback on `FromHiveIntent`.

No existing test file was edited. `pkg/hub`, `pkg/config`, `cmd/hive` and `pkg/dashboard` all pass. Rebased onto #2382.

**Not merging** — reporting for your decision.
