### PR TITLE
🐛 fix(hub): data race on registryPath global between test writers and leaked saveLoop readers

### DIFF
--- a/v2/pkg/hub/fleet_stats_test.go
+++ b/v2/pkg/hub/fleet_stats_test.go
@@ -357,10 +357,9 @@ func TestComputeFleetStatsSkipsRepolessHives(t *testing.T) {
 // into a temp dir, so recordFleetStatsLKG's requestSave cannot touch /data.
 func fleetStatsLKGTestServer(t *testing.T) *HubServer {
 	t.Helper()
-	old := registryPath
-	registryPath = t.TempDir() + "/reg.json"
-	t.Cleanup(func() { registryPath = old })
-	return &HubServer{logger: slog.Default()}
+	// Per-server field, not the registryPath global: mutating the global races
+	// leaked saveLoop goroutines from servers built by other tests.
+	return &HubServer{logger: slog.Default(), registryPath: t.TempDir() + "/reg.json"}
 }
 
 func decodeFleetStats(t *testing.T, s *HubServer) FleetStats {
@@ -535,7 +534,7 @@ func TestFleetStatsLKG_PersistsAcrossReload(t *testing.T) {
 		t.Fatalf("saveRegistryNow: %v", err)
 	}
 	var reloaded Registry
-	data, err := os.ReadFile(registryPath)
+	data, err := os.ReadFile(s.registryPath)
 	if err != nil {
 		t.Fatalf("read registry: %v", err)
 	}

--- a/v2/pkg/hub/provision_approve_coverage_test.go
+++ b/v2/pkg/hub/provision_approve_coverage_test.go
@@ -19,25 +19,25 @@ import (
 func TestLoadRegistry(t *testing.T) {
 	dir := t.TempDir()
 
-	// Missing file -> starts fresh, no error.
-	old := registryPath
-	registryPath = filepath.Join(dir, "missing.json")
-	defer func() { registryPath = old }()
-	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	// Missing file -> starts fresh, no error. The path is a per-server field,
+	// NOT the registryPath global: writing the global here raced the leaked
+	// saveLoop goroutines of servers built by earlier tests (nothing closes
+	// saveCh), which read it at use time before the field existed.
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, registryPath: filepath.Join(dir, "missing.json")}
 	s.loadRegistry()
 
 	// Valid file -> loads hives.
-	registryPath = filepath.Join(dir, "reg.json")
-	os.WriteFile(registryPath, []byte(`{"hives":[{"id":"h1"},{"id":"h2"}]}`), 0o644)
-	s2 := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	regFile := filepath.Join(dir, "reg.json")
+	os.WriteFile(regFile, []byte(`{"hives":[{"id":"h1"},{"id":"h2"}]}`), 0o644)
+	s2 := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, registryPath: regFile}
 	s2.loadRegistry()
 	if len(s2.registry.Hives) != 2 {
 		t.Errorf("expected 2 hives loaded, got %d", len(s2.registry.Hives))
 	}
 
 	// Bad JSON -> logged, registry left empty.
-	os.WriteFile(registryPath, []byte(`{not json`), 0o644)
-	s3 := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	os.WriteFile(regFile, []byte(`{not json`), 0o644)
+	s3 := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, registryPath: regFile}
 	s3.loadRegistry()
 	if len(s3.registry.Hives) != 0 {
 		t.Errorf("bad JSON should leave registry empty, got %d", len(s3.registry.Hives))

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -29,8 +29,12 @@ import (
 //go:embed static/*
 var staticFS embed.FS
 
-// registryPath is the on-disk hub registry file. A var (not a const) so tests
-// can redirect it at a temp file; production keeps the default.
+// registryPath is the DEFAULT on-disk hub registry file. A var (not a const)
+// so tests can redirect it at a temp file before constructing a server;
+// production keeps the default. NewHubServer copies it into the per-instance
+// HubServer.registryPath at construction, and all production reads and writes
+// go through that field — never this global — so a saveLoop goroutine leaked
+// by one test's server can never race a later test reassigning this var.
 var registryPath = "/data/hub-registry.json"
 
 // hubBannersPath is the on-disk file where admin-sent banners are persisted so
@@ -591,11 +595,18 @@ type HeartbeatHealthEntry struct {
 }
 
 type HubServer struct {
-	mux          *http.ServeMux
-	registry     Registry
-	mu           sync.RWMutex
-	logger       *slog.Logger
-	saveCh       chan struct{}
+	mux      *http.ServeMux
+	registry Registry
+	mu       sync.RWMutex
+	logger   *slog.Logger
+	saveCh   chan struct{}
+	// registryPath is this server's on-disk registry file, captured from the
+	// package-level default at construction and immutable afterwards. It is a
+	// per-instance field (not a use-time read of the global) so the saveLoop
+	// goroutine — which outlives test servers, since nothing closes saveCh —
+	// only ever sees its own path and cannot race a test redirecting the
+	// global for the next server (the TestLoadRegistry -race failure).
+	registryPath string
 	hubGitHash   string
 	hubGitBranch string
 	hubSecret    string
@@ -852,6 +863,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		mux:                     http.NewServeMux(),
 		logger:                  logger,
 		saveCh:                  make(chan struct{}, 1),
+		registryPath:            registryPath,
 		hubGitHash:              gitHash,
 		hubGitBranch:            gitBranch,
 		hubSecret:               secret,
@@ -2293,6 +2305,20 @@ func (s *HubServer) removeRegistryEntry(id, by string) {
 	s.logger.Info("audit: registry entry removed", "id", id, "by", by)
 }
 
+// regPath returns this server's registry file path: the per-instance field
+// captured at construction, or — for servers built directly in tests as bare
+// &HubServer{...} literals without one — the package-level default. The
+// fallback cannot reintroduce the registryPath data race: only NewHubServer
+// starts a saveLoop goroutine (the sole reader that outlives its test), and
+// NewHubServer always sets the field, so the global is only ever read from a
+// test's own goroutine, synchronously with any test redirecting it.
+func (s *HubServer) regPath() string {
+	if s.registryPath != "" {
+		return s.registryPath
+	}
+	return registryPath
+}
+
 // saveRegistryNow marshals and writes the registry to disk immediately, via a
 // temp file plus atomic rename so a crash mid-write cannot truncate it.
 func (s *HubServer) saveRegistryNow() error {
@@ -2302,11 +2328,12 @@ func (s *HubServer) saveRegistryNow() error {
 	if err != nil {
 		return fmt.Errorf("marshal hub registry: %w", err)
 	}
-	tmpPath := registryPath + ".tmp"
+	path := s.regPath()
+	tmpPath := path + ".tmp"
 	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
 		return fmt.Errorf("write hub registry: %w", err)
 	}
-	if err := os.Rename(tmpPath, registryPath); err != nil {
+	if err := os.Rename(tmpPath, path); err != nil {
 		return fmt.Errorf("rename hub registry: %w", err)
 	}
 	return nil
@@ -2464,7 +2491,7 @@ func (s *HubServer) serveStatic(path string) http.HandlerFunc {
 }
 
 func (s *HubServer) loadRegistry() {
-	data, err := os.ReadFile(registryPath)
+	data, err := os.ReadFile(s.regPath())
 	if err != nil {
 		s.logger.Info("no existing hub registry, starting fresh")
 		return
@@ -2535,12 +2562,12 @@ func (s *HubServer) saveLoop() {
 			s.logger.Warn("hub registry marshal failed", "error", err)
 			continue
 		}
-		tmpPath := registryPath + ".tmp"
+		tmpPath := s.registryPath + ".tmp"
 		if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
 			s.logger.Warn("hub registry save failed", "path", tmpPath, "error", err)
 			continue
 		}
-		if err := os.Rename(tmpPath, registryPath); err != nil {
+		if err := os.Rename(tmpPath, s.registryPath); err != nil {
 			s.logger.Warn("hub registry rename failed", "error", err)
 		}
 	}


### PR DESCRIPTION
## Problem

Post-merge CI on v2 HEAD (2ce52cf) went red: `TestLoadRegistry` failed with \`race detected during execution of test\` in [run 30862900225](https://github.com/kubestellar/hive/actions/runs/30862900225).

The detector's two stacks name the pair exactly:

- **Write**: `TestLoadRegistry` at `pkg/hub/provision_approve_coverage_test.go:24` reassigning the package-level `registryPath` var at a temp file.
- **Read**: the `saveLoop` goroutine (`pkg/hub/server.go`, `tmpPath := registryPath + ".tmp"`) of a `HubServer` built by an earlier test (`TestHeartbeatUpgradeToForSpokeManaged`). Nothing closes `saveCh`, so every test-built server's `saveLoop` outlives its test and keeps reading the global at use time.

Any test that redirects `registryPath` can race any previously leaked `saveLoop`, so the failure is order- and timing-dependent — which is why it only fired post-merge.

## Fix (at the root)

The registry file path becomes per-instance state:

- New immutable `HubServer.registryPath` field, captured from the package default in `NewHubServer`.
- `saveLoop` — the only reader that outlives its test — reads **only** the field, never the global.
- `loadRegistry` / `saveRegistryNow` go through a `regPath()` accessor: the field when set, falling back to the package default for servers constructed directly in tests as bare `&HubServer{...}` literals. The fallback cannot race: such servers never start a `saveLoop`, so the global is only ever read from a test's own goroutine, synchronously with any redirect.
- `TestLoadRegistry` and `fleetStatsLKGTestServer` now set the field instead of mutating the global; tests that redirect the global before `NewHubServer` keep working via the construction-time snapshot.

## Verification

- `go test -race ./pkg/hub/ -count=2` fully green (was flaky-red on CI).
- Mutation check: reintroducing the unlocked global read in `saveLoop` and driving it with a targeted repro (leaked `saveLoop` + concurrent global redirect) makes `-race` fail with the same `saveLoop` stack; restoring the fix makes the identical repro pass.
- No behavior change in production: the field is captured from the same default the global has always held.