### PR TITLE
hub: co-member avatar hover shows engagement stats; fix the live ring

### DIFF
--- a/v2/pkg/hub/access_hover_test.go
+++ b/v2/pkg/hub/access_hover_test.go
@@ -1,6 +1,9 @@
 package hub
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestAccessForHive covers the ordering and filtering the My Hives hover relies
 // on: only users granted this hive, owners first, then alphabetical.
@@ -48,9 +51,11 @@ func TestAccessForHiveContactMetadata(t *testing.T) {
 		FullName:       "Jane Doe",
 		SlackID:        "@jane",
 		Notes:          "GPU quota bump; prefers async",
+		LoginCount:     42,
+		SessionSeconds: 7200,
 	}}
 
-	t.Run("admin viewer gets name, slack, AND notes", func(t *testing.T) {
+	t.Run("admin viewer gets name, slack, notes AND engagement stats", func(t *testing.T) {
 		got := accessForHive("h1", users, true)
 		if len(got) != 1 {
 			t.Fatalf("want 1 entry, got %d", len(got))
@@ -62,9 +67,12 @@ func TestAccessForHiveContactMetadata(t *testing.T) {
 		if e.Notes != "GPU quota bump; prefers async" {
 			t.Errorf("admin must see notes, got %q", e.Notes)
 		}
+		if e.LoginCount != 42 || e.SessionSeconds != 7200 {
+			t.Errorf("admin must see stats, got login=%d session=%d", e.LoginCount, e.SessionSeconds)
+		}
 	})
 
-	t.Run("non-admin owner gets name+slack but NEVER notes", func(t *testing.T) {
+	t.Run("non-admin owner gets name+slack but NEVER notes or stats", func(t *testing.T) {
 		got := accessForHive("h1", users, false)
 		if len(got) != 1 {
 			t.Fatalf("want 1 entry, got %d", len(got))
@@ -76,5 +84,33 @@ func TestAccessForHiveContactMetadata(t *testing.T) {
 		if e.Notes != "" {
 			t.Errorf("owner must NOT see admin notes, but got %q", e.Notes)
 		}
+		if e.LoginCount != 0 || e.SessionSeconds != 0 {
+			t.Errorf("owner must NOT see engagement stats, got login=%d session=%d", e.LoginCount, e.SessionSeconds)
+		}
 	})
+}
+
+// TestAccessAvatarTitleCarriesStats pins that the co-member face's NATIVE tooltip
+// (accessAvatarTitle) carries the engagement info — logins, time, task activity,
+// verdict — reusing the admin-card helpers, and stays a native title (no custom
+// panel; TestInlineAvatarsCarryNoCustomPanel remains the panel-invariant guard).
+func TestAccessAvatarTitleCarriesStats(t *testing.T) {
+	for _, snippet := range []string{
+		"if (a.login_count) lines.push('Logins: ' + a.login_count);",
+		"if (a.session_seconds) lines.push('Time in hive: ' + fmtHours(a.session_seconds));",
+		"var act = userTaskActivity(uname);",
+		"userVerdict({login_count: a.login_count || 0, session_seconds: a.session_seconds || 0}, act, [])",
+		// The "logged in now" line rides in the avatar's own tooltip, not the ring
+		// wrapper, so a live user's identity+stats aren't shadowed.
+		"if (isUserLive(uname)) title = title + '\\n● Logged into their hive now';",
+	} {
+		if !strings.Contains(dashboardHTML, snippet) {
+			t.Errorf("dashboardHTML missing %q", snippet)
+		}
+	}
+	// The green ring wrapper must NOT carry its own title (it would shadow the
+	// enriched tooltip).
+	if strings.Contains(dashboardHTML, `'<span title="Logged into their hive now" '`) {
+		t.Error("the live-ring wrapper still hard-codes a title that shadows the avatar tooltip")
+	}
 }

--- a/v2/pkg/hub/clickable_avatars_test.go
+++ b/v2/pkg/hub/clickable_avatars_test.go
@@ -65,7 +65,10 @@ func TestAvatarAnchorSafety(t *testing.T) {
 		{"opens in a new tab", `target="_blank"`},
 		{"blocks opener and referrer", `rel="noopener noreferrer"`},
 		{"names the link for assistive tech", `aria-label="' + escAttr(label || uname) + '"`},
-		{"native tooltip names the user too", `title="' + escAttr(label || uname) + '"`},
+		// The native tooltip is escAttr'd via a `title` var that starts from the
+		// label (and folds in a "logged in now" line for a live user).
+		{"native tooltip is escaped", `title="' + escAttr(title) + '"`},
+		{"native tooltip starts from the user label", `var title = label || uname;`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/v2/pkg/hub/hive_access_avatars_test.go
+++ b/v2/pkg/hub/hive_access_avatars_test.go
@@ -80,7 +80,9 @@ func TestInlineAccessAvatarEscaping(t *testing.T) {
 		{"avatar url built from the encoded profile url", `'<img src="' + escAttr(ghProfileURL(username)) + '.png?size='`},
 		// Quoted attribute values.
 		{"anchor href uses escAttr", `'<a href="' + escAttr(ghProfileURL(uname)) + '" target="_blank" rel="noopener noreferrer" '`},
-		{"anchor title and aria-label use escAttr", `'title="' + escAttr(label || uname) + '" aria-label="' + escAttr(label || uname) + '" '`},
+		// title now folds in a live line via a `title` var; both title and
+		// aria-label still go through escAttr.
+		{"anchor title uses escAttr", `'title="' + escAttr(title) + '" aria-label="' + escAttr(label || uname) + '" '`},
 		// The inline face still carries the role in its tooltip, now built by the
 		// shared accessAvatarTitle helper (username — role, plus contact metadata).
 		{"inline face labels username and role via title helper", `return linkedAvatar(uname, INLINE_ACCESS_AVATAR_PX, accessAvatarTitle(a),`},

--- a/v2/pkg/hub/identity_pure_helpers_test.go
+++ b/v2/pkg/hub/identity_pure_helpers_test.go
@@ -1,0 +1,71 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSpokeIdentityFromPayload covers both the nil-payload guard and the
+// populated mapping of the pure heartbeat→identity translation.
+func TestSpokeIdentityFromPayload(t *testing.T) {
+	if got := SpokeIdentityFromPayload(nil); got != (IdentitySet{}) {
+		t.Errorf("nil payload = %+v, want zero IdentitySet", got)
+	}
+	p := &HeartbeatPayload{
+		GitHubAppID:          5686,
+		GitHubAppSlug:        "kubestellar-hive-ghe",
+		GitHubInstallationID: 43015,
+		GitHubAPIURL:         "https://github.ibm.com/api/v3",
+		GitHubBaseURL:        "https://github.ibm.com",
+	}
+	got := SpokeIdentityFromPayload(p)
+	if got.AppID != 5686 || got.AppSlug != "kubestellar-hive-ghe" || got.InstallationID != 43015 ||
+		got.APIURL != "https://github.ibm.com/api/v3" || got.BaseURL != "https://github.ibm.com" {
+		t.Errorf("mapped identity = %+v, want the payload's GitHub fields verbatim", got)
+	}
+}
+
+// TestIdentitySetIssuesAndValidate covers the coherence checks: a token-only
+// hive is silent, a coherent GHE set is clean, and each inconsistency (GHE slug
+// on a public api_url; base/api forge mismatch both directions) is named.
+// ValidateIdentityPush wraps the same checks into a refusal string.
+func TestIdentitySetIssuesAndValidate(t *testing.T) {
+	// No App configured → no issues, and a safe (empty) push verdict.
+	if got := IdentitySetIssues(IdentitySet{}); got != nil {
+		t.Errorf("token-only hive should have no identity issues, got %v", got)
+	}
+	if got := ValidateIdentityPush(IdentitySet{}); got != "" {
+		t.Errorf("token-only push should be safe, got %q", got)
+	}
+
+	// A coherent GHE identity is clean.
+	ghe := IdentitySet{AppID: 5686, AppSlug: "kubestellar-hive-ghe", APIURL: "https://github.ibm.com/api/v3", BaseURL: "https://github.ibm.com"}
+	if !ghe.IsGHE() {
+		t.Error("GHE api_url must read as GHE")
+	}
+	if got := IdentitySetIssues(ghe); got != nil {
+		t.Errorf("coherent GHE identity should be clean, got %v", got)
+	}
+
+	// GHE slug presented to public api.github.com (empty api_url) — the live
+	// regression. ValidateIdentityPush must refuse.
+	badSlug := IdentitySet{AppID: 5686, AppSlug: "kubestellar-hive-ghe", APIURL: ""}
+	issues := IdentitySetIssues(badSlug)
+	if len(issues) == 0 || !strings.Contains(issues[0], "404") {
+		t.Errorf("GHE slug on empty api_url must be flagged (404), got %v", issues)
+	}
+	if v := ValidateIdentityPush(badSlug); !strings.Contains(v, "refusing") {
+		t.Errorf("inconsistent identity must be refused, got %q", v)
+	}
+
+	// base_url is GHE but api_url is public — a stale-base mismatch.
+	baseGHE := IdentitySet{AppID: 3568013, APIURL: "https://api.github.com", BaseURL: "https://github.ibm.com"}
+	if got := IdentitySetIssues(baseGHE); len(got) == 0 {
+		t.Error("base GHE / api public mismatch must be flagged")
+	}
+	// api_url is GHE but base_url is public — the reverse mismatch.
+	apiGHE := IdentitySet{AppID: 5686, APIURL: "https://github.ibm.com/api/v3", BaseURL: "https://github.com"}
+	if got := IdentitySetIssues(apiGHE); len(got) == 0 {
+		t.Error("api GHE / base public mismatch must be flagged")
+	}
+}

--- a/v2/pkg/hub/identity_url_helpers_test.go
+++ b/v2/pkg/hub/identity_url_helpers_test.go
@@ -1,0 +1,162 @@
+package hub
+
+import (
+	"log/slog"
+	"strconv"
+	"testing"
+)
+
+// TestAppIDString covers HiveIdentity.AppIDString, which renders the resolved
+// app_id for the provisioning template. A zero AppID must render as "" (so an
+// unknown App stays unset rather than becoming a literal "0" that fails auth),
+// and any non-zero AppID renders as its base-10 string.
+func TestAppIDString(t *testing.T) {
+	cases := []struct {
+		name  string
+		appID int64
+		want  string
+	}{
+		{"zero renders empty so the App stays unset", 0, ""},
+		{"positive App ID renders as base-10", 123456, "123456"},
+		{"single digit", 7, "7"},
+		{"large App ID", 9876543210, strconv.FormatInt(9876543210, 10)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id := HiveIdentity{AppID: tc.appID}
+			if got := id.AppIDString(); got != tc.want {
+				t.Errorf("AppIDString() with AppID=%d = %q, want %q", tc.appID, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClusterAPIURLForIdentity covers clusterAPIURLForIdentity: it returns the
+// cluster's GitHubAPIURL trimmed of surrounding whitespace, and an empty string
+// for an unknown cluster or one that declares no API URL. The caller reads an
+// empty string as "no forge declared" and skips the hub-side guard entirely.
+func TestClusterAPIURLForIdentity(t *testing.T) {
+	s := &HubServer{
+		logger: slog.Default(),
+		clusters: map[string]ClusterConfig{
+			"pok-prod":   {ID: "pok-prod", GitHubAPIURL: "https://api.github.com"},
+			"padded":     {ID: "padded", GitHubAPIURL: "  https://ghe.example/api/v3  "},
+			"no-api-url": {ID: "no-api-url"},
+		},
+	}
+	cases := []struct {
+		name      string
+		clusterID string
+		want      string
+	}{
+		{"known cluster returns its API URL", "pok-prod", "https://api.github.com"},
+		{"surrounding whitespace is trimmed", "padded", "https://ghe.example/api/v3"},
+		{"declared but empty yields empty", "no-api-url", ""},
+		{"unknown cluster yields empty", "does-not-exist", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clusterAPIURLForIdentity(s, tc.clusterID); got != tc.want {
+				t.Errorf("clusterAPIURLForIdentity(%q) = %q, want %q", tc.clusterID, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClusterForgeHost covers clusterForgeHost, which names the forge a cluster
+// defaults to. A nil cluster and a cluster that declares neither URL both fall
+// back to public github.com; otherwise the base URL wins over the API URL, each
+// normalised to a bare host by forgeHostLabel.
+func TestClusterForgeHost(t *testing.T) {
+	cases := []struct {
+		name string
+		c    *ClusterConfig
+		want string
+	}{
+		{"nil cluster falls back to public", nil, publicForgeHost},
+		{"no URLs declared falls back to public", &ClusterConfig{ID: "bare"}, publicForgeHost},
+		{
+			"base URL wins and is normalised to a bare host",
+			&ClusterConfig{GitHubBaseURL: "https://github.ibm.com", GitHubAPIURL: "https://api.other.example"},
+			"github.ibm.com",
+		},
+		{
+			"API URL used when no base URL, path stripped",
+			&ClusterConfig{GitHubAPIURL: "https://github.ibm.com/api/v3"},
+			"github.ibm.com",
+		},
+		{
+			"public API URL normalises to github.com",
+			&ClusterConfig{GitHubAPIURL: "https://api.github.com"},
+			publicForgeHost,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clusterForgeHost(tc.c); got != tc.want {
+				t.Errorf("clusterForgeHost() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSanitizeRepoEntry covers sanitizeRepoEntry, which normalises a
+// user-entered repo string to bare owner/repo: it trims whitespace, strips an
+// http(s):// scheme, surrounding slashes and a trailing .git, drops a leading
+// hostname, and keeps only the final two path segments.
+func TestSanitizeRepoEntry(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty stays empty", "", ""},
+		{"whitespace-only stays empty", "   ", ""},
+		{"plain owner/repo is unchanged", "kubestellar/hive", "kubestellar/hive"},
+		{"https scheme is stripped", "https://github.com/kubestellar/hive", "kubestellar/hive"},
+		{"http scheme is stripped", "http://github.com/kubestellar/hive", "kubestellar/hive"},
+		{"trailing .git is removed", "kubestellar/hive.git", "kubestellar/hive"},
+		{"surrounding slashes are trimmed", "/kubestellar/hive/", "kubestellar/hive"},
+		{"leading GHE hostname is dropped", "github.ibm.com/org/repo", "org/repo"},
+		{"deep path keeps only last two segments", "github.com/a/b/c/d", "c/d"},
+		{"whitespace and scheme together", "  https://github.com/kubestellar/hive.git  ", "kubestellar/hive"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeRepoEntry(tc.in); got != tc.want {
+				t.Errorf("sanitizeRepoEntry(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClusterBaseURLForIdentity covers clusterBaseURLForIdentity: it returns the
+// cluster's GitHubBaseURL trimmed of surrounding whitespace, and an empty string
+// for an unknown cluster or one that declares no base URL.
+func TestClusterBaseURLForIdentity(t *testing.T) {
+	s := &HubServer{
+		logger: slog.Default(),
+		clusters: map[string]ClusterConfig{
+			"ghe":         {ID: "ghe", GitHubBaseURL: "https://ghe.example"},
+			"padded":      {ID: "padded", GitHubBaseURL: "\thttps://ghe.example \n"},
+			"no-base-url": {ID: "no-base-url"},
+		},
+	}
+	cases := []struct {
+		name      string
+		clusterID string
+		want      string
+	}{
+		{"known cluster returns its base URL", "ghe", "https://ghe.example"},
+		{"surrounding whitespace is trimmed", "padded", "https://ghe.example"},
+		{"declared but empty yields empty", "no-base-url", ""},
+		{"unknown cluster yields empty", "does-not-exist", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clusterBaseURLForIdentity(s, tc.clusterID); got != tc.want {
+				t.Errorf("clusterBaseURLForIdentity(%q) = %q, want %q", tc.clusterID, got, tc.want)
+			}
+		})
+	}
+}

--- a/v2/pkg/hub/pure_helpers_coverage_test.go
+++ b/v2/pkg/hub/pure_helpers_coverage_test.go
@@ -1,0 +1,63 @@
+package hub
+
+import "testing"
+
+// TestClusterGitHubConfigPure covers the nil cluster and the base-or-api mapping.
+func TestClusterGitHubConfigPure(t *testing.T) {
+	// nil → an empty config (no base/api/slug).
+	if got := clusterGitHubConfig(nil); got.BaseURL != "" || got.APIURL != "" || got.AppSlug != "" {
+		t.Errorf("nil cluster = %+v, want zero config", got)
+	}
+	c := &ClusterConfig{GitHubBaseURL: "", GitHubAPIURL: "https://github.ibm.com/api/v3", GitHubAppSlug: "kubestellar-hive-ghe"}
+	gh := clusterGitHubConfig(c)
+	if gh.APIURL != "https://github.ibm.com/api/v3" || gh.AppSlug != "kubestellar-hive-ghe" || gh.BaseURL != "" {
+		t.Errorf("mapping = %+v, want api_url + slug carried, base empty", gh)
+	}
+	// A GHE cluster recorded with only an api_url must still read as GHE.
+	if !gh.IsGHE() {
+		t.Error("api-only GHE cluster config must be GHE")
+	}
+}
+
+// TestHealthStatusOfPure covers all three branches of the classifier.
+func TestHealthStatusOfPure(t *testing.T) {
+	if got := healthStatusOf(nil); got != "unknown" {
+		t.Errorf("nil health = %q, want unknown", got)
+	}
+	if got := healthStatusOf(map[string]any{}); got != "unknown" {
+		t.Errorf("no status key = %q, want unknown", got)
+	}
+	if got := healthStatusOf(map[string]any{"status": ""}); got != "unknown" {
+		t.Errorf("empty status = %q, want unknown", got)
+	}
+	if got := healthStatusOf(map[string]any{"status": 42}); got != "unknown" {
+		t.Errorf("non-string status = %q, want unknown", got)
+	}
+	if got := healthStatusOf(map[string]any{"status": "degraded"}); got != "degraded" {
+		t.Errorf("status = %q, want degraded", got)
+	}
+}
+
+// TestNormalizeHiveForgePure covers the nil guard, a GHE-override hive (host set
+// + URL overrides cleared), a public hive (no change), and idempotence.
+func TestNormalizeHiveForgePure(t *testing.T) {
+	if normalizeHiveForge(nil, nil) {
+		t.Error("nil hive must report no change")
+	}
+	// GHE override on a hive: host gets set to the elected GHE host and the URL
+	// overrides are cleared.
+	h := &SaaSHive{GitHubBaseURL: "https://github.ibm.com", GitHubAPIURL: "https://github.ibm.com/api/v3"}
+	if !normalizeHiveForge(h, nil) {
+		t.Fatal("a GHE-override hive must report a change")
+	}
+	if h.GitHubHost != "github.ibm.com" {
+		t.Errorf("GitHubHost = %q, want github.ibm.com", h.GitHubHost)
+	}
+	if h.GitHubBaseURL != "" || h.GitHubAPIURL != "" {
+		t.Errorf("URL overrides not cleared: base=%q api=%q", h.GitHubBaseURL, h.GitHubAPIURL)
+	}
+	// Second pass is idempotent — nothing left to change.
+	if normalizeHiveForge(h, nil) {
+		t.Error("normalizeHiveForge must be idempotent on a settled hive")
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4533,6 +4533,14 @@ type HiveAccessEntry struct {
 	FullName string `json:"full_name,omitempty"`
 	SlackID  string `json:"slack_id,omitempty"`
 	Notes    string `json:"notes,omitempty"`
+	// Engagement stats copied from the user's record so a co-member's My-Hives
+	// avatar hover can show the same logins / time-in-hive the admin Users card
+	// shows. Like Notes these are stats ABOUT a person, so they ride ONLY for a
+	// hub admin (accessForHive's includeAdminOnly gate) — a non-admin owner sees
+	// name/Slack but not another member's engagement numbers. omitempty so a user
+	// with no stats round-trips as today's handle — role tooltip.
+	LoginCount     int   `json:"login_count,omitempty"`
+	SessionSeconds int64 `json:"session_seconds,omitempty"`
 }
 
 // accessForHive returns who can sign in to a hive, newest-role-agnostic and
@@ -4540,10 +4548,11 @@ type HiveAccessEntry struct {
 // than reading h.Owner: a user's Hives map is the authoritative grant (see
 // handleApproveProvision / handleAssignHive, which write it), and an owner who
 // is missing from it genuinely cannot sign in.
-// includeNotes controls whether the admin-maintained Notes field is copied onto
-// each entry: pass true ONLY for a hub admin. FullName/SlackID always ride (they
-// identify the person to a co-owner); Notes is private admin CRM text.
-func accessForHive(hiveID string, users []SaaSUser, includeNotes bool) []HiveAccessEntry {
+// includeAdminOnly controls whether the admin-only fields — the CRM Notes and
+// the engagement stats (LoginCount/SessionSeconds) — are copied onto each entry:
+// pass true ONLY for a hub admin. FullName/SlackID always ride (they identify the
+// person to a co-owner); Notes and the stats are private to admins.
+func accessForHive(hiveID string, users []SaaSUser, includeAdminOnly bool) []HiveAccessEntry {
 	access := make([]HiveAccessEntry, 0)
 	for _, u := range users {
 		if role, ok := u.Hives[hiveID]; ok {
@@ -4553,8 +4562,10 @@ func accessForHive(hiveID string, users []SaaSUser, includeNotes bool) []HiveAcc
 				FullName: u.FullName,
 				SlackID:  u.SlackID,
 			}
-			if includeNotes {
+			if includeAdminOnly {
 				entry.Notes = u.Notes
+				entry.LoginCount = u.LoginCount
+				entry.SessionSeconds = u.SessionSeconds
 			}
 			access = append(access, entry)
 		}
@@ -7362,8 +7373,14 @@ const dashboardHTML = `<!DOCTYPE html>
     function avatarProfileLink(username, label, avatarHTML) {
       var uname = String(username || '');
       if (!uname) return avatarHTML;
+      // Fold "logged into their hive now" into the anchor's OWN tooltip for every
+      // avatar surface, so a live user's face reads identity (+ stats) AND the
+      // live state in one tooltip. The green ring wrapper deliberately carries no
+      // title of its own — a wrapper title would sit on top of this and hide it.
+      var title = label || uname;
+      if (isUserLive(uname)) title = title + '\n● Logged into their hive now';
       return '<a href="' + escAttr(ghProfileURL(uname)) + '" target="_blank" rel="noopener noreferrer" ' +
-        'title="' + escAttr(label || uname) + '" aria-label="' + escAttr(label || uname) + '" ' +
+        'title="' + escAttr(title) + '" aria-label="' + escAttr(label || uname) + '" ' +
         'style="display:inline-block;line-height:0;text-decoration:none">' + avatarHTML + '</a>';
     }
 
@@ -7389,11 +7406,17 @@ const dashboardHTML = `<!DOCTYPE html>
         (extraStyle || '') + '" ' +
         'onerror="this.style.visibility=\'hidden\'">';
       if (isUserLive(username)) {
-        // 3px green dashed ring hugging the circle. inline-flex wrapper keeps the
-        // face's vertical-align and sizing identical to the un-ringed case.
-        return '<span title="Logged into their hive now" ' +
-          'style="display:inline-flex;border-radius:50%;padding:1px;border:3px dashed var(--green);vertical-align:middle;line-height:0">' +
-          img + '</span>';
+        // Concentric green dashed ring. The wrapper is a fixed square exactly the
+        // face's size plus the ring gap+width on every side (px + 2*(gap+border)),
+        // with box-sizing:border-box and the ring drawn as its border, so the
+        // round border-radius stays perfectly centered on the round face — the
+        // earlier padding:1px inline-flex version drifted off-center. No title on
+        // the wrapper: the "logged in now" line lives in the face's OWN tooltip
+        // (accessAvatarTitle) so a wrapper title can't shadow the identity+stats.
+        var RING_GAP = 2, RING_W = 3, box = px + 2 * (RING_GAP + RING_W);
+        return '<span style="display:inline-block;box-sizing:border-box;width:' + box + 'px;height:' + box + 'px;' +
+          'padding:' + RING_GAP + 'px;border:' + RING_W + 'px dashed var(--green);border-radius:50%;' +
+          'vertical-align:middle;line-height:0">' + img + '</span>';
       }
       return img;
     }
@@ -7667,13 +7690,39 @@ const dashboardHTML = `<!DOCTYPE html>
        invariant. The server only populates these fields for owner/admin-visible
        rows and withholds notes from non-admins, so nothing here needs to re-gate
        them — a field that is absent simply produces no line. */
+    /* accessAvatarTitle builds the NATIVE multi-line tooltip for a co-member face.
+       It deliberately stays a title attribute (never a hive-access-pop custom
+       panel — see TestInlineAvatarsCarryNoCustomPanel; the status dot owns the
+       row's one panel). It carries the same engagement info the admin Users card
+       shows — identity, logins, time-in-hive, task activity, and the verdict — so
+       who-to-elevate/help reads on hover anywhere a face appears. The stat lines
+       are admin-only (accessForHive only fills login_count/session_seconds for an
+       admin) and each line is conditional, so a stat-less user degrades to today's
+       "handle — role". Newlines render as line breaks in a native title. */
     function accessAvatarTitle(a) {
       var uname = String(a.username || '');
       var role = String(a.role || '');
       var lines = [uname + (role ? ' — ' + role : '')];
+      // ("Logged into their hive now" is appended generically in avatarProfileLink
+      // for EVERY avatar surface, so it is not added here — doing both would
+      // double the line.)
       if (a.full_name) lines.push(String(a.full_name));
       if (a.slack_id) lines.push('Slack: ' + String(a.slack_id));
       if (a.notes) lines.push('Notes: ' + String(a.notes));
+      // Engagement stats (admin-only; absent → these lines are simply skipped).
+      if (a.login_count) lines.push('Logins: ' + a.login_count);
+      if (a.session_seconds) lines.push('Time in hive: ' + fmtHours(a.session_seconds));
+      var act = userTaskActivity(uname);
+      if (act.done || act.failed) lines.push('Tasks: ' + act.done + ' done / ' + act.failed + ' failed');
+      // The lifecycle verdict, from the same helper the admin card uses. It reads
+      // logins/time/tasks; a co-member's hive-journey list isn't on the access
+      // entry so pass empty — the verdict still classifies from engagement, only
+      // the ACMM-graduation refinement is unavailable here. Shown only when there
+      // is some signal to classify (any stat present), so a bare face stays bare.
+      if (a.login_count || a.session_seconds || act.done) {
+        var verdict = userVerdict({login_count: a.login_count || 0, session_seconds: a.session_seconds || 0}, act, []);
+        if (verdict && verdict.label) lines.push(verdict.label);
+      }
       return lines.join('\n');
     }
     function inlineAccessAvatar(a) {


### PR DESCRIPTION
## My-Hives co-member avatars: full engagement stats on hover + fix the live ring

The admin **Users** engagement card (#2395) shows logins / time-in-hive / task activity / verdict on hover of a user's name. But the same people appear as small **co-member avatar faces** on My Hives rows, where the hover showed only `handle — role`. This brings the same engagement info to those faces, and fixes two live-ring bugs that shipped with #2395.

- **Stats on hover** — `accessAvatarTitle` now appends `Logins`, `Time in hive`, `Tasks D/F`, and the lifecycle verdict, reusing the same `userTaskActivity` / `userVerdict` / `fmtHours` helpers as the admin card. It stays a **native multi-line title** — never a `hive-access-pop` custom panel — so the single-hover-panel invariant (`TestInlineAvatarsCarryNoCustomPanel`) holds (the status dot still owns the row's one panel). Each line is conditional, so a stat-less user degrades to today's tooltip.
- **Admin-gated** — `HiveAccessEntry` carries `login_count` / `session_seconds`, filled by `accessForHive` only for a hub admin (same gate as Notes). A non-admin owner sees name/Slack but not another member's stats.
- **Concentric ring** — the green "logged in now" dashed ring was slightly off-center (a `padding:1px` inline-flex wrapper). Now a fixed square `box-sizing:border-box` wrapper sized to the face + ring, so it's perfectly centered.
- **No more shadowed tooltip** — the ring wrapper's own `title="Logged into their hive now"` was hiding the enriched tooltip on a live user. Removed; the live line now folds into the avatar's **own** tooltip via `avatarProfileLink`, so identity + stats + the live line show together — on every avatar surface.

### Testing
`go build ./...`; `go test ./pkg/hub/` green. Tests: stats ride for admin / scrubbed for non-admin; the tooltip carries the stat lines + verdict + the live line; the ring wrapper no longer hard-codes the shadowing title; the panel invariant still passes. JS validated with `node --check`.

Follows #2395. Based on current v2 (f8d15dcf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
