### PR TITLE
fix(hub): wire token_refresh so long contributor sessions keep push access (#2393-2)

### DIFF
--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -21,12 +21,21 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/github"
 )
 
 const (
-	wsHeartbeatInterval  = 30 * time.Second
-	wsHeartbeatTimeout   = 90 * time.Second
-	wsTaskTimeout        = 30 * time.Minute
+	wsHeartbeatInterval = 30 * time.Second
+	wsHeartbeatTimeout  = 90 * time.Second
+	wsTaskTimeout       = 30 * time.Minute
+	// wsTokenTTL is how long a minted scoped GitHub token stays valid. It must
+	// match the token_expires_at we advertise to the relay so both sides agree
+	// on when the token dies.
+	wsTokenTTL = 55 * time.Minute
+	// wsTokenRefreshPeriod is how long after minting we proactively re-mint and
+	// push a fresh token to an active task, before wsTokenTTL expires. The gap
+	// (5 min) absorbs clock skew and in-flight gh commands so a long,
+	// human-steered session never silently loses push access. See #2393 item 2.
 	wsTokenRefreshPeriod = 50 * time.Minute
 	wsAuthTimeout        = 30 * time.Second
 	wsMaxMessageSize     = 64 * 1024
@@ -58,7 +67,12 @@ type ContributorConnection struct {
 	currentTask *WSTaskAssign
 	lastPong    time.Time
 	tmuxOutput  []string
-	mu          sync.Mutex
+	// tokenMintedAt is when the scoped GitHub token for currentTask was last
+	// minted. The heartbeat loop uses it to re-mint and push a token_refresh
+	// once wsTokenRefreshPeriod has elapsed, before the token expires. Zero when
+	// no task is active. See #2393 item 2.
+	tokenMintedAt time.Time
+	mu            sync.Mutex
 }
 
 type WSMessage struct {
@@ -441,6 +455,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			contributor.mu.Lock()
 			abandonedTask := contributor.currentTask
 			contributor.currentTask = nil
+			contributor.tokenMintedAt = time.Time{}
 			contributor.mu.Unlock()
 			if abandonedTask != nil {
 				h.logger.Warn("[contribute-ws] task released on disconnect",
@@ -644,6 +659,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				hasTask := contributor.currentTask != nil && contributor.currentTask.TaskID == msg.TaskID
 				completedTask := contributor.currentTask
 				contributor.currentTask = nil
+				contributor.tokenMintedAt = time.Time{}
 				contributor.tmuxOutput = msg.TmuxOutput
 				contributor.mu.Unlock()
 
@@ -682,6 +698,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				contributor.mu.Lock()
 				hasTask := contributor.currentTask != nil && contributor.currentTask.TaskID == msg.TaskID
 				contributor.currentTask = nil
+				contributor.tokenMintedAt = time.Time{}
 				contributor.mu.Unlock()
 
 				if hasTask {
@@ -732,12 +749,86 @@ func (h *ContributeWSHub) heartbeatLoop(c *ContributorConnection) {
 			return
 		}
 
+		h.maybeRefreshToken(c)
+
 		if err := sendJSON(c.ws, WSMessage{Type: "ping", Seq: h.nextSeq()}); err != nil {
 			h.logger.Info("[contribute-ws] heartbeat ping failed, closing", "username", c.profile.GitHubUsername)
 			c.ws.Close()
 			return
 		}
 	}
+}
+
+// maybeRefreshToken re-mints a scoped GitHub token and pushes a token_refresh to
+// the relay once wsTokenRefreshPeriod has elapsed since the current task's token
+// was minted, provided a task is still active. This keeps long, human-steered
+// sessions from silently losing push access when the original token expires at
+// wsTokenTTL. The relay's token_refresh handler consumes github_token +
+// token_expires_at (bin/contributor-relay.sh). See #2393 item 2.
+func (h *ContributeWSHub) maybeRefreshToken(c *ContributorConnection) {
+	tier, due := tokenRefreshDue(c, time.Now())
+	if !due {
+		return
+	}
+
+	tok, err := h.mintScopedToken(tier)
+	if err != nil {
+		h.logger.Warn("[contribute-ws] token refresh: mint failed, will retry next heartbeat",
+			"username", c.profile.GitHubUsername, "tier", tier, "error", err)
+		return
+	}
+	if tok == "" {
+		// No new token available (no App auth / no cache): leave the relay's
+		// existing token in place and try again next heartbeat.
+		return
+	}
+
+	if err := h.sendTokenRefresh(c, tok); err != nil {
+		h.logger.Info("[contribute-ws] token refresh: send failed", "username", c.profile.GitHubUsername, "error", err)
+		return
+	}
+
+	h.logger.Info("[contribute-ws] token refreshed for active task",
+		"username", c.profile.GitHubUsername, "tier", tier)
+}
+
+// tokenRefreshDue reports whether the connection has an active task whose scoped
+// token was minted at least wsTokenRefreshPeriod ago, meaning it is time to
+// re-mint before wsTokenTTL. It returns the trust tier to mint for. Pure and
+// clock-injectable so the timing can be tested without a real clock.
+func tokenRefreshDue(c *ContributorConnection, now time.Time) (tier string, due bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.currentTask == nil || c.tokenMintedAt.IsZero() {
+		return "", false
+	}
+	if now.Sub(c.tokenMintedAt) < wsTokenRefreshPeriod {
+		return "", false
+	}
+	if c.profile != nil {
+		tier = c.profile.TrustTier
+	}
+	return tier, true
+}
+
+// sendTokenRefresh writes a token_refresh message carrying the new token and its
+// expiry, then records the new mint time. The field names (github_token,
+// token_expires_at) match exactly what the relay's token_refresh handler
+// consumes in bin/contributor-relay.sh. See #2393 item 2.
+func (h *ContributeWSHub) sendTokenRefresh(c *ContributorConnection, tok string) error {
+	msg := WSMessage{
+		Type:           "token_refresh",
+		Seq:            h.nextSeq(),
+		GitHubToken:    tok,
+		TokenExpiresAt: time.Now().Add(wsTokenTTL).UTC().Format(time.RFC3339),
+	}
+	if err := sendJSON(c.ws, msg); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.tokenMintedAt = time.Now()
+	c.mu.Unlock()
+	return nil
 }
 
 func (h *ContributeWSHub) checkModelAllowed(model string) (bool, []string) {
@@ -781,6 +872,27 @@ func (h *ContributeWSHub) cleanupLoop() {
 		}
 		h.mu.Unlock()
 	}
+}
+
+// mintScopedToken produces a scoped GitHub token for the given trust tier via
+// the GitHub App auth path, falling back to the on-disk cache when no App auth
+// is configured (dev/single-token deployments). This is the single mint path
+// shared by task_assign and the heartbeat token-refresh, so both advertise
+// tokens minted the same way. See #2393 item 2.
+func (h *ContributeWSHub) mintScopedToken(tier string) (string, error) {
+	if h.server != nil && h.server.deps != nil && h.server.deps.GHAppAuth != nil {
+		ctx := h.server.deps.Ctx
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		return h.server.deps.GHAppAuth.ScopedToken(ctx, tier)
+	}
+	if tokenBytes, err := os.ReadFile(github.TokenCachePath); err == nil {
+		return string(tokenBytes), nil
+	}
+	// No App auth and no cache: mint nothing rather than fail. Callers treat an
+	// empty token as "leave the relay's current token in place".
+	return "", nil
 }
 
 func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
@@ -880,21 +992,11 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				}
 			}
 
-			ghToken := ""
-			if h.server.deps != nil && h.server.deps.GHAppAuth != nil {
-				ctx := h.server.deps.Ctx
-				if ctx == nil {
-					ctx = context.Background()
-				}
-				if tok, err := h.server.deps.GHAppAuth.ScopedToken(ctx, c.profile.TrustTier); err == nil {
-					ghToken = tok
-				} else {
-					h.logger.Warn("[contribute-ws] failed to mint scoped token — skipping task",
-						"tier", c.profile.TrustTier, "error", err)
-					return nil
-				}
-			} else if tokenBytes, err := os.ReadFile("/var/run/hive-metrics/gh-app-token.cache"); err == nil {
-				ghToken = string(tokenBytes)
+			ghToken, err := h.mintScopedToken(c.profile.TrustTier)
+			if err != nil {
+				h.logger.Warn("[contribute-ws] failed to mint scoped token — skipping task",
+					"tier", c.profile.TrustTier, "error", err)
+				return nil
 			}
 
 			taskID := fmt.Sprintf("ct-%s-%d-%d", repo.Full, number, time.Now().Unix())
@@ -918,6 +1020,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				Number: number,
 				Title:  title,
 			}
+			c.tokenMintedAt = time.Now()
 			c.mu.Unlock()
 
 			return &WSMessage{
@@ -930,7 +1033,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				Title:          title,
 				URL:            url,
 				GitHubToken:    ghToken,
-				TokenExpiresAt: time.Now().Add(55 * time.Minute).UTC().Format(time.RFC3339),
+				TokenExpiresAt: time.Now().Add(wsTokenTTL).UTC().Format(time.RFC3339),
 				Prompt:         prompt,
 				ContribLabels:  []string{"contributor/" + c.profile.GitHubUsername},
 			}

--- a/v2/pkg/dashboard/contribute_ws_token_refresh_test.go
+++ b/v2/pkg/dashboard/contribute_ws_token_refresh_test.go
@@ -1,0 +1,168 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// TestTokenRefreshDue covers the timing decision that gates the heartbeat's
+// token re-mint: only an active task whose token was minted at least
+// wsTokenRefreshPeriod ago is due. See #2393 item 2.
+func TestTokenRefreshDue(t *testing.T) {
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		task     *WSTaskAssign
+		mintedAt time.Time
+		now      time.Time
+		wantDue  bool
+		wantTier string
+	}{
+		{
+			name:     "no active task",
+			task:     nil,
+			mintedAt: base,
+			now:      base.Add(wsTokenRefreshPeriod + time.Minute),
+			wantDue:  false,
+		},
+		{
+			name:     "active task but never minted",
+			task:     &WSTaskAssign{TaskID: "t1"},
+			mintedAt: time.Time{},
+			now:      base.Add(time.Hour),
+			wantDue:  false,
+		},
+		{
+			name:     "active task, not yet due",
+			task:     &WSTaskAssign{TaskID: "t1"},
+			mintedAt: base,
+			now:      base.Add(wsTokenRefreshPeriod - time.Minute),
+			wantDue:  false,
+		},
+		{
+			name:     "active task, past refresh period",
+			task:     &WSTaskAssign{TaskID: "t1"},
+			mintedAt: base,
+			now:      base.Add(wsTokenRefreshPeriod + time.Second),
+			wantDue:  true,
+			wantTier: "contributor",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &ContributorConnection{
+				profile:       &ContributorProfile{TrustTier: "contributor"},
+				currentTask:   tc.task,
+				tokenMintedAt: tc.mintedAt,
+			}
+			tier, due := tokenRefreshDue(c, tc.now)
+			if due != tc.wantDue {
+				t.Fatalf("due = %v, want %v", due, tc.wantDue)
+			}
+			if due && tier != tc.wantTier {
+				t.Fatalf("tier = %q, want %q", tier, tc.wantTier)
+			}
+		})
+	}
+
+	// wsTokenRefreshPeriod must leave headroom before wsTokenTTL, or a refresh
+	// would race the expiry it is meant to beat.
+	if wsTokenRefreshPeriod >= wsTokenTTL {
+		t.Fatalf("wsTokenRefreshPeriod (%s) must be < wsTokenTTL (%s)", wsTokenRefreshPeriod, wsTokenTTL)
+	}
+}
+
+// TestSendTokenRefreshShape verifies that a token_refresh emitted for an active
+// task carries github_token + token_expires_at with the exact field names the
+// relay's token_refresh handler consumes (bin/contributor-relay.sh), and that
+// the mint timestamp is advanced so the next refresh is scheduled correctly.
+func TestSendTokenRefreshShape(t *testing.T) {
+	hub := &ContributeWSHub{logger: slog.Default()}
+
+	// Stand up a real websocket pair so sendJSON writes an actual frame the
+	// client can read back and inspect.
+	var serverConn *websocket.Conn
+	connReady := make(chan struct{})
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		serverConn = c
+		close(connReady)
+		// Keep the handler alive so the conn stays open for the read below.
+		time.Sleep(2 * time.Second)
+	}))
+	defer srv.Close()
+
+	client, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+	<-connReady
+
+	before := time.Now()
+	conn := &ContributorConnection{
+		ws:            serverConn,
+		profile:       &ContributorProfile{TrustTier: "contributor", GitHubUsername: "refresh-user"},
+		currentTask:   &WSTaskAssign{TaskID: "t-refresh"},
+		tokenMintedAt: before.Add(-wsTokenRefreshPeriod - time.Minute),
+	}
+
+	const newToken = "ghs_new_scoped_token"
+	if err := hub.sendTokenRefresh(conn, newToken); err != nil {
+		t.Fatalf("sendTokenRefresh: %v", err)
+	}
+
+	client.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, raw, err := client.ReadMessage()
+	if err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+
+	// Decode into a bare map to assert the ON-THE-WIRE field names the relay
+	// reads (msg.github_token / msg.token_expires_at), not the Go struct names.
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if wire["type"] != "token_refresh" {
+		t.Fatalf("type = %v, want token_refresh", wire["type"])
+	}
+	if wire["github_token"] != newToken {
+		t.Fatalf("github_token = %v, want %q", wire["github_token"], newToken)
+	}
+	expStr, ok := wire["token_expires_at"].(string)
+	if !ok || expStr == "" {
+		t.Fatalf("token_expires_at missing/empty: %v", wire["token_expires_at"])
+	}
+	exp, err := time.Parse(time.RFC3339, expStr)
+	if err != nil {
+		t.Fatalf("token_expires_at not RFC3339: %v", err)
+	}
+	// Expiry must be roughly one TTL out from now, i.e. in the future.
+	if !exp.After(before.Add(wsTokenTTL - time.Minute)) {
+		t.Fatalf("token_expires_at %s not ~wsTokenTTL out from %s", exp, before)
+	}
+
+	// The mint timestamp must have advanced so the next refresh is scheduled
+	// off the new token, not the stale one.
+	conn.mu.Lock()
+	minted := conn.tokenMintedAt
+	conn.mu.Unlock()
+	if !minted.After(before.Add(-time.Second)) {
+		t.Fatalf("tokenMintedAt not advanced: %s", minted)
+	}
+}


### PR DESCRIPTION
`wsTokenRefreshPeriod` was declared but never used and the hub never sent `token_refresh`, so a task running past ~55min silently lost push ability — while the relay already had a complete handler for it. Wired the hub to re-mint a scoped token and send `token_refresh` (matching the relay's exact `github_token`/`token_expires_at` fields) on the 50-min ticker while a task is active. Real-websocket test asserts the on-wire shape. Addresses #2393 item 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)