### PR TITLE
🐛 hub: arm the heartbeat upgrade fallback when kubectl cannot reach the hive's cluster

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2971,33 +2971,59 @@ func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"no cluster config for this hive"}`, http.StatusInternalServerError)
 		return
 	}
-	ns := "hive-hosted-" + id
-	cmd := kubectlForCluster(cluster, "rollout", "restart", "deployment/hive", "-n", ns)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		s.logger.Warn("upgrade failed", "hive", id, "cluster", cluster.ID, "output", string(out))
-		http.Error(w, `{"error":"upgrade failed — check hub logs for details"}`, http.StatusInternalServerError)
-		return
-	}
-	s.logger.Info("audit: hosted hive upgraded", "hive_id", id, "by", username, "cluster", cluster.ID)
-	s.recordTimeline(id, TimelineUpgradeStarted, "upgrade requested from the hub dashboard", username)
+
+	// kubectl is attempt one; the heartbeat fallback below is the ONLY path
+	// that works for a cluster the hub cannot route to (the spoke pulls, the
+	// hub answers). rolloutRestartHive bounds the attempt and honours the
+	// unreachable-cluster cache, so a firewalled cluster costs seconds here,
+	// not a gateway timeout.
+	delivered := s.rolloutRestartHive(cluster, id)
+
 	s.mu.Lock()
+	var latestSHA string
 	for i := range s.registry.Hives {
 		if s.registry.Hives[i].ID == id {
 			branch := s.registry.Hives[i].GitBranch
 			if branch == "" {
 				branch = "v2"
 			}
-			latestSHA := getLatestSHAForBranch(branch)
+			latestSHA = getLatestSHAForBranch(branch)
 			s.registry.Hives[i].Upgrading = true
 			s.registry.Hives[i].UpgradeTarget = latestSHA
 			s.registry.Hives[i].UpgradeStartedAt = time.Now()
 			break
 		}
 	}
+	if !delivered && latestSHA != "" {
+		// Arm the durable fallback: the spoke self-restarts onto the target
+		// when its next heartbeat carries UpgradeTo. The stale-upgrade sweep
+		// re-arms this if the spoke misses it, so the request cannot be lost.
+		if s.heartbeatUpgrade == nil {
+			s.heartbeatUpgrade = make(map[string]string)
+		}
+		s.heartbeatUpgrade[id] = latestSHA
+	}
 	s.mu.Unlock()
+
+	if !delivered && latestSHA == "" {
+		// kubectl failed AND no build target is known for the branch — there is
+		// nothing a heartbeat could deliver. This is the only remaining
+		// hard-failure case.
+		s.logger.Warn("upgrade failed: cluster unreachable and no build target known",
+			"hive", id, "cluster", cluster.ID)
+		http.Error(w, `{"error":"upgrade failed — cluster unreachable and no build target known"}`, http.StatusBadGateway)
+		return
+	}
+
+	mode := "kubectl"
+	if !delivered {
+		mode = "heartbeat"
+	}
+	s.logger.Info("audit: hosted hive upgrade requested",
+		"hive_id", id, "by", username, "cluster", cluster.ID, "mode", mode)
+	s.recordTimeline(id, TimelineUpgradeStarted, "upgrade requested from the hub dashboard ("+mode+")", username)
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"status":"upgrading"}`))
+	w.Write([]byte(`{"status":"upgrading","mode":"` + mode + `"}`))
 }
 
 // branchToTag converts a git branch name into a valid Docker image tag.
@@ -4021,6 +4047,9 @@ func (s *HubServer) markClusterUnreachable(clusterID string) {
 	}
 	s.clusterUnreachableMu.Lock()
 	defer s.clusterUnreachableMu.Unlock()
+	if s.clusterUnreachableUntil == nil {
+		s.clusterUnreachableUntil = make(map[string]time.Time)
+	}
 	s.clusterUnreachableUntil[clusterID] = time.Now().Add(clusterUnreachableTTL)
 }
 

--- a/v2/pkg/hub/saas_handlers_coverage_test.go
+++ b/v2/pkg/hub/saas_handlers_coverage_test.go
@@ -241,13 +241,16 @@ func TestHandleUpgradeHiveKubectlFails(t *testing.T) {
 		t.Errorf("missing hive status = %d, want 404", rec.Code)
 	}
 
-	// Owner, cluster resolves, kubectl fails (fake) -> 500.
+	// Owner, cluster resolves, kubectl fails (fake), and no build target is
+	// known for the branch — the one remaining hard-failure case. A kubectl
+	// failure alone no longer fails the request: with a known target it arms
+	// the heartbeat fallback instead (TestHandleUpgradeHiveUnreachableCluster*).
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", ClusterID: "hive-oke"})
 	rec = httptest.NewRecorder()
 	req = setPathValue(reqWithUser(http.MethodPost, "/up", "", "alice"), "id", "h1")
 	s.handleUpgradeHive(rec, req)
-	if rec.Code != http.StatusInternalServerError {
-		t.Errorf("kubectl-fail upgrade status = %d, want 500", rec.Code)
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("kubectl-fail upgrade with no target status = %d, want 502", rec.Code)
 	}
 }
 

--- a/v2/pkg/hub/upgrade_fallback_test.go
+++ b/v2/pkg/hub/upgrade_fallback_test.go
@@ -1,0 +1,113 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// seedLatestSHA installs a fake image-verified head SHA for a branch and
+// restores the previous cache on cleanup, so tests don't leak into each other.
+func seedLatestSHA(t *testing.T, branch, sha string) {
+	t.Helper()
+	latestSHAMu.Lock()
+	prev, had := latestSHAByBranch[branch]
+	latestSHAByBranch[branch] = branchSHAInfo{SHA: sha}
+	latestSHAMu.Unlock()
+	t.Cleanup(func() {
+		latestSHAMu.Lock()
+		if had {
+			latestSHAByBranch[branch] = prev
+		} else {
+			delete(latestSHAByBranch, branch)
+		}
+		latestSHAMu.Unlock()
+	})
+}
+
+// An upgrade against a cluster the hub cannot reach must not fail — it must
+// arm the heartbeat fallback, which is the only delivery path that works for
+// firewalled clusters (the spoke pulls; the hub answers). This is the exact
+// production case of the vllm-d cluster: every manual upgrade 504ed and armed
+// nothing, so hives there could never be upgraded from the hub.
+func TestHandleUpgradeHiveUnreachableClusterArmsHeartbeatFallback(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	mkUser(t, "alice")
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", ClusterID: "vllm-d"})
+	s := &HubServer{
+		hubSecret: testHubSecret,
+		logger:    slog.Default(),
+		clusters:  map[string]ClusterConfig{"vllm-d": {ID: "vllm-d"}},
+		// The unreachable cache is pre-populated, exactly as it is in
+		// production after the first failed kubectl: rolloutRestartHive skips
+		// kubectl entirely and reports non-delivery.
+		clusterUnreachableUntil: map[string]time.Time{"vllm-d": time.Now().Add(time.Hour)},
+	}
+	s.registry.Hives = []RegistryEntry{{ID: "h1", GitBranch: "v2"}}
+	seedLatestSHA(t, "v2", "abc1234")
+
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser("POST", "/up", "", "alice"), "id", "h1")
+	s.handleUpgradeHive(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("unreachable-cluster upgrade status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"mode":"heartbeat"`) {
+		t.Errorf("response should name the heartbeat mode, got %s", rec.Body.String())
+	}
+	s.mu.Lock()
+	armed := s.heartbeatUpgrade["h1"]
+	var latched bool
+	var target string
+	for i := range s.registry.Hives {
+		if s.registry.Hives[i].ID == "h1" {
+			latched = s.registry.Hives[i].Upgrading
+			target = s.registry.Hives[i].UpgradeTarget
+		}
+	}
+	s.mu.Unlock()
+	if armed != "abc1234" {
+		t.Errorf("heartbeat fallback armed with %q, want abc1234", armed)
+	}
+	if !latched || target != "abc1234" {
+		t.Errorf("registry not latched: upgrading=%v target=%q, want true/abc1234", latched, target)
+	}
+}
+
+// When kubectl cannot deliver AND no image-verified build target exists for
+// the branch, there is genuinely nothing a heartbeat could carry — that is the
+// one remaining hard-failure case, and it must say so rather than pretend.
+func TestHandleUpgradeHiveUnreachableClusterWithoutTargetFails(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	mkUser(t, "alice")
+	saveSaaSHive(&SaaSHive{ID: "h2", Owner: "alice", ClusterID: "vllm-d"})
+	s := &HubServer{
+		hubSecret:               testHubSecret,
+		logger:                  slog.Default(),
+		clusters:                map[string]ClusterConfig{"vllm-d": {ID: "vllm-d"}},
+		clusterUnreachableUntil: map[string]time.Time{"vllm-d": time.Now().Add(time.Hour)},
+	}
+	// The registry names a branch with NO cached SHA: no target can exist.
+	s.registry.Hives = []RegistryEntry{{ID: "h2", GitBranch: "branch-with-no-builds"}}
+
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser("POST", "/up", "", "alice"), "id", "h2")
+	s.handleUpgradeHive(rec, req)
+
+	if rec.Code != 502 {
+		t.Fatalf("no-target upgrade status = %d, want 502 (body=%s)", rec.Code, rec.Body.String())
+	}
+	s.mu.Lock()
+	_, armed := s.heartbeatUpgrade["h2"]
+	s.mu.Unlock()
+	if armed {
+		t.Error("heartbeat fallback must not be armed when there is no target SHA")
+	}
+}


### PR DESCRIPTION
## Problem

A manual **Upgrade** from the hub dashboard ran kubectl synchronously and failed outright when the hive's cluster is unreachable — a 504 through the ingress, with nothing armed. Every hive on a firewalled cluster was therefore impossible to upgrade from the hub, even though the heartbeat fallback (the path the auto-upgrade sweep already uses) works there. The spoke pulls; the hub answers — the manual path just never used the answering channel.

## Fix

- `handleUpgradeHive` now delivers via `rolloutRestartHive` (bounded timeout + unreachable-cluster cache — seconds, not a gateway timeout) and, when kubectl does not deliver, latches the registry (`Upgrading`/`UpgradeTarget`/`UpgradeStartedAt`) and arms `heartbeatUpgrade` so the spoke self-restarts onto the target at its next beat. The stale-upgrade sweep re-arms it if the beat is missed, so the request cannot be lost.
- The only remaining hard failure (502) is a cluster kubectl cannot reach **and** a branch with no image-verified build target — there is genuinely nothing a heartbeat could carry.
- `markClusterUnreachable` lazily initialises its map so a `HubServer` constructed without it cannot panic.

## Tests

- `TestHandleUpgradeHiveUnreachableClusterArmsHeartbeatFallback` — unreachable cluster + known target → 200, `mode:heartbeat`, fallback armed, registry latched.
- `TestHandleUpgradeHiveUnreachableClusterWithoutTargetFails` — no target → 502, nothing armed.
- `TestHandleUpgradeHiveKubectlFails` updated to the new contract.
- Mutation-verified: un-arming the fallback, skipping the 502 branch, and dropping the registry latch each fail a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)