### PR TITLE
feat(contribute): extend Management & Operations tab — accurate trust tiers, idle reasons, prompt preview (#2544 #2546 #2539)

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -308,6 +308,28 @@ func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request)
 	}, host)
 	hubURL := fmt.Sprintf("%s://%s/contribute", wsProto, host)
 
+	// #2544: render the Contributor/Trusted trust-tier rows from the SAME constants
+	// the promotion code uses (contributorAutoPromoteAt / contributorTrustedAt) so
+	// the on-page numbers cannot drift from the code again, and word them to match
+	// what the code actually does:
+	//   - Auto-promotion (newcomer -> contributor) counts TasksWithPR — completions
+	//     that REPORTED A PR — not bare completed tasks (see contribute_ws.go
+	//     TasksWithPR >= contributorAutoPromoteAt). The old "5 completed tasks"
+	//     over-promised.
+	//   - "Trusted" is NOT auto-granted at 20: there is no code path that promotes
+	//     to trusted on a task count. It is set by an operator via
+	//     PUT /api/contributors/{id}/trust — the "maintainer voucher" in practice.
+	//     contributorTrustedAt is the documented guideline threshold, so we phrase
+	//     it as "~20 PR tasks, then granted by a maintainer" rather than implying an
+	//     automatic unlock. Trusted's scoped token adds checks:read on top of the
+	//     contributor scopes; the merge decision itself is still gated by the
+	//     project's /approve + lgtm automation, so we do not claim "Merge PRs".
+	tierTableRows := fmt.Sprintf(
+		`<tr><td>Contributor</td><td>%d tasks that produced a PR</td><td>Create PRs, push code</td></tr>`+
+			`<tr><td>Trusted</td><td>~%d PR tasks, then granted by a maintainer</td><td>Extra review scope (checks:read)</td></tr>`,
+		contributorAutoPromoteAt, contributorTrustedAt,
+	)
+
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	fmt.Fprintf(w, `<!DOCTYPE html>
 <html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Contribute to %s</title>
@@ -397,6 +419,14 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .ops-empty{padding:32px 20px;text-align:center;color:#8b949e;font-size:.85rem}
 .ops-note{color:#6e7681;font-size:.78rem;margin-top:12px;line-height:1.5}
 .ops-note code{background:#0d1117;padding:1px 6px;border-radius:4px}
+.prompt-preview{margin-top:10px;border-top:1px solid #21262d;padding-top:8px}
+.prompt-preview summary{cursor:pointer;color:#58a6ff;font-size:.78rem;list-style:none}
+.prompt-preview summary::-webkit-details-marker{display:none}
+.prompt-preview summary::before{content:'\25B8 ';color:#8b949e}
+.prompt-preview[open] summary::before{content:'\25BE '}
+.prompt-labels{margin:8px 0 4px;display:flex;flex-wrap:wrap;gap:4px}
+.prompt-text{margin-top:8px;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:12px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.75rem;color:#c9d1d9;white-space:pre-wrap;word-break:break-word;max-height:220px;overflow-y:auto}
+.prompt-preview .ops-note{margin-top:8px}
 </style></head><body>
 <div class="page-tabs" role="tablist">
 <button class="page-tab active" role="tab" id="ptab-onboarding" aria-selected="true" data-panel="tab-onboarding">Onboarding</button>
@@ -561,8 +591,7 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 <table class="tier-table">
 <tr><th>Tier</th><th>Unlocked at</th><th>Can do</th></tr>
 <tr><td>Newcomer</td><td>Registration</td><td>Comment on issues</td></tr>
-<tr><td>Contributor</td><td>5 completed tasks</td><td>Create PRs, push code</td></tr>
-<tr><td>Trusted</td><td>20 tasks + maintainer voucher</td><td>Merge PRs</td></tr>
+%s
 <tr><td>Advisor</td><td>Registration</td><td>Review agent PRs</td></tr>
 </table>
 </div>
@@ -645,6 +674,14 @@ document.querySelectorAll('.ops-filter').forEach(function(f){f.addEventListener(
 function esc(s){var d=document.createElement('div');d.textContent=(s==null?'':String(s));return d.innerHTML;}
 function rel(ts){if(!ts)return '';var d=new Date(ts);if(isNaN(d))return '';var s=Math.floor((Date.now()-d.getTime())/1000);if(s<60)return s+'s ago';var m=Math.floor(s/60);if(m<60)return m+'m ago';var h=Math.floor(m/60);if(h<24)return h+'h ago';return Math.floor(h/24)+'d ago';}
 
+// #2546: human-readable label for the machine reason a clanker is idle. Keeps the
+// raw reason as a fallback so a new server-side reason still renders legibly.
+function idleReasonLabel(r){
+  var m={contribution_suspended:'contribution suspended',hub_not_ready:'hub not ready',
+    no_matching_work:'no matching work',token_mint_failed:'token mint failed',
+    tier_disabled:'tier disabled',concurrency_limit:'concurrency limit'};
+  return m[r]||String(r).replace(/_/g,' ');
+}
 function renderClankers(list){
   var el=document.getElementById('clanker-list');
   document.getElementById('clanker-count').textContent=(list.length)+(list.length===1?' connected':' connected');
@@ -653,7 +690,10 @@ function renderClankers(list){
     var user=c.github_username||c.contributor_id||'clanker';
     var av=c.github_username?'<img class="clanker-av" src="https://github.com/'+esc(c.github_username)+'.png" alt="">':'<span class="clanker-av"></span>';
     var sub=[c.cli_backend,c.model,c.role,c.trust_tier].filter(Boolean).map(esc).join(' &middot; ');
-    var task=c.current_task?('<div class="clanker-sub">on '+esc(c.current_task.repo)+'#'+esc(c.current_task.number)+'</div>'):'';
+    // #2546: when idle with a known reason, show "idle: no matching work" etc.
+    var task=c.current_task
+      ?('<div class="clanker-sub">on '+esc(c.current_task.repo)+'#'+esc(c.current_task.number)+'</div>')
+      :(c.idle_reason?('<div class="clanker-sub">idle: '+esc(idleReasonLabel(c.idle_reason))+'</div>'):'');
     return '<div class="clanker-row"><span class="clanker-dot'+(c.stale?' stale':'')+'"></span>'+av+
       '<div class="clanker-main"><div class="clanker-user">'+esc(user)+'</div>'+
       '<div class="clanker-sub">'+(sub||'&mdash;')+'</div>'+task+'</div>'+
@@ -684,9 +724,18 @@ function renderWork(list){
   el.innerHTML=shown.map(function(w){
     var who=w.github_username?('<span class="feed-role">'+esc(w.github_username)+'</span>'):'';
     var cli=w.cli_backend?(' &middot; '+esc(w.cli_backend)):'';
+    // #2539: read-only prompt preview. Show the exact prompt the agent runs plus
+    // task metadata (repo/number/title). The server never puts the github_token in
+    // prompt_preview, so this can never leak the credential.
+    var labels=(w.labels&&w.labels.length)?('<div class="prompt-labels">'+w.labels.map(function(l){return '<span class="pill pill-idle">'+esc(l)+'</span>';}).join(' ')+'</div>'):'';
+    var preview=w.prompt_preview
+      ?('<details class="prompt-preview"><summary>Prompt preview</summary>'+labels+
+        '<pre class="prompt-text">'+esc(w.prompt_preview)+'</pre>'+
+        '<p class="ops-note">Read-only. This is the instruction the agent receives; the scoped GitHub token is delivered separately and is never shown here.</p></details>')
+      :'';
     return '<div class="work-item"><div class="work-repo">'+esc(w.repo||'')+(w.number?('#'+esc(w.number)):'')+'</div>'+
       '<div class="work-title">'+esc(w.title||'(untitled task)')+'</div>'+
-      '<div class="work-meta">'+statusPill(w.status)+who+cli+'</div></div>';
+      '<div class="work-meta">'+statusPill(w.status)+who+cli+'</div>'+preview+'</div>';
   }).join('');
 }
 function renderPolicy(p){
@@ -702,10 +751,11 @@ function renderPolicy(p){
     ['Skip assigned-to-others',p.skip_assigned_to_others?'yes':'no'],
     ['Disabled tiers',list(p.disabled_tiers)],
     ['Disabled repos',list(p.disabled_repos)],
-    ['Auto-promote at',esc(p.auto_promote_at)+' tasks &rarr; contributor'],
-    ['Trusted at',esc(p.trusted_at)+' tasks + maintainer voucher']
+    ['Auto-promote at',esc(p.auto_promote_at)+' tasks that produced a PR &rarr; contributor'],
+    ['Trusted at','~'+esc(p.trusted_at)+' PR tasks, then granted by a maintainer']
   ];
-  el.innerHTML=rows.map(function(r){return '<div class="policy-row"><span class="policy-key">'+r[0]+'</span><span class="policy-val">'+r[1]+'</span></div>';}).join('');
+  el.innerHTML=rows.map(function(r){return '<div class="policy-row"><span class="policy-key">'+r[0]+'</span><span class="policy-val">'+r[1]+'</span></div>';}).join('')+
+    '<p class="ops-note">Promotion counts completions that reported a pull request (not bare completed tasks). Auto-promotion only lifts newcomer &rarr; contributor; the trusted tier is granted by an operator, not unlocked automatically.</p>';
 }
 async function opsPoll(){
   try{
@@ -758,7 +808,7 @@ fetch('/api/version').then(function(r){return r.json()}).then(function(d){
   el.innerHTML=dot+' Hive v'+d.version+' ('+d.short+')' + (d.behind?' · <span style="color:#d29922">update available</span>':' · up to date');
 }).catch(function(){});
 </script>
-</body></html>`, projectName, projectName, len(profiles), tierBoxes.String(), hubURL, hubURL)
+</body></html>`, projectName, projectName, len(profiles), tierBoxes.String(), hubURL, hubURL, tierTableRows)
 }
 
 // ── Registration ───────────────────────────────────────────────────────────

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -248,6 +249,53 @@ func TestContributeFleet(t *testing.T) {
 	}
 	if resp.Policy.TrustedAt != contributorTrustedAt {
 		t.Errorf("trusted_at = %d, want %d", resp.Policy.TrustedAt, contributorTrustedAt)
+	}
+}
+
+// TestTrustTierTableMatchesConstants (#2544): the on-page trust-tier table must
+// describe what the promotion code actually does — auto-promotion counts tasks
+// that PRODUCED A PR (TasksWithPR), not bare completed tasks — and must render
+// its numbers from contributorAutoPromoteAt / contributorTrustedAt so the page
+// cannot drift from the code again. The old over-promising wording ("5 completed
+// tasks", "maintainer voucher" + "Merge PRs") must be gone.
+func TestTrustTierTableMatchesConstants(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+
+	// A missing format arg would render as %!s(MISSING); the whole page must be
+	// clean (this also guards the spliced tier-table %s verb).
+	if strings.Contains(body, "%!") {
+		t.Fatalf("landing page has a format error (%%! present) — verb/arg mismatch")
+	}
+
+	// Corrected, constant-sourced wording is present.
+	wantAutoPromote := fmt.Sprintf("%d tasks that produced a PR", contributorAutoPromoteAt)
+	if !strings.Contains(body, wantAutoPromote) {
+		t.Errorf("tier table missing corrected contributor row %q", wantAutoPromote)
+	}
+	wantTrusted := fmt.Sprintf("~%d PR tasks, then granted by a maintainer", contributorTrustedAt)
+	if !strings.Contains(body, wantTrusted) {
+		t.Errorf("tier table missing corrected trusted row %q", wantTrusted)
+	}
+
+	// The old inaccurate wording must be gone.
+	for _, gone := range []string{
+		"5 completed tasks",
+		"20 tasks + maintainer voucher",
+		"<td>Merge PRs</td>",
+	} {
+		if strings.Contains(body, gone) {
+			t.Errorf("tier table still contains inaccurate wording %q", gone)
+		}
 	}
 }
 

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -73,7 +73,24 @@ type ContributorConnection struct {
 	// once wsTokenRefreshPeriod has elapsed, before the token expires. Zero when
 	// no task is active. See #2393 item 2.
 	tokenMintedAt time.Time
-	mu            sync.Mutex
+	// currentPrompt is the exact assignment prompt that was built for currentTask
+	// and shipped in its task_assign (#2539). It is stored so the read-only ops
+	// tab can PREVIEW the instruction the agent is running WITHOUT ever exposing
+	// the minted github_token that travelled in the same message. It never carries
+	// a credential — buildTaskPrompt is a pure function of task metadata. Zero when
+	// no task is active.
+	currentPrompt string
+	// currentLabels are the chosen issue's labels for currentTask (#2539), stored
+	// so the ops Task-panel preview can list them alongside the prompt. Metadata
+	// only — never a credential. Zero when no task is active.
+	currentLabels []string
+	// lastIdleReason is the most recent reason selectTask had no work to hand this
+	// connection (#2546): one of the taskUnavailable* reasons. It lets the ops tab
+	// show WHY a connected clanker is idle (suspended vs hub-not-ready vs
+	// no-matching-work vs an enforced refusal) instead of an indistinguishable
+	// silence. Cleared when a task is actually assigned. Purely diagnostic.
+	lastIdleReason string
+	mu             sync.Mutex
 }
 
 type WSMessage struct {
@@ -756,6 +773,17 @@ type FleetClanker struct {
 	LastActivity   string        `json:"last_activity,omitempty"`
 	Stale          bool          `json:"stale,omitempty"`
 	CurrentTask    *WSTaskAssign `json:"current_task,omitempty"`
+	// IdleReason is the machine-readable reason this clanker currently has no work
+	// (#2546): one of the taskUnavailable* reasons last sent to it. Empty when the
+	// clanker is actively working (CurrentTask set) or has never been refused. It
+	// lets the operator distinguish "idle: no_matching_work" from "idle:
+	// contribution_suspended" instead of an undifferentiated idle. Read-only.
+	IdleReason string `json:"idle_reason,omitempty"`
+	// PromptPreview is the exact assignment prompt built for CurrentTask (#2539),
+	// surfaced read-only so an operator can see the instruction the agent is
+	// running. It NEVER contains the minted github_token — the token travels on the
+	// task_assign WSMessage separately and is not stored here. Empty when idle.
+	PromptPreview string `json:"prompt_preview,omitempty"`
 }
 
 // FleetWorkItem is a read-only view of one in-flight task the fleet is working,
@@ -772,6 +800,13 @@ type FleetWorkItem struct {
 	GitHubUsername string `json:"github_username,omitempty"`
 	CLIBackend     string `json:"cli_backend,omitempty"`
 	Status         string `json:"status"`
+	// Labels are the chosen issue's labels (#2539), shown alongside the prompt
+	// preview in the ops Task panel. Metadata only.
+	Labels []string `json:"labels,omitempty"`
+	// PromptPreview is the exact prompt shipped for this work item (#2539),
+	// surfaced read-only in the ops Task panel so the instruction is legible
+	// before/as it runs. It NEVER contains the github_token. Empty if unknown.
+	PromptPreview string `json:"prompt_preview,omitempty"`
 }
 
 // FleetSnapshot is the read-only payload the Management & Operations tab hydrates
@@ -809,12 +844,27 @@ func (h *ContributeWSHub) FleetSnapshot() FleetSnapshot {
 			fc.TrustTier = c.profile.TrustTier
 		}
 		var task *WSTaskAssign
+		var promptPreview string
+		var taskLabels []string
 		if c.currentTask != nil && !fc.Stale {
 			t := *c.currentTask
 			task = &t
+			// #2539: surface the stored prompt (never the token) for the active
+			// task so the ops tab can preview the instruction being run.
+			promptPreview = c.currentPrompt
+			if len(c.currentLabels) > 0 {
+				taskLabels = append([]string(nil), c.currentLabels...)
+			}
+		}
+		// #2546: when the clanker is NOT actively working, expose why it is idle so
+		// the operator sees "idle: no_matching_work" etc. Suppressed while a task is
+		// in flight (the reason, if any, is stale then).
+		if task == nil {
+			fc.IdleReason = c.lastIdleReason
 		}
 		c.mu.Unlock()
 		fc.CurrentTask = task
+		fc.PromptPreview = promptPreview
 		if task != nil {
 			snap.Work = append(snap.Work, FleetWorkItem{
 				TaskID:         task.TaskID,
@@ -826,6 +876,8 @@ func (h *ContributeWSHub) FleetSnapshot() FleetSnapshot {
 				GitHubUsername: fc.GitHubUsername,
 				CLIBackend:     fc.CLIBackend,
 				Status:         "in-progress",
+				Labels:         taskLabels,
+				PromptPreview:  promptPreview,
 			})
 		}
 		snap.Clankers = append(snap.Clankers, fc)
@@ -1108,15 +1160,23 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			task := h.selectTask(contributor)
 			switch {
 			case task == nil:
-				// No admissible work and no enforced refusal (e.g. suspended, no
-				// status yet, or an empty candidate set). Behaviour unchanged.
+				// Defensive backstop only: after #2436 and #2546 every selectTask
+				// path returns an explicit message, so this should not be reached.
+				// Kept so an unforeseen nil still fails safe (no send) rather than
+				// panicking.
 				h.logger.Info("[contribute-ws] no tasks available",
 					"username", contributor.profile.GitHubUsername,
 				)
 			case task.Type == "task_unavailable":
-				// #2436 finding 1/2/3: an explicit negative-ack (mint failure,
-				// disabled tier, or concurrency limit) rather than silence. Send it
-				// so the contributor can diagnose instead of hanging forever.
+				// An explicit negative-ack rather than silence. #2436 finding 1/2/3
+				// covers the enforced refusals (mint failure, disabled tier,
+				// concurrency limit); #2546 adds the three formerly-silent
+				// no-work-right-now reasons (contribution_suspended, hub_not_ready,
+				// no_matching_work). Record the reason on the connection so the ops
+				// tab can show WHY this clanker is idle, then send it.
+				contributor.mu.Lock()
+				contributor.lastIdleReason = task.Reason
+				contributor.mu.Unlock()
 				if err := sendJSON(conn, *task); err != nil {
 					h.logger.Warn("[contribute-ws] failed to send task_unavailable", "error", err)
 					return
@@ -1165,6 +1225,10 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				hasTask := contributor.currentTask != nil && contributor.currentTask.TaskID == msg.TaskID
 				completedTask := contributor.currentTask
 				contributor.currentTask = nil
+				// #2539: drop the previewable prompt with the task it belonged to so
+				// the ops tab does not show a stale instruction after completion.
+				contributor.currentPrompt = ""
+				contributor.currentLabels = nil
 				contributor.tokenMintedAt = time.Time{}
 				contributor.tmuxOutput = msg.TmuxOutput
 				contributor.mu.Unlock()
@@ -1438,6 +1502,27 @@ const (
 	// tier_limits.max_concurrent for this identity (counting every live
 	// connection this identity holds).
 	taskUnavailableConcurrencyLimit = "concurrency_limit"
+
+	// The reasons below (kubestellar/hive#2546) extend the same task_unavailable
+	// negative-ack to the three formerly-SILENT selectTask paths — each returned a
+	// bare nil, so an idle contributor could not tell "operator suspended us" from
+	// "hub is not ready yet" from "nothing matches right now". They are additive
+	// and wire-compatible: same message type/shape as #2436, only new reason
+	// strings. Unlike the #2436 reasons these are not enforced refusals — they mean
+	// "no work to hand you right now, and here is why".
+	//
+	// taskUnavailableContributionSuspended: the operator has turned the whole
+	// contribute queue off (hub.contribute_suspended). No contributor gets work
+	// until it is re-enabled.
+	taskUnavailableContributionSuspended = "contribution_suspended"
+	// taskUnavailableHubNotReady: the hub has no status snapshot yet (it has not
+	// finished its first enumeration, or has no server reference), so there is no
+	// candidate set to select from. Transient at startup.
+	taskUnavailableHubNotReady = "hub_not_ready"
+	// taskUnavailableNoMatchingWork: the hub is running and unsuspended but, after
+	// all filters (cooldown, disabled repos, allow/deny, skip-assigned, own-work),
+	// the candidate set is empty. There is simply nothing admissible to do now.
+	taskUnavailableNoMatchingWork = "no_matching_work"
 )
 
 // identityOf returns the stable key that groups a contributor's live
@@ -1466,15 +1551,56 @@ func (h *ContributeWSHub) taskUnavailable(reason string) *WSMessage {
 	}
 }
 
+// buildTaskPrompt constructs the exact assignment prompt sent to a contributor's
+// agent for a given issue. It is a PURE function of the task's public metadata
+// (repo / number / title) and deliberately contains NO credential: the scoped
+// github_token is attached to the task_assign WSMessage separately, so this text
+// is safe to preview read-only in the ops tab (#2539). selectTask ships whatever
+// this returns, and the ops preview reads the very same string back off the
+// connection, so "what is previewed" always matches "what runs".
+func buildTaskPrompt(repoFull string, number int, title string) string {
+	// The workspace contract (kubestellar/hive#2545): your tmux pane already
+	// starts rooted in $HIVE_WORKSPACE_DIR (contributor-agent.sh creates it and
+	// launches the session with -c pointed there), but nothing had put a repo
+	// on disk there yet. The previous prompt's only repository instruction was
+	// 'gh repo fork ... --clone=false' — a fork WITHOUT a checkout — so an
+	// agent that followed it literally, or one that stalled before improvising
+	// its own clone, was left sitting in an empty directory while the
+	// assignment slot stayed held. Spell out an actual clone into that known
+	// directory so there is a concrete first step rather than an implied one.
+	return fmt.Sprintf(
+		"You are a contributor to the %s hive. Work on issue %s#%d: \"%s\". "+
+			"You do NOT have push access to the upstream repo. "+
+			"Start by getting a real checkout on disk: "+
+			"'gh repo fork %s --clone=true --remote=true "+
+			"$HIVE_WORKSPACE_DIR/%s' (or, if that directory already has a clone "+
+			"from a prior task, 'cd' into it and 'git fetch' instead of "+
+			"re-forking). Then 'cd' into that checkout, read the issue, "+
+			"understand what's needed, and take action. "+
+			"Push your branch to your fork remote, then open a PR from your fork. "+
+			"Use the GH_TOKEN env var for all gh commands (do NOT use 'unset GITHUB_TOKEN').",
+		repoFull, repoFull, number, title, repoFull, repoFull,
+	)
+}
+
 func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	h.selectMu.Lock()
 	defer h.selectMu.Unlock()
 
 	if h.server == nil {
-		return nil
+		// No server reference — the hub cannot read status or config, so there is
+		// nothing to select from. Jorge flagged this path as arguably not
+		// contributor-visible; it is folded into hub_not_ready since it is the same
+		// "the hub cannot serve work yet" condition and giving it a reason is
+		// trivial and harmless (#2546).
+		return h.taskUnavailable(taskUnavailableHubNotReady)
 	}
 	if h.server.deps != nil && h.server.deps.Config != nil && h.server.deps.Config.Hub.ContributeSuspended {
-		return nil
+		// #2546: the operator suspended the whole contribute queue. Previously this
+		// returned a bare nil and the contributor waited in silence, unable to tell
+		// "suspended" from "misconfigured" from "wedged". Send an explicit
+		// contribution_suspended negative-ack so the idle state is legible.
+		return h.taskUnavailable(taskUnavailableContributionSuspended)
 	}
 
 	h.server.statusMu.RLock()
@@ -1482,7 +1608,10 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	h.server.statusMu.RUnlock()
 
 	if status == nil {
-		return nil
+		// #2546: no status snapshot yet (hub still warming up). Same wire-shape as
+		// above, distinct reason, so the contributor learns it is a transient
+		// not-ready state rather than a permanent refusal.
+		return h.taskUnavailable(taskUnavailableHubNotReady)
 	}
 
 	// #2436 finding 2: refuse to assign work to a contributor whose TrustTier is
@@ -1705,7 +1834,11 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	}
 
 	if len(candidates) == 0 {
-		return nil
+		// #2546: the hub is running and unsuspended but nothing is admissible right
+		// now (everything is in cooldown, filtered out, disabled, or already held).
+		// Previously a bare nil — indistinguishable on the wire from "suspended" or
+		// "hub not ready". Send an explicit no_matching_work negative-ack.
+		return h.taskUnavailable(taskUnavailableNoMatchingWork)
 	}
 
 	// Order the admissible set with a STABLE sort so the pick is deterministic
@@ -1756,28 +1889,14 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 
 	taskID := fmt.Sprintf("ct-%s-%d-%d", chosen.repoFull, chosen.number, time.Now().Unix())
 
-	// The workspace contract (kubestellar/hive#2545): your tmux pane already
-	// starts rooted in $HIVE_WORKSPACE_DIR (contributor-agent.sh creates it and
-	// launches the session with -c pointed there), but nothing had put a repo
-	// on disk there yet. The previous prompt's only repository instruction was
-	// 'gh repo fork ... --clone=false' — a fork WITHOUT a checkout — so an
-	// agent that followed it literally, or one that stalled before improvising
-	// its own clone, was left sitting in an empty directory while the
-	// assignment slot stayed held. Spell out an actual clone into that known
-	// directory so there is a concrete first step rather than an implied one.
-	prompt := fmt.Sprintf(
-		"You are a contributor to the %s hive. Work on issue %s#%d: \"%s\". "+
-			"You do NOT have push access to the upstream repo. "+
-			"Start by getting a real checkout on disk: "+
-			"'gh repo fork %s --clone=true --remote=true "+
-			"$HIVE_WORKSPACE_DIR/%s' (or, if that directory already has a clone "+
-			"from a prior task, 'cd' into it and 'git fetch' instead of "+
-			"re-forking). Then 'cd' into that checkout, read the issue, "+
-			"understand what's needed, and take action. "+
-			"Push your branch to your fork remote, then open a PR from your fork. "+
-			"Use the GH_TOKEN env var for all gh commands (do NOT use 'unset GITHUB_TOKEN').",
-		chosen.repoFull, chosen.repoFull, chosen.number, chosen.title, chosen.repoFull, chosen.repoFull,
-	)
+	// #2539: build the prompt through the shared, credential-free buildTaskPrompt
+	// so the exact text shipped in task_assign below can also be PREVIEWED
+	// read-only in the ops tab. The prompt is a pure function of task metadata —
+	// the minted github_token is attached to the WSMessage separately (never inside
+	// the prompt), so previewing the prompt can never leak the token. buildTaskPrompt
+	// itself carries the #2545 workspace-clone instruction (real checkout into
+	// $HIVE_WORKSPACE_DIR rather than a fork-only --clone=false).
+	prompt := buildTaskPrompt(chosen.repoFull, chosen.number, chosen.title)
 
 	c.mu.Lock()
 	c.currentTask = &WSTaskAssign{
@@ -1787,6 +1906,11 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		Number: chosen.number,
 		Title:  chosen.title,
 	}
+	// Store the prompt (never the token) so FleetSnapshot can preview it (#2539),
+	// and clear any stale idle reason now that this connection has real work.
+	c.currentPrompt = prompt
+	c.currentLabels = chosen.labels
+	c.lastIdleReason = ""
 	c.tokenMintedAt = time.Now()
 	c.mu.Unlock()
 

--- a/v2/pkg/dashboard/contribute_ws_more_coverage_test.go
+++ b/v2/pkg/dashboard/contribute_ws_more_coverage_test.go
@@ -133,15 +133,15 @@ func TestCovK2_SelectTask(t *testing.T) {
 		lastPong: time.Now(),
 	}
 
-	// No status yet → nil.
-	if msg := hub.selectTask(conn); msg != nil {
-		t.Fatalf("expected nil task with no status")
+	// No status yet → explicit hub_not_ready negative-ack (#2546).
+	if msg := hub.selectTask(conn); msg == nil || msg.Reason != taskUnavailableHubNotReady {
+		t.Fatalf("expected task_unavailable/%s with no status, got %+v", taskUnavailableHubNotReady, msg)
 	}
 
-	// Suspended contribute → nil.
+	// Suspended contribute → explicit contribution_suspended negative-ack (#2546).
 	s.deps.Config.Hub.ContributeSuspended = true
-	if msg := hub.selectTask(conn); msg != nil {
-		t.Fatalf("expected nil task when contribute suspended")
+	if msg := hub.selectTask(conn); msg == nil || msg.Reason != taskUnavailableContributionSuspended {
+		t.Fatalf("expected task_unavailable/%s when suspended, got %+v", taskUnavailableContributionSuspended, msg)
 	}
 	s.deps.Config.Hub.ContributeSuspended = false
 
@@ -177,8 +177,9 @@ func TestCovK2_SelectTask(t *testing.T) {
 	// is skipped (activeIssues), and after marking it complete it's in cooldown.
 	hub.markTaskCompleted("myorg/repo1", 7, "https://github.com/myorg/repo1/pull/9")
 	conn.currentTask = nil
-	if msg := hub.selectTask(conn); msg != nil {
-		t.Fatalf("expected nil task (cooldown) but got %+v", msg)
+	// The sole candidate is now in cooldown → empty candidate set → no_matching_work (#2546).
+	if msg := hub.selectTask(conn); msg == nil || msg.Reason != taskUnavailableNoMatchingWork {
+		t.Fatalf("expected task_unavailable/%s (cooldown) but got %+v", taskUnavailableNoMatchingWork, msg)
 	}
 }
 

--- a/v2/pkg/dashboard/contribute_ws_ops_ext_test.go
+++ b/v2/pkg/dashboard/contribute_ws_ops_ext_test.go
@@ -1,0 +1,187 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- #2546: the three formerly-silent selectTask paths now emit an explicit
+// task_unavailable with a machine-readable reason ---------------------------------
+
+// TestNoWork_ContributionSuspended (#2546): when the operator has suspended the
+// whole contribute queue, selectTask returns an explicit contribution_suspended
+// negative-ack instead of a bare nil (which sent NOTHING to the contributor).
+func TestNoWork_ContributionSuspended(t *testing.T) {
+	hub, s := covK2Hub(t)
+	oneActionableIssue(s) // work IS available; suspension, not scarcity, is the reason.
+	s.deps.Config.Hub.ContributeSuspended = true
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "newcomer"},
+		lastPong: time.Now(),
+	}
+	msg := hub.selectTask(conn)
+	if msg == nil {
+		t.Fatalf("suspended queue must send an explicit negative-ack, got nil (silent)")
+	}
+	if msg.Type != "task_unavailable" || msg.Reason != taskUnavailableContributionSuspended {
+		t.Fatalf("expected task_unavailable/%s, got type=%q reason=%q",
+			taskUnavailableContributionSuspended, msg.Type, msg.Reason)
+	}
+}
+
+// TestNoWork_HubNotReady (#2546): with no status snapshot yet, selectTask returns
+// an explicit hub_not_ready negative-ack rather than a silent nil.
+func TestNoWork_HubNotReady(t *testing.T) {
+	hub, s := covK2Hub(t)
+	// Deliberately do NOT install a status snapshot: s.status stays nil.
+	s.statusMu.Lock()
+	s.status = nil
+	s.statusMu.Unlock()
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "bob", ContributorID: "c-bob", TrustTier: "newcomer"},
+		lastPong: time.Now(),
+	}
+	msg := hub.selectTask(conn)
+	if msg == nil {
+		t.Fatalf("no-status must send an explicit negative-ack, got nil (silent)")
+	}
+	if msg.Type != "task_unavailable" || msg.Reason != taskUnavailableHubNotReady {
+		t.Fatalf("expected task_unavailable/%s, got type=%q reason=%q",
+			taskUnavailableHubNotReady, msg.Type, msg.Reason)
+	}
+}
+
+// TestNoWork_NoMatchingWork (#2546): with a status snapshot but an empty candidate
+// set (no actionable issues), selectTask returns an explicit no_matching_work
+// negative-ack rather than a silent nil.
+func TestNoWork_NoMatchingWork(t *testing.T) {
+	hub, s := covK2Hub(t)
+	// A status snapshot with a repo but NO actionable issues → empty candidate set.
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{{Name: "repo1", Full: "myorg/repo1", ActionableIssues: []any{}}},
+	}
+	s.statusMu.Unlock()
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "carol", ContributorID: "c-carol", TrustTier: "newcomer"},
+		lastPong: time.Now(),
+	}
+	msg := hub.selectTask(conn)
+	if msg == nil {
+		t.Fatalf("empty candidate set must send an explicit negative-ack, got nil (silent)")
+	}
+	if msg.Type != "task_unavailable" || msg.Reason != taskUnavailableNoMatchingWork {
+		t.Fatalf("expected task_unavailable/%s, got type=%q reason=%q",
+			taskUnavailableNoMatchingWork, msg.Type, msg.Reason)
+	}
+}
+
+// TestFleetSnapshot_IdleReasonSurfaced (#2546): a connection that was last told
+// there is no matching work surfaces that reason on its FleetClanker so the ops
+// tab can show "idle: no_matching_work".
+func TestFleetSnapshot_IdleReasonSurfaced(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	conn := &ContributorConnection{
+		profile:        &ContributorProfile{GitHubUsername: "dave", ContributorID: "c-dave", TrustTier: "newcomer"},
+		lastPong:       time.Now(),
+		lastIdleReason: taskUnavailableNoMatchingWork,
+	}
+	hub.mu.Lock()
+	hub.connections["conn-dave"] = conn
+	hub.mu.Unlock()
+
+	snap := hub.FleetSnapshot()
+	if len(snap.Clankers) != 1 {
+		t.Fatalf("expected 1 clanker, got %d", len(snap.Clankers))
+	}
+	if snap.Clankers[0].IdleReason != taskUnavailableNoMatchingWork {
+		t.Fatalf("idle_reason = %q, want %q", snap.Clankers[0].IdleReason, taskUnavailableNoMatchingWork)
+	}
+	// An idle clanker contributes no work item.
+	if len(snap.Work) != 0 {
+		t.Fatalf("idle clanker should produce no work items, got %d", len(snap.Work))
+	}
+}
+
+// --- #2539: the ops tab previews the assignment prompt + task metadata, and the
+// preview NEVER carries the minted github_token ----------------------------------
+
+const testGitHubToken = "ghs_SUPERSECRETTOKENVALUE_must_never_leak"
+
+// TestPromptPreview_SurfacesPromptAndMetadata_NoToken (#2539): FleetSnapshot
+// surfaces the exact prompt and task metadata (repo/number/title/labels) for an
+// active task, and the minted github_token — even when present on the live
+// task_assign — never appears anywhere in the preview payload.
+func TestPromptPreview_SurfacesPromptAndMetadata_NoToken(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	repo, number, title := "myorg/repo1", 101, "Actionable issue"
+	prompt := buildTaskPrompt(repo, number, title)
+
+	// The token must NEVER appear in the prompt the server builds.
+	if strings.Contains(prompt, testGitHubToken) || strings.Contains(prompt, "ghs_") {
+		t.Fatalf("buildTaskPrompt leaked a token-shaped string: %q", prompt)
+	}
+
+	conn := &ContributorConnection{
+		profile: &ContributorProfile{GitHubUsername: "erin", ContributorID: "c-erin", TrustTier: "contributor"},
+		currentTask: &WSTaskAssign{
+			TaskID: "ct-x", Kind: "issue", Repo: repo, Number: number, Title: title,
+		},
+		currentPrompt: prompt,
+		currentLabels: []string{"good first issue", "bug"},
+		lastPong:      time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["conn-erin"] = conn
+	hub.mu.Unlock()
+
+	snap := hub.FleetSnapshot()
+
+	// Clanker-level preview.
+	if len(snap.Clankers) != 1 {
+		t.Fatalf("expected 1 clanker, got %d", len(snap.Clankers))
+	}
+	fc := snap.Clankers[0]
+	if fc.PromptPreview != prompt {
+		t.Fatalf("clanker prompt_preview mismatch:\n got %q\nwant %q", fc.PromptPreview, prompt)
+	}
+	if fc.CurrentTask == nil || fc.CurrentTask.Repo != repo || fc.CurrentTask.Number != number || fc.CurrentTask.Title != title {
+		t.Fatalf("clanker current_task metadata missing/wrong: %+v", fc.CurrentTask)
+	}
+
+	// Work-level preview: prompt text + repo/number/title/labels present.
+	if len(snap.Work) != 1 {
+		t.Fatalf("expected 1 work item, got %d", len(snap.Work))
+	}
+	w := snap.Work[0]
+	if w.PromptPreview != prompt {
+		t.Fatalf("work prompt_preview mismatch:\n got %q\nwant %q", w.PromptPreview, prompt)
+	}
+	if !strings.Contains(w.PromptPreview, title) {
+		t.Fatalf("prompt preview should reference the issue title %q, got %q", title, w.PromptPreview)
+	}
+	if w.Repo != repo || w.Number != number || w.Title != title {
+		t.Fatalf("work metadata missing/wrong: repo=%q number=%d title=%q", w.Repo, w.Number, w.Title)
+	}
+	if len(w.Labels) != 2 || w.Labels[0] != "good first issue" {
+		t.Fatalf("work labels missing/wrong: %+v", w.Labels)
+	}
+
+	// The critical assertion: NEITHER preview surface carries a github_token.
+	// Assert on the whole marshaled snapshot so no field (existing or future) can
+	// smuggle the credential to the read-only ops view.
+	raw, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	blob := string(raw)
+	if strings.Contains(blob, testGitHubToken) || strings.Contains(blob, "github_token") {
+		t.Fatalf("prompt-preview snapshot leaked a github_token:\n%s", blob)
+	}
+}

--- a/v2/pkg/dashboard/contribute_ws_test.go
+++ b/v2/pkg/dashboard/contribute_ws_test.go
@@ -236,8 +236,14 @@ func TestWSReady(t *testing.T) {
 	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
 	readMsg(t, conn) // auth_ok
 
-	// Send ready — should not error (no tasks available is fine)
+	// Send ready. With no status snapshot the hub now replies with an explicit
+	// task_unavailable/hub_not_ready negative-ack instead of silence (#2546).
 	conn.WriteJSON(WSMessage{Type: "ready", Seq: 1})
+	na := readMsg(t, conn)
+	if na.Type != "task_unavailable" || na.Reason != taskUnavailableHubNotReady {
+		t.Fatalf("expected task_unavailable/%s after ready with no status, got type=%s reason=%s",
+			taskUnavailableHubNotReady, na.Type, na.Reason)
+	}
 
 	// Send ping to verify connection is still alive
 	conn.WriteJSON(WSMessage{Type: "ping", Seq: 99})
@@ -503,8 +509,15 @@ func TestWSRoleBasedReady(t *testing.T) {
 	})
 	readMsg(t, conn) // auth_ok
 
-	// Send ready — role-based contributors should not get task assignments
+	// Send ready. With no status snapshot the hub replies with an explicit
+	// task_unavailable/hub_not_ready negative-ack (#2546) rather than silence;
+	// role-based contributors still get no task_assign.
 	conn.WriteJSON(WSMessage{Type: "ready", Seq: 1})
+	na := readMsg(t, conn)
+	if na.Type != "task_unavailable" || na.Reason != taskUnavailableHubNotReady {
+		t.Fatalf("expected task_unavailable/%s after role-based ready, got type=%s reason=%s",
+			taskUnavailableHubNotReady, na.Type, na.Reason)
+	}
 
 	// Verify connection is still alive
 	conn.WriteJSON(WSMessage{Type: "ping", Seq: 99})

--- a/v2/pkg/dashboard/coverage_boost_test.go
+++ b/v2/pkg/dashboard/coverage_boost_test.go
@@ -26,9 +26,9 @@ func TestMaskToken(t *testing.T) {
 		want  string
 	}{
 		{"", ""},
-		{"abc", "abc"},              // <= 4 chars, returned as-is
-		{"abcd", "abcd"},            // exactly 4 chars
-		{"abcde", "•bcde"},          // 5 chars, 1 hidden
+		{"abc", "abc"},     // <= 4 chars, returned as-is
+		{"abcd", "abcd"},   // exactly 4 chars
+		{"abcde", "•bcde"}, // 5 chars, 1 hidden
 		{"ghp_1234567890", "••••••••••7890"}, // typical token
 	}
 	for _, tt := range tests {
@@ -46,8 +46,8 @@ func TestMaskToken(t *testing.T) {
 
 func TestRedactTokensInLine(t *testing.T) {
 	tests := []struct {
-		input    string
-		contains string
+		input       string
+		contains    string
 		notContains string
 	}{
 		{"no token here", "no token here", ""},
@@ -1070,8 +1070,8 @@ func TestContributeWSHub_LiveStates(t *testing.T) {
 
 	// Add a mock connection
 	conn := &ContributorConnection{
-		profile:   &ContributorProfile{ContributorID: "cid-1", GitHubUsername: "testuser"},
-		lastPong:  time.Now(),
+		profile:     &ContributorProfile{ContributorID: "cid-1", GitHubUsername: "testuser"},
+		lastPong:    time.Now(),
 		currentTask: &WSTaskAssign{TaskID: "task-1", Kind: "issue", Repo: "org/repo", Number: 42},
 	}
 	hub.connections["conn-1"] = conn
@@ -1155,8 +1155,10 @@ func TestContributeWSHub_SelectTask_NilServer(t *testing.T) {
 		profile: &ContributorProfile{ContributorID: "cid-1"},
 	}
 	result := hub.selectTask(conn)
-	if result != nil {
-		t.Error("expected nil for nil server")
+	// #2546: the no-server-reference path now sends an explicit hub_not_ready
+	// negative-ack instead of a silent nil.
+	if result == nil || result.Type != "task_unavailable" || result.Reason != taskUnavailableHubNotReady {
+		t.Errorf("expected task_unavailable/%s for nil server, got %+v", taskUnavailableHubNotReady, result)
 	}
 }
 
@@ -1175,8 +1177,9 @@ func TestContributeWSHub_SelectTask_Suspended(t *testing.T) {
 		profile: &ContributorProfile{ContributorID: "cid-1"},
 	}
 	result := hub.selectTask(conn)
-	if result != nil {
-		t.Error("expected nil when suspended")
+	// #2546: a suspended queue now sends contribution_suspended, not a silent nil.
+	if result == nil || result.Type != "task_unavailable" || result.Reason != taskUnavailableContributionSuspended {
+		t.Errorf("expected task_unavailable/%s when suspended, got %+v", taskUnavailableContributionSuspended, result)
 	}
 }
 
@@ -1194,8 +1197,9 @@ func TestContributeWSHub_SelectTask_NoStatus(t *testing.T) {
 		profile: &ContributorProfile{ContributorID: "cid-1"},
 	}
 	result := hub.selectTask(conn)
-	if result != nil {
-		t.Error("expected nil when no status")
+	// #2546: no status snapshot now sends hub_not_ready, not a silent nil.
+	if result == nil || result.Type != "task_unavailable" || result.Reason != taskUnavailableHubNotReady {
+		t.Errorf("expected task_unavailable/%s when no status, got %+v", taskUnavailableHubNotReady, result)
 	}
 }
 
@@ -1272,8 +1276,10 @@ func TestContributeWSHub_SelectTask_Cooldown(t *testing.T) {
 		profile: &ContributorProfile{ContributorID: "cid-1", TrustTier: "contributor"},
 	}
 	result := hub.selectTask(conn)
-	if result != nil {
-		t.Error("expected nil for task in cooldown")
+	// #2546: the only candidate is in cooldown, so the candidate set is empty and
+	// selectTask now sends no_matching_work rather than a silent nil.
+	if result == nil || result.Type != "task_unavailable" || result.Reason != taskUnavailableNoMatchingWork {
+		t.Errorf("expected task_unavailable/%s for task in cooldown, got %+v", taskUnavailableNoMatchingWork, result)
 	}
 }
 
@@ -1746,16 +1752,16 @@ func TestLoadAgentStats_FallbackToDefaults(t *testing.T) {
 func TestBuildExportYAML_Basic(t *testing.T) {
 	srv := newFullServer(t)
 	agentCfg := config.AgentConfig{
-		Backend:     "claude",
-		Model:       "sonnet",
-		Role:        "scanner",
-		DisplayName: "Scanner",
-		Description: "Scans issues",
-		Emoji:       "🔍",
-		Color:       "#00ff00",
-		LaneKeywords: []string{"bug", "fix"},
+		Backend:        "claude",
+		Model:          "sonnet",
+		Role:           "scanner",
+		DisplayName:    "Scanner",
+		Description:    "Scans issues",
+		Emoji:          "🔍",
+		Color:          "#00ff00",
+		LaneKeywords:   []string{"bug", "fix"},
 		DetectKeywords: []string{"error"},
-		Aliases:     []string{"scan"},
+		Aliases:        []string{"scan"},
 	}
 	cadences := map[string]string{"idle": "15m", "busy": "5m"}
 	yaml := srv.buildExportYAML("scanner", agentCfg, cadences, true, "# my prompt\nDo stuff.")


### PR DESCRIPTION
## Summary

Extends the read-only **Management & Operations** tab on `/contribute` (added in #2542) with three small, additive, tab-aligned improvements. Everything here is read-only surfacing plus one additive, wire-compatible protocol extension. No credential-gating (that is #2537, out of scope), and no relay / workspace / routing / token-delivery changes.

Fixes #2544
Fixes #2546
Fixes #2539

## #2544 — trust-tier table now matches the promotion code

The static tier table on `/contribute` over-promised: it claimed **Contributor: "5 completed tasks"** and **Trusted: "20 tasks + maintainer voucher" → "Merge PRs"**. The code actually:

- auto-promotes **newcomer → contributor** on `TasksWithPR` (completions that reported a PR URL), gated by `contributorAutoPromoteAt`, **not** bare completed tasks;
- has **no** code path that auto-promotes to `trusted` on a task count — `trusted` is set by an operator via `PUT /api/contributors/{id}/trust` (the "voucher" in practice), and `contributorTrustedAt` is a documented guideline, not an enforced gate;
- grants `trusted` scoped tokens `checks:read` on top of the contributor scopes — it does not by itself confer merge (that is gated by the project's `/approve` + `lgtm` automation).

Changes:
- The Contributor / Trusted rows are now **rendered from the `contributorAutoPromoteAt` / `contributorTrustedAt` constants** so the page can't drift from the code again, and worded to match what the code does ("tasks that produced a PR"; "~20 PR tasks, then granted by a maintainer"; trusted's extra scope is `checks:read`).
- The ops **policy panel** gets a note that promotion counts PRs (not bare completions) and that trusted is operator-granted, alongside the existing `auto_promote_at` / `trusted_at` values.

## #2546 — an idle contributor learns *why* there is no work

Three `selectTask` paths returned a bare `nil` and sent **nothing** to the client, so "operator suspended us" / "hub not ready yet" / "nothing matches right now" were indistinguishable on the wire. Each now sends an explicit `task_unavailable` with a machine-readable `reason`, **extending the existing `task_unavailable` pattern from #2436** (same message type and shape, new reason strings):

- `contribution_suspended` — `hub.contribute_suspended` is on;
- `hub_not_ready` — no status snapshot yet (also folds the arguably-not-visible no-server-reference path, since it is the same "hub can't serve yet" condition);
- `no_matching_work` — running and unsuspended, but the candidate set is empty after cooldown / filters.

The latest reason is recorded on the connection and surfaced **read-only** on the fleet snapshot, so the ops tab shows e.g. `idle: no matching work` for a connected-but-idle clanker.

## #2539 — prompt preview (visibility only)

Lets an operator see the exact assignment prompt an agent will run, in the ops **Task panel** — the visibility half of the ask. The credential-**gating** mechanism (#2537) is explicitly **out of scope** and not implemented here.

- The assignment prompt is now built through a shared, credential-free `buildTaskPrompt(repo, number, title)` and stored on the connection, so the previewed text is the *same construction the server ships* — what's previewed matches what runs.
- The ops Task panel renders the prompt text plus task metadata (repo / number / title / labels) in a collapsible, read-only preview.
- **The `github_token` never appears in the preview.** The minted token travels on the `task_assign` message separately and is never stored on the connection or placed on any `Fleet*` type. A test marshals the entire fleet snapshot and asserts neither the token value nor the `github_token` key is present.
- Relay ack behaviour and token-delivery timing are unchanged.

## Tests

- Each formerly-silent path emits the correct `task_unavailable` reason; the idle reason is surfaced on the snapshot.
- The prompt preview surfaces prompt + task metadata and does **not** include the `github_token` (asserted against the whole marshaled snapshot).
- The tier table renders the corrected, constant-sourced wording and no longer contains the old inaccurate strings.
- Existing `selectTask` / `ready` tests updated from the old silent-`nil` contract to the new explicit-negative-ack contract.

`go build ./...`, `go vet ./pkg/dashboard/`, and the `pkg/dashboard` test suite pass; the extracted ops-tab inline script passes `node --check`.
