### PR TITLE
feat(contribute): mirror Governor Hub controls into the Management & Operations tab (#2534)

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3533,27 +3533,28 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			// service-account-file fallback chain. Omitted (empty string)
 			// outside a cluster, which the Hub tab renders by skipping the
 			// line rather than showing a blank/"undefined" value.
-			"namespace":                        podNamespace(),
-			"url":                              cfg.Hub.URL,
-			"dashboard_url":                    cfg.Hub.DashboardURL,
-			"snapshot_url":                     cfg.Hub.SnapshotURL,
-			"is_public":                        cfg.Hub.IsPublic,
-			"auto_snapshot":                    cfg.Hub.AutoSnapshot,
-			"auto_upgrade":                     cfg.Hub.AutoUpgrade,
-			"snapshot_interval_min":            cfg.Hub.SnapshotIntervalMin,
-			"contribute_suspended":             cfg.Hub.ContributeSuspended,
-			"contribute_titles_mode":           cfg.Hub.ContributeTitlesMode,
-			"contribute_authors_mode":          cfg.Hub.ContributeAuthorsMode,
-			"contribute_labels_mode":           cfg.Hub.ContributeLabelsMode,
-			"contribute_allow_labels":          cfg.Hub.ContributeAllowLabels,
-			"contribute_deny_labels":           cfg.Hub.ContributeDenyLabels,
-			"contribute_deny_titles":           cfg.Hub.ContributeDenyTitles,
-			"contribute_deny_authors":          cfg.Hub.ContributeDenyAuthors,
-			"contribute_allow_models":          cfg.Hub.ContributeAllowModels,
-			"contribute_reject_unknown_models": cfg.Hub.ContributeRejectUnknownModels,
-			"disabled_repos":                   cfg.Hub.DisabledRepos,
-			"disabled_tiers":                   cfg.Hub.DisabledTiers,
-			"tier_limits":                      cfg.Hub.TierLimits,
+			"namespace":                          podNamespace(),
+			"url":                                cfg.Hub.URL,
+			"dashboard_url":                      cfg.Hub.DashboardURL,
+			"snapshot_url":                       cfg.Hub.SnapshotURL,
+			"is_public":                          cfg.Hub.IsPublic,
+			"auto_snapshot":                      cfg.Hub.AutoSnapshot,
+			"auto_upgrade":                       cfg.Hub.AutoUpgrade,
+			"snapshot_interval_min":              cfg.Hub.SnapshotIntervalMin,
+			"contribute_suspended":               cfg.Hub.ContributeSuspended,
+			"contribute_titles_mode":             cfg.Hub.ContributeTitlesMode,
+			"contribute_authors_mode":            cfg.Hub.ContributeAuthorsMode,
+			"contribute_labels_mode":             cfg.Hub.ContributeLabelsMode,
+			"contribute_allow_labels":            cfg.Hub.ContributeAllowLabels,
+			"contribute_deny_labels":             cfg.Hub.ContributeDenyLabels,
+			"contribute_deny_titles":             cfg.Hub.ContributeDenyTitles,
+			"contribute_deny_authors":            cfg.Hub.ContributeDenyAuthors,
+			"contribute_allow_models":            cfg.Hub.ContributeAllowModels,
+			"contribute_reject_unknown_models":   cfg.Hub.ContributeRejectUnknownModels,
+			"contribute_skip_assigned_to_others": cfg.Hub.ContributeSkipAssignedToOthers,
+			"disabled_repos":                     cfg.Hub.DisabledRepos,
+			"disabled_tiers":                     cfg.Hub.DisabledTiers,
+			"tier_limits":                        cfg.Hub.TierLimits,
 		},
 	})
 }
@@ -3899,26 +3900,27 @@ func (s *Server) handleGovernorLogging(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Enabled                       *bool                      `json:"enabled"`
-		URL                           string                     `json:"url"`
-		DashboardURL                  string                     `json:"dashboard_url"`
-		SnapshotURL                   string                     `json:"snapshot_url"`
-		IsPublic                      *bool                      `json:"is_public"`
-		AutoSnapshot                  *bool                      `json:"auto_snapshot"`
-		AutoUpgrade                   *bool                      `json:"auto_upgrade"`
-		ContributeSuspended           *bool                      `json:"contribute_suspended"`
-		ContributeTitlesMode          *string                    `json:"contribute_titles_mode"`
-		ContributeAuthorsMode         *string                    `json:"contribute_authors_mode"`
-		ContributeLabelsMode          *string                    `json:"contribute_labels_mode"`
-		ContributeAllowLabels         []string                   `json:"contribute_allow_labels"`
-		ContributeDenyLabels          []string                   `json:"contribute_deny_labels"`
-		ContributeDenyTitles          []string                   `json:"contribute_deny_titles"`
-		ContributeDenyAuthors         []string                   `json:"contribute_deny_authors"`
-		ContributeAllowModels         []string                   `json:"contribute_allow_models"`
-		ContributeRejectUnknownModels *bool                      `json:"contribute_reject_unknown_models"`
-		DisabledRepos                 []string                   `json:"disabled_repos"`
-		DisabledTiers                 []string                   `json:"disabled_tiers"`
-		TierLimits                    map[string]config.TierRate `json:"tier_limits"`
+		Enabled                        *bool                      `json:"enabled"`
+		URL                            string                     `json:"url"`
+		DashboardURL                   string                     `json:"dashboard_url"`
+		SnapshotURL                    string                     `json:"snapshot_url"`
+		IsPublic                       *bool                      `json:"is_public"`
+		AutoSnapshot                   *bool                      `json:"auto_snapshot"`
+		AutoUpgrade                    *bool                      `json:"auto_upgrade"`
+		ContributeSuspended            *bool                      `json:"contribute_suspended"`
+		ContributeTitlesMode           *string                    `json:"contribute_titles_mode"`
+		ContributeAuthorsMode          *string                    `json:"contribute_authors_mode"`
+		ContributeLabelsMode           *string                    `json:"contribute_labels_mode"`
+		ContributeAllowLabels          []string                   `json:"contribute_allow_labels"`
+		ContributeDenyLabels           []string                   `json:"contribute_deny_labels"`
+		ContributeDenyTitles           []string                   `json:"contribute_deny_titles"`
+		ContributeDenyAuthors          []string                   `json:"contribute_deny_authors"`
+		ContributeAllowModels          []string                   `json:"contribute_allow_models"`
+		ContributeRejectUnknownModels  *bool                      `json:"contribute_reject_unknown_models"`
+		ContributeSkipAssignedToOthers *bool                      `json:"contribute_skip_assigned_to_others"`
+		DisabledRepos                  []string                   `json:"disabled_repos"`
+		DisabledTiers                  []string                   `json:"disabled_tiers"`
+		TierLimits                     map[string]config.TierRate `json:"tier_limits"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
@@ -3973,6 +3975,9 @@ func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 	}
 	if body.ContributeRejectUnknownModels != nil {
 		cfg.Hub.ContributeRejectUnknownModels = *body.ContributeRejectUnknownModels
+	}
+	if body.ContributeSkipAssignedToOthers != nil {
+		cfg.Hub.ContributeSkipAssignedToOthers = *body.ContributeSkipAssignedToOthers
 	}
 	if body.DisabledRepos != nil {
 		cfg.Hub.DisabledRepos = body.DisabledRepos

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -427,6 +427,50 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .prompt-labels{margin:8px 0 4px;display:flex;flex-wrap:wrap;gap:4px}
 .prompt-text{margin-top:8px;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:12px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.75rem;color:#c9d1d9;white-space:pre-wrap;word-break:break-word;max-height:220px;overflow-y:auto}
 .prompt-preview .ops-note{margin-top:8px}
+/* #2534 Operator admin controls — mirror the Governor Hub config controls into the
+   Management & Operations tab. Owner/read-write only; a read viewer never sees them. */
+.ops-admin{display:none}
+.ops-admin.enabled{display:block}
+.admin-badge{font-size:.68rem;font-weight:600;padding:2px 8px;border-radius:999px;background:rgba(210,153,34,.12);color:#d29922;border:1px solid rgba(210,153,34,.3);margin-left:auto}
+.admin-body{padding:16px 20px}
+.admin-toggle{display:flex;align-items:center;gap:10px;padding:8px 0}
+.admin-switch{width:38px;height:20px;border-radius:999px;background:#30363d;position:relative;cursor:pointer;flex-shrink:0;transition:background .15s}
+.admin-switch::after{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%%;background:#e6edf3;transition:left .15s}
+.admin-switch.on{background:#1f6feb}
+.admin-switch.on.danger{background:#f85149}
+.admin-switch.on::after{left:20px}
+.admin-toggle-label{font-size:.85rem;color:#e6edf3}
+.admin-toggle-sub{font-size:.74rem;color:#8b949e}
+.admin-field{margin:14px 0}
+.admin-field>label{display:block;font-size:.78rem;color:#8b949e;margin-bottom:6px}
+.admin-modeseg{display:inline-flex;border:1px solid #30363d;border-radius:6px;overflow:hidden;margin-bottom:6px}
+.admin-modeseg button{background:#0d1117;border:none;color:#8b949e;font-size:.72rem;padding:3px 10px;cursor:pointer;font-family:inherit}
+.admin-modeseg button.on{background:#1f6feb;color:#fff}
+.admin-chips{display:flex;flex-wrap:wrap;gap:4px;margin-bottom:6px}
+.admin-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-size:.72rem;background:rgba(139,148,158,.12);color:#c9d1d9;border:1px solid #30363d}
+.admin-chip .x{cursor:pointer;opacity:.7}
+.admin-chip .x:hover{opacity:1;color:#f85149}
+.admin-addrow{display:flex;gap:4px}
+.admin-addrow input{flex:1;background:#0d1117;border:1px solid #30363d;border-radius:6px;color:#e6edf3;font-size:.78rem;padding:5px 8px;font-family:inherit}
+.admin-addrow button,.admin-save{background:#238636;border:1px solid #2ea043;color:#fff;font-size:.75rem;padding:5px 12px;border-radius:6px;cursor:pointer;font-family:inherit}
+.admin-addrow button{background:#21262d;border-color:#30363d;color:#c9d1d9}
+.admin-save{margin-top:8px}
+.admin-save:disabled{opacity:.5;cursor:default}
+.admin-hr{border:none;border-top:1px solid #21262d;margin:16px 0}
+.admin-actions{display:flex;gap:6px;flex-wrap:wrap;margin-left:auto}
+.admin-act{background:#21262d;border:1px solid #30363d;color:#c9d1d9;font-size:.7rem;padding:3px 9px;border-radius:6px;cursor:pointer;font-family:inherit}
+.admin-act:hover{border-color:#8b949e}
+.admin-act.danger:hover{border-color:#f85149;color:#f85149}
+.admin-act select{background:#0d1117;border:1px solid #30363d;color:#c9d1d9;font-size:.7rem;border-radius:6px;padding:2px 4px;font-family:inherit}
+.admin-modal-back{display:none;position:fixed;inset:0;background:rgba(1,4,9,.7);z-index:1000;align-items:center;justify-content:center}
+.admin-modal-back.show{display:flex}
+.admin-modal{background:#161b22;border:1px solid #30363d;border-radius:12px;max-width:420px;width:90%%;padding:22px}
+.admin-modal h4{margin:0 0 8px;font-size:1rem;color:#e6edf3}
+.admin-modal p{font-size:.85rem;color:#8b949e;line-height:1.5;margin:0 0 18px}
+.admin-modal-btns{display:flex;gap:8px;justify-content:flex-end}
+.admin-modal-btns button{font-size:.8rem;padding:6px 14px;border-radius:6px;cursor:pointer;font-family:inherit;border:1px solid #30363d;background:#21262d;color:#c9d1d9}
+.admin-modal-btns button.confirm{background:#da3633;border-color:#f85149;color:#fff}
+.admin-note{color:#6e7681;font-size:.76rem;margin-top:10px;line-height:1.5}
 </style></head><body>
 <div class="page-tabs" role="tablist">
 <button class="page-tab active" role="tab" id="ptab-onboarding" aria-selected="true" data-panel="tab-onboarding">Onboarding</button>
@@ -611,7 +655,48 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 <div class="tab-panel" id="tab-ops" role="tabpanel" aria-labelledby="ptab-ops">
 <div class="ops">
 <h1>Management &amp; Operations</h1>
-<p class="subtitle" style="font-size:.95rem">A read-only operations view over the contributor (&ldquo;clanker&rdquo;) fleet and its in-flight work &mdash; surfaced from what this hive already knows. No controls here mutate policy or the fleet.</p>
+<p class="subtitle" style="font-size:.95rem">An operations view over the contributor (&ldquo;clanker&rdquo;) fleet and its in-flight work. The read-only panels below surface what this hive already knows; operators with write access also get the admin controls, mirrored from the Governor Hub configuration.</p>
+
+<!-- #2534 Operator admin controls. Hidden by default; shown only after /api/role
+     reports owner or read-write. These mirror the Governor Hub config section
+     (Suspend Contributions + the admission filters) and write through the SAME
+     endpoint the Governor dialog uses (PUT /api/config/governor/hub), plus the
+     existing per-contributor endpoints. The Governor Hub tab stays the canonical
+     editor — this is a mirror for the clanker-ops context. -->
+<div class="ops-card ops-admin" id="ops-admin">
+<div class="ops-card-head"><span class="feed-dot"></span><h3>Operator admin controls</h3><span class="admin-badge" id="admin-role-badge"></span></div>
+<div class="admin-body">
+<p class="ops-note" style="margin-top:0">Mirrored from the Governor Hub configuration. Changes here write the same <code>Config.Hub.*</code> fields the Governor config dialog edits. Owner &amp; read-write only.</p>
+
+<div class="admin-toggle">
+<div class="admin-switch" id="admin-suspend-switch" data-key="contribute_suspended"></div>
+<div><div class="admin-toggle-label">Suspend contributions</div><div class="admin-toggle-sub">Stop assigning tasks. Connected clankers stay online but idle.</div></div>
+</div>
+<div class="admin-toggle">
+<div class="admin-switch" id="admin-skip-switch" data-key="contribute_skip_assigned_to_others"></div>
+<div><div class="admin-toggle-label">Skip issues assigned to others</div><div class="admin-toggle-sub">Never serve an issue already assigned to a different GitHub user.</div></div>
+</div>
+
+<hr class="admin-hr">
+<h3 style="font-size:.9rem;color:#e6edf3;margin:0 0 4px">Admission filters</h3>
+<p class="ops-note" style="margin-top:0">The queue-shaping levers. Deny (default) skips matches; Allow serves only matches.</p>
+
+<div class="admin-field" id="admin-filter-titles"></div>
+<div class="admin-field" id="admin-filter-authors"></div>
+<div class="admin-field" id="admin-filter-labels"></div>
+
+<div class="admin-field">
+<label>Allowed models <span style="color:#6e7681">— wildcards (*) and /regex/. Empty = allow all.</span></label>
+<div class="admin-chips" id="admin-allow-models"></div>
+<div class="admin-addrow"><input type="text" id="admin-allow-model-input" placeholder="e.g. claude-opus*, /gemini-\d/"><button type="button" id="admin-add-model">Add</button></div>
+<div class="admin-toggle" style="padding-top:8px"><div class="admin-switch" id="admin-reject-switch" data-key="contribute_reject_unknown_models"></div><div class="admin-toggle-sub">Reject unknown models at connect time (only when the allowlist is non-empty).</div></div>
+</div>
+
+<button type="button" class="admin-save" id="admin-save-btn" disabled>Save filters</button>
+<p class="admin-note" id="admin-save-hint">Suspend / skip toggles apply immediately. Filter edits apply on Save. Both persist through <code>PUT /api/config/governor/hub</code>.</p>
+</div>
+</div>
+
 <div class="ops-grid">
 <div>
 <div class="ops-card">
@@ -659,7 +744,7 @@ tabs.forEach(function(t){t.addEventListener('click',function(){
   t.classList.add('active');t.setAttribute('aria-selected','true');
   var panel=document.getElementById(t.getAttribute('data-panel'));
   if(panel)panel.classList.add('active');
-  if(t.getAttribute('data-panel')==='tab-ops'&&!opsStarted){opsStarted=true;opsPoll();}
+  if(t.getAttribute('data-panel')==='tab-ops'&&!opsStarted){opsStarted=true;opsPoll();initAdmin();}
 });});
 
 var currentFilter='all';
@@ -673,6 +758,203 @@ document.querySelectorAll('.ops-filter').forEach(function(f){f.addEventListener(
 
 function esc(s){var d=document.createElement('div');d.textContent=(s==null?'':String(s));return d.innerHTML;}
 function rel(ts){if(!ts)return '';var d=new Date(ts);if(isNaN(d))return '';var s=Math.floor((Date.now()-d.getTime())/1000);if(s<60)return s+'s ago';var m=Math.floor(s/60);if(m<60)return m+'m ago';var h=Math.floor(m/60);if(h<24)return h+'h ago';return Math.floor(h/24)+'d ago';}
+
+// ── #2534 Operator admin controls (mirror of the Governor Hub config) ──────────
+// adminEnabled gates everything: it is only ever set true after /api/role reports
+// owner or read-write. A read viewer never sees a control, and the server enforces
+// the same boundary independently (roleEnforcement blocks non-GET on
+// /api/config/governor/hub for read; requireContributorWrite blocks the
+// contributor endpoints), so hiding is UX, not the security boundary.
+var adminEnabled=false;
+var adminHub=null;      // last-loaded Config.Hub.* snapshot (contribute_* fields)
+var adminDirty=false;   // filter edits pending Save
+
+function toast(msg,ok){
+  var t=document.createElement('div');
+  t.textContent=msg;
+  t.style.cssText='position:fixed;bottom:24px;left:50%%;transform:translateX(-50%%);z-index:1100;padding:10px 18px;border-radius:8px;font-size:.85rem;color:#fff;background:'+(ok===false?'#da3633':'#238636')+';box-shadow:0 4px 16px rgba(1,4,9,.5)';
+  document.body.appendChild(t);
+  setTimeout(function(){t.style.opacity='0';t.style.transition='opacity .4s';setTimeout(function(){t.remove();},400);},2600);
+}
+
+// Themed confirm — never native window.confirm (dashboard house rule).
+var _confirmCb=null;
+function adminConfirm(title,msg,okLabel,cb){
+  document.getElementById('admin-confirm-title').textContent=title;
+  document.getElementById('admin-confirm-msg').textContent=msg;
+  var ok=document.getElementById('admin-confirm-ok');
+  ok.textContent=okLabel||'Confirm';
+  _confirmCb=cb;
+  document.getElementById('admin-confirm-back').classList.add('show');
+}
+document.getElementById('admin-confirm-cancel').addEventListener('click',function(){document.getElementById('admin-confirm-back').classList.remove('show');_confirmCb=null;});
+document.getElementById('admin-confirm-ok').addEventListener('click',function(){var cb=_confirmCb;document.getElementById('admin-confirm-back').classList.remove('show');_confirmCb=null;if(cb)cb();});
+
+// Persist a subset of Config.Hub.* through the SAME endpoint the Governor Hub
+// dialog uses. Only the passed keys are sent; the handler ignores omitted fields.
+async function adminSaveHub(patch,okMsg){
+  try{
+    var res=await fetch('/api/config/governor/hub',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(patch)});
+    if(!res.ok){
+      var msg='Save failed ('+res.status+')';
+      try{var d=await res.json();if(d&&d.error)msg=d.error;}catch(e){}
+      toast(msg,false);return false;
+    }
+    toast(okMsg||'Saved',true);
+    return true;
+  }catch(e){toast('Save failed: '+(e&&e.message||'network error'),false);return false;}
+}
+
+function renderAdminFilter(fieldId,label,noun,modeKey,listKey){
+  var el=document.getElementById(fieldId);
+  if(!el||!adminHub)return;
+  var mode=(adminHub[modeKey]==='allow')?'allow':'deny';
+  var list=adminHub[listKey]||[];
+  var chips=list.map(function(v){
+    return '<span class="admin-chip">'+esc(v)+'<span class="x" data-list="'+listKey+'" data-val="'+esc(v)+'">&times;</span></span>';
+  }).join('');
+  el.innerHTML='<label>'+esc(label)+' filter</label>'+
+    '<div class="admin-modeseg" data-mode-key="'+modeKey+'">'+
+      '<button type="button" data-mode="deny"'+(mode==='deny'?' class="on"':'')+'>Deny</button>'+
+      '<button type="button" data-mode="allow"'+(mode==='allow'?' class="on"':'')+'>Allow</button>'+
+    '</div>'+
+    '<div class="admin-chips">'+(chips||'<span class="admin-toggle-sub">none</span>')+'</div>'+
+    '<div class="admin-addrow"><input type="text" data-add-list="'+listKey+'" placeholder="add '+esc(noun)+'&hellip;"><button type="button" data-add-list-btn="'+listKey+'">Add</button></div>';
+}
+
+function renderAdminModels(){
+  var el=document.getElementById('admin-allow-models');
+  if(!el||!adminHub)return;
+  var list=adminHub.contribute_allow_models||[];
+  el.innerHTML=list.length?list.map(function(v){
+    return '<span class="admin-chip">'+esc(v)+'<span class="x" data-list="contribute_allow_models" data-val="'+esc(v)+'">&times;</span></span>';
+  }).join(''):'<span class="admin-toggle-sub">all models accepted</span>';
+}
+
+function renderAdminControls(){
+  if(!adminEnabled||!adminHub)return;
+  // Immediate toggles.
+  document.getElementById('admin-suspend-switch').classList.toggle('on',!!adminHub.contribute_suspended);
+  document.getElementById('admin-suspend-switch').classList.toggle('danger',!!adminHub.contribute_suspended);
+  document.getElementById('admin-skip-switch').classList.toggle('on',!!adminHub.contribute_skip_assigned_to_others);
+  document.getElementById('admin-reject-switch').classList.toggle('on',!!adminHub.contribute_reject_unknown_models);
+  // Filters (mirror Governor Hub: titles/authors/labels + modes, allow-models).
+  renderAdminFilter('admin-filter-titles','Titles','title','contribute_titles_mode','contribute_deny_titles');
+  renderAdminFilter('admin-filter-authors','Authors','author','contribute_authors_mode','contribute_deny_authors');
+  renderAdminFilter('admin-filter-labels','Labels','label','contribute_labels_mode','contribute_deny_labels');
+  renderAdminModels();
+  var save=document.getElementById('admin-save-btn');
+  if(save)save.disabled=!adminDirty;
+}
+
+// Immediate-apply toggle (suspend / skip): flips config and persists at once,
+// like the Governor Hub toggle switches. Filters are the deferred-Save path.
+function bindImmediateToggle(id){
+  var sw=document.getElementById(id);
+  if(!sw)return;
+  sw.addEventListener('click',function(){
+    var key=sw.getAttribute('data-key');
+    var next=!(adminHub&&adminHub[key]);
+    var patch={};patch[key]=next;
+    adminSaveHub(patch,next?'Enabled '+key.replace(/_/g,' '):'Disabled '+key.replace(/_/g,' ')).then(function(ok){
+      if(ok){adminHub[key]=next;renderAdminControls();}
+    });
+  });
+}
+
+// Delegated handlers for the filter editors (mode switch, add, remove) — mark
+// dirty so nothing is sent until the operator clicks Save.
+document.getElementById('ops-admin').addEventListener('click',function(e){
+  var t=e.target;
+  var seg=t.closest?t.closest('.admin-modeseg button'):null;
+  if(seg){var mk=seg.parentNode.getAttribute('data-mode-key');adminHub[mk]=seg.getAttribute('data-mode');adminDirty=true;renderAdminControls();return;}
+  if(t.classList&&t.classList.contains('x')&&t.getAttribute('data-list')){
+    var lk=t.getAttribute('data-list'),val=t.getAttribute('data-val');
+    adminHub[lk]=(adminHub[lk]||[]).filter(function(v){return v!==val;});
+    adminDirty=true;renderAdminControls();return;
+  }
+  if(t.getAttribute&&t.getAttribute('data-add-list-btn')){
+    var lk2=t.getAttribute('data-add-list-btn');
+    var inp=document.querySelector('[data-add-list="'+lk2+'"]');
+    if(inp&&inp.value.trim()){adminHub[lk2]=(adminHub[lk2]||[]).concat([inp.value.trim()]);inp.value='';adminDirty=true;renderAdminControls();}
+    return;
+  }
+});
+
+document.getElementById('admin-add-model').addEventListener('click',function(){
+  var inp=document.getElementById('admin-allow-model-input');
+  if(inp&&inp.value.trim()){adminHub.contribute_allow_models=(adminHub.contribute_allow_models||[]).concat([inp.value.trim()]);inp.value='';adminDirty=true;renderAdminControls();}
+});
+
+document.getElementById('admin-save-btn').addEventListener('click',function(){
+  if(!adminDirty||!adminHub)return;
+  var patch={
+    contribute_titles_mode:adminHub.contribute_titles_mode||'deny',
+    contribute_authors_mode:adminHub.contribute_authors_mode||'deny',
+    contribute_labels_mode:adminHub.contribute_labels_mode||'deny',
+    contribute_deny_titles:adminHub.contribute_deny_titles||[],
+    contribute_deny_authors:adminHub.contribute_deny_authors||[],
+    contribute_deny_labels:adminHub.contribute_deny_labels||[],
+    contribute_allow_models:adminHub.contribute_allow_models||[]
+  };
+  adminSaveHub(patch,'Admission filters saved').then(function(ok){if(ok){adminDirty=false;renderAdminControls();}});
+});
+
+// Per-contributor actions (delegated on the clanker list). Each calls an EXISTING
+// endpoint; destructive ones go through the themed confirm.
+document.getElementById('clanker-list').addEventListener('change',function(e){
+  var sel=e.target;
+  if(!adminEnabled||sel.getAttribute('data-role')!=='tier')return;
+  var cid=sel.getAttribute('data-cid'),tier=sel.value;
+  fetch('/api/contributors/'+encodeURIComponent(cid)+'/trust',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({tier:tier})})
+    .then(function(r){return r.json().then(function(d){return{ok:r.ok,d:d};});})
+    .then(function(x){if(x.ok){toast('Trust tier set to '+tier,true);opsPoll();}else{toast((x.d&&x.d.error)||'Failed to set tier',false);}})
+    .catch(function(){toast('Failed to set tier',false);});
+});
+document.getElementById('clanker-list').addEventListener('click',function(e){
+  var b=e.target;
+  if(!adminEnabled||b.tagName!=='BUTTON')return;
+  var role=b.getAttribute('data-role');
+  if(role!=='revoke'&&role!=='remove')return;
+  var cid=b.getAttribute('data-cid'),user=b.getAttribute('data-user')||'this contributor';
+  if(role==='revoke'){
+    adminConfirm('Revoke '+user,'Set '+user+' to the revoked tier. Their agent stops receiving scoped tokens for new work. This uses the existing POST /api/contributors/{id}/revoke endpoint.','Revoke',function(){
+      fetch('/api/contributors/'+encodeURIComponent(cid)+'/revoke',{method:'POST'})
+        .then(function(r){return r.json().then(function(d){return{ok:r.ok,d:d};});})
+        .then(function(x){if(x.ok){toast(user+' revoked',true);opsPoll();}else{toast((x.d&&x.d.error)||'Revoke failed',false);}})
+        .catch(function(){toast('Revoke failed',false);});
+    });
+  }else{
+    adminConfirm('Remove '+user,'Permanently delete '+user+'&rsquo;s contributor profile from this hive. This uses the existing DELETE /api/contributors/{id} endpoint and cannot be undone.','Remove',function(){
+      fetch('/api/contributors/'+encodeURIComponent(cid),{method:'DELETE'})
+        .then(function(r){return r.json().then(function(d){return{ok:r.ok,d:d};});})
+        .then(function(x){if(x.ok){toast(user+' removed',true);opsPoll();}else{toast((x.d&&x.d.error)||'Remove failed',false);}})
+        .catch(function(){toast('Remove failed',false);});
+    });
+  }
+});
+
+// Gate: only owner / read-write get the controls. Mirrors the main dashboard,
+// which reads the viewer role from /api/role.
+async function initAdmin(){
+  var role='owner';
+  try{var r=await fetch('/api/role');var d=await r.json();if(d&&d.role)role=d.role;}catch(e){}
+  if(role!=='owner'&&role!=='read-write')return; // read viewer: controls stay hidden
+  adminEnabled=true;
+  var badge=document.getElementById('admin-role-badge');if(badge)badge.textContent=role;
+  document.getElementById('ops-admin').classList.add('enabled');
+  bindImmediateToggle('admin-suspend-switch');
+  bindImmediateToggle('admin-skip-switch');
+  bindImmediateToggle('admin-reject-switch');
+  try{
+    // The Governor config GET is what carries the hub.contribute_* fields the
+    // Governor Hub dialog edits (GET /api/config, by contrast, is a thin summary
+    // without them). Reading the same source keeps this mirror in lockstep.
+    var cr=await fetch('/api/config/governor');var cd=await cr.json();
+    adminHub=(cd&&cd.hub)?cd.hub:{};
+  }catch(e){adminHub={};}
+  renderAdminControls();
+}
 
 // #2546: human-readable label for the machine reason a clanker is idle. Keeps the
 // raw reason as a fallback so a new server-side reason still renders legibly.
@@ -694,10 +976,27 @@ function renderClankers(list){
     var task=c.current_task
       ?('<div class="clanker-sub">on '+esc(c.current_task.repo)+'#'+esc(c.current_task.number)+'</div>')
       :(c.idle_reason?('<div class="clanker-sub">idle: '+esc(idleReasonLabel(c.idle_reason))+'</div>'):'');
+    // #2534: owner/read-write get per-contributor admin actions wired to the
+    // EXISTING endpoints — set trust tier / promote (PUT /api/contributors/{id}/trust),
+    // revoke (POST .../revoke), remove (DELETE .../{id}). Hidden for read viewers.
+    // The contributor id (not the username) keys those endpoints.
+    var actions='';
+    if(adminEnabled&&c.contributor_id){
+      var cid=esc(c.contributor_id);
+      var tier=c.trust_tier||'newcomer';
+      var opts=['newcomer','contributor','trusted','advisor'].map(function(t){
+        return '<option value="'+t+'"'+(t===tier?' selected':'')+'>'+t+'</option>';
+      }).join('');
+      actions='<div class="admin-actions">'+
+        '<select class="admin-act" title="Set trust tier (maintainer voucher)" data-cid="'+cid+'" data-role="tier">'+opts+'</select>'+
+        '<button type="button" class="admin-act danger" data-cid="'+cid+'" data-user="'+esc(user)+'" data-role="revoke">Revoke</button>'+
+        '<button type="button" class="admin-act danger" data-cid="'+cid+'" data-user="'+esc(user)+'" data-role="remove">Remove</button>'+
+        '</div>';
+    }
     return '<div class="clanker-row"><span class="clanker-dot'+(c.stale?' stale':'')+'"></span>'+av+
       '<div class="clanker-main"><div class="clanker-user">'+esc(user)+'</div>'+
       '<div class="clanker-sub">'+(sub||'&mdash;')+'</div>'+task+'</div>'+
-      '<span class="feed-time">'+esc(rel(c.connected_at))+'</span></div>';
+      (actions||('<span class="feed-time">'+esc(rel(c.connected_at))+'</span>'))+'</div>';
   }).join('');
 }
 
@@ -798,6 +1097,15 @@ if(f.innerHTML!==html){f.innerHTML=html;if(isNew)f.scrollTop=0;}
 }catch(e){}}
 poll();setInterval(poll,3000);
 </script>
+<!-- Themed confirm modal for the destructive admin actions (revoke / remove).
+     The dashboard convention is a themed overlay, never native window.confirm. -->
+<div class="admin-modal-back" id="admin-confirm-back">
+<div class="admin-modal">
+<h4 id="admin-confirm-title">Confirm</h4>
+<p id="admin-confirm-msg"></p>
+<div class="admin-modal-btns"><button type="button" id="admin-confirm-cancel">Cancel</button><button type="button" class="confirm" id="admin-confirm-ok">Confirm</button></div>
+</div>
+</div>
 <div style="margin-top:40px;padding:16px 0;border-top:1px solid #30363d;font-size:.75rem;color:#8b949e;display:flex;align-items:center;gap:8px">
   <span id="hive-version">loading...</span>
 </div>
@@ -1026,6 +1334,31 @@ func (s *Server) handleContributeFleet(w http.ResponseWriter, r *http.Request) {
 
 // ── Contributor management ─────────────────────────────────────────────────
 
+// requireContributorWrite enforces owner/read-write authorization on the
+// contributor mutation endpoints (trust/revoke/delete) that the Management &
+// Operations tab surfaces as admin controls.
+//
+// These handlers live under the /api/contributors/... path. That path shares
+// the "/api/contribute" prefix that roleEnforcement (server.go) intentionally
+// EXEMPTS from its blanket read-only block — that exemption exists so a signed-in
+// contributor can still register/onboard themselves. As a result the middleware
+// does NOT stop a "read" viewer from calling these mutation endpoints, so each
+// mutation handler must enforce the boundary itself. This mirrors the in-handler
+// role check used by handleConfigDownload / handleSelfUpgrade: read X-Hive-Role,
+// treat an absent header as owner (local/dev, no hub nginx), and reject "read".
+// UI hiding on the ops tab is UX; this is the security boundary.
+func (s *Server) requireContributorWrite(w http.ResponseWriter, r *http.Request) bool {
+	role := r.Header.Get("X-Hive-Role")
+	if role == "" {
+		role = "owner"
+	}
+	if role == "read" {
+		jsonError(w, "your permissions on this hive are read-only, so changes are not allowed. Contact the owner of this hive to ask for write permissions.", http.StatusForbidden)
+		return false
+	}
+	return true
+}
+
 func (s *Server) handleContributorsList(w http.ResponseWriter, r *http.Request) {
 	profiles := listContributorProfiles()
 	var liveStates map[string]ContributorLiveState
@@ -1058,6 +1391,9 @@ func (s *Server) handleContributorGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleContributorTrust(w http.ResponseWriter, r *http.Request) {
+	if !s.requireContributorWrite(w, r) {
+		return
+	}
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	id := r.PathValue("id")
 	p := findContributor(id)
@@ -1087,6 +1423,9 @@ func (s *Server) handleContributorTrust(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) handleContributorRevoke(w http.ResponseWriter, r *http.Request) {
+	if !s.requireContributorWrite(w, r) {
+		return
+	}
 	id := r.PathValue("id")
 	p := findContributor(id)
 	if p == nil {
@@ -1100,6 +1439,9 @@ func (s *Server) handleContributorRevoke(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) handleContributorDelete(w http.ResponseWriter, r *http.Request) {
+	if !s.requireContributorWrite(w, r) {
+		return
+	}
 	id := r.PathValue("id")
 	p := findContributor(id)
 	if p == nil {

--- a/v2/pkg/dashboard/api_contribute_admin_controls_test.go
+++ b/v2/pkg/dashboard/api_contribute_admin_controls_test.go
@@ -1,0 +1,225 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// #2534 — Operator admin controls mirrored into the Management & Operations tab.
+//
+// These tests pin two things:
+//   1. The UI: the /contribute page must ship the (initially hidden) admin-controls
+//      markup that mirrors the Governor Hub config — suspend/skip toggles, the
+//      admission-filter editors, and the per-contributor action wiring — plus the
+//      /api/role gate and the themed confirm modal. Rendering is gated CLIENT-side
+//      by initAdmin() reading /api/role; a read viewer never enables it.
+//   2. The server boundary: the contributor mutation endpoints the tab drives
+//      (trust / revoke / delete) must reject a "read" viewer with 403 and allow
+//      owner + read-write — because roleEnforcement EXEMPTS the /api/contribute*
+//      path prefix, so hiding in the UI is not the boundary.
+
+// TestOpsTabHasAdminControlsMarkup asserts the admin-controls area, the filter
+// editors, the /api/role gate, and the themed confirm modal are all present in
+// the rendered /contribute page, and that the read-only-only display panels from
+// #2542/#2558 remain intact.
+func TestOpsTabHasAdminControlsMarkup(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+
+	// Admin controls area + the role gate that only shows it for owner/read-write.
+	for _, want := range []string{
+		`id="ops-admin"`,                      // the admin card
+		`class="ops-card ops-admin"`,          // hidden until enabled
+		`Operator admin controls`,             // heading
+		`initAdmin`,                           // gate function
+		`/api/role`,                           // reads the viewer role
+		`role!=='owner'&&role!=='read-write'`, // owner + read-write only
+		// Suspend / skip immediate toggles (mirror the Governor Hub switches).
+		`id="admin-suspend-switch"`,
+		`data-key="contribute_suspended"`,
+		`id="admin-skip-switch"`,
+		`data-key="contribute_skip_assigned_to_others"`,
+		// Admission filters — the priority controls, mirrored from Governor Hub.
+		`id="admin-filter-titles"`,
+		`id="admin-filter-authors"`,
+		`id="admin-filter-labels"`,
+		`id="admin-allow-models"`,
+		`contribute_deny_titles`,
+		`contribute_deny_authors`,
+		`contribute_deny_labels`,
+		`contribute_allow_models`,
+		// Filters persist through the SAME endpoint the Governor dialog uses, and
+		// read the same source the Governor dialog reads.
+		`/api/config/governor/hub`,
+		`/api/config/governor`,
+		// Per-contributor actions wired to the EXISTING endpoints.
+		`/trust`,
+		`/revoke`,
+		`data-role="tier"`,
+		`data-role="revoke"`,
+		`data-role="remove"`,
+		// Themed confirm modal (never native window.confirm).
+		`id="admin-confirm-back"`,
+		`function adminConfirm(`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("admin controls markup missing %q", want)
+		}
+	}
+
+	// The house rule: no native confirm() in the admin flow.
+	if strings.Contains(body, "window.confirm(") {
+		t.Error("admin controls must use the themed modal, not native window.confirm")
+	}
+
+	// The read-only display panels from #2542/#2558 must remain intact.
+	for _, want := range []string{
+		`Connected clankers`,
+		`id="work-list"`,
+		`/api/contribute/fleet`,
+		`Prompt preview`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("read-only ops panel content missing %q (must remain intact)", want)
+		}
+	}
+}
+
+// contributorWriteCase is one mutation endpoint exercised by the tab.
+type contributorWriteCase struct {
+	name   string
+	invoke func(s *Server, w http.ResponseWriter, r *http.Request)
+	method string
+	target string // request path (only the role gate is under test here)
+	body   string
+}
+
+func contributorWriteCases() []contributorWriteCase {
+	return []contributorWriteCase{
+		{"trust", (*Server).handleContributorTrust, http.MethodPut, "/api/contributors/alice/trust", `{"tier":"trusted"}`},
+		{"revoke", (*Server).handleContributorRevoke, http.MethodPost, "/api/contributors/alice/revoke", ``},
+		{"delete", (*Server).handleContributorDelete, http.MethodDelete, "/api/contributors/alice", ``},
+	}
+}
+
+// TestContributorWrite_ReadViewerForbidden proves a "read" viewer is rejected with
+// 403 on every contributor mutation endpoint the ops tab surfaces — the boundary
+// the UI hiding merely shadows. roleEnforcement exempts /api/contribute*, so this
+// must be enforced in-handler.
+func TestContributorWrite_ReadViewerForbidden(t *testing.T) {
+	for _, tc := range contributorWriteCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			setupContributeEnv(t)
+			// Seed a real contributor so a *missing role check* would 200/404, not 403.
+			if err := saveContributorProfile(&ContributorProfile{
+				GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "newcomer",
+			}); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			s := NewServer(0, slog.Default())
+			s.registerContributeRoutes()
+
+			var reqBody *strings.Reader
+			if tc.body != "" {
+				reqBody = strings.NewReader(tc.body)
+			} else {
+				reqBody = strings.NewReader("")
+			}
+			req := httptest.NewRequest(tc.method, tc.target, reqBody)
+			req.Header.Set("X-Hive-Role", "read")
+			w := httptest.NewRecorder()
+			tc.invoke(s, w, req)
+
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("read viewer got %d, want 403 (body: %s)", w.Code, w.Body.String())
+			}
+			// The read viewer must not have mutated anything.
+			if p := findContributor("c-alice"); p == nil || p.TrustTier != "newcomer" {
+				t.Errorf("read viewer mutated the profile: %+v", p)
+			}
+		})
+	}
+}
+
+// TestContributorWrite_OwnerAndRWAllowed proves owner and read-write pass the gate
+// (they are not blocked), and that an absent header falls back to owner (local/dev).
+func TestContributorWrite_OwnerAndRWAllowed(t *testing.T) {
+	for _, role := range []string{"owner", "read-write", ""} {
+		t.Run("trust_"+role, func(t *testing.T) {
+			setupContributeEnv(t)
+			if err := saveContributorProfile(&ContributorProfile{
+				GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "newcomer",
+			}); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			s := NewServer(0, slog.Default())
+			s.registerContributeRoutes()
+
+			req := httptest.NewRequest(http.MethodPut, "/api/contributors/alice/trust", strings.NewReader(`{"tier":"trusted"}`))
+			req.SetPathValue("id", "alice")
+			if role != "" {
+				req.Header.Set("X-Hive-Role", role)
+			}
+			w := httptest.NewRecorder()
+			s.handleContributorTrust(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("role %q got %d, want 200 (body: %s)", role, w.Code, w.Body.String())
+			}
+			if p := findContributor("alice"); p == nil || p.TrustTier != "trusted" {
+				t.Errorf("role %q: tier not promoted: %+v", role, p)
+			}
+		})
+	}
+}
+
+// TestGovernorHubAcceptsSkipAssigned pins the bidirectional-parity addition: the
+// Governor Hub config write path (the canonical editor, and the one the ops-tab
+// toggle drives) now persists contribute_skip_assigned_to_others, and GET /api/config
+// reflects it — so both surfaces edit the same underlying Config.Hub.* state.
+func TestGovernorHubAcceptsSkipAssigned(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.Hub.ContributeSkipAssignedToOthers = false
+
+	req := httptest.NewRequest(http.MethodPut, "/api/governor/hub",
+		strings.NewReader(`{"contribute_skip_assigned_to_others":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.handleGovernorHub(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("governor hub update got %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	if !deps.Config.Hub.ContributeSkipAssignedToOthers {
+		t.Error("contribute_skip_assigned_to_others not persisted by handleGovernorHub")
+	}
+
+	// GET /api/config/governor must expose it so the mirror UI can reflect current
+	// state (this is the endpoint that carries hub.contribute_* — the same source
+	// the Governor Hub dialog reads).
+	rec := doGet(s, "/api/config/governor")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/config/governor got %d", rec.Code)
+	}
+	var cfg struct {
+		Hub map[string]any `json:"hub"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &cfg); err != nil {
+		t.Fatalf("config json: %v", err)
+	}
+	if got, ok := cfg.Hub["contribute_skip_assigned_to_others"]; !ok || got != true {
+		t.Errorf("config hub missing/false contribute_skip_assigned_to_others: %v (ok=%v)", got, ok)
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -15033,6 +15033,11 @@ function burnAreaChart() {
           <span class="config-toggle-label" style="${hub.contribute_suspended ? 'color:var(--red);font-weight:600' : ''}">Suspend Contributions <span class="config-info">i<span class="config-tooltip">Temporarily stop assigning tasks to contributors. Connected contributors stay online but idle.</span></span></span>
         </div>
 
+        <div class="config-toggle">
+          <div class="config-toggle-switch ${hub.contribute_skip_assigned_to_others ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="hub" data-key="contribute_skip_assigned_to_others"></div>
+          <span class="config-toggle-label">Skip Issues Assigned to Others <span class="config-info">i<span class="config-tooltip">When on, the contribute queue never serves an issue that is already assigned to a different GitHub user, so contributors don't pick up work a maintainer has claimed. Mirrored on the /contribute Management &amp; Operations tab.</span></span></span>
+        </div>
+
         ${renderFilterWithMode({
           label: 'Titles', noun: 'title', unit: 'issue',
           modeKey: 'contribute_titles_mode', listKey: 'contribute_deny_titles',


### PR DESCRIPTION
## What & why

The Management & Operations tab (#2542, #2558) on `/contribute` only **displayed** fleet, work, pipeline, policy, and the prompt preview — it had **no controls**. This adds an **Operator admin controls** area to that tab, **mirrored from the existing Governor Hub configuration** so the pattern, the write path, and the permission gate are all reused rather than reinvented.

This is the **operations/control half** of the tab; the read-only display panels from #2542/#2558 are untouched.

`Refs #2534`

## Controls surfaced (each reuses an EXISTING endpoint)

**Queue-shaping / admission filters — the priority controls**, mirrored from the Governor Hub config and persisted through the **same** path the Governor Hub dialog uses (`PUT /api/config/governor/hub`, read from `GET /api/config/governor`):

| Control | Config field |
|---|---|
| Suspend / resume contributions | `contribute_suspended` |
| Skip issues assigned to others | `contribute_skip_assigned_to_others` |
| Deny/Allow **titles** (+ mode) | `contribute_deny_titles` / `contribute_titles_mode` |
| Deny/Allow **authors** (+ mode) | `contribute_deny_authors` / `contribute_authors_mode` |
| Deny/Allow **labels** (+ mode) | `contribute_deny_labels` / `contribute_labels_mode` |
| Allowed models + reject-unknown | `contribute_allow_models` / `contribute_reject_unknown_models` |

**Per-contributor actions** on the connected-clanker rows, wired to the existing endpoints:

| Action | Endpoint |
|---|---|
| Set trust tier / promote (maintainer voucher) | `PUT /api/contributors/{id}/trust` |
| Revoke | `POST /api/contributors/{id}/revoke` |
| Remove | `DELETE /api/contributors/{id}` |

Destructive actions go through the dashboard's **themed confirm modal** — never native `window.confirm`.

## Owner + read-write only — gated on BOTH surfaces

- **UI:** `initAdmin()` reads `/api/role` (same source the main dashboard uses) and only enables the controls for `owner` / `read-write`. A `read` viewer never sees them.
- **Server (the real boundary):** the contributor mutation handlers now enforce the gate **in-handler** (`requireContributorWrite`, rejecting `read` with 403). This closes a real gap: `roleEnforcement` intentionally **exempts** the `/api/contribute*` path prefix (so a signed-in contributor can still self-register), which meant these `/api/contributors/...` mutations were **not** blocked for `read` viewers by the middleware. UI hiding was never the boundary; now the server enforces it, matching `handleConfigDownload` / `handleSelfUpgrade`. The Governor Hub filter writes stay protected by `roleEnforcement` (they're not under the exempt prefix).

## Bidirectional parity (Governor Hub tab is the single source of truth)

`contribute_skip_assigned_to_others` was **displayed** by the ops policy but was **not editable** in the canonical Governor Hub config. To keep both surfaces editing the same `Config.Hub.*` state, it is now:
- accepted by `handleGovernorHub`,
- returned by `GET /api/config/governor`,
- given a toggle in the Governor Hub config UI (`renderGovHub`),
- and mirrored in the Mgmt/Ops admin controls.

All other controls already existed in the Governor Hub config, so they are mirrored as-is.

## Scope guards

- **No new queue-mutation endpoints were invented.** Requeue / reprioritize a stalled task is left as a clearly-labeled follow-up (no safe existing endpoint).
- **No change** to credential delivery (#2537) or routing (#2547) — those remain design-pending; this only surfaces existing controls.

## Tests

- `TestOpsTabHasAdminControlsMarkup` — the admin area, filter editors, `/api/role` gate (owner+read-write only), themed confirm modal, and the per-contributor action wiring all render; the #2542/#2558 read-only panels remain intact; no native `window.confirm`.
- `TestContributorWrite_ReadViewerForbidden` — trust/revoke/delete each return **403** for a `read` viewer and mutate nothing.
- `TestContributorWrite_OwnerAndRWAllowed` — owner / read-write / (absent header → owner) all pass and the tier is applied.
- `TestGovernorHubAcceptsSkipAssigned` — the parity field is persisted by `handleGovernorHub` and reflected by `GET /api/config/governor`.

`go build`, `go vet`, and the full `pkg/dashboard` test package pass; the extracted ops-tab inline script passes `node --check`.
