### PR TITLE
✨ hub+spoke: detect duplicate spoke instances and deliver a remote rolling restart

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -665,6 +665,17 @@ func startDocsTokenRefresh(ctx context.Context, cfg *config.Config, appKeyFile s
 // short uptime that keeps resetting is the only visible tell.
 var processStartedAt = time.Now()
 
+// reporterName identifies this spoke process to the hub (HeartbeatPayload
+// Reporter). In-cluster the hostname IS the pod name; on failure it stays
+// empty, which the hub reads as "too old / cannot report", never as data.
+var reporterName, _ = os.Hostname()
+
+// spokeRestartMinUptime is how old this process must be before it acts on a
+// hub-delivered restart. The hub delivers the instruction to every beat in a
+// multi-minute window so all instances hear it; without this guard the
+// restarted process would come back inside the same window and restart again.
+const spokeRestartMinUptime = 10 * time.Minute
+
 func main() {
 	startTime := time.Now()
 	defaultConfig := "/etc/hive/hive.yaml"
@@ -2449,6 +2460,10 @@ func main() {
 				AIAuthor:          cfg.Project.AIAuthor,
 				AIAuthorEffective: cfg.EffectiveAIAuthor(),
 				StartedAt:         processStartedAt.UTC().Format(time.RFC3339),
+				// Reporter names THIS process (the pod) so the hub can tell two
+				// instances reporting as one hive apart — the pod name is the
+				// hostname inside the container.
+				Reporter: reporterName,
 				// Advisory-staleness signal (mirrors StartedAt/uptime). Report the
 				// last successful digest-post time only if the spoke has actually
 				// posted one — a zero time is left as an empty string so the hub
@@ -2601,7 +2616,23 @@ func main() {
 				// and then stops re-sending them.
 				GitHubAppKeysHeld: heldPerAppIDKeyFingerprints(),
 			}
-		}, heartbeatSendInterval, logger, hub.UpgradeCallback(func(targetSHA string) {
+		}, heartbeatSendInterval, logger, hub.RestartSpokeCallback(func() {
+			if up := time.Since(processStartedAt); up < spokeRestartMinUptime {
+				logger.Info("hub requested a spoke restart; ignoring — this process just started",
+					"uptime", up.Round(time.Second))
+				return
+			}
+			logger.Warn("hub requested a spoke restart — rolling this deployment",
+				"reporter", reporterName)
+			if err := hub.RolloutRestartSelf(logger); err != nil {
+				// Do NOT exit here: without deployment-patch RBAC an exit would
+				// restart onto the same state every delivery and look like a
+				// crash-loop. The error names the missing Role instead.
+				logger.Error("spoke restart failed: could not patch own Deployment",
+					"error", err,
+					"hint", "grant get/patch on deployments/hive in this namespace (hive-self-upgrade Role/RoleBinding)")
+			}
+		}), hub.UpgradeCallback(func(targetSHA string) {
 			const upgradeMarkerPath = "/data/upgrade-requested"
 
 			// attemptCount carries the number of PREVIOUS failed attempts for this

--- a/v2/pkg/hub/drift.go
+++ b/v2/pkg/hub/drift.go
@@ -70,6 +70,10 @@ const (
 	// app-missing/app-perm-issue so operator work is never filed as an
 	// owner-facing adoption problem.
 	DriftKindAppCredsOperator = "app-creds-operator"
+	// DriftKindDuplicateSpoke: two spoke instances are alternating reports as
+	// this one hive, so every registry field flips with whichever spoke
+	// reported last.
+	DriftKindDuplicateSpoke = "duplicate-spoke"
 	// DriftKindAppIDPlaceholder marks a hive still authenticating as the
 	// placeholder App sentinel (config.PlaceholderAppID). Distinct from
 	// app-creds-operator because the fault is the app_id itself, not the key:
@@ -493,6 +497,18 @@ func computeDrift(h MyHiveEntry, norm fleetNorm, latestSHAs map[string]string, n
 			"This hive is authenticating as the placeholder App ID, which is not a real GitHub App — "+
 				"no installation ID or private key can make it work. The hub must assign the cluster's real "+
 				"github_app_id; the hive owner cannot fix this and should not be asked to")
+	}
+
+	// Two instances alternating as one hive poisons every other signal in
+	// this entry — each drift row below reflects whichever instance reported
+	// last, and the dashboard flips with them. Raised first and always (even
+	// on a placeholder): the fix is shedding the stale instance, and the hub
+	// has a delivered path for that (Restart Spoke arms RolloutRestartSelf on
+	// every instance via the heartbeat).
+	if h.ConflictingReporters != "" {
+		add(DriftKindDuplicateSpoke, DriftCritical,
+			"two spoke instances are reporting as this hive ("+h.ConflictingReporters+
+				") and their states alternate every beat — use Restart Spoke to shed the stale instance")
 	}
 
 	// A placeholder legitimately has no App, no agents and ACMM 0. Flagging it

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -316,6 +316,13 @@ type HeartbeatPayload struct {
 	// but restarted 35 times — is visible in My Hives instead of looking
 	// healthy. A short uptime that keeps resetting is the tell.
 	StartedAt string `json:"started_at,omitempty"`
+	// Reporter is the pod name (os.Hostname) of the spoke PROCESS that sent
+	// this beat. It exists because two spoke instances can report as the same
+	// hive_id — a stale ReplicaSet pod surviving a rollout, or an orphaned
+	// duplicate deployment — and their alternating states made the dashboard
+	// flip every beat with nothing naming the culprit. Empty means the spoke
+	// is too old to report it: UNKNOWN, never evidence of anything.
+	Reporter string `json:"reporter,omitempty"`
 	// AdvisoryLastPostedAt is when this spoke last SUCCESSFULLY posted/updated
 	// its advisory-digest issue (RFC3339). It is the mirror of StartedAt for the
 	// advisory path: the hub renders a "stale advisory" pill so a hive that
@@ -514,6 +521,10 @@ type StatusCollector func() *HeartbeatPayload
 
 // UpgradeCallback is called when the hub instructs this hive to upgrade
 // to a specific SHA via the heartbeat response.
+// RestartSpokeCallback handles a hub-requested rolling restart of this spoke
+// (HeartbeatResponse.RestartSpoke). The callback owns the uptime guard.
+type RestartSpokeCallback func()
+
 type UpgradeCallback func(targetSHA string)
 
 func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, interval time.Duration, logger *slog.Logger, callbacks ...any) {
@@ -533,6 +544,7 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 	var onAuthorizedUsers AuthorizedUsersCallback
 	var onProjectConfig ProjectConfigCallback
 	var onGatewayConfig GatewayConfigCallback
+	var onRestartSpoke RestartSpokeCallback
 	for _, cb := range callbacks {
 		switch fn := cb.(type) {
 		case UpgradeCallback:
@@ -551,6 +563,8 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 			onProjectConfig = fn
 		case GatewayConfigCallback:
 			onGatewayConfig = fn
+		case RestartSpokeCallback:
+			onRestartSpoke = fn
 		}
 	}
 
@@ -593,6 +607,9 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 		// creates/replaces the gateway.
 		if resp.PendingGateway != nil && onGatewayConfig != nil {
 			onGatewayConfig(resp.PendingGateway)
+		}
+		if resp.RestartSpoke && onRestartSpoke != nil {
+			onRestartSpoke()
 		}
 	}
 
@@ -991,7 +1008,16 @@ type HeartbeatResponse struct {
 	// ghcr.io/kubestellar/hive:<SwitchToTag> and restart. Used for branch
 	// switches on clusters the hub can't reach over kubectl — the spoke has
 	// in-cluster RBAC (hive-self-upgrade role) to patch its own deployment.
-	SwitchToTag     string                    `json:"switch_to_tag,omitempty"`
+	SwitchToTag string `json:"switch_to_tag,omitempty"`
+	// RestartSpoke instructs the spoke to rolling-restart its own deployment
+	// (RolloutRestartSelf) without changing the image. It is the remote kill
+	// switch for a duplicate spoke instance on a cluster the hub cannot reach:
+	// an upgrade can't help (the instance is already at the target SHA), only
+	// a restart sheds it. Delivered to every beat inside a bounded arm window
+	// so ALL instances reporting as this hive receive it; the spoke's own
+	// uptime guard keeps a freshly restarted process from acting on the same
+	// window twice.
+	RestartSpoke    bool                      `json:"restart_spoke,omitempty"`
 	GitHubAppConfig *HeartbeatGitHubAppConfig `json:"github_app_config,omitempty"`
 	HubBanner       *HubBanner                `json:"hub_banner,omitempty"`
 	IsPublic        *bool                     `json:"is_public,omitempty"`

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -213,6 +213,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	// switch-branch and auto-upgrade above.
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/forge", s.requireAuth(s.handleSwitchForge))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/reset-app", s.requireAuth(s.handleResetApp))
+	s.mux.HandleFunc("POST /api/saas/hives/{id}/restart-spoke", s.requireAuth(s.handleRestartSpoke))
 	s.mux.HandleFunc("GET /api/saas/hive-config/{hiveID}", s.requireAuth(s.handleProxyHiveConfig))
 	s.mux.HandleFunc("GET /api/saas/latest-sha", s.handleLatestSHA)
 	s.mux.HandleFunc("POST /api/saas/hub/upgrade", s.requireAdmin(s.handleHubSelfUpgrade))
@@ -11393,6 +11394,12 @@ const dashboardHTML = `<!DOCTYPE html>
            that App's installation_id after its identity is moved to the fleet
            App, so every field reads correct while freshly minted tokens 404. */
         if (_isAdmin && isHosted) menuItems.push('<div onclick="resetHiveApp(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">Reset App</div>');
+        /* Restart Spoke rolling-restarts every instance reporting as this
+           hive. The case it exists for: two instances alternating as one hive
+           (conflictingReporters drift) on a cluster the hub cannot reach —
+           the heartbeat is the only channel, and a restart sheds the stale
+           instance while costing the healthy one a single rolling restart. */
+        if (_isAdmin && isHosted) menuItems.push('<div onclick="restartHiveSpoke(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">Restart Spoke</div>');
         if (isLocal && h.role === 'owner') menuItems.push('<div onclick="removeLocalHive(\'' + esc(h.id) + '\')" style="' + mi + '">Remove</div>');
         if (isHosted && h.role === 'owner' && _clusterList && _clusterList.length > 1 && h.migrationStatus !== 'migrating') menuItems.push('<div onclick="openMigrateModal(\'' + esc(h.id) + '\',\'' + esc(h.clusterId || '') + '\')" style="' + mi + '">Move to cluster</div>');
         if (isHosted && h.role === 'owner') menuItems.push('<div style="border-top:1px solid #30363d;margin:4px 0"></div><div onclick="deleteHive(\'' + esc(h.id) + '\')" style="' + mi + ';color:#f85149">Delete</div>');
@@ -12322,6 +12329,22 @@ const dashboardHTML = `<!DOCTYPE html>
         if (typeof loadHives === 'function') loadHives();
       } catch (e) {
         alert('Reset failed: ' + e);
+      }
+    }
+
+    /* Restart Spoke: arms a rolling restart delivered to every spoke instance
+       reporting as this hive on their next heartbeats (bounded window). Used
+       to shed a stale duplicate instance the hub cannot delete directly. */
+    async function restartHiveSpoke(hiveId, hiveName) {
+      if (!confirm('Restart the spoke for "' + hiveName + '"?\n\nEvery instance reporting as this hive rolling-restarts on its next heartbeat (up to 5 minutes). The image and configuration are unchanged.')) return;
+      try {
+        var resp = await fetch('/api/saas/hives/' + encodeURIComponent(hiveId) + '/restart-spoke', {method: 'POST'});
+        var data = await resp.json().catch(function() { return {}; });
+        if (!resp.ok) { alert('Restart failed: ' + (data.error || resp.status)); return; }
+        alert('Spoke restart armed for "' + hiveName + '".\n\nInstances restart on their next heartbeat within the 5-minute window.');
+        if (typeof loadHives === 'function') loadHives();
+      } catch (e) {
+        alert('Restart failed: ' + e);
       }
     }
 

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -545,6 +545,14 @@ type SaaSHive struct {
 	// delivery (see AppIdentityDelivered), so a lost beat is retried.
 	PendingAppConfig *PendingAppIdentity `json:"pending_app_config,omitempty"`
 
+	// RequestedRestartAt (RFC3339) arms a rolling restart of this hive's spoke,
+	// delivered on every heartbeat inside spokeRestartDeliveryWindow and then
+	// cleared. Durable on the hive record for the same reason as
+	// PendingAppConfig: an in-memory flag dies with a hub restart and a missed
+	// beat, and the whole point of this switch is reaching spokes the hub
+	// cannot touch any other way.
+	RequestedRestartAt string `json:"requested_restart_at,omitempty"`
+
 	Error           string                 `json:"error,omitempty"`
 	AutoUpgrade     bool                   `json:"auto_upgrade"`
 	IsPublic        bool                   `json:"is_public"`

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -192,6 +192,11 @@ type RegistryEntry struct {
 	GitHubAppRequired     bool         `json:"githubAppRequired,omitempty"`
 	GitHubAppPermIssue    string       `json:"githubAppPermIssue,omitempty"`
 	GitHubAppState        string       `json:"githubAppState,omitempty"`
+	// ConflictingReporters names two spoke instances that are BOTH reporting
+	// as this hive (e.g. "hive-abc… ↔ hive-def…"), set when their beats
+	// alternate. Non-empty is a critical drift signal: every field in this
+	// entry is only as trustworthy as whichever instance reported last.
+	ConflictingReporters string `json:"conflictingReporters,omitempty"`
 	// GitHubAppID is the App ID the spoke reports it is authenticating AS.
 	//
 	// Carried into the registry so the hub can SEE a spoke running the
@@ -602,6 +607,12 @@ type HubServer struct {
 	// the time after which kubectl may be retried.
 	clusterUnreachableUntil map[string]time.Time
 	clusterUnreachableMu    sync.Mutex
+	// reporterSeen tracks which spoke instance (payload.Reporter, the pod
+	// name) last reported as each hive, to catch two instances alternating
+	// under one hive_id. Guarded by reporterMu, not s.mu — it is touched on
+	// every beat and must never contend with the registry lock.
+	reporterSeen map[string]*reporterFlipState
+	reporterMu   sync.Mutex
 	// heartbeatSwitchTag tracks hives that should switch their deployment
 	// image to a specific tag (branch switch) via heartbeat, for clusters
 	// the hub can't reach over kubectl. Cleared once the spoke reports it.
@@ -973,6 +984,10 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		AIAuthor:          sanitizeField(payload.AIAuthor),
 		AIAuthorEffective: sanitizeField(payload.AIAuthorEffective),
 		StartedAt:         sanitizeField(payload.StartedAt),
+		// Duplicate-instance detection. noteReporter returns "" until two
+		// distinct reporters have ALTERNATED (A→B→A), so a normal rollout
+		// (A→B, B stays) never trips it.
+		ConflictingReporters: s.noteReporter(payload.HiveID, sanitizeField(payload.Reporter)),
 		// Advisory-staleness signal. Both are sanitized like every other
 		// spoke-reported string; an empty AdvisoryLastPostedAt is preserved as
 		// empty so the render/gate reads it as UNKNOWN rather than stale.
@@ -1499,6 +1514,11 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			"from", payload.GitHash,
 			"to", hbTarget,
 		)
+	}
+
+	if s.restartSpokeForHeartbeat(payload.HiveID) {
+		resp.RestartSpoke = true
+		s.logger.Info("heartbeat: delivering spoke restart", "hive_id", payload.HiveID, "reporter", payload.Reporter)
 	}
 
 	if ghCfg := s.pendingAppIdentityForHeartbeat(&payload); ghCfg != nil {

--- a/v2/pkg/hub/spoke_restart.go
+++ b/v2/pkg/hub/spoke_restart.go
@@ -1,0 +1,140 @@
+package hub
+
+import (
+	"net/http"
+	"time"
+)
+
+// spokeRestartDeliveryWindow is how long an armed restart keeps being
+// delivered after RequestedRestartAt. It must be long enough that EVERY
+// instance reporting as the hive gets at least one beat inside it (beats are
+// 1–2 minutes apart), because the whole point is reaching a duplicate
+// instance whose existence the hub can't otherwise act on. The spoke-side
+// uptime guard (spokeRestartMinUptime in cmd/hive) keeps a process that
+// already restarted from acting on the same window twice.
+const spokeRestartDeliveryWindow = 5 * time.Minute
+
+// reporterConflictWindow is how recently two reporters must have alternated
+// for the conflict to still be considered live. A rollout leaves exactly one
+// reporter, so the alternation stops and the conflict ages out on its own.
+const reporterConflictWindow = 15 * time.Minute
+
+// reporterFlipsToConfirm is how many A→B→A alternations are required before
+// two reporters are declared in conflict. One change of reporter is a normal
+// rollout (old pod's last beat, new pod's first); a return to a PREVIOUS
+// reporter is the signature of two live instances.
+const reporterFlipsToConfirm = 2
+
+// reporterFlipState is the per-hive memory behind noteReporter.
+type reporterFlipState struct {
+	last     string // reporter of the most recent beat
+	prev     string // reporter seen immediately before last
+	flips    int    // times the reporter returned to a previously seen one
+	lastFlip time.Time
+}
+
+// noteReporter records which spoke instance sent this beat and returns a
+// non-empty "a ↔ b" description while two instances are alternating as the
+// same hive. Empty reporter (a spoke too old to report one) is UNKNOWN and
+// never counts for or against a conflict — the state is left untouched.
+func (s *HubServer) noteReporter(hiveID, reporter string) string {
+	if reporter == "" {
+		return ""
+	}
+	s.reporterMu.Lock()
+	defer s.reporterMu.Unlock()
+	if s.reporterSeen == nil {
+		s.reporterSeen = make(map[string]*reporterFlipState)
+	}
+	st := s.reporterSeen[hiveID]
+	if st == nil {
+		st = &reporterFlipState{last: reporter}
+		s.reporterSeen[hiveID] = st
+		return ""
+	}
+	if reporter != st.last {
+		if reporter == st.prev {
+			// The reporter came BACK — both instances are alive.
+			st.flips++
+		} else {
+			// A reporter never seen adjacent to this one: treat as a fresh
+			// handover (rollout), not a conflict.
+			st.flips = 0
+		}
+		st.prev, st.last = st.last, reporter
+		st.lastFlip = time.Now()
+	}
+	if st.flips >= reporterFlipsToConfirm && time.Since(st.lastFlip) < reporterConflictWindow {
+		a, b := st.prev, st.last
+		if a > b {
+			a, b = b, a
+		}
+		return a + " ↔ " + b
+	}
+	if time.Since(st.lastFlip) >= reporterConflictWindow {
+		st.flips = 0
+	}
+	return ""
+}
+
+// restartSpokeForHeartbeat reports whether an armed restart should ride this
+// beat. It delivers to EVERY beat inside the window — all instances reporting
+// as this hive must hear it — and clears the armed record on the first beat
+// after the window so the file does not stay armed forever.
+func (s *HubServer) restartSpokeForHeartbeat(hiveID string) bool {
+	h := loadSaaSHive(hiveID)
+	if h == nil || h.RequestedRestartAt == "" {
+		return false
+	}
+	armedAt, err := time.Parse(time.RFC3339, h.RequestedRestartAt)
+	if err != nil {
+		// Unparseable is unrecoverable — clear it rather than deliver forever.
+		h.RequestedRestartAt = ""
+		if saveErr := saveSaaSHive(h); saveErr != nil {
+			s.logger.Warn("spoke restart: failed to clear bad timestamp", "hive_id", hiveID, "error", saveErr)
+		}
+		return false
+	}
+	if time.Since(armedAt) >= spokeRestartDeliveryWindow {
+		h.RequestedRestartAt = ""
+		if err := saveSaaSHive(h); err != nil {
+			s.logger.Warn("spoke restart: failed to clear expired request", "hive_id", hiveID, "error", err)
+		}
+		s.logger.Info("spoke restart window closed", "hive_id", hiveID, "armed_at", armedAt.Format(time.RFC3339))
+		return false
+	}
+	return true
+}
+
+// handleRestartSpoke arms a rolling restart for one hive's spoke:
+// POST /api/saas/hives/{id}/restart-spoke
+//
+// WHY AN OPERATOR NEEDS THIS. When two spoke instances report as one hive
+// (ConflictingReporters — a stale ReplicaSet pod, an orphaned duplicate
+// deployment), the dashboard flips state every beat and one instance is
+// usually broken in a way that pollutes the registry. The hub often cannot
+// reach the cluster to delete anything; the heartbeat is the only channel.
+// A restart delivered to every instance makes each patch its own Deployment
+// (RolloutRestartSelf): a stale pod is replaced and never comes back, while
+// the healthy instance suffers one rolling restart.
+func (s *HubServer) handleRestartSpoke(w http.ResponseWriter, r *http.Request) {
+	if s.getAuthUser(r) != hubAdminUsername {
+		http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
+		return
+	}
+	hiveID := r.PathValue("id")
+	h := loadSaaSHive(hiveID)
+	if h == nil {
+		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
+		return
+	}
+	h.RequestedRestartAt = time.Now().UTC().Format(time.RFC3339)
+	if err := saveSaaSHive(h); err != nil {
+		s.logger.Error("failed to arm spoke restart", "hive_id", hiveID, "error", err)
+		http.Error(w, `{"error":"could not arm the restart"}`, http.StatusInternalServerError)
+		return
+	}
+	s.logger.Info("spoke restart armed by operator", "hive_id", hiveID)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(`{"status":"armed","detail":"every spoke instance reporting as this hive will rolling-restart on its next heartbeat within the delivery window"}`))
+}

--- a/v2/pkg/hub/spoke_restart_test.go
+++ b/v2/pkg/hub/spoke_restart_test.go
@@ -1,0 +1,144 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Two instances alternating as one hive is the production signature this
+// package exists to catch (the WVA flip: ok at :22, key-invalid at :58,
+// forever). A single reporter change is a rollout and must stay silent.
+func TestNoteReporterFlagsAlternation(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+
+	if got := s.noteReporter("h1", "pod-a"); got != "" {
+		t.Fatalf("first beat flagged: %q", got)
+	}
+	if got := s.noteReporter("h1", "pod-b"); got != "" {
+		t.Fatalf("single handover flagged (a rollout would false-positive): %q", got)
+	}
+	if got := s.noteReporter("h1", "pod-a"); got != "" {
+		t.Fatalf("first return flagged too early: %q", got)
+	}
+	got := s.noteReporter("h1", "pod-b")
+	if got == "" {
+		t.Fatal("sustained alternation was not flagged")
+	}
+	if !strings.Contains(got, "pod-a") || !strings.Contains(got, "pod-b") {
+		t.Errorf("conflict does not name both reporters: %q", got)
+	}
+	// The conflict must persist while the alternation continues.
+	if got := s.noteReporter("h1", "pod-a"); got == "" {
+		t.Error("ongoing alternation lost the conflict")
+	}
+}
+
+func TestNoteReporterSilentOnRolloutAndUnknown(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+
+	// Rollout: a → b, then b keeps reporting. Never a conflict.
+	s.noteReporter("h2", "pod-a")
+	s.noteReporter("h2", "pod-b")
+	for i := 0; i < 5; i++ {
+		if got := s.noteReporter("h2", "pod-b"); got != "" {
+			t.Fatalf("steady reporter after rollout flagged: %q", got)
+		}
+	}
+
+	// A spoke too old to report one sends "": UNKNOWN, never data, and it
+	// must not disturb the state of what HAS been reported.
+	s3 := &HubServer{logger: slog.Default()}
+	s3.noteReporter("h3", "pod-a")
+	s3.noteReporter("h3", "pod-b")
+	s3.noteReporter("h3", "")
+	s3.noteReporter("h3", "pod-a")
+	if got := s3.noteReporter("h3", "pod-b"); got == "" {
+		t.Error("an interleaved empty reporter destroyed alternation tracking")
+	}
+}
+
+// An armed restart rides every beat inside the window (all instances must
+// hear it) and the record clears itself on the first beat after it.
+func TestRestartSpokeDeliveryWindow(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := &HubServer{logger: slog.Default()}
+
+	// Not armed → nothing.
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice"})
+	if s.restartSpokeForHeartbeat("h1") {
+		t.Fatal("unarmed hive got a restart")
+	}
+
+	// Freshly armed → delivered, and STILL armed for the next beat.
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice",
+		RequestedRestartAt: time.Now().UTC().Format(time.RFC3339)})
+	if !s.restartSpokeForHeartbeat("h1") {
+		t.Fatal("armed restart not delivered")
+	}
+	if !s.restartSpokeForHeartbeat("h1") {
+		t.Fatal("second beat inside the window missed the restart — a second instance would never hear it")
+	}
+
+	// Expired → not delivered, and the record is cleared durably.
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice",
+		RequestedRestartAt: time.Now().Add(-spokeRestartDeliveryWindow - time.Minute).UTC().Format(time.RFC3339)})
+	if s.restartSpokeForHeartbeat("h1") {
+		t.Fatal("expired restart still delivered")
+	}
+	if h := loadSaaSHive("h1"); h.RequestedRestartAt != "" {
+		t.Errorf("expired restart not cleared from the record: %q", h.RequestedRestartAt)
+	}
+
+	// Unparseable → cleared, never delivered.
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", RequestedRestartAt: "not-a-time"})
+	if s.restartSpokeForHeartbeat("h1") {
+		t.Fatal("unparseable timestamp delivered a restart")
+	}
+	if h := loadSaaSHive("h1"); h.RequestedRestartAt != "" {
+		t.Errorf("unparseable timestamp not cleared: %q", h.RequestedRestartAt)
+	}
+}
+
+func TestHandleRestartSpokeArmsDurably(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := &HubServer{hubSecret: testHubSecret, logger: slog.Default()}
+	mkUser(t, hubAdminUsername)
+	mkUser(t, "mallory")
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "someone"})
+
+	// Non-admin: forbidden, nothing armed.
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser("POST", "/rs", "", "mallory"), "id", "h1")
+	s.handleRestartSpoke(rec, req)
+	if rec.Code != 403 {
+		t.Fatalf("non-admin restart status = %d, want 403", rec.Code)
+	}
+	if h := loadSaaSHive("h1"); h.RequestedRestartAt != "" {
+		t.Fatal("non-admin request armed a restart")
+	}
+
+	// Admin: armed with a parseable fresh timestamp.
+	rec = httptest.NewRecorder()
+	req = setPathValue(reqWithUser("POST", "/rs", "", hubAdminUsername), "id", "h1")
+	s.handleRestartSpoke(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("admin restart status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	h := loadSaaSHive("h1")
+	armedAt, err := time.Parse(time.RFC3339, h.RequestedRestartAt)
+	if err != nil {
+		t.Fatalf("armed timestamp unparseable: %q (%v)", h.RequestedRestartAt, err)
+	}
+	if time.Since(armedAt) > time.Minute {
+		t.Errorf("armed timestamp not fresh: %v", armedAt)
+	}
+	// And the armed record is exactly what delivery reads.
+	if !s.restartSpokeForHeartbeat("h1") {
+		t.Error("endpoint-armed restart not delivered on the next beat")
+	}
+}


### PR DESCRIPTION
## Problem — the dashboard flip

Two spoke instances can report as the same `hive_id` (a stale ReplicaSet pod surviving a rollout, or an orphaned duplicate deployment). Their alternating heartbeats make the hive's dashboard state flip every beat — live case: `llm-d/llm-d-workload-variant-autoscaler` flips ok ↔ key-invalid on a strict 2-minute metronome, one state per phase offset — with nothing naming the culprit. On firewalled clusters (vllm-d) the hub cannot delete anything, and an upgrade can't help: the stale instance is already at the target SHA. The heartbeat is the only channel.

## Detection

- Spoke reports its pod name: `payload.reporter` (`os.Hostname()`). Empty = spoke too old to report — UNKNOWN, never counted as evidence.
- Hub tracks the reporter per hive: sustained **A→B→A alternation** sets `conflictingReporters` ("pod-a ↔ pod-b") on the registry entry and raises a critical `duplicate-spoke` drift signal naming both pods. A single handover (normal rollout) stays silent.

## Remedy

- `POST /api/saas/hives/{id}/restart-spoke` (admin; also a **Restart Spoke** menu item) durably arms `requested_restart_at` on the hive record — same armed-until-done pattern as Reset App (#2426).
- Delivery rides **every** beat inside a 5-minute window so all instances hear it, then self-clears. Each instance patches its own Deployment (`RolloutRestartSelf`, existing RBAC) — a stale pod is replaced and never comes back; the healthy one costs a single rolling restart.
- Spoke-side uptime guard (10 min) keeps a freshly restarted process from acting on the same window twice. On missing RBAC it logs the exact Role hint and does NOT exit (no crash-loop).

## Tests

- `TestNoteReporterFlagsAlternation` / `TestNoteReporterSilentOnRolloutAndUnknown` — alternation flags with both pod names; rollouts and empty reporters never do.
- `TestRestartSpokeDeliveryWindow` — delivered to every beat in the window; expired and unparseable records self-clear durably.
- `TestHandleRestartSpokeArmsDurably` — admin-only; armed record is exactly what delivery reads.
- Mutation-verified: 4 mutations (unreachable flip threshold, rollout-counts-as-flip, deliver-once, endpoint-arms-nothing) each fail a test.

Note: uses `confirm()`/`alert()` matching current v2; if #2431 (custom modals) lands first I'll rebase onto `hiveConfirm`/`hiveNotify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)