### PR TITLE
✨ feat(hub): state a hive's identity explicitly instead of implying it

### DIFF
--- a/v2/pkg/config/provenance.go
+++ b/v2/pkg/config/provenance.go
@@ -302,6 +302,11 @@ func forgeOfAppID(appID int64) string {
 // Returns "" for an unrecognised App ID (a third forge, self-hosted, the
 // placeholder sentinel). Unknown must never be treated as a mismatch, or a
 // legitimate deployment is refused — the same contract as forgeOfAppID.
+// SlugOfAppID is the exported form, for callers outside this package that need
+// to fill a blank slug rather than ship an empty field for a resolver default
+// to guess at.
+func SlugOfAppID(appID int64) string { return slugOfAppID(appID) }
+
 func slugOfAppID(appID int64) string {
 	switch appID {
 	case PublicGitHubAppID:

--- a/v2/pkg/hub/explicit_identity_test.go
+++ b/v2/pkg/hub/explicit_identity_test.go
@@ -1,0 +1,83 @@
+package hub
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+const vllmDDual = `{
+  "id": "vllm-d",
+  "github_base_url": "https://github.ibm.com",
+  "github_api_url": "https://github.ibm.com/api/v3",
+  "github_app_id": 5686,
+  "github_app_slug": "kubestellar-hive-ghe",
+  "forges": { "github.com": { "app_id": 3568013 } }
+}`
+
+// TestResolvedPublicIdentityIsExplicit pins that a public election produces
+// STATED values, not empty fields a downstream resolver has to fill in.
+//
+// Empty used to be the convention: base_url was empty on 48 of 51 spokes,
+// api_url on 41, app_slug on 33 — implicit state was the fleet's normal
+// condition. That is exactly what hid the 2026-07-31 incident, where a GHE
+// app_id beside an empty api_url read as *unset* rather than *mismatched* and
+// nothing flagged it until a token call returned 404.
+func TestResolvedPublicIdentityIsExplicit(t *testing.T) {
+	var c ClusterConfig
+	if err := json.Unmarshal([]byte(vllmDDual), &c); err != nil {
+		t.Fatal(err)
+	}
+
+	got := ResolveHiveIdentity(&SaaSHive{ID: "pub", GitHubHost: "github.com"}, &c)
+
+	if got.APIURL != config.DefaultGitHubAPIURL {
+		t.Errorf("APIURL = %q, want the explicit %q", got.APIURL, config.DefaultGitHubAPIURL)
+	}
+	if got.BaseURL != config.DefaultGitHubBaseURL {
+		t.Errorf("BaseURL = %q, want the explicit %q", got.BaseURL, config.DefaultGitHubBaseURL)
+	}
+	// The cluster's forges entry names an app_id and NO slug. It must be filled
+	// from the App ID rather than shipped empty — an empty slug builds an
+	// install link against the public default, which is how ten GHE hives got a
+	// link pointing at an App that does not exist on their host.
+	if got.AppSlug != config.PublicGitHubAppSlug {
+		t.Errorf("AppSlug = %q, want it filled from app_id as %q", got.AppSlug, config.PublicGitHubAppSlug)
+	}
+	// Explicit must still be COHERENT — this is not just non-empty.
+	if err := config.RejectIdentitySet(config.GitHubConfig{
+		AppID: got.AppID, AppSlug: got.AppSlug, APIURL: got.APIURL, BaseURL: got.BaseURL,
+	}); err != nil {
+		t.Fatalf("explicit identity is not self-consistent: %v", err)
+	}
+}
+
+// TestUnknownAppKeepsAnEmptySlug: filling a blank slug must never become
+// INVENTING one. daviddiaz0317-visual-hive runs app_id 4240368 — a third App
+// with its own key — and a guessed slug there is a confident wrong answer where
+// no answer is correct.
+func TestUnknownAppKeepsAnEmptySlug(t *testing.T) {
+	if got := config.SlugOfAppID(4240368); got != "" {
+		t.Fatalf("SlugOfAppID(4240368) = %q, want \"\" — an unrecognised App must not be given a slug", got)
+	}
+}
+
+// TestHealthyImplicitSpokesStillValidate is the most important negative case.
+// 48 of 51 live spokes carry at least one empty identity field. Making the hub
+// SERVE explicit values must not make those spokes' own stored config invalid,
+// or the change breaks the healthy fleet on the way to fixing it.
+func TestHealthyImplicitSpokesStillValidate(t *testing.T) {
+	shapes := []config.GitHubConfig{
+		{AppID: config.PublicGitHubAppID},                                            // all three empty — the console hive
+		{AppID: config.PublicGitHubAppID, AppSlug: config.PublicGitHubAppSlug},       // slug only
+		{AppID: config.EnterpriseGitHubAppID, APIURL: config.EnterpriseGitHubAPIURL}, // GHE, api only
+		{AppID: config.EnterpriseGitHubAppID, AppSlug: config.EnterpriseGitHubAppSlug,
+			APIURL: config.EnterpriseGitHubAPIURL, BaseURL: config.EnterpriseGitHubBaseURL},
+	}
+	for i, gh := range shapes {
+		if err := config.RejectIdentitySet(gh); err != nil {
+			t.Errorf("shape %d (%+v) rejected: %v — implicit spokes must keep working while the fleet converges", i, gh, err)
+		}
+	}
+}

--- a/v2/pkg/hub/forge_election_live_test.go
+++ b/v2/pkg/hub/forge_election_live_test.go
@@ -71,9 +71,13 @@ func TestLiveVllmDEntryRepairsElectedHives(t *testing.T) {
 		if got.AppSlug != config.PublicGitHubAppSlug {
 			t.Fatalf("app_slug = %q, want %q", got.AppSlug, config.PublicGitHubAppSlug)
 		}
-		// Empty URLs are correct here: every healthy public spoke runs that way.
-		if got.APIURL != "" || got.BaseURL != "" {
-			t.Fatalf("public hive should carry empty URLs, got api=%q base=%q", got.APIURL, got.BaseURL)
+		// EXPLICIT urls are now correct here. They used to be empty, matching how
+		// every healthy public spoke is stored on disk — but a field that means
+		// something by being absent is what let a GHE app_id sit beside an empty
+		// api_url and read as *unset* rather than *mismatched*. The values are
+		// the same ones the resolver would have derived; they are now stated.
+		if got.APIURL != config.DefaultGitHubAPIURL || got.BaseURL != config.DefaultGitHubBaseURL {
+			t.Fatalf("public hive should carry explicit urls, got api=%q base=%q", got.APIURL, got.BaseURL)
 		}
 		mustPassValidator(t, got)
 	})

--- a/v2/pkg/hub/hive_identity.go
+++ b/v2/pkg/hub/hive_identity.go
@@ -4,6 +4,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
 // ============================================================================
@@ -66,11 +68,16 @@ type HiveIdentity struct {
 	// built from. An empty slug falls back to the public default and 404s on a
 	// GHE host, so it travels with the ID.
 	AppSlug string
-	// APIURL/BaseURL are the forge endpoints. Empty means public github.com —
-	// the fleet-wide on-disk convention, which ResolvedAPIURL/ResolvedBaseURL
-	// already map to api.github.com/github.com. They are left empty rather than
-	// spelled out so a resolved identity is byte-identical to what every healthy
-	// public spoke already carries.
+	// APIURL/BaseURL are the forge endpoints, always stated EXPLICITLY — public
+	// github.com resolves to https://api.github.com / https://github.com rather
+	// than to empty strings.
+	//
+	// They used to be left empty for public, matching the fleet-wide on-disk
+	// convention that ResolvedAPIURL/ResolvedBaseURL already map to those two
+	// values. But a field that means something by being ABSENT is what hid the
+	// 2026-07-31 incident: a GHE app_id beside an empty api_url read as *unset*
+	// rather than *mismatched*. Explicit values cost nothing and remove the
+	// ambiguity.
 	APIURL  string
 	BaseURL string
 	// Forge is the bare host label this identity belongs to ("github.com",
@@ -117,6 +124,24 @@ func ResolveHiveIdentity(h *SaaSHive, cluster *ClusterConfig) HiveIdentity {
 		BaseURL: cluster.GitHubBaseURL,
 		Forge:   clusterForge,
 	}
+	// DELIBERATELY NOT made explicit here, unlike the elected-forge branch below.
+	//
+	// A cluster that declares no url fields looks public to clusterForgeHost —
+	// but so does a GHE cluster that simply has not backfilled its urls, and
+	// several real records are in exactly that state. Writing public urls on
+	// that silence would stamp api.github.com onto GHE clusters and break the
+	// repair path this whole design exists to serve. SILENCE IS NOT EVIDENCE.
+	//
+	// An ELECTION is different: a hive that records github_host is stating its
+	// forge, so the urls can be stated with it. Explicitness is safe where there
+	// is evidence and dangerous where there is only absence — which is the same
+	// unknown-vs-mismatch rule the push flags follow.
+	//
+	// Filling the slug IS safe: slugOfAppID keys on app_id, which is always
+	// populated, and returns "" for an App this build does not recognise.
+	if id.AppSlug == "" {
+		id.AppSlug = config.SlugOfAppID(id.AppID)
+	}
 
 	elected := electedForgeForHive(h, cluster)
 	if elected == "" || sameGitHubHost(elected, clusterForge) {
@@ -126,8 +151,23 @@ func ResolveHiveIdentity(h *SaaSHive, cluster *ClusterConfig) HiveIdentity {
 	// Rule 1: the hive elected a forge its cluster does not default to.
 	elect := HiveIdentity{Forge: elected, FromHiveIntent: true}
 	if isPublicForgeHost(elected) {
-		// Public github.com: empty URLs, matching every healthy public spoke.
-		elect.APIURL, elect.BaseURL = "", ""
+		// Public github.com: state the URLs EXPLICITLY rather than leaving them
+		// empty for a resolver default to fill in later.
+		//
+		// Empty used to be correct-by-convention here — it matched how every
+		// healthy public spoke was stored, and ResolvedAPIURL/ResolvedBaseURL
+		// turn "" into exactly these two constants. But an empty field means
+		// something by NOT being there, and that is what hid the 2026-07-31
+		// incident: a GitHub Enterprise app_id sitting beside an empty api_url
+		// read as *unset* rather than *mismatched*, so nothing flagged it until
+		// a token call returned 404 Integration not found.
+		//
+		// These are the SAME values the resolver would have produced; the only
+		// change is that the spoke is now told them instead of inferring them.
+		// Measured on the fleet before this: base_url was empty on 48 of 51
+		// spokes, api_url on 41, app_slug on 33 — implicit state was the normal
+		// condition, not a handful of stragglers.
+		elect.APIURL, elect.BaseURL = config.DefaultGitHubAPIURL, config.DefaultGitHubBaseURL
 	} else {
 		elect.BaseURL = "https://" + elected
 		elect.APIURL = "https://" + elected + gheAPIPathSuffix
@@ -136,6 +176,20 @@ func ResolveHiveIdentity(h *SaaSHive, cluster *ClusterConfig) HiveIdentity {
 	// Rule 3: only adopt the election if the hub can actually NAME an App on it.
 	if app, ok := clusterAppForForge(cluster, elected); ok {
 		elect.AppID, elect.AppSlug = app.AppID, strings.TrimSpace(app.AppSlug)
+		// A cluster entry may name an App ID and leave the slug blank. Fill it
+		// from the App ID rather than shipping an empty field for the spoke's
+		// ResolvedAppSlug() to guess at: the slug builds the "Install GitHub
+		// App" link, and an empty one falls back to the public default — which
+		// is how ten GHE hives ended up with an install link pointing at an App
+		// that does not exist on their host.
+		//
+		// slugOfAppID returns "" for an App ID this build does not recognise,
+		// and that stays empty ON PURPOSE. daviddiaz0317-visual-hive runs
+		// app_id 4240368 — a third App with its own key — and inventing a slug
+		// for it would be a confident wrong answer where no answer is correct.
+		if elect.AppSlug == "" {
+			elect.AppSlug = config.SlugOfAppID(elect.AppID)
+		}
 		return elect
 	}
 	// The cluster names no App on the elected forge. Keep the hive's forge —

--- a/v2/pkg/hub/hive_identity_test.go
+++ b/v2/pkg/hub/hive_identity_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
 // Live fleet identity values, used so every case below is a REAL shape rather
@@ -128,8 +130,14 @@ func TestResolveHiveIdentityBothMismatchDirections(t *testing.T) {
 			// A resolved identity that names one forge while carrying another's
 			// URLs is the exact half-identity this design exists to prevent.
 			if isPublicForgeHost(got.Forge) {
-				if got.APIURL != "" || got.BaseURL != "" {
-					t.Errorf("a public identity must carry empty URLs (the fleet-wide shape), got api=%q base=%q",
+				// Either empty (inherited from a cluster whose silence must NOT
+				// be read as evidence — see ResolveHiveIdentity) or the explicit
+				// public urls (stated when the HIVE elected public). Both are
+				// coherent; what must never appear is another forge's urls.
+				okEmpty := got.APIURL == "" && got.BaseURL == ""
+				okExplicit := got.APIURL == config.DefaultGitHubAPIURL && got.BaseURL == config.DefaultGitHubBaseURL
+				if !okEmpty && !okExplicit {
+					t.Errorf("a public identity carried non-public urls: api=%q base=%q",
 						got.APIURL, got.BaseURL)
 				}
 			} else {


### PR DESCRIPTION
## Why

An empty field means something by **not being there**, and that's what hid the 2026-07-31 incident: a GHE `app_id` beside an empty `api_url` read as *unset* rather than *mismatched*, so nothing flagged it until a token call returned `404 Integration not found`.

**Measured first:** `base_url` empty on **48 of 51** spokes, `api_url` on 41, `app_slug` on 33. Only three spokes were fully explicit — implicit state was the fleet's normal condition.

## What changed

- A hive that **elects** a forge resolves to explicit urls (`https://api.github.com` / `https://github.com`). Same values `ResolvedAPIURL`/`ResolvedBaseURL` would have produced — the spoke is now *told* them instead of inferring them.
- `app_slug` is filled from `app_id` wherever blank. An empty slug builds the install link against the public default, which is how ten GHE hives got a link pointing at an App that doesn't exist on their host.

## What it deliberately does NOT do — the more important half

The **cluster-default** path is left alone. A cluster declaring no url fields looks public to `clusterForgeHost` — but so does a GHE cluster that never backfilled its urls, and several real records are in that state. Writing public urls onto that silence would stamp `api.github.com` onto GHE clusters and break the repair path this design exists to serve.

I made that change. A test caught it, with exactly the right message:

> *a cluster that declares no forge URLs was refused — silence is not evidence of public GitHub, and this stops the repair path on every un-backfilled GHE cluster*

**The principle: explicitness is safe where there is evidence and dangerous where there is only absence.** A hive recording `github_host` is *stating* its forge, so its urls can be stated with it. A cluster's silence states nothing. Same unknown-vs-mismatch rule as #2389, from the other direction.

Filling the slug passes that same test: `slugOfAppID` keys on `app_id` — always populated — and returns `""` for an unrecognised App. `daviddiaz0317-visual-hive` runs `app_id 4240368` with its own key and correctly keeps an empty slug.

## Tests

The most important is negative: **48 of 51 live spokes carry at least one empty identity field and must keep validating** while the fleet converges. `TestHealthyImplicitSpokesStillValidate` pins the four real shapes, including the console hive with all three empty.

| Mutation | Result |
|---|---|
| Revert public urls to empty | 1 failure ✓ |
| Stop filling the blank slug | 1 failure ✓ |
| Invent a slug for an unknown App | 1 failure ✓ |

`pkg/hub`, `pkg/config` green.