### PR TITLE
🐛 fix(spoke): persist removed-agents tombstone across boot and reload (#2439)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -727,7 +727,14 @@ func main() {
 		return
 	}
 
-	cfg, err := config.Load(*configPath)
+	// Use LoadWithDashboardOverlay (not plain Load) so the dashboard overlay's
+	// removed_agents tombstones are populated into cfg.RemovedAgents at boot —
+	// BEFORE the startup ApplyPack below reconciles the ACMM roster. Plain Load
+	// never reads the overlay, so on restart the tombstone was invisible and
+	// ApplyPack re-added deleted pack agents (brainstorm/guide) every time
+	// (#2439). Same return signature as Load; falls back to the seed when no
+	// overlay exists or the pod is not in Kubernetes.
+	cfg, err := config.LoadWithDashboardOverlay(*configPath)
 	if err != nil {
 		logger.Error("failed to load config", "error", err)
 		os.Exit(1)
@@ -2036,6 +2043,18 @@ func main() {
 		if cfg.ACMMLevel != nil {
 			newCfg.ACMMLevel = cfg.ACMMLevel
 		}
+
+		// Preserve removed-agent tombstones across the swap as a union of the
+		// live cfg and the incoming reload. LoadWithDashboardOverlay now carries
+		// the overlay's tombstones into newCfg, but a removal that landed in the
+		// live cfg after this reload's snapshot (or an overlay too short/stale to
+		// echo it back yet) must not be lost — otherwise the next persistState
+		// saver rewrites every layer tombstone-free and the deleted agents
+		// reappear (#2439). Union keeps any tombstone present in either side.
+		for _, name := range cfg.RemovedAgents {
+			newCfg.MarkAgentRemoved(name)
+		}
+		newCfg.PruneRemovedAgents()
 
 		// Capture the outgoing GitHub App identity before the swap so we can
 		// tell whether the reload changed it.

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -2022,15 +2022,23 @@ func LoadWithDashboardOverlay(path string) (*Config, error) {
 	if err := yaml.Unmarshal([]byte(expandEnvVars(string(data))), &overlay); err != nil {
 		return cfg, nil // malformed overlay: fall back to seed, don't fail the reload
 	}
+	// Tombstones live in the dashboard overlay because that is the only agent
+	// source the dashboard can write. Adopt them BEFORE the fullness guard below
+	// so a short/empty overlay (one that has no agents yet, or only carries the
+	// removed_agents list) still yields the tombstone. Previously this ran AFTER
+	// the guard, so on a reload the guard's early return dropped RemovedAgents to
+	// empty; the ~2-min saver then rewrote every layer tombstone-free and the
+	// deleted agents reappeared on an interval (#2439). Merge already skips and
+	// prunes tombstoned agents, so adopting them early is safe even when we bail.
+	if len(overlay.RemovedAgents) > 0 {
+		cfg.RemovedAgents = overlay.RemovedAgents
+		cfg.PruneRemovedAgents()
+	}
 	// Guard: the overlay must look like a full hive config (same check the
 	// entrypoint and validateSaveGuard apply) before we trust its agents.
 	if overlay.Project.Org == "" || len(overlay.Agents) == 0 {
 		return cfg, nil
 	}
-	// Tombstones live in the dashboard overlay because that is the only agent
-	// source the dashboard can write. Adopt them BEFORE merging so a deleted
-	// agent is neither re-merged from the overlay nor left behind by the seed.
-	cfg.RemovedAgents = overlay.RemovedAgents
 	// Overlay agents win — they carry the reconciled pack-behavior fields.
 	cfg.MergeAgentOverrides(overlay.Agents)
 	for name := range overlay.Agents {

--- a/v2/pkg/config/tombstone_persist_test.go
+++ b/v2/pkg/config/tombstone_persist_test.go
@@ -1,0 +1,176 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadWithDashboardOverlay_AdoptsTombstoneAtBoot is the boot half of the
+// #2439 regression: on restart the entrypoint loads the seed and the startup
+// ApplyPack reconciles the ACMM roster. If the tombstone written by the delete
+// handler (which only lands in the dashboard overlay, the sole agent source the
+// dashboard can write) is not adopted at load time, ApplyPack cannot see it and
+// re-adds the deleted pack agents (brainstorm/guide) every restart.
+//
+// Before the fix the boot path used plain config.Load, which never reads the
+// overlay, so cfg.RemovedAgents was empty and the agents came back. This test
+// asserts LoadWithDashboardOverlay surfaces the overlay's removed_agents AND
+// evicts a tombstoned agent that lingers in the seed.
+func TestLoadWithDashboardOverlay_AdoptsTombstoneAtBoot(t *testing.T) {
+	dir := t.TempDir()
+	seedPath := filepath.Join(dir, "hive.yaml")
+
+	// Seed = the stale ConfigMap the entrypoint restores over the runtime file.
+	// It still lists guide, because the dashboard cannot rewrite the ConfigMap.
+	seed := `
+project:
+  org: testorg
+  repos: [repo1]
+github:
+  token: ghp_test123456789
+agents:
+  scanner:
+    backend: copilot
+    kick_template: scanner-advisory.md
+  guide:
+    backend: copilot
+    kick_template: guide.md
+  brainstorm:
+    backend: copilot
+    kick_template: brainstorm.md
+`
+	if err := os.WriteFile(seedPath, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Overlay = what the delete handler persisted: brainstorm+guide tombstoned.
+	overlayPath := filepath.Join(dir, "hive.yaml.dashboard")
+	overlay := `
+project:
+  org: testorg
+  repos: [repo1]
+github:
+  token: ghp_test123456789
+removed_agents: [brainstorm, guide]
+agents:
+  scanner:
+    backend: copilot
+    kick_template: scanner-advisory.md
+`
+	if err := os.WriteFile(overlayPath, []byte(overlay), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origOverlay := DashboardOverlayFile
+	DashboardOverlayFile = overlayPath
+	t.Cleanup(func() { DashboardOverlayFile = origOverlay })
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+
+	// Precondition and the crux of the boot bug: plain Load (what main.go used at
+	// boot) never reads the overlay, so the tombstone is invisible and the seed's
+	// guide/brainstorm survive. This is exactly why ApplyPack re-added them.
+	raw, err := Load(seedPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if raw.IsAgentRemoved("guide") {
+		t.Fatal("precondition: plain Load must NOT see the overlay tombstone (that is the boot bug)")
+	}
+
+	cfg, err := LoadWithDashboardOverlay(seedPath)
+	if err != nil {
+		t.Fatalf("LoadWithDashboardOverlay: %v", err)
+	}
+
+	for _, name := range []string{"brainstorm", "guide"} {
+		if !cfg.IsAgentRemoved(name) {
+			t.Errorf("tombstone for %q not adopted from overlay at boot", name)
+		}
+		if _, ok := cfg.Agents[name]; ok {
+			t.Errorf("tombstoned agent %q survived in roster from the seed", name)
+		}
+	}
+	if _, ok := cfg.Agents["scanner"]; !ok {
+		t.Error("non-deleted agent scanner should still be present")
+	}
+}
+
+// TestLoadWithDashboardOverlay_TombstoneSurvivesShortOverlay is the reload half
+// of #2439. The ~2-min persistState saver reloads via LoadWithDashboardOverlay.
+// The fullness guard (overlay.Project.Org == "" || len(overlay.Agents) == 0)
+// early-returns for a short or agent-less overlay. Before the fix that early
+// return skipped the RemovedAgents assignment, so the reload dropped the
+// tombstone to empty and the next save rewrote every layer tombstone-free —
+// the deleted agents then reappeared on an interval. The tombstone must be
+// adopted even when the overlay is otherwise too short to trust its agents.
+func TestLoadWithDashboardOverlay_TombstoneSurvivesShortOverlay(t *testing.T) {
+	dir := t.TempDir()
+	seedPath := filepath.Join(dir, "hive.yaml")
+	seed := `
+project:
+  org: testorg
+  repos: [repo1]
+github:
+  token: ghp_test123456789
+agents:
+  scanner:
+    backend: copilot
+    kick_template: scanner-advisory.md
+  guide:
+    backend: copilot
+    kick_template: guide.md
+`
+	if err := os.WriteFile(seedPath, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Short overlay: carries the tombstone but NO agents (and empty org). This
+	// trips the fullness guard, which used to skip the RemovedAgents adoption.
+	overlayPath := filepath.Join(dir, "hive.yaml.dashboard")
+	overlay := `
+removed_agents: [guide]
+`
+	if err := os.WriteFile(overlayPath, []byte(overlay), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origOverlay := DashboardOverlayFile
+	DashboardOverlayFile = overlayPath
+	t.Cleanup(func() { DashboardOverlayFile = origOverlay })
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+
+	cfg, err := LoadWithDashboardOverlay(seedPath)
+	if err != nil {
+		t.Fatalf("LoadWithDashboardOverlay: %v", err)
+	}
+	if !cfg.IsAgentRemoved("guide") {
+		t.Fatal("tombstone dropped by the short-overlay early bail (#2439 reload wipe)")
+	}
+	if _, ok := cfg.Agents["guide"]; ok {
+		t.Error("tombstoned guide should be pruned from the roster even on a short overlay")
+	}
+}
+
+// TestMergeAgentOverridesTombstoneWinsOverStaleFile pins the defense-in-depth
+// contract from #2439 FIX 3: even if a stale /data/agent-configs/<name>.yaml
+// survives the delete (RemoveAgentFile failed and was logged non-fatally), the
+// tombstone must win — MergeAgentOverrides skips the file's agent. This makes
+// the tombstone authoritative independent of the per-agent file's deletion.
+func TestMergeAgentOverridesTombstoneWinsOverStaleFile(t *testing.T) {
+	cfg := &Config{
+		Agents:        map[string]AgentConfig{},
+		RemovedAgents: []string{"brainstorm"},
+	}
+	// The stale per-agent overlay file, still on disk, offered up by a reload.
+	cfg.MergeAgentOverrides(map[string]AgentConfig{
+		"brainstorm": {KickTemplate: "brainstorm.md"},
+		"scanner":    {KickTemplate: "scanner-advisory.md"},
+	})
+	if _, ok := cfg.Agents["brainstorm"]; ok {
+		t.Error("tombstone must win over a stale per-agent overlay file")
+	}
+	if _, ok := cfg.Agents["scanner"]; !ok {
+		t.Error("a non-tombstoned agent must still merge from its file")
+	}
+}


### PR DESCRIPTION
## Problem

Reported by @castrojo (castrojo/projectbluefin): agents removed via the Governor UI (brainstorm, guide) keep coming back on an interval, and config reverts to defaults.

When an operator removes an agent, `handleGovernorRemoveAgent` writes a `removed_agents` tombstone (#2361 mechanism) to the dashboard overlay — the only agent source the dashboard can write. The tombstone was then wiped before it durably persisted, via **two** independent paths:

### 1. BOOT wipe
`v2/cmd/hive/main.go` loaded config with plain `config.Load`, which **never reads the `.dashboard` overlay's `RemovedAgents`**. On restart the tombstone was invisible, so the startup `ApplyPack` re-materialized the pack's agents (startup log showed `"tombstoned":0` — they were re-added, not skipped).

### 2. RELOAD wipe
The ~2-min `persistState` saver reloads via `LoadWithDashboardOverlay`. Its fullness guard (`overlay.Project.Org == "" || len(overlay.Agents) == 0`) early-returned for a short/empty overlay **before** the `cfg.RemovedAgents = overlay.RemovedAgents` assignment, dropping the tombstone to empty. The saver then rewrote every layer tombstone-free, and the deleted agents reappeared on an interval.

## Fix

- **Boot** (`main.go`): load via `config.LoadWithDashboardOverlay` (same signature as `Load`) so `cfg.RemovedAgents` is populated **before** the startup `ApplyPack` runs — `ApplyPack` already skips tombstoned agents.
- **Reload** (`config.go`): adopt `overlay.RemovedAgents` (and prune) **before** the fullness guard, so the tombstone survives even when the overlay is otherwise too short to trust its agents.
- **Reload swap** (`main.go`): union-preserve `RemovedAgents` across `*cfg = *newCfg` (same pattern as `HiveID`/`ACMMLevel`) so an in-flight removal is never lost.
- **Defense in depth**: `MergeAgentOverrides` already skips + prunes tombstoned agents, so the tombstone wins even if a stale per-agent overlay file lingers on disk.

## Test

Adds `v2/pkg/config/tombstone_persist_test.go` covering both wipe paths (boot adoption, short-overlay reload) and the tombstone-wins-over-stale-file merge contract. The reload test **fails before** the fix and **passes after**.

`go build ./...` clean; `go test ./pkg/config/ ./cmd/hive/ ./pkg/dashboard/ -short` green; `gofmt -l` clean.

Fixes #2439

🤖 Generated with [Claude Code](https://claude.com/claude-code)