### PR TITLE
♻️ refactor(hub): name the reconcile rule, and the unknown-vs-mismatch case

### DIFF
--- a/v2/pkg/hub/push_rule.go
+++ b/v2/pkg/hub/push_rule.go
@@ -1,0 +1,23 @@
+package hub
+
+// needsPush is the shape every hub->spoke reconcile rule shares: the hub has a
+// value it wants (desired) and the spoke reports something else (observed).
+//
+// The observedKnown argument is the part that is NOT boilerplate. An empty
+// report means one of two things and conflating them breaks the fleet in
+// opposite directions:
+//
+//	observedKnown=true  — the spoke reported, and "" is a real value.
+//	observedKnown=false — the spoke is too old to report this field at all.
+//	                      That is UNKNOWN, not a mismatch. Pushing on it
+//	                      re-sends every beat with no read-back that could
+//	                      ever stop it, because the spoke cannot report what
+//	                      it does not know how to report.
+//
+// Only the api_url rule needs observedKnown today, but naming the distinction
+// keeps the next rule from quietly dropping it: the push flags look like copies
+// of one expression and are not, and each difference was learned from a live
+// outage.
+func needsPush(desired, observed string, observedKnown bool) bool {
+	return desired != "" && observedKnown && observed != desired
+}

--- a/v2/pkg/hub/push_rule_test.go
+++ b/v2/pkg/hub/push_rule_test.go
@@ -1,0 +1,47 @@
+package hub
+
+import "testing"
+
+// TestNeedsPushUnknownIsNotMismatch pins the distinction the six push flags
+// encode and that a naive "desired != observed" diff destroys.
+//
+// An empty report from a spoke means one of two things, and conflating them
+// breaks the fleet in opposite directions:
+//
+//	observedKnown=true  — the spoke reported; "" is a real value
+//	observedKnown=false — the spoke is too old to report this field at all
+//
+// Treating UNKNOWN as a mismatch re-sends on every beat forever, because no
+// read-back can ever satisfy it — the spoke cannot report what it does not
+// know how to report.
+func TestNeedsPushUnknownIsNotMismatch(t *testing.T) {
+	cases := []struct {
+		name     string
+		desired  string
+		observed string
+		known    bool
+		want     bool
+		why      string
+	}{
+		{"push when observed differs and is known", "https://ghe/api/v3", "https://api.github.com", true, true,
+			"a real mismatch must be corrected"},
+		{"no push when observed already matches", "https://ghe/api/v3", "https://ghe/api/v3", true, false,
+			"converged; re-sending would never stop"},
+		{"NO push when observed is UNKNOWN", "https://ghe/api/v3", "", false, false,
+			"a spoke too old to report must not be pushed forever with no read-back to stop it"},
+		{"push when observed is known-empty and differs", "https://ghe/api/v3", "", true, true,
+			"the spoke reported it has none; that IS a mismatch"},
+		{"no push when the hub wants nothing", "", "https://api.github.com", true, false,
+			"no desired value is not an instruction to blank the spoke's"},
+		{"no push when the hub wants nothing and observed is unknown", "", "", false, false,
+			"nothing known on either side"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := needsPush(tc.desired, tc.observed, tc.known); got != tc.want {
+				t.Fatalf("needsPush(%q,%q,%v) = %v, want %v — %s",
+					tc.desired, tc.observed, tc.known, got, tc.want, tc.why)
+			}
+		})
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -5980,7 +5980,9 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 	// spoke confirms it. curACMM == 0 means the spoke did not report a level, so
 	// there is nothing to correct yet.
 	needACMMPush := !h.ACMMDelivered && h.RequestedACMMLevel > 0 && curACMM != h.RequestedACMMLevel
-	needURLPush := h.VanityURL != "" && curURL != h.VanityURL
+	// Vanity URL: the spoke always reports its dashboard URL, so observed is
+	// known and an empty one is a real "I have none" rather than silence.
+	needURLPush := needsPush(h.VanityURL, curURL, true)
 	// A spoke reporting a repo that fails isValidRepoRef is wedged: the hub 400s
 	// its every heartbeat ("invalid repo name"), /api/livez then fails on the
 	// stale heartbeat and the kubelet crash-loops the pod. Push a corrected
@@ -6006,7 +6008,11 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 	// to report its API URL, which is UNKNOWN, not a mismatch — pushing on it
 	// would re-send on every beat with no read-back to ever stop it.
 	wantAPIURL := gheAPIURLForHost(h.GitHubHost)
-	needGHEAPIPush := wantAPIURL != "" && curAPIURL != "" && curAPIURL != wantAPIURL
+	// The api_url is the field where unknown-vs-mismatch actually bites: a spoke
+	// too old to report it sends "", which is NOT "I am on api.github.com". The
+	// observedKnown argument carries that distinction explicitly instead of
+	// hiding it in a curAPIURL != "" conjunct that a later edit could drop.
+	needGHEAPIPush := needsPush(wantAPIURL, curAPIURL, curAPIURL != "")
 	// A pending FORGE SWITCH pushes on its own handshake. It cannot ride
 	// needGHEAPIPush: that gate is deliberately conservative about an empty
 	// curAPIURL (unknown, not a mismatch) and — more importantly — it can never


### PR DESCRIPTION
## Why not one generic diff

Six `needXPush` flags decide what the hub sends a spoke. Five share one shape — the hub wants a value, the spoke reports something else — so they *read* like copies of `desired != observed`. They aren't, and each difference was learned from a live outage:

| flag | the difference |
|---|---|
| `needGHEAPIPush` | requires `curAPIURL != ""` — an empty report means the spoke is **too old to report**, which is UNKNOWN, not a mismatch |
| `needForgePush` | can't ride that rule: a switch to public github.com has `wantAPIURL == ""` by definition |
| `needRepoRepair` | fires **even after delivery**, because a wedged spoke can never report anything the hub will accept |
| `needClaimPush` | compares case-insensitively |

Collapsing them into a generic diff would delete all four. This does the opposite — it names the shared shape and makes the one non-obvious argument explicit.

## The change

```go
needsPush(desired, observed string, observedKnown bool) bool
```

`observedKnown` is load-bearing. Treating UNKNOWN as a mismatch re-sends on every beat with **no read-back that can ever stop it**, because a spoke cannot report a field it doesn't know how to report. That rule previously lived in a `curAPIURL != ""` conjunct any later edit could drop silently.

Routed `needURLPush` and `needGHEAPIPush` through it — the two that fit exactly. The other four keep their own preconditions **deliberately**: a rule that doesn't fit the shape should look different, not be forced into it.

## On the test

`needsPush` is package-level, not a closure, so the test exercises the **real** function. An earlier draft redefined it locally and would have passed against any change to production code — the same "tested the thing beside the change" gap that let a guard fix pass unverified earlier today.

| Mutation | Result |
|---|---|
| Drop `observedKnown` (unknown → mismatch) | 2 failures ✓ |
| Push when the hub wants nothing | 2 failures ✓ |

`pkg/hub`, `pkg/config`, `cmd/hive` green.