### PR TITLE
contributor: prepare a real workspace and release held slots on abandon

### DIFF
--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -281,9 +281,22 @@ GOOSECFG
     ;;
 esac
 
+# Prepare a concrete workspace directory for the agent (kubestellar/hive#2545).
+# Previously the tmux session inherited the bare $HOME (/home/dev in the stock
+# container) with no working directory prepared, while the assignment prompt's
+# only repository instruction was a fork WITHOUT a clone
+# ('gh repo fork ... --clone=false'). Nothing on either side promised the agent
+# a real checkout, so a session could sit fully idle — no repo on disk, task
+# slot still held — until a human intervened. HIVE_WORKSPACE_DIR gives the
+# agent (and the assignment prompt built in contribute_ws.go) one fixed,
+# known-to-exist directory to clone into; the tmux session itself is started
+# rooted there via -c so any 'cd ~/workspace' step is redundant, not required.
+export HIVE_WORKSPACE_DIR="${HIVE_WORKSPACE_DIR:-${HOME}/workspace}"
+mkdir -p "$HIVE_WORKSPACE_DIR"
+
 # Create tmux session for the agent
 tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
-tmux new-session -d -s "$TMUX_SESSION" -x 200 -y 50
+tmux new-session -d -s "$TMUX_SESSION" -c "$HIVE_WORKSPACE_DIR" -x 200 -y 50
 
 # Start the relay in the background
 echo "Starting ClankeR relay connection to hub..."

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -1074,12 +1074,32 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			}
 			contributor.mu.Lock()
 			abandoned := contributor.currentTask
+			contributor.currentTask = nil
+			contributor.tokenMintedAt = time.Time{}
 			contributor.mu.Unlock()
 			if abandoned != nil {
 				h.logger.Warn("[contribute-ws] task abandoned without completion",
 					"username", contributor.profile.GitHubUsername,
 					"abandoned_task", abandoned.TaskID,
 				)
+				// kubestellar/hive#2545: a contributor that sends "ready" while
+				// still holding a task (e.g. the relay's own MAX_TASK_DURATION_MS
+				// watchdog gives up and requeues, or an agent that never actually
+				// started work asks for something new) used to leave currentTask
+				// set and booked no cooldown at all — worse than the disconnect
+				// path immediately above (#2356/#2435), which does both. That left
+				// the abandoned issue permanently out of activeIssues circulation
+				// for the life of the connection: no PR, no failure record, no
+				// re-offer, just a silently held slot. Clear currentTask (above)
+				// so selectTask's activeIssues scan releases the issue, and mirror
+				// the disconnect/task_failed paths by booking the SAME short
+				// non-permanent failure cooldown, so the just-abandoned issue is
+				// not instantly handed straight back to the same contributor in
+				// the very selectTask call below. Synthetic pr-review tasks carry
+				// Number == 0 and must not poison an issue key.
+				if abandoned.Number > 0 {
+					h.recordTaskFailure(abandoned.Repo, abandoned.Number, false)
+				}
 			}
 			h.logger.Info("[contribute-ws] ready for work",
 				"username", contributor.profile.GitHubUsername,
@@ -1736,15 +1756,27 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 
 	taskID := fmt.Sprintf("ct-%s-%d-%d", chosen.repoFull, chosen.number, time.Now().Unix())
 
+	// The workspace contract (kubestellar/hive#2545): your tmux pane already
+	// starts rooted in $HIVE_WORKSPACE_DIR (contributor-agent.sh creates it and
+	// launches the session with -c pointed there), but nothing had put a repo
+	// on disk there yet. The previous prompt's only repository instruction was
+	// 'gh repo fork ... --clone=false' — a fork WITHOUT a checkout — so an
+	// agent that followed it literally, or one that stalled before improvising
+	// its own clone, was left sitting in an empty directory while the
+	// assignment slot stayed held. Spell out an actual clone into that known
+	// directory so there is a concrete first step rather than an implied one.
 	prompt := fmt.Sprintf(
 		"You are a contributor to the %s hive. Work on issue %s#%d: \"%s\". "+
-			"Read the issue, understand what's needed, and take action. "+
 			"You do NOT have push access to the upstream repo. "+
-			"Fork it first with 'gh repo fork %s --clone=false', "+
-			"add the fork as a remote, push your branch there, "+
-			"then open a PR from your fork. "+
+			"Start by getting a real checkout on disk: "+
+			"'gh repo fork %s --clone=true --remote=true "+
+			"$HIVE_WORKSPACE_DIR/%s' (or, if that directory already has a clone "+
+			"from a prior task, 'cd' into it and 'git fetch' instead of "+
+			"re-forking). Then 'cd' into that checkout, read the issue, "+
+			"understand what's needed, and take action. "+
+			"Push your branch to your fork remote, then open a PR from your fork. "+
 			"Use the GH_TOKEN env var for all gh commands (do NOT use 'unset GITHUB_TOKEN').",
-		chosen.repoFull, chosen.repoFull, chosen.number, chosen.title, chosen.repoFull,
+		chosen.repoFull, chosen.repoFull, chosen.number, chosen.title, chosen.repoFull, chosen.repoFull,
 	)
 
 	c.mu.Lock()

--- a/v2/pkg/dashboard/contribute_ws_livelock_test.go
+++ b/v2/pkg/dashboard/contribute_ws_livelock_test.go
@@ -375,3 +375,78 @@ func TestDupePR_DisconnectReleaseIgnoresSyntheticReviewTask(t *testing.T) {
 		t.Fatalf("a synthetic review task (Number==0) must never be parked in a cooldown")
 	}
 }
+
+// TestHeldSlot_ReadyWhileHoldingTaskReleasesAndCoolsDown is the kubestellar/
+// hive#2545 regression: a contributor that never actually starts work on an
+// assigned issue (bare workspace, no checkout, agent idle) but stays connected
+// and eventually sends "ready" again — e.g. because the relay's own
+// MAX_TASK_DURATION_MS watchdog gave up and requeued, or the agent itself asked
+// for something new — used to hold the assignment slot forever: the "ready"
+// handler logged "task abandoned without completion" but left currentTask set
+// and booked no cooldown at all, unlike the disconnect path (#2356) right above
+// it. That kept the abandoned issue out of activeIssues circulation for the
+// life of the connection with no PR, no failure record, and no re-offer ever
+// produced. After the fix, sending "ready" while holding a task clears
+// currentTask (releasing the issue back into activeIssues) and books the same
+// short non-permanent failure cooldown task_failed and disconnect already use,
+// so the issue is not instantly handed straight back to the very next
+// selectTask call — here, the "ready" call that triggers the release itself.
+func TestHeldSlot_ReadyWhileHoldingTaskReleasesAndCoolsDown(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	// Two admissible issues: A (#10, head of scan) and B (#20). If the abandoned
+	// A were still re-admissible, the very next selection (triggered by the same
+	// "ready" that abandons it) would return A again; after the fix it must be
+	// parked and B offered instead.
+	twoIssueStatus(s)
+
+	body := `{"github_username":"held-slot-user"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn) // auth_ok
+
+	// First "ready": get assigned the head-of-scan issue A (#10). Simulate the
+	// stalled contributor: never send task_progress/task_complete/task_failed for
+	// it — just sit there, exactly like a session with no workspace prepared.
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 1})
+	assign := readMsg(t, conn)
+	if assign.Type != "task_assign" || assign.Number != 10 {
+		t.Fatalf("expected task_assign for head-of-scan A (#10), got type=%s number=%d", assign.Type, assign.Number)
+	}
+
+	// The contributor (or its relay's own timeout) asks for work again WITHOUT
+	// ever reporting progress, completion, or failure on A. This is the abandon
+	// path under test, not a disconnect.
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 2})
+	second := readMsg(t, conn)
+	if second.Type != "task_assign" {
+		t.Fatalf("expected a fresh task_assign after abandoning A, got type=%s", second.Type)
+	}
+	if second.Number == 10 {
+		t.Fatalf("held slot: A (#10) was re-offered on the very same ready that abandoned it; expected it released and cooled down (#2545)")
+	}
+	if second.Number != 20 {
+		t.Fatalf("expected the other issue B (#20) to be offered, got #%d", second.Number)
+	}
+
+	// The abandoned issue A must be recorded in the short failure cooldown, the
+	// same ledger entry task_failed and disconnect-release use — proving this is
+	// reused machinery, not a new mechanism.
+	if !s.contributeHub.isTaskInFailureCooldown("myorg/repo1", 10) {
+		t.Fatalf("abandoning a task via ready did not record a failure cooldown for the released issue (#2545)")
+	}
+}


### PR DESCRIPTION
Fixes #2545

## The problem

Jorge's field report: a contributor took an assignment, posted a public claim
comment, and then sat at an empty working directory doing nothing until a
human cloned the repo by hand. The assignment slot stayed consumed the whole
time. Two independent gaps in the contributor path caused this:

1. **No workspace contract.** The assignment prompt built in
   `contribute_ws.go`'s `selectTask` was the only place the protocol
   mentioned getting the code, and it said *fork without a clone*
   (`gh repo fork %s --clone=false`). The stock contributor container starts
   `USER dev` / `WORKDIR /home/dev`, and `contributor-agent.sh` created the
   agent's tmux session with no working-directory argument at all
   (`tmux new-session -d -s "$TMUX_SESSION" -x 200 -y 50`). Nothing on either
   side promised the agent a real checkout or even a concrete directory to
   put one in.

2. **No slot release on abandon.** `contribute_ws.go`'s `HandleWS` already
   has good machinery for this class of problem: a *disconnect* while
   holding a task releases it AND books the short non-permanent failure
   cooldown (`recordTaskFailure`), specifically so the issue isn't instantly
   re-handed out during the reconnect window (#2356/#2435). But a
   contributor that sends `ready` again while *still holding* a task — e.g.
   the relay's own `MAX_TASK_DURATION_MS` (30 min) watchdog gives up and
   requeues, or the agent itself just asks for something new — took a
   different, worse path: the handler logged
   `"task abandoned without completion"` but left `currentTask` set and
   booked **no cooldown at all**. That kept the issue out of `activeIssues`
   circulation for the life of the connection, with no PR, no failure
   record, and no re-offer, ever.

## What I changed

- **`bin/contributor-agent.sh`** — create `$HIVE_WORKSPACE_DIR` (default
  `$HOME/workspace`) and start the agent's tmux session rooted there via
  `tmux new-session -c "$HIVE_WORKSPACE_DIR"`, so the agent has one fixed,
  known-to-exist working directory before any task arrives, instead of a
  bare `$HOME`.
- **`v2/pkg/dashboard/contribute_ws.go` (prompt)** — rewrote the assignment
  prompt to give a concrete first step: `gh repo fork <repo> --clone=true
  --remote=true $HIVE_WORKSPACE_DIR/<repo>` (with a note to `cd`+`fetch`
  instead of re-forking if a prior task already left a clone there), then
  `cd` into that checkout before doing anything else. This replaces the old
  clone-less fork instruction with an unambiguous, executable one that
  matches the directory the tmux session now actually starts in.
- **`v2/pkg/dashboard/contribute_ws.go` (`ready` handler)** — sending
  `ready` while still holding a task now clears `currentTask` (releasing the
  issue back into `activeIssues`) and calls the existing
  `recordTaskFailure(repo, number, false)` — the exact same short
  non-permanent cooldown the disconnect path and `task_failed` already use.
  This reuses existing ledger machinery (#2435/#2356) rather than inventing
  a new mechanism, and brings the "abandoned via ready" case up to parity
  with "abandoned via disconnect."
- **Test** — added
  `TestHeldSlot_ReadyWhileHoldingTaskReleasesAndCoolsDown` in
  `contribute_ws_livelock_test.go`, following the existing
  `TestDupePR_DisconnectReleaseRecordsCooldown` pattern: assign issue A,
  send `ready` again without ever reporting progress/completion/failure on
  it, and assert (a) the very next assignment is a *different* issue, not
  an instant re-offer of A, and (b) A is recorded in the short failure
  cooldown. Full `go build ./... && go vet ./... && go test
  ./pkg/dashboard/...` pass.

## What I deliberately left as a documented follow-up

- **No hub-driven automatic clone.** The hub still doesn't clone on the
  contributor's behalf — it gives the agent a concrete directory and a
  concrete instruction, but the agent (or a human-steered session) does the
  actual `gh repo fork`. A fully automatic clone step felt like a bigger
  behavioral change than warranted for tonight's fix, and per the issue,
  downstream images are in a better position to own filesystem/mount
  specifics; this PR fixes the *contract* (explicit prompt + prepared
  directory), not the *implementation* of an unattended clone.
- **No hub-side `wsTaskTimeout` enforcement.** `wsTaskTimeout = 30 *
  time.Minute` is declared in `contribute_ws.go` but was (and remains)
  unreferenced anywhere else in the hub. The relay's own client-side
  `MAX_TASK_DURATION_MS` (also 30 min) already reports `task_failed` on its
  own schedule regardless of agent activity, which — combined with this
  PR's `ready`-abandon fix — bounds a stalled task to that same 30-minute
  window as long as the relay process itself stays alive and connected. A
  hub-side timeout that fires even when a relay is silently wedged (not
  just idle) is a materially larger change (new ticking-goroutine
  lifecycle, another tunable for operators) and is out of scope here.

No sweeping relay/protocol changes — the wire message types and their
fields are unchanged.