### PR TITLE
feat(escalation): fix-loop circuit breaker with raw CI evidence

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -785,6 +785,31 @@ ${_PRS_INLINE}"
   [ "$_ENUM_SLA" -gt 0 ] 2>/dev/null && _WORK_LIST="${_WORK_LIST}
 ⚠️ ${_ENUM_SLA} SLA VIOLATIONS (>30 min)"
 fi
+_FAILING_FILE="/var/run/hive-metrics/ci-failing.json"
+_FAILING_INLINE=""
+_ESCALATED_INLINE=""
+if [ -f "$_FAILING_FILE" ]; then
+  _FAILING_INLINE=$(python3 -c "
+import json
+d = json.load(open('$_FAILING_FILE'))
+for p in d.get('ci_failing', []):
+    if p.get('escalated'):
+        continue
+    checks = ','.join(p.get('failing_checks', [])[:4])
+    print(f\"  {p['repo']}#{p['number']} [{checks}] {p['title'][:60]}\")
+    ex = (p.get('excerpt') or '').strip()
+    if ex:
+        for line in ex.split(chr(10))[:3]:
+            print(f\"      ERROR: {line[:180]}\")
+" 2>/dev/null || echo "")
+  _ESCALATED_INLINE=$(python3 -c "
+import json
+d = json.load(open('$_FAILING_FILE'))
+for p in d.get('ci_failing', []):
+    if p.get('escalated'):
+        print(f\"  {p['repo']}#{p['number']} {p['title'][:60]}\")
+" 2>/dev/null || echo "")
+fi
 _MERGE_INLINE=""
 if [ -f "$_MERGE_FILE" ]; then
   _MERGE_COUNT=$(python3 -c "import json; print(json.load(open('$_MERGE_FILE')).get('count',0))" 2>/dev/null || echo 0)
@@ -817,7 +842,7 @@ fi
 SCANNER_MSG="[agent:scanner] [KICK] git pull /tmp/hive. ${_SCANNER_POLICY_INSTR}
 ${_GH_AUTH_INSTR}
 YOUR WORK LIST (pre-filtered — hold/ADOPTERS/drafts excluded, classified):
-${_WORK_LIST}${_CLUSTER_SECTION}${_MERGE_INLINE}
+${_WORK_LIST}${_CLUSTER_SECTION}${_MERGE_INLINE}$([ -n "$_FAILING_INLINE" ] && printf '\nCI-FAILING PRs (fix these — the ERROR lines are the RAW CI evidence, start from them, do NOT guess):\n%s' "$_FAILING_INLINE")$([ -n "$_ESCALATED_INLINE" ] && printf '\n🛑 ESCALATED (fix loop breaker tripped — do NOT open or push more fix PRs for these; a human owns them until the needs-human label is removed):\n%s' "$_ESCALATED_INLINE")
 ⛔ NEVER run gh issue list, gh pr list, gh search issues, or gh search prs — the work list above is your ONLY source. You may use gh issue view, gh pr view, gh pr merge, gh pr create on individual items.
 ⛔ NEVER post @copilot or @claude comments on issues. NEVER use gh issue comment to dispatch work. NEVER assign copilot-swe-agent[bot]. Posting @copilot comments does nothing and wastes cycles.
 ⛔ MERGE DISCIPLINE: You may ONLY merge PRs listed in the MERGE-READY section above. If no MERGE-READY section exists, merge NOTHING. NEVER merge a PR you created in this session — it must pass CI first and appear in a future kick's MERGE-READY list. Before merging, run 'gh pr checks <number> --repo <repo>' and verify every line shows 'pass' (ignore 'tide'). If ANY check is 'fail' or 'pending', do NOT merge — wait for the next kick.

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/dashboard"
 	"github.com/kubestellar/hive/v2/pkg/defsrc"
 	"github.com/kubestellar/hive/v2/pkg/discord"
+	"github.com/kubestellar/hive/v2/pkg/escalation"
 	"github.com/kubestellar/hive/v2/pkg/github"
 	"github.com/kubestellar/hive/v2/pkg/governor"
 	"github.com/kubestellar/hive/v2/pkg/hub"
@@ -4178,7 +4179,9 @@ func runEvalCycle(
 	// bounded ring in one cycle, and no I/O happens on this path.
 	recordEnumeratedIssues(dashSrv, actionable)
 
-	writeMergeEligible(actionable, actionable.Hold, cfg.Project.Org, logger)
+	escalatedPRs := runEscalationSweep(ctx, cfg, ghClient, actionable, notifier, logger)
+
+	writeMergeEligible(actionable, actionable.Hold, cfg.Project.Org, escalatedPRs, logger)
 
 	shaResult, shaErr := ghClient.EnforceSHAHold(ctx, github.SHAHoldConfig{
 		PrimaryRepo:     cfg.Project.PrimaryRepo,
@@ -4953,6 +4956,106 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 	}
 }
 
+var (
+	escalationStoreOnce sync.Once
+	escalationStore     *escalation.Store
+)
+
+const escalationLedgerPath = "/data/metrics/fix-streaks.json"
+
+// runEscalationSweep folds this enumeration pass into the fix-loop breaker
+// ledger and fires the one-time escalation actions (evidence comment +
+// needs-human label + ntfy) for any agent-authored PR that just crossed the
+// threshold of distinct failed fix attempts. Returns the full set of
+// escalated PR keys so the work-list writers can flag them. Deterministic by
+// design: no agent judgment is involved in counting, evidence, or the
+// stop-order. Human-authored PRs are never escalated.
+func runEscalationSweep(
+	ctx context.Context,
+	cfg *config.Config,
+	ghClient *github.Client,
+	actionable *github.ActionableResult,
+	notifier *notify.Notifier,
+	logger *slog.Logger,
+) map[string]bool {
+	escalated := map[string]bool{}
+	if cfg.Escalation.Disabled || ghClient == nil || actionable == nil {
+		return escalated
+	}
+	escalationStoreOnce.Do(func() {
+		escalationStore = escalation.Load(escalationLedgerPath)
+	})
+
+	fullRepo := func(repo string) string {
+		if !strings.Contains(repo, "/") && cfg.Project.Org != "" {
+			return cfg.Project.Org + "/" + repo
+		}
+		return repo
+	}
+	isAgentAuthor := func(author string) bool {
+		return author == cfg.Project.AIAuthor || strings.HasSuffix(author, "[bot]")
+	}
+
+	var obs []escalation.Observation
+	type prMeta struct{ checks []string }
+	meta := map[string]prMeta{}
+	for _, pr := range actionable.PRs.Items {
+		if !isAgentAuthor(pr.Author) {
+			continue
+		}
+		repo := fullRepo(pr.Repo)
+		obs = append(obs, escalation.Observation{
+			Repo:    repo,
+			Number:  pr.Number,
+			HeadSHA: pr.HeadSHA,
+			Red:     pr.CIStatus == "failure",
+			Excerpt: pr.CIFailureExcerpt,
+		})
+		meta[escalation.Key(repo, pr.Number)] = prMeta{checks: pr.FailingChecks}
+	}
+	results := escalationStore.Sweep(obs, cfg.Escalation.EffectiveThreshold())
+
+	for _, o := range obs {
+		key := escalation.Key(o.Repo, o.Number)
+		r, ok := results[key]
+		if !ok {
+			continue
+		}
+		if r.Escalated {
+			escalated[key] = true
+		}
+		if !r.NewlyEscala {
+			continue
+		}
+		escalated[key] = true
+		excerpt := o.Excerpt
+		if excerpt == "" {
+			excerpt = escalationStore.Excerpt(o.Repo, o.Number)
+		}
+		body := escalation.CommentBody(r.Attempts, meta[key].checks, excerpt)
+		if err := ghClient.CreateIssueComment(ctx, o.Repo, o.Number, body); err != nil {
+			// Retry next pass rather than marking escalated with no comment:
+			// the whole point is that the evidence reaches a human.
+			logger.Warn("escalation comment failed; will retry next pass",
+				"repo", o.Repo, "pr", o.Number, "error", err)
+			continue
+		}
+		if err := ghClient.AddLabels(ctx, o.Repo, o.Number, []string{escalation.NeedsHumanLabel}); err != nil {
+			logger.Warn("escalation label failed", "repo", o.Repo, "pr", o.Number, "error", err)
+		}
+		escalationStore.MarkEscalated(o.Repo, o.Number)
+		logger.Info("fix loop escalated to human",
+			"repo", o.Repo, "pr", o.Number, "attempts", r.Attempts,
+			"failing_checks", strings.Join(meta[key].checks, ","))
+		if notifier != nil {
+			notifier.Send("Fix loop escalated",
+				fmt.Sprintf("%s#%d red on %d fix attempts — needs a human (see PR comment for the raw error)", o.Repo, o.Number, r.Attempts),
+				notify.PriorityHigh)
+		}
+	}
+	return escalated
+}
+
 const mergeEligiblePath = "/var/run/hive-metrics/merge-eligible.json"
 const ciFailingPath = "/var/run/hive-metrics/ci-failing.json"
 
@@ -5020,7 +5123,7 @@ func applyDuplicatePRGuard(
 	github.ApplyDuplicatePRGuard(ctx, ghClient, claimLedger, hiveIdentity(cfg), actionable, logger)
 }
 
-func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldResult, org string, logger *slog.Logger) {
+func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldResult, org string, escalatedPRs map[string]bool, logger *slog.Logger) {
 	holdSet := make(map[string]bool)
 	for _, h := range hold.Items {
 		key := fmt.Sprintf("%s/%d", h.Repo, h.Number)
@@ -5046,6 +5149,14 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 		Title   string `json:"title"`
 		Author  string `json:"author"`
 		HeadSHA string `json:"head_sha,omitempty"`
+		// FailingChecks + Excerpt carry the raw CI evidence into the kick
+		// work list so fix agents see the actual error, not just "red".
+		FailingChecks []string `json:"failing_checks,omitempty"`
+		Excerpt       string   `json:"excerpt,omitempty"`
+		// Escalated marks PRs past the fix-loop breaker threshold: kick
+		// builders list them separately and agents must NOT dispatch more
+		// fix work for them.
+		Escalated bool `json:"escalated,omitempty"`
 	}
 
 	var eligible []eligiblePR
@@ -5065,11 +5176,14 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 
 		if pr.CIStatus == "failure" {
 			failing = append(failing, failingPR{
-				Number:  pr.Number,
-				Repo:    fullRepo,
-				Title:   pr.Title,
-				Author:  pr.Author,
-				HeadSHA: pr.HeadSHA,
+				Number:        pr.Number,
+				Repo:          fullRepo,
+				Title:         pr.Title,
+				Author:        pr.Author,
+				HeadSHA:       pr.HeadSHA,
+				FailingChecks: pr.FailingChecks,
+				Excerpt:       pr.CIFailureExcerpt,
+				Escalated:     escalatedPRs[escalation.Key(fullRepo, pr.Number)],
 			})
 			continue
 		}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	Ioscan     IoscanConfig     `yaml:"ioscan,omitempty" json:"ioscan,omitempty"`
 	Classifier ClassifierConfig `yaml:"classifier,omitempty" json:"classifier,omitempty"`
 	Planning   PlanningConfig   `yaml:"planning,omitempty" json:"planning,omitempty"`
+	Escalation EscalationConfig `yaml:"escalation,omitempty" json:"escalation,omitempty"`
 
 	// RemovedAgents are agent names an operator deliberately deleted. It is a
 	// TOMBSTONE list, and it exists because deletion had no durable record
@@ -3573,4 +3574,29 @@ func LabelsFilterPasses(labels []string, list []string, mode string) bool {
 		}
 		return true
 	}
+}
+
+// EscalationConfig tunes the fix-loop circuit breaker (pkg/escalation): after
+// Threshold distinct failed fix attempts on the same agent-authored PR, the
+// hub stops dispatching further fixes and escalates to a human with the raw
+// CI failure evidence.
+type EscalationConfig struct {
+	// Disabled turns the breaker off entirely (the zero value keeps it on —
+	// escalation is a safety net and must be opt-out, not opt-in).
+	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+	// Threshold is the distinct-red-attempt count that triggers escalation.
+	// Zero means DefaultEscalationThreshold.
+	Threshold int `yaml:"threshold,omitempty" json:"threshold,omitempty"`
+}
+
+// DefaultEscalationThreshold matches escalation.DefaultThreshold; duplicated
+// here (a constant, checked by test) to avoid a config→escalation import.
+const DefaultEscalationThreshold = 3
+
+// EffectiveThreshold resolves the configured threshold with its default.
+func (e EscalationConfig) EffectiveThreshold() int {
+	if e.Threshold > 0 {
+		return e.Threshold
+	}
+	return DefaultEscalationThreshold
 }

--- a/v2/pkg/escalation/escalation.go
+++ b/v2/pkg/escalation/escalation.go
@@ -1,0 +1,224 @@
+// Package escalation implements the fix-loop circuit breaker for agent-authored
+// PRs: when the same PR keeps failing CI across distinct fix attempts (new head
+// SHAs, still red), the hub stops re-dispatching fix work and escalates to a
+// human with the raw CI failure evidence attached.
+//
+// The counting, evidence-gathering, and stop-order are all deterministic code —
+// no agent judgment is involved. This exists because of the 2026-07-31→08-04
+// incident on kubestellar/console: a truncated test-file split kept main red for
+// four days while the scanner iterated blind fix PRs, never seeing the one-line
+// "ReferenceError: seedMission is not defined" buried in the shard logs.
+package escalation
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultThreshold is the number of distinct red head SHAs (fix attempts that
+// still failed CI) after which a PR is escalated instead of re-dispatched.
+const DefaultThreshold = 3
+
+// maxTrackedSHAs bounds the per-PR attempt history so the ledger cannot grow
+// without limit on a pathological PR.
+const maxTrackedSHAs = 20
+
+// Entry is the persisted per-PR attempt record.
+type Entry struct {
+	// RedSHAs are the distinct head SHAs observed with failing CI, oldest
+	// first. Length == number of failed fix attempts.
+	RedSHAs []string `json:"red_shas"`
+	// Escalated is set once the escalation actions (comment + label) have
+	// fired, so they never repeat for the same PR.
+	Escalated bool `json:"escalated"`
+	// LastExcerpt is the most recent CI failure excerpt, kept so the
+	// escalation comment can include evidence even if the final enumeration
+	// pass failed to fetch annotations.
+	LastExcerpt string    `json:"last_excerpt,omitempty"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// Store is the on-PVC attempt ledger. All methods are safe for concurrent use.
+type Store struct {
+	mu      sync.Mutex
+	path    string
+	entries map[string]*Entry // key: "repo#number"
+}
+
+// Load reads the ledger at path, returning an empty usable store on any error
+// (a missing or corrupt ledger must never block enumeration).
+func Load(path string) *Store {
+	s := &Store{path: path, entries: map[string]*Entry{}}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return s
+	}
+	var m map[string]*Entry
+	if json.Unmarshal(data, &m) == nil && m != nil {
+		s.entries = m
+	}
+	return s
+}
+
+// Key builds the ledger key for a PR.
+func Key(repo string, number int) string {
+	return fmt.Sprintf("%s#%d", repo, number)
+}
+
+// Observation is one PR's CI state from the current enumeration pass.
+type Observation struct {
+	Repo    string
+	Number  int
+	HeadSHA string
+	Red     bool // CI status is failure
+	Excerpt string
+}
+
+// Result reports the ledger's verdict for one observed PR.
+type Result struct {
+	Attempts    int
+	Escalated   bool // escalation actions already fired (now or previously)
+	NewlyEscala bool // this pass crossed the threshold — fire actions now
+}
+
+// Sweep folds a full enumeration pass into the ledger: increments attempt
+// counts for red PRs with unseen head SHAs, clears entries for PRs that went
+// green, prunes PRs no longer present, and reports which PRs crossed the
+// escalation threshold on this pass. The caller performs the side effects
+// (comment, label, notify) and then calls MarkEscalated for each.
+func (s *Store) Sweep(obs []Observation, threshold int) map[string]Result {
+	if threshold <= 0 {
+		threshold = DefaultThreshold
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	seen := make(map[string]bool, len(obs))
+	results := make(map[string]Result, len(obs))
+	for _, o := range obs {
+		key := Key(o.Repo, o.Number)
+		seen[key] = true
+		if !o.Red {
+			// Green: the loop converged — forget the history entirely so a
+			// future regression on the same PR starts a fresh count.
+			delete(s.entries, key)
+			continue
+		}
+		e := s.entries[key]
+		if e == nil {
+			e = &Entry{}
+			s.entries[key] = e
+		}
+		if o.HeadSHA != "" && !containsSHA(e.RedSHAs, o.HeadSHA) {
+			e.RedSHAs = append(e.RedSHAs, o.HeadSHA)
+			if len(e.RedSHAs) > maxTrackedSHAs {
+				e.RedSHAs = e.RedSHAs[len(e.RedSHAs)-maxTrackedSHAs:]
+			}
+		}
+		if o.Excerpt != "" {
+			e.LastExcerpt = o.Excerpt
+		}
+		e.UpdatedAt = time.Now().UTC()
+		results[key] = Result{
+			Attempts:    len(e.RedSHAs),
+			Escalated:   e.Escalated,
+			NewlyEscala: !e.Escalated && len(e.RedSHAs) >= threshold,
+		}
+	}
+	// Prune PRs that left the open set (merged or closed).
+	for key := range s.entries {
+		if !seen[key] {
+			delete(s.entries, key)
+		}
+	}
+	s.saveLocked()
+	return results
+}
+
+// MarkEscalated records that escalation side effects fired for the PR, so they
+// are never repeated.
+func (s *Store) MarkEscalated(repo string, number int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if e := s.entries[Key(repo, number)]; e != nil {
+		e.Escalated = true
+		e.UpdatedAt = time.Now().UTC()
+	}
+	s.saveLocked()
+}
+
+// Excerpt returns the stored failure excerpt for a PR ("" if none).
+func (s *Store) Excerpt(repo string, number int) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if e := s.entries[Key(repo, number)]; e != nil {
+		return e.LastExcerpt
+	}
+	return ""
+}
+
+// Attempts returns the recorded failed-attempt count for a PR.
+func (s *Store) Attempts(repo string, number int) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if e := s.entries[Key(repo, number)]; e != nil {
+		return len(e.RedSHAs)
+	}
+	return 0
+}
+
+func (s *Store) saveLocked() {
+	if s.path == "" {
+		return
+	}
+	data, err := json.MarshalIndent(s.entries, "", "  ")
+	if err != nil {
+		return
+	}
+	_ = os.MkdirAll(filepath.Dir(s.path), 0o755)
+	tmp := s.path + ".tmp"
+	if os.WriteFile(tmp, data, 0o644) == nil {
+		_ = os.Rename(tmp, s.path)
+	}
+}
+
+func containsSHA(shas []string, sha string) bool {
+	for _, s := range shas {
+		if s == sha {
+			return true
+		}
+	}
+	return false
+}
+
+// CommentBody renders the escalation comment posted on the PR. It leads with
+// the raw CI evidence — the whole point is that a human (or the next agent
+// pass) sees the actual error, not just "CI failed".
+func CommentBody(attempts int, failingChecks []string, excerpt string) string {
+	var b strings.Builder
+	b.WriteString("## 🛑 Fix loop escalated — human attention needed\n\n")
+	fmt.Fprintf(&b, "This PR has failed CI on **%d distinct fix attempts** (new commits, still red). ", attempts)
+	b.WriteString("The hive has stopped dispatching further automated fixes for it.\n\n")
+	if len(failingChecks) > 0 {
+		sorted := append([]string(nil), failingChecks...)
+		sort.Strings(sorted)
+		fmt.Fprintf(&b, "**Failing checks:** %s\n\n", strings.Join(sorted, ", "))
+	}
+	if excerpt != "" {
+		b.WriteString("**Raw failure evidence (from check-run annotations):**\n\n```\n")
+		b.WriteString(excerpt)
+		b.WriteString("\n```\n\n")
+	}
+	b.WriteString("Remove the `needs-human` label after addressing the root cause to return the PR to the automated fix lane.\n")
+	return b.String()
+}
+
+// NeedsHumanLabel is the label applied to escalated PRs. Kick builders exclude
+// items carrying it from fix dispatch.
+const NeedsHumanLabel = "needs-human"

--- a/v2/pkg/escalation/escalation_test.go
+++ b/v2/pkg/escalation/escalation_test.go
@@ -1,0 +1,76 @@
+package escalation
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func obs(repo string, num int, sha string, red bool) Observation {
+	return Observation{Repo: repo, Number: num, HeadSHA: sha, Red: red, Excerpt: "ReferenceError: seedMission is not defined"}
+}
+
+func TestSweep_EscalatesAtThresholdOfDistinctRedSHAs(t *testing.T) {
+	s := Load(filepath.Join(t.TempDir(), "streaks.json"))
+
+	// Attempt 1: red.
+	r := s.Sweep([]Observation{obs("org/repo", 7, "sha1", true)}, 3)
+	if got := r[Key("org/repo", 7)]; got.Attempts != 1 || got.NewlyEscala {
+		t.Fatalf("attempt 1: got %+v", got)
+	}
+	// Same SHA re-observed: NOT a new attempt.
+	r = s.Sweep([]Observation{obs("org/repo", 7, "sha1", true)}, 3)
+	if got := r[Key("org/repo", 7)]; got.Attempts != 1 {
+		t.Fatalf("same sha must not increment: got %+v", got)
+	}
+	// Attempts 2 and 3: new SHAs, still red — threshold crossed on 3.
+	s.Sweep([]Observation{obs("org/repo", 7, "sha2", true)}, 3)
+	r = s.Sweep([]Observation{obs("org/repo", 7, "sha3", true)}, 3)
+	got := r[Key("org/repo", 7)]
+	if got.Attempts != 3 || !got.NewlyEscala {
+		t.Fatalf("attempt 3 must escalate: got %+v", got)
+	}
+
+	// After MarkEscalated, further sweeps must not re-fire.
+	s.MarkEscalated("org/repo", 7)
+	r = s.Sweep([]Observation{obs("org/repo", 7, "sha4", true)}, 3)
+	got = r[Key("org/repo", 7)]
+	if got.NewlyEscala || !got.Escalated {
+		t.Fatalf("escalation must fire once: got %+v", got)
+	}
+}
+
+func TestSweep_GreenResetsAndAbsencePrunes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "streaks.json")
+	s := Load(path)
+
+	s.Sweep([]Observation{obs("org/repo", 7, "sha1", true)}, 3)
+	s.Sweep([]Observation{obs("org/repo", 7, "sha2", true)}, 3)
+	// Goes green: history forgotten.
+	s.Sweep([]Observation{obs("org/repo", 7, "sha3", false)}, 3)
+	if n := s.Attempts("org/repo", 7); n != 0 {
+		t.Fatalf("green must reset, got %d attempts", n)
+	}
+	// Red again, then vanishes from the open set (merged/closed): pruned.
+	s.Sweep([]Observation{obs("org/repo", 7, "sha4", true)}, 3)
+	s.Sweep([]Observation{obs("org/repo", 8, "shaX", true)}, 3)
+	if n := s.Attempts("org/repo", 7); n != 0 {
+		t.Fatalf("absent PR must be pruned, got %d attempts", n)
+	}
+
+	// Persistence across Load.
+	s2 := Load(path)
+	if n := s2.Attempts("org/repo", 8); n != 1 {
+		t.Fatalf("ledger must persist, got %d attempts for #8", n)
+	}
+}
+
+func TestCommentBody_LeadsWithEvidence(t *testing.T) {
+	body := CommentBody(3, []string{"Coverage Suite", "build-gate"}, "ReferenceError: seedMission is not defined")
+	for _, want := range []string{"3 distinct fix attempts", "Coverage Suite", "seedMission is not defined", NeedsHumanLabel} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("comment body missing %q:\n%s", want, body)
+		}
+	}
+}

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -93,6 +93,13 @@ type PullRequest struct {
 	Mergeable Mergeable `json:"mergeable"`
 	CIStatus  string    `json:"ci_status"`
 	HeadSHA   string    `json:"head_sha,omitempty"`
+	// FailingChecks names the completed check runs whose conclusion was
+	// failure/action_required. CIFailureExcerpt carries the raw error lines
+	// pulled from those runs' annotations — the evidence a fix agent (or an
+	// escalation comment) needs; "CI failed" alone left agents guessing for
+	// four days in the 2026-08 seedMission incident.
+	FailingChecks    []string `json:"failing_checks,omitempty"`
+	CIFailureExcerpt string   `json:"ci_failure_excerpt,omitempty"`
 }
 
 // Mergeable is a tri-state mergeability verdict for a pull request.
@@ -528,6 +535,8 @@ func (c *Client) EnrichCIStatus(ctx context.Context, prs []PullRequest) {
 		hasFail := false
 		allDone := true
 		ciChecksFound := 0
+		var failingNames []string
+		var failingIDs []int64
 		for _, cr := range checkRuns.CheckRuns {
 			if cr.GetName() == "tide" {
 				continue
@@ -540,6 +549,8 @@ func (c *Client) EnrichCIStatus(ctx context.Context, prs []PullRequest) {
 			conclusion := cr.GetConclusion()
 			if conclusion == "failure" || conclusion == "action_required" {
 				hasFail = true
+				failingNames = append(failingNames, cr.GetName())
+				failingIDs = append(failingIDs, cr.GetID())
 			}
 		}
 		if ciChecksFound == 0 {
@@ -549,12 +560,105 @@ func (c *Client) EnrichCIStatus(ctx context.Context, prs []PullRequest) {
 		switch {
 		case hasFail:
 			prs[i].CIStatus = ciStatusFailure
+			prs[i].FailingChecks = failingNames
+			prs[i].CIFailureExcerpt = c.fetchFailureExcerpt(ctx, owner, repoName, failingIDs, failingNames)
 		case allDone:
 			prs[i].CIStatus = ciStatusSuccess
 		default:
 			prs[i].CIStatus = ciStatusPending
 		}
 	}
+}
+
+// Bounds for fetchFailureExcerpt: annotations are fetched for at most
+// excerptMaxRuns failing check runs, keeping at most excerptMaxLines lines and
+// excerptMaxChars characters total. Enough to carry a stack of real errors
+// into a kick prompt without flooding it.
+const (
+	excerptMaxRuns  = 2
+	excerptMaxLines = 8
+	excerptMaxChars = 900
+)
+
+// fetchFailureExcerpt pulls the raw error lines from the annotations of the
+// given failing check runs. Annotations capture workflow ##[error] lines (test
+// failures, compile errors), which is exactly the evidence fix agents never
+// see from a bare "CI failed" status. Works on GitHub and GHE through the
+// client's configured API base; on errors it degrades to "" — the excerpt is
+// an enrichment, never a gate.
+func (c *Client) fetchFailureExcerpt(ctx context.Context, owner, repo string, runIDs []int64, runNames []string) string {
+	var lines []string
+	total := 0
+	seen := map[string]bool{}
+	for idx, id := range runIDs {
+		if idx >= excerptMaxRuns || len(lines) >= excerptMaxLines {
+			break
+		}
+		anns, _, err := c.client.Checks.ListCheckRunAnnotations(ctx, owner, repo, id, &gh.ListOptions{PerPage: 20})
+		if err != nil {
+			continue
+		}
+		name := ""
+		if idx < len(runNames) {
+			name = runNames[idx]
+		}
+		for _, a := range anns {
+			level := a.GetAnnotationLevel()
+			if level != "failure" && level != "warning" {
+				continue
+			}
+			msg := strings.TrimSpace(a.GetMessage())
+			if msg == "" || seen[msg] {
+				continue
+			}
+			seen[msg] = true
+			line := msg
+			if name != "" {
+				line = name + ": " + msg
+			}
+			if nl := strings.IndexByte(line, '\n'); nl > 0 {
+				line = line[:nl]
+			}
+			if len(line) > 300 {
+				line = line[:300]
+			}
+			if total+len(line) > excerptMaxChars {
+				return strings.Join(lines, "\n")
+			}
+			lines = append(lines, line)
+			total += len(line)
+			if len(lines) >= excerptMaxLines {
+				break
+			}
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// CreateIssueComment posts a comment on an issue or PR. The signature mirrors
+// forge.Forge.CreateIssueComment so escalation callers can swap in a neutral
+// forge adapter on non-GitHub hives without changing call sites.
+func (c *Client) CreateIssueComment(ctx context.Context, repo string, number int, body string) error {
+	if c == nil {
+		return ErrNoGitHubClient
+	}
+	owner, repoName := c.splitRepo(repo)
+	_, _, err := c.client.Issues.CreateComment(ctx, owner, repoName, number, &gh.IssueComment{Body: gh.Ptr(body)})
+	return err
+}
+
+// AddLabels adds labels to an issue or PR (no-op for an empty list), mirroring
+// forge.Forge.AddLabels for the same swap-in reason as CreateIssueComment.
+func (c *Client) AddLabels(ctx context.Context, repo string, number int, labels []string) error {
+	if c == nil {
+		return ErrNoGitHubClient
+	}
+	if len(labels) == 0 {
+		return nil
+	}
+	owner, repoName := c.splitRepo(repo)
+	_, _, err := c.client.Issues.AddLabelsToIssue(ctx, owner, repoName, number, labels)
+	return err
 }
 
 func extractLabels(labels []*gh.Label) []string {

--- a/v2/pkg/policies/defaults/scanner-automerge.md
+++ b/v2/pkg/policies/defaults/scanner-automerge.md
@@ -171,3 +171,9 @@ ${PR_LIST}
 ⛔ NEVER run `gh issue list`, `gh pr list`, or `gh search issues`.
 
 ${KNOWLEDGE}
+
+## Escalated PRs — fix-loop breaker
+
+Items marked **ESCALATED** in your kick (or PRs carrying the `needs-human` label) have failed CI across multiple distinct fix attempts and the hub has escalated them to a human with the raw failure evidence. Do NOT open new fix PRs, push commits, or retrigger CI for them. They re-enter your lane only when a human removes the `needs-human` label.
+
+For **CI-FAILING** items, your kick includes `ERROR:` lines extracted from the failing check-run annotations — that is the actual failure. Start your diagnosis from those lines; do not guess from the check name alone.


### PR DESCRIPTION
## The rule (operator-approved design)

When an agent-authored PR fails CI on **N distinct fix attempts** (new head SHAs, still red — default 3, `escalation.threshold`), the hub **deterministically** stops dispatching fix work and escalates to a human. No agent judgment in the counting, the evidence, or the stop-order.

Born from the 7/31→8/4 console incident: a truncated test-file split kept main red four days while the scanner iterated blind — `ReferenceError: seedMission is not defined` sat in check-run annotations the whole time.

## Two halves

**1. Evidence injection (fixes the blindness):** `EnrichCIStatus` now records failing check names + a failure excerpt pulled from check-run annotations per red PR → flows through `ci-failing.json` → the scanner kick's new **CI-FAILING** section shows `ERROR:` lines under each red PR. Agents read the actual error instead of guessing.

**2. The breaker:** new `v2/pkg/escalation` — persisted attempt ledger on the PVC keyed by PR, counting **distinct red head SHAs** (same SHA re-observed ≠ new attempt; green resets; merged/closed prunes). At threshold, once only: evidence comment on the PR + `needs-human` label + high-priority ntfy + **ESCALATED** kick section forbidding further fix PRs. Human removes the label → PR re-enters the fix lane.

## Multi-forge

Ledger/counting are forge-neutral. Excerpt fetch + actions go through the github client's configured API base (GHE ✓); `Client.CreateIssueComment`/`AddLabels` mirror `forge.Forge` signatures for drop-in adapter swap on GitLab/Gitea hives. Excerpt fetch degrades to "" on any error — enrichment, never a gate. Comment failure retries next pass rather than silently marking escalated.

## Applied retroactively to last week

Attempt 1 kick would have contained `ERROR: ReferenceError: seedMission is not defined` (probably fixed same-day); worst case attempt 3 freezes the lane and hands the operator that exact line on **Aug 1** instead of a 4-day loop.

Unit tests: threshold/same-SHA dedup, green-reset, absent-prune, persistence, once-only firing, comment body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)