### PR TITLE
landing: align Active Hives / leaderboard with the full-width sections above

### DIFF
--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -486,7 +486,12 @@
     /* scroll-margin-top clears the sticky .site-header (~4.5rem tall) so an
        in-page jump (Contributors/Public-hives tiles, leaderboard link) lands
        with the section's own heading visible, not scrolled up under the nav. */
-    .section { max-width: 1200px; margin: 0 auto; padding: 0 clamp(1rem, 4vw, 4.5rem) 3rem; scroll-margin-top: 5.5rem; }
+    /* Match .section-pad's horizontal geometry (same side padding, no narrower
+       max-width cap) so #hives ("Active Hives") and #leaderboard line up with the
+       full-width sections above them. Previously .section capped at 1200px and
+       centered, so on a wide viewport its left edge sat far right of the
+       edge-to-edge .section-pad sections and the table looked misaligned. */
+    .section { margin: 0 auto; padding: 0 clamp(1rem, 4vw, 4.5rem) 3rem; scroll-margin-top: 5.5rem; }
     .section > h2 {
       font-size: 1.4rem;
       font-weight: 800;


### PR DESCRIPTION
**Active Hives is not centered / looks misaligned on the hub main page.**

Root cause (pre-existing): the `#hives` (Active Hives) and `#leaderboard` sections use the `.section` class (`max-width:1200px; margin:0 auto` — centered, capped), while every section above them uses `.section-pad` (full width, `clamp(1rem,4vw,4.5rem)` side padding). On a wide viewport, `.section`'s left edge sits at `(viewport − 1200px)/2` — far to the right of the edge-to-edge `.section-pad` sections above — so Active Hives' heading, blurb, and table look inset and out of line with the LLM-methods table directly above.

**Fix (CSS only):** drop the 1200px cap on `.section` and give it the same side padding as `.section-pad`, so `#hives` and `#leaderboard` share the same left edge and width as the sections above. `.hive-table` is `width:100%`, so it fills the section cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)