### PR TITLE
landing: fix Hives online (up/total), add Available-hives tile, make Public-hives tile jump

### DIFF
--- a/v2/pkg/hub/fleet_stats_test.go
+++ b/v2/pkg/hub/fleet_stats_test.go
@@ -61,7 +61,7 @@ func TestComputeFleetStats(t *testing.T) {
 					PRsMerged90d: ptrInt(5), PRsRejected90d: ptrInt(1), CVEsClosed: ptrInt(3)},
 			},
 			// repos: a/r1, a/r2, a/r3 = 3 distinct; a/r2 reported twice + as "r2".
-			want: FleetStats{ReposManaged: 3, PRsMerged: 15, PRsRejected: 3, CVEsClosed: 4, Hives: 2, Reporting: 2, Eligible: 2},
+			want: FleetStats{ReposManaged: 3, PRsMerged: 15, PRsRejected: 3, CVEsClosed: 4, Hives: 2, TotalHives: 2, Reporting: 2, Eligible: 2},
 		},
 		{
 			// A PRIVATE hive now COUNTS: these totals are anonymous sums, and
@@ -75,7 +75,9 @@ func TestComputeFleetStats(t *testing.T) {
 				{IsPublic: true, Online: false, Org: "a", Repos: []string{"r2"}, PRsMerged90d: ptrInt(99)},
 				{IsPublic: true, Online: true, Org: "a", Repos: []string{"r3"}, PRsMerged90d: ptrInt(7)},
 			},
-			want: FleetStats{ReposManaged: 2, PRsMerged: 106, Hives: 2, Reporting: 2, Eligible: 2},
+			// TotalHives is 3: all three are assigned (Org set); one is offline so
+			// it's in the total but not "up" (Hives 2).
+			want: FleetStats{ReposManaged: 2, PRsMerged: 106, Hives: 2, TotalHives: 3, Reporting: 2, Eligible: 2},
 		},
 		{
 			name: "nil counts are not aggregated as zero",
@@ -83,7 +85,7 @@ func TestComputeFleetStats(t *testing.T) {
 				{IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}}, // all nil
 				{IsPublic: true, Online: true, Org: "a", Repos: []string{"r2"}, PRsMerged90d: ptrInt(4)},
 			},
-			want: FleetStats{ReposManaged: 2, PRsMerged: 4, Hives: 2, Reporting: 1, Eligible: 2},
+			want: FleetStats{ReposManaged: 2, PRsMerged: 4, Hives: 2, TotalHives: 2, Reporting: 1, Eligible: 2},
 		},
 		{
 			name: "empty repo strings are skipped",
@@ -91,7 +93,21 @@ func TestComputeFleetStats(t *testing.T) {
 				{IsPublic: true, Online: true, Org: "a", Repos: []string{"", "r1", ""},
 					PRsMerged90d: ptrInt(2)},
 			},
-			want: FleetStats{ReposManaged: 1, PRsMerged: 2, Hives: 1, Reporting: 1, Eligible: 1},
+			want: FleetStats{ReposManaged: 1, PRsMerged: 2, Hives: 1, TotalHives: 1, Reporting: 1, Eligible: 1},
+		},
+		{
+			// Unassigned placeholders (Org == "") are counted as AVAILABLE and
+			// excluded from the assigned totals — "hives up / total" is about the
+			// working fleet, not idle inventory. Here: 2 assigned (1 up), 3 available.
+			name: "unassigned placeholders count as available, not assigned",
+			hives: []RegistryEntry{
+				{IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(3)},
+				{IsPublic: false, Online: false, Org: "b", Repos: []string{"r2"}, PRsMerged90d: ptrInt(1)},
+				{Online: true, Org: ""},  // available placeholder, online
+				{Online: false, Org: ""}, // available placeholder, offline
+				{Online: true, Org: ""},  // available placeholder, online
+			},
+			want: FleetStats{ReposManaged: 1, PRsMerged: 3, Hives: 1, TotalHives: 2, AvailableHives: 3, Reporting: 1, Eligible: 1},
 		},
 		{
 			name:  "no hives yields empty",

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1812,11 +1812,20 @@ func (s *HubServer) handleStats(w http.ResponseWriter, r *http.Request) {
 // hive, so the numbers are a true fleet total (every managed repo of every
 // live spoke) rather than a single org's figures.
 type FleetStats struct {
-	ReposManaged int    `json:"repos_managed"`
-	PRsMerged    int    `json:"prs_merged"`
-	PRsRejected  int    `json:"prs_rejected"`
-	CVEsClosed   int    `json:"cves_closed"`
-	Hives        int    `json:"hives"`
+	ReposManaged int `json:"repos_managed"`
+	PRsMerged    int `json:"prs_merged"`
+	PRsRejected  int `json:"prs_rejected"`
+	CVEsClosed   int `json:"cves_closed"`
+	// Hives is the number of ONLINE, ASSIGNED hives fleet-wide (the loop below
+	// skips offline and unassigned ones) — i.e. "hives up". TotalHives is every
+	// ASSIGNED hive, online or not. The landing page shows "hives up / total"
+	// (Hives/TotalHives) so the ratio reflects real fleet uptime rather than the
+	// public-list size, and unclaimed inventory doesn't inflate it. AvailableHives
+	// is the count of UNASSIGNED placeholders a user could still request. All
+	// three are anonymous scalars — no name/org/repo/owner/URL is derivable.
+	Hives          int `json:"hives"`
+	TotalHives     int `json:"total_hives"`
+	AvailableHives int `json:"available_hives"`
 	// AgentsRunning and Contributors are fleet-wide ANONYMOUS counts, summed
 	// over ALL online hives rather than only the public ones.
 	//
@@ -1826,9 +1835,9 @@ type FleetStats struct {
 	// public). Computing them here counts every hive while disclosing none: like
 	// every other field on this struct they are scalars, and no name, org, repo,
 	// owner or URL is derivable from them.
-	AgentsRunning int `json:"agents_running"`
-	Contributors  int `json:"contributors"`
-	UpdatedAt    string `json:"updated_at"`
+	AgentsRunning int    `json:"agents_running"`
+	Contributors  int    `json:"contributors"`
+	UpdatedAt     string `json:"updated_at"`
 	// Reporting is the number of eligible hives that actually contributed a
 	// fresh count to the totals above; Eligible is how many were considered.
 	// Without this pair the totals are indistinguishable from a healthy fleet:
@@ -1878,7 +1887,20 @@ func (s *HubServer) computeFleetStats() FleetStats {
 	var fs FleetStats
 	repoSet := make(map[string]struct{})
 	for _, h := range s.registry.Hives {
-		// ALL hives count, public and private alike.
+		// An UNASSIGNED hive is a pre-provisioned placeholder nobody has claimed
+		// yet — it carries no project, so its Org is empty (a claimed hive always
+		// has one). It is counted as AVAILABLE and excluded from the assigned
+		// totals below: "hives up / total" and the contribution sums are about the
+		// working fleet, not idle inventory a user could still request.
+		if h.Org == "" {
+			fs.AvailableHives++
+			continue
+		}
+		// TotalHives is every ASSIGNED hive (online or not) — the denominator of
+		// "hives up / total". Counted before the online skip below so a down hive
+		// still contributes to the total.
+		fs.TotalHives++
+		// ALL assigned hives count, public and private alike.
 		//
 		// These totals are ANONYMOUS SUMS: every field on FleetStats is a
 		// scalar — counts, a timestamp, booleans. No name, org, repo, owner or

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -356,6 +356,21 @@
     }
     .metric-grid span { color: var(--muted); font-size: .86rem; }
     .metric-grid strong { color: var(--green); font-size: 1.4rem; }
+    /* The Public hives tile is an <a> so it can jump to the hive table; give it
+       the same box as the sibling <div> tiles, plus a clickable affordance. */
+    .metric-grid a.stat-jump {
+      border: 1px solid var(--line);
+      background: #080b0f85;
+      border-radius: .7rem;
+      gap: .35rem;
+      min-height: 5.5rem;
+      padding: 1rem;
+      display: grid;
+      text-decoration: none;
+      cursor: pointer;
+      transition: border-color .15s ease, background .15s ease;
+    }
+    .metric-grid a.stat-jump:hover { border-color: var(--green); background: #0b1016; }
 
     /* ── Loop rail ── */
     .loop { background: linear-gradient(#0c121900, #121922bf 30%, #12192200); }
@@ -676,7 +691,12 @@
           <div><span>Agents running</span><strong id="stat-agents">—</strong></div>
           <div><span>Managed repos</span><strong id="stat-repos">—</strong></div>
           <div><span>Contributors</span><strong id="stat-contributors">—</strong></div>
-          <div><span>Public hives</span><strong id="stat-total">—</strong></div>
+          <!-- The Public hives tile jumps to the public-hive table below (#hives),
+               since that table IS the list of public hives this count describes.
+               An <a> (not a JS scroll handler) keeps it keyboard-focusable and
+               right-click-openable; the href drives a native smooth scroll via
+               the page's scroll-behavior. -->
+          <a href="#hives" class="stat-jump" title="Jump to the public hives"><span>Public hives</span><strong id="stat-total">—</strong></a>
         </div>
       </div>
     </section>
@@ -1111,15 +1131,23 @@
     function renderStats(hives) {
       var agents = 0, contributors = 0, online = 0, repos = 0;
       hives.forEach(function(h) { agents += h.agentCount || 0; contributors += h.activeContributors || 0; repos += (h.repos || []).length; if (h.online) online++; });
+      // "Hives online" is online-out-of-TOTAL-FLEET: the denominator is the
+      // fleet-wide hive count (_fleetWide.hives, which covers every spoke, ~50),
+      // NOT the public-list length (~18) — showing 18/18 read as "all hives up"
+      // when two-thirds of the fleet is simply not public. The numerator stays
+      // the online count from the public list the page can actually see; fall
+      // back to the public length until the fleet-stats poll lands so it never
+      // shows online/undefined.
+      var f = _fleetWide;
+      var fleetTotal = (f && typeof f.hives === 'number' && f.hives >= hives.length) ? f.hives : hives.length;
+      document.getElementById('stat-online').textContent = online + '/' + fleetTotal;
       // "Public hives" is deliberately the length of the PUBLIC list — it
       // labels exactly what the table below shows, and is the one counter here
       // that should not be fleet-wide.
-      document.getElementById('stat-online').textContent = online + '/' + hives.length;
       document.getElementById('stat-total').textContent = hives.length;
       // The rest are fleet-wide when the hub has told us, falling back to the
       // public-list sums so an older hub (or a failed poll) still renders a
-      // number rather than an em dash.
-      var f = _fleetWide;
+      // number rather than an em dash. (f = _fleetWide, resolved above.)
       document.getElementById('stat-agents').textContent =
         f && typeof f.agents_running === 'number' ? f.agents_running : agents;
       document.getElementById('stat-repos').textContent =

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -697,6 +697,11 @@
                right-click-openable; the href drives a native smooth scroll via
                the page's scroll-behavior. -->
           <a href="#hives" class="stat-jump" title="Jump to the public hives"><span>Public hives</span><strong id="stat-total">—</strong></a>
+          <!-- Available hives = unassigned placeholders a user could claim. The
+               tile links to the Request-a-Hive wizard (/get-started), so seeing
+               "N available" and acting on it is one click. Anchor for the same
+               keyboard/right-click reasons as the Public hives tile. -->
+          <a href="/get-started" class="stat-jump" title="Request one of the available hives"><span>Available hives</span><strong id="stat-available">—</strong></a>
         </div>
       </div>
     </section>
@@ -1131,20 +1136,27 @@
     function renderStats(hives) {
       var agents = 0, contributors = 0, online = 0, repos = 0;
       hives.forEach(function(h) { agents += h.agentCount || 0; contributors += h.activeContributors || 0; repos += (h.repos || []).length; if (h.online) online++; });
-      // "Hives online" is online-out-of-TOTAL-FLEET: the denominator is the
-      // fleet-wide hive count (_fleetWide.hives, which covers every spoke, ~50),
-      // NOT the public-list length (~18) — showing 18/18 read as "all hives up"
-      // when two-thirds of the fleet is simply not public. The numerator stays
-      // the online count from the public list the page can actually see; fall
-      // back to the public length until the fleet-stats poll lands so it never
-      // shows online/undefined.
+      // "Hives online" is HIVES UP / TOTAL ASSIGNED, both fleet-wide:
+      //   • up    = _fleetWide.hives  (online, assigned hives across the fleet)
+      //   • total = _fleetWide.total_hives (all assigned hives, up or not)
+      // Neither is the public-list size — showing online-public/public read
+      // "18/18" (all up) when two-thirds of the fleet is simply not public.
+      // Unassigned placeholders are excluded from both (they're counted under
+      // "Available hives"). Until the fleet-stats poll lands, fall back to the
+      // public list the page can see so it never renders undefined.
       var f = _fleetWide;
-      var fleetTotal = (f && typeof f.hives === 'number' && f.hives >= hives.length) ? f.hives : hives.length;
-      document.getElementById('stat-online').textContent = online + '/' + fleetTotal;
-      // "Public hives" is deliberately the length of the PUBLIC list — it
-      // labels exactly what the table below shows, and is the one counter here
-      // that should not be fleet-wide.
+      var up = (f && typeof f.hives === 'number') ? f.hives : online;
+      var total = (f && typeof f.total_hives === 'number') ? f.total_hives : hives.length;
+      document.getElementById('stat-online').textContent = up + '/' + total;
+      // "Public hives" is deliberately the length of the PUBLIC list — it labels
+      // exactly the table below and is the one counter here that is not fleet-wide.
       document.getElementById('stat-total').textContent = hives.length;
+      // "Available hives" = unassigned placeholders a user can request (fleet-wide,
+      // anonymous scalar). Em dash until the poll lands.
+      var availEl = document.getElementById('stat-available');
+      if (availEl) {
+        availEl.textContent = (f && typeof f.available_hives === 'number') ? f.available_hives : '—';
+      }
       // The rest are fleet-wide when the hub has told us, falling back to the
       // public-list sums so an older hub (or a failed poll) still renders a
       // number rather than an em dash. (f = _fleetWide, resolved above.)


### PR DESCRIPTION
## Fleet-status panel: correct "Hives online", add "Available hives", make tiles actionable

Fixes the public **Live fleet status** panel so its numbers mean what they say and the tiles are useful.

### "Hives online" now = hives up / total assigned (fleet-wide)
It rendered `online / hives.length` where `hives` is the **public** list only (~18), so a fleet with 18 public spokes read **`18/18`** — looking like "the whole fleet is up" when ~2/3 of the fleet (private hives) wasn't even counted. Now:
- **numerator** = online assigned hives, fleet-wide (`_fleetWide.hives`)
- **denominator** = every **assigned** hive, up or not (`_fleetWide.total_hives`)
- **unassigned placeholders are excluded from both** — idle inventory a user could still request shouldn't inflate uptime.

So it reads e.g. **`50/50`** when all assigned hives are up. Falls back to the public list until the fleet-stats poll lands, so it never renders `undefined`.

### New "Available hives" tile → Request-a-Hive wizard
Counts the **unassigned** placeholders (detected server-side by an empty `Org` — anonymous scalar, safe on the public page). Clicking the tile opens **`/get-started`** (the Request-a-Hive wizard), so seeing availability and acting on it is one click.

### "Public hives" tile jumps to the list
The **Public hives** tile is now an `<a href="#hives">` that smooth-scrolls to the public-hive table it counts (keyboard-focusable, styled to match the other tiles).

### Backend
`FleetStats` gains `TotalHives` (assigned, online-or-not) and `AvailableHives` (unassigned). `computeFleetStats` skips unassigned hives from the assigned totals and counts them under `AvailableHives`.

### Testing
`go build ./...`; `go test ./pkg/hub/` green (bar the 2 known kubectl-env flakes). Fleet-stats tests updated with `TotalHives` expectations plus a dedicated unassigned-placeholder case. Landing JS validated with `node --check`.

Based on current v2 (00ff7343).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
