### PR TITLE
🐛 fix(hub): stop losing funded gateways on a single dropped beat

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2366,7 +2366,12 @@ func main() {
 			// "genuinely zero agents configured" from "old spoke, unknown".
 			agentsWithModel := agentMgr.CountAgentsWithModel()
 			return &hub.HeartbeatPayload{
-				AgentsWithModel:   &agentsWithModel,
+				AgentsWithModel: &agentsWithModel,
+				// Read-back for hub-funded gateways: the hub clears its pending
+				// record only when it sees the gateway named here, so a lost
+				// delivery is re-offered rather than dropped. Names only — the
+				// key never leaves the spoke.
+				GatewayNames:      dashSrv.ConfiguredGatewayNames(),
 				HiveID:            cfg.HiveID,
 				Org:               cfg.Project.Org,
 				AIAuthor:          cfg.Project.AIAuthor,

--- a/v2/pkg/dashboard/openrouter.go
+++ b/v2/pkg/dashboard/openrouter.go
@@ -325,3 +325,30 @@ func (s *Server) resolveOpenRouterKey() string {
 func (s *Server) redirectOpenRouter(w http.ResponseWriter, r *http.Request, flag string) {
 	http.Redirect(w, r, "/"+flag, http.StatusFound)
 }
+
+// ConfiguredGatewayNames returns the names of the model gateways this spoke
+// currently has, for the heartbeat read-back.
+//
+// It is what lets the hub stop re-offering a funded gateway: the hub clears its
+// pending record only when the spoke reports that gateway back, so a delivery
+// lost in flight — or one that failed inside ApplyDeliveredGateway — is offered
+// again on the next beat instead of vanishing.
+//
+// Names only. A gateway carries a secret key and an endpoint; neither belongs
+// in a heartbeat payload, and the name alone is sufficient to confirm arrival.
+func (s *Server) ConfiguredGatewayNames() []string {
+	if s == nil || s.deps.Config == nil {
+		return nil
+	}
+	gws := s.deps.Config.Governor.ResolvedGateways()
+	if len(gws) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(gws))
+	for _, gw := range gws {
+		if n := strings.TrimSpace(gw.Name); n != "" {
+			out = append(out, n)
+		}
+	}
+	return out
+}

--- a/v2/pkg/hub/gateway_at_least_once_test.go
+++ b/v2/pkg/hub/gateway_at_least_once_test.go
@@ -1,0 +1,56 @@
+package hub
+
+import "testing"
+
+// TestFundedGatewayIsReOfferedUntilConfirmed pins that a gateway the user has
+// PAID for is not lost to a single dropped beat.
+//
+// takePendingGateway deleted the record the moment it went on the wire, so a
+// response lost in flight, a hub restart before the next beat, or a spoke-side
+// ApplyDeliveredGateway error all dropped it permanently — no retry, and only a
+// spoke log line to say the user's money bought nothing.
+func TestFundedGatewayIsReOfferedUntilConfirmed(t *testing.T) {
+	s := &HubServer{pendingGateways: map[string]*HeartbeatGatewayConfig{}}
+	s.queuePendingGateway("h1", &HeartbeatGatewayConfig{Name: "openrouter", Key: "secret"})
+
+	t.Run("offered while the spoke has not reported it", func(t *testing.T) {
+		if got := s.pendingGatewayFor("h1", nil); got == nil {
+			t.Fatal("not offered on the first beat")
+		}
+		// The beat is lost. It must still be offered.
+		if got := s.pendingGatewayFor("h1", nil); got == nil {
+			t.Fatal("a lost delivery was dropped — this is the paid-for-nothing case")
+		}
+	})
+
+	t.Run("an empty report is UNKNOWN, not a confirmation", func(t *testing.T) {
+		// A spoke too old to report gateways sends nothing. That must never be
+		// read as "it has the gateway", or delivery silently stops.
+		if got := s.pendingGatewayFor("h1", []string{}); got == nil {
+			t.Fatal("an empty report cleared the pending gateway")
+		}
+	})
+
+	t.Run("a DIFFERENT gateway is not a confirmation", func(t *testing.T) {
+		if got := s.pendingGatewayFor("h1", []string{"some-other-gw"}); got == nil {
+			t.Fatal("an unrelated gateway confirmed the delivery")
+		}
+	})
+
+	t.Run("reporting it back clears the record and stops the offers", func(t *testing.T) {
+		if got := s.pendingGatewayFor("h1", []string{"openrouter"}); got != nil {
+			t.Fatal("still offered after the spoke confirmed it")
+		}
+		// And it stays cleared — no re-charge, no re-delivery.
+		if got := s.pendingGatewayFor("h1", nil); got != nil {
+			t.Fatal("the gateway came back after being confirmed")
+		}
+	})
+
+	t.Run("case-insensitive, like every other name comparison here", func(t *testing.T) {
+		s.queuePendingGateway("h2", &HeartbeatGatewayConfig{Name: "openrouter"})
+		if got := s.pendingGatewayFor("h2", []string{"OpenRouter"}); got != nil {
+			t.Fatal("a case-different report failed to confirm")
+		}
+	})
+}

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -401,6 +401,17 @@ type HeartbeatPayload struct {
 	// nudge", NOT as a genuine zero. Never threaten a hive over a signal that
 	// was never sent.
 	AgentsWithModel *int `json:"agents_with_model,omitempty"`
+	// GatewayNames lists the model gateways this spoke currently has configured.
+	//
+	// It is the READ-BACK for a hub-funded gateway. Without it the hub drained
+	// its pending record the moment it put the gateway on the wire, so a
+	// delivery lost to a dropped beat, a hub restart, or a spoke-side
+	// ApplyDeliveredGateway error was gone for good — the user paid and the
+	// gateway never arrived, with nothing left to retry from.
+	//
+	// nil/empty means the spoke is too old to report (UNKNOWN, never "has
+	// none"), so an absent list must not be read as a failed delivery.
+	GatewayNames []string `json:"gateway_names,omitempty"`
 	// GitHubAppKeyFingerprint is a NON-SECRET identifier for the GitHub App
 	// private key this spoke currently holds — "sha256:<hex>" over the DER
 	// public key derived from it (config.AppKeyFingerprint). It exists so the

--- a/v2/pkg/hub/heartbeat_handler_coverage_test.go
+++ b/v2/pkg/hub/heartbeat_handler_coverage_test.go
@@ -116,13 +116,37 @@ func TestHandleHeartbeatDeliversPending(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
 	}
-	// The pending gateway should be drained on delivery.
-	if s.hasPendingGateway(hiveID) {
-		t.Error("expected pending gateway drained after heartbeat delivery")
-	}
-	// The response body should carry the funded gateway.
+	// The response body must carry the funded gateway.
 	if !strings.Contains(rec.Body.String(), "openrouter") {
 		t.Errorf("expected pending gateway in response, got %s", rec.Body.String())
+	}
+	// It must NOT be drained yet. This assertion is inverted from what it used to
+	// be: draining on send made a paid-for gateway at-most-once, so a response
+	// lost in flight — or one the spoke failed to apply — dropped it with nothing
+	// left to retry from. The spoke's payload above reports no gateways, which is
+	// UNKNOWN (an older spoke cannot report), never a confirmation.
+	if !s.hasPendingGateway(hiveID) {
+		t.Error("gateway was drained on send; it must survive until the spoke reports it back")
+	}
+
+	// Once the spoke reports the gateway, the hub stops offering it.
+	confirmBody := `{
+		"hive_id":"kellyaa",
+		"org":"testorg",
+		"primary_repo":"repo",
+		"repos":["repo"],
+		"dashboard_url":"https://kellyaa.hive.kubestellar.io",
+		"git_hash":"deadbeef1234",
+		"is_public":true,
+		"tokens_24h":42,
+		"gateway_names":["openrouter"]
+	}`
+	rec2 := postHeartbeat(t, s, confirmBody)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("confirm status = %d body=%s", rec2.Code, rec2.Body.String())
+	}
+	if s.hasPendingGateway(hiveID) {
+		t.Error("gateway still pending after the spoke reported it back")
 	}
 }
 

--- a/v2/pkg/hub/openrouter.go
+++ b/v2/pkg/hub/openrouter.go
@@ -220,16 +220,37 @@ func (s *HubServer) queuePendingGateway(hiveID string, gw *HeartbeatGatewayConfi
 	s.pendingGateways[hiveID] = gw
 }
 
-// takePendingGateway returns and REMOVES the pending gateway for hiveID (drained
-// on delivery so a secret key is sent once, not re-sent every beat), or nil.
-func (s *HubServer) takePendingGateway(hiveID string) *HeartbeatGatewayConfig {
+// pendingGatewayFor returns the gateway queued for hiveID, clearing it only once
+// the spoke has REPORTED that gateway back.
+//
+// It used to delete on send. That made delivery at-most-once for a value the
+// user has already paid for: a beat lost in flight, a hub restart before the
+// next beat, or a spoke-side ApplyDeliveredGateway error all dropped the
+// gateway permanently, with nothing left to retry from and only a spoke log
+// line to say so.
+//
+// Draining on CONFIRMATION instead makes it at-least-once-then-stop, the same
+// contract the GitHub identity record uses. Re-sending until confirmed is safe:
+// ApplyDeliveredGateway replaces a gateway of the same name, so a duplicate
+// delivery is a no-op rather than a second charge.
+//
+// reported is what the spoke says it currently has. An EMPTY list means the
+// spoke is too old to report — UNKNOWN, not "does not have it" — so it never
+// counts as confirmation and never as failure; the delivery simply stays queued
+// and keeps being offered.
+func (s *HubServer) pendingGatewayFor(hiveID string, reported []string) *HeartbeatGatewayConfig {
 	s.pendingGatewaysMu.Lock()
 	defer s.pendingGatewaysMu.Unlock()
 	gw, ok := s.pendingGateways[hiveID]
 	if !ok {
 		return nil
 	}
-	delete(s.pendingGateways, hiveID)
+	for _, name := range reported {
+		if strings.EqualFold(strings.TrimSpace(name), strings.TrimSpace(gw.Name)) {
+			delete(s.pendingGateways, hiveID)
+			return nil
+		}
+	}
 	return gw
 }
 

--- a/v2/pkg/hub/openrouter_coverage_test.go
+++ b/v2/pkg/hub/openrouter_coverage_test.go
@@ -34,8 +34,8 @@ func TestPendingGatewayLifecycle(t *testing.T) {
 	if s.hasPendingGateway("h1") {
 		t.Error("no gateway should be pending initially")
 	}
-	if got := s.takePendingGateway("h1"); got != nil {
-		t.Error("take on empty should be nil")
+	if got := s.pendingGatewayFor("h1", nil); got != nil {
+		t.Error("fetch on empty should be nil")
 	}
 
 	gw := &HeartbeatGatewayConfig{Name: "openrouter", Key: "k"}
@@ -43,12 +43,22 @@ func TestPendingGatewayLifecycle(t *testing.T) {
 	if !s.hasPendingGateway("h1") {
 		t.Error("gateway should be pending after queue")
 	}
-	got := s.takePendingGateway("h1")
+	got := s.pendingGatewayFor("h1", nil)
 	if got == nil || got.Key != "k" {
-		t.Errorf("take = %+v, want key=k", got)
+		t.Errorf("fetch = %+v, want key=k", got)
+	}
+	// This assertion is INVERTED from what it used to be. It previously required
+	// the record to be gone after a single fetch, which is what made a funded
+	// gateway at-most-once: one lost beat and the user's money bought nothing.
+	// It must now survive until the spoke reports the gateway back.
+	if !s.hasPendingGateway("h1") {
+		t.Error("gateway was drained on send; it must persist until the spoke confirms it")
+	}
+	if got := s.pendingGatewayFor("h1", []string{"openrouter"}); got != nil {
+		t.Error("still offered after the spoke confirmed it")
 	}
 	if s.hasPendingGateway("h1") {
-		t.Error("gateway should be drained after take")
+		t.Error("gateway should be cleared once confirmed")
 	}
 }
 

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1379,9 +1379,10 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Deliver a funded OpenRouter gateway to a firewalled/heartbeat-only spoke.
-	// Drained on delivery (carries a secret key value, so it is sent once, not
-	// re-sent every beat). The key value is not logged.
-	if gw := s.takePendingGateway(payload.HiveID); gw != nil {
+	// Re-offered until the spoke REPORTS the gateway back, then cleared. The key
+	// value is never logged. Draining on send instead made this at-most-once for
+	// something already paid for — see pendingGatewayFor.
+	if gw := s.pendingGatewayFor(payload.HiveID, payload.GatewayNames); gw != nil {
 		resp.PendingGateway = gw
 		s.logger.Info("heartbeat: delivering funded gateway to spoke",
 			"hive_id", payload.HiveID, "gateway", gw.Name, "default_model", gw.DefaultModel)


### PR DESCRIPTION
## The bug

`takePendingGateway` deleted the record the moment the gateway went on the wire — at-most-once delivery for something the user has **already paid for**. Three ways it vanished with nothing left to retry from:

- the heartbeat response is lost in flight
- the hub restarts before the next beat (the queue is an in-memory map)
- `ApplyDeliveredGateway` **fails on the spoke** — the hub has already dropped its copy, and only a spoke-side log line records it

## The fix

Same contract the GitHub identity record has used since #2379: **drain on confirmation, not on send.**

| | |
|---|---|
| `HeartbeatPayload.GatewayNames` | the spoke reports which gateways it has — names only, the key never leaves the spoke |
| `Server.ConfiguredGatewayNames()` | supplies it from resolved config |
| `pendingGatewayFor(hiveID, reported)` | replaces `takePendingGateway`; clears only when the spoke names that gateway back |

**An empty report is UNKNOWN, not confirmation.** A spoke too old to report sends nothing, and reading that as "it has the gateway" would silently stop delivery — the same unknown-vs-mismatch rule the identity push already follows.

**Re-sending is safe:** `ApplyDeliveredGateway` replaces a gateway of the same name, so a duplicate delivery is a no-op, not a second charge.

## Two tests were pinning the data loss

`TestPendingGatewayLifecycle` asserted *"gateway should be drained after take"* and `TestHandleHeartbeatDeliversPending` asserted *"expected pending gateway drained after heartbeat delivery"*. Both assertions are inverted here — they were encoding the at-most-once behaviour as correct.

The handler test now also posts a second heartbeat carrying `gateway_names` and asserts the offer stops, covering the full confirm cycle through the real HTTP path.

## Mutations

| Mutation | Result |
|---|---|
| Revert to drain-on-send | 6 failures ✓ |
| Treat an empty report as confirmed | 4 failures ✓ |

`pkg/hub`, `pkg/dashboard`, `cmd/hive` green.