### PR TITLE
🎨 dashboard: stack combined table headers (title over sort chips) to narrow the fleet table

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -10429,6 +10429,33 @@ const dashboardHTML = `<!DOCTYPE html>
         (titleRaw ? ' title="' + titleRaw + '"' : '') + '>' + label + '</span>';
     }
 
+    /* stackHeader lays a combined column's header out on TWO lines instead of one
+       inline string: the title on line 1, its sub-sort ⇅ chips on line 2. The
+       inline form ("Uptime ⇅ Prov ⇅", "Activity Iss ⇅ PRs ⇅ Ctr ⇅") set each
+       folded column's width from the full concatenated string, which made the
+       fleet table far wider than it needed to be. Stacking makes the column width
+       track the widest SINGLE line instead.
+
+       .hive-table th sets white-space:nowrap, which would keep everything on one
+       line; a flex column overrides that for layout, and the chip row is allowed
+       to wrap (flex-wrap) so three chips fold onto a further line on a truly
+       narrow table rather than forcing the column wide. Colours come from the
+       existing --muted token and the inherited th colour, so both themes track.
+
+       titleHTML    — the line-1 content. May be plain text (e.g. 'Maturity') or
+                      an already-built clickable span; inserted VERBATIM, callers
+                      pass trusted markup only.
+       subSortsHTML — the line-2 content: one or more subSort() spans (each already
+                      carries its own onclick + event.stopPropagation()). Passed
+                      through unchanged, so every folded sort stays reachable and
+                      the stopPropagation contract is untouched. */
+    function stackHeader(titleHTML, subSortsHTML) {
+      return '<span style="display:inline-flex;flex-direction:column;align-items:center;gap:1px;line-height:1.15">' +
+        '<span style="white-space:nowrap">' + titleHTML + '</span>' +
+        '<span style="display:inline-flex;flex-wrap:wrap;justify-content:center;gap:2px;font-size:0.9em;color:var(--muted)">' +
+        subSortsHTML + '</span></span>';
+    }
+
     /* persistHiveSort records the operator's EXPLICIT sort choice. Written only
        from sortDashHives (a header click), never from loadHiveSortPrefs, so
        restoring a preference can't rewrite it and a first visit leaves the key
@@ -11830,18 +11857,18 @@ const dashboardHTML = `<!DOCTYPE html>
            sort keys, so each key gets its own inline clickable span. subSort() is
            the shared helper; every folded sort therefore stays reachable directly
            from the header, exactly as the standalone columns were. */
-        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer" title="Where this hive runs, and whether it is listed publicly">Location / Public ⇅</th>' +
+        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer;vertical-align:middle" title="Where this hive runs, and whether it is listed publicly">' + stackHeader('Location /', 'Public ⇅') + '</th>' +
         /* Uptime hosts BOTH temporal sorts: live uptime (startedAt) and the folded
            provision-date sort (registeredAt, the old "Prov ⇅"). The date itself now
            lives in the status hover; only its sort trigger rides here. */
-        '<th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅ ' + subSort('registeredAt', 'Prov ⇅', 'Sort by when this hive was first provisioned (the hub&apos;s first-seen time). The date itself now lives in the status hover.') + '</th>' +
+        '<th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer;vertical-align:middle" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">' + stackHeader('Uptime ⇅', subSort('registeredAt', 'Prov ⇅', 'Sort by when this hive was first provisioned (the hub&apos;s first-seen time). The date itself now lives in the status hover.')) + '</th>' +
         '<th title="Version, branch and any configuration drift from the fleet norm — a coloured dot appears beside the commit when this hive drifts; hover it for the specific signals">Version</th><th>Repos</th>' +
         /* MATURITY folds ACMM (where it is) and Journey (what it owes next); both
            sorts survive as inline ⇅ controls. */
-        '<th title="Adoption maturity: ACMM level and the next journey step">Maturity ' + subSort('acmmLevel', 'ACMM ⇅', 'Sort by ACMM level') + ' ' + subSort('journey', 'Journey ⇅', 'Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run ClankeR, the contributor relay), then raise the ACMM level') + '</th>' +
+        '<th style="vertical-align:middle" title="Adoption maturity: ACMM level and the next journey step">' + stackHeader('Maturity', subSort('acmmLevel', 'ACMM ⇅', 'Sort by ACMM level') + subSort('journey', 'Journey ⇅', 'Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run ClankeR, the contributor relay), then raise the ACMM level')) + '</th>' +
         '<th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th>' +
         /* ACTIVITY folds Issues, PRs and Contrib; each keeps its own sort ⇅. */
-        '<th title="Actionable issues, actionable PRs and active contributors">Activity ' + subSort('actionableIssues', 'Iss ⇅', 'Sort by actionable issues') + ' ' + subSort('actionablePRs', 'PRs ⇅', 'Sort by actionable PRs') + ' ' + subSort('activeContributors', 'Ctr ⇅', 'Sort by active contributors') + '</th>' +
+        '<th style="vertical-align:middle" title="Actionable issues, actionable PRs and active contributors">' + stackHeader('Activity', subSort('actionableIssues', 'Iss ⇅', 'Sort by actionable issues') + subSort('actionablePRs', 'PRs ⇅', 'Sort by actionable PRs') + subSort('activeContributors', 'Ctr ⇅', 'Sort by active contributors')) + '</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table></div>';
       /* Delegated, so binding once is enough no matter how often the table is
          re-rendered. The guard keeps repeated renders from stacking listeners. */

--- a/v2/pkg/hub/saas_dashboard_facet_tray_test.go
+++ b/v2/pkg/hub/saas_dashboard_facet_tray_test.go
@@ -424,8 +424,15 @@ func TestDriftFoldedIntoVersion(t *testing.T) {
 	if n := strings.Count(header, ">Version<"); n != 1 {
 		t.Errorf("Version header appears %d times, want 1", n)
 	}
-	if !strings.Contains(header, ">Maturity ") {
-		t.Error("Maturity header cell is missing — ACMM and Journey were meant to fold into it")
+	// The Maturity header is now stacked (title on line 1, the ACMM/Journey sort
+	// chips on line 2) via stackHeader, so the source builds it as
+	// stackHeader('Maturity', ...) rather than the old inline "Maturity " prefix.
+	// Both folded sort controls must still be reachable in the header.
+	if !strings.Contains(header, "stackHeader('Maturity'") {
+		t.Error("Maturity header title is missing — ACMM and Journey were meant to fold into it")
+	}
+	if !strings.Contains(header, "subSort('acmmLevel', 'ACMM ⇅'") || !strings.Contains(header, "subSort('journey', 'Journey ⇅'") {
+		t.Error("the Maturity header dropped a folded sort control — both ACMM and Journey ⇅ must stay reachable")
 	}
 	if !strings.Contains(body, "acmmBadge(h.acmmLevel)") || !strings.Contains(body, "journeyBadge(h.journey)") {
 		t.Error("the Maturity cell must render BOTH acmmBadge and journeyBadge — no maturity datum may be dropped")


### PR DESCRIPTION
## What

Narrows the hub fleet spoke table by **stacking** the combined column headers vertically: the column title on line 1, and its sub-sort `⇅` chips wrapped onto a tight row below it. Builds directly on the 15→9 column fold (#2429).

## Why

After the fold, the combined headers rendered their title + sub-sort chips all on ONE inline line, so the column width was driven by the full concatenated string:

- `Uptime ⇅ Prov ⇅`
- `Maturity ACMM ⇅ Journey ⇅`
- `Activity Iss ⇅ PRs ⇅ Ctr ⇅`
- `Location / Public ⇅`

These made those columns unnecessarily wide. Stacking makes each column's width track the widest **single** line instead of the full inline string.

## How

- New `stackHeader(titleHTML, subSortsHTML)` helper renders a two-line header cell: title on line 1 (`white-space:nowrap`), and the sub-sort chips on line 2 in a `flex-wrap` row with a reduced font-size (`0.9em`) and small gap. Layout is a flex column so it overrides `.hive-table th`'s `white-space:nowrap`.
- Applied to the three combined headers (**Uptime+Prov**, **Maturity**, **Activity**) plus **Location / Public**.
- **Theme-aware**: colours come from the existing `--muted` token and the inherited `th` colour — no hardcoded colours that would break either theme.

## Sorts preserved

- Every sort key is still reachable and unchanged. The chips are still built by the existing `subSort()` helper, so each keeps its own `onclick` + `event.stopPropagation()` and its `title=` tooltip.
- **Uptime** keeps BOTH sorts: the title stays clickable for `startedAt` (its own `<th>` onclick), and the `Prov ⇅` chip still sorts `registeredAt` with its own `stopPropagation`.
- **Location / Public** keeps its whole-`<th>` `clusterId` sort.
- All `<th>` `title=` tooltips retained.

## Column count unchanged

Still 12 `<th>`/`<td>` cells — `TOTAL_COLUMNS` / `TOTAL_COLUMNS_HEADER` unchanged (stacking is inner markup, adds no `<th>`).

## Tests

- Updated `TestDriftFoldedIntoVersion`'s Maturity assertion to match the stacked markup (`stackHeader('Maturity', ...)`) and **strengthened** it to also confirm both the `ACMM ⇅` and `Journey ⇅` sort controls stay reachable.
- `TestHiveTableColumnCountsAgree` / `TestHiveTableColumnCountUnchanged` pass unchanged (count still 12).
- `TestHiveProvisionSortUsesRegisteredAt` passes unchanged (`subSort('registeredAt', 'Prov ⇅'` intact).
- `go build ./...` clean; `go test ./pkg/hub/ -short` all pass; extracted inline dashboard JS passes `node --check`; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
