### PR TITLE
feat: task_complete reports pr_url; cooldown conditional on it (#2393-7)

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -356,6 +356,34 @@ function captureTmuxLines(n) {
   }
 }
 
+// Best-effort scan of the agent's recent output for a GitHub pull-request URL
+// it opened for this task. Reported on task_complete as pr_url so the hub can
+// tell "work shipped" from "agent merely went idle" and pick the right issue
+// cooldown (kubestellar/hive#2393 item 7). This is intentionally best-effort:
+// when no PR link is visible we return '' and the hub applies its short no-PR
+// cooldown. When `repo` is known (owner/repo) we prefer a URL under that repo
+// so an unrelated PR mentioned in passing does not get attributed to the task.
+function detectPRURL(lines, repo) {
+  if (!Array.isArray(lines) || lines.length === 0) return '';
+  // Matches https://github.com/<owner>/<repo>/pull/<number>, capturing owner/repo.
+  const PR_URL_RE = /https:\/\/github\.com\/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\/pull\/\d+/g;
+  let repoMatch = '';
+  let anyMatch = '';
+  for (const line of lines) {
+    let m;
+    PR_URL_RE.lastIndex = 0;
+    while ((m = PR_URL_RE.exec(line)) !== null) {
+      const url = m[0];
+      if (!anyMatch) anyMatch = url;
+      if (repo && m[1] === repo) { repoMatch = url; break; }
+    }
+    if (repoMatch) break;
+  }
+  // Prefer a URL under the task's own repo; otherwise fall back to the first
+  // PR URL seen (better an approximate audit trail than none).
+  return repoMatch || anyMatch;
+}
+
 // True while a bob CLI process is alive. bob exits at the end of every turn,
 // so "process gone" means the turn finished — see the bob branch of
 // checkTmuxIdle(). Matches the launch command rather than the bare name so a
@@ -624,7 +652,13 @@ function progressTick() {
     console.log(`Task ${currentTask.task_id} completed — agent idle`);
     // Successful completion clears this work item's crash-retry budget.
     cliRestartCounts.delete(taskKey(currentTask));
-    send({ type: 'task_complete', seq: nextSeq(), task_id: currentTask.task_id, result: 'completed', summary: 'Agent returned to idle', tmux_output: tmuxLines });
+    // Best-effort: report the PR the agent opened, if one is visible in its
+    // recent output, so the hub can distinguish "shipped a PR" from "just went
+    // idle" and pick the right issue cooldown (kubestellar/hive#2393 item 7).
+    // Empty when no PR link is found — the hub then applies the short cooldown.
+    const prURL = detectPRURL(tmuxLines, currentTask.repo);
+    if (prURL) console.log(`Detected PR for ${currentTask.task_id}: ${prURL}`);
+    send({ type: 'task_complete', seq: nextSeq(), task_id: currentTask.task_id, result: 'completed', summary: 'Agent returned to idle', tmux_output: tmuxLines, pr_url: prURL });
     // bob exits after each turn, so the pane is now a bare shell. Bring it
     // back up before the next task, or the prompt would be typed into bash
     // ("-bash: <prompt>: command not found") and silently lost.

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -109,6 +109,16 @@ type WSMessage struct {
 	Summary        string          `json:"summary,omitempty"`
 	TmuxOutput     []string        `json:"tmux_output,omitempty"`
 	AcceptedModels []string        `json:"accepted_models,omitempty"`
+	// PRURL is the pull request the agent opened for this task, reported on
+	// task_complete. It is best-effort: the relay fills it when it can spot a
+	// PR link in the agent's output, and it is empty when the agent went idle
+	// without shipping anything. The hub uses its presence to decide how long
+	// to keep the underlying issue in cooldown — see markTaskCompleted and
+	// kubestellar/hive#2393 item 7 (an idle-but-no-PR completion must NOT lock
+	// the issue for a full week). A known PR URL per issue also feeds the
+	// #2356 duplicate-detection work. Field naming follows the PRURL
+	// convention in v2/pkg/github/prclaims.go.
+	PRURL string `json:"pr_url,omitempty"`
 	// Permanent marks a task_failed the relay will not retry: it exhausted its
 	// per-task CLI-restart budget and gave up (see MAX_TASK_CLI_RESTARTS in
 	// bin/contributor-relay.sh). Reassigning the same work item to the same
@@ -146,18 +156,45 @@ type ContributeWSHub struct {
 	activity       []ActivityEntry
 	server         *Server
 	completedTasks map[string]time.Time
-	completedMu    sync.Mutex
-	selectMu       sync.Mutex
+	// completedTaskCooldown holds a per-task override for how long, from the
+	// completion time in completedTasks, the issue stays in cooldown. It is
+	// populated by markTaskCompleted based on whether a PR was reported. When a
+	// key is absent (e.g. tasks restored from an older on-disk format, or set
+	// directly by tests) isTaskInCooldown falls back to the full
+	// completedTaskCooldownHours, preserving the original conservative default.
+	completedTaskCooldown map[string]time.Duration
+	// completedTaskPRURL records the PR URL reported for a completed task, kept
+	// for stats/audit and to feed #2356 duplicate detection (a known PR URL per
+	// issue). Empty means the completion reported no PR.
+	completedTaskPRURL map[string]string
+	completedMu        sync.Mutex
+	selectMu           sync.Mutex
 }
 
+// completedTaskCooldownHours is the cooldown applied when a task completes
+// having actually shipped a pull request: real work landed, so we should not
+// re-dispatch the same issue for a week.
 const completedTaskCooldownHours = 168
+
+// completedNoPRCooldownHours is the cooldown applied when a task "completes"
+// only because the agent went idle WITHOUT reporting a PR (the common case the
+// old code could not distinguish — see kubestellar/hive#2393 item 7). Nothing
+// shipped, so locking the issue for a full week wrongly starves it: another
+// contributor should be able to pick it up soon. We keep a short, non-zero
+// cooldown (not zero) so the very next selector pass does not instantly hand
+// the same untouched issue back to the same idle contributor in a tight loop;
+// a few hours is long enough to break that loop while still freeing the issue
+// the same day.
+const completedNoPRCooldownHours = 4
 
 func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 	hub := &ContributeWSHub{
-		connections:    make(map[string]*ContributorConnection),
-		completedTasks: make(map[string]time.Time),
-		logger:         logger,
-		server:         server,
+		connections:           make(map[string]*ContributorConnection),
+		completedTasks:        make(map[string]time.Time),
+		completedTaskCooldown: make(map[string]time.Duration),
+		completedTaskPRURL:    make(map[string]string),
+		logger:                logger,
+		server:                server,
 	}
 	hub.loadCompletedTasks()
 	hub.loadActivity()
@@ -239,6 +276,18 @@ func (h *ContributeWSHub) RecentActivity() []ActivityEntry {
 
 const completedTasksFile = "/data/contributors/completed-tasks.json"
 
+// completedTaskRecord is the on-disk shape of one completed-task entry. It
+// carries the completion time plus, since #2393 item 7, the per-task cooldown
+// and the PR URL that decided it, so a hub restart preserves whether an issue
+// got the short no-PR cooldown or the full one. Entries written by older builds
+// were a bare RFC3339 timestamp string; loadCompletedTasks still accepts that
+// legacy form and treats it as a full-cooldown, no-PR entry.
+type completedTaskRecord struct {
+	CompletedAt   time.Time `json:"completed_at"`
+	CooldownHours float64   `json:"cooldown_hours,omitempty"`
+	PRURL         string    `json:"pr_url,omitempty"`
+}
+
 func (h *ContributeWSHub) loadCompletedTasks() {
 	h.completedMu.Lock()
 	defer h.completedMu.Unlock()
@@ -246,15 +295,42 @@ func (h *ContributeWSHub) loadCompletedTasks() {
 	if err != nil {
 		return
 	}
-	var saved map[string]string
-	if json.Unmarshal(data, &saved) != nil {
-		return
-	}
-	for k, v := range saved {
-		if t, err := time.Parse(time.RFC3339, v); err == nil {
-			if time.Since(t) < completedTaskCooldownHours*time.Hour {
-				h.completedTasks[k] = t
+
+	// Accept both the current object form and the legacy map[string]string
+	// (key -> RFC3339 timestamp) form so an upgrade never drops cooldowns.
+	records := make(map[string]completedTaskRecord)
+	if json.Unmarshal(data, &records) != nil {
+		var legacy map[string]string
+		if json.Unmarshal(data, &legacy) != nil {
+			return
+		}
+		records = make(map[string]completedTaskRecord, len(legacy))
+		for k, v := range legacy {
+			if t, err := time.Parse(time.RFC3339, v); err == nil {
+				records[k] = completedTaskRecord{CompletedAt: t}
 			}
+		}
+	}
+
+	for k, rec := range records {
+		if rec.CompletedAt.IsZero() {
+			continue
+		}
+		cooldown := completedTaskCooldownHours * time.Hour
+		if rec.CooldownHours > 0 {
+			cooldown = time.Duration(rec.CooldownHours * float64(time.Hour))
+		}
+		// Skip anything already past its own cooldown so we don't resurrect
+		// stale locks.
+		if time.Since(rec.CompletedAt) >= cooldown {
+			continue
+		}
+		h.completedTasks[k] = rec.CompletedAt
+		if h.completedTaskCooldown != nil {
+			h.completedTaskCooldown[k] = cooldown
+		}
+		if h.completedTaskPRURL != nil {
+			h.completedTaskPRURL[k] = rec.PRURL
 		}
 	}
 	h.logger.Info("[contribute-ws] loaded completed tasks", "count", len(h.completedTasks))
@@ -262,9 +338,18 @@ func (h *ContributeWSHub) loadCompletedTasks() {
 
 func (h *ContributeWSHub) saveCompletedTasks() {
 	h.completedMu.Lock()
-	saved := make(map[string]string, len(h.completedTasks))
+	saved := make(map[string]completedTaskRecord, len(h.completedTasks))
 	for k, t := range h.completedTasks {
-		saved[k] = t.Format(time.RFC3339)
+		rec := completedTaskRecord{CompletedAt: t}
+		if h.completedTaskCooldown != nil {
+			if d, ok := h.completedTaskCooldown[k]; ok {
+				rec.CooldownHours = d.Hours()
+			}
+		}
+		if h.completedTaskPRURL != nil {
+			rec.PRURL = h.completedTaskPRURL[k]
+		}
+		saved[k] = rec
 	}
 	h.completedMu.Unlock()
 	data, err := json.Marshal(saved)
@@ -283,12 +368,45 @@ func (h *ContributeWSHub) saveCompletedTasks() {
 	}
 }
 
-func (h *ContributeWSHub) markTaskCompleted(repo string, number int) {
+// markTaskCompleted records a completed task and starts its issue cooldown.
+//
+// The cooldown length is conditional on whether the completion actually shipped
+// a pull request (kubestellar/hive#2393 item 7): a completion WITH a prURL gets
+// the full completedTaskCooldownHours (real work landed — don't re-dispatch for
+// a week), while a completion WITHOUT one — the agent merely returned to idle —
+// gets the short completedNoPRCooldownHours so an issue where nothing shipped
+// is not locked out for a week. The chosen expiry is stored per task and honored
+// by isTaskInCooldown; the prURL is retained for stats/audit and #2356
+// duplicate detection.
+func (h *ContributeWSHub) markTaskCompleted(repo string, number int, prURL string) {
 	key := fmt.Sprintf("%s#%d", repo, number)
+	cooldown := completedNoPRCooldownHours * time.Hour
+	if prURL != "" {
+		cooldown = completedTaskCooldownHours * time.Hour
+	}
 	h.completedMu.Lock()
 	h.completedTasks[key] = time.Now()
+	if h.completedTaskCooldown != nil {
+		h.completedTaskCooldown[key] = cooldown
+	}
+	if h.completedTaskPRURL != nil {
+		h.completedTaskPRURL[key] = prURL
+	}
 	h.completedMu.Unlock()
 	h.saveCompletedTasks()
+}
+
+// cooldownForLocked returns the cooldown duration to apply to key. Callers must
+// already hold completedMu. When no per-task override was recorded (older
+// on-disk entries, or hubs built directly in tests) it falls back to the full
+// completedTaskCooldownHours — the original, conservative default.
+func (h *ContributeWSHub) cooldownForLocked(key string) time.Duration {
+	if h.completedTaskCooldown != nil {
+		if d, ok := h.completedTaskCooldown[key]; ok {
+			return d
+		}
+	}
+	return completedTaskCooldownHours * time.Hour
 }
 
 func (h *ContributeWSHub) isTaskInCooldown(repo string, number int) bool {
@@ -299,8 +417,10 @@ func (h *ContributeWSHub) isTaskInCooldown(repo string, number int) bool {
 	if !ok {
 		return false
 	}
-	if time.Since(t) > completedTaskCooldownHours*time.Hour {
+	if time.Since(t) > h.cooldownForLocked(key) {
 		delete(h.completedTasks, key)
+		delete(h.completedTaskCooldown, key)
+		delete(h.completedTaskPRURL, key)
 		return false
 	}
 	return true
@@ -670,7 +790,10 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 
 				if hasTask {
 					if completedTask != nil {
-						h.markTaskCompleted(completedTask.Repo, completedTask.Number)
+						// #2393 item 7: keep the full week-long cooldown only when a
+						// PR was actually reported; an idle-but-no-PR completion gets
+						// the short cooldown so the issue is not locked for a week.
+						h.markTaskCompleted(completedTask.Repo, completedTask.Number, msg.PRURL)
 					}
 					h.addActivity(contributor.profile.GitHubUsername, "completed", contributor.role, contributor.cliBackend, contributor.model, msg.TaskID)
 					h.logger.Info("[contribute-ws] task complete",

--- a/v2/pkg/dashboard/contribute_ws_more_coverage_test.go
+++ b/v2/pkg/dashboard/contribute_ws_more_coverage_test.go
@@ -71,12 +71,56 @@ func TestCovK2_AddActivityCap(t *testing.T) {
 
 func TestCovK2_MarkTaskCompletedAndCooldown(t *testing.T) {
 	hub, _ := covK2Hub(t)
-	hub.markTaskCompleted("org/repo", 42)
+	hub.markTaskCompleted("org/repo", 42, "https://github.com/org/repo/pull/1")
 	if !hub.isTaskInCooldown("org/repo", 42) {
 		t.Fatalf("expected task in cooldown after marking complete")
 	}
 	if hub.isTaskInCooldown("org/repo", 99) {
 		t.Fatalf("unmarked task should not be in cooldown")
+	}
+}
+
+// TestConditionalCooldownByPRURL covers kubestellar/hive#2393 item 7: a
+// completion that reports a PR URL keeps the full week-long cooldown, while a
+// completion with no PR (agent merely went idle) gets only the short no-PR
+// cooldown, so an issue where nothing shipped is not locked out for a week.
+func TestConditionalCooldownByPRURL(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	// WITH a PR URL -> full completedTaskCooldownHours (168h).
+	hub.markTaskCompleted("org/withpr", 1, "https://github.com/org/withpr/pull/1")
+	if !hub.isTaskInCooldown("org/withpr", 1) {
+		t.Fatalf("task with PR should be in cooldown immediately after completion")
+	}
+	// Age it just under the short no-PR window: still in cooldown because it
+	// holds the full 168h cooldown, not the short one.
+	hub.completedMu.Lock()
+	hub.completedTasks["org/withpr#1"] = time.Now().Add(-(completedNoPRCooldownHours + 1) * time.Hour)
+	hub.completedMu.Unlock()
+	if !hub.isTaskInCooldown("org/withpr", 1) {
+		t.Fatalf("task with PR should still be in cooldown after %dh (full cooldown is %dh)",
+			completedNoPRCooldownHours+1, completedTaskCooldownHours)
+	}
+	// Aged past the full cooldown -> released.
+	hub.completedMu.Lock()
+	hub.completedTasks["org/withpr#1"] = time.Now().Add(-(completedTaskCooldownHours + 1) * time.Hour)
+	hub.completedMu.Unlock()
+	if hub.isTaskInCooldown("org/withpr", 1) {
+		t.Fatalf("task with PR should be released after the full cooldown elapses")
+	}
+
+	// WITHOUT a PR URL -> short completedNoPRCooldownHours.
+	hub.markTaskCompleted("org/nopr", 2, "")
+	if !hub.isTaskInCooldown("org/nopr", 2) {
+		t.Fatalf("no-PR task should be in a (short) cooldown right after completion")
+	}
+	// Aged just past the short no-PR window -> released, unlike the 168h default.
+	hub.completedMu.Lock()
+	hub.completedTasks["org/nopr#2"] = time.Now().Add(-(completedNoPRCooldownHours + 1) * time.Hour)
+	hub.completedMu.Unlock()
+	if hub.isTaskInCooldown("org/nopr", 2) {
+		t.Fatalf("no-PR task should be released after only %dh, not locked for %dh",
+			completedNoPRCooldownHours, completedTaskCooldownHours)
 	}
 }
 
@@ -131,7 +175,7 @@ func TestCovK2_SelectTask(t *testing.T) {
 
 	// A second select for the same issue while it's the connection's current task
 	// is skipped (activeIssues), and after marking it complete it's in cooldown.
-	hub.markTaskCompleted("myorg/repo1", 7)
+	hub.markTaskCompleted("myorg/repo1", 7, "https://github.com/myorg/repo1/pull/9")
 	conn.currentTask = nil
 	if msg := hub.selectTask(conn); msg != nil {
 		t.Fatalf("expected nil task (cooldown) but got %+v", msg)

--- a/v2/pkg/dashboard/coverage_boost_test.go
+++ b/v2/pkg/dashboard/coverage_boost_test.go
@@ -1302,7 +1302,7 @@ func TestContributeWSHub_MarkTaskCompleted(t *testing.T) {
 		completedTasks: make(map[string]time.Time),
 		logger:         slog.Default(),
 	}
-	hub.markTaskCompleted("org/repo", 42)
+	hub.markTaskCompleted("org/repo", 42, "https://github.com/org/repo/pull/1")
 
 	if !hub.isTaskInCooldown("org/repo", 42) {
 		t.Error("expected task to be in cooldown after marking complete")


### PR DESCRIPTION
`task_complete` couldn't say whether a PR shipped, yet always applied a 168h issue cooldown — locking an issue for a week even when nothing was opened. Adds an optional `pr_url` (relay best-effort detects it from the tmux tail), and makes the cooldown conditional: full 168h with a PR, a short 4h without, so an issue where nothing shipped is freed same-day. Restart-safe persistence + test. Also gives the hub a per-issue PR URL for the #2356 dupe check. Addresses #2393 item 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)