### PR TITLE
fix(governor): read the persisted Period(days) and Critical Percent settings (Fixes #2323)

### DIFF
--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -32,22 +32,22 @@ type ModeChange struct {
 }
 
 type EvalSnapshot struct {
-	Timestamp     int64             `json:"t"`
-	Mode          Mode              `json:"govMode"`
-	QueueIssues   int               `json:"govIssues"`
-	QueuePRs      int               `json:"govPrs"`
-	QueueTotal    int               `json:"govTotal"`
-	QueueHold     int               `json:"govHold"`
-	QueueActive   int               `json:"govActive"`
-	SLAViolations int               `json:"sla_violations,omitempty"`
-	AgentsKicked  []string          `json:"agents_kicked,omitempty"`
-	Actionable    int               `json:"actionableCount"`
-	OpenPRs       int               `json:"openPrCount"`
-	Mergeable     int               `json:"mergeableCount"`
-	BeadsWorkers  int               `json:"beadsWorkers"`
-	BeadsSupervisor int             `json:"beadsSupervisor"`
-	Repos         map[string]RepoSnapshot `json:"repos,omitempty"`
-	AgentStats    map[string]map[string]any `json:"agentStats,omitempty"`
+	Timestamp       int64                     `json:"t"`
+	Mode            Mode                      `json:"govMode"`
+	QueueIssues     int                       `json:"govIssues"`
+	QueuePRs        int                       `json:"govPrs"`
+	QueueTotal      int                       `json:"govTotal"`
+	QueueHold       int                       `json:"govHold"`
+	QueueActive     int                       `json:"govActive"`
+	SLAViolations   int                       `json:"sla_violations,omitempty"`
+	AgentsKicked    []string                  `json:"agents_kicked,omitempty"`
+	Actionable      int                       `json:"actionableCount"`
+	OpenPRs         int                       `json:"openPrCount"`
+	Mergeable       int                       `json:"mergeableCount"`
+	BeadsWorkers    int                       `json:"beadsWorkers"`
+	BeadsSupervisor int                       `json:"beadsSupervisor"`
+	Repos           map[string]RepoSnapshot   `json:"repos,omitempty"`
+	AgentStats      map[string]map[string]any `json:"agentStats,omitempty"`
 }
 
 type RepoSnapshot struct {
@@ -78,16 +78,54 @@ type BudgetInfo struct {
 	WindowBaseline int64 `json:"window_baseline"`
 }
 
-// BudgetWindowDuration is the length of one budget accounting window; the
-// "weekly" limit applies to spend accumulated within it.
-const BudgetWindowDuration = 7 * 24 * time.Hour
+// BudgetWindowDuration is the DEFAULT length of one budget accounting
+// window; the "weekly" limit applies to spend accumulated within it. As of
+// #2323 the effective window is the configured governor.budget.period_days
+// (see budgetWindowDuration); this constant is the fallback used when that
+// setting is unset/zero.
+const BudgetWindowDuration = defaultBudgetWindowDays * 24 * time.Hour
 
-// BudgetWarnPct is the percent of the weekly limit at which the soft
-// budget warning fires.
+// defaultBudgetWindowDays is the fallback budget-window length in days,
+// matching config.defaultBudgetPeriodDays. Used when period_days is unset.
+const defaultBudgetWindowDays = 7
+
+// BudgetWarnPct is the DEFAULT percent of the weekly limit at which the soft
+// budget warning fires. As of #2323 the effective threshold is the
+// configured governor.budget.critical_pct (see budgetWarnPct); this constant
+// is the fallback used when that setting is unset/zero.
 const BudgetWarnPct = 90
 
 // percentDenominator converts a percentage into a fraction of a whole.
 const percentDenominator = 100
+
+// hoursPerDay converts a day count into hours for time.Duration math.
+const hoursPerDay = 24
+
+// budgetWindowDuration returns the effective budget-window length. It reads
+// the configured governor.budget.period_days (#2323 — previously this value
+// was persisted but never read, so the window was silently pinned to 7 days)
+// and falls back to the BudgetWindowDuration default when the setting is
+// unset/zero (a 0-day window would roll every eval and break budgeting).
+// Callers must hold g.mu.
+func (g *Governor) budgetWindowDuration() time.Duration {
+	if days := g.cfg.Budget.PeriodDays; days > 0 {
+		return time.Duration(days) * hoursPerDay * time.Hour
+	}
+	return BudgetWindowDuration
+}
+
+// budgetWarnPct returns the effective soft-warning threshold as an integer
+// percent (0-100). It reads the configured governor.budget.critical_pct
+// (#2323 — previously persisted but never read, so warnings were silently
+// pinned to 90%) and falls back to the BudgetWarnPct default when the
+// setting is unset/zero (a 0% threshold would warn immediately). Callers
+// must hold g.mu.
+func (g *Governor) budgetWarnPct() int {
+	if pct := g.cfg.Budget.CriticalPct; pct > 0 {
+		return pct
+	}
+	return BudgetWarnPct
+}
 
 // BudgetTransitions reports budget threshold state from a single
 // UpdateBudgetFromTotals call. WarnCrossed and ExhaustedCrossed are
@@ -624,7 +662,7 @@ func (g *Governor) UpdateBudgetFromTotals(totalTokens int64, byAgent map[string]
 		// First run or legacy snapshot without a window: open one now.
 		g.budget.ResetAt = now
 		g.budget.WindowBaseline = totalTokens
-	} else if now.Sub(g.budget.ResetAt) >= BudgetWindowDuration {
+	} else if now.Sub(g.budget.ResetAt) >= g.budgetWindowDuration() {
 		g.budget.ResetAt = now
 		g.budget.WindowBaseline = totalTokens
 		g.budgetWarned = false
@@ -656,7 +694,7 @@ func (g *Governor) UpdateBudgetFromTotals(totalTokens int64, byAgent map[string]
 
 	// WeeklyLimit == 0 disables budgeting entirely: no thresholds, no alerts.
 	if g.budget.WeeklyLimit > 0 {
-		warnThreshold := g.budget.WeeklyLimit * BudgetWarnPct / percentDenominator
+		warnThreshold := g.budget.WeeklyLimit * int64(g.budgetWarnPct()) / percentDenominator
 		trans.WarnActive = g.budget.CurrentSpend >= warnThreshold
 		trans.ExhaustedActive = g.budget.CurrentSpend >= g.budget.WeeklyLimit
 		if trans.WarnActive && !g.budgetWarned {

--- a/v2/pkg/governor/governor_settings_wiring_test.go
+++ b/v2/pkg/governor/governor_settings_wiring_test.go
@@ -1,0 +1,128 @@
+package governor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// #2323: governor.budget.period_days and .critical_pct were persisted in
+// config but never read, so the window was pinned to 7 days and the warning
+// to 90%. These tests lock in that both are now honored, and that an
+// unset/zero value falls back to the defaults instead of 0.
+
+// TestBudgetWindowDuration_ConfiguredPeriodDays verifies a configured
+// period_days sets the effective window (30 days), not the hardcoded 7.
+func TestBudgetWindowDuration_ConfiguredPeriodDays(t *testing.T) {
+	cfg := config.GovernorConfig{Budget: config.BudgetConfig{PeriodDays: 30}}
+	g := New(cfg, map[string]config.AgentConfig{}, testLogger())
+
+	want := 30 * 24 * time.Hour
+	if got := g.budgetWindowDuration(); got != want {
+		t.Errorf("budgetWindowDuration() = %v, want %v", got, want)
+	}
+}
+
+// TestBudgetWindowDuration_ZeroFallsBackToDefault verifies an unset
+// period_days falls back to the 7-day default, not a 0-length window.
+func TestBudgetWindowDuration_ZeroFallsBackToDefault(t *testing.T) {
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, testLogger())
+
+	if got := g.budgetWindowDuration(); got != BudgetWindowDuration {
+		t.Errorf("zero period_days: budgetWindowDuration() = %v, want default %v", got, BudgetWindowDuration)
+	}
+	if BudgetWindowDuration != 7*24*time.Hour {
+		t.Errorf("default window = %v, want 7 days", BudgetWindowDuration)
+	}
+}
+
+// TestBudgetWindowRoll_HonorsConfiguredPeriod verifies the actual roll logic
+// uses the configured window: a window opened 8 days ago must NOT roll when
+// period_days is 30 (it would have rolled under the hardcoded 7-day window).
+func TestBudgetWindowRoll_HonorsConfiguredPeriod(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	cfg.Budget.PeriodDays = 30
+	g := New(cfg, agents, testLogger())
+
+	g.SetBudgetLimit(1000)
+	// Window opened 8 days ago, exhausted. Under the old hardcoded 7-day
+	// window this would roll and clear suppression; under the configured
+	// 30-day window it must still be within the window.
+	g.SeedBudget(1500, nil, nil, time.Now().Add(-8*24*time.Hour))
+
+	// Totals update at 8 days: must NOT roll (30-day window).
+	g.UpdateBudgetFromTotals(1600, nil, nil)
+	if due := dueSet(g); due["scanner"] {
+		t.Error("30-day window must not roll after only 8 days; scanner should stay suppressed")
+	}
+	if !g.GetState().BudgetExhausted {
+		t.Error("30-day window must not roll after only 8 days; budget should stay exhausted")
+	}
+}
+
+// TestBudgetWindowRoll_ConfiguredPeriodRolls verifies the configured window
+// still rolls once elapsed: a 30-day window opened 31 days ago rolls and
+// clears suppression.
+func TestBudgetWindowRoll_ConfiguredPeriodRolls(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	cfg.Budget.PeriodDays = 30
+	g := New(cfg, agents, testLogger())
+
+	g.SetBudgetLimit(1000)
+	g.SeedBudget(1500, nil, nil, time.Now().Add(-31*24*time.Hour))
+
+	// Totals update at 31 days: rolls the window, resetting spend to zero.
+	g.UpdateBudgetFromTotals(5000, nil, nil)
+	if due := dueSet(g); !due["scanner"] {
+		t.Error("30-day window should roll after 31 days and clear suppression")
+	}
+	if g.GetState().BudgetExhausted {
+		t.Error("state should clear exhausted after the configured window rolls")
+	}
+}
+
+// TestBudgetWarnPct_ConfiguredThreshold verifies critical_pct=75 triggers the
+// warning at 75% of the limit, not the hardcoded 90%.
+func TestBudgetWarnPct_ConfiguredThreshold(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	cfg.Budget.CriticalPct = 75
+	g := New(cfg, agents, testLogger())
+
+	g.SetBudgetLimit(1000)
+	g.SetBudgetResetAt(time.Now()) // open window with baseline 0
+
+	// 800 tokens = 80%: below the hardcoded 90% but above the configured 75%.
+	trans := g.UpdateBudgetFromTotals(800, nil, nil)
+	if !trans.WarnCrossed || !trans.WarnActive {
+		t.Errorf("configured 75%% threshold should warn at 80%% spend, got %+v", trans)
+	}
+	if got := g.budgetWarnPct(); got != 75 {
+		t.Errorf("budgetWarnPct() = %d, want 75", got)
+	}
+}
+
+// TestBudgetWarnPct_ZeroFallsBackToDefault verifies an unset critical_pct
+// falls back to the 90% default, not a 0% (warn-immediately) threshold.
+func TestBudgetWarnPct_ZeroFallsBackToDefault(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	g := New(cfg, agents, testLogger())
+
+	if got := g.budgetWarnPct(); got != BudgetWarnPct {
+		t.Errorf("zero critical_pct: budgetWarnPct() = %d, want default %d", got, BudgetWarnPct)
+	}
+
+	g.SetBudgetLimit(1000)
+	g.SetBudgetResetAt(time.Now())
+
+	// 800 tokens = 80%: below the 90% default, so no warn should fire.
+	trans := g.UpdateBudgetFromTotals(800, nil, nil)
+	if trans.WarnCrossed || trans.WarnActive {
+		t.Errorf("default 90%% threshold must not warn at 80%% spend, got %+v", trans)
+	}
+	// 950 tokens = 95%: above 90%, warn should fire.
+	trans = g.UpdateBudgetFromTotals(950, nil, nil)
+	if !trans.WarnCrossed || !trans.WarnActive {
+		t.Errorf("default 90%% threshold should warn at 95%% spend, got %+v", trans)
+	}
+}


### PR DESCRIPTION
The Governor 'Period (days)' and 'Critical Percent' budget settings were persisted but never read — the budget window was hardcoded to 7 days and the warn threshold to 90%, so setting them was a silent no-op. Wired both through governor.go via the config the governor already holds, with a zero-value fallback to the 7-day/90% defaults (named constants, no magic numbers). Tested: a 30-day period gives a 30-day window; a 75% threshold warns at 75; unset falls back. Fixes #2323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)