### PR TITLE
🐛 hub: stop alerting auth-class health checks on unclaimed placeholders

### DIFF
--- a/v2/pkg/hub/alerts.go
+++ b/v2/pkg/hub/alerts.go
@@ -622,7 +622,38 @@ const (
 	// reason string. A hive with everything failing should not produce a
 	// paragraph; the count still reflects the true total.
 	maxNamedFailingChecks = 3
+
+	// healthCheckGitHubAuth is the spoke's GitHub credential check
+	// (pkg/dashboard/server.go builds it in both HealthSummary and
+	// handleHealthDeep). It fails whenever no App or token is configured.
+	healthCheckGitHubAuth = "github_auth"
+	// healthCheckGitHubAppPrefix catches any GitHub-App-scoped check name a
+	// spoke version may report (e.g. a future github_app_key). Every check in
+	// that family verifies credentials a placeholder cannot have yet.
+	healthCheckGitHubAppPrefix = "github_app"
 )
+
+// isAuthClassHealthCheck reports whether a named health check verifies GitHub
+// credentials (App or token) rather than the spoke process itself. The split
+// matters for placeholders: an UNASSIGNED pool slot has no GitHub auth BY
+// DESIGN — credentials only arrive when a project is claimed — so an auth
+// check failing on a placeholder is the pool working as designed, not a fault.
+func isAuthClassHealthCheck(name string) bool {
+	return name == healthCheckGitHubAuth ||
+		strings.HasPrefix(name, healthCheckGitHubAppPrefix)
+}
+
+// withoutAuthClassChecks filters auth-class names out of a failing-checks list.
+// Used only for placeholders; a claimed hive's list passes through untouched.
+func withoutAuthClassChecks(names []string) []string {
+	kept := names[:0:0]
+	for _, n := range names {
+		if !isAuthClassHealthCheck(n) {
+			kept = append(kept, n)
+		}
+	}
+	return kept
+}
 
 // fleetMedianTokens returns the median TotalTokens24h across claimed, online
 // hives, and how many hives contributed. Placeholders are excluded — an idle
@@ -756,7 +787,18 @@ func evaluateAlerts(state *alertState, hives []alertHive, driftAlerts []Alert, n
 		}
 
 		// --- Rule: a named health check is failing. ---
-		if failing := failingHealthChecks(h.Health); len(failing) > 0 {
+		// Placeholders keep this rule — drift.go deliberately treats health as
+		// NOT claimed-only, because a pool slot runs a real spoke process that
+		// can genuinely be degraded — but auth-class checks are exempt for
+		// them, mirroring drift's rule 2 ("never flag a placeholder for a
+		// claimed-hive concern"): an unassigned slot has no GitHub auth by
+		// design, and every live placeholder alerting github_auth was burying
+		// a real alert under pool noise. A claimed hive's list is untouched.
+		failing := failingHealthChecks(h.Health)
+		if h.IsPlaceholder {
+			failing = withoutAuthClassChecks(failing)
+		}
+		if len(failing) > 0 {
 			shown := failing
 			suffix := ""
 			if len(shown) > maxNamedFailingChecks {

--- a/v2/pkg/hub/alerts_test.go
+++ b/v2/pkg/hub/alerts_test.go
@@ -406,6 +406,84 @@ func TestEvaluateAlerts_HealthCheckFailingRule(t *testing.T) {
 	}
 }
 
+func TestEvaluateAlerts_PlaceholderAuthCheckSuppressed(t *testing.T) {
+	// An UNCLAIMED placeholder has no GitHub auth by design, so a failing
+	// github_auth (or any github_app*) check must produce NO alert — every
+	// available-* pool slot alerting github_auth buries the real alerts.
+	h := baseHive("p1")
+	h.IsPlaceholder = true
+	h.Health = map[string]any{"checks": []any{
+		map[string]any{"name": "github_auth", "status": "fail", "detail": "no GitHub auth configured"},
+		map[string]any{"name": "github_app_key", "status": "fail"},
+	}}
+	got := evaluateAlerts(newAlertState(), []alertHive{h}, nil, fixedNow)
+	if a, ok := findAlert(got.Alerts, "p1", AlertTypeHealthCheckFailing); ok {
+		t.Fatalf("placeholder with only auth-class checks failing must not alert, got %+v", a)
+	}
+}
+
+func TestEvaluateAlerts_ClaimedHiveAuthCheckStillAlerts(t *testing.T) {
+	// The placeholder exemption must not leak: the SAME failing github_auth
+	// check on a claimed hive is a real fault and must keep alerting.
+	h := baseHive("h1")
+	h.Health = map[string]any{"checks": []any{
+		map[string]any{"name": "github_auth", "status": "fail", "detail": "token expired"},
+	}}
+	got := evaluateAlerts(newAlertState(), []alertHive{h}, nil, fixedNow)
+	a, ok := findAlert(got.Alerts, "h1", AlertTypeHealthCheckFailing)
+	if !ok {
+		t.Fatalf("claimed hive with failing github_auth must alert, got %+v", got.Alerts)
+	}
+	if !contains(a.Reason, "github_auth") {
+		t.Fatalf("reason %q must name the failing check", a.Reason)
+	}
+}
+
+func TestEvaluateAlerts_ClaimedHiveNonAuthCheckStillAlerts(t *testing.T) {
+	// A claimed hive's non-auth checks (the "agents" family) are entirely
+	// outside the exemption and must keep alerting.
+	h := baseHive("h1")
+	h.Health = map[string]any{"checks": []any{
+		map[string]any{"name": "agents", "status": "fail", "detail": "2 agents down"},
+	}}
+	got := evaluateAlerts(newAlertState(), []alertHive{h}, nil, fixedNow)
+	a, ok := findAlert(got.Alerts, "h1", AlertTypeHealthCheckFailing)
+	if !ok {
+		t.Fatalf("claimed hive with failing agents check must alert, got %+v", got.Alerts)
+	}
+	if !contains(a.Reason, "agents") {
+		t.Fatalf("reason %q must name the failing check", a.Reason)
+	}
+}
+
+func TestEvaluateAlerts_PlaceholderNonAuthCheckStillAlerts(t *testing.T) {
+	// Only auth-class checks are placeholder-exempt. Drift deliberately treats
+	// health as NOT claimed-only (a pool slot runs a real spoke process that
+	// can genuinely be degraded), so a placeholder's non-auth failure must
+	// still alert — and the auth-class name failing alongside it must be
+	// filtered out of both the count and the reason.
+	h := baseHive("p1")
+	h.IsPlaceholder = true
+	h.Health = map[string]any{"checks": []any{
+		map[string]any{"name": "github_auth", "status": "fail"},
+		map[string]any{"name": "queue", "status": "fail", "detail": "queue wedged"},
+	}}
+	got := evaluateAlerts(newAlertState(), []alertHive{h}, nil, fixedNow)
+	a, ok := findAlert(got.Alerts, "p1", AlertTypeHealthCheckFailing)
+	if !ok {
+		t.Fatalf("placeholder with a failing non-auth check must alert, got %+v", got.Alerts)
+	}
+	if !contains(a.Reason, "queue") {
+		t.Fatalf("reason %q must name the non-auth failing check", a.Reason)
+	}
+	if contains(a.Reason, "github_auth") {
+		t.Fatalf("reason %q must not name the exempt auth check", a.Reason)
+	}
+	if !contains(a.Reason, "1 health check failing") {
+		t.Fatalf("reason %q must count only the non-exempt check", a.Reason)
+	}
+}
+
 func TestEvaluateAlerts_HealthCheckReasonTruncatesButCountsAll(t *testing.T) {
 	var checks []any
 	total := maxNamedFailingChecks + 4


### PR DESCRIPTION
## Problem

Every UNASSIGNED placeholder hive (e.g. `available-oke-12/placeholder`) raises a **"1 health check failing: github_auth"** alert. Placeholders have no GitHub auth **by design** — credentials only arrive when a project is assigned — so the pool floods the attention list with noise that buries real alerts (live: available-oke-12/13/14 all alerting github_auth alongside a genuine agents-check alert).

## Fix

In the health-check alert rule (`pkg/hub/alerts.go`), filter **auth-class** check names — `github_auth` and the `github_app*` family — from the failing list **for placeholders only**, using the same `isPlaceholderEntry` predicate drift already uses (via `alertHive.IsPlaceholder`, alerts and drift can never disagree about what counts as claimed).

Follows drift's lead precisely:
- drift's rule 2: *never flag a placeholder for a claimed-hive concern* (no GitHub App / no tokens is the pool working as designed) → auth checks exempt
- drift's health signal is deliberately NOT claimed-only (*"Placeholders run a real spoke process and can genuinely be degraded"*) → non-auth checks on placeholders keep alerting

Claimed hives are completely unaffected.

## Tests

- Placeholder + failing `github_auth`/`github_app_key` → NO alert
- Claimed hive + failing `github_auth` → alert (exemption must not leak)
- Claimed hive + failing `agents` → alert
- Placeholder + failing `queue` alongside `github_auth` → alert names/counts only `queue`

Mutation-verified: inverting the placeholder guard fails 3 tests; dropping the guard fails the placeholder-suppression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)