### PR TITLE
🐛 agent: announce aborted launches in the tmux pane instead of leaving a silent bare shell

### DIFF
--- a/v2/pkg/agent/launch_failure_banner_test.go
+++ b/v2/pkg/agent/launch_failure_banner_test.go
@@ -1,0 +1,131 @@
+package agent
+
+// Tests for the loud-launch-failure fix: a launch that launchInTmux aborts
+// before typing anything (missing backend binary, bob with no API key) must
+// announce itself IN the agent's tmux pane instead of leaving a silent bare
+// shell. Observed live: a hosted hive's "quality" agent switched to backend
+// "bob" and restarted showed only an idle bash prompt in ttyd, with the only
+// explanation in the hive log.
+//
+// backendBinary resolves through exec.LookPath, so both branches are driven
+// deterministically here by pointing PATH at a temp dir: empty for the
+// missing-binary branch, containing a stub `bob` executable for the
+// missing-key branch. No tmux server is needed — the pane writes are
+// best-effort and the composed banner is recorded on the agent.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+func TestLaunchFailureBanner(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want []string
+	}{
+		{
+			name: "plain message is prefixed and single-quoted",
+			msg:  "backend bob did not launch",
+			want: []string{"echo '" + launchFailurePrefix + "backend bob did not launch'"},
+		},
+		{
+			name: "single quotes and newlines cannot break the quoting",
+			msg:  "it's broken\nsecond line",
+			want: []string{"echo '", "it s broken second line'"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := launchFailureBanner(tc.msg)
+			for _, w := range tc.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("launchFailureBanner(%q) = %q, want it to contain %q", tc.msg, got, w)
+				}
+			}
+			if strings.Count(got, "'") != 2 {
+				t.Errorf("launchFailureBanner(%q) = %q, want exactly the two wrapping single quotes", tc.msg, got)
+			}
+		})
+	}
+}
+
+// TestMissingBinaryLaunchAnnouncesInPane pins the loud half of the
+// missing-binary branch: the pane banner must name the attempted backend and
+// that its binary was not found, and the agent must be parked failed with the
+// reason surfaced to the dashboard via LastError.
+func TestMissingBinaryLaunchAnnouncesInPane(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // empty dir: no bob anywhere on PATH
+
+	m := &Manager{logger: discardLogger()}
+	m.SetBobAPIKeyResolver(func() string { return "key-present-but-irrelevant" })
+
+	agent := &AgentProcess{
+		Name:   "quality",
+		Config: config.AgentConfig{Backend: bobBackend},
+	}
+	if err := m.launchInTmux(t.Context(), agent); err != nil {
+		t.Fatalf("launchInTmux returned error, want nil so one agent never aborts the fleet: %v", err)
+	}
+	if agent.State != StateFailed {
+		t.Errorf("State = %q, want %q", agent.State, StateFailed)
+	}
+	banner := agent.lastLaunchFailureBanner
+	if banner == "" {
+		t.Fatal("lastLaunchFailureBanner is empty — the aborted launch left a silent bare shell, which is the exact bug this fix exists for")
+	}
+	for _, want := range []string{launchFailurePrefix, "bob", "not found", "hive image"} {
+		if !strings.Contains(banner, want) {
+			t.Errorf("banner %q does not contain %q", banner, want)
+		}
+	}
+	if agent.LastError == "" || !strings.Contains(agent.LastError, "not found") {
+		t.Errorf("LastError = %q, want the missing-binary reason so the dashboard can show it", agent.LastError)
+	}
+}
+
+// TestBobMissingKeyLaunchAnnouncesInPane pins the loud half of the missing-key
+// branch: with the bob binary present but no key configured, the pane banner
+// must name the missing credential (BOBSHELL_API_KEY — the name, never a
+// value) and where to save it.
+func TestBobMissingKeyLaunchAnnouncesInPane(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "bob")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("writing stub bob binary: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	m := &Manager{logger: discardLogger()}
+	m.SetBobAPIKeyResolver(func() string { return "" })
+
+	agent := &AgentProcess{
+		Name:   "quality",
+		Config: config.AgentConfig{Backend: bobBackend},
+	}
+	if err := m.launchInTmux(t.Context(), agent); err != nil {
+		t.Fatalf("launchInTmux returned error, want nil so one agent never aborts the fleet: %v", err)
+	}
+	if agent.State != StateFailed {
+		t.Errorf("State = %q, want %q", agent.State, StateFailed)
+	}
+	if !agent.awaitingBobKey {
+		t.Error("awaitingBobKey = false, want true — the key-save relaunch cannot find this agent without the marker")
+	}
+	banner := agent.lastLaunchFailureBanner
+	if banner == "" {
+		t.Fatal("lastLaunchFailureBanner is empty — the aborted launch left a silent bare shell, which is the exact bug this fix exists for")
+	}
+	for _, want := range []string{launchFailurePrefix, config.BobAPIKeyEnvVar, "API key", "Governor"} {
+		if !strings.Contains(banner, want) {
+			t.Errorf("banner %q does not contain %q", banner, want)
+		}
+	}
+	if agent.LastError == "" || !strings.Contains(agent.LastError, config.BobAPIKeyEnvVar) {
+		t.Errorf("LastError = %q, want the missing-key reason so the dashboard can show it", agent.LastError)
+	}
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -111,6 +111,17 @@ type AgentProcess struct {
 	// save would restart agents whose problem the key does not fix.
 	// Set only on the missing-key branch, cleared on every launch attempt.
 	awaitingBobKey bool
+
+	// lastLaunchFailureBanner is the exact in-pane shell line typed by the most
+	// recent aborted launch (see announceLaunchFailureInPane), "" after a
+	// successful launch. A launch aborted before send-keys used to leave a
+	// BARE interactive shell with the only explanation in the hive log — an
+	// operator attached via ttyd saw a silent prompt and nothing else
+	// (observed live: backend "bob" on a hive whose launch was refused). The
+	// pane itself is the production surface for the banner; this field exists
+	// so tests can assert the announcement actually happened without a tmux
+	// server.
+	lastLaunchFailureBanner string
 }
 
 // effectiveBackend returns the agent's backend accounting for any override.
@@ -955,7 +966,15 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	binary, err := backendBinary(backend)
 	if err != nil {
 		agent.State = StateFailed
+		agent.LastError = err.Error()
 		m.logger.Warn("backend binary not found", "name", agent.Name, "backend", backend, "error", err)
+		// The tmux session already exists (Start/Restart ran ensureTmuxSession
+		// before this), so without a banner the pane is a silent bare shell —
+		// the operator attaches and sees a prompt, not a failure. Say which
+		// binary was attempted, that it is missing, and what to do.
+		m.announceLaunchFailureInPane(agent, fmt.Sprintf(
+			"backend %s did not launch: %v. The CLI for this backend is not installed in this hive image — upgrade the hive image or switch this agent to a different backend.",
+			backend, err))
 		return nil
 	}
 
@@ -977,12 +996,20 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		if m.bobAPIKey() == "" {
 			agent.State = StateFailed
 			agent.awaitingBobKey = true
+			agent.LastError = "no bob API key configured (" + config.BobAPIKeyEnvVar + ")"
 			m.logger.Warn("bob requires "+config.BobAPIKeyEnvVar+" for headless operation; ask your hub admin to configure it",
 				"name", agent.Name,
 				"backend", backend,
 				"remedy", "set governor.bob.api_key_file (e.g. "+config.DefaultBobAPIKeyFile+
 					") or the "+config.DefaultBobAPIKeyEnv+" env var on the hive pod",
 			)
+			// Same silent-bare-shell hazard as the missing-binary branch above:
+			// the session exists, nothing was typed, and the log line is
+			// invisible from the terminal. Name the missing credential (never
+			// its value) and the remedy in the pane itself.
+			m.announceLaunchFailureInPane(agent, fmt.Sprintf(
+				"backend bob did not launch: no API key is configured (%s). Save an IBM bob API key in the dashboard under Governor -> Bob — parked bob agents relaunch automatically when a key is saved.",
+				config.BobAPIKeyEnvVar))
 			return nil
 		}
 		// Re-assert hive's ownership of the SHARED /data/home/.bob/settings.json
@@ -1170,6 +1197,8 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		m.logger.Info("CLI already running in tmux pane, skipping launch", "name", agent.Name, "session", agent.tmuxSession)
 		now := time.Now()
 		agent.State = StateRunning
+		agent.LastError = ""
+		agent.lastLaunchFailureBanner = ""
 		agent.StartedAt = &now
 
 		agentCtx, cancel := context.WithCancel(ctx)
@@ -1242,6 +1271,11 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 
 	now := time.Now()
 	agent.State = StateRunning
+	// A prior aborted launch is history the moment a real one succeeds; a
+	// stale "no API key" reason lingering after a key-save relaunch would
+	// send an operator chasing a problem that no longer exists.
+	agent.LastError = ""
+	agent.lastLaunchFailureBanner = ""
 	agent.StartedAt = &now
 	agent.launchGen++
 	m.logger.Info("audit: agent started",
@@ -2705,6 +2739,45 @@ func (m *Manager) deliverStartupKick(agent *AgentProcess, prompt string, gen int
 // tmuxSendLiteralForAgent sends text using the agent's tmux socket.
 func (m *Manager) tmuxSendLiteralForAgent(agent *AgentProcess, text string) {
 	_ = m.tmuxCmd(agent, "send-keys", "-t", agent.tmuxSession, "-l", text).Run()
+}
+
+// launchFailurePrefix opens every in-pane launch-failure banner so the line is
+// unmistakable in a pane full of shell prompts and greppable in scrollback.
+const launchFailurePrefix = "HIVE LAUNCH FAILED: "
+
+// launchFailureBanner composes the exact shell line typed into a pane when a
+// launch is aborted before any CLI starts. The message is wrapped in single
+// quotes; any single quotes, newlines, or carriage returns inside it are
+// replaced with spaces so the line can never break out of the quoting or
+// leave bash in PS2 continuation (the same hazard the C-c before every real
+// launch guards against).
+func launchFailureBanner(msg string) string {
+	sanitized := strings.Map(func(r rune) rune {
+		switch r {
+		case '\'', '\n', '\r':
+			return ' '
+		}
+		return r
+	}, msg)
+	return "echo '" + launchFailurePrefix + sanitized + "'"
+}
+
+// announceLaunchFailureInPane makes an aborted launch visible IN the agent's
+// tmux pane. launchInTmux's park-and-return branches (missing backend binary,
+// bob with no API key) run after ensureTmuxSession has already created a
+// fresh shell, so returning silently leaves a bare prompt: the operator
+// attaches via ttyd, sees nothing wrong, and the only explanation is in the
+// hive log they are not reading. Typing an echo into the pane puts the reason
+// and the remedy exactly where the operator is looking.
+//
+// Best-effort by design: the send-keys errors are ignored like every other
+// pane write on the launch path — a missing session must not turn a parked
+// agent into a crashed manager. Caller holds m.mu (same discipline as
+// launchInTmux, which is its only caller).
+func (m *Manager) announceLaunchFailureInPane(agent *AgentProcess, msg string) {
+	agent.lastLaunchFailureBanner = launchFailureBanner(msg)
+	m.tmuxSendLiteralForAgent(agent, agent.lastLaunchFailureBanner)
+	m.tmuxSendKeysForAgent(agent, "Enter")
 }
 
 // dismissInferencePrompts polls the tmux pane for Claude Code interactive


### PR DESCRIPTION
## Problem

An agent configured with backend `bob` can show a **bare idle shell** in its tmux session after a restart — the CLI never launches and no error is visible anywhere the operator is looking (observed live: a quality agent switched to bob and restarted showed only `hive-quality@hive-...:/data/agents/quality$`).

## Root cause

`launchInTmux` has two park-and-return branches that abort a launch **before any keys are sent to the pane**:

1. backend binary not found on PATH (`backendBinary` lookup fails), and
2. backend `bob` with no API key resolvable at launch time.

Both run *after* `Start`/`Restart` have already created the session and respawned a fresh shell via `ensureTmuxSession`, so the pane is left as a pristine bash prompt. The agent is parked `StateFailed`, but the only explanation is a `logger.Warn` in the hive log — the terminal the operator attaches to says nothing. (The bobshell CLI itself is installed and pinned in the image — Dockerfile layer 9, hard-failing with `which bob` — and the key env/command composition chain is intact; the failure was purely silent, not structural.)

## Fix

Both abort branches now:

- **Type a loud banner into the pane** (`HIVE LAUNCH FAILED: ...`) naming what was attempted and why it could not launch — the missing binary, or the missing `BOBSHELL_API_KEY` credential (name only, never a value) — plus the remedy. The shell line is single-quote wrapped with quotes/newlines sanitized so it can never break out of quoting or leave bash in PS2 continuation.
- **Record the reason in `agent.LastError`**, which the status builder already surfaces, so the dashboard's failed state says *why* ("it failed to start: ...").

Classification was already correct — `StateFailed` reads as down, and `BackendAuthAvailable("bob")` already feeds the needs-auth seam for the missing-key case — so no new state was invented; the missing piece was in-session visibility. A successful launch clears the banner and `LastError` so a stale reason cannot outlive a key-save relaunch.

## Tests

- `TestLaunchFailureBanner` — banner composition + quoting safety.
- `TestMissingBinaryLaunchAnnouncesInPane` — drives `launchInTmux` with an empty PATH; asserts the banner names the backend, the missing binary, and the remedy, and that `LastError` is set.
- `TestBobMissingKeyLaunchAnnouncesInPane` — drives `launchInTmux` with a stub `bob` on PATH and an empty key resolver; asserts the banner names `BOBSHELL_API_KEY` and the Governor → Bob remedy, `awaitingBobKey` stays set, and `LastError` is set.

Mutation-verified: removing either announce call fails the corresponding new test; removing the `BOBSHELL_API_KEY` env injection fails the existing `TestBobEnvPairInjection`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)