### PR TITLE
🐛 fix(dashboard): make Set ID rebuild GitHub auth with hub-delivered per-app-id keys

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1796,6 +1796,13 @@ func main() {
 			}
 			return nil
 		},
+		// Same key resolution as boot (initGitHubAuth) and the heartbeat apply
+		// path: without it, the dashboard Set ID handler gated reinit on the
+		// raw key_file, which is deliberately empty on hub-delivered per-app-id
+		// keys (#2459).
+		ResolveAppKeyFileFunc: func(configured string, appID int64) string {
+			return resolveAppKeyFile(configured, os.Getenv("GH_APP_KEY_FILE"), appID)
+		},
 	})
 
 	dashSrv.SetGitHubAppRequired(githubAppRequired)

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4945,6 +4945,16 @@ func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
 
 	cfg := s.deps.Config
 
+	// saveConfig() silently no-ops when the config has no source path, so
+	// without this guard the handler would report "status":"updated" for a
+	// value that lives only in memory and is lost on the next restart (#2459).
+	// Refuse up front, before mutating anything, and name the cause.
+	if cfg.SourcePath == "" {
+		s.logger.Error("github config update rejected: config has no source path, save would be an in-memory no-op")
+		jsonError(w, "config not persisted: config has no source path, so the change would be lost on restart", http.StatusInternalServerError)
+		return
+	}
+
 	if body.PrivateKey != "" {
 		keyPath := body.KeyFile
 		if keyPath == "" {
@@ -4986,12 +4996,23 @@ func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
 		"key_file":        cfg.GitHub.KeyFile,
 	}
 
+	// Resolve the signing key the same way the boot and heartbeat-apply paths
+	// do, NOT from the raw config value: on hosted spokes the key is
+	// hub-delivered to the per-app-id path with key_file deliberately left
+	// empty, and gating reinit on cfg.GitHub.KeyFile alone made Set ID save the
+	// installation_id but never rebuild the client — banner never cleared,
+	// Re-check dead-ended on a nil client (#2459).
+	keyFile := cfg.GitHub.KeyFile
+	if s.deps.ResolveAppKeyFileFunc != nil {
+		keyFile = s.deps.ResolveAppKeyFileFunc(cfg.GitHub.KeyFile, cfg.GitHub.AppID)
+	}
+
 	// HasUsableApp() rejects the placeholder sentinel: reinitializing App auth
 	// against it would fail on every save and, before this guard, could not
 	// succeed no matter what installation_id the operator supplied.
-	if cfg.GitHub.HasUsableApp() && cfg.GitHub.KeyFile != "" {
+	if cfg.GitHub.HasUsableApp() && keyFile != "" {
 		if s.deps.ReinitGitHubFunc != nil {
-			if err := s.deps.ReinitGitHubFunc(cfg.GitHub.AppID, cfg.GitHub.InstallationID, cfg.GitHub.KeyFile); err != nil {
+			if err := s.deps.ReinitGitHubFunc(cfg.GitHub.AppID, cfg.GitHub.InstallationID, keyFile); err != nil {
 				s.logger.Error("github client reinit failed", "error", err)
 				result["reinit"] = "failed"
 				result["reinit_error"] = err.Error()

--- a/v2/pkg/dashboard/api_broad_coverage_test.go
+++ b/v2/pkg/dashboard/api_broad_coverage_test.go
@@ -76,6 +76,9 @@ func TestCovBR_ConfigGitHub_BadBody(t *testing.T) {
 
 func TestCovBR_ConfigGitHub_KeyFileAndIDs(t *testing.T) {
 	s := covApiServer(t)
+	// The handler now refuses updates it cannot persist (#2459), so the
+	// config needs a real source path.
+	s.deps.Config.SourcePath = filepath.Join(t.TempDir(), "hive.yaml")
 	appID := int64(123)
 	instID := int64(456)
 	rec := doPut(s, "/api/config/github", map[string]any{
@@ -95,6 +98,7 @@ func TestCovBR_ConfigGitHub_KeyFileAndIDs(t *testing.T) {
 
 func TestCovBR_ConfigGitHub_PrivateKeyWrite(t *testing.T) {
 	s := covApiServer(t)
+	s.deps.Config.SourcePath = filepath.Join(t.TempDir(), "hive.yaml")
 	keyPath := filepath.Join(t.TempDir(), "sub", "gh-app-key.pem")
 	rec := doPut(s, "/api/config/github", map[string]any{
 		"private_key": "-----BEGIN KEY-----\nabc\n-----END KEY-----",

--- a/v2/pkg/dashboard/api_config_github_test.go
+++ b/v2/pkg/dashboard/api_config_github_test.go
@@ -1,0 +1,149 @@
+package dashboard
+
+// Regression tests for #2459: the dashboard "Set ID" flow (PUT
+// /api/config/github) on hosted spokes whose GitHub App private key was
+// hub-delivered to the per-app-id path with key_file deliberately left empty.
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Live values from the spoke the bug was observed on (hosted-available-
+// vllmd-06): App 5686 on github.ibm.com, installation 43021. Any real IDs
+// would do; these make the scenario recognizable.
+const (
+	testHubDeliveredAppID          = int64(5686)
+	testHubDeliveredInstallationID = 43021
+)
+
+// TestConfigGitHub_SetIDReinitsWithHubDeliveredKey drives the fleet-standard
+// hosted-spoke configuration through the production handler: key_file empty,
+// key present only at the per-app-id delivered path. Setting the installation
+// ID must trigger the GitHub client rebuild with the RESOLVED key — before
+// #2459 the reinit was gated on the raw cfg.GitHub.KeyFile and silently
+// skipped, leaving the banner up and Re-check dead on a nil client.
+func TestConfigGitHub_SetIDReinitsWithHubDeliveredKey(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.SourcePath = filepath.Join(t.TempDir(), "hive.yaml")
+	deps.Config.GitHub.AppID = testHubDeliveredAppID
+	deps.Config.GitHub.InstallationID = 0
+	deps.Config.GitHub.KeyFile = "" // hub-delivered keys never persist key_file
+
+	// The hub-delivered per-app-id key, at a path the config does not name.
+	delivered := filepath.Join(t.TempDir(), "gh-app-key-5686.pem")
+	if err := os.WriteFile(delivered, []byte("-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mirrors resolveAppKeyFile's contract (cmd/hive): an explicit config
+	// value wins, otherwise the per-app-id delivered file is preferred.
+	deps.ResolveAppKeyFileFunc = func(configured string, appID int64) string {
+		if strings.TrimSpace(configured) != "" {
+			return configured
+		}
+		if appID == testHubDeliveredAppID {
+			return delivered
+		}
+		return ""
+	}
+
+	var gotAppID, gotInstallationID int64
+	var gotKeyFile string
+	reinitCalls := 0
+	deps.ReinitGitHubFunc = func(appID, installationID int64, keyFile string) error {
+		reinitCalls++
+		gotAppID, gotInstallationID, gotKeyFile = appID, installationID, keyFile
+		return nil
+	}
+
+	rec := doPut(s, "/api/config/github", map[string]any{"installation_id": testHubDeliveredInstallationID})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set id: want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	body := decodeJSON(t, rec)
+	if body["reinit"] != "ok" {
+		t.Fatalf("reinit not reported ok: body = %v", body)
+	}
+	if reinitCalls != 1 {
+		t.Fatalf("ReinitGitHubFunc calls = %d, want 1 (raw key_file gate skipped the rebuild?)", reinitCalls)
+	}
+	if gotKeyFile != delivered {
+		t.Fatalf("reinit key file = %q, want the resolved per-app-id key %q", gotKeyFile, delivered)
+	}
+	if gotAppID != testHubDeliveredAppID || gotInstallationID != testHubDeliveredInstallationID {
+		t.Fatalf("reinit ids = (%d, %d), want (%d, %d)", gotAppID, gotInstallationID, testHubDeliveredAppID, testHubDeliveredInstallationID)
+	}
+}
+
+// TestConfigGitHub_ExplicitKeyFileStillWins keeps the pre-#2459 behavior
+// intact: when the operator configured a key_file, the reinit signs with that
+// exact path, resolver or not.
+func TestConfigGitHub_ExplicitKeyFileStillWins(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.SourcePath = filepath.Join(t.TempDir(), "hive.yaml")
+	deps.Config.GitHub.AppID = testHubDeliveredAppID
+	explicit := filepath.Join(t.TempDir(), "operator-key.pem")
+	deps.Config.GitHub.KeyFile = explicit
+
+	deps.ResolveAppKeyFileFunc = func(configured string, appID int64) string {
+		if strings.TrimSpace(configured) != "" {
+			return configured
+		}
+		return "/data/should-not-be-used.pem"
+	}
+
+	var gotKeyFile string
+	deps.ReinitGitHubFunc = func(appID, installationID int64, keyFile string) error {
+		gotKeyFile = keyFile
+		return nil
+	}
+
+	rec := doPut(s, "/api/config/github", map[string]any{"installation_id": testHubDeliveredInstallationID})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set id: want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if gotKeyFile != explicit {
+		t.Fatalf("reinit key file = %q, want the explicit %q", gotKeyFile, explicit)
+	}
+}
+
+// TestConfigGitHub_UnpersistableSaveIsAnError covers the secondary #2459 bug:
+// with no config source path the save was a silent no-op, yet the handler
+// reported "status":"updated" — the owner's installation_id lived only in
+// memory and vanished on the next restart. The handler must refuse and name
+// the cause instead.
+func TestConfigGitHub_UnpersistableSaveIsAnError(t *testing.T) {
+	s, deps := apiServer(t)
+	if deps.Config.SourcePath != "" {
+		t.Fatalf("precondition: test deps config should have no source path")
+	}
+
+	reinitCalls := 0
+	deps.ReinitGitHubFunc = func(appID, installationID int64, keyFile string) error {
+		reinitCalls++
+		return nil
+	}
+
+	rec := doPut(s, "/api/config/github", map[string]any{"installation_id": testHubDeliveredInstallationID})
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("unpersistable save: want 500, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	body := decodeJSON(t, rec)
+	if body["status"] == "updated" {
+		t.Fatalf("unpersistable save must never report \"updated\": body = %v", body)
+	}
+	errMsg, _ := body["error"].(string)
+	if !strings.Contains(errMsg, "source path") {
+		t.Fatalf("error must name the cause (no source path): body = %v", body)
+	}
+	if deps.Config.GitHub.InstallationID != 0 {
+		t.Fatalf("installation_id mutated in memory despite refused save: %d", deps.Config.GitHub.InstallationID)
+	}
+	if reinitCalls != 0 {
+		t.Fatalf("reinit attempted despite refused save: %d calls", reinitCalls)
+	}
+}

--- a/v2/pkg/dashboard/api_knowledge_coverage_test.go
+++ b/v2/pkg/dashboard/api_knowledge_coverage_test.go
@@ -147,6 +147,9 @@ func TestCovC_AgentConfigConnections(t *testing.T) {
 
 func TestCovC_ConfigGitHub(t *testing.T) {
 	s := covCServer(t)
+	// The handler now refuses updates it cannot persist (#2459), so the
+	// config needs a real source path.
+	s.deps.Config.SourcePath = filepath.Join(t.TempDir(), "hive.yaml")
 
 	// bad body -> 400
 	rec := doPut(s, "/api/config/github", "bad")

--- a/v2/pkg/dashboard/deps.go
+++ b/v2/pkg/dashboard/deps.go
@@ -12,37 +12,45 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/agent"
 	"github.com/kubestellar/hive/v2/pkg/beads"
 	"github.com/kubestellar/hive/v2/pkg/config"
-	"github.com/kubestellar/hive/v2/pkg/governor"
 	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+	"github.com/kubestellar/hive/v2/pkg/governor"
 	"github.com/kubestellar/hive/v2/pkg/knowledge"
 	"github.com/kubestellar/hive/v2/pkg/scheduler"
 	"github.com/kubestellar/hive/v2/pkg/tokens"
 )
 
 type Dependencies struct {
-	Config           *config.Config
-	AgentMgr         *agent.Manager
-	Governor         *governor.Governor
-	GHClient         *ghpkg.Client
-	GHAppAuth        *ghpkg.AppAuth
-	Tokens           *tokens.Collector
-	Knowledge        *knowledge.KnowledgeAPI
-	Inception        *knowledge.InceptionEngine
-	Nous             *NousState
-	Scheduler        *scheduler.Scheduler
-	MetricsCollector *MetricsCollector
-	BeadSynthesizer  *knowledge.BeadSynthesizer
-	BeadStores       map[string]*beads.Store
-	Logger           *slog.Logger
-	Ctx              context.Context
-	RefreshFunc      func()
-	PersistFunc      func()
-	SkipReloadFunc   func()
-	ReInitFunc       func()
-	SetUserClient    func(token string)
-	EnumerateFunc      func()
-	AdvisoryResetFunc  func(newPrimaryRepo string)
-	ReinitGitHubFunc   func(appID, installationID int64, keyFile string) error
+	Config            *config.Config
+	AgentMgr          *agent.Manager
+	Governor          *governor.Governor
+	GHClient          *ghpkg.Client
+	GHAppAuth         *ghpkg.AppAuth
+	Tokens            *tokens.Collector
+	Knowledge         *knowledge.KnowledgeAPI
+	Inception         *knowledge.InceptionEngine
+	Nous              *NousState
+	Scheduler         *scheduler.Scheduler
+	MetricsCollector  *MetricsCollector
+	BeadSynthesizer   *knowledge.BeadSynthesizer
+	BeadStores        map[string]*beads.Store
+	Logger            *slog.Logger
+	Ctx               context.Context
+	RefreshFunc       func()
+	PersistFunc       func()
+	SkipReloadFunc    func()
+	ReInitFunc        func()
+	SetUserClient     func(token string)
+	EnumerateFunc     func()
+	AdvisoryResetFunc func(newPrimaryRepo string)
+	ReinitGitHubFunc  func(appID, installationID int64, keyFile string) error
+	// ResolveAppKeyFileFunc resolves which App private key the process would
+	// actually sign with, given the configured key_file and app_id — the SAME
+	// resolution the boot and heartbeat-apply paths use (config value, then
+	// $GH_APP_KEY_FILE, then the per-app-id delivered file, then the generic
+	// fallbacks). Hub-delivered keys deliberately leave key_file empty, so any
+	// handler that gates on the raw config value alone dead-ends on exactly the
+	// fleet-standard hosted-spoke configuration (#2459).
+	ResolveAppKeyFileFunc func(configured string, appID int64) string
 }
 
 type NousState struct {
@@ -69,15 +77,15 @@ type NousPrinciple struct {
 const NousBaselineTarget = 672
 
 type NousSnapshot struct {
-	Timestamp     string         `json:"timestamp"`
-	Mode          string         `json:"mode"`
-	QueueIssues   int            `json:"queue_issues"`
-	QueuePRs      int            `json:"queue_prs"`
-	QueueHold     int            `json:"queue_hold"`
-	SLAViolations int            `json:"sla_violations"`
-	AgentsKicked  []string       `json:"agents_kicked,omitempty"`
+	Timestamp     string            `json:"timestamp"`
+	Mode          string            `json:"mode"`
+	QueueIssues   int               `json:"queue_issues"`
+	QueuePRs      int               `json:"queue_prs"`
+	QueueHold     int               `json:"queue_hold"`
+	SLAViolations int               `json:"sla_violations"`
+	AgentsKicked  []string          `json:"agents_kicked,omitempty"`
 	AgentStates   map[string]string `json:"agent_states,omitempty"`
-	TotalTokens   int64          `json:"total_tokens"`
+	TotalTokens   int64             `json:"total_tokens"`
 }
 
 func (ns *NousState) RecordSnapshot(govState governor.State, actionable *ghpkg.ActionableResult, agentsKicked []string, agentStatuses map[string]*agent.AgentProcess, tokenSummary *tokens.AggregateSummary) error {
@@ -86,13 +94,13 @@ func (ns *NousState) RecordSnapshot(govState governor.State, actionable *ghpkg.A
 	}
 
 	snap := NousSnapshot{
-		Timestamp:     time.Now().UTC().Format(time.RFC3339),
-		Mode:          string(govState.Mode),
-		QueueIssues:   govState.QueueIssues,
-		QueuePRs:      govState.QueuePRs,
-		QueueHold:     govState.QueueHold,
-		AgentsKicked:  agentsKicked,
-		AgentStates:   make(map[string]string),
+		Timestamp:    time.Now().UTC().Format(time.RFC3339),
+		Mode:         string(govState.Mode),
+		QueueIssues:  govState.QueueIssues,
+		QueuePRs:     govState.QueuePRs,
+		QueueHold:    govState.QueueHold,
+		AgentsKicked: agentsKicked,
+		AgentStates:  make(map[string]string),
 	}
 	if actionable != nil {
 		snap.SLAViolations = actionable.Issues.SLAViolations


### PR DESCRIPTION
## Summary

Fixes #2459

On hosted spokes the GitHub App private key is hub-delivered to the per-app-id path (`/data/gh-app-key-<app_id>.pem`) with `github.key_file` deliberately left empty. `handleConfigGitHub` (the banner's **Set ID** → `PUT /api/config/github`) gated the client reinit on the RAW `cfg.GitHub.KeyFile`, so on exactly the fleet-standard hosted configuration it saved the installation_id, skipped the rebuild, never cleared the banner, and left **Re-check** dead-ending forever on a nil client (observed live on `hosted-available-vllmd-06`).

## Changes

- **Resolved-key gate**: the handler now resolves the signing key the same way boot (`initGitHubAuth`) and the heartbeat apply path do — config value → `$GH_APP_KEY_FILE` → per-app-id delivered file → generic fallbacks. Since `resolveAppKeyFile` lives in `cmd/hive`, the resolution is injected as `Dependencies.ResolveAppKeyFileFunc`, following the existing callback pattern (`ReinitGitHubFunc`, `SetGitHubAppRecheckFn`). The reinit gate and the key passed to `ReinitGitHubFunc` both use the resolved path.
- **Silent-save hole closed**: `saveConfig()` silently no-ops when the config has no `SourcePath`, so the handler reported `"status":"updated"` for a value that lived only in memory and vanished on the next restart. The handler now refuses such updates up front (before mutating anything) with an error naming the cause — never `"updated"`.

## Tests

- `TestConfigGitHub_SetIDReinitsWithHubDeliveredKey` — key_file empty, per-app-id key delivered → Set ID triggers reinit with the resolved key (fails if the raw-KeyFile gate is restored).
- `TestConfigGitHub_ExplicitKeyFileStillWins` — operator-named key_file still wins outright.
- `TestConfigGitHub_UnpersistableSaveIsAnError` — no SourcePath → 500 naming the cause, no in-memory mutation, no reinit (fails if the silent no-op is restored).
- Existing coverage tests updated to give the test config a real source path, since the handler now refuses unpersistable updates.

Both targeted mutations (raw-KeyFile gate restored; save-guard removed) were verified to fail their respective tests before push.