### PR TITLE
✨ feat(image): ship pinned Codex CLI in the main spoke image

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -99,6 +99,19 @@ ARG COPILOT_SDK_VERSION=1.0.8
 RUN npm install -g @github/copilot-sdk@${COPILOT_SDK_VERSION} && npm cache clean --force || \
     echo "WARN: GitHub Copilot SDK install failed — skipping"
 
+# --- Layer 4: OpenAI Codex CLI (pinned; backend: codex + live model discovery) ---
+# Pinned for reproducibility; version matches v2/Dockerfile.contributor —
+# keep the two pins in sync. @openai/codex resolves a platform-specific
+# native binary (@openai/codex-<platform>) via optionalDependencies, so a
+# plain npm install serves both linux/amd64 and linux/arm64.
+# Tolerant of failure like the copilot layer: if codex is absent, the
+# dashboard's codex model discovery (`codex app-server` model/list — pure
+# local stdio, no network, unaffected by the proxy CA) falls back to the
+# static list, and non-codex backends are unaffected.
+ARG CODEX_VERSION=0.146.0
+RUN npm install -g @openai/codex@${CODEX_VERSION} && npm cache clean --force || \
+    echo "WARN: OpenAI Codex CLI install failed — skipping"
+
 # --- Layer 7: Claude Code (most frequent updates) ---
 ARG CLAUDE_CODE_VERSION=latest
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} && npm cache clean --force


### PR DESCRIPTION
## Why

PR #2528 landed the codex model-discovery probe (`cli_models_codex.go`), but the main spoke image (`v2/Dockerfile`) does not install the Codex CLI — so hosted spokes always take the static-fallback path. This installs `@openai/codex@0.146.0` (same pin as `v2/Dockerfile.contributor`) into the main image, which:

- activates live codex model discovery on hosted spokes (probe runs `codex app-server` model/list instead of falling back to the static list), and
- makes codex usable as an agent backend on hosted hives (previously contributor-image only).

## Details

- **Pin sync**: 0.146.0 matches `Dockerfile.contributor`'s inline pin (its comment notes the static fallback list tracks 0.146.0). The new layer's comment says to keep the two pins in sync.
- **Failure-tolerant layer** (`|| echo "WARN: ..."`), matching the copilot layer convention: codex absence degrades gracefully — discovery falls back, non-codex backends are unaffected.
- **Multi-arch**: `@openai/codex` resolves its native platform binary via optionalDependencies; plain `npm install` (no `--force`, no platform pinning) works for both linux/amd64 and linux/arm64.
- **Image size**: adds the codex native binary to the image — accepted tradeoff for enabling the backend + live discovery.

## Scope boundary

No proxy/MITM changes, no copilot-pin changes, no agent-launch.sh changes. The discovery probe is pure local stdio (no network, no auth), so the MITM proxy CA is irrelevant to it; runtime codex agent traffic is pre-existing behavior on contributor-image hives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)