### PR TITLE
Fix guide agent git-clone auth on GitHub Enterprise hives

### DIFF
--- a/bin/git-credential-hive.sh
+++ b/bin/git-credential-hive.sh
@@ -1,9 +1,41 @@
 #!/bin/bash
 # git-credential-hive.sh — Git credential helper that uses the GitHub App token.
 # Reads from the cached token file, refreshing if stale (>55 min old).
-# Install: git config --global credential.https://github.com.helper /usr/local/bin/git-credential-hive.sh
+#
+# Install (github.com): git config --global credential.https://github.com.helper /usr/local/bin/git-credential-hive.sh
+# Install (GHE):         git config --global credential.https://<ghe-host>.helper /usr/local/bin/git-credential-hive.sh
+#
+# GHE-aware host matching: git invokes credential helpers once per remote host
+# and feeds `protocol=...` / `host=...` (and optionally `path=...`) on stdin
+# for the `get` operation (see git-credential(1)). A helper that ignores this
+# and always answers "host=github.com" — as this script did before — silently
+# returns NO credential for any other host git actually asked about, and git
+# then falls through to an interactive prompt, which fails hard in a
+# non-interactive agent shell with "terminal prompts disabled". This version
+# echoes back whatever host git asked for (once it has confirmed a token
+# exists for it) instead of a hardcoded "github.com", so the same script and
+# the same underlying App-installation token work for github.com AND any
+# configured GitHub Enterprise host (e.g. github.ibm.com) — entrypoint.sh
+# wires the credential.helper entry for the hive's actual configured host
+# (github.HostLabel() in the Go config), so this script only ever gets
+# invoked for a host it is actually supposed to answer for.
 
 set -euo pipefail
+
+# ── Read git's credential request off stdin (protocol=... / host=... lines,
+# terminated by a blank line) so we can echo the SAME host back. Git passes
+# this on `get`; other ops (store/erase) are no-ops below and don't need it,
+# but reading it unconditionally is harmless and keeps the parsing in one
+# place. See git-credential(1) "Credential Helpers" for the wire format.
+REQUEST_PROTOCOL=""
+REQUESTED_HOST=""
+while IFS='=' read -r _cred_key _cred_val; do
+  [ -z "$_cred_key" ] && break
+  case "$_cred_key" in
+    protocol) REQUEST_PROTOCOL="$_cred_val" ;;
+    host) REQUESTED_HOST="$_cred_val" ;;
+  esac
+done
 
 # ── UID-based identity verification (defense-in-depth) ──
 # When running under a per-agent UID (>= 2001), derive the agent name from
@@ -101,11 +133,24 @@ TOKEN_ACCESS_LOG="/var/run/hive-metrics/token-access.jsonl"
 
 case "${1:-}" in
   get)
-    printf '{"ts":"%s","agent":"%s","uid":%d,"op":"git-credential"}\n' \
-      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${AGENT:-unknown}" "$(id -u)" \
+    # Only ever answer for https — this script has no business supplying a
+    # credential for git+ssh or any other protocol, on any host.
+    if [ -n "$REQUEST_PROTOCOL" ] && [ "$REQUEST_PROTOCOL" != "https" ]; then
+      exit 0
+    fi
+    printf '{"ts":"%s","agent":"%s","uid":%d,"op":"git-credential","host":"%s"}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${AGENT:-unknown}" "$(id -u)" "${REQUESTED_HOST:-unknown}" \
       >> "$TOKEN_ACCESS_LOG" 2>/dev/null || true
+    # Echo back the SAME host git asked about (github.com, github.ibm.com, or
+    # any other configured GitHub Enterprise host) rather than a hardcoded
+    # "github.com" — see the file header. entrypoint.sh only registers this
+    # helper for `credential.https://<configured-host>.helper`, so by the time
+    # git invokes it for `get`, REQUESTED_HOST is already the one host this
+    # hive is authorized to answer for. Falling back to "github.com" when git
+    # sends no host at all (older git, or a manual invocation) preserves the
+    # previous behavior for the public-GitHub case.
     echo "protocol=https"
-    echo "host=github.com"
+    echo "host=${REQUESTED_HOST:-github.com}"
     echo "username=x-access-token"
     echo "password=$TOKEN"
     ;;

--- a/bin/hive-config.sh
+++ b/bin/hive-config.sh
@@ -17,7 +17,43 @@
 #   GH_APP_ID, GH_APP_INSTALLATION_ID, GH_APP_KEY_FILE,
 #   HIVE_GITHUB_TOKEN (auto-generated if GitHub App is configured), GH_TOKEN
 
-HIVE_REPO_DIR="${HIVE_REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd || echo /tmp/hive)}"
+# HIVE_REPO_DIR is meant to name the hive git checkout this script lives
+# under (e.g. /tmp/hive when this file is at /tmp/hive/bin/hive-config.sh,
+# used by hive-deploy.sh to `cd` in and `git pull`). In production this file
+# is COPIED (not checked out) to /usr/local/bin/hive-config.sh (see
+# v2/Dockerfile), so "one directory up from where this script lives" is
+# /usr/local — never a real hive checkout — and the naive derivation below
+# was WRONG for every deployed container even before considering the failure
+# mode below.
+#
+# It gets actively dangerous, not just wrong, when ${BASH_SOURCE[0]} is empty
+# — which happens when this file is sourced from a context where the
+# BASH_SOURCE array isn't populated as expected (e.g. `sh` rather than
+# `bash`, or certain non-interactive sourcing paths). `dirname ""` returns
+# ".", so `cd "./.." ` resolves relative to whatever the CALLER's cwd
+# happened to be at sourcing time. entrypoint.sh sources this file (as root,
+# before any `cd`) while the process's cwd can be "/" — so this silently
+# resolved to "/" rather than falling through to the "echo /tmp/hive"
+# fallback the original author intended (that fallback only fires if the
+# `cd` itself fails; `cd /..` succeeds — it just lands on "/"). This is the
+# root cause of a live guide-agent failure: HIVE_REPO_DIR=/ leaked into the
+# agent's shell env, and guide's own workspace (/data/agents/guide/workspace)
+# stayed empty because nothing sane can clone into "/".
+#
+# Fix: never derive from BASH_SOURCE at all. An explicit HIVE_REPO_DIR (env
+# override, e.g. for local dev running bin/ scripts straight from a git
+# checkout) always wins; otherwise default to a real, known-safe path.
+# hive-deploy.sh is the only real consumer and already treats HIVE_REPO_DIR
+# as "the hive git checkout to `git pull` in", so /tmp/hive (its own
+# pre-existing fallback default) is the correct unconditional default here.
+HIVE_REPO_DIR="${HIVE_REPO_DIR:-/tmp/hive}"
+# Guard of last resort: whatever produced this value (env override included),
+# an empty string or "/" can never be a valid HIVE_REPO_DIR — using either as
+# a clone/work/`cd` target is always a misconfiguration, never intentional.
+if [ -z "$HIVE_REPO_DIR" ] || [ "$HIVE_REPO_DIR" = "/" ]; then
+  echo "[hive-config.sh] WARNING: HIVE_REPO_DIR resolved to '${HIVE_REPO_DIR}' — refusing to use it, falling back to /tmp/hive" >&2
+  HIVE_REPO_DIR="/tmp/hive"
+fi
 export HIVE_REPO_DIR
 
 _HIVE_CONFIG="${HIVE_PROJECT_CONFIG:-/etc/hive/hive-project.yaml}"

--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -12,6 +12,19 @@ TIMESTAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 
 log() { echo "[$TIMESTAMP] $*" >> "$LOG" 2>/dev/null || true; }
 
+# Guard of last resort: this script does `cd "$HIVE_REPO"` followed by
+# `git checkout main --force` and `git reset --hard origin/main` (see the
+# recovery paths below). If HIVE_REPO_DIR were ever empty or "/" — which a
+# buggy derivation upstream in hive-config.sh could produce (see that file's
+# HIVE_REPO_DIR comment for the exact failure mode) — those commands would
+# operate on the filesystem root instead of a hive checkout. Refuse outright
+# rather than let a misconfigured HIVE_REPO_DIR anywhere upstream turn into a
+# destructive git operation on "/".
+if [ -z "$HIVE_REPO" ] || [ "$HIVE_REPO" = "/" ]; then
+  log "ERROR: HIVE_REPO_DIR resolved to '${HIVE_REPO}' — refusing to operate on it"
+  exit 1
+fi
+
 if [ ! -d "$HIVE_REPO/.git" ]; then
   log "ERROR: $HIVE_REPO is not a git repo"
   exit 1

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -740,6 +740,54 @@ git config --global user.email "hive-bot@kubestellar.io"
 git config --global --replace-all credential.helper ""
 git config --global --replace-all "credential.https://github.com.helper" "/usr/local/bin/git-credential-hive.sh"
 
+# Also wire the credential helper for this hive's ACTUAL GitHub host when it
+# is NOT public github.com (a GitHub Enterprise instance, e.g. github.ibm.com).
+#
+# Without this, a hive whose repos/App live on GHE only ever gets the helper
+# registered for credential.https://github.com.helper (above). git matches
+# credential helpers by exact host, so `git clone https://github.ibm.com/...`
+# never invokes ANY helper for that host, falls through to an interactive
+# prompt, and fails in this non-interactive shell with "fatal: could not read
+# Username for 'https://github.ibm.com': terminal prompts disabled" — this was
+# reported live from a GHE hive (devx-prod/epx-vscode-ext-poc) where scanner
+# and quality (which talk to the GitHub API, not git-over-HTTPS) worked fine
+# while guide's `git clone` could not authenticate at all.
+#
+# The host is derived the same way the Go binary's GitHubConfig.HostLabel()
+# derives it (pkg/config/config.go): prefer github.base_url, fall back to the
+# host portion of github.api_url, strip scheme and a trailing /api/v3, default
+# to github.com. Reading it here (from the same hive.yaml the Go binary reads)
+# rather than hardcoding "github.ibm.com" keeps this general for ANY configured
+# GHE host, and a no-op for a plain github.com hive (GHE_GIT_HOST resolves to
+# "github.com", which already has its helper wired above).
+GHE_GIT_HOST=""
+if [ -f "${HIVE_CONFIG:-/etc/hive/hive.yaml}" ]; then
+  GHE_GIT_HOST=$(python3 -c "
+import sys, yaml
+try:
+    with open(sys.argv[1]) as f:
+        cfg = yaml.safe_load(f) or {}
+except Exception:
+    sys.exit(0)
+gh = cfg.get('github') or {}
+pick = (gh.get('base_url') or gh.get('api_url') or '').strip()
+if pick.startswith('https://'):
+    pick = pick[len('https://'):]
+elif pick.startswith('http://'):
+    pick = pick[len('http://'):]
+pick = pick.rstrip('/')
+if pick.endswith('/api/v3'):
+    pick = pick[: -len('/api/v3')]
+host = pick.split('/', 1)[0]
+if host and host.lower() != 'api.github.com' and host.lower() != 'github.com':
+    print(host)
+" "${HIVE_CONFIG:-/etc/hive/hive.yaml}" 2>/dev/null) || true
+fi
+if [ -n "$GHE_GIT_HOST" ]; then
+  git config --global --replace-all "credential.https://${GHE_GIT_HOST}.helper" "/usr/local/bin/git-credential-hive.sh"
+  echo "[entrypoint] git credential helper wired for GitHub Enterprise host: ${GHE_GIT_HOST}"
+fi
+
 # Generate initial GitHub App token if credentials are available
 if [ -x /usr/local/bin/hive-config.sh ]; then
   . /usr/local/bin/hive-config.sh 2>/dev/null || true


### PR DESCRIPTION
## Problem

On a GitHub Enterprise hive (`github.ibm.com`), the **guide** agent cannot read repository content because `git clone` over HTTPS fails:

```
fatal: could not read Username for 'https://github.ibm.com': terminal prompts disabled
```

Meanwhile **scanner** and **quality** on the same hive read repo content fine — they go through the GitHub API (App installation token), not `git clone`. The failure is isolated to guide's git-clone-over-HTTPS path. This is a config/credential-helper bug, not a GitHub App permission problem — the App installation itself is fine, and 403/scope hypotheses in guide's own finding history were stale re-diagnosis before it converged on the credential helper.

Two independent bugs cause this:

### 1. `bin/git-credential-hive.sh` only ever answered for `github.com`

git's credential-helper protocol has git pass `protocol=https` / `host=<the-remote-host>` on stdin for a `get` request. This script ignored that entirely and always echoed back `host=github.com` in its response, regardless of what host git actually asked about. git matches credential helpers (and validates the credential they return) by exact host, so for any `github.ibm.com` remote, this helper effectively returned **no usable credential** — git then fell through to an interactive prompt, which fails hard in a non-interactive agent shell with the "terminal prompts disabled" error above.

**Fix**: the helper now reads git's stdin request (`protocol=`/`host=`) and echoes back the *same* host it was asked about, gated to `https` only. The underlying credential is unchanged — it's still the cached GitHub App installation token at `/var/run/hive-metrics/gh-app-token.cache` (or the per-agent scoped token), the exact same token source scanner/quality's API calls use. This is host-agnostic by design: it works for `github.com`, `github.ibm.com`, or any other configured GHE host without special-casing any of them.

### 2. `v2/deploy/entrypoint.sh` only ever wired the helper for `github.com`

Even with the helper fixed, git never invokes it for a host with no `credential.<url>.helper` entry. `entrypoint.sh` only ran:
```
git config --global credential.https://github.com.helper /usr/local/bin/git-credential-hive.sh
```
so a GHE hive's git config had no helper registered for `github.ibm.com` at all.

**Fix**: added a second `credential.https://<host>.helper` registration, where `<host>` is derived from the hive's configured `github.base_url` / `github.api_url` (`hive.yaml`) — preferring `base_url`, falling back to the host portion of `api_url`, stripping scheme and a trailing `/api/v3`. This mirrors exactly how `GitHubConfig.HostLabel()` derives the host in Go (`pkg/config/config.go`). It's general across any GHE host (not just github.ibm.com), and a no-op on a plain github.com hive (derivation yields nothing extra to wire, since github.com already has its helper registered above).

### 3. `HIVE_REPO_DIR` was `/`

Separately flagged in guide's diagnosis: `HIVE_REPO_DIR` resolved to `/` and guide's workspace (`/data/agents/guide/workspace`) stayed empty.

Root cause: `bin/hive-config.sh` derived `HIVE_REPO_DIR` as `dirname("${BASH_SOURCE[0]}")/..`. In the shipped container this file is *copied* (not checked out) to `/usr/local/bin/hive-config.sh`, so that derivation was already wrong (`/usr/local`, not a real checkout) — and it gets actively dangerous when `BASH_SOURCE[0]` is empty in the sourcing context: `dirname ""` returns `"."`, so `cd "./.."` resolves relative to whatever the *caller's* cwd was. `entrypoint.sh` sources this file as root before any `cd`, so the cwd can be `/` — landing `HIVE_REPO_DIR` on `/`.

**Fix**: dropped the `BASH_SOURCE`-based derivation entirely. `HIVE_REPO_DIR` now defaults to `/tmp/hive` (the same fallback the original code already intended for the "cd failed" case) unless explicitly overridden, plus a guard that refuses an empty or `/` value and falls back safely. Added the same guard in the one real consumer, `bin/hive-deploy.sh`, which does a destructive `git reset --hard` / `git checkout --force` inside `$HIVE_REPO_DIR` — so a stray `/` there is not just wrong, it's dangerous.

## Files changed

- `bin/git-credential-hive.sh` — host-aware credential response (parses git's stdin request instead of hardcoding `github.com`)
- `v2/deploy/entrypoint.sh` — wires `credential.https://<host>.helper` for the hive's actual configured GitHub host, derived the same way `GitHubConfig.HostLabel()` derives it in Go
- `bin/hive-config.sh` — fixed `HIVE_REPO_DIR` derivation bug + added an empty/`/` guard
- `bin/hive-deploy.sh` — added the same guard at its one real consumption point (defense in depth against a destructive git operation on `/`)

## Scope / regression check

- General across **any** GHE host — host is derived from the hive's own `github.base_url`/`api_url` config, never hardcoded to `github.ibm.com`.
- No behavior change on a plain `github.com` hive: the existing `credential.https://github.com.helper` wiring is untouched, and the new GHE-host wiring is a no-op when the config resolves to public GitHub.
- No Go files touched, so no Go-level test gap opened by this change; `go build ./...` passes unaffected. The shell changes were verified by hand (credential-helper host-echo logic against `github.ibm.com`, `github.com`, a non-`https` protocol, and a no-stdin legacy call; the entrypoint's host-derivation snippet against a GHE config with `base_url`, a GHE config with only `api_url`, and a plain public config). `shellcheck` is clean on all four changed files — only pre-existing warnings elsewhere in `entrypoint.sh`/`hive-deploy.sh` remain, none introduced here.