### PR TITLE
🐛 dashboard: make the Copilot device-flow poller cancellable (fixes v2 race on 5f01184)

### DIFF
--- a/v2/pkg/dashboard/copilot_auth.go
+++ b/v2/pkg/dashboard/copilot_auth.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -54,6 +55,13 @@ type copilotAuthFlow struct {
 	mu        sync.Mutex
 	polling   bool
 	lastError string
+
+	// cancel stops the active poll goroutine; nil when none is running.
+	cancel context.CancelFunc
+	// done is closed when the active poll goroutine exits, letting
+	// stopCopilotPoll join it so a stale poller can never race a newer
+	// flow (or, in tests, outlive its test).
+	done chan struct{}
 }
 
 // registerCopilotAuthRoutes wires up the Copilot device-flow API endpoints.
@@ -137,17 +145,23 @@ func (s *Server) handleCopilotAuthStart(w http.ResponseWriter, r *http.Request) 
 		expiry = time.Duration(dc.ExpiresIn) * time.Second
 	}
 
+	// A prior poll goroutine may still be running against a stale device
+	// code; cancel it and wait for it to exit so it can never clobber the
+	// new flow's state or token file.
+	s.stopCopilotPoll()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
 	s.copilotAuthFlow.mu.Lock()
-	alreadyPolling := s.copilotAuthFlow.polling
 	s.copilotAuthFlow.polling = true
 	s.copilotAuthFlow.lastError = ""
+	s.copilotAuthFlow.cancel = cancel
+	s.copilotAuthFlow.done = done
 	s.copilotAuthFlow.mu.Unlock()
-
-	// A prior poll goroutine may still be running against a stale device
-	// code; it will fail with expired_token and exit on its own. Always
-	// poll for the newest code.
-	_ = alreadyPolling
-	go s.pollCopilotToken(dc.DeviceCode, interval, expiry)
+	go func() {
+		defer close(done)
+		s.pollCopilotToken(ctx, dc.DeviceCode, interval, expiry)
+	}()
 
 	s.auditFromRequest(r, "copilot_auth_start", "", "")
 	jsonResponse(w, map[string]interface{}{
@@ -157,9 +171,31 @@ func (s *Server) handleCopilotAuthStart(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
+// stopCopilotPoll cancels any in-flight poll goroutine and waits for it to
+// exit. Safe to call when no poll is running.
+func (s *Server) stopCopilotPoll() {
+	s.copilotAuthFlow.mu.Lock()
+	cancel := s.copilotAuthFlow.cancel
+	done := s.copilotAuthFlow.done
+	s.copilotAuthFlow.cancel = nil
+	s.copilotAuthFlow.done = nil
+	s.copilotAuthFlow.mu.Unlock()
+	if cancel == nil {
+		return
+	}
+	cancel()
+	<-done
+	// A canceled poller returns without touching flow state (its owner is
+	// the one transitioning it); mark the flow idle on its behalf.
+	s.copilotAuthFlow.mu.Lock()
+	s.copilotAuthFlow.polling = false
+	s.copilotAuthFlow.mu.Unlock()
+}
+
 // pollCopilotToken polls GitHub's access token endpoint until the user
-// approves the device code, it expires, or access is denied.
-func (s *Server) pollCopilotToken(deviceCode string, intervalSec int, expiry time.Duration) {
+// approves the device code, it expires, is superseded (ctx canceled), or
+// access is denied.
+func (s *Server) pollCopilotToken(ctx context.Context, deviceCode string, intervalSec int, expiry time.Duration) {
 	deadline := time.Now().Add(expiry)
 	client := &http.Client{Timeout: copilotHTTPTimeout}
 
@@ -171,9 +207,16 @@ func (s *Server) pollCopilotToken(deviceCode string, intervalSec int, expiry tim
 	}
 
 	for time.Now().Before(deadline) {
-		time.Sleep(time.Duration(intervalSec) * time.Second)
+		timer := time.NewTimer(time.Duration(intervalSec) * time.Second)
+		select {
+		case <-ctx.Done():
+			// Superseded or shut down — leave flow state to the canceler.
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
 
-		req, err := http.NewRequest(http.MethodPost, copilotAccessTokenURL,
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, copilotAccessTokenURL,
 			strings.NewReader(url.Values{
 				"client_id":   {copilotClientID},
 				"device_code": {deviceCode},
@@ -188,6 +231,10 @@ func (s *Server) pollCopilotToken(deviceCode string, intervalSec int, expiry tim
 
 		resp, err := client.Do(req)
 		if err != nil {
+			if ctx.Err() != nil {
+				// Canceled mid-request — leave flow state to the canceler.
+				return
+			}
 			// Transient network error — keep polling.
 			continue
 		}

--- a/v2/pkg/dashboard/copilot_auth_test.go
+++ b/v2/pkg/dashboard/copilot_auth_test.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -160,6 +161,10 @@ func TestCopilotAuthStart_ReturnsDeviceCode(t *testing.T) {
 
 	s := NewServer(0, covBLogger())
 	s.RegisterAPI(testDeps(t))
+	// The handler spawns a poll goroutine that reads the package-level
+	// endpoint/path vars; join it before the withCopilot* cleanups restore
+	// them, or it races the restores (and later tests' mocks).
+	t.Cleanup(s.stopCopilotPoll)
 
 	rec := doPost(s, "/api/copilot-auth/start", map[string]interface{}{})
 	if rec.Code != http.StatusOK {
@@ -231,7 +236,7 @@ func TestPollCopilotToken_SucceedsAndSavesToken(t *testing.T) {
 	// does not sleep for real GitHub-scale intervals.
 	done := make(chan struct{})
 	go func() {
-		s.pollCopilotToken("dev-code-1", 0, 2*time.Second)
+		s.pollCopilotToken(context.Background(), "dev-code-1", 0, 2*time.Second)
 		close(done)
 	}()
 
@@ -275,7 +280,7 @@ func TestPollCopilotToken_RetriesOnPendingThenSucceeds(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		s.pollCopilotToken("dev-code-2", 0, 5*time.Second)
+		s.pollCopilotToken(context.Background(), "dev-code-2", 0, 5*time.Second)
 		close(done)
 	}()
 
@@ -317,7 +322,7 @@ func TestPollCopilotToken_SlowDownBumpsInterval(t *testing.T) {
 		// its expiry deadline only at the top of each loop iteration (after
 		// the sleep), so with a 6s expiry the bumped 5s sleep still fits
 		// inside the deadline and the second (successful) poll fires.
-		s.pollCopilotToken("dev-code-3", 0, 6*time.Second)
+		s.pollCopilotToken(context.Background(), "dev-code-3", 0, 6*time.Second)
 		close(done)
 	}()
 
@@ -360,7 +365,7 @@ func TestPollCopilotToken_ExpiresWithoutSuccess(t *testing.T) {
 	start := time.Now()
 	done := make(chan struct{})
 	go func() {
-		s.pollCopilotToken("dev-code-4", 0, 300*time.Millisecond)
+		s.pollCopilotToken(context.Background(), "dev-code-4", 0, 300*time.Millisecond)
 		close(done)
 	}()
 
@@ -398,7 +403,7 @@ func TestPollCopilotToken_AccessDeniedStopsImmediately(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		s.pollCopilotToken("dev-code-5", 0, 10*time.Second)
+		s.pollCopilotToken(context.Background(), "dev-code-5", 0, 10*time.Second)
 		close(done)
 	}()
 
@@ -515,4 +520,75 @@ func TestCopilotAuthLogout_NoFileIsNoop(t *testing.T) {
 	if got["status"] != "logged_out" {
 		t.Fatalf("status = %v, want logged_out", got["status"])
 	}
+}
+
+func TestPollCopilotToken_CancelStopsPromptly(t *testing.T) {
+	withCopilotTokenPath(t)
+	mock := newCopilotDeviceMock(t, "dev-code-6", 900, 0,
+		map[string]any{"error": "authorization_pending"},
+	)
+	withCopilotMockURLs(t, mock.srv.URL)
+
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	// interval 5s: without cancellation the poller would sit in its sleep
+	// for the full interval (and keep polling for the whole 10m expiry).
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.pollCopilotToken(ctx, "dev-code-6", 5, 10*time.Minute)
+		close(done)
+	}()
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("pollCopilotToken did not stop promptly after cancel")
+	}
+}
+
+func TestStopCopilotPoll_JoinsHandlerSpawnedPoller(t *testing.T) {
+	withCopilotTokenPath(t)
+	mock := newCopilotDeviceMock(t, "dev-code-7", 900, 5,
+		map[string]any{"error": "authorization_pending"},
+	)
+	withCopilotMockURLs(t, mock.srv.URL)
+
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	rec := doPost(s, "/api/copilot-auth/start", map[string]interface{}{})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// stopCopilotPoll must cancel the goroutine the handler spawned, wait
+	// for it to exit, and leave the flow idle — promptly, not after the
+	// poller's 5s interval or 900s expiry.
+	joined := make(chan struct{})
+	go func() {
+		s.stopCopilotPoll()
+		close(joined)
+	}()
+	select {
+	case <-joined:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("stopCopilotPoll did not join the poll goroutine promptly")
+	}
+
+	s.copilotAuthFlow.mu.Lock()
+	polling := s.copilotAuthFlow.polling
+	cancelFn := s.copilotAuthFlow.cancel
+	s.copilotAuthFlow.mu.Unlock()
+	if polling {
+		t.Fatalf("polling = true after stopCopilotPoll, want false")
+	}
+	if cancelFn != nil {
+		t.Fatalf("cancel should be cleared after stopCopilotPoll")
+	}
+
+	// A second stop with no poller running must be a harmless no-op.
+	s.stopCopilotPoll()
 }


### PR DESCRIPTION
## Summary

The scheduled v2 test run on 5f01184 failed with a data race detected during `TestPollCopilotToken_SlowDownBumpsInterval` (pkg/dashboard). Reproduced on current `origin/v2` HEAD — not superseded by today's merges.

### Root cause
The poll goroutine spawned by `handleCopilotAuthStart` was unstoppable: a raw `time.Sleep` loop with no context and no join handle, alive for up to the 15-minute device-code expiry. `TestCopilotAuthStart_ReturnsDeviceCode` triggered one (interval 5s) and returned immediately; the leaked goroutine woke 5s later inside the slow-down test, read the package-level `copilotAccessTokenURL`/`copilotUserTokenPath` test seams while cleanups were restoring them (write at `copilot_auth_test.go:76` vs read at `copilot_auth.go:245`), and could even fetch the later test's mock token and write it through `saveCopilotToken`.

The same design was a real production wart: a stale poller from a previous login attempt could clobber the new flow's `polling`/`lastError` state (surfacing a bogus `expired_token` after a fresh start).

### Fix (deterministic, not a retry)
- `pollCopilotToken` now takes a `context.Context`; the interval wait is a timer+select and the token request uses `NewRequestWithContext`, so cancellation is prompt even mid-sleep. A canceled poller exits without touching flow state (the canceler owns the transition).
- `copilotAuthFlow` tracks the active poller's cancel func + done channel; new `stopCopilotPoll()` cancels and joins it.
- `handleCopilotAuthStart` stops any prior poller before starting a new one, so exactly one poller can ever be live.
- Tests join the handler-spawned poller via `t.Cleanup(s.stopCopilotPoll)` and two new tests pin the behavior (`TestPollCopilotToken_CancelStopsPromptly`, `TestStopCopilotPoll_JoinsHandlerSpawnedPoller`).

### Verification
- `go test ./pkg/dashboard/ -race -count=1` green (was failing with the race on HEAD before the fix).
- Mutation test: no-op'ing `stopCopilotPoll` reproduces the original race and fails `TestStopCopilotPoll_JoinsHandlerSpawnedPoller`.

Fixes #2464