### PR TITLE
dashboard: rename Resources 'Issues' link to 'Report an Issue'

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2569,7 +2569,7 @@
       <a class="oc-nav-item" data-section="faq-section" onclick="ocNavigate('faq-section')" title="Answers to common first-time questions: the Advisory Digest, ACMM levels, how to advance, and managing cost"><span class="oc-nav-emoji">❓</span><span class="oc-nav-text">FAQ</span></a>
       <a class="oc-nav-item" id="welcome-nav-item" style="display:none" onclick="openWelcomeDialog()" title="Open the Getting Started checklist — one-time setup steps for a new hive"><span class="oc-nav-emoji">🚀</span><span class="oc-nav-text">Getting Started</span></a>
       <a class="oc-nav-item" href="/api/docs" target="_blank"><span class="oc-nav-emoji">📘</span><span class="oc-nav-text">API Spec (Redoc)</span></a>
-      <a class="oc-nav-item" href="https://github.com/kubestellar/hive/issues" target="_blank" rel="noopener noreferrer"><span class="oc-nav-emoji">🐛</span><span class="oc-nav-text">Issues</span></a>
+      <a class="oc-nav-item" href="https://github.com/kubestellar/hive/issues" target="_blank" rel="noopener noreferrer"><span class="oc-nav-emoji">🐛</span><span class="oc-nav-text">Report an Issue</span></a>
     </div>
     <div class="system-gauges" id="system-gauges">
       <div class="sys-gauge-row" id="sys-gauge-disk" title="Disk usage">


### PR DESCRIPTION
## Summary
Renames the Resources nav link text from 'Issues' to 'Report an Issue'. The 🐛 link to github.com/kubestellar/hive/issues was added in #2422. This change updates only the visible link text, keeping all attributes (href, target, rel, class) unchanged.

## Changes
- Line 2572 in `v2/pkg/dashboard/static/index.html`: Text-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)