### PR TITLE
✨ feat(contribute): live SSE command center for the Operations tab

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -111,6 +111,13 @@ func (s *Server) registerContributeRoutes() {
 	s.mux.HandleFunc("GET /api/contribute/status", s.handleContributeStatus)
 	s.mux.HandleFunc("GET /api/contribute/activity", s.handleContributeActivity)
 	s.mux.HandleFunc("GET /api/contribute/fleet", s.handleContributeFleet)
+	// Read-only live event stream for the Operations command center. Under the
+	// /api/contribute* prefix, so isPublicPath (server.go) makes it PUBLIC —
+	// anonymous viewers may subscribe to this read-only info. GET only.
+	s.mux.HandleFunc("GET /api/contribute/events", s.handleContributeEvents)
+	// Read-only ready-work QUEUE snapshot (the admissible issues waiting to be
+	// picked off). Also public; a JSON fallback for the SSE hello payload.
+	s.mux.HandleFunc("GET /api/contribute/queue", s.handleContributeQueue)
 	s.mux.HandleFunc("GET /api/contributors", s.handleContributorsList)
 	s.mux.HandleFunc("GET /api/contributors/{id}", s.handleContributorGet)
 	s.mux.HandleFunc("PUT /api/contributors/{id}/trust", s.handleContributorTrust)
@@ -480,6 +487,70 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .admin-modal-btns button{font-size:.8rem;padding:6px 14px;border-radius:6px;cursor:pointer;font-family:inherit;border:1px solid #30363d;background:#21262d;color:#c9d1d9}
 .admin-modal-btns button.confirm{background:#da3633;border-color:#f85149;color:#fff}
 .admin-note{color:#6e7681;font-size:.76rem;margin-top:10px;line-height:1.5}
+/* ── Operations command center — live SSE-driven queue / travel / dev-log /
+   achievements / army framing. Subtle-professional motion only; degrades to the
+   existing poll when SSE is unavailable. Additive, read-only. ─────────────── */
+.cc-live{display:inline-flex;align-items:center;gap:6px;font-size:.68rem;font-weight:600;padding:2px 8px;border-radius:999px;margin-left:auto;border:1px solid rgba(63,185,80,.3);background:rgba(63,185,80,.1);color:#3fb950}
+.cc-live .cc-live-dot{width:7px;height:7px;border-radius:50%%;background:#3fb950;animation:pulse 2s infinite}
+.cc-live.stale{border-color:rgba(210,153,34,.3);background:rgba(210,153,34,.1);color:#d29922}
+.cc-live.stale .cc-live-dot{background:#d29922;animation:none}
+/* Army roster header line under the clanker card */
+.cc-army{display:flex;align-items:center;gap:14px;padding:10px 20px;border-bottom:1px solid #21262d;font-size:.78rem;color:#8b949e}
+.cc-army b{color:#e6edf3;font-weight:600}
+.cc-army-stat{display:inline-flex;align-items:center;gap:5px}
+.cc-army-stat .dot{width:7px;height:7px;border-radius:50%%}
+.cc-army-stat.working .dot{background:#58a6ff}
+.cc-army-stat.reviewing .dot{background:#d29922}
+.cc-army-stat.idle .dot{background:#8b949e}
+/* Clanker rows: enter pop-in / leave fade so the roster feels alive */
+@keyframes cc-popin{from{opacity:0;transform:translateY(-6px) scale(.98)}to{opacity:1;transform:none}}
+@keyframes cc-fadeout{from{opacity:1}to{opacity:0;transform:translateX(8px)}}
+.clanker-row.cc-enter{animation:cc-popin .4s ease}
+.clanker-row.cc-leave{animation:cc-fadeout .5s ease forwards}
+/* A clanker actively receiving a travelling task pulses its border briefly */
+@keyframes cc-landing{0%%{box-shadow:0 0 0 0 rgba(88,166,255,.5)}100%%{box-shadow:0 0 0 6px rgba(88,166,255,0)}}
+.clanker-row.cc-landing{animation:cc-landing .8s ease}
+.clanker-status{font-size:.68rem;font-weight:600;padding:1px 7px;border-radius:999px;margin-left:6px;border:1px solid transparent}
+.clanker-status.working{background:rgba(88,166,255,.12);color:#58a6ff;border-color:rgba(88,166,255,.3)}
+.clanker-status.reviewing{background:rgba(210,153,34,.12);color:#d29922;border-color:rgba(210,153,34,.3)}
+.clanker-status.idle{background:rgba(139,148,158,.12);color:#8b949e;border-color:rgba(139,148,158,.3)}
+/* Ready-work QUEUE — the stack of issues waiting to be picked off */
+.cc-queue{max-height:340px;overflow-y:auto}
+.cc-q-item{display:flex;align-items:flex-start;gap:10px;padding:11px 20px;border-bottom:1px solid #21262d;animation:cc-popin .35s ease;position:relative}
+.cc-q-item:first-child{background:rgba(88,166,255,.05)}
+.cc-q-idx{font-size:.7rem;color:#6e7681;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;flex-shrink:0;width:22px;text-align:right;padding-top:2px}
+.cc-q-body{flex:1;min-width:0}
+.cc-q-repo{font-size:.72rem;color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.cc-q-title{font-size:.86rem;color:#e6edf3;margin:2px 0 4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.cc-q-labels{display:flex;flex-wrap:wrap;gap:4px}
+.cc-q-next{font-size:.62rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#58a6ff;flex-shrink:0;padding-top:2px}
+.cc-q-item.cc-leaving{animation:cc-fadeout .45s ease forwards}
+/* The travelling token that flies from the queue to a clanker on task_assign */
+.cc-token{position:fixed;z-index:1200;pointer-events:none;background:#1f6feb;color:#fff;font-size:.72rem;font-weight:600;padding:6px 12px;border-radius:999px;box-shadow:0 6px 20px rgba(31,111,235,.5);white-space:nowrap;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;transition:transform .9s cubic-bezier(.5,0,.2,1),opacity .9s ease;will-change:transform,opacity}
+/* Dev-log — a running chat log of the development */
+.cc-log{max-height:360px;overflow-y:auto;padding:4px 0}
+.cc-log-line{display:flex;align-items:flex-start;gap:10px;padding:8px 20px;font-size:.83rem;border-bottom:1px solid #1c2128;animation:cc-logline .45s ease}
+@keyframes cc-logline{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:none}}
+.cc-log-line:last-child{border-bottom:none}
+.cc-log-ic{flex-shrink:0}
+.cc-log-body{flex:1;min-width:0;color:#c9d1d9;line-height:1.45}
+.cc-log-body b{color:#e6edf3}
+.cc-log-body .who{color:#58a6ff;font-weight:600}
+.cc-log-body .ref{color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.78rem}
+.cc-log-time{flex-shrink:0;color:#6e7681;font-size:.72rem;white-space:nowrap;padding-top:1px}
+/* Achievement pops — tasteful badge toast, top-right, debounced */
+.cc-ach-wrap{position:fixed;top:16px;right:16px;z-index:1150;display:flex;flex-direction:column;gap:8px;pointer-events:none}
+.cc-ach{display:flex;align-items:center;gap:10px;background:linear-gradient(135deg,#161b22,#1c2333);border:1px solid rgba(210,153,34,.4);border-radius:10px;padding:10px 14px;box-shadow:0 8px 28px rgba(1,4,9,.55);animation:cc-ach-in .4s ease;max-width:300px}
+@keyframes cc-ach-in{from{opacity:0;transform:translateX(24px)}to{opacity:1;transform:none}}
+.cc-ach.cc-ach-out{animation:cc-ach-out .4s ease forwards}
+@keyframes cc-ach-out{to{opacity:0;transform:translateX(24px)}}
+.cc-ach-ic{font-size:1.3rem;flex-shrink:0}
+.cc-ach-txt{min-width:0}
+.cc-ach-h{font-size:.7rem;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:#d29922}
+.cc-ach-s{font-size:.82rem;color:#e6edf3;margin-top:1px}
+@media(prefers-reduced-motion:reduce){
+  .clanker-row.cc-enter,.clanker-row.cc-leave,.clanker-row.cc-landing,.cc-q-item,.cc-q-item.cc-leaving,.cc-log-line,.cc-ach,.cc-token{animation:none!important;transition:none!important}
+}
 </style></head><body>
 <div class="page-tabs" role="tablist">
 <button class="page-tab active" role="tab" id="ptab-onboarding" aria-selected="true" data-panel="tab-onboarding">Onboarding</button>
@@ -727,6 +798,13 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 <div>
 <div class="ops-card">
 <div class="ops-card-head"><span class="feed-dot"></span><h3>Connected clankers</h3><span class="ops-card-count" id="clanker-count"></span></div>
+<!-- Army roster header: live count + at-a-glance status split, fed by the fleet snapshot. -->
+<div class="cc-army" id="cc-army">
+  <span style="color:#e6edf3;font-weight:600">Your army</span>
+  <span class="cc-army-stat working"><span class="dot"></span><b id="cc-army-working">0</b>&nbsp;working</span>
+  <span class="cc-army-stat reviewing"><span class="dot"></span><b id="cc-army-reviewing">0</b>&nbsp;reviewing</span>
+  <span class="cc-army-stat idle"><span class="dot"></span><b id="cc-army-idle">0</b>&nbsp;idle</span>
+</div>
 <div id="clanker-list"><div class="ops-empty">Loading fleet&hellip;</div></div>
 </div>
 <div class="ops-card" style="margin-top:20px">
@@ -744,7 +822,20 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 </div>
 </div>
 <div>
+<!-- Command center: the READY-WORK QUEUE (issues waiting to be picked off, top =
+     next up) and the live DEV-LOG (a running chat log of the development). Both are
+     fed by REAL events — the queue from ActionableIssues (the same set selectTask
+     offers from), the log from the ActivityEntry SSE stream. All read-only. -->
 <div class="ops-card">
+<div class="ops-card-head"><span class="feed-dot"></span><h3>Ready-work queue</h3><span class="cc-live stale" id="cc-live"><span class="cc-live-dot"></span><span id="cc-live-label">connecting</span></span></div>
+<div class="cc-queue" id="cc-queue"><div class="ops-empty">Loading queue&hellip;</div></div>
+<p class="ops-note" style="padding:10px 20px 14px;margin:0">The stack of admissible issues waiting to be picked off &mdash; top is next up. When a clanker grabs one you&rsquo;ll see it fly from here to that clanker. Derived from this hive&rsquo;s actionable backlog; read-only.</p>
+</div>
+<div class="ops-card" style="margin-top:20px">
+<div class="ops-card-head"><span class="feed-dot"></span><h3>Development log</h3><span class="ops-card-count" id="cc-log-count"></span></div>
+<div class="cc-log" id="cc-log"><div class="ops-empty">Watching the hive&hellip;</div></div>
+</div>
+<div class="ops-card" style="margin-top:20px">
 <div class="ops-card-head"><h3>My work</h3><span class="ops-card-count" id="work-count"></span></div>
 <div class="ops-filters" role="tablist">
 <button class="ops-filter active" data-filter="all">All</button>
@@ -798,7 +889,7 @@ function activateTab(t){
   var panel=document.getElementById(dp);
   if(panel)panel.classList.add('active');
   if((dp==='tab-ops'||dp==='tab-manage')&&!adminStarted){adminStarted=true;initAdmin();}
-  if(dp==='tab-ops'&&!opsStarted){opsStarted=true;opsPoll();}
+  if(dp==='tab-ops'&&!opsStarted){opsStarted=true;opsPoll();ccStart();}
   // Leaderboard hydrates client-side on first open — read-only, no role gate.
   if(dp==='tab-leaderboard'&&!lbStarted){lbStarted=true;loadLeaderboard();}
 }
@@ -1107,11 +1198,39 @@ function renderClankers(list){
         '<button type="button" class="admin-act danger" data-cid="'+cid+'" data-user="'+esc(user)+'" data-role="remove">Remove</button>'+
         '</div>';
     }
-    return '<div class="clanker-row"><span class="clanker-dot'+(c.stale?' stale':'')+'"></span>'+av+
-      '<div class="clanker-main"><div class="clanker-user">'+esc(user)+'</div>'+
+    // #command-center: at-a-glance status pill (working / reviewing / idle) and a
+    // stable data-clanker key so the travel animation can target this row. "review"
+    // is inferred when the in-flight task carries a review-ish signal; otherwise a
+    // task in flight is "working" and no task is "idle".
+    var st=c.current_task?'working':'idle';
+    if(c.current_task&&/review|lgtm|approve/i.test((c.current_task.kind||'')+' '+(c.current_task.title||'')))st='reviewing';
+    var statusPill='<span class="clanker-status '+st+'">'+st+'</span>';
+    var key=(c.github_username||c.contributor_id||'').toLowerCase();
+    // Enter pop-in for a clanker we haven't seen in the previous render (army framing).
+    var isNew=key&&!ccKnownClankers[key];
+    var rowCls='clanker-row'+(isNew?' cc-enter':'');
+    return '<div class="'+rowCls+'" data-clanker="'+esc(key)+'"><span class="clanker-dot'+(c.stale?' stale':'')+'"></span>'+av+
+      '<div class="clanker-main"><div class="clanker-user">'+esc(user)+statusPill+'</div>'+
       '<div class="clanker-sub">'+(sub||'&mdash;')+'</div>'+task+'</div>'+
       (actions||('<span class="feed-time">'+esc(rel(c.connected_at))+'</span>'))+'</div>';
   }).join('');
+  // Update the "your army" roster header from the same list (army framing).
+  ccUpdateArmy(list);
+}
+// ccUpdateArmy summarises the fleet into working/reviewing/idle counts. Army framing
+// derived entirely from the live fleet snapshot — no fabricated numbers.
+function ccUpdateArmy(list){
+  var w=0,rv=0,idle=0;
+  (list||[]).forEach(function(c){
+    if(c.current_task){ if(/review|lgtm|approve/i.test((c.current_task.kind||'')+' '+(c.current_task.title||'')))rv++; else w++; }
+    else idle++;
+  });
+  var setTxt=function(id,v){var el=document.getElementById(id);if(el)el.textContent=v;};
+  setTxt('cc-army-working',w);setTxt('cc-army-reviewing',rv);setTxt('cc-army-idle',idle);
+  // Refresh the known-clanker set so the NEXT render only pops-in genuinely new
+  // arrivals (enter animation). ccKnownClankers is also read by the SSE join event.
+  var next={};(list||[]).forEach(function(c){var k=(c.github_username||c.contributor_id||'').toLowerCase();if(k)next[k]=true;});
+  ccKnownClankers=next;
 }
 
 function workMatchesFilter(w){
@@ -1180,6 +1299,179 @@ async function opsPoll(){
   }catch(e){}
   if(document.getElementById('tab-ops').classList.contains('active'))setTimeout(opsPoll,4000);
 }
+
+// ══ Operations command center: live SSE stream driving the ready-work queue, the
+//    task-assign travel animation, the dev-log narration, achievements, and army
+//    enter/leave motion. All from REAL events (ActivityEntry + ActionableIssues).
+//    Degrades gracefully: if EventSource is unsupported or the stream drops, we
+//    fall back to polling /api/contribute/queue so the tab still works. ═════════
+var ccStarted=false;
+var ccQueue=[];            // current ready-work items (top = next up)
+var ccLogLines=[];         // dev-log scrollback
+var ccLogCap=60;           // capped scrollback length
+var ccEs=null;             // EventSource handle
+var ccQueuePollTimer=null; // fallback poll timer
+var ccKnownClankers={};    // username -> true, for enter/leave detection
+var ccCompleteStreak={};   // username -> consecutive completes (achievement combos)
+var ccLastAch=0;           // debounce achievement pops
+
+function ccQueueKey(q){return (q.repo||'')+'#'+(q.number||'');}
+
+function ccRenderQueue(){
+  var el=document.getElementById('cc-queue');if(!el)return;
+  if(!ccQueue.length){el.innerHTML='<div class="ops-empty">No work waiting &mdash; the backlog is clear or everything is in flight.</div>';return;}
+  el.innerHTML=ccQueue.map(function(q,i){
+    var labels=(q.labels&&q.labels.length)?('<div class="cc-q-labels">'+q.labels.slice(0,4).map(function(l){return '<span class="pill pill-idle">'+esc(l)+'</span>';}).join('')+'</div>'):'';
+    var next=(i===0)?'<span class="cc-q-next">next up</span>':'';
+    return '<div class="cc-q-item" data-qkey="'+esc(ccQueueKey(q))+'"><span class="cc-q-idx">'+(i+1)+'</span>'+
+      '<div class="cc-q-body"><div class="cc-q-repo">'+esc(q.repo||'')+'#'+esc(q.number||'')+'</div>'+
+      '<div class="cc-q-title" title="'+esc(q.title||'')+'">'+esc(q.title||'(untitled)')+'</div>'+labels+'</div>'+next+'</div>';
+  }).join('');
+}
+function ccSetLive(state){ // 'live' | 'poll' | 'connecting'
+  var el=document.getElementById('cc-live'),lbl=document.getElementById('cc-live-label');if(!el||!lbl)return;
+  if(state==='live'){el.classList.remove('stale');lbl.textContent='live';}
+  else if(state==='poll'){el.classList.add('stale');lbl.textContent='polling';}
+  else{el.classList.add('stale');lbl.textContent='connecting';}
+}
+
+// ── Dev-log narration: build a human-readable line from an ActivityEntry ───────
+function ccNarrate(e){
+  var icons={joined:'🟢',left:'⚪',"picked up":'🔧',completed:'✅',failed:'❌',promoted:'🎖️'};
+  var ic=icons[e.action]||'⚡';
+  var who='<span class="who">'+esc(e.username||'someone')+'</span>';
+  var ref=e.task?' <span class="ref">'+esc(e.task)+'</span>':'';
+  var body;
+  switch(e.action){
+    case 'joined': body=who+' entered the hive'+(e.cli?' <span class="ref">via '+esc(e.cli)+'</span>':''); break;
+    case 'left': body=who+' left the hive'; break;
+    case 'picked up': body=who+' grabbed'+ref; break;
+    case 'completed': body=who+' completed'+ref; break;
+    case 'failed': body=who+' hit a snag on'+ref; break;
+    case 'promoted': body=who+' was promoted to <b>'+esc(e.task||e.role||'contributor')+'</b>'; break;
+    default: body=who+' '+esc(e.action)+ref;
+  }
+  return {ic:ic,body:body,ts:e.timestamp};
+}
+function ccRenderLog(){
+  var el=document.getElementById('cc-log');if(!el)return;
+  var cnt=document.getElementById('cc-log-count');if(cnt)cnt.textContent=ccLogLines.length+(ccLogLines.length===1?' event':' events');
+  if(!ccLogLines.length){el.innerHTML='<div class="ops-empty">Watching the hive&hellip;</div>';return;}
+  // Newest at TOP (reads best for a live feed).
+  el.innerHTML=ccLogLines.slice().reverse().map(function(l){
+    var t='';try{var d=new Date(l.ts);if(!isNaN(d))t=d.toLocaleTimeString([],{hour:'numeric',minute:'2-digit'});}catch(e){}
+    return '<div class="cc-log-line"><span class="cc-log-ic">'+l.ic+'</span><div class="cc-log-body">'+l.body+'</div><span class="cc-log-time">'+esc(t)+'</span></div>';
+  }).join('');
+  el.scrollTop=0;
+}
+function ccPushLog(e){
+  ccLogLines.push(ccNarrate(e));
+  if(ccLogLines.length>ccLogCap)ccLogLines=ccLogLines.slice(ccLogLines.length-ccLogCap);
+  ccRenderLog();
+}
+
+// ── Achievements: derived from REAL streak/threshold logic in the event stream ──
+function ccAchievement(head,sub,ic){
+  var now=Date.now();if(now-ccLastAch<1200)return; // debounce so pops don't spam
+  ccLastAch=now;
+  var wrap=document.getElementById('cc-ach-wrap');if(!wrap)return;
+  var d=document.createElement('div');d.className='cc-ach';
+  d.innerHTML='<span class="cc-ach-ic">'+(ic||'🏆')+'</span><div class="cc-ach-txt"><div class="cc-ach-h">'+esc(head)+'</div><div class="cc-ach-s">'+sub+'</div></div>';
+  wrap.appendChild(d);
+  setTimeout(function(){d.classList.add('cc-ach-out');setTimeout(function(){d.remove();},420);},3600);
+}
+function ccMaybeAchieve(e){
+  if(e.action==='completed'){
+    var u=e.username||'?';
+    ccCompleteStreak[u]=(ccCompleteStreak[u]||0)+1;
+    var n=ccCompleteStreak[u];
+    if(n===3)ccAchievement('Triple combo','<span class="who">'+esc(u)+'</span> shipped 3 in a row','🔥');
+    else if(n>3&&n%%5===0)ccAchievement(n+'× streak','<span class="who">'+esc(u)+'</span> is on a roll','⚡');
+  } else if(e.action==='failed'){
+    if(e.username)ccCompleteStreak[e.username]=0; // a failure breaks the streak
+  } else if(e.action==='promoted'){
+    ccAchievement('Achievement unlocked','<span class="who">'+esc(e.username||'a clanker')+'</span> reached <b>'+esc(e.task||'contributor')+'</b>','🎖️');
+  }
+}
+
+// ── The travel animation: on "picked up", fly a token from the queue to the
+//    clanker that grabbed it, then remove the item from the queue. Robust when the
+//    exact queue item is not rendered (a generic token flies from the queue area).
+function ccTravel(e){
+  var key=(e.username||'').toLowerCase();
+  var target=document.querySelector('.clanker-row[data-clanker="'+(window.CSS&&CSS.escape?CSS.escape(key):key)+'"]');
+  // Source: the matching queue item if present, else the queue card itself.
+  var qEl=null;
+  if(e.task){var qk=String(e.task).replace(/\s+/g,'');
+    var items=document.querySelectorAll('#cc-queue .cc-q-item');
+    for(var i=0;i<items.length;i++){if(items[i].getAttribute('data-qkey')===e.task){qEl=items[i];break;}}
+  }
+  var src=qEl||document.getElementById('cc-queue');
+  if(src&&target&&!(window.matchMedia&&matchMedia('(prefers-reduced-motion:reduce)').matches)){
+    var a=src.getBoundingClientRect(),b=target.getBoundingClientRect();
+    var tok=document.createElement('div');tok.className='cc-token';
+    tok.textContent=e.task||'task';
+    tok.style.left=(a.left+12)+'px';tok.style.top=(a.top+8)+'px';
+    document.body.appendChild(tok);
+    var dx=(b.left+18)-(a.left+12),dy=(b.top+b.height/2)-(a.top+8);
+    requestAnimationFrame(function(){tok.style.transform='translate('+dx+'px,'+dy+'px) scale(.85)';tok.style.opacity='.2';});
+    setTimeout(function(){tok.remove();if(target){target.classList.add('cc-landing');setTimeout(function(){target.classList.remove('cc-landing');},820);}},960);
+  } else if(target){
+    target.classList.add('cc-landing');setTimeout(function(){target.classList.remove('cc-landing');},820);
+  }
+  // Drop the item from the local queue model with a leave animation.
+  if(qEl){qEl.classList.add('cc-leaving');}
+  if(e.task){ccQueue=ccQueue.filter(function(q){return ccQueueKey(q)!==e.task;});}
+  setTimeout(ccRenderQueue,480);
+}
+
+// ── Consume one activity event from the stream ─────────────────────────────────
+function ccOnActivity(e){
+  if(!e||!e.action)return;
+  ccPushLog(e);
+  ccMaybeAchieve(e);
+  if(e.action==='picked up')ccTravel(e);
+}
+
+// ── SSE lifecycle with graceful fallback ───────────────────────────────────────
+function ccHydrate(payload){
+  if(payload.queue){ccQueue=payload.queue.slice();ccRenderQueue();}
+  if(payload.replay&&payload.replay.length){
+    payload.replay.forEach(function(e){ccLogLines.push(ccNarrate(e));});
+    if(ccLogLines.length>ccLogCap)ccLogLines=ccLogLines.slice(ccLogLines.length-ccLogCap);
+    ccRenderLog();
+  }
+}
+function ccQueuePoll(){ // fallback when SSE is down: refresh queue only
+  fetch('/api/contribute/queue').then(function(r){return r.json();}).then(function(d){
+    if(d&&d.queue){ccQueue=d.queue.slice();ccRenderQueue();}
+  }).catch(function(){});
+  ccQueuePollTimer=setTimeout(ccQueuePoll,6000);
+}
+function ccStopFallback(){if(ccQueuePollTimer){clearTimeout(ccQueuePollTimer);ccQueuePollTimer=null;}}
+function ccStart(){
+  if(ccStarted)return;ccStarted=true;
+  if(!('EventSource' in window)){ccSetLive('poll');ccQueuePoll();return;}
+  function connect(){
+    ccSetLive('connecting');
+    try{ccEs=new EventSource('/api/contribute/events');}catch(err){ccSetLive('poll');ccQueuePoll();return;}
+    ccEs.onopen=function(){ccSetLive('live');ccStopFallback();};
+    ccEs.onmessage=function(m){
+      try{var ev=JSON.parse(m.data);}catch(err){return;}
+      if(ev.type==='hello')ccHydrate(ev);
+      else if(ev.type==='activity'&&ev.activity)ccOnActivity(ev.activity);
+    };
+    ccEs.onerror=function(){
+      // Stream dropped. Show polling state, start the queue fallback, and let the
+      // browser's built-in EventSource auto-reconnect re-establish the live stream.
+      ccSetLive('poll');
+      if(!ccQueuePollTimer)ccQueuePoll();
+      // If the connection is fully closed (not merely reconnecting), rebuild it.
+      if(ccEs&&ccEs.readyState===2){try{ccEs.close();}catch(e){}ccEs=null;setTimeout(connect,4000);}
+    };
+  }
+  connect();
+}
 })();
 </script>
 <script>
@@ -1213,6 +1505,9 @@ poll();setInterval(poll,3000);
 </script>
 <!-- Themed confirm modal for the destructive admin actions (revoke / remove).
      The dashboard convention is a themed overlay, never native window.confirm. -->
+<!-- Command-center overlays: achievement pops (top-right) + the travelling-task
+     token layer. Fixed, pointer-events:none, purely presentational. -->
+<div class="cc-ach-wrap" id="cc-ach-wrap"></div>
 <div class="admin-modal-back" id="admin-confirm-back">
 <div class="admin-modal">
 <h4 id="admin-confirm-title">Confirm</h4>
@@ -1444,6 +1739,19 @@ func (s *Server) handleContributeFleet(w http.ResponseWriter, r *http.Request) {
 		"work":     snap.Work,
 		"policy":   s.buildContributeAdmissionPolicy(),
 	})
+}
+
+// handleContributeQueue serves the read-only ready-work QUEUE — the admissible
+// issues waiting to be picked off, derived from the SAME ActionableIssues set
+// selectTask offers from (see ReadyQueue). GET only, public, no side effects. It
+// is both a JSON fallback for browsers without EventSource and the same payload
+// the SSE "hello" frame carries, so the queue renders even if the stream drops.
+func (s *Server) handleContributeQueue(w http.ResponseWriter, r *http.Request) {
+	queue := []ReadyQueueItem{}
+	if s.contributeHub != nil {
+		queue = s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	}
+	jsonResponse(w, map[string]any{"queue": queue})
 }
 
 // ── Contributor management ─────────────────────────────────────────────────

--- a/v2/pkg/dashboard/contribute_sse.go
+++ b/v2/pkg/dashboard/contribute_sse.go
@@ -1,0 +1,375 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// ── Operations command center: live SSE broadcast + ready-work queue ──────────
+//
+// This file is PURELY ADDITIVE and READ-ONLY. It exposes the events the hub
+// ALREADY records (ActivityEntry — join/leave/pick-up/complete/fail/promote) as a
+// Server-Sent-Events stream, plus a read-only snapshot of the ready-work QUEUE
+// derived from the SAME ActionableIssues set selectTask offers from. Nothing here
+// changes the contributor WS protocol, assignment, credentials, or any control
+// behaviour: it is a fan-out of information the dashboard could already poll, made
+// live so the Operations tab can render an SRE "command center" (a live queue, a
+// travel animation when work is picked up, a dev-log narration, and army framing).
+//
+// The stream lives under the /api/contribute* path prefix, so isPublicPath
+// (server.go) already makes it PUBLIC — the whole clanker page is viewable with no
+// auth, and this stream is read-only info, so anonymous viewers may subscribe. The
+// gated MUTATION endpoints (trust/revoke/delete) are untouched and still enforced
+// by requireContributorWrite.
+
+// sseReplayCap is how many recent ActivityEntry events a freshly-connected SSE
+// subscriber is replayed so its page is not blank on load. It is bounded by the
+// hub's own maxActivityEntries ring buffer (50); we cap the replay a little lower
+// so a reconnect does not re-narrate the entire history every time.
+const sseReplayCap = 20
+
+// sseSubscriberBuffer is the per-subscriber channel depth. A slow browser that
+// falls this far behind is dropped rather than allowed to back-pressure the hub —
+// the broadcast must NEVER block the WS event path (an appended activity entry
+// fans out under a non-blocking send). The subscriber simply reconnects and
+// replays the recent buffer, so a momentary drop is self-healing.
+const sseSubscriberBuffer = 32
+
+// readyQueueDefaultLimit is the default number of ready-work items surfaced in the
+// queue snapshot / SSE initial payload. It is the "top of the stack" an operator
+// watches get picked off; the full admissible set can be large, so we cap it.
+const readyQueueDefaultLimit = 25
+
+// sseEvent is one framed message pushed to subscribers. Type distinguishes the
+// initial hydration payload (queue + replay) from subsequent single activity
+// events so the client can render each without guessing.
+type sseEvent struct {
+	Type     string           `json:"type"`               // "activity" | "hello"
+	Activity *ActivityEntry   `json:"activity,omitempty"` // set when Type=="activity"
+	Replay   []ActivityEntry  `json:"replay,omitempty"`   // set when Type=="hello"
+	Queue    []ReadyQueueItem `json:"queue,omitempty"`    // set when Type=="hello"
+}
+
+// ReadyQueueItem is one admissible/ready issue in the "queue waiting to be picked
+// off". It carries only public issue metadata (repo, number, title, labels) —
+// exactly what selectTask reads as its candidate set. No credentials, no prompt.
+type ReadyQueueItem struct {
+	Repo   string   `json:"repo"`
+	Number int      `json:"number"`
+	Title  string   `json:"title"`
+	URL    string   `json:"url,omitempty"`
+	Labels []string `json:"labels,omitempty"`
+}
+
+// sseSubscriber is one connected browser. events is the fan-out channel; done is
+// closed by the HTTP handler when the client disconnects so the registry can drop
+// it. Guarded by the hub's sseMu.
+type sseSubscriber struct {
+	events chan sseEvent
+}
+
+// sseRegistry holds the live SSE subscribers. It is a small struct on the hub so
+// the broadcast path (addActivity) can fan out without reaching into HTTP state.
+type sseRegistry struct {
+	mu   sync.Mutex
+	subs map[*sseSubscriber]struct{}
+}
+
+func newSSERegistry() *sseRegistry {
+	return &sseRegistry{subs: make(map[*sseSubscriber]struct{})}
+}
+
+// subscribe registers a new subscriber and returns it. Caller MUST call
+// unsubscribe when the client disconnects to avoid a leak.
+func (r *sseRegistry) subscribe() *sseSubscriber {
+	sub := &sseSubscriber{events: make(chan sseEvent, sseSubscriberBuffer)}
+	r.mu.Lock()
+	r.subs[sub] = struct{}{}
+	r.mu.Unlock()
+	return sub
+}
+
+// unsubscribe removes a subscriber and closes its channel. Idempotent: a second
+// call (e.g. handler cleanup after a broadcast already dropped a wedged sub) is a
+// no-op because the map delete guards the close.
+func (r *sseRegistry) unsubscribe(sub *sseSubscriber) {
+	r.mu.Lock()
+	if _, ok := r.subs[sub]; ok {
+		delete(r.subs, sub)
+		close(sub.events)
+	}
+	r.mu.Unlock()
+}
+
+// broadcast fans an event out to every subscriber with a NON-BLOCKING send. A
+// subscriber whose buffer is full is skipped (its browser will reconnect and
+// replay) — the broadcast must never block the caller, which is the hub's event
+// path. This is the leak-safe, back-pressure-free contract the spec requires.
+func (r *sseRegistry) broadcast(ev sseEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for sub := range r.subs {
+		select {
+		case sub.events <- ev:
+		default:
+			// Subscriber is behind; drop this event for it rather than block the
+			// hub. The client's ring-buffer replay on reconnect recovers state.
+		}
+	}
+}
+
+// count returns the number of live subscribers (used by tests to assert cleanup).
+func (r *sseRegistry) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.subs)
+}
+
+// broadcastActivity is the hook addActivity calls after appending an entry. It
+// fans the single new event out to all SSE subscribers. Nil-safe so a hub built
+// without a registry (older tests) never panics.
+func (h *ContributeWSHub) broadcastActivity(entry ActivityEntry) {
+	if h == nil || h.sse == nil {
+		return
+	}
+	e := entry
+	h.sse.broadcast(sseEvent{Type: "activity", Activity: &e})
+}
+
+// ReadyQueue returns the top-N ready-work items — the admissible issues selectTask
+// would offer from, derived from the SAME ActionableIssues candidate set and the
+// SAME cooldown / failure / disabled-repo / admission-filter exclusions used at
+// assignment time (contribute_ws.go selectTask). Read-only; it assigns nothing.
+//
+// Ordering note (honest scope): selectTask's richest ordering signal is OWN-WORK
+// first (#2390), which is per-CONNECTED-CONTRIBUTOR and therefore meaningless for
+// an anonymous queue view. So this shared queue drops that per-viewer partition
+// and offers the deterministic scan order (repo order, then issue scan order) with
+// the failure-aware exclusions applied — i.e. exactly the candidate set selectTask
+// draws from, minus the per-contributor own-work reshuffle. That is the documented
+// "simple recent/top-N is acceptable" fallback the spec permits.
+func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
+	if limit <= 0 {
+		limit = readyQueueDefaultLimit
+	}
+	out := []ReadyQueueItem{}
+	if h == nil || h.server == nil {
+		return out
+	}
+
+	h.server.statusMu.RLock()
+	status := h.server.status
+	h.server.statusMu.RUnlock()
+	if status == nil {
+		return out
+	}
+
+	// Which issues are already being worked right now — exclude them from "ready"
+	// exactly as selectTask does (an in-flight issue is not waiting to be picked).
+	active := h.activeIssueKeys()
+
+	var disabledRepos []string
+	if h.server.deps != nil && h.server.deps.Config != nil {
+		disabledRepos = h.server.deps.Config.Hub.DisabledRepos
+	}
+
+	for _, repo := range status.Repos {
+		if len(repo.ActionableIssues) == 0 {
+			continue
+		}
+		if config.MatchesAny(repo.Full, disabledRepos) || config.MatchesAny(repo.Name, disabledRepos) {
+			continue
+		}
+		for _, raw := range repo.ActionableIssues {
+			b, err := json.Marshal(raw)
+			if err != nil {
+				continue
+			}
+			var issue map[string]any
+			if err := json.Unmarshal(b, &issue); err != nil {
+				continue
+			}
+			number := 0
+			switch n := issue["number"].(type) {
+			case float64:
+				number = int(n)
+			case int:
+				number = n
+			}
+			if number == 0 {
+				continue
+			}
+			if h.isTaskInCooldown(repo.Full, number) {
+				continue
+			}
+			if h.isTaskInFailureCooldown(repo.Full, number) {
+				continue
+			}
+			if active[fmt.Sprintf("%s#%d", repo.Full, number)] {
+				continue
+			}
+			title, _ := issue["title"].(string)
+			url, _ := issue["url"].(string)
+			author, _ := issue["author"].(string)
+			labels := stringSliceFromAny(issue["labels"])
+			assignees := stringSliceFromAny(issue["assignees"])
+
+			// Apply the SAME admission filters selectTask enforces so the queue
+			// shows genuinely-admissible work, not items the filters would reject.
+			if h.server.deps != nil && h.server.deps.Config != nil {
+				hub := h.server.deps.Config.Hub
+				if !config.FilterPasses(title, hub.ContributeDenyTitles, hub.ContributeTitlesMode) ||
+					!config.FilterPasses(author, hub.ContributeDenyAuthors, hub.ContributeAuthorsMode) ||
+					!config.LabelsFilterPasses(labels, hub.ContributeDenyLabels, hub.ContributeLabelsMode) {
+					continue
+				}
+				// Own-work is meaningless for an anonymous queue view, so pass an
+				// empty "self" — an issue assigned solely to OTHERS is skipped, one
+				// unassigned stays. This matches selectTask's skip-assigned toggle.
+				if hub.ContributeSkipAssignedToOthers && assignedToOthers(assignees, "") {
+					continue
+				}
+			}
+
+			out = append(out, ReadyQueueItem{
+				Repo:   repo.Full,
+				Number: number,
+				Title:  title,
+				URL:    url,
+				Labels: labels,
+			})
+			if len(out) >= limit {
+				return out
+			}
+		}
+	}
+	return out
+}
+
+// activeIssueKeys returns the set of "repo#number" keys currently in flight across
+// all connected clankers, so ReadyQueue can exclude work that is already picked up.
+// Mirrors the activeIssues set selectTask builds, read-only.
+func (h *ContributeWSHub) activeIssueKeys() map[string]bool {
+	active := map[string]bool{}
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for _, c := range h.connections {
+		c.mu.Lock()
+		if c.currentTask != nil {
+			active[fmt.Sprintf("%s#%d", c.currentTask.Repo, c.currentTask.Number)] = true
+		}
+		c.mu.Unlock()
+	}
+	return active
+}
+
+// handleContributeEvents is the READ-ONLY Server-Sent-Events endpoint
+// (GET /api/contribute/events). It streams contributor activity events to any
+// connected dashboard browser. It lives under /api/contribute*, so isPublicPath
+// makes it PUBLIC — anonymous viewers may subscribe (read-only info only). It never
+// mutates anything and never carries credentials.
+//
+// On connect it sends a "hello" frame (recent-activity replay + the ready-work
+// queue snapshot) so a fresh page is not blank, then forwards each subsequent
+// appended ActivityEntry as an "activity" frame. Subscriber cleanup is guaranteed:
+// the deferred unsubscribe runs on ANY exit (client disconnect via r.Context, or
+// server flush error), closing the channel and removing the registry entry — no
+// goroutine or subscriber leak.
+func (s *Server) handleContributeEvents(w http.ResponseWriter, r *http.Request) {
+	if s.contributeHub == nil || s.contributeHub.sse == nil {
+		http.Error(w, "event stream unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	// The dashboard is same-origin; no CORS needed. Prevent proxies from buffering
+	// the stream (nginx honours this) so events arrive live.
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	sub := s.contributeHub.sse.subscribe()
+	defer s.contributeHub.sse.unsubscribe(sub)
+
+	// Initial hydration: recent activity (bounded) + the ready-work queue snapshot.
+	replay := s.contributeHub.RecentActivity()
+	if len(replay) > sseReplayCap {
+		replay = replay[len(replay)-sseReplayCap:]
+	}
+	hello := sseEvent{
+		Type:   "hello",
+		Replay: replay,
+		Queue:  s.contributeHub.ReadyQueue(readyQueueDefaultLimit),
+	}
+	if !writeSSE(w, hello) {
+		return
+	}
+	flusher.Flush()
+
+	ctx := r.Context()
+	// A heartbeat comment keeps intermediaries from timing out an idle stream and
+	// lets a broken pipe surface promptly as a flush error.
+	ticker := time.NewTicker(sseHeartbeatInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, open := <-sub.events:
+			if !open {
+				return // registry closed our channel (server shutdown / forced drop)
+			}
+			if !writeSSE(w, ev) {
+				return
+			}
+			flusher.Flush()
+		case <-ticker.C:
+			if _, err := fmt.Fprint(w, ": ping\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+// sseHeartbeatInterval is how often an idle stream emits an SSE comment ping. It is
+// short enough to keep proxies/load-balancers from closing an idle connection and
+// to detect a dead client promptly, without meaningful overhead.
+const sseHeartbeatInterval = 25 * time.Second
+
+// writeSSE marshals one event and writes it as a single SSE "data:" frame. Returns
+// false on a write/marshal error so the caller can tear down the subscriber.
+func writeSSE(w http.ResponseWriter, ev sseEvent) bool {
+	b, err := json.Marshal(ev)
+	if err != nil {
+		return false
+	}
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", b); err != nil {
+		return false
+	}
+	return true
+}
+
+// sortReadyQueue is a small helper kept for deterministic test assertions: it
+// orders items by repo then number. The live ReadyQueue preserves scan order (to
+// mirror selectTask); tests that only care about set membership can sort a copy.
+func sortReadyQueue(items []ReadyQueueItem) {
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Repo != items[j].Repo {
+			return items[i].Repo < items[j].Repo
+		}
+		return items[i].Number < items[j].Number
+	})
+}

--- a/v2/pkg/dashboard/contribute_sse_test.go
+++ b/v2/pkg/dashboard/contribute_sse_test.go
@@ -1,0 +1,273 @@
+package dashboard
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ── Operations command center: SSE stream + ready-work queue ─────────────────
+//
+// These tests pin the READ-ONLY command-center backend:
+//   1. /api/contribute/events is PUBLIC (isPublicPath) and streams an appended
+//      ActivityEntry to a subscriber, then cleans the subscriber up on disconnect
+//      (no leaked subscriber/goroutine).
+//   2. ReadyQueue reflects the ActionableIssues set.
+//   3. The rendered /contribute page ships the command-center markup.
+//   4. The public-page / gated-controls invariant holds: an anonymous (read)
+//      viewer gets the stream + queue but 403 on the control endpoints.
+
+// TestSSEEventsIsPublic asserts the stream path is in isPublicPath so anonymous
+// viewers may subscribe — the whole clanker page is public, and this stream is
+// read-only info.
+func TestSSEEventsIsPublic(t *testing.T) {
+	for _, p := range []string{"/api/contribute/events", "/api/contribute/queue"} {
+		if !isPublicPath(p) {
+			t.Errorf("%s must be public (read-only viewers subscribe with no auth)", p)
+		}
+	}
+}
+
+// TestSSEStreamsAppendedActivity connects a subscriber, appends an activity event,
+// and asserts the event is streamed as an SSE "data:" frame. Then it cancels the
+// request context and asserts the subscriber is unregistered (leak-safe cleanup).
+func TestSSEStreamsAppendedActivity(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+	hub := s.contributeHub
+
+	if got := hub.sse.count(); got != 0 {
+		t.Fatalf("expected 0 subscribers at start, got %d", got)
+	}
+
+	// httptest.ResponseRecorder implements http.Flusher, so the handler streams.
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/events", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		s.handleContributeEvents(rec, req)
+		close(done)
+	}()
+
+	// Wait for the handler to register its subscriber (it does so before blocking).
+	waitFor(t, func() bool { return hub.sse.count() == 1 }, "subscriber to register")
+
+	// Append a real activity event — this is the exact fan-in point join/leave/
+	// pick-up/complete all funnel through.
+	hub.addActivity("kylerankin", "picked up", "contributor", "claude", "sonnet", "projectbluefin/common#796")
+
+	// The event must reach the stream as an SSE data frame carrying the username.
+	waitFor(t, func() bool {
+		return strings.Contains(rec.Body.String(), "kylerankin") &&
+			strings.Contains(rec.Body.String(), "data:")
+	}, "activity event to stream to subscriber")
+
+	// Disconnect: cancelling the context must tear the handler down AND unregister
+	// the subscriber — no leak.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not return after context cancel (possible goroutine leak)")
+	}
+	if got := hub.sse.count(); got != 0 {
+		t.Fatalf("subscriber not cleaned up after disconnect: %d still registered (leak)", got)
+	}
+}
+
+// TestSSEHelloReplaysRecentActivity asserts a fresh subscriber gets a "hello" frame
+// so the page is not blank on load — recent activity is replayed.
+func TestSSEHelloReplaysRecentActivity(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+	hub := s.contributeHub
+	hub.addActivity("castrojo", "completed", "trusted", "claude", "opus", "projectbluefin/common#707")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/events", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	go s.handleContributeEvents(rec, req)
+
+	waitFor(t, func() bool {
+		b := rec.Body.String()
+		return strings.Contains(b, `"type":"hello"`) && strings.Contains(b, "castrojo")
+	}, "hello frame with replayed activity")
+}
+
+// TestReadyQueueReflectsActionableIssues seeds a status with ActionableIssues and
+// asserts ReadyQueue surfaces them (repo/number/title), i.e. the queue read maps to
+// the real candidate set.
+func TestReadyQueueReflectsActionableIssues(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{
+			{
+				Name: "common", Full: "projectbluefin/common",
+				ActionableIssues: []any{
+					map[string]any{"number": float64(796), "title": "Fix the widget", "labels": []any{"bug"}},
+					map[string]any{"number": float64(707), "title": "Add docs", "labels": []any{}},
+				},
+			},
+		},
+	}
+	s.statusMu.Unlock()
+
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 2 {
+		t.Fatalf("expected 2 ready-queue items, got %d: %+v", len(q), q)
+	}
+	sortReadyQueue(q)
+	if q[0].Repo != "projectbluefin/common" || q[0].Number != 707 {
+		t.Errorf("unexpected first item: %+v", q[0])
+	}
+	if q[1].Number != 796 || q[1].Title != "Fix the widget" {
+		t.Errorf("unexpected second item: %+v", q[1])
+	}
+
+	// The public JSON queue endpoint returns the same set.
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/queue", nil)
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("queue endpoint: got %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "projectbluefin/common") {
+		t.Errorf("queue endpoint missing seeded repo: %s", rec.Body.String())
+	}
+}
+
+// TestReadyQueueExcludesInFlight asserts an issue already being worked is NOT shown
+// as "ready" (it is not waiting to be picked off) — mirroring selectTask.
+func TestReadyQueueExcludesInFlight(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+	hub := s.contributeHub
+
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{{
+			Name: "common", Full: "projectbluefin/common",
+			ActionableIssues: []any{
+				map[string]any{"number": float64(796), "title": "Fix the widget"},
+			},
+		}},
+	}
+	s.statusMu.Unlock()
+
+	// Simulate the issue being in flight on a connected clanker.
+	hub.mu.Lock()
+	hub.connections["c1"] = &ContributorConnection{
+		currentTask: &WSTaskAssign{Repo: "projectbluefin/common", Number: 796},
+	}
+	hub.mu.Unlock()
+
+	q := hub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 0 {
+		t.Fatalf("in-flight issue should not be in the ready queue, got %+v", q)
+	}
+}
+
+// TestCommandCenterMarkupRendered asserts the /contribute page ships the
+// command-center markup (queue, dev-log, army framing, live pill, SSE wiring).
+func TestCommandCenterMarkupRendered(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		`id="cc-queue"`,          // ready-work queue
+		`id="cc-log"`,            // dev-log narration
+		`id="cc-army"`,           // army framing
+		`id="cc-live"`,           // live/poll status pill
+		`id="cc-ach-wrap"`,       // achievement pops
+		`/api/contribute/events`, // SSE wiring
+		`EventSource`,            // stream client
+		`/api/contribute/queue`,  // graceful poll fallback
+		`function ccTravel`,      // task-assign travel animation
+		`Ready-work queue`,       // queue heading
+		`Development log`,        // dev-log heading
+		`Your army`,              // army heading
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("rendered page missing command-center marker %q", want)
+		}
+	}
+	// The gated controls invariant: the per-clanker admin actions + role gate must
+	// still be present (command center did not weaken them).
+	for _, want := range []string{`initAdmin`, `/api/role`, `role!=='owner'&&role!=='read-write'`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("rendered page lost the role gate marker %q (controls must stay gated)", want)
+		}
+	}
+}
+
+// TestCommandCenterPublicButControlsGated proves the invariant end-to-end through
+// the real Handler middleware chain: an anonymous "read" viewer can GET the stream
+// and the queue (public, read-only) but is 403'd on the control endpoints.
+func TestCommandCenterPublicButControlsGated(t *testing.T) {
+	setupContributeEnv(t)
+	if err := saveContributorProfile(&ContributorProfile{
+		GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "newcomer",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+	h := s.Handler()
+
+	// Read viewer CAN read the public queue endpoint (200).
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/queue", nil)
+	req.Header.Set("X-Hive-Role", "read")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("read viewer denied the public queue: got %d, want 200", rec.Code)
+	}
+
+	// Read viewer CANNOT drive a control endpoint (403).
+	req2 := httptest.NewRequest(http.MethodPost, "/api/contributors/c-alice/revoke", nil)
+	req2.Header.Set("X-Hive-Role", "read")
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusForbidden {
+		t.Fatalf("read viewer was allowed a control endpoint: got %d, want 403", rec2.Code)
+	}
+	if p := findContributor("c-alice"); p == nil || p.TrustTier != "newcomer" {
+		t.Errorf("read viewer mutated a profile through a control endpoint: %+v", p)
+	}
+}
+
+// waitFor polls cond up to ~2s. Keeps the SSE tests free of fixed sleeps that would
+// be flaky under load while still bounding the wait.
+func waitFor(t *testing.T, cond func() bool, what string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -222,6 +222,11 @@ type ContributeWSHub struct {
 	// stays bounded. Guarded by rateMu.
 	assignmentTimes map[string][]time.Time
 	rateMu          sync.Mutex
+	// sse is the read-only Server-Sent-Events broadcast registry (contribute_sse.go).
+	// Every appended ActivityEntry is fanned out to subscribed dashboard browsers so
+	// the Operations "command center" renders live. It is purely additive: the fan-out
+	// is a NON-BLOCKING send, so it can never back-pressure this WS event path.
+	sse *sseRegistry
 }
 
 // rateLimitHourWindow and rateLimitDayWindow are the trailing (rolling) windows
@@ -298,6 +303,7 @@ func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 		assignmentTimes:       make(map[string][]time.Time),
 		logger:                logger,
 		server:                server,
+		sse:                   newSSERegistry(),
 	}
 	hub.loadCompletedTasks()
 	hub.loadFailedTasks()
@@ -346,16 +352,16 @@ const activityDebounceSecs = 60
 
 func (h *ContributeWSHub) addActivity(username, action, role, cli, model, task string) {
 	h.activityMu.Lock()
-	defer h.activityMu.Unlock()
 	if len(h.activity) > 0 && (action == "joined" || action == "left") {
 		last := h.activity[len(h.activity)-1]
 		if last.Username == username && last.Action == action {
 			if t, err := time.Parse(time.RFC3339, last.Timestamp); err == nil && time.Since(t) < activityDebounceSecs*time.Second {
+				h.activityMu.Unlock()
 				return
 			}
 		}
 	}
-	h.activity = append(h.activity, ActivityEntry{
+	entry := ActivityEntry{
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 		Username:  username,
 		Action:    action,
@@ -363,11 +369,17 @@ func (h *ContributeWSHub) addActivity(username, action, role, cli, model, task s
 		CLI:       cli,
 		Model:     model,
 		Task:      task,
-	})
+	}
+	h.activity = append(h.activity, entry)
 	if len(h.activity) > maxActivityEntries {
 		h.activity = h.activity[len(h.activity)-maxActivityEntries:]
 	}
+	h.activityMu.Unlock()
 	go h.saveActivity()
+	// Fan the appended event out to any live SSE subscribers (Operations command
+	// center). Done AFTER releasing activityMu, and the fan-out itself is a
+	// non-blocking send, so a subscribed browser can never stall the WS path.
+	h.broadcastActivity(entry)
 }
 
 func (h *ContributeWSHub) RecentActivity() []ActivityEntry {
@@ -1366,11 +1378,24 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					// Completion is self-reported, so counting bare task_complete
 					// messages — or unverified PR URLs — would hand out contents:write
 					// and pulls:write for work that was never shown to exist.
+					promoted := false
 					if contributor.profile.TrustTier == "newcomer" && contributor.profile.TasksWithPR >= contributorAutoPromoteAt {
 						contributor.profile.TrustTier = "contributor"
+						promoted = true
 						h.logger.Info("[contribute-ws] auto-promoted", "username", contributor.profile.GitHubUsername)
 					}
+					promotedUser := contributor.profile.GitHubUsername
+					promotedCLI := contributor.cliBackend
+					promotedModel := contributor.model
 					contributor.mu.Unlock()
+					// #2390-era command center: narrate the promotion as its own
+					// activity event so the Operations dev-log and achievement pops
+					// (contribute_sse.go broadcast) surface "promoted to contributor".
+					// Read-only signalling — it changes no control behaviour and is
+					// emitted only on the real newcomer -> contributor transition.
+					if promoted {
+						h.addActivity(promotedUser, "promoted", "contributor", promotedCLI, promotedModel, "contributor")
+					}
 					_ = saveContributorProfile(contributor.profile)
 				} else {
 					h.logger.Warn("[contribute-ws] task_complete for unassigned task ignored",


### PR DESCRIPTION
## Operations tab → live command center

Transforms the `/contribute` **Operations** tab into an SRE-style **command center** driven by **REAL events** over a new **read-only Server-Sent-Events stream**. Real data, real events, subtle-professional motion (no confetti/arcade) — every number is derived from existing hub state, nothing is fabricated. This is the "make it feel like you're in COMMAND, but it's REAL" flagship feature.

Built on top of the merged inline **Leaderboard tab** (#2572) and all of #2558/#2562/#2569/#2570/#2571.

### Backend — additive, read-only
- **`GET /api/contribute/events` (SSE)** — broadcasts every appended `ActivityEntry` (join / leave / pick-up / complete / fail, plus a new `promoted` event) to all subscribed dashboard browsers. Subscriber registry + per-sub channels; the fan-out is a **non-blocking send** so it can never back-pressure the WS event path (a slow browser is dropped and self-heals on reconnect). **Leak-safe**: a deferred unsubscribe runs on any handler exit (client disconnect via request context, or a flush error), closing the channel and removing the registry entry. On connect it sends a `hello` frame that **replays** the recent activity ring buffer + the ready-work queue so a fresh page isn't blank. It lives under the `/api/contribute*` prefix, so `isPublicPath` already makes it **PUBLIC** — the whole clanker page is viewable with no auth and this stream is read-only info, so anonymous viewers may subscribe.
- **`GET /api/contribute/queue` + `ReadyQueue()`** — the ready-work **QUEUE**, derived from the **same `ActionableIssues` candidate set `selectTask` offers from**, applying the same cooldown / failure / disabled-repo / admission-filter exclusions and excluding in-flight issues. Own-work-first ordering is per-connected-contributor and meaningless for an anonymous view, so the shared queue uses the deterministic scan order (documented top-N fallback the spec permits). Doubles as the SSE `hello` payload and the poll fallback.

No change to the contributor WS protocol, assignment, credentials, or any control behaviour.

### Frontend — Operations right region (theme-aware, subtle motion)
1. **Ready-work QUEUE** — a live stack of issues (top = next up): repo#num + title + labels, fed by the actionable list.
2. **Task-assign TRAVEL animation (centerpiece)** — on a `picked up` event a token flies from the queue across to the matching connected-clanker row, then the item settles as that clanker's task and leaves the queue. Robust when the exact queue item isn't rendered (a generic token flies from the queue area). Reduced-motion safe.
3. **Development log** — a running human-readable chat log of the development, built from `ActivityEntry` fields ("kylerankin grabbed projectbluefin/common#796", "…was promoted to contributor"). Newest on top, subtle slide/fade in, capped scrollback.
4. **Achievements / combos** — tasteful, debounced pops from **real** streak/threshold logic in the event stream: task-complete combos ("triple combo"), and tier-promotion ("achievement unlocked: Contributor"). A failure breaks the streak.
5. **"Your army" framing** — the Connected-clankers card gains a live roster header (working / reviewing / idle counts) + a per-row status pill + gentle enter pop-in for new arrivals.

### Graceful degradation
If `EventSource` is unsupported or the stream drops, the tab falls back to polling `/api/contribute/queue`, and the browser's built-in EventSource auto-reconnect re-establishes the live stream. A live/polling pill shows the current state.

### Row-overlap fix
Tidies the Connected-clankers rows (adds an at-a-glance status pill + a stable `data-clanker` key) so the avatar, identity text, and the trust/Revoke/Remove controls no longer collide.

### Invariants preserved
- The clanker page stays **PUBLIC**; the stream + queue + dev-log + achievements are read-only and visible to everyone including anonymous viewers.
- The **Management controls** and the **per-clanker admin buttons (trust / Revoke / Remove)** stay **owner / read-write only** — UI-gated via the existing `initAdmin()`/role logic **and** server-enforced by `requireContributorWrite` / `roleEnforcement`. Not weakened, no control made public, role-gate init unchanged.
- Other tabs (Onboarding, Management, Leaderboard) untouched; My work / Pipeline & policy stay visible.

### Tests
- SSE endpoint is public; streams an appended activity event to a subscriber; cleans up on disconnect (no leaked subscriber/goroutine).
- `hello` frame replays recent activity.
- Ready-queue reflects `ActionableIssues` and excludes in-flight work; the public queue endpoint returns the same set.
- The rendered page ships the command-center markup and keeps the role-gate markers.
- End-to-end through the real Handler: a read/anon viewer gets the queue (200) but is 403'd on a control endpoint (and mutates nothing).

`go build` / `go vet` / full `pkg/dashboard` test suite green; inline script passes `node --check`.