### PR TITLE
fix(contribute): verify reported PR server-side before trusting it (#2565)

### DIFF
--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -557,6 +557,61 @@ func (h *ContributeWSHub) markTaskCompleted(repo string, number int, prURL strin
 	}
 }
 
+// verifyReportedPR checks a client-reported PR URL against GitHub server-side
+// before the hub trusts it for the LONG cooldown or for trust credit
+// (kubestellar/hive#2565). The contributor relay scrapes a PR URL from tmux
+// output and reports it on task_complete, preferring the assigned repo but
+// falling back to the FIRST PR URL mentioned anywhere in the output — so the
+// field is entirely client-supplied and, on its own, must not drive the 168h
+// cooldown or newcomer→contributor promotion. #2437 raised the bar (PR required)
+// but left this hole open because PRURL stayed unverified.
+//
+// It returns true only when the reported PR (1) exists, (2) has a BASE repo
+// matching the assignment's repo, and (3) is authored by the connected
+// contributor. Any other outcome — no URL reported, unparseable URL, wrong repo,
+// wrong author, or a GitHub API error — returns false, and the completion is
+// treated as an unverified/no-PR completion (short cooldown, no trust credit).
+//
+// Degradation is deliberate and safe: on a GitHub error (rate limit, transient,
+// 404, or no client configured) we fail CLOSED on TRUST (no promotion credit)
+// but never crash the completion handler or strand the contributor — the issue
+// still gets the short anti-duplicate cooldown and the contributor keeps its
+// TasksCompleted credit; only the PR-gated rewards are withheld. The reason is
+// always logged for audit. We do not retry here: a completion is a single
+// user-driven event, the relay can re-report on a later completion, and a
+// blocking retry would hold the hub read loop.
+func (h *ContributeWSHub) verifyReportedPR(assignedRepo, prURL, contributorUsername string) bool {
+	if prURL == "" {
+		return false
+	}
+	if h.server == nil || h.server.deps == nil || h.server.deps.GHClient == nil {
+		// No GitHub client (hive booted without credentials, or a bare test hub):
+		// we cannot verify, so we must not grant trust. Degrade to unverified.
+		h.logger.Warn("[contribute-ws] PR verification skipped: no github client",
+			"repo", assignedRepo, "pr_url", prURL, "username", contributorUsername)
+		return false
+	}
+	ctx := h.server.deps.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	res := h.server.deps.GHClient.VerifyReportedPR(ctx, assignedRepo, prURL, contributorUsername)
+	if res.Verified {
+		h.logger.Info("[contribute-ws] reported PR verified",
+			"repo", assignedRepo, "pr_url", prURL, "username", contributorUsername,
+			"author", res.Author, "base_repo", res.BaseRepo)
+		return true
+	}
+	// Distinguish a clean negative from an API error only in the log; both
+	// downgrade to unverified.
+	logArgs := []any{"repo", assignedRepo, "pr_url", prURL, "username", contributorUsername, "reason", res.Reason}
+	if res.Err != nil {
+		logArgs = append(logArgs, "error", res.Err.Error())
+	}
+	h.logger.Warn("[contribute-ws] reported PR NOT verified — treating completion as no-PR", logArgs...)
+	return false
+}
+
 // cooldownForLocked returns the cooldown duration to apply to key. Callers must
 // already hold completedMu. When no per-task override was recorded (older
 // on-disk entries, or hubs built directly in tests) it falls back to the full
@@ -1234,31 +1289,52 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				contributor.mu.Unlock()
 
 				if hasTask {
+					// #2565: the reported PR URL is client-supplied (tmux-scraped by
+					// the relay), so before it drives the LONG cooldown OR trust credit
+					// we verify it server-side against GitHub — it must exist, have a
+					// base repo matching THIS assignment, and be authored by this
+					// contributor. Anything else (no URL, wrong repo/author, API error)
+					// downgrades to an unverified/no-PR completion: the short cooldown
+					// and no trust credit. This closes the hole #2437 left open (the
+					// bar was "a PR was reported", still trusting an unverified field).
+					// verifiedPR is the ONLY value allowed to unlock the PR-gated
+					// rewards below; the raw msg.PRURL is never trusted directly again.
+					verifiedPR := ""
+					if completedTask != nil && h.verifyReportedPR(completedTask.Repo, msg.PRURL, contributor.profile.GitHubUsername) {
+						verifiedPR = msg.PRURL
+					}
 					if completedTask != nil {
-						// #2393 item 7: keep the full week-long cooldown only when a
-						// PR was actually reported; an idle-but-no-PR completion gets
-						// the short cooldown so the issue is not locked for a week.
-						h.markTaskCompleted(completedTask.Repo, completedTask.Number, msg.PRURL)
+						// #2393 item 7 + #2565: the full week-long cooldown is applied
+						// only for a VERIFIED PR; an unverified or no-PR completion gets
+						// the short cooldown so the issue is not locked for a week (and,
+						// per #2492/#2557, still gets a non-zero cooldown so it is not
+						// instantly re-offered in a tight loop).
+						h.markTaskCompleted(completedTask.Repo, completedTask.Number, verifiedPR)
 					}
 					h.addActivity(contributor.profile.GitHubUsername, "completed", contributor.role, contributor.cliBackend, contributor.model, msg.TaskID)
 					h.logger.Info("[contribute-ws] task complete",
 						"username", contributor.profile.GitHubUsername,
 						"task", msg.TaskID,
 						"result", msg.Result,
+						"pr_verified", verifiedPR != "",
 					)
 					contributor.mu.Lock()
 					contributor.profile.TasksCompleted++
-					if msg.PRURL != "" {
+					// Trust credit is gated on the VERIFIED PR, not the reported one:
+					// counting the raw self-reported field would hand out
+					// contents:write / pulls:write for a PR that was never shown to
+					// exist, belongs to another repo, or was authored by someone else.
+					if verifiedPR != "" {
 						contributor.profile.TasksWithPR++
 					}
 					contributor.profile.LastActive = time.Now().UTC().Format(time.RFC3339)
 					if completedTask != nil {
 						contributor.profile.LastCompletedTask = completedTask
 					}
-					// Promote on completions that actually produced a pull
-					// request. Completion is self-reported, so counting bare
-					// task_complete messages would hand out contents:write and
-					// pulls:write for work that was never shown to exist.
+					// Promote on completions that produced a VERIFIED pull request.
+					// Completion is self-reported, so counting bare task_complete
+					// messages — or unverified PR URLs — would hand out contents:write
+					// and pulls:write for work that was never shown to exist.
 					if contributor.profile.TrustTier == "newcomer" && contributor.profile.TasksWithPR >= contributorAutoPromoteAt {
 						contributor.profile.TrustTier = "contributor"
 						h.logger.Info("[contribute-ws] auto-promoted", "username", contributor.profile.GitHubUsername)

--- a/v2/pkg/dashboard/contribute_ws_integration_test.go
+++ b/v2/pkg/dashboard/contribute_ws_integration_test.go
@@ -330,6 +330,15 @@ func TestIntegration_SelectTask_PromotionRequiresPR(t *testing.T) {
 	s, ts := setupWSTest(t)
 	defer ts.Close()
 
+	// #2565: TasksWithPR / promotion now require the reported PR to be VERIFIED
+	// server-side (exists, base repo == assignment repo, author == contributor).
+	// Install a GitHub mock that returns, for any pulls lookup, a PR in
+	// myorg/repo1 authored by "promotion-user" so the PR-shipping loop below can
+	// legitimately advance TasksWithPR. Without this the reported URL stays
+	// unverified and (correctly) earns no trust credit — which is what the
+	// wrong-author/wrong-repo/error tests assert instead.
+	s.deps = verifyDepsFor(t, "myorg", "repo1", "promotion-user")
+
 	body := `{"github_username":"promotion-user"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")

--- a/v2/pkg/dashboard/contribute_ws_pr_verify_test.go
+++ b/v2/pkg/dashboard/contribute_ws_pr_verify_test.go
@@ -1,0 +1,194 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// verifyDepsFor returns Dependencies whose GHClient answers any pulls lookup with
+// a PR in owner/repo authored by author, so #2565 server-side PR verification
+// passes. The PR number is echoed from the request path so distinct rounds each
+// resolve to their own PR. Shared by the WS integration/promotion tests.
+func verifyDepsFor(t *testing.T, owner, repo, author string) *Dependencies {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	full := owner + "/" + repo
+	prefix := "/repos/" + full + "/pulls/"
+	mux := http.NewServeMux()
+	mux.HandleFunc(prefix, func(w http.ResponseWriter, r *http.Request) {
+		num := strings.TrimPrefix(r.URL.Path, prefix)
+		n, _ := strconv.Atoi(num)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"number":   n,
+			"html_url": "https://github.com/" + full + "/pull/" + num,
+			"user":     map[string]any{"login": author},
+			"base": map[string]any{
+				"repo": map[string]any{
+					"name":      repo,
+					"full_name": full,
+					"owner":     map[string]any{"login": owner},
+				},
+			},
+		})
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return &Dependencies{
+		GHClient: ghpkg.NewClientForTest(ts.URL, owner, []string{repo}, logger),
+		Logger:   logger,
+		Ctx:      context.Background(),
+	}
+}
+
+// prVerifyHub builds a hub whose GHClient points at a mux serving a single PR
+// (base repo "myorg/repo1", author authorLogin, number prNum). status controls
+// the HTTP response so callers can exercise the API-error path.
+func prVerifyHub(t *testing.T, status int, authorLogin string, prNum int) *ContributeWSHub {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if status != http.StatusOK {
+			http.Error(w, `{"message":"boom"}`, status)
+			return
+		}
+		body := map[string]any{
+			"number":   prNum,
+			"html_url": "https://github.com/myorg/repo1/pull/" + strconv.Itoa(prNum),
+			"user":     map[string]any{"login": authorLogin},
+			"base": map[string]any{
+				"repo": map[string]any{
+					"name":      "repo1",
+					"full_name": "myorg/repo1",
+					"owner":     map[string]any{"login": "myorg"},
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(body)
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	s := NewServer(0, logger)
+	deps := testDeps(t)
+	deps.GHClient = ghpkg.NewClientForTest(ts.URL, "myorg", []string{"repo1"}, logger)
+	s.RegisterAPI(deps)
+	return NewContributeWSHub(logger, s)
+}
+
+const prVerifyURL = "https://github.com/myorg/repo1/pull/7"
+
+// TestVerifyReportedPR_HubHappyPath: all three checks pass → verified, and a
+// verified completion earns the FULL (168h) cooldown, mirroring what the
+// task_complete handler does with the verified URL.
+func TestVerifyReportedPR_HubHappyPath(t *testing.T) {
+	hub := prVerifyHub(t, http.StatusOK, "alice", 7)
+
+	if !hub.verifyReportedPR("repo1", prVerifyURL, "alice") {
+		t.Fatalf("expected verification to pass for matching repo+author")
+	}
+
+	// The handler feeds the verified URL to markTaskCompleted → full cooldown.
+	hub.markTaskCompleted("myorg/repo1", 7, prVerifyURL)
+	hub.completedMu.Lock()
+	hub.completedTasks["myorg/repo1#7"] = time.Now().Add(-(completedNoPRCooldownHours + 1) * time.Hour)
+	hub.completedMu.Unlock()
+	if !hub.isTaskInCooldown("myorg/repo1", 7) {
+		t.Fatalf("verified PR completion should hold the full %dh cooldown, not the short %dh one",
+			completedTaskCooldownHours, completedNoPRCooldownHours)
+	}
+}
+
+// TestVerifyReportedPR_HubWrongAuthor: the reported PR exists in the right repo
+// but was authored by someone else → NOT verified → the handler would pass ""
+// to markTaskCompleted → SHORT cooldown, no trust credit.
+func TestVerifyReportedPR_HubWrongAuthor(t *testing.T) {
+	hub := prVerifyHub(t, http.StatusOK, "mallory", 7)
+
+	if hub.verifyReportedPR("repo1", prVerifyURL, "alice") {
+		t.Fatalf("expected verification to FAIL for wrong author")
+	}
+	assertShortCooldown(t, hub, "myorg/repo1", 7)
+}
+
+// TestVerifyReportedPR_HubWrongRepo: the reported URL points at a DIFFERENT repo
+// than the assignment (the relay's "first PR URL anywhere" fallback) → NOT
+// verified even though the PR exists and the author matches.
+func TestVerifyReportedPR_HubWrongRepo(t *testing.T) {
+	hub := prVerifyHub(t, http.StatusOK, "alice", 7)
+
+	// Assignment repo is "other", but the reported/served PR belongs to repo1.
+	if hub.verifyReportedPR("other", prVerifyURL, "alice") {
+		t.Fatalf("expected verification to FAIL when PR base repo != assigned repo")
+	}
+}
+
+// TestVerifyReportedPR_HubGHError: a transient GitHub API failure must degrade
+// safely — no crash, no trust — and the completion falls back to the short
+// cooldown so the contributor is not stranded.
+func TestVerifyReportedPR_HubGHError(t *testing.T) {
+	hub := prVerifyHub(t, http.StatusInternalServerError, "alice", 7)
+
+	if hub.verifyReportedPR("repo1", prVerifyURL, "alice") {
+		t.Fatalf("expected verification to FAIL (degrade) on GitHub API error")
+	}
+	assertShortCooldown(t, hub, "myorg/repo1", 7)
+}
+
+// TestVerifyReportedPR_HubEmptyURL: no PR reported → not verified, without any
+// GitHub call.
+func TestVerifyReportedPR_HubEmptyURL(t *testing.T) {
+	hub := prVerifyHub(t, http.StatusOK, "alice", 7)
+	if hub.verifyReportedPR("repo1", "", "alice") {
+		t.Fatalf("empty PR URL must never verify")
+	}
+}
+
+// TestVerifyReportedPR_HubNoClient: a hub without a GitHub client cannot verify,
+// so it must degrade to unverified rather than crash.
+func TestVerifyReportedPR_HubNoClient(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	s := NewServer(0, logger)
+	deps := testDeps(t)
+	deps.GHClient = nil
+	s.RegisterAPI(deps)
+	hub := NewContributeWSHub(logger, s)
+
+	if hub.verifyReportedPR("repo1", prVerifyURL, "alice") {
+		t.Fatalf("no-client hub must not verify")
+	}
+}
+
+// assertShortCooldown confirms that a completion recorded WITHOUT a verified PR
+// (empty URL passed to markTaskCompleted, exactly what the handler does on a
+// failed verification) gets the short no-PR cooldown, preserving the
+// anti-duplicate protection (#2492/#2557) without over-rewarding.
+func assertShortCooldown(t *testing.T, hub *ContributeWSHub, repo string, num int) {
+	t.Helper()
+	hub.markTaskCompleted(repo, num, "") // unverified → no PR credit for cooldown
+	key := repo + "#" + strconv.Itoa(num)
+	if !hub.isTaskInCooldown(repo, num) {
+		t.Fatalf("unverified completion should still hold a short cooldown (anti-dup), got none")
+	}
+	// Aged just past the short window → released, proving it is NOT the 168h lock.
+	hub.completedMu.Lock()
+	hub.completedTasks[key] = time.Now().Add(-(completedNoPRCooldownHours + 1) * time.Hour)
+	hub.completedMu.Unlock()
+	if hub.isTaskInCooldown(repo, num) {
+		t.Fatalf("unverified completion should release after the short %dh window, not hold the full %dh lock",
+			completedNoPRCooldownHours, completedTaskCooldownHours)
+	}
+}

--- a/v2/pkg/dashboard/contribute_ws_test.go
+++ b/v2/pkg/dashboard/contribute_ws_test.go
@@ -553,6 +553,12 @@ func TestWSAutoPromotionRequiresReportedPR(t *testing.T) {
 	s, ts := setupWSTest(t)
 	defer ts.Close()
 
+	// #2565: PR-backed promotion now requires server-side verification. Install a
+	// GitHub mock answering the pulls lookup with a PR in acme/widgets authored by
+	// "promote-user", matching the completions this test reports, so the verified
+	// path can legitimately grant credit + promotion.
+	s.deps = verifyDepsFor(t, "acme", "widgets", "promote-user")
+
 	body := `{"github_username":"promote-user"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")

--- a/v2/pkg/github/pullrequest_verify.go
+++ b/v2/pkg/github/pullrequest_verify.go
@@ -1,0 +1,161 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// PRRef identifies a pull request parsed out of a GitHub PR URL.
+type PRRef struct {
+	Owner  string
+	Repo   string
+	Number int
+}
+
+// FullName returns "owner/repo".
+func (r PRRef) FullName() string { return r.Owner + "/" + r.Repo }
+
+// prURLPattern matches the "…/{owner}/{repo}/pull/{number}" tail of a GitHub PR
+// URL. It is deliberately host-agnostic (works for github.com AND GHE hosts) and
+// anchored on the "/pull/" segment so trailing paths (/files, #discussion) and
+// query strings do not defeat it. Only the FIRST such match in the string is
+// used by ParsePRURL — the reported URL is expected to be a single PR link.
+var prURLPattern = regexp.MustCompile(`([^/\s]+)/([^/\s]+)/pull/(\d+)`)
+
+// ParsePRURL extracts owner, repo and PR number from a GitHub pull-request URL.
+// It accepts full URLs (https://github.com/owner/repo/pull/123, GHE hosts, with
+// or without trailing path/fragment/query) and is intentionally strict about the
+// "/pull/<number>" shape so an arbitrary non-PR URL does not parse. It returns an
+// error when no PR reference can be found.
+func ParsePRURL(prURL string) (PRRef, error) {
+	s := strings.TrimSpace(prURL)
+	if s == "" {
+		return PRRef{}, fmt.Errorf("empty PR URL")
+	}
+	m := prURLPattern.FindStringSubmatch(s)
+	if m == nil {
+		return PRRef{}, fmt.Errorf("not a recognizable GitHub pull request URL: %q", prURL)
+	}
+	num, err := strconv.Atoi(m[3])
+	if err != nil || num <= 0 {
+		return PRRef{}, fmt.Errorf("invalid PR number in URL %q", prURL)
+	}
+	return PRRef{Owner: m[1], Repo: m[2], Number: num}, nil
+}
+
+// PRVerification is the result of VerifyReportedPR. Verified is true only when
+// the PR exists, its base repo matches the expected repo, and its author matches
+// the expected contributor. When Verified is false, Reason explains why (used for
+// logging/audit) and Err is set when the failure was a GitHub API error (as
+// opposed to a clean "PR does not match" negative).
+type PRVerification struct {
+	Verified bool
+	Reason   string
+	Err      error
+	// Author is the resolved PR author login (best-effort, for logging).
+	Author string
+	// BaseRepo is the resolved PR base repo "owner/repo" (best-effort, for logging).
+	BaseRepo string
+}
+
+// VerifyReportedPR checks a client-reported PR URL against GitHub server-side
+// before the hub is willing to trust it (see kubestellar/hive#2565). The
+// contributor relay scrapes a PR URL out of tmux output and reports it on
+// task_complete; that value is entirely client-supplied, so on its own it must
+// not drive the long completion cooldown or trust promotion. This resolves the
+// URL via the GitHub API and confirms three things:
+//
+//  1. Exists      — the PR resolves via GET /repos/{owner}/{repo}/pulls/{number}.
+//  2. Assigned    — the PR's BASE repo equals expectedRepo (the repo of the
+//     assignment). This closes the relay's "first PR URL mentioned anywhere in
+//     the tmux tail" fallback: an unrelated PR link no longer counts.
+//  3. Author      — the PR author login equals expectedAuthor (the connected
+//     contributor's GitHub identity, which the hub already knows).
+//
+// expectedRepo may be a bare repo name ("repo") or "owner/repo"; only the repo
+// component is compared when no owner is supplied, so callers that track just the
+// short repo name still match. Comparisons are case-insensitive (GitHub logins
+// and repo names are).
+//
+// The method never panics and never returns an error to abort a caller: a
+// GitHub API failure (rate limit, transient network, 404) yields
+// Verified=false with Err set, so the completion handler can degrade to the
+// short cooldown / no trust credit rather than crashing or stranding the
+// contributor. A nil client (hive without GitHub credentials) is treated the
+// same way — it cannot verify, so it must not grant trust.
+func (c *Client) VerifyReportedPR(ctx context.Context, expectedRepo, prURL, expectedAuthor string) PRVerification {
+	if c == nil || c.client == nil {
+		return PRVerification{Reason: "no github client configured", Err: ErrNoGitHubClient}
+	}
+
+	ref, err := ParsePRURL(prURL)
+	if err != nil {
+		// A malformed / non-PR URL is a clean negative, not an API error: there
+		// is nothing to look up. No Err → caller treats it as "no verified PR".
+		return PRVerification{Reason: "unparseable PR URL: " + err.Error()}
+	}
+
+	pr, _, err := c.client.PullRequests.Get(ctx, ref.Owner, ref.Repo, ref.Number)
+	if err != nil {
+		// Transient/permission/404 — fail CLOSED on trust, but surface Err so the
+		// caller logs it and treats the completion as unverified rather than
+		// aborting. We do NOT distinguish 404 here: a PR the App cannot see is,
+		// for trust purposes, indistinguishable from one that does not exist.
+		return PRVerification{Reason: "github lookup failed", Err: err}
+	}
+	if pr == nil {
+		return PRVerification{Reason: "github returned no pull request"}
+	}
+
+	author := safeGetLogin(pr.GetUser())
+	baseRepo := pr.GetBase().GetRepo().GetFullName() // "owner/repo"
+	v := PRVerification{Author: author, BaseRepo: baseRepo}
+
+	if !prBaseRepoMatches(baseRepo, expectedRepo) {
+		v.Reason = fmt.Sprintf("PR base repo %q does not match assigned repo %q", baseRepo, expectedRepo)
+		return v
+	}
+	if expectedAuthor == "" || author == "" || !strings.EqualFold(author, expectedAuthor) {
+		v.Reason = fmt.Sprintf("PR author %q does not match contributor %q", author, expectedAuthor)
+		return v
+	}
+
+	v.Verified = true
+	return v
+}
+
+// prBaseRepoMatches reports whether a PR's base repo ("owner/repo", from the API)
+// satisfies the expected repo. expected may be bare ("repo") or "owner/repo".
+// When expected carries an owner, both owner and repo must match; when it is a
+// bare name, only the repo component is compared (callers that track only the
+// short repo name still match). All comparisons are case-insensitive.
+func prBaseRepoMatches(baseFullName, expected string) bool {
+	baseFullName = strings.TrimSpace(baseFullName)
+	expected = strings.TrimSpace(expected)
+	if baseFullName == "" || expected == "" {
+		return false
+	}
+	baseOwner, baseRepo := splitRepo(baseFullName)
+	if expOwner, expRepo := splitRepo(expected); expOwner != "" {
+		return strings.EqualFold(expOwner, baseOwner) && strings.EqualFold(expRepo, baseRepo)
+	} else {
+		return strings.EqualFold(expRepo, baseRepo)
+	}
+}
+
+// splitRepo splits "owner/repo" into its parts. A bare "repo" yields an empty
+// owner. Anything with more than one slash keeps only the last two segments.
+func splitRepo(full string) (owner, repo string) {
+	full = strings.Trim(strings.TrimSpace(full), "/")
+	if full == "" {
+		return "", ""
+	}
+	parts := strings.Split(full, "/")
+	if len(parts) == 1 {
+		return "", parts[0]
+	}
+	return parts[len(parts)-2], parts[len(parts)-1]
+}

--- a/v2/pkg/github/pullrequest_verify_test.go
+++ b/v2/pkg/github/pullrequest_verify_test.go
@@ -1,0 +1,235 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func verifyTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func TestParsePRURL(t *testing.T) {
+	cases := []struct {
+		name        string
+		url         string
+		wantErr     bool
+		owner, repo string
+		number      int
+	}{
+		{"canonical", "https://github.com/kubestellar/hive/pull/2565", false, "kubestellar", "hive", 2565},
+		{"trailing files", "https://github.com/kubestellar/hive/pull/2565/files", false, "kubestellar", "hive", 2565},
+		{"with fragment", "https://github.com/o/r/pull/7#discussion_r1", false, "o", "r", 7},
+		{"with query", "https://github.com/o/r/pull/7?w=1", false, "o", "r", 7},
+		{"ghe host", "https://ghe.example.com/o/r/pull/12", false, "o", "r", 12},
+		{"whitespace", "   https://github.com/o/r/pull/9   ", false, "o", "r", 9},
+		{"empty", "", true, "", "", 0},
+		{"not a pr", "https://github.com/o/r/issues/9", true, "", "", 0},
+		{"random text", "the agent finished the work", true, "", "", 0},
+		{"zero number", "https://github.com/o/r/pull/0", true, "", "", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ref, err := ParsePRURL(tc.url)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %+v", tc.url, ref)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.url, err)
+			}
+			if ref.Owner != tc.owner || ref.Repo != tc.repo || ref.Number != tc.number {
+				t.Fatalf("parsed %+v, want %s/%s#%d", ref, tc.owner, tc.repo, tc.number)
+			}
+		})
+	}
+}
+
+func TestPRBaseRepoMatches(t *testing.T) {
+	cases := []struct {
+		base, expected string
+		want           bool
+	}{
+		{"kubestellar/hive", "hive", true},               // bare expected, repo matches
+		{"kubestellar/hive", "Hive", true},               // case-insensitive
+		{"kubestellar/hive", "kubestellar/hive", true},   // full match
+		{"kubestellar/hive", "someone/hive", false},      // owner differs
+		{"kubestellar/hive", "kubestellar/other", false}, // repo differs
+		{"kubestellar/hive", "other", false},             // bare, repo differs
+		{"", "hive", false},                              // empty base
+		{"kubestellar/hive", "", false},                  // empty expected
+	}
+	for _, tc := range cases {
+		if got := prBaseRepoMatches(tc.base, tc.expected); got != tc.want {
+			t.Errorf("prBaseRepoMatches(%q,%q)=%v want %v", tc.base, tc.expected, got, tc.want)
+		}
+	}
+}
+
+// prJSON builds a minimal go-github PR body with the base repo full name and
+// author login the tests care about.
+func prJSON(baseFullName, authorLogin string, number int) string {
+	owner, repo := splitRepo(baseFullName)
+	m := map[string]any{
+		"number":   number,
+		"html_url": "https://github.com/" + baseFullName + "/pull/" + itoa(number),
+		"user":     map[string]any{"login": authorLogin},
+		"base": map[string]any{
+			"repo": map[string]any{
+				"name":      repo,
+				"full_name": baseFullName,
+				"owner":     map[string]any{"login": owner},
+			},
+		},
+	}
+	b, _ := json.Marshal(m)
+	return string(b)
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// verifyMux serves GET /repos/{owner}/{repo}/pulls/{number}. When status != 200
+// it returns an error body to exercise the API-error path.
+func verifyMux(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if status != http.StatusOK {
+			http.Error(w, `{"message":"boom"}`, status)
+			return
+		}
+		_, _ = io.WriteString(w, body)
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestVerifyReportedPR_AllChecksPass(t *testing.T) {
+	ts := verifyMux(t, http.StatusOK, prJSON("kubestellar/hive", "alice", 2565))
+	c := NewClientForTest(ts.URL, "kubestellar", []string{"hive"}, verifyTestLogger())
+
+	res := c.VerifyReportedPR(context.Background(), "hive", "https://github.com/kubestellar/hive/pull/2565", "alice")
+	if !res.Verified {
+		t.Fatalf("expected verified, got reason=%q err=%v", res.Reason, res.Err)
+	}
+	if res.Author != "alice" || res.BaseRepo != "kubestellar/hive" {
+		t.Fatalf("unexpected resolved fields: %+v", res)
+	}
+}
+
+func TestVerifyReportedPR_CaseInsensitiveAuthorAndRepo(t *testing.T) {
+	ts := verifyMux(t, http.StatusOK, prJSON("KubeStellar/Hive", "Alice", 2565))
+	c := NewClientForTest(ts.URL, "kubestellar", []string{"hive"}, verifyTestLogger())
+
+	res := c.VerifyReportedPR(context.Background(), "kubestellar/hive", "https://github.com/kubestellar/hive/pull/2565", "alice")
+	if !res.Verified {
+		t.Fatalf("expected verified (case-insensitive), reason=%q", res.Reason)
+	}
+}
+
+func TestVerifyReportedPR_WrongRepo(t *testing.T) {
+	// PR base repo is a DIFFERENT repo than the assignment — the "first PR URL
+	// mentioned anywhere" fallback risk. Must NOT verify.
+	ts := verifyMux(t, http.StatusOK, prJSON("kubestellar/other", "alice", 99))
+	c := NewClientForTest(ts.URL, "kubestellar", []string{"hive"}, verifyTestLogger())
+
+	res := c.VerifyReportedPR(context.Background(), "hive", "https://github.com/kubestellar/other/pull/99", "alice")
+	if res.Verified {
+		t.Fatalf("expected NOT verified for wrong repo")
+	}
+	if res.Err != nil {
+		t.Fatalf("wrong-repo is a clean negative, want no Err, got %v", res.Err)
+	}
+}
+
+func TestVerifyReportedPR_WrongAuthor(t *testing.T) {
+	ts := verifyMux(t, http.StatusOK, prJSON("kubestellar/hive", "mallory", 2565))
+	c := NewClientForTest(ts.URL, "kubestellar", []string{"hive"}, verifyTestLogger())
+
+	res := c.VerifyReportedPR(context.Background(), "hive", "https://github.com/kubestellar/hive/pull/2565", "alice")
+	if res.Verified {
+		t.Fatalf("expected NOT verified for wrong author")
+	}
+	if res.Err != nil {
+		t.Fatalf("wrong-author is a clean negative, want no Err, got %v", res.Err)
+	}
+}
+
+func TestVerifyReportedPR_DoesNotExist(t *testing.T) {
+	ts := verifyMux(t, http.StatusNotFound, "")
+	c := NewClientForTest(ts.URL, "kubestellar", []string{"hive"}, verifyTestLogger())
+
+	res := c.VerifyReportedPR(context.Background(), "hive", "https://github.com/kubestellar/hive/pull/404", "alice")
+	if res.Verified {
+		t.Fatalf("expected NOT verified for nonexistent PR")
+	}
+	if res.Err == nil {
+		t.Fatalf("a 404 lookup should surface Err so the caller can log it")
+	}
+}
+
+func TestVerifyReportedPR_APIError(t *testing.T) {
+	ts := verifyMux(t, http.StatusInternalServerError, "")
+	c := NewClientForTest(ts.URL, "kubestellar", []string{"hive"}, verifyTestLogger())
+
+	res := c.VerifyReportedPR(context.Background(), "hive", "https://github.com/kubestellar/hive/pull/2565", "alice")
+	if res.Verified {
+		t.Fatalf("expected NOT verified on API error (fail closed on trust)")
+	}
+	if res.Err == nil {
+		t.Fatalf("transient API error should surface Err")
+	}
+}
+
+func TestVerifyReportedPR_UnparseableURL(t *testing.T) {
+	ts := verifyMux(t, http.StatusOK, prJSON("kubestellar/hive", "alice", 1))
+	c := NewClientForTest(ts.URL, "kubestellar", []string{"hive"}, verifyTestLogger())
+
+	res := c.VerifyReportedPR(context.Background(), "hive", "not a url", "alice")
+	if res.Verified {
+		t.Fatalf("expected NOT verified for unparseable URL")
+	}
+	if res.Err != nil {
+		t.Fatalf("unparseable URL is a clean negative (nothing to look up), got Err %v", res.Err)
+	}
+}
+
+func TestVerifyReportedPR_NilClient(t *testing.T) {
+	var c *Client
+	res := c.VerifyReportedPR(context.Background(), "hive", "https://github.com/kubestellar/hive/pull/1", "alice")
+	if res.Verified {
+		t.Fatalf("nil client must never verify")
+	}
+	if res.Err == nil {
+		t.Fatalf("nil client should report ErrNoGitHubClient")
+	}
+}


### PR DESCRIPTION
## Problem

The contributor relay scrapes a GitHub PR URL out of the tmux tail (`bin/contributor-relay.sh`, preferring the assigned repo but **falling back to the first PR URL mentioned anywhere in the output**) and sends it on `task_complete`. The hub trusted that single **client-supplied, unverified** field to drive two decisions with very different risk:

- **Cooldown length** (`contribute_ws.go` `markTaskCompleted`): a non-empty `PRURL` → **168h** cooldown; empty → **4h**.
- **Trust** (`task_complete` handler): the same field incremented **`TasksWithPR`** and could trigger **newcomer→contributor** auto-promotion, granting `contents:write` / `pulls:write`.

So a false positive — an unrelated or nonexistent PR link scraped from the terminal — could earn a **week-long cooldown AND promotion credit**. **#2437** already noted this "raises the bar but does not close the hole" because `PRURL` stayed client-supplied. Jorge has live evidence of issues marked complete, then reassigned + re-PR'd.

## Fix — Jorge's Option 1: verify server-side before trusting

Before a reported URL unlocks the long cooldown or any trust credit, it is verified against GitHub server-side, reusing the **existing** `pkg/github` App/installation client (`s.deps.GHClient`, via `GoGitHub().PullRequests.Get`) — no new HTTP path. Three checks must all hold:

1. **Exists** — the PR resolves via `GET /repos/{owner}/{repo}/pulls/{number}`.
2. **Assigned repo** — the PR's **base** repo matches the assignment's repo. This directly closes the relay's "first PR URL mentioned anywhere" fallback: an unrelated PR link no longer counts.
3. **Author** — the PR author matches the connected contributor's GitHub identity (which the hub already knows).

Only a **verified** PR earns the **168h** cooldown, the **`TasksWithPR`** increment, and **promotion** eligibility. `TasksCompleted` and the (short) anti-duplicate cooldown always happen regardless.

### Safe degradation

Any verification failure — no URL, unparseable URL, wrong repo, wrong author, **GitHub API error** (rate limit / transient / 404), or no client configured — degrades to an **unverified/no-PR completion**: the short cooldown, **no trust credit**, reason logged. GitHub errors **fail closed on trust** but never crash the completion handler or strand the contributor. We do **not** retry inside the handler (a completion is a single event; the relay can re-report on a later completion), documented in the code. The short-cooldown default preserves the anti-duplicate protections from **#2492/#2557**.

Wire-compatible: the relay still sends what it sends; the change is entirely hub-side verification of the reported URL.

## Changes

- `v2/pkg/github/pullrequest_verify.go` — `ParsePRURL` (host-agnostic, strict `/pull/<n>` parse) + `VerifyReportedPR` (the three checks; returns structured result with `Err` set only on API errors).
- `v2/pkg/dashboard/contribute_ws.go` — new `verifyReportedPR` hub helper; `task_complete` gates the 168h cooldown, `TasksWithPR++`, and promotion on the **verified** URL rather than raw `msg.PRURL`.

## Tests

- **github pkg**: URL parsing table, repo-match logic, and `VerifyReportedPR` for all-pass, case-insensitive, wrong-repo, wrong-author, 404, API-error, unparseable, nil-client.
- **dashboard**: hub `verifyReportedPR` happy path (→ full 168h cooldown), wrong-author / wrong-repo / GH-error (→ short cooldown, no credit, no crash), empty URL, no-client; plus the existing full-WebSocket promotion tests updated to mock a matching PR so the verified path still grants credit + promotion.

`go build` / `go vet` / `gofmt` clean.

Fixes #2565