### PR TITLE
🐛 hub: render unassigned placeholder rows green with the status noting why

### DIFF
--- a/v2/pkg/hub/placeholder_health.go
+++ b/v2/pkg/hub/placeholder_health.go
@@ -1,0 +1,171 @@
+package hub
+
+// Placeholder (unassigned pool) rows on the My Hives dashboard.
+//
+// An UNCLAIMED pool slot has no GitHub auth BY DESIGN — credentials only
+// arrive when a project is claimed — so the spoke's auth-class health checks
+// (github_auth, and any github_app* variant) legitimately fail on every
+// placeholder. Left alone, that painted the whole "Unassigned Hives" section
+// red: every row carried a degraded dot, a warning icon and a "2 checks
+// failing" pill, burying the one placeholder that is genuinely broken. The
+// maintainer's rule: if unassigned, that is noted in the status, and the
+// hive's overall status is green.
+//
+// sanitizePlaceholderRows therefore rewrites each placeholder's spoke-reported
+// Health payload before it ships to the browser: failing auth-class checks are
+// reclassified as "skip" with placeholderAuthNote as their detail, and the
+// overall status / fails / warns are recomputed from the surviving checks
+// using the spoke's own thresholds. Genuine placeholder-applicable failures —
+// not ready, agents crash-looping, queue wedged — keep their status untouched
+// and still turn the row red, exactly as drift.go's rule 2 intends ("never
+// flag a placeholder for a claimed-hive concern", and never hide a real one).
+//
+// Which rows count as placeholders is decided by isPlaceholderEntry
+// (drift.go), the SAME predicate computeDrift and the alert evaluator use, so
+// the row dot, the drift badge and the Attention Needed panel can never
+// disagree about what an unassigned hive is.
+
+// placeholderAuthNote is the status-hover text that replaces an auth-class
+// failure's error detail on an unassigned row, so the hover says WHY the check
+// is not evaluated instead of presenting a designed state as a fault.
+const placeholderAuthNote = "Unassigned — auth not configured by design"
+
+const (
+	// healthCheckStatusSkip is the spoke's own not-applicable check status
+	// (rendered as a muted dash by the dashboard), which is exactly what an
+	// auth check on a slot with no auth configured by design is.
+	healthCheckStatusSkip = "skip"
+	// healthCheckStatusWarn / Critical / Error are the remaining non-passing
+	// statuses the dashboard's FAILING_CHECK_STATUSES treats as failures.
+	// Critical and error never come from today's spoke HealthSummary (it emits
+	// pass/fail/warn/skip) but the field is a free-form passthrough, so they
+	// are matched defensively.
+	healthCheckStatusWarn     = "warn"
+	healthCheckStatusCritical = "critical"
+	healthCheckStatusError    = "error"
+)
+
+const (
+	// healthStatusOK / Warning / Degraded / Critical mirror the overall values
+	// the spoke's HealthSummary (pkg/dashboard/server.go) emits.
+	healthStatusOK       = "ok"
+	healthStatusWarning  = "warning"
+	healthStatusDegraded = "degraded"
+	healthStatusCritical = "critical"
+	// healthCriticalFailThreshold mirrors HealthSummary's rule: MORE than this
+	// many failing checks is "critical"; any failing check is "degraded".
+	healthCriticalFailThreshold = 2
+)
+
+// isFailingCheckStatus mirrors the dashboard's FAILING_CHECK_STATUSES: the
+// check statuses that count as a failure for the row pill and the hover.
+func isFailingCheckStatus(st string) bool {
+	switch st {
+	case healthCheckStatusFail, healthCheckStatusWarn, healthCheckStatusCritical, healthCheckStatusError:
+		return true
+	}
+	return false
+}
+
+// sanitizePlaceholderRows rewrites the Health payload of every UNASSIGNED
+// placeholder row in the My Hives result so auth-class check failures — the
+// pool's designed state — no longer read as degradation, while every other
+// failure keeps its colour. Claimed hives pass through untouched. Called after
+// enrichFromSaaSMeta has run on every row (provStatus must be present, or a
+// placeholder that has not yet reported it would be misread as claimed by
+// everything downstream of the org-prefix fallback).
+func sanitizePlaceholderRows(result []MyHiveEntry) {
+	for i := range result {
+		if !isPlaceholderEntry(result[i]) {
+			continue
+		}
+		result[i].Health = placeholderSanitizedHealth(result[i].Health)
+	}
+}
+
+// placeholderSanitizedHealth returns a COPY of the health map in which every
+// failing auth-class check is reclassified as "skip" with placeholderAuthNote
+// as its detail, and status / fails / warns are recomputed from the surviving
+// checks with the spoke's own thresholds. When nothing needs neutralising the
+// input is returned as-is.
+//
+// The input is never mutated: RegistryEntry.Health is a map shared by
+// reference with the hub's live registry snapshot (handleMyHives copies the
+// slice, not the maps), so an in-place rewrite here would corrupt the hub's
+// own record of what the spoke reported.
+//
+// Only the ARRAY shape of "checks" — the shape the heartbeat actually carries
+// (spoke HealthSummary) — is rewritten. The defensive map shape that
+// failingHealthChecks also accepts is left untouched: turning a row green
+// demands positive evidence that only designed-state checks were failing, and
+// an unrecognised shape is not that.
+func placeholderSanitizedHealth(health map[string]any) map[string]any {
+	if health == nil {
+		return nil
+	}
+	rawChecks, ok := health["checks"].([]any)
+	if !ok {
+		return health
+	}
+
+	neutralized := 0
+	fails, warns := 0, 0
+	outChecks := make([]any, 0, len(rawChecks))
+	for _, v := range rawChecks {
+		ck, isObj := v.(map[string]any)
+		if !isObj {
+			outChecks = append(outChecks, v)
+			continue
+		}
+		name, _ := ck["name"].(string)
+		st, _ := ck["status"].(string)
+		if isAuthClassHealthCheck(name) && isFailingCheckStatus(st) {
+			neutralized++
+			replaced := make(map[string]any, len(ck)+1)
+			for k, val := range ck {
+				replaced[k] = val
+			}
+			replaced["status"] = healthCheckStatusSkip
+			replaced["detail"] = placeholderAuthNote
+			outChecks = append(outChecks, replaced)
+			continue
+		}
+		// Non-auth checks keep their reported status and are what the row's
+		// recomputed overall status is derived from.
+		switch st {
+		case healthCheckStatusFail, healthCheckStatusCritical, healthCheckStatusError:
+			fails++
+		case healthCheckStatusWarn:
+			warns++
+		}
+		outChecks = append(outChecks, v)
+	}
+	if neutralized == 0 {
+		return health
+	}
+
+	out := make(map[string]any, len(health))
+	for k, v := range health {
+		out[k] = v
+	}
+	out["checks"] = outChecks
+	out["fails"] = fails
+	out["warns"] = warns
+	out["status"] = overallHealthStatus(fails, warns)
+	return out
+}
+
+// overallHealthStatus mirrors the spoke's HealthSummary thresholds exactly, so
+// a recomputed status is always one the dashboard already knows how to colour.
+func overallHealthStatus(fails, warns int) string {
+	switch {
+	case fails > healthCriticalFailThreshold:
+		return healthStatusCritical
+	case fails > 0:
+		return healthStatusDegraded
+	case warns > 0:
+		return healthStatusWarning
+	default:
+		return healthStatusOK
+	}
+}

--- a/v2/pkg/hub/placeholder_health_test.go
+++ b/v2/pkg/hub/placeholder_health_test.go
@@ -1,0 +1,318 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// checkStatusByName pulls one named check's status out of a health map, using
+// the same array shape the heartbeat carries.
+func checkStatusByName(t *testing.T, health map[string]any, name string) (status, detail string) {
+	t.Helper()
+	raw, _ := health["checks"].([]any)
+	for _, v := range raw {
+		ck, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		if n, _ := ck["name"].(string); n == name {
+			status, _ = ck["status"].(string)
+			detail, _ = ck["detail"].(string)
+			return status, detail
+		}
+	}
+	t.Fatalf("check %q not found in %v", name, health["checks"])
+	return "", ""
+}
+
+func placeholderEntryWithHealth(health map[string]any) MyHiveEntry {
+	return MyHiveEntry{RegistryEntry: RegistryEntry{
+		ID:     "pool-1",
+		Org:    placeholderOrgPrefix + "3",
+		Online: true,
+		Health: health,
+	}}
+}
+
+func authFailingHealth() map[string]any {
+	return map[string]any{
+		"status": "degraded",
+		"fails":  2,
+		"warns":  0,
+		"checks": []any{
+			map[string]any{"name": "ready", "status": "pass"},
+			map[string]any{"name": "github_auth", "status": "fail", "detail": "no GitHub auth configured"},
+			map[string]any{"name": "github_app_key", "status": "fail", "detail": "no key delivered"},
+		},
+	}
+}
+
+// An UNASSIGNED placeholder whose only failures are auth-class checks is the
+// pool working as designed: the row must ship GREEN ("ok"), with the auth
+// checks reclassified as skip and the hover detail saying why.
+func TestPlaceholderRowGreenWhenOnlyAuthChecksFail(t *testing.T) {
+	e := placeholderEntryWithHealth(authFailingHealth())
+	original := e.Health
+
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	got := rows[0].Health
+
+	if st := healthStatusOf(got); st != healthStatusOK {
+		t.Fatalf("placeholder with only auth-class failures: status = %q, want %q", st, healthStatusOK)
+	}
+	if fails, _ := got["fails"].(int); fails != 0 {
+		t.Errorf("fails = %v, want 0 — the failing-checks pill must not render", got["fails"])
+	}
+	for _, name := range []string{"github_auth", "github_app_key"} {
+		st, detail := checkStatusByName(t, got, name)
+		if st != healthCheckStatusSkip {
+			t.Errorf("%s status = %q, want %q", name, st, healthCheckStatusSkip)
+		}
+		if detail != placeholderAuthNote {
+			t.Errorf("%s detail = %q, want the unassigned note %q", name, detail, placeholderAuthNote)
+		}
+	}
+	if st, _ := checkStatusByName(t, got, "ready"); st != "pass" {
+		t.Errorf("ready status = %q, want pass (non-auth checks untouched)", st)
+	}
+
+	// The registry's own map must not have been rewritten: Health is shared by
+	// reference with the live registry snapshot.
+	if st := healthStatusOf(original); st != healthStatusDegraded {
+		t.Errorf("original health map was mutated: status = %q, want %q untouched", st, healthStatusDegraded)
+	}
+	if st, _ := checkStatusByName(t, original, "github_auth"); st != healthCheckStatusFail {
+		t.Errorf("original github_auth was mutated to %q", st)
+	}
+}
+
+// The SAME failing auth checks on a CLAIMED hive are a real fault: the
+// sanitizer must leave the entry byte-for-byte alone.
+func TestClaimedRowKeepsFailingAuthCheck(t *testing.T) {
+	e := MyHiveEntry{RegistryEntry: RegistryEntry{
+		ID:     "claimed-1",
+		Org:    "acme",
+		Online: true,
+		Health: authFailingHealth(),
+	}}
+	e.ProvStatus = "active"
+
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	got := rows[0].Health
+
+	if st := healthStatusOf(got); st != healthStatusDegraded {
+		t.Fatalf("claimed hive status = %q, want %q — the exemption must not leak past placeholders", st, healthStatusDegraded)
+	}
+	if st, _ := checkStatusByName(t, got, "github_auth"); st != healthCheckStatusFail {
+		t.Errorf("claimed hive github_auth = %q, want fail", st)
+	}
+}
+
+// provStatus "available" is the authoritative placeholder signal (the org
+// prefix is only the fallback) — the sanitizer must honour it too, exactly as
+// isPlaceholderEntry does.
+func TestPlaceholderByProvStatusIsSanitized(t *testing.T) {
+	e := MyHiveEntry{RegistryEntry: RegistryEntry{
+		ID:     "pool-2",
+		Org:    "some-org",
+		Online: true,
+		Health: authFailingHealth(),
+	}}
+	e.ProvStatus = statusAvailable
+
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	if st := healthStatusOf(rows[0].Health); st != healthStatusOK {
+		t.Fatalf("provStatus=available placeholder: status = %q, want %q", st, healthStatusOK)
+	}
+}
+
+// A placeholder-applicable failure — here "ready" failing, the not-ready case —
+// must still turn the row red: only auth-class checks are designed-state.
+func TestPlaceholderRowStaysDegradedOnRealFailure(t *testing.T) {
+	e := placeholderEntryWithHealth(map[string]any{
+		"status": "degraded",
+		"fails":  2,
+		"warns":  0,
+		"checks": []any{
+			map[string]any{"name": "ready", "status": "fail", "detail": "not ready"},
+			map[string]any{"name": "github_auth", "status": "fail", "detail": "no GitHub auth configured"},
+		},
+	})
+
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	got := rows[0].Health
+
+	if st := healthStatusOf(got); st != healthStatusDegraded {
+		t.Fatalf("placeholder with a real failure: status = %q, want %q", st, healthStatusDegraded)
+	}
+	if fails, _ := got["fails"].(int); fails != 1 {
+		t.Errorf("fails = %v, want 1 — only the genuine failure counts toward the pill", got["fails"])
+	}
+	if st, _ := checkStatusByName(t, got, "ready"); st != healthCheckStatusFail {
+		t.Errorf("ready = %q, want fail — genuine failures keep their status", st)
+	}
+	if st, _ := checkStatusByName(t, got, "github_auth"); st != healthCheckStatusSkip {
+		t.Errorf("github_auth = %q, want %q", st, healthCheckStatusSkip)
+	}
+}
+
+// A warning-class non-auth check must survive as the overall status too.
+func TestPlaceholderRowKeepsWarningFromRealCheck(t *testing.T) {
+	e := placeholderEntryWithHealth(map[string]any{
+		"status": "degraded",
+		"checks": []any{
+			map[string]any{"name": "stall_detection", "status": "warn", "detail": "1 stalled"},
+			map[string]any{"name": "github_auth", "status": "fail"},
+		},
+	})
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	if st := healthStatusOf(rows[0].Health); st != healthStatusWarning {
+		t.Fatalf("status = %q, want %q — a real warn survives the recompute", st, healthStatusWarning)
+	}
+}
+
+// The sanitizer only touches Health: liveness signals (online, lastHeartbeat)
+// that drive the offline dot and the stale-heartbeat drift/alert rules must
+// pass through untouched, so a stale placeholder still reads as degraded.
+func TestPlaceholderSanitizeLeavesLivenessAlone(t *testing.T) {
+	stale := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+	e := placeholderEntryWithHealth(authFailingHealth())
+	e.Online = false
+	e.LastHeartbeat = stale
+
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+
+	if rows[0].Online {
+		t.Errorf("Online was rewritten — the offline dot must keep showing")
+	}
+	if rows[0].LastHeartbeat != stale {
+		t.Errorf("LastHeartbeat = %q, want %q untouched", rows[0].LastHeartbeat, stale)
+	}
+	// And the stale-heartbeat drift rule still fires on the sanitized entry.
+	rep := computeDrift(rows[0], fleetNorm{}, nil, time.Now())
+	found := false
+	for _, sig := range rep.Signals {
+		if sig.Kind == DriftKindHeartbeatStale {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("heartbeat-stale drift signal missing on a sanitized stale placeholder: %+v", rep.Signals)
+	}
+}
+
+// A health map with no recognisable checks array (the defensive map shape, or
+// no checks at all) is left exactly as reported — greening a row demands
+// positive evidence.
+func TestPlaceholderUnknownHealthShapeUntouched(t *testing.T) {
+	for name, health := range map[string]map[string]any{
+		"nil":       nil,
+		"no checks": {"status": "degraded"},
+		"map shape": {"status": "degraded", "checks": map[string]any{"github_auth": map[string]any{"status": "fail"}}},
+	} {
+		e := placeholderEntryWithHealth(health)
+		rows := []MyHiveEntry{e}
+		sanitizePlaceholderRows(rows)
+		if healthStatusOf(rows[0].Health) == healthStatusOK {
+			t.Errorf("%s: shape without positive evidence was greened: %v", name, rows[0].Health)
+		}
+	}
+}
+
+// End-to-end through the handler: the My Hives payload must ship a green
+// placeholder and an unchanged degraded claimed hive in the same response —
+// this is what pins the sanitizer CALL in handleMyHives, not just the helper.
+func TestMyHivesPlaceholderRowShipsGreenHealth(t *testing.T) {
+	const owner = "placeholder-green-owner"
+	const token = "ghp_placeholder_green"
+
+	dir := t.TempDir()
+	origUsers, origTimeline := saasUsersDir, timelineDir
+	saasUsersDir = dir + "/users"
+	timelineDir = dir + "/timeline"
+	t.Cleanup(func() { saasUsersDir, timelineDir = origUsers, origTimeline })
+
+	cleanup := helperSetupAuthUser(t, token, owner)
+	defer cleanup()
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	s := NewHubServer(0, slog.Default(), "test", "v2")
+	s.mu.Lock()
+	s.registry.Hives = []RegistryEntry{
+		{
+			ID: "pool-slot-1", Name: "available-3/pending", Org: placeholderOrgPrefix + "3",
+			Owner: owner, Online: true, LastHeartbeat: now,
+			Health: authFailingHealth(),
+		},
+		{
+			ID: "claimed-9", Name: "acme/widget", Org: "acme",
+			Owner: owner, Online: true, LastHeartbeat: now,
+			Health: authFailingHealth(),
+		},
+	}
+	s.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/saas/my-hives", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	s.handleMyHives(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("handleMyHives = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Hives []MyHiveEntry `json:"hives"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	byID := map[string]MyHiveEntry{}
+	for _, h := range resp.Hives {
+		byID[h.ID] = h
+	}
+
+	pool, ok := byID["pool-slot-1"]
+	if !ok {
+		t.Fatalf("placeholder missing from response")
+	}
+	if st := healthStatusOf(pool.Health); st != healthStatusOK {
+		t.Errorf("placeholder shipped status %q, want %q", st, healthStatusOK)
+	}
+	if st, detail := checkStatusByName(t, pool.Health, "github_auth"); st != healthCheckStatusSkip || detail != placeholderAuthNote {
+		t.Errorf("placeholder github_auth shipped as %q/%q, want skip with the unassigned note", st, detail)
+	}
+
+	claimed, ok := byID["claimed-9"]
+	if !ok {
+		t.Fatalf("claimed hive missing from response")
+	}
+	if st := healthStatusOf(claimed.Health); st != healthStatusDegraded {
+		t.Errorf("claimed hive shipped status %q, want %q — sanitizing must be placeholder-only", st, healthStatusDegraded)
+	}
+}
+
+// The dashboard's own placeholder handling: healthBadge must carry the
+// unassigned line instead of forcing App-degraded, and hiveStatusFlags must
+// mirror the same placeholder guard so dot and chip agree. String-anchored on
+// the raw dashboardHTML, same as the other JS structure tests.
+func TestDashboardPlaceholderRowsRenderGreen(t *testing.T) {
+	if !strings.Contains(dashboardHTML, "Unassigned — GitHub auth not configured by design") {
+		t.Errorf("healthBadge lost its unassigned hover line — a placeholder row would claim a GitHub App state it cannot have")
+	}
+	if n := strings.Count(dashboardHTML, "!isPlaceholderHive(h) && !!h.githubAppRequired"); n < 2 {
+		t.Errorf("hiveStatusFlags placeholder guard appears %d times, want 2 (appMissing and degraded) — dropping either lets an unassigned row read as degraded", n)
+	}
+	if !strings.Contains(dashboardHTML, "if (isPlaceholderHive(h)) {\n        /* An UNASSIGNED pool slot has no GitHub auth BY DESIGN") {
+		t.Errorf("healthBadge no longer short-circuits the GitHub-App degraded rules for placeholders")
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2066,6 +2066,14 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Unassigned placeholder rows: auth-class check failures are the pool's
+	// DESIGNED state, not degradation, so neutralise them before anything
+	// downstream (drift, the fleet alerts, the browser's row dot and
+	// failing-checks pill) reads Health. Runs after enrichment for the same
+	// provStatus reason annotateDrift documents below, and before it so the
+	// drift health signal and the row agree. See placeholder_health.go.
+	sanitizePlaceholderRows(result)
+
 	// Config drift, computed once over the caller's full visible set — the
 	// fleet norm is derived from that set, so this must run AFTER every row has
 	// been collected and enriched (a row still missing its provStatus would be
@@ -7879,9 +7887,11 @@ const dashboardHTML = `<!DOCTYPE html>
       var st = hp.status || 'unknown';
       /* githubAppRequired means the spoke wants the App but it is not usable:
          with a perm issue it is installed-but-insufficient, without one it is
-         not installed at all. healthBadge() forces "degraded" in both cases. */
-      var appMissing = !!h.githubAppRequired && !h.githubAppPermIssue;
-      var degraded = !!h.githubAppRequired || st === 'degraded' || st === 'critical';
+         not installed at all. healthBadge() forces "degraded" in both cases —
+         EXCEPT on an unassigned placeholder, where having no usable App is the
+         pool's designed state (mirrored here so dot and chip never disagree). */
+      var appMissing = !isPlaceholderHive(h) && !!h.githubAppRequired && !h.githubAppPermIssue;
+      var degraded = (!isPlaceholderHive(h) && !!h.githubAppRequired) || st === 'degraded' || st === 'critical';
       /* An offline hive has no live reading at all, so it is not "OK" even if
          its last stored health snapshot said ok. */
       var ok = !degraded && st === 'ok' && !!h.online;
@@ -8153,7 +8163,15 @@ const dashboardHTML = `<!DOCTYPE html>
         if (ck.detail) line += ': ' + ck.detail;
         lines.push(line);
       }
-      if (h.githubAppRequired && ghAppIsOperatorSide(h.githubAppState)) {
+      if (isPlaceholderHive(h)) {
+        /* An UNASSIGNED pool slot has no GitHub auth BY DESIGN — credentials
+           only arrive when a project is claimed — so none of the App-degraded
+           rules below may fire here. The hub has already reclassified the
+           auth-class checks (sanitizePlaceholderRows, placeholder_health.go);
+           this line says WHY the row is green instead of claiming an App. */
+        lines.push('– Unassigned — GitHub auth not configured by design');
+      }
+      else if (h.githubAppRequired && ghAppIsOperatorSide(h.githubAppState)) {
         /* Operator-side: the key we distribute has not landed, or is for the
            wrong App. Still degraded — the hive genuinely cannot work — but the
            hover must name the real cause so an admin does not chase the user


### PR DESCRIPTION
## Problem

On the hub dashboard, every row in the **Unassigned Hives** section shipped a red dot, a warning icon and a "2 checks failing" pill (`github_auth` and friends). An unclaimed pool slot has no GitHub auth **by design** — credentials only arrive when a project is claimed — so the section read as a wall of degradation and buried the one placeholder that is genuinely broken.

Maintainer's spec: **if unassigned, that should be noted in the status, and the hive's overall status is green.**

## Fix (hub-side only, `pkg/hub`)

- **`placeholder_health.go` (new):** `sanitizePlaceholderRows` runs in `handleMyHives` before drift/alerts/payload. For rows matched by `isPlaceholderEntry` (drift.go — the **same predicate** `computeDrift` and the alert evaluator use, and the same auth-class family #2466 exempted via `isAuthClassHealthCheck`), failing auth-class checks are reclassified as `skip` with hover detail **"Unassigned — auth not configured by design"**, and `status`/`fails`/`warns` are recomputed from the surviving checks using the spoke's own `HealthSummary` thresholds. The registry's own Health map is shared by reference and is never mutated — the sanitizer copies.
- **Genuine failures still turn the row red:** not-ready, stale heartbeat, crash-looping agents, wedged queue etc. keep their status; only positive evidence (array-shaped checks, only auth-class failing) greens a row.
- **`saas.go` dashboard JS:** `healthBadge()` and `hiveStatusFlags()` no longer force App-degraded on a placeholder; the hover carries the unassigned line instead of claiming a GitHub App state the slot cannot have. Dot and chip stay in lockstep.

## Tests

- Placeholder with only `github_auth`/`github_app_key` failing ⇒ `ok`, pill self-suppresses, hover notes unassigned; original map untouched.
- Claimed hive with the identical failure ⇒ stays `degraded` (exemption cannot leak).
- Placeholder with `ready: fail` (not-ready) ⇒ stays `degraded`; real `warn` survives as `warning`.
- Offline/stale placeholder ⇒ liveness fields untouched, heartbeat-stale drift still fires.
- Unknown health shapes ⇒ left as reported (no green-washing without evidence).
- End-to-end `handleMyHives` test pins the call site; JS structure test pins the `healthBadge`/`hiveStatusFlags` guards.

Mutation-tested: inverting `isPlaceholderEntry`, emptying the sanitizer, and deleting the handler call each fail tests.

Full `go build ./...` and `go test ./pkg/hub/` green.