### PR TITLE
✨ feat(dashboard): live claude model discovery via /v1/models OAuth

### DIFF
--- a/v2/pkg/dashboard/cli_models.go
+++ b/v2/pkg/dashboard/cli_models.go
@@ -11,9 +11,12 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/claude"
 )
 
 // This file adds runtime model discovery for the CLI backends (copilot,
@@ -29,10 +32,17 @@ import (
 //     api.github.com/copilot_internal/user (endpoints.api). Verified live.
 //   - gemini:  GET generativelanguage.googleapis.com/v1beta/models with the
 //     configured Gemini API key. Live only when a key is configured.
-//   - claude:  Anthropic publishes no per-subscription "list my models"
-//     endpoint and the Claude CLI has no non-interactive `claude models`
-//     command, so this is a maintained static list of CURRENT model ids
-//     (kept in sync with CLAUDE_CLI_MODELS in static/index.html).
+//   - claude:  GET api.anthropic.com/v1/models. The endpoint accepts BOTH a
+//     standard Anthropic API key (x-api-key, preferred when ANTHROPIC_API_KEY
+//     is set) and the Claude Code subscription OAuth bearer token stored by
+//     the CLI in ~/.claude/.credentials.json (verified live: HTTP 200 with a
+//     subscription token). The OAuth token is short-lived (<1 day) and is
+//     refreshed ONLY when the claude CLI itself runs, so the prober re-reads
+//     the file on every probe, checks expiresAt BEFORE any HTTP call, and
+//     NEVER attempts a token refresh itself — rotating the token out from
+//     under the CLI would break its login (the hive inotify-watches
+//     ~/.claude/). Expired/absent credentials skip straight to the static
+//     fallback (kept in sync with CLAUDE_CLI_MODELS in static/index.html).
 //   - goose:   provider-configured (Ollama/OpenAI/Anthropic/...). goose
 //     >= 1.37 ships an ACP (Agent Client Protocol) agent server (`goose acp`,
 //     JSON-RPC over stdio): initialize + session/new returns result.models
@@ -221,25 +231,57 @@ const (
 	gooseACPInitializeID   = 1
 	gooseACPSessionNewID   = 2
 	gooseACPSessionCloseID = 3
+
+	// --- Claude (Anthropic) ---
+
+	// anthropicModelsURL lists the models available to the presented credential
+	// (API key or Claude Code subscription OAuth token — both accepted,
+	// verified live).
+	anthropicModelsURL = "https://api.anthropic.com/v1/models"
+
+	// anthropicModelsPageLimit is the ?limit= page size for /v1/models. Set to
+	// the API maximum so a single call covers the whole catalog (currently
+	// ~a dozen ids) without pagination.
+	anthropicModelsPageLimit = 1000
+
+	// anthropicAPIVersion is the required anthropic-version header value.
+	anthropicAPIVersion = "2023-06-01"
+
+	// anthropicOAuthBeta is the anthropic-beta value sent alongside a Claude
+	// Code subscription OAuth bearer token. Currently optional for /v1/models
+	// (verified live: 200 without it) but sent anyway for forward
+	// compatibility, mirroring what the Claude CLI sends.
+	anthropicOAuthBeta = "oauth-2025-04-20"
+
+	// claudeTokenExpirySkew is the safety margin subtracted from the stored
+	// token's expiresAt before use: a token within this window of expiring is
+	// treated as already expired so we never fire an HTTP call that a few
+	// seconds of clock skew or transit time would turn into a 401.
+	claudeTokenExpirySkew = 2 * time.Minute
 )
 
 // --- Static fallback lists (kept CURRENT — July 2026) ---
 
-// claudeStaticModels is the maintained fallback/authoritative list for the
-// Claude CLI. Anthropic exposes no "list my models" API and the CLI has no
-// non-interactive list command, so this list IS the source of truth. Keep it
+// claudeStaticModels is the fallback offered when the Claude models probe
+// cannot run (no API key and no fresh OAuth token in the CLI credentials
+// file) or fails. Live discovery via api.anthropic.com/v1/models is strongly
+// preferred; this is only a floor so the dropdown is never empty. Refreshed
+// 2026-08-03 from a live /v1/models response (11 ids, in API order). Keep it
 // in sync with CLAUDE_CLI_MODELS in static/index.html. Both the canonical
-// dated/versioned ids AND the bare aliases the CLI accepts are included.
+// ids AND the bare aliases the CLI accepts are included.
 var claudeStaticModels = []string{
+	"claude-opus-5",
+	"claude-sonnet-5",
 	"claude-fable-5",
 	"claude-opus-4-8",
 	"claude-opus-4-7",
-	"claude-opus-4-6",
-	"claude-sonnet-5",
 	"claude-sonnet-4-6",
-	"claude-sonnet-4-5",
-	"claude-haiku-4-5",
-	// Bare aliases the Claude CLI also accepts.
+	"claude-opus-4-6",
+	"claude-opus-4-5-20251101",
+	"claude-haiku-4-5-20251001",
+	"claude-sonnet-4-5-20250929",
+	"claude-opus-4-1-20250805",
+	// Bare aliases the Claude CLI also accepts (see claudeAlwaysIncludeModels).
 	"opus",
 	"sonnet",
 	"haiku",
@@ -276,6 +318,18 @@ var copilotAlwaysIncludeModels = []string{
 	// Auto-select sentinel — never returned by the /models catalog, but a valid
 	// launch value, so it must always be offered and must survive auto-heal.
 	copilotAutoModel,
+}
+
+// claudeAlwaysIncludeModels are ids that must ALWAYS be offered in the claude
+// dropdown, whether the served list came from live discovery or the static
+// fallback (mirrors copilotAlwaysIncludeModels). The Anthropic /v1/models
+// endpoint never returns the bare aliases, but they are valid `claude --model`
+// values, so they are appended to every served claude list — surviving both
+// paths and the dashboard's model auto-heal.
+var claudeAlwaysIncludeModels = []string{
+	"opus",
+	"sonnet",
+	"haiku",
 }
 
 // bobStaticModels is bob's complete model list: exactly one entry, the auto
@@ -453,8 +507,7 @@ func (s *Server) queryCLIModels(backend string) cliModelResult {
 	case "goose":
 		r = s.discoverGooseModels()
 	case "claude":
-		// No live source exists; the maintained static list is authoritative.
-		r = cliModelResult{models: dedupeModels(claudeStaticModels), fallback: false}
+		r = s.discoverClaudeModels()
 	case "codex":
 		// No probe wired yet; the maintained static list is authoritative and
 		// OpenAI-only (Claude ids are rejected by Codex with a ChatGPT account).
@@ -480,9 +533,12 @@ func (s *Server) queryCLIModels(backend string) cliModelResult {
 	}
 	// Applied after stabilization/fallback so the pinned ids survive BOTH
 	// paths: a live sample that omits a rollout-gated id and the static
-	// fallback list (see copilotAlwaysIncludeModels).
+	// fallback list (see copilotAlwaysIncludeModels / claudeAlwaysIncludeModels).
 	if backend == "copilot" {
 		r.models = dedupeModels(append(r.models, copilotAlwaysIncludeModels...))
+	}
+	if backend == "claude" {
+		r.models = dedupeModels(append(r.models, claudeAlwaysIncludeModels...))
 	}
 	if s.cliModels != nil {
 		s.cliModels.set(backend, r)
@@ -832,6 +888,159 @@ func parseGeminiModelsResponse(r io.Reader) ([]string, error) {
 			continue
 		}
 		out = append(out, strings.TrimPrefix(m.Name, "models/"))
+	}
+	return out, nil
+}
+
+// --- Claude (Anthropic) discovery ---
+
+// claudePodCredentialsPath is a var (not a const) solely so tests can point it
+// at a temp file (mirroring sharedClaudeCredentialPath in pkg/agent). The
+// production value — the hosted-pod home — is never mutated at runtime.
+var claudePodCredentialsPath = claude.CredentialsPath
+
+// anthropicModelsEndpoint redirects the models call away from the real
+// Anthropic endpoint. TEST SEAM ONLY: it is never changed in production, where
+// every probe goes to anthropicModelsURL. It exists so discoverClaudeModels'
+// response handling (success, 401, malformed JSON) can be exercised against an
+// httptest server without a live API round trip.
+var anthropicModelsEndpoint = anthropicModelsURL
+
+// discoverClaudeModels lists the models available to the local Claude
+// credential by calling the Anthropic /v1/models endpoint. Credential
+// precedence: ANTHROPIC_API_KEY (x-api-key header), else the Claude Code
+// subscription OAuth access token from the CLI's credentials file
+// (Authorization: Bearer — accepted by the endpoint, verified live).
+// Best-effort: no credential, an expired token, or any HTTP/parse failure
+// returns fallback=true with an empty list so the caller substitutes the
+// static list. The stored token is NEVER refreshed here (see file header).
+func (s *Server) discoverClaudeModels() cliModelResult {
+	header, value, ok := claudeAPICredential()
+	if !ok {
+		// No API key and no fresh OAuth token. Skip the HTTP call entirely —
+		// on copilot-only spokes the credentials file can sit expired for
+		// weeks, and refreshing it is forbidden (it would rotate the token
+		// out from under the claude CLI's own login).
+		return cliModelResult{fallback: true}
+	}
+	models, err := fetchClaudeModels(anthropicModelsEndpoint, header, value)
+	if err != nil || len(models) == 0 {
+		if err != nil {
+			// Do NOT log the credential or response body; just the failure.
+			s.logger.Warn("claude model discovery failed", "err", err.Error())
+		}
+		return cliModelResult{fallback: true}
+	}
+	return cliModelResult{models: dedupeModels(models), fallback: false}
+}
+
+// claudeAPICredential resolves the credential for the Anthropic models call as
+// an (header name, header value) pair. ANTHROPIC_API_KEY wins when set; else
+// the freshest non-expired OAuth access token from the Claude CLI credentials
+// file is used as a bearer. ok=false means no usable credential. Secret —
+// never log the value.
+func claudeAPICredential() (header, value string, ok bool) {
+	if k := os.Getenv("ANTHROPIC_API_KEY"); k != "" {
+		return "x-api-key", k, true
+	}
+	for _, path := range claudeCredentialCandidatePaths() {
+		if tok := readFreshClaudeToken(path); tok != "" {
+			return "Authorization", "Bearer " + tok, true
+		}
+	}
+	return "", "", false
+}
+
+// claudeCredentialCandidatePaths returns the credentials-file locations to
+// try, in order: the hosted-pod shared home (the same /data/home the agent
+// manager uses for agent homes), then $HOME/.claude/.credentials.json for
+// non-hosted spokes. Computed per call — never cached — because the claude
+// CLI rewrites the file whenever it runs and the probe must see the freshest
+// token.
+func claudeCredentialCandidatePaths() []string {
+	paths := []string{claudePodCredentialsPath}
+	if home := os.Getenv("HOME"); home != "" {
+		if p := filepath.Join(home, ".claude", ".credentials.json"); p != claudePodCredentialsPath {
+			paths = append(paths, p)
+		}
+	}
+	return paths
+}
+
+// readFreshClaudeToken reads and parses one credentials file and returns its
+// OAuth access token ONLY if it is not expired (with claudeTokenExpirySkew of
+// margin). Absent file, malformed JSON, missing token, or an expired/expiring
+// token all return "" — the caller then falls back rather than firing a
+// doomed HTTP call. This deliberately does not reuse claude.ReadAccessToken,
+// which applies no skew margin.
+func readFreshClaudeToken(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	var creds claude.Credentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return ""
+	}
+	o := creds.ClaudeAIOAuth
+	if o == nil || o.AccessToken == "" {
+		return ""
+	}
+	// expiresAt is a millisecond epoch; treat anything inside the skew window
+	// as already expired.
+	if o.ExpiresAt > 0 && time.UnixMilli(o.ExpiresAt).Before(time.Now().Add(claudeTokenExpirySkew)) {
+		return ""
+	}
+	return o.AccessToken
+}
+
+// fetchClaudeModels performs the GET <endpoint>?limit=N call and returns the
+// model ids. authHeader/authValue carry either the API key (x-api-key) or the
+// OAuth bearer (Authorization) — see claudeAPICredential.
+func fetchClaudeModels(modelsURL, authHeader, authValue string) ([]string, error) {
+	client := &http.Client{Timeout: cliModelQueryTimeout}
+	url := fmt.Sprintf("%s?limit=%d", modelsURL, anthropicModelsPageLimit)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set(authHeader, authValue)
+	req.Header.Set("anthropic-version", anthropicAPIVersion)
+	if authHeader == "Authorization" {
+		// OAuth (subscription-token) calls also send the oauth beta flag —
+		// currently optional for /v1/models, sent for forward compatibility.
+		req.Header.Set("anthropic-beta", anthropicOAuthBeta)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("upstream returned %d", resp.StatusCode)
+	}
+	return parseClaudeModelsResponse(resp.Body)
+}
+
+// parseClaudeModelsResponse decodes the Anthropic /v1/models body and returns
+// the model ids. The response shape is:
+//
+//	{"data":[{"id":"claude-opus-5","type":"model",...}, ...]}
+func parseClaudeModelsResponse(r io.Reader) ([]string, error) {
+	var body struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(r).Decode(&body); err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, m := range body.Data {
+		if m.ID == "" {
+			continue
+		}
+		out = append(out, m.ID)
 	}
 	return out, nil
 }

--- a/v2/pkg/dashboard/cli_models_claude_test.go
+++ b/v2/pkg/dashboard/cli_models_claude_test.go
@@ -1,0 +1,308 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/claude"
+)
+
+// withoutClaudeCredentials makes the claude discovery credential resolution
+// deterministic and offline: no ANTHROPIC_API_KEY, an empty temp HOME, and the
+// hosted-pod credentials path redirected to a nonexistent temp file. Restores
+// the path seam on cleanup.
+func withoutClaudeCredentials(t *testing.T) {
+	t.Helper()
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("HOME", t.TempDir())
+	orig := claudePodCredentialsPath
+	claudePodCredentialsPath = filepath.Join(t.TempDir(), "absent", ".credentials.json")
+	t.Cleanup(func() { claudePodCredentialsPath = orig })
+}
+
+// writeClaudeCredentials writes a credentials file in the CLI's on-disk shape
+// under a temp HOME and points $HOME at it. The hosted-pod path seam is
+// redirected to a nonexistent file so a real /data volume (if present) can
+// never leak into the test. Returns the file path.
+func writeClaudeCredentials(t *testing.T, token string, expiresAt int64) string {
+	t.Helper()
+	orig := claudePodCredentialsPath
+	claudePodCredentialsPath = filepath.Join(t.TempDir(), "absent", ".credentials.json")
+	t.Cleanup(func() { claudePodCredentialsPath = orig })
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, ".credentials.json")
+	creds := claude.Credentials{ClaudeAIOAuth: &claude.OAuthTokens{
+		AccessToken: token,
+		ExpiresAt:   expiresAt,
+	}}
+	data, err := json.Marshal(creds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// redirectAnthropicEndpoint points the models probe at a test server and
+// restores it on cleanup.
+func redirectAnthropicEndpoint(t *testing.T, url string) {
+	t.Helper()
+	orig := anthropicModelsEndpoint
+	anthropicModelsEndpoint = url
+	t.Cleanup(func() { anthropicModelsEndpoint = orig })
+}
+
+// futureExpiryMs returns a millisecond-epoch expiry comfortably outside the
+// skew window.
+func futureExpiryMs() int64 {
+	return time.Now().Add(claudeTokenExpirySkew + time.Hour).UnixMilli()
+}
+
+// --- credentials parsing ---
+
+func TestReadFreshClaudeToken_Valid(t *testing.T) {
+	path := writeClaudeCredentials(t, "sk-ant-oat-test", futureExpiryMs())
+	if got := readFreshClaudeToken(path); got != "sk-ant-oat-test" {
+		t.Fatalf("got %q, want the stored token", got)
+	}
+}
+
+func TestReadFreshClaudeToken_AbsentFile(t *testing.T) {
+	if got := readFreshClaudeToken(filepath.Join(t.TempDir(), "nope.json")); got != "" {
+		t.Fatalf("absent file must yield empty token, got %q", got)
+	}
+}
+
+func TestReadFreshClaudeToken_Malformed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".credentials.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := readFreshClaudeToken(path); got != "" {
+		t.Fatalf("malformed file must yield empty token, got %q", got)
+	}
+}
+
+func TestReadFreshClaudeToken_Expired(t *testing.T) {
+	// Long expired — the copilot-only-spoke case where the file sits stale
+	// for weeks. Must be rejected BEFORE any HTTP call.
+	path := writeClaudeCredentials(t, "tok", time.Now().Add(-24*time.Hour).UnixMilli())
+	if got := readFreshClaudeToken(path); got != "" {
+		t.Fatalf("expired token must yield empty, got %q", got)
+	}
+}
+
+func TestReadFreshClaudeToken_WithinSkewWindow(t *testing.T) {
+	// Not yet expired, but inside the skew margin — treated as expired so a
+	// few seconds of clock skew can't turn the probe into a doomed 401.
+	path := writeClaudeCredentials(t, "tok", time.Now().Add(claudeTokenExpirySkew/2).UnixMilli())
+	if got := readFreshClaudeToken(path); got != "" {
+		t.Fatalf("token inside skew window must yield empty, got %q", got)
+	}
+}
+
+// --- credential precedence ---
+
+func TestClaudeAPICredential_EnvKeyPrecedence(t *testing.T) {
+	// A valid OAuth file exists, but ANTHROPIC_API_KEY must win with x-api-key.
+	writeClaudeCredentials(t, "oauth-token", futureExpiryMs())
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-api-key")
+	header, value, ok := claudeAPICredential()
+	if !ok || header != "x-api-key" || value != "sk-ant-api-key" {
+		t.Fatalf("env key must win: got %q=%q ok=%v", header, value, ok)
+	}
+}
+
+func TestClaudeAPICredential_OAuthBearerFromHome(t *testing.T) {
+	writeClaudeCredentials(t, "oauth-token", futureExpiryMs())
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	header, value, ok := claudeAPICredential()
+	if !ok || header != "Authorization" || value != "Bearer oauth-token" {
+		t.Fatalf("expected bearer from $HOME credentials: got %q=%q ok=%v", header, value, ok)
+	}
+}
+
+func TestClaudeAPICredential_NoneAvailable(t *testing.T) {
+	withoutClaudeCredentials(t)
+	if _, _, ok := claudeAPICredential(); ok {
+		t.Fatal("no env key and no file must yield ok=false")
+	}
+}
+
+// --- discovery over httptest (never the real API) ---
+
+// claudeModelsTestServer serves a canned /v1/models body and records the
+// request headers for assertion.
+func claudeModelsTestServer(t *testing.T, status int, body string, gotHeaders *http.Header) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if gotHeaders != nil {
+			*gotHeaders = r.Header.Clone()
+		}
+		if r.URL.Query().Get("limit") == "" {
+			t.Error("models request missing ?limit= page-size parameter")
+		}
+		w.WriteHeader(status)
+		w.Write([]byte(body))
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestDiscoverClaudeModels_LiveSuccess(t *testing.T) {
+	writeClaudeCredentials(t, "oauth-token", futureExpiryMs())
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	var hdr http.Header
+	ts := claudeModelsTestServer(t, http.StatusOK,
+		`{"data":[{"id":"claude-opus-5","type":"model"},{"id":"claude-sonnet-5","type":"model"},{"id":""}]}`, &hdr)
+	redirectAnthropicEndpoint(t, ts.URL)
+
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverClaudeModels()
+	if r.fallback {
+		t.Fatal("successful probe must not be marked fallback")
+	}
+	if !equalStrings(r.models, []string{"claude-opus-5", "claude-sonnet-5"}) {
+		t.Fatalf("got %v, want the two non-empty live ids", r.models)
+	}
+	// OAuth request shape: bearer + version + oauth beta.
+	if got := hdr.Get("Authorization"); got != "Bearer oauth-token" {
+		t.Fatalf("Authorization = %q", got)
+	}
+	if got := hdr.Get("anthropic-version"); got != anthropicAPIVersion {
+		t.Fatalf("anthropic-version = %q", got)
+	}
+	if got := hdr.Get("anthropic-beta"); got != anthropicOAuthBeta {
+		t.Fatalf("anthropic-beta = %q", got)
+	}
+}
+
+func TestDiscoverClaudeModels_APIKeyHeader(t *testing.T) {
+	withoutClaudeCredentials(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-key")
+	var hdr http.Header
+	ts := claudeModelsTestServer(t, http.StatusOK, `{"data":[{"id":"claude-opus-5"}]}`, &hdr)
+	redirectAnthropicEndpoint(t, ts.URL)
+
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverClaudeModels()
+	if r.fallback || !equalStrings(r.models, []string{"claude-opus-5"}) {
+		t.Fatalf("got %+v, want live single-id result", r)
+	}
+	if got := hdr.Get("x-api-key"); got != "sk-ant-key" {
+		t.Fatalf("x-api-key = %q", got)
+	}
+	if hdr.Get("Authorization") != "" {
+		t.Fatal("API-key path must not send an Authorization header")
+	}
+}
+
+func TestDiscoverClaudeModels_Unauthorized(t *testing.T) {
+	writeClaudeCredentials(t, "stale-but-unexpired", futureExpiryMs())
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	ts := claudeModelsTestServer(t, http.StatusUnauthorized, `{"error":{"type":"authentication_error"}}`, nil)
+	redirectAnthropicEndpoint(t, ts.URL)
+
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	if r := s.discoverClaudeModels(); !r.fallback || len(r.models) != 0 {
+		t.Fatalf("401 must yield empty fallback result, got %+v", r)
+	}
+}
+
+func TestDiscoverClaudeModels_MalformedBody(t *testing.T) {
+	writeClaudeCredentials(t, "tok", futureExpiryMs())
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	ts := claudeModelsTestServer(t, http.StatusOK, `{not json`, nil)
+	redirectAnthropicEndpoint(t, ts.URL)
+
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	if r := s.discoverClaudeModels(); !r.fallback || len(r.models) != 0 {
+		t.Fatalf("malformed body must yield empty fallback result, got %+v", r)
+	}
+}
+
+func TestDiscoverClaudeModels_ExpiredSkipsHTTP(t *testing.T) {
+	// The expired-token path must never reach the network: the test server
+	// fails the test if it receives any request.
+	writeClaudeCredentials(t, "tok", time.Now().Add(-time.Hour).UnixMilli())
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("expired credentials must not trigger an HTTP call")
+	}))
+	t.Cleanup(ts.Close)
+	redirectAnthropicEndpoint(t, ts.URL)
+
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	if r := s.discoverClaudeModels(); !r.fallback {
+		t.Fatalf("expired token must fall back, got %+v", r)
+	}
+}
+
+func TestParseClaudeModelsResponse_Malformed(t *testing.T) {
+	if _, err := parseClaudeModelsResponse(strings.NewReader("nope")); err == nil {
+		t.Fatal("expected error on malformed body")
+	}
+}
+
+// --- full queryCLIModels paths: aliases + auto-heal exclusion semantics ---
+
+func TestQueryCLIModels_ClaudeAliasesOnLivePath(t *testing.T) {
+	writeClaudeCredentials(t, "tok", futureExpiryMs())
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	ts := claudeModelsTestServer(t, http.StatusOK,
+		`{"data":[{"id":"claude-opus-5"},{"id":"claude-sonnet-5"}]}`, nil)
+	redirectAnthropicEndpoint(t, ts.URL)
+
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.queryCLIModels("claude")
+	if r.fallback {
+		t.Fatalf("live probe must not be fallback: %+v", r)
+	}
+	if !contains(r.models, "claude-opus-5") {
+		t.Fatalf("live id missing: %v", r.models)
+	}
+	for _, alias := range claudeAlwaysIncludeModels {
+		if !contains(r.models, alias) {
+			t.Fatalf("alias %q must survive the live path (API never returns it): %v", alias, r.models)
+		}
+	}
+	// Live data IS usable for validation/auto-heal — and the appended aliases
+	// are part of the cached list, so auto-heal can never heal an agent off a
+	// bare-alias selection.
+	ids := s.modelIDsForBackend("claude")
+	if len(ids) == 0 {
+		t.Fatal("modelIDsForBackend must return live claude ids")
+	}
+	for _, alias := range claudeAlwaysIncludeModels {
+		if !contains(ids, alias) {
+			t.Fatalf("alias %q missing from validation ids: %v", alias, ids)
+		}
+	}
+}
+
+func TestQueryCLIModels_ClaudeFallbackExcludedFromAutoHeal(t *testing.T) {
+	withoutClaudeCredentials(t)
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.queryCLIModels("claude")
+	if !r.fallback {
+		t.Fatalf("no-credential claude must be fallback, got %+v", r)
+	}
+	// Fallback (static) data is a maintained guess, not the account's
+	// inventory — it must never drive validation or model auto-heal.
+	if ids := s.modelIDsForBackend("claude"); ids != nil {
+		t.Fatalf("fallback claude data must yield nil validation ids, got %v", ids)
+	}
+}

--- a/v2/pkg/dashboard/cli_models_coverage_test.go
+++ b/v2/pkg/dashboard/cli_models_coverage_test.go
@@ -11,6 +11,7 @@ import (
 // the static-list, cache, and fallback branches (all offline).
 func TestCovD_QueryCLIModels(t *testing.T) {
 	swapGooseProbe(t, gooseProbeMissing)
+	withoutClaudeCredentials(t)
 	logger := testLoggerCovD()
 	s := NewServer(0, logger)
 

--- a/v2/pkg/dashboard/cli_models_test.go
+++ b/v2/pkg/dashboard/cli_models_test.go
@@ -85,19 +85,26 @@ func TestDedupeModels(t *testing.T) {
 	}
 }
 
-// TestQueryCLIModels_ClaudeStatic verifies claude returns a non-empty,
-// non-fallback (authoritative static) list without any network call.
-func TestQueryCLIModels_ClaudeStatic(t *testing.T) {
-	s := &Server{cliModels: newCLIModelCache()}
+// TestQueryCLIModels_ClaudeFallbackNoCreds verifies that with no API key and
+// no credentials file, claude discovery skips the network entirely and serves
+// the static fallback (non-empty, fallback=true) with the aliases appended.
+func TestQueryCLIModels_ClaudeFallbackNoCreds(t *testing.T) {
+	withoutClaudeCredentials(t)
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
 	r := s.queryCLIModels("claude")
 	if len(r.models) == 0 {
 		t.Fatal("claude models should never be empty")
 	}
-	if r.fallback {
-		t.Fatal("claude static list is authoritative, not a fallback")
+	if !r.fallback {
+		t.Fatal("claude with no credential must be marked fallback")
 	}
 	if !contains(r.models, "claude-opus-4-8") {
 		t.Fatalf("claude models missing current id: %v", r.models)
+	}
+	for _, alias := range claudeAlwaysIncludeModels {
+		if !contains(r.models, alias) {
+			t.Fatalf("alias %q missing from fallback claude list: %v", alias, r.models)
+		}
 	}
 }
 
@@ -327,6 +334,7 @@ func TestCliStaticFallback_BobAutoOnly(t *testing.T) {
 // where adding bob narrows or empties another CLI backend's catalog.
 func TestQueryCLIModels_BobDoesNotAffectOtherBackends(t *testing.T) {
 	swapGooseProbe(t, gooseProbeMissing)
+	withoutClaudeCredentials(t)
 	t.Setenv("COPILOT_GITHUB_TOKEN", "")
 	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
 	for _, backend := range []string{"claude", "copilot", "gemini", "goose", "codex"} {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6346,14 +6346,26 @@
           .filter(name => name && !KNOWN_BACKENDS.includes(name));
       } catch (e) { /* keep prior list; dropdowns fall back to KNOWN_BACKENDS */ }
     }
+    // Fallback list only — the server now discovers claude models live via
+    // GET api.anthropic.com/v1/models (see claudeStaticModels in
+    // pkg/dashboard/cli_models.go; keep the two lists in sync). Refreshed
+    // 2026-08-03 from a live /v1/models response, in API order, plus the bare
+    // aliases the claude CLI accepts as --model values.
     const CLAUDE_CLI_MODELS = [
+      { value: 'claude-opus-5', label: 'Opus 5' },
+      { value: 'claude-sonnet-5', label: 'Sonnet 5' },
+      { value: 'claude-fable-5', label: 'Fable 5' },
       { value: 'claude-opus-4-8', label: 'Opus 4.8' },
       { value: 'claude-opus-4-7', label: 'Opus 4.7' },
-      { value: 'claude-opus-4-6', label: 'Opus 4.6' },
       { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
-      { value: 'claude-sonnet-4-5', label: 'Sonnet 4.5' },
-      { value: 'claude-haiku-4-5', label: 'Haiku 4.5' },
-      { value: 'claude-fable-5', label: 'Fable 5' },
+      { value: 'claude-opus-4-6', label: 'Opus 4.6' },
+      { value: 'claude-opus-4-5-20251101', label: 'Opus 4.5' },
+      { value: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
+      { value: 'claude-sonnet-4-5-20250929', label: 'Sonnet 4.5' },
+      { value: 'claude-opus-4-1-20250805', label: 'Opus 4.1' },
+      { value: 'opus', label: 'Opus (alias)' },
+      { value: 'sonnet', label: 'Sonnet (alias)' },
+      { value: 'haiku', label: 'Haiku (alias)' },
     ];
     const COPILOT_CLI_MODELS = [
       // Auto sentinel: `copilot --model auto` lets the Copilot CLI pick/adjust


### PR DESCRIPTION
## What

Wires LIVE model discovery for the `claude` CLI backend, replacing the static-authoritative list in `v2/pkg/dashboard/cli_models.go`. The prober calls `GET https://api.anthropic.com/v1/models`, which accepts **both** a standard Anthropic API key and the Claude Code **subscription OAuth bearer token** stored by the CLI in `~/.claude/.credentials.json`.

## Mechanism

- `discoverClaudeModels()` mirrors `discoverCopilotModels()`:
  1. Credential precedence: `ANTHROPIC_API_KEY` env → `x-api-key` header; else the OAuth access token from the credentials file (`/data/home/.claude/.credentials.json` on hosted pods, then `$HOME/.claude/.credentials.json`) → `Authorization: Bearer` + `anthropic-beta: oauth-2025-04-20` (currently optional, sent for forward-compat) + `anthropic-version: 2023-06-01`.
  2. `GET /v1/models?limit=1000`, parse `data[].id`, existing `cliModelQueryTimeout` applies.
- Live results flow through the existing `stabilize()` retention, then `claudeAlwaysIncludeModels` appends the bare `opus`/`sonnet`/`haiku` aliases (valid `--model` values the API never returns) — **after** stabilization/fallback, exactly like `copilotAlwaysIncludeModels`, so aliases survive both paths and model auto-heal.

## Expiry / no-refresh semantics

The subscription token is short-lived (<1 day) and refreshes **only** when the claude CLI itself runs — on copilot-only spokes the file sits expired for weeks. So the prober re-reads the file on every probe, checks `expiresAt` (with a named 2-minute clock-skew margin, `claudeTokenExpirySkew`) **before** any HTTP call, and **never** attempts a token refresh: rotating the token would break the CLI's own login (the hive inotify-watches `~/.claude/`). Expired/absent creds skip straight to fallback with zero network traffic.

## Fallback chain

env API key → fresh OAuth token from credentials file → static `claudeStaticModels` (`fallback: true`). Any failure (file absent, expired, malformed, 401, non-200, network, bad JSON) lands on the static list, and `modelIDsForBackend` keeps returning `nil` for fallback data, preserving the auto-heal exclusion semantics — the maintained static guess never drives validation or model auto-heal.

## Stale static list refreshed

`claudeStaticModels` was missing the opus-5/sonnet-5-era ids. Refreshed to the 11 live ids + 3 aliases, and the synced frontend constant `CLAUDE_CLI_MODELS` in `static/index.html` updated identically.

## Verification evidence

Investigated live on 2026-08-03: `GET /v1/models` with the Claude Code subscription OAuth bearer returned **HTTP 200** with 11 model ids: claude-opus-5, claude-sonnet-5, claude-fable-5, claude-opus-4-8, claude-opus-4-7, claude-sonnet-4-6, claude-opus-4-6, claude-opus-4-5-20251101, claude-haiku-4-5-20251001, claude-sonnet-4-5-20250929, claude-opus-4-1-20250805.

## Tests (no real API calls)

- Credentials parsing: valid / absent / malformed / expired / within-skew via temp HOME.
- `ANTHROPIC_API_KEY` precedence over a valid OAuth file; header shape assertions for both auth modes.
- httptest `/v1/models`: success → live list; 401 → fallback; malformed JSON → fallback; expired creds provably never reach the network.
- Aliases appended on BOTH live and fallback paths; fallback marked `fallback: true` and excluded from `modelIDsForBackend`.