### PR TITLE
✨ feat(hub): drift pills own the search box; Usage card above attention strip

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -7298,11 +7298,14 @@ const dashboardHTML = `<!DOCTYPE html>
       <div id="past-requests-body" style="display:none;overflow-x:auto"><div id="admin-request-history"></div></div>
     </div>
 
+    <!-- Usage renders ABOVE the attention strip on purpose: the strip's drift
+         pills filter the hive list, so the strip and the list it narrows must
+         sit directly adjacent with no unrelated card between them. -->
+    <div id="usage-panel" style="display:none;margin-bottom:24px"></div>
     <div id="hive-drift-summary" style="display:none"></div>
     <div id="fleet-alerts-panel" style="display:none"></div>
     <div id="hive-view-bar" style="display:none"></div>
     <div id="hive-filter-bar" style="display:none"></div>
-    <div id="usage-panel" style="display:none;margin-bottom:24px"></div>
     <div id="bulk-action-bar" style="display:none"></div>
     <div class="hive-layout">
       <div class="facet-shell" id="hive-facet-shell">
@@ -8668,6 +8671,14 @@ const dashboardHTML = `<!DOCTYPE html>
        states", this answers "which specific misconfiguration". */
     var _dashDriftFilter = '';
 
+    /* Search text stashed away while a drift pill is selected, or null when no
+       stash is held. Clicking a pill clears the search box (a stale search
+       silently intersecting with the pill filter reads as hives having
+       disappeared) but remembers what was typed; deselecting the last pill
+       restores it. Typing WHILE a pill is active drops the stash — the new
+       text is what the user wants and must survive deselection. */
+    var _driftSearchStash = null;
+
     /* hiveMatchesDriftFilter answers whether a hive carries the selected drift
        kind. Guarded so a row with no drift report never throws. */
     function hiveMatchesDriftFilter(h) {
@@ -9257,6 +9268,9 @@ const dashboardHTML = `<!DOCTYPE html>
       _dashStatusFilters = {};
       _dashFailingCheckFilter = '';
       _dashDriftFilter = '';
+      /* Everything is being cleared, search included — a search stashed at
+         drift-pill-selection time must not come back later. */
+      _driftSearchStash = null;
       _dashUpgradeFilter = '';
       _dashAdvisoryStaleFilter = false;
       _alertTypeFilter = '';
@@ -9670,6 +9684,10 @@ const dashboardHTML = `<!DOCTYPE html>
       var el = document.getElementById('hive-search');
       var next = el ? el.value : '';
       if (_hiveSearchTimer) clearTimeout(_hiveSearchTimer);
+      /* Typing while a drift pill is active supersedes the search stashed at
+         pill-selection time: drop the stash immediately (not in the debounce)
+         so a quick type-then-deselect cannot resurrect the old text. */
+      if (_dashDriftFilter) _driftSearchStash = null;
       _hiveSearchTimer = setTimeout(function() {
         _dashSearchQuery = next;
         renderHives(_allDashHives, true);
@@ -9680,6 +9698,9 @@ const dashboardHTML = `<!DOCTYPE html>
       var el = document.getElementById('hive-search');
       if (el) el.value = '';
       _dashSearchQuery = '';
+      /* An explicit Clear is a statement the user wants NO search — do not
+         resurrect a stashed one when the drift pills are later deselected. */
+      _driftSearchStash = null;
       renderHives(_allDashHives, true);
     }
 
@@ -10169,6 +10190,9 @@ const dashboardHTML = `<!DOCTYPE html>
          button look broken. */
       _dashFailingCheckFilter = '';
       _dashDriftFilter = '';
+      /* The drift filter is being force-cleared without going through
+         toggleDriftFilter, so drop any stashed search with it. */
+      _driftSearchStash = null;
       _dashUpgradeFilter = '';
       _dashAdvisoryStaleFilter = false;
       renderHives(_allDashHives, true);
@@ -10189,9 +10213,32 @@ const dashboardHTML = `<!DOCTYPE html>
     }
 
     /* toggleDriftFilter selects (or deselects) one drift kind in the fleet
-       exceptions summary. */
+       exceptions summary.
+
+       Pill selection also owns the search box: selecting the first pill
+       stashes and clears the search (so a stale search cannot silently
+       intersect with the pill filter), switching between pills keeps the
+       stash, and deselecting the last pill restores the stashed text —
+       unless the user typed a new search while a pill was active, in which
+       case the stash was dropped and their new text wins. */
     function toggleDriftFilter(kind) {
+      var prev = _dashDriftFilter;
       _dashDriftFilter = (_dashDriftFilter === kind) ? '' : kind;
+      var searchEl = document.getElementById('hive-search');
+      if (!prev && _dashDriftFilter) {
+        /* First pill selected: stash the search and clear it. */
+        _driftSearchStash = _dashSearchQuery;
+        _dashSearchQuery = '';
+        if (searchEl) searchEl.value = '';
+      } else if (prev && !_dashDriftFilter) {
+        /* Last pill deselected: restore the stashed search, if it is still
+           ours to restore. */
+        if (_driftSearchStash !== null) {
+          _dashSearchQuery = _driftSearchStash;
+          if (searchEl) searchEl.value = _dashSearchQuery;
+        }
+        _driftSearchStash = null;
+      }
       renderHives(_allDashHives, true);
     }
 

--- a/v2/pkg/hub/saas_dashboard_attention_ux_test.go
+++ b/v2/pkg/hub/saas_dashboard_attention_ux_test.go
@@ -1,0 +1,106 @@
+package hub
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// jsFunctionBody extracts the source of one top-level inline-script function
+// from dashboardHTML, from its declaration to the next top-level declaration.
+// Good enough for presence assertions on what a handler does.
+func jsFunctionBody(t *testing.T, name string) string {
+	t.Helper()
+	decl := "function " + name + "("
+	start := strings.Index(dashboardHTML, decl)
+	if start < 0 {
+		t.Fatalf("function %s not found in dashboardHTML", name)
+	}
+	rest := dashboardHTML[start+len(decl):]
+	// Next top-level declaration (column-4 indent) ends the slice.
+	next := regexp.MustCompile(`(?m)^ {4}(function |var )`).FindStringIndex(rest)
+	if next == nil {
+		return rest
+	}
+	return rest[:next[0]]
+}
+
+// Clicking a drift pill must CLEAR the hive search (a stale search silently
+// intersecting with the pill filter reads as hives having disappeared), stash
+// what was typed, and restore it when the last pill is deselected — unless the
+// user typed a new search while a pill was active, in which case the new text
+// wins.
+func TestDriftPillClearsAndStashesSearch(t *testing.T) {
+	// The stash must be top-level render state, like the other filter state.
+	if !regexp.MustCompile(`(?m)^ {4}var _driftSearchStash\b`).MatchString(dashboardHTML) {
+		t.Fatal("var _driftSearchStash is not declared at top level of the inline script")
+	}
+
+	body := jsFunctionBody(t, "toggleDriftFilter")
+	for _, want := range []struct{ snippet, why string }{
+		{"_driftSearchStash = _dashSearchQuery;",
+			"first pill selection must stash the current search text"},
+		{"_dashSearchQuery = '';",
+			"pill selection must clear the search filter state"},
+		{"searchEl.value = '';",
+			"pill selection must blank the visible search input, not just the state"},
+		{"_dashSearchQuery = _driftSearchStash;",
+			"deselecting the last pill must restore the stashed search"},
+		{"_driftSearchStash = null;",
+			"deselecting the last pill must drop the stash after restoring"},
+	} {
+		if !strings.Contains(body, want.snippet) {
+			t.Errorf("toggleDriftFilter is missing %q — %s", want.snippet, want.why)
+		}
+	}
+}
+
+// Typing a new search while a drift pill is active supersedes the stashed
+// text: the stash is dropped so deselecting the pill cannot clobber what the
+// user just typed.
+func TestSearchInputWhilePillActiveDropsStash(t *testing.T) {
+	body := jsFunctionBody(t, "onHiveSearchInput")
+	if !strings.Contains(body, "if (_dashDriftFilter) _driftSearchStash = null;") {
+		t.Error("onHiveSearchInput must drop _driftSearchStash while a drift pill " +
+			"is active, so new text typed by the user survives pill deselection")
+	}
+}
+
+// The clear-everything paths bypass toggleDriftFilter when resetting the drift
+// filter, so they must drop the stash themselves — otherwise a search cleared
+// by "Clear filters" could silently come back later.
+func TestClearFilterPathsDropSearchStash(t *testing.T) {
+	for _, fn := range []string{"clearAllHiveFilters", "clearStatusFilters", "clearHiveSearch"} {
+		body := jsFunctionBody(t, fn)
+		if !strings.Contains(body, "_driftSearchStash = null;") {
+			t.Errorf("%s must drop _driftSearchStash", fn)
+		}
+	}
+}
+
+// The Usage card must render ABOVE the "N hives need attention" strip, so the
+// strip's drift pills sit directly adjacent to the hive list they filter, with
+// the alerts panel and the view bar between the strip and the list only.
+func TestUsagePanelRendersAboveAttentionStrip(t *testing.T) {
+	ids := []string{
+		`<div id="usage-panel"`,
+		`<div id="hive-drift-summary"`,
+		`<div id="fleet-alerts-panel"`,
+		`<div id="hive-view-bar"`,
+		`<div id="hive-filter-bar"`,
+	}
+	prev := -1
+	prevID := ""
+	for _, id := range ids {
+		idx := strings.Index(dashboardHTML, id)
+		if idx < 0 {
+			t.Fatalf("%s not found in dashboardHTML", id)
+		}
+		if idx <= prev {
+			t.Errorf("%s (offset %d) must appear after %s (offset %d) in dashboardHTML",
+				id, idx, prevID, prev)
+		}
+		prev = idx
+		prevID = id
+	}
+}


### PR DESCRIPTION
## Summary

Two hub-dashboard UX changes, both in the `dashboardHTML` inline script/markup in `v2/pkg/hub/saas.go` (task #43).

### 1. Drift pills clear (and later restore) the search filter
Previously a stale search string silently intersected with the "N hives need attention" pill filtering — clicking a pill could show fewer hives than the pill count promised, with no visible reason. Now:
- Selecting the first pill **stashes** the current search text, clears the search state, and blanks the input box.
- Switching between pills keeps the stash; the search stays cleared while any pill is selected.
- Deselecting the last pill **restores** the stashed search text (state + input box).
- Typing a new search while a pill is active **drops the stash** immediately — the new text wins and survives pill deselection.
- The clear-everything paths (`clearAllHiveFilters`, `clearStatusFilters`, `clearHiveSearch`) drop the stash too, since they reset the drift filter without going through `toggleDriftFilter`.

### 2. Usage card moved above the attention strip
Section order is now: Past Requests → **Usage** → attention strip → attention-needed alerts → GROUP BY/view bar → hive list — so the attention strip and the hive list its pills filter sit directly adjacent. Pure static-markup reorder; all JS addresses these sections by `getElementById` and the dynamic banners insert relative to `hives-container`, so nothing depended on the old order. No CSS sibling selectors involved.

## Tests
New `pkg/hub/saas_dashboard_attention_ux_test.go` pins both behaviors (stash/clear/restore snippets inside the handlers; markup-order assertion). Mutation-checked: removing the search-clear on pill select fails `TestDriftPillClearsAndStashesSearch`; swapping the section order back fails `TestUsagePanelRendersAboveAttentionStrip`. Full `go test ./pkg/hub/` green locally.