### PR TITLE
✨ hub: flag hives whose status keeps flipping, as a drift pill in the attention strip

### DIFF
--- a/v2/pkg/hub/drift.go
+++ b/v2/pkg/hub/drift.go
@@ -74,6 +74,9 @@ const (
 	// this one hive, so every registry field flips with whichever spoke
 	// reported last.
 	DriftKindDuplicateSpoke = "duplicate-spoke"
+	// DriftKindStatusFlipping: the hive's reported status keeps alternating
+	// between two values on a heartbeat cadence — the row cannot be trusted.
+	DriftKindStatusFlipping = "status-flipping"
 	// DriftKindAppIDPlaceholder marks a hive still authenticating as the
 	// placeholder App sentinel (config.PlaceholderAppID). Distinct from
 	// app-creds-operator because the fault is the app_id itself, not the key:
@@ -509,6 +512,15 @@ func computeDrift(h MyHiveEntry, norm fleetNorm, latestSHAs map[string]string, n
 		add(DriftKindDuplicateSpoke, DriftCritical,
 			"two spoke instances are reporting as this hive ("+h.ConflictingReporters+
 				") and their states alternate every beat — use Restart Spoke to shed the stale instance")
+	} else if h.StatusFlipping {
+		// Suppressed when duplicate-spoke already fired: that signal carries
+		// the same fact PLUS the culprit pod names, and two rows for one
+		// oscillation would double-count the hive in the summary strip.
+		add(DriftKindStatusFlipping, DriftWarn,
+			"reported status keeps flipping between two values on a heartbeat cadence — "+
+				"usually two spoke instances alternating as this hive (a spoke too old to report "+
+				"its pod name cannot be told apart) or an auth check oscillating; "+
+				"use Restart Spoke, or upgrade the spoke so the instances identify themselves")
 	}
 
 	// A placeholder legitimately has no App, no agents and ACMM 0. Flagging it

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -8293,7 +8293,9 @@ const dashboardHTML = `<!DOCTYPE html>
       'health-degraded': 'Health degraded',
       'upgrade-stuck':   'Upgrade stuck',
       'acmm-unset':      'ACMM level unset',
-      'no-agents':       'No agents running'
+      'no-agents':       'No agents running',
+      'duplicate-spoke': 'Duplicate spoke instances',
+      'status-flipping': 'Status flipping'
     };
 
     function driftKindLabel(kind) { return DRIFT_KIND_LABELS[kind] || kind || 'Unknown'; }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -197,6 +197,12 @@ type RegistryEntry struct {
 	// alternate. Non-empty is a critical drift signal: every field in this
 	// entry is only as trustworthy as whichever instance reported last.
 	ConflictingReporters string `json:"conflictingReporters,omitempty"`
+	// StatusFlipping is true while this hive's reported App-auth state keeps
+	// alternating between two values (status_flip.go) — the row cannot be
+	// trusted because each beat tells a different story. Works for spokes too
+	// old to report a Reporter; when both fire, duplicate-spoke names the
+	// culprit pods.
+	StatusFlipping bool `json:"statusFlipping,omitempty"`
 	// GitHubAppID is the App ID the spoke reports it is authenticating AS.
 	//
 	// Carried into the registry so the hub can SEE a spoke running the
@@ -613,6 +619,11 @@ type HubServer struct {
 	// every beat and must never contend with the registry lock.
 	reporterSeen map[string]*reporterFlipState
 	reporterMu   sync.Mutex
+	// statusFlipSeen tracks each hive's reported App-auth state to catch
+	// oscillation (status_flip.go). Same shape as reporterSeen, separate
+	// mutex for the same reason: touched on every beat.
+	statusFlipSeen map[string]*reporterFlipState
+	statusFlipMu   sync.Mutex
 	// heartbeatSwitchTag tracks hives that should switch their deployment
 	// image to a specific tag (branch switch) via heartbeat, for clusters
 	// the hub can't reach over kubectl. Cleared once the spoke reports it.
@@ -1069,6 +1080,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		GitHubAppRequired:       payload.GitHubAppRequired,
 		GitHubAppPermIssue:      sanitizeHeartbeatField(payload.GitHubAppPermIssue),
 		GitHubAppState:          sanitizeHeartbeatField(payload.GitHubAppState),
+		StatusFlipping:          s.noteStatusFlip(payload.HiveID, sanitizeHeartbeatField(payload.GitHubAppState)),
 		GitHubAppID:             payload.GitHubAppID,
 		GitHubAppSlug:           payload.GitHubAppSlug,
 		GitHubInstallationID:    payload.GitHubInstallationID,

--- a/v2/pkg/hub/status_flip.go
+++ b/v2/pkg/hub/status_flip.go
@@ -1,0 +1,61 @@
+package hub
+
+import "time"
+
+// Status-flip detection: a hive whose reported App-auth state keeps
+// ALTERNATING (ok → key-invalid → ok → …) is not transitioning, it is
+// oscillating — in practice two spoke instances alternating under one
+// hive_id, or a spoke whose auth check flaps every beat. Either way the
+// dashboard flips with it and every glance at the row tells a different
+// story.
+//
+// This is the reporter-blind sibling of noteReporter: it needs NOTHING from
+// the spoke (old builds included), because it watches the states the hub
+// already receives. When the spoke is new enough to also report its pod name,
+// the duplicate-spoke signal names the culprits; this signal only says the
+// row cannot be trusted.
+
+// statusFlipsToConfirm is how many returns to a previously reported state are
+// required before a hive is declared flipping. A single bounce (degraded →
+// ok → degraded hours later) is a hive having a bad day; three returns on a
+// heartbeat cadence is an oscillation.
+const statusFlipsToConfirm = 3
+
+// statusFlipWindow bounds how recent the last alternation must be for the
+// flag to persist. Beats are 1–2 minutes apart, so a genuine oscillation
+// re-arms this continuously; a hive that settles stops flapping and the flag
+// ages out on its own.
+const statusFlipWindow = 10 * time.Minute
+
+// noteStatusFlip records the App-auth state this beat reported and returns
+// true while the state is oscillating between two values. Unlike reporters,
+// an EMPTY state is meaningful here — it is "healthy" — so it participates in
+// alternation tracking rather than being skipped.
+func (s *HubServer) noteStatusFlip(hiveID, state string) bool {
+	s.statusFlipMu.Lock()
+	defer s.statusFlipMu.Unlock()
+	if s.statusFlipSeen == nil {
+		s.statusFlipSeen = make(map[string]*reporterFlipState)
+	}
+	st := s.statusFlipSeen[hiveID]
+	if st == nil {
+		s.statusFlipSeen[hiveID] = &reporterFlipState{last: state}
+		return false
+	}
+	if state != st.last {
+		if state == st.prev {
+			st.flips++
+		} else {
+			// A state never seen adjacent to this one: a normal transition,
+			// not an oscillation.
+			st.flips = 0
+		}
+		st.prev, st.last = st.last, state
+		st.lastFlip = time.Now()
+	}
+	if time.Since(st.lastFlip) >= statusFlipWindow {
+		st.flips = 0
+		return false
+	}
+	return st.flips >= statusFlipsToConfirm
+}

--- a/v2/pkg/hub/status_flip_test.go
+++ b/v2/pkg/hub/status_flip_test.go
@@ -1,0 +1,75 @@
+package hub
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// The production signature this exists for: WVA reported ok at :22 and
+// key-invalid at :58, every cycle, for an hour ("" is how a healthy state
+// arrives — it must count in the alternation, not be skipped).
+func TestNoteStatusFlipFlagsOscillation(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+	beats := []string{"", "key-invalid", "", "key-invalid", "", "key-invalid", ""}
+	flagged := false
+	for _, st := range beats {
+		flagged = s.noteStatusFlip("h1", st)
+	}
+	if !flagged {
+		t.Fatal("a sustained ok ↔ key-invalid oscillation was not flagged")
+	}
+	// And it stays flagged while the oscillation continues.
+	if !s.noteStatusFlip("h1", "key-invalid") {
+		t.Error("ongoing oscillation lost the flag")
+	}
+}
+
+// Genuine transitions must stay silent: a hive that degrades, recovers once,
+// or walks through DIFFERENT states is having a normal life, not oscillating.
+func TestNoteStatusFlipSilentOnRealTransitions(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+
+	// Degrade and stay degraded.
+	for _, st := range []string{"", "key-invalid", "key-invalid", "key-invalid"} {
+		if s.noteStatusFlip("h2", st) {
+			t.Fatal("a plain degradation was flagged as flipping")
+		}
+	}
+
+	// One bounce: degraded → recovered → degraded is below the threshold.
+	s2 := &HubServer{logger: slog.Default()}
+	for _, st := range []string{"", "not-installed", "", "not-installed"} {
+		if s2.noteStatusFlip("h3", st) {
+			t.Fatal("a single bounce was flagged as flipping")
+		}
+	}
+
+	// Walking through distinct states never flags: each is a fresh
+	// transition, not a return.
+	s3 := &HubServer{logger: slog.Default()}
+	for _, st := range []string{"", "key-missing", "not-installed", "wrong-installation", "key-invalid"} {
+		if s3.noteStatusFlip("h4", st) {
+			t.Fatal("a walk through distinct states was flagged as flipping")
+		}
+	}
+}
+
+// The drift signal must fire on a flipping hive, use the stable kind, and be
+// suppressed when duplicate-spoke already names the culprits — one
+// oscillation must not count a hive twice in the summary strip.
+func TestStatusFlippingDriftSignal(t *testing.T) {
+	h := MyHiveEntry{RegistryEntry: RegistryEntry{ID: "h1", StatusFlipping: true}}
+	if _, ok := hasSignal(computeDrift(h, fleetNorm{}, nil, time.Now()), DriftKindStatusFlipping); !ok {
+		t.Fatal("flipping hive raised no status-flipping signal")
+	}
+
+	h.ConflictingReporters = "pod-a ↔ pod-b"
+	rep := computeDrift(h, fleetNorm{}, nil, time.Now())
+	if _, ok := hasSignal(rep, DriftKindStatusFlipping); ok {
+		t.Error("status-flipping not suppressed when duplicate-spoke names the culprits")
+	}
+	if _, ok := hasSignal(rep, DriftKindDuplicateSpoke); !ok {
+		t.Error("duplicate-spoke signal missing")
+	}
+}


### PR DESCRIPTION
## What

Adds a **Status flipping** pill to the "N hives need attention" strip, counting hives whose reported App-auth state keeps ALTERNATING on a heartbeat cadence (the WVA case: ok at :22, key-invalid at :58, every cycle, for an hour — every glance at the row told a different story and nothing counted it).

## How

- `noteStatusFlip` (hub-side, `status_flip.go`) watches the states the hub already receives — so it works for **every spoke, including builds too old to report a pod name**. It is the reporter-blind sibling of #2444's duplicate-spoke detection.
- Three returns to a previously reported state inside a 10-minute window set `statusFlipping` on the registry entry; a settled hive ages out on its own. Genuine transitions stay silent: degrade-and-stay, a single bounce, and a walk through distinct states never flag.
- New `status-flipping` drift kind (warn), **suppressed when duplicate-spoke already fired** so one oscillation cannot count a hive twice in the strip.
- The attention strip picks any new kind up as a counting, clickable pill automatically; labels added for `status-flipping` and for `duplicate-spoke` (which was falling back to its raw identifier).

## Tests

- `TestNoteStatusFlipFlagsOscillation` — the live WVA fixture, empty-state ("healthy") counted in the alternation.
- `TestNoteStatusFlipSilentOnRealTransitions` — degrade-and-stay / single bounce / distinct-state walk all silent.
- `TestStatusFlippingDriftSignal` — signal fires via `computeDrift`, and is suppressed when duplicate-spoke names the culprits.
- Mutation-verified: 4 mutations (unreachable threshold, every-transition-counts, signal-never-added, suppression-dropped) each fail a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)