### PR TITLE
✨ spoke: Forge App tab — every App credential the hive holds, fingerprints only

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1819,6 +1819,26 @@ func main() {
 		},
 	})
 
+	// Forge App tab inventory: the resolved active key path and the per-app-id
+	// PVC keys live here in cmd/hive, so they are injected as a provider (the
+	// SetGitHubAppRecheckFn pattern). Fingerprints and paths only — the
+	// provider never touches key material.
+	dashSrv.SetForgeAppInventoryFn(func() dashboard.ForgeAppInventory {
+		held := heldPerAppIDKeyFingerprints()
+		keys := make([]dashboard.ForgeAppKey, 0, len(held))
+		for idStr, fp := range held {
+			keys = append(keys, dashboard.ForgeAppKey{
+				AppID:       idStr,
+				Path:        filepath.Join(spokeAppKeyDir, perAppIDKeyFilePrefix+idStr+perAppIDKeyFileSuffix),
+				Fingerprint: fp,
+			})
+		}
+		return dashboard.ForgeAppInventory{
+			ActiveKeyFile: resolveAppKeyFile(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), cfg.GitHub.AppID),
+			HeldKeys:      keys,
+		}
+	})
+
 	dashSrv.SetGitHubAppRequired(githubAppRequired)
 	// Order matters: SetGitHubAppRequired(false) clears both fields, so the
 	// classified state is applied only after it, and only when a failure was

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -141,6 +141,9 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	// and hands back the correct per-forge install URL when it is not.
 	s.mux.HandleFunc("POST /api/config/governor/repos/check-access", s.handleGovernorRepoCheckAccess)
 	s.mux.HandleFunc("PUT /api/config/github", s.handleConfigGitHub)
+	// Read-only inventory for the Forge App tab: every App credential this
+	// spoke holds (active config + per-app-id PVC keys), fingerprints only.
+	s.mux.HandleFunc("GET /api/config/github/forge-apps", s.handleConfigGitHubForgeApps)
 
 	s.mux.HandleFunc("GET /api/agents", s.handleAgentsList)
 	s.mux.HandleFunc("POST /api/agents", s.handleAgentCreate)

--- a/v2/pkg/dashboard/forge_apps.go
+++ b/v2/pkg/dashboard/forge_apps.go
@@ -1,0 +1,142 @@
+package dashboard
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// This file backs the spoke dashboard's "Forge App" tab: a read-only inventory
+// of every forge App credential the spoke holds, plus the single editable
+// active config. It NEVER returns or logs private key material — paths and
+// fingerprints only.
+
+// ForgeAppKey is one per-app-id private key held on the spoke's PVC
+// (/data/gh-app-key-<appid>.pem). Fingerprint and path only — the key material
+// itself must never leave the pod.
+type ForgeAppKey struct {
+	AppID       string `json:"app_id"`
+	Path        string `json:"path"`
+	Fingerprint string `json:"fingerprint"`
+}
+
+// ForgeAppInventory is what only cmd/hive can supply (the key resolution and
+// PVC scan live there): the key file the process would actually sign with, and
+// every per-app-id key on disk. Injected via SetForgeAppInventoryFn, following
+// the SetGitHubAppRecheckFn provider pattern, so pkg/dashboard never imports
+// cmd code.
+type ForgeAppInventory struct {
+	// ActiveKeyFile is the resolved path of the key the active config signs
+	// with ("" when none could be resolved).
+	ActiveKeyFile string
+	// HeldKeys lists every per-app-id key file on the PVC, fingerprints only.
+	HeldKeys []ForgeAppKey
+}
+
+// SetForgeAppInventoryFn registers the cmd/hive-side provider for the Forge
+// App tab. Called once at startup, before the HTTP server serves requests.
+func (s *Server) SetForgeAppInventoryFn(fn func() ForgeAppInventory) {
+	s.forgeAppInventoryFn = fn
+}
+
+// forgeActiveApp is the JSON shape of the active github config row.
+type forgeActiveApp struct {
+	AppID          int64  `json:"app_id"`
+	AppSlug        string `json:"app_slug"`
+	APIURL         string `json:"api_url"`
+	BaseURL        string `json:"base_url"`
+	InstallationID int64  `json:"installation_id"`
+	KeyFile        string `json:"key_file"`
+	KeyFingerprint string `json:"key_fingerprint"`
+	// AuthState is the classified github.AppAuthState wire token, verbatim
+	// ("not-installed", "wrong-installation", "key-invalid", ... or "" when
+	// no classification has run). This is a debugging surface — do not
+	// prettify it here.
+	AuthState string `json:"auth_state"`
+	Forge     string `json:"forge"`
+	Editable  bool   `json:"editable"`
+}
+
+type forgeAppsResponse struct {
+	Active forgeActiveApp `json:"active"`
+	// ReposForge is the forge host the spoke's configured repos live on,
+	// derived from the configured base/api URL host (empty = github.com).
+	ReposForge string        `json:"repos_forge"`
+	HeldKeys   []ForgeAppKey `json:"held_keys"`
+}
+
+// normalizeForgeAppHost canonicalizes a forge host for comparison: trimmed,
+// lowercased, and empty meaning public github.com — mirroring how the config
+// layer treats an absent base/api URL.
+func normalizeForgeAppHost(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return "github.com"
+	}
+	return host
+}
+
+// forgeAppEditable reports whether an App config whose forge is appForge may
+// be edited from this spoke's dashboard: ONLY when it matches the forge the
+// spoke's repos live on. Everything else is displayed read-only — editing a
+// credential for a forge this hive's repos do not use is never useful and is
+// exactly how the wrong key ends up active.
+func forgeAppEditable(appForge, reposForge string) bool {
+	return normalizeForgeAppHost(appForge) == normalizeForgeAppHost(reposForge)
+}
+
+// handleConfigGitHubForgeApps serves GET /api/config/github/forge-apps.
+func (s *Server) handleConfigGitHubForgeApps(w http.ResponseWriter, r *http.Request) {
+	if s.deps == nil || s.deps.Config == nil {
+		jsonError(w, "config not loaded", http.StatusServiceUnavailable)
+		return
+	}
+	g := s.deps.Config.GitHub
+
+	inv := ForgeAppInventory{}
+	if s.forgeAppInventoryFn != nil {
+		inv = s.forgeAppInventoryFn()
+	}
+
+	keyFile := inv.ActiveKeyFile
+	if keyFile == "" {
+		keyFile = g.KeyFile
+	}
+	fingerprint := ""
+	if keyFile != "" {
+		// A missing/unparseable key simply reports an empty fingerprint — the
+		// tab's job is to show what is there, not to fail on what is not.
+		if fp, err := config.AppKeyFingerprintFromFile(keyFile); err == nil {
+			fingerprint = fp
+		}
+	}
+
+	// The repos' forge comes from the configured base/api URL host (empty =
+	// github.com): HostLabel() is the single authority on that derivation.
+	// The App config's own forge honours an explicit `forge:` field first.
+	reposForge := normalizeForgeAppHost(g.HostLabel())
+	appForge := normalizeForgeAppHost(g.Forge())
+
+	held := append([]ForgeAppKey(nil), inv.HeldKeys...)
+	sort.Slice(held, func(i, j int) bool { return held[i].AppID < held[j].AppID })
+
+	resp := forgeAppsResponse{
+		Active: forgeActiveApp{
+			AppID:          g.AppID,
+			AppSlug:        g.ResolvedAppSlug(),
+			APIURL:         g.ResolvedAPIURL(),
+			BaseURL:        g.ResolvedBaseURL(),
+			InstallationID: g.InstallationID,
+			KeyFile:        keyFile,
+			KeyFingerprint: fingerprint,
+			AuthState:      s.GetGitHubAppState(),
+			Forge:          appForge,
+			Editable:       forgeAppEditable(appForge, reposForge),
+		},
+		ReposForge: reposForge,
+		HeldKeys:   held,
+	}
+	jsonResponse(w, resp)
+}

--- a/v2/pkg/dashboard/forge_apps_test.go
+++ b/v2/pkg/dashboard/forge_apps_test.go
@@ -1,0 +1,225 @@
+package dashboard
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// forgeTestKeyBits keeps test key generation fast; strength is irrelevant —
+// the key only has to be parseable for fingerprinting.
+const forgeTestKeyBits = 2048
+
+// writeForgeTestKey writes a parseable RSA private key PEM to dir and returns
+// its path and the PEM body (so tests can assert the material never appears in
+// a response).
+func writeForgeTestKey(t *testing.T, dir, name string) (string, string) {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, forgeTestKeyBits)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)})
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return path, string(pemBytes)
+}
+
+func getForgeApps(t *testing.T, s *Server) (*httptest.ResponseRecorder, map[string]any) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/config/github/forge-apps", nil)
+	s.mux.ServeHTTP(rec, req)
+	var body map[string]any
+	if rec.Code == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+	}
+	return rec, body
+}
+
+// TestForgeApps_ProviderInjected_FingerprintsNeverKeyMaterial feeds the
+// provider real key paths and asserts the response carries fingerprints and
+// paths ONLY — no fragment of the PEM may appear anywhere in the body.
+func TestForgeApps_ProviderInjected_FingerprintsNeverKeyMaterial(t *testing.T) {
+	srv := newFullServer(t)
+	dir := t.TempDir()
+	activePath, activePEM := writeForgeTestKey(t, dir, "gh-app-key.pem")
+	heldPath, heldPEM := writeForgeTestKey(t, dir, "gh-app-key-777.pem")
+	heldFP, err := config.AppKeyFingerprintFromFile(heldPath)
+	if err != nil || heldFP == "" {
+		t.Fatalf("fingerprint held key: %v", err)
+	}
+	activeFP, err := config.AppKeyFingerprintFromFile(activePath)
+	if err != nil || activeFP == "" {
+		t.Fatalf("fingerprint active key: %v", err)
+	}
+
+	srv.SetForgeAppInventoryFn(func() ForgeAppInventory {
+		return ForgeAppInventory{
+			ActiveKeyFile: activePath,
+			HeldKeys: []ForgeAppKey{
+				{AppID: "777", Path: heldPath, Fingerprint: heldFP},
+			},
+		}
+	})
+	srv.deps.Config.GitHub.AppID = 123456
+	srv.deps.Config.GitHub.InstallationID = 42980
+
+	rec, body := getForgeApps(t, srv)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+
+	raw := rec.Body.String()
+	// The load-bearing assertion: key MATERIAL is absent even though the
+	// provider was fed real key paths.
+	if strings.Contains(raw, "PRIVATE KEY") {
+		t.Fatalf("response contains PEM header — key material leaked: %s", raw)
+	}
+	for _, pemBody := range []string{activePEM, heldPEM} {
+		// Check a distinctive base64 chunk from the middle of the key too, in
+		// case a future edit strips headers but leaks the payload.
+		lines := strings.Split(strings.TrimSpace(pemBody), "\n")
+		if len(lines) > 2 {
+			if strings.Contains(raw, lines[len(lines)/2]) {
+				t.Fatalf("response contains key material payload")
+			}
+		}
+	}
+
+	active, _ := body["active"].(map[string]any)
+	if active == nil {
+		t.Fatalf("missing active in %s", raw)
+	}
+	if active["key_file"] != activePath {
+		t.Errorf("active key_file = %v, want %s", active["key_file"], activePath)
+	}
+	if active["key_fingerprint"] != activeFP {
+		t.Errorf("active key_fingerprint = %v, want %s", active["key_fingerprint"], activeFP)
+	}
+	held, _ := body["held_keys"].([]any)
+	if len(held) != 1 {
+		t.Fatalf("held_keys = %v, want 1 row", body["held_keys"])
+	}
+	row := held[0].(map[string]any)
+	if row["app_id"] != "777" || row["fingerprint"] != heldFP || row["path"] != heldPath {
+		t.Errorf("held key row = %v, want app 777 with fingerprint %s at %s", row, heldFP, heldPath)
+	}
+}
+
+// TestForgeApps_AuthStateVerbatim pins the classified wire token passing
+// through unprettified — it is the debugging surface.
+func TestForgeApps_AuthStateVerbatim(t *testing.T) {
+	srv := newFullServer(t)
+	srv.SetGitHubAppRequired(true)
+	srv.SetGitHubAppState("wrong-installation")
+
+	rec, body := getForgeApps(t, srv)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	active := body["active"].(map[string]any)
+	if active["auth_state"] != "wrong-installation" {
+		t.Errorf("auth_state = %v, want the wire token verbatim", active["auth_state"])
+	}
+}
+
+// TestForgeApps_EditableOnlyWhenForgeMatchesRepos drives the editable rule
+// through the endpoint: a config whose forge matches the repos' forge (from
+// the base/api URL host, empty = github.com) is editable; a config whose
+// explicit forge names a different host is not.
+func TestForgeApps_EditableOnlyWhenForgeMatchesRepos(t *testing.T) {
+	t.Run("default github.com config is editable", func(t *testing.T) {
+		srv := newFullServer(t)
+		rec, body := getForgeApps(t, srv)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d", rec.Code)
+		}
+		active := body["active"].(map[string]any)
+		if active["editable"] != true {
+			t.Errorf("editable = %v, want true — repos and App both resolve to github.com", active["editable"])
+		}
+		if body["repos_forge"] != "github.com" {
+			t.Errorf("repos_forge = %v, want github.com for empty URLs", body["repos_forge"])
+		}
+	})
+
+	t.Run("GHE config with GHE repos is editable", func(t *testing.T) {
+		srv := newFullServer(t)
+		srv.deps.Config.GitHub.APIURL = "https://github.ibm.com/api/v3"
+		rec, body := getForgeApps(t, srv)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d", rec.Code)
+		}
+		active := body["active"].(map[string]any)
+		if active["editable"] != true {
+			t.Errorf("editable = %v, want true — App forge and repos forge are both github.ibm.com", active["editable"])
+		}
+	})
+
+	t.Run("explicit forge differing from repos host is read-only", func(t *testing.T) {
+		srv := newFullServer(t)
+		// Repos live on github.com (empty URLs) but the config claims an App
+		// on a different forge: the one case that must NOT be editable.
+		srv.deps.Config.GitHub.Forge_ = "github.ibm.com"
+		rec, body := getForgeApps(t, srv)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d", rec.Code)
+		}
+		active := body["active"].(map[string]any)
+		if active["editable"] != false {
+			t.Errorf("editable = %v, want false — App forge github.ibm.com does not match repos forge github.com", active["editable"])
+		}
+	})
+}
+
+// TestForgeAppEditable is the unit truth table for the pure comparison.
+func TestForgeAppEditable(t *testing.T) {
+	cases := []struct {
+		name                 string
+		appForge, reposForge string
+		want                 bool
+	}{
+		{"both empty means github.com", "", "", true},
+		{"empty vs explicit github.com", "", "github.com", true},
+		{"case-insensitive match", "GitHub.com", "github.com", true},
+		{"GHE match", "github.ibm.com", "github.ibm.com", true},
+		{"GHE vs public mismatch", "github.ibm.com", "github.com", false},
+		{"public vs GHE mismatch", "", "github.ibm.com", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := forgeAppEditable(tc.appForge, tc.reposForge); got != tc.want {
+				t.Errorf("forgeAppEditable(%q, %q) = %v, want %v", tc.appForge, tc.reposForge, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestForgeApps_NoProvider proves the endpoint degrades gracefully when
+// cmd/hive has not injected an inventory (tests, early boot): config values
+// still serve, with no held keys.
+func TestForgeApps_NoProvider(t *testing.T) {
+	srv := newFullServer(t)
+	rec, body := getForgeApps(t, srv)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 without a provider", rec.Code)
+	}
+	if held, ok := body["held_keys"].([]any); ok && len(held) != 0 {
+		t.Errorf("held_keys = %v, want empty without a provider", held)
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -187,6 +187,12 @@ type Server struct {
 	hubBanner   *HubBannerState
 
 	githubAppRecheckFn func() bool
+
+	// forgeAppInventoryFn supplies the Forge App tab's key inventory from
+	// cmd/hive (resolved active key path + per-app-id PVC keys, fingerprints
+	// only). Set once at startup via SetForgeAppInventoryFn; nil in tests and
+	// early boot, which the handler tolerates.
+	forgeAppInventoryFn func() ForgeAppInventory
 }
 
 // StatusPayload matches the JSON contract the dashboard frontend render() expects.

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -13044,7 +13044,7 @@ function burnAreaChart() {
     // hub-synced user/role data. It sits next to Model Gateways because both
     // are backend configuration.
     const GOVERNOR_BOB_TAB = 'Bob';
-    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Hub', 'Model Gateways', GOVERNOR_BOB_TAB, 'Variables', 'Access'];
+    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Hub', 'Forge App', 'Model Gateways', GOVERNOR_BOB_TAB, 'Variables', 'Access'];
     const PIPELINE_STAGES = ['resolve-beads', 'track-prs', 'stale-check', 'repo-scan', 'coverage-gate', 'prompt-compose', 'budget-check', 'api-collect', 'final-compose'];
     const PIPELINE_STAGE_TIPS = {
       'resolve-beads': 'Fetch and inject knowledge beads (facts, patterns, gotchas) relevant to the agent\'s current task context.',
@@ -13503,6 +13503,9 @@ function burnAreaChart() {
         if (tabId === 'Model Gateways') {
           loadGateways();
         }
+        // The Forge App tab renders a shell synchronously, then loads the
+        // credential inventory (fingerprints only) from the spoke.
+        if (tabId === 'Forge App') loadForgeApps();
       }
       // Keep the Save button's enabled state in lockstep with the repos/default
       // invariant on every render (requirement #4). Cheap and idempotent — a
@@ -13640,6 +13643,7 @@ function burnAreaChart() {
         case 'Sensing': return renderGovSensing(d.sensing || {});
         case 'Logging': return renderGovLogging(d.logging || {});
         case 'Hub': return renderGovHub(d.hub || {});
+        case 'Forge App': return renderGovForgeApp();
         case 'Model Gateways': return renderGovGateways();
         case GOVERNOR_BOB_TAB: return renderGovBob();
         case 'Variables': return renderGovVariables();
@@ -14119,6 +14123,143 @@ function burnAreaChart() {
 
     function gatewayKindMeta(kind) {
       return GATEWAY_KIND_META[kind] || GATEWAY_KIND_META.custom;
+    }
+
+    // ---- Forge App tab -----------------------------------------------------
+    // Inventory of every forge App credential this spoke holds: the active
+    // github config plus every per-app-id key file on the PVC. Fingerprints
+    // and paths ONLY — private key material never reaches this page. Only the
+    // config whose forge matches the forge this hive's repos live on is
+    // editable; everything else renders read-only.
+    function renderGovForgeApp() {
+      return `
+        <div style="font-size:0.82rem;color:var(--muted);margin-bottom:14px">
+          Every forge App credential this hive holds. The active config is editable only
+          when its forge matches the forge this hive's repos live on; everything else is
+          read-only. Private keys appear as fingerprints — key material never leaves the hive.
+        </div>
+        <div id="forge-app-host"><div style="color:var(--muted);font-size:0.8rem">Loading forge Apps…</div></div>`;
+    }
+
+    async function loadForgeApps() {
+      const host = document.getElementById('forge-app-host');
+      try {
+        const res = await fetch('/api/config/github/forge-apps');
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        renderForgeApps(await res.json());
+      } catch (e) {
+        if (host) host.innerHTML = `<div style="color:var(--red);font-size:0.8rem">Failed to load forge Apps: ${esc(e.message)}</div>`;
+      }
+    }
+
+    function forgeAppRow(label, valueHtml) {
+      return `<div style="display:flex;gap:10px;font-size:0.78rem;padding:3px 0"><span style="min-width:140px;color:var(--muted);flex-shrink:0">${esc(label)}</span><span style="word-break:break-all">${valueHtml}</span></div>`;
+    }
+
+    function renderForgeApps(data) {
+      const host = document.getElementById('forge-app-host');
+      if (!host) return;
+      const a = data.active || {};
+      // The classified auth state is a debugging surface: show the wire token
+      // verbatim (not-installed / wrong-installation / key-invalid / ...).
+      const stateHtml = a.auth_state
+        ? `<code style="font-size:0.74rem;padding:1px 6px;border:1px solid ${a.auth_state === 'ok' ? 'var(--green)' : 'var(--yellow)'};border-radius:6px">${esc(a.auth_state)}</code>`
+        : '<span style="color:var(--muted)">— (not classified)</span>';
+      const editBadge = a.editable
+        ? '<span style="font-size:0.68rem;font-weight:600;padding:2px 8px;border-radius:10px;border:1px solid var(--green);color:var(--green)">editable</span>'
+        : `<span style="font-size:0.68rem;font-weight:600;padding:2px 8px;border-radius:10px;border:1px solid var(--border);color:var(--muted)">read-only — repos are on ${esc(data.repos_forge || 'github.com')}</span>`;
+      let html = `
+        <div style="border:1px solid var(--border);border-radius:8px;padding:12px 14px;margin-bottom:12px;background:var(--surface)">
+          <div style="display:flex;align-items:center;gap:10px;margin-bottom:8px;flex-wrap:wrap">
+            <span style="font-weight:600;font-size:0.9rem">Active config — ${esc(a.forge || 'github.com')}</span>
+            ${editBadge}
+          </div>
+          ${forgeAppRow('App ID', esc(String(a.app_id || 0)))}
+          ${forgeAppRow('App slug', esc(a.app_slug || '—'))}
+          ${forgeAppRow('API URL', esc(a.api_url || '—'))}
+          ${forgeAppRow('Base URL', esc(a.base_url || '—'))}
+          ${forgeAppRow('Installation ID', esc(String(a.installation_id || 0)))}
+          ${forgeAppRow('Key file', esc(a.key_file || '—'))}
+          ${forgeAppRow('Key fingerprint', a.key_fingerprint ? '<code style="font-size:0.74rem">' + esc(a.key_fingerprint) + '</code>' : '<span style="color:var(--muted)">— (no usable key)</span>')}
+          ${forgeAppRow('Auth state', stateHtml)}
+          ${a.editable ? forgeAppEditForm(a) : ''}
+        </div>`;
+      html += '<div style="font-weight:600;font-size:0.85rem;margin:14px 0 6px">Per-app-id keys on disk</div>';
+      const keys = data.held_keys || [];
+      if (!keys.length) {
+        html += '<div style="color:var(--muted);font-size:0.78rem">No per-app-id key files held on this hive.</div>';
+      } else {
+        html += keys.map(k => `
+          <div style="border:1px solid var(--border);border-radius:8px;padding:8px 12px;margin-bottom:6px;font-size:0.76rem;background:var(--surface)">
+            <div style="display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+              <span style="font-weight:600">App ${esc(k.app_id)}</span>
+              <span style="font-size:0.66rem;font-weight:600;padding:1px 7px;border-radius:10px;border:1px solid var(--border);color:var(--muted)">read-only</span>
+            </div>
+            <div style="color:var(--muted);word-break:break-all;margin-top:4px">${esc(k.path)}</div>
+            <div style="margin-top:2px">fingerprint: <code style="font-size:0.72rem">${esc(k.fingerprint)}</code></div>
+          </div>`).join('');
+      }
+      host.innerHTML = html;
+    }
+
+    function forgeAppEditForm(a) {
+      const inputStyle = 'width:100%;padding:6px 8px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem;box-sizing:border-box';
+      return `
+        <div style="border-top:1px solid var(--border);margin-top:10px;padding-top:10px">
+          <div style="font-size:0.78rem;font-weight:600;margin-bottom:8px">Edit active config</div>
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:8px">
+            <label style="font-size:0.72rem;color:var(--muted)">App ID<input id="forge-app-appid" type="number" value="${esc(String(a.app_id || ''))}" style="${inputStyle}"></label>
+            <label style="font-size:0.72rem;color:var(--muted)">Installation ID<input id="forge-app-instid" type="number" value="${esc(String(a.installation_id || ''))}" style="${inputStyle}"></label>
+          </div>
+          <label style="font-size:0.72rem;color:var(--muted)">Key file path<input id="forge-app-keyfile" type="text" value="${esc(a.key_file || '')}" style="${inputStyle};margin-bottom:8px"></label>
+          <label style="font-size:0.72rem;color:var(--muted)">Private key (PEM — write-only, replaces the key file; never displayed back)<textarea id="forge-app-pem" rows="3" placeholder="-----BEGIN RSA PRIVATE KEY----- (leave empty to keep the current key)" style="${inputStyle};font-family:monospace;margin-bottom:8px"></textarea></label>
+          <button id="forge-app-save-btn" onclick="saveForgeApp()" style="padding:7px 16px;border:none;border-radius:6px;background:var(--cyan);color:var(--bg);cursor:pointer;font-weight:600;font-size:0.8rem">Save</button>
+        </div>`;
+    }
+
+    async function saveForgeApp() {
+      const btn = document.getElementById('forge-app-save-btn');
+      const numVal = id => {
+        const el = document.getElementById(id);
+        const v = (el && el.value || '').trim();
+        return v === '' ? null : parseInt(v, 10);
+      };
+      const appId = numVal('forge-app-appid');
+      const instId = numVal('forge-app-instid');
+      const keyFileEl = document.getElementById('forge-app-keyfile');
+      const pemEl = document.getElementById('forge-app-pem');
+      const keyFile = (keyFileEl && keyFileEl.value || '').trim();
+      const pem = (pemEl && pemEl.value || '').trim();
+      const body = {};
+      if (appId !== null) {
+        if (isNaN(appId) || appId <= 0) { showToast('App ID must be a positive number', 'error'); return; }
+        body.app_id = appId;
+      }
+      if (instId !== null) {
+        if (isNaN(instId) || instId < 0) { showToast('Installation ID must be a non-negative number', 'error'); return; }
+        body.installation_id = instId;
+      }
+      if (keyFile) body.key_file = keyFile;
+      if (pem) body.private_key = pem;
+      if (!Object.keys(body).length) { showToast('Nothing to save', 'error'); return; }
+      if (btn) { btn.disabled = true; btn.textContent = 'Saving…'; }
+      try {
+        // The existing config-github handler: persists, then live-reinits the
+        // GitHub client when the config becomes usable.
+        const res = await fetch('/api/config/github', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(data.error || ('HTTP ' + res.status));
+        showToast(data.reinit === 'ok' ? 'Forge App config saved and reconnected' : 'Forge App config saved', 'success');
+        loadForgeApps();
+      } catch (e) {
+        showToast('Save failed: ' + e.message, 'error');
+      } finally {
+        if (btn) { btn.disabled = false; btn.textContent = 'Save'; }
+      }
     }
 
     function renderGovGateways() {

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -7632,6 +7632,18 @@ const dashboardHTML = `<!DOCTYPE html>
     function ghAppIsOperatorSide(state) {
       return GH_APP_OPERATOR_STATES[String(state || '').trim()] === true;
     }
+    /* Popover label for a user-side App issue, from the classified state.
+       The blanket "permissions insufficient" wording is reserved for genuine
+       permission states (and for unclassified reports from older spokes);
+       the other states name their real cause so the hover stops sending an
+       admin to approve permissions when the installation_id is what's wrong. */
+    function ghAppPermIssueLabel(state) {
+      var s = String(state || '').trim();
+      if (s === 'wrong-installation') return 'wrong installation (installation_id points at another account)';
+      if (s === 'write-forbidden') return 'write forbidden (repo not in the App installation)';
+      if (s === 'no-app-assigned') return 'no App assigned yet';
+      return 'permissions insufficient';
+    }
 
     /* Labels for each journey stage, matching JourneyStage.String() on the hub. */
     var JOURNEY_STAGE_LABELS = {
@@ -8181,7 +8193,7 @@ const dashboardHTML = `<!DOCTYPE html>
           : '⚠ GitHub App: credentials not yet delivered by the hub (operator action)');
         st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel;
       }
-      else if (h.githubAppRequired && h.githubAppPermIssue) { lines.push('✓ GitHub App installed'); lines.push('⚠ GitHub App: permissions insufficient'); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
+      else if (h.githubAppRequired && h.githubAppPermIssue) { lines.push('✓ GitHub App installed'); lines.push('⚠ GitHub App: ' + ghAppPermIssueLabel(h.githubAppState)); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
       else if (h.githubAppRequired) { lines.push('✕ GitHub App not installed'); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
       else if (!h.githubAppRequired) { lines.push('✓ GitHub App: not in use'); }
       if (!checks.length) lines.push('No check data');


### PR DESCRIPTION
## What

**Spoke dashboard** — Governor Configuration gains a **Forge App** tab:

- Shows the active github config: `app_id`, `app_slug`, `api_url`, `base_url`, `installation_id`, key file path + key fingerprint, and the **classified auth state wire token verbatim** (`not-installed` / `wrong-installation` / `key-invalid` / …) — the debugging surface.
- Lists every per-app-id key on the PVC (`/data/gh-app-key-<appid>.pem`) as read-only rows — **fingerprints and paths only, never key material**.
- Only the config whose forge matches the forge of this hive's repos (derived from the configured base/api URL host, empty = github.com) is editable; the form saves through the existing `PUT /api/config/github` handler and live-reinits the client.

**Backend** — `GET /api/config/github/forge-apps` in `pkg/dashboard`. The key resolution and PVC scan live in `cmd/hive`, injected as a provider following the `SetGitHubAppRecheckFn` pattern. Fingerprints via `config.AppKeyFingerprintFromFile`.

**Hub popover** — the blanket '⚠ GitHub App: permissions insufficient' label now reflects the classified state (e.g. `wrong-installation` → 'wrong installation'), falling back to the permissions wording only for genuine permission issues and unclassified older spokes.

## Tests

- Provider fed real key paths → response asserted to contain **no PEM fragment** (header or payload), only fingerprints/paths.
- Editable rule driven through the endpoint and as a unit truth table (empty = github.com, case-insensitive, GHE match/mismatch).
- Auth state passes through verbatim.
- Endpoint degrades gracefully with no provider injected.
- Mutation-checked: forcing `forgeAppEditable` to always-true and removing the empty-host default each fail a test.