### PR TITLE
🐛 spoke: config truth outranks cached tokens — no installation means not-installed everywhere

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -933,6 +933,17 @@ func main() {
 	// against a hive whose credentials the operator never delivered).
 	githubAppDiag := appAuthFailure
 	githubAppState := appAuthState
+	// Config truth outranks live probes: an App with no installation cannot
+	// mint, period. A cached token can keep clients green for up to an hour
+	// after an installation is cleared, and waiting for the first failed mint
+	// left the banner down and the hub green exactly when the operator needed
+	// the opposite (the fast-model-actuation incident).
+	if cfg.GitHub.ConfiguredButUninstalled() {
+		githubAppRequired = true
+		githubAppState = github.AppStateNotInstalled
+		githubAppDiag = "GitHub App " + strconv.FormatInt(cfg.GitHub.AppID, 10) +
+			" has no installation for this org — install it (the spoke adopts the installation automatically)"
+	}
 
 	// Find or create the pinned advisory issue. Any level can have advisory
 	// agents whose findings should be posted to this issue.
@@ -2960,6 +2971,11 @@ func main() {
 			// the hub does not track); assigning zero here would blank a working
 			// value and turn a key-only fault into a total auth outage.
 			if next, cleared := nextInstallationID(cfg.GitHub.InstallationID, ghCfg); cleared {
+				// The banner and the hub must flip to not-installed NOW, not
+				// when the cached token dies an hour from now. Same config-truth
+				// rule as startup.
+				dashSrv.SetGitHubAppRequired(true)
+				dashSrv.SetGitHubAppState(github.AppStateNotInstalled.String())
 				logger.Info("clearing github app installation_id on operator request",
 					"was", cfg.GitHub.InstallationID)
 				cfg.GitHub.InstallationID = next

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1539,6 +1539,17 @@ func (g GitHubConfig) HasUsableApp() bool {
 	return g.HasApp() && g.InstallationID != 0
 }
 
+// ConfiguredButUninstalled reports the half-configured state that must NEVER
+// read as healthy: a real App is named but there is no installation to mint
+// tokens against. Every token this hive will ever hold is App-minted, so this
+// state means auth is a countdown — any client still working is riding a
+// cached token that cannot be renewed. Callers use this to raise the install
+// banner and fail github_auth from CONFIG truth, not from whether a residual
+// token still breathes.
+func (g GitHubConfig) ConfiguredButUninstalled() bool {
+	return g.HasApp() && g.InstallationID == 0
+}
+
 // ResolvedAPIURL returns the configured API URL or the default for github.com.
 func (g GitHubConfig) ResolvedAPIURL() string {
 	if g.APIURL != "" {

--- a/v2/pkg/config/configured_but_uninstalled_test.go
+++ b/v2/pkg/config/configured_but_uninstalled_test.go
@@ -1,0 +1,51 @@
+package config
+
+import "testing"
+
+// TestConfiguredButUninstalled pins the config-truth rule that drives the
+// "GitHub App not installed" banner and the github_auth health failure: a REAL
+// app_id with no installation must read as uninstalled, while placeholder
+// apps, installed apps, and app-less configs must not.
+func TestConfiguredButUninstalled(t *testing.T) {
+	const realAppID int64 = 123456
+
+	cases := []struct {
+		name string
+		g    GitHubConfig
+		want bool
+	}{
+		{
+			name: "real app with no installation is uninstalled",
+			g:    GitHubConfig{AppID: realAppID, InstallationID: 0},
+			want: true,
+		},
+		{
+			name: "placeholder app never reads as uninstalled",
+			g:    GitHubConfig{AppID: PlaceholderAppID, InstallationID: 0},
+			want: false,
+		},
+		{
+			name: "installed app is not uninstalled",
+			g:    GitHubConfig{AppID: realAppID, InstallationID: 42980},
+			want: false,
+		},
+		{
+			name: "no app configured is not uninstalled",
+			g:    GitHubConfig{AppID: 0, InstallationID: 0},
+			want: false,
+		},
+		{
+			name: "installation without app is not uninstalled",
+			g:    GitHubConfig{AppID: 0, InstallationID: 42980},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.g.ConfiguredButUninstalled(); got != tc.want {
+				t.Errorf("ConfiguredButUninstalled() = %v, want %v (config %+v)", got, tc.want, tc.g)
+			}
+		})
+	}
+}

--- a/v2/pkg/dashboard/github_auth_config_truth_test.go
+++ b/v2/pkg/dashboard/github_auth_config_truth_test.go
@@ -1,0 +1,121 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// These tests pin the config-truth rule for github_auth: when the spoke knows
+// from CONFIG that its GitHub App has no installation (SetGitHubAppRequired
+// true + state "not-installed"), BOTH health surfaces must fail github_auth
+// with "GitHub App not installed" — even while a live GHClient still exists,
+// because any such client is riding a cached token that cannot be renewed.
+
+// notInstalledServer builds a full test server carrying a live (non-nil)
+// GHClient and the not-installed config-truth state.
+func notInstalledServer(t *testing.T) *Server {
+	t.Helper()
+	srv := newFullServer(t)
+	srv.MarkReady()
+
+	// A real, reachable client object — it must NOT mask the config truth.
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("{}"))
+	}))
+	t.Cleanup(gh.Close)
+	srv.deps.GHClient = ghpkg.NewClientForTest(gh.URL, "testorg", []string{"testrepo"}, covBLogger())
+
+	srv.SetGitHubAppRequired(true)
+	srv.SetGitHubAppState("not-installed")
+	return srv
+}
+
+func TestHealthDeep_GitHubAuthFailsFromConfigTruth_DespiteLiveClient(t *testing.T) {
+	srv := notInstalledServer(t)
+
+	req := httptest.NewRequest("GET", "/api/health/deep", nil)
+	w := httptest.NewRecorder()
+	srv.handleHealthDeep(w, req)
+
+	var result map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	checks, ok := result["checks"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing checks in %v", result)
+	}
+	ga, ok := checks["github_auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing github_auth check in %v", checks)
+	}
+	if ga["status"] != "fail" {
+		t.Errorf("github_auth status = %v, want fail (live GHClient must not mask a missing installation)", ga["status"])
+	}
+	detail, _ := ga["detail"].(string)
+	if !strings.Contains(detail, "GitHub App not installed") {
+		t.Errorf("github_auth detail = %q, want it to name the missing installation", detail)
+	}
+}
+
+func TestHealthSummary_GitHubAuthFailsFromConfigTruth_DespiteLiveClient(t *testing.T) {
+	srv := notInstalledServer(t)
+
+	sum := srv.HealthSummary()
+	raw, err := json.Marshal(sum)
+	if err != nil {
+		t.Fatalf("marshal summary: %v", err)
+	}
+	var parsed struct {
+		Checks []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+			Detail string `json:"detail"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal summary: %v", err)
+	}
+	found := false
+	for _, c := range parsed.Checks {
+		if c.Name != "github_auth" {
+			continue
+		}
+		found = true
+		if c.Status != "fail" {
+			t.Errorf("github_auth status = %q, want fail (live GHClient must not mask a missing installation)", c.Status)
+		}
+		if !strings.Contains(c.Detail, "GitHub App not installed") {
+			t.Errorf("github_auth detail = %q, want it to name the missing installation", c.Detail)
+		}
+	}
+	if !found {
+		t.Fatalf("no github_auth check in summary: %s", raw)
+	}
+}
+
+// TestGitHubAuth_PassesWhenInstallationStateCleared is the contrast case: the
+// same live client with the not-installed state cleared must pass, proving the
+// failure above comes from the config-truth branch and nothing else.
+func TestGitHubAuth_PassesWhenInstallationStateCleared(t *testing.T) {
+	srv := notInstalledServer(t)
+	srv.SetGitHubAppState("")
+
+	req := httptest.NewRequest("GET", "/api/health/deep", nil)
+	w := httptest.NewRecorder()
+	srv.handleHealthDeep(w, req)
+
+	var result map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	ga := result["checks"].(map[string]any)["github_auth"].(map[string]any)
+	if ga["status"] != "pass" {
+		t.Errorf("github_auth status = %v, want pass once state is cleared", ga["status"])
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -1142,6 +1142,23 @@ func (s *Server) handleBannerDismissed(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, map[string]bool{"ok": true})
 }
 
+// githubAppStateNotInstalledToken is the pkg/github AppAuthState wire token
+// for "genuinely not installed" (AppStateNotInstalled.String()), kept as the
+// string the setter receives so this package needs no classifier dependency.
+const githubAppStateNotInstalledToken = "not-installed"
+
+// githubAppNotInstalled reports the config-truth state that must fail
+// github_auth in BOTH health surfaces regardless of which client object still
+// exists: an App with no installation cannot mint, so any working client is
+// riding a cached token that cannot be renewed. Waiting for the first failed
+// mint kept the banner down and the hub green for up to an hour after an
+// installation was cleared — exactly when the operator needed the opposite.
+func (s *Server) githubAppNotInstalled() bool {
+	s.githubAppMu.RLock()
+	defer s.githubAppMu.RUnlock()
+	return s.githubAppRequired && s.githubAppState == githubAppStateNotInstalledToken
+}
+
 func (s *Server) SetGitHubAppRequired(required bool) {
 	s.githubAppMu.Lock()
 	defer s.githubAppMu.Unlock()
@@ -1441,8 +1458,12 @@ func (s *Server) handleHealthDeep(w http.ResponseWriter, r *http.Request) {
 		failCount++
 	}
 
-	// 2. GitHub auth
-	if s.deps != nil && s.deps.GHAppAuth != nil {
+	// 2. GitHub auth — config truth first (see githubAppNotInstalled).
+	if s.githubAppNotInstalled() {
+		checks["github_auth"] = map[string]any{"status": "fail", "detail": "GitHub App not installed — no installation for this org"}
+		overall = "degraded"
+		failCount++
+	} else if s.deps != nil && s.deps.GHAppAuth != nil {
 		if _, err := s.deps.GHAppAuth.Token(s.deps.Ctx); err == nil {
 			checks["github_auth"] = map[string]any{"status": "pass"}
 		} else {
@@ -2020,8 +2041,11 @@ func (s *Server) HealthSummary() map[string]any {
 		fails++
 	}
 
-	// 2. GitHub auth
-	if s.deps != nil && s.deps.GHAppAuth != nil {
+	// 2. GitHub auth — config truth first (see githubAppNotInstalled).
+	if s.githubAppNotInstalled() {
+		checks = append(checks, check{Name: "github_auth", Status: "fail", Detail: "GitHub App not installed — no installation for this org"})
+		fails++
+	} else if s.deps != nil && s.deps.GHAppAuth != nil {
 		if _, err := s.deps.GHAppAuth.Token(s.deps.Ctx); err != nil {
 			// Surface the underlying error, not a bare "token error": this
 			// detail travels to the hub and into the dashboard tooltip, and a

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -8165,7 +8165,7 @@ const dashboardHTML = `<!DOCTYPE html>
       }
       else if (h.githubAppRequired && h.githubAppPermIssue) { lines.push('✓ GitHub App installed'); lines.push('⚠ GitHub App: permissions insufficient'); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
       else if (h.githubAppRequired) { lines.push('✕ GitHub App not installed'); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
-      else if (!h.githubAppRequired) { lines.push('✓ GitHub App installed'); }
+      else if (!h.githubAppRequired) { lines.push('✓ GitHub App: not in use'); }
       if (!checks.length) lines.push('No check data');
       // Heartbeat freshness — so a reading that is minutes old isn't mistaken
       // for current health (the source of "stuck Degraded" reports: the last


### PR DESCRIPTION
## What

- `GitHubConfig.ConfiguredButUninstalled()`: a REAL `app_id` with `installation_id: 0` now reports not-installed on BOTH health surfaces (deep health + heartbeat summary) and raises the install banner at startup and on heartbeat-delivered reset — regardless of any cached token or residual client still working.
- Hub popover mislabel: when the App is merely not required, the hover printed '✓ GitHub App installed'; it now says '✓ GitHub App: not in use'.

## Tests

- `pkg/config`: truth table for `ConfiguredButUninstalled` — true only for a real app with no installation; false for placeholder app, installed app, and app-less configs.
- `pkg/dashboard`: both health surfaces fail `github_auth` with 'GitHub App not installed' under `SetGitHubAppRequired(true)` + state `not-installed` even while `deps.GHClient` is non-nil, plus a contrast case proving the failure comes from the config-truth branch alone.
- Mutation-checked: forcing `ConfiguredButUninstalled` to always return false and removing the not-installed branch from the deep-health surface each fail a test.