### PR TITLE
🐛 fix(contributor): enforce trust controls — token-mint negative-ack, disabled_tiers/MaxConcurrent (findings 1-3 of #2436)

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -39,6 +39,11 @@ const BASE_RECONNECT_DELAY_MS = 1000;
 const TOKEN_REFRESH_MARGIN_MS = 300000;
 const MAX_TASK_DURATION_MS = 1800000;
 const NETWORK_ERROR_RETRY_DELAY_MS = 5000;
+// After the hub sends an explicit task_unavailable negative-ack (no admissible
+// work, a disabled tier, a concurrency limit, or a token-mint failure — see
+// kubestellar/hive#2436), wait before re-asking so we neither hang forever
+// (the old silent-nil behaviour) nor busy-loop the hub.
+const TASK_UNAVAILABLE_RETRY_MS = 30000;
 
 // Per-task CLI-crash retry budget. Issue #2203: a task whose CLI kept dying was
 // reassigned by the hub and failed identically forever (5+ times in ~20min),
@@ -778,6 +783,20 @@ function handleMessage(data) {
       taskAssignedAt = 0;
       if (progressInterval) { clearInterval(progressInterval); progressInterval = null; }
       send({ type: 'ready', seq: nextSeq() });
+      break;
+
+    case 'task_unavailable':
+      // #2436 finding 1/2/3: the hub explicitly declined to assign work and told
+      // us why (reason: no_work / token_mint_failed / tier_disabled /
+      // concurrency_limit). Surface the reason instead of hanging silently, then
+      // re-ask after a delay so a transient condition (a freed slot, a fixed
+      // installation permission) recovers on its own.
+      console.log(`No task assigned — reason: ${msg.reason || 'unspecified'}; retrying in ${TASK_UNAVAILABLE_RETRY_MS / 1000}s`);
+      setTimeout(() => {
+        if (ws && ws.readyState === WebSocket.OPEN && !currentTask) {
+          send({ type: 'ready', seq: nextSeq() });
+        }
+      }, TASK_UNAVAILABLE_RETRY_MS);
       break;
 
     case 'ping':

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -740,7 +740,26 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				"role", contributor.role,
 			)
 			task := h.selectTask(contributor)
-			if task != nil {
+			switch {
+			case task == nil:
+				// No admissible work and no enforced refusal (e.g. suspended, no
+				// status yet, or an empty candidate set). Behaviour unchanged.
+				h.logger.Info("[contribute-ws] no tasks available",
+					"username", contributor.profile.GitHubUsername,
+				)
+			case task.Type == "task_unavailable":
+				// #2436 finding 1/2/3: an explicit negative-ack (mint failure,
+				// disabled tier, or concurrency limit) rather than silence. Send it
+				// so the contributor can diagnose instead of hanging forever.
+				if err := sendJSON(conn, *task); err != nil {
+					h.logger.Warn("[contribute-ws] failed to send task_unavailable", "error", err)
+					return
+				}
+				h.logger.Info("[contribute-ws] task unavailable",
+					"username", contributor.profile.GitHubUsername,
+					"reason", task.Reason,
+				)
+			default:
 				if err := sendJSON(conn, *task); err != nil {
 					h.logger.Warn("[contribute-ws] failed to send task_assign", "error", err)
 					return
@@ -752,10 +771,6 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					"task", task.TaskID,
 					"repo", task.Repo,
 					"number", task.Number,
-				)
-			} else {
-				h.logger.Info("[contribute-ws] no tasks available",
-					"username", contributor.profile.GitHubUsername,
 				)
 			}
 
@@ -1023,6 +1038,52 @@ func (h *ContributeWSHub) mintScopedToken(tier string) (string, error) {
 	return "", nil
 }
 
+// taskUnavailableReason* are the machine-readable reasons carried on a
+// task_unavailable negative-ack. They let the relay (and operators reading the
+// log) tell "there is simply no admissible work right now" apart from "the hub
+// refused to assign work to this contributor" for a specific enforced reason.
+// See kubestellar/hive#2436.
+const (
+	// taskUnavailableTokenMintFailed: a scoped GitHub token could not be minted
+	// for the contributor's tier (e.g. the installation lacks the permission the
+	// tier requests), so no task_assign can be honestly issued. Previously this
+	// path returned nil and the contributor waited forever with no explanation.
+	taskUnavailableTokenMintFailed = "token_mint_failed"
+	// taskUnavailableTierDisabled: the contributor's TrustTier is listed in
+	// hub.disabled_tiers, so the operator has switched that tier off.
+	taskUnavailableTierDisabled = "tier_disabled"
+	// taskUnavailableConcurrencyLimit: assigning would exceed the tier's
+	// tier_limits.max_concurrent for this identity (counting every live
+	// connection this identity holds).
+	taskUnavailableConcurrencyLimit = "concurrency_limit"
+)
+
+// identityOf returns the stable key that groups a contributor's live
+// connections for per-identity concurrency accounting (#2436 finding 3). The
+// registered ContributorID is preferred; GitHubUsername is the fallback for
+// connections whose profile predates or lacks an ID. Two WebSocket connections
+// opened by the same registered contributor therefore share one identity.
+func identityOf(c *ContributorConnection) string {
+	if c == nil || c.profile == nil {
+		return ""
+	}
+	if c.profile.ContributorID != "" {
+		return c.profile.ContributorID
+	}
+	return c.profile.GitHubUsername
+}
+
+// taskUnavailable builds the explicit negative-ack the ready handler sends in
+// place of silence. It carries a machine-readable reason so the failure is
+// diagnosable rather than an indefinite hang (kubestellar/hive#2436, finding 1).
+func (h *ContributeWSHub) taskUnavailable(reason string) *WSMessage {
+	return &WSMessage{
+		Type:   "task_unavailable",
+		Seq:    h.nextSeq(),
+		Reason: reason,
+	}
+}
+
 func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	h.selectMu.Lock()
 	defer h.selectMu.Unlock()
@@ -1042,16 +1103,61 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		return nil
 	}
 
+	// #2436 finding 2: refuse to assign work to a contributor whose TrustTier is
+	// switched off via hub.disabled_tiers. This control was declared and
+	// admin-writable but never read, so an operator "disabling" a tier changed
+	// nothing. Send an explicit tier_disabled negative-ack rather than silently
+	// handing out work anyway.
+	tier := ""
+	if c.profile != nil {
+		tier = c.profile.TrustTier
+	}
+	if h.server.deps != nil && h.server.deps.Config != nil {
+		for _, dt := range h.server.deps.Config.Hub.DisabledTiers {
+			if dt == tier {
+				h.logger.Warn("[contribute-ws] refusing task: tier disabled",
+					"username", identityOf(c), "tier", tier)
+				return h.taskUnavailable(taskUnavailableTierDisabled)
+			}
+		}
+	}
+
+	// activeIssues tracks issues already held by SOME live connection so we do
+	// not double-assign the same work item. identityHolds counts, per identity,
+	// how many tasks that identity currently holds across ALL of its live
+	// connections — the source of truth for the #2436 finding 3 concurrency gate
+	// (one identity opening several connections must not exceed MaxConcurrent).
 	activeIssues := make(map[string]bool)
+	identityHolds := make(map[string]int)
 	h.mu.RLock()
 	for _, conn := range h.connections {
 		conn.mu.Lock()
 		if conn.currentTask != nil {
 			activeIssues[fmt.Sprintf("%s#%d", conn.currentTask.Repo, conn.currentTask.Number)] = true
+			identityHolds[identityOf(conn)]++
 		}
 		conn.mu.Unlock()
 	}
 	h.mu.RUnlock()
+
+	// #2436 finding 3: enforce tier_limits.max_concurrent per identity. The
+	// config ships populated MaxConcurrent defaults, so an operator reasonably
+	// believes concurrency is capped; before this it was inert. A limit <= 0 is
+	// treated as "unlimited" (the "advisor" default is 0 and existing configs
+	// that never set the field must keep working). MaxPerHour / MaxPerDay remain
+	// TODO(#2436): they require per-identity rate counters that are not tracked
+	// today, so they are intentionally left unenforced rather than pretended —
+	// see the PR note. Only MaxConcurrent is wired here.
+	if h.server.deps != nil && h.server.deps.Config != nil {
+		if limits, ok := h.server.deps.Config.Hub.TierLimits[tier]; ok && limits.MaxConcurrent > 0 {
+			if identityHolds[identityOf(c)] >= limits.MaxConcurrent {
+				h.logger.Warn("[contribute-ws] refusing task: concurrency limit reached",
+					"username", identityOf(c), "tier", tier,
+					"held", identityHolds[identityOf(c)], "max_concurrent", limits.MaxConcurrent)
+				return h.taskUnavailable(taskUnavailableConcurrencyLimit)
+			}
+		}
+	}
 
 	totalAvailable := 0
 	for _, repo := range status.Repos {
@@ -1232,9 +1338,16 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	// arms the refresh ticker for the token we hand out here.
 	ghToken, err := h.mintScopedToken(c.profile.TrustTier)
 	if err != nil {
-		h.logger.Warn("[contribute-ws] failed to mint scoped token — skipping task",
+		// #2436 finding 1: a mint failure previously returned nil, stranding the
+		// contributor with no message (the log even said "skipping task" while
+		// abandoning the whole selection). Send an explicit token_mint_failed
+		// negative-ack so the failure is diagnosable instead of an indefinite
+		// hang. We do not fall through to another candidate: the mint is keyed on
+		// the contributor's tier, not the candidate, so every candidate in this
+		// pass would fail identically. Preserve the existing Warn log.
+		h.logger.Warn("[contribute-ws] failed to mint scoped token — task unavailable",
 			"tier", c.profile.TrustTier, "error", err)
-		return nil
+		return h.taskUnavailable(taskUnavailableTokenMintFailed)
 	}
 
 	taskID := fmt.Sprintf("ct-%s-%d-%d", chosen.repoFull, chosen.number, time.Now().Unix())

--- a/v2/pkg/dashboard/contribute_ws_trust_controls_test.go
+++ b/v2/pkg/dashboard/contribute_ws_trust_controls_test.go
@@ -1,0 +1,193 @@
+package dashboard
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// oneActionableIssue installs a status with a single actionable issue that any
+// tier can be assigned (author is someone else, so no #2390 own-work skew).
+func oneActionableIssue(s *Server) {
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{
+			{
+				Name: "repo1",
+				Full: "myorg/repo1",
+				ActionableIssues: []any{
+					map[string]any{
+						"number": float64(101),
+						"title":  "Actionable issue",
+						"url":    "https://github.com/myorg/repo1/issues/101",
+						"author": "someone-else",
+					},
+				},
+			},
+		},
+	}
+	s.statusMu.Unlock()
+}
+
+// TestTrustControls_DisabledTierRefused (#2436 finding 2): a contributor whose
+// TrustTier is in hub.disabled_tiers is refused with a tier_disabled negative-ack
+// rather than silently handed work.
+func TestTrustControls_DisabledTierRefused(t *testing.T) {
+	hub, s := covK2Hub(t)
+	oneActionableIssue(s)
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "newcomer"},
+		lastPong: time.Now(),
+	}
+
+	// Fail-before shape: without disabled_tiers the tier gets assigned work.
+	if msg := hub.selectTask(conn); msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("expected a task_assign before disabling the tier, got %+v", msg)
+	}
+	// Clear the connection's held task and re-provide a fresh actionable issue so
+	// the next select isn't skipped as an already-active issue.
+	conn.currentTask = nil
+	oneActionableIssue(s)
+
+	// Now disable the newcomer tier: selection must refuse with tier_disabled.
+	s.deps.Config.Hub.DisabledTiers = []string{"newcomer"}
+	msg := hub.selectTask(conn)
+	if msg == nil {
+		t.Fatalf("expected an explicit negative-ack for a disabled tier, got nil (silent)")
+	}
+	if msg.Type != "task_unavailable" || msg.Reason != taskUnavailableTierDisabled {
+		t.Fatalf("expected task_unavailable/%s, got type=%q reason=%q",
+			taskUnavailableTierDisabled, msg.Type, msg.Reason)
+	}
+}
+
+// TestTrustControls_MaxConcurrentEnforced (#2436 finding 3): a second concurrent
+// assignment to the SAME identity beyond tier_limits.max_concurrent is refused
+// with a concurrency_limit negative-ack. Uses the live-connection holds as the
+// source of truth.
+func TestTrustControls_MaxConcurrentEnforced(t *testing.T) {
+	hub, s := covK2Hub(t)
+
+	// newcomer defaults to MaxConcurrent: 1 (config.go). Make it explicit so the
+	// test does not depend on defaulting having run.
+	s.deps.Config.Hub.TierLimits = map[string]config.TierRate{
+		"newcomer": {MaxPerHour: 3, MaxPerDay: 10, MaxConcurrent: 1},
+	}
+
+	// Two live connections for the SAME identity (same ContributorID), simulating
+	// one identity opening several connections. The first already holds a task.
+	held := &ContributorConnection{
+		profile:     &ContributorProfile{GitHubUsername: "bob", ContributorID: "c-bob", TrustTier: "newcomer"},
+		currentTask: &WSTaskAssign{TaskID: "t-held", Repo: "myorg/other", Number: 5},
+		lastPong:    time.Now(),
+	}
+	second := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "bob", ContributorID: "c-bob", TrustTier: "newcomer"},
+		lastPong: time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["conn-held"] = held
+	hub.connections["conn-second"] = second
+	hub.mu.Unlock()
+
+	oneActionableIssue(s)
+
+	// The identity already holds 1 == MaxConcurrent, so the second connection is
+	// refused rather than given a second concurrent write-capable assignment.
+	msg := hub.selectTask(second)
+	if msg == nil {
+		t.Fatalf("expected a concurrency-limit negative-ack, got nil (silent)")
+	}
+	if msg.Type != "task_unavailable" || msg.Reason != taskUnavailableConcurrencyLimit {
+		t.Fatalf("expected task_unavailable/%s, got type=%q reason=%q",
+			taskUnavailableConcurrencyLimit, msg.Type, msg.Reason)
+	}
+
+	// Fail-before shape: with a higher limit the same second connection is served.
+	s.deps.Config.Hub.TierLimits = map[string]config.TierRate{
+		"newcomer": {MaxPerHour: 3, MaxPerDay: 10, MaxConcurrent: 2},
+	}
+	oneActionableIssue(s)
+	if msg := hub.selectTask(second); msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("with MaxConcurrent=2 the second assignment should be served, got %+v", msg)
+	}
+}
+
+// newFailingAppAuth builds a real *ghpkg.AppAuth whose JWT generation succeeds
+// (valid RSA key) but whose CreateInstallationToken call hits a server that
+// always 500s, so ScopedToken — and therefore mintScopedToken — returns an
+// error. This exercises the #2436 finding 1 mint-failure path deterministically
+// and offline.
+func newFailingAppAuth(t *testing.T) *ghpkg.AppAuth {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	keyFile := filepath.Join(t.TempDir(), "app-key.pem")
+	if err := os.WriteFile(keyFile, pemBytes, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	auth, err := ghpkg.NewAppAuthWithCache(1, 2, keyFile,
+		filepath.Join(t.TempDir(), "token.cache"), logger, srv.URL)
+	if err != nil {
+		t.Fatalf("NewAppAuthWithCache: %v", err)
+	}
+	return auth
+}
+
+// TestTrustControls_MintFailureNegativeAck (#2436 finding 1): when the scoped
+// token mint fails, selectTask sends an explicit token_mint_failed negative-ack
+// instead of returning a silent nil that strands the contributor.
+func TestTrustControls_MintFailureNegativeAck(t *testing.T) {
+	hub, s := covK2Hub(t)
+	oneActionableIssue(s)
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "carol", ContributorID: "c-carol", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+
+	// Force the mint to fail via a real AppAuth whose token endpoint 500s.
+	s.deps.GHAppAuth = newFailingAppAuth(t)
+
+	msg := hub.selectTask(conn)
+	if msg == nil {
+		t.Fatalf("expected an explicit token-mint negative-ack, got nil (silent strand)")
+	}
+	if msg.Type != "task_unavailable" || msg.Reason != taskUnavailableTokenMintFailed {
+		t.Fatalf("expected task_unavailable/%s, got type=%q reason=%q",
+			taskUnavailableTokenMintFailed, msg.Type, msg.Reason)
+	}
+	// The contributor was NOT left holding a phantom task.
+	conn.mu.Lock()
+	ct := conn.currentTask
+	conn.mu.Unlock()
+	if ct != nil {
+		t.Fatalf("mint failure must not leave a currentTask assigned, got %+v", ct)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes three of the four defects in #2436 where a contributor **trust control looks authoritative but is not enforced** (silent failures). **Finding 4 (PR-gated auto-promotion) is deliberately excluded** — it is owned by #2437 by the issue reporter. This PR does not touch the promotion / `task_complete` counting lines, so the two can land independently.

## The three fixes

**Finding 1 — token-mint failure silently dropped the task.**
`selectTask`'s mint-failure path returned `nil`, stranding the contributor with no message (the log even said "skipping task" while abandoning the whole selection). It now returns an explicit `task_unavailable` negative-ack with reason `token_mint_failed`. The mint is keyed on the contributor's **tier**, not the candidate, so every candidate would fail identically — a negative-ack is the right shape here rather than `continue` to the next candidate. The relay (`bin/contributor-relay.sh`) learns a new `case 'task_unavailable'` that surfaces the reason and re-asks after a delay instead of hanging.

**Finding 2 — `hub.disabled_tiers` was inert** (declared, admin GET/PUT-able, never read). `selectTask` now refuses a contributor whose `TrustTier` is listed in `disabled_tiers`, sending `task_unavailable` / `tier_disabled`.

**Finding 3 — `hub.tier_limits.MaxConcurrent` was inert while shipping populated defaults**, so operators believed concurrency was capped when nothing enforced it. `selectTask` now enforces `MaxConcurrent` **per identity**, counting every task held across all of that identity's live connections (so one identity opening several connections cannot exceed the cap). The existing live-connection tracking is the source of truth. A limit `<= 0` means "unlimited" so existing / unset configs (and the `advisor` 0-default) keep working. Config schema and admin GET/PUT are unchanged.

### Enforced vs. explicitly-left-TODO
| Field | Status |
|---|---|
| `disabled_tiers` | ✅ enforced (`tier_disabled`) |
| `tier_limits.MaxConcurrent` | ✅ enforced per-identity (`concurrency_limit`) |
| `tier_limits.MaxPerHour` / `MaxPerDay` | ⛔ **TODO(#2436)** — need per-identity rate counters not tracked today; left **explicitly unenforced and documented in code**, not pretended |

## Tests
`v2/pkg/dashboard/contribute_ws_trust_controls_test.go`:
- mint failure → explicit `token_mint_failed` negative-ack, and no phantom `currentTask` left assigned
- disabled tier → assigned before disabling, then refused with `tier_disabled`
- `MaxConcurrent` → a second concurrent assignment to the same identity is refused; served again once the limit is raised

`go build ./...` clean; `go test ./pkg/dashboard/ ./pkg/config/ -short` green.

## `contribute_ws.go` line ranges touched (for #2435 / #2437 rebase)
- ready-handler `switch` on the `selectTask` result: **~742–797**
- `identityOf` + `taskUnavailable` helpers + reason consts: **~1045–1090**
- `selectTask` `disabled_tiers` + per-identity concurrency gates: **~1103–1160**
- `selectTask` mint-failure negative-ack: **~1338–1352**

`selectTask`'s #2390 candidate-collection loop is deliberately **untouched** so #2435's `selectTask` change rebases cleanly.

Addresses #2436 (findings 1-3; finding 4 handled by #2437).

🤖 Generated with [Claude Code](https://claude.com/claude-code)