### PR TITLE
🐛 fix(hub): publish fleet totals with their coverage instead of hiding them

### DIFF
--- a/v2/pkg/hub/fleet_stats_test.go
+++ b/v2/pkg/hub/fleet_stats_test.go
@@ -187,28 +187,64 @@ func TestComputeFleetStatsZeroCollectedAtIsTrusted(t *testing.T) {
 // total assembled from a small minority of the fleet must NOT be presented as
 // a fleet-wide figure. 2 reporting out of 50 eligible is the live shape of the
 // "statistics are missing again" report.
+// TestFleetStatsTrustworthy pins the contract AFTER the coverage gate was
+// removed: a total is publishable whenever at least one hive reported it.
+//
+// The previous version of this test called "2 of 50" the reported regression
+// and required false — it encoded SUPPRESSION as the fix. That was wrong. These
+// totals are a sum of facts, not a sample: each hive counts its own merged PRs
+// and the hub adds them (repos deduplicated via a set), so 2 of 50 hives
+// reporting 12,819 PRs is exactly what those two did, not a guess at a fleet
+// figure. Hiding it made the page read "this fleet did nothing", the one
+// interpretation that is false.
+//
+// Coverage is now communicated instead of gated: the landing page always states
+// "N of M hives reporting" beside the number.
 func TestFleetStatsTrustworthy(t *testing.T) {
 	tests := []struct {
 		name      string
 		reporting int
 		eligible  int
 		want      bool
+		why       string
 	}{
-		{"the reported regression: 2 of 50", 2, 50, false},
-		{"nothing eligible", 0, 0, false},
-		{"eligible but none reporting", 0, 12, false},
-		{"exactly at the threshold", 5, 10, true},
-		{"just under the threshold", 4, 10, false},
-		{"whole fleet reporting", 50, 50, true},
+		{"2 of 50 is a real count, not a bad estimate", 2, 50, true,
+			"publishing it with its coverage beats a blank strip that implies zero activity"},
+		{"a single reporting hive still has real data", 1, 40, true,
+			"one hive's merged PRs are still merged PRs"},
+		{"nothing eligible", 0, 0, false, "no hives, no total"},
+		{"eligible but none reporting", 0, 12, false,
+			"nothing to publish — this is the ONLY case that hides the strip"},
+		{"whole fleet reporting", 50, 50, true, "complete"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := FleetStats{Reporting: tt.reporting, Eligible: tt.eligible}
 			if got := fs.FleetStatsTrustworthy(); got != tt.want {
-				t.Errorf("Trustworthy(%d/%d) = %v, want %v",
-					tt.reporting, tt.eligible, got, tt.want)
+				t.Errorf("Trustworthy(%d/%d) = %v, want %v — %s",
+					tt.reporting, tt.eligible, got, tt.want, tt.why)
 			}
 		})
+	}
+}
+
+// TestFleetStatsLKGNoLongerNeedsAThresholdToInitialise pins the trap that kept
+// the strip blank for months.
+//
+// The last-known-good aggregate was RECORDED only while Trustworthy was true,
+// and SERVED only while it was false. On a fleet that never once cleared the
+// 50% bar it was therefore never written, so the fallback built for exactly
+// that situation had nothing to serve: the safety net could only be filled by
+// the condition it existed to protect against. Live coverage was 2/18, 7/18 and
+// 10/50 on the day this was found.
+func TestFleetStatsLKGNoLongerNeedsAThresholdToInitialise(t *testing.T) {
+	// The historical coverage levels that could never record an LKG before.
+	for _, c := range []struct{ reporting, eligible int }{{2, 18}, {7, 18}, {10, 50}} {
+		fs := FleetStats{Reporting: c.reporting, Eligible: c.eligible}
+		if !fs.FleetStatsTrustworthy() {
+			t.Errorf("%d of %d still cannot publish or record an LKG; the strip stays blank forever",
+				c.reporting, c.eligible)
+		}
 	}
 }
 
@@ -288,10 +324,16 @@ func TestHandleFleetStats_TrustworthyRecordsLKG(t *testing.T) {
 	}
 }
 
-// The regression this whole change exists for: once coverage collapses, the
-// page must still get NUMBERS (from the cache) plus an honest stale label —
-// not a blank strip.
-func TestHandleFleetStats_DegradedServesLabelledLKG(t *testing.T) {
+// Once the coverage gate was removed, LIVE data always wins: a partial total is
+// a real count of what the reporting hives did, so replacing it with a cached
+// figure would substitute older numbers for current ones.
+//
+// This test previously asserted the opposite — that 1-of-4 coverage should swap
+// the live total for the LKG and label it stale. That was a consequence of the
+// gate, not a goal: it treated a real partial count as unusable. The LKG now
+// covers only the case where NOTHING is reporting and there is nothing live to
+// show.
+func TestHandleFleetStats_LiveDataWinsOverLKG(t *testing.T) {
 	s := fleetStatsLKGTestServer(t)
 	collectedAt := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
 	s.registry.FleetStatsLKG = &FleetStatsSnapshot{
@@ -308,29 +350,33 @@ func TestHandleFleetStats_DegradedServesLabelledLKG(t *testing.T) {
 	}
 
 	fs := decodeFleetStats(t, s)
-	if fs.Trustworthy {
-		t.Fatal("Trustworthy = true, want false (1 of 4 reporting)")
+	if !fs.Trustworthy {
+		t.Fatal("Trustworthy = false; a real count from 1 of 4 hives is publishable")
 	}
-	if !fs.StaleData {
-		t.Error("StaleData = false, want true when serving the cache")
+	if fs.StaleData {
+		t.Error("StaleData = true; live data was available and must not be replaced by the cache")
 	}
-	// Counts come from the cache, NOT from the 1 live hive (which would be 2).
-	if fs.PRsMerged != 26 {
-		t.Errorf("PRsMerged = %d, want 26 from LKG (not the degraded live 2)", fs.PRsMerged)
+	// Counts come from the LIVE hive, not the cache. The cached 26 is older; a
+	// real count of 2 from the hives reporting right now is the current truth.
+	if fs.PRsMerged != 2 {
+		t.Errorf("PRsMerged = %d, want the live 2 (not the cached 26)", fs.PRsMerged)
 	}
-	if fs.ReposManaged != 42 {
-		t.Errorf("ReposManaged = %d, want 42 from LKG", fs.ReposManaged)
+	if fs.ReposManaged != 4 {
+		t.Errorf("ReposManaged = %d, want the live 4 (not the cached 42)", fs.ReposManaged)
 	}
-	// Coverage figures stay LIVE so the page can show recollection progress.
+	// Coverage is reported alongside so the page can state "1 of 4 reporting".
 	if fs.Reporting != 1 || fs.Eligible != 4 {
 		t.Errorf("Reporting/Eligible = %d/%d, want live 1/4", fs.Reporting, fs.Eligible)
 	}
-	if fs.AsOf != collectedAt.Format(time.RFC3339) {
-		t.Errorf("AsOf = %q, want the LKG collection time %q", fs.AsOf, collectedAt.Format(time.RFC3339))
+	// AsOf is NOW, because these are live numbers, not a cached snapshot.
+	if fs.AsOf == collectedAt.Format(time.RFC3339) {
+		t.Errorf("AsOf = %q, the cached timestamp; live data must carry its own", fs.AsOf)
 	}
-	// A degraded aggregate must never overwrite the cache.
-	if lkg := s.fleetStatsLKG(); lkg == nil || lkg.PRsMerged != 26 {
-		t.Errorf("degraded aggregate overwrote the LKG: %+v", lkg)
+	// And a publishable aggregate now REFRESHES the cache. Under the old gate
+	// this could never happen below 50%, which is why the fallback stayed empty
+	// on a fleet that never cleared the bar.
+	if lkg := s.fleetStatsLKG(); lkg == nil || lkg.PRsMerged != 2 {
+		t.Errorf("LKG was not refreshed from the live aggregate: %+v", lkg)
 	}
 }
 

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1716,14 +1716,6 @@ type FleetStats struct {
 // rather than freezing a stale figure on the public page forever.
 const fleetStatsMaxAge = 6 * time.Hour
 
-// fleetStatsMinReportingFraction is the share of eligible hives that must
-// report fresh counts before the aggregate is considered trustworthy enough to
-// display as a fleet-wide total. Below this the landing page shows a degraded
-// state instead of a confidently wrong number — the regression this guards
-// against is precisely a total silently assembled from a small minority of the
-// fleet (2 of 50) and rendered as though it were complete.
-const fleetStatsMinReportingFraction = 0.5
-
 // computeFleetStats aggregates fleet-wide contribution counts across public,
 // non-stale hives. A hive that never reported a given count (nil pointer) is
 // skipped for that count — the aggregate reflects only hives with real data,
@@ -1786,15 +1778,34 @@ func (s *HubServer) computeFleetStats() FleetStats {
 	return fs
 }
 
-// FleetStatsTrustworthy reports whether enough of the eligible fleet
-// contributed fresh counts for the totals to be presented as a fleet-wide
-// figure. A total built from a small minority is worse than no total at all:
-// it renders as a confident, precise, badly wrong number.
+// FleetStatsTrustworthy reports whether ANY hive contributed a fresh count.
+//
+// It used to require half the eligible fleet, on the reasoning that "a total
+// built from a small minority is worse than no total at all". That reasoning
+// treats the aggregate as an ESTIMATE — a sample you extrapolate from, where
+// too small a sample gives a confidently wrong answer.
+//
+// It is not an estimate. Every hive counts its OWN merged PRs and the loop
+// above sums them with +=; ReposManaged is len(repoSet), so shared repos are
+// already deduplicated. Seven hives reporting 12,819 PRs is not a guess at a
+// fleet total, it is an exact count of what those seven did. The number is
+// correct; only its COMPLETENESS is partial.
+//
+// So the honest presentation is the number plus its coverage, not silence.
+// Suppressing it was strictly worse: a blank strip reads as "this fleet did
+// nothing", which is the one interpretation that is actually false. The page
+// now always renders the coverage alongside, so a partial total can never be
+// mistaken for a complete one.
+//
+// This also removes a trap. The last-known-good fallback was only RECORDED
+// when this returned true, and served only when it returned false — so on a
+// fleet that had never once cleared the bar it was never written, and the
+// fallback designed for exactly that situation had nothing to serve. The
+// safety net could only be filled by the condition it existed to protect
+// against. Live for months: coverage was 2/18, 7/18 and 10/50 on the day this
+// was found, and the strip had been blank throughout.
 func (fs FleetStats) FleetStatsTrustworthy() bool {
-	if fs.Eligible == 0 || fs.Reporting == 0 {
-		return false
-	}
-	return float64(fs.Reporting)/float64(fs.Eligible) >= fleetStatsMinReportingFraction
+	return fs.Reporting > 0
 }
 
 // fleetStatsLKG returns a copy of the persisted last-known-good aggregate, or
@@ -1875,12 +1886,21 @@ func (s *HubServer) handleFleetStats(w http.ResponseWriter, r *http.Request) {
 	// no log line, a fleet-wide collector failure looks identical to a quiet
 	// day. This is the operator-visible signal that the data, not the fleet,
 	// is what shrank.
-	if !fs.Trustworthy {
-		s.logger.Warn("fleet stats degraded: too few hives reporting to publish a fleet total",
+	// The total is always published now, so this is no longer a publish gate —
+	// it is the operator signal that the DATA shrank, not the fleet. Keep it
+	// loud: a silent hide is how the blank strip regressed unnoticed before,
+	// where a fleet-wide collector failure looked identical to a quiet day.
+	if fs.Eligible > 0 && fs.Reporting*2 < fs.Eligible {
+		s.logger.Warn("fleet stats: fewer than half the eligible hives are reporting; the published total is partial",
 			"reporting", fs.Reporting,
 			"eligible", fs.Eligible,
 			"stale", fs.Stale,
-			"min_fraction", fleetStatsMinReportingFraction,
+		)
+	}
+	if fs.Reporting == 0 && fs.Eligible > 0 {
+		s.logger.Warn("fleet stats: NO hive reported a fresh count; the strip will show nothing",
+			"eligible", fs.Eligible,
+			"stale", fs.Stale,
 		)
 	}
 

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -1352,8 +1352,20 @@
         // upgrade skew never blanks a strip that is actually fine.
         var trustworthy = !data || typeof data.trustworthy !== 'boolean' ? true : data.trustworthy;
         var stale = !!(data && data.stale_data);
-        // Show the numbers when the live aggregate is trustworthy OR when the
-        // hub handed us a labelled last-known-good one.
+        // Show a real number whenever we have one.
+        //
+        // These totals are a SUM OF FACTS, not a sample: every hive counts its
+        // own merged PRs and the hub adds them up (repos are deduplicated via a
+        // set). A total from 7 of 18 hives is not a guess at a fleet figure, it
+        // is exactly what those 7 did — correct, merely incomplete. So the
+        // honest presentation is the number plus its coverage, which the
+        // caption below always states.
+        //
+        // Hiding it was strictly worse: a blank strip reads as "this fleet did
+        // nothing", the one reading that is actually false. It stayed blank for
+        // months because the old gate needed >=50% coverage AND its
+        // last-known-good fallback was only ever written while ABOVE that bar,
+        // so on a fleet that never cleared it the fallback was never filled.
         var showValues = trustworthy || stale;
         var anyLive = false;
         (LIVE_STATS || []).forEach(function(s) {
@@ -1380,6 +1392,23 @@
               ' while the fleet recollects &mdash; ' + fmt((data && data.reporting) || 0) + ' of ' +
               fmt((data && data.eligible) || 0) + ' hives reporting right now. ' +
               '<a href="/learn" target="_blank" rel="noopener">Learn how earned autonomy works</a>.';
+          }
+        }
+        // Values shown and LIVE: state the coverage alongside them. This is the
+        // half that makes an ungated total honest — the number is exactly what
+        // the reporting hives did, and saying how many reported is what stops a
+        // partial total being read as a complete one. Without this line,
+        // removing the coverage gate would trade a misleading blank for a
+        // misleadingly confident number.
+        if (anyLive && !stale) {
+          var noteLive = document.getElementById('hero-proof-note');
+          var rep = (data && data.reporting) || 0;
+          var elig = (data && data.eligible) || 0;
+          if (noteLive && elig > 0) {
+            noteLive.innerHTML = 'The <strong>90% coverage gate</strong> is enforced on Hive\'s own build. Fleet totals above are the sum from <strong>' +
+              fmt(rep) + ' of ' + fmt(elig) + ' hives</strong> reporting' +
+              (rep < elig ? ' &mdash; the rest are still collecting' : '') +
+              '. <a href="/learn" target="_blank" rel="noopener">Learn how earned autonomy works</a>.';
           }
         }
         var note = document.getElementById('hero-proof-note');


### PR DESCRIPTION
## The strip has been blank while the data was fine

`/api/fleet-stats` returns **12,819 merged PRs across 42 repos**. The page shows nothing. Two faults:

1. **The publish gate needed ≥50% coverage.** Live coverage was 2/18, 7/18, 10/50 on the day this was diagnosed.
2. **The last-known-good fallback could never initialise.** It was *recorded* only while above the bar and *served* only while below it — so on a fleet that never cleared 50%, it was never written and had nothing to serve. **The safety net could only be filled by the condition it existed to protect against.**

Frontend: `showValues = trustworthy || stale` → both false → every box hidden.

## The gate was wrong in principle

It treats the aggregate as an **estimate** — a sample you extrapolate from, where too few samples give a confidently wrong answer.

It isn't one. Each hive counts its **own** merged PRs and the hub sums them with `+=`; `ReposManaged` is `len(repoSet)`, so shared repos are already deduplicated. Seven hives reporting 12,819 PRs is not a guess at a fleet figure — it is exactly what those seven did. The number is correct; only its **completeness** is partial.

Hiding it was strictly worse than labelling it: a blank strip reads as *"this fleet did nothing"*, the one interpretation that is actually false.

## Changes

- `FleetStatsTrustworthy` → `Reporting > 0`. Zero reporting is the only state that shows no total.
- The page **always states coverage** beside the number — *"the sum from 7 of 18 hives reporting"*. This is the half that makes an ungated total honest; without it, removing the gate would trade a misleading blank for a misleadingly confident number.
- **Live data wins over the cache** — a partial count is current, the LKG is older.
- The operator warning is kept but is no longer a publish gate: it fires on low coverage, and separately on zero reporting.

## Two tests were pinning the old behaviour

One called `"2 of 50"` *"the reported regression"* and required `false` — encoding suppression as the fix. The other required a 1-of-4 live total to be **replaced** by the cache and labelled stale, substituting older numbers for current ones.

| Mutation | Result |
|---|---|
| Restore the 50% gate | 5 failures ✓ |
| Publish with zero reporting | 3 failures ✓ |

`pkg/hub` green.