### PR TITLE
fix(hub): surface App write-403 into health instead of reporting OK (Fixes #2353)

### DIFF
--- a/v2/cmd/hive/ghapp_banner_verdict_test.go
+++ b/v2/cmd/hive/ghapp_banner_verdict_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kubestellar/hive/v2/pkg/github"
@@ -182,6 +183,72 @@ func TestClassifyGitHubAppFailure_OperatorFaultIsNotBlamedOnUser(t *testing.T) {
 	}
 	if !state.OperatorActionable() || state.UserActionable() {
 		t.Error("key-invalid is the operator's fault and must never be blamed on the user")
+	}
+}
+
+// TestClassifyGitHubAppWriteForbidden_HealthyInstallSurfacesWriteFailure is the
+// #2353 regression: the App authenticates, the installation resolves on the
+// right account and grants issues:write (so diagnoseGitHubApp returns OK), yet a
+// real write returned 403 "Resource not accessible by integration". Health must
+// NOT stay silent (None) and must NOT be mislabeled "lacks Issues: Read &
+// Write" — it must report the DISTINCT write-forbidden state with accurate copy
+// naming the repo and the repo-scope cause.
+func TestClassifyGitHubAppWriteForbidden_HealthyInstallSurfacesWriteFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// GetInstallation reports a perfectly healthy installation: right owner,
+		// issues:write granted. This is exactly the live case from #2353.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":          verdictTestInstallationID,
+			"account":     map[string]any{"login": "open-horizon-services"},
+			"permissions": map[string]any{"issues": "write"},
+		})
+	}))
+	defer srv.Close()
+
+	msg, state := classifyGitHubAppWriteForbidden(
+		context.Background(),
+		verdictTestAuth(t, srv.URL),
+		"open-horizon-services",
+		"Getting-Started",
+	)
+	if state == github.AppStateOK || state == github.AppStateUnknown {
+		t.Fatalf("a write-403 on a healthy install must not stay silent; state=%s", state)
+	}
+	if state == github.AppStateInsufficientPerms {
+		t.Error("must NOT be mislabeled as an Issues permission gap — the permission is granted")
+	}
+	if state != github.AppStateWriteForbidden {
+		t.Errorf("state = %s, want write-forbidden", state)
+	}
+	if msg == "" {
+		t.Error("write-forbidden must carry an accurate, non-empty message")
+	}
+	if !strings.Contains(msg, "Getting-Started") {
+		t.Errorf("message must name the repo; got %q", msg)
+	}
+	if strings.Contains(msg, "lacks Issues") {
+		t.Errorf("message must not fabricate a permission gap; got %q", msg)
+	}
+}
+
+// TestClassifyGitHubAppWriteForbidden_RealAuthProblemWins — when the write 403
+// coincides with a GENUINE App-auth fault (here: a 401 key-invalid), report that
+// real cause rather than masking it behind the repo-scope story.
+func TestClassifyGitHubAppWriteForbidden_RealAuthProblemWins(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "A JSON web token could not be decoded"})
+	}))
+	defer srv.Close()
+
+	_, state := classifyGitHubAppWriteForbidden(
+		context.Background(),
+		verdictTestAuth(t, srv.URL),
+		"open-horizon-services",
+		"Getting-Started",
+	)
+	if state != github.AppStateKeyInvalid {
+		t.Errorf("state = %s, want key-invalid — the real fault must win", state)
 	}
 }
 

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1801,6 +1801,31 @@ func main() {
 					dashSrv.AuditLog("system", "github_app_check", "result=installed but write NOT verified: "+diag, "")
 					return false
 				}
+				// #2353: the classifier above only proves the installation
+				// authenticates and grants issues:write — NOT that this repo can
+				// actually be written. Finding the advisory issue is a READ, which
+				// succeeds even when the repo is not in the App installation's
+				// selected repos. Perform a REAL write probe before clearing the
+				// banner, so re-check cannot falsely "verify write" for a repo the
+				// App can only read (the recheck false-positive).
+				if werr := ghClient.ProbeIssueWrite(ctx, recheckRepo, num); werr != nil {
+					if strings.Contains(werr.Error(), "403") && strings.Contains(werr.Error(), "Resource not accessible by integration") {
+						msg, state := classifyGitHubAppWriteForbidden(ctx, ghClient.AppAuth(), cfg.Project.Org, recheckRepo)
+						dashSrv.SetGitHubAppPermIssue(msg)
+						dashSrv.SetGitHubAppState(state.String())
+						logger.Warn("github app recheck: write probe returned 403 — not clearing the banner",
+							"repo", recheckRepo, "state", state.String(), "detail", msg)
+						dashSrv.AuditLog("system", "github_app_check", "result=write probe FORBIDDEN: "+msg, "")
+						return false
+					}
+					// A non-403 probe failure is inconclusive (rate limit,
+					// transient network). Do NOT clear the banner on a write we
+					// could not confirm, but also do NOT accuse anyone.
+					logger.Warn("github app recheck: write probe inconclusive — leaving banner as-is",
+						"repo", recheckRepo, "error", werr)
+					dashSrv.AuditLog("system", "github_app_check", "result=write probe inconclusive", "")
+					return false
+				}
 				logger.Info("github app recheck: app detected, write verified", "repo", recheckRepo, "number", num)
 				dashSrv.AuditLog("system", "github_app_check", "result=OK (installed, write verified)", "")
 				return true
@@ -3471,6 +3496,49 @@ func classifyGitHubAppFailure(ctx context.Context, appAuth *github.AppAuth, expe
 	return true, msg, state
 }
 
+// classifyGitHubAppWriteForbidden (#2353) is the verdict for a REAL write that
+// returned 403 "Resource not accessible by integration". Authentication-only
+// health checks (classifyGitHubAppFailure / diagnoseGitHubApp) inspect the
+// installation's granted PERMISSIONS but never whether the target repo is in
+// the installation's `selected` repositories — so they return AppStateOK for a
+// repo the App cannot write, and the write failure stayed invisible to health
+// (githubAppState=None) or, worse, got hard-overridden into a false "lacks
+// Issues: Read & Write" banner.
+//
+// The rule here keeps attribution honest:
+//
+//   - If diagnoseGitHubApp finds a genuine, classifiable App-auth problem
+//     (wrong installation, missing key, insufficient PERMISSION, etc.), report
+//     THAT — it is the real cause and its copy is already accurate.
+//   - If diagnoseGitHubApp reports the installation is healthy (AppStateOK:
+//     right owner, issues:write granted) OR could not reach a verdict
+//     (AppStateUnknown), the write 403 is still real and must NOT be silently
+//     healthy. Report AppStateWriteForbidden with copy that names the repo and
+//     the likeliest cause (repo not in the installation's selected repos),
+//     WITHOUT inventing a permission gap that the diagnosis just proved absent.
+//
+// It always raises: a write that returned 403 is a genuine, standing failure to
+// surface, distinct from the transient/unknown probe failures
+// classifyGitHubAppFailure guards against.
+func classifyGitHubAppWriteForbidden(ctx context.Context, appAuth *github.AppAuth, expectedOwner, repo string) (msg string, state github.AppAuthState) {
+	diagMsg, diagState := diagnoseGitHubApp(ctx, appAuth, expectedOwner)
+	if diagState != github.AppStateOK && diagState != github.AppStateUnknown {
+		// A real, classifiable App-auth problem — its message is the accurate
+		// one (e.g. wrong-installation, key-missing, or a genuine permission
+		// gap). Use it as-is rather than masking it with the repo-scope story.
+		return diagMsg, diagState
+	}
+	// Installation authenticates and (per the diagnosis) holds issues:write, yet
+	// the write was forbidden. Attribute it to the one thing the permission
+	// check cannot see — repo scope — and name the repo so the fix is concrete.
+	d := github.AppAuthDiagnosis{
+		State:           github.AppStateWriteForbidden,
+		ExpectedAccount: expectedOwner,
+		Repo:            repo,
+	}
+	return d.Message(), github.AppStateWriteForbidden
+}
+
 func runEvalCycle(
 	ctx context.Context,
 	cfg *config.Config,
@@ -3781,15 +3849,20 @@ func runEvalCycle(
 						}
 						logger.Warn("failed to post advisory digest via app", "repo", primaryRepo, "issue", issueNum, "error", err)
 						if strings.Contains(err.Error(), "403") && strings.Contains(err.Error(), "Resource not accessible by integration") {
-							// App is installed (we found the issue) but can't write.
-							// Resolve the actual cause — pending permission approval
-							// vs. an installation_id pointing at the wrong org — so
-							// the banner tells the user what to actually fix.
-							msg, state := diagnoseGitHubApp(ctx, ghClient.AppAuth(), cfg.Project.Org)
-							if msg == "" {
-								msg = "The GitHub App is installed but lacks Issues: Read & Write permission. The org owner must approve updated permissions at the app installation settings page."
-								state = github.AppStateInsufficientPerms
-							}
+							// App is installed (we found the issue) but a real
+							// WRITE was forbidden. #2353: attribute this honestly.
+							// diagnoseGitHubApp only inspects installation-level
+							// PERMISSIONS, so when it comes back healthy (issues:write
+							// granted, right owner) the previous code hard-overrode
+							// that "OK" into a false "lacks Issues: Read & Write"
+							// banner — the exact misattribution #2353 reports. When
+							// the diagnosis is genuinely a permission/installation
+							// problem, use it; otherwise surface a DISTINCT
+							// write-forbidden state naming the likeliest real cause
+							// (the repo is not in the App installation's selected
+							// repos), instead of leaving health at None or faking a
+							// permission gap the diagnosis just disproved.
+							msg, state := classifyGitHubAppWriteForbidden(ctx, ghClient.AppAuth(), cfg.Project.Org, primaryRepo)
 							dashSrv.SetGitHubAppRequired(true)
 							dashSrv.SetGitHubAppPermIssue(msg)
 							dashSrv.SetGitHubAppState(state.String())

--- a/v2/pkg/github/advisory.go
+++ b/v2/pkg/github/advisory.go
@@ -113,6 +113,42 @@ func (c *Client) PostAdvisoryDigest(ctx context.Context, repo string, issueNum i
 	return nil
 }
 
+// ProbeIssueWrite (#2353) verifies that the current credential can actually
+// WRITE to repo by performing a benign, self-reverting edit of the advisory
+// issue: it reads the issue's current body and writes that same body straight
+// back. GitHub records no visible change, but the request still exercises the
+// exact issues:write path (and repo scope) a real digest post needs.
+//
+// This closes the recheck false-positive: a READ (finding the advisory issue)
+// succeeds even when the App cannot write, and an installation-permission check
+// cannot see that the repo is absent from the App installation's selected
+// repos. Only a real write proves write capability, so callers that must not
+// clear the write-forbidden banner (#2353) probe with this before declaring the
+// App healthy.
+//
+// Returns nil on a successful write; the underlying error (e.g. the 403
+// "Resource not accessible by integration") otherwise, so the caller can
+// classify it exactly as it would a failed digest post.
+func (c *Client) ProbeIssueWrite(ctx context.Context, repo string, issueNum int) error {
+	if c == nil {
+		return ErrNoGitHubClient
+	}
+	owner, repoName := c.splitRepo(repo)
+	issue, _, err := c.client.Issues.Get(ctx, owner, repoName, issueNum)
+	if err != nil {
+		return fmt.Errorf("reading advisory issue %s#%d for write probe: %w", repo, issueNum, err)
+	}
+	// Write the current body back unchanged — a no-op edit that still requires
+	// (and thus proves) issues:write on THIS repo.
+	_, _, err = c.client.Issues.Edit(ctx, owner, repoName, issueNum, &gh.IssueRequest{
+		Body: gh.Ptr(issue.GetBody()),
+	})
+	if err != nil {
+		return fmt.Errorf("write probe on advisory issue %s#%d: %w", repo, issueNum, err)
+	}
+	return nil
+}
+
 func truncateDigest(digest string) string {
 	if len(digest) <= githubCommentCharLimit {
 		return digest
@@ -176,8 +212,8 @@ func (c *Client) findAdvisoryIssue(ctx context.Context, owner, repo string) (int
 
 	// Fallback 1: list by label (works when search API is unavailable)
 	opts := &gh.IssueListByRepoOptions{
-		State:  "open",
-		Labels: []string{advisoryLabelName},
+		State:       "open",
+		Labels:      []string{advisoryLabelName},
 		ListOptions: gh.ListOptions{PerPage: 10},
 	}
 	issues, _, listErr := c.client.Issues.ListByRepo(ctx, owner, repo, opts)

--- a/v2/pkg/github/app_state.go
+++ b/v2/pkg/github/app_state.go
@@ -69,6 +69,24 @@ const (
 	// JWT fails before the installation is ever consulted. That misdiagnosis is
 	// what cost the owner of the first hive to hit this real debugging time.
 	AppStateNoAppAssigned
+
+	// AppStateWriteForbidden (#2353) means the App authenticated, the
+	// installation resolved on the RIGHT account, and DiagnoseAppAuth reports
+	// the installation grants issues:write — yet a real WRITE attempt returned
+	// 403 "Resource not accessible by integration". DiagnoseAppAuth only
+	// inspects installation-level PERMISSIONS; it never checks whether the
+	// target repo is in the installation's `selected` repositories. So an
+	// authentication-and-permission check passes while the write is still
+	// forbidden.
+	//
+	// The most likely cause is exactly that gap: the repo is not included in the
+	// App installation's selected repositories, so no granted permission applies
+	// to it. It is DISTINCT from AppStateInsufficientPerms — the permission IS
+	// granted here, so labelling this "lacks Issues: Read & Write" is a false
+	// accusation. USER-ACTIONABLE (by an org owner): add the repo to the App
+	// installation (or, if using "all repositories", approve any pending
+	// permission update).
+	AppStateWriteForbidden
 )
 
 // String returns the stable wire token for a state. These tokens cross the
@@ -90,6 +108,8 @@ func (s AppAuthState) String() string {
 		return "key-invalid"
 	case AppStateNoAppAssigned:
 		return "no-app-assigned"
+	case AppStateWriteForbidden:
+		return "write-forbidden"
 	default:
 		return "unknown"
 	}
@@ -107,7 +127,7 @@ func (s AppAuthState) OperatorActionable() bool {
 // this state themselves. Only these states justify a "do something" banner.
 func (s AppAuthState) UserActionable() bool {
 	switch s {
-	case AppStateNotInstalled, AppStateWrongInstallation, AppStateInsufficientPerms:
+	case AppStateNotInstalled, AppStateWrongInstallation, AppStateInsufficientPerms, AppStateWriteForbidden:
 		return true
 	default:
 		return false
@@ -133,6 +153,8 @@ func ParseAppAuthState(s string) AppAuthState {
 		return AppStateKeyInvalid
 	case "no-app-assigned":
 		return AppStateNoAppAssigned
+	case "write-forbidden":
+		return AppStateWriteForbidden
 	default:
 		return AppStateUnknown
 	}
@@ -236,6 +258,10 @@ type AppAuthDiagnosis struct {
 	// IssuesPerm is the granted issues permission, when the installation
 	// resolved.
 	IssuesPerm string
+	// Repo, when set, is the repository whose write attempt was forbidden.
+	// Only AppStateWriteForbidden (#2353) populates it, so the banner can name
+	// the exact repo the operator must add to the App installation.
+	Repo string
 	// Err is the underlying error, for logs. Never rendered to a user
 	// verbatim, because it can carry raw API text.
 	Err error
@@ -386,6 +412,20 @@ func (d AppAuthDiagnosis) Message() string {
 		}
 		return fmt.Sprintf("The GitHub App is installed for '%s' but granted Issues: %s (Issues: Read & Write required). "+
 			"The org owner must approve the updated permissions at the app installation settings page.", acct, granted)
+
+	case AppStateWriteForbidden:
+		// #2353: authentication and installation-level permissions both check
+		// out, but a real write returned 403. Do NOT claim a missing
+		// permission — the permission IS granted. The likeliest gap is repo
+		// scope: this repo is not in the App installation's selected repos.
+		repo := strings.TrimSpace(d.Repo)
+		if repo == "" {
+			repo = "this repository"
+		}
+		return fmt.Sprintf("The GitHub App is installed and authenticated for '%s' and holds Issues: Read & Write, "+
+			"but a write to %s returned 403 (Resource not accessible by integration). The most likely cause is that "+
+			"%s is not included in the App installation's selected repositories — add it to the installation "+
+			"(or, if a permission update is pending, approve it) at the app installation settings page.", owner, repo, repo)
 
 	default:
 		return "Could not verify this hive's GitHub App credentials. This is usually transient — " +

--- a/v2/pkg/github/app_state_test.go
+++ b/v2/pkg/github/app_state_test.go
@@ -249,6 +249,7 @@ func TestAppAuthState_WireRoundTrip(t *testing.T) {
 	all := []AppAuthState{
 		AppStateUnknown, AppStateOK, AppStateNotInstalled, AppStateWrongInstallation,
 		AppStateInsufficientPerms, AppStateKeyMissing, AppStateKeyInvalid,
+		AppStateNoAppAssigned, AppStateWriteForbidden,
 	}
 	for _, s := range all {
 		if got := ParseAppAuthState(s.String()); got != s {
@@ -269,6 +270,7 @@ func TestAppAuthState_ActionabilityIsExclusive(t *testing.T) {
 	all := []AppAuthState{
 		AppStateUnknown, AppStateOK, AppStateNotInstalled, AppStateWrongInstallation,
 		AppStateInsufficientPerms, AppStateKeyMissing, AppStateKeyInvalid,
+		AppStateNoAppAssigned, AppStateWriteForbidden,
 	}
 	for _, s := range all {
 		if s.OperatorActionable() && s.UserActionable() {
@@ -280,6 +282,39 @@ func TestAppAuthState_ActionabilityIsExclusive(t *testing.T) {
 	}
 	if AppStateUnknown.OperatorActionable() || AppStateUnknown.UserActionable() {
 		t.Error("the unknown state must not be actionable by anyone")
+	}
+}
+
+// TestAppStateWriteForbidden_MessageIsAccurate (#2353) locks in the honest copy
+// for a write-403 on a healthy installation: it must NOT claim the App lacks
+// Issues: Read & Write (the permission IS granted), must name the repo, and must
+// point at the real likely cause — the repo not being in the installation's
+// selected repositories. It is user-actionable (an org owner adds the repo),
+// never operator-side.
+func TestAppStateWriteForbidden_MessageIsAccurate(t *testing.T) {
+	d := AppAuthDiagnosis{
+		State:           AppStateWriteForbidden,
+		ExpectedAccount: "open-horizon-services",
+		Repo:            "Getting-Started",
+	}
+	msg := d.Message()
+	if msg == "" {
+		t.Fatal("write-forbidden must carry banner copy")
+	}
+	if strings.Contains(msg, "lacks Issues") || strings.Contains(msg, "granted Issues: none") {
+		t.Errorf("must not claim a permission gap; got %q", msg)
+	}
+	if !strings.Contains(msg, "Getting-Started") {
+		t.Errorf("message must name the repo; got %q", msg)
+	}
+	if !strings.Contains(msg, "selected repositories") {
+		t.Errorf("message must point at repo-scope as the likely cause; got %q", msg)
+	}
+	if AppStateWriteForbidden.OperatorActionable() {
+		t.Error("write-forbidden is fixed by an org owner, not the operator")
+	}
+	if !AppStateWriteForbidden.UserActionable() {
+		t.Error("write-forbidden must be user-actionable (add the repo to the installation)")
 	}
 }
 

--- a/v2/pkg/hub/advisory_staleness.go
+++ b/v2/pkg/hub/advisory_staleness.go
@@ -33,7 +33,10 @@ func appCanWriteForAdvisory(e RegistryEntry) bool {
 	}
 	switch e.GitHubAppState {
 	case "not-installed", "key-missing", "key-invalid", "no-app-assigned",
-		"wrong-installation", "insufficient-permissions":
+		"wrong-installation", "insufficient-permissions",
+		// #2353: a write returned 403 on an otherwise-healthy install — the App
+		// demonstrably cannot write this repo, so it is NOT writable here.
+		"write-forbidden":
 		return false
 	default:
 		// "ok", "unknown", or empty (spoke too old to classify) — the App is


### PR DESCRIPTION
A hive reported a healthy GitHub App state while unable to WRITE — App authentication and authorization were checked separately and only auth fed health, so a write 403 'Resource not accessible by integration' surfaced only in advisoryError. Added a distinct `write-forbidden` App state with accurate messaging (the repo is likely not in the App installation's selected repositories — NOT a false 'lacks Issues: Read & Write' claim), and a real write-probe so the recheck stops falsely clearing the banner after a read-only verify. Matches the live open-horizon-services/Getting-Started case. Tested. Fixes #2353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)