### PR TITLE
feat(agent): blocked-action thrash breaker + terminal policy-block messages

### DIFF
--- a/bin/git-credential-hive.sh
+++ b/bin/git-credential-hive.sh
@@ -80,6 +80,7 @@ if [ -n "$AGENT_MODE" ]; then
   case "$AGENT_MODE" in
     NO_GITHUB|ADVISORY|ISSUES_ONLY)
       echo "⛔ git push blocked: ${AGENT} is in ${AGENT_MODE} mode" >&2
+      echo "⛔ TERMINAL: this block is mode-enforced and retrying can NEVER succeed. Do NOT retry, loop, or seek workarounds. Record your intended change as an advisory finding (bd create / [FINDING]) and end this task." >&2
       exit 1
       ;;
   esac
@@ -89,10 +90,12 @@ else
   if [ -n "$AGENT" ] && [ "$ACMM" -gt 0 ]; then
     if [ "$ACMM" -lt 3 ]; then
       echo "⛔ git push blocked: ACMM L${ACMM} agents are advisory-only" >&2
+      echo "⛔ TERMINAL: this block is mode-enforced and retrying can NEVER succeed. Do NOT retry, loop, or seek workarounds. Record your intended change as an advisory finding (bd create / [FINDING]) and end this task." >&2
       exit 1
     fi
     if [ "$ACMM" -eq 3 ] && [ "$AGENT" != "quality" ]; then
       echo "⛔ git push blocked: only quality agent can push at ACMM L3" >&2
+      echo "⛔ TERMINAL: this block is mode-enforced and retrying can NEVER succeed. Do NOT retry, loop, or seek workarounds. Record your intended change as an advisory finding (bd create / [FINDING]) and end this task." >&2
       exit 1
     fi
   fi

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -149,9 +149,14 @@ type ProjectContext struct {
 }
 
 type Manager struct {
-	agents           map[string]*AgentProcess
-	idToName         map[string]string
-	mu               sync.RWMutex
+	agents   map[string]*AgentProcess
+	idToName map[string]string
+	mu       sync.RWMutex
+	// thrashMu guards thrash — its own mutex, NEVER m.mu: the breaker runs on
+	// the output-capture goroutines, and taking m.mu there risks the startup
+	// re-entrancy deadlock class (see the 2026-07 provisionWG incident).
+	thrashMu         sync.Mutex
+	thrash           map[string]*thrashState
 	logger           *slog.Logger
 	workDir          string
 	project          ProjectContext
@@ -1986,6 +1991,7 @@ func (m *Manager) pollTmuxOutput(name, session string, buf *RingBuffer, ctx cont
 			for _, l := range newLines {
 				buf.Write(l)
 				m.logOutputSignals(name, l)
+				m.checkBlockedThrash(name, l)
 			}
 			prevLines = filtered
 		}
@@ -2008,6 +2014,94 @@ func (m *Manager) logOutputSignals(agent, line string) {
 			return
 		}
 	}
+}
+
+// Blocked-action thrash breaker: an agent that keeps hammering a policy wall
+// (e.g. git push in ADVISORY mode, blocked every ~3s by git-credential-hive)
+// burns model tokens indefinitely with zero possible output — observed live
+// 2026-08-04 on a hosted L2 hive whose guide agent retried a blocked push
+// every 3 seconds. The hub, not the model, breaks the loop: thrashThreshold
+// blocked-action lines within thrashWindow pauses the session (visible,
+// reversible, stops governor kicks) with the reason spelled out.
+const (
+	thrashWindow    = 60 * time.Second
+	thrashThreshold = 5
+	thrashCooldown  = 10 * time.Minute
+)
+
+// blockedActionMarkers are the policy-wall stderr lines that can never
+// succeed by retrying. Keep in sync with bin/git-credential-hive.sh and the
+// proxy's hard-deny responses.
+var blockedActionMarkers = []string{
+	"git push blocked:",
+	"blocked by hive policy",
+}
+
+type thrashState struct {
+	times    []time.Time
+	lastTrip time.Time
+}
+
+// checkBlockedThrash records a blocked-action output line for the agent and,
+// past the threshold, pauses the agent asynchronously (never inline: this is
+// called from the output-capture goroutine and Pause takes m.mu).
+func (m *Manager) checkBlockedThrash(agent, line string) {
+	matched := false
+	for _, marker := range blockedActionMarkers {
+		if strings.Contains(line, marker) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return
+	}
+	now := time.Now()
+	m.thrashMu.Lock()
+	if m.thrash == nil {
+		m.thrash = map[string]*thrashState{}
+	}
+	st := m.thrash[agent]
+	if st == nil {
+		st = &thrashState{}
+		m.thrash[agent] = st
+	}
+	trip := recordBlockedAndCheck(st, now, thrashWindow, thrashThreshold, thrashCooldown)
+	m.thrashMu.Unlock()
+	if !trip {
+		return
+	}
+	reason := fmt.Sprintf("blocked-action loop: %d+ policy-blocked attempts in %s — the block is terminal in this mode; paused to stop token burn", thrashThreshold, thrashWindow)
+	m.logger.Warn("thrash breaker tripped", "agent", agent, "line", truncateStr(line, 160))
+	go func() {
+		if err := m.Pause(agent, "thrash-breaker", reason); err != nil {
+			m.logger.Warn("thrash breaker pause failed", "agent", agent, "error", err)
+		}
+	}()
+}
+
+// recordBlockedAndCheck is the pure sliding-window decision: append now, drop
+// entries older than window, and report whether the threshold is crossed
+// outside the cooldown. Split out for direct unit testing.
+func recordBlockedAndCheck(st *thrashState, now time.Time, window time.Duration, threshold int, cooldown time.Duration) bool {
+	st.times = append(st.times, now)
+	cutoff := now.Add(-window)
+	kept := st.times[:0]
+	for _, t := range st.times {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	st.times = kept
+	if len(st.times) < threshold {
+		return false
+	}
+	if !st.lastTrip.IsZero() && now.Sub(st.lastTrip) < cooldown {
+		return false
+	}
+	st.lastTrip = now
+	st.times = nil
+	return true
 }
 
 var kickRefusalPatterns = []string{

--- a/v2/pkg/agent/thrash_test.go
+++ b/v2/pkg/agent/thrash_test.go
@@ -1,0 +1,49 @@
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRecordBlockedAndCheck_TripsAtThresholdWithinWindow(t *testing.T) {
+	st := &thrashState{}
+	base := time.Now()
+	window, threshold, cooldown := 60*time.Second, 5, 10*time.Minute
+
+	// Four hits: below threshold, never trips.
+	for i := 0; i < 4; i++ {
+		if recordBlockedAndCheck(st, base.Add(time.Duration(i)*3*time.Second), window, threshold, cooldown) {
+			t.Fatalf("tripped below threshold at hit %d", i+1)
+		}
+	}
+	// Fifth hit inside the window: trips.
+	if !recordBlockedAndCheck(st, base.Add(12*time.Second), window, threshold, cooldown) {
+		t.Fatal("did not trip at threshold")
+	}
+	// Immediately after a trip (cooldown), even a fresh burst must not re-trip.
+	for i := 0; i < 6; i++ {
+		if recordBlockedAndCheck(st, base.Add(20*time.Second+time.Duration(i)*3*time.Second), window, threshold, cooldown) {
+			t.Fatal("re-tripped inside cooldown")
+		}
+	}
+	// After the cooldown, a new burst trips again.
+	late := base.Add(11 * time.Minute)
+	for i := 0; i < 4; i++ {
+		recordBlockedAndCheck(st, late.Add(time.Duration(i)*3*time.Second), window, threshold, cooldown)
+	}
+	if !recordBlockedAndCheck(st, late.Add(12*time.Second), window, threshold, cooldown) {
+		t.Fatal("did not trip after cooldown expired")
+	}
+}
+
+func TestRecordBlockedAndCheck_SlowDripNeverTrips(t *testing.T) {
+	st := &thrashState{}
+	base := time.Now()
+	// One blocked push every 2 minutes: legitimate occasional denials (an agent
+	// probing once per task) must never pause the agent.
+	for i := 0; i < 20; i++ {
+		if recordBlockedAndCheck(st, base.Add(time.Duration(i)*2*time.Minute), 60*time.Second, 5, 10*time.Minute) {
+			t.Fatalf("slow drip tripped at hit %d", i+1)
+		}
+	}
+}


### PR DESCRIPTION
## The incident

Hosted L2 hive (operator report): bob coin usage climbing every few minutes despite paused supervisor and 4–6h cadences. Root cause: the **guide agent retried an advisory-blocked `git push` every ~3 seconds** — the credential gate said *what* was denied but not *to stop*, and nothing hub-side bounded the loop. Cadence limits kick frequency, not session behavior.

## Fix (both layers deterministic, no agent judgment)

1. **Terminal block messages** — `git-credential-hive.sh` mode/level denials now state the block can NEVER succeed by retrying and direct the agent to record an advisory finding and end the task.
2. **Hub-side thrash breaker** — output-capture loop feeds `git push blocked:` / policy-block lines into a per-agent sliding window (**5 hits/60s**, 10-min cooldown). Crossing it **pauses the agent** (trigger `thrash-breaker`, explicit reason) — dashboard-visible, resume-reversible, stops governor kicks; same UX as the login-detector.

Locking: breaker has its own `thrashMu`; `Pause` fires from a fresh goroutine, never `m.mu` from the capture path (the July re-entrancy deadlock class). Slow-drip immunity unit-tested (occasional legitimate denials never pause).

Companion to #2561: that breaker stops cross-PR fix loops; this one stops in-session action loops.

v2 backport follows (the reporting hive runs v2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)