### PR TITLE
🐛 dashboard: serve /terminal from the Go server so hosted terminal links stop 404ing

### DIFF
--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -637,6 +637,10 @@ func (s *Server) registerCoreRoutes() {
 	// second GitHub device-flow login. Public path (see isPublicPath) because
 	// the caller has no session yet — the token IS the credential.
 	s.mux.HandleFunc("GET /sso", s.handleSSO)
+	// /terminal → in-container ttyd, so the dashboard's "▶ terminal" links
+	// work even when the cluster route sends the whole host to this server
+	// (see registerTerminalProxy).
+	s.registerTerminalProxy()
 }
 
 func (s *Server) Start() error {

--- a/v2/pkg/dashboard/terminal_proxy.go
+++ b/v2/pkg/dashboard/terminal_proxy.go
@@ -1,0 +1,77 @@
+package dashboard
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// defaultTtydPort is where the container's ttyd process listens (see
+// deploy/entrypoint.sh, which starts ttyd alongside this server). Overridable
+// via HIVE_TTYD_PORT, mirroring the Node proxy's knob in proxy/server.js.
+const defaultTtydPort = 7681
+
+// terminalPathPrefix is the public path the dashboard's "▶ terminal" links
+// point at (see terminalUrl() in static/index.html). It is stripped before
+// forwarding because ttyd serves its UI and websocket at the root.
+const terminalPathPrefix = "/terminal"
+
+// ttydPort resolves the local ttyd port, falling back to the default on an
+// unset or malformed HIVE_TTYD_PORT.
+func ttydPort() int {
+	if v := os.Getenv("HIVE_TTYD_PORT"); v != "" {
+		if p, err := strconv.Atoi(v); err == nil && p > 0 {
+			return p
+		}
+	}
+	return defaultTtydPort
+}
+
+// registerTerminalProxy mounts /terminal on the Go dashboard mux, reverse
+// proxying to the in-container ttyd (HTTP assets and the terminal
+// websocket — httputil.ReverseProxy passes protocol upgrades through).
+//
+// Why the Go server must serve this itself: hosted spokes route the
+// dashboard host's "/" straight to this server (port 3002), while the
+// Ingress/Route that is supposed to peel off /terminal to the Node proxy
+// (port 3001) does not exist on every spoke — clicking "▶ terminal" then
+// landed on the static FileServer here and returned a bare Go
+// "404 page not found" (task #39, vllm-d hosted spokes). Serving /terminal
+// from this server makes the link work regardless of which Service port the
+// cluster's route actually targets, and puts terminal access behind the same
+// authenticate() middleware as the rest of the dashboard (session cookie,
+// hub-injected identity, or ?token= — which the dashboard link already
+// appends).
+//
+// Registered with an explicit GET method: everything ttyd serves (assets,
+// auth token endpoint, websocket handshake) is a GET, and a method-less
+// "/terminal/" pattern would conflict with Start()'s "GET /" under the Go
+// 1.22 ServeMux precedence rules (overlapping, neither more specific).
+func (s *Server) registerTerminalProxy() {
+	target := &url.URL{Scheme: "http", Host: fmt.Sprintf("127.0.0.1:%d", ttydPort())}
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(target)
+			// Strip the /terminal prefix: ttyd serves at the root. Mirrors the
+			// Node proxy's pathRewrite (p.replace(/^\/terminal/, '') || '/').
+			p := strings.TrimPrefix(pr.In.URL.Path, terminalPathPrefix)
+			if p == "" || !strings.HasPrefix(p, "/") {
+				p = "/" + p
+			}
+			pr.Out.URL.Path = p
+			pr.Out.URL.RawPath = ""
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			s.logger.Error("terminal proxy error", "path", r.URL.Path, "error", err)
+			// Same body the Node proxy returns when ttyd is down — a clear
+			// signal, not a bare 404.
+			http.Error(w, "Terminal unavailable", http.StatusBadGateway)
+		},
+	}
+	s.mux.Handle("GET "+terminalPathPrefix, proxy)
+	s.mux.Handle("GET "+terminalPathPrefix+"/", proxy)
+}

--- a/v2/pkg/dashboard/terminal_proxy_test.go
+++ b/v2/pkg/dashboard/terminal_proxy_test.go
@@ -1,0 +1,128 @@
+package dashboard
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// startFakeTtyd runs a local HTTP server standing in for ttyd and points
+// HIVE_TTYD_PORT at it. It records the last path+query it was asked for so
+// tests can assert the /terminal prefix is stripped and the query survives.
+func startFakeTtyd(t *testing.T) (lastURL *string) {
+	t.Helper()
+	var last string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		last = r.URL.RequestURI()
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ttyd-ok")
+	}))
+	t.Cleanup(backend.Close)
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(backend.URL, "http://"))
+	if err != nil {
+		t.Fatalf("splitting backend addr: %v", err)
+	}
+	t.Setenv("HIVE_TTYD_PORT", port)
+	return &last
+}
+
+func newTerminalTestHandler(t *testing.T, authToken string) http.Handler {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	if authToken == "" {
+		return NewServer(0, logger).Handler()
+	}
+	return NewServerWithAuth(0, authToken, logger).Handler()
+}
+
+// The dashboard builds terminal links as /terminal/?arg=hive-<agent> (see
+// terminalUrl in static/index.html). On hosted spokes whose route sends the
+// whole host to the Go server, that exact URL returned the FileServer's bare
+// 404 — the regression under test. It must reach ttyd with the prefix
+// stripped and the ?arg= query intact.
+func TestTerminalProxyServesDashboardLink(t *testing.T) {
+	last := startFakeTtyd(t)
+	h := newTerminalTestHandler(t, "")
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/terminal/?arg=hive-quality", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /terminal/?arg=hive-quality: got %d, want 200 (body %q)", rec.Code, rec.Body.String())
+	}
+	if *last != "/?arg=hive-quality" {
+		t.Fatalf("backend saw %q, want %q", *last, "/?arg=hive-quality")
+	}
+}
+
+func TestTerminalProxyPathRewrites(t *testing.T) {
+	last := startFakeTtyd(t)
+	h := newTerminalTestHandler(t, "")
+
+	cases := []struct{ in, want string }{
+		{"/terminal", "/"},
+		{"/terminal/", "/"},
+		{"/terminal/token", "/token"},
+		{"/terminal/ws?arg=hive-quality", "/ws?arg=hive-quality"},
+	}
+	for _, c := range cases {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, c.in, nil))
+		if rec.Code != http.StatusOK {
+			t.Errorf("GET %s: got %d, want 200", c.in, rec.Code)
+			continue
+		}
+		if *last != c.want {
+			t.Errorf("GET %s: backend saw %q, want %q", c.in, *last, c.want)
+		}
+	}
+}
+
+// Terminal access must sit behind the same auth gate as the rest of the
+// dashboard: no credential → 401, and the ?token= the dashboard link appends
+// must be accepted.
+func TestTerminalProxyAuth(t *testing.T) {
+	startFakeTtyd(t)
+	const token = "test-terminal-token"
+	h := newTerminalTestHandler(t, token)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/terminal/?arg=hive-quality", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated: got %d, want 401", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/terminal/?arg=hive-quality&token="+token, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("with ?token=: got %d, want 200 (body %q)", rec.Code, rec.Body.String())
+	}
+}
+
+// When ttyd is down the proxy must answer 502 "Terminal unavailable" (the
+// Node proxy's contract), never the FileServer's bare 404.
+func TestTerminalProxyTtydDown(t *testing.T) {
+	// Reserve a port with nothing listening on it.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+	t.Setenv("HIVE_TTYD_PORT", strconv.Itoa(port))
+	h := newTerminalTestHandler(t, "")
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/terminal/", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("ttyd down: got %d, want 502", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "Terminal unavailable") {
+		t.Fatalf("ttyd down: body %q, want it to mention Terminal unavailable", rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Problem (task #39)

Clicking the **▶ terminal** button for an agent on a hosted spoke dashboard opens `https://<spoke-host>/terminal/?arg=hive-<agent>` and renders a bare **"404 page not found"**.

Live repro: `hosted-z-aiops-unite-ui-sqru.apps.fmaas-vllm-d.fmaas.res.ibm.com/terminal/?arg=hive-quality`.

### Root cause
On hosted spokes the dashboard host's route sends every path to the **Go dashboard server** (port 3002). The provisioning template also creates a `hive-terminal` Ingress/Route that peels `/terminal` off to the Node proxy (port 3001 → ttyd 7681), but that route does not exist/route correctly on every spoke — and the Go server had **no `/terminal` handler at all**. An authenticated request passed `authenticate()` and fell into the embedded static `FileServer`, which answered Go's default `404 page not found`. (Unauthenticated curl of the same URL gets the Go login page — confirming the Go server, not the Node proxy or ttyd, is answering `/terminal/*` on these spokes.) Repairing per-cluster routes is not an option for clusters the hub cannot reach.

### Fix
Mount a `GET /terminal` + `GET /terminal/` reverse proxy to the in-container ttyd on the Go server itself (`pkg/dashboard/terminal_proxy.go`), registered in `registerCoreRoutes()` so both `Start()` and `Handler()` serve it:

- Default target `127.0.0.1:7681`, overridable via `HIVE_TTYD_PORT` (same knob as `proxy/server.js`)
- Strips the `/terminal` prefix exactly like the Node proxy (`/terminal/?arg=hive-quality` → `/?arg=hive-quality`), query preserved; `httputil.ReverseProxy` passes the terminal websocket upgrade through
- Sits behind the existing `authenticate()` middleware — session cookie, hub identity headers, or the `?token=` the dashboard link already appends; no new public surface
- ttyd down → `502 Terminal unavailable` (Node proxy's contract), never a bare 404
- Explicit `GET` method in the patterns: a method-less `/terminal/` conflicts with `Start()`'s `GET /` under Go 1.22 ServeMux precedence, and everything ttyd serves is a GET

The `?arg=hive-<agent>` contract is unchanged and still correct: ttyd runs with `-a` and passes it as `$1` to `ttyd-tmux.sh`, which attaches the `hive-<agent>` tmux session.

### Tests
`pkg/dashboard/terminal_proxy_test.go`: exact dashboard-link shape proxied with query intact; prefix rewrites (`/terminal`, `/terminal/`, `/terminal/token`, `/terminal/ws`); auth gate (401 without credential, 200 with `?token=`); ttyd-down 502. Mutation-checked: with the registration removed, the tests fail with the exact production symptom (`404 page not found`).