### PR TITLE
🐛 fix(config): app_slug is implied by app_id — assert it

### DIFF
--- a/v2/pkg/config/identity_reject_test.go
+++ b/v2/pkg/config/identity_reject_test.go
@@ -39,16 +39,21 @@ func (c identityCombo) cfg() GitHubConfig {
 // separately in TestIdentitySet_RealFleetShapes so a failure tells you which of
 // the two is broken.
 //
-// ONE EXCEPTION, and it is a deliberate one. app_slug is NOT derivable from
-// app_id: App ID 5686 legitimately appears in this tree under both
-// "kubestellar-hive-ghe" and "ibm-hive" (the vllm-d cluster fixture), because a
-// slug is an operator-chosen App URL name. So the combination
+// NO EXCEPTIONS. app_slug IS derivable from app_id — a GitHub App has exactly
+// one slug, fixed at registration. So the combination
 //
 //	app_id 5686 + slug kubestellar-hive + GHE api_url + GHE base_url
 //
-// is a REAL, VALID production shape wearing a slug that happens not to contain
-// "ghe" — a rule rejecting it would refuse a live cluster. It is enumerated
-// below as wantValid, with the reason attached, rather than quietly skipped.
+// names two different Apps and is REJECTED. Exactly 2 of the 16 are valid.
+//
+// An earlier revision of this test carved out an exception for a second slug
+// on App 5686 ("ibm-hive"), citing pkg/hub/cluster_app_key_test.go. That
+// citation was to a TEST FIXTURE, not a deployment: "ibm-hive" appears in no
+// production config, no cluster entry, and on none of the 51 fleet spokes —
+// live clusters.json carries "kubestellar-hive-ghe" for vllm-d. The exception
+// let a GHE App under a non-"ghe" slug pass validation, which is the exact
+// shape this file exists to reject. Any future exception here needs a citation
+// to live config, not to a fixture. It is enumerated
 // See the note on EnterpriseGitHubAppSlug.
 func TestIdentitySet_All16Combinations(t *testing.T) {
 	appIDs := []int64{PublicGitHubAppID, EnterpriseGitHubAppID}
@@ -66,12 +71,9 @@ func TestIdentitySet_All16Combinations(t *testing.T) {
 					seen++
 					combo := identityCombo{appID: appID, slug: slug, apiURL: apiURL, baseURL: baseURL}
 					forgeAgrees := ai == pi && pi == bi
-					// The slug may lag the forge only in the direction that is
-					// genuinely ambiguous: a GHE App under a slug without the
-					// "ghe" marker. A public App under a GHE-marked slug is
-					// unambiguously wrong and stays rejected.
-					slugTolerated := si == ai || (ai == 1 && si == 0)
-					wantValid := forgeAgrees && slugTolerated
+					// A GitHub App has exactly one slug, so the slug must match
+					// the app_id — in BOTH directions. No tolerance.
+					wantValid := forgeAgrees && si == ai
 
 					err := RejectIdentitySet(combo.cfg())
 					if err != nil {
@@ -93,9 +95,9 @@ func TestIdentitySet_All16Combinations(t *testing.T) {
 	if seen != 16 {
 		t.Fatalf("walked %d combinations, want 16", seen)
 	}
-	// 3 valid: public×public, GHE×GHE, and the GHE App under the non-"ghe"
-	// slug. Pinning the count catches a rule that silently stops firing.
-	if want := 13; rejected != want {
+	// Exactly 2 valid: public×public×public×public and GHE×GHE×GHE×GHE.
+	// Pinning the count catches a rule that silently stops firing.
+	if want := 14; rejected != want {
 		t.Errorf("rejected %d of 16 combinations, want %d", rejected, want)
 	}
 }
@@ -184,14 +186,26 @@ func TestIdentitySet_RealFleetShapes(t *testing.T) {
 			wantReject: true,
 		},
 		{
-			// The vllm-d cluster's real shape: the GHE App under the operator-
-			// chosen slug "ibm-hive", which carries no "ghe" marker. This MUST
-			// be accepted — a rule tying app_id to a specific slug refuses a
-			// live production cluster. See pkg/hub/cluster_app_key_test.go.
-			name: "GHE app_id under the operator-chosen ibm-hive slug",
+			// A GHE App wearing a slug with no "ghe" marker. Every marker-based
+			// rule is blind to this: slugIsGHE is false, and both URLs agree
+			// with each other. Only the app_id -> slug rule catches it, which is
+			// why that rule has to key on app_id rather than on string markers.
+			name: "GHE app_id under a slug that is not its own",
 			gh: GitHubConfig{
 				AppID:   EnterpriseGitHubAppID,
 				AppSlug: "ibm-hive",
+				APIURL:  EnterpriseGitHubAPIURL,
+				BaseURL: EnterpriseGitHubBaseURL,
+			},
+			wantReject: true,
+		},
+		{
+			// The real fleet shape: slug UNSET. ResolvedAppSlug() supplies the
+			// default, so an empty slug is not a mismatch and must be accepted —
+			// most spokes run exactly this way.
+			name: "GHE app_id with slug unset",
+			gh: GitHubConfig{
+				AppID:   EnterpriseGitHubAppID,
 				APIURL:  EnterpriseGitHubAPIURL,
 				BaseURL: EnterpriseGitHubBaseURL,
 			},
@@ -248,7 +262,7 @@ func TestIdentitySet_RuleIsReachableWithoutStringMarkers(t *testing.T) {
 func TestIdentitySet_OneEmptyURLIsNotAContradiction(t *testing.T) {
 	valid := []GitHubConfig{
 		// The vllm-d cluster record: GHE base_url declared, api_url unset.
-		{AppID: EnterpriseGitHubAppID, AppSlug: "ibm-hive", BaseURL: EnterpriseGitHubBaseURL},
+		{AppID: EnterpriseGitHubAppID, AppSlug: EnterpriseGitHubAppSlug, BaseURL: EnterpriseGitHubBaseURL},
 		// Pooled/placeholder GHE hives: GHE api_url declared, base_url unset.
 		{AppID: EnterpriseGitHubAppID, AppSlug: EnterpriseGitHubAppSlug, APIURL: EnterpriseGitHubAPIURL},
 	}

--- a/v2/pkg/config/provenance.go
+++ b/v2/pkg/config/provenance.go
@@ -240,16 +240,21 @@ const (
 	// kubestellar-hive-ghe GitHub App. This is the value that was pushed onto
 	// seven public-GitHub hives on 2026-07-31.
 	EnterpriseGitHubAppID int64 = 5686
-	// EnterpriseGitHubAppSlug is the slug the config/dashboard paths use for
-	// that App.
+	// EnterpriseGitHubAppSlug is the slug for that App, and the ONLY slug it
+	// may carry.
 	//
-	// NOTE: app_slug is NOT derivable from app_id, and no rule here treats it
-	// as such. App ID 5686 appears in this tree under TWO slugs — this one and
-	// "ibm-hive", which is what the vllm-d cluster fixture carries (see
-	// pkg/hub/cluster_app_key_test.go). Both are legitimate: the slug is an
-	// operator-chosen App URL name, so a rule asserting "app_id 5686 implies
-	// slug kubestellar-hive-ghe" refuses a real production cluster. Only the
-	// app_id → FORGE mapping below is safe to assert.
+	// A GitHub App has exactly one slug — it is the App's URL name, fixed when
+	// the App is registered, not a per-deployment label. So app_id DOES imply
+	// app_slug, and slugOfAppID below asserts it.
+	//
+	// An earlier revision of this file claimed 5686 legitimately appeared under
+	// a second slug ("ibm-hive") and declined to assert the mapping. That was
+	// wrong: "ibm-hive" existed only in _test.go fixtures — it appears in no
+	// production config, in no cluster entry, and on none of the 51 fleet
+	// spokes (live clusters.json carries github_app_slug
+	// "kubestellar-hive-ghe" for vllm-d). Relaxing the rule for an invented
+	// fixture left a GHE App under a non-"ghe" slug passing validation, which
+	// is precisely the shape this package exists to reject.
 	EnterpriseGitHubAppSlug = "kubestellar-hive-ghe"
 	// EnterpriseGitHubAPIURL and EnterpriseGitHubBaseURL are the forge URLs the
 	// enterprise App lives on.
@@ -275,6 +280,28 @@ func forgeOfAppID(appID int64) string {
 		return DefaultGitHubBaseURL[len("https://"):] // "github.com"
 	case EnterpriseGitHubAppID:
 		return EnterpriseGitHubBaseURL[len("https://"):] // "github.ibm.com"
+	}
+	return ""
+}
+
+// slugOfAppID returns the ONE slug a known App ID may carry.
+//
+// A GitHub App's slug is its URL name, fixed at registration — an App has
+// exactly one, so app_id determines app_slug. A mismatch means the identity
+// set was assembled from two different Apps, which is the defect this package
+// exists to catch: a GHE app_id carrying a public-looking slug (or the
+// reverse) passes every marker-based rule, because those markers key on the
+// string "ghe" appearing in a slug or URL.
+//
+// Returns "" for an unrecognised App ID (a third forge, self-hosted, the
+// placeholder sentinel). Unknown must never be treated as a mismatch, or a
+// legitimate deployment is refused — the same contract as forgeOfAppID.
+func slugOfAppID(appID int64) string {
+	switch appID {
+	case PublicGitHubAppID:
+		return DefaultGitHubAppSlug
+	case EnterpriseGitHubAppID:
+		return EnterpriseGitHubAppSlug
 	}
 	return ""
 }
@@ -336,10 +363,34 @@ func IdentitySetIssues(gh GitHubConfig) []string {
 		}
 	}
 
+	// app_slug must be THE slug of app_id. A GitHub App has one slug, so any
+	// other value means the set was assembled from two different Apps.
+	//
+	// This catches what the marker rules below structurally cannot: they ask
+	// whether the string "ghe" appears in the slug or the URLs, so a GHE App
+	// under a slug without that marker is invisible to them. Keying on app_id
+	// — always populated, unlike slug and both URLs — makes the check reachable
+	// on real fleet data.
+	//
+	// An EMPTY slug is not a mismatch: it resolves to DefaultGitHubAppSlug via
+	// ResolvedAppSlug(), and most of the fleet leaves it unset. Only a slug
+	// that is present AND wrong is refused.
+	if wantSlug := slugOfAppID(gh.AppID); wantSlug != "" && gh.AppSlug != "" &&
+		!strings.EqualFold(gh.AppSlug, wantSlug) {
+		issues = append(issues, "app_slug ("+gh.AppSlug+") is not the slug of app_id "+
+			strconv.FormatInt(gh.AppID, 10)+" (expected "+wantSlug+
+			") — a GitHub App has exactly one slug, so this identity set names two different Apps")
+	}
+
 	// The live regression: an App is configured and the forge markers
 	// disagree with each other.
 	if gh.AppID != 0 {
-		if slugIsGHE && !apiIsGHE {
+		// An empty api_url is not a public one when base_url already names GHE:
+		// pooled/placeholder GHE hives and the vllm-d cluster record carry
+		// exactly one of the two. Only claim a contradiction when api_url is
+		// populated, or when NEITHER url names the forge (the incident shape,
+		// which the app_id rule above catches on its own).
+		if slugIsGHE && !apiIsGHE && !baseIsGHE && gh.APIURL != "" {
 			issues = append(issues, "app_slug looks like a GitHub Enterprise slug ("+gh.AppSlug+
 				") but api_url is not a GHE API URL ("+displayOrEmpty(gh.APIURL)+
 				") — a GHE App ID presented to api.github.com returns 404 Integration not found")

--- a/v2/pkg/hub/both_app_keys_test.go
+++ b/v2/pkg/hub/both_app_keys_test.go
@@ -41,7 +41,7 @@ func twoClusterHub(t *testing.T) (*HubServer, map[int64]string) {
 		logger: appKeyTestLogger(),
 		clusters: map[string]ClusterConfig{
 			"hive-oke": {ID: "hive-oke", GitHubAppID: testGitHubComAppID, GitHubAppSlug: "kubestellar-hive"},
-			"vllm-d":   {ID: "vllm-d", GitHubAppID: testGHEAppID, GitHubAppSlug: "ibm-hive"},
+			"vllm-d":   {ID: "vllm-d", GitHubAppID: testGHEAppID, GitHubAppSlug: "kubestellar-hive-ghe"},
 		},
 	}
 	return s, map[int64]string{testGitHubComAppID: publicFP, testGHEAppID: gheFP}

--- a/v2/pkg/hub/cluster_app_key_test.go
+++ b/v2/pkg/hub/cluster_app_key_test.go
@@ -489,7 +489,7 @@ func TestAppIdentityForCluster(t *testing.T) {
 	}
 
 	s := &HubServer{clusters: map[string]ClusterConfig{
-		"vllm-d":   {ID: "vllm-d", GitHubAppID: 5686, GitHubAppSlug: "ibm-hive"},
+		"vllm-d":   {ID: "vllm-d", GitHubAppID: 5686, GitHubAppSlug: "kubestellar-hive-ghe"},
 		"keyonly":  {ID: "keyonly"},
 		"hive-oke": {ID: "hive-oke", GitHubAppID: 12345},
 	}}
@@ -505,7 +505,7 @@ func TestAppIdentityForCluster(t *testing.T) {
 		wantNoKey bool
 		reason    string
 	}{
-		{name: "app id and key present", clusterID: "vllm-d", wantAppID: 5686, wantSlug: "ibm-hive"},
+		{name: "app id and key present", clusterID: "vllm-d", wantAppID: 5686, wantSlug: "kubestellar-hive-ghe"},
 		{name: "key but no app id", clusterID: "keyonly", wantNil: true, reason: "an app_id-less cluster has no identity to enforce"},
 		// A configured app_id with no stored key IS an identity. Returning nil
 		// here is the bug that made #2333's sentinel repair unreachable in
@@ -580,7 +580,7 @@ func TestAppKeySyncForHeartbeat(t *testing.T) {
 
 	s := &HubServer{
 		logger:   appKeyTestLogger(),
-		clusters: map[string]ClusterConfig{"vllm-d": {ID: "vllm-d", GitHubAppID: 5686, GitHubAppSlug: "ibm-hive"}},
+		clusters: map[string]ClusterConfig{"vllm-d": {ID: "vllm-d", GitHubAppID: 5686, GitHubAppSlug: "kubestellar-hive-ghe"}},
 	}
 
 	tests := []struct {
@@ -594,14 +594,14 @@ func TestAppKeySyncForHeartbeat(t *testing.T) {
 			name:     "spoke with no key gets the cluster key",
 			payload:  &HeartbeatPayload{HiveID: "vllmd-06", ClusterID: "vllm-d"},
 			wantCfg:  true,
-			wantSlug: "ibm-hive",
+			wantSlug: "kubestellar-hive-ghe",
 			reason:   "the four keyless hives",
 		},
 		{
 			name:     "spoke with the wrong key gets corrected",
 			payload:  &HeartbeatPayload{HiveID: "vllmd-01", ClusterID: "vllm-d", GitHubAppKeyFingerprint: "sha256:deadbeefdeadbeefdeadbeefdeadbeef"},
 			wantCfg:  true,
-			wantSlug: "ibm-hive",
+			wantSlug: "kubestellar-hive-ghe",
 			reason:   "the three hives carrying the public github.com key",
 		},
 		{
@@ -696,7 +696,7 @@ func TestAppKeySyncForHeartbeatPublicPinnedHive(t *testing.T) {
 			"vllm-d": {
 				ID:            "vllm-d",
 				GitHubAppID:   5686,
-				GitHubAppSlug: "ibm-hive",
+				GitHubAppSlug: "kubestellar-hive-ghe",
 				GitHubBaseURL: "https://github.ibm.com",
 			},
 		},
@@ -786,7 +786,7 @@ func TestClusterKeyNeverSerializedIntoAPIPayload(t *testing.T) {
 		Name:          "GPU pool",
 		Domain:        "hive.example.com",
 		GitHubAppID:   5686,
-		GitHubAppSlug: "ibm-hive",
+		GitHubAppSlug: "kubestellar-hive-ghe",
 	}
 	identity := (&HubServer{clusters: map[string]ClusterConfig{"vllm-d": cluster}}).appIdentityForCluster("vllm-d")
 	if identity == nil {

--- a/v2/pkg/hub/identity_push_guard_test.go
+++ b/v2/pkg/hub/identity_push_guard_test.go
@@ -115,7 +115,7 @@ func TestPushGuard_UnderSpecifiedClusterIsNotGated(t *testing.T) {
 			"vllm-d": {
 				ID:            "vllm-d",
 				GitHubAppID:   config.EnterpriseGitHubAppID,
-				GitHubAppSlug: "ibm-hive",
+				GitHubAppSlug: "kubestellar-hive-ghe",
 			},
 		},
 		logger: appKeyTestLogger(),


### PR DESCRIPTION
## What

A GitHub App has exactly one slug, fixed at registration. `app_id` therefore determines `app_slug`, and a set whose slug disagrees with its app_id names **two different Apps**.

## Why #2382 didn't assert this

It found App `5686` under a second slug, `ibm-hive`, and concluded slugs were operator-chosen. That citation was to **`pkg/hub/cluster_app_key_test.go` — a test fixture.**

Verified against live config:

```
clusters.json  hive-oke: github_app_slug "kubestellar-hive"
clusters.json  vllm-d:   github_app_slug "kubestellar-hive-ghe"
fleet spokes carrying "ibm-hive": NONE (0 of 51)
```

The exception left the check blind to what it exists to catch: a GHE App under a slug without the `ghe` marker passes every marker-based rule, since those key on the literal string `ghe` in a slug or URL.

## Changes

- `slugOfAppID`, mirroring `forgeOfAppID`'s contract — an unrecognised app_id returns `""` and is never judged, so a third forge or self-hosted deployment isn't refused
- **Empty slug is not a mismatch.** `ResolvedAppSlug()` supplies the default and most of the fleet leaves it unset; only a slug that is present *and* wrong is refused
- Corrected the three hub fixtures that invented `ibm-hive`
- 16-combination test: exactly **2** valid states, not 3

## Also fixes a pre-existing rule

Correcting the fixtures exposed `slugIsGHE && !apiIsGHE` firing on a real vllm-d shape — GHE slug, `base_url` set, `api_url` empty. An empty `api_url` is not a public one when `base_url` already names the forge; this is the same defer-to-the-other-URL logic #2382 applied to the base/api pair. The incident shape, where **neither** URL is set, is still caught by the app_id rule.

## Verification

| | |
|---|---|
| `pkg/config` | pass |
| `pkg/hub` | pass |
| Mutation: disable slug rule | **4 tests fail** ✓ |
| Mutation: `slugOfAppID` returns wrong slug | **6 tests fail** ✓ |

Healthy fleet shapes still accepted: public app + all URLs empty (~41 spokes), GHE app + `base_url` only, GHE app + `api_url` only, and any app with slug unset.