### PR TITLE
🐛 fix(hub): validate identity against the hive's forge, not its cluster's

### DIFF
--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -181,8 +181,23 @@ func clusterAppKeyFingerprint(clusterID string) string {
 // authenticating as. Assembled from the cluster config (app_id, non-secret) and
 // the key store (the key itself, never in any config file).
 type clusterAppIdentity struct {
-	AppID       int64
-	AppSlug     string
+	AppID   int64
+	AppSlug string
+	// APIURL, BaseURL and Forge describe the forge THIS HIVE resolved to, which
+	// is not necessarily its cluster's default.
+	//
+	// They are carried here because dropping them is what made the hub refuse
+	// its own repair: the guard below re-read the URLs from the CLUSTER record,
+	// so a hive that elected github.com had its public app_id validated against
+	// the cluster's GHE api_url/base_url. That pair IS inconsistent, so
+	// RejectIdentitySet correctly refused it — and the push those hives needed
+	// was dropped every ~30s with the right answer already computed.
+	//
+	// Forge distinguishes "public, whose URLs are legitimately empty" from "no
+	// forge resolved"; the URLs alone cannot.
+	APIURL      string
+	BaseURL     string
+	Forge       string
 	PrivateKey  string
 	Fingerprint string
 }
@@ -252,6 +267,9 @@ func (s *HubServer) appIdentityForHive(h *SaaSHive, clusterID string) *clusterAp
 	identity := &clusterAppIdentity{
 		AppID:   resolved.AppID,
 		AppSlug: resolved.AppSlug,
+		APIURL:  resolved.APIURL,
+		BaseURL: resolved.BaseURL,
+		Forge:   resolved.Forge,
 	}
 	// The KEY must follow the APP, not the cluster. A hive that elected a forge
 	// its cluster does not default to needs that App's key; the cluster's key
@@ -849,8 +867,20 @@ func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFing
 	// same class of outage this guard exists to prevent, in the other direction.
 	// Silence is never evidence. When the cluster does declare a forge, the full
 	// set is checked.
-	clusterAPIURL := clusterAPIURLForIdentity(s, clusterID)
-	clusterBaseURL := clusterBaseURLForIdentity(s, clusterID)
+	// Validate against the forge THIS HIVE resolved to. The App and the URLs
+	// must come from the SAME resolution or the check compares two forges and
+	// refuses a set that is actually correct.
+	//
+	// Fall back to the cluster record only when the resolver named no forge at
+	// all. A public election legitimately resolves to EMPTY urls — that is how
+	// every healthy public spoke runs — so empty is not itself a reason to fall
+	// back; only an unresolved forge is.
+	clusterAPIURL := identity.APIURL
+	clusterBaseURL := identity.BaseURL
+	if identity.Forge == "" {
+		clusterAPIURL = clusterAPIURLForIdentity(s, clusterID)
+		clusterBaseURL = clusterBaseURLForIdentity(s, clusterID)
+	}
 	clusterDeclaresForge := clusterAPIURL != "" || clusterBaseURL != ""
 
 	if err := config.RejectIdentitySet(config.GitHubConfig{

--- a/v2/pkg/hub/forge_single_input_test.go
+++ b/v2/pkg/hub/forge_single_input_test.go
@@ -1,0 +1,138 @@
+package hub
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// liveVllmD is the production clusters.json entry for vllm-d: a GHE-DEFAULT
+// cluster that also names the public App, so hives on it may elect either.
+const liveVllmD = `{
+  "id": "vllm-d",
+  "github_base_url": "https://github.ibm.com",
+  "github_api_url": "https://github.ibm.com/api/v3",
+  "github_app_id": 5686,
+  "github_app_slug": "kubestellar-hive-ghe",
+  "forges": { "github.com": { "app_id": 3568013, "app_slug": "kubestellar-hive" } }
+}`
+
+// TestHeartbeatPushSurvivesTheGuard drives appKeyConfigForHeartbeat — the
+// function that CONTAINS the guard — rather than the resolver beside it.
+//
+// This distinction is the whole point. An earlier version of this test asserted
+// on appIdentityForHive, which returns the correct identity whether or not the
+// guard is fixed; the mutation that reverted the guard passed it. Only a test
+// that calls the guarding function can prove the push is actually emitted.
+//
+// The bug: the guard validated the hive's resolved app_id (3568013, public)
+// against api_url/base_url read from the CLUSTER (github.ibm.com), so
+// RejectIdentitySet refused a set the hub had assembled itself, and 26 hives
+// went unrepaired while the log said "nothing was sent".
+func TestHeartbeatPushSurvivesTheGuard(t *testing.T) {
+	withTempAppKeyDir(t)
+	oldHives := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = oldHives })
+
+	if err := storeClusterAppKey("vllm-d", testAppKeyPEM(t)); err != nil {
+		t.Fatal(err)
+	}
+	var c ClusterConfig
+	if err := json.Unmarshal([]byte(liveVllmD), &c); err != nil {
+		t.Fatal(err)
+	}
+	s := &HubServer{logger: appKeyTestLogger(), clusters: map[string]ClusterConfig{"vllm-d": c}}
+
+	// torch-spyre: repos live on github.com, so github_host records github.com.
+	pub := &SaaSHive{ID: "hosted-torch-spyre", ClusterID: "vllm-d", GitHubHost: "github.com"}
+	if err := saveSaaSHive(pub); err != nil {
+		t.Fatal(err)
+	}
+	// Enrico: repos on github.ibm.com.
+	ghe := &SaaSHive{ID: "hosted-vllmd-03", ClusterID: "vllm-d", GitHubHost: "github.ibm.com"}
+	if err := saveSaaSHive(ghe); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("public hive: the push is EMITTED, not refused", func(t *testing.T) {
+		got := s.appKeyConfigForHeartbeat("hosted-torch-spyre", "vllm-d", "", false, false,
+			config.EnterpriseGitHubAppID, 148549259, s.logger, pub)
+		if got == nil {
+			t.Fatal("push was REFUSED (nil) — the guard is still validating against the cluster's forge instead of the hive's")
+		}
+		if got.AppID != config.PublicGitHubAppID {
+			t.Fatalf("pushed app_id = %d, want %d", got.AppID, config.PublicGitHubAppID)
+		}
+	})
+
+	t.Run("GHE hive still gets its own App", func(t *testing.T) {
+		got := s.appKeyConfigForHeartbeat("hosted-vllmd-03", "vllm-d", "", false, false,
+			0, 43057, s.logger, ghe)
+		if got == nil {
+			t.Fatal("GHE hive push refused")
+		}
+		if got.AppID != config.EnterpriseGitHubAppID {
+			t.Fatalf("pushed app_id = %d, want %d", got.AppID, config.EnterpriseGitHubAppID)
+		}
+	})
+}
+
+// TestGitHubHostIsTheSingleInput pins that a hive's forge comes from one field.
+func TestGitHubHostIsTheSingleInput(t *testing.T) {
+	var c ClusterConfig
+	if err := json.Unmarshal([]byte(liveVllmD), &c); err != nil {
+		t.Fatal(err)
+	}
+	t.Run("legacy sentinel is normalized onto GitHubHost and the URLs cleared", func(t *testing.T) {
+		legacy := &SaaSHive{ID: "old", ClusterID: "vllm-d", GitHubBaseURL: githubHostPublic}
+		if !normalizeHiveForge(legacy, &c) {
+			t.Fatal("expected normalization to change the hive")
+		}
+		if !isPublicForgeHost(legacy.GitHubHost) {
+			t.Fatalf("GitHubHost = %q, want public", legacy.GitHubHost)
+		}
+		if legacy.GitHubBaseURL != "" || legacy.GitHubAPIURL != "" {
+			t.Fatalf("per-hive URLs survived: base=%q api=%q — a second copy of the forge can drift from the first",
+				legacy.GitHubBaseURL, legacy.GitHubAPIURL)
+		}
+		// And it must resolve the same way afterwards.
+		if got := ResolveHiveIdentity(legacy, &c); got.AppID != config.PublicGitHubAppID {
+			t.Fatalf("after normalization app_id = %d, want %d", got.AppID, config.PublicGitHubAppID)
+		}
+	})
+	t.Run("a hive with no determinable forge is left alone", func(t *testing.T) {
+		unknown := &SaaSHive{ID: "u", ClusterID: "vllm-d"}
+		if normalizeHiveForge(unknown, &c) {
+			t.Fatal("normalized a hive whose forge is unknown — that silently moves it to the cluster default")
+		}
+	})
+
+	t.Run("URLs are NEVER cleared while the host is unset", func(t *testing.T) {
+		// The clearing step removes the SECOND copy of the forge. Running it
+		// when the host does not hold the fact destroys the only copy, leaving
+		// the hive to inherit its cluster's forge — a public hive on vllm-d
+		// would silently become GHE. An unresolvable per-hive URL is exactly
+		// that case: electedForgeForHive cannot label it, so nothing may be
+		// dropped.
+		// A hive with NO forge evidence at all: nothing to normalize, and
+		// nothing may be invented or erased.
+		bare := &SaaSHive{ID: "bare", ClusterID: "vllm-d"}
+		normalizeHiveForge(bare, &c)
+		if bare.GitHubHost != "" {
+			t.Fatalf("invented a forge %q for a hive that named none", bare.GitHubHost)
+		}
+
+		// A hive whose ONLY record is a per-hive URL keeps a usable record:
+		// either the host now holds it, or the URL still does. Never neither.
+		urlOnly := &SaaSHive{ID: "urlonly", ClusterID: "vllm-d", GitHubBaseURL: "https://github.ibm.com"}
+		normalizeHiveForge(urlOnly, &c)
+		if urlOnly.GitHubHost == "" && urlOnly.GitHubBaseURL == "" {
+			t.Fatal("the hive's only record of its forge was erased — it will now inherit the cluster's App")
+		}
+		if !sameGitHubHost(urlOnly.GitHubHost, "github.ibm.com") {
+			t.Fatalf("forge moved during normalization: host=%q", urlOnly.GitHubHost)
+		}
+	})
+}

--- a/v2/pkg/hub/hive_identity.go
+++ b/v2/pkg/hub/hive_identity.go
@@ -199,12 +199,23 @@ func electedForgeForHive(h *SaaSHive, cluster *ClusterConfig) string {
 	if h == nil {
 		return ""
 	}
+	// GitHubHost IS the forge of this hive's repos. It is captured at request
+	// time from the org URL the user pastes, and every repo is validated to be
+	// on that same host ("single-host-per-spoke"), so it is the one input from
+	// which app_id, app_slug, api_url, base_url and the key file all derive.
 	if host := strings.TrimSpace(h.GitHubHost); host != "" {
 		return forgeHostLabel(host)
 	}
-	// No recorded host, but an explicit per-hive base URL still expresses
-	// intent — notably the "public" sentinel, which exists precisely to force
-	// public github.com on a cluster whose default is GHE.
+	// LEGACY ONLY. Hives assigned before github_host was recorded express the
+	// same fact through GitHubBaseURL — including the "public" sentinel, which
+	// exists solely because an empty base URL could not distinguish "public" from
+	// "unset". Reading it here keeps those hives resolving while they carry no
+	// host; normalizeHiveForge writes the derived host back so a hive passes
+	// through this branch at most once.
+	//
+	// Nothing new should ever set GitHubBaseURL on a hive. Two fields encoding
+	// one fact is what let a hive's own recorded forge disagree with the URLs
+	// validated against it, which refused the identity push for 26 hives.
 	if raw := strings.TrimSpace(h.GitHubBaseURL); raw != "" {
 		if effectiveGitHubBaseURL(h, cluster) == "" {
 			return publicForgeHost
@@ -212,6 +223,60 @@ func electedForgeForHive(h *SaaSHive, cluster *ClusterConfig) string {
 		return forgeHostLabel(raw)
 	}
 	return ""
+}
+
+// normalizeHiveForge collapses a hive's forge onto GitHubHost, the single
+// stored input, and reports whether it changed anything.
+//
+// A hive may arrive expressing its forge three ways: GitHubHost (current),
+// GitHubBaseURL holding a real URL (older), or GitHubBaseURL holding the
+// "public" sentinel (older still, meaning "force public on a GHE-default
+// cluster"). All three say the same thing, and any two of them can drift apart
+// — which is exactly what happened on 2026-07-31.
+//
+// After this runs, GitHubHost carries the answer and the per-hive URL fields
+// carry nothing, so there is no second copy left to disagree with.
+func normalizeHiveForge(h *SaaSHive, cluster *ClusterConfig) bool {
+	if h == nil {
+		return false
+	}
+	elected := electedForgeForHive(h, cluster)
+	// Store the elected host VERBATIM when the field does not already hold it.
+	//
+	// Deliberately NOT `!sameGitHubHost(h.GitHubHost, elected)`: that helper
+	// treats "" as equivalent to github.com, so for a public hive it reports
+	// "already correct" and the write is skipped — leaving GitHubHost empty
+	// while the URL fields below are cleared, which destroys the only record of
+	// the forge and drops the hive onto its cluster's default. That is the exact
+	// failure this change exists to remove, reintroduced by the normalizer.
+	changed := false
+	if elected != "" && h.GitHubHost != elected {
+		h.GitHubHost = elected
+		changed = true
+	}
+	// Only now drop the per-hive URL overrides: the host is holding the fact, so
+	// removing the second copy cannot lose it.
+	//
+	// The `elected != ""` gate is DEFENSIVE, not load-bearing, and a mutation
+	// test proved it: electedForgeForHive returns non-empty for any non-empty
+	// GitHubBaseURL, so whenever there is a URL to clear, elected is already
+	// set. Removing the gate breaks no test today. It stays because it states
+	// the invariant that matters — never erase a hive's only record of its
+	// forge, which would drop it onto the cluster default and turn a public
+	// hive on vllm-d into a GHE one — and because a future change to
+	// electedForgeForHive could make it reachable. Flagged rather than left
+	// looking verified.
+	if elected != "" {
+		if h.GitHubBaseURL != "" {
+			h.GitHubBaseURL = ""
+			changed = true
+		}
+		if h.GitHubAPIURL != "" {
+			h.GitHubAPIURL = ""
+			changed = true
+		}
+	}
+	return changed
 }
 
 // clusterForgeHost is the forge a cluster defaults to: the host named by its


### PR DESCRIPTION
## The hub was refusing its own repair

`appIdentityForHive` resolved the correct App for a hive that elected `github.com`. Then the guard in `appKeyConfigForHeartbeat` re-read `api_url`/`base_url` from the **cluster** record. A public `app_id` beside GHE URLs *is* an inconsistent set, so `RejectIdentitySet` correctly refused — and the push was dropped every ~30s, for 26 hives, with the right answer already computed:

```
REFUSING to push cluster github app config: app_id 3568013 is the GitHub App
on github.com, but api_url (https://github.ibm.com/api/v3) and base_url
(https://github.ibm.com) resolve to github.ibm.com
```

The App and the URLs must come from the same resolution. `clusterAppIdentity` now carries the resolved `APIURL`/`BaseURL`/`Forge`; the guard uses them and falls back to the cluster only when no forge resolved. A public election legitimately resolves to **empty** URLs — that is how every healthy public spoke runs — so `Forge`, not the URLs, distinguishes "public" from "unresolved".

## One field for one fact

`github_host` **is** the forge of the hive's repos: captured at request time from the pasted org URL, validated so every repo shares that host. The per-hive `GitHubBaseURL`/`GitHubAPIURL` say the same thing a second time — including the `"public"` sentinel, which exists only because an empty base URL could not distinguish *public* from *unset*.

Two fields for one fact is what let a hive's recorded forge disagree with the URLs validated against it. `normalizeHiveForge` writes the derived host onto `github_host` and clears the duplicate.

## Mutation testing

| Mutation | Result |
|---|---|
| Guard reverted to cluster URLs | **2 failures** ✓ |
| Normalizer using `sameGitHubHost` | **2 failures** ✓ |
| Clearing URLs unconditionally | **survives — gate is unreachable, flagged in-code** |

The second mutation is a bug this change nearly shipped: `sameGitHubHost` treats `""` as equal to `github.com`, so for a public hive it reported "already correct", skipped the write, then cleared the URLs — erasing the only record of the forge.

The third is honest: `electedForgeForHive` returns non-empty whenever a URL exists, so that gate cannot currently be false. It stays for the invariant it states, marked as defensive rather than left looking verified.

## Testing the right function

These tests drive `appKeyConfigForHeartbeat`, the function that **contains** the guard. An earlier version asserted on `appIdentityForHive`, which returns the correct identity either way — the mutation reverting the guard passed it.

`pkg/hub`, `pkg/config`, `cmd/hive` all green.