### PR TITLE
✨ spoke: report unauthenticated agents as 'need login', not 'down'

### DIFF
--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -2000,6 +2000,30 @@ func (s *Server) AdvisoryState() (lastPostedAt time.Time, lastFindings int, last
 }
 
 // HealthSummary returns a deep-health summary with individual check results for heartbeats.
+// agentCLIUnauthenticated reports whether an agent's CLI backend lacks working
+// credentials — the exact signal the agent panel uses to render its AUTH/Login
+// button: the pane poller saw a login prompt (proc.NeedsLogin), or the
+// shared-credential probe registered via SetBackendAuthProvider (wired to
+// agent.Manager.BackendAuthAvailable in main.go) reports the backend's auth
+// state as known-and-unavailable. Backend resolution mirrors buildAgents:
+// BackendOverride wins over the configured backend. For backends the probe
+// cannot introspect (known=false) this returns false — an unknown auth state
+// must not reclassify a genuinely crashed agent out of "down".
+func agentCLIUnauthenticated(proc *agent.AgentProcess, authFn func(backend string) (available, known bool)) bool {
+	if proc.NeedsLogin {
+		return true
+	}
+	if authFn == nil {
+		return false
+	}
+	backend := proc.Config.Backend
+	if proc.BackendOverride != "" {
+		backend = proc.BackendOverride
+	}
+	available, known := authFn(backend)
+	return known && !available
+}
+
 func (s *Server) HealthSummary() map[string]any {
 	type check struct {
 		Name   string `json:"name"`
@@ -2051,10 +2075,12 @@ func (s *Server) HealthSummary() map[string]any {
 		stalled := 0
 		unsubstituted := 0
 		down := 0
+		needLogin := 0
 		// The names behind the counts. "1 down" alone is unactionable — the
 		// operator's next question is always WHICH one, and the answer was
 		// dropped right here where it was known.
-		var downNames, stalledNames []string
+		var downNames, stalledNames, needLoginNames []string
+		authFn := getBackendAuthFn()
 		for name, proc := range s.deps.AgentMgr.AllStatuses() {
 			if proc.Paused {
 				paused++
@@ -2077,8 +2103,18 @@ func (s *Server) HealthSummary() map[string]any {
 					}
 				}
 			} else if !grace {
-				down++
-				downNames = append(downNames, name)
+				// A non-running agent whose CLI has no credentials is not
+				// crashed — it is waiting for a human to click Login on the
+				// agent panel. Bucket it separately so the operator reads an
+				// owner-actionable "need login" instead of chasing a "down"
+				// agent that will keep exiting until someone authenticates.
+				if agentCLIUnauthenticated(proc, authFn) {
+					needLogin++
+					needLoginNames = append(needLoginNames, name)
+				} else {
+					down++
+					downNames = append(downNames, name)
+				}
 			}
 		}
 		// Map iteration order is random; sorted names keep the detail line
@@ -2086,6 +2122,7 @@ func (s *Server) HealthSummary() map[string]any {
 		// is really the same agents in a different order.
 		sort.Strings(downNames)
 		sort.Strings(stalledNames)
+		sort.Strings(needLoginNames)
 		detail := fmt.Sprintf("%d running", running)
 		if paused > 0 {
 			detail += fmt.Sprintf(", %d paused", paused)
@@ -2093,8 +2130,14 @@ func (s *Server) HealthSummary() map[string]any {
 		if down > 0 {
 			detail += fmt.Sprintf(", %d down: %s", down, strings.Join(downNames, ", "))
 		}
+		if needLogin > 0 {
+			detail += fmt.Sprintf(", %d need login: %s", needLogin, strings.Join(needLoginNames, ", "))
+		}
 		st := "pass"
-		if down > 0 {
+		// need-login keeps the same fail semantics as down: the agent still
+		// cannot work, and the hub row must keep surfacing it until a human
+		// clicks Login — the detail line tells them which kind of broken it is.
+		if down > 0 || needLogin > 0 {
 			st = "fail"
 			fails++
 		}

--- a/v2/pkg/dashboard/server_health_needlogin_test.go
+++ b/v2/pkg/dashboard/server_health_needlogin_test.go
@@ -1,0 +1,147 @@
+package dashboard
+
+// Health-check classification of unauthenticated agents. An agent whose CLI
+// has no credentials is not crashed — it is waiting for a human to click
+// Login on the agent panel — so the agents health check must report it in a
+// separate "need login" bucket instead of lumping it in with "down". These
+// tests drive the real HealthSummary path through a real agent.Manager plus
+// the same SetBackendAuthProvider seam production wires in main.go.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/agent"
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// healthChecksOf runs HealthSummary and decodes its checks through JSON (the
+// check struct is a function-local type, so tests read it the same way the
+// wire does).
+func healthChecksOf(t *testing.T, s *Server) []struct{ Name, Status, Detail string } {
+	t.Helper()
+	raw, err := json.Marshal(s.HealthSummary())
+	if err != nil {
+		t.Fatalf("marshal HealthSummary: %v", err)
+	}
+	var parsed struct {
+		Checks []struct{ Name, Status, Detail string } `json:"checks"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal HealthSummary: %v", err)
+	}
+	return parsed.Checks
+}
+
+func agentsCheckOf(t *testing.T, s *Server) (status, detail string) {
+	t.Helper()
+	for _, c := range healthChecksOf(t, s) {
+		if c.Name == "agents" {
+			return c.Status, c.Detail
+		}
+	}
+	t.Fatalf("no 'agents' check in HealthSummary")
+	return "", ""
+}
+
+// TestHealthSummary_NeedLoginBucket locks in the full classification: an
+// authenticated crashed agent stays in "down", unauthenticated non-running
+// agents land in "need login" with their (sorted) names, both buckets coexist
+// on one detail line, and the check still fails so the hub row surfaces it.
+func TestHealthSummary_NeedLoginBucket(t *testing.T) {
+	deps := testDeps(t)
+	agentCfgs := map[string]config.AgentConfig{
+		"crashed": {Backend: "claude", Enabled: true}, // authenticated, not running → down
+		"needy-b": {Backend: "bob", Enabled: true},    // unauthenticated → need login
+		"needy-a": {Backend: "bob", Enabled: true},    // unauthenticated → need login
+	}
+	deps.AgentMgr = agent.NewManager(agentCfgs, deps.Logger, agent.ProjectContext{})
+
+	SetBackendAuthProvider(func(backend string) (available, known bool) {
+		switch backend {
+		case "claude":
+			return true, true // credentials present
+		case "bob":
+			return false, true // known unauthenticated — the Login-button state
+		}
+		return false, false
+	})
+	t.Cleanup(func() { SetBackendAuthProvider(nil) })
+
+	s := NewServer(0, deps.Logger)
+	s.RegisterAPI(deps)
+	// No MarkReady: readyAt stays zero so the health grace window is not
+	// active and non-running agents are classified instead of skipped.
+
+	status, detail := agentsCheckOf(t, s)
+
+	// Exact line: names sorted, down and need-login coexisting, and the
+	// unauthenticated agents NOT counted as down.
+	want := "0 running, 1 down: crashed, 2 need login: needy-a, needy-b"
+	if detail != want {
+		t.Fatalf("agents detail = %q, want %q", detail, want)
+	}
+	// Agents that cannot work still fail the check — need-login must not
+	// silently soften the hub row.
+	if status != "fail" {
+		t.Fatalf("agents status = %q, want fail (agents needing login cannot work)", status)
+	}
+}
+
+// TestHealthSummary_NeedLoginOnly checks the detail line when every
+// non-running agent is merely unauthenticated: no "down" segment at all.
+func TestHealthSummary_NeedLoginOnly(t *testing.T) {
+	deps := testDeps(t)
+	deps.AgentMgr = agent.NewManager(map[string]config.AgentConfig{
+		"supervisor": {Backend: "bob", Enabled: true},
+	}, deps.Logger, agent.ProjectContext{})
+
+	SetBackendAuthProvider(func(backend string) (available, known bool) {
+		return false, backend == "bob"
+	})
+	t.Cleanup(func() { SetBackendAuthProvider(nil) })
+
+	s := NewServer(0, deps.Logger)
+	s.RegisterAPI(deps)
+
+	status, detail := agentsCheckOf(t, s)
+	if want := "0 running, 1 need login: supervisor"; detail != want {
+		t.Fatalf("agents detail = %q, want %q", detail, want)
+	}
+	if status != "fail" {
+		t.Fatalf("agents status = %q, want fail", status)
+	}
+}
+
+// TestAgentCLIUnauthenticated covers the classifier's edges directly.
+func TestAgentCLIUnauthenticated(t *testing.T) {
+	authFor := func(m map[string][2]bool) func(string) (bool, bool) {
+		return func(backend string) (bool, bool) {
+			v := m[backend]
+			return v[0], v[1]
+		}
+	}
+
+	// Pane poller saw a login prompt → unauthenticated even with no probe.
+	if !agentCLIUnauthenticated(&agent.AgentProcess{NeedsLogin: true}, nil) {
+		t.Fatal("NeedsLogin=true must classify as unauthenticated")
+	}
+	// Unknown auth state must NOT reclassify a crashed agent out of "down".
+	p := &agent.AgentProcess{Config: config.AgentConfig{Backend: "mystery"}}
+	if agentCLIUnauthenticated(p, authFor(map[string][2]bool{"mystery": {false, false}})) {
+		t.Fatal("unknown auth state must not count as need-login")
+	}
+	// Nil probe (never registered) → same conservatism.
+	if agentCLIUnauthenticated(p, nil) {
+		t.Fatal("nil auth probe must not count as need-login")
+	}
+	// BackendOverride wins over the configured backend, mirroring buildAgents.
+	p = &agent.AgentProcess{
+		Config:          config.AgentConfig{Backend: "claude"},
+		BackendOverride: "bob",
+	}
+	fn := authFor(map[string][2]bool{"claude": {true, true}, "bob": {false, true}})
+	if !agentCLIUnauthenticated(p, fn) {
+		t.Fatal("BackendOverride's auth state must be the one consulted")
+	}
+}


### PR DESCRIPTION
## Problem

The agents health check lumps agents whose CLI is unauthenticated in with "down". An unauthenticated agent is not crashed — it is waiting for a human to click the **Login** button on the agent panel (owner-actionable). Live examples: jeejz `supervisor` and laredo `quality`/`supervisor` — CLI `bob` with an active AUTH Login button; the processes start, cannot work without auth, and exit (laredo quality: 41 restarts/24h) — yet health reports "1 down: supervisor", sending the operator on a crash hunt when the fix is one click.

## Change

- The agents health check (`HealthSummary` in `pkg/dashboard/server.go`) now classifies a would-be-down agent whose CLI is unauthenticated into a separate **need login** bucket:

  ```
  agents: 0 running, 1 down: crashed, 2 need login: needy-a, needy-b
  ```

  Names are sorted, same stability rationale as the existing down/stalled sort (#2452, kept intact).

- **No new probe.** Classification reuses the exact signal the agent panel's AUTH/Login button renders: the pane poller's `NeedsLogin` flag, plus the shared-credential probe registered via `SetBackendAuthProvider` (wired to `agent.Manager.BackendAuthAvailable` in `main.go`) reporting known-and-unavailable for the agent's resolved backend (`BackendOverride` wins, mirroring `buildAgents`). Backends whose auth state is unknown (`known=false`) stay in "down" — an unintrospectable CLI must not hide a real crash.

- The check **still fails** when agents need login: they cannot work, and the hub row must keep surfacing it until someone authenticates. The detail line now tells the operator *which kind of broken* it is. (Considered softening to warn; kept fail deliberately so the hub row does not go quiet on a hive that is doing no work.)

- No hub-side change needed: `failingHealthChecks` (`pkg/hub/alerts.go`) only reads `name`/`status` structurally; the detail line is rendered verbatim in the hover.

## Tests

`pkg/dashboard/server_health_needlogin_test.go` drives the real `HealthSummary` path through a real `agent.Manager` plus the production `SetBackendAuthProvider` seam:

- unauthenticated non-running agent lands in "need login" with its name, NOT in "down"
- authenticated crashed agent stays in "down"
- both buckets coexist on one detail line (exact-string assertion)
- classifier edges: `NeedsLogin` pane flag, unknown auth state stays "down", nil probe stays "down", `BackendOverride` resolution

Mutation-tested: (a) reclassifying need-login agents as down fails 2 tests; (b) dropping the names from the new bucket fails 2 tests.