### PR TITLE
feat(contribute): make each tab URL-addressable + fix clanker-row overlap

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -105,6 +105,12 @@ func (s *Server) BuildContributorPoolStatus() *ContributorPoolStatus {
 func (s *Server) registerContributeRoutes() {
 	s.contributeHub = NewContributeWSHub(s.logger, s)
 	s.mux.HandleFunc("GET /contribute", s.handleContributeLanding)
+	// Path-style deep links: /contribute/onboarding|management|operations|leaderboard
+	// (and the short id forms) all serve the SAME landing HTML — the client JS reads
+	// location.pathname and activates the matching tab. The {tab} segment is not used
+	// server-side; it exists so each tab is a real bookmarkable/shareable URL. Any
+	// /contribute/<tab> is already treated as public by isPublicPath (server.go).
+	s.mux.HandleFunc("GET /contribute/{tab}", s.handleContributeLanding)
 	s.mux.HandleFunc("GET /api/contribute/ws", s.contributeHub.HandleWS)
 	s.mux.HandleFunc("POST /api/contribute/register", s.handleContributeRegister)
 	s.mux.HandleFunc("POST /api/contribute/reissue-token", s.handleContributeReissueToken)
@@ -408,12 +414,30 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .pill-passed{background:rgba(63,185,80,.12);color:#3fb950;border-color:rgba(63,185,80,.3)}
 .pill-blocked{background:rgba(248,81,73,.12);color:#f85149;border-color:rgba(248,81,73,.3)}
 .pill-idle{background:rgba(139,148,158,.12);color:#8b949e;border-color:rgba(139,148,158,.3)}
-.clanker-row{display:flex;align-items:center;gap:10px;padding:12px 20px;border-bottom:1px solid #21262d}
+/* #2574 (follow-up): the Connected-clankers card is a NARROW column. The old
+   layout put the multi-line identity text (.clanker-main) and the inline
+   controls (.admin-actions: tier dropdown + Revoke + Remove) in the SAME
+   align-items:center flex row with margin-left:auto. In the narrow column the
+   controls got vertically centered over the middle of the tall text block and
+   rendered ON TOP OF the "cli · model · role · on repo#N" lines. Fix: the row is
+   now a 3-column CSS grid — [dot][avatar][identity] on the top line — and the
+   trailing element (.admin-actions, or the non-admin .feed-time) is placed on its
+   OWN line spanning the full width BELOW the identity, so it never competes
+   horizontally with the multi-line text. Long repo paths in .clanker-sub wrap
+   (overflow-wrap:anywhere) rather than pushing into anything. align-items:start
+   keeps the dot/avatar top-aligned with the first text line. */
+.clanker-row{display:grid;grid-template-columns:auto auto minmax(0,1fr);align-items:start;column-gap:10px;row-gap:8px;padding:12px 20px;border-bottom:1px solid #21262d}
+/* The trailing controls / timestamp: full-width line beneath the identity. It is
+   always the LAST grid child, so grid-column:1/-1 drops it below regardless of
+   whether it's .admin-actions or the .feed-time fallback. */
+.clanker-row>.admin-actions,.clanker-row>.feed-time{grid-column:1/-1}
 .clanker-av{width:28px;height:28px;border-radius:50%%;flex-shrink:0;background:#30363d}
-.clanker-main{flex:1;min-width:0}
+.clanker-main{min-width:0}
 .clanker-user{font-size:.88rem;color:#e6edf3;font-weight:500}
-.clanker-sub{font-size:.74rem;color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
-.clanker-dot{width:8px;height:8px;border-radius:50%%;background:#3fb950;flex-shrink:0}
+.clanker-sub{font-size:.74rem;color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;overflow-wrap:anywhere;word-break:break-word}
+/* Row is align-items:start (grid), so nudge the small dot down to sit level with
+   the username's first line instead of the very top of the row. */
+.clanker-dot{width:8px;height:8px;border-radius:50%%;background:#3fb950;flex-shrink:0;margin-top:7px}
 .clanker-dot.stale{background:#8b949e}
 .pipeline{display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin:14px 0}
 .pipe-node{background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:8px 14px;font-size:.82rem;color:#e6edf3}
@@ -473,7 +497,10 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .admin-save{margin-top:8px}
 .admin-save:disabled{opacity:.5;cursor:default}
 .admin-hr{border:none;border-top:1px solid #21262d;margin:16px 0}
-.admin-actions{display:flex;gap:6px;flex-wrap:wrap;margin-left:auto}
+/* No margin-left:auto — .admin-actions is now a full-width grid row beneath the
+   identity (see .clanker-row grid), left-aligned and wrapping if the buttons
+   don't fit the narrow column. */
+.admin-actions{display:flex;gap:6px;flex-wrap:wrap}
 .admin-act{background:#21262d;border:1px solid #30363d;color:#c9d1d9;font-size:.7rem;padding:3px 9px;border-radius:6px;cursor:pointer;font-family:inherit}
 .admin-act:hover{border-color:#8b949e}
 .admin-act.danger:hover{border-color:#f85149;color:#f85149}
@@ -880,7 +907,39 @@ var lbStarted=false;    // Leaderboard hydrated (fetches /api/leaderboard once)
 // It is idempotent (fetches /api/role once) and independent of opsPoll().
 // activateTab drives both a user click and the deep-link path (/leaderboard →
 // /contribute?tab=leaderboard) through the SAME show/hide + hydration logic.
-function activateTab(t){
+// Canonical URL scheme: each tab is a real, shareable path under /contribute.
+//   Onboarding  -> /contribute            (bare; the default landing)
+//   Management  -> /contribute/management
+//   Operations  -> /contribute/operations
+//   Leaderboard -> /contribute/leaderboard
+// PANEL_SLUG maps each panel id to its clean path slug; SLUG_PANEL maps every
+// accepted friendly name / short id BACK to a panel id, so both the clean name
+// (management/operations) and the legacy short id (manage/ops) deep-link, and
+// the pre-existing ?tab=leaderboard query form keeps working. Onboarding has no
+// slug: it lives at the bare /contribute.
+var PANEL_SLUG={'tab-manage':'management','tab-ops':'operations','tab-leaderboard':'leaderboard'};
+var SLUG_PANEL={
+  'onboarding':'tab-onboarding',
+  'management':'tab-manage','manage':'tab-manage',
+  'operations':'tab-ops','ops':'tab-ops',
+  'leaderboard':'tab-leaderboard'
+};
+// Resolve a friendly name / short id to the tab BUTTON element (id ptab-*), or
+// null if it names no real tab. panelToButtonId turns a data-panel value back
+// into its button id (tab-manage -> ptab-manage) — the buttons keep the short
+// suffix, so we strip the leading "tab-".
+function panelToButtonId(dp){return 'ptab-'+dp.replace(/^tab-/,'');}
+function buttonForName(name){
+  if(!name)return null;
+  var dp=SLUG_PANEL[name.toLowerCase()];
+  if(!dp)return null;
+  return document.getElementById(panelToButtonId(dp));
+}
+// activateTab shows/hides panels, fires lazy hydration, and (unless push===false)
+// reflects the active tab in the address bar via history.pushState — no reload.
+// popstate-driven activations pass push===false so Back/Forward do NOT push a new
+// history entry (which would create a loop / trap the user).
+function activateTab(t,push){
   if(!t)return;
   tabs.forEach(function(x){x.classList.remove('active');x.setAttribute('aria-selected','false');});
   panels.forEach(function(p){p.classList.remove('active');});
@@ -900,21 +959,46 @@ function activateTab(t){
   }
   // Leaderboard hydrates client-side on first open — read-only, no role gate.
   if(dp==='tab-leaderboard'&&!lbStarted){lbStarted=true;loadLeaderboard();}
+  // Reflect the visible tab in the URL. pushState only — never a reload. Skipped
+  // when push===false (popstate replay) so we don't stack duplicate history entries.
+  if(push!==false&&window.history&&window.history.pushState){
+    var slug=PANEL_SLUG[dp];
+    var url=slug?('/contribute/'+slug):'/contribute';
+    if(url!==window.location.pathname){
+      try{window.history.pushState({tab:dp},'',url);}catch(e){/* pushState may throw on file:// etc. */}
+    }
+  }
 }
+// Click never needs to be told to push (default push===true).
 tabs.forEach(function(t){t.addEventListener('click',function(){activateTab(t);});});
 // Onboarding CTA opens the Leaderboard tab in place (no navigate-away).
 var gotoLb=document.getElementById('goto-leaderboard-tab');
 if(gotoLb)gotoLb.addEventListener('click',function(){activateTab(document.getElementById('ptab-leaderboard'));});
-// Deep link: /leaderboard redirects to /contribute?tab=leaderboard, which opens
-// the Leaderboard tab on a fresh load. Absent the param, the default (Onboarding)
-// stays active — we only override when the param names a real tab.
-(function(){
+// Deep link on load: prefer the path form (/contribute/<tab>), fall back to the
+// legacy ?tab=<name> query form (kept for back-compat with old bookmarks and the
+// /leaderboard shim). tabFromLocation returns the matching button or null.
+// Because we activate WITHOUT pushing here (the URL already IS the target), the
+// address bar is left exactly as the user arrived — no history churn on load.
+function tabFromLocation(){
+  var seg=/^\/contribute\/([^\/?#]+)/.exec(window.location.pathname);
+  if(seg){var b=buttonForName(decodeURIComponent(seg[1]));if(b)return b;}
   var m=/[?&]tab=([^&]+)/.exec(window.location.search);
-  if(!m)return;
-  var want=decodeURIComponent(m[1]);
-  var target=document.getElementById('ptab-'+want);
-  if(target)activateTab(target);
+  if(m){var b2=buttonForName(decodeURIComponent(m[1]));if(b2)return b2;}
+  return null;
+}
+(function(){
+  var target=tabFromLocation();
+  // Absent/unknown tab -> default (Onboarding) stays active. Activate without
+  // pushing so we never add a spurious history entry for the initial page.
+  if(target)activateTab(target,false);
 })();
+// Back/Forward: re-derive the tab from the (now-updated) location and activate it
+// WITHOUT pushing — popstate already moved history, a push here would loop. When
+// the path/param names no tab (e.g. Back to bare /contribute), fall to Onboarding.
+window.addEventListener('popstate',function(){
+  var target=tabFromLocation()||document.getElementById('ptab-onboarding');
+  activateTab(target,false);
+});
 
 // loadLeaderboard hydrates the Leaderboard tab from GET /api/leaderboard — the
 // SAME endpoint the (now-folded) standalone page used. Response shape:
@@ -2329,11 +2413,14 @@ func (s *Server) countAgentActivity(agentName string) (prs, issues, findings int
 // handleLeaderboardPage is kept for backward compatibility with the /leaderboard
 // route and any external bookmarks. The leaderboard now lives INLINE as a tab on
 // the /contribute page (hydrated from GET /api/leaderboard), so this handler is a
-// deep-link shim: it redirects to /contribute?tab=leaderboard, where the tab JS
-// reads the ?tab param on load and opens the Leaderboard tab. The former
-// standalone full-page render was folded into that tab to avoid a duplicate.
+// deep-link shim: it redirects to the canonical path-style tab URL
+// /contribute/leaderboard, where the tab JS reads location.pathname on load and
+// opens the Leaderboard tab. The former standalone full-page render was folded
+// into that tab to avoid a duplicate. (The legacy /contribute?tab=leaderboard
+// query form still works on load for back-compat, but the canonical shareable
+// URL is now the path form.)
 func (s *Server) handleLeaderboardPage(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/contribute?tab=leaderboard", http.StatusFound)
+	http.Redirect(w, r, "/contribute/leaderboard", http.StatusFound)
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -525,8 +525,9 @@ func TestLeaderboardAPISorted(t *testing.T) {
 
 // TestLeaderboardPageRedirect pins the deep-link shim behaviour: the standalone
 // leaderboard page was folded into the /contribute Leaderboard tab, so
-// GET /leaderboard now redirects to /contribute?tab=leaderboard (which the tab JS
-// reads on load to open the Leaderboard tab). Data still comes from the reused
+// GET /leaderboard now redirects to the canonical path-style tab URL
+// /contribute/leaderboard (which the tab JS reads from location.pathname on load
+// to open the Leaderboard tab). Data still comes from the reused
 // /api/leaderboard endpoint (asserted by TestLeaderboardAPISorted), so the
 // redirect must hold regardless of whether any contributors exist.
 func TestLeaderboardPageRedirect(t *testing.T) {
@@ -544,8 +545,8 @@ func TestLeaderboardPageRedirect(t *testing.T) {
 	if w.Code != http.StatusFound {
 		t.Fatalf("expected 302 redirect, got %d: %s", w.Code, w.Body.String())
 	}
-	if loc := w.Header().Get("Location"); loc != "/contribute?tab=leaderboard" {
-		t.Errorf("Location = %q, want /contribute?tab=leaderboard", loc)
+	if loc := w.Header().Get("Location"); loc != "/contribute/leaderboard" {
+		t.Errorf("Location = %q, want /contribute/leaderboard", loc)
 	}
 }
 
@@ -564,8 +565,8 @@ func TestLeaderboardPageRedirectEmpty(t *testing.T) {
 	if w.Code != http.StatusFound {
 		t.Fatalf("expected 302 redirect, got %d", w.Code)
 	}
-	if loc := w.Header().Get("Location"); loc != "/contribute?tab=leaderboard" {
-		t.Errorf("Location = %q, want /contribute?tab=leaderboard", loc)
+	if loc := w.Header().Get("Location"); loc != "/contribute/leaderboard" {
+		t.Errorf("Location = %q, want /contribute/leaderboard", loc)
 	}
 }
 
@@ -1001,5 +1002,93 @@ func TestBodySizeLimit(t *testing.T) {
 	s.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for huge body, got %d", w.Code)
+	}
+}
+
+// TestContributeTabPathServesLanding pins the path-style deep links introduced
+// with URL-addressable tabs: GET /contribute/<tab> must serve the SAME landing
+// HTML as /contribute (the client JS reads location.pathname on load and
+// activates the matching tab). Every accepted slug — clean names and legacy
+// short ids — must 200 with the page body, so Operations/Leaderboard hydrate on
+// direct load exactly as a click would (activateTab is the single choke point).
+func TestContributeTabPathServesLanding(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	paths := []string{
+		"/contribute",
+		"/contribute/onboarding",
+		"/contribute/management",
+		"/contribute/manage",
+		"/contribute/operations",
+		"/contribute/ops",
+		"/contribute/leaderboard",
+	}
+	for _, p := range paths {
+		req := httptest.NewRequest(http.MethodGet, p, nil)
+		w := httptest.NewRecorder()
+		s.mux.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("GET %s: expected 200, got %d", p, w.Code)
+			continue
+		}
+		// The same landing page (not a redirect / empty body): the ClankeR
+		// heading and the tab strip must be present.
+		if !bytes.Contains(w.Body.Bytes(), []byte("Contribute to")) {
+			t.Errorf("GET %s: landing page content missing", p)
+		}
+		if !bytes.Contains(w.Body.Bytes(), []byte(`data-panel="tab-ops"`)) {
+			t.Errorf("GET %s: tab strip missing (page not fully rendered)", p)
+		}
+	}
+}
+
+// TestContributeTabURLWiring asserts the client-side URL-addressable-tab plumbing
+// is present in the served HTML: the path/param reader (tabFromLocation), the
+// address-bar reflection via history.pushState, the Back/Forward popstate handler,
+// and the friendly-name -> panel mapping. These are runtime behaviours we can't
+// execute in a Go test, so we pin their presence to guard against silent removal.
+func TestContributeTabURLWiring(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+
+	for _, needle := range []string{
+		"function tabFromLocation",   // reads location.pathname + ?tab= on load
+		"history.pushState",          // address-bar reflection on tab switch
+		"popstate",                   // Back/Forward navigation
+		"'operations'",               // clean name accepted for Operations
+		"'management'",               // clean name accepted for Management
+		"/contribute/'+slug",         // path-style URL construction
+	} {
+		if !strings.Contains(body, needle) {
+			t.Errorf("served page missing tab-URL wiring: %q", needle)
+		}
+	}
+}
+
+// TestContributeSubpathsArePublic guards that the path-style tab URLs stay
+// anonymous-accessible: isPublicPath already prefixes /contribute/, but the tabs
+// depend on it, so pin it. A regression here would 401 shared/bookmarked tab URLs.
+func TestContributeSubpathsArePublic(t *testing.T) {
+	for _, p := range []string{
+		"/contribute",
+		"/contribute/onboarding",
+		"/contribute/management",
+		"/contribute/operations",
+		"/contribute/leaderboard",
+	} {
+		if !isPublicPath(p) {
+			t.Errorf("isPublicPath(%q) = false, want true (shared tab URLs must be public)", p)
+		}
 	}
 }

--- a/v2/pkg/dashboard/coverage_boost4_test.go
+++ b/v2/pkg/dashboard/coverage_boost4_test.go
@@ -106,8 +106,8 @@ func TestHandleLeaderboardPage(t *testing.T) {
 	if w.Code != http.StatusFound {
 		t.Errorf("code = %d, want 302 (redirect)", w.Code)
 	}
-	if loc := w.Header().Get("Location"); loc != "/contribute?tab=leaderboard" {
-		t.Errorf("Location = %q, want /contribute?tab=leaderboard", loc)
+	if loc := w.Header().Get("Location"); loc != "/contribute/leaderboard" {
+		t.Errorf("Location = %q, want /contribute/leaderboard", loc)
 	}
 }
 


### PR DESCRIPTION
## Make each `/contribute` tab URL-addressable + fix the clanker-row overlap

### URL-addressable tabs
The `/contribute` page has four tabs (Onboarding, Management, Operations, Leaderboard) but the URL stayed `/contribute` regardless of the visible tab — you could not bookmark or share a specific tab, and switching tabs never updated the address bar. This makes each tab a real, shareable, bookmarkable URL and reflects the active tab in the address bar as the user switches.

Canonical scheme (path-style, clean):
- Onboarding → `/contribute` (bare; the default landing)
- Management → `/contribute/management`
- Operations → `/contribute/operations`
- Leaderboard → `/contribute/leaderboard`

What changed:
- **Served server-side.** `GET /contribute/{tab}` is registered alongside `GET /contribute` and serves the **same** landing HTML — the `{tab}` segment is read only on the client. `isPublicPath` already treats the `/contribute/` prefix as public, so shared/bookmarked tab URLs stay anonymous-accessible (pinned by a test).
- **Deep-link on load (all tabs).** On load the client reads `location.pathname` (path form) and falls back to the legacy `?tab=` query form for back-compat with old bookmarks. Both the clean names (`management`, `operations`) and the legacy short ids (`manage`, `ops`) map to the right panel; unknown/absent tab keeps the Onboarding default.
- **Address-bar reflection (the missing piece).** On a tab switch, `activateTab` now updates the address bar via **`history.pushState`** to the clean `/contribute/<tab>` URL — no reload.
- **Back/Forward.** A `popstate` handler re-derives the tab from the (already-updated) location and activates it **without** pushing again, so there is no pushState loop.
- **Lazy hydration preserved.** Everything routes through the single `activateTab` choke point, so landing directly on `/contribute/operations` or `/contribute/leaderboard` fires the exact same hydration a click does — `initAdmin` (role gate / per-row controls), `opsPoll` + `ccStart` (fleet, queue, dev-log / SSE command center), and `loadLeaderboard`. A direct load of Operations comes up fully hydrated.
- **`/leaderboard` preserved.** It still redirects; the target is now the canonical `/contribute/leaderboard`. Old `/leaderboard` bookmarks still land on the Leaderboard tab.

Dependency-free vanilla JS; `activateTab` remains the single choke point.

### Clanker-row overlap fix (follow-up to #2574)
The overlap was still live. The Connected-clankers card is a narrow column, and the multi-line identity text (`.clanker-main`) shared one `align-items:center` flex row with the inline controls (tier dropdown / Revoke / Remove, `.admin-actions` with `margin-left:auto`). In the narrow column the controls got vertically centered over the tall text block and rendered **on top of** the `cli · model · role` / `on repo#N` metadata lines.

Fix — restructure the row:
- `.clanker-row` is now a **3-column CSS grid** (`[dot][avatar][identity]`) on the top line.
- The trailing element (`.admin-actions`, or the non-admin `.feed-time` timestamp) is placed on its **own full-width line below** the identity via `grid-column:1/-1`, so it no longer competes horizontally with the text.
- `.clanker-sub` gains `overflow-wrap:anywhere` so a long repo path wraps instead of pushing into anything.
- The avatar stays left-aligned beside the text; the status pill stays next to the username; `data-clanker` and the `cc-enter`/`cc-leave`/`cc-landing` animation classes and the owner/RW gating are unchanged.

Verified geometrically (headless render at the narrow column width, `castrojo` / `goose · gpt-5.6-luna` / `contributor` / working on `projectbluefin/actions#375` with the tier dropdown + Revoke + Remove): the controls sit **below** the identity block with **zero** vertical overlap.

### Tests
- `GET /contribute/<tab>` (all subpaths + short ids) returns 200 with the landing HTML.
- The served page carries the `tabFromLocation` / `history.pushState` / `popstate` wiring and the friendly-name mapping.
- `isPublicPath` covers the `/contribute/<tab>` subpaths.
- `/leaderboard` redirect target updated to `/contribute/leaderboard` (three existing tests updated).
- `go build`, `go vet`, full `pkg/dashboard` test package, and `node --check` on the extracted inline script all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
