### PR TITLE
Sync v2 into mk

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -356,6 +356,34 @@ function captureTmuxLines(n) {
   }
 }
 
+// Best-effort scan of the agent's recent output for a GitHub pull-request URL
+// it opened for this task. Reported on task_complete as pr_url so the hub can
+// tell "work shipped" from "agent merely went idle" and pick the right issue
+// cooldown (kubestellar/hive#2393 item 7). This is intentionally best-effort:
+// when no PR link is visible we return '' and the hub applies its short no-PR
+// cooldown. When `repo` is known (owner/repo) we prefer a URL under that repo
+// so an unrelated PR mentioned in passing does not get attributed to the task.
+function detectPRURL(lines, repo) {
+  if (!Array.isArray(lines) || lines.length === 0) return '';
+  // Matches https://github.com/<owner>/<repo>/pull/<number>, capturing owner/repo.
+  const PR_URL_RE = /https:\/\/github\.com\/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\/pull\/\d+/g;
+  let repoMatch = '';
+  let anyMatch = '';
+  for (const line of lines) {
+    let m;
+    PR_URL_RE.lastIndex = 0;
+    while ((m = PR_URL_RE.exec(line)) !== null) {
+      const url = m[0];
+      if (!anyMatch) anyMatch = url;
+      if (repo && m[1] === repo) { repoMatch = url; break; }
+    }
+    if (repoMatch) break;
+  }
+  // Prefer a URL under the task's own repo; otherwise fall back to the first
+  // PR URL seen (better an approximate audit trail than none).
+  return repoMatch || anyMatch;
+}
+
 // True while a bob CLI process is alive. bob exits at the end of every turn,
 // so "process gone" means the turn finished — see the bob branch of
 // checkTmuxIdle(). Matches the launch command rather than the bare name so a
@@ -624,7 +652,13 @@ function progressTick() {
     console.log(`Task ${currentTask.task_id} completed — agent idle`);
     // Successful completion clears this work item's crash-retry budget.
     cliRestartCounts.delete(taskKey(currentTask));
-    send({ type: 'task_complete', seq: nextSeq(), task_id: currentTask.task_id, result: 'completed', summary: 'Agent returned to idle', tmux_output: tmuxLines });
+    // Best-effort: report the PR the agent opened, if one is visible in its
+    // recent output, so the hub can distinguish "shipped a PR" from "just went
+    // idle" and pick the right issue cooldown (kubestellar/hive#2393 item 7).
+    // Empty when no PR link is found — the hub then applies the short cooldown.
+    const prURL = detectPRURL(tmuxLines, currentTask.repo);
+    if (prURL) console.log(`Detected PR for ${currentTask.task_id}: ${prURL}`);
+    send({ type: 'task_complete', seq: nextSeq(), task_id: currentTask.task_id, result: 'completed', summary: 'Agent returned to idle', tmux_output: tmuxLines, pr_url: prURL });
     // bob exits after each turn, so the pane is now a bare shell. Bring it
     // back up before the next task, or the prompt would be typed into bash
     // ("-bash: <prompt>: command not found") and silently lost.

--- a/v2/cmd/hive/app_reset_adopt_test.go
+++ b/v2/cmd/hive/app_reset_adopt_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/hub"
+)
+
+// These tests drive nextInstallationID — the REAL decision in main.go — not a
+// restatement of it. An earlier version defined its own copy of the rule and
+// stayed green when the production branch was disabled entirely, which is the
+// same "tested the thing beside the change" flaw that let four checks pass
+// while testing nothing this week.
+func applyInstallation(cur config.GitHubConfig, ghCfg *hub.HeartbeatGitHubAppConfig) config.GitHubConfig {
+	next := cur
+	next.InstallationID, _ = nextInstallationID(cur.InstallationID, ghCfg)
+	return next
+}
+
+// TestPushedZeroStillCannotBlankAnInstallation is the guard the reset feature
+// must not weaken.
+//
+// Zero on the wire means "the hub is not speaking to this field". The
+// cluster-wide key reconcile sends zero on every beat, because it repairs KEYS
+// on hives whose installation the hub does not track. If zero were read as
+// "clear it", that reconcile would blank a working installation on every hive
+// it touches — turning a key-only fault into a total auth outage.
+func TestPushedZeroStillCannotBlankAnInstallation(t *testing.T) {
+	cur := config.GitHubConfig{AppID: config.PublicGitHubAppID, InstallationID: 145050760}
+
+	got := applyInstallation(cur, &hub.HeartbeatGitHubAppConfig{AppID: config.PublicGitHubAppID})
+	if got.InstallationID != 145050760 {
+		t.Fatalf("a pushed zero blanked a working installation (%d) — this is the outage the guard prevents", got.InstallationID)
+	}
+}
+
+// TestResetFlagClearsTheInstallation: only the explicit flag may zero it.
+// Clearing makes HasUsableApp() false, which raises githubAppRequired — the
+// prompt to install the App again, and the trigger for the self-heal ticker
+// whose RediscoverAndAdopt finds the right installation.
+func TestResetFlagClearsTheInstallation(t *testing.T) {
+	cur := config.GitHubConfig{AppID: config.PublicGitHubAppID, InstallationID: 145050760}
+	if !cur.HasUsableApp() {
+		t.Fatal("precondition: the hive should start with a usable App")
+	}
+
+	got := applyInstallation(cur, &hub.HeartbeatGitHubAppConfig{ResetInstallation: true})
+	if got.InstallationID != 0 {
+		t.Fatalf("reset did not clear the installation: %d", got.InstallationID)
+	}
+	if got.HasUsableApp() {
+		t.Fatal("App still reads as usable after the reset; the owner would never be prompted to reinstall")
+	}
+	// The rest of the identity must survive — a reset costs one re-install,
+	// not an identity rebuild.
+	if got.AppID != cur.AppID {
+		t.Fatalf("reset changed app_id: %d -> %d", cur.AppID, got.AppID)
+	}
+}
+
+// TestResetWins: a delivery carrying BOTH a reset and an installation must
+// reset. The hub never sends both, but the spoke should not depend on that.
+func TestResetWins(t *testing.T) {
+	cur := config.GitHubConfig{AppID: config.PublicGitHubAppID, InstallationID: 145050760}
+	got := applyInstallation(cur, &hub.HeartbeatGitHubAppConfig{
+		ResetInstallation: true, InstallationID: 999999,
+	})
+	if got.InstallationID != 0 {
+		t.Fatalf("installation %d was adopted despite a reset", got.InstallationID)
+	}
+}

--- a/v2/cmd/hive/ghapp_banner_verdict_test.go
+++ b/v2/cmd/hive/ghapp_banner_verdict_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kubestellar/hive/v2/pkg/github"
@@ -182,6 +183,72 @@ func TestClassifyGitHubAppFailure_OperatorFaultIsNotBlamedOnUser(t *testing.T) {
 	}
 	if !state.OperatorActionable() || state.UserActionable() {
 		t.Error("key-invalid is the operator's fault and must never be blamed on the user")
+	}
+}
+
+// TestClassifyGitHubAppWriteForbidden_HealthyInstallSurfacesWriteFailure is the
+// #2353 regression: the App authenticates, the installation resolves on the
+// right account and grants issues:write (so diagnoseGitHubApp returns OK), yet a
+// real write returned 403 "Resource not accessible by integration". Health must
+// NOT stay silent (None) and must NOT be mislabeled "lacks Issues: Read &
+// Write" — it must report the DISTINCT write-forbidden state with accurate copy
+// naming the repo and the repo-scope cause.
+func TestClassifyGitHubAppWriteForbidden_HealthyInstallSurfacesWriteFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// GetInstallation reports a perfectly healthy installation: right owner,
+		// issues:write granted. This is exactly the live case from #2353.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":          verdictTestInstallationID,
+			"account":     map[string]any{"login": "open-horizon-services"},
+			"permissions": map[string]any{"issues": "write"},
+		})
+	}))
+	defer srv.Close()
+
+	msg, state := classifyGitHubAppWriteForbidden(
+		context.Background(),
+		verdictTestAuth(t, srv.URL),
+		"open-horizon-services",
+		"Getting-Started",
+	)
+	if state == github.AppStateOK || state == github.AppStateUnknown {
+		t.Fatalf("a write-403 on a healthy install must not stay silent; state=%s", state)
+	}
+	if state == github.AppStateInsufficientPerms {
+		t.Error("must NOT be mislabeled as an Issues permission gap — the permission is granted")
+	}
+	if state != github.AppStateWriteForbidden {
+		t.Errorf("state = %s, want write-forbidden", state)
+	}
+	if msg == "" {
+		t.Error("write-forbidden must carry an accurate, non-empty message")
+	}
+	if !strings.Contains(msg, "Getting-Started") {
+		t.Errorf("message must name the repo; got %q", msg)
+	}
+	if strings.Contains(msg, "lacks Issues") {
+		t.Errorf("message must not fabricate a permission gap; got %q", msg)
+	}
+}
+
+// TestClassifyGitHubAppWriteForbidden_RealAuthProblemWins — when the write 403
+// coincides with a GENUINE App-auth fault (here: a 401 key-invalid), report that
+// real cause rather than masking it behind the repo-scope story.
+func TestClassifyGitHubAppWriteForbidden_RealAuthProblemWins(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "A JSON web token could not be decoded"})
+	}))
+	defer srv.Close()
+
+	_, state := classifyGitHubAppWriteForbidden(
+		context.Background(),
+		verdictTestAuth(t, srv.URL),
+		"open-horizon-services",
+		"Getting-Started",
+	)
+	if state != github.AppStateKeyInvalid {
+		t.Errorf("state = %s, want key-invalid — the real fault must win", state)
 	}
 }
 

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -167,6 +167,38 @@ func prospectiveGitHubIdentity(cur config.GitHubConfig, ghCfg *hub.HeartbeatGitH
 	return &next
 }
 
+// nextInstallationID decides what a hive's installation_id becomes after a
+// hub delivery, and reports whether the change is an operator RESET.
+//
+// Three cases, and the difference between the last two is load-bearing:
+//
+//	ResetInstallation  -> 0. The operator clicked "Reset App". Clearing makes
+//	                     HasUsableApp() false, which raises githubAppRequired:
+//	                     the owner is prompted to install the App again and the
+//	                     self-heal ticker starts, whose RediscoverAndAdopt
+//	                     adopts the correct installation for whatever they
+//	                     install.
+//	non-zero pushed    -> adopt it.
+//	zero pushed        -> KEEP the current value. Zero means "the hub is not
+//	                     speaking to this field", not "clear it". The
+//	                     cluster-wide key reconcile sends zero on every beat
+//	                     because it repairs KEYS on hives whose installation the
+//	                     hub does not track; reading that as a clear would blank
+//	                     a working installation fleet-wide and turn a key-only
+//	                     fault into a total auth outage.
+func nextInstallationID(current int64, ghCfg *hub.HeartbeatGitHubAppConfig) (next int64, reset bool) {
+	if ghCfg == nil {
+		return current, false
+	}
+	if ghCfg.ResetInstallation {
+		return 0, current != 0
+	}
+	if ghCfg.InstallationID != 0 {
+		return ghCfg.InstallationID, false
+	}
+	return current, false
+}
+
 func perAppIDKeyPath(appID int64) string {
 	if appID <= 0 {
 		return ""
@@ -2896,8 +2928,12 @@ func main() {
 			// KEY on hives whose installation_id is already correct (and which
 			// the hub does not track); assigning zero here would blank a working
 			// value and turn a key-only fault into a total auth outage.
-			if ghCfg.InstallationID != 0 {
-				cfg.GitHub.InstallationID = ghCfg.InstallationID
+			if next, cleared := nextInstallationID(cfg.GitHub.InstallationID, ghCfg); cleared {
+				logger.Info("clearing github app installation_id on operator request",
+					"was", cfg.GitHub.InstallationID)
+				cfg.GitHub.InstallationID = next
+			} else {
+				cfg.GitHub.InstallationID = next
 			}
 			// Deliberately NOT `cfg.GitHub.KeyFile = keyPath`.
 			//

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1807,6 +1807,31 @@ func main() {
 					dashSrv.AuditLog("system", "github_app_check", "result=installed but write NOT verified: "+diag, "")
 					return false
 				}
+				// #2353: the classifier above only proves the installation
+				// authenticates and grants issues:write — NOT that this repo can
+				// actually be written. Finding the advisory issue is a READ, which
+				// succeeds even when the repo is not in the App installation's
+				// selected repos. Perform a REAL write probe before clearing the
+				// banner, so re-check cannot falsely "verify write" for a repo the
+				// App can only read (the recheck false-positive).
+				if werr := ghClient.ProbeIssueWrite(ctx, recheckRepo, num); werr != nil {
+					if strings.Contains(werr.Error(), "403") && strings.Contains(werr.Error(), "Resource not accessible by integration") {
+						msg, state := classifyGitHubAppWriteForbidden(ctx, ghClient.AppAuth(), cfg.Project.Org, recheckRepo)
+						dashSrv.SetGitHubAppPermIssue(msg)
+						dashSrv.SetGitHubAppState(state.String())
+						logger.Warn("github app recheck: write probe returned 403 — not clearing the banner",
+							"repo", recheckRepo, "state", state.String(), "detail", msg)
+						dashSrv.AuditLog("system", "github_app_check", "result=write probe FORBIDDEN: "+msg, "")
+						return false
+					}
+					// A non-403 probe failure is inconclusive (rate limit,
+					// transient network). Do NOT clear the banner on a write we
+					// could not confirm, but also do NOT accuse anyone.
+					logger.Warn("github app recheck: write probe inconclusive — leaving banner as-is",
+						"repo", recheckRepo, "error", werr)
+					dashSrv.AuditLog("system", "github_app_check", "result=write probe inconclusive", "")
+					return false
+				}
 				logger.Info("github app recheck: app detected, write verified", "repo", recheckRepo, "number", num)
 				dashSrv.AuditLog("system", "github_app_check", "result=OK (installed, write verified)", "")
 				return true
@@ -3477,6 +3502,49 @@ func classifyGitHubAppFailure(ctx context.Context, appAuth *github.AppAuth, expe
 	return true, msg, state
 }
 
+// classifyGitHubAppWriteForbidden (#2353) is the verdict for a REAL write that
+// returned 403 "Resource not accessible by integration". Authentication-only
+// health checks (classifyGitHubAppFailure / diagnoseGitHubApp) inspect the
+// installation's granted PERMISSIONS but never whether the target repo is in
+// the installation's `selected` repositories — so they return AppStateOK for a
+// repo the App cannot write, and the write failure stayed invisible to health
+// (githubAppState=None) or, worse, got hard-overridden into a false "lacks
+// Issues: Read & Write" banner.
+//
+// The rule here keeps attribution honest:
+//
+//   - If diagnoseGitHubApp finds a genuine, classifiable App-auth problem
+//     (wrong installation, missing key, insufficient PERMISSION, etc.), report
+//     THAT — it is the real cause and its copy is already accurate.
+//   - If diagnoseGitHubApp reports the installation is healthy (AppStateOK:
+//     right owner, issues:write granted) OR could not reach a verdict
+//     (AppStateUnknown), the write 403 is still real and must NOT be silently
+//     healthy. Report AppStateWriteForbidden with copy that names the repo and
+//     the likeliest cause (repo not in the installation's selected repos),
+//     WITHOUT inventing a permission gap that the diagnosis just proved absent.
+//
+// It always raises: a write that returned 403 is a genuine, standing failure to
+// surface, distinct from the transient/unknown probe failures
+// classifyGitHubAppFailure guards against.
+func classifyGitHubAppWriteForbidden(ctx context.Context, appAuth *github.AppAuth, expectedOwner, repo string) (msg string, state github.AppAuthState) {
+	diagMsg, diagState := diagnoseGitHubApp(ctx, appAuth, expectedOwner)
+	if diagState != github.AppStateOK && diagState != github.AppStateUnknown {
+		// A real, classifiable App-auth problem — its message is the accurate
+		// one (e.g. wrong-installation, key-missing, or a genuine permission
+		// gap). Use it as-is rather than masking it with the repo-scope story.
+		return diagMsg, diagState
+	}
+	// Installation authenticates and (per the diagnosis) holds issues:write, yet
+	// the write was forbidden. Attribute it to the one thing the permission
+	// check cannot see — repo scope — and name the repo so the fix is concrete.
+	d := github.AppAuthDiagnosis{
+		State:           github.AppStateWriteForbidden,
+		ExpectedAccount: expectedOwner,
+		Repo:            repo,
+	}
+	return d.Message(), github.AppStateWriteForbidden
+}
+
 func runEvalCycle(
 	ctx context.Context,
 	cfg *config.Config,
@@ -3787,15 +3855,20 @@ func runEvalCycle(
 						}
 						logger.Warn("failed to post advisory digest via app", "repo", primaryRepo, "issue", issueNum, "error", err)
 						if strings.Contains(err.Error(), "403") && strings.Contains(err.Error(), "Resource not accessible by integration") {
-							// App is installed (we found the issue) but can't write.
-							// Resolve the actual cause — pending permission approval
-							// vs. an installation_id pointing at the wrong org — so
-							// the banner tells the user what to actually fix.
-							msg, state := diagnoseGitHubApp(ctx, ghClient.AppAuth(), cfg.Project.Org)
-							if msg == "" {
-								msg = "The GitHub App is installed but lacks Issues: Read & Write permission. The org owner must approve updated permissions at the app installation settings page."
-								state = github.AppStateInsufficientPerms
-							}
+							// App is installed (we found the issue) but a real
+							// WRITE was forbidden. #2353: attribute this honestly.
+							// diagnoseGitHubApp only inspects installation-level
+							// PERMISSIONS, so when it comes back healthy (issues:write
+							// granted, right owner) the previous code hard-overrode
+							// that "OK" into a false "lacks Issues: Read & Write"
+							// banner — the exact misattribution #2353 reports. When
+							// the diagnosis is genuinely a permission/installation
+							// problem, use it; otherwise surface a DISTINCT
+							// write-forbidden state naming the likeliest real cause
+							// (the repo is not in the App installation's selected
+							// repos), instead of leaving health at None or faking a
+							// permission gap the diagnosis just disproved.
+							msg, state := classifyGitHubAppWriteForbidden(ctx, ghClient.AppAuth(), cfg.Project.Org, primaryRepo)
 							dashSrv.SetGitHubAppRequired(true)
 							dashSrv.SetGitHubAppPermIssue(msg)
 							dashSrv.SetGitHubAppState(state.String())

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -136,6 +136,10 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("POST /api/config/governor/agents", s.handleGovernorAddAgent)
 	s.mux.HandleFunc("DELETE /api/config/governor/agents/{name}", s.handleGovernorRemoveAgent)
 	s.mux.HandleFunc("PUT /api/config/governor/repos", s.handleGovernorRepos)
+	// Access probe run when the Repos tab adds a new repo: verifies the hive's
+	// GitHub App is installed on the new repo's org before the repo is accepted,
+	// and hands back the correct per-forge install URL when it is not.
+	s.mux.HandleFunc("POST /api/config/governor/repos/check-access", s.handleGovernorRepoCheckAccess)
 	s.mux.HandleFunc("PUT /api/config/github", s.handleConfigGitHub)
 
 	s.mux.HandleFunc("GET /api/agents", s.handleAgentsList)
@@ -4649,6 +4653,34 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 	}
 	org := s.deps.Config.Project.Org
 
+	// Single-host-per-spoke (defence in depth; the Repos tab also checks this
+	// client-side so it fails fast). Every repo the user submits must live on
+	// this hive's forge — mixing github.com and a GHE instance silently breaks
+	// App auth for half the repos. Check the raw pasted values BEFORE the loop
+	// below strips the host off each one. hiveForgeHost() is this hive's own
+	// GitHub host (github.com or the GHE hostname), the same value the dashboard
+	// derives from github_base_url.
+	// Snapshot so a validation failure AFTER we mutate the in-memory config can
+	// restore it — the "always exactly one default" guard below runs once the
+	// final repos+primary are known, and a reject must not leave a half-applied
+	// config in memory (which would then be persisted on the next unrelated save).
+	prevRepos := append([]string(nil), s.deps.Config.Project.Repos...)
+	prevPrimary := s.deps.Config.Project.PrimaryRepo
+
+	spokeHost := s.hiveForgeHost()
+	for _, ref := range body.Repos {
+		if h := repoRefHostLabel(ref); h != "" && !sameForgeHost(h, spokeHost) {
+			jsonError(w, fmt.Sprintf("repo %q is on %s but this hive is on %s — a hive's repos must all be on one GitHub host. Remove the mismatched repo or use a repo on %s.", strings.TrimSpace(ref), h, spokeHost, spokeHost), http.StatusBadRequest)
+			return
+		}
+	}
+	if body.PrimaryRepo != nil {
+		if h := repoRefHostLabel(*body.PrimaryRepo); h != "" && !sameForgeHost(h, spokeHost) {
+			jsonError(w, fmt.Sprintf("default repo %q is on %s but this hive is on %s — the default must live on this hive's forge.", strings.TrimSpace(*body.PrimaryRepo), h, spokeHost), http.StatusBadRequest)
+			return
+		}
+	}
+
 	if len(body.Repos) > 0 {
 		stripped := make([]string, 0, len(body.Repos))
 		for _, repo := range body.Repos {
@@ -4704,6 +4736,31 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Always exactly one default: a hive with repos must name a primary_repo that
+	// is one of them — that is the repo the advisory issue is maintained in. The
+	// Repos tab disables Save until a star is chosen, but enforce it server-side
+	// too so no client (or a stale one) can persist repos with no default. Reject
+	// and restore the pre-mutation config so the in-memory state stays coherent.
+	if final := s.deps.Config.Project.Repos; len(final) > 0 {
+		primary := s.deps.Config.Project.PrimaryRepo
+		inList := false
+		for _, r := range final {
+			if r == primary {
+				inList = true
+				break
+			}
+		}
+		if primary == "" || !inList {
+			s.deps.Config.Project.Repos = prevRepos
+			s.deps.Config.Project.PrimaryRepo = prevPrimary
+			if s.deps.GHClient != nil {
+				s.deps.GHClient.SetRepos(prevRepos)
+			}
+			jsonError(w, "set a default repo before saving — one of the monitored repos must be marked as the default (the repo where the advisory issue is maintained)", http.StatusBadRequest)
+			return
+		}
+	}
+
 	if err := s.saveConfig(); err != nil {
 		s.logger.Error("failed to persist config", "error", err)
 	}
@@ -4713,6 +4770,152 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 	s.auditFromRequest(r, "config_governor_repos", auditDetail("section", "repos"), "")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
+}
+
+// hiveForgeHost returns the bare GitHub hostname this hive's repos and App live
+// on ("github.com" or a GHE hostname like "github.ibm.com"). It is the single
+// source of truth the single-host-per-spoke guard compares each submitted repo
+// against, and mirrors config.GitHubConfig.HostLabel() (the same value the
+// dashboard reads as github_base_url's host). Falls back to public github.com
+// when no config is loaded (tests/early boot).
+func (s *Server) hiveForgeHost() string {
+	if s.deps != nil && s.deps.Config != nil {
+		return s.deps.Config.GitHub.HostLabel()
+	}
+	return "github.com"
+}
+
+// repoRefHostLabel extracts the GitHub host a repo string was pasted with, or ""
+// when none was given (a bare "repo" or "owner/repo", which by definition belongs
+// to the hive's own forge). Mirrors hub.repoRefHost: a full URL or a leading
+// dotted segment ("github.ibm.com/org/repo") names an explicit host. Returned
+// lowercased for case-insensitive comparison in sameForgeHost.
+func repoRefHostLabel(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	s = strings.Trim(s, "/")
+	if s == "" {
+		return ""
+	}
+	parts := strings.Split(s, "/")
+	if len(parts) > 1 && strings.Contains(parts[0], ".") {
+		return strings.ToLower(parts[0])
+	}
+	return ""
+}
+
+// sameForgeHost reports whether two host labels refer to the same GitHub. Both
+// "" and "github.com" mean public GitHub; a GHE host equals only itself.
+// Case-insensitive. Mirrors hub.sameGitHubHost so the dashboard's single-host
+// rule matches the hub's request/assign validation exactly.
+func sameForgeHost(a, b string) bool {
+	norm := func(h string) string {
+		h = strings.ToLower(strings.TrimSpace(h))
+		if h == "" || h == "github.com" {
+			return "github.com"
+		}
+		return h
+	}
+	return norm(a) == norm(b)
+}
+
+// handleGovernorRepoCheckAccess verifies that this hive's GitHub App can access
+// a repo the operator is about to add, and — when it cannot — returns the
+// per-forge App install/authorize URL so the Repos tab can guide the user to
+// grant access before the repo is finally accepted (requirement #3).
+//
+// The check today probes at ORG granularity: DiscoverInstallationID(org) returns
+// ErrNoInstallationForOrg when the App is not installed on the repo's org at all,
+// which is the common "new org the App was never installed on" case and the one
+// that hard-blocks reads and writes. On a positive result we report ok:true.
+//
+// TODO(repo-access-probe): tighten to REPO granularity. An App installed on the
+// org "Only select repositories" may still lack THIS repo (see #2353's
+// write-forbidden case). The deeper probe should mint an installation token and
+// GET /repos/{org}/{repo} (s.deps.GHClient.GetRepo) — a 404/403 there means the
+// installation exists but this repo is not in its selected set, which needs the
+// same "manage installation" URL to add the repo to the selection. That probe is
+// scoped out of this change to keep it focused; the org-level check plus the
+// install workflow already covers the "App not installed on the org" footgun.
+func (s *Server) handleGovernorRepoCheckAccess(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Repo string `json:"repo"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	ref := sanitizeString(body.Repo)
+	if ref == "" {
+		jsonError(w, "repo is required", http.StatusBadRequest)
+		return
+	}
+	// Single-host guard here too: an added repo on a different forge is rejected
+	// before we even probe access, with the same message as the save path.
+	spokeHost := s.hiveForgeHost()
+	if h := repoRefHostLabel(ref); h != "" && !sameForgeHost(h, spokeHost) {
+		jsonError(w, fmt.Sprintf("repo %q is on %s but this hive is on %s — a hive's repos must all be on one GitHub host.", ref, h, spokeHost), http.StatusBadRequest)
+		return
+	}
+	// Resolve the org the repo lives in. The paste may be "org/repo", a bare
+	// "repo" (org is the hive's configured org), or a full URL. Strip any host
+	// and pull the org segment when present.
+	org := s.deps.Config.Project.Org
+	stripped := ref
+	stripped = strings.TrimPrefix(stripped, "https://")
+	stripped = strings.TrimPrefix(stripped, "http://")
+	stripped = strings.Trim(stripped, "/")
+	parts := strings.Split(stripped, "/")
+	// Drop a leading host segment ("github.ibm.com/org/repo" -> "org/repo").
+	if len(parts) > 1 && strings.Contains(parts[0], ".") {
+		parts = parts[1:]
+	}
+	if len(parts) >= 2 && parts[0] != "" {
+		org = parts[0]
+	}
+	if org == "" {
+		jsonError(w, "cannot determine the org for this repo — use org/repo format", http.StatusBadRequest)
+		return
+	}
+
+	// An App-less hive (advisory-only, no private key) cannot and need not probe
+	// installation access: it never writes. Treat it as "no access check needed"
+	// so the add proceeds — the single-host guard above already ran.
+	if s.deps.GHAppAuth == nil || !s.deps.GHAppAuth.HasKey() {
+		okResponse(w, map[string]string{"status": "no-app"})
+		return
+	}
+
+	ctx := s.deps.Ctx
+	if ctx == nil {
+		ctx = r.Context()
+	}
+	if _, err := s.deps.GHAppAuth.DiscoverInstallationID(ctx, org); err != nil {
+		// Not installed on this org (or discovery failed). Surface the correct
+		// per-forge install URL and arm the existing pending-install mechanism so
+		// the banner/recheck plumbing the App-required flow already uses drives
+		// this to completion. AppInstallURL() returns "" for a GHE host whose App
+		// slug was never configured — the UI renders that as a config message
+		// rather than a dead link.
+		installURL := ""
+		if s.deps.Config != nil {
+			installURL = s.deps.Config.GitHub.AppInstallURL()
+		}
+		s.SetPendingGitHubAppInstall()
+		s.logger.Info("repo add blocked: app not installed on org", "org", org, "repo", ref, "error", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":           false,
+			"needsInstall": true,
+			"org":          org,
+			"installUrl":   installURL,
+			"error":        fmt.Sprintf("the Hive GitHub App is not installed on %q, so it cannot read or write %s. Install/authorize the App for %q, then re-check.", org, ref, org),
+		})
+		return
+	}
+	okResponse(w, map[string]string{"status": "ok", "org": org})
 }
 
 func (s *Server) handleGitHubAppInstallClicked(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -1477,7 +1477,9 @@ func TestHandleGovernorBudget_Success(t *testing.T) {
 
 func TestHandleGovernorRepos_Success(t *testing.T) {
 	s, _ := apiServer(t)
-	rec := doPut(s, "/api/config/governor/repos", map[string]interface{}{"repos": []string{"myorg/repo1", "myorg/repo2"}})
+	// Replacing the repo set must name a default among the new repos (the
+	// always-exactly-one-default invariant), so send primaryRepo too.
+	rec := doPut(s, "/api/config/governor/repos", map[string]interface{}{"repos": []string{"myorg/repo1", "myorg/repo2"}, "primaryRepo": "repo1"})
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}
@@ -1485,7 +1487,7 @@ func TestHandleGovernorRepos_Success(t *testing.T) {
 
 func TestHandleGovernorRepos_StripOrg(t *testing.T) {
 	s, deps := apiServer(t)
-	rec := doPut(s, "/api/config/governor/repos", map[string]interface{}{"repos": []string{"myorg/new-repo"}})
+	rec := doPut(s, "/api/config/governor/repos", map[string]interface{}{"repos": []string{"myorg/new-repo"}, "primaryRepo": "myorg/new-repo"})
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}

--- a/v2/pkg/dashboard/api_governor_coverage_test.go
+++ b/v2/pkg/dashboard/api_governor_coverage_test.go
@@ -129,12 +129,18 @@ func TestCovGov_Repos(t *testing.T) {
 	if rec := doPut(s, "/api/config/governor/repos", map[string]any{"repos": []string{"bad;rm"}}); rec.Code != http.StatusBadRequest {
 		t.Fatalf("repos invalid: %d", rec.Code)
 	}
-	// Valid plain repo list.
-	if rec := doPut(s, "/api/config/governor/repos", map[string]any{"repos": []string{"repoA", "repoB"}}); rec.Code != http.StatusOK {
+	// Valid plain repo list (with a default among them — required now).
+	if rec := doPut(s, "/api/config/governor/repos", map[string]any{"repos": []string{"repoA", "repoB"}, "primaryRepo": "repoA"}); rec.Code != http.StatusOK {
 		t.Fatalf("repos ok: %d", rec.Code)
 	}
-	// A full GitHub URL repo (exercises URL-parsing branch, incl GHE host).
-	if rec := doPut(s, "/api/config/governor/repos", map[string]any{"repos": []string{"https://github.ibm.com/myorg/repoC"}}); rec.Code != http.StatusOK {
+	// A cross-forge repo (GHE URL on a public-github.com hive) must be REJECTED
+	// by the single-host-per-spoke guard — a hive's repos all live on one host.
+	if rec := doPut(s, "/api/config/governor/repos", map[string]any{"repos": []string{"https://github.ibm.com/myorg/repoC"}, "primaryRepo": "repoC"}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("cross-forge repo should be rejected: %d", rec.Code)
+	}
+	// A full same-forge (github.com) URL repo still exercises the URL-parsing
+	// branch and is accepted.
+	if rec := doPut(s, "/api/config/governor/repos", map[string]any{"repos": []string{"https://github.com/myorg/repoC"}, "primaryRepo": "repoC"}); rec.Code != http.StatusOK {
 		t.Fatalf("repos url: %d", rec.Code)
 	}
 }

--- a/v2/pkg/dashboard/api_test.go
+++ b/v2/pkg/dashboard/api_test.go
@@ -51,11 +51,11 @@ func testDeps(t *testing.T) *Dependencies {
 	_ = &refreshCalled
 	_ = &persistCalled
 	return &Dependencies{
-		Config:   cfg,
-		AgentMgr: mgr,
-		Governor: gov,
-		Logger:   logger,
-		Ctx:      context.Background(),
+		Config:      cfg,
+		AgentMgr:    mgr,
+		Governor:    gov,
+		Logger:      logger,
+		Ctx:         context.Background(),
 		RefreshFunc: func() { refreshCalled.Store(true) },
 		PersistFunc: func() { persistCalled.Store(true) },
 	}
@@ -499,7 +499,7 @@ func TestHandleGovernorRemoveAgent_NotFound(t *testing.T) {
 func TestHandleGovernorRepos(t *testing.T) {
 	s, _ := apiServer(t)
 	rec := doPut(s, "/api/config/governor/repos",
-		map[string]interface{}{"repos": []string{"myorg/repo1", "myorg/repo2"}})
+		map[string]interface{}{"repos": []string{"myorg/repo1", "myorg/repo2"}, "primaryRepo": "repo1"})
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -109,6 +109,16 @@ type WSMessage struct {
 	Summary        string          `json:"summary,omitempty"`
 	TmuxOutput     []string        `json:"tmux_output,omitempty"`
 	AcceptedModels []string        `json:"accepted_models,omitempty"`
+	// PRURL is the pull request the agent opened for this task, reported on
+	// task_complete. It is best-effort: the relay fills it when it can spot a
+	// PR link in the agent's output, and it is empty when the agent went idle
+	// without shipping anything. The hub uses its presence to decide how long
+	// to keep the underlying issue in cooldown — see markTaskCompleted and
+	// kubestellar/hive#2393 item 7 (an idle-but-no-PR completion must NOT lock
+	// the issue for a full week). A known PR URL per issue also feeds the
+	// #2356 duplicate-detection work. Field naming follows the PRURL
+	// convention in v2/pkg/github/prclaims.go.
+	PRURL string `json:"pr_url,omitempty"`
 	// Permanent marks a task_failed the relay will not retry: it exhausted its
 	// per-task CLI-restart budget and gave up (see MAX_TASK_CLI_RESTARTS in
 	// bin/contributor-relay.sh). Reassigning the same work item to the same
@@ -146,18 +156,45 @@ type ContributeWSHub struct {
 	activity       []ActivityEntry
 	server         *Server
 	completedTasks map[string]time.Time
-	completedMu    sync.Mutex
-	selectMu       sync.Mutex
+	// completedTaskCooldown holds a per-task override for how long, from the
+	// completion time in completedTasks, the issue stays in cooldown. It is
+	// populated by markTaskCompleted based on whether a PR was reported. When a
+	// key is absent (e.g. tasks restored from an older on-disk format, or set
+	// directly by tests) isTaskInCooldown falls back to the full
+	// completedTaskCooldownHours, preserving the original conservative default.
+	completedTaskCooldown map[string]time.Duration
+	// completedTaskPRURL records the PR URL reported for a completed task, kept
+	// for stats/audit and to feed #2356 duplicate detection (a known PR URL per
+	// issue). Empty means the completion reported no PR.
+	completedTaskPRURL map[string]string
+	completedMu        sync.Mutex
+	selectMu           sync.Mutex
 }
 
+// completedTaskCooldownHours is the cooldown applied when a task completes
+// having actually shipped a pull request: real work landed, so we should not
+// re-dispatch the same issue for a week.
 const completedTaskCooldownHours = 168
+
+// completedNoPRCooldownHours is the cooldown applied when a task "completes"
+// only because the agent went idle WITHOUT reporting a PR (the common case the
+// old code could not distinguish — see kubestellar/hive#2393 item 7). Nothing
+// shipped, so locking the issue for a full week wrongly starves it: another
+// contributor should be able to pick it up soon. We keep a short, non-zero
+// cooldown (not zero) so the very next selector pass does not instantly hand
+// the same untouched issue back to the same idle contributor in a tight loop;
+// a few hours is long enough to break that loop while still freeing the issue
+// the same day.
+const completedNoPRCooldownHours = 4
 
 func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 	hub := &ContributeWSHub{
-		connections:    make(map[string]*ContributorConnection),
-		completedTasks: make(map[string]time.Time),
-		logger:         logger,
-		server:         server,
+		connections:           make(map[string]*ContributorConnection),
+		completedTasks:        make(map[string]time.Time),
+		completedTaskCooldown: make(map[string]time.Duration),
+		completedTaskPRURL:    make(map[string]string),
+		logger:                logger,
+		server:                server,
 	}
 	hub.loadCompletedTasks()
 	hub.loadActivity()
@@ -239,6 +276,18 @@ func (h *ContributeWSHub) RecentActivity() []ActivityEntry {
 
 const completedTasksFile = "/data/contributors/completed-tasks.json"
 
+// completedTaskRecord is the on-disk shape of one completed-task entry. It
+// carries the completion time plus, since #2393 item 7, the per-task cooldown
+// and the PR URL that decided it, so a hub restart preserves whether an issue
+// got the short no-PR cooldown or the full one. Entries written by older builds
+// were a bare RFC3339 timestamp string; loadCompletedTasks still accepts that
+// legacy form and treats it as a full-cooldown, no-PR entry.
+type completedTaskRecord struct {
+	CompletedAt   time.Time `json:"completed_at"`
+	CooldownHours float64   `json:"cooldown_hours,omitempty"`
+	PRURL         string    `json:"pr_url,omitempty"`
+}
+
 func (h *ContributeWSHub) loadCompletedTasks() {
 	h.completedMu.Lock()
 	defer h.completedMu.Unlock()
@@ -246,15 +295,42 @@ func (h *ContributeWSHub) loadCompletedTasks() {
 	if err != nil {
 		return
 	}
-	var saved map[string]string
-	if json.Unmarshal(data, &saved) != nil {
-		return
-	}
-	for k, v := range saved {
-		if t, err := time.Parse(time.RFC3339, v); err == nil {
-			if time.Since(t) < completedTaskCooldownHours*time.Hour {
-				h.completedTasks[k] = t
+
+	// Accept both the current object form and the legacy map[string]string
+	// (key -> RFC3339 timestamp) form so an upgrade never drops cooldowns.
+	records := make(map[string]completedTaskRecord)
+	if json.Unmarshal(data, &records) != nil {
+		var legacy map[string]string
+		if json.Unmarshal(data, &legacy) != nil {
+			return
+		}
+		records = make(map[string]completedTaskRecord, len(legacy))
+		for k, v := range legacy {
+			if t, err := time.Parse(time.RFC3339, v); err == nil {
+				records[k] = completedTaskRecord{CompletedAt: t}
 			}
+		}
+	}
+
+	for k, rec := range records {
+		if rec.CompletedAt.IsZero() {
+			continue
+		}
+		cooldown := completedTaskCooldownHours * time.Hour
+		if rec.CooldownHours > 0 {
+			cooldown = time.Duration(rec.CooldownHours * float64(time.Hour))
+		}
+		// Skip anything already past its own cooldown so we don't resurrect
+		// stale locks.
+		if time.Since(rec.CompletedAt) >= cooldown {
+			continue
+		}
+		h.completedTasks[k] = rec.CompletedAt
+		if h.completedTaskCooldown != nil {
+			h.completedTaskCooldown[k] = cooldown
+		}
+		if h.completedTaskPRURL != nil {
+			h.completedTaskPRURL[k] = rec.PRURL
 		}
 	}
 	h.logger.Info("[contribute-ws] loaded completed tasks", "count", len(h.completedTasks))
@@ -262,9 +338,18 @@ func (h *ContributeWSHub) loadCompletedTasks() {
 
 func (h *ContributeWSHub) saveCompletedTasks() {
 	h.completedMu.Lock()
-	saved := make(map[string]string, len(h.completedTasks))
+	saved := make(map[string]completedTaskRecord, len(h.completedTasks))
 	for k, t := range h.completedTasks {
-		saved[k] = t.Format(time.RFC3339)
+		rec := completedTaskRecord{CompletedAt: t}
+		if h.completedTaskCooldown != nil {
+			if d, ok := h.completedTaskCooldown[k]; ok {
+				rec.CooldownHours = d.Hours()
+			}
+		}
+		if h.completedTaskPRURL != nil {
+			rec.PRURL = h.completedTaskPRURL[k]
+		}
+		saved[k] = rec
 	}
 	h.completedMu.Unlock()
 	data, err := json.Marshal(saved)
@@ -283,12 +368,45 @@ func (h *ContributeWSHub) saveCompletedTasks() {
 	}
 }
 
-func (h *ContributeWSHub) markTaskCompleted(repo string, number int) {
+// markTaskCompleted records a completed task and starts its issue cooldown.
+//
+// The cooldown length is conditional on whether the completion actually shipped
+// a pull request (kubestellar/hive#2393 item 7): a completion WITH a prURL gets
+// the full completedTaskCooldownHours (real work landed — don't re-dispatch for
+// a week), while a completion WITHOUT one — the agent merely returned to idle —
+// gets the short completedNoPRCooldownHours so an issue where nothing shipped
+// is not locked out for a week. The chosen expiry is stored per task and honored
+// by isTaskInCooldown; the prURL is retained for stats/audit and #2356
+// duplicate detection.
+func (h *ContributeWSHub) markTaskCompleted(repo string, number int, prURL string) {
 	key := fmt.Sprintf("%s#%d", repo, number)
+	cooldown := completedNoPRCooldownHours * time.Hour
+	if prURL != "" {
+		cooldown = completedTaskCooldownHours * time.Hour
+	}
 	h.completedMu.Lock()
 	h.completedTasks[key] = time.Now()
+	if h.completedTaskCooldown != nil {
+		h.completedTaskCooldown[key] = cooldown
+	}
+	if h.completedTaskPRURL != nil {
+		h.completedTaskPRURL[key] = prURL
+	}
 	h.completedMu.Unlock()
 	h.saveCompletedTasks()
+}
+
+// cooldownForLocked returns the cooldown duration to apply to key. Callers must
+// already hold completedMu. When no per-task override was recorded (older
+// on-disk entries, or hubs built directly in tests) it falls back to the full
+// completedTaskCooldownHours — the original, conservative default.
+func (h *ContributeWSHub) cooldownForLocked(key string) time.Duration {
+	if h.completedTaskCooldown != nil {
+		if d, ok := h.completedTaskCooldown[key]; ok {
+			return d
+		}
+	}
+	return completedTaskCooldownHours * time.Hour
 }
 
 func (h *ContributeWSHub) isTaskInCooldown(repo string, number int) bool {
@@ -299,8 +417,10 @@ func (h *ContributeWSHub) isTaskInCooldown(repo string, number int) bool {
 	if !ok {
 		return false
 	}
-	if time.Since(t) > completedTaskCooldownHours*time.Hour {
+	if time.Since(t) > h.cooldownForLocked(key) {
 		delete(h.completedTasks, key)
+		delete(h.completedTaskCooldown, key)
+		delete(h.completedTaskPRURL, key)
 		return false
 	}
 	return true
@@ -670,7 +790,10 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 
 				if hasTask {
 					if completedTask != nil {
-						h.markTaskCompleted(completedTask.Repo, completedTask.Number)
+						// #2393 item 7: keep the full week-long cooldown only when a
+						// PR was actually reported; an idle-but-no-PR completion gets
+						// the short cooldown so the issue is not locked for a week.
+						h.markTaskCompleted(completedTask.Repo, completedTask.Number, msg.PRURL)
 					}
 					h.addActivity(contributor.profile.GitHubUsername, "completed", contributor.role, contributor.cliBackend, contributor.model, msg.TaskID)
 					h.logger.Info("[contribute-ws] task complete",

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -1064,6 +1064,54 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		disabledRepos = h.server.deps.Config.Hub.DisabledRepos
 	}
 
+	// --- Collect the eligible candidates, then order them (#2390) ---------------
+	//
+	// #2390 (castrojo): "a great default would be starting with MY PRs that are
+	// blocking someone else or have been reviewed and are waiting for something."
+	// i.e. before we hand a connected contributor a brand-new issue, prefer a work
+	// item that is already THEIRS and needs their attention.
+	//
+	// Priority order applied below:
+	//   1. The contributor's OWN work (candidate author == c.profile.GitHubUsername)
+	//   2. Everything else — today's plain first-eligible ordering
+	//
+	// Honest scope note on the available signal:
+	//   selectTask only iterates ActionableIssues (issues), and the per-candidate
+	//   map carries `author` but NO review state. The richer signal #2390 really
+	//   wants — "my PR has been reviewed / is approved / requested changes / is
+	//   blocking someone else" — is not collected anywhere yet:
+	//     * bin/enumerate-actionable.sh enumerates PRs with only
+	//       title/labels/author/draft/url (no reviewDecision, no requested-changes,
+	//       no "blocking"), and those PRs land in FrontendRepo.OpenPrs, which this
+	//       selector does not read at all.
+	//     * github.PullRequest has no review-decision field.
+	//   So this change implements ONLY the ordering half of #2390, keyed on the one
+	//   own-work signal that actually exists today (issue authorship). When the
+	//   contributor has no own-authored candidate, we fall back to today's exact
+	//   ordering — behaviour is unchanged in that (common) case.
+	//
+	//   TODO(#2390, depends on read-only-gh #2393-#2396): thread review state into
+	//   the candidate data — extend enumerate-actionable.sh to collect the
+	//   contributor's own open PRs together with their reviewDecision
+	//   (APPROVED / CHANGES_REQUESTED / REVIEW_REQUIRED) and any "blocking" signal,
+	//   surface those as candidates here, and refine ownWorkPriority to rank a
+	//   reviewed/blocking own-PR ahead of a merely-own issue. Guard gracefully when
+	//   that data is absent, exactly as the ownWork fallback does now.
+	ownUsername := ""
+	if c.profile != nil {
+		ownUsername = c.profile.GitHubUsername
+	}
+
+	type candidate struct {
+		repoFull string
+		number   int
+		title    string
+		url      string
+		labels   []string
+		isOwn    bool
+	}
+	var candidates []candidate
+
 	for _, repo := range status.Repos {
 		if len(repo.ActionableIssues) == 0 {
 			continue
@@ -1129,59 +1177,108 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				}
 			}
 
-			ghToken, err := h.mintScopedToken(c.profile.TrustTier)
-			if err != nil {
-				h.logger.Warn("[contribute-ws] failed to mint scoped token — skipping task",
-					"tier", c.profile.TrustTier, "error", err)
-				return nil
-			}
-
-			taskID := fmt.Sprintf("ct-%s-%d-%d", repo.Full, number, time.Now().Unix())
-
-			prompt := fmt.Sprintf(
-				"You are a contributor to the %s hive. Work on issue %s#%d: \"%s\". "+
-					"Read the issue, understand what's needed, and take action. "+
-					"You do NOT have push access to the upstream repo. "+
-					"Fork it first with 'gh repo fork %s --clone=false', "+
-					"add the fork as a remote, push your branch there, "+
-					"then open a PR from your fork. "+
-					"Use the GH_TOKEN env var for all gh commands (do NOT use 'unset GITHUB_TOKEN').",
-				repo.Full, repo.Full, number, title, repo.Full,
-			)
-
-			c.mu.Lock()
-			c.currentTask = &WSTaskAssign{
-				TaskID: taskID,
-				Kind:   "issue",
-				Repo:   repo.Full,
-				Number: number,
-				Title:  title,
-			}
-			c.tokenMintedAt = time.Now()
-			c.mu.Unlock()
-
-			return &WSMessage{
-				Type:           "task_assign",
-				Seq:            h.nextSeq(),
-				TaskID:         taskID,
-				Kind:           "issue",
-				Repo:           repo.Full,
-				Number:         number,
-				Title:          title,
-				URL:            url,
-				GitHubToken:    ghToken,
-				TokenExpiresAt: time.Now().Add(wsTokenTTL).UTC().Format(time.RFC3339),
-				Prompt:         prompt,
-				// The issue's own labels — the Labels envelope field was declared but
-				// never populated, so a client reading it got nothing (kubestellar/
+			// #2390: instead of assigning the first eligible issue inline, collect
+			// it as a candidate. The own-work partition below reorders the whole
+			// eligible set before we pick and assign one. The sibling filters
+			// (#2357 skip-assigned, contribute allow/deny) have already run above,
+			// so every appended candidate is genuinely assignable.
+			candidates = append(candidates, candidate{
+				repoFull: repo.Full,
+				number:   number,
+				title:    title,
+				url:      url,
+				// The issue's own labels travel with the candidate so the chosen
+				// task_assign can populate the Labels envelope field (kubestellar/
 				// hive#2393 item 8). They're already computed for filtering above.
-				Labels:        labels,
-				ContribLabels: []string{"contributor/" + c.profile.GitHubUsername},
-			}
+				labels: labels,
+				// "Own work" is the only #2390 signal available today: the
+				// candidate was authored by the connected contributor. When the
+				// username is unknown (empty), nothing is own → we keep today's
+				// ordering untouched.
+				isOwn: ownUsername != "" && strings.EqualFold(author, ownUsername),
+			})
 		}
 	}
 
-	return nil
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	// Stable partition: own-work candidates first, in their original scan order;
+	// then everything else, also in original scan order. A stable sort keeps the
+	// established per-repo / creation ordering within each bucket, so when the
+	// contributor has no own work this is a no-op and behaviour is identical to
+	// the previous first-eligible pick.
+	ownFirst := make([]candidate, 0, len(candidates))
+	for _, cand := range candidates {
+		if cand.isOwn {
+			ownFirst = append(ownFirst, cand)
+		}
+	}
+	for _, cand := range candidates {
+		if !cand.isOwn {
+			ownFirst = append(ownFirst, cand)
+		}
+	}
+
+	chosen := ownFirst[0]
+	if chosen.isOwn {
+		h.logger.Info("[contribute-ws] prioritizing contributor's own work (#2390)",
+			"username", ownUsername, "repo", chosen.repoFull, "number", chosen.number)
+	}
+
+	// Mint through the shared path so task_assign and the heartbeat token-refresh
+	// advertise tokens minted the same way (#2393 item 2). tokenMintedAt below
+	// arms the refresh ticker for the token we hand out here.
+	ghToken, err := h.mintScopedToken(c.profile.TrustTier)
+	if err != nil {
+		h.logger.Warn("[contribute-ws] failed to mint scoped token — skipping task",
+			"tier", c.profile.TrustTier, "error", err)
+		return nil
+	}
+
+	taskID := fmt.Sprintf("ct-%s-%d-%d", chosen.repoFull, chosen.number, time.Now().Unix())
+
+	prompt := fmt.Sprintf(
+		"You are a contributor to the %s hive. Work on issue %s#%d: \"%s\". "+
+			"Read the issue, understand what's needed, and take action. "+
+			"You do NOT have push access to the upstream repo. "+
+			"Fork it first with 'gh repo fork %s --clone=false', "+
+			"add the fork as a remote, push your branch there, "+
+			"then open a PR from your fork. "+
+			"Use the GH_TOKEN env var for all gh commands (do NOT use 'unset GITHUB_TOKEN').",
+		chosen.repoFull, chosen.repoFull, chosen.number, chosen.title, chosen.repoFull,
+	)
+
+	c.mu.Lock()
+	c.currentTask = &WSTaskAssign{
+		TaskID: taskID,
+		Kind:   "issue",
+		Repo:   chosen.repoFull,
+		Number: chosen.number,
+		Title:  chosen.title,
+	}
+	c.tokenMintedAt = time.Now()
+	c.mu.Unlock()
+
+	return &WSMessage{
+		Type:           "task_assign",
+		Seq:            h.nextSeq(),
+		TaskID:         taskID,
+		Kind:           "issue",
+		Repo:           chosen.repoFull,
+		Number:         chosen.number,
+		Title:          chosen.title,
+		URL:            chosen.url,
+		GitHubToken:    ghToken,
+		TokenExpiresAt: time.Now().Add(wsTokenTTL).UTC().Format(time.RFC3339),
+		Prompt:         prompt,
+		// The chosen issue's own labels — the Labels envelope field was declared
+		// but never populated, so a client reading it got nothing (kubestellar/
+		// hive#2393 item 8). Carried on the candidate from the scan above.
+		Labels:        chosen.labels,
+		ContribLabels: []string{"contributor/" + c.profile.GitHubUsername},
+	}
 }
 
 // assignedToOthers reports whether an issue is assigned to at least one user

--- a/v2/pkg/dashboard/contribute_ws_more_coverage_test.go
+++ b/v2/pkg/dashboard/contribute_ws_more_coverage_test.go
@@ -71,12 +71,56 @@ func TestCovK2_AddActivityCap(t *testing.T) {
 
 func TestCovK2_MarkTaskCompletedAndCooldown(t *testing.T) {
 	hub, _ := covK2Hub(t)
-	hub.markTaskCompleted("org/repo", 42)
+	hub.markTaskCompleted("org/repo", 42, "https://github.com/org/repo/pull/1")
 	if !hub.isTaskInCooldown("org/repo", 42) {
 		t.Fatalf("expected task in cooldown after marking complete")
 	}
 	if hub.isTaskInCooldown("org/repo", 99) {
 		t.Fatalf("unmarked task should not be in cooldown")
+	}
+}
+
+// TestConditionalCooldownByPRURL covers kubestellar/hive#2393 item 7: a
+// completion that reports a PR URL keeps the full week-long cooldown, while a
+// completion with no PR (agent merely went idle) gets only the short no-PR
+// cooldown, so an issue where nothing shipped is not locked out for a week.
+func TestConditionalCooldownByPRURL(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	// WITH a PR URL -> full completedTaskCooldownHours (168h).
+	hub.markTaskCompleted("org/withpr", 1, "https://github.com/org/withpr/pull/1")
+	if !hub.isTaskInCooldown("org/withpr", 1) {
+		t.Fatalf("task with PR should be in cooldown immediately after completion")
+	}
+	// Age it just under the short no-PR window: still in cooldown because it
+	// holds the full 168h cooldown, not the short one.
+	hub.completedMu.Lock()
+	hub.completedTasks["org/withpr#1"] = time.Now().Add(-(completedNoPRCooldownHours + 1) * time.Hour)
+	hub.completedMu.Unlock()
+	if !hub.isTaskInCooldown("org/withpr", 1) {
+		t.Fatalf("task with PR should still be in cooldown after %dh (full cooldown is %dh)",
+			completedNoPRCooldownHours+1, completedTaskCooldownHours)
+	}
+	// Aged past the full cooldown -> released.
+	hub.completedMu.Lock()
+	hub.completedTasks["org/withpr#1"] = time.Now().Add(-(completedTaskCooldownHours + 1) * time.Hour)
+	hub.completedMu.Unlock()
+	if hub.isTaskInCooldown("org/withpr", 1) {
+		t.Fatalf("task with PR should be released after the full cooldown elapses")
+	}
+
+	// WITHOUT a PR URL -> short completedNoPRCooldownHours.
+	hub.markTaskCompleted("org/nopr", 2, "")
+	if !hub.isTaskInCooldown("org/nopr", 2) {
+		t.Fatalf("no-PR task should be in a (short) cooldown right after completion")
+	}
+	// Aged just past the short no-PR window -> released, unlike the 168h default.
+	hub.completedMu.Lock()
+	hub.completedTasks["org/nopr#2"] = time.Now().Add(-(completedNoPRCooldownHours + 1) * time.Hour)
+	hub.completedMu.Unlock()
+	if hub.isTaskInCooldown("org/nopr", 2) {
+		t.Fatalf("no-PR task should be released after only %dh, not locked for %dh",
+			completedNoPRCooldownHours, completedTaskCooldownHours)
 	}
 }
 
@@ -131,7 +175,7 @@ func TestCovK2_SelectTask(t *testing.T) {
 
 	// A second select for the same issue while it's the connection's current task
 	// is skipped (activeIssues), and after marking it complete it's in cooldown.
-	hub.markTaskCompleted("myorg/repo1", 7)
+	hub.markTaskCompleted("myorg/repo1", 7, "https://github.com/myorg/repo1/pull/9")
 	conn.currentTask = nil
 	if msg := hub.selectTask(conn); msg != nil {
 		t.Fatalf("expected nil task (cooldown) but got %+v", msg)

--- a/v2/pkg/dashboard/contribute_ws_more_coverage_test.go
+++ b/v2/pkg/dashboard/contribute_ws_more_coverage_test.go
@@ -182,6 +182,69 @@ func TestCovK2_SelectTask(t *testing.T) {
 	}
 }
 
+// TestCovK2_SelectTaskPrioritizesOwnWork covers the #2390 ordering default:
+// among the eligible actionable candidates, one authored by the connected
+// contributor is chosen before a fresh item authored by someone else — and when
+// the contributor has no own-authored candidate, selection falls back to the
+// previous first-eligible order.
+func TestCovK2_SelectTaskPrioritizesOwnWork(t *testing.T) {
+	hub, s := covK2Hub(t)
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+
+	// A repo whose first (earliest) actionable item is someone else's, and whose
+	// second is the contributor's own. Without prioritization the first-eligible
+	// pick would be #10 (someone else); with #2390 it must be #20 (alice's own).
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{
+			{
+				Name: "repo1",
+				Full: "myorg/repo1",
+				ActionableIssues: []any{
+					map[string]any{
+						"number": float64(10),
+						"title":  "Someone else's fresh issue",
+						"url":    "https://github.com/myorg/repo1/issues/10",
+						"author": "bob",
+					},
+					map[string]any{
+						"number": float64(20),
+						"title":  "Alice's own work",
+						"url":    "https://github.com/myorg/repo1/issues/20",
+						"author": "alice",
+					},
+				},
+			},
+		},
+	}
+	s.statusMu.Unlock()
+
+	msg := hub.selectTask(conn)
+	if msg == nil {
+		t.Fatalf("expected a task assignment")
+	}
+	if msg.Number != 20 {
+		t.Fatalf("expected own work (#20) to be prioritized, got #%d", msg.Number)
+	}
+
+	// Fallback: with no own-authored candidate, selection keeps the previous
+	// first-eligible order (the earliest item, #10).
+	conn2 := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "carol", ContributorID: "c-carol", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	msg2 := hub.selectTask(conn2)
+	if msg2 == nil {
+		t.Fatalf("expected a task assignment for carol")
+	}
+	if msg2.Number != 10 {
+		t.Fatalf("expected fallback to first-eligible (#10) with no own work, got #%d", msg2.Number)
+	}
+}
+
 // HandleWS on a plain (non-websocket) request fails the upgrade with a 4xx.
 func TestCovK2_HandleWSNonWebsocket(t *testing.T) {
 	hub, _ := covK2Hub(t)

--- a/v2/pkg/dashboard/coverage_boost2_test.go
+++ b/v2/pkg/dashboard/coverage_boost2_test.go
@@ -75,7 +75,9 @@ func TestHandleGovernorRepos_InvalidBody_Boost(t *testing.T) {
 
 func TestHandleGovernorRepos_SimpleRepos(t *testing.T) {
 	srv := newFullServer(t)
-	body := `{"repos":["repo1","repo2"]}`
+	// A save that replaces the repo set must also name a default that is one of
+	// the new repos (the always-exactly-one-default invariant), so send both.
+	body := `{"repos":["repo1","repo2"],"primaryRepo":"repo1"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -88,7 +90,7 @@ func TestHandleGovernorRepos_SimpleRepos(t *testing.T) {
 
 func TestHandleGovernorRepos_URLParsing(t *testing.T) {
 	srv := newFullServer(t)
-	body := `{"repos":["https://github.com/myorg/myrepo"]}`
+	body := `{"repos":["https://github.com/myorg/myrepo"],"primaryRepo":"myrepo"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -117,8 +119,10 @@ func TestHandleGovernorRepos_InvalidRepoName(t *testing.T) {
 
 func TestHandleGovernorRepos_PrimaryRepo(t *testing.T) {
 	srv := newFullServer(t)
+	// The chosen default must be one of the monitored repos, so send both the
+	// repo and the primaryRepo that names it (always-exactly-one-default).
 	primary := "newrepo"
-	body := `{"primaryRepo":"newrepo"}`
+	body := `{"repos":["newrepo"],"primaryRepo":"newrepo"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -133,18 +137,22 @@ func TestHandleGovernorRepos_PrimaryRepo(t *testing.T) {
 }
 
 func TestHandleGovernorRepos_GHE_URL(t *testing.T) {
+	// A hive already on github.com (newFullServer's testrepo) must NOT be able to
+	// add a repo on a different forge — that would mix hosts and silently break
+	// App auth for half the repos. The single-host-per-spoke guard rejects it and
+	// leaves the hive's forge untouched.
 	srv := newFullServer(t)
-	body := `{"repos":["https://ghe.example.com/myorg/myrepo"]}`
+	body := `{"repos":["https://ghe.example.com/myorg/myrepo"],"primaryRepo":"myrepo"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.handleGovernorRepos(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("code = %d, want 200", w.Code)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 (cross-forge repo rejected)", w.Code)
 	}
-	if srv.deps.Config.GitHub.BaseURL != "https://ghe.example.com" {
-		t.Errorf("baseURL = %q", srv.deps.Config.GitHub.BaseURL)
+	if srv.deps.Config.GitHub.BaseURL == "https://ghe.example.com" {
+		t.Errorf("hive forge was switched to a mismatched host: %q", srv.deps.Config.GitHub.BaseURL)
 	}
 }
 
@@ -300,7 +308,7 @@ func TestHandleSnapshotPage_CustomHubURL(t *testing.T) {
 func TestHandleGovernorRepos_StripOrgPrefix(t *testing.T) {
 	srv := newFullServer(t)
 	srv.deps.Config.Project.Org = "testorg"
-	body := `{"repos":["testorg/repo1"]}`
+	body := `{"repos":["testorg/repo1"],"primaryRepo":"repo1"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/v2/pkg/dashboard/coverage_boost3_test.go
+++ b/v2/pkg/dashboard/coverage_boost3_test.go
@@ -909,7 +909,9 @@ func TestHealthSummary_WithAgents(t *testing.T) {
 
 func TestHandleGovernorRepos_PrimaryRepoURL(t *testing.T) {
 	srv := newFullServer(t)
-	body := `{"primaryRepo":"https://github.com/otherorg/otherrepo"}`
+	// The default must be one of the monitored repos, so send the repo alongside
+	// the pasted primary-repo URL (which the handler strips to a bare name).
+	body := `{"repos":["otherrepo"],"primaryRepo":"https://github.com/otherorg/otherrepo"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/v2/pkg/dashboard/coverage_boost4_test.go
+++ b/v2/pkg/dashboard/coverage_boost4_test.go
@@ -406,7 +406,7 @@ func newDeepTestServer(t *testing.T) *Server {
 			Org: "testorg", Name: "test", PrimaryRepo: "testrepo",
 			Repos: []string{"testrepo"},
 		},
-		Data:   config.DataConfig{AgentsDir: agentsDir},
+		Data: config.DataConfig{AgentsDir: agentsDir},
 		Agents: map[string]config.AgentConfig{
 			"scanner": {ID: "scan-001", Role: "scanner", Backend: "claude", Model: "sonnet", DisplayName: "Scanner", Enabled: true},
 		},
@@ -433,12 +433,12 @@ func newDeepTestServer(t *testing.T) *Server {
 
 	srv := NewServer(0, logger)
 	srv.deps = &Dependencies{
-		Config:     cfg,
-		AgentMgr:   mgr,
-		Governor:   gov,
-		BeadStores: map[string]*beads.Store{"scanner": scannerStore},
-		Logger:     logger,
-		Ctx:        context.Background(),
+		Config:         cfg,
+		AgentMgr:       mgr,
+		Governor:       gov,
+		BeadStores:     map[string]*beads.Store{"scanner": scannerStore},
+		Logger:         logger,
+		Ctx:            context.Background(),
 		RefreshFunc:    func() {},
 		PersistFunc:    func() {},
 		SkipReloadFunc: func() {},
@@ -479,7 +479,7 @@ func TestHandleGovernorRepos_WithEnumerateFunc(t *testing.T) {
 	srv := newFullServer(t)
 	srv.deps.EnumerateFunc = func() {}
 
-	body := `{"repos":["repo1","repo2"]}`
+	body := `{"repos":["repo1","repo2"],"primaryRepo":"repo1"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/v2/pkg/dashboard/coverage_boost_test.go
+++ b/v2/pkg/dashboard/coverage_boost_test.go
@@ -1302,7 +1302,7 @@ func TestContributeWSHub_MarkTaskCompleted(t *testing.T) {
 		completedTasks: make(map[string]time.Time),
 		logger:         slog.Default(),
 	}
-	hub.markTaskCompleted("org/repo", 42)
+	hub.markTaskCompleted("org/repo", 42, "https://github.com/org/repo/pull/1")
 
 	if !hub.isTaskInCooldown("org/repo", 42) {
 		t.Error("expected task to be in cooldown after marking complete")

--- a/v2/pkg/dashboard/dashboard_handlers_extra_test.go
+++ b/v2/pkg/dashboard/dashboard_handlers_extra_test.go
@@ -29,7 +29,7 @@ func newFullServer(t *testing.T) *Server {
 			Org: "testorg", Name: "test", PrimaryRepo: "testrepo",
 			Repos: []string{"testrepo"},
 		},
-		Data:   config.DataConfig{AgentsDir: t.TempDir()},
+		Data: config.DataConfig{AgentsDir: t.TempDir()},
 		Agents: map[string]config.AgentConfig{
 			"scanner": {ID: "scan-001", Role: "scanner", Backend: "claude", Model: "sonnet", DisplayName: "Scanner"},
 		},
@@ -47,12 +47,12 @@ func newFullServer(t *testing.T) *Server {
 
 	srv := NewServer(0, logger)
 	srv.deps = &Dependencies{
-		Config:   cfg,
-		AgentMgr: mgr,
-		Governor: gov,
-		BeadStores: map[string]*beads.Store{"scanner": scannerStore},
-		Logger:   logger,
-		Ctx:      context.Background(),
+		Config:         cfg,
+		AgentMgr:       mgr,
+		Governor:       gov,
+		BeadStores:     map[string]*beads.Store{"scanner": scannerStore},
+		Logger:         logger,
+		Ctx:            context.Background(),
 		RefreshFunc:    func() {},
 		PersistFunc:    func() {},
 		SkipReloadFunc: func() {},
@@ -222,7 +222,9 @@ func TestHandleGovernorReposBadJSON(t *testing.T) {
 
 func TestHandleGovernorReposValid(t *testing.T) {
 	srv := newFullServer(t)
-	body := `{"repos":["repo1","repo2"],"primary_repo":"repo1"}`
+	// Field is primaryRepo (camelCase — the handler decodes that key); it must
+	// name one of the repos so the always-exactly-one-default guard passes.
+	body := `{"repos":["repo1","repo2"],"primaryRepo":"repo1"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -673,7 +675,7 @@ func TestHandleGovernorReposSpecialChars(t *testing.T) {
 
 func TestHandleGovernorReposStripOrgPrefix(t *testing.T) {
 	srv := newFullServer(t)
-	body := `{"repos":["testorg/my-repo","other-repo"]}`
+	body := `{"repos":["testorg/my-repo","other-repo"],"primaryRepo":"my-repo"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/v2/pkg/dashboard/repo_add_form_test.go
+++ b/v2/pkg/dashboard/repo_add_form_test.go
@@ -1,0 +1,217 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// These tests cover the Repos-tab add-form backend guards:
+//   - single-forge rejection on add (requirement #2)
+//   - save rejected when repos exist but no default is set (requirement #4)
+//   - the App-access probe endpoint's single-host + org-resolution behaviour
+//     (requirement #3)
+
+// Requirement #2: a hive on github.com must reject a repo pasted on a different
+// forge — the single-host-per-spoke invariant. newFullServer's testrepo is on
+// public github.com, so a github.ibm.com repo is a mixing attempt.
+func TestGovernorRepos_RejectsCrossForge(t *testing.T) {
+	srv := newFullServer(t)
+	body := `{"repos":["github.ibm.com/acme/widget"],"primaryRepo":"widget"}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorRepos(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 for a cross-forge repo", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "one GitHub host") {
+		t.Errorf("expected single-host message, got: %s", w.Body.String())
+	}
+	// The hive's forge must be left untouched.
+	if srv.deps.Config.GitHub.BaseURL != "" {
+		t.Errorf("hive forge was mutated to %q", srv.deps.Config.GitHub.BaseURL)
+	}
+}
+
+// A GHE hive must accept a repo pasted with its OWN GHE host (same forge), and
+// reject a github.com repo (the mirror-image mixing case).
+func TestGovernorRepos_GHEHiveHostRules(t *testing.T) {
+	srv := newFullServer(t)
+	srv.deps.Config.GitHub.BaseURL = "https://github.ibm.com"
+	srv.deps.Config.GitHub.APIURL = "https://github.ibm.com/api/v3"
+
+	// Same-forge paste (full URL on the hive's own GHE host): accepted. The
+	// handler strips the scheme+host and org prefix down to the bare repo name.
+	ok := `{"repos":["https://github.ibm.com/acme/widget"],"primaryRepo":"widget"}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(ok))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorRepos(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("same-forge add: code = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+
+	// public github.com paste on a GHE hive: rejected as mixing.
+	bad := `{"repos":["github.com/acme/other"],"primaryRepo":"other"}`
+	req = httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(bad))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	srv.handleGovernorRepos(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("cross-forge add on GHE hive: code = %d, want 400", w.Code)
+	}
+}
+
+// Requirement #4: a save that leaves repos with no default (primary not among
+// them) is rejected, and the pre-mutation config is restored intact.
+func TestGovernorRepos_RejectsSaveWithNoDefault(t *testing.T) {
+	srv := newFullServer(t)
+	prevRepos := append([]string(nil), srv.deps.Config.Project.Repos...)
+	prevPrimary := srv.deps.Config.Project.PrimaryRepo
+
+	// Replace the repo set with repos that do NOT include the current default,
+	// and do not send a new primary — the default is now dangling.
+	body := `{"repos":["alpha","beta"]}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorRepos(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 when no default is set", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "default repo") {
+		t.Errorf("expected 'default repo' message, got: %s", w.Body.String())
+	}
+	// The rejected save must not leave a half-applied config in memory.
+	if got := srv.deps.Config.Project.Repos; len(got) != len(prevRepos) || (len(got) > 0 && got[0] != prevRepos[0]) {
+		t.Errorf("repos mutated on reject: got %v, want %v", got, prevRepos)
+	}
+	if srv.deps.Config.Project.PrimaryRepo != prevPrimary {
+		t.Errorf("primary mutated on reject: got %q, want %q", srv.deps.Config.Project.PrimaryRepo, prevPrimary)
+	}
+}
+
+// Removing the current default (dropping it from the repos list) without naming
+// a replacement is rejected too — the same no-default guard.
+func TestGovernorRepos_RejectsRemovingDefault(t *testing.T) {
+	srv := newFullServer(t)
+	// Baseline: testrepo is the only repo and the default. Submit a set that
+	// drops it entirely and names no new default.
+	body := `{"repos":["another"]}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorRepos(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 when the default is removed with no replacement", w.Code)
+	}
+
+	// Same set WITH a valid new default is accepted.
+	body = `{"repos":["another"],"primaryRepo":"another"}`
+	req = httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	srv.handleGovernorRepos(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200 once a new default is named (body: %s)", w.Code, w.Body.String())
+	}
+	if srv.deps.Config.Project.PrimaryRepo != "another" {
+		t.Errorf("primary = %q, want 'another'", srv.deps.Config.Project.PrimaryRepo)
+	}
+}
+
+// Requirement #3: the access-probe endpoint rejects a cross-forge repo before it
+// even attempts an installation lookup (same single-host message).
+func TestGovernorRepoCheckAccess_RejectsCrossForge(t *testing.T) {
+	srv := newFullServer(t)
+	body := `{"repo":"github.ibm.com/acme/widget"}`
+	req := httptest.NewRequest("POST", "/api/config/governor/repos/check-access", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorRepoCheckAccess(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 for a cross-forge repo", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "one GitHub host") {
+		t.Errorf("expected single-host message, got: %s", w.Body.String())
+	}
+}
+
+// An App-less hive (no App private key) needs no installation-access check: the
+// probe reports "no-app" and the add proceeds. newFullServer has no GHAppAuth.
+func TestGovernorRepoCheckAccess_AppLessHiveSkips(t *testing.T) {
+	srv := newFullServer(t)
+	body := `{"repo":"testorg/somerepo"}`
+	req := httptest.NewRequest("POST", "/api/config/governor/repos/check-access", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorRepoCheckAccess(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200 (no-app skip); body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "no-app") {
+		t.Errorf("expected no-app status, got: %s", w.Body.String())
+	}
+}
+
+// The probe requires a resolvable org: a bare repo name with no configured org
+// cannot name one, so it is a 400 rather than a silent pass.
+func TestGovernorRepoCheckAccess_RequiresOrg(t *testing.T) {
+	srv := newFullServer(t)
+	srv.deps.Config.Project.Org = ""
+	body := `{"repo":"lonelyrepo"}`
+	req := httptest.NewRequest("POST", "/api/config/governor/repos/check-access", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorRepoCheckAccess(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 when the org cannot be determined", w.Code)
+	}
+}
+
+// repoRefHostLabel / sameForgeHost unit coverage — the shared single-host rule.
+func TestRepoRefHostLabelAndSameForgeHost(t *testing.T) {
+	cases := []struct {
+		in   string
+		host string
+	}{
+		{"repo", ""},
+		{"owner/repo", ""},
+		{"github.ibm.com/owner/repo", "github.ibm.com"},
+		{"https://github.com/owner/repo", "github.com"},
+		{"GitHub.IBM.com/o/r", "github.ibm.com"}, // lowercased
+	}
+	for _, c := range cases {
+		if got := repoRefHostLabel(c.in); got != c.host {
+			t.Errorf("repoRefHostLabel(%q) = %q, want %q", c.in, got, c.host)
+		}
+	}
+	if !sameForgeHost("", "github.com") {
+		t.Error(`"" and "github.com" should be the same forge`)
+	}
+	if !sameForgeHost("GITHUB.COM", "github.com") {
+		t.Error("host comparison should be case-insensitive")
+	}
+	if sameForgeHost("github.ibm.com", "github.com") {
+		t.Error("a GHE host must not equal public github.com")
+	}
+}
+
+// hiveForgeHost mirrors config.HostLabel(): github.com by default, the GHE host
+// when the hive carries one.
+func TestHiveForgeHost(t *testing.T) {
+	srv := newFullServer(t)
+	if got := srv.hiveForgeHost(); got != "github.com" {
+		t.Errorf("default forge = %q, want github.com", got)
+	}
+	srv.deps.Config.GitHub = config.GitHubConfig{BaseURL: "https://github.ibm.com"}
+	if got := srv.hiveForgeHost(); got != "github.ibm.com" {
+		t.Errorf("GHE forge = %q, want github.ibm.com", got)
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -183,7 +183,7 @@
     }
     .oc-nav-emoji { display: inline-flex; width: 18px; font-size: 0.9rem; flex-shrink: 0; justify-content: center; }
     .oc-nav-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
-    .oc-nav-mode { flex-shrink: 0; font-size: 0.9rem; margin-left: 2px; transition: opacity 0.15s; }
+    .oc-nav-mode { flex-shrink: 0; font-size: 0.9rem; margin-left: 2px; transition: opacity 0.15s; text-shadow: 0 1px 2px rgba(0,0,0,0.5); }
     /* The hover-revealed row actions (⚙/✕) take the right edge — fade the
        passive mode icon out so they never overlap it at any sidebar width. */
     .oc-nav-item:hover .oc-nav-mode { opacity: 0; }
@@ -2569,6 +2569,7 @@
       <a class="oc-nav-item" data-section="faq-section" onclick="ocNavigate('faq-section')" title="Answers to common first-time questions: the Advisory Digest, ACMM levels, how to advance, and managing cost"><span class="oc-nav-emoji">❓</span><span class="oc-nav-text">FAQ</span></a>
       <a class="oc-nav-item" id="welcome-nav-item" style="display:none" onclick="openWelcomeDialog()" title="Open the Getting Started checklist — one-time setup steps for a new hive"><span class="oc-nav-emoji">🚀</span><span class="oc-nav-text">Getting Started</span></a>
       <a class="oc-nav-item" href="/api/docs" target="_blank"><span class="oc-nav-emoji">📘</span><span class="oc-nav-text">API Spec (Redoc)</span></a>
+      <a class="oc-nav-item" href="https://github.com/kubestellar/hive/issues" target="_blank" rel="noopener noreferrer"><span class="oc-nav-emoji">🐛</span><span class="oc-nav-text">Issues</span></a>
     </div>
     <div class="system-gauges" id="system-gauges">
       <div class="sys-gauge-row" id="sys-gauge-disk" title="Disk usage">

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2569,7 +2569,7 @@
       <a class="oc-nav-item" data-section="faq-section" onclick="ocNavigate('faq-section')" title="Answers to common first-time questions: the Advisory Digest, ACMM levels, how to advance, and managing cost"><span class="oc-nav-emoji">❓</span><span class="oc-nav-text">FAQ</span></a>
       <a class="oc-nav-item" id="welcome-nav-item" style="display:none" onclick="openWelcomeDialog()" title="Open the Getting Started checklist — one-time setup steps for a new hive"><span class="oc-nav-emoji">🚀</span><span class="oc-nav-text">Getting Started</span></a>
       <a class="oc-nav-item" href="/api/docs" target="_blank"><span class="oc-nav-emoji">📘</span><span class="oc-nav-text">API Spec (Redoc)</span></a>
-      <a class="oc-nav-item" href="https://github.com/kubestellar/hive/issues" target="_blank" rel="noopener noreferrer"><span class="oc-nav-emoji">🐛</span><span class="oc-nav-text">Issues</span></a>
+      <a class="oc-nav-item" href="https://github.com/kubestellar/hive/issues" target="_blank" rel="noopener noreferrer"><span class="oc-nav-emoji">🐛</span><span class="oc-nav-text">Report an Issue</span></a>
     </div>
     <div class="system-gauges" id="system-gauges">
       <div class="sys-gauge-row" id="sys-gauge-disk" title="Disk usage">

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -13400,6 +13400,10 @@ function burnAreaChart() {
           loadGateways();
         }
       }
+      // Keep the Save button's enabled state in lockstep with the repos/default
+      // invariant on every render (requirement #4). Cheap and idempotent — a
+      // no-op on tabs/dialogs without a repos list.
+      if (typeof syncRepoSaveGuard === 'function') syncRepoSaveGuard();
     }
 
     function renderAgentImport() {
@@ -16167,14 +16171,32 @@ function burnAreaChart() {
       const hostNote = isGHE
         ? ` on <strong style="color:var(--indigo)">${esc(ghHost)}</strong> (GitHub Enterprise)`
         : ` on <strong>${esc(ghHost)}</strong>`;
+      // The forge is shown as a fixed, non-editable prefix before the input so
+      // the user only types org/repo and the GitHub host can never be
+      // mistaken (requirement #1). The prefix color matches the per-row pill
+      // (indigo for GHE, muted for public github.com). All host machinery is
+      // client-side + CSP-safe (inline styles, no external resources).
+      const prefixColor = isGHE ? 'var(--indigo)' : 'var(--muted)';
+      // needDefault is true when repos exist but none is the current default —
+      // the Save-guard state. renderGovRepos surfaces it inline; syncRepoSaveGuard
+      // (called on every tab render) is what actually disables the Save button.
+      const needDefault = repos.length > 0 && !repos.includes(primary);
+      const defaultWarn = needDefault
+        ? '<div id="cfg-repo-default-warn" style="font-size:0.72rem;color:var(--amber);margin-top:6px">⚠ Set a default repo before saving — click a ☆ star to choose the repo where the advisory issue is maintained.</div>'
+        : '';
       return `
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">GitHub repositories monitored by this hive${hostNote}. Click the star to set the default repo where the advisory issue is maintained.</p>
         <div class="config-list">
           ${list || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No repos configured</div>'}
-          <div class="config-list-add">
-            <input type="text" id="cfg-repo-input" placeholder="org/repo (on ${esc(ghHost)})" title="GitHub repository in org/repo format (e.g. kubestellar/console). It must live on this hive's forge, ${esc(ghHost)} — the governor rejects repos on other GitHub hosts. It will be monitored for issues, PRs, and CI status.">
+          <div class="config-list-add" style="align-items:stretch">
+            <div style="display:flex;flex:1;min-width:0;align-items:stretch;border:1px solid var(--border);border-radius:6px;overflow:hidden">
+              <span style="display:inline-flex;align-items:center;padding:0 8px;background:color-mix(in srgb, ${prefixColor} 12%, var(--surface));color:${prefixColor};font-size:0.78rem;font-weight:600;white-space:nowrap;border-right:1px solid var(--border)" title="This hive's forge — every repo must live on ${esc(ghHost)}">${esc(ghHost)}/</span>
+              <input type="text" id="cfg-repo-input" style="flex:1;min-width:0;border:none;border-radius:0" placeholder="org/repo" onkeydown="if(event.key==='Enter'){event.preventDefault();addListItem('repos','list','cfg-repo-input');}" title="GitHub repository in org/repo format (e.g. kubestellar/console). It must live on this hive's forge, ${esc(ghHost)} — the governor rejects repos on other GitHub hosts. It will be monitored for issues, PRs, and CI status.">
+            </div>
             <button onclick="addListItem('repos','list','cfg-repo-input')" title="Add this repository to the monitored list">+ Add</button>
           </div>
+          <div id="cfg-repo-add-status" style="font-size:0.72rem;margin-top:6px"></div>
+          ${defaultWarn}
         </div>`;
     }
 
@@ -16605,6 +16627,143 @@ function burnAreaChart() {
       return raw.replace(/^https?:\/\/github\.com\//, '').replace(/\/+$/, '');
     }
 
+    // hiveForgeHostLabel returns this hive's bare GitHub host ("github.com" or a
+    // GHE hostname). Mirrors the server's hiveForgeHost() and renderGovRepos so
+    // the single-host rule matches everywhere.
+    function hiveForgeHostLabel() {
+      const ghBase = window._githubBaseUrl || 'https://github.com';
+      return ghBase.replace(/^https?:\/\//, '').replace(/\/$/, '') || 'github.com';
+    }
+
+    // repoRefHostLabel extracts the GitHub host a pasted repo carries, or '' when
+    // it names none (bare "repo"/"owner/repo" belong to the hive's forge).
+    // Mirrors the server's repoRefHostLabel (a leading dotted segment or full URL
+    // is an explicit host).
+    function repoRefHostLabel(s) {
+      s = (s || '').trim().replace(/^https?:\/\//, '').replace(/^\/+|\/+$/g, '');
+      if (!s) return '';
+      const parts = s.split('/');
+      if (parts.length > 1 && parts[0].indexOf('.') !== -1) return parts[0].toLowerCase();
+      return '';
+    }
+
+    function sameForgeHost(a, b) {
+      const norm = h => { h = (h || '').trim().toLowerCase(); return (!h || h === 'github.com') ? 'github.com' : h; };
+      return norm(a) === norm(b);
+    }
+
+    // addRepoWithChecks handles the Repos-tab "+ Add": it enforces the
+    // single-host-per-spoke rule client-side (requirement #2), then asks the
+    // server whether the hive's GitHub App can access the new repo's org and, if
+    // not, guides the user through installing/authorizing the App before the repo
+    // is accepted (requirement #3). Only on a clean check is the repo appended.
+    async function addRepoWithChecks() {
+      const input = document.getElementById('cfg-repo-input');
+      if (!input) return;
+      const raw = input.value.trim();
+      if (!raw) return;
+      const statusEl = document.getElementById('cfg-repo-add-status');
+      const setStatus = (html, color) => { if (statusEl) { statusEl.innerHTML = html; statusEl.style.color = color || 'var(--muted)'; } };
+
+      // Requirement #2: reject a paste on a different forge before any round-trip.
+      const spokeHost = hiveForgeHostLabel();
+      const refHost = repoRefHostLabel(raw);
+      if (refHost && !sameForgeHost(refHost, spokeHost)) {
+        setStatus('✕ ' + esc(raw) + ' is on <strong>' + esc(refHost) + '</strong>, but this hive is on <strong>' + esc(spokeHost) + '</strong>. A hive\'s repos must all live on one GitHub host — remove the host or use a repo on ' + esc(spokeHost) + '.', 'var(--red)');
+        return;
+      }
+
+      const val = normalizeRepoInput(raw);
+      if (!_configState.data.repos) _configState.data.repos = [];
+      if (_configState.data.repos.includes(val)) {
+        setStatus('This repo is already in the list.', 'var(--muted)');
+        return;
+      }
+
+      // Requirement #3: verify the App can access the repo's org.
+      setStatus('Checking GitHub App access…', 'var(--muted)');
+      try {
+        const res = await fetch('/api/config/governor/repos/check-access', {
+          method: 'POST', headers: _inceptionAuthHeaders(),
+          body: JSON.stringify({ repo: val })
+        });
+        const d = await res.json().catch(() => ({}));
+        if (res.status === 409 && d && d.needsInstall) {
+          // App not installed on the new org: surface the correct per-forge
+          // install URL wired to the existing pending-install/recheck plumbing.
+          // Clicking Install flags the heartbeat (handleGitHubAppInstallClicked)
+          // exactly like the App-required banner; Re-check re-probes and, on
+          // success, completes the add.
+          const installBtn = (d.installUrl)
+            ? '<a href="' + esc(d.installUrl) + '" target="_blank" rel="noopener" onclick="markGitHubAppInstallClicked()" style="color:var(--accent);font-weight:600">Install/authorize the App for ' + esc(d.org || '') + ' ↗</a>'
+            : '<span style="color:var(--amber)">This hive\'s GitHub Enterprise App slug is not configured, so an install link cannot be built — ask your operator to install the Hive App for ' + esc(d.org || '') + '.</span>';
+          setStatus('⚠ ' + esc(d.error || ('The App needs access to ' + val)) + '<br>' + installBtn + ' &nbsp;·&nbsp; <a href="#" onclick="recheckRepoAccessThenAdd(event)" style="color:var(--accent);font-weight:600">Re-check &amp; add</a>', 'var(--amber)');
+          return;
+        }
+        if (!res.ok) {
+          setStatus('✕ ' + esc((d && d.error) || ('HTTP ' + res.status)), 'var(--red)');
+          return;
+        }
+      } catch (e) {
+        // Network error probing access is non-fatal: the server re-validates the
+        // single-host rule and the default-repo rule on save, so let the add
+        // proceed rather than hard-block on a transient dashboard hiccup.
+        _appendRepoAccepted(val);
+        setStatus('Added (App-access check could not be reached; the server will re-validate on save).', 'var(--muted)');
+        return;
+      }
+      _appendRepoAccepted(val);
+      setStatus('✓ Added — App has access.', 'var(--green)');
+    }
+
+    // _appendRepoAccepted appends a validated repo, seeds the first repo as the
+    // default (a hive must always have one), and re-renders.
+    function _appendRepoAccepted(val) {
+      if (!_configState.data.repos) _configState.data.repos = [];
+      _configState.data.repos.push(val);
+      markDirty('repos', 'repos', _configState.data.repos);
+      // First repo added to an empty list becomes the default automatically, so
+      // there is always exactly one default (requirement #4).
+      if (!_configState.data.primaryRepo || !_configState.data.repos.includes(_configState.data.primaryRepo)) {
+        _configState.data.primaryRepo = val;
+        markDirty('repos', 'primaryRepo', val);
+      }
+      const input = document.getElementById('cfg-repo-input');
+      if (input) input.value = '';
+      renderConfigTab(_configState.tab);
+    }
+
+    // markGitHubAppInstallClicked flags the heartbeat that an install link was
+    // clicked, reusing the existing pending-install endpoint. Fire-and-forget.
+    function markGitHubAppInstallClicked() {
+      fetch('/api/github-app/install-clicked', { method: 'POST', headers: _inceptionAuthHeaders() }).catch(() => {});
+    }
+
+    // recheckRepoAccessThenAdd re-runs the App-access probe after the user
+    // installs/authorizes the App, and completes the add when access is now
+    // confirmed — the same re-check pattern the App-required banner uses.
+    async function recheckRepoAccessThenAdd(ev) {
+      if (ev) ev.preventDefault();
+      await addRepoWithChecks();
+    }
+
+    // syncRepoSaveGuard disables the config dialog Save button while the Repos
+    // tab has repos but no default selected, so a hive can never be saved without
+    // exactly one default (requirement #4). Called after every config tab render.
+    function syncRepoSaveGuard() {
+      const saveBtn = document.querySelector('.config-footer .config-save');
+      if (!saveBtn) return;
+      let block = false;
+      const d = _configState.data || {};
+      if (_configState.type === 'governor' && Array.isArray(d.repos) && d.repos.length > 0) {
+        block = !d.primaryRepo || !d.repos.includes(d.primaryRepo);
+      }
+      saveBtn.disabled = block;
+      saveBtn.style.opacity = block ? '0.5' : '';
+      saveBtn.style.cursor = block ? 'not-allowed' : '';
+      saveBtn.title = block ? 'Set a default repo before saving — click a ☆ star in the Repos tab.' : '';
+    }
+
     function addListItem(section, key, inputId) {
       const input = document.getElementById(inputId);
       let val = input.value.trim();
@@ -16619,10 +16778,11 @@ function burnAreaChart() {
         _configState.data.labels.push(val);
         markDirty('labels', 'labels', _configState.data.labels);
       } else if (section === 'repos') {
-        val = normalizeRepoInput(val);
-        if (!_configState.data.repos) _configState.data.repos = [];
-        _configState.data.repos.push(val);
-        markDirty('repos', 'repos', _configState.data.repos);
+        // Repos go through the async host-check + App-access workflow, which
+        // owns input clearing and re-render on success. Return here so the
+        // synchronous tail below does not double-add or clear prematurely.
+        addRepoWithChecks();
+        return;
       }
       input.value = '';
       renderConfigTab(_configState.tab);
@@ -16730,6 +16890,19 @@ function burnAreaChart() {
 
     async function saveConfig() {
       const dirty = _configState.dirty;
+
+      // Guard: a governor config with repos must always name a default that is
+      // one of them (requirement #4). The Save button is disabled in this state,
+      // but a keyboard/racy click could still reach here — refuse and point the
+      // user at the fix rather than letting the server 400 opaquely.
+      if (_configState.type === 'governor') {
+        const d = _configState.data || {};
+        if (Array.isArray(d.repos) && d.repos.length > 0 && (!d.primaryRepo || !d.repos.includes(d.primaryRepo))) {
+          showToast('Set a default repo before saving — click a ☆ star in the Repos tab.', 'error');
+          renderConfigTab('Repos');
+          return;
+        }
+      }
 
       if (_configState.isCreate) {
         const createData = dirty._create || {};

--- a/v2/pkg/github/advisory.go
+++ b/v2/pkg/github/advisory.go
@@ -113,6 +113,42 @@ func (c *Client) PostAdvisoryDigest(ctx context.Context, repo string, issueNum i
 	return nil
 }
 
+// ProbeIssueWrite (#2353) verifies that the current credential can actually
+// WRITE to repo by performing a benign, self-reverting edit of the advisory
+// issue: it reads the issue's current body and writes that same body straight
+// back. GitHub records no visible change, but the request still exercises the
+// exact issues:write path (and repo scope) a real digest post needs.
+//
+// This closes the recheck false-positive: a READ (finding the advisory issue)
+// succeeds even when the App cannot write, and an installation-permission check
+// cannot see that the repo is absent from the App installation's selected
+// repos. Only a real write proves write capability, so callers that must not
+// clear the write-forbidden banner (#2353) probe with this before declaring the
+// App healthy.
+//
+// Returns nil on a successful write; the underlying error (e.g. the 403
+// "Resource not accessible by integration") otherwise, so the caller can
+// classify it exactly as it would a failed digest post.
+func (c *Client) ProbeIssueWrite(ctx context.Context, repo string, issueNum int) error {
+	if c == nil {
+		return ErrNoGitHubClient
+	}
+	owner, repoName := c.splitRepo(repo)
+	issue, _, err := c.client.Issues.Get(ctx, owner, repoName, issueNum)
+	if err != nil {
+		return fmt.Errorf("reading advisory issue %s#%d for write probe: %w", repo, issueNum, err)
+	}
+	// Write the current body back unchanged — a no-op edit that still requires
+	// (and thus proves) issues:write on THIS repo.
+	_, _, err = c.client.Issues.Edit(ctx, owner, repoName, issueNum, &gh.IssueRequest{
+		Body: gh.Ptr(issue.GetBody()),
+	})
+	if err != nil {
+		return fmt.Errorf("write probe on advisory issue %s#%d: %w", repo, issueNum, err)
+	}
+	return nil
+}
+
 func truncateDigest(digest string) string {
 	if len(digest) <= githubCommentCharLimit {
 		return digest
@@ -176,8 +212,8 @@ func (c *Client) findAdvisoryIssue(ctx context.Context, owner, repo string) (int
 
 	// Fallback 1: list by label (works when search API is unavailable)
 	opts := &gh.IssueListByRepoOptions{
-		State:  "open",
-		Labels: []string{advisoryLabelName},
+		State:       "open",
+		Labels:      []string{advisoryLabelName},
 		ListOptions: gh.ListOptions{PerPage: 10},
 	}
 	issues, _, listErr := c.client.Issues.ListByRepo(ctx, owner, repo, opts)

--- a/v2/pkg/github/app_state.go
+++ b/v2/pkg/github/app_state.go
@@ -69,6 +69,24 @@ const (
 	// JWT fails before the installation is ever consulted. That misdiagnosis is
 	// what cost the owner of the first hive to hit this real debugging time.
 	AppStateNoAppAssigned
+
+	// AppStateWriteForbidden (#2353) means the App authenticated, the
+	// installation resolved on the RIGHT account, and DiagnoseAppAuth reports
+	// the installation grants issues:write — yet a real WRITE attempt returned
+	// 403 "Resource not accessible by integration". DiagnoseAppAuth only
+	// inspects installation-level PERMISSIONS; it never checks whether the
+	// target repo is in the installation's `selected` repositories. So an
+	// authentication-and-permission check passes while the write is still
+	// forbidden.
+	//
+	// The most likely cause is exactly that gap: the repo is not included in the
+	// App installation's selected repositories, so no granted permission applies
+	// to it. It is DISTINCT from AppStateInsufficientPerms — the permission IS
+	// granted here, so labelling this "lacks Issues: Read & Write" is a false
+	// accusation. USER-ACTIONABLE (by an org owner): add the repo to the App
+	// installation (or, if using "all repositories", approve any pending
+	// permission update).
+	AppStateWriteForbidden
 )
 
 // String returns the stable wire token for a state. These tokens cross the
@@ -90,6 +108,8 @@ func (s AppAuthState) String() string {
 		return "key-invalid"
 	case AppStateNoAppAssigned:
 		return "no-app-assigned"
+	case AppStateWriteForbidden:
+		return "write-forbidden"
 	default:
 		return "unknown"
 	}
@@ -107,7 +127,7 @@ func (s AppAuthState) OperatorActionable() bool {
 // this state themselves. Only these states justify a "do something" banner.
 func (s AppAuthState) UserActionable() bool {
 	switch s {
-	case AppStateNotInstalled, AppStateWrongInstallation, AppStateInsufficientPerms:
+	case AppStateNotInstalled, AppStateWrongInstallation, AppStateInsufficientPerms, AppStateWriteForbidden:
 		return true
 	default:
 		return false
@@ -133,6 +153,8 @@ func ParseAppAuthState(s string) AppAuthState {
 		return AppStateKeyInvalid
 	case "no-app-assigned":
 		return AppStateNoAppAssigned
+	case "write-forbidden":
+		return AppStateWriteForbidden
 	default:
 		return AppStateUnknown
 	}
@@ -236,6 +258,10 @@ type AppAuthDiagnosis struct {
 	// IssuesPerm is the granted issues permission, when the installation
 	// resolved.
 	IssuesPerm string
+	// Repo, when set, is the repository whose write attempt was forbidden.
+	// Only AppStateWriteForbidden (#2353) populates it, so the banner can name
+	// the exact repo the operator must add to the App installation.
+	Repo string
 	// Err is the underlying error, for logs. Never rendered to a user
 	// verbatim, because it can carry raw API text.
 	Err error
@@ -386,6 +412,20 @@ func (d AppAuthDiagnosis) Message() string {
 		}
 		return fmt.Sprintf("The GitHub App is installed for '%s' but granted Issues: %s (Issues: Read & Write required). "+
 			"The org owner must approve the updated permissions at the app installation settings page.", acct, granted)
+
+	case AppStateWriteForbidden:
+		// #2353: authentication and installation-level permissions both check
+		// out, but a real write returned 403. Do NOT claim a missing
+		// permission — the permission IS granted. The likeliest gap is repo
+		// scope: this repo is not in the App installation's selected repos.
+		repo := strings.TrimSpace(d.Repo)
+		if repo == "" {
+			repo = "this repository"
+		}
+		return fmt.Sprintf("The GitHub App is installed and authenticated for '%s' and holds Issues: Read & Write, "+
+			"but a write to %s returned 403 (Resource not accessible by integration). The most likely cause is that "+
+			"%s is not included in the App installation's selected repositories — add it to the installation "+
+			"(or, if a permission update is pending, approve it) at the app installation settings page.", owner, repo, repo)
 
 	default:
 		return "Could not verify this hive's GitHub App credentials. This is usually transient — " +

--- a/v2/pkg/github/app_state_test.go
+++ b/v2/pkg/github/app_state_test.go
@@ -249,6 +249,7 @@ func TestAppAuthState_WireRoundTrip(t *testing.T) {
 	all := []AppAuthState{
 		AppStateUnknown, AppStateOK, AppStateNotInstalled, AppStateWrongInstallation,
 		AppStateInsufficientPerms, AppStateKeyMissing, AppStateKeyInvalid,
+		AppStateNoAppAssigned, AppStateWriteForbidden,
 	}
 	for _, s := range all {
 		if got := ParseAppAuthState(s.String()); got != s {
@@ -269,6 +270,7 @@ func TestAppAuthState_ActionabilityIsExclusive(t *testing.T) {
 	all := []AppAuthState{
 		AppStateUnknown, AppStateOK, AppStateNotInstalled, AppStateWrongInstallation,
 		AppStateInsufficientPerms, AppStateKeyMissing, AppStateKeyInvalid,
+		AppStateNoAppAssigned, AppStateWriteForbidden,
 	}
 	for _, s := range all {
 		if s.OperatorActionable() && s.UserActionable() {
@@ -280,6 +282,39 @@ func TestAppAuthState_ActionabilityIsExclusive(t *testing.T) {
 	}
 	if AppStateUnknown.OperatorActionable() || AppStateUnknown.UserActionable() {
 		t.Error("the unknown state must not be actionable by anyone")
+	}
+}
+
+// TestAppStateWriteForbidden_MessageIsAccurate (#2353) locks in the honest copy
+// for a write-403 on a healthy installation: it must NOT claim the App lacks
+// Issues: Read & Write (the permission IS granted), must name the repo, and must
+// point at the real likely cause — the repo not being in the installation's
+// selected repositories. It is user-actionable (an org owner adds the repo),
+// never operator-side.
+func TestAppStateWriteForbidden_MessageIsAccurate(t *testing.T) {
+	d := AppAuthDiagnosis{
+		State:           AppStateWriteForbidden,
+		ExpectedAccount: "open-horizon-services",
+		Repo:            "Getting-Started",
+	}
+	msg := d.Message()
+	if msg == "" {
+		t.Fatal("write-forbidden must carry banner copy")
+	}
+	if strings.Contains(msg, "lacks Issues") || strings.Contains(msg, "granted Issues: none") {
+		t.Errorf("must not claim a permission gap; got %q", msg)
+	}
+	if !strings.Contains(msg, "Getting-Started") {
+		t.Errorf("message must name the repo; got %q", msg)
+	}
+	if !strings.Contains(msg, "selected repositories") {
+		t.Errorf("message must point at repo-scope as the likely cause; got %q", msg)
+	}
+	if AppStateWriteForbidden.OperatorActionable() {
+		t.Error("write-forbidden is fixed by an org owner, not the operator")
+	}
+	if !AppStateWriteForbidden.UserActionable() {
+		t.Error("write-forbidden must be user-actionable (add the repo to the installation)")
 	}
 }
 

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -32,22 +32,22 @@ type ModeChange struct {
 }
 
 type EvalSnapshot struct {
-	Timestamp     int64             `json:"t"`
-	Mode          Mode              `json:"govMode"`
-	QueueIssues   int               `json:"govIssues"`
-	QueuePRs      int               `json:"govPrs"`
-	QueueTotal    int               `json:"govTotal"`
-	QueueHold     int               `json:"govHold"`
-	QueueActive   int               `json:"govActive"`
-	SLAViolations int               `json:"sla_violations,omitempty"`
-	AgentsKicked  []string          `json:"agents_kicked,omitempty"`
-	Actionable    int               `json:"actionableCount"`
-	OpenPRs       int               `json:"openPrCount"`
-	Mergeable     int               `json:"mergeableCount"`
-	BeadsWorkers  int               `json:"beadsWorkers"`
-	BeadsSupervisor int             `json:"beadsSupervisor"`
-	Repos         map[string]RepoSnapshot `json:"repos,omitempty"`
-	AgentStats    map[string]map[string]any `json:"agentStats,omitempty"`
+	Timestamp       int64                     `json:"t"`
+	Mode            Mode                      `json:"govMode"`
+	QueueIssues     int                       `json:"govIssues"`
+	QueuePRs        int                       `json:"govPrs"`
+	QueueTotal      int                       `json:"govTotal"`
+	QueueHold       int                       `json:"govHold"`
+	QueueActive     int                       `json:"govActive"`
+	SLAViolations   int                       `json:"sla_violations,omitempty"`
+	AgentsKicked    []string                  `json:"agents_kicked,omitempty"`
+	Actionable      int                       `json:"actionableCount"`
+	OpenPRs         int                       `json:"openPrCount"`
+	Mergeable       int                       `json:"mergeableCount"`
+	BeadsWorkers    int                       `json:"beadsWorkers"`
+	BeadsSupervisor int                       `json:"beadsSupervisor"`
+	Repos           map[string]RepoSnapshot   `json:"repos,omitempty"`
+	AgentStats      map[string]map[string]any `json:"agentStats,omitempty"`
 }
 
 type RepoSnapshot struct {
@@ -78,16 +78,54 @@ type BudgetInfo struct {
 	WindowBaseline int64 `json:"window_baseline"`
 }
 
-// BudgetWindowDuration is the length of one budget accounting window; the
-// "weekly" limit applies to spend accumulated within it.
-const BudgetWindowDuration = 7 * 24 * time.Hour
+// BudgetWindowDuration is the DEFAULT length of one budget accounting
+// window; the "weekly" limit applies to spend accumulated within it. As of
+// #2323 the effective window is the configured governor.budget.period_days
+// (see budgetWindowDuration); this constant is the fallback used when that
+// setting is unset/zero.
+const BudgetWindowDuration = defaultBudgetWindowDays * 24 * time.Hour
 
-// BudgetWarnPct is the percent of the weekly limit at which the soft
-// budget warning fires.
+// defaultBudgetWindowDays is the fallback budget-window length in days,
+// matching config.defaultBudgetPeriodDays. Used when period_days is unset.
+const defaultBudgetWindowDays = 7
+
+// BudgetWarnPct is the DEFAULT percent of the weekly limit at which the soft
+// budget warning fires. As of #2323 the effective threshold is the
+// configured governor.budget.critical_pct (see budgetWarnPct); this constant
+// is the fallback used when that setting is unset/zero.
 const BudgetWarnPct = 90
 
 // percentDenominator converts a percentage into a fraction of a whole.
 const percentDenominator = 100
+
+// hoursPerDay converts a day count into hours for time.Duration math.
+const hoursPerDay = 24
+
+// budgetWindowDuration returns the effective budget-window length. It reads
+// the configured governor.budget.period_days (#2323 — previously this value
+// was persisted but never read, so the window was silently pinned to 7 days)
+// and falls back to the BudgetWindowDuration default when the setting is
+// unset/zero (a 0-day window would roll every eval and break budgeting).
+// Callers must hold g.mu.
+func (g *Governor) budgetWindowDuration() time.Duration {
+	if days := g.cfg.Budget.PeriodDays; days > 0 {
+		return time.Duration(days) * hoursPerDay * time.Hour
+	}
+	return BudgetWindowDuration
+}
+
+// budgetWarnPct returns the effective soft-warning threshold as an integer
+// percent (0-100). It reads the configured governor.budget.critical_pct
+// (#2323 — previously persisted but never read, so warnings were silently
+// pinned to 90%) and falls back to the BudgetWarnPct default when the
+// setting is unset/zero (a 0% threshold would warn immediately). Callers
+// must hold g.mu.
+func (g *Governor) budgetWarnPct() int {
+	if pct := g.cfg.Budget.CriticalPct; pct > 0 {
+		return pct
+	}
+	return BudgetWarnPct
+}
 
 // BudgetTransitions reports budget threshold state from a single
 // UpdateBudgetFromTotals call. WarnCrossed and ExhaustedCrossed are
@@ -624,7 +662,7 @@ func (g *Governor) UpdateBudgetFromTotals(totalTokens int64, byAgent map[string]
 		// First run or legacy snapshot without a window: open one now.
 		g.budget.ResetAt = now
 		g.budget.WindowBaseline = totalTokens
-	} else if now.Sub(g.budget.ResetAt) >= BudgetWindowDuration {
+	} else if now.Sub(g.budget.ResetAt) >= g.budgetWindowDuration() {
 		g.budget.ResetAt = now
 		g.budget.WindowBaseline = totalTokens
 		g.budgetWarned = false
@@ -656,7 +694,7 @@ func (g *Governor) UpdateBudgetFromTotals(totalTokens int64, byAgent map[string]
 
 	// WeeklyLimit == 0 disables budgeting entirely: no thresholds, no alerts.
 	if g.budget.WeeklyLimit > 0 {
-		warnThreshold := g.budget.WeeklyLimit * BudgetWarnPct / percentDenominator
+		warnThreshold := g.budget.WeeklyLimit * int64(g.budgetWarnPct()) / percentDenominator
 		trans.WarnActive = g.budget.CurrentSpend >= warnThreshold
 		trans.ExhaustedActive = g.budget.CurrentSpend >= g.budget.WeeklyLimit
 		if trans.WarnActive && !g.budgetWarned {

--- a/v2/pkg/governor/governor_settings_wiring_test.go
+++ b/v2/pkg/governor/governor_settings_wiring_test.go
@@ -1,0 +1,128 @@
+package governor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// #2323: governor.budget.period_days and .critical_pct were persisted in
+// config but never read, so the window was pinned to 7 days and the warning
+// to 90%. These tests lock in that both are now honored, and that an
+// unset/zero value falls back to the defaults instead of 0.
+
+// TestBudgetWindowDuration_ConfiguredPeriodDays verifies a configured
+// period_days sets the effective window (30 days), not the hardcoded 7.
+func TestBudgetWindowDuration_ConfiguredPeriodDays(t *testing.T) {
+	cfg := config.GovernorConfig{Budget: config.BudgetConfig{PeriodDays: 30}}
+	g := New(cfg, map[string]config.AgentConfig{}, testLogger())
+
+	want := 30 * 24 * time.Hour
+	if got := g.budgetWindowDuration(); got != want {
+		t.Errorf("budgetWindowDuration() = %v, want %v", got, want)
+	}
+}
+
+// TestBudgetWindowDuration_ZeroFallsBackToDefault verifies an unset
+// period_days falls back to the 7-day default, not a 0-length window.
+func TestBudgetWindowDuration_ZeroFallsBackToDefault(t *testing.T) {
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, testLogger())
+
+	if got := g.budgetWindowDuration(); got != BudgetWindowDuration {
+		t.Errorf("zero period_days: budgetWindowDuration() = %v, want default %v", got, BudgetWindowDuration)
+	}
+	if BudgetWindowDuration != 7*24*time.Hour {
+		t.Errorf("default window = %v, want 7 days", BudgetWindowDuration)
+	}
+}
+
+// TestBudgetWindowRoll_HonorsConfiguredPeriod verifies the actual roll logic
+// uses the configured window: a window opened 8 days ago must NOT roll when
+// period_days is 30 (it would have rolled under the hardcoded 7-day window).
+func TestBudgetWindowRoll_HonorsConfiguredPeriod(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	cfg.Budget.PeriodDays = 30
+	g := New(cfg, agents, testLogger())
+
+	g.SetBudgetLimit(1000)
+	// Window opened 8 days ago, exhausted. Under the old hardcoded 7-day
+	// window this would roll and clear suppression; under the configured
+	// 30-day window it must still be within the window.
+	g.SeedBudget(1500, nil, nil, time.Now().Add(-8*24*time.Hour))
+
+	// Totals update at 8 days: must NOT roll (30-day window).
+	g.UpdateBudgetFromTotals(1600, nil, nil)
+	if due := dueSet(g); due["scanner"] {
+		t.Error("30-day window must not roll after only 8 days; scanner should stay suppressed")
+	}
+	if !g.GetState().BudgetExhausted {
+		t.Error("30-day window must not roll after only 8 days; budget should stay exhausted")
+	}
+}
+
+// TestBudgetWindowRoll_ConfiguredPeriodRolls verifies the configured window
+// still rolls once elapsed: a 30-day window opened 31 days ago rolls and
+// clears suppression.
+func TestBudgetWindowRoll_ConfiguredPeriodRolls(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	cfg.Budget.PeriodDays = 30
+	g := New(cfg, agents, testLogger())
+
+	g.SetBudgetLimit(1000)
+	g.SeedBudget(1500, nil, nil, time.Now().Add(-31*24*time.Hour))
+
+	// Totals update at 31 days: rolls the window, resetting spend to zero.
+	g.UpdateBudgetFromTotals(5000, nil, nil)
+	if due := dueSet(g); !due["scanner"] {
+		t.Error("30-day window should roll after 31 days and clear suppression")
+	}
+	if g.GetState().BudgetExhausted {
+		t.Error("state should clear exhausted after the configured window rolls")
+	}
+}
+
+// TestBudgetWarnPct_ConfiguredThreshold verifies critical_pct=75 triggers the
+// warning at 75% of the limit, not the hardcoded 90%.
+func TestBudgetWarnPct_ConfiguredThreshold(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	cfg.Budget.CriticalPct = 75
+	g := New(cfg, agents, testLogger())
+
+	g.SetBudgetLimit(1000)
+	g.SetBudgetResetAt(time.Now()) // open window with baseline 0
+
+	// 800 tokens = 80%: below the hardcoded 90% but above the configured 75%.
+	trans := g.UpdateBudgetFromTotals(800, nil, nil)
+	if !trans.WarnCrossed || !trans.WarnActive {
+		t.Errorf("configured 75%% threshold should warn at 80%% spend, got %+v", trans)
+	}
+	if got := g.budgetWarnPct(); got != 75 {
+		t.Errorf("budgetWarnPct() = %d, want 75", got)
+	}
+}
+
+// TestBudgetWarnPct_ZeroFallsBackToDefault verifies an unset critical_pct
+// falls back to the 90% default, not a 0% (warn-immediately) threshold.
+func TestBudgetWarnPct_ZeroFallsBackToDefault(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	g := New(cfg, agents, testLogger())
+
+	if got := g.budgetWarnPct(); got != BudgetWarnPct {
+		t.Errorf("zero critical_pct: budgetWarnPct() = %d, want default %d", got, BudgetWarnPct)
+	}
+
+	g.SetBudgetLimit(1000)
+	g.SetBudgetResetAt(time.Now())
+
+	// 800 tokens = 80%: below the 90% default, so no warn should fire.
+	trans := g.UpdateBudgetFromTotals(800, nil, nil)
+	if trans.WarnCrossed || trans.WarnActive {
+		t.Errorf("default 90%% threshold must not warn at 80%% spend, got %+v", trans)
+	}
+	// 950 tokens = 95%: above 90%, warn should fire.
+	trans = g.UpdateBudgetFromTotals(950, nil, nil)
+	if !trans.WarnCrossed || !trans.WarnActive {
+		t.Errorf("default 90%% threshold should warn at 95%% spend, got %+v", trans)
+	}
+}

--- a/v2/pkg/hub/access_hover_test.go
+++ b/v2/pkg/hub/access_hover_test.go
@@ -1,6 +1,9 @@
 package hub
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestAccessForHive covers the ordering and filtering the My Hives hover relies
 // on: only users granted this hive, owners first, then alphabetical.
@@ -48,9 +51,11 @@ func TestAccessForHiveContactMetadata(t *testing.T) {
 		FullName:       "Jane Doe",
 		SlackID:        "@jane",
 		Notes:          "GPU quota bump; prefers async",
+		LoginCount:     42,
+		SessionSeconds: 7200,
 	}}
 
-	t.Run("admin viewer gets name, slack, AND notes", func(t *testing.T) {
+	t.Run("admin viewer gets name, slack, notes AND engagement stats", func(t *testing.T) {
 		got := accessForHive("h1", users, true)
 		if len(got) != 1 {
 			t.Fatalf("want 1 entry, got %d", len(got))
@@ -62,9 +67,12 @@ func TestAccessForHiveContactMetadata(t *testing.T) {
 		if e.Notes != "GPU quota bump; prefers async" {
 			t.Errorf("admin must see notes, got %q", e.Notes)
 		}
+		if e.LoginCount != 42 || e.SessionSeconds != 7200 {
+			t.Errorf("admin must see stats, got login=%d session=%d", e.LoginCount, e.SessionSeconds)
+		}
 	})
 
-	t.Run("non-admin owner gets name+slack but NEVER notes", func(t *testing.T) {
+	t.Run("non-admin owner gets name+slack but NEVER notes or stats", func(t *testing.T) {
 		got := accessForHive("h1", users, false)
 		if len(got) != 1 {
 			t.Fatalf("want 1 entry, got %d", len(got))
@@ -76,5 +84,33 @@ func TestAccessForHiveContactMetadata(t *testing.T) {
 		if e.Notes != "" {
 			t.Errorf("owner must NOT see admin notes, but got %q", e.Notes)
 		}
+		if e.LoginCount != 0 || e.SessionSeconds != 0 {
+			t.Errorf("owner must NOT see engagement stats, got login=%d session=%d", e.LoginCount, e.SessionSeconds)
+		}
 	})
+}
+
+// TestAccessAvatarTitleCarriesStats pins that the co-member face's NATIVE tooltip
+// (accessAvatarTitle) carries the engagement info — logins, time, task activity,
+// verdict — reusing the admin-card helpers, and stays a native title (no custom
+// panel; TestInlineAvatarsCarryNoCustomPanel remains the panel-invariant guard).
+func TestAccessAvatarTitleCarriesStats(t *testing.T) {
+	for _, snippet := range []string{
+		"if (a.login_count) lines.push('Logins: ' + a.login_count);",
+		"if (a.session_seconds) lines.push('Time in hive: ' + fmtHours(a.session_seconds));",
+		"var act = userTaskActivity(uname);",
+		"userVerdict({login_count: a.login_count || 0, session_seconds: a.session_seconds || 0}, act, [])",
+		// The "logged in now" line rides in the avatar's own tooltip, not the ring
+		// wrapper, so a live user's identity+stats aren't shadowed.
+		"if (isUserLive(uname)) title = title + '\\n● Logged into their hive now';",
+	} {
+		if !strings.Contains(dashboardHTML, snippet) {
+			t.Errorf("dashboardHTML missing %q", snippet)
+		}
+	}
+	// The green ring wrapper must NOT carry its own title (it would shadow the
+	// enriched tooltip).
+	if strings.Contains(dashboardHTML, `'<span title="Logged into their hive now" '`) {
+		t.Error("the live-ring wrapper still hard-codes a title that shadows the avatar tooltip")
+	}
 }

--- a/v2/pkg/hub/advisory_staleness.go
+++ b/v2/pkg/hub/advisory_staleness.go
@@ -33,7 +33,10 @@ func appCanWriteForAdvisory(e RegistryEntry) bool {
 	}
 	switch e.GitHubAppState {
 	case "not-installed", "key-missing", "key-invalid", "no-app-assigned",
-		"wrong-installation", "insufficient-permissions":
+		"wrong-installation", "insufficient-permissions",
+		// #2353: a write returned 403 on an otherwise-healthy install — the App
+		// demonstrably cannot write this repo, so it is NOT writable here.
+		"write-forbidden":
 		return false
 	default:
 		// "ok", "unknown", or empty (spoke too old to classify) — the App is

--- a/v2/pkg/hub/app_reset_test.go
+++ b/v2/pkg/hub/app_reset_test.go
@@ -1,0 +1,75 @@
+package hub
+
+import "testing"
+
+// TestAppResetIsDeliveredUntilConfirmed pins the operator-facing contract for
+// "Reset App": the request survives until the spoke reports installation_id 0.
+//
+// It cannot be expressed by pushing a zero. The spoke adopts an installation
+// only when the pushed value is NON-zero, deliberately — zero means "the hub is
+// not speaking to this field", and treating it as a clear once turned a
+// key-only fault into a total auth outage. So the reset is its own flag.
+func TestAppResetIsDeliveredUntilConfirmed(t *testing.T) {
+	oldHives := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = oldHives })
+
+	h := &SaaSHive{ID: "reset-me", ClusterID: "hive-oke", RequestedAppReset: true}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+	s := &HubServer{logger: appKeyTestLogger()}
+
+	t.Run("delivered while the spoke still reports an installation", func(t *testing.T) {
+		got := s.pendingAppIdentityForHeartbeat(&HeartbeatPayload{
+			HiveID: "reset-me", GitHubInstallationID: 145050760,
+		})
+		if got == nil || !got.ResetInstallation {
+			t.Fatalf("reset not delivered: %+v", got)
+		}
+		// A lost beat must not drop it.
+		again := s.pendingAppIdentityForHeartbeat(&HeartbeatPayload{
+			HiveID: "reset-me", GitHubInstallationID: 145050760,
+		})
+		if again == nil || !again.ResetInstallation {
+			t.Fatal("reset was dropped after one delivery; a lost beat would lose the operator's click")
+		}
+	})
+
+	t.Run("cleared once the spoke reports installation 0", func(t *testing.T) {
+		if got := s.pendingAppIdentityForHeartbeat(&HeartbeatPayload{
+			HiveID: "reset-me", GitHubInstallationID: 0,
+		}); got != nil {
+			t.Fatalf("still delivering after confirmation: %+v", got)
+		}
+		// And it stays cleared — the hive must not be reset forever.
+		if h2 := loadSaaSHive("reset-me"); h2 == nil || h2.RequestedAppReset {
+			t.Fatal("RequestedAppReset was not cleared on the hive record")
+		}
+		if got := s.pendingAppIdentityForHeartbeat(&HeartbeatPayload{
+			HiveID: "reset-me", GitHubInstallationID: 145050760,
+		}); got != nil && got.ResetInstallation {
+			t.Fatal("reset re-armed itself after being confirmed")
+		}
+	})
+}
+
+// TestNoResetMeansNoResetFlag: a hive that was never reset must never receive
+// the flag. Sending it spuriously would blank a working installation and take
+// the hive offline until its owner reinstalls.
+func TestNoResetMeansNoResetFlag(t *testing.T) {
+	oldHives := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = oldHives })
+
+	if err := saveSaaSHive(&SaaSHive{ID: "healthy", ClusterID: "hive-oke"}); err != nil {
+		t.Fatal(err)
+	}
+	s := &HubServer{logger: appKeyTestLogger()}
+	got := s.pendingAppIdentityForHeartbeat(&HeartbeatPayload{
+		HiveID: "healthy", GitHubInstallationID: 12345,
+	})
+	if got != nil && got.ResetInstallation {
+		t.Fatal("a healthy hive was told to reset its App")
+	}
+}

--- a/v2/pkg/hub/clickable_avatars_test.go
+++ b/v2/pkg/hub/clickable_avatars_test.go
@@ -65,7 +65,10 @@ func TestAvatarAnchorSafety(t *testing.T) {
 		{"opens in a new tab", `target="_blank"`},
 		{"blocks opener and referrer", `rel="noopener noreferrer"`},
 		{"names the link for assistive tech", `aria-label="' + escAttr(label || uname) + '"`},
-		{"native tooltip names the user too", `title="' + escAttr(label || uname) + '"`},
+		// The native tooltip is escAttr'd via a `title` var that starts from the
+		// label (and folds in a "logged in now" line for a live user).
+		{"native tooltip is escaped", `title="' + escAttr(title) + '"`},
+		{"native tooltip starts from the user label", `var title = label || uname;`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/v2/pkg/hub/fleet_stats_test.go
+++ b/v2/pkg/hub/fleet_stats_test.go
@@ -98,45 +98,51 @@ func TestComputeFleetStats(t *testing.T) {
 		{
 			// Unassigned placeholders are counted as AVAILABLE and excluded from
 			// the assigned totals — "hives up / total" is about the working fleet,
-			// not idle inventory. The AUTHORITATIVE signal is ProvStatus=="available";
-			// the "hosted-available-" ID prefix / "available-" org prefix are only a
-			// FALLBACK for entries with no ProvStatus yet. Here: 2 assigned (1 up),
-			// 3 available (all via the prefix fallback, ProvStatus empty).
-			name: "placeholders count as available, not assigned",
+			// not idle inventory. Availability mirrors the dashboard EXACTLY:
+			// ProvStatus=="available" OR an "available-" org prefix. The immutable
+			// "hosted-available-" ID prefix is deliberately NOT a signal (a claimed
+			// placeholder keeps that ID forever). Here: h1 (up) + h2 (down) are
+			// assigned; the "available-pool" org rows are available; the ID-only row
+			// with a cleared org is a CLAIMED placeholder → assigned, offline.
+			name: "placeholders count as available via provStatus/org, not the ID prefix",
 			hives: []RegistryEntry{
 				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(3)},
 				{ID: "h2", IsPublic: false, Online: false, Org: "b", Repos: []string{"r2"}, PRsMerged90d: ptrInt(1)},
-				{ID: "hosted-available-oke-01-placeholder-aa01", Online: true, Org: "available-pool"}, // both markers, online, ProvStatus empty
-				{ID: "hosted-available-oke-02-placeholder-aa02", Online: false, Org: ""},              // ID marker only, offline
-				{ID: "regular-id", Online: true, Org: "available-pool"},                               // org marker only, online
+				{ID: "hosted-available-oke-01-placeholder-aa01", Online: true, Org: "available-pool"}, // org marker → available
+				{ID: "hosted-available-oke-02-placeholder-aa02", Online: false, Org: ""},              // claimed: ID prefix alone is NOT available → assigned, down
+				{ID: "regular-id", Online: true, Org: "available-pool"},                               // org marker → available
 			},
-			want: FleetStats{ReposManaged: 1, PRsMerged: 3, Hives: 1, TotalHives: 2, AvailableHives: 3, Reporting: 1, Eligible: 1},
+			// Assigned total = h1 + h2 + the ID-only row (3); assigned & up = h1 (1);
+			// available = the two "available-pool" rows (2).
+			want: FleetStats{ReposManaged: 1, PRsMerged: 3, Hives: 1, TotalHives: 3, AvailableHives: 2, Reporting: 1, Eligible: 1},
 		},
 		{
-			// A leftover REAL pool org is still available WHEN unclaimed (live
-			// example id="hosted-available-oke-01-placeholder-bb95",
-			// org="TradingAsBuddies"): here ProvStatus is empty, so the
-			// "hosted-available-" ID prefix marks it available.
-			name: "placeholder with leftover real org is available via ID fallback",
+			// A CLAIMED placeholder whose org was rewritten off the pool prefix
+			// (live example id="hosted-available-oke-01-placeholder-bb95",
+			// org="TradingAsBuddies") is ASSIGNED — its status is not "available"
+			// and its org has no "available-" prefix. The "hosted-available-" ID it
+			// still carries must NOT resurrect it as available. This is the exact
+			// over-count that showed 38 available when only 17 are unclaimed.
+			name: "claimed placeholder with rewritten org is assigned, not available via ID prefix",
 			hives: []RegistryEntry{
 				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(9)},
-				{ID: "hosted-available-oke-01-placeholder-bb95", Online: true, Org: "TradingAsBuddies", Repos: []string{"leftover/repo"}},
+				{ID: "hosted-available-oke-01-placeholder-bb95", Online: true, Org: "TradingAsBuddies", Repos: []string{"leftover/repo"}, PRsMerged90d: ptrInt(4)},
 			},
-			want: FleetStats{ReposManaged: 1, PRsMerged: 9, Hives: 1, TotalHives: 1, AvailableHives: 1, Reporting: 1, Eligible: 1},
+			// Both assigned & up; the placeholder's rewritten org means 0 available.
+			want: FleetStats{ReposManaged: 2, PRsMerged: 13, Hives: 2, TotalHives: 2, AvailableHives: 0, Reporting: 2, Eligible: 2},
 		},
 		{
-			// THE OVER-COUNT BUG: a CLAIMED placeholder KEEPS its "hosted-available-"
-			// ID (minted at pool creation, never rewritten on claim) and its leftover
-			// pool org. Gating on the prefix alone counted this as AVAILABLE — the
-			// exact reason the landing page showed 38 available when only 17 are
-			// unclaimed and 33 are assigned. ProvStatus is authoritative: a claimed
-			// status ("claimed") makes it ASSIGNED regardless of the ID/org prefix.
-			// Here: both hives assigned (2 total, 2 up), 0 available.
-			name: "claimed placeholder keeps hosted-available ID but counts as assigned",
+			// THE OVER-COUNT BUG, now via the explicit statusAssigned the claim
+			// paths set: a CLAIMED placeholder KEEPS its "hosted-available-" ID and
+			// a leftover "available-pool" org, but its provStatus is "assigned".
+			// Availability keys off provStatus=="available" (false) and the org
+			// prefix — and here the claim rewrote neither the ID nor the org, so
+			// this case pins that provStatus alone must win: assigned, NOT available.
+			name: "claimed placeholder keeps hosted-available ID/org but statusAssigned makes it assigned",
 			hives: []RegistryEntry{
-				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(4), ProvStatus: "claimed"},
-				{ID: "hosted-available-oke-01-placeholder-cc11", Online: true, Org: "available-pool",
-					Repos: []string{"real/repo"}, PRsMerged90d: ptrInt(6), ProvStatus: "claimed"},
+				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(4), ProvStatus: statusAssigned},
+				{ID: "hosted-available-oke-01-placeholder-cc11", Online: true, Org: "claimed-org",
+					Repos: []string{"real/repo"}, PRsMerged90d: ptrInt(6), ProvStatus: statusAssigned},
 			},
 			want: FleetStats{ReposManaged: 2, PRsMerged: 10, Hives: 2, TotalHives: 2, AvailableHives: 0, Reporting: 2, Eligible: 2},
 		},
@@ -155,16 +161,16 @@ func TestComputeFleetStats(t *testing.T) {
 		{
 			// Reconciliation shape mirroring the live fleet the bug was found on:
 			// 2 hosted-available-* IDs, one still unclaimed (ProvStatus available →
-			// AVAILABLE) and one claimed (ProvStatus claimed → ASSIGNED). The claimed
-			// one must NOT be double-counted as available even though its ID prefix
-			// matches. Available=1, assigned total=2 (the plain hive + the claimed
-			// placeholder).
+			// AVAILABLE) and one claimed (statusAssigned + org rewritten off the pool
+			// prefix → ASSIGNED). The claimed one must NOT be double-counted as
+			// available even though its ID prefix matches. Available=1, assigned
+			// total=2 (the plain hive + the claimed placeholder).
 			name: "mixed hosted-available pool splits by provStatus",
 			hives: []RegistryEntry{
 				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(2)},
 				{ID: "hosted-available-oke-01-placeholder-dd01", Online: true, Org: "available-pool", ProvStatus: statusAvailable},
-				{ID: "hosted-available-oke-02-placeholder-dd02", Online: true, Org: "available-pool",
-					Repos: []string{"claimed/repo"}, PRsMerged90d: ptrInt(3), ProvStatus: "claimed"},
+				{ID: "hosted-available-oke-02-placeholder-dd02", Online: true, Org: "claimed-org",
+					Repos: []string{"claimed/repo"}, PRsMerged90d: ptrInt(3), ProvStatus: statusAssigned},
 			},
 			want: FleetStats{ReposManaged: 2, PRsMerged: 5, Hives: 2, TotalHives: 2, AvailableHives: 1, Reporting: 2, Eligible: 2},
 		},

--- a/v2/pkg/hub/fleet_stats_test.go
+++ b/v2/pkg/hub/fleet_stats_test.go
@@ -98,31 +98,75 @@ func TestComputeFleetStats(t *testing.T) {
 		{
 			// Unassigned placeholders are counted as AVAILABLE and excluded from
 			// the assigned totals — "hives up / total" is about the working fleet,
-			// not idle inventory. A placeholder is detected by its "hosted-available-"
-			// ID prefix OR "available-" org prefix, NOT by an empty Org (an unclaimed
-			// slot keeps a leftover pool org). Here: 2 assigned (1 up), 3 available.
+			// not idle inventory. The AUTHORITATIVE signal is ProvStatus=="available";
+			// the "hosted-available-" ID prefix / "available-" org prefix are only a
+			// FALLBACK for entries with no ProvStatus yet. Here: 2 assigned (1 up),
+			// 3 available (all via the prefix fallback, ProvStatus empty).
 			name: "placeholders count as available, not assigned",
 			hives: []RegistryEntry{
 				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(3)},
 				{ID: "h2", IsPublic: false, Online: false, Org: "b", Repos: []string{"r2"}, PRsMerged90d: ptrInt(1)},
-				{ID: "hosted-available-oke-01-placeholder-aa01", Online: true, Org: "available-pool"}, // both markers, online
+				{ID: "hosted-available-oke-01-placeholder-aa01", Online: true, Org: "available-pool"}, // both markers, online, ProvStatus empty
 				{ID: "hosted-available-oke-02-placeholder-aa02", Online: false, Org: ""},              // ID marker only, offline
 				{ID: "regular-id", Online: true, Org: "available-pool"},                               // org marker only, online
 			},
 			want: FleetStats{ReposManaged: 1, PRsMerged: 3, Hives: 1, TotalHives: 2, AvailableHives: 3, Reporting: 1, Eligible: 1},
 		},
 		{
-			// THE BUG: an unclaimed slot keeps a leftover REAL pool org (live
+			// A leftover REAL pool org is still available WHEN unclaimed (live
 			// example id="hosted-available-oke-01-placeholder-bb95",
-			// org="TradingAsBuddies"). The old Org=="" check missed it entirely —
-			// counting it as assigned and inflating hives-up/total. The
-			// "hosted-available-" ID prefix still marks it available.
-			name: "placeholder with leftover real org is still available",
+			// org="TradingAsBuddies"): here ProvStatus is empty, so the
+			// "hosted-available-" ID prefix marks it available.
+			name: "placeholder with leftover real org is available via ID fallback",
 			hives: []RegistryEntry{
 				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(9)},
 				{ID: "hosted-available-oke-01-placeholder-bb95", Online: true, Org: "TradingAsBuddies", Repos: []string{"leftover/repo"}},
 			},
 			want: FleetStats{ReposManaged: 1, PRsMerged: 9, Hives: 1, TotalHives: 1, AvailableHives: 1, Reporting: 1, Eligible: 1},
+		},
+		{
+			// THE OVER-COUNT BUG: a CLAIMED placeholder KEEPS its "hosted-available-"
+			// ID (minted at pool creation, never rewritten on claim) and its leftover
+			// pool org. Gating on the prefix alone counted this as AVAILABLE — the
+			// exact reason the landing page showed 38 available when only 17 are
+			// unclaimed and 33 are assigned. ProvStatus is authoritative: a claimed
+			// status ("claimed") makes it ASSIGNED regardless of the ID/org prefix.
+			// Here: both hives assigned (2 total, 2 up), 0 available.
+			name: "claimed placeholder keeps hosted-available ID but counts as assigned",
+			hives: []RegistryEntry{
+				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(4), ProvStatus: "claimed"},
+				{ID: "hosted-available-oke-01-placeholder-cc11", Online: true, Org: "available-pool",
+					Repos: []string{"real/repo"}, PRsMerged90d: ptrInt(6), ProvStatus: "claimed"},
+			},
+			want: FleetStats{ReposManaged: 2, PRsMerged: 10, Hives: 2, TotalHives: 2, AvailableHives: 0, Reporting: 2, Eligible: 2},
+		},
+		{
+			// ProvStatus=="available" is authoritative even for a hive whose ID does
+			// NOT carry the "hosted-available-" prefix and whose org is not a pool
+			// prefix — a placeholder whose ID/org markers alone would miss it. It
+			// still counts as AVAILABLE, matching the dashboard's Unassigned section.
+			name: "provStatus available is authoritative regardless of ID",
+			hives: []RegistryEntry{
+				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(5)},
+				{ID: "regular-looking-id", Online: true, Org: "some-org", ProvStatus: statusAvailable},
+			},
+			want: FleetStats{ReposManaged: 1, PRsMerged: 5, Hives: 1, TotalHives: 1, AvailableHives: 1, Reporting: 1, Eligible: 1},
+		},
+		{
+			// Reconciliation shape mirroring the live fleet the bug was found on:
+			// 2 hosted-available-* IDs, one still unclaimed (ProvStatus available →
+			// AVAILABLE) and one claimed (ProvStatus claimed → ASSIGNED). The claimed
+			// one must NOT be double-counted as available even though its ID prefix
+			// matches. Available=1, assigned total=2 (the plain hive + the claimed
+			// placeholder).
+			name: "mixed hosted-available pool splits by provStatus",
+			hives: []RegistryEntry{
+				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(2)},
+				{ID: "hosted-available-oke-01-placeholder-dd01", Online: true, Org: "available-pool", ProvStatus: statusAvailable},
+				{ID: "hosted-available-oke-02-placeholder-dd02", Online: true, Org: "available-pool",
+					Repos: []string{"claimed/repo"}, PRsMerged90d: ptrInt(3), ProvStatus: "claimed"},
+			},
+			want: FleetStats{ReposManaged: 2, PRsMerged: 5, Hives: 2, TotalHives: 2, AvailableHives: 1, Reporting: 2, Eligible: 2},
 		},
 		{
 			name:  "no hives yields empty",

--- a/v2/pkg/hub/fleet_stats_test.go
+++ b/v2/pkg/hub/fleet_stats_test.go
@@ -96,18 +96,33 @@ func TestComputeFleetStats(t *testing.T) {
 			want: FleetStats{ReposManaged: 1, PRsMerged: 2, Hives: 1, TotalHives: 1, Reporting: 1, Eligible: 1},
 		},
 		{
-			// Unassigned placeholders (Org == "") are counted as AVAILABLE and
-			// excluded from the assigned totals — "hives up / total" is about the
-			// working fleet, not idle inventory. Here: 2 assigned (1 up), 3 available.
-			name: "unassigned placeholders count as available, not assigned",
+			// Unassigned placeholders are counted as AVAILABLE and excluded from
+			// the assigned totals — "hives up / total" is about the working fleet,
+			// not idle inventory. A placeholder is detected by its "hosted-available-"
+			// ID prefix OR "available-" org prefix, NOT by an empty Org (an unclaimed
+			// slot keeps a leftover pool org). Here: 2 assigned (1 up), 3 available.
+			name: "placeholders count as available, not assigned",
 			hives: []RegistryEntry{
-				{IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(3)},
-				{IsPublic: false, Online: false, Org: "b", Repos: []string{"r2"}, PRsMerged90d: ptrInt(1)},
-				{Online: true, Org: ""},  // available placeholder, online
-				{Online: false, Org: ""}, // available placeholder, offline
-				{Online: true, Org: ""},  // available placeholder, online
+				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(3)},
+				{ID: "h2", IsPublic: false, Online: false, Org: "b", Repos: []string{"r2"}, PRsMerged90d: ptrInt(1)},
+				{ID: "hosted-available-oke-01-placeholder-aa01", Online: true, Org: "available-pool"}, // both markers, online
+				{ID: "hosted-available-oke-02-placeholder-aa02", Online: false, Org: ""},              // ID marker only, offline
+				{ID: "regular-id", Online: true, Org: "available-pool"},                               // org marker only, online
 			},
 			want: FleetStats{ReposManaged: 1, PRsMerged: 3, Hives: 1, TotalHives: 2, AvailableHives: 3, Reporting: 1, Eligible: 1},
+		},
+		{
+			// THE BUG: an unclaimed slot keeps a leftover REAL pool org (live
+			// example id="hosted-available-oke-01-placeholder-bb95",
+			// org="TradingAsBuddies"). The old Org=="" check missed it entirely —
+			// counting it as assigned and inflating hives-up/total. The
+			// "hosted-available-" ID prefix still marks it available.
+			name: "placeholder with leftover real org is still available",
+			hives: []RegistryEntry{
+				{ID: "h1", IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(9)},
+				{ID: "hosted-available-oke-01-placeholder-bb95", Online: true, Org: "TradingAsBuddies", Repos: []string{"leftover/repo"}},
+			},
+			want: FleetStats{ReposManaged: 1, PRsMerged: 9, Hives: 1, TotalHives: 1, AvailableHives: 1, Reporting: 1, Eligible: 1},
 		},
 		{
 			name:  "no hives yields empty",

--- a/v2/pkg/hub/fleet_stats_test.go
+++ b/v2/pkg/hub/fleet_stats_test.go
@@ -460,6 +460,46 @@ func TestHandleFleetStats_LiveDataWinsOverLKG(t *testing.T) {
 	}
 }
 
+// When NOTHING is reporting but eligible hives exist AND a last-known-good
+// aggregate was stored, the handler serves the cached counts and labels them
+// stale — the strip keeps a real (older) number rather than going blank on a
+// fleet that has merely gone quiet. This exercises the LKG-serving branch that
+// only fires at zero live coverage.
+func TestHandleFleetStats_ZeroReportingServesStaleLKG(t *testing.T) {
+	s := fleetStatsLKGTestServer(t)
+	collectedAt := time.Now().Add(-3 * time.Hour).UTC().Truncate(time.Second)
+	s.registry.FleetStatsLKG = &FleetStatsSnapshot{
+		ReposManaged: 42, PRsMerged: 26, PRsRejected: 3, CVEsClosed: 1,
+		Hives: 5, Reporting: 5, Eligible: 5, CollectedAt: collectedAt,
+	}
+	// Eligible (online, has repos) but NOT reporting (no counts at all), so
+	// Reporting==0 while Eligible>0 — the exact state the LKG fallback covers.
+	s.registry.Hives = []RegistryEntry{
+		{ID: "h1", IsPublic: true, Online: true, LastHeartbeat: freshHeartbeat(), Org: "a", Repos: []string{"r1"}},
+		{ID: "h2", IsPublic: true, Online: true, LastHeartbeat: freshHeartbeat(), Org: "a", Repos: []string{"r2"}},
+	}
+
+	fs := decodeFleetStats(t, s)
+	if fs.Trustworthy {
+		t.Fatal("Trustworthy = true, want false when nothing is reporting")
+	}
+	if !fs.StaleData {
+		t.Error("StaleData = false, want true when serving the cached aggregate")
+	}
+	// The served counts come from the cache, not the (empty) live aggregate.
+	if fs.PRsMerged != 26 || fs.ReposManaged != 42 {
+		t.Errorf("served PRsMerged/ReposManaged = %d/%d, want cached 26/42", fs.PRsMerged, fs.ReposManaged)
+	}
+	// AsOf reflects the cache's collection time, not now.
+	if fs.AsOf != collectedAt.Format(time.RFC3339) {
+		t.Errorf("AsOf = %q, want the cached collection time %q", fs.AsOf, collectedAt.Format(time.RFC3339))
+	}
+	// Live coverage figures are kept so the page can show recollection progress.
+	if fs.Reporting != 0 || fs.Eligible != 2 {
+		t.Errorf("Reporting/Eligible = %d/%d, want live 0/2", fs.Reporting, fs.Eligible)
+	}
+}
+
 // Genuine first boot — never collected, nothing cached — is the only state
 // that legitimately shows no total.
 func TestHandleFleetStats_NoLKGShowsNothing(t *testing.T) {

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -838,6 +838,18 @@ type HeartbeatGitHubAppConfig struct {
 	// Empty means "leave the spoke's slug unchanged" — never a way to blank a
 	// working value.
 	AppSlug string `json:"app_slug,omitempty"`
+	// ResetInstallation tells the spoke to CLEAR its installation_id.
+	//
+	// A separate flag because zero cannot carry this meaning: the spoke adopts
+	// an installation only when the pushed value is non-zero, since zero means
+	// "not speaking to this field". Overloading it would make every push that
+	// omits an installation blank a working one.
+	//
+	// The spoke clearing its installation makes HasUsableApp() false, which
+	// raises githubAppRequired — so the owner is prompted to install the App
+	// again AND the 2-minute self-heal ticker starts, whose RediscoverAndAdopt
+	// finds the correct installation for whichever App is installed.
+	ResetInstallation bool `json:"reset_installation,omitempty"`
 	// APIURL and BaseURL complete the identity SET.
 	//
 	// WHY THEY ARE HERE AND NOT ON ProjectConfig

--- a/v2/pkg/hub/hive_access_avatars_test.go
+++ b/v2/pkg/hub/hive_access_avatars_test.go
@@ -80,7 +80,9 @@ func TestInlineAccessAvatarEscaping(t *testing.T) {
 		{"avatar url built from the encoded profile url", `'<img src="' + escAttr(ghProfileURL(username)) + '.png?size='`},
 		// Quoted attribute values.
 		{"anchor href uses escAttr", `'<a href="' + escAttr(ghProfileURL(uname)) + '" target="_blank" rel="noopener noreferrer" '`},
-		{"anchor title and aria-label use escAttr", `'title="' + escAttr(label || uname) + '" aria-label="' + escAttr(label || uname) + '" '`},
+		// title now folds in a live line via a `title` var; both title and
+		// aria-label still go through escAttr.
+		{"anchor title uses escAttr", `'title="' + escAttr(title) + '" aria-label="' + escAttr(label || uname) + '" '`},
 		// The inline face still carries the role in its tooltip, now built by the
 		// shared accessAvatarTitle helper (username — role, plus contact metadata).
 		{"inline face labels username and role via title helper", `return linkedAvatar(uname, INLINE_ACCESS_AVATAR_PX, accessAvatarTitle(a),`},

--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -1137,8 +1137,12 @@ func TestHandleApproveProvisionWithFilesystem(t *testing.T) {
 	if h.Org != "org" {
 		t.Errorf("org = %q, want org", h.Org)
 	}
-	if h.Status != "" {
-		t.Errorf("status = %q, want empty (cleared)", h.Status)
+	// A claimed placeholder must carry the explicit statusAssigned, NOT an empty
+	// string. Empty was indistinguishable from "unknown" and made every
+	// availability check fall back to the immutable "hosted-available-" ID
+	// prefix, mis-counting claimed hives as available (38 shown vs the true 17).
+	if h.Status != statusAssigned {
+		t.Errorf("status = %q, want %q (claimed, no longer available)", h.Status, statusAssigned)
 	}
 }
 
@@ -1213,7 +1217,10 @@ func TestHandleAssignHiveWithFilesystem(t *testing.T) {
 	if h == nil {
 		t.Fatal("hive missing after assign")
 	}
-	if h.Owner != "newowner" || h.Org != "neworg" || h.PrimaryRepo != "repoa" || h.ACMMLevel != 3 || h.Status != "" {
+	// Status must be the explicit statusAssigned on claim, not empty — empty made
+	// the fleet counters fall back to the immutable ID prefix and over-count
+	// available hives.
+	if h.Owner != "newowner" || h.Org != "neworg" || h.PrimaryRepo != "repoa" || h.ACMMLevel != 3 || h.Status != statusAssigned {
 		t.Errorf("assign wrote wrong meta: %+v", h)
 	}
 

--- a/v2/pkg/hub/identity.go
+++ b/v2/pkg/hub/identity.go
@@ -62,7 +62,10 @@ package hub
 // atomicity property (never half-apply) without pretending three transports
 // are one.
 
-import "strings"
+import (
+	"net/http"
+	"strings"
+)
 
 // gheAPIPathMarker identifies a GitHub Enterprise API URL. GHE APIs live under
 // /api/v3; public GitHub uses api.github.com.
@@ -217,6 +220,31 @@ func (s *HubServer) pendingAppIdentityForHeartbeat(p *HeartbeatPayload) *Heartbe
 	}
 
 	h := loadSaaSHive(p.HiveID)
+
+	// An operator-requested App reset outranks everything below: a hive being
+	// reset has no pending identity to deliver, and the point is to get it back
+	// to "App not installed" so the owner reinstalls.
+	//
+	// Cleared on READ-BACK — when the spoke reports installation_id 0 — not on
+	// send. A reset lost to a dropped beat or a hub restart would otherwise be
+	// silently forgotten, leaving the operator's click with no effect and no
+	// signal.
+	if h != nil && h.RequestedAppReset {
+		if p.GitHubInstallationID == 0 {
+			h.RequestedAppReset = false
+			if err := saveSaaSHive(h); err != nil {
+				s.logger.Warn("app reset confirmed but could not be cleared",
+					"hive_id", p.HiveID, "error", err)
+			}
+			s.logger.Info("app reset confirmed by spoke; installation cleared",
+				"hive_id", p.HiveID)
+			return nil
+		}
+		s.logger.Info("delivering app reset to spoke",
+			"hive_id", p.HiveID, "spoke_installation_id", p.GitHubInstallationID)
+		return &HeartbeatGitHubAppConfig{ResetInstallation: true}
+	}
+
 	if h == nil || h.PendingAppConfig == nil {
 		return nil
 	}
@@ -293,4 +321,46 @@ func SpokeIdentityFromPayload(p *HeartbeatPayload) IdentitySet {
 		APIURL:         p.GitHubAPIURL,
 		BaseURL:        p.GitHubBaseURL,
 	}
+}
+
+// handleResetApp arms an App reset for one hive: POST /api/saas/hives/{id}/reset-app
+//
+// The spoke clears its installation_id on the next beat, which makes
+// HasUsableApp() false and raises githubAppRequired — the owner is prompted to
+// install the App again, and the 2-minute self-heal ticker starts, whose
+// RediscoverAndAdopt adopts the correct installation for whichever App they
+// install.
+//
+// WHY AN OPERATOR NEEDS THIS. A hive provisioned with its OWN GitHub App keeps
+// that App's installation_id if its identity is later moved to the fleet's
+// public App. Every field then looks right — app_id, app_slug and key_file all
+// name the public App — while the installation belongs to a different one, so
+// freshly minted tokens return "404 Not Found" and cached ones keep working.
+// Nothing in the config reads as wrong, and no automatic path fixes it: the
+// hub does not track installation IDs, and the spoke's self-heal only runs when
+// the App is already flagged as missing.
+//
+// Deliberately NOT destructive beyond the one field. The App ID, slug and key
+// are untouched, so a reset on a healthy hive costs one re-install rather than
+// an outage.
+func (s *HubServer) handleResetApp(w http.ResponseWriter, r *http.Request) {
+	if s.getAuthUser(r) != hubAdminUsername {
+		http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
+		return
+	}
+	hiveID := r.PathValue("id")
+	h := loadSaaSHive(hiveID)
+	if h == nil {
+		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
+		return
+	}
+	h.RequestedAppReset = true
+	if err := saveSaaSHive(h); err != nil {
+		s.logger.Error("failed to arm app reset", "hive_id", hiveID, "error", err)
+		http.Error(w, `{"error":"could not arm the reset"}`, http.StatusInternalServerError)
+		return
+	}
+	s.logger.Info("app reset armed by operator", "hive_id", hiveID)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(`{"status":"armed","detail":"the spoke will clear its installation on the next heartbeat and prompt for a fresh App install"}`))
 }

--- a/v2/pkg/hub/identity_pure_helpers_test.go
+++ b/v2/pkg/hub/identity_pure_helpers_test.go
@@ -1,0 +1,71 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSpokeIdentityFromPayload covers both the nil-payload guard and the
+// populated mapping of the pure heartbeat→identity translation.
+func TestSpokeIdentityFromPayload(t *testing.T) {
+	if got := SpokeIdentityFromPayload(nil); got != (IdentitySet{}) {
+		t.Errorf("nil payload = %+v, want zero IdentitySet", got)
+	}
+	p := &HeartbeatPayload{
+		GitHubAppID:          5686,
+		GitHubAppSlug:        "kubestellar-hive-ghe",
+		GitHubInstallationID: 43015,
+		GitHubAPIURL:         "https://github.ibm.com/api/v3",
+		GitHubBaseURL:        "https://github.ibm.com",
+	}
+	got := SpokeIdentityFromPayload(p)
+	if got.AppID != 5686 || got.AppSlug != "kubestellar-hive-ghe" || got.InstallationID != 43015 ||
+		got.APIURL != "https://github.ibm.com/api/v3" || got.BaseURL != "https://github.ibm.com" {
+		t.Errorf("mapped identity = %+v, want the payload's GitHub fields verbatim", got)
+	}
+}
+
+// TestIdentitySetIssuesAndValidate covers the coherence checks: a token-only
+// hive is silent, a coherent GHE set is clean, and each inconsistency (GHE slug
+// on a public api_url; base/api forge mismatch both directions) is named.
+// ValidateIdentityPush wraps the same checks into a refusal string.
+func TestIdentitySetIssuesAndValidate(t *testing.T) {
+	// No App configured → no issues, and a safe (empty) push verdict.
+	if got := IdentitySetIssues(IdentitySet{}); got != nil {
+		t.Errorf("token-only hive should have no identity issues, got %v", got)
+	}
+	if got := ValidateIdentityPush(IdentitySet{}); got != "" {
+		t.Errorf("token-only push should be safe, got %q", got)
+	}
+
+	// A coherent GHE identity is clean.
+	ghe := IdentitySet{AppID: 5686, AppSlug: "kubestellar-hive-ghe", APIURL: "https://github.ibm.com/api/v3", BaseURL: "https://github.ibm.com"}
+	if !ghe.IsGHE() {
+		t.Error("GHE api_url must read as GHE")
+	}
+	if got := IdentitySetIssues(ghe); got != nil {
+		t.Errorf("coherent GHE identity should be clean, got %v", got)
+	}
+
+	// GHE slug presented to public api.github.com (empty api_url) — the live
+	// regression. ValidateIdentityPush must refuse.
+	badSlug := IdentitySet{AppID: 5686, AppSlug: "kubestellar-hive-ghe", APIURL: ""}
+	issues := IdentitySetIssues(badSlug)
+	if len(issues) == 0 || !strings.Contains(issues[0], "404") {
+		t.Errorf("GHE slug on empty api_url must be flagged (404), got %v", issues)
+	}
+	if v := ValidateIdentityPush(badSlug); !strings.Contains(v, "refusing") {
+		t.Errorf("inconsistent identity must be refused, got %q", v)
+	}
+
+	// base_url is GHE but api_url is public — a stale-base mismatch.
+	baseGHE := IdentitySet{AppID: 3568013, APIURL: "https://api.github.com", BaseURL: "https://github.ibm.com"}
+	if got := IdentitySetIssues(baseGHE); len(got) == 0 {
+		t.Error("base GHE / api public mismatch must be flagged")
+	}
+	// api_url is GHE but base_url is public — the reverse mismatch.
+	apiGHE := IdentitySet{AppID: 5686, APIURL: "https://github.ibm.com/api/v3", BaseURL: "https://github.com"}
+	if got := IdentitySetIssues(apiGHE); len(got) == 0 {
+		t.Error("api GHE / base public mismatch must be flagged")
+	}
+}

--- a/v2/pkg/hub/identity_url_helpers_test.go
+++ b/v2/pkg/hub/identity_url_helpers_test.go
@@ -1,0 +1,162 @@
+package hub
+
+import (
+	"log/slog"
+	"strconv"
+	"testing"
+)
+
+// TestAppIDString covers HiveIdentity.AppIDString, which renders the resolved
+// app_id for the provisioning template. A zero AppID must render as "" (so an
+// unknown App stays unset rather than becoming a literal "0" that fails auth),
+// and any non-zero AppID renders as its base-10 string.
+func TestAppIDString(t *testing.T) {
+	cases := []struct {
+		name  string
+		appID int64
+		want  string
+	}{
+		{"zero renders empty so the App stays unset", 0, ""},
+		{"positive App ID renders as base-10", 123456, "123456"},
+		{"single digit", 7, "7"},
+		{"large App ID", 9876543210, strconv.FormatInt(9876543210, 10)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id := HiveIdentity{AppID: tc.appID}
+			if got := id.AppIDString(); got != tc.want {
+				t.Errorf("AppIDString() with AppID=%d = %q, want %q", tc.appID, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClusterAPIURLForIdentity covers clusterAPIURLForIdentity: it returns the
+// cluster's GitHubAPIURL trimmed of surrounding whitespace, and an empty string
+// for an unknown cluster or one that declares no API URL. The caller reads an
+// empty string as "no forge declared" and skips the hub-side guard entirely.
+func TestClusterAPIURLForIdentity(t *testing.T) {
+	s := &HubServer{
+		logger: slog.Default(),
+		clusters: map[string]ClusterConfig{
+			"pok-prod":   {ID: "pok-prod", GitHubAPIURL: "https://api.github.com"},
+			"padded":     {ID: "padded", GitHubAPIURL: "  https://ghe.example/api/v3  "},
+			"no-api-url": {ID: "no-api-url"},
+		},
+	}
+	cases := []struct {
+		name      string
+		clusterID string
+		want      string
+	}{
+		{"known cluster returns its API URL", "pok-prod", "https://api.github.com"},
+		{"surrounding whitespace is trimmed", "padded", "https://ghe.example/api/v3"},
+		{"declared but empty yields empty", "no-api-url", ""},
+		{"unknown cluster yields empty", "does-not-exist", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clusterAPIURLForIdentity(s, tc.clusterID); got != tc.want {
+				t.Errorf("clusterAPIURLForIdentity(%q) = %q, want %q", tc.clusterID, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClusterForgeHost covers clusterForgeHost, which names the forge a cluster
+// defaults to. A nil cluster and a cluster that declares neither URL both fall
+// back to public github.com; otherwise the base URL wins over the API URL, each
+// normalised to a bare host by forgeHostLabel.
+func TestClusterForgeHost(t *testing.T) {
+	cases := []struct {
+		name string
+		c    *ClusterConfig
+		want string
+	}{
+		{"nil cluster falls back to public", nil, publicForgeHost},
+		{"no URLs declared falls back to public", &ClusterConfig{ID: "bare"}, publicForgeHost},
+		{
+			"base URL wins and is normalised to a bare host",
+			&ClusterConfig{GitHubBaseURL: "https://github.ibm.com", GitHubAPIURL: "https://api.other.example"},
+			"github.ibm.com",
+		},
+		{
+			"API URL used when no base URL, path stripped",
+			&ClusterConfig{GitHubAPIURL: "https://github.ibm.com/api/v3"},
+			"github.ibm.com",
+		},
+		{
+			"public API URL normalises to github.com",
+			&ClusterConfig{GitHubAPIURL: "https://api.github.com"},
+			publicForgeHost,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clusterForgeHost(tc.c); got != tc.want {
+				t.Errorf("clusterForgeHost() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSanitizeRepoEntry covers sanitizeRepoEntry, which normalises a
+// user-entered repo string to bare owner/repo: it trims whitespace, strips an
+// http(s):// scheme, surrounding slashes and a trailing .git, drops a leading
+// hostname, and keeps only the final two path segments.
+func TestSanitizeRepoEntry(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty stays empty", "", ""},
+		{"whitespace-only stays empty", "   ", ""},
+		{"plain owner/repo is unchanged", "kubestellar/hive", "kubestellar/hive"},
+		{"https scheme is stripped", "https://github.com/kubestellar/hive", "kubestellar/hive"},
+		{"http scheme is stripped", "http://github.com/kubestellar/hive", "kubestellar/hive"},
+		{"trailing .git is removed", "kubestellar/hive.git", "kubestellar/hive"},
+		{"surrounding slashes are trimmed", "/kubestellar/hive/", "kubestellar/hive"},
+		{"leading GHE hostname is dropped", "github.ibm.com/org/repo", "org/repo"},
+		{"deep path keeps only last two segments", "github.com/a/b/c/d", "c/d"},
+		{"whitespace and scheme together", "  https://github.com/kubestellar/hive.git  ", "kubestellar/hive"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeRepoEntry(tc.in); got != tc.want {
+				t.Errorf("sanitizeRepoEntry(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClusterBaseURLForIdentity covers clusterBaseURLForIdentity: it returns the
+// cluster's GitHubBaseURL trimmed of surrounding whitespace, and an empty string
+// for an unknown cluster or one that declares no base URL.
+func TestClusterBaseURLForIdentity(t *testing.T) {
+	s := &HubServer{
+		logger: slog.Default(),
+		clusters: map[string]ClusterConfig{
+			"ghe":         {ID: "ghe", GitHubBaseURL: "https://ghe.example"},
+			"padded":      {ID: "padded", GitHubBaseURL: "\thttps://ghe.example \n"},
+			"no-base-url": {ID: "no-base-url"},
+		},
+	}
+	cases := []struct {
+		name      string
+		clusterID string
+		want      string
+	}{
+		{"known cluster returns its base URL", "ghe", "https://ghe.example"},
+		{"surrounding whitespace is trimmed", "padded", "https://ghe.example"},
+		{"declared but empty yields empty", "no-base-url", ""},
+		{"unknown cluster yields empty", "does-not-exist", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clusterBaseURLForIdentity(s, tc.clusterID); got != tc.want {
+				t.Errorf("clusterBaseURLForIdentity(%q) = %q, want %q", tc.clusterID, got, tc.want)
+			}
+		})
+	}
+}

--- a/v2/pkg/hub/login_count_backfill_test.go
+++ b/v2/pkg/hub/login_count_backfill_test.go
@@ -1,0 +1,57 @@
+package hub
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadSaaSUserBackfillsLoginCount covers the read-time backfill: a record
+// that predates the login counter (a real LastLogin but LoginCount 0) must load
+// as at least 1 login, so the stats card never shows the contradictory
+// "0 logins (last <date>)". A genuine count is never lowered, and a user who has
+// never logged in (no LastLogin) stays at 0.
+func TestLoadSaaSUserBackfillsLoginCount(t *testing.T) {
+	orig := saasUsersDir
+	saasUsersDir = filepath.Join(t.TempDir(), "users")
+	if err := os.MkdirAll(saasUsersDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { saasUsersDir = orig })
+
+	cases := []struct {
+		name      string
+		user      SaaSUser
+		wantCount int
+	}{
+		{
+			name:      "pre-counter user: last_login set, count 0 -> 1",
+			user:      SaaSUser{GitHubUsername: "gee4vee", LastLogin: "2026-07-30T18:10:00Z"},
+			wantCount: 1,
+		},
+		{
+			name:      "genuine count is preserved, never lowered",
+			user:      SaaSUser{GitHubUsername: "active", LastLogin: "2026-07-30T18:10:00Z", LoginCount: 42},
+			wantCount: 42,
+		},
+		{
+			name:      "never-logged-in user stays at 0",
+			user:      SaaSUser{GitHubUsername: "newbie"},
+			wantCount: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := saveSaaSUser(&tc.user); err != nil {
+				t.Fatal(err)
+			}
+			got := loadSaaSUser(tc.user.GitHubUsername)
+			if got == nil {
+				t.Fatal("loadSaaSUser returned nil")
+			}
+			if got.LoginCount != tc.wantCount {
+				t.Errorf("LoginCount = %d, want %d", got.LoginCount, tc.wantCount)
+			}
+		})
+	}
+}

--- a/v2/pkg/hub/pure_helpers_coverage_test.go
+++ b/v2/pkg/hub/pure_helpers_coverage_test.go
@@ -1,0 +1,63 @@
+package hub
+
+import "testing"
+
+// TestClusterGitHubConfigPure covers the nil cluster and the base-or-api mapping.
+func TestClusterGitHubConfigPure(t *testing.T) {
+	// nil → an empty config (no base/api/slug).
+	if got := clusterGitHubConfig(nil); got.BaseURL != "" || got.APIURL != "" || got.AppSlug != "" {
+		t.Errorf("nil cluster = %+v, want zero config", got)
+	}
+	c := &ClusterConfig{GitHubBaseURL: "", GitHubAPIURL: "https://github.ibm.com/api/v3", GitHubAppSlug: "kubestellar-hive-ghe"}
+	gh := clusterGitHubConfig(c)
+	if gh.APIURL != "https://github.ibm.com/api/v3" || gh.AppSlug != "kubestellar-hive-ghe" || gh.BaseURL != "" {
+		t.Errorf("mapping = %+v, want api_url + slug carried, base empty", gh)
+	}
+	// A GHE cluster recorded with only an api_url must still read as GHE.
+	if !gh.IsGHE() {
+		t.Error("api-only GHE cluster config must be GHE")
+	}
+}
+
+// TestHealthStatusOfPure covers all three branches of the classifier.
+func TestHealthStatusOfPure(t *testing.T) {
+	if got := healthStatusOf(nil); got != "unknown" {
+		t.Errorf("nil health = %q, want unknown", got)
+	}
+	if got := healthStatusOf(map[string]any{}); got != "unknown" {
+		t.Errorf("no status key = %q, want unknown", got)
+	}
+	if got := healthStatusOf(map[string]any{"status": ""}); got != "unknown" {
+		t.Errorf("empty status = %q, want unknown", got)
+	}
+	if got := healthStatusOf(map[string]any{"status": 42}); got != "unknown" {
+		t.Errorf("non-string status = %q, want unknown", got)
+	}
+	if got := healthStatusOf(map[string]any{"status": "degraded"}); got != "degraded" {
+		t.Errorf("status = %q, want degraded", got)
+	}
+}
+
+// TestNormalizeHiveForgePure covers the nil guard, a GHE-override hive (host set
+// + URL overrides cleared), a public hive (no change), and idempotence.
+func TestNormalizeHiveForgePure(t *testing.T) {
+	if normalizeHiveForge(nil, nil) {
+		t.Error("nil hive must report no change")
+	}
+	// GHE override on a hive: host gets set to the elected GHE host and the URL
+	// overrides are cleared.
+	h := &SaaSHive{GitHubBaseURL: "https://github.ibm.com", GitHubAPIURL: "https://github.ibm.com/api/v3"}
+	if !normalizeHiveForge(h, nil) {
+		t.Fatal("a GHE-override hive must report a change")
+	}
+	if h.GitHubHost != "github.ibm.com" {
+		t.Errorf("GitHubHost = %q, want github.ibm.com", h.GitHubHost)
+	}
+	if h.GitHubBaseURL != "" || h.GitHubAPIURL != "" {
+		t.Errorf("URL overrides not cleared: base=%q api=%q", h.GitHubBaseURL, h.GitHubAPIURL)
+	}
+	// Second pass is idempotent — nothing left to change.
+	if normalizeHiveForge(h, nil) {
+		t.Error("normalizeHiveForge must be idempotent on a settled hive")
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -847,6 +847,15 @@ type ClusterHealthNode struct {
 // hives; pods in these namespaces identify hives running on a node.
 const hiveHostedNamespacePrefix = "hive-hosted-"
 
+// hostedAvailableIDPrefix is the ID prefix a pre-provisioned pool slot carries
+// while it is unclaimed inventory (e.g. "hosted-available-oke-01-placeholder-bb95").
+// It is the RegistryEntry-side marker for an available placeholder: unlike
+// MyHiveEntry, RegistryEntry has no ProvStatus field, so the ID prefix (paired
+// with the "available-" org prefix, placeholderOrgPrefix) is the reliable signal
+// that a slot is idle inventory rather than a claimed hive. A claimed hive keeps
+// neither marker.
+const hostedAvailableIDPrefix = "hosted-available-"
+
 type ClusterHealthSummary struct {
 	TotalNodes    int `json:"total_nodes"`
 	TotalCPUCores int `json:"total_cpu_cores"`

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -440,6 +440,16 @@ func loadSaaSUser(username string) *SaaSUser {
 	if u.Hives == nil {
 		u.Hives = make(map[string]string)
 	}
+	// Backfill LoginCount for records that predate the login counter (added with
+	// the admin engagement card). Those users have a real LastLogin but a zero
+	// LoginCount, which renders as the contradictory "0 logins (last <date>)" on
+	// the stats card. A user who has logged in at least once is, at minimum, one
+	// login — so a present LastLogin with a zero count normalizes to 1. This is a
+	// read-time floor only; the real counter keeps incrementing from here on the
+	// next OAuth login (handleOAuthCallback), and it never lowers a genuine count.
+	if u.LoginCount == 0 && strings.TrimSpace(u.LastLogin) != "" {
+		u.LoginCount = 1
+	}
 	return &u
 }
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -5560,8 +5560,10 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Rewrite the placeholder's meta.json to the requesting user's real project.
-	// Clearing status makes it show under the new owner in My Hives; the project
-	// config reaches the spoke via the heartbeat channel (projectConfigForHiveID).
+	// Flipping status to statusAssigned makes it show under the new owner in My
+	// Hives AND marks it as no-longer-available for the fleet counters; the
+	// project config reaches the spoke via the heartbeat channel
+	// (projectConfigForHiveID).
 	h.Owner = targetUsername
 	h.Org = pr.Org
 	h.Repos = repos
@@ -5588,7 +5590,7 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 	// must re-arm on (re)assignment for exactly the same reason ACMMDelivered
 	// does above. (The assign path — handleAssignHive — already does this.)
 	h.ClaimDelivered = false
-	h.Status = ""
+	h.Status = statusAssigned
 	h.Error = ""
 	// Preserve the placeholder's real cluster before ANY cluster-derived
 	// resolution below (host backfill uses s.clusterForHive(h), which silently
@@ -6398,7 +6400,7 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	h.RequestedACMMLevel = acmm
 	h.ACMMDelivered = false
 	h.IsPublic = body.IsPublic
-	h.Status = ""
+	h.Status = statusAssigned
 	h.Error = ""
 	// A (re)assignment is a new claim payload: reset delivery so the hub pushes
 	// this project to the spoke until it reports the new org/repos back, before

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -212,6 +212,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	// requireAuth plus an inner owner-or-admin check, exactly like
 	// switch-branch and auto-upgrade above.
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/forge", s.requireAuth(s.handleSwitchForge))
+	s.mux.HandleFunc("POST /api/saas/hives/{id}/reset-app", s.requireAuth(s.handleResetApp))
 	s.mux.HandleFunc("GET /api/saas/hive-config/{hiveID}", s.requireAuth(s.handleProxyHiveConfig))
 	s.mux.HandleFunc("GET /api/saas/latest-sha", s.handleLatestSHA)
 	s.mux.HandleFunc("POST /api/saas/hub/upgrade", s.requireAdmin(s.handleHubSelfUpgrade))
@@ -11335,6 +11336,13 @@ const dashboardHTML = `<!DOCTYPE html>
         if (isHosted && (h.role === 'owner' || _isAdmin)) menuItems.push('<div onclick="openTimelineModal(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">Activity Timeline</div>');
         if (h.role === 'owner' || h.role === 'read-write' || _isAdmin) menuItems.push('<div onclick="openOpenRouterFundModal(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">⚡ Fund with OpenRouter</div>');
         if (_isAdmin && isHosted) menuItems.push('<div onclick="openBannerForHive(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">Send Banner</div>');
+        /* Reset App clears ONLY the spoke's installation_id, which makes
+           HasUsableApp() false and prompts the owner to install the App again.
+           Admin-only and hosted-only, matching the endpoint's own guard. The
+           case it exists for: a hive provisioned with its own GitHub App keeps
+           that App's installation_id after its identity is moved to the fleet
+           App, so every field reads correct while freshly minted tokens 404. */
+        if (_isAdmin && isHosted) menuItems.push('<div onclick="resetHiveApp(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">Reset App</div>');
         if (isLocal && h.role === 'owner') menuItems.push('<div onclick="removeLocalHive(\'' + esc(h.id) + '\')" style="' + mi + '">Remove</div>');
         if (isHosted && h.role === 'owner' && _clusterList && _clusterList.length > 1 && h.migrationStatus !== 'migrating') menuItems.push('<div onclick="openMigrateModal(\'' + esc(h.id) + '\',\'' + esc(h.clusterId || '') + '\')" style="' + mi + '">Move to cluster</div>');
         if (isHosted && h.role === 'owner') menuItems.push('<div style="border-top:1px solid #30363d;margin:4px 0"></div><div onclick="deleteHive(\'' + esc(h.id) + '\')" style="' + mi + ';color:#f85149">Delete</div>');
@@ -12208,6 +12216,23 @@ const dashboardHTML = `<!DOCTYPE html>
     }
 
     var _switchTimers = {};
+    /* Reset App: clears the spoke's installation_id so the owner is prompted
+       to install the GitHub App again. Confirmed first because it costs the
+       owner a re-install, and the reset is delivered on the spoke's next
+       heartbeat rather than immediately. */
+    async function resetHiveApp(hiveId, hiveName) {
+      if (!confirm('Reset the GitHub App for "' + hiveName + '"?\n\nThe spoke clears its installation ID on the next heartbeat and the owner is prompted to install the App again. The App ID, slug and key are left alone.')) return;
+      try {
+        var resp = await fetch('/api/saas/hives/' + encodeURIComponent(hiveId) + '/reset-app', {method: 'POST'});
+        var data = await resp.json().catch(function() { return {}; });
+        if (!resp.ok) { alert('Reset failed: ' + (data.error || resp.status)); return; }
+        alert('App reset armed for "' + hiveName + '".\n\nThe spoke clears its installation on the next heartbeat (~30s), then shows the install prompt.');
+        if (typeof loadHives === 'function') loadHives();
+      } catch (e) {
+        alert('Reset failed: ' + e);
+      }
+    }
+
     function switchBranch(hiveId, newBranch, el) {
       if (el) el.closest('[id^="branch-menu-"]').style.display = 'none';
       if (_switchTimers[hiveId]) {

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4542,6 +4542,14 @@ type HiveAccessEntry struct {
 	FullName string `json:"full_name,omitempty"`
 	SlackID  string `json:"slack_id,omitempty"`
 	Notes    string `json:"notes,omitempty"`
+	// Engagement stats copied from the user's record so a co-member's My-Hives
+	// avatar hover can show the same logins / time-in-hive the admin Users card
+	// shows. Like Notes these are stats ABOUT a person, so they ride ONLY for a
+	// hub admin (accessForHive's includeAdminOnly gate) — a non-admin owner sees
+	// name/Slack but not another member's engagement numbers. omitempty so a user
+	// with no stats round-trips as today's handle — role tooltip.
+	LoginCount     int   `json:"login_count,omitempty"`
+	SessionSeconds int64 `json:"session_seconds,omitempty"`
 }
 
 // accessForHive returns who can sign in to a hive, newest-role-agnostic and
@@ -4549,10 +4557,11 @@ type HiveAccessEntry struct {
 // than reading h.Owner: a user's Hives map is the authoritative grant (see
 // handleApproveProvision / handleAssignHive, which write it), and an owner who
 // is missing from it genuinely cannot sign in.
-// includeNotes controls whether the admin-maintained Notes field is copied onto
-// each entry: pass true ONLY for a hub admin. FullName/SlackID always ride (they
-// identify the person to a co-owner); Notes is private admin CRM text.
-func accessForHive(hiveID string, users []SaaSUser, includeNotes bool) []HiveAccessEntry {
+// includeAdminOnly controls whether the admin-only fields — the CRM Notes and
+// the engagement stats (LoginCount/SessionSeconds) — are copied onto each entry:
+// pass true ONLY for a hub admin. FullName/SlackID always ride (they identify the
+// person to a co-owner); Notes and the stats are private to admins.
+func accessForHive(hiveID string, users []SaaSUser, includeAdminOnly bool) []HiveAccessEntry {
 	access := make([]HiveAccessEntry, 0)
 	for _, u := range users {
 		if role, ok := u.Hives[hiveID]; ok {
@@ -4562,8 +4571,10 @@ func accessForHive(hiveID string, users []SaaSUser, includeNotes bool) []HiveAcc
 				FullName: u.FullName,
 				SlackID:  u.SlackID,
 			}
-			if includeNotes {
+			if includeAdminOnly {
 				entry.Notes = u.Notes
+				entry.LoginCount = u.LoginCount
+				entry.SessionSeconds = u.SessionSeconds
 			}
 			access = append(access, entry)
 		}
@@ -7382,8 +7393,14 @@ const dashboardHTML = `<!DOCTYPE html>
     function avatarProfileLink(username, label, avatarHTML) {
       var uname = String(username || '');
       if (!uname) return avatarHTML;
+      // Fold "logged into their hive now" into the anchor's OWN tooltip for every
+      // avatar surface, so a live user's face reads identity (+ stats) AND the
+      // live state in one tooltip. The green ring wrapper deliberately carries no
+      // title of its own — a wrapper title would sit on top of this and hide it.
+      var title = label || uname;
+      if (isUserLive(uname)) title = title + '\n● Logged into their hive now';
       return '<a href="' + escAttr(ghProfileURL(uname)) + '" target="_blank" rel="noopener noreferrer" ' +
-        'title="' + escAttr(label || uname) + '" aria-label="' + escAttr(label || uname) + '" ' +
+        'title="' + escAttr(title) + '" aria-label="' + escAttr(label || uname) + '" ' +
         'style="display:inline-block;line-height:0;text-decoration:none">' + avatarHTML + '</a>';
     }
 
@@ -7409,11 +7426,17 @@ const dashboardHTML = `<!DOCTYPE html>
         (extraStyle || '') + '" ' +
         'onerror="this.style.visibility=\'hidden\'">';
       if (isUserLive(username)) {
-        // 3px green dashed ring hugging the circle. inline-flex wrapper keeps the
-        // face's vertical-align and sizing identical to the un-ringed case.
-        return '<span title="Logged into their hive now" ' +
-          'style="display:inline-flex;border-radius:50%;padding:1px;border:3px dashed var(--green);vertical-align:middle;line-height:0">' +
-          img + '</span>';
+        // Concentric green dashed ring. The wrapper is a fixed square exactly the
+        // face's size plus the ring gap+width on every side (px + 2*(gap+border)),
+        // with box-sizing:border-box and the ring drawn as its border, so the
+        // round border-radius stays perfectly centered on the round face — the
+        // earlier padding:1px inline-flex version drifted off-center. No title on
+        // the wrapper: the "logged in now" line lives in the face's OWN tooltip
+        // (accessAvatarTitle) so a wrapper title can't shadow the identity+stats.
+        var RING_GAP = 2, RING_W = 3, box = px + 2 * (RING_GAP + RING_W);
+        return '<span style="display:inline-block;box-sizing:border-box;width:' + box + 'px;height:' + box + 'px;' +
+          'padding:' + RING_GAP + 'px;border:' + RING_W + 'px dashed var(--green);border-radius:50%;' +
+          'vertical-align:middle;line-height:0">' + img + '</span>';
       }
       return img;
     }
@@ -7687,13 +7710,39 @@ const dashboardHTML = `<!DOCTYPE html>
        invariant. The server only populates these fields for owner/admin-visible
        rows and withholds notes from non-admins, so nothing here needs to re-gate
        them — a field that is absent simply produces no line. */
+    /* accessAvatarTitle builds the NATIVE multi-line tooltip for a co-member face.
+       It deliberately stays a title attribute (never a hive-access-pop custom
+       panel — see TestInlineAvatarsCarryNoCustomPanel; the status dot owns the
+       row's one panel). It carries the same engagement info the admin Users card
+       shows — identity, logins, time-in-hive, task activity, and the verdict — so
+       who-to-elevate/help reads on hover anywhere a face appears. The stat lines
+       are admin-only (accessForHive only fills login_count/session_seconds for an
+       admin) and each line is conditional, so a stat-less user degrades to today's
+       "handle — role". Newlines render as line breaks in a native title. */
     function accessAvatarTitle(a) {
       var uname = String(a.username || '');
       var role = String(a.role || '');
       var lines = [uname + (role ? ' — ' + role : '')];
+      // ("Logged into their hive now" is appended generically in avatarProfileLink
+      // for EVERY avatar surface, so it is not added here — doing both would
+      // double the line.)
       if (a.full_name) lines.push(String(a.full_name));
       if (a.slack_id) lines.push('Slack: ' + String(a.slack_id));
       if (a.notes) lines.push('Notes: ' + String(a.notes));
+      // Engagement stats (admin-only; absent → these lines are simply skipped).
+      if (a.login_count) lines.push('Logins: ' + a.login_count);
+      if (a.session_seconds) lines.push('Time in hive: ' + fmtHours(a.session_seconds));
+      var act = userTaskActivity(uname);
+      if (act.done || act.failed) lines.push('Tasks: ' + act.done + ' done / ' + act.failed + ' failed');
+      // The lifecycle verdict, from the same helper the admin card uses. It reads
+      // logins/time/tasks; a co-member's hive-journey list isn't on the access
+      // entry so pass empty — the verdict still classifies from engagement, only
+      // the ACMM-graduation refinement is unavailable here. Shown only when there
+      // is some signal to classify (any stat present), so a bare face stays bare.
+      if (a.login_count || a.session_seconds || act.done) {
+        var verdict = userVerdict({login_count: a.login_count || 0, session_seconds: a.session_seconds || 0}, act, []);
+        if (verdict && verdict.label) lines.push(verdict.label);
+      }
       return lines.join('\n');
     }
     function inlineAccessAvatar(a) {

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -100,11 +100,26 @@ const gpuClusterID = "vllm-d"
 
 // Placeholder-hive lifecycle status values. A pre-provisioned placeholder sits
 // at statusAvailable until an admin assigns it to a requesting user, at which
-// point its status is cleared (empty) and it behaves like any owned hive.
+// point its status flips to statusAssigned and it behaves like any owned hive.
 const (
 	// statusAvailable marks a pre-provisioned placeholder hive that is idle and
 	// waiting to be claimed. Only such a hive may be assigned.
 	statusAvailable = "available"
+	// statusAssigned marks a placeholder that has been CLAIMED by a user. It is
+	// the authoritative "no longer available" signal.
+	//
+	// The claim paths (handleApproveProvision, handleAssignHive) previously set
+	// Status = "" here. That empty string is indistinguishable from "unknown",
+	// so every downstream availability check that keys off ProvStatus (the
+	// landing-page fleet tiles, computeFleetStats) fell back to the immutable
+	// "hosted-available-" ID prefix — which a claimed placeholder KEEPS forever
+	// — and mis-counted 22 claimed hives as still available (38 shown vs the
+	// true 17). Setting an explicit assigned status makes ProvStatus the single
+	// authoritative signal: a claimed hive reads provStatus!="available" without
+	// any prefix guessing. A live spoke later overwrites this with its real
+	// lifecycle status ("provisioning"/"running") on the next heartbeat; until
+	// then "assigned" is the correct, honest state.
+	statusAssigned = "assigned"
 )
 
 // ACMM level bounds for a claimed/assigned hive. The maturity model spans

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -493,6 +493,31 @@ type SaaSHive struct {
 	// stops for good and the spoke owns the value again. Both default to their
 	// zero values on every existing hive, so nothing is delivered to a hive
 	// nobody switched: the push is gated on a NON-EMPTY RequestedGitHubHost.
+	// RequestedAppReset asks the spoke to CLEAR its installation_id, so the
+	// hive falls back to "App not installed" and prompts the owner to install
+	// it again.
+	//
+	// WHY THIS NEEDS ITS OWN FIELD RATHER THAN JUST PUSHING ZERO
+	//
+	// The wire cannot express a clear. The spoke adopts a pushed installation
+	// only when it is non-zero (cmd/hive: `if ghCfg.InstallationID != 0`),
+	// deliberately — zero means "the hub is not speaking to this field", and
+	// treating it as "blank it" once turned a key-only fault into a total auth
+	// outage. So a reset has to be a distinct instruction, not a value.
+	//
+	// It is a REQUEST, persisted on the hive record, because the operator's
+	// intent has to survive a missed beat and a hub restart. Cleared when the
+	// spoke reports installation_id 0 back — read-back confirmation, the same
+	// contract the forge switch uses.
+	//
+	// The live case: a hive provisioned with its OWN GitHub App kept that App's
+	// installation_id after its identity was later moved to the fleet's public
+	// App. app_id, app_slug and key_file all named the public App while the
+	// installation belonged to another, so every freshly minted token returned
+	// "404 Not Found" while cached ones kept working — 84 failures in three
+	// hours on one hive, with no config field visibly wrong.
+	RequestedAppReset bool `json:"requested_app_reset,omitempty"`
+
 	RequestedGitHubHost string `json:"requested_github_host,omitempty"`
 	// ForgeDelivered flips true once the spoke reports the requested forge host.
 	ForgeDelivered bool `json:"forge_delivered,omitempty"`

--- a/v2/pkg/hub/saas_user_contact_test.go
+++ b/v2/pkg/hub/saas_user_contact_test.go
@@ -318,8 +318,12 @@ func TestSaaSUserWithoutContactFieldsRoundTrips(t *testing.T) {
 			t.Errorf("re-saved legacy record contains %q; omitempty should have dropped it:\n%s", key, data)
 		}
 	}
-	// The round-tripped record must be byte-identical to the original, modulo
-	// the marshaller's formatting — compare the decoded maps to be precise.
+	// The round-tripped record must be byte-identical to the original EXCEPT for
+	// login_count: loadSaaSUser backfills it to 1 for any record with a last_login
+	// (the pre-counter backfill), so a legacy record that has logged in legitimately
+	// gains that one key on load. That is intended and is NOT a contact-field leak —
+	// drop it before the field-count compare, which exists to guard the contact
+	// fields (full_name/slack_id/notes) don't persist.
 	var before, after map[string]any
 	if err := json.Unmarshal([]byte(legacy), &before); err != nil {
 		t.Fatalf("unmarshal before: %v", err)
@@ -327,6 +331,7 @@ func TestSaaSUserWithoutContactFieldsRoundTrips(t *testing.T) {
 	if err := json.Unmarshal(data, &after); err != nil {
 		t.Fatalf("unmarshal after: %v", err)
 	}
+	delete(after, "login_count")
 	if len(before) != len(after) {
 		t.Errorf("field count changed: before %d keys, after %d keys (%v vs %v)", len(before), len(after), before, after)
 	}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1888,11 +1888,21 @@ func (s *HubServer) computeFleetStats() FleetStats {
 	repoSet := make(map[string]struct{})
 	for _, h := range s.registry.Hives {
 		// An UNASSIGNED hive is a pre-provisioned placeholder nobody has claimed
-		// yet — it carries no project, so its Org is empty (a claimed hive always
-		// has one). It is counted as AVAILABLE and excluded from the assigned
-		// totals below: "hives up / total" and the contribution sums are about the
+		// yet. It is counted as AVAILABLE and excluded from the assigned totals
+		// below: "hives up / total" and the contribution sums are about the
 		// working fleet, not idle inventory a user could still request.
-		if h.Org == "" {
+		//
+		// A placeholder is NOT detectable by an empty Org: an unclaimed slot
+		// keeps its "hosted-available-" ID prefix and frequently a leftover pool
+		// org (live example: id="hosted-available-oke-01-placeholder-bb95",
+		// org="TradingAsBuddies"). Testing Org=="" therefore matched zero
+		// placeholders AND counted every one as assigned, inflating total_hives
+		// and hives-up. Detect it the way the rest of the codebase does — see
+		// isPlaceholderEntry in drift.go, which uses ProvStatus=="available"
+		// (authoritative) with the "available-" org prefix as fallback. RegistryEntry
+		// has no ProvStatus, so here we use the two markers it does carry: the
+		// "hosted-available-" ID prefix or the "available-" org prefix.
+		if strings.HasPrefix(h.ID, hostedAvailableIDPrefix) || strings.HasPrefix(h.Org, placeholderOrgPrefix) {
 			fs.AvailableHives++
 			continue
 		}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1895,17 +1895,25 @@ const fleetStatsMaxAge = 6 * time.Hour
 
 // isAvailableRegistryEntry reports whether a registry entry is a genuinely
 // unclaimed pool placeholder — the "available"/"unassigned" bucket on the
-// landing page and dashboard. It mirrors isPlaceholderEntry (drift.go) exactly:
-// ProvStatus==statusAvailable is AUTHORITATIVE, and the "hosted-available-" ID
-// prefix / "available-" org prefix are only a FALLBACK for entries whose
-// ProvStatus is unknown (empty). A CLAIMED placeholder keeps its
-// "hosted-available-" ID after assignment, so gating on the prefix alone
-// over-counts available hives; gating on ProvStatus first fixes that.
+// landing page and dashboard. It mirrors the frontend's isPlaceholderHive and
+// drift.go's isPlaceholderEntry EXACTLY:
+//
+//	provStatus == "available"  OR  org has the "available-" prefix
+//
+// The "hosted-available-" ID prefix is deliberately NOT consulted. A claimed
+// placeholder KEEPS that ID forever (it is minted at pool-creation time and
+// never rewritten on assignment), so an ID-prefix fallback counted every
+// claimed placeholder as still available — 38 reported vs the true 17. The
+// claim paths rewrite the org OFF the "available-" prefix and now set an
+// explicit statusAssigned, so both remaining signals flip correctly on claim.
+// Keeping this in lockstep with the JS and drift.go is what lets the landing
+// tiles, the dashboard's Assigned/Unassigned split, and server-side drift never
+// disagree about what is claimed.
 func isAvailableRegistryEntry(h RegistryEntry) bool {
-	if h.ProvStatus != "" {
-		return h.ProvStatus == statusAvailable
+	if h.ProvStatus == statusAvailable {
+		return true
 	}
-	return strings.HasPrefix(h.ID, hostedAvailableIDPrefix) || strings.HasPrefix(h.Org, placeholderOrgPrefix)
+	return strings.HasPrefix(h.Org, placeholderOrgPrefix)
 }
 
 // computeFleetStats aggregates fleet-wide contribution counts across public,

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -111,29 +111,42 @@ type RegistryEntry struct {
 	// AdvisoryError is the log-safe error from the spoke's most recent failed
 	// advisory-post attempt ("" on success). When set on an app-can-write hive
 	// it trips the stale pill directly, carrying the specific cause.
-	AdvisoryError      string         `json:"advisoryError,omitempty"`
-	PrimaryRepo        string         `json:"primaryRepo"`
-	DashboardURL       string         `json:"dashboardUrl"`
-	SnapshotURL        string         `json:"snapshotUrl,omitempty"`
-	ACMMLevel          int            `json:"acmmLevel"`
-	AgentCount         int            `json:"agentCount"`
-	GovernorMode       string         `json:"governorMode"`
-	TotalTokens24h     int64          `json:"totalTokens24h"`
-	ActionableIssues   int            `json:"actionableIssues"`
-	ActionablePRs      int            `json:"actionablePRs"`
-	ContributorCount   int            `json:"contributorCount"`
-	ActiveContributors int            `json:"activeContributors"`
-	Owner              string         `json:"owner,omitempty"`
-	ClusterID          string         `json:"clusterId,omitempty"`
-	ClusterName        string         `json:"clusterName,omitempty"`
-	HiveType           string         `json:"hiveType,omitempty"`
-	IsPublic           bool           `json:"isPublic"`
-	RegisteredAt       string         `json:"registeredAt"`
-	LastHeartbeat      string         `json:"lastHeartbeat"`
-	Health             map[string]any `json:"health"`
-	Version            string         `json:"version"`
-	GitHash            string         `json:"gitHash,omitempty"`
-	GitBranch          string         `json:"gitBranch,omitempty"`
+	AdvisoryError      string `json:"advisoryError,omitempty"`
+	PrimaryRepo        string `json:"primaryRepo"`
+	DashboardURL       string `json:"dashboardUrl"`
+	SnapshotURL        string `json:"snapshotUrl,omitempty"`
+	ACMMLevel          int    `json:"acmmLevel"`
+	AgentCount         int    `json:"agentCount"`
+	GovernorMode       string `json:"governorMode"`
+	TotalTokens24h     int64  `json:"totalTokens24h"`
+	ActionableIssues   int    `json:"actionableIssues"`
+	ActionablePRs      int    `json:"actionablePRs"`
+	ContributorCount   int    `json:"contributorCount"`
+	ActiveContributors int    `json:"activeContributors"`
+	Owner              string `json:"owner,omitempty"`
+	ClusterID          string `json:"clusterId,omitempty"`
+	ClusterName        string `json:"clusterName,omitempty"`
+	HiveType           string `json:"hiveType,omitempty"`
+	// ProvStatus is the authoritative provisioning status copied from the hive's
+	// SaaSHive record (sh.Status) on the heartbeat path — statusAvailable
+	// ("available") for a genuinely-unclaimed pool placeholder, else a claimed
+	// status ("claimed", "assigned", …) or "" for a hive with no SaaSHive record.
+	//
+	// It exists because a CLAIMED placeholder KEEPS its "hosted-available-" ID and
+	// leftover pool org after assignment (the ID is minted at pool creation and
+	// never changes on claim), so the ID/org prefix alone OVER-counts available
+	// hives. computeFleetStats and isPlaceholderEntry both treat this field as
+	// authoritative, with the prefix used only as a fallback when it is empty, so
+	// the landing-page count and the dashboard's Assigned/Unassigned sections
+	// agree on what "available" means. A scalar status — no PII.
+	ProvStatus    string         `json:"provStatus,omitempty"`
+	IsPublic      bool           `json:"isPublic"`
+	RegisteredAt  string         `json:"registeredAt"`
+	LastHeartbeat string         `json:"lastHeartbeat"`
+	Health        map[string]any `json:"health"`
+	Version       string         `json:"version"`
+	GitHash       string         `json:"gitHash,omitempty"`
+	GitBranch     string         `json:"gitBranch,omitempty"`
 	// ImageRef is the container image this spoke's own Deployment runs, as
 	// read in-cluster by the spoke and reported over the heartbeat. The hub
 	// cannot see it any other way for firewalled/heartbeat-only spokes, and
@@ -1071,10 +1084,15 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		AgentsWithModel: clampFleetCount(payload.AgentsWithModel),
 	}
 
-	// Populate ClusterID from SaaS hive record, heartbeat payload, or default.
+	// Populate ClusterID and the authoritative ProvStatus from the SaaS hive
+	// record (a single load reused for both). ProvStatus is what lets
+	// computeFleetStats tell a genuinely-unclaimed placeholder (statusAvailable)
+	// from a CLAIMED one that still carries the "hosted-available-" ID — the ID
+	// prefix alone over-counts available hives because it never changes on claim.
 	clusterID := ""
 	if sh := loadSaaSHive(payload.HiveID); sh != nil {
 		clusterID = sh.ClusterID
+		entry.ProvStatus = sh.Status
 	}
 	if clusterID == "" && payload.ClusterID != "" {
 		clusterID = sanitizeHeartbeatField(payload.ClusterID)
@@ -1875,6 +1893,21 @@ type FleetStats struct {
 // rather than freezing a stale figure on the public page forever.
 const fleetStatsMaxAge = 6 * time.Hour
 
+// isAvailableRegistryEntry reports whether a registry entry is a genuinely
+// unclaimed pool placeholder — the "available"/"unassigned" bucket on the
+// landing page and dashboard. It mirrors isPlaceholderEntry (drift.go) exactly:
+// ProvStatus==statusAvailable is AUTHORITATIVE, and the "hosted-available-" ID
+// prefix / "available-" org prefix are only a FALLBACK for entries whose
+// ProvStatus is unknown (empty). A CLAIMED placeholder keeps its
+// "hosted-available-" ID after assignment, so gating on the prefix alone
+// over-counts available hives; gating on ProvStatus first fixes that.
+func isAvailableRegistryEntry(h RegistryEntry) bool {
+	if h.ProvStatus != "" {
+		return h.ProvStatus == statusAvailable
+	}
+	return strings.HasPrefix(h.ID, hostedAvailableIDPrefix) || strings.HasPrefix(h.Org, placeholderOrgPrefix)
+}
+
 // computeFleetStats aggregates fleet-wide contribution counts across public,
 // non-stale hives. A hive that never reported a given count (nil pointer) is
 // skipped for that count — the aggregate reflects only hives with real data,
@@ -1896,13 +1929,22 @@ func (s *HubServer) computeFleetStats() FleetStats {
 		// keeps its "hosted-available-" ID prefix and frequently a leftover pool
 		// org (live example: id="hosted-available-oke-01-placeholder-bb95",
 		// org="TradingAsBuddies"). Testing Org=="" therefore matched zero
-		// placeholders AND counted every one as assigned, inflating total_hives
-		// and hives-up. Detect it the way the rest of the codebase does — see
-		// isPlaceholderEntry in drift.go, which uses ProvStatus=="available"
-		// (authoritative) with the "available-" org prefix as fallback. RegistryEntry
-		// has no ProvStatus, so here we use the two markers it does carry: the
-		// "hosted-available-" ID prefix or the "available-" org prefix.
-		if strings.HasPrefix(h.ID, hostedAvailableIDPrefix) || strings.HasPrefix(h.Org, placeholderOrgPrefix) {
+		// placeholders AND counted every one as assigned.
+		//
+		// The ID/org PREFIX alone over-counts the other way: a CLAIMED placeholder
+		// KEEPS its "hosted-available-" ID and pool org after assignment (the ID is
+		// minted at pool creation and never changes on claim). ~21 of the 38
+		// "hosted-available-" hives are actually claimed, so the prefix reported 38
+		// "available" when the truth is 17 unclaimed / 33 assigned.
+		//
+		// Detect it the way the rest of the codebase does — see isPlaceholderEntry
+		// in drift.go and the dashboard's Assigned/Unassigned sections: the
+		// authoritative signal is ProvStatus==statusAvailable, with the
+		// "hosted-available-" ID prefix / "available-" org prefix used ONLY as a
+		// fallback when ProvStatus is unknown (empty — a hive with no SaaSHive
+		// record or one that predates the field). A claimed placeholder therefore
+		// counts as ASSIGNED, not available.
+		if isAvailableRegistryEntry(h) {
 			fs.AvailableHives++
 			continue
 		}

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -371,6 +371,8 @@
       transition: border-color .15s ease, background .15s ease;
     }
     .metric-grid a.stat-jump:hover { border-color: var(--green); background: #0b1016; }
+    /* Muted call-to-action subtext inside a stat tile (e.g. "click to request one"). */
+    .metric-grid a.stat-jump .stat-cta { color: var(--muted); font-size: .7rem; }
 
     /* ── Loop rail ── */
     .loop { background: linear-gradient(#0c121900, #121922bf 30%, #12192200); }
@@ -690,7 +692,12 @@
         <div class="metric-grid">
           <div><span>Agents running</span><strong id="stat-agents">—</strong></div>
           <div><span>Managed repos</span><strong id="stat-repos">—</strong></div>
-          <div><span>Contributors</span><strong id="stat-contributors">—</strong></div>
+          <!-- The Contributors tile links to the "Contribute compute to a hive"
+               card (#contribute-compute), which explains how contributing works:
+               you lend your AI CLI to run agents for a public hive via ClankeR
+               and climb the leaderboard. Same stat-jump affordance/keyboard
+               access as the Public hives tile. -->
+          <a href="#contribute-compute" class="stat-jump" title="Learn how to contribute compute"><span>Contributors</span><strong id="stat-contributors">—</strong></a>
           <!-- The Public hives tile jumps to the public-hive table below (#hives),
                since that table IS the list of public hives this count describes.
                An <a> (not a JS scroll handler) keeps it keyboard-focusable and
@@ -701,7 +708,7 @@
                tile links to the Request-a-Hive wizard (/get-started), so seeing
                "N available" and acting on it is one click. Anchor for the same
                keyboard/right-click reasons as the Public hives tile. -->
-          <a href="/get-started" class="stat-jump" title="Request one of the available hives"><span>Available hives</span><strong id="stat-available">—</strong></a>
+          <a href="/get-started" class="stat-jump" title="Request one of the available hives"><span>Available hives</span><strong id="stat-available">—</strong><span class="stat-cta">click to request one</span></a>
         </div>
       </div>
     </section>
@@ -881,10 +888,10 @@
           <div style="margin-top:1rem"><a class="button primary" href="/get-started">Request a Hive</a></div>
           <p style="font-size:.8rem;margin-top:.8rem"><a href="/get-started#self-host" style="color:var(--blue)">Prefer to self-host? →</a></p>
         </div>
-        <div class="proof-card">
+        <div class="proof-card" id="contribute-compute">
           <div class="tag">Community</div>
           <h3>Contribute compute to a hive</h3>
-          <p>Lend your AI CLI to run agents for a public project. Earn trust tiers as you complete tasks and climb the leaderboard.</p>
+          <p>Lend your AI CLI to run agents for a public project via ClankeR, the contributor relay. Pick a public hive from the table below, run the contribute command, and ClankeR hands your CLI tasks to work &mdash; your GitHub username shows up as a live contributor on that hive with the PRs you land, not as a new hive. Earn trust tiers as you complete tasks and climb the leaderboard.</p>
           <div style="margin-top:1rem"><a class="button secondary" href="/get-started#contribute">Start contributing</a></div>
         </div>
         <div class="proof-card">
@@ -984,6 +991,9 @@
         <h2>Active Hives</h2>
         <input type="text" id="hive-search" placeholder="Search hives..." oninput="filterHiveTable()" style="padding:8px 14px;background:var(--bg-soft);border:1px solid var(--line);border-radius:6px;color:var(--text);font-size:0.85rem;width:250px">
       </div>
+      <!-- Contribute blurb: the Contributors tile and the "Contribute compute"
+           card both point here, so name the action next to the list it refers to. -->
+      <p style="color:var(--muted);font-size:.85rem;margin:-4px 0 14px;max-width:60ch">Want to help? Pick a public hive below and lend your AI CLI to run its agents through ClankeR &mdash; <a href="/get-started#contribute" style="color:var(--blue)">start contributing</a>. Your work shows up as tasks completed under your GitHub username on that hive and on the leaderboard.</p>
       <div id="hive-table-container"><div class="loading">Loading hives...</div></div>
     </section>
 

--- a/v2/pkg/hub/user_stats_card_test.go
+++ b/v2/pkg/hub/user_stats_card_test.go
@@ -71,7 +71,7 @@ func TestUserStatsCardNoTitleOnWrapper(t *testing.T) {
 // in handleOAuthCallback.
 func TestLoginCountNotIncrementedByEnsure(t *testing.T) {
 	useTempUserDir(t)
-	// First call creates the record.
+	// First call creates a fresh record — no prior login, so LoginCount 0.
 	u := ensureSaaSUser("counter-user")
 	if u == nil {
 		t.Fatal("ensureSaaSUser returned nil")
@@ -79,11 +79,15 @@ func TestLoginCountNotIncrementedByEnsure(t *testing.T) {
 	if u.LoginCount != 0 {
 		t.Fatalf("a freshly ensured user must have LoginCount 0, got %d", u.LoginCount)
 	}
-	// Subsequent ensures (the my-hives poll path) must not bump it.
+	// The KEY guarantee: ensureSaaSUser never INCREMENTS the counter (only
+	// handleOAuthCallback does). The load-time backfill floors a record that has
+	// a last_login to 1, so after the first ensure the count settles at 1 — and
+	// crucially STAYS at 1 across any number of poll-path ensures, never climbing.
+	// (If ensure were wrongly incrementing, this would march 2,3,4,…)
 	for i := 0; i < 5; i++ {
 		ensureSaaSUser("counter-user")
 	}
-	if got := loadSaaSUser("counter-user").LoginCount; got != 0 {
-		t.Errorf("ensureSaaSUser must never increment LoginCount, got %d after 6 calls", got)
+	if got := loadSaaSUser("counter-user").LoginCount; got != 1 {
+		t.Errorf("LoginCount must settle at the backfill floor of 1 and never climb, got %d after 6 ensures", got)
 	}
 }


### PR DESCRIPTION
Propagates latest v2 (incl. #2425 fleet-count fix, #2424 rename, #2423 repo-add-form, #2426 Reset App, and all today's merges) into mk. Clean merge, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)