### PR TITLE
feat(contribute): enforce per-tier hourly/daily contributor rate limits (#2566)

### DIFF
--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -204,7 +204,37 @@ type ContributeWSHub struct {
 	consecutiveFailures map[string]int
 	completedMu         sync.Mutex
 	selectMu            sync.Mutex
+	// assignmentTimes records, per contributor identity (identityOf), the wall-clock
+	// times of the task_assign messages that identity has been handed. It backs the
+	// #2436/#2566 per-tier rate gate: tier_limits.max_per_hour / max_per_day were
+	// admin-writable and displayed by the Management & Operations control-plane
+	// (#2562) as if authoritative, but selectTask enforced only max_concurrent, so
+	// the numbers an operator set were inert. We enforce them here by counting the
+	// timestamps in this ledger that fall inside a ROLLING 1-hour and 24-hour window
+	// ending "now" (a sliding window keyed off each assignment's timestamp, NOT a
+	// calendar-hour/calendar-day bucket that would reset on the clock). A slot frees
+	// exactly `rateLimitHourWindow` / `rateLimitDayWindow` after it was taken, so a
+	// contributor who hit max_per_hour can resume as soon as their oldest assignment
+	// in the trailing hour ages out. The counter is ASSIGNMENTS (each task handed
+	// out), mirroring max_concurrent's "tasks handed to this identity" semantics and
+	// the max_tasks_per_hour/day field naming; it is not gated on completion. Old
+	// entries beyond the day window are pruned on every recording pass so the map
+	// stays bounded. Guarded by rateMu.
+	assignmentTimes map[string][]time.Time
+	rateMu          sync.Mutex
 }
+
+// rateLimitHourWindow and rateLimitDayWindow are the trailing (rolling) windows
+// over which tier_limits.max_per_hour and max_per_day are counted (#2566). They
+// are sliding windows anchored on "now", not calendar buckets: a contributor's
+// assignment stops counting against the hourly cap exactly rateLimitHourWindow
+// after it was made, and against the daily cap after rateLimitDayWindow. This
+// matches the field names (per HOUR / per DAY) while avoiding a hard reset at the
+// top of the clock hour/day that would let a burst straddle the boundary.
+const (
+	rateLimitHourWindow = time.Hour
+	rateLimitDayWindow  = 24 * time.Hour
+)
 
 // completedTaskCooldownHours is the cooldown applied when a task completes
 // having actually shipped a pull request: real work landed, so we should not
@@ -265,6 +295,7 @@ func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 		completedTaskPRURL:    make(map[string]string),
 		failedTasks:           make(map[string]time.Time),
 		consecutiveFailures:   make(map[string]int),
+		assignmentTimes:       make(map[string][]time.Time),
 		logger:                logger,
 		server:                server,
 	}
@@ -1502,6 +1533,16 @@ const (
 	// tier_limits.max_concurrent for this identity (counting every live
 	// connection this identity holds).
 	taskUnavailableConcurrencyLimit = "concurrency_limit"
+	// taskUnavailableHourlyLimit / taskUnavailableDailyLimit (#2566): assigning
+	// would exceed the tier's tier_limits.max_per_hour / max_per_day for this
+	// identity, counting the assignments handed out inside the trailing
+	// rateLimitHourWindow / rateLimitDayWindow. These mirror the enforced-refusal
+	// shape of taskUnavailableConcurrencyLimit (#2436) and the tier_disabled gate:
+	// the fields were admin-writable and displayed by the #2562 control-plane but
+	// previously left as TODO(#2436) and never enforced, so the displayed caps were
+	// inert. A contributor at or over the cap now learns exactly which window it hit.
+	taskUnavailableHourlyLimit = "hourly_limit"
+	taskUnavailableDailyLimit  = "daily_limit"
 
 	// The reasons below (kubestellar/hive#2546) extend the same task_unavailable
 	// negative-ack to the three formerly-SILENT selectTask paths — each returned a
@@ -1538,6 +1579,61 @@ func identityOf(c *ContributorConnection) string {
 		return c.profile.ContributorID
 	}
 	return c.profile.GitHubUsername
+}
+
+// rateWindowCounts returns how many task assignments the given identity has been
+// handed inside the trailing hour and day windows ending at `now`. It prunes any
+// timestamps older than the day window (the widest of the two) as a side effect so
+// assignmentTimes stays bounded to at most a day of history per identity. Caller
+// must NOT hold rateMu; this method takes it. See assignmentTimes / #2566 for the
+// rolling-window semantics.
+func (h *ContributeWSHub) rateWindowCounts(identity string, now time.Time) (hour, day int) {
+	if identity == "" {
+		return 0, 0
+	}
+	dayCutoff := now.Add(-rateLimitDayWindow)
+	hourCutoff := now.Add(-rateLimitHourWindow)
+
+	h.rateMu.Lock()
+	defer h.rateMu.Unlock()
+
+	times := h.assignmentTimes[identity]
+	kept := times[:0]
+	for _, t := range times {
+		if t.Before(dayCutoff) {
+			// Older than the widest window — it can never count again; drop it.
+			continue
+		}
+		kept = append(kept, t)
+		day++
+		if !t.Before(hourCutoff) {
+			hour++
+		}
+	}
+	if len(kept) == 0 {
+		delete(h.assignmentTimes, identity)
+	} else {
+		h.assignmentTimes[identity] = kept
+	}
+	return hour, day
+}
+
+// recordAssignment appends an assignment timestamp for the identity. Called once
+// per task_assign actually shipped, so the rate windows count tasks HANDED OUT
+// (matching max_concurrent's semantics and the max_tasks_per_hour/day naming), not
+// completions. Caller must NOT hold rateMu. See #2566.
+func (h *ContributeWSHub) recordAssignment(identity string, at time.Time) {
+	if identity == "" {
+		return
+	}
+	h.rateMu.Lock()
+	if h.assignmentTimes == nil {
+		// The constructor initializes this map; a hub built as a bare struct literal
+		// (some tests, defensive) would otherwise panic on append to a nil map.
+		h.assignmentTimes = make(map[string][]time.Time)
+	}
+	h.assignmentTimes[identity] = append(h.assignmentTimes[identity], at)
+	h.rateMu.Unlock()
 }
 
 // taskUnavailable builds the explicit negative-ack the ready handler sends in
@@ -1651,21 +1747,45 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	}
 	h.mu.RUnlock()
 
-	// #2436 finding 3: enforce tier_limits.max_concurrent per identity. The
-	// config ships populated MaxConcurrent defaults, so an operator reasonably
-	// believes concurrency is capped; before this it was inert. A limit <= 0 is
-	// treated as "unlimited" (the "advisor" default is 0 and existing configs
-	// that never set the field must keep working). MaxPerHour / MaxPerDay remain
-	// TODO(#2436): they require per-identity rate counters that are not tracked
-	// today, so they are intentionally left unenforced rather than pretended —
-	// see the PR note. Only MaxConcurrent is wired here.
+	// #2436 finding 3 / #2566: enforce tier_limits per identity. The config ships
+	// populated MaxConcurrent/MaxPerHour/MaxPerDay defaults, so an operator
+	// reasonably believes concurrency AND rate are capped — and since #2562 the
+	// Management & Operations control-plane DISPLAYS all three as if authoritative.
+	// Before this, only MaxConcurrent was enforced; MaxPerHour / MaxPerDay were left
+	// as TODO(#2436) and never read, so the hourly/daily numbers an operator set (or
+	// saw in the control-plane) were inert. All three are now enforced here.
+	//
+	// A limit <= 0 is treated as "unlimited" for every field (the "advisor" default
+	// is 0 across the board, and existing configs that never set a field must keep
+	// working). MaxConcurrent counts tasks currently HELD (identityHolds, from the
+	// live-connection scan above); MaxPerHour / MaxPerDay count tasks ASSIGNED inside
+	// the trailing rateLimitHourWindow / rateLimitDayWindow (rolling windows, see
+	// assignmentTimes). Concurrency is checked first as the tightest, most immediate
+	// gate; the rate windows are checked next so a contributor learns exactly which
+	// cap they hit. The daily assignment is recorded only once a task is actually
+	// shipped, at the task_assign site below.
 	if h.server.deps != nil && h.server.deps.Config != nil {
-		if limits, ok := h.server.deps.Config.Hub.TierLimits[tier]; ok && limits.MaxConcurrent > 0 {
-			if identityHolds[identityOf(c)] >= limits.MaxConcurrent {
+		if limits, ok := h.server.deps.Config.Hub.TierLimits[tier]; ok {
+			if limits.MaxConcurrent > 0 && identityHolds[identityOf(c)] >= limits.MaxConcurrent {
 				h.logger.Warn("[contribute-ws] refusing task: concurrency limit reached",
 					"username", identityOf(c), "tier", tier,
 					"held", identityHolds[identityOf(c)], "max_concurrent", limits.MaxConcurrent)
 				return h.taskUnavailable(taskUnavailableConcurrencyLimit)
+			}
+			if limits.MaxPerHour > 0 || limits.MaxPerDay > 0 {
+				hourCount, dayCount := h.rateWindowCounts(identityOf(c), time.Now())
+				if limits.MaxPerHour > 0 && hourCount >= limits.MaxPerHour {
+					h.logger.Warn("[contribute-ws] refusing task: hourly rate limit reached",
+						"username", identityOf(c), "tier", tier,
+						"assigned_last_hour", hourCount, "max_per_hour", limits.MaxPerHour)
+					return h.taskUnavailable(taskUnavailableHourlyLimit)
+				}
+				if limits.MaxPerDay > 0 && dayCount >= limits.MaxPerDay {
+					h.logger.Warn("[contribute-ws] refusing task: daily rate limit reached",
+						"username", identityOf(c), "tier", tier,
+						"assigned_last_day", dayCount, "max_per_day", limits.MaxPerDay)
+					return h.taskUnavailable(taskUnavailableDailyLimit)
+				}
 			}
 		}
 	}
@@ -1913,6 +2033,14 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	c.lastIdleReason = ""
 	c.tokenMintedAt = time.Now()
 	c.mu.Unlock()
+
+	// #2566: record this assignment against the identity's rolling hourly/daily
+	// windows so the next selectTask enforces tier_limits.max_per_hour /
+	// max_per_day. Recorded here — after the task is committed to the connection
+	// and we are certain a task_assign will ship — so a refused pass (which returns
+	// early above) never consumes a slot. Uses the same identity key as the
+	// concurrency gate.
+	h.recordAssignment(identityOf(c), time.Now())
 
 	return &WSMessage{
 		Type:           "task_assign",

--- a/v2/pkg/dashboard/contribute_ws_rate_limits_test.go
+++ b/v2/pkg/dashboard/contribute_ws_rate_limits_test.go
@@ -1,0 +1,192 @@
+package dashboard
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// oneActionableIssueN installs a status with a single actionable issue whose
+// number/url are keyed off n, so successive selectTask passes are handed DIFFERENT
+// issues (the same issue would be skipped once held/active). Author is someone else
+// so the #2390 own-work ordering does not skew selection. Mirrors oneActionableIssue
+// in contribute_ws_trust_controls_test.go.
+func oneActionableIssueN(s *Server, n int) {
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{
+			{
+				Name: "repo1",
+				Full: "myorg/repo1",
+				ActionableIssues: []any{
+					map[string]any{
+						"number": float64(1000 + n),
+						"title":  "Actionable issue",
+						"url":    "https://github.com/myorg/repo1/issues/1000",
+						"author": "someone-else",
+					},
+				},
+			},
+		},
+	}
+	s.statusMu.Unlock()
+}
+
+// TestRateLimits_HourlyEnforced (#2566): a contributor at tier_limits.max_per_hour
+// for their tier is refused the next assignment with an hourly_limit negative-ack,
+// mirroring the concurrency_limit gate. One assignment under the cap is admitted.
+func TestRateLimits_HourlyEnforced(t *testing.T) {
+	hub, s := covK2Hub(t)
+
+	// max_per_hour: 2, and a high max_concurrent/max_per_day so ONLY the hourly cap
+	// can trip. currentTask is cleared between passes so concurrency never binds.
+	s.deps.Config.Hub.TierLimits = map[string]config.TierRate{
+		"newcomer": {MaxPerHour: 2, MaxPerDay: 100, MaxConcurrent: 100},
+	}
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "newcomer"},
+		lastPong: time.Now(),
+	}
+
+	// Two assignments are admitted (0 -> 1 -> at cap after the 2nd).
+	for i := 0; i < 2; i++ {
+		oneActionableIssueN(s, i)
+		msg := hub.selectTask(conn)
+		if msg == nil || msg.Type != "task_assign" {
+			t.Fatalf("assignment %d under max_per_hour=2 should be served, got %+v", i+1, msg)
+		}
+		conn.currentTask = nil // release the concurrency hold for the next pass
+	}
+
+	// Third assignment: identity now has 2 == max_per_hour in the trailing hour, so
+	// it is refused with hourly_limit rather than silently handed work.
+	oneActionableIssueN(s, 2)
+	msg := hub.selectTask(conn)
+	if msg == nil {
+		t.Fatalf("expected an hourly-limit negative-ack, got nil (silent)")
+	}
+	if msg.Type != "task_unavailable" || msg.Reason != taskUnavailableHourlyLimit {
+		t.Fatalf("expected task_unavailable/%s, got type=%q reason=%q",
+			taskUnavailableHourlyLimit, msg.Type, msg.Reason)
+	}
+
+	// Fail-before shape: raising max_per_hour admits the same identity again.
+	s.deps.Config.Hub.TierLimits["newcomer"] = config.TierRate{MaxPerHour: 3, MaxPerDay: 100, MaxConcurrent: 100}
+	oneActionableIssueN(s, 3)
+	if msg := hub.selectTask(conn); msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("with max_per_hour raised to 3 the next assignment should be served, got %+v", msg)
+	}
+}
+
+// TestRateLimits_DailyEnforced (#2566): a contributor at tier_limits.max_per_day is
+// refused with a daily_limit negative-ack. Seeds the assignment ledger directly to
+// keep the test independent of how many issues are enumerated.
+func TestRateLimits_DailyEnforced(t *testing.T) {
+	hub, s := covK2Hub(t)
+
+	// High hourly cap so only the daily cap can trip; max_per_day: 3.
+	s.deps.Config.Hub.TierLimits = map[string]config.TierRate{
+		"newcomer": {MaxPerHour: 100, MaxPerDay: 3, MaxConcurrent: 100},
+	}
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "bob", ContributorID: "c-bob", TrustTier: "newcomer"},
+		lastPong: time.Now(),
+	}
+
+	// Seed 3 assignments spread across the last day but OUTSIDE the trailing hour, so
+	// the hourly window is empty and only the daily cap is at its limit.
+	now := time.Now()
+	hub.assignmentTimes[identityOf(conn)] = []time.Time{
+		now.Add(-20 * time.Hour),
+		now.Add(-10 * time.Hour),
+		now.Add(-3 * time.Hour),
+	}
+
+	oneActionableIssueN(s, 0)
+	msg := hub.selectTask(conn)
+	if msg == nil {
+		t.Fatalf("expected a daily-limit negative-ack, got nil (silent)")
+	}
+	if msg.Type != "task_unavailable" || msg.Reason != taskUnavailableDailyLimit {
+		t.Fatalf("expected task_unavailable/%s, got type=%q reason=%q",
+			taskUnavailableDailyLimit, msg.Type, msg.Reason)
+	}
+
+	// Fail-before shape: raising max_per_day admits the identity again.
+	s.deps.Config.Hub.TierLimits["newcomer"] = config.TierRate{MaxPerHour: 100, MaxPerDay: 4, MaxConcurrent: 100}
+	oneActionableIssueN(s, 1)
+	if msg := hub.selectTask(conn); msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("with max_per_day raised to 4 the assignment should be served, got %+v", msg)
+	}
+}
+
+// TestRateLimits_RollingWindowReset (#2566): the windows are ROLLING, not calendar
+// buckets. An assignment older than the hour window no longer counts against
+// max_per_hour, and one older than the day window no longer counts against
+// max_per_day and is pruned from the ledger.
+func TestRateLimits_RollingWindowReset(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	conn := &ContributorConnection{
+		profile: &ContributorProfile{GitHubUsername: "carol", ContributorID: "c-carol", TrustTier: "newcomer"},
+	}
+	id := identityOf(conn)
+	now := time.Now()
+
+	// One assignment 90 minutes ago (outside the hour window, inside the day window)
+	// and one 25 hours ago (outside BOTH windows).
+	hub.assignmentTimes[id] = []time.Time{
+		now.Add(-90 * time.Minute),
+		now.Add(-25 * time.Hour),
+	}
+
+	hour, day := hub.rateWindowCounts(id, now)
+	if hour != 0 {
+		t.Fatalf("assignment 90m ago must not count in the trailing hour, got hour=%d", hour)
+	}
+	if day != 1 {
+		t.Fatalf("only the 90m-ago assignment falls inside the day window, got day=%d", day)
+	}
+
+	// The 25h-ago entry is beyond the widest window and must have been pruned.
+	if got := len(hub.assignmentTimes[id]); got != 1 {
+		t.Fatalf("expected the >24h assignment to be pruned, ledger len=%d", got)
+	}
+
+	// A fresh identity with no history counts zero on both windows.
+	if h, d := hub.rateWindowCounts("nobody", now); h != 0 || d != 0 {
+		t.Fatalf("unknown identity should count zero, got hour=%d day=%d", h, d)
+	}
+}
+
+// TestRateLimits_ZeroMeansUnlimited (#2566): a limit <= 0 disables that window (the
+// "advisor" tier defaults every field to 0), so the identity is never refused on a
+// zero cap regardless of history.
+func TestRateLimits_ZeroMeansUnlimited(t *testing.T) {
+	hub, s := covK2Hub(t)
+
+	s.deps.Config.Hub.TierLimits = map[string]config.TierRate{
+		"advisor": {MaxPerHour: 0, MaxPerDay: 0, MaxConcurrent: 0},
+	}
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "dave", ContributorID: "c-dave", TrustTier: "advisor"},
+		lastPong: time.Now(),
+	}
+
+	// Pre-load a large history; with all caps at 0 it must be ignored.
+	now := time.Now()
+	var seeded []time.Time
+	for i := 0; i < 50; i++ {
+		seeded = append(seeded, now.Add(-time.Duration(i)*time.Minute))
+	}
+	hub.assignmentTimes[identityOf(conn)] = seeded
+
+	oneActionableIssueN(s, 0)
+	if msg := hub.selectTask(conn); msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("with all tier limits 0 (unlimited) the assignment should be served, got %+v", msg)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2566.

`tier_limits.max_per_hour` and `tier_limits.max_per_day` were **admin-writable and displayed as authoritative** — PR #2562 added the Management & Operations control-plane that surfaces all three per-tier limits to operators — but `selectTask` enforced **only** `max_concurrent`. The hourly/daily fields were left as `TODO(#2436)` and never read, so the caps an operator set (or saw in the control-plane) were inert. Tracker and source disagreed: #2436 was closed claiming `tier_limits` was enforced by #2456, but that change wired only concurrency.

This is Jorge's **Option 1 (enforce)** — enforcement was tractable because a natural counter (assignments handed out) and enforcement point (the existing `max_concurrent` gate in `selectTask`) already exist.

## What was implemented

Enforcement lives at the same per-identity gate in `selectTask` where `max_concurrent` is already checked (`v2/pkg/dashboard/contribute_ws.go`):

- **Counter — assignments.** A per-identity ledger (`assignmentTimes map[string][]time.Time`) records the timestamp of every `task_assign` actually shipped, recorded at the assignment site right after `currentTask` is committed (so a refused pass never consumes a slot). Assignments — tasks *handed out* — match `max_concurrent`'s "tasks held by this identity" semantics and the `max_tasks_per_hour`/`max_tasks_per_day` field naming; it is **not** gated on completion.
- **Windows — rolling, documented.** Counts use trailing/sliding windows anchored on *now* (`rateLimitHourWindow = 1h`, `rateLimitDayWindow = 24h`), **not** calendar-hour/day buckets. A slot frees exactly one window after it was taken, so a contributor who hit `max_per_hour` resumes as soon as their oldest trailing-hour assignment ages out — no hard reset at the top of the clock that would let a burst straddle the boundary. Entries beyond the day window are pruned on every counting pass so the map stays bounded. The window/reset semantics are documented in comments on `assignmentTimes` and the `rateLimit*Window` constants.
- **Refusal — mirrors the existing pattern.** An identity at or over `max_per_hour` / `max_per_day` for its tier is refused with a machine-readable `task_unavailable` reason — `hourly_limit` / `daily_limit` — mirroring the `concurrency_limit` refusal added in #2436 and the negative-ack philosophy of #2546 (the contributor learns *why*, distinctly per window). No new refusal mechanism was invented.
- **Zero means unlimited.** A limit `<= 0` disables that window (the `advisor` tier defaults every field to 0; configs that never set a field keep working).
- Removed the `TODO(#2436)` comment. The numbers the #2562 control-plane displays are now actually enforced, closing the policy-truthfulness gap.

## Tests

`v2/pkg/dashboard/contribute_ws_rate_limits_test.go`, matching the existing `selectTask` trust-control test style:

- `TestRateLimits_HourlyEnforced` — two assignments admitted under `max_per_hour=2`, the third refused with `hourly_limit`; raising the cap admits again (fail-before shape).
- `TestRateLimits_DailyEnforced` — an identity at `max_per_day` refused with `daily_limit`; raising the cap admits again.
- `TestRateLimits_RollingWindowReset` — an assignment older than the hour window no longer counts hourly; one older than the day window no longer counts daily and is pruned.
- `TestRateLimits_ZeroMeansUnlimited` — all caps at 0 never refuse regardless of history.

`go build ./...`, `go vet ./pkg/dashboard/`, and the full `go test ./pkg/dashboard/` suite pass locally.
