### PR TITLE
🐛 hub: readable drift-hover prose, first-seen timestamps, overflow wrap

### DIFF
--- a/v2/pkg/hub/drift.go
+++ b/v2/pkg/hub/drift.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
@@ -108,6 +109,12 @@ type DriftSignal struct {
 	Kind     string        `json:"kind"`
 	Severity DriftSeverity `json:"severity"`
 	Reason   string        `json:"reason"`
+	// FirstSeen is when the hub first observed this (hive, kind) signal,
+	// RFC3339. It is stable while the signal persists across recomputes and
+	// resets only after the signal clears, so the hover can say "since 3:42 PM"
+	// instead of drifting to "now" on every beat. Empty on reports the tracker
+	// has not stamped (defensive: a caller that builds a DriftReport directly).
+	FirstSeen string `json:"firstSeen,omitempty"`
 }
 
 // DriftReport is the per-hive drift result attached to a My Hives row.
@@ -356,11 +363,18 @@ func healthFailingChecks(health map[string]any) []string {
 		if status == "" || status == "pass" || status == "skip" {
 			continue
 		}
+		// Health rides the heartbeat as a free-form map and is stored
+		// unsanitized, so the strings composed into a hub-rendered reason are
+		// neutralized here — with the PROSE sanitizer, because a check detail
+		// is a sentence and the identifier sanitizer would strip its spaces.
+		status = sanitizeProseField(status)
 		name, _ := ck["name"].(string)
+		name = sanitizeProseField(name)
 		if name == "" {
 			name = "unnamed check"
 		}
 		detail, _ := ck["detail"].(string)
+		detail = sanitizeProseField(detail)
 		if detail != "" {
 			out = append(out, fmt.Sprintf("%s (%s: %s)", name, status, detail))
 			continue
@@ -641,6 +655,69 @@ func annotateDrift(hives []MyHiveEntry, latestSHAs map[string]string, now time.T
 	}
 	norm := computeFleetNorm(hives)
 	for i := range hives {
-		hives[i].Drift = computeDrift(hives[i], norm, latestSHAs, now)
+		report := computeDrift(hives[i], norm, latestSHAs, now)
+		stampDriftFirstSeen(hives[i].ID, &report, now)
+		hives[i].Drift = report
+	}
+}
+
+// driftFirstSeen tracks when each (hive, kind) drift signal was first observed,
+// keyed by driftFirstSeenKey. Guarded by driftFirstSeenMu: annotateDrift runs
+// on every My Hives request, and two requests may recompute concurrently.
+//
+// The map is IN-MEMORY ONLY — a hub restart re-baselines every "since" to the
+// first recompute after boot. That is an accepted trade: the timestamp is a
+// triage aid ("did this start before or after my change?"), not an audit
+// record, and persisting it would put a disk write on the hottest read path.
+var (
+	driftFirstSeenMu sync.Mutex
+	driftFirstSeen   = map[string]time.Time{}
+)
+
+// driftFirstSeenKeySep joins hive ID and signal kind into one map key. NUL can
+// appear in neither side (hive IDs are isValidName-validated, kinds are
+// compile-time constants), so the key can never be ambiguous.
+const driftFirstSeenKeySep = "\x00"
+
+func driftFirstSeenKey(hiveID, kind string) string {
+	return hiveID + driftFirstSeenKeySep + kind
+}
+
+// stampDriftFirstSeen annotates each signal in report with the time this
+// (hive, kind) was FIRST observed, keeping that instant stable across
+// recomputes for as long as the signal stays present. Entries for kinds that
+// no longer fire on this hive are cleared, so a signal that goes away and
+// later returns gets a fresh first-seen rather than resurrecting the old one.
+//
+// Keyed by kind, not by reason: a reason legitimately mutates while the
+// condition persists ("No heartbeat for 3 min" becomes "... for 4 min"), and
+// re-stamping on every wording change is exactly the drift-to-now this
+// tracker exists to prevent. Multiple same-kind signals (identity-split can
+// raise several) share one first-seen, which is the honest reading: the hub
+// first saw that KIND of trouble then.
+func stampDriftFirstSeen(hiveID string, report *DriftReport, now time.Time) {
+	if hiveID == "" {
+		return
+	}
+	driftFirstSeenMu.Lock()
+	defer driftFirstSeenMu.Unlock()
+	present := make(map[string]bool, len(report.Signals))
+	for i := range report.Signals {
+		kind := report.Signals[i].Kind
+		present[kind] = true
+		key := driftFirstSeenKey(hiveID, kind)
+		first, ok := driftFirstSeen[key]
+		if !ok {
+			first = now
+			driftFirstSeen[key] = now
+		}
+		report.Signals[i].FirstSeen = first.UTC().Format(time.RFC3339)
+	}
+	// Clear cleared signals so a future recurrence is dated to its recurrence.
+	prefix := hiveID + driftFirstSeenKeySep
+	for key := range driftFirstSeen {
+		if strings.HasPrefix(key, prefix) && !present[strings.TrimPrefix(key, prefix)] {
+			delete(driftFirstSeen, key)
+		}
 	}
 }

--- a/v2/pkg/hub/drift_first_seen_test.go
+++ b/v2/pkg/hub/drift_first_seen_test.go
@@ -1,0 +1,192 @@
+package hub
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ============================================================
+// server.go — sanitizeProseField vs sanitizeHeartbeatField
+//
+// The drift hover rendered "TheGitHubAppisconfiguredbuthasnoinstallation."
+// because spoke-reported PROSE (App-permission diagnoses, upgrade errors)
+// went through the identifier sanitizer, which deletes spaces. Prose fields
+// now take sanitizeProseField, which keeps the sentence readable while still
+// neutralizing control characters and markup.
+// ============================================================
+
+func TestSanitizeProseFieldPreservesSentencesVerbatim(t *testing.T) {
+	cases := []string{
+		"The GitHub App is configured but has no installation. Install the app on your org to enable agents.",
+		"This hive is authenticating as GitHub App installation 150350880 which belongs to another org.",
+		"missing contents:write (have: read)",
+		"Upgrade to v2-latest failed: image pull back-off",
+	}
+	for _, in := range cases {
+		if got := sanitizeProseField(in); got != in {
+			t.Errorf("sanitizeProseField(%q) = %q, want the sentence verbatim", in, got)
+		}
+	}
+}
+
+func TestSanitizeProseFieldNeutralizesDangerousInput(t *testing.T) {
+	in := "line one\r\nline\ttwo \x1b[31mred\x00 <script>alert('x')</script> a & b `tick`"
+	got := sanitizeProseField(in)
+	for _, bad := range []string{"<", ">", "&", "`", "\n", "\r", "\t", "\x1b", "\x00"} {
+		if strings.Contains(got, bad) {
+			t.Errorf("sanitizeProseField left %q in %q", bad, got)
+		}
+	}
+	// Newlines/tabs become spaces and runs collapse, so the words stay separated.
+	if !strings.Contains(got, "line one line two") {
+		t.Errorf("newlines should become single spaces, got %q", got)
+	}
+	// No tag survives even if a render path forgets to escape.
+	if strings.Contains(got, "<script") {
+		t.Errorf("markup survived sanitization: %q", got)
+	}
+}
+
+func TestSanitizeProseFieldCapsLength(t *testing.T) {
+	long := strings.Repeat("word ", maxProseFieldRunes)
+	if n := len([]rune(sanitizeProseField(long))); n > maxProseFieldRunes {
+		t.Errorf("sanitized prose is %d runes, want <= %d", n, maxProseFieldRunes)
+	}
+}
+
+// Identifier-shaped fields must NOT be loosened by the prose fix: an org, a
+// branch or an agent state still may not carry spaces or markup at all.
+func TestSanitizeHeartbeatFieldStaysStrictForIdentifiers(t *testing.T) {
+	if got := sanitizeHeartbeatField("my org name"); got != "myorgname" {
+		t.Errorf("identifier sanitizer must still strip spaces, got %q", got)
+	}
+	if got := sanitizeHeartbeatField("v2 <b>"); got != "v2b" {
+		t.Errorf("identifier sanitizer must still strip markup, got %q", got)
+	}
+}
+
+// End-to-end through handleHeartbeat: the prose fields reach the registry with
+// their spaces intact, while an identifier field on the same payload is still
+// stripped strictly.
+func TestHeartbeatProseFieldsKeepSpaces(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	const permIssue = "The GitHub App is configured but has no installation. Install the app on your org to enable agents."
+	body := fmt.Sprintf(`{"hive_id":"prose-hive","org":"kubestellar","primary_repo":"hive",`+
+		`"github_app_perm_issue":%q,"advisory_error":"advisory post failed: HTTP 403 from GitHub",`+
+		`"git_branch":"v 2"}`, permIssue)
+	rec := postHeartbeat(t, s, body)
+	if rec.Code != 200 {
+		t.Fatalf("heartbeat status = %d (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	var entry *RegistryEntry
+	for i := range s.registry.Hives {
+		if s.registry.Hives[i].ID == "prose-hive" {
+			entry = &s.registry.Hives[i]
+		}
+	}
+	if entry == nil {
+		t.Fatal("heartbeat did not register the hive")
+	}
+	if entry.GitHubAppPermIssue != permIssue {
+		t.Errorf("GitHubAppPermIssue = %q, want the sentence verbatim %q", entry.GitHubAppPermIssue, permIssue)
+	}
+	if entry.AdvisoryError != "advisory post failed: HTTP 403 from GitHub" {
+		t.Errorf("AdvisoryError = %q, want spaces preserved", entry.AdvisoryError)
+	}
+	// The identifier on the same payload stays strict.
+	if entry.GitBranch != "v2" {
+		t.Errorf("GitBranch = %q, want the strict sanitizer to still strip the space", entry.GitBranch)
+	}
+}
+
+// Health-check details are composed into drift reasons from an unsanitized
+// free-form map, so they are neutralized at composition — with the prose
+// sanitizer, keeping "disk almost full" readable.
+func TestHealthFailingChecksSanitizesButKeepsSpaces(t *testing.T) {
+	health := map[string]any{
+		"status": "degraded",
+		"checks": []any{
+			map[string]any{"name": "disk space", "status": "warn", "detail": "disk almost full <b>93%</b>"},
+		},
+	}
+	got := healthFailingChecks(health)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 failing check, got %v", got)
+	}
+	if got[0] != "disk space (warn: disk almost full b93%/b)" {
+		t.Errorf("failing check = %q, want spaces kept and markup stripped", got[0])
+	}
+}
+
+// ============================================================
+// drift.go — first-seen tracking
+//
+// stampDriftFirstSeen keeps one instant per (hive, kind): stable while the
+// signal persists across recomputes, cleared when it clears, fresh when it
+// recurs. The hover renders it as "since 3:42 PM".
+// ============================================================
+
+// firstSeenFleet returns a norm-sized fleet plus one broken hive whose only
+// deliberate fault is ACMM unset (and the no-agents that rides along with
+// AgentCount forced to keep healthyEntry defaults elsewhere).
+func firstSeenFleet(id string, acmmLevel int) []MyHiveEntry {
+	broken := healthyEntry(id)
+	broken.ACMMLevel = acmmLevel
+	return append(normFleet(), broken)
+}
+
+func TestDriftFirstSeenStableWhileSignalPersists(t *testing.T) {
+	const hive = "first-seen-stable-hive"
+	latest := map[string]string{"v2": "abc1234"}
+	t0 := driftNow
+
+	hives := firstSeenFleet(hive, 0)
+	annotateDrift(hives, latest, t0)
+	sig, ok := driftKindsOf(hives[3].Drift)[DriftKindACMMUnset]
+	if !ok {
+		t.Fatal("test setup: acmm-unset signal expected")
+	}
+	if sig.FirstSeen != rfc(t0) {
+		t.Fatalf("first observation: FirstSeen = %q, want %q", sig.FirstSeen, rfc(t0))
+	}
+
+	// Recompute from scratch five minutes later with the signal still present:
+	// the stamp must not move.
+	hives2 := firstSeenFleet(hive, 0)
+	annotateDrift(hives2, latest, t0.Add(5*time.Minute))
+	sig2 := driftKindsOf(hives2[3].Drift)[DriftKindACMMUnset]
+	if sig2.FirstSeen != rfc(t0) {
+		t.Fatalf("FirstSeen drifted on recompute: %q, want stable %q", sig2.FirstSeen, rfc(t0))
+	}
+}
+
+func TestDriftFirstSeenResetsAfterSignalClears(t *testing.T) {
+	const hive = "first-seen-reset-hive"
+	latest := map[string]string{"v2": "abc1234"}
+	t0 := driftNow
+
+	annotateDrift(firstSeenFleet(hive, 0), latest, t0)
+
+	// The fault is fixed: the signal clears, and the tracker forgets it.
+	fixed := firstSeenFleet(hive, 3)
+	annotateDrift(fixed, latest, t0.Add(10*time.Minute))
+	if _, ok := driftKindsOf(fixed[3].Drift)[DriftKindACMMUnset]; ok {
+		t.Fatal("acmm-unset should have cleared at level 3")
+	}
+
+	// It recurs later: the stamp must be the recurrence time, not the
+	// resurrected original.
+	t2 := t0.Add(20 * time.Minute)
+	again := firstSeenFleet(hive, 0)
+	annotateDrift(again, latest, t2)
+	sig := driftKindsOf(again[3].Drift)[DriftKindACMMUnset]
+	if sig.FirstSeen != rfc(t2) {
+		t.Fatalf("recurrence FirstSeen = %q, want fresh %q", sig.FirstSeen, rfc(t2))
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -8412,13 +8412,36 @@ const dashboardHTML = `<!DOCTYPE html>
         s = s || {};
         var sc = DRIFT_SEVERITY_COLORS[s.severity] || DRIFT_SEVERITY_COLORS.info;
         var sevLabel = DRIFT_SEVERITY_LABELS[s.severity] || s.severity || 'Info';
+        /* First-seen: the server stamps when this (hive, kind) signal was
+           first observed and keeps it stable while the signal persists (see
+           stampDriftFirstSeen in drift.go). Rendered compactly ("since
+           3:42 PM" today, "since Jul 30, 3:42 PM" otherwise) with the full
+           absolute datetime as the title. An absent or unparseable stamp
+           (older hub, hand-built report) renders nothing rather than a
+           misleading "since Invalid Date". */
+        var since = '';
+        if (s.firstSeen) {
+          var fd = new Date(s.firstSeen);
+          if (!isNaN(fd.getTime())) {
+            var timeStr = fd.toLocaleTimeString([], {hour: 'numeric', minute: '2-digit'});
+            var label = fd.toDateString() === new Date().toDateString()
+              ? timeStr
+              : fd.toLocaleDateString([], {month: 'short', day: 'numeric'}) + ', ' + timeStr;
+            since = '<div style="color:var(--muted);font-size:0.62rem;margin-top:2px" title="' +
+              esc(fd.toLocaleString()) + '">since ' + esc(label) + '</div>';
+          }
+        }
+        /* overflow-wrap on the reason: a signal can quote an unbroken token
+           (an image ref, a URL, a pod name) longer than the panel is wide,
+           and without a break opportunity it runs out of the dialog. */
         return '<div style="padding:4px 0;border-top:1px solid var(--border)">' +
           '<div style="display:flex;align-items:center;gap:6px;margin-bottom:2px">' +
           '<span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:' + sc + ';flex:0 0 auto"></span>' +
           '<span style="color:' + sc + ';font-weight:600">' + esc(driftKindLabel(s.kind)) + '</span>' +
           '<span style="margin-left:auto;color:var(--muted);font-size:0.6rem;text-transform:uppercase;letter-spacing:0.04em">' + esc(sevLabel) + '</span>' +
           '</div>' +
-          '<div style="color:var(--muted);line-height:1.4">' + esc(s.reason || '') + '</div>' +
+          '<div style="color:var(--muted);line-height:1.4;overflow-wrap:anywhere;word-break:break-word">' + esc(s.reason || '') + '</div>' +
+          since +
           '</div>';
       }).join('');
 
@@ -8429,7 +8452,8 @@ const dashboardHTML = `<!DOCTYPE html>
         'color:' + c + ';background:rgba(255,255,255,0.04);border:1px solid ' + c + '">' + d.count + '</span>' +
         '<span class="hive-access-pop" style="display:none;position:absolute;right:0;top:calc(100% + 6px);z-index:60;' +
         'min-width:260px;max-width:380px;padding:8px 10px;border-radius:8px;border:1px solid var(--border);' +
-        'background:var(--surface);box-shadow:0 6px 20px rgba(0,0,0,0.35);font-size:0.72rem;text-align:left;font-weight:400;white-space:normal">' +
+        'background:var(--surface);box-shadow:0 6px 20px rgba(0,0,0,0.35);font-size:0.72rem;text-align:left;font-weight:400;' +
+        'white-space:normal;overflow-wrap:anywhere;word-break:break-word">' +
         '<span style="display:block;color:' + c + ';font-weight:600;margin-bottom:2px">' + esc(heading) + '</span>' +
         rows + '</span></span>';
     }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1055,11 +1055,14 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		// distinct reporters have ALTERNATED (A→B→A), so a normal rollout
 		// (A→B, B stays) never trips it.
 		ConflictingReporters: s.noteReporter(payload.HiveID, sanitizeField(payload.Reporter)),
-		// Advisory-staleness signal. Both are sanitized like every other
-		// spoke-reported string; an empty AdvisoryLastPostedAt is preserved as
-		// empty so the render/gate reads it as UNKNOWN rather than stale.
+		// Advisory-staleness signal. The timestamp is an identifier-shaped
+		// string; the error is prose (a sentence shown to a human), so it takes
+		// the prose sanitizer — html.EscapeString here plus the dashboard's own
+		// esc() double-escaped it into "&amp;amp;" artifacts. An empty
+		// AdvisoryLastPostedAt is preserved as empty so the render/gate reads
+		// it as UNKNOWN rather than stale.
 		AdvisoryLastPostedAt: sanitizeField(payload.AdvisoryLastPostedAt),
-		AdvisoryError:        sanitizeField(payload.AdvisoryError),
+		AdvisoryError:        sanitizeProseField(payload.AdvisoryError),
 		// Inference-backend auth-failure signal. Sanitized like every other
 		// spoke-reported string; empty is preserved as empty (no signal).
 		InferenceAuthError: sanitizeField(payload.InferenceAuthError),
@@ -1131,13 +1134,19 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			for i := range payload.Leaderboard {
 				payload.Leaderboard[i].HiveName = hiveName
 				payload.Leaderboard[i].GitHubUsername = sanitizeHeartbeatField(payload.Leaderboard[i].GitHubUsername)
-				payload.Leaderboard[i].CurrentTask = sanitizeHeartbeatField(payload.Leaderboard[i].CurrentTask)
+				// A task title is prose ("Fix the drift hover"), not an
+				// identifier — the strict sanitizer would strip its spaces.
+				payload.Leaderboard[i].CurrentTask = sanitizeProseField(payload.Leaderboard[i].CurrentTask)
 			}
 			return payload.Leaderboard
 		}(),
-		Online:                  true,
-		GitHubAppRequired:       payload.GitHubAppRequired,
-		GitHubAppPermIssue:      sanitizeHeartbeatField(payload.GitHubAppPermIssue),
+		Online:            true,
+		GitHubAppRequired: payload.GitHubAppRequired,
+		// GitHubAppPermIssue is a full sentence the drift hover renders
+		// verbatim ("The GitHub App is configured but has no installation.
+		// Install the app on your org to enable agents.") — the strict
+		// identifier sanitizer stripped every space out of it.
+		GitHubAppPermIssue:      sanitizeProseField(payload.GitHubAppPermIssue),
 		GitHubAppState:          sanitizeHeartbeatField(payload.GitHubAppState),
 		StatusFlipping:          s.noteStatusFlip(payload.HiveID, sanitizeHeartbeatField(payload.GitHubAppState)),
 		GitHubAppID:             payload.GitHubAppID,
@@ -1203,7 +1212,8 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	if payload.UpgradeFailed {
 		entry.Upgrading = false
 		entry.UpgradeFailed = true
-		entry.UpgradeError = sanitizeHeartbeatField(payload.UpgradeError)
+		// An upgrade failure cause is a sentence, not an identifier.
+		entry.UpgradeError = sanitizeProseField(payload.UpgradeError)
 		entry.UpgradeFailedAt = time.Now()
 		s.mu.Lock()
 		delete(s.heartbeatUpgrade, payload.HiveID)
@@ -2695,6 +2705,60 @@ func sanitizeHeartbeatField(s string) string {
 		}
 	}
 	return b.String()
+}
+
+// maxProseFieldRunes bounds a sanitized prose field. Prose fields carry full
+// sentences (an App-permission diagnosis, an upgrade failure cause), so the cap
+// is generous — but a hostile or broken spoke must still not be able to bloat
+// the registry with megabytes of "detail".
+const maxProseFieldRunes = 500
+
+// sanitizeProseField sanitizes a spoke-reported HUMAN-READABLE string — a
+// sentence the dashboard renders verbatim to a person, such as
+// GitHubAppPermIssue, UpgradeError, AdvisoryError, a leaderboard task title, or
+// a health-check detail.
+//
+// This is DELIBERATELY separate from sanitizeHeartbeatField. That allowlist is
+// for identifiers (hive IDs, branches, owners, agent states) where a space is
+// never legal — but applied to prose it deletes every space and renders
+// "The GitHub App is configured but has no installation." as
+// "TheGitHubAppisconfiguredbuthasnoinstallation.", which is exactly the
+// mangling this variant exists to end. Identifiers keep the strict sanitizer;
+// only fields whose value is a sentence go through this one.
+//
+// What it keeps: letters, digits, spaces, and normal punctuation — the text
+// stays a readable sentence.
+//
+// What it still neutralizes:
+//   - '<', '>' and '&' are dropped, so no tag and no entity can ever be formed
+//     even if a future render path forgets to escape;
+//   - backticks are dropped (they are fenced-code/template metacharacters in
+//     every surface this text could be pasted into);
+//   - newlines, carriage returns and tabs become single spaces (these fields
+//     are one-line UI strings and log fields);
+//   - all other control characters (including ESC, so ANSI sequences cannot
+//     ride along) are dropped;
+//   - runs of whitespace collapse to one space and the result is trimmed;
+//   - length is capped at maxProseFieldRunes.
+func sanitizeProseField(s string) string {
+	var b strings.Builder
+	for _, c := range s {
+		switch {
+		case c == '\n' || c == '\r' || c == '\t':
+			b.WriteRune(' ')
+		case c < 0x20 || c == 0x7f:
+			// Other control characters (incl. ESC): dropped entirely.
+		case c == '<' || c == '>' || c == '&' || c == '`':
+			// HTML/markup-dangerous: dropped.
+		default:
+			b.WriteRune(c)
+		}
+	}
+	out := strings.Join(strings.Fields(b.String()), " ")
+	if runes := []rune(out); len(runes) > maxProseFieldRunes {
+		out = string(runes[:maxProseFieldRunes])
+	}
+	return out
 }
 
 // sanitizeImageRef sanitizes a container image reference reported by a spoke.


### PR DESCRIPTION
Fixes three defects in the hub dashboard's drift-signals hover, all observed live.

## 1. Space-stripped prose

The "GitHub App permissions" signal rendered its detail as
"TheGitHubAppisconfiguredbuthasnoinstallation.Installtheapponyourorgtoenableagents." — the same mangling visible in raw registry dumps of `githubAppPermIssue`. Cause: spoke-reported human-readable sentences went through `sanitizeHeartbeatField`, an identifier allowlist that deletes spaces (and all punctuation beyond `-_./`).

New `sanitizeProseField` (pkg/hub/server.go) for fields whose value is a sentence:
- keeps interior spaces and normal punctuation;
- folds newlines/CR/tabs to single spaces, collapses whitespace runs, trims;
- drops all other control characters (including ESC, so ANSI sequences cannot ride along);
- drops `<`, `>`, `&` and backticks so no tag or entity can ever be formed even if a render path forgets to escape;
- caps length at a named constant (500 runes).

Fields moved to the prose sanitizer (every `sanitizeHeartbeatField` call site was audited):
- `GitHubAppPermIssue` (the signal seen live)
- `UpgradeError`
- `AdvisoryError` (was `sanitizeField`/`html.EscapeString`, which double-escaped against the dashboard's own `esc()`)
- leaderboard `CurrentTask` (a task title, not an identifier)
- health-check `name`/`status`/`detail` at composition time in `healthFailingChecks` (pkg/hub/drift.go) — the health map is stored free-form, so the strings are neutralized where they enter a hub-rendered reason

Identifiers (hive ID, org, repos, branches, versions, agent names/states, usernames, governor mode, hosts, cluster ID, App state) keep the strict sanitizer unchanged.

## 2. First-seen timestamps

Drift signals now carry `firstSeen` (RFC3339), stamped hub-side in `annotateDrift` via a keyed (hive, kind) map (`stampDriftFirstSeen`, pkg/hub/drift.go):
- stable across recomputes while the signal stays present (keyed by kind, not reason, so a mutating reason like "No heartbeat for 3 min" -> "4 min" does not re-stamp);
- cleared when the signal clears; a recurrence gets a fresh stamp;
- the hover renders "since 3:42 PM" (today) or "since Jul 30, 3:42 PM", with the full absolute datetime as the title.

**Note:** the tracker is in-memory only. A hub restart re-baselines every "since" to the first recompute after boot — accepted trade for keeping disk writes off the hottest read path; the stamp is a triage aid, not an audit record.

## 3. Overflow

Long unbreakable tokens (image refs, URLs, pod names) ran out of the hover dialog. The reason container and the panel now carry `overflow-wrap:anywhere; word-break:break-word`.

## Tests

`pkg/hub/drift_first_seen_test.go`:
- prose sanitizer preserves the live-observed sentence verbatim while neutralizing control chars/markup; length cap; identifier sanitizer still strict;
- end-to-end through `handleHeartbeat`: prose fields keep spaces, identifiers on the same payload stay strict;
- `healthFailingChecks` keeps spaces, strips markup;
- first-seen stable across two annotate rounds while the signal persists; resets after it clears and recurs.

Mutation-tested: re-stripping spaces in the prose variant fails 4 tests; re-stamping first-seen every round fails the stability test.

`go build ./...` and the full `go test ./pkg/hub/` suite pass; dashboard JS structure tests green (no backticks introduced into the raw-string HTML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)