### PR TITLE
feat(governor): count open PRs toward mode pressure (mk backport)

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3745,8 +3745,12 @@
         const OC_THRESH_QUIET = govThresh.quiet ?? 2;
         const OC_THRESH_BUSY = govThresh.busy ?? 10;
         const OC_THRESH_SURGE = govThresh.surge ?? 20;
-        const OC_GAUGE_MAX = Math.max(OC_THRESH_SURGE + 10, govActionable + 5);
-        const gaugePct = Math.min(govActionable / OC_GAUGE_MAX * 100, 100);
+        // Mode pressure = actionable issues + open PRs, matching the
+        // governor's computeMode input — an issues-only needle read "idle"
+        // while a 20+ PR backlog sat unmerged.
+        const govPressure = govActionable + govPrs;
+        const OC_GAUGE_MAX = Math.max(OC_THRESH_SURGE + 10, govPressure + 5);
+        const gaugePct = Math.min(govPressure / OC_GAUGE_MAX * 100, 100);
         govOuter.innerHTML = `
           <div class="gov-metric"><span class="gm-label">timer</span><span class="gm-val" style="color:var(--green)">${gov.active !== false ? '● active' : '○ off'}</span></div>
           <div class="gov-metric"><span class="gm-label">mode</span><span class="gm-val ${govModeClass}">${esc(gov.mode || '—')}</span></div>
@@ -3758,7 +3762,7 @@
             <div class="temp-gauge-track" style="background:linear-gradient(to right, var(--green) 0%, var(--green) ${OC_THRESH_QUIET/OC_GAUGE_MAX*100}%, var(--blue) ${OC_THRESH_QUIET/OC_GAUGE_MAX*100}%, var(--blue) ${OC_THRESH_BUSY/OC_GAUGE_MAX*100}%, var(--yellow) ${OC_THRESH_BUSY/OC_GAUGE_MAX*100}%, var(--yellow) ${OC_THRESH_SURGE/OC_GAUGE_MAX*100}%, var(--red) ${OC_THRESH_SURGE/OC_GAUGE_MAX*100}%, var(--red) 100%)">
               <div class="temp-gauge-glow" style="width:100%"></div>
               <div class="temp-gauge-ticks"><span style="left:2%;-webkit-transform:translate(0,-50%);transform:translate(0,-50%)">0</span><span style="left:${OC_THRESH_QUIET/OC_GAUGE_MAX*100}%;-webkit-transform:translate(-50%,-50%);transform:translate(-50%,-50%)">${OC_THRESH_QUIET}</span><span style="left:${OC_THRESH_BUSY/OC_GAUGE_MAX*100}%;-webkit-transform:translate(-50%,-50%);transform:translate(-50%,-50%)">${OC_THRESH_BUSY}</span><span style="left:${OC_THRESH_SURGE/OC_GAUGE_MAX*100}%;-webkit-transform:translate(-50%,-50%);transform:translate(-50%,-50%)">${OC_THRESH_SURGE}</span><span style="left:98%;-webkit-transform:translate(-100%,-50%);transform:translate(-100%,-50%)">${OC_GAUGE_MAX}</span></div>
-              <div class="temp-gauge-needle" style="left:${gaugePct}%" data-val="${govActionable}"></div>
+              <div class="temp-gauge-needle" style="left:${gaugePct}%" data-val="${govPressure}"></div>
             </div>
             <div class="temp-gauge-labels">
               <span class="tl-idle" style="position:absolute;left:${OC_THRESH_QUIET / OC_GAUGE_MAX * 50}%;transform:translateX(-50%)">idle</span>

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -223,7 +223,12 @@ func (g *Governor) Evaluate(queueIssues, queuePRs, queueHold, slaViolations int)
 	g.state.SLAViolations = slaViolations
 	g.state.LastEval = time.Now()
 
-	newMode := g.computeMode(queueIssues)
+	// Queue pressure is actionable issues PLUS open PRs. Issues alone let the
+	// governor idle while a large PR backlog sat unmerged (observed 2026-08-03:
+	// 23 open PRs, 1 actionable issue → idle cadence → merge sweeps too rare
+	// to drain the queue). Held items stay excluded — they are waiting on a
+	// human by definition and faster kicks cannot move them.
+	newMode := g.computeMode(queueIssues + queuePRs)
 	modeChanged := newMode != g.state.Mode
 	if modeChanged {
 		g.logger.Info("governor mode change",

--- a/v2/pkg/governor/governor_test.go
+++ b/v2/pkg/governor/governor_test.go
@@ -149,6 +149,30 @@ func TestEvaluate_ReturnsCorrectMode(t *testing.T) {
 	}
 }
 
+func TestEvaluate_OpenPRsCountTowardModePressure(t *testing.T) {
+	// Mode pressure is issues + open PRs. Issues alone let the governor idle
+	// while a large PR backlog sat unmerged (2026-08-03: 23 open PRs, 1
+	// actionable issue → idle cadence → merge sweeps too rare to drain).
+	cfg, agents := standardConfig("scanner")
+	g := New(cfg, agents, testLogger())
+
+	g.Evaluate(1, 15, 0, 0)
+	if s := g.GetState(); s.Mode != ModeBusy {
+		t.Errorf("expected BUSY with issues=1 prs=15 (pressure 16), got %s", s.Mode)
+	}
+
+	g.Evaluate(0, 25, 0, 0)
+	if s := g.GetState(); s.Mode != ModeSurge {
+		t.Errorf("expected SURGE with issues=0 prs=25 (pressure 25), got %s", s.Mode)
+	}
+
+	// Held items must NOT add pressure — they are waiting on a human.
+	g.Evaluate(0, 0, 30, 0)
+	if s := g.GetState(); s.Mode != ModeIdle {
+		t.Errorf("expected IDLE with only held items queued, got %s", s.Mode)
+	}
+}
+
 func TestEvaluate_UpdatesQueueFields(t *testing.T) {
 	cfg, agents := standardConfig()
 	g := New(cfg, agents, testLogger())


### PR DESCRIPTION
Backport of #2509 to `mk` — governor mode pressure is now actionable issues + open PRs (held items still excluded), and the dashboard gauge shows the same combined number. Fixes the idle-governor-with-full-PR-queue failure observed on the console hive 2026-08-03. Clean cherry-pick, regression test included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)