### PR TITLE
Stamp hosted namespace identity labels + name-bearing vanity Route

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3525,7 +3525,15 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 		"litellm":    litellmSectionResponse(&cfg.Governor.LiteLLM),
 		"trajectory": trajectorySectionResponse(&cfg.Governor),
 		"hub": map[string]interface{}{
-			"enabled":                          cfg.Hub.Enabled,
+			"enabled": cfg.Hub.Enabled,
+			// namespace is read-only, runtime-derived display info (never
+			// persisted to hive.yaml, never accepted back on save) — the
+			// Kubernetes namespace this pod is actually running in. See
+			// podNamespace's doc comment for the POD_NAMESPACE/NAMESPACE/
+			// service-account-file fallback chain. Omitted (empty string)
+			// outside a cluster, which the Hub tab renders by skipping the
+			// line rather than showing a blank/"undefined" value.
+			"namespace":                        podNamespace(),
 			"url":                              cfg.Hub.URL,
 			"dashboard_url":                    cfg.Hub.DashboardURL,
 			"snapshot_url":                     cfg.Hub.SnapshotURL,

--- a/v2/pkg/dashboard/pod_namespace.go
+++ b/v2/pkg/dashboard/pod_namespace.go
@@ -1,0 +1,46 @@
+package dashboard
+
+import (
+	"os"
+	"strings"
+)
+
+// podNamespaceServiceAccountPath is the in-cluster fallback source for the
+// pod's namespace, mirroring pkg/hub/self_upgrade.go's k8sNamespacePath. A
+// var (not a const) so tests can redirect it to a temp file, same reason.
+var podNamespaceServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+// podNamespace returns the Kubernetes namespace this spoke's pod is running
+// in, for display in the dashboard's Hub tab (renderGovHub in
+// pkg/dashboard/static/index.html) — the spoke-side complement to the
+// hive.kubestellar.io/* namespace labels stamped hub-side in
+// pkg/hub/hosted_namespace_identity.go.
+//
+// Preference order:
+//  1. POD_NAMESPACE — set via the Kubernetes downward API
+//     (fieldRef: metadata.namespace) on the hive Deployment (see the env
+//     block in saas_provision.go's k8sManifestTemplate). This is the
+//     authoritative, always-correct source once a spoke is provisioned by a
+//     build that sets it.
+//  2. NAMESPACE — an alternate env var name some deployments (or an operator
+//     hand-editing a Deployment) may already use.
+//  3. The service-account namespace file, present in every pod regardless of
+//     how it was deployed, including spokes provisioned before POD_NAMESPACE
+//     existed.
+//
+// Returns "" when none of the three resolve (e.g. running outside a
+// cluster), so the caller can omit the line entirely rather than display an
+// empty or misleading value.
+func podNamespace() string {
+	if v := strings.TrimSpace(os.Getenv("POD_NAMESPACE")); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv("NAMESPACE")); v != "" {
+		return v
+	}
+	data, err := os.ReadFile(podNamespaceServiceAccountPath)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/v2/pkg/dashboard/pod_namespace_test.go
+++ b/v2/pkg/dashboard/pod_namespace_test.go
@@ -1,0 +1,106 @@
+package dashboard
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ============================================================
+// pod_namespace.go — podNamespace(), and its wiring into the "hub" config
+// GET response (handleGovernorConfigGet) that feeds the dashboard's Hub tab
+// (renderGovHub in pkg/dashboard/static/index.html).
+// ============================================================
+
+func TestPodNamespacePrefersPodNamespaceEnv(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "hive-hosted-hosted-avail-y99x")
+	t.Setenv("NAMESPACE", "should-not-be-used")
+	if got := podNamespace(); got != "hive-hosted-hosted-avail-y99x" {
+		t.Errorf("podNamespace() = %q, want POD_NAMESPACE value", got)
+	}
+}
+
+func TestPodNamespaceFallsBackToNamespaceEnv(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "")
+	t.Setenv("NAMESPACE", "hive-hosted-x")
+	if got := podNamespace(); got != "hive-hosted-x" {
+		t.Errorf("podNamespace() = %q, want NAMESPACE fallback value", got)
+	}
+}
+
+func TestPodNamespaceFallsBackToServiceAccountFile(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "")
+	t.Setenv("NAMESPACE", "")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "namespace")
+	if err := os.WriteFile(path, []byte("hive-hosted-from-file\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := podNamespaceServiceAccountPath
+	podNamespaceServiceAccountPath = path
+	defer func() { podNamespaceServiceAccountPath = old }()
+
+	if got := podNamespace(); got != "hive-hosted-from-file" {
+		t.Errorf("podNamespace() = %q, want trimmed file contents", got)
+	}
+}
+
+func TestPodNamespaceEmptyWhenNoSourceAvailable(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "")
+	t.Setenv("NAMESPACE", "")
+	old := podNamespaceServiceAccountPath
+	podNamespaceServiceAccountPath = filepath.Join(t.TempDir(), "does-not-exist")
+	defer func() { podNamespaceServiceAccountPath = old }()
+
+	if got := podNamespace(); got != "" {
+		t.Errorf("podNamespace() = %q, want empty when no source resolves", got)
+	}
+}
+
+// TestHubTabRendersNamespace pins the spoke dashboard's Hub config tab
+// (renderGovHub in static/index.html) to include the namespace row — the
+// spoke-side complement to the hub dashboard's status-hover namespace line
+// and the hive.kubestellar.io/* namespace labels stamped hub-side. Uses the
+// spokeIndexHTML helper from gh_app_banner_test.go, matching that file's
+// structure-pin style.
+func TestHubTabRendersNamespace(t *testing.T) {
+	html := spokeIndexHTML(t)
+
+	required := []struct {
+		snippet string
+		why     string
+	}{
+		{"const namespaceRow = hub.namespace", "the Hub tab must read hub.namespace from the config payload"},
+		{"<label>Namespace ", "the Hub tab must render a labeled Namespace row"},
+		{"readonly disabled", "the namespace row must be read-only — no new mutation from the UI"},
+	}
+	for _, r := range required {
+		if !strings.Contains(html, r.snippet) {
+			t.Errorf("static/index.html is missing %q — %s", r.snippet, r.why)
+		}
+	}
+}
+
+// TestHandleGovernorConfigGetIncludesNamespace guards that the "hub" section
+// of the governor config GET response — the payload renderGovHub() reads in
+// the dashboard's Hub tab — carries the resolved namespace, gracefully empty
+// when unset rather than absent.
+func TestHandleGovernorConfigGetIncludesNamespace(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "hive-hosted-hosted-avail-nb01")
+	s, _ := apiServer(t)
+	rec := doGet(s, "/api/config/governor")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	result := decodeJSON(t, rec)
+	hub, ok := result["hub"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected hub key in governor config response")
+	}
+	if got, _ := hub["namespace"].(string); got != "hive-hosted-hosted-avail-nb01" {
+		t.Errorf("hub.namespace = %q, want %q", got, "hive-hosted-hosted-avail-nb01")
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -14958,7 +14958,23 @@ function burnAreaChart() {
       const titlesMode = (hub.contribute_titles_mode === 'allow') ? 'allow' : 'deny';
       const authorsMode = (hub.contribute_authors_mode === 'allow') ? 'allow' : 'deny';
       const labelsMode = (hub.contribute_labels_mode === 'allow') ? 'allow' : 'deny';
+      // Read-only, runtime-derived — never sent back on save (markDirty is
+      // never wired to this field). See podNamespace() in
+      // pkg/dashboard/pod_namespace.go for how the hub API resolved it
+      // (POD_NAMESPACE downward-API env, else NAMESPACE, else the
+      // service-account namespace file). Omitted entirely when unknown
+      // (running outside a cluster, or an old spoke build with no
+      // POD_NAMESPACE wired) rather than showing a blank/"undefined" line —
+      // this is the spoke-side complement to the hive.kubestellar.io/*
+      // namespace labels the hub stamps onto this same namespace at
+      // provision/claim/assign time.
+      const namespaceRow = hub.namespace ? `
+        <div class="config-field">
+          <label>Namespace <span class="config-info">i<span class="config-tooltip">The Kubernetes namespace this hive's pod is running in. Unlike the hive's name/org, this never changes after the namespace is first created — see the hive.kubestellar.io/* labels on it for an operator-facing way to map it back to this hive.</span></span></label>
+          <input type="text" value="${esc(hub.namespace)}" readonly disabled style="opacity:0.7">
+        </div>` : '';
       return `
+        ${namespaceRow}
         <div class="config-toggle">
           <div class="config-toggle-switch ${hub.enabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="hub" data-key="enabled"></div>
           <span class="config-toggle-label">Hub Enabled <span class="config-info">i<span class="config-tooltip">Register this hive with the central hub at hive.kubestellar.io so it appears in the public registry.</span></span></span>

--- a/v2/pkg/hub/hosted_namespace_identity.go
+++ b/v2/pkg/hub/hosted_namespace_identity.go
@@ -1,0 +1,354 @@
+package hub
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"strings"
+	"time"
+)
+
+// ============================================================================
+// HOSTED NAMESPACE IDENTITY — making a namespace self-describing
+// ============================================================================
+//
+// A hosted hive's Kubernetes namespace is created ONCE, at provisioning time,
+// named after whatever ID the hive had THEN — almost always a pool
+// placeholder ID like "hive-hosted-hosted-available-oke-03-placeholder-y99x".
+// When that placeholder is later claimed by a real owner/org (approve-provision
+// or the manual assign path), the hive's meta.json is rewritten with the real
+// identity, but the NAMESPACE NAME is never renamed — Kubernetes has no atomic
+// namespace-rename primitive, and renaming would mean recreating every object
+// inside it. The namespace therefore keeps its placeholder name FOREVER, and
+// there is no way to go from "which namespace is this?" back to "which hive/
+// org is running here?" without cross-referencing the hub's hive registry and
+// reverse-engineering a mangled slug.
+//
+// The fix is not to rename the namespace — it is to make the namespace
+// self-describing by stamping identity labels (and a human-readable
+// annotation) onto it at every point the hive's identity is known or changes:
+//
+//  1. hosted namespace CREATION (provisionHive) — stamp what's known then
+//     (at minimum the hive_id; org/name may still be placeholder values).
+//  2. CLAIM (handleApproveProvision) — the hive's real name/org become known
+//     here for the first time, so the labels MUST be (re)written.
+//  3. ASSIGN / reassign (handleAssignHive) — same: refresh the labels so a
+//     reassigned placeholder's namespace reflects its new owner.
+//
+// All three call stampHostedNamespaceIdentity, which idempotently patches the
+// namespace's labels/annotations via `kubectl label`/`kubectl annotate`
+// (--overwrite) rather than recreating it, and merges into whatever labels
+// already exist instead of clobbering them.
+
+const (
+	// hiveLabelPrefix is the label/annotation prefix already established
+	// elsewhere in this package (see self_upgrade.go's restart-at/
+	// upgrade-target-sha annotations) — reused here rather than inventing a
+	// second convention.
+	hiveLabelPrefix = "hive.kubestellar.io/"
+
+	// hiveNameLabel/hiveOrgLabel/hiveIDLabel are RFC-1123-safe label VALUES
+	// (see sanitizeLabelValue) recording the hive's identity on its namespace.
+	hiveNameLabel = hiveLabelPrefix + "hive-name"
+	hiveOrgLabel  = hiveLabelPrefix + "org"
+	hiveIDLabel   = hiveLabelPrefix + "hive-id"
+
+	// hiveDisplayNameAnnotation carries the EXACT, unsanitized hive name.
+	// Annotations allow arbitrary values, so this is the recoverable source of
+	// truth when the sanitized label value has been lossily transformed
+	// (capitals folded, unicode stripped, truncated to 63 chars, ...).
+	hiveDisplayNameAnnotation = hiveLabelPrefix + "display-name"
+
+	// maxLabelValueLen is the Kubernetes label-value length limit (RFC 1123
+	// label / DNS label rules), enforced by sanitizeLabelValue.
+	maxLabelValueLen = 63
+)
+
+// hiveNamespaceIdentityLabels builds the labels and annotations that make a
+// hosted hive's namespace self-describing: given the hive's display name, its
+// forge org, and its internal hive_id, it returns the label map (sanitized,
+// RFC-1123-safe values) and the annotation map (the exact display name).
+//
+// A field whose sanitized value is empty is OMITTED from the labels map
+// rather than written as an invalid/empty label — Kubernetes rejects an empty
+// label value only in some API versions, but an omitted key is unambiguous
+// and never fails validation. The display-name annotation is included only
+// when the raw name is non-empty (an empty annotation value is legal but
+// pointless — the omission of hiveNameLabel already tells the same story).
+func hiveNamespaceIdentityLabels(name, org, hiveID string) (labels map[string]string, annotations map[string]string) {
+	labels = map[string]string{}
+	annotations = map[string]string{}
+
+	if v := sanitizeLabelValue(name); v != "" {
+		labels[hiveNameLabel] = v
+	}
+	if v := sanitizeLabelValue(org); v != "" {
+		labels[hiveOrgLabel] = v
+	}
+	if v := sanitizeLabelValue(hiveID); v != "" {
+		labels[hiveIDLabel] = v
+	}
+	if trimmed := strings.TrimSpace(name); trimmed != "" {
+		annotations[hiveDisplayNameAnnotation] = trimmed
+	}
+
+	return labels, annotations
+}
+
+// sanitizeLabelValue converts an arbitrary string into a valid Kubernetes
+// label value: lower-case, restricted to [a-z0-9.-], trimmed of leading and
+// trailing non-alphanumeric characters, and capped at 63 characters (the
+// RFC-1123 label-value limit).
+//
+// Kubernetes label values must match
+// (([A-Za-z0-9])|([A-Za-z0-9][A-Za-z0-9\-_.]*[A-Za-z0-9]))? — this function
+// deliberately narrows that to a stricter [a-z0-9.-] subset (no uppercase, no
+// underscore) so the SAME sanitizer is safe to reuse anywhere a
+// lower-cased/DNS-label-like value is wanted, matching the style of the
+// existing `sanitize` helper in saas_provision.go (which does the same for
+// hive IDs, minus dots). Unicode and any other byte is dropped outright
+// rather than transliterated — a confident wrong transliteration is worse
+// than an honestly shortened value, and the exact original is always
+// recoverable from the paired display-name annotation.
+//
+// Edge cases handled explicitly so this never produces an invalid label
+// value: empty input returns ""; a string that sanitizes to only separators
+// (e.g. "---", "...") returns "" after trimming; a value longer than 63
+// characters is truncated and then re-trimmed in case truncation left a
+// trailing separator.
+func sanitizeLabelValue(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '.':
+			b.WriteRune(r)
+		default:
+			// Unicode letters/digits, spaces, underscores, and everything else
+			// are dropped rather than mapped to '-': collapsing runs of dropped
+			// characters to a single separator would still be a lossy guess at
+			// intent, and the raw value survives in the paired annotation.
+		}
+	}
+	out := b.String()
+
+	out = strings.Trim(out, "-.")
+	if out == "" {
+		return ""
+	}
+
+	if len(out) > maxLabelValueLen {
+		out = out[:maxLabelValueLen]
+		out = strings.Trim(out, "-.")
+	}
+
+	return out
+}
+
+// hostedNamespaceForHive returns the Kubernetes namespace a hosted hive runs
+// in. Every call site in this package has historically inlined
+// "hive-hosted-"+id (see hiveHostedNamespacePrefix in saas.go); this is the
+// same computation, added here so the claim/assign call sites below and any
+// future caller share one definition instead of re-deriving it.
+func hostedNamespaceForHive(h *SaaSHive) string {
+	if h == nil {
+		return ""
+	}
+	return hiveHostedNamespacePrefix + h.ID
+}
+
+// stampHostedNamespaceIdentity idempotently patches a hosted hive's namespace
+// with the identity labels/annotations from hiveNamespaceIdentityLabels, via
+// `kubectl label`/`kubectl annotate --overwrite`. It merges into whatever
+// labels the namespace already carries rather than recreating it — safe to
+// call on a namespace that does not exist yet only if the caller applies the
+// namespace-creation manifest first (see provisionHive, which does).
+//
+// Best-effort: a failure here (e.g. no kubectl on PATH, namespace not yet
+// created, transient API error) is logged and swallowed rather than failing
+// the caller's request. The alternative — failing a claim/assign because a
+// cosmetic label patch failed — would turn an operability nicety into an
+// availability regression, and the heartbeat/provisioning retry paths in this
+// package already tolerate exactly this kind of partial failure (see
+// makeVanityHostServable's "log at Warn, keep working" precedent).
+//
+// Bounded by stampNamespaceIdentityTimeout via kubectlForClusterContext —
+// the same context+"--request-timeout" idiom buildSingleClusterHealth and
+// RolloutRestartSelf already use for kubectl calls that must never hang the
+// HTTP request that triggered them (claim/assign are synchronous admin API
+// calls; an unreachable cluster must fail this cosmetic step fast, not stall
+// the response).
+func stampHostedNamespaceIdentity(cluster *ClusterConfig, namespace, name, org, hiveID string, logger *slog.Logger) {
+	if cluster == nil || strings.TrimSpace(namespace) == "" {
+		return
+	}
+	labels, annotations := hiveNamespaceIdentityLabels(name, org, hiveID)
+	if len(labels) == 0 && len(annotations) == 0 {
+		return
+	}
+
+	if len(labels) > 0 {
+		args := []string{"--request-timeout", stampNamespaceIdentityTimeout.String(), "label", "namespace", namespace, "--overwrite"}
+		for k, v := range labels {
+			args = append(args, fmt.Sprintf("%s=%s", k, v))
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), stampNamespaceIdentityTimeout)
+		out, err := kubectlForClusterContext(ctx, cluster, args...).CombinedOutput()
+		cancel()
+		if err != nil {
+			if logger != nil {
+				logger.Warn("failed to label hosted namespace with hive identity",
+					"namespace", namespace, "cluster", cluster.ID, "output", string(out), "error", err)
+			}
+		}
+	}
+
+	if len(annotations) > 0 {
+		args := []string{"--request-timeout", stampNamespaceIdentityTimeout.String(), "annotate", "namespace", namespace, "--overwrite"}
+		for k, v := range annotations {
+			args = append(args, fmt.Sprintf("%s=%s", k, v))
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), stampNamespaceIdentityTimeout)
+		out, err := kubectlForClusterContext(ctx, cluster, args...).CombinedOutput()
+		cancel()
+		if err != nil {
+			if logger != nil {
+				logger.Warn("failed to annotate hosted namespace with hive display name",
+					"namespace", namespace, "cluster", cluster.ID, "output", string(out), "error", err)
+			}
+		}
+	}
+}
+
+// stampNamespaceIdentityTimeout bounds each kubectl label/annotate call in
+// stampHostedNamespaceIdentity. Matches upgradeKubectlTimeout's value — both
+// are a single synchronous kubectl call issued from an HTTP handler, so both
+// need to fail fast against an unreachable cluster rather than hold the
+// request (or, in tests with no kubectl on PATH / no reachable API server,
+// hold the test) for kubectl's own default timeout.
+const stampNamespaceIdentityTimeout = 15 * time.Second
+
+// ============================================================================
+// OPTION B — a name-bearing Route, without renaming the namespace
+// ============================================================================
+//
+// A hosted spoke's public URL on OpenShift is an OpenShift Route host. Because
+// the namespace never renames (see above), a Route whose host is DERIVED from
+// the namespace name — the original provisioning template sets exactly one
+// host, DashboardHost = "<hive-id>.<cluster domain>" — permanently encodes the
+// placeholder slug (e.g. "hosted-available-vllmd-06.apps...") rather than the
+// hive's name, even after the hive is claimed by "TradingAsBuddies"/devx-prod.
+//
+// RENAMING OR MIGRATING THE NAMESPACE IS OFF THE TABLE: it would mean a
+// teardown + recreate + PVC/PV migration + outage. Nothing here creates a
+// replacement namespace or moves a PVC.
+//
+// The fix already exists in this file as of the vanity-URL feature
+// (addVanityHostToIngress, called from handleAssignHive and the retroactive
+// repair repairVanityURLForHive): OpenShift lets a Route's spec.host be set
+// EXPLICITLY, independent of the namespace it lives in, so an ADDITIONAL
+// "<name>-vanity" Route — same Service backend, same namespace — gives the
+// hive a name-bearing URL without touching the namespace, PVC, Deployment, or
+// Service. The ORIGINAL Route (and its placeholder host) is left completely
+// alone, so any in-flight bookmark/callback against it keeps working.
+//
+// That existing mechanism keys its hostname off org+primary-repo
+// (generateHiveID). hiveNameHostLabel below is the DNS-label-safe sanitizer
+// for building the SAME kind of name-bearing host from the hive's own display
+// NAME instead — reusing sanitizeLabelValue's stripping logic but enforcing
+// hostname-specific rules (a label value may lead/trail with '.', a DNS label
+// may not). hiveNameVanityHost composes it into a full host; handleAssignHive
+// (saas.go) calls it to prefer a name-bearing host over the org/repo-derived
+// one when the hive has a display name, then hands the result to the SAME
+// existing get-or-create path — makeVanityHostServable /
+// addVanityHostToIngress — so the idempotency, cluster-domain handling, and
+// "never adopt an unservable host" guarantees are unchanged from before this
+// feature existed.
+
+// hiveNameHostLabel converts a hive's display name into a single valid DNS
+// label (RFC 1123): lowercase, [a-z0-9-] only, no leading or trailing dash,
+// max 63 characters. This is DELIBERATELY STRICTER than sanitizeLabelValue —
+// a Kubernetes label VALUE may contain '.', but a single DNS LABEL (one dot-
+// separated segment of a hostname) may not, so '.' is dropped here rather
+// than kept.
+//
+// Unicode and punctuation are dropped outright, matching sanitizeLabelValue's
+// stance: a confident wrong transliteration is worse than an honestly
+// shortened value, and the exact name is recoverable from the
+// hive.kubestellar.io/display-name annotation stamped on the namespace.
+func hiveNameHostLabel(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			b.WriteRune(r)
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if len(out) > maxLabelValueLen {
+		out = strings.Trim(out[:maxLabelValueLen], "-")
+	}
+	return out
+}
+
+// vanityHostSuffixLen is the length of the random uniqueness suffix appended
+// to a name-bearing vanity host, matching generateHiveID's existing suffix
+// length so both host-generation schemes read consistently and collide with
+// the same (very low) probability.
+const vanityHostSuffixLen = 4
+
+// randomHostSuffix returns a short lowercase alphanumeric string, used to
+// keep two hives with similar/identical sanitized names from colliding on the
+// same vanity host. Mirrors generateHiveID's own suffix generation.
+func randomHostSuffix() string {
+	const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, vanityHostSuffixLen)
+	for i := range b {
+		b[i] = chars[rand.Intn(len(chars))]
+	}
+	return string(b)
+}
+
+// hiveNameVanityHost builds a name-bearing hostname for a hive, of the form
+// "<sanitized-name>-<suffix>.<domain>". name is typically the hive's
+// ProjectName/display name (falling back to org-repo elsewhere when a hive
+// has no display name — see hiveNameOrFallback). domain is the cluster's
+// wildcard apps domain, which the caller must supply from a source of truth
+// it already trusts (cluster.Domain from config, or one parsed off an
+// existing Route — see vanityHostDomainFromExistingRoute) rather than a
+// hardcoded value.
+//
+// Returns "" when either input is unusable (empty domain, or a name that
+// sanitizes to nothing) — the caller must treat that as "cannot build a host"
+// and skip rather than fabricate one, per the same fail-closed rule
+// addVanityHostToIngress already follows for an unreachable cluster.
+func hiveNameVanityHost(name, domain string) string {
+	domain = strings.TrimSpace(strings.Trim(domain, "."))
+	label := hiveNameHostLabel(name)
+	if domain == "" || label == "" {
+		return ""
+	}
+	return label + "-" + randomHostSuffix() + "." + domain
+}
+
+// vanityHostDomainFromExistingRoute extracts the wildcard apps domain from an
+// existing Route's host, by stripping its leading "<hive-id>." label. Used as
+// a fallback source of truth for the domain when the caller does not already
+// have cluster.Domain in hand, so the domain is always DERIVED from
+// something real on the cluster rather than assumed. Returns "" when
+// existingHost does not look like "<something>.<domain...>" (no dot), which
+// the caller must treat as "cannot determine the domain" and skip creating a
+// Route rather than guess.
+func vanityHostDomainFromExistingRoute(existingHost string) string {
+	existingHost = strings.TrimSpace(existingHost)
+	i := strings.Index(existingHost, ".")
+	if i < 0 || i == len(existingHost)-1 {
+		return ""
+	}
+	return existingHost[i+1:]
+}

--- a/v2/pkg/hub/hosted_namespace_identity_test.go
+++ b/v2/pkg/hub/hosted_namespace_identity_test.go
@@ -1,0 +1,560 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ============================================================
+// hosted_namespace_identity.go — sanitizeLabelValue /
+// hiveNamespaceIdentityLabels / stampHostedNamespaceIdentity, plus the three
+// call sites that must stamp a hosted namespace's identity: provisionHive
+// (creation), handleApproveProvision (claim), handleAssignHive (assign).
+// ============================================================
+
+func TestSanitizeLabelValue(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"already valid", "acme-repo", "acme-repo"},
+		{"caps folded", "TradingAsBuddies", "tradingasbuddies"},
+		{"spaces stripped", "Trading As Buddies", "tradingasbuddies"},
+		{"unicode dropped", "café-org", "caf-org"},
+		{"leading/trailing dash trimmed", "-acme-", "acme"},
+		{"leading/trailing dot trimmed", ".acme.", "acme"},
+		{"only separators", "---", ""},
+		{"dots and dashes preserved mid-string", "acme.corp-inc", "acme.corp-inc"},
+		{"underscore dropped", "acme_corp", "acmecorp"},
+		{"whitespace-only", "   ", ""},
+		{"exactly 63 chars kept whole", strings.Repeat("a", 63), strings.Repeat("a", 63)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeLabelValue(tc.in)
+			if got != tc.want {
+				t.Errorf("sanitizeLabelValue(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if len(got) > maxLabelValueLen {
+				t.Errorf("sanitizeLabelValue(%q) = %q exceeds %d chars", tc.in, got, maxLabelValueLen)
+			}
+		})
+	}
+}
+
+func TestSanitizeLabelValueLongInputTruncatedAndRetrimmed(t *testing.T) {
+	// 70 'a's followed by a run of dashes that would land exactly at the cut
+	// point — truncation must not leave a trailing separator.
+	in := strings.Repeat("a", 60) + "----------"
+	got := sanitizeLabelValue(in)
+	if len(got) > maxLabelValueLen {
+		t.Fatalf("result exceeds max length: %d", len(got))
+	}
+	if strings.HasSuffix(got, "-") || strings.HasSuffix(got, ".") {
+		t.Errorf("sanitizeLabelValue(%q) = %q ends in a separator after truncation", in, got)
+	}
+	if got != strings.Repeat("a", 60) {
+		t.Errorf("sanitizeLabelValue(%q) = %q, want %q", in, got, strings.Repeat("a", 60))
+	}
+}
+
+func TestSanitizeLabelValueNeverProducesInvalidValue(t *testing.T) {
+	// Fuzz-lite: a battery of adversarial inputs must never yield a value
+	// starting/ending in '-'/'.' or exceeding the length limit.
+	inputs := []string{
+		"", " ", "\t\n", "----...----", "A.B.C", "..hidden", "trailing.",
+		"日本語", "MiXeD_Case-Name.With.Dots", strings.Repeat("x-", 40),
+		"🎉party🎉", "a", "-", ".", "a-",
+	}
+	for _, in := range inputs {
+		got := sanitizeLabelValue(in)
+		if got == "" {
+			continue
+		}
+		if len(got) > maxLabelValueLen {
+			t.Errorf("sanitizeLabelValue(%q) = %q too long (%d)", in, got, len(got))
+		}
+		if strings.HasPrefix(got, "-") || strings.HasPrefix(got, ".") ||
+			strings.HasSuffix(got, "-") || strings.HasSuffix(got, ".") {
+			t.Errorf("sanitizeLabelValue(%q) = %q has leading/trailing separator", in, got)
+		}
+		for _, r := range got {
+			if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '.') {
+				t.Errorf("sanitizeLabelValue(%q) = %q contains disallowed rune %q", in, got, r)
+			}
+		}
+	}
+}
+
+func TestHiveNamespaceIdentityLabels(t *testing.T) {
+	labels, annotations := hiveNamespaceIdentityLabels("TradingAsBuddies", "falcon-core", "hosted-falcon-buddies-a1b2")
+
+	if got := labels[hiveNameLabel]; got != "tradingasbuddies" {
+		t.Errorf("hive-name label = %q, want %q", got, "tradingasbuddies")
+	}
+	if got := labels[hiveOrgLabel]; got != "falcon-core" {
+		t.Errorf("org label = %q, want %q", got, "falcon-core")
+	}
+	if got := labels[hiveIDLabel]; got != "hosted-falcon-buddies-a1b2" {
+		t.Errorf("hive-id label = %q, want %q", got, "hosted-falcon-buddies-a1b2")
+	}
+	if got := annotations[hiveDisplayNameAnnotation]; got != "TradingAsBuddies" {
+		t.Errorf("display-name annotation = %q, want exact unsanitized %q", got, "TradingAsBuddies")
+	}
+}
+
+func TestHiveNamespaceIdentityLabelsOmitsEmptyFields(t *testing.T) {
+	// A hive with no name yet (a bare pool placeholder) must not get an empty
+	// or invalid hive-name label, and must not get a display-name annotation
+	// with an empty value.
+	labels, annotations := hiveNamespaceIdentityLabels("", "", "hosted-oke-03-placeholder-y99x")
+
+	if _, ok := labels[hiveNameLabel]; ok {
+		t.Errorf("hive-name label present with empty input: %v", labels)
+	}
+	if _, ok := labels[hiveOrgLabel]; ok {
+		t.Errorf("org label present with empty input: %v", labels)
+	}
+	if got := labels[hiveIDLabel]; got != "hosted-oke-03-placeholder-y99x" {
+		t.Errorf("hive-id label = %q, want %q", got, "hosted-oke-03-placeholder-y99x")
+	}
+	if _, ok := annotations[hiveDisplayNameAnnotation]; ok {
+		t.Errorf("display-name annotation present with empty input: %v", annotations)
+	}
+}
+
+func TestHiveNamespaceIdentityLabelsAllEmpty(t *testing.T) {
+	labels, annotations := hiveNamespaceIdentityLabels("", "", "")
+	if len(labels) != 0 {
+		t.Errorf("expected no labels for all-empty input, got %v", labels)
+	}
+	if len(annotations) != 0 {
+		t.Errorf("expected no annotations for all-empty input, got %v", annotations)
+	}
+}
+
+// installLoggingKubectl writes a fake kubectl that appends its full argument
+// list to a log file (one line per invocation) and exits 0, so tests can
+// assert exactly what stampHostedNamespaceIdentity ran without a real
+// cluster. Returns the log file path.
+func installLoggingKubectl(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "kubectl.log")
+	script := `#!/bin/sh
+echo "$*" >> "` + logPath + `"
+echo "{}"
+exit 0
+`
+	path := filepath.Join(dir, "kubectl")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return logPath
+}
+
+func TestStampHostedNamespaceIdentityInvokesKubectlLabelAndAnnotate(t *testing.T) {
+	logPath := installLoggingKubectl(t)
+	cluster := &ClusterConfig{ID: "hive-oke", InCluster: true}
+
+	stampHostedNamespaceIdentity(cluster, "hive-hosted-hosted-falcon-buddies-a1b2",
+		"TradingAsBuddies", "falcon-core", "hosted-falcon-buddies-a1b2", slog.Default())
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading kubectl log: %v", err)
+	}
+	logged := string(data)
+
+	if !strings.Contains(logged, "label namespace hive-hosted-hosted-falcon-buddies-a1b2 --overwrite") {
+		t.Errorf("expected a kubectl label invocation, got:\n%s", logged)
+	}
+	if !strings.Contains(logged, hiveNameLabel+"=tradingasbuddies") {
+		t.Errorf("expected hive-name label in kubectl args, got:\n%s", logged)
+	}
+	if !strings.Contains(logged, hiveOrgLabel+"=falcon-core") {
+		t.Errorf("expected org label in kubectl args, got:\n%s", logged)
+	}
+	if !strings.Contains(logged, hiveIDLabel+"=hosted-falcon-buddies-a1b2") {
+		t.Errorf("expected hive-id label in kubectl args, got:\n%s", logged)
+	}
+	if !strings.Contains(logged, "annotate namespace hive-hosted-hosted-falcon-buddies-a1b2 --overwrite") {
+		t.Errorf("expected a kubectl annotate invocation, got:\n%s", logged)
+	}
+	if !strings.Contains(logged, hiveDisplayNameAnnotation+"=TradingAsBuddies") {
+		t.Errorf("expected display-name annotation with EXACT unsanitized name, got:\n%s", logged)
+	}
+}
+
+func TestStampHostedNamespaceIdentityNoopOnNilClusterOrEmptyNamespace(t *testing.T) {
+	logPath := installLoggingKubectl(t)
+
+	stampHostedNamespaceIdentity(nil, "hive-hosted-x", "name", "org", "id", slog.Default())
+	stampHostedNamespaceIdentity(&ClusterConfig{ID: "c", InCluster: true}, "", "name", "org", "id", slog.Default())
+
+	if data, err := os.ReadFile(logPath); err == nil && len(data) != 0 {
+		t.Errorf("expected no kubectl invocations, got:\n%s", string(data))
+	}
+}
+
+func TestStampHostedNamespaceIdentityToleratesKubectlFailure(t *testing.T) {
+	// A failing kubectl must not panic and must be swallowed (best-effort).
+	dir := t.TempDir()
+	script := "#!/bin/sh\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// Must not panic.
+	stampHostedNamespaceIdentity(&ClusterConfig{ID: "c", InCluster: true}, "hive-hosted-x", "n", "o", "i", slog.Default())
+}
+
+func TestHostedNamespaceForHive(t *testing.T) {
+	if got := hostedNamespaceForHive(nil); got != "" {
+		t.Errorf("hostedNamespaceForHive(nil) = %q, want empty", got)
+	}
+	h := &SaaSHive{ID: "hosted-acme-repo-abcd"}
+	if got := hostedNamespaceForHive(h); got != "hive-hosted-hosted-acme-repo-abcd" {
+		t.Errorf("hostedNamespaceForHive = %q, want %q", got, "hive-hosted-hosted-acme-repo-abcd")
+	}
+}
+
+// TestProvisionHiveStampsNamespaceIdentity guards entry point 1: automatic
+// (pool) provisioning must stamp what's known at creation time, at minimum
+// the hive_id.
+func TestProvisionHiveStampsNamespaceIdentity(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	logPath := installLoggingKubectl(t)
+
+	h := &SaaSHive{ID: "hosted-acme-repo-abcd", Owner: "alice", Org: "acme", Repos: []string{"repo"}, PrimaryRepo: "repo", ACMMLevel: 2}
+	req := &CreateHiveRequest{Org: "acme", Repos: "repo", PrimaryRepo: "repo", ACMMLevel: 2, ClusterID: "hive-oke"}
+
+	if err := provisionHive(h, req, dynamicCluster(), nil, slog.Default()); err != nil {
+		t.Fatalf("provisionHive: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading kubectl log: %v", err)
+	}
+	logged := string(data)
+	if !strings.Contains(logged, "label namespace hive-hosted-hosted-acme-repo-abcd") {
+		t.Errorf("expected provisionHive to label the namespace it just created, got:\n%s", logged)
+	}
+	if !strings.Contains(logged, hiveIDLabel+"=hosted-acme-repo-abcd") {
+		t.Errorf("expected hive-id label stamped at creation, got:\n%s", logged)
+	}
+}
+
+// TestHandleApproveProvisionStampsNamespaceIdentity guards entry point 2: the
+// claim path is where the hive's real name/org first become known, so the
+// namespace labels must be (re)written here.
+func TestHandleApproveProvisionStampsNamespaceIdentity(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	logPath := installLoggingKubectl(t)
+	mkUser(t, hubAdminUsername)
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, saveCh: make(chan struct{}, 1), clusters: map[string]ClusterConfig{"hive-oke": *dynamicCluster()}}
+
+	saveProvisionRequest(&ProvisionRequest{
+		Username: "bob", Org: "falcon-core", Repos: "buddies", PrimaryRepo: "buddies", ACMMLevel: 2,
+		AuthMethod: "public", RequestedAt: time.Now().UTC().Format(time.RFC3339), Status: provisionStatusPending,
+	})
+	saveSaaSHive(&SaaSHive{ID: "hosted-avail-y99x", Owner: hubAdminUsername, Status: statusAvailable, ClusterID: "hive-oke"})
+
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/approve-prov", "", hubAdminUsername), "username", "bob")
+	s.handleApproveProvision(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("approve status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading kubectl log: %v", err)
+	}
+	logged := string(data)
+	if !strings.Contains(logged, "label namespace hive-hosted-hosted-avail-y99x --overwrite") {
+		t.Errorf("expected claim to (re)label the placeholder's namespace, got:\n%s", logged)
+	}
+	if !strings.Contains(logged, hiveOrgLabel+"=falcon-core") {
+		t.Errorf("expected org label with the newly-claimed org, got:\n%s", logged)
+	}
+}
+
+// ============================================================
+// Option B — hiveNameHostLabel / hiveNameVanityHost /
+// vanityHostDomainFromExistingRoute, plus handleAssignHive preferring a
+// name-bearing vanity host when the hive has a display name.
+// ============================================================
+
+func TestHiveNameHostLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"already valid", "acme-repo", "acme-repo"},
+		{"caps folded", "TradingAsBuddies", "tradingasbuddies"},
+		{"spaces stripped", "Trading As Buddies", "tradingasbuddies"},
+		{"dots dropped (unlike label sanitizer)", "acme.corp", "acmecorp"},
+		{"leading/trailing dash trimmed", "-acme-", "acme"},
+		{"only dashes", "----", ""},
+		{"underscore dropped", "acme_corp", "acmecorp"},
+		{"unicode dropped", "café", "caf"},
+		{"exactly 63 chars kept whole", strings.Repeat("a", 63), strings.Repeat("a", 63)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hiveNameHostLabel(tc.in)
+			if got != tc.want {
+				t.Errorf("hiveNameHostLabel(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if len(got) > maxLabelValueLen {
+				t.Errorf("hiveNameHostLabel(%q) = %q exceeds %d chars", tc.in, got, maxLabelValueLen)
+			}
+			for _, r := range got {
+				if r == '.' {
+					t.Errorf("hiveNameHostLabel(%q) = %q contains a dot, which is not a valid DNS-label character", tc.in, got)
+				}
+			}
+		})
+	}
+}
+
+func TestHiveNameHostLabelLongInputTruncatedAndRetrimmed(t *testing.T) {
+	in := strings.Repeat("a", 60) + "----------"
+	got := hiveNameHostLabel(in)
+	if len(got) > maxLabelValueLen {
+		t.Fatalf("result exceeds max length: %d", len(got))
+	}
+	if strings.HasSuffix(got, "-") {
+		t.Errorf("hiveNameHostLabel(%q) = %q ends in a dash after truncation", in, got)
+	}
+}
+
+func TestHiveNameVanityHost(t *testing.T) {
+	host := hiveNameVanityHost("TradingAsBuddies", "apps.example.com")
+	if !strings.HasPrefix(host, "tradingasbuddies-") {
+		t.Errorf("hiveNameVanityHost = %q, want prefix %q", host, "tradingasbuddies-")
+	}
+	if !strings.HasSuffix(host, ".apps.example.com") {
+		t.Errorf("hiveNameVanityHost = %q, want suffix %q", host, ".apps.example.com")
+	}
+	// label-suffix-domain: exactly one more dash-delimited random suffix
+	// between the sanitized label and the domain.
+	labelAndSuffix := strings.TrimSuffix(host, ".apps.example.com")
+	parts := strings.Split(labelAndSuffix, "-")
+	if len(parts) < 2 {
+		t.Fatalf("hiveNameVanityHost = %q, want a label-suffix pair before the domain", host)
+	}
+	suffix := parts[len(parts)-1]
+	if len(suffix) != vanityHostSuffixLen {
+		t.Errorf("suffix %q has length %d, want %d", suffix, len(suffix), vanityHostSuffixLen)
+	}
+}
+
+func TestHiveNameVanityHostUniquenessAcrossCalls(t *testing.T) {
+	// Two hives with the SAME sanitized name must not collide on the same
+	// host — the random suffix is what prevents that.
+	seen := map[string]bool{}
+	for i := 0; i < 20; i++ {
+		h := hiveNameVanityHost("TradingAsBuddies", "apps.example.com")
+		if seen[h] {
+			t.Fatalf("hiveNameVanityHost produced a duplicate host across calls: %q", h)
+		}
+		seen[h] = true
+	}
+}
+
+func TestHiveNameVanityHostEmptyOnUnusableInput(t *testing.T) {
+	if got := hiveNameVanityHost("TradingAsBuddies", ""); got != "" {
+		t.Errorf("hiveNameVanityHost with empty domain = %q, want empty (never fabricate a domain)", got)
+	}
+	if got := hiveNameVanityHost("", "apps.example.com"); got != "" {
+		t.Errorf("hiveNameVanityHost with unsanitizable name = %q, want empty", got)
+	}
+	if got := hiveNameVanityHost("---", "apps.example.com"); got != "" {
+		t.Errorf("hiveNameVanityHost(%q) = %q, want empty (name sanitizes to nothing)", "---", got)
+	}
+}
+
+func TestVanityHostDomainFromExistingRoute(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"hosted-acme-repo-abcd.apps.example.com", "apps.example.com"},
+		{"hosted-x.hive.kubestellar.io", "hive.kubestellar.io"},
+		{"no-dot-here", ""},
+		{"", ""},
+		{"trailing-dot.", ""},
+	}
+	for _, tc := range cases {
+		if got := vanityHostDomainFromExistingRoute(tc.in); got != tc.want {
+			t.Errorf("vanityHostDomainFromExistingRoute(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestHandleAssignHivePrefersNameBearingVanityHost guards Option B: at
+// assignment, a hive with a display name (ProjectName) gets a vanity host
+// built from that name rather than the org/repo-derived one, without
+// changing the namespace, and via the SAME get-or-create route-creation seam
+// (vanityHostServable, stubbed here exactly as the existing vanity-URL tests
+// stub it) — so this only proves the HOST CHOICE changed, not the mechanism.
+func TestHandleAssignHivePrefersNameBearingVanityHost(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+
+	s := &HubServer{
+		logger: slog.Default(), hubSecret: testHubSecret, saveCh: make(chan struct{}, 1),
+		clusters: map[string]ClusterConfig{"hive-oke": *dynamicCluster()},
+	}
+	var gotHost string
+	s.vanityHostServable = func(_, host string, _ *ClusterConfig) error {
+		gotHost = host
+		return nil
+	}
+	saveSaaSHive(&SaaSHive{ID: "hosted-avail-nb01", Owner: hubAdminUsername, Status: statusAvailable, ClusterID: "hive-oke"})
+
+	body := `{"owner":"carol","org":"falcon-core","repos":"buddies","primary_repo":"buddies","acmm_level":2,"project_name":"TradingAsBuddies"}`
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/api/saas/hives/hosted-avail-nb01/assign", body, hubAdminUsername), "id", "hosted-avail-nb01")
+	s.handleAssignHive(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("assign status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	if !strings.HasPrefix(gotHost, "tradingasbuddies-") {
+		t.Errorf("vanity host = %q, want a name-bearing host prefixed %q", gotHost, "tradingasbuddies-")
+	}
+
+	got := loadSaaSHive("hosted-avail-nb01")
+	if got == nil {
+		t.Fatal("expected saved hive")
+	}
+	if !strings.Contains(got.VanityURL, "tradingasbuddies-") {
+		t.Errorf("VanityURL = %q, want it to contain the name-bearing host", got.VanityURL)
+	}
+	// The namespace itself must be untouched — same id as before assignment.
+	if got.ID != "hosted-avail-nb01" {
+		t.Errorf("hive ID changed from %q to %q — namespace must never be renamed/migrated", "hosted-avail-nb01", got.ID)
+	}
+}
+
+// TestHandleAssignHiveFallsBackToOrgRepoHostWithoutDisplayName guards that a
+// hive assigned with no project_name behaves EXACTLY as before this feature:
+// the org/repo-derived vanity host, unchanged.
+func TestHandleAssignHiveFallsBackToOrgRepoHostWithoutDisplayName(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+
+	s := &HubServer{
+		logger: slog.Default(), hubSecret: testHubSecret, saveCh: make(chan struct{}, 1),
+		clusters: map[string]ClusterConfig{"hive-oke": *dynamicCluster()},
+	}
+	var gotHost string
+	s.vanityHostServable = func(_, host string, _ *ClusterConfig) error {
+		gotHost = host
+		return nil
+	}
+	saveSaaSHive(&SaaSHive{ID: "hosted-avail-nb02", Owner: hubAdminUsername, Status: statusAvailable, ClusterID: "hive-oke"})
+
+	body := `{"owner":"dave","org":"acme","repos":"widgets","primary_repo":"widgets","acmm_level":2}`
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/api/saas/hives/hosted-avail-nb02/assign", body, hubAdminUsername), "id", "hosted-avail-nb02")
+	s.handleAssignHive(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("assign status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	if !strings.HasPrefix(gotHost, "hosted-acme-widgets-") {
+		t.Errorf("vanity host = %q, want the unchanged org/repo-derived host prefixed %q", gotHost, "hosted-acme-widgets-")
+	}
+}
+
+// TestK8sManifestTemplateSetsPodNamespaceDownwardAPI guards that the spoke
+// Deployment template wires POD_NAMESPACE via the Kubernetes downward API
+// (fieldRef: metadata.namespace) — the spoke-side source of truth
+// pkg/dashboard/pod_namespace.go's podNamespace() reads first, for the Hub
+// tab's namespace row.
+func TestK8sManifestTemplateSetsPodNamespaceDownwardAPI(t *testing.T) {
+	if !strings.Contains(k8sManifestTemplate, "name: POD_NAMESPACE") {
+		t.Error("k8sManifestTemplate is missing a POD_NAMESPACE env var")
+	}
+	if !strings.Contains(k8sManifestTemplate, "fieldPath: metadata.namespace") {
+		t.Error("k8sManifestTemplate's POD_NAMESPACE is not wired via the downward API (fieldRef: metadata.namespace)")
+	}
+}
+
+// TestStatusHoverRendersNamespace pins the hub dashboard's status hover
+// (healthBadge in the inline dashboardHTML JS) to include the hosted
+// namespace line — the hub-side surface an operator uses to map a
+// Kubernetes namespace back to a hive without touching the cluster. Mirrors
+// the structure-pin style of TestHoverPanelRendersConsolidatedSections in
+// hover_timeline_relay_test.go.
+func TestStatusHoverRendersNamespace(t *testing.T) {
+	cases := []struct {
+		name    string
+		snippet string
+	}{
+		{"namespace line is composed into the hover", "lines.push('Namespace: ' + hns);"},
+		{"hiveNamespace helper exists", "function hiveNamespace(h)"},
+		{"hiveNamespace derives from hive-hosted- + id", "return 'hive-hosted-' + h.id;"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(dashboardHTML, tc.snippet) {
+				t.Errorf("dashboardHTML is missing %q", tc.snippet)
+			}
+		})
+	}
+}
+
+// TestHandleAssignHiveStampsNamespaceIdentity guards entry point 3: the
+// assign/reassign path must refresh the namespace labels too.
+func TestHandleAssignHiveStampsNamespaceIdentity(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	logPath := installLoggingKubectl(t)
+	mkUser(t, hubAdminUsername)
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, saveCh: make(chan struct{}, 1), clusters: map[string]ClusterConfig{"hive-oke": *dynamicCluster()}}
+	saveSaaSHive(&SaaSHive{ID: "hosted-avail-z01a", Owner: hubAdminUsername, Status: statusAvailable, ClusterID: "hive-oke"})
+
+	body := `{"owner":"carol","org":"acme","repos":"repo1","primary_repo":"repo1","acmm_level":2}`
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/api/saas/hives/hosted-avail-z01a/assign", body, hubAdminUsername), "id", "hosted-avail-z01a")
+	s.handleAssignHive(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("assign status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading kubectl log: %v", err)
+	}
+	logged := string(data)
+	if !strings.Contains(logged, "label namespace hive-hosted-hosted-avail-z01a --overwrite") {
+		t.Errorf("expected assign to (re)label the placeholder's namespace, got:\n%s", logged)
+	}
+	if !strings.Contains(logged, hiveOrgLabel+"=acme") {
+		t.Errorf("expected org label with the newly-assigned org, got:\n%s", logged)
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -5720,6 +5720,14 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Entry point 2/3 for namespace identity: this is the moment a placeholder
+	// gets a real owner/org — the hive's identity is known here for the first
+	// time, so the namespace's labels/annotations MUST be (re)written now
+	// rather than left holding whatever provisionHive stamped at pool-creation
+	// time (typically just hive_id). Best-effort — see
+	// stampHostedNamespaceIdentity's doc comment.
+	stampHostedNamespaceIdentity(s.clusterForHive(h), hostedNamespaceForHive(h), h.ProjectName, h.Org, h.ID, s.logger)
+
 	// Ensure the user record exists, grant them owner access, and count this
 	// owned hive against a quota.
 	//
@@ -6480,7 +6488,21 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	// registry's dashboardUrl becomes the vanity URL and stays that way.
 	if h.VanityURL == "" {
 		if cluster := s.clusterForHive(h); cluster != nil && cluster.Domain != "" {
-			vanityHost := generateHiveID(body.Org, primaryRepo) + "." + cluster.Domain
+			// Option B (namespace-identity operability): prefer a host built
+			// from the hive's OWN display name (h.ProjectName /
+			// body.ProjectName) when one is set — "TradingAsBuddies" reads as
+			// the hive an operator actually asked for, where
+			// "hosted-acme-repo-*" only reads as org/repo. Falls back to the
+			// existing org/repo-derived host (generateHiveID) when no display
+			// name is set, so a hive claimed without one behaves exactly as
+			// before. Both schemes share the same suffix length and the same
+			// "no route until makeVanityHostServable succeeds" adoption rule
+			// below — this only changes what the label PORTION of the host
+			// says, never the get-or-create/idempotency semantics.
+			vanityHost := hiveNameVanityHost(h.ProjectName, cluster.Domain)
+			if vanityHost == "" {
+				vanityHost = generateHiveID(body.Org, primaryRepo) + "." + cluster.Domain
+			}
 			// Make the vanity host servable, then adopt it. Nothing else creates a
 			// route for this host: provisioning templates a single DashboardHost, so
 			// a vanity URL minted here resolves to no backend and every hub link to
@@ -6520,6 +6542,14 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"failed to save hive assignment"}`, http.StatusInternalServerError)
 		return
 	}
+
+	// Entry point 3/3 for namespace identity: the (re)assignment path. A
+	// claimed placeholder can be reassigned to a different owner/org later
+	// (or an admin can assign directly, bypassing the approve-provision flow
+	// entirely), so the namespace's labels/annotations must be refreshed here
+	// too — same rationale as handleApproveProvision above. Best-effort — see
+	// stampHostedNamespaceIdentity's doc comment.
+	stampHostedNamespaceIdentity(s.clusterForHive(h), hostedNamespaceForHive(h), h.ProjectName, h.Org, h.ID, s.logger)
 
 	// Grant the assignee owner access. handleAccessList builds a hive's access
 	// list by scanning every user record for Hives[hiveID], NOT from h.Owner —
@@ -8275,6 +8305,22 @@ const dashboardHTML = `<!DOCTYPE html>
       // "is registeredAt usable"; an em dash, never 'Invalid Date', when not.
       if (hiveProvisionTime(h) !== null) {
         lines.push('— provisioned ' + fmtUserTS(h.registeredAt));
+      }
+      // Kubernetes namespace. A hosted hive's namespace is the deterministic
+      // "hive-hosted-<id>" (see hostedNamespaceForHive in
+      // pkg/hub/hosted_namespace_identity.go) and — unlike the hive's
+      // name/org — NEVER changes after a claim: the namespace this hive was
+      // first provisioned into keeps its original (often placeholder) name
+      // forever, because Kubernetes has no atomic namespace rename. Surfacing
+      // it here is what lets an operator map "some namespace on the cluster"
+      // back to "this hive" without cross-referencing the registry by hand —
+      // exactly the gap the hive.kubestellar.io/* namespace labels close from
+      // the cluster side. Computed client-side (not a separate stored field)
+      // so it can never drift from the one place the namespace name is
+      // decided; omitted for a non-hosted row, which has no such namespace.
+      var hns = hiveNamespace(h);
+      if (hns) {
+        lines.push('Namespace: ' + hns);
       }
       var access = h.access || [];
       var dotMarkup = '<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + c + '"></span>' +
@@ -11191,6 +11237,19 @@ const dashboardHTML = `<!DOCTYPE html>
     function isPlaceholderHive(h) {
       if (!h) return false;
       return h.provStatus === 'available' || (!!h.org && h.org.indexOf('available-') === 0);
+    }
+
+    /* hiveNamespace returns the Kubernetes namespace a hosted hive's spoke
+       runs in, or '' for a non-hosted (local) hive, which has no such
+       namespace. Mirrors hostedNamespaceForHive in
+       pkg/hub/hosted_namespace_identity.go — "hive-hosted-" + id — computed
+       here rather than shipped as its own field so it can never disagree
+       with the one place (server-side) that decides the namespace name. */
+    function hiveNamespace(h) {
+      if (!h || !h.id) return '';
+      var isHosted = h.hiveType === 'hosted' || h.id.indexOf('hosted-') === 0 || h.id.indexOf('saas-') === 0;
+      if (!isHosted) return '';
+      return 'hive-hosted-' + h.id;
     }
 
     /* ---------- Bulk multi-select actions ----------

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1512,6 +1512,15 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 		return fmt.Errorf("provisioning failed — check hub logs for details")
 	}
 
+	// Entry point 1/3 for namespace identity: stamp what's known at creation
+	// time. For a freshly-created pool placeholder this is often just the
+	// hive_id (h.Owner/h.Org are still the admin/placeholder values) — the
+	// claim (handleApproveProvision) and assign (handleAssignHive) paths
+	// overwrite these once the real owner/org are known. See
+	// hosted_namespace_identity.go for why the namespace itself is never
+	// renamed and must instead be kept self-describing via labels.
+	stampHostedNamespaceIdentity(cluster, data["Namespace"].(string), h.ProjectName, h.Org, h.ID, logger)
+
 	logger.Info("audit: saas hive provisioned", "hive_id", h.ID, "owner", h.Owner, "org", h.Org, "cluster", cluster.ID)
 	return nil
 }
@@ -2182,6 +2191,17 @@ spec:
               key: dashboard-token
         - name: HIVE_ID
           value: "{{.ID}}"
+        # POD_NAMESPACE via the downward API — the spoke's OWN authoritative
+        # source for the namespace it runs in. Provisioning already computes
+        # this namespace (see .Namespace above) to create it, but the pod
+        # cannot read the template's own values at runtime, and re-deriving
+        # "hive-hosted-"+HIVE_ID client-side would silently break the day
+        # that convention changes. The downward API can never disagree with
+        # reality: it is the API server's own answer, not a guess.
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: HIVE_LEVEL
           value: "{{.ACMMLevel}}"
         - name: HIVE_HUB_URL


### PR DESCRIPTION
## Problem

Hosted hives run in Kubernetes namespaces created once, at provisioning time, named after whatever ID the hive had THEN — almost always a pool-placeholder ID like `hive-hosted-hosted-available-oke-03-placeholder-y99x`. When that placeholder is later CLAIMED by a real owner (e.g. hive "TradingAsBuddies", org "falcon-core"), the hive's meta.json gets rewritten with the real identity, but the **namespace name never changes** — Kubernetes has no atomic namespace rename, and renaming would mean a teardown+recreate + PVC/PV migration + outage, which is off the table.

The result: there is no way to go from "some namespace on the cluster" back to "which hive/org is running here" without cross-referencing the hub's hive registry and reverse-engineering a mangled slug.

## Fix — namespace identity labels (three entry points)

Added `pkg/hub/hosted_namespace_identity.go` with a shared helper:

- `hiveNamespaceIdentityLabels(name, org, hiveID) (labels, annotations map[string]string)`
- `sanitizeLabelValue(s string) string` — lowercase, `[a-z0-9.-]`, trimmed of leading/trailing separators, capped at 63 chars (RFC-1123 label value). Empty/edge inputs never produce an invalid value — an all-separator or empty input yields `""`, and a field whose sanitized value is `""` is **omitted** from the labels map rather than written invalid.
- `stampHostedNamespaceIdentity(cluster, namespace, name, org, hiveID, logger)` — idempotent `kubectl label`/`kubectl annotate --overwrite` (merges into existing labels, never clobbers), bounded by a 15s timeout (`stampNamespaceIdentityTimeout`, same idiom as the existing `upgradeKubectlTimeout`) so an unreachable cluster fails this best-effort cosmetic step fast instead of stalling the admin request that triggered it.

Label/annotation scheme (reusing the `hive.kubestellar.io/` prefix already established in this package — see `self_upgrade.go`'s `restart-at`/`upgrade-target-sha` annotations — rather than inventing a second convention):

| Key | Kind | Value |
|---|---|---|
| `hive.kubestellar.io/hive-name` | label | sanitized hive name |
| `hive.kubestellar.io/org` | label | sanitized forge org |
| `hive.kubestellar.io/hive-id` | label | sanitized hive_id |
| `hive.kubestellar.io/display-name` | annotation | **exact**, unsanitized hive name |

Called from all three points a hive's identity is known or changes:

1. **Automatic provisioning** — `provisionHive` (`pkg/hub/saas_provision.go`), right after `kubectl apply` succeeds. Stamps what's known at creation — for a fresh pool placeholder this is typically just `hive-id`.
2. **Manual / claim provisioning** — `handleApproveProvision` (`pkg/hub/saas.go`), right after `saveSaaSHive`. This is where the hive's real name/org become known for the first time (related to #2372's ClaimDelivered re-arm on the same code path), so the labels are (re)written here.
3. **Assignment workflow** — `handleAssignHive` (`pkg/hub/saas.go`), right after `saveSaaSHive`. Refreshes the labels on (re)assignment too.

## Option B — a name-bearing Route, without renaming the namespace

A hosted spoke's public URL on OpenShift is an OpenShift Route host, and the existing provisioning template sets exactly one Route host, `DashboardHost = "<hive-id>.<cluster-domain>"` — permanently placeholder-shaped.

**Investigation finding:** this codebase already has the exact right mechanism for this, built for the "vanity URL" feature — `addVanityHostToIngress` / `makeVanityHostServable` (`pkg/hub/saas_provision.go`), called from `handleAssignHive` and the retroactive repair `repairVanityURLForHive`. On OpenShift it creates an **additional** `<name>-vanity` Route (same Service backend, same namespace) via `kubectl apply -f -`, which is naturally get-or-create/idempotent and never touches the original Route (an in-flight bookmark against the placeholder host keeps working). The domain comes from `cluster.Domain` (config), not hardcoded.

That existing mechanism keys its hostname off org+primary-repo (`generateHiveID`). This PR adds a **hive-name-based** alternative:

- `hiveNameHostLabel(s string) string` — DNS-label sanitizer (RFC-1123 DNS label): lowercase, `[a-z0-9-]` only (no `.`, unlike the K8s-label-value sanitizer above, since a single DNS label cannot contain a dot), no leading/trailing dash, ≤63 chars.
- `hiveNameVanityHost(name, domain) string` — builds `<sanitized-name>-<4-char-suffix>.<domain>`; returns `""` (never fabricates) when the domain is empty or the name sanitizes to nothing.
- `vanityHostDomainFromExistingRoute(host) string` — extracts the wildcard domain from an existing Route host as a fallback source of truth, for future callers that don't already have `cluster.Domain` in hand.

Wired into `handleAssignHive`: when the hive has a display name (`ProjectName`), the vanity host is built from that name instead of org/repo; otherwise it falls back to the **unchanged** `generateHiveID(org, repo)` behavior. Both share the same `makeVanityHostServable`/`addVanityHostToIngress` get-or-create seam — this change only affects what the host's label portion says, never the idempotency or adoption semantics.

## Namespace visible in the UI (read-only, two spots)

1. **Hub dashboard status hover** (`pkg/hub/saas.go`, `healthBadge()` in the inline dashboard JS): added a `Namespace: hive-hosted-<id>` line. Computed **client-side** from `h.id` via a new `hiveNamespace(h)` helper rather than a new stored registry field — the namespace is deterministically `"hive-hosted-"+id` for every hosted hive (already the convention at 6+ call sites in this package), so computing it client-side means it can never drift from the one place the namespace name is actually decided. Omitted for non-hosted rows.
2. **Spoke "Hub" config tab** (`renderGovHub()` in `pkg/dashboard/static/index.html`): added a read-only `Namespace` field near the top, sourced from a new `hub.namespace` key in the `/api/config/governor` response (`pkg/dashboard/api.go`). Backed by a new `podNamespace()` helper (`pkg/dashboard/pod_namespace.go`) with a fallback chain: `POD_NAMESPACE` env → `NAMESPACE` env → the service-account namespace file. `POD_NAMESPACE` is now wired via the Kubernetes downward API (`fieldRef: metadata.namespace`) on the hive Deployment template (`k8sManifestTemplate` in `saas_provision.go`) since it wasn't previously set. Gracefully omitted (not shown as blank/"undefined") when unresolvable, e.g. running outside a cluster or an old spoke build.

## Tests

- `pkg/hub/hosted_namespace_identity_test.go` — sanitizer edge cases (caps, spaces, unicode, leading/trailing separators, >63 chars, empty, all-separators) for both `sanitizeLabelValue` and `hiveNameHostLabel`; `hiveNamespaceIdentityLabels` (full + omit-empty + all-empty); `stampHostedNamespaceIdentity` (invokes kubectl label+annotate, no-ops on nil cluster/empty namespace, tolerates kubectl failure); each of the three entry points (`provisionHive`, `handleApproveProvision`, `handleAssignHive`) asserted via a logging fake `kubectl` on `PATH`; the name-bearing-vs-fallback vanity host choice in `handleAssignHive`; a structure-pin test for the hub dashboard's status-hover JS; a structure-pin test for the `POD_NAMESPACE` downward-API block in the manifest template.
- `pkg/dashboard/pod_namespace_test.go` — `podNamespace()`'s three-way fallback chain; `/api/config/governor` response includes `hub.namespace`; a structure-pin test for the Hub tab's namespace row in `static/index.html`.

All new/touched tests pass locally (`go test ./pkg/hub/... ./pkg/dashboard/...`); `go build ./...` and `go vet ./...` are clean. CI is the merge gate per repo convention — not merging, just opening for review.

Fixes: namespace→hive un-mappability for hosted spokes
Refs: #2372 (ClaimDelivered re-arm on the same claim path this PR also stamps identity on); the existing fleet-count/status-prefix fix noted in `saas.go` around `hostedAvailableIDPrefix` (a claimed placeholder keeps its `hosted-available-` ID/status prefix — the same underlying "identity survives past claim in surprising ways" class of issue this PR closes from the cluster side)