### PR TITLE
🐛 fix(hub): stop perpetual 'Upgrading' with a zero/stale start timestamp

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -12252,12 +12252,24 @@ const dashboardHTML = `<!DOCTYPE html>
        as a lie. */
     var UPGRADE_ELAPSED_SKEW_TOLERANCE_MS = 60 * 1000; // treat small negatives as 0
 
+    /* Go serialises a zero time.Time as "0001-01-01T00:00:00Z" and — because
+       json:"...,omitempty" does NOT omit a zero struct — the hub emits exactly
+       that string for a hive whose UpgradeStartedAt was never set or was reset.
+       Date.parse() accepts it happily, and now − year 0001 is ~17.7 MILLION
+       hours: the live "Upgrading 17755944h28m" wedge on ibm-alchemy. Any
+       upgradeStartedAt at or before this cutoff is not a real start time but a
+       lost/zero one, and the counter must be suppressed rather than rendered as
+       a two-thousand-year duration. 2020-01-01 predates the project itself, so
+       no genuine upgrade can legitimately fall before it. */
+    var UPGRADE_STARTED_MIN_SANE_MS = Date.UTC(2020, 0, 1); // any earlier start time is a lost/zero timestamp
+
     /* upgradeElapsedMs returns how long a hive has been upgrading, in ms, or
-       null when that cannot be known — a MISSING, EMPTY or UNPARSEABLE
-       upgradeStartedAt, or a negative elapsed beyond the skew tolerance.
-       Callers must render nothing on null; they must never render NaN, a
-       negative duration, or a fabricated "0s" that implies the upgrade just
-       started when in truth the timestamp was lost.
+       null when that cannot be known — a MISSING, EMPTY, UNPARSEABLE or
+       PRE-EPOCH (zero/lost) upgradeStartedAt, or a negative elapsed beyond the
+       skew tolerance. Callers must render nothing on null; they must never
+       render NaN, a negative duration, a two-thousand-year duration, or a
+       fabricated "0s" that implies the upgrade just started when in truth the
+       timestamp was lost.
 
        Note a real server behaviour this relies on: upgradeStartedAt is stamped
        ONLY where Upgrading is set true, so a hive that is merely QUEUED has no
@@ -12268,6 +12280,7 @@ const dashboardHTML = `<!DOCTYPE html>
       if (!started || typeof started !== 'string') return null;
       var t = Date.parse(started);
       if (isNaN(t)) return null; /* unparseable timestamp — show nothing, never NaN */
+      if (t < UPGRADE_STARTED_MIN_SANE_MS) return null; /* zero/lost start time (year 0001) — never a real "17.7M hour" upgrade */
       var elapsed = (typeof nowMs === 'number' ? nowMs : Date.now()) - t;
       if (elapsed < 0) {
         /* Clock skew. A small negative is the browser being marginally behind

--- a/v2/pkg/hub/stale_upgrade.go
+++ b/v2/pkg/hub/stale_upgrade.go
@@ -82,17 +82,25 @@ func evaluateOrphanedUpgrade(entry *RegistryEntry, now time.Time) upgradeAttempt
 	if entry.UpgradeFailed {
 		return ev
 	}
-	// Without a start timestamp there is no elapsed time to reason about. The
-	// auto-upgrade recovery path treats a zero timestamp as stale, but that path
-	// re-arms delivery rather than clearing state; clearing on no evidence at
-	// all would risk dropping a genuinely fresh upgrade, so we decline.
-	if entry.UpgradeStartedAt.IsZero() {
-		return ev
-	}
-
-	ev.elapsed = now.Sub(entry.UpgradeStartedAt)
-	if ev.elapsed < orphanedUpgradeClearAfter {
-		return ev
+	// A zero UpgradeStartedAt with Upgrading still latched is not a fresh
+	// upgrade — every path that sets Upgrading=true stamps UpgradeStartedAt to
+	// time.Now() in the same breath (saas.go, saas_bulk.go), so a zero value can
+	// only mean the timestamp was lost or reset while the flag survived. That is
+	// the exact live wedge on ibm-alchemy: Upgrading=true, UpgradeStartedAt =
+	// 0001-01-01, which the dashboard rendered as "Upgrading 17755944h28m" and
+	// which no elapsed-based sweep can ever reach because there is no elapsed to
+	// measure. We must not simply return here (the previous behaviour, which is
+	// what let ibm-alchemy stay wedged forever); instead we skip the
+	// elapsed-time gate and fall through to the SAME liveness evidence used for a
+	// real stale upgrade. We still only clear when the spoke has demonstrably
+	// checked in since — and is not already on the target — so a genuinely
+	// fresh upgrade whose stamp merely lags a beat is never dropped.
+	zeroStart := entry.UpgradeStartedAt.IsZero()
+	if !zeroStart {
+		ev.elapsed = now.Sub(entry.UpgradeStartedAt)
+		if ev.elapsed < orphanedUpgradeClearAfter {
+			return ev
+		}
 	}
 
 	// Evidence: has the spoke checked in since we instructed the upgrade?
@@ -117,9 +125,17 @@ func evaluateOrphanedUpgrade(entry *RegistryEntry, now time.Time) upgradeAttempt
 	}
 
 	ev.orphaned = true
-	ev.reason = "spoke heartbeated " + roundedDuration(now.Sub(lastBeat)) +
-		" ago still running " + orDash(entry.GitHash) +
-		", no upgrade attempt in flight"
+	if zeroStart {
+		// No trustworthy start time to report an elapsed from — the flag itself is
+		// the corruption. Name that so the timeline reads honestly.
+		ev.reason = "upgrade latched with no start time (lost/zero UpgradeStartedAt); spoke heartbeated " +
+			roundedDuration(now.Sub(lastBeat)) + " ago still running " + orDash(entry.GitHash) +
+			", no upgrade attempt in flight"
+	} else {
+		ev.reason = "spoke heartbeated " + roundedDuration(now.Sub(lastBeat)) +
+			" ago still running " + orDash(entry.GitHash) +
+			", no upgrade attempt in flight"
+	}
 	return ev
 }
 

--- a/v2/pkg/hub/stale_upgrade_test.go
+++ b/v2/pkg/hub/stale_upgrade_test.go
@@ -90,10 +90,39 @@ func TestEvaluateOrphanedUpgrade(t *testing.T) {
 			orphaned: false,
 		},
 		{
-			name: "not orphaned: no start timestamp means no elapsed time to judge",
+			// The ibm-alchemy live wedge: Upgrading latched with a ZERO
+			// UpgradeStartedAt (0001-01-01), which the dashboard rendered as
+			// "Upgrading 17755944h28m". A zero start can never be a fresh upgrade
+			// (every set-site stamps time.Now()), so with a live spoke still on the
+			// old SHA it must be cleared, not left wedged forever.
+			name: "orphaned: zero start time with a live spoke on the old SHA (ibm-alchemy wedge)",
 			entry: RegistryEntry{
 				Upgrading:     true,
 				GitHash:       "c11643a",
+				UpgradeTarget: "fc32ae4",
+				LastHeartbeat: rfc3339(fixedSweepNow.Add(-30 * time.Second)),
+			},
+			orphaned: true,
+		},
+		{
+			// A zero start is still only cleared on the same liveness evidence as a
+			// real stale upgrade. Never heartbeated ⇒ we cannot prove the attempt is
+			// gone, so we do not clear even with a zero timestamp.
+			name: "not orphaned: zero start time but the spoke never heartbeated",
+			entry: RegistryEntry{
+				Upgrading:     true,
+				GitHash:       "c11643a",
+				UpgradeTarget: "fc32ae4",
+			},
+			orphaned: false,
+		},
+		{
+			// Zero start, alive, but the spoke already reports the target SHA: the
+			// heartbeat path clears it, this sweep must not race ahead.
+			name: "not orphaned: zero start time but the spoke already reports the target",
+			entry: RegistryEntry{
+				Upgrading:     true,
+				GitHash:       "fc32ae4",
 				UpgradeTarget: "fc32ae4",
 				LastHeartbeat: rfc3339(fixedSweepNow.Add(-30 * time.Second)),
 			},
@@ -251,5 +280,39 @@ func TestSweepBelowBudgetStillReArms(t *testing.T) {
 	}
 	if got := s.heartbeatUpgrade["first-orphan"]; got != "fc32ae4" {
 		t.Errorf("below the budget the upgrade must still be re-armed, got %q", got)
+	}
+}
+
+// TestSweepUnwedgesZeroStartTimestamp is the anti-regression test for the live
+// ibm-alchemy wedge: a hive latched Upgrading=true with a ZERO UpgradeStartedAt
+// (0001-01-01) was NEVER swept, because the old evaluateOrphanedUpgrade bailed
+// on IsZero() before it ever looked at liveness evidence. It stayed "Upgrading"
+// forever with a 17.7M-hour counter and blocked any fresh upgrade from being
+// recognised. The sweep must now clear such a hive (given a live spoke still on
+// the old SHA) and re-arm delivery so it can upgrade again.
+func TestSweepUnwedgesZeroStartTimestamp(t *testing.T) {
+	s := &HubServer{
+		logger:           slog.Default(),
+		heartbeatUpgrade: make(map[string]string),
+	}
+	s.registry.Hives = []RegistryEntry{{
+		ID:            "ibm-alchemy-wedged",
+		Upgrading:     true,
+		GitHash:       "c11643a",
+		UpgradeTarget: "fc32ae4",
+		LastHeartbeat: rfc3339(time.Now().Add(-30 * time.Second)),
+		// UpgradeStartedAt left zero on purpose — the wedge itself.
+	}}
+	if !s.registry.Hives[0].UpgradeStartedAt.IsZero() {
+		t.Fatal("precondition: the wedged hive must carry a zero UpgradeStartedAt")
+	}
+
+	s.sweepOrphanedUpgrades()
+
+	if s.registry.Hives[0].Upgrading {
+		t.Error("a zero-timestamp wedged upgrade must be cleared, not left latched forever")
+	}
+	if got := s.heartbeatUpgrade["ibm-alchemy-wedged"]; got != "fc32ae4" {
+		t.Errorf("the un-wedged hive must be re-armed for delivery, got %q", got)
 	}
 }

--- a/v2/pkg/hub/upgrade_elapsed_ui_test.go
+++ b/v2/pkg/hub/upgrade_elapsed_ui_test.go
@@ -42,6 +42,7 @@ func TestUpgradeElapsedUsesNamedConstants(t *testing.T) {
 		"var UPGRADE_ELAPSED_AMBER_MS =",
 		"var UPGRADE_ELAPSED_MIN_SHOW_MS =",
 		"var UPGRADE_ELAPSED_SKEW_TOLERANCE_MS =",
+		"var UPGRADE_STARTED_MIN_SANE_MS =",
 		"var UPGRADE_FACET_STUCK_MS =",
 	} {
 		if !strings.Contains(dashboardHTML, decl) {
@@ -59,6 +60,9 @@ func TestUpgradeElapsedHandlesUnknownStartTime(t *testing.T) {
 		"if (!started || typeof started !== 'string') return null;",
 		// Unparseable timestamp — Date.parse yields NaN.
 		"if (isNaN(t)) return null;",
+		// Zero / lost start time (Go's 0001-01-01) parses fine but is decades
+		// before the cutoff — the live "17755944h" wedge. Must be suppressed.
+		"if (t < UPGRADE_STARTED_MIN_SANE_MS) return null;",
 		// Negative elapsed from clock skew.
 		"if (elapsed < 0) {",
 		"if (elapsed > -UPGRADE_ELAPSED_SKEW_TOLERANCE_MS) return 0;",
@@ -74,6 +78,36 @@ func TestUpgradeElapsedHandlesUnknownStartTime(t *testing.T) {
 	if !strings.Contains(dashboardHTML,
 		"if (typeof ms !== 'number' || isNaN(ms) || ms < 0) return '';") {
 		t.Error("formatUpgradeElapsed must reject NaN and negative durations")
+	}
+}
+
+// TestUpgradeElapsedRejectsZeroStartTime is the anti-regression test for the
+// live ibm-alchemy wedge: hosted-ibm-alchemy-logg-ptoo showed
+// "Upgrading 17755944h28m". Its UpgradeStartedAt was Go's zero time, which
+// json:"...,omitempty" does NOT omit for a struct, so the hub emitted
+// "0001-01-01T00:00:00Z". Date.parse() accepts it and now − year 0001 is
+// ~17.7 million hours. upgradeElapsedMs must reject any start time before the
+// sane epoch (2020-01-01, which predates the project) so the counter is
+// suppressed instead of rendering a two-thousand-year duration.
+func TestUpgradeElapsedRejectsZeroStartTime(t *testing.T) {
+	// The cutoff must be anchored to a real date, not left as a bare 0 or a
+	// magic number, and it must sit before any plausible real upgrade yet after
+	// Go's zero year so the year-0001 emission falls below it.
+	if !strings.Contains(dashboardHTML, "var UPGRADE_STARTED_MIN_SANE_MS = Date.UTC(2020, 0, 1);") {
+		t.Error("UPGRADE_STARTED_MIN_SANE_MS must be Date.UTC(2020, 0, 1) — the sane-epoch cutoff " +
+			"that rejects Go's 0001-01-01 zero-time emission")
+	}
+	// The guard must run BEFORE the elapsed subtraction, so a pre-epoch stamp
+	// returns null rather than flowing into a giant positive duration.
+	body := dashboardHTML
+	guardAt := strings.Index(body, "if (t < UPGRADE_STARTED_MIN_SANE_MS) return null;")
+	elapsedAt := strings.Index(body, "var elapsed = (typeof nowMs === 'number' ? nowMs : Date.now()) - t;")
+	if guardAt < 0 || elapsedAt < 0 {
+		t.Fatalf("guard/elapsed lines not both found (guard=%d elapsed=%d)", guardAt, elapsedAt)
+	}
+	if guardAt > elapsedAt {
+		t.Error("the pre-epoch guard must precede the elapsed computation, " +
+			"or the year-0001 timestamp would still yield a 17.7M-hour duration")
 	}
 }
 


### PR DESCRIPTION
## The bug (live)

A hive could sit pinned in **Upgrading** forever with an absurd elapsed time. Observed live on **ibm-alchemy** (\`hosted-ibm-alchemy-logg-ptoo\`) as **\"Upgrading 17755944h28m\"** (~2000 years).

Root cause: the hive's \`UpgradeStartedAt\` was Go's zero \`time.Time\`. \`json:\"...,omitempty\"\` does **not** omit a zero struct, so the hub emitted \`\"upgradeStartedAt\":\"0001-01-01T00:00:00Z\"\`. The dashboard's \`Date.parse\` accepted it and computed \`now − year 0001\` ≈ 17.7 million hours → the nonsense counter. Worse, the state never cleared, so the hive was wedged and a fresh upgrade couldn't be recognized.

## Fix — two independent defects

**1. Display guard** — \`v2/pkg/hub/saas.go\`, \`upgradeElapsedMs\`
The counter accepted any parseable timestamp, so year 0001 flowed into a giant positive duration. Added \`UPGRADE_STARTED_MIN_SANE_MS = Date.UTC(2020, 0, 1)\` (a date predating the project); a start time at or before it is a lost/zero stamp and the counter is suppressed (returns \`null\`) rather than rendering a two-thousand-year duration.

**2. Stale-clear** — \`v2/pkg/hub/stale_upgrade.go\`, \`evaluateOrphanedUpgrade\`
The orphan sweep bailed early on a zero \`UpgradeStartedAt\`, so it could **never** clear a hive wedged with a zero stamp — exactly the ibm-alchemy case. Since every set-site stamps \`time.Now()\` alongside \`Upgrading=true\`, a zero stamp can only be lost state, never a fresh upgrade. The sweep now skips only the elapsed-time gate for the zero case and falls through to the **same** liveness evidence (spoke alive, has checked in since, still on the old SHA) before clearing and re-arming delivery — so a genuinely fresh upgrade whose stamp merely lags is never dropped.

Display/state correctness only — upgrade delivery is unchanged. All thresholds are named constants with comments (no magic numbers).

## Tests
- Zero-time start (\`0001-01-01\`) renders no counter and is not treated as in-flight.
- A live spoke wedged with a zero stamp is un-wedged by the sweep and re-armed.
- A recent real start still shows a sane duration (no regression).
- A zero stamp with a silent / never-heartbeated spoke is left alone (conservative).

\`go build ./...\` clean, \`gofmt -l\` clean, \`go test ./pkg/hub/ ./pkg/dashboard/ -short\` green, inline JS \`node --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)