### PR TITLE
🔊 observability(spoke): log the agent-removal tombstone lifecycle (refs #2439)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -750,6 +750,16 @@ func main() {
 	cfg.HiveID = loadOrGenerateHiveID(logger)
 	os.Setenv("HIVE_ID", cfg.HiveID)
 
+	// Observability (#2439): report the removed-agents tombstone LoadWithDashboardOverlay
+	// adopted from the dashboard overlay at boot, BEFORE the startup ApplyPack below. On
+	// a non-sticking-removal report this line is the first check — an empty set here on a
+	// hive that removed an agent means the tombstone did not persist across the restart.
+	logger.Info("boot: loaded removed-agents tombstone",
+		"hive_id", cfg.HiveID,
+		"count", len(cfg.RemovedAgents),
+		"agents", cfg.RemovedAgents,
+	)
+
 	// Surface config provenance: when the persisted runtime config exists, init
 	// containers restore it over the ConfigMap seed on restart, so edits made
 	// only to the seed (or only to the live file) silently lose to it.
@@ -2055,6 +2065,16 @@ func main() {
 			newCfg.MarkAgentRemoved(name)
 		}
 		newCfg.PruneRemovedAgents()
+
+		// Observability (#2439): this is the ~2-min interval reload path, so keep it
+		// at DEBUG to avoid spamming a healthy hive. When a removal is not sticking,
+		// enabling DEBUG shows the tombstone surviving each swap — an empty count here
+		// while the agent keeps reappearing localizes the leak to this union-preserve.
+		logger.Debug("reload: preserved removed-agents",
+			"hive_id", cfg.HiveID,
+			"count", len(newCfg.RemovedAgents),
+			"agents", newCfg.RemovedAgents,
+		)
 
 		// Capture the outgoing GitHub App identity before the swap so we can
 		// tell whether the reload changed it.

--- a/v2/pkg/config/agent_overlay.go
+++ b/v2/pkg/config/agent_overlay.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -61,6 +62,15 @@ func (c *Config) MergeAgentOverrides(overlays map[string]AgentConfig) {
 	}
 	for name, agent := range overlays {
 		if c.IsAgentRemoved(name) {
+			// Observability (#2439): a tombstoned agent still had a per-agent
+			// overlay file on disk (it is a key in overlays) — the stale-file
+			// resurrection vector — and the tombstone guard just won over it.
+			// Log at INFO once per skip: this line firing proves the guard held.
+			slog.Default().Info("merge: skipped tombstoned agent",
+				"hive_id", c.HiveID,
+				"agent", name,
+				"had_overlay_file", true,
+			)
 			continue
 		}
 		agent.Managed = true

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -2033,6 +2033,15 @@ func LoadWithDashboardOverlay(path string) (*Config, error) {
 	if len(overlay.RemovedAgents) > 0 {
 		cfg.RemovedAgents = overlay.RemovedAgents
 		cfg.PruneRemovedAgents()
+		// Observability (#2439): this runs on boot AND on every ~2-min config reload,
+		// so keep it at DEBUG. It confirms the reload adopted the overlay's tombstones
+		// BEFORE the fullness guard below — the exact ordering whose absence let the
+		// deleted agents reappear on an interval.
+		slog.Default().Debug("reload: adopted removed-agents from overlay",
+			"hive_id", cfg.HiveID,
+			"count", len(cfg.RemovedAgents),
+			"agents", cfg.RemovedAgents,
+		)
 	}
 	// Guard: the overlay must look like a full hive config (same check the
 	// entrypoint and validateSaveGuard apply) before we trust its agents.

--- a/v2/pkg/config/merge_tombstone_log_test.go
+++ b/v2/pkg/config/merge_tombstone_log_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestMergeAgentOverridesLogsTombstoneSkip pins the observability added for
+// #2439: when MergeAgentOverrides skips a tombstoned agent that still had a
+// per-agent overlay file, it emits a greppable INFO line naming the agent. The
+// log is the whole point — on a live hive it is what proves the stale-file guard
+// fired without exec'ing in to diff config files. Behavior is unchanged; this
+// asserts only the line.
+func TestMergeAgentOverridesLogsTombstoneSkip(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	cfg := &Config{
+		HiveID:        "hive-test",
+		Agents:        map[string]AgentConfig{},
+		RemovedAgents: []string{"guide"},
+	}
+	cfg.MergeAgentOverrides(map[string]AgentConfig{
+		"guide": {Model: "claude-sonnet-4-6"},
+	})
+
+	out := buf.String()
+	if !strings.Contains(out, "merge: skipped tombstoned agent") {
+		t.Errorf("expected the tombstone-skip audit line, got: %q", out)
+	}
+	if !strings.Contains(out, "agent=guide") {
+		t.Errorf("audit line must name the agent, got: %q", out)
+	}
+	if !strings.Contains(out, "had_overlay_file=true") {
+		t.Errorf("audit line must flag the lingering overlay file, got: %q", out)
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4571,8 +4571,8 @@ func (s *Server) handleGovernorRemoveAgent(w http.ResponseWriter, r *http.Reques
 	//
 	// The tombstone closes both: MergeAgentOverrides skips and prunes it, and
 	// ApplyPack refuses to re-create it.
-	s.deps.Config.MarkAgentRemoved(name)
-	s.removeAgentOverlayFile(name)
+	tombstoned := s.deps.Config.MarkAgentRemoved(name)
+	overlayExisted, overlayDeleted := s.removeAgentOverlayFile(name)
 
 	if err := s.saveConfig(); err != nil {
 		s.logger.Error("failed to persist config after agent removal", "error", err)
@@ -4581,23 +4581,53 @@ func (s *Server) handleGovernorRemoveAgent(w http.ResponseWriter, r *http.Reques
 	s.refreshAndPersist()
 	s.logger.Info("agent removed and tombstoned", "agent", name,
 		"note", "will not be re-created by an ACMM pack apply until explicitly re-added")
+	// One greppable audit line for the whole removal action: whether the
+	// tombstone was newly written, whether a stale per-agent overlay file was
+	// present and whether it was deleted, and the resulting tombstone set so a
+	// grep by agent name tells the story of a non-sticking removal report
+	// (#2439) without exec'ing into the pod to diff config files.
+	s.logger.Info("audit: agent removed via dashboard",
+		"hive_id", s.deps.Config.HiveID,
+		"agent", name,
+		"tombstoned", tombstoned,
+		"overlay_file_existed", overlayExisted,
+		"overlay_file_deleted", overlayDeleted,
+		"removed_agents", s.deps.Config.RemovedAgents,
+	)
 	jsonResponse(w, agentDeletionResponse("removed", name, packLevelsDefining(name)))
 }
 
 // removeAgentOverlayFile deletes /data/agent-configs/<name>.yaml. A leftover
 // overlay file is re-merged by every config load, which is one of the two ways
 // a deleted agent used to come back.
-func (s *Server) removeAgentOverlayFile(name string) {
+//
+// Returns (existed, deleted) purely for the caller's audit log: existed reports
+// whether a per-agent overlay file was present before the delete (the stale-file
+// resurrection vector), and deleted reports whether the removal succeeded. The
+// deletion behavior itself is unchanged — an error is still non-fatal because the
+// tombstone already prevents the merge from resurrecting the agent.
+func (s *Server) removeAgentOverlayFile(name string) (existed, deleted bool) {
 	agentsDir := s.deps.Config.Data.AgentsDir
 	if agentsDir == "" {
-		return
+		return false, false
+	}
+	// Observe presence before deleting so the audit log can distinguish
+	// "no stale file" from "stale file removed". Stat errors other than
+	// not-exist leave existed false — we only claim a file was present when
+	// we positively saw one.
+	overlayPath := filepath.Join(agentsDir, name+".yaml")
+	if _, statErr := os.Stat(overlayPath); statErr == nil {
+		existed = true
 	}
 	if err := config.RemoveAgentFile(agentsDir, name); err != nil {
 		// Not fatal: the tombstone already prevents the merge from
-		// resurrecting the agent. Log it so a stale file is still visible.
-		s.logger.Error("failed to remove agent overlay file after delete (tombstone still applies)",
-			"agent", name, "error", err)
+		// resurrecting the agent. Log it at WARN so a stale file — the
+		// resurrection vector for #2439 — is loud and greppable with its path.
+		s.logger.Warn("failed to remove agent overlay file after delete (tombstone still applies)",
+			"hive_id", s.deps.Config.HiveID, "agent", name, "path", overlayPath, "error", err)
+		return existed, false
 	}
+	return existed, existed
 }
 
 // packLevelsDefining returns the ACMM levels whose pack defines this agent, so

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -291,7 +291,11 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 
 	s.persistOnly()
 	go s.refreshAsync()
-	s.logger.Info("ACMM pack applied", "level", level, "name", pack.Name, "created", len(created), "updated", len(updated), "skipped", len(skipped), "paused", len(paused), "resumed", len(resumed), "tombstoned", len(tombstoned))
+	// Observability (#2439): the counts alone ("tombstoned":0) were the tell in the
+	// field report, so also list WHICH agents were tombstoned (deleted by the operator
+	// and NOT re-created) vs skipped (already present) — a grep by agent name against
+	// this single line answers "did the pack try to re-add the agent I removed?".
+	s.logger.Info("ACMM pack applied", "hive_id", s.deps.Config.HiveID, "level", level, "name", pack.Name, "created", len(created), "updated", len(updated), "skipped", len(skipped), "paused", len(paused), "resumed", len(resumed), "tombstoned", len(tombstoned), "tombstoned_agents", tombstoned, "skipped_agents", skipped)
 	if len(tombstoned) > 0 {
 		// Say it plainly in the log too: an operator reading "this level has 6
 		// agents but I see 4" needs the reason, not a silent gap.


### PR DESCRIPTION
## What

Adds targeted, greppable logging along the agent-removal + tombstone + config-assembly path so that when a hive owner reports "I removed an agent but it came back" (castrojo/projectbluefin, #2439), `kubectl logs` alone tells the story — no exec'ing into the pod to diff config files.

**This is observability only — zero behavior change.** No control flow, gating, or tombstone logic is altered.

## The 5 log points

1. **`handleGovernorRemoveAgent`** (`v2/pkg/dashboard/api.go`) — **INFO** `audit: agent removed via dashboard` with `tombstoned`, `overlay_file_existed`, `overlay_file_deleted`, resulting `removed_agents`. Stale-file delete failure now logged at **WARN** with its `path` (the resurrection vector — loud on purpose).
2. **Boot adoption** (`v2/cmd/hive/main.go`) — **INFO** `boot: loaded removed-agents tombstone` (count + agents) right after `LoadWithDashboardOverlay`, so a restart shows whether the tombstone persisted.
3. **ApplyPack** (`v2/pkg/dashboard/api_packs.go`) — **INFO** enriched `ACMM pack applied` to list `tombstoned_agents` + `skipped_agents` (the report cited `"tombstoned":0` as the tell) and `hive_id`. Log fields only.
4. **Reload swap + reload adopt** (`v2/cmd/hive/main.go`, `v2/pkg/config/config.go`) — **DEBUG** `reload: preserved removed-agents` / `reload: adopted removed-agents from overlay` on the ~2-min interval path (DEBUG so a healthy hive isn't spammed).
5. **MergeAgentOverrides** (`v2/pkg/config/agent_overlay.go`) — **INFO** `merge: skipped tombstoned agent` (`agent` + `had_overlay_file`) once per skip, proving the stale-file-wins-over-tombstone guard fired.

## Notes

- `removeAgentOverlayFile` now returns `(existed, deleted)` purely to feed the audit line; deletion behavior and its non-fatal error handling are unchanged (Error→Warn per the vector's importance).
- Uses the existing `slog` logger; `hive_id` included where in scope; no secrets logged; no magic numbers.
- Added one lightweight test asserting the `merge: skipped tombstoned agent` line is emitted.
- `go build ./...` clean; `go test ./pkg/dashboard/ ./pkg/config/ ./cmd/hive/ -short` green; `gofmt -l` clean.

Refs #2439 — the bug is already fixed by #2451; this is diagnostics for future non-sticking reports.