### PR TITLE
✨ feat(dashboard): SDK-backed copilot model discovery via @github/copilot-sdk

### DIFF
--- a/bin/copilot-models.mjs
+++ b/bin/copilot-models.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// copilot-models.mjs — list the Copilot models available to this machine's
+// Copilot auth, via the official @github/copilot-sdk.
+//
+// The SDK spawns the installed copilot CLI as a JSON-RPC server over stdio and
+// asks it for its model catalog, so the probe rides the CLI's OWN auth
+// resolution (stored device-flow OAuth under $HOME/.copilot, or the
+// COPILOT_GITHUB_TOKEN env var) and the CLI's own TLS handling
+// (NODE_EXTRA_CA_CERTS — required behind the egress proxy). That makes it work
+// in auth configurations the dashboard's raw-HTTP /models probe cannot reach.
+//
+// Contract with the Go caller (v2/pkg/dashboard/cli_models.go):
+//   - success: exactly ONE line of JSON on stdout —
+//       {"models":[{"id":...,"name":...,"policyState":...,"efforts":[...],"defaultEffort":...}]}
+//     and exit code 0.
+//   - failure: NOTHING on stdout, a short error on stderr, nonzero exit.
+//   - never hangs: a hard internal deadline force-exits the process, and the
+//     spawned copilot server is stopped in a finally + reaped by process exit.
+//   - never prints tokens or environment values.
+
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+// ---- Constants ----
+
+// Hard internal deadline for the whole probe (start + listModels + stop).
+// The Go caller's exec timeout (copilotSDKProbeTimeout in cli_models.go) sits
+// slightly ABOVE this so the helper always gets to report its own error
+// instead of being killed mid-flight.
+const INTERNAL_TIMEOUT_MS = 15_000;
+
+// Process exit codes: 0 = model list on stdout, 1 = any failure (no stdout).
+const EXIT_OK = 0;
+const EXIT_FAIL = 1;
+
+// Node entry of the PINNED copilot CLI installed globally by the image
+// (v2/Dockerfile Layer 3). The image deletes the CLI's native binary so the
+// CLI runs its Node.js path (which honors NODE_EXTRA_CA_CERTS); pointing the
+// SDK's runtime connection at THIS entry guarantees the probe runs the fleet's
+// pinned CLI — never the newer @github/copilot the SDK bundles as its own
+// nested dependency, whose native binary does not trust the proxy CA.
+// The SDK spawns `node <entry> --server ...` when the path ends in ".js".
+const PINNED_CLI_ENTRY = "/usr/local/lib/node_modules/@github/copilot/index.js";
+
+// npm global roots to search for @github/copilot-sdk. ESM bare-specifier
+// resolution NEVER consults the global node_modules, so a plain
+// `import "@github/copilot-sdk"` fails for a globally-installed SDK; instead
+// the SDK is loaded with createRequire() anchored inside the global root —
+// the package ships a CJS build under its "require" export condition
+// (dist/cjs/index.js), so require() works regardless of where this script
+// lives. The execPath-derived candidate covers non-default npm prefixes.
+const GLOBAL_NODE_MODULES_CANDIDATES = [
+  "/usr/local/lib/node_modules",
+  path.join(path.dirname(process.execPath), "..", "lib", "node_modules"),
+];
+
+// Anchor filename for createRequire inside a node_modules root. The file need
+// not exist — createRequire only uses it to derive resolution paths.
+const REQUIRE_ANCHOR_BASENAME = "hive-require-anchor.js";
+
+const SDK_PACKAGE_NAME = "@github/copilot-sdk";
+
+// ---- Failure-mode plumbing ----
+
+function fail(message) {
+  process.stderr.write(`copilot-models: ${message}\n`);
+  process.exit(EXIT_FAIL);
+}
+
+// Watchdog: force-exit on deadline no matter what the SDK is doing. Not
+// unref()ed on purpose — a successful run exits explicitly before it fires.
+setTimeout(() => {
+  fail(`timed out after ${INTERNAL_TIMEOUT_MS}ms`);
+}, INTERNAL_TIMEOUT_MS);
+
+// ---- SDK loading ----
+
+function loadSdk() {
+  // Local resolution first (works when a node_modules ancestor has the SDK,
+  // e.g. dev checkouts), then the global roots.
+  const localRequire = createRequire(import.meta.url);
+  const anchors = [null, ...GLOBAL_NODE_MODULES_CANDIDATES];
+  const errors = [];
+  for (const root of anchors) {
+    try {
+      const req = root === null
+        ? localRequire
+        : createRequire(path.join(root, REQUIRE_ANCHOR_BASENAME));
+      return req(SDK_PACKAGE_NAME);
+    } catch (err) {
+      errors.push(err?.code || err?.message || String(err));
+    }
+  }
+  throw new Error(`cannot load ${SDK_PACKAGE_NAME} (${errors.join("; ")})`);
+}
+
+// ---- Main ----
+
+async function main() {
+  const { CopilotClient, RuntimeConnection } = loadSdk();
+
+  // Honor an explicit COPILOT_CLI_PATH override, else pin to the image's CLI
+  // entry when present, else let the SDK resolve (dev machines).
+  const cliPath =
+    process.env.COPILOT_CLI_PATH ||
+    (existsSync(PINNED_CLI_ENTRY) ? PINNED_CLI_ENTRY : undefined);
+  const options = {};
+  if (cliPath) {
+    options.connection = RuntimeConnection.forStdio({ path: cliPath });
+  }
+  // When a token is present, hand it to the SDK explicitly (the documented
+  // path for token auth, kubestellar/hive#2519); when absent, the CLI
+  // resolves its stored logged-in auth ($HOME/.copilot) on its own.
+  if (process.env.COPILOT_GITHUB_TOKEN) {
+    options.gitHubToken = process.env.COPILOT_GITHUB_TOKEN;
+  }
+
+  const client = new CopilotClient(options);
+  try {
+    await client.start();
+    const models = await client.listModels();
+    const out = {
+      models: (models || []).map((m) => ({
+        id: m.id,
+        name: m.name,
+        policyState: m.policy?.state,
+        efforts: m.supportedReasoningEfforts,
+        defaultEffort: m.defaultReasoningEffort,
+      })),
+    };
+    process.stdout.write(JSON.stringify(out) + "\n");
+  } finally {
+    // Best-effort server shutdown; the explicit process.exit below reaps
+    // anything a failed stop leaves behind so no copilot server lingers.
+    try {
+      await client.stop();
+    } catch {
+      // ignored — see comment above
+    }
+  }
+}
+
+main().then(
+  () => process.exit(EXIT_OK),
+  (err) => fail(err?.message || String(err)),
+);

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -87,6 +87,18 @@ RUN npm install -g @github/copilot@${COPILOT_VERSION} && npm cache clean --force
 # the MITM proxy's forged certificates. The Node.js path respects NODE_EXTRA_CA_CERTS.
 RUN rm -f /usr/local/lib/node_modules/@github/copilot/node_modules/@github/copilot-linux-*/copilot 2>/dev/null; true
 
+# --- Layer 3b: GitHub Copilot SDK (pinned; powers SDK-based model discovery) ---
+# The dashboard's copilot model discovery prefers a probe through the official
+# SDK (bin/copilot-models.mjs → /usr/local/bin/copilot-models.mjs) because it
+# rides the CLI's own auth and TLS handling. The helper pins the SDK's runtime
+# connection to the Layer 3 CLI entry above, so the newer @github/copilot the
+# SDK nests as its own dependency is never executed (its native binary would
+# reject the proxy CA). Tolerant of failure like the copilot layer: discovery
+# falls back to the raw HTTP probe when the SDK is absent.
+ARG COPILOT_SDK_VERSION=1.0.8
+RUN npm install -g @github/copilot-sdk@${COPILOT_SDK_VERSION} && npm cache clean --force || \
+    echo "WARN: GitHub Copilot SDK install failed — skipping"
+
 # --- Layer 7: Claude Code (most frequent updates) ---
 ARG CLAUDE_CODE_VERSION=latest
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} && npm cache clean --force
@@ -163,6 +175,9 @@ COPY v2/deploy/hive-panes.sh /usr/local/bin/hive-panes
 COPY bin/gh-app-token.sh bin/hive-config.sh bin/agent-launch.sh bin/git-credential-hive.sh /usr/local/bin/
 COPY bin/hive-open-pr.sh /usr/local/bin/hive-open-pr
 COPY bin/gh-wrapper.sh /usr/local/bin/gh
+# SDK-based copilot model discovery helper (see Layer 3b). Invoked as
+# `node /usr/local/bin/copilot-models.mjs` by the dashboard, so no exec bit.
+COPY bin/copilot-models.mjs /usr/local/bin/copilot-models.mjs
 COPY config/backends.conf /usr/local/etc/hive/backends.conf
 RUN chmod +x /usr/local/bin/ttyd-tmux.sh /usr/local/bin/hive-panes /usr/local/bin/gh-app-token.sh \
     /usr/local/bin/hive-config.sh /usr/local/bin/agent-launch.sh /usr/local/bin/gh \

--- a/v2/pkg/dashboard/cli_models.go
+++ b/v2/pkg/dashboard/cli_models.go
@@ -1,11 +1,14 @@
 package dashboard
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -85,6 +88,45 @@ const (
 	// copilotEditorVersion is sent as Editor-Version; the Copilot endpoints
 	// require a plausible editor identifier.
 	copilotEditorVersion = "vscode/1.99.0"
+
+	// copilotSDKHelperPath is where the image installs the Node helper that
+	// lists Copilot models through the official @github/copilot-sdk (source:
+	// bin/copilot-models.mjs, COPYed by v2/Dockerfile). The SDK spawns the
+	// pinned copilot CLI as a JSON-RPC server, so the probe rides the CLI's
+	// own stored auth and TLS handling — auth configurations the raw-HTTP
+	// probe below cannot reach (verified live against copilot CLI 1.0.59 in a
+	// hive pod: 25 models via stored device-flow auth behind the egress
+	// proxy). Absent outside the image, in which case the SDK probe is
+	// skipped instantly.
+	copilotSDKHelperPath = "/usr/local/bin/copilot-models.mjs"
+
+	// copilotSDKNodeBinary runs the helper. The helper is plain-Node ESM; it
+	// is invoked explicitly (not via shebang) so no exec bit is needed.
+	copilotSDKNodeBinary = "node"
+
+	// copilotSDKProbeTimeout bounds the helper exec. The helper enforces its
+	// OWN hard deadline (INTERNAL_TIMEOUT_MS = 15s in copilot-models.mjs);
+	// this sits slightly above it so the helper always gets to report its own
+	// error on stderr instead of being killed mid-flight.
+	copilotSDKProbeTimeout = 20 * time.Second
+
+	// copilotSDKAgentHome is the shared agent HOME the copilot CLI's stored
+	// device-flow auth lives under ($HOME/.copilot). Agents launch with
+	// HOME=/data/home (see agent.Manager; on hosted spokes /home/dev symlinks
+	// to it), so the helper is run with the same HOME when the directory
+	// exists — otherwise the server process's own HOME is left in place.
+	copilotSDKAgentHome = "/data/home"
+
+	// copilotSDKStderrLogLimit caps how much helper stderr is folded into the
+	// returned error (and thus a single log line) — enough to diagnose, never
+	// a dump. Helper stderr carries only error text, never tokens.
+	copilotSDKStderrLogLimit = 300
+
+	// copilotPolicyStateEnabled is the SDK policy.state value marking a model
+	// as usable by this account; models carrying any OTHER explicit state are
+	// excluded. Models with no policy at all are kept (the catalog omits
+	// policy for unrestricted models).
+	copilotPolicyStateEnabled = "enabled"
 
 	// copilotAutoModel is the Copilot auto-selection sentinel: `copilot --model
 	// auto` lets the Copilot CLI pick/adjust the optimal model per task instead
@@ -414,12 +456,32 @@ func cliStaticFallback(backend string) []string {
 
 // --- Copilot discovery ---
 
-// discoverCopilotModels lists the chat-capable models available to the stored
-// Copilot token. The api host is itself discovered per-account (public vs
-// enterprise). Best-effort: any failure returns fallback=true with an empty
-// list so the caller substitutes the static list.
+// discoverCopilotModels lists the models available to this hive's Copilot
+// auth. Hardened probe order:
+//
+//  1. the official-SDK helper (copilotSDKHelperPath) — the SDK drives the
+//     installed copilot CLI, so it rides the CLI's own auth resolution and
+//     TLS handling and works in configurations the raw-HTTP probe cannot
+//     reach (e.g. stored device-flow auth with no token surfaced here);
+//  2. the raw HTTP GET <copilot-api>/models probe with the stored token,
+//     where the api host is itself discovered per-account (public vs
+//     enterprise);
+//  3. any failure returns fallback=true with an empty list so the caller
+//     substitutes the static list.
+//
+// Successful results from either live probe feed the same cache/retention
+// machinery (see stabilize) via queryCLIModels.
 func (s *Server) discoverCopilotModels() cliModelResult {
 	token := s.copilotToken()
+
+	if models, err := s.probeCopilotModelsSDK(token); err != nil {
+		s.logger.Info("copilot SDK model discovery unavailable, falling back to HTTP probe", "err", err.Error())
+	} else if len(models) == 0 {
+		s.logger.Info("copilot SDK model discovery returned no models, falling back to HTTP probe")
+	} else {
+		return cliModelResult{models: dedupeModels(models), fallback: false}
+	}
+
 	if token == "" {
 		return cliModelResult{fallback: true}
 	}
@@ -433,11 +495,97 @@ func (s *Server) discoverCopilotModels() cliModelResult {
 	if err != nil || len(models) == 0 {
 		if err != nil {
 			// Do NOT log the token or full URL query; just the failure.
-			s.logger.Warn("copilot model discovery failed", "err", err.Error())
+			s.logger.Warn("copilot HTTP model discovery failed, serving static fallback", "err", err.Error())
 		}
 		return cliModelResult{fallback: true}
 	}
 	return cliModelResult{models: dedupeModels(models), fallback: false}
+}
+
+// runCopilotSDKHelper executes the SDK helper and returns its stdout. A
+// package-level seam (mirroring healthAgentStatuses) so unit tests can
+// substitute helper output without running node or the real CLI.
+var runCopilotSDKHelper = execCopilotSDKHelper
+
+// probeCopilotModelsSDK runs the SDK helper under its own timeout and parses
+// the resulting model ids. token may be empty — the CLI then resolves stored
+// device-flow auth on its own, which is exactly the hardening this path adds.
+func (s *Server) probeCopilotModelsSDK(token string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), copilotSDKProbeTimeout)
+	defer cancel()
+	out, err := runCopilotSDKHelper(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	return parseCopilotSDKModels(out)
+}
+
+// execCopilotSDKHelper is the real helper runner: `node copilot-models.mjs`
+// with the inherited environment plus the agent HOME (stored CLI auth) and,
+// when known, the device-flow token. Skips instantly when the helper is not
+// installed (dev machines, unit tests).
+func execCopilotSDKHelper(ctx context.Context, token string) ([]byte, error) {
+	if _, err := os.Stat(copilotSDKHelperPath); err != nil {
+		return nil, fmt.Errorf("sdk helper not installed: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, copilotSDKNodeBinary, copilotSDKHelperPath)
+	// os/exec documents that for duplicate keys the LAST value wins, so
+	// appending overrides the inherited values.
+	env := os.Environ()
+	if st, err := os.Stat(copilotSDKAgentHome); err == nil && st.IsDir() {
+		env = append(env, "HOME="+copilotSDKAgentHome)
+	}
+	if token != "" {
+		// The copilot CLI honors COPILOT_GITHUB_TOKEN; the device-flow token
+		// may exist only in the agent manager's memory. Secret — never logged.
+		env = append(env, "COPILOT_GITHUB_TOKEN="+token)
+	}
+	cmd.Env = env
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if len(msg) > copilotSDKStderrLogLimit {
+			msg = msg[:copilotSDKStderrLogLimit]
+		}
+		return nil, fmt.Errorf("sdk helper: %w (stderr: %s)", err, msg)
+	}
+	return stdout.Bytes(), nil
+}
+
+// copilotSDKModel mirrors one entry of the helper's stdout JSON. The helper
+// also emits name/efforts/defaultEffort for future use; discovery only needs
+// the id and the policy gate today.
+type copilotSDKModel struct {
+	ID          string `json:"id"`
+	PolicyState string `json:"policyState"`
+}
+
+// parseCopilotSDKModels decodes the helper output ({"models":[...]}) and
+// returns usable model ids: models carrying an explicit policy state other
+// than "enabled" are excluded, as is the "auto" pseudo-entry — the dropdown
+// pipeline expects real catalog ids and re-appends the auto sentinel itself
+// via copilotAlwaysIncludeModels (matching the raw-HTTP probe, whose catalog
+// never returns "auto").
+func parseCopilotSDKModels(data []byte) ([]string, error) {
+	var body struct {
+		Models []copilotSDKModel `json:"models"`
+	}
+	if err := json.Unmarshal(data, &body); err != nil {
+		return nil, fmt.Errorf("parse sdk helper output: %w", err)
+	}
+	var out []string
+	for _, m := range body.Models {
+		if m.ID == "" || m.ID == copilotAutoModel {
+			continue
+		}
+		if m.PolicyState != "" && m.PolicyState != copilotPolicyStateEnabled {
+			continue
+		}
+		out = append(out, m.ID)
+	}
+	return out, nil
 }
 
 // copilotToken resolves the Copilot GitHub OAuth token from the agent manager

--- a/v2/pkg/dashboard/cli_models_sdk_test.go
+++ b/v2/pkg/dashboard/cli_models_sdk_test.go
@@ -1,0 +1,156 @@
+package dashboard
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// swapSDKHelper substitutes the SDK-helper seam for one test and restores it.
+func swapSDKHelper(t *testing.T, fn func(ctx context.Context, token string) ([]byte, error)) {
+	t.Helper()
+	prev := runCopilotSDKHelper
+	runCopilotSDKHelper = fn
+	t.Cleanup(func() { runCopilotSDKHelper = prev })
+}
+
+func TestParseCopilotSDKModels_FiltersPolicyAndAuto(t *testing.T) {
+	body := []byte(`{"models":[
+		{"id":"gpt-5.4","name":"GPT-5.4","policyState":"enabled"},
+		{"id":"claude-fable-5","name":"Claude Fable 5","policyState":"enabled","efforts":["low","medium","high"],"defaultEffort":"medium"},
+		{"id":"grok-code-fast-1","name":"Grok","policyState":"unconfigured"},
+		{"id":"gemini-2.5-pro","name":"Gemini"},
+		{"id":"auto","name":"Auto"},
+		{"id":"","name":"nameless"}
+	]}`)
+	got, err := parseCopilotSDKModels(body)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	// enabled ids kept; absent policy kept; non-enabled policy dropped; the
+	// "auto" pseudo-entry and empty ids dropped.
+	want := []string{"gpt-5.4", "claude-fable-5", "gemini-2.5-pro"}
+	if !equalStrings(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestParseCopilotSDKModels_Malformed(t *testing.T) {
+	if _, err := parseCopilotSDKModels([]byte("not json")); err == nil {
+		t.Fatal("expected error on malformed helper output")
+	}
+}
+
+func TestParseCopilotSDKModels_Empty(t *testing.T) {
+	got, err := parseCopilotSDKModels([]byte(`{"models":[]}`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected no models, got %v", got)
+	}
+}
+
+// TestDiscoverCopilotModels_SDKSuccess verifies the SDK probe is consulted
+// FIRST and that a successful helper run yields a live (non-fallback) result
+// even with no token available to the raw-HTTP path — the hardening this
+// probe adds.
+func TestDiscoverCopilotModels_SDKSuccess(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	swapSDKHelper(t, func(ctx context.Context, token string) ([]byte, error) {
+		return []byte(`{"models":[{"id":"gpt-5.4","policyState":"enabled"},{"id":"claude-fable-5","policyState":"enabled"}]}`), nil
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverCopilotModels()
+	if r.fallback {
+		t.Fatalf("SDK success must be a live result, got fallback: %+v", r)
+	}
+	if !equalStrings(r.models, []string{"gpt-5.4", "claude-fable-5"}) {
+		t.Fatalf("got %v, want SDK-discovered ids", r.models)
+	}
+}
+
+// TestDiscoverCopilotModels_SDKFailureFallsBack verifies a nonzero-exit
+// helper falls through to the raw-HTTP probe path; with no token that path
+// resolves to the static fallback, so the chain ends at fallback=true rather
+// than an error or empty list.
+func TestDiscoverCopilotModels_SDKFailureFallsBack(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	swapSDKHelper(t, func(ctx context.Context, token string) ([]byte, error) {
+		return nil, errors.New("exit status 1")
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverCopilotModels()
+	if !r.fallback {
+		t.Fatalf("SDK failure with no token must fall back, got %+v", r)
+	}
+	// The full pipeline still serves a non-empty static list.
+	q := s.queryCLIModels("copilot")
+	if len(q.models) == 0 || !q.fallback {
+		t.Fatalf("pipeline must serve non-empty static fallback, got %+v", q)
+	}
+}
+
+// TestDiscoverCopilotModels_SDKMalformedFallsBack verifies helper stdout that
+// fails to parse is treated exactly like a failed probe.
+func TestDiscoverCopilotModels_SDKMalformedFallsBack(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	swapSDKHelper(t, func(ctx context.Context, token string) ([]byte, error) {
+		return []byte("garbage"), nil
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	if r := s.discoverCopilotModels(); !r.fallback {
+		t.Fatalf("malformed SDK output must fall back, got %+v", r)
+	}
+}
+
+// TestDiscoverCopilotModels_SDKEmptyFallsBack verifies a well-formed helper
+// response with zero usable models is not served as a live (empty) list.
+func TestDiscoverCopilotModels_SDKEmptyFallsBack(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	swapSDKHelper(t, func(ctx context.Context, token string) ([]byte, error) {
+		return []byte(`{"models":[{"id":"auto"}]}`), nil
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	if r := s.discoverCopilotModels(); !r.fallback {
+		t.Fatalf("empty SDK result must fall back, got %+v", r)
+	}
+}
+
+// TestQueryCLIModels_SDKResultsFeedRetention verifies SDK-discovered models
+// ride the same stabilize/retention machinery as the HTTP probe: a model seen
+// in one live SDK sample survives its absence from the next sample.
+func TestQueryCLIModels_SDKResultsFeedRetention(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	sample := []byte(`{"models":[{"id":"gpt-5.4","policyState":"enabled"},{"id":"claude-fable-5","policyState":"enabled"}]}`)
+	swapSDKHelper(t, func(ctx context.Context, token string) ([]byte, error) {
+		out := sample
+		return out, nil
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	if r := s.queryCLIModels("copilot"); !contains(r.models, "claude-fable-5") {
+		t.Fatalf("first live sample missing id: %v", r.models)
+	}
+	// Next probe omits claude-fable-5; expire the cache and re-query.
+	sample = []byte(`{"models":[{"id":"gpt-5.4","policyState":"enabled"}]}`)
+	s.cliModels.entries = map[string]cliModelCacheEntry{}
+	r := s.queryCLIModels("copilot")
+	if r.fallback {
+		t.Fatalf("live SDK result must not be fallback: %+v", r)
+	}
+	if !contains(r.models, "claude-fable-5") {
+		t.Fatalf("retention should keep recently-seen id through one miss: %v", r.models)
+	}
+}
+
+// TestProbeCopilotModelsSDK_HelperNotInstalled verifies the real exec path
+// degrades instantly (no hang, no panic) when the helper script is absent —
+// the situation on dev machines and CI runners.
+func TestProbeCopilotModelsSDK_HelperNotInstalled(t *testing.T) {
+	s := &Server{logger: testLogger()}
+	if _, err := s.probeCopilotModelsSDK(""); err == nil {
+		// The helper is installed only inside the hive image; if this machine
+		// actually has it, the probe may legitimately succeed — skip then.
+		t.Skip("copilot SDK helper present on this machine; skipping absence check")
+	}
+}


### PR DESCRIPTION
## What

Hardens copilot CLI model discovery by adding an SDK-backed probe through the official `@github/copilot-sdk`, tried **before** the existing raw-HTTP `/models` probe, feeding the same cache/retention pipeline.

Fixes #2519

## Why

The raw-HTTP probe needs a GitHub OAuth token surfaced to the dashboard server. The SDK path instead drives the installed copilot CLI as a JSON-RPC server (`models.list`), so discovery rides the CLI's **own** auth resolution (stored device-flow auth under `$HOME/.copilot`, or `COPILOT_GITHUB_TOKEN`) and the CLI's own TLS handling (`NODE_EXTRA_CA_CERTS`) — working in auth configurations the raw-HTTP path cannot reach, and never inferring entitlement from any public supported-model table.

## Fallback chain

1. **SDK probe** — `node /usr/local/bin/copilot-models.mjs` (20s exec timeout wrapping the helper's own hard 15s deadline). Helper emits one line of JSON; nothing on stdout + nonzero exit on failure; `client.stop()` in a finally + forced `process.exit` so no copilot server lingers; tokens never printed.
2. **Raw HTTP probe** — unchanged: per-account api-host discovery via `copilot_internal/user`, then `GET <copilot-api>/models`.
3. **Static fallback list** — unchanged floor so dropdowns are never empty.

One concise log line at each fallback step. Live results from either probe pass through the existing 30s cache (`cliModelCacheTTL`) and consecutive-miss retention (`cliModelDropAfterMisses`).

## Issue #2519 requirement mapping

1. **SDK-backed adapter normalizing `ModelInfo[]`** — `bin/copilot-models.mjs` (CopilotClient start → listModels → stop; normalizes to `{id, name, policyState, efforts, defaultEffort}`) + `parseCopilotSDKModels` in `cli_models.go`.
2. **Only `policy.state === "enabled"`, `id` verbatim** — models with an explicit non-`enabled` policy state are excluded (absent policy kept — the catalog omits policy for unrestricted models); ids flow untouched into the existing `AGENT_MODEL` → `copilot --model` path. The `auto` pseudo-entry is excluded from discovery and re-appended by the existing `copilotAlwaysIncludeModels` sentinel handling, matching the raw-HTTP probe.
3. **Pinned models preserved on discovery/auth failure** — any failure ends in a result marked `fallback: true`; `modelIDsForBackend` returns nil for fallback results, so validation lets pinned values through and model auto-heal never acts on static data.
4. **Brief caching, refreshed, identity-aware** — the existing 30s TTL + `stabilize()` retention; the helper runs with the CLI's own auth context (constructor `gitHubToken` when `COPILOT_GITHUB_TOKEN` is present, else stored `~/.copilot` auth under the agent HOME), and the cache is per-hive-process, i.e. per authenticated identity on a spoke. CLI version is fixed per image (pinned), so the cache key is implicitly version-stable.
5. **Per-user effective access** — `listModels()` is inherently the authenticated user's effective catalog, not org inventory. BYOK setups replace `models.list` and are out of scope here (the SDK's `onListModels` hook is the extension point).

## Verification

Verified live today inside a real hive pod against the fleet's pinned copilot CLI **1.0.59** (Node.js path, egress-proxy environment, stored auth at `/data/home/.copilot`): `listModels()` returned **25 models**, including the `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` ids the issue asks discovery to detect. Also verified with `COPILOT_GITHUB_TOKEN` set.

The helper pins the SDK's runtime connection to the image's copilot CLI entry (`/usr/local/lib/node_modules/@github/copilot/index.js`), so the copilot version pin is untouched and the newer `@github/copilot` the SDK nests as its own dependency is never executed. The SDK install (`@github/copilot-sdk@1.0.8`, pinned) is failure-tolerant like the copilot layer — a missing SDK just means discovery starts at step 2.

## Tests

`cli_models_sdk_test.go` (exec seam, no real CLI): helper success (SDK-first, no token needed), nonzero exit → fallback chain, malformed JSON → fallback, empty result → fallback, policy filtering + `auto` exclusion, retention smoothing over SDK samples, instant degradation when the helper is absent.
