### PR TITLE
🐛 fix(spoke): resolve LiteLLM inference key from the same gateway as entitlement (no stale-key 401)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2315,12 +2315,36 @@ func main() {
 					if model == "" {
 						model = lc.DefaultModel
 					}
+					// Key source must MATCH the entitlement/probe path (gateways.go,
+					// cost.go, openrouter.go), which resolve the key from the gateway
+					// via ResolveGateway(backend).ResolveAPIKey(). When an EXPLICIT
+					// `gateways:` block names this backend, that gateway carries its
+					// own api_key_file (e.g. the key saved from the Model Gateways
+					// tab). Reading the legacy Governor.LiteLLM key file here instead
+					// would send a DIFFERENT (often stale) key than entitlement
+					// validated, causing inference 401s after a key rotation done via
+					// the Gateways tab. Resolve from the same gateway so inference and
+					// entitlement always agree on one key source.
+					//
+					// Only explicit gateways override: ResolvedGateways synthesizes an
+					// implicit "litellm" gateway from the legacy block when no
+					// `gateways:` are set, but that synthetic gateway lacks the
+					// multi-location file fallback of LiteLLMConfig.ResolveAPIKey
+					// (k8s Secret mount + PVC copy). For no-gateway hives we therefore
+					// keep the legacy resolver to preserve today's behavior.
+					apiKey := cfg.Governor.ResolveLiteLLMInferenceKey(backend)
+					caBundle := lc.CABundle
+					if len(cfg.Governor.Gateways) > 0 {
+						if gw := cfg.Governor.ResolveGateway(backend); gw != nil {
+							caBundle = gw.CABundle
+						}
+					}
 					githubProxy.SetInferenceRoute(agentName, &proxy.InferenceRoute{
 						Backend:  backend,
 						Endpoint: endpoint,
 						Model:    model,
-						APIKey:   lc.ResolveAPIKey(),
-						CABundle: lc.CABundle,
+						APIKey:   apiKey,
+						CABundle: caBundle,
 					})
 					return
 				}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -674,6 +674,35 @@ func (g GovernorConfig) ResolveGateway(name string) *GatewayConfig {
 	return nil
 }
 
+// ResolveLiteLLMInferenceKey resolves the API key an agent should present when
+// its inference routes through the legacy "litellm" backend. It MUST agree with
+// the key the entitlement/probe path validates (dashboard gateways.go/cost.go/
+// openrouter.go, which use ResolveGateway(name).ResolveAPIKey()) — otherwise a
+// key rotation performed via the Model Gateways tab updates only the gateway key
+// file, entitlement passes, but inference keeps sending the stale legacy key and
+// 401s.
+//
+// Resolution rule:
+//   - When an EXPLICIT `gateways:` block is configured, resolve the key from the
+//     gateway matching this backend (its own api_key_file — the file the Model
+//     Gateways tab writes), exactly as entitlement does. One source, no drift.
+//   - When NO explicit gateways are configured, fall back to the legacy
+//     Governor.LiteLLM resolver, which consults the k8s Secret mount and PVC copy
+//     in addition to api_key_file. The synthetic gateway from ResolvedGateways
+//     lacks that multi-location fallback, so we must not use it here — preserving
+//     today's behavior for classic single-`litellm:`-block hives.
+//
+// backend is the agent's backend name (typically "litellm"); it selects which
+// explicit gateway to consult.
+func (g GovernorConfig) ResolveLiteLLMInferenceKey(backend string) string {
+	if len(g.Gateways) > 0 {
+		if gw := g.ResolveGateway(backend); gw != nil {
+			return gw.ResolveAPIKey()
+		}
+	}
+	return g.LiteLLM.ResolveAPIKey()
+}
+
 // ResolveAPIKey returns this gateway's key value, preferring the env var when
 // set and falling back to the file. Returns "" when neither yields a value
 // (a keyless endpoint). Mirrors LiteLLMConfig key resolution.

--- a/v2/pkg/config/gateways_test.go
+++ b/v2/pkg/config/gateways_test.go
@@ -1,6 +1,82 @@
 package config
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Regression for the LiteLLM inference/entitlement split-brain (post-rotation
+// 401s): when an explicit `gateways:` block names a "litellm" gateway with its
+// OWN key file (the file the Model Gateways tab writes), inference must resolve
+// its key from THAT gateway — the same source the entitlement/probe path uses
+// (ResolveGateway(name).ResolveAPIKey()) — not from the legacy Governor.LiteLLM
+// key file. Before the fix, inference read the legacy file and sent a stale key
+// while entitlement validated the fresh gateway key, causing inference 401s.
+func TestResolveLiteLLMInferenceKeyMatchesEntitlement(t *testing.T) {
+	dir := t.TempDir()
+	// Key A: the fresh key saved via the Gateways tab (the gateway's file).
+	gatewayKeyFile := filepath.Join(dir, "gateway_litellm_api_key")
+	if err := os.WriteFile(gatewayKeyFile, []byte("sk-gateway-FRESH\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Key B: the stale legacy key (the classic litellm_api_key file).
+	legacyKeyFile := filepath.Join(dir, "litellm_api_key")
+	if err := os.WriteFile(legacyKeyFile, []byte("sk-legacy-STALE\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	g := GovernorConfig{
+		// Legacy block points at the STALE file B.
+		LiteLLM: LiteLLMConfig{
+			Endpoint:   "https://litellm.example.com",
+			APIKeyFile: legacyKeyFile,
+		},
+		// Explicit gateway named "litellm" points at the FRESH file A — this is
+		// what the entitlement/probe path resolves and validates.
+		Gateways: []GatewayConfig{
+			{Name: "litellm", Kind: GatewayKindLiteLLM, Endpoint: "https://litellm.example.com", APIKeyFile: gatewayKeyFile},
+		},
+	}
+
+	// Entitlement path (dashboard) resolves the gateway's key.
+	entitlementKey := g.ResolveGateway("litellm").ResolveAPIKey()
+	if entitlementKey != "sk-gateway-FRESH" {
+		t.Fatalf("entitlement key = %q, want the gateway's fresh key", entitlementKey)
+	}
+
+	// Inference path MUST resolve the same fresh key (fails before the fix,
+	// which returned the legacy stale key).
+	inferenceKey := g.ResolveLiteLLMInferenceKey("litellm")
+	if inferenceKey != entitlementKey {
+		t.Fatalf("inference key = %q, want %q (must match entitlement — one source, no split-brain)", inferenceKey, entitlementKey)
+	}
+	if inferenceKey == "sk-legacy-STALE" {
+		t.Fatal("inference resolved the STALE legacy key — the split-brain 401 bug is back")
+	}
+}
+
+// No-regression: a classic hive with only the legacy `litellm:` block (NO
+// explicit gateways:) must still resolve the inference key from the legacy
+// Governor.LiteLLM resolver, including its multi-location file fallback. The fix
+// must not change behavior for these hives.
+func TestResolveLiteLLMInferenceKeyLegacyFallback(t *testing.T) {
+	dir := t.TempDir()
+	legacyKeyFile := filepath.Join(dir, "litellm_api_key")
+	if err := os.WriteFile(legacyKeyFile, []byte("sk-legacy-ONLY\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	g := GovernorConfig{
+		LiteLLM: LiteLLMConfig{
+			Endpoint:   "https://litellm.example.com",
+			APIKeyFile: legacyKeyFile,
+		},
+		// No Gateways configured.
+	}
+	if got := g.ResolveLiteLLMInferenceKey("litellm"); got != "sk-legacy-ONLY" {
+		t.Fatalf("no-gateway hive: inference key = %q, want the legacy key %q", got, "sk-legacy-ONLY")
+	}
+}
 
 // A hive with only the legacy litellm block (no gateways:) must resolve to a
 // single implicit gateway named "litellm" so existing agents route unchanged.


### PR DESCRIPTION
## Problem

A hive's LiteLLM **inference** calls and its **entitlement / model-discovery / probe** checks resolved their API key from **different files**. A key rotation done via the **Model Gateways** dashboard tab updated only the gateway key file, so:

- **Entitlement / discovery / probe** (`pkg/dashboard/gateways.go`, `cost.go`, `openrouter.go`) resolve the key via `ResolveGateway(name).ResolveAPIKey()` — the **gateway** key file. Fresh key → **passes**.
- **Agent inference** (`cmd/hive/main.go` `setRoute` callback, `backend=="litellm"`) resolved the key from the **legacy** `Governor.LiteLLM` block via `LiteLLMConfig.ResolveAPIKey()` — a **different (legacy)** key file, untouched by the Gateways-tab save. Stale key → **inference 401**.

The gateway branch that would use the gateway key is short-circuited by `!IsInferenceBackend(backend)`, and `"litellm"` **is** an inference backend — so an explicitly-configured `litellm` gateway (with its own `api_key_file`) was never consulted for inference key resolution. Entitlement (gateway key) and inference (legacy key) diverged.

## Fix

Chose the **inference-side** fix (single read source is cleaner than duplicating writes on the save side). Added `GovernorConfig.ResolveLiteLLMInferenceKey(backend)`:

- When an **explicit** `gateways:` block is configured, resolve the inference key from the gateway matching the backend — **the same source entitlement uses** — so both agree on one key.
- When **no** explicit gateways are configured, fall back to the legacy `Governor.LiteLLM` resolver (which also consults the k8s Secret mount + PVC copy). The synthetic gateway from `ResolvedGateways` lacks that multi-location fallback, so classic single-`litellm:`-block hives keep today's exact behavior.

The `setRoute` callback now sources the litellm route's key (and CA bundle) from this helper. **vllm/llm-d and no-gateway hives are unchanged.**

## Regression test

`pkg/config/gateways_test.go`:
- `TestResolveLiteLLMInferenceKeyMatchesEntitlement`: explicit `litellm` gateway with a **fresh** key file A + legacy block with a **stale** key file B → asserts the inference key equals the entitlement (gateway) key A, not the stale legacy key. **Fails before the fix, passes after.**
- `TestResolveLiteLLMInferenceKeyLegacyFallback`: no-gateway hive still falls back to the legacy key (no regression).

## Validation

- `go build ./...` clean
- `go test ./cmd/hive/ ./pkg/config/ ./pkg/dashboard/ -short` all pass
- `gofmt -l` clean

## Operator note

This code fix does **not** repair an already-broken live hive on its own. For a live hive that already 401s after a Gateways-tab rotation, the operator must also either re-save the fresh key into the legacy LiteLLM tab **or** deploy this fix and trigger a config refresh so the inference route re-resolves from the gateway key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)