### PR TITLE
fix(dashboard): remove redundant boxed Upgrading pill in header

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -12984,7 +12984,6 @@ function burnAreaChart() {
         if (v.dirty) html += ' <span class="git-dirty">*</span>';
         if (_upgradeInProgress && v.hash !== _upgradeTargetHash) {
           html += ` <span class="git-behind" title="Upgrading to ${escapeHtml(v.latestShort || '?')}">⬆ upgrading</span>`;
-          html += ` <span style="display:inline-block;padding:3px 10px;background:var(--surface);border:1px solid var(--border);border-radius:4px;font-size:0.7rem;margin-left:6px;white-space:nowrap;opacity:0.8"><span style="display:inline-block;width:12px;height:12px;border:2px solid rgba(255,255,255,0.3);border-top-color:#fff;border-radius:50%;animation:spin 1s linear infinite;vertical-align:middle;margin-right:4px"></span>Upgrading</span>`;
         } else if (_upgradeInProgress && v.hash === _upgradeTargetHash) {
           _upgradeInProgress = false;
           _upgradeTargetHash = null;


### PR DESCRIPTION
## Problem

The hive dashboard header renders two indicators for the same single upgrade state, side by side:

1. `⬆ upgrading` — an up-arrow glyph followed by the word "upgrading" (colored text, next to the version pill and commit sha)
2. A separate boxed pill — spinner + the bare word **"Upgrading"** — immediately to the right of (1)

Both are produced in the same block, driven by the same `_upgradeInProgress` flag, in `fetchGitVersion()`. Verified live that the underlying hive has a single pod, single rollout, and single registry `startedAt` — it is not upgrading twice. This is purely a duplicated display, not a real double-upgrade condition.

## Fix

Removed only the rightmost boxed "Upgrading" pill (the spinner + bare-word span). Kept the `⬆ upgrading` arrow+text indicator, the version pill, the commit sha, and all upgrade state/detection logic untouched. Display-only change.

The pill markup was inline in the header's `fetchGitVersion()` function only — not a shared component, so no other UI (e.g. fleet table) is affected.

### File changed

`v2/pkg/dashboard/static/index.html`

```diff
         if (_upgradeInProgress && v.hash !== _upgradeTargetHash) {
           html += ` <span class="git-behind" title="Upgrading to ${escapeHtml(v.latestShort || '?')}">⬆ upgrading</span>`;
-          html += ` <span style="display:inline-block;padding:3px 10px;background:var(--surface);border:1px solid var(--border);border-radius:4px;font-size:0.7rem;margin-left:6px;white-space:nowrap;opacity:0.8"><span style="display:inline-block;width:12px;height:12px;border:2px solid rgba(255,255,255,0.3);border-top-color:#fff;border-radius:50%;animation:spin 1s linear infinite;vertical-align:middle;margin-right:4px"></span>Upgrading</span>`;
         } else if (_upgradeInProgress && v.hash === _upgradeTargetHash) {
```

## Testing

- `go build ./...` passes in `v2/`
- Extracted and syntax-checked the embedded `<script>` block with `node --check` — no errors
- No Go test asserts the boxed pill's presence in the header (searched for `Upgrading`/`git-version`/`fetchGitVersion` across test files); no test changes needed