### PR TITLE
🐛 fix(spoke): re-anchor agent-click scroll while late renders shift layout

### DIFF
--- a/v2/pkg/dashboard/agent_scroll_anchor_test.go
+++ b/v2/pkg/dashboard/agent_scroll_anchor_test.go
@@ -1,0 +1,66 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// These tests pin the STRUCTURE of the agent-click scroll anchoring in the
+// embedded static/index.html. The scroll logic itself is pure browser JS
+// (requestAnimationFrame, scrollTo, live DOM rects) and cannot be executed
+// here — what these tests honestly guarantee is only that the settle helper,
+// its user-input cancellation, and its call sites survive future edits to the
+// file. Behavior (no jump-fighting, correct final anchor) is manual-verify.
+
+// TestAgentScrollSettleHelperPresent asserts the settle helper and its named
+// constants exist. Losing any of these regresses #45: clicks land the scroll
+// on stale coordinates whenever content renders after the click.
+func TestAgentScrollSettleHelperPresent(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		"function ocScrollToAgentDetail(behavior)",
+		"const OC_SCROLL_SETTLE_MS = 700;",
+		"const OC_SCROLL_TOLERANCE_PX = 4;",
+		"const OC_SCROLL_CANCEL_EVENTS = ['wheel', 'touchstart', 'mousedown', 'keydown'];",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing %q — agent-click scroll settle logic regressed", snippet)
+		}
+	}
+}
+
+// TestAgentScrollSettleCancelsOnUserInput asserts the correction loop is
+// cancellable by user scroll input and that the cancel listeners are passive.
+// Without this, the settle loop would fight a user who scrolls right after
+// clicking an agent — the one failure mode the feature must never have.
+func TestAgentScrollSettleCancelsOnUserInput(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		"OC_SCROLL_CANCEL_EVENTS.forEach(t => window.addEventListener(t, cancel, { passive: true }));",
+		"OC_SCROLL_CANCEL_EVENTS.forEach(t => window.removeEventListener(t, cancel));",
+		"if (performance.now() > deadline) { cancel(); return; }",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing %q — settle loop lost its user-input cancellation or its hard time cap", snippet)
+		}
+	}
+}
+
+// TestAgentScrollCallSitesUseHelper asserts both scroll-to-agent paths route
+// through the settle helper instead of a raw one-shot scrollTo: the click path
+// (smooth) and the hash-restore path on first load (instant).
+func TestAgentScrollCallSitesUseHelper(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		"ocScrollToAgentDetail('smooth');",
+		"ocScrollToAgentDetail('instant');",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing %q — a scroll-to-agent call site bypasses the settle helper", snippet)
+		}
+	}
+	// The click path must not have kept a competing raw scroll to the panel.
+	if strings.Count(html, "detail.getBoundingClientRect().top + window.scrollY - OC_TOPBAR_HEIGHT") != 1 {
+		t.Error("expected exactly one raw detail-panel Y computation (inside ocScrollToAgentDetail); a call site regrew its own scrollTo")
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3453,6 +3453,57 @@
       });
     }
 
+    // ---- Agent-detail scroll anchoring ------------------------------------
+    // Clicking an agent scrolls to the detail panel, but content that renders
+    // AFTER the click shifts the layout out from under the in-flight scroll:
+    // the 3s status poll re-renders every section above the panel (agents,
+    // repos, gov strip), and ocFetchPane lands async pane content. The scroll
+    // then finishes at a stale Y and the view is anchored on the wrong thing.
+    // ocScrollToAgentDetail() re-anchors for a short settle window: on each
+    // animation frame it recomputes the panel's target Y and, if layout drift
+    // moved it beyond a small tolerance, retargets the scroll (scrollTo with
+    // the same behavior redirects the in-flight smooth scroll — no visible
+    // restart). The window is hard-capped, and ANY user scroll input (wheel,
+    // touch, scrollbar mousedown, keys) cancels correction immediately so
+    // manual scrolling right after a click is never hijacked.
+    const OC_SCROLL_SETTLE_MS = 700;   // correction window after a click; capped so late shifts never fight the user
+    const OC_SCROLL_TOLERANCE_PX = 4;  // re-anchor only when the target drifted beyond this
+    const OC_SCROLL_CANCEL_EVENTS = ['wheel', 'touchstart', 'mousedown', 'keydown'];
+    let _ocScrollSettleCancel = null;
+
+    function ocScrollToAgentDetail(behavior) {
+      const detail = document.getElementById('oc-agent-detail');
+      if (!detail) return;
+      if (_ocScrollSettleCancel) _ocScrollSettleCancel();
+      const mode = behavior || 'smooth';
+      const targetY = () => Math.max(0, detail.getBoundingClientRect().top + window.scrollY - OC_TOPBAR_HEIGHT);
+      let lastTarget = targetY();
+      window.scrollTo({ top: lastTarget, behavior: mode });
+      let cancelled = false;
+      const cancel = () => {
+        if (cancelled) return;
+        cancelled = true;
+        OC_SCROLL_CANCEL_EVENTS.forEach(t => window.removeEventListener(t, cancel));
+        if (_ocScrollSettleCancel === cancel) _ocScrollSettleCancel = null;
+      };
+      // Passive listeners: cancellation must never delay the user's own
+      // scrolling. Programmatic scrolls fire none of these events, so the
+      // settle loop cannot cancel itself.
+      OC_SCROLL_CANCEL_EVENTS.forEach(t => window.addEventListener(t, cancel, { passive: true }));
+      _ocScrollSettleCancel = cancel;
+      const deadline = performance.now() + OC_SCROLL_SETTLE_MS;
+      (function settle() {
+        if (cancelled) return;
+        const want = targetY();
+        if (Math.abs(want - lastTarget) > OC_SCROLL_TOLERANCE_PX) {
+          lastTarget = want;
+          window.scrollTo({ top: want, behavior: mode });
+        }
+        if (performance.now() > deadline) { cancel(); return; }
+        requestAnimationFrame(settle);
+      })();
+    }
+
     function ocSelectAgent(name) {
       _ocSelectedAgent = name;
       history.replaceState(null, '', name ? '#' + name : location.pathname);
@@ -3462,11 +3513,7 @@
       ocRenderAgentDetail();
       ocUpdateFocusedState();
       if (name) { ocStartPanePoll(); } else { ocStopPanePoll(); }
-      const detail = document.getElementById('oc-agent-detail');
-      if (detail) {
-        const y = detail.getBoundingClientRect().top + window.scrollY - OC_TOPBAR_HEIGHT;
-        window.scrollTo({ top: y, behavior: 'smooth' });
-      }
+      ocScrollToAgentDetail('smooth');
     }
 
     function ocFormatSummary(raw) {
@@ -10750,8 +10797,10 @@ function burnAreaChart() {
             const detail = document.getElementById('oc-agent-detail');
             if (detail) {
               detail.classList.add('active');
-              const y = detail.getBoundingClientRect().top + window.scrollY - OC_TOPBAR_HEIGHT;
-              window.scrollTo({ top: y, behavior: 'instant' });
+              // Instant behavior (no animation on load), but still routed
+              // through the settle loop: first-load layout shifts the most
+              // (deferred sections, images, async fetches all land late).
+              ocScrollToAgentDetail('instant');
             }
           });
         } else {


### PR DESCRIPTION
## Problem (task #45)

On the spoke dashboard, clicking an agent in the left menu scrolls to that agent's detail panel — but the target Y is computed once, at click time. Components that render **after** the click shift the layout while (or after) the smooth scroll animates, so the view lands anchored on the wrong content:

- the 3s status poll rebuilds every section above the panel (`renderAgents`, `renderRepos`, gov strip, badges)
- `ocFetchPane` lands async pane content into the panel
- on first load (hash restore), deferred sections and images all render late — the worst case

## Fix

New `ocScrollToAgentDetail(behavior)` helper; both scroll-to-agent paths route through it (click → `'smooth'`, hash-restore on load → `'instant'`):

- issues the initial scroll immediately (click stays responsive)
- then a settle loop on `requestAnimationFrame`: recomputes the panel's target Y each frame; if layout drift moved it beyond a 4px tolerance, retargets via `scrollTo` with the same behavior — the browser redirects the in-flight smooth scroll, no visible restart or jump-fighting
- hard-capped at 700ms (`OC_SCROLL_SETTLE_MS`)
- **any user scroll input cancels correction instantly**: passive `wheel` / `touchstart` / `mousedown` (scrollbar drag) / `keydown` listeners — manual scrolling right after a click is never hijacked; programmatic scrolls fire none of these, so the loop cannot cancel itself
- a new click cancels the previous settle loop before starting its own

## Tests

`pkg/dashboard/agent_scroll_anchor_test.go` pins the structure: helper + named constants present, user-input cancellation + time cap present, both call sites use the helper (and no competing raw scrollTo to the panel remains). The runtime timing behavior is pure browser JS and is honestly documented as manual-verify.

- `go build ./...` ✅
- `go test ./pkg/dashboard/ -count=1` ✅ (full suite)
