### PR TITLE
fix(dashboard): fall back to initials avatar instead of an empty ring

### DIFF
--- a/v2/pkg/hub/clickable_avatars_test.go
+++ b/v2/pkg/hub/clickable_avatars_test.go
@@ -88,12 +88,32 @@ func TestAvatarLinkDegradesWithoutUsername(t *testing.T) {
 	}
 }
 
-// TestAvatarOnErrorFallbackKept asserts the 404-avatar fallback survived the
-// move into an anchor. A broken-image glyph inside a link reads as a dead
-// control, which is worse than the gap it replaced.
-func TestAvatarOnErrorFallbackKept(t *testing.T) {
-	if !strings.Contains(dashboardHTML, `onerror="this.style.visibility=\'hidden\'"`) {
-		t.Error("avatarImg no longer hides a broken avatar image")
+// TestAvatarOnErrorFallsBackToInitials asserts a failed avatar load swaps to a
+// same-size initials avatar instead of hiding the image. github.com/<login>.png
+// returns 403 when the request is unauthenticated or rate-limited, which is
+// common for a hub visited without an active GitHub session; the old
+// visibility:hidden onerror left the face's box empty, which — inside the
+// "logged in now" live-ring wrapper — rendered as an empty dashed ring with
+// nobody home. The fallback must also disarm onerror (this.onerror=null)
+// before swapping so a bad fallback source can never loop.
+func TestAvatarOnErrorFallsBackToInitials(t *testing.T) {
+	if strings.Contains(dashboardHTML, `onerror="this.style.visibility=\'hidden\'"`) {
+		t.Error("avatarImg still hides a broken avatar image instead of falling back")
+	}
+	if !strings.Contains(dashboardHTML, `onerror="this.onerror=null;this.src=`) {
+		t.Error("avatarImg no longer disarms onerror before swapping to the fallback")
+	}
+	if !strings.Contains(dashboardHTML, "function avatarInitialsSVG(username, px)") {
+		t.Error("avatarInitialsSVG helper is missing — the initials fallback must be a shared, testable function")
+	}
+	if !strings.Contains(dashboardHTML, "data:image/svg+xml;charset=UTF-8,") {
+		t.Error("avatarInitialsSVG no longer builds a CSP-safe data: URI fallback")
+	}
+	// The nav-bar avatar (viewer's own face, built from the auth payload's
+	// avatar_url rather than through avatarImg) must get the same treatment —
+	// it is the other avatar builder that duplicated the hide-on-error pattern.
+	if !strings.Contains(dashboardHTML, "avatarInitialsSVG(data.login, NAV_AVATAR_PX)") {
+		t.Error("nav-bar avatar no longer falls back to initials on load failure")
 	}
 }
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -7517,11 +7517,46 @@ const dashboardHTML = `<!DOCTYPE html>
 
     /* Round avatar <img> for a github.com login, at the given rendered size in
        CSS pixels. Requests 2x from GitHub so the face stays sharp on HiDPI.
-       onerror hides a 404 avatar rather than leaving a broken-image glyph — an
-       especially important detail now that the image sits inside a link, where
-       a broken icon would read as a dead control. extraStyle appends to the
-       inline style (borders, flex sizing) and defaults to nothing. */
+       github.com/<login>.png is a redirect to GitHub's CDN and returns 403 when
+       the request is unauthenticated or rate-limited — common for a hub visited
+       by a browser without an active GitHub session. onerror used to just hide
+       the broken image (visibility:hidden), which left the face's OWN size/shape
+       box empty; inside a live-ring wrapper that reads as an empty dashed ring
+       with nobody home. onerror now swaps to a same-size, same-shape initials
+       avatar instead, so a failed load never leaves a hole. this.onerror=null
+       before the swap stops a data: URI (which cannot itself 403) from ever
+       re-triggering onerror and looping. extraStyle appends to the inline style
+       (borders, flex sizing) and defaults to nothing. */
     var AVATAR_HIDPI_SCALE = 2;
+    /* avatarInitialsSVG builds a self-contained data: URI — no network request,
+       so it always renders and is exempt from the CSP's img-src allowance for
+       https: (the CSP already allows img-src data:, so no policy change is
+       needed). The background color is deterministic from the username (a
+       simple string hash into a fixed hue set) so the same person gets the same
+       color every time rather than a random one on every failed load. */
+    var AVATAR_FALLBACK_HUES = [0, 25, 50, 145, 175, 200, 230, 260, 290, 330];
+    function avatarInitials(username) {
+      var clean = String(username || '').replace(/[^A-Za-z0-9]/g, '');
+      if (!clean) return '?';
+      return clean.length === 1 ? clean.charAt(0).toUpperCase() : (clean.charAt(0) + clean.charAt(clean.length - 1)).toUpperCase();
+    }
+    function avatarFallbackHue(username) {
+      var s = String(username || '');
+      var hash = 0;
+      for (var i = 0; i < s.length; i++) hash = (hash * 31 + s.charCodeAt(i)) >>> 0;
+      return AVATAR_FALLBACK_HUES[hash % AVATAR_FALLBACK_HUES.length];
+    }
+    function avatarInitialsSVG(username, px) {
+      var initials = avatarInitials(username);
+      var hue = avatarFallbackHue(username);
+      var r = px / 2;
+      var fontSize = Math.round(px * 0.42);
+      var svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' + px + '" height="' + px + '" viewBox="0 0 ' + px + ' ' + px + '">' +
+        '<circle cx="' + r + '" cy="' + r + '" r="' + r + '" fill="hsl(' + hue + ',45%,32%)"/>' +
+        '<text x="50%" y="50%" dy="0.35em" text-anchor="middle" font-family="system-ui,sans-serif" ' +
+        'font-size="' + fontSize + '" font-weight="600" fill="#fff">' + initials + '</text></svg>';
+      return 'data:image/svg+xml;charset=UTF-8,' + encodeURIComponent(svg);
+    }
     /* A user LOGGED INTO THEIR HIVE right now gets a thick green dashed ring, so
        "who is active this moment" reads at a glance wherever a face appears. The
        border is drawn on a wrapper (a border on the round <img> itself would clip
@@ -7535,7 +7570,7 @@ const dashboardHTML = `<!DOCTYPE html>
       var img = '<img src="' + escAttr(ghProfileURL(username)) + '.png?size=' + (px * AVATAR_HIDPI_SCALE) + '" alt="" ' +
         'style="width:' + px + 'px;height:' + px + 'px;border-radius:50%;vertical-align:middle;' +
         (extraStyle || '') + '" ' +
-        'onerror="this.style.visibility=\'hidden\'">';
+        'onerror="this.onerror=null;this.src=' + jsArg(avatarInitialsSVG(username, px)) + '">';
       if (isUserLive(username)) {
         // Concentric green dashed ring. The wrapper is a fixed square exactly the
         // face's size plus the ring gap+width on every side (px + 2*(gap+border)),
@@ -7564,6 +7599,7 @@ const dashboardHTML = `<!DOCTYPE html>
     var PANEL_ACCESS_AVATAR_PX = 18;   /* rows inside the status-dot hover panel */
     var LIST_AVATAR_PX = 20;           /* compact request/access lists */
     var TABLE_AVATAR_PX = 24;          /* admin Users table + provision cards */
+    var NAV_AVATAR_PX = 28;            /* top nav viewer avatar; mirrors .nav-avatar CSS */
 
     // ghRepoURL builds the URL for an org/repo on the RIGHT GitHub instance.
     // Hives are not all on public github.com: a provision request carries a
@@ -8612,12 +8648,14 @@ const dashboardHTML = `<!DOCTYPE html>
           /* The viewer's own face links to their own profile, like every other
              face in the dashboard. avatar_url comes from the auth payload (it is
              GitHub's CDN URL, not derivable from the login), so this one builds
-             its <img> directly rather than via avatarImg — but the anchor and
-             the role tooltip are the shared ones. */
+             its <img> directly rather than via avatarImg — but the anchor, the
+             role tooltip, and the initials fallback on load failure are shared.
+             NAV_AVATAR_PX mirrors the .nav-avatar CSS rule's fixed 28px size, so
+             the fallback SVG matches the box it is replacing. */
           document.getElementById('nav-user').innerHTML =
             avatarProfileLink(data.login, String(data.login || '') + ' — ' + roleText,
               '<img src="' + escAttr(data.avatar_url) + '" class="nav-avatar" alt="" ' +
-              'onerror="this.style.visibility=\'hidden\'">') +
+              'onerror="this.onerror=null;this.src=' + jsArg(avatarInitialsSVG(data.login, NAV_AVATAR_PX)) + '">') +
             '<span style="font-size:0.85rem">' + esc(data.login) + '</span>' +
             '<span style="font-size:0.65rem;color:var(--muted);margin-left:6px">' + roleText + '</span>';
         }


### PR DESCRIPTION
## Summary

Owner/user avatars in the hub dashboard sometimes render as an empty circle — most visibly as an empty green dashed "logged in to their hive now" ring with no face inside, in the fleet (hive list) rows.

**Root cause:** every avatar's `src` is built from `github.com/<login>.png`, which redirects to GitHub's CDN. That redirect returns HTTP 403 when the request is unauthenticated or rate-limited — common for a browser without an active GitHub session. `avatarImg`'s `onerror` responded to any load failure by hiding the `<img>` (`visibility:hidden`). For a live user, the face sits inside a thick green dashed ring wrapper drawn separately from the image; hiding the image left the ring around nothing.

Note: the issue as described pointed at `v2/pkg/dashboard/static/index.html`, but that file's `avatarImg` (checked first) doesn't build the "logged in now" ring at all. The actual dashed live-ring wrapper and its matching `avatarImg`/`linkedAvatar`/`isUserLive` helpers live in `v2/pkg/hub/saas.go` — the hub's dashboard, which renders the fleet-of-hives list with each hive's owner/access-list avatars. That's the file this PR changes.

## Fix

- `avatarImg` now falls back to a same-size, same-shape **initials avatar** on load failure instead of hiding the image: two-letter initials on a deterministic HSL-colored circle, built as an inline `data:image/svg+xml` URI. No network request, so it always renders.
- **CSP-safe**: the dashboard's `Content-Security-Policy` already allows `img-src 'self' data: https:`, so a `data:` image src needs no policy change.
- `this.onerror` is disarmed (`this.onerror=null`) before swapping to the fallback, so a bad fallback source can never re-trigger `onerror` and loop.
- The nav-bar viewer avatar built its own `<img>` directly (from the auth payload's `avatar_url`) and duplicated the same hide-on-error pattern — it's now wired to the same `avatarInitialsSVG` fallback via a new `NAV_AVATAR_PX` constant mirroring its `.nav-avatar` CSS size.
- `avatar_url`-CDN preference: checked every `avatarImg`/`linkedAvatar` call site in this file — none thread through a per-record `avatar_url`, only `username`, so there's no CDN URL available to prefer over `github.com/<login>.png` at the fleet-row sites. The initials fallback is what covers the 403 case there. (The nav-bar site already used `avatar_url` from the auth payload as its primary source.)
- Single-point fix: `avatarImg` is the shared helper behind every avatar in this file (pinned by the existing `TestAvatarSitesUseSharedHelper`/`TestNoHandRolledAvatarImages` tests), so fixing it here covers every avatar surface — fleet rows, access lists, admin tables, provision cards.

## Tests

- Updated `TestAvatarOnErrorFallbackKept` → `TestAvatarOnErrorFallsBackToInitials` in `clickable_avatars_test.go`: asserts the old `visibility='hidden'` onerror is gone, the new fallback disarms `onerror` before swapping, `avatarInitialsSVG` exists, it builds a `data:image/svg+xml` URI, and the nav-bar avatar uses the same fallback.
- `node --check` on all four inline `<script>` blocks extracted from the served `dashboardHTML` — all pass.
- `go build ./...`, `go vet ./...`, `gofmt -l` on changed files — clean.
- `go test ./pkg/hub/...` — all pass.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` on changed files
- [x] `go test ./pkg/hub/...`
- [x] `node --check` on extracted inline JS
- [ ] CI green