### PR TITLE
✨ feat(hub): Upgrading pill filters mid-upgrade hives in the drift summary

### DIFF
--- a/v2/pkg/hub/drift.go
+++ b/v2/pkg/hub/drift.go
@@ -98,8 +98,19 @@ const (
 	DriftKindIdentitySplit  = "identity-split"
 	DriftKindHealthDegraded = "health-degraded"
 	DriftKindUpgradeStuck   = "upgrade-stuck"
-	DriftKindACMMUnset      = "acmm-unset"
-	DriftKindNoAgents       = "no-agents"
+	// DriftKindUpgrading marks a hive whose upgrade is ACTIVELY in progress:
+	// Upgrading set, a real (non-zero) start stamp within staleUpgradeTimeout,
+	// and no terminal failure recorded. Informational by design — it is status,
+	// not alarm. The pill exists so an operator can separate "being fixed right
+	// now" from "needs attention": during an upgrade wave, mid-upgrade hives
+	// otherwise pollute the version-differs breakdown with drift that is the
+	// expected state. Complementary to upgrade-stuck — past staleUpgradeTimeout
+	// (or with no usable stamp) that signal takes over, so a hive can never
+	// show as harmlessly "Upgrading" forever off a zero or stale timestamp
+	// (the same bound #2517 made the elapsed counter and orphan sweep honor).
+	DriftKindUpgrading = "upgrading"
+	DriftKindACMMUnset = "acmm-unset"
+	DriftKindNoAgents  = "no-agents"
 )
 
 // DriftSignal is one detected deviation. Reason is a complete, human-readable
@@ -430,6 +441,15 @@ func computeDrift(h MyHiveEntry, norm fleetNorm, latestSHAs map[string]string, n
 	// Upgrade wedged. Reuses staleUpgradeTimeout, the same bound the hub's own
 	// upgrade-state machine uses to call an in-flight upgrade stuck, so the
 	// drift badge and the row's upgrade spinner agree on when to give up.
+	//
+	// activelyUpgrading is true only in the healthy remainder: a real start
+	// stamp, within the timeout, and no recorded failure. It raises the
+	// informational "upgrading" signal and suppresses the fleet-relative
+	// version/branch signals below — mid-upgrade drift from the fleet is the
+	// expected state, not a deviation. The zero-stamp and past-timeout arms
+	// keep firing upgrade-stuck instead, so this signal can never pin a hive
+	// as "Upgrading" forever off a lost or stale timestamp (#2517).
+	activelyUpgrading := false
 	if h.Upgrading {
 		started, ok := parseRFC3339OrTime(h.UpgradeStartedAt, "")
 		if !ok || started.IsZero() {
@@ -442,6 +462,19 @@ func computeDrift(h MyHiveEntry, norm fleetNorm, latestSHAs map[string]string, n
 			}
 			add(DriftKindUpgradeStuck, DriftCritical,
 				fmt.Sprintf("Upgrade to %s has been in flight for %s (limit %s) — it is stuck, not progressing",
+					target, driftHumanDuration(age), driftHumanDuration(staleUpgradeTimeout)))
+		} else if !h.UpgradeFailed && h.UpgradeFailedAt.IsZero() {
+			// A reported failure is terminal, not in-flight (the heartbeat
+			// handler clears Upgrading when a spoke reports one), so a row
+			// carrying failure state is defensively excluded here rather than
+			// shown as making progress it is not making.
+			activelyUpgrading = true
+			target := h.UpgradeTarget
+			if target == "" {
+				target = "an unrecorded target"
+			}
+			add(DriftKindUpgrading, DriftInfo,
+				fmt.Sprintf("Upgrade to %s has been in flight for %s — version drift from the fleet is expected until it lands (called stuck after %s)",
 					target, driftHumanDuration(age), driftHumanDuration(staleUpgradeTimeout)))
 		}
 	}
@@ -597,8 +630,14 @@ func computeDrift(h MyHiveEntry, norm fleetNorm, latestSHAs map[string]string, n
 	//
 	// Skipped entirely when no norm could be derived, and skipped for offline
 	// hives (whose last-reported version is not evidence of current state) and
-	// placeholders (which track the pool image, not the fleet).
-	if norm.Branch != "" && h.Online && !placeholder {
+	// placeholders (which track the pool image, not the fleet). Also skipped
+	// while the hive is ACTIVELY upgrading — mid-upgrade version and branch
+	// drift is the expected state the upgrade exists to resolve, and flagging
+	// it would file "being fixed" under "needs attention" (same suppression
+	// discipline as status-flipping yielding to duplicate-spoke above). The
+	// moment the upgrade lands, fails, or exceeds staleUpgradeTimeout,
+	// activelyUpgrading drops and any remaining drift is flagged again.
+	if norm.Branch != "" && h.Online && !placeholder && !activelyUpgrading {
 		hiveBranch := strings.TrimSpace(h.GitBranch)
 		if hiveBranch != "" && !strings.EqualFold(hiveBranch, norm.Branch) {
 			add(DriftKindBranchMismatch, DriftWarn,

--- a/v2/pkg/hub/drift_test.go
+++ b/v2/pkg/hub/drift_test.go
@@ -200,14 +200,21 @@ func TestComputeDriftSignals(t *testing.T) {
 			wantReasonHas: "v2-latest",
 		},
 		{
-			name: "upgrade in flight but still within the timeout is not drift",
+			name: "upgrade actively in flight raises the informational upgrading signal",
 			mutate: func(h *MyHiveEntry) {
 				h.Upgrading = true
 				h.UpgradeTarget = "v2-latest"
 				h.UpgradeStartedAt = driftNow.Add(-1 * time.Minute)
 			},
+			wantKind:      DriftKindUpgrading,
+			wantSev:       DriftInfo,
+			wantReasonHas: "v2-latest",
 		},
 		{
+			// The exactly-one-signal assertion below doubles as the guard that
+			// a stuck or stamp-less upgrade never ALSO reads as "upgrading":
+			// the two upgrade-stuck cases in this table would fail with two
+			// signals if the new kind leaked past the staleness bound.
 			name: "upgrade with no recorded start time is a warning",
 			mutate: func(h *MyHiveEntry) {
 				h.Upgrading = true
@@ -215,6 +222,19 @@ func TestComputeDriftSignals(t *testing.T) {
 			wantKind:      DriftKindUpgradeStuck,
 			wantSev:       DriftWarn,
 			wantReasonHas: "no recorded start time",
+		},
+		{
+			// A reported failure is terminal, not in-flight: even if the
+			// Upgrading flag and a fresh stamp linger on the row, a hive that
+			// failed its upgrade must not show as making progress.
+			name: "failed upgrade is not 'upgrading'",
+			mutate: func(h *MyHiveEntry) {
+				h.Upgrading = true
+				h.UpgradeTarget = "v2-latest"
+				h.UpgradeStartedAt = driftNow.Add(-1 * time.Minute)
+				h.UpgradeFailed = true
+				h.UpgradeFailedAt = driftNow.Add(-30 * time.Second)
+			},
 		},
 		{
 			name: "acmm unset on a claimed hive",
@@ -358,6 +378,78 @@ func TestComputeDriftStillFlagsPlaceholderUniversalSignals(t *testing.T) {
 	}
 	if _, ok := byKind[DriftKindPinnedImage]; !ok {
 		t.Errorf("pinned image must be flagged on placeholders too: %+v", got.Signals)
+	}
+}
+
+// While a hive is ACTIVELY upgrading, its version-behind and branch-mismatch
+// signals are suppressed: mid-upgrade drift from the fleet is the expected
+// state the upgrade exists to resolve, and the whole point of the "Upgrading"
+// pill is separating "being fixed" from "needs attention". The moment the
+// upgrade goes stuck (past staleUpgradeTimeout) the suppression lifts and the
+// relative drift is flagged again.
+func TestComputeDriftUpgradingSuppressesFleetRelativeSignals(t *testing.T) {
+	norm := computeFleetNorm(normFleet())
+	latest := map[string]string{"v2": "abc1234"}
+
+	// Baseline: the same divergences WITHOUT an upgrade in flight do flag, so
+	// the suppression assertions below cannot pass vacuously.
+	behind := healthyEntry("behind")
+	behind.GitHash = "0000fff"
+	if got := driftKindsOf(computeDrift(behind, norm, latest, driftNow)); got[DriftKindVersionBehind] == (DriftSignal{}) {
+		t.Fatalf("test setup: expected version-behind without an upgrade, got %+v", got)
+	}
+	offBranch := healthyEntry("off-branch")
+	offBranch.GitBranch = "v3"
+	if got := driftKindsOf(computeDrift(offBranch, norm, latest, driftNow)); got[DriftKindBranchMismatch] == (DriftSignal{}) {
+		t.Fatalf("test setup: expected branch-mismatch without an upgrade, got %+v", got)
+	}
+
+	// Same divergences with an ACTIVE upgrade: only "upgrading" fires.
+	for _, tc := range []struct {
+		name       string
+		mutate     func(*MyHiveEntry)
+		suppressed string
+	}{
+		{"version-behind suppressed mid-upgrade", func(h *MyHiveEntry) { h.GitHash = "0000fff" }, DriftKindVersionBehind},
+		{"branch-mismatch suppressed mid-upgrade", func(h *MyHiveEntry) { h.GitBranch = "v3" }, DriftKindBranchMismatch},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := healthyEntry("subject")
+			tc.mutate(&h)
+			h.Upgrading = true
+			h.UpgradeTarget = "v2-latest"
+			h.UpgradeStartedAt = driftNow.Add(-1 * time.Minute)
+
+			got := computeDrift(h, norm, latest, driftNow)
+			byKind := driftKindsOf(got)
+			if _, ok := byKind[tc.suppressed]; ok {
+				t.Errorf("%s must be suppressed while actively upgrading: %+v", tc.suppressed, got.Signals)
+			}
+			if _, ok := byKind[DriftKindUpgrading]; !ok {
+				t.Errorf("expected the upgrading signal, got %+v", got.Signals)
+			}
+			if len(got.Signals) != 1 {
+				t.Errorf("expected exactly the upgrading signal, got %+v", got.Signals)
+			}
+		})
+	}
+
+	// A STUCK upgrade does not suppress: past the bound the hive is back to
+	// "needs attention", relative drift included.
+	stuck := healthyEntry("stuck")
+	stuck.GitHash = "0000fff"
+	stuck.Upgrading = true
+	stuck.UpgradeTarget = "v2-latest"
+	stuck.UpgradeStartedAt = driftNow.Add(-2 * time.Hour)
+	byKind := driftKindsOf(computeDrift(stuck, norm, latest, driftNow))
+	if _, ok := byKind[DriftKindUpgradeStuck]; !ok {
+		t.Errorf("expected upgrade-stuck on a wedged upgrade, got %+v", byKind)
+	}
+	if _, ok := byKind[DriftKindVersionBehind]; !ok {
+		t.Errorf("a stuck upgrade must not keep suppressing version-behind, got %+v", byKind)
+	}
+	if _, ok := byKind[DriftKindUpgrading]; ok {
+		t.Errorf("a stuck upgrade must not read as 'upgrading', got %+v", byKind)
 	}
 }
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -8419,6 +8419,7 @@ const dashboardHTML = `<!DOCTYPE html>
       'app-id-placeholder': 'Placeholder App ID (operator)',
       'health-degraded': 'Health degraded',
       'upgrade-stuck':   'Upgrade stuck',
+      'upgrading':       'Upgrading',
       'acmm-unset':      'ACMM level unset',
       'no-agents':       'No agents running',
       'duplicate-spoke': 'Duplicate spoke instances',


### PR DESCRIPTION
## What

Adds an **Upgrading** pill to the hub dashboard's needs-attention drift summary (the "N hives need attention — configuration drift detected from the fleet norm" strip), so an operator can click it and filter the hive list to hives whose upgrade is actively in progress.

## Why

During an upgrade wave, mid-upgrade hives pollute the "Version differs from fleet" (and sometimes "Branch differs") pills with drift that is the *expected* state — the operator cannot separate "being fixed right now" from "needs attention". This pill is that separation, and it is deliberately **informational** severity: status, not alarm.

## Detection rule

A new drift kind `DriftKindUpgrading` (`"upgrading"`, label "Upgrading") is emitted in `computeDrift` (v2/pkg/hub/drift.go) when ALL of:

- `Upgrading` is set,
- `UpgradeStartedAt` is a real (non-zero) stamp,
- elapsed since start is **within `staleUpgradeTimeout`** — the exact bound #2517 made the elapsed counter and orphan sweep honor, reused rather than a new threshold,
- no terminal failure recorded (`UpgradeFailed` false and `UpgradeFailedAt` zero — failed is not upgrading).

The zero-stamp and past-timeout arms keep firing the existing `upgrade-stuck` signal instead, so a hive is never both, and can never sit "Upgrading" forever off a zero/stale timestamp.

## Suppression (included)

The drift model already has a suppression precedent (status-flipping yields to duplicate-spoke), so while a hive is actively upgrading its fleet-relative `version-behind` **and** `branch-mismatch` signals are suppressed — one extra condition on the existing fleet-relative gate. The suppression lifts the moment the upgrade lands, fails, or exceeds `staleUpgradeTimeout`.

## Pill behavior

`renderDriftSummary` in the dashboard auto-renders every server-emitted kind as a click-to-filter chip with a per-hive count, and only renders kinds carried by ≥1 hive — verified, so the only dashboard change is one `DRIFT_KIND_LABELS` entry (`'upgrading': 'Upgrading'`). The pill appears in the strip alongside the existing ones, sorted into the info tier, shows the count of mid-upgrade hives, and clicking it filters the table to exactly those hives (clicking again or "Show all" clears). No backticks were added to the `dashboardHTML` raw string.

## Tests (drift_test.go)

- active upgrade → `upgrading` (info) emitted
- zero start stamp → `upgrade-stuck` (warn) only, never `upgrading`
- stale stamp past the bound → `upgrade-stuck` (critical) only, never `upgrading`
- `UpgradeFailed`/`UpgradeFailedAt` set → neither emitted
- mid-upgrade suppression of `version-behind` and `branch-mismatch`, with non-vacuous baselines proving both fire without an upgrade
- stuck upgrade stops suppressing (relative drift flags again)

🤖 Generated with [Claude Code](https://claude.com/claude-code)