### PR TITLE
contributor: goose context files, config no-clobber, entrypoint hook, envelope labels (#2393)

### DIFF
--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -38,6 +38,25 @@ export HIVE_CONTRIBUTOR_CLI="$AGENT_BACKEND"
 # Username is extracted from contributor.env (set during registration)
 export HIVE_CONTRIBUTOR_USERNAME="${CONTRIBUTOR_USERNAME:-unknown}"
 
+# Extension seam for downstream images (kubestellar/hive#2393 item 4). A derived
+# image (e.g. projectbluefin/donate-clanker) can drop *.sh into
+# /etc/hive/entrypoint.d/ and/or set HIVE_PRE_AGENT_HOOK to run setup here —
+# after the full contributor env is exported, before backend detection and the
+# tmux launch — WITHOUT forking this entrypoint and re-implementing the tmux
+# wait/attach logic. Sourced (not exec'd) so hooks can export env the agent sees.
+if [[ -d /etc/hive/entrypoint.d ]]; then
+  for _hook in /etc/hive/entrypoint.d/*.sh; do
+    [[ -r "$_hook" ]] || continue
+    echo "Running entrypoint hook: $_hook"
+    # shellcheck source=/dev/null
+    source "$_hook"
+  done
+fi
+if [[ -n "${HIVE_PRE_AGENT_HOOK:-}" ]]; then
+  echo "Running HIVE_PRE_AGENT_HOOK"
+  eval "$HIVE_PRE_AGENT_HOOK"
+fi
+
 # Source backends.conf for binary detection
 BACKENDS_CONF="${SCRIPT_DIR}/../config/backends.conf"
 if [[ -f "$BACKENDS_CONF" ]]; then
@@ -223,14 +242,28 @@ case "$AGENT_BACKEND" in
     ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
     ;;
   goose)
+    # Goose reads AGENTS.md and .goosehints; .goose-instructions.md / CLAUDE.md
+    # are NOT names it looks for (unless CONTEXT_FILE_NAMES is overridden), so
+    # without these two the knowledge export downloaded above never reached the
+    # model. Keep the old names for backward-compat, but add the ones Goose
+    # actually reads. (kubestellar/hive#2393 item 1.)
+    ln -sf "$AGENT_MD" "${HOME}/AGENTS.md"
+    ln -sf "$AGENT_MD" "${HOME}/.goosehints"
     ln -sf "$AGENT_MD" "${HOME}/.goose-instructions.md"
     ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
     mkdir -p "${HOME}/.config/goose"
-    cat > "${HOME}/.config/goose/config.yaml" <<GOOSECFG
+    # Write the config only if the contributor/derived image hasn't provided one,
+    # so a downstream can add Goose extensions (MCP servers) or other settings
+    # without it being clobbered on every start. (kubestellar/hive#2393 item 3.)
+    if [ ! -f "${HOME}/.config/goose/config.yaml" ]; then
+      cat > "${HOME}/.config/goose/config.yaml" <<GOOSECFG
 GOOSE_PROVIDER: ${GOOSE_PROVIDER:-ollama}
 GOOSE_MODEL: ${GOOSE_MODEL:-phi4}
 GOOSECFG
-    echo "Goose config: provider=${GOOSE_PROVIDER:-ollama} model=${GOOSE_MODEL:-phi4}"
+      echo "Goose config: provider=${GOOSE_PROVIDER:-ollama} model=${GOOSE_MODEL:-phi4}"
+    else
+      echo "Goose config: keeping existing ${HOME}/.config/goose/config.yaml"
+    fi
     ;;
   codex)
     ln -sf "$AGENT_MD" "${HOME}/AGENTS.md"

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -62,34 +62,39 @@ type ContributorConnection struct {
 }
 
 type WSMessage struct {
-	Type              string          `json:"type"`
-	Seq               int             `json:"seq,omitempty"`
-	Nonce             string          `json:"nonce,omitempty"`
-	ContributorID     string          `json:"contributor_id,omitempty"`
-	TrustTier         string          `json:"trust_tier,omitempty"`
-	Permissions       []string        `json:"permissions,omitempty"`
-	Reason            string          `json:"reason,omitempty"`
-	RegistrationToken string          `json:"registration_token,omitempty"`
-	CLIBackend        string          `json:"cli_backend,omitempty"`
-	Model             string          `json:"model,omitempty"`
-	TaskID            string          `json:"task_id,omitempty"`
-	Kind              string          `json:"kind,omitempty"`
-	Repo              string          `json:"repo,omitempty"`
-	Number            int             `json:"number,omitempty"`
-	Title             string          `json:"title,omitempty"`
-	URL               string          `json:"url,omitempty"`
-	Labels            []string        `json:"labels,omitempty"`
-	Prompt            string          `json:"prompt,omitempty"`
-	GitHubToken       string          `json:"github_token,omitempty"`
-	TokenExpiresAt    string          `json:"token_expires_at,omitempty"`
-	Restrictions      json.RawMessage `json:"restrictions,omitempty"`
-	Role              string          `json:"role,omitempty"`
-	ContribLabels     []string        `json:"contributor_labels,omitempty"`
-	Status            string          `json:"status,omitempty"`
-	Result            string          `json:"result,omitempty"`
-	Summary           string          `json:"summary,omitempty"`
-	TmuxOutput        []string        `json:"tmux_output,omitempty"`
-	AcceptedModels    []string        `json:"accepted_models,omitempty"`
+	Type              string   `json:"type"`
+	Seq               int      `json:"seq,omitempty"`
+	Nonce             string   `json:"nonce,omitempty"`
+	ContributorID     string   `json:"contributor_id,omitempty"`
+	TrustTier         string   `json:"trust_tier,omitempty"`
+	Permissions       []string `json:"permissions,omitempty"`
+	Reason            string   `json:"reason,omitempty"`
+	RegistrationToken string   `json:"registration_token,omitempty"`
+	CLIBackend        string   `json:"cli_backend,omitempty"`
+	Model             string   `json:"model,omitempty"`
+	TaskID            string   `json:"task_id,omitempty"`
+	Kind              string   `json:"kind,omitempty"`
+	Repo              string   `json:"repo,omitempty"`
+	Number            int      `json:"number,omitempty"`
+	Title             string   `json:"title,omitempty"`
+	URL               string   `json:"url,omitempty"`
+	Labels            []string `json:"labels,omitempty"`
+	Prompt            string   `json:"prompt,omitempty"`
+	GitHubToken       string   `json:"github_token,omitempty"`
+	TokenExpiresAt    string   `json:"token_expires_at,omitempty"`
+	// Restrictions is RESERVED and intentionally not populated by the server yet:
+	// the contributor command restrictions are enforced server-side (gh-wrapper /
+	// contributor-default.json), so shipping the policy to the client would be
+	// advisory-only and risk drift. Left as omitempty so it never appears on the
+	// wire until a concrete client contract exists. (kubestellar/hive#2393 item 8.)
+	Restrictions   json.RawMessage `json:"restrictions,omitempty"`
+	Role           string          `json:"role,omitempty"`
+	ContribLabels  []string        `json:"contributor_labels,omitempty"`
+	Status         string          `json:"status,omitempty"`
+	Result         string          `json:"result,omitempty"`
+	Summary        string          `json:"summary,omitempty"`
+	TmuxOutput     []string        `json:"tmux_output,omitempty"`
+	AcceptedModels []string        `json:"accepted_models,omitempty"`
 	// Permanent marks a task_failed the relay will not retry: it exhausted its
 	// per-task CLI-restart budget and gave up (see MAX_TASK_CLI_RESTARTS in
 	// bin/contributor-relay.sh). Reassigning the same work item to the same
@@ -932,7 +937,11 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				GitHubToken:    ghToken,
 				TokenExpiresAt: time.Now().Add(55 * time.Minute).UTC().Format(time.RFC3339),
 				Prompt:         prompt,
-				ContribLabels:  []string{"contributor/" + c.profile.GitHubUsername},
+				// The issue's own labels — the Labels envelope field was declared but
+				// never populated, so a client reading it got nothing (kubestellar/
+				// hive#2393 item 8). They're already computed for filtering above.
+				Labels:        labels,
+				ContribLabels: []string{"contributor/" + c.profile.GitHubUsername},
 			}
 		}
 	}


### PR DESCRIPTION
## Contributor front-end quick-wins from the donate-clanker feedback

Four small, self-contained fixes from the excellent [projectbluefin / donate-clanker feedback in #2393](https://github.com/kubestellar/hive/issues/2393) — the mechanical items where the fix is unambiguous. Thanks to the projectbluefin folks for the detailed, cited report.

- **Goose never saw the knowledge export (#2393 item 1).** The `goose` backend symlinked `agent.md` into `.goose-instructions.md` / `CLAUDE.md`, which Goose does not read — so the org context downloaded and refreshed every 10 min never reached the model. Add `AGENTS.md` and `.goosehints` (the names Goose actually reads), keeping the old ones for backward-compat. The `codex`/`pi` branches already did this.
- **Goose `config.yaml` clobbered on every start (#2393 item 3).** It was written unconditionally, so a derived image / contributor couldn't add Goose extensions (MCP servers) or any setting. Now written only when absent.
- **No extension seam in the contributor entrypoint (#2393 item 4).** Source `/etc/hive/entrypoint.d/*.sh` and honour `HIVE_PRE_AGENT_HOOK`, after the contributor env is exported and before the tmux launch — so a downstream can hook setup without forking the entrypoint and re-implementing the tmux wait/attach logic.
- **`Labels`/`Restrictions` envelope fields declared but never set (#2393 item 8).** Populate `Labels` with the issue's labels (already computed for filtering); document `Restrictions` as reserved (restrictions are enforced server-side, so shipping the policy to the client would be advisory-only and risk drift).

Not included here (they need a design/policy decision, tracked separately): item 2 (wire-or-delete `token_refresh`), item 5 (image pinning — a maintainer stance), item 6 (read-only `gh` for contributors) and item 7 (`pr_url` in `task_complete`) — the latter two unblock the dupe-PR problem (#2356) and warrant agreeing the shape first.

### Testing
`go build ./...` clean; `gofmt` clean; `bash -n bin/contributor-agent.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
