### PR TITLE
✨ feat(hub): "Reset App" — clear a hive's installation so the owner reinstalls

### DIFF
--- a/v2/cmd/hive/app_reset_adopt_test.go
+++ b/v2/cmd/hive/app_reset_adopt_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/hub"
+)
+
+// These tests drive nextInstallationID — the REAL decision in main.go — not a
+// restatement of it. An earlier version defined its own copy of the rule and
+// stayed green when the production branch was disabled entirely, which is the
+// same "tested the thing beside the change" flaw that let four checks pass
+// while testing nothing this week.
+func applyInstallation(cur config.GitHubConfig, ghCfg *hub.HeartbeatGitHubAppConfig) config.GitHubConfig {
+	next := cur
+	next.InstallationID, _ = nextInstallationID(cur.InstallationID, ghCfg)
+	return next
+}
+
+// TestPushedZeroStillCannotBlankAnInstallation is the guard the reset feature
+// must not weaken.
+//
+// Zero on the wire means "the hub is not speaking to this field". The
+// cluster-wide key reconcile sends zero on every beat, because it repairs KEYS
+// on hives whose installation the hub does not track. If zero were read as
+// "clear it", that reconcile would blank a working installation on every hive
+// it touches — turning a key-only fault into a total auth outage.
+func TestPushedZeroStillCannotBlankAnInstallation(t *testing.T) {
+	cur := config.GitHubConfig{AppID: config.PublicGitHubAppID, InstallationID: 145050760}
+
+	got := applyInstallation(cur, &hub.HeartbeatGitHubAppConfig{AppID: config.PublicGitHubAppID})
+	if got.InstallationID != 145050760 {
+		t.Fatalf("a pushed zero blanked a working installation (%d) — this is the outage the guard prevents", got.InstallationID)
+	}
+}
+
+// TestResetFlagClearsTheInstallation: only the explicit flag may zero it.
+// Clearing makes HasUsableApp() false, which raises githubAppRequired — the
+// prompt to install the App again, and the trigger for the self-heal ticker
+// whose RediscoverAndAdopt finds the right installation.
+func TestResetFlagClearsTheInstallation(t *testing.T) {
+	cur := config.GitHubConfig{AppID: config.PublicGitHubAppID, InstallationID: 145050760}
+	if !cur.HasUsableApp() {
+		t.Fatal("precondition: the hive should start with a usable App")
+	}
+
+	got := applyInstallation(cur, &hub.HeartbeatGitHubAppConfig{ResetInstallation: true})
+	if got.InstallationID != 0 {
+		t.Fatalf("reset did not clear the installation: %d", got.InstallationID)
+	}
+	if got.HasUsableApp() {
+		t.Fatal("App still reads as usable after the reset; the owner would never be prompted to reinstall")
+	}
+	// The rest of the identity must survive — a reset costs one re-install,
+	// not an identity rebuild.
+	if got.AppID != cur.AppID {
+		t.Fatalf("reset changed app_id: %d -> %d", cur.AppID, got.AppID)
+	}
+}
+
+// TestResetWins: a delivery carrying BOTH a reset and an installation must
+// reset. The hub never sends both, but the spoke should not depend on that.
+func TestResetWins(t *testing.T) {
+	cur := config.GitHubConfig{AppID: config.PublicGitHubAppID, InstallationID: 145050760}
+	got := applyInstallation(cur, &hub.HeartbeatGitHubAppConfig{
+		ResetInstallation: true, InstallationID: 999999,
+	})
+	if got.InstallationID != 0 {
+		t.Fatalf("installation %d was adopted despite a reset", got.InstallationID)
+	}
+}

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -167,6 +167,38 @@ func prospectiveGitHubIdentity(cur config.GitHubConfig, ghCfg *hub.HeartbeatGitH
 	return &next
 }
 
+// nextInstallationID decides what a hive's installation_id becomes after a
+// hub delivery, and reports whether the change is an operator RESET.
+//
+// Three cases, and the difference between the last two is load-bearing:
+//
+//	ResetInstallation  -> 0. The operator clicked "Reset App". Clearing makes
+//	                     HasUsableApp() false, which raises githubAppRequired:
+//	                     the owner is prompted to install the App again and the
+//	                     self-heal ticker starts, whose RediscoverAndAdopt
+//	                     adopts the correct installation for whatever they
+//	                     install.
+//	non-zero pushed    -> adopt it.
+//	zero pushed        -> KEEP the current value. Zero means "the hub is not
+//	                     speaking to this field", not "clear it". The
+//	                     cluster-wide key reconcile sends zero on every beat
+//	                     because it repairs KEYS on hives whose installation the
+//	                     hub does not track; reading that as a clear would blank
+//	                     a working installation fleet-wide and turn a key-only
+//	                     fault into a total auth outage.
+func nextInstallationID(current int64, ghCfg *hub.HeartbeatGitHubAppConfig) (next int64, reset bool) {
+	if ghCfg == nil {
+		return current, false
+	}
+	if ghCfg.ResetInstallation {
+		return 0, current != 0
+	}
+	if ghCfg.InstallationID != 0 {
+		return ghCfg.InstallationID, false
+	}
+	return current, false
+}
+
 func perAppIDKeyPath(appID int64) string {
 	if appID <= 0 {
 		return ""
@@ -2896,8 +2928,12 @@ func main() {
 			// KEY on hives whose installation_id is already correct (and which
 			// the hub does not track); assigning zero here would blank a working
 			// value and turn a key-only fault into a total auth outage.
-			if ghCfg.InstallationID != 0 {
-				cfg.GitHub.InstallationID = ghCfg.InstallationID
+			if next, cleared := nextInstallationID(cfg.GitHub.InstallationID, ghCfg); cleared {
+				logger.Info("clearing github app installation_id on operator request",
+					"was", cfg.GitHub.InstallationID)
+				cfg.GitHub.InstallationID = next
+			} else {
+				cfg.GitHub.InstallationID = next
 			}
 			// Deliberately NOT `cfg.GitHub.KeyFile = keyPath`.
 			//

--- a/v2/pkg/hub/app_reset_test.go
+++ b/v2/pkg/hub/app_reset_test.go
@@ -1,0 +1,75 @@
+package hub
+
+import "testing"
+
+// TestAppResetIsDeliveredUntilConfirmed pins the operator-facing contract for
+// "Reset App": the request survives until the spoke reports installation_id 0.
+//
+// It cannot be expressed by pushing a zero. The spoke adopts an installation
+// only when the pushed value is NON-zero, deliberately — zero means "the hub is
+// not speaking to this field", and treating it as a clear once turned a
+// key-only fault into a total auth outage. So the reset is its own flag.
+func TestAppResetIsDeliveredUntilConfirmed(t *testing.T) {
+	oldHives := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = oldHives })
+
+	h := &SaaSHive{ID: "reset-me", ClusterID: "hive-oke", RequestedAppReset: true}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+	s := &HubServer{logger: appKeyTestLogger()}
+
+	t.Run("delivered while the spoke still reports an installation", func(t *testing.T) {
+		got := s.pendingAppIdentityForHeartbeat(&HeartbeatPayload{
+			HiveID: "reset-me", GitHubInstallationID: 145050760,
+		})
+		if got == nil || !got.ResetInstallation {
+			t.Fatalf("reset not delivered: %+v", got)
+		}
+		// A lost beat must not drop it.
+		again := s.pendingAppIdentityForHeartbeat(&HeartbeatPayload{
+			HiveID: "reset-me", GitHubInstallationID: 145050760,
+		})
+		if again == nil || !again.ResetInstallation {
+			t.Fatal("reset was dropped after one delivery; a lost beat would lose the operator's click")
+		}
+	})
+
+	t.Run("cleared once the spoke reports installation 0", func(t *testing.T) {
+		if got := s.pendingAppIdentityForHeartbeat(&HeartbeatPayload{
+			HiveID: "reset-me", GitHubInstallationID: 0,
+		}); got != nil {
+			t.Fatalf("still delivering after confirmation: %+v", got)
+		}
+		// And it stays cleared — the hive must not be reset forever.
+		if h2 := loadSaaSHive("reset-me"); h2 == nil || h2.RequestedAppReset {
+			t.Fatal("RequestedAppReset was not cleared on the hive record")
+		}
+		if got := s.pendingAppIdentityForHeartbeat(&HeartbeatPayload{
+			HiveID: "reset-me", GitHubInstallationID: 145050760,
+		}); got != nil && got.ResetInstallation {
+			t.Fatal("reset re-armed itself after being confirmed")
+		}
+	})
+}
+
+// TestNoResetMeansNoResetFlag: a hive that was never reset must never receive
+// the flag. Sending it spuriously would blank a working installation and take
+// the hive offline until its owner reinstalls.
+func TestNoResetMeansNoResetFlag(t *testing.T) {
+	oldHives := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = oldHives })
+
+	if err := saveSaaSHive(&SaaSHive{ID: "healthy", ClusterID: "hive-oke"}); err != nil {
+		t.Fatal(err)
+	}
+	s := &HubServer{logger: appKeyTestLogger()}
+	got := s.pendingAppIdentityForHeartbeat(&HeartbeatPayload{
+		HiveID: "healthy", GitHubInstallationID: 12345,
+	})
+	if got != nil && got.ResetInstallation {
+		t.Fatal("a healthy hive was told to reset its App")
+	}
+}

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -838,6 +838,18 @@ type HeartbeatGitHubAppConfig struct {
 	// Empty means "leave the spoke's slug unchanged" — never a way to blank a
 	// working value.
 	AppSlug string `json:"app_slug,omitempty"`
+	// ResetInstallation tells the spoke to CLEAR its installation_id.
+	//
+	// A separate flag because zero cannot carry this meaning: the spoke adopts
+	// an installation only when the pushed value is non-zero, since zero means
+	// "not speaking to this field". Overloading it would make every push that
+	// omits an installation blank a working one.
+	//
+	// The spoke clearing its installation makes HasUsableApp() false, which
+	// raises githubAppRequired — so the owner is prompted to install the App
+	// again AND the 2-minute self-heal ticker starts, whose RediscoverAndAdopt
+	// finds the correct installation for whichever App is installed.
+	ResetInstallation bool `json:"reset_installation,omitempty"`
 	// APIURL and BaseURL complete the identity SET.
 	//
 	// WHY THEY ARE HERE AND NOT ON ProjectConfig

--- a/v2/pkg/hub/identity.go
+++ b/v2/pkg/hub/identity.go
@@ -62,7 +62,10 @@ package hub
 // atomicity property (never half-apply) without pretending three transports
 // are one.
 
-import "strings"
+import (
+	"net/http"
+	"strings"
+)
 
 // gheAPIPathMarker identifies a GitHub Enterprise API URL. GHE APIs live under
 // /api/v3; public GitHub uses api.github.com.
@@ -217,6 +220,31 @@ func (s *HubServer) pendingAppIdentityForHeartbeat(p *HeartbeatPayload) *Heartbe
 	}
 
 	h := loadSaaSHive(p.HiveID)
+
+	// An operator-requested App reset outranks everything below: a hive being
+	// reset has no pending identity to deliver, and the point is to get it back
+	// to "App not installed" so the owner reinstalls.
+	//
+	// Cleared on READ-BACK — when the spoke reports installation_id 0 — not on
+	// send. A reset lost to a dropped beat or a hub restart would otherwise be
+	// silently forgotten, leaving the operator's click with no effect and no
+	// signal.
+	if h != nil && h.RequestedAppReset {
+		if p.GitHubInstallationID == 0 {
+			h.RequestedAppReset = false
+			if err := saveSaaSHive(h); err != nil {
+				s.logger.Warn("app reset confirmed but could not be cleared",
+					"hive_id", p.HiveID, "error", err)
+			}
+			s.logger.Info("app reset confirmed by spoke; installation cleared",
+				"hive_id", p.HiveID)
+			return nil
+		}
+		s.logger.Info("delivering app reset to spoke",
+			"hive_id", p.HiveID, "spoke_installation_id", p.GitHubInstallationID)
+		return &HeartbeatGitHubAppConfig{ResetInstallation: true}
+	}
+
 	if h == nil || h.PendingAppConfig == nil {
 		return nil
 	}
@@ -293,4 +321,46 @@ func SpokeIdentityFromPayload(p *HeartbeatPayload) IdentitySet {
 		APIURL:         p.GitHubAPIURL,
 		BaseURL:        p.GitHubBaseURL,
 	}
+}
+
+// handleResetApp arms an App reset for one hive: POST /api/saas/hives/{id}/reset-app
+//
+// The spoke clears its installation_id on the next beat, which makes
+// HasUsableApp() false and raises githubAppRequired — the owner is prompted to
+// install the App again, and the 2-minute self-heal ticker starts, whose
+// RediscoverAndAdopt adopts the correct installation for whichever App they
+// install.
+//
+// WHY AN OPERATOR NEEDS THIS. A hive provisioned with its OWN GitHub App keeps
+// that App's installation_id if its identity is later moved to the fleet's
+// public App. Every field then looks right — app_id, app_slug and key_file all
+// name the public App — while the installation belongs to a different one, so
+// freshly minted tokens return "404 Not Found" and cached ones keep working.
+// Nothing in the config reads as wrong, and no automatic path fixes it: the
+// hub does not track installation IDs, and the spoke's self-heal only runs when
+// the App is already flagged as missing.
+//
+// Deliberately NOT destructive beyond the one field. The App ID, slug and key
+// are untouched, so a reset on a healthy hive costs one re-install rather than
+// an outage.
+func (s *HubServer) handleResetApp(w http.ResponseWriter, r *http.Request) {
+	if s.getAuthUser(r) != hubAdminUsername {
+		http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
+		return
+	}
+	hiveID := r.PathValue("id")
+	h := loadSaaSHive(hiveID)
+	if h == nil {
+		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
+		return
+	}
+	h.RequestedAppReset = true
+	if err := saveSaaSHive(h); err != nil {
+		s.logger.Error("failed to arm app reset", "hive_id", hiveID, "error", err)
+		http.Error(w, `{"error":"could not arm the reset"}`, http.StatusInternalServerError)
+		return
+	}
+	s.logger.Info("app reset armed by operator", "hive_id", hiveID)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(`{"status":"armed","detail":"the spoke will clear its installation on the next heartbeat and prompt for a fresh App install"}`))
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -212,6 +212,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	// requireAuth plus an inner owner-or-admin check, exactly like
 	// switch-branch and auto-upgrade above.
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/forge", s.requireAuth(s.handleSwitchForge))
+	s.mux.HandleFunc("POST /api/saas/hives/{id}/reset-app", s.requireAuth(s.handleResetApp))
 	s.mux.HandleFunc("GET /api/saas/hive-config/{hiveID}", s.requireAuth(s.handleProxyHiveConfig))
 	s.mux.HandleFunc("GET /api/saas/latest-sha", s.handleLatestSHA)
 	s.mux.HandleFunc("POST /api/saas/hub/upgrade", s.requireAdmin(s.handleHubSelfUpgrade))
@@ -11333,6 +11334,13 @@ const dashboardHTML = `<!DOCTYPE html>
         if (isHosted && (h.role === 'owner' || _isAdmin)) menuItems.push('<div onclick="openTimelineModal(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">Activity Timeline</div>');
         if (h.role === 'owner' || h.role === 'read-write' || _isAdmin) menuItems.push('<div onclick="openOpenRouterFundModal(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">⚡ Fund with OpenRouter</div>');
         if (_isAdmin && isHosted) menuItems.push('<div onclick="openBannerForHive(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">Send Banner</div>');
+        /* Reset App clears ONLY the spoke's installation_id, which makes
+           HasUsableApp() false and prompts the owner to install the App again.
+           Admin-only and hosted-only, matching the endpoint's own guard. The
+           case it exists for: a hive provisioned with its own GitHub App keeps
+           that App's installation_id after its identity is moved to the fleet
+           App, so every field reads correct while freshly minted tokens 404. */
+        if (_isAdmin && isHosted) menuItems.push('<div onclick="resetHiveApp(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">Reset App</div>');
         if (isLocal && h.role === 'owner') menuItems.push('<div onclick="removeLocalHive(\'' + esc(h.id) + '\')" style="' + mi + '">Remove</div>');
         if (isHosted && h.role === 'owner' && _clusterList && _clusterList.length > 1 && h.migrationStatus !== 'migrating') menuItems.push('<div onclick="openMigrateModal(\'' + esc(h.id) + '\',\'' + esc(h.clusterId || '') + '\')" style="' + mi + '">Move to cluster</div>');
         if (isHosted && h.role === 'owner') menuItems.push('<div style="border-top:1px solid #30363d;margin:4px 0"></div><div onclick="deleteHive(\'' + esc(h.id) + '\')" style="' + mi + ';color:#f85149">Delete</div>');
@@ -12206,6 +12214,23 @@ const dashboardHTML = `<!DOCTYPE html>
     }
 
     var _switchTimers = {};
+    /* Reset App: clears the spoke's installation_id so the owner is prompted
+       to install the GitHub App again. Confirmed first because it costs the
+       owner a re-install, and the reset is delivered on the spoke's next
+       heartbeat rather than immediately. */
+    async function resetHiveApp(hiveId, hiveName) {
+      if (!confirm('Reset the GitHub App for "' + hiveName + '"?\n\nThe spoke clears its installation ID on the next heartbeat and the owner is prompted to install the App again. The App ID, slug and key are left alone.')) return;
+      try {
+        var resp = await fetch('/api/saas/hives/' + encodeURIComponent(hiveId) + '/reset-app', {method: 'POST'});
+        var data = await resp.json().catch(function() { return {}; });
+        if (!resp.ok) { alert('Reset failed: ' + (data.error || resp.status)); return; }
+        alert('App reset armed for "' + hiveName + '".\n\nThe spoke clears its installation on the next heartbeat (~30s), then shows the install prompt.');
+        if (typeof loadHives === 'function') loadHives();
+      } catch (e) {
+        alert('Reset failed: ' + e);
+      }
+    }
+
     function switchBranch(hiveId, newBranch, el) {
       if (el) el.closest('[id^="branch-menu-"]').style.display = 'none';
       if (_switchTimers[hiveId]) {

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -478,6 +478,31 @@ type SaaSHive struct {
 	// stops for good and the spoke owns the value again. Both default to their
 	// zero values on every existing hive, so nothing is delivered to a hive
 	// nobody switched: the push is gated on a NON-EMPTY RequestedGitHubHost.
+	// RequestedAppReset asks the spoke to CLEAR its installation_id, so the
+	// hive falls back to "App not installed" and prompts the owner to install
+	// it again.
+	//
+	// WHY THIS NEEDS ITS OWN FIELD RATHER THAN JUST PUSHING ZERO
+	//
+	// The wire cannot express a clear. The spoke adopts a pushed installation
+	// only when it is non-zero (cmd/hive: `if ghCfg.InstallationID != 0`),
+	// deliberately — zero means "the hub is not speaking to this field", and
+	// treating it as "blank it" once turned a key-only fault into a total auth
+	// outage. So a reset has to be a distinct instruction, not a value.
+	//
+	// It is a REQUEST, persisted on the hive record, because the operator's
+	// intent has to survive a missed beat and a hub restart. Cleared when the
+	// spoke reports installation_id 0 back — read-back confirmation, the same
+	// contract the forge switch uses.
+	//
+	// The live case: a hive provisioned with its OWN GitHub App kept that App's
+	// installation_id after its identity was later moved to the fleet's public
+	// App. app_id, app_slug and key_file all named the public App while the
+	// installation belonged to another, so every freshly minted token returned
+	// "404 Not Found" while cached ones kept working — 84 failures in three
+	// hours on one hive, with no config field visibly wrong.
+	RequestedAppReset bool `json:"requested_app_reset,omitempty"`
+
 	RequestedGitHubHost string `json:"requested_github_host,omitempty"`
 	// ForgeDelivered flips true once the spoke reports the requested forge host.
 	ForgeDelivered bool `json:"forge_delivered,omitempty"`


### PR DESCRIPTION
Adds a **Reset App** item to a hive's menu in the hub. The spoke clears its `installation_id` on the next beat → `HasUsableApp()` false → `githubAppRequired` raised → the owner is prompted to install the App again, and the 2-minute self-heal ticker starts, whose `RediscoverAndAdopt` adopts the correct installation for whichever App they install.

## The case it exists for, observed live

A hive provisioned with its **own** GitHub App kept that App's `installation_id` after its identity was later moved to the fleet's public App:

```yaml
app_id: 3568013                 # public App
installation_id: 145050760      # granted to a DIFFERENT App
key_file: /data/gh-app-key.pem  # public key
```

Every field reads correct. But freshly minted tokens returned `404 Not Found` while cached ones kept working — **84 failures in three hours**, with nothing visibly wrong in config. No automatic path repairs it: the hub doesn't track installation IDs, and the spoke's self-heal only runs once the App is already flagged missing.

## Why a flag, not a zero

The wire **cannot** express a clear. The spoke adopts a pushed installation only when non-zero, deliberately — zero means *"the hub is not speaking to this field"*. The cluster-wide key reconcile sends zero on every beat because it repairs **keys** on hives whose installation the hub doesn't track. Reading zero as "clear it" would blank a working installation fleet-wide.

## Why a durable request

`RequestedAppReset` persists on the hive record and clears on **read-back** — the spoke reporting `installation_id 0` — not on send. A reset lost to a dropped beat or hub restart would otherwise leave the click with no effect and no signal. Same contract as the forge switch.

**Scope is one field.** `app_id`, `app_slug` and the key are untouched, so a reset on a healthy hive costs one re-install, not an outage.

| Mutation | Result |
|---|---|
| Hub clears the request on send, not confirmation | 2 failures ✓ |
| Spoke ignores the reset flag | 2 failures ✓ |

The second **initially survived** — the spoke test defined its own copy of the adoption rule, so disabling the production branch left it green. The decision is now `nextInstallationID()` and the test drives it.