### PR TITLE
🐛 fix(hub): never store a blank github_host for an explicit public choice

### DIFF
--- a/v2/pkg/hub/no_blank_host_test.go
+++ b/v2/pkg/hub/no_blank_host_test.go
@@ -1,0 +1,70 @@
+package hub
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestNoCodePathStoresABlankGitHubHost is a source-level guard.
+//
+// github_host is the SINGLE stored input for a hive's identity (#2386): app_id,
+// app_slug, api_url and base_url are all derived from it. A blank one therefore
+// means "work it out yourself", which is exactly the ambiguity that hid the
+// 2026-07-31 incident — a GHE app_id beside an empty api_url read as *unset*
+// rather than *mismatched*, and 25 of 50 hub records carried no github_host at
+// all.
+//
+// Explicit public github.com used to be stored as a blank host PLUS the
+// "public" sentinel in GitHubBaseURL, because a blank was the only way to stop
+// backfillGitHubHostFromCluster re-GHE-ing the hive on the next line. Storing
+// the real host achieves the same protection — that backfill only ever fills an
+// EMPTY value — without an absent field anyone has to interpret.
+//
+// A source scan rather than a behavioural test: the assignment sites are spread
+// across three handlers, and what matters is that NO path anywhere reintroduces
+// one. A behavioural test would have to enumerate the handlers and would pass
+// while a fourth path quietly did it.
+func TestNoCodePathStoresABlankGitHubHost(t *testing.T) {
+	// Matches h.GitHubHost = "" / entry.GitHubHost = "" and friends.
+	blank := regexp.MustCompile(`\.GitHubHost\s*=\s*""`)
+
+	var offenders []string
+	scanned := 0
+	err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		if strings.HasSuffix(path, "_test.go") {
+			return nil // fixtures may legitimately construct a blank
+		}
+		src, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		scanned++
+		for i, line := range strings.Split(string(src), "\n") {
+			if blank.MatchString(line) {
+				offenders = append(offenders, filepath.ToSlash(path)+":"+strconv.Itoa(i+1)+" "+strings.TrimSpace(line))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A source scan that reads nothing passes for the wrong reason. Mutating
+	// the walk root to a bad path made this test green WITH a real offender in
+	// the tree, so the count is asserted: it is the difference between "no
+	// offenders" and "no files looked at".
+	if scanned < 20 {
+		t.Fatalf("only %d source files scanned — the walk is not covering pkg/hub, so a passing result proves nothing", scanned)
+	}
+	if len(offenders) > 0 {
+		t.Errorf("a code path stores a BLANK github_host. It is the single stored input for hive identity, so a blank means \"infer it\" — the ambiguity this package exists to remove. Store the real host (publicForgeHost for public github.com); backfillGitHubHostFromCluster only fills an EMPTY value, so a stated host blocks it just as a blank did:\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -5572,8 +5572,18 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 		// own api.github.com default — and so the cluster backfill below, which
 		// only ever fills a blank, does not silently re-GHE it.
 		if strings.EqualFold(host, githubHostPublic) {
-			h.GitHubHost = ""
-			h.GitHubBaseURL = githubHostPublic
+			// Record public github.com EXPLICITLY. This used to store a blank
+			// host plus the "public" sentinel, because a blank was the only way
+			// to stop backfillGitHubHostFromCluster re-GHE-ing the hive on the
+			// next line. Storing the real host achieves the same thing — that
+			// backfill only ever fills a value that is EMPTY — without leaving
+			// an absent field that means "public" by implication.
+			//
+			// An absent field is what hid the 2026-07-31 incident and what left
+			// 25 of 50 hub records with no github_host at all. github_host is
+			// the single stored input for a hive's identity (#2386); it should
+			// never be the one field we deliberately leave blank.
+			h.GitHubHost = publicForgeHost
 		} else {
 			h.GitHubHost = host
 		}
@@ -5584,8 +5594,11 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 		// github.com request must be pinned public — NOT stored as the literal host
 		// "public", and NOT left blank for the cluster backfill below to re-GHE.
 		if strings.EqualFold(pr.GitHubHost, githubHostPublic) {
-			h.GitHubHost = ""
-			h.GitHubBaseURL = githubHostPublic
+			// Same as the admin-override branch above: store the real host, not
+			// a blank plus the sentinel. The literal string "public" must never
+			// be stored as a host — it is a request-time marker, not a hostname,
+			// and a hive naming it resolves to no forge at all.
+			h.GitHubHost = publicForgeHost
 		} else {
 			h.GitHubHost = pr.GitHubHost
 		}
@@ -6310,8 +6323,11 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	// re-GHE the hive. Without the sentinel a blank host would simply be
 	// refilled from the cluster on the very next line.
 	if strings.EqualFold(body.GitHubHost, githubHostPublic) {
-		h.GitHubHost = ""
-		h.GitHubBaseURL = githubHostPublic
+		// Explicit public github.com, stored as the real host rather than a
+		// blank + sentinel. The cluster backfill below only fills an EMPTY
+		// host, so a stated value blocks it just as the blank did — and does
+		// not leave a field whose absence has to be interpreted.
+		h.GitHubHost = publicForgeHost
 	} else if body.GitHubHost != "" {
 		h.GitHubHost = body.GitHubHost
 	}


### PR DESCRIPTION
## An explicit choice recorded as an absence

`github_host` is the **single stored input** for a hive's identity since #2386 — `app_id`, `app_slug`, `api_url` and `base_url` all derive from it. Three paths stored it **blank** when a user explicitly chose public github.com (admin override in approve, the request's own host, and the assign handler).

Each paired the blank with the `"public"` sentinel in `GitHubBaseURL`, and the comments explain why: a blank was the only way to stop `backfillGitHubHostFromCluster` re-GHE-ing the hive on the very next line.

But that backfill only ever fills a value that is **empty**:

```go
if h == nil || h.GitHubHost != "" || cluster == nil { return "" }
```

So storing the real host blocks it exactly as well — without leaving a field whose **absence** has to be interpreted.

## Why it matters

**25 of 50 hub records carried no `github_host` at all.** Two of them — `hosted-available-vllmd-01` (katamari) and `hosted-available-vllmd-07` (z-aiops-unite) — inherited their cluster's GHE default, took the public App against GHE urls, and returned `404 Integration not found` on every token call until repaired today.

The literal string `"public"` is a request-time marker, not a hostname, and is still never stored as a host — a hive naming it resolves to no forge at all.

## On the test

A **source scan**, deliberately not a behavioural test: the assignment sites are spread across three handlers, and what matters is that no *fourth* path reintroduces one. A behavioural test would enumerate the three and pass while a fourth quietly did it.

The scan also asserts it read **≥20 files**. Mutating its walk root to a bad path made it pass *with a real offender in the tree* — a test that scans nothing is green for the wrong reason, which is the exact failure mode that let four other checks pass this week while testing nothing.

| Mutation | Result |
|---|---|
| Reintroduce a blank write | 1 failure ✓ |
| Break the walk root (scan nothing) | 1 failure ✓ (after the coverage assert) |