### PR TITLE
fix(hub): reset ClaimDelivered on approve so a recycled placeholder re-delivers its claim (Fixes #2372)

### DIFF
--- a/v2/pkg/hub/provision_approve_coverage_test.go
+++ b/v2/pkg/hub/provision_approve_coverage_test.go
@@ -80,6 +80,53 @@ func TestHandleApproveProvision(t *testing.T) {
 	}
 }
 
+// TestHandleApproveProvisionRearmClaimDelivered guards #2372: a RECYCLED
+// placeholder (one previously claimed, then returned to the pool) still carries
+// the prior tenant's ClaimDelivered=true. Approving it for a new owner must
+// re-arm the org/repos claim handshake — resetting ClaimDelivered to false —
+// exactly as it re-arms ACMMDelivered. Leaving it true would suppress the
+// org/repos PUSH to the spoke and make the heartbeat adopt the spoke's stale
+// self-report, so hub and spoke silently keep the previous tenant's project.
+func TestHandleApproveProvisionRearmClaimDelivered(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, saveCh: make(chan struct{}, 1), clusters: map[string]ClusterConfig{"hive-oke": *dynamicCluster()}}
+
+	saveProvisionRequest(&ProvisionRequest{
+		Username: "carol", Org: "acme", Repos: "repo", PrimaryRepo: "repo", ACMMLevel: 2,
+		AuthMethod: "public", RequestedAt: time.Now().UTC().Format(time.RFC3339), Status: provisionStatusPending,
+	})
+
+	// A recycled placeholder: available again but with BOTH delivery latches
+	// left true by the previous tenancy.
+	saveSaaSHive(&SaaSHive{
+		ID: "recycled1", Owner: hubAdminUsername, Status: statusAvailable, ClusterID: "hive-oke",
+		ClaimDelivered: true, ACMMDelivered: true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/approve-prov", `{"hive_id":"recycled1"}`, hubAdminUsername), "username", "carol")
+	s.handleApproveProvision(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("approve status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	got := loadSaaSHive("recycled1")
+	if got == nil {
+		t.Fatal("expected saved hive after approve")
+	}
+	if got.ClaimDelivered {
+		t.Errorf("ClaimDelivered = true after (re)assignment; want false so the next heartbeat re-delivers the org/repos claim (#2372)")
+	}
+	if got.ACMMDelivered {
+		t.Errorf("ACMMDelivered = true after (re)assignment; want false")
+	}
+	if got.Owner != "carol" {
+		t.Errorf("Owner = %q, want carol (placeholder should be claimed)", got.Owner)
+	}
+}
+
 func TestHandleToggleAutoUpgradeHeartbeatOnly(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -5547,6 +5547,17 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 	// assignments, so a flag left true by a previous tenancy would suppress
 	// delivery for the new owner.
 	h.ACMMDelivered = false
+	// Re-arm the org/repos claim handshake too (#2372). ClaimDelivered gates
+	// both halves of adoptSpokeProjectConfig: the org/repos PUSH fires only
+	// while !ClaimDelivered, and the spoke's report is ADOPTED only once it is
+	// true. A RECYCLED placeholder (previously claimed, returned to the pool)
+	// carries the prior tenant's ClaimDelivered=true, so without this reset the
+	// hub never pushes the new owner's org/repos AND adopts the spoke's stale
+	// self-report — hub and spoke silently agree on the PREVIOUS tenant's
+	// project. The heartbeat is the only hub->spoke write channel, so the claim
+	// must re-arm on (re)assignment for exactly the same reason ACMMDelivered
+	// does above. (The assign path — handleAssignHive — already does this.)
+	h.ClaimDelivered = false
 	h.Status = ""
 	h.Error = ""
 	// Preserve the placeholder's real cluster before ANY cluster-derived


### PR DESCRIPTION
handleApproveProvision re-armed ACMMDelivered but never reset ClaimDelivered, so a **recycled** placeholder (previously claimed, returned to the pool) kept the prior tenant's ClaimDelivered=true — which suppressed the org/repos push to the spoke AND made the heartbeat adopt the spoke's stale self-report, so hub and spoke silently agreed on the *previous* tenant's org/repos.

Reset `ClaimDelivered = false` alongside `ACMMDelivered` in the approve path (the assign path already did this). No-op for a fresh placeholder (already false); only fixes the recycled case. No RequestedClaim counterpart is needed — the claim payload lives in h.Org/h.Repos/h.PrimaryRepo, which approve already rewrites. Tested (recycled placeholder → ClaimDelivered reset on approve); full hub suite green. Same defect class as #2354 (ACMM), on the org/repos field. Fixes #2372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)