### PR TITLE
✨ feat(spoke): invocation attribution trailer + audit trail for agent PRs and issues

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1049,6 +1049,20 @@ func main() {
 			" has no installation for this org — install it (the spoke adopts the installation automatically)"
 	}
 
+	// Invocation-attribution trail (pkg/github/attribution.go): stamp hive-
+	// created PRs/issues with what the hive invoked, and audit every such
+	// creation. Wired in stages as dependencies come up: the trailer gate now
+	// (cfg exists, and the advisory-issue ensure just below must respect the
+	// toggle), the per-agent resolver after the agent manager exists, and the
+	// audit sink after the dashboard server exists. cfg is the live pointer
+	// (the config watcher swaps contents in place), so the toggle is read
+	// fresh per creation — a dashboard flip takes effect immediately.
+	if ghClient != nil {
+		ghClient.SetAttributionHooks(github.AttributionHooks{
+			TrailerEnabled: func() bool { return cfg.Governor.AttributionTrailerEnabled() },
+		})
+	}
+
 	// Find or create the pinned advisory issue. Any level can have advisory
 	// agents whose findings should be posted to this issue.
 	advisoryIssues := map[string]int{}
@@ -1168,6 +1182,30 @@ func main() {
 	// as, and requests simply accumulate rather than opening under a wrong
 	// identity. ghClient uses the App installation token (see ghAuth wiring).
 	if ghClient != nil && cfg.GitHub.HasUsableApp() {
+		// Attribution resolver: effective backend/model from the manager
+		// (runtime overrides included), falling back to the configured values
+		// for an agent the manager does not know; tool version resolved
+		// lazily per backend and cached. Only launch descriptors flow here —
+		// never tokens, keys, or prompt content.
+		ghClient.SetAttributionResolver(func(agentName string) github.InvocationMeta {
+			backend, model, known := agentMgr.InvocationMetadata(agentName)
+			if !known {
+				if ac, inCfg := cfg.Agents[agentName]; inCfg {
+					backend, model = ac.Backend, ac.Model
+				}
+			}
+			tool, toolVersion := github.ResolveToolVersion(backend)
+			return github.InvocationMeta{
+				Agent:   agentName,
+				Backend: backend,
+				// bob self-selects (no catalog): requested model is honestly
+				// "auto" — see github.RequestedModel for the known follow-up
+				// on discovering bob's internal routing.
+				Model:       github.RequestedModel(backend, model),
+				Tool:        tool,
+				ToolVersion: toolVersion,
+			}
+		})
 		// authz enforces the SAME per-agent ACMM write-gate + forge-resistance as
 		// the direct `gh pr create` path — the request-file route grants no extra
 		// privilege. A denied request is quarantined, never opened.
@@ -1344,6 +1382,17 @@ func main() {
 	// bug on direct-route spokes. /data is the CephFS PVC (same place cost/fact
 	// history persist).
 	dashSrv.EnableSessionPersistence("/data/dashboard-sessions.json")
+
+	// Attribution audit sink: every hive-mediated PR/issue creation lands in
+	// the dashboard audit log (audit.jsonl + ring) UNCONDITIONALLY — the
+	// trailer toggle never gates this. Creations before this point (the
+	// startup advisory-issue ensure) fall back to the hive log inside
+	// recordCreationAudit, so no creation goes unrecorded.
+	if ghClient != nil {
+		ghClient.SetAttributionAudit(func(action, detail, agent string) {
+			dashSrv.AuditLog("system", action, detail, agent)
+		})
+	}
 
 	// Seed token sparkline history now that the dashboard server exists
 	if len(pendingTokenSeed) > 0 {

--- a/v2/pkg/agent/invocation_metadata_test.go
+++ b/v2/pkg/agent/invocation_metadata_test.go
@@ -1,0 +1,71 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// TestInvocationMetadata pins the contract the invocation-attribution trail
+// depends on: the EFFECTIVE backend/model (runtime overrides win over config),
+// and ok=false for an agent the manager does not know.
+func TestInvocationMetadata(t *testing.T) {
+	tests := []struct {
+		name        string
+		agent       *AgentProcess
+		wantBackend string
+		wantModel   string
+	}{
+		{
+			name:        "config values with no overrides",
+			agent:       &AgentProcess{Name: "a", Config: config.AgentConfig{Backend: "claude", Model: "claude-opus-4-6"}},
+			wantBackend: "claude",
+			wantModel:   "claude-opus-4-6",
+		},
+		{
+			name: "backend override wins over config",
+			agent: &AgentProcess{Name: "a", Config: config.AgentConfig{Backend: "claude", Model: "claude-opus-4-6"},
+				BackendOverride: "copilot"},
+			wantBackend: "copilot",
+			wantModel:   "claude-opus-4-6",
+		},
+		{
+			name: "model override wins over config",
+			agent: &AgentProcess{Name: "a", Config: config.AgentConfig{Backend: "claude", Model: "claude-opus-4-6"},
+				ModelOverride: "claude-haiku-4-5"},
+			wantBackend: "claude",
+			wantModel:   "claude-haiku-4-5",
+		},
+		{
+			name:        "empty config stays empty (omitted, never guessed)",
+			agent:       &AgentProcess{Name: "a"},
+			wantBackend: "",
+			wantModel:   "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := testManager(acmmLevelPushCapable)
+			m.agents["a"] = tc.agent
+
+			backend, model, ok := m.InvocationMetadata("a")
+			if !ok {
+				t.Fatal("InvocationMetadata: ok=false for a known agent")
+			}
+			if backend != tc.wantBackend || model != tc.wantModel {
+				t.Errorf("InvocationMetadata = (%q, %q), want (%q, %q)",
+					backend, model, tc.wantBackend, tc.wantModel)
+			}
+		})
+	}
+}
+
+// TestInvocationMetadataUnknownAgent: the caller falls back to static config
+// on ok=false, so an unknown name must report exactly that — not guesses.
+func TestInvocationMetadataUnknownAgent(t *testing.T) {
+	m := testManager(acmmLevelPushCapable)
+	if backend, model, ok := m.InvocationMetadata("nobody"); ok || backend != "" || model != "" {
+		t.Errorf("unknown agent must be (\"\", \"\", false); got (%q, %q, %v)", backend, model, ok)
+	}
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -26,11 +26,11 @@ import (
 type ProcessState string
 
 const (
-	StateIdle     ProcessState = "idle"
-	StateRunning  ProcessState = "running"
-	StateStopped  ProcessState = "stopped"
-	StateFailed   ProcessState = "failed"
-	StatePaused   ProcessState = "paused"
+	StateIdle    ProcessState = "idle"
+	StateRunning ProcessState = "running"
+	StateStopped ProcessState = "stopped"
+	StateFailed  ProcessState = "failed"
+	StatePaused  ProcessState = "paused"
 )
 
 type KickRecord struct {
@@ -49,40 +49,40 @@ const (
 )
 
 type AgentProcess struct {
-	Name            string
-	ID              string
-	Config          config.AgentConfig
-	State           ProcessState
-	PID             int
-	UID             int
-	StartedAt       *time.Time
-	LastKick        *time.Time
-	Paused          bool
-	PausedAt        time.Time
-	PausedReason    string
-	PausedTrigger   string
-	PinnedCLI       string
-	PinnedModel     string
-	ModelOverride   string
-	BackendOverride string
-	RestartCount    int
-	OutputBuffer    *RingBuffer
-	lastPaneCapture []string
-	paneMu          sync.RWMutex
-	KickHistory     []KickRecord
-	LastKickMessage    string
-	KickRefused        bool
-	KickRefusalReason  string
-	LaunchedMode       AgentMode
-	HasLaunched     bool
-	tmuxSession     string
-	tmuxSocket      string
-	cancel context.CancelFunc
-	forceRelaunch       bool
-	BootstrapOverride   string // when set, replaces buildBootstrapPrompt output
-	LastError           string // captured from bare copilot diagnostic launch
-	lastTokenRestart    time.Time // cooldown for auto-restart after token detection
-	NeedsLogin          bool   // true when pane shows a login prompt
+	Name              string
+	ID                string
+	Config            config.AgentConfig
+	State             ProcessState
+	PID               int
+	UID               int
+	StartedAt         *time.Time
+	LastKick          *time.Time
+	Paused            bool
+	PausedAt          time.Time
+	PausedReason      string
+	PausedTrigger     string
+	PinnedCLI         string
+	PinnedModel       string
+	ModelOverride     string
+	BackendOverride   string
+	RestartCount      int
+	OutputBuffer      *RingBuffer
+	lastPaneCapture   []string
+	paneMu            sync.RWMutex
+	KickHistory       []KickRecord
+	LastKickMessage   string
+	KickRefused       bool
+	KickRefusalReason string
+	LaunchedMode      AgentMode
+	HasLaunched       bool
+	tmuxSession       string
+	tmuxSocket        string
+	cancel            context.CancelFunc
+	forceRelaunch     bool
+	BootstrapOverride string    // when set, replaces buildBootstrapPrompt output
+	LastError         string    // captured from bare copilot diagnostic launch
+	lastTokenRestart  time.Time // cooldown for auto-restart after token detection
+	NeedsLogin        bool      // true when pane shows a login prompt
 	// LastPaneChange is when the agent's tmux pane content last CHANGED, as
 	// observed by the 3s pane poller. It is the spoke's only evidence of an
 	// agent actually doing something: State says what the manager intends,
@@ -91,17 +91,17 @@ type AgentProcess struct {
 	// authenticated CLI sits there producing nothing. Written under paneMu by
 	// pollTmuxOutputForAgent alongside lastPaneCapture; zero until the poller
 	// has seen two differing captures, which reads as "unknown", never "idle".
-	LastPaneChange      time.Time
-	consentSeenAt       time.Time // watcher: when a consent screen was first seen in the pane
-	lastConsentDismiss  time.Time // watcher: cooldown for re-running dismissInferencePrompts
-	lastInferKickAt     time.Time // stall watchdog: when the last kick was delivered to an inference agent
-	lastInferKickPane   string    // stall watchdog: hash of the visible pane just after kick delivery
-	stallNudgeSent      bool      // stall watchdog: at most one nudge per kick
-	StallNudges         int       // total post-kick stall nudges sent (surfaced to the dashboard)
-	launchGen           int       // increments per launch; stale deliverStartupKick goroutines check it and drop
-	lastInferKickMarks  int       // no-action watchdog: tool-marker count in pane+scrollback just after kick delivery
-	actionNudgeSent     bool      // no-action watchdog: at most one action nudge per kick
-	ActionNudges        int       // total prose-only-response action nudges sent (surfaced to the dashboard)
+	LastPaneChange     time.Time
+	consentSeenAt      time.Time // watcher: when a consent screen was first seen in the pane
+	lastConsentDismiss time.Time // watcher: cooldown for re-running dismissInferencePrompts
+	lastInferKickAt    time.Time // stall watchdog: when the last kick was delivered to an inference agent
+	lastInferKickPane  string    // stall watchdog: hash of the visible pane just after kick delivery
+	stallNudgeSent     bool      // stall watchdog: at most one nudge per kick
+	StallNudges        int       // total post-kick stall nudges sent (surfaced to the dashboard)
+	launchGen          int       // increments per launch; stale deliverStartupKick goroutines check it and drop
+	lastInferKickMarks int       // no-action watchdog: tool-marker count in pane+scrollback just after kick delivery
+	actionNudgeSent    bool      // no-action watchdog: at most one action nudge per kick
+	ActionNudges       int       // total prose-only-response action nudges sent (surfaced to the dashboard)
 
 	// awaitingBobKey marks an agent that launchInTmux parked in StateFailed
 	// for the single, fully-recoverable reason "bob backend with no API key".
@@ -529,11 +529,11 @@ func NewManager(agents map[string]config.AgentConfig, logger *slog.Logger, proje
 			}
 		}
 		m.agents[name] = &AgentProcess{
-			Name:         name,
-			ID:           agentID,
-			Config:       cfg,
-			State:        StateStopped,
-			UID:          agentUID,
+			Name:   name,
+			ID:     agentID,
+			Config: cfg,
+			State:  StateStopped,
+			UID:    agentUID,
 			// Restore a persisted operator pause so a restart/upgrade
 			// doesn't silently un-pause the agent.
 			Paused:       cfg.Paused,
@@ -929,7 +929,6 @@ func paneShowsConsentScreen(pane string) bool {
 	}
 	return false
 }
-
 
 // backendDefersStartupKick reports whether a backend's bootstrap prompt is
 // delivered AFTER the CLI is ready (deliverStartupKick) instead of being
@@ -1702,7 +1701,6 @@ func (m *Manager) findACMMFragments() []string {
 	return files
 }
 
-
 func (m *Manager) buildProjectPreamble(agent *AgentProcess) string {
 	p := m.project
 	if p.Org == "" || len(p.Repos) == 0 {
@@ -2066,7 +2064,6 @@ func findOverlap(prev, curr []string) int {
 	}
 	return -1
 }
-
 
 // paneShowsInputPrompt reports whether the pane content shows a CLI input
 // prompt that is ready to accept a kick.
@@ -3301,13 +3298,13 @@ func (m *Manager) tmuxSendKeysForAgent(agent *AgentProcess, keys ...string) {
 }
 
 const (
-	clearBeforeKickDelay  = 2 * time.Second
-	enterCount            = 3
-	enterDelay            = 300 * time.Millisecond
-	textToEnterDelay      = 1 * time.Second
-	chunkSize             = 400
-	chunkDelay            = 1 * time.Second
-	staleCheckDelay       = 1 * time.Second
+	clearBeforeKickDelay    = 2 * time.Second
+	enterCount              = 3
+	enterDelay              = 300 * time.Millisecond
+	textToEnterDelay        = 1 * time.Second
+	chunkSize               = 400
+	chunkDelay              = 1 * time.Second
+	staleCheckDelay         = 1 * time.Second
 	cliReadyPollInterval    = 2 * time.Second
 	cliReadyTimeout         = 60 * time.Second
 	inputPromptPollInterval = 2 * time.Second
@@ -3959,8 +3956,8 @@ func (m *Manager) fixSharedConfigPerms(agent *AgentProcess) {
 }
 
 const (
-	claudeInferenceSettingsPath  = "/tmp/.claude-inference-settings.json"
-	claudeInferenceHomePrefix = "/tmp/.claude-inference-home-"
+	claudeInferenceSettingsPath = "/tmp/.claude-inference-settings.json"
+	claudeInferenceHomePrefix   = "/tmp/.claude-inference-home-"
 )
 
 // inferenceHomePath returns the per-agent inference HOME directory.
@@ -4017,11 +4014,11 @@ const bobBackend = "bob"
 //     by `["debug",...,"auth-method"].forEach(c=>t.hide(c))`. Verified by
 //     running the real 1.0.6 bundle: `--help` is 67 lines with 0 matches for
 //     auth-method, yet the parser distinguishes it from a typo —
-//       $ bob --definitely-not-a-flag x -p hi
-//       Unknown arguments: definitely-not-a-flag, definitelyNotAFlag
-//       $ bob --auth-method bogus-value -p hi
-//       Invalid values: Argument: auth-method, Given: "bogus-value",
-//                       Choices: "sso", "api-key"
+//     $ bob --definitely-not-a-flag x -p hi
+//     Unknown arguments: definitely-not-a-flag, definitelyNotAFlag
+//     $ bob --auth-method bogus-value -p hi
+//     Invalid values: Argument: auth-method, Given: "bogus-value",
+//     Choices: "sso", "api-key"
 //     while `--auth-method api-key` is accepted silently. An unknown flag under
 //     yargs .strict() would have errored, so the option is live.
 //
@@ -4534,6 +4531,27 @@ func (m *Manager) AuthorizePROpen(agentName string, fileUID int) error {
 			agentName, m.agentMode(agent).String())
 	}
 	return nil
+}
+
+// InvocationMetadata reports the effective backend and model the hive invokes
+// for the named agent, accounting for runtime overrides — the launch-time
+// truth the invocation-attribution trail records (see pkg/github/attribution
+// .go). ok=false when the agent is unknown to the manager (the caller then
+// falls back to static config). Read-only under RLock; called from the
+// PR-request watcher goroutine, never from the launch path.
+func (m *Manager) InvocationMetadata(agentName string) (backend, model string, ok bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	agent, exists := m.agents[agentName]
+	if !exists {
+		return "", "", false
+	}
+	backend = effectiveBackend(agent)
+	model = agent.Config.Model
+	if agent.ModelOverride != "" {
+		model = agent.ModelOverride
+	}
+	return backend, model, true
 }
 
 // filteredEnv returns os.Environ() with write-capable tokens removed for advisory agents.

--- a/v2/pkg/config/attribution_trailer_test.go
+++ b/v2/pkg/config/attribution_trailer_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestAttributionTrailerDefaultOn(t *testing.T) {
+	// nil (key omitted) → enabled: an untouched hive stamps the trailer.
+	var g GovernorConfig
+	if !g.AttributionTrailerEnabled() {
+		t.Error("omitted governor.attribution_trailer must default to on")
+	}
+	// explicit false → disabled (trailer only; audit is not gated here).
+	f := false
+	g.AttributionTrailer = &f
+	if g.AttributionTrailerEnabled() {
+		t.Error("explicit attribution_trailer=false must disable the trailer")
+	}
+	// explicit true → enabled
+	tr := true
+	g.AttributionTrailer = &tr
+	if !g.AttributionTrailerEnabled() {
+		t.Error("explicit attribution_trailer=true must enable the trailer")
+	}
+}
+
+func TestAttributionTrailerYAMLParsing(t *testing.T) {
+	// Absent key parses to nil → default ON.
+	var g GovernorConfig
+	if err := yaml.Unmarshal([]byte("eval_interval_s: 30\n"), &g); err != nil {
+		t.Fatal(err)
+	}
+	if g.AttributionTrailer != nil || !g.AttributionTrailerEnabled() {
+		t.Errorf("absent key: pointer=%v enabled=%v, want nil/true", g.AttributionTrailer, g.AttributionTrailerEnabled())
+	}
+	// Explicit false round-trips as an explicit false, not as "unset".
+	g = GovernorConfig{}
+	if err := yaml.Unmarshal([]byte("attribution_trailer: false\n"), &g); err != nil {
+		t.Fatal(err)
+	}
+	if g.AttributionTrailer == nil || *g.AttributionTrailer || g.AttributionTrailerEnabled() {
+		t.Errorf("explicit false not honored: pointer=%v", g.AttributionTrailer)
+	}
+	// Explicit true.
+	g = GovernorConfig{}
+	if err := yaml.Unmarshal([]byte("attribution_trailer: true\n"), &g); err != nil {
+		t.Fatal(err)
+	}
+	if g.AttributionTrailer == nil || !*g.AttributionTrailer || !g.AttributionTrailerEnabled() {
+		t.Errorf("explicit true not honored: pointer=%v", g.AttributionTrailer)
+	}
+}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -587,6 +587,25 @@ type GovernorConfig struct {
 	// gateway named "litellm" is synthesized from the legacy LiteLLM block above
 	// so existing hives keep working with zero config change. See ResolveGateway.
 	Gateways []GatewayConfig `yaml:"gateways"`
+	// AttributionTrailer controls the VISIBLE invocation-attribution line
+	// ("— hive: agent=… backend=… model=…") appended at creation time to the
+	// body of PRs the hive opens for agents (the PR-request watcher) and issues
+	// the hive itself creates. It is a *bool so absent (nil) is distinct from an
+	// explicit false: default is ON (see AttributionTrailerEnabled), matching
+	// the github.app_authored_prs convention. It gates ONLY the visible trailer
+	// — the audit-log entry for every such creation is written unconditionally,
+	// so turning this off never removes the operator's ability to answer "which
+	// backend/model produced this PR?".
+	AttributionTrailer *bool `yaml:"attribution_trailer,omitempty"`
+}
+
+// AttributionTrailerEnabled reports whether the visible attribution trailer on
+// hive-created PRs/issues is on for this hive. Default ON: a hive that says
+// nothing gets the trailer; set `governor.attribution_trailer: false` to hide
+// it. The audit-log entry for each creation is unconditional and is NOT gated
+// by this.
+func (g *GovernorConfig) AttributionTrailerEnabled() bool {
+	return g.AttributionTrailer == nil || *g.AttributionTrailer
 }
 
 // GatewayConfig is one named, OpenAI-compatible model gateway. A hive may

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -117,6 +117,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("PUT /api/config/governor/notifications", s.handleGovernorNotifications)
 	s.mux.HandleFunc("PUT /api/config/governor/health", s.handleGovernorHealth)
 	s.mux.HandleFunc("PUT /api/config/governor/logging", s.handleGovernorLogging)
+	s.mux.HandleFunc("PUT /api/config/governor/attribution", s.handleGovernorAttribution)
 	s.mux.HandleFunc("PUT /api/config/governor/hub", s.handleGovernorHub)
 	s.mux.HandleFunc("PUT /api/config/governor/litellm", s.handleGovernorLiteLLM)
 	s.mux.HandleFunc("PUT /api/config/governor/trajectory", s.handleGovernorTrajectory)
@@ -3524,6 +3525,11 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 		},
 		"litellm":    litellmSectionResponse(&cfg.Governor.LiteLLM),
 		"trajectory": trajectorySectionResponse(&cfg.Governor),
+		"attribution": map[string]interface{}{
+			// Effective value (default ON when unset) — the UI renders the
+			// switch from this, so an untouched hive shows it on.
+			"attributionTrailer": cfg.Governor.AttributionTrailerEnabled(),
+		},
 		"hub": map[string]interface{}{
 			"enabled": cfg.Hub.Enabled,
 			// namespace is read-only, runtime-derived display info (never
@@ -3894,6 +3900,30 @@ func (s *Server) handleGovernorLogging(w http.ResponseWriter, r *http.Request) {
 		s.logger.Error("failed to persist config after logging update", "error", err)
 	}
 	s.auditFromRequest(r, "config_governor_logging", auditDetail("section", "logging"), "")
+	s.refreshAndPersist()
+	okResponse(w, map[string]string{"status": "updated"})
+}
+
+// handleGovernorAttribution updates the hive-wide attribution-trailer toggle.
+// One boolean, applied to ALL agents (no per-agent granularity): it gates ONLY
+// the visible "— hive: …" trailer appended to hive-created PRs and issues.
+// The audit-log entry for every such creation is written unconditionally, so
+// turning the trailer off never loses the invocation record.
+func (s *Server) handleGovernorAttribution(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		AttributionTrailer *bool `json:"attributionTrailer"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	if body.AttributionTrailer != nil {
+		s.deps.Config.Governor.AttributionTrailer = body.AttributionTrailer
+	}
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after attribution update", "error", err)
+	}
+	s.auditFromRequest(r, "config_governor_attribution", auditDetail("section", "attribution"), "")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
 }

--- a/v2/pkg/dashboard/api_acmm_eval.go
+++ b/v2/pkg/dashboard/api_acmm_eval.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
 	gh "github.com/google/go-github/v72/github"
+
+	"github.com/kubestellar/hive/v2/pkg/github"
 )
 
 const acmmEvalTTL = time.Hour
@@ -212,6 +215,15 @@ func (s *Server) handleACMMCreateIssue(w http.ResponseWriter, r *http.Request) {
 		acmmCriterionWhyItMatters(criterion.Level, criterion.Category),
 	)
 
+	// Invocation-attribution trail: this issue is created by the hive on an
+	// operator's dashboard action — stamp the (config-gated) visible trailer
+	// and, after creation, record the (unconditional) audit entry: the same
+	// two layers the PR-request watcher applies (see pkg/github/attribution.go).
+	meta := github.InvocationMeta{Agent: github.AttributionAgentDashboard}
+	if s.deps.Config.Governor.AttributionTrailerEnabled() {
+		body = github.AppendTrailer(body, meta)
+	}
+
 	issueReq := &gh.IssueRequest{
 		Title: gh.Ptr(title),
 		Body:  gh.Ptr(body),
@@ -225,6 +237,13 @@ func (s *Server) handleACMMCreateIssue(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("failed to create issue: %v", err), http.StatusInternalServerError)
 		return
 	}
+	// Unconditional audit entry — written even with the trailer toggled off.
+	s.auditFromRequest(r, github.AuditActionHiveIssueCreated,
+		meta.AuditDetail(
+			"repo", owner+"/"+req.Repo,
+			"number", strconv.Itoa(issue.GetNumber()),
+			"url", issue.GetHTMLURL(),
+			"flow", "acmm-eval"), "")
 
 	jsonResponse(w, map[string]interface{}{
 		"issue_number": issue.GetNumber(),
@@ -359,9 +378,9 @@ func (s *Server) prefetchDirectories(ctx context.Context, owner, repo string) ma
 	cache := make(map[string]map[string]bool)
 
 	dirs := []string{
-		"",                   // root
-		".github",            // templates, configs
-		".github/workflows",  // CI workflows
+		"",                  // root
+		".github",           // templates, configs
+		".github/workflows", // CI workflows
 		".github/ISSUE_TEMPLATE",
 		".github/prompts",
 		".github/agents",

--- a/v2/pkg/dashboard/api_governor_attribution_test.go
+++ b/v2/pkg/dashboard/api_governor_attribution_test.go
@@ -1,0 +1,70 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// governorAttributionValue reads the effective attribution.attributionTrailer
+// boolean out of GET /api/config/governor.
+func governorAttributionValue(t *testing.T, s *Server) bool {
+	t.Helper()
+	rec := doGet(s, "/api/config/governor")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET governor config: %d", rec.Code)
+	}
+	var resp struct {
+		Attribution struct {
+			AttributionTrailer bool `json:"attributionTrailer"`
+		} `json:"attribution"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	return resp.Attribution.AttributionTrailer
+}
+
+func TestGovAttribution_DefaultOnAndToggle(t *testing.T) {
+	s := govServer(t)
+
+	// Untouched config → default ON reflected to the UI.
+	if !governorAttributionValue(t, s) {
+		t.Fatal("attributionTrailer must default to on")
+	}
+	if !s.deps.Config.Governor.AttributionTrailerEnabled() {
+		t.Fatal("config accessor must default to on")
+	}
+
+	// Bad body → 400.
+	if rec := doPutRaw(s, "/api/config/governor/attribution", "bad"); rec.Code != http.StatusBadRequest {
+		t.Fatalf("bad body: expected 400, got %d", rec.Code)
+	}
+
+	// Toggle OFF: gates ONLY the trailer; persisted as an explicit false.
+	if rec := doPut(s, "/api/config/governor/attribution", map[string]any{"attributionTrailer": false}); rec.Code != http.StatusOK {
+		t.Fatalf("put false: %d", rec.Code)
+	}
+	if s.deps.Config.Governor.AttributionTrailer == nil || *s.deps.Config.Governor.AttributionTrailer {
+		t.Fatal("explicit false must be stored as an explicit false pointer")
+	}
+	if governorAttributionValue(t, s) {
+		t.Fatal("GET must reflect the trailer off")
+	}
+
+	// Absent field in the body → no change (partial-update convention).
+	if rec := doPut(s, "/api/config/governor/attribution", map[string]any{}); rec.Code != http.StatusOK {
+		t.Fatalf("put empty: %d", rec.Code)
+	}
+	if s.deps.Config.Governor.AttributionTrailerEnabled() {
+		t.Fatal("empty body must not flip the stored value")
+	}
+
+	// Toggle back ON.
+	if rec := doPut(s, "/api/config/governor/attribution", map[string]any{"attributionTrailer": true}); rec.Code != http.StatusOK {
+		t.Fatalf("put true: %d", rec.Code)
+	}
+	if !governorAttributionValue(t, s) {
+		t.Fatal("GET must reflect the trailer back on")
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -16301,6 +16301,8 @@ function burnAreaChart() {
     function renderGovGeneral() {
       const currentId = (window._lastStatus || {}).hiveId || '';
       const currentACMMLevel = (window._lastStatus || {}).acmmLevel || 0;
+      const attrib = (_configState.data || {}).attribution || {};
+      const attribOn = attrib.attributionTrailer !== false; // default on
       const traj = (_configState.data || {}).trajectory || {};
       const trajOn = traj.enabled !== false; // default on
       const trajReady = traj.reviewerReady === true;
@@ -16330,6 +16332,10 @@ function burnAreaChart() {
             <button class="btn" onclick="closeConfigDialog();openACMMDialog()" title="Open the ACMM maturity level selector">Change&hellip;</button>
           </div>
           <span style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:block">Each level applies a curated agent pack. Change&hellip; opens the level selector.</span>
+        </div>
+        <div class="config-toggle" style="margin-top:14px">
+          <div class="config-toggle-switch ${attribOn ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="attribution" data-key="attributionTrailer"></div>
+          <span class="config-toggle-label">Attribution Trailer <span class="config-info">i<span class="config-tooltip">Append attribution trailer (agent, backend, model) to agent-created PRs and issues &mdash; audit log always records regardless. Hive-wide: one setting for all agents.</span></span></span>
         </div>
         <div class="config-field" style="border-top:1px solid var(--border);margin-top:18px;padding-top:16px">
           <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap">

--- a/v2/pkg/github/advisory.go
+++ b/v2/pkg/github/advisory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -57,6 +58,15 @@ func (c *Client) EnsureAdvisoryIssue(ctx context.Context, repo string) (int, err
 		"The governor posts periodic digest comments summarizing what advisory agents found.\n\n" +
 		"**Do not close this issue.** It is a living document."
 
+	// Invocation-attribution trail (attribution.go): this issue is created by
+	// the hive itself, so the "agent" is the governor flow — backend/model are
+	// genuinely unknown here and are omitted rather than guessed. Trailer is
+	// config-gated; the audit entry below is unconditional.
+	meta := InvocationMeta{Agent: AttributionAgentGovernor}
+	if c.attributionTrailerOn() {
+		body = AppendTrailer(body, meta)
+	}
+
 	req := &gh.IssueRequest{
 		Title: gh.Ptr(advisoryTitle),
 		Body:  gh.Ptr(body),
@@ -68,6 +78,11 @@ func (c *Client) EnsureAdvisoryIssue(ctx context.Context, repo string) (int, err
 	if err != nil {
 		return 0, fmt.Errorf("creating advisory issue: %w", err)
 	}
+	c.recordCreationAudit(AuditActionHiveIssueCreated, meta,
+		"repo", owner+"/"+repo,
+		"number", strconv.Itoa(issue.GetNumber()),
+		"url", issue.GetHTMLURL(),
+		"flow", "advisory")
 
 	c.logger.Info("created advisory issue — pin it manually for visibility", slog.String("repo", repo), slog.Int("number", issue.GetNumber()))
 	return issue.GetNumber(), nil

--- a/v2/pkg/github/attribution.go
+++ b/v2/pkg/github/attribution.go
@@ -1,0 +1,340 @@
+package github
+
+import (
+	"context"
+	"log/slog"
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// This file is the invocation-attribution trail for artifacts the hive itself
+// creates on GitHub: agent PRs opened by the PR-request watcher and issues the
+// hive creates (advisory issue, dashboard ACMM-gap issues). It exists because
+// an operator looking at an agent-authored PR previously had no way to answer
+// "which backend/model produced this?" — the App-bot author is deterministic
+// by design, so the invocation metadata must be recorded separately.
+//
+// Two layers, fed from the same launch-time metadata:
+//
+//  1. A VISIBLE one-line trailer appended to the artifact body at creation
+//     time, gated by governor.attribution_trailer (default ON).
+//  2. An AUDIT entry recorded for every such creation through the hooked
+//     audit sink (the dashboard's audit.jsonl + ring buffer), written
+//     regardless of the trailer toggle.
+//
+// Scope: only creations the hive MEDIATES are stamped. An issue an agent opens
+// directly through its own CLI never passes through this code and is not
+// covered — that limitation is intentional (the hive records what IT invoked,
+// it does not rewrite artifacts it did not create).
+
+// AttributionTrailerPrefix opens the visible trailer line. Neutral wording,
+// stable and greppable — also the marker AppendTrailer uses to avoid stacking
+// a second trailer onto a retried request.
+const AttributionTrailerPrefix = "— hive:"
+
+// Audit action names for creation events, following the audit log's
+// snake_case action convention (cf. "config_governor_health").
+const (
+	// AuditActionAgentPRCreated is the audit action recorded when the
+	// PR-request watcher opens a PR on an agent's behalf.
+	AuditActionAgentPRCreated = "agent_pr_created"
+	// AuditActionHiveIssueCreated is the audit action recorded when the hive
+	// itself creates an issue (advisory issue, ACMM-gap issue).
+	AuditActionHiveIssueCreated = "hive_issue_created"
+)
+
+// System "agent" names recorded for creations no single coding agent
+// performed. They occupy the same trailer/audit field as real agent names, so
+// they must never collide with a configured agent name pattern in practice.
+const (
+	// AttributionAgentGovernor marks creations the governor/startup path makes
+	// itself (e.g. the pinned advisory issue).
+	AttributionAgentGovernor = "governor"
+	// AttributionAgentDashboard marks creations triggered by an operator
+	// action in the dashboard (e.g. ACMM-gap issues).
+	AttributionAgentDashboard = "dashboard"
+)
+
+// backend ids / tool names used by the attribution mapping. These mirror the
+// backend_binary() table in config/backends.conf — keep the two in sync.
+const (
+	backendBob     = "bob"      // IBM bobshell CLI; the binary is `bob`
+	backendLiteLLM = "litellm"  // Claude Code pointed at a LiteLLM proxy
+	toolBobshell   = "bobshell" // display name for the bob binary's version
+	binaryClaude   = "claude"
+	// bobAutoModel mirrors the dashboard's cli_models.go bobAutoModel: bob
+	// exposes no model catalog and always self-selects, so "auto" is the
+	// honest requested-model value. Discovering bob's INTERNAL routing (which
+	// model actually served the session) is a known follow-up, deliberately
+	// out of scope here.
+	bobAutoModel = "auto"
+)
+
+// InvocationMeta is the launch-time metadata the hive knows about what it
+// invoked. Fields left empty are OMITTED from the trailer and audit detail —
+// the trail records what the hive actually knows, never a guess. It must only
+// ever carry launch descriptors: no tokens, keys, or prompt content.
+type InvocationMeta struct {
+	// Agent is the hive agent name, or a system flow name (see
+	// AttributionAgentGovernor / AttributionAgentDashboard).
+	Agent string
+	// Backend is the CLI backend the hive invoked (claude, copilot, bob, …),
+	// including any runtime override in effect at launch.
+	Backend string
+	// Model is the model REQUESTED at launch. For backends that self-select
+	// (bob), this is honestly "auto" — see RequestedModel.
+	Model string
+	// Tool is the display name for the version field (e.g. "bobshell"); the
+	// trailer renders it as "<tool>=<version>".
+	Tool string
+	// ToolVersion is the CLI version as reported by `<binary> --version`.
+	ToolVersion string
+	// Session is a session/run identifier when the launch path has one.
+	// Currently unset: the spoke's tmux session name is just the agent name,
+	// so recording it would add no information. The field exists so a real
+	// per-run id can flow through without a format change.
+	Session string
+}
+
+// pairs returns the known metadata as ordered key/value pairs, omitting
+// unknown (empty) fields.
+func (m InvocationMeta) pairs() []string {
+	var kv []string
+	add := func(k, v string) {
+		if v = strings.TrimSpace(v); v != "" {
+			kv = append(kv, k, v)
+		}
+	}
+	add("agent", m.Agent)
+	add("backend", m.Backend)
+	add("model", m.Model)
+	if ver := strings.TrimSpace(m.ToolVersion); ver != "" {
+		tool := strings.TrimSpace(m.Tool)
+		if tool == "" {
+			tool = "tool"
+		}
+		kv = append(kv, tool, ver)
+	}
+	add("session", m.Session)
+	return kv
+}
+
+// Trailer renders the one-line visible trailer, e.g.:
+//
+//	— hive: agent=quality backend=bob model=auto bobshell=1.0.6 session=abc123
+//
+// Unknown fields are omitted; all-unknown metadata renders "" (no trailer at
+// all rather than a bare prefix).
+func (m InvocationMeta) Trailer() string {
+	kv := m.pairs()
+	if len(kv) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(kv)/2)
+	for i := 0; i+1 < len(kv); i += 2 {
+		parts = append(parts, kv[i]+"="+kv[i+1])
+	}
+	return AttributionTrailerPrefix + " " + strings.Join(parts, " ")
+}
+
+// AuditDetail renders the audit-entry detail string in the audit log's
+// "k=v, k=v" convention (see dashboard auditDetail): the artifact coordinates
+// first (extra pairs, e.g. "repo", "org/x", "number", "12", "url", …), then
+// the invocation metadata.
+func (m InvocationMeta) AuditDetail(extra ...string) string {
+	kv := append(append([]string{}, extra...), m.pairs()...)
+	parts := make([]string, 0, len(kv)/2)
+	for i := 0; i+1 < len(kv); i += 2 {
+		parts = append(parts, kv[i]+"="+kv[i+1])
+	}
+	return strings.Join(parts, ", ")
+}
+
+// AppendTrailer appends the visible trailer to body, blank-line separated.
+// No-op when the trailer is empty or the body already carries one — a request
+// the watcher retries after a partial failure must not stack trailers.
+func AppendTrailer(body string, m InvocationMeta) string {
+	t := m.Trailer()
+	if t == "" || strings.Contains(body, AttributionTrailerPrefix) {
+		return body
+	}
+	body = strings.TrimRight(body, "\n")
+	if body == "" {
+		return t
+	}
+	return body + "\n\n" + t
+}
+
+// RequestedModel normalizes the model recorded in the trail: bob has no model
+// catalog and always self-selects, so an empty model on the bob backend is
+// honestly "auto" rather than unknown. Every other backend passes through
+// unchanged (empty stays empty and is omitted, never guessed).
+func RequestedModel(backend, model string) string {
+	if backend == backendBob && strings.TrimSpace(model) == "" {
+		return bobAutoModel
+	}
+	return model
+}
+
+// toolVersionTimeout bounds the one-shot `<binary> --version` probe so a hung
+// CLI can never stall the PR-open path.
+const toolVersionTimeout = 5 * time.Second
+
+// toolVersionPattern extracts the version token (e.g. "1.0.6") from CLI
+// --version output, which varies in shape across backends.
+var toolVersionPattern = regexp.MustCompile(`\d+\.\d+(\.\d+)?`)
+
+// toolVersionCache caches binary → version ("" = probe failed) per process.
+// CLIs change only via image rebuild or an in-place upgrade followed by an
+// agent relaunch; either way the next hive restart refreshes the cache.
+var toolVersionCache sync.Map
+
+// backendToolBinary maps a backend id to its (display tool name, binary).
+// Mirrors backend_binary() in config/backends.conf — keep the two in sync.
+// Unknown/inference backends map to themselves; a missing binary simply
+// resolves to no version, which the trailer omits.
+func backendToolBinary(backend string) (tool, binary string) {
+	switch backend {
+	case backendBob:
+		return toolBobshell, backendBob
+	case backendLiteLLM:
+		// litellm agents run the Claude CLI pointed at a LiteLLM proxy.
+		return binaryClaude, binaryClaude
+	case "":
+		return "", ""
+	default:
+		return backend, backend
+	}
+}
+
+// ResolveToolVersion best-effort resolves the CLI version for a backend by
+// running `<binary> --version` once per process (cached). Returns ("", "")
+// when unknown; callers omit the field rather than guessing.
+func ResolveToolVersion(backend string) (tool, version string) {
+	tool, binary := backendToolBinary(backend)
+	if binary == "" {
+		return "", ""
+	}
+	if v, ok := toolVersionCache.Load(binary); ok {
+		return tool, v.(string)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), toolVersionTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, binary, "--version").CombinedOutput()
+	if err == nil {
+		version = toolVersionPattern.FindString(string(out))
+	}
+	toolVersionCache.Store(binary, version)
+	return tool, version
+}
+
+// AttributionHooks are the seams main() wires so this package can stamp and
+// record creations without importing the agent or dashboard packages (both
+// import this one). Each hook is optional and becomes available at a
+// different point during startup — see the Set* methods.
+type AttributionHooks struct {
+	// Resolve returns launch metadata for a named agent (effective backend/
+	// model from the agent manager plus tool version). nil → metadata beyond
+	// the agent name is simply unknown and omitted.
+	Resolve func(agent string) InvocationMeta
+	// TrailerEnabled gates ONLY the visible trailer. nil → enabled (the
+	// config default is ON). Read per-creation so a dashboard toggle takes
+	// effect immediately, no restart.
+	TrailerEnabled func() bool
+	// Audit records the audit entry (action, detail, agent) — wired to the
+	// dashboard audit log (audit.jsonl + ring). It is called for EVERY
+	// mediated creation regardless of the trailer toggle. nil → the creation
+	// is still recorded in the hive log via slog so the trail never fully
+	// disappears (only the pre-dashboard startup window can hit this).
+	Audit func(action, detail, agent string)
+}
+
+// SetAttributionHooks installs the initial hook set. Safe to call before the
+// watcher starts; individual hooks can be added later via SetAttribution
+// Resolver / SetAttributionAudit as their dependencies come up.
+func (c *Client) SetAttributionHooks(h AttributionHooks) {
+	if c == nil {
+		return
+	}
+	c.attribMu.Lock()
+	defer c.attribMu.Unlock()
+	c.attribution = h
+}
+
+// SetAttributionResolver installs the per-agent metadata resolver (available
+// once the agent manager exists).
+func (c *Client) SetAttributionResolver(fn func(agent string) InvocationMeta) {
+	if c == nil {
+		return
+	}
+	c.attribMu.Lock()
+	defer c.attribMu.Unlock()
+	c.attribution.Resolve = fn
+}
+
+// SetAttributionAudit installs the audit sink (available once the dashboard
+// server exists).
+func (c *Client) SetAttributionAudit(fn func(action, detail, agent string)) {
+	if c == nil {
+		return
+	}
+	c.attribMu.Lock()
+	defer c.attribMu.Unlock()
+	c.attribution.Audit = fn
+}
+
+// attributionMeta resolves launch metadata for an agent name, degrading to
+// name-only metadata when no resolver is wired.
+func (c *Client) attributionMeta(agent string) InvocationMeta {
+	if c == nil {
+		return InvocationMeta{Agent: agent}
+	}
+	c.attribMu.RLock()
+	resolve := c.attribution.Resolve
+	c.attribMu.RUnlock()
+	if resolve == nil {
+		return InvocationMeta{Agent: agent}
+	}
+	m := resolve(agent)
+	if m.Agent == "" {
+		m.Agent = agent
+	}
+	return m
+}
+
+// attributionTrailerOn reports whether the visible trailer should be stamped.
+// Default ON when no hook is wired, matching the config default.
+func (c *Client) attributionTrailerOn() bool {
+	if c == nil {
+		return true
+	}
+	c.attribMu.RLock()
+	enabled := c.attribution.TrailerEnabled
+	c.attribMu.RUnlock()
+	if enabled == nil {
+		return true
+	}
+	return enabled()
+}
+
+// recordCreationAudit writes the unconditional audit entry for a mediated
+// creation. With no sink wired yet (pre-dashboard startup window) it falls
+// back to the hive log so the event is still recorded somewhere durable.
+func (c *Client) recordCreationAudit(action string, m InvocationMeta, extra ...string) {
+	if c == nil {
+		return
+	}
+	detail := m.AuditDetail(extra...)
+	c.attribMu.RLock()
+	audit := c.attribution.Audit
+	c.attribMu.RUnlock()
+	if audit != nil {
+		audit(action, detail, m.Agent)
+		return
+	}
+	c.logger.Info("attribution audit (no audit sink wired yet)",
+		slog.String("action", action), slog.String("detail", detail), slog.String("agent", m.Agent))
+}

--- a/v2/pkg/github/attribution_test.go
+++ b/v2/pkg/github/attribution_test.go
@@ -1,0 +1,217 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// --- Trailer formatting ---
+
+func TestAttributionTrailer_AllFields(t *testing.T) {
+	m := InvocationMeta{
+		Agent: "quality", Backend: "bob", Model: "auto",
+		Tool: "bobshell", ToolVersion: "1.0.6", Session: "abc123",
+	}
+	want := "— hive: agent=quality backend=bob model=auto bobshell=1.0.6 session=abc123"
+	if got := m.Trailer(); got != want {
+		t.Errorf("Trailer() = %q, want %q", got, want)
+	}
+}
+
+func TestAttributionTrailer_OmitsUnknownFields(t *testing.T) {
+	m := InvocationMeta{Agent: "scanner", Backend: "claude"}
+	want := "— hive: agent=scanner backend=claude"
+	if got := m.Trailer(); got != want {
+		t.Errorf("Trailer() = %q, want %q", got, want)
+	}
+	// Version without a tool name gets a generic key rather than being dropped.
+	m = InvocationMeta{Agent: "scanner", ToolVersion: "2.1.0"}
+	if got := m.Trailer(); got != "— hive: agent=scanner tool=2.1.0" {
+		t.Errorf("Trailer() = %q", got)
+	}
+}
+
+func TestAttributionTrailer_AllUnknownRendersEmpty(t *testing.T) {
+	if got := (InvocationMeta{}).Trailer(); got != "" {
+		t.Errorf("empty meta should render no trailer, got %q", got)
+	}
+}
+
+func TestAppendTrailer(t *testing.T) {
+	m := InvocationMeta{Agent: "quality", Backend: "copilot"}
+	got := AppendTrailer("Fixes #1\n", m)
+	want := "Fixes #1\n\n— hive: agent=quality backend=copilot"
+	if got != want {
+		t.Errorf("AppendTrailer = %q, want %q", got, want)
+	}
+	// Empty body → trailer alone.
+	if got := AppendTrailer("", m); got != m.Trailer() {
+		t.Errorf("empty body: got %q", got)
+	}
+	// Idempotent: a body that already carries a trailer is left alone.
+	if again := AppendTrailer(got, m); again != got {
+		t.Errorf("trailer stacked on retry: %q", again)
+	}
+	// Empty meta → body unchanged.
+	if got := AppendTrailer("body", InvocationMeta{}); got != "body" {
+		t.Errorf("empty meta must not touch the body, got %q", got)
+	}
+}
+
+func TestAttributionAuditDetail(t *testing.T) {
+	m := InvocationMeta{Agent: "quality", Backend: "bob", Model: "auto"}
+	got := m.AuditDetail("repo", "o/r", "number", "42")
+	want := "repo=o/r, number=42, agent=quality, backend=bob, model=auto"
+	if got != want {
+		t.Errorf("AuditDetail = %q, want %q", got, want)
+	}
+}
+
+func TestRequestedModel_BobDefaultsToAuto(t *testing.T) {
+	if got := RequestedModel("bob", ""); got != "auto" {
+		t.Errorf("bob empty model = %q, want auto", got)
+	}
+	if got := RequestedModel("bob", "auto"); got != "auto" {
+		t.Errorf("bob auto model = %q", got)
+	}
+	// Other backends: empty stays empty (omitted, never guessed).
+	if got := RequestedModel("claude", ""); got != "" {
+		t.Errorf("claude empty model = %q, want empty", got)
+	}
+	if got := RequestedModel("copilot", "claude-opus-4.6"); got != "claude-opus-4.6" {
+		t.Errorf("copilot model passthrough = %q", got)
+	}
+}
+
+// --- Hooks defaults ---
+
+func TestAttributionDefaults_NilClientAndNilHooks(t *testing.T) {
+	var nilClient *Client
+	if !nilClient.attributionTrailerOn() {
+		t.Error("nil client: trailer should default ON")
+	}
+	if m := nilClient.attributionMeta("x"); m.Agent != "x" {
+		t.Errorf("nil client meta = %+v", m)
+	}
+	nilClient.recordCreationAudit(AuditActionAgentPRCreated, InvocationMeta{}) // must not panic
+
+	c := NewClientForTest("http://127.0.0.1:0", "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if !c.attributionTrailerOn() {
+		t.Error("no hooks: trailer should default ON (config default)")
+	}
+	if m := c.attributionMeta("scanner"); m.Agent != "scanner" || m.Backend != "" {
+		t.Errorf("no resolver: meta should be name-only, got %+v", m)
+	}
+}
+
+// --- Watcher integration: trailer + audit through the PR-open choke point ---
+
+// attribPRMock captures the body POSTed to /pulls.
+func attribPRMock(t *testing.T, postedBody *string) *httptest.Server {
+	t.Helper()
+	var mu sync.Mutex
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pulls"):
+			_, _ = io.WriteString(w, `[]`)
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pulls"):
+			raw, _ := io.ReadAll(r.Body)
+			var np map[string]any
+			_ = json.Unmarshal(raw, &np)
+			mu.Lock()
+			*postedBody = asString(np["body"])
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":7,"html_url":"https://github.com/o/r/pull/7"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func runAttribWatcherOnce(t *testing.T, c *Client) {
+	t.Helper()
+	dir := t.TempDir()
+	old := prRequestDirForTest
+	prRequestDirForTest = dir
+	defer func() { prRequestDirForTest = old }()
+	if _, err := WritePRRequest(dir, PRRequest{Repo: "o/r", Head: "quality/fix", Title: "fix", Body: "Fixes #9", Agent: "quality"}); err != nil {
+		t.Fatal(err)
+	}
+	c.ProcessPRRequestsOnce(context.Background())
+}
+
+type auditRec struct {
+	action, detail, agent string
+}
+
+func TestPRRequestWatcher_TrailerOnAndAudit(t *testing.T) {
+	var posted string
+	srv := attribPRMock(t, &posted)
+	defer srv.Close()
+	c := testClient(t, srv.URL)
+
+	var audits []auditRec
+	c.SetAttributionHooks(AttributionHooks{
+		Resolve: func(agent string) InvocationMeta {
+			return InvocationMeta{Agent: agent, Backend: "bob", Model: "auto", Tool: "bobshell", ToolVersion: "1.0.6"}
+		},
+		TrailerEnabled: func() bool { return true },
+		Audit:          func(action, detail, agent string) { audits = append(audits, auditRec{action, detail, agent}) },
+	})
+
+	runAttribWatcherOnce(t, c)
+
+	wantTrailer := "— hive: agent=quality backend=bob model=auto bobshell=1.0.6"
+	if !strings.Contains(posted, "Fixes #9") || !strings.Contains(posted, wantTrailer) {
+		t.Errorf("PR body missing trailer: %q", posted)
+	}
+	if len(audits) != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", len(audits))
+	}
+	a := audits[0]
+	if a.action != AuditActionAgentPRCreated || a.agent != "quality" {
+		t.Errorf("audit = %+v", a)
+	}
+	for _, frag := range []string{"repo=o/r", "number=7", "url=https://github.com/o/r/pull/7", "reused=false", "backend=bob", "model=auto"} {
+		if !strings.Contains(a.detail, frag) {
+			t.Errorf("audit detail missing %q: %q", frag, a.detail)
+		}
+	}
+}
+
+func TestPRRequestWatcher_TrailerOffStillAudits(t *testing.T) {
+	var posted string
+	srv := attribPRMock(t, &posted)
+	defer srv.Close()
+	c := testClient(t, srv.URL)
+
+	var audits []auditRec
+	c.SetAttributionHooks(AttributionHooks{
+		Resolve:        func(agent string) InvocationMeta { return InvocationMeta{Agent: agent, Backend: "claude"} },
+		TrailerEnabled: func() bool { return false },
+		Audit:          func(action, detail, agent string) { audits = append(audits, auditRec{action, detail, agent}) },
+	})
+
+	runAttribWatcherOnce(t, c)
+
+	if strings.Contains(posted, AttributionTrailerPrefix) {
+		t.Errorf("trailer must not appear with the toggle off: %q", posted)
+	}
+	if posted != "Fixes #9" {
+		t.Errorf("body should be untouched with the toggle off: %q", posted)
+	}
+	if len(audits) != 1 {
+		t.Fatalf("audit entry must be written even with the trailer off; got %d", len(audits))
+	}
+	if !strings.Contains(audits[0].detail, "backend=claude") {
+		t.Errorf("audit detail = %q", audits[0].detail)
+	}
+}

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -36,6 +36,12 @@ type Client struct {
 	// per-agent ACMM write-policy + forge-resistance. nil fails closed. Set by
 	// StartPRRequestWatcher.
 	prAuthz PRRequestAuthorizer
+	// attribution holds the invocation-attribution hooks (trailer gate,
+	// per-agent metadata resolver, audit sink) — see attribution.go. Guarded by
+	// attribMu because the hooks are installed in stages during startup while
+	// the PR-request watcher goroutine may already be reading them.
+	attribMu    sync.RWMutex
+	attribution AttributionHooks
 }
 
 // GoGitHub returns the underlying go-github client for direct API access.

--- a/v2/pkg/github/pr_request_watcher.go
+++ b/v2/pkg/github/pr_request_watcher.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -186,7 +187,18 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 		return
 	}
 
-	res, err := c.CreatePR(ctx, req.Repo, req.Head, req.Base, req.Title, req.Body)
+	// Invocation-attribution trail (attribution.go): resolve what the hive
+	// invoked for this agent, append the visible trailer to the PR body when
+	// the toggle is on, and — below, on success — record the audit entry
+	// unconditionally. This choke point covers every agent regardless of CLI,
+	// because the proxy hard-denies direct POST /pulls.
+	meta := c.attributionMeta(req.Agent)
+	body := req.Body
+	if c.attributionTrailerOn() {
+		body = AppendTrailer(body, meta)
+	}
+
+	res, err := c.CreatePR(ctx, req.Repo, req.Head, req.Base, req.Title, body)
 	resp := PRResponse{At: nowFn().UTC().Format(time.RFC3339)}
 	if err != nil {
 		// Leave the request in place so the next tick retries (transient API
@@ -202,6 +214,16 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 	resp.Number = res.Number
 	resp.URL = res.URL
 	resp.AlreadyExisted = res.AlreadyExisted
+	// Audit the creation UNCONDITIONALLY (not gated by the trailer toggle) —
+	// this is the durable answer to "which backend/model produced this PR?".
+	// A reused PR is recorded too (reused=true): the watcher may be
+	// re-processing a request that partially succeeded, and the invocation
+	// that produced the branch is the same.
+	c.recordCreationAudit(AuditActionAgentPRCreated, meta,
+		"repo", req.Repo,
+		"number", strconv.Itoa(res.Number),
+		"url", res.URL,
+		"reused", strconv.FormatBool(res.AlreadyExisted))
 	c.writePRResult(path, resp)
 	// Success (or reuse of an existing PR) — consume the request so it isn't
 	// reprocessed.


### PR DESCRIPTION
## Motivation

A real support thread ended with *"there is no real way to tell"* when an operator asked **which backend/model produced an agent PR**. App-bot authorship is deterministic by design, so the artifact itself carries no invocation signal. The hive cannot control opaque backend routing, but it CAN record what it invoked — this PR adds that trail.

## Two layers, one metadata source

Both layers are fed from the same launch-time metadata (agent name, effective backend/model incl. runtime overrides from the agent manager, CLI tool version resolved via `<binary> --version`, cached per process):

**1. Visible trailer** — appended at creation time to the body of hive-mediated creations, e.g.:

```
— hive: agent=quality backend=bob model=auto bobshell=1.0.6
```

Single line, neutral wording, unknown fields omitted rather than guessed, never any token/secret/prompt material. Idempotent on watcher retries (never stacks a second trailer).

**2. Audit-log entry** — written **unconditionally** for every such creation through the existing `audit.jsonl` + ring-buffer machinery (`v2/pkg/dashboard/audit.go`), encoding repo, artifact number/URL, and the invocation metadata into `Detail` using that file's `k=v, k=v` convention. Actions: `agent_pr_created`, `hive_issue_created`.

## Toggle semantics

New `governor.attribution_trailer` boolean (`*bool`, absent = **ON**, same convention as `github.app_authored_prs`). It is **hive-wide** (one value for all agents) and gates **only the visible trailer — the audit entry always writes regardless**. Editable at runtime from the Governor config dialog (General tab, next to the other hive-wide settings) via the standard section save path: `PUT /api/config/governor/attribution`, persisted through the dashboard-writable overlay like every other dashboard-edited setting.

## Wiring points

- **PRs**: the PR-request watcher (`handleOnePRRequest` in `v2/pkg/github/pr_request_watcher.go`) — the hive-open-pr choke point that covers ALL agents regardless of CLI (the proxy hard-denies direct `POST /pulls`).
- **Issues**: the two hive-mediated creation sites — the pinned advisory issue (`EnsureAdvisoryIssue`) and dashboard ACMM-gap issues (`handleACMMCreateIssue`), recorded as `agent=governor` / `agent=dashboard`.
- Hooks are wired in `cmd/hive/main.go` in stages as dependencies come up (trailer gate → per-agent resolver → audit sink); a creation before the dashboard exists falls back to the hive log so nothing goes unrecorded.

## Limitations (honest scope)

- Only creations the **hive mediates** are stamped. An issue an agent opens directly through its own CLI never passes through this code and is not covered.
- **bob** records `model=auto` honestly: bob exposes no model catalog and self-selects internally. Discovering bob's internal routing is marked as a known follow-up in `pkg/github/attribution.go` and is deliberately out of scope here.
- No session/run identifier yet: the spoke's tmux session name is just the agent name, so recording it adds nothing; the `Session` field exists so a real per-run id can flow through without a format change.

## Tests

- Trailer formatting: all fields / missing fields / all-unknown, append idempotency, audit-detail rendering, bob `model=auto` normalization.
- Watcher integration: trailer present when ON; body untouched when OFF **while the audit entry still fires**.
- Config: default-ON parsing (`nil`/`false`/`true`) at both YAML and accessor level.
- Dashboard: `PUT /api/config/governor/attribution` toggle round-trip + GET reflection + partial-update behavior.