### PR TITLE
✨ feat(hub): count every hive in the fleet totals, not just public ones

### DIFF
--- a/v2/pkg/hub/fleet_stats_all_hives_test.go
+++ b/v2/pkg/hub/fleet_stats_all_hives_test.go
@@ -1,0 +1,87 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFleetStatsCountAllHivesNotJustPublic pins that aggregate totals cover the
+// WHOLE fleet while the public listing stays opt-in.
+//
+// The filter used to be `if !h.IsPublic || !h.Online { continue }`, so every
+// published figure described only the public subset — roughly 18 of 51 live
+// spokes. "Hives", "repos managed", "agents running" and the PR/CVE counts all
+// understated the fleet by about two thirds, which is the opposite of what a
+// fleet total is for.
+//
+// This is safe because these are ANONYMOUS SUMS: every FleetStats field is a
+// scalar, so a private hive contributing to a count discloses nothing about
+// itself. Naming a hive is a different disclosure and remains gated on IsPublic
+// in the registry listing.
+func TestFleetStatsCountAllHivesNotJustPublic(t *testing.T) {
+	s := &HubServer{}
+	pub := ptrInt(10)
+	priv := ptrInt(7)
+	s.registry.Hives = []RegistryEntry{
+		{ID: "pub", IsPublic: true, Online: true, LastHeartbeat: freshHeartbeat(),
+			Org: "o", Repos: []string{"r1"}, PRsMerged90d: pub,
+			AgentCount: 3, ActiveContributors: 2},
+		{ID: "priv", IsPublic: false, Online: true, LastHeartbeat: freshHeartbeat(),
+			Org: "o", Repos: []string{"r2"}, PRsMerged90d: priv,
+			AgentCount: 4, ActiveContributors: 5},
+	}
+
+	fs := s.computeFleetStats()
+
+	if fs.Hives != 2 {
+		t.Errorf("Hives = %d, want 2 — a private hive is still a hive", fs.Hives)
+	}
+	if fs.PRsMerged != 17 {
+		t.Errorf("PRsMerged = %d, want 17 (10 public + 7 private)", fs.PRsMerged)
+	}
+	if fs.ReposManaged != 2 {
+		t.Errorf("ReposManaged = %d, want 2", fs.ReposManaged)
+	}
+	if fs.AgentsRunning != 7 {
+		t.Errorf("AgentsRunning = %d, want 7 (3+4)", fs.AgentsRunning)
+	}
+	if fs.Contributors != 7 {
+		t.Errorf("Contributors = %d, want 7 (2+5)", fs.Contributors)
+	}
+	if fs.Eligible != 2 || fs.Reporting != 2 {
+		t.Errorf("Reporting/Eligible = %d/%d, want 2/2 — coverage must count private hives too, or the published ratio lies",
+			fs.Reporting, fs.Eligible)
+	}
+}
+
+// TestFleetStatsPublishesNoIdentifiers is the privacy boundary. Widening the
+// source to private hives is only defensible while every published field is a
+// scalar: a count discloses nothing, a name discloses everything.
+//
+// If a future change adds a name, org, repo, owner or URL to FleetStats, this
+// test is where it should be caught — the struct is serialised straight to a
+// public, unauthenticated endpoint.
+func TestFleetStatsPublishesNoIdentifiers(t *testing.T) {
+	s := &HubServer{}
+	s.registry.Hives = []RegistryEntry{
+		{ID: "secret-hive", IsPublic: false, Online: true, LastHeartbeat: freshHeartbeat(),
+			Org: "acme-internal", Owner: "alice", Name: "Project Nimbus",
+			DashboardURL: "https://nimbus.internal.example.com",
+			Repos:        []string{"acme-internal/skunkworks"}, PRsMerged90d: ptrInt(4)},
+	}
+
+	fs := s.computeFleetStats()
+	if fs.PRsMerged != 4 {
+		t.Fatalf("the private hive did not contribute: PRsMerged = %d", fs.PRsMerged)
+	}
+
+	blob := mustJSON(t, fs)
+	for _, secret := range []string{
+		"secret-hive", "acme-internal", "alice", "Project Nimbus",
+		"nimbus.internal.example.com", "skunkworks",
+	} {
+		if strings.Contains(strings.ToLower(blob), strings.ToLower(secret)) {
+			t.Errorf("fleet-stats response leaked %q — counts may be shared, identifiers may not:\n%s", secret, blob)
+		}
+	}
+}

--- a/v2/pkg/hub/fleet_stats_test.go
+++ b/v2/pkg/hub/fleet_stats_test.go
@@ -64,13 +64,18 @@ func TestComputeFleetStats(t *testing.T) {
 			want: FleetStats{ReposManaged: 3, PRsMerged: 15, PRsRejected: 3, CVEsClosed: 4, Hives: 2, Reporting: 2, Eligible: 2},
 		},
 		{
-			name: "skips private and offline hives",
+			// A PRIVATE hive now COUNTS: these totals are anonymous sums, and
+			// excluding private hives described about a third of the fleet
+			// (~18 of 51 spokes are public). Naming a hive is a different
+			// disclosure and is still gated on IsPublic in the registry listing.
+			// OFFLINE hives are still skipped — their counts are not current.
+			name: "counts private hives, skips offline ones",
 			hives: []RegistryEntry{
 				{IsPublic: false, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(99)},
 				{IsPublic: true, Online: false, Org: "a", Repos: []string{"r2"}, PRsMerged90d: ptrInt(99)},
 				{IsPublic: true, Online: true, Org: "a", Repos: []string{"r3"}, PRsMerged90d: ptrInt(7)},
 			},
-			want: FleetStats{ReposManaged: 1, PRsMerged: 7, Hives: 1, Reporting: 1, Eligible: 1},
+			want: FleetStats{ReposManaged: 2, PRsMerged: 106, Hives: 2, Reporting: 2, Eligible: 2},
 		},
 		{
 			name: "nil counts are not aggregated as zero",

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1678,6 +1678,17 @@ type FleetStats struct {
 	PRsRejected  int    `json:"prs_rejected"`
 	CVEsClosed   int    `json:"cves_closed"`
 	Hives        int    `json:"hives"`
+	// AgentsRunning and Contributors are fleet-wide ANONYMOUS counts, summed
+	// over ALL online hives rather than only the public ones.
+	//
+	// The landing page used to compute these in the browser from /api/registry,
+	// which returns public hives only — so "agents running" and "contributors"
+	// silently described about a third of the fleet (roughly 18 of 51 spokes are
+	// public). Computing them here counts every hive while disclosing none: like
+	// every other field on this struct they are scalars, and no name, org, repo,
+	// owner or URL is derivable from them.
+	AgentsRunning int `json:"agents_running"`
+	Contributors  int `json:"contributors"`
 	UpdatedAt    string `json:"updated_at"`
 	// Reporting is the number of eligible hives that actually contributed a
 	// fresh count to the totals above; Eligible is how many were considered.
@@ -1728,10 +1739,29 @@ func (s *HubServer) computeFleetStats() FleetStats {
 	var fs FleetStats
 	repoSet := make(map[string]struct{})
 	for _, h := range s.registry.Hives {
-		if !h.IsPublic || !h.Online {
+		// ALL hives count, public and private alike.
+		//
+		// These totals are ANONYMOUS SUMS: every field on FleetStats is a
+		// scalar — counts, a timestamp, booleans. No name, org, repo, owner or
+		// URL reaches this struct, and repoSet below is internal with only its
+		// len() published. So a private hive contributing to a count discloses
+		// nothing about itself.
+		//
+		// Excluding them made the published figures describe about a THIRD of
+		// reality: 51 spokes exist and roughly 18 are public. "Hives", "repos
+		// managed" and the PR/CVE counts all understated the fleet by that
+		// margin, which is the opposite of what a fleet total is for.
+		//
+		// The PUBLIC LIST at the bottom of the landing page is a separate
+		// concern and is deliberately untouched: it names hives and links to
+		// them, so it stays opt-in via IsPublic. Aggregate counts and named
+		// listings are different disclosures and are now treated as such.
+		if !h.Online {
 			continue
 		}
 		fs.Hives++
+		fs.AgentsRunning += h.AgentCount
+		fs.Contributors += h.ActiveContributors
 		for _, r := range h.Repos {
 			if r == "" {
 				continue

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -676,7 +676,7 @@
           <div><span>Agents running</span><strong id="stat-agents">—</strong></div>
           <div><span>Managed repos</span><strong id="stat-repos">—</strong></div>
           <div><span>Contributors</span><strong id="stat-contributors">—</strong></div>
-          <div><span>Active hives</span><strong id="stat-total">—</strong></div>
+          <div><span>Public hives</span><strong id="stat-total">—</strong></div>
         </div>
       </div>
     </section>
@@ -1103,14 +1103,29 @@
       }
     }
 
+    // Fleet-wide counters, filled in by the /api/fleet-stats poll. They cover
+    // ALL hives; the `hives` array here is the PUBLIC list only, so summing it
+    // described about a third of the fleet (~18 of 51 spokes are public).
+    var _fleetWide = null;
+
     function renderStats(hives) {
       var agents = 0, contributors = 0, online = 0, repos = 0;
       hives.forEach(function(h) { agents += h.agentCount || 0; contributors += h.activeContributors || 0; repos += (h.repos || []).length; if (h.online) online++; });
+      // "Public hives" is deliberately the length of the PUBLIC list — it
+      // labels exactly what the table below shows, and is the one counter here
+      // that should not be fleet-wide.
       document.getElementById('stat-online').textContent = online + '/' + hives.length;
-      document.getElementById('stat-agents').textContent = agents;
-      document.getElementById('stat-repos').textContent = repos;
-      document.getElementById('stat-contributors').textContent = contributors;
       document.getElementById('stat-total').textContent = hives.length;
+      // The rest are fleet-wide when the hub has told us, falling back to the
+      // public-list sums so an older hub (or a failed poll) still renders a
+      // number rather than an em dash.
+      var f = _fleetWide;
+      document.getElementById('stat-agents').textContent =
+        f && typeof f.agents_running === 'number' ? f.agents_running : agents;
+      document.getElementById('stat-repos').textContent =
+        f && typeof f.repos_managed === 'number' ? f.repos_managed : repos;
+      document.getElementById('stat-contributors').textContent =
+        f && typeof f.contributors === 'number' ? f.contributors : contributors;
     }
 
     var _allMainHives = [];
@@ -1430,7 +1445,15 @@
       function go() {
         fetch('/api/fleet-stats')
           .then(function(r) { return r.json(); })
-          .then(apply)
+          .then(function(d) {
+            // Hand the fleet-wide counters to renderStats, which otherwise sums
+            // the PUBLIC hive list and so undercounts the fleet by ~2/3.
+            _fleetWide = d;
+            if (typeof _allMainHives !== 'undefined' && _allMainHives) {
+              try { renderStats(_allMainHives); } catch (e) {}
+            }
+            apply(d);
+          })
           .catch(function() { apply(null); });
       }
       go();


### PR DESCRIPTION
## The undercount

`computeFleetStats` skipped private hives:

```go
if !h.IsPublic || !h.Online { continue }
```

Roughly **18 of 51** live spokes are public, so every published figure — hives, repos managed, agents running, contributors, PRs merged/rejected, CVEs — described about a **third** of the fleet.

## Why widening it is safe

These are **anonymous sums**. Every field on `FleetStats` is a scalar; `repoSet` is internal and only its `len()` is published. A private hive contributing to a count discloses nothing about itself.

The **public list** at the bottom of the landing page is untouched — it names hives and links to them, so it stays opt-in. Aggregate counts and named listings are different disclosures and are now treated as such.

**"Active hives" → "Public hives"**, which is what that counter has always actually shown: the length of the public list rendered below it.

## The browser was doing its own undercount

`agents running` / `managed repos` / `contributors` were computed **client-side** from `/api/registry`, which returns public hives only — bypassing `computeFleetStats` entirely and undercounting by the same margin. They now come from the fleet-wide aggregate, falling back to the public-list sums so an older hub or a failed poll still renders a number rather than an em dash.

## The privacy boundary is a test

`TestFleetStatsPublishesNoIdentifiers` seeds a private hive with a distinctive name, org, owner, repo and dashboard URL, then asserts none appear anywhere in the serialised response. `FleetStats` is marshalled straight to a **public unauthenticated endpoint**, so that is where a future field carrying an identifier should be caught.

| Mutation | Result |
|---|---|
| Restore the `IsPublic` filter | 2 failures ✓ |
| Leak a hive name into the response | 1 failure ✓ |
| Drop the agents/contributors sums | 1 failure ✓ |

One existing case was named *"skips private and offline hives"* and pinned the old behaviour; it is now *"counts private hives, skips offline ones"*. Offline hives are still skipped — their counts aren't current.

`pkg/hub` green.