### PR TITLE
🐛 spoke: make a second concurrent heartbeat loop impossible (#2453)

### DIFF
--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"runtime/debug"
 	"sync/atomic"
 	"time"
 )
@@ -37,6 +38,28 @@ var lastHeartbeatSuccessUnix atomic.Int64
 // heartbeat freshness at all — otherwise every hub-less hive would fail
 // liveness forever. Set once at startup; read from the HTTP handler.
 var heartbeatLoopStarted atomic.Bool
+
+// heartbeatLoopActive is the process-wide "a heartbeat loop is RUNNING right
+// now" guard — deliberately separate from heartbeatLoopStarted, which records
+// "a loop was ever launched" and feeds /api/livez via HeartbeatEnabled (a
+// semantics that must not change: liveness keeps gating on heartbeat freshness
+// even while a duplicate start is being refused).
+//
+// WHY THIS EXISTS (#2453): a production spoke was observed running TWO
+// concurrent heartbeat loops in one process — two independent 2-minute
+// cadences from one pod, alternating a fresh and a stale auth snapshot on the
+// wire, flipping the hub registry every beat. The code has exactly one
+// StartHeartbeat call site, so the second loop's origin is unknown. This CAS
+// makes a second concurrent loop impossible no matter what path tries to
+// start one: the first caller wins, every later caller is refused and returns
+// cleanly. The refusal logs the refused caller's FULL STACK at ERROR, so the
+// next time the trigger fires in production the log names it — the guard is
+// both the fix and the instrument.
+//
+// Cleared (via defer) when a loop exits on context cancellation, so a
+// deliberate stop-then-restart stays possible; only CONCURRENT duplication is
+// refused.
+var heartbeatLoopActive atomic.Bool
 
 // lastHeartbeatAttemptUnix holds the unix-seconds timestamp of the most
 // recent heartbeat the loop *tried* to send, regardless of whether the hub
@@ -532,6 +555,21 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 		logger.Info("hub heartbeat disabled (no HIVE_HUB_URL)")
 		return
 	}
+	// Durable single-loop guard (#2453): exactly one heartbeat loop may run in
+	// this process, ever, no matter which path calls StartHeartbeat. A refused
+	// duplicate returns cleanly — the already-running loop keeps beating — and
+	// logs the refused caller's full stack so a live occurrence names the
+	// trigger instead of just alternating states on the wire.
+	if !heartbeatLoopActive.CompareAndSwap(false, true) {
+		logger.Error("duplicate StartHeartbeat REFUSED: a heartbeat loop is already running in this process (#2453) — the stack below names the caller that tried to start a second one",
+			"hub_url", hubURL,
+			"stack", string(debug.Stack()),
+		)
+		return
+	}
+	// Release only when THIS loop exits (context cancelled), so a deliberate
+	// stop-then-restart works while concurrent duplication stays impossible.
+	defer heartbeatLoopActive.Store(false)
 	// Mark the loop as active before the first send so /api/livez can tell
 	// "hub-connected, awaiting first beat" (healthy during startup grace)
 	// apart from "no hub configured" (never gated on heartbeat freshness).
@@ -629,10 +667,19 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 	}
 }
 
+// waitForReady's knobs are vars (not consts) for the same reason as
+// taskPushInterval: tests need a StartHeartbeat that reaches its send loop in
+// milliseconds, not after a 3-minute readiness wait. Production keeps the
+// defaults.
+var (
+	waitForReadyPollInterval = 5 * time.Second
+	waitForReadyMaxWait      = 3 * time.Minute
+)
+
 func waitForReady(ctx context.Context, logger *slog.Logger) {
 	const healthURL = "http://localhost:3001/api/health"
-	const pollInterval = 5 * time.Second
-	const maxWait = 3 * time.Minute
+	pollInterval := waitForReadyPollInterval
+	maxWait := waitForReadyMaxWait
 	deadline := time.After(maxWait)
 	logger.Info("heartbeat waiting for dashboard readiness")
 	for {

--- a/v2/pkg/hub/heartbeat_single_loop_test.go
+++ b/v2/pkg/hub/heartbeat_single_loop_test.go
@@ -1,0 +1,185 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// These tests drive the #2453 single-loop guard through the PRODUCTION
+// StartHeartbeat path: a real send loop against an httptest hub, with the
+// readiness wait collapsed so the loop is beating within milliseconds.
+
+// singleLoopTestInterval is short enough that several ticks fit in a
+// sub-second observation window, long enough that the scheduler reliably
+// delivers every tick even on a loaded CI runner.
+const singleLoopTestInterval = 50 * time.Millisecond
+
+// collapseReadinessWait shrinks waitForReady's knobs for the duration of a
+// test so StartHeartbeat reaches its send loop immediately instead of polling
+// localhost:3001 for up to 3 minutes.
+func collapseReadinessWait(t *testing.T) {
+	t.Helper()
+	prevPoll, prevMax := waitForReadyPollInterval, waitForReadyMaxWait
+	waitForReadyPollInterval = time.Millisecond
+	waitForReadyMaxWait = 0
+	t.Cleanup(func() {
+		waitForReadyPollInterval = prevPoll
+		waitForReadyMaxWait = prevMax
+	})
+}
+
+// resetSingleLoopGuard clears the process-global heartbeat state so one
+// test's loop cannot bleed into the next.
+func resetSingleLoopGuard(t *testing.T) {
+	t.Helper()
+	heartbeatLoopActive.Store(false)
+	ResetHeartbeatStateForTest()
+	t.Cleanup(func() {
+		heartbeatLoopActive.Store(false)
+		ResetHeartbeatStateForTest()
+	})
+}
+
+// countingHub is an httptest hub that counts every heartbeat POST it accepts.
+func countingHub(t *testing.T, beats *atomic.Int32) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/heartbeat" {
+			beats.Add(1)
+		}
+		json.NewEncoder(w).Encode(HeartbeatResponse{OK: true})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// waitForBeats blocks until the hub has seen at least n beats, or fails the
+// test after a generous deadline.
+func waitForBeats(t *testing.T, beats *atomic.Int32, n int32) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for beats.Load() < n {
+		if time.Now().After(deadline) {
+			t.Fatalf("hub saw %d beats, wanted at least %d", beats.Load(), n)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestStartHeartbeatSecondConcurrentCallRefused is the #2453 regression test:
+// two concurrent StartHeartbeat invocations must yield exactly ONE active
+// loop. The refused call is observable in two independent ways — it returns
+// promptly while the first loop is still running (an un-refused call blocks
+// until its context is cancelled), and the beat count over a multi-interval
+// window matches a single cadence, not two.
+func TestStartHeartbeatSecondConcurrentCallRefused(t *testing.T) {
+	resetSingleLoopGuard(t)
+	collapseReadinessWait(t)
+
+	var beats atomic.Int32
+	srv := countingHub(t, &beats)
+	collect := func() *HeartbeatPayload { return &HeartbeatPayload{HiveID: "h-2453"} }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	firstDone := make(chan struct{})
+	go func() {
+		StartHeartbeat(ctx, srv.URL, collect, singleLoopTestInterval, slog.Default())
+		close(firstDone)
+	}()
+
+	// The first loop is beating.
+	waitForBeats(t, &beats, 1)
+
+	// Second concurrent invocation: with the guard it is refused and returns
+	// immediately; without it this call runs a second loop and blocks here
+	// until ctx is cancelled — which is exactly the production double-sender.
+	secondDone := make(chan struct{})
+	go func() {
+		StartHeartbeat(ctx, srv.URL, collect, singleLoopTestInterval, slog.Default())
+		close(secondDone)
+	}()
+	select {
+	case <-secondDone:
+		// refused, as required
+	case <-time.After(3 * time.Second):
+		t.Fatal("second concurrent StartHeartbeat did not return: the duplicate loop was NOT refused (two senders are running)")
+	}
+
+	// Cadence check over several intervals: one loop produces ~window/interval
+	// beats; a second loop would double that. The ceiling sits between the two
+	// so a duplicate sender fails even with generous scheduler jitter.
+	beats.Store(0)
+	const window = 12 * singleLoopTestInterval
+	time.Sleep(window)
+	got := beats.Load()
+	if got == 0 {
+		t.Fatal("no beats observed after the refusal — the FIRST loop must keep running")
+	}
+	if max := int32(window/singleLoopTestInterval) + 3; got > max {
+		t.Fatalf("observed %d beats in %v (interval %v) — more than one heartbeat cadence is on the wire", got, window, singleLoopTestInterval)
+	}
+
+	// A refused duplicate must not have broken the /api/livez contract.
+	if !HeartbeatEnabled() {
+		t.Error("HeartbeatEnabled() must remain true while the surviving loop runs")
+	}
+
+	cancel()
+	select {
+	case <-firstDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("first loop did not stop on context cancellation")
+	}
+}
+
+// TestStartHeartbeatGuardReleasedAfterLoopExit proves the guard is a "running
+// now" flag, not a "ran once" latch: after the first loop exits on context
+// cancellation, a fresh StartHeartbeat must run (not be refused) and beat.
+func TestStartHeartbeatGuardReleasedAfterLoopExit(t *testing.T) {
+	resetSingleLoopGuard(t)
+	collapseReadinessWait(t)
+
+	var beats atomic.Int32
+	srv := countingHub(t, &beats)
+	collect := func() *HeartbeatPayload { return &HeartbeatPayload{HiveID: "h-restart"} }
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	firstDone := make(chan struct{})
+	go func() {
+		StartHeartbeat(ctx1, srv.URL, collect, singleLoopTestInterval, slog.Default())
+		close(firstDone)
+	}()
+	waitForBeats(t, &beats, 1)
+	cancel1()
+	select {
+	case <-firstDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("first loop did not stop on context cancellation")
+	}
+
+	// Restart: must be admitted, and must beat again.
+	beats.Store(0)
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	secondDone := make(chan struct{})
+	go func() {
+		StartHeartbeat(ctx2, srv.URL, collect, singleLoopTestInterval, slog.Default())
+		close(secondDone)
+	}()
+	waitForBeats(t, &beats, 1)
+
+	cancel2()
+	select {
+	case <-secondDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("restarted loop did not stop on context cancellation")
+	}
+}


### PR DESCRIPTION
Mitigates #2453 — the issue stays open for the trigger.

## What this does

A production spoke ran **two concurrent heartbeat loops in one process** (two independent 2-minute cadences from one pod, alternating a fresh and a stale auth snapshot on the wire every beat). This PR makes that state impossible and instruments the refusal so the next occurrence names its trigger:

- **`heartbeatLoopActive`** — a new process-wide atomic CAS "loop running NOW" flag in `pkg/hub/heartbeat.go`. The first `StartHeartbeat` caller wins; any concurrent duplicate is **refused and returns cleanly** while the surviving loop keeps beating. Deliberately separate from `heartbeatLoopStarted`, which means "ever launched" and feeds `/api/livez` via `HeartbeatEnabled()` — that contract is unchanged.
- **The instrument**: a refused duplicate logs at ERROR with the refused caller's **full stack** (`runtime/debug.Stack()`). If the double-loop ever recurs in production, the spoke log will name the exact re-entry path instead of just flipping states on the hub.
- The guard is released via `defer` when a loop exits on context cancellation, so a deliberate stop-then-restart still works; only *concurrent* duplication is refused.

## Trigger hunt — no concrete in-process re-entry path found

Every candidate path was audited; none can start a second loop:

- **Call sites**: exactly one `go hub.StartHeartbeat(...)`, directly inside `func main()` (`cmd/hive/main.go`) — `main` runs once per process and contains no loop/goto around that block.
- **Heartbeat response callbacks** (upgrade, restart-spoke, GitHub App config apply, project-config adoption, gateway apply, restart): all dispatched *synchronously inside the loop goroutine* via `processHeartbeatResponse`; none call `StartHeartbeat` or spawn a sender. The only three POSTers to `/api/heartbeat` are the loop itself plus the one-shot `SendUpgradingHeartbeat` / `ReportUpgradeFailure`.
- **Config reload** (`pkg/config/watcher.go` → the reload closure in `main.go`): swaps the config in place and rebuilds GitHub auth/clients; never touches the heartbeat.
- **`waitForReady` / retry structure**: one ticker, no recursion, no branch that spawns a second sender.
- **Container**: `deploy/entrypoint.sh` launches `hive "$@" &` exactly once and `wait`s on it; the node proxy and ttyd wrapper spawn nothing.

**Remaining suspect (unproven): a second `hive` process in the same container.** It fits every observation: same reporter (pod hostname), stale auth snapshot, and — critically — a second process would *survive silently*, because `dashSrv.Start()` bind failure is only logged (`cmd/hive/main.go` ~2308) and its `waitForReady` would succeed against the FIRST process's healthy `:3001`. Nothing in the shipped scripts launches one, so no direct fix is possible yet. The in-process guard cannot stop a separate process, but the ERROR+stack instrument will conclusively rule in-process re-entry in or out at the next occurrence, and the #2450 flip-detection pill catches it either way.

## Tests (production code paths, mutation-checked)

`pkg/hub/heartbeat_single_loop_test.go` drives the real `StartHeartbeat` send loop against an `httptest` hub counting beat POSTs (readiness-wait knobs became package vars, same precedent as `taskPushInterval`):

- Two concurrent `StartHeartbeat` calls → exactly one active loop: the duplicate returns promptly (an un-refused call blocks until ctx cancel), and the beat count over a 12×50 ms window matches a single cadence, not two. `HeartbeatEnabled()` stays true throughout.
- Guard releases after a clean loop exit: a restart is admitted and beats again.

**Mutation test**: neutering the CAS (`if false && !heartbeatLoopActive.CompareAndSwap(...)`) makes `TestStartHeartbeatSecondConcurrentCallRefused` fail with "the duplicate loop was NOT refused (two senders are running)"; restoring the guard turns it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)