### PR TITLE
♻️ refactor(spoke): copy the ConfigMap seed only on first boot

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -90,6 +90,15 @@ if [ "$IS_KUBERNETES" = "true" ]; then
       echo "[entrypoint] K8s mode — config path read-only, using $HIVE_CONFIG_BOOT directly"
     fi
   elif [ -f "$HIVE_CONFIG_PATH" ] && [ -s "$HIVE_CONFIG_PATH" ]; then
+    # FIRST BOOT ONLY. The copy-config init container now seeds the config path
+    # solely when the PVC has no runtime config, so reaching here means this
+    # hive has never written one.
+    #
+    # The overlay merge below is kept for one case that is real: a hive
+    # REPROVISIONED onto an existing PVC has a dashboard overlay but no runtime
+    # config, and dropping its overlay would silently discard the owner's agent
+    # roster and level. On a genuinely new hive there is no overlay and the
+    # merge is a no-op.
     # The copy-config init container re-seeded $HIVE_CONFIG_PATH from the
     # ConfigMap on this boot. Config saved via the dashboard (Config.Save
     # writes /etc/hive/hive.yaml, an emptyDir) would be silently lost —

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -2033,12 +2033,20 @@ spec:
       - name: copy-config
         image: ghcr.io/kubestellar/hive:{{.ImageTag}}
         imagePullPolicy: {{.ImagePullPolicy}}
-        # Seed-wins variant: the ConfigMap is copied over the config path and
-        # the PVC runtime config is only REPORTED, never restored here. The
-        # entrypoint does the real overlay merge. Both the new and legacy
-        # names are probed so the diagnostic stays truthful while hives that
-        # predate the hive.yaml.runtime rename still carry only the old file.
-        command: ["sh", "-c", "cp /etc/hive-seed/hive.yaml /etc/hive/hive.yaml && echo configmap-copied; if [ -f /data/hive.yaml.runtime ]; then echo runtime-config-exists-for-recovery; elif [ -f /data/hive.yaml.bak ]; then echo legacy-runtime-config-exists-for-recovery; fi"]
+        # SEED-ONLY variant (phase 3 of the layer collapse). The ConfigMap is
+        # copied ONLY when the PVC carries no runtime config — i.e. first boot.
+        #
+        # It used to copy unconditionally on every boot, which meant the frozen
+        # seed overwrote the config path before the entrypoint had a say. Phase
+        # 2 made the entrypoint prefer the runtime config, so that copy became
+        # redundant work that still had to be undone one line later; skipping it
+        # is what actually makes the ConfigMap a seed rather than a per-boot
+        # input.
+        #
+        # Both runtime names are probed: ~16 of 50 live spokes still carry only
+        # the legacy hive.yaml.bak, so keying on the new name alone would treat
+        # them as first-boot and re-seed a hive that has real config on its PVC.
+        command: ["sh", "-c", "if [ -s /data/hive.yaml.runtime ]; then echo runtime-config-exists-for-recovery; elif [ -s /data/hive.yaml.bak ]; then echo legacy-runtime-config-exists-for-recovery; else cp /etc/hive-seed/hive.yaml /etc/hive/hive.yaml && echo configmap-copied-first-boot; fi"]
         volumeMounts:
         - name: config
           mountPath: /etc/hive-seed

--- a/v2/pkg/hub/seed_only_first_boot_test.go
+++ b/v2/pkg/hub/seed_only_first_boot_test.go
@@ -1,0 +1,126 @@
+package hub
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// initCommand extracts the copy-config init container's shell command from the
+// provisioning template, so the test runs the REAL command rather than a
+// paraphrase of it. A copy pasted into the test would keep passing after the
+// template changed.
+func initCommand(t *testing.T) string {
+	t.Helper()
+	src, err := os.ReadFile("saas_provision.go")
+	if err != nil {
+		t.Fatalf("read template: %v", err)
+	}
+	re := regexp.MustCompile(`command: \["sh", "-c", "((?:[^"\\]|\\.)*)"\]`)
+	for _, m := range re.FindAllStringSubmatch(string(src), -1) {
+		if strings.Contains(m[1], "hive-seed") {
+			return strings.ReplaceAll(m[1], `\"`, `"`)
+		}
+	}
+	t.Fatal("could not find the copy-config command in saas_provision.go — it moved, and this test would silently cover nothing")
+	return ""
+}
+
+// runInit executes the init command against a temp filesystem and returns what
+// it echoed plus whether the seed was copied over the config path.
+func runInit(t *testing.T, files map[string]string) (string, bool) {
+	t.Helper()
+	root := t.TempDir()
+	for rel, content := range files {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(root, "etc/hive"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := initCommand(t)
+	cmd = strings.ReplaceAll(cmd, "/data/", root+"/data/")
+	cmd = strings.ReplaceAll(cmd, "/etc/hive-seed/", root+"/etc/hive-seed/")
+	cmd = strings.ReplaceAll(cmd, "/etc/hive/", root+"/etc/hive/")
+
+	out, _ := exec.Command("sh", "-c", cmd).CombinedOutput()
+	copied := false
+	if b, err := os.ReadFile(filepath.Join(root, "etc/hive/hive.yaml")); err == nil && len(b) > 0 {
+		copied = true
+	}
+	return string(out), copied
+}
+
+// TestSeedIsCopiedOnlyOnFirstBoot pins phase 3: the ConfigMap is a SEED, not a
+// per-boot input.
+//
+// It used to be copied over the config path unconditionally on every boot, so
+// the frozen seed overwrote the config before the entrypoint could prefer the
+// PVC. Phase 2 made the entrypoint prefer the runtime config; this makes the
+// copy stop happening at all once one exists.
+func TestSeedIsCopiedOnlyOnFirstBoot(t *testing.T) {
+	seed := map[string]string{"etc/hive-seed/hive.yaml": "acmm_level: 3\n"}
+
+	t.Run("first boot: no PVC config, seed IS copied", func(t *testing.T) {
+		out, copied := runInit(t, seed)
+		if !copied {
+			t.Fatalf("seed was not copied on first boot; the hive has nothing to start from:\n%s", out)
+		}
+		if !strings.Contains(out, "configmap-copied-first-boot") {
+			t.Errorf("first boot not reported: %s", out)
+		}
+	})
+
+	t.Run("steady state: runtime config exists, seed is NOT copied", func(t *testing.T) {
+		files := map[string]string{"data/hive.yaml.runtime": "acmm_level: 5\n"}
+		for k, v := range seed {
+			files[k] = v
+		}
+		out, copied := runInit(t, files)
+		if copied {
+			t.Fatalf("the frozen seed overwrote the config path on a hive that has its own runtime config:\n%s", out)
+		}
+		if !strings.Contains(out, "runtime-config-exists-for-recovery") {
+			t.Errorf("runtime config not reported: %s", out)
+		}
+	})
+
+	// THE MIGRATION CASE. ~16 of 50 live spokes still carry only the legacy
+	// hive.yaml.bak. Keying first-boot detection on the new name alone would
+	// treat every one of them as new and re-seed a hive that has real config.
+	t.Run("legacy .bak only: still NOT first boot", func(t *testing.T) {
+		files := map[string]string{"data/hive.yaml.bak": "acmm_level: 5\n"}
+		for k, v := range seed {
+			files[k] = v
+		}
+		out, copied := runInit(t, files)
+		if copied {
+			t.Fatalf("a spoke carrying only the LEGACY runtime name was re-seeded — that is ~16 of 50 live spokes losing their config:\n%s", out)
+		}
+		if !strings.Contains(out, "legacy-runtime-config-exists-for-recovery") {
+			t.Errorf("legacy runtime config not reported: %s", out)
+		}
+	})
+
+	// An empty file is not a config. Watchtower zeroing the file is a real
+	// failure mode the entrypoint already recovers from; the init container
+	// must not mistake it for "this hive has config".
+	t.Run("zero-byte runtime config is treated as absent", func(t *testing.T) {
+		files := map[string]string{"data/hive.yaml.runtime": ""}
+		for k, v := range seed {
+			files[k] = v
+		}
+		_, copied := runInit(t, files)
+		if !copied {
+			t.Fatal("a zero-byte runtime config blocked the seed; the hive would boot with no config at all")
+		}
+	})
+}


### PR DESCRIPTION
Phase 3 of the config-layer collapse. Phase 1 renamed `hive.yaml.bak` → `hive.yaml.runtime` (#2380); phase 2 made the entrypoint boot from the runtime config rather than merging the seed over it (#2392).

## The remnant phase 2 left

The `copy-config` init container still copied the ConfigMap over `/etc/hive/hive.yaml` **unconditionally on every boot**, before the entrypoint ran. The frozen seed overwrote the config path, and the entrypoint then preferred the PVC one line later — work done and immediately undone.

Skipping that copy is what actually makes the ConfigMap a **seed** rather than a per-boot input. It now copies only when the PVC carries no runtime config.

## The migration case is the one that matters

**~16 of 50 live spokes still carry only the legacy `hive.yaml.bak`.** Keying first-boot detection on the new name alone would treat every one as new and **re-seed a hive that has real config on its PVC**. Both names are probed.

Zero-byte files count as absent (`-s`, not `-f`): a config zeroed by a container recreation is a real failure mode the entrypoint already recovers from, and the init container must not mistake it for "this hive has config".

## Kept deliberately

The entrypoint's first-boot branch keeps its overlay merge. A hive **reprovisioned onto an existing PVC** has a dashboard overlay but no runtime config, and dropping it would silently discard the owner's agent roster and level. On a genuinely new hive there's no overlay and the merge is a no-op.

## Tests

They extract the init container's shell command **from the template** and run it under `sh` against a temp filesystem — the real command, not a copy pasted into the test that would keep passing after the template changed. The extractor fails loudly if it can't find the command rather than silently covering nothing.

| Mutation | Result |
|---|---|
| Revert to unconditional copy | 3 failures ✓ |
| Drop legacy `.bak` detection (re-seeds 16 live spokes) | 2 failures ✓ |
| Accept a zero-byte file as config | 2 failures ✓ |

`pkg/hub`, `pkg/config` green.