### PR TITLE
♻️ refactor(spoke): boot K8s hives from the runtime config, not the seed

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -58,8 +58,38 @@ if [ -n "${KUBERNETES_SERVICE_HOST:-}" ] || [ -f /var/run/secrets/kubernetes.io/
 fi
 
 if [ "$IS_KUBERNETES" = "true" ]; then
-  # ── Kubernetes mode: ConfigMap seed + dashboard overlay ────────────
-  if [ -f "$HIVE_CONFIG_PATH" ] && [ -s "$HIVE_CONFIG_PATH" ]; then
+  # ── Kubernetes mode: the PVC runtime config is the boot input ──────
+  #
+  # PHASE 2 OF THE LAYER COLLAPSE. The ConfigMap is now a SEED — consulted
+  # on first boot, when the PVC has no runtime config yet — and not a
+  # per-boot input that has to be merged over.
+  #
+  # Why this is the right way round: the ConfigMap is frozen at provision
+  # time and cannot be written by anything at runtime (the hub has only
+  # `get` on ConfigMaps, spoke RBAC omits them entirely, and the hub has no
+  # kubectl path to vllm-d at all). The runtime config on the PVC is the
+  # only layer any component can actually write. Treating the writable
+  # layer as the input — instead of merging it over a frozen one on every
+  # boot — is what removes the "which layer wins" question that cost about
+  # an hour during the 2026-07-31 GHE incident, when three read-only layers
+  # were patched before the writable one was found.
+  #
+  # Measured before the change: on 50 readable spokes all three layers held
+  # identical values for every identity field. The merge was recomputing a
+  # result equal to its own input on every boot.
+  HIVE_CONFIG_BOOT="$(hive_runtime_config_read)"
+  if [ -n "$HIVE_CONFIG_BOOT" ]; then
+    # Steady state: boot from what this hive last had. The ConfigMap seed is
+    # deliberately NOT merged — it is frozen at provision and every field it
+    # could contribute is either already here or re-asserted by the hub on
+    # the next heartbeat (~30s), including hub.is_public.
+    if cp "$HIVE_CONFIG_BOOT" "$HIVE_CONFIG_PATH" 2>/dev/null; then
+      echo "[entrypoint] K8s mode — booting from runtime config $HIVE_CONFIG_BOOT (ConfigMap is a seed, not merged)"
+    else
+      export HIVE_CONFIG="$HIVE_CONFIG_BOOT"
+      echo "[entrypoint] K8s mode — config path read-only, using $HIVE_CONFIG_BOOT directly"
+    fi
+  elif [ -f "$HIVE_CONFIG_PATH" ] && [ -s "$HIVE_CONFIG_PATH" ]; then
     # The copy-config init container re-seeded $HIVE_CONFIG_PATH from the
     # ConfigMap on this boot. Config saved via the dashboard (Config.Save
     # writes /etc/hive/hive.yaml, an emptyDir) would be silently lost —
@@ -182,22 +212,11 @@ PYEOF
     cp "$HIVE_CONFIG_PATH" "$HIVE_CONFIG_RUNTIME" 2>/dev/null || true
     echo "[entrypoint] K8s mode — ConfigMap is the seed, runtime config written to $HIVE_CONFIG_RUNTIME"
   else
-    # ConfigMap is missing or empty. Fall back to the persisted runtime
-    # config, preferring the new name and accepting the legacy one so a
-    # hive that has not yet written the new file still recovers.
-    HIVE_CONFIG_RECOVER="$(hive_runtime_config_read)"
-    if [ -n "$HIVE_CONFIG_RECOVER" ]; then
-      if cp "$HIVE_CONFIG_RECOVER" "$HIVE_CONFIG_PATH" 2>/dev/null; then
-        echo "[entrypoint] K8s mode — ConfigMap missing/empty, RECOVERED from $HIVE_CONFIG_RECOVER"
-      else
-        export HIVE_CONFIG="$HIVE_CONFIG_RECOVER"
-        echo "[entrypoint] K8s mode — ConfigMap missing/empty and read-only, using $HIVE_CONFIG_RECOVER directly"
-      fi
-    else
-      echo "[entrypoint] ERROR: No ConfigMap at $HIVE_CONFIG_PATH and no PVC runtime config at $HIVE_CONFIG_RUNTIME (or legacy $HIVE_CONFIG_RUNTIME_LEGACY)."
-      echo "[entrypoint] Ensure the hive ConfigMap is created before deploying."
-      exit 1
-    fi
+    # Neither source exists: no runtime config on the PVC (checked first,
+    # above) and no ConfigMap seed. There is nothing to boot from.
+    echo "[entrypoint] ERROR: no runtime config at $HIVE_CONFIG_RUNTIME (or legacy $HIVE_CONFIG_RUNTIME_LEGACY) and no ConfigMap seed at $HIVE_CONFIG_PATH."
+    echo "[entrypoint] Ensure the hive ConfigMap is created before deploying."
+    exit 1
   fi
 else
   # ── Docker mode: the PVC runtime config is the source of truth ─────

--- a/v2/pkg/config/entrypoint_boot_test.go
+++ b/v2/pkg/config/entrypoint_boot_test.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// entrypointPath is the script under test, relative to this package.
+const entrypointPath = "../../deploy/entrypoint.sh"
+
+// runBootPrelude executes ONLY the config-resolution prelude of entrypoint.sh
+// against a temp filesystem, and returns what it logged.
+//
+// It extracts the script up to the end of the K8s/Docker config branch rather
+// than running the whole thing (which would try to create users, iptables rules
+// and tmux sessions). That keeps the test honest about WHICH code it covers: it
+// executes the real branching logic, not a paraphrase of it.
+func runBootPrelude(t *testing.T, env map[string]string, files map[string]string) string {
+	t.Helper()
+	src, err := os.ReadFile(entrypointPath)
+	if err != nil {
+		t.Skipf("entrypoint.sh not readable from this package: %v", err)
+	}
+	text := string(src)
+	// Cut at the cleanup marker that follows the config branch.
+	end := strings.Index(text, "# ── Cleanup stale stderr logs")
+	if end < 0 {
+		t.Fatal("could not find the end of the config branch in entrypoint.sh; the marker moved and this test would silently cover nothing")
+	}
+	root := t.TempDir()
+	for rel, content := range files {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Rewrite the absolute paths onto the temp root.
+	body := text[:end]
+	body = strings.ReplaceAll(body, `"/data/`, `"`+root+`/data/`)
+	body = strings.ReplaceAll(body, `/etc/hive/hive.yaml`, root+"/etc/hive/hive.yaml")
+
+	cmd := exec.Command("bash", "-c", body)
+	cmd.Env = append(os.Environ(), "HIVE_CONFIG="+root+"/etc/hive/hive.yaml")
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	out, _ := cmd.CombinedOutput()
+	return string(out)
+}
+
+// TestK8sBootsFromRuntimeConfigNotTheSeed pins the phase-2 precedence: the PVC
+// runtime config is the boot INPUT and the ConfigMap is only a first-boot seed.
+//
+// Booting from the seed and merging the overlay over it on every start is what
+// made "which layer wins" a live question — three read-only layers were patched
+// during the 2026-07-31 incident before the writable one was found.
+func TestK8sBootsFromRuntimeConfigNotTheSeed(t *testing.T) {
+	out := runBootPrelude(t,
+		map[string]string{"KUBERNETES_SERVICE_HOST": "10.0.0.1"},
+		map[string]string{
+			"data/hive.yaml.runtime": "acmm_level: 5\n",
+			"etc/hive/hive.yaml":     "acmm_level: 3\n", // stale seed
+		})
+	if !strings.Contains(out, "booting from runtime config") {
+		t.Fatalf("did not boot from the runtime config:\n%s", out)
+	}
+	if strings.Contains(out, "overlay merged over ConfigMap seed") {
+		t.Fatalf("the per-boot merge still ran; the ConfigMap must be a seed only:\n%s", out)
+	}
+}
+
+// TestK8sLegacyBakStillBoots: ~48 of 51 live spokes still carry only the old
+// hive.yaml.bak name. They must keep booting while the rename rolls out.
+func TestK8sLegacyBakStillBoots(t *testing.T) {
+	out := runBootPrelude(t,
+		map[string]string{"KUBERNETES_SERVICE_HOST": "10.0.0.1"},
+		map[string]string{
+			"data/hive.yaml.bak": "acmm_level: 5\n",
+			"etc/hive/hive.yaml": "acmm_level: 3\n",
+		})
+	if !strings.Contains(out, "hive.yaml.bak") {
+		t.Fatalf("a spoke with only the legacy name did not boot from it:\n%s", out)
+	}
+}
+
+// TestK8sFirstBootUsesTheSeed: with no PVC config at all, the ConfigMap seed is
+// the only source and must still work.
+func TestK8sFirstBootUsesTheSeed(t *testing.T) {
+	out := runBootPrelude(t,
+		map[string]string{"KUBERNETES_SERVICE_HOST": "10.0.0.1"},
+		map[string]string{"etc/hive/hive.yaml": "acmm_level: 3\n"})
+	if !strings.Contains(out, "ConfigMap is the seed") {
+		t.Fatalf("first boot did not fall back to the seed:\n%s", out)
+	}
+}
+
+// TestK8sNoConfigAtAllFailsLoudly: silence here would start a hive with no
+// project and no agents, which reads as a broken hive rather than a broken
+// deploy.
+func TestK8sNoConfigAtAllFailsLoudly(t *testing.T) {
+	out := runBootPrelude(t,
+		map[string]string{"KUBERNETES_SERVICE_HOST": "10.0.0.1"},
+		map[string]string{})
+	if !strings.Contains(out, "ERROR: no runtime config") {
+		t.Fatalf("missing config did not fail loudly:\n%s", out)
+	}
+}


### PR DESCRIPTION
Phase 2 of the config-layer collapse. Phase 1 was the `hive.yaml.runtime` rename (#2380).

## The inversion

K8s booted from the **ConfigMap seed** and merged the PVC overlay over it on *every* start — ~140 lines of Python with per-field precedence.

That's backwards. The ConfigMap is frozen at provision and **cannot be written by anything at runtime**: the hub holds only `get` on ConfigMaps, spoke RBAC omits them entirely, and the hub has no kubectl path to `vllm-d` at all. The PVC runtime config is the only layer any component can actually write.

Treating the writable layer as the boot input removes the "which layer wins" question outright — the question that cost ~an hour during the 2026-07-31 GHE incident, when three *read-only* layers were patched (hub `meta.json`, `clusters.json`, the ConfigMap) before the writable one was found.

**Measured before changing anything:** across 50 readable spokes, all three layers held identical values for every identity field; the three files on a sampled spoke are byte-identical at 464 lines. The merge was recomputing a result equal to its own input on every boot.

## Behaviour

| | |
|---|---|
| steady state | boot from `/data/hive.yaml.runtime` (or legacy `hive.yaml.bak`, still on most of the fleet) |
| first boot | no PVC config yet → ConfigMap seed, merge still runs (a reprovision onto an existing PVC can legitimately have an overlay) |
| neither | fail loudly, as before |

The seed isn't merged in steady state: every field it could contribute is either already in the runtime config or re-asserted by the hub within one ~30s heartbeat, including `hub.is_public`.

## The test is the point

`pkg/config/entrypoint_boot_test.go` is the **first test to execute `entrypoint.sh`**. It extracts the config-resolution prelude and runs it under bash against a temp filesystem — exercising the real branching, not a paraphrase — and fails loudly if the marker it cuts on ever moves, rather than silently covering nothing.

#2380 verified its rename by grep-counting the script. That's exactly the kind of check that passes while testing nothing.

| Mutation | Result |
|---|---|
| Revert to seed-first | 2 failures ✓ |
| Drop legacy `.bak` support | 1 failure ✓ |
| Silence the no-config error | 1 failure ✓ |

`pkg/config` green.