### PR TITLE
governor(repos): forge-prefixed add form, no forge mixing, App-access-on-add, enforced default repo

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -136,6 +136,10 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("POST /api/config/governor/agents", s.handleGovernorAddAgent)
 	s.mux.HandleFunc("DELETE /api/config/governor/agents/{name}", s.handleGovernorRemoveAgent)
 	s.mux.HandleFunc("PUT /api/config/governor/repos", s.handleGovernorRepos)
+	// Access probe run when the Repos tab adds a new repo: verifies the hive's
+	// GitHub App is installed on the new repo's org before the repo is accepted,
+	// and hands back the correct per-forge install URL when it is not.
+	s.mux.HandleFunc("POST /api/config/governor/repos/check-access", s.handleGovernorRepoCheckAccess)
 	s.mux.HandleFunc("PUT /api/config/github", s.handleConfigGitHub)
 
 	s.mux.HandleFunc("GET /api/agents", s.handleAgentsList)
@@ -4649,6 +4653,34 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 	}
 	org := s.deps.Config.Project.Org
 
+	// Single-host-per-spoke (defence in depth; the Repos tab also checks this
+	// client-side so it fails fast). Every repo the user submits must live on
+	// this hive's forge — mixing github.com and a GHE instance silently breaks
+	// App auth for half the repos. Check the raw pasted values BEFORE the loop
+	// below strips the host off each one. hiveForgeHost() is this hive's own
+	// GitHub host (github.com or the GHE hostname), the same value the dashboard
+	// derives from github_base_url.
+	// Snapshot so a validation failure AFTER we mutate the in-memory config can
+	// restore it — the "always exactly one default" guard below runs once the
+	// final repos+primary are known, and a reject must not leave a half-applied
+	// config in memory (which would then be persisted on the next unrelated save).
+	prevRepos := append([]string(nil), s.deps.Config.Project.Repos...)
+	prevPrimary := s.deps.Config.Project.PrimaryRepo
+
+	spokeHost := s.hiveForgeHost()
+	for _, ref := range body.Repos {
+		if h := repoRefHostLabel(ref); h != "" && !sameForgeHost(h, spokeHost) {
+			jsonError(w, fmt.Sprintf("repo %q is on %s but this hive is on %s — a hive's repos must all be on one GitHub host. Remove the mismatched repo or use a repo on %s.", strings.TrimSpace(ref), h, spokeHost, spokeHost), http.StatusBadRequest)
+			return
+		}
+	}
+	if body.PrimaryRepo != nil {
+		if h := repoRefHostLabel(*body.PrimaryRepo); h != "" && !sameForgeHost(h, spokeHost) {
+			jsonError(w, fmt.Sprintf("default repo %q is on %s but this hive is on %s — the default must live on this hive's forge.", strings.TrimSpace(*body.PrimaryRepo), h, spokeHost), http.StatusBadRequest)
+			return
+		}
+	}
+
 	if len(body.Repos) > 0 {
 		stripped := make([]string, 0, len(body.Repos))
 		for _, repo := range body.Repos {
@@ -4704,6 +4736,31 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Always exactly one default: a hive with repos must name a primary_repo that
+	// is one of them — that is the repo the advisory issue is maintained in. The
+	// Repos tab disables Save until a star is chosen, but enforce it server-side
+	// too so no client (or a stale one) can persist repos with no default. Reject
+	// and restore the pre-mutation config so the in-memory state stays coherent.
+	if final := s.deps.Config.Project.Repos; len(final) > 0 {
+		primary := s.deps.Config.Project.PrimaryRepo
+		inList := false
+		for _, r := range final {
+			if r == primary {
+				inList = true
+				break
+			}
+		}
+		if primary == "" || !inList {
+			s.deps.Config.Project.Repos = prevRepos
+			s.deps.Config.Project.PrimaryRepo = prevPrimary
+			if s.deps.GHClient != nil {
+				s.deps.GHClient.SetRepos(prevRepos)
+			}
+			jsonError(w, "set a default repo before saving — one of the monitored repos must be marked as the default (the repo where the advisory issue is maintained)", http.StatusBadRequest)
+			return
+		}
+	}
+
 	if err := s.saveConfig(); err != nil {
 		s.logger.Error("failed to persist config", "error", err)
 	}
@@ -4713,6 +4770,152 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 	s.auditFromRequest(r, "config_governor_repos", auditDetail("section", "repos"), "")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
+}
+
+// hiveForgeHost returns the bare GitHub hostname this hive's repos and App live
+// on ("github.com" or a GHE hostname like "github.ibm.com"). It is the single
+// source of truth the single-host-per-spoke guard compares each submitted repo
+// against, and mirrors config.GitHubConfig.HostLabel() (the same value the
+// dashboard reads as github_base_url's host). Falls back to public github.com
+// when no config is loaded (tests/early boot).
+func (s *Server) hiveForgeHost() string {
+	if s.deps != nil && s.deps.Config != nil {
+		return s.deps.Config.GitHub.HostLabel()
+	}
+	return "github.com"
+}
+
+// repoRefHostLabel extracts the GitHub host a repo string was pasted with, or ""
+// when none was given (a bare "repo" or "owner/repo", which by definition belongs
+// to the hive's own forge). Mirrors hub.repoRefHost: a full URL or a leading
+// dotted segment ("github.ibm.com/org/repo") names an explicit host. Returned
+// lowercased for case-insensitive comparison in sameForgeHost.
+func repoRefHostLabel(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	s = strings.Trim(s, "/")
+	if s == "" {
+		return ""
+	}
+	parts := strings.Split(s, "/")
+	if len(parts) > 1 && strings.Contains(parts[0], ".") {
+		return strings.ToLower(parts[0])
+	}
+	return ""
+}
+
+// sameForgeHost reports whether two host labels refer to the same GitHub. Both
+// "" and "github.com" mean public GitHub; a GHE host equals only itself.
+// Case-insensitive. Mirrors hub.sameGitHubHost so the dashboard's single-host
+// rule matches the hub's request/assign validation exactly.
+func sameForgeHost(a, b string) bool {
+	norm := func(h string) string {
+		h = strings.ToLower(strings.TrimSpace(h))
+		if h == "" || h == "github.com" {
+			return "github.com"
+		}
+		return h
+	}
+	return norm(a) == norm(b)
+}
+
+// handleGovernorRepoCheckAccess verifies that this hive's GitHub App can access
+// a repo the operator is about to add, and — when it cannot — returns the
+// per-forge App install/authorize URL so the Repos tab can guide the user to
+// grant access before the repo is finally accepted (requirement #3).
+//
+// The check today probes at ORG granularity: DiscoverInstallationID(org) returns
+// ErrNoInstallationForOrg when the App is not installed on the repo's org at all,
+// which is the common "new org the App was never installed on" case and the one
+// that hard-blocks reads and writes. On a positive result we report ok:true.
+//
+// TODO(repo-access-probe): tighten to REPO granularity. An App installed on the
+// org "Only select repositories" may still lack THIS repo (see #2353's
+// write-forbidden case). The deeper probe should mint an installation token and
+// GET /repos/{org}/{repo} (s.deps.GHClient.GetRepo) — a 404/403 there means the
+// installation exists but this repo is not in its selected set, which needs the
+// same "manage installation" URL to add the repo to the selection. That probe is
+// scoped out of this change to keep it focused; the org-level check plus the
+// install workflow already covers the "App not installed on the org" footgun.
+func (s *Server) handleGovernorRepoCheckAccess(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Repo string `json:"repo"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	ref := sanitizeString(body.Repo)
+	if ref == "" {
+		jsonError(w, "repo is required", http.StatusBadRequest)
+		return
+	}
+	// Single-host guard here too: an added repo on a different forge is rejected
+	// before we even probe access, with the same message as the save path.
+	spokeHost := s.hiveForgeHost()
+	if h := repoRefHostLabel(ref); h != "" && !sameForgeHost(h, spokeHost) {
+		jsonError(w, fmt.Sprintf("repo %q is on %s but this hive is on %s — a hive's repos must all be on one GitHub host.", ref, h, spokeHost), http.StatusBadRequest)
+		return
+	}
+	// Resolve the org the repo lives in. The paste may be "org/repo", a bare
+	// "repo" (org is the hive's configured org), or a full URL. Strip any host
+	// and pull the org segment when present.
+	org := s.deps.Config.Project.Org
+	stripped := ref
+	stripped = strings.TrimPrefix(stripped, "https://")
+	stripped = strings.TrimPrefix(stripped, "http://")
+	stripped = strings.Trim(stripped, "/")
+	parts := strings.Split(stripped, "/")
+	// Drop a leading host segment ("github.ibm.com/org/repo" -> "org/repo").
+	if len(parts) > 1 && strings.Contains(parts[0], ".") {
+		parts = parts[1:]
+	}
+	if len(parts) >= 2 && parts[0] != "" {
+		org = parts[0]
+	}
+	if org == "" {
+		jsonError(w, "cannot determine the org for this repo — use org/repo format", http.StatusBadRequest)
+		return
+	}
+
+	// An App-less hive (advisory-only, no private key) cannot and need not probe
+	// installation access: it never writes. Treat it as "no access check needed"
+	// so the add proceeds — the single-host guard above already ran.
+	if s.deps.GHAppAuth == nil || !s.deps.GHAppAuth.HasKey() {
+		okResponse(w, map[string]string{"status": "no-app"})
+		return
+	}
+
+	ctx := s.deps.Ctx
+	if ctx == nil {
+		ctx = r.Context()
+	}
+	if _, err := s.deps.GHAppAuth.DiscoverInstallationID(ctx, org); err != nil {
+		// Not installed on this org (or discovery failed). Surface the correct
+		// per-forge install URL and arm the existing pending-install mechanism so
+		// the banner/recheck plumbing the App-required flow already uses drives
+		// this to completion. AppInstallURL() returns "" for a GHE host whose App
+		// slug was never configured — the UI renders that as a config message
+		// rather than a dead link.
+		installURL := ""
+		if s.deps.Config != nil {
+			installURL = s.deps.Config.GitHub.AppInstallURL()
+		}
+		s.SetPendingGitHubAppInstall()
+		s.logger.Info("repo add blocked: app not installed on org", "org", org, "repo", ref, "error", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":           false,
+			"needsInstall": true,
+			"org":          org,
+			"installUrl":   installURL,
+			"error":        fmt.Sprintf("the Hive GitHub App is not installed on %q, so it cannot read or write %s. Install/authorize the App for %q, then re-check.", org, ref, org),
+		})
+		return
+	}
+	okResponse(w, map[string]string{"status": "ok", "org": org})
 }
 
 func (s *Server) handleGitHubAppInstallClicked(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -1477,7 +1477,9 @@ func TestHandleGovernorBudget_Success(t *testing.T) {
 
 func TestHandleGovernorRepos_Success(t *testing.T) {
 	s, _ := apiServer(t)
-	rec := doPut(s, "/api/config/governor/repos", map[string]interface{}{"repos": []string{"myorg/repo1", "myorg/repo2"}})
+	// Replacing the repo set must name a default among the new repos (the
+	// always-exactly-one-default invariant), so send primaryRepo too.
+	rec := doPut(s, "/api/config/governor/repos", map[string]interface{}{"repos": []string{"myorg/repo1", "myorg/repo2"}, "primaryRepo": "repo1"})
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}
@@ -1485,7 +1487,7 @@ func TestHandleGovernorRepos_Success(t *testing.T) {
 
 func TestHandleGovernorRepos_StripOrg(t *testing.T) {
 	s, deps := apiServer(t)
-	rec := doPut(s, "/api/config/governor/repos", map[string]interface{}{"repos": []string{"myorg/new-repo"}})
+	rec := doPut(s, "/api/config/governor/repos", map[string]interface{}{"repos": []string{"myorg/new-repo"}, "primaryRepo": "myorg/new-repo"})
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}

--- a/v2/pkg/dashboard/api_governor_coverage_test.go
+++ b/v2/pkg/dashboard/api_governor_coverage_test.go
@@ -129,12 +129,18 @@ func TestCovGov_Repos(t *testing.T) {
 	if rec := doPut(s, "/api/config/governor/repos", map[string]any{"repos": []string{"bad;rm"}}); rec.Code != http.StatusBadRequest {
 		t.Fatalf("repos invalid: %d", rec.Code)
 	}
-	// Valid plain repo list.
-	if rec := doPut(s, "/api/config/governor/repos", map[string]any{"repos": []string{"repoA", "repoB"}}); rec.Code != http.StatusOK {
+	// Valid plain repo list (with a default among them — required now).
+	if rec := doPut(s, "/api/config/governor/repos", map[string]any{"repos": []string{"repoA", "repoB"}, "primaryRepo": "repoA"}); rec.Code != http.StatusOK {
 		t.Fatalf("repos ok: %d", rec.Code)
 	}
-	// A full GitHub URL repo (exercises URL-parsing branch, incl GHE host).
-	if rec := doPut(s, "/api/config/governor/repos", map[string]any{"repos": []string{"https://github.ibm.com/myorg/repoC"}}); rec.Code != http.StatusOK {
+	// A cross-forge repo (GHE URL on a public-github.com hive) must be REJECTED
+	// by the single-host-per-spoke guard — a hive's repos all live on one host.
+	if rec := doPut(s, "/api/config/governor/repos", map[string]any{"repos": []string{"https://github.ibm.com/myorg/repoC"}, "primaryRepo": "repoC"}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("cross-forge repo should be rejected: %d", rec.Code)
+	}
+	// A full same-forge (github.com) URL repo still exercises the URL-parsing
+	// branch and is accepted.
+	if rec := doPut(s, "/api/config/governor/repos", map[string]any{"repos": []string{"https://github.com/myorg/repoC"}, "primaryRepo": "repoC"}); rec.Code != http.StatusOK {
 		t.Fatalf("repos url: %d", rec.Code)
 	}
 }

--- a/v2/pkg/dashboard/api_test.go
+++ b/v2/pkg/dashboard/api_test.go
@@ -51,11 +51,11 @@ func testDeps(t *testing.T) *Dependencies {
 	_ = &refreshCalled
 	_ = &persistCalled
 	return &Dependencies{
-		Config:   cfg,
-		AgentMgr: mgr,
-		Governor: gov,
-		Logger:   logger,
-		Ctx:      context.Background(),
+		Config:      cfg,
+		AgentMgr:    mgr,
+		Governor:    gov,
+		Logger:      logger,
+		Ctx:         context.Background(),
 		RefreshFunc: func() { refreshCalled.Store(true) },
 		PersistFunc: func() { persistCalled.Store(true) },
 	}
@@ -499,7 +499,7 @@ func TestHandleGovernorRemoveAgent_NotFound(t *testing.T) {
 func TestHandleGovernorRepos(t *testing.T) {
 	s, _ := apiServer(t)
 	rec := doPut(s, "/api/config/governor/repos",
-		map[string]interface{}{"repos": []string{"myorg/repo1", "myorg/repo2"}})
+		map[string]interface{}{"repos": []string{"myorg/repo1", "myorg/repo2"}, "primaryRepo": "repo1"})
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}

--- a/v2/pkg/dashboard/coverage_boost2_test.go
+++ b/v2/pkg/dashboard/coverage_boost2_test.go
@@ -75,7 +75,9 @@ func TestHandleGovernorRepos_InvalidBody_Boost(t *testing.T) {
 
 func TestHandleGovernorRepos_SimpleRepos(t *testing.T) {
 	srv := newFullServer(t)
-	body := `{"repos":["repo1","repo2"]}`
+	// A save that replaces the repo set must also name a default that is one of
+	// the new repos (the always-exactly-one-default invariant), so send both.
+	body := `{"repos":["repo1","repo2"],"primaryRepo":"repo1"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -88,7 +90,7 @@ func TestHandleGovernorRepos_SimpleRepos(t *testing.T) {
 
 func TestHandleGovernorRepos_URLParsing(t *testing.T) {
 	srv := newFullServer(t)
-	body := `{"repos":["https://github.com/myorg/myrepo"]}`
+	body := `{"repos":["https://github.com/myorg/myrepo"],"primaryRepo":"myrepo"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -117,8 +119,10 @@ func TestHandleGovernorRepos_InvalidRepoName(t *testing.T) {
 
 func TestHandleGovernorRepos_PrimaryRepo(t *testing.T) {
 	srv := newFullServer(t)
+	// The chosen default must be one of the monitored repos, so send both the
+	// repo and the primaryRepo that names it (always-exactly-one-default).
 	primary := "newrepo"
-	body := `{"primaryRepo":"newrepo"}`
+	body := `{"repos":["newrepo"],"primaryRepo":"newrepo"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -133,18 +137,22 @@ func TestHandleGovernorRepos_PrimaryRepo(t *testing.T) {
 }
 
 func TestHandleGovernorRepos_GHE_URL(t *testing.T) {
+	// A hive already on github.com (newFullServer's testrepo) must NOT be able to
+	// add a repo on a different forge — that would mix hosts and silently break
+	// App auth for half the repos. The single-host-per-spoke guard rejects it and
+	// leaves the hive's forge untouched.
 	srv := newFullServer(t)
-	body := `{"repos":["https://ghe.example.com/myorg/myrepo"]}`
+	body := `{"repos":["https://ghe.example.com/myorg/myrepo"],"primaryRepo":"myrepo"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.handleGovernorRepos(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("code = %d, want 200", w.Code)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 (cross-forge repo rejected)", w.Code)
 	}
-	if srv.deps.Config.GitHub.BaseURL != "https://ghe.example.com" {
-		t.Errorf("baseURL = %q", srv.deps.Config.GitHub.BaseURL)
+	if srv.deps.Config.GitHub.BaseURL == "https://ghe.example.com" {
+		t.Errorf("hive forge was switched to a mismatched host: %q", srv.deps.Config.GitHub.BaseURL)
 	}
 }
 
@@ -300,7 +308,7 @@ func TestHandleSnapshotPage_CustomHubURL(t *testing.T) {
 func TestHandleGovernorRepos_StripOrgPrefix(t *testing.T) {
 	srv := newFullServer(t)
 	srv.deps.Config.Project.Org = "testorg"
-	body := `{"repos":["testorg/repo1"]}`
+	body := `{"repos":["testorg/repo1"],"primaryRepo":"repo1"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/v2/pkg/dashboard/coverage_boost3_test.go
+++ b/v2/pkg/dashboard/coverage_boost3_test.go
@@ -909,7 +909,9 @@ func TestHealthSummary_WithAgents(t *testing.T) {
 
 func TestHandleGovernorRepos_PrimaryRepoURL(t *testing.T) {
 	srv := newFullServer(t)
-	body := `{"primaryRepo":"https://github.com/otherorg/otherrepo"}`
+	// The default must be one of the monitored repos, so send the repo alongside
+	// the pasted primary-repo URL (which the handler strips to a bare name).
+	body := `{"repos":["otherrepo"],"primaryRepo":"https://github.com/otherorg/otherrepo"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/v2/pkg/dashboard/coverage_boost4_test.go
+++ b/v2/pkg/dashboard/coverage_boost4_test.go
@@ -406,7 +406,7 @@ func newDeepTestServer(t *testing.T) *Server {
 			Org: "testorg", Name: "test", PrimaryRepo: "testrepo",
 			Repos: []string{"testrepo"},
 		},
-		Data:   config.DataConfig{AgentsDir: agentsDir},
+		Data: config.DataConfig{AgentsDir: agentsDir},
 		Agents: map[string]config.AgentConfig{
 			"scanner": {ID: "scan-001", Role: "scanner", Backend: "claude", Model: "sonnet", DisplayName: "Scanner", Enabled: true},
 		},
@@ -433,12 +433,12 @@ func newDeepTestServer(t *testing.T) *Server {
 
 	srv := NewServer(0, logger)
 	srv.deps = &Dependencies{
-		Config:     cfg,
-		AgentMgr:   mgr,
-		Governor:   gov,
-		BeadStores: map[string]*beads.Store{"scanner": scannerStore},
-		Logger:     logger,
-		Ctx:        context.Background(),
+		Config:         cfg,
+		AgentMgr:       mgr,
+		Governor:       gov,
+		BeadStores:     map[string]*beads.Store{"scanner": scannerStore},
+		Logger:         logger,
+		Ctx:            context.Background(),
 		RefreshFunc:    func() {},
 		PersistFunc:    func() {},
 		SkipReloadFunc: func() {},
@@ -479,7 +479,7 @@ func TestHandleGovernorRepos_WithEnumerateFunc(t *testing.T) {
 	srv := newFullServer(t)
 	srv.deps.EnumerateFunc = func() {}
 
-	body := `{"repos":["repo1","repo2"]}`
+	body := `{"repos":["repo1","repo2"],"primaryRepo":"repo1"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/v2/pkg/dashboard/dashboard_handlers_extra_test.go
+++ b/v2/pkg/dashboard/dashboard_handlers_extra_test.go
@@ -29,7 +29,7 @@ func newFullServer(t *testing.T) *Server {
 			Org: "testorg", Name: "test", PrimaryRepo: "testrepo",
 			Repos: []string{"testrepo"},
 		},
-		Data:   config.DataConfig{AgentsDir: t.TempDir()},
+		Data: config.DataConfig{AgentsDir: t.TempDir()},
 		Agents: map[string]config.AgentConfig{
 			"scanner": {ID: "scan-001", Role: "scanner", Backend: "claude", Model: "sonnet", DisplayName: "Scanner"},
 		},
@@ -47,12 +47,12 @@ func newFullServer(t *testing.T) *Server {
 
 	srv := NewServer(0, logger)
 	srv.deps = &Dependencies{
-		Config:   cfg,
-		AgentMgr: mgr,
-		Governor: gov,
-		BeadStores: map[string]*beads.Store{"scanner": scannerStore},
-		Logger:   logger,
-		Ctx:      context.Background(),
+		Config:         cfg,
+		AgentMgr:       mgr,
+		Governor:       gov,
+		BeadStores:     map[string]*beads.Store{"scanner": scannerStore},
+		Logger:         logger,
+		Ctx:            context.Background(),
 		RefreshFunc:    func() {},
 		PersistFunc:    func() {},
 		SkipReloadFunc: func() {},
@@ -222,7 +222,9 @@ func TestHandleGovernorReposBadJSON(t *testing.T) {
 
 func TestHandleGovernorReposValid(t *testing.T) {
 	srv := newFullServer(t)
-	body := `{"repos":["repo1","repo2"],"primary_repo":"repo1"}`
+	// Field is primaryRepo (camelCase — the handler decodes that key); it must
+	// name one of the repos so the always-exactly-one-default guard passes.
+	body := `{"repos":["repo1","repo2"],"primaryRepo":"repo1"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -673,7 +675,7 @@ func TestHandleGovernorReposSpecialChars(t *testing.T) {
 
 func TestHandleGovernorReposStripOrgPrefix(t *testing.T) {
 	srv := newFullServer(t)
-	body := `{"repos":["testorg/my-repo","other-repo"]}`
+	body := `{"repos":["testorg/my-repo","other-repo"],"primaryRepo":"my-repo"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/v2/pkg/dashboard/repo_add_form_test.go
+++ b/v2/pkg/dashboard/repo_add_form_test.go
@@ -1,0 +1,217 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// These tests cover the Repos-tab add-form backend guards:
+//   - single-forge rejection on add (requirement #2)
+//   - save rejected when repos exist but no default is set (requirement #4)
+//   - the App-access probe endpoint's single-host + org-resolution behaviour
+//     (requirement #3)
+
+// Requirement #2: a hive on github.com must reject a repo pasted on a different
+// forge — the single-host-per-spoke invariant. newFullServer's testrepo is on
+// public github.com, so a github.ibm.com repo is a mixing attempt.
+func TestGovernorRepos_RejectsCrossForge(t *testing.T) {
+	srv := newFullServer(t)
+	body := `{"repos":["github.ibm.com/acme/widget"],"primaryRepo":"widget"}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorRepos(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 for a cross-forge repo", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "one GitHub host") {
+		t.Errorf("expected single-host message, got: %s", w.Body.String())
+	}
+	// The hive's forge must be left untouched.
+	if srv.deps.Config.GitHub.BaseURL != "" {
+		t.Errorf("hive forge was mutated to %q", srv.deps.Config.GitHub.BaseURL)
+	}
+}
+
+// A GHE hive must accept a repo pasted with its OWN GHE host (same forge), and
+// reject a github.com repo (the mirror-image mixing case).
+func TestGovernorRepos_GHEHiveHostRules(t *testing.T) {
+	srv := newFullServer(t)
+	srv.deps.Config.GitHub.BaseURL = "https://github.ibm.com"
+	srv.deps.Config.GitHub.APIURL = "https://github.ibm.com/api/v3"
+
+	// Same-forge paste (full URL on the hive's own GHE host): accepted. The
+	// handler strips the scheme+host and org prefix down to the bare repo name.
+	ok := `{"repos":["https://github.ibm.com/acme/widget"],"primaryRepo":"widget"}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(ok))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorRepos(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("same-forge add: code = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+
+	// public github.com paste on a GHE hive: rejected as mixing.
+	bad := `{"repos":["github.com/acme/other"],"primaryRepo":"other"}`
+	req = httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(bad))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	srv.handleGovernorRepos(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("cross-forge add on GHE hive: code = %d, want 400", w.Code)
+	}
+}
+
+// Requirement #4: a save that leaves repos with no default (primary not among
+// them) is rejected, and the pre-mutation config is restored intact.
+func TestGovernorRepos_RejectsSaveWithNoDefault(t *testing.T) {
+	srv := newFullServer(t)
+	prevRepos := append([]string(nil), srv.deps.Config.Project.Repos...)
+	prevPrimary := srv.deps.Config.Project.PrimaryRepo
+
+	// Replace the repo set with repos that do NOT include the current default,
+	// and do not send a new primary — the default is now dangling.
+	body := `{"repos":["alpha","beta"]}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorRepos(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 when no default is set", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "default repo") {
+		t.Errorf("expected 'default repo' message, got: %s", w.Body.String())
+	}
+	// The rejected save must not leave a half-applied config in memory.
+	if got := srv.deps.Config.Project.Repos; len(got) != len(prevRepos) || (len(got) > 0 && got[0] != prevRepos[0]) {
+		t.Errorf("repos mutated on reject: got %v, want %v", got, prevRepos)
+	}
+	if srv.deps.Config.Project.PrimaryRepo != prevPrimary {
+		t.Errorf("primary mutated on reject: got %q, want %q", srv.deps.Config.Project.PrimaryRepo, prevPrimary)
+	}
+}
+
+// Removing the current default (dropping it from the repos list) without naming
+// a replacement is rejected too — the same no-default guard.
+func TestGovernorRepos_RejectsRemovingDefault(t *testing.T) {
+	srv := newFullServer(t)
+	// Baseline: testrepo is the only repo and the default. Submit a set that
+	// drops it entirely and names no new default.
+	body := `{"repos":["another"]}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorRepos(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 when the default is removed with no replacement", w.Code)
+	}
+
+	// Same set WITH a valid new default is accepted.
+	body = `{"repos":["another"],"primaryRepo":"another"}`
+	req = httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	srv.handleGovernorRepos(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200 once a new default is named (body: %s)", w.Code, w.Body.String())
+	}
+	if srv.deps.Config.Project.PrimaryRepo != "another" {
+		t.Errorf("primary = %q, want 'another'", srv.deps.Config.Project.PrimaryRepo)
+	}
+}
+
+// Requirement #3: the access-probe endpoint rejects a cross-forge repo before it
+// even attempts an installation lookup (same single-host message).
+func TestGovernorRepoCheckAccess_RejectsCrossForge(t *testing.T) {
+	srv := newFullServer(t)
+	body := `{"repo":"github.ibm.com/acme/widget"}`
+	req := httptest.NewRequest("POST", "/api/config/governor/repos/check-access", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorRepoCheckAccess(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 for a cross-forge repo", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "one GitHub host") {
+		t.Errorf("expected single-host message, got: %s", w.Body.String())
+	}
+}
+
+// An App-less hive (no App private key) needs no installation-access check: the
+// probe reports "no-app" and the add proceeds. newFullServer has no GHAppAuth.
+func TestGovernorRepoCheckAccess_AppLessHiveSkips(t *testing.T) {
+	srv := newFullServer(t)
+	body := `{"repo":"testorg/somerepo"}`
+	req := httptest.NewRequest("POST", "/api/config/governor/repos/check-access", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorRepoCheckAccess(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200 (no-app skip); body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "no-app") {
+		t.Errorf("expected no-app status, got: %s", w.Body.String())
+	}
+}
+
+// The probe requires a resolvable org: a bare repo name with no configured org
+// cannot name one, so it is a 400 rather than a silent pass.
+func TestGovernorRepoCheckAccess_RequiresOrg(t *testing.T) {
+	srv := newFullServer(t)
+	srv.deps.Config.Project.Org = ""
+	body := `{"repo":"lonelyrepo"}`
+	req := httptest.NewRequest("POST", "/api/config/governor/repos/check-access", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorRepoCheckAccess(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 when the org cannot be determined", w.Code)
+	}
+}
+
+// repoRefHostLabel / sameForgeHost unit coverage — the shared single-host rule.
+func TestRepoRefHostLabelAndSameForgeHost(t *testing.T) {
+	cases := []struct {
+		in   string
+		host string
+	}{
+		{"repo", ""},
+		{"owner/repo", ""},
+		{"github.ibm.com/owner/repo", "github.ibm.com"},
+		{"https://github.com/owner/repo", "github.com"},
+		{"GitHub.IBM.com/o/r", "github.ibm.com"}, // lowercased
+	}
+	for _, c := range cases {
+		if got := repoRefHostLabel(c.in); got != c.host {
+			t.Errorf("repoRefHostLabel(%q) = %q, want %q", c.in, got, c.host)
+		}
+	}
+	if !sameForgeHost("", "github.com") {
+		t.Error(`"" and "github.com" should be the same forge`)
+	}
+	if !sameForgeHost("GITHUB.COM", "github.com") {
+		t.Error("host comparison should be case-insensitive")
+	}
+	if sameForgeHost("github.ibm.com", "github.com") {
+		t.Error("a GHE host must not equal public github.com")
+	}
+}
+
+// hiveForgeHost mirrors config.HostLabel(): github.com by default, the GHE host
+// when the hive carries one.
+func TestHiveForgeHost(t *testing.T) {
+	srv := newFullServer(t)
+	if got := srv.hiveForgeHost(); got != "github.com" {
+		t.Errorf("default forge = %q, want github.com", got)
+	}
+	srv.deps.Config.GitHub = config.GitHubConfig{BaseURL: "https://github.ibm.com"}
+	if got := srv.hiveForgeHost(); got != "github.ibm.com" {
+		t.Errorf("GHE forge = %q, want github.ibm.com", got)
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -13399,6 +13399,10 @@ function burnAreaChart() {
           loadGateways();
         }
       }
+      // Keep the Save button's enabled state in lockstep with the repos/default
+      // invariant on every render (requirement #4). Cheap and idempotent — a
+      // no-op on tabs/dialogs without a repos list.
+      if (typeof syncRepoSaveGuard === 'function') syncRepoSaveGuard();
     }
 
     function renderAgentImport() {
@@ -16166,14 +16170,32 @@ function burnAreaChart() {
       const hostNote = isGHE
         ? ` on <strong style="color:var(--indigo)">${esc(ghHost)}</strong> (GitHub Enterprise)`
         : ` on <strong>${esc(ghHost)}</strong>`;
+      // The forge is shown as a fixed, non-editable prefix before the input so
+      // the user only types org/repo and the GitHub host can never be
+      // mistaken (requirement #1). The prefix color matches the per-row pill
+      // (indigo for GHE, muted for public github.com). All host machinery is
+      // client-side + CSP-safe (inline styles, no external resources).
+      const prefixColor = isGHE ? 'var(--indigo)' : 'var(--muted)';
+      // needDefault is true when repos exist but none is the current default —
+      // the Save-guard state. renderGovRepos surfaces it inline; syncRepoSaveGuard
+      // (called on every tab render) is what actually disables the Save button.
+      const needDefault = repos.length > 0 && !repos.includes(primary);
+      const defaultWarn = needDefault
+        ? '<div id="cfg-repo-default-warn" style="font-size:0.72rem;color:var(--amber);margin-top:6px">⚠ Set a default repo before saving — click a ☆ star to choose the repo where the advisory issue is maintained.</div>'
+        : '';
       return `
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">GitHub repositories monitored by this hive${hostNote}. Click the star to set the default repo where the advisory issue is maintained.</p>
         <div class="config-list">
           ${list || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No repos configured</div>'}
-          <div class="config-list-add">
-            <input type="text" id="cfg-repo-input" placeholder="org/repo (on ${esc(ghHost)})" title="GitHub repository in org/repo format (e.g. kubestellar/console). It must live on this hive's forge, ${esc(ghHost)} — the governor rejects repos on other GitHub hosts. It will be monitored for issues, PRs, and CI status.">
+          <div class="config-list-add" style="align-items:stretch">
+            <div style="display:flex;flex:1;min-width:0;align-items:stretch;border:1px solid var(--border);border-radius:6px;overflow:hidden">
+              <span style="display:inline-flex;align-items:center;padding:0 8px;background:color-mix(in srgb, ${prefixColor} 12%, var(--surface));color:${prefixColor};font-size:0.78rem;font-weight:600;white-space:nowrap;border-right:1px solid var(--border)" title="This hive's forge — every repo must live on ${esc(ghHost)}">${esc(ghHost)}/</span>
+              <input type="text" id="cfg-repo-input" style="flex:1;min-width:0;border:none;border-radius:0" placeholder="org/repo" onkeydown="if(event.key==='Enter'){event.preventDefault();addListItem('repos','list','cfg-repo-input');}" title="GitHub repository in org/repo format (e.g. kubestellar/console). It must live on this hive's forge, ${esc(ghHost)} — the governor rejects repos on other GitHub hosts. It will be monitored for issues, PRs, and CI status.">
+            </div>
             <button onclick="addListItem('repos','list','cfg-repo-input')" title="Add this repository to the monitored list">+ Add</button>
           </div>
+          <div id="cfg-repo-add-status" style="font-size:0.72rem;margin-top:6px"></div>
+          ${defaultWarn}
         </div>`;
     }
 
@@ -16604,6 +16626,143 @@ function burnAreaChart() {
       return raw.replace(/^https?:\/\/github\.com\//, '').replace(/\/+$/, '');
     }
 
+    // hiveForgeHostLabel returns this hive's bare GitHub host ("github.com" or a
+    // GHE hostname). Mirrors the server's hiveForgeHost() and renderGovRepos so
+    // the single-host rule matches everywhere.
+    function hiveForgeHostLabel() {
+      const ghBase = window._githubBaseUrl || 'https://github.com';
+      return ghBase.replace(/^https?:\/\//, '').replace(/\/$/, '') || 'github.com';
+    }
+
+    // repoRefHostLabel extracts the GitHub host a pasted repo carries, or '' when
+    // it names none (bare "repo"/"owner/repo" belong to the hive's forge).
+    // Mirrors the server's repoRefHostLabel (a leading dotted segment or full URL
+    // is an explicit host).
+    function repoRefHostLabel(s) {
+      s = (s || '').trim().replace(/^https?:\/\//, '').replace(/^\/+|\/+$/g, '');
+      if (!s) return '';
+      const parts = s.split('/');
+      if (parts.length > 1 && parts[0].indexOf('.') !== -1) return parts[0].toLowerCase();
+      return '';
+    }
+
+    function sameForgeHost(a, b) {
+      const norm = h => { h = (h || '').trim().toLowerCase(); return (!h || h === 'github.com') ? 'github.com' : h; };
+      return norm(a) === norm(b);
+    }
+
+    // addRepoWithChecks handles the Repos-tab "+ Add": it enforces the
+    // single-host-per-spoke rule client-side (requirement #2), then asks the
+    // server whether the hive's GitHub App can access the new repo's org and, if
+    // not, guides the user through installing/authorizing the App before the repo
+    // is accepted (requirement #3). Only on a clean check is the repo appended.
+    async function addRepoWithChecks() {
+      const input = document.getElementById('cfg-repo-input');
+      if (!input) return;
+      const raw = input.value.trim();
+      if (!raw) return;
+      const statusEl = document.getElementById('cfg-repo-add-status');
+      const setStatus = (html, color) => { if (statusEl) { statusEl.innerHTML = html; statusEl.style.color = color || 'var(--muted)'; } };
+
+      // Requirement #2: reject a paste on a different forge before any round-trip.
+      const spokeHost = hiveForgeHostLabel();
+      const refHost = repoRefHostLabel(raw);
+      if (refHost && !sameForgeHost(refHost, spokeHost)) {
+        setStatus('✕ ' + esc(raw) + ' is on <strong>' + esc(refHost) + '</strong>, but this hive is on <strong>' + esc(spokeHost) + '</strong>. A hive\'s repos must all live on one GitHub host — remove the host or use a repo on ' + esc(spokeHost) + '.', 'var(--red)');
+        return;
+      }
+
+      const val = normalizeRepoInput(raw);
+      if (!_configState.data.repos) _configState.data.repos = [];
+      if (_configState.data.repos.includes(val)) {
+        setStatus('This repo is already in the list.', 'var(--muted)');
+        return;
+      }
+
+      // Requirement #3: verify the App can access the repo's org.
+      setStatus('Checking GitHub App access…', 'var(--muted)');
+      try {
+        const res = await fetch('/api/config/governor/repos/check-access', {
+          method: 'POST', headers: _inceptionAuthHeaders(),
+          body: JSON.stringify({ repo: val })
+        });
+        const d = await res.json().catch(() => ({}));
+        if (res.status === 409 && d && d.needsInstall) {
+          // App not installed on the new org: surface the correct per-forge
+          // install URL wired to the existing pending-install/recheck plumbing.
+          // Clicking Install flags the heartbeat (handleGitHubAppInstallClicked)
+          // exactly like the App-required banner; Re-check re-probes and, on
+          // success, completes the add.
+          const installBtn = (d.installUrl)
+            ? '<a href="' + esc(d.installUrl) + '" target="_blank" rel="noopener" onclick="markGitHubAppInstallClicked()" style="color:var(--accent);font-weight:600">Install/authorize the App for ' + esc(d.org || '') + ' ↗</a>'
+            : '<span style="color:var(--amber)">This hive\'s GitHub Enterprise App slug is not configured, so an install link cannot be built — ask your operator to install the Hive App for ' + esc(d.org || '') + '.</span>';
+          setStatus('⚠ ' + esc(d.error || ('The App needs access to ' + val)) + '<br>' + installBtn + ' &nbsp;·&nbsp; <a href="#" onclick="recheckRepoAccessThenAdd(event)" style="color:var(--accent);font-weight:600">Re-check &amp; add</a>', 'var(--amber)');
+          return;
+        }
+        if (!res.ok) {
+          setStatus('✕ ' + esc((d && d.error) || ('HTTP ' + res.status)), 'var(--red)');
+          return;
+        }
+      } catch (e) {
+        // Network error probing access is non-fatal: the server re-validates the
+        // single-host rule and the default-repo rule on save, so let the add
+        // proceed rather than hard-block on a transient dashboard hiccup.
+        _appendRepoAccepted(val);
+        setStatus('Added (App-access check could not be reached; the server will re-validate on save).', 'var(--muted)');
+        return;
+      }
+      _appendRepoAccepted(val);
+      setStatus('✓ Added — App has access.', 'var(--green)');
+    }
+
+    // _appendRepoAccepted appends a validated repo, seeds the first repo as the
+    // default (a hive must always have one), and re-renders.
+    function _appendRepoAccepted(val) {
+      if (!_configState.data.repos) _configState.data.repos = [];
+      _configState.data.repos.push(val);
+      markDirty('repos', 'repos', _configState.data.repos);
+      // First repo added to an empty list becomes the default automatically, so
+      // there is always exactly one default (requirement #4).
+      if (!_configState.data.primaryRepo || !_configState.data.repos.includes(_configState.data.primaryRepo)) {
+        _configState.data.primaryRepo = val;
+        markDirty('repos', 'primaryRepo', val);
+      }
+      const input = document.getElementById('cfg-repo-input');
+      if (input) input.value = '';
+      renderConfigTab(_configState.tab);
+    }
+
+    // markGitHubAppInstallClicked flags the heartbeat that an install link was
+    // clicked, reusing the existing pending-install endpoint. Fire-and-forget.
+    function markGitHubAppInstallClicked() {
+      fetch('/api/github-app/install-clicked', { method: 'POST', headers: _inceptionAuthHeaders() }).catch(() => {});
+    }
+
+    // recheckRepoAccessThenAdd re-runs the App-access probe after the user
+    // installs/authorizes the App, and completes the add when access is now
+    // confirmed — the same re-check pattern the App-required banner uses.
+    async function recheckRepoAccessThenAdd(ev) {
+      if (ev) ev.preventDefault();
+      await addRepoWithChecks();
+    }
+
+    // syncRepoSaveGuard disables the config dialog Save button while the Repos
+    // tab has repos but no default selected, so a hive can never be saved without
+    // exactly one default (requirement #4). Called after every config tab render.
+    function syncRepoSaveGuard() {
+      const saveBtn = document.querySelector('.config-footer .config-save');
+      if (!saveBtn) return;
+      let block = false;
+      const d = _configState.data || {};
+      if (_configState.type === 'governor' && Array.isArray(d.repos) && d.repos.length > 0) {
+        block = !d.primaryRepo || !d.repos.includes(d.primaryRepo);
+      }
+      saveBtn.disabled = block;
+      saveBtn.style.opacity = block ? '0.5' : '';
+      saveBtn.style.cursor = block ? 'not-allowed' : '';
+      saveBtn.title = block ? 'Set a default repo before saving — click a ☆ star in the Repos tab.' : '';
+    }
+
     function addListItem(section, key, inputId) {
       const input = document.getElementById(inputId);
       let val = input.value.trim();
@@ -16618,10 +16777,11 @@ function burnAreaChart() {
         _configState.data.labels.push(val);
         markDirty('labels', 'labels', _configState.data.labels);
       } else if (section === 'repos') {
-        val = normalizeRepoInput(val);
-        if (!_configState.data.repos) _configState.data.repos = [];
-        _configState.data.repos.push(val);
-        markDirty('repos', 'repos', _configState.data.repos);
+        // Repos go through the async host-check + App-access workflow, which
+        // owns input clearing and re-render on success. Return here so the
+        // synchronous tail below does not double-add or clear prematurely.
+        addRepoWithChecks();
+        return;
       }
       input.value = '';
       renderConfigTab(_configState.tab);
@@ -16729,6 +16889,19 @@ function burnAreaChart() {
 
     async function saveConfig() {
       const dirty = _configState.dirty;
+
+      // Guard: a governor config with repos must always name a default that is
+      // one of them (requirement #4). The Save button is disabled in this state,
+      // but a keyboard/racy click could still reach here — refuse and point the
+      // user at the fix rather than letting the server 400 opaquely.
+      if (_configState.type === 'governor') {
+        const d = _configState.data || {};
+        if (Array.isArray(d.repos) && d.repos.length > 0 && (!d.primaryRepo || !d.repos.includes(d.primaryRepo))) {
+          showToast('Set a default repo before saving — click a ☆ star in the Repos tab.', 'error');
+          renderConfigTab('Repos');
+          return;
+        }
+      }
 
       if (_configState.isCreate) {
         const createData = dirty._create || {};


### PR DESCRIPTION
Enhances the **Governor Configuration → Repos tab** add-repo form (in `v2/pkg/dashboard/static/index.html` + `v2/pkg/dashboard/api.go`'s `handleGovernorRepos`). All four requested requirements are implemented.

## 1. Forge-URL placeholder prefix ✅
The add-repo input now renders the hive's forge host as a **fixed, non-editable prefix label** (e.g. `github.ibm.com/`) before the text field, so the user types only `org/repo` and the forge is unambiguous. GHE hosts get an indigo prefix; public github.com gets a muted one. Derived from the hive's own `github_base_url` (which comes from `config.GitHubConfig.HostLabel()`/`ResolvedBaseURL()`).

## 2. No mixing forges ✅
Single-host-per-spoke is enforced in **two places**:
- **Client-side** (fail fast, before any round-trip): `repoRefHostLabel`/`sameForgeHost` mirror the hub's `repoRefHost`/`sameGitHubHost` rule. A repo pasted on a different forge shows a clear inline message.
- **Server-side** (defence in depth): `handleGovernorRepos` and the new access-probe endpoint reject any submitted repo (or default) whose explicit host differs from the hive's forge, with the same single-host message the hub uses. This also blocks the old "paste a GHE URL to silently switch the hive's forge" behaviour.

## 3. App-access check + install workflow on Add ✅ (org-granularity; repo-granularity TODO)
New endpoint **`POST /api/config/governor/repos/check-access`**. On Add, after client validation, the UI probes whether the hive's GitHub App can access the new repo's org via **`AppAuth.DiscoverInstallationID(org)`** (already used by the App-required flow). If the App is **not installed on that org**, the endpoint:
- returns the correct **per-forge install URL** (`config.GitHubConfig.AppInstallURL()` → `/apps/…` for github.com, `/github-apps/…` for GHE, `""` when a GHE App slug is unconfigured), and
- arms the **existing** pending-install mechanism (`SetPendingGitHubAppInstall`).

The UI then renders *"the Hive GitHub App is not installed on `<org>` — [Install/authorize the App ↗]  ·  Re-check & add"*, reusing the existing install-clicked (`/api/github-app/install-clicked`) and recheck plumbing. The repo is only appended once access is confirmed. An App-less (advisory-only) hive skips the check (it never writes). A network error probing access is non-fatal (server re-validates on save).

**Scope note / TODO** (commented on the handler): the probe is at **org granularity**. An App installed on the org with *"Only select repositories"* may still lack a specific repo (the write-forbidden case from #2353). The deeper repo-granularity probe should mint an installation token and `GET /repos/{org}/{repo}` (`GHClient.GetRepo`), treating 404/403 as "installed but this repo not in the selected set". That tightening is left as a documented TODO to keep this change focused; the org-level check + install workflow already covers the common "App not installed on the org" footgun.

## 4. Always a default repo ✅
Exactly one `★` default is enforced:
- **Client**: `syncRepoSaveGuard` (run on every config-tab render) **disables Save** while repos exist with no valid default, with a message and an inline ⚠ warning in the Repos tab; `saveConfig` also guards against a racy click. The first repo added to an empty list is auto-selected as the default.
- **Server**: `handleGovernorRepos` rejects a save whose repos have no valid `primaryRepo` and **restores the pre-mutation config** so a rejected save never leaves a half-applied state in memory.

The existing star-to-set-default interaction (`setDefaultRepo`) is unchanged.

## Validation
- `go build ./...` clean; `gofmt -l` clean on changed `.go` files; the inline `<script>` in `index.html` passes `node --check`.
- `go test ./pkg/dashboard/` passes (adapted the existing repos-tab tests to the new default-required contract; the GHE-URL test now asserts the cross-forge rejection instead of a silent forge switch).
- **New tests** (`repo_add_form_test.go`): single-forge rejection on add (both directions), save rejected when repos exist but no default is set, default-removal rejection, the access-probe's single-host + org-resolution + App-less-skip paths, and the shared host-rule helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)