### PR TITLE
🐛 fix(hub): parse the org from a GHE org URL, not the host (claim path)

### DIFF
--- a/v2/pkg/hub/normalize_org_ghe_host_test.go
+++ b/v2/pkg/hub/normalize_org_ghe_host_test.go
@@ -1,0 +1,94 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestNormalizeOrgRef_GHEHostOnly is the regression for the claim-path bug that
+// produced two broken CLAIMED hives on the vllm-d (github.ibm.com) cluster:
+// pasting ONLY the GHE forge host into the "GitHub Organization" field captured
+// the HOSTNAME as the org (org="github.ibm.com"), dropping the real org and
+// minting a vanity URL from <host>-<repo>. A bare forge host with no path must
+// resolve to (host, "") so the caller rejects it, never (,"github.ibm.com").
+func TestNormalizeOrgRef_GHEHostOnly(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		wantHost string
+		wantOrg  string
+	}{
+		// The bug: a lone GHE/public host must NOT become the org.
+		{"ghe host bare", "github.ibm.com", "github.ibm.com", ""},
+		{"ghe host https", "https://github.ibm.com", "github.ibm.com", ""},
+		{"ghe host trailing slash", "https://github.ibm.com/", "github.ibm.com", ""},
+		{"public host bare", "github.com", "github.com", ""},
+		{"public host https", "https://github.com", "github.com", ""},
+		{"another ghe host", "github.cisco.com", "github.cisco.com", ""},
+
+		// Still-correct behaviour: a host WITH an org path splits normally.
+		{"ghe host with org", "https://github.ibm.com/z-aiops-unite", "github.ibm.com", "z-aiops-unite"},
+		{"ghe host with org no scheme", "github.ibm.com/z-aiops-unite", "github.ibm.com", "z-aiops-unite"},
+
+		// A bare org name (even one containing a dot) is untouched — the fix keys
+		// on the "github." forge prefix, so a real org is never reclassified.
+		{"bare org", "z-aiops-unite", "", "z-aiops-unite"},
+		{"bare org with dot", "my.org", "", "my.org"},
+		{"empty", "", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			host, org := normalizeOrgRef(tc.in)
+			if host != tc.wantHost || org != tc.wantOrg {
+				t.Fatalf("normalizeOrgRef(%q) = (%q, %q); want (%q, %q)",
+					tc.in, host, org, tc.wantHost, tc.wantOrg)
+			}
+		})
+	}
+}
+
+// TestAssignHive_RejectsBareGHEHostAsOrg is the end-to-end regression for the
+// exact path that produced hosted-available-vllmd-02 / -09: an admin (or the
+// claim UI) submits a bare GHE forge host in the org field. The assign handler
+// must 400 — never store the hostname as the org. Before the fix, isValidName
+// accepted "github.ibm.com" (dots are legal in names), so the host was silently
+// stored as the org and the hive was claimed against host-as-org.
+func TestAssignHive_RejectsBareGHEHostAsOrg(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+	s := newHandlerHub2()
+
+	for _, orgField := range []string{"github.ibm.com", "https://github.ibm.com", "https://github.ibm.com/"} {
+		saveSaaSHive(&SaaSHive{ID: "ph-hostorg", Owner: hubAdminUsername, Status: statusAvailable, ClusterID: "hive-oke"})
+		body := `{"owner":"bob","org":"` + orgField + `","repos":"forthehive","primary_repo":"forthehive"}`
+		rec := httptest.NewRecorder()
+		req := setPathValue(reqWithUser(http.MethodPost, "/assign", body, hubAdminUsername), "id", "ph-hostorg")
+		s.handleAssignHive(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("assign with org=%q status = %d, want 400 (body=%s)", orgField, rec.Code, rec.Body.String())
+		}
+		// And it must NOT have persisted the host as the org.
+		if got := loadSaaSHive("ph-hostorg"); got != nil && got.Org == "github.ibm.com" {
+			t.Fatalf("assign with org=%q stored the host as the org: %q", orgField, got.Org)
+		}
+	}
+
+	// A proper GHE org URL still assigns cleanly and records the real org + host.
+	saveSaaSHive(&SaaSHive{ID: "ph-realorg", Owner: hubAdminUsername, Status: statusAvailable, ClusterID: "hive-oke"})
+	body := `{"owner":"bob","org":"https://github.ibm.com/z-aiops-unite","repos":"forthehive","primary_repo":"forthehive"}`
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/assign", body, hubAdminUsername), "id", "ph-realorg")
+	s.handleAssignHive(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("assign with real GHE org URL status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	got := loadSaaSHive("ph-realorg")
+	if got == nil || got.Org != "z-aiops-unite" {
+		t.Fatalf("real GHE org not parsed from URL: %+v", got)
+	}
+	if got.GitHubHost != "github.ibm.com" {
+		t.Errorf("GHE host not recorded from org URL: GitHubHost = %q, want github.ibm.com", got.GitHubHost)
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -6304,10 +6304,15 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Accept a pasted org/repo URL here too — an admin assigning a hive reaches
-	// for the same paste the requester did.
-	if h, o := normalizeOrgRef(body.Org); o != "" {
-		body.Org = o
-		if h != "" && body.GitHubHost == "" {
+	// for the same paste the requester did. normalizeOrgRef returns a non-empty
+	// host with an EMPTY org when the field held only a forge host
+	// ("github.ibm.com") and no org — clear body.Org in that case so the
+	// isValidName check below rejects it, instead of the raw hostname (which
+	// isValidName accepts, dots and all) silently becoming the org. That
+	// host-as-org bug produced the two broken github.ibm.com claims on vllm-d.
+	if h, o := normalizeOrgRef(body.Org); h != "" {
+		body.Org = o // may be "" for a bare-host paste — rejected just below
+		if body.GitHubHost == "" {
 			body.GitHubHost = h
 		}
 	}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -394,6 +394,18 @@ func normalizeForgeHost(s string) (string, bool) {
 //	https://github.ibm.com/z-aiops-unite  -> ("github.ibm.com", "z-aiops-unite")
 //	github.ibm.com/z-aiops-unite          -> ("github.ibm.com", "z-aiops-unite")
 //	z-aiops-unite                         -> ("",               "z-aiops-unite")
+//	https://github.ibm.com                -> ("github.ibm.com", "")
+//	github.ibm.com                        -> ("github.ibm.com", "")
+//
+// The last two cases are the claim-path footgun this guards: a user who reads
+// "GitHub Organization" and pastes ONLY the forge host (no org segment) must
+// NOT have that hostname captured as the org. Before this, "github.ibm.com"
+// with no path fell through to the bare-name return and became org
+// "github.ibm.com" — the hive was then claimed against host-as-org, its vanity
+// URL minted from <host>-<repo>, and agents targeted github.ibm.com/<repo>.
+// Returning ("host", "") instead leaves the org empty, so the caller's
+// isValidName("") check rejects the paste with the "use the org name or its
+// URL" message rather than silently storing a broken project.
 func normalizeOrgRef(s string) (host, org string) {
 	s = strings.TrimSpace(s)
 	s = strings.TrimPrefix(s, "https://")
@@ -409,7 +421,33 @@ func normalizeOrgRef(s string) (host, org string) {
 	if len(parts) > 1 && strings.Contains(parts[0], ".") {
 		return parts[0], parts[1]
 	}
+	// A lone segment with no path that is itself a GitHub forge host is a host,
+	// not an org — the user pasted the forge URL into the org field and left the
+	// real org out. Recognise "github.<something>" (github.com, github.ibm.com,
+	// github.cisco.com, …) so the hostname is never mistaken for the org. A
+	// legitimate org that merely contains a dot ("my.org") does not start with
+	// "github." and is untouched.
+	if len(parts) == 1 && looksLikeGitHubForgeHost(parts[0]) {
+		return parts[0], ""
+	}
 	return "", parts[0]
+}
+
+// looksLikeGitHubForgeHost reports whether a bare label is a GitHub forge
+// hostname (github.com or a GitHub Enterprise host like github.ibm.com) rather
+// than an org name. GitHub Enterprise hosts are conventionally "github.<org
+// domain>", and the public host is "github.com"; both start with "github." and
+// carry at least two dot-separated labels. This is deliberately narrow: it must
+// never reclassify a real org that happens to contain a dot, so it keys on the
+// "github." prefix that only a forge host carries. Case-insensitive.
+func looksLikeGitHubForgeHost(label string) bool {
+	l := strings.ToLower(strings.TrimSpace(label))
+	if !strings.HasPrefix(l, "github.") {
+		return false
+	}
+	// "github." alone (a trailing-dot typo) is not a host; require a non-empty
+	// domain after the prefix, i.e. at least two labels total.
+	return len(strings.Split(l, ".")) >= minForgeHostLabels && !strings.HasSuffix(l, ".")
 }
 
 // normalizeRepoRef strips a GitHub URL or "org/repo" prefix down to the bare


### PR DESCRIPTION
## Problem

`normalizeOrgRef` captured a bare GitHub **forge host** as the **org**, and the assign handler stored it. When a user reads "GitHub Organization" and pastes only the forge URL — `https://github.ibm.com`, `github.ibm.com`, or `https://github.ibm.com/` — with no org path segment, the lone dotted segment fell through to the bare-name return (`return "", parts[0]`) and became the org. The assign handler's own guard did not catch it either: `isValidName` permits dots (hostnames need them), so `isValidName("github.ibm.com")` is true and the raw hostname was persisted as the org.

## Live evidence (vllm-d / github.ibm.com cluster)

Two **CLAIMED, broken** hives:

| hive | org (stored) | primary_repo | vanity |
|---|---|---|---|
| `hosted-available-vllmd-02` (BluePixelAI) | `github.ibm.com` | `forthehive` | `hosted-githubibmcom-forthehive-…` |
| `hosted-available-vllmd-09` (lee-cooper500) | `github.ibm.com` | `lee-cooper` | `hosted-githubibmcom-lee-cooper-…` |

Both vanity URLs are `<host>-<repo>` with the real org dropped — proof the org was literally `github.ibm.com` at claim time. Consequences: agents target `github.ibm.com/<repo>` (wrong org path), and because App-installation auto-discovery keys on the org, `GET /orgs/github.ibm.com/installation` 404s forever, so `installation_id` stays 0.

## Root cause

`normalizeOrgRef` (`v2/pkg/hub/server.go`) only treated the leading segment as a host when a path segment followed it:

```go
if len(parts) > 1 && strings.Contains(parts[0], ".") { return parts[0], parts[1] }
return "", parts[0]  // a lone "github.ibm.com" lands here -> org = the host
```

A lone forge host was never recognised as a host — and `isValidName` downstream accepts a dotted hostname, so nothing rejected it.

## Fix (two parts)

1. **`normalizeOrgRef`** recognises a bare `github.<domain>` forge host (public or GHE) with no path and returns `(host, "")` instead of `("", host)`. A legitimate org that merely contains a dot (`my.org`) does not start with `github.` and is untouched.
2. **`handleAssignHive`** clears `body.Org` when `normalizeOrgRef` reports a host with an empty org, so the existing *"invalid org name — use the org name or its URL (e.g. github.ibm.com/my-org)"* 400 fires instead of the raw hostname surviving `isValidName` and being stored as the org. The request-submit path (`handleSubmitProvisionRequest`) already assigned `body.Org = orgName` unconditionally, so it was already covered.

## Tests

`v2/pkg/hub/normalize_org_ghe_host_test.go`:
- Unit table: bare/https/trailing-slash GHE + public hosts return `(host, "")`; host+org URLs still split; dot-containing bare orgs untouched.
- End-to-end `handleAssignHive`: a bare GHE host in the org field returns 400 and is never persisted as org; a real GHE org URL returns 200 with `org="z-aiops-unite"` and `github_host="github.ibm.com"`.

`cd v2 && go build ./...` clean; `go test ./pkg/hub/ -short` green (full package, 113s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
