### PR TITLE
fix(dashboard): stop prompting hosted operators for HIVE_DASHBOARD_TOKEN

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -6688,7 +6688,11 @@ func (s *Server) handleAuthToken(w http.ResponseWriter, r *http.Request) {
 	// shared token no longer grants API access on that path (see authenticate).
 	// Exposing it publicly here would leak the internal server-to-server secret
 	// (used as X-Hive-Internal by the local proxy) to any visitor.
-	if s.directRouteAuthzEnabled() {
+	// The same applies on a hub-proxied spoke: nginx injects per-user identity,
+	// so the token is server-to-server only there too — and reporting
+	// configured=true made the SPA prompt hosted operators for a token they
+	// were never given (and don't need; their hub login already authorizes).
+	if s.directRouteAuthzEnabled() || s.hubProxied() {
 		jsonError(w, "not available on this hive", http.StatusNotFound)
 		return
 	}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -895,6 +895,14 @@ func (s *Server) directRouteAuthzEnabled() bool {
 		s.deps.Config.Dashboard.IsDirectRouteAuthzEnabled()
 }
 
+// hubProxied reports whether this spoke sits behind the hub's nginx, which
+// injects per-user X-Hive-User/X-Hive-Role identity headers. There the shared
+// dashboard token is a server-to-server credential only and must never be
+// requested from (or disclosed to) a browser.
+func (s *Server) hubProxied() bool {
+	return s.deps != nil && s.deps.Config != nil && s.deps.Config.Dashboard.HubProxied
+}
+
 // isPublicPath returns true for paths that should be accessible without
 // authentication even when DASHBOARD_AUTH_TOKEN is set. This covers health
 // checks, the snapshot preview, the contribute flow, and auth negotiation.

--- a/v2/pkg/dashboard/spoke_authz_test.go
+++ b/v2/pkg/dashboard/spoke_authz_test.go
@@ -386,6 +386,26 @@ func TestHandleAuthToken_HiddenOnDirectRoute(t *testing.T) {
 	}
 }
 
+func TestHandleAuthToken_HiddenOnHubProxied(t *testing.T) {
+	// On a hub-proxied spoke identity comes from nginx-injected headers; the
+	// shared token is server-to-server only. Reporting configured=true here
+	// made the SPA prompt hosted operators to paste a token they were never
+	// given (and a leaked value would let read-role users escalate to writes).
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	s.deps.Config.Dashboard.HubProxied = true
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"clubanderson:owner", "someone:read"}
+	req := httptest.NewRequest("GET", "/api/auth/token", nil)
+	w := httptest.NewRecorder()
+	s.handleAuthToken(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("auth token endpoint must 404 on hub-proxied spoke, got %d", w.Code)
+	}
+	if strings.Contains(w.Body.String(), s.authToken) {
+		t.Fatal("shared token must never be returned on a hub-proxied spoke")
+	}
+}
+
 func TestHandleAuthToken_AvailableWithoutAllowlist(t *testing.T) {
 	s := newFullServer(t)
 	s.authToken = "shared-secret-token"

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3254,6 +3254,16 @@
           } catch { _authConfigured = false; }
         }
         if (_authConfigured && !_authToken) {
+          // Never prompt a user who already has an authenticated identity —
+          // a hub login or device-flow session authorizes mutations on its
+          // own, and hosted operators are never given the shared token.
+          try {
+            const st = await _origFetch('/api/gh-user-auth/status');
+            if (st.ok) {
+              const d = await st.json();
+              if (d.logged_in) { _authConfigured = false; return null; }
+            }
+          } catch {}
           // Self-hosted hive with a token configured but none stored locally:
           // ask the operator to paste it once. It persists in localStorage.
           const entered = window.prompt('This hive requires its dashboard token to make changes. Paste HIVE_DASHBOARD_TOKEN:');


### PR DESCRIPTION
## Problem

On hosted (hub-proxied) hives, clicking any mutating dashboard control (resume/restart/pause) pops:

> This hive requires its dashboard token to make changes. Paste HIVE_DASHBOARD_TOKEN:

Hosted operators are never given this value — it's injected server-side from the `hive-secrets` Kubernetes secret. Their hub login already authorizes mutations via nginx-injected `X-Hive-User`/`X-Hive-Role` headers.

Root cause: the v4 mutation fetch-wrapper (added in #2178) checks `GET /api/auth/token`; that endpoint only 404s in direct-route mode (`!hub_proxied && allowlist`), so on a hub-proxied spoke it reports `configured=true` and the SPA falls into the self-hosted paste-once flow.

## Fix

- `/api/auth/token` now 404s on hub-proxied spokes, exactly like direct-route ones — in both modes the shared token is a server-to-server credential (`X-Hive-Internal`), and advertising its existence to browsers is misleading.
- The SPA additionally skips the prompt whenever `/api/gh-user-auth/status` reports a logged-in identity, so no authenticated user is ever asked for the token regardless of spoke configuration drift.
- Regression test `TestHandleAuthToken_HiddenOnHubProxied` locks in the 404.

The self-hosted token-only flow (no allowlist, not hub-proxied) is unchanged: the prompt still appears there, where the operator genuinely owns the token.

Observed on `hosted-kubestellar-console-4vkt` (v4, 454ea77) when resuming the scanner agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)