### PR TITLE
✨ dashboard: live Test-key validation for the bob backend + open-config-on-method-select

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -126,6 +126,8 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/config/governor/bob", s.handleGovernorBobStatus)
 	s.mux.HandleFunc("PUT /api/config/governor/bob", s.handleGovernorBobKey)
 	s.mux.HandleFunc("DELETE /api/config/governor/bob", s.handleGovernorBobKeyClear)
+	// Live key validation (pasted or saved key) — see bob_key_probe.go.
+	s.mux.HandleFunc("POST /api/config/governor/bob/test", s.handleGovernorBobKeyTest)
 	s.mux.HandleFunc("POST /api/config/governor/litellm/test", s.handleGovernorLiteLLMTest)
 	s.mux.HandleFunc("GET /api/config/governor/gateways", s.handleGovernorGatewaysList)
 	s.mux.HandleFunc("PUT /api/config/governor/gateways", s.handleGovernorGatewaysUpsert)
@@ -4377,6 +4379,15 @@ func (s *Server) handleGovernorBobKey(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(key) > bobKeyMaxLen {
 		jsonError(w, fmt.Sprintf("apiKey is too long (limit %d characters)", bobKeyMaxLen),
+			http.StatusBadRequest)
+		return
+	}
+	// A key with interior whitespace/newlines is always a broken paste, and
+	// storing one is a proven auth failure ("invalid jwt string" 401 → every
+	// bob agent parks at the auth prompt). Refuse at save time with the real
+	// explanation. Leading/trailing whitespace was already trimmed above.
+	if strings.ContainsAny(key, " \t\r\n") {
+		jsonError(w, "apiKey contains interior whitespace or line breaks — a bob API key is a single unbroken token; re-copy it from bob.ibm.com and paste it again",
 			http.StatusBadRequest)
 		return
 	}

--- a/v2/pkg/dashboard/bob_key_probe.go
+++ b/v2/pkg/dashboard/bob_key_probe.go
@@ -1,0 +1,299 @@
+package dashboard
+
+// Live validation ("Test key") for the IBM bobshell ("bob") API key stored by
+// bob_key_store.go. bob authenticates with an API key only (its browser SSO
+// cannot complete inside a pod — see bob_key_store.go), and until now the
+// dashboard had no way to tell a working key from a bad one: owners saved a
+// key and found out from bob agents crash-looping at the auth prompt.
+//
+// The probe is the cheapest authenticated call the bob backend supports —
+// GET /inference/v1/model/info — verified live against the production
+// backend. There is no pre-existing hive-side bob HTTP client to reuse; the
+// wire conventions below were confirmed with a real multi-key test:
+//
+//   - base URL https://api.us-east.bob.ibm.com
+//   - opaque keys (bob_prod_…) authenticate as `Authorization: Apikey <key>`.
+//     bobshell itself first sends Bearer, fails to parse the key as a JWT,
+//     and flips to Apikey — the probe goes straight to the scheme that
+//     matches the key's shape (Bearer only for JWT-shaped keys).
+//   - a 401 "Token verification failed: invalid jwt string" means the key
+//     reached the backend in a form it tried to parse as a JWT (wrong scheme
+//     or a dirty/truncated value) — the key itself may be fine.
+//   - a 402 insufficient_quota_or_plan_expired means the credential is valid
+//     but has no inference entitlement (wrong key kind/scope).
+//   - an HTML 403 is the CDN/edge blocking the request — not a key verdict.
+//
+// SECURITY: a key under test is never persisted, never logged, and never
+// echoed back. Every error string that could embed the key (transport errors,
+// backend error bodies) passes through redactSecret before leaving the
+// process.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	// defaultBobAPIBaseURL is the bob backend's API host, confirmed live.
+	// Keys are issued at bob.ibm.com (Scope: Inference); the API itself is
+	// served from this regional host.
+	defaultBobAPIBaseURL = "https://api.us-east.bob.ibm.com"
+
+	// bobAPIBaseURLEnv optionally overrides the probe's base URL (self-hosted
+	// relays, IBM moving the API host, and tests). Only the base URL is
+	// configurable — the probe path and auth convention are fixed.
+	bobAPIBaseURLEnv = "HIVE_BOB_API_URL"
+
+	// bobProbePath is the cheapest authenticated request the backend
+	// supports (confirmed live): no body, no inference cost.
+	bobProbePath = "/inference/v1/model/info"
+
+	// bobAuthSchemeAPIKey / bobAuthSchemeBearer are the two Authorization
+	// schemes the backend accepts. Opaque keys (bob_prod_…) use Apikey;
+	// Bearer is only correct for JWT-shaped credentials.
+	bobAuthSchemeAPIKey = "Apikey "
+	bobAuthSchemeBearer = "Bearer "
+
+	// bobKeyManageURL is where an operator creates a correctly-scoped key —
+	// surfaced in entitlement-failure details. Keep in sync with
+	// BOB_API_KEY_MANAGE_URL in static/index.html.
+	bobKeyManageURL = "https://bob.ibm.com/admin/apikeys"
+
+	// bobProbeTimeout bounds the whole test round-trip so a black-holed host
+	// cannot hang the dashboard request.
+	bobProbeTimeout = 10 * time.Second
+
+	// bobProbeMaxErrBody caps how much of a backend error body is read and
+	// surfaced. Error bodies can be huge; the useful part ("invalid api key",
+	// "wrong scope") is at the front.
+	bobProbeMaxErrBody = 512
+)
+
+// Machine-readable failure classes for the test endpoint. The UI shows the
+// human-readable detail; the reason is stable for scripting/tests.
+const (
+	bobTestReasonUnauthorized  = "unauthorized"
+	bobTestReasonNoEntitlement = "no_entitlement"
+	bobTestReasonUnreachable   = "unreachable"
+	bobTestReasonTimeout       = "timeout"
+	bobTestReasonBadStatus     = "bad_status"
+	bobTestReasonNoKey         = "no_key"
+	bobTestReasonBadKeyFormat  = "bad_key_format"
+)
+
+// bobProbeBaseURL resolves the backend base URL, honoring the env override.
+func bobProbeBaseURL() string {
+	if v := strings.TrimSpace(os.Getenv(bobAPIBaseURLEnv)); v != "" {
+		return v
+	}
+	return defaultBobAPIBaseURL
+}
+
+// bobBackendSays extracts everything useful the backend included with a
+// failure — error body, WWW-Authenticate challenge, request id — so the
+// operator sees the backend's own words ("invalid api key", "key expired",
+// "wrong scope: needs Inference"), not just a classification. The body is
+// truncated to bobProbeMaxErrBody, whitespace-collapsed to a single line,
+// and redacted so key material can never ride along.
+func bobBackendSays(resp *http.Response, key string) string {
+	var parts []string
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, bobProbeMaxErrBody))
+	if msg := strings.Join(strings.Fields(string(body)), " "); msg != "" {
+		parts = append(parts, msg)
+	}
+	if wa := strings.TrimSpace(resp.Header.Get("WWW-Authenticate")); wa != "" {
+		parts = append(parts, "WWW-Authenticate: "+wa)
+	}
+	// Both spellings observed across IBM services; first one present wins.
+	for _, h := range []string{"X-Request-Id", "X-Global-Transaction-Id"} {
+		if rid := strings.TrimSpace(resp.Header.Get(h)); rid != "" {
+			parts = append(parts, "request-id "+rid)
+			break
+		}
+	}
+	return redactSecret(strings.Join(parts, "; "), key)
+}
+
+// bobAuthHeaderValue picks the Authorization scheme by the key's shape:
+// Bearer only for JWT-shaped credentials (three dot-separated segments,
+// "eyJ" header), Apikey for everything else — including bob_prod_ opaque
+// keys, whose confirmed wire scheme is Apikey. This skips bobshell's own
+// Bearer-then-flip dance and its guaranteed "invalid jwt string" 401.
+func bobAuthHeaderValue(key string) string {
+	if strings.HasPrefix(key, "eyJ") && strings.Count(key, ".") == 2 {
+		return bobAuthSchemeBearer + key
+	}
+	return bobAuthSchemeAPIKey + key
+}
+
+// bobJWTVerdictDetail is the decoded explanation for the backend's
+// "Token verification failed: invalid jwt string" 401 — which means the key
+// reached the backend in a form it tried to parse as a JWT, NOT necessarily
+// that the key is bad.
+const bobJWTVerdictDetail = "the backend received the key in a form it tried to parse as a JWT — " +
+	"usually a stray newline/truncation in the stored value, or bob fell back to browser auth " +
+	"because it could not read the key file (perms must allow the agent UID, e.g. 440)"
+
+// bobEntitlementDetail is the decoded explanation for a 402: the credential
+// authenticates but cannot run inference (wrong key kind or scope).
+const bobEntitlementDetail = "key authenticates but has no inference entitlement — " +
+	"create an API key with Scope: Inference at " + bobKeyManageURL
+
+// probeBobAPIKey makes one authenticated model-info request with the given
+// key. An empty reason means the backend accepted the key; otherwise reason
+// is one of the bobTestReason* classes and detail is a human-readable,
+// key-free explanation that includes — and where possible decodes — whatever
+// the backend itself said.
+func probeBobAPIKey(key string) (reason, detail string) {
+	req, err := http.NewRequest(http.MethodGet, strings.TrimRight(bobProbeBaseURL(), "/")+bobProbePath, nil)
+	if err != nil {
+		return bobTestReasonUnreachable, "building request: " + redactSecret(err.Error(), key)
+	}
+	req.Header.Set("Authorization", bobAuthHeaderValue(key))
+	client := &http.Client{Timeout: bobProbeTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return bobTestReasonTimeout,
+				fmt.Sprintf("the bob backend did not respond within %s", bobProbeTimeout)
+		}
+		// Transport errors can embed header values (e.g. Go's invalid-header
+		// rejection quotes the offending value) — always redact.
+		return bobTestReasonUnreachable, "cannot reach the bob backend: " + redactSecret(err.Error(), key)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		return "", ""
+	}
+
+	says := bobBackendSays(resp, key)
+	withSays := func(msg string) string {
+		if says != "" {
+			return msg + ": " + says
+		}
+		return msg
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized:
+		detail = withSays(fmt.Sprintf("the bob backend rejected the key (HTTP %d)", resp.StatusCode))
+		// Decode the known "invalid jwt string" verdict: it fingers the key's
+		// DELIVERY, not its validity.
+		if strings.Contains(says, "invalid jwt string") || strings.Contains(says, "Token verification failed") {
+			detail += " — " + bobJWTVerdictDetail
+		}
+		return bobTestReasonUnauthorized, detail
+	case resp.StatusCode == http.StatusPaymentRequired:
+		// 402 insufficient_quota_or_plan_expired: a real credential of the
+		// wrong kind (e.g. a bob-user key instead of an Inference API key).
+		return bobTestReasonNoEntitlement, withSays(bobEntitlementDetail)
+	case resp.StatusCode == http.StatusForbidden:
+		// An HTML 403 is the CDN/edge (Cloudflare) blocking the request —
+		// bob's auth never evaluated the key, so it is not a key verdict.
+		if bobLooksLikeEdgeHTML(resp, says) {
+			return bobTestReasonUnreachable,
+				"the request was blocked at the network edge (HTML 403 from the CDN/proxy), " +
+					"not by bob's auth — the key was likely never evaluated"
+		}
+		return bobTestReasonUnauthorized,
+			withSays(fmt.Sprintf("the bob backend rejected the key (HTTP %d)", resp.StatusCode))
+	default:
+		return bobTestReasonBadStatus,
+			withSays(fmt.Sprintf("the bob backend returned HTTP %d", resp.StatusCode))
+	}
+}
+
+// bobLooksLikeEdgeHTML reports whether a 403 response is an HTML edge/CDN
+// block page rather than a JSON auth verdict from bob itself.
+func bobLooksLikeEdgeHTML(resp *http.Response, says string) bool {
+	if strings.Contains(strings.ToLower(resp.Header.Get("Content-Type")), "text/html") {
+		return true
+	}
+	trimmed := strings.TrimSpace(says)
+	return strings.HasPrefix(trimmed, "<!DOCTYPE") || strings.HasPrefix(trimmed, "<html")
+}
+
+// handleGovernorBobKeyTest is POST /api/config/governor/bob/test — live
+// validation of a bob API key. A body carrying a non-empty apiKey tests THAT
+// key (pre-save validation; the value is never persisted, logged, or echoed);
+// an empty/absent body tests the SAVED key via the same resolution agents use
+// (ResolveAPIKey), so the key material never leaves the process.
+//
+// The response is always HTTP 200 with the verdict in the body —
+// {"status":"ok"} or {"status":"error","reason":...,"detail":...} — so the UI
+// distinguishes "the test ran and failed" from transport/auth failures of the
+// dashboard itself. Session auth and the read-only write-gate come from the
+// same authenticate/roleEnforcement middleware as every other /api/config
+// route (this is a POST, so read-only roles are rejected before the handler).
+func (s *Server) handleGovernorBobKeyTest(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		APIKey *string `json:"apiKey"`
+	}
+	// The body is OPTIONAL (absent/empty means "test the saved key"), so an
+	// immediate EOF is not an error — only malformed JSON is.
+	if err := decodeBody(r, &body); err != nil && !errors.Is(err, io.EOF) {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+
+	mode := "saved"
+	key := ""
+	if body.APIKey != nil {
+		key = strings.TrimSpace(*body.APIKey)
+	}
+	if key != "" {
+		mode = "pasted"
+		if len(key) > bobKeyMaxLen {
+			jsonError(w, fmt.Sprintf("apiKey is too long (limit %d characters)", bobKeyMaxLen),
+				http.StatusBadRequest)
+			return
+		}
+		// Interior whitespace/newlines can never be part of a bob key, and a
+		// broken paste is a proven "invalid jwt string" 401 — refuse with the
+		// real explanation instead of testing a value that cannot work.
+		// (Leading/trailing whitespace was already trimmed above.)
+		if strings.ContainsAny(key, " \t\r\n") {
+			jsonResponse(w, map[string]interface{}{
+				"status": "error",
+				"reason": bobTestReasonBadKeyFormat,
+				"detail": "the pasted value contains interior whitespace or line breaks — a bob API key is a single unbroken token; re-copy it from bob.ibm.com and paste it again",
+			})
+			return
+		}
+	} else {
+		key = s.deps.Config.Governor.Bob.ResolveAPIKey()
+		if key == "" {
+			jsonResponse(w, map[string]interface{}{
+				"status": "error",
+				"reason": bobTestReasonNoKey,
+				"detail": "no bob API key is configured — paste a key to test, or save one first",
+			})
+			return
+		}
+	}
+
+	reason, detail := probeBobAPIKey(key)
+	if reason == "" {
+		// mode/reason only — never key material, never backend bodies.
+		s.logger.Info("bob api key test ok", "mode", mode)
+		jsonResponse(w, map[string]interface{}{
+			"status": "ok",
+			"detail": "the bob backend accepted the key",
+		})
+		return
+	}
+	s.logger.Info("bob api key test failed", "mode", mode, "reason", reason)
+	jsonResponse(w, map[string]interface{}{
+		"status": "error",
+		"reason": reason,
+		"detail": detail,
+	})
+}

--- a/v2/pkg/dashboard/bob_key_probe_test.go
+++ b/v2/pkg/dashboard/bob_key_probe_test.go
@@ -1,0 +1,386 @@
+package dashboard
+
+// Tests for the bob "Test key" endpoint (handleGovernorBobKeyTest /
+// probeBobAPIKey). Every test runs against an httptest bob backend via the
+// HIVE_BOB_API_URL override, and the leak assertions capture the server's
+// logger output so "the key never appears in responses OR logs" is enforced
+// mechanically, not by inspection.
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// newBobProbeServer builds a Server whose logger writes into the returned
+// buffer at Info level, so tests can assert what was (not) logged.
+func newBobProbeServer(t *testing.T) (*Server, *bytes.Buffer) {
+	t.Helper()
+	var logBuf bytes.Buffer
+	s := NewServer(0, slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	s.deps = &Dependencies{Config: &config.Config{}}
+	return s, &logBuf
+}
+
+// isolateBobKeySources makes saved-key resolution deterministic: the PVC file
+// points into a temp dir and both env fallbacks are blanked.
+func isolateBobKeySources(t *testing.T) string {
+	t.Helper()
+	path := pointBobKeyAtTempDir(t)
+	t.Setenv(config.DefaultBobAPIKeyEnv, "")
+	t.Setenv("BOBSHELL_API_KEY", "")
+	return path
+}
+
+// postBobKeyTest exercises the handler and decodes the verdict.
+func postBobKeyTest(t *testing.T, s *Server, body string) (*httptest.ResponseRecorder, map[string]interface{}) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/config/governor/bob/test", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	s.handleGovernorBobKeyTest(rec, req)
+	var out map[string]interface{}
+	if rec.Code == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+			t.Fatalf("response is not JSON: %v (body: %s)", err, rec.Body.String())
+		}
+	}
+	return rec, out
+}
+
+// A pasted opaque key is sent to the backend with the confirmed wire scheme
+// (`Authorization: Apikey <key>`) against the model-info path, a 200 maps to
+// status ok, and the key is not persisted anywhere.
+func TestBobKeyTest_PastedKeyOK_NotPersisted(t *testing.T) {
+	path := isolateBobKeySources(t)
+	var gotAuth, gotPath string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		if gotAuth != "Apikey "+bobTestKey {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Write([]byte(`{"model":"auto"}`))
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, logBuf := newBobProbeServer(t)
+	rec, out := postBobKeyTest(t, s, `{"apiKey":"`+bobTestKey+`"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if out["status"] != "ok" {
+		t.Fatalf("verdict = %v, want ok (body: %s)", out["status"], rec.Body.String())
+	}
+	// Opaque (non-JWT) keys must use the Apikey scheme — the Bearer scheme is
+	// a guaranteed "invalid jwt string" 401 for them.
+	if gotAuth != "Apikey "+bobTestKey {
+		t.Errorf("backend saw Authorization %q, want %q", gotAuth, "Apikey "+bobTestKey)
+	}
+	if gotPath != bobProbePath {
+		t.Errorf("probe hit %q, want %q", gotPath, bobProbePath)
+	}
+	// Pre-save validation must not persist the key or touch config.
+	if _, err := os.Stat(path); err == nil {
+		t.Error("tested key was written to the PVC key file")
+	}
+	if s.deps.Config.Governor.Bob.APIKeyFile != "" {
+		t.Error("test mutated governor.bob.api_key_file")
+	}
+	if strings.Contains(rec.Body.String(), bobTestKey) {
+		t.Error("response body leaks the key")
+	}
+	if strings.Contains(logBuf.String(), bobTestKey) {
+		t.Error("logs leak the key")
+	}
+}
+
+// A 401 maps to reason "unauthorized", the backend's own words (body,
+// WWW-Authenticate, request id) surface in the detail, and the key never
+// appears in the response or logs even when the BACKEND echoes it back.
+func TestBobKeyTest_Unauthorized_RichDetail_NoKeyMaterial(t *testing.T) {
+	isolateBobKeySources(t)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", "APIKey realm=bob")
+		w.Header().Set("X-Request-Id", "req-42")
+		w.WriteHeader(http.StatusUnauthorized)
+		// Hostile-backend case: the error body echoes the submitted key.
+		w.Write([]byte(`{"error":"invalid api key ` + bobTestKey + ` — wrong scope: needs Inference"}`))
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, logBuf := newBobProbeServer(t)
+	rec, out := postBobKeyTest(t, s, `{"apiKey":"`+bobTestKey+`"}`)
+
+	if out["status"] != "error" || out["reason"] != bobTestReasonUnauthorized {
+		t.Fatalf("verdict = %v/%v, want error/unauthorized (body: %s)", out["status"], out["reason"], rec.Body.String())
+	}
+	detail, _ := out["detail"].(string)
+	// The backend's own words must be surfaced, not just the classification.
+	for _, want := range []string{"invalid api key", "wrong scope: needs Inference", "WWW-Authenticate", "req-42"} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("detail %q does not surface backend info %q", detail, want)
+		}
+	}
+	if strings.Contains(rec.Body.String(), bobTestKey) {
+		t.Error("response body leaks the key the backend echoed")
+	}
+	if strings.Contains(logBuf.String(), bobTestKey) {
+		t.Error("logs leak the key")
+	}
+}
+
+// A connection-refused backend maps to reason "unreachable".
+func TestBobKeyTest_Unreachable(t *testing.T) {
+	isolateBobKeySources(t)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := backend.URL
+	backend.Close() // now refuses connections
+	t.Setenv(bobAPIBaseURLEnv, deadURL)
+
+	s, logBuf := newBobProbeServer(t)
+	rec, out := postBobKeyTest(t, s, `{"apiKey":"`+bobTestKey+`"}`)
+
+	if out["status"] != "error" || out["reason"] != bobTestReasonUnreachable {
+		t.Fatalf("verdict = %v/%v, want error/unreachable (body: %s)", out["status"], out["reason"], rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), bobTestKey) || strings.Contains(logBuf.String(), bobTestKey) {
+		t.Error("key material leaked on transport failure")
+	}
+}
+
+// An empty body tests the SAVED key: the handler resolves it through the
+// same BobConfig.ResolveAPIKey the agents use, reads the key file, and the
+// value stays inside the process (never echoed).
+func TestBobKeyTest_SavedKeyMode_ReadsKeyFile(t *testing.T) {
+	path := isolateBobKeySources(t)
+	if err := writeBobKeyFile(bobTestKey); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotAuth string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Write([]byte(`{"model":"auto"}`))
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, logBuf := newBobProbeServer(t)
+	s.deps.Config.Governor.Bob.APIKeyFile = path
+
+	rec, out := postBobKeyTest(t, s, `{}`)
+	if out["status"] != "ok" {
+		t.Fatalf("verdict = %v, want ok (body: %s)", out["status"], rec.Body.String())
+	}
+	if gotAuth != "Apikey "+bobTestKey {
+		t.Errorf("backend saw Authorization %q, want the saved key with the Apikey scheme", gotAuth)
+	}
+	if strings.Contains(rec.Body.String(), bobTestKey) || strings.Contains(logBuf.String(), bobTestKey) {
+		t.Error("saved-key test leaked key material")
+	}
+}
+
+// No pasted key and no saved key is a distinct, actionable verdict — not a
+// backend round-trip.
+func TestBobKeyTest_NoKeyConfigured(t *testing.T) {
+	isolateBobKeySources(t)
+	// Any backend hit here is a bug: there is no key to test with.
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("probe reached the backend without a key")
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, _ := newBobProbeServer(t)
+	rec, out := postBobKeyTest(t, s, `{}`)
+	if out["status"] != "error" || out["reason"] != bobTestReasonNoKey {
+		t.Fatalf("verdict = %v/%v, want error/no_key (body: %s)", out["status"], out["reason"], rec.Body.String())
+	}
+	_ = rec
+}
+
+// Guardrails: oversized pasted keys and malformed bodies are rejected before
+// any network I/O; an absent body behaves like {} (saved-key mode).
+func TestBobKeyTest_BadRequests(t *testing.T) {
+	isolateBobKeySources(t)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("rejected request must not reach the backend")
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, _ := newBobProbeServer(t)
+
+	rec, _ := postBobKeyTest(t, s, `{"apiKey":"`+strings.Repeat("x", bobKeyMaxLen+1)+`"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("oversized key: status = %d, want 400", rec.Code)
+	}
+
+	rec, _ = postBobKeyTest(t, s, `not json`)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("malformed body: status = %d, want 400", rec.Code)
+	}
+
+	// Absent body == saved-key mode; with no key saved that is the no_key
+	// verdict, not a 400.
+	req := httptest.NewRequest(http.MethodPost, "/api/config/governor/bob/test", nil)
+	recNil := httptest.NewRecorder()
+	s.handleGovernorBobKeyTest(recNil, req)
+	if recNil.Code != http.StatusOK || !strings.Contains(recNil.Body.String(), bobTestReasonNoKey) {
+		t.Errorf("absent body: status = %d body = %s, want 200/no_key", recNil.Code, recNil.Body.String())
+	}
+}
+
+// The backend's "invalid jwt string" 401 is DECODED, not just surfaced: it
+// means the key's delivery was broken (scheme/newline/perms), not that the
+// key is bad, and the detail must say so.
+func TestBobKeyTest_JWTVerdictDecoded(t *testing.T) {
+	isolateBobKeySources(t)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"unauthorized","message":"Token verification failed: invalid jwt string"}`))
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, _ := newBobProbeServer(t)
+	rec, out := postBobKeyTest(t, s, `{"apiKey":"`+bobTestKey+`"}`)
+	if out["reason"] != bobTestReasonUnauthorized {
+		t.Fatalf("reason = %v, want unauthorized (body: %s)", out["reason"], rec.Body.String())
+	}
+	detail, _ := out["detail"].(string)
+	for _, want := range []string{"invalid jwt string", "stray newline", "agent UID"} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("detail %q missing decoded explanation fragment %q", detail, want)
+		}
+	}
+}
+
+// A 402 is a valid credential with no inference entitlement — its own reason
+// with the create-a-scoped-key fix in the detail.
+func TestBobKeyTest_EntitlementFailureDecoded(t *testing.T) {
+	isolateBobKeySources(t)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusPaymentRequired)
+		w.Write([]byte(`{"type":"insufficient_quota_or_plan_expired","message":"team user not found"}`))
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, _ := newBobProbeServer(t)
+	rec, out := postBobKeyTest(t, s, `{"apiKey":"`+bobTestKey+`"}`)
+	if out["reason"] != bobTestReasonNoEntitlement {
+		t.Fatalf("reason = %v, want no_entitlement (body: %s)", out["reason"], rec.Body.String())
+	}
+	detail, _ := out["detail"].(string)
+	for _, want := range []string{"Scope: Inference", "bob.ibm.com/admin/apikeys", "team user not found"} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("detail %q missing %q", detail, want)
+		}
+	}
+}
+
+// A Cloudflare-style HTML 403 is a network/edge block, not a key verdict —
+// it must classify as unreachable, never unauthorized.
+func TestBobKeyTest_EdgeHTML403IsNotAKeyVerdict(t *testing.T) {
+	isolateBobKeySources(t)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`<!DOCTYPE html><html><body>Access denied | cloudflare</body></html>`))
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, _ := newBobProbeServer(t)
+	rec, out := postBobKeyTest(t, s, `{"apiKey":"`+bobTestKey+`"}`)
+	if out["reason"] != bobTestReasonUnreachable {
+		t.Fatalf("reason = %v, want unreachable for an HTML edge 403 (body: %s)", out["reason"], rec.Body.String())
+	}
+	detail, _ := out["detail"].(string)
+	if !strings.Contains(detail, "network edge") {
+		t.Errorf("detail %q does not explain the edge block", detail)
+	}
+}
+
+// Interior whitespace in a pasted key is refused with the real explanation
+// before any network I/O — a broken paste is a proven 401.
+func TestBobKeyTest_InteriorWhitespaceRefused(t *testing.T) {
+	isolateBobKeySources(t)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("a malformed key must not reach the backend")
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, _ := newBobProbeServer(t)
+	rec, out := postBobKeyTest(t, s, `{"apiKey":"bob_prod_abc\ndef"}`)
+	if out["reason"] != bobTestReasonBadKeyFormat {
+		t.Fatalf("reason = %v, want bad_key_format (body: %s)", out["reason"], rec.Body.String())
+	}
+	detail, _ := out["detail"].(string)
+	if !strings.Contains(detail, "single unbroken token") {
+		t.Errorf("detail %q missing the re-copy guidance", detail)
+	}
+}
+
+// The SAVE handler refuses interior whitespace too — storing a broken paste
+// recreates the exact crash-loop the test feature exists to prevent.
+func TestHandleGovernorBobKey_InteriorWhitespaceRefused(t *testing.T) {
+	path := isolateBobKeySources(t)
+	s, _ := newBobProbeServer(t)
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/bob",
+		strings.NewReader(`{"apiKey":"bob_prod_abc def"}`))
+	rec := httptest.NewRecorder()
+	s.handleGovernorBobKey(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Error("broken key was persisted")
+	}
+}
+
+// A JWT-shaped credential keeps the Bearer scheme.
+func TestBobAuthHeaderValue_SchemeByKeyShape(t *testing.T) {
+	jwt := "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJib2IifQ.c2ln"
+	if got := bobAuthHeaderValue(jwt); got != "Bearer "+jwt {
+		t.Errorf("JWT-shaped key: got %q, want Bearer scheme", got)
+	}
+	if got := bobAuthHeaderValue("bob_prod_opaque123"); got != "Apikey bob_prod_opaque123" {
+		t.Errorf("opaque key: got %q, want Apikey scheme", got)
+	}
+}
+
+// Non-auth backend failures (e.g. a 500) map to bad_status and still surface
+// the backend's message.
+func TestBobKeyTest_BadStatusSurfacesBackendMessage(t *testing.T) {
+	isolateBobKeySources(t)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("bob backend melted"))
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, _ := newBobProbeServer(t)
+	rec, out := postBobKeyTest(t, s, `{"apiKey":"`+bobTestKey+`"}`)
+	if out["reason"] != bobTestReasonBadStatus {
+		t.Fatalf("reason = %v, want bad_status (body: %s)", out["reason"], rec.Body.String())
+	}
+	detail, _ := out["detail"].(string)
+	if !strings.Contains(detail, "HTTP 500") || !strings.Contains(detail, "bob backend melted") {
+		t.Errorf("detail %q missing status or backend message", detail)
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -11923,9 +11923,12 @@ function burnAreaChart() {
       dismissToast(toast, `${agent} restart counter reset`, 'success');
     }
 
-    // Prompts for the LiteLLM endpoint + API key the first time the
-    // backend is selected anywhere in the UI. Resolves true when litellm
-    // is (or has just been) configured; false when the user cancels. The
+    // Prompts for the LiteLLM endpoint + API key when litellm is picked in
+    // the agent-config dialog flows (CLI pin / create), where navigating to
+    // Governor Config would discard unsaved edits. The agent-card METHOD
+    // dropdown instead saves the choice and navigates (maybeOpenMethodConfig).
+    // Resolves true when litellm is (or has just been) configured; false when
+    // the user cancels. The
     // key VALUE goes to the server's private key store — never hive.yaml —
     // and the save runs a live /v1/models test whose result is shown
     // inline (endpoint/key mistakes fail here, not as agent 401s later).
@@ -12031,15 +12034,63 @@ function burnAreaChart() {
       });
     }
 
+
+    // Methods that need hive-side configuration before they can actually run:
+    // bob needs its API key (Governor Config → Bob); the gateway-backed
+    // methods need a Model Gateway configured FOR THAT method (Governor
+    // Config → Model Gateways). The check is per-method — an openrouter
+    // gateway does not satisfy a vllm selection.
+    const GATEWAY_METHODS = ['openrouter', 'litellm', 'vllm', 'llm-d'];
+
+    // maybeOpenMethodConfig runs AFTER a method switch is saved: the choice is
+    // never blocked, but when the selected method's backing config is absent
+    // the Governor Configuration dialog opens directly on the tab that fixes
+    // it. Presence comes from data the dashboard already serves — the bob key
+    // status endpoint (presence only, never material) and the configured
+    // gateway list — plus the live model-discovery cache (a non-fallback
+    // discovery proves an env-configured vllm/llm-d endpoint exists even
+    // without a named gateway). Best-effort: any fetch failure just skips the
+    // navigation rather than interrupting the switch.
+    async function maybeOpenMethodConfig(backend) {
+      try {
+        if (backend === 'bob') {
+          const r = await fetch('/api/config/governor/bob');
+          if (!r.ok) return;
+          const d = await r.json();
+          if (d.configured !== true) {
+            showToast('bob needs an API key — opening Governor Config → Bob', 'info');
+            openConfigDialog('governor', null, GOVERNOR_BOB_TAB);
+          }
+          return;
+        }
+        if (!GATEWAY_METHODS.includes(backend)) return;
+        // A live (non-fallback) model discovery for this method means it is
+        // genuinely configured (possibly via HIVE_*_ENDPOINT env, which never
+        // appears in the gateway list) — nothing to fix.
+        const cached = _inferenceModelCache[backend];
+        if (cached && !cached.fallback) return;
+        const r = await fetch('/api/config/governor/gateways');
+        if (!r.ok) return;
+        const d = await r.json();
+        const has = (d.gateways || []).some(g => g && (g.kind === backend || g.name === backend));
+        if (!has) {
+          showToast('No ' + backend + ' gateway configured — opening Governor Config → Model Gateways', 'info');
+          openConfigDialog('governor', null, 'Model Gateways');
+        }
+      } catch (e) { /* presence check is best-effort; never surface as a switch error */ }
+    }
+
     async function switchCli(agent, backend) {
       if (!backend) return;
-      if (backend === 'litellm' && !(await ensureLiteLLMConfigured())) return;
       const label = INFERENCE_BACKENDS.includes(backend) ? 'method' : 'CLI';
       const toast = showToast(`Switching ${agent} ${label} → ${backend} (restarting session)...`, 'info', true);
       const res = await fetch(`/api/switch/${agent}/${backend}`, { method: 'POST' });
       const data = await res.json();
       if (!data.ok) { dismissToast(toast, `Switch failed: ${data.error || 'unknown'}`, 'error'); return; }
       dismissToast(toast, `${agent} ${label} → ${backend} (session restarted)`, 'success');
+      // The selection is saved; if its backing config is missing, land the
+      // user on the Governor Config tab that fixes it (never blocks).
+      maybeOpenMethodConfig(backend);
       await updateModelDropdown(agent, backend);
       if (window._lastAgents) {
         const a = window._lastAgents.find(x => x.name === agent);
@@ -13790,6 +13841,7 @@ function burnAreaChart() {
             <span style="font-weight:600;font-size:0.9rem">bob</span>
             <span style="font-size:0.68rem;font-weight:600;padding:2px 8px;border-radius:10px;border:1px solid #4589ff;color:#4589ff">IBM bobshell</span>
             <span style="flex:1"></span>
+            ${configured ? '<button data-action="bobKeyTest" title="Validate the saved key against the bob backend — the key value never leaves this hive" style="padding:4px 12px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);cursor:pointer;font-size:0.74rem">Test</button>' : ''}
             ${configured ? '<button data-action="bobKeyClear" style="padding:4px 12px;border:1px solid var(--red);border-radius:6px;background:var(--bg);color:var(--red);cursor:pointer;font-size:0.74rem">Clear key</button>' : ''}
             <button data-action="bobKeySet" style="padding:4px 12px;border:none;border-radius:6px;background:#0f62fe;color:#fff;cursor:pointer;font-size:0.74rem;font-weight:600">${configured ? 'Replace key' : 'Set API key'}</button>
           </div>
@@ -13812,6 +13864,18 @@ function burnAreaChart() {
       if (setBtn) setBtn.addEventListener('click', () => openBobKeyDialog(configured, source));
       const clearBtn = host.querySelector('[data-action="bobKeyClear"]');
       if (clearBtn) clearBtn.addEventListener('click', clearBobKey);
+      // Test the SAVED key from the card: result goes to the card's inline
+      // status line (green ok / red reason + backend detail).
+      const testBtn = host.querySelector('[data-action="bobKeyTest"]');
+      if (testBtn) testBtn.addEventListener('click', async () => {
+        const statusEl = document.getElementById('bob-key-inline-status');
+        const setStatus = (msg, color) => {
+          if (statusEl) { statusEl.textContent = msg; statusEl.style.color = color || 'var(--muted)'; }
+        };
+        testBtn.disabled = true;
+        await testBobKey('', setStatus);
+        testBtn.disabled = false;
+      });
     }
 
     function renderGovAccess() {
@@ -17733,8 +17797,34 @@ function burnAreaChart() {
     // authoritative one for this CLI, so the dialog says Inference and links
     // BOTH pages so the operator can check if a key is rejected.
     var BOB_PORTAL_URL = 'https://bob.ibm.com';
+    var BOB_API_KEY_MANAGE_URL = 'https://bob.ibm.com/admin/apikeys';
     var BOB_API_KEY_DOCS_URL = 'https://bob.ibm.com/docs/ide/account/api-keys';
     var BOB_SHELL_SETUP_DOCS_URL = 'https://bob.ibm.com/docs/shell/getting-started/install-and-setup';
+
+    // testBobKey POSTs to the bob key-test endpoint and reports the verdict
+    // via setStatus. `pastedKey` non-empty tests THAT key (pre-save); empty
+    // tests the SAVED key — the server resolves it, the value never reaches
+    // the browser. Shared by the key dialog and the Bob tab card.
+    async function testBobKey(pastedKey, setStatus) {
+      setStatus(pastedKey ? 'Testing pasted key…' : 'Testing saved key…');
+      try {
+        var resp = await fetch('/api/config/governor/bob/test', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(pastedKey ? { apiKey: pastedKey } : {})
+        });
+        var data = await resp.json().catch(function() { return {}; });
+        if (!resp.ok) {
+          setStatus(data.error || ('Test failed (HTTP ' + resp.status + ')'), 'var(--red)');
+        } else if (data.status === 'ok') {
+          setStatus('✓ ' + (data.detail || 'The bob backend accepted the key.'), 'var(--green)');
+        } else {
+          setStatus('✗ ' + (data.detail || data.reason || 'Test failed'), 'var(--red)');
+        }
+      } catch (e) {
+        setStatus('Test failed: ' + e.message, 'var(--red)');
+      }
+    }
 
     function openBobKeyDialog(configured, source) {
       var overlay = document.getElementById('bob-key-overlay');
@@ -17762,7 +17852,8 @@ function burnAreaChart() {
           '<ol style="margin:0;padding-left:18px;line-height:1.6">' +
             '<li>Sign in at <a href="' + BOB_PORTAL_URL + '" target="_blank" rel="noopener noreferrer" ' +
               'style="color:#4589ff">bob.ibm.com</a> and open your subscription instance.</li>' +
-            '<li>Go to API key management and create a key with <strong>Scope: Inference</strong>.</li>' +
+            '<li>Go to <a href="' + BOB_API_KEY_MANAGE_URL + '" target="_blank" rel="noopener noreferrer" ' +
+              'style="color:#4589ff">API key management</a> and create a key with <strong>Scope: Inference</strong>.</li>' +
             '<li>Copy it immediately — IBM shows the value only once.</li>' +
           '</ol>' +
           '<div style="margin-top:8px">' +
@@ -17779,6 +17870,9 @@ function burnAreaChart() {
         '<div id="bob-key-status" style="color:var(--muted);font-size:0.8rem;min-height:20px;margin:4px 0"></div>' +
         '<div style="display:flex;gap:8px;justify-content:flex-end;margin-top:8px">' +
           '<button id="bob-key-cancel" class="gh-cancel" style="margin-top:0">Cancel</button>' +
+          '<button id="bob-key-test" style="background:var(--bg);color:var(--fg);border:1px solid var(--border);' +
+            'padding:6px 16px;border-radius:6px;font-weight:600;cursor:pointer" ' +
+            'title="Validate against the bob backend without saving: tests the pasted key if the field is non-empty, else the saved key">Test key</button>' +
           '<button id="bob-key-save" style="background:#0f62fe;color:#fff;border:none;padding:6px 16px;' +
             'border-radius:6px;font-weight:600;cursor:pointer">Save key</button>' +
         '</div>' +
@@ -17801,6 +17895,21 @@ function burnAreaChart() {
 
       var cancelBtn = document.getElementById('bob-key-cancel');
       if (cancelBtn) cancelBtn.addEventListener('click', closeDialog);
+
+      // Test key: pre-save validation of the pasted value, or of the saved
+      // key when the field is empty. The pasted value goes only to the test
+      // endpoint (never persisted); the result renders inline.
+      var testBtn = document.getElementById('bob-key-test');
+      if (testBtn) testBtn.addEventListener('click', async function() {
+        var pasted = (input && input.value || '').trim();
+        if (!pasted && !configured) {
+          setStatus('Paste a key to test — none is saved yet.', 'var(--red)');
+          return;
+        }
+        testBtn.disabled = true;
+        await testBobKey(pasted, setStatus);
+        testBtn.disabled = false;
+      });
 
       var saveBtn = document.getElementById('bob-key-save');
       if (saveBtn) saveBtn.addEventListener('click', async function() {


### PR DESCRIPTION
## What

### Test key for the bob backend
- New `POST /api/config/governor/bob/test`: live validation of a bob API key against the backend — `GET /inference/v1/model/info` on `https://api.us-east.bob.ibm.com` (env-overridable via `HIVE_BOB_API_URL`), bounded by a 10s timeout.
- A body carrying `apiKey` tests THAT key pre-save — never persisted, never logged, never echoed. An empty body tests the SAVED key via the same `BobConfig.ResolveAPIKey` the agents use, so key material never leaves the process.
- Wire conventions confirmed live: opaque `bob_prod_` keys use `Authorization: Apikey <key>` (Bearer only for JWT-shaped credentials), skipping bobshell's Bearer-then-flip dance.
- Verdicts decode the backend's real failure modes with the backend's own words in the detail (always key-free — redacted even when the backend echoes the key back):
  - 401 `invalid jwt string` → broken key DELIVERY (stray newline/truncation, or unreadable key file perms), not necessarily a bad key
  - 402 `insufficient_quota_or_plan_expired` → valid credential, no inference entitlement; points at creating a Scope: Inference key
  - HTML edge/CDN 403 → classified unreachable, not a key verdict
  - plus unauthorized / unreachable / timeout / bad_status / no_key / bad_key_format
- Pasted keys with interior whitespace are refused at test AND save time — a broken paste is a proven auth crash-loop.
- Same session auth + read-only write-gate as every other `/api/config` route (POST, so roleEnforcement rejects read-only roles).

### UI
- **Test key** button in the bob API key dialog (tests the pasted value if non-empty, else the saved key) with inline green/red result text.
- **Test** affordance on the Bob tab's key card for the saved key.
- Step 2 of "How to get a key" now links directly to the key-management page.

### Open Governor Config on method selection
Selecting a method from an agent's METHOD dropdown whose backing config is absent now lands the user on the fix — the selection is saved first, never blocked:
- `bob` + no API key → Governor Config → **Bob**
- `openrouter` / `litellm` / `vllm` / `llm-d` with no gateway configured **for that method** → Governor Config → **Model Gateways** (per-method check; a live non-fallback model discovery also counts as configured, covering env-configured vllm/llm-d endpoints)

The agent-config dialog flows (CLI pin / create) keep the existing inline LiteLLM prompt, since navigating away there would discard unsaved edits.

## Tests
- httptest bob backend drives the handler: pasted-key 200→ok (asserting the Apikey scheme and probe path on the wire), 401→unauthorized with decoded jwt-verdict, 402→no_entitlement, HTML 403→unreachable, conn-refused→unreachable, saved-key mode reads the key file, no-key verdict, interior-whitespace refusal (test + save), oversized/malformed bodies.
- Leak assertions capture the server's logger output and scan response bodies — the key never appears in either, even when the backend echoes it.
- Mutation-verified: forcing the endpoint to always return ok fails 6 tests; leaking the key into the detail fails the no-key-material test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)