### PR TITLE
🎨 dashboard: hollow-green agent dot for healthy-but-governor-paused agents

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -361,6 +361,13 @@
        and operators could not tell "resting by choice" from "blocked on a
        human logging in". Hollow reads as "waiting to be filled in". */
     .oc-agent-detail-header .status-dot.needs-login { background: transparent; border: 2px solid var(--amber); box-sizing: border-box; }
+    /* off-healthy is a HOLLOW GREEN ring (same technique as needs-login, green
+       instead of amber). The agent process is healthy, but its governor cadence
+       for the CURRENT mode is pause/off — so the governor will never kick it.
+       A solid green dot read as "running/idle" and hid that the agent was
+       actually off (e.g. a hive stuck in SURGE where every cadence is pause).
+       Hollow green = alive but not being kicked. No pulse: it is not working. */
+    .oc-agent-detail-header .status-dot.off-healthy { background: transparent; border: 2px solid var(--green); box-sizing: border-box; }
     .oc-agent-detail-header .status-dot.off { background: var(--muted); }
     .oc-detail-fields {
       display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px 24px; margin-bottom: 16px;
@@ -426,6 +433,10 @@
     .oc-agent-dot.on-demand { background: var(--indigo); }
     .oc-agent-dot.stopped { background: var(--red); }
     .oc-agent-dot.needs-login { background: transparent; border: 2px solid var(--amber); box-sizing: border-box; }
+    /* off-healthy: hollow GREEN ring — healthy agent whose governor cadence for
+       the current mode is pause/off, so it will not be kicked. Mirrors the
+       needs-login hollow technique (see detail-header rule above). No pulse. */
+    .oc-agent-dot.off-healthy { background: transparent; border: 2px solid var(--green); box-sizing: border-box; }
     .oc-agent-dot.off { background: var(--muted); }
     @keyframes oc-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
@@ -842,6 +853,9 @@
     .dot.paused { background: var(--yellow); }
     .dot.on-demand { background: var(--indigo); }
     .dot.off { background: var(--muted); }
+    /* off-healthy: hollow GREEN — healthy agent, governor cadence paused/off for
+       the current mode, so it will not be kicked (mirrors needs-login, green). */
+    .dot.off-healthy { background: transparent; border: 2px solid var(--green); box-sizing: border-box; }
     .dot.stopped { background: var(--red); }
     .dot.needs-login { background: transparent; border: 2px solid var(--amber); box-sizing: border-box; }
     .agent-field { display: flex; justify-content: space-between; font-size: 0.8rem; padding: 2px 0; }
@@ -3444,6 +3458,10 @@
     })();
 
     const STRATEGY_AGENT_NAMES = ['strategist'];
+    // Tooltip for the hollow-green (off-healthy) dot: the agent process is fine,
+    // but its governor cadence for the current mode is paused/off, so it is not
+    // being kicked. Shared by every renderer that can show the hollow-green dot.
+    const OFF_HEALTHY_TITLE = "Agent is healthy but off — the governor's cadence for this mode is paused, so it won't be kicked.";
     function ocUpdateFocusedState() {
       const isFocused = !!_ocSelectedAgent && getLayout() === 'light';
       document.body.classList.toggle('oc-agent-focused', isFocused);
@@ -3673,6 +3691,15 @@
       const needsLoginDown = (isStopped && (a.needsLogin === true || (a.authKnown === true && a.authAvailable !== true))) || a.needsLogin === true;
       const isRunning = a.busy === 'working' && !isPaused && !isOff && !isStopped;
       const dotCls = needsLoginDown ? 'needs-login' : isStopped ? 'stopped' : isOnDemand ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'running' : 'idle';
+      // A healthy agent that is off *because of its governor cadence* (offByCadence,
+      // i.e. cadence==pause/off for the current mode) reaches the isOff branch above
+      // only after the stopped / needs-login / on-demand / manual-paused guards, so
+      // it is provably alive. Render its DOT as hollow green (off-healthy) instead of
+      // grey 'off' to show "alive but the governor won't kick it" — a solid green dot
+      // misled operators into thinking a surge-paused agent was running. The border/
+      // state class (dotCls) stays 'off' so the panel border rule still applies.
+      const dotState = isOff ? 'off-healthy' : dotCls;
+      const dotTitle = isOff ? OFF_HEALTHY_TITLE : '';
 
       detail.className = 'oc-agent-detail active state-' + dotCls;
       const stateLabel = needsLoginDown ? 'needs login' : isStopped ? 'down' : isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'working' : 'idle';
@@ -3705,7 +3732,7 @@
           existingSummary.scrollTop = existingSummary.scrollHeight;
         }
         const dot = detail.querySelector('.status-dot');
-        if (dot) { dot.className = 'status-dot ' + dotCls; }
+        if (dot) { dot.className = 'status-dot ' + dotState; dot.title = dotTitle; }
         const stateSpan = detail.querySelector('.oc-agent-detail-header > span:last-child');
         if (stateSpan) { stateSpan.innerHTML = stateLabel + pauseInfoIcon(a); }
         // The pause/resume toggle must track state here too — the fast path
@@ -3778,7 +3805,7 @@
 
       detail.innerHTML = `
         <div class="oc-agent-detail-header">
-          <span class="status-dot ${dotCls}"></span>
+          <span class="status-dot ${dotState}"${dotTitle ? ` title="${esc(dotTitle)}"` : ''}></span>
           <span class="agent-name-big">${esc(a.displayName || a.name)}</span>${needsLoginDown ? '<span title="CLI needs login" style="margin-left:6px">\uD83D\uDD11</span>' : ''}
           <span style="font-size:0.78rem;color:var(--muted);margin-left:auto">${stateLabel}${pauseInfoIcon(a)}</span>
         </div>
@@ -3946,13 +3973,17 @@
       const isRunning = a.busy === 'working' && !isPaused && !isOff && !isDown;
       const isOnDemandIdle = isOnDemand && !isRunning;
       const dotCls = needsLoginDown ? 'needs-login' : isDown ? 'stopped' : isOnDemandIdle ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'running' : 'idle';
+      // Healthy-but-governor-paused → hollow green dot (see detail-header renderer).
+      // isOff is only reached past the down / needs-login / on-demand / manual-paused
+      // guards, so the agent is provably alive; render off-healthy instead of grey off.
+      const dotState = isOff ? 'off-healthy' : dotCls;
       const isActive = _ocSelectedAgent === a.name ? ' active' : '';
       const baseDesc = a.description || AGENT_DESCRIPTIONS[a.name] || '';
       const agentDesc = needsLoginDown ? (baseDesc ? baseDesc + '\n' : '') + 'needs login — CLI unauthenticated, the agent cannot work until logged in' : baseDesc;
       const label = a.displayName || a.name;
       const emojiHtml = a.emoji ? `<span class="oc-nav-emoji">${a.emoji}</span>` : '';
       const modeHtml = (a.modeEmoji || a.mode) ? `<span class="oc-nav-mode" title="${esc(a.mode || '')}">${a.modeEmoji || modeEmoji(a.mode)}</span>` : '';
-      return `<a class="oc-nav-item${isActive}" data-agent-nav="${esc(a.name)}" draggable="true" data-action="ocSelectAgent" data-agent="${esc(a.name)}" title="${esc(agentDesc)}"><span class="oc-agent-dot ${dotCls}"></span>${emojiHtml}<span class="oc-nav-text">${esc(label)}</span>${needsLoginDown ? '<span class="oc-nav-key" title="CLI needs login">\uD83D\uDD11</span>' : ''}${modeHtml}<span class="oc-nav-actions"><button data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure">⚙</button><button class="oc-nav-delete" data-action="deleteAgentFromConfig" data-agent="${esc(a.name)}" title="Delete">✕</button></span></a>`;
+      return `<a class="oc-nav-item${isActive}" data-agent-nav="${esc(a.name)}" draggable="true" data-action="ocSelectAgent" data-agent="${esc(a.name)}" title="${esc(agentDesc)}"><span class="oc-agent-dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${emojiHtml}<span class="oc-nav-text">${esc(label)}</span>${needsLoginDown ? '<span class="oc-nav-key" title="CLI needs login">\uD83D\uDD11</span>' : ''}${modeHtml}<span class="oc-nav-actions"><button data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure">⚙</button><button class="oc-nav-delete" data-action="deleteAgentFromConfig" data-agent="${esc(a.name)}" title="Delete">✕</button></span></a>`;
     }
 
     function _sidebarBuildGroups(agents) {
@@ -5310,6 +5341,8 @@
         // Down + unauthenticated CLI = amber needs-login (same formula as the
         // card's Login button above), not plain down-red (#2465).
         const dotCls = (isStopped && needsLogin) ? 'needs-login' : isStopped ? 'stopped' : isOnDemandIdle ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy === 'working' ? 'running' : 'idle';
+        // Healthy-but-governor-paused → hollow green dot (see detail-header renderer).
+        const dotState = isOff ? 'off-healthy' : dotCls;
         const canToggle = a.beadRole !== 'supervisor';
         const toggleBtn = canToggle ? (isOff
           ? `<button class="btn-toggle off" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Agent is off in this governor mode — click to configure per-mode cadences">⚙ off</button>`
@@ -5335,7 +5368,7 @@
         const compactCls = isAgentCompact(a.name) ? ' compact' : '';
         return `<div class="agent-card ${cls}${compactCls}" data-agent="${esc(a.name)}">
           <span class="working-indicator"></span>
-          <div class="agent-name"><span class="dot ${dotCls}"></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''} ${toggleBtn} <button class="compact-toggle" onclick="event.stopPropagation();toggleAgentCompact('${esc(a.name)}')" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure ${esc(a.displayName || a.name)}">⚙️</button></div>
+          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''} ${toggleBtn} <button class="compact-toggle" onclick="event.stopPropagation();toggleAgentCompact('${esc(a.name)}')" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure ${esc(a.displayName || a.name)}">⚙️</button></div>
           <div class="agent-state ${isOnDemand ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}${pauseInfoIcon(a)}${(() => {
             if (a.structuredStatus === 'BLOCKED') return '<span class="status-badge blocked" title="' + esc(a.statusEvidence) + '">blocked</span>';
             if (a.structuredStatus === 'NEEDS_CONTEXT') return '<span class="status-badge needs-context" title="' + esc(a.statusEvidence) + '">needs context</span>';

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -26,6 +26,15 @@ import (
 
 const defaultLookbackHours = 24
 
+// Cadence sentinel values: a per-mode cadence set to one of these means the
+// governor will not kick the agent on a timer in that mode. Kept as named
+// constants so the offByCadence detection and computeNextKick agree on the
+// exact spellings the config layer emits.
+const (
+	cadencePause = "pause"
+	cadenceOff   = "off"
+)
+
 // SetProxyViolationsProvider registers a function that returns per-agent
 // proxy violation counts, called during status builds.
 func SetProxyViolationsProvider(fn func() map[string]int) {
@@ -240,6 +249,17 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 		}
 		nextKick := computeNextKick(proc.LastKick, cadence)
 
+		// offByCadence: the agent's cadence for the CURRENT governor mode is a
+		// non-kicking value ("pause"/"off"), so the governor will never kick it
+		// even though the process itself may be perfectly healthy. This is how
+		// a hive stuck in SURGE (where surge:{scanner:pause,...}) leaves every
+		// agent alive-but-off. The dashboard surfaces this as a hollow-green
+		// dot so operators do not mistake a governor-paused agent for a running
+		// one. On-demand agents are excluded — they are intentionally not on a
+		// cadence and carry their own on-demand styling.
+		offByCadence := (cadence == cadencePause || cadence == cadenceOff) &&
+			!proc.Config.OnDemand && !onDemandSet[name]
+
 		pinnedCli := proc.PinnedCLI != "" || proc.Config.CLIPinned
 		pinnedModel := proc.PinnedModel != ""
 
@@ -288,6 +308,7 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 			PausedAt:      formatOptionalTime(proc.PausedAt),
 			PausedReason:  proc.PausedReason,
 			PausedTrigger: proc.PausedTrigger,
+			OffByCadence:  offByCadence,
 			CLI:           cli,
 			Model:         model,
 			Cadence:       cadence,

--- a/v2/pkg/dashboard/status_builder_test.go
+++ b/v2/pkg/dashboard/status_builder_test.go
@@ -343,19 +343,19 @@ func TestBuildAgents(t *testing.T) {
 
 	statuses := map[string]*agent.AgentProcess{
 		"scanner": {
-			Name:     "scanner",
-			Config:   config.AgentConfig{Backend: "claude", Model: "sonnet"},
-			State:    agent.StateRunning,
-			LastKick: &now,
+			Name:         "scanner",
+			Config:       config.AgentConfig{Backend: "claude", Model: "sonnet"},
+			State:        agent.StateRunning,
+			LastKick:     &now,
 			OutputBuffer: buf,
 		},
 		"supervisor": {
-			Name:     "supervisor",
-			Config:   config.AgentConfig{Backend: "claude", Model: "opus"},
-			State:    agent.StatePaused,
-			Paused:   true,
-			PinnedCLI:   "claude",
-			PinnedModel: "opus",
+			Name:         "supervisor",
+			Config:       config.AgentConfig{Backend: "claude", Model: "opus"},
+			State:        agent.StatePaused,
+			Paused:       true,
+			PinnedCLI:    "claude",
+			PinnedModel:  "opus",
 			OutputBuffer: agent.NewRingBuffer(10),
 		},
 	}
@@ -390,6 +390,68 @@ func TestBuildAgents(t *testing.T) {
 	}
 }
 
+// TestBuildAgents_OffByCadence verifies that an agent whose cadence for the
+// current governor mode is a non-kicking value ("pause"/"off") is flagged
+// OffByCadence, while a normally-scheduled agent is not. This is the signal the
+// dashboard uses to paint a hollow-green (alive-but-governor-off) dot for hives
+// stuck in a mode where every cadence is paused (e.g. SURGE).
+func TestBuildAgents_OffByCadence(t *testing.T) {
+	statuses := map[string]*agent.AgentProcess{
+		"scanner": {
+			Name:         "scanner",
+			Config:       config.AgentConfig{Backend: "claude"},
+			State:        agent.StateRunning,
+			OutputBuffer: agent.NewRingBuffer(10),
+		},
+		"quality": {
+			Name:         "quality",
+			Config:       config.AgentConfig{Backend: "claude"},
+			State:        agent.StateRunning,
+			OutputBuffer: agent.NewRingBuffer(10),
+		},
+		"brainstorm": {
+			Name:         "brainstorm",
+			Config:       config.AgentConfig{Backend: "claude", OnDemand: true},
+			State:        agent.StateRunning,
+			OutputBuffer: agent.NewRingBuffer(10),
+		},
+	}
+	cfg := &config.Config{
+		Agents: map[string]config.AgentConfig{
+			"scanner":    {Backend: "claude", SortOrder: 10},
+			"quality":    {Backend: "claude", SortOrder: 20},
+			"brainstorm": {Backend: "claude", OnDemand: true, SortOrder: 30},
+		},
+		Governor: config.GovernorConfig{
+			Modes: map[string]config.ModeConfig{
+				// SURGE mode pauses scanner but keeps quality on a timer;
+				// brainstorm is paused too but is on-demand, so it must be excluded.
+				"surge": {Cadences: map[string]string{
+					"scanner":    "pause",
+					"quality":    "15m",
+					"brainstorm": "pause",
+				}},
+			},
+		},
+	}
+
+	agents := buildAgents(statuses, cfg, governor.State{Mode: governor.ModeSurge})
+	byName := map[string]FrontendAgent{}
+	for _, a := range agents {
+		byName[a.Name] = a
+	}
+
+	if !byName["scanner"].OffByCadence {
+		t.Error("scanner cadence=pause in surge: want OffByCadence=true")
+	}
+	if byName["quality"].OffByCadence {
+		t.Error("quality cadence=15m in surge: want OffByCadence=false")
+	}
+	if byName["brainstorm"].OffByCadence {
+		t.Error("brainstorm is on-demand: want OffByCadence=false even though cadence=pause")
+	}
+}
+
 func TestBuildFrontendStatus(t *testing.T) {
 	cfg := &config.Config{
 		Project: config.ProjectConfig{Org: "myorg", Repos: []string{"repo1"}},
@@ -409,9 +471,9 @@ func TestBuildFrontendStatus(t *testing.T) {
 
 	statuses := map[string]*agent.AgentProcess{
 		"scanner": {
-			Name:   "scanner",
-			Config: config.AgentConfig{Backend: "claude", Model: "sonnet"},
-			State:  agent.StateRunning,
+			Name:         "scanner",
+			Config:       config.AgentConfig{Backend: "claude", Model: "sonnet"},
+			State:        agent.StateRunning,
 			OutputBuffer: agent.NewRingBuffer(10),
 		},
 	}


### PR DESCRIPTION
## Problem

A healthy agent whose governor cadence for the **current mode** is `pause`/`off` rendered as a **solid green** dot — indistinguishable from a running/idle agent. Operators read that as "running" when the governor will never kick it.

Worst case is a hive stuck in **SURGE**, where `surge: {scanner: pause, quality: pause, ...}` pauses every agent's cadence: the tmux session is alive and bob is at the prompt, so the dot went green, but the governor timer never fires.

**Real case:** `z-aiops-unite` (backlog 39 > surge threshold 15) — the operator saw a green indicator while the governor panel showed the agent off.

## Fix

Add a new dot state — **hollow GREEN ring** (`off-healthy`) — meaning "alive but not being kicked". Mirrors the existing `needs-login` hollow-amber ring technique (`background: transparent; border: 2px solid var(--green); box-sizing: border-box;`), no pulse.

- **Hollow green** = healthy but the governor cadence is paused/off for this mode.
- **Solid green** stays "running/idle".

## Changes

- **Backend** (`status_builder.go`): `OffByCadence` (previously a dead, never-set field) is now populated in `buildAgents` when the agent's cadence for the current governor mode is `pause`/`off` **and** the agent is not on-demand. Uses the already-available signal — no new API field invented.
- **Frontend** (`static/index.html`): the `isOff` branch — reached only after the stopped / needs-login / on-demand / manual-paused guards, so the agent is provably healthy — now paints the dot `off-healthy` instead of grey `off`, across all three renderers (detail-header, left-nav, legacy agent-card) plus the detail fast-path. A shared tooltip explains the state.
- **CSS**: added `.status-dot.off-healthy`, `.oc-agent-dot.off-healthy`, `.dot.off-healthy`.
- **Test**: `TestBuildAgents_OffByCadence` asserts the flag is set for a surge-paused agent, not set for a scheduled one, and excluded for on-demand.

## Guarantees

Purely a **display** change — governor behavior and cadences untouched. No regressions to other states: manual-pause stays solid yellow, running stays pulsing green, needs-login stays hollow amber, stopped/down stay red/grey.

- `go build ./...` clean, `gofmt -l` clean
- `go test ./pkg/dashboard/ -short` green
- inline dashboard JS passes `node --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)