### PR TITLE
🐛 spoke: header Health pill and agent dots must render the deep checks

### DIFF
--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -199,6 +199,13 @@ type StatusPayload struct {
 	Repos               []FrontendRepo         `json:"repos"`
 	Beads               FrontendBeads          `json:"beads"`
 	Health              map[string]any         `json:"health"`
+	// DeepHealth carries the spoke's own deep health checks (HealthSummary:
+	// ready, github_auth, agents, …) — the same checks the heartbeat reports
+	// to the hub. The dashboard's header Health pill renders from these, NOT
+	// from the shallow /api/health liveness signal or the repo-workflow
+	// Health map above, so the pill can never show "Health OK" while the
+	// spoke's own agents are down (#2465).
+	DeepHealth          map[string]any         `json:"deepHealth,omitempty"`
 	Budget              FrontendBudget         `json:"budget"`
 	CadenceMatrix       []FrontendCadence      `json:"cadenceMatrix"`
 	GHRateLimits        map[string]any         `json:"ghRateLimits"`
@@ -1017,6 +1024,17 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 	s.githubAppMu.RUnlock()
 
 	status.InferenceBackends = s.buildInferenceBackends()
+
+	// Deep checks travel inside the status payload so every dashboard surface
+	// (header pill included) renders the same truth the heartbeat sends the
+	// hub. Judged against the payload in hand: it becomes s.status moments
+	// from now, so "ready" must not fail merely because the first beat's
+	// payload has not been assigned yet. Computed before statusMu is taken
+	// below (healthSummaryFor must not run under it).
+	s.statusMu.RLock()
+	readyForDeep := s.ready
+	s.statusMu.RUnlock()
+	status.DeepHealth = s.healthSummaryFor(status, readyForDeep)
 
 	s.systemAlertsMu.RLock()
 	if len(s.systemAlerts) > 0 {
@@ -2001,6 +2019,20 @@ func (s *Server) AdvisoryState() (lastPostedAt time.Time, lastFindings int, last
 
 // HealthSummary returns a deep-health summary with individual check results for heartbeats.
 func (s *Server) HealthSummary() map[string]any {
+	s.statusMu.RLock()
+	status := s.status
+	ready := s.status != nil && s.ready
+	s.statusMu.RUnlock()
+	return s.healthSummaryFor(status, ready)
+}
+
+// healthSummaryFor computes the deep-health checks against an explicit status
+// payload and readiness verdict, so UpdateStatus can embed a snapshot judged
+// against the payload it is ABOUT to install — judging s.status there would
+// report a false "ready: fail" on the first beat after boot, before any
+// payload has been assigned. Callers must not hold statusMu (the readiness
+// and queue inputs are passed in instead of read here).
+func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]any {
 	type check struct {
 		Name   string `json:"name"`
 		Status string `json:"status"`
@@ -2011,9 +2043,6 @@ func (s *Server) HealthSummary() map[string]any {
 	warns := 0
 
 	// 1. Readiness
-	s.statusMu.RLock()
-	ready := s.status != nil && s.ready
-	s.statusMu.RUnlock()
 	if ready {
 		checks = append(checks, check{Name: "ready", Status: "pass"})
 	} else {
@@ -2150,15 +2179,13 @@ func (s *Server) HealthSummary() map[string]any {
 	}
 
 	// 7. Queue
-	s.statusMu.RLock()
-	if s.status != nil {
+	if status != nil {
 		total := 0
-		for _, repo := range s.status.Repos {
+		for _, repo := range status.Repos {
 			total += len(repo.ActionableIssues)
 		}
 		checks = append(checks, check{Name: "queue", Status: "pass", Detail: fmt.Sprintf("%d actionable", total)})
 	}
-	s.statusMu.RUnlock()
 
 	overall := "ok"
 	if fails > 2 {

--- a/v2/pkg/dashboard/spoke_health_truth_test.go
+++ b/v2/pkg/dashboard/spoke_health_truth_test.go
@@ -184,6 +184,18 @@ func TestSpokeHealthTruthUIWiring(t *testing.T) {
 			snippet: "const isDown = a.state !== 'running' && !isPaused && !isOff && !isOnDemand;",
 			why:     "the sidebar dot must treat every non-running, non-paused process state (stopped, failed, idle) as down",
 		},
+		{
+			snippet: "const needsLoginDown = isDown && needsLogin;",
+			why:     "a down agent with an unauthenticated CLI must get the distinct needs-login state, not plain down-red",
+		},
+		{
+			snippet: ".oc-agent-dot.needs-login { background: var(--amber); }",
+			why:     "the sidebar needs-login dot must render amber (warning), not green or red",
+		},
+		{
+			snippet: "needs login — CLI unauthenticated",
+			why:     "the needs-login state must carry a 'needs login' note in the tooltip",
+		},
 	}
 	for _, r := range required {
 		if !strings.Contains(html, r.snippet) {

--- a/v2/pkg/dashboard/spoke_health_truth_test.go
+++ b/v2/pkg/dashboard/spoke_health_truth_test.go
@@ -1,0 +1,163 @@
+package dashboard
+
+// Issue #2465: the spoke dashboard showed a green "Health OK" header pill and
+// green sidebar agent dots while the spoke's own deep health checks reported
+// agents down. Two weak signals were rendered where truth exists: the pill
+// ignored the deep checks, and the sidebar dot only knew the 'stopped' state,
+// so 'failed' (crash-looping) agents fell through to the green 'idle' class.
+//
+// These tests pin the server-side contract (the status payload carries the
+// deep checks) and the UI wiring (pill and dot read the strong signal).
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// deepHealthAgentsCheck digs the "agents" check out of a decoded deepHealth
+// map. Returns nil if absent.
+func deepHealthAgentsCheck(t *testing.T, deep map[string]any) map[string]any {
+	t.Helper()
+	checks, ok := deep["checks"].([]any)
+	if !ok {
+		t.Fatalf("deepHealth.checks is %T, want array", deep["checks"])
+	}
+	for _, c := range checks {
+		m, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["name"] == "agents" {
+			return m
+		}
+	}
+	return nil
+}
+
+// The /api/status payload must carry the deep health checks — the same ones
+// the heartbeat reports to the hub — so the header pill can render them. A
+// down (registered but never launched ⇒ StateStopped) agent must appear as a
+// failing "agents" check with its name in the detail.
+func TestStatusPayloadCarriesDeepHealth(t *testing.T) {
+	srv := newFullServer(t)
+	srv.MarkReady()
+	// Age readiness past the health grace period so the agents check judges
+	// the fleet for real instead of skipping it as "just booted".
+	srv.statusMu.Lock()
+	srv.readyAt = time.Now().Add(-2 * healthGracePeriod)
+	srv.statusMu.Unlock()
+
+	srv.UpdateStatus(minimalPayload())
+
+	req := httptest.NewRequest("GET", "/api/status", nil)
+	w := httptest.NewRecorder()
+	srv.handleStatus(w, req)
+
+	var got struct {
+		DeepHealth map[string]any `json:"deepHealth"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decoding /api/status: %v", err)
+	}
+	if got.DeepHealth == nil {
+		t.Fatal("/api/status payload has no deepHealth — the header pill has nothing truthful to render (#2465)")
+	}
+	if got.DeepHealth["status"] != "degraded" {
+		t.Errorf("deepHealth.status = %v, want degraded (scanner is registered but not running)", got.DeepHealth["status"])
+	}
+	agents := deepHealthAgentsCheck(t, got.DeepHealth)
+	if agents == nil {
+		t.Fatal("deepHealth.checks has no 'agents' check")
+	}
+	if agents["status"] != "fail" {
+		t.Errorf("agents check status = %v, want fail", agents["status"])
+	}
+	detail, _ := agents["detail"].(string)
+	if !strings.Contains(detail, "1 down: scanner") {
+		t.Errorf("agents check detail = %q, want it to name the down agent (\"1 down: scanner\")", detail)
+	}
+}
+
+// The deep snapshot embedded on the FIRST beat is judged against the payload
+// being installed, not the not-yet-assigned s.status — otherwise every boot
+// flashed a false "ready: fail" (and a red pill) until the second full update.
+func TestDeepHealthFirstBeatReadyPasses(t *testing.T) {
+	srv := newFullServer(t)
+	srv.MarkReady()
+
+	// First UpdateStatus ever: s.status is still nil when the snapshot is computed.
+	srv.UpdateStatus(minimalPayload())
+
+	// Read the installed payload through the same JSON the frontend sees —
+	// the in-memory map holds a typed check slice, so round-trip it.
+	req := httptest.NewRequest("GET", "/api/status", nil)
+	w := httptest.NewRecorder()
+	srv.handleStatus(w, req)
+
+	var got struct {
+		DeepHealth map[string]any `json:"deepHealth"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decoding /api/status: %v", err)
+	}
+	if got.DeepHealth == nil {
+		t.Fatal("first beat has no deepHealth")
+	}
+	checks, ok := got.DeepHealth["checks"].([]any)
+	if !ok {
+		t.Fatalf("deepHealth.checks is %T, want array", got.DeepHealth["checks"])
+	}
+	for _, c := range checks {
+		m, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["name"] == "ready" && m["status"] != "pass" {
+			t.Errorf("first-beat ready check = %v, want pass — the snapshot must be judged against the payload being installed", m["status"])
+		}
+	}
+}
+
+// UI wiring: the header pill and sidebar agent dots must read the strong
+// signals. Snippet assertions in the style of gh_app_banner_test.go — they
+// pin the load-bearing lines of the inline script.
+func TestSpokeHealthTruthUIWiring(t *testing.T) {
+	b, err := os.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatalf("reading static/index.html: %v", err)
+	}
+	html := string(b)
+
+	required := []struct {
+		snippet string
+		why     string
+	}{
+		{
+			snippet: "data.deepHealth",
+			why:     "the header pill must render the deep checks from the status payload, not just the repo-workflow health map",
+		},
+		{
+			snippet: "'● Degraded'",
+			why:     "any failing deep check must flip the pill to Degraded",
+		},
+		{
+			snippet: "const isDown = a.state !== 'running' && !isPaused && !isOff && !isOnDemand;",
+			why:     "the sidebar dot must treat every non-running, non-paused process state (stopped, failed, idle) as down",
+		},
+	}
+	for _, r := range required {
+		if !strings.Contains(html, r.snippet) {
+			t.Errorf("static/index.html is missing %q — %s (#2465)", r.snippet, r.why)
+		}
+	}
+
+	// The old weak signal must be gone: matching only 'stopped' let 'failed'
+	// (crash-looping) agents render the green idle dot.
+	if strings.Contains(html, "const isStopped = a.state === 'stopped'") {
+		t.Error("static/index.html still derives the sidebar dot from the 'stopped'-only check — 'failed' agents would render green again (#2465)")
+	}
+}

--- a/v2/pkg/dashboard/spoke_health_truth_test.go
+++ b/v2/pkg/dashboard/spoke_health_truth_test.go
@@ -122,6 +122,42 @@ func TestDeepHealthFirstBeatReadyPasses(t *testing.T) {
 	}
 }
 
+// The refactor onto healthSummaryFor must not weaken the public path: an
+// un-ready server (no MarkReady, no status) still reports a failing "ready"
+// check through HealthSummary, exactly as the heartbeat relies on.
+func TestHealthSummaryNotReadyStillFails(t *testing.T) {
+	srv := newFullServer(t)
+
+	raw, err := json.Marshal(srv.HealthSummary())
+	if err != nil {
+		t.Fatalf("marshal summary: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal summary: %v", err)
+	}
+	checks, ok := m["checks"].([]any)
+	if !ok {
+		t.Fatalf("checks is %T, want array", m["checks"])
+	}
+	found := false
+	for _, c := range checks {
+		cm, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if cm["name"] == "ready" {
+			found = true
+			if cm["status"] != "fail" {
+				t.Errorf("ready check on un-ready server = %v, want fail", cm["status"])
+			}
+		}
+	}
+	if !found {
+		t.Error("HealthSummary has no ready check")
+	}
+}
+
 // UI wiring: the header pill and sidebar agent dots must read the strong
 // signals. Snippet assertions in the style of gh_app_banner_test.go — they
 // pin the load-bearing lines of the inline script.

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3603,12 +3603,15 @@
       const isOff = a.offByCadence === true;
       const isOnDemand = a.onDemand === true;
       const isPaused = a.paused === true && !isOff && !isOnDemand;
-      const isStopped = a.state === 'stopped';
+      // Down = process not alive ('stopped', 'failed', …) — anything but
+      // 'running'. Matching only 'stopped' let 'failed' agents render the
+      // green idle styling here (#2465).
+      const isStopped = a.state !== 'running' && !isPaused && !isOff && !isOnDemand;
       const isRunning = a.busy === 'working' && !isPaused && !isOff && !isStopped;
       const dotCls = isStopped ? 'stopped' : isOnDemand ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'running' : 'idle';
 
       detail.className = 'oc-agent-detail active state-' + dotCls;
-      const stateLabel = isStopped ? 'stopped' : isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'working' : 'idle';
+      const stateLabel = isStopped ? 'down' : isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'working' : 'idle';
 
       const kickId = `oc-kick-${a.name}`;
       const prevInput = document.getElementById(kickId);
@@ -3862,10 +3865,16 @@
       const isOff = a.offByCadence === true;
       const isOnDemand = a.onDemand === true;
       const isPaused = a.paused === true && !isOff && !isOnDemand;
-      const isStopped = a.state === 'stopped';
-      const isRunning = a.busy === 'working' && !isPaused && !isOff && !isStopped;
+      // Down = the PROCESS is not alive ('stopped', 'failed', or never
+      // launched — anything but 'running'). The dot used to read only the
+      // 'stopped' state, so a failed/crash-looping agent fell through to the
+      // green 'idle' class while the deep "agents" health check reported it
+      // down (#2465). Match the deep check: non-running + non-paused = down,
+      // with paused/off/on-demand keeping their own styling.
+      const isDown = a.state !== 'running' && !isPaused && !isOff && !isOnDemand;
+      const isRunning = a.busy === 'working' && !isPaused && !isOff && !isDown;
       const isOnDemandIdle = isOnDemand && !isRunning;
-      const dotCls = isStopped ? 'stopped' : isOnDemandIdle ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'running' : 'idle';
+      const dotCls = isDown ? 'stopped' : isOnDemandIdle ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'running' : 'idle';
       const isActive = _ocSelectedAgent === a.name ? ' active' : '';
       const agentDesc = a.description || AGENT_DESCRIPTIONS[a.name] || '';
       const label = a.displayName || a.name;
@@ -5215,7 +5224,9 @@
         const isOff = a.offByCadence === true;
         const isOnDemand = a.onDemand === true;
         const isPaused = a.paused === true && !isOff && !isOnDemand;
-        const isStopped = a.state === 'stopped' && !isPaused && !isOff;
+        // Down = process not alive — anything but 'running'. 'stopped'-only
+        // matching rendered crash-looping ('failed') agents green (#2465).
+        const isStopped = a.state !== 'running' && !isPaused && !isOff && !isOnDemand;
         const STALE_MS = 1200000; // 20 minutes
         const isStale = a.summaryUpdated && !isPaused && a.busy === 'working' && (Date.now() - new Date(a.summaryUpdated).getTime()) > STALE_MS;
         let statusCls = '';
@@ -10605,7 +10616,21 @@ function burnAreaChart() {
         const CI_PASS_THRESHOLD = 70;
         const HEALTH_LABELS = _buildHealthLabels(data.agents || []);
         const failing = [];
+        const warning = [];
         const passing = [];
+        // Deep checks first — the spoke's own health (ready, github_auth,
+        // agents with "N down: names", …), the exact checks the heartbeat
+        // reports to the hub. These decide the pill's color: a pill that read
+        // only the repo-workflow map below showed "Health OK" while this
+        // spoke's own agents were down (#2465).
+        const deepChecks = Array.isArray((data.deepHealth || {}).checks) ? data.deepHealth.checks : [];
+        const deepFailNames = [];
+        for (const c of deepChecks) {
+          const line = c.detail ? `${c.name}: ${c.detail}` : c.name;
+          if (c.status === 'fail') { deepFailNames.push(c.name); failing.push(line); }
+          else if (c.status === 'warn') warning.push(line);
+          else passing.push(line);
+        }
         for (const [k, v] of Object.entries(h)) {
           const label = HEALTH_LABELS[k] || k;
           if (k === 'ci') {
@@ -10621,9 +10646,17 @@ function burnAreaChart() {
         }
         const hoverLines = [];
         if (failing.length) hoverLines.push('FAILING:\n' + failing.map(f => '  ✗ ' + f).join('\n'));
+        if (warning.length) hoverLines.push('WARNINGS:\n' + warning.map(wl => '  ⚠ ' + wl).join('\n'));
         if (passing.length) hoverLines.push('PASSING:\n' + passing.map(p => '  ✓ ' + p).join('\n'));
         ocHealth.title = hoverLines.join('\n\n') || 'No health data';
-        if (failing.length > 0) {
+        if (deepFailNames.length > 0) {
+          // Any failing deep check ⇒ the spoke itself is degraded — same
+          // verdict the hub renders for this hive's row.
+          ocHealth.textContent = '● Degraded';
+          ocHealth.style.color = 'var(--red)';
+          ocHealth.style.background = 'var(--red-bg)';
+          ocHealth.style.borderColor = 'var(--red-border)';
+        } else if (failing.length > 0) {
           ocHealth.textContent = `● ${failing.length} Issue${failing.length > 1 ? 's' : ''}`;
           ocHealth.style.color = 'var(--red)';
           ocHealth.style.background = 'var(--red-bg)';

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -338,6 +338,7 @@
     .oc-agent-detail.state-paused { border-color: var(--yellow); }
     .oc-agent-detail.state-on-demand { border-color: var(--indigo); }
     .oc-agent-detail.state-stopped { border-color: var(--red); }
+    .oc-agent-detail.state-needs-login { border-color: var(--amber); }
     .oc-agent-detail.state-off { border-color: var(--line); }
     .oc-agent-detail-header {
       display: flex; align-items: center; gap: 10px; margin-bottom: 16px;
@@ -355,6 +356,7 @@
     .oc-agent-detail-header .status-dot.paused { background: var(--yellow); }
     .oc-agent-detail-header .status-dot.on-demand { background: var(--indigo); }
     .oc-agent-detail-header .status-dot.stopped { background: var(--red); }
+    .oc-agent-detail-header .status-dot.needs-login { background: var(--amber); }
     .oc-agent-detail-header .status-dot.off { background: var(--muted); }
     .oc-detail-fields {
       display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px 24px; margin-bottom: 16px;
@@ -419,6 +421,7 @@
     .oc-agent-dot.paused { background: var(--yellow); }
     .oc-agent-dot.on-demand { background: var(--indigo); }
     .oc-agent-dot.stopped { background: var(--red); }
+    .oc-agent-dot.needs-login { background: var(--amber); }
     .oc-agent-dot.off { background: var(--muted); }
     @keyframes oc-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
@@ -836,6 +839,7 @@
     .dot.on-demand { background: var(--indigo); }
     .dot.off { background: var(--muted); }
     .dot.stopped { background: var(--red); }
+    .dot.needs-login { background: var(--amber); }
     .agent-field { display: flex; justify-content: space-between; font-size: 0.8rem; padding: 2px 0; }
     .agent-field .label { color: var(--muted); }
     .agent-field .value { text-align: right; }
@@ -3607,11 +3611,15 @@
       // 'running'. Matching only 'stopped' let 'failed' agents render the
       // green idle styling here (#2465).
       const isStopped = a.state !== 'running' && !isPaused && !isOff && !isOnDemand;
+      // Same formula as the Auth section's Login button below: a down agent
+      // with an unauthenticated CLI gets the amber needs-login state instead
+      // of plain down-red (#2465).
+      const needsLoginDown = isStopped && (a.needsLogin === true || (a.authKnown === true && a.authAvailable !== true));
       const isRunning = a.busy === 'working' && !isPaused && !isOff && !isStopped;
-      const dotCls = isStopped ? 'stopped' : isOnDemand ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'running' : 'idle';
+      const dotCls = needsLoginDown ? 'needs-login' : isStopped ? 'stopped' : isOnDemand ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'running' : 'idle';
 
       detail.className = 'oc-agent-detail active state-' + dotCls;
-      const stateLabel = isStopped ? 'down' : isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'working' : 'idle';
+      const stateLabel = needsLoginDown ? 'needs login' : isStopped ? 'down' : isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'working' : 'idle';
 
       const kickId = `oc-kick-${a.name}`;
       const prevInput = document.getElementById(kickId);
@@ -3872,11 +3880,19 @@
       // down (#2465). Match the deep check: non-running + non-paused = down,
       // with paused/off/on-demand keeping their own styling.
       const isDown = a.state !== 'running' && !isPaused && !isOff && !isOnDemand;
+      // A down agent whose CLI is unauthenticated is not merely down — it can
+      // never do work until someone logs it in. Same formula as the agent
+      // panel's Login button; rendered amber with a "needs login" note. Only
+      // applies when the agent is not running: a running authenticated agent
+      // is green, a non-running authenticated agent is red (#2465).
+      const needsLogin = a.needsLogin === true || (a.authKnown === true && a.authAvailable !== true);
+      const needsLoginDown = isDown && needsLogin;
       const isRunning = a.busy === 'working' && !isPaused && !isOff && !isDown;
       const isOnDemandIdle = isOnDemand && !isRunning;
-      const dotCls = isDown ? 'stopped' : isOnDemandIdle ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'running' : 'idle';
+      const dotCls = needsLoginDown ? 'needs-login' : isDown ? 'stopped' : isOnDemandIdle ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'running' : 'idle';
       const isActive = _ocSelectedAgent === a.name ? ' active' : '';
-      const agentDesc = a.description || AGENT_DESCRIPTIONS[a.name] || '';
+      const baseDesc = a.description || AGENT_DESCRIPTIONS[a.name] || '';
+      const agentDesc = needsLoginDown ? (baseDesc ? baseDesc + '\n' : '') + 'needs login — CLI unauthenticated, the agent cannot work until logged in' : baseDesc;
       const label = a.displayName || a.name;
       const emojiHtml = a.emoji ? `<span class="oc-nav-emoji">${a.emoji}</span>` : '';
       const modeHtml = (a.modeEmoji || a.mode) ? `<span class="oc-nav-mode" title="${esc(a.mode || '')}">${a.modeEmoji || modeEmoji(a.mode)}</span>` : '';
@@ -5235,7 +5251,9 @@
         else if (isStale) statusCls = 'status-stale';
         const isOnDemandIdle = isOnDemand && a.busy !== 'working';
         const cls = needsLogin ? 'needs-login' : isOnDemandIdle ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : isStopped ? 'stopped' : `${a.busy} ${statusCls}`.trim();
-        const dotCls = isStopped ? 'stopped' : isOnDemandIdle ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy === 'working' ? 'running' : 'idle';
+        // Down + unauthenticated CLI = amber needs-login (same formula as the
+        // card's Login button above), not plain down-red (#2465).
+        const dotCls = (isStopped && needsLogin) ? 'needs-login' : isStopped ? 'stopped' : isOnDemandIdle ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy === 'working' ? 'running' : 'idle';
         const canToggle = a.beadRole !== 'supervisor';
         const toggleBtn = canToggle ? (isOff
           ? `<button class="btn-toggle off" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Agent is off in this governor mode — click to configure per-mode cadences">⚙ off</button>`


### PR DESCRIPTION
## Summary

Confirmed on two production hives (jeejz: 1 down agent; laredo: 2 down, one crash-looping at 41 restarts/24h): the spoke dashboard showed a green **Health OK** pill and green agent dots while the spoke's own deep health checks reported those agents down. Two weak signals were rendered where truth exists.

### What drove each green lie

- **Header pill**: read only the repo-workflow health map (`data.health`: CI %, nightly workflows, brew/helm). The spoke's deep checks — `ready`, `github_auth`, `agents` with its `N down: names` detail, the exact checks the heartbeat reports to the hub — never reached the payload the pill renders from.
- **Agent dots** (sidebar, cards, detail panel): matched only `state === 'stopped'`, so a `failed` (crash-looping) agent fell through to the green `idle` class. Enabled-but-not-running rendered green.

### Fix

- `StatusPayload` gains `deepHealth` (populated in `UpdateStatus` from the same `HealthSummary` checks the heartbeat sends). Any failing deep check flips the pill to a red **● Degraded**, with failing/warning/passing checks itemized in the tooltip. Repo-workflow issues keep the existing `N Issues` rendering when no deep check fails.
- All three dot sites now apply the deep check's rule: non-running + non-paused = down (red); paused/off-by-cadence/on-demand keep their existing styling.
- **Needs-login state**: a down agent whose CLI is unauthenticated (active Login button — jeejz supervisor, laredo quality) renders a distinct **amber** dot with a 'needs login' note instead of plain down-red, using the exact formula the Login button renders from. Precedence: running authenticated = green; non-running authenticated = red; non-running unauthenticated = amber.
- `HealthSummary` refactored onto `healthSummaryFor(status, ready)` so the embedded snapshot is judged against the payload being installed — judging `s.status` would flash a false `ready: fail` (red pill) on the first beat after every boot.

### Tests

- `TestStatusPayloadCarriesDeepHealth` — /api/status carries `deepHealth` with a failing `agents` check naming the down agent
- `TestDeepHealthFirstBeatReadyPasses` — first-beat snapshot judged against the installed payload
- `TestHealthSummaryNotReadyStillFails` — added after a mutation check showed the not-ready path uncovered
- `TestSpokeHealthTruthUIWiring` — pins the pill/dot/needs-login wiring in the inline script and rejects the old 'stopped'-only pattern
- All server-side mutants killed; `go build ./...` and full `pkg/dashboard` + `pkg/hub` dashboard tests green; both inline script blocks pass `node --check`

Fixes #2465

🤖 Generated with [Claude Code](https://claude.com/claude-code)