### PR TITLE
🐛 fix(spoke): auto-remediate non-writable bob state dirs (chmod 770) instead of only warning

### DIFF
--- a/v2/pkg/agent/permissions_bobstate_test.go
+++ b/v2/pkg/agent/permissions_bobstate_test.go
@@ -1,0 +1,205 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// bobStateStartMode is the exact production-observed starting mode for a broken
+// bob state dir: owner rwx, group r-x, other r-x (0755). The group lacks write,
+// so bob — which reaches the dir as an agent UID through the node group — cannot
+// persist settings or initialize its logger and runs degraded.
+const bobStateStartMode os.FileMode = 0o755
+
+// bobStateWantMode is the mode after remediation: the group must have gained
+// r/w/x, bringing the dir to at least 0770. Owner and other bits are preserved.
+const bobStateWantMode os.FileMode = 0o775
+
+// mkBobStateDir creates a `.bob` directory pinned to a given mode (Mkdir is
+// umask-filtered, so the mode is re-applied explicitly).
+func mkBobStateDir(t *testing.T, parent string, mode os.FileMode) string {
+	t.Helper()
+	dir := filepath.Join(parent, bobStateDirBase)
+	if err := os.Mkdir(dir, mode); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.Chmod(dir, mode); err != nil {
+		t.Fatalf("chmod %s: %v", dir, err)
+	}
+	return dir
+}
+
+// TestFixBobStateDirGroupWriteAddsGroupBits is the core fail-before/pass-after:
+// a .bob dir created 0755 (no group write) must come back group-writable so an
+// agent UID in the node group can persist bob's state.
+func TestFixBobStateDirGroupWriteAddsGroupBits(t *testing.T) {
+	dir := mkBobStateDir(t, t.TempDir(), bobStateStartMode)
+
+	// Precondition: the group genuinely lacks write before remediation, so the
+	// assertion below is meaningful (fail-before).
+	if before := statMode(t, dir); before&bobStateDirGroupRWX == bobStateDirGroupRWX {
+		t.Fatalf("precondition: %s already group-rwx at %v; test asserts nothing", dir, before)
+	}
+
+	fi, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	fixBobStateDirGroupWrite(dir, fi.Mode(), quietLogger())
+
+	got := statMode(t, dir)
+	if got&bobStateDirGroupRWX != bobStateDirGroupRWX {
+		t.Errorf("mode = %v, want group r/w/x (%v) set so an agent UID can write", got, bobStateDirGroupRWX)
+	}
+	if got != bobStateWantMode {
+		t.Errorf("mode = %v, want exactly %v (only group bits added, owner/other preserved)", got, bobStateWantMode)
+	}
+	if got&bobStateGroupWriteBit == 0 {
+		t.Errorf("mode = %v, want the group write bit that lets bob save settings", got)
+	}
+}
+
+// TestFixBobStateDirGroupWriteIsIdempotent pins that an already-group-writable
+// dir is left byte-identical: the watcher must not churn a healthy dir every
+// tick, and must never narrow a dir that has MORE than the required bits.
+func TestFixBobStateDirGroupWriteIsIdempotent(t *testing.T) {
+	for _, mode := range []os.FileMode{0o770, 0o775, 0o777} {
+		dir := mkBobStateDir(t, t.TempDir(), mode)
+
+		fi, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		fixBobStateDirGroupWrite(dir, fi.Mode(), quietLogger())
+
+		if got := statMode(t, dir); got != mode {
+			t.Errorf("mode = %v, want it unchanged at %v: an already-group-writable dir must not be touched", got, mode)
+		}
+	}
+}
+
+// TestFixBobStateDirGroupWriteHandlesChmodFailure covers the EPERM arm: when the
+// chmod cannot be performed the function must log and return, never panic. We
+// force the failure by pointing at a path inside a read-only parent (the child
+// dir's mode cannot be changed once its parent denies write to a non-owner path
+// on most systems); more portably, we remove the dir out from under the call so
+// chmod hits ENOENT. Either way the contract is: no panic, mode untouched.
+func TestFixBobStateDirGroupWriteHandlesChmodFailure(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, bobStateDirBase)
+
+	// Capture a FileInfo for a dir that no longer exists, so the chmod inside
+	// the function fails with ENOENT — exercising the error path without
+	// requiring elevated privileges to manufacture an EPERM.
+	if err := os.Mkdir(dir, bobStateStartMode); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	fi, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if err := os.Remove(dir); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	// Must not panic; must return cleanly after logging.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("fixBobStateDirGroupWrite panicked on chmod failure: %v", r)
+		}
+	}()
+	fixBobStateDirGroupWrite(dir, fi.Mode(), quietLogger())
+
+	// The dir stays gone — the function did not recreate or otherwise mutate.
+	if _, statErr := os.Stat(dir); !os.IsNotExist(statErr) {
+		t.Errorf("expected %s to remain absent after a failed chmod, stat err = %v", dir, statErr)
+	}
+}
+
+// TestFixEntryRemediatesBobStateDir proves the wiring: fixEntry, the per-entry
+// callback the walk invokes, recognizes a .bob directory by name and widens it
+// even though the general owner guard would otherwise skip a non-DevUID dir.
+// The test process owns the temp dir, so the chmod is permitted here.
+func TestFixEntryRemediatesBobStateDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX mode bits are not meaningful on Windows")
+	}
+	dir := mkBobStateDir(t, t.TempDir(), bobStateStartMode)
+
+	fi, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	fixEntry(dir, fi, quietLogger())
+
+	if got := statMode(t, dir); got&bobStateDirGroupRWX != bobStateDirGroupRWX {
+		t.Errorf("mode = %v, want fixEntry to have added group r/w/x (%v) to the .bob dir", got, bobStateDirGroupRWX)
+	}
+}
+
+// TestFixEntryIgnoresNonBobDirs guards scope: a directory that is NOT a .bob
+// state dir must not be widened by the bob-specific arm. (Owner-guarded general
+// widening may still apply when the process owns the dir, so we assert only that
+// a non-.bob dir owned by the test process is not force-group-widened past what
+// the general DirPerms arm would do — here we use a name that is not ".bob" and
+// a mode already satisfying DirPerms so neither arm should touch it.)
+func TestFixEntryIgnoresNonBobDirs(t *testing.T) {
+	root := t.TempDir()
+	other := filepath.Join(root, "not-dot-bob")
+	if err := os.Mkdir(other, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(other, 0o750); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	fi, err := os.Stat(other)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	fixEntry(other, fi, quietLogger())
+
+	// The bob-specific arm keys strictly on the ".bob" basename, so this dir
+	// must not have gained the group write bit from that arm.
+	if got := statMode(t, other); got&bobStateGroupWriteBit != 0 && filepath.Base(other) != bobStateDirBase {
+		// The general (owner-guarded) arm could add DirPerms only when the
+		// process runs as DevUID; under test we are not DevUID, so no widening
+		// should occur and the dir must stay 0750.
+		if !runningAsDevUID() {
+			t.Errorf("mode = %v, want non-.bob dir left at 0750 (bob arm must not touch it)", got)
+		}
+	}
+}
+
+// TestFixPermissionsRemediatesBobStateDirEndToEnd drives the full watcher tick:
+// pointing WatchedHomeDirs at a temp tree containing a broken 0755 .bob dir, one
+// fixPermissions pass must leave it group-writable, mirroring how the running
+// watcher self-heals /data/agents/<name>/.bob and /data/home/.bob every tick.
+func TestFixPermissionsRemediatesBobStateDirEndToEnd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX mode bits are not meaningful on Windows")
+	}
+	root := filepath.Join(t.TempDir(), "data-agents")
+	agentDir := filepath.Join(root, "scanner")
+	if err := os.MkdirAll(agentDir, 0o775); err != nil {
+		t.Fatalf("mkdirall: %v", err)
+	}
+	bobDir := mkBobStateDir(t, agentDir, bobStateStartMode)
+
+	origWatched, origGoose := WatchedHomeDirs, GooseLogsDir
+	WatchedHomeDirs = []string{root}
+	GooseLogsDir = filepath.Join(t.TempDir(), "goose-logs")
+	t.Cleanup(func() { WatchedHomeDirs = origWatched; GooseLogsDir = origGoose })
+
+	if before := statMode(t, bobDir); before&bobStateDirGroupRWX == bobStateDirGroupRWX {
+		t.Fatalf("precondition: %s already group-rwx at %v", bobDir, before)
+	}
+
+	fixPermissions(quietLogger())
+
+	if got := statMode(t, bobDir); got&bobStateDirGroupRWX != bobStateDirGroupRWX {
+		t.Errorf("after a watcher tick, %s mode = %v, want group r/w/x (%v)", bobDir, got, bobStateDirGroupRWX)
+	}
+}

--- a/v2/pkg/agent/permissions_watcher.go
+++ b/v2/pkg/agent/permissions_watcher.go
@@ -25,7 +25,26 @@ const (
 
 	// FilePerms is the minimum permission bits required on files (u+rw, g+rw).
 	FilePerms = 0o660
+
+	// bobStateDirGroupRWX is `g+rwx` — the bits a bob state directory (.bob)
+	// must grant the shared `node` group so an agent UID can create, replace and
+	// traverse the files bob persists there (settings, installation_id, the
+	// .bob-errors/ logger target). A dir-owning hive-<agent> user commonly
+	// creates these 0755 (owner rwx, group r-x), which leaves the group without
+	// write and makes bob log "error saving your latest settings changes" and
+	// "Failed to initialize logger" while running degraded. The watcher ORs
+	// these bits in to bring such a dir to at least 0770 without ever narrowing
+	// the owner or other bits it already has.
+	bobStateDirGroupRWX os.FileMode = 0o070
 )
+
+// bobStateDirBase is the directory name bob uses for both its shared-HOME state
+// (/data/home/.bob) and its per-agent workdir state (/data/agents/<name>/.bob).
+// The watcher recognizes an entry as a bob state dir by this basename so it can
+// self-heal the group-write bit the general fixEntry guard would otherwise skip
+// (those dirs are owned by hive-<agent>, not DevUID). Kept in sync with
+// config.BobStateDirName without importing config here to avoid a cycle.
+const bobStateDirBase = ".bob"
 
 // WatchedHomeDirs are the subdirectories under the shared home and data
 // volume that tools (Copilot, Claude, etc.) or init containers frequently
@@ -178,6 +197,21 @@ func fixEntry(path string, fi os.FileInfo, logger *slog.Logger) {
 		}
 	}
 
+	// bob state dirs (.bob) are the one class of directory the watcher must
+	// widen even though they are owned by a hive-<agent> UID rather than
+	// DevUID: bob runs as that agent's UID through the shared `node` group, so
+	// a 0755 dir leaves the group without write and bob logs "error saving your
+	// latest settings changes" / "Failed to initialize logger" and runs
+	// degraded. verifyBobStateDirsWritable only DETECTS this; here we actually
+	// fix it, on every tick and at startup, so the fleet self-heals instead of
+	// staying degraded until an operator hand-chmods the pod. Handled before
+	// the general owner guard below precisely because that guard would skip
+	// these non-DevUID dirs. Only the group r/w/x bits are added — owner and
+	// other bits are preserved — so an already-770 dir is left untouched.
+	if fi.IsDir() && filepath.Base(path) == bobStateDirBase {
+		fixBobStateDirGroupWrite(path, fi.Mode(), logger)
+	}
+
 	// Only fix permissions on files we own or just chowned.
 	// Skipping files owned by other users avoids "operation not permitted"
 	// spam when agents create files as their own users.
@@ -221,4 +255,45 @@ func fixEntry(path string, fi os.FileInfo, logger *slog.Logger) {
 			}
 		}
 	}
+}
+
+// fixBobStateDirGroupWrite ensures a bob state directory (.bob) grants the
+// shared `node` group read+write+execute, so an agent UID reaching it through
+// that group can persist bob's settings, installation_id and .bob-errors/
+// logger target. It ORs bobStateDirGroupRWX into whatever the dir already has —
+// never narrowing owner or other bits — so a dir that is already group-writable
+// (>= 0770) is left byte-identical and the watcher stays idempotent.
+//
+// This is the remediation that verifyBobStateDirsWritable only ever DETECTED:
+// production .bob dirs are created 0755 (r-x for the group) by their
+// hive-<agent> owner, which is why bob logged "error saving your latest
+// settings changes" / "Failed to initialize logger" fleet-wide and ran
+// degraded. The chmod runs on every watcher tick and at startup, so the fix
+// self-heals rather than requiring a hand-chmod on the pod.
+//
+// Safe and non-fatal: a chmod we are not permitted to perform (EPERM — we are
+// neither the owner nor privileged) is logged and swallowed, exactly like the
+// watcher's other chmod/chown arms, so it never blocks or panics.
+func fixBobStateDirGroupWrite(path string, mode os.FileMode, logger *slog.Logger) {
+	perm := mode.Perm()
+	// Nothing to do when the group already has all of r/w/x — this keeps an
+	// already-remediated (>= 0770) dir untouched and the walk idempotent.
+	if perm&bobStateDirGroupRWX == bobStateDirGroupRWX {
+		return
+	}
+	newPerm := perm | bobStateDirGroupRWX
+	if err := os.Chmod(path, newPerm); err != nil {
+		logger.Error("permissions watcher: chmod bob state dir failed; bob will keep reporting 'error saving your latest settings changes' and run degraded",
+			"path", path,
+			"old_mode", perm.String(),
+			"want_mode", newPerm.String(),
+			"error", err,
+		)
+		return
+	}
+	logger.Info("permissions watcher: fixed bob state dir permissions",
+		"path", path,
+		"old_mode", perm.String(),
+		"new_mode", newPerm.String(),
+	)
 }


### PR DESCRIPTION
## Incident

On a live hive (devx-prod / hosted-available-vllmd-06 on vllm-d) **every** bob backend agent (scanner uid 2004, quality 2003, supervisor 2005) repeatedly logged:

> `bob state dir is not writable by the agent UID; bob will report 'error saving your latest settings changes' and 'Failed to initialize logger'` … `remedy="chmod 770 /data/agents/scanner/.bob and ensure it is group-owned by node"`

and ran **degraded** (`✖ N errors` in its TUI). The per-agent `.bob` dirs were `drwxr-xr-x` (0755) owned by `hive-<agent>:node`; agents run as their own UID in group `node`, so 0755 gives the group no write and bob cannot persist settings or initialize its logger.

## Root cause

The code **detected** this and printed the remedy but **never applied it**:

- `verifyBobStateDirsWritable` (`bob_settings.go`) only appends the dir to an `unwritable` list and logs `remedy: chmod 770 <dir>`.
- The permissions watcher (`permissions_watcher.go`) chowns entries under `/data/agents` and `/data/home/.bob`, but its `fixEntry` chmod arm **early-returns for entries owned by a non-DevUID user** — which every `hive-<agent>`-owned `.bob` dir is — so the group-write bit was never added. The writability failure was re-detected every tick and never fixed.

## Fix

The watcher now recognizes a `.bob` state dir by basename in `fixEntry` and ORs in group r/w/x (bringing it to at least `0770`) **before** the general owner guard, via a new `fixBobStateDirGroupWrite`. This self-heals on every 10s tick and at startup, consistent with how the watcher already chowns.

- **Idempotent**: a dir already `>= 0770` is left byte-identical; owner/other bits preserved.
- **Non-fatal**: a chmod EPERM is logged and swallowed — the watcher never blocks or panics.
- A successful fix logs `INFO "permissions watcher: fixed bob state dir permissions"`; only a failed chmod logs `ERROR`.
- **Scoped**: only `.bob` state dirs are widened — no broadening of the general traversal/ownership logic. Named perm constant `bobStateDirGroupRWX` (0o070), no magic numbers.

## Tests (`pkg/agent`)

- 0755 `.bob` dir becomes group-writable after remediation (fail-before / pass-after)
- already-770 dir unchanged (idempotence), higher modes not narrowed
- chmod failure handled without panic
- `fixEntry` wires the `.bob` recognition
- non-`.bob` dirs untouched (scope guard)
- a full `fixPermissions` tick heals a `/data/agents/<name>/.bob` tree end-to-end

## Operator note

The running devx-prod hive needs the rebuilt image to pick this up. A manual `chmod 770 /data/agents/*/.bob` on the live pod would unblock the agents immediately in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)