### PR TITLE
🔀 Top-up: sync mk with fresh v2 (aa1eab6e)

### DIFF
--- a/v2/pkg/agent/launch_failure_banner_test.go
+++ b/v2/pkg/agent/launch_failure_banner_test.go
@@ -1,0 +1,131 @@
+package agent
+
+// Tests for the loud-launch-failure fix: a launch that launchInTmux aborts
+// before typing anything (missing backend binary, bob with no API key) must
+// announce itself IN the agent's tmux pane instead of leaving a silent bare
+// shell. Observed live: a hosted hive's "quality" agent switched to backend
+// "bob" and restarted showed only an idle bash prompt in ttyd, with the only
+// explanation in the hive log.
+//
+// backendBinary resolves through exec.LookPath, so both branches are driven
+// deterministically here by pointing PATH at a temp dir: empty for the
+// missing-binary branch, containing a stub `bob` executable for the
+// missing-key branch. No tmux server is needed — the pane writes are
+// best-effort and the composed banner is recorded on the agent.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+func TestLaunchFailureBanner(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want []string
+	}{
+		{
+			name: "plain message is prefixed and single-quoted",
+			msg:  "backend bob did not launch",
+			want: []string{"echo '" + launchFailurePrefix + "backend bob did not launch'"},
+		},
+		{
+			name: "single quotes and newlines cannot break the quoting",
+			msg:  "it's broken\nsecond line",
+			want: []string{"echo '", "it s broken second line'"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := launchFailureBanner(tc.msg)
+			for _, w := range tc.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("launchFailureBanner(%q) = %q, want it to contain %q", tc.msg, got, w)
+				}
+			}
+			if strings.Count(got, "'") != 2 {
+				t.Errorf("launchFailureBanner(%q) = %q, want exactly the two wrapping single quotes", tc.msg, got)
+			}
+		})
+	}
+}
+
+// TestMissingBinaryLaunchAnnouncesInPane pins the loud half of the
+// missing-binary branch: the pane banner must name the attempted backend and
+// that its binary was not found, and the agent must be parked failed with the
+// reason surfaced to the dashboard via LastError.
+func TestMissingBinaryLaunchAnnouncesInPane(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // empty dir: no bob anywhere on PATH
+
+	m := &Manager{logger: discardLogger()}
+	m.SetBobAPIKeyResolver(func() string { return "key-present-but-irrelevant" })
+
+	agent := &AgentProcess{
+		Name:   "quality",
+		Config: config.AgentConfig{Backend: bobBackend},
+	}
+	if err := m.launchInTmux(t.Context(), agent); err != nil {
+		t.Fatalf("launchInTmux returned error, want nil so one agent never aborts the fleet: %v", err)
+	}
+	if agent.State != StateFailed {
+		t.Errorf("State = %q, want %q", agent.State, StateFailed)
+	}
+	banner := agent.lastLaunchFailureBanner
+	if banner == "" {
+		t.Fatal("lastLaunchFailureBanner is empty — the aborted launch left a silent bare shell, which is the exact bug this fix exists for")
+	}
+	for _, want := range []string{launchFailurePrefix, "bob", "not found", "hive image"} {
+		if !strings.Contains(banner, want) {
+			t.Errorf("banner %q does not contain %q", banner, want)
+		}
+	}
+	if agent.LastError == "" || !strings.Contains(agent.LastError, "not found") {
+		t.Errorf("LastError = %q, want the missing-binary reason so the dashboard can show it", agent.LastError)
+	}
+}
+
+// TestBobMissingKeyLaunchAnnouncesInPane pins the loud half of the missing-key
+// branch: with the bob binary present but no key configured, the pane banner
+// must name the missing credential (BOBSHELL_API_KEY — the name, never a
+// value) and where to save it.
+func TestBobMissingKeyLaunchAnnouncesInPane(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "bob")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("writing stub bob binary: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	m := &Manager{logger: discardLogger()}
+	m.SetBobAPIKeyResolver(func() string { return "" })
+
+	agent := &AgentProcess{
+		Name:   "quality",
+		Config: config.AgentConfig{Backend: bobBackend},
+	}
+	if err := m.launchInTmux(t.Context(), agent); err != nil {
+		t.Fatalf("launchInTmux returned error, want nil so one agent never aborts the fleet: %v", err)
+	}
+	if agent.State != StateFailed {
+		t.Errorf("State = %q, want %q", agent.State, StateFailed)
+	}
+	if !agent.awaitingBobKey {
+		t.Error("awaitingBobKey = false, want true — the key-save relaunch cannot find this agent without the marker")
+	}
+	banner := agent.lastLaunchFailureBanner
+	if banner == "" {
+		t.Fatal("lastLaunchFailureBanner is empty — the aborted launch left a silent bare shell, which is the exact bug this fix exists for")
+	}
+	for _, want := range []string{launchFailurePrefix, config.BobAPIKeyEnvVar, "API key", "Governor"} {
+		if !strings.Contains(banner, want) {
+			t.Errorf("banner %q does not contain %q", banner, want)
+		}
+	}
+	if agent.LastError == "" || !strings.Contains(agent.LastError, config.BobAPIKeyEnvVar) {
+		t.Errorf("LastError = %q, want the missing-key reason so the dashboard can show it", agent.LastError)
+	}
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -111,6 +111,17 @@ type AgentProcess struct {
 	// save would restart agents whose problem the key does not fix.
 	// Set only on the missing-key branch, cleared on every launch attempt.
 	awaitingBobKey bool
+
+	// lastLaunchFailureBanner is the exact in-pane shell line typed by the most
+	// recent aborted launch (see announceLaunchFailureInPane), "" after a
+	// successful launch. A launch aborted before send-keys used to leave a
+	// BARE interactive shell with the only explanation in the hive log — an
+	// operator attached via ttyd saw a silent prompt and nothing else
+	// (observed live: backend "bob" on a hive whose launch was refused). The
+	// pane itself is the production surface for the banner; this field exists
+	// so tests can assert the announcement actually happened without a tmux
+	// server.
+	lastLaunchFailureBanner string
 }
 
 // effectiveBackend returns the agent's backend accounting for any override.
@@ -955,7 +966,15 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	binary, err := backendBinary(backend)
 	if err != nil {
 		agent.State = StateFailed
+		agent.LastError = err.Error()
 		m.logger.Warn("backend binary not found", "name", agent.Name, "backend", backend, "error", err)
+		// The tmux session already exists (Start/Restart ran ensureTmuxSession
+		// before this), so without a banner the pane is a silent bare shell —
+		// the operator attaches and sees a prompt, not a failure. Say which
+		// binary was attempted, that it is missing, and what to do.
+		m.announceLaunchFailureInPane(agent, fmt.Sprintf(
+			"backend %s did not launch: %v. The CLI for this backend is not installed in this hive image — upgrade the hive image or switch this agent to a different backend.",
+			backend, err))
 		return nil
 	}
 
@@ -977,12 +996,20 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		if m.bobAPIKey() == "" {
 			agent.State = StateFailed
 			agent.awaitingBobKey = true
+			agent.LastError = "no bob API key configured (" + config.BobAPIKeyEnvVar + ")"
 			m.logger.Warn("bob requires "+config.BobAPIKeyEnvVar+" for headless operation; ask your hub admin to configure it",
 				"name", agent.Name,
 				"backend", backend,
 				"remedy", "set governor.bob.api_key_file (e.g. "+config.DefaultBobAPIKeyFile+
 					") or the "+config.DefaultBobAPIKeyEnv+" env var on the hive pod",
 			)
+			// Same silent-bare-shell hazard as the missing-binary branch above:
+			// the session exists, nothing was typed, and the log line is
+			// invisible from the terminal. Name the missing credential (never
+			// its value) and the remedy in the pane itself.
+			m.announceLaunchFailureInPane(agent, fmt.Sprintf(
+				"backend bob did not launch: no API key is configured (%s). Save an IBM bob API key in the dashboard under Governor -> Bob — parked bob agents relaunch automatically when a key is saved.",
+				config.BobAPIKeyEnvVar))
 			return nil
 		}
 		// Re-assert hive's ownership of the SHARED /data/home/.bob/settings.json
@@ -1170,6 +1197,8 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		m.logger.Info("CLI already running in tmux pane, skipping launch", "name", agent.Name, "session", agent.tmuxSession)
 		now := time.Now()
 		agent.State = StateRunning
+		agent.LastError = ""
+		agent.lastLaunchFailureBanner = ""
 		agent.StartedAt = &now
 
 		agentCtx, cancel := context.WithCancel(ctx)
@@ -1242,6 +1271,11 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 
 	now := time.Now()
 	agent.State = StateRunning
+	// A prior aborted launch is history the moment a real one succeeds; a
+	// stale "no API key" reason lingering after a key-save relaunch would
+	// send an operator chasing a problem that no longer exists.
+	agent.LastError = ""
+	agent.lastLaunchFailureBanner = ""
 	agent.StartedAt = &now
 	agent.launchGen++
 	m.logger.Info("audit: agent started",
@@ -2705,6 +2739,45 @@ func (m *Manager) deliverStartupKick(agent *AgentProcess, prompt string, gen int
 // tmuxSendLiteralForAgent sends text using the agent's tmux socket.
 func (m *Manager) tmuxSendLiteralForAgent(agent *AgentProcess, text string) {
 	_ = m.tmuxCmd(agent, "send-keys", "-t", agent.tmuxSession, "-l", text).Run()
+}
+
+// launchFailurePrefix opens every in-pane launch-failure banner so the line is
+// unmistakable in a pane full of shell prompts and greppable in scrollback.
+const launchFailurePrefix = "HIVE LAUNCH FAILED: "
+
+// launchFailureBanner composes the exact shell line typed into a pane when a
+// launch is aborted before any CLI starts. The message is wrapped in single
+// quotes; any single quotes, newlines, or carriage returns inside it are
+// replaced with spaces so the line can never break out of the quoting or
+// leave bash in PS2 continuation (the same hazard the C-c before every real
+// launch guards against).
+func launchFailureBanner(msg string) string {
+	sanitized := strings.Map(func(r rune) rune {
+		switch r {
+		case '\'', '\n', '\r':
+			return ' '
+		}
+		return r
+	}, msg)
+	return "echo '" + launchFailurePrefix + sanitized + "'"
+}
+
+// announceLaunchFailureInPane makes an aborted launch visible IN the agent's
+// tmux pane. launchInTmux's park-and-return branches (missing backend binary,
+// bob with no API key) run after ensureTmuxSession has already created a
+// fresh shell, so returning silently leaves a bare prompt: the operator
+// attaches via ttyd, sees nothing wrong, and the only explanation is in the
+// hive log they are not reading. Typing an echo into the pane puts the reason
+// and the remedy exactly where the operator is looking.
+//
+// Best-effort by design: the send-keys errors are ignored like every other
+// pane write on the launch path — a missing session must not turn a parked
+// agent into a crashed manager. Caller holds m.mu (same discipline as
+// launchInTmux, which is its only caller).
+func (m *Manager) announceLaunchFailureInPane(agent *AgentProcess, msg string) {
+	agent.lastLaunchFailureBanner = launchFailureBanner(msg)
+	m.tmuxSendLiteralForAgent(agent, agent.lastLaunchFailureBanner)
+	m.tmuxSendKeysForAgent(agent, "Enter")
 }
 
 // dismissInferencePrompts polls the tmux pane for Claude Code interactive

--- a/v2/pkg/hub/normalize_org_ghe_host_test.go
+++ b/v2/pkg/hub/normalize_org_ghe_host_test.go
@@ -1,0 +1,94 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestNormalizeOrgRef_GHEHostOnly is the regression for the claim-path bug that
+// produced two broken CLAIMED hives on the vllm-d (github.ibm.com) cluster:
+// pasting ONLY the GHE forge host into the "GitHub Organization" field captured
+// the HOSTNAME as the org (org="github.ibm.com"), dropping the real org and
+// minting a vanity URL from <host>-<repo>. A bare forge host with no path must
+// resolve to (host, "") so the caller rejects it, never (,"github.ibm.com").
+func TestNormalizeOrgRef_GHEHostOnly(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		wantHost string
+		wantOrg  string
+	}{
+		// The bug: a lone GHE/public host must NOT become the org.
+		{"ghe host bare", "github.ibm.com", "github.ibm.com", ""},
+		{"ghe host https", "https://github.ibm.com", "github.ibm.com", ""},
+		{"ghe host trailing slash", "https://github.ibm.com/", "github.ibm.com", ""},
+		{"public host bare", "github.com", "github.com", ""},
+		{"public host https", "https://github.com", "github.com", ""},
+		{"another ghe host", "github.cisco.com", "github.cisco.com", ""},
+
+		// Still-correct behaviour: a host WITH an org path splits normally.
+		{"ghe host with org", "https://github.ibm.com/z-aiops-unite", "github.ibm.com", "z-aiops-unite"},
+		{"ghe host with org no scheme", "github.ibm.com/z-aiops-unite", "github.ibm.com", "z-aiops-unite"},
+
+		// A bare org name (even one containing a dot) is untouched — the fix keys
+		// on the "github." forge prefix, so a real org is never reclassified.
+		{"bare org", "z-aiops-unite", "", "z-aiops-unite"},
+		{"bare org with dot", "my.org", "", "my.org"},
+		{"empty", "", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			host, org := normalizeOrgRef(tc.in)
+			if host != tc.wantHost || org != tc.wantOrg {
+				t.Fatalf("normalizeOrgRef(%q) = (%q, %q); want (%q, %q)",
+					tc.in, host, org, tc.wantHost, tc.wantOrg)
+			}
+		})
+	}
+}
+
+// TestAssignHive_RejectsBareGHEHostAsOrg is the end-to-end regression for the
+// exact path that produced hosted-available-vllmd-02 / -09: an admin (or the
+// claim UI) submits a bare GHE forge host in the org field. The assign handler
+// must 400 — never store the hostname as the org. Before the fix, isValidName
+// accepted "github.ibm.com" (dots are legal in names), so the host was silently
+// stored as the org and the hive was claimed against host-as-org.
+func TestAssignHive_RejectsBareGHEHostAsOrg(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+	s := newHandlerHub2()
+
+	for _, orgField := range []string{"github.ibm.com", "https://github.ibm.com", "https://github.ibm.com/"} {
+		saveSaaSHive(&SaaSHive{ID: "ph-hostorg", Owner: hubAdminUsername, Status: statusAvailable, ClusterID: "hive-oke"})
+		body := `{"owner":"bob","org":"` + orgField + `","repos":"forthehive","primary_repo":"forthehive"}`
+		rec := httptest.NewRecorder()
+		req := setPathValue(reqWithUser(http.MethodPost, "/assign", body, hubAdminUsername), "id", "ph-hostorg")
+		s.handleAssignHive(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("assign with org=%q status = %d, want 400 (body=%s)", orgField, rec.Code, rec.Body.String())
+		}
+		// And it must NOT have persisted the host as the org.
+		if got := loadSaaSHive("ph-hostorg"); got != nil && got.Org == "github.ibm.com" {
+			t.Fatalf("assign with org=%q stored the host as the org: %q", orgField, got.Org)
+		}
+	}
+
+	// A proper GHE org URL still assigns cleanly and records the real org + host.
+	saveSaaSHive(&SaaSHive{ID: "ph-realorg", Owner: hubAdminUsername, Status: statusAvailable, ClusterID: "hive-oke"})
+	body := `{"owner":"bob","org":"https://github.ibm.com/z-aiops-unite","repos":"forthehive","primary_repo":"forthehive"}`
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/assign", body, hubAdminUsername), "id", "ph-realorg")
+	s.handleAssignHive(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("assign with real GHE org URL status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	got := loadSaaSHive("ph-realorg")
+	if got == nil || got.Org != "z-aiops-unite" {
+		t.Fatalf("real GHE org not parsed from URL: %+v", got)
+	}
+	if got.GitHubHost != "github.ibm.com" {
+		t.Errorf("GHE host not recorded from org URL: GitHubHost = %q, want github.ibm.com", got.GitHubHost)
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -6304,10 +6304,15 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Accept a pasted org/repo URL here too — an admin assigning a hive reaches
-	// for the same paste the requester did.
-	if h, o := normalizeOrgRef(body.Org); o != "" {
-		body.Org = o
-		if h != "" && body.GitHubHost == "" {
+	// for the same paste the requester did. normalizeOrgRef returns a non-empty
+	// host with an EMPTY org when the field held only a forge host
+	// ("github.ibm.com") and no org — clear body.Org in that case so the
+	// isValidName check below rejects it, instead of the raw hostname (which
+	// isValidName accepts, dots and all) silently becoming the org. That
+	// host-as-org bug produced the two broken github.ibm.com claims on vllm-d.
+	if h, o := normalizeOrgRef(body.Org); h != "" {
+		body.Org = o // may be "" for a bare-host paste — rejected just below
+		if body.GitHubHost == "" {
 			body.GitHubHost = h
 		}
 	}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -394,6 +394,18 @@ func normalizeForgeHost(s string) (string, bool) {
 //	https://github.ibm.com/z-aiops-unite  -> ("github.ibm.com", "z-aiops-unite")
 //	github.ibm.com/z-aiops-unite          -> ("github.ibm.com", "z-aiops-unite")
 //	z-aiops-unite                         -> ("",               "z-aiops-unite")
+//	https://github.ibm.com                -> ("github.ibm.com", "")
+//	github.ibm.com                        -> ("github.ibm.com", "")
+//
+// The last two cases are the claim-path footgun this guards: a user who reads
+// "GitHub Organization" and pastes ONLY the forge host (no org segment) must
+// NOT have that hostname captured as the org. Before this, "github.ibm.com"
+// with no path fell through to the bare-name return and became org
+// "github.ibm.com" — the hive was then claimed against host-as-org, its vanity
+// URL minted from <host>-<repo>, and agents targeted github.ibm.com/<repo>.
+// Returning ("host", "") instead leaves the org empty, so the caller's
+// isValidName("") check rejects the paste with the "use the org name or its
+// URL" message rather than silently storing a broken project.
 func normalizeOrgRef(s string) (host, org string) {
 	s = strings.TrimSpace(s)
 	s = strings.TrimPrefix(s, "https://")
@@ -409,7 +421,33 @@ func normalizeOrgRef(s string) (host, org string) {
 	if len(parts) > 1 && strings.Contains(parts[0], ".") {
 		return parts[0], parts[1]
 	}
+	// A lone segment with no path that is itself a GitHub forge host is a host,
+	// not an org — the user pasted the forge URL into the org field and left the
+	// real org out. Recognise "github.<something>" (github.com, github.ibm.com,
+	// github.cisco.com, …) so the hostname is never mistaken for the org. A
+	// legitimate org that merely contains a dot ("my.org") does not start with
+	// "github." and is untouched.
+	if len(parts) == 1 && looksLikeGitHubForgeHost(parts[0]) {
+		return parts[0], ""
+	}
 	return "", parts[0]
+}
+
+// looksLikeGitHubForgeHost reports whether a bare label is a GitHub forge
+// hostname (github.com or a GitHub Enterprise host like github.ibm.com) rather
+// than an org name. GitHub Enterprise hosts are conventionally "github.<org
+// domain>", and the public host is "github.com"; both start with "github." and
+// carry at least two dot-separated labels. This is deliberately narrow: it must
+// never reclassify a real org that happens to contain a dot, so it keys on the
+// "github." prefix that only a forge host carries. Case-insensitive.
+func looksLikeGitHubForgeHost(label string) bool {
+	l := strings.ToLower(strings.TrimSpace(label))
+	if !strings.HasPrefix(l, "github.") {
+		return false
+	}
+	// "github." alone (a trailing-dot typo) is not a host; require a non-empty
+	// domain after the prefix, i.e. at least two labels total.
+	return len(strings.Split(l, ".")) >= minForgeHostLabels && !strings.HasSuffix(l, ".")
 }
 
 // normalizeRepoRef strips a GitHub URL or "org/repo" prefix down to the bare


### PR DESCRIPTION
Top-up merge — v2 gained 2 commits (#2481, #2482) while the previous sync PRs were in CI. Brings `mk` to 0 behind `origin/v2` (aa1eab6e).

Clean merge — no conflicts.

Merge with a merge commit (not squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)