### PR TITLE
🐛 hub: recover armed heartbeat upgrades after restart and for non-auto-upgrade hives

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4104,25 +4104,6 @@ func (s *HubServer) rolloutRestartHive(cluster *ClusterConfig, hiveID string) bo
 func (s *HubServer) triggerAutoUpgrades() {
 	hives := listSaaSHives()
 	for _, h := range hives {
-		if !h.AutoUpgrade {
-			continue
-		}
-		// Scheduling gate. Instant-mode hives (and every legacy record, whose
-		// mode is empty) pass straight through, so this changes nothing for the
-		// existing fleet. Daily-mode hives are held until the first cycle at or
-		// after autoUpgradeDailyHour ET and released only once per ET day.
-		// Evaluated BEFORE any of the work below so a held hive costs nothing.
-		decision := shouldAutoUpgradeNow(h.AutoUpgradeMode, h.AutoUpgradeLastFired, time.Now())
-		if !decision.Allowed {
-			s.logger.Debug("auto-upgrade held by schedule",
-				"hive_id", h.ID, "mode", h.AutoUpgradeMode, "reason", decision.Reason)
-			continue
-		}
-		// Skip hives that are actively provisioning or in error state.
-		// Empty status means the hive predates the provisioning system — treat as eligible.
-		if h.Status == "provisioning" || h.Status == "error" {
-			continue
-		}
 		s.mu.RLock()
 		var currentSHA, branch, upgradeTarget string
 		var alreadyUpgrading bool
@@ -4138,10 +4119,18 @@ func (s *HubServer) triggerAutoUpgrades() {
 			}
 		}
 		s.mu.RUnlock()
+		if branch == "" {
+			branch = "v2"
+		}
 		if alreadyUpgrading {
-			if branch == "" {
-				branch = "v2"
-			}
+			// Latched-upgrade recovery runs for EVERY hive, deliberately BEFORE
+			// the AutoUpgrade gate below (#2476). The registry latch
+			// (Upgrading/UpgradeTarget/UpgradeStartedAt) is durable, but
+			// heartbeatUpgrade — the map that actually delivers the instruction
+			// — is in-memory; when this recovery lived behind
+			// `if !h.AutoUpgrade { continue }`, a hub restart orphaned every
+			// manually upgraded hive forever: latched "Upgrading" in the
+			// registry, zero instructions on the wire.
 			upgradeAge := time.Since(upgradeStartedAt)
 			// Zero UpgradeStartedAt means the timestamp was lost (heartbeats
 			// used to wipe it on rebuild) — treat as stale so already-stuck
@@ -4163,13 +4152,21 @@ func (s *HubServer) triggerAutoUpgrades() {
 				// target advances. Previously, when the target already equalled
 				// latest, this branch was skipped entirely and the hive stayed
 				// latched-upgrading forever behind an unreachable kubectl.
-				latestSHA := getLatestSHAForBranch(branch)
 				recoverTarget := upgradeTarget
-				if latestSHA != "" && latestSHA != upgradeTarget {
+				if h.AutoUpgrade {
+					// Target advancement is an auto-upgrade behaviour: those
+					// hives always chase latest. A manual upgrade keeps exactly
+					// the target that was requested — with AutoUpgrade off,
+					// silently delivering a newer build than the one the owner
+					// clicked would override their setting.
+					if latestSHA := getLatestSHAForBranch(branch); latestSHA != "" && latestSHA != upgradeTarget {
+						recoverTarget = latestSHA
+					}
+				}
+				if recoverTarget != upgradeTarget {
 					s.logger.Warn("advancing upgrade target for stale upgrade",
 						"hive", h.ID, "stale_minutes", int(upgradeAge.Minutes()),
-						"old_target", upgradeTarget, "new_target", latestSHA)
-					recoverTarget = latestSHA
+						"old_target", upgradeTarget, "new_target", recoverTarget)
 				} else {
 					s.logger.Warn("re-arming heartbeat fallback for stale upgrade",
 						"hive", h.ID, "stale_minutes", int(upgradeAge.Minutes()),
@@ -4214,8 +4211,26 @@ func (s *HubServer) triggerAutoUpgrades() {
 				"hive", h.ID, "current", currentSHA)
 			continue
 		}
-		if branch == "" {
-			branch = "v2"
+		// Everything below STARTS a new upgrade, which only auto-upgrade hives
+		// opt into. The recovery above must stay ahead of this gate — see #2476.
+		if !h.AutoUpgrade {
+			continue
+		}
+		// Scheduling gate. Instant-mode hives (and every legacy record, whose
+		// mode is empty) pass straight through, so this changes nothing for the
+		// existing fleet. Daily-mode hives are held until the first cycle at or
+		// after autoUpgradeDailyHour ET and released only once per ET day.
+		// Evaluated BEFORE any of the work below so a held hive costs nothing.
+		decision := shouldAutoUpgradeNow(h.AutoUpgradeMode, h.AutoUpgradeLastFired, time.Now())
+		if !decision.Allowed {
+			s.logger.Debug("auto-upgrade held by schedule",
+				"hive_id", h.ID, "mode", h.AutoUpgradeMode, "reason", decision.Reason)
+			continue
+		}
+		// Skip hives that are actively provisioning or in error state.
+		// Empty status means the hive predates the provisioning system — treat as eligible.
+		if h.Status == "provisioning" || h.Status == "error" {
+			continue
 		}
 		if currentSHA == "" {
 			continue

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -820,6 +820,10 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 	}
 
 	s.loadRegistry()
+	// Rebuild the in-memory upgrade-delivery map from the durable registry
+	// BEFORE the server takes its first heartbeat, so a hub restart can never
+	// orphan an armed upgrade (#2476).
+	s.recoverArmedUpgrades()
 	s.loadHubBanners()
 	s.timeline.load()
 	if err := s.journey.load(time.Now()); err != nil {
@@ -2404,6 +2408,48 @@ func (s *HubServer) loadRegistry() {
 		s.logger.Warn("failed to parse hub registry", "error", err)
 	} else {
 		s.logger.Info("hub registry loaded", "hives", len(s.registry.Hives))
+	}
+}
+
+// recoverArmedUpgrades rebuilds s.heartbeatUpgrade — the in-memory map that
+// actually DELIVERS upgrade instructions on each heartbeat — from the durable
+// registry latch (Upgrading/UpgradeTarget), which survives a hub restart.
+//
+// Without this, a hub restart between arming an upgrade (handleUpgradeHive,
+// bulk upgrade, auto-upgrade fallback) and its completion silently dropped the
+// instruction: the registry kept saying "Upgrading" while the hub sent the
+// spoke nothing, forever, because the map died with the old process (#2476 —
+// four hives sat latched 15+ minutes with zero instructions after a hub
+// self-upgrade). The heartbeat path clears both the map entry and the registry
+// latch when the spoke reports the target SHA, so re-arming here is idempotent
+// and self-terminating.
+//
+// Called from NewHubServer immediately after loadRegistry; takes s.mu like
+// every other heartbeatUpgrade writer so it is also safe to invoke later.
+func (s *HubServer) recoverArmedUpgrades() {
+	type armed struct{ id, target string }
+	var recovered []armed
+	s.mu.Lock()
+	if s.heartbeatUpgrade == nil {
+		s.heartbeatUpgrade = make(map[string]string)
+	}
+	for i := range s.registry.Hives {
+		h := &s.registry.Hives[i]
+		if !h.Upgrading || h.UpgradeTarget == "" {
+			continue
+		}
+		// A recorded terminal failure must stay terminal — re-arming it would
+		// resurrect an upgrade the orphan sweep already gave up on and reported.
+		if h.UpgradeFailed {
+			continue
+		}
+		s.heartbeatUpgrade[h.ID] = h.UpgradeTarget
+		recovered = append(recovered, armed{id: h.ID, target: h.UpgradeTarget})
+	}
+	s.mu.Unlock()
+	for _, a := range recovered {
+		s.logger.Info("recovered armed upgrade from registry after restart",
+			"hive_id", a.id, "target", a.target)
 	}
 }
 

--- a/v2/pkg/hub/upgrade_recovery_test.go
+++ b/v2/pkg/hub/upgrade_recovery_test.go
@@ -1,0 +1,157 @@
+package hub
+
+// Tests for #2476: a hub restart must never orphan an armed upgrade.
+//
+// The registry latch (Upgrading/UpgradeTarget/UpgradeStartedAt) is durable,
+// but heartbeatUpgrade — the map the heartbeat path reads to actually deliver
+// an upgrade instruction — is in-memory. The two recovery paths under test:
+//
+//  1. recoverArmedUpgrades() rebuilds the map from the registry at startup.
+//  2. triggerAutoUpgrades() recovers stale latched hives regardless of
+//     AutoUpgrade — the recovery used to live behind the AutoUpgrade gate, so
+//     manually upgraded hives were never recovered at all.
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestRecoverArmedUpgradesRebuildsHeartbeatMap constructs a HubServer whose
+// registry carries a latched entry (exactly what a restarted hub loads from
+// disk) and asserts the startup-recovery path re-arms delivery for it — and
+// only for it.
+func TestRecoverArmedUpgradesRebuildsHeartbeatMap(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+	s.registry.Hives = []RegistryEntry{
+		// The incident shape: durably latched Upgrading with a target, armed by
+		// handleUpgradeHive before the hub restarted.
+		{ID: "latched", Upgrading: true, UpgradeTarget: "fc32ae4"},
+		// Not upgrading — a leftover target alone must not arm delivery.
+		{ID: "idle", Upgrading: false, UpgradeTarget: "deadbee"},
+		// Latched but with no target — nothing a heartbeat could deliver.
+		{ID: "no-target", Upgrading: true},
+		// Terminal failure recorded by the orphan sweep — must stay terminal.
+		{ID: "failed", Upgrading: true, UpgradeTarget: "fc32ae4", UpgradeFailed: true},
+	}
+
+	// heartbeatUpgrade is deliberately left nil: at this point in NewHubServer
+	// the recovery must work regardless, like every other writer of the map.
+	s.recoverArmedUpgrades()
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if got := s.heartbeatUpgrade["latched"]; got != "fc32ae4" {
+		t.Errorf("latched upgrade must be re-armed at startup, heartbeatUpgrade = %q, want %q", got, "fc32ae4")
+	}
+	for _, id := range []string{"idle", "no-target", "failed"} {
+		if target, armed := s.heartbeatUpgrade[id]; armed {
+			t.Errorf("hive %q must NOT be re-armed at startup, got target %q", id, target)
+		}
+	}
+}
+
+// TestNewHubServerRecoversArmedUpgradesFromDisk goes through the real startup
+// path: a registry file on disk with a latched entry, loaded by NewHubServer,
+// must leave the hub with delivery armed. This is the end-to-end guard — it
+// fails if the recovery call is ever dropped from server construction, not
+// just if the method's logic regresses.
+func TestNewHubServerRecoversArmedUpgradesFromDisk(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	oldRegistry := registryPath
+	registryPath = filepath.Join(t.TempDir(), "hub-registry.json")
+	defer func() { registryPath = oldRegistry }()
+
+	reg := Registry{Hives: []RegistryEntry{
+		{ID: "latched-disk", Upgrading: true, UpgradeTarget: "fc32ae4"},
+	}}
+	data, err := json.Marshal(reg)
+	if err != nil {
+		t.Fatalf("marshal registry: %v", err)
+	}
+	if err := os.WriteFile(registryPath, data, 0o644); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+
+	s := NewHubServer(0, slog.Default(), "test", "v2")
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if got := s.heartbeatUpgrade["latched-disk"]; got != "fc32ae4" {
+		t.Errorf("hub restart orphaned an armed upgrade: heartbeatUpgrade = %q, want %q", got, "fc32ae4")
+	}
+}
+
+// TestTriggerAutoUpgradesRecoversStaleManualUpgrade is the sweep half of
+// #2476: a hive with AutoUpgrade FALSE, latched Upgrading past
+// staleUpgradeTimeout, must have its heartbeat delivery re-armed — with the
+// target it originally requested, not advanced to the branch's latest SHA
+// (target advancement is auto-upgrade behaviour).
+func TestTriggerAutoUpgradesRecoversStaleManualUpgrade(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	installScriptedKubectl(t)
+
+	remote := ClusterConfig{ID: "remote", InCluster: false, KubeconfigPath: "/tmp/kc", Context: "ctx"}
+	saveSaaSHive(&SaaSHive{ID: "manual-1", Owner: "alice", AutoUpgrade: false, Status: "running", ClusterID: "remote"})
+	resetSHACaches(t)
+	// A newer SHA exists on the branch; a manual upgrade must NOT be advanced
+	// to it during recovery.
+	latestSHAMu.Lock()
+	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "newer99"}
+	latestSHAMu.Unlock()
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string), clusters: map[string]ClusterConfig{"remote": remote}}
+	s.registry.Hives = []RegistryEntry{{
+		ID: "manual-1", GitBranch: "v2", GitHash: "old1234", Upgrading: true,
+		UpgradeTarget: "fc32ae4", UpgradeStartedAt: time.Now().Add(-30 * time.Minute),
+	}}
+
+	s.triggerAutoUpgrades()
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if got := s.heartbeatUpgrade["manual-1"]; got != "fc32ae4" {
+		t.Errorf("stale manual upgrade must be re-armed for delivery, heartbeatUpgrade = %q, want %q", got, "fc32ae4")
+	}
+	if got := s.registry.Hives[0].UpgradeTarget; got != "fc32ae4" {
+		t.Errorf("a manual upgrade's target must not be advanced to latest, got %q", got)
+	}
+	if !s.registry.Hives[0].Upgrading {
+		t.Error("recovery must keep the durable Upgrading latch until the spoke reports the target")
+	}
+	if age := time.Since(s.registry.Hives[0].UpgradeStartedAt); age > time.Minute {
+		t.Errorf("recovery must refresh UpgradeStartedAt, still %v old", age)
+	}
+}
+
+// TestTriggerAutoUpgradesNotStaleManualRepopulates covers the hub-restart case
+// before the stale threshold: a latched manual upgrade on a remote cluster is
+// re-populated into heartbeatUpgrade even when it is not yet stale, exactly as
+// the auto-upgrade path always did.
+func TestTriggerAutoUpgradesNotStaleManualRepopulates(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	remote := ClusterConfig{ID: "remote", InCluster: false, KubeconfigPath: "/tmp/kc", Context: "ctx"}
+	saveSaaSHive(&SaaSHive{ID: "manual-2", Owner: "alice", AutoUpgrade: false, Status: "running", ClusterID: "remote"})
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string), clusters: map[string]ClusterConfig{"remote": remote}}
+	s.registry.Hives = []RegistryEntry{{
+		ID: "manual-2", GitBranch: "v2", GitHash: "old1234", Upgrading: true,
+		UpgradeTarget: "keepTarget", UpgradeStartedAt: time.Now(),
+	}}
+
+	s.triggerAutoUpgrades()
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if got := s.heartbeatUpgrade["manual-2"]; got != "keepTarget" {
+		t.Errorf("in-flight manual upgrade must be re-populated after a hub restart, got %q", got)
+	}
+}

--- a/v2/pkg/hub/upgrade_recovery_test.go
+++ b/v2/pkg/hub/upgrade_recovery_test.go
@@ -130,6 +130,52 @@ func TestTriggerAutoUpgradesRecoversStaleManualUpgrade(t *testing.T) {
 	}
 }
 
+// TestTriggerAutoUpgradesRecoversStaleDailyModeHiveHeldBySchedule pins the
+// #2496 half of the restructure: a daily-mode hive that already fired today is
+// held by the schedule gate ("already upgraded today") — but staleness
+// recovery is NOT a scheduled upgrade and must never be held by the daily
+// window. Before the restructure the schedule gate sat ahead of the
+// alreadyUpgrading branch, so a stuck upgrade on such a hive was not re-armed
+// until the next ET day.
+func TestTriggerAutoUpgradesRecoversStaleDailyModeHiveHeldBySchedule(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	installScriptedKubectl(t)
+
+	loc, err := autoUpgradeLocation()
+	if err != nil {
+		t.Fatalf("autoUpgradeLocation: %v", err)
+	}
+	today := time.Now().In(loc).Format(autoUpgradeDateFormat)
+
+	remote := ClusterConfig{ID: "remote", InCluster: false, KubeconfigPath: "/tmp/kc", Context: "ctx"}
+	saveSaaSHive(&SaaSHive{
+		ID: "daily-1", Owner: "alice", AutoUpgrade: true,
+		AutoUpgradeMode: AutoUpgradeModeDaily, AutoUpgradeLastFired: today,
+		Status: "running", ClusterID: "remote",
+	})
+	// No latest SHA cached: recovery keeps the latched target rather than
+	// advancing, which keeps the assertion on the re-arm itself.
+	resetSHACaches(t)
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string), clusters: map[string]ClusterConfig{"remote": remote}}
+	s.registry.Hives = []RegistryEntry{{
+		ID: "daily-1", GitBranch: "v2", GitHash: "old1234", Upgrading: true,
+		UpgradeTarget: "fc32ae4", UpgradeStartedAt: time.Now().Add(-30 * time.Minute),
+	}}
+
+	s.triggerAutoUpgrades()
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if got := s.heartbeatUpgrade["daily-1"]; got != "fc32ae4" {
+		t.Errorf("stale upgrade on a daily-mode hive that already fired today must still be re-armed, heartbeatUpgrade = %q, want %q", got, "fc32ae4")
+	}
+	if !s.registry.Hives[0].Upgrading {
+		t.Error("recovery must keep the durable Upgrading latch until the spoke reports the target")
+	}
+}
+
 // TestTriggerAutoUpgradesNotStaleManualRepopulates covers the hub-restart case
 // before the stale threshold: a latched manual upgrade on a remote cluster is
 // re-populated into heartbeatUpgrade even when it is not yet stale, exactly as


### PR DESCRIPTION
## Problem

A manual upgrade (`handleUpgradeHive`, #2443) arms `s.heartbeatUpgrade` — the **in-memory** map the heartbeat path reads to deliver the instruction — and durably latches the registry (`Upgrading`/`UpgradeTarget`/`UpgradeStartedAt`). Two gaps turned that into a live incident (four vllm-d hives latched \"Upgrading\" 15+ minutes with zero instructions on the wire):

1. A hub restart (e.g. hub self-upgrade) killed the map while the registry latch survived on disk — nothing re-armed delivery.
2. The only recovery path lived inside `triggerAutoUpgrades()` behind `if !h.AutoUpgrade { continue }`, so latched hives **without** auto-upgrade were never recovered at all.

## Fix (both halves, complementary)

**Startup recovery** — `NewHubServer` now calls `recoverArmedUpgrades()` immediately after `loadRegistry()`: every registry entry with `Upgrading == true && UpgradeTarget != \"\"` (and no recorded terminal `UpgradeFailed`) is re-armed into `heartbeatUpgrade` under the same `s.mu` discipline the heartbeat path uses. Re-arming is idempotent and self-terminating — the heartbeat path clears both the map entry and the latch when the spoke reports the target SHA (`sameCommit`), which is untouched.

**Sweep coverage** — the latched-`Upgrading` recovery block in `triggerAutoUpgrades()` is hoisted ahead of the `AutoUpgrade` gate so it runs for ALL hives. Auto-upgrade behaviour is preserved exactly: target advancement to latest on staleness, the `rolloutRestartHive` attempt, heartbeat re-arm, and the existing \"advancing upgrade target\" / \"re-arming heartbeat fallback for stale upgrade\" log lines. Manual upgrades are re-armed with the target originally requested — advancing them to latest would override the owner's `AutoUpgrade=false` setting.

The 10-minute `staleUpgradeTimeout` \"Upgrade stuck\" tripwire and the orphaned-upgrade sweep (`sweepOrphanedUpgrades`) are unchanged.

## Tests

- `TestRecoverArmedUpgradesRebuildsHeartbeatMap` — latched entry re-armed; idle / no-target / terminal-failed entries are not.
- `TestNewHubServerRecoversArmedUpgradesFromDisk` — end-to-end through the real startup path (registry file on disk → `NewHubServer` → delivery armed); fails if the startup hook is ever dropped.
- `TestTriggerAutoUpgradesRecoversStaleManualUpgrade` — stale latched hive with `AutoUpgrade: false` is re-armed with its requested target (not advanced to latest), latch kept, `UpgradeStartedAt` refreshed.
- `TestTriggerAutoUpgradesNotStaleManualRepopulates` — pre-stale hub-restart case re-populates the map for a manual upgrade on a remote cluster.
- Mutation-verified: removing the startup hook fails the disk test; restoring the `AutoUpgrade` gate over the recovery fails both manual-hive tests. Full `pkg/hub` suite green.

Fixes #2476

## Also fixes #2496 (daily schedule gate holding recovery)

Confirmed live during the fma incident: the daily-mode schedule gate (`shouldAutoUpgradeNow`, "already upgraded today") sat ahead of the stale-recovery branch, so a stuck upgrade on a daily-mode hive that had already fired was never re-armed until the next ET day. The restructure here hoists recovery ahead of the schedule gate too — staleness recovery is not a scheduled upgrade and is never held by the daily window. Pinned by `TestTriggerAutoUpgradesRecoversStaleDailyModeHiveHeldBySchedule` (mutation-verified: restoring the gate over the recovery block fails it).

Fixes #2496


🤖 Generated with [Claude Code](https://claude.com/claude-code)
