### PR TITLE
🐛 fix(spoke): derive the App key path from app_id instead of storing it

### DIFF
--- a/v2/cmd/hive/app_key_derivation_test.go
+++ b/v2/cmd/hive/app_key_derivation_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// testRSAKeyPEM is a throwaway key generated for these tests only. It never
+// authenticates anything — these tests assert WHICH path is selected, and the
+// key only has to be parseable for AppKeyFingerprintFromFile to succeed.
+const testRSAKeyPEM = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDOpynovzSc6LQ9
+8/nCv8aPUkgC0/y3wm66LtpqcP5FDQXvcO0lJ64GDZPsNCQa4pOp3D6KBCsVOS6A
+PW30xvs4EZqhsXOxnEVzNIvouSqvgQyw6CTw/AUvgHNQBetWxnVjgjlgcXtcagZS
+34eTghJB9PowZbH2xl+zpsCAVtnfyqq52we9aeT0KUM8Secd+PXcuiCy2g90gRWm
+a1Y56Fmhvr5Jk2CGSAZ68FPBFU4lqqJ0Hf5i6ejTCmaD8XGLGOMvSFz1z86k7Wpe
+JuBTMJK9y19LMRLWaVjfiMR8xLH5x8OefwmIeXY72Uf9ndjVyT/zPn9Fo03dOjWs
+U56/WjxDAgMBAAECggEABr3ZVih2tO+6gZLmAP50odRTWRRFWFFVf2lr4rEQ+nu0
+R91tPxsOSFBFFR2WV/IwUwhGWgZMyYJ2C+T1I1kidO/OFZxOY+rvMRTzw4HW7KbP
+HS5Vli8ClEwidufah5gt2DM1X/oTxi4HSsjUCXHi2pf9WXrX1W8fTCMSgJ1UukI5
+UJ6ghMvZ9TVpXcIod2nEMWxn5viO/lGYXmPhLU13ckrO15TuqdDp3LyZQbOKLdWl
+NML9jIrlRo1+huiAINgfEzuNkbwwT4IhrMn0fLRzf5VRQw2qvlMR3mrov9as0JBT
+LRLnvvBO452VYCG7m6BwGko1MROlHjt8VPXt0nzi8QKBgQDrtUnmMQkLnWqigaMK
+BtSFF3BYRLNJLnR488N2hu7oikX/5DQ2ifVaPVSjXiFWjIm/uTq2Sni7pkruolAl
+LHzW+OqL5hLVa+Ib29p5t3Bx/eyPSYMxjJOJm1Cnpzd4AN+o1JNDa4jNAvcO2/Yo
+730g7g9gwWBfORl+orKUA0DIhwKBgQDgcYkXjzUsjLPIV5DODgOt7x/0kYnsAX0V
+ZUZ1eDnFaooW9JsA8hN9WF/SHeN1KJh/xxPbqzAPi7pPXJkIMoQcGFtTa/cpJ4Js
+kqCLK1LnCBgvg10zbgS5S8oNqFwOPUKoZCJGuvzlGbH4RHxfgyYTrX+lMBrqla/a
+qoabFsapZQKBgAaGMBN1DAEMTGVPHUorwjok2fE3hZbi+EpYxPJE7dv159YbZO6V
+hvsGc49KDbYtkaqC4AMnsIvRIIXWbE17G8F/hk51AdRydgG7ZiK0VyJwmtmkeUMn
+1vWaHPNnB3wE2iv8Jk9ZbKHwERKSOBAOAPKmZDqTX62DEReWPUcnh+WFAoGAaSpJ
+xlQ/4iP7iYAeRa6jYriNDJe1PHRmG8Rcg2ZWC36kPaVXi9Xh8/WY0GdY0Oi4rAan
+82H/HwmlvtHwkrq41EFFaY1JPmtY3W7G8u7V5ZMRYhH3dcWzSO+OOWAN4k4qEaT5
+upKbNO4ZSe8tJ8PX75h4GvqzYf/JanhEoh7F71ECgYEA3RhPTmznvCXfXYTOFK/G
+2Ab+QNjA8tkVxn1OpOrmSPqtL0bs+Hjl8nvhRAhUJ1P3eoLC0BglOrArv01gTS8i
+DEbf6ZaMYueH1DDUjFLLI+SuvqAiv34uaYkAGMX9wiPyR6YCKB5zTMU3l4qJllja
+/R753+9uhRTs+hupixvQlEA=
+-----END PRIVATE KEY-----
+`
+
+// writeKey drops a syntactically valid RSA key at path so
+// AppKeyFingerprintFromFile can parse it. Content is irrelevant to these tests
+// beyond being parseable; only WHICH path is selected is under test.
+func writeKey(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(testRSAKeyPEM), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestResolveAppKeyFileIgnoresStaleGenericPin pins the 2026-07-31 production
+// state: every vllm-d spoke carried key_file: /data/gh-app-key.pem holding the
+// GHE key, so correcting app_id to the public App still authenticated with the
+// wrong key and returned 404 Integration not found.
+//
+// The generic path names no App, so it cannot be trusted once the app_id we
+// claim has a per-app-id key of its own.
+func TestResolveAppKeyFileIgnoresStaleGenericPin(t *testing.T) {
+	dir := t.TempDir()
+	origDir, origGeneric := spokeAppKeyDir, spokeAppKeyPath
+	spokeAppKeyDir = dir
+	spokeAppKeyPath = filepath.Join(dir, "gh-app-key.pem")
+	t.Cleanup(func() { spokeAppKeyDir, spokeAppKeyPath = origDir, origGeneric })
+
+	const publicAppID = 3568013
+	writeKey(t, spokeAppKeyPath)              // the stale GHE key
+	writeKey(t, perAppIDKeyPath(publicAppID)) // the correct public key
+
+	got := resolveAppKeyFile(spokeAppKeyPath, "", publicAppID)
+	if want := perAppIDKeyPath(publicAppID); got != want {
+		t.Fatalf("resolved %q, want %q — a stale generic pin must not shadow the key for the App we claim", got, want)
+	}
+}
+
+// TestResolveAppKeyFileKeepsOperatorOverride guards the escape hatch. A hive on
+// an App this build does not know (daviddiaz0317-visual-hive runs app_id
+// 4240368, neither the public nor the GHE App) may legitimately point key_file
+// at a bespoke location, and that must still win.
+func TestResolveAppKeyFileKeepsOperatorOverride(t *testing.T) {
+	dir := t.TempDir()
+	origDir, origGeneric := spokeAppKeyDir, spokeAppKeyPath
+	spokeAppKeyDir = dir
+	spokeAppKeyPath = filepath.Join(dir, "gh-app-key.pem")
+	t.Cleanup(func() { spokeAppKeyDir, spokeAppKeyPath = origDir, origGeneric })
+
+	const oddAppID = 4240368
+	bespoke := filepath.Join(dir, "custom", "my-app.pem")
+	writeKey(t, bespoke)
+	writeKey(t, perAppIDKeyPath(oddAppID)) // present, and must NOT be preferred
+
+	if got := resolveAppKeyFile(bespoke, "", oddAppID); got != bespoke {
+		t.Fatalf("resolved %q, want the operator's %q", got, bespoke)
+	}
+}
+
+// TestResolveAppKeyFileGenericPinSurvivesWithoutPerAppKey: the override is
+// narrow. With no per-app-id key on disk, the generic pin is all there is and
+// must be returned rather than dropping the hive to no key at all.
+func TestResolveAppKeyFileGenericPinSurvivesWithoutPerAppKey(t *testing.T) {
+	dir := t.TempDir()
+	origDir, origGeneric := spokeAppKeyDir, spokeAppKeyPath
+	spokeAppKeyDir = dir
+	spokeAppKeyPath = filepath.Join(dir, "gh-app-key.pem")
+	t.Cleanup(func() { spokeAppKeyDir, spokeAppKeyPath = origDir, origGeneric })
+
+	writeKey(t, spokeAppKeyPath)
+	if got := resolveAppKeyFile(spokeAppKeyPath, "", 3568013); got != spokeAppKeyPath {
+		t.Fatalf("resolved %q, want %q — with no per-app key the generic one is still the only key", got, spokeAppKeyPath)
+	}
+}
+
+// TestEnvOverrideStillWins: GH_APP_KEY_FILE outranks everything, unchanged.
+func TestEnvOverrideStillWins(t *testing.T) {
+	dir := t.TempDir()
+	origDir, origGeneric := spokeAppKeyDir, spokeAppKeyPath
+	spokeAppKeyDir = dir
+	spokeAppKeyPath = filepath.Join(dir, "gh-app-key.pem")
+	t.Cleanup(func() { spokeAppKeyDir, spokeAppKeyPath = origDir, origGeneric })
+
+	writeKey(t, spokeAppKeyPath)
+	writeKey(t, perAppIDKeyPath(3568013))
+	env := filepath.Join(dir, "env.pem")
+	writeKey(t, env)
+	if got := resolveAppKeyFile(spokeAppKeyPath, env, 3568013); got != env {
+		t.Fatalf("resolved %q, want env override %q", got, env)
+	}
+}
+
+// TestDeliveredKeyPathNamesTheApp pins that a hub-delivered key is stored under
+// a filename identifying the App it belongs to.
+//
+// Writing every delivery to the generic /data/gh-app-key.pem is what made the
+// 2026-07-31 outage unrecoverable in place: the file held the GHE key, nothing
+// on disk said so, and correcting app_id to the public App kept signing with it.
+func TestDeliveredKeyPathNamesTheApp(t *testing.T) {
+	dir := t.TempDir()
+	origDir, origGeneric := spokeAppKeyDir, spokeAppKeyPath
+	spokeAppKeyDir = dir
+	spokeAppKeyPath = filepath.Join(dir, "gh-app-key.pem")
+	t.Cleanup(func() { spokeAppKeyDir, spokeAppKeyPath = origDir, origGeneric })
+
+	const publicAppID, gheAppID = 3568013, 5686
+
+	pub := deliveredKeyPath(publicAppID)
+	ghe := deliveredKeyPath(gheAppID)
+
+	if pub == spokeAppKeyPath {
+		t.Fatalf("delivered key for app %d landed on the generic path %q — the filename must name the App", publicAppID, pub)
+	}
+	if pub == ghe {
+		t.Fatalf("two different Apps share one key path %q; a key for one App would overwrite the other's", pub)
+	}
+	if want := perAppIDKeyPath(publicAppID); pub != want {
+		t.Fatalf("delivered path = %q, want %q", pub, want)
+	}
+
+	// A delivery naming no App must still land somewhere rather than be lost.
+	if got := deliveredKeyPath(0); got != spokeAppKeyPath {
+		t.Fatalf("App-less delivery = %q, want the generic %q", got, spokeAppKeyPath)
+	}
+}

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -155,6 +155,24 @@ func perAppIDKeyPath(appID int64) string {
 	return filepath.Join(spokeAppKeyDir, fmt.Sprintf("gh-app-key-%d.pem", appID))
 }
 
+// deliveredKeyPath is where a hub-delivered private key for appID is stored.
+//
+// The filename NAMES the App, so a key can only ever be found under the App it
+// was delivered for. The generic /data/gh-app-key.pem carries no such evidence:
+// a key written there for one App silently becomes "the key" for whatever
+// app_id the config later claims, which is how all 33 vllm-d spokes ended up
+// signing as the public App with the GHE key and getting
+// 404 Integration not found.
+//
+// Falls back to the generic path only when the delivery names no App, so a key
+// is never dropped on the floor.
+func deliveredKeyPath(appID int64) string {
+	if p := perAppIDKeyPath(appID); p != "" {
+		return p
+	}
+	return spokeAppKeyPath
+}
+
 // perAppIDProvisionedKeyPath is perAppIDKeyPath's read-only twin: the same
 // per-app-id filename under the provisioning Secret mount. It is consulted only
 // when the PVC has no usable key for the app_id, so a heartbeat-delivered key
@@ -347,6 +365,28 @@ func resolveAppKeyFile(configured, envOverride string, appID int64) string {
 		return v
 	}
 	if v := strings.TrimSpace(configured); v != "" {
+		// MIGRATION. A configured key_file that is the GENERIC path is not an
+		// operator's choice — it is a value older builds wrote automatically on
+		// every key delivery, and it does not name the App it holds. When we can
+		// see a per-app-id key for the app_id we actually claim, that key is
+		// correct by construction and the generic pin is stale, so ignore it.
+		//
+		// Without this, the ~33 spokes already carrying
+		// key_file: /data/gh-app-key.pem keep signing with whichever App's key
+		// happens to sit there — the live 404 Integration not found — because an
+		// explicit value short-circuits the per-app-id lookup below.
+		//
+		// Deliberately narrow: only the exact generic path is overridden, and
+		// only when a usable per-app-id key exists. Any other path is a genuine
+		// operator override (a hive on a third App with a bespoke key location)
+		// and still wins outright.
+		if v == spokeAppKeyPath {
+			if p := perAppIDKeyPath(appID); p != "" {
+				if fp, err := config.AppKeyFingerprintFromFile(p); err == nil && fp != "" {
+					return p
+				}
+			}
+		}
 		return v
 	}
 	// Nothing explicitly configured. Prefer a per-app-id key matching the App we
@@ -2672,7 +2712,24 @@ func main() {
 				}
 			}
 
-			keyPath := spokeAppKeyPath
+			// Write the delivered key to the path that NAMES the App it belongs
+			// to, not to a generic filename.
+			//
+			// /data/gh-app-key.pem carries no evidence of which App signed it, so
+			// a key delivered for one App silently becomes "the key" for whatever
+			// app_id the config later claims. On 2026-07-31 that is exactly what
+			// happened: all 33 vllm-d spokes had key_file pinned to the generic
+			// path holding the GHE key, so correcting app_id to the public App
+			// still produced 404 Integration not found — the right key was
+			// already on disk at gh-app-key-3568013.pem and unreachable, because
+			// an explicit key_file short-circuits resolveAppKeyFile before the
+			// per-app-id lookup runs.
+			//
+			// Deriving the filename from the app_id makes that mismatch
+			// unrepresentable: a key can only be found under the App it was
+			// delivered for. Falls back to the generic path when the delivery
+			// names no App, so a key is never dropped on the floor.
+			keyPath := deliveredKeyPath(ghCfg.AppID)
 			// keyChanged gates dropping the cached installation token below: a
 			// token minted under the previous key is invalid the moment the key
 			// is replaced, but a redelivery of the SAME key must not throw away a
@@ -2766,9 +2823,21 @@ func main() {
 			if ghCfg.InstallationID != 0 {
 				cfg.GitHub.InstallationID = ghCfg.InstallationID
 			}
-			if ghCfg.PrivateKey != "" {
-				cfg.GitHub.KeyFile = keyPath
-			}
+			// Deliberately NOT `cfg.GitHub.KeyFile = keyPath`.
+			//
+			// key_file is DERIVABLE from app_id (resolveAppKeyFile prefers
+			// /data/gh-app-key-<app_id>.pem, the only key correct by
+			// construction). Persisting the path turns a derived value into a
+			// stored one that outlives the App it was derived for: once written,
+			// it short-circuits resolveAppKeyFile on every later boot, so a
+			// corrected app_id keeps signing with the previous App's key. That is
+			// what left all 33 vllm-d spokes pinned to the GHE key.
+			//
+			// Leaving it empty lets derivation run every time, so the key always
+			// tracks the App actually in effect. An operator-set key_file still
+			// wins — that override is intentional, for a hive whose App this
+			// build does not know (e.g. a hive on a third App ID with a key at a
+			// bespoke path).
 			// Same "empty means unchanged" contract as installation_id: adopting
 			// an empty slug would blank a working install link.
 			if ghCfg.AppSlug != "" && cfg.GitHub.AppSlug != ghCfg.AppSlug {
@@ -2808,10 +2877,12 @@ func main() {
 					logger.Error("github app auth init via heartbeat failed", "error", err)
 					return
 				}
-				// Record the key file actually in effect so subsequent config
-				// reads and heartbeat fingerprint reports reflect the resolved
-				// per-app-id key rather than an empty configured value.
-				cfg.GitHub.KeyFile = rebuildKeyFile
+				// Deliberately NOT persisted. rebuildKeyFile is the RESOLVED
+				// path, and writing a resolved value back into config is what
+				// converts a derivation into a pin: the next boot reads it as an
+				// explicit key_file, short-circuits resolveAppKeyFile, and keeps
+				// using this App's key even after app_id changes. Re-resolving on
+				// every use costs a stat and cannot go stale.
 				// Hub-delivered creds can carry a wrong installation_id just as
 				// easily as a hand-edited config; correct (and persist) it
 				// before building a client that would 403 on every write.


### PR DESCRIPTION
## The pattern

`key_file` is **derivable** from `app_id` — `resolveAppKeyFile` already prefers `/data/gh-app-key-<app_id>.pem`, the only key correct by construction. Two write sites persisted a *resolved* path back into config, turning that derivation into a pin:

```go
main.go:2770  cfg.GitHub.KeyFile = keyPath        // on every key delivery
main.go:2814  cfg.GitHub.KeyFile = rebuildKeyFile
```

An explicit `key_file` short-circuits `resolveAppKeyFile` before the per-app-id lookup, so the key stops tracking the App in effect.

## Live impact

**All 33 running vllm-d spokes carry `key_file: /data/gh-app-key.pem`. Not one is empty.** That file holds the GHE key (`ffbb4dcc…`), so correcting `app_id` to the public App still authenticates with the GHE key:

```
404 Integration not found
```

The correct key is already on those spokes at `gh-app-key-3568013.pem` (`60cce495…`) and unreachable.

## Changes

- **`deliveredKeyPath(appID)`** — a delivered key lands under a filename naming its App. The generic path carries no evidence of which App signed it.
- **Stop persisting `key_file`** at both sites. Re-resolving costs a stat and cannot go stale.
- **Migration** — treat a stored `key_file` equal to the *generic* path as unset when a usable per-app-id key exists. Without it the ~33 pinned spokes never recover.

The migration is deliberately narrow: only the exact generic path, only when a per-app-id key is present. A bespoke path is a real operator override — e.g. a hive on `app_id 4240368`, an App this build does not know — and still wins, as does `GH_APP_KEY_FILE`.

## Verification

| Mutation | Result |
|---|---|
| Remove the stale-pin migration | 4 failures ✓ |
| Widen migration to any configured path | 4 failures ✓ |
| Revert deliveries to the generic filename | 4 failures ✓ |

The third **initially survived** — the delivery path was inline with no test. `deliveredKeyPath` was extracted to give it a seam rather than leaving the change unverified.

`cmd/hive` and `pkg/config` green; pre-existing key-resolution tests unchanged and passing.