### PR TITLE
🐛 hub: stop the zero-consumed tokens warning ambering unassigned placeholders

### DIFF
--- a/v2/pkg/hub/placeholder_health.go
+++ b/v2/pkg/hub/placeholder_health.go
@@ -12,8 +12,11 @@ package hub
 // hive's overall status is green.
 //
 // sanitizePlaceholderRows therefore rewrites each placeholder's spoke-reported
-// Health payload before it ships to the browser: failing auth-class checks are
-// reclassified as "skip" with placeholderAuthNote as their detail, and the
+// Health payload before it ships to the browser: checks whose non-passing
+// state IS the designed state of an unassigned slot — the auth-class family,
+// and the tokens check's zero-consumed warning (no project means no workload
+// to spend on); see placeholderDesignedCheckNote — are reclassified as "skip"
+// with a note saying why as their detail, and the
 // overall status / fails / warns are recomputed from the surviving checks
 // using the spoke's own thresholds. Genuine placeholder-applicable failures —
 // not ready, agents crash-looping, queue wedged — keep their status untouched
@@ -29,6 +32,33 @@ package hub
 // failure's error detail on an unassigned row, so the hover says WHY the check
 // is not evaluated instead of presenting a designed state as a fault.
 const placeholderAuthNote = "Unassigned — auth not configured by design"
+
+// healthCheckTokens is the spoke's token-consumption check (HealthSummary,
+// pkg/dashboard/server.go). It warns with "zero consumed" whenever the hive
+// has spent nothing — which on an unassigned pool slot is not a warning at
+// all: a slot with no project has no workload to spend tokens on.
+const healthCheckTokens = "tokens"
+
+// placeholderTokensNote replaces the tokens check's "zero consumed" warning
+// detail on an unassigned row, for the same reason as placeholderAuthNote.
+const placeholderTokensNote = "Unassigned — no workload by design"
+
+// placeholderDesignedCheckNote reports whether a named check's non-passing
+// state is the DESIGNED state of an unassigned pool slot, and if so returns
+// the hover note that replaces its error detail. Everything else returns ""
+// and keeps its reported status: ready, agents, stall_detection,
+// template_vars, kick_refusal and queue failures are genuine faults even on a
+// placeholder (it runs a real spoke process), and governor/contribute only
+// ever report pass.
+func placeholderDesignedCheckNote(name string) string {
+	switch {
+	case isAuthClassHealthCheck(name):
+		return placeholderAuthNote
+	case name == healthCheckTokens:
+		return placeholderTokensNote
+	}
+	return ""
+}
 
 const (
 	// healthCheckStatusSkip is the spoke's own not-applicable check status
@@ -68,9 +98,10 @@ func isFailingCheckStatus(st string) bool {
 }
 
 // sanitizePlaceholderRows rewrites the Health payload of every UNASSIGNED
-// placeholder row in the My Hives result so auth-class check failures — the
-// pool's designed state — no longer read as degradation, while every other
-// failure keeps its colour. Claimed hives pass through untouched. Called after
+// placeholder row in the My Hives result so designed-state check failures
+// (placeholderDesignedCheckNote: the auth-class family and the zero-consumed
+// tokens warning) no longer read as degradation, while every other failure
+// keeps its colour. Claimed hives pass through untouched. Called after
 // enrichFromSaaSMeta has run on every row (provStatus must be present, or a
 // placeholder that has not yet reported it would be misread as claimed by
 // everything downstream of the org-prefix fallback).
@@ -119,19 +150,20 @@ func placeholderSanitizedHealth(health map[string]any) map[string]any {
 		}
 		name, _ := ck["name"].(string)
 		st, _ := ck["status"].(string)
-		if isAuthClassHealthCheck(name) && isFailingCheckStatus(st) {
+		if note := placeholderDesignedCheckNote(name); note != "" && isFailingCheckStatus(st) {
 			neutralized++
 			replaced := make(map[string]any, len(ck)+1)
 			for k, val := range ck {
 				replaced[k] = val
 			}
 			replaced["status"] = healthCheckStatusSkip
-			replaced["detail"] = placeholderAuthNote
+			replaced["detail"] = note
 			outChecks = append(outChecks, replaced)
 			continue
 		}
-		// Non-auth checks keep their reported status and are what the row's
-		// recomputed overall status is derived from.
+		// Checks whose failure is genuine even on a placeholder keep their
+		// reported status and are what the recomputed overall status is
+		// derived from.
 		switch st {
 		case healthCheckStatusFail, healthCheckStatusCritical, healthCheckStatusError:
 			fails++

--- a/v2/pkg/hub/placeholder_health_test.go
+++ b/v2/pkg/hub/placeholder_health_test.go
@@ -180,6 +180,85 @@ func TestPlaceholderRowKeepsWarningFromRealCheck(t *testing.T) {
 	}
 }
 
+// Zero token consumption is the DESIGNED state of an unassigned pool slot —
+// no project means no workload to spend on — so the spoke's tokens check
+// warning ("zero consumed") must not amber the row: it is reclassified to
+// skip with the no-workload note and the row ships green.
+func TestPlaceholderRowGreenWhenTokensWarnZeroConsumed(t *testing.T) {
+	e := placeholderEntryWithHealth(map[string]any{
+		"status": "warning",
+		"fails":  0,
+		"warns":  1,
+		"checks": []any{
+			map[string]any{"name": "ready", "status": "pass"},
+			map[string]any{"name": healthCheckTokens, "status": "warn", "detail": "zero consumed"},
+		},
+	})
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	got := rows[0].Health
+
+	if st := healthStatusOf(got); st != healthStatusOK {
+		t.Fatalf("placeholder with only the zero-consumed tokens warning: status = %q, want %q", st, healthStatusOK)
+	}
+	if warns, _ := got["warns"].(int); warns != 0 {
+		t.Errorf("warns = %v, want 0 — the pill must not render", got["warns"])
+	}
+	st, detail := checkStatusByName(t, got, healthCheckTokens)
+	if st != healthCheckStatusSkip {
+		t.Errorf("tokens status = %q, want %q", st, healthCheckStatusSkip)
+	}
+	if detail != placeholderTokensNote {
+		t.Errorf("tokens detail = %q, want the no-workload note %q", detail, placeholderTokensNote)
+	}
+}
+
+// The SAME zero-consumed warning on a CLAIMED hive is a real signal (an
+// assigned project spending nothing is worth noticing) and must pass through
+// untouched.
+func TestClaimedRowKeepsTokensWarning(t *testing.T) {
+	e := MyHiveEntry{RegistryEntry: RegistryEntry{
+		ID:     "claimed-2",
+		Org:    "acme",
+		Online: true,
+		Health: map[string]any{
+			"status": "warning",
+			"checks": []any{
+				map[string]any{"name": healthCheckTokens, "status": "warn", "detail": "zero consumed"},
+			},
+		},
+	}}
+	e.ProvStatus = "active"
+
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	got := rows[0].Health
+
+	if st := healthStatusOf(got); st != healthStatusWarning {
+		t.Fatalf("claimed hive status = %q, want %q — the tokens exemption must not leak", st, healthStatusWarning)
+	}
+	if st, detail := checkStatusByName(t, got, healthCheckTokens); st != healthCheckStatusWarn || detail != "zero consumed" {
+		t.Errorf("claimed hive tokens shipped as %q/%q, want warn/zero consumed untouched", st, detail)
+	}
+}
+
+// A tokens warning alongside a genuine failure: the tokens check is
+// neutralised but the real fault still owns the row colour.
+func TestPlaceholderTokensWarnDoesNotMaskRealFailure(t *testing.T) {
+	e := placeholderEntryWithHealth(map[string]any{
+		"status": "degraded",
+		"checks": []any{
+			map[string]any{"name": "ready", "status": "fail", "detail": "not ready"},
+			map[string]any{"name": healthCheckTokens, "status": "warn", "detail": "zero consumed"},
+		},
+	})
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	if st := healthStatusOf(rows[0].Health); st != healthStatusDegraded {
+		t.Fatalf("status = %q, want %q — neutralising tokens must not hide the not-ready fault", st, healthStatusDegraded)
+	}
+}
+
 // The sanitizer only touches Health: liveness signals (online, lastHeartbeat)
 // that drive the offline dot and the stale-heartbeat drift/alert rules must
 // pass through untouched, so a stale placeholder still reads as degraded.


### PR DESCRIPTION
## Problem

Follow-up to #2469, from the maintainer's live screenshot: unassigned placeholder rows still showed AMBER, with the status hover led by `tokens: zero consumed` (warn). Zero consumption is the **designed** state of an unassigned hive — no project means no workload to spend tokens on — the same reasoning that already exempts the auth-class checks.

## Fix

`placeholderDesignedCheckNote` (pkg/hub/placeholder_health.go) now names every check whose non-passing state is by-design on an unassigned slot:

- auth-class family (`github_auth`, `github_app*`) — unchanged from #2469, note "Unassigned — auth not configured by design"
- `tokens` zero-consumed warning — **new**, reclassified to `skip` with hover detail "Unassigned — no workload by design"

Status/fails/warns recomputed as before with the spoke's own HealthSummary thresholds. Claimed hives keep the warning untouched (an assigned project spending nothing is worth noticing).

## Checks considered and deliberately NOT exempted

Audited against the spoke's HealthSummary (pkg/dashboard/server.go):

- `ready` fail — the spoke is genuinely not serving, even on a pool slot
- `agents` fail (agents down) — a placeholder runs a real spoke with real agents; down is down
- `stall_detection` warn — only fires when a RUNNING agent has produced no output; genuine
- `template_vars` warn — raw ${VARS} in a kick is a real config fault
- `kick_refusal` warn — genuine
- `governor`, `contribute`, `queue` — only ever report `pass`, nothing to exempt

## Tests

- Placeholder with only the tokens warning ⇒ `ok`, warns 0, skip + no-workload note
- Claimed hive with the identical warning ⇒ stays `warning`, check untouched
- Tokens warning alongside `ready: fail` ⇒ row stays `degraded` (no masking)
- Mutation-checked: removing the tokens branch from `placeholderDesignedCheckNote` fails the green test

Full `go build ./...` and `go test ./pkg/hub/` green.