### PR TITLE
🐛 fix(contribute): Operations fleet panels stuck on "Loading…" (#2574 regression)

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -889,7 +889,15 @@ function activateTab(t){
   var panel=document.getElementById(dp);
   if(panel)panel.classList.add('active');
   if((dp==='tab-ops'||dp==='tab-manage')&&!adminStarted){adminStarted=true;initAdmin();}
-  if(dp==='tab-ops'&&!opsStarted){opsStarted=true;opsPoll();ccStart();}
+  // opsPoll() (fleet/policy/work hydration) and ccStart() (the SSE command center)
+  // are INDEPENDENT: a throw in one must never prevent the other from running. The
+  // fleet panels predate the command center, so a command-center start failure must
+  // not leave Connected clankers / Pipeline & policy / My work stuck on "Loading…"
+  // (regression #2574). Each is guarded on its own.
+  if(dp==='tab-ops'&&!opsStarted){opsStarted=true;
+    try{opsPoll();}catch(e){console.error('opsPoll start failed',e);}
+    try{ccStart();}catch(e){console.error('ccStart failed',e);}
+  }
   // Leaderboard hydrates client-side on first open — read-only, no role gate.
   if(dp==='tab-leaderboard'&&!lbStarted){lbStarted=true;loadLeaderboard();}
 }
@@ -1170,8 +1178,17 @@ function idleReasonLabel(r){
   return m[r]||String(r).replace(/_/g,' ');
 }
 function renderClankers(list){
+  list=list||[];
   var el=document.getElementById('clanker-list');
-  document.getElementById('clanker-count').textContent=(list.length)+(list.length===1?' connected':' connected');
+  var cnt=document.getElementById('clanker-count');
+  if(cnt)cnt.textContent=(list.length)+(list.length===1?' connected':' connected');
+  // Update the "your army" roster FIRST and independently of the row render. The
+  // roster (working/reviewing/idle) is derived from the same snapshot, so it must
+  // hydrate even if building an individual clanker row throws — otherwise a single
+  // malformed row leaves BOTH the list on "Loading…" AND the roster at 0/0/0
+  // (regression #2574: the exact live symptom). ccUpdateArmy is itself nil-safe.
+  ccUpdateArmy(list);
+  if(!el)return;
   if(!list.length){el.innerHTML='<div class="ops-empty">No clankers connected right now.</div>';return;}
   el.innerHTML=list.map(function(c){
     var user=c.github_username||c.contributor_id||'clanker';
@@ -1214,8 +1231,6 @@ function renderClankers(list){
       '<div class="clanker-sub">'+(sub||'&mdash;')+'</div>'+task+'</div>'+
       (actions||('<span class="feed-time">'+esc(rel(c.connected_at))+'</span>'))+'</div>';
   }).join('');
-  // Update the "your army" roster header from the same list (army framing).
-  ccUpdateArmy(list);
 }
 // ccUpdateArmy summarises the fleet into working/reviewing/idle counts. Army framing
 // derived entirely from the live fleet snapshot — no fabricated numbers.
@@ -1289,15 +1304,25 @@ function renderPolicy(p){
   el.innerHTML=rows.map(function(r){return '<div class="policy-row"><span class="policy-key">'+r[0]+'</span><span class="policy-val">'+r[1]+'</span></div>';}).join('')+
     '<p class="ops-note">Promotion counts completions that reported a pull request (not bare completed tasks). Auto-promotion only lifts newcomer &rarr; contributor; the trusted tier is granted by an operator, not unlocked automatically.</p>';
 }
+// safeRender runs one panel render in isolation: a throw in one panel must NOT
+// prevent the others from hydrating (regression #2574 left all three stuck when a
+// single render threw). Errors are logged, never silently swallowed.
+function safeRender(name,fn){try{fn();}catch(e){console.error('opsPoll render failed: '+name,e);}}
 async function opsPoll(){
   try{
     var res=await fetch('/api/contribute/fleet');
     var data=await res.json();
-    renderClankers(data.clankers||[]);
-    renderWork(data.work||[]);
-    renderPolicy(data.policy);
-  }catch(e){}
-  if(document.getElementById('tab-ops').classList.contains('active'))setTimeout(opsPoll,4000);
+    // Each panel renders independently — one failing does not block the others.
+    safeRender('clankers',function(){renderClankers((data&&data.clankers)||[]);});
+    safeRender('work',function(){renderWork((data&&data.work)||[]);});
+    safeRender('policy',function(){renderPolicy(data&&data.policy);});
+  }catch(e){
+    // fetch/parse failed — log so the "Loading…" placeholders are diagnosable, and
+    // fall through to reschedule so a transient failure self-heals on the next poll.
+    console.error('opsPoll fetch failed',e);
+  }
+  var tab=document.getElementById('tab-ops');
+  if(tab&&tab.classList.contains('active'))setTimeout(opsPoll,4000);
 }
 
 // ══ Operations command center: live SSE stream driving the ready-work queue, the

--- a/v2/pkg/dashboard/contribute_sse_test.go
+++ b/v2/pkg/dashboard/contribute_sse_test.go
@@ -258,6 +258,89 @@ func TestCommandCenterPublicButControlsGated(t *testing.T) {
 	}
 }
 
+// TestOpsFleetHydrationIsResilient pins the regression fix for #2574: the command
+// center must NOT be able to leave the pre-existing fleet panels (Connected
+// clankers / Pipeline & policy / My work) stuck on their "Loading…" placeholders.
+//
+// The failure mode was JS coupling introduced by #2574:
+//   - renderClankers updated the army roster only AFTER the row map, so a throw in
+//     a row builder left BOTH the list on "Loading fleet…" AND the roster at 0/0/0;
+//   - opsPoll rendered all three panels in one try block with an empty catch, so a
+//     single throw stuck all three with no diagnostics;
+//   - activateTab called opsPoll();ccStart(); on one line, so a ccStart() throw
+//     could abort fleet hydration.
+//
+// We can't execute the inline JS in a Go test, so we assert the RESILIENCE WIRING
+// is present in the served page: the roster hydrates independently of the rows,
+// each panel renders in isolation (safeRender), errors are logged not swallowed,
+// and opsPoll()/ccStart() are guarded independently. A separate node --check in CI
+// (and the PR's manual harness) covers runtime correctness.
+func TestOpsFleetHydrationIsResilient(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+
+	// The three fleet panels + their placeholders must still exist (the panels we
+	// are keeping alive).
+	for _, want := range []string{
+		`id="clanker-list"`, `Loading fleet`,
+		`id="policy-body"`, `Loading policy`,
+		`id="work-list"`, `Loading work`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("served page missing fleet panel marker %q", want)
+		}
+	}
+
+	// Resilience wiring introduced by the fix:
+	for _, want := range []string{
+		// opsPoll renders each panel in isolation so one throw cannot stick all three.
+		`function safeRender`,
+		`safeRender('clankers'`,
+		`safeRender('work'`,
+		`safeRender('policy'`,
+		// Errors are logged, never silently swallowed (the old empty catch{}).
+		`opsPoll fetch failed`,
+		// opsPoll() and ccStart() are started independently so one throwing cannot
+		// prevent the other.
+		`try{opsPoll();}catch`,
+		`try{ccStart();}catch`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("served page missing resilience wiring %q (regression #2574 could recur)", want)
+		}
+	}
+
+	// The army roster must be updated BEFORE the row map in renderClankers, so a
+	// row-build throw cannot leave the roster at 0/0/0. Assert ccUpdateArmy(list)
+	// appears ahead of the row map (el.innerHTML=list.map) within renderClankers.
+	rc := body[strings.Index(body, "function renderClankers"):]
+	rc = rc[:strings.Index(rc, "function ccUpdateArmy")]
+	army := strings.Index(rc, "ccUpdateArmy(list)")
+	rowMap := strings.Index(rc, "el.innerHTML=list.map")
+	if army < 0 || rowMap < 0 {
+		t.Fatalf("renderClankers missing expected structure (army=%d rowMap=%d)", army, rowMap)
+	}
+	if army > rowMap {
+		t.Errorf("renderClankers updates the army roster AFTER the row map; a row throw would leave the roster at 0/0/0 (regression #2574)")
+	}
+
+	// The command center must stay intact alongside the fix.
+	for _, want := range []string{`function ccStart`, `id="cc-queue"`, `id="cc-log"`, `id="cc-army"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("fix regressed the command center: missing %q", want)
+		}
+	}
+}
+
 // waitFor polls cond up to ~2s. Keeps the SSE tests free of fixed sleeps that would
 // be flaky under load while still bounding the wait.
 func waitFor(t *testing.T, cond func() bool, what string) {


### PR DESCRIPTION
## Live regression

On the `/contribute` **Operations** tab, three panels were stuck forever on their loading placeholders on a production hive:

- **Connected clankers** → "Loading fleet…", with the "Your army" roster showing **0 working / 0 reviewing / 0 idle** (but "1 connected").
- **Pipeline & policy** → "Loading policy…".
- **My work** → "Loading work…".

The backend is fine: `GET /api/contribute/fleet` returns valid, complete JSON (HTTP 200, correct shape). The command center added in #2574 broke the **client-side** fleet-hydration path that predates it, so the placeholders were never replaced.

`Fixes` the regression from #2574.

## Root cause (all client-side, `v2/pkg/dashboard/api_contribute.go`)

#2574 coupled three things that must be independent:

1. **`renderClankers`** updated the "Your army" roster (`ccUpdateArmy(list)`) **only after** `el.innerHTML=list.map(...)`. So a throw while building any clanker row left **both** the list on "Loading fleet…" **and** the roster at 0/0/0 — the exact live symptom (count set to "1 connected", roster stuck at 0/0/0, list on the placeholder).
2. **`opsPoll`** rendered all three panels inside one `try` with an **empty `catch(e){}`** that swallowed the error silently, so a single throw stuck **all three** panels with zero diagnostics — and it still rescheduled, so it kept re-throwing every 4s.
3. **`activateTab`** ran `opsPoll();ccStart();` on one line; a synchronous throw in the new `ccStart()` could abort before/around fleet hydration.

## Fix

- `renderClankers` now calls `ccUpdateArmy(list)` **first**, independently of the row render, so the roster hydrates even if a row builder throws. Nil-safe DOM lookups.
- `opsPoll` renders each panel in isolation via a small `safeRender` helper (errors **logged, never swallowed**) and **always reschedules**, so a transient/one-panel failure self-heals on the next poll.
- `opsPoll()` and `ccStart()` are started under **independent** `try/catch` — one throwing can no longer prevent the other.

The backend `/api/contribute/fleet` and `FleetSnapshot` are unchanged (they are correct). The command center (ready-work queue, dev-log, SSE stream, travel animation, achievements) and the public-page / gated-controls invariant are untouched.

## Verification

Rendered the real served page and executed the inline `renderClankers`/`renderWork`/`renderPolicy`/`opsPoll` against the exact live fleet JSON (castrojo, goose, `current_task` on `projectbluefin/actions#375`):

- Connected clankers shows **castrojo working on actions#375**;
- army roster shows **1 working / 0 reviewing / 0 idle**;
- Pipeline & policy shows the deny-lists + **auto-promote 5 / trusted 20**;
- My work shows the **in-progress actions#375** item.

A fault-injection run confirms a throwing row no longer blanks the roster, and a throwing clankers-render no longer blocks work/policy. `go build`, `go vet`, `gofmt`, `node --check` (extracted inline script) and the full `pkg/dashboard` test suite pass. Adds `TestOpsFleetHydrationIsResilient` pinning the resilience wiring and the roster-before-rows ordering so the regression can't silently recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)