### PR TITLE
🔀 Sync dd with latest v2 (2026-08-04 am)

### DIFF
--- a/bin/copilot-models.mjs
+++ b/bin/copilot-models.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// copilot-models.mjs — list the Copilot models available to this machine's
+// Copilot auth, via the official @github/copilot-sdk.
+//
+// The SDK spawns the installed copilot CLI as a JSON-RPC server over stdio and
+// asks it for its model catalog, so the probe rides the CLI's OWN auth
+// resolution (stored device-flow OAuth under $HOME/.copilot, or the
+// COPILOT_GITHUB_TOKEN env var) and the CLI's own TLS handling
+// (NODE_EXTRA_CA_CERTS — required behind the egress proxy). That makes it work
+// in auth configurations the dashboard's raw-HTTP /models probe cannot reach.
+//
+// Contract with the Go caller (v2/pkg/dashboard/cli_models.go):
+//   - success: exactly ONE line of JSON on stdout —
+//       {"models":[{"id":...,"name":...,"policyState":...,"efforts":[...],"defaultEffort":...}]}
+//     and exit code 0.
+//   - failure: NOTHING on stdout, a short error on stderr, nonzero exit.
+//   - never hangs: a hard internal deadline force-exits the process, and the
+//     spawned copilot server is stopped in a finally + reaped by process exit.
+//   - never prints tokens or environment values.
+
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+// ---- Constants ----
+
+// Hard internal deadline for the whole probe (start + listModels + stop).
+// The Go caller's exec timeout (copilotSDKProbeTimeout in cli_models.go) sits
+// slightly ABOVE this so the helper always gets to report its own error
+// instead of being killed mid-flight.
+const INTERNAL_TIMEOUT_MS = 15_000;
+
+// Process exit codes: 0 = model list on stdout, 1 = any failure (no stdout).
+const EXIT_OK = 0;
+const EXIT_FAIL = 1;
+
+// Node entry of the PINNED copilot CLI installed globally by the image
+// (v2/Dockerfile Layer 3). The image deletes the CLI's native binary so the
+// CLI runs its Node.js path (which honors NODE_EXTRA_CA_CERTS); pointing the
+// SDK's runtime connection at THIS entry guarantees the probe runs the fleet's
+// pinned CLI — never the newer @github/copilot the SDK bundles as its own
+// nested dependency, whose native binary does not trust the proxy CA.
+// The SDK spawns `node <entry> --server ...` when the path ends in ".js".
+const PINNED_CLI_ENTRY = "/usr/local/lib/node_modules/@github/copilot/index.js";
+
+// npm global roots to search for @github/copilot-sdk. ESM bare-specifier
+// resolution NEVER consults the global node_modules, so a plain
+// `import "@github/copilot-sdk"` fails for a globally-installed SDK; instead
+// the SDK is loaded with createRequire() anchored inside the global root —
+// the package ships a CJS build under its "require" export condition
+// (dist/cjs/index.js), so require() works regardless of where this script
+// lives. The execPath-derived candidate covers non-default npm prefixes.
+const GLOBAL_NODE_MODULES_CANDIDATES = [
+  "/usr/local/lib/node_modules",
+  path.join(path.dirname(process.execPath), "..", "lib", "node_modules"),
+];
+
+// Anchor filename for createRequire inside a node_modules root. The file need
+// not exist — createRequire only uses it to derive resolution paths.
+const REQUIRE_ANCHOR_BASENAME = "hive-require-anchor.js";
+
+const SDK_PACKAGE_NAME = "@github/copilot-sdk";
+
+// ---- Failure-mode plumbing ----
+
+function fail(message) {
+  process.stderr.write(`copilot-models: ${message}\n`);
+  process.exit(EXIT_FAIL);
+}
+
+// Watchdog: force-exit on deadline no matter what the SDK is doing. Not
+// unref()ed on purpose — a successful run exits explicitly before it fires.
+setTimeout(() => {
+  fail(`timed out after ${INTERNAL_TIMEOUT_MS}ms`);
+}, INTERNAL_TIMEOUT_MS);
+
+// ---- SDK loading ----
+
+function loadSdk() {
+  // Local resolution first (works when a node_modules ancestor has the SDK,
+  // e.g. dev checkouts), then the global roots.
+  const localRequire = createRequire(import.meta.url);
+  const anchors = [null, ...GLOBAL_NODE_MODULES_CANDIDATES];
+  const errors = [];
+  for (const root of anchors) {
+    try {
+      const req = root === null
+        ? localRequire
+        : createRequire(path.join(root, REQUIRE_ANCHOR_BASENAME));
+      return req(SDK_PACKAGE_NAME);
+    } catch (err) {
+      errors.push(err?.code || err?.message || String(err));
+    }
+  }
+  throw new Error(`cannot load ${SDK_PACKAGE_NAME} (${errors.join("; ")})`);
+}
+
+// ---- Main ----
+
+async function main() {
+  const { CopilotClient, RuntimeConnection } = loadSdk();
+
+  // Honor an explicit COPILOT_CLI_PATH override, else pin to the image's CLI
+  // entry when present, else let the SDK resolve (dev machines).
+  const cliPath =
+    process.env.COPILOT_CLI_PATH ||
+    (existsSync(PINNED_CLI_ENTRY) ? PINNED_CLI_ENTRY : undefined);
+  const options = {};
+  if (cliPath) {
+    options.connection = RuntimeConnection.forStdio({ path: cliPath });
+  }
+  // When a token is present, hand it to the SDK explicitly (the documented
+  // path for token auth, kubestellar/hive#2519); when absent, the CLI
+  // resolves its stored logged-in auth ($HOME/.copilot) on its own.
+  if (process.env.COPILOT_GITHUB_TOKEN) {
+    options.gitHubToken = process.env.COPILOT_GITHUB_TOKEN;
+  }
+
+  const client = new CopilotClient(options);
+  try {
+    await client.start();
+    const models = await client.listModels();
+    const out = {
+      models: (models || []).map((m) => ({
+        id: m.id,
+        name: m.name,
+        policyState: m.policy?.state,
+        efforts: m.supportedReasoningEfforts,
+        defaultEffort: m.defaultReasoningEffort,
+      })),
+    };
+    process.stdout.write(JSON.stringify(out) + "\n");
+  } finally {
+    // Best-effort server shutdown; the explicit process.exit below reaps
+    // anything a failed stop leaves behind so no copilot server lingers.
+    try {
+      await client.stop();
+    } catch {
+      // ignored — see comment above
+    }
+  }
+}
+
+main().then(
+  () => process.exit(EXIT_OK),
+  (err) => fail(err?.message || String(err)),
+);

--- a/bin/git-credential-hive.sh
+++ b/bin/git-credential-hive.sh
@@ -1,9 +1,41 @@
 #!/bin/bash
 # git-credential-hive.sh — Git credential helper that uses the GitHub App token.
 # Reads from the cached token file, refreshing if stale (>55 min old).
-# Install: git config --global credential.https://github.com.helper /usr/local/bin/git-credential-hive.sh
+#
+# Install (github.com): git config --global credential.https://github.com.helper /usr/local/bin/git-credential-hive.sh
+# Install (GHE):         git config --global credential.https://<ghe-host>.helper /usr/local/bin/git-credential-hive.sh
+#
+# GHE-aware host matching: git invokes credential helpers once per remote host
+# and feeds `protocol=...` / `host=...` (and optionally `path=...`) on stdin
+# for the `get` operation (see git-credential(1)). A helper that ignores this
+# and always answers "host=github.com" — as this script did before — silently
+# returns NO credential for any other host git actually asked about, and git
+# then falls through to an interactive prompt, which fails hard in a
+# non-interactive agent shell with "terminal prompts disabled". This version
+# echoes back whatever host git asked for (once it has confirmed a token
+# exists for it) instead of a hardcoded "github.com", so the same script and
+# the same underlying App-installation token work for github.com AND any
+# configured GitHub Enterprise host (e.g. github.ibm.com) — entrypoint.sh
+# wires the credential.helper entry for the hive's actual configured host
+# (github.HostLabel() in the Go config), so this script only ever gets
+# invoked for a host it is actually supposed to answer for.
 
 set -euo pipefail
+
+# ── Read git's credential request off stdin (protocol=... / host=... lines,
+# terminated by a blank line) so we can echo the SAME host back. Git passes
+# this on `get`; other ops (store/erase) are no-ops below and don't need it,
+# but reading it unconditionally is harmless and keeps the parsing in one
+# place. See git-credential(1) "Credential Helpers" for the wire format.
+REQUEST_PROTOCOL=""
+REQUESTED_HOST=""
+while IFS='=' read -r _cred_key _cred_val; do
+  [ -z "$_cred_key" ] && break
+  case "$_cred_key" in
+    protocol) REQUEST_PROTOCOL="$_cred_val" ;;
+    host) REQUESTED_HOST="$_cred_val" ;;
+  esac
+done
 
 # ── UID-based identity verification (defense-in-depth) ──
 # When running under a per-agent UID (>= 2001), derive the agent name from
@@ -101,11 +133,24 @@ TOKEN_ACCESS_LOG="/var/run/hive-metrics/token-access.jsonl"
 
 case "${1:-}" in
   get)
-    printf '{"ts":"%s","agent":"%s","uid":%d,"op":"git-credential"}\n' \
-      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${AGENT:-unknown}" "$(id -u)" \
+    # Only ever answer for https — this script has no business supplying a
+    # credential for git+ssh or any other protocol, on any host.
+    if [ -n "$REQUEST_PROTOCOL" ] && [ "$REQUEST_PROTOCOL" != "https" ]; then
+      exit 0
+    fi
+    printf '{"ts":"%s","agent":"%s","uid":%d,"op":"git-credential","host":"%s"}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${AGENT:-unknown}" "$(id -u)" "${REQUESTED_HOST:-unknown}" \
       >> "$TOKEN_ACCESS_LOG" 2>/dev/null || true
+    # Echo back the SAME host git asked about (github.com, github.ibm.com, or
+    # any other configured GitHub Enterprise host) rather than a hardcoded
+    # "github.com" — see the file header. entrypoint.sh only registers this
+    # helper for `credential.https://<configured-host>.helper`, so by the time
+    # git invokes it for `get`, REQUESTED_HOST is already the one host this
+    # hive is authorized to answer for. Falling back to "github.com" when git
+    # sends no host at all (older git, or a manual invocation) preserves the
+    # previous behavior for the public-GitHub case.
     echo "protocol=https"
-    echo "host=github.com"
+    echo "host=${REQUESTED_HOST:-github.com}"
     echo "username=x-access-token"
     echo "password=$TOKEN"
     ;;

--- a/bin/hive-config.sh
+++ b/bin/hive-config.sh
@@ -17,7 +17,43 @@
 #   GH_APP_ID, GH_APP_INSTALLATION_ID, GH_APP_KEY_FILE,
 #   HIVE_GITHUB_TOKEN (auto-generated if GitHub App is configured), GH_TOKEN
 
-HIVE_REPO_DIR="${HIVE_REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd || echo /tmp/hive)}"
+# HIVE_REPO_DIR is meant to name the hive git checkout this script lives
+# under (e.g. /tmp/hive when this file is at /tmp/hive/bin/hive-config.sh,
+# used by hive-deploy.sh to `cd` in and `git pull`). In production this file
+# is COPIED (not checked out) to /usr/local/bin/hive-config.sh (see
+# v2/Dockerfile), so "one directory up from where this script lives" is
+# /usr/local — never a real hive checkout — and the naive derivation below
+# was WRONG for every deployed container even before considering the failure
+# mode below.
+#
+# It gets actively dangerous, not just wrong, when ${BASH_SOURCE[0]} is empty
+# — which happens when this file is sourced from a context where the
+# BASH_SOURCE array isn't populated as expected (e.g. `sh` rather than
+# `bash`, or certain non-interactive sourcing paths). `dirname ""` returns
+# ".", so `cd "./.." ` resolves relative to whatever the CALLER's cwd
+# happened to be at sourcing time. entrypoint.sh sources this file (as root,
+# before any `cd`) while the process's cwd can be "/" — so this silently
+# resolved to "/" rather than falling through to the "echo /tmp/hive"
+# fallback the original author intended (that fallback only fires if the
+# `cd` itself fails; `cd /..` succeeds — it just lands on "/"). This is the
+# root cause of a live guide-agent failure: HIVE_REPO_DIR=/ leaked into the
+# agent's shell env, and guide's own workspace (/data/agents/guide/workspace)
+# stayed empty because nothing sane can clone into "/".
+#
+# Fix: never derive from BASH_SOURCE at all. An explicit HIVE_REPO_DIR (env
+# override, e.g. for local dev running bin/ scripts straight from a git
+# checkout) always wins; otherwise default to a real, known-safe path.
+# hive-deploy.sh is the only real consumer and already treats HIVE_REPO_DIR
+# as "the hive git checkout to `git pull` in", so /tmp/hive (its own
+# pre-existing fallback default) is the correct unconditional default here.
+HIVE_REPO_DIR="${HIVE_REPO_DIR:-/tmp/hive}"
+# Guard of last resort: whatever produced this value (env override included),
+# an empty string or "/" can never be a valid HIVE_REPO_DIR — using either as
+# a clone/work/`cd` target is always a misconfiguration, never intentional.
+if [ -z "$HIVE_REPO_DIR" ] || [ "$HIVE_REPO_DIR" = "/" ]; then
+  echo "[hive-config.sh] WARNING: HIVE_REPO_DIR resolved to '${HIVE_REPO_DIR}' — refusing to use it, falling back to /tmp/hive" >&2
+  HIVE_REPO_DIR="/tmp/hive"
+fi
 export HIVE_REPO_DIR
 
 _HIVE_CONFIG="${HIVE_PROJECT_CONFIG:-/etc/hive/hive-project.yaml}"

--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -12,6 +12,19 @@ TIMESTAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 
 log() { echo "[$TIMESTAMP] $*" >> "$LOG" 2>/dev/null || true; }
 
+# Guard of last resort: this script does `cd "$HIVE_REPO"` followed by
+# `git checkout main --force` and `git reset --hard origin/main` (see the
+# recovery paths below). If HIVE_REPO_DIR were ever empty or "/" — which a
+# buggy derivation upstream in hive-config.sh could produce (see that file's
+# HIVE_REPO_DIR comment for the exact failure mode) — those commands would
+# operate on the filesystem root instead of a hive checkout. Refuse outright
+# rather than let a misconfigured HIVE_REPO_DIR anywhere upstream turn into a
+# destructive git operation on "/".
+if [ -z "$HIVE_REPO" ] || [ "$HIVE_REPO" = "/" ]; then
+  log "ERROR: HIVE_REPO_DIR resolved to '${HIVE_REPO}' — refusing to operate on it"
+  exit 1
+fi
+
 if [ ! -d "$HIVE_REPO/.git" ]; then
   log "ERROR: $HIVE_REPO is not a git repo"
   exit 1

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -87,6 +87,18 @@ RUN npm install -g @github/copilot@${COPILOT_VERSION} && npm cache clean --force
 # the MITM proxy's forged certificates. The Node.js path respects NODE_EXTRA_CA_CERTS.
 RUN rm -f /usr/local/lib/node_modules/@github/copilot/node_modules/@github/copilot-linux-*/copilot 2>/dev/null; true
 
+# --- Layer 3b: GitHub Copilot SDK (pinned; powers SDK-based model discovery) ---
+# The dashboard's copilot model discovery prefers a probe through the official
+# SDK (bin/copilot-models.mjs → /usr/local/bin/copilot-models.mjs) because it
+# rides the CLI's own auth and TLS handling. The helper pins the SDK's runtime
+# connection to the Layer 3 CLI entry above, so the newer @github/copilot the
+# SDK nests as its own dependency is never executed (its native binary would
+# reject the proxy CA). Tolerant of failure like the copilot layer: discovery
+# falls back to the raw HTTP probe when the SDK is absent.
+ARG COPILOT_SDK_VERSION=1.0.8
+RUN npm install -g @github/copilot-sdk@${COPILOT_SDK_VERSION} && npm cache clean --force || \
+    echo "WARN: GitHub Copilot SDK install failed — skipping"
+
 # --- Layer 7: Claude Code (most frequent updates) ---
 ARG CLAUDE_CODE_VERSION=latest
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} && npm cache clean --force
@@ -163,6 +175,9 @@ COPY v2/deploy/hive-panes.sh /usr/local/bin/hive-panes
 COPY bin/gh-app-token.sh bin/hive-config.sh bin/agent-launch.sh bin/git-credential-hive.sh /usr/local/bin/
 COPY bin/hive-open-pr.sh /usr/local/bin/hive-open-pr
 COPY bin/gh-wrapper.sh /usr/local/bin/gh
+# SDK-based copilot model discovery helper (see Layer 3b). Invoked as
+# `node /usr/local/bin/copilot-models.mjs` by the dashboard, so no exec bit.
+COPY bin/copilot-models.mjs /usr/local/bin/copilot-models.mjs
 COPY config/backends.conf /usr/local/etc/hive/backends.conf
 RUN chmod +x /usr/local/bin/ttyd-tmux.sh /usr/local/bin/hive-panes /usr/local/bin/gh-app-token.sh \
     /usr/local/bin/hive-config.sh /usr/local/bin/agent-launch.sh /usr/local/bin/gh \

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -99,6 +99,19 @@ ARG COPILOT_SDK_VERSION=1.0.8
 RUN npm install -g @github/copilot-sdk@${COPILOT_SDK_VERSION} && npm cache clean --force || \
     echo "WARN: GitHub Copilot SDK install failed — skipping"
 
+# --- Layer 4: OpenAI Codex CLI (pinned; backend: codex + live model discovery) ---
+# Pinned for reproducibility; version matches v2/Dockerfile.contributor —
+# keep the two pins in sync. @openai/codex resolves a platform-specific
+# native binary (@openai/codex-<platform>) via optionalDependencies, so a
+# plain npm install serves both linux/amd64 and linux/arm64.
+# Tolerant of failure like the copilot layer: if codex is absent, the
+# dashboard's codex model discovery (`codex app-server` model/list — pure
+# local stdio, no network, unaffected by the proxy CA) falls back to the
+# static list, and non-codex backends are unaffected.
+ARG CODEX_VERSION=0.146.0
+RUN npm install -g @openai/codex@${CODEX_VERSION} && npm cache clean --force || \
+    echo "WARN: OpenAI Codex CLI install failed — skipping"
+
 # --- Layer 7: Claude Code (most frequent updates) ---
 ARG CLAUDE_CODE_VERSION=latest
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} && npm cache clean --force

--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -12,7 +12,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
     > /etc/apt/sources.list.d/nodesource.list \
   && apt-get update && apt-get install -y nodejs \
-  && npm install -g @anthropic-ai/claude-code @github/copilot @openai/codex \
+  # codex is pinned for reproducibility (matching the copilot pin convention
+  # in v2/Dockerfile): its model catalog is baked into the binary per version,
+  # and the dashboard's static fallback list tracks 0.146.0.
+  && npm install -g @anthropic-ai/claude-code @github/copilot @openai/codex@0.146.0 \
   && rm -rf /var/lib/apt/lists/*
 
 # Install bobshell (IBM "bob"). Mirrors Layer 9 of v2/Dockerfile so the

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -740,6 +740,54 @@ git config --global user.email "hive-bot@kubestellar.io"
 git config --global --replace-all credential.helper ""
 git config --global --replace-all "credential.https://github.com.helper" "/usr/local/bin/git-credential-hive.sh"
 
+# Also wire the credential helper for this hive's ACTUAL GitHub host when it
+# is NOT public github.com (a GitHub Enterprise instance, e.g. github.ibm.com).
+#
+# Without this, a hive whose repos/App live on GHE only ever gets the helper
+# registered for credential.https://github.com.helper (above). git matches
+# credential helpers by exact host, so `git clone https://github.ibm.com/...`
+# never invokes ANY helper for that host, falls through to an interactive
+# prompt, and fails in this non-interactive shell with "fatal: could not read
+# Username for 'https://github.ibm.com': terminal prompts disabled" — this was
+# reported live from a GHE hive (devx-prod/epx-vscode-ext-poc) where scanner
+# and quality (which talk to the GitHub API, not git-over-HTTPS) worked fine
+# while guide's `git clone` could not authenticate at all.
+#
+# The host is derived the same way the Go binary's GitHubConfig.HostLabel()
+# derives it (pkg/config/config.go): prefer github.base_url, fall back to the
+# host portion of github.api_url, strip scheme and a trailing /api/v3, default
+# to github.com. Reading it here (from the same hive.yaml the Go binary reads)
+# rather than hardcoding "github.ibm.com" keeps this general for ANY configured
+# GHE host, and a no-op for a plain github.com hive (GHE_GIT_HOST resolves to
+# "github.com", which already has its helper wired above).
+GHE_GIT_HOST=""
+if [ -f "${HIVE_CONFIG:-/etc/hive/hive.yaml}" ]; then
+  GHE_GIT_HOST=$(python3 -c "
+import sys, yaml
+try:
+    with open(sys.argv[1]) as f:
+        cfg = yaml.safe_load(f) or {}
+except Exception:
+    sys.exit(0)
+gh = cfg.get('github') or {}
+pick = (gh.get('base_url') or gh.get('api_url') or '').strip()
+if pick.startswith('https://'):
+    pick = pick[len('https://'):]
+elif pick.startswith('http://'):
+    pick = pick[len('http://'):]
+pick = pick.rstrip('/')
+if pick.endswith('/api/v3'):
+    pick = pick[: -len('/api/v3')]
+host = pick.split('/', 1)[0]
+if host and host.lower() != 'api.github.com' and host.lower() != 'github.com':
+    print(host)
+" "${HIVE_CONFIG:-/etc/hive/hive.yaml}" 2>/dev/null) || true
+fi
+if [ -n "$GHE_GIT_HOST" ]; then
+  git config --global --replace-all "credential.https://${GHE_GIT_HOST}.helper" "/usr/local/bin/git-credential-hive.sh"
+  echo "[entrypoint] git credential helper wired for GitHub Enterprise host: ${GHE_GIT_HOST}"
+fi
+
 # Generate initial GitHub App token if credentials are available
 if [ -x /usr/local/bin/hive-config.sh ]; then
   . /usr/local/bin/hive-config.sh 2>/dev/null || true

--- a/v2/docs/manual-provisioning.md
+++ b/v2/docs/manual-provisioning.md
@@ -680,6 +680,119 @@ Until the dashboard "assign" flow lands, claiming is manual:
 
 ---
 
+## Mapping a namespace back to its hive (identity labels)
+
+A claimed placeholder's namespace **keeps its original placeholder name
+forever** — e.g. `hive-hosted-hosted-available-oke-01-placeholder-bb95` — even
+after the hub API's claim/assign flow gives the hive a real name and org.
+Kubernetes has no atomic namespace-rename primitive, and renaming would mean
+recreating every object inside it (including the PVC), so the namespace name
+is never changed. Historically this meant there was no way to look at a
+namespace on the cluster and tell which hive/org it belonged to without
+cross-referencing the hub registry and reverse-engineering the placeholder
+slug.
+
+Instead, the hub stamps **identity labels** and a **display-name annotation**
+onto the namespace itself, keeping it self-describing even though its name
+never changes:
+
+| Key | Kind | Holds |
+|---|---|---|
+| `hive.kubestellar.io/hive-name` | label | The hive's display name (`ProjectName`), **sanitized** to a valid RFC-1123 label value. |
+| `hive.kubestellar.io/org` | label | The hive's forge org, sanitized the same way. |
+| `hive.kubestellar.io/hive-id` | label | The hive's internal `hive_id`, sanitized the same way. |
+| `hive.kubestellar.io/display-name` | annotation | The **exact, unsanitized** hive name — the recoverable source of truth when the sanitized label value has been lossily transformed. |
+
+**Sanitization**: label values are lower-cased, restricted to `[a-z0-9.-]`
+(everything else — spaces, underscores, unicode, punctuation — is dropped
+outright rather than transliterated), trimmed of leading/trailing separators,
+and capped at 63 characters (the RFC-1123 label-value limit). So a hive named
+`"TradingAsBuddies"` gets the label value `tradingasbuddies`, while the
+`hive.kubestellar.io/display-name` annotation preserves the original
+`TradingAsBuddies` exactly. A field that sanitizes to empty (or wasn't set
+yet — e.g. a fresh placeholder with no real name/org) is **omitted** from the
+labels rather than written as an empty/invalid label.
+
+Given a hive name, find its namespace:
+
+```bash
+kubectl --context hive-oke get ns \
+  -l hive.kubestellar.io/hive-name=tradingasbuddies
+```
+
+Given a namespace, find the hive that owns it:
+
+```bash
+kubectl --context hive-oke get ns hive-hosted-hosted-available-oke-01-placeholder-bb95 \
+  -o jsonpath='{.metadata.annotations.hive\.kubestellar\.io/display-name}'
+# -> TradingAsBuddies
+```
+
+**When the labels/annotation are (re)written** — the hub calls the same
+`stampHostedNamespaceIdentity` helper at all three points a hive's identity is
+known or changes, so the namespace never goes stale:
+
+1. **Automatic provisioning** (`provisionHive`, Path A above) — stamps
+   whatever is known at namespace-creation time. For a freshly-created pool
+   placeholder this is often just `hive.kubestellar.io/hive-id`, since
+   `org`/`name` are still placeholder values at this point.
+2. **Claim** (`handleApproveProvision`) — the real name/org become known here
+   for the first time, so the labels/annotation are (re)written.
+3. **Assign / reassign** (`handleAssignHive`) — same, so a placeholder that
+   gets reassigned to a different owner has its namespace identity refreshed
+   too.
+
+The stamp is applied via idempotent `kubectl label`/`kubectl annotate
+--overwrite` (merged into whatever the namespace already carries, not
+replaced) and is **best-effort**: a failure to label (no `kubectl` on PATH, a
+transient API error) is logged and does not fail the claim/assign request —
+this is a cosmetic/operability nicety, not a required step for the hive to
+work.
+
+### Name-bearing vanity Route
+
+The same problem — a URL permanently encoding the placeholder slug — applies
+to the dashboard's public URL. The **assign** path (`handleAssignHive`) also
+creates an **additional** OpenShift Route whose host is derived from the
+hive's own display name, rather than the org/repo-derived host used
+previously:
+
+```
+<sanitized-hive-name>-<4-char-suffix>.<cluster-domain>
+```
+
+For example, a hive named `TradingAsBuddies` on a cluster with domain
+`apps.example.com` gets a Route host like
+`tradingasbuddies-a1b2.apps.example.com`, adopted as
+`https://tradingasbuddies-a1b2.apps.example.com`. The random suffix keeps two
+hives with similar/identical sanitized names from colliding on the same host.
+
+This is an **additional** Route, not a rename: the original Route (host
+derived from org/repo or the placeholder ID) is left completely alone, so any
+in-flight bookmark or callback against it keeps working. **The namespace
+itself is still never renamed or recreated** — only a second Route pointing at
+the same Service is added. If the hive has no display name set, the vanity
+host falls back to the previous org/repo-derived scheme.
+
+### Namespace shown in the dashboards
+
+The namespace is now surfaced in two read-only UI spots, so an operator or
+hive owner doesn't need `kubectl` at all to find it:
+
+- **Spoke dashboard → Hub tab.** The hive's own dashboard shows its
+  Kubernetes namespace next to the hub URL/name info. The spoke learns its own
+  namespace from the `POD_NAMESPACE` env var, set via the Kubernetes downward
+  API (`fieldRef: metadata.namespace`) on the hive Deployment — falling back to
+  a `NAMESPACE` env var, then to the in-cluster service-account namespace file,
+  if `POD_NAMESPACE` isn't set (e.g. a spoke provisioned before this env var
+  existed). The row is omitted entirely when none of the three resolve.
+- **Hub dashboard → per-spoke status hover.** Hovering a hive in the hub's
+  fleet view shows its namespace, computed client-side as `"hive-hosted-" +
+  <hive-id>` — the same convention the hub uses server-side — so it can never
+  disagree with the namespace the identity labels above are stamped on.
+
+---
+
 ## Deprovisioning
 
 ```bash

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3525,7 +3525,15 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 		"litellm":    litellmSectionResponse(&cfg.Governor.LiteLLM),
 		"trajectory": trajectorySectionResponse(&cfg.Governor),
 		"hub": map[string]interface{}{
-			"enabled":                          cfg.Hub.Enabled,
+			"enabled": cfg.Hub.Enabled,
+			// namespace is read-only, runtime-derived display info (never
+			// persisted to hive.yaml, never accepted back on save) — the
+			// Kubernetes namespace this pod is actually running in. See
+			// podNamespace's doc comment for the POD_NAMESPACE/NAMESPACE/
+			// service-account-file fallback chain. Omitted (empty string)
+			// outside a cluster, which the Hub tab renders by skipping the
+			// line rather than showing a blank/"undefined" value.
+			"namespace":                        podNamespace(),
 			"url":                              cfg.Hub.URL,
 			"dashboard_url":                    cfg.Hub.DashboardURL,
 			"snapshot_url":                     cfg.Hub.SnapshotURL,

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	defaultContributorsDir     = "/data/contributors"
-	contributorAutoPromoteAt   = 5
-	contributorTrustedAt       = 20
-	defaultFederationRegistry  = "/data/federation/registry.json"
+	defaultContributorsDir    = "/data/contributors"
+	contributorAutoPromoteAt  = 5
+	contributorTrustedAt      = 20
+	defaultFederationRegistry = "/data/federation/registry.json"
 )
 
 func getContributorsDir() string {
@@ -42,40 +42,40 @@ func getFederationRegistryPath() string {
 }
 
 type ContributorProfile struct {
-	GitHubUsername      string                `json:"github_username"`
-	ContributorID      string                `json:"contributor_id"`
-	RegistrationToken  string                `json:"registration_token"`
-	TokenPlain         string                `json:"registration_token_plain,omitempty"`
-	TrustTier          string                `json:"trust_tier"`
-	PreferredRole      string                `json:"preferred_role,omitempty"`
-	CLIBackend         string                `json:"cli_backend,omitempty"`
-	Model              string                `json:"model,omitempty"`
-	AvatarURL          string                `json:"avatar_url,omitempty"`
-	RegisteredAt       string                `json:"registered_at"`
-	TasksCompleted     int                   `json:"total_tasks_completed"`
+	GitHubUsername    string `json:"github_username"`
+	ContributorID     string `json:"contributor_id"`
+	RegistrationToken string `json:"registration_token"`
+	TokenPlain        string `json:"registration_token_plain,omitempty"`
+	TrustTier         string `json:"trust_tier"`
+	PreferredRole     string `json:"preferred_role,omitempty"`
+	CLIBackend        string `json:"cli_backend,omitempty"`
+	Model             string `json:"model,omitempty"`
+	AvatarURL         string `json:"avatar_url,omitempty"`
+	RegisteredAt      string `json:"registered_at"`
+	TasksCompleted    int    `json:"total_tasks_completed"`
 	// TasksWithPR counts only completions that reported a pull request.
 	// Auto-promotion reads this rather than TasksCompleted, so write access is
 	// never granted for completions where nothing was shown to have shipped.
-	TasksWithPR        int                   `json:"total_tasks_completed_with_pr"`
-	TasksFailed        int                   `json:"total_tasks_failed"`
-	LastActive         string                `json:"last_active,omitempty"`
-	LastCompletedTask  *WSTaskAssign         `json:"last_completed_task,omitempty"`
-	RateLimits         ContributorRateLimits `json:"rate_limits"`
-	Active             bool                  `json:"active,omitempty"`
-	CurrentTask        *WSTaskAssign         `json:"current_task,omitempty"`
-	ActiveTasks        []WSTaskAssign        `json:"active_tasks,omitempty"`
-	Sessions           int                   `json:"sessions,omitempty"`
+	TasksWithPR       int                   `json:"total_tasks_completed_with_pr"`
+	TasksFailed       int                   `json:"total_tasks_failed"`
+	LastActive        string                `json:"last_active,omitempty"`
+	LastCompletedTask *WSTaskAssign         `json:"last_completed_task,omitempty"`
+	RateLimits        ContributorRateLimits `json:"rate_limits"`
+	Active            bool                  `json:"active,omitempty"`
+	CurrentTask       *WSTaskAssign         `json:"current_task,omitempty"`
+	ActiveTasks       []WSTaskAssign        `json:"active_tasks,omitempty"`
+	Sessions          int                   `json:"sessions,omitempty"`
 }
 
 type ContributorRateLimits struct {
-	MaxConcurrent  int `json:"max_concurrent_tasks"`
-	MaxPerHour     int `json:"max_tasks_per_hour"`
-	MaxPerDay      int `json:"max_tasks_per_day"`
+	MaxConcurrent int `json:"max_concurrent_tasks"`
+	MaxPerHour    int `json:"max_tasks_per_hour"`
+	MaxPerDay     int `json:"max_tasks_per_day"`
 }
 
 type ContributorPool struct {
-	Active     int                     `json:"active"`
-	Registered int                     `json:"registered"`
+	Active     int `json:"active"`
+	Registered int `json:"registered"`
 	mu         sync.RWMutex
 }
 
@@ -110,6 +110,7 @@ func (s *Server) registerContributeRoutes() {
 	s.mux.HandleFunc("POST /api/contribute/reissue-token", s.handleContributeReissueToken)
 	s.mux.HandleFunc("GET /api/contribute/status", s.handleContributeStatus)
 	s.mux.HandleFunc("GET /api/contribute/activity", s.handleContributeActivity)
+	s.mux.HandleFunc("GET /api/contribute/fleet", s.handleContributeFleet)
 	s.mux.HandleFunc("GET /api/contributors", s.handleContributorsList)
 	s.mux.HandleFunc("GET /api/contributors/{id}", s.handleContributorGet)
 	s.mux.HandleFunc("PUT /api/contributors/{id}/trust", s.handleContributorTrust)
@@ -204,7 +205,7 @@ func createContributorProfile(username string) (*ContributorProfile, string) {
 	cid := "c-" + randomHex(6)
 	token := randomHex(32)
 	p := &ContributorProfile{
-		GitHubUsername:     username,
+		GitHubUsername:    username,
 		ContributorID:     cid,
 		RegistrationToken: sha256Hex(token),
 		TokenPlain:        token,
@@ -347,7 +348,61 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .feed-cli{color:#8b949e;font-size:.8rem}
 .feed-empty{padding:40px 20px;text-align:center;color:#8b949e;font-size:.85rem}
 @media(max-width:768px){.page{flex-direction:column}.sidebar{border-left:none;border-top:1px solid #30363d;max-width:none;max-height:300px}}
+/* Management & Operations tab chrome — additive, does not touch onboarding content */
+.page-tabs{display:flex;gap:2px;background:#161b22;border-bottom:1px solid #30363d;padding:0 48px}
+.page-tab{background:none;border:none;color:#8b949e;font-size:.95rem;font-weight:500;padding:14px 20px;cursor:pointer;border-bottom:2px solid transparent;font-family:inherit}
+.page-tab:hover{color:#e6edf3}
+.page-tab.active{color:#e6edf3;border-bottom-color:#58a6ff}
+.tab-panel{display:none}
+.tab-panel.active{display:block}
+.ops{padding:40px 48px;overflow-y:auto}
+.ops h1{font-size:1.7rem;margin-bottom:6px}
+.ops-grid{display:grid;grid-template-columns:340px 1fr;gap:20px;margin-top:24px}
+@media(max-width:900px){.ops-grid{grid-template-columns:1fr}}
+.ops-card{background:#161b22;border:1px solid #30363d;border-radius:12px;padding:0;overflow:hidden}
+.ops-card-head{padding:16px 20px;border-bottom:1px solid #30363d;display:flex;align-items:center;gap:10px}
+.ops-card-head h3{font-size:.95rem;color:#e6edf3;margin:0}
+.ops-card-count{font-size:.75rem;color:#8b949e;margin-left:auto}
+.ops-filters{display:flex;gap:4px;padding:12px 20px;border-bottom:1px solid #21262d;flex-wrap:wrap}
+.ops-filter{background:#0d1117;border:1px solid #30363d;color:#8b949e;font-size:.78rem;padding:4px 12px;border-radius:999px;cursor:pointer;font-family:inherit}
+.ops-filter.active{background:#1f6feb;border-color:#1f6feb;color:#fff}
+.work-list{max-height:520px;overflow-y:auto}
+.work-item{padding:14px 20px;border-bottom:1px solid #21262d;cursor:pointer}
+.work-item:hover{background:rgba(88,166,255,.04)}
+.work-item.selected{background:rgba(88,166,255,.08)}
+.work-repo{font-size:.75rem;color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.work-title{font-size:.9rem;color:#e6edf3;margin:2px 0 6px}
+.work-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-size:.75rem;color:#8b949e}
+.pill{display:inline-block;padding:2px 8px;border-radius:999px;font-size:.7rem;font-weight:600;border:1px solid transparent}
+.pill-progress{background:rgba(88,166,255,.12);color:#58a6ff;border-color:rgba(88,166,255,.3)}
+.pill-review{background:rgba(210,153,34,.12);color:#d29922;border-color:rgba(210,153,34,.3)}
+.pill-passed{background:rgba(63,185,80,.12);color:#3fb950;border-color:rgba(63,185,80,.3)}
+.pill-blocked{background:rgba(248,81,73,.12);color:#f85149;border-color:rgba(248,81,73,.3)}
+.pill-idle{background:rgba(139,148,158,.12);color:#8b949e;border-color:rgba(139,148,158,.3)}
+.clanker-row{display:flex;align-items:center;gap:10px;padding:12px 20px;border-bottom:1px solid #21262d}
+.clanker-av{width:28px;height:28px;border-radius:50%%;flex-shrink:0;background:#30363d}
+.clanker-main{flex:1;min-width:0}
+.clanker-user{font-size:.88rem;color:#e6edf3;font-weight:500}
+.clanker-sub{font-size:.74rem;color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.clanker-dot{width:8px;height:8px;border-radius:50%%;background:#3fb950;flex-shrink:0}
+.clanker-dot.stale{background:#8b949e}
+.pipeline{display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin:14px 0}
+.pipe-node{background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:8px 14px;font-size:.82rem;color:#e6edf3}
+.pipe-node .lgtm{color:#3fb950;font-size:.72rem}
+.pipe-arrow{color:#8b949e}
+.policy-row{display:flex;justify-content:space-between;gap:12px;padding:8px 0;border-bottom:1px solid #21262d;font-size:.85rem}
+.policy-row:last-child{border-bottom:none}
+.policy-key{color:#8b949e}
+.policy-val{color:#e6edf3;text-align:right;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;word-break:break-word}
+.ops-empty{padding:32px 20px;text-align:center;color:#8b949e;font-size:.85rem}
+.ops-note{color:#6e7681;font-size:.78rem;margin-top:12px;line-height:1.5}
+.ops-note code{background:#0d1117;padding:1px 6px;border-radius:4px}
 </style></head><body>
+<div class="page-tabs" role="tablist">
+<button class="page-tab active" role="tab" id="ptab-onboarding" aria-selected="true" data-panel="tab-onboarding">Onboarding</button>
+<button class="page-tab" role="tab" id="ptab-ops" aria-selected="false" data-panel="tab-ops">Management &amp; Operations</button>
+</div>
+<div class="tab-panel active" id="tab-onboarding" role="tabpanel" aria-labelledby="ptab-onboarding">
 <div class="page">
 <div class="main">
 <h1>🐝 Contribute to %s</h1>
@@ -502,6 +557,147 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 </div>
 </div>
 </div>
+</div>
+<div class="tab-panel" id="tab-ops" role="tabpanel" aria-labelledby="ptab-ops">
+<div class="ops">
+<h1>Management &amp; Operations</h1>
+<p class="subtitle" style="font-size:.95rem">A read-only operations view over the contributor (&ldquo;clanker&rdquo;) fleet and its in-flight work &mdash; surfaced from what this hive already knows. No controls here mutate policy or the fleet.</p>
+<div class="ops-grid">
+<div>
+<div class="ops-card">
+<div class="ops-card-head"><span class="feed-dot"></span><h3>Connected clankers</h3><span class="ops-card-count" id="clanker-count"></span></div>
+<div id="clanker-list"><div class="ops-empty">Loading fleet&hellip;</div></div>
+</div>
+<div class="ops-card" style="margin-top:20px">
+<div class="ops-card-head"><h3>Pipeline &amp; policy</h3></div>
+<div style="padding:16px 20px">
+<div class="pipeline">
+<span class="pipe-node">opened</span><span class="pipe-arrow">&rarr;</span>
+<span class="pipe-node">review <span class="lgtm">[lgtm]</span></span><span class="pipe-arrow">&rarr;</span>
+<span class="pipe-node">approved</span><span class="pipe-arrow">&rarr;</span>
+<span class="pipe-node">merged</span>
+</div>
+<div id="policy-body"><div class="ops-empty">Loading policy&hellip;</div></div>
+<p class="ops-note">Merge automation advances a PR when CI is green and a maintainer signals <code>/approve</code> or <code>lgtm</code>; a <code>do-not-merge</code> label blocks it. This panel displays the configured admission posture &mdash; it does not change it.</p>
+</div>
+</div>
+</div>
+<div>
+<div class="ops-card">
+<div class="ops-card-head"><h3>My work</h3><span class="ops-card-count" id="work-count"></span></div>
+<div class="ops-filters" role="tablist">
+<button class="ops-filter active" data-filter="all">All</button>
+<button class="ops-filter" data-filter="active">Active</button>
+<button class="ops-filter" data-filter="review">Review requests</button>
+<button class="ops-filter" data-filter="done">Done</button>
+</div>
+<div class="work-list" id="work-list"><div class="ops-empty">Loading work&hellip;</div></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<script>
+(function(){
+// Tab switching for the /contribute page. Additive: leaves onboarding intact.
+var tabs=document.querySelectorAll('.page-tab');
+var panels=document.querySelectorAll('.tab-panel');
+var opsStarted=false;
+tabs.forEach(function(t){t.addEventListener('click',function(){
+  tabs.forEach(function(x){x.classList.remove('active');x.setAttribute('aria-selected','false');});
+  panels.forEach(function(p){p.classList.remove('active');});
+  t.classList.add('active');t.setAttribute('aria-selected','true');
+  var panel=document.getElementById(t.getAttribute('data-panel'));
+  if(panel)panel.classList.add('active');
+  if(t.getAttribute('data-panel')==='tab-ops'&&!opsStarted){opsStarted=true;opsPoll();}
+});});
+
+var currentFilter='all';
+var lastWork=[];
+document.querySelectorAll('.ops-filter').forEach(function(f){f.addEventListener('click',function(){
+  document.querySelectorAll('.ops-filter').forEach(function(x){x.classList.remove('active');});
+  f.classList.add('active');
+  currentFilter=f.getAttribute('data-filter');
+  renderWork(lastWork);
+});});
+
+function esc(s){var d=document.createElement('div');d.textContent=(s==null?'':String(s));return d.innerHTML;}
+function rel(ts){if(!ts)return '';var d=new Date(ts);if(isNaN(d))return '';var s=Math.floor((Date.now()-d.getTime())/1000);if(s<60)return s+'s ago';var m=Math.floor(s/60);if(m<60)return m+'m ago';var h=Math.floor(m/60);if(h<24)return h+'h ago';return Math.floor(h/24)+'d ago';}
+
+function renderClankers(list){
+  var el=document.getElementById('clanker-list');
+  document.getElementById('clanker-count').textContent=(list.length)+(list.length===1?' connected':' connected');
+  if(!list.length){el.innerHTML='<div class="ops-empty">No clankers connected right now.</div>';return;}
+  el.innerHTML=list.map(function(c){
+    var user=c.github_username||c.contributor_id||'clanker';
+    var av=c.github_username?'<img class="clanker-av" src="https://github.com/'+esc(c.github_username)+'.png" alt="">':'<span class="clanker-av"></span>';
+    var sub=[c.cli_backend,c.model,c.role,c.trust_tier].filter(Boolean).map(esc).join(' &middot; ');
+    var task=c.current_task?('<div class="clanker-sub">on '+esc(c.current_task.repo)+'#'+esc(c.current_task.number)+'</div>'):'';
+    return '<div class="clanker-row"><span class="clanker-dot'+(c.stale?' stale':'')+'"></span>'+av+
+      '<div class="clanker-main"><div class="clanker-user">'+esc(user)+'</div>'+
+      '<div class="clanker-sub">'+(sub||'&mdash;')+'</div>'+task+'</div>'+
+      '<span class="feed-time">'+esc(rel(c.connected_at))+'</span></div>';
+  }).join('');
+}
+
+function workMatchesFilter(w){
+  if(currentFilter==='all')return true;
+  if(currentFilter==='active')return w.status==='in-progress';
+  if(currentFilter==='review')return w.status==='review';
+  if(currentFilter==='done')return w.status==='done';
+  return true;
+}
+function statusPill(s){
+  if(s==='in-progress')return '<span class="pill pill-progress">in-progress</span>';
+  if(s==='review')return '<span class="pill pill-review">review</span>';
+  if(s==='done')return '<span class="pill pill-passed">done</span>';
+  if(s==='blocked')return '<span class="pill pill-blocked">blocked</span>';
+  return '<span class="pill pill-idle">'+esc(s)+'</span>';
+}
+function renderWork(list){
+  lastWork=list;
+  var shown=list.filter(workMatchesFilter);
+  document.getElementById('work-count').textContent=shown.length+(shown.length===1?' item':' items');
+  var el=document.getElementById('work-list');
+  if(!shown.length){el.innerHTML='<div class="ops-empty">No work items in flight'+(currentFilter!=='all'?' for this filter.':'.')+'</div>';return;}
+  el.innerHTML=shown.map(function(w){
+    var who=w.github_username?('<span class="feed-role">'+esc(w.github_username)+'</span>'):'';
+    var cli=w.cli_backend?(' &middot; '+esc(w.cli_backend)):'';
+    return '<div class="work-item"><div class="work-repo">'+esc(w.repo||'')+(w.number?('#'+esc(w.number)):'')+'</div>'+
+      '<div class="work-title">'+esc(w.title||'(untitled task)')+'</div>'+
+      '<div class="work-meta">'+statusPill(w.status)+who+cli+'</div></div>';
+  }).join('');
+}
+function renderPolicy(p){
+  var el=document.getElementById('policy-body');
+  if(!p){el.innerHTML='<div class="ops-empty">Policy unavailable.</div>';return;}
+  function list(a){return (a&&a.length)?a.map(esc).join(', '):'&mdash;';}
+  var rows=[
+    ['Contribute queue',p.suspended?'<span class="pill pill-blocked">suspended</span>':'<span class="pill pill-passed">active</span>'],
+    ['Title filter',esc(p.titles_mode||'deny')+': '+list(p.deny_titles)],
+    ['Author filter',esc(p.authors_mode||'deny')+': '+list(p.deny_authors)],
+    ['Label filter',esc(p.labels_mode||'deny')+': '+list(p.labels_mode==='allow'?p.allow_labels:p.deny_labels)],
+    ['Model allowlist',(p.reject_unknown_models?'strict &middot; ':'')+list(p.allow_models)],
+    ['Skip assigned-to-others',p.skip_assigned_to_others?'yes':'no'],
+    ['Disabled tiers',list(p.disabled_tiers)],
+    ['Disabled repos',list(p.disabled_repos)],
+    ['Auto-promote at',esc(p.auto_promote_at)+' tasks &rarr; contributor'],
+    ['Trusted at',esc(p.trusted_at)+' tasks + maintainer voucher']
+  ];
+  el.innerHTML=rows.map(function(r){return '<div class="policy-row"><span class="policy-key">'+r[0]+'</span><span class="policy-val">'+r[1]+'</span></div>';}).join('');
+}
+async function opsPoll(){
+  try{
+    var res=await fetch('/api/contribute/fleet');
+    var data=await res.json();
+    renderClankers(data.clankers||[]);
+    renderWork(data.work||[]);
+    renderPolicy(data.policy);
+  }catch(e){}
+  if(document.getElementById('tab-ops').classList.contains('active'))setTimeout(opsPoll,4000);
+}
+})();
+</script>
 <script>
 let prevCount=0;
 async function poll(){try{
@@ -677,7 +873,7 @@ func (s *Server) handleContributeStatus(w http.ResponseWriter, r *http.Request) 
 	}
 	s.statusMu.RUnlock()
 	jsonResponse(w, map[string]any{
-		"hub":                  "online",
+		"hub":                 "online",
 		"active_contributors": active,
 		"total_registered":    len(profiles),
 		"actionable_items":    actionable,
@@ -690,6 +886,71 @@ func (s *Server) handleContributeActivity(w http.ResponseWriter, r *http.Request
 		return
 	}
 	jsonResponse(w, map[string]any{"activity": s.contributeHub.RecentActivity()})
+}
+
+// ContributeAdmissionPolicy is a read-only summary of the merge/automation
+// posture and the contributor admission filters that ALREADY exist server-side.
+// It is surfaced to the Management & Operations tab so an operator can read what
+// is configured; it adds no controls and changes nothing.
+type ContributeAdmissionPolicy struct {
+	Suspended            bool     `json:"suspended"`
+	TitlesMode           string   `json:"titles_mode,omitempty"`
+	AuthorsMode          string   `json:"authors_mode,omitempty"`
+	LabelsMode           string   `json:"labels_mode,omitempty"`
+	DenyTitles           []string `json:"deny_titles,omitempty"`
+	DenyAuthors          []string `json:"deny_authors,omitempty"`
+	DenyLabels           []string `json:"deny_labels,omitempty"`
+	AllowLabels          []string `json:"allow_labels,omitempty"`
+	AllowModels          []string `json:"allow_models,omitempty"`
+	RejectUnknownModels  bool     `json:"reject_unknown_models"`
+	SkipAssignedToOthers bool     `json:"skip_assigned_to_others"`
+	DisabledTiers        []string `json:"disabled_tiers,omitempty"`
+	DisabledRepos        []string `json:"disabled_repos,omitempty"`
+	AutoPromoteAt        int      `json:"auto_promote_at"`
+	TrustedAt            int      `json:"trusted_at"`
+}
+
+// buildContributeAdmissionPolicy reads the configured contributor admission
+// posture from the hub config. It never mutates config and returns a zero-value
+// policy when config is unavailable.
+func (s *Server) buildContributeAdmissionPolicy() ContributeAdmissionPolicy {
+	p := ContributeAdmissionPolicy{
+		AutoPromoteAt: contributorAutoPromoteAt,
+		TrustedAt:     contributorTrustedAt,
+	}
+	if s.deps == nil || s.deps.Config == nil {
+		return p
+	}
+	h := s.deps.Config.Hub
+	p.Suspended = h.ContributeSuspended
+	p.TitlesMode = h.ContributeTitlesMode
+	p.AuthorsMode = h.ContributeAuthorsMode
+	p.LabelsMode = h.ContributeLabelsMode
+	p.DenyTitles = h.ContributeDenyTitles
+	p.DenyAuthors = h.ContributeDenyAuthors
+	p.DenyLabels = h.ContributeDenyLabels
+	p.AllowLabels = h.ContributeAllowLabels
+	p.AllowModels = h.ContributeAllowModels
+	p.RejectUnknownModels = h.ContributeRejectUnknownModels
+	p.SkipAssignedToOthers = h.ContributeSkipAssignedToOthers
+	p.DisabledTiers = h.DisabledTiers
+	p.DisabledRepos = h.DisabledRepos
+	return p
+}
+
+// handleContributeFleet serves the read-only fleet/work/policy snapshot that the
+// Management & Operations tab hydrates. GET only, no side effects: it surfaces
+// the hub's live connection state and the already-configured admission policy.
+func (s *Server) handleContributeFleet(w http.ResponseWriter, r *http.Request) {
+	snap := FleetSnapshot{Clankers: []FleetClanker{}, Work: []FleetWorkItem{}}
+	if s.contributeHub != nil {
+		snap = s.contributeHub.FleetSnapshot()
+	}
+	jsonResponse(w, map[string]any{
+		"clankers": snap.Clankers,
+		"work":     snap.Work,
+		"policy":   s.buildContributeAdmissionPolicy(),
+	})
 }
 
 // ── Contributor management ─────────────────────────────────────────────────
@@ -784,7 +1045,6 @@ func (s *Server) handleContributorDelete(w http.ResponseWriter, r *http.Request)
 }
 
 // ── Federation registry ────────────────────────────────────────────────────
-
 
 type FederationRegistry struct {
 	Hives []FederationHive `json:"hives"`
@@ -1028,8 +1288,8 @@ func (s *Server) handleLeaderboardAPI(w http.ResponseWriter, _ *http.Request) {
 	contributors := buildLeaderboard()
 	agents := s.buildAgentLeaderboardEntries()
 	jsonResponse(w, map[string]any{
-		"leaderboard":  contributors,
-		"agents":       agents,
+		"leaderboard": contributors,
+		"agents":      agents,
 	})
 }
 
@@ -1164,8 +1424,8 @@ func (s *Server) buildAgentLeaderboardEntries() []LeaderboardEntry {
 
 		entries = append(entries, LeaderboardEntry{
 			GitHubUsername: name,
-			AvatarURL:     fmt.Sprintf(agentAvatarURLTemplate, name),
-			TrustTier:     agentTierLabel,
+			AvatarURL:      fmt.Sprintf(agentAvatarURLTemplate, name),
+			TrustTier:      agentTierLabel,
 			TasksCompleted: tasksCompleted,
 			TasksFailed:    proc.RestartCount,
 			Findings:       totalFindings,
@@ -2080,4 +2340,3 @@ a{color:#58a6ff}
 
 </body></html>`, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL)
 }
-

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -128,6 +128,93 @@ func TestContributeLanding(t *testing.T) {
 	}
 }
 
+// TestContributeLandingHasOpsTab pins the additive tab chrome: the landing page
+// must now render the Onboarding / Management & Operations tab bar, the new ops
+// panel, AND still carry the existing onboarding content unchanged.
+func TestContributeLandingHasOpsTab(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+
+	// New tab chrome.
+	for _, want := range []string{
+		`class="page-tabs"`,
+		`data-panel="tab-onboarding"`,
+		`data-panel="tab-ops"`,
+		`Management &amp; Operations`,
+		`id="tab-ops"`,
+		`Connected clankers`,
+		`id="work-list"`,
+		`/api/contribute/fleet`,
+		`opened`, // pipeline node
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("ops tab chrome missing %q", want)
+		}
+	}
+
+	// Existing onboarding content must still be present and unchanged.
+	for _, want := range []string{
+		`id="cli-select"`,
+		`id="mode-select"`,
+		`id="runtime-select"`,
+		`How it works`,
+		`Powered by <strong style="color:#e6edf3">ClankeR</strong>`,
+		`Trust tiers`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("onboarding content missing %q (must remain unchanged)", want)
+		}
+	}
+}
+
+// TestContributeFleet pins the read-only fleet endpoint JSON shape.
+func TestContributeFleet(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/fleet", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Clankers []FleetClanker            `json:"clankers"`
+		Work     []FleetWorkItem           `json:"work"`
+		Policy   ContributeAdmissionPolicy `json:"policy"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	// With no connections the fleet is empty but the keys must be present arrays.
+	if resp.Clankers == nil {
+		t.Error("clankers should be a non-nil array")
+	}
+	if resp.Work == nil {
+		t.Error("work should be a non-nil array")
+	}
+	// Policy always exposes the promotion thresholds sourced from constants.
+	if resp.Policy.AutoPromoteAt != contributorAutoPromoteAt {
+		t.Errorf("auto_promote_at = %d, want %d", resp.Policy.AutoPromoteAt, contributorAutoPromoteAt)
+	}
+	if resp.Policy.TrustedAt != contributorTrustedAt {
+		t.Errorf("trusted_at = %d, want %d", resp.Policy.TrustedAt, contributorTrustedAt)
+	}
+}
+
 func TestContributorNotFound(t *testing.T) {
 	setupContributeEnv(t)
 	s := NewServer(0, slog.Default())
@@ -311,22 +398,22 @@ func TestLeaderboardPageHTML(t *testing.T) {
 
 	body := w.Body.String()
 	checks := map[string]string{
-		"gradient-text":       "animated gradient header text",
-		"Leaderboard":         "page heading",
-		"alice":               "contributor username",
+		"gradient-text":        "animated gradient header text",
+		"Leaderboard":          "page heading",
+		"alice":                "contributor username",
 		"github.com/alice.png": "avatar URL",
-		"github.com/alice":    "GitHub profile link",
-		"search":              "search input",
-		"sort-completed":      "sortable completed column",
-		"Trust Tiers":         "trust tiers reference section",
-		"bg-stars":            "starfield background",
-		"var AGENTS":          "JavaScript agent entries data",
-		"var CONTRIBUTORS":    "JavaScript contributor entries data",
-		"toggleSort":          "sort toggle function",
-		"renderRows":          "row rendering function",
-		"hover-card":          "contributor hover card CSS",
-		"hc-header":           "hover card header",
-		"hc-bar":              "hover card success rate bar",
+		"github.com/alice":     "GitHub profile link",
+		"search":               "search input",
+		"sort-completed":       "sortable completed column",
+		"Trust Tiers":          "trust tiers reference section",
+		"bg-stars":             "starfield background",
+		"var AGENTS":           "JavaScript agent entries data",
+		"var CONTRIBUTORS":     "JavaScript contributor entries data",
+		"toggleSort":           "sort toggle function",
+		"renderRows":           "row rendering function",
+		"hover-card":           "contributor hover card CSS",
+		"hc-header":            "hover card header",
+		"hc-bar":               "hover card success rate bar",
 	}
 	for needle, desc := range checks {
 		if !strings.Contains(body, needle) {

--- a/v2/pkg/dashboard/cli_models.go
+++ b/v2/pkg/dashboard/cli_models.go
@@ -11,9 +11,12 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/claude"
 )
 
 // This file adds runtime model discovery for the CLI backends (copilot,
@@ -29,10 +32,17 @@ import (
 //     api.github.com/copilot_internal/user (endpoints.api). Verified live.
 //   - gemini:  GET generativelanguage.googleapis.com/v1beta/models with the
 //     configured Gemini API key. Live only when a key is configured.
-//   - claude:  Anthropic publishes no per-subscription "list my models"
-//     endpoint and the Claude CLI has no non-interactive `claude models`
-//     command, so this is a maintained static list of CURRENT model ids
-//     (kept in sync with CLAUDE_CLI_MODELS in static/index.html).
+//   - claude:  GET api.anthropic.com/v1/models. The endpoint accepts BOTH a
+//     standard Anthropic API key (x-api-key, preferred when ANTHROPIC_API_KEY
+//     is set) and the Claude Code subscription OAuth bearer token stored by
+//     the CLI in ~/.claude/.credentials.json (verified live: HTTP 200 with a
+//     subscription token). The OAuth token is short-lived (<1 day) and is
+//     refreshed ONLY when the claude CLI itself runs, so the prober re-reads
+//     the file on every probe, checks expiresAt BEFORE any HTTP call, and
+//     NEVER attempts a token refresh itself — rotating the token out from
+//     under the CLI would break its login (the hive inotify-watches
+//     ~/.claude/). Expired/absent credentials skip straight to the static
+//     fallback (kept in sync with CLAUDE_CLI_MODELS in static/index.html).
 //   - goose:   provider-configured (Ollama/OpenAI/Anthropic/...). goose
 //     >= 1.37 ships an ACP (Agent Client Protocol) agent server (`goose acp`,
 //     JSON-RPC over stdio): initialize + session/new returns result.models
@@ -221,25 +231,57 @@ const (
 	gooseACPInitializeID   = 1
 	gooseACPSessionNewID   = 2
 	gooseACPSessionCloseID = 3
+
+	// --- Claude (Anthropic) ---
+
+	// anthropicModelsURL lists the models available to the presented credential
+	// (API key or Claude Code subscription OAuth token — both accepted,
+	// verified live).
+	anthropicModelsURL = "https://api.anthropic.com/v1/models"
+
+	// anthropicModelsPageLimit is the ?limit= page size for /v1/models. Set to
+	// the API maximum so a single call covers the whole catalog (currently
+	// ~a dozen ids) without pagination.
+	anthropicModelsPageLimit = 1000
+
+	// anthropicAPIVersion is the required anthropic-version header value.
+	anthropicAPIVersion = "2023-06-01"
+
+	// anthropicOAuthBeta is the anthropic-beta value sent alongside a Claude
+	// Code subscription OAuth bearer token. Currently optional for /v1/models
+	// (verified live: 200 without it) but sent anyway for forward
+	// compatibility, mirroring what the Claude CLI sends.
+	anthropicOAuthBeta = "oauth-2025-04-20"
+
+	// claudeTokenExpirySkew is the safety margin subtracted from the stored
+	// token's expiresAt before use: a token within this window of expiring is
+	// treated as already expired so we never fire an HTTP call that a few
+	// seconds of clock skew or transit time would turn into a 401.
+	claudeTokenExpirySkew = 2 * time.Minute
 )
 
 // --- Static fallback lists (kept CURRENT — July 2026) ---
 
-// claudeStaticModels is the maintained fallback/authoritative list for the
-// Claude CLI. Anthropic exposes no "list my models" API and the CLI has no
-// non-interactive list command, so this list IS the source of truth. Keep it
+// claudeStaticModels is the fallback offered when the Claude models probe
+// cannot run (no API key and no fresh OAuth token in the CLI credentials
+// file) or fails. Live discovery via api.anthropic.com/v1/models is strongly
+// preferred; this is only a floor so the dropdown is never empty. Refreshed
+// 2026-08-03 from a live /v1/models response (11 ids, in API order). Keep it
 // in sync with CLAUDE_CLI_MODELS in static/index.html. Both the canonical
-// dated/versioned ids AND the bare aliases the CLI accepts are included.
+// ids AND the bare aliases the CLI accepts are included.
 var claudeStaticModels = []string{
+	"claude-opus-5",
+	"claude-sonnet-5",
 	"claude-fable-5",
 	"claude-opus-4-8",
 	"claude-opus-4-7",
-	"claude-opus-4-6",
-	"claude-sonnet-5",
 	"claude-sonnet-4-6",
-	"claude-sonnet-4-5",
-	"claude-haiku-4-5",
-	// Bare aliases the Claude CLI also accepts.
+	"claude-opus-4-6",
+	"claude-opus-4-5-20251101",
+	"claude-haiku-4-5-20251001",
+	"claude-sonnet-4-5-20250929",
+	"claude-opus-4-1-20250805",
+	// Bare aliases the Claude CLI also accepts (see claudeAlwaysIncludeModels).
 	"opus",
 	"sonnet",
 	"haiku",
@@ -276,6 +318,18 @@ var copilotAlwaysIncludeModels = []string{
 	// Auto-select sentinel — never returned by the /models catalog, but a valid
 	// launch value, so it must always be offered and must survive auto-heal.
 	copilotAutoModel,
+}
+
+// claudeAlwaysIncludeModels are ids that must ALWAYS be offered in the claude
+// dropdown, whether the served list came from live discovery or the static
+// fallback (mirrors copilotAlwaysIncludeModels). The Anthropic /v1/models
+// endpoint never returns the bare aliases, but they are valid `claude --model`
+// values, so they are appended to every served claude list — surviving both
+// paths and the dashboard's model auto-heal.
+var claudeAlwaysIncludeModels = []string{
+	"opus",
+	"sonnet",
+	"haiku",
 }
 
 // bobStaticModels is bob's complete model list: exactly one entry, the auto
@@ -453,8 +507,7 @@ func (s *Server) queryCLIModels(backend string) cliModelResult {
 	case "goose":
 		r = s.discoverGooseModels()
 	case "claude":
-		// No live source exists; the maintained static list is authoritative.
-		r = cliModelResult{models: dedupeModels(claudeStaticModels), fallback: false}
+		r = s.discoverClaudeModels()
 	case "codex":
 		// No probe wired yet; the maintained static list is authoritative and
 		// OpenAI-only (Claude ids are rejected by Codex with a ChatGPT account).
@@ -480,9 +533,12 @@ func (s *Server) queryCLIModels(backend string) cliModelResult {
 	}
 	// Applied after stabilization/fallback so the pinned ids survive BOTH
 	// paths: a live sample that omits a rollout-gated id and the static
-	// fallback list (see copilotAlwaysIncludeModels).
+	// fallback list (see copilotAlwaysIncludeModels / claudeAlwaysIncludeModels).
 	if backend == "copilot" {
 		r.models = dedupeModels(append(r.models, copilotAlwaysIncludeModels...))
+	}
+	if backend == "claude" {
+		r.models = dedupeModels(append(r.models, claudeAlwaysIncludeModels...))
 	}
 	if s.cliModels != nil {
 		s.cliModels.set(backend, r)
@@ -832,6 +888,159 @@ func parseGeminiModelsResponse(r io.Reader) ([]string, error) {
 			continue
 		}
 		out = append(out, strings.TrimPrefix(m.Name, "models/"))
+	}
+	return out, nil
+}
+
+// --- Claude (Anthropic) discovery ---
+
+// claudePodCredentialsPath is a var (not a const) solely so tests can point it
+// at a temp file (mirroring sharedClaudeCredentialPath in pkg/agent). The
+// production value — the hosted-pod home — is never mutated at runtime.
+var claudePodCredentialsPath = claude.CredentialsPath
+
+// anthropicModelsEndpoint redirects the models call away from the real
+// Anthropic endpoint. TEST SEAM ONLY: it is never changed in production, where
+// every probe goes to anthropicModelsURL. It exists so discoverClaudeModels'
+// response handling (success, 401, malformed JSON) can be exercised against an
+// httptest server without a live API round trip.
+var anthropicModelsEndpoint = anthropicModelsURL
+
+// discoverClaudeModels lists the models available to the local Claude
+// credential by calling the Anthropic /v1/models endpoint. Credential
+// precedence: ANTHROPIC_API_KEY (x-api-key header), else the Claude Code
+// subscription OAuth access token from the CLI's credentials file
+// (Authorization: Bearer — accepted by the endpoint, verified live).
+// Best-effort: no credential, an expired token, or any HTTP/parse failure
+// returns fallback=true with an empty list so the caller substitutes the
+// static list. The stored token is NEVER refreshed here (see file header).
+func (s *Server) discoverClaudeModels() cliModelResult {
+	header, value, ok := claudeAPICredential()
+	if !ok {
+		// No API key and no fresh OAuth token. Skip the HTTP call entirely —
+		// on copilot-only spokes the credentials file can sit expired for
+		// weeks, and refreshing it is forbidden (it would rotate the token
+		// out from under the claude CLI's own login).
+		return cliModelResult{fallback: true}
+	}
+	models, err := fetchClaudeModels(anthropicModelsEndpoint, header, value)
+	if err != nil || len(models) == 0 {
+		if err != nil {
+			// Do NOT log the credential or response body; just the failure.
+			s.logger.Warn("claude model discovery failed", "err", err.Error())
+		}
+		return cliModelResult{fallback: true}
+	}
+	return cliModelResult{models: dedupeModels(models), fallback: false}
+}
+
+// claudeAPICredential resolves the credential for the Anthropic models call as
+// an (header name, header value) pair. ANTHROPIC_API_KEY wins when set; else
+// the freshest non-expired OAuth access token from the Claude CLI credentials
+// file is used as a bearer. ok=false means no usable credential. Secret —
+// never log the value.
+func claudeAPICredential() (header, value string, ok bool) {
+	if k := os.Getenv("ANTHROPIC_API_KEY"); k != "" {
+		return "x-api-key", k, true
+	}
+	for _, path := range claudeCredentialCandidatePaths() {
+		if tok := readFreshClaudeToken(path); tok != "" {
+			return "Authorization", "Bearer " + tok, true
+		}
+	}
+	return "", "", false
+}
+
+// claudeCredentialCandidatePaths returns the credentials-file locations to
+// try, in order: the hosted-pod shared home (the same /data/home the agent
+// manager uses for agent homes), then $HOME/.claude/.credentials.json for
+// non-hosted spokes. Computed per call — never cached — because the claude
+// CLI rewrites the file whenever it runs and the probe must see the freshest
+// token.
+func claudeCredentialCandidatePaths() []string {
+	paths := []string{claudePodCredentialsPath}
+	if home := os.Getenv("HOME"); home != "" {
+		if p := filepath.Join(home, ".claude", ".credentials.json"); p != claudePodCredentialsPath {
+			paths = append(paths, p)
+		}
+	}
+	return paths
+}
+
+// readFreshClaudeToken reads and parses one credentials file and returns its
+// OAuth access token ONLY if it is not expired (with claudeTokenExpirySkew of
+// margin). Absent file, malformed JSON, missing token, or an expired/expiring
+// token all return "" — the caller then falls back rather than firing a
+// doomed HTTP call. This deliberately does not reuse claude.ReadAccessToken,
+// which applies no skew margin.
+func readFreshClaudeToken(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	var creds claude.Credentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return ""
+	}
+	o := creds.ClaudeAIOAuth
+	if o == nil || o.AccessToken == "" {
+		return ""
+	}
+	// expiresAt is a millisecond epoch; treat anything inside the skew window
+	// as already expired.
+	if o.ExpiresAt > 0 && time.UnixMilli(o.ExpiresAt).Before(time.Now().Add(claudeTokenExpirySkew)) {
+		return ""
+	}
+	return o.AccessToken
+}
+
+// fetchClaudeModels performs the GET <endpoint>?limit=N call and returns the
+// model ids. authHeader/authValue carry either the API key (x-api-key) or the
+// OAuth bearer (Authorization) — see claudeAPICredential.
+func fetchClaudeModels(modelsURL, authHeader, authValue string) ([]string, error) {
+	client := &http.Client{Timeout: cliModelQueryTimeout}
+	url := fmt.Sprintf("%s?limit=%d", modelsURL, anthropicModelsPageLimit)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set(authHeader, authValue)
+	req.Header.Set("anthropic-version", anthropicAPIVersion)
+	if authHeader == "Authorization" {
+		// OAuth (subscription-token) calls also send the oauth beta flag —
+		// currently optional for /v1/models, sent for forward compatibility.
+		req.Header.Set("anthropic-beta", anthropicOAuthBeta)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("upstream returned %d", resp.StatusCode)
+	}
+	return parseClaudeModelsResponse(resp.Body)
+}
+
+// parseClaudeModelsResponse decodes the Anthropic /v1/models body and returns
+// the model ids. The response shape is:
+//
+//	{"data":[{"id":"claude-opus-5","type":"model",...}, ...]}
+func parseClaudeModelsResponse(r io.Reader) ([]string, error) {
+	var body struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(r).Decode(&body); err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, m := range body.Data {
+		if m.ID == "" {
+			continue
+		}
+		out = append(out, m.ID)
 	}
 	return out, nil
 }

--- a/v2/pkg/dashboard/cli_models.go
+++ b/v2/pkg/dashboard/cli_models.go
@@ -1,9 +1,11 @@
 package dashboard
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -31,9 +33,16 @@ import (
 //     endpoint and the Claude CLI has no non-interactive `claude models`
 //     command, so this is a maintained static list of CURRENT model ids
 //     (kept in sync with CLAUDE_CLI_MODELS in static/index.html).
-//   - goose:   provider-configured (Ollama/OpenAI/Anthropic/...). Without a
-//     stable machine-readable "list models for my provider" command, this
-//     returns a per-provider static list, or "default" when unconfigured.
+//   - goose:   provider-configured (Ollama/OpenAI/Anthropic/...). goose
+//     >= 1.37 ships an ACP (Agent Client Protocol) agent server (`goose acp`,
+//     JSON-RPC over stdio): initialize + session/new returns result.models
+//     {currentModelId, availableModels}, sourced from goose's provider
+//     inventory, which live-fetches the CONFIGURED provider's own models
+//     endpoint. goose resolves ALL provider credentials itself (keyring /
+//     secrets.yaml / env) — hive never reads goose secrets. Unconfigured or
+//     pre-1.37 goose omits the models key from the session/new result (the
+//     clean fallback signal); that, a missing binary, or any error falls
+//     back to a curated per-provider static list.
 //
 // Every discovery is BEST-EFFORT: a failed or absent probe falls back to a
 // current static list so a dropdown is never empty and never errors. Results
@@ -165,6 +174,53 @@ const (
 	// geminiGenerateMethod is the supportedGenerationMethods entry that marks
 	// a model as usable for chat/content generation (vs embeddings, etc.).
 	geminiGenerateMethod = "generateContent"
+
+	// --- Goose (ACP) ---
+
+	// gooseACPBinary and gooseACPSubcommand spawn goose's ACP agent server
+	// (`goose acp`, goose >= 1.37): JSON-RPC 2.0, newline-delimited, on stdio.
+	gooseACPBinary     = "goose"
+	gooseACPSubcommand = "acp"
+
+	// gooseACPProbeTimeout bounds the whole probe (spawn + initialize +
+	// session/new + session/close). Measured 0.39s locally against a live
+	// Ollama including process spawn; the headroom is for slow remote
+	// providers, whose models endpoint goose fetches inline.
+	gooseACPProbeTimeout = 10 * time.Second
+
+	// gooseACPProtocolVersion is the ACP protocol version sent in initialize.
+	// Verified against goose 1.37.0, which answers protocolVersion 1.
+	gooseACPProtocolVersion = 1
+
+	// gooseACPShutdownGrace is how long the probe waits for goose to exit on
+	// its own after stdin closes (letting it process the best-effort
+	// session/close) before killing it. The process is ALWAYS reaped either
+	// way; this only bounds how long a lingering goose can hold the probe.
+	gooseACPShutdownGrace = 2 * time.Second
+
+	// gooseACPClientName / gooseACPClientVersion identify this probe in the
+	// ACP initialize handshake's clientInfo.
+	gooseACPClientName    = "hive-model-probe"
+	gooseACPClientVersion = "1.0"
+
+	// gooseACPAgentHome is the shared agent HOME (see copilotSDKAgentHome —
+	// same directory, same rationale): goose reads its provider config from
+	// ~/.config/goose/config.yaml, so the probe must run under the HOME the
+	// agents use to see which provider is configured. Unlike codex, goose
+	// needs no isolated HOME. Side-effect: each probe writes a session (plus
+	// inventory rows) into goose's sessions.db under this HOME, which is why
+	// the probe sends session/close when done (see gooseACPExchange).
+	gooseACPAgentHome = "/data/home"
+
+	// gooseACPMaxLineBytes caps a single ACP stdout line. session/new results
+	// carry the full model inventory, which can exceed bufio.Scanner's 64 KiB
+	// default.
+	gooseACPMaxLineBytes = 1 << 20
+
+	// JSON-RPC request ids for the fixed probe sequence.
+	gooseACPInitializeID   = 1
+	gooseACPSessionNewID   = 2
+	gooseACPSessionCloseID = 3
 )
 
 // --- Static fallback lists (kept CURRENT — July 2026) ---
@@ -782,13 +838,81 @@ func parseGeminiModelsResponse(r io.Reader) ([]string, error) {
 
 // --- Goose discovery ---
 
-// discoverGooseModels returns models for goose's configured provider. Goose has
-// no stable machine-readable "list models for my configured provider" command
-// across providers, so this maps the configured provider (via GOOSE_PROVIDER /
-// GOOSE_MODEL env, honoring the pinned model) to a static per-provider list,
-// or "default" when unconfigured. Marked fallback=true since it is not a live
-// provider query.
+// errGooseBinaryMissing means goose is not on PATH — today's NORMAL on hosted
+// spokes (verified: goose is not installed in the hive pods), so it is an
+// expected fallback signal, not a logged failure.
+var errGooseBinaryMissing = errors.New("goose binary not on PATH")
+
+// errGooseModelsAbsent means session/new answered WITHOUT a models key: goose
+// is unconfigured (no provider) or predates 1.37. This is goose's clean
+// "nothing to discover" signal, so it too falls back silently.
+var errGooseModelsAbsent = errors.New("goose session/new returned no models (unconfigured or pre-1.37 goose)")
+
+// gooseACPModels is the parsed result.models of an ACP session/new response.
+type gooseACPModels struct {
+	// CurrentModelID is goose's active model (goose also lists it first in
+	// AvailableModels).
+	CurrentModelID string
+	// AvailableModels are the modelId values of result.models.availableModels.
+	AvailableModels []string
+}
+
+// runGooseACPProbe is the probe seam (mirroring runCopilotSDKHelper) so unit
+// tests can substitute canned inventories without a goose binary.
+var runGooseACPProbe = execGooseACPProbe
+
+// discoverGooseModels lists the models goose's CONFIGURED provider serves, by
+// driving `goose acp` (goose >= 1.37): initialize + session/new returns
+// result.models {currentModelId, availableModels}, backed by goose's
+// provider-inventory subsystem, which live-fetches the provider's own models
+// endpoint (verified end-to-end against a live Ollama: the exact /api/tags
+// inventory, ~0.4s round trip including process spawn).
+//
+// Design invariants:
+//
+//   - hive NEVER reads goose's provider credentials — goose resolves them
+//     itself (keyring / secrets.yaml / env). That is the whole advantage of
+//     this probe over probing providers directly, and it must stay that way.
+//   - GOOSE_PROVIDER / GOOSE_MODEL env (inherited by the spawned goose)
+//     override the config's active provider/model; a GOOSE_MODEL pin is also
+//     surfaced first in the served list.
+//   - For providers goose cannot (or is not configured to) refresh — e.g.
+//     ollama without OLLAMA_HOST — availableModels is goose's curated catalog
+//     rather than live inventory, with no distinguishing flag. Acceptable:
+//     still fresher than hive's static map. On a slow remote provider the
+//     FIRST call may serve catalog data with the refreshed inventory arriving
+//     on the next call; the stabilize() retention absorbs that churn.
+//   - Missing binary, absent models key, error, or timeout → empty result →
+//     the caller serves the curated per-provider static fallback below.
 func (s *Server) discoverGooseModels() cliModelResult {
+	ctx, cancel := context.WithTimeout(context.Background(), gooseACPProbeTimeout)
+	defer cancel()
+	inv, err := runGooseACPProbe(ctx)
+	if err == nil && inv != nil && len(inv.AvailableModels) > 0 {
+		// Pinned model first: an explicit GOOSE_MODEL env pin wins, else
+		// goose's own current model (which goose already orders first).
+		pinned := strings.TrimSpace(os.Getenv("GOOSE_MODEL"))
+		if pinned == "" {
+			pinned = inv.CurrentModelID
+		}
+		models := inv.AvailableModels
+		if pinned != "" {
+			models = append([]string{pinned}, models...)
+		}
+		return cliModelResult{models: dedupeModels(models), fallback: false}
+	}
+	if err != nil && !errors.Is(err, errGooseBinaryMissing) && !errors.Is(err, errGooseModelsAbsent) {
+		// Only our own error text — never session payloads, never secrets.
+		s.logger.Info("goose ACP model discovery unavailable, serving static fallback", "err", err.Error())
+	}
+	return gooseStaticProviderResult()
+}
+
+// gooseStaticProviderResult maps the configured provider (GOOSE_PROVIDER env)
+// to the curated static list, honoring a GOOSE_MODEL pin first, or ["default"]
+// when unconfigured. Always fallback=true: this is a curated list, not a live
+// enumeration of the provider's catalog.
+func gooseStaticProviderResult() cliModelResult {
 	provider := strings.ToLower(strings.TrimSpace(os.Getenv("GOOSE_PROVIDER")))
 	var models []string
 	if list, ok := gooseProviderStaticModels[provider]; ok {
@@ -801,9 +925,204 @@ func (s *Server) discoverGooseModels() cliModelResult {
 	if len(models) == 0 {
 		models = []string{"default"}
 	}
-	// Always fallback=true: this is a curated per-provider list, not a live
-	// enumeration of the provider's catalog.
 	return cliModelResult{models: dedupeModels(models), fallback: true}
+}
+
+// execGooseACPProbe spawns `goose acp` and runs the fixed ACP exchange. The
+// probe runs under the shared agent HOME (gooseACPAgentHome) when it exists so
+// goose sees the agents' provider config; otherwise the server's own HOME is
+// left in place (dev machines). The spawned process is always reaped.
+func execGooseACPProbe(ctx context.Context) (*gooseACPModels, error) {
+	bin, err := exec.LookPath(gooseACPBinary)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", errGooseBinaryMissing, err.Error())
+	}
+	cmd := exec.CommandContext(ctx, bin, gooseACPSubcommand)
+	// os/exec documents that for duplicate keys the LAST value wins, so
+	// appending overrides the inherited HOME. GOOSE_PROVIDER / GOOSE_MODEL
+	// pass through via the inherited environment.
+	env := os.Environ()
+	cwd := os.TempDir()
+	if st, statErr := os.Stat(gooseACPAgentHome); statErr == nil && st.IsDir() {
+		env = append(env, "HOME="+gooseACPAgentHome)
+		cwd = gooseACPAgentHome
+	}
+	cmd.Env = env
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("goose acp stdin: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("goose acp stdout: %w", err)
+	}
+	// goose logs startup chatter on stderr; it is discarded, never parsed and
+	// never logged (it could echo config details).
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("goose acp start: %w", err)
+	}
+	inv, exchErr := gooseACPExchange(ctx, stdin, stdout, cwd)
+	// Closing stdin is the ACP server's shutdown signal (after it drains the
+	// best-effort session/close). Give it a short grace to exit on its own,
+	// then kill; either way Wait reaps the process. A nonzero exit after a
+	// successful exchange is irrelevant.
+	_ = stdin.Close()
+	waitDone := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(waitDone)
+	}()
+	select {
+	case <-waitDone:
+	case <-time.After(gooseACPShutdownGrace):
+		_ = cmd.Process.Kill()
+		<-waitDone
+	}
+	return inv, exchErr
+}
+
+// gooseACPRequest writes one newline-delimited JSON-RPC 2.0 request.
+func gooseACPRequest(w io.Writer, id int, method string, params any) error {
+	msg, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"method":  method,
+		"params":  params,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", method, err)
+	}
+	if _, err := w.Write(append(msg, '\n')); err != nil {
+		return fmt.Errorf("write %s: %w", method, err)
+	}
+	return nil
+}
+
+// gooseACPAwait reads newline-delimited JSON-RPC messages until the response
+// carrying the given id arrives, skipping notifications and agent-initiated
+// requests (anything carrying a method). Honors ctx.
+func gooseACPAwait(ctx context.Context, lines <-chan []byte, id int) (json.RawMessage, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("awaiting goose acp response %d: %w", id, ctx.Err())
+		case line, ok := <-lines:
+			if !ok {
+				return nil, fmt.Errorf("goose acp stream ended awaiting response %d", id)
+			}
+			var msg struct {
+				ID     *int            `json:"id"`
+				Method string          `json:"method"`
+				Result json.RawMessage `json:"result"`
+				Error  *struct {
+					Code    int    `json:"code"`
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(line, &msg); err != nil {
+				continue // non-JSON chatter — skip, like notifications
+			}
+			if msg.Method != "" || msg.ID == nil || *msg.ID != id {
+				continue
+			}
+			if msg.Error != nil {
+				return nil, fmt.Errorf("goose acp error %d on request %d: %s", msg.Error.Code, id, msg.Error.Message)
+			}
+			return msg.Result, nil
+		}
+	}
+}
+
+// gooseACPExchange speaks the fixed probe sequence over an already-connected
+// stdio pair (factored off the process plumbing so tests can feed canned
+// responses through pipes):
+//
+//	initialize (protocolVersion 1) → session/new (cwd, no MCP servers) →
+//	parse result.models → best-effort session/close.
+//
+// session/close matters: every session/new persists a session (plus inventory
+// rows) into goose's sessions.db under the probe HOME, and closing the session
+// (the capability is advertised by goose 1.37) keeps repeated probes from
+// accumulating rows. Close failures are ignored — the inventory is already in
+// hand.
+func gooseACPExchange(ctx context.Context, w io.Writer, r io.Reader, cwd string) (*gooseACPModels, error) {
+	lines := make(chan []byte)
+	go func() {
+		defer close(lines)
+		sc := bufio.NewScanner(r)
+		sc.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), gooseACPMaxLineBytes)
+		for sc.Scan() {
+			line := strings.TrimSpace(sc.Text())
+			if line == "" {
+				continue
+			}
+			select {
+			case lines <- []byte(line):
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	initParams := map[string]any{
+		"protocolVersion": gooseACPProtocolVersion,
+		"clientCapabilities": map[string]any{
+			// The probe serves no filesystem to the agent.
+			"fs": map[string]bool{"readTextFile": false, "writeTextFile": false},
+		},
+		"clientInfo": map[string]string{"name": gooseACPClientName, "version": gooseACPClientVersion},
+	}
+	if err := gooseACPRequest(w, gooseACPInitializeID, "initialize", initParams); err != nil {
+		return nil, err
+	}
+	if _, err := gooseACPAwait(ctx, lines, gooseACPInitializeID); err != nil {
+		return nil, err
+	}
+
+	newParams := map[string]any{"cwd": cwd, "mcpServers": []any{}}
+	if err := gooseACPRequest(w, gooseACPSessionNewID, "session/new", newParams); err != nil {
+		return nil, err
+	}
+	result, err := gooseACPAwait(ctx, lines, gooseACPSessionNewID)
+	if err != nil {
+		return nil, err
+	}
+
+	var res struct {
+		SessionID string `json:"sessionId"`
+		Models    *struct {
+			CurrentModelID  string `json:"currentModelId"`
+			AvailableModels []struct {
+				ModelID string `json:"modelId"`
+			} `json:"availableModels"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(result, &res); err != nil {
+		return nil, fmt.Errorf("parse session/new result: %w", err)
+	}
+
+	// Best-effort session/close BEFORE returning, whether or not models were
+	// present — session/new persisted a session either way. Fire and forget:
+	// no await, and a write failure is ignored.
+	if res.SessionID != "" {
+		_ = gooseACPRequest(w, gooseACPSessionCloseID, "session/close", map[string]any{"sessionId": res.SessionID})
+	}
+
+	if res.Models == nil {
+		return nil, errGooseModelsAbsent
+	}
+	inv := &gooseACPModels{CurrentModelID: res.Models.CurrentModelID}
+	for _, m := range res.Models.AvailableModels {
+		if m.ModelID == "" {
+			continue
+		}
+		inv.AvailableModels = append(inv.AvailableModels, m.ModelID)
+	}
+	if len(inv.AvailableModels) == 0 {
+		return nil, errGooseModelsAbsent
+	}
+	return inv, nil
 }
 
 // --- helpers ---

--- a/v2/pkg/dashboard/cli_models.go
+++ b/v2/pkg/dashboard/cli_models.go
@@ -1,11 +1,14 @@
 package dashboard
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -85,6 +88,45 @@ const (
 	// copilotEditorVersion is sent as Editor-Version; the Copilot endpoints
 	// require a plausible editor identifier.
 	copilotEditorVersion = "vscode/1.99.0"
+
+	// copilotSDKHelperPath is where the image installs the Node helper that
+	// lists Copilot models through the official @github/copilot-sdk (source:
+	// bin/copilot-models.mjs, COPYed by v2/Dockerfile). The SDK spawns the
+	// pinned copilot CLI as a JSON-RPC server, so the probe rides the CLI's
+	// own stored auth and TLS handling — auth configurations the raw-HTTP
+	// probe below cannot reach (verified live against copilot CLI 1.0.59 in a
+	// hive pod: 25 models via stored device-flow auth behind the egress
+	// proxy). Absent outside the image, in which case the SDK probe is
+	// skipped instantly.
+	copilotSDKHelperPath = "/usr/local/bin/copilot-models.mjs"
+
+	// copilotSDKNodeBinary runs the helper. The helper is plain-Node ESM; it
+	// is invoked explicitly (not via shebang) so no exec bit is needed.
+	copilotSDKNodeBinary = "node"
+
+	// copilotSDKProbeTimeout bounds the helper exec. The helper enforces its
+	// OWN hard deadline (INTERNAL_TIMEOUT_MS = 15s in copilot-models.mjs);
+	// this sits slightly above it so the helper always gets to report its own
+	// error on stderr instead of being killed mid-flight.
+	copilotSDKProbeTimeout = 20 * time.Second
+
+	// copilotSDKAgentHome is the shared agent HOME the copilot CLI's stored
+	// device-flow auth lives under ($HOME/.copilot). Agents launch with
+	// HOME=/data/home (see agent.Manager; on hosted spokes /home/dev symlinks
+	// to it), so the helper is run with the same HOME when the directory
+	// exists — otherwise the server process's own HOME is left in place.
+	copilotSDKAgentHome = "/data/home"
+
+	// copilotSDKStderrLogLimit caps how much helper stderr is folded into the
+	// returned error (and thus a single log line) — enough to diagnose, never
+	// a dump. Helper stderr carries only error text, never tokens.
+	copilotSDKStderrLogLimit = 300
+
+	// copilotPolicyStateEnabled is the SDK policy.state value marking a model
+	// as usable by this account; models carrying any OTHER explicit state are
+	// excluded. Models with no policy at all are kept (the catalog omits
+	// policy for unrestricted models).
+	copilotPolicyStateEnabled = "enabled"
 
 	// copilotAutoModel is the Copilot auto-selection sentinel: `copilot --model
 	// auto` lets the Copilot CLI pick/adjust the optimal model per task instead
@@ -414,12 +456,32 @@ func cliStaticFallback(backend string) []string {
 
 // --- Copilot discovery ---
 
-// discoverCopilotModels lists the chat-capable models available to the stored
-// Copilot token. The api host is itself discovered per-account (public vs
-// enterprise). Best-effort: any failure returns fallback=true with an empty
-// list so the caller substitutes the static list.
+// discoverCopilotModels lists the models available to this hive's Copilot
+// auth. Hardened probe order:
+//
+//  1. the official-SDK helper (copilotSDKHelperPath) — the SDK drives the
+//     installed copilot CLI, so it rides the CLI's own auth resolution and
+//     TLS handling and works in configurations the raw-HTTP probe cannot
+//     reach (e.g. stored device-flow auth with no token surfaced here);
+//  2. the raw HTTP GET <copilot-api>/models probe with the stored token,
+//     where the api host is itself discovered per-account (public vs
+//     enterprise);
+//  3. any failure returns fallback=true with an empty list so the caller
+//     substitutes the static list.
+//
+// Successful results from either live probe feed the same cache/retention
+// machinery (see stabilize) via queryCLIModels.
 func (s *Server) discoverCopilotModels() cliModelResult {
 	token := s.copilotToken()
+
+	if models, err := s.probeCopilotModelsSDK(token); err != nil {
+		s.logger.Info("copilot SDK model discovery unavailable, falling back to HTTP probe", "err", err.Error())
+	} else if len(models) == 0 {
+		s.logger.Info("copilot SDK model discovery returned no models, falling back to HTTP probe")
+	} else {
+		return cliModelResult{models: dedupeModels(models), fallback: false}
+	}
+
 	if token == "" {
 		return cliModelResult{fallback: true}
 	}
@@ -433,11 +495,97 @@ func (s *Server) discoverCopilotModels() cliModelResult {
 	if err != nil || len(models) == 0 {
 		if err != nil {
 			// Do NOT log the token or full URL query; just the failure.
-			s.logger.Warn("copilot model discovery failed", "err", err.Error())
+			s.logger.Warn("copilot HTTP model discovery failed, serving static fallback", "err", err.Error())
 		}
 		return cliModelResult{fallback: true}
 	}
 	return cliModelResult{models: dedupeModels(models), fallback: false}
+}
+
+// runCopilotSDKHelper executes the SDK helper and returns its stdout. A
+// package-level seam (mirroring healthAgentStatuses) so unit tests can
+// substitute helper output without running node or the real CLI.
+var runCopilotSDKHelper = execCopilotSDKHelper
+
+// probeCopilotModelsSDK runs the SDK helper under its own timeout and parses
+// the resulting model ids. token may be empty — the CLI then resolves stored
+// device-flow auth on its own, which is exactly the hardening this path adds.
+func (s *Server) probeCopilotModelsSDK(token string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), copilotSDKProbeTimeout)
+	defer cancel()
+	out, err := runCopilotSDKHelper(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	return parseCopilotSDKModels(out)
+}
+
+// execCopilotSDKHelper is the real helper runner: `node copilot-models.mjs`
+// with the inherited environment plus the agent HOME (stored CLI auth) and,
+// when known, the device-flow token. Skips instantly when the helper is not
+// installed (dev machines, unit tests).
+func execCopilotSDKHelper(ctx context.Context, token string) ([]byte, error) {
+	if _, err := os.Stat(copilotSDKHelperPath); err != nil {
+		return nil, fmt.Errorf("sdk helper not installed: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, copilotSDKNodeBinary, copilotSDKHelperPath)
+	// os/exec documents that for duplicate keys the LAST value wins, so
+	// appending overrides the inherited values.
+	env := os.Environ()
+	if st, err := os.Stat(copilotSDKAgentHome); err == nil && st.IsDir() {
+		env = append(env, "HOME="+copilotSDKAgentHome)
+	}
+	if token != "" {
+		// The copilot CLI honors COPILOT_GITHUB_TOKEN; the device-flow token
+		// may exist only in the agent manager's memory. Secret — never logged.
+		env = append(env, "COPILOT_GITHUB_TOKEN="+token)
+	}
+	cmd.Env = env
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if len(msg) > copilotSDKStderrLogLimit {
+			msg = msg[:copilotSDKStderrLogLimit]
+		}
+		return nil, fmt.Errorf("sdk helper: %w (stderr: %s)", err, msg)
+	}
+	return stdout.Bytes(), nil
+}
+
+// copilotSDKModel mirrors one entry of the helper's stdout JSON. The helper
+// also emits name/efforts/defaultEffort for future use; discovery only needs
+// the id and the policy gate today.
+type copilotSDKModel struct {
+	ID          string `json:"id"`
+	PolicyState string `json:"policyState"`
+}
+
+// parseCopilotSDKModels decodes the helper output ({"models":[...]}) and
+// returns usable model ids: models carrying an explicit policy state other
+// than "enabled" are excluded, as is the "auto" pseudo-entry — the dropdown
+// pipeline expects real catalog ids and re-appends the auto sentinel itself
+// via copilotAlwaysIncludeModels (matching the raw-HTTP probe, whose catalog
+// never returns "auto").
+func parseCopilotSDKModels(data []byte) ([]string, error) {
+	var body struct {
+		Models []copilotSDKModel `json:"models"`
+	}
+	if err := json.Unmarshal(data, &body); err != nil {
+		return nil, fmt.Errorf("parse sdk helper output: %w", err)
+	}
+	var out []string
+	for _, m := range body.Models {
+		if m.ID == "" || m.ID == copilotAutoModel {
+			continue
+		}
+		if m.PolicyState != "" && m.PolicyState != copilotPolicyStateEnabled {
+			continue
+		}
+		out = append(out, m.ID)
+	}
+	return out, nil
 }
 
 // copilotToken resolves the Copilot GitHub OAuth token from the agent manager

--- a/v2/pkg/dashboard/cli_models.go
+++ b/v2/pkg/dashboard/cli_models.go
@@ -53,6 +53,10 @@ import (
 //     pre-1.37 goose omits the models key from the session/new result (the
 //     clean fallback signal); that, a missing binary, or any error falls
 //     back to a curated per-provider static list.
+//   - codex:   `codex app-server` (stdio JSON-RPC) answers model/list with
+//     the catalog BAKED INTO the installed CLI binary — per-CLI-version, not
+//     per-account (the per-account remote_models fetch was removed upstream),
+//     and fully unauthenticated. See cli_models_codex.go.
 //
 // Every discovery is BEST-EFFORT: a failed or absent probe falls back to a
 // current static list so a dropdown is never empty and never errors. Results
@@ -338,19 +342,26 @@ var claudeAlwaysIncludeModels = []string{
 // either does nothing or breaks inference.
 var bobStaticModels = []string{bobAutoModel}
 
-// codexStaticModels is the maintained list for the OpenAI Codex CLI. Codex only
-// accepts OpenAI models — Claude ids are rejected with a ChatGPT account
-// ("model is not supported when using Codex with a ChatGPT account"), so codex
-// must never fall through to the copilot list. Order mirrors `codex /model`
-// (sol is the default). Keep CURRENT with the Codex CLI's model set.
+// codexStaticModels is the fallback for the OpenAI Codex CLI, served when the
+// `codex app-server` model/list probe cannot run (binary absent — the case on
+// hosted spokes) or fails (see cli_models_codex.go). Codex only accepts OpenAI
+// models — Claude ids are rejected with a ChatGPT account ("model is not
+// supported when using Codex with a ChatGPT account"), so codex must never
+// fall through to the copilot list. The catalog is baked into the CLI binary
+// (per-CLI-version, not per-account); this snapshot matches codex 0.146.0:
+// visible ids in picker order (sol is the default), then the hidden ids —
+// hidden entries are still valid --model values (see orderCodexServedModels).
+// Keep in sync with CODEX_CLI_MODELS in static/index.html.
 var codexStaticModels = []string{
 	"gpt-5.6-sol",
 	"gpt-5.6-terra",
 	"gpt-5.6-luna",
 	"gpt-5.5",
+	"gpt-5.2",
+	// Hidden in the 0.146.0 picker but still valid --model values.
 	"gpt-5.4",
 	"gpt-5.4-mini",
-	"gpt-5.3-codex-spark",
+	"codex-auto-review",
 }
 
 // geminiStaticModels is the fallback when no Gemini API key is configured (or
@@ -509,9 +520,7 @@ func (s *Server) queryCLIModels(backend string) cliModelResult {
 	case "claude":
 		r = s.discoverClaudeModels()
 	case "codex":
-		// No probe wired yet; the maintained static list is authoritative and
-		// OpenAI-only (Claude ids are rejected by Codex with a ChatGPT account).
-		r = cliModelResult{models: dedupeModels(codexStaticModels), fallback: false}
+		r = s.discoverCodexModels()
 	case bobBackendID:
 		// bob picks its own model and exposes no catalog, so there is nothing
 		// to discover. The single auto sentinel is authoritative (not a

--- a/v2/pkg/dashboard/cli_models_claude_test.go
+++ b/v2/pkg/dashboard/cli_models_claude_test.go
@@ -1,0 +1,308 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/claude"
+)
+
+// withoutClaudeCredentials makes the claude discovery credential resolution
+// deterministic and offline: no ANTHROPIC_API_KEY, an empty temp HOME, and the
+// hosted-pod credentials path redirected to a nonexistent temp file. Restores
+// the path seam on cleanup.
+func withoutClaudeCredentials(t *testing.T) {
+	t.Helper()
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("HOME", t.TempDir())
+	orig := claudePodCredentialsPath
+	claudePodCredentialsPath = filepath.Join(t.TempDir(), "absent", ".credentials.json")
+	t.Cleanup(func() { claudePodCredentialsPath = orig })
+}
+
+// writeClaudeCredentials writes a credentials file in the CLI's on-disk shape
+// under a temp HOME and points $HOME at it. The hosted-pod path seam is
+// redirected to a nonexistent file so a real /data volume (if present) can
+// never leak into the test. Returns the file path.
+func writeClaudeCredentials(t *testing.T, token string, expiresAt int64) string {
+	t.Helper()
+	orig := claudePodCredentialsPath
+	claudePodCredentialsPath = filepath.Join(t.TempDir(), "absent", ".credentials.json")
+	t.Cleanup(func() { claudePodCredentialsPath = orig })
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, ".credentials.json")
+	creds := claude.Credentials{ClaudeAIOAuth: &claude.OAuthTokens{
+		AccessToken: token,
+		ExpiresAt:   expiresAt,
+	}}
+	data, err := json.Marshal(creds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// redirectAnthropicEndpoint points the models probe at a test server and
+// restores it on cleanup.
+func redirectAnthropicEndpoint(t *testing.T, url string) {
+	t.Helper()
+	orig := anthropicModelsEndpoint
+	anthropicModelsEndpoint = url
+	t.Cleanup(func() { anthropicModelsEndpoint = orig })
+}
+
+// futureExpiryMs returns a millisecond-epoch expiry comfortably outside the
+// skew window.
+func futureExpiryMs() int64 {
+	return time.Now().Add(claudeTokenExpirySkew + time.Hour).UnixMilli()
+}
+
+// --- credentials parsing ---
+
+func TestReadFreshClaudeToken_Valid(t *testing.T) {
+	path := writeClaudeCredentials(t, "sk-ant-oat-test", futureExpiryMs())
+	if got := readFreshClaudeToken(path); got != "sk-ant-oat-test" {
+		t.Fatalf("got %q, want the stored token", got)
+	}
+}
+
+func TestReadFreshClaudeToken_AbsentFile(t *testing.T) {
+	if got := readFreshClaudeToken(filepath.Join(t.TempDir(), "nope.json")); got != "" {
+		t.Fatalf("absent file must yield empty token, got %q", got)
+	}
+}
+
+func TestReadFreshClaudeToken_Malformed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".credentials.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := readFreshClaudeToken(path); got != "" {
+		t.Fatalf("malformed file must yield empty token, got %q", got)
+	}
+}
+
+func TestReadFreshClaudeToken_Expired(t *testing.T) {
+	// Long expired — the copilot-only-spoke case where the file sits stale
+	// for weeks. Must be rejected BEFORE any HTTP call.
+	path := writeClaudeCredentials(t, "tok", time.Now().Add(-24*time.Hour).UnixMilli())
+	if got := readFreshClaudeToken(path); got != "" {
+		t.Fatalf("expired token must yield empty, got %q", got)
+	}
+}
+
+func TestReadFreshClaudeToken_WithinSkewWindow(t *testing.T) {
+	// Not yet expired, but inside the skew margin — treated as expired so a
+	// few seconds of clock skew can't turn the probe into a doomed 401.
+	path := writeClaudeCredentials(t, "tok", time.Now().Add(claudeTokenExpirySkew/2).UnixMilli())
+	if got := readFreshClaudeToken(path); got != "" {
+		t.Fatalf("token inside skew window must yield empty, got %q", got)
+	}
+}
+
+// --- credential precedence ---
+
+func TestClaudeAPICredential_EnvKeyPrecedence(t *testing.T) {
+	// A valid OAuth file exists, but ANTHROPIC_API_KEY must win with x-api-key.
+	writeClaudeCredentials(t, "oauth-token", futureExpiryMs())
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-api-key")
+	header, value, ok := claudeAPICredential()
+	if !ok || header != "x-api-key" || value != "sk-ant-api-key" {
+		t.Fatalf("env key must win: got %q=%q ok=%v", header, value, ok)
+	}
+}
+
+func TestClaudeAPICredential_OAuthBearerFromHome(t *testing.T) {
+	writeClaudeCredentials(t, "oauth-token", futureExpiryMs())
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	header, value, ok := claudeAPICredential()
+	if !ok || header != "Authorization" || value != "Bearer oauth-token" {
+		t.Fatalf("expected bearer from $HOME credentials: got %q=%q ok=%v", header, value, ok)
+	}
+}
+
+func TestClaudeAPICredential_NoneAvailable(t *testing.T) {
+	withoutClaudeCredentials(t)
+	if _, _, ok := claudeAPICredential(); ok {
+		t.Fatal("no env key and no file must yield ok=false")
+	}
+}
+
+// --- discovery over httptest (never the real API) ---
+
+// claudeModelsTestServer serves a canned /v1/models body and records the
+// request headers for assertion.
+func claudeModelsTestServer(t *testing.T, status int, body string, gotHeaders *http.Header) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if gotHeaders != nil {
+			*gotHeaders = r.Header.Clone()
+		}
+		if r.URL.Query().Get("limit") == "" {
+			t.Error("models request missing ?limit= page-size parameter")
+		}
+		w.WriteHeader(status)
+		w.Write([]byte(body))
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestDiscoverClaudeModels_LiveSuccess(t *testing.T) {
+	writeClaudeCredentials(t, "oauth-token", futureExpiryMs())
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	var hdr http.Header
+	ts := claudeModelsTestServer(t, http.StatusOK,
+		`{"data":[{"id":"claude-opus-5","type":"model"},{"id":"claude-sonnet-5","type":"model"},{"id":""}]}`, &hdr)
+	redirectAnthropicEndpoint(t, ts.URL)
+
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverClaudeModels()
+	if r.fallback {
+		t.Fatal("successful probe must not be marked fallback")
+	}
+	if !equalStrings(r.models, []string{"claude-opus-5", "claude-sonnet-5"}) {
+		t.Fatalf("got %v, want the two non-empty live ids", r.models)
+	}
+	// OAuth request shape: bearer + version + oauth beta.
+	if got := hdr.Get("Authorization"); got != "Bearer oauth-token" {
+		t.Fatalf("Authorization = %q", got)
+	}
+	if got := hdr.Get("anthropic-version"); got != anthropicAPIVersion {
+		t.Fatalf("anthropic-version = %q", got)
+	}
+	if got := hdr.Get("anthropic-beta"); got != anthropicOAuthBeta {
+		t.Fatalf("anthropic-beta = %q", got)
+	}
+}
+
+func TestDiscoverClaudeModels_APIKeyHeader(t *testing.T) {
+	withoutClaudeCredentials(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-key")
+	var hdr http.Header
+	ts := claudeModelsTestServer(t, http.StatusOK, `{"data":[{"id":"claude-opus-5"}]}`, &hdr)
+	redirectAnthropicEndpoint(t, ts.URL)
+
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverClaudeModels()
+	if r.fallback || !equalStrings(r.models, []string{"claude-opus-5"}) {
+		t.Fatalf("got %+v, want live single-id result", r)
+	}
+	if got := hdr.Get("x-api-key"); got != "sk-ant-key" {
+		t.Fatalf("x-api-key = %q", got)
+	}
+	if hdr.Get("Authorization") != "" {
+		t.Fatal("API-key path must not send an Authorization header")
+	}
+}
+
+func TestDiscoverClaudeModels_Unauthorized(t *testing.T) {
+	writeClaudeCredentials(t, "stale-but-unexpired", futureExpiryMs())
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	ts := claudeModelsTestServer(t, http.StatusUnauthorized, `{"error":{"type":"authentication_error"}}`, nil)
+	redirectAnthropicEndpoint(t, ts.URL)
+
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	if r := s.discoverClaudeModels(); !r.fallback || len(r.models) != 0 {
+		t.Fatalf("401 must yield empty fallback result, got %+v", r)
+	}
+}
+
+func TestDiscoverClaudeModels_MalformedBody(t *testing.T) {
+	writeClaudeCredentials(t, "tok", futureExpiryMs())
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	ts := claudeModelsTestServer(t, http.StatusOK, `{not json`, nil)
+	redirectAnthropicEndpoint(t, ts.URL)
+
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	if r := s.discoverClaudeModels(); !r.fallback || len(r.models) != 0 {
+		t.Fatalf("malformed body must yield empty fallback result, got %+v", r)
+	}
+}
+
+func TestDiscoverClaudeModels_ExpiredSkipsHTTP(t *testing.T) {
+	// The expired-token path must never reach the network: the test server
+	// fails the test if it receives any request.
+	writeClaudeCredentials(t, "tok", time.Now().Add(-time.Hour).UnixMilli())
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("expired credentials must not trigger an HTTP call")
+	}))
+	t.Cleanup(ts.Close)
+	redirectAnthropicEndpoint(t, ts.URL)
+
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	if r := s.discoverClaudeModels(); !r.fallback {
+		t.Fatalf("expired token must fall back, got %+v", r)
+	}
+}
+
+func TestParseClaudeModelsResponse_Malformed(t *testing.T) {
+	if _, err := parseClaudeModelsResponse(strings.NewReader("nope")); err == nil {
+		t.Fatal("expected error on malformed body")
+	}
+}
+
+// --- full queryCLIModels paths: aliases + auto-heal exclusion semantics ---
+
+func TestQueryCLIModels_ClaudeAliasesOnLivePath(t *testing.T) {
+	writeClaudeCredentials(t, "tok", futureExpiryMs())
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	ts := claudeModelsTestServer(t, http.StatusOK,
+		`{"data":[{"id":"claude-opus-5"},{"id":"claude-sonnet-5"}]}`, nil)
+	redirectAnthropicEndpoint(t, ts.URL)
+
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.queryCLIModels("claude")
+	if r.fallback {
+		t.Fatalf("live probe must not be fallback: %+v", r)
+	}
+	if !contains(r.models, "claude-opus-5") {
+		t.Fatalf("live id missing: %v", r.models)
+	}
+	for _, alias := range claudeAlwaysIncludeModels {
+		if !contains(r.models, alias) {
+			t.Fatalf("alias %q must survive the live path (API never returns it): %v", alias, r.models)
+		}
+	}
+	// Live data IS usable for validation/auto-heal — and the appended aliases
+	// are part of the cached list, so auto-heal can never heal an agent off a
+	// bare-alias selection.
+	ids := s.modelIDsForBackend("claude")
+	if len(ids) == 0 {
+		t.Fatal("modelIDsForBackend must return live claude ids")
+	}
+	for _, alias := range claudeAlwaysIncludeModels {
+		if !contains(ids, alias) {
+			t.Fatalf("alias %q missing from validation ids: %v", alias, ids)
+		}
+	}
+}
+
+func TestQueryCLIModels_ClaudeFallbackExcludedFromAutoHeal(t *testing.T) {
+	withoutClaudeCredentials(t)
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.queryCLIModels("claude")
+	if !r.fallback {
+		t.Fatalf("no-credential claude must be fallback, got %+v", r)
+	}
+	// Fallback (static) data is a maintained guess, not the account's
+	// inventory — it must never drive validation or model auto-heal.
+	if ids := s.modelIDsForBackend("claude"); ids != nil {
+		t.Fatalf("fallback claude data must yield nil validation ids, got %v", ids)
+	}
+}

--- a/v2/pkg/dashboard/cli_models_codex.go
+++ b/v2/pkg/dashboard/cli_models_codex.go
@@ -1,0 +1,326 @@
+package dashboard
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// Live model discovery for the OpenAI Codex CLI.
+//
+// `codex app-server` speaks a newline-delimited JSON-RPC-style protocol over
+// stdio (the "v2 app-server protocol", documented in openai/codex
+// codex-rs/app-server/README.md) and exposes a `model/list` request. The
+// returned catalog is BAKED INTO the installed CLI binary — it is
+// per-CLI-VERSION, not per-account: the per-account `remote_models` fetch was
+// a feature flag that has been removed upstream, and the probe works with a
+// completely empty, unauthenticated CODEX_HOME (verified live against codex
+// 0.146.0; round-trip ~0.5s).
+//
+// CODEX_HOME rule: the app-server WRITES into CODEX_HOME (sqlite, lock files,
+// installation_id) and requires ownership of it, so the probe always runs
+// with CODEX_HOME overridden to a throwaway temp dir the dashboard owns —
+// NEVER an agent's own `.codex-<id>` home, whose locks/state must not be
+// touched by a probe.
+//
+// Failure semantics mirror the copilot SDK probe: any failure (binary
+// missing, spawn error, handshake timeout, parse error, empty data) yields an
+// empty result so queryCLIModels serves the static list with fallback=true.
+// On hosted spokes the main image does not install codex at all, so the probe
+// degrades instantly to the fallback there — expected and fine.
+
+const (
+	// codexBinaryName is the Codex CLI binary probed on PATH. When absent the
+	// probe is skipped instantly and the static fallback is served.
+	codexBinaryName = "codex"
+
+	// codexAppServerArg is the subcommand that starts the stdio JSON-RPC
+	// app-server the probe speaks to.
+	codexAppServerArg = "app-server"
+
+	// codexProbeTimeout bounds the whole spawn+handshake+model/list exchange.
+	// The measured live round-trip is ~0.5s; 10s leaves generous headroom for
+	// cold page cache without letting a wedged binary stall the caller.
+	codexProbeTimeout = 10 * time.Second
+
+	// codexRPCClientName / codexRPCClientVersion identify this probe in the
+	// mandatory initialize clientInfo. Values are informational to the server
+	// but required by the protocol.
+	codexRPCClientName    = "hive-dashboard"
+	codexRPCClientVersion = "1.0.0"
+
+	// codexProbeHomePrefix names the throwaway per-probe CODEX_HOME temp dir
+	// (see the CODEX_HOME rule above). Removed after every probe.
+	codexProbeHomePrefix = "hive-codex-probe-"
+
+	// codexRPCInitializeID / codexRPCModelListID are the JSON-RPC request ids
+	// for the two requests the probe sends. Arbitrary but fixed so responses
+	// can be matched among interleaved server notifications.
+	codexRPCInitializeID = 1
+	codexRPCModelListID  = 2
+
+	// codexRPCInitializedMethod is the notification the app-server emits once
+	// the initialize handshake is accepted.
+	codexRPCInitializedMethod = "initialized"
+
+	// codexRPCModelListMethod is the request returning the model catalog.
+	codexRPCModelListMethod = "model/list"
+
+	// codexRPCMaxLineBytes caps a single scanned protocol line. The model/list
+	// response is small (a few KB), but the default bufio.Scanner limit (64KB)
+	// is raised defensively so a verbose future response cannot break parsing.
+	codexRPCMaxLineBytes = 1 << 20
+
+	// codexRPCErrorLogLimit caps how much of a JSON-RPC error object is folded
+	// into a returned error (and thus a log line) — enough to diagnose, never
+	// a full response-body dump.
+	codexRPCErrorLogLimit = 300
+)
+
+// codexModelEntry mirrors one element of the model/list response data array.
+// The server also emits displayName/defaultReasoningEffort/
+// supportedReasoningEfforts; discovery only needs the id and the
+// hidden/default flags today.
+type codexModelEntry struct {
+	ID        string `json:"id"`
+	Model     string `json:"model"`
+	IsDefault bool   `json:"isDefault"`
+	Hidden    bool   `json:"hidden"`
+}
+
+// codexRPCMessage is the envelope of one newline-delimited protocol message.
+// The app-server protocol is JSON-RPC-shaped but omits the "jsonrpc":"2.0"
+// field, so none is sent or required here.
+type codexRPCMessage struct {
+	ID     *int64          `json:"id,omitempty"`
+	Method string          `json:"method,omitempty"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  json.RawMessage `json:"error,omitempty"`
+}
+
+// runCodexModelProbe executes the app-server probe and returns the served id
+// order. A package-level seam (mirroring runCopilotSDKHelper) so unit tests
+// can substitute canned results without a real codex binary.
+var runCodexModelProbe = execCodexModelProbe
+
+// discoverCodexModels lists the model catalog of the installed Codex CLI via
+// `codex app-server` model/list. Best-effort: any probe failure returns
+// fallback=true with an empty list so the caller substitutes the static list,
+// exactly like the copilot probe's failure semantics.
+func (s *Server) discoverCodexModels() cliModelResult {
+	models, err := runCodexModelProbe()
+	if err != nil {
+		// Expected on hosted spokes (main image ships no codex binary); the
+		// static fallback keeps the dropdown populated. Never logs bodies.
+		s.logger.Info("codex model discovery unavailable, serving static fallback", "err", err.Error())
+		return cliModelResult{fallback: true}
+	}
+	if len(models) == 0 {
+		return cliModelResult{fallback: true}
+	}
+	return cliModelResult{models: dedupeModels(models), fallback: false}
+}
+
+// execCodexModelProbe is the real prober: spawn `codex app-server` with a
+// throwaway CODEX_HOME, run the initialize handshake and model/list exchange
+// over stdio, then kill and reap the server.
+func execCodexModelProbe() ([]string, error) {
+	if _, err := exec.LookPath(codexBinaryName); err != nil {
+		return nil, fmt.Errorf("codex binary not on PATH: %w", err)
+	}
+
+	// Throwaway dashboard-owned CODEX_HOME (see the CODEX_HOME rule in the
+	// file header); removed after the probe.
+	home, err := os.MkdirTemp("", codexProbeHomePrefix)
+	if err != nil {
+		return nil, fmt.Errorf("create probe CODEX_HOME: %w", err)
+	}
+	defer os.RemoveAll(home)
+
+	ctx, cancel := context.WithTimeout(context.Background(), codexProbeTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, codexBinaryName, codexAppServerArg)
+	// os/exec documents that for duplicate keys the LAST value wins, so
+	// appending overrides any inherited CODEX_HOME.
+	cmd.Env = append(os.Environ(), "CODEX_HOME="+home)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("app-server stdin: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("app-server stdout: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("spawn app-server: %w", err)
+	}
+	// The server runs until killed; always reap it so no zombie is left. On
+	// timeout the CommandContext kill closes the pipes, which surfaces in the
+	// exchange as a read error.
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	entries, err := codexModelListExchange(stdin, stdout)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("app-server probe timed out: %w", ctx.Err())
+		}
+		return nil, err
+	}
+	return orderCodexServedModels(entries), nil
+}
+
+// codexModelListExchange drives the newline-delimited protocol over the given
+// transport: initialize (with mandatory clientInfo), wait for the handshake
+// acknowledgement, then model/list with includeHidden:true. Factored over
+// io.Writer/io.Reader so tests can feed canned stdout without a real binary.
+func codexModelListExchange(in io.Writer, out io.Reader) ([]codexModelEntry, error) {
+	sc := bufio.NewScanner(out)
+	sc.Buffer(make([]byte, 0, 4096), codexRPCMaxLineBytes)
+
+	if err := writeCodexRPC(in, map[string]any{
+		"id":     codexRPCInitializeID,
+		"method": "initialize",
+		"params": map[string]any{
+			"clientInfo": map[string]any{
+				"name":    codexRPCClientName,
+				"version": codexRPCClientVersion,
+			},
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("send initialize: %w", err)
+	}
+
+	// The handshake is complete once the server answers the initialize
+	// request or emits the `initialized` notification — accept whichever
+	// arrives first (any duplicate is skipped by the model/list loop below).
+	for {
+		msg, err := readCodexRPC(sc)
+		if err != nil {
+			return nil, fmt.Errorf("initialize handshake: %w", err)
+		}
+		if msg.ID != nil && *msg.ID == codexRPCInitializeID {
+			if len(msg.Error) != 0 {
+				return nil, fmt.Errorf("initialize rejected: %s", truncateForLog(msg.Error, codexRPCErrorLogLimit))
+			}
+			break
+		}
+		if msg.Method == codexRPCInitializedMethod {
+			break
+		}
+	}
+
+	// includeHidden:true — hidden ids are deliberately requested and served
+	// (see orderCodexServedModels for why).
+	if err := writeCodexRPC(in, map[string]any{
+		"id":     codexRPCModelListID,
+		"method": codexRPCModelListMethod,
+		"params": map[string]any{"includeHidden": true},
+	}); err != nil {
+		return nil, fmt.Errorf("send model/list: %w", err)
+	}
+
+	for {
+		msg, err := readCodexRPC(sc)
+		if err != nil {
+			return nil, fmt.Errorf("model/list: %w", err)
+		}
+		if msg.ID == nil || *msg.ID != codexRPCModelListID {
+			continue // server notification or stray message — skip
+		}
+		if len(msg.Error) != 0 {
+			return nil, fmt.Errorf("model/list rejected: %s", truncateForLog(msg.Error, codexRPCErrorLogLimit))
+		}
+		var result struct {
+			Data []codexModelEntry `json:"data"`
+		}
+		if err := json.Unmarshal(msg.Result, &result); err != nil {
+			return nil, fmt.Errorf("parse model/list result: %w", err)
+		}
+		if len(result.Data) == 0 {
+			return nil, errors.New("model/list returned no models")
+		}
+		return result.Data, nil
+	}
+}
+
+// orderCodexServedModels builds the served id order from a model/list result:
+// visible models first in the server's returned (picker) order with the
+// isDefault entry promoted to the front, then hidden ids appended at the end.
+//
+// Hidden ids are included on purpose: they are still valid `--model` values
+// (e.g. gpt-5.4 at codex 0.146.0), and excluding them would let the
+// stabilize/auto-heal machinery migrate agents off a working pinned model the
+// moment a CLI upgrade hides it from the picker.
+func orderCodexServedModels(entries []codexModelEntry) []string {
+	var def, visible, hidden []string
+	for _, e := range entries {
+		id := e.ID
+		if id == "" {
+			// The catalog id and underlying model slug are usually identical;
+			// tolerate an entry that only carries the latter.
+			id = e.Model
+		}
+		if id == "" {
+			continue
+		}
+		switch {
+		case e.Hidden:
+			hidden = append(hidden, id)
+		case e.IsDefault:
+			def = append(def, id)
+		default:
+			visible = append(visible, id)
+		}
+	}
+	return append(append(def, visible...), hidden...)
+}
+
+// writeCodexRPC marshals one protocol message and writes it newline-delimited.
+func writeCodexRPC(in io.Writer, msg map[string]any) error {
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	_, err = in.Write(append(b, '\n'))
+	return err
+}
+
+// readCodexRPC scans the next non-empty protocol line and decodes its
+// envelope. A non-JSON line is a protocol violation, not something to skip.
+func readCodexRPC(sc *bufio.Scanner) (codexRPCMessage, error) {
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var msg codexRPCMessage
+		if err := json.Unmarshal(line, &msg); err != nil {
+			return codexRPCMessage{}, fmt.Errorf("malformed protocol line: %w", err)
+		}
+		return msg, nil
+	}
+	if err := sc.Err(); err != nil {
+		return codexRPCMessage{}, err
+	}
+	return codexRPCMessage{}, io.ErrUnexpectedEOF
+}
+
+// truncateForLog bounds raw upstream bytes destined for an error/log line.
+func truncateForLog(b []byte, limit int) string {
+	s := string(b)
+	if len(s) > limit {
+		return s[:limit]
+	}
+	return s
+}

--- a/v2/pkg/dashboard/cli_models_codex_test.go
+++ b/v2/pkg/dashboard/cli_models_codex_test.go
@@ -1,0 +1,176 @@
+package dashboard
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// swapCodexProbe substitutes the codex probe seam for one test and restores it.
+func swapCodexProbe(t *testing.T, fn func() ([]string, error)) {
+	t.Helper()
+	prev := runCodexModelProbe
+	runCodexModelProbe = fn
+	t.Cleanup(func() { runCodexModelProbe = prev })
+}
+
+// codexCannedStdout builds a canned app-server stdout: initialize response,
+// initialized notification, then the model/list response with the given data.
+func codexCannedStdout(data string) *bytes.Buffer {
+	return bytes.NewBufferString(
+		`{"id":1,"result":{}}` + "\n" +
+			`{"method":"initialized"}` + "\n" +
+			`{"id":2,"result":{"data":[` + data + `]}}` + "\n")
+}
+
+// TestCodexModelListExchange_HiddenOrdering verifies the served order: visible
+// models in returned (picker) order with the isDefault entry promoted first,
+// then hidden ids appended at the end — hidden ids are still valid --model
+// values and must survive so auto-heal cannot migrate agents off them.
+func TestCodexModelListExchange_HiddenOrdering(t *testing.T) {
+	stdout := codexCannedStdout(strings.Join([]string{
+		`{"id":"gpt-5.6-terra","model":"gpt-5.6-terra","displayName":"GPT-5.6 Terra"}`,
+		`{"id":"gpt-5.4","model":"gpt-5.4","hidden":true}`,
+		`{"id":"gpt-5.6-sol","model":"gpt-5.6-sol","isDefault":true}`,
+		`{"id":"gpt-5.5","model":"gpt-5.5"}`,
+		`{"id":"gpt-5.4-mini","model":"gpt-5.4-mini","hidden":true}`,
+	}, ","))
+	var stdin bytes.Buffer
+	entries, err := codexModelListExchange(&stdin, stdout)
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	got := orderCodexServedModels(entries)
+	want := []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini"}
+	if !equalStrings(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	// The exchange must have requested hidden models explicitly.
+	if !strings.Contains(stdin.String(), `"includeHidden":true`) {
+		t.Fatalf("model/list request missing includeHidden:true: %s", stdin.String())
+	}
+	if !strings.Contains(stdin.String(), `"clientInfo"`) {
+		t.Fatalf("initialize request missing clientInfo: %s", stdin.String())
+	}
+}
+
+// TestCodexModelListExchange_Malformed verifies a non-JSON protocol line is a
+// hard error (→ fallback), never silently skipped.
+func TestCodexModelListExchange_Malformed(t *testing.T) {
+	var stdin bytes.Buffer
+	if _, err := codexModelListExchange(&stdin, bytes.NewBufferString("garbage\n")); err == nil {
+		t.Fatal("expected error on malformed protocol line")
+	}
+}
+
+// TestCodexModelListExchange_TruncatedStream verifies a stream that ends
+// before the model/list response (the shape a killed-on-timeout process
+// produces: pipes close, reads hit EOF) surfaces as an error.
+func TestCodexModelListExchange_TruncatedStream(t *testing.T) {
+	var stdin bytes.Buffer
+	stdout := bytes.NewBufferString(`{"id":1,"result":{}}` + "\n")
+	if _, err := codexModelListExchange(&stdin, stdout); err == nil {
+		t.Fatal("expected error on stream truncated before model/list response")
+	}
+}
+
+// TestCodexModelListExchange_RPCError verifies an error response to
+// model/list is an error, not an empty success.
+func TestCodexModelListExchange_RPCError(t *testing.T) {
+	var stdin bytes.Buffer
+	stdout := bytes.NewBufferString(
+		`{"id":1,"result":{}}` + "\n" +
+			`{"id":2,"error":{"code":-32601,"message":"nope"}}` + "\n")
+	if _, err := codexModelListExchange(&stdin, stdout); err == nil {
+		t.Fatal("expected error on model/list error response")
+	}
+}
+
+// TestCodexModelListExchange_EmptyData verifies zero models is treated as a
+// failed probe rather than served as a live empty list.
+func TestCodexModelListExchange_EmptyData(t *testing.T) {
+	var stdin bytes.Buffer
+	if _, err := codexModelListExchange(&stdin, codexCannedStdout("")); err == nil {
+		t.Fatal("expected error on empty model/list data")
+	}
+}
+
+// TestQueryCLIModels_CodexProbeSuccess verifies a successful probe is served
+// live (fallback=false) through the full pipeline, including stabilize.
+func TestQueryCLIModels_CodexProbeSuccess(t *testing.T) {
+	swapCodexProbe(t, func() ([]string, error) {
+		return []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.4"}, nil
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.queryCLIModels("codex")
+	if r.fallback {
+		t.Fatalf("live probe result must not be fallback: %+v", r)
+	}
+	if !equalStrings(r.models, []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.4"}) {
+		t.Fatalf("got %v, want probe order preserved", r.models)
+	}
+}
+
+// TestQueryCLIModels_CodexBinaryMissingFallsBack verifies the no-binary case
+// (hosted spokes: the main image ships no codex) serves the static list
+// marked fallback=true.
+func TestQueryCLIModels_CodexBinaryMissingFallsBack(t *testing.T) {
+	swapCodexProbe(t, func() ([]string, error) {
+		return nil, errors.New("codex binary not on PATH")
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.queryCLIModels("codex")
+	if !r.fallback {
+		t.Fatalf("missing binary must serve fallback, got %+v", r)
+	}
+	if !equalStrings(r.models, dedupeModels(codexStaticModels)) {
+		t.Fatalf("fallback must be the static list, got %v", r.models)
+	}
+}
+
+// TestQueryCLIModels_CodexTimeoutFallsBack verifies a handshake timeout is a
+// plain probe failure → static fallback.
+func TestQueryCLIModels_CodexTimeoutFallsBack(t *testing.T) {
+	swapCodexProbe(t, func() ([]string, error) {
+		return nil, context.DeadlineExceeded
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	if r := s.queryCLIModels("codex"); !r.fallback || len(r.models) == 0 {
+		t.Fatalf("timeout must serve non-empty static fallback, got %+v", r)
+	}
+}
+
+// TestQueryCLIModels_CodexResultsFeedRetention verifies live codex results
+// ride the same stabilize/retention machinery as the other backends: a model
+// seen in one live sample survives its absence from the next.
+func TestQueryCLIModels_CodexResultsFeedRetention(t *testing.T) {
+	sample := []string{"gpt-5.6-sol", "gpt-5.4"}
+	swapCodexProbe(t, func() ([]string, error) {
+		return append([]string(nil), sample...), nil
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	if r := s.queryCLIModels("codex"); !contains(r.models, "gpt-5.4") {
+		t.Fatalf("first live sample missing id: %v", r.models)
+	}
+	sample = []string{"gpt-5.6-sol"}
+	s.cliModels.entries = map[string]cliModelCacheEntry{}
+	r := s.queryCLIModels("codex")
+	if r.fallback {
+		t.Fatalf("live result must not be fallback: %+v", r)
+	}
+	if !contains(r.models, "gpt-5.4") {
+		t.Fatalf("retention should keep recently-seen id through one miss: %v", r.models)
+	}
+}
+
+// TestExecCodexModelProbe_BinaryMissing verifies the real prober degrades
+// instantly (no hang, no panic) when codex is not on PATH — the hosted-spoke
+// situation.
+func TestExecCodexModelProbe_BinaryMissing(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	if _, err := execCodexModelProbe(); err == nil {
+		t.Fatal("expected error when codex binary is absent from PATH")
+	}
+}

--- a/v2/pkg/dashboard/cli_models_coverage_test.go
+++ b/v2/pkg/dashboard/cli_models_coverage_test.go
@@ -11,6 +11,7 @@ import (
 // the static-list, cache, and fallback branches (all offline).
 func TestCovD_QueryCLIModels(t *testing.T) {
 	swapGooseProbe(t, gooseProbeMissing)
+	withoutClaudeCredentials(t)
 	logger := testLoggerCovD()
 	s := NewServer(0, logger)
 

--- a/v2/pkg/dashboard/cli_models_coverage_test.go
+++ b/v2/pkg/dashboard/cli_models_coverage_test.go
@@ -10,6 +10,7 @@ import (
 // TestCovD_QueryCLIModels drives queryCLIModels for every backend, exercising
 // the static-list, cache, and fallback branches (all offline).
 func TestCovD_QueryCLIModels(t *testing.T) {
+	swapGooseProbe(t, gooseProbeMissing)
 	logger := testLoggerCovD()
 	s := NewServer(0, logger)
 
@@ -78,8 +79,11 @@ func TestCovD_DiscoverModelsNoCreds(t *testing.T) {
 	}
 }
 
-// TestCovD_DiscoverGooseModels covers env-driven goose discovery.
+// TestCovD_DiscoverGooseModels covers the env-driven goose static fallback
+// (probe seam pinned to "binary missing" so a locally installed goose cannot
+// make this nondeterministic).
 func TestCovD_DiscoverGooseModels(t *testing.T) {
+	swapGooseProbe(t, gooseProbeMissing)
 	logger := testLoggerCovD()
 	s := NewServer(0, logger)
 

--- a/v2/pkg/dashboard/cli_models_goose_test.go
+++ b/v2/pkg/dashboard/cli_models_goose_test.go
@@ -1,0 +1,259 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+)
+
+// swapGooseProbe substitutes the goose ACP probe seam for one test and
+// restores it (mirrors swapSDKHelper for the copilot SDK probe).
+func swapGooseProbe(t *testing.T, fn func(ctx context.Context) (*gooseACPModels, error)) {
+	t.Helper()
+	prev := runGooseACPProbe
+	runGooseACPProbe = fn
+	t.Cleanup(func() { runGooseACPProbe = prev })
+}
+
+// gooseProbeMissing is the seam stand-in for "goose not on PATH" — today's
+// normal on hosted spokes.
+func gooseProbeMissing(ctx context.Context) (*gooseACPModels, error) {
+	return nil, errGooseBinaryMissing
+}
+
+// fakeGooseACP runs a canned ACP agent over pipes and returns the client-side
+// ends plus a channel that reports whether session/close was sent. The
+// sessionNewResult string is served verbatim as the session/new result.
+func fakeGooseACP(t *testing.T, sessionNewResult string) (io.WriteCloser, io.Reader, <-chan string) {
+	t.Helper()
+	clientR, clientW := io.Pipe() // agent -> client
+	agentR, agentW := io.Pipe()   // client -> agent
+	closed := make(chan string, 1)
+	go func() {
+		defer clientW.Close()
+		dec := json.NewDecoder(agentR)
+		for {
+			var msg struct {
+				ID     int             `json:"id"`
+				Method string          `json:"method"`
+				Params json.RawMessage `json:"params"`
+			}
+			if err := dec.Decode(&msg); err != nil {
+				return
+			}
+			switch msg.Method {
+			case "initialize":
+				fmt.Fprintf(clientW, `{"jsonrpc":"2.0","id":%d,"result":{"protocolVersion":1,"agentCapabilities":{"sessionCapabilities":{"close":true}}}}`+"\n", msg.ID)
+			case "session/new":
+				// Interleave a notification first — the client must skip it.
+				fmt.Fprintln(clientW, `{"jsonrpc":"2.0","method":"session/update","params":{}}`)
+				fmt.Fprintf(clientW, `{"jsonrpc":"2.0","id":%d,"result":%s}`+"\n", msg.ID, sessionNewResult)
+			case "session/close":
+				var p struct {
+					SessionID string `json:"sessionId"`
+				}
+				_ = json.Unmarshal(msg.Params, &p)
+				select {
+				case closed <- p.SessionID:
+				default:
+				}
+				fmt.Fprintf(clientW, `{"jsonrpc":"2.0","id":%d,"result":null}`+"\n", msg.ID)
+			}
+		}
+	}()
+	return agentW, clientR, closed
+}
+
+// TestGooseACPExchange_ModelsPresent verifies the full happy path: the live
+// inventory is parsed and session/close is sent for the created session.
+func TestGooseACPExchange_ModelsPresent(t *testing.T) {
+	w, r, closed := fakeGooseACP(t, `{"sessionId":"sess-1","models":{"currentModelId":"qwen2.5","availableModels":[{"modelId":"qwen2.5","name":"Qwen"},{"modelId":"llama3.3"},{"modelId":""}]}}`)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	inv, err := gooseACPExchange(ctx, w, r, t.TempDir())
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	if inv.CurrentModelID != "qwen2.5" {
+		t.Fatalf("currentModelId = %q, want qwen2.5", inv.CurrentModelID)
+	}
+	if !equalStrings(inv.AvailableModels, []string{"qwen2.5", "llama3.3"}) {
+		t.Fatalf("availableModels = %v (empty ids must be dropped)", inv.AvailableModels)
+	}
+	select {
+	case id := <-closed:
+		if id != "sess-1" {
+			t.Fatalf("session/close for %q, want sess-1", id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("session/close was never sent — probe sessions would accumulate in sessions.db")
+	}
+}
+
+// TestGooseACPExchange_ModelsAbsent verifies the clean fallback signal: an
+// unconfigured (or pre-1.37) goose omits the models key entirely, and the
+// session that was still created gets closed.
+func TestGooseACPExchange_ModelsAbsent(t *testing.T) {
+	w, r, closed := fakeGooseACP(t, `{"sessionId":"sess-2","modes":{"currentModeId":"auto"}}`)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := gooseACPExchange(ctx, w, r, t.TempDir()); !errors.Is(err, errGooseModelsAbsent) {
+		t.Fatalf("err = %v, want errGooseModelsAbsent", err)
+	}
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("session/close must be sent even when models are absent")
+	}
+}
+
+// TestGooseACPExchange_MalformedResult verifies a result whose models field
+// has the wrong shape is an error (→ fallback), not a panic or a bogus list.
+func TestGooseACPExchange_MalformedResult(t *testing.T) {
+	w, r, _ := fakeGooseACP(t, `{"sessionId":"sess-3","models":"nope"}`)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := gooseACPExchange(ctx, w, r, t.TempDir()); err == nil {
+		t.Fatal("expected error on malformed session/new result")
+	}
+}
+
+// TestGooseACPExchange_Timeout verifies a hung agent (garbage output, no
+// response) is bounded by ctx rather than blocking the backends endpoint.
+func TestGooseACPExchange_Timeout(t *testing.T) {
+	clientR, clientW := io.Pipe()
+	agentR, agentW := io.Pipe()
+	go func() {
+		// Emit non-JSON chatter and never answer.
+		fmt.Fprintln(clientW, "not json at all")
+		_, _ = io.Copy(io.Discard, agentR)
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err := gooseACPExchange(ctx, agentW, clientR, t.TempDir())
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want context deadline", err)
+	}
+	_ = clientW.Close()
+}
+
+// TestDiscoverGooseModels_LiveInventory verifies a successful probe yields a
+// live (fallback=false) list with goose's current model first.
+func TestDiscoverGooseModels_LiveInventory(t *testing.T) {
+	t.Setenv("GOOSE_MODEL", "")
+	swapGooseProbe(t, func(ctx context.Context) (*gooseACPModels, error) {
+		return &gooseACPModels{
+			CurrentModelID:  "qwen2.5",
+			AvailableModels: []string{"qwen2.5", "llama3.3", "deepseek-r1"},
+		}, nil
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverGooseModels()
+	if r.fallback {
+		t.Fatalf("live inventory must not be fallback: %+v", r)
+	}
+	if !equalStrings(r.models, []string{"qwen2.5", "llama3.3", "deepseek-r1"}) {
+		t.Fatalf("models = %v, want current-first deduped inventory", r.models)
+	}
+}
+
+// TestDiscoverGooseModels_EnvPinFirst verifies a GOOSE_MODEL env pin outranks
+// currentModelId for first position and is deduped against the inventory.
+func TestDiscoverGooseModels_EnvPinFirst(t *testing.T) {
+	t.Setenv("GOOSE_MODEL", "llama3.3")
+	swapGooseProbe(t, func(ctx context.Context) (*gooseACPModels, error) {
+		return &gooseACPModels{
+			CurrentModelID:  "qwen2.5",
+			AvailableModels: []string{"qwen2.5", "llama3.3"},
+		}, nil
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverGooseModels()
+	if !equalStrings(r.models, []string{"llama3.3", "qwen2.5"}) {
+		t.Fatalf("models = %v, want env pin first with no duplicate", r.models)
+	}
+	if r.fallback {
+		t.Fatal("env-pinned live inventory is still a live result")
+	}
+}
+
+// TestDiscoverGooseModels_BinaryMissingFallsBack verifies the real exec path:
+// with goose absent from PATH (today's normal on hosted spokes) the provider
+// static fallback is served, silently.
+func TestDiscoverGooseModels_BinaryMissingFallsBack(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // empty dir — no goose binary
+	t.Setenv("GOOSE_PROVIDER", "anthropic")
+	t.Setenv("GOOSE_MODEL", "")
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverGooseModels()
+	if !r.fallback {
+		t.Fatalf("missing binary must serve fallback, got %+v", r)
+	}
+	if !contains(r.models, "claude-opus-4-8") {
+		t.Fatalf("fallback should be the anthropic static list, got %v", r.models)
+	}
+}
+
+// TestDiscoverGooseModels_ProbeErrorFallsBack verifies any probe error
+// (spawn failure, timeout, protocol error) lands on the static fallback.
+func TestDiscoverGooseModels_ProbeErrorFallsBack(t *testing.T) {
+	t.Setenv("GOOSE_PROVIDER", "ollama")
+	t.Setenv("GOOSE_MODEL", "")
+	swapGooseProbe(t, func(ctx context.Context) (*gooseACPModels, error) {
+		return nil, errors.New("boom")
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverGooseModels()
+	if !r.fallback || !contains(r.models, "llama3.3") {
+		t.Fatalf("probe error must serve the ollama static fallback, got %+v", r)
+	}
+}
+
+// TestDiscoverGooseModels_ModelsAbsentFallsBack verifies the absent-models
+// signal (unconfigured goose) falls back cleanly.
+func TestDiscoverGooseModels_ModelsAbsentFallsBack(t *testing.T) {
+	t.Setenv("GOOSE_PROVIDER", "")
+	t.Setenv("GOOSE_MODEL", "")
+	swapGooseProbe(t, func(ctx context.Context) (*gooseACPModels, error) {
+		return nil, errGooseModelsAbsent
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverGooseModels()
+	if !r.fallback || !equalStrings(r.models, []string{"default"}) {
+		t.Fatalf("unconfigured goose must fall back to [default], got %+v", r)
+	}
+}
+
+// TestQueryCLIModels_GooseLiveThroughStabilize verifies the live goose list
+// flows through the query pipeline (cache + stabilize) as a non-fallback
+// result with the pinned model still first.
+func TestQueryCLIModels_GooseLiveThroughStabilize(t *testing.T) {
+	t.Setenv("GOOSE_MODEL", "")
+	swapGooseProbe(t, func(ctx context.Context) (*gooseACPModels, error) {
+		return &gooseACPModels{
+			CurrentModelID:  "qwen2.5",
+			AvailableModels: []string{"qwen2.5", "llama3.3"},
+		}, nil
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.queryCLIModels("goose")
+	if r.fallback {
+		t.Fatalf("live goose discovery through queryCLIModels must not be fallback: %+v", r)
+	}
+	if len(r.models) == 0 || r.models[0] != "qwen2.5" {
+		t.Fatalf("pinned/current model must stay first through stabilize, got %v", r.models)
+	}
+	// A second successful probe missing llama3.3 must retain it (stabilize).
+	swapGooseProbe(t, func(ctx context.Context) (*gooseACPModels, error) {
+		return &gooseACPModels{CurrentModelID: "qwen2.5", AvailableModels: []string{"qwen2.5"}}, nil
+	})
+	s.cliModels.entries = map[string]cliModelCacheEntry{} // bust the TTL cache
+	r = s.queryCLIModels("goose")
+	if !contains(r.models, "llama3.3") {
+		t.Fatalf("recently-seen model must be retained through a transient miss, got %v", r.models)
+	}
+}

--- a/v2/pkg/dashboard/cli_models_sdk_test.go
+++ b/v2/pkg/dashboard/cli_models_sdk_test.go
@@ -1,0 +1,156 @@
+package dashboard
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// swapSDKHelper substitutes the SDK-helper seam for one test and restores it.
+func swapSDKHelper(t *testing.T, fn func(ctx context.Context, token string) ([]byte, error)) {
+	t.Helper()
+	prev := runCopilotSDKHelper
+	runCopilotSDKHelper = fn
+	t.Cleanup(func() { runCopilotSDKHelper = prev })
+}
+
+func TestParseCopilotSDKModels_FiltersPolicyAndAuto(t *testing.T) {
+	body := []byte(`{"models":[
+		{"id":"gpt-5.4","name":"GPT-5.4","policyState":"enabled"},
+		{"id":"claude-fable-5","name":"Claude Fable 5","policyState":"enabled","efforts":["low","medium","high"],"defaultEffort":"medium"},
+		{"id":"grok-code-fast-1","name":"Grok","policyState":"unconfigured"},
+		{"id":"gemini-2.5-pro","name":"Gemini"},
+		{"id":"auto","name":"Auto"},
+		{"id":"","name":"nameless"}
+	]}`)
+	got, err := parseCopilotSDKModels(body)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	// enabled ids kept; absent policy kept; non-enabled policy dropped; the
+	// "auto" pseudo-entry and empty ids dropped.
+	want := []string{"gpt-5.4", "claude-fable-5", "gemini-2.5-pro"}
+	if !equalStrings(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestParseCopilotSDKModels_Malformed(t *testing.T) {
+	if _, err := parseCopilotSDKModels([]byte("not json")); err == nil {
+		t.Fatal("expected error on malformed helper output")
+	}
+}
+
+func TestParseCopilotSDKModels_Empty(t *testing.T) {
+	got, err := parseCopilotSDKModels([]byte(`{"models":[]}`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected no models, got %v", got)
+	}
+}
+
+// TestDiscoverCopilotModels_SDKSuccess verifies the SDK probe is consulted
+// FIRST and that a successful helper run yields a live (non-fallback) result
+// even with no token available to the raw-HTTP path — the hardening this
+// probe adds.
+func TestDiscoverCopilotModels_SDKSuccess(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	swapSDKHelper(t, func(ctx context.Context, token string) ([]byte, error) {
+		return []byte(`{"models":[{"id":"gpt-5.4","policyState":"enabled"},{"id":"claude-fable-5","policyState":"enabled"}]}`), nil
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverCopilotModels()
+	if r.fallback {
+		t.Fatalf("SDK success must be a live result, got fallback: %+v", r)
+	}
+	if !equalStrings(r.models, []string{"gpt-5.4", "claude-fable-5"}) {
+		t.Fatalf("got %v, want SDK-discovered ids", r.models)
+	}
+}
+
+// TestDiscoverCopilotModels_SDKFailureFallsBack verifies a nonzero-exit
+// helper falls through to the raw-HTTP probe path; with no token that path
+// resolves to the static fallback, so the chain ends at fallback=true rather
+// than an error or empty list.
+func TestDiscoverCopilotModels_SDKFailureFallsBack(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	swapSDKHelper(t, func(ctx context.Context, token string) ([]byte, error) {
+		return nil, errors.New("exit status 1")
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverCopilotModels()
+	if !r.fallback {
+		t.Fatalf("SDK failure with no token must fall back, got %+v", r)
+	}
+	// The full pipeline still serves a non-empty static list.
+	q := s.queryCLIModels("copilot")
+	if len(q.models) == 0 || !q.fallback {
+		t.Fatalf("pipeline must serve non-empty static fallback, got %+v", q)
+	}
+}
+
+// TestDiscoverCopilotModels_SDKMalformedFallsBack verifies helper stdout that
+// fails to parse is treated exactly like a failed probe.
+func TestDiscoverCopilotModels_SDKMalformedFallsBack(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	swapSDKHelper(t, func(ctx context.Context, token string) ([]byte, error) {
+		return []byte("garbage"), nil
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	if r := s.discoverCopilotModels(); !r.fallback {
+		t.Fatalf("malformed SDK output must fall back, got %+v", r)
+	}
+}
+
+// TestDiscoverCopilotModels_SDKEmptyFallsBack verifies a well-formed helper
+// response with zero usable models is not served as a live (empty) list.
+func TestDiscoverCopilotModels_SDKEmptyFallsBack(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	swapSDKHelper(t, func(ctx context.Context, token string) ([]byte, error) {
+		return []byte(`{"models":[{"id":"auto"}]}`), nil
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	if r := s.discoverCopilotModels(); !r.fallback {
+		t.Fatalf("empty SDK result must fall back, got %+v", r)
+	}
+}
+
+// TestQueryCLIModels_SDKResultsFeedRetention verifies SDK-discovered models
+// ride the same stabilize/retention machinery as the HTTP probe: a model seen
+// in one live SDK sample survives its absence from the next sample.
+func TestQueryCLIModels_SDKResultsFeedRetention(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	sample := []byte(`{"models":[{"id":"gpt-5.4","policyState":"enabled"},{"id":"claude-fable-5","policyState":"enabled"}]}`)
+	swapSDKHelper(t, func(ctx context.Context, token string) ([]byte, error) {
+		out := sample
+		return out, nil
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	if r := s.queryCLIModels("copilot"); !contains(r.models, "claude-fable-5") {
+		t.Fatalf("first live sample missing id: %v", r.models)
+	}
+	// Next probe omits claude-fable-5; expire the cache and re-query.
+	sample = []byte(`{"models":[{"id":"gpt-5.4","policyState":"enabled"}]}`)
+	s.cliModels.entries = map[string]cliModelCacheEntry{}
+	r := s.queryCLIModels("copilot")
+	if r.fallback {
+		t.Fatalf("live SDK result must not be fallback: %+v", r)
+	}
+	if !contains(r.models, "claude-fable-5") {
+		t.Fatalf("retention should keep recently-seen id through one miss: %v", r.models)
+	}
+}
+
+// TestProbeCopilotModelsSDK_HelperNotInstalled verifies the real exec path
+// degrades instantly (no hang, no panic) when the helper script is absent —
+// the situation on dev machines and CI runners.
+func TestProbeCopilotModelsSDK_HelperNotInstalled(t *testing.T) {
+	s := &Server{logger: testLogger()}
+	if _, err := s.probeCopilotModelsSDK(""); err == nil {
+		// The helper is installed only inside the hive image; if this machine
+		// actually has it, the probe may legitimately succeed — skip then.
+		t.Skip("copilot SDK helper present on this machine; skipping absence check")
+	}
+}

--- a/v2/pkg/dashboard/cli_models_test.go
+++ b/v2/pkg/dashboard/cli_models_test.go
@@ -85,19 +85,26 @@ func TestDedupeModels(t *testing.T) {
 	}
 }
 
-// TestQueryCLIModels_ClaudeStatic verifies claude returns a non-empty,
-// non-fallback (authoritative static) list without any network call.
-func TestQueryCLIModels_ClaudeStatic(t *testing.T) {
-	s := &Server{cliModels: newCLIModelCache()}
+// TestQueryCLIModels_ClaudeFallbackNoCreds verifies that with no API key and
+// no credentials file, claude discovery skips the network entirely and serves
+// the static fallback (non-empty, fallback=true) with the aliases appended.
+func TestQueryCLIModels_ClaudeFallbackNoCreds(t *testing.T) {
+	withoutClaudeCredentials(t)
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
 	r := s.queryCLIModels("claude")
 	if len(r.models) == 0 {
 		t.Fatal("claude models should never be empty")
 	}
-	if r.fallback {
-		t.Fatal("claude static list is authoritative, not a fallback")
+	if !r.fallback {
+		t.Fatal("claude with no credential must be marked fallback")
 	}
 	if !contains(r.models, "claude-opus-4-8") {
 		t.Fatalf("claude models missing current id: %v", r.models)
+	}
+	for _, alias := range claudeAlwaysIncludeModels {
+		if !contains(r.models, alias) {
+			t.Fatalf("alias %q missing from fallback claude list: %v", alias, r.models)
+		}
 	}
 }
 
@@ -327,6 +334,7 @@ func TestCliStaticFallback_BobAutoOnly(t *testing.T) {
 // where adding bob narrows or empties another CLI backend's catalog.
 func TestQueryCLIModels_BobDoesNotAffectOtherBackends(t *testing.T) {
 	swapGooseProbe(t, gooseProbeMissing)
+	withoutClaudeCredentials(t)
 	t.Setenv("COPILOT_GITHUB_TOKEN", "")
 	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
 	for _, backend := range []string{"claude", "copilot", "gemini", "goose", "codex"} {

--- a/v2/pkg/dashboard/cli_models_test.go
+++ b/v2/pkg/dashboard/cli_models_test.go
@@ -160,6 +160,7 @@ func TestQueryCLIModels_GeminiFallbackNoKey(t *testing.T) {
 // TestQueryCLIModels_GooseUsesProvider verifies goose maps a configured
 // provider to its static list.
 func TestQueryCLIModels_GooseUsesProvider(t *testing.T) {
+	swapGooseProbe(t, gooseProbeMissing)
 	t.Setenv("GOOSE_PROVIDER", "anthropic")
 	t.Setenv("GOOSE_MODEL", "")
 	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
@@ -173,6 +174,7 @@ func TestQueryCLIModels_GooseUsesProvider(t *testing.T) {
 }
 
 func TestQueryCLIModels_GooseUnconfigured(t *testing.T) {
+	swapGooseProbe(t, gooseProbeMissing)
 	t.Setenv("GOOSE_PROVIDER", "")
 	t.Setenv("GOOSE_MODEL", "")
 	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
@@ -183,6 +185,7 @@ func TestQueryCLIModels_GooseUnconfigured(t *testing.T) {
 }
 
 func TestQueryCLIModels_GoosePinnedModelFirst(t *testing.T) {
+	swapGooseProbe(t, gooseProbeMissing)
 	t.Setenv("GOOSE_PROVIDER", "ollama")
 	t.Setenv("GOOSE_MODEL", "my-pinned-model")
 	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
@@ -323,6 +326,7 @@ func TestCliStaticFallback_BobAutoOnly(t *testing.T) {
 // TestQueryCLIModels_BobDoesNotAffectOtherBackends guards against a regression
 // where adding bob narrows or empties another CLI backend's catalog.
 func TestQueryCLIModels_BobDoesNotAffectOtherBackends(t *testing.T) {
+	swapGooseProbe(t, gooseProbeMissing)
 	t.Setenv("COPILOT_GITHUB_TOKEN", "")
 	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
 	for _, backend := range []string{"claude", "copilot", "gemini", "goose", "codex"} {

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -741,6 +741,111 @@ func (h *ContributeWSHub) RoleBreakdown() map[string]int {
 	return breakdown
 }
 
+// FleetClanker is a read-only view of one connected contributor ("clanker")
+// session as the operator-facing Management & Operations tab renders it. It
+// carries only what the contributor handshake already put on the wire plus the
+// live connection timing the hub already tracks — no secrets, no new state.
+type FleetClanker struct {
+	ContributorID  string        `json:"contributor_id"`
+	GitHubUsername string        `json:"github_username,omitempty"`
+	CLIBackend     string        `json:"cli_backend,omitempty"`
+	Model          string        `json:"model,omitempty"`
+	Role           string        `json:"role,omitempty"`
+	TrustTier      string        `json:"trust_tier,omitempty"`
+	ConnectedAt    string        `json:"connected_at,omitempty"`
+	LastActivity   string        `json:"last_activity,omitempty"`
+	Stale          bool          `json:"stale,omitempty"`
+	CurrentTask    *WSTaskAssign `json:"current_task,omitempty"`
+}
+
+// FleetWorkItem is a read-only view of one in-flight task the fleet is working,
+// surfaced the way the operator work-list lists items (repo / number / title /
+// who is on it / status). Derived entirely from live connection state — the hub
+// tracks currentTask per connection; nothing here is fabricated.
+type FleetWorkItem struct {
+	TaskID         string `json:"task_id"`
+	Kind           string `json:"kind,omitempty"`
+	Repo           string `json:"repo,omitempty"`
+	Number         int    `json:"number,omitempty"`
+	Title          string `json:"title,omitempty"`
+	ContributorID  string `json:"contributor_id,omitempty"`
+	GitHubUsername string `json:"github_username,omitempty"`
+	CLIBackend     string `json:"cli_backend,omitempty"`
+	Status         string `json:"status"`
+}
+
+// FleetSnapshot is the read-only payload the Management & Operations tab hydrates
+// from. Everything is derived from the hub's current live connections — it adds
+// no enforcement and mutates nothing.
+type FleetSnapshot struct {
+	Clankers []FleetClanker  `json:"clankers"`
+	Work     []FleetWorkItem `json:"work"`
+}
+
+// FleetSnapshot returns the current connected-clanker fleet and its in-flight
+// work, read-only, from the hub's live connection registry. A connection whose
+// last pong is older than wsHeartbeatTimeout is reported with Stale=true and its
+// in-flight task is treated as no longer active (matching LiveStates()).
+func (h *ContributeWSHub) FleetSnapshot() FleetSnapshot {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	snap := FleetSnapshot{
+		Clankers: make([]FleetClanker, 0, len(h.connections)),
+		Work:     make([]FleetWorkItem, 0),
+	}
+	for _, c := range h.connections {
+		c.mu.Lock()
+		fc := FleetClanker{
+			CLIBackend:   c.cliBackend,
+			Model:        c.model,
+			Role:         c.role,
+			ConnectedAt:  c.connectedAt.UTC().Format(time.RFC3339),
+			LastActivity: c.lastPong.UTC().Format(time.RFC3339),
+			Stale:        time.Since(c.lastPong) > wsHeartbeatTimeout,
+		}
+		if c.profile != nil {
+			fc.ContributorID = c.profile.ContributorID
+			fc.GitHubUsername = c.profile.GitHubUsername
+			fc.TrustTier = c.profile.TrustTier
+		}
+		var task *WSTaskAssign
+		if c.currentTask != nil && !fc.Stale {
+			t := *c.currentTask
+			task = &t
+		}
+		c.mu.Unlock()
+		fc.CurrentTask = task
+		if task != nil {
+			snap.Work = append(snap.Work, FleetWorkItem{
+				TaskID:         task.TaskID,
+				Kind:           task.Kind,
+				Repo:           task.Repo,
+				Number:         task.Number,
+				Title:          task.Title,
+				ContributorID:  fc.ContributorID,
+				GitHubUsername: fc.GitHubUsername,
+				CLIBackend:     fc.CLIBackend,
+				Status:         "in-progress",
+			})
+		}
+		snap.Clankers = append(snap.Clankers, fc)
+	}
+	// Deterministic order so the operator view is stable across polls.
+	sort.Slice(snap.Clankers, func(i, j int) bool {
+		if snap.Clankers[i].ConnectedAt != snap.Clankers[j].ConnectedAt {
+			return snap.Clankers[i].ConnectedAt < snap.Clankers[j].ConnectedAt
+		}
+		return snap.Clankers[i].ContributorID < snap.Clankers[j].ContributorID
+	})
+	sort.Slice(snap.Work, func(i, j int) bool {
+		if snap.Work[i].Repo != snap.Work[j].Repo {
+			return snap.Work[i].Repo < snap.Work[j].Repo
+		}
+		return snap.Work[i].Number < snap.Work[j].Number
+	})
+	return snap
+}
+
 func (h *ContributeWSHub) ActiveConnections() []ContributorConnection {
 	h.mu.RLock()
 	defer h.mu.RUnlock()

--- a/v2/pkg/dashboard/pod_namespace.go
+++ b/v2/pkg/dashboard/pod_namespace.go
@@ -1,0 +1,46 @@
+package dashboard
+
+import (
+	"os"
+	"strings"
+)
+
+// podNamespaceServiceAccountPath is the in-cluster fallback source for the
+// pod's namespace, mirroring pkg/hub/self_upgrade.go's k8sNamespacePath. A
+// var (not a const) so tests can redirect it to a temp file, same reason.
+var podNamespaceServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+// podNamespace returns the Kubernetes namespace this spoke's pod is running
+// in, for display in the dashboard's Hub tab (renderGovHub in
+// pkg/dashboard/static/index.html) — the spoke-side complement to the
+// hive.kubestellar.io/* namespace labels stamped hub-side in
+// pkg/hub/hosted_namespace_identity.go.
+//
+// Preference order:
+//  1. POD_NAMESPACE — set via the Kubernetes downward API
+//     (fieldRef: metadata.namespace) on the hive Deployment (see the env
+//     block in saas_provision.go's k8sManifestTemplate). This is the
+//     authoritative, always-correct source once a spoke is provisioned by a
+//     build that sets it.
+//  2. NAMESPACE — an alternate env var name some deployments (or an operator
+//     hand-editing a Deployment) may already use.
+//  3. The service-account namespace file, present in every pod regardless of
+//     how it was deployed, including spokes provisioned before POD_NAMESPACE
+//     existed.
+//
+// Returns "" when none of the three resolve (e.g. running outside a
+// cluster), so the caller can omit the line entirely rather than display an
+// empty or misleading value.
+func podNamespace() string {
+	if v := strings.TrimSpace(os.Getenv("POD_NAMESPACE")); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv("NAMESPACE")); v != "" {
+		return v
+	}
+	data, err := os.ReadFile(podNamespaceServiceAccountPath)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/v2/pkg/dashboard/pod_namespace_test.go
+++ b/v2/pkg/dashboard/pod_namespace_test.go
@@ -1,0 +1,106 @@
+package dashboard
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ============================================================
+// pod_namespace.go — podNamespace(), and its wiring into the "hub" config
+// GET response (handleGovernorConfigGet) that feeds the dashboard's Hub tab
+// (renderGovHub in pkg/dashboard/static/index.html).
+// ============================================================
+
+func TestPodNamespacePrefersPodNamespaceEnv(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "hive-hosted-hosted-avail-y99x")
+	t.Setenv("NAMESPACE", "should-not-be-used")
+	if got := podNamespace(); got != "hive-hosted-hosted-avail-y99x" {
+		t.Errorf("podNamespace() = %q, want POD_NAMESPACE value", got)
+	}
+}
+
+func TestPodNamespaceFallsBackToNamespaceEnv(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "")
+	t.Setenv("NAMESPACE", "hive-hosted-x")
+	if got := podNamespace(); got != "hive-hosted-x" {
+		t.Errorf("podNamespace() = %q, want NAMESPACE fallback value", got)
+	}
+}
+
+func TestPodNamespaceFallsBackToServiceAccountFile(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "")
+	t.Setenv("NAMESPACE", "")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "namespace")
+	if err := os.WriteFile(path, []byte("hive-hosted-from-file\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := podNamespaceServiceAccountPath
+	podNamespaceServiceAccountPath = path
+	defer func() { podNamespaceServiceAccountPath = old }()
+
+	if got := podNamespace(); got != "hive-hosted-from-file" {
+		t.Errorf("podNamespace() = %q, want trimmed file contents", got)
+	}
+}
+
+func TestPodNamespaceEmptyWhenNoSourceAvailable(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "")
+	t.Setenv("NAMESPACE", "")
+	old := podNamespaceServiceAccountPath
+	podNamespaceServiceAccountPath = filepath.Join(t.TempDir(), "does-not-exist")
+	defer func() { podNamespaceServiceAccountPath = old }()
+
+	if got := podNamespace(); got != "" {
+		t.Errorf("podNamespace() = %q, want empty when no source resolves", got)
+	}
+}
+
+// TestHubTabRendersNamespace pins the spoke dashboard's Hub config tab
+// (renderGovHub in static/index.html) to include the namespace row — the
+// spoke-side complement to the hub dashboard's status-hover namespace line
+// and the hive.kubestellar.io/* namespace labels stamped hub-side. Uses the
+// spokeIndexHTML helper from gh_app_banner_test.go, matching that file's
+// structure-pin style.
+func TestHubTabRendersNamespace(t *testing.T) {
+	html := spokeIndexHTML(t)
+
+	required := []struct {
+		snippet string
+		why     string
+	}{
+		{"const namespaceRow = hub.namespace", "the Hub tab must read hub.namespace from the config payload"},
+		{"<label>Namespace ", "the Hub tab must render a labeled Namespace row"},
+		{"readonly disabled", "the namespace row must be read-only — no new mutation from the UI"},
+	}
+	for _, r := range required {
+		if !strings.Contains(html, r.snippet) {
+			t.Errorf("static/index.html is missing %q — %s", r.snippet, r.why)
+		}
+	}
+}
+
+// TestHandleGovernorConfigGetIncludesNamespace guards that the "hub" section
+// of the governor config GET response — the payload renderGovHub() reads in
+// the dashboard's Hub tab — carries the resolved namespace, gracefully empty
+// when unset rather than absent.
+func TestHandleGovernorConfigGetIncludesNamespace(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "hive-hosted-hosted-avail-nb01")
+	s, _ := apiServer(t)
+	rec := doGet(s, "/api/config/governor")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	result := decodeJSON(t, rec)
+	hub, ok := result["hub"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected hub key in governor config response")
+	}
+	if got, _ := hub["namespace"].(string); got != "hive-hosted-hosted-avail-nb01" {
+		t.Errorf("hub.namespace = %q, want %q", got, "hive-hosted-hosted-avail-nb01")
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6346,14 +6346,26 @@
           .filter(name => name && !KNOWN_BACKENDS.includes(name));
       } catch (e) { /* keep prior list; dropdowns fall back to KNOWN_BACKENDS */ }
     }
+    // Fallback list only — the server now discovers claude models live via
+    // GET api.anthropic.com/v1/models (see claudeStaticModels in
+    // pkg/dashboard/cli_models.go; keep the two lists in sync). Refreshed
+    // 2026-08-03 from a live /v1/models response, in API order, plus the bare
+    // aliases the claude CLI accepts as --model values.
     const CLAUDE_CLI_MODELS = [
+      { value: 'claude-opus-5', label: 'Opus 5' },
+      { value: 'claude-sonnet-5', label: 'Sonnet 5' },
+      { value: 'claude-fable-5', label: 'Fable 5' },
       { value: 'claude-opus-4-8', label: 'Opus 4.8' },
       { value: 'claude-opus-4-7', label: 'Opus 4.7' },
-      { value: 'claude-opus-4-6', label: 'Opus 4.6' },
       { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
-      { value: 'claude-sonnet-4-5', label: 'Sonnet 4.5' },
-      { value: 'claude-haiku-4-5', label: 'Haiku 4.5' },
-      { value: 'claude-fable-5', label: 'Fable 5' },
+      { value: 'claude-opus-4-6', label: 'Opus 4.6' },
+      { value: 'claude-opus-4-5-20251101', label: 'Opus 4.5' },
+      { value: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
+      { value: 'claude-sonnet-4-5-20250929', label: 'Sonnet 4.5' },
+      { value: 'claude-opus-4-1-20250805', label: 'Opus 4.1' },
+      { value: 'opus', label: 'Opus (alias)' },
+      { value: 'sonnet', label: 'Sonnet (alias)' },
+      { value: 'haiku', label: 'Haiku (alias)' },
     ];
     const COPILOT_CLI_MODELS = [
       // Auto sentinel: `copilot --model auto` lets the Copilot CLI pick/adjust

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -12984,7 +12984,6 @@ function burnAreaChart() {
         if (v.dirty) html += ' <span class="git-dirty">*</span>';
         if (_upgradeInProgress && v.hash !== _upgradeTargetHash) {
           html += ` <span class="git-behind" title="Upgrading to ${escapeHtml(v.latestShort || '?')}">⬆ upgrading</span>`;
-          html += ` <span style="display:inline-block;padding:3px 10px;background:var(--surface);border:1px solid var(--border);border-radius:4px;font-size:0.7rem;margin-left:6px;white-space:nowrap;opacity:0.8"><span style="display:inline-block;width:12px;height:12px;border:2px solid rgba(255,255,255,0.3);border-top-color:#fff;border-radius:50%;animation:spin 1s linear infinite;vertical-align:middle;margin-right:4px"></span>Upgrading</span>`;
         } else if (_upgradeInProgress && v.hash === _upgradeTargetHash) {
           _upgradeInProgress = false;
           _upgradeTargetHash = null;

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5924,6 +5924,11 @@
       const prsSpark = sparkline('govPrs');
       const totalSpark = sparkline('govTotal');
       const issueCount = gov.issues || 0;
+      // Mode pressure = actionable issues + open PRs, matching the governor's
+      // computeMode input. The gauge previously read issues alone, so the
+      // needle sat at "2" in the idle band while the mode said surge.
+      const prCount = gov.prs || 0;
+      const govPressure = issueCount + prCount;
       const currentMode = gov.mode || 'idle';
       const modes = ['idle', 'quiet', 'busy', 'surge'];
 
@@ -5932,8 +5937,8 @@
       const CLASSIC_THRESH_QUIET = _gt.quiet ?? 2;
       const CLASSIC_THRESH_BUSY = _gt.busy ?? 10;
       const CLASSIC_THRESH_SURGE = _gt.surge ?? 20;
-      const maxQ = Math.max(CLASSIC_THRESH_SURGE + 10, issueCount + 5);
-      const pct = Math.min(issueCount / maxQ * 100, 100);
+      const maxQ = Math.max(CLASSIC_THRESH_SURGE + 10, govPressure + 5);
+      const pct = Math.min(govPressure / maxQ * 100, 100);
       const modeColors = { idle: 'var(--green)', quiet: 'var(--blue)', busy: 'var(--yellow)', surge: 'var(--red)' };
       const modeColor = modeColors[gov.mode] || 'var(--muted)';
 
@@ -5966,8 +5971,8 @@
         <div class="gov-title">Governor <button class="config-gear" onclick="openConfigDialog('governor')" title="Open Governor configuration — manage agents, thresholds, budget, notifications, health checks, and sensing patterns">⚙️</button></div>
         <div class="gov-grid">
           <div class="gov-stat" title="TIMER — is the governor's evaluation loop alive?&#10;&#10;WHAT: The governor re-evaluates mode and kicks due agents on a fixed cadence. This shows whether that loop is running.&#10;&#10;HOW: 'active' if the governor reported a heartbeat within its expected interval; 'starting' during boot before the first tick; 'DEAD' if no heartbeat has arrived — agents will NOT be kicked automatically until it recovers."><div class="label">timer</div><div class="val ${cls}">${gov.active ? '● active' : (isStarting ? '⏳ starting' : '⚠ DEAD')}</div></div>
-          <div class="gov-stat" title="MODE — the governor's current activity level.&#10;&#10;WHAT: Sets how aggressively agents are scheduled. idle → quiet → busy → surge, each with faster cadences.&#10;&#10;HOW: Derived purely from the actionable-issue count against the thresholds shown on the gauge below: 0–${CLASSIC_THRESH_QUIET-1}=idle, ${CLASSIC_THRESH_QUIET}–${CLASSIC_THRESH_BUSY-1}=quiet, ${CLASSIC_THRESH_BUSY}–${CLASSIC_THRESH_SURGE-1}=busy, ≥${CLASSIC_THRESH_SURGE}=surge. Thresholds are configurable in Governor settings."><div class="label">mode</div><div class="val" style="color:${modeColor}">${escapeHtml(gov.mode)}</div></div>
-          <div class="gov-stat" title="ACTIONABLE ISSUES — open work the agents can pick up.&#10;&#10;WHAT: The queue depth that drives the governor mode. The sparkline shows its recent trend.&#10;&#10;HOW: Count of open GitHub issues across all monitored KubeStellar repos, MINUS any labeled hold / do-not-merge / wontfix / blocked. This is the exact number the mode gauge below reads."><div class="label">actionable issues</div><div class="spark-row"><span class="val">${issueCount}</span>${issuesSpark}</div></div>
+          <div class="gov-stat" title="MODE — the governor's current activity level.&#10;&#10;WHAT: Sets how aggressively agents are scheduled. idle → quiet → busy → surge, each with faster cadences.&#10;&#10;HOW: Derived from queue pressure — actionable issues + open PRs — against the thresholds shown on the gauge below: 0–${CLASSIC_THRESH_QUIET-1}=idle, ${CLASSIC_THRESH_QUIET}–${CLASSIC_THRESH_BUSY-1}=quiet, ${CLASSIC_THRESH_BUSY}–${CLASSIC_THRESH_SURGE-1}=busy, ≥${CLASSIC_THRESH_SURGE}=surge. Thresholds are configurable in Governor settings."><div class="label">mode</div><div class="val" style="color:${modeColor}">${escapeHtml(gov.mode)}</div></div>
+          <div class="gov-stat" title="ACTIONABLE ISSUES — open work the agents can pick up.&#10;&#10;WHAT: The issue half of the queue pressure that drives the governor mode (pressure = issues + open PRs). The sparkline shows its recent trend.&#10;&#10;HOW: Count of open GitHub issues across all monitored KubeStellar repos, MINUS any labeled hold / do-not-merge / wontfix / blocked."><div class="label">actionable issues</div><div class="spark-row"><span class="val">${issueCount}</span>${issuesSpark}</div></div>
           <div class="gov-stat" title="PRS — open pull requests in flight.&#10;&#10;WHAT: How many PRs are currently open across the fleet. The sparkline shows the recent trend.&#10;&#10;HOW: Count of open pull requests across all monitored KubeStellar repos at the last scan (includes both agent-authored and human PRs; does not subtract held PRs)."><div class="label">PRs</div><div class="spark-row"><span class="val">${gov.prs}</span>${prsSpark}</div></div>
           <div class="gov-stat" title="${itmTitle}"><div class="label">MTTR</div><div class="spark-row"><span class="val">${formatFixTime(itmMedian)}</span>${itmSpark}</div></div>
           <div class="gov-stat" title="${holdTooltip}"><div class="label">on hold</div><div class="spark-row"><span class="val">${holdTotal}</span>${holdSpark}</div></div>
@@ -5975,11 +5980,11 @@
           <div class="gov-stat" title="PR AUTHOR — the GitHub identity this hive's agents open PRs and push commits as.&#10;&#10;WHAT: Either the configured project.ai_author, or the GitHub App bot ('<slug>[bot]') when the hive runs in App-authored mode.&#10;&#10;HOW: Reported by the spoke as ai_author_effective. A '[bot]' value means PRs are authored by the App installation, not a personal account."><div class="label">PR author</div><div class="val">${escapeHtml(window._aiAuthor || '—')}</div></div>
         </div>
         <div class="temp-gauge" style="cursor:pointer" onclick="openConfigDialog('governor',null,'Thresholds')" title="Click to adjust governor thresholds">
-          <div class="temp-gauge-label"><span>Issues: ${issueCount}</span><span>max ${maxQ}</span></div>
+          <div class="temp-gauge-label"><span>Pressure: ${govPressure} (${issueCount} issues + ${prCount} PRs)</span><span>max ${maxQ}</span></div>
           <div class="temp-gauge-track" style="background:linear-gradient(to right, var(--green) 0%, var(--green) ${CLASSIC_THRESH_QUIET/maxQ*100}%, var(--blue) ${CLASSIC_THRESH_QUIET/maxQ*100}%, var(--blue) ${CLASSIC_THRESH_BUSY/maxQ*100}%, var(--yellow) ${CLASSIC_THRESH_BUSY/maxQ*100}%, var(--yellow) ${CLASSIC_THRESH_SURGE/maxQ*100}%, var(--red) ${CLASSIC_THRESH_SURGE/maxQ*100}%, var(--red) 100%)">
             <div class="temp-gauge-glow" style="width:100%"></div>
             <div class="temp-gauge-ticks"><span style="left:2%;-webkit-transform:translate(0,-50%);transform:translate(0,-50%)">0</span><span style="left:${CLASSIC_THRESH_QUIET/maxQ*100}%;-webkit-transform:translate(-50%,-50%);transform:translate(-50%,-50%)">${CLASSIC_THRESH_QUIET}</span><span style="left:${CLASSIC_THRESH_BUSY/maxQ*100}%;-webkit-transform:translate(-50%,-50%);transform:translate(-50%,-50%)">${CLASSIC_THRESH_BUSY}</span><span style="left:${CLASSIC_THRESH_SURGE/maxQ*100}%;-webkit-transform:translate(-50%,-50%);transform:translate(-50%,-50%)">${CLASSIC_THRESH_SURGE}</span><span style="left:98%;-webkit-transform:translate(-100%,-50%);transform:translate(-100%,-50%)">${maxQ}</span></div>
-            <div class="temp-gauge-needle" style="left:${pct}%" data-val="${issueCount}"></div>
+            <div class="temp-gauge-needle" style="left:${pct}%" data-val="${govPressure}"></div>
           </div>
           <div class="temp-gauge-labels">
             <span class="tl-idle" style="position:absolute;left:${CLASSIC_THRESH_QUIET / maxQ * 50}%;transform:translateX(-50%)">idle</span>

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -14958,7 +14958,23 @@ function burnAreaChart() {
       const titlesMode = (hub.contribute_titles_mode === 'allow') ? 'allow' : 'deny';
       const authorsMode = (hub.contribute_authors_mode === 'allow') ? 'allow' : 'deny';
       const labelsMode = (hub.contribute_labels_mode === 'allow') ? 'allow' : 'deny';
+      // Read-only, runtime-derived — never sent back on save (markDirty is
+      // never wired to this field). See podNamespace() in
+      // pkg/dashboard/pod_namespace.go for how the hub API resolved it
+      // (POD_NAMESPACE downward-API env, else NAMESPACE, else the
+      // service-account namespace file). Omitted entirely when unknown
+      // (running outside a cluster, or an old spoke build with no
+      // POD_NAMESPACE wired) rather than showing a blank/"undefined" line —
+      // this is the spoke-side complement to the hive.kubestellar.io/*
+      // namespace labels the hub stamps onto this same namespace at
+      // provision/claim/assign time.
+      const namespaceRow = hub.namespace ? `
+        <div class="config-field">
+          <label>Namespace <span class="config-info">i<span class="config-tooltip">The Kubernetes namespace this hive's pod is running in. Unlike the hive's name/org, this never changes after the namespace is first created — see the hive.kubestellar.io/* labels on it for an operator-facing way to map it back to this hive.</span></span></label>
+          <input type="text" value="${esc(hub.namespace)}" readonly disabled style="opacity:0.7">
+        </div>` : '';
       return `
+        ${namespaceRow}
         <div class="config-toggle">
           <div class="config-toggle-switch ${hub.enabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="hub" data-key="enabled"></div>
           <span class="config-toggle-label">Hub Enabled <span class="config-info">i<span class="config-tooltip">Register this hive with the central hub at hive.kubestellar.io so it appears in the public registry.</span></span></span>

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6384,15 +6384,21 @@
     // Codex (OpenAI CLI) exposes its own OpenAI-only models. Claude models are
     // rejected by Codex with a ChatGPT account ("model is not supported when
     // using Codex with a ChatGPT account"), so codex must NOT fall through to
-    // the copilot list. Order mirrors `codex /model` (sol is the default).
+    // the copilot list. The server discovers the live catalog via
+    // `codex app-server` model/list (per-CLI-version, baked into the binary);
+    // this is only the pre-discovery fallback. Snapshot of codex 0.146.0:
+    // visible ids in picker order (sol is the default), then hidden ids —
+    // hidden entries are still valid --model values. Keep in sync with
+    // codexStaticModels in cli_models.go.
     const CODEX_CLI_MODELS = [
       { value: 'gpt-5.6-sol', label: 'GPT-5.6 Sol' },
       { value: 'gpt-5.6-terra', label: 'GPT-5.6 Terra' },
       { value: 'gpt-5.6-luna', label: 'GPT-5.6 Luna' },
       { value: 'gpt-5.5', label: 'GPT-5.5' },
+      { value: 'gpt-5.2', label: 'GPT-5.2' },
       { value: 'gpt-5.4', label: 'GPT-5.4' },
       { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
-      { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' },
+      { value: 'codex-auto-review', label: 'Codex Auto Review' },
     ];
     // bob (IBM bobshell) selects its own model and has NO usable --model flag:
     // launching `bob --model <concrete-id>` makes every prompt die with

--- a/v2/pkg/hub/fleet_stats_test.go
+++ b/v2/pkg/hub/fleet_stats_test.go
@@ -357,10 +357,9 @@ func TestComputeFleetStatsSkipsRepolessHives(t *testing.T) {
 // into a temp dir, so recordFleetStatsLKG's requestSave cannot touch /data.
 func fleetStatsLKGTestServer(t *testing.T) *HubServer {
 	t.Helper()
-	old := registryPath
-	registryPath = t.TempDir() + "/reg.json"
-	t.Cleanup(func() { registryPath = old })
-	return &HubServer{logger: slog.Default()}
+	// Per-server field, not the registryPath global: mutating the global races
+	// leaked saveLoop goroutines from servers built by other tests.
+	return &HubServer{logger: slog.Default(), registryPath: t.TempDir() + "/reg.json"}
 }
 
 func decodeFleetStats(t *testing.T, s *HubServer) FleetStats {
@@ -535,7 +534,7 @@ func TestFleetStatsLKG_PersistsAcrossReload(t *testing.T) {
 		t.Fatalf("saveRegistryNow: %v", err)
 	}
 	var reloaded Registry
-	data, err := os.ReadFile(registryPath)
+	data, err := os.ReadFile(s.registryPath)
 	if err != nil {
 		t.Fatalf("read registry: %v", err)
 	}

--- a/v2/pkg/hub/hosted_namespace_identity.go
+++ b/v2/pkg/hub/hosted_namespace_identity.go
@@ -1,0 +1,354 @@
+package hub
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"strings"
+	"time"
+)
+
+// ============================================================================
+// HOSTED NAMESPACE IDENTITY — making a namespace self-describing
+// ============================================================================
+//
+// A hosted hive's Kubernetes namespace is created ONCE, at provisioning time,
+// named after whatever ID the hive had THEN — almost always a pool
+// placeholder ID like "hive-hosted-hosted-available-oke-03-placeholder-y99x".
+// When that placeholder is later claimed by a real owner/org (approve-provision
+// or the manual assign path), the hive's meta.json is rewritten with the real
+// identity, but the NAMESPACE NAME is never renamed — Kubernetes has no atomic
+// namespace-rename primitive, and renaming would mean recreating every object
+// inside it. The namespace therefore keeps its placeholder name FOREVER, and
+// there is no way to go from "which namespace is this?" back to "which hive/
+// org is running here?" without cross-referencing the hub's hive registry and
+// reverse-engineering a mangled slug.
+//
+// The fix is not to rename the namespace — it is to make the namespace
+// self-describing by stamping identity labels (and a human-readable
+// annotation) onto it at every point the hive's identity is known or changes:
+//
+//  1. hosted namespace CREATION (provisionHive) — stamp what's known then
+//     (at minimum the hive_id; org/name may still be placeholder values).
+//  2. CLAIM (handleApproveProvision) — the hive's real name/org become known
+//     here for the first time, so the labels MUST be (re)written.
+//  3. ASSIGN / reassign (handleAssignHive) — same: refresh the labels so a
+//     reassigned placeholder's namespace reflects its new owner.
+//
+// All three call stampHostedNamespaceIdentity, which idempotently patches the
+// namespace's labels/annotations via `kubectl label`/`kubectl annotate`
+// (--overwrite) rather than recreating it, and merges into whatever labels
+// already exist instead of clobbering them.
+
+const (
+	// hiveLabelPrefix is the label/annotation prefix already established
+	// elsewhere in this package (see self_upgrade.go's restart-at/
+	// upgrade-target-sha annotations) — reused here rather than inventing a
+	// second convention.
+	hiveLabelPrefix = "hive.kubestellar.io/"
+
+	// hiveNameLabel/hiveOrgLabel/hiveIDLabel are RFC-1123-safe label VALUES
+	// (see sanitizeLabelValue) recording the hive's identity on its namespace.
+	hiveNameLabel = hiveLabelPrefix + "hive-name"
+	hiveOrgLabel  = hiveLabelPrefix + "org"
+	hiveIDLabel   = hiveLabelPrefix + "hive-id"
+
+	// hiveDisplayNameAnnotation carries the EXACT, unsanitized hive name.
+	// Annotations allow arbitrary values, so this is the recoverable source of
+	// truth when the sanitized label value has been lossily transformed
+	// (capitals folded, unicode stripped, truncated to 63 chars, ...).
+	hiveDisplayNameAnnotation = hiveLabelPrefix + "display-name"
+
+	// maxLabelValueLen is the Kubernetes label-value length limit (RFC 1123
+	// label / DNS label rules), enforced by sanitizeLabelValue.
+	maxLabelValueLen = 63
+)
+
+// hiveNamespaceIdentityLabels builds the labels and annotations that make a
+// hosted hive's namespace self-describing: given the hive's display name, its
+// forge org, and its internal hive_id, it returns the label map (sanitized,
+// RFC-1123-safe values) and the annotation map (the exact display name).
+//
+// A field whose sanitized value is empty is OMITTED from the labels map
+// rather than written as an invalid/empty label — Kubernetes rejects an empty
+// label value only in some API versions, but an omitted key is unambiguous
+// and never fails validation. The display-name annotation is included only
+// when the raw name is non-empty (an empty annotation value is legal but
+// pointless — the omission of hiveNameLabel already tells the same story).
+func hiveNamespaceIdentityLabels(name, org, hiveID string) (labels map[string]string, annotations map[string]string) {
+	labels = map[string]string{}
+	annotations = map[string]string{}
+
+	if v := sanitizeLabelValue(name); v != "" {
+		labels[hiveNameLabel] = v
+	}
+	if v := sanitizeLabelValue(org); v != "" {
+		labels[hiveOrgLabel] = v
+	}
+	if v := sanitizeLabelValue(hiveID); v != "" {
+		labels[hiveIDLabel] = v
+	}
+	if trimmed := strings.TrimSpace(name); trimmed != "" {
+		annotations[hiveDisplayNameAnnotation] = trimmed
+	}
+
+	return labels, annotations
+}
+
+// sanitizeLabelValue converts an arbitrary string into a valid Kubernetes
+// label value: lower-case, restricted to [a-z0-9.-], trimmed of leading and
+// trailing non-alphanumeric characters, and capped at 63 characters (the
+// RFC-1123 label-value limit).
+//
+// Kubernetes label values must match
+// (([A-Za-z0-9])|([A-Za-z0-9][A-Za-z0-9\-_.]*[A-Za-z0-9]))? — this function
+// deliberately narrows that to a stricter [a-z0-9.-] subset (no uppercase, no
+// underscore) so the SAME sanitizer is safe to reuse anywhere a
+// lower-cased/DNS-label-like value is wanted, matching the style of the
+// existing `sanitize` helper in saas_provision.go (which does the same for
+// hive IDs, minus dots). Unicode and any other byte is dropped outright
+// rather than transliterated — a confident wrong transliteration is worse
+// than an honestly shortened value, and the exact original is always
+// recoverable from the paired display-name annotation.
+//
+// Edge cases handled explicitly so this never produces an invalid label
+// value: empty input returns ""; a string that sanitizes to only separators
+// (e.g. "---", "...") returns "" after trimming; a value longer than 63
+// characters is truncated and then re-trimmed in case truncation left a
+// trailing separator.
+func sanitizeLabelValue(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '.':
+			b.WriteRune(r)
+		default:
+			// Unicode letters/digits, spaces, underscores, and everything else
+			// are dropped rather than mapped to '-': collapsing runs of dropped
+			// characters to a single separator would still be a lossy guess at
+			// intent, and the raw value survives in the paired annotation.
+		}
+	}
+	out := b.String()
+
+	out = strings.Trim(out, "-.")
+	if out == "" {
+		return ""
+	}
+
+	if len(out) > maxLabelValueLen {
+		out = out[:maxLabelValueLen]
+		out = strings.Trim(out, "-.")
+	}
+
+	return out
+}
+
+// hostedNamespaceForHive returns the Kubernetes namespace a hosted hive runs
+// in. Every call site in this package has historically inlined
+// "hive-hosted-"+id (see hiveHostedNamespacePrefix in saas.go); this is the
+// same computation, added here so the claim/assign call sites below and any
+// future caller share one definition instead of re-deriving it.
+func hostedNamespaceForHive(h *SaaSHive) string {
+	if h == nil {
+		return ""
+	}
+	return hiveHostedNamespacePrefix + h.ID
+}
+
+// stampHostedNamespaceIdentity idempotently patches a hosted hive's namespace
+// with the identity labels/annotations from hiveNamespaceIdentityLabels, via
+// `kubectl label`/`kubectl annotate --overwrite`. It merges into whatever
+// labels the namespace already carries rather than recreating it — safe to
+// call on a namespace that does not exist yet only if the caller applies the
+// namespace-creation manifest first (see provisionHive, which does).
+//
+// Best-effort: a failure here (e.g. no kubectl on PATH, namespace not yet
+// created, transient API error) is logged and swallowed rather than failing
+// the caller's request. The alternative — failing a claim/assign because a
+// cosmetic label patch failed — would turn an operability nicety into an
+// availability regression, and the heartbeat/provisioning retry paths in this
+// package already tolerate exactly this kind of partial failure (see
+// makeVanityHostServable's "log at Warn, keep working" precedent).
+//
+// Bounded by stampNamespaceIdentityTimeout via kubectlForClusterContext —
+// the same context+"--request-timeout" idiom buildSingleClusterHealth and
+// RolloutRestartSelf already use for kubectl calls that must never hang the
+// HTTP request that triggered them (claim/assign are synchronous admin API
+// calls; an unreachable cluster must fail this cosmetic step fast, not stall
+// the response).
+func stampHostedNamespaceIdentity(cluster *ClusterConfig, namespace, name, org, hiveID string, logger *slog.Logger) {
+	if cluster == nil || strings.TrimSpace(namespace) == "" {
+		return
+	}
+	labels, annotations := hiveNamespaceIdentityLabels(name, org, hiveID)
+	if len(labels) == 0 && len(annotations) == 0 {
+		return
+	}
+
+	if len(labels) > 0 {
+		args := []string{"--request-timeout", stampNamespaceIdentityTimeout.String(), "label", "namespace", namespace, "--overwrite"}
+		for k, v := range labels {
+			args = append(args, fmt.Sprintf("%s=%s", k, v))
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), stampNamespaceIdentityTimeout)
+		out, err := kubectlForClusterContext(ctx, cluster, args...).CombinedOutput()
+		cancel()
+		if err != nil {
+			if logger != nil {
+				logger.Warn("failed to label hosted namespace with hive identity",
+					"namespace", namespace, "cluster", cluster.ID, "output", string(out), "error", err)
+			}
+		}
+	}
+
+	if len(annotations) > 0 {
+		args := []string{"--request-timeout", stampNamespaceIdentityTimeout.String(), "annotate", "namespace", namespace, "--overwrite"}
+		for k, v := range annotations {
+			args = append(args, fmt.Sprintf("%s=%s", k, v))
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), stampNamespaceIdentityTimeout)
+		out, err := kubectlForClusterContext(ctx, cluster, args...).CombinedOutput()
+		cancel()
+		if err != nil {
+			if logger != nil {
+				logger.Warn("failed to annotate hosted namespace with hive display name",
+					"namespace", namespace, "cluster", cluster.ID, "output", string(out), "error", err)
+			}
+		}
+	}
+}
+
+// stampNamespaceIdentityTimeout bounds each kubectl label/annotate call in
+// stampHostedNamespaceIdentity. Matches upgradeKubectlTimeout's value — both
+// are a single synchronous kubectl call issued from an HTTP handler, so both
+// need to fail fast against an unreachable cluster rather than hold the
+// request (or, in tests with no kubectl on PATH / no reachable API server,
+// hold the test) for kubectl's own default timeout.
+const stampNamespaceIdentityTimeout = 15 * time.Second
+
+// ============================================================================
+// OPTION B — a name-bearing Route, without renaming the namespace
+// ============================================================================
+//
+// A hosted spoke's public URL on OpenShift is an OpenShift Route host. Because
+// the namespace never renames (see above), a Route whose host is DERIVED from
+// the namespace name — the original provisioning template sets exactly one
+// host, DashboardHost = "<hive-id>.<cluster domain>" — permanently encodes the
+// placeholder slug (e.g. "hosted-available-vllmd-06.apps...") rather than the
+// hive's name, even after the hive is claimed by "TradingAsBuddies"/devx-prod.
+//
+// RENAMING OR MIGRATING THE NAMESPACE IS OFF THE TABLE: it would mean a
+// teardown + recreate + PVC/PV migration + outage. Nothing here creates a
+// replacement namespace or moves a PVC.
+//
+// The fix already exists in this file as of the vanity-URL feature
+// (addVanityHostToIngress, called from handleAssignHive and the retroactive
+// repair repairVanityURLForHive): OpenShift lets a Route's spec.host be set
+// EXPLICITLY, independent of the namespace it lives in, so an ADDITIONAL
+// "<name>-vanity" Route — same Service backend, same namespace — gives the
+// hive a name-bearing URL without touching the namespace, PVC, Deployment, or
+// Service. The ORIGINAL Route (and its placeholder host) is left completely
+// alone, so any in-flight bookmark/callback against it keeps working.
+//
+// That existing mechanism keys its hostname off org+primary-repo
+// (generateHiveID). hiveNameHostLabel below is the DNS-label-safe sanitizer
+// for building the SAME kind of name-bearing host from the hive's own display
+// NAME instead — reusing sanitizeLabelValue's stripping logic but enforcing
+// hostname-specific rules (a label value may lead/trail with '.', a DNS label
+// may not). hiveNameVanityHost composes it into a full host; handleAssignHive
+// (saas.go) calls it to prefer a name-bearing host over the org/repo-derived
+// one when the hive has a display name, then hands the result to the SAME
+// existing get-or-create path — makeVanityHostServable /
+// addVanityHostToIngress — so the idempotency, cluster-domain handling, and
+// "never adopt an unservable host" guarantees are unchanged from before this
+// feature existed.
+
+// hiveNameHostLabel converts a hive's display name into a single valid DNS
+// label (RFC 1123): lowercase, [a-z0-9-] only, no leading or trailing dash,
+// max 63 characters. This is DELIBERATELY STRICTER than sanitizeLabelValue —
+// a Kubernetes label VALUE may contain '.', but a single DNS LABEL (one dot-
+// separated segment of a hostname) may not, so '.' is dropped here rather
+// than kept.
+//
+// Unicode and punctuation are dropped outright, matching sanitizeLabelValue's
+// stance: a confident wrong transliteration is worse than an honestly
+// shortened value, and the exact name is recoverable from the
+// hive.kubestellar.io/display-name annotation stamped on the namespace.
+func hiveNameHostLabel(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			b.WriteRune(r)
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if len(out) > maxLabelValueLen {
+		out = strings.Trim(out[:maxLabelValueLen], "-")
+	}
+	return out
+}
+
+// vanityHostSuffixLen is the length of the random uniqueness suffix appended
+// to a name-bearing vanity host, matching generateHiveID's existing suffix
+// length so both host-generation schemes read consistently and collide with
+// the same (very low) probability.
+const vanityHostSuffixLen = 4
+
+// randomHostSuffix returns a short lowercase alphanumeric string, used to
+// keep two hives with similar/identical sanitized names from colliding on the
+// same vanity host. Mirrors generateHiveID's own suffix generation.
+func randomHostSuffix() string {
+	const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, vanityHostSuffixLen)
+	for i := range b {
+		b[i] = chars[rand.Intn(len(chars))]
+	}
+	return string(b)
+}
+
+// hiveNameVanityHost builds a name-bearing hostname for a hive, of the form
+// "<sanitized-name>-<suffix>.<domain>". name is typically the hive's
+// ProjectName/display name (falling back to org-repo elsewhere when a hive
+// has no display name — see hiveNameOrFallback). domain is the cluster's
+// wildcard apps domain, which the caller must supply from a source of truth
+// it already trusts (cluster.Domain from config, or one parsed off an
+// existing Route — see vanityHostDomainFromExistingRoute) rather than a
+// hardcoded value.
+//
+// Returns "" when either input is unusable (empty domain, or a name that
+// sanitizes to nothing) — the caller must treat that as "cannot build a host"
+// and skip rather than fabricate one, per the same fail-closed rule
+// addVanityHostToIngress already follows for an unreachable cluster.
+func hiveNameVanityHost(name, domain string) string {
+	domain = strings.TrimSpace(strings.Trim(domain, "."))
+	label := hiveNameHostLabel(name)
+	if domain == "" || label == "" {
+		return ""
+	}
+	return label + "-" + randomHostSuffix() + "." + domain
+}
+
+// vanityHostDomainFromExistingRoute extracts the wildcard apps domain from an
+// existing Route's host, by stripping its leading "<hive-id>." label. Used as
+// a fallback source of truth for the domain when the caller does not already
+// have cluster.Domain in hand, so the domain is always DERIVED from
+// something real on the cluster rather than assumed. Returns "" when
+// existingHost does not look like "<something>.<domain...>" (no dot), which
+// the caller must treat as "cannot determine the domain" and skip creating a
+// Route rather than guess.
+func vanityHostDomainFromExistingRoute(existingHost string) string {
+	existingHost = strings.TrimSpace(existingHost)
+	i := strings.Index(existingHost, ".")
+	if i < 0 || i == len(existingHost)-1 {
+		return ""
+	}
+	return existingHost[i+1:]
+}

--- a/v2/pkg/hub/hosted_namespace_identity_test.go
+++ b/v2/pkg/hub/hosted_namespace_identity_test.go
@@ -1,0 +1,560 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ============================================================
+// hosted_namespace_identity.go — sanitizeLabelValue /
+// hiveNamespaceIdentityLabels / stampHostedNamespaceIdentity, plus the three
+// call sites that must stamp a hosted namespace's identity: provisionHive
+// (creation), handleApproveProvision (claim), handleAssignHive (assign).
+// ============================================================
+
+func TestSanitizeLabelValue(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"already valid", "acme-repo", "acme-repo"},
+		{"caps folded", "TradingAsBuddies", "tradingasbuddies"},
+		{"spaces stripped", "Trading As Buddies", "tradingasbuddies"},
+		{"unicode dropped", "café-org", "caf-org"},
+		{"leading/trailing dash trimmed", "-acme-", "acme"},
+		{"leading/trailing dot trimmed", ".acme.", "acme"},
+		{"only separators", "---", ""},
+		{"dots and dashes preserved mid-string", "acme.corp-inc", "acme.corp-inc"},
+		{"underscore dropped", "acme_corp", "acmecorp"},
+		{"whitespace-only", "   ", ""},
+		{"exactly 63 chars kept whole", strings.Repeat("a", 63), strings.Repeat("a", 63)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeLabelValue(tc.in)
+			if got != tc.want {
+				t.Errorf("sanitizeLabelValue(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if len(got) > maxLabelValueLen {
+				t.Errorf("sanitizeLabelValue(%q) = %q exceeds %d chars", tc.in, got, maxLabelValueLen)
+			}
+		})
+	}
+}
+
+func TestSanitizeLabelValueLongInputTruncatedAndRetrimmed(t *testing.T) {
+	// 70 'a's followed by a run of dashes that would land exactly at the cut
+	// point — truncation must not leave a trailing separator.
+	in := strings.Repeat("a", 60) + "----------"
+	got := sanitizeLabelValue(in)
+	if len(got) > maxLabelValueLen {
+		t.Fatalf("result exceeds max length: %d", len(got))
+	}
+	if strings.HasSuffix(got, "-") || strings.HasSuffix(got, ".") {
+		t.Errorf("sanitizeLabelValue(%q) = %q ends in a separator after truncation", in, got)
+	}
+	if got != strings.Repeat("a", 60) {
+		t.Errorf("sanitizeLabelValue(%q) = %q, want %q", in, got, strings.Repeat("a", 60))
+	}
+}
+
+func TestSanitizeLabelValueNeverProducesInvalidValue(t *testing.T) {
+	// Fuzz-lite: a battery of adversarial inputs must never yield a value
+	// starting/ending in '-'/'.' or exceeding the length limit.
+	inputs := []string{
+		"", " ", "\t\n", "----...----", "A.B.C", "..hidden", "trailing.",
+		"日本語", "MiXeD_Case-Name.With.Dots", strings.Repeat("x-", 40),
+		"🎉party🎉", "a", "-", ".", "a-",
+	}
+	for _, in := range inputs {
+		got := sanitizeLabelValue(in)
+		if got == "" {
+			continue
+		}
+		if len(got) > maxLabelValueLen {
+			t.Errorf("sanitizeLabelValue(%q) = %q too long (%d)", in, got, len(got))
+		}
+		if strings.HasPrefix(got, "-") || strings.HasPrefix(got, ".") ||
+			strings.HasSuffix(got, "-") || strings.HasSuffix(got, ".") {
+			t.Errorf("sanitizeLabelValue(%q) = %q has leading/trailing separator", in, got)
+		}
+		for _, r := range got {
+			if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '.') {
+				t.Errorf("sanitizeLabelValue(%q) = %q contains disallowed rune %q", in, got, r)
+			}
+		}
+	}
+}
+
+func TestHiveNamespaceIdentityLabels(t *testing.T) {
+	labels, annotations := hiveNamespaceIdentityLabels("TradingAsBuddies", "falcon-core", "hosted-falcon-buddies-a1b2")
+
+	if got := labels[hiveNameLabel]; got != "tradingasbuddies" {
+		t.Errorf("hive-name label = %q, want %q", got, "tradingasbuddies")
+	}
+	if got := labels[hiveOrgLabel]; got != "falcon-core" {
+		t.Errorf("org label = %q, want %q", got, "falcon-core")
+	}
+	if got := labels[hiveIDLabel]; got != "hosted-falcon-buddies-a1b2" {
+		t.Errorf("hive-id label = %q, want %q", got, "hosted-falcon-buddies-a1b2")
+	}
+	if got := annotations[hiveDisplayNameAnnotation]; got != "TradingAsBuddies" {
+		t.Errorf("display-name annotation = %q, want exact unsanitized %q", got, "TradingAsBuddies")
+	}
+}
+
+func TestHiveNamespaceIdentityLabelsOmitsEmptyFields(t *testing.T) {
+	// A hive with no name yet (a bare pool placeholder) must not get an empty
+	// or invalid hive-name label, and must not get a display-name annotation
+	// with an empty value.
+	labels, annotations := hiveNamespaceIdentityLabels("", "", "hosted-oke-03-placeholder-y99x")
+
+	if _, ok := labels[hiveNameLabel]; ok {
+		t.Errorf("hive-name label present with empty input: %v", labels)
+	}
+	if _, ok := labels[hiveOrgLabel]; ok {
+		t.Errorf("org label present with empty input: %v", labels)
+	}
+	if got := labels[hiveIDLabel]; got != "hosted-oke-03-placeholder-y99x" {
+		t.Errorf("hive-id label = %q, want %q", got, "hosted-oke-03-placeholder-y99x")
+	}
+	if _, ok := annotations[hiveDisplayNameAnnotation]; ok {
+		t.Errorf("display-name annotation present with empty input: %v", annotations)
+	}
+}
+
+func TestHiveNamespaceIdentityLabelsAllEmpty(t *testing.T) {
+	labels, annotations := hiveNamespaceIdentityLabels("", "", "")
+	if len(labels) != 0 {
+		t.Errorf("expected no labels for all-empty input, got %v", labels)
+	}
+	if len(annotations) != 0 {
+		t.Errorf("expected no annotations for all-empty input, got %v", annotations)
+	}
+}
+
+// installLoggingKubectl writes a fake kubectl that appends its full argument
+// list to a log file (one line per invocation) and exits 0, so tests can
+// assert exactly what stampHostedNamespaceIdentity ran without a real
+// cluster. Returns the log file path.
+func installLoggingKubectl(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "kubectl.log")
+	script := `#!/bin/sh
+echo "$*" >> "` + logPath + `"
+echo "{}"
+exit 0
+`
+	path := filepath.Join(dir, "kubectl")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return logPath
+}
+
+func TestStampHostedNamespaceIdentityInvokesKubectlLabelAndAnnotate(t *testing.T) {
+	logPath := installLoggingKubectl(t)
+	cluster := &ClusterConfig{ID: "hive-oke", InCluster: true}
+
+	stampHostedNamespaceIdentity(cluster, "hive-hosted-hosted-falcon-buddies-a1b2",
+		"TradingAsBuddies", "falcon-core", "hosted-falcon-buddies-a1b2", slog.Default())
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading kubectl log: %v", err)
+	}
+	logged := string(data)
+
+	if !strings.Contains(logged, "label namespace hive-hosted-hosted-falcon-buddies-a1b2 --overwrite") {
+		t.Errorf("expected a kubectl label invocation, got:\n%s", logged)
+	}
+	if !strings.Contains(logged, hiveNameLabel+"=tradingasbuddies") {
+		t.Errorf("expected hive-name label in kubectl args, got:\n%s", logged)
+	}
+	if !strings.Contains(logged, hiveOrgLabel+"=falcon-core") {
+		t.Errorf("expected org label in kubectl args, got:\n%s", logged)
+	}
+	if !strings.Contains(logged, hiveIDLabel+"=hosted-falcon-buddies-a1b2") {
+		t.Errorf("expected hive-id label in kubectl args, got:\n%s", logged)
+	}
+	if !strings.Contains(logged, "annotate namespace hive-hosted-hosted-falcon-buddies-a1b2 --overwrite") {
+		t.Errorf("expected a kubectl annotate invocation, got:\n%s", logged)
+	}
+	if !strings.Contains(logged, hiveDisplayNameAnnotation+"=TradingAsBuddies") {
+		t.Errorf("expected display-name annotation with EXACT unsanitized name, got:\n%s", logged)
+	}
+}
+
+func TestStampHostedNamespaceIdentityNoopOnNilClusterOrEmptyNamespace(t *testing.T) {
+	logPath := installLoggingKubectl(t)
+
+	stampHostedNamespaceIdentity(nil, "hive-hosted-x", "name", "org", "id", slog.Default())
+	stampHostedNamespaceIdentity(&ClusterConfig{ID: "c", InCluster: true}, "", "name", "org", "id", slog.Default())
+
+	if data, err := os.ReadFile(logPath); err == nil && len(data) != 0 {
+		t.Errorf("expected no kubectl invocations, got:\n%s", string(data))
+	}
+}
+
+func TestStampHostedNamespaceIdentityToleratesKubectlFailure(t *testing.T) {
+	// A failing kubectl must not panic and must be swallowed (best-effort).
+	dir := t.TempDir()
+	script := "#!/bin/sh\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// Must not panic.
+	stampHostedNamespaceIdentity(&ClusterConfig{ID: "c", InCluster: true}, "hive-hosted-x", "n", "o", "i", slog.Default())
+}
+
+func TestHostedNamespaceForHive(t *testing.T) {
+	if got := hostedNamespaceForHive(nil); got != "" {
+		t.Errorf("hostedNamespaceForHive(nil) = %q, want empty", got)
+	}
+	h := &SaaSHive{ID: "hosted-acme-repo-abcd"}
+	if got := hostedNamespaceForHive(h); got != "hive-hosted-hosted-acme-repo-abcd" {
+		t.Errorf("hostedNamespaceForHive = %q, want %q", got, "hive-hosted-hosted-acme-repo-abcd")
+	}
+}
+
+// TestProvisionHiveStampsNamespaceIdentity guards entry point 1: automatic
+// (pool) provisioning must stamp what's known at creation time, at minimum
+// the hive_id.
+func TestProvisionHiveStampsNamespaceIdentity(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	logPath := installLoggingKubectl(t)
+
+	h := &SaaSHive{ID: "hosted-acme-repo-abcd", Owner: "alice", Org: "acme", Repos: []string{"repo"}, PrimaryRepo: "repo", ACMMLevel: 2}
+	req := &CreateHiveRequest{Org: "acme", Repos: "repo", PrimaryRepo: "repo", ACMMLevel: 2, ClusterID: "hive-oke"}
+
+	if err := provisionHive(h, req, dynamicCluster(), nil, slog.Default()); err != nil {
+		t.Fatalf("provisionHive: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading kubectl log: %v", err)
+	}
+	logged := string(data)
+	if !strings.Contains(logged, "label namespace hive-hosted-hosted-acme-repo-abcd") {
+		t.Errorf("expected provisionHive to label the namespace it just created, got:\n%s", logged)
+	}
+	if !strings.Contains(logged, hiveIDLabel+"=hosted-acme-repo-abcd") {
+		t.Errorf("expected hive-id label stamped at creation, got:\n%s", logged)
+	}
+}
+
+// TestHandleApproveProvisionStampsNamespaceIdentity guards entry point 2: the
+// claim path is where the hive's real name/org first become known, so the
+// namespace labels must be (re)written here.
+func TestHandleApproveProvisionStampsNamespaceIdentity(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	logPath := installLoggingKubectl(t)
+	mkUser(t, hubAdminUsername)
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, saveCh: make(chan struct{}, 1), clusters: map[string]ClusterConfig{"hive-oke": *dynamicCluster()}}
+
+	saveProvisionRequest(&ProvisionRequest{
+		Username: "bob", Org: "falcon-core", Repos: "buddies", PrimaryRepo: "buddies", ACMMLevel: 2,
+		AuthMethod: "public", RequestedAt: time.Now().UTC().Format(time.RFC3339), Status: provisionStatusPending,
+	})
+	saveSaaSHive(&SaaSHive{ID: "hosted-avail-y99x", Owner: hubAdminUsername, Status: statusAvailable, ClusterID: "hive-oke"})
+
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/approve-prov", "", hubAdminUsername), "username", "bob")
+	s.handleApproveProvision(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("approve status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading kubectl log: %v", err)
+	}
+	logged := string(data)
+	if !strings.Contains(logged, "label namespace hive-hosted-hosted-avail-y99x --overwrite") {
+		t.Errorf("expected claim to (re)label the placeholder's namespace, got:\n%s", logged)
+	}
+	if !strings.Contains(logged, hiveOrgLabel+"=falcon-core") {
+		t.Errorf("expected org label with the newly-claimed org, got:\n%s", logged)
+	}
+}
+
+// ============================================================
+// Option B — hiveNameHostLabel / hiveNameVanityHost /
+// vanityHostDomainFromExistingRoute, plus handleAssignHive preferring a
+// name-bearing vanity host when the hive has a display name.
+// ============================================================
+
+func TestHiveNameHostLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"already valid", "acme-repo", "acme-repo"},
+		{"caps folded", "TradingAsBuddies", "tradingasbuddies"},
+		{"spaces stripped", "Trading As Buddies", "tradingasbuddies"},
+		{"dots dropped (unlike label sanitizer)", "acme.corp", "acmecorp"},
+		{"leading/trailing dash trimmed", "-acme-", "acme"},
+		{"only dashes", "----", ""},
+		{"underscore dropped", "acme_corp", "acmecorp"},
+		{"unicode dropped", "café", "caf"},
+		{"exactly 63 chars kept whole", strings.Repeat("a", 63), strings.Repeat("a", 63)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hiveNameHostLabel(tc.in)
+			if got != tc.want {
+				t.Errorf("hiveNameHostLabel(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if len(got) > maxLabelValueLen {
+				t.Errorf("hiveNameHostLabel(%q) = %q exceeds %d chars", tc.in, got, maxLabelValueLen)
+			}
+			for _, r := range got {
+				if r == '.' {
+					t.Errorf("hiveNameHostLabel(%q) = %q contains a dot, which is not a valid DNS-label character", tc.in, got)
+				}
+			}
+		})
+	}
+}
+
+func TestHiveNameHostLabelLongInputTruncatedAndRetrimmed(t *testing.T) {
+	in := strings.Repeat("a", 60) + "----------"
+	got := hiveNameHostLabel(in)
+	if len(got) > maxLabelValueLen {
+		t.Fatalf("result exceeds max length: %d", len(got))
+	}
+	if strings.HasSuffix(got, "-") {
+		t.Errorf("hiveNameHostLabel(%q) = %q ends in a dash after truncation", in, got)
+	}
+}
+
+func TestHiveNameVanityHost(t *testing.T) {
+	host := hiveNameVanityHost("TradingAsBuddies", "apps.example.com")
+	if !strings.HasPrefix(host, "tradingasbuddies-") {
+		t.Errorf("hiveNameVanityHost = %q, want prefix %q", host, "tradingasbuddies-")
+	}
+	if !strings.HasSuffix(host, ".apps.example.com") {
+		t.Errorf("hiveNameVanityHost = %q, want suffix %q", host, ".apps.example.com")
+	}
+	// label-suffix-domain: exactly one more dash-delimited random suffix
+	// between the sanitized label and the domain.
+	labelAndSuffix := strings.TrimSuffix(host, ".apps.example.com")
+	parts := strings.Split(labelAndSuffix, "-")
+	if len(parts) < 2 {
+		t.Fatalf("hiveNameVanityHost = %q, want a label-suffix pair before the domain", host)
+	}
+	suffix := parts[len(parts)-1]
+	if len(suffix) != vanityHostSuffixLen {
+		t.Errorf("suffix %q has length %d, want %d", suffix, len(suffix), vanityHostSuffixLen)
+	}
+}
+
+func TestHiveNameVanityHostUniquenessAcrossCalls(t *testing.T) {
+	// Two hives with the SAME sanitized name must not collide on the same
+	// host — the random suffix is what prevents that.
+	seen := map[string]bool{}
+	for i := 0; i < 20; i++ {
+		h := hiveNameVanityHost("TradingAsBuddies", "apps.example.com")
+		if seen[h] {
+			t.Fatalf("hiveNameVanityHost produced a duplicate host across calls: %q", h)
+		}
+		seen[h] = true
+	}
+}
+
+func TestHiveNameVanityHostEmptyOnUnusableInput(t *testing.T) {
+	if got := hiveNameVanityHost("TradingAsBuddies", ""); got != "" {
+		t.Errorf("hiveNameVanityHost with empty domain = %q, want empty (never fabricate a domain)", got)
+	}
+	if got := hiveNameVanityHost("", "apps.example.com"); got != "" {
+		t.Errorf("hiveNameVanityHost with unsanitizable name = %q, want empty", got)
+	}
+	if got := hiveNameVanityHost("---", "apps.example.com"); got != "" {
+		t.Errorf("hiveNameVanityHost(%q) = %q, want empty (name sanitizes to nothing)", "---", got)
+	}
+}
+
+func TestVanityHostDomainFromExistingRoute(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"hosted-acme-repo-abcd.apps.example.com", "apps.example.com"},
+		{"hosted-x.hive.kubestellar.io", "hive.kubestellar.io"},
+		{"no-dot-here", ""},
+		{"", ""},
+		{"trailing-dot.", ""},
+	}
+	for _, tc := range cases {
+		if got := vanityHostDomainFromExistingRoute(tc.in); got != tc.want {
+			t.Errorf("vanityHostDomainFromExistingRoute(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestHandleAssignHivePrefersNameBearingVanityHost guards Option B: at
+// assignment, a hive with a display name (ProjectName) gets a vanity host
+// built from that name rather than the org/repo-derived one, without
+// changing the namespace, and via the SAME get-or-create route-creation seam
+// (vanityHostServable, stubbed here exactly as the existing vanity-URL tests
+// stub it) — so this only proves the HOST CHOICE changed, not the mechanism.
+func TestHandleAssignHivePrefersNameBearingVanityHost(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+
+	s := &HubServer{
+		logger: slog.Default(), hubSecret: testHubSecret, saveCh: make(chan struct{}, 1),
+		clusters: map[string]ClusterConfig{"hive-oke": *dynamicCluster()},
+	}
+	var gotHost string
+	s.vanityHostServable = func(_, host string, _ *ClusterConfig) error {
+		gotHost = host
+		return nil
+	}
+	saveSaaSHive(&SaaSHive{ID: "hosted-avail-nb01", Owner: hubAdminUsername, Status: statusAvailable, ClusterID: "hive-oke"})
+
+	body := `{"owner":"carol","org":"falcon-core","repos":"buddies","primary_repo":"buddies","acmm_level":2,"project_name":"TradingAsBuddies"}`
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/api/saas/hives/hosted-avail-nb01/assign", body, hubAdminUsername), "id", "hosted-avail-nb01")
+	s.handleAssignHive(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("assign status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	if !strings.HasPrefix(gotHost, "tradingasbuddies-") {
+		t.Errorf("vanity host = %q, want a name-bearing host prefixed %q", gotHost, "tradingasbuddies-")
+	}
+
+	got := loadSaaSHive("hosted-avail-nb01")
+	if got == nil {
+		t.Fatal("expected saved hive")
+	}
+	if !strings.Contains(got.VanityURL, "tradingasbuddies-") {
+		t.Errorf("VanityURL = %q, want it to contain the name-bearing host", got.VanityURL)
+	}
+	// The namespace itself must be untouched — same id as before assignment.
+	if got.ID != "hosted-avail-nb01" {
+		t.Errorf("hive ID changed from %q to %q — namespace must never be renamed/migrated", "hosted-avail-nb01", got.ID)
+	}
+}
+
+// TestHandleAssignHiveFallsBackToOrgRepoHostWithoutDisplayName guards that a
+// hive assigned with no project_name behaves EXACTLY as before this feature:
+// the org/repo-derived vanity host, unchanged.
+func TestHandleAssignHiveFallsBackToOrgRepoHostWithoutDisplayName(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+
+	s := &HubServer{
+		logger: slog.Default(), hubSecret: testHubSecret, saveCh: make(chan struct{}, 1),
+		clusters: map[string]ClusterConfig{"hive-oke": *dynamicCluster()},
+	}
+	var gotHost string
+	s.vanityHostServable = func(_, host string, _ *ClusterConfig) error {
+		gotHost = host
+		return nil
+	}
+	saveSaaSHive(&SaaSHive{ID: "hosted-avail-nb02", Owner: hubAdminUsername, Status: statusAvailable, ClusterID: "hive-oke"})
+
+	body := `{"owner":"dave","org":"acme","repos":"widgets","primary_repo":"widgets","acmm_level":2}`
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/api/saas/hives/hosted-avail-nb02/assign", body, hubAdminUsername), "id", "hosted-avail-nb02")
+	s.handleAssignHive(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("assign status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	if !strings.HasPrefix(gotHost, "hosted-acme-widgets-") {
+		t.Errorf("vanity host = %q, want the unchanged org/repo-derived host prefixed %q", gotHost, "hosted-acme-widgets-")
+	}
+}
+
+// TestK8sManifestTemplateSetsPodNamespaceDownwardAPI guards that the spoke
+// Deployment template wires POD_NAMESPACE via the Kubernetes downward API
+// (fieldRef: metadata.namespace) — the spoke-side source of truth
+// pkg/dashboard/pod_namespace.go's podNamespace() reads first, for the Hub
+// tab's namespace row.
+func TestK8sManifestTemplateSetsPodNamespaceDownwardAPI(t *testing.T) {
+	if !strings.Contains(k8sManifestTemplate, "name: POD_NAMESPACE") {
+		t.Error("k8sManifestTemplate is missing a POD_NAMESPACE env var")
+	}
+	if !strings.Contains(k8sManifestTemplate, "fieldPath: metadata.namespace") {
+		t.Error("k8sManifestTemplate's POD_NAMESPACE is not wired via the downward API (fieldRef: metadata.namespace)")
+	}
+}
+
+// TestStatusHoverRendersNamespace pins the hub dashboard's status hover
+// (healthBadge in the inline dashboardHTML JS) to include the hosted
+// namespace line — the hub-side surface an operator uses to map a
+// Kubernetes namespace back to a hive without touching the cluster. Mirrors
+// the structure-pin style of TestHoverPanelRendersConsolidatedSections in
+// hover_timeline_relay_test.go.
+func TestStatusHoverRendersNamespace(t *testing.T) {
+	cases := []struct {
+		name    string
+		snippet string
+	}{
+		{"namespace line is composed into the hover", "lines.push('Namespace: ' + hns);"},
+		{"hiveNamespace helper exists", "function hiveNamespace(h)"},
+		{"hiveNamespace derives from hive-hosted- + id", "return 'hive-hosted-' + h.id;"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(dashboardHTML, tc.snippet) {
+				t.Errorf("dashboardHTML is missing %q", tc.snippet)
+			}
+		})
+	}
+}
+
+// TestHandleAssignHiveStampsNamespaceIdentity guards entry point 3: the
+// assign/reassign path must refresh the namespace labels too.
+func TestHandleAssignHiveStampsNamespaceIdentity(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	logPath := installLoggingKubectl(t)
+	mkUser(t, hubAdminUsername)
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, saveCh: make(chan struct{}, 1), clusters: map[string]ClusterConfig{"hive-oke": *dynamicCluster()}}
+	saveSaaSHive(&SaaSHive{ID: "hosted-avail-z01a", Owner: hubAdminUsername, Status: statusAvailable, ClusterID: "hive-oke"})
+
+	body := `{"owner":"carol","org":"acme","repos":"repo1","primary_repo":"repo1","acmm_level":2}`
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/api/saas/hives/hosted-avail-z01a/assign", body, hubAdminUsername), "id", "hosted-avail-z01a")
+	s.handleAssignHive(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("assign status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading kubectl log: %v", err)
+	}
+	logged := string(data)
+	if !strings.Contains(logged, "label namespace hive-hosted-hosted-avail-z01a --overwrite") {
+		t.Errorf("expected assign to (re)label the placeholder's namespace, got:\n%s", logged)
+	}
+	if !strings.Contains(logged, hiveOrgLabel+"=acme") {
+		t.Errorf("expected org label with the newly-assigned org, got:\n%s", logged)
+	}
+}

--- a/v2/pkg/hub/provision_approve_coverage_test.go
+++ b/v2/pkg/hub/provision_approve_coverage_test.go
@@ -19,25 +19,25 @@ import (
 func TestLoadRegistry(t *testing.T) {
 	dir := t.TempDir()
 
-	// Missing file -> starts fresh, no error.
-	old := registryPath
-	registryPath = filepath.Join(dir, "missing.json")
-	defer func() { registryPath = old }()
-	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	// Missing file -> starts fresh, no error. The path is a per-server field,
+	// NOT the registryPath global: writing the global here raced the leaked
+	// saveLoop goroutines of servers built by earlier tests (nothing closes
+	// saveCh), which read it at use time before the field existed.
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, registryPath: filepath.Join(dir, "missing.json")}
 	s.loadRegistry()
 
 	// Valid file -> loads hives.
-	registryPath = filepath.Join(dir, "reg.json")
-	os.WriteFile(registryPath, []byte(`{"hives":[{"id":"h1"},{"id":"h2"}]}`), 0o644)
-	s2 := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	regFile := filepath.Join(dir, "reg.json")
+	os.WriteFile(regFile, []byte(`{"hives":[{"id":"h1"},{"id":"h2"}]}`), 0o644)
+	s2 := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, registryPath: regFile}
 	s2.loadRegistry()
 	if len(s2.registry.Hives) != 2 {
 		t.Errorf("expected 2 hives loaded, got %d", len(s2.registry.Hives))
 	}
 
 	// Bad JSON -> logged, registry left empty.
-	os.WriteFile(registryPath, []byte(`{not json`), 0o644)
-	s3 := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	os.WriteFile(regFile, []byte(`{not json`), 0o644)
+	s3 := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, registryPath: regFile}
 	s3.loadRegistry()
 	if len(s3.registry.Hives) != 0 {
 		t.Errorf("bad JSON should leave registry empty, got %d", len(s3.registry.Hives))

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -12252,12 +12252,24 @@ const dashboardHTML = `<!DOCTYPE html>
        as a lie. */
     var UPGRADE_ELAPSED_SKEW_TOLERANCE_MS = 60 * 1000; // treat small negatives as 0
 
+    /* Go serialises a zero time.Time as "0001-01-01T00:00:00Z" and — because
+       json:"...,omitempty" does NOT omit a zero struct — the hub emits exactly
+       that string for a hive whose UpgradeStartedAt was never set or was reset.
+       Date.parse() accepts it happily, and now − year 0001 is ~17.7 MILLION
+       hours: the live "Upgrading 17755944h28m" wedge on ibm-alchemy. Any
+       upgradeStartedAt at or before this cutoff is not a real start time but a
+       lost/zero one, and the counter must be suppressed rather than rendered as
+       a two-thousand-year duration. 2020-01-01 predates the project itself, so
+       no genuine upgrade can legitimately fall before it. */
+    var UPGRADE_STARTED_MIN_SANE_MS = Date.UTC(2020, 0, 1); // any earlier start time is a lost/zero timestamp
+
     /* upgradeElapsedMs returns how long a hive has been upgrading, in ms, or
-       null when that cannot be known — a MISSING, EMPTY or UNPARSEABLE
-       upgradeStartedAt, or a negative elapsed beyond the skew tolerance.
-       Callers must render nothing on null; they must never render NaN, a
-       negative duration, or a fabricated "0s" that implies the upgrade just
-       started when in truth the timestamp was lost.
+       null when that cannot be known — a MISSING, EMPTY, UNPARSEABLE or
+       PRE-EPOCH (zero/lost) upgradeStartedAt, or a negative elapsed beyond the
+       skew tolerance. Callers must render nothing on null; they must never
+       render NaN, a negative duration, a two-thousand-year duration, or a
+       fabricated "0s" that implies the upgrade just started when in truth the
+       timestamp was lost.
 
        Note a real server behaviour this relies on: upgradeStartedAt is stamped
        ONLY where Upgrading is set true, so a hive that is merely QUEUED has no
@@ -12268,6 +12280,7 @@ const dashboardHTML = `<!DOCTYPE html>
       if (!started || typeof started !== 'string') return null;
       var t = Date.parse(started);
       if (isNaN(t)) return null; /* unparseable timestamp — show nothing, never NaN */
+      if (t < UPGRADE_STARTED_MIN_SANE_MS) return null; /* zero/lost start time (year 0001) — never a real "17.7M hour" upgrade */
       var elapsed = (typeof nowMs === 'number' ? nowMs : Date.now()) - t;
       if (elapsed < 0) {
         /* Clock skew. A small negative is the browser being marginally behind

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -5720,6 +5720,14 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Entry point 2/3 for namespace identity: this is the moment a placeholder
+	// gets a real owner/org — the hive's identity is known here for the first
+	// time, so the namespace's labels/annotations MUST be (re)written now
+	// rather than left holding whatever provisionHive stamped at pool-creation
+	// time (typically just hive_id). Best-effort — see
+	// stampHostedNamespaceIdentity's doc comment.
+	stampHostedNamespaceIdentity(s.clusterForHive(h), hostedNamespaceForHive(h), h.ProjectName, h.Org, h.ID, s.logger)
+
 	// Ensure the user record exists, grant them owner access, and count this
 	// owned hive against a quota.
 	//
@@ -6480,7 +6488,21 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	// registry's dashboardUrl becomes the vanity URL and stays that way.
 	if h.VanityURL == "" {
 		if cluster := s.clusterForHive(h); cluster != nil && cluster.Domain != "" {
-			vanityHost := generateHiveID(body.Org, primaryRepo) + "." + cluster.Domain
+			// Option B (namespace-identity operability): prefer a host built
+			// from the hive's OWN display name (h.ProjectName /
+			// body.ProjectName) when one is set — "TradingAsBuddies" reads as
+			// the hive an operator actually asked for, where
+			// "hosted-acme-repo-*" only reads as org/repo. Falls back to the
+			// existing org/repo-derived host (generateHiveID) when no display
+			// name is set, so a hive claimed without one behaves exactly as
+			// before. Both schemes share the same suffix length and the same
+			// "no route until makeVanityHostServable succeeds" adoption rule
+			// below — this only changes what the label PORTION of the host
+			// says, never the get-or-create/idempotency semantics.
+			vanityHost := hiveNameVanityHost(h.ProjectName, cluster.Domain)
+			if vanityHost == "" {
+				vanityHost = generateHiveID(body.Org, primaryRepo) + "." + cluster.Domain
+			}
 			// Make the vanity host servable, then adopt it. Nothing else creates a
 			// route for this host: provisioning templates a single DashboardHost, so
 			// a vanity URL minted here resolves to no backend and every hub link to
@@ -6520,6 +6542,14 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"failed to save hive assignment"}`, http.StatusInternalServerError)
 		return
 	}
+
+	// Entry point 3/3 for namespace identity: the (re)assignment path. A
+	// claimed placeholder can be reassigned to a different owner/org later
+	// (or an admin can assign directly, bypassing the approve-provision flow
+	// entirely), so the namespace's labels/annotations must be refreshed here
+	// too — same rationale as handleApproveProvision above. Best-effort — see
+	// stampHostedNamespaceIdentity's doc comment.
+	stampHostedNamespaceIdentity(s.clusterForHive(h), hostedNamespaceForHive(h), h.ProjectName, h.Org, h.ID, s.logger)
 
 	// Grant the assignee owner access. handleAccessList builds a hive's access
 	// list by scanning every user record for Hives[hiveID], NOT from h.Owner —
@@ -8275,6 +8305,22 @@ const dashboardHTML = `<!DOCTYPE html>
       // "is registeredAt usable"; an em dash, never 'Invalid Date', when not.
       if (hiveProvisionTime(h) !== null) {
         lines.push('— provisioned ' + fmtUserTS(h.registeredAt));
+      }
+      // Kubernetes namespace. A hosted hive's namespace is the deterministic
+      // "hive-hosted-<id>" (see hostedNamespaceForHive in
+      // pkg/hub/hosted_namespace_identity.go) and — unlike the hive's
+      // name/org — NEVER changes after a claim: the namespace this hive was
+      // first provisioned into keeps its original (often placeholder) name
+      // forever, because Kubernetes has no atomic namespace rename. Surfacing
+      // it here is what lets an operator map "some namespace on the cluster"
+      // back to "this hive" without cross-referencing the registry by hand —
+      // exactly the gap the hive.kubestellar.io/* namespace labels close from
+      // the cluster side. Computed client-side (not a separate stored field)
+      // so it can never drift from the one place the namespace name is
+      // decided; omitted for a non-hosted row, which has no such namespace.
+      var hns = hiveNamespace(h);
+      if (hns) {
+        lines.push('Namespace: ' + hns);
       }
       var access = h.access || [];
       var dotMarkup = '<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + c + '"></span>' +
@@ -11191,6 +11237,19 @@ const dashboardHTML = `<!DOCTYPE html>
     function isPlaceholderHive(h) {
       if (!h) return false;
       return h.provStatus === 'available' || (!!h.org && h.org.indexOf('available-') === 0);
+    }
+
+    /* hiveNamespace returns the Kubernetes namespace a hosted hive's spoke
+       runs in, or '' for a non-hosted (local) hive, which has no such
+       namespace. Mirrors hostedNamespaceForHive in
+       pkg/hub/hosted_namespace_identity.go — "hive-hosted-" + id — computed
+       here rather than shipped as its own field so it can never disagree
+       with the one place (server-side) that decides the namespace name. */
+    function hiveNamespace(h) {
+      if (!h || !h.id) return '';
+      var isHosted = h.hiveType === 'hosted' || h.id.indexOf('hosted-') === 0 || h.id.indexOf('saas-') === 0;
+      if (!isHosted) return '';
+      return 'hive-hosted-' + h.id;
     }
 
     /* ---------- Bulk multi-select actions ----------

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1512,6 +1512,15 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 		return fmt.Errorf("provisioning failed — check hub logs for details")
 	}
 
+	// Entry point 1/3 for namespace identity: stamp what's known at creation
+	// time. For a freshly-created pool placeholder this is often just the
+	// hive_id (h.Owner/h.Org are still the admin/placeholder values) — the
+	// claim (handleApproveProvision) and assign (handleAssignHive) paths
+	// overwrite these once the real owner/org are known. See
+	// hosted_namespace_identity.go for why the namespace itself is never
+	// renamed and must instead be kept self-describing via labels.
+	stampHostedNamespaceIdentity(cluster, data["Namespace"].(string), h.ProjectName, h.Org, h.ID, logger)
+
 	logger.Info("audit: saas hive provisioned", "hive_id", h.ID, "owner", h.Owner, "org", h.Org, "cluster", cluster.ID)
 	return nil
 }
@@ -2182,6 +2191,17 @@ spec:
               key: dashboard-token
         - name: HIVE_ID
           value: "{{.ID}}"
+        # POD_NAMESPACE via the downward API — the spoke's OWN authoritative
+        # source for the namespace it runs in. Provisioning already computes
+        # this namespace (see .Namespace above) to create it, but the pod
+        # cannot read the template's own values at runtime, and re-deriving
+        # "hive-hosted-"+HIVE_ID client-side would silently break the day
+        # that convention changes. The downward API can never disagree with
+        # reality: it is the API server's own answer, not a guess.
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: HIVE_LEVEL
           value: "{{.ACMMLevel}}"
         - name: HIVE_HUB_URL

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -29,8 +29,12 @@ import (
 //go:embed static/*
 var staticFS embed.FS
 
-// registryPath is the on-disk hub registry file. A var (not a const) so tests
-// can redirect it at a temp file; production keeps the default.
+// registryPath is the DEFAULT on-disk hub registry file. A var (not a const)
+// so tests can redirect it at a temp file before constructing a server;
+// production keeps the default. NewHubServer copies it into the per-instance
+// HubServer.registryPath at construction, and all production reads and writes
+// go through that field — never this global — so a saveLoop goroutine leaked
+// by one test's server can never race a later test reassigning this var.
 var registryPath = "/data/hub-registry.json"
 
 // hubBannersPath is the on-disk file where admin-sent banners are persisted so
@@ -591,11 +595,18 @@ type HeartbeatHealthEntry struct {
 }
 
 type HubServer struct {
-	mux          *http.ServeMux
-	registry     Registry
-	mu           sync.RWMutex
-	logger       *slog.Logger
-	saveCh       chan struct{}
+	mux      *http.ServeMux
+	registry Registry
+	mu       sync.RWMutex
+	logger   *slog.Logger
+	saveCh   chan struct{}
+	// registryPath is this server's on-disk registry file, captured from the
+	// package-level default at construction and immutable afterwards. It is a
+	// per-instance field (not a use-time read of the global) so the saveLoop
+	// goroutine — which outlives test servers, since nothing closes saveCh —
+	// only ever sees its own path and cannot race a test redirecting the
+	// global for the next server (the TestLoadRegistry -race failure).
+	registryPath string
 	hubGitHash   string
 	hubGitBranch string
 	hubSecret    string
@@ -852,6 +863,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		mux:                     http.NewServeMux(),
 		logger:                  logger,
 		saveCh:                  make(chan struct{}, 1),
+		registryPath:            registryPath,
 		hubGitHash:              gitHash,
 		hubGitBranch:            gitBranch,
 		hubSecret:               secret,
@@ -2293,6 +2305,20 @@ func (s *HubServer) removeRegistryEntry(id, by string) {
 	s.logger.Info("audit: registry entry removed", "id", id, "by", by)
 }
 
+// regPath returns this server's registry file path: the per-instance field
+// captured at construction, or — for servers built directly in tests as bare
+// &HubServer{...} literals without one — the package-level default. The
+// fallback cannot reintroduce the registryPath data race: only NewHubServer
+// starts a saveLoop goroutine (the sole reader that outlives its test), and
+// NewHubServer always sets the field, so the global is only ever read from a
+// test's own goroutine, synchronously with any test redirecting it.
+func (s *HubServer) regPath() string {
+	if s.registryPath != "" {
+		return s.registryPath
+	}
+	return registryPath
+}
+
 // saveRegistryNow marshals and writes the registry to disk immediately, via a
 // temp file plus atomic rename so a crash mid-write cannot truncate it.
 func (s *HubServer) saveRegistryNow() error {
@@ -2302,11 +2328,12 @@ func (s *HubServer) saveRegistryNow() error {
 	if err != nil {
 		return fmt.Errorf("marshal hub registry: %w", err)
 	}
-	tmpPath := registryPath + ".tmp"
+	path := s.regPath()
+	tmpPath := path + ".tmp"
 	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
 		return fmt.Errorf("write hub registry: %w", err)
 	}
-	if err := os.Rename(tmpPath, registryPath); err != nil {
+	if err := os.Rename(tmpPath, path); err != nil {
 		return fmt.Errorf("rename hub registry: %w", err)
 	}
 	return nil
@@ -2464,7 +2491,7 @@ func (s *HubServer) serveStatic(path string) http.HandlerFunc {
 }
 
 func (s *HubServer) loadRegistry() {
-	data, err := os.ReadFile(registryPath)
+	data, err := os.ReadFile(s.regPath())
 	if err != nil {
 		s.logger.Info("no existing hub registry, starting fresh")
 		return
@@ -2535,12 +2562,12 @@ func (s *HubServer) saveLoop() {
 			s.logger.Warn("hub registry marshal failed", "error", err)
 			continue
 		}
-		tmpPath := registryPath + ".tmp"
+		tmpPath := s.registryPath + ".tmp"
 		if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
 			s.logger.Warn("hub registry save failed", "path", tmpPath, "error", err)
 			continue
 		}
-		if err := os.Rename(tmpPath, registryPath); err != nil {
+		if err := os.Rename(tmpPath, s.registryPath); err != nil {
 			s.logger.Warn("hub registry rename failed", "error", err)
 		}
 	}

--- a/v2/pkg/hub/stale_upgrade.go
+++ b/v2/pkg/hub/stale_upgrade.go
@@ -82,17 +82,25 @@ func evaluateOrphanedUpgrade(entry *RegistryEntry, now time.Time) upgradeAttempt
 	if entry.UpgradeFailed {
 		return ev
 	}
-	// Without a start timestamp there is no elapsed time to reason about. The
-	// auto-upgrade recovery path treats a zero timestamp as stale, but that path
-	// re-arms delivery rather than clearing state; clearing on no evidence at
-	// all would risk dropping a genuinely fresh upgrade, so we decline.
-	if entry.UpgradeStartedAt.IsZero() {
-		return ev
-	}
-
-	ev.elapsed = now.Sub(entry.UpgradeStartedAt)
-	if ev.elapsed < orphanedUpgradeClearAfter {
-		return ev
+	// A zero UpgradeStartedAt with Upgrading still latched is not a fresh
+	// upgrade — every path that sets Upgrading=true stamps UpgradeStartedAt to
+	// time.Now() in the same breath (saas.go, saas_bulk.go), so a zero value can
+	// only mean the timestamp was lost or reset while the flag survived. That is
+	// the exact live wedge on ibm-alchemy: Upgrading=true, UpgradeStartedAt =
+	// 0001-01-01, which the dashboard rendered as "Upgrading 17755944h28m" and
+	// which no elapsed-based sweep can ever reach because there is no elapsed to
+	// measure. We must not simply return here (the previous behaviour, which is
+	// what let ibm-alchemy stay wedged forever); instead we skip the
+	// elapsed-time gate and fall through to the SAME liveness evidence used for a
+	// real stale upgrade. We still only clear when the spoke has demonstrably
+	// checked in since — and is not already on the target — so a genuinely
+	// fresh upgrade whose stamp merely lags a beat is never dropped.
+	zeroStart := entry.UpgradeStartedAt.IsZero()
+	if !zeroStart {
+		ev.elapsed = now.Sub(entry.UpgradeStartedAt)
+		if ev.elapsed < orphanedUpgradeClearAfter {
+			return ev
+		}
 	}
 
 	// Evidence: has the spoke checked in since we instructed the upgrade?
@@ -117,9 +125,17 @@ func evaluateOrphanedUpgrade(entry *RegistryEntry, now time.Time) upgradeAttempt
 	}
 
 	ev.orphaned = true
-	ev.reason = "spoke heartbeated " + roundedDuration(now.Sub(lastBeat)) +
-		" ago still running " + orDash(entry.GitHash) +
-		", no upgrade attempt in flight"
+	if zeroStart {
+		// No trustworthy start time to report an elapsed from — the flag itself is
+		// the corruption. Name that so the timeline reads honestly.
+		ev.reason = "upgrade latched with no start time (lost/zero UpgradeStartedAt); spoke heartbeated " +
+			roundedDuration(now.Sub(lastBeat)) + " ago still running " + orDash(entry.GitHash) +
+			", no upgrade attempt in flight"
+	} else {
+		ev.reason = "spoke heartbeated " + roundedDuration(now.Sub(lastBeat)) +
+			" ago still running " + orDash(entry.GitHash) +
+			", no upgrade attempt in flight"
+	}
 	return ev
 }
 

--- a/v2/pkg/hub/stale_upgrade_test.go
+++ b/v2/pkg/hub/stale_upgrade_test.go
@@ -90,10 +90,39 @@ func TestEvaluateOrphanedUpgrade(t *testing.T) {
 			orphaned: false,
 		},
 		{
-			name: "not orphaned: no start timestamp means no elapsed time to judge",
+			// The ibm-alchemy live wedge: Upgrading latched with a ZERO
+			// UpgradeStartedAt (0001-01-01), which the dashboard rendered as
+			// "Upgrading 17755944h28m". A zero start can never be a fresh upgrade
+			// (every set-site stamps time.Now()), so with a live spoke still on the
+			// old SHA it must be cleared, not left wedged forever.
+			name: "orphaned: zero start time with a live spoke on the old SHA (ibm-alchemy wedge)",
 			entry: RegistryEntry{
 				Upgrading:     true,
 				GitHash:       "c11643a",
+				UpgradeTarget: "fc32ae4",
+				LastHeartbeat: rfc3339(fixedSweepNow.Add(-30 * time.Second)),
+			},
+			orphaned: true,
+		},
+		{
+			// A zero start is still only cleared on the same liveness evidence as a
+			// real stale upgrade. Never heartbeated ⇒ we cannot prove the attempt is
+			// gone, so we do not clear even with a zero timestamp.
+			name: "not orphaned: zero start time but the spoke never heartbeated",
+			entry: RegistryEntry{
+				Upgrading:     true,
+				GitHash:       "c11643a",
+				UpgradeTarget: "fc32ae4",
+			},
+			orphaned: false,
+		},
+		{
+			// Zero start, alive, but the spoke already reports the target SHA: the
+			// heartbeat path clears it, this sweep must not race ahead.
+			name: "not orphaned: zero start time but the spoke already reports the target",
+			entry: RegistryEntry{
+				Upgrading:     true,
+				GitHash:       "fc32ae4",
 				UpgradeTarget: "fc32ae4",
 				LastHeartbeat: rfc3339(fixedSweepNow.Add(-30 * time.Second)),
 			},
@@ -251,5 +280,39 @@ func TestSweepBelowBudgetStillReArms(t *testing.T) {
 	}
 	if got := s.heartbeatUpgrade["first-orphan"]; got != "fc32ae4" {
 		t.Errorf("below the budget the upgrade must still be re-armed, got %q", got)
+	}
+}
+
+// TestSweepUnwedgesZeroStartTimestamp is the anti-regression test for the live
+// ibm-alchemy wedge: a hive latched Upgrading=true with a ZERO UpgradeStartedAt
+// (0001-01-01) was NEVER swept, because the old evaluateOrphanedUpgrade bailed
+// on IsZero() before it ever looked at liveness evidence. It stayed "Upgrading"
+// forever with a 17.7M-hour counter and blocked any fresh upgrade from being
+// recognised. The sweep must now clear such a hive (given a live spoke still on
+// the old SHA) and re-arm delivery so it can upgrade again.
+func TestSweepUnwedgesZeroStartTimestamp(t *testing.T) {
+	s := &HubServer{
+		logger:           slog.Default(),
+		heartbeatUpgrade: make(map[string]string),
+	}
+	s.registry.Hives = []RegistryEntry{{
+		ID:            "ibm-alchemy-wedged",
+		Upgrading:     true,
+		GitHash:       "c11643a",
+		UpgradeTarget: "fc32ae4",
+		LastHeartbeat: rfc3339(time.Now().Add(-30 * time.Second)),
+		// UpgradeStartedAt left zero on purpose — the wedge itself.
+	}}
+	if !s.registry.Hives[0].UpgradeStartedAt.IsZero() {
+		t.Fatal("precondition: the wedged hive must carry a zero UpgradeStartedAt")
+	}
+
+	s.sweepOrphanedUpgrades()
+
+	if s.registry.Hives[0].Upgrading {
+		t.Error("a zero-timestamp wedged upgrade must be cleared, not left latched forever")
+	}
+	if got := s.heartbeatUpgrade["ibm-alchemy-wedged"]; got != "fc32ae4" {
+		t.Errorf("the un-wedged hive must be re-armed for delivery, got %q", got)
 	}
 }

--- a/v2/pkg/hub/upgrade_elapsed_ui_test.go
+++ b/v2/pkg/hub/upgrade_elapsed_ui_test.go
@@ -42,6 +42,7 @@ func TestUpgradeElapsedUsesNamedConstants(t *testing.T) {
 		"var UPGRADE_ELAPSED_AMBER_MS =",
 		"var UPGRADE_ELAPSED_MIN_SHOW_MS =",
 		"var UPGRADE_ELAPSED_SKEW_TOLERANCE_MS =",
+		"var UPGRADE_STARTED_MIN_SANE_MS =",
 		"var UPGRADE_FACET_STUCK_MS =",
 	} {
 		if !strings.Contains(dashboardHTML, decl) {
@@ -59,6 +60,9 @@ func TestUpgradeElapsedHandlesUnknownStartTime(t *testing.T) {
 		"if (!started || typeof started !== 'string') return null;",
 		// Unparseable timestamp — Date.parse yields NaN.
 		"if (isNaN(t)) return null;",
+		// Zero / lost start time (Go's 0001-01-01) parses fine but is decades
+		// before the cutoff — the live "17755944h" wedge. Must be suppressed.
+		"if (t < UPGRADE_STARTED_MIN_SANE_MS) return null;",
 		// Negative elapsed from clock skew.
 		"if (elapsed < 0) {",
 		"if (elapsed > -UPGRADE_ELAPSED_SKEW_TOLERANCE_MS) return 0;",
@@ -74,6 +78,36 @@ func TestUpgradeElapsedHandlesUnknownStartTime(t *testing.T) {
 	if !strings.Contains(dashboardHTML,
 		"if (typeof ms !== 'number' || isNaN(ms) || ms < 0) return '';") {
 		t.Error("formatUpgradeElapsed must reject NaN and negative durations")
+	}
+}
+
+// TestUpgradeElapsedRejectsZeroStartTime is the anti-regression test for the
+// live ibm-alchemy wedge: hosted-ibm-alchemy-logg-ptoo showed
+// "Upgrading 17755944h28m". Its UpgradeStartedAt was Go's zero time, which
+// json:"...,omitempty" does NOT omit for a struct, so the hub emitted
+// "0001-01-01T00:00:00Z". Date.parse() accepts it and now − year 0001 is
+// ~17.7 million hours. upgradeElapsedMs must reject any start time before the
+// sane epoch (2020-01-01, which predates the project) so the counter is
+// suppressed instead of rendering a two-thousand-year duration.
+func TestUpgradeElapsedRejectsZeroStartTime(t *testing.T) {
+	// The cutoff must be anchored to a real date, not left as a bare 0 or a
+	// magic number, and it must sit before any plausible real upgrade yet after
+	// Go's zero year so the year-0001 emission falls below it.
+	if !strings.Contains(dashboardHTML, "var UPGRADE_STARTED_MIN_SANE_MS = Date.UTC(2020, 0, 1);") {
+		t.Error("UPGRADE_STARTED_MIN_SANE_MS must be Date.UTC(2020, 0, 1) — the sane-epoch cutoff " +
+			"that rejects Go's 0001-01-01 zero-time emission")
+	}
+	// The guard must run BEFORE the elapsed subtraction, so a pre-epoch stamp
+	// returns null rather than flowing into a giant positive duration.
+	body := dashboardHTML
+	guardAt := strings.Index(body, "if (t < UPGRADE_STARTED_MIN_SANE_MS) return null;")
+	elapsedAt := strings.Index(body, "var elapsed = (typeof nowMs === 'number' ? nowMs : Date.now()) - t;")
+	if guardAt < 0 || elapsedAt < 0 {
+		t.Fatalf("guard/elapsed lines not both found (guard=%d elapsed=%d)", guardAt, elapsedAt)
+	}
+	if guardAt > elapsedAt {
+		t.Error("the pre-epoch guard must precede the elapsed computation, " +
+			"or the year-0001 timestamp would still yield a 17.7M-hour duration")
 	}
 }
 


### PR DESCRIPTION
Morning sync — 13 v2 commits: model-discovery quartet (copilot #2523, claude #2524, codex #2528, goose #2529), pinned Codex CLI in spoke image (#2531), governor gauge pressure display (#2527), Upgrading-pill cleanup (#2532), Management & Operations contribute tab (#2542), and namespace-identity docs. Clean merge, 0 behind fresh v2. Merge with a merge commit (not squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)