### PR TITLE
landing: fix Available-hives count, add tile CTAs (request / contribute)

### DIFF
--- a/v2/pkg/hub/fleet_stats_test.go
+++ b/v2/pkg/hub/fleet_stats_test.go
@@ -96,18 +96,33 @@ func TestComputeFleetStats(t *testing.T) {
 			want: FleetStats{ReposManaged: 1, PRsMerged: 2, Hives: 1, TotalHives: 1, Reporting: 1, Eligible: 1},
 		},
 		{
-			// Unassigned placeholders (Org == "") are counted as AVAILABLE and
-			// excluded from the assigned totals — "hives up / total" is about the
-			// working fleet, not idle inventory. Here: 2 assigned (1 up), 3 available.
-			name: "unassigned placeholders count as available, not assigned",
+			// Unassigned placeholders are counted as AVAILABLE and excluded from
+			// the assigned totals — "hives up / total" is about the working fleet,
+			// not idle inventory. A placeholder is detected by its "hosted-available-"
+			// ID prefix OR "available-" org prefix, NOT by an empty Org (an unclaimed
+			// slot keeps a leftover pool org). Here: 2 assigned (1 up), 3 available.
+			name: "placeholders count as available, not assigned",
 			hives: []RegistryEntry{
-				{IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(3)},
-				{IsPublic: false, Online: false, Org: "b", Repos: []string{"r2"}, PRsMerged90d: ptrInt(1)},
-				{Online: true, Org: ""},  // available placeholder, online
-				{Online: false, Org: ""}, // available placeholder, offline
-				{Online: true, Org: ""},  // available placeholder, online
+				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(3)},
+				{ID: "h2", IsPublic: false, Online: false, Org: "b", Repos: []string{"r2"}, PRsMerged90d: ptrInt(1)},
+				{ID: "hosted-available-oke-01-placeholder-aa01", Online: true, Org: "available-pool"}, // both markers, online
+				{ID: "hosted-available-oke-02-placeholder-aa02", Online: false, Org: ""},              // ID marker only, offline
+				{ID: "regular-id", Online: true, Org: "available-pool"},                               // org marker only, online
 			},
 			want: FleetStats{ReposManaged: 1, PRsMerged: 3, Hives: 1, TotalHives: 2, AvailableHives: 3, Reporting: 1, Eligible: 1},
+		},
+		{
+			// THE BUG: an unclaimed slot keeps a leftover REAL pool org (live
+			// example id="hosted-available-oke-01-placeholder-bb95",
+			// org="TradingAsBuddies"). The old Org=="" check missed it entirely —
+			// counting it as assigned and inflating hives-up/total. The
+			// "hosted-available-" ID prefix still marks it available.
+			name: "placeholder with leftover real org is still available",
+			hives: []RegistryEntry{
+				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(9)},
+				{ID: "hosted-available-oke-01-placeholder-bb95", Online: true, Org: "TradingAsBuddies", Repos: []string{"leftover/repo"}},
+			},
+			want: FleetStats{ReposManaged: 1, PRsMerged: 9, Hives: 1, TotalHives: 1, AvailableHives: 1, Reporting: 1, Eligible: 1},
 		},
 		{
 			name:  "no hives yields empty",

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -847,6 +847,15 @@ type ClusterHealthNode struct {
 // hives; pods in these namespaces identify hives running on a node.
 const hiveHostedNamespacePrefix = "hive-hosted-"
 
+// hostedAvailableIDPrefix is the ID prefix a pre-provisioned pool slot carries
+// while it is unclaimed inventory (e.g. "hosted-available-oke-01-placeholder-bb95").
+// It is the RegistryEntry-side marker for an available placeholder: unlike
+// MyHiveEntry, RegistryEntry has no ProvStatus field, so the ID prefix (paired
+// with the "available-" org prefix, placeholderOrgPrefix) is the reliable signal
+// that a slot is idle inventory rather than a claimed hive. A claimed hive keeps
+// neither marker.
+const hostedAvailableIDPrefix = "hosted-available-"
+
 type ClusterHealthSummary struct {
 	TotalNodes    int `json:"total_nodes"`
 	TotalCPUCores int `json:"total_cpu_cores"`

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1888,11 +1888,21 @@ func (s *HubServer) computeFleetStats() FleetStats {
 	repoSet := make(map[string]struct{})
 	for _, h := range s.registry.Hives {
 		// An UNASSIGNED hive is a pre-provisioned placeholder nobody has claimed
-		// yet — it carries no project, so its Org is empty (a claimed hive always
-		// has one). It is counted as AVAILABLE and excluded from the assigned
-		// totals below: "hives up / total" and the contribution sums are about the
+		// yet. It is counted as AVAILABLE and excluded from the assigned totals
+		// below: "hives up / total" and the contribution sums are about the
 		// working fleet, not idle inventory a user could still request.
-		if h.Org == "" {
+		//
+		// A placeholder is NOT detectable by an empty Org: an unclaimed slot
+		// keeps its "hosted-available-" ID prefix and frequently a leftover pool
+		// org (live example: id="hosted-available-oke-01-placeholder-bb95",
+		// org="TradingAsBuddies"). Testing Org=="" therefore matched zero
+		// placeholders AND counted every one as assigned, inflating total_hives
+		// and hives-up. Detect it the way the rest of the codebase does — see
+		// isPlaceholderEntry in drift.go, which uses ProvStatus=="available"
+		// (authoritative) with the "available-" org prefix as fallback. RegistryEntry
+		// has no ProvStatus, so here we use the two markers it does carry: the
+		// "hosted-available-" ID prefix or the "available-" org prefix.
+		if strings.HasPrefix(h.ID, hostedAvailableIDPrefix) || strings.HasPrefix(h.Org, placeholderOrgPrefix) {
 			fs.AvailableHives++
 			continue
 		}

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -371,6 +371,8 @@
       transition: border-color .15s ease, background .15s ease;
     }
     .metric-grid a.stat-jump:hover { border-color: var(--green); background: #0b1016; }
+    /* Muted call-to-action subtext inside a stat tile (e.g. "click to request one"). */
+    .metric-grid a.stat-jump .stat-cta { color: var(--muted); font-size: .7rem; }
 
     /* ── Loop rail ── */
     .loop { background: linear-gradient(#0c121900, #121922bf 30%, #12192200); }
@@ -690,7 +692,12 @@
         <div class="metric-grid">
           <div><span>Agents running</span><strong id="stat-agents">—</strong></div>
           <div><span>Managed repos</span><strong id="stat-repos">—</strong></div>
-          <div><span>Contributors</span><strong id="stat-contributors">—</strong></div>
+          <!-- The Contributors tile links to the "Contribute compute to a hive"
+               card (#contribute-compute), which explains how contributing works:
+               you lend your AI CLI to run agents for a public hive via ClankeR
+               and climb the leaderboard. Same stat-jump affordance/keyboard
+               access as the Public hives tile. -->
+          <a href="#contribute-compute" class="stat-jump" title="Learn how to contribute compute"><span>Contributors</span><strong id="stat-contributors">—</strong></a>
           <!-- The Public hives tile jumps to the public-hive table below (#hives),
                since that table IS the list of public hives this count describes.
                An <a> (not a JS scroll handler) keeps it keyboard-focusable and
@@ -701,7 +708,7 @@
                tile links to the Request-a-Hive wizard (/get-started), so seeing
                "N available" and acting on it is one click. Anchor for the same
                keyboard/right-click reasons as the Public hives tile. -->
-          <a href="/get-started" class="stat-jump" title="Request one of the available hives"><span>Available hives</span><strong id="stat-available">—</strong></a>
+          <a href="/get-started" class="stat-jump" title="Request one of the available hives"><span>Available hives</span><strong id="stat-available">—</strong><span class="stat-cta">click to request one</span></a>
         </div>
       </div>
     </section>
@@ -881,10 +888,10 @@
           <div style="margin-top:1rem"><a class="button primary" href="/get-started">Request a Hive</a></div>
           <p style="font-size:.8rem;margin-top:.8rem"><a href="/get-started#self-host" style="color:var(--blue)">Prefer to self-host? →</a></p>
         </div>
-        <div class="proof-card">
+        <div class="proof-card" id="contribute-compute">
           <div class="tag">Community</div>
           <h3>Contribute compute to a hive</h3>
-          <p>Lend your AI CLI to run agents for a public project. Earn trust tiers as you complete tasks and climb the leaderboard.</p>
+          <p>Lend your AI CLI to run agents for a public project via ClankeR, the contributor relay. Pick a public hive from the table below, run the contribute command, and ClankeR hands your CLI tasks to work &mdash; your GitHub username shows up as a live contributor on that hive with the PRs you land, not as a new hive. Earn trust tiers as you complete tasks and climb the leaderboard.</p>
           <div style="margin-top:1rem"><a class="button secondary" href="/get-started#contribute">Start contributing</a></div>
         </div>
         <div class="proof-card">
@@ -984,6 +991,9 @@
         <h2>Active Hives</h2>
         <input type="text" id="hive-search" placeholder="Search hives..." oninput="filterHiveTable()" style="padding:8px 14px;background:var(--bg-soft);border:1px solid var(--line);border-radius:6px;color:var(--text);font-size:0.85rem;width:250px">
       </div>
+      <!-- Contribute blurb: the Contributors tile and the "Contribute compute"
+           card both point here, so name the action next to the list it refers to. -->
+      <p style="color:var(--muted);font-size:.85rem;margin:-4px 0 14px;max-width:60ch">Want to help? Pick a public hive below and lend your AI CLI to run its agents through ClankeR &mdash; <a href="/get-started#contribute" style="color:var(--blue)">start contributing</a>. Your work shows up as tasks completed under your GitHub username on that hive and on the leaderboard.</p>
       <div id="hive-table-container"><div class="loading">Loading hives...</div></div>
     </section>
 


### PR DESCRIPTION
Three fixes to the public Live-fleet-status panel:

- **Available hives showed 0** — it counted placeholders by `Org == ""`, but an unclaimed placeholder keeps a leftover pool org (e.g. `hosted-available-oke-01-placeholder-bb95` / org `TradingAsBuddies`), so it matched none AND counted every placeholder as *assigned* (inflating hives-up/total). Now keyed off the real markers — the `hosted-available-` ID prefix or the `available-` org prefix (mirroring isPlaceholderEntry) — so available counts correctly and placeholders are excluded from the assigned totals.
- **'Available hives' tile** gains a 'click to request one' subtext (links to /get-started).
- **'Contributors' tile** is now a link to the 'Contribute compute' section, whose copy explains ClankeR: lend your AI CLI, pick a public hive from the table, run the contribute command — your GitHub username shows up as a live contributor with landed PRs (not a new hive). Plus a short contribute blurb above the Active Hives table.

Tested (fleet-stats marker cases incl. a placeholder with a leftover real org); JS node-checked. Based on current v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)