### PR TITLE
♻️ refactor(heartbeat): deliver GitHub identity as one set

### DIFF
--- a/v2/cmd/hive/identity_set_delivery_test.go
+++ b/v2/cmd/hive/identity_set_delivery_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/hub"
+)
+
+// TestIdentityTravelsAsOneSet pins that the App and its forge URLs arrive
+// together and are validated together.
+//
+// Before this, app_id/app_slug rode HeartbeatGitHubAppConfig while api_url rode
+// HeartbeatProjectConfig — two structs dispatched to two independent callbacks
+// (heartbeat.go:511 and :527), with nothing composing them. A forge switch
+// deliberately sends api_url ALONE, so between beats the spoke held a public
+// app_id against GHE urls: "404 Integration not found", the 2026-07-31 outage.
+func TestIdentityTravelsAsOneSet(t *testing.T) {
+	// A GHE hive being moved to public github.com — the switch that previously
+	// arrived in two unordered halves.
+	cur := config.GitHubConfig{
+		AppID:   config.EnterpriseGitHubAppID,
+		AppSlug: config.EnterpriseGitHubAppSlug,
+		APIURL:  config.EnterpriseGitHubAPIURL,
+		BaseURL: config.EnterpriseGitHubBaseURL,
+	}
+
+	t.Run("a complete public set is coherent and accepted", func(t *testing.T) {
+		got := prospectiveGitHubIdentity(cur, &hub.HeartbeatGitHubAppConfig{
+			AppID:   config.PublicGitHubAppID,
+			AppSlug: config.PublicGitHubAppSlug,
+			APIURL:  config.DefaultGitHubAPIURL,
+			BaseURL: config.DefaultGitHubBaseURL,
+		})
+		if got == nil {
+			t.Fatal("a full identity change produced no prospective set")
+		}
+		if got.APIURL != config.DefaultGitHubAPIURL || got.BaseURL != config.DefaultGitHubBaseURL {
+			t.Fatalf("URLs did not travel with the App: api=%q base=%q", got.APIURL, got.BaseURL)
+		}
+		if err := config.RejectIdentitySet(*got); err != nil {
+			t.Fatalf("complete set rejected: %v", err)
+		}
+	})
+
+	t.Run("App WITHOUT its urls is caught as the half-set it is", func(t *testing.T) {
+		// The old shape: public app_id delivered while the GHE urls remain.
+		got := prospectiveGitHubIdentity(cur, &hub.HeartbeatGitHubAppConfig{
+			AppID:   config.PublicGitHubAppID,
+			AppSlug: config.PublicGitHubAppSlug,
+		})
+		if got == nil {
+			t.Fatal("expected a prospective set")
+		}
+		if err := config.RejectIdentitySet(*got); err == nil {
+			t.Fatal("a public App left sitting on GHE urls was ACCEPTED — this is the 404 Integration not found shape")
+		}
+	})
+
+	t.Run("empty urls mean unchanged, never blank", func(t *testing.T) {
+		// A healthy GHE hive receiving a key-only refresh must keep its urls.
+		got := prospectiveGitHubIdentity(cur, &hub.HeartbeatGitHubAppConfig{
+			AppID:      config.EnterpriseGitHubAppID,
+			PrivateKey: "x",
+		})
+		if got == nil {
+			return // nothing adopted at all is also fine
+		}
+		if got.APIURL != cur.APIURL || got.BaseURL != cur.BaseURL {
+			t.Fatalf("empty urls blanked a working config: api=%q base=%q", got.APIURL, got.BaseURL)
+		}
+	})
+}

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -142,6 +142,25 @@ func prospectiveGitHubIdentity(cur config.GitHubConfig, ghCfg *hub.HeartbeatGitH
 		next.AppSlug = ghCfg.AppSlug
 		touched = true
 	}
+	// The forge URLs are part of the SAME set as the App above, so they are
+	// adopted here and validated with it rather than arriving separately on the
+	// project-config channel. An App ID presented to the wrong forge returns
+	// "404 Integration not found", so applying one half without the other is the
+	// live failure this function exists to prevent.
+	//
+	// Empty means "unchanged", matching AppSlug. It cannot mean "make me
+	// public": empty URLs are also the correct steady state for a public hive
+	// (~41 of 50 spokes), so silence here is indistinguishable from "no opinion"
+	// and must never blank a working GHE URL. A hive moving TO public gets that
+	// from its app_id, which the resolver derives from its forge.
+	if ghCfg.APIURL != "" && ghCfg.APIURL != cur.APIURL {
+		next.APIURL = ghCfg.APIURL
+		touched = true
+	}
+	if ghCfg.BaseURL != "" && ghCfg.BaseURL != cur.BaseURL {
+		next.BaseURL = ghCfg.BaseURL
+		touched = true
+	}
 	if !touched {
 		return nil
 	}
@@ -2844,6 +2863,24 @@ func main() {
 				logger.Info("adopting github app slug from hub",
 					"was", cfg.GitHub.AppSlug, "now", ghCfg.AppSlug)
 				cfg.GitHub.AppSlug = ghCfg.AppSlug
+			}
+			// Adopt the forge URLs from the SAME delivery as the App above.
+			// prospectiveGitHubIdentity already validated all four fields
+			// together, so reaching here means the complete set is coherent —
+			// applying the App without its URLs would undo that check by leaving
+			// the spoke pointed at the previous forge.
+			//
+			// Same "empty means unchanged" contract: empty is the correct steady
+			// state for a public hive, so it can never be read as "blank this".
+			if ghCfg.APIURL != "" && cfg.GitHub.APIURL != ghCfg.APIURL {
+				logger.Info("adopting github api url from hub",
+					"was", cfg.GitHub.APIURL, "now", ghCfg.APIURL)
+				cfg.GitHub.APIURL = ghCfg.APIURL
+			}
+			if ghCfg.BaseURL != "" && cfg.GitHub.BaseURL != ghCfg.BaseURL {
+				logger.Info("adopting github base url from hub",
+					"was", cfg.GitHub.BaseURL, "now", ghCfg.BaseURL)
+				cfg.GitHub.BaseURL = ghCfg.BaseURL
 			}
 
 			// Persist the adopted App IDENTITY to the PVC overlay, exactly as the

--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -902,11 +902,22 @@ func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFing
 		return nil
 	}
 
+	// Emit the COMPLETE set. The guard above validated app_id/app_slug against
+	// the forge URLs this hive resolved to; sending the App without those URLs
+	// would ship a set the spoke cannot reassemble, and leave it to be completed
+	// — or contradicted — by a ProjectConfig push on a different channel.
+	//
+	// The URLs are the RESOLVED ones (identity.APIURL/BaseURL), so what the
+	// spoke receives is byte-identical to what was just validated. A public
+	// election resolves to empty URLs, which the spoke reads as "unchanged" —
+	// correct, because empty is also how every healthy public spoke is stored.
 	return &HeartbeatGitHubAppConfig{
 		AppID:          identity.AppID,
 		InstallationID: installationID,
 		PrivateKey:     privateKey,
 		AppSlug:        identity.AppSlug,
+		APIURL:         identity.APIURL,
+		BaseURL:        identity.BaseURL,
 	}
 }
 

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -776,6 +776,30 @@ type HeartbeatGitHubAppConfig struct {
 	// Empty means "leave the spoke's slug unchanged" — never a way to blank a
 	// working value.
 	AppSlug string `json:"app_slug,omitempty"`
+	// APIURL and BaseURL complete the identity SET.
+	//
+	// WHY THEY ARE HERE AND NOT ON ProjectConfig
+	//
+	// app_id, app_slug, api_url and base_url are ONE value: an App ID presented
+	// to the wrong forge returns "404 Integration not found". Until now the App
+	// half travelled on this channel and api_url travelled on
+	// HeartbeatProjectConfig, dispatched independently to a different callback.
+	// Nothing composed them, so nothing could validate them together — and a
+	// forge switch (saas.go, pendingForgeAPIURL) deliberately sends api_url
+	// ALONE, which is precisely the operation that changes identity. Between
+	// those beats the spoke holds a half-identity: exactly the 404 shape that
+	// took 26 hives down on 2026-07-31.
+	//
+	// Carrying them here lets the whole set be built and validated in one place,
+	// and lets the spoke adopt it atomically instead of in two unordered halves.
+	//
+	// Empty means "leave the spoke's value unchanged", the same contract as
+	// AppSlug — never a way to blank a working URL. Note that empty is ALSO the
+	// correct steady state for a public-GitHub hive (~41 of 50 spokes run that
+	// way), which is why the spoke must not infer "public" from silence here;
+	// the App ID is the field that names the forge.
+	APIURL  string `json:"api_url,omitempty"`
+	BaseURL string `json:"base_url,omitempty"`
 	// AdditionalKeys carries EVERY OTHER GitHub App private key the fleet knows,
 	// keyed by its own app_id, so a spoke can hold both the github.com App key
 	// AND its cluster's GitHub Enterprise App key at once — and pick whichever

--- a/v2/pkg/hub/identity_set_emitted_test.go
+++ b/v2/pkg/hub/identity_set_emitted_test.go
@@ -1,0 +1,64 @@
+package hub
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+const vllmDWithForges = `{
+  "id": "vllm-d",
+  "github_base_url": "https://github.ibm.com",
+  "github_api_url": "https://github.ibm.com/api/v3",
+  "github_app_id": 5686,
+  "github_app_slug": "kubestellar-hive-ghe",
+  "forges": { "github.com": { "app_id": 3568013, "app_slug": "kubestellar-hive" } }
+}`
+
+// TestHubEmitsTheCompleteIdentitySet pins that what the hub SENDS is a full,
+// self-consistent identity — not an App whose forge urls the spoke must obtain
+// from a different channel on a different beat.
+//
+// Validating the set hub-side and then shipping only half of it leaves the
+// check meaningless: the spoke reassembles the App against whatever urls it
+// already had, which is how a public app_id came to sit on GHE urls and 404.
+func TestHubEmitsTheCompleteIdentitySet(t *testing.T) {
+	withTempAppKeyDir(t)
+	oldHives := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = oldHives })
+
+	if err := storeClusterAppKey("vllm-d", testAppKeyPEM(t)); err != nil {
+		t.Fatal(err)
+	}
+	var c ClusterConfig
+	if err := json.Unmarshal([]byte(vllmDWithForges), &c); err != nil {
+		t.Fatal(err)
+	}
+	s := &HubServer{logger: appKeyTestLogger(), clusters: map[string]ClusterConfig{"vllm-d": c}}
+
+	ghe := &SaaSHive{ID: "ghe-hive", ClusterID: "vllm-d", GitHubHost: "github.ibm.com"}
+	if err := saveSaaSHive(ghe); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("GHE hive: the emitted set carries its forge urls", func(t *testing.T) {
+		got := s.appKeyConfigForHeartbeat("ghe-hive", "vllm-d", "", false, false, 0, 43057, s.logger, ghe)
+		if got == nil {
+			t.Fatal("no config emitted")
+		}
+		if got.APIURL == "" && got.BaseURL == "" {
+			t.Fatal("the App was sent with NO forge urls — the spoke must then pair it with whatever it already had, which is the half-identity this change removes")
+		}
+		// What is sent must itself be a valid set.
+		if err := config.RejectIdentitySet(config.GitHubConfig{
+			AppID: got.AppID, AppSlug: got.AppSlug, APIURL: got.APIURL, BaseURL: got.BaseURL,
+		}); err != nil {
+			t.Fatalf("the hub emitted an inconsistent set: %v", err)
+		}
+		if got.AppID != config.EnterpriseGitHubAppID {
+			t.Fatalf("app_id = %d, want %d", got.AppID, config.EnterpriseGitHubAppID)
+		}
+	})
+}


### PR DESCRIPTION
## The split

`app_id`, `app_slug`, `api_url`, `base_url` are **one value** — an App ID presented to the wrong forge returns `404 Integration not found`. They travelled on **two channels**:

| Field | Channel | Callback |
|---|---|---|
| `app_id`, `app_slug`, key | `HeartbeatGitHubAppConfig` | `heartbeat.go:511` |
| `api_url` | `HeartbeatProjectConfig` | `heartbeat.go:527` |

Dispatched independently, with nothing composing them — so nothing could validate them together. **Nine construction sites** built one identity: six for `GitHubAppConfig`, three for `ProjectConfig`.

A forge switch makes it concrete: `pendingForgeAPIURL` (`saas.go:5933`) deliberately sends `api_url` **alone**, because it must work regardless of project completeness — and that is exactly the operation that changes identity. Between those beats the spoke holds a public `app_id` against GHE urls: the 2026-07-31 shape.

## The change

- `HeartbeatGitHubAppConfig` carries `APIURL`/`BaseURL` — the App and its forge travel together
- The hub emits the **resolved** urls, byte-identical to what its guard just validated. Validating a set and shipping half of it makes the check meaningless, since the spoke reassembles the App against whatever it already had.
- `prospectiveGitHubIdentity` adopts all four, so `RejectIdentitySet` sees the whole set before anything applies
- The spoke applies the urls in the same delivery as the App

**Empty still means "unchanged."** It cannot mean "make me public": empty urls are the correct steady state for a public hive (~41 of 50 spokes), so silence is indistinguishable from "no opinion" and must never blank a working GHE url.

**Purely additive on the wire** — an older spoke ignores the new fields.

## Mutations

| Mutation | Result |
|---|---|
| Drop url adoption from the prospective set | 2 failures ✓ |
| Adopt urls even when empty (blank a working config) | 2 failures ✓ |
| Hub stops emitting the urls | 2 failures ✓ |

The third **initially survived.** The spoke half was tested and the hub half was not — so the hub could have shipped an App with no urls and every test would have passed. Same "tested the function beside the change" gap that let an earlier guard fix pass unverified. `TestHubEmitsTheCompleteIdentitySet` closes it.

`pkg/hub`, `pkg/config`, `cmd/hive` green.