### PR TITLE
Sync v2 into dd

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -726,12 +726,24 @@
     .gh-idhint-btn[aria-expanded="true"] + .gh-idhint-pop { display: block; }
     .gh-idhint-pop .gh-idhint-lead { font-size: var(--fs-xs); color: var(--text); margin-bottom: 8px; line-height: 1.45; }
     .gh-idhint-pop .gh-idhint-foot { font-size: var(--fs-xs); color: var(--muted); margin-top: 8px; line-height: 1.45; }
-    /* The URL mock: a rendered address bar, not a screenshot. Scrolls inside
-       itself so a long org name cannot push the panel wider than the viewport. */
+    /* The URL mock: a rendered browser address bar, not a screenshot.
+       .gh-idhint-url is the pill-shaped chrome (rounded ends, lock glyph);
+       .gh-idhint-urltext is the scrollable URL row inside it, and the caret
+       callout sits below as its own line so it keeps pointing at the ID
+       segment even while the URL row scrolls horizontally. */
     .gh-idhint-url {
+      display: flex; align-items: center; gap: 7px;
+      background: var(--bg-soft); border: 1px solid var(--line-strong);
+      border-radius: 999px; padding: 6px 12px;
+    }
+    /* Lock glyph stands in for the browser's HTTPS padlock. Shrink-to-fit so
+       it never gets squeezed by the scrolling URL text next to it. */
+    .gh-idhint-url .seg-lock {
+      flex: 0 0 auto; color: var(--green); font-size: 0.72rem; opacity: 0.9;
+    }
+    .gh-idhint-urltext {
+      flex: 1 1 auto; min-width: 0;
       font-family: var(--font-mono); font-size: 0.66rem; line-height: 1.6;
-      background: var(--bg-soft); border: 1px solid var(--line);
-      border-radius: var(--radius-sm); padding: 7px 9px;
       color: var(--muted); overflow-x: auto; white-space: nowrap;
     }
     .gh-idhint-url .seg-host { color: var(--text); }
@@ -743,7 +755,13 @@
       border: 1px solid color-mix(in srgb, var(--amber) 55%, transparent);
       border-radius: 3px; padding: 1px 4px;
     }
-    .gh-idhint-url .seg-caret { display: block; color: var(--amber); font-size: 0.6rem; }
+    /* Caret callout under the bar, pointing up at the ID segment. Own line
+       (not inside the scrolling pill) so it never gets clipped by
+       overflow-x when a long org name scrolls the URL row. */
+    .gh-idhint-caret {
+      display: block; color: var(--amber); font-size: 0.6rem;
+      font-family: var(--font-mono); margin-top: 4px; padding-left: 12px;
+    }
     .gh-app-perm-details { font-size: 0.8rem; margin-top: 6px; color: var(--text); }
     .gh-app-perm-details .perm-ok { color: var(--green); }
     .gh-app-perm-details .perm-missing { color: var(--red); font-weight: 600; }
@@ -5349,24 +5367,29 @@
       return org || INSTALL_ID_ORG_PLACEHOLDER;
     }
 
-    /* Builds the popover markup: a short lead, the mocked URL with the ID
-       segment highlighted and MASKED, and a footnote. Every interpolated value
-       is escaped — org and host originate from server config. */
+    /* Builds the popover markup: a short lead, a mocked browser address bar
+       (lock glyph + URL) with the ID segment highlighted and MASKED, a caret
+       callout pointing at it, and a footnote. Every interpolated value is
+       escaped — org and host originate from server config. */
     function ghAppInstallIdHintHtml(data) {
       var host = escapeHtml(ghAppHintHost(data));
       var org = escapeHtml(ghAppHintOrg());
       return '<span class="gh-idhint-lead">Your Installation ID is the <strong>last part of the URL</strong> '
-        + 'on your org’s installed-app settings page:</span>'
+        + 'in your browser’s address bar on your org’s installed-app settings page:</span>'
         + '<span class="gh-idhint-url">'
-        +   'https://<span class="seg-host">' + host + '</span>/organizations/'
-        +   org + '/settings/installations/'
-        +   '<span class="seg-id">' + INSTALL_ID_MASK + '</span>'
-        +   '<span class="seg-caret">' + new Array(INSTALL_ID_MASK_LENGTH + 1).join('↑')
-        +     ' this number</span>'
+        +   '<span class="seg-lock" aria-hidden="true">🔒</span>'
+        +   '<span class="gh-idhint-urltext">'
+        +     'https://<span class="seg-host">' + host + '</span>/organizations/'
+        +     org + '/settings/installations/'
+        +     '<span class="seg-id">' + INSTALL_ID_MASK + '</span>'
+        +   '</span>'
         + '</span>'
+        + '<span class="gh-idhint-caret">' + new Array(INSTALL_ID_MASK_LENGTH + 1).join('↑')
+        +   ' this number</span>'
         + '<span class="gh-idhint-foot">Open <strong>' + host + '</strong> → your org → '
         + 'Settings → GitHub Apps → the Hive app → <em>Configure</em>, then copy the digits '
-        + 'from the address bar. The circles above are a placeholder — they are not a real ID.</span>';
+        + 'shown in your browser’s address bar. The circles above are a placeholder — '
+        + 'they are not a real ID.</span>';
     }
 
     /* Refreshes the hint content for the hive's current host/org. Safe to call

--- a/v2/pkg/hub/hive_access_avatars_test.go
+++ b/v2/pkg/hub/hive_access_avatars_test.go
@@ -182,17 +182,18 @@ func TestHoverPanelReusesSharedRoleColor(t *testing.T) {
 // section-header colspan and the pending-expand colspan all stay correct; a
 // stale count leaves the table visibly ragged.
 //
-// 17 = the columns left after the standalone Public column folded into Location
-// (visibility stacks beneath the location badge) and the AI Author column folded
-// into the Repos cell (its "as:" line); the Provisioned column survives as a thin
-// sort-only header (its date moved into the status hover panel).
+// 12 = the columns left after the 15-to-9 fold (PROV, DRIFT, ACMM+JOURNEY→Maturity,
+// ISSUES+PRS+CONTRIB→Activity), on top of the earlier Public→Location and
+// AI-Author→Repos folds. The inline access avatars still add NO column — they live
+// inside the existing name cell, so the header, section-header colspan and
+// pending-expand colspan all stay correct.
 // TestHiveTableColumnCountsAgree is the authority on this number: it counts the
 // emitted <th> and <td> cells rather than trusting a literal, so update it
 // first and follow it here.
 func TestHiveTableColumnCountUnchanged(t *testing.T) {
 	for _, snippet := range []string{
-		"var TOTAL_COLUMNS = 17;",
-		"var TOTAL_COLUMNS_HEADER = 17;",
+		"var TOTAL_COLUMNS = 12;",
+		"var TOTAL_COLUMNS_HEADER = 12;",
 	} {
 		if !strings.Contains(dashboardHTML, snippet) {
 			t.Errorf("dashboardHTML is missing %q — did the hive table gain or lose a column?", snippet)

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -10429,6 +10429,33 @@ const dashboardHTML = `<!DOCTYPE html>
         (titleRaw ? ' title="' + titleRaw + '"' : '') + '>' + label + '</span>';
     }
 
+    /* stackHeader lays a combined column's header out on TWO lines instead of one
+       inline string: the title on line 1, its sub-sort ⇅ chips on line 2. The
+       inline form ("Uptime ⇅ Prov ⇅", "Activity Iss ⇅ PRs ⇅ Ctr ⇅") set each
+       folded column's width from the full concatenated string, which made the
+       fleet table far wider than it needed to be. Stacking makes the column width
+       track the widest SINGLE line instead.
+
+       .hive-table th sets white-space:nowrap, which would keep everything on one
+       line; a flex column overrides that for layout, and the chip row is allowed
+       to wrap (flex-wrap) so three chips fold onto a further line on a truly
+       narrow table rather than forcing the column wide. Colours come from the
+       existing --muted token and the inherited th colour, so both themes track.
+
+       titleHTML    — the line-1 content. May be plain text (e.g. 'Maturity') or
+                      an already-built clickable span; inserted VERBATIM, callers
+                      pass trusted markup only.
+       subSortsHTML — the line-2 content: one or more subSort() spans (each already
+                      carries its own onclick + event.stopPropagation()). Passed
+                      through unchanged, so every folded sort stays reachable and
+                      the stopPropagation contract is untouched. */
+    function stackHeader(titleHTML, subSortsHTML) {
+      return '<span style="display:inline-flex;flex-direction:column;align-items:center;gap:1px;line-height:1.15">' +
+        '<span style="white-space:nowrap">' + titleHTML + '</span>' +
+        '<span style="display:inline-flex;flex-wrap:wrap;justify-content:center;gap:2px;font-size:0.9em;color:var(--muted)">' +
+        subSortsHTML + '</span></span>';
+    }
+
     /* persistHiveSort records the operator's EXPLICIT sort choice. Written only
        from sortDashHives (a header click), never from loadHiveSortPrefs, so
        restoring a preference can't rewrite it and a first visit leaves the key
@@ -11830,18 +11857,18 @@ const dashboardHTML = `<!DOCTYPE html>
            sort keys, so each key gets its own inline clickable span. subSort() is
            the shared helper; every folded sort therefore stays reachable directly
            from the header, exactly as the standalone columns were. */
-        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer" title="Where this hive runs, and whether it is listed publicly">Location / Public ⇅</th>' +
+        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer;vertical-align:middle" title="Where this hive runs, and whether it is listed publicly">' + stackHeader('Location /', 'Public ⇅') + '</th>' +
         /* Uptime hosts BOTH temporal sorts: live uptime (startedAt) and the folded
            provision-date sort (registeredAt, the old "Prov ⇅"). The date itself now
            lives in the status hover; only its sort trigger rides here. */
-        '<th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅ ' + subSort('registeredAt', 'Prov ⇅', 'Sort by when this hive was first provisioned (the hub&apos;s first-seen time). The date itself now lives in the status hover.') + '</th>' +
+        '<th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer;vertical-align:middle" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">' + stackHeader('Uptime ⇅', subSort('registeredAt', 'Prov ⇅', 'Sort by when this hive was first provisioned (the hub&apos;s first-seen time). The date itself now lives in the status hover.')) + '</th>' +
         '<th title="Version, branch and any configuration drift from the fleet norm — a coloured dot appears beside the commit when this hive drifts; hover it for the specific signals">Version</th><th>Repos</th>' +
         /* MATURITY folds ACMM (where it is) and Journey (what it owes next); both
            sorts survive as inline ⇅ controls. */
-        '<th title="Adoption maturity: ACMM level and the next journey step">Maturity ' + subSort('acmmLevel', 'ACMM ⇅', 'Sort by ACMM level') + ' ' + subSort('journey', 'Journey ⇅', 'Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run ClankeR, the contributor relay), then raise the ACMM level') + '</th>' +
+        '<th style="vertical-align:middle" title="Adoption maturity: ACMM level and the next journey step">' + stackHeader('Maturity', subSort('acmmLevel', 'ACMM ⇅', 'Sort by ACMM level') + subSort('journey', 'Journey ⇅', 'Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run ClankeR, the contributor relay), then raise the ACMM level')) + '</th>' +
         '<th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th>' +
         /* ACTIVITY folds Issues, PRs and Contrib; each keeps its own sort ⇅. */
-        '<th title="Actionable issues, actionable PRs and active contributors">Activity ' + subSort('actionableIssues', 'Iss ⇅', 'Sort by actionable issues') + ' ' + subSort('actionablePRs', 'PRs ⇅', 'Sort by actionable PRs') + ' ' + subSort('activeContributors', 'Ctr ⇅', 'Sort by active contributors') + '</th>' +
+        '<th style="vertical-align:middle" title="Actionable issues, actionable PRs and active contributors">' + stackHeader('Activity', subSort('actionableIssues', 'Iss ⇅', 'Sort by actionable issues') + subSort('actionablePRs', 'PRs ⇅', 'Sort by actionable PRs') + subSort('activeContributors', 'Ctr ⇅', 'Sort by active contributors')) + '</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table></div>';
       /* Delegated, so binding once is enough no matter how often the table is
          re-rendered. The guard keeps repeated renders from stacking listeners. */

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -10406,6 +10406,29 @@ const dashboardHTML = `<!DOCTYPE html>
       renderHives(sortedDashHives(), true);
     }
 
+    /* subSort renders ONE inline, clickable sort control for a combined-column
+       header. A folded column (Maturity, Activity) hosts two or three sort keys,
+       so the whole <th> can no longer own a single onclick — each key gets its
+       own ⇅ span instead, keeping every folded sort reachable directly from the
+       header exactly as the standalone columns' ⇅ were.
+
+       key      — the sortDashHives sort key (a fixed literal, never user input);
+       label    — the visible ⇅ text (e.g. 'Prov ⇅');
+       titleRaw — the hover text, inserted VERBATIM into the title attribute to
+                  match how the original standalone headers embedded literals
+                  (some carry pre-encoded entities like &apos;). Callers pass
+                  trusted string constants only.
+
+       event.stopPropagation() so a sub-sort inside a <th> that ALSO has its own
+       onclick (Uptime hosts the Prov sub-sort) fires only its own key, not the
+       parent's. jsArg supplies the quotes around the key so an apostrophe could
+       never break out of the handler. */
+    function subSort(key, label, titleRaw) {
+      return '<span onclick="event.stopPropagation();sortDashHives(' + jsArg(key) + ')" ' +
+        'style="cursor:pointer;font-weight:400;color:var(--muted);margin-left:2px"' +
+        (titleRaw ? ' title="' + titleRaw + '"' : '') + '>' + label + '</span>';
+    }
+
     /* persistHiveSort records the operator's EXPLICIT sort choice. Written only
        from sortDashHives (a header click), never from loadHiveSortPrefs, so
        restoring a preference can't rewrite it and a first visit leaves the key
@@ -11347,6 +11370,16 @@ const dashboardHTML = `<!DOCTYPE html>
         if (isHosted && h.role === 'owner' && _clusterList && _clusterList.length > 1 && h.migrationStatus !== 'migrating') menuItems.push('<div onclick="openMigrateModal(\'' + esc(h.id) + '\',\'' + esc(h.clusterId || '') + '\')" style="' + mi + '">Move to cluster</div>');
         if (isHosted && h.role === 'owner') menuItems.push('<div style="border-top:1px solid #30363d;margin:4px 0"></div><div onclick="deleteHive(\'' + esc(h.id) + '\')" style="' + mi + ';color:#f85149">Delete</div>');
         var sha = h.gitHash || '';
+        /* Drift folded ONTO Version: config drift is overwhelmingly "this hive's
+           version/branch differs from the fleet", so the drift indicator reads as
+           a property of the Version cell rather than earning its own column. Only
+           emitted when there IS drift (driftOf().count > 0); driftBadge() returns
+           its own colored count pill with the full per-signal hover panel, so no
+           datum is lost — hover the dot for every drift reason exactly as before.
+           A clean hive shows nothing here, keeping the cell as tight as it was.
+           driftBadge carries its own hive-access-pop panel and NO title, so the
+           single-hover-panel invariant holds (it is a badge, not an inline face). */
+        var driftDot = driftOf(h).count > 0 ? driftBadge(h) : '';
         var versionCell = '';
         if (sha) {
           var branchName = h.gitBranch || 'v2';
@@ -11482,14 +11515,20 @@ const dashboardHTML = `<!DOCTYPE html>
              Lines 3 and 4 are omitted entirely when empty — a read-only viewer
              gets two lines, not four with two blanks. Every fragment below is
              embedded verbatim, so ids, handlers and tooltips are preserved. */
-          var shaLine = '<span style="font-family:monospace;color:var(--muted)" title="' + escAttr(shaMsg) + '">' + esc(sha) + '</span>' + status;
+          /* The drift dot rides on the SHA line, right of the current/behind
+             glyph: "what commit is this hive on, and does it match the fleet" is
+             one thought. It sets no extra line, so a drifting hive is no taller. */
+          var shaLine = '<span style="font-family:monospace;color:var(--muted)" title="' + escAttr(shaMsg) + '">' + esc(sha) + '</span>' + status + (driftDot ? ' ' + driftDot : '');
           versionCell = '<div style="' + STACKED_CELL_STYLE + '">' +
             '<div style="' + STACKED_LINE_STYLE + '">' + branch + '</div>' +
             '<div style="' + STACKED_LINE_STYLE + '">' + shaLine + '</div>' +
             (upgradeIcon ? '<div style="' + STACKED_LINE_STYLE + '">' + upgradeIcon + '</div>' : '') +
             (autoUpgradeCheck ? '<div style="' + STACKED_LINE_STYLE + '">' + autoUpgradeCheck + '</div>' : '') +
             '</div>';
-        } else { versionCell = '<span style="color:var(--muted)">—</span>'; }
+        /* No version reported, but drift can still exist (e.g. heartbeat-stale on a
+           spoke too old to report a SHA) — surface the dot beside the dash so
+           folding Drift into Version never hides a signal. */
+        } else { versionCell = '<span style="color:var(--muted)">—</span>' + (driftDot ? ' ' + driftDot : ''); }
         var pendingBadge = (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write'))
           ? '<span style="position:absolute;top:-2px;right:-2px;background:var(--blue);color:#fff;border-radius:50%;width:16px;height:16px;font-size:0.6rem;display:flex;align-items:center;justify-content:center;font-weight:700">' + h.pendingRequestCount + '</span>'
           : '';
@@ -11497,14 +11536,16 @@ const dashboardHTML = `<!DOCTYPE html>
         if (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write')) {
           pendingPill = '<a href="#" onclick="togglePendingRow(\'' + esc(h.id) + '\');return false" style="display:inline-flex;align-items:center;gap:4px;padding:3px 10px;background:rgba(59,130,246,0.12);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);border-radius:4px;font-size:0.7rem;text-decoration:none;cursor:pointer;white-space:nowrap">&#x1F514; ' + h.pendingRequestCount + ' pending</a>';
         }
-        // 17 = the 13 original columns, plus Uptime, plus Drift, plus the
-        // bulk-select column, plus Journey, plus the thin Provisioned SORT column
-        // (date moved into the status hover; sortable header + empty placeholder
-        // cell remain), MINUS Public (visibility stacks under Location) and MINUS
-        // AI Author (folded into the Repos cell as its "as:" line). Counted
-        // against the <th> cells in the header and the <td> cells emitted below
-        // (bulkCheckboxCell contributes one).
-        var TOTAL_COLUMNS = 17;
+        // 12 columns after the 15-to-9 fold. The visible cells are: bulk-select,
+        // the ⋮ menu, Hive, Location, Uptime, Version, Repos, Maturity, Agents,
+        // Tokens, Mode, Activity. Four folds collapsed six columns:
+        //   PROV    → date lives in the status hover; sort rides the Uptime header
+        //   DRIFT   → dot on the Version cell (driftBadge, full hover preserved)
+        //   ACMM+JOURNEY  → one Maturity cell (both badges stacked, both sorts kept)
+        //   ISSUES+PRS+CONTRIB → one Activity cell (all 3 stats + sparklines, 3 sorts kept)
+        // Counted against the <th> cells in the header and the <td> cells emitted
+        // below (bulkCheckboxCell contributes one).
+        var TOTAL_COLUMNS = 12;
         /* Visibility moved OUT of its own column and under Location: "where
            does this hive run" and "who can see it" are both facts about the
            hive's placement, so they read as one cell, and folding them saves a
@@ -11611,37 +11652,45 @@ const dashboardHTML = `<!DOCTYPE html>
               '<div style="' + STACKED_LINE_STYLE + ';color:var(--muted)" title="GitHub identity this hive opens PRs/commits as (— = no GitHub App installed yet)">as: ' + esc(h.aiAuthorEffective || '—') + '</div>' +
             '</div>' +
           '</td>' +
-          '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
-          '<td>' + journeyBadge(h.journey) + '</td>' +
-          /* Drift sits immediately right of Journey: both answer "how healthy
-             is this hive's configuration", so they read as one pair rather
-             than being separated by nine metric columns. Header index and body
-             index are both 10 of 16 — keep them in lockstep. */
-          '<td style="white-space:nowrap;text-align:right">' + driftBadge(h) + '</td>' +
+          /* MATURITY: the ACMM level badge and the Journey status stacked into
+             ONE cell. Both answer "how far along is this hive's adoption" — the
+             ACMM level is where it IS, the journey is the next step it OWES — so
+             they read as one column instead of two. Each badge keeps its own
+             hover (acmmBadge's title explains the level, journeyBadge's the
+             stage), so no datum is lost; both sorts stay reachable from the
+             MATURITY header's two ⇅ controls (acmmLevel and journey). */
+          '<td>' +
+            '<div style="' + STACKED_CELL_STYLE + '">' +
+              '<div style="' + STACKED_LINE_STYLE + '">' + acmmBadge(h.acmmLevel) + '</div>' +
+              '<div style="' + STACKED_LINE_STYLE + '">' + journeyBadge(h.journey) + '</div>' +
+            '</div>' +
+          '</td>' +
           '<td title="' + esc((h.agents || []).map(function(a){ var label = a.name + ' (' + a.state + ')'; if (a.mode === 'on_demand') label += ' — on demand'; return label; }).join('\n')) + '" style="cursor:' + ((h.agentCount || 0) > 0 ? 'help' : 'default') + '">' + (h.agentCount || 0) + '</td>' +
           '<td title="Cumulative tokens consumed, as of the last heartbeat" style="white-space:nowrap;cursor:help">' + fmtTokens(h.totalTokens24h || 0) + '</td>' +
           '<td>' + modeCell + '</td>' +
-          '<td>' + sparkline(h.issueHistory, '#f59e0b', 50, 14) + (h.actionableIssues || 0) + '</td>' +
-          '<td>' + sparkline(h.prHistory, '#3b82f6', 50, 14) + (h.actionablePRs || 0) + '</td>' +
-          '<td>' + (h.activeContributors || 0) + '</td>' +
-          /* Provisioned: the DATE moved into the status hover panel (healthBadge) —
-             it is reference metadata, not a live metric. This cell is intentionally
-             empty: the thin "Prov ⇅" header above still sorts the table by
-             registeredAt (a deliberately-kept feature), but the wide per-row date
-             no longer occupies the grid. hiveProvisionTime remains the source of
-             truth for both the hover line and the sort comparator. */
-          '<td></td>' +
+          /* ACTIVITY: Issues, PRs and Contributors — three mini-stats that were
+             three columns — stacked densely into ONE cell. Every number and both
+             sparklines survive verbatim; each line is labelled (I/PR/C) and
+             carries a native title so a folded value is never ambiguous. All
+             three sorts stay reachable from the ACTIVITY header's three ⇅
+             controls (actionableIssues, actionablePRs, activeContributors). */
+          '<td style="font-size:0.72rem">' +
+            '<div style="' + STACKED_CELL_STYLE + ';align-items:flex-start">' +
+              '<div style="' + STACKED_LINE_STYLE + '" title="Actionable issues"><span style="color:var(--muted);min-width:24px;display:inline-block">Iss</span>' + sparkline(h.issueHistory, '#f59e0b', 40, 12) + (h.actionableIssues || 0) + '</div>' +
+              '<div style="' + STACKED_LINE_STYLE + '" title="Actionable PRs"><span style="color:var(--muted);min-width:24px;display:inline-block">PRs</span>' + sparkline(h.prHistory, '#3b82f6', 40, 12) + (h.actionablePRs || 0) + '</div>' +
+              '<div style="' + STACKED_LINE_STYLE + '" title="Active contributors"><span style="color:var(--muted);min-width:24px;display:inline-block">Ctr</span>' + (h.activeContributors || 0) + '</div>' +
+            '</div>' +
+          '</td>' +
           '</tr>' + pendingExpandRow;
       };
       /* Section-header row: a labeled separator spanning all columns, styled to
          match the table's muted uppercase heading treatment (see .hive-table th). */
       /* Count of <th> cells in the hive table header below. The section-header
          row spans all of them; a stale value would leave the separator short
-         and the table visibly ragged. Drift + bulk-select + Journey + a thin
-         Provisioned SORT column, minus Public (visibility stacked under Location)
-         and minus AI Author (folded into the Repos cell). Must stay equal to
+         and the table visibly ragged. 12 after the 15-to-9 fold (PROV, DRIFT,
+         ACMM/JOURNEY→Maturity, ISSUES/PRS/CONTRIB→Activity). Must stay equal to
          TOTAL_COLUMNS. */
-      var TOTAL_COLUMNS_HEADER = 17;
+      var TOTAL_COLUMNS_HEADER = 12;
       /* The header is a click target that expands/collapses its section. The
          caret mirrors aria-expanded so the affordance and the a11y state can
          never disagree. sectionKey also scopes the select-all checkbox to THIS
@@ -11776,7 +11825,23 @@ const dashboardHTML = `<!DOCTYPE html>
         /* Non-admin lists have no section headers, so the flat list's
            select-all lives in the table head instead. */
         '<th style="width:26px;text-align:center">' + (_isAdmin ? '' : bulkSectionCheckbox('all')) + '</th>' +
-        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer" title="Where this hive runs, and whether it is listed publicly">Location / Public ⇅</th><th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'journey\')" style="cursor:pointer" title="Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run ClankeR, the contributor relay), then raise the ACMM level">Journey ⇅</th><th title="Configuration drift from the fleet norm — hover a value for the specific signals">Drift</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer" title="Active contributors">Contrib ⇅</th><th onclick="sortDashHives(\'registeredAt\')" style="cursor:pointer" title="Sort by when this hive was first provisioned (the hub&apos;s first-seen time). The date itself now lives in the status hover.">Prov ⇅</th>' +
+        /* A combined-column header carries ONE sort control per folded field: the
+           header cell can no longer own a single onclick once it hosts two or three
+           sort keys, so each key gets its own inline clickable span. subSort() is
+           the shared helper; every folded sort therefore stays reachable directly
+           from the header, exactly as the standalone columns were. */
+        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer" title="Where this hive runs, and whether it is listed publicly">Location / Public ⇅</th>' +
+        /* Uptime hosts BOTH temporal sorts: live uptime (startedAt) and the folded
+           provision-date sort (registeredAt, the old "Prov ⇅"). The date itself now
+           lives in the status hover; only its sort trigger rides here. */
+        '<th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅ ' + subSort('registeredAt', 'Prov ⇅', 'Sort by when this hive was first provisioned (the hub&apos;s first-seen time). The date itself now lives in the status hover.') + '</th>' +
+        '<th title="Version, branch and any configuration drift from the fleet norm — a coloured dot appears beside the commit when this hive drifts; hover it for the specific signals">Version</th><th>Repos</th>' +
+        /* MATURITY folds ACMM (where it is) and Journey (what it owes next); both
+           sorts survive as inline ⇅ controls. */
+        '<th title="Adoption maturity: ACMM level and the next journey step">Maturity ' + subSort('acmmLevel', 'ACMM ⇅', 'Sort by ACMM level') + ' ' + subSort('journey', 'Journey ⇅', 'Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run ClankeR, the contributor relay), then raise the ACMM level') + '</th>' +
+        '<th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th>' +
+        /* ACTIVITY folds Issues, PRs and Contrib; each keeps its own sort ⇅. */
+        '<th title="Actionable issues, actionable PRs and active contributors">Activity ' + subSort('actionableIssues', 'Iss ⇅', 'Sort by actionable issues') + ' ' + subSort('actionablePRs', 'PRs ⇅', 'Sort by actionable PRs') + ' ' + subSort('activeContributors', 'Ctr ⇅', 'Sort by active contributors') + '</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table></div>';
       /* Delegated, so binding once is enough no matter how often the table is
          re-rendered. The guard keeps repeated renders from stacking listeners. */

--- a/v2/pkg/hub/saas_dashboard_facet_tray_test.go
+++ b/v2/pkg/hub/saas_dashboard_facet_tray_test.go
@@ -349,21 +349,23 @@ func TestHiveTableColumnCountsAgree(t *testing.T) {
 		t.Errorf("header emits %d <th> cells but a row emits %d cells — "+
 			"every column right of the mismatch is shifted", thCount, tdCount)
 	}
-	// 17: the Public column folded into Location (visibility stacks beneath the
-	// location badge) and the AI Author column folded into the Repos cell (its
-	// "as:" line, freeing a column). Provisioned keeps a thin sort-only header
-	// ("Prov ⇅") but its date moved into the status hover panel — so it stays a
-	// column (empty placeholder cell) for the sort trigger while giving back the
-	// wide date. Provision-date ordering still works via that header.
-	const wantColumns = 17
+	// 12: the fleet table was folded from 15 named columns down to ~9 (four folds
+	// on top of the earlier Public→Location and AI-Author→Repos folds):
+	//   PROV    → date in the status hover; its sort rides the Uptime header
+	//   DRIFT   → a dot on the Version cell (driftBadge, full hover preserved)
+	//   ACMM+JOURNEY  → one Maturity cell (both badges stacked, both sorts kept)
+	//   ISSUES+PRS+CONTRIB → one Activity cell (all 3 stats + sparklines, 3 sorts)
+	// The 12 <th>/<td> cells are: bulk, ⋮ menu, Hive, Location, Uptime, Version,
+	// Repos, Maturity, Agents, Tokens, Mode, Activity.
+	const wantColumns = 12
 	if thCount != wantColumns {
 		t.Errorf("hive table has %d columns, want %d", thCount, wantColumns)
 	}
 	// The colspan constants span the whole table; a stale value leaves the
 	// section separators and the pending-requests row visibly short.
 	for _, decl := range []string{
-		"var TOTAL_COLUMNS = 17;",
-		"var TOTAL_COLUMNS_HEADER = 17;",
+		"var TOTAL_COLUMNS = 12;",
+		"var TOTAL_COLUMNS_HEADER = 12;",
 	} {
 		if !strings.Contains(html, decl) {
 			t.Errorf("missing or stale colspan constant: %s", decl)
@@ -371,63 +373,61 @@ func TestHiveTableColumnCountsAgree(t *testing.T) {
 	}
 }
 
-// TestDriftColumnSitsRightOfJourney pins the column ORDER, in both the header
-// and the body, at the same index. Asserting only the header is how the last
-// column-move bug shipped.
-func TestDriftColumnSitsRightOfJourney(t *testing.T) {
+// TestDriftFoldedIntoVersion pins the DRIFT fold: after the 15-to-9 fold the
+// Drift column is gone and its indicator rides on the Version cell instead. The
+// datum is not lost — driftBadge (its full per-signal hover panel) still renders
+// once in the body, gated on there being drift — and there is no standalone Drift
+// header or column any more.
+func TestDriftFoldedIntoVersion(t *testing.T) {
 	html := dashScript(t)
 
-	// --- header order.
 	start := strings.Index(html, `'<div class="table-wrap"><table class="hive-table"><thead><tr>'`)
 	end := strings.Index(html[start:], `</tr></thead><tbody>' + rows`)
 	if start < 0 || end < 0 {
 		t.Fatal("could not isolate the hive table header")
 	}
 	header := html[start : start+end]
-	journeyTh := strings.Index(header, ">Journey ")
-	driftTh := strings.Index(header, ">Drift<")
-	if journeyTh < 0 || driftTh < 0 {
-		t.Fatal("could not find the Journey and Drift header cells")
-	}
-	if driftTh < journeyTh {
-		t.Fatal("Drift header cell comes before Journey")
-	}
-	// Nothing but the closing tag of Journey's own cell may sit between them:
-	// any other <th> would mean Drift is not IMMEDIATELY right of Journey.
-	between := header[journeyTh:driftTh]
-	if n := len(regexp.MustCompile(`<th[\s>]`).FindAllString(between, -1)); n != 1 {
-		t.Errorf("found %d header cells between Journey and Drift, want exactly 1 "+
-			"(Drift's own <th>) — Drift must sit immediately right of Journey", n)
+	// No standalone Drift column header survives the fold.
+	if strings.Contains(header, ">Drift<") {
+		t.Error("a standalone Drift header cell is still present — it was meant to fold onto Version")
 	}
 
-	// --- body order, over the same expression the row is built from.
+	// The whole buildRow body, not just its return expression: driftDot is
+	// computed above the return, so the drift-fold assertions look at the body.
 	bStart := strings.Index(html, "var buildRow = function(h, i, section) {")
+	if bStart < 0 {
+		t.Fatal("could not find buildRow")
+	}
+	bEnd := strings.Index(html[bStart:], "'</tr>' + pendingExpandRow;")
 	retIdx := strings.Index(html[bStart:], buildRowReturnAnchor)
-	rStart := bStart + retIdx
-	rEnd := strings.Index(html[rStart:], "'</tr>' + pendingExpandRow;")
-	if bStart < 0 || retIdx < 0 || rEnd < 0 {
-		t.Fatal("could not isolate buildRow's return expression")
+	if bEnd < 0 || retIdx < 0 {
+		t.Fatal("could not isolate buildRow's body")
 	}
-	rowExpr := html[rStart : rStart+rEnd]
-	journeyTd := strings.Index(rowExpr, "journeyBadge(h.journey)")
-	driftTd := strings.Index(rowExpr, "driftBadge(h)")
-	if journeyTd < 0 || driftTd < 0 {
-		t.Fatal("could not find the Journey and Drift body cells")
+	body := html[bStart : bStart+bEnd]
+
+	// The drift indicator is computed once (driftDot) and embedded in the Version
+	// cell; the full per-signal panel (driftBadge) is still what renders it, so no
+	// drift detail was dropped when the column went away.
+	if !strings.Contains(body, "var driftDot = driftOf(h).count > 0 ? driftBadge(h)") {
+		t.Error("buildRow no longer computes driftDot — drift is not folded into Version")
 	}
-	if driftTd < journeyTd {
-		t.Fatal("the Drift body cell comes before the Journey body cell")
+	if n := strings.Count(body, "driftBadge(h)"); n != 1 {
+		t.Errorf("driftBadge appears %d times in a row, want 1 (folded into the Version cell)", n)
 	}
-	between = rowExpr[journeyTd:driftTd]
-	if n := len(regexp.MustCompile(`'<td[\s>]`).FindAllString(between, -1)); n != 1 {
-		t.Errorf("found %d body cells between Journey and Drift, want exactly 1 "+
-			"(Drift's own <td>) — the body must match the header order", n)
+	// driftDot must actually reach the Version cell, not just be computed.
+	if !strings.Contains(body, "driftDot ? ' ' + driftDot") {
+		t.Error("driftDot is computed but never embedded in the Version cell")
 	}
-	// Drift must appear exactly once in each, i.e. the move did not leave a copy
-	// behind at the old position.
-	if n := strings.Count(header, ">Drift<"); n != 1 {
-		t.Errorf("Drift appears %d times in the header, want 1", n)
+
+	// Version and Maturity (ACMM + Journey folded together) must both be present
+	// exactly once, and the Maturity cell must render BOTH badges.
+	if n := strings.Count(header, ">Version<"); n != 1 {
+		t.Errorf("Version header appears %d times, want 1", n)
 	}
-	if n := strings.Count(rowExpr, "driftBadge(h)"); n != 1 {
-		t.Errorf("driftBadge appears %d times in a row, want 1", n)
+	if !strings.Contains(header, ">Maturity ") {
+		t.Error("Maturity header cell is missing — ACMM and Journey were meant to fold into it")
+	}
+	if !strings.Contains(body, "acmmBadge(h.acmmLevel)") || !strings.Contains(body, "journeyBadge(h.journey)") {
+		t.Error("the Maturity cell must render BOTH acmmBadge and journeyBadge — no maturity datum may be dropped")
 	}
 }

--- a/v2/pkg/hub/saas_dashboard_facet_tray_test.go
+++ b/v2/pkg/hub/saas_dashboard_facet_tray_test.go
@@ -424,8 +424,15 @@ func TestDriftFoldedIntoVersion(t *testing.T) {
 	if n := strings.Count(header, ">Version<"); n != 1 {
 		t.Errorf("Version header appears %d times, want 1", n)
 	}
-	if !strings.Contains(header, ">Maturity ") {
-		t.Error("Maturity header cell is missing — ACMM and Journey were meant to fold into it")
+	// The Maturity header is now stacked (title on line 1, the ACMM/Journey sort
+	// chips on line 2) via stackHeader, so the source builds it as
+	// stackHeader('Maturity', ...) rather than the old inline "Maturity " prefix.
+	// Both folded sort controls must still be reachable in the header.
+	if !strings.Contains(header, "stackHeader('Maturity'") {
+		t.Error("Maturity header title is missing — ACMM and Journey were meant to fold into it")
+	}
+	if !strings.Contains(header, "subSort('acmmLevel', 'ACMM ⇅'") || !strings.Contains(header, "subSort('journey', 'Journey ⇅'") {
+		t.Error("the Maturity header dropped a folded sort control — both ACMM and Journey ⇅ must stay reachable")
 	}
 	if !strings.Contains(body, "acmmBadge(h.acmmLevel)") || !strings.Contains(body, "journeyBadge(h.journey)") {
 		t.Error("the Maturity cell must render BOTH acmmBadge and journeyBadge — no maturity datum may be dropped")

--- a/v2/pkg/hub/saas_dashboard_hive_sort_test.go
+++ b/v2/pkg/hub/saas_dashboard_hive_sort_test.go
@@ -113,9 +113,10 @@ func TestHiveProvisionSortUsesRegisteredAt(t *testing.T) {
 	for _, snippet := range []string{
 		"function hiveProvisionTime(h)",
 		"var raw = h && h.registeredAt;",
-		"sortDashHives(\\'registeredAt\\')",
-		// The provision-date sort survives as a thin "Prov ⇅" header (the date
-		// itself moved into the status hover); the sort trigger must remain.
+		// After the 15-to-9 fold the standalone Prov column is gone, but its sort
+		// survives as an inline "Prov ⇅" control on the Uptime header, wired via the
+		// subSort() helper to the registeredAt key. The trigger must remain reachable.
+		"subSort('registeredAt', 'Prov ⇅'",
 		"Prov ⇅",
 		// registeredAt must be a recognised sort key, otherwise a persisted
 		// choice of it would be rejected on the next load.

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -82,7 +82,7 @@
     .header-right { display: flex; align-items: center; gap: .8rem; justify-self: end; }
 
     /* ── Utility ── */
-    .section-pad { padding: clamp(4rem, 8vw, 7rem) clamp(1rem, 4vw, 4.5rem); }
+    .section-pad { padding: clamp(4rem, 8vw, 7rem) clamp(1rem, 4vw, 4.5rem); scroll-margin-top: 5.5rem; }
     .section-label {
       color: var(--amber);
       letter-spacing: .12em;
@@ -483,7 +483,10 @@
     }
 
     /* ── Hive table ── */
-    .section { max-width: 1200px; margin: 0 auto; padding: 0 clamp(1rem, 4vw, 4.5rem) 3rem; }
+    /* scroll-margin-top clears the sticky .site-header (~4.5rem tall) so an
+       in-page jump (Contributors/Public-hives tiles, leaderboard link) lands
+       with the section's own heading visible, not scrolled up under the nav. */
+    .section { max-width: 1200px; margin: 0 auto; padding: 0 clamp(1rem, 4vw, 4.5rem) 3rem; scroll-margin-top: 5.5rem; }
     .section > h2 {
       font-size: 1.4rem;
       font-weight: 800;
@@ -692,12 +695,15 @@
         <div class="metric-grid">
           <div><span>Agents running</span><strong id="stat-agents">—</strong></div>
           <div><span>Managed repos</span><strong id="stat-repos">—</strong></div>
-          <!-- The Contributors tile links to the "Contribute compute to a hive"
-               card (#contribute-compute), which explains how contributing works:
-               you lend your AI CLI to run agents for a public hive via ClankeR
-               and climb the leaderboard. Same stat-jump affordance/keyboard
-               access as the Public hives tile. -->
-          <a href="#contribute-compute" class="stat-jump" title="Learn how to contribute compute"><span>Contributors</span><strong id="stat-contributors">—</strong></a>
+          <!-- The Contributors tile jumps to the public-hive table (#hives),
+               where the "Want to help?" blurb explains that clicking a hive's
+               Contribute button lends your AI CLI to run its agents via ClankeR.
+               Sending the click straight to the actionable list (rather than the
+               explainer card lower down) is why this points at #hives; the
+               "click to help a hive" CTA names the action, mirroring the
+               "click to request one" Available-hives tile. Same stat-jump
+               affordance/keyboard access as the Public hives tile. -->
+          <a href="#hives" class="stat-jump" title="Help a public hive — lend your CLI to its agents"><span>Contributors</span><strong id="stat-contributors">—</strong><span class="stat-cta">click to help a hive</span></a>
           <!-- The Public hives tile jumps to the public-hive table below (#hives),
                since that table IS the list of public hives this count describes.
                An <a> (not a JS scroll handler) keeps it keyboard-focusable and
@@ -993,7 +999,7 @@
       </div>
       <!-- Contribute blurb: the Contributors tile and the "Contribute compute"
            card both point here, so name the action next to the list it refers to. -->
-      <p style="color:var(--muted);font-size:.85rem;margin:-4px 0 14px;max-width:60ch">Want to help? Pick a public hive below and lend your AI CLI to run its agents through ClankeR &mdash; <a href="/get-started#contribute" style="color:var(--blue)">start contributing</a>. Your work shows up as tasks completed under your GitHub username on that hive and on the leaderboard.</p>
+      <p style="color:var(--muted);font-size:.85rem;margin:-4px 0 14px;max-width:60ch">Want to help? Pick a public hive below and click its <strong style="color:var(--text)">Contribute</strong> button to run its agents through ClankeR and contribute fixes to a hive of your choice. Your work shows up as tasks completed under your GitHub username, on that hive and on the <a href="#leaderboard" style="color:var(--blue)">leaderboard</a>.</p>
       <div id="hive-table-container"><div class="loading">Loading hives...</div></div>
     </section>
 

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -486,7 +486,12 @@
     /* scroll-margin-top clears the sticky .site-header (~4.5rem tall) so an
        in-page jump (Contributors/Public-hives tiles, leaderboard link) lands
        with the section's own heading visible, not scrolled up under the nav. */
-    .section { max-width: 1200px; margin: 0 auto; padding: 0 clamp(1rem, 4vw, 4.5rem) 3rem; scroll-margin-top: 5.5rem; }
+    /* Match .section-pad's horizontal geometry (same side padding, no narrower
+       max-width cap) so #hives ("Active Hives") and #leaderboard line up with the
+       full-width sections above them. Previously .section capped at 1200px and
+       centered, so on a wide viewport its left edge sat far right of the
+       edge-to-edge .section-pad sections and the table looked misaligned. */
+    .section { margin: 0 auto; padding: 0 clamp(1rem, 4vw, 4.5rem) 3rem; scroll-margin-top: 5.5rem; }
     .section > h2 {
       font-size: 1.4rem;
       font-weight: 800;


### PR DESCRIPTION
Propagates latest v2 (UI PRs #2427/#2429/#2432/#2433/#2434) into dd.

handleGovernorRepos taken wholesale from v2 per maintainer decision (prior sync #2430 already established v2's saveConfig + single-forge/default-repo validation on dd, so this refresh merged cleanly with no new conflicts). ConfigCoordinator (configSnapshot/mutateConfig) remains intact everywhere else on dd. go build ./... clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)