### PR TITLE
🐛 fix(contributor): break queue livelock — failure cooldown + quarantine + failure-aware selection (#2435)

### DIFF
--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -15,6 +15,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -167,8 +168,25 @@ type ContributeWSHub struct {
 	// for stats/audit and to feed #2356 duplicate detection (a known PR URL per
 	// issue). Empty means the completion reported no PR.
 	completedTaskPRURL map[string]string
-	completedMu        sync.Mutex
-	selectMu           sync.Mutex
+	// failedTasks records, per "repo#number", the time of the most recent
+	// task_failed. It backs the SHORT failure cooldown (failedTaskCooldownMinutes)
+	// that breaks the queue livelock in #2435: without it a just-failed issue is
+	// immediately re-admissible and, sitting at the same position in the same
+	// deterministic scan, is handed straight back out ahead of every other
+	// admissible issue. Kept separate from completedTasks so a failure never masks
+	// as a completion in stats/audit. Guarded by completedMu (shared with the
+	// completed-task ledger — they are read/written from the same paths).
+	failedTasks map[string]time.Time
+	// consecutiveFailures counts back-to-back task_failed reports per
+	// "repo#number", reset to zero on completion. Once it reaches
+	// consecutiveFailureQuarantineThreshold the issue is QUARANTINED for the
+	// longer quarantineCooldownHours window (#2435 remedy 2): this distinguishes
+	// "flaky once" from "nobody can do this", which a flat short cooldown cannot.
+	// A permanent failure (msg.Permanent) counts as permanentFailureWeight toward
+	// the threshold. Guarded by completedMu.
+	consecutiveFailures map[string]int
+	completedMu         sync.Mutex
+	selectMu            sync.Mutex
 }
 
 // completedTaskCooldownHours is the cooldown applied when a task completes
@@ -187,16 +205,54 @@ const completedTaskCooldownHours = 168
 // the same day.
 const completedNoPRCooldownHours = 4
 
+// failedTaskCooldownMinutes is the SHORT cooldown applied to an issue when a
+// contributor reports task_failed (#2435). It is deliberately far shorter than
+// the completion cooldowns above: a failure is often purely environmental
+// (expired token, model outage, transient network) and the issue is likely
+// still perfectly workable, so we must not park it for long. This short window
+// is only large enough to break the tight reject/re-offer livelock — where a
+// just-failed issue at the head of the deterministic scan order is handed
+// straight back out ahead of the whole rest of the queue — while still letting a
+// legitimate retry happen within a few minutes.
+const failedTaskCooldownMinutes = 10
+
+// consecutiveFailureQuarantineThreshold is how many consecutive failures an
+// issue may accumulate (weighted — see permanentFailureWeight) before it is
+// QUARANTINED for the longer quarantineCooldownHours window (#2435 remedy 2).
+// A poison issue that nobody can complete burns at most this many assignments
+// before it is parked for hours instead of minutes, so it stops starving the
+// queue. The counter resets to zero on the issue's next completion.
+const consecutiveFailureQuarantineThreshold = 3
+
+// quarantineCooldownHours is the LONGER cooldown applied once an issue crosses
+// consecutiveFailureQuarantineThreshold. It parks a reliably-failing issue for
+// hours (long enough to stop it dominating the queue) without locking it as long
+// as a genuine week-long completion cooldown — the issue may become workable
+// again (e.g. a dependency merges) and should re-enter circulation the same day.
+const quarantineCooldownHours = 6
+
+// permanentFailureWeight is how much a permanent failure (msg.Permanent — the
+// relay exhausted its per-task CLI-restart budget and will not retry, see
+// bin/contributor-relay.sh) counts toward consecutiveFailureQuarantineThreshold.
+// A permanent failure is a strong "nobody here can do this" signal, so it
+// advances the quarantine counter faster than an ordinary (possibly transient)
+// failure. With a weight of 3 and a threshold of 3, a single permanent failure
+// quarantines the issue immediately.
+const permanentFailureWeight = 3
+
 func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 	hub := &ContributeWSHub{
 		connections:           make(map[string]*ContributorConnection),
 		completedTasks:        make(map[string]time.Time),
 		completedTaskCooldown: make(map[string]time.Duration),
 		completedTaskPRURL:    make(map[string]string),
+		failedTasks:           make(map[string]time.Time),
+		consecutiveFailures:   make(map[string]int),
 		logger:                logger,
 		server:                server,
 	}
 	hub.loadCompletedTasks()
+	hub.loadFailedTasks()
 	hub.loadActivity()
 	go hub.cleanupLoop()
 	return hub
@@ -286,6 +342,74 @@ type completedTaskRecord struct {
 	CompletedAt   time.Time `json:"completed_at"`
 	CooldownHours float64   `json:"cooldown_hours,omitempty"`
 	PRURL         string    `json:"pr_url,omitempty"`
+}
+
+const failedTasksFile = "/data/contributors/failed-tasks.json"
+
+// failedTaskRecord is the on-disk shape of one failed-task entry (#2435). It
+// preserves the last-failure time and the running consecutive-failure count so a
+// hub restart does not reset a quarantine — otherwise a bounce would re-admit a
+// poison issue that had already earned its longer parking window.
+type failedTaskRecord struct {
+	FailedAt            time.Time `json:"failed_at"`
+	ConsecutiveFailures int       `json:"consecutive_failures,omitempty"`
+}
+
+func (h *ContributeWSHub) loadFailedTasks() {
+	h.completedMu.Lock()
+	defer h.completedMu.Unlock()
+	data, err := os.ReadFile(failedTasksFile)
+	if err != nil {
+		return
+	}
+	records := make(map[string]failedTaskRecord)
+	if json.Unmarshal(data, &records) != nil {
+		return
+	}
+	for k, rec := range records {
+		if rec.FailedAt.IsZero() {
+			continue
+		}
+		// Drop entries already past the longest failure-side window we could have
+		// applied (the quarantine cooldown) so we never resurrect a stale park.
+		if time.Since(rec.FailedAt) >= quarantineCooldownHours*time.Hour {
+			continue
+		}
+		if h.failedTasks != nil {
+			h.failedTasks[k] = rec.FailedAt
+		}
+		if h.consecutiveFailures != nil && rec.ConsecutiveFailures > 0 {
+			h.consecutiveFailures[k] = rec.ConsecutiveFailures
+		}
+	}
+	h.logger.Info("[contribute-ws] loaded failed tasks", "count", len(h.failedTasks))
+}
+
+func (h *ContributeWSHub) saveFailedTasks() {
+	h.completedMu.Lock()
+	saved := make(map[string]failedTaskRecord, len(h.failedTasks))
+	for k, t := range h.failedTasks {
+		rec := failedTaskRecord{FailedAt: t}
+		if h.consecutiveFailures != nil {
+			rec.ConsecutiveFailures = h.consecutiveFailures[k]
+		}
+		saved[k] = rec
+	}
+	h.completedMu.Unlock()
+	data, err := json.Marshal(saved)
+	if err != nil {
+		h.logger.Warn("[contribute-ws] failed tasks marshal failed", "error", err)
+		return
+	}
+	os.MkdirAll("/data/contributors", 0o755)
+	tmpPath := failedTasksFile + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		h.logger.Warn("[contribute-ws] failed tasks write failed", "error", err)
+		return
+	}
+	if err := os.Rename(tmpPath, failedTasksFile); err != nil {
+		h.logger.Warn("[contribute-ws] failed tasks rename failed", "error", err)
+	}
 }
 
 func (h *ContributeWSHub) loadCompletedTasks() {
@@ -392,8 +516,28 @@ func (h *ContributeWSHub) markTaskCompleted(repo string, number int, prURL strin
 	if h.completedTaskPRURL != nil {
 		h.completedTaskPRURL[key] = prURL
 	}
+	// A completion clears any failure history for the issue (#2435): the
+	// consecutive-failure counter resets so a flaky-then-fixed issue does not
+	// carry a stale quarantine, and the short failure cooldown is superseded by
+	// the (longer) completion cooldown recorded just above.
+	failureCleared := false
+	if h.failedTasks != nil {
+		if _, ok := h.failedTasks[key]; ok {
+			delete(h.failedTasks, key)
+			failureCleared = true
+		}
+	}
+	if h.consecutiveFailures != nil {
+		if _, ok := h.consecutiveFailures[key]; ok {
+			delete(h.consecutiveFailures, key)
+			failureCleared = true
+		}
+	}
 	h.completedMu.Unlock()
 	h.saveCompletedTasks()
+	if failureCleared {
+		h.saveFailedTasks()
+	}
 }
 
 // cooldownForLocked returns the cooldown duration to apply to key. Callers must
@@ -424,6 +568,86 @@ func (h *ContributeWSHub) isTaskInCooldown(repo string, number int) bool {
 		return false
 	}
 	return true
+}
+
+// recordTaskFailure books a task_failed against an issue (#2435). It stamps the
+// short failure cooldown and advances the issue's consecutive-failure counter
+// (a permanent failure advances it by permanentFailureWeight rather than one),
+// so a reliably-failing issue crosses consecutiveFailureQuarantineThreshold and
+// earns the longer quarantine window instead of being handed straight back out.
+// The counter is reset on completion (see markTaskCompleted).
+func (h *ContributeWSHub) recordTaskFailure(repo string, number int, permanent bool) {
+	key := fmt.Sprintf("%s#%d", repo, number)
+	weight := 1
+	if permanent {
+		weight = permanentFailureWeight
+	}
+	h.completedMu.Lock()
+	h.failedTasks[key] = time.Now()
+	h.consecutiveFailures[key] += weight
+	h.completedMu.Unlock()
+	h.saveFailedTasks()
+}
+
+// failureCooldownForLocked returns how long, from the last failure time, an
+// issue should be excluded from selection. It is the SHORT
+// failedTaskCooldownMinutes normally, or the LONGER quarantineCooldownHours once
+// the issue's consecutive-failure count has reached
+// consecutiveFailureQuarantineThreshold. Callers must hold completedMu.
+func (h *ContributeWSHub) failureCooldownForLocked(key string) time.Duration {
+	if h.consecutiveFailures[key] >= consecutiveFailureQuarantineThreshold {
+		return quarantineCooldownHours * time.Hour
+	}
+	return failedTaskCooldownMinutes * time.Minute
+}
+
+// isTaskInFailureCooldown reports whether an issue is currently excluded because
+// of a recent failure — either the short post-failure cooldown or the longer
+// quarantine (#2435). It self-heals in two stages so the failure-aware selection
+// backstop (recentFailureCount) still has something to work with just after the
+// short window lapses:
+//   - Once the APPLICABLE window (short cooldown, or quarantine) has elapsed the
+//     issue is admissible again → returns false.
+//   - The consecutive-failure COUNT is only cleared once the full quarantine
+//     window has elapsed. So an issue whose short cooldown just expired is
+//     admissible but still carries its failure history, letting selectTask
+//     deprioritise it behind never-failed peers rather than instantly restoring
+//     it to the head of the queue. The count also resets on completion.
+func (h *ContributeWSHub) isTaskInFailureCooldown(repo string, number int) bool {
+	key := fmt.Sprintf("%s#%d", repo, number)
+	h.completedMu.Lock()
+	defer h.completedMu.Unlock()
+	t, ok := h.failedTasks[key]
+	if !ok {
+		return false
+	}
+	// Keep the failure ledger for the full quarantine window (the longest window
+	// we could apply), then clear timestamp AND count together so stale history
+	// never lingers indefinitely. Retaining the timestamp past the short cooldown
+	// is what preserves the consecutive-failure count for the selection backstop.
+	if time.Since(t) > quarantineCooldownHours*time.Hour {
+		delete(h.failedTasks, key)
+		delete(h.consecutiveFailures, key)
+		return false
+	}
+	// Inside the quarantine window: excluded only while within the currently
+	// applicable cooldown (short cooldown, or the full quarantine once the count
+	// crosses the threshold). Past that, the issue is admissible again but its
+	// count remains on record — recentFailureCount reads it to deprioritise the
+	// issue behind never-failed peers.
+	return time.Since(t) <= h.failureCooldownForLocked(key)
+}
+
+// recentFailureCount returns the number of failures currently on record for an
+// issue (0 when none/expired). selectTask uses it as a stable tie-break so that,
+// among equally-admissible candidates, those without recent failures are offered
+// before those that have failed recently — guaranteeing forward progress even if
+// the failure cooldown has just elapsed (#2435 remedy 3 backstop).
+func (h *ContributeWSHub) recentFailureCount(repo string, number int) int {
+	key := fmt.Sprintf("%s#%d", repo, number)
+	h.completedMu.Lock()
+	defer h.completedMu.Unlock()
+	return h.consecutiveFailures[key]
 }
 
 func (h *ContributeWSHub) nextSeq() int {
@@ -832,11 +1056,20 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			if contributor != nil {
 				contributor.mu.Lock()
 				hasTask := contributor.currentTask != nil && contributor.currentTask.TaskID == msg.TaskID
+				failedTask := contributor.currentTask
 				contributor.currentTask = nil
 				contributor.tokenMintedAt = time.Time{}
 				contributor.mu.Unlock()
 
 				if hasTask {
+					if failedTask != nil {
+						// #2435: record a short failure cooldown (and advance the
+						// consecutive-failure/quarantine counter) so a just-failed
+						// issue is not immediately re-admissible and handed straight
+						// back out ahead of the rest of the queue. A permanent failure
+						// counts more toward the quarantine threshold.
+						h.recordTaskFailure(failedTask.Repo, failedTask.Number, msg.Permanent)
+					}
 					h.addActivity(contributor.profile.GitHubUsername, "failed", contributor.role, contributor.cliBackend, contributor.model, msg.TaskID)
 					h.logger.Info("[contribute-ws] task failed",
 						"username", contributor.profile.GitHubUsername,
@@ -1116,6 +1349,13 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		url      string
 		labels   []string
 		isOwn    bool
+		// recentFailures is the issue's current consecutive-failure count (#2435).
+		// It is a stable tie-break in the ordering below: among equally-admissible
+		// candidates, fewer-recent-failures first. Issues in an active failure
+		// cooldown are already excluded above, so this only deprioritises an issue
+		// whose short cooldown just elapsed but which still has failure history —
+		// a backstop that keeps the queue moving even if the ledger is imperfect.
+		recentFailures int
 	}
 	var candidates []candidate
 
@@ -1152,6 +1392,12 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				continue
 			}
 			if h.isTaskInCooldown(repo.Full, number) {
+				continue
+			}
+			// #2435: skip an issue still inside its short post-failure cooldown or
+			// its longer quarantine. This is the primary livelock fix — a failing
+			// issue at the head of the scan is no longer instantly re-admissible.
+			if h.isTaskInFailureCooldown(repo.Full, number) {
 				continue
 			}
 			if activeIssues[fmt.Sprintf("%s#%d", repo.Full, number)] {
@@ -1203,6 +1449,9 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				// username is unknown (empty), nothing is own → we keep today's
 				// ordering untouched.
 				isOwn: ownUsername != "" && strings.EqualFold(author, ownUsername),
+				// #2435: carry any lingering failure history so the ordering below
+				// can deprioritise a recently-failed issue within its bucket.
+				recentFailures: h.recentFailureCount(repo.Full, number),
 			})
 		}
 	}
@@ -1211,22 +1460,28 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		return nil
 	}
 
-	// Stable partition: own-work candidates first, in their original scan order;
-	// then everything else, also in original scan order. A stable sort keeps the
-	// established per-repo / creation ordering within each bucket, so when the
-	// contributor has no own work this is a no-op and behaviour is identical to
-	// the previous first-eligible pick.
-	ownFirst := make([]candidate, 0, len(candidates))
-	for _, cand := range candidates {
-		if cand.isOwn {
-			ownFirst = append(ownFirst, cand)
+	// Order the admissible set with a STABLE sort so the pick is deterministic
+	// (easy to reason about and to test — no randomness):
+	//   1. own-work first (#2390 — preserved unchanged);
+	//   2. then fewer recent failures first (#2435 remedy 3 backstop) — an issue
+	//      whose short failure cooldown has just elapsed but which still carries
+	//      failure history is deprioritised behind never-failed peers, so a
+	//      flaky issue can no longer monopolise the head of the queue even if the
+	//      ledger is imperfect;
+	//   3. otherwise the established per-repo / creation scan order is kept.
+	// When the contributor has no own work AND nothing has failed, this is a no-op
+	// and behaviour is identical to the previous first-eligible pick.
+	ownFirst := make([]candidate, len(candidates))
+	copy(ownFirst, candidates)
+	sort.SliceStable(ownFirst, func(i, j int) bool {
+		if ownFirst[i].isOwn != ownFirst[j].isOwn {
+			return ownFirst[i].isOwn // own work sorts ahead of non-own
 		}
-	}
-	for _, cand := range candidates {
-		if !cand.isOwn {
-			ownFirst = append(ownFirst, cand)
+		if ownFirst[i].recentFailures != ownFirst[j].recentFailures {
+			return ownFirst[i].recentFailures < ownFirst[j].recentFailures // fewer failures first
 		}
-	}
+		return false // equal keys → SliceStable preserves original scan order
+	})
 
 	chosen := ownFirst[0]
 	if chosen.isOwn {

--- a/v2/pkg/dashboard/contribute_ws_livelock_test.go
+++ b/v2/pkg/dashboard/contribute_ws_livelock_test.go
@@ -1,0 +1,284 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// twoIssueStatus seeds a status with two admissible issues in the same repo:
+// A (#10, ahead in scan order) and B (#20). Neither is authored by the test
+// contributor, so #2390 own-work ordering is inert and the pick is driven purely
+// by scan order and the #2435 failure ledger.
+func twoIssueStatus(s *Server) {
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{
+			{
+				Name: "repo1",
+				Full: "myorg/repo1",
+				ActionableIssues: []any{
+					map[string]any{
+						"number": float64(10),
+						"title":  "Issue A (head of scan order)",
+						"url":    "https://github.com/myorg/repo1/issues/10",
+						"author": "someone",
+					},
+					map[string]any{
+						"number": float64(20),
+						"title":  "Issue B (starved before the fix)",
+						"url":    "https://github.com/myorg/repo1/issues/20",
+						"author": "someone",
+					},
+				},
+			},
+		},
+	}
+	s.statusMu.Unlock()
+}
+
+// TestQueueLivelock_FailureCooldownFreesStarvedIssue is the #2435 regression:
+// before the fix, task_failed recorded no cooldown and selectTask had no
+// failure-aware ranking, so the same head-of-scan issue (A/#10) was handed out
+// over and over while B/#20 was never offered. After the fix, once A fails it is
+// parked by the short failure cooldown, so the very next assignment must NOT be A
+// again immediately, and B must be offered.
+func TestQueueLivelock_FailureCooldownFreesStarvedIssue(t *testing.T) {
+	hub, s := covK2Hub(t)
+	twoIssueStatus(s)
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "ct", ContributorID: "c-ct", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+
+	// First assignment: head-of-scan issue A (#10).
+	msg := hub.selectTask(conn)
+	if msg == nil {
+		t.Fatalf("expected an assignment, got nil")
+	}
+	if msg.Number != 10 {
+		t.Fatalf("expected first assignment to be head-of-scan A (#10), got #%d", msg.Number)
+	}
+
+	// The contributor reports task_failed for A. Clear currentTask as the real
+	// task_failed handler does, then record the failure through the same hub path
+	// the handler uses.
+	conn.mu.Lock()
+	conn.currentTask = nil
+	conn.mu.Unlock()
+	hub.recordTaskFailure("myorg/repo1", 10, false)
+
+	// Next assignment MUST NOT be A again immediately — it is in the short failure
+	// cooldown — and B (#20) is offered instead. This is the exact behaviour that
+	// was broken: pre-fix this returned #10 again.
+	msg2 := hub.selectTask(conn)
+	if msg2 == nil {
+		t.Fatalf("expected B to be offered after A failed, got nil (queue starved)")
+	}
+	if msg2.Number == 10 {
+		t.Fatalf("livelock: A (#10) was re-offered immediately after failing; expected it parked in failure cooldown")
+	}
+	if msg2.Number != 20 {
+		t.Fatalf("expected the starved issue B (#20) to be offered, got #%d", msg2.Number)
+	}
+
+	// Sanity: A really is in failure cooldown, and its short window is far shorter
+	// than any completion cooldown.
+	if !hub.isTaskInFailureCooldown("myorg/repo1", 10) {
+		t.Fatalf("A should be in failure cooldown right after a task_failed")
+	}
+	if failedTaskCooldownMinutes*time.Minute >= completedNoPRCooldownHours*time.Hour {
+		t.Fatalf("failure cooldown (%dm) must be far shorter than the no-PR completion cooldown (%dh)",
+			failedTaskCooldownMinutes, completedNoPRCooldownHours)
+	}
+}
+
+// TestQueueLivelock_ConsecutiveFailuresQuarantine verifies remedy 2: an issue
+// that fails consecutiveFailureQuarantineThreshold times is parked for the
+// LONGER quarantine window, not just the short failure cooldown.
+func TestQueueLivelock_ConsecutiveFailuresQuarantine(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	for i := 0; i < consecutiveFailureQuarantineThreshold; i++ {
+		hub.recordTaskFailure("myorg/repo1", 10, false)
+	}
+	if !hub.isTaskInFailureCooldown("myorg/repo1", 10) {
+		t.Fatalf("issue should be quarantined after %d failures", consecutiveFailureQuarantineThreshold)
+	}
+
+	// Age the last failure just past the SHORT cooldown but well inside the
+	// quarantine window: a non-quarantined issue would be free, a quarantined one
+	// is still parked.
+	hub.completedMu.Lock()
+	hub.failedTasks["myorg/repo1#10"] = time.Now().Add(-(failedTaskCooldownMinutes + 1) * time.Minute)
+	hub.completedMu.Unlock()
+	if !hub.isTaskInFailureCooldown("myorg/repo1", 10) {
+		t.Fatalf("quarantined issue must stay parked past the short cooldown (quarantine is %dh)", quarantineCooldownHours)
+	}
+
+	// Age it past the full quarantine window: now it self-heals and the counter
+	// resets.
+	hub.completedMu.Lock()
+	hub.failedTasks["myorg/repo1#10"] = time.Now().Add(-(quarantineCooldownHours + 1) * time.Hour)
+	hub.completedMu.Unlock()
+	if hub.isTaskInFailureCooldown("myorg/repo1", 10) {
+		t.Fatalf("quarantine should expire after %dh", quarantineCooldownHours)
+	}
+	if hub.recentFailureCount("myorg/repo1", 10) != 0 {
+		t.Fatalf("consecutive-failure count should reset once the quarantine expires")
+	}
+}
+
+// TestQueueLivelock_PermanentFailureQuarantinesFaster verifies that a permanent
+// failure (msg.Permanent) crosses the quarantine threshold in a single report,
+// whereas one ordinary failure only earns the short cooldown.
+func TestQueueLivelock_PermanentFailureQuarantinesFaster(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	// One ordinary failure: short cooldown only, NOT quarantined. Prove it by
+	// aging past the short window — it frees.
+	hub.recordTaskFailure("myorg/repo1", 30, false)
+	hub.completedMu.Lock()
+	hub.failedTasks["myorg/repo1#30"] = time.Now().Add(-(failedTaskCooldownMinutes + 1) * time.Minute)
+	hub.completedMu.Unlock()
+	if hub.isTaskInFailureCooldown("myorg/repo1", 30) {
+		t.Fatalf("a single ordinary failure must only earn the short cooldown, not a quarantine")
+	}
+
+	// One PERMANENT failure: quarantined immediately (weight >= threshold). Aging
+	// past the short window leaves it parked.
+	hub.recordTaskFailure("myorg/repo1", 40, true)
+	hub.completedMu.Lock()
+	hub.failedTasks["myorg/repo1#40"] = time.Now().Add(-(failedTaskCooldownMinutes + 1) * time.Minute)
+	hub.completedMu.Unlock()
+	if !hub.isTaskInFailureCooldown("myorg/repo1", 40) {
+		t.Fatalf("a permanent failure must quarantine immediately (weight %d, threshold %d)",
+			permanentFailureWeight, consecutiveFailureQuarantineThreshold)
+	}
+}
+
+// TestQueueLivelock_CompletionResetsFailureHistory verifies a completion clears
+// the failure ledger so a flaky-then-fixed issue does not carry a stale
+// quarantine.
+func TestQueueLivelock_CompletionResetsFailureHistory(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	hub.recordTaskFailure("myorg/repo1", 50, true) // quarantined
+	if !hub.isTaskInFailureCooldown("myorg/repo1", 50) {
+		t.Fatalf("expected quarantine after a permanent failure")
+	}
+	hub.markTaskCompleted("myorg/repo1", 50, "https://github.com/myorg/repo1/pull/99")
+	if hub.isTaskInFailureCooldown("myorg/repo1", 50) {
+		t.Fatalf("a completion must clear the failure cooldown/quarantine")
+	}
+	if hub.recentFailureCount("myorg/repo1", 50) != 0 {
+		t.Fatalf("a completion must reset the consecutive-failure counter")
+	}
+}
+
+// TestQueueLivelock_FailureAwareSelectionBackstop verifies remedy 3: even after
+// A's short failure cooldown has elapsed, a never-failed peer B is preferred
+// because A still carries failure history — so a flaky head-of-scan issue cannot
+// re-monopolise the queue purely on scan position.
+func TestQueueLivelock_FailureAwareSelectionBackstop(t *testing.T) {
+	hub, s := covK2Hub(t)
+	twoIssueStatus(s)
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "ct", ContributorID: "c-ct", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+
+	// A (#10) failed once, then its SHORT cooldown elapsed (so it is admissible
+	// again) but it still carries one recent failure.
+	hub.recordTaskFailure("myorg/repo1", 10, false)
+	hub.completedMu.Lock()
+	hub.failedTasks["myorg/repo1#10"] = time.Now().Add(-(failedTaskCooldownMinutes + 1) * time.Minute)
+	hub.completedMu.Unlock()
+	if hub.isTaskInFailureCooldown("myorg/repo1", 10) {
+		t.Fatalf("A's short cooldown should have elapsed for this backstop check")
+	}
+
+	// Both A and B are now admissible. The failure-aware sort must prefer B (#20,
+	// zero failures) over A (#10, one recent failure) even though A is ahead in
+	// scan order.
+	msg := hub.selectTask(conn)
+	if msg == nil {
+		t.Fatalf("expected an assignment, got nil")
+	}
+	if msg.Number != 20 {
+		t.Fatalf("failure-aware backstop: expected never-failed B (#20) preferred over recently-failed A (#10), got #%d", msg.Number)
+	}
+}
+
+// TestQueueLivelock_TaskFailedHandlerRecordsCooldown drives the real WebSocket
+// task_failed handler end-to-end and verifies it records a failure cooldown
+// through the hub — i.e. the handler is actually wired to recordTaskFailure and
+// not just the direct hub methods the other tests call.
+func TestQueueLivelock_TaskFailedHandlerRecordsCooldown(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	// Seed one admissible issue so `ready` yields a task_assign.
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{
+			{
+				Name: "repo1",
+				Full: "myorg/repo1",
+				ActionableIssues: []any{
+					map[string]any{
+						"number": float64(77),
+						"title":  "Reliably failing issue",
+						"url":    "https://github.com/myorg/repo1/issues/77",
+						"author": "someone",
+					},
+				},
+			},
+		},
+	}
+	s.statusMu.Unlock()
+
+	body := `{"github_username":"livelock-handler-user"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn) // auth_ok
+
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 1})
+	assign := readMsg(t, conn)
+	if assign.Type != "task_assign" || assign.Number != 77 {
+		t.Fatalf("expected task_assign for #77, got type=%s number=%d", assign.Type, assign.Number)
+	}
+
+	// Report the assigned task as failed via the real handler.
+	conn.WriteJSON(WSMessage{Type: "task_failed", TaskID: assign.TaskID, Reason: "could not build", Permanent: false})
+
+	// The handler runs asynchronously; poll briefly for the recorded cooldown.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if s.contributeHub.isTaskInFailureCooldown("myorg/repo1", 77) {
+			return // handler wired correctly
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("task_failed handler did not record a failure cooldown for the assigned issue")
+}


### PR DESCRIPTION
## Problem

`task_complete` recorded a per-issue cooldown but `task_failed` recorded **none**, and `selectTask` had no failure-aware ranking — it assigned the first admissible issue in a stable scan order. A failing issue was therefore immediately re-admissible and, sitting at the same position in the same deterministic scan, handed straight back out ahead of every other admissible issue.

On a live hub this produced a **livelock**: over a 9h15m window, 11 of 13 assignments were the same reliably-failing issue (`projectbluefin/common#900`) while 33 other admissible issues were never offered once. Aggregate throughput for the whole contributor pool was set by one issue that could not be completed.

## Fix

Three coordinated defenses in `v2/pkg/dashboard/contribute_ws.go`:

1. **Short failure cooldown.** `task_failed` now records the issue in a dedicated failure ledger for `failedTaskCooldownMinutes` (**10m**) — long enough to break the tight reject/re-offer loop, short enough not to park an issue that failed for a purely environmental reason (expired token, model outage).

2. **Consecutive-failure quarantine.** Consecutive failures are counted per `repo#number` (reset on completion); once the count reaches `consecutiveFailureQuarantineThreshold` (**3**) the issue is parked for the longer `quarantineCooldownHours` (**6h**). A permanent failure (`msg.Permanent`) counts `permanentFailureWeight` (**3**) toward the threshold, so a single permanent failure quarantines immediately. The failure ledger persists to `/data/contributors/failed-tasks.json`, so a hub restart does not re-admit a still-quarantined issue.

3. **Failure-aware selection backstop.** `selectTask` now stably sorts the admissible set: own-work first (preserved from #2390), then fewer-recent-failures first, then original scan order. Even after an issue's short cooldown lapses it is deprioritised behind never-failed peers rather than instantly returning to the head of the queue. The sort is **deterministic** (no randomness) so behaviour stays predictable and testable.

Every literal is a named constant with a comment — no magic numbers.

## Regression test

`contribute_ws_livelock_test.go` seeds two admissible issues A (ahead in scan order) and B, fails A, and asserts A is **not** re-offered immediately while B — which was starved before — **is** offered. Also asserts: a permanent failure quarantines faster, quarantine expiry self-heals and resets the counter, a completion clears failure history, and the real `task_failed` WebSocket handler records the cooldown end-to-end. These fail before the fix and pass after.

## Scope note

The relay idle-re-ask defect (remedy 5 in the issue — client-side, in `bin/contributor-relay.sh`) is a **separate concern** and remains a follow-up: fixing the ledger does not fix it and vice versa.

Rebased on latest `v2` (on top of #2437's promote-only-on-PR change to the same file — both concerns kept).

Fixes #2435

🤖 Generated with [Claude Code](https://claude.com/claude-code)