### PR TITLE
feat(hub): contribute_skip_assigned_to_others toggle (Fixes #2357)

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1789,19 +1789,25 @@ type HubConfig struct {
 	// filter regardless of mode (names kept for backward compatibility with
 	// existing on-disk config; the mode decides allow vs deny). ContributeAllowLabels
 	// is retained only for one-time migration into DenyLabels+LabelsMode.
-	ContributeTitlesMode          string              `yaml:"contribute_titles_mode,omitempty"`
-	ContributeAuthorsMode         string              `yaml:"contribute_authors_mode,omitempty"`
-	ContributeLabelsMode          string              `yaml:"contribute_labels_mode,omitempty"`
-	ContributeAllowLabels         []string            `yaml:"contribute_allow_labels"`
-	ContributeDenyLabels          []string            `yaml:"contribute_deny_labels"`
-	ContributeDenyTitles          []string            `yaml:"contribute_deny_titles"`
-	ContributeDenyAuthors         []string            `yaml:"contribute_deny_authors"`
-	ContributeAllowModels         []string            `yaml:"contribute_allow_models"`
-	ContributeRejectUnknownModels bool                `yaml:"contribute_reject_unknown_models"`
-	DisabledRepos                 []string            `yaml:"disabled_repos"`
-	DisabledTiers                 []string            `yaml:"disabled_tiers"`
-	TierLimits                    map[string]TierRate `yaml:"tier_limits"`
-	SnapshotIntervalMin           int                 `yaml:"snapshot_interval_min"`
+	ContributeTitlesMode          string   `yaml:"contribute_titles_mode,omitempty"`
+	ContributeAuthorsMode         string   `yaml:"contribute_authors_mode,omitempty"`
+	ContributeLabelsMode          string   `yaml:"contribute_labels_mode,omitempty"`
+	ContributeAllowLabels         []string `yaml:"contribute_allow_labels"`
+	ContributeDenyLabels          []string `yaml:"contribute_deny_labels"`
+	ContributeDenyTitles          []string `yaml:"contribute_deny_titles"`
+	ContributeDenyAuthors         []string `yaml:"contribute_deny_authors"`
+	ContributeAllowModels         []string `yaml:"contribute_allow_models"`
+	ContributeRejectUnknownModels bool     `yaml:"contribute_reject_unknown_models"`
+	// ContributeSkipAssignedToOthers, when true, makes the /contribute queue
+	// skip any issue that is already assigned to someone OTHER than the
+	// contributor requesting work. An issue assigned to the contributor
+	// themselves (or unassigned) is still eligible. Default false preserves the
+	// prior behavior of handing out issues regardless of assignment (#2357).
+	ContributeSkipAssignedToOthers bool                `yaml:"contribute_skip_assigned_to_others"`
+	DisabledRepos                  []string            `yaml:"disabled_repos"`
+	DisabledTiers                  []string            `yaml:"disabled_tiers"`
+	TierLimits                     map[string]TierRate `yaml:"tier_limits"`
+	SnapshotIntervalMin            int                 `yaml:"snapshot_interval_min"`
 }
 
 type TierRate struct {

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -867,6 +867,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 			url, _ := issue["url"].(string)
 			author, _ := issue["author"].(string)
 			labels := stringSliceFromAny(issue["labels"])
+			assignees := stringSliceFromAny(issue["assignees"])
 
 			// Apply the title / author / label contribute filters. Each is a
 			// single list plus a mode (allow = only matching pass; deny = matching
@@ -876,6 +877,14 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				if !config.FilterPasses(title, hub.ContributeDenyTitles, hub.ContributeTitlesMode) ||
 					!config.FilterPasses(author, hub.ContributeDenyAuthors, hub.ContributeAuthorsMode) ||
 					!config.LabelsFilterPasses(labels, hub.ContributeDenyLabels, hub.ContributeLabelsMode) {
+					continue
+				}
+				// #2357: optionally skip issues already assigned to someone else.
+				// An issue assigned to the contributor themselves (or unassigned)
+				// stays eligible; only issues assigned solely to OTHER users are
+				// skipped when the toggle is on.
+				if hub.ContributeSkipAssignedToOthers &&
+					assignedToOthers(assignees, c.profile.GitHubUsername) {
 					continue
 				}
 			}
@@ -938,6 +947,23 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	}
 
 	return nil
+}
+
+// assignedToOthers reports whether an issue is assigned to at least one user
+// AND none of its assignees is the given contributor. An unassigned issue
+// (empty list) returns false, and an issue assigned to the contributor
+// themselves returns false, so both remain eligible for pickup (#2357). The
+// username comparison is case-insensitive to match GitHub login semantics.
+func assignedToOthers(assignees []string, username string) bool {
+	if len(assignees) == 0 {
+		return false
+	}
+	for _, a := range assignees {
+		if strings.EqualFold(a, username) {
+			return false
+		}
+	}
+	return true
 }
 
 // stringSliceFromAny coerces a JSON-decoded value (from an issue map marshaled

--- a/v2/pkg/dashboard/contribute_ws_assigned_test.go
+++ b/v2/pkg/dashboard/contribute_ws_assigned_test.go
@@ -1,0 +1,31 @@
+package dashboard
+
+import "testing"
+
+// TestAssignedToOthers exercises the #2357 skip-assigned guard: an issue is
+// skipped only when it has assignees and none of them is the contributor.
+func TestAssignedToOthers(t *testing.T) {
+	const me = "octocat"
+
+	cases := []struct {
+		name      string
+		assignees []string
+		want      bool
+	}{
+		{"unassigned nil", nil, false},
+		{"unassigned empty", []string{}, false},
+		{"assigned to someone else", []string{"alice"}, true},
+		{"assigned to multiple others", []string{"alice", "bob"}, true},
+		{"assigned to me only", []string{me}, false},
+		{"assigned to me and others", []string{"alice", me}, false},
+		{"assigned to me case-insensitive", []string{"OctoCat"}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := assignedToOthers(tc.assignees, me); got != tc.want {
+				t.Errorf("assignedToOthers(%v, %q) = %v, want %v", tc.assignees, me, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Opt-in `contribute_skip_assigned_to_others` (default off) so the /contribute queue skips issues already assigned to someone else. An issue assigned to the contributor themselves is never skipped (case-insensitive). Reuses the assignees already collected in actionable.json. Unit-tested. Fixes #2357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)