### PR TITLE
🔀 Sync dd with latest v2 (2026-08-03)

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -39,6 +39,11 @@ const BASE_RECONNECT_DELAY_MS = 1000;
 const TOKEN_REFRESH_MARGIN_MS = 300000;
 const MAX_TASK_DURATION_MS = 1800000;
 const NETWORK_ERROR_RETRY_DELAY_MS = 5000;
+// After the hub sends an explicit task_unavailable negative-ack (no admissible
+// work, a disabled tier, a concurrency limit, or a token-mint failure — see
+// kubestellar/hive#2436), wait before re-asking so we neither hang forever
+// (the old silent-nil behaviour) nor busy-loop the hub.
+const TASK_UNAVAILABLE_RETRY_MS = 30000;
 
 // Per-task CLI-crash retry budget. Issue #2203: a task whose CLI kept dying was
 // reassigned by the hub and failed identically forever (5+ times in ~20min),
@@ -778,6 +783,20 @@ function handleMessage(data) {
       taskAssignedAt = 0;
       if (progressInterval) { clearInterval(progressInterval); progressInterval = null; }
       send({ type: 'ready', seq: nextSeq() });
+      break;
+
+    case 'task_unavailable':
+      // #2436 finding 1/2/3: the hub explicitly declined to assign work and told
+      // us why (reason: no_work / token_mint_failed / tier_disabled /
+      // concurrency_limit). Surface the reason instead of hanging silently, then
+      // re-ask after a delay so a transient condition (a freed slot, a fixed
+      // installation permission) recovers on its own.
+      console.log(`No task assigned — reason: ${msg.reason || 'unspecified'}; retrying in ${TASK_UNAVAILABLE_RETRY_MS / 1000}s`);
+      setTimeout(() => {
+        if (ws && ws.readyState === WebSocket.OPEN && !currentTask) {
+          send({ type: 'ready', seq: nextSeq() });
+        }
+      }, TASK_UNAVAILABLE_RETRY_MS);
       break;
 
     case 'ping':

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -727,7 +727,14 @@ func main() {
 		return
 	}
 
-	cfg, err := config.Load(*configPath)
+	// Use LoadWithDashboardOverlay (not plain Load) so the dashboard overlay's
+	// removed_agents tombstones are populated into cfg.RemovedAgents at boot —
+	// BEFORE the startup ApplyPack below reconciles the ACMM roster. Plain Load
+	// never reads the overlay, so on restart the tombstone was invisible and
+	// ApplyPack re-added deleted pack agents (brainstorm/guide) every time
+	// (#2439). Same return signature as Load; falls back to the seed when no
+	// overlay exists or the pod is not in Kubernetes.
+	cfg, err := config.LoadWithDashboardOverlay(*configPath)
 	if err != nil {
 		logger.Error("failed to load config", "error", err)
 		os.Exit(1)
@@ -2036,6 +2043,18 @@ func main() {
 		if cfg.ACMMLevel != nil {
 			newCfg.ACMMLevel = cfg.ACMMLevel
 		}
+
+		// Preserve removed-agent tombstones across the swap as a union of the
+		// live cfg and the incoming reload. LoadWithDashboardOverlay now carries
+		// the overlay's tombstones into newCfg, but a removal that landed in the
+		// live cfg after this reload's snapshot (or an overlay too short/stale to
+		// echo it back yet) must not be lost — otherwise the next persistState
+		// saver rewrites every layer tombstone-free and the deleted agents
+		// reappear (#2439). Union keeps any tombstone present in either side.
+		for _, name := range cfg.RemovedAgents {
+			newCfg.MarkAgentRemoved(name)
+		}
+		newCfg.PruneRemovedAgents()
 
 		// Capture the outgoing GitHub App identity before the swap so we can
 		// tell whether the reload changed it.

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -665,6 +665,17 @@ func startDocsTokenRefresh(ctx context.Context, cfg *config.Config, appKeyFile s
 // short uptime that keeps resetting is the only visible tell.
 var processStartedAt = time.Now()
 
+// reporterName identifies this spoke process to the hub (HeartbeatPayload
+// Reporter). In-cluster the hostname IS the pod name; on failure it stays
+// empty, which the hub reads as "too old / cannot report", never as data.
+var reporterName, _ = os.Hostname()
+
+// spokeRestartMinUptime is how old this process must be before it acts on a
+// hub-delivered restart. The hub delivers the instruction to every beat in a
+// multi-minute window so all instances hear it; without this guard the
+// restarted process would come back inside the same window and restart again.
+const spokeRestartMinUptime = 10 * time.Minute
+
 func main() {
 	startTime := time.Now()
 	defaultConfig := "/etc/hive/hive.yaml"
@@ -2449,6 +2460,10 @@ func main() {
 				AIAuthor:          cfg.Project.AIAuthor,
 				AIAuthorEffective: cfg.EffectiveAIAuthor(),
 				StartedAt:         processStartedAt.UTC().Format(time.RFC3339),
+				// Reporter names THIS process (the pod) so the hub can tell two
+				// instances reporting as one hive apart — the pod name is the
+				// hostname inside the container.
+				Reporter: reporterName,
 				// Advisory-staleness signal (mirrors StartedAt/uptime). Report the
 				// last successful digest-post time only if the spoke has actually
 				// posted one — a zero time is left as an empty string so the hub
@@ -2601,7 +2616,23 @@ func main() {
 				// and then stops re-sending them.
 				GitHubAppKeysHeld: heldPerAppIDKeyFingerprints(),
 			}
-		}, heartbeatSendInterval, logger, hub.UpgradeCallback(func(targetSHA string) {
+		}, heartbeatSendInterval, logger, hub.RestartSpokeCallback(func() {
+			if up := time.Since(processStartedAt); up < spokeRestartMinUptime {
+				logger.Info("hub requested a spoke restart; ignoring — this process just started",
+					"uptime", up.Round(time.Second))
+				return
+			}
+			logger.Warn("hub requested a spoke restart — rolling this deployment",
+				"reporter", reporterName)
+			if err := hub.RolloutRestartSelf(logger); err != nil {
+				// Do NOT exit here: without deployment-patch RBAC an exit would
+				// restart onto the same state every delivery and look like a
+				// crash-loop. The error names the missing Role instead.
+				logger.Error("spoke restart failed: could not patch own Deployment",
+					"error", err,
+					"hint", "grant get/patch on deployments/hive in this namespace (hive-self-upgrade Role/RoleBinding)")
+			}
+		}), hub.UpgradeCallback(func(targetSHA string) {
 			const upgradeMarkerPath = "/data/upgrade-requested"
 
 			// attemptCount carries the number of PREVIOUS failed attempts for this

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -750,6 +750,16 @@ func main() {
 	cfg.HiveID = loadOrGenerateHiveID(logger)
 	os.Setenv("HIVE_ID", cfg.HiveID)
 
+	// Observability (#2439): report the removed-agents tombstone LoadWithDashboardOverlay
+	// adopted from the dashboard overlay at boot, BEFORE the startup ApplyPack below. On
+	// a non-sticking-removal report this line is the first check — an empty set here on a
+	// hive that removed an agent means the tombstone did not persist across the restart.
+	logger.Info("boot: loaded removed-agents tombstone",
+		"hive_id", cfg.HiveID,
+		"count", len(cfg.RemovedAgents),
+		"agents", cfg.RemovedAgents,
+	)
+
 	// Surface config provenance: when the persisted runtime config exists, init
 	// containers restore it over the ConfigMap seed on restart, so edits made
 	// only to the seed (or only to the live file) silently lose to it.
@@ -2055,6 +2065,16 @@ func main() {
 			newCfg.MarkAgentRemoved(name)
 		}
 		newCfg.PruneRemovedAgents()
+
+		// Observability (#2439): this is the ~2-min interval reload path, so keep it
+		// at DEBUG to avoid spamming a healthy hive. When a removal is not sticking,
+		// enabling DEBUG shows the tombstone surviving each swap — an empty count here
+		// while the agent keeps reappearing localizes the leak to this union-preserve.
+		logger.Debug("reload: preserved removed-agents",
+			"hive_id", cfg.HiveID,
+			"count", len(newCfg.RemovedAgents),
+			"agents", newCfg.RemovedAgents,
+		)
 
 		// Capture the outgoing GitHub App identity before the swap so we can
 		// tell whether the reload changed it.

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1826,6 +1826,26 @@ func main() {
 		},
 	})
 
+	// Forge App tab inventory: the resolved active key path and the per-app-id
+	// PVC keys live here in cmd/hive, so they are injected as a provider (the
+	// SetGitHubAppRecheckFn pattern). Fingerprints and paths only — the
+	// provider never touches key material.
+	dashSrv.SetForgeAppInventoryFn(func() dashboard.ForgeAppInventory {
+		held := heldPerAppIDKeyFingerprints()
+		keys := make([]dashboard.ForgeAppKey, 0, len(held))
+		for idStr, fp := range held {
+			keys = append(keys, dashboard.ForgeAppKey{
+				AppID:       idStr,
+				Path:        filepath.Join(spokeAppKeyDir, perAppIDKeyFilePrefix+idStr+perAppIDKeyFileSuffix),
+				Fingerprint: fp,
+			})
+		}
+		return dashboard.ForgeAppInventory{
+			ActiveKeyFile: resolveAppKeyFile(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), cfg.GitHub.AppID),
+			HeldKeys:      keys,
+		}
+	})
+
 	dashSrv.SetGitHubAppRequired(githubAppRequired)
 	// Order matters: SetGitHubAppRequired(false) clears both fields, so the
 	// classified state is applied only after it, and only when a failure was

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -950,6 +950,17 @@ func main() {
 	// against a hive whose credentials the operator never delivered).
 	githubAppDiag := appAuthFailure
 	githubAppState := appAuthState
+	// Config truth outranks live probes: an App with no installation cannot
+	// mint, period. A cached token can keep clients green for up to an hour
+	// after an installation is cleared, and waiting for the first failed mint
+	// left the banner down and the hub green exactly when the operator needed
+	// the opposite (the fast-model-actuation incident).
+	if cfg.GitHub.ConfiguredButUninstalled() {
+		githubAppRequired = true
+		githubAppState = github.AppStateNotInstalled
+		githubAppDiag = "GitHub App " + strconv.FormatInt(cfg.GitHub.AppID, 10) +
+			" has no installation for this org — install it (the spoke adopts the installation automatically)"
+	}
 
 	// Find or create the pinned advisory issue. Any level can have advisory
 	// agents whose findings should be posted to this issue.
@@ -2999,6 +3010,11 @@ func main() {
 			// the hub does not track); assigning zero here would blank a working
 			// value and turn a key-only fault into a total auth outage.
 			if next, cleared := nextInstallationID(cfg.GitHub.InstallationID, ghCfg); cleared {
+				// The banner and the hub must flip to not-installed NOW, not
+				// when the cached token dies an hour from now. Same config-truth
+				// rule as startup.
+				dashSrv.SetGitHubAppRequired(true)
+				dashSrv.SetGitHubAppState(github.AppStateNotInstalled.String())
 				logger.Info("clearing github app installation_id on operator request",
 					"was", cfg.GitHub.InstallationID)
 				cfg.GitHub.InstallationID = next

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1817,6 +1817,13 @@ func main() {
 			}
 			return nil
 		},
+		// Same key resolution as boot (initGitHubAuth) and the heartbeat apply
+		// path: without it, the dashboard Set ID handler gated reinit on the
+		// raw key_file, which is deliberately empty on hub-delivered per-app-id
+		// keys (#2459).
+		ResolveAppKeyFileFunc: func(configured string, appID int64) string {
+			return resolveAppKeyFile(configured, os.Getenv("GH_APP_KEY_FILE"), appID)
+		},
 	})
 
 	dashSrv.SetGitHubAppRequired(githubAppRequired)

--- a/v2/pkg/config/agent_overlay.go
+++ b/v2/pkg/config/agent_overlay.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -61,6 +62,15 @@ func (c *Config) MergeAgentOverrides(overlays map[string]AgentConfig) {
 	}
 	for name, agent := range overlays {
 		if c.IsAgentRemoved(name) {
+			// Observability (#2439): a tombstoned agent still had a per-agent
+			// overlay file on disk (it is a key in overlays) — the stale-file
+			// resurrection vector — and the tombstone guard just won over it.
+			// Log at INFO once per skip: this line firing proves the guard held.
+			slog.Default().Info("merge: skipped tombstoned agent",
+				"hive_id", c.HiveID,
+				"agent", name,
+				"had_overlay_file", true,
+			)
 			continue
 		}
 		agent.Managed = true

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -2022,15 +2022,23 @@ func LoadWithDashboardOverlay(path string) (*Config, error) {
 	if err := yaml.Unmarshal([]byte(expandEnvVars(string(data))), &overlay); err != nil {
 		return cfg, nil // malformed overlay: fall back to seed, don't fail the reload
 	}
+	// Tombstones live in the dashboard overlay because that is the only agent
+	// source the dashboard can write. Adopt them BEFORE the fullness guard below
+	// so a short/empty overlay (one that has no agents yet, or only carries the
+	// removed_agents list) still yields the tombstone. Previously this ran AFTER
+	// the guard, so on a reload the guard's early return dropped RemovedAgents to
+	// empty; the ~2-min saver then rewrote every layer tombstone-free and the
+	// deleted agents reappeared on an interval (#2439). Merge already skips and
+	// prunes tombstoned agents, so adopting them early is safe even when we bail.
+	if len(overlay.RemovedAgents) > 0 {
+		cfg.RemovedAgents = overlay.RemovedAgents
+		cfg.PruneRemovedAgents()
+	}
 	// Guard: the overlay must look like a full hive config (same check the
 	// entrypoint and validateSaveGuard apply) before we trust its agents.
 	if overlay.Project.Org == "" || len(overlay.Agents) == 0 {
 		return cfg, nil
 	}
-	// Tombstones live in the dashboard overlay because that is the only agent
-	// source the dashboard can write. Adopt them BEFORE merging so a deleted
-	// agent is neither re-merged from the overlay nor left behind by the seed.
-	cfg.RemovedAgents = overlay.RemovedAgents
 	// Overlay agents win — they carry the reconciled pack-behavior fields.
 	cfg.MergeAgentOverrides(overlay.Agents)
 	for name := range overlay.Agents {

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -2033,6 +2033,15 @@ func LoadWithDashboardOverlay(path string) (*Config, error) {
 	if len(overlay.RemovedAgents) > 0 {
 		cfg.RemovedAgents = overlay.RemovedAgents
 		cfg.PruneRemovedAgents()
+		// Observability (#2439): this runs on boot AND on every ~2-min config reload,
+		// so keep it at DEBUG. It confirms the reload adopted the overlay's tombstones
+		// BEFORE the fullness guard below — the exact ordering whose absence let the
+		// deleted agents reappear on an interval.
+		slog.Default().Debug("reload: adopted removed-agents from overlay",
+			"hive_id", cfg.HiveID,
+			"count", len(cfg.RemovedAgents),
+			"agents", cfg.RemovedAgents,
+		)
 	}
 	// Guard: the overlay must look like a full hive config (same check the
 	// entrypoint and validateSaveGuard apply) before we trust its agents.

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1539,6 +1539,17 @@ func (g GitHubConfig) HasUsableApp() bool {
 	return g.HasApp() && g.InstallationID != 0
 }
 
+// ConfiguredButUninstalled reports the half-configured state that must NEVER
+// read as healthy: a real App is named but there is no installation to mint
+// tokens against. Every token this hive will ever hold is App-minted, so this
+// state means auth is a countdown — any client still working is riding a
+// cached token that cannot be renewed. Callers use this to raise the install
+// banner and fail github_auth from CONFIG truth, not from whether a residual
+// token still breathes.
+func (g GitHubConfig) ConfiguredButUninstalled() bool {
+	return g.HasApp() && g.InstallationID == 0
+}
+
 // ResolvedAPIURL returns the configured API URL or the default for github.com.
 func (g GitHubConfig) ResolvedAPIURL() string {
 	if g.APIURL != "" {

--- a/v2/pkg/config/configured_but_uninstalled_test.go
+++ b/v2/pkg/config/configured_but_uninstalled_test.go
@@ -1,0 +1,51 @@
+package config
+
+import "testing"
+
+// TestConfiguredButUninstalled pins the config-truth rule that drives the
+// "GitHub App not installed" banner and the github_auth health failure: a REAL
+// app_id with no installation must read as uninstalled, while placeholder
+// apps, installed apps, and app-less configs must not.
+func TestConfiguredButUninstalled(t *testing.T) {
+	const realAppID int64 = 123456
+
+	cases := []struct {
+		name string
+		g    GitHubConfig
+		want bool
+	}{
+		{
+			name: "real app with no installation is uninstalled",
+			g:    GitHubConfig{AppID: realAppID, InstallationID: 0},
+			want: true,
+		},
+		{
+			name: "placeholder app never reads as uninstalled",
+			g:    GitHubConfig{AppID: PlaceholderAppID, InstallationID: 0},
+			want: false,
+		},
+		{
+			name: "installed app is not uninstalled",
+			g:    GitHubConfig{AppID: realAppID, InstallationID: 42980},
+			want: false,
+		},
+		{
+			name: "no app configured is not uninstalled",
+			g:    GitHubConfig{AppID: 0, InstallationID: 0},
+			want: false,
+		},
+		{
+			name: "installation without app is not uninstalled",
+			g:    GitHubConfig{AppID: 0, InstallationID: 42980},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.g.ConfiguredButUninstalled(); got != tc.want {
+				t.Errorf("ConfiguredButUninstalled() = %v, want %v (config %+v)", got, tc.want, tc.g)
+			}
+		})
+	}
+}

--- a/v2/pkg/config/merge_tombstone_log_test.go
+++ b/v2/pkg/config/merge_tombstone_log_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestMergeAgentOverridesLogsTombstoneSkip pins the observability added for
+// #2439: when MergeAgentOverrides skips a tombstoned agent that still had a
+// per-agent overlay file, it emits a greppable INFO line naming the agent. The
+// log is the whole point — on a live hive it is what proves the stale-file guard
+// fired without exec'ing in to diff config files. Behavior is unchanged; this
+// asserts only the line.
+func TestMergeAgentOverridesLogsTombstoneSkip(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	cfg := &Config{
+		HiveID:        "hive-test",
+		Agents:        map[string]AgentConfig{},
+		RemovedAgents: []string{"guide"},
+	}
+	cfg.MergeAgentOverrides(map[string]AgentConfig{
+		"guide": {Model: "claude-sonnet-4-6"},
+	})
+
+	out := buf.String()
+	if !strings.Contains(out, "merge: skipped tombstoned agent") {
+		t.Errorf("expected the tombstone-skip audit line, got: %q", out)
+	}
+	if !strings.Contains(out, "agent=guide") {
+		t.Errorf("audit line must name the agent, got: %q", out)
+	}
+	if !strings.Contains(out, "had_overlay_file=true") {
+		t.Errorf("audit line must flag the lingering overlay file, got: %q", out)
+	}
+}

--- a/v2/pkg/config/tombstone_persist_test.go
+++ b/v2/pkg/config/tombstone_persist_test.go
@@ -1,0 +1,176 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadWithDashboardOverlay_AdoptsTombstoneAtBoot is the boot half of the
+// #2439 regression: on restart the entrypoint loads the seed and the startup
+// ApplyPack reconciles the ACMM roster. If the tombstone written by the delete
+// handler (which only lands in the dashboard overlay, the sole agent source the
+// dashboard can write) is not adopted at load time, ApplyPack cannot see it and
+// re-adds the deleted pack agents (brainstorm/guide) every restart.
+//
+// Before the fix the boot path used plain config.Load, which never reads the
+// overlay, so cfg.RemovedAgents was empty and the agents came back. This test
+// asserts LoadWithDashboardOverlay surfaces the overlay's removed_agents AND
+// evicts a tombstoned agent that lingers in the seed.
+func TestLoadWithDashboardOverlay_AdoptsTombstoneAtBoot(t *testing.T) {
+	dir := t.TempDir()
+	seedPath := filepath.Join(dir, "hive.yaml")
+
+	// Seed = the stale ConfigMap the entrypoint restores over the runtime file.
+	// It still lists guide, because the dashboard cannot rewrite the ConfigMap.
+	seed := `
+project:
+  org: testorg
+  repos: [repo1]
+github:
+  token: ghp_test123456789
+agents:
+  scanner:
+    backend: copilot
+    kick_template: scanner-advisory.md
+  guide:
+    backend: copilot
+    kick_template: guide.md
+  brainstorm:
+    backend: copilot
+    kick_template: brainstorm.md
+`
+	if err := os.WriteFile(seedPath, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Overlay = what the delete handler persisted: brainstorm+guide tombstoned.
+	overlayPath := filepath.Join(dir, "hive.yaml.dashboard")
+	overlay := `
+project:
+  org: testorg
+  repos: [repo1]
+github:
+  token: ghp_test123456789
+removed_agents: [brainstorm, guide]
+agents:
+  scanner:
+    backend: copilot
+    kick_template: scanner-advisory.md
+`
+	if err := os.WriteFile(overlayPath, []byte(overlay), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origOverlay := DashboardOverlayFile
+	DashboardOverlayFile = overlayPath
+	t.Cleanup(func() { DashboardOverlayFile = origOverlay })
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+
+	// Precondition and the crux of the boot bug: plain Load (what main.go used at
+	// boot) never reads the overlay, so the tombstone is invisible and the seed's
+	// guide/brainstorm survive. This is exactly why ApplyPack re-added them.
+	raw, err := Load(seedPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if raw.IsAgentRemoved("guide") {
+		t.Fatal("precondition: plain Load must NOT see the overlay tombstone (that is the boot bug)")
+	}
+
+	cfg, err := LoadWithDashboardOverlay(seedPath)
+	if err != nil {
+		t.Fatalf("LoadWithDashboardOverlay: %v", err)
+	}
+
+	for _, name := range []string{"brainstorm", "guide"} {
+		if !cfg.IsAgentRemoved(name) {
+			t.Errorf("tombstone for %q not adopted from overlay at boot", name)
+		}
+		if _, ok := cfg.Agents[name]; ok {
+			t.Errorf("tombstoned agent %q survived in roster from the seed", name)
+		}
+	}
+	if _, ok := cfg.Agents["scanner"]; !ok {
+		t.Error("non-deleted agent scanner should still be present")
+	}
+}
+
+// TestLoadWithDashboardOverlay_TombstoneSurvivesShortOverlay is the reload half
+// of #2439. The ~2-min persistState saver reloads via LoadWithDashboardOverlay.
+// The fullness guard (overlay.Project.Org == "" || len(overlay.Agents) == 0)
+// early-returns for a short or agent-less overlay. Before the fix that early
+// return skipped the RemovedAgents assignment, so the reload dropped the
+// tombstone to empty and the next save rewrote every layer tombstone-free —
+// the deleted agents then reappeared on an interval. The tombstone must be
+// adopted even when the overlay is otherwise too short to trust its agents.
+func TestLoadWithDashboardOverlay_TombstoneSurvivesShortOverlay(t *testing.T) {
+	dir := t.TempDir()
+	seedPath := filepath.Join(dir, "hive.yaml")
+	seed := `
+project:
+  org: testorg
+  repos: [repo1]
+github:
+  token: ghp_test123456789
+agents:
+  scanner:
+    backend: copilot
+    kick_template: scanner-advisory.md
+  guide:
+    backend: copilot
+    kick_template: guide.md
+`
+	if err := os.WriteFile(seedPath, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Short overlay: carries the tombstone but NO agents (and empty org). This
+	// trips the fullness guard, which used to skip the RemovedAgents adoption.
+	overlayPath := filepath.Join(dir, "hive.yaml.dashboard")
+	overlay := `
+removed_agents: [guide]
+`
+	if err := os.WriteFile(overlayPath, []byte(overlay), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origOverlay := DashboardOverlayFile
+	DashboardOverlayFile = overlayPath
+	t.Cleanup(func() { DashboardOverlayFile = origOverlay })
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+
+	cfg, err := LoadWithDashboardOverlay(seedPath)
+	if err != nil {
+		t.Fatalf("LoadWithDashboardOverlay: %v", err)
+	}
+	if !cfg.IsAgentRemoved("guide") {
+		t.Fatal("tombstone dropped by the short-overlay early bail (#2439 reload wipe)")
+	}
+	if _, ok := cfg.Agents["guide"]; ok {
+		t.Error("tombstoned guide should be pruned from the roster even on a short overlay")
+	}
+}
+
+// TestMergeAgentOverridesTombstoneWinsOverStaleFile pins the defense-in-depth
+// contract from #2439 FIX 3: even if a stale /data/agent-configs/<name>.yaml
+// survives the delete (RemoveAgentFile failed and was logged non-fatally), the
+// tombstone must win — MergeAgentOverrides skips the file's agent. This makes
+// the tombstone authoritative independent of the per-agent file's deletion.
+func TestMergeAgentOverridesTombstoneWinsOverStaleFile(t *testing.T) {
+	cfg := &Config{
+		Agents:        map[string]AgentConfig{},
+		RemovedAgents: []string{"brainstorm"},
+	}
+	// The stale per-agent overlay file, still on disk, offered up by a reload.
+	cfg.MergeAgentOverrides(map[string]AgentConfig{
+		"brainstorm": {KickTemplate: "brainstorm.md"},
+		"scanner":    {KickTemplate: "scanner-advisory.md"},
+	})
+	if _, ok := cfg.Agents["brainstorm"]; ok {
+		t.Error("tombstone must win over a stale per-agent overlay file")
+	}
+	if _, ok := cfg.Agents["scanner"]; !ok {
+		t.Error("a non-tombstoned agent must still merge from its file")
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4571,8 +4571,8 @@ func (s *Server) handleGovernorRemoveAgent(w http.ResponseWriter, r *http.Reques
 	//
 	// The tombstone closes both: MergeAgentOverrides skips and prunes it, and
 	// ApplyPack refuses to re-create it.
-	s.deps.Config.MarkAgentRemoved(name)
-	s.removeAgentOverlayFile(name)
+	tombstoned := s.deps.Config.MarkAgentRemoved(name)
+	overlayExisted, overlayDeleted := s.removeAgentOverlayFile(name)
 
 	if err := s.saveConfig(); err != nil {
 		s.logger.Error("failed to persist config after agent removal", "error", err)
@@ -4581,23 +4581,53 @@ func (s *Server) handleGovernorRemoveAgent(w http.ResponseWriter, r *http.Reques
 	s.refreshAndPersist()
 	s.logger.Info("agent removed and tombstoned", "agent", name,
 		"note", "will not be re-created by an ACMM pack apply until explicitly re-added")
+	// One greppable audit line for the whole removal action: whether the
+	// tombstone was newly written, whether a stale per-agent overlay file was
+	// present and whether it was deleted, and the resulting tombstone set so a
+	// grep by agent name tells the story of a non-sticking removal report
+	// (#2439) without exec'ing into the pod to diff config files.
+	s.logger.Info("audit: agent removed via dashboard",
+		"hive_id", s.deps.Config.HiveID,
+		"agent", name,
+		"tombstoned", tombstoned,
+		"overlay_file_existed", overlayExisted,
+		"overlay_file_deleted", overlayDeleted,
+		"removed_agents", s.deps.Config.RemovedAgents,
+	)
 	jsonResponse(w, agentDeletionResponse("removed", name, packLevelsDefining(name)))
 }
 
 // removeAgentOverlayFile deletes /data/agent-configs/<name>.yaml. A leftover
 // overlay file is re-merged by every config load, which is one of the two ways
 // a deleted agent used to come back.
-func (s *Server) removeAgentOverlayFile(name string) {
+//
+// Returns (existed, deleted) purely for the caller's audit log: existed reports
+// whether a per-agent overlay file was present before the delete (the stale-file
+// resurrection vector), and deleted reports whether the removal succeeded. The
+// deletion behavior itself is unchanged — an error is still non-fatal because the
+// tombstone already prevents the merge from resurrecting the agent.
+func (s *Server) removeAgentOverlayFile(name string) (existed, deleted bool) {
 	agentsDir := s.deps.Config.Data.AgentsDir
 	if agentsDir == "" {
-		return
+		return false, false
+	}
+	// Observe presence before deleting so the audit log can distinguish
+	// "no stale file" from "stale file removed". Stat errors other than
+	// not-exist leave existed false — we only claim a file was present when
+	// we positively saw one.
+	overlayPath := filepath.Join(agentsDir, name+".yaml")
+	if _, statErr := os.Stat(overlayPath); statErr == nil {
+		existed = true
 	}
 	if err := config.RemoveAgentFile(agentsDir, name); err != nil {
 		// Not fatal: the tombstone already prevents the merge from
-		// resurrecting the agent. Log it so a stale file is still visible.
-		s.logger.Error("failed to remove agent overlay file after delete (tombstone still applies)",
-			"agent", name, "error", err)
+		// resurrecting the agent. Log it at WARN so a stale file — the
+		// resurrection vector for #2439 — is loud and greppable with its path.
+		s.logger.Warn("failed to remove agent overlay file after delete (tombstone still applies)",
+			"hive_id", s.deps.Config.HiveID, "agent", name, "path", overlayPath, "error", err)
+		return existed, false
 	}
+	return existed, existed
 }
 
 // packLevelsDefining returns the ACMM levels whose pack defines this agent, so

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -126,6 +126,8 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/config/governor/bob", s.handleGovernorBobStatus)
 	s.mux.HandleFunc("PUT /api/config/governor/bob", s.handleGovernorBobKey)
 	s.mux.HandleFunc("DELETE /api/config/governor/bob", s.handleGovernorBobKeyClear)
+	// Live key validation (pasted or saved key) — see bob_key_probe.go.
+	s.mux.HandleFunc("POST /api/config/governor/bob/test", s.handleGovernorBobKeyTest)
 	s.mux.HandleFunc("POST /api/config/governor/litellm/test", s.handleGovernorLiteLLMTest)
 	s.mux.HandleFunc("GET /api/config/governor/gateways", s.handleGovernorGatewaysList)
 	s.mux.HandleFunc("PUT /api/config/governor/gateways", s.handleGovernorGatewaysUpsert)
@@ -4377,6 +4379,15 @@ func (s *Server) handleGovernorBobKey(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(key) > bobKeyMaxLen {
 		jsonError(w, fmt.Sprintf("apiKey is too long (limit %d characters)", bobKeyMaxLen),
+			http.StatusBadRequest)
+		return
+	}
+	// A key with interior whitespace/newlines is always a broken paste, and
+	// storing one is a proven auth failure ("invalid jwt string" 401 → every
+	// bob agent parks at the auth prompt). Refuse at save time with the real
+	// explanation. Leading/trailing whitespace was already trimmed above.
+	if strings.ContainsAny(key, " \t\r\n") {
+		jsonError(w, "apiKey contains interior whitespace or line breaks — a bob API key is a single unbroken token; re-copy it from bob.ibm.com and paste it again",
 			http.StatusBadRequest)
 		return
 	}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -143,6 +143,9 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	// and hands back the correct per-forge install URL when it is not.
 	s.mux.HandleFunc("POST /api/config/governor/repos/check-access", s.handleGovernorRepoCheckAccess)
 	s.mux.HandleFunc("PUT /api/config/github", s.handleConfigGitHub)
+	// Read-only inventory for the Forge App tab: every App credential this
+	// spoke holds (active config + per-app-id PVC keys), fingerprints only.
+	s.mux.HandleFunc("GET /api/config/github/forge-apps", s.handleConfigGitHubForgeApps)
 
 	s.mux.HandleFunc("GET /api/agents", s.handleAgentsList)
 	s.mux.HandleFunc("POST /api/agents", s.handleAgentCreate)

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4986,6 +4986,16 @@ func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
 
 	cfg := s.deps.Config
 
+	// saveConfig() silently no-ops when the config has no source path, so
+	// without this guard the handler would report "status":"updated" for a
+	// value that lives only in memory and is lost on the next restart (#2459).
+	// Refuse up front, before mutating anything, and name the cause.
+	if cfg.SourcePath == "" {
+		s.logger.Error("github config update rejected: config has no source path, save would be an in-memory no-op")
+		jsonError(w, "config not persisted: config has no source path, so the change would be lost on restart", http.StatusInternalServerError)
+		return
+	}
+
 	if body.PrivateKey != "" {
 		keyPath := body.KeyFile
 		if keyPath == "" {
@@ -5027,12 +5037,23 @@ func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
 		"key_file":        cfg.GitHub.KeyFile,
 	}
 
+	// Resolve the signing key the same way the boot and heartbeat-apply paths
+	// do, NOT from the raw config value: on hosted spokes the key is
+	// hub-delivered to the per-app-id path with key_file deliberately left
+	// empty, and gating reinit on cfg.GitHub.KeyFile alone made Set ID save the
+	// installation_id but never rebuild the client — banner never cleared,
+	// Re-check dead-ended on a nil client (#2459).
+	keyFile := cfg.GitHub.KeyFile
+	if s.deps.ResolveAppKeyFileFunc != nil {
+		keyFile = s.deps.ResolveAppKeyFileFunc(cfg.GitHub.KeyFile, cfg.GitHub.AppID)
+	}
+
 	// HasUsableApp() rejects the placeholder sentinel: reinitializing App auth
 	// against it would fail on every save and, before this guard, could not
 	// succeed no matter what installation_id the operator supplied.
-	if cfg.GitHub.HasUsableApp() && cfg.GitHub.KeyFile != "" {
+	if cfg.GitHub.HasUsableApp() && keyFile != "" {
 		if s.deps.ReinitGitHubFunc != nil {
-			if err := s.deps.ReinitGitHubFunc(cfg.GitHub.AppID, cfg.GitHub.InstallationID, cfg.GitHub.KeyFile); err != nil {
+			if err := s.deps.ReinitGitHubFunc(cfg.GitHub.AppID, cfg.GitHub.InstallationID, keyFile); err != nil {
 				s.logger.Error("github client reinit failed", "error", err)
 				result["reinit"] = "failed"
 				result["reinit_error"] = err.Error()

--- a/v2/pkg/dashboard/api_acmm_eval_test.go
+++ b/v2/pkg/dashboard/api_acmm_eval_test.go
@@ -1,0 +1,932 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// acmmEvalTestLogger returns a quiet logger for these tests.
+func acmmEvalTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// ---------- scoreResults: pure-logic table-driven coverage ----------
+
+func TestScoreResults_TableDriven(t *testing.T) {
+	s := NewServer(0, acmmEvalTestLogger())
+
+	tests := []struct {
+		name           string
+		results        []CriterionResult
+		wantTotal      int
+		wantPassed     int
+		wantLevelCount int
+		wantCodebase   int
+		wantLevelName  string
+	}{
+		{
+			// codebaseLevel is 0 with no results, and acmmLevelNames[0] is
+			// "Prerequisites" -- the "None" fallback only fires when a level
+			// has no name entry at all, which level 0 always has.
+			name:           "zero criteria",
+			results:        nil,
+			wantTotal:      0,
+			wantPassed:     0,
+			wantLevelCount: 0,
+			wantCodebase:   0,
+			wantLevelName:  "Prerequisites",
+		},
+		{
+			name: "all pass single level promotes L0 to L1",
+			results: []CriterionResult{
+				{ID: "a", Level: 0, Passed: true},
+				{ID: "b", Level: 0, Passed: true},
+			},
+			wantTotal:      2,
+			wantPassed:     2,
+			wantLevelCount: 1,
+			wantCodebase:   1,
+			wantLevelName:  "Foundational",
+		},
+		{
+			name: "all fail stays at level 0, not promoted",
+			results: []CriterionResult{
+				{ID: "a", Level: 0, Passed: false},
+				{ID: "b", Level: 2, Passed: false},
+			},
+			wantTotal:      2,
+			wantPassed:     0,
+			wantLevelCount: 2,
+			wantCodebase:   0,
+			wantLevelName:  "Prerequisites",
+		},
+		{
+			name: "mixed: L0 passes, L2 fails -> stop climb at L1",
+			results: []CriterionResult{
+				{ID: "a", Level: 0, Passed: true},
+				{ID: "b", Level: 2, Passed: false},
+				{ID: "c", Level: 2, Passed: false},
+			},
+			wantTotal:      3,
+			wantPassed:     1,
+			wantLevelCount: 2,
+			wantCodebase:   1,
+			wantLevelName:  "Foundational",
+		},
+		{
+			name: "mixed: L0 and L2 both pass, L3 fails -> climbs to L2",
+			results: []CriterionResult{
+				{ID: "a", Level: 0, Passed: true},
+				{ID: "b", Level: 2, Passed: true},
+				{ID: "c", Level: 3, Passed: false},
+			},
+			wantTotal:      3,
+			wantPassed:     2,
+			wantLevelCount: 3,
+			wantCodebase:   2,
+			wantLevelName:  "Instructed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			eval := s.scoreResults(tc.results)
+			if eval.CriteriaTotal != tc.wantTotal {
+				t.Errorf("CriteriaTotal = %d, want %d", eval.CriteriaTotal, tc.wantTotal)
+			}
+			if eval.CriteriaPassed != tc.wantPassed {
+				t.Errorf("CriteriaPassed = %d, want %d", eval.CriteriaPassed, tc.wantPassed)
+			}
+			if len(eval.Levels) != tc.wantLevelCount {
+				t.Errorf("len(Levels) = %d, want %d", len(eval.Levels), tc.wantLevelCount)
+			}
+			if eval.CodebaseLevel != tc.wantCodebase {
+				t.Errorf("CodebaseLevel = %d, want %d", eval.CodebaseLevel, tc.wantCodebase)
+			}
+			if eval.CodebaseLevelName != tc.wantLevelName {
+				t.Errorf("CodebaseLevelName = %q, want %q", eval.CodebaseLevelName, tc.wantLevelName)
+			}
+			// Levels must always be sorted ascending.
+			if !sort.SliceIsSorted(eval.Levels, func(i, j int) bool {
+				return eval.Levels[i].Level < eval.Levels[j].Level
+			}) {
+				t.Errorf("Levels not sorted: %+v", eval.Levels)
+			}
+			// CriteriaResults must be echoed back verbatim.
+			if len(eval.CriteriaResults) != len(tc.results) {
+				t.Errorf("CriteriaResults len = %d, want %d", len(eval.CriteriaResults), len(tc.results))
+			}
+		})
+	}
+}
+
+func TestScoreResults_ScoreMathExact(t *testing.T) {
+	s := NewServer(0, acmmEvalTestLogger())
+
+	// 3 of 4 at level 2 pass -> score 0.75, above the 0.70 threshold -> passed.
+	results := []CriterionResult{
+		{ID: "a", Level: 2, Passed: true},
+		{ID: "b", Level: 2, Passed: true},
+		{ID: "c", Level: 2, Passed: true},
+		{ID: "d", Level: 2, Passed: false},
+	}
+	eval := s.scoreResults(results)
+	if len(eval.Levels) != 1 {
+		t.Fatalf("levels = %d, want 1", len(eval.Levels))
+	}
+	lvl := eval.Levels[0]
+	if lvl.Total != 4 || lvl.Matched != 3 {
+		t.Fatalf("total/matched = %d/%d, want 4/3", lvl.Total, lvl.Matched)
+	}
+	if lvl.Score != 0.75 {
+		t.Fatalf("score = %v, want 0.75", lvl.Score)
+	}
+	if lvl.Threshold != acmmLevelThreshold {
+		t.Fatalf("threshold = %v, want %v", lvl.Threshold, acmmLevelThreshold)
+	}
+	if !lvl.Passed {
+		t.Fatalf("expected level to pass at 0.75 >= 0.70 threshold")
+	}
+
+	// Exactly at the boundary (2/... not exact 0.70) -- use 7/10 = 0.70 exactly.
+	var boundary []CriterionResult
+	for i := 0; i < 7; i++ {
+		boundary = append(boundary, CriterionResult{ID: "p", Level: 3, Passed: true})
+	}
+	for i := 0; i < 3; i++ {
+		boundary = append(boundary, CriterionResult{ID: "f", Level: 3, Passed: false})
+	}
+	evalBoundary := s.scoreResults(boundary)
+	if !evalBoundary.Levels[0].Passed {
+		t.Fatalf("expected exact-threshold score to pass (score >= threshold)")
+	}
+
+	// Just below the boundary: 6/10 = 0.60 must fail.
+	var below []CriterionResult
+	for i := 0; i < 6; i++ {
+		below = append(below, CriterionResult{ID: "p", Level: 3, Passed: true})
+	}
+	for i := 0; i < 4; i++ {
+		below = append(below, CriterionResult{ID: "f", Level: 3, Passed: false})
+	}
+	evalBelow := s.scoreResults(below)
+	if evalBelow.Levels[0].Passed {
+		t.Fatalf("expected below-threshold score to fail")
+	}
+}
+
+func TestScoreResults_UnknownLevelName(t *testing.T) {
+	s := NewServer(0, acmmEvalTestLogger())
+
+	// Level 999 has no entry in acmmLevelNames -> falls back to "Unknown".
+	results := []CriterionResult{
+		{ID: "a", Level: 999, Passed: true},
+	}
+	eval := s.scoreResults(results)
+	if len(eval.Levels) != 1 {
+		t.Fatalf("levels = %d, want 1", len(eval.Levels))
+	}
+	if eval.Levels[0].Name != "Unknown" {
+		t.Fatalf("level name = %q, want Unknown", eval.Levels[0].Name)
+	}
+	// codebaseLevel becomes 999 (passed). The per-level Name fallback is
+	// "Unknown" but the overall CodebaseLevelName fallback is "None" --
+	// two different literals for the same "no map entry" case.
+	if eval.CodebaseLevelName != "None" {
+		t.Fatalf("CodebaseLevelName = %q, want None", eval.CodebaseLevelName)
+	}
+}
+
+// ---------- minInt ----------
+
+func TestMinInt_AllBranches(t *testing.T) {
+	if got := minInt(1, 2); got != 1 {
+		t.Fatalf("minInt(1,2) = %d, want 1", got)
+	}
+	if got := minInt(5, 3); got != 3 {
+		t.Fatalf("minInt(5,3) = %d, want 3", got)
+	}
+	if got := minInt(4, 4); got != 4 {
+		t.Fatalf("minInt(4,4) = %d, want 4", got)
+	}
+	if got := minInt(-1, 0); got != -1 {
+		t.Fatalf("minInt(-1,0) = %d, want -1", got)
+	}
+}
+
+// ---------- checkCriterion / patternExists ----------
+
+func TestPatternExists_FileAndDirFromCache(t *testing.T) {
+	s := NewServer(0, acmmEvalTestLogger())
+
+	cache := map[string]map[string]bool{
+		"": {
+			"README.md": true,
+			"docs":      true,
+			"docs/":     true,
+		},
+	}
+
+	if !s.patternExists(context.TODO(), "o", "r", "README.md", cache) {
+		t.Fatal("expected README.md (file) to exist from cache")
+	}
+	if s.patternExists(context.TODO(), "o", "r", "MISSING.md", cache) {
+		t.Fatal("expected MISSING.md to not exist")
+	}
+	if !s.patternExists(context.TODO(), "o", "r", "docs/", cache) {
+		t.Fatal("expected docs/ (dir) to exist from cache via dir-suffix entry")
+	}
+}
+
+func TestPatternExists_DirEntryWithoutTrailingSlash(t *testing.T) {
+	s := NewServer(0, acmmEvalTestLogger())
+
+	// Directory recorded without the "/" suffix should still satisfy an
+	// isDir lookup via the `entries[base]` fallback in the OR condition.
+	cache := map[string]map[string]bool{
+		"": {"test": true},
+	}
+	if !s.patternExists(context.TODO(), "o", "r", "test/", cache) {
+		t.Fatal("expected test/ to resolve via bare 'test' cache entry")
+	}
+}
+
+func TestPatternExists_NestedPathSplitsParentBase(t *testing.T) {
+	s := NewServer(0, acmmEvalTestLogger())
+
+	cache := map[string]map[string]bool{
+		".github/workflows": {"ci.yml": true},
+	}
+	if !s.patternExists(context.TODO(), "o", "r", ".github/workflows/ci.yml", cache) {
+		t.Fatal("expected nested path to resolve using parent-dir cache bucket")
+	}
+	if s.patternExists(context.TODO(), "o", "r", ".github/workflows/missing.yml", cache) {
+		t.Fatal("expected missing nested file to be absent")
+	}
+}
+
+func TestPatternExists_CacheMissFallsBackToGitHubAPI(t *testing.T) {
+	// Dedicated mux: serves a direct single-file content lookup for
+	// go.mod (the go-github GetContents "file" response shape) and 404s
+	// everything else, so this test exercises patternExists' live-API
+	// fallback in isolation from the directory-listing fixture.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/myorg/repo1/contents/go.mod", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"name": "go.mod", "path": "go.mod", "type": "file", "sha": "abc123",
+		})
+	})
+	mux.HandleFunc("/repos/myorg/repo1/contents/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	s := NewServer(0, acmmEvalTestLogger())
+	deps := testDeps(t)
+	deps.GHClient = ghpkg.NewClientForTest(ts.URL, "myorg", []string{"repo1"}, acmmEvalTestLogger())
+	s.RegisterAPI(deps)
+
+	// Empty cache forces the live-API path in patternExists.
+	empty := map[string]map[string]bool{}
+	if !s.patternExists(t.Context(), "myorg", "repo1", "go.mod", empty) {
+		t.Fatal("expected go.mod to exist via direct GetContents call")
+	}
+	if s.patternExists(t.Context(), "myorg", "repo1", "does-not-exist.txt", empty) {
+		t.Fatal("expected nonexistent path to return false via direct GetContents 404")
+	}
+}
+
+func TestPatternExists_NilGHClientOnCacheMiss(t *testing.T) {
+	s := NewServer(0, acmmEvalTestLogger())
+	deps := testDeps(t)
+	deps.GHClient = nil
+	s.RegisterAPI(deps)
+
+	empty := map[string]map[string]bool{}
+	if s.patternExists(t.Context(), "myorg", "repo1", "anything", empty) {
+		t.Fatal("expected false when GHClient is nil and cache misses")
+	}
+}
+
+func TestCheckCriterion_AnyPatternMatches(t *testing.T) {
+	s := NewServer(0, acmmEvalTestLogger())
+
+	cache := map[string]map[string]bool{
+		"": {"go.mod": true},
+	}
+	c := ACMMCriterion{
+		ID:       "acmm:test",
+		Level:    0,
+		Patterns: []string{"does-not-exist.yml", "go.mod", "also-missing.txt"},
+	}
+	if !s.checkCriterion(context.TODO(), "o", "r", c, cache) {
+		t.Fatal("expected checkCriterion to pass when any pattern matches")
+	}
+}
+
+func TestCheckCriterion_NoPatternMatches(t *testing.T) {
+	s := NewServer(0, acmmEvalTestLogger())
+
+	cache := map[string]map[string]bool{
+		"": {"go.mod": true},
+	}
+	c := ACMMCriterion{
+		ID:       "acmm:test",
+		Level:    0,
+		Patterns: []string{"missing-a.yml", "missing-b.yml"},
+	}
+	if s.checkCriterion(context.TODO(), "o", "r", c, cache) {
+		t.Fatal("expected checkCriterion to fail when no pattern matches")
+	}
+}
+
+// ---------- prefetchDirectories ----------
+
+func TestPrefetchDirectories_CachesEntriesAndSkipsErrors(t *testing.T) {
+	ts := acmmEvalGitHubMux(t)
+	s := NewServer(0, acmmEvalTestLogger())
+	deps := testDeps(t)
+	deps.GHClient = ghpkg.NewClientForTest(ts.URL, "myorg", []string{"repo1"}, acmmEvalTestLogger())
+	s.RegisterAPI(deps)
+
+	cache := s.prefetchDirectories(t.Context(), "myorg", "repo1")
+
+	// Root dir listing must be cached with both file and directory entries,
+	// directories recorded with a trailing slash.
+	root, ok := cache[""]
+	if !ok {
+		t.Fatal("expected root dir cached")
+	}
+	if !root["README.md"] {
+		t.Fatal("expected README.md entry in root cache")
+	}
+	if !root["workflows/"] {
+		t.Fatal("expected directory entry to carry trailing slash")
+	}
+
+	// A dir that consistently 404s (not registered in the mux) must be
+	// skipped rather than cached or causing an error.
+	if _, ok := cache["docs/security"]; ok {
+		// docs/security IS registered in the mux (returns a listing), so
+		// assert instead that an unregistered path used by no criterion
+		// prefetch is absent -- prefetchDirectories only ever requests the
+		// fixed dir list, so verify that list matches expectations exactly.
+		t.Log("docs/security present as expected (registered in mux)")
+	}
+}
+
+func TestPrefetchDirectories_NilGHClientReturnsEmptyCache(t *testing.T) {
+	s := NewServer(0, acmmEvalTestLogger())
+	deps := testDeps(t)
+	deps.GHClient = nil
+	s.RegisterAPI(deps)
+
+	cache := s.prefetchDirectories(t.Context(), "myorg", "repo1")
+	if len(cache) != 0 {
+		t.Fatalf("expected empty cache with nil GHClient, got %d entries", len(cache))
+	}
+}
+
+func TestPrefetchDirectories_ErrorDirsAreSkipped(t *testing.T) {
+	// A mux that 404s on every content path -- every prefetch dir errors,
+	// so the cache must end up empty (the `continue` branch on every dir).
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/myorg/repo2/contents/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	s := NewServer(0, acmmEvalTestLogger())
+	deps := testDeps(t)
+	deps.GHClient = ghpkg.NewClientForTest(ts.URL, "myorg", []string{"repo2"}, acmmEvalTestLogger())
+	s.RegisterAPI(deps)
+
+	cache := s.prefetchDirectories(t.Context(), "myorg", "repo2")
+	if len(cache) != 0 {
+		t.Fatalf("expected all-error prefetch to yield empty cache, got %d entries", len(cache))
+	}
+}
+
+// ---------- handleACMMEvaluation ----------
+
+func TestHandleACMMEvaluation_JSONShape(t *testing.T) {
+	ts := acmmEvalGitHubMux(t)
+	s := NewServer(0, acmmEvalTestLogger())
+	deps := testDeps(t)
+	deps.GHClient = ghpkg.NewClientForTest(ts.URL, "myorg", []string{"repo1"}, acmmEvalTestLogger())
+	s.RegisterAPI(deps)
+
+	rec := doGet(s, "/api/acmm/evaluation")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	var eval ACMMEvaluation
+	if err := json.Unmarshal(rec.Body.Bytes(), &eval); err != nil {
+		t.Fatalf("failed to decode response: %v; body=%s", err, rec.Body.String())
+	}
+
+	if eval.CriteriaTotal != len(universalCriteria) {
+		t.Fatalf("CriteriaTotal = %d, want %d (len(universalCriteria))", eval.CriteriaTotal, len(universalCriteria))
+	}
+	if eval.LastEvaluatedAt == "" {
+		t.Fatal("expected LastEvaluatedAt to be set")
+	}
+	if _, err := time.Parse(time.RFC3339, eval.LastEvaluatedAt); err != nil {
+		t.Fatalf("LastEvaluatedAt not RFC3339: %v", err)
+	}
+	if len(eval.RepoResults) != 1 {
+		t.Fatalf("RepoResults len = %d, want 1", len(eval.RepoResults))
+	}
+	if eval.RepoResults[0].Repo != "repo1" {
+		t.Fatalf("RepoResults[0].Repo = %q, want repo1", eval.RepoResults[0].Repo)
+	}
+	if len(eval.CriteriaResults) != len(universalCriteria) {
+		t.Fatalf("CriteriaResults len = %d, want %d", len(eval.CriteriaResults), len(universalCriteria))
+	}
+	// OperationalLevel/Name/OverallLevel must be populated from
+	// detectCurrentLevel(), independent of the cached codebase eval.
+	if eval.OperationalName == "" {
+		t.Fatal("expected OperationalName to be populated")
+	}
+	if eval.OverallLevel > eval.CodebaseLevel || eval.OverallLevel > eval.OperationalLevel {
+		t.Fatalf("OverallLevel = %d must be min(CodebaseLevel=%d, OperationalLevel=%d)",
+			eval.OverallLevel, eval.CodebaseLevel, eval.OperationalLevel)
+	}
+}
+
+func TestHandleACMMEvaluation_UnknownOperationalLevelName(t *testing.T) {
+	ts := acmmEvalGitHubMux(t)
+	s := NewServer(0, acmmEvalTestLogger())
+	deps := testDeps(t)
+	deps.GHClient = ghpkg.NewClientForTest(ts.URL, "myorg", []string{"repo1"}, acmmEvalTestLogger())
+	unknownLevel := 999
+	deps.Config.ACMMLevel = &unknownLevel
+	s.RegisterAPI(deps)
+
+	rec := doGet(s, "/api/acmm/evaluation")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var eval ACMMEvaluation
+	if err := json.Unmarshal(rec.Body.Bytes(), &eval); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if eval.OperationalLevel != 999 {
+		t.Fatalf("OperationalLevel = %d, want 999", eval.OperationalLevel)
+	}
+	if eval.OperationalName != "Unknown" {
+		t.Fatalf("OperationalName = %q, want Unknown", eval.OperationalName)
+	}
+}
+
+func TestHandleACMMEvaluation_PrimedCacheHitSkipsReEvaluation(t *testing.T) {
+	// Priming acmmEvalCache directly (same package) exercises the
+	// read-lock cache-hit branch without racing a second goroutine against
+	// the write-lock double-check branch.
+	s := NewServer(0, acmmEvalTestLogger())
+	deps := testDeps(t)
+	// No GHClient at all -- if the handler mistakenly re-evaluated instead
+	// of serving from cache, evaluateAllRepos would overwrite CodebaseLevel
+	// via the "GitHub client not available" error path, which carries no
+	// RepoResults. Serving from cache must preserve the primed RepoResults.
+	s.RegisterAPI(deps)
+
+	primed := &ACMMEvaluation{
+		CodebaseLevel:     3,
+		CodebaseLevelName: "Measured",
+		CriteriaTotal:     10,
+		CriteriaPassed:    8,
+		LastEvaluatedAt:   time.Now().UTC().Format(time.RFC3339),
+		RepoResults:       []RepoEvaluation{{Repo: "primed-repo"}},
+	}
+	s.acmmEvalMu.Lock()
+	s.acmmEvalCache = primed
+	s.acmmEvalCachedAt = time.Now()
+	s.acmmEvalMu.Unlock()
+
+	rec := doGet(s, "/api/acmm/evaluation")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var eval ACMMEvaluation
+	if err := json.Unmarshal(rec.Body.Bytes(), &eval); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if eval.CodebaseLevel != 3 {
+		t.Fatalf("CodebaseLevel = %d, want 3 (served from primed cache)", eval.CodebaseLevel)
+	}
+	if len(eval.RepoResults) != 1 || eval.RepoResults[0].Repo != "primed-repo" {
+		t.Fatalf("expected primed RepoResults to be preserved, got %+v", eval.RepoResults)
+	}
+}
+
+func TestHandleACMMEvaluation_ExpiredCacheReEvaluates(t *testing.T) {
+	ts := acmmEvalGitHubMux(t)
+	s := NewServer(0, acmmEvalTestLogger())
+	deps := testDeps(t)
+	deps.GHClient = ghpkg.NewClientForTest(ts.URL, "myorg", []string{"repo1"}, acmmEvalTestLogger())
+	s.RegisterAPI(deps)
+
+	stale := &ACMMEvaluation{
+		CodebaseLevel: 6,
+		RepoResults:   []RepoEvaluation{{Repo: "stale-repo"}},
+	}
+	s.acmmEvalMu.Lock()
+	s.acmmEvalCache = stale
+	s.acmmEvalCachedAt = time.Now().Add(-2 * acmmEvalTTL)
+	s.acmmEvalMu.Unlock()
+
+	rec := doGet(s, "/api/acmm/evaluation")
+	var eval ACMMEvaluation
+	if err := json.Unmarshal(rec.Body.Bytes(), &eval); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// The expired cache (CodebaseLevel 6, repo "stale-repo") must be
+	// discarded and replaced by a fresh evaluateAllRepos() run against the
+	// live fixture repo "repo1".
+	if len(eval.RepoResults) != 1 || eval.RepoResults[0].Repo != "repo1" {
+		t.Fatalf("expected fresh evaluation against repo1 to replace stale cache, got %+v", eval.RepoResults)
+	}
+	if eval.CodebaseLevel == 6 {
+		t.Fatalf("expected fresh CodebaseLevel to be recomputed, not reused from stale cache (got 6)")
+	}
+}
+
+// ---------- evaluateAllRepos ----------
+
+func TestEvaluateAllRepos_NilDepsOrConfig(t *testing.T) {
+	s := NewServer(0, acmmEvalTestLogger())
+	// deps is never set via RegisterAPI, so s.deps stays nil.
+	eval := s.evaluateAllRepos()
+	if eval.Error != "config not loaded" {
+		t.Fatalf("error = %q, want %q", eval.Error, "config not loaded")
+	}
+	if _, err := time.Parse(time.RFC3339, eval.LastEvaluatedAt); err != nil {
+		t.Fatalf("LastEvaluatedAt not RFC3339: %v", err)
+	}
+}
+
+func TestEvaluateAllRepos_AggregatesAcrossRepos(t *testing.T) {
+	ts := acmmEvalMultiRepoMux(t)
+	s := NewServer(0, acmmEvalTestLogger())
+	deps := testDeps(t)
+	deps.Config.Project.Repos = []string{"repo-a", "repo-b"}
+	deps.GHClient = ghpkg.NewClientForTest(ts.URL, "myorg", []string{"repo-a", "repo-b"}, acmmEvalTestLogger())
+	s.RegisterAPI(deps)
+
+	eval := s.evaluateAllRepos()
+	if len(eval.RepoResults) != 2 {
+		t.Fatalf("RepoResults len = %d, want 2", len(eval.RepoResults))
+	}
+	// repo-a has everything, repo-b has nothing -- aggregate pass-if-any-repo
+	// means the aggregate criteria results should show more passes than
+	// repo-b alone.
+	var repoBPassed, aggPassed int
+	for _, rr := range eval.RepoResults {
+		if rr.Repo == "repo-b" {
+			repoBPassed = rr.CriteriaPassed
+		}
+	}
+	aggPassed = eval.CriteriaPassed
+	if aggPassed < repoBPassed {
+		t.Fatalf("aggregate passed (%d) should be >= repo-b alone (%d)", aggPassed, repoBPassed)
+	}
+	if aggPassed == 0 {
+		t.Fatal("expected at least some criteria to pass in the aggregate (repo-a has everything)")
+	}
+}
+
+// ---------- handleACMMCreateIssue ----------
+
+func TestHandleACMMCreateIssue_BodyFormattingAndLabels(t *testing.T) {
+	var captured map[string]interface{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/myorg/repo1/labels", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"name": "acmm"})
+	})
+	mux.HandleFunc("/repos/myorg/repo1/issues", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&captured)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"number": 42, "html_url": "https://github.com/myorg/repo1/issues/42",
+		})
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	s := NewServer(0, acmmEvalTestLogger())
+	deps := testDeps(t)
+	deps.GHClient = ghpkg.NewClientForTest(ts.URL, "myorg", []string{"repo1"}, acmmEvalTestLogger())
+	s.RegisterAPI(deps)
+
+	var criterion *ACMMCriterion
+	for i := range universalCriteria {
+		if universalCriteria[i].ID == "acmm:prereq-cicd" {
+			criterion = &universalCriteria[i]
+			break
+		}
+	}
+	if criterion == nil {
+		t.Fatal("fixture criterion acmm:prereq-cicd not found in universalCriteria")
+	}
+
+	rec := doPost(s, "/api/acmm/issue", map[string]interface{}{
+		"repo": "repo1", "criterion_id": criterion.ID,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	body := captured
+	if body["title"] == nil {
+		t.Fatal("expected title in captured issue request")
+	}
+	title := body["title"].(string)
+	wantTitlePrefix := "[ACMM L0] Add " + criterion.Name
+	if title != wantTitlePrefix {
+		t.Fatalf("title = %q, want %q", title, wantTitlePrefix)
+	}
+
+	issueBody := body["body"].(string)
+	for _, want := range []string{
+		"## ACMM Gap: " + criterion.Name,
+		"**Level:** L0 Prerequisites",
+		"**Category:** prerequisite",
+		"**Criterion ID:** `" + criterion.ID + "`",
+		"Opened by Hive ACMM Evaluation",
+	} {
+		if !strings.Contains(issueBody, want) {
+			t.Fatalf("issue body missing %q; got:\n%s", want, issueBody)
+		}
+	}
+	for _, pattern := range criterion.Patterns {
+		if !strings.Contains(issueBody, "`"+pattern+"`") {
+			t.Fatalf("issue body missing pattern %q; got:\n%s", pattern, issueBody)
+		}
+	}
+
+	labelsRaw, ok := body["labels"].([]interface{})
+	if !ok {
+		t.Fatalf("expected labels array in request, got %T: %v", body["labels"], body["labels"])
+	}
+	var labels []string
+	for _, l := range labelsRaw {
+		labels = append(labels, l.(string))
+	}
+	if !acmmEvalContainsStr(labels, "acmm") || !acmmEvalContainsStr(labels, "ai-fix-requested") {
+		t.Fatalf("labels = %v, want to include acmm and ai-fix-requested", labels)
+	}
+}
+
+func TestHandleACMMCreateIssue_LabelCreateFailsButNotAlreadyExists_NoLabelsAssigned(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/myorg/repo1/labels", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"some other failure"}`, http.StatusInternalServerError)
+	})
+	var captured map[string]interface{}
+	mux.HandleFunc("/repos/myorg/repo1/issues", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&captured)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"number": 7, "html_url": "https://github.com/myorg/repo1/issues/7",
+		})
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	s := NewServer(0, acmmEvalTestLogger())
+	deps := testDeps(t)
+	deps.GHClient = ghpkg.NewClientForTest(ts.URL, "myorg", []string{"repo1"}, acmmEvalTestLogger())
+	s.RegisterAPI(deps)
+
+	rec := doPost(s, "/api/acmm/issue", map[string]interface{}{
+		"repo": "repo1", "criterion_id": "acmm:claude-md",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if captured["labels"] != nil {
+		t.Fatalf("expected no labels field when label creation genuinely failed, got %v", captured["labels"])
+	}
+}
+
+func TestHandleACMMCreateIssue_LabelAlreadyExists_LabelsStillAssigned(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/myorg/repo1/labels", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"already_exists"}`, http.StatusUnprocessableEntity)
+	})
+	var captured map[string]interface{}
+	mux.HandleFunc("/repos/myorg/repo1/issues", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&captured)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"number": 8, "html_url": "https://github.com/myorg/repo1/issues/8",
+		})
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	s := NewServer(0, acmmEvalTestLogger())
+	deps := testDeps(t)
+	deps.GHClient = ghpkg.NewClientForTest(ts.URL, "myorg", []string{"repo1"}, acmmEvalTestLogger())
+	s.RegisterAPI(deps)
+
+	rec := doPost(s, "/api/acmm/issue", map[string]interface{}{
+		"repo": "repo1", "criterion_id": "acmm:claude-md",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if captured["labels"] == nil {
+		t.Fatal("expected labels to be assigned when label already existed")
+	}
+}
+
+func TestHandleACMMCreateIssue_UnknownLevelNameFallback(t *testing.T) {
+	// acmm:claude-md is a known criterion; if its level had no name entry
+	// the handler must fall back to "Unknown" in the issue body. We can't
+	// mutate universalCriteria safely across parallel tests, so instead
+	// verify the fallback function directly covers the same code path used
+	// by handleACMMCreateIssue (acmmLevelNames[level] == "").
+	if name := acmmLevelNames[12345]; name != "" {
+		t.Fatalf("test assumption broken: level 12345 unexpectedly named %q", name)
+	}
+}
+
+func TestHandleACMMCreateIssue_GHIssueCreateError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/myorg/repo1/labels", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"name": "acmm"})
+	})
+	mux.HandleFunc("/repos/myorg/repo1/issues", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"issue creation failed"}`, http.StatusInternalServerError)
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	s := NewServer(0, acmmEvalTestLogger())
+	deps := testDeps(t)
+	deps.GHClient = ghpkg.NewClientForTest(ts.URL, "myorg", []string{"repo1"}, acmmEvalTestLogger())
+	s.RegisterAPI(deps)
+
+	rec := doPost(s, "/api/acmm/issue", map[string]interface{}{
+		"repo": "repo1", "criterion_id": "acmm:claude-md",
+	})
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleACMMCreateIssue_NoSpuriousCallWithoutFindings(t *testing.T) {
+	// handleACMMCreateIssue is only ever invoked by the frontend for a
+	// specific failed criterion; it has no "scan then maybe create" path of
+	// its own. This test verifies that when the request is well-formed but
+	// carries an empty/missing criterion_id (i.e. no finding selected), the
+	// handler validates and returns before ever touching the GitHub API --
+	// so no issue-create call reaches the mock server.
+	called := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/myorg/repo1/issues", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"number": 1})
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	s := NewServer(0, acmmEvalTestLogger())
+	deps := testDeps(t)
+	deps.GHClient = ghpkg.NewClientForTest(ts.URL, "myorg", []string{"repo1"}, acmmEvalTestLogger())
+	s.RegisterAPI(deps)
+
+	rec := doPost(s, "/api/acmm/issue", map[string]interface{}{
+		"repo": "repo1", "criterion_id": "",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for missing criterion_id", rec.Code)
+	}
+	if called {
+		t.Fatal("expected no GitHub issue-create call when no criterion_id (no finding) is supplied")
+	}
+}
+
+func TestHandleACMMCreateIssue_NilConfig(t *testing.T) {
+	s := NewServer(0, acmmEvalTestLogger())
+	deps := testDeps(t)
+	deps.Config = nil
+	s.RegisterAPI(deps)
+
+	rec := doPost(s, "/api/acmm/issue", map[string]interface{}{
+		"repo": "repo1", "criterion_id": "acmm:claude-md",
+	})
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 for nil config", rec.Code)
+	}
+}
+
+// ---------- shared fixtures / helpers ----------
+
+// acmmEvalGitHubMux serves a single-repo GitHub API fixture: a populated
+// root + well-known subdirectory listings (so most criteria pass), label
+// creation, and issue creation.
+func acmmEvalGitHubMux(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/repos/myorg/repo1/contents/", func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path[len("/repos/myorg/repo1/contents/"):]
+		w.Header().Set("Content-Type", "application/json")
+		switch path {
+		case "", ".github", ".github/workflows", ".github/ISSUE_TEMPLATE",
+			".github/prompts", ".github/agents", ".claude", "docs", "docs/security":
+			entries := []map[string]interface{}{
+				{"name": "README.md", "type": "file"},
+				{"name": "go.mod", "type": "file"},
+				{"name": "CLAUDE.md", "type": "file"},
+				{"name": "CONTRIBUTING.md", "type": "file"},
+				{"name": "workflows", "type": "dir"},
+				{"name": "ISSUE_TEMPLATE", "type": "dir"},
+			}
+			_ = json.NewEncoder(w).Encode(entries)
+		default:
+			http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+		}
+	})
+
+	mux.HandleFunc("/repos/myorg/repo1/labels", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"name": "acmm"})
+	})
+
+	mux.HandleFunc("/repos/myorg/repo1/issues", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"number":   42,
+			"html_url": "https://github.com/myorg/repo1/issues/42",
+		})
+	})
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// acmmEvalMultiRepoMux serves two repos: repo-a has every well-known dir
+// populated (most criteria pass), repo-b has nothing (every criterion
+// fails), exercising the pass-if-any-repo aggregation in evaluateAllRepos.
+func acmmEvalMultiRepoMux(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/repos/myorg/repo-a/contents/", func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path[len("/repos/myorg/repo-a/contents/"):]
+		w.Header().Set("Content-Type", "application/json")
+		switch path {
+		case "", ".github", ".github/workflows", ".github/ISSUE_TEMPLATE",
+			".github/prompts", ".github/agents", ".claude", "docs", "docs/security":
+			entries := []map[string]interface{}{
+				{"name": "README.md", "type": "file"},
+				{"name": "go.mod", "type": "file"},
+				{"name": "CLAUDE.md", "type": "file"},
+				{"name": "CONTRIBUTING.md", "type": "file"},
+				{"name": "workflows", "type": "dir"},
+				{"name": "ISSUE_TEMPLATE", "type": "dir"},
+			}
+			_ = json.NewEncoder(w).Encode(entries)
+		default:
+			http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+		}
+	})
+	mux.HandleFunc("/repos/myorg/repo-b/contents/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+	})
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func acmmEvalContainsStr(list []string, want string) bool {
+	for _, v := range list {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/v2/pkg/dashboard/api_broad_coverage_test.go
+++ b/v2/pkg/dashboard/api_broad_coverage_test.go
@@ -76,6 +76,9 @@ func TestCovBR_ConfigGitHub_BadBody(t *testing.T) {
 
 func TestCovBR_ConfigGitHub_KeyFileAndIDs(t *testing.T) {
 	s := covApiServer(t)
+	// The handler now refuses updates it cannot persist (#2459), so the
+	// config needs a real source path.
+	s.deps.Config.SourcePath = filepath.Join(t.TempDir(), "hive.yaml")
 	appID := int64(123)
 	instID := int64(456)
 	rec := doPut(s, "/api/config/github", map[string]any{
@@ -95,6 +98,7 @@ func TestCovBR_ConfigGitHub_KeyFileAndIDs(t *testing.T) {
 
 func TestCovBR_ConfigGitHub_PrivateKeyWrite(t *testing.T) {
 	s := covApiServer(t)
+	s.deps.Config.SourcePath = filepath.Join(t.TempDir(), "hive.yaml")
 	keyPath := filepath.Join(t.TempDir(), "sub", "gh-app-key.pem")
 	rec := doPut(s, "/api/config/github", map[string]any{
 		"private_key": "-----BEGIN KEY-----\nabc\n-----END KEY-----",

--- a/v2/pkg/dashboard/api_config_github_test.go
+++ b/v2/pkg/dashboard/api_config_github_test.go
@@ -1,0 +1,149 @@
+package dashboard
+
+// Regression tests for #2459: the dashboard "Set ID" flow (PUT
+// /api/config/github) on hosted spokes whose GitHub App private key was
+// hub-delivered to the per-app-id path with key_file deliberately left empty.
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Live values from the spoke the bug was observed on (hosted-available-
+// vllmd-06): App 5686 on github.ibm.com, installation 43021. Any real IDs
+// would do; these make the scenario recognizable.
+const (
+	testHubDeliveredAppID          = int64(5686)
+	testHubDeliveredInstallationID = 43021
+)
+
+// TestConfigGitHub_SetIDReinitsWithHubDeliveredKey drives the fleet-standard
+// hosted-spoke configuration through the production handler: key_file empty,
+// key present only at the per-app-id delivered path. Setting the installation
+// ID must trigger the GitHub client rebuild with the RESOLVED key — before
+// #2459 the reinit was gated on the raw cfg.GitHub.KeyFile and silently
+// skipped, leaving the banner up and Re-check dead on a nil client.
+func TestConfigGitHub_SetIDReinitsWithHubDeliveredKey(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.SourcePath = filepath.Join(t.TempDir(), "hive.yaml")
+	deps.Config.GitHub.AppID = testHubDeliveredAppID
+	deps.Config.GitHub.InstallationID = 0
+	deps.Config.GitHub.KeyFile = "" // hub-delivered keys never persist key_file
+
+	// The hub-delivered per-app-id key, at a path the config does not name.
+	delivered := filepath.Join(t.TempDir(), "gh-app-key-5686.pem")
+	if err := os.WriteFile(delivered, []byte("-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mirrors resolveAppKeyFile's contract (cmd/hive): an explicit config
+	// value wins, otherwise the per-app-id delivered file is preferred.
+	deps.ResolveAppKeyFileFunc = func(configured string, appID int64) string {
+		if strings.TrimSpace(configured) != "" {
+			return configured
+		}
+		if appID == testHubDeliveredAppID {
+			return delivered
+		}
+		return ""
+	}
+
+	var gotAppID, gotInstallationID int64
+	var gotKeyFile string
+	reinitCalls := 0
+	deps.ReinitGitHubFunc = func(appID, installationID int64, keyFile string) error {
+		reinitCalls++
+		gotAppID, gotInstallationID, gotKeyFile = appID, installationID, keyFile
+		return nil
+	}
+
+	rec := doPut(s, "/api/config/github", map[string]any{"installation_id": testHubDeliveredInstallationID})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set id: want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	body := decodeJSON(t, rec)
+	if body["reinit"] != "ok" {
+		t.Fatalf("reinit not reported ok: body = %v", body)
+	}
+	if reinitCalls != 1 {
+		t.Fatalf("ReinitGitHubFunc calls = %d, want 1 (raw key_file gate skipped the rebuild?)", reinitCalls)
+	}
+	if gotKeyFile != delivered {
+		t.Fatalf("reinit key file = %q, want the resolved per-app-id key %q", gotKeyFile, delivered)
+	}
+	if gotAppID != testHubDeliveredAppID || gotInstallationID != testHubDeliveredInstallationID {
+		t.Fatalf("reinit ids = (%d, %d), want (%d, %d)", gotAppID, gotInstallationID, testHubDeliveredAppID, testHubDeliveredInstallationID)
+	}
+}
+
+// TestConfigGitHub_ExplicitKeyFileStillWins keeps the pre-#2459 behavior
+// intact: when the operator configured a key_file, the reinit signs with that
+// exact path, resolver or not.
+func TestConfigGitHub_ExplicitKeyFileStillWins(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.SourcePath = filepath.Join(t.TempDir(), "hive.yaml")
+	deps.Config.GitHub.AppID = testHubDeliveredAppID
+	explicit := filepath.Join(t.TempDir(), "operator-key.pem")
+	deps.Config.GitHub.KeyFile = explicit
+
+	deps.ResolveAppKeyFileFunc = func(configured string, appID int64) string {
+		if strings.TrimSpace(configured) != "" {
+			return configured
+		}
+		return "/data/should-not-be-used.pem"
+	}
+
+	var gotKeyFile string
+	deps.ReinitGitHubFunc = func(appID, installationID int64, keyFile string) error {
+		gotKeyFile = keyFile
+		return nil
+	}
+
+	rec := doPut(s, "/api/config/github", map[string]any{"installation_id": testHubDeliveredInstallationID})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set id: want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if gotKeyFile != explicit {
+		t.Fatalf("reinit key file = %q, want the explicit %q", gotKeyFile, explicit)
+	}
+}
+
+// TestConfigGitHub_UnpersistableSaveIsAnError covers the secondary #2459 bug:
+// with no config source path the save was a silent no-op, yet the handler
+// reported "status":"updated" — the owner's installation_id lived only in
+// memory and vanished on the next restart. The handler must refuse and name
+// the cause instead.
+func TestConfigGitHub_UnpersistableSaveIsAnError(t *testing.T) {
+	s, deps := apiServer(t)
+	if deps.Config.SourcePath != "" {
+		t.Fatalf("precondition: test deps config should have no source path")
+	}
+
+	reinitCalls := 0
+	deps.ReinitGitHubFunc = func(appID, installationID int64, keyFile string) error {
+		reinitCalls++
+		return nil
+	}
+
+	rec := doPut(s, "/api/config/github", map[string]any{"installation_id": testHubDeliveredInstallationID})
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("unpersistable save: want 500, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	body := decodeJSON(t, rec)
+	if body["status"] == "updated" {
+		t.Fatalf("unpersistable save must never report \"updated\": body = %v", body)
+	}
+	errMsg, _ := body["error"].(string)
+	if !strings.Contains(errMsg, "source path") {
+		t.Fatalf("error must name the cause (no source path): body = %v", body)
+	}
+	if deps.Config.GitHub.InstallationID != 0 {
+		t.Fatalf("installation_id mutated in memory despite refused save: %d", deps.Config.GitHub.InstallationID)
+	}
+	if reinitCalls != 0 {
+		t.Fatalf("reinit attempted despite refused save: %d calls", reinitCalls)
+	}
+}

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -53,6 +53,10 @@ type ContributorProfile struct {
 	AvatarURL          string                `json:"avatar_url,omitempty"`
 	RegisteredAt       string                `json:"registered_at"`
 	TasksCompleted     int                   `json:"total_tasks_completed"`
+	// TasksWithPR counts only completions that reported a pull request.
+	// Auto-promotion reads this rather than TasksCompleted, so write access is
+	// never granted for completions where nothing was shown to have shipped.
+	TasksWithPR        int                   `json:"total_tasks_completed_with_pr"`
 	TasksFailed        int                   `json:"total_tasks_failed"`
 	LastActive         string                `json:"last_active,omitempty"`
 	LastCompletedTask  *WSTaskAssign         `json:"last_completed_task,omitempty"`

--- a/v2/pkg/dashboard/api_knowledge_coverage_test.go
+++ b/v2/pkg/dashboard/api_knowledge_coverage_test.go
@@ -147,6 +147,9 @@ func TestCovC_AgentConfigConnections(t *testing.T) {
 
 func TestCovC_ConfigGitHub(t *testing.T) {
 	s := covCServer(t)
+	// The handler now refuses updates it cannot persist (#2459), so the
+	// config needs a real source path.
+	s.deps.Config.SourcePath = filepath.Join(t.TempDir(), "hive.yaml")
 
 	// bad body -> 400
 	rec := doPut(s, "/api/config/github", "bad")

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -291,7 +291,11 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 
 	s.persistOnly()
 	go s.refreshAsync()
-	s.logger.Info("ACMM pack applied", "level", level, "name", pack.Name, "created", len(created), "updated", len(updated), "skipped", len(skipped), "paused", len(paused), "resumed", len(resumed), "tombstoned", len(tombstoned))
+	// Observability (#2439): the counts alone ("tombstoned":0) were the tell in the
+	// field report, so also list WHICH agents were tombstoned (deleted by the operator
+	// and NOT re-created) vs skipped (already present) — a grep by agent name against
+	// this single line answers "did the pack try to re-add the agent I removed?".
+	s.logger.Info("ACMM pack applied", "hive_id", s.deps.Config.HiveID, "level", level, "name", pack.Name, "created", len(created), "updated", len(updated), "skipped", len(skipped), "paused", len(paused), "resumed", len(resumed), "tombstoned", len(tombstoned), "tombstoned_agents", tombstoned, "skipped_agents", skipped)
 	if len(tombstoned) > 0 {
 		// Say it plainly in the log too: an operator reading "this level has 6
 		// agents but I see 4" needs the reason, not a silent gap.

--- a/v2/pkg/dashboard/bob_key_probe.go
+++ b/v2/pkg/dashboard/bob_key_probe.go
@@ -1,0 +1,299 @@
+package dashboard
+
+// Live validation ("Test key") for the IBM bobshell ("bob") API key stored by
+// bob_key_store.go. bob authenticates with an API key only (its browser SSO
+// cannot complete inside a pod — see bob_key_store.go), and until now the
+// dashboard had no way to tell a working key from a bad one: owners saved a
+// key and found out from bob agents crash-looping at the auth prompt.
+//
+// The probe is the cheapest authenticated call the bob backend supports —
+// GET /inference/v1/model/info — verified live against the production
+// backend. There is no pre-existing hive-side bob HTTP client to reuse; the
+// wire conventions below were confirmed with a real multi-key test:
+//
+//   - base URL https://api.us-east.bob.ibm.com
+//   - opaque keys (bob_prod_…) authenticate as `Authorization: Apikey <key>`.
+//     bobshell itself first sends Bearer, fails to parse the key as a JWT,
+//     and flips to Apikey — the probe goes straight to the scheme that
+//     matches the key's shape (Bearer only for JWT-shaped keys).
+//   - a 401 "Token verification failed: invalid jwt string" means the key
+//     reached the backend in a form it tried to parse as a JWT (wrong scheme
+//     or a dirty/truncated value) — the key itself may be fine.
+//   - a 402 insufficient_quota_or_plan_expired means the credential is valid
+//     but has no inference entitlement (wrong key kind/scope).
+//   - an HTML 403 is the CDN/edge blocking the request — not a key verdict.
+//
+// SECURITY: a key under test is never persisted, never logged, and never
+// echoed back. Every error string that could embed the key (transport errors,
+// backend error bodies) passes through redactSecret before leaving the
+// process.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	// defaultBobAPIBaseURL is the bob backend's API host, confirmed live.
+	// Keys are issued at bob.ibm.com (Scope: Inference); the API itself is
+	// served from this regional host.
+	defaultBobAPIBaseURL = "https://api.us-east.bob.ibm.com"
+
+	// bobAPIBaseURLEnv optionally overrides the probe's base URL (self-hosted
+	// relays, IBM moving the API host, and tests). Only the base URL is
+	// configurable — the probe path and auth convention are fixed.
+	bobAPIBaseURLEnv = "HIVE_BOB_API_URL"
+
+	// bobProbePath is the cheapest authenticated request the backend
+	// supports (confirmed live): no body, no inference cost.
+	bobProbePath = "/inference/v1/model/info"
+
+	// bobAuthSchemeAPIKey / bobAuthSchemeBearer are the two Authorization
+	// schemes the backend accepts. Opaque keys (bob_prod_…) use Apikey;
+	// Bearer is only correct for JWT-shaped credentials.
+	bobAuthSchemeAPIKey = "Apikey "
+	bobAuthSchemeBearer = "Bearer "
+
+	// bobKeyManageURL is where an operator creates a correctly-scoped key —
+	// surfaced in entitlement-failure details. Keep in sync with
+	// BOB_API_KEY_MANAGE_URL in static/index.html.
+	bobKeyManageURL = "https://bob.ibm.com/admin/apikeys"
+
+	// bobProbeTimeout bounds the whole test round-trip so a black-holed host
+	// cannot hang the dashboard request.
+	bobProbeTimeout = 10 * time.Second
+
+	// bobProbeMaxErrBody caps how much of a backend error body is read and
+	// surfaced. Error bodies can be huge; the useful part ("invalid api key",
+	// "wrong scope") is at the front.
+	bobProbeMaxErrBody = 512
+)
+
+// Machine-readable failure classes for the test endpoint. The UI shows the
+// human-readable detail; the reason is stable for scripting/tests.
+const (
+	bobTestReasonUnauthorized  = "unauthorized"
+	bobTestReasonNoEntitlement = "no_entitlement"
+	bobTestReasonUnreachable   = "unreachable"
+	bobTestReasonTimeout       = "timeout"
+	bobTestReasonBadStatus     = "bad_status"
+	bobTestReasonNoKey         = "no_key"
+	bobTestReasonBadKeyFormat  = "bad_key_format"
+)
+
+// bobProbeBaseURL resolves the backend base URL, honoring the env override.
+func bobProbeBaseURL() string {
+	if v := strings.TrimSpace(os.Getenv(bobAPIBaseURLEnv)); v != "" {
+		return v
+	}
+	return defaultBobAPIBaseURL
+}
+
+// bobBackendSays extracts everything useful the backend included with a
+// failure — error body, WWW-Authenticate challenge, request id — so the
+// operator sees the backend's own words ("invalid api key", "key expired",
+// "wrong scope: needs Inference"), not just a classification. The body is
+// truncated to bobProbeMaxErrBody, whitespace-collapsed to a single line,
+// and redacted so key material can never ride along.
+func bobBackendSays(resp *http.Response, key string) string {
+	var parts []string
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, bobProbeMaxErrBody))
+	if msg := strings.Join(strings.Fields(string(body)), " "); msg != "" {
+		parts = append(parts, msg)
+	}
+	if wa := strings.TrimSpace(resp.Header.Get("WWW-Authenticate")); wa != "" {
+		parts = append(parts, "WWW-Authenticate: "+wa)
+	}
+	// Both spellings observed across IBM services; first one present wins.
+	for _, h := range []string{"X-Request-Id", "X-Global-Transaction-Id"} {
+		if rid := strings.TrimSpace(resp.Header.Get(h)); rid != "" {
+			parts = append(parts, "request-id "+rid)
+			break
+		}
+	}
+	return redactSecret(strings.Join(parts, "; "), key)
+}
+
+// bobAuthHeaderValue picks the Authorization scheme by the key's shape:
+// Bearer only for JWT-shaped credentials (three dot-separated segments,
+// "eyJ" header), Apikey for everything else — including bob_prod_ opaque
+// keys, whose confirmed wire scheme is Apikey. This skips bobshell's own
+// Bearer-then-flip dance and its guaranteed "invalid jwt string" 401.
+func bobAuthHeaderValue(key string) string {
+	if strings.HasPrefix(key, "eyJ") && strings.Count(key, ".") == 2 {
+		return bobAuthSchemeBearer + key
+	}
+	return bobAuthSchemeAPIKey + key
+}
+
+// bobJWTVerdictDetail is the decoded explanation for the backend's
+// "Token verification failed: invalid jwt string" 401 — which means the key
+// reached the backend in a form it tried to parse as a JWT, NOT necessarily
+// that the key is bad.
+const bobJWTVerdictDetail = "the backend received the key in a form it tried to parse as a JWT — " +
+	"usually a stray newline/truncation in the stored value, or bob fell back to browser auth " +
+	"because it could not read the key file (perms must allow the agent UID, e.g. 440)"
+
+// bobEntitlementDetail is the decoded explanation for a 402: the credential
+// authenticates but cannot run inference (wrong key kind or scope).
+const bobEntitlementDetail = "key authenticates but has no inference entitlement — " +
+	"create an API key with Scope: Inference at " + bobKeyManageURL
+
+// probeBobAPIKey makes one authenticated model-info request with the given
+// key. An empty reason means the backend accepted the key; otherwise reason
+// is one of the bobTestReason* classes and detail is a human-readable,
+// key-free explanation that includes — and where possible decodes — whatever
+// the backend itself said.
+func probeBobAPIKey(key string) (reason, detail string) {
+	req, err := http.NewRequest(http.MethodGet, strings.TrimRight(bobProbeBaseURL(), "/")+bobProbePath, nil)
+	if err != nil {
+		return bobTestReasonUnreachable, "building request: " + redactSecret(err.Error(), key)
+	}
+	req.Header.Set("Authorization", bobAuthHeaderValue(key))
+	client := &http.Client{Timeout: bobProbeTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return bobTestReasonTimeout,
+				fmt.Sprintf("the bob backend did not respond within %s", bobProbeTimeout)
+		}
+		// Transport errors can embed header values (e.g. Go's invalid-header
+		// rejection quotes the offending value) — always redact.
+		return bobTestReasonUnreachable, "cannot reach the bob backend: " + redactSecret(err.Error(), key)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		return "", ""
+	}
+
+	says := bobBackendSays(resp, key)
+	withSays := func(msg string) string {
+		if says != "" {
+			return msg + ": " + says
+		}
+		return msg
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized:
+		detail = withSays(fmt.Sprintf("the bob backend rejected the key (HTTP %d)", resp.StatusCode))
+		// Decode the known "invalid jwt string" verdict: it fingers the key's
+		// DELIVERY, not its validity.
+		if strings.Contains(says, "invalid jwt string") || strings.Contains(says, "Token verification failed") {
+			detail += " — " + bobJWTVerdictDetail
+		}
+		return bobTestReasonUnauthorized, detail
+	case resp.StatusCode == http.StatusPaymentRequired:
+		// 402 insufficient_quota_or_plan_expired: a real credential of the
+		// wrong kind (e.g. a bob-user key instead of an Inference API key).
+		return bobTestReasonNoEntitlement, withSays(bobEntitlementDetail)
+	case resp.StatusCode == http.StatusForbidden:
+		// An HTML 403 is the CDN/edge (Cloudflare) blocking the request —
+		// bob's auth never evaluated the key, so it is not a key verdict.
+		if bobLooksLikeEdgeHTML(resp, says) {
+			return bobTestReasonUnreachable,
+				"the request was blocked at the network edge (HTML 403 from the CDN/proxy), " +
+					"not by bob's auth — the key was likely never evaluated"
+		}
+		return bobTestReasonUnauthorized,
+			withSays(fmt.Sprintf("the bob backend rejected the key (HTTP %d)", resp.StatusCode))
+	default:
+		return bobTestReasonBadStatus,
+			withSays(fmt.Sprintf("the bob backend returned HTTP %d", resp.StatusCode))
+	}
+}
+
+// bobLooksLikeEdgeHTML reports whether a 403 response is an HTML edge/CDN
+// block page rather than a JSON auth verdict from bob itself.
+func bobLooksLikeEdgeHTML(resp *http.Response, says string) bool {
+	if strings.Contains(strings.ToLower(resp.Header.Get("Content-Type")), "text/html") {
+		return true
+	}
+	trimmed := strings.TrimSpace(says)
+	return strings.HasPrefix(trimmed, "<!DOCTYPE") || strings.HasPrefix(trimmed, "<html")
+}
+
+// handleGovernorBobKeyTest is POST /api/config/governor/bob/test — live
+// validation of a bob API key. A body carrying a non-empty apiKey tests THAT
+// key (pre-save validation; the value is never persisted, logged, or echoed);
+// an empty/absent body tests the SAVED key via the same resolution agents use
+// (ResolveAPIKey), so the key material never leaves the process.
+//
+// The response is always HTTP 200 with the verdict in the body —
+// {"status":"ok"} or {"status":"error","reason":...,"detail":...} — so the UI
+// distinguishes "the test ran and failed" from transport/auth failures of the
+// dashboard itself. Session auth and the read-only write-gate come from the
+// same authenticate/roleEnforcement middleware as every other /api/config
+// route (this is a POST, so read-only roles are rejected before the handler).
+func (s *Server) handleGovernorBobKeyTest(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		APIKey *string `json:"apiKey"`
+	}
+	// The body is OPTIONAL (absent/empty means "test the saved key"), so an
+	// immediate EOF is not an error — only malformed JSON is.
+	if err := decodeBody(r, &body); err != nil && !errors.Is(err, io.EOF) {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+
+	mode := "saved"
+	key := ""
+	if body.APIKey != nil {
+		key = strings.TrimSpace(*body.APIKey)
+	}
+	if key != "" {
+		mode = "pasted"
+		if len(key) > bobKeyMaxLen {
+			jsonError(w, fmt.Sprintf("apiKey is too long (limit %d characters)", bobKeyMaxLen),
+				http.StatusBadRequest)
+			return
+		}
+		// Interior whitespace/newlines can never be part of a bob key, and a
+		// broken paste is a proven "invalid jwt string" 401 — refuse with the
+		// real explanation instead of testing a value that cannot work.
+		// (Leading/trailing whitespace was already trimmed above.)
+		if strings.ContainsAny(key, " \t\r\n") {
+			jsonResponse(w, map[string]interface{}{
+				"status": "error",
+				"reason": bobTestReasonBadKeyFormat,
+				"detail": "the pasted value contains interior whitespace or line breaks — a bob API key is a single unbroken token; re-copy it from bob.ibm.com and paste it again",
+			})
+			return
+		}
+	} else {
+		key = s.deps.Config.Governor.Bob.ResolveAPIKey()
+		if key == "" {
+			jsonResponse(w, map[string]interface{}{
+				"status": "error",
+				"reason": bobTestReasonNoKey,
+				"detail": "no bob API key is configured — paste a key to test, or save one first",
+			})
+			return
+		}
+	}
+
+	reason, detail := probeBobAPIKey(key)
+	if reason == "" {
+		// mode/reason only — never key material, never backend bodies.
+		s.logger.Info("bob api key test ok", "mode", mode)
+		jsonResponse(w, map[string]interface{}{
+			"status": "ok",
+			"detail": "the bob backend accepted the key",
+		})
+		return
+	}
+	s.logger.Info("bob api key test failed", "mode", mode, "reason", reason)
+	jsonResponse(w, map[string]interface{}{
+		"status": "error",
+		"reason": reason,
+		"detail": detail,
+	})
+}

--- a/v2/pkg/dashboard/bob_key_probe_test.go
+++ b/v2/pkg/dashboard/bob_key_probe_test.go
@@ -1,0 +1,386 @@
+package dashboard
+
+// Tests for the bob "Test key" endpoint (handleGovernorBobKeyTest /
+// probeBobAPIKey). Every test runs against an httptest bob backend via the
+// HIVE_BOB_API_URL override, and the leak assertions capture the server's
+// logger output so "the key never appears in responses OR logs" is enforced
+// mechanically, not by inspection.
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// newBobProbeServer builds a Server whose logger writes into the returned
+// buffer at Info level, so tests can assert what was (not) logged.
+func newBobProbeServer(t *testing.T) (*Server, *bytes.Buffer) {
+	t.Helper()
+	var logBuf bytes.Buffer
+	s := NewServer(0, slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	s.deps = &Dependencies{Config: &config.Config{}}
+	return s, &logBuf
+}
+
+// isolateBobKeySources makes saved-key resolution deterministic: the PVC file
+// points into a temp dir and both env fallbacks are blanked.
+func isolateBobKeySources(t *testing.T) string {
+	t.Helper()
+	path := pointBobKeyAtTempDir(t)
+	t.Setenv(config.DefaultBobAPIKeyEnv, "")
+	t.Setenv("BOBSHELL_API_KEY", "")
+	return path
+}
+
+// postBobKeyTest exercises the handler and decodes the verdict.
+func postBobKeyTest(t *testing.T, s *Server, body string) (*httptest.ResponseRecorder, map[string]interface{}) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/config/governor/bob/test", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	s.handleGovernorBobKeyTest(rec, req)
+	var out map[string]interface{}
+	if rec.Code == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+			t.Fatalf("response is not JSON: %v (body: %s)", err, rec.Body.String())
+		}
+	}
+	return rec, out
+}
+
+// A pasted opaque key is sent to the backend with the confirmed wire scheme
+// (`Authorization: Apikey <key>`) against the model-info path, a 200 maps to
+// status ok, and the key is not persisted anywhere.
+func TestBobKeyTest_PastedKeyOK_NotPersisted(t *testing.T) {
+	path := isolateBobKeySources(t)
+	var gotAuth, gotPath string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		if gotAuth != "Apikey "+bobTestKey {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Write([]byte(`{"model":"auto"}`))
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, logBuf := newBobProbeServer(t)
+	rec, out := postBobKeyTest(t, s, `{"apiKey":"`+bobTestKey+`"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if out["status"] != "ok" {
+		t.Fatalf("verdict = %v, want ok (body: %s)", out["status"], rec.Body.String())
+	}
+	// Opaque (non-JWT) keys must use the Apikey scheme — the Bearer scheme is
+	// a guaranteed "invalid jwt string" 401 for them.
+	if gotAuth != "Apikey "+bobTestKey {
+		t.Errorf("backend saw Authorization %q, want %q", gotAuth, "Apikey "+bobTestKey)
+	}
+	if gotPath != bobProbePath {
+		t.Errorf("probe hit %q, want %q", gotPath, bobProbePath)
+	}
+	// Pre-save validation must not persist the key or touch config.
+	if _, err := os.Stat(path); err == nil {
+		t.Error("tested key was written to the PVC key file")
+	}
+	if s.deps.Config.Governor.Bob.APIKeyFile != "" {
+		t.Error("test mutated governor.bob.api_key_file")
+	}
+	if strings.Contains(rec.Body.String(), bobTestKey) {
+		t.Error("response body leaks the key")
+	}
+	if strings.Contains(logBuf.String(), bobTestKey) {
+		t.Error("logs leak the key")
+	}
+}
+
+// A 401 maps to reason "unauthorized", the backend's own words (body,
+// WWW-Authenticate, request id) surface in the detail, and the key never
+// appears in the response or logs even when the BACKEND echoes it back.
+func TestBobKeyTest_Unauthorized_RichDetail_NoKeyMaterial(t *testing.T) {
+	isolateBobKeySources(t)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", "APIKey realm=bob")
+		w.Header().Set("X-Request-Id", "req-42")
+		w.WriteHeader(http.StatusUnauthorized)
+		// Hostile-backend case: the error body echoes the submitted key.
+		w.Write([]byte(`{"error":"invalid api key ` + bobTestKey + ` — wrong scope: needs Inference"}`))
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, logBuf := newBobProbeServer(t)
+	rec, out := postBobKeyTest(t, s, `{"apiKey":"`+bobTestKey+`"}`)
+
+	if out["status"] != "error" || out["reason"] != bobTestReasonUnauthorized {
+		t.Fatalf("verdict = %v/%v, want error/unauthorized (body: %s)", out["status"], out["reason"], rec.Body.String())
+	}
+	detail, _ := out["detail"].(string)
+	// The backend's own words must be surfaced, not just the classification.
+	for _, want := range []string{"invalid api key", "wrong scope: needs Inference", "WWW-Authenticate", "req-42"} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("detail %q does not surface backend info %q", detail, want)
+		}
+	}
+	if strings.Contains(rec.Body.String(), bobTestKey) {
+		t.Error("response body leaks the key the backend echoed")
+	}
+	if strings.Contains(logBuf.String(), bobTestKey) {
+		t.Error("logs leak the key")
+	}
+}
+
+// A connection-refused backend maps to reason "unreachable".
+func TestBobKeyTest_Unreachable(t *testing.T) {
+	isolateBobKeySources(t)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := backend.URL
+	backend.Close() // now refuses connections
+	t.Setenv(bobAPIBaseURLEnv, deadURL)
+
+	s, logBuf := newBobProbeServer(t)
+	rec, out := postBobKeyTest(t, s, `{"apiKey":"`+bobTestKey+`"}`)
+
+	if out["status"] != "error" || out["reason"] != bobTestReasonUnreachable {
+		t.Fatalf("verdict = %v/%v, want error/unreachable (body: %s)", out["status"], out["reason"], rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), bobTestKey) || strings.Contains(logBuf.String(), bobTestKey) {
+		t.Error("key material leaked on transport failure")
+	}
+}
+
+// An empty body tests the SAVED key: the handler resolves it through the
+// same BobConfig.ResolveAPIKey the agents use, reads the key file, and the
+// value stays inside the process (never echoed).
+func TestBobKeyTest_SavedKeyMode_ReadsKeyFile(t *testing.T) {
+	path := isolateBobKeySources(t)
+	if err := writeBobKeyFile(bobTestKey); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotAuth string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Write([]byte(`{"model":"auto"}`))
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, logBuf := newBobProbeServer(t)
+	s.deps.Config.Governor.Bob.APIKeyFile = path
+
+	rec, out := postBobKeyTest(t, s, `{}`)
+	if out["status"] != "ok" {
+		t.Fatalf("verdict = %v, want ok (body: %s)", out["status"], rec.Body.String())
+	}
+	if gotAuth != "Apikey "+bobTestKey {
+		t.Errorf("backend saw Authorization %q, want the saved key with the Apikey scheme", gotAuth)
+	}
+	if strings.Contains(rec.Body.String(), bobTestKey) || strings.Contains(logBuf.String(), bobTestKey) {
+		t.Error("saved-key test leaked key material")
+	}
+}
+
+// No pasted key and no saved key is a distinct, actionable verdict — not a
+// backend round-trip.
+func TestBobKeyTest_NoKeyConfigured(t *testing.T) {
+	isolateBobKeySources(t)
+	// Any backend hit here is a bug: there is no key to test with.
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("probe reached the backend without a key")
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, _ := newBobProbeServer(t)
+	rec, out := postBobKeyTest(t, s, `{}`)
+	if out["status"] != "error" || out["reason"] != bobTestReasonNoKey {
+		t.Fatalf("verdict = %v/%v, want error/no_key (body: %s)", out["status"], out["reason"], rec.Body.String())
+	}
+	_ = rec
+}
+
+// Guardrails: oversized pasted keys and malformed bodies are rejected before
+// any network I/O; an absent body behaves like {} (saved-key mode).
+func TestBobKeyTest_BadRequests(t *testing.T) {
+	isolateBobKeySources(t)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("rejected request must not reach the backend")
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, _ := newBobProbeServer(t)
+
+	rec, _ := postBobKeyTest(t, s, `{"apiKey":"`+strings.Repeat("x", bobKeyMaxLen+1)+`"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("oversized key: status = %d, want 400", rec.Code)
+	}
+
+	rec, _ = postBobKeyTest(t, s, `not json`)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("malformed body: status = %d, want 400", rec.Code)
+	}
+
+	// Absent body == saved-key mode; with no key saved that is the no_key
+	// verdict, not a 400.
+	req := httptest.NewRequest(http.MethodPost, "/api/config/governor/bob/test", nil)
+	recNil := httptest.NewRecorder()
+	s.handleGovernorBobKeyTest(recNil, req)
+	if recNil.Code != http.StatusOK || !strings.Contains(recNil.Body.String(), bobTestReasonNoKey) {
+		t.Errorf("absent body: status = %d body = %s, want 200/no_key", recNil.Code, recNil.Body.String())
+	}
+}
+
+// The backend's "invalid jwt string" 401 is DECODED, not just surfaced: it
+// means the key's delivery was broken (scheme/newline/perms), not that the
+// key is bad, and the detail must say so.
+func TestBobKeyTest_JWTVerdictDecoded(t *testing.T) {
+	isolateBobKeySources(t)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"unauthorized","message":"Token verification failed: invalid jwt string"}`))
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, _ := newBobProbeServer(t)
+	rec, out := postBobKeyTest(t, s, `{"apiKey":"`+bobTestKey+`"}`)
+	if out["reason"] != bobTestReasonUnauthorized {
+		t.Fatalf("reason = %v, want unauthorized (body: %s)", out["reason"], rec.Body.String())
+	}
+	detail, _ := out["detail"].(string)
+	for _, want := range []string{"invalid jwt string", "stray newline", "agent UID"} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("detail %q missing decoded explanation fragment %q", detail, want)
+		}
+	}
+}
+
+// A 402 is a valid credential with no inference entitlement — its own reason
+// with the create-a-scoped-key fix in the detail.
+func TestBobKeyTest_EntitlementFailureDecoded(t *testing.T) {
+	isolateBobKeySources(t)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusPaymentRequired)
+		w.Write([]byte(`{"type":"insufficient_quota_or_plan_expired","message":"team user not found"}`))
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, _ := newBobProbeServer(t)
+	rec, out := postBobKeyTest(t, s, `{"apiKey":"`+bobTestKey+`"}`)
+	if out["reason"] != bobTestReasonNoEntitlement {
+		t.Fatalf("reason = %v, want no_entitlement (body: %s)", out["reason"], rec.Body.String())
+	}
+	detail, _ := out["detail"].(string)
+	for _, want := range []string{"Scope: Inference", "bob.ibm.com/admin/apikeys", "team user not found"} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("detail %q missing %q", detail, want)
+		}
+	}
+}
+
+// A Cloudflare-style HTML 403 is a network/edge block, not a key verdict —
+// it must classify as unreachable, never unauthorized.
+func TestBobKeyTest_EdgeHTML403IsNotAKeyVerdict(t *testing.T) {
+	isolateBobKeySources(t)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`<!DOCTYPE html><html><body>Access denied | cloudflare</body></html>`))
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, _ := newBobProbeServer(t)
+	rec, out := postBobKeyTest(t, s, `{"apiKey":"`+bobTestKey+`"}`)
+	if out["reason"] != bobTestReasonUnreachable {
+		t.Fatalf("reason = %v, want unreachable for an HTML edge 403 (body: %s)", out["reason"], rec.Body.String())
+	}
+	detail, _ := out["detail"].(string)
+	if !strings.Contains(detail, "network edge") {
+		t.Errorf("detail %q does not explain the edge block", detail)
+	}
+}
+
+// Interior whitespace in a pasted key is refused with the real explanation
+// before any network I/O — a broken paste is a proven 401.
+func TestBobKeyTest_InteriorWhitespaceRefused(t *testing.T) {
+	isolateBobKeySources(t)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("a malformed key must not reach the backend")
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, _ := newBobProbeServer(t)
+	rec, out := postBobKeyTest(t, s, `{"apiKey":"bob_prod_abc\ndef"}`)
+	if out["reason"] != bobTestReasonBadKeyFormat {
+		t.Fatalf("reason = %v, want bad_key_format (body: %s)", out["reason"], rec.Body.String())
+	}
+	detail, _ := out["detail"].(string)
+	if !strings.Contains(detail, "single unbroken token") {
+		t.Errorf("detail %q missing the re-copy guidance", detail)
+	}
+}
+
+// The SAVE handler refuses interior whitespace too — storing a broken paste
+// recreates the exact crash-loop the test feature exists to prevent.
+func TestHandleGovernorBobKey_InteriorWhitespaceRefused(t *testing.T) {
+	path := isolateBobKeySources(t)
+	s, _ := newBobProbeServer(t)
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/bob",
+		strings.NewReader(`{"apiKey":"bob_prod_abc def"}`))
+	rec := httptest.NewRecorder()
+	s.handleGovernorBobKey(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Error("broken key was persisted")
+	}
+}
+
+// A JWT-shaped credential keeps the Bearer scheme.
+func TestBobAuthHeaderValue_SchemeByKeyShape(t *testing.T) {
+	jwt := "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJib2IifQ.c2ln"
+	if got := bobAuthHeaderValue(jwt); got != "Bearer "+jwt {
+		t.Errorf("JWT-shaped key: got %q, want Bearer scheme", got)
+	}
+	if got := bobAuthHeaderValue("bob_prod_opaque123"); got != "Apikey bob_prod_opaque123" {
+		t.Errorf("opaque key: got %q, want Apikey scheme", got)
+	}
+}
+
+// Non-auth backend failures (e.g. a 500) map to bad_status and still surface
+// the backend's message.
+func TestBobKeyTest_BadStatusSurfacesBackendMessage(t *testing.T) {
+	isolateBobKeySources(t)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("bob backend melted"))
+	}))
+	defer backend.Close()
+	t.Setenv(bobAPIBaseURLEnv, backend.URL)
+
+	s, _ := newBobProbeServer(t)
+	rec, out := postBobKeyTest(t, s, `{"apiKey":"`+bobTestKey+`"}`)
+	if out["reason"] != bobTestReasonBadStatus {
+		t.Fatalf("reason = %v, want bad_status (body: %s)", out["reason"], rec.Body.String())
+	}
+	detail, _ := out["detail"].(string)
+	if !strings.Contains(detail, "HTTP 500") || !strings.Contains(detail, "bob backend melted") {
+		t.Errorf("detail %q missing status or backend message", detail)
+	}
+}

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -803,11 +803,18 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					)
 					contributor.mu.Lock()
 					contributor.profile.TasksCompleted++
+					if msg.PRURL != "" {
+						contributor.profile.TasksWithPR++
+					}
 					contributor.profile.LastActive = time.Now().UTC().Format(time.RFC3339)
 					if completedTask != nil {
 						contributor.profile.LastCompletedTask = completedTask
 					}
-					if contributor.profile.TrustTier == "newcomer" && contributor.profile.TasksCompleted >= contributorAutoPromoteAt {
+					// Promote on completions that actually produced a pull
+					// request. Completion is self-reported, so counting bare
+					// task_complete messages would hand out contents:write and
+					// pulls:write for work that was never shown to exist.
+					if contributor.profile.TrustTier == "newcomer" && contributor.profile.TasksWithPR >= contributorAutoPromoteAt {
 						contributor.profile.TrustTier = "contributor"
 						h.logger.Info("[contribute-ws] auto-promoted", "username", contributor.profile.GitHubUsername)
 					}

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -15,6 +15,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -167,8 +168,25 @@ type ContributeWSHub struct {
 	// for stats/audit and to feed #2356 duplicate detection (a known PR URL per
 	// issue). Empty means the completion reported no PR.
 	completedTaskPRURL map[string]string
-	completedMu        sync.Mutex
-	selectMu           sync.Mutex
+	// failedTasks records, per "repo#number", the time of the most recent
+	// task_failed. It backs the SHORT failure cooldown (failedTaskCooldownMinutes)
+	// that breaks the queue livelock in #2435: without it a just-failed issue is
+	// immediately re-admissible and, sitting at the same position in the same
+	// deterministic scan, is handed straight back out ahead of every other
+	// admissible issue. Kept separate from completedTasks so a failure never masks
+	// as a completion in stats/audit. Guarded by completedMu (shared with the
+	// completed-task ledger — they are read/written from the same paths).
+	failedTasks map[string]time.Time
+	// consecutiveFailures counts back-to-back task_failed reports per
+	// "repo#number", reset to zero on completion. Once it reaches
+	// consecutiveFailureQuarantineThreshold the issue is QUARANTINED for the
+	// longer quarantineCooldownHours window (#2435 remedy 2): this distinguishes
+	// "flaky once" from "nobody can do this", which a flat short cooldown cannot.
+	// A permanent failure (msg.Permanent) counts as permanentFailureWeight toward
+	// the threshold. Guarded by completedMu.
+	consecutiveFailures map[string]int
+	completedMu         sync.Mutex
+	selectMu            sync.Mutex
 }
 
 // completedTaskCooldownHours is the cooldown applied when a task completes
@@ -187,16 +205,54 @@ const completedTaskCooldownHours = 168
 // the same day.
 const completedNoPRCooldownHours = 4
 
+// failedTaskCooldownMinutes is the SHORT cooldown applied to an issue when a
+// contributor reports task_failed (#2435). It is deliberately far shorter than
+// the completion cooldowns above: a failure is often purely environmental
+// (expired token, model outage, transient network) and the issue is likely
+// still perfectly workable, so we must not park it for long. This short window
+// is only large enough to break the tight reject/re-offer livelock — where a
+// just-failed issue at the head of the deterministic scan order is handed
+// straight back out ahead of the whole rest of the queue — while still letting a
+// legitimate retry happen within a few minutes.
+const failedTaskCooldownMinutes = 10
+
+// consecutiveFailureQuarantineThreshold is how many consecutive failures an
+// issue may accumulate (weighted — see permanentFailureWeight) before it is
+// QUARANTINED for the longer quarantineCooldownHours window (#2435 remedy 2).
+// A poison issue that nobody can complete burns at most this many assignments
+// before it is parked for hours instead of minutes, so it stops starving the
+// queue. The counter resets to zero on the issue's next completion.
+const consecutiveFailureQuarantineThreshold = 3
+
+// quarantineCooldownHours is the LONGER cooldown applied once an issue crosses
+// consecutiveFailureQuarantineThreshold. It parks a reliably-failing issue for
+// hours (long enough to stop it dominating the queue) without locking it as long
+// as a genuine week-long completion cooldown — the issue may become workable
+// again (e.g. a dependency merges) and should re-enter circulation the same day.
+const quarantineCooldownHours = 6
+
+// permanentFailureWeight is how much a permanent failure (msg.Permanent — the
+// relay exhausted its per-task CLI-restart budget and will not retry, see
+// bin/contributor-relay.sh) counts toward consecutiveFailureQuarantineThreshold.
+// A permanent failure is a strong "nobody here can do this" signal, so it
+// advances the quarantine counter faster than an ordinary (possibly transient)
+// failure. With a weight of 3 and a threshold of 3, a single permanent failure
+// quarantines the issue immediately.
+const permanentFailureWeight = 3
+
 func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 	hub := &ContributeWSHub{
 		connections:           make(map[string]*ContributorConnection),
 		completedTasks:        make(map[string]time.Time),
 		completedTaskCooldown: make(map[string]time.Duration),
 		completedTaskPRURL:    make(map[string]string),
+		failedTasks:           make(map[string]time.Time),
+		consecutiveFailures:   make(map[string]int),
 		logger:                logger,
 		server:                server,
 	}
 	hub.loadCompletedTasks()
+	hub.loadFailedTasks()
 	hub.loadActivity()
 	go hub.cleanupLoop()
 	return hub
@@ -286,6 +342,74 @@ type completedTaskRecord struct {
 	CompletedAt   time.Time `json:"completed_at"`
 	CooldownHours float64   `json:"cooldown_hours,omitempty"`
 	PRURL         string    `json:"pr_url,omitempty"`
+}
+
+const failedTasksFile = "/data/contributors/failed-tasks.json"
+
+// failedTaskRecord is the on-disk shape of one failed-task entry (#2435). It
+// preserves the last-failure time and the running consecutive-failure count so a
+// hub restart does not reset a quarantine — otherwise a bounce would re-admit a
+// poison issue that had already earned its longer parking window.
+type failedTaskRecord struct {
+	FailedAt            time.Time `json:"failed_at"`
+	ConsecutiveFailures int       `json:"consecutive_failures,omitempty"`
+}
+
+func (h *ContributeWSHub) loadFailedTasks() {
+	h.completedMu.Lock()
+	defer h.completedMu.Unlock()
+	data, err := os.ReadFile(failedTasksFile)
+	if err != nil {
+		return
+	}
+	records := make(map[string]failedTaskRecord)
+	if json.Unmarshal(data, &records) != nil {
+		return
+	}
+	for k, rec := range records {
+		if rec.FailedAt.IsZero() {
+			continue
+		}
+		// Drop entries already past the longest failure-side window we could have
+		// applied (the quarantine cooldown) so we never resurrect a stale park.
+		if time.Since(rec.FailedAt) >= quarantineCooldownHours*time.Hour {
+			continue
+		}
+		if h.failedTasks != nil {
+			h.failedTasks[k] = rec.FailedAt
+		}
+		if h.consecutiveFailures != nil && rec.ConsecutiveFailures > 0 {
+			h.consecutiveFailures[k] = rec.ConsecutiveFailures
+		}
+	}
+	h.logger.Info("[contribute-ws] loaded failed tasks", "count", len(h.failedTasks))
+}
+
+func (h *ContributeWSHub) saveFailedTasks() {
+	h.completedMu.Lock()
+	saved := make(map[string]failedTaskRecord, len(h.failedTasks))
+	for k, t := range h.failedTasks {
+		rec := failedTaskRecord{FailedAt: t}
+		if h.consecutiveFailures != nil {
+			rec.ConsecutiveFailures = h.consecutiveFailures[k]
+		}
+		saved[k] = rec
+	}
+	h.completedMu.Unlock()
+	data, err := json.Marshal(saved)
+	if err != nil {
+		h.logger.Warn("[contribute-ws] failed tasks marshal failed", "error", err)
+		return
+	}
+	os.MkdirAll("/data/contributors", 0o755)
+	tmpPath := failedTasksFile + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		h.logger.Warn("[contribute-ws] failed tasks write failed", "error", err)
+		return
+	}
+	if err := os.Rename(tmpPath, failedTasksFile); err != nil {
+		h.logger.Warn("[contribute-ws] failed tasks rename failed", "error", err)
+	}
 }
 
 func (h *ContributeWSHub) loadCompletedTasks() {
@@ -392,8 +516,28 @@ func (h *ContributeWSHub) markTaskCompleted(repo string, number int, prURL strin
 	if h.completedTaskPRURL != nil {
 		h.completedTaskPRURL[key] = prURL
 	}
+	// A completion clears any failure history for the issue (#2435): the
+	// consecutive-failure counter resets so a flaky-then-fixed issue does not
+	// carry a stale quarantine, and the short failure cooldown is superseded by
+	// the (longer) completion cooldown recorded just above.
+	failureCleared := false
+	if h.failedTasks != nil {
+		if _, ok := h.failedTasks[key]; ok {
+			delete(h.failedTasks, key)
+			failureCleared = true
+		}
+	}
+	if h.consecutiveFailures != nil {
+		if _, ok := h.consecutiveFailures[key]; ok {
+			delete(h.consecutiveFailures, key)
+			failureCleared = true
+		}
+	}
 	h.completedMu.Unlock()
 	h.saveCompletedTasks()
+	if failureCleared {
+		h.saveFailedTasks()
+	}
 }
 
 // cooldownForLocked returns the cooldown duration to apply to key. Callers must
@@ -424,6 +568,86 @@ func (h *ContributeWSHub) isTaskInCooldown(repo string, number int) bool {
 		return false
 	}
 	return true
+}
+
+// recordTaskFailure books a task_failed against an issue (#2435). It stamps the
+// short failure cooldown and advances the issue's consecutive-failure counter
+// (a permanent failure advances it by permanentFailureWeight rather than one),
+// so a reliably-failing issue crosses consecutiveFailureQuarantineThreshold and
+// earns the longer quarantine window instead of being handed straight back out.
+// The counter is reset on completion (see markTaskCompleted).
+func (h *ContributeWSHub) recordTaskFailure(repo string, number int, permanent bool) {
+	key := fmt.Sprintf("%s#%d", repo, number)
+	weight := 1
+	if permanent {
+		weight = permanentFailureWeight
+	}
+	h.completedMu.Lock()
+	h.failedTasks[key] = time.Now()
+	h.consecutiveFailures[key] += weight
+	h.completedMu.Unlock()
+	h.saveFailedTasks()
+}
+
+// failureCooldownForLocked returns how long, from the last failure time, an
+// issue should be excluded from selection. It is the SHORT
+// failedTaskCooldownMinutes normally, or the LONGER quarantineCooldownHours once
+// the issue's consecutive-failure count has reached
+// consecutiveFailureQuarantineThreshold. Callers must hold completedMu.
+func (h *ContributeWSHub) failureCooldownForLocked(key string) time.Duration {
+	if h.consecutiveFailures[key] >= consecutiveFailureQuarantineThreshold {
+		return quarantineCooldownHours * time.Hour
+	}
+	return failedTaskCooldownMinutes * time.Minute
+}
+
+// isTaskInFailureCooldown reports whether an issue is currently excluded because
+// of a recent failure — either the short post-failure cooldown or the longer
+// quarantine (#2435). It self-heals in two stages so the failure-aware selection
+// backstop (recentFailureCount) still has something to work with just after the
+// short window lapses:
+//   - Once the APPLICABLE window (short cooldown, or quarantine) has elapsed the
+//     issue is admissible again → returns false.
+//   - The consecutive-failure COUNT is only cleared once the full quarantine
+//     window has elapsed. So an issue whose short cooldown just expired is
+//     admissible but still carries its failure history, letting selectTask
+//     deprioritise it behind never-failed peers rather than instantly restoring
+//     it to the head of the queue. The count also resets on completion.
+func (h *ContributeWSHub) isTaskInFailureCooldown(repo string, number int) bool {
+	key := fmt.Sprintf("%s#%d", repo, number)
+	h.completedMu.Lock()
+	defer h.completedMu.Unlock()
+	t, ok := h.failedTasks[key]
+	if !ok {
+		return false
+	}
+	// Keep the failure ledger for the full quarantine window (the longest window
+	// we could apply), then clear timestamp AND count together so stale history
+	// never lingers indefinitely. Retaining the timestamp past the short cooldown
+	// is what preserves the consecutive-failure count for the selection backstop.
+	if time.Since(t) > quarantineCooldownHours*time.Hour {
+		delete(h.failedTasks, key)
+		delete(h.consecutiveFailures, key)
+		return false
+	}
+	// Inside the quarantine window: excluded only while within the currently
+	// applicable cooldown (short cooldown, or the full quarantine once the count
+	// crosses the threshold). Past that, the issue is admissible again but its
+	// count remains on record — recentFailureCount reads it to deprioritise the
+	// issue behind never-failed peers.
+	return time.Since(t) <= h.failureCooldownForLocked(key)
+}
+
+// recentFailureCount returns the number of failures currently on record for an
+// issue (0 when none/expired). selectTask uses it as a stable tie-break so that,
+// among equally-admissible candidates, those without recent failures are offered
+// before those that have failed recently — guaranteeing forward progress even if
+// the failure cooldown has just elapsed (#2435 remedy 3 backstop).
+func (h *ContributeWSHub) recentFailureCount(repo string, number int) int {
+	key := fmt.Sprintf("%s#%d", repo, number)
+	h.completedMu.Lock()
+	defer h.completedMu.Unlock()
+	return h.consecutiveFailures[key]
 }
 
 func (h *ContributeWSHub) nextSeq() int {
@@ -847,11 +1071,20 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			if contributor != nil {
 				contributor.mu.Lock()
 				hasTask := contributor.currentTask != nil && contributor.currentTask.TaskID == msg.TaskID
+				failedTask := contributor.currentTask
 				contributor.currentTask = nil
 				contributor.tokenMintedAt = time.Time{}
 				contributor.mu.Unlock()
 
 				if hasTask {
+					if failedTask != nil {
+						// #2435: record a short failure cooldown (and advance the
+						// consecutive-failure/quarantine counter) so a just-failed
+						// issue is not immediately re-admissible and handed straight
+						// back out ahead of the rest of the queue. A permanent failure
+						// counts more toward the quarantine threshold.
+						h.recordTaskFailure(failedTask.Repo, failedTask.Number, msg.Permanent)
+					}
 					h.addActivity(contributor.profile.GitHubUsername, "failed", contributor.role, contributor.cliBackend, contributor.model, msg.TaskID)
 					h.logger.Info("[contribute-ws] task failed",
 						"username", contributor.profile.GitHubUsername,
@@ -1222,6 +1455,13 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		url      string
 		labels   []string
 		isOwn    bool
+		// recentFailures is the issue's current consecutive-failure count (#2435).
+		// It is a stable tie-break in the ordering below: among equally-admissible
+		// candidates, fewer-recent-failures first. Issues in an active failure
+		// cooldown are already excluded above, so this only deprioritises an issue
+		// whose short cooldown just elapsed but which still has failure history —
+		// a backstop that keeps the queue moving even if the ledger is imperfect.
+		recentFailures int
 	}
 	var candidates []candidate
 
@@ -1258,6 +1498,12 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				continue
 			}
 			if h.isTaskInCooldown(repo.Full, number) {
+				continue
+			}
+			// #2435: skip an issue still inside its short post-failure cooldown or
+			// its longer quarantine. This is the primary livelock fix — a failing
+			// issue at the head of the scan is no longer instantly re-admissible.
+			if h.isTaskInFailureCooldown(repo.Full, number) {
 				continue
 			}
 			if activeIssues[fmt.Sprintf("%s#%d", repo.Full, number)] {
@@ -1309,6 +1555,9 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				// username is unknown (empty), nothing is own → we keep today's
 				// ordering untouched.
 				isOwn: ownUsername != "" && strings.EqualFold(author, ownUsername),
+				// #2435: carry any lingering failure history so the ordering below
+				// can deprioritise a recently-failed issue within its bucket.
+				recentFailures: h.recentFailureCount(repo.Full, number),
 			})
 		}
 	}
@@ -1317,22 +1566,28 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		return nil
 	}
 
-	// Stable partition: own-work candidates first, in their original scan order;
-	// then everything else, also in original scan order. A stable sort keeps the
-	// established per-repo / creation ordering within each bucket, so when the
-	// contributor has no own work this is a no-op and behaviour is identical to
-	// the previous first-eligible pick.
-	ownFirst := make([]candidate, 0, len(candidates))
-	for _, cand := range candidates {
-		if cand.isOwn {
-			ownFirst = append(ownFirst, cand)
+	// Order the admissible set with a STABLE sort so the pick is deterministic
+	// (easy to reason about and to test — no randomness):
+	//   1. own-work first (#2390 — preserved unchanged);
+	//   2. then fewer recent failures first (#2435 remedy 3 backstop) — an issue
+	//      whose short failure cooldown has just elapsed but which still carries
+	//      failure history is deprioritised behind never-failed peers, so a
+	//      flaky issue can no longer monopolise the head of the queue even if the
+	//      ledger is imperfect;
+	//   3. otherwise the established per-repo / creation scan order is kept.
+	// When the contributor has no own work AND nothing has failed, this is a no-op
+	// and behaviour is identical to the previous first-eligible pick.
+	ownFirst := make([]candidate, len(candidates))
+	copy(ownFirst, candidates)
+	sort.SliceStable(ownFirst, func(i, j int) bool {
+		if ownFirst[i].isOwn != ownFirst[j].isOwn {
+			return ownFirst[i].isOwn // own work sorts ahead of non-own
 		}
-	}
-	for _, cand := range candidates {
-		if !cand.isOwn {
-			ownFirst = append(ownFirst, cand)
+		if ownFirst[i].recentFailures != ownFirst[j].recentFailures {
+			return ownFirst[i].recentFailures < ownFirst[j].recentFailures // fewer failures first
 		}
-	}
+		return false // equal keys → SliceStable preserves original scan order
+	})
 
 	chosen := ownFirst[0]
 	if chosen.isOwn {

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -740,7 +740,26 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				"role", contributor.role,
 			)
 			task := h.selectTask(contributor)
-			if task != nil {
+			switch {
+			case task == nil:
+				// No admissible work and no enforced refusal (e.g. suspended, no
+				// status yet, or an empty candidate set). Behaviour unchanged.
+				h.logger.Info("[contribute-ws] no tasks available",
+					"username", contributor.profile.GitHubUsername,
+				)
+			case task.Type == "task_unavailable":
+				// #2436 finding 1/2/3: an explicit negative-ack (mint failure,
+				// disabled tier, or concurrency limit) rather than silence. Send it
+				// so the contributor can diagnose instead of hanging forever.
+				if err := sendJSON(conn, *task); err != nil {
+					h.logger.Warn("[contribute-ws] failed to send task_unavailable", "error", err)
+					return
+				}
+				h.logger.Info("[contribute-ws] task unavailable",
+					"username", contributor.profile.GitHubUsername,
+					"reason", task.Reason,
+				)
+			default:
 				if err := sendJSON(conn, *task); err != nil {
 					h.logger.Warn("[contribute-ws] failed to send task_assign", "error", err)
 					return
@@ -752,10 +771,6 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					"task", task.TaskID,
 					"repo", task.Repo,
 					"number", task.Number,
-				)
-			} else {
-				h.logger.Info("[contribute-ws] no tasks available",
-					"username", contributor.profile.GitHubUsername,
 				)
 			}
 
@@ -1030,6 +1045,52 @@ func (h *ContributeWSHub) mintScopedToken(tier string) (string, error) {
 	return "", nil
 }
 
+// taskUnavailableReason* are the machine-readable reasons carried on a
+// task_unavailable negative-ack. They let the relay (and operators reading the
+// log) tell "there is simply no admissible work right now" apart from "the hub
+// refused to assign work to this contributor" for a specific enforced reason.
+// See kubestellar/hive#2436.
+const (
+	// taskUnavailableTokenMintFailed: a scoped GitHub token could not be minted
+	// for the contributor's tier (e.g. the installation lacks the permission the
+	// tier requests), so no task_assign can be honestly issued. Previously this
+	// path returned nil and the contributor waited forever with no explanation.
+	taskUnavailableTokenMintFailed = "token_mint_failed"
+	// taskUnavailableTierDisabled: the contributor's TrustTier is listed in
+	// hub.disabled_tiers, so the operator has switched that tier off.
+	taskUnavailableTierDisabled = "tier_disabled"
+	// taskUnavailableConcurrencyLimit: assigning would exceed the tier's
+	// tier_limits.max_concurrent for this identity (counting every live
+	// connection this identity holds).
+	taskUnavailableConcurrencyLimit = "concurrency_limit"
+)
+
+// identityOf returns the stable key that groups a contributor's live
+// connections for per-identity concurrency accounting (#2436 finding 3). The
+// registered ContributorID is preferred; GitHubUsername is the fallback for
+// connections whose profile predates or lacks an ID. Two WebSocket connections
+// opened by the same registered contributor therefore share one identity.
+func identityOf(c *ContributorConnection) string {
+	if c == nil || c.profile == nil {
+		return ""
+	}
+	if c.profile.ContributorID != "" {
+		return c.profile.ContributorID
+	}
+	return c.profile.GitHubUsername
+}
+
+// taskUnavailable builds the explicit negative-ack the ready handler sends in
+// place of silence. It carries a machine-readable reason so the failure is
+// diagnosable rather than an indefinite hang (kubestellar/hive#2436, finding 1).
+func (h *ContributeWSHub) taskUnavailable(reason string) *WSMessage {
+	return &WSMessage{
+		Type:   "task_unavailable",
+		Seq:    h.nextSeq(),
+		Reason: reason,
+	}
+}
+
 func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	h.selectMu.Lock()
 	defer h.selectMu.Unlock()
@@ -1049,16 +1110,61 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		return nil
 	}
 
+	// #2436 finding 2: refuse to assign work to a contributor whose TrustTier is
+	// switched off via hub.disabled_tiers. This control was declared and
+	// admin-writable but never read, so an operator "disabling" a tier changed
+	// nothing. Send an explicit tier_disabled negative-ack rather than silently
+	// handing out work anyway.
+	tier := ""
+	if c.profile != nil {
+		tier = c.profile.TrustTier
+	}
+	if h.server.deps != nil && h.server.deps.Config != nil {
+		for _, dt := range h.server.deps.Config.Hub.DisabledTiers {
+			if dt == tier {
+				h.logger.Warn("[contribute-ws] refusing task: tier disabled",
+					"username", identityOf(c), "tier", tier)
+				return h.taskUnavailable(taskUnavailableTierDisabled)
+			}
+		}
+	}
+
+	// activeIssues tracks issues already held by SOME live connection so we do
+	// not double-assign the same work item. identityHolds counts, per identity,
+	// how many tasks that identity currently holds across ALL of its live
+	// connections — the source of truth for the #2436 finding 3 concurrency gate
+	// (one identity opening several connections must not exceed MaxConcurrent).
 	activeIssues := make(map[string]bool)
+	identityHolds := make(map[string]int)
 	h.mu.RLock()
 	for _, conn := range h.connections {
 		conn.mu.Lock()
 		if conn.currentTask != nil {
 			activeIssues[fmt.Sprintf("%s#%d", conn.currentTask.Repo, conn.currentTask.Number)] = true
+			identityHolds[identityOf(conn)]++
 		}
 		conn.mu.Unlock()
 	}
 	h.mu.RUnlock()
+
+	// #2436 finding 3: enforce tier_limits.max_concurrent per identity. The
+	// config ships populated MaxConcurrent defaults, so an operator reasonably
+	// believes concurrency is capped; before this it was inert. A limit <= 0 is
+	// treated as "unlimited" (the "advisor" default is 0 and existing configs
+	// that never set the field must keep working). MaxPerHour / MaxPerDay remain
+	// TODO(#2436): they require per-identity rate counters that are not tracked
+	// today, so they are intentionally left unenforced rather than pretended —
+	// see the PR note. Only MaxConcurrent is wired here.
+	if h.server.deps != nil && h.server.deps.Config != nil {
+		if limits, ok := h.server.deps.Config.Hub.TierLimits[tier]; ok && limits.MaxConcurrent > 0 {
+			if identityHolds[identityOf(c)] >= limits.MaxConcurrent {
+				h.logger.Warn("[contribute-ws] refusing task: concurrency limit reached",
+					"username", identityOf(c), "tier", tier,
+					"held", identityHolds[identityOf(c)], "max_concurrent", limits.MaxConcurrent)
+				return h.taskUnavailable(taskUnavailableConcurrencyLimit)
+			}
+		}
+	}
 
 	totalAvailable := 0
 	for _, repo := range status.Repos {
@@ -1239,9 +1345,16 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	// arms the refresh ticker for the token we hand out here.
 	ghToken, err := h.mintScopedToken(c.profile.TrustTier)
 	if err != nil {
-		h.logger.Warn("[contribute-ws] failed to mint scoped token — skipping task",
+		// #2436 finding 1: a mint failure previously returned nil, stranding the
+		// contributor with no message (the log even said "skipping task" while
+		// abandoning the whole selection). Send an explicit token_mint_failed
+		// negative-ack so the failure is diagnosable instead of an indefinite
+		// hang. We do not fall through to another candidate: the mint is keyed on
+		// the contributor's tier, not the candidate, so every candidate in this
+		// pass would fail identically. Preserve the existing Warn log.
+		h.logger.Warn("[contribute-ws] failed to mint scoped token — task unavailable",
 			"tier", c.profile.TrustTier, "error", err)
-		return nil
+		return h.taskUnavailable(taskUnavailableTokenMintFailed)
 	}
 
 	taskID := fmt.Sprintf("ct-%s-%d-%d", chosen.repoFull, chosen.number, time.Now().Unix())

--- a/v2/pkg/dashboard/contribute_ws_integration_test.go
+++ b/v2/pkg/dashboard/contribute_ws_integration_test.go
@@ -1,0 +1,513 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// contribute_ws_integration_test.go is the INTEGRATION test called for by
+// kubestellar/hive#2413: v2/pkg/dashboard/contribute_ws.go's selectTask is
+// modified by a chain of PRs, each of which added its own isolated unit tests
+// (contribute_ws_more_coverage_test.go for #2408/#2409, provision_approve_
+// coverage_test.go for #2410, contribute_ws_trust_controls_test.go for #2436,
+// contribute_ws_livelock_test.go for #2435). None of them exercises the
+// COMBINED behavior of a queue that mixes every kind of candidate at once.
+// This file does that: it builds one status payload/hub state carrying own
+// work, cooldown issues (with and without a reported PR), quarantined/
+// recently-failed issues, and trust-tier restrictions together, then asserts
+// selectTask's priority order and gating end to end.
+//
+// Scope note on #2410 (ClaimDelivered reset): issue #2413 lists #2410 as a
+// third PR modifying selectTask's queue/state lifecycle. It does not. #2410
+// ("hub: re-arm ClaimDelivered on approve-provision (re)assignment") touches
+// SaaSHive.ClaimDelivered in v2/pkg/hub/saas.go — the hub/spoke SaaS
+// provisioning claim handshake — a completely different subsystem from the
+// contributor task queue in this package. contribute_ws.go's selectTask has
+// no ClaimDelivered field or recycled-placeholder concept; grepping this
+// package for "ClaimDelivered" and "SaaSHive" turns up nothing. There is
+// nothing in selectTask's combined behavior to integration-test for #2410,
+// so no scenario below references it. #2410 already has its own regression
+// coverage in v2/pkg/hub/provision_approve_coverage_test.go
+// (TestHandleApproveProvisionRearmClaimDelivered).
+//
+// PRs actually covered here, all confirmed by reading contribute_ws.go at
+// HEAD (v2 branch) before writing this file:
+//   #2408 — conditional cooldown by pr_url (completedTaskCooldownHours=168h
+//           with a PR, completedNoPRCooldownHours=4h without)
+//   #2409 — own-authored candidates ordered ahead of everyone else's work
+//   #2436 (via #2456 + #2437) — disabled_tiers refusal, tier_limits.
+//           MaxConcurrent enforced per identity, and auto-promotion gated on
+//           TasksWithPR (a PR-less task_complete does not promote)
+//   #2435 (via #2455) — task_failed records a short failure cooldown,
+//           consecutive failures quarantine an issue for the longer window,
+//           and the failure-aware stable sort deprioritizes a recently-failed
+//           issue behind never-failed peers so the queue cannot livelock
+
+// intgIssue is a small builder for the map[string]any shape selectTask reads
+// out of FrontendRepo.ActionableIssues (see oneActionableIssue /
+// twoIssueStatus in the sibling _test.go files for the same shape used in
+// isolation).
+func intgIssue(number int, title, author string, assignees []string) map[string]any {
+	issue := map[string]any{
+		"number": float64(number),
+		"title":  title,
+		"url":    "https://github.com/myorg/repo1/issues/" + itoa(number),
+		"author": author,
+	}
+	if len(assignees) > 0 {
+		anyAssignees := make([]any, len(assignees))
+		for i, a := range assignees {
+			anyAssignees[i] = a
+		}
+		issue["assignees"] = anyAssignees
+	}
+	return issue
+}
+
+// itoa avoids pulling in strconv just for this file's URL-building.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// setStatusIssues installs a status with exactly the given actionable issues
+// in one repo (myorg/repo1), replacing whatever was there before. Centralizing
+// this (rather than repeating the StatusPayload literal per case) keeps the
+// table cases in this file focused on WHICH issues are present, not on
+// plumbing.
+func setStatusIssues(s *Server, issues ...map[string]any) {
+	anyIssues := make([]any, len(issues))
+	for i, iss := range issues {
+		anyIssues[i] = iss
+	}
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{
+			{
+				Name:             "repo1",
+				Full:             "myorg/repo1",
+				ActionableIssues: anyIssues,
+			},
+		},
+	}
+	s.statusMu.Unlock()
+}
+
+// TestIntegration_SelectTask_PriorityOrdering builds a queue mixing:
+//   - an issue authored by the connecting contributor ("own work", #2409)
+//   - an issue authored by someone else, never failed
+//   - an issue authored by someone else that has ONE recent (non-quarantining)
+//     failure on record, admissible again but deprioritized (#2435 remedy 3)
+//
+// and asserts selectTask's stable sort delivers them in exactly the order the
+// combined PRs specify: own work first, then fewer-recent-failures first,
+// then scan order — regardless of the failed issue's earlier position in the
+// scan.
+func TestIntegration_SelectTask_PriorityOrdering(t *testing.T) {
+	hub, s := covK2Hub(t)
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+
+	// Scan order: #1 (someone else, one recent failure, AHEAD in scan order),
+	// #2 (someone else, never failed), #3 (alice's own work, LAST in scan
+	// order). Pre-#2409 first-eligible behavior would pick #1. Post-#2409
+	// alone (ignoring #2435) would pick #3 (own work) correctly on the first
+	// call but, once #3 is taken, would fall back to plain scan order and
+	// hand out #1 (recently failed) ahead of #2 (clean) — the exact ordering
+	// bug #2435 fixes. This test asserts the FULL combined order across two
+	// consecutive selections.
+	setStatusIssues(s,
+		intgIssue(1, "Someone else's issue, will fail once", "bob", nil),
+		intgIssue(2, "Someone else's clean issue", "carol", nil),
+		intgIssue(3, "Alice's own work", "alice", nil),
+	)
+
+	// Give #1 one recorded (non-quarantining) failure, then age it past the
+	// SHORT cooldown so it is admissible again but still deprioritized by the
+	// #2435 remedy-3 backstop.
+	hub.recordTaskFailure("myorg/repo1", 1, false)
+	hub.completedMu.Lock()
+	hub.failedTasks["myorg/repo1#1"] = time.Now().Add(-(failedTaskCooldownMinutes + 1) * time.Minute)
+	hub.completedMu.Unlock()
+	if hub.isTaskInFailureCooldown("myorg/repo1", 1) {
+		t.Fatalf("setup: #1's short failure cooldown should have elapsed for this ordering check")
+	}
+
+	// First selection: own work (#3) must win despite being last in scan
+	// order and despite #1/#2 being fully admissible (#2409, preserved by
+	// #2435's sort which checks isOwn before recentFailures).
+	first := hub.selectTask(conn)
+	if first == nil || first.Type != "task_assign" {
+		t.Fatalf("expected a task_assign, got %+v", first)
+	}
+	if first.Number != 3 {
+		t.Fatalf("expected own work (#3) prioritized first (#2409), got #%d", first.Number)
+	}
+
+	// Release #3 (simulate it becoming active elsewhere is not needed — clear
+	// currentTask and re-seed so #3 is no longer offered a second time via the
+	// activeIssues guard, keeping focus on the #1 vs #2 ordering).
+	conn.mu.Lock()
+	conn.currentTask = nil
+	conn.mu.Unlock()
+	setStatusIssues(s,
+		intgIssue(1, "Someone else's issue, will fail once", "bob", nil),
+		intgIssue(2, "Someone else's clean issue", "carol", nil),
+	)
+
+	// Second selection: with own work gone, #2 (never failed) must be
+	// preferred over #1 (one recent failure) even though #1 is ahead in scan
+	// order — the #2435 remedy-3 backstop that prevents a flaky head-of-scan
+	// issue from monopolizing the queue.
+	second := hub.selectTask(conn)
+	if second == nil {
+		t.Fatalf("expected a second assignment, got nil")
+	}
+	if second.Number == 1 {
+		t.Fatalf("failure-aware backstop broken: recently-failed #1 was offered ahead of clean #2")
+	}
+	if second.Number != 2 {
+		t.Fatalf("expected clean #2 preferred over recently-failed #1, got #%d", second.Number)
+	}
+}
+
+// TestIntegration_SelectTask_CooldownTiming validates #2408 in the same
+// combined-queue shape used elsewhere in this file: a completion WITH a
+// pr_url excludes the issue for the long (168h) window, while a completion
+// WITHOUT one excludes it only for the short (4h) window — verified via the
+// same isTaskInCooldown/selectTask exclusion path exercised end to end.
+func TestIntegration_SelectTask_CooldownTiming(t *testing.T) {
+	hub, s := covK2Hub(t)
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "dave", ContributorID: "c-dave", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+
+	// #10 completed WITH a PR: full 168h cooldown.
+	hub.markTaskCompleted("myorg/repo1", 10, "https://github.com/myorg/repo1/pull/1")
+	// #20 completed WITHOUT a PR: short 4h cooldown.
+	hub.markTaskCompleted("myorg/repo1", 20, "")
+
+	setStatusIssues(s,
+		intgIssue(10, "Shipped a PR", "someone", nil),
+		intgIssue(20, "Went idle, no PR", "someone", nil),
+		intgIssue(30, "Untouched, always eligible", "someone", nil),
+	)
+
+	// Immediately after completion both #10 and #20 are excluded; only #30 is
+	// admissible.
+	msg := hub.selectTask(conn)
+	if msg == nil || msg.Number != 30 {
+		t.Fatalf("expected only #30 admissible right after both completions, got %+v", msg)
+	}
+
+	// Age both completions past the SHORT (4h) window but still well inside
+	// the LONG (168h) window: #20 (no-PR) must now be admissible again, #10
+	// (with-PR) must still be excluded.
+	hub.completedMu.Lock()
+	hub.completedTasks["myorg/repo1#10"] = time.Now().Add(-(completedNoPRCooldownHours + 1) * time.Hour)
+	hub.completedTasks["myorg/repo1#20"] = time.Now().Add(-(completedNoPRCooldownHours + 1) * time.Hour)
+	hub.completedMu.Unlock()
+
+	if !hub.isTaskInCooldown("myorg/repo1", 10) {
+		t.Fatalf("with-PR completion (#10) must still be in cooldown after only %dh (full cooldown is %dh)",
+			completedNoPRCooldownHours+1, completedTaskCooldownHours)
+	}
+	if hub.isTaskInCooldown("myorg/repo1", 20) {
+		t.Fatalf("no-PR completion (#20) must be released after %dh, not held for the full %dh",
+			completedNoPRCooldownHours, completedTaskCooldownHours)
+	}
+
+	conn.mu.Lock()
+	conn.currentTask = nil
+	conn.mu.Unlock()
+	setStatusIssues(s,
+		intgIssue(10, "Shipped a PR", "someone", nil),
+		intgIssue(20, "Went idle, no PR", "someone", nil),
+	)
+	msg2 := hub.selectTask(conn)
+	if msg2 == nil {
+		t.Fatalf("expected #20 to be admissible again, got nil")
+	}
+	if msg2.Number != 20 {
+		t.Fatalf("expected released no-PR issue #20 to be selected, got #%d", msg2.Number)
+	}
+}
+
+// TestIntegration_SelectTask_TrustControls exercises #2436's two selectTask-
+// level gates (disabled_tiers refusal and per-identity MaxConcurrent) inside
+// the same mixed-queue shape as the other cases, confirming they compose with
+// the #2409 own-work ordering and #2408 cooldown filtering rather than only
+// working in isolation.
+func TestIntegration_SelectTask_TrustControls(t *testing.T) {
+	hub, s := covK2Hub(t)
+
+	setStatusIssues(s, intgIssue(1, "Admissible issue", "someone", nil))
+
+	// Disabled tier: refused outright with an explicit negative-ack, never
+	// silently handed the admissible issue that exists in the queue.
+	disabled := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "erin", ContributorID: "c-erin", TrustTier: "newcomer"},
+		lastPong: time.Now(),
+	}
+	s.deps.Config.Hub.DisabledTiers = []string{"newcomer"}
+	msg := hub.selectTask(disabled)
+	if msg == nil || msg.Type != "task_unavailable" || msg.Reason != taskUnavailableTierDisabled {
+		t.Fatalf("expected task_unavailable/%s for a disabled tier, got %+v", taskUnavailableTierDisabled, msg)
+	}
+	s.deps.Config.Hub.DisabledTiers = nil
+
+	// MaxConcurrent: a second live connection for the SAME identity, already
+	// holding one task at the configured limit of 1, is refused even though
+	// the queue has an admissible issue.
+	s.deps.Config.Hub.TierLimits = map[string]config.TierRate{
+		"contributor": {MaxConcurrent: 1},
+	}
+	held := &ContributorConnection{
+		profile:     &ContributorProfile{GitHubUsername: "frank", ContributorID: "c-frank", TrustTier: "contributor"},
+		currentTask: &WSTaskAssign{TaskID: "t-held", Repo: "myorg/other", Number: 99},
+		lastPong:    time.Now(),
+	}
+	second := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "frank", ContributorID: "c-frank", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["conn-held"] = held
+	hub.connections["conn-second"] = second
+	hub.mu.Unlock()
+
+	setStatusIssues(s, intgIssue(1, "Admissible issue", "someone", nil))
+	msg2 := hub.selectTask(second)
+	if msg2 == nil || msg2.Type != "task_unavailable" || msg2.Reason != taskUnavailableConcurrencyLimit {
+		t.Fatalf("expected task_unavailable/%s at MaxConcurrent=1, got %+v", taskUnavailableConcurrencyLimit, msg2)
+	}
+
+	// Raising the limit admits the second connection to the same queue.
+	s.deps.Config.Hub.TierLimits["contributor"] = config.TierRate{MaxConcurrent: 2}
+	setStatusIssues(s, intgIssue(1, "Admissible issue", "someone", nil))
+	msg3 := hub.selectTask(second)
+	if msg3 == nil || msg3.Type != "task_assign" || msg3.Number != 1 {
+		t.Fatalf("expected task_assign for #1 once MaxConcurrent raised to 2, got %+v", msg3)
+	}
+}
+
+// TestIntegration_SelectTask_PromotionRequiresPR exercises the #2436/#2437
+// promotion gate through the real WebSocket task_complete handler (not just
+// the hub method), confirming that a task_complete with an empty PRURL does
+// NOT advance a newcomer toward auto-promotion, while one that reports a
+// PRURL does.
+func TestIntegration_SelectTask_PromotionRequiresPR(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	body := `{"github_username":"promotion-user"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn) // auth_ok
+
+	// Drive contributorAutoPromoteAt PR-less completions. Each requires its
+	// own task_assign first (task_complete for an unassigned task is a no-op).
+	for i := 0; i < contributorAutoPromoteAt; i++ {
+		s.statusMu.Lock()
+		s.status = &StatusPayload{
+			Repos: []FrontendRepo{
+				{
+					Name: "repo1",
+					Full: "myorg/repo1",
+					ActionableIssues: []any{
+						intgIssue(100+i, "No-PR completion round", "someone", nil),
+					},
+				},
+			},
+		}
+		s.statusMu.Unlock()
+
+		conn.WriteJSON(WSMessage{Type: "ready", Seq: i + 2})
+		assign := readMsg(t, conn)
+		if assign.Type != "task_assign" {
+			t.Fatalf("round %d: expected task_assign, got %+v", i, assign)
+		}
+		conn.WriteJSON(WSMessage{Type: "task_complete", TaskID: assign.TaskID, Result: "no_pr", PRURL: ""})
+		time.Sleep(30 * time.Millisecond)
+	}
+
+	p := findContributor(reg["contributor_id"])
+	if p == nil {
+		t.Fatalf("contributor not found")
+	}
+	if p.TasksCompleted != contributorAutoPromoteAt {
+		t.Fatalf("expected %d completions recorded, got %d", contributorAutoPromoteAt, p.TasksCompleted)
+	}
+	if p.TrustTier != "newcomer" {
+		t.Fatalf("PR-less completions must NOT auto-promote (#2436/#2437): expected still newcomer, got %q", p.TrustTier)
+	}
+
+	// One completion that DOES report a PR must advance TasksWithPR and, once
+	// it reaches contributorAutoPromoteAt, promote the contributor.
+	for p.TasksWithPR < contributorAutoPromoteAt {
+		s.statusMu.Lock()
+		s.status = &StatusPayload{
+			Repos: []FrontendRepo{
+				{
+					Name: "repo1",
+					Full: "myorg/repo1",
+					ActionableIssues: []any{
+						intgIssue(200+p.TasksWithPR, "PR-shipping round", "someone", nil),
+					},
+				},
+			},
+		}
+		s.statusMu.Unlock()
+
+		conn.WriteJSON(WSMessage{Type: "ready", Seq: 1000 + p.TasksWithPR})
+		assign := readMsg(t, conn)
+		if assign.Type != "task_assign" {
+			t.Fatalf("expected task_assign while driving TasksWithPR, got %+v", assign)
+		}
+		prURL := "https://github.com/myorg/repo1/pull/" + itoa(500+p.TasksWithPR)
+		conn.WriteJSON(WSMessage{Type: "task_complete", TaskID: assign.TaskID, Result: "pr_created", PRURL: prURL})
+		time.Sleep(30 * time.Millisecond)
+		p = findContributor(reg["contributor_id"])
+		if p == nil {
+			t.Fatalf("contributor disappeared mid-loop")
+		}
+	}
+	if p.TrustTier != "contributor" {
+		t.Fatalf("expected auto-promotion to contributor once TasksWithPR reached %d, got tier %q (TasksWithPR=%d)",
+			contributorAutoPromoteAt, p.TrustTier, p.TasksWithPR)
+	}
+}
+
+// TestIntegration_SelectTask_FailureQuarantineDoesNotStarveQueue is the
+// end-to-end livelock regression (#2435) run inside a queue that ALSO carries
+// own work and a cooldown issue (#2408/#2409), confirming quarantine composes
+// with the rest of selectTask rather than only being provable in isolation.
+// A repeatedly-failing head-of-scan issue must not starve a second admissible
+// issue, and once it crosses the quarantine threshold it is parked for the
+// long window while the rest of the queue keeps moving.
+func TestIntegration_SelectTask_FailureQuarantineDoesNotStarveQueue(t *testing.T) {
+	hub, s := covK2Hub(t)
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "grace", ContributorID: "c-grace", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+
+	// #999 is completed (in a long cooldown) and must never be offered
+	// regardless of the failure/own-work behavior under test.
+	hub.markTaskCompleted("myorg/repo1", 999, "https://github.com/myorg/repo1/pull/1")
+
+	poisonRepo, poisonNum := "myorg/repo1", 1
+	goodNum := 2
+
+	// Round 0: with no failure history yet, the poison issue (head of scan,
+	// #1) is the expected pick — proving it is genuinely admissible and
+	// genuinely ahead in scan order before any #2435 defense engages.
+	setStatusIssues(s,
+		intgIssue(poisonNum, "Reliably failing issue (head of scan)", "someone", nil),
+		intgIssue(goodNum, "Healthy second issue", "someone", nil),
+		intgIssue(999, "Completed, in cooldown", "someone", nil),
+	)
+	first := hub.selectTask(conn)
+	if first == nil || first.Number != poisonNum {
+		t.Fatalf("expected poison issue #%d first (no failures yet), got %+v", poisonNum, first)
+	}
+	conn.mu.Lock()
+	conn.currentTask = nil
+	conn.mu.Unlock()
+
+	// Drive the poison issue's failure count directly to
+	// consecutiveFailureQuarantineThreshold (mirroring the real client flow:
+	// each round the contributor is handed it, fails it, and the ledger
+	// advances) rather than relying on selectTask to keep re-offering it —
+	// once its own short cooldown is active it is legitimately NOT re-offered
+	// (that is remedy 1 working), so the queue naturally serves #2 in between.
+	// What we're proving here is the CONSEQUENCE: after enough failures the
+	// issue crosses into quarantine and the queue keeps moving throughout.
+	for i := 0; i < consecutiveFailureQuarantineThreshold; i++ {
+		hub.recordTaskFailure(poisonRepo, poisonNum, false)
+	}
+
+	// Livelock check at the first failure: with the poison issue in its short
+	// cooldown, the very next selection must serve the healthy issue instead
+	// of starving (this is remedy 1 in isolation — the head-of-scan issue no
+	// longer monopolizes the queue after a single failure).
+	setStatusIssues(s,
+		intgIssue(poisonNum, "Reliably failing issue (short cooldown)", "someone", nil),
+		intgIssue(goodNum, "Healthy second issue", "someone", nil),
+	)
+	afterFirstFailure := hub.selectTask(conn)
+	if afterFirstFailure == nil {
+		t.Fatalf("expected the healthy issue to be offered right after the first failure, got nil (queue starved)")
+	}
+	if afterFirstFailure.Number != goodNum {
+		t.Fatalf("expected healthy issue #%d offered while #%d is in its short failure cooldown, got #%d",
+			goodNum, poisonNum, afterFirstFailure.Number)
+	}
+	conn.mu.Lock()
+	conn.currentTask = nil
+	conn.mu.Unlock()
+
+	// After consecutiveFailureQuarantineThreshold failures the poison issue
+	// must be quarantined for the LONG window, not just short-cooldown.
+	if !hub.isTaskInFailureCooldown(poisonRepo, poisonNum) {
+		t.Fatalf("expected poison issue quarantined after %d consecutive failures", consecutiveFailureQuarantineThreshold)
+	}
+
+	// The queue must still be able to make forward progress: the healthy
+	// second issue is offered instead of starving behind the poison one.
+	setStatusIssues(s,
+		intgIssue(poisonNum, "Reliably failing issue (quarantined)", "someone", nil),
+		intgIssue(goodNum, "Healthy second issue", "someone", nil),
+	)
+	final := hub.selectTask(conn)
+	if final == nil {
+		t.Fatalf("expected the healthy issue to be offered, got nil (queue starved by quarantined poison issue)")
+	}
+	if final.Number != goodNum {
+		t.Fatalf("expected healthy issue #%d offered while #%d is quarantined, got #%d", goodNum, poisonNum, final.Number)
+	}
+}

--- a/v2/pkg/dashboard/contribute_ws_livelock_test.go
+++ b/v2/pkg/dashboard/contribute_ws_livelock_test.go
@@ -1,0 +1,284 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// twoIssueStatus seeds a status with two admissible issues in the same repo:
+// A (#10, ahead in scan order) and B (#20). Neither is authored by the test
+// contributor, so #2390 own-work ordering is inert and the pick is driven purely
+// by scan order and the #2435 failure ledger.
+func twoIssueStatus(s *Server) {
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{
+			{
+				Name: "repo1",
+				Full: "myorg/repo1",
+				ActionableIssues: []any{
+					map[string]any{
+						"number": float64(10),
+						"title":  "Issue A (head of scan order)",
+						"url":    "https://github.com/myorg/repo1/issues/10",
+						"author": "someone",
+					},
+					map[string]any{
+						"number": float64(20),
+						"title":  "Issue B (starved before the fix)",
+						"url":    "https://github.com/myorg/repo1/issues/20",
+						"author": "someone",
+					},
+				},
+			},
+		},
+	}
+	s.statusMu.Unlock()
+}
+
+// TestQueueLivelock_FailureCooldownFreesStarvedIssue is the #2435 regression:
+// before the fix, task_failed recorded no cooldown and selectTask had no
+// failure-aware ranking, so the same head-of-scan issue (A/#10) was handed out
+// over and over while B/#20 was never offered. After the fix, once A fails it is
+// parked by the short failure cooldown, so the very next assignment must NOT be A
+// again immediately, and B must be offered.
+func TestQueueLivelock_FailureCooldownFreesStarvedIssue(t *testing.T) {
+	hub, s := covK2Hub(t)
+	twoIssueStatus(s)
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "ct", ContributorID: "c-ct", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+
+	// First assignment: head-of-scan issue A (#10).
+	msg := hub.selectTask(conn)
+	if msg == nil {
+		t.Fatalf("expected an assignment, got nil")
+	}
+	if msg.Number != 10 {
+		t.Fatalf("expected first assignment to be head-of-scan A (#10), got #%d", msg.Number)
+	}
+
+	// The contributor reports task_failed for A. Clear currentTask as the real
+	// task_failed handler does, then record the failure through the same hub path
+	// the handler uses.
+	conn.mu.Lock()
+	conn.currentTask = nil
+	conn.mu.Unlock()
+	hub.recordTaskFailure("myorg/repo1", 10, false)
+
+	// Next assignment MUST NOT be A again immediately — it is in the short failure
+	// cooldown — and B (#20) is offered instead. This is the exact behaviour that
+	// was broken: pre-fix this returned #10 again.
+	msg2 := hub.selectTask(conn)
+	if msg2 == nil {
+		t.Fatalf("expected B to be offered after A failed, got nil (queue starved)")
+	}
+	if msg2.Number == 10 {
+		t.Fatalf("livelock: A (#10) was re-offered immediately after failing; expected it parked in failure cooldown")
+	}
+	if msg2.Number != 20 {
+		t.Fatalf("expected the starved issue B (#20) to be offered, got #%d", msg2.Number)
+	}
+
+	// Sanity: A really is in failure cooldown, and its short window is far shorter
+	// than any completion cooldown.
+	if !hub.isTaskInFailureCooldown("myorg/repo1", 10) {
+		t.Fatalf("A should be in failure cooldown right after a task_failed")
+	}
+	if failedTaskCooldownMinutes*time.Minute >= completedNoPRCooldownHours*time.Hour {
+		t.Fatalf("failure cooldown (%dm) must be far shorter than the no-PR completion cooldown (%dh)",
+			failedTaskCooldownMinutes, completedNoPRCooldownHours)
+	}
+}
+
+// TestQueueLivelock_ConsecutiveFailuresQuarantine verifies remedy 2: an issue
+// that fails consecutiveFailureQuarantineThreshold times is parked for the
+// LONGER quarantine window, not just the short failure cooldown.
+func TestQueueLivelock_ConsecutiveFailuresQuarantine(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	for i := 0; i < consecutiveFailureQuarantineThreshold; i++ {
+		hub.recordTaskFailure("myorg/repo1", 10, false)
+	}
+	if !hub.isTaskInFailureCooldown("myorg/repo1", 10) {
+		t.Fatalf("issue should be quarantined after %d failures", consecutiveFailureQuarantineThreshold)
+	}
+
+	// Age the last failure just past the SHORT cooldown but well inside the
+	// quarantine window: a non-quarantined issue would be free, a quarantined one
+	// is still parked.
+	hub.completedMu.Lock()
+	hub.failedTasks["myorg/repo1#10"] = time.Now().Add(-(failedTaskCooldownMinutes + 1) * time.Minute)
+	hub.completedMu.Unlock()
+	if !hub.isTaskInFailureCooldown("myorg/repo1", 10) {
+		t.Fatalf("quarantined issue must stay parked past the short cooldown (quarantine is %dh)", quarantineCooldownHours)
+	}
+
+	// Age it past the full quarantine window: now it self-heals and the counter
+	// resets.
+	hub.completedMu.Lock()
+	hub.failedTasks["myorg/repo1#10"] = time.Now().Add(-(quarantineCooldownHours + 1) * time.Hour)
+	hub.completedMu.Unlock()
+	if hub.isTaskInFailureCooldown("myorg/repo1", 10) {
+		t.Fatalf("quarantine should expire after %dh", quarantineCooldownHours)
+	}
+	if hub.recentFailureCount("myorg/repo1", 10) != 0 {
+		t.Fatalf("consecutive-failure count should reset once the quarantine expires")
+	}
+}
+
+// TestQueueLivelock_PermanentFailureQuarantinesFaster verifies that a permanent
+// failure (msg.Permanent) crosses the quarantine threshold in a single report,
+// whereas one ordinary failure only earns the short cooldown.
+func TestQueueLivelock_PermanentFailureQuarantinesFaster(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	// One ordinary failure: short cooldown only, NOT quarantined. Prove it by
+	// aging past the short window — it frees.
+	hub.recordTaskFailure("myorg/repo1", 30, false)
+	hub.completedMu.Lock()
+	hub.failedTasks["myorg/repo1#30"] = time.Now().Add(-(failedTaskCooldownMinutes + 1) * time.Minute)
+	hub.completedMu.Unlock()
+	if hub.isTaskInFailureCooldown("myorg/repo1", 30) {
+		t.Fatalf("a single ordinary failure must only earn the short cooldown, not a quarantine")
+	}
+
+	// One PERMANENT failure: quarantined immediately (weight >= threshold). Aging
+	// past the short window leaves it parked.
+	hub.recordTaskFailure("myorg/repo1", 40, true)
+	hub.completedMu.Lock()
+	hub.failedTasks["myorg/repo1#40"] = time.Now().Add(-(failedTaskCooldownMinutes + 1) * time.Minute)
+	hub.completedMu.Unlock()
+	if !hub.isTaskInFailureCooldown("myorg/repo1", 40) {
+		t.Fatalf("a permanent failure must quarantine immediately (weight %d, threshold %d)",
+			permanentFailureWeight, consecutiveFailureQuarantineThreshold)
+	}
+}
+
+// TestQueueLivelock_CompletionResetsFailureHistory verifies a completion clears
+// the failure ledger so a flaky-then-fixed issue does not carry a stale
+// quarantine.
+func TestQueueLivelock_CompletionResetsFailureHistory(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	hub.recordTaskFailure("myorg/repo1", 50, true) // quarantined
+	if !hub.isTaskInFailureCooldown("myorg/repo1", 50) {
+		t.Fatalf("expected quarantine after a permanent failure")
+	}
+	hub.markTaskCompleted("myorg/repo1", 50, "https://github.com/myorg/repo1/pull/99")
+	if hub.isTaskInFailureCooldown("myorg/repo1", 50) {
+		t.Fatalf("a completion must clear the failure cooldown/quarantine")
+	}
+	if hub.recentFailureCount("myorg/repo1", 50) != 0 {
+		t.Fatalf("a completion must reset the consecutive-failure counter")
+	}
+}
+
+// TestQueueLivelock_FailureAwareSelectionBackstop verifies remedy 3: even after
+// A's short failure cooldown has elapsed, a never-failed peer B is preferred
+// because A still carries failure history — so a flaky head-of-scan issue cannot
+// re-monopolise the queue purely on scan position.
+func TestQueueLivelock_FailureAwareSelectionBackstop(t *testing.T) {
+	hub, s := covK2Hub(t)
+	twoIssueStatus(s)
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "ct", ContributorID: "c-ct", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+
+	// A (#10) failed once, then its SHORT cooldown elapsed (so it is admissible
+	// again) but it still carries one recent failure.
+	hub.recordTaskFailure("myorg/repo1", 10, false)
+	hub.completedMu.Lock()
+	hub.failedTasks["myorg/repo1#10"] = time.Now().Add(-(failedTaskCooldownMinutes + 1) * time.Minute)
+	hub.completedMu.Unlock()
+	if hub.isTaskInFailureCooldown("myorg/repo1", 10) {
+		t.Fatalf("A's short cooldown should have elapsed for this backstop check")
+	}
+
+	// Both A and B are now admissible. The failure-aware sort must prefer B (#20,
+	// zero failures) over A (#10, one recent failure) even though A is ahead in
+	// scan order.
+	msg := hub.selectTask(conn)
+	if msg == nil {
+		t.Fatalf("expected an assignment, got nil")
+	}
+	if msg.Number != 20 {
+		t.Fatalf("failure-aware backstop: expected never-failed B (#20) preferred over recently-failed A (#10), got #%d", msg.Number)
+	}
+}
+
+// TestQueueLivelock_TaskFailedHandlerRecordsCooldown drives the real WebSocket
+// task_failed handler end-to-end and verifies it records a failure cooldown
+// through the hub — i.e. the handler is actually wired to recordTaskFailure and
+// not just the direct hub methods the other tests call.
+func TestQueueLivelock_TaskFailedHandlerRecordsCooldown(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	// Seed one admissible issue so `ready` yields a task_assign.
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{
+			{
+				Name: "repo1",
+				Full: "myorg/repo1",
+				ActionableIssues: []any{
+					map[string]any{
+						"number": float64(77),
+						"title":  "Reliably failing issue",
+						"url":    "https://github.com/myorg/repo1/issues/77",
+						"author": "someone",
+					},
+				},
+			},
+		},
+	}
+	s.statusMu.Unlock()
+
+	body := `{"github_username":"livelock-handler-user"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn) // auth_ok
+
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 1})
+	assign := readMsg(t, conn)
+	if assign.Type != "task_assign" || assign.Number != 77 {
+		t.Fatalf("expected task_assign for #77, got type=%s number=%d", assign.Type, assign.Number)
+	}
+
+	// Report the assigned task as failed via the real handler.
+	conn.WriteJSON(WSMessage{Type: "task_failed", TaskID: assign.TaskID, Reason: "could not build", Permanent: false})
+
+	// The handler runs asynchronously; poll briefly for the recorded cooldown.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if s.contributeHub.isTaskInFailureCooldown("myorg/repo1", 77) {
+			return // handler wired correctly
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("task_failed handler did not record a failure cooldown for the assigned issue")
+}

--- a/v2/pkg/dashboard/contribute_ws_test.go
+++ b/v2/pkg/dashboard/contribute_ws_test.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -529,5 +530,82 @@ func TestContributorProfilePreferredRole(t *testing.T) {
 	}
 	if loaded.PreferredRole != "scanner" {
 		t.Fatalf("expected preferred_role 'scanner', got %q", loaded.PreferredRole)
+	}
+}
+
+// Auto-promotion grants contents:write and pulls:write, so it must not fire on
+// completions that never reported a pull request. Completion is self-reported:
+// an agent that goes idle without shipping anything still sends task_complete.
+func TestWSAutoPromotionRequiresReportedPR(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	body := `{"github_username":"promote-user"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn)
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn)
+
+	// complete drives one task through the hub as if it had been assigned,
+	// reporting a PR only when prURL is non-empty.
+	complete := func(taskID, prURL string) {
+		t.Helper()
+		s.contributeHub.mu.RLock()
+		var c *ContributorConnection
+		for _, candidate := range s.contributeHub.connections {
+			c = candidate
+		}
+		s.contributeHub.mu.RUnlock()
+		if c == nil {
+			t.Fatal("no live contributor connection")
+		}
+		c.mu.Lock()
+		c.currentTask = &WSTaskAssign{TaskID: taskID, Kind: "issue", Repo: "acme/widgets", Number: 1}
+		c.mu.Unlock()
+
+		conn.WriteJSON(WSMessage{Type: "task_complete", TaskID: taskID, Result: "done", PRURL: prURL})
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	for i := 0; i < contributorAutoPromoteAt; i++ {
+		complete(fmt.Sprintf("no-pr-%d", i), "")
+	}
+
+	p := findContributor(reg["contributor_id"])
+	if p == nil {
+		t.Fatal("contributor not found")
+	}
+	if p.TasksCompleted != contributorAutoPromoteAt {
+		t.Fatalf("expected %d completions recorded, got %d", contributorAutoPromoteAt, p.TasksCompleted)
+	}
+	if p.TasksWithPR != 0 {
+		t.Fatalf("expected 0 completions with a PR, got %d", p.TasksWithPR)
+	}
+	if p.TrustTier != "newcomer" {
+		t.Fatalf("promoted to %q on completions that reported no PR", p.TrustTier)
+	}
+
+	for i := 0; i < contributorAutoPromoteAt; i++ {
+		complete(fmt.Sprintf("with-pr-%d", i), "https://github.com/acme/widgets/pull/7")
+	}
+
+	p = findContributor(reg["contributor_id"])
+	if p.TasksWithPR != contributorAutoPromoteAt {
+		t.Fatalf("expected %d completions with a PR, got %d", contributorAutoPromoteAt, p.TasksWithPR)
+	}
+	if p.TrustTier != "contributor" {
+		t.Fatalf("expected promotion to contributor after %d PR-backed completions, got %q", contributorAutoPromoteAt, p.TrustTier)
 	}
 }

--- a/v2/pkg/dashboard/contribute_ws_trust_controls_test.go
+++ b/v2/pkg/dashboard/contribute_ws_trust_controls_test.go
@@ -1,0 +1,193 @@
+package dashboard
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// oneActionableIssue installs a status with a single actionable issue that any
+// tier can be assigned (author is someone else, so no #2390 own-work skew).
+func oneActionableIssue(s *Server) {
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{
+			{
+				Name: "repo1",
+				Full: "myorg/repo1",
+				ActionableIssues: []any{
+					map[string]any{
+						"number": float64(101),
+						"title":  "Actionable issue",
+						"url":    "https://github.com/myorg/repo1/issues/101",
+						"author": "someone-else",
+					},
+				},
+			},
+		},
+	}
+	s.statusMu.Unlock()
+}
+
+// TestTrustControls_DisabledTierRefused (#2436 finding 2): a contributor whose
+// TrustTier is in hub.disabled_tiers is refused with a tier_disabled negative-ack
+// rather than silently handed work.
+func TestTrustControls_DisabledTierRefused(t *testing.T) {
+	hub, s := covK2Hub(t)
+	oneActionableIssue(s)
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "newcomer"},
+		lastPong: time.Now(),
+	}
+
+	// Fail-before shape: without disabled_tiers the tier gets assigned work.
+	if msg := hub.selectTask(conn); msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("expected a task_assign before disabling the tier, got %+v", msg)
+	}
+	// Clear the connection's held task and re-provide a fresh actionable issue so
+	// the next select isn't skipped as an already-active issue.
+	conn.currentTask = nil
+	oneActionableIssue(s)
+
+	// Now disable the newcomer tier: selection must refuse with tier_disabled.
+	s.deps.Config.Hub.DisabledTiers = []string{"newcomer"}
+	msg := hub.selectTask(conn)
+	if msg == nil {
+		t.Fatalf("expected an explicit negative-ack for a disabled tier, got nil (silent)")
+	}
+	if msg.Type != "task_unavailable" || msg.Reason != taskUnavailableTierDisabled {
+		t.Fatalf("expected task_unavailable/%s, got type=%q reason=%q",
+			taskUnavailableTierDisabled, msg.Type, msg.Reason)
+	}
+}
+
+// TestTrustControls_MaxConcurrentEnforced (#2436 finding 3): a second concurrent
+// assignment to the SAME identity beyond tier_limits.max_concurrent is refused
+// with a concurrency_limit negative-ack. Uses the live-connection holds as the
+// source of truth.
+func TestTrustControls_MaxConcurrentEnforced(t *testing.T) {
+	hub, s := covK2Hub(t)
+
+	// newcomer defaults to MaxConcurrent: 1 (config.go). Make it explicit so the
+	// test does not depend on defaulting having run.
+	s.deps.Config.Hub.TierLimits = map[string]config.TierRate{
+		"newcomer": {MaxPerHour: 3, MaxPerDay: 10, MaxConcurrent: 1},
+	}
+
+	// Two live connections for the SAME identity (same ContributorID), simulating
+	// one identity opening several connections. The first already holds a task.
+	held := &ContributorConnection{
+		profile:     &ContributorProfile{GitHubUsername: "bob", ContributorID: "c-bob", TrustTier: "newcomer"},
+		currentTask: &WSTaskAssign{TaskID: "t-held", Repo: "myorg/other", Number: 5},
+		lastPong:    time.Now(),
+	}
+	second := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "bob", ContributorID: "c-bob", TrustTier: "newcomer"},
+		lastPong: time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["conn-held"] = held
+	hub.connections["conn-second"] = second
+	hub.mu.Unlock()
+
+	oneActionableIssue(s)
+
+	// The identity already holds 1 == MaxConcurrent, so the second connection is
+	// refused rather than given a second concurrent write-capable assignment.
+	msg := hub.selectTask(second)
+	if msg == nil {
+		t.Fatalf("expected a concurrency-limit negative-ack, got nil (silent)")
+	}
+	if msg.Type != "task_unavailable" || msg.Reason != taskUnavailableConcurrencyLimit {
+		t.Fatalf("expected task_unavailable/%s, got type=%q reason=%q",
+			taskUnavailableConcurrencyLimit, msg.Type, msg.Reason)
+	}
+
+	// Fail-before shape: with a higher limit the same second connection is served.
+	s.deps.Config.Hub.TierLimits = map[string]config.TierRate{
+		"newcomer": {MaxPerHour: 3, MaxPerDay: 10, MaxConcurrent: 2},
+	}
+	oneActionableIssue(s)
+	if msg := hub.selectTask(second); msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("with MaxConcurrent=2 the second assignment should be served, got %+v", msg)
+	}
+}
+
+// newFailingAppAuth builds a real *ghpkg.AppAuth whose JWT generation succeeds
+// (valid RSA key) but whose CreateInstallationToken call hits a server that
+// always 500s, so ScopedToken — and therefore mintScopedToken — returns an
+// error. This exercises the #2436 finding 1 mint-failure path deterministically
+// and offline.
+func newFailingAppAuth(t *testing.T) *ghpkg.AppAuth {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	keyFile := filepath.Join(t.TempDir(), "app-key.pem")
+	if err := os.WriteFile(keyFile, pemBytes, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	auth, err := ghpkg.NewAppAuthWithCache(1, 2, keyFile,
+		filepath.Join(t.TempDir(), "token.cache"), logger, srv.URL)
+	if err != nil {
+		t.Fatalf("NewAppAuthWithCache: %v", err)
+	}
+	return auth
+}
+
+// TestTrustControls_MintFailureNegativeAck (#2436 finding 1): when the scoped
+// token mint fails, selectTask sends an explicit token_mint_failed negative-ack
+// instead of returning a silent nil that strands the contributor.
+func TestTrustControls_MintFailureNegativeAck(t *testing.T) {
+	hub, s := covK2Hub(t)
+	oneActionableIssue(s)
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "carol", ContributorID: "c-carol", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+
+	// Force the mint to fail via a real AppAuth whose token endpoint 500s.
+	s.deps.GHAppAuth = newFailingAppAuth(t)
+
+	msg := hub.selectTask(conn)
+	if msg == nil {
+		t.Fatalf("expected an explicit token-mint negative-ack, got nil (silent strand)")
+	}
+	if msg.Type != "task_unavailable" || msg.Reason != taskUnavailableTokenMintFailed {
+		t.Fatalf("expected task_unavailable/%s, got type=%q reason=%q",
+			taskUnavailableTokenMintFailed, msg.Type, msg.Reason)
+	}
+	// The contributor was NOT left holding a phantom task.
+	conn.mu.Lock()
+	ct := conn.currentTask
+	conn.mu.Unlock()
+	if ct != nil {
+		t.Fatalf("mint failure must not leave a currentTask assigned, got %+v", ct)
+	}
+}

--- a/v2/pkg/dashboard/copilot_auth.go
+++ b/v2/pkg/dashboard/copilot_auth.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -54,6 +55,13 @@ type copilotAuthFlow struct {
 	mu        sync.Mutex
 	polling   bool
 	lastError string
+
+	// cancel stops the active poll goroutine; nil when none is running.
+	cancel context.CancelFunc
+	// done is closed when the active poll goroutine exits, letting
+	// stopCopilotPoll join it so a stale poller can never race a newer
+	// flow (or, in tests, outlive its test).
+	done chan struct{}
 }
 
 // registerCopilotAuthRoutes wires up the Copilot device-flow API endpoints.
@@ -137,17 +145,23 @@ func (s *Server) handleCopilotAuthStart(w http.ResponseWriter, r *http.Request) 
 		expiry = time.Duration(dc.ExpiresIn) * time.Second
 	}
 
+	// A prior poll goroutine may still be running against a stale device
+	// code; cancel it and wait for it to exit so it can never clobber the
+	// new flow's state or token file.
+	s.stopCopilotPoll()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
 	s.copilotAuthFlow.mu.Lock()
-	alreadyPolling := s.copilotAuthFlow.polling
 	s.copilotAuthFlow.polling = true
 	s.copilotAuthFlow.lastError = ""
+	s.copilotAuthFlow.cancel = cancel
+	s.copilotAuthFlow.done = done
 	s.copilotAuthFlow.mu.Unlock()
-
-	// A prior poll goroutine may still be running against a stale device
-	// code; it will fail with expired_token and exit on its own. Always
-	// poll for the newest code.
-	_ = alreadyPolling
-	go s.pollCopilotToken(dc.DeviceCode, interval, expiry)
+	go func() {
+		defer close(done)
+		s.pollCopilotToken(ctx, dc.DeviceCode, interval, expiry)
+	}()
 
 	s.auditFromRequest(r, "copilot_auth_start", "", "")
 	jsonResponse(w, map[string]interface{}{
@@ -157,9 +171,31 @@ func (s *Server) handleCopilotAuthStart(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
+// stopCopilotPoll cancels any in-flight poll goroutine and waits for it to
+// exit. Safe to call when no poll is running.
+func (s *Server) stopCopilotPoll() {
+	s.copilotAuthFlow.mu.Lock()
+	cancel := s.copilotAuthFlow.cancel
+	done := s.copilotAuthFlow.done
+	s.copilotAuthFlow.cancel = nil
+	s.copilotAuthFlow.done = nil
+	s.copilotAuthFlow.mu.Unlock()
+	if cancel == nil {
+		return
+	}
+	cancel()
+	<-done
+	// A canceled poller returns without touching flow state (its owner is
+	// the one transitioning it); mark the flow idle on its behalf.
+	s.copilotAuthFlow.mu.Lock()
+	s.copilotAuthFlow.polling = false
+	s.copilotAuthFlow.mu.Unlock()
+}
+
 // pollCopilotToken polls GitHub's access token endpoint until the user
-// approves the device code, it expires, or access is denied.
-func (s *Server) pollCopilotToken(deviceCode string, intervalSec int, expiry time.Duration) {
+// approves the device code, it expires, is superseded (ctx canceled), or
+// access is denied.
+func (s *Server) pollCopilotToken(ctx context.Context, deviceCode string, intervalSec int, expiry time.Duration) {
 	deadline := time.Now().Add(expiry)
 	client := &http.Client{Timeout: copilotHTTPTimeout}
 
@@ -171,9 +207,16 @@ func (s *Server) pollCopilotToken(deviceCode string, intervalSec int, expiry tim
 	}
 
 	for time.Now().Before(deadline) {
-		time.Sleep(time.Duration(intervalSec) * time.Second)
+		timer := time.NewTimer(time.Duration(intervalSec) * time.Second)
+		select {
+		case <-ctx.Done():
+			// Superseded or shut down — leave flow state to the canceler.
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
 
-		req, err := http.NewRequest(http.MethodPost, copilotAccessTokenURL,
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, copilotAccessTokenURL,
 			strings.NewReader(url.Values{
 				"client_id":   {copilotClientID},
 				"device_code": {deviceCode},
@@ -188,6 +231,10 @@ func (s *Server) pollCopilotToken(deviceCode string, intervalSec int, expiry tim
 
 		resp, err := client.Do(req)
 		if err != nil {
+			if ctx.Err() != nil {
+				// Canceled mid-request — leave flow state to the canceler.
+				return
+			}
 			// Transient network error — keep polling.
 			continue
 		}

--- a/v2/pkg/dashboard/copilot_auth.go
+++ b/v2/pkg/dashboard/copilot_auth.go
@@ -18,12 +18,6 @@ const (
 	// for the device flow (same app the Copilot CLI authenticates as).
 	copilotClientID = "Iv1.b507a08c87ecfe98"
 
-	// copilotDeviceCodeURL starts a device-flow authorization.
-	copilotDeviceCodeURL = "https://github.com/login/device/code"
-
-	// copilotAccessTokenURL is polled until the user enters the code.
-	copilotAccessTokenURL = "https://github.com/login/oauth/access_token"
-
 	// copilotDefaultPollIntervalSec is used when GitHub doesn't specify one.
 	copilotDefaultPollIntervalSec = 5
 
@@ -36,6 +30,23 @@ const (
 
 	// copilotHTTPTimeout limits each GitHub API call.
 	copilotHTTPTimeout = 30 * time.Second
+)
+
+// copilotDeviceCodeURL, copilotAccessTokenURL, and copilotUserTokenPath are
+// `var`s (not `const`) purely so tests can redirect them at a httptest server
+// / t.TempDir() path (see copilot_auth_test.go). Production always uses the
+// values below; nothing else in this file mutates them.
+var (
+	// copilotDeviceCodeURL starts a device-flow authorization.
+	copilotDeviceCodeURL = "https://github.com/login/device/code"
+
+	// copilotAccessTokenURL is polled until the user enters the code.
+	copilotAccessTokenURL = "https://github.com/login/oauth/access_token"
+
+	// copilotUserTokenPath mirrors agent.CopilotUserTokenPath; kept as an
+	// overridable var (test-only seam) rather than referencing the agent
+	// package constant directly everywhere below.
+	copilotUserTokenPath = agent.CopilotUserTokenPath
 )
 
 // copilotAuthFlow holds server-side state for an in-progress device-flow login.
@@ -61,7 +72,7 @@ func (s *Server) handleCopilotAuthStatus(w http.ResponseWriter, r *http.Request)
 	s.copilotAuthFlow.mu.Unlock()
 
 	loggedIn := false
-	if data, err := os.ReadFile(agent.CopilotUserTokenPath); err == nil && strings.TrimSpace(string(data)) != "" {
+	if data, err := os.ReadFile(copilotUserTokenPath); err == nil && strings.TrimSpace(string(data)) != "" {
 		loggedIn = true
 	} else if os.Getenv("COPILOT_GITHUB_TOKEN") != "" {
 		loggedIn = true
@@ -227,11 +238,11 @@ func (s *Server) pollCopilotToken(deviceCode string, intervalSec int, expiry tim
 
 // saveCopilotToken persists the token and hands it to the agent manager.
 func (s *Server) saveCopilotToken(token string) error {
-	tmpPath := agent.CopilotUserTokenPath + ".tmp"
+	tmpPath := copilotUserTokenPath + ".tmp"
 	if err := os.WriteFile(tmpPath, []byte(token), 0o600); err != nil {
 		return err
 	}
-	if err := os.Rename(tmpPath, agent.CopilotUserTokenPath); err != nil {
+	if err := os.Rename(tmpPath, copilotUserTokenPath); err != nil {
 		return err
 	}
 	if s.deps != nil && s.deps.AgentMgr != nil {
@@ -242,7 +253,7 @@ func (s *Server) saveCopilotToken(token string) error {
 
 // handleCopilotAuthLogout removes the stored Copilot token.
 func (s *Server) handleCopilotAuthLogout(w http.ResponseWriter, r *http.Request) {
-	os.Remove(agent.CopilotUserTokenPath)
+	os.Remove(copilotUserTokenPath)
 	if s.deps != nil && s.deps.AgentMgr != nil {
 		s.deps.AgentMgr.SetCopilotToken("")
 	}

--- a/v2/pkg/dashboard/copilot_auth_test.go
+++ b/v2/pkg/dashboard/copilot_auth_test.go
@@ -1,0 +1,518 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// copilotDeviceMock serves fake /login/device/code and /login/oauth/access_token
+// endpoints so handleCopilotAuthStart and pollCopilotToken can be driven without
+// real network access. tokenResponses is consumed in order for successive polls
+// of the access_token endpoint; the last entry repeats once exhausted.
+type copilotDeviceMock struct {
+	srv            *httptest.Server
+	tokenResponses []map[string]any
+	callCount      int
+	pollTimes      []time.Time
+}
+
+func newCopilotDeviceMock(t *testing.T, deviceCode string, expiresIn, interval int, tokenResponses ...map[string]any) *copilotDeviceMock {
+	t.Helper()
+	m := &copilotDeviceMock{tokenResponses: tokenResponses}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login/device/code", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"device_code":      deviceCode,
+			"user_code":        "ABCD-1234",
+			"verification_uri": "https://github.com/login/device",
+			"expires_in":       expiresIn,
+			"interval":         interval,
+		})
+	})
+	mux.HandleFunc("/login/oauth/access_token", func(w http.ResponseWriter, r *http.Request) {
+		m.pollTimes = append(m.pollTimes, time.Now())
+		idx := m.callCount
+		if idx >= len(m.tokenResponses) {
+			idx = len(m.tokenResponses) - 1
+		}
+		m.callCount++
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(m.tokenResponses[idx])
+	})
+	m.srv = httptest.NewServer(mux)
+	t.Cleanup(m.srv.Close)
+	return m
+}
+
+// withCopilotMockURLs redirects the package-level device-flow endpoint vars at
+// the mock server for the duration of the test, restoring the real GitHub URLs
+// afterward.
+func withCopilotMockURLs(t *testing.T, mockURL string) {
+	t.Helper()
+	origDevice := copilotDeviceCodeURL
+	origToken := copilotAccessTokenURL
+	copilotDeviceCodeURL = mockURL + "/login/device/code"
+	copilotAccessTokenURL = mockURL + "/login/oauth/access_token"
+	t.Cleanup(func() {
+		copilotDeviceCodeURL = origDevice
+		copilotAccessTokenURL = origToken
+	})
+}
+
+// withCopilotTokenPath redirects the package-level token-file path var at a
+// file inside t.TempDir(), restoring the real path afterward.
+func withCopilotTokenPath(t *testing.T) string {
+	t.Helper()
+	orig := copilotUserTokenPath
+	path := filepath.Join(t.TempDir(), "copilot-user-token")
+	copilotUserTokenPath = path
+	t.Cleanup(func() {
+		copilotUserTokenPath = orig
+	})
+	return path
+}
+
+// ---- handleCopilotAuthStatus ----
+
+func TestCopilotAuthStatus_Unauthenticated(t *testing.T) {
+	withCopilotTokenPath(t)
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	rec := doGet(s, "/api/copilot-auth/status")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	got := decodeJSON(t, rec)
+	if got["logged_in"] != false {
+		t.Fatalf("logged_in = %v, want false", got["logged_in"])
+	}
+	if got["pending"] != false {
+		t.Fatalf("pending = %v, want false", got["pending"])
+	}
+	if got["error"] != "" {
+		t.Fatalf("error = %v, want empty", got["error"])
+	}
+}
+
+func TestCopilotAuthStatus_AuthenticatedViaTokenFile(t *testing.T) {
+	path := withCopilotTokenPath(t)
+	if err := os.WriteFile(path, []byte("gho_faketoken"), 0o600); err != nil {
+		t.Fatalf("seed token file: %v", err)
+	}
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	rec := doGet(s, "/api/copilot-auth/status")
+	got := decodeJSON(t, rec)
+	if got["logged_in"] != true {
+		t.Fatalf("logged_in = %v, want true (token file present)", got["logged_in"])
+	}
+}
+
+func TestCopilotAuthStatus_AuthenticatedViaEnv(t *testing.T) {
+	withCopilotTokenPath(t)
+	t.Setenv("COPILOT_GITHUB_TOKEN", "gho_envtoken")
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	rec := doGet(s, "/api/copilot-auth/status")
+	got := decodeJSON(t, rec)
+	if got["logged_in"] != true {
+		t.Fatalf("logged_in = %v, want true (env token)", got["logged_in"])
+	}
+}
+
+func TestCopilotAuthStatus_ReflectsPollingAndLastError(t *testing.T) {
+	withCopilotTokenPath(t)
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	s.copilotAuthFlow.mu.Lock()
+	s.copilotAuthFlow.polling = true
+	s.copilotAuthFlow.lastError = "some prior error"
+	s.copilotAuthFlow.mu.Unlock()
+
+	rec := doGet(s, "/api/copilot-auth/status")
+	got := decodeJSON(t, rec)
+	if got["pending"] != true {
+		t.Fatalf("pending = %v, want true", got["pending"])
+	}
+	if got["error"] != "some prior error" {
+		t.Fatalf("error = %v, want %q", got["error"], "some prior error")
+	}
+}
+
+// ---- handleCopilotAuthStart ----
+
+func TestCopilotAuthStart_ReturnsDeviceCode(t *testing.T) {
+	withCopilotTokenPath(t)
+	mock := newCopilotDeviceMock(t, "dev-code-abc", 900, 5,
+		map[string]any{"error": "authorization_pending"},
+	)
+	withCopilotMockURLs(t, mock.srv.URL)
+
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	rec := doPost(s, "/api/copilot-auth/start", map[string]interface{}{})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	got := decodeJSON(t, rec)
+	if got["user_code"] != "ABCD-1234" {
+		t.Fatalf("user_code = %v, want ABCD-1234", got["user_code"])
+	}
+	if got["verification_uri"] != "https://github.com/login/device" {
+		t.Fatalf("verification_uri = %v, want https://github.com/login/device", got["verification_uri"])
+	}
+	if got["expires_in"] != float64(900) {
+		t.Fatalf("expires_in = %v, want 900", got["expires_in"])
+	}
+
+	// handleCopilotAuthStart also flips polling=true and spawns the poll
+	// goroutine; verify the flag flipped promptly (goroutine start is async).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		s.copilotAuthFlow.mu.Lock()
+		polling := s.copilotAuthFlow.polling
+		s.copilotAuthFlow.mu.Unlock()
+		if polling {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("expected polling=true after start")
+}
+
+func TestCopilotAuthStart_DeviceCodeEndpointError(t *testing.T) {
+	withCopilotTokenPath(t)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login/device/code", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"error": "boom"})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	withCopilotMockURLs(t, srv.URL)
+
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	rec := doPost(s, "/api/copilot-auth/start", map[string]interface{}{})
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// ---- pollCopilotToken ----
+
+func TestPollCopilotToken_SucceedsAndSavesToken(t *testing.T) {
+	tokenPath := withCopilotTokenPath(t)
+	mock := newCopilotDeviceMock(t, "dev-code-1", 900, 0, // interval 0 -> fast, driven directly below
+		map[string]any{"access_token": "gho_realtoken", "token_type": "bearer"},
+	)
+	withCopilotMockURLs(t, mock.srv.URL)
+
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	s.copilotAuthFlow.mu.Lock()
+	s.copilotAuthFlow.polling = true
+	s.copilotAuthFlow.mu.Unlock()
+
+	// Poll directly with a 0-second interval and a short expiry so the test
+	// does not sleep for real GitHub-scale intervals.
+	done := make(chan struct{})
+	go func() {
+		s.pollCopilotToken("dev-code-1", 0, 2*time.Second)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("pollCopilotToken did not return in time")
+	}
+
+	s.copilotAuthFlow.mu.Lock()
+	polling := s.copilotAuthFlow.polling
+	lastErr := s.copilotAuthFlow.lastError
+	s.copilotAuthFlow.mu.Unlock()
+	if polling {
+		t.Fatalf("polling should be false after success")
+	}
+	if lastErr != "" {
+		t.Fatalf("lastError = %q, want empty on success", lastErr)
+	}
+
+	data, err := os.ReadFile(tokenPath)
+	if err != nil {
+		t.Fatalf("token file not written: %v", err)
+	}
+	if string(data) != "gho_realtoken" {
+		t.Fatalf("token file contents = %q, want gho_realtoken", string(data))
+	}
+}
+
+func TestPollCopilotToken_RetriesOnPendingThenSucceeds(t *testing.T) {
+	withCopilotTokenPath(t)
+	mock := newCopilotDeviceMock(t, "dev-code-2", 900, 0,
+		map[string]any{"error": "authorization_pending"},
+		map[string]any{"error": "authorization_pending"},
+		map[string]any{"access_token": "gho_afterretries", "token_type": "bearer"},
+	)
+	withCopilotMockURLs(t, mock.srv.URL)
+
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	done := make(chan struct{})
+	go func() {
+		s.pollCopilotToken("dev-code-2", 0, 5*time.Second)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("pollCopilotToken did not return in time")
+	}
+
+	if mock.callCount < 3 {
+		t.Fatalf("expected at least 3 polls (2 pending + 1 success), got %d", mock.callCount)
+	}
+
+	s.copilotAuthFlow.mu.Lock()
+	lastErr := s.copilotAuthFlow.lastError
+	s.copilotAuthFlow.mu.Unlock()
+	if lastErr != "" {
+		t.Fatalf("lastError = %q, want empty on eventual success", lastErr)
+	}
+}
+
+func TestPollCopilotToken_SlowDownBumpsInterval(t *testing.T) {
+	withCopilotTokenPath(t)
+	mock := newCopilotDeviceMock(t, "dev-code-3", 900, 0,
+		map[string]any{"error": "slow_down"},
+		map[string]any{"access_token": "gho_afterslowdown", "token_type": "bearer"},
+	)
+	withCopilotMockURLs(t, mock.srv.URL)
+
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	start := time.Now()
+	done := make(chan struct{})
+	go func() {
+		// Start at interval 0; after slow_down the poller adds
+		// copilotSlowDownBumpSec (5s) to intervalSec, so the NEXT loop
+		// iteration sleeps 5s before polling again. pollCopilotToken checks
+		// its expiry deadline only at the top of each loop iteration (after
+		// the sleep), so with a 6s expiry the bumped 5s sleep still fits
+		// inside the deadline and the second (successful) poll fires.
+		s.pollCopilotToken("dev-code-3", 0, 6*time.Second)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(8 * time.Second):
+		t.Fatalf("pollCopilotToken did not return in time")
+	}
+	elapsed := time.Since(start)
+
+	if mock.callCount < 2 {
+		t.Fatalf("expected slow_down poll + a retry poll (>=2 calls), got %d (elapsed=%s)", mock.callCount, elapsed)
+	}
+	// The retry must not have fired immediately — the slow_down bump should
+	// have forced a real gap between the first and second poll.
+	if len(mock.pollTimes) >= 2 {
+		gap := mock.pollTimes[1].Sub(mock.pollTimes[0])
+		if gap < 4*time.Second {
+			t.Fatalf("gap between slow_down and retry = %s, want >= ~5s (bump honored)", gap)
+		}
+	}
+	s.copilotAuthFlow.mu.Lock()
+	lastErr := s.copilotAuthFlow.lastError
+	s.copilotAuthFlow.mu.Unlock()
+	if lastErr != "" {
+		t.Fatalf("expected eventual success after slow_down retry, got error %q", lastErr)
+	}
+}
+
+func TestPollCopilotToken_ExpiresWithoutSuccess(t *testing.T) {
+	withCopilotTokenPath(t)
+	mock := newCopilotDeviceMock(t, "dev-code-4", 900, 0,
+		map[string]any{"error": "authorization_pending"},
+	)
+	withCopilotMockURLs(t, mock.srv.URL)
+
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	start := time.Now()
+	done := make(chan struct{})
+	go func() {
+		s.pollCopilotToken("dev-code-4", 0, 300*time.Millisecond)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("pollCopilotToken did not return in time (expiry not honored)")
+	}
+	elapsed := time.Since(start)
+	if elapsed > 2*time.Second {
+		t.Fatalf("pollCopilotToken took %s, expiry should have stopped it quickly", elapsed)
+	}
+
+	s.copilotAuthFlow.mu.Lock()
+	polling := s.copilotAuthFlow.polling
+	lastErr := s.copilotAuthFlow.lastError
+	s.copilotAuthFlow.mu.Unlock()
+	if polling {
+		t.Fatalf("polling should be false after expiry")
+	}
+	if lastErr == "" {
+		t.Fatalf("expected a non-empty expiry error message")
+	}
+}
+
+func TestPollCopilotToken_AccessDeniedStopsImmediately(t *testing.T) {
+	withCopilotTokenPath(t)
+	mock := newCopilotDeviceMock(t, "dev-code-5", 900, 0,
+		map[string]any{"error": "access_denied", "error_description": "user declined"},
+	)
+	withCopilotMockURLs(t, mock.srv.URL)
+
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	done := make(chan struct{})
+	go func() {
+		s.pollCopilotToken("dev-code-5", 0, 10*time.Second)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("pollCopilotToken should stop immediately on access_denied")
+	}
+
+	s.copilotAuthFlow.mu.Lock()
+	lastErr := s.copilotAuthFlow.lastError
+	s.copilotAuthFlow.mu.Unlock()
+	if lastErr == "" {
+		t.Fatalf("expected access_denied error message")
+	}
+	if lastErr != "access_denied — user declined" {
+		t.Fatalf("lastError = %q, want %q", lastErr, "access_denied — user declined")
+	}
+}
+
+// ---- saveCopilotToken ----
+
+func TestSaveCopilotToken_WritesAtomicallyWithPermissions(t *testing.T) {
+	tokenPath := withCopilotTokenPath(t)
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	if err := s.saveCopilotToken("gho_savedtoken"); err != nil {
+		t.Fatalf("saveCopilotToken: %v", err)
+	}
+
+	info, err := os.Stat(tokenPath)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("permissions = %o, want 0600", perm)
+	}
+
+	data, err := os.ReadFile(tokenPath)
+	if err != nil {
+		t.Fatalf("read token file: %v", err)
+	}
+	if string(data) != "gho_savedtoken" {
+		t.Fatalf("token contents = %q, want gho_savedtoken", string(data))
+	}
+
+	// The temp file used for the atomic rename should not be left behind.
+	if _, err := os.Stat(tokenPath + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("expected .tmp file to be gone after rename, stat err = %v", err)
+	}
+}
+
+func TestSaveCopilotToken_ErrorOnBadPath(t *testing.T) {
+	orig := copilotUserTokenPath
+	// A path with a nonexistent parent directory forces os.WriteFile to fail.
+	copilotUserTokenPath = filepath.Join(t.TempDir(), "nonexistent-subdir", "copilot-user-token")
+	t.Cleanup(func() { copilotUserTokenPath = orig })
+
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	if err := s.saveCopilotToken("gho_x"); err == nil {
+		t.Fatalf("expected error writing to a path with a missing parent dir")
+	}
+}
+
+// ---- handleCopilotAuthLogout ----
+
+func TestCopilotAuthLogout_RemovesTokenFile(t *testing.T) {
+	tokenPath := withCopilotTokenPath(t)
+	if err := os.WriteFile(tokenPath, []byte("gho_tobedeleted"), 0o600); err != nil {
+		t.Fatalf("seed token file: %v", err)
+	}
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	// Sanity: status is authenticated before logout.
+	rec := doGet(s, "/api/copilot-auth/status")
+	if got := decodeJSON(t, rec); got["logged_in"] != true {
+		t.Fatalf("precondition: logged_in = %v, want true", got["logged_in"])
+	}
+
+	rec = doPost(s, "/api/copilot-auth/logout", map[string]interface{}{})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	got := decodeJSON(t, rec)
+	if got["status"] != "logged_out" {
+		t.Fatalf("status = %v, want logged_out", got["status"])
+	}
+
+	if _, err := os.Stat(tokenPath); !os.IsNotExist(err) {
+		t.Fatalf("expected token file removed, stat err = %v", err)
+	}
+
+	rec = doGet(s, "/api/copilot-auth/status")
+	got = decodeJSON(t, rec)
+	if got["logged_in"] != false {
+		t.Fatalf("logged_in after logout = %v, want false", got["logged_in"])
+	}
+}
+
+func TestCopilotAuthLogout_NoFileIsNoop(t *testing.T) {
+	withCopilotTokenPath(t)
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	rec := doPost(s, "/api/copilot-auth/logout", map[string]interface{}{})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	got := decodeJSON(t, rec)
+	if got["status"] != "logged_out" {
+		t.Fatalf("status = %v, want logged_out", got["status"])
+	}
+}

--- a/v2/pkg/dashboard/copilot_auth_test.go
+++ b/v2/pkg/dashboard/copilot_auth_test.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -160,6 +161,10 @@ func TestCopilotAuthStart_ReturnsDeviceCode(t *testing.T) {
 
 	s := NewServer(0, covBLogger())
 	s.RegisterAPI(testDeps(t))
+	// The handler spawns a poll goroutine that reads the package-level
+	// endpoint/path vars; join it before the withCopilot* cleanups restore
+	// them, or it races the restores (and later tests' mocks).
+	t.Cleanup(s.stopCopilotPoll)
 
 	rec := doPost(s, "/api/copilot-auth/start", map[string]interface{}{})
 	if rec.Code != http.StatusOK {
@@ -231,7 +236,7 @@ func TestPollCopilotToken_SucceedsAndSavesToken(t *testing.T) {
 	// does not sleep for real GitHub-scale intervals.
 	done := make(chan struct{})
 	go func() {
-		s.pollCopilotToken("dev-code-1", 0, 2*time.Second)
+		s.pollCopilotToken(context.Background(), "dev-code-1", 0, 2*time.Second)
 		close(done)
 	}()
 
@@ -275,7 +280,7 @@ func TestPollCopilotToken_RetriesOnPendingThenSucceeds(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		s.pollCopilotToken("dev-code-2", 0, 5*time.Second)
+		s.pollCopilotToken(context.Background(), "dev-code-2", 0, 5*time.Second)
 		close(done)
 	}()
 
@@ -317,7 +322,7 @@ func TestPollCopilotToken_SlowDownBumpsInterval(t *testing.T) {
 		// its expiry deadline only at the top of each loop iteration (after
 		// the sleep), so with a 6s expiry the bumped 5s sleep still fits
 		// inside the deadline and the second (successful) poll fires.
-		s.pollCopilotToken("dev-code-3", 0, 6*time.Second)
+		s.pollCopilotToken(context.Background(), "dev-code-3", 0, 6*time.Second)
 		close(done)
 	}()
 
@@ -360,7 +365,7 @@ func TestPollCopilotToken_ExpiresWithoutSuccess(t *testing.T) {
 	start := time.Now()
 	done := make(chan struct{})
 	go func() {
-		s.pollCopilotToken("dev-code-4", 0, 300*time.Millisecond)
+		s.pollCopilotToken(context.Background(), "dev-code-4", 0, 300*time.Millisecond)
 		close(done)
 	}()
 
@@ -398,7 +403,7 @@ func TestPollCopilotToken_AccessDeniedStopsImmediately(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		s.pollCopilotToken("dev-code-5", 0, 10*time.Second)
+		s.pollCopilotToken(context.Background(), "dev-code-5", 0, 10*time.Second)
 		close(done)
 	}()
 
@@ -515,4 +520,75 @@ func TestCopilotAuthLogout_NoFileIsNoop(t *testing.T) {
 	if got["status"] != "logged_out" {
 		t.Fatalf("status = %v, want logged_out", got["status"])
 	}
+}
+
+func TestPollCopilotToken_CancelStopsPromptly(t *testing.T) {
+	withCopilotTokenPath(t)
+	mock := newCopilotDeviceMock(t, "dev-code-6", 900, 0,
+		map[string]any{"error": "authorization_pending"},
+	)
+	withCopilotMockURLs(t, mock.srv.URL)
+
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	// interval 5s: without cancellation the poller would sit in its sleep
+	// for the full interval (and keep polling for the whole 10m expiry).
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.pollCopilotToken(ctx, "dev-code-6", 5, 10*time.Minute)
+		close(done)
+	}()
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("pollCopilotToken did not stop promptly after cancel")
+	}
+}
+
+func TestStopCopilotPoll_JoinsHandlerSpawnedPoller(t *testing.T) {
+	withCopilotTokenPath(t)
+	mock := newCopilotDeviceMock(t, "dev-code-7", 900, 5,
+		map[string]any{"error": "authorization_pending"},
+	)
+	withCopilotMockURLs(t, mock.srv.URL)
+
+	s := NewServer(0, covBLogger())
+	s.RegisterAPI(testDeps(t))
+
+	rec := doPost(s, "/api/copilot-auth/start", map[string]interface{}{})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// stopCopilotPoll must cancel the goroutine the handler spawned, wait
+	// for it to exit, and leave the flow idle — promptly, not after the
+	// poller's 5s interval or 900s expiry.
+	joined := make(chan struct{})
+	go func() {
+		s.stopCopilotPoll()
+		close(joined)
+	}()
+	select {
+	case <-joined:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("stopCopilotPoll did not join the poll goroutine promptly")
+	}
+
+	s.copilotAuthFlow.mu.Lock()
+	polling := s.copilotAuthFlow.polling
+	cancelFn := s.copilotAuthFlow.cancel
+	s.copilotAuthFlow.mu.Unlock()
+	if polling {
+		t.Fatalf("polling = true after stopCopilotPoll, want false")
+	}
+	if cancelFn != nil {
+		t.Fatalf("cancel should be cleared after stopCopilotPoll")
+	}
+
+	// A second stop with no poller running must be a harmless no-op.
+	s.stopCopilotPoll()
 }

--- a/v2/pkg/dashboard/deps.go
+++ b/v2/pkg/dashboard/deps.go
@@ -12,37 +12,45 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/agent"
 	"github.com/kubestellar/hive/v2/pkg/beads"
 	"github.com/kubestellar/hive/v2/pkg/config"
-	"github.com/kubestellar/hive/v2/pkg/governor"
 	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+	"github.com/kubestellar/hive/v2/pkg/governor"
 	"github.com/kubestellar/hive/v2/pkg/knowledge"
 	"github.com/kubestellar/hive/v2/pkg/scheduler"
 	"github.com/kubestellar/hive/v2/pkg/tokens"
 )
 
 type Dependencies struct {
-	Config           *config.Config
-	AgentMgr         *agent.Manager
-	Governor         *governor.Governor
-	GHClient         *ghpkg.Client
-	GHAppAuth        *ghpkg.AppAuth
-	Tokens           *tokens.Collector
-	Knowledge        *knowledge.KnowledgeAPI
-	Inception        *knowledge.InceptionEngine
-	Nous             *NousState
-	Scheduler        *scheduler.Scheduler
-	MetricsCollector *MetricsCollector
-	BeadSynthesizer  *knowledge.BeadSynthesizer
-	BeadStores       map[string]*beads.Store
-	Logger           *slog.Logger
-	Ctx              context.Context
-	RefreshFunc      func()
-	PersistFunc      func()
-	SkipReloadFunc   func()
-	ReInitFunc       func()
-	SetUserClient    func(token string)
-	EnumerateFunc      func()
-	AdvisoryResetFunc  func(newPrimaryRepo string)
-	ReinitGitHubFunc   func(appID, installationID int64, keyFile string) error
+	Config            *config.Config
+	AgentMgr          *agent.Manager
+	Governor          *governor.Governor
+	GHClient          *ghpkg.Client
+	GHAppAuth         *ghpkg.AppAuth
+	Tokens            *tokens.Collector
+	Knowledge         *knowledge.KnowledgeAPI
+	Inception         *knowledge.InceptionEngine
+	Nous              *NousState
+	Scheduler         *scheduler.Scheduler
+	MetricsCollector  *MetricsCollector
+	BeadSynthesizer   *knowledge.BeadSynthesizer
+	BeadStores        map[string]*beads.Store
+	Logger            *slog.Logger
+	Ctx               context.Context
+	RefreshFunc       func()
+	PersistFunc       func()
+	SkipReloadFunc    func()
+	ReInitFunc        func()
+	SetUserClient     func(token string)
+	EnumerateFunc     func()
+	AdvisoryResetFunc func(newPrimaryRepo string)
+	ReinitGitHubFunc  func(appID, installationID int64, keyFile string) error
+	// ResolveAppKeyFileFunc resolves which App private key the process would
+	// actually sign with, given the configured key_file and app_id — the SAME
+	// resolution the boot and heartbeat-apply paths use (config value, then
+	// $GH_APP_KEY_FILE, then the per-app-id delivered file, then the generic
+	// fallbacks). Hub-delivered keys deliberately leave key_file empty, so any
+	// handler that gates on the raw config value alone dead-ends on exactly the
+	// fleet-standard hosted-spoke configuration (#2459).
+	ResolveAppKeyFileFunc func(configured string, appID int64) string
 }
 
 type NousState struct {
@@ -69,15 +77,15 @@ type NousPrinciple struct {
 const NousBaselineTarget = 672
 
 type NousSnapshot struct {
-	Timestamp     string         `json:"timestamp"`
-	Mode          string         `json:"mode"`
-	QueueIssues   int            `json:"queue_issues"`
-	QueuePRs      int            `json:"queue_prs"`
-	QueueHold     int            `json:"queue_hold"`
-	SLAViolations int            `json:"sla_violations"`
-	AgentsKicked  []string       `json:"agents_kicked,omitempty"`
+	Timestamp     string            `json:"timestamp"`
+	Mode          string            `json:"mode"`
+	QueueIssues   int               `json:"queue_issues"`
+	QueuePRs      int               `json:"queue_prs"`
+	QueueHold     int               `json:"queue_hold"`
+	SLAViolations int               `json:"sla_violations"`
+	AgentsKicked  []string          `json:"agents_kicked,omitempty"`
 	AgentStates   map[string]string `json:"agent_states,omitempty"`
-	TotalTokens   int64          `json:"total_tokens"`
+	TotalTokens   int64             `json:"total_tokens"`
 }
 
 func (ns *NousState) RecordSnapshot(govState governor.State, actionable *ghpkg.ActionableResult, agentsKicked []string, agentStatuses map[string]*agent.AgentProcess, tokenSummary *tokens.AggregateSummary) error {
@@ -86,13 +94,13 @@ func (ns *NousState) RecordSnapshot(govState governor.State, actionable *ghpkg.A
 	}
 
 	snap := NousSnapshot{
-		Timestamp:     time.Now().UTC().Format(time.RFC3339),
-		Mode:          string(govState.Mode),
-		QueueIssues:   govState.QueueIssues,
-		QueuePRs:      govState.QueuePRs,
-		QueueHold:     govState.QueueHold,
-		AgentsKicked:  agentsKicked,
-		AgentStates:   make(map[string]string),
+		Timestamp:    time.Now().UTC().Format(time.RFC3339),
+		Mode:         string(govState.Mode),
+		QueueIssues:  govState.QueueIssues,
+		QueuePRs:     govState.QueuePRs,
+		QueueHold:    govState.QueueHold,
+		AgentsKicked: agentsKicked,
+		AgentStates:  make(map[string]string),
 	}
 	if actionable != nil {
 		snap.SLAViolations = actionable.Issues.SLAViolations

--- a/v2/pkg/dashboard/forge_apps.go
+++ b/v2/pkg/dashboard/forge_apps.go
@@ -1,0 +1,142 @@
+package dashboard
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// This file backs the spoke dashboard's "Forge App" tab: a read-only inventory
+// of every forge App credential the spoke holds, plus the single editable
+// active config. It NEVER returns or logs private key material — paths and
+// fingerprints only.
+
+// ForgeAppKey is one per-app-id private key held on the spoke's PVC
+// (/data/gh-app-key-<appid>.pem). Fingerprint and path only — the key material
+// itself must never leave the pod.
+type ForgeAppKey struct {
+	AppID       string `json:"app_id"`
+	Path        string `json:"path"`
+	Fingerprint string `json:"fingerprint"`
+}
+
+// ForgeAppInventory is what only cmd/hive can supply (the key resolution and
+// PVC scan live there): the key file the process would actually sign with, and
+// every per-app-id key on disk. Injected via SetForgeAppInventoryFn, following
+// the SetGitHubAppRecheckFn provider pattern, so pkg/dashboard never imports
+// cmd code.
+type ForgeAppInventory struct {
+	// ActiveKeyFile is the resolved path of the key the active config signs
+	// with ("" when none could be resolved).
+	ActiveKeyFile string
+	// HeldKeys lists every per-app-id key file on the PVC, fingerprints only.
+	HeldKeys []ForgeAppKey
+}
+
+// SetForgeAppInventoryFn registers the cmd/hive-side provider for the Forge
+// App tab. Called once at startup, before the HTTP server serves requests.
+func (s *Server) SetForgeAppInventoryFn(fn func() ForgeAppInventory) {
+	s.forgeAppInventoryFn = fn
+}
+
+// forgeActiveApp is the JSON shape of the active github config row.
+type forgeActiveApp struct {
+	AppID          int64  `json:"app_id"`
+	AppSlug        string `json:"app_slug"`
+	APIURL         string `json:"api_url"`
+	BaseURL        string `json:"base_url"`
+	InstallationID int64  `json:"installation_id"`
+	KeyFile        string `json:"key_file"`
+	KeyFingerprint string `json:"key_fingerprint"`
+	// AuthState is the classified github.AppAuthState wire token, verbatim
+	// ("not-installed", "wrong-installation", "key-invalid", ... or "" when
+	// no classification has run). This is a debugging surface — do not
+	// prettify it here.
+	AuthState string `json:"auth_state"`
+	Forge     string `json:"forge"`
+	Editable  bool   `json:"editable"`
+}
+
+type forgeAppsResponse struct {
+	Active forgeActiveApp `json:"active"`
+	// ReposForge is the forge host the spoke's configured repos live on,
+	// derived from the configured base/api URL host (empty = github.com).
+	ReposForge string        `json:"repos_forge"`
+	HeldKeys   []ForgeAppKey `json:"held_keys"`
+}
+
+// normalizeForgeAppHost canonicalizes a forge host for comparison: trimmed,
+// lowercased, and empty meaning public github.com — mirroring how the config
+// layer treats an absent base/api URL.
+func normalizeForgeAppHost(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return "github.com"
+	}
+	return host
+}
+
+// forgeAppEditable reports whether an App config whose forge is appForge may
+// be edited from this spoke's dashboard: ONLY when it matches the forge the
+// spoke's repos live on. Everything else is displayed read-only — editing a
+// credential for a forge this hive's repos do not use is never useful and is
+// exactly how the wrong key ends up active.
+func forgeAppEditable(appForge, reposForge string) bool {
+	return normalizeForgeAppHost(appForge) == normalizeForgeAppHost(reposForge)
+}
+
+// handleConfigGitHubForgeApps serves GET /api/config/github/forge-apps.
+func (s *Server) handleConfigGitHubForgeApps(w http.ResponseWriter, r *http.Request) {
+	if s.deps == nil || s.deps.Config == nil {
+		jsonError(w, "config not loaded", http.StatusServiceUnavailable)
+		return
+	}
+	g := s.deps.Config.GitHub
+
+	inv := ForgeAppInventory{}
+	if s.forgeAppInventoryFn != nil {
+		inv = s.forgeAppInventoryFn()
+	}
+
+	keyFile := inv.ActiveKeyFile
+	if keyFile == "" {
+		keyFile = g.KeyFile
+	}
+	fingerprint := ""
+	if keyFile != "" {
+		// A missing/unparseable key simply reports an empty fingerprint — the
+		// tab's job is to show what is there, not to fail on what is not.
+		if fp, err := config.AppKeyFingerprintFromFile(keyFile); err == nil {
+			fingerprint = fp
+		}
+	}
+
+	// The repos' forge comes from the configured base/api URL host (empty =
+	// github.com): HostLabel() is the single authority on that derivation.
+	// The App config's own forge honours an explicit `forge:` field first.
+	reposForge := normalizeForgeAppHost(g.HostLabel())
+	appForge := normalizeForgeAppHost(g.Forge())
+
+	held := append([]ForgeAppKey(nil), inv.HeldKeys...)
+	sort.Slice(held, func(i, j int) bool { return held[i].AppID < held[j].AppID })
+
+	resp := forgeAppsResponse{
+		Active: forgeActiveApp{
+			AppID:          g.AppID,
+			AppSlug:        g.ResolvedAppSlug(),
+			APIURL:         g.ResolvedAPIURL(),
+			BaseURL:        g.ResolvedBaseURL(),
+			InstallationID: g.InstallationID,
+			KeyFile:        keyFile,
+			KeyFingerprint: fingerprint,
+			AuthState:      s.GetGitHubAppState(),
+			Forge:          appForge,
+			Editable:       forgeAppEditable(appForge, reposForge),
+		},
+		ReposForge: reposForge,
+		HeldKeys:   held,
+	}
+	jsonResponse(w, resp)
+}

--- a/v2/pkg/dashboard/forge_apps_test.go
+++ b/v2/pkg/dashboard/forge_apps_test.go
@@ -1,0 +1,225 @@
+package dashboard
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// forgeTestKeyBits keeps test key generation fast; strength is irrelevant —
+// the key only has to be parseable for fingerprinting.
+const forgeTestKeyBits = 2048
+
+// writeForgeTestKey writes a parseable RSA private key PEM to dir and returns
+// its path and the PEM body (so tests can assert the material never appears in
+// a response).
+func writeForgeTestKey(t *testing.T, dir, name string) (string, string) {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, forgeTestKeyBits)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)})
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return path, string(pemBytes)
+}
+
+func getForgeApps(t *testing.T, s *Server) (*httptest.ResponseRecorder, map[string]any) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/config/github/forge-apps", nil)
+	s.mux.ServeHTTP(rec, req)
+	var body map[string]any
+	if rec.Code == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+	}
+	return rec, body
+}
+
+// TestForgeApps_ProviderInjected_FingerprintsNeverKeyMaterial feeds the
+// provider real key paths and asserts the response carries fingerprints and
+// paths ONLY — no fragment of the PEM may appear anywhere in the body.
+func TestForgeApps_ProviderInjected_FingerprintsNeverKeyMaterial(t *testing.T) {
+	srv := newFullServer(t)
+	dir := t.TempDir()
+	activePath, activePEM := writeForgeTestKey(t, dir, "gh-app-key.pem")
+	heldPath, heldPEM := writeForgeTestKey(t, dir, "gh-app-key-777.pem")
+	heldFP, err := config.AppKeyFingerprintFromFile(heldPath)
+	if err != nil || heldFP == "" {
+		t.Fatalf("fingerprint held key: %v", err)
+	}
+	activeFP, err := config.AppKeyFingerprintFromFile(activePath)
+	if err != nil || activeFP == "" {
+		t.Fatalf("fingerprint active key: %v", err)
+	}
+
+	srv.SetForgeAppInventoryFn(func() ForgeAppInventory {
+		return ForgeAppInventory{
+			ActiveKeyFile: activePath,
+			HeldKeys: []ForgeAppKey{
+				{AppID: "777", Path: heldPath, Fingerprint: heldFP},
+			},
+		}
+	})
+	srv.deps.Config.GitHub.AppID = 123456
+	srv.deps.Config.GitHub.InstallationID = 42980
+
+	rec, body := getForgeApps(t, srv)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+
+	raw := rec.Body.String()
+	// The load-bearing assertion: key MATERIAL is absent even though the
+	// provider was fed real key paths.
+	if strings.Contains(raw, "PRIVATE KEY") {
+		t.Fatalf("response contains PEM header — key material leaked: %s", raw)
+	}
+	for _, pemBody := range []string{activePEM, heldPEM} {
+		// Check a distinctive base64 chunk from the middle of the key too, in
+		// case a future edit strips headers but leaks the payload.
+		lines := strings.Split(strings.TrimSpace(pemBody), "\n")
+		if len(lines) > 2 {
+			if strings.Contains(raw, lines[len(lines)/2]) {
+				t.Fatalf("response contains key material payload")
+			}
+		}
+	}
+
+	active, _ := body["active"].(map[string]any)
+	if active == nil {
+		t.Fatalf("missing active in %s", raw)
+	}
+	if active["key_file"] != activePath {
+		t.Errorf("active key_file = %v, want %s", active["key_file"], activePath)
+	}
+	if active["key_fingerprint"] != activeFP {
+		t.Errorf("active key_fingerprint = %v, want %s", active["key_fingerprint"], activeFP)
+	}
+	held, _ := body["held_keys"].([]any)
+	if len(held) != 1 {
+		t.Fatalf("held_keys = %v, want 1 row", body["held_keys"])
+	}
+	row := held[0].(map[string]any)
+	if row["app_id"] != "777" || row["fingerprint"] != heldFP || row["path"] != heldPath {
+		t.Errorf("held key row = %v, want app 777 with fingerprint %s at %s", row, heldFP, heldPath)
+	}
+}
+
+// TestForgeApps_AuthStateVerbatim pins the classified wire token passing
+// through unprettified — it is the debugging surface.
+func TestForgeApps_AuthStateVerbatim(t *testing.T) {
+	srv := newFullServer(t)
+	srv.SetGitHubAppRequired(true)
+	srv.SetGitHubAppState("wrong-installation")
+
+	rec, body := getForgeApps(t, srv)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	active := body["active"].(map[string]any)
+	if active["auth_state"] != "wrong-installation" {
+		t.Errorf("auth_state = %v, want the wire token verbatim", active["auth_state"])
+	}
+}
+
+// TestForgeApps_EditableOnlyWhenForgeMatchesRepos drives the editable rule
+// through the endpoint: a config whose forge matches the repos' forge (from
+// the base/api URL host, empty = github.com) is editable; a config whose
+// explicit forge names a different host is not.
+func TestForgeApps_EditableOnlyWhenForgeMatchesRepos(t *testing.T) {
+	t.Run("default github.com config is editable", func(t *testing.T) {
+		srv := newFullServer(t)
+		rec, body := getForgeApps(t, srv)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d", rec.Code)
+		}
+		active := body["active"].(map[string]any)
+		if active["editable"] != true {
+			t.Errorf("editable = %v, want true — repos and App both resolve to github.com", active["editable"])
+		}
+		if body["repos_forge"] != "github.com" {
+			t.Errorf("repos_forge = %v, want github.com for empty URLs", body["repos_forge"])
+		}
+	})
+
+	t.Run("GHE config with GHE repos is editable", func(t *testing.T) {
+		srv := newFullServer(t)
+		srv.deps.Config.GitHub.APIURL = "https://github.ibm.com/api/v3"
+		rec, body := getForgeApps(t, srv)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d", rec.Code)
+		}
+		active := body["active"].(map[string]any)
+		if active["editable"] != true {
+			t.Errorf("editable = %v, want true — App forge and repos forge are both github.ibm.com", active["editable"])
+		}
+	})
+
+	t.Run("explicit forge differing from repos host is read-only", func(t *testing.T) {
+		srv := newFullServer(t)
+		// Repos live on github.com (empty URLs) but the config claims an App
+		// on a different forge: the one case that must NOT be editable.
+		srv.deps.Config.GitHub.Forge_ = "github.ibm.com"
+		rec, body := getForgeApps(t, srv)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d", rec.Code)
+		}
+		active := body["active"].(map[string]any)
+		if active["editable"] != false {
+			t.Errorf("editable = %v, want false — App forge github.ibm.com does not match repos forge github.com", active["editable"])
+		}
+	})
+}
+
+// TestForgeAppEditable is the unit truth table for the pure comparison.
+func TestForgeAppEditable(t *testing.T) {
+	cases := []struct {
+		name                 string
+		appForge, reposForge string
+		want                 bool
+	}{
+		{"both empty means github.com", "", "", true},
+		{"empty vs explicit github.com", "", "github.com", true},
+		{"case-insensitive match", "GitHub.com", "github.com", true},
+		{"GHE match", "github.ibm.com", "github.ibm.com", true},
+		{"GHE vs public mismatch", "github.ibm.com", "github.com", false},
+		{"public vs GHE mismatch", "", "github.ibm.com", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := forgeAppEditable(tc.appForge, tc.reposForge); got != tc.want {
+				t.Errorf("forgeAppEditable(%q, %q) = %v, want %v", tc.appForge, tc.reposForge, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestForgeApps_NoProvider proves the endpoint degrades gracefully when
+// cmd/hive has not injected an inventory (tests, early boot): config values
+// still serve, with no held keys.
+func TestForgeApps_NoProvider(t *testing.T) {
+	srv := newFullServer(t)
+	rec, body := getForgeApps(t, srv)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 without a provider", rec.Code)
+	}
+	if held, ok := body["held_keys"].([]any); ok && len(held) != 0 {
+		t.Errorf("held_keys = %v, want empty without a provider", held)
+	}
+}

--- a/v2/pkg/dashboard/github_auth_config_truth_test.go
+++ b/v2/pkg/dashboard/github_auth_config_truth_test.go
@@ -1,0 +1,121 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// These tests pin the config-truth rule for github_auth: when the spoke knows
+// from CONFIG that its GitHub App has no installation (SetGitHubAppRequired
+// true + state "not-installed"), BOTH health surfaces must fail github_auth
+// with "GitHub App not installed" — even while a live GHClient still exists,
+// because any such client is riding a cached token that cannot be renewed.
+
+// notInstalledServer builds a full test server carrying a live (non-nil)
+// GHClient and the not-installed config-truth state.
+func notInstalledServer(t *testing.T) *Server {
+	t.Helper()
+	srv := newFullServer(t)
+	srv.MarkReady()
+
+	// A real, reachable client object — it must NOT mask the config truth.
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("{}"))
+	}))
+	t.Cleanup(gh.Close)
+	srv.deps.GHClient = ghpkg.NewClientForTest(gh.URL, "testorg", []string{"testrepo"}, covBLogger())
+
+	srv.SetGitHubAppRequired(true)
+	srv.SetGitHubAppState("not-installed")
+	return srv
+}
+
+func TestHealthDeep_GitHubAuthFailsFromConfigTruth_DespiteLiveClient(t *testing.T) {
+	srv := notInstalledServer(t)
+
+	req := httptest.NewRequest("GET", "/api/health/deep", nil)
+	w := httptest.NewRecorder()
+	srv.handleHealthDeep(w, req)
+
+	var result map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	checks, ok := result["checks"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing checks in %v", result)
+	}
+	ga, ok := checks["github_auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing github_auth check in %v", checks)
+	}
+	if ga["status"] != "fail" {
+		t.Errorf("github_auth status = %v, want fail (live GHClient must not mask a missing installation)", ga["status"])
+	}
+	detail, _ := ga["detail"].(string)
+	if !strings.Contains(detail, "GitHub App not installed") {
+		t.Errorf("github_auth detail = %q, want it to name the missing installation", detail)
+	}
+}
+
+func TestHealthSummary_GitHubAuthFailsFromConfigTruth_DespiteLiveClient(t *testing.T) {
+	srv := notInstalledServer(t)
+
+	sum := srv.HealthSummary()
+	raw, err := json.Marshal(sum)
+	if err != nil {
+		t.Fatalf("marshal summary: %v", err)
+	}
+	var parsed struct {
+		Checks []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+			Detail string `json:"detail"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal summary: %v", err)
+	}
+	found := false
+	for _, c := range parsed.Checks {
+		if c.Name != "github_auth" {
+			continue
+		}
+		found = true
+		if c.Status != "fail" {
+			t.Errorf("github_auth status = %q, want fail (live GHClient must not mask a missing installation)", c.Status)
+		}
+		if !strings.Contains(c.Detail, "GitHub App not installed") {
+			t.Errorf("github_auth detail = %q, want it to name the missing installation", c.Detail)
+		}
+	}
+	if !found {
+		t.Fatalf("no github_auth check in summary: %s", raw)
+	}
+}
+
+// TestGitHubAuth_PassesWhenInstallationStateCleared is the contrast case: the
+// same live client with the not-installed state cleared must pass, proving the
+// failure above comes from the config-truth branch and nothing else.
+func TestGitHubAuth_PassesWhenInstallationStateCleared(t *testing.T) {
+	srv := notInstalledServer(t)
+	srv.SetGitHubAppState("")
+
+	req := httptest.NewRequest("GET", "/api/health/deep", nil)
+	w := httptest.NewRecorder()
+	srv.handleHealthDeep(w, req)
+
+	var result map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	ga := result["checks"].(map[string]any)["github_auth"].(map[string]any)
+	if ga["status"] != "pass" {
+		t.Errorf("github_auth status = %v, want pass once state is cleared", ga["status"])
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -187,6 +187,12 @@ type Server struct {
 	hubBanner   *HubBannerState
 
 	githubAppRecheckFn func() bool
+
+	// forgeAppInventoryFn supplies the Forge App tab's key inventory from
+	// cmd/hive (resolved active key path + per-app-id PVC keys, fingerprints
+	// only). Set once at startup via SetForgeAppInventoryFn; nil in tests and
+	// early boot, which the handler tolerates.
+	forgeAppInventoryFn func() ForgeAppInventory
 }
 
 // StatusPayload matches the JSON contract the dashboard frontend render() expects.

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -2050,7 +2051,11 @@ func (s *Server) HealthSummary() map[string]any {
 		stalled := 0
 		unsubstituted := 0
 		down := 0
-		for _, proc := range s.deps.AgentMgr.AllStatuses() {
+		// The names behind the counts. "1 down" alone is unactionable — the
+		// operator's next question is always WHICH one, and the answer was
+		// dropped right here where it was known.
+		var downNames, stalledNames []string
+		for name, proc := range s.deps.AgentMgr.AllStatuses() {
 			if proc.Paused {
 				paused++
 				continue
@@ -2068,18 +2073,25 @@ func (s *Server) HealthSummary() map[string]any {
 				if !grace && proc.OutputBuffer != nil && proc.OutputBuffer.Count() == 0 && proc.LastKick != nil {
 					if time.Since(*proc.LastKick) > staleOutputThreshold {
 						stalled++
+						stalledNames = append(stalledNames, name)
 					}
 				}
 			} else if !grace {
 				down++
+				downNames = append(downNames, name)
 			}
 		}
+		// Map iteration order is random; sorted names keep the detail line
+		// stable across beats so the hub does not see a "changed" status that
+		// is really the same agents in a different order.
+		sort.Strings(downNames)
+		sort.Strings(stalledNames)
 		detail := fmt.Sprintf("%d running", running)
 		if paused > 0 {
 			detail += fmt.Sprintf(", %d paused", paused)
 		}
 		if down > 0 {
-			detail += fmt.Sprintf(", %d down", down)
+			detail += fmt.Sprintf(", %d down: %s", down, strings.Join(downNames, ", "))
 		}
 		st := "pass"
 		if down > 0 {
@@ -2089,7 +2101,7 @@ func (s *Server) HealthSummary() map[string]any {
 		checks = append(checks, check{Name: "agents", Status: st, Detail: detail})
 
 		if stalled > 0 {
-			checks = append(checks, check{Name: "stall_detection", Status: "warn", Detail: fmt.Sprintf("%d stalled (no output 30+ min)", stalled)})
+			checks = append(checks, check{Name: "stall_detection", Status: "warn", Detail: fmt.Sprintf("%d stalled (no output 30+ min): %s", stalled, strings.Join(stalledNames, ", "))})
 			warns++
 		} else {
 			checks = append(checks, check{Name: "stall_detection", Status: "pass"})

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -1143,6 +1143,23 @@ func (s *Server) handleBannerDismissed(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, map[string]bool{"ok": true})
 }
 
+// githubAppStateNotInstalledToken is the pkg/github AppAuthState wire token
+// for "genuinely not installed" (AppStateNotInstalled.String()), kept as the
+// string the setter receives so this package needs no classifier dependency.
+const githubAppStateNotInstalledToken = "not-installed"
+
+// githubAppNotInstalled reports the config-truth state that must fail
+// github_auth in BOTH health surfaces regardless of which client object still
+// exists: an App with no installation cannot mint, so any working client is
+// riding a cached token that cannot be renewed. Waiting for the first failed
+// mint kept the banner down and the hub green for up to an hour after an
+// installation was cleared — exactly when the operator needed the opposite.
+func (s *Server) githubAppNotInstalled() bool {
+	s.githubAppMu.RLock()
+	defer s.githubAppMu.RUnlock()
+	return s.githubAppRequired && s.githubAppState == githubAppStateNotInstalledToken
+}
+
 func (s *Server) SetGitHubAppRequired(required bool) {
 	s.githubAppMu.Lock()
 	defer s.githubAppMu.Unlock()
@@ -1442,8 +1459,12 @@ func (s *Server) handleHealthDeep(w http.ResponseWriter, r *http.Request) {
 		failCount++
 	}
 
-	// 2. GitHub auth
-	if s.deps != nil && s.deps.GHAppAuth != nil {
+	// 2. GitHub auth — config truth first (see githubAppNotInstalled).
+	if s.githubAppNotInstalled() {
+		checks["github_auth"] = map[string]any{"status": "fail", "detail": "GitHub App not installed — no installation for this org"}
+		overall = "degraded"
+		failCount++
+	} else if s.deps != nil && s.deps.GHAppAuth != nil {
 		if _, err := s.deps.GHAppAuth.Token(s.deps.Ctx); err == nil {
 			checks["github_auth"] = map[string]any{"status": "pass"}
 		} else {
@@ -2021,8 +2042,11 @@ func (s *Server) HealthSummary() map[string]any {
 		fails++
 	}
 
-	// 2. GitHub auth
-	if s.deps != nil && s.deps.GHAppAuth != nil {
+	// 2. GitHub auth — config truth first (see githubAppNotInstalled).
+	if s.githubAppNotInstalled() {
+		checks = append(checks, check{Name: "github_auth", Status: "fail", Detail: "GitHub App not installed — no installation for this org"})
+		fails++
+	} else if s.deps != nil && s.deps.GHAppAuth != nil {
 		if _, err := s.deps.GHAppAuth.Token(s.deps.Ctx); err != nil {
 			// Surface the underlying error, not a bare "token error": this
 			// detail travels to the hub and into the dashboard tooltip, and a

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -199,6 +199,13 @@ type StatusPayload struct {
 	Repos               []FrontendRepo         `json:"repos"`
 	Beads               FrontendBeads          `json:"beads"`
 	Health              map[string]any         `json:"health"`
+	// DeepHealth carries the spoke's own deep health checks (HealthSummary:
+	// ready, github_auth, agents, …) — the same checks the heartbeat reports
+	// to the hub. The dashboard's header Health pill renders from these, NOT
+	// from the shallow /api/health liveness signal or the repo-workflow
+	// Health map above, so the pill can never show "Health OK" while the
+	// spoke's own agents are down (#2465).
+	DeepHealth          map[string]any         `json:"deepHealth,omitempty"`
 	Budget              FrontendBudget         `json:"budget"`
 	CadenceMatrix       []FrontendCadence      `json:"cadenceMatrix"`
 	GHRateLimits        map[string]any         `json:"ghRateLimits"`
@@ -1017,6 +1024,17 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 	s.githubAppMu.RUnlock()
 
 	status.InferenceBackends = s.buildInferenceBackends()
+
+	// Deep checks travel inside the status payload so every dashboard surface
+	// (header pill included) renders the same truth the heartbeat sends the
+	// hub. Judged against the payload in hand: it becomes s.status moments
+	// from now, so "ready" must not fail merely because the first beat's
+	// payload has not been assigned yet. Computed before statusMu is taken
+	// below (healthSummaryFor must not run under it).
+	s.statusMu.RLock()
+	readyForDeep := s.ready
+	s.statusMu.RUnlock()
+	status.DeepHealth = s.healthSummaryFor(status, readyForDeep)
 
 	s.systemAlertsMu.RLock()
 	if len(s.systemAlerts) > 0 {
@@ -2022,6 +2040,20 @@ func (s *Server) AdvisoryState() (lastPostedAt time.Time, lastFindings int, last
 
 // HealthSummary returns a deep-health summary with individual check results for heartbeats.
 func (s *Server) HealthSummary() map[string]any {
+	s.statusMu.RLock()
+	status := s.status
+	ready := s.status != nil && s.ready
+	s.statusMu.RUnlock()
+	return s.healthSummaryFor(status, ready)
+}
+
+// healthSummaryFor computes the deep-health checks against an explicit status
+// payload and readiness verdict, so UpdateStatus can embed a snapshot judged
+// against the payload it is ABOUT to install — judging s.status there would
+// report a false "ready: fail" on the first beat after boot, before any
+// payload has been assigned. Callers must not hold statusMu (the readiness
+// and queue inputs are passed in instead of read here).
+func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]any {
 	type check struct {
 		Name   string `json:"name"`
 		Status string `json:"status"`
@@ -2032,9 +2064,6 @@ func (s *Server) HealthSummary() map[string]any {
 	warns := 0
 
 	// 1. Readiness
-	s.statusMu.RLock()
-	ready := s.status != nil && s.ready
-	s.statusMu.RUnlock()
 	if ready {
 		checks = append(checks, check{Name: "ready", Status: "pass"})
 	} else {
@@ -2174,15 +2203,13 @@ func (s *Server) HealthSummary() map[string]any {
 	}
 
 	// 7. Queue
-	s.statusMu.RLock()
-	if s.status != nil {
+	if status != nil {
 		total := 0
-		for _, repo := range s.status.Repos {
+		for _, repo := range status.Repos {
 			total += len(repo.ActionableIssues)
 		}
 		checks = append(checks, check{Name: "queue", Status: "pass", Detail: fmt.Sprintf("%d actionable", total)})
 	}
-	s.statusMu.RUnlock()
 
 	overall := "ok"
 	if fails > 2 {

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -2039,6 +2039,30 @@ func (s *Server) AdvisoryState() (lastPostedAt time.Time, lastFindings int, last
 }
 
 // HealthSummary returns a deep-health summary with individual check results for heartbeats.
+// agentCLIUnauthenticated reports whether an agent's CLI backend lacks working
+// credentials — the exact signal the agent panel uses to render its AUTH/Login
+// button: the pane poller saw a login prompt (proc.NeedsLogin), or the
+// shared-credential probe registered via SetBackendAuthProvider (wired to
+// agent.Manager.BackendAuthAvailable in main.go) reports the backend's auth
+// state as known-and-unavailable. Backend resolution mirrors buildAgents:
+// BackendOverride wins over the configured backend. For backends the probe
+// cannot introspect (known=false) this returns false — an unknown auth state
+// must not reclassify a genuinely crashed agent out of "down".
+func agentCLIUnauthenticated(proc *agent.AgentProcess, authFn func(backend string) (available, known bool)) bool {
+	if proc.NeedsLogin {
+		return true
+	}
+	if authFn == nil {
+		return false
+	}
+	backend := proc.Config.Backend
+	if proc.BackendOverride != "" {
+		backend = proc.BackendOverride
+	}
+	available, known := authFn(backend)
+	return known && !available
+}
+
 func (s *Server) HealthSummary() map[string]any {
 	s.statusMu.RLock()
 	status := s.status
@@ -2104,10 +2128,12 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 		stalled := 0
 		unsubstituted := 0
 		down := 0
+		needLogin := 0
 		// The names behind the counts. "1 down" alone is unactionable — the
 		// operator's next question is always WHICH one, and the answer was
 		// dropped right here where it was known.
-		var downNames, stalledNames []string
+		var downNames, stalledNames, needLoginNames []string
+		authFn := getBackendAuthFn()
 		for name, proc := range s.deps.AgentMgr.AllStatuses() {
 			if proc.Paused {
 				paused++
@@ -2130,8 +2156,18 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 					}
 				}
 			} else if !grace {
-				down++
-				downNames = append(downNames, name)
+				// A non-running agent whose CLI has no credentials is not
+				// crashed — it is waiting for a human to click Login on the
+				// agent panel. Bucket it separately so the operator reads an
+				// owner-actionable "need login" instead of chasing a "down"
+				// agent that will keep exiting until someone authenticates.
+				if agentCLIUnauthenticated(proc, authFn) {
+					needLogin++
+					needLoginNames = append(needLoginNames, name)
+				} else {
+					down++
+					downNames = append(downNames, name)
+				}
 			}
 		}
 		// Map iteration order is random; sorted names keep the detail line
@@ -2139,6 +2175,7 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 		// is really the same agents in a different order.
 		sort.Strings(downNames)
 		sort.Strings(stalledNames)
+		sort.Strings(needLoginNames)
 		detail := fmt.Sprintf("%d running", running)
 		if paused > 0 {
 			detail += fmt.Sprintf(", %d paused", paused)
@@ -2146,8 +2183,14 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 		if down > 0 {
 			detail += fmt.Sprintf(", %d down: %s", down, strings.Join(downNames, ", "))
 		}
+		if needLogin > 0 {
+			detail += fmt.Sprintf(", %d need login: %s", needLogin, strings.Join(needLoginNames, ", "))
+		}
 		st := "pass"
-		if down > 0 {
+		// need-login keeps the same fail semantics as down: the agent still
+		// cannot work, and the hub row must keep surfacing it until a human
+		// clicks Login — the detail line tells them which kind of broken it is.
+		if down > 0 || needLogin > 0 {
 			st = "fail"
 			fails++
 		}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -197,14 +197,14 @@ type Server struct {
 
 // StatusPayload matches the JSON contract the dashboard frontend render() expects.
 type StatusPayload struct {
-	Timestamp           string                 `json:"timestamp"`
-	HiveID              string                 `json:"hiveId"`
-	Agents              []FrontendAgent        `json:"agents"`
-	Governor            FrontendGovernor       `json:"governor"`
-	Tokens              FrontendTokens         `json:"tokens"`
-	Repos               []FrontendRepo         `json:"repos"`
-	Beads               FrontendBeads          `json:"beads"`
-	Health              map[string]any         `json:"health"`
+	Timestamp string           `json:"timestamp"`
+	HiveID    string           `json:"hiveId"`
+	Agents    []FrontendAgent  `json:"agents"`
+	Governor  FrontendGovernor `json:"governor"`
+	Tokens    FrontendTokens   `json:"tokens"`
+	Repos     []FrontendRepo   `json:"repos"`
+	Beads     FrontendBeads    `json:"beads"`
+	Health    map[string]any   `json:"health"`
 	// DeepHealth carries the spoke's own deep health checks (HealthSummary:
 	// ready, github_auth, agents, …) — the same checks the heartbeat reports
 	// to the hub. The dashboard's header Health pill renders from these, NOT
@@ -2190,7 +2190,11 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 			detail += fmt.Sprintf(", %d down: %s", down, strings.Join(downNames, ", "))
 		}
 		if needLogin > 0 {
-			detail += fmt.Sprintf(", %d need login: %s", needLogin, strings.Join(needLoginNames, ", "))
+			verb := "need"
+			if needLogin == 1 {
+				verb = "needs"
+			}
+			detail += fmt.Sprintf(", %d %s login: %s", needLogin, verb, strings.Join(needLoginNames, ", "))
 		}
 		st := "pass"
 		// need-login keeps the same fail semantics as down: the agent still

--- a/v2/pkg/dashboard/server_health_needlogin_test.go
+++ b/v2/pkg/dashboard/server_health_needlogin_test.go
@@ -1,0 +1,147 @@
+package dashboard
+
+// Health-check classification of unauthenticated agents. An agent whose CLI
+// has no credentials is not crashed — it is waiting for a human to click
+// Login on the agent panel — so the agents health check must report it in a
+// separate "need login" bucket instead of lumping it in with "down". These
+// tests drive the real HealthSummary path through a real agent.Manager plus
+// the same SetBackendAuthProvider seam production wires in main.go.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/agent"
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// healthChecksOf runs HealthSummary and decodes its checks through JSON (the
+// check struct is a function-local type, so tests read it the same way the
+// wire does).
+func healthChecksOf(t *testing.T, s *Server) []struct{ Name, Status, Detail string } {
+	t.Helper()
+	raw, err := json.Marshal(s.HealthSummary())
+	if err != nil {
+		t.Fatalf("marshal HealthSummary: %v", err)
+	}
+	var parsed struct {
+		Checks []struct{ Name, Status, Detail string } `json:"checks"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal HealthSummary: %v", err)
+	}
+	return parsed.Checks
+}
+
+func agentsCheckOf(t *testing.T, s *Server) (status, detail string) {
+	t.Helper()
+	for _, c := range healthChecksOf(t, s) {
+		if c.Name == "agents" {
+			return c.Status, c.Detail
+		}
+	}
+	t.Fatalf("no 'agents' check in HealthSummary")
+	return "", ""
+}
+
+// TestHealthSummary_NeedLoginBucket locks in the full classification: an
+// authenticated crashed agent stays in "down", unauthenticated non-running
+// agents land in "need login" with their (sorted) names, both buckets coexist
+// on one detail line, and the check still fails so the hub row surfaces it.
+func TestHealthSummary_NeedLoginBucket(t *testing.T) {
+	deps := testDeps(t)
+	agentCfgs := map[string]config.AgentConfig{
+		"crashed": {Backend: "claude", Enabled: true}, // authenticated, not running → down
+		"needy-b": {Backend: "bob", Enabled: true},    // unauthenticated → need login
+		"needy-a": {Backend: "bob", Enabled: true},    // unauthenticated → need login
+	}
+	deps.AgentMgr = agent.NewManager(agentCfgs, deps.Logger, agent.ProjectContext{})
+
+	SetBackendAuthProvider(func(backend string) (available, known bool) {
+		switch backend {
+		case "claude":
+			return true, true // credentials present
+		case "bob":
+			return false, true // known unauthenticated — the Login-button state
+		}
+		return false, false
+	})
+	t.Cleanup(func() { SetBackendAuthProvider(nil) })
+
+	s := NewServer(0, deps.Logger)
+	s.RegisterAPI(deps)
+	// No MarkReady: readyAt stays zero so the health grace window is not
+	// active and non-running agents are classified instead of skipped.
+
+	status, detail := agentsCheckOf(t, s)
+
+	// Exact line: names sorted, down and need-login coexisting, and the
+	// unauthenticated agents NOT counted as down.
+	want := "0 running, 1 down: crashed, 2 need login: needy-a, needy-b"
+	if detail != want {
+		t.Fatalf("agents detail = %q, want %q", detail, want)
+	}
+	// Agents that cannot work still fail the check — need-login must not
+	// silently soften the hub row.
+	if status != "fail" {
+		t.Fatalf("agents status = %q, want fail (agents needing login cannot work)", status)
+	}
+}
+
+// TestHealthSummary_NeedLoginOnly checks the detail line when every
+// non-running agent is merely unauthenticated: no "down" segment at all.
+func TestHealthSummary_NeedLoginOnly(t *testing.T) {
+	deps := testDeps(t)
+	deps.AgentMgr = agent.NewManager(map[string]config.AgentConfig{
+		"supervisor": {Backend: "bob", Enabled: true},
+	}, deps.Logger, agent.ProjectContext{})
+
+	SetBackendAuthProvider(func(backend string) (available, known bool) {
+		return false, backend == "bob"
+	})
+	t.Cleanup(func() { SetBackendAuthProvider(nil) })
+
+	s := NewServer(0, deps.Logger)
+	s.RegisterAPI(deps)
+
+	status, detail := agentsCheckOf(t, s)
+	if want := "0 running, 1 need login: supervisor"; detail != want {
+		t.Fatalf("agents detail = %q, want %q", detail, want)
+	}
+	if status != "fail" {
+		t.Fatalf("agents status = %q, want fail", status)
+	}
+}
+
+// TestAgentCLIUnauthenticated covers the classifier's edges directly.
+func TestAgentCLIUnauthenticated(t *testing.T) {
+	authFor := func(m map[string][2]bool) func(string) (bool, bool) {
+		return func(backend string) (bool, bool) {
+			v := m[backend]
+			return v[0], v[1]
+		}
+	}
+
+	// Pane poller saw a login prompt → unauthenticated even with no probe.
+	if !agentCLIUnauthenticated(&agent.AgentProcess{NeedsLogin: true}, nil) {
+		t.Fatal("NeedsLogin=true must classify as unauthenticated")
+	}
+	// Unknown auth state must NOT reclassify a crashed agent out of "down".
+	p := &agent.AgentProcess{Config: config.AgentConfig{Backend: "mystery"}}
+	if agentCLIUnauthenticated(p, authFor(map[string][2]bool{"mystery": {false, false}})) {
+		t.Fatal("unknown auth state must not count as need-login")
+	}
+	// Nil probe (never registered) → same conservatism.
+	if agentCLIUnauthenticated(p, nil) {
+		t.Fatal("nil auth probe must not count as need-login")
+	}
+	// BackendOverride wins over the configured backend, mirroring buildAgents.
+	p = &agent.AgentProcess{
+		Config:          config.AgentConfig{Backend: "claude"},
+		BackendOverride: "bob",
+	}
+	fn := authFor(map[string][2]bool{"claude": {true, true}, "bob": {false, true}})
+	if !agentCLIUnauthenticated(p, fn) {
+		t.Fatal("BackendOverride's auth state must be the one consulted")
+	}
+}

--- a/v2/pkg/dashboard/server_health_needlogin_test.go
+++ b/v2/pkg/dashboard/server_health_needlogin_test.go
@@ -105,7 +105,7 @@ func TestHealthSummary_NeedLoginOnly(t *testing.T) {
 	s.RegisterAPI(deps)
 
 	status, detail := agentsCheckOf(t, s)
-	if want := "0 running, 1 need login: supervisor"; detail != want {
+	if want := "0 running, 1 needs login: supervisor"; detail != want {
 		t.Fatalf("agents detail = %q, want %q", detail, want)
 	}
 	if status != "fail" {

--- a/v2/pkg/dashboard/spoke_health_truth_test.go
+++ b/v2/pkg/dashboard/spoke_health_truth_test.go
@@ -1,0 +1,211 @@
+package dashboard
+
+// Issue #2465: the spoke dashboard showed a green "Health OK" header pill and
+// green sidebar agent dots while the spoke's own deep health checks reported
+// agents down. Two weak signals were rendered where truth exists: the pill
+// ignored the deep checks, and the sidebar dot only knew the 'stopped' state,
+// so 'failed' (crash-looping) agents fell through to the green 'idle' class.
+//
+// These tests pin the server-side contract (the status payload carries the
+// deep checks) and the UI wiring (pill and dot read the strong signal).
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// deepHealthAgentsCheck digs the "agents" check out of a decoded deepHealth
+// map. Returns nil if absent.
+func deepHealthAgentsCheck(t *testing.T, deep map[string]any) map[string]any {
+	t.Helper()
+	checks, ok := deep["checks"].([]any)
+	if !ok {
+		t.Fatalf("deepHealth.checks is %T, want array", deep["checks"])
+	}
+	for _, c := range checks {
+		m, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["name"] == "agents" {
+			return m
+		}
+	}
+	return nil
+}
+
+// The /api/status payload must carry the deep health checks — the same ones
+// the heartbeat reports to the hub — so the header pill can render them. A
+// down (registered but never launched ⇒ StateStopped) agent must appear as a
+// failing "agents" check with its name in the detail.
+func TestStatusPayloadCarriesDeepHealth(t *testing.T) {
+	srv := newFullServer(t)
+	srv.MarkReady()
+	// Age readiness past the health grace period so the agents check judges
+	// the fleet for real instead of skipping it as "just booted".
+	srv.statusMu.Lock()
+	srv.readyAt = time.Now().Add(-2 * healthGracePeriod)
+	srv.statusMu.Unlock()
+
+	srv.UpdateStatus(minimalPayload())
+
+	req := httptest.NewRequest("GET", "/api/status", nil)
+	w := httptest.NewRecorder()
+	srv.handleStatus(w, req)
+
+	var got struct {
+		DeepHealth map[string]any `json:"deepHealth"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decoding /api/status: %v", err)
+	}
+	if got.DeepHealth == nil {
+		t.Fatal("/api/status payload has no deepHealth — the header pill has nothing truthful to render (#2465)")
+	}
+	if got.DeepHealth["status"] != "degraded" {
+		t.Errorf("deepHealth.status = %v, want degraded (scanner is registered but not running)", got.DeepHealth["status"])
+	}
+	agents := deepHealthAgentsCheck(t, got.DeepHealth)
+	if agents == nil {
+		t.Fatal("deepHealth.checks has no 'agents' check")
+	}
+	if agents["status"] != "fail" {
+		t.Errorf("agents check status = %v, want fail", agents["status"])
+	}
+	detail, _ := agents["detail"].(string)
+	if !strings.Contains(detail, "1 down: scanner") {
+		t.Errorf("agents check detail = %q, want it to name the down agent (\"1 down: scanner\")", detail)
+	}
+}
+
+// The deep snapshot embedded on the FIRST beat is judged against the payload
+// being installed, not the not-yet-assigned s.status — otherwise every boot
+// flashed a false "ready: fail" (and a red pill) until the second full update.
+func TestDeepHealthFirstBeatReadyPasses(t *testing.T) {
+	srv := newFullServer(t)
+	srv.MarkReady()
+
+	// First UpdateStatus ever: s.status is still nil when the snapshot is computed.
+	srv.UpdateStatus(minimalPayload())
+
+	// Read the installed payload through the same JSON the frontend sees —
+	// the in-memory map holds a typed check slice, so round-trip it.
+	req := httptest.NewRequest("GET", "/api/status", nil)
+	w := httptest.NewRecorder()
+	srv.handleStatus(w, req)
+
+	var got struct {
+		DeepHealth map[string]any `json:"deepHealth"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decoding /api/status: %v", err)
+	}
+	if got.DeepHealth == nil {
+		t.Fatal("first beat has no deepHealth")
+	}
+	checks, ok := got.DeepHealth["checks"].([]any)
+	if !ok {
+		t.Fatalf("deepHealth.checks is %T, want array", got.DeepHealth["checks"])
+	}
+	for _, c := range checks {
+		m, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["name"] == "ready" && m["status"] != "pass" {
+			t.Errorf("first-beat ready check = %v, want pass — the snapshot must be judged against the payload being installed", m["status"])
+		}
+	}
+}
+
+// The refactor onto healthSummaryFor must not weaken the public path: an
+// un-ready server (no MarkReady, no status) still reports a failing "ready"
+// check through HealthSummary, exactly as the heartbeat relies on.
+func TestHealthSummaryNotReadyStillFails(t *testing.T) {
+	srv := newFullServer(t)
+
+	raw, err := json.Marshal(srv.HealthSummary())
+	if err != nil {
+		t.Fatalf("marshal summary: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal summary: %v", err)
+	}
+	checks, ok := m["checks"].([]any)
+	if !ok {
+		t.Fatalf("checks is %T, want array", m["checks"])
+	}
+	found := false
+	for _, c := range checks {
+		cm, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if cm["name"] == "ready" {
+			found = true
+			if cm["status"] != "fail" {
+				t.Errorf("ready check on un-ready server = %v, want fail", cm["status"])
+			}
+		}
+	}
+	if !found {
+		t.Error("HealthSummary has no ready check")
+	}
+}
+
+// UI wiring: the header pill and sidebar agent dots must read the strong
+// signals. Snippet assertions in the style of gh_app_banner_test.go — they
+// pin the load-bearing lines of the inline script.
+func TestSpokeHealthTruthUIWiring(t *testing.T) {
+	b, err := os.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatalf("reading static/index.html: %v", err)
+	}
+	html := string(b)
+
+	required := []struct {
+		snippet string
+		why     string
+	}{
+		{
+			snippet: "data.deepHealth",
+			why:     "the header pill must render the deep checks from the status payload, not just the repo-workflow health map",
+		},
+		{
+			snippet: "'● Degraded'",
+			why:     "any failing deep check must flip the pill to Degraded",
+		},
+		{
+			snippet: "const isDown = a.state !== 'running' && !isPaused && !isOff && !isOnDemand;",
+			why:     "the sidebar dot must treat every non-running, non-paused process state (stopped, failed, idle) as down",
+		},
+		{
+			snippet: "const needsLoginDown = isDown && needsLogin;",
+			why:     "a down agent with an unauthenticated CLI must get the distinct needs-login state, not plain down-red",
+		},
+		{
+			snippet: ".oc-agent-dot.needs-login { background: var(--amber); }",
+			why:     "the sidebar needs-login dot must render amber (warning), not green or red",
+		},
+		{
+			snippet: "needs login — CLI unauthenticated",
+			why:     "the needs-login state must carry a 'needs login' note in the tooltip",
+		},
+	}
+	for _, r := range required {
+		if !strings.Contains(html, r.snippet) {
+			t.Errorf("static/index.html is missing %q — %s (#2465)", r.snippet, r.why)
+		}
+	}
+
+	// The old weak signal must be gone: matching only 'stopped' let 'failed'
+	// (crash-looping) agents render the green idle dot.
+	if strings.Contains(html, "const isStopped = a.state === 'stopped'") {
+		t.Error("static/index.html still derives the sidebar dot from the 'stopped'-only check — 'failed' agents would render green again (#2465)")
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3553,6 +3553,45 @@
       return `<span class="pause-info" title="${esc(reason)} (${esc(trigger)})">ℹ️<span class="pause-tooltip">Reason: ${esc(reason)}<br>Trigger: ${esc(trigger)}<br>Since: ${esc(at)}</span></span>`;
     }
 
+    // Volatile stat fields of the focused agent-detail panel, factored out so
+    // the fast path can refresh them on every status payload. Everything shown
+    // here (pause/interval state, last/next run, restarts, tokens, auth) goes
+    // permanently stale while an agent is focused otherwise.
+    function ocDetailFieldsHtml(a, isPaused, isOff, isOnDemand) {
+      const _tok = (window._tokensByAgent || {})[a.name] || {};
+      const _tokTotal = (_tok.input || 0) + (_tok.output || 0) + (_tok.cacheRead || 0);
+      const _tokAvg = _tok.avgPerSession || (_tok.sessions > 0 ? Math.floor(_tokTotal / _tok.sessions) : 0);
+      return `
+        <div class="oc-detail-fields">
+          <div class="oc-detail-field"><div class="label" title="${INFERENCE_BACKENDS.includes(a.cli) ? 'Inference backend (self-hosted model server)' : 'The CLI backend running this agent (e.g. claude, copilot, gemini)'}">${INFERENCE_BACKENDS.includes(a.cli) ? 'Method' : 'CLI'}</div><div class="value">${INFERENCE_BACKENDS.includes(a.cli) ? backendLabel(a.cli) : esc(a.cli || '—')}${(a.pinnedBoth || a.pinnedCli) ? ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="true" style="cursor:pointer" title="Unpin CLI">📌</span>` : ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="false" style="cursor:pointer;opacity:0.3" title="Pin CLI">📌</span>`}</div></div>
+          <div class="oc-detail-field"><div class="label" title="The LLM model powering this agent. Governor may change it based on budget.">Model</div><div class="value">${esc(a.model || '—')}${(a.pinnedBoth || a.pinnedModel) ? ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="model" data-unpin="true" style="cursor:pointer" title="Unpin model">📌</span>` : ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="model" data-unpin="false" style="cursor:pointer;opacity:0.3" title="Pin model">📌</span>`}</div></div>
+          <div class="oc-detail-field"><div class="label" title="Time between governor kicks in the current mode. Configured per mode (idle/quiet/busy/surge).">Interval</div><div class="value">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : esc(a.cadence || '—')}</div></div>
+          <div class="oc-detail-field"><div class="label" title="When the governor last kicked (started a work pass for) this agent.">Last Run</div><div class="value">${esc(a.lastKick || '—')}</div></div>
+          <div class="oc-detail-field"><div class="label" title="When the governor will next kick this agent based on its cadence interval.">Next Run</div><div class="value">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : esc(a.nextKick || '—')}</div></div>
+          <div class="oc-detail-field"><div class="label" title="Total tokens consumed by this agent in the last 24 hours across all sessions.">Tokens (24h)</div><div class="value">${_tokTotal > 0 ? fmtTokens(_tokTotal) : (_tok.sessions > 0 ? _tok.sessions + ' sess' : '—')}</div></div>
+          <div class="oc-detail-field"><div class="label" title="Number of times this agent has been restarted in the last 24 hours. High counts may indicate instability.">Restarts</div><div class="value${(a.restarts || 0) > 5 ? ' restart-high' : (a.restarts || 0) > 0 ? ' restart-warn' : ''}">${a.restarts ?? 0}<span class="restart-label">24h</span>${(a.restarts || 0) > 0 ? ` <button class="restart-reset" data-action="resetRestarts" data-agent="${esc(a.name)}" title="Reset the restart counter to zero — does not affect the agent">✕</button>` : ''}<span class="restart-spark">${restartSparkSvg(a.name)}</span></div></div>
+          <div class="oc-detail-field"><div class="label" title="Average tokens consumed per work pass (kick session). Lower is more efficient.">Avg/Pass</div><div class="value">${_tokAvg > 0 ? fmtTokens(_tokAvg) : '—'}</div></div>
+          <div class="oc-detail-field"><div class="label" title="Number of separate CLI sessions this agent has had in the last 24 hours.">Sessions</div><div class="value">${_tok.sessions ?? '—'}</div></div>
+          <div class="oc-detail-field"><div class="label" title="Total number of messages (prompts + responses) across all sessions in the last 24 hours.">Messages</div><div class="value">${_tok.messages ?? '—'}</div></div>
+          <div class="oc-detail-field"><div class="label" title="CLI authentication status — log in to authenticate the agent's CLI tool">Auth</div><div class="value">${(() => {
+            const isClaude = a.cli === 'claude';
+            const isCopilot = a.cli === 'copilot';
+            const _needsLogin = a.needsLogin === true || (a.authKnown === true && a.authAvailable !== true);
+            const claudeIcon = '<span class="cli-icon claude-icon"></span>';
+            const copilotIcon = '<span class="cli-icon copilot-icon"></span>';
+            if (_needsLogin) {
+              if (isClaude) return '<button class="cli-login-btn claude" onclick="event.stopPropagation();loginAgent(\x27' + esc(a.name) + '\x27,\x27claude\x27)" title="Authenticate Claude Code CLI">' + claudeIcon + ' Login</button>';
+              if (isCopilot) return '<button class="cli-login-btn copilot" onclick="event.stopPropagation();loginAgent(\x27' + esc(a.name) + '\x27,\x27copilot\x27)" title="Authenticate GitHub Copilot CLI">' + copilotIcon + ' Login</button>';
+              return '<button class="cli-login-btn disabled" disabled title="This backend requires manual /login in the terminal">Login</button>';
+            }
+            if (isClaude) return '<button class="cli-login-btn logged-in" onclick="event.stopPropagation();loginAgent(\x27' + esc(a.name) + '\x27,\x27claude\x27)" title="Re-authenticate Claude Code CLI">' + claudeIcon + ' ✓ logged in</button>';
+            if (isCopilot) return '<button class="cli-login-btn logged-in" onclick="event.stopPropagation();loginAgent(\x27' + esc(a.name) + '\x27,\x27copilot\x27)" title="Re-authenticate GitHub Copilot CLI">' + copilotIcon + ' ✓ logged in</button>';
+            return '<button class="cli-login-btn disabled" disabled title="This backend requires manual /login in the terminal">✓ logged in</button>';
+          })()}</div></div>
+        </div>
+      `;
+    }
+
     function ocRenderAgentDetail() {
       const detail = document.getElementById('oc-agent-detail');
       if (!detail || !_ocSelectedAgent) return;
@@ -3601,7 +3640,24 @@
         const dot = detail.querySelector('.status-dot');
         if (dot) { dot.className = 'status-dot ' + dotCls; }
         const stateSpan = detail.querySelector('.oc-agent-detail-header > span:last-child');
-        if (stateSpan) { stateSpan.textContent = stateLabel; }
+        if (stateSpan) { stateSpan.innerHTML = stateLabel + pauseInfoIcon(a); }
+        // The pause/resume toggle must track state here too — the fast path
+        // runs on every status poll while an agent is focused, so a stale
+        // button would otherwise persist until the user navigates away.
+        const fastToggle = detail.querySelector('.oc-detail-actions .btn-toggle');
+        if (fastToggle && !isOnDemand) {
+          fastToggle.className = `btn-toggle ${isPaused ? 'paused' : isOff ? 'off' : 'running'}`;
+          fastToggle.textContent = isPaused ? '▶ resume' : isOff ? '▶ start' : '⏸ pause';
+          fastToggle.dataset.paused = String(isPaused);
+          fastToggle.title = isPaused ? 'Resume this agent — it will start running on its configured cadence' : isOff ? 'Start this agent — it is currently off in this governor mode' : 'Pause this agent — stops governor from kicking it until resumed';
+        }
+        // Same for the stat fields and indicators — they live outside the
+        // scroll region, so replacing them wholesale cannot cause the scroll
+        // jumps the fast path exists to prevent.
+        const fieldsEl = detail.querySelector('.oc-detail-fields');
+        if (fieldsEl) fieldsEl.outerHTML = ocDetailFieldsHtml(a, isPaused, isOff, isOnDemand);
+        const indEl = detail.querySelector('.oc-detail-indicators');
+        if (indEl) indEl.innerHTML = agentIndicators(a.name);
         detail.className = 'oc-agent-detail active state-' + dotCls;
         return;
       }
@@ -3653,10 +3709,6 @@
         mergeable: (window._lastStatus?.repos || []).reduce((n, r) => n + (r.openPrs || []).filter(p => p.mergeable).length, 0),
       };
 
-      const _tok = (window._tokensByAgent || {})[a.name] || {};
-      const _tokTotal = (_tok.input || 0) + (_tok.output || 0) + (_tok.cacheRead || 0);
-      const _tokAvg = _tok.avgPerSession || (_tok.sessions > 0 ? Math.floor(_tokTotal / _tok.sessions) : 0);
-
       detail.innerHTML = `
         <div class="oc-agent-detail-header">
           <span class="status-dot ${dotCls}"></span>
@@ -3680,33 +3732,7 @@
             ${modelOptionsHtml(a.cli, a.model)}
           </select>
         </div>
-        <div class="oc-detail-fields">
-          <div class="oc-detail-field"><div class="label" title="${INFERENCE_BACKENDS.includes(a.cli) ? 'Inference backend (self-hosted model server)' : 'The CLI backend running this agent (e.g. claude, copilot, gemini)'}">${INFERENCE_BACKENDS.includes(a.cli) ? 'Method' : 'CLI'}</div><div class="value">${INFERENCE_BACKENDS.includes(a.cli) ? backendLabel(a.cli) : esc(a.cli || '—')}${(a.pinnedBoth || a.pinnedCli) ? ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="true" style="cursor:pointer" title="Unpin CLI">📌</span>` : ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="false" style="cursor:pointer;opacity:0.3" title="Pin CLI">📌</span>`}</div></div>
-          <div class="oc-detail-field"><div class="label" title="The LLM model powering this agent. Governor may change it based on budget.">Model</div><div class="value">${esc(a.model || '—')}${(a.pinnedBoth || a.pinnedModel) ? ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="model" data-unpin="true" style="cursor:pointer" title="Unpin model">📌</span>` : ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="model" data-unpin="false" style="cursor:pointer;opacity:0.3" title="Pin model">📌</span>`}</div></div>
-          <div class="oc-detail-field"><div class="label" title="Time between governor kicks in the current mode. Configured per mode (idle/quiet/busy/surge).">Interval</div><div class="value">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : esc(a.cadence || '—')}</div></div>
-          <div class="oc-detail-field"><div class="label" title="When the governor last kicked (started a work pass for) this agent.">Last Run</div><div class="value">${esc(a.lastKick || '—')}</div></div>
-          <div class="oc-detail-field"><div class="label" title="When the governor will next kick this agent based on its cadence interval.">Next Run</div><div class="value">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : esc(a.nextKick || '—')}</div></div>
-          <div class="oc-detail-field"><div class="label" title="Total tokens consumed by this agent in the last 24 hours across all sessions.">Tokens (24h)</div><div class="value">${_tokTotal > 0 ? fmtTokens(_tokTotal) : (_tok.sessions > 0 ? _tok.sessions + ' sess' : '—')}</div></div>
-          <div class="oc-detail-field"><div class="label" title="Number of times this agent has been restarted in the last 24 hours. High counts may indicate instability.">Restarts</div><div class="value${(a.restarts || 0) > 5 ? ' restart-high' : (a.restarts || 0) > 0 ? ' restart-warn' : ''}">${a.restarts ?? 0}<span class="restart-label">24h</span>${(a.restarts || 0) > 0 ? ` <button class="restart-reset" data-action="resetRestarts" data-agent="${esc(a.name)}" title="Reset the restart counter to zero — does not affect the agent">✕</button>` : ''}<span class="restart-spark">${restartSparkSvg(a.name)}</span></div></div>
-          <div class="oc-detail-field"><div class="label" title="Average tokens consumed per work pass (kick session). Lower is more efficient.">Avg/Pass</div><div class="value">${_tokAvg > 0 ? fmtTokens(_tokAvg) : '—'}</div></div>
-          <div class="oc-detail-field"><div class="label" title="Number of separate CLI sessions this agent has had in the last 24 hours.">Sessions</div><div class="value">${_tok.sessions ?? '—'}</div></div>
-          <div class="oc-detail-field"><div class="label" title="Total number of messages (prompts + responses) across all sessions in the last 24 hours.">Messages</div><div class="value">${_tok.messages ?? '—'}</div></div>
-          <div class="oc-detail-field"><div class="label" title="CLI authentication status — log in to authenticate the agent's CLI tool">Auth</div><div class="value">${(() => {
-            const isClaude = a.cli === 'claude';
-            const isCopilot = a.cli === 'copilot';
-            const _needsLogin = a.needsLogin === true || (a.authKnown === true && a.authAvailable !== true);
-            const claudeIcon = '<span class="cli-icon claude-icon"></span>';
-            const copilotIcon = '<span class="cli-icon copilot-icon"></span>';
-            if (_needsLogin) {
-              if (isClaude) return '<button class="cli-login-btn claude" onclick="event.stopPropagation();loginAgent(\x27' + esc(a.name) + '\x27,\x27claude\x27)" title="Authenticate Claude Code CLI">' + claudeIcon + ' Login</button>';
-              if (isCopilot) return '<button class="cli-login-btn copilot" onclick="event.stopPropagation();loginAgent(\x27' + esc(a.name) + '\x27,\x27copilot\x27)" title="Authenticate GitHub Copilot CLI">' + copilotIcon + ' Login</button>';
-              return '<button class="cli-login-btn disabled" disabled title="This backend requires manual /login in the terminal">Login</button>';
-            }
-            if (isClaude) return '<button class="cli-login-btn logged-in" onclick="event.stopPropagation();loginAgent(\x27' + esc(a.name) + '\x27,\x27claude\x27)" title="Re-authenticate Claude Code CLI">' + claudeIcon + ' ✓ logged in</button>';
-            if (isCopilot) return '<button class="cli-login-btn logged-in" onclick="event.stopPropagation();loginAgent(\x27' + esc(a.name) + '\x27,\x27copilot\x27)" title="Re-authenticate GitHub Copilot CLI">' + copilotIcon + ' ✓ logged in</button>';
-            return '<button class="cli-login-btn disabled" disabled title="This backend requires manual /login in the terminal">✓ logged in</button>';
-          })()}</div></div>
-        </div>
+        ${ocDetailFieldsHtml(a, isPaused, isOff, isOnDemand)}
         <div class="oc-detail-indicators">${agentIndicators(a.name)}</div>
         <div class="oc-detail-summary-wrap">
           <div class="oc-detail-summary" id="oc-summary-scroll">${(a.detailSummary || a.liveSummary) ? escBlock(a.detailSummary || a.liveSummary) : '<span style="color:var(--muted)">No activity summary</span>'}</div>
@@ -11863,6 +11889,10 @@ function burnAreaChart() {
       // Update in-memory agent state so cadence table re-renders correctly
       const agentObj = (window._lastAgents || []).find(a => a.name === agent);
       if (agentObj) { agentObj.paused = (action === 'pause'); }
+      // The focused agent-detail panel renders its own toggle button — the
+      // .agent-card loop above never reaches it, so re-render it from the
+      // just-updated state or the button stays stale until navigation.
+      if (typeof ocRenderAgentDetail === 'function') ocRenderAgentDetail();
       const lastData = window._lastStatus || {};
       if (lastData.governor) {
         renderGovernor(lastData.governor, lastData.cadenceMatrix || [], lastData);

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -338,6 +338,7 @@
     .oc-agent-detail.state-paused { border-color: var(--yellow); }
     .oc-agent-detail.state-on-demand { border-color: var(--indigo); }
     .oc-agent-detail.state-stopped { border-color: var(--red); }
+    .oc-agent-detail.state-needs-login { border-color: var(--amber); }
     .oc-agent-detail.state-off { border-color: var(--line); }
     .oc-agent-detail-header {
       display: flex; align-items: center; gap: 10px; margin-bottom: 16px;
@@ -355,6 +356,7 @@
     .oc-agent-detail-header .status-dot.paused { background: var(--yellow); }
     .oc-agent-detail-header .status-dot.on-demand { background: var(--indigo); }
     .oc-agent-detail-header .status-dot.stopped { background: var(--red); }
+    .oc-agent-detail-header .status-dot.needs-login { background: var(--amber); }
     .oc-agent-detail-header .status-dot.off { background: var(--muted); }
     .oc-detail-fields {
       display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px 24px; margin-bottom: 16px;
@@ -419,6 +421,7 @@
     .oc-agent-dot.paused { background: var(--yellow); }
     .oc-agent-dot.on-demand { background: var(--indigo); }
     .oc-agent-dot.stopped { background: var(--red); }
+    .oc-agent-dot.needs-login { background: var(--amber); }
     .oc-agent-dot.off { background: var(--muted); }
     @keyframes oc-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
@@ -836,6 +839,7 @@
     .dot.on-demand { background: var(--indigo); }
     .dot.off { background: var(--muted); }
     .dot.stopped { background: var(--red); }
+    .dot.needs-login { background: var(--amber); }
     .agent-field { display: flex; justify-content: space-between; font-size: 0.8rem; padding: 2px 0; }
     .agent-field .label { color: var(--muted); }
     .agent-field .value { text-align: right; }
@@ -3603,12 +3607,19 @@
       const isOff = a.offByCadence === true;
       const isOnDemand = a.onDemand === true;
       const isPaused = a.paused === true && !isOff && !isOnDemand;
-      const isStopped = a.state === 'stopped';
+      // Down = process not alive ('stopped', 'failed', …) — anything but
+      // 'running'. Matching only 'stopped' let 'failed' agents render the
+      // green idle styling here (#2465).
+      const isStopped = a.state !== 'running' && !isPaused && !isOff && !isOnDemand;
+      // Same formula as the Auth section's Login button below: a down agent
+      // with an unauthenticated CLI gets the amber needs-login state instead
+      // of plain down-red (#2465).
+      const needsLoginDown = isStopped && (a.needsLogin === true || (a.authKnown === true && a.authAvailable !== true));
       const isRunning = a.busy === 'working' && !isPaused && !isOff && !isStopped;
-      const dotCls = isStopped ? 'stopped' : isOnDemand ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'running' : 'idle';
+      const dotCls = needsLoginDown ? 'needs-login' : isStopped ? 'stopped' : isOnDemand ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'running' : 'idle';
 
       detail.className = 'oc-agent-detail active state-' + dotCls;
-      const stateLabel = isStopped ? 'stopped' : isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'working' : 'idle';
+      const stateLabel = needsLoginDown ? 'needs login' : isStopped ? 'down' : isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'working' : 'idle';
 
       const kickId = `oc-kick-${a.name}`;
       const prevInput = document.getElementById(kickId);
@@ -3862,12 +3873,26 @@
       const isOff = a.offByCadence === true;
       const isOnDemand = a.onDemand === true;
       const isPaused = a.paused === true && !isOff && !isOnDemand;
-      const isStopped = a.state === 'stopped';
-      const isRunning = a.busy === 'working' && !isPaused && !isOff && !isStopped;
+      // Down = the PROCESS is not alive ('stopped', 'failed', or never
+      // launched — anything but 'running'). The dot used to read only the
+      // 'stopped' state, so a failed/crash-looping agent fell through to the
+      // green 'idle' class while the deep "agents" health check reported it
+      // down (#2465). Match the deep check: non-running + non-paused = down,
+      // with paused/off/on-demand keeping their own styling.
+      const isDown = a.state !== 'running' && !isPaused && !isOff && !isOnDemand;
+      // A down agent whose CLI is unauthenticated is not merely down — it can
+      // never do work until someone logs it in. Same formula as the agent
+      // panel's Login button; rendered amber with a "needs login" note. Only
+      // applies when the agent is not running: a running authenticated agent
+      // is green, a non-running authenticated agent is red (#2465).
+      const needsLogin = a.needsLogin === true || (a.authKnown === true && a.authAvailable !== true);
+      const needsLoginDown = isDown && needsLogin;
+      const isRunning = a.busy === 'working' && !isPaused && !isOff && !isDown;
       const isOnDemandIdle = isOnDemand && !isRunning;
-      const dotCls = isStopped ? 'stopped' : isOnDemandIdle ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'running' : 'idle';
+      const dotCls = needsLoginDown ? 'needs-login' : isDown ? 'stopped' : isOnDemandIdle ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'running' : 'idle';
       const isActive = _ocSelectedAgent === a.name ? ' active' : '';
-      const agentDesc = a.description || AGENT_DESCRIPTIONS[a.name] || '';
+      const baseDesc = a.description || AGENT_DESCRIPTIONS[a.name] || '';
+      const agentDesc = needsLoginDown ? (baseDesc ? baseDesc + '\n' : '') + 'needs login — CLI unauthenticated, the agent cannot work until logged in' : baseDesc;
       const label = a.displayName || a.name;
       const emojiHtml = a.emoji ? `<span class="oc-nav-emoji">${a.emoji}</span>` : '';
       const modeHtml = (a.modeEmoji || a.mode) ? `<span class="oc-nav-mode" title="${esc(a.mode || '')}">${a.modeEmoji || modeEmoji(a.mode)}</span>` : '';
@@ -5215,7 +5240,9 @@
         const isOff = a.offByCadence === true;
         const isOnDemand = a.onDemand === true;
         const isPaused = a.paused === true && !isOff && !isOnDemand;
-        const isStopped = a.state === 'stopped' && !isPaused && !isOff;
+        // Down = process not alive — anything but 'running'. 'stopped'-only
+        // matching rendered crash-looping ('failed') agents green (#2465).
+        const isStopped = a.state !== 'running' && !isPaused && !isOff && !isOnDemand;
         const STALE_MS = 1200000; // 20 minutes
         const isStale = a.summaryUpdated && !isPaused && a.busy === 'working' && (Date.now() - new Date(a.summaryUpdated).getTime()) > STALE_MS;
         let statusCls = '';
@@ -5224,7 +5251,9 @@
         else if (isStale) statusCls = 'status-stale';
         const isOnDemandIdle = isOnDemand && a.busy !== 'working';
         const cls = needsLogin ? 'needs-login' : isOnDemandIdle ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : isStopped ? 'stopped' : `${a.busy} ${statusCls}`.trim();
-        const dotCls = isStopped ? 'stopped' : isOnDemandIdle ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy === 'working' ? 'running' : 'idle';
+        // Down + unauthenticated CLI = amber needs-login (same formula as the
+        // card's Login button above), not plain down-red (#2465).
+        const dotCls = (isStopped && needsLogin) ? 'needs-login' : isStopped ? 'stopped' : isOnDemandIdle ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy === 'working' ? 'running' : 'idle';
         const canToggle = a.beadRole !== 'supervisor';
         const toggleBtn = canToggle ? (isOff
           ? `<button class="btn-toggle off" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Agent is off in this governor mode — click to configure per-mode cadences">⚙ off</button>`
@@ -10605,7 +10634,21 @@ function burnAreaChart() {
         const CI_PASS_THRESHOLD = 70;
         const HEALTH_LABELS = _buildHealthLabels(data.agents || []);
         const failing = [];
+        const warning = [];
         const passing = [];
+        // Deep checks first — the spoke's own health (ready, github_auth,
+        // agents with "N down: names", …), the exact checks the heartbeat
+        // reports to the hub. These decide the pill's color: a pill that read
+        // only the repo-workflow map below showed "Health OK" while this
+        // spoke's own agents were down (#2465).
+        const deepChecks = Array.isArray((data.deepHealth || {}).checks) ? data.deepHealth.checks : [];
+        const deepFailNames = [];
+        for (const c of deepChecks) {
+          const line = c.detail ? `${c.name}: ${c.detail}` : c.name;
+          if (c.status === 'fail') { deepFailNames.push(c.name); failing.push(line); }
+          else if (c.status === 'warn') warning.push(line);
+          else passing.push(line);
+        }
         for (const [k, v] of Object.entries(h)) {
           const label = HEALTH_LABELS[k] || k;
           if (k === 'ci') {
@@ -10621,9 +10664,17 @@ function burnAreaChart() {
         }
         const hoverLines = [];
         if (failing.length) hoverLines.push('FAILING:\n' + failing.map(f => '  ✗ ' + f).join('\n'));
+        if (warning.length) hoverLines.push('WARNINGS:\n' + warning.map(wl => '  ⚠ ' + wl).join('\n'));
         if (passing.length) hoverLines.push('PASSING:\n' + passing.map(p => '  ✓ ' + p).join('\n'));
         ocHealth.title = hoverLines.join('\n\n') || 'No health data';
-        if (failing.length > 0) {
+        if (deepFailNames.length > 0) {
+          // Any failing deep check ⇒ the spoke itself is degraded — same
+          // verdict the hub renders for this hive's row.
+          ocHealth.textContent = '● Degraded';
+          ocHealth.style.color = 'var(--red)';
+          ocHealth.style.background = 'var(--red-bg)';
+          ocHealth.style.borderColor = 'var(--red-border)';
+        } else if (failing.length > 0) {
           ocHealth.textContent = `● ${failing.length} Issue${failing.length > 1 ? 's' : ''}`;
           ocHealth.style.color = 'var(--red)';
           ocHealth.style.background = 'var(--red-bg)';

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -11974,9 +11974,12 @@ function burnAreaChart() {
       dismissToast(toast, `${agent} restart counter reset`, 'success');
     }
 
-    // Prompts for the LiteLLM endpoint + API key the first time the
-    // backend is selected anywhere in the UI. Resolves true when litellm
-    // is (or has just been) configured; false when the user cancels. The
+    // Prompts for the LiteLLM endpoint + API key when litellm is picked in
+    // the agent-config dialog flows (CLI pin / create), where navigating to
+    // Governor Config would discard unsaved edits. The agent-card METHOD
+    // dropdown instead saves the choice and navigates (maybeOpenMethodConfig).
+    // Resolves true when litellm is (or has just been) configured; false when
+    // the user cancels. The
     // key VALUE goes to the server's private key store — never hive.yaml —
     // and the save runs a live /v1/models test whose result is shown
     // inline (endpoint/key mistakes fail here, not as agent 401s later).
@@ -12082,15 +12085,63 @@ function burnAreaChart() {
       });
     }
 
+
+    // Methods that need hive-side configuration before they can actually run:
+    // bob needs its API key (Governor Config → Bob); the gateway-backed
+    // methods need a Model Gateway configured FOR THAT method (Governor
+    // Config → Model Gateways). The check is per-method — an openrouter
+    // gateway does not satisfy a vllm selection.
+    const GATEWAY_METHODS = ['openrouter', 'litellm', 'vllm', 'llm-d'];
+
+    // maybeOpenMethodConfig runs AFTER a method switch is saved: the choice is
+    // never blocked, but when the selected method's backing config is absent
+    // the Governor Configuration dialog opens directly on the tab that fixes
+    // it. Presence comes from data the dashboard already serves — the bob key
+    // status endpoint (presence only, never material) and the configured
+    // gateway list — plus the live model-discovery cache (a non-fallback
+    // discovery proves an env-configured vllm/llm-d endpoint exists even
+    // without a named gateway). Best-effort: any fetch failure just skips the
+    // navigation rather than interrupting the switch.
+    async function maybeOpenMethodConfig(backend) {
+      try {
+        if (backend === 'bob') {
+          const r = await fetch('/api/config/governor/bob');
+          if (!r.ok) return;
+          const d = await r.json();
+          if (d.configured !== true) {
+            showToast('bob needs an API key — opening Governor Config → Bob', 'info');
+            openConfigDialog('governor', null, GOVERNOR_BOB_TAB);
+          }
+          return;
+        }
+        if (!GATEWAY_METHODS.includes(backend)) return;
+        // A live (non-fallback) model discovery for this method means it is
+        // genuinely configured (possibly via HIVE_*_ENDPOINT env, which never
+        // appears in the gateway list) — nothing to fix.
+        const cached = _inferenceModelCache[backend];
+        if (cached && !cached.fallback) return;
+        const r = await fetch('/api/config/governor/gateways');
+        if (!r.ok) return;
+        const d = await r.json();
+        const has = (d.gateways || []).some(g => g && (g.kind === backend || g.name === backend));
+        if (!has) {
+          showToast('No ' + backend + ' gateway configured — opening Governor Config → Model Gateways', 'info');
+          openConfigDialog('governor', null, 'Model Gateways');
+        }
+      } catch (e) { /* presence check is best-effort; never surface as a switch error */ }
+    }
+
     async function switchCli(agent, backend) {
       if (!backend) return;
-      if (backend === 'litellm' && !(await ensureLiteLLMConfigured())) return;
       const label = INFERENCE_BACKENDS.includes(backend) ? 'method' : 'CLI';
       const toast = showToast(`Switching ${agent} ${label} → ${backend} (restarting session)...`, 'info', true);
       const res = await fetch(`/api/switch/${agent}/${backend}`, { method: 'POST' });
       const data = await res.json();
       if (!data.ok) { dismissToast(toast, `Switch failed: ${data.error || 'unknown'}`, 'error'); return; }
       dismissToast(toast, `${agent} ${label} → ${backend} (session restarted)`, 'success');
+      // The selection is saved; if its backing config is missing, land the
+      // user on the Governor Config tab that fixes it (never blocks).
+      maybeOpenMethodConfig(backend);
       await updateModelDropdown(agent, backend);
       if (window._lastAgents) {
         const a = window._lastAgents.find(x => x.name === agent);
@@ -13841,6 +13892,7 @@ function burnAreaChart() {
             <span style="font-weight:600;font-size:0.9rem">bob</span>
             <span style="font-size:0.68rem;font-weight:600;padding:2px 8px;border-radius:10px;border:1px solid #4589ff;color:#4589ff">IBM bobshell</span>
             <span style="flex:1"></span>
+            ${configured ? '<button data-action="bobKeyTest" title="Validate the saved key against the bob backend — the key value never leaves this hive" style="padding:4px 12px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);cursor:pointer;font-size:0.74rem">Test</button>' : ''}
             ${configured ? '<button data-action="bobKeyClear" style="padding:4px 12px;border:1px solid var(--red);border-radius:6px;background:var(--bg);color:var(--red);cursor:pointer;font-size:0.74rem">Clear key</button>' : ''}
             <button data-action="bobKeySet" style="padding:4px 12px;border:none;border-radius:6px;background:#0f62fe;color:#fff;cursor:pointer;font-size:0.74rem;font-weight:600">${configured ? 'Replace key' : 'Set API key'}</button>
           </div>
@@ -13863,6 +13915,18 @@ function burnAreaChart() {
       if (setBtn) setBtn.addEventListener('click', () => openBobKeyDialog(configured, source));
       const clearBtn = host.querySelector('[data-action="bobKeyClear"]');
       if (clearBtn) clearBtn.addEventListener('click', clearBobKey);
+      // Test the SAVED key from the card: result goes to the card's inline
+      // status line (green ok / red reason + backend detail).
+      const testBtn = host.querySelector('[data-action="bobKeyTest"]');
+      if (testBtn) testBtn.addEventListener('click', async () => {
+        const statusEl = document.getElementById('bob-key-inline-status');
+        const setStatus = (msg, color) => {
+          if (statusEl) { statusEl.textContent = msg; statusEl.style.color = color || 'var(--muted)'; }
+        };
+        testBtn.disabled = true;
+        await testBobKey('', setStatus);
+        testBtn.disabled = false;
+      });
     }
 
     function renderGovAccess() {
@@ -17784,8 +17848,34 @@ function burnAreaChart() {
     // authoritative one for this CLI, so the dialog says Inference and links
     // BOTH pages so the operator can check if a key is rejected.
     var BOB_PORTAL_URL = 'https://bob.ibm.com';
+    var BOB_API_KEY_MANAGE_URL = 'https://bob.ibm.com/admin/apikeys';
     var BOB_API_KEY_DOCS_URL = 'https://bob.ibm.com/docs/ide/account/api-keys';
     var BOB_SHELL_SETUP_DOCS_URL = 'https://bob.ibm.com/docs/shell/getting-started/install-and-setup';
+
+    // testBobKey POSTs to the bob key-test endpoint and reports the verdict
+    // via setStatus. `pastedKey` non-empty tests THAT key (pre-save); empty
+    // tests the SAVED key — the server resolves it, the value never reaches
+    // the browser. Shared by the key dialog and the Bob tab card.
+    async function testBobKey(pastedKey, setStatus) {
+      setStatus(pastedKey ? 'Testing pasted key…' : 'Testing saved key…');
+      try {
+        var resp = await fetch('/api/config/governor/bob/test', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(pastedKey ? { apiKey: pastedKey } : {})
+        });
+        var data = await resp.json().catch(function() { return {}; });
+        if (!resp.ok) {
+          setStatus(data.error || ('Test failed (HTTP ' + resp.status + ')'), 'var(--red)');
+        } else if (data.status === 'ok') {
+          setStatus('✓ ' + (data.detail || 'The bob backend accepted the key.'), 'var(--green)');
+        } else {
+          setStatus('✗ ' + (data.detail || data.reason || 'Test failed'), 'var(--red)');
+        }
+      } catch (e) {
+        setStatus('Test failed: ' + e.message, 'var(--red)');
+      }
+    }
 
     function openBobKeyDialog(configured, source) {
       var overlay = document.getElementById('bob-key-overlay');
@@ -17813,7 +17903,8 @@ function burnAreaChart() {
           '<ol style="margin:0;padding-left:18px;line-height:1.6">' +
             '<li>Sign in at <a href="' + BOB_PORTAL_URL + '" target="_blank" rel="noopener noreferrer" ' +
               'style="color:#4589ff">bob.ibm.com</a> and open your subscription instance.</li>' +
-            '<li>Go to API key management and create a key with <strong>Scope: Inference</strong>.</li>' +
+            '<li>Go to <a href="' + BOB_API_KEY_MANAGE_URL + '" target="_blank" rel="noopener noreferrer" ' +
+              'style="color:#4589ff">API key management</a> and create a key with <strong>Scope: Inference</strong>.</li>' +
             '<li>Copy it immediately — IBM shows the value only once.</li>' +
           '</ol>' +
           '<div style="margin-top:8px">' +
@@ -17830,6 +17921,9 @@ function burnAreaChart() {
         '<div id="bob-key-status" style="color:var(--muted);font-size:0.8rem;min-height:20px;margin:4px 0"></div>' +
         '<div style="display:flex;gap:8px;justify-content:flex-end;margin-top:8px">' +
           '<button id="bob-key-cancel" class="gh-cancel" style="margin-top:0">Cancel</button>' +
+          '<button id="bob-key-test" style="background:var(--bg);color:var(--fg);border:1px solid var(--border);' +
+            'padding:6px 16px;border-radius:6px;font-weight:600;cursor:pointer" ' +
+            'title="Validate against the bob backend without saving: tests the pasted key if the field is non-empty, else the saved key">Test key</button>' +
           '<button id="bob-key-save" style="background:#0f62fe;color:#fff;border:none;padding:6px 16px;' +
             'border-radius:6px;font-weight:600;cursor:pointer">Save key</button>' +
         '</div>' +
@@ -17852,6 +17946,21 @@ function burnAreaChart() {
 
       var cancelBtn = document.getElementById('bob-key-cancel');
       if (cancelBtn) cancelBtn.addEventListener('click', closeDialog);
+
+      // Test key: pre-save validation of the pasted value, or of the saved
+      // key when the field is empty. The pasted value goes only to the test
+      // endpoint (never persisted); the result renders inline.
+      var testBtn = document.getElementById('bob-key-test');
+      if (testBtn) testBtn.addEventListener('click', async function() {
+        var pasted = (input && input.value || '').trim();
+        if (!pasted && !configured) {
+          setStatus('Paste a key to test — none is saved yet.', 'var(--red)');
+          return;
+        }
+        testBtn.disabled = true;
+        await testBobKey(pasted, setStatus);
+        testBtn.disabled = false;
+      });
 
       var saveBtn = document.getElementById('bob-key-save');
       if (saveBtn) saveBtn.addEventListener('click', async function() {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -13095,7 +13095,7 @@ function burnAreaChart() {
     // hub-synced user/role data. It sits next to Model Gateways because both
     // are backend configuration.
     const GOVERNOR_BOB_TAB = 'Bob';
-    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Hub', 'Model Gateways', GOVERNOR_BOB_TAB, 'Variables', 'Access'];
+    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Hub', 'Forge App', 'Model Gateways', GOVERNOR_BOB_TAB, 'Variables', 'Access'];
     const PIPELINE_STAGES = ['resolve-beads', 'track-prs', 'stale-check', 'repo-scan', 'coverage-gate', 'prompt-compose', 'budget-check', 'api-collect', 'final-compose'];
     const PIPELINE_STAGE_TIPS = {
       'resolve-beads': 'Fetch and inject knowledge beads (facts, patterns, gotchas) relevant to the agent\'s current task context.',
@@ -13554,6 +13554,9 @@ function burnAreaChart() {
         if (tabId === 'Model Gateways') {
           loadGateways();
         }
+        // The Forge App tab renders a shell synchronously, then loads the
+        // credential inventory (fingerprints only) from the spoke.
+        if (tabId === 'Forge App') loadForgeApps();
       }
       // Keep the Save button's enabled state in lockstep with the repos/default
       // invariant on every render (requirement #4). Cheap and idempotent — a
@@ -13691,6 +13694,7 @@ function burnAreaChart() {
         case 'Sensing': return renderGovSensing(d.sensing || {});
         case 'Logging': return renderGovLogging(d.logging || {});
         case 'Hub': return renderGovHub(d.hub || {});
+        case 'Forge App': return renderGovForgeApp();
         case 'Model Gateways': return renderGovGateways();
         case GOVERNOR_BOB_TAB: return renderGovBob();
         case 'Variables': return renderGovVariables();
@@ -14183,6 +14187,143 @@ function burnAreaChart() {
 
     function gatewayKindMeta(kind) {
       return GATEWAY_KIND_META[kind] || GATEWAY_KIND_META.custom;
+    }
+
+    // ---- Forge App tab -----------------------------------------------------
+    // Inventory of every forge App credential this spoke holds: the active
+    // github config plus every per-app-id key file on the PVC. Fingerprints
+    // and paths ONLY — private key material never reaches this page. Only the
+    // config whose forge matches the forge this hive's repos live on is
+    // editable; everything else renders read-only.
+    function renderGovForgeApp() {
+      return `
+        <div style="font-size:0.82rem;color:var(--muted);margin-bottom:14px">
+          Every forge App credential this hive holds. The active config is editable only
+          when its forge matches the forge this hive's repos live on; everything else is
+          read-only. Private keys appear as fingerprints — key material never leaves the hive.
+        </div>
+        <div id="forge-app-host"><div style="color:var(--muted);font-size:0.8rem">Loading forge Apps…</div></div>`;
+    }
+
+    async function loadForgeApps() {
+      const host = document.getElementById('forge-app-host');
+      try {
+        const res = await fetch('/api/config/github/forge-apps');
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        renderForgeApps(await res.json());
+      } catch (e) {
+        if (host) host.innerHTML = `<div style="color:var(--red);font-size:0.8rem">Failed to load forge Apps: ${esc(e.message)}</div>`;
+      }
+    }
+
+    function forgeAppRow(label, valueHtml) {
+      return `<div style="display:flex;gap:10px;font-size:0.78rem;padding:3px 0"><span style="min-width:140px;color:var(--muted);flex-shrink:0">${esc(label)}</span><span style="word-break:break-all">${valueHtml}</span></div>`;
+    }
+
+    function renderForgeApps(data) {
+      const host = document.getElementById('forge-app-host');
+      if (!host) return;
+      const a = data.active || {};
+      // The classified auth state is a debugging surface: show the wire token
+      // verbatim (not-installed / wrong-installation / key-invalid / ...).
+      const stateHtml = a.auth_state
+        ? `<code style="font-size:0.74rem;padding:1px 6px;border:1px solid ${a.auth_state === 'ok' ? 'var(--green)' : 'var(--yellow)'};border-radius:6px">${esc(a.auth_state)}</code>`
+        : '<span style="color:var(--muted)">— (not classified)</span>';
+      const editBadge = a.editable
+        ? '<span style="font-size:0.68rem;font-weight:600;padding:2px 8px;border-radius:10px;border:1px solid var(--green);color:var(--green)">editable</span>'
+        : `<span style="font-size:0.68rem;font-weight:600;padding:2px 8px;border-radius:10px;border:1px solid var(--border);color:var(--muted)">read-only — repos are on ${esc(data.repos_forge || 'github.com')}</span>`;
+      let html = `
+        <div style="border:1px solid var(--border);border-radius:8px;padding:12px 14px;margin-bottom:12px;background:var(--surface)">
+          <div style="display:flex;align-items:center;gap:10px;margin-bottom:8px;flex-wrap:wrap">
+            <span style="font-weight:600;font-size:0.9rem">Active config — ${esc(a.forge || 'github.com')}</span>
+            ${editBadge}
+          </div>
+          ${forgeAppRow('App ID', esc(String(a.app_id || 0)))}
+          ${forgeAppRow('App slug', esc(a.app_slug || '—'))}
+          ${forgeAppRow('API URL', esc(a.api_url || '—'))}
+          ${forgeAppRow('Base URL', esc(a.base_url || '—'))}
+          ${forgeAppRow('Installation ID', esc(String(a.installation_id || 0)))}
+          ${forgeAppRow('Key file', esc(a.key_file || '—'))}
+          ${forgeAppRow('Key fingerprint', a.key_fingerprint ? '<code style="font-size:0.74rem">' + esc(a.key_fingerprint) + '</code>' : '<span style="color:var(--muted)">— (no usable key)</span>')}
+          ${forgeAppRow('Auth state', stateHtml)}
+          ${a.editable ? forgeAppEditForm(a) : ''}
+        </div>`;
+      html += '<div style="font-weight:600;font-size:0.85rem;margin:14px 0 6px">Per-app-id keys on disk</div>';
+      const keys = data.held_keys || [];
+      if (!keys.length) {
+        html += '<div style="color:var(--muted);font-size:0.78rem">No per-app-id key files held on this hive.</div>';
+      } else {
+        html += keys.map(k => `
+          <div style="border:1px solid var(--border);border-radius:8px;padding:8px 12px;margin-bottom:6px;font-size:0.76rem;background:var(--surface)">
+            <div style="display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+              <span style="font-weight:600">App ${esc(k.app_id)}</span>
+              <span style="font-size:0.66rem;font-weight:600;padding:1px 7px;border-radius:10px;border:1px solid var(--border);color:var(--muted)">read-only</span>
+            </div>
+            <div style="color:var(--muted);word-break:break-all;margin-top:4px">${esc(k.path)}</div>
+            <div style="margin-top:2px">fingerprint: <code style="font-size:0.72rem">${esc(k.fingerprint)}</code></div>
+          </div>`).join('');
+      }
+      host.innerHTML = html;
+    }
+
+    function forgeAppEditForm(a) {
+      const inputStyle = 'width:100%;padding:6px 8px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem;box-sizing:border-box';
+      return `
+        <div style="border-top:1px solid var(--border);margin-top:10px;padding-top:10px">
+          <div style="font-size:0.78rem;font-weight:600;margin-bottom:8px">Edit active config</div>
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:8px">
+            <label style="font-size:0.72rem;color:var(--muted)">App ID<input id="forge-app-appid" type="number" value="${esc(String(a.app_id || ''))}" style="${inputStyle}"></label>
+            <label style="font-size:0.72rem;color:var(--muted)">Installation ID<input id="forge-app-instid" type="number" value="${esc(String(a.installation_id || ''))}" style="${inputStyle}"></label>
+          </div>
+          <label style="font-size:0.72rem;color:var(--muted)">Key file path<input id="forge-app-keyfile" type="text" value="${esc(a.key_file || '')}" style="${inputStyle};margin-bottom:8px"></label>
+          <label style="font-size:0.72rem;color:var(--muted)">Private key (PEM — write-only, replaces the key file; never displayed back)<textarea id="forge-app-pem" rows="3" placeholder="-----BEGIN RSA PRIVATE KEY----- (leave empty to keep the current key)" style="${inputStyle};font-family:monospace;margin-bottom:8px"></textarea></label>
+          <button id="forge-app-save-btn" onclick="saveForgeApp()" style="padding:7px 16px;border:none;border-radius:6px;background:var(--cyan);color:var(--bg);cursor:pointer;font-weight:600;font-size:0.8rem">Save</button>
+        </div>`;
+    }
+
+    async function saveForgeApp() {
+      const btn = document.getElementById('forge-app-save-btn');
+      const numVal = id => {
+        const el = document.getElementById(id);
+        const v = (el && el.value || '').trim();
+        return v === '' ? null : parseInt(v, 10);
+      };
+      const appId = numVal('forge-app-appid');
+      const instId = numVal('forge-app-instid');
+      const keyFileEl = document.getElementById('forge-app-keyfile');
+      const pemEl = document.getElementById('forge-app-pem');
+      const keyFile = (keyFileEl && keyFileEl.value || '').trim();
+      const pem = (pemEl && pemEl.value || '').trim();
+      const body = {};
+      if (appId !== null) {
+        if (isNaN(appId) || appId <= 0) { showToast('App ID must be a positive number', 'error'); return; }
+        body.app_id = appId;
+      }
+      if (instId !== null) {
+        if (isNaN(instId) || instId < 0) { showToast('Installation ID must be a non-negative number', 'error'); return; }
+        body.installation_id = instId;
+      }
+      if (keyFile) body.key_file = keyFile;
+      if (pem) body.private_key = pem;
+      if (!Object.keys(body).length) { showToast('Nothing to save', 'error'); return; }
+      if (btn) { btn.disabled = true; btn.textContent = 'Saving…'; }
+      try {
+        // The existing config-github handler: persists, then live-reinits the
+        // GitHub client when the config becomes usable.
+        const res = await fetch('/api/config/github', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(data.error || ('HTTP ' + res.status));
+        showToast(data.reinit === 'ok' ? 'Forge App config saved and reconnected' : 'Forge App config saved', 'success');
+        loadForgeApps();
+      } catch (e) {
+        showToast('Save failed: ' + e.message, 'error');
+      } finally {
+        if (btn) { btn.disabled = false; btn.textContent = 'Save'; }
+      }
     }
 
     function renderGovGateways() {

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -1258,6 +1258,17 @@ func collectSystemResources() *SystemResources {
 			}
 			cpuFraction := deltaUsec / (deltaSec * microsecondsPerSec * numCPUs)
 			res.CpuPct = roundTo(cpuFraction*pctMultiplierSysRes, 1)
+			// Clamp: on a noisy/oversubscribed host (e.g. a shared CI
+			// runner), scheduler bursts within the short cpuSampleDelayMs
+			// window can push the measured delta a hair past the
+			// theoretical 100% ceiling (observed: 100.1). CpuPct is a
+			// display/reporting value, so clamp rather than let a
+			// momentary sampling artifact read as over-100% or negative.
+			if res.CpuPct > pctMultiplierSysRes {
+				res.CpuPct = pctMultiplierSysRes
+			} else if res.CpuPct < 0 {
+				res.CpuPct = 0
+			}
 		}
 	}
 

--- a/v2/pkg/hub/alerts.go
+++ b/v2/pkg/hub/alerts.go
@@ -622,7 +622,38 @@ const (
 	// reason string. A hive with everything failing should not produce a
 	// paragraph; the count still reflects the true total.
 	maxNamedFailingChecks = 3
+
+	// healthCheckGitHubAuth is the spoke's GitHub credential check
+	// (pkg/dashboard/server.go builds it in both HealthSummary and
+	// handleHealthDeep). It fails whenever no App or token is configured.
+	healthCheckGitHubAuth = "github_auth"
+	// healthCheckGitHubAppPrefix catches any GitHub-App-scoped check name a
+	// spoke version may report (e.g. a future github_app_key). Every check in
+	// that family verifies credentials a placeholder cannot have yet.
+	healthCheckGitHubAppPrefix = "github_app"
 )
+
+// isAuthClassHealthCheck reports whether a named health check verifies GitHub
+// credentials (App or token) rather than the spoke process itself. The split
+// matters for placeholders: an UNASSIGNED pool slot has no GitHub auth BY
+// DESIGN — credentials only arrive when a project is claimed — so an auth
+// check failing on a placeholder is the pool working as designed, not a fault.
+func isAuthClassHealthCheck(name string) bool {
+	return name == healthCheckGitHubAuth ||
+		strings.HasPrefix(name, healthCheckGitHubAppPrefix)
+}
+
+// withoutAuthClassChecks filters auth-class names out of a failing-checks list.
+// Used only for placeholders; a claimed hive's list passes through untouched.
+func withoutAuthClassChecks(names []string) []string {
+	kept := names[:0:0]
+	for _, n := range names {
+		if !isAuthClassHealthCheck(n) {
+			kept = append(kept, n)
+		}
+	}
+	return kept
+}
 
 // fleetMedianTokens returns the median TotalTokens24h across claimed, online
 // hives, and how many hives contributed. Placeholders are excluded — an idle
@@ -756,7 +787,18 @@ func evaluateAlerts(state *alertState, hives []alertHive, driftAlerts []Alert, n
 		}
 
 		// --- Rule: a named health check is failing. ---
-		if failing := failingHealthChecks(h.Health); len(failing) > 0 {
+		// Placeholders keep this rule — drift.go deliberately treats health as
+		// NOT claimed-only, because a pool slot runs a real spoke process that
+		// can genuinely be degraded — but auth-class checks are exempt for
+		// them, mirroring drift's rule 2 ("never flag a placeholder for a
+		// claimed-hive concern"): an unassigned slot has no GitHub auth by
+		// design, and every live placeholder alerting github_auth was burying
+		// a real alert under pool noise. A claimed hive's list is untouched.
+		failing := failingHealthChecks(h.Health)
+		if h.IsPlaceholder {
+			failing = withoutAuthClassChecks(failing)
+		}
+		if len(failing) > 0 {
 			shown := failing
 			suffix := ""
 			if len(shown) > maxNamedFailingChecks {

--- a/v2/pkg/hub/alerts_test.go
+++ b/v2/pkg/hub/alerts_test.go
@@ -406,6 +406,84 @@ func TestEvaluateAlerts_HealthCheckFailingRule(t *testing.T) {
 	}
 }
 
+func TestEvaluateAlerts_PlaceholderAuthCheckSuppressed(t *testing.T) {
+	// An UNCLAIMED placeholder has no GitHub auth by design, so a failing
+	// github_auth (or any github_app*) check must produce NO alert — every
+	// available-* pool slot alerting github_auth buries the real alerts.
+	h := baseHive("p1")
+	h.IsPlaceholder = true
+	h.Health = map[string]any{"checks": []any{
+		map[string]any{"name": "github_auth", "status": "fail", "detail": "no GitHub auth configured"},
+		map[string]any{"name": "github_app_key", "status": "fail"},
+	}}
+	got := evaluateAlerts(newAlertState(), []alertHive{h}, nil, fixedNow)
+	if a, ok := findAlert(got.Alerts, "p1", AlertTypeHealthCheckFailing); ok {
+		t.Fatalf("placeholder with only auth-class checks failing must not alert, got %+v", a)
+	}
+}
+
+func TestEvaluateAlerts_ClaimedHiveAuthCheckStillAlerts(t *testing.T) {
+	// The placeholder exemption must not leak: the SAME failing github_auth
+	// check on a claimed hive is a real fault and must keep alerting.
+	h := baseHive("h1")
+	h.Health = map[string]any{"checks": []any{
+		map[string]any{"name": "github_auth", "status": "fail", "detail": "token expired"},
+	}}
+	got := evaluateAlerts(newAlertState(), []alertHive{h}, nil, fixedNow)
+	a, ok := findAlert(got.Alerts, "h1", AlertTypeHealthCheckFailing)
+	if !ok {
+		t.Fatalf("claimed hive with failing github_auth must alert, got %+v", got.Alerts)
+	}
+	if !contains(a.Reason, "github_auth") {
+		t.Fatalf("reason %q must name the failing check", a.Reason)
+	}
+}
+
+func TestEvaluateAlerts_ClaimedHiveNonAuthCheckStillAlerts(t *testing.T) {
+	// A claimed hive's non-auth checks (the "agents" family) are entirely
+	// outside the exemption and must keep alerting.
+	h := baseHive("h1")
+	h.Health = map[string]any{"checks": []any{
+		map[string]any{"name": "agents", "status": "fail", "detail": "2 agents down"},
+	}}
+	got := evaluateAlerts(newAlertState(), []alertHive{h}, nil, fixedNow)
+	a, ok := findAlert(got.Alerts, "h1", AlertTypeHealthCheckFailing)
+	if !ok {
+		t.Fatalf("claimed hive with failing agents check must alert, got %+v", got.Alerts)
+	}
+	if !contains(a.Reason, "agents") {
+		t.Fatalf("reason %q must name the failing check", a.Reason)
+	}
+}
+
+func TestEvaluateAlerts_PlaceholderNonAuthCheckStillAlerts(t *testing.T) {
+	// Only auth-class checks are placeholder-exempt. Drift deliberately treats
+	// health as NOT claimed-only (a pool slot runs a real spoke process that
+	// can genuinely be degraded), so a placeholder's non-auth failure must
+	// still alert — and the auth-class name failing alongside it must be
+	// filtered out of both the count and the reason.
+	h := baseHive("p1")
+	h.IsPlaceholder = true
+	h.Health = map[string]any{"checks": []any{
+		map[string]any{"name": "github_auth", "status": "fail"},
+		map[string]any{"name": "queue", "status": "fail", "detail": "queue wedged"},
+	}}
+	got := evaluateAlerts(newAlertState(), []alertHive{h}, nil, fixedNow)
+	a, ok := findAlert(got.Alerts, "p1", AlertTypeHealthCheckFailing)
+	if !ok {
+		t.Fatalf("placeholder with a failing non-auth check must alert, got %+v", got.Alerts)
+	}
+	if !contains(a.Reason, "queue") {
+		t.Fatalf("reason %q must name the non-auth failing check", a.Reason)
+	}
+	if contains(a.Reason, "github_auth") {
+		t.Fatalf("reason %q must not name the exempt auth check", a.Reason)
+	}
+	if !contains(a.Reason, "1 health check failing") {
+		t.Fatalf("reason %q must count only the non-exempt check", a.Reason)
+	}
+}
+
 func TestEvaluateAlerts_HealthCheckReasonTruncatesButCountsAll(t *testing.T) {
 	var checks []any
 	total := maxNamedFailingChecks + 4

--- a/v2/pkg/hub/drift.go
+++ b/v2/pkg/hub/drift.go
@@ -74,6 +74,9 @@ const (
 	// this one hive, so every registry field flips with whichever spoke
 	// reported last.
 	DriftKindDuplicateSpoke = "duplicate-spoke"
+	// DriftKindStatusFlipping: the hive's reported status keeps alternating
+	// between two values on a heartbeat cadence — the row cannot be trusted.
+	DriftKindStatusFlipping = "status-flipping"
 	// DriftKindAppIDPlaceholder marks a hive still authenticating as the
 	// placeholder App sentinel (config.PlaceholderAppID). Distinct from
 	// app-creds-operator because the fault is the app_id itself, not the key:
@@ -509,6 +512,15 @@ func computeDrift(h MyHiveEntry, norm fleetNorm, latestSHAs map[string]string, n
 		add(DriftKindDuplicateSpoke, DriftCritical,
 			"two spoke instances are reporting as this hive ("+h.ConflictingReporters+
 				") and their states alternate every beat — use Restart Spoke to shed the stale instance")
+	} else if h.StatusFlipping {
+		// Suppressed when duplicate-spoke already fired: that signal carries
+		// the same fact PLUS the culprit pod names, and two rows for one
+		// oscillation would double-count the hive in the summary strip.
+		add(DriftKindStatusFlipping, DriftWarn,
+			"reported status keeps flipping between two values on a heartbeat cadence — "+
+				"usually two spoke instances alternating as this hive (a spoke too old to report "+
+				"its pod name cannot be told apart) or an auth check oscillating; "+
+				"use Restart Spoke, or upgrade the spoke so the instances identify themselves")
 	}
 
 	// A placeholder legitimately has no App, no agents and ACMM 0. Flagging it

--- a/v2/pkg/hub/drift.go
+++ b/v2/pkg/hub/drift.go
@@ -70,6 +70,10 @@ const (
 	// app-missing/app-perm-issue so operator work is never filed as an
 	// owner-facing adoption problem.
 	DriftKindAppCredsOperator = "app-creds-operator"
+	// DriftKindDuplicateSpoke: two spoke instances are alternating reports as
+	// this one hive, so every registry field flips with whichever spoke
+	// reported last.
+	DriftKindDuplicateSpoke = "duplicate-spoke"
 	// DriftKindAppIDPlaceholder marks a hive still authenticating as the
 	// placeholder App sentinel (config.PlaceholderAppID). Distinct from
 	// app-creds-operator because the fault is the app_id itself, not the key:
@@ -493,6 +497,18 @@ func computeDrift(h MyHiveEntry, norm fleetNorm, latestSHAs map[string]string, n
 			"This hive is authenticating as the placeholder App ID, which is not a real GitHub App — "+
 				"no installation ID or private key can make it work. The hub must assign the cluster's real "+
 				"github_app_id; the hive owner cannot fix this and should not be asked to")
+	}
+
+	// Two instances alternating as one hive poisons every other signal in
+	// this entry — each drift row below reflects whichever instance reported
+	// last, and the dashboard flips with them. Raised first and always (even
+	// on a placeholder): the fix is shedding the stale instance, and the hub
+	// has a delivered path for that (Restart Spoke arms RolloutRestartSelf on
+	// every instance via the heartbeat).
+	if h.ConflictingReporters != "" {
+		add(DriftKindDuplicateSpoke, DriftCritical,
+			"two spoke instances are reporting as this hive ("+h.ConflictingReporters+
+				") and their states alternate every beat — use Restart Spoke to shed the stale instance")
 	}
 
 	// A placeholder legitimately has no App, no agents and ACMM 0. Flagging it

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"runtime/debug"
 	"sync/atomic"
 	"time"
 )
@@ -37,6 +38,28 @@ var lastHeartbeatSuccessUnix atomic.Int64
 // heartbeat freshness at all — otherwise every hub-less hive would fail
 // liveness forever. Set once at startup; read from the HTTP handler.
 var heartbeatLoopStarted atomic.Bool
+
+// heartbeatLoopActive is the process-wide "a heartbeat loop is RUNNING right
+// now" guard — deliberately separate from heartbeatLoopStarted, which records
+// "a loop was ever launched" and feeds /api/livez via HeartbeatEnabled (a
+// semantics that must not change: liveness keeps gating on heartbeat freshness
+// even while a duplicate start is being refused).
+//
+// WHY THIS EXISTS (#2453): a production spoke was observed running TWO
+// concurrent heartbeat loops in one process — two independent 2-minute
+// cadences from one pod, alternating a fresh and a stale auth snapshot on the
+// wire, flipping the hub registry every beat. The code has exactly one
+// StartHeartbeat call site, so the second loop's origin is unknown. This CAS
+// makes a second concurrent loop impossible no matter what path tries to
+// start one: the first caller wins, every later caller is refused and returns
+// cleanly. The refusal logs the refused caller's FULL STACK at ERROR, so the
+// next time the trigger fires in production the log names it — the guard is
+// both the fix and the instrument.
+//
+// Cleared (via defer) when a loop exits on context cancellation, so a
+// deliberate stop-then-restart stays possible; only CONCURRENT duplication is
+// refused.
+var heartbeatLoopActive atomic.Bool
 
 // lastHeartbeatAttemptUnix holds the unix-seconds timestamp of the most
 // recent heartbeat the loop *tried* to send, regardless of whether the hub
@@ -532,6 +555,21 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 		logger.Info("hub heartbeat disabled (no HIVE_HUB_URL)")
 		return
 	}
+	// Durable single-loop guard (#2453): exactly one heartbeat loop may run in
+	// this process, ever, no matter which path calls StartHeartbeat. A refused
+	// duplicate returns cleanly — the already-running loop keeps beating — and
+	// logs the refused caller's full stack so a live occurrence names the
+	// trigger instead of just alternating states on the wire.
+	if !heartbeatLoopActive.CompareAndSwap(false, true) {
+		logger.Error("duplicate StartHeartbeat REFUSED: a heartbeat loop is already running in this process (#2453) — the stack below names the caller that tried to start a second one",
+			"hub_url", hubURL,
+			"stack", string(debug.Stack()),
+		)
+		return
+	}
+	// Release only when THIS loop exits (context cancelled), so a deliberate
+	// stop-then-restart works while concurrent duplication stays impossible.
+	defer heartbeatLoopActive.Store(false)
 	// Mark the loop as active before the first send so /api/livez can tell
 	// "hub-connected, awaiting first beat" (healthy during startup grace)
 	// apart from "no hub configured" (never gated on heartbeat freshness).
@@ -629,10 +667,19 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 	}
 }
 
+// waitForReady's knobs are vars (not consts) for the same reason as
+// taskPushInterval: tests need a StartHeartbeat that reaches its send loop in
+// milliseconds, not after a 3-minute readiness wait. Production keeps the
+// defaults.
+var (
+	waitForReadyPollInterval = 5 * time.Second
+	waitForReadyMaxWait      = 3 * time.Minute
+)
+
 func waitForReady(ctx context.Context, logger *slog.Logger) {
 	const healthURL = "http://localhost:3001/api/health"
-	const pollInterval = 5 * time.Second
-	const maxWait = 3 * time.Minute
+	pollInterval := waitForReadyPollInterval
+	maxWait := waitForReadyMaxWait
 	deadline := time.After(maxWait)
 	logger.Info("heartbeat waiting for dashboard readiness")
 	for {

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -316,6 +316,13 @@ type HeartbeatPayload struct {
 	// but restarted 35 times — is visible in My Hives instead of looking
 	// healthy. A short uptime that keeps resetting is the tell.
 	StartedAt string `json:"started_at,omitempty"`
+	// Reporter is the pod name (os.Hostname) of the spoke PROCESS that sent
+	// this beat. It exists because two spoke instances can report as the same
+	// hive_id — a stale ReplicaSet pod surviving a rollout, or an orphaned
+	// duplicate deployment — and their alternating states made the dashboard
+	// flip every beat with nothing naming the culprit. Empty means the spoke
+	// is too old to report it: UNKNOWN, never evidence of anything.
+	Reporter string `json:"reporter,omitempty"`
 	// AdvisoryLastPostedAt is when this spoke last SUCCESSFULLY posted/updated
 	// its advisory-digest issue (RFC3339). It is the mirror of StartedAt for the
 	// advisory path: the hub renders a "stale advisory" pill so a hive that
@@ -514,6 +521,10 @@ type StatusCollector func() *HeartbeatPayload
 
 // UpgradeCallback is called when the hub instructs this hive to upgrade
 // to a specific SHA via the heartbeat response.
+// RestartSpokeCallback handles a hub-requested rolling restart of this spoke
+// (HeartbeatResponse.RestartSpoke). The callback owns the uptime guard.
+type RestartSpokeCallback func()
+
 type UpgradeCallback func(targetSHA string)
 
 func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, interval time.Duration, logger *slog.Logger, callbacks ...any) {
@@ -533,6 +544,7 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 	var onAuthorizedUsers AuthorizedUsersCallback
 	var onProjectConfig ProjectConfigCallback
 	var onGatewayConfig GatewayConfigCallback
+	var onRestartSpoke RestartSpokeCallback
 	for _, cb := range callbacks {
 		switch fn := cb.(type) {
 		case UpgradeCallback:
@@ -551,6 +563,8 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 			onProjectConfig = fn
 		case GatewayConfigCallback:
 			onGatewayConfig = fn
+		case RestartSpokeCallback:
+			onRestartSpoke = fn
 		}
 	}
 
@@ -593,6 +607,9 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 		// creates/replaces the gateway.
 		if resp.PendingGateway != nil && onGatewayConfig != nil {
 			onGatewayConfig(resp.PendingGateway)
+		}
+		if resp.RestartSpoke && onRestartSpoke != nil {
+			onRestartSpoke()
 		}
 	}
 
@@ -991,7 +1008,16 @@ type HeartbeatResponse struct {
 	// ghcr.io/kubestellar/hive:<SwitchToTag> and restart. Used for branch
 	// switches on clusters the hub can't reach over kubectl — the spoke has
 	// in-cluster RBAC (hive-self-upgrade role) to patch its own deployment.
-	SwitchToTag     string                    `json:"switch_to_tag,omitempty"`
+	SwitchToTag string `json:"switch_to_tag,omitempty"`
+	// RestartSpoke instructs the spoke to rolling-restart its own deployment
+	// (RolloutRestartSelf) without changing the image. It is the remote kill
+	// switch for a duplicate spoke instance on a cluster the hub cannot reach:
+	// an upgrade can't help (the instance is already at the target SHA), only
+	// a restart sheds it. Delivered to every beat inside a bounded arm window
+	// so ALL instances reporting as this hive receive it; the spoke's own
+	// uptime guard keeps a freshly restarted process from acting on the same
+	// window twice.
+	RestartSpoke    bool                      `json:"restart_spoke,omitempty"`
 	GitHubAppConfig *HeartbeatGitHubAppConfig `json:"github_app_config,omitempty"`
 	HubBanner       *HubBanner                `json:"hub_banner,omitempty"`
 	IsPublic        *bool                     `json:"is_public,omitempty"`

--- a/v2/pkg/hub/heartbeat_single_loop_test.go
+++ b/v2/pkg/hub/heartbeat_single_loop_test.go
@@ -1,0 +1,185 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// These tests drive the #2453 single-loop guard through the PRODUCTION
+// StartHeartbeat path: a real send loop against an httptest hub, with the
+// readiness wait collapsed so the loop is beating within milliseconds.
+
+// singleLoopTestInterval is short enough that several ticks fit in a
+// sub-second observation window, long enough that the scheduler reliably
+// delivers every tick even on a loaded CI runner.
+const singleLoopTestInterval = 50 * time.Millisecond
+
+// collapseReadinessWait shrinks waitForReady's knobs for the duration of a
+// test so StartHeartbeat reaches its send loop immediately instead of polling
+// localhost:3001 for up to 3 minutes.
+func collapseReadinessWait(t *testing.T) {
+	t.Helper()
+	prevPoll, prevMax := waitForReadyPollInterval, waitForReadyMaxWait
+	waitForReadyPollInterval = time.Millisecond
+	waitForReadyMaxWait = 0
+	t.Cleanup(func() {
+		waitForReadyPollInterval = prevPoll
+		waitForReadyMaxWait = prevMax
+	})
+}
+
+// resetSingleLoopGuard clears the process-global heartbeat state so one
+// test's loop cannot bleed into the next.
+func resetSingleLoopGuard(t *testing.T) {
+	t.Helper()
+	heartbeatLoopActive.Store(false)
+	ResetHeartbeatStateForTest()
+	t.Cleanup(func() {
+		heartbeatLoopActive.Store(false)
+		ResetHeartbeatStateForTest()
+	})
+}
+
+// countingHub is an httptest hub that counts every heartbeat POST it accepts.
+func countingHub(t *testing.T, beats *atomic.Int32) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/heartbeat" {
+			beats.Add(1)
+		}
+		json.NewEncoder(w).Encode(HeartbeatResponse{OK: true})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// waitForBeats blocks until the hub has seen at least n beats, or fails the
+// test after a generous deadline.
+func waitForBeats(t *testing.T, beats *atomic.Int32, n int32) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for beats.Load() < n {
+		if time.Now().After(deadline) {
+			t.Fatalf("hub saw %d beats, wanted at least %d", beats.Load(), n)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestStartHeartbeatSecondConcurrentCallRefused is the #2453 regression test:
+// two concurrent StartHeartbeat invocations must yield exactly ONE active
+// loop. The refused call is observable in two independent ways — it returns
+// promptly while the first loop is still running (an un-refused call blocks
+// until its context is cancelled), and the beat count over a multi-interval
+// window matches a single cadence, not two.
+func TestStartHeartbeatSecondConcurrentCallRefused(t *testing.T) {
+	resetSingleLoopGuard(t)
+	collapseReadinessWait(t)
+
+	var beats atomic.Int32
+	srv := countingHub(t, &beats)
+	collect := func() *HeartbeatPayload { return &HeartbeatPayload{HiveID: "h-2453"} }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	firstDone := make(chan struct{})
+	go func() {
+		StartHeartbeat(ctx, srv.URL, collect, singleLoopTestInterval, slog.Default())
+		close(firstDone)
+	}()
+
+	// The first loop is beating.
+	waitForBeats(t, &beats, 1)
+
+	// Second concurrent invocation: with the guard it is refused and returns
+	// immediately; without it this call runs a second loop and blocks here
+	// until ctx is cancelled — which is exactly the production double-sender.
+	secondDone := make(chan struct{})
+	go func() {
+		StartHeartbeat(ctx, srv.URL, collect, singleLoopTestInterval, slog.Default())
+		close(secondDone)
+	}()
+	select {
+	case <-secondDone:
+		// refused, as required
+	case <-time.After(3 * time.Second):
+		t.Fatal("second concurrent StartHeartbeat did not return: the duplicate loop was NOT refused (two senders are running)")
+	}
+
+	// Cadence check over several intervals: one loop produces ~window/interval
+	// beats; a second loop would double that. The ceiling sits between the two
+	// so a duplicate sender fails even with generous scheduler jitter.
+	beats.Store(0)
+	const window = 12 * singleLoopTestInterval
+	time.Sleep(window)
+	got := beats.Load()
+	if got == 0 {
+		t.Fatal("no beats observed after the refusal — the FIRST loop must keep running")
+	}
+	if max := int32(window/singleLoopTestInterval) + 3; got > max {
+		t.Fatalf("observed %d beats in %v (interval %v) — more than one heartbeat cadence is on the wire", got, window, singleLoopTestInterval)
+	}
+
+	// A refused duplicate must not have broken the /api/livez contract.
+	if !HeartbeatEnabled() {
+		t.Error("HeartbeatEnabled() must remain true while the surviving loop runs")
+	}
+
+	cancel()
+	select {
+	case <-firstDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("first loop did not stop on context cancellation")
+	}
+}
+
+// TestStartHeartbeatGuardReleasedAfterLoopExit proves the guard is a "running
+// now" flag, not a "ran once" latch: after the first loop exits on context
+// cancellation, a fresh StartHeartbeat must run (not be refused) and beat.
+func TestStartHeartbeatGuardReleasedAfterLoopExit(t *testing.T) {
+	resetSingleLoopGuard(t)
+	collapseReadinessWait(t)
+
+	var beats atomic.Int32
+	srv := countingHub(t, &beats)
+	collect := func() *HeartbeatPayload { return &HeartbeatPayload{HiveID: "h-restart"} }
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	firstDone := make(chan struct{})
+	go func() {
+		StartHeartbeat(ctx1, srv.URL, collect, singleLoopTestInterval, slog.Default())
+		close(firstDone)
+	}()
+	waitForBeats(t, &beats, 1)
+	cancel1()
+	select {
+	case <-firstDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("first loop did not stop on context cancellation")
+	}
+
+	// Restart: must be admitted, and must beat again.
+	beats.Store(0)
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	secondDone := make(chan struct{})
+	go func() {
+		StartHeartbeat(ctx2, srv.URL, collect, singleLoopTestInterval, slog.Default())
+		close(secondDone)
+	}()
+	waitForBeats(t, &beats, 1)
+
+	cancel2()
+	select {
+	case <-secondDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("restarted loop did not stop on context cancellation")
+	}
+}

--- a/v2/pkg/hub/placeholder_health.go
+++ b/v2/pkg/hub/placeholder_health.go
@@ -12,8 +12,11 @@ package hub
 // hive's overall status is green.
 //
 // sanitizePlaceholderRows therefore rewrites each placeholder's spoke-reported
-// Health payload before it ships to the browser: failing auth-class checks are
-// reclassified as "skip" with placeholderAuthNote as their detail, and the
+// Health payload before it ships to the browser: checks whose non-passing
+// state IS the designed state of an unassigned slot — the auth-class family,
+// and the tokens check's zero-consumed warning (no project means no workload
+// to spend on); see placeholderDesignedCheckNote — are reclassified as "skip"
+// with a note saying why as their detail, and the
 // overall status / fails / warns are recomputed from the surviving checks
 // using the spoke's own thresholds. Genuine placeholder-applicable failures —
 // not ready, agents crash-looping, queue wedged — keep their status untouched
@@ -29,6 +32,33 @@ package hub
 // failure's error detail on an unassigned row, so the hover says WHY the check
 // is not evaluated instead of presenting a designed state as a fault.
 const placeholderAuthNote = "Unassigned — auth not configured by design"
+
+// healthCheckTokens is the spoke's token-consumption check (HealthSummary,
+// pkg/dashboard/server.go). It warns with "zero consumed" whenever the hive
+// has spent nothing — which on an unassigned pool slot is not a warning at
+// all: a slot with no project has no workload to spend tokens on.
+const healthCheckTokens = "tokens"
+
+// placeholderTokensNote replaces the tokens check's "zero consumed" warning
+// detail on an unassigned row, for the same reason as placeholderAuthNote.
+const placeholderTokensNote = "Unassigned — no workload by design"
+
+// placeholderDesignedCheckNote reports whether a named check's non-passing
+// state is the DESIGNED state of an unassigned pool slot, and if so returns
+// the hover note that replaces its error detail. Everything else returns ""
+// and keeps its reported status: ready, agents, stall_detection,
+// template_vars, kick_refusal and queue failures are genuine faults even on a
+// placeholder (it runs a real spoke process), and governor/contribute only
+// ever report pass.
+func placeholderDesignedCheckNote(name string) string {
+	switch {
+	case isAuthClassHealthCheck(name):
+		return placeholderAuthNote
+	case name == healthCheckTokens:
+		return placeholderTokensNote
+	}
+	return ""
+}
 
 const (
 	// healthCheckStatusSkip is the spoke's own not-applicable check status
@@ -68,9 +98,10 @@ func isFailingCheckStatus(st string) bool {
 }
 
 // sanitizePlaceholderRows rewrites the Health payload of every UNASSIGNED
-// placeholder row in the My Hives result so auth-class check failures — the
-// pool's designed state — no longer read as degradation, while every other
-// failure keeps its colour. Claimed hives pass through untouched. Called after
+// placeholder row in the My Hives result so designed-state check failures
+// (placeholderDesignedCheckNote: the auth-class family and the zero-consumed
+// tokens warning) no longer read as degradation, while every other failure
+// keeps its colour. Claimed hives pass through untouched. Called after
 // enrichFromSaaSMeta has run on every row (provStatus must be present, or a
 // placeholder that has not yet reported it would be misread as claimed by
 // everything downstream of the org-prefix fallback).
@@ -119,19 +150,20 @@ func placeholderSanitizedHealth(health map[string]any) map[string]any {
 		}
 		name, _ := ck["name"].(string)
 		st, _ := ck["status"].(string)
-		if isAuthClassHealthCheck(name) && isFailingCheckStatus(st) {
+		if note := placeholderDesignedCheckNote(name); note != "" && isFailingCheckStatus(st) {
 			neutralized++
 			replaced := make(map[string]any, len(ck)+1)
 			for k, val := range ck {
 				replaced[k] = val
 			}
 			replaced["status"] = healthCheckStatusSkip
-			replaced["detail"] = placeholderAuthNote
+			replaced["detail"] = note
 			outChecks = append(outChecks, replaced)
 			continue
 		}
-		// Non-auth checks keep their reported status and are what the row's
-		// recomputed overall status is derived from.
+		// Checks whose failure is genuine even on a placeholder keep their
+		// reported status and are what the recomputed overall status is
+		// derived from.
 		switch st {
 		case healthCheckStatusFail, healthCheckStatusCritical, healthCheckStatusError:
 			fails++

--- a/v2/pkg/hub/placeholder_health.go
+++ b/v2/pkg/hub/placeholder_health.go
@@ -1,0 +1,171 @@
+package hub
+
+// Placeholder (unassigned pool) rows on the My Hives dashboard.
+//
+// An UNCLAIMED pool slot has no GitHub auth BY DESIGN — credentials only
+// arrive when a project is claimed — so the spoke's auth-class health checks
+// (github_auth, and any github_app* variant) legitimately fail on every
+// placeholder. Left alone, that painted the whole "Unassigned Hives" section
+// red: every row carried a degraded dot, a warning icon and a "2 checks
+// failing" pill, burying the one placeholder that is genuinely broken. The
+// maintainer's rule: if unassigned, that is noted in the status, and the
+// hive's overall status is green.
+//
+// sanitizePlaceholderRows therefore rewrites each placeholder's spoke-reported
+// Health payload before it ships to the browser: failing auth-class checks are
+// reclassified as "skip" with placeholderAuthNote as their detail, and the
+// overall status / fails / warns are recomputed from the surviving checks
+// using the spoke's own thresholds. Genuine placeholder-applicable failures —
+// not ready, agents crash-looping, queue wedged — keep their status untouched
+// and still turn the row red, exactly as drift.go's rule 2 intends ("never
+// flag a placeholder for a claimed-hive concern", and never hide a real one).
+//
+// Which rows count as placeholders is decided by isPlaceholderEntry
+// (drift.go), the SAME predicate computeDrift and the alert evaluator use, so
+// the row dot, the drift badge and the Attention Needed panel can never
+// disagree about what an unassigned hive is.
+
+// placeholderAuthNote is the status-hover text that replaces an auth-class
+// failure's error detail on an unassigned row, so the hover says WHY the check
+// is not evaluated instead of presenting a designed state as a fault.
+const placeholderAuthNote = "Unassigned — auth not configured by design"
+
+const (
+	// healthCheckStatusSkip is the spoke's own not-applicable check status
+	// (rendered as a muted dash by the dashboard), which is exactly what an
+	// auth check on a slot with no auth configured by design is.
+	healthCheckStatusSkip = "skip"
+	// healthCheckStatusWarn / Critical / Error are the remaining non-passing
+	// statuses the dashboard's FAILING_CHECK_STATUSES treats as failures.
+	// Critical and error never come from today's spoke HealthSummary (it emits
+	// pass/fail/warn/skip) but the field is a free-form passthrough, so they
+	// are matched defensively.
+	healthCheckStatusWarn     = "warn"
+	healthCheckStatusCritical = "critical"
+	healthCheckStatusError    = "error"
+)
+
+const (
+	// healthStatusOK / Warning / Degraded / Critical mirror the overall values
+	// the spoke's HealthSummary (pkg/dashboard/server.go) emits.
+	healthStatusOK       = "ok"
+	healthStatusWarning  = "warning"
+	healthStatusDegraded = "degraded"
+	healthStatusCritical = "critical"
+	// healthCriticalFailThreshold mirrors HealthSummary's rule: MORE than this
+	// many failing checks is "critical"; any failing check is "degraded".
+	healthCriticalFailThreshold = 2
+)
+
+// isFailingCheckStatus mirrors the dashboard's FAILING_CHECK_STATUSES: the
+// check statuses that count as a failure for the row pill and the hover.
+func isFailingCheckStatus(st string) bool {
+	switch st {
+	case healthCheckStatusFail, healthCheckStatusWarn, healthCheckStatusCritical, healthCheckStatusError:
+		return true
+	}
+	return false
+}
+
+// sanitizePlaceholderRows rewrites the Health payload of every UNASSIGNED
+// placeholder row in the My Hives result so auth-class check failures — the
+// pool's designed state — no longer read as degradation, while every other
+// failure keeps its colour. Claimed hives pass through untouched. Called after
+// enrichFromSaaSMeta has run on every row (provStatus must be present, or a
+// placeholder that has not yet reported it would be misread as claimed by
+// everything downstream of the org-prefix fallback).
+func sanitizePlaceholderRows(result []MyHiveEntry) {
+	for i := range result {
+		if !isPlaceholderEntry(result[i]) {
+			continue
+		}
+		result[i].Health = placeholderSanitizedHealth(result[i].Health)
+	}
+}
+
+// placeholderSanitizedHealth returns a COPY of the health map in which every
+// failing auth-class check is reclassified as "skip" with placeholderAuthNote
+// as its detail, and status / fails / warns are recomputed from the surviving
+// checks with the spoke's own thresholds. When nothing needs neutralising the
+// input is returned as-is.
+//
+// The input is never mutated: RegistryEntry.Health is a map shared by
+// reference with the hub's live registry snapshot (handleMyHives copies the
+// slice, not the maps), so an in-place rewrite here would corrupt the hub's
+// own record of what the spoke reported.
+//
+// Only the ARRAY shape of "checks" — the shape the heartbeat actually carries
+// (spoke HealthSummary) — is rewritten. The defensive map shape that
+// failingHealthChecks also accepts is left untouched: turning a row green
+// demands positive evidence that only designed-state checks were failing, and
+// an unrecognised shape is not that.
+func placeholderSanitizedHealth(health map[string]any) map[string]any {
+	if health == nil {
+		return nil
+	}
+	rawChecks, ok := health["checks"].([]any)
+	if !ok {
+		return health
+	}
+
+	neutralized := 0
+	fails, warns := 0, 0
+	outChecks := make([]any, 0, len(rawChecks))
+	for _, v := range rawChecks {
+		ck, isObj := v.(map[string]any)
+		if !isObj {
+			outChecks = append(outChecks, v)
+			continue
+		}
+		name, _ := ck["name"].(string)
+		st, _ := ck["status"].(string)
+		if isAuthClassHealthCheck(name) && isFailingCheckStatus(st) {
+			neutralized++
+			replaced := make(map[string]any, len(ck)+1)
+			for k, val := range ck {
+				replaced[k] = val
+			}
+			replaced["status"] = healthCheckStatusSkip
+			replaced["detail"] = placeholderAuthNote
+			outChecks = append(outChecks, replaced)
+			continue
+		}
+		// Non-auth checks keep their reported status and are what the row's
+		// recomputed overall status is derived from.
+		switch st {
+		case healthCheckStatusFail, healthCheckStatusCritical, healthCheckStatusError:
+			fails++
+		case healthCheckStatusWarn:
+			warns++
+		}
+		outChecks = append(outChecks, v)
+	}
+	if neutralized == 0 {
+		return health
+	}
+
+	out := make(map[string]any, len(health))
+	for k, v := range health {
+		out[k] = v
+	}
+	out["checks"] = outChecks
+	out["fails"] = fails
+	out["warns"] = warns
+	out["status"] = overallHealthStatus(fails, warns)
+	return out
+}
+
+// overallHealthStatus mirrors the spoke's HealthSummary thresholds exactly, so
+// a recomputed status is always one the dashboard already knows how to colour.
+func overallHealthStatus(fails, warns int) string {
+	switch {
+	case fails > healthCriticalFailThreshold:
+		return healthStatusCritical
+	case fails > 0:
+		return healthStatusDegraded
+	case warns > 0:
+		return healthStatusWarning
+	default:
+		return healthStatusOK
+	}
+}

--- a/v2/pkg/hub/placeholder_health_test.go
+++ b/v2/pkg/hub/placeholder_health_test.go
@@ -180,6 +180,85 @@ func TestPlaceholderRowKeepsWarningFromRealCheck(t *testing.T) {
 	}
 }
 
+// Zero token consumption is the DESIGNED state of an unassigned pool slot —
+// no project means no workload to spend on — so the spoke's tokens check
+// warning ("zero consumed") must not amber the row: it is reclassified to
+// skip with the no-workload note and the row ships green.
+func TestPlaceholderRowGreenWhenTokensWarnZeroConsumed(t *testing.T) {
+	e := placeholderEntryWithHealth(map[string]any{
+		"status": "warning",
+		"fails":  0,
+		"warns":  1,
+		"checks": []any{
+			map[string]any{"name": "ready", "status": "pass"},
+			map[string]any{"name": healthCheckTokens, "status": "warn", "detail": "zero consumed"},
+		},
+	})
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	got := rows[0].Health
+
+	if st := healthStatusOf(got); st != healthStatusOK {
+		t.Fatalf("placeholder with only the zero-consumed tokens warning: status = %q, want %q", st, healthStatusOK)
+	}
+	if warns, _ := got["warns"].(int); warns != 0 {
+		t.Errorf("warns = %v, want 0 — the pill must not render", got["warns"])
+	}
+	st, detail := checkStatusByName(t, got, healthCheckTokens)
+	if st != healthCheckStatusSkip {
+		t.Errorf("tokens status = %q, want %q", st, healthCheckStatusSkip)
+	}
+	if detail != placeholderTokensNote {
+		t.Errorf("tokens detail = %q, want the no-workload note %q", detail, placeholderTokensNote)
+	}
+}
+
+// The SAME zero-consumed warning on a CLAIMED hive is a real signal (an
+// assigned project spending nothing is worth noticing) and must pass through
+// untouched.
+func TestClaimedRowKeepsTokensWarning(t *testing.T) {
+	e := MyHiveEntry{RegistryEntry: RegistryEntry{
+		ID:     "claimed-2",
+		Org:    "acme",
+		Online: true,
+		Health: map[string]any{
+			"status": "warning",
+			"checks": []any{
+				map[string]any{"name": healthCheckTokens, "status": "warn", "detail": "zero consumed"},
+			},
+		},
+	}}
+	e.ProvStatus = "active"
+
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	got := rows[0].Health
+
+	if st := healthStatusOf(got); st != healthStatusWarning {
+		t.Fatalf("claimed hive status = %q, want %q — the tokens exemption must not leak", st, healthStatusWarning)
+	}
+	if st, detail := checkStatusByName(t, got, healthCheckTokens); st != healthCheckStatusWarn || detail != "zero consumed" {
+		t.Errorf("claimed hive tokens shipped as %q/%q, want warn/zero consumed untouched", st, detail)
+	}
+}
+
+// A tokens warning alongside a genuine failure: the tokens check is
+// neutralised but the real fault still owns the row colour.
+func TestPlaceholderTokensWarnDoesNotMaskRealFailure(t *testing.T) {
+	e := placeholderEntryWithHealth(map[string]any{
+		"status": "degraded",
+		"checks": []any{
+			map[string]any{"name": "ready", "status": "fail", "detail": "not ready"},
+			map[string]any{"name": healthCheckTokens, "status": "warn", "detail": "zero consumed"},
+		},
+	})
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	if st := healthStatusOf(rows[0].Health); st != healthStatusDegraded {
+		t.Fatalf("status = %q, want %q — neutralising tokens must not hide the not-ready fault", st, healthStatusDegraded)
+	}
+}
+
 // The sanitizer only touches Health: liveness signals (online, lastHeartbeat)
 // that drive the offline dot and the stale-heartbeat drift/alert rules must
 // pass through untouched, so a stale placeholder still reads as degraded.

--- a/v2/pkg/hub/placeholder_health_test.go
+++ b/v2/pkg/hub/placeholder_health_test.go
@@ -1,0 +1,318 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// checkStatusByName pulls one named check's status out of a health map, using
+// the same array shape the heartbeat carries.
+func checkStatusByName(t *testing.T, health map[string]any, name string) (status, detail string) {
+	t.Helper()
+	raw, _ := health["checks"].([]any)
+	for _, v := range raw {
+		ck, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		if n, _ := ck["name"].(string); n == name {
+			status, _ = ck["status"].(string)
+			detail, _ = ck["detail"].(string)
+			return status, detail
+		}
+	}
+	t.Fatalf("check %q not found in %v", name, health["checks"])
+	return "", ""
+}
+
+func placeholderEntryWithHealth(health map[string]any) MyHiveEntry {
+	return MyHiveEntry{RegistryEntry: RegistryEntry{
+		ID:     "pool-1",
+		Org:    placeholderOrgPrefix + "3",
+		Online: true,
+		Health: health,
+	}}
+}
+
+func authFailingHealth() map[string]any {
+	return map[string]any{
+		"status": "degraded",
+		"fails":  2,
+		"warns":  0,
+		"checks": []any{
+			map[string]any{"name": "ready", "status": "pass"},
+			map[string]any{"name": "github_auth", "status": "fail", "detail": "no GitHub auth configured"},
+			map[string]any{"name": "github_app_key", "status": "fail", "detail": "no key delivered"},
+		},
+	}
+}
+
+// An UNASSIGNED placeholder whose only failures are auth-class checks is the
+// pool working as designed: the row must ship GREEN ("ok"), with the auth
+// checks reclassified as skip and the hover detail saying why.
+func TestPlaceholderRowGreenWhenOnlyAuthChecksFail(t *testing.T) {
+	e := placeholderEntryWithHealth(authFailingHealth())
+	original := e.Health
+
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	got := rows[0].Health
+
+	if st := healthStatusOf(got); st != healthStatusOK {
+		t.Fatalf("placeholder with only auth-class failures: status = %q, want %q", st, healthStatusOK)
+	}
+	if fails, _ := got["fails"].(int); fails != 0 {
+		t.Errorf("fails = %v, want 0 — the failing-checks pill must not render", got["fails"])
+	}
+	for _, name := range []string{"github_auth", "github_app_key"} {
+		st, detail := checkStatusByName(t, got, name)
+		if st != healthCheckStatusSkip {
+			t.Errorf("%s status = %q, want %q", name, st, healthCheckStatusSkip)
+		}
+		if detail != placeholderAuthNote {
+			t.Errorf("%s detail = %q, want the unassigned note %q", name, detail, placeholderAuthNote)
+		}
+	}
+	if st, _ := checkStatusByName(t, got, "ready"); st != "pass" {
+		t.Errorf("ready status = %q, want pass (non-auth checks untouched)", st)
+	}
+
+	// The registry's own map must not have been rewritten: Health is shared by
+	// reference with the live registry snapshot.
+	if st := healthStatusOf(original); st != healthStatusDegraded {
+		t.Errorf("original health map was mutated: status = %q, want %q untouched", st, healthStatusDegraded)
+	}
+	if st, _ := checkStatusByName(t, original, "github_auth"); st != healthCheckStatusFail {
+		t.Errorf("original github_auth was mutated to %q", st)
+	}
+}
+
+// The SAME failing auth checks on a CLAIMED hive are a real fault: the
+// sanitizer must leave the entry byte-for-byte alone.
+func TestClaimedRowKeepsFailingAuthCheck(t *testing.T) {
+	e := MyHiveEntry{RegistryEntry: RegistryEntry{
+		ID:     "claimed-1",
+		Org:    "acme",
+		Online: true,
+		Health: authFailingHealth(),
+	}}
+	e.ProvStatus = "active"
+
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	got := rows[0].Health
+
+	if st := healthStatusOf(got); st != healthStatusDegraded {
+		t.Fatalf("claimed hive status = %q, want %q — the exemption must not leak past placeholders", st, healthStatusDegraded)
+	}
+	if st, _ := checkStatusByName(t, got, "github_auth"); st != healthCheckStatusFail {
+		t.Errorf("claimed hive github_auth = %q, want fail", st)
+	}
+}
+
+// provStatus "available" is the authoritative placeholder signal (the org
+// prefix is only the fallback) — the sanitizer must honour it too, exactly as
+// isPlaceholderEntry does.
+func TestPlaceholderByProvStatusIsSanitized(t *testing.T) {
+	e := MyHiveEntry{RegistryEntry: RegistryEntry{
+		ID:     "pool-2",
+		Org:    "some-org",
+		Online: true,
+		Health: authFailingHealth(),
+	}}
+	e.ProvStatus = statusAvailable
+
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	if st := healthStatusOf(rows[0].Health); st != healthStatusOK {
+		t.Fatalf("provStatus=available placeholder: status = %q, want %q", st, healthStatusOK)
+	}
+}
+
+// A placeholder-applicable failure — here "ready" failing, the not-ready case —
+// must still turn the row red: only auth-class checks are designed-state.
+func TestPlaceholderRowStaysDegradedOnRealFailure(t *testing.T) {
+	e := placeholderEntryWithHealth(map[string]any{
+		"status": "degraded",
+		"fails":  2,
+		"warns":  0,
+		"checks": []any{
+			map[string]any{"name": "ready", "status": "fail", "detail": "not ready"},
+			map[string]any{"name": "github_auth", "status": "fail", "detail": "no GitHub auth configured"},
+		},
+	})
+
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	got := rows[0].Health
+
+	if st := healthStatusOf(got); st != healthStatusDegraded {
+		t.Fatalf("placeholder with a real failure: status = %q, want %q", st, healthStatusDegraded)
+	}
+	if fails, _ := got["fails"].(int); fails != 1 {
+		t.Errorf("fails = %v, want 1 — only the genuine failure counts toward the pill", got["fails"])
+	}
+	if st, _ := checkStatusByName(t, got, "ready"); st != healthCheckStatusFail {
+		t.Errorf("ready = %q, want fail — genuine failures keep their status", st)
+	}
+	if st, _ := checkStatusByName(t, got, "github_auth"); st != healthCheckStatusSkip {
+		t.Errorf("github_auth = %q, want %q", st, healthCheckStatusSkip)
+	}
+}
+
+// A warning-class non-auth check must survive as the overall status too.
+func TestPlaceholderRowKeepsWarningFromRealCheck(t *testing.T) {
+	e := placeholderEntryWithHealth(map[string]any{
+		"status": "degraded",
+		"checks": []any{
+			map[string]any{"name": "stall_detection", "status": "warn", "detail": "1 stalled"},
+			map[string]any{"name": "github_auth", "status": "fail"},
+		},
+	})
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	if st := healthStatusOf(rows[0].Health); st != healthStatusWarning {
+		t.Fatalf("status = %q, want %q — a real warn survives the recompute", st, healthStatusWarning)
+	}
+}
+
+// The sanitizer only touches Health: liveness signals (online, lastHeartbeat)
+// that drive the offline dot and the stale-heartbeat drift/alert rules must
+// pass through untouched, so a stale placeholder still reads as degraded.
+func TestPlaceholderSanitizeLeavesLivenessAlone(t *testing.T) {
+	stale := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+	e := placeholderEntryWithHealth(authFailingHealth())
+	e.Online = false
+	e.LastHeartbeat = stale
+
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+
+	if rows[0].Online {
+		t.Errorf("Online was rewritten — the offline dot must keep showing")
+	}
+	if rows[0].LastHeartbeat != stale {
+		t.Errorf("LastHeartbeat = %q, want %q untouched", rows[0].LastHeartbeat, stale)
+	}
+	// And the stale-heartbeat drift rule still fires on the sanitized entry.
+	rep := computeDrift(rows[0], fleetNorm{}, nil, time.Now())
+	found := false
+	for _, sig := range rep.Signals {
+		if sig.Kind == DriftKindHeartbeatStale {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("heartbeat-stale drift signal missing on a sanitized stale placeholder: %+v", rep.Signals)
+	}
+}
+
+// A health map with no recognisable checks array (the defensive map shape, or
+// no checks at all) is left exactly as reported — greening a row demands
+// positive evidence.
+func TestPlaceholderUnknownHealthShapeUntouched(t *testing.T) {
+	for name, health := range map[string]map[string]any{
+		"nil":       nil,
+		"no checks": {"status": "degraded"},
+		"map shape": {"status": "degraded", "checks": map[string]any{"github_auth": map[string]any{"status": "fail"}}},
+	} {
+		e := placeholderEntryWithHealth(health)
+		rows := []MyHiveEntry{e}
+		sanitizePlaceholderRows(rows)
+		if healthStatusOf(rows[0].Health) == healthStatusOK {
+			t.Errorf("%s: shape without positive evidence was greened: %v", name, rows[0].Health)
+		}
+	}
+}
+
+// End-to-end through the handler: the My Hives payload must ship a green
+// placeholder and an unchanged degraded claimed hive in the same response —
+// this is what pins the sanitizer CALL in handleMyHives, not just the helper.
+func TestMyHivesPlaceholderRowShipsGreenHealth(t *testing.T) {
+	const owner = "placeholder-green-owner"
+	const token = "ghp_placeholder_green"
+
+	dir := t.TempDir()
+	origUsers, origTimeline := saasUsersDir, timelineDir
+	saasUsersDir = dir + "/users"
+	timelineDir = dir + "/timeline"
+	t.Cleanup(func() { saasUsersDir, timelineDir = origUsers, origTimeline })
+
+	cleanup := helperSetupAuthUser(t, token, owner)
+	defer cleanup()
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	s := NewHubServer(0, slog.Default(), "test", "v2")
+	s.mu.Lock()
+	s.registry.Hives = []RegistryEntry{
+		{
+			ID: "pool-slot-1", Name: "available-3/pending", Org: placeholderOrgPrefix + "3",
+			Owner: owner, Online: true, LastHeartbeat: now,
+			Health: authFailingHealth(),
+		},
+		{
+			ID: "claimed-9", Name: "acme/widget", Org: "acme",
+			Owner: owner, Online: true, LastHeartbeat: now,
+			Health: authFailingHealth(),
+		},
+	}
+	s.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/saas/my-hives", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	s.handleMyHives(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("handleMyHives = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Hives []MyHiveEntry `json:"hives"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	byID := map[string]MyHiveEntry{}
+	for _, h := range resp.Hives {
+		byID[h.ID] = h
+	}
+
+	pool, ok := byID["pool-slot-1"]
+	if !ok {
+		t.Fatalf("placeholder missing from response")
+	}
+	if st := healthStatusOf(pool.Health); st != healthStatusOK {
+		t.Errorf("placeholder shipped status %q, want %q", st, healthStatusOK)
+	}
+	if st, detail := checkStatusByName(t, pool.Health, "github_auth"); st != healthCheckStatusSkip || detail != placeholderAuthNote {
+		t.Errorf("placeholder github_auth shipped as %q/%q, want skip with the unassigned note", st, detail)
+	}
+
+	claimed, ok := byID["claimed-9"]
+	if !ok {
+		t.Fatalf("claimed hive missing from response")
+	}
+	if st := healthStatusOf(claimed.Health); st != healthStatusDegraded {
+		t.Errorf("claimed hive shipped status %q, want %q — sanitizing must be placeholder-only", st, healthStatusDegraded)
+	}
+}
+
+// The dashboard's own placeholder handling: healthBadge must carry the
+// unassigned line instead of forcing App-degraded, and hiveStatusFlags must
+// mirror the same placeholder guard so dot and chip agree. String-anchored on
+// the raw dashboardHTML, same as the other JS structure tests.
+func TestDashboardPlaceholderRowsRenderGreen(t *testing.T) {
+	if !strings.Contains(dashboardHTML, "Unassigned — GitHub auth not configured by design") {
+		t.Errorf("healthBadge lost its unassigned hover line — a placeholder row would claim a GitHub App state it cannot have")
+	}
+	if n := strings.Count(dashboardHTML, "!isPlaceholderHive(h) && !!h.githubAppRequired"); n < 2 {
+		t.Errorf("hiveStatusFlags placeholder guard appears %d times, want 2 (appMissing and degraded) — dropping either lets an unassigned row read as degraded", n)
+	}
+	if !strings.Contains(dashboardHTML, "if (isPlaceholderHive(h)) {\n        /* An UNASSIGNED pool slot has no GitHub auth BY DESIGN") {
+		t.Errorf("healthBadge no longer short-circuits the GitHub-App degraded rules for placeholders")
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2971,33 +2971,59 @@ func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"no cluster config for this hive"}`, http.StatusInternalServerError)
 		return
 	}
-	ns := "hive-hosted-" + id
-	cmd := kubectlForCluster(cluster, "rollout", "restart", "deployment/hive", "-n", ns)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		s.logger.Warn("upgrade failed", "hive", id, "cluster", cluster.ID, "output", string(out))
-		http.Error(w, `{"error":"upgrade failed — check hub logs for details"}`, http.StatusInternalServerError)
-		return
-	}
-	s.logger.Info("audit: hosted hive upgraded", "hive_id", id, "by", username, "cluster", cluster.ID)
-	s.recordTimeline(id, TimelineUpgradeStarted, "upgrade requested from the hub dashboard", username)
+
+	// kubectl is attempt one; the heartbeat fallback below is the ONLY path
+	// that works for a cluster the hub cannot route to (the spoke pulls, the
+	// hub answers). rolloutRestartHive bounds the attempt and honours the
+	// unreachable-cluster cache, so a firewalled cluster costs seconds here,
+	// not a gateway timeout.
+	delivered := s.rolloutRestartHive(cluster, id)
+
 	s.mu.Lock()
+	var latestSHA string
 	for i := range s.registry.Hives {
 		if s.registry.Hives[i].ID == id {
 			branch := s.registry.Hives[i].GitBranch
 			if branch == "" {
 				branch = "v2"
 			}
-			latestSHA := getLatestSHAForBranch(branch)
+			latestSHA = getLatestSHAForBranch(branch)
 			s.registry.Hives[i].Upgrading = true
 			s.registry.Hives[i].UpgradeTarget = latestSHA
 			s.registry.Hives[i].UpgradeStartedAt = time.Now()
 			break
 		}
 	}
+	if !delivered && latestSHA != "" {
+		// Arm the durable fallback: the spoke self-restarts onto the target
+		// when its next heartbeat carries UpgradeTo. The stale-upgrade sweep
+		// re-arms this if the spoke misses it, so the request cannot be lost.
+		if s.heartbeatUpgrade == nil {
+			s.heartbeatUpgrade = make(map[string]string)
+		}
+		s.heartbeatUpgrade[id] = latestSHA
+	}
 	s.mu.Unlock()
+
+	if !delivered && latestSHA == "" {
+		// kubectl failed AND no build target is known for the branch — there is
+		// nothing a heartbeat could deliver. This is the only remaining
+		// hard-failure case.
+		s.logger.Warn("upgrade failed: cluster unreachable and no build target known",
+			"hive", id, "cluster", cluster.ID)
+		http.Error(w, `{"error":"upgrade failed — cluster unreachable and no build target known"}`, http.StatusBadGateway)
+		return
+	}
+
+	mode := "kubectl"
+	if !delivered {
+		mode = "heartbeat"
+	}
+	s.logger.Info("audit: hosted hive upgrade requested",
+		"hive_id", id, "by", username, "cluster", cluster.ID, "mode", mode)
+	s.recordTimeline(id, TimelineUpgradeStarted, "upgrade requested from the hub dashboard ("+mode+")", username)
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"status":"upgrading"}`))
+	w.Write([]byte(`{"status":"upgrading","mode":"` + mode + `"}`))
 }
 
 // branchToTag converts a git branch name into a valid Docker image tag.
@@ -4021,6 +4047,9 @@ func (s *HubServer) markClusterUnreachable(clusterID string) {
 	}
 	s.clusterUnreachableMu.Lock()
 	defer s.clusterUnreachableMu.Unlock()
+	if s.clusterUnreachableUntil == nil {
+		s.clusterUnreachableUntil = make(map[string]time.Time)
+	}
 	s.clusterUnreachableUntil[clusterID] = time.Now().Add(clusterUnreachableTTL)
 }
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -8293,7 +8293,9 @@ const dashboardHTML = `<!DOCTYPE html>
       'health-degraded': 'Health degraded',
       'upgrade-stuck':   'Upgrade stuck',
       'acmm-unset':      'ACMM level unset',
-      'no-agents':       'No agents running'
+      'no-agents':       'No agents running',
+      'duplicate-spoke': 'Duplicate spoke instances',
+      'status-flipping': 'Status flipping'
     };
 
     function driftKindLabel(kind) { return DRIFT_KIND_LABELS[kind] || kind || 'Unknown'; }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2066,6 +2066,14 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Unassigned placeholder rows: auth-class check failures are the pool's
+	// DESIGNED state, not degradation, so neutralise them before anything
+	// downstream (drift, the fleet alerts, the browser's row dot and
+	// failing-checks pill) reads Health. Runs after enrichment for the same
+	// provStatus reason annotateDrift documents below, and before it so the
+	// drift health signal and the row agree. See placeholder_health.go.
+	sanitizePlaceholderRows(result)
+
 	// Config drift, computed once over the caller's full visible set — the
 	// fleet norm is derived from that set, so this must run AFTER every row has
 	// been collected and enriched (a row still missing its provStatus would be
@@ -7879,9 +7887,11 @@ const dashboardHTML = `<!DOCTYPE html>
       var st = hp.status || 'unknown';
       /* githubAppRequired means the spoke wants the App but it is not usable:
          with a perm issue it is installed-but-insufficient, without one it is
-         not installed at all. healthBadge() forces "degraded" in both cases. */
-      var appMissing = !!h.githubAppRequired && !h.githubAppPermIssue;
-      var degraded = !!h.githubAppRequired || st === 'degraded' || st === 'critical';
+         not installed at all. healthBadge() forces "degraded" in both cases —
+         EXCEPT on an unassigned placeholder, where having no usable App is the
+         pool's designed state (mirrored here so dot and chip never disagree). */
+      var appMissing = !isPlaceholderHive(h) && !!h.githubAppRequired && !h.githubAppPermIssue;
+      var degraded = (!isPlaceholderHive(h) && !!h.githubAppRequired) || st === 'degraded' || st === 'critical';
       /* An offline hive has no live reading at all, so it is not "OK" even if
          its last stored health snapshot said ok. */
       var ok = !degraded && st === 'ok' && !!h.online;
@@ -8153,7 +8163,15 @@ const dashboardHTML = `<!DOCTYPE html>
         if (ck.detail) line += ': ' + ck.detail;
         lines.push(line);
       }
-      if (h.githubAppRequired && ghAppIsOperatorSide(h.githubAppState)) {
+      if (isPlaceholderHive(h)) {
+        /* An UNASSIGNED pool slot has no GitHub auth BY DESIGN — credentials
+           only arrive when a project is claimed — so none of the App-degraded
+           rules below may fire here. The hub has already reclassified the
+           auth-class checks (sanitizePlaceholderRows, placeholder_health.go);
+           this line says WHY the row is green instead of claiming an App. */
+        lines.push('– Unassigned — GitHub auth not configured by design');
+      }
+      else if (h.githubAppRequired && ghAppIsOperatorSide(h.githubAppState)) {
         /* Operator-side: the key we distribute has not landed, or is for the
            wrong App. Still degraded — the hive genuinely cannot work — but the
            hover must name the real cause so an admin does not chase the user

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -7632,6 +7632,18 @@ const dashboardHTML = `<!DOCTYPE html>
     function ghAppIsOperatorSide(state) {
       return GH_APP_OPERATOR_STATES[String(state || '').trim()] === true;
     }
+    /* Popover label for a user-side App issue, from the classified state.
+       The blanket "permissions insufficient" wording is reserved for genuine
+       permission states (and for unclassified reports from older spokes);
+       the other states name their real cause so the hover stops sending an
+       admin to approve permissions when the installation_id is what's wrong. */
+    function ghAppPermIssueLabel(state) {
+      var s = String(state || '').trim();
+      if (s === 'wrong-installation') return 'wrong installation (installation_id points at another account)';
+      if (s === 'write-forbidden') return 'write forbidden (repo not in the App installation)';
+      if (s === 'no-app-assigned') return 'no App assigned yet';
+      return 'permissions insufficient';
+    }
 
     /* Labels for each journey stage, matching JourneyStage.String() on the hub. */
     var JOURNEY_STAGE_LABELS = {
@@ -8181,7 +8193,7 @@ const dashboardHTML = `<!DOCTYPE html>
           : '⚠ GitHub App: credentials not yet delivered by the hub (operator action)');
         st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel;
       }
-      else if (h.githubAppRequired && h.githubAppPermIssue) { lines.push('✓ GitHub App installed'); lines.push('⚠ GitHub App: permissions insufficient'); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
+      else if (h.githubAppRequired && h.githubAppPermIssue) { lines.push('✓ GitHub App installed'); lines.push('⚠ GitHub App: ' + ghAppPermIssueLabel(h.githubAppState)); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
       else if (h.githubAppRequired) { lines.push('✕ GitHub App not installed'); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
       else if (!h.githubAppRequired) { lines.push('✓ GitHub App: not in use'); }
       if (!checks.length) lines.push('No check data');

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -8183,7 +8183,7 @@ const dashboardHTML = `<!DOCTYPE html>
       }
       else if (h.githubAppRequired && h.githubAppPermIssue) { lines.push('✓ GitHub App installed'); lines.push('⚠ GitHub App: permissions insufficient'); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
       else if (h.githubAppRequired) { lines.push('✕ GitHub App not installed'); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
-      else if (!h.githubAppRequired) { lines.push('✓ GitHub App installed'); }
+      else if (!h.githubAppRequired) { lines.push('✓ GitHub App: not in use'); }
       if (!checks.length) lines.push('No check data');
       // Heartbeat freshness — so a reading that is minutes old isn't mistaken
       // for current health (the source of "stuck Degraded" reports: the last

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -213,6 +213,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	// switch-branch and auto-upgrade above.
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/forge", s.requireAuth(s.handleSwitchForge))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/reset-app", s.requireAuth(s.handleResetApp))
+	s.mux.HandleFunc("POST /api/saas/hives/{id}/restart-spoke", s.requireAuth(s.handleRestartSpoke))
 	s.mux.HandleFunc("GET /api/saas/hive-config/{hiveID}", s.requireAuth(s.handleProxyHiveConfig))
 	s.mux.HandleFunc("GET /api/saas/latest-sha", s.handleLatestSHA)
 	s.mux.HandleFunc("POST /api/saas/hub/upgrade", s.requireAdmin(s.handleHubSelfUpgrade))
@@ -11422,6 +11423,12 @@ const dashboardHTML = `<!DOCTYPE html>
            that App's installation_id after its identity is moved to the fleet
            App, so every field reads correct while freshly minted tokens 404. */
         if (_isAdmin && isHosted) menuItems.push('<div onclick="resetHiveApp(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">Reset App</div>');
+        /* Restart Spoke rolling-restarts every instance reporting as this
+           hive. The case it exists for: two instances alternating as one hive
+           (conflictingReporters drift) on a cluster the hub cannot reach —
+           the heartbeat is the only channel, and a restart sheds the stale
+           instance while costing the healthy one a single rolling restart. */
+        if (_isAdmin && isHosted) menuItems.push('<div onclick="restartHiveSpoke(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">Restart Spoke</div>');
         if (isLocal && h.role === 'owner') menuItems.push('<div onclick="removeLocalHive(\'' + esc(h.id) + '\')" style="' + mi + '">Remove</div>');
         if (isHosted && h.role === 'owner' && _clusterList && _clusterList.length > 1 && h.migrationStatus !== 'migrating') menuItems.push('<div onclick="openMigrateModal(\'' + esc(h.id) + '\',\'' + esc(h.clusterId || '') + '\')" style="' + mi + '">Move to cluster</div>');
         if (isHosted && h.role === 'owner') menuItems.push('<div style="border-top:1px solid #30363d;margin:4px 0"></div><div onclick="deleteHive(\'' + esc(h.id) + '\')" style="' + mi + ';color:#f85149">Delete</div>');
@@ -12351,6 +12358,22 @@ const dashboardHTML = `<!DOCTYPE html>
         if (typeof loadHives === 'function') loadHives();
       } catch (e) {
         alert('Reset failed: ' + e);
+      }
+    }
+
+    /* Restart Spoke: arms a rolling restart delivered to every spoke instance
+       reporting as this hive on their next heartbeats (bounded window). Used
+       to shed a stale duplicate instance the hub cannot delete directly. */
+    async function restartHiveSpoke(hiveId, hiveName) {
+      if (!confirm('Restart the spoke for "' + hiveName + '"?\n\nEvery instance reporting as this hive rolling-restarts on its next heartbeat (up to 5 minutes). The image and configuration are unchanged.')) return;
+      try {
+        var resp = await fetch('/api/saas/hives/' + encodeURIComponent(hiveId) + '/restart-spoke', {method: 'POST'});
+        var data = await resp.json().catch(function() { return {}; });
+        if (!resp.ok) { alert('Restart failed: ' + (data.error || resp.status)); return; }
+        alert('Spoke restart armed for "' + hiveName + '".\n\nInstances restart on their next heartbeat within the 5-minute window.');
+        if (typeof loadHives === 'function') loadHives();
+      } catch (e) {
+        alert('Restart failed: ' + e);
       }
     }
 

--- a/v2/pkg/hub/saas_handlers_coverage_test.go
+++ b/v2/pkg/hub/saas_handlers_coverage_test.go
@@ -241,13 +241,16 @@ func TestHandleUpgradeHiveKubectlFails(t *testing.T) {
 		t.Errorf("missing hive status = %d, want 404", rec.Code)
 	}
 
-	// Owner, cluster resolves, kubectl fails (fake) -> 500.
+	// Owner, cluster resolves, kubectl fails (fake), and no build target is
+	// known for the branch — the one remaining hard-failure case. A kubectl
+	// failure alone no longer fails the request: with a known target it arms
+	// the heartbeat fallback instead (TestHandleUpgradeHiveUnreachableCluster*).
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", ClusterID: "hive-oke"})
 	rec = httptest.NewRecorder()
 	req = setPathValue(reqWithUser(http.MethodPost, "/up", "", "alice"), "id", "h1")
 	s.handleUpgradeHive(rec, req)
-	if rec.Code != http.StatusInternalServerError {
-		t.Errorf("kubectl-fail upgrade status = %d, want 500", rec.Code)
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("kubectl-fail upgrade with no target status = %d, want 502", rec.Code)
 	}
 }
 

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -545,6 +545,14 @@ type SaaSHive struct {
 	// delivery (see AppIdentityDelivered), so a lost beat is retried.
 	PendingAppConfig *PendingAppIdentity `json:"pending_app_config,omitempty"`
 
+	// RequestedRestartAt (RFC3339) arms a rolling restart of this hive's spoke,
+	// delivered on every heartbeat inside spokeRestartDeliveryWindow and then
+	// cleared. Durable on the hive record for the same reason as
+	// PendingAppConfig: an in-memory flag dies with a hub restart and a missed
+	// beat, and the whole point of this switch is reaching spokes the hub
+	// cannot touch any other way.
+	RequestedRestartAt string `json:"requested_restart_at,omitempty"`
+
 	Error           string                 `json:"error,omitempty"`
 	AutoUpgrade     bool                   `json:"auto_upgrade"`
 	IsPublic        bool                   `json:"is_public"`

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -197,6 +197,12 @@ type RegistryEntry struct {
 	// alternate. Non-empty is a critical drift signal: every field in this
 	// entry is only as trustworthy as whichever instance reported last.
 	ConflictingReporters string `json:"conflictingReporters,omitempty"`
+	// StatusFlipping is true while this hive's reported App-auth state keeps
+	// alternating between two values (status_flip.go) — the row cannot be
+	// trusted because each beat tells a different story. Works for spokes too
+	// old to report a Reporter; when both fire, duplicate-spoke names the
+	// culprit pods.
+	StatusFlipping bool `json:"statusFlipping,omitempty"`
 	// GitHubAppID is the App ID the spoke reports it is authenticating AS.
 	//
 	// Carried into the registry so the hub can SEE a spoke running the
@@ -613,6 +619,11 @@ type HubServer struct {
 	// every beat and must never contend with the registry lock.
 	reporterSeen map[string]*reporterFlipState
 	reporterMu   sync.Mutex
+	// statusFlipSeen tracks each hive's reported App-auth state to catch
+	// oscillation (status_flip.go). Same shape as reporterSeen, separate
+	// mutex for the same reason: touched on every beat.
+	statusFlipSeen map[string]*reporterFlipState
+	statusFlipMu   sync.Mutex
 	// heartbeatSwitchTag tracks hives that should switch their deployment
 	// image to a specific tag (branch switch) via heartbeat, for clusters
 	// the hub can't reach over kubectl. Cleared once the spoke reports it.
@@ -1069,6 +1080,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		GitHubAppRequired:       payload.GitHubAppRequired,
 		GitHubAppPermIssue:      sanitizeHeartbeatField(payload.GitHubAppPermIssue),
 		GitHubAppState:          sanitizeHeartbeatField(payload.GitHubAppState),
+		StatusFlipping:          s.noteStatusFlip(payload.HiveID, sanitizeHeartbeatField(payload.GitHubAppState)),
 		GitHubAppID:             payload.GitHubAppID,
 		GitHubAppSlug:           payload.GitHubAppSlug,
 		GitHubInstallationID:    payload.GitHubInstallationID,

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -192,6 +192,11 @@ type RegistryEntry struct {
 	GitHubAppRequired     bool         `json:"githubAppRequired,omitempty"`
 	GitHubAppPermIssue    string       `json:"githubAppPermIssue,omitempty"`
 	GitHubAppState        string       `json:"githubAppState,omitempty"`
+	// ConflictingReporters names two spoke instances that are BOTH reporting
+	// as this hive (e.g. "hive-abc… ↔ hive-def…"), set when their beats
+	// alternate. Non-empty is a critical drift signal: every field in this
+	// entry is only as trustworthy as whichever instance reported last.
+	ConflictingReporters string `json:"conflictingReporters,omitempty"`
 	// GitHubAppID is the App ID the spoke reports it is authenticating AS.
 	//
 	// Carried into the registry so the hub can SEE a spoke running the
@@ -602,6 +607,12 @@ type HubServer struct {
 	// the time after which kubectl may be retried.
 	clusterUnreachableUntil map[string]time.Time
 	clusterUnreachableMu    sync.Mutex
+	// reporterSeen tracks which spoke instance (payload.Reporter, the pod
+	// name) last reported as each hive, to catch two instances alternating
+	// under one hive_id. Guarded by reporterMu, not s.mu — it is touched on
+	// every beat and must never contend with the registry lock.
+	reporterSeen map[string]*reporterFlipState
+	reporterMu   sync.Mutex
 	// heartbeatSwitchTag tracks hives that should switch their deployment
 	// image to a specific tag (branch switch) via heartbeat, for clusters
 	// the hub can't reach over kubectl. Cleared once the spoke reports it.
@@ -973,6 +984,10 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		AIAuthor:          sanitizeField(payload.AIAuthor),
 		AIAuthorEffective: sanitizeField(payload.AIAuthorEffective),
 		StartedAt:         sanitizeField(payload.StartedAt),
+		// Duplicate-instance detection. noteReporter returns "" until two
+		// distinct reporters have ALTERNATED (A→B→A), so a normal rollout
+		// (A→B, B stays) never trips it.
+		ConflictingReporters: s.noteReporter(payload.HiveID, sanitizeField(payload.Reporter)),
 		// Advisory-staleness signal. Both are sanitized like every other
 		// spoke-reported string; an empty AdvisoryLastPostedAt is preserved as
 		// empty so the render/gate reads it as UNKNOWN rather than stale.
@@ -1499,6 +1514,11 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			"from", payload.GitHash,
 			"to", hbTarget,
 		)
+	}
+
+	if s.restartSpokeForHeartbeat(payload.HiveID) {
+		resp.RestartSpoke = true
+		s.logger.Info("heartbeat: delivering spoke restart", "hive_id", payload.HiveID, "reporter", payload.Reporter)
 	}
 
 	if ghCfg := s.pendingAppIdentityForHeartbeat(&payload); ghCfg != nil {

--- a/v2/pkg/hub/spoke_restart.go
+++ b/v2/pkg/hub/spoke_restart.go
@@ -1,0 +1,140 @@
+package hub
+
+import (
+	"net/http"
+	"time"
+)
+
+// spokeRestartDeliveryWindow is how long an armed restart keeps being
+// delivered after RequestedRestartAt. It must be long enough that EVERY
+// instance reporting as the hive gets at least one beat inside it (beats are
+// 1–2 minutes apart), because the whole point is reaching a duplicate
+// instance whose existence the hub can't otherwise act on. The spoke-side
+// uptime guard (spokeRestartMinUptime in cmd/hive) keeps a process that
+// already restarted from acting on the same window twice.
+const spokeRestartDeliveryWindow = 5 * time.Minute
+
+// reporterConflictWindow is how recently two reporters must have alternated
+// for the conflict to still be considered live. A rollout leaves exactly one
+// reporter, so the alternation stops and the conflict ages out on its own.
+const reporterConflictWindow = 15 * time.Minute
+
+// reporterFlipsToConfirm is how many A→B→A alternations are required before
+// two reporters are declared in conflict. One change of reporter is a normal
+// rollout (old pod's last beat, new pod's first); a return to a PREVIOUS
+// reporter is the signature of two live instances.
+const reporterFlipsToConfirm = 2
+
+// reporterFlipState is the per-hive memory behind noteReporter.
+type reporterFlipState struct {
+	last     string // reporter of the most recent beat
+	prev     string // reporter seen immediately before last
+	flips    int    // times the reporter returned to a previously seen one
+	lastFlip time.Time
+}
+
+// noteReporter records which spoke instance sent this beat and returns a
+// non-empty "a ↔ b" description while two instances are alternating as the
+// same hive. Empty reporter (a spoke too old to report one) is UNKNOWN and
+// never counts for or against a conflict — the state is left untouched.
+func (s *HubServer) noteReporter(hiveID, reporter string) string {
+	if reporter == "" {
+		return ""
+	}
+	s.reporterMu.Lock()
+	defer s.reporterMu.Unlock()
+	if s.reporterSeen == nil {
+		s.reporterSeen = make(map[string]*reporterFlipState)
+	}
+	st := s.reporterSeen[hiveID]
+	if st == nil {
+		st = &reporterFlipState{last: reporter}
+		s.reporterSeen[hiveID] = st
+		return ""
+	}
+	if reporter != st.last {
+		if reporter == st.prev {
+			// The reporter came BACK — both instances are alive.
+			st.flips++
+		} else {
+			// A reporter never seen adjacent to this one: treat as a fresh
+			// handover (rollout), not a conflict.
+			st.flips = 0
+		}
+		st.prev, st.last = st.last, reporter
+		st.lastFlip = time.Now()
+	}
+	if st.flips >= reporterFlipsToConfirm && time.Since(st.lastFlip) < reporterConflictWindow {
+		a, b := st.prev, st.last
+		if a > b {
+			a, b = b, a
+		}
+		return a + " ↔ " + b
+	}
+	if time.Since(st.lastFlip) >= reporterConflictWindow {
+		st.flips = 0
+	}
+	return ""
+}
+
+// restartSpokeForHeartbeat reports whether an armed restart should ride this
+// beat. It delivers to EVERY beat inside the window — all instances reporting
+// as this hive must hear it — and clears the armed record on the first beat
+// after the window so the file does not stay armed forever.
+func (s *HubServer) restartSpokeForHeartbeat(hiveID string) bool {
+	h := loadSaaSHive(hiveID)
+	if h == nil || h.RequestedRestartAt == "" {
+		return false
+	}
+	armedAt, err := time.Parse(time.RFC3339, h.RequestedRestartAt)
+	if err != nil {
+		// Unparseable is unrecoverable — clear it rather than deliver forever.
+		h.RequestedRestartAt = ""
+		if saveErr := saveSaaSHive(h); saveErr != nil {
+			s.logger.Warn("spoke restart: failed to clear bad timestamp", "hive_id", hiveID, "error", saveErr)
+		}
+		return false
+	}
+	if time.Since(armedAt) >= spokeRestartDeliveryWindow {
+		h.RequestedRestartAt = ""
+		if err := saveSaaSHive(h); err != nil {
+			s.logger.Warn("spoke restart: failed to clear expired request", "hive_id", hiveID, "error", err)
+		}
+		s.logger.Info("spoke restart window closed", "hive_id", hiveID, "armed_at", armedAt.Format(time.RFC3339))
+		return false
+	}
+	return true
+}
+
+// handleRestartSpoke arms a rolling restart for one hive's spoke:
+// POST /api/saas/hives/{id}/restart-spoke
+//
+// WHY AN OPERATOR NEEDS THIS. When two spoke instances report as one hive
+// (ConflictingReporters — a stale ReplicaSet pod, an orphaned duplicate
+// deployment), the dashboard flips state every beat and one instance is
+// usually broken in a way that pollutes the registry. The hub often cannot
+// reach the cluster to delete anything; the heartbeat is the only channel.
+// A restart delivered to every instance makes each patch its own Deployment
+// (RolloutRestartSelf): a stale pod is replaced and never comes back, while
+// the healthy instance suffers one rolling restart.
+func (s *HubServer) handleRestartSpoke(w http.ResponseWriter, r *http.Request) {
+	if s.getAuthUser(r) != hubAdminUsername {
+		http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
+		return
+	}
+	hiveID := r.PathValue("id")
+	h := loadSaaSHive(hiveID)
+	if h == nil {
+		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
+		return
+	}
+	h.RequestedRestartAt = time.Now().UTC().Format(time.RFC3339)
+	if err := saveSaaSHive(h); err != nil {
+		s.logger.Error("failed to arm spoke restart", "hive_id", hiveID, "error", err)
+		http.Error(w, `{"error":"could not arm the restart"}`, http.StatusInternalServerError)
+		return
+	}
+	s.logger.Info("spoke restart armed by operator", "hive_id", hiveID)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(`{"status":"armed","detail":"every spoke instance reporting as this hive will rolling-restart on its next heartbeat within the delivery window"}`))
+}

--- a/v2/pkg/hub/spoke_restart_test.go
+++ b/v2/pkg/hub/spoke_restart_test.go
@@ -1,0 +1,144 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Two instances alternating as one hive is the production signature this
+// package exists to catch (the WVA flip: ok at :22, key-invalid at :58,
+// forever). A single reporter change is a rollout and must stay silent.
+func TestNoteReporterFlagsAlternation(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+
+	if got := s.noteReporter("h1", "pod-a"); got != "" {
+		t.Fatalf("first beat flagged: %q", got)
+	}
+	if got := s.noteReporter("h1", "pod-b"); got != "" {
+		t.Fatalf("single handover flagged (a rollout would false-positive): %q", got)
+	}
+	if got := s.noteReporter("h1", "pod-a"); got != "" {
+		t.Fatalf("first return flagged too early: %q", got)
+	}
+	got := s.noteReporter("h1", "pod-b")
+	if got == "" {
+		t.Fatal("sustained alternation was not flagged")
+	}
+	if !strings.Contains(got, "pod-a") || !strings.Contains(got, "pod-b") {
+		t.Errorf("conflict does not name both reporters: %q", got)
+	}
+	// The conflict must persist while the alternation continues.
+	if got := s.noteReporter("h1", "pod-a"); got == "" {
+		t.Error("ongoing alternation lost the conflict")
+	}
+}
+
+func TestNoteReporterSilentOnRolloutAndUnknown(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+
+	// Rollout: a → b, then b keeps reporting. Never a conflict.
+	s.noteReporter("h2", "pod-a")
+	s.noteReporter("h2", "pod-b")
+	for i := 0; i < 5; i++ {
+		if got := s.noteReporter("h2", "pod-b"); got != "" {
+			t.Fatalf("steady reporter after rollout flagged: %q", got)
+		}
+	}
+
+	// A spoke too old to report one sends "": UNKNOWN, never data, and it
+	// must not disturb the state of what HAS been reported.
+	s3 := &HubServer{logger: slog.Default()}
+	s3.noteReporter("h3", "pod-a")
+	s3.noteReporter("h3", "pod-b")
+	s3.noteReporter("h3", "")
+	s3.noteReporter("h3", "pod-a")
+	if got := s3.noteReporter("h3", "pod-b"); got == "" {
+		t.Error("an interleaved empty reporter destroyed alternation tracking")
+	}
+}
+
+// An armed restart rides every beat inside the window (all instances must
+// hear it) and the record clears itself on the first beat after it.
+func TestRestartSpokeDeliveryWindow(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := &HubServer{logger: slog.Default()}
+
+	// Not armed → nothing.
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice"})
+	if s.restartSpokeForHeartbeat("h1") {
+		t.Fatal("unarmed hive got a restart")
+	}
+
+	// Freshly armed → delivered, and STILL armed for the next beat.
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice",
+		RequestedRestartAt: time.Now().UTC().Format(time.RFC3339)})
+	if !s.restartSpokeForHeartbeat("h1") {
+		t.Fatal("armed restart not delivered")
+	}
+	if !s.restartSpokeForHeartbeat("h1") {
+		t.Fatal("second beat inside the window missed the restart — a second instance would never hear it")
+	}
+
+	// Expired → not delivered, and the record is cleared durably.
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice",
+		RequestedRestartAt: time.Now().Add(-spokeRestartDeliveryWindow - time.Minute).UTC().Format(time.RFC3339)})
+	if s.restartSpokeForHeartbeat("h1") {
+		t.Fatal("expired restart still delivered")
+	}
+	if h := loadSaaSHive("h1"); h.RequestedRestartAt != "" {
+		t.Errorf("expired restart not cleared from the record: %q", h.RequestedRestartAt)
+	}
+
+	// Unparseable → cleared, never delivered.
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", RequestedRestartAt: "not-a-time"})
+	if s.restartSpokeForHeartbeat("h1") {
+		t.Fatal("unparseable timestamp delivered a restart")
+	}
+	if h := loadSaaSHive("h1"); h.RequestedRestartAt != "" {
+		t.Errorf("unparseable timestamp not cleared: %q", h.RequestedRestartAt)
+	}
+}
+
+func TestHandleRestartSpokeArmsDurably(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := &HubServer{hubSecret: testHubSecret, logger: slog.Default()}
+	mkUser(t, hubAdminUsername)
+	mkUser(t, "mallory")
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "someone"})
+
+	// Non-admin: forbidden, nothing armed.
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser("POST", "/rs", "", "mallory"), "id", "h1")
+	s.handleRestartSpoke(rec, req)
+	if rec.Code != 403 {
+		t.Fatalf("non-admin restart status = %d, want 403", rec.Code)
+	}
+	if h := loadSaaSHive("h1"); h.RequestedRestartAt != "" {
+		t.Fatal("non-admin request armed a restart")
+	}
+
+	// Admin: armed with a parseable fresh timestamp.
+	rec = httptest.NewRecorder()
+	req = setPathValue(reqWithUser("POST", "/rs", "", hubAdminUsername), "id", "h1")
+	s.handleRestartSpoke(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("admin restart status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	h := loadSaaSHive("h1")
+	armedAt, err := time.Parse(time.RFC3339, h.RequestedRestartAt)
+	if err != nil {
+		t.Fatalf("armed timestamp unparseable: %q (%v)", h.RequestedRestartAt, err)
+	}
+	if time.Since(armedAt) > time.Minute {
+		t.Errorf("armed timestamp not fresh: %v", armedAt)
+	}
+	// And the armed record is exactly what delivery reads.
+	if !s.restartSpokeForHeartbeat("h1") {
+		t.Error("endpoint-armed restart not delivered on the next beat")
+	}
+}

--- a/v2/pkg/hub/status_flip.go
+++ b/v2/pkg/hub/status_flip.go
@@ -1,0 +1,61 @@
+package hub
+
+import "time"
+
+// Status-flip detection: a hive whose reported App-auth state keeps
+// ALTERNATING (ok → key-invalid → ok → …) is not transitioning, it is
+// oscillating — in practice two spoke instances alternating under one
+// hive_id, or a spoke whose auth check flaps every beat. Either way the
+// dashboard flips with it and every glance at the row tells a different
+// story.
+//
+// This is the reporter-blind sibling of noteReporter: it needs NOTHING from
+// the spoke (old builds included), because it watches the states the hub
+// already receives. When the spoke is new enough to also report its pod name,
+// the duplicate-spoke signal names the culprits; this signal only says the
+// row cannot be trusted.
+
+// statusFlipsToConfirm is how many returns to a previously reported state are
+// required before a hive is declared flipping. A single bounce (degraded →
+// ok → degraded hours later) is a hive having a bad day; three returns on a
+// heartbeat cadence is an oscillation.
+const statusFlipsToConfirm = 3
+
+// statusFlipWindow bounds how recent the last alternation must be for the
+// flag to persist. Beats are 1–2 minutes apart, so a genuine oscillation
+// re-arms this continuously; a hive that settles stops flapping and the flag
+// ages out on its own.
+const statusFlipWindow = 10 * time.Minute
+
+// noteStatusFlip records the App-auth state this beat reported and returns
+// true while the state is oscillating between two values. Unlike reporters,
+// an EMPTY state is meaningful here — it is "healthy" — so it participates in
+// alternation tracking rather than being skipped.
+func (s *HubServer) noteStatusFlip(hiveID, state string) bool {
+	s.statusFlipMu.Lock()
+	defer s.statusFlipMu.Unlock()
+	if s.statusFlipSeen == nil {
+		s.statusFlipSeen = make(map[string]*reporterFlipState)
+	}
+	st := s.statusFlipSeen[hiveID]
+	if st == nil {
+		s.statusFlipSeen[hiveID] = &reporterFlipState{last: state}
+		return false
+	}
+	if state != st.last {
+		if state == st.prev {
+			st.flips++
+		} else {
+			// A state never seen adjacent to this one: a normal transition,
+			// not an oscillation.
+			st.flips = 0
+		}
+		st.prev, st.last = st.last, state
+		st.lastFlip = time.Now()
+	}
+	if time.Since(st.lastFlip) >= statusFlipWindow {
+		st.flips = 0
+		return false
+	}
+	return st.flips >= statusFlipsToConfirm
+}

--- a/v2/pkg/hub/status_flip_test.go
+++ b/v2/pkg/hub/status_flip_test.go
@@ -1,0 +1,75 @@
+package hub
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// The production signature this exists for: WVA reported ok at :22 and
+// key-invalid at :58, every cycle, for an hour ("" is how a healthy state
+// arrives — it must count in the alternation, not be skipped).
+func TestNoteStatusFlipFlagsOscillation(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+	beats := []string{"", "key-invalid", "", "key-invalid", "", "key-invalid", ""}
+	flagged := false
+	for _, st := range beats {
+		flagged = s.noteStatusFlip("h1", st)
+	}
+	if !flagged {
+		t.Fatal("a sustained ok ↔ key-invalid oscillation was not flagged")
+	}
+	// And it stays flagged while the oscillation continues.
+	if !s.noteStatusFlip("h1", "key-invalid") {
+		t.Error("ongoing oscillation lost the flag")
+	}
+}
+
+// Genuine transitions must stay silent: a hive that degrades, recovers once,
+// or walks through DIFFERENT states is having a normal life, not oscillating.
+func TestNoteStatusFlipSilentOnRealTransitions(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+
+	// Degrade and stay degraded.
+	for _, st := range []string{"", "key-invalid", "key-invalid", "key-invalid"} {
+		if s.noteStatusFlip("h2", st) {
+			t.Fatal("a plain degradation was flagged as flipping")
+		}
+	}
+
+	// One bounce: degraded → recovered → degraded is below the threshold.
+	s2 := &HubServer{logger: slog.Default()}
+	for _, st := range []string{"", "not-installed", "", "not-installed"} {
+		if s2.noteStatusFlip("h3", st) {
+			t.Fatal("a single bounce was flagged as flipping")
+		}
+	}
+
+	// Walking through distinct states never flags: each is a fresh
+	// transition, not a return.
+	s3 := &HubServer{logger: slog.Default()}
+	for _, st := range []string{"", "key-missing", "not-installed", "wrong-installation", "key-invalid"} {
+		if s3.noteStatusFlip("h4", st) {
+			t.Fatal("a walk through distinct states was flagged as flipping")
+		}
+	}
+}
+
+// The drift signal must fire on a flipping hive, use the stable kind, and be
+// suppressed when duplicate-spoke already names the culprits — one
+// oscillation must not count a hive twice in the summary strip.
+func TestStatusFlippingDriftSignal(t *testing.T) {
+	h := MyHiveEntry{RegistryEntry: RegistryEntry{ID: "h1", StatusFlipping: true}}
+	if _, ok := hasSignal(computeDrift(h, fleetNorm{}, nil, time.Now()), DriftKindStatusFlipping); !ok {
+		t.Fatal("flipping hive raised no status-flipping signal")
+	}
+
+	h.ConflictingReporters = "pod-a ↔ pod-b"
+	rep := computeDrift(h, fleetNorm{}, nil, time.Now())
+	if _, ok := hasSignal(rep, DriftKindStatusFlipping); ok {
+		t.Error("status-flipping not suppressed when duplicate-spoke names the culprits")
+	}
+	if _, ok := hasSignal(rep, DriftKindDuplicateSpoke); !ok {
+		t.Error("duplicate-spoke signal missing")
+	}
+}

--- a/v2/pkg/hub/upgrade_fallback_test.go
+++ b/v2/pkg/hub/upgrade_fallback_test.go
@@ -1,0 +1,113 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// seedLatestSHA installs a fake image-verified head SHA for a branch and
+// restores the previous cache on cleanup, so tests don't leak into each other.
+func seedLatestSHA(t *testing.T, branch, sha string) {
+	t.Helper()
+	latestSHAMu.Lock()
+	prev, had := latestSHAByBranch[branch]
+	latestSHAByBranch[branch] = branchSHAInfo{SHA: sha}
+	latestSHAMu.Unlock()
+	t.Cleanup(func() {
+		latestSHAMu.Lock()
+		if had {
+			latestSHAByBranch[branch] = prev
+		} else {
+			delete(latestSHAByBranch, branch)
+		}
+		latestSHAMu.Unlock()
+	})
+}
+
+// An upgrade against a cluster the hub cannot reach must not fail — it must
+// arm the heartbeat fallback, which is the only delivery path that works for
+// firewalled clusters (the spoke pulls; the hub answers). This is the exact
+// production case of the vllm-d cluster: every manual upgrade 504ed and armed
+// nothing, so hives there could never be upgraded from the hub.
+func TestHandleUpgradeHiveUnreachableClusterArmsHeartbeatFallback(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	mkUser(t, "alice")
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", ClusterID: "vllm-d"})
+	s := &HubServer{
+		hubSecret: testHubSecret,
+		logger:    slog.Default(),
+		clusters:  map[string]ClusterConfig{"vllm-d": {ID: "vllm-d"}},
+		// The unreachable cache is pre-populated, exactly as it is in
+		// production after the first failed kubectl: rolloutRestartHive skips
+		// kubectl entirely and reports non-delivery.
+		clusterUnreachableUntil: map[string]time.Time{"vllm-d": time.Now().Add(time.Hour)},
+	}
+	s.registry.Hives = []RegistryEntry{{ID: "h1", GitBranch: "v2"}}
+	seedLatestSHA(t, "v2", "abc1234")
+
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser("POST", "/up", "", "alice"), "id", "h1")
+	s.handleUpgradeHive(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("unreachable-cluster upgrade status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"mode":"heartbeat"`) {
+		t.Errorf("response should name the heartbeat mode, got %s", rec.Body.String())
+	}
+	s.mu.Lock()
+	armed := s.heartbeatUpgrade["h1"]
+	var latched bool
+	var target string
+	for i := range s.registry.Hives {
+		if s.registry.Hives[i].ID == "h1" {
+			latched = s.registry.Hives[i].Upgrading
+			target = s.registry.Hives[i].UpgradeTarget
+		}
+	}
+	s.mu.Unlock()
+	if armed != "abc1234" {
+		t.Errorf("heartbeat fallback armed with %q, want abc1234", armed)
+	}
+	if !latched || target != "abc1234" {
+		t.Errorf("registry not latched: upgrading=%v target=%q, want true/abc1234", latched, target)
+	}
+}
+
+// When kubectl cannot deliver AND no image-verified build target exists for
+// the branch, there is genuinely nothing a heartbeat could carry — that is the
+// one remaining hard-failure case, and it must say so rather than pretend.
+func TestHandleUpgradeHiveUnreachableClusterWithoutTargetFails(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	mkUser(t, "alice")
+	saveSaaSHive(&SaaSHive{ID: "h2", Owner: "alice", ClusterID: "vllm-d"})
+	s := &HubServer{
+		hubSecret:               testHubSecret,
+		logger:                  slog.Default(),
+		clusters:                map[string]ClusterConfig{"vllm-d": {ID: "vllm-d"}},
+		clusterUnreachableUntil: map[string]time.Time{"vllm-d": time.Now().Add(time.Hour)},
+	}
+	// The registry names a branch with NO cached SHA: no target can exist.
+	s.registry.Hives = []RegistryEntry{{ID: "h2", GitBranch: "branch-with-no-builds"}}
+
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser("POST", "/up", "", "alice"), "id", "h2")
+	s.handleUpgradeHive(rec, req)
+
+	if rec.Code != 502 {
+		t.Fatalf("no-target upgrade status = %d, want 502 (body=%s)", rec.Code, rec.Body.String())
+	}
+	s.mu.Lock()
+	_, armed := s.heartbeatUpgrade["h2"]
+	s.mu.Unlock()
+	if armed {
+		t.Error("heartbeat fallback must not be armed when there is no target SHA")
+	}
+}


### PR DESCRIPTION
Merge of `origin/v2` (ac4f52ed, 25 commits) into `dd`. Verified against a fresh `origin/v2` fetch — 0 behind at merge time.

Five files conflicted where dd's ConfigCoordinator/Visual-Hive rework met v2's newer changes; all resolved as unions:
- **deps.go / server.go / main.go (deps literal)** — kept dd's Integrated*/ConfigCoordinator/listener fields AND added v2's ResolveAppKeyFileFunc + Forge App inventory provider (#2459).
- **api_packs.go** — took v2's tombstone observability logging (#2439).
- **status_builder.go** — kept dd's cpuUsagePercent() helper (it already clamps to [0,100] and uses measured elapsed time, superseding v2's inline clamp).
- **main.go (config watcher)** — kept dd's DigestWatcher/coordinator flow and ported v2's #2439 removed-agent tombstone union into the coordinator Replace callback, so deleted agents cannot reappear on reload.

Touched files gofmt'd.

Merge with a merge commit (not squash) to keep the sync history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)