### PR TITLE
🐛 fix(hub): unassigned placeholders with login-pending agents show green, not degraded

### DIFF
--- a/v2/pkg/hub/placeholder_health.go
+++ b/v2/pkg/hub/placeholder_health.go
@@ -1,5 +1,7 @@
 package hub
 
+import "strings"
+
 // Placeholder (unassigned pool) rows on the My Hives dashboard.
 //
 // An UNCLAIMED pool slot has no GitHub auth BY DESIGN — credentials only
@@ -13,15 +15,26 @@ package hub
 //
 // sanitizePlaceholderRows therefore rewrites each placeholder's spoke-reported
 // Health payload before it ships to the browser: checks whose non-passing
-// state IS the designed state of an unassigned slot — the auth-class family,
-// and the tokens check's zero-consumed warning (no project means no workload
-// to spend on); see placeholderDesignedCheckNote — are reclassified as "skip"
-// with a note saying why as their detail, and the
-// overall status / fails / warns are recomputed from the surviving checks
-// using the spoke's own thresholds. Genuine placeholder-applicable failures —
-// not ready, agents crash-looping, queue wedged — keep their status untouched
-// and still turn the row red, exactly as drift.go's rule 2 intends ("never
-// flag a placeholder for a claimed-hive concern", and never hide a real one).
+// state IS the designed state of an unassigned slot — the auth-class family;
+// the tokens check's zero-consumed warning (no project means no workload to
+// spend on); and the agents check when it fails ONLY because agents await the
+// owner's CLI login (see placeholderDesignedCheckNote and
+// agentsFailIsLoginPending) — are reclassified as "skip" with a note saying why
+// as their detail, and the overall status / fails / warns are recomputed from
+// the surviving checks using the spoke's own thresholds. Genuine
+// placeholder-applicable failures — not ready, agents CRASH-LOOPING (a "down:"
+// agent, distinct from a login-pending one), queue wedged — keep their status
+// untouched and still turn the row red, exactly as drift.go's rule 2 intends
+// ("never flag a placeholder for a claimed-hive concern", and never hide a real
+// one).
+//
+// The agents distinction is why the sanitizer inspects a check's detail, not
+// just its name: on an unclaimed slot, agents "0 running / paused / need login"
+// is the by-design unclaimed state (no owner has claimed the slot or run the
+// CLI login yet) — the exact analogue of github_auth being unconfigured by
+// design. But an agent that is genuinely "down:" (crash-looping / exiting) is a
+// real fault even on a placeholder, so only the login-pending shape is exempted;
+// anything ambiguous stays degrading.
 //
 // Which rows count as placeholders is decided by isPlaceholderEntry
 // (drift.go), the SAME predicate computeDrift and the alert evaluator use, so
@@ -43,19 +56,66 @@ const healthCheckTokens = "tokens"
 // detail on an unassigned row, for the same reason as placeholderAuthNote.
 const placeholderTokensNote = "Unassigned — no workload by design"
 
-// placeholderDesignedCheckNote reports whether a named check's non-passing
-// state is the DESIGNED state of an unassigned pool slot, and if so returns
-// the hover note that replaces its error detail. Everything else returns ""
-// and keeps its reported status: ready, agents, stall_detection,
-// template_vars, kick_refusal and queue failures are genuine faults even on a
-// placeholder (it runs a real spoke process), and governor/contribute only
-// ever report pass.
-func placeholderDesignedCheckNote(name string) string {
+// healthCheckAgents is the spoke's agent-liveness check (HealthSummary,
+// pkg/dashboard/server.go). It fails with a detail line like
+// "0 running, 1 paused, 4 need login: guide, quality, scanner, supervisor"
+// when agents are not doing work.
+const healthCheckAgents = "agents"
+
+// placeholderAgentsNote replaces the agents check's login-pending failure
+// detail on an unassigned row. On an UNCLAIMED slot, agents that are "0
+// running / paused / need login" are not broken — no owner has claimed the
+// slot or run the CLI login yet, so their idleness is the designed state,
+// exactly like github_auth being unconfigured by design.
+const placeholderAgentsNote = "Unassigned — agents await the owner's CLI login by design"
+
+// Agents-check detail markers. The spoke's HealthSummary composes the agents
+// detail line from named buckets (pkg/dashboard/server.go): "need login" for
+// an agent whose CLI is simply unauthenticated (owner-actionable), and "down:"
+// for an agent that is genuinely not running for any other reason
+// (crash-looping / exiting). We discriminate on these substrings rather than
+// re-deriving agent state the hub does not have.
+const (
+	// agentsDetailNeedLogin marks the login-pending bucket, whose detail reads
+	// "N need login: ..." (plural) or "1 needs login: ..." (singular). Both end
+	// in "login:", so matching that colon-terminated suffix catches both spellings
+	// without also matching the "down:" bucket.
+	agentsDetailNeedLogin = "login:"
+	// agentsDetailDown marks the crash/exit bucket ("N down: ..."). Its presence
+	// means at least one agent is genuinely broken, so the fail is NOT by-design
+	// even on a placeholder.
+	agentsDetailDown = "down:"
+)
+
+// agentsFailIsLoginPending reports whether a failing agents check is failing
+// ONLY because agents await the owner's CLI login — the by-design unclaimed
+// state of a pool slot — and not because any agent is genuinely down
+// (crash-looping / exiting). It requires positive evidence of the login-pending
+// bucket AND the absence of the "down:" crash bucket: a "down:" agent is a real
+// fault even on a placeholder, and a detail with neither marker (an unrecognised
+// shape) is treated as ambiguous and left degrading.
+func agentsFailIsLoginPending(detail string) bool {
+	return strings.Contains(detail, agentsDetailNeedLogin) &&
+		!strings.Contains(detail, agentsDetailDown)
+}
+
+// placeholderDesignedCheckNote reports whether a check's non-passing state is
+// the DESIGNED state of an unassigned pool slot, and if so returns the hover
+// note that replaces its error detail. It takes the check's detail because the
+// agents check is designed-state ONLY when its failure is login-pending
+// (agentsFailIsLoginPending); a crash-looping ("down:") agents check is a
+// genuine fault even on a placeholder. Everything else returns "" and keeps its
+// reported status: ready, stall_detection, template_vars, kick_refusal and
+// queue failures are genuine faults even on a placeholder (it runs a real spoke
+// process), and governor/contribute only ever report pass.
+func placeholderDesignedCheckNote(name, detail string) string {
 	switch {
 	case isAuthClassHealthCheck(name):
 		return placeholderAuthNote
 	case name == healthCheckTokens:
 		return placeholderTokensNote
+	case name == healthCheckAgents && agentsFailIsLoginPending(detail):
+		return placeholderAgentsNote
 	}
 	return ""
 }
@@ -99,9 +159,9 @@ func isFailingCheckStatus(st string) bool {
 
 // sanitizePlaceholderRows rewrites the Health payload of every UNASSIGNED
 // placeholder row in the My Hives result so designed-state check failures
-// (placeholderDesignedCheckNote: the auth-class family and the zero-consumed
-// tokens warning) no longer read as degradation, while every other failure
-// keeps its colour. Claimed hives pass through untouched. Called after
+// (placeholderDesignedCheckNote: the auth-class family, the zero-consumed
+// tokens warning, and a login-pending agents check) no longer read as
+// degradation, while every other failure keeps its colour. Claimed hives pass through untouched. Called after
 // enrichFromSaaSMeta has run on every row (provStatus must be present, or a
 // placeholder that has not yet reported it would be misread as claimed by
 // everything downstream of the org-prefix fallback).
@@ -150,7 +210,8 @@ func placeholderSanitizedHealth(health map[string]any) map[string]any {
 		}
 		name, _ := ck["name"].(string)
 		st, _ := ck["status"].(string)
-		if note := placeholderDesignedCheckNote(name); note != "" && isFailingCheckStatus(st) {
+		detail, _ := ck["detail"].(string)
+		if note := placeholderDesignedCheckNote(name, detail); note != "" && isFailingCheckStatus(st) {
 			neutralized++
 			replaced := make(map[string]any, len(ck)+1)
 			for k, val := range ck {

--- a/v2/pkg/hub/placeholder_health_test.go
+++ b/v2/pkg/hub/placeholder_health_test.go
@@ -380,6 +380,152 @@ func TestMyHivesPlaceholderRowShipsGreenHealth(t *testing.T) {
 	}
 }
 
+// An UNASSIGNED placeholder whose agents check fails only because agents await
+// the owner's CLI login ("0 running, N paused, M need login: ...") is the pool
+// working as designed — no owner has claimed the slot or run the CLI login yet,
+// exactly like github_auth being unconfigured by design. The row must ship
+// GREEN with the agents check reclassified to skip and the login-pending note.
+// This is the live available-oke-12 case.
+func TestPlaceholderRowGreenWhenAgentsAwaitLogin(t *testing.T) {
+	e := placeholderEntryWithHealth(map[string]any{
+		"status": "degraded",
+		"fails":  1,
+		"warns":  0,
+		"checks": []any{
+			map[string]any{"name": "ready", "status": "pass"},
+			map[string]any{"name": "github_auth", "status": "fail", "detail": "no GitHub auth configured"},
+			map[string]any{"name": healthCheckAgents, "status": "fail", "detail": "0 running, 1 paused, 4 need login: guide, quality, scanner, supervisor"},
+		},
+	})
+
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	got := rows[0].Health
+
+	if st := healthStatusOf(got); st != healthStatusOK {
+		t.Fatalf("placeholder with login-pending agents: status = %q, want %q", st, healthStatusOK)
+	}
+	if fails, _ := got["fails"].(int); fails != 0 {
+		t.Errorf("fails = %v, want 0 — a login-pending agents check must not degrade a placeholder", got["fails"])
+	}
+	st, detail := checkStatusByName(t, got, healthCheckAgents)
+	if st != healthCheckStatusSkip {
+		t.Errorf("agents status = %q, want %q", st, healthCheckStatusSkip)
+	}
+	if detail != placeholderAgentsNote {
+		t.Errorf("agents detail = %q, want the login-pending note %q", detail, placeholderAgentsNote)
+	}
+}
+
+// A placeholder whose agents are genuinely DOWN (crash-looping / exiting, the
+// "down:" bucket) is a real fault even on an unassigned slot: the agents check
+// must NOT be exempted and the row must stay degraded. This preserves the
+// original intent — only the by-design login-pending shape is greened.
+func TestPlaceholderRowStaysDegradedWhenAgentsCrashLoop(t *testing.T) {
+	e := placeholderEntryWithHealth(map[string]any{
+		"status": "degraded",
+		"fails":  1,
+		"warns":  0,
+		"checks": []any{
+			map[string]any{"name": "ready", "status": "pass"},
+			map[string]any{"name": "github_auth", "status": "fail", "detail": "no GitHub auth configured"},
+			map[string]any{"name": healthCheckAgents, "status": "fail", "detail": "0 running, 2 down: scanner, supervisor"},
+		},
+	})
+
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	got := rows[0].Health
+
+	if st := healthStatusOf(got); st != healthStatusDegraded {
+		t.Fatalf("placeholder with crash-looping agents: status = %q, want %q — down agents are a real fault", st, healthStatusDegraded)
+	}
+	if st, _ := checkStatusByName(t, got, healthCheckAgents); st != healthCheckStatusFail {
+		t.Errorf("agents status = %q, want fail — crash-looping agents keep their status even on a placeholder", st)
+	}
+	// The auth check alongside is still exempted, so the ONLY thing degrading
+	// the row is the genuine agents failure.
+	if fails, _ := got["fails"].(int); fails != 1 {
+		t.Errorf("fails = %v, want 1 — only the genuine agents failure counts", got["fails"])
+	}
+}
+
+// A placeholder with agents both DOWN and needing login: the presence of a
+// "down:" agent makes the whole agents fail genuine — the exemption requires
+// positive evidence that NO agent is actually broken. The row stays degraded.
+func TestPlaceholderAgentsDownAndLoginStaysDegraded(t *testing.T) {
+	e := placeholderEntryWithHealth(map[string]any{
+		"status": "degraded",
+		"checks": []any{
+			map[string]any{"name": healthCheckAgents, "status": "fail", "detail": "0 running, 1 down: crashed, 2 need login: needy-a, needy-b"},
+		},
+	})
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	got := rows[0].Health
+
+	if st := healthStatusOf(got); st != healthStatusDegraded {
+		t.Fatalf("status = %q, want %q — a down agent alongside login-pending ones is still a real fault", st, healthStatusDegraded)
+	}
+	if st, _ := checkStatusByName(t, got, healthCheckAgents); st != healthCheckStatusFail {
+		t.Errorf("agents status = %q, want fail", st)
+	}
+}
+
+// The SAME login-pending agents failure on a CLAIMED hive is a real signal (an
+// owner-actionable "log in your CLI" prompt) and must pass through untouched:
+// the exemption applies ONLY to placeholders.
+func TestClaimedRowKeepsLoginPendingAgentsFail(t *testing.T) {
+	e := MyHiveEntry{RegistryEntry: RegistryEntry{
+		ID:     "claimed-3",
+		Org:    "acme",
+		Online: true,
+		Health: map[string]any{
+			"status": "degraded",
+			"checks": []any{
+				map[string]any{"name": healthCheckAgents, "status": "fail", "detail": "0 running, 1 needs login: supervisor"},
+			},
+		},
+	}}
+	e.ProvStatus = "active"
+
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	got := rows[0].Health
+
+	if st := healthStatusOf(got); st != healthStatusDegraded {
+		t.Fatalf("claimed hive status = %q, want %q — the agents exemption must not leak past placeholders", st, healthStatusDegraded)
+	}
+	if st, detail := checkStatusByName(t, got, healthCheckAgents); st != healthCheckStatusFail || !strings.Contains(detail, "needs login") {
+		t.Errorf("claimed hive agents shipped as %q/%q, want fail with the login detail untouched", st, detail)
+	}
+}
+
+// agentsFailIsLoginPending is the discrimination at the heart of the fix:
+// login-pending detail (need/needs login, no "down:") is by-design; anything
+// with a "down:" crash marker, or an unrecognised shape with neither marker, is
+// left degrading.
+func TestAgentsFailIsLoginPending(t *testing.T) {
+	cases := []struct {
+		detail string
+		want   bool
+	}{
+		{"0 running, 1 paused, 4 need login: guide, quality, scanner, supervisor", true},
+		{"0 running, 1 needs login: supervisor", true},
+		{"1 running, 1 needs login: wedged", true},
+		{"0 running, 2 down: scanner, supervisor", false},
+		{"0 running, 1 down: crashed, 2 need login: needy-a, needy-b", false},
+		{"0 running, 1 down: crashed", false},
+		{"3 running", false}, // no login-pending evidence → not exempt
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := agentsFailIsLoginPending(c.detail); got != c.want {
+			t.Errorf("agentsFailIsLoginPending(%q) = %v, want %v", c.detail, got, c.want)
+		}
+	}
+}
+
 // The dashboard's own placeholder handling: healthBadge must carry the
 // unassigned line instead of forcing App-degraded, and hiveStatusFlags must
 // mirror the same placeholder guard so dot and chip agree. String-anchored on


### PR DESCRIPTION
## Problem

An UNASSIGNED placeholder pool slot (e.g. the live `available-oke-12`) showed a RED "Degraded" dot even though every check was green or explicitly "by design" except one:

```
✗ agents: 0 running, 1 paused, 4 need login: guide, quality, scanner, supervisor
✓ ready | – github_auth: Unassigned — auth not configured by design | ✓ stall_detection
✓ governor: IDLE | ✓ contribute: 0 active | – tokens: Unassigned — no workload by design | ✓ queue: 0 actionable
```

The placeholder sanitizer already exempts `github_auth` and `tokens` for unassigned slots, but the `agents` check kept firing red and dragged the whole row to Degraded. On an unclaimed slot, agents "need login / 0 running / paused" is the by-design unclaimed state (no owner has claimed the slot or run the CLI login yet) — exactly analogous to `github_auth` being unconfigured by design.

## Fix

On a placeholder, reclassify the `agents` check to `skip` (non-degrading, with the note **"Unassigned — agents await the owner's CLI login by design"**) WHEN the failure is purely login-pending. Discrimination is on the agents-check detail line, mirroring how `placeholderDesignedCheckNote` already handles auth/tokens:

- **by-design (exempt → green):** detail contains a `login:` bucket (`"need login:"` / `"needs login:"`) and NO `down:` crash bucket.
- **genuine fault (still degrades):** detail contains `down:` (crash-looping / exiting agents) — a real problem even on a placeholder, preserving the original intent.
- **ambiguous (neither marker):** left degrading — greening a row demands positive evidence.

Implemented via a named helper `agentsFailIsLoginPending(detail)` with the markers as named constants. The exemption is placeholder-only; a claimed hive with login-pending agents is unchanged.

## Tests

Extended `placeholder_health_test.go`:
- placeholder with login-pending agents → GREEN, agents reclassified skip with the note (the `available-oke-12` case)
- placeholder with crash-looping (`down:`) agents → still Degraded, agents NOT exempted
- placeholder with both down + login-pending → still Degraded (a down agent makes the fail genuine)
- claimed hive with login-pending agents → unchanged (Degraded, detail untouched)
- table test for `agentsFailIsLoginPending` discrimination
- existing auth/tokens exemptions still pass

## Dashboard JS

No mirror needed. The health status/fails/warns recompute is authoritative on the Go hub side (`placeholderSanitizedHealth`); the My Hives payload ships the already-sanitized status and skip'd checks. The dashboard's placeholder JS guards (`healthBadge`/`hiveStatusFlags`/`isPlaceholderHive`) only concern the github-App-required flag, not the agents-check recompute.

## Validation

- `go build ./...` clean
- `go test ./pkg/hub/ -short` green (no pre-existing red)
- `gofmt -l` clean on edited files

🤖 Generated with [Claude Code](https://claude.com/claude-code)