### PR TITLE
swap Operations panel order — My work now above Ready-work queue

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -569,6 +569,10 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .cc-q-labels{display:flex;flex-wrap:wrap;gap:4px}
 .cc-q-next{font-size:.62rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#58a6ff;flex-shrink:0;padding-top:2px}
 .cc-q-item.cc-leaving{animation:cc-fadeout .45s ease forwards}
+/* FLIP glide for operator drag-reorder: items that changed slot are given an
+   inverse transform (see ccFlipQueue) then eased back to translateY(0). Subtle —
+   an SRE ops tool, not a game — so no bounce/overshoot, just a smooth glide. */
+.cc-q-item.cc-q-flip{transition:transform .26s ease}
 /* The travelling token that flies from the queue to a clanker on task_assign */
 .cc-token{position:fixed;z-index:1200;pointer-events:none;background:#1f6feb;color:#fff;font-size:.72rem;font-weight:600;padding:6px 12px;border-radius:999px;box-shadow:0 6px 20px rgba(31,111,235,.5);white-space:nowrap;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;transition:transform .9s cubic-bezier(.5,0,.2,1),opacity .9s ease;will-change:transform,opacity}
 /* Dev-log — a running chat log of the development */
@@ -631,7 +635,7 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
   .ops-rail.collapsed{flex-basis:auto}
 }
 @media(prefers-reduced-motion:reduce){
-  .clanker-row.cc-enter,.clanker-row.cc-leave,.clanker-row.cc-landing,.cc-q-item,.cc-q-item.cc-leaving,.cc-log-line,.cc-ach,.cc-token{animation:none!important;transition:none!important}
+  .clanker-row.cc-enter,.clanker-row.cc-leave,.clanker-row.cc-landing,.cc-q-item,.cc-q-item.cc-leaving,.cc-q-item.cc-q-flip,.cc-log-line,.cc-ach,.cc-token{animation:none!important;transition:none!important}
   .ops-rail,.ops-rail-inner,.ops-rail-chevron{transition:none!important}
 }
 </style></head><body>
@@ -913,16 +917,14 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 </div>
 </div>
 <div>
-<!-- Command center: the READY-WORK QUEUE (issues waiting to be picked off, top =
-     next up) and the live DEV-LOG (a running chat log of the development). Both are
-     fed by REAL events — the queue from ActionableIssues (the same set selectTask
-     offers from), the log from the ActivityEntry SSE stream. All read-only. -->
+<!-- Command center: MY WORK (this operator's in-flight items) stacked above the
+     READY-WORK QUEUE (issues waiting to be picked off, top = next up), and the live
+     DEV-LOG (a running chat log of the development, now in the rail). Both panels
+     are fed by REAL events — the queue from ActionableIssues (the same set
+     selectTask offers from), My work from the fleet snapshot. All read-only except
+     the queue's owner/read-write drag-reorder. Panel order: My work first, then
+     Ready-work queue — a pure vertical swap, no id/behavior change. -->
 <div class="ops-card">
-<div class="ops-card-head"><span class="feed-dot"></span><h3>Ready-work queue</h3><span class="cc-live stale" id="cc-live"><span class="cc-live-dot"></span><span id="cc-live-label">connecting</span></span></div>
-<div class="cc-queue" id="cc-queue"><div class="ops-empty">Loading queue&hellip;</div></div>
-<p class="ops-note" style="padding:10px 20px 14px;margin:0">The stack of admissible issues waiting to be picked off &mdash; top is next up. When a clanker grabs one you&rsquo;ll see it fly from here to that clanker. Derived from this hive&rsquo;s actionable backlog; read-only.</p>
-</div>
-<div class="ops-card" style="margin-top:20px">
 <div class="ops-card-head"><h3>My work</h3><span class="ops-card-count" id="work-count"></span></div>
 <div class="ops-filters" role="tablist">
 <button class="ops-filter active" data-filter="all">All</button>
@@ -931,6 +933,11 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 <button class="ops-filter" data-filter="done">Done</button>
 </div>
 <div class="work-list" id="work-list"><div class="ops-empty">Loading work&hellip;</div></div>
+</div>
+<div class="ops-card" style="margin-top:20px">
+<div class="ops-card-head"><span class="feed-dot"></span><h3>Ready-work queue</h3><span class="cc-live stale" id="cc-live"><span class="cc-live-dot"></span><span id="cc-live-label">connecting</span></span></div>
+<div class="cc-queue" id="cc-queue"><div class="ops-empty">Loading queue&hellip;</div></div>
+<p class="ops-note" style="padding:10px 20px 14px;margin:0">The stack of admissible issues waiting to be picked off &mdash; top is next up. When a clanker grabs one you&rsquo;ll see it fly from here to that clanker. Derived from this hive&rsquo;s actionable backlog; read-only.</p>
 </div>
 </div>
 </div>
@@ -1517,8 +1524,14 @@ var ccLastAch=0;           // debounce achievement pops
 
 function ccQueueKey(q){return (q.repo||'')+'#'+(q.number||'');}
 
-function ccRenderQueue(){
+function ccRenderQueue(flip){
   var el=document.getElementById('cc-queue');if(!el)return;
+  // flip=true (set only from the drag-drop handler) records each row's rect BEFORE
+  // the rebuild so ccFlipPlay can glide displaced rows to their new slots instead of
+  // a hard jump. Every other caller (initial load, SSE queue push, poll fallback)
+  // omits it and gets the plain re-render — no glide on data refreshes, only on the
+  // operator's own drag.
+  var first=flip?ccFlipFirst(el):null;
   // Drag-reorder is an operator CONTROL: only owner/read-write viewers get grab
   // bars. adminEnabled is set true by initAdmin ONLY after /api/role reports owner
   // or read-write; a read/anon viewer never gets the handles and cannot reorder.
@@ -1540,6 +1553,7 @@ function ccRenderQueue(){
       '<div class="cc-q-title" title="'+esc(q.title||'')+'">'+esc(q.title||'(untitled)')+'</div>'+labels+'</div>'+next+'</div>';
   }).join('');
   if(adminEnabled)ccBindQueueDrag(el);
+  if(first)ccFlipPlay(el,first);
 }
 
 // ── Operator drag-reorder (grab bars) — owner/read-write only ──────────────────
@@ -1573,10 +1587,60 @@ function ccBindQueueDrag(root){
       toIdx=-1;for(var b=0;b<ccQueue.length;b++){if(ccQueueKey(ccQueue[b])===to){toIdx=b;break;}}
       if(toIdx<0)toIdx=ccQueue.length;
       ccQueue.splice(toIdx,0,moved);
-      ccRenderQueue();
+      ccRenderQueue(true); // FLIP: glide displaced items to their new slots instead of a hard jump.
       ccPersistQueueOrder();
     });
   })(items[i]);}
+}
+// ── FLIP animation for drag-reorder (First-Last-Invert-Play) ───────────────────
+// Dependency-free: record each row's bounding rect BEFORE the re-render (First),
+// let ccRenderQueue() rebuild the DOM in the new order, then read each row's rect
+// AFTER (Last). For every row keyed the same before/after that actually moved,
+// apply an inverse translateY so it appears at its old spot, then transition it to
+// translateY(0) — a smooth glide, not a snap. Reads are batched before writes to
+// avoid layout thrash. Rows that did not move (delta 0) are left alone. Skipped
+// entirely under prefers-reduced-motion, matching the rest of this page's motion.
+function ccFlipFirst(root){
+  var first={};
+  var items=root.querySelectorAll('.cc-q-item');
+  for(var i=0;i<items.length;i++){
+    var k=items[i].getAttribute('data-qkey');
+    if(k)first[k]=items[i].getBoundingClientRect().top;
+  }
+  return first;
+}
+function ccFlipPlay(root,first){
+  if(window.matchMedia&&matchMedia('(prefers-reduced-motion:reduce)').matches)return;
+  var items=root.querySelectorAll('.cc-q-item');
+  // Batch reads (Last) before any writes (Invert), then batch writes, then batch
+  // the rAF that clears the inversion — no interleaved read/write layout thrash.
+  var moves=[];
+  for(var i=0;i<items.length;i++){
+    var it=items[i],k=it.getAttribute('data-qkey');
+    if(!k||!(k in first))continue;
+    var last=it.getBoundingClientRect().top;
+    var delta=first[k]-last;
+    if(Math.abs(delta)<1)continue; // didn't move (or scrolled out of view symmetrically) — no-op
+    moves.push([it,delta]);
+  }
+  if(!moves.length)return;
+  for(var m=0;m<moves.length;m++){
+    moves[m][0].style.transition='none';
+    moves[m][0].style.transform='translateY('+moves[m][1]+'px)';
+  }
+  // Force one reflow so the inverted position is committed before we animate to 0.
+  void root.offsetHeight;
+  requestAnimationFrame(function(){
+    for(var n=0;n<moves.length;n++){
+      var el=moves[n][0];
+      el.classList.add('cc-q-flip');
+      el.style.transition='';
+      el.style.transform='';
+    }
+    setTimeout(function(){
+      for(var p=0;p<moves.length;p++)moves[p][0].classList.remove('cc-q-flip');
+    },300); // matches .cc-q-flip transition duration (260ms) + a small margin
+  });
 }
 function ccPersistQueueOrder(){
   var order=ccQueue.map(ccQueueKey);

--- a/v2/pkg/dashboard/contribute_ops_panel_order_test.go
+++ b/v2/pkg/dashboard/contribute_ops_panel_order_test.go
@@ -1,0 +1,127 @@
+package dashboard
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The Operations tab's two command-center panels (My work / Ready-work queue)
+// were swapped vertically: My work now renders ABOVE the Ready-work queue (was
+// below it). This is a pure DOM reorder — same region (.ops-main), same ids,
+// same behavior, same travel/drag animations. These tests pin the new order and
+// prove both panels still hydrate (ids intact) after the swap.
+
+// TestOpsPanelOrderMyWorkAboveQueue pins the new vertical order: the "My work"
+// card head must precede the "Ready-work queue" card head in the served markup,
+// and both must still sit inside .ops-main (the main command-center area).
+func TestOpsPanelOrderMyWorkAboveQueue(t *testing.T) {
+	body := renderContributePage(t)
+
+	mainStart := strings.Index(body, `class="ops-main"`)
+	railStart := strings.Index(body, `class="ops-rail"`)
+	myWork := strings.Index(body, `<h3>My work</h3>`)
+	queue := strings.Index(body, `<h3>Ready-work queue</h3>`)
+
+	if mainStart < 0 || railStart < 0 || myWork < 0 || queue < 0 {
+		t.Fatalf("missing structure markers (main=%d rail=%d mywork=%d queue=%d)", mainStart, railStart, myWork, queue)
+	}
+	if !(mainStart < myWork && myWork < railStart) {
+		t.Errorf("My work heading is not inside .ops-main (main=%d mywork=%d rail=%d)", mainStart, myWork, railStart)
+	}
+	if !(mainStart < queue && queue < railStart) {
+		t.Errorf("Ready-work queue heading is not inside .ops-main (main=%d queue=%d rail=%d)", mainStart, queue, railStart)
+	}
+	if !(myWork < queue) {
+		t.Errorf("expected My work panel to render ABOVE Ready-work queue (mywork=%d, queue=%d)", myWork, queue)
+	}
+}
+
+// TestOpsPanelOrderHydrationIntact proves the reorder did not disturb the ids the
+// render/hydration JS targets by getElementById, the filter buttons, the queue's
+// live pill, or the gating/animation wiring.
+func TestOpsPanelOrderHydrationIntact(t *testing.T) {
+	body := renderContributePage(t)
+
+	for _, want := range []string{
+		// My work panel: id, count badge, filter tabs, list container.
+		`id="work-count"`,
+		`data-filter="all"`,
+		`data-filter="active"`,
+		`data-filter="review"`,
+		`data-filter="done"`,
+		`id="work-list"`,
+		// Ready-work queue panel: id, live pill, queue container.
+		`id="cc-live"`,
+		`id="cc-live-label"`,
+		`id="cc-queue"`,
+		// Render/hydration entry points still wired.
+		`function renderWork`,
+		`function ccRenderQueue`,
+		`function ccBindQueueDrag`,
+		`function ccTravel`,
+		// Drag-reorder + FLIP glide wiring (grip, drag model, FLIP helpers).
+		`cc-q-grip`,
+		`function ccFlipFirst`,
+		`function ccFlipPlay`,
+		`ccRenderQueue(true)`, // drop handler requests the FLIP glide, not a hard jump
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("panel-swap broke hydration wiring: missing %q", want)
+		}
+	}
+}
+
+// TestOpsPanelOrderFlipRespectsReducedMotion proves the FLIP glide is gated by
+// prefers-reduced-motion, consistent with the rest of this page's motion (travel
+// animation, achievement pops, dev-log lines all already respect it).
+func TestOpsPanelOrderFlipRespectsReducedMotion(t *testing.T) {
+	body := renderContributePage(t)
+
+	if !strings.Contains(body, `function ccFlipPlay`) {
+		t.Fatal("ccFlipPlay missing")
+	}
+	// ccFlipPlay must bail out under reduced motion before touching any transform.
+	idx := strings.Index(body, `function ccFlipPlay`)
+	end := strings.Index(body[idx:], "\n}\n")
+	if end < 0 {
+		t.Fatal("could not locate end of ccFlipPlay body")
+	}
+	fn := body[idx : idx+end]
+	if !strings.Contains(fn, `prefers-reduced-motion:reduce`) {
+		t.Error("ccFlipPlay does not check prefers-reduced-motion")
+	}
+
+	// The CSS reduced-motion media block must also list .cc-q-item.cc-q-flip among
+	// the selectors neutralized with transition:none!important, so even a stray
+	// inline style is inert.
+	rmIdx := strings.Index(body, `@media(prefers-reduced-motion:reduce)`)
+	if rmIdx < 0 {
+		t.Fatal("reduced-motion media block missing")
+	}
+	rmEnd := strings.Index(body[rmIdx:], "</style>")
+	rmBlock := body[rmIdx:]
+	if rmEnd > 0 {
+		rmBlock = body[rmIdx : rmIdx+rmEnd]
+	}
+	if !strings.Contains(rmBlock, `cc-q-item.cc-q-flip`) {
+		t.Error("reduced-motion CSS block does not neutralize .cc-q-item.cc-q-flip")
+	}
+}
+
+// TestOpsPanelOrderPageStillRenders is a smoke test that the full /contribute page
+// still returns 200 with the swap in place (no accidental unclosed tag / structural
+// break from the reorder).
+func TestOpsPanelOrderPageStillRenders(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary

Swap Operations panel order — My work now above Ready-work queue.

- Pure DOM reorder inside `.ops-main`: the two Operations command-center panels (My work / Ready-work queue) swap vertical stacking order so **My work renders first, Ready-work queue second**. All element ids (`cc-queue`, `work-list`, `cc-live`, `work-count`, the filter buttons), classes, owner/read-write gating, the queue's live pill, and the travel-animation source/target are unchanged — verified the render functions (`renderWork`, `ccRenderQueue`, `ccBindQueueDrag`, `ccTravel`) still find their targets by id regardless of DOM order.
- Builds on top of the dev-log right-rail restructure (#2585, merged) and the drag-reorder feature (#2582, already on v2).

## Additional change folded in (same file, same region)

Operator drag-reorder of the ready-work queue now **animates** the moved item and every displaced item to their new slots instead of snapping instantly, using a dependency-free FLIP (First-Last-Invert-Play):

- Before the drop re-renders the list, each row's bounding rect is recorded (First).
- After the DOM rebuilds in the new order, rows that changed position get an inverse `translateY` so they appear at their old spot, then transition to `translateY(0)` over ~260ms ease (Invert → Play). Reads are batched before writes to avoid layout thrash.
- Items that didn't move are left alone; only the drag-drop path triggers the glide (SSE/poll refreshes of the queue still re-render in place, unchanged).
- Subtle, no bounce/overshoot — consistent with the page's existing motion (travel animation, achievement pops).
- Respects `prefers-reduced-motion`: the glide is skipped in JS before any transform is applied, and the CSS reduced-motion media block also neutralizes `.cc-q-item.cc-q-flip`.
- The existing travel animation (picked-up item flying from `#cc-queue` to a `.clanker-row`) is untouched — it's a separate code path (`ccTravel`) and still resolves correctly with the queue in its new (lower) position, since it targets `#cc-queue` by id and uses `position:fixed` coordinates independent of DOM order.

## Testing

- `go build ./...`, `go vet ./...` — clean.
- `go test ./pkg/dashboard/...` — all pass, including the existing dev-log-rail, command-center, and queue-order tests (none of them assert relative order between the two panels, so nothing regressed).
- Added `contribute_ops_panel_order_test.go`: pins the new order (My work markup precedes Ready-work-queue markup, both still inside `.ops-main`), asserts both panels still hydrate (ids intact: `work-count`, filter buttons, `work-list`, `cc-live`, `cc-queue`), asserts the FLIP helpers/wiring are present, and asserts the FLIP glide is reduced-motion-safe (bails before any transform under `prefers-reduced-motion`, and the CSS block also neutralizes `.cc-q-item.cc-q-flip`).
- Extracted and ran `node --check` on the page's inline `<script>` blocks — the block containing this change's JS parses cleanly (the one pre-existing `node --check` failure elsewhere in the file is an unrelated Go-template `%%` escape that predates this change, confirmed present on `origin/v2` before this PR).