### PR TITLE
landing: count available/assigned hives by ProvStatus, not the hosted-available- prefix

### DIFF
--- a/v2/pkg/hub/fleet_stats_test.go
+++ b/v2/pkg/hub/fleet_stats_test.go
@@ -98,31 +98,75 @@ func TestComputeFleetStats(t *testing.T) {
 		{
 			// Unassigned placeholders are counted as AVAILABLE and excluded from
 			// the assigned totals — "hives up / total" is about the working fleet,
-			// not idle inventory. A placeholder is detected by its "hosted-available-"
-			// ID prefix OR "available-" org prefix, NOT by an empty Org (an unclaimed
-			// slot keeps a leftover pool org). Here: 2 assigned (1 up), 3 available.
+			// not idle inventory. The AUTHORITATIVE signal is ProvStatus=="available";
+			// the "hosted-available-" ID prefix / "available-" org prefix are only a
+			// FALLBACK for entries with no ProvStatus yet. Here: 2 assigned (1 up),
+			// 3 available (all via the prefix fallback, ProvStatus empty).
 			name: "placeholders count as available, not assigned",
 			hives: []RegistryEntry{
 				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(3)},
 				{ID: "h2", IsPublic: false, Online: false, Org: "b", Repos: []string{"r2"}, PRsMerged90d: ptrInt(1)},
-				{ID: "hosted-available-oke-01-placeholder-aa01", Online: true, Org: "available-pool"}, // both markers, online
+				{ID: "hosted-available-oke-01-placeholder-aa01", Online: true, Org: "available-pool"}, // both markers, online, ProvStatus empty
 				{ID: "hosted-available-oke-02-placeholder-aa02", Online: false, Org: ""},              // ID marker only, offline
 				{ID: "regular-id", Online: true, Org: "available-pool"},                               // org marker only, online
 			},
 			want: FleetStats{ReposManaged: 1, PRsMerged: 3, Hives: 1, TotalHives: 2, AvailableHives: 3, Reporting: 1, Eligible: 1},
 		},
 		{
-			// THE BUG: an unclaimed slot keeps a leftover REAL pool org (live
+			// A leftover REAL pool org is still available WHEN unclaimed (live
 			// example id="hosted-available-oke-01-placeholder-bb95",
-			// org="TradingAsBuddies"). The old Org=="" check missed it entirely —
-			// counting it as assigned and inflating hives-up/total. The
-			// "hosted-available-" ID prefix still marks it available.
-			name: "placeholder with leftover real org is still available",
+			// org="TradingAsBuddies"): here ProvStatus is empty, so the
+			// "hosted-available-" ID prefix marks it available.
+			name: "placeholder with leftover real org is available via ID fallback",
 			hives: []RegistryEntry{
 				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(9)},
 				{ID: "hosted-available-oke-01-placeholder-bb95", Online: true, Org: "TradingAsBuddies", Repos: []string{"leftover/repo"}},
 			},
 			want: FleetStats{ReposManaged: 1, PRsMerged: 9, Hives: 1, TotalHives: 1, AvailableHives: 1, Reporting: 1, Eligible: 1},
+		},
+		{
+			// THE OVER-COUNT BUG: a CLAIMED placeholder KEEPS its "hosted-available-"
+			// ID (minted at pool creation, never rewritten on claim) and its leftover
+			// pool org. Gating on the prefix alone counted this as AVAILABLE — the
+			// exact reason the landing page showed 38 available when only 17 are
+			// unclaimed and 33 are assigned. ProvStatus is authoritative: a claimed
+			// status ("claimed") makes it ASSIGNED regardless of the ID/org prefix.
+			// Here: both hives assigned (2 total, 2 up), 0 available.
+			name: "claimed placeholder keeps hosted-available ID but counts as assigned",
+			hives: []RegistryEntry{
+				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(4), ProvStatus: "claimed"},
+				{ID: "hosted-available-oke-01-placeholder-cc11", Online: true, Org: "available-pool",
+					Repos: []string{"real/repo"}, PRsMerged90d: ptrInt(6), ProvStatus: "claimed"},
+			},
+			want: FleetStats{ReposManaged: 2, PRsMerged: 10, Hives: 2, TotalHives: 2, AvailableHives: 0, Reporting: 2, Eligible: 2},
+		},
+		{
+			// ProvStatus=="available" is authoritative even for a hive whose ID does
+			// NOT carry the "hosted-available-" prefix and whose org is not a pool
+			// prefix — a placeholder whose ID/org markers alone would miss it. It
+			// still counts as AVAILABLE, matching the dashboard's Unassigned section.
+			name: "provStatus available is authoritative regardless of ID",
+			hives: []RegistryEntry{
+				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(5)},
+				{ID: "regular-looking-id", Online: true, Org: "some-org", ProvStatus: statusAvailable},
+			},
+			want: FleetStats{ReposManaged: 1, PRsMerged: 5, Hives: 1, TotalHives: 1, AvailableHives: 1, Reporting: 1, Eligible: 1},
+		},
+		{
+			// Reconciliation shape mirroring the live fleet the bug was found on:
+			// 2 hosted-available-* IDs, one still unclaimed (ProvStatus available →
+			// AVAILABLE) and one claimed (ProvStatus claimed → ASSIGNED). The claimed
+			// one must NOT be double-counted as available even though its ID prefix
+			// matches. Available=1, assigned total=2 (the plain hive + the claimed
+			// placeholder).
+			name: "mixed hosted-available pool splits by provStatus",
+			hives: []RegistryEntry{
+				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(2)},
+				{ID: "hosted-available-oke-01-placeholder-dd01", Online: true, Org: "available-pool", ProvStatus: statusAvailable},
+				{ID: "hosted-available-oke-02-placeholder-dd02", Online: true, Org: "available-pool",
+					Repos: []string{"claimed/repo"}, PRsMerged90d: ptrInt(3), ProvStatus: "claimed"},
+			},
+			want: FleetStats{ReposManaged: 2, PRsMerged: 5, Hives: 2, TotalHives: 2, AvailableHives: 1, Reporting: 2, Eligible: 2},
 		},
 		{
 			name:  "no hives yields empty",

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -111,29 +111,42 @@ type RegistryEntry struct {
 	// AdvisoryError is the log-safe error from the spoke's most recent failed
 	// advisory-post attempt ("" on success). When set on an app-can-write hive
 	// it trips the stale pill directly, carrying the specific cause.
-	AdvisoryError      string         `json:"advisoryError,omitempty"`
-	PrimaryRepo        string         `json:"primaryRepo"`
-	DashboardURL       string         `json:"dashboardUrl"`
-	SnapshotURL        string         `json:"snapshotUrl,omitempty"`
-	ACMMLevel          int            `json:"acmmLevel"`
-	AgentCount         int            `json:"agentCount"`
-	GovernorMode       string         `json:"governorMode"`
-	TotalTokens24h     int64          `json:"totalTokens24h"`
-	ActionableIssues   int            `json:"actionableIssues"`
-	ActionablePRs      int            `json:"actionablePRs"`
-	ContributorCount   int            `json:"contributorCount"`
-	ActiveContributors int            `json:"activeContributors"`
-	Owner              string         `json:"owner,omitempty"`
-	ClusterID          string         `json:"clusterId,omitempty"`
-	ClusterName        string         `json:"clusterName,omitempty"`
-	HiveType           string         `json:"hiveType,omitempty"`
-	IsPublic           bool           `json:"isPublic"`
-	RegisteredAt       string         `json:"registeredAt"`
-	LastHeartbeat      string         `json:"lastHeartbeat"`
-	Health             map[string]any `json:"health"`
-	Version            string         `json:"version"`
-	GitHash            string         `json:"gitHash,omitempty"`
-	GitBranch          string         `json:"gitBranch,omitempty"`
+	AdvisoryError      string `json:"advisoryError,omitempty"`
+	PrimaryRepo        string `json:"primaryRepo"`
+	DashboardURL       string `json:"dashboardUrl"`
+	SnapshotURL        string `json:"snapshotUrl,omitempty"`
+	ACMMLevel          int    `json:"acmmLevel"`
+	AgentCount         int    `json:"agentCount"`
+	GovernorMode       string `json:"governorMode"`
+	TotalTokens24h     int64  `json:"totalTokens24h"`
+	ActionableIssues   int    `json:"actionableIssues"`
+	ActionablePRs      int    `json:"actionablePRs"`
+	ContributorCount   int    `json:"contributorCount"`
+	ActiveContributors int    `json:"activeContributors"`
+	Owner              string `json:"owner,omitempty"`
+	ClusterID          string `json:"clusterId,omitempty"`
+	ClusterName        string `json:"clusterName,omitempty"`
+	HiveType           string `json:"hiveType,omitempty"`
+	// ProvStatus is the authoritative provisioning status copied from the hive's
+	// SaaSHive record (sh.Status) on the heartbeat path — statusAvailable
+	// ("available") for a genuinely-unclaimed pool placeholder, else a claimed
+	// status ("claimed", "assigned", …) or "" for a hive with no SaaSHive record.
+	//
+	// It exists because a CLAIMED placeholder KEEPS its "hosted-available-" ID and
+	// leftover pool org after assignment (the ID is minted at pool creation and
+	// never changes on claim), so the ID/org prefix alone OVER-counts available
+	// hives. computeFleetStats and isPlaceholderEntry both treat this field as
+	// authoritative, with the prefix used only as a fallback when it is empty, so
+	// the landing-page count and the dashboard's Assigned/Unassigned sections
+	// agree on what "available" means. A scalar status — no PII.
+	ProvStatus    string         `json:"provStatus,omitempty"`
+	IsPublic      bool           `json:"isPublic"`
+	RegisteredAt  string         `json:"registeredAt"`
+	LastHeartbeat string         `json:"lastHeartbeat"`
+	Health        map[string]any `json:"health"`
+	Version       string         `json:"version"`
+	GitHash       string         `json:"gitHash,omitempty"`
+	GitBranch     string         `json:"gitBranch,omitempty"`
 	// ImageRef is the container image this spoke's own Deployment runs, as
 	// read in-cluster by the spoke and reported over the heartbeat. The hub
 	// cannot see it any other way for firewalled/heartbeat-only spokes, and
@@ -1071,10 +1084,15 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		AgentsWithModel: clampFleetCount(payload.AgentsWithModel),
 	}
 
-	// Populate ClusterID from SaaS hive record, heartbeat payload, or default.
+	// Populate ClusterID and the authoritative ProvStatus from the SaaS hive
+	// record (a single load reused for both). ProvStatus is what lets
+	// computeFleetStats tell a genuinely-unclaimed placeholder (statusAvailable)
+	// from a CLAIMED one that still carries the "hosted-available-" ID — the ID
+	// prefix alone over-counts available hives because it never changes on claim.
 	clusterID := ""
 	if sh := loadSaaSHive(payload.HiveID); sh != nil {
 		clusterID = sh.ClusterID
+		entry.ProvStatus = sh.Status
 	}
 	if clusterID == "" && payload.ClusterID != "" {
 		clusterID = sanitizeHeartbeatField(payload.ClusterID)
@@ -1875,6 +1893,21 @@ type FleetStats struct {
 // rather than freezing a stale figure on the public page forever.
 const fleetStatsMaxAge = 6 * time.Hour
 
+// isAvailableRegistryEntry reports whether a registry entry is a genuinely
+// unclaimed pool placeholder — the "available"/"unassigned" bucket on the
+// landing page and dashboard. It mirrors isPlaceholderEntry (drift.go) exactly:
+// ProvStatus==statusAvailable is AUTHORITATIVE, and the "hosted-available-" ID
+// prefix / "available-" org prefix are only a FALLBACK for entries whose
+// ProvStatus is unknown (empty). A CLAIMED placeholder keeps its
+// "hosted-available-" ID after assignment, so gating on the prefix alone
+// over-counts available hives; gating on ProvStatus first fixes that.
+func isAvailableRegistryEntry(h RegistryEntry) bool {
+	if h.ProvStatus != "" {
+		return h.ProvStatus == statusAvailable
+	}
+	return strings.HasPrefix(h.ID, hostedAvailableIDPrefix) || strings.HasPrefix(h.Org, placeholderOrgPrefix)
+}
+
 // computeFleetStats aggregates fleet-wide contribution counts across public,
 // non-stale hives. A hive that never reported a given count (nil pointer) is
 // skipped for that count — the aggregate reflects only hives with real data,
@@ -1896,13 +1929,22 @@ func (s *HubServer) computeFleetStats() FleetStats {
 		// keeps its "hosted-available-" ID prefix and frequently a leftover pool
 		// org (live example: id="hosted-available-oke-01-placeholder-bb95",
 		// org="TradingAsBuddies"). Testing Org=="" therefore matched zero
-		// placeholders AND counted every one as assigned, inflating total_hives
-		// and hives-up. Detect it the way the rest of the codebase does — see
-		// isPlaceholderEntry in drift.go, which uses ProvStatus=="available"
-		// (authoritative) with the "available-" org prefix as fallback. RegistryEntry
-		// has no ProvStatus, so here we use the two markers it does carry: the
-		// "hosted-available-" ID prefix or the "available-" org prefix.
-		if strings.HasPrefix(h.ID, hostedAvailableIDPrefix) || strings.HasPrefix(h.Org, placeholderOrgPrefix) {
+		// placeholders AND counted every one as assigned.
+		//
+		// The ID/org PREFIX alone over-counts the other way: a CLAIMED placeholder
+		// KEEPS its "hosted-available-" ID and pool org after assignment (the ID is
+		// minted at pool creation and never changes on claim). ~21 of the 38
+		// "hosted-available-" hives are actually claimed, so the prefix reported 38
+		// "available" when the truth is 17 unclaimed / 33 assigned.
+		//
+		// Detect it the way the rest of the codebase does — see isPlaceholderEntry
+		// in drift.go and the dashboard's Assigned/Unassigned sections: the
+		// authoritative signal is ProvStatus==statusAvailable, with the
+		// "hosted-available-" ID prefix / "available-" org prefix used ONLY as a
+		// fallback when ProvStatus is unknown (empty — a hive with no SaaSHive
+		// record or one that predates the field). A claimed placeholder therefore
+		// counts as ASSIGNED, not available.
+		if isAvailableRegistryEntry(h) {
 			fs.AvailableHives++
 			continue
 		}


### PR DESCRIPTION
## Problem

The public landing page (\"Live fleet status\") showed **38 available hives** while the admin dashboard's own section headers say **33 assigned / 17 unassigned**. The two disagreed.

## Root cause

\`computeFleetStats()\` classified an available/unassigned hive by the \`hosted-available-\` **ID prefix** (or \`available-\` **org prefix**). That over-counts: a **claimed** placeholder KEEPS its \`hosted-available-\` ID and leftover pool org after assignment — the ID is minted at pool creation and never rewritten on claim (live example \`id=hosted-available-oke-01-placeholder-bb95, org=TradingAsBuddies\`). ~21 of the 38 \`hosted-available-\` hives are actually claimed, so the prefix reported 38 available when the truth is 17 unclaimed / 33 assigned.

The authoritative \"unclaimed\" signal is \`ProvStatus == \"available\"\` (\`statusAvailable\`) — exactly what \`isPlaceholderEntry\` (drift.go) and the dashboard's Assigned/Unassigned sections use. But \`RegistryEntry\` did not carry \`ProvStatus\` — it lived only on \`MyHiveEntry\`.

## Fix

- Add \`ProvStatus\` (scalar status, no PII) to \`RegistryEntry\`, populated on the heartbeat path from the \`SaaSHive\` record already loaded there for \`ClusterID\` (\`entry.ProvStatus = sh.Status\`).
- \`computeFleetStats\` now gates the available count on \`ProvStatus == statusAvailable\`, falling back to the ID/org prefix **only** when \`ProvStatus\` is empty — mirroring \`isPlaceholderEntry\`'s precedence exactly. A claimed \`hosted-available-*\` hive now counts as **assigned**; only genuinely-unclaimed slots count as \`AvailableHives\`.

## Tests

Updated \`TestComputeFleetStats\`:
- \`ProvStatus==available\` counts as available regardless of ID.
- A \`hosted-available-*\` ID with a **claimed** ProvStatus counts as **ASSIGNED** (the exact over-count bug).
- Prefix/org fallback still applies when ProvStatus is empty.
- Mixed hosted-available pool splits correctly by ProvStatus.

\`go build ./...\`, \`gofmt\`, and \`go test ./pkg/hub/ -run 'FleetStats|ComputeFleetStats'\` + heartbeat/registry tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)