### PR TITLE
🐛 fix(spoke+hub): stop same-pod duplicate hive senders — flock singleton, pid-bearing reporter, key-delivery back-off

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/logscrub"
 	"github.com/kubestellar/hive/v2/pkg/notify"
 	"github.com/kubestellar/hive/v2/pkg/policies"
+	"github.com/kubestellar/hive/v2/pkg/proclock"
 	"github.com/kubestellar/hive/v2/pkg/promptsrc"
 	"github.com/kubestellar/hive/v2/pkg/proxy"
 	"github.com/kubestellar/hive/v2/pkg/scheduler"
@@ -665,10 +666,74 @@ func startDocsTokenRefresh(ctx context.Context, cfg *config.Config, appKeyFile s
 // short uptime that keeps resetting is the only visible tell.
 var processStartedAt = time.Now()
 
-// reporterName identifies this spoke process to the hub (HeartbeatPayload
-// Reporter). In-cluster the hostname IS the pod name; on failure it stays
-// empty, which the hub reads as "too old / cannot report", never as data.
-var reporterName, _ = os.Hostname()
+// reporterName identifies this spoke PROCESS to the hub (HeartbeatPayload
+// Reporter) as "<hostname>/<pid>". In-cluster the hostname IS the pod name;
+// the PID suffix exists because two hive processes were observed beating from
+// ONE pod (#2453, #2496) — bare os.Hostname() made them indistinguishable, so
+// the hub's duplicate-spoke detector (noteReporter) stayed silent through 11+
+// alternating beats while the dashboard flipped state every beat. With the
+// PID attached, same-pod duplicates alternate as "pod-x/123 ↔ pod-x/456" and
+// the detector names the exact culprits. The hub compares the whole string as
+// an opaque identity, so old spokes sending bare hostnames keep working; a
+// hostname failure yields empty, which the hub reads as "too old / cannot
+// report", never as data.
+var reporterName = func() string {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/%d", host, os.Getpid())
+}()
+
+// ── Process singleton (#2453, #2496) ────────────────────────────────────
+//
+// A spoke pod ran TWO hive processes concurrently: startedAt alternated
+// between two values beat to beat, the hub saw 4-5 heartbeat senders behind
+// one pod name, and one process's stale App-auth snapshot flipped the
+// dashboard every beat. The per-process StartHeartbeat guard (#2462) cannot
+// see across processes; only a kernel-level mutual exclusion can. main()
+// takes an exclusive flock before doing anything else — the second process
+// logs the holder's PID and exits instead of becoming a shadow sender. The
+// flock releases automatically on process death, so a crashed holder never
+// blocks a legitimate restart.
+const (
+	// singletonLockEnv overrides the lock file location (tests, unusual
+	// container layouts). Empty means the default resolution below.
+	singletonLockEnv = "HIVE_SINGLETON_LOCK"
+	// singletonLockDisable is the env value that skips the guard entirely —
+	// an escape hatch for deliberately running two instances on one host
+	// (local development with distinct configs).
+	singletonLockDisable = "off"
+	// singletonLockDir is the preferred lock directory: container-local tmpfs
+	// created by the entrypoint, shared by every process in the container but
+	// by NOTHING outside it. Deliberately NOT /data — the PVC is shared
+	// across PODS during a rolling update (maxSurge=1), and a pod-spanning
+	// lock would deadlock the surge pod against the terminating one.
+	singletonLockDir = "/var/run/hive-metrics"
+	// singletonLockName is the lock file's basename in whichever directory is
+	// chosen.
+	singletonLockName = "hive.singleton.lock"
+	// duplicateProcessExitCode marks an exit caused by refusing to run beside
+	// an already-running hive process. Distinct from 0 (clean) and 17
+	// (selfUpgradeFailureExitCode) so the refusal is legible in the
+	// container's termination state.
+	duplicateProcessExitCode = 18
+)
+
+// singletonLockPath resolves where the process singleton lock lives. Every
+// process in a container resolves the same path (the filesystem is shared),
+// so the choice is deterministic where it matters; the temp-dir fallback
+// covers bare-metal/dev runs where the entrypoint never created the
+// container dir.
+func singletonLockPath() string {
+	if p := os.Getenv(singletonLockEnv); p != "" {
+		return p
+	}
+	if st, err := os.Stat(singletonLockDir); err == nil && st.IsDir() {
+		return filepath.Join(singletonLockDir, singletonLockName)
+	}
+	return filepath.Join(os.TempDir(), singletonLockName)
+}
 
 // spokeRestartMinUptime is how old this process must be before it acts on a
 // hub-delivered restart. The hub delivers the instruction to every beat in a
@@ -696,6 +761,28 @@ func main() {
 
 	logger := slog.New(logscrub.NewHandler(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})))
 	slog.SetDefault(logger)
+
+	// Process singleton: refuse to become a second hive process in this
+	// container (#2453, #2496). Two concurrent processes beat as the same pod,
+	// alternate registry state every beat, and are invisible to both the
+	// in-process StartHeartbeat guard and the hub's duplicate-spoke detector.
+	// The flock releases on process death, so this never blocks a restart.
+	if os.Getenv(singletonLockEnv) != singletonLockDisable {
+		lockPath := singletonLockPath()
+		procLock, lockErr := proclock.Acquire(lockPath)
+		if lockErr != nil {
+			logger.Error("another hive process is already running in this container — refusing to start a duplicate (#2453, #2496)",
+				"lock", lockPath,
+				"pid", os.Getpid(),
+				"error", lockErr.Error(),
+			)
+			os.Exit(duplicateProcessExitCode)
+		}
+		// Held for the process lifetime; the kernel releases it on exit. Kept
+		// referenced so the *os.File is never garbage-collected (a collected
+		// file closes its descriptor, which would silently drop the flock).
+		defer procLock.Release()
+	}
 
 	// Clear stale upgrade marker if the current SHA differs from the marker's
 	// current_sha — this means the upgrade succeeded and the marker is from a

--- a/v2/cmd/hive/reporter_identity_test.go
+++ b/v2/cmd/hive/reporter_identity_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+)
+
+// The heartbeat reporter must identify the PROCESS, not just the pod: two hive
+// processes in one pod (#2453, #2496) share a hostname, and a bare-hostname
+// reporter kept the hub's duplicate-spoke detector blind while the registry
+// alternated beat to beat. "<hostname>/<pid>" makes same-pod duplicates
+// distinguishable on the hub with no payload schema change.
+func TestReporterNameCarriesProcessIdentity(t *testing.T) {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		t.Skip("no hostname on this machine — reporterName is legitimately empty")
+	}
+	want := fmt.Sprintf("%s/%d", host, os.Getpid())
+	if reporterName != want {
+		t.Fatalf("reporterName = %q, want %q (hostname/pid)", reporterName, want)
+	}
+	// The shape the hub-side conflict rendering relies on ("pod-x/123 ↔
+	// pod-x/456"): identity ends in a slash-separated PID.
+	if !regexp.MustCompile(`^.+/\d+$`).MatchString(reporterName) {
+		t.Fatalf("reporterName %q does not end in /<pid>", reporterName)
+	}
+}
+
+// singletonLockPath must honour the env override (so tests and unusual
+// layouts can redirect it) and never return an empty path otherwise.
+func TestSingletonLockPath(t *testing.T) {
+	t.Setenv(singletonLockEnv, "/some/where/hive.lock")
+	if got := singletonLockPath(); got != "/some/where/hive.lock" {
+		t.Fatalf("env override ignored: %q", got)
+	}
+	t.Setenv(singletonLockEnv, "")
+	if got := singletonLockPath(); got == "" {
+		t.Fatal("default lock path is empty")
+	}
+}

--- a/v2/pkg/hub/app_key_backoff.go
+++ b/v2/pkg/hub/app_key_backoff.go
@@ -1,0 +1,101 @@
+package hub
+
+import (
+	"time"
+)
+
+// Per-hive back-off for non-converging GitHub App key delivery.
+//
+// WHY THIS EXISTS (#2496, and the #2453 precursor)
+//
+// The key reconcile is written to be idempotent: the hub pushes key material
+// only while the spoke's reported fingerprint differs (or is absent), and the
+// push stops on the first beat after the spoke reports the delivered key. That
+// convergence assumes the spoke CAN converge. A broken sender — observed live:
+// a duplicate same-pod process holding a stale in-memory config that never
+// reflects any delivery — reports no fingerprint on every beat, forever, and
+// the hub re-sent App private-key material every ~2 minutes for 30+ minutes
+// with nothing flagging it. That is unbounded credential exposure on the wire
+// paced by someone else's bug.
+//
+// The fix keeps the first deliveries immediate — a genuinely new spoke gets
+// its keys on its first beats, exactly as before — and then, once the count of
+// CONSECUTIVE non-converging deliveries exceeds a budget, drops to one
+// delivery per backoff interval with a WARN naming the hive and the count.
+// Any sign of convergence (a beat needing no key material while the spoke
+// reports a fingerprint) resets the budget in full.
+
+const (
+	// appKeyDeliveryImmediateBudget is how many consecutive key deliveries to
+	// one hive stay immediate (every beat) before the hub concludes delivery
+	// is not converging. Both delivery paths — the primary cluster-key
+	// reconcile and the additional-keys pass — share the counter, so a spoke
+	// broken on both reaches the budget in about half as many beats; at a 2-
+	// minute beat cadence the budget spans roughly 6-12 minutes either way,
+	// ample for any spoke that is actually applying what it receives.
+	appKeyDeliveryImmediateBudget = 6
+	// appKeyDeliveryBackoffInterval is how often key material is still
+	// delivered once the budget is exhausted. Long enough to stop the
+	// every-beat hot loop; short enough that a spoke that recovers (restart,
+	// upgrade) is re-keyed within minutes.
+	appKeyDeliveryBackoffInterval = 10 * time.Minute
+)
+
+// appKeyDeliveryState is the per-hive delivery ledger.
+type appKeyDeliveryState struct {
+	// consecutive counts key deliveries since the last observed convergence.
+	consecutive int
+	// lastSent is when key material last actually rode a beat.
+	lastSent time.Time
+}
+
+// allowAppKeyDelivery reports whether key material may ride this beat for the
+// hive. Inside the immediate budget it is always true; past it, true only once
+// per appKeyDeliveryBackoffInterval, with a WARN naming the hive and the
+// consecutive-delivery count so the non-convergence is legible in hub logs
+// instead of silently re-sending key material forever.
+func (s *HubServer) allowAppKeyDelivery(hiveID string) bool {
+	s.appKeyDeliveryMu.Lock()
+	defer s.appKeyDeliveryMu.Unlock()
+	st := s.appKeyDelivery[hiveID]
+	if st == nil || st.consecutive < appKeyDeliveryImmediateBudget {
+		return true
+	}
+	if time.Since(st.lastSent) >= appKeyDeliveryBackoffInterval {
+		if s.logger != nil {
+			s.logger.Warn("heartbeat: app key delivery to this hive is NOT converging — spoke never reflects delivered keys; throttled to one delivery per backoff interval",
+				"hive_id", hiveID,
+				"consecutive_deliveries", st.consecutive,
+				"backoff", appKeyDeliveryBackoffInterval.String(),
+				"hint", "the spoke is not persisting or not reporting delivered key material — check for a duplicate spoke process (#2496) or a /data write failure",
+			)
+		}
+		return true
+	}
+	return false
+}
+
+// noteAppKeyDelivered records that key material rode a beat to this hive.
+func (s *HubServer) noteAppKeyDelivered(hiveID string) {
+	s.appKeyDeliveryMu.Lock()
+	defer s.appKeyDeliveryMu.Unlock()
+	if s.appKeyDelivery == nil {
+		s.appKeyDelivery = make(map[string]*appKeyDeliveryState)
+	}
+	st := s.appKeyDelivery[hiveID]
+	if st == nil {
+		st = &appKeyDeliveryState{}
+		s.appKeyDelivery[hiveID] = st
+	}
+	st.consecutive++
+	st.lastSent = time.Now()
+}
+
+// noteAppKeyConverged clears the hive's delivery ledger: the spoke's report
+// shows delivery landed (or nothing is pending), so future deliveries are
+// immediate again.
+func (s *HubServer) noteAppKeyConverged(hiveID string) {
+	s.appKeyDeliveryMu.Lock()
+	defer s.appKeyDeliveryMu.Unlock()
+	delete(s.appKeyDelivery, hiveID)
+}

--- a/v2/pkg/hub/app_key_backoff_test.go
+++ b/v2/pkg/hub/app_key_backoff_test.go
@@ -1,0 +1,143 @@
+package hub
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// The #2496 hot loop: a spoke that never reports a key fingerprint got the
+// cluster key re-pushed on EVERY beat, forever. The first deliveries must stay
+// immediate (a genuinely new spoke is keyed promptly), then delivery throttles
+// to the back-off interval, and any sign of convergence resets the budget.
+func TestAppKeyDeliveryBackoffOnPrimaryReconcile(t *testing.T) {
+	withTempAppKeyDir(t)
+	keyPEM := testAppKeyPEM(t)
+	if err := storeClusterAppKey("vllm-d", keyPEM); err != nil {
+		t.Fatal(err)
+	}
+	clusterFP, err := config.AppKeyFingerprint(keyPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &HubServer{
+		logger:   appKeyTestLogger(),
+		clusters: map[string]ClusterConfig{"vllm-d": {ID: "vllm-d", GitHubAppID: 5686, GitHubAppSlug: "kubestellar-hive-ghe"}},
+	}
+	// The broken sender's signature: no fingerprint reported, beat after beat.
+	keyless := &HeartbeatPayload{HiveID: "broken", ClusterID: "vllm-d"}
+
+	// Inside the immediate budget every beat delivers.
+	for i := 0; i < appKeyDeliveryImmediateBudget; i++ {
+		cfg := s.appKeySyncForHeartbeat(keyless)
+		if cfg == nil || cfg.PrivateKey == "" {
+			t.Fatalf("beat %d: key not delivered inside the immediate budget", i+1)
+		}
+	}
+
+	// Budget exhausted: the very next beats are suppressed.
+	for i := 0; i < 3; i++ {
+		if cfg := s.appKeySyncForHeartbeat(keyless); cfg != nil {
+			t.Fatalf("beat after budget %d: delivery not suppressed — the every-beat key hot loop is back", i+1)
+		}
+	}
+
+	// After the back-off interval one delivery goes through again…
+	s.appKeyDeliveryMu.Lock()
+	s.appKeyDelivery["broken"].lastSent = time.Now().Add(-appKeyDeliveryBackoffInterval)
+	s.appKeyDeliveryMu.Unlock()
+	if cfg := s.appKeySyncForHeartbeat(keyless); cfg == nil || cfg.PrivateKey == "" {
+		t.Fatal("throttled delivery did not resume after the back-off interval — a recovered spoke would never be re-keyed")
+	}
+	// …and the throttle immediately re-engages.
+	if cfg := s.appKeySyncForHeartbeat(keyless); cfg != nil {
+		t.Fatal("throttle did not re-engage after the back-off delivery")
+	}
+
+	// CONVERGENCE: the spoke reports the cluster fingerprint. No push is
+	// needed, and the ledger resets so future deliveries are immediate again.
+	converged := &HeartbeatPayload{HiveID: "broken", ClusterID: "vllm-d", GitHubAppKeyFingerprint: clusterFP}
+	if cfg := s.appKeySyncForHeartbeat(converged); cfg != nil {
+		t.Fatal("converged spoke still got a key push")
+	}
+	if cfg := s.appKeySyncForHeartbeat(keyless); cfg == nil || cfg.PrivateKey == "" {
+		t.Fatal("delivery counter did not reset on convergence — a spoke that re-lost its key would be throttled from its first beat")
+	}
+}
+
+// The additional-keys pass re-delivered every beat too while a broken sender's
+// GitHubAppKeysHeld never reflected the delivery. It shares the per-hive
+// ledger, so it throttles the same way.
+func TestAppKeyDeliveryBackoffOnAdditionalKeys(t *testing.T) {
+	s, _ := twoClusterHub(t)
+	// A GHE-primary hive that never reports holding the github.com key.
+	payload := &HeartbeatPayload{
+		HiveID:      "broken-add",
+		ClusterID:   "vllm-d",
+		GitHubAppID: testGHEAppID,
+	}
+
+	for i := 0; i < appKeyDeliveryImmediateBudget; i++ {
+		var resp HeartbeatResponse
+		s.attachMissingAppKeys(&resp, payload)
+		if resp.GitHubAppConfig == nil || len(resp.GitHubAppConfig.AdditionalKeys) == 0 {
+			t.Fatalf("beat %d: additional key not delivered inside the immediate budget", i+1)
+		}
+	}
+
+	var resp HeartbeatResponse
+	s.attachMissingAppKeys(&resp, payload)
+	if resp.GitHubAppConfig != nil {
+		t.Fatal("additional-keys delivery not suppressed after the budget — key material would ride every beat forever")
+	}
+
+	// A spoke that reports holding the key is converged on this path: nothing
+	// is attached and nothing is counted.
+	held := &HeartbeatPayload{
+		HiveID:      "healthy-add",
+		ClusterID:   "vllm-d",
+		GitHubAppID: testGHEAppID,
+		GitHubAppKeysHeld: map[string]string{
+			"3568013": s.appKeysByAppID()[testGitHubComAppID].Fingerprint,
+		},
+	}
+	for i := 0; i < appKeyDeliveryImmediateBudget+2; i++ {
+		var r HeartbeatResponse
+		s.attachMissingAppKeys(&r, held)
+		if r.GitHubAppConfig != nil {
+			t.Fatalf("beat %d: spoke holding every key still got a delivery", i+1)
+		}
+	}
+}
+
+// Unit contract of the ledger itself: budget, throttle, reset.
+func TestAppKeyDeliveryLedger(t *testing.T) {
+	s := &HubServer{logger: appKeyTestLogger()}
+
+	for i := 0; i < appKeyDeliveryImmediateBudget; i++ {
+		if !s.allowAppKeyDelivery("h") {
+			t.Fatalf("delivery %d refused inside the immediate budget", i+1)
+		}
+		s.noteAppKeyDelivered("h")
+	}
+	if s.allowAppKeyDelivery("h") {
+		t.Fatal("delivery allowed immediately after the budget was exhausted")
+	}
+	// Another hive is unaffected — the ledger is per hive.
+	if !s.allowAppKeyDelivery("other") {
+		t.Fatal("an unrelated hive was throttled")
+	}
+	// The throttled hive is allowed again once the interval has passed.
+	s.appKeyDeliveryMu.Lock()
+	s.appKeyDelivery["h"].lastSent = time.Now().Add(-appKeyDeliveryBackoffInterval)
+	s.appKeyDeliveryMu.Unlock()
+	if !s.allowAppKeyDelivery("h") {
+		t.Fatal("throttled hive not allowed after the back-off interval")
+	}
+	// Convergence resets in full.
+	s.noteAppKeyConverged("h")
+	if !s.allowAppKeyDelivery("h") {
+		t.Fatal("converged hive still throttled")
+	}
+}

--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -458,6 +458,16 @@ func (s *HubServer) attachMissingAppKeys(resp *HeartbeatResponse, payload *Heart
 		return
 	}
 
+	// Non-convergence back-off (#2496): this path re-delivers every beat while
+	// the spoke's GitHubAppKeysHeld never reflects the delivery — the exact
+	// hot loop observed from a broken same-pod duplicate sender. It shares the
+	// per-hive ledger with the primary reconcile, so key material of any kind
+	// stops riding every beat once the budget is exhausted.
+	if !s.allowAppKeyDelivery(payload.HiveID) {
+		return
+	}
+	s.noteAppKeyDelivered(payload.HiveID)
+
 	if resp.GitHubAppConfig == nil {
 		// No primary key change this beat — attach a bare carrier. AppID 0 and an
 		// empty PrivateKey both mean "leave the spoke's primary alone"; only the
@@ -1154,7 +1164,7 @@ func (s *HubServer) appKeySyncForHeartbeat(payload *HeartbeatPayload) *Heartbeat
 	// KEY. Sending 0 tells the spoke to leave its (already correct) installation
 	// ID alone — see the callback in cmd/hive.
 	const installationIDUnchanged = 0
-	return s.appKeyConfigForHeartbeat(
+	cfg := s.appKeyConfigForHeartbeat(
 		payload.HiveID,
 		clusterID,
 		payload.GitHubAppKeyFingerprint,
@@ -1165,4 +1175,24 @@ func (s *HubServer) appKeySyncForHeartbeat(payload *HeartbeatPayload) *Heartbeat
 		s.logger,
 		sh,
 	)
+	// Non-convergence back-off (#2496). The reconcile above is idempotent only
+	// when the spoke reflects deliveries; a broken sender that reports no
+	// fingerprint forever would otherwise pull key material every beat without
+	// bound. Track consecutive key deliveries and throttle past the budget —
+	// while a beat that needs no key from a spoke reporting a fingerprint is
+	// the convergence signal that resets the ledger.
+	if cfg == nil || cfg.PrivateKey == "" {
+		if strings.TrimSpace(payload.GitHubAppKeyFingerprint) != "" {
+			s.noteAppKeyConverged(payload.HiveID)
+		}
+		return cfg
+	}
+	if !s.allowAppKeyDelivery(payload.HiveID) {
+		// Suppressed this beat; the WARN in allowAppKeyDelivery names the hive
+		// when the throttled delivery does go out. Returning nil (rather than
+		// stripping the key) keeps the wire contract simple: nothing rides.
+		return nil
+	}
+	s.noteAppKeyDelivered(payload.HiveID)
+	return cfg
 }

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -339,12 +339,18 @@ type HeartbeatPayload struct {
 	// but restarted 35 times — is visible in My Hives instead of looking
 	// healthy. A short uptime that keeps resetting is the tell.
 	StartedAt string `json:"started_at,omitempty"`
-	// Reporter is the pod name (os.Hostname) of the spoke PROCESS that sent
-	// this beat. It exists because two spoke instances can report as the same
-	// hive_id — a stale ReplicaSet pod surviving a rollout, or an orphaned
-	// duplicate deployment — and their alternating states made the dashboard
-	// flip every beat with nothing naming the culprit. Empty means the spoke
-	// is too old to report it: UNKNOWN, never evidence of anything.
+	// Reporter identifies the spoke PROCESS that sent this beat as
+	// "<pod-name>/<pid>" (hostname/PID; older spokes send the bare hostname).
+	// It exists because two spoke instances can report as the same hive_id —
+	// a stale ReplicaSet pod surviving a rollout, an orphaned duplicate
+	// deployment, or (#2453/#2496) a SECOND PROCESS in the same pod — and
+	// their alternating states made the dashboard flip every beat with
+	// nothing naming the culprit. The PID suffix is what makes the same-pod
+	// case visible: two processes in one pod share a hostname, so a bare pod
+	// name kept the hub's duplicate-spoke detector silent while the registry
+	// churned. The hub treats the whole string as an opaque identity, so old
+	// and new formats interoperate. Empty means the spoke is too old to
+	// report it: UNKNOWN, never evidence of anything.
 	Reporter string `json:"reporter,omitempty"`
 	// AdvisoryLastPostedAt is when this spoke last SUCCESSFULLY posted/updated
 	// its advisory-digest issue (RFC3339). It is the mirror of StartedAt for the

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -670,6 +670,12 @@ type HubServer struct {
 	// mutex for the same reason: touched on every beat.
 	statusFlipSeen map[string]*reporterFlipState
 	statusFlipMu   sync.Mutex
+	// appKeyDelivery tracks, per hive, consecutive GitHub App key deliveries
+	// that the spoke never reflected, so a broken reporter cannot pull key
+	// material onto the wire every beat forever (app_key_backoff.go, #2496).
+	// Own mutex for the reporterSeen reason: touched on every beat.
+	appKeyDelivery   map[string]*appKeyDeliveryState
+	appKeyDeliveryMu sync.Mutex
 	// heartbeatSwitchTag tracks hives that should switch their deployment
 	// image to a specific tag (branch switch) via heartbeat, for clusters
 	// the hub can't reach over kubectl. Cleared once the spoke reports it.

--- a/v2/pkg/hub/spoke_restart.go
+++ b/v2/pkg/hub/spoke_restart.go
@@ -2,6 +2,8 @@ package hub
 
 import (
 	"net/http"
+	"sort"
+	"strings"
 	"time"
 )
 
@@ -25,18 +27,32 @@ const reporterConflictWindow = 15 * time.Minute
 // reporter is the signature of two live instances.
 const reporterFlipsToConfirm = 2
 
-// reporterFlipState is the per-hive memory behind noteReporter.
+// reporterFlipState is the per-hive memory behind noteReporter (and, minus
+// the seen set, noteStatusFlip).
 type reporterFlipState struct {
 	last     string // reporter of the most recent beat
 	prev     string // reporter seen immediately before last
 	flips    int    // times the reporter returned to a previously seen one
 	lastFlip time.Time
+	// seen maps every reporter observed within reporterConflictWindow to the
+	// time it last beat (noteReporter only; noteStatusFlip never populates
+	// it). Tracking the SET rather than only prev/last is what closes the
+	// ≥3-reporter blind spot found in #2496: with 4-5 senders rotating
+	// (A,B,C,A,B,C,…) a beat almost never returns to the IMMEDIATELY
+	// preceding reporter, so a prev-only comparison declared "fresh handover"
+	// forever and the conflict was never flagged. A return to ANY recently
+	// seen reporter is the signature of concurrent instances.
+	seen map[string]time.Time
 }
 
 // noteReporter records which spoke instance sent this beat and returns a
-// non-empty "a ↔ b" description while two instances are alternating as the
-// same hive. Empty reporter (a spoke too old to report one) is UNKNOWN and
-// never counts for or against a conflict — the state is left untouched.
+// non-empty "a ↔ b" (or "a ↔ b ↔ c …") description while two or more
+// instances are alternating as the same hive. Reporters are opaque identity
+// strings: modern spokes send "<pod>/<pid>" so even two processes in ONE pod
+// (#2453/#2496) alternate visibly as "pod-x/123 ↔ pod-x/456"; older spokes
+// send the bare pod name and keep working unchanged. Empty reporter (a spoke
+// too old to report one) is UNKNOWN and never counts for or against a
+// conflict — the state is left untouched.
 func (s *HubServer) noteReporter(hiveID, reporter string) string {
 	if reporter == "" {
 		return ""
@@ -46,32 +62,50 @@ func (s *HubServer) noteReporter(hiveID, reporter string) string {
 	if s.reporterSeen == nil {
 		s.reporterSeen = make(map[string]*reporterFlipState)
 	}
+	now := time.Now()
 	st := s.reporterSeen[hiveID]
 	if st == nil {
-		st = &reporterFlipState{last: reporter}
+		st = &reporterFlipState{last: reporter, seen: map[string]time.Time{reporter: now}}
 		s.reporterSeen[hiveID] = st
 		return ""
 	}
+	if st.seen == nil {
+		st.seen = make(map[string]time.Time)
+		st.seen[st.last] = now
+	}
+	// Age out reporters that have not beaten within the window BEFORE deciding
+	// whether this one "came back": a pod gone for longer than the window is a
+	// completed rollout, and its eventual reuse must not read as a conflict.
+	for r, ts := range st.seen {
+		if r != st.last && now.Sub(ts) >= reporterConflictWindow {
+			delete(st.seen, r)
+		}
+	}
 	if reporter != st.last {
-		if reporter == st.prev {
-			// The reporter came BACK — both instances are alive.
+		if _, cameBack := st.seen[reporter]; cameBack {
+			// The reporter returned while another was beating in between —
+			// multiple instances are alive.
 			st.flips++
 		} else {
-			// A reporter never seen adjacent to this one: treat as a fresh
-			// handover (rollout), not a conflict.
+			// A reporter never seen recently: treat as a fresh handover
+			// (rollout), not a conflict.
 			st.flips = 0
 		}
 		st.prev, st.last = st.last, reporter
-		st.lastFlip = time.Now()
+		st.lastFlip = now
 	}
-	if st.flips >= reporterFlipsToConfirm && time.Since(st.lastFlip) < reporterConflictWindow {
-		a, b := st.prev, st.last
-		if a > b {
-			a, b = b, a
+	st.seen[reporter] = now
+	if st.flips >= reporterFlipsToConfirm && now.Sub(st.lastFlip) < reporterConflictWindow {
+		// Name EVERY instance currently alternating, not just the last two —
+		// with 4-5 senders (#2496) the pair alone under-reports the fault.
+		names := make([]string, 0, len(st.seen))
+		for r := range st.seen {
+			names = append(names, r)
 		}
-		return a + " ↔ " + b
+		sort.Strings(names)
+		return strings.Join(names, " ↔ ")
 	}
-	if time.Since(st.lastFlip) >= reporterConflictWindow {
+	if now.Sub(st.lastFlip) >= reporterConflictWindow {
 		st.flips = 0
 	}
 	return ""

--- a/v2/pkg/hub/spoke_restart_test.go
+++ b/v2/pkg/hub/spoke_restart_test.go
@@ -36,6 +36,52 @@ func TestNoteReporterFlagsAlternation(t *testing.T) {
 	}
 }
 
+// Same-pod duplicate processes (#2496): the spoke reporter now carries the
+// PID ("pod/pid"), so two hive processes sharing ONE pod name alternate as
+// distinct identities and the conflict names the exact culprits. With the old
+// bare-hostname reporter both processes reported the identical string and this
+// detector stayed silent through 11+ alternating beats.
+func TestNoteReporterFlagsSamePodPIDAlternation(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+
+	s.noteReporter("h1", "pod-x/123")
+	s.noteReporter("h1", "pod-x/456")
+	s.noteReporter("h1", "pod-x/123")
+	got := s.noteReporter("h1", "pod-x/456")
+	if got == "" {
+		t.Fatal("same-pod PID alternation was not flagged — two processes in one pod would stay invisible")
+	}
+	if !strings.Contains(got, "pod-x/123") || !strings.Contains(got, "pod-x/456") {
+		t.Errorf("conflict does not name both processes precisely: %q", got)
+	}
+}
+
+// The ≥3-sender blind spot (#2496): with reporters ROTATING (A,B,C,A,B,C,…) a
+// beat almost never returns to the immediately preceding reporter, so a
+// prev-only comparison read every beat as a fresh handover and 4-5 concurrent
+// senders went completely undetected. A return to ANY recently seen reporter
+// must count as alternation, and the conflict must name every live sender.
+func TestNoteReporterFlagsThreeWayRotation(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+	rotation := []string{"pod-x/101", "pod-x/202", "pod-x/303"}
+
+	var got string
+	const rounds = 3
+	for i := 0; i < rounds; i++ {
+		for _, r := range rotation {
+			got = s.noteReporter("h1", r)
+		}
+	}
+	if got == "" {
+		t.Fatal("three-way sender rotation was never flagged (the #2496 blind spot)")
+	}
+	for _, r := range rotation {
+		if !strings.Contains(got, r) {
+			t.Errorf("conflict %q does not name live sender %s", got, r)
+		}
+	}
+}
+
 func TestNoteReporterSilentOnRolloutAndUnknown(t *testing.T) {
 	s := &HubServer{logger: slog.Default()}
 

--- a/v2/pkg/proclock/proclock.go
+++ b/v2/pkg/proclock/proclock.go
@@ -1,0 +1,116 @@
+// Package proclock provides an exclusive, self-releasing process singleton
+// lock built on flock(2).
+//
+// WHY THIS EXISTS (#2453, #2496)
+//
+// A spoke pod was observed running TWO hive processes at once: the registry's
+// startedAt alternated between two values beat to beat, 4-5 heartbeat senders
+// shared one pod name, and one process held a stale App-auth snapshot while
+// the other was healthy — the dashboard flipped state on every beat. The
+// in-process StartHeartbeat guard (#2462) is scoped to a single process and
+// is structurally blind to this class: each process passes its own guard.
+//
+// The only guard that works across processes is a kernel object both
+// processes contend on. flock gives exactly that, with the crucial property
+// that the lock is released automatically when the holding process dies —
+// however it dies (SIGKILL included). There is no stale-pidfile problem: a
+// lock file left on disk by a dead process is simply an unlocked file.
+//
+// The lock file must live on CONTAINER-LOCAL storage (/var/run, /tmp), never
+// on the shared /data PVC: during a rolling update (maxSurge=1) the old and
+// new PODS legitimately overlap, and on an RWX PVC a shared lock would
+// deadlock the surge pod against the terminating one. Same-pod duplicates —
+// the fault this exists to stop — always share the container filesystem.
+package proclock
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"syscall"
+)
+
+// lockFileMode is world-readable so the holder PID in the file is legible to
+// anything diagnosing the container; the file content is only a PID.
+const lockFileMode = 0o644
+
+// maxHolderBytes bounds how much of the lock file is read back for the error
+// message. The content is a PID and a newline; anything longer is garbage.
+const maxHolderBytes = 64
+
+// Lock is an acquired exclusive process lock. It holds the lock file open for
+// the life of the process; the kernel releases the flock when the file
+// descriptor closes, which happens at the latest when the process dies.
+type Lock struct {
+	file *os.File
+	path string
+}
+
+// Acquire takes a non-blocking exclusive flock on path, creating the file if
+// needed. On success it records the caller's PID in the file (for the NEXT
+// contender's error message) and returns a Lock that must be kept for the
+// process lifetime. When the lock is already held — by another process, or by
+// another open descriptor in this one — it returns an error naming the
+// holder's PID when one is legible.
+func Acquire(path string) (*Lock, error) {
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, lockFileMode)
+	if err != nil {
+		return nil, fmt.Errorf("open singleton lock file %s: %w", path, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		holder := readHolder(f)
+		f.Close()
+		if holder != "" {
+			return nil, fmt.Errorf("singleton lock %s is held by process %s: %w", path, holder, err)
+		}
+		return nil, fmt.Errorf("singleton lock %s is held by another process: %w", path, err)
+	}
+	// Best-effort PID record: the lock itself is the flock, not this content,
+	// so a failed write must not fail the acquisition.
+	if err := f.Truncate(0); err == nil {
+		if _, err := f.Seek(0, io.SeekStart); err == nil {
+			fmt.Fprintf(f, "%d\n", os.Getpid())
+			f.Sync()
+		}
+	}
+	return &Lock{file: f, path: path}, nil
+}
+
+// Path returns the lock file location, for logging.
+func (l *Lock) Path() string {
+	if l == nil {
+		return ""
+	}
+	return l.path
+}
+
+// Release drops the lock explicitly. Production code never needs to call it —
+// process death releases the flock — but tests acquiring and re-acquiring in
+// one process do.
+func (l *Lock) Release() {
+	if l == nil || l.file == nil {
+		return
+	}
+	syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+	l.file.Close()
+	l.file = nil
+}
+
+// readHolder returns the PID recorded in the lock file by its current holder,
+// or "" when none is legible.
+func readHolder(f *os.File) string {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return ""
+	}
+	buf := make([]byte, maxHolderBytes)
+	n, _ := f.Read(buf)
+	holder := strings.TrimSpace(string(buf[:n]))
+	// Only a plausible PID is worth naming; anything else is noise.
+	for _, r := range holder {
+		if r < '0' || r > '9' {
+			return ""
+		}
+	}
+	return holder
+}

--- a/v2/pkg/proclock/proclock_test.go
+++ b/v2/pkg/proclock/proclock_test.go
@@ -1,0 +1,95 @@
+package proclock
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The whole point of the lock (#2453/#2496): a second acquisition while the
+// first is held MUST fail. flock contention is per open file description, so
+// two Acquire calls in one process exercise the same kernel path a second
+// hive process in the same container would.
+func TestSecondAcquisitionFails(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hive.singleton.lock")
+
+	first, err := Acquire(path)
+	if err != nil {
+		t.Fatalf("first acquisition failed: %v", err)
+	}
+	defer first.Release()
+
+	second, err := Acquire(path)
+	if err == nil {
+		second.Release()
+		t.Fatal("second concurrent acquisition succeeded — a duplicate hive process would be allowed to run")
+	}
+	// The refusal must name the holder so the container log points at the
+	// culprit PID, not just "locked".
+	wantPID := fmt.Sprintf("%d", os.Getpid())
+	if !strings.Contains(err.Error(), wantPID) {
+		t.Errorf("refusal does not name the holder PID %s: %v", wantPID, err)
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("refusal does not name the lock path: %v", err)
+	}
+}
+
+// Releasing the lock (as process death does implicitly) must make the lock
+// acquirable again — a legitimate restart is never blocked by the previous
+// process's leftover lock FILE, only by a still-LIVE holder.
+func TestReleaseAllowsReacquisition(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hive.singleton.lock")
+
+	first, err := Acquire(path)
+	if err != nil {
+		t.Fatalf("first acquisition failed: %v", err)
+	}
+	first.Release()
+
+	second, err := Acquire(path)
+	if err != nil {
+		t.Fatalf("re-acquisition after release failed — a stale lock file blocked a clean restart: %v", err)
+	}
+	second.Release()
+}
+
+// The holder records its PID in the file for diagnosability.
+func TestLockFileRecordsHolderPID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hive.singleton.lock")
+	l, err := Acquire(path)
+	if err != nil {
+		t.Fatalf("acquisition failed: %v", err)
+	}
+	defer l.Release()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("lock file unreadable: %v", err)
+	}
+	want := fmt.Sprintf("%d", os.Getpid())
+	if strings.TrimSpace(string(data)) != want {
+		t.Errorf("lock file records %q, want holder PID %q", strings.TrimSpace(string(data)), want)
+	}
+	if l.Path() != path {
+		t.Errorf("Path() = %q, want %q", l.Path(), path)
+	}
+}
+
+// An unwritable location must fail loudly, not silently skip the guard.
+func TestUnwritableLocationErrors(t *testing.T) {
+	if _, err := Acquire(filepath.Join(t.TempDir(), "no-such-dir", "hive.lock")); err == nil {
+		t.Fatal("acquiring in a nonexistent directory succeeded")
+	}
+}
+
+// Nil-safety for the accessors (defensive: Release on a failed acquisition).
+func TestNilLockSafe(t *testing.T) {
+	var l *Lock
+	l.Release() // must not panic
+	if l.Path() != "" {
+		t.Error("nil lock has a path")
+	}
+}


### PR DESCRIPTION
## Summary

Second episode of the duplicate-sender fault (#2496, first seen as #2453): a spoke pod ran **two hive processes concurrently** — \`startedAt\` alternated in the registry beat to beat, the hub counted 4-5 heartbeat senders behind ONE pod name, and App key material was re-pushed on every beat of the broken sender for 30+ minutes. Three defenses, each covering a blindness the incident proved:

### 1. Process-level singleton (the root fix) — \`pkg/proclock\`
\`main()\` takes an exclusive **flock** on a container-local lock file before doing anything else. A second hive process in the same container logs an ERROR naming the holder's PID and exits with a distinct code (18). Because the lock is a kernel flock, it releases automatically on process death — no stale-pidfile problem, a crashed holder never blocks a restart.

- Lock lives on **container-local tmpfs** (\`/var/run/hive-metrics\`, \`/tmp\` fallback, \`HIVE_SINGLETON_LOCK\` override / \`off\` escape hatch) — deliberately **not** \`/data\`: the PVC spans PODS during a rolling update (maxSurge=1), and a pod-spanning lock would deadlock the surge pod against the terminating one. Same-pod duplicates always share the container filesystem.
- The #2462 \`StartHeartbeat\` guard is per-process and structurally cannot see this class; the flock can.

### 2. Reporter carries process identity
The heartbeat \`Reporter\` is now \`<hostname>/<pid>\` instead of bare \`os.Hostname()\`. Same-pod duplicates now alternate as distinct identities and the hub's duplicate-spoke detector names the culprits precisely: \`pod-x/123 ↔ pod-x/456\`. The hub compares the whole string as an opaque identity, so **old spokes sending bare hostnames keep working unchanged** — no payload schema change.

Also closes the **≥3-sender rotation blind spot** called out in #2496: \`noteReporter\` previously only compared against the immediately preceding reporter, so senders rotating A,B,C,A,B,C… never fired the detector. It now tracks the set of reporters seen within the conflict window; a return to ANY recently seen reporter counts as alternation, and the conflict string names every live sender.

### 3. Key-delivery convergence back-off (hub)
A spoke that reports **no key fingerprint** (or never lists a delivered additional key as held) previously pulled App private-key material onto the wire **every beat, forever** — the exact non-converging hot loop in the #2496 (and #2453 precursor) logs. Both delivery paths — the primary cluster-key reconcile (\`appKeySyncForHeartbeat\`) and the additional-keys pass (\`attachMissingAppKeys\`) — now share a per-hive ledger:

- first \`appKeyDeliveryImmediateBudget\` (6) consecutive deliveries stay **immediate** — a genuinely new spoke is keyed on its first beats exactly as before;
- past the budget, delivery throttles to one per **10 minutes**, with a WARN naming the hive and the consecutive-delivery count;
- any sign of convergence (a beat needing no key material while the spoke reports a fingerprint) resets the ledger in full.

## Spawner audit (#2453)

Audited \`deploy/entrypoint.sh\` and every launch path: the hive binary is launched exactly once (\`hive "\$@" &\` … \`wait\`), the wrapper exits when the binary does, there is **no respawn loop for the hive binary** and no \`exec\`/re-exec path in the Go code (the self-upgrade path exits or blocks for SIGTERM; \`RolloutRestartSelf\` replaces the pod, not the process). No \`shareProcessNamespace\` in any pod spec. **The concrete in-container duplication mechanism remains unidentified** — which is exactly why the flock guard is unconditional rather than a fix to one spawner. #2453 stays open for the trigger; a future occurrence will now be stopped at startup and logged with the holder PID, which is also the forensic breadcrumb needed to finally name the spawner.

## Tests (each mutation-verified)

- \`pkg/proclock\`: second concurrent acquisition of a real flock fails naming the holder PID; release/death allows reacquisition. *Mutation: removing the flock → test fails.*
- \`cmd/hive\` + \`pkg/hub\`: reporter format includes the PID; \`noteReporter\` flags \`pod-x/123 ↔ pod-x/456\` alternation AND 3-way rotation, naming all senders. *Mutations: stripping the PID → format test fails; restoring prev-only comparison → rotation test fails.*
- \`pkg/hub\`: N immediate deliveries then suppression on both delivery paths; resumes after the interval; ledger resets on convergence. *Mutation: removing the back-off → both delivery tests fail.*

Full \`pkg/hub\`, \`pkg/dashboard\`, \`pkg/config\`, \`cmd/hive\` suites green.

Fixes #2496
Refs #2453

🤖 Generated with [Claude Code](https://claude.com/claude-code)