### PR TITLE
✨ feat(dashboard): live codex model discovery via app-server model/list

### DIFF
--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -12,7 +12,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
     > /etc/apt/sources.list.d/nodesource.list \
   && apt-get update && apt-get install -y nodejs \
-  && npm install -g @anthropic-ai/claude-code @github/copilot @openai/codex \
+  # codex is pinned for reproducibility (matching the copilot pin convention
+  # in v2/Dockerfile): its model catalog is baked into the binary per version,
+  # and the dashboard's static fallback list tracks 0.146.0.
+  && npm install -g @anthropic-ai/claude-code @github/copilot @openai/codex@0.146.0 \
   && rm -rf /var/lib/apt/lists/*
 
 # Install bobshell (IBM "bob"). Mirrors Layer 9 of v2/Dockerfile so the

--- a/v2/pkg/dashboard/cli_models.go
+++ b/v2/pkg/dashboard/cli_models.go
@@ -43,6 +43,10 @@ import (
 //     pre-1.37 goose omits the models key from the session/new result (the
 //     clean fallback signal); that, a missing binary, or any error falls
 //     back to a curated per-provider static list.
+//   - codex:   `codex app-server` (stdio JSON-RPC) answers model/list with
+//     the catalog BAKED INTO the installed CLI binary — per-CLI-version, not
+//     per-account (the per-account remote_models fetch was removed upstream),
+//     and fully unauthenticated. See cli_models_codex.go.
 //
 // Every discovery is BEST-EFFORT: a failed or absent probe falls back to a
 // current static list so a dropdown is never empty and never errors. Results
@@ -284,19 +288,26 @@ var copilotAlwaysIncludeModels = []string{
 // either does nothing or breaks inference.
 var bobStaticModels = []string{bobAutoModel}
 
-// codexStaticModels is the maintained list for the OpenAI Codex CLI. Codex only
-// accepts OpenAI models — Claude ids are rejected with a ChatGPT account
-// ("model is not supported when using Codex with a ChatGPT account"), so codex
-// must never fall through to the copilot list. Order mirrors `codex /model`
-// (sol is the default). Keep CURRENT with the Codex CLI's model set.
+// codexStaticModels is the fallback for the OpenAI Codex CLI, served when the
+// `codex app-server` model/list probe cannot run (binary absent — the case on
+// hosted spokes) or fails (see cli_models_codex.go). Codex only accepts OpenAI
+// models — Claude ids are rejected with a ChatGPT account ("model is not
+// supported when using Codex with a ChatGPT account"), so codex must never
+// fall through to the copilot list. The catalog is baked into the CLI binary
+// (per-CLI-version, not per-account); this snapshot matches codex 0.146.0:
+// visible ids in picker order (sol is the default), then the hidden ids —
+// hidden entries are still valid --model values (see orderCodexServedModels).
+// Keep in sync with CODEX_CLI_MODELS in static/index.html.
 var codexStaticModels = []string{
 	"gpt-5.6-sol",
 	"gpt-5.6-terra",
 	"gpt-5.6-luna",
 	"gpt-5.5",
+	"gpt-5.2",
+	// Hidden in the 0.146.0 picker but still valid --model values.
 	"gpt-5.4",
 	"gpt-5.4-mini",
-	"gpt-5.3-codex-spark",
+	"codex-auto-review",
 }
 
 // geminiStaticModels is the fallback when no Gemini API key is configured (or
@@ -456,9 +467,7 @@ func (s *Server) queryCLIModels(backend string) cliModelResult {
 		// No live source exists; the maintained static list is authoritative.
 		r = cliModelResult{models: dedupeModels(claudeStaticModels), fallback: false}
 	case "codex":
-		// No probe wired yet; the maintained static list is authoritative and
-		// OpenAI-only (Claude ids are rejected by Codex with a ChatGPT account).
-		r = cliModelResult{models: dedupeModels(codexStaticModels), fallback: false}
+		r = s.discoverCodexModels()
 	case bobBackendID:
 		// bob picks its own model and exposes no catalog, so there is nothing
 		// to discover. The single auto sentinel is authoritative (not a

--- a/v2/pkg/dashboard/cli_models_codex.go
+++ b/v2/pkg/dashboard/cli_models_codex.go
@@ -1,0 +1,326 @@
+package dashboard
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// Live model discovery for the OpenAI Codex CLI.
+//
+// `codex app-server` speaks a newline-delimited JSON-RPC-style protocol over
+// stdio (the "v2 app-server protocol", documented in openai/codex
+// codex-rs/app-server/README.md) and exposes a `model/list` request. The
+// returned catalog is BAKED INTO the installed CLI binary — it is
+// per-CLI-VERSION, not per-account: the per-account `remote_models` fetch was
+// a feature flag that has been removed upstream, and the probe works with a
+// completely empty, unauthenticated CODEX_HOME (verified live against codex
+// 0.146.0; round-trip ~0.5s).
+//
+// CODEX_HOME rule: the app-server WRITES into CODEX_HOME (sqlite, lock files,
+// installation_id) and requires ownership of it, so the probe always runs
+// with CODEX_HOME overridden to a throwaway temp dir the dashboard owns —
+// NEVER an agent's own `.codex-<id>` home, whose locks/state must not be
+// touched by a probe.
+//
+// Failure semantics mirror the copilot SDK probe: any failure (binary
+// missing, spawn error, handshake timeout, parse error, empty data) yields an
+// empty result so queryCLIModels serves the static list with fallback=true.
+// On hosted spokes the main image does not install codex at all, so the probe
+// degrades instantly to the fallback there — expected and fine.
+
+const (
+	// codexBinaryName is the Codex CLI binary probed on PATH. When absent the
+	// probe is skipped instantly and the static fallback is served.
+	codexBinaryName = "codex"
+
+	// codexAppServerArg is the subcommand that starts the stdio JSON-RPC
+	// app-server the probe speaks to.
+	codexAppServerArg = "app-server"
+
+	// codexProbeTimeout bounds the whole spawn+handshake+model/list exchange.
+	// The measured live round-trip is ~0.5s; 10s leaves generous headroom for
+	// cold page cache without letting a wedged binary stall the caller.
+	codexProbeTimeout = 10 * time.Second
+
+	// codexRPCClientName / codexRPCClientVersion identify this probe in the
+	// mandatory initialize clientInfo. Values are informational to the server
+	// but required by the protocol.
+	codexRPCClientName    = "hive-dashboard"
+	codexRPCClientVersion = "1.0.0"
+
+	// codexProbeHomePrefix names the throwaway per-probe CODEX_HOME temp dir
+	// (see the CODEX_HOME rule above). Removed after every probe.
+	codexProbeHomePrefix = "hive-codex-probe-"
+
+	// codexRPCInitializeID / codexRPCModelListID are the JSON-RPC request ids
+	// for the two requests the probe sends. Arbitrary but fixed so responses
+	// can be matched among interleaved server notifications.
+	codexRPCInitializeID = 1
+	codexRPCModelListID  = 2
+
+	// codexRPCInitializedMethod is the notification the app-server emits once
+	// the initialize handshake is accepted.
+	codexRPCInitializedMethod = "initialized"
+
+	// codexRPCModelListMethod is the request returning the model catalog.
+	codexRPCModelListMethod = "model/list"
+
+	// codexRPCMaxLineBytes caps a single scanned protocol line. The model/list
+	// response is small (a few KB), but the default bufio.Scanner limit (64KB)
+	// is raised defensively so a verbose future response cannot break parsing.
+	codexRPCMaxLineBytes = 1 << 20
+
+	// codexRPCErrorLogLimit caps how much of a JSON-RPC error object is folded
+	// into a returned error (and thus a log line) — enough to diagnose, never
+	// a full response-body dump.
+	codexRPCErrorLogLimit = 300
+)
+
+// codexModelEntry mirrors one element of the model/list response data array.
+// The server also emits displayName/defaultReasoningEffort/
+// supportedReasoningEfforts; discovery only needs the id and the
+// hidden/default flags today.
+type codexModelEntry struct {
+	ID        string `json:"id"`
+	Model     string `json:"model"`
+	IsDefault bool   `json:"isDefault"`
+	Hidden    bool   `json:"hidden"`
+}
+
+// codexRPCMessage is the envelope of one newline-delimited protocol message.
+// The app-server protocol is JSON-RPC-shaped but omits the "jsonrpc":"2.0"
+// field, so none is sent or required here.
+type codexRPCMessage struct {
+	ID     *int64          `json:"id,omitempty"`
+	Method string          `json:"method,omitempty"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  json.RawMessage `json:"error,omitempty"`
+}
+
+// runCodexModelProbe executes the app-server probe and returns the served id
+// order. A package-level seam (mirroring runCopilotSDKHelper) so unit tests
+// can substitute canned results without a real codex binary.
+var runCodexModelProbe = execCodexModelProbe
+
+// discoverCodexModels lists the model catalog of the installed Codex CLI via
+// `codex app-server` model/list. Best-effort: any probe failure returns
+// fallback=true with an empty list so the caller substitutes the static list,
+// exactly like the copilot probe's failure semantics.
+func (s *Server) discoverCodexModels() cliModelResult {
+	models, err := runCodexModelProbe()
+	if err != nil {
+		// Expected on hosted spokes (main image ships no codex binary); the
+		// static fallback keeps the dropdown populated. Never logs bodies.
+		s.logger.Info("codex model discovery unavailable, serving static fallback", "err", err.Error())
+		return cliModelResult{fallback: true}
+	}
+	if len(models) == 0 {
+		return cliModelResult{fallback: true}
+	}
+	return cliModelResult{models: dedupeModels(models), fallback: false}
+}
+
+// execCodexModelProbe is the real prober: spawn `codex app-server` with a
+// throwaway CODEX_HOME, run the initialize handshake and model/list exchange
+// over stdio, then kill and reap the server.
+func execCodexModelProbe() ([]string, error) {
+	if _, err := exec.LookPath(codexBinaryName); err != nil {
+		return nil, fmt.Errorf("codex binary not on PATH: %w", err)
+	}
+
+	// Throwaway dashboard-owned CODEX_HOME (see the CODEX_HOME rule in the
+	// file header); removed after the probe.
+	home, err := os.MkdirTemp("", codexProbeHomePrefix)
+	if err != nil {
+		return nil, fmt.Errorf("create probe CODEX_HOME: %w", err)
+	}
+	defer os.RemoveAll(home)
+
+	ctx, cancel := context.WithTimeout(context.Background(), codexProbeTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, codexBinaryName, codexAppServerArg)
+	// os/exec documents that for duplicate keys the LAST value wins, so
+	// appending overrides any inherited CODEX_HOME.
+	cmd.Env = append(os.Environ(), "CODEX_HOME="+home)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("app-server stdin: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("app-server stdout: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("spawn app-server: %w", err)
+	}
+	// The server runs until killed; always reap it so no zombie is left. On
+	// timeout the CommandContext kill closes the pipes, which surfaces in the
+	// exchange as a read error.
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	entries, err := codexModelListExchange(stdin, stdout)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("app-server probe timed out: %w", ctx.Err())
+		}
+		return nil, err
+	}
+	return orderCodexServedModels(entries), nil
+}
+
+// codexModelListExchange drives the newline-delimited protocol over the given
+// transport: initialize (with mandatory clientInfo), wait for the handshake
+// acknowledgement, then model/list with includeHidden:true. Factored over
+// io.Writer/io.Reader so tests can feed canned stdout without a real binary.
+func codexModelListExchange(in io.Writer, out io.Reader) ([]codexModelEntry, error) {
+	sc := bufio.NewScanner(out)
+	sc.Buffer(make([]byte, 0, 4096), codexRPCMaxLineBytes)
+
+	if err := writeCodexRPC(in, map[string]any{
+		"id":     codexRPCInitializeID,
+		"method": "initialize",
+		"params": map[string]any{
+			"clientInfo": map[string]any{
+				"name":    codexRPCClientName,
+				"version": codexRPCClientVersion,
+			},
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("send initialize: %w", err)
+	}
+
+	// The handshake is complete once the server answers the initialize
+	// request or emits the `initialized` notification — accept whichever
+	// arrives first (any duplicate is skipped by the model/list loop below).
+	for {
+		msg, err := readCodexRPC(sc)
+		if err != nil {
+			return nil, fmt.Errorf("initialize handshake: %w", err)
+		}
+		if msg.ID != nil && *msg.ID == codexRPCInitializeID {
+			if len(msg.Error) != 0 {
+				return nil, fmt.Errorf("initialize rejected: %s", truncateForLog(msg.Error, codexRPCErrorLogLimit))
+			}
+			break
+		}
+		if msg.Method == codexRPCInitializedMethod {
+			break
+		}
+	}
+
+	// includeHidden:true — hidden ids are deliberately requested and served
+	// (see orderCodexServedModels for why).
+	if err := writeCodexRPC(in, map[string]any{
+		"id":     codexRPCModelListID,
+		"method": codexRPCModelListMethod,
+		"params": map[string]any{"includeHidden": true},
+	}); err != nil {
+		return nil, fmt.Errorf("send model/list: %w", err)
+	}
+
+	for {
+		msg, err := readCodexRPC(sc)
+		if err != nil {
+			return nil, fmt.Errorf("model/list: %w", err)
+		}
+		if msg.ID == nil || *msg.ID != codexRPCModelListID {
+			continue // server notification or stray message — skip
+		}
+		if len(msg.Error) != 0 {
+			return nil, fmt.Errorf("model/list rejected: %s", truncateForLog(msg.Error, codexRPCErrorLogLimit))
+		}
+		var result struct {
+			Data []codexModelEntry `json:"data"`
+		}
+		if err := json.Unmarshal(msg.Result, &result); err != nil {
+			return nil, fmt.Errorf("parse model/list result: %w", err)
+		}
+		if len(result.Data) == 0 {
+			return nil, errors.New("model/list returned no models")
+		}
+		return result.Data, nil
+	}
+}
+
+// orderCodexServedModels builds the served id order from a model/list result:
+// visible models first in the server's returned (picker) order with the
+// isDefault entry promoted to the front, then hidden ids appended at the end.
+//
+// Hidden ids are included on purpose: they are still valid `--model` values
+// (e.g. gpt-5.4 at codex 0.146.0), and excluding them would let the
+// stabilize/auto-heal machinery migrate agents off a working pinned model the
+// moment a CLI upgrade hides it from the picker.
+func orderCodexServedModels(entries []codexModelEntry) []string {
+	var def, visible, hidden []string
+	for _, e := range entries {
+		id := e.ID
+		if id == "" {
+			// The catalog id and underlying model slug are usually identical;
+			// tolerate an entry that only carries the latter.
+			id = e.Model
+		}
+		if id == "" {
+			continue
+		}
+		switch {
+		case e.Hidden:
+			hidden = append(hidden, id)
+		case e.IsDefault:
+			def = append(def, id)
+		default:
+			visible = append(visible, id)
+		}
+	}
+	return append(append(def, visible...), hidden...)
+}
+
+// writeCodexRPC marshals one protocol message and writes it newline-delimited.
+func writeCodexRPC(in io.Writer, msg map[string]any) error {
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	_, err = in.Write(append(b, '\n'))
+	return err
+}
+
+// readCodexRPC scans the next non-empty protocol line and decodes its
+// envelope. A non-JSON line is a protocol violation, not something to skip.
+func readCodexRPC(sc *bufio.Scanner) (codexRPCMessage, error) {
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var msg codexRPCMessage
+		if err := json.Unmarshal(line, &msg); err != nil {
+			return codexRPCMessage{}, fmt.Errorf("malformed protocol line: %w", err)
+		}
+		return msg, nil
+	}
+	if err := sc.Err(); err != nil {
+		return codexRPCMessage{}, err
+	}
+	return codexRPCMessage{}, io.ErrUnexpectedEOF
+}
+
+// truncateForLog bounds raw upstream bytes destined for an error/log line.
+func truncateForLog(b []byte, limit int) string {
+	s := string(b)
+	if len(s) > limit {
+		return s[:limit]
+	}
+	return s
+}

--- a/v2/pkg/dashboard/cli_models_codex_test.go
+++ b/v2/pkg/dashboard/cli_models_codex_test.go
@@ -1,0 +1,176 @@
+package dashboard
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// swapCodexProbe substitutes the codex probe seam for one test and restores it.
+func swapCodexProbe(t *testing.T, fn func() ([]string, error)) {
+	t.Helper()
+	prev := runCodexModelProbe
+	runCodexModelProbe = fn
+	t.Cleanup(func() { runCodexModelProbe = prev })
+}
+
+// codexCannedStdout builds a canned app-server stdout: initialize response,
+// initialized notification, then the model/list response with the given data.
+func codexCannedStdout(data string) *bytes.Buffer {
+	return bytes.NewBufferString(
+		`{"id":1,"result":{}}` + "\n" +
+			`{"method":"initialized"}` + "\n" +
+			`{"id":2,"result":{"data":[` + data + `]}}` + "\n")
+}
+
+// TestCodexModelListExchange_HiddenOrdering verifies the served order: visible
+// models in returned (picker) order with the isDefault entry promoted first,
+// then hidden ids appended at the end — hidden ids are still valid --model
+// values and must survive so auto-heal cannot migrate agents off them.
+func TestCodexModelListExchange_HiddenOrdering(t *testing.T) {
+	stdout := codexCannedStdout(strings.Join([]string{
+		`{"id":"gpt-5.6-terra","model":"gpt-5.6-terra","displayName":"GPT-5.6 Terra"}`,
+		`{"id":"gpt-5.4","model":"gpt-5.4","hidden":true}`,
+		`{"id":"gpt-5.6-sol","model":"gpt-5.6-sol","isDefault":true}`,
+		`{"id":"gpt-5.5","model":"gpt-5.5"}`,
+		`{"id":"gpt-5.4-mini","model":"gpt-5.4-mini","hidden":true}`,
+	}, ","))
+	var stdin bytes.Buffer
+	entries, err := codexModelListExchange(&stdin, stdout)
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	got := orderCodexServedModels(entries)
+	want := []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini"}
+	if !equalStrings(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	// The exchange must have requested hidden models explicitly.
+	if !strings.Contains(stdin.String(), `"includeHidden":true`) {
+		t.Fatalf("model/list request missing includeHidden:true: %s", stdin.String())
+	}
+	if !strings.Contains(stdin.String(), `"clientInfo"`) {
+		t.Fatalf("initialize request missing clientInfo: %s", stdin.String())
+	}
+}
+
+// TestCodexModelListExchange_Malformed verifies a non-JSON protocol line is a
+// hard error (→ fallback), never silently skipped.
+func TestCodexModelListExchange_Malformed(t *testing.T) {
+	var stdin bytes.Buffer
+	if _, err := codexModelListExchange(&stdin, bytes.NewBufferString("garbage\n")); err == nil {
+		t.Fatal("expected error on malformed protocol line")
+	}
+}
+
+// TestCodexModelListExchange_TruncatedStream verifies a stream that ends
+// before the model/list response (the shape a killed-on-timeout process
+// produces: pipes close, reads hit EOF) surfaces as an error.
+func TestCodexModelListExchange_TruncatedStream(t *testing.T) {
+	var stdin bytes.Buffer
+	stdout := bytes.NewBufferString(`{"id":1,"result":{}}` + "\n")
+	if _, err := codexModelListExchange(&stdin, stdout); err == nil {
+		t.Fatal("expected error on stream truncated before model/list response")
+	}
+}
+
+// TestCodexModelListExchange_RPCError verifies an error response to
+// model/list is an error, not an empty success.
+func TestCodexModelListExchange_RPCError(t *testing.T) {
+	var stdin bytes.Buffer
+	stdout := bytes.NewBufferString(
+		`{"id":1,"result":{}}` + "\n" +
+			`{"id":2,"error":{"code":-32601,"message":"nope"}}` + "\n")
+	if _, err := codexModelListExchange(&stdin, stdout); err == nil {
+		t.Fatal("expected error on model/list error response")
+	}
+}
+
+// TestCodexModelListExchange_EmptyData verifies zero models is treated as a
+// failed probe rather than served as a live empty list.
+func TestCodexModelListExchange_EmptyData(t *testing.T) {
+	var stdin bytes.Buffer
+	if _, err := codexModelListExchange(&stdin, codexCannedStdout("")); err == nil {
+		t.Fatal("expected error on empty model/list data")
+	}
+}
+
+// TestQueryCLIModels_CodexProbeSuccess verifies a successful probe is served
+// live (fallback=false) through the full pipeline, including stabilize.
+func TestQueryCLIModels_CodexProbeSuccess(t *testing.T) {
+	swapCodexProbe(t, func() ([]string, error) {
+		return []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.4"}, nil
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.queryCLIModels("codex")
+	if r.fallback {
+		t.Fatalf("live probe result must not be fallback: %+v", r)
+	}
+	if !equalStrings(r.models, []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.4"}) {
+		t.Fatalf("got %v, want probe order preserved", r.models)
+	}
+}
+
+// TestQueryCLIModels_CodexBinaryMissingFallsBack verifies the no-binary case
+// (hosted spokes: the main image ships no codex) serves the static list
+// marked fallback=true.
+func TestQueryCLIModels_CodexBinaryMissingFallsBack(t *testing.T) {
+	swapCodexProbe(t, func() ([]string, error) {
+		return nil, errors.New("codex binary not on PATH")
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.queryCLIModels("codex")
+	if !r.fallback {
+		t.Fatalf("missing binary must serve fallback, got %+v", r)
+	}
+	if !equalStrings(r.models, dedupeModels(codexStaticModels)) {
+		t.Fatalf("fallback must be the static list, got %v", r.models)
+	}
+}
+
+// TestQueryCLIModels_CodexTimeoutFallsBack verifies a handshake timeout is a
+// plain probe failure → static fallback.
+func TestQueryCLIModels_CodexTimeoutFallsBack(t *testing.T) {
+	swapCodexProbe(t, func() ([]string, error) {
+		return nil, context.DeadlineExceeded
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	if r := s.queryCLIModels("codex"); !r.fallback || len(r.models) == 0 {
+		t.Fatalf("timeout must serve non-empty static fallback, got %+v", r)
+	}
+}
+
+// TestQueryCLIModels_CodexResultsFeedRetention verifies live codex results
+// ride the same stabilize/retention machinery as the other backends: a model
+// seen in one live sample survives its absence from the next.
+func TestQueryCLIModels_CodexResultsFeedRetention(t *testing.T) {
+	sample := []string{"gpt-5.6-sol", "gpt-5.4"}
+	swapCodexProbe(t, func() ([]string, error) {
+		return append([]string(nil), sample...), nil
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	if r := s.queryCLIModels("codex"); !contains(r.models, "gpt-5.4") {
+		t.Fatalf("first live sample missing id: %v", r.models)
+	}
+	sample = []string{"gpt-5.6-sol"}
+	s.cliModels.entries = map[string]cliModelCacheEntry{}
+	r := s.queryCLIModels("codex")
+	if r.fallback {
+		t.Fatalf("live result must not be fallback: %+v", r)
+	}
+	if !contains(r.models, "gpt-5.4") {
+		t.Fatalf("retention should keep recently-seen id through one miss: %v", r.models)
+	}
+}
+
+// TestExecCodexModelProbe_BinaryMissing verifies the real prober degrades
+// instantly (no hang, no panic) when codex is not on PATH — the hosted-spoke
+// situation.
+func TestExecCodexModelProbe_BinaryMissing(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	if _, err := execCodexModelProbe(); err == nil {
+		t.Fatal("expected error when codex binary is absent from PATH")
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6372,15 +6372,21 @@
     // Codex (OpenAI CLI) exposes its own OpenAI-only models. Claude models are
     // rejected by Codex with a ChatGPT account ("model is not supported when
     // using Codex with a ChatGPT account"), so codex must NOT fall through to
-    // the copilot list. Order mirrors `codex /model` (sol is the default).
+    // the copilot list. The server discovers the live catalog via
+    // `codex app-server` model/list (per-CLI-version, baked into the binary);
+    // this is only the pre-discovery fallback. Snapshot of codex 0.146.0:
+    // visible ids in picker order (sol is the default), then hidden ids —
+    // hidden entries are still valid --model values. Keep in sync with
+    // codexStaticModels in cli_models.go.
     const CODEX_CLI_MODELS = [
       { value: 'gpt-5.6-sol', label: 'GPT-5.6 Sol' },
       { value: 'gpt-5.6-terra', label: 'GPT-5.6 Terra' },
       { value: 'gpt-5.6-luna', label: 'GPT-5.6 Luna' },
       { value: 'gpt-5.5', label: 'GPT-5.5' },
+      { value: 'gpt-5.2', label: 'GPT-5.2' },
       { value: 'gpt-5.4', label: 'GPT-5.4' },
       { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
-      { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' },
+      { value: 'codex-auto-review', label: 'Codex Auto Review' },
     ];
     // bob (IBM bobshell) selects its own model and has NO usable --model flag:
     // launching `bob --model <concrete-id>` makes every prompt die with


### PR DESCRIPTION
## What

Wires LIVE model discovery for the `codex` CLI backend, replacing the static-only list.

## Mechanism

`codex app-server` speaks a newline-delimited JSON-RPC-style protocol over stdio (the v2 app-server protocol, documented in openai/codex `codex-rs/app-server/README.md`). The probe:

1. spawns `codex app-server` via `exec.CommandContext` under a named-constant 10s timeout (measured live round-trip: ~0.5s),
2. sends `initialize` with the mandatory `clientInfo`, waits for the handshake acknowledgement,
3. requests `model/list` with `includeHidden: true`,
4. kills and reaps the server.

Results flow through the existing cache + `stabilize()` retention machinery, mirroring the copilot branch structure in `queryCLIModels`.

## Per-CLI-version semantics (NOT per-account)

The returned catalog is **baked into the CLI binary** — it changes with the installed codex version, not with the account: the per-account `remote_models` fetch was a feature flag that has been **removed upstream**, and the probe works with a completely empty, unauthenticated CODEX_HOME (verified live against codex 0.146.0).

## Throwaway CODEX_HOME

The app-server WRITES into CODEX_HOME (sqlite, lock files, installation_id) and requires ownership, so the probe always overrides CODEX_HOME to a per-probe temp dir the dashboard owns (removed afterwards) — never an agent's `.codex-<id>` home.

## Hidden-model ordering rationale

Served list = visible models in picker order (`isDefault` first), then hidden ids appended at the end. Hidden ids (gpt-5.4, gpt-5.4-mini, codex-auto-review at 0.146.0) are still valid `--model` values; excluding them would let the stabilize/auto-heal machinery migrate agents off a working pinned model like gpt-5.4.

## Static-list drift fixes (backend + `CODEX_CLI_MODELS` in index.html)

The maintained list had drifted vs codex 0.146.0:
- **dropped** `gpt-5.3-codex-spark` — absent from the binary entirely
- **added** `gpt-5.2` — visible in the live picker
- gpt-5.4 / gpt-5.4-mini moved to the hidden tail; `codex-auto-review` (hidden) added

## Graceful no-binary fallback

The main v2 image does not install codex, so on hosted spokes the probe degrades instantly (`exec.LookPath` miss) to the static list marked `fallback: true` — expected and fine. Any other failure (spawn, handshake timeout, parse, empty data) behaves identically, matching the copilot probe's failure semantics.

## Also

- Pins `@openai/codex@0.146.0` in `Dockerfile.contributor` (pinned-for-reproducibility convention, matching the copilot layer).
- Tests fake the prober transport (canned stdout over the factored JSON-RPC exchange) — success/hidden ordering, binary missing, timeout, malformed JSON, truncated stream, RPC error, empty data, retention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)