### PR TITLE
feat(contribute): longer scrollable ready-work queue + operator drag-reorder

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1843,11 +1843,23 @@ type HubConfig struct {
 	// contributor requesting work. An issue assigned to the contributor
 	// themselves (or unassigned) is still eligible. Default false preserves the
 	// prior behavior of handing out issues regardless of assignment (#2357).
-	ContributeSkipAssignedToOthers bool                `yaml:"contribute_skip_assigned_to_others"`
-	DisabledRepos                  []string            `yaml:"disabled_repos"`
-	DisabledTiers                  []string            `yaml:"disabled_tiers"`
-	TierLimits                     map[string]TierRate `yaml:"tier_limits"`
-	SnapshotIntervalMin            int                 `yaml:"snapshot_interval_min"`
+	ContributeSkipAssignedToOthers bool `yaml:"contribute_skip_assigned_to_others"`
+	// ContributeQueueOrder is the OPERATOR PRIORITY OVERRIDE for the ready-work
+	// queue: an ordered list of "owner/repo#number" keys the operator dragged to
+	// the front on the Operations tab. When set, these issues are OFFERED FIRST —
+	// both in the queue display (ReadyQueue) and in selectTask's candidate ordering
+	// — in exactly this order; everything else follows in the established default
+	// order. It only reorders OFFER PRIORITY: a key here that is filtered out by
+	// admission / cooldown / disabled-repo / in-flight rules is still excluded, and
+	// a stale key (no longer actionable) is simply skipped. Persisted through the
+	// same Config.Hub.* mechanism as the other admission settings so it survives
+	// restart, and edited only through the authenticated PUT /api/contribute/queue/order
+	// endpoint (owner/read-write only).
+	ContributeQueueOrder []string            `yaml:"contribute_queue_order,omitempty"`
+	DisabledRepos        []string            `yaml:"disabled_repos"`
+	DisabledTiers        []string            `yaml:"disabled_tiers"`
+	TierLimits           map[string]TierRate `yaml:"tier_limits"`
+	SnapshotIntervalMin  int                 `yaml:"snapshot_interval_min"`
 }
 
 type TierRate struct {

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -12,7 +12,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -118,6 +120,10 @@ func (s *Server) registerContributeRoutes() {
 	// Read-only ready-work QUEUE snapshot (the admissible issues waiting to be
 	// picked off). Also public; a JSON fallback for the SSE hello payload.
 	s.mux.HandleFunc("GET /api/contribute/queue", s.handleContributeQueue)
+	// Operator priority override for the ready-work queue. Owner/read-write only —
+	// enforced IN-HANDLER via requireContributorWrite because the /api/contribute
+	// prefix is exempt from roleEnforcement's read-only block (see that helper).
+	s.mux.HandleFunc("PUT /api/contribute/queue/order", s.handleContributeQueueOrder)
 	s.mux.HandleFunc("GET /api/contributors", s.handleContributorsList)
 	s.mux.HandleFunc("GET /api/contributors/{id}", s.handleContributorGet)
 	s.mux.HandleFunc("PUT /api/contributors/{id}/trust", s.handleContributorTrust)
@@ -514,10 +520,21 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .clanker-status.working{background:rgba(88,166,255,.12);color:#58a6ff;border-color:rgba(88,166,255,.3)}
 .clanker-status.reviewing{background:rgba(210,153,34,.12);color:#d29922;border-color:rgba(210,153,34,.3)}
 .clanker-status.idle{background:rgba(139,148,158,.12);color:#8b949e;border-color:rgba(139,148,158,.3)}
-/* Ready-work QUEUE — the stack of issues waiting to be picked off */
-.cc-queue{max-height:340px;overflow-y:auto}
+/* Ready-work QUEUE — the stack of issues waiting to be picked off. A generous
+   max-height keeps a long backlog (up to ~150 items) scrolling inside the card
+   instead of stretching the page; the panel scrolls, the page does not. */
+.cc-queue{max-height:560px;overflow-y:auto}
 .cc-q-item{display:flex;align-items:flex-start;gap:10px;padding:11px 20px;border-bottom:1px solid #21262d;animation:cc-popin .35s ease;position:relative}
 .cc-q-item:first-child{background:rgba(88,166,255,.05)}
+/* Drag handle (grab bar) — owner/read-write only. Hidden unless the queue root
+   carries .cc-q-draggable (set by initAdmin after /api/role). Reduced-motion and
+   pointer friendly. */
+.cc-q-grip{display:none;flex-shrink:0;width:16px;align-self:stretch;cursor:grab;color:#6e7681;font-size:.9rem;line-height:1;align-items:center;justify-content:center;user-select:none;touch-action:none}
+.cc-q-grip:hover{color:#c9d1d9}
+.cc-queue.cc-q-draggable .cc-q-grip{display:flex}
+.cc-queue.cc-q-draggable .cc-q-item{cursor:default}
+.cc-q-item.cc-q-dragging{opacity:.5;cursor:grabbing}
+.cc-q-item.cc-q-over{box-shadow:inset 0 2px 0 0 #58a6ff}
 .cc-q-idx{font-size:.7rem;color:#6e7681;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;flex-shrink:0;width:22px;text-align:right;padding-top:2px}
 .cc-q-body{flex:1;min-width:0}
 .cc-q-repo{font-size:.72rem;color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
@@ -1167,6 +1184,10 @@ async function initAdmin(){
     adminHub=(cd&&cd.hub)?cd.hub:{};
   }catch(e){adminHub={};}
   renderAdminControls();
+  // The ready-work queue may have rendered before this role check resolved (SSE
+  // hello / poll fires immediately on tab open). Re-render now that adminEnabled is
+  // true so the grab bars appear for this owner/read-write viewer.
+  if(typeof ccRenderQueue==='function')ccRenderQueue();
 }
 
 // #2546: human-readable label for the machine reason a clanker is idle. Keeps the
@@ -1344,14 +1365,70 @@ function ccQueueKey(q){return (q.repo||'')+'#'+(q.number||'');}
 
 function ccRenderQueue(){
   var el=document.getElementById('cc-queue');if(!el)return;
+  // Drag-reorder is an operator CONTROL: only owner/read-write viewers get grab
+  // bars. adminEnabled is set true by initAdmin ONLY after /api/role reports owner
+  // or read-write; a read/anon viewer never gets the handles and cannot reorder.
+  // The server enforces the same boundary independently (403 on the order endpoint).
+  el.classList.toggle('cc-q-draggable',!!adminEnabled);
   if(!ccQueue.length){el.innerHTML='<div class="ops-empty">No work waiting &mdash; the backlog is clear or everything is in flight.</div>';return;}
   el.innerHTML=ccQueue.map(function(q,i){
-    var labels=(q.labels&&q.labels.length)?('<div class="cc-q-labels">'+q.labels.slice(0,4).map(function(l){return '<span class="pill pill-idle">'+esc(l)+'</span>';}).join('')+'</div>'):'';
+    // Show ALL of the issue's gh labels as pills (the backend already carries the
+    // full label set). "My work" items render every label the same way, so the
+    // queue is consistent with them. esc() guards each label.
+    var labels=(q.labels&&q.labels.length)?('<div class="cc-q-labels">'+q.labels.map(function(l){return '<span class="pill pill-idle">'+esc(l)+'</span>';}).join('')+'</div>'):'';
     var next=(i===0)?'<span class="cc-q-next">next up</span>':'';
-    return '<div class="cc-q-item" data-qkey="'+esc(ccQueueKey(q))+'"><span class="cc-q-idx">'+(i+1)+'</span>'+
+    // The grab bar is always in the DOM but only VISIBLE via CSS when the queue
+    // root carries .cc-q-draggable (owner/read-write). draggable is likewise gated
+    // so a read viewer's markup is inert. aria-hidden: purely a mouse/pointer affordance.
+    var grip=adminEnabled?'<span class="cc-q-grip" aria-hidden="true" title="Drag to reprioritise">&#x283F;</span>':'';
+    return '<div class="cc-q-item"'+(adminEnabled?' draggable="true"':'')+' data-qkey="'+esc(ccQueueKey(q))+'">'+grip+'<span class="cc-q-idx">'+(i+1)+'</span>'+
       '<div class="cc-q-body"><div class="cc-q-repo">'+esc(q.repo||'')+'#'+esc(q.number||'')+'</div>'+
       '<div class="cc-q-title" title="'+esc(q.title||'')+'">'+esc(q.title||'(untitled)')+'</div>'+labels+'</div>'+next+'</div>';
   }).join('');
+  if(adminEnabled)ccBindQueueDrag(el);
+}
+
+// ── Operator drag-reorder (grab bars) — owner/read-write only ──────────────────
+// Dependency-free HTML5 drag-and-drop. On drop it recomputes ccQueue from the new
+// DOM order, re-renders (so indices / "next up" update), and PERSISTS the order to
+// the authenticated endpoint. The persisted order becomes the offer-priority
+// override that ReadyQueue AND selectTask honour — but it only reorders OFFER
+// PRIORITY; the server still applies every admission/cooldown filter, so a pinned
+// issue that is filtered out or no longer actionable is skipped, never forced in.
+var ccDragKey=null; // qkey of the row currently being dragged
+function ccBindQueueDrag(root){
+  var items=root.querySelectorAll('.cc-q-item');
+  for(var i=0;i<items.length;i++){(function(it){
+    it.addEventListener('dragstart',function(e){
+      ccDragKey=it.getAttribute('data-qkey');it.classList.add('cc-q-dragging');
+      try{e.dataTransfer.effectAllowed='move';e.dataTransfer.setData('text/plain',ccDragKey);}catch(err){}
+    });
+    it.addEventListener('dragend',function(){it.classList.remove('cc-q-dragging');
+      var all=root.querySelectorAll('.cc-q-item');for(var k=0;k<all.length;k++)all[k].classList.remove('cc-q-over');});
+    it.addEventListener('dragover',function(e){e.preventDefault();try{e.dataTransfer.dropEffect='move';}catch(err){}it.classList.add('cc-q-over');});
+    it.addEventListener('dragleave',function(){it.classList.remove('cc-q-over');});
+    it.addEventListener('drop',function(e){
+      e.preventDefault();it.classList.remove('cc-q-over');
+      var from=ccDragKey,to=it.getAttribute('data-qkey');if(!from||from===to)return;
+      // Reorder the ccQueue model: pull the dragged item, insert it before the drop target.
+      var fromIdx=-1,toIdx=-1;
+      for(var a=0;a<ccQueue.length;a++){if(ccQueueKey(ccQueue[a])===from)fromIdx=a;if(ccQueueKey(ccQueue[a])===to)toIdx=a;}
+      if(fromIdx<0||toIdx<0)return;
+      var moved=ccQueue.splice(fromIdx,1)[0];
+      // After splice the target index may have shifted; recompute against the moved-out array.
+      toIdx=-1;for(var b=0;b<ccQueue.length;b++){if(ccQueueKey(ccQueue[b])===to){toIdx=b;break;}}
+      if(toIdx<0)toIdx=ccQueue.length;
+      ccQueue.splice(toIdx,0,moved);
+      ccRenderQueue();
+      ccPersistQueueOrder();
+    });
+  })(items[i]);}
+}
+function ccPersistQueueOrder(){
+  var order=ccQueue.map(ccQueueKey);
+  fetch('/api/contribute/queue/order',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({order:order})})
+    .then(function(r){if(!r.ok)throw new Error('http '+r.status);return r.json();})
+    .catch(function(){/* a read viewer would 403 here, but the UI never shows handles to them */});
 }
 function ccSetLive(state){ // 'live' | 'poll' | 'connecting'
   var el=document.getElementById('cc-live'),lbl=document.getElementById('cc-live-label');if(!el||!lbl)return;
@@ -1777,6 +1854,66 @@ func (s *Server) handleContributeQueue(w http.ResponseWriter, r *http.Request) {
 		queue = s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
 	}
 	jsonResponse(w, map[string]any{"queue": queue})
+}
+
+// maxQueueOrderKeys caps how many priority keys the operator override may carry.
+// It is well above readyQueueDefaultLimit (the whole visible queue could be
+// pinned) yet bounds a pathological / hostile payload so it can neither bloat
+// hive.yaml nor slow the per-selectTask ordering lookup.
+const maxQueueOrderKeys = 512
+
+// queueOrderKeyPattern validates one "owner/repo#number" priority key. Keeping the
+// stored override to well-formed keys means a malformed entry can never match a
+// candidate (it would simply be a permanent no-op) and keeps hive.yaml clean.
+var queueOrderKeyPattern = regexp.MustCompile(`^[^\s/#]+/[^\s/#]+#[0-9]+$`)
+
+// handleContributeQueueOrder persists the OPERATOR PRIORITY OVERRIDE for the
+// ready-work queue — the ordered "owner/repo#number" list the operator produced by
+// dragging queue rows on the Operations tab. It is a CONTROL, so it is owner/read-
+// write ONLY, enforced server-side by requireContributorWrite (a read/anon caller
+// gets 403). It stores the order into Config.Hub.ContributeQueueOrder through the
+// SAME refreshAndPersist path the Governor Hub admission settings use, so it
+// survives restart. The override only changes OFFER PRIORITY: ReadyQueue and
+// selectTask both apply it AFTER their admission/cooldown/disabled/in-flight
+// exclusions, so a pinned issue that is filtered out or stale is skipped, never
+// resurrected. It never bypasses any filter.
+func (s *Server) handleContributeQueueOrder(w http.ResponseWriter, r *http.Request) {
+	if !s.requireContributorWrite(w, r) {
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	var body struct {
+		Order []string `json:"order"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonError(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if len(body.Order) > maxQueueOrderKeys {
+		jsonError(w, "too many queue-order keys", http.StatusBadRequest)
+		return
+	}
+	// Sanitise: keep only well-formed, unique keys, preserving the operator's order.
+	// A malformed or duplicate key is dropped rather than rejected so a partially
+	// stale UI payload still persists the good keys.
+	seen := make(map[string]struct{}, len(body.Order))
+	cleaned := make([]string, 0, len(body.Order))
+	for _, k := range body.Order {
+		k = strings.TrimSpace(k)
+		if k == "" || !queueOrderKeyPattern.MatchString(k) {
+			continue
+		}
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		cleaned = append(cleaned, k)
+	}
+	s.deps.Config.Hub.ContributeQueueOrder = cleaned
+	s.auditFromRequest(r, "contribute_queue_order", auditDetail("keys", strconv.Itoa(len(cleaned))), "")
+	s.refreshAndPersist()
+	s.logger.Info("contribute queue order updated", "keys", len(cleaned))
+	jsonResponse(w, map[string]any{"ok": true, "order": cleaned})
 }
 
 // ── Contributor management ─────────────────────────────────────────────────

--- a/v2/pkg/dashboard/contribute_queue_order_test.go
+++ b/v2/pkg/dashboard/contribute_queue_order_test.go
@@ -1,0 +1,305 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// seedActionable builds a status with n actionable issues in one repo, numbered
+// 1..n, so the ready queue has a long candidate set to exercise the raised cap
+// and the operator priority override.
+func seedActionable(repo string, n int) *StatusPayload {
+	issues := make([]any, 0, n)
+	for i := 1; i <= n; i++ {
+		issues = append(issues, map[string]any{
+			"number": float64(i),
+			"title":  fmt.Sprintf("issue %d", i),
+			"labels": []any{},
+		})
+	}
+	return &StatusPayload{
+		Repos: []FrontendRepo{{Name: repo, Full: repo, ActionableIssues: issues}},
+	}
+}
+
+// TestReadyQueueRaisedCapReturnsMoreThanTen proves Feature 1: the queue is no
+// longer capped at ~10 — a backlog well over 10 surfaces up to the (raised)
+// readyQueueDefaultLimit, and the cap still bounds a pathological backlog.
+func TestReadyQueueRaisedCapReturnsMoreThanTen(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	// 140 actionable items — comfortably more than the old cap of 10/25.
+	s.statusMu.Lock()
+	s.status = seedActionable("projectbluefin/common", 140)
+	s.statusMu.Unlock()
+
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) <= 10 {
+		t.Fatalf("raised cap: expected far more than 10 items, got %d", len(q))
+	}
+	if len(q) != 140 {
+		t.Fatalf("expected all 140 items under the raised cap, got %d", len(q))
+	}
+
+	// The cap still bounds a backlog larger than the limit.
+	s.statusMu.Lock()
+	s.status = seedActionable("projectbluefin/common", readyQueueDefaultLimit+50)
+	s.statusMu.Unlock()
+	q = s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != readyQueueDefaultLimit {
+		t.Fatalf("cap: expected %d items, got %d", readyQueueDefaultLimit, len(q))
+	}
+}
+
+// TestReadyQueueRespectsOperatorOrder proves the persisted priority override is
+// reflected in the queue OUTPUT: pinned keys are offered first, in the operator's
+// order, with unpinned items keeping their scan order behind them.
+func TestReadyQueueRespectsOperatorOrder(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.RegisterAPI(testDeps(t))
+
+	s.statusMu.Lock()
+	s.status = seedActionable("acme/repo", 5) // issues 1..5 in scan order
+	s.statusMu.Unlock()
+
+	// Operator drags #4 then #2 to the front.
+	s.deps.Config.Hub.ContributeQueueOrder = []string{"acme/repo#4", "acme/repo#2"}
+
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 5 {
+		t.Fatalf("expected 5 items, got %d", len(q))
+	}
+	if q[0].Number != 4 || q[1].Number != 2 {
+		t.Fatalf("pinned items not offered first in operator order: got %d,%d", q[0].Number, q[1].Number)
+	}
+	// The rest keep their original scan order: 1,3,5.
+	if q[2].Number != 1 || q[3].Number != 3 || q[4].Number != 5 {
+		t.Fatalf("unpinned items lost scan order: got %d,%d,%d", q[2].Number, q[3].Number, q[4].Number)
+	}
+}
+
+// TestReadyQueueSkipsStalePin proves a pinned key that is no longer actionable is
+// simply skipped — never resurrected into the queue.
+func TestReadyQueueSkipsStalePin(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.RegisterAPI(testDeps(t))
+
+	s.statusMu.Lock()
+	s.status = seedActionable("acme/repo", 3) // only issues 1..3 are actionable
+	s.statusMu.Unlock()
+
+	// #999 is pinned but not in the actionable set (stale); #3 is pinned and real.
+	s.deps.Config.Hub.ContributeQueueOrder = []string{"acme/repo#999", "acme/repo#3"}
+
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 3 {
+		t.Fatalf("stale pin must not add items: expected 3, got %d", len(q))
+	}
+	for _, it := range q {
+		if it.Number == 999 {
+			t.Fatalf("stale pinned key was resurrected into the queue: %+v", it)
+		}
+	}
+	// The real pin (#3) still floats to the front.
+	if q[0].Number != 3 {
+		t.Fatalf("real pin should be first, got %d", q[0].Number)
+	}
+}
+
+// TestReadyQueueOrderDoesNotBypassAdmission proves the override only changes OFFER
+// PRIORITY: a pinned issue that admission filters exclude stays out regardless of
+// pin order.
+func TestReadyQueueOrderDoesNotBypassAdmission(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.RegisterAPI(testDeps(t))
+
+	s.statusMu.Lock()
+	s.status = &StatusPayload{Repos: []FrontendRepo{{
+		Name: "acme/repo", Full: "acme/repo",
+		ActionableIssues: []any{
+			map[string]any{"number": float64(1), "title": "keep me", "labels": []any{}},
+			map[string]any{"number": float64(2), "title": "SPAM please ignore", "labels": []any{}},
+		},
+	}}}
+	s.statusMu.Unlock()
+
+	// Deny any title containing "SPAM"; pin the denied issue to the front anyway.
+	s.deps.Config.Hub.ContributeTitlesMode = config.FilterModeDeny
+	s.deps.Config.Hub.ContributeDenyTitles = []string{"SPAM"}
+	s.deps.Config.Hub.ContributeQueueOrder = []string{"acme/repo#2"}
+
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	for _, it := range q {
+		if it.Number == 2 {
+			t.Fatalf("pin bypassed the admission filter: #2 should be excluded, got %+v", q)
+		}
+	}
+	if len(q) != 1 || q[0].Number != 1 {
+		t.Fatalf("expected only the admissible #1, got %+v", q)
+	}
+}
+
+// TestQueueOrderEndpointRoleGate proves the write endpoint is owner/read-write
+// ONLY, enforced server-side: a "read" caller gets 403; owner/read-write succeed.
+func TestQueueOrderEndpointRoleGate(t *testing.T) {
+	cases := []struct {
+		role string
+		want int
+	}{
+		{"read", http.StatusForbidden},
+		{"owner", http.StatusOK},
+		{"read-write", http.StatusOK},
+		{"", http.StatusOK}, // absent header = local/dev owner
+	}
+	for _, tc := range cases {
+		t.Run("role_"+tc.role, func(t *testing.T) {
+			s, deps := apiServer(t)
+			_ = deps
+			req := httptest.NewRequest(http.MethodPut, "/api/contribute/queue/order",
+				strings.NewReader(`{"order":["acme/repo#1"]}`))
+			req.Header.Set("Content-Type", "application/json")
+			if tc.role != "" {
+				req.Header.Set("X-Hive-Role", tc.role)
+			}
+			w := httptest.NewRecorder()
+			s.mux.ServeHTTP(w, req)
+			if w.Code != tc.want {
+				t.Fatalf("role %q: got %d, want %d (body: %s)", tc.role, w.Code, tc.want, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestQueueOrderEndpointPersistsAndSanitizes proves an accepted PUT stores the
+// order into Config.Hub.ContributeQueueOrder and drops malformed / duplicate keys.
+func TestQueueOrderEndpointPersistsAndSanitizes(t *testing.T) {
+	s, deps := apiServer(t)
+
+	body := `{"order":["acme/repo#4"," acme/repo#2 ","not a key","acme/repo#4","","acme/repo#7"]}`
+	req := httptest.NewRequest(http.MethodPut, "/api/contribute/queue/order", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+
+	got := deps.Config.Hub.ContributeQueueOrder
+	want := []string{"acme/repo#4", "acme/repo#2", "acme/repo#7"} // trimmed, deduped, malformed dropped
+	if len(got) != len(want) {
+		t.Fatalf("persisted order = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("persisted order[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+
+	// Response echoes the cleaned order.
+	var resp struct {
+		OK    bool     `json:"ok"`
+		Order []string `json:"order"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.OK || len(resp.Order) != 3 {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+// TestQueueOrderEndpointRejectsOversizePayload proves the key cap bounds a hostile
+// payload.
+func TestQueueOrderEndpointRejectsOversizePayload(t *testing.T) {
+	s, _ := apiServer(t)
+	keys := make([]string, maxQueueOrderKeys+1)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("acme/repo#%d", i+1)
+	}
+	payload, _ := json.Marshal(map[string]any{"order": keys})
+	// The body cap (maxRequestBodyBytes) may trip first for a very large payload;
+	// either way the endpoint must not accept it. Use a payload just over the key
+	// cap but within the body cap by keeping keys short — assert non-200.
+	req := httptest.NewRequest(http.MethodPut, "/api/contribute/queue/order", strings.NewReader(string(payload)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code == http.StatusOK {
+		t.Fatalf("oversize payload was accepted; want rejection, got 200")
+	}
+}
+
+// TestSelectTaskHonorsOperatorOrder proves the persisted priority override changes
+// selectTask's CANDIDATE ORDERING: a pinned issue is offered ahead of the
+// contributor's OWN work (the override is the top sort key). Without the pin,
+// selectTask would hand alice her own issue (#2390); with #2 pinned, #2 wins.
+func TestSelectTaskHonorsOperatorOrder(t *testing.T) {
+	hub, s := covK2Hub(t)
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	setStatusIssues(s,
+		intgIssue(1, "Someone else's issue", "bob", nil),
+		intgIssue(2, "Another of bob's issues", "bob", nil),
+		intgIssue(3, "Alice's own work", "alice", nil),
+	)
+
+	// Baseline: no override → own-work (#3) wins per #2390.
+	if msg := hub.selectTask(conn); msg == nil || msg.Type != "task_assign" || msg.Number != 3 {
+		t.Fatalf("baseline: expected own-work #3, got %+v", msg)
+	}
+	// Clear the assignment so the next call re-selects from the full set.
+	conn.mu.Lock()
+	conn.currentTask = nil
+	conn.mu.Unlock()
+
+	// Operator pins #2 to the front. Now #2 must be offered ahead of alice's own #3.
+	s.deps.Config.Hub.ContributeQueueOrder = []string{"myorg/repo1#2"}
+	if msg := hub.selectTask(conn); msg == nil || msg.Type != "task_assign" || msg.Number != 2 {
+		t.Fatalf("with #2 pinned: expected #2 offered first, got %+v", msg)
+	}
+}
+
+// TestSelectTaskPinDoesNotBypassCooldown proves a pinned issue still obeys
+// admission: an issue in failure cooldown is skipped even when pinned to the front.
+func TestSelectTaskPinDoesNotBypassCooldown(t *testing.T) {
+	hub, s := covK2Hub(t)
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	setStatusIssues(s,
+		intgIssue(1, "clean issue", "bob", nil),
+		intgIssue(2, "flaky issue in cooldown", "bob", nil),
+	)
+	// Put #2 into an ACTIVE failure cooldown so it is not admissible right now.
+	hub.recordTaskFailure("myorg/repo1", 2, false)
+
+	// Pin the cooling-down #2 to the front anyway.
+	s.deps.Config.Hub.ContributeQueueOrder = []string{"myorg/repo1#2"}
+
+	msg := hub.selectTask(conn)
+	if msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("expected a task_assign for the admissible issue, got %+v", msg)
+	}
+	if msg.Number == 2 {
+		t.Fatalf("pinned issue in cooldown bypassed admission: got #2")
+	}
+	if msg.Number != 1 {
+		t.Fatalf("expected the clean #1, got #%d", msg.Number)
+	}
+}

--- a/v2/pkg/dashboard/contribute_sse.go
+++ b/v2/pkg/dashboard/contribute_sse.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -43,8 +44,14 @@ const sseSubscriberBuffer = 32
 
 // readyQueueDefaultLimit is the default number of ready-work items surfaced in the
 // queue snapshot / SSE initial payload. It is the "top of the stack" an operator
-// watches get picked off; the full admissible set can be large, so we cap it.
-const readyQueueDefaultLimit = 25
+// watches get picked off. The full admissible set can be large (the hive routinely
+// has ~150+ actionable items), and the operator wants to SEE and REORDER a long
+// list, not just the top handful. So the cap is generous — high enough that the
+// whole realistic backlog is visible and draggable — but still bounded so a
+// pathological backlog can never blow out the JSON payload or the DOM. The queue
+// panel is a fixed-height scroll container (.cc-queue), so a long list scrolls
+// inside its card rather than stretching the page.
+const readyQueueDefaultLimit = 150
 
 // sseEvent is one framed message pushed to subscribers. Type distinguishes the
 // initial hydration payload (queue + replay) from subsequent single activity
@@ -244,12 +251,72 @@ func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
 				URL:    url,
 				Labels: labels,
 			})
-			if len(out) >= limit {
-				return out
-			}
 		}
 	}
+
+	// Operator priority override (#queue-reorder): if the operator dragged items to
+	// the front on the Operations tab, offer those FIRST — in exactly the operator's
+	// order — and keep everything else in the established scan order behind them. A
+	// stable sort keyed on the priority index does this without disturbing the
+	// relative order of unpinned items. This only reorders OFFER PRIORITY: every item
+	// in `out` already passed the SAME admission / cooldown / disabled-repo /
+	// in-flight exclusions above, so a pinned issue that is no longer actionable was
+	// never collected and is simply absent (stale keys are skipped, not resurrected).
+	if h.server.deps != nil && h.server.deps.Config != nil {
+		applyQueueOrder(out, h.server.deps.Config.Hub.ContributeQueueOrder)
+	}
+
+	// Cap AFTER ordering so the operator's pinned items are guaranteed to survive the
+	// truncation (they sort to the front), not be dropped by an arbitrary scan cut.
+	if len(out) > limit {
+		out = out[:limit]
+	}
 	return out
+}
+
+// queueOrderIndex builds a "owner/repo#number" -> priority-rank map from the
+// operator's ordered override list. Earlier entries rank lower (offered sooner).
+// Keys not present rank as "unpinned" for callers (they use a sentinel above the
+// map size). Returned map is nil-safe to range over when the override is empty.
+func queueOrderIndex(order []string) map[string]int {
+	if len(order) == 0 {
+		return nil
+	}
+	idx := make(map[string]int, len(order))
+	for i, key := range order {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		// First occurrence wins so a duplicated key keeps its earliest (highest)
+		// priority rather than being demoted by a later copy.
+		if _, seen := idx[key]; !seen {
+			idx[key] = i
+		}
+	}
+	return idx
+}
+
+// applyQueueOrder stably reorders items so any whose "repo#number" key appears in
+// the operator override sort to the front in the operator's order, with unpinned
+// items keeping their original relative (scan) order behind them. In place; no-op
+// when the override is empty.
+func applyQueueOrder(items []ReadyQueueItem, order []string) {
+	idx := queueOrderIndex(order)
+	if len(idx) == 0 {
+		return
+	}
+	// Unpinned items rank at len(idx) (all pinned ranks are < len(idx)), so they all
+	// sort behind every pinned item while SliceStable preserves their scan order.
+	rank := func(it ReadyQueueItem) int {
+		if r, ok := idx[fmt.Sprintf("%s#%d", it.Repo, it.Number)]; ok {
+			return r
+		}
+		return len(idx)
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		return rank(items[i]) < rank(items[j])
+	})
 }
 
 // activeIssueKeys returns the set of "repo#number" keys currently in flight across

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -2062,8 +2062,33 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		return h.taskUnavailable(taskUnavailableNoMatchingWork)
 	}
 
+	// Operator priority override (#queue-reorder): the ordered list of issue keys
+	// the operator dragged to the front of the ready-work queue on the Operations
+	// tab. It takes precedence over the default ordering below so a prioritised
+	// issue is OFFERED FIRST. It never bypasses admission: every entry in
+	// `candidates` already passed the SAME cooldown / failure / disabled-repo /
+	// filter / in-flight exclusions above, so a pinned-but-no-longer-actionable key
+	// simply never became a candidate (stale keys are skipped). Rank sentinel: a
+	// candidate NOT in the override ranks at len(override), so all pinned candidates
+	// sort ahead of all unpinned ones while their own relative order is the operator's.
+	var queueOrderIdx map[string]int
+	if h.server.deps != nil && h.server.deps.Config != nil {
+		queueOrderIdx = queueOrderIndex(h.server.deps.Config.Hub.ContributeQueueOrder)
+	}
+	orderRank := func(c candidate) int {
+		if len(queueOrderIdx) == 0 {
+			return 0 // no override → every candidate ties, key is a no-op
+		}
+		if r, ok := queueOrderIdx[fmt.Sprintf("%s#%d", c.repoFull, c.number)]; ok {
+			return r
+		}
+		return len(queueOrderIdx)
+	}
+
 	// Order the admissible set with a STABLE sort so the pick is deterministic
 	// (easy to reason about and to test — no randomness):
+	//   0. operator priority override first (#queue-reorder) — pinned issues in the
+	//      operator's dragged order; a no-op when no override is set;
 	//   1. own-work first (#2390 — preserved unchanged);
 	//   2. then fewer recent failures first (#2435 remedy 3 backstop) — an issue
 	//      whose short failure cooldown has just elapsed but which still carries
@@ -2071,11 +2096,14 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	//      flaky issue can no longer monopolise the head of the queue even if the
 	//      ledger is imperfect;
 	//   3. otherwise the established per-repo / creation scan order is kept.
-	// When the contributor has no own work AND nothing has failed, this is a no-op
-	// and behaviour is identical to the previous first-eligible pick.
+	// When the contributor has no own work AND nothing has failed AND no override is
+	// set, this is a no-op and behaviour is identical to the previous first-eligible pick.
 	ownFirst := make([]candidate, len(candidates))
 	copy(ownFirst, candidates)
 	sort.SliceStable(ownFirst, func(i, j int) bool {
+		if ri, rj := orderRank(ownFirst[i]), orderRank(ownFirst[j]); ri != rj {
+			return ri < rj // operator-pinned (lower rank) sorts ahead
+		}
 		if ownFirst[i].isOwn != ownFirst[j].isOwn {
 			return ownFirst[i].isOwn // own work sorts ahead of non-own
 		}


### PR DESCRIPTION
Two enhancements to the Operations-tab **ready-work QUEUE**, built on top of the merged #2579 fleet-loading regression fix.

## 1. Longer, scrollable queue (was capped at ~10)
- `readyQueueDefaultLimit` raised **25 → 150**. The hive routinely has ~150+ actionable items; the operator wants to see (and reorder) the whole realistic backlog, not just the top handful. The cap still bounds a pathological backlog so the JSON payload / DOM can't blow out.
- The queue panel (`.cc-queue`) is a **fixed-height (560px) `overflow-y:auto` scroll container**, so a long list scrolls inside its card rather than stretching the page. The **"next up"** indicator stays on the top item.
- Queue rows now show **all** of each issue's GitHub labels as pills (dropped the client-side `slice(0,4)` truncation), matching the "My work" panel which already renders every label. `esc()` still guards each label.

## 2. Operator drag-reorder (grab bars) — owner/read-write only
- Each queue row gets a **grab-bar handle (⠿)**, visible and draggable **only for owner/read-write viewers** (gated on `adminEnabled`, set after `/api/role`). A `read`/anon viewer sees the queue but **no handles** and cannot reorder.
- Dependency-free **HTML5 drag-and-drop** reorders the queue; on drop it persists the new order via `PUT /api/contribute/queue/order`.
- The endpoint is **owner/read-write ONLY, enforced server-side** by `requireContributorWrite` (a `read`/anon caller gets **403**) — the `/api/contribute` prefix is exempt from `roleEnforcement`'s read-only block, so the handler enforces the boundary itself (same pattern as the trust/revoke/remove endpoints). UI hiding is UX; this is the security boundary.
- The accepted order is stored into **`Config.Hub.ContributeQueueOrder`** through the same `refreshAndPersist` path the admission settings use, so it **survives restart**. Keys are validated (`owner/repo#number`), trimmed, deduped, and capped.

### Effect on selection (offer-priority override, no admission bypass)
The persisted order is applied in **both** `ReadyQueue` (queue display) **and** `selectTask` (candidate ordering, as the **top sort key** ahead of own-work). It only reorders **offer priority**: it is applied **AFTER** every admission / cooldown / disabled-repo / in-flight exclusion, so:
- a **pinned issue that is filtered out** (deny title/author/label, disabled repo, in-flight, cooldown) stays excluded regardless of pin order, and
- a **stale pin** (a key no longer actionable) is simply **skipped**, never resurrected.

## Invariants preserved
- The `/contribute` page stays public; queue + dev-log + army remain viewable by everyone. Only the drag-reorder control and its endpoint are owner/read-write (UI + server).
- The #2579 fleet/policy/work hydration fix remains intact; other tabs unchanged; the command-center travel animation / achievements / SSE keep working with the longer, reordered queue.

## Tests
- queue returns **>10** items up to the raised cap (and the cap still bounds a larger backlog);
- the order endpoint is **owner/read-write only** (`read` → 403; owner/read-write/absent → 200);
- a persisted order is reflected in **both** the queue output **and** `selectTask`'s pick (pinned issue offered ahead of own-work);
- **stale pins are skipped**;
- **admission filters and failure cooldowns still exclude** a pinned issue;
- payload sanitisation (trim/dedupe/malformed-drop) and the key cap;
- `go build` / `go vet` / `gofmt` clean; embedded JS `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)