### PR TITLE
fix(spoke): persist fleet-stat counts on the PVC so a restart resumes (Fixes #2329)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1316,6 +1316,12 @@ func main() {
 			"author", fleetStatsAuthor, "org", cfg.Project.Org)
 	}
 	fleetStatsCollector := dashboard.NewFleetStatsCollector(ghClient, fleetStatsAuthor, cfg.Project.Org, logger)
+	// Persist the collected counts on the /data PVC (same store as sessions and
+	// cost/fact history) so a restart resumes from the last-known counts instead
+	// of nil. Without this, a fleet-wide upgrade clears every spoke's in-memory
+	// counts and the public landing-page total collapses until all spokes
+	// re-collect (#2329, building on the hub-side #2328 defensive aging fix).
+	fleetStatsCollector.EnablePersistence("/data/fleet-stats.json")
 	go fleetStatsCollector.Start(ctx)
 
 	var lastActionable atomic.Pointer[github.ActionableResult]

--- a/v2/pkg/dashboard/fleet_stats_collector.go
+++ b/v2/pkg/dashboard/fleet_stats_collector.go
@@ -2,8 +2,10 @@ package dashboard
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"math/rand"
+	"os"
 	"sync"
 	"time"
 
@@ -64,6 +66,21 @@ type FleetStatsCollector struct {
 	// collect that has since started failing, and surface the difference rather
 	// than presenting stale numbers as current.
 	collectedAt time.Time
+
+	// persistPath is where the last successful collect is mirrored on the spoke
+	// PVC so a restart resumes from the last-known counts instead of nil. Empty
+	// disables persistence (the collector is purely in-memory). See #2329.
+	persistPath string
+}
+
+// persistedFleetStats is the on-disk shape written to persistPath. It carries
+// the raw counts plus the REAL collect time — never re-stamped to now — so the
+// hub's fleetStatsMaxAge aging still applies to counts restored after a
+// restart. A spoke that has been down long enough for its last collect to age
+// out is aged out on the hub exactly as if it had never re-collected.
+type persistedFleetStats struct {
+	Counts      ghpkg.FleetContribCounts `json:"counts"`
+	CollectedAt time.Time                `json:"collected_at"`
 }
 
 // NewFleetStatsCollector builds a collector for the given AI author and org.
@@ -76,6 +93,88 @@ func NewFleetStatsCollector(ghClient *ghpkg.Client, author, org string, logger *
 		author:   author,
 		org:      org,
 		logger:   logger,
+	}
+}
+
+// EnablePersistence makes the collected fleet-stat counts survive a process
+// restart by mirroring each successful collect to path on the spoke PVC, and by
+// loading whatever is already there NOW so the first heartbeat after a restart
+// reports the last-known counts (with their real collectedAt) instead of nil.
+// Without this the counts live only in memory: a mass restart clears them and
+// the public fleet total collapses until every spoke re-collects (#2329). The
+// hub already keeps + ages the last value it saw (#2328); this stops the spoke
+// from forgetting in the first place. Call once at startup before Start.
+//
+// A missing file is a clean no-op (first boot). A corrupt file is logged and
+// ignored — a restart that resumes from nothing is no worse than today.
+func (fc *FleetStatsCollector) EnablePersistence(path string) {
+	if fc == nil {
+		return
+	}
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	fc.persistPath = path
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) && fc.logger != nil {
+			fc.logger.Warn("fleet stats store unreadable — starting with no restored counts",
+				"path", path, "error", err)
+		}
+		return
+	}
+	var stored persistedFleetStats
+	if err := json.Unmarshal(data, &stored); err != nil {
+		if fc.logger != nil {
+			fc.logger.Warn("fleet stats store corrupt — starting with no restored counts",
+				"path", path, "error", err)
+		}
+		return
+	}
+	// A zero collectedAt means the file never held a real collect; treat it as
+	// absent rather than reporting counts the hub would immediately age out
+	// against a zero timestamp.
+	if stored.CollectedAt.IsZero() {
+		return
+	}
+	fc.counts = stored.Counts
+	fc.collectedAt = stored.CollectedAt
+	fc.ready = true
+	if fc.logger != nil {
+		fc.logger.Info("restored fleet stats from PVC",
+			"prs_merged", stored.Counts.PRsMerged,
+			"prs_rejected", stored.Counts.PRsRejected,
+			"cves_closed", stored.Counts.CVEsClosed,
+			"collected_at", stored.CollectedAt.Format(time.RFC3339),
+			"path", path)
+	}
+}
+
+// persistLocked mirrors the current counts + collectedAt to persistPath, if
+// persistence is enabled. Callers must hold mu. The file is a single tiny
+// record, so a full atomic rewrite (tmp + rename, mirroring the session store)
+// per collect is cheaper than anything incremental. 0600: the counts are not
+// secret, but this keeps every PVC-persisted dashboard file in one trust domain.
+func (fc *FleetStatsCollector) persistLocked() {
+	if fc.persistPath == "" {
+		return
+	}
+	data, err := json.Marshal(persistedFleetStats{
+		Counts:      fc.counts,
+		CollectedAt: fc.collectedAt,
+	})
+	if err != nil {
+		return
+	}
+	tmp := fc.persistPath + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		if fc.logger != nil {
+			fc.logger.Warn("failed to write fleet stats store", "path", fc.persistPath, "error", err)
+		}
+		return
+	}
+	if err := os.Rename(tmp, fc.persistPath); err != nil && fc.logger != nil {
+		fc.logger.Warn("failed to replace fleet stats store", "path", fc.persistPath, "error", err)
 	}
 }
 
@@ -136,6 +235,9 @@ func (fc *FleetStatsCollector) collect(ctx context.Context) {
 			fc.counts = counts
 			fc.ready = true
 			fc.collectedAt = time.Now()
+			// Mirror to the PVC while holding mu so a restart resumes from this
+			// exact collect (with its real timestamp) instead of nil (#2329).
+			fc.persistLocked()
 			fc.mu.Unlock()
 			if fc.logger != nil {
 				fc.logger.Info("fleet stats collected",

--- a/v2/pkg/dashboard/fleet_stats_collector_test.go
+++ b/v2/pkg/dashboard/fleet_stats_collector_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -234,6 +236,93 @@ func TestFleetStatsCollector_RetriesThenSucceeds(t *testing.T) {
 	}
 	if fc.CollectedAt().IsZero() {
 		t.Error("CollectedAt must be set after a successful collect")
+	}
+}
+
+// TestFleetStatsCollector_PersistAndReload is the #2329 durability guard: a
+// successful collect must be written to the PVC, and a FRESH collector must load
+// those exact counts on start — with the ORIGINAL collectedAt, never restamped
+// to now — so a spoke restart resumes from its last-known counts (which the
+// hub's fleetStatsMaxAge aging can still evaluate) instead of nil.
+func TestFleetStatsCollector_PersistAndReload(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fleet-stats.json")
+
+	c := newFleetTestClient(t, map[string]int{
+		"is:merged merged:>=":             20,
+		"is:closed is:unmerged closed:>=": 3,
+		`"CVE-"`:                          6,
+	})
+	fc := NewFleetStatsCollector(c, "bot", "org", slog.Default())
+	fc.EnablePersistence(path) // no file yet: clean no-op, stays not-ready
+	if _, ready := fc.Snapshot(); ready {
+		t.Fatal("collector should be not-ready before any collect (missing file is a no-op)")
+	}
+	fc.collect(context.Background())
+	want, ready := fc.Snapshot()
+	if !ready {
+		t.Fatal("collector should be ready after collect")
+	}
+	origCollectedAt := fc.CollectedAt()
+	if origCollectedAt.IsZero() {
+		t.Fatal("collectedAt must be set after a successful collect")
+	}
+
+	// The file must now exist on the PVC.
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected fleet stats file at %s: %v", path, err)
+	}
+
+	// A fresh collector (simulating a restart) must resume from the file WITHOUT
+	// any collect, reporting the same counts and the same collectedAt.
+	fresh := NewFleetStatsCollector(nil, "bot", "org", slog.Default())
+	fresh.EnablePersistence(path)
+	got, ready := fresh.Snapshot()
+	if !ready {
+		t.Fatal("fresh collector should be ready after loading persisted counts")
+	}
+	if got != want {
+		t.Errorf("restored counts = %+v, want %+v", got, want)
+	}
+	if !fresh.CollectedAt().Equal(origCollectedAt) {
+		t.Errorf("restored collectedAt = %v, want original %v (must not be restamped)",
+			fresh.CollectedAt(), origCollectedAt)
+	}
+}
+
+// TestFleetStatsCollector_LoadCorruptOrMissing confirms a missing file and a
+// corrupt file both load cleanly as not-ready (zero counts), never a panic and
+// never a fake zero contribution.
+func TestFleetStatsCollector_LoadCorruptOrMissing(t *testing.T) {
+	// Missing file.
+	missing := filepath.Join(t.TempDir(), "does-not-exist.json")
+	fc := NewFleetStatsCollector(nil, "bot", "org", slog.Default())
+	fc.EnablePersistence(missing)
+	if _, ready := fc.Snapshot(); ready {
+		t.Error("missing file should load as not-ready")
+	}
+
+	// Corrupt file.
+	corrupt := filepath.Join(t.TempDir(), "corrupt.json")
+	if err := os.WriteFile(corrupt, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write corrupt file: %v", err)
+	}
+	fc2 := NewFleetStatsCollector(nil, "bot", "org", slog.Default())
+	fc2.EnablePersistence(corrupt)
+	if snap, ready := fc2.Snapshot(); ready || snap != (ghpkg.FleetContribCounts{}) {
+		t.Errorf("corrupt file should load as not-ready/zero, got ready=%v snap=%+v", ready, snap)
+	}
+
+	// A well-formed file with a zero collectedAt is treated as absent — the hub
+	// would otherwise age it out against a zero timestamp.
+	zeroTime := filepath.Join(t.TempDir(), "zero-time.json")
+	blob, _ := json.Marshal(map[string]any{"counts": map[string]int{"prs_merged": 5}})
+	if err := os.WriteFile(zeroTime, blob, 0o600); err != nil {
+		t.Fatalf("write zero-time file: %v", err)
+	}
+	fc3 := NewFleetStatsCollector(nil, "bot", "org", slog.Default())
+	fc3.EnablePersistence(zeroTime)
+	if _, ready := fc3.Snapshot(); ready {
+		t.Error("file with zero collectedAt should load as not-ready")
 	}
 }
 


### PR DESCRIPTION
The defensive fix (#2328) stopped the hub overwriting stored counts with nil, but the spoke still recomputed from GitHub, so coverage dipped after every mass restart. The spoke now persists its collected counts to /data/fleet-stats.json (atomic tmp+rename, mirroring the session store) and loads them on start **preserving the real collectedAt** so the hub's existing aging still applies. A restart now degrades to 'slightly stale' instead of 'absent'. Tested. Fixes #2329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)