### PR TITLE
fix(contribute): promote only on completions that reported a PR

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -53,6 +53,10 @@ type ContributorProfile struct {
 	AvatarURL          string                `json:"avatar_url,omitempty"`
 	RegisteredAt       string                `json:"registered_at"`
 	TasksCompleted     int                   `json:"total_tasks_completed"`
+	// TasksWithPR counts only completions that reported a pull request.
+	// Auto-promotion reads this rather than TasksCompleted, so write access is
+	// never granted for completions where nothing was shown to have shipped.
+	TasksWithPR        int                   `json:"total_tasks_completed_with_pr"`
 	TasksFailed        int                   `json:"total_tasks_failed"`
 	LastActive         string                `json:"last_active,omitempty"`
 	LastCompletedTask  *WSTaskAssign         `json:"last_completed_task,omitempty"`

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -803,11 +803,18 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					)
 					contributor.mu.Lock()
 					contributor.profile.TasksCompleted++
+					if msg.PRURL != "" {
+						contributor.profile.TasksWithPR++
+					}
 					contributor.profile.LastActive = time.Now().UTC().Format(time.RFC3339)
 					if completedTask != nil {
 						contributor.profile.LastCompletedTask = completedTask
 					}
-					if contributor.profile.TrustTier == "newcomer" && contributor.profile.TasksCompleted >= contributorAutoPromoteAt {
+					// Promote on completions that actually produced a pull
+					// request. Completion is self-reported, so counting bare
+					// task_complete messages would hand out contents:write and
+					// pulls:write for work that was never shown to exist.
+					if contributor.profile.TrustTier == "newcomer" && contributor.profile.TasksWithPR >= contributorAutoPromoteAt {
 						contributor.profile.TrustTier = "contributor"
 						h.logger.Info("[contribute-ws] auto-promoted", "username", contributor.profile.GitHubUsername)
 					}

--- a/v2/pkg/dashboard/contribute_ws_test.go
+++ b/v2/pkg/dashboard/contribute_ws_test.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -529,5 +530,82 @@ func TestContributorProfilePreferredRole(t *testing.T) {
 	}
 	if loaded.PreferredRole != "scanner" {
 		t.Fatalf("expected preferred_role 'scanner', got %q", loaded.PreferredRole)
+	}
+}
+
+// Auto-promotion grants contents:write and pulls:write, so it must not fire on
+// completions that never reported a pull request. Completion is self-reported:
+// an agent that goes idle without shipping anything still sends task_complete.
+func TestWSAutoPromotionRequiresReportedPR(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	body := `{"github_username":"promote-user"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn)
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn)
+
+	// complete drives one task through the hub as if it had been assigned,
+	// reporting a PR only when prURL is non-empty.
+	complete := func(taskID, prURL string) {
+		t.Helper()
+		s.contributeHub.mu.RLock()
+		var c *ContributorConnection
+		for _, candidate := range s.contributeHub.connections {
+			c = candidate
+		}
+		s.contributeHub.mu.RUnlock()
+		if c == nil {
+			t.Fatal("no live contributor connection")
+		}
+		c.mu.Lock()
+		c.currentTask = &WSTaskAssign{TaskID: taskID, Kind: "issue", Repo: "acme/widgets", Number: 1}
+		c.mu.Unlock()
+
+		conn.WriteJSON(WSMessage{Type: "task_complete", TaskID: taskID, Result: "done", PRURL: prURL})
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	for i := 0; i < contributorAutoPromoteAt; i++ {
+		complete(fmt.Sprintf("no-pr-%d", i), "")
+	}
+
+	p := findContributor(reg["contributor_id"])
+	if p == nil {
+		t.Fatal("contributor not found")
+	}
+	if p.TasksCompleted != contributorAutoPromoteAt {
+		t.Fatalf("expected %d completions recorded, got %d", contributorAutoPromoteAt, p.TasksCompleted)
+	}
+	if p.TasksWithPR != 0 {
+		t.Fatalf("expected 0 completions with a PR, got %d", p.TasksWithPR)
+	}
+	if p.TrustTier != "newcomer" {
+		t.Fatalf("promoted to %q on completions that reported no PR", p.TrustTier)
+	}
+
+	for i := 0; i < contributorAutoPromoteAt; i++ {
+		complete(fmt.Sprintf("with-pr-%d", i), "https://github.com/acme/widgets/pull/7")
+	}
+
+	p = findContributor(reg["contributor_id"])
+	if p.TasksWithPR != contributorAutoPromoteAt {
+		t.Fatalf("expected %d completions with a PR, got %d", contributorAutoPromoteAt, p.TasksWithPR)
+	}
+	if p.TrustTier != "contributor" {
+		t.Fatalf("expected promotion to contributor after %d PR-backed completions, got %q", contributorAutoPromoteAt, p.TrustTier)
 	}
 }


### PR DESCRIPTION
Fixes finding 4 of #2436. Smallest of the four; the others need a design decision from you, so I've left them.

## Problem

Auto-promotion moves a contributor from `newcomer` to `contributor`, granting `contents:write` and `pulls:write`. It fired on `TasksCompleted`, which counts bare `task_complete` messages.

Completion is self-reported. `bin/contributor-relay.sh` reports `task_complete` from a tmux idleness heuristic, so an agent that never reached its model or GitHub still goes idle, still reports completion, and still accrues credit toward write access. Five such messages promoted an account that had never been shown to ship anything.

## Fix

The signal was already here — `markTaskCompleted` takes `msg.PRURL` and uses it to choose the cooldown length (#2393 item 7). This counts the same value into a separate `TasksWithPR` total and promotes on that instead:

```go
contributor.profile.TasksCompleted++
if msg.PRURL != "" {
    contributor.profile.TasksWithPR++
}
...
if contributor.profile.TrustTier == "newcomer" && contributor.profile.TasksWithPR >= contributorAutoPromoteAt {
```

## Compatibility

- `TasksCompleted` keeps its existing meaning, so the leaderboard and per-contributor stats are unchanged.
- Existing profiles start at `TasksWithPR = 0`. The check only ever promotes, so **nobody is demoted** — already-promoted contributors keep their tier.
- New field is additive with an `omitempty`-free JSON tag matching the existing naming style.

## Testing

`TestWSAutoPromotionRequiresReportedPR` drives ten completions through the real websocket handler: five without a PR URL, then five with one.

I verified it is a genuine regression test — with the promotion condition reverted to `TasksCompleted` it fails with:

```
contribute_ws_test.go:597: promoted to "contributor" on completions that reported no PR
```

and passes with the fix. Full package suite is green:

```
ok  github.com/kubestellar/hive/v2/pkg/dashboard  7.204s
```

## Notes

`msg.PRURL` is client-supplied, so this **raises the bar rather than closing the hole**. Verifying the URL resolves to a PR authored by that contributor against the assigned repo would close it, at the cost of a GitHub API call on the completion path — happy to follow up with that if you want it, or to gate promotion on a maintainer action instead.

I did not run `gofmt -w` on `api_contribute.go`: it is already not gofmt-clean on `v2` (the const block and struct alignment), and reformatting it would have buried a 4-line change in ~74 lines of whitespace. My added lines match the surrounding style. Say the word if you'd rather I normalise the file.