### PR TITLE
dashboard: drop shadow on mode icons; add Issues link to Resources

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -183,7 +183,7 @@
     }
     .oc-nav-emoji { display: inline-flex; width: 18px; font-size: 0.9rem; flex-shrink: 0; justify-content: center; }
     .oc-nav-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
-    .oc-nav-mode { flex-shrink: 0; font-size: 0.9rem; margin-left: 2px; transition: opacity 0.15s; }
+    .oc-nav-mode { flex-shrink: 0; font-size: 0.9rem; margin-left: 2px; transition: opacity 0.15s; text-shadow: 0 1px 2px rgba(0,0,0,0.5); }
     /* The hover-revealed row actions (⚙/✕) take the right edge — fade the
        passive mode icon out so they never overlap it at any sidebar width. */
     .oc-nav-item:hover .oc-nav-mode { opacity: 0; }
@@ -2569,6 +2569,7 @@
       <a class="oc-nav-item" data-section="faq-section" onclick="ocNavigate('faq-section')" title="Answers to common first-time questions: the Advisory Digest, ACMM levels, how to advance, and managing cost"><span class="oc-nav-emoji">❓</span><span class="oc-nav-text">FAQ</span></a>
       <a class="oc-nav-item" id="welcome-nav-item" style="display:none" onclick="openWelcomeDialog()" title="Open the Getting Started checklist — one-time setup steps for a new hive"><span class="oc-nav-emoji">🚀</span><span class="oc-nav-text">Getting Started</span></a>
       <a class="oc-nav-item" href="/api/docs" target="_blank"><span class="oc-nav-emoji">📘</span><span class="oc-nav-text">API Spec (Redoc)</span></a>
+      <a class="oc-nav-item" href="https://github.com/kubestellar/hive/issues" target="_blank" rel="noopener noreferrer"><span class="oc-nav-emoji">🐛</span><span class="oc-nav-text">Issues</span></a>
     </div>
     <div class="system-gauges" id="system-gauges">
       <div class="sys-gauge-row" id="sys-gauge-disk" title="Disk usage">


### PR DESCRIPTION
Two small dashboard UI tweaks (`v2/pkg/dashboard/static/index.html`).

## Drop shadow on mode icons
The per-agent mode emoji in the sidebar (📝 advisory, 🎫 issues-only, 🔧 CI-gated, 🚀 auto-merge) rendered flat against the dark sidebar. Added a subtle `text-shadow: 0 1px 2px rgba(0,0,0,0.5)` to the `.oc-nav-mode` class so the glyphs read with depth. Scoped to that class only — no other emoji are affected.

## Issues link in Resources
Added an **Issues** row (🐛) to the Resources nav group, linking to https://github.com/kubestellar/hive/issues. Placed after **API Spec (Redoc)**, styled identically to its sibling `oc-nav-item` rows, opening in a new tab (`target="_blank" rel="noopener noreferrer"`). No count pill.

## Validation
- `go build ./...` clean.
- `go test ./pkg/dashboard/` passes.
- No JS changed (static HTML/CSS only); no test pins the changed markup.

🤖 Generated with Claude Code