### PR TITLE
Split /contribute 'Management & Operations' tab into 'Management' + 'Operations'

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -474,7 +474,8 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 </style></head><body>
 <div class="page-tabs" role="tablist">
 <button class="page-tab active" role="tab" id="ptab-onboarding" aria-selected="true" data-panel="tab-onboarding">Onboarding</button>
-<button class="page-tab" role="tab" id="ptab-ops" aria-selected="false" data-panel="tab-ops">Management &amp; Operations</button>
+<button class="page-tab" role="tab" id="ptab-manage" aria-selected="false" data-panel="tab-manage">Management</button>
+<button class="page-tab" role="tab" id="ptab-ops" aria-selected="false" data-panel="tab-ops">Operations</button>
 </div>
 <div class="tab-panel active" id="tab-onboarding" role="tabpanel" aria-labelledby="ptab-onboarding">
 <div class="page">
@@ -652,10 +653,14 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 </div>
 </div>
 </div>
-<div class="tab-panel" id="tab-ops" role="tabpanel" aria-labelledby="ptab-ops">
+<!-- Management tab — operator admin CONTROLS only. Split out of the former
+     single "Management & Operations" tab so controls (this panel) and monitoring
+     (the Operations panel below) live apart. The admin block below is moved here
+     verbatim; nothing about its gating, IDs, or endpoints changed. -->
+<div class="tab-panel" id="tab-manage" role="tabpanel" aria-labelledby="ptab-manage">
 <div class="ops">
-<h1>Management &amp; Operations</h1>
-<p class="subtitle" style="font-size:.95rem">An operations view over the contributor (&ldquo;clanker&rdquo;) fleet and its in-flight work. The read-only panels below surface what this hive already knows; operators with write access also get the admin controls, mirrored from the Governor Hub configuration.</p>
+<h1>Management</h1>
+<p class="subtitle" style="font-size:.95rem">Operator admin controls for the contributor (&ldquo;clanker&rdquo;) fleet, mirrored from the Governor Hub configuration. Owner &amp; read-write only &mdash; a read viewer sees no controls here. Live monitoring of the fleet lives under the <strong style="color:#e6edf3">Operations</strong> tab.</p>
 
 <!-- #2534 Operator admin controls. Hidden by default; shown only after /api/role
      reports owner or read-write. These mirror the Governor Hub config section
@@ -696,6 +701,17 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 <p class="admin-note" id="admin-save-hint">Suspend / skip toggles apply immediately. Filter edits apply on Save. Both persist through <code>PUT /api/config/governor/hub</code>.</p>
 </div>
 </div>
+</div>
+</div>
+<!-- Operations tab — MONITORING. The Connected-clankers list (with its per-row
+     trust / Revoke / Remove controls, still owner/read-write gated), My work
+     queue, and the read-only Pipeline & policy panel. Split out of the former
+     "Management & Operations" tab; the admin CONTROLS moved to the Management
+     panel above, everything here stayed put. -->
+<div class="tab-panel" id="tab-ops" role="tabpanel" aria-labelledby="ptab-ops">
+<div class="ops">
+<h1>Operations</h1>
+<p class="subtitle" style="font-size:.95rem">A live view over the contributor (&ldquo;clanker&rdquo;) fleet and its in-flight work. The panels below surface what this hive already knows; the per-clanker trust / revoke / remove controls are owner &amp; read-write only. Admin controls (suspend, admission filters) live under the <strong style="color:#e6edf3">Management</strong> tab.</p>
 
 <div class="ops-grid">
 <div>
@@ -737,14 +753,22 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 // Tab switching for the /contribute page. Additive: leaves onboarding intact.
 var tabs=document.querySelectorAll('.page-tab');
 var panels=document.querySelectorAll('.tab-panel');
-var opsStarted=false;
+var opsStarted=false;   // Operations fleet polling started
+var adminStarted=false; // /api/role gate resolved (adminEnabled set)
+// The role gate now backs controls in BOTH tabs: the admin block under Management
+// AND the per-clanker trust/revoke/remove buttons under Operations. So initAdmin()
+// must run when EITHER tab is first opened — otherwise a viewer who lands straight
+// on Operations would never resolve their role and would lose the per-row controls.
+// It is idempotent (fetches /api/role once) and independent of opsPoll().
 tabs.forEach(function(t){t.addEventListener('click',function(){
   tabs.forEach(function(x){x.classList.remove('active');x.setAttribute('aria-selected','false');});
   panels.forEach(function(p){p.classList.remove('active');});
   t.classList.add('active');t.setAttribute('aria-selected','true');
   var panel=document.getElementById(t.getAttribute('data-panel'));
   if(panel)panel.classList.add('active');
-  if(t.getAttribute('data-panel')==='tab-ops'&&!opsStarted){opsStarted=true;opsPoll();initAdmin();}
+  var dp=t.getAttribute('data-panel');
+  if((dp==='tab-ops'||dp==='tab-manage')&&!adminStarted){adminStarted=true;initAdmin();}
+  if(dp==='tab-ops'&&!opsStarted){opsStarted=true;opsPoll();}
 });});
 
 var currentFilter='all';

--- a/v2/pkg/dashboard/api_contribute_admin_controls_test.go
+++ b/v2/pkg/dashboard/api_contribute_admin_controls_test.go
@@ -9,14 +9,18 @@ import (
 	"testing"
 )
 
-// #2534 — Operator admin controls mirrored into the Management & Operations tab.
+// #2534 — Operator admin controls. Originally in a single "Management & Operations"
+// tab; that tab is now split into "Management" (the admin CONTROLS block below) and
+// "Operations" (monitoring + the per-clanker controls). The gating is unchanged and
+// applies to controls in BOTH tabs.
 //
 // These tests pin two things:
 //   1. The UI: the /contribute page must ship the (initially hidden) admin-controls
 //      markup that mirrors the Governor Hub config — suspend/skip toggles, the
 //      admission-filter editors, and the per-contributor action wiring — plus the
 //      /api/role gate and the themed confirm modal. Rendering is gated CLIENT-side
-//      by initAdmin() reading /api/role; a read viewer never enables it.
+//      by initAdmin() reading /api/role; a read viewer never enables it. The SAME
+//      gate (adminEnabled) governs the per-clanker controls now under Operations.
 //   2. The server boundary: the contributor mutation endpoints the tab drives
 //      (trust / revoke / delete) must reject a "read" viewer with 403 and allow
 //      owner + read-write — because roleEnforcement EXEMPTS the /api/contribute*
@@ -95,6 +99,36 @@ func TestOpsTabHasAdminControlsMarkup(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("read-only ops panel content missing %q (must remain intact)", want)
 		}
+	}
+
+	// Split placement: the admin CONTROLS block moved to the Management panel;
+	// the per-clanker controls + monitoring stayed under Operations.
+	iManage := strings.Index(body, `id="tab-manage"`)
+	iAdmin := strings.Index(body, `id="ops-admin"`)
+	iOps := strings.Index(body, `id="tab-ops"`)
+	iClankerCtl := strings.Index(body, `data-role="revoke"`)
+	if iManage < 0 || iAdmin < 0 || iOps < 0 || iClankerCtl < 0 {
+		t.Fatalf("anchors missing: manage=%d admin=%d ops=%d clankerCtl=%d", iManage, iAdmin, iOps, iClankerCtl)
+	}
+	if !(iManage < iAdmin && iAdmin < iOps) {
+		t.Errorf("admin controls must be under Management, before Operations: manage=%d admin=%d ops=%d", iManage, iAdmin, iOps)
+	}
+	if iClankerCtl < iOps {
+		t.Errorf("per-clanker controls must stay under Operations (after tab-ops): ops=%d clankerCtl=%d", iOps, iClankerCtl)
+	}
+
+	// One gate for both tabs: the per-clanker controls are emitted only when
+	// adminEnabled is set, which initAdmin() sets solely for owner/read-write.
+	// This is the same gate as the Management admin block — the split must not
+	// give the Operations controls a weaker (or absent) gate.
+	if !strings.Contains(body, `if(adminEnabled&&c.contributor_id){`) {
+		t.Error("per-clanker controls must remain gated on adminEnabled (owner/read-write only)")
+	}
+	// initAdmin() must run for the Management OR the Operations tab, so a viewer
+	// landing straight on Operations still resolves their role for the per-row
+	// controls (and read viewers still get none).
+	if !strings.Contains(body, `dp==='tab-ops'||dp==='tab-manage'`) {
+		t.Error("initAdmin() must be wired to run when either the Management or Operations tab is opened")
 	}
 }
 
@@ -221,5 +255,31 @@ func TestGovernorHubAcceptsSkipAssigned(t *testing.T) {
 	}
 	if got, ok := cfg.Hub["contribute_skip_assigned_to_others"]; !ok || got != true {
 		t.Errorf("config hub missing/false contribute_skip_assigned_to_others: %v (ok=%v)", got, ok)
+	}
+}
+
+// TestGovernorHubSave_ReadViewerForbidden proves the Management-tab filter-save
+// boundary: a "read" viewer's PUT /api/config/governor/hub is 403'd by the
+// roleEnforcement middleware, independent of the UI hiding. This is the server
+// gate behind the Management admin block after the tab split — the split must not
+// weaken it. Exercised through the full handler chain (Handler()) so the
+// middleware actually runs.
+func TestGovernorHubSave_ReadViewerForbidden(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.Hub.ContributeSuspended = false
+
+	h := s.Handler()
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/hub",
+		strings.NewReader(`{"contribute_suspended":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-Role", "read")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("read viewer PUT /api/config/governor/hub got %d, want 403 (body: %s)", w.Code, w.Body.String())
+	}
+	if deps.Config.Hub.ContributeSuspended {
+		t.Error("read viewer mutated Config.Hub.ContributeSuspended through the filter-save endpoint")
 	}
 }

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -166,8 +166,9 @@ func TestContributeLanding(t *testing.T) {
 }
 
 // TestContributeLandingHasOpsTab pins the additive tab chrome: the landing page
-// must now render the Onboarding / Management & Operations tab bar, the new ops
-// panel, AND still carry the existing onboarding content unchanged.
+// must now render the Onboarding / Management / Operations tab bar (the former
+// single "Management & Operations" tab is split in two), the Operations panel,
+// AND still carry the existing onboarding content unchanged.
 func TestContributeLandingHasOpsTab(t *testing.T) {
 	setupContributeEnv(t)
 	s := NewServer(0, slog.Default())
@@ -182,12 +183,17 @@ func TestContributeLandingHasOpsTab(t *testing.T) {
 	}
 	body := w.Body.String()
 
-	// New tab chrome.
+	// New tab chrome: THREE tabs now — Onboarding, Management, Operations.
 	for _, want := range []string{
 		`class="page-tabs"`,
 		`data-panel="tab-onboarding"`,
+		`data-panel="tab-manage"`,
 		`data-panel="tab-ops"`,
-		`Management &amp; Operations`,
+		`id="ptab-manage"`,
+		`id="ptab-ops"`,
+		`>Management<`,  // Management tab label (controls only)
+		`>Operations<`,  // Operations tab label (monitoring)
+		`id="tab-manage"`,
 		`id="tab-ops"`,
 		`Connected clankers`,
 		`id="work-list"`,
@@ -195,8 +201,31 @@ func TestContributeLandingHasOpsTab(t *testing.T) {
 		`opened`, // pipeline node
 	} {
 		if !strings.Contains(body, want) {
-			t.Errorf("ops tab chrome missing %q", want)
+			t.Errorf("tab chrome missing %q", want)
 		}
+	}
+
+	// The single "Management & Operations" tab was split; that combined label
+	// must no longer appear.
+	if strings.Contains(body, "Management &amp; Operations") {
+		t.Error(`combined "Management & Operations" tab label still present after the split`)
+	}
+
+	// The split must place the admin CONTROLS block under Management and the
+	// monitoring panels (clankers list / my work / pipeline) under Operations.
+	// Verify ordering: ops-admin appears inside tab-manage, before tab-ops opens.
+	iManage := strings.Index(body, `id="tab-manage"`)
+	iAdmin := strings.Index(body, `id="ops-admin"`)
+	iOps := strings.Index(body, `id="tab-ops"`)
+	iClankers := strings.Index(body, `<h3>Connected clankers</h3>`)
+	if iManage < 0 || iAdmin < 0 || iOps < 0 || iClankers < 0 {
+		t.Fatalf("missing anchors: manage=%d admin=%d ops=%d clankers=%d", iManage, iAdmin, iOps, iClankers)
+	}
+	if !(iManage < iAdmin && iAdmin < iOps) {
+		t.Errorf("admin controls must render under Management (before Operations): manage=%d admin=%d ops=%d", iManage, iAdmin, iOps)
+	}
+	if !(iOps < iClankers) {
+		t.Errorf("Connected clankers must render under Operations (after tab-ops opens): ops=%d clankers=%d", iOps, iClankers)
 	}
 
 	// Existing onboarding content must still be present and unchanged.


### PR DESCRIPTION
Splits the single **Management & Operations** tab on the `/contribute` page into two tabs.

## What changed
The tab bar goes from two tabs to three: **Onboarding** (unchanged), **Management**, **Operations**.

- **Management** — the operator admin **controls** ONLY: the Suspend-contributions / Skip-assigned toggles and the Admission filters (Titles/Authors/Labels deny/allow, Allowed models, Reject-unknown) with **Save filters**. These persist through the same `PUT /api/config/governor/hub` endpoint as before.
- **Operations** — monitoring: the **Connected clankers** list (keeping its per-row **trust dropdown / Revoke / Remove** controls), the **My work** queue (All/Active/Review/Done), and the read-only **Pipeline & policy** panel.

## UI reorg only
This is a pure UI reorganization of already-merged content (#2542 / #2558 / #2562). **No new endpoints, no behavior change.** The only markup that moves is the `ops-admin` controls block, relocated from the Operations panel into the new Management panel. All IDs / JS hooks are preserved (`initAdmin()`, the filter save, `/api/contribute/fleet` polling, the per-clanker actions, the All/Active/Review/Done filtering, the prompt preview, idle reasons).

## Gating preserved (UI + server)
The invariant is unchanged: **wherever a control appears, in either tab, it is read-only unless the viewer is owner or read-write.**

- The Management admin block stays owner/read-write-only via the existing `initAdmin()` / `/api/role` gate.
- The per-clanker controls under Operations keep the **same** `adminEnabled` gate. `initAdmin()` is now wired to run when **either** tab is first opened, so a viewer who lands straight on Operations still resolves their role for the per-row controls (and a read viewer still gets none).
- Server enforcement is untouched: `requireContributorWrite` on the trust/revoke/delete endpoints and `roleEnforcement` on `PUT /api/config/governor/hub` still `403` a read viewer — UI hiding is never the only defense.
- The **Onboarding** tab is unchanged.

## Tests
- Updated the tab-chrome test to assert three tabs and that the combined label is gone; added positional assertions that the admin-controls block renders under **Management** and the clankers/work/pipeline under **Operations**.
- Added assertions that the per-clanker controls stay gated on `adminEnabled` and that `initAdmin()` runs for either tab.
- Added `TestGovernorHubSave_ReadViewerForbidden`: a `read` viewer hitting `PUT /api/config/governor/hub` through the full middleware chain gets `403` and mutates nothing (the Management filter-save server gate). Existing `TestContributorWrite_ReadViewerForbidden` continues to cover the Operations per-clanker endpoints.
- `go build`, `go vet`, and the full `pkg/dashboard` test suite pass; the inline scripts pass `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)