### PR TITLE
✨ feat(hub+spoke): honest user engagement tiers — real actions and focus-aware presence

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2781,6 +2781,13 @@ func main() {
 				// per-user "time in hive". Bare usernames only — never session
 				// ids/tokens (ActiveSessionUsernames guarantees this).
 				ActiveSessionUsers: dashSrv.ActiveSessionUsernames(),
+				// The honest subset of the above: users whose browser reported
+				// focused, recent-input presence (see dashboard/presence.go).
+				// An idle open tab appears in ActiveSessionUsers but not here.
+				EngagedSessionUsers: dashSrv.EngagedSessionUsernames(),
+				// Per-user last audit-logged real action, so the hub can tell
+				// users who DO things from users who merely stay logged in.
+				UserLastActions: dashSrv.UserLastActions(),
 				Owner: func() string {
 					if td, err := os.ReadFile("/data/gh-user-token"); err == nil {
 						tok := strings.TrimSpace(string(td))

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -43,6 +43,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("PUT /api/config/variables/{name}", s.handleVariableUpsert)
 	s.mux.HandleFunc("DELETE /api/config/variables/{name}", s.handleVariableDelete)
 	s.mux.HandleFunc("GET /api/audit", s.handleAuditLog)
+	s.mux.HandleFunc("POST /api/presence", s.handlePresence)
 	s.mux.HandleFunc("GET /api/prompt-history", s.handlePromptHistory)
 	s.mux.HandleFunc("POST /api/self-upgrade", s.handleSelfUpgrade)
 	// Self-service, owner-only spoke backup (encrypted; includes the bead

--- a/v2/pkg/dashboard/audit.go
+++ b/v2/pkg/dashboard/audit.go
@@ -141,6 +141,11 @@ func (a *AuditLog) noteUserAction(user, ts string) {
 	if err != nil {
 		return
 	}
+	// Lazy init: several tests (and any future caller) construct AuditLog as a
+	// bare struct literal rather than through newAuditLog.
+	if a.lastAction == nil {
+		a.lastAction = make(map[string]time.Time)
+	}
 	prev, known := a.lastAction[user]
 	if !known && len(a.lastAction) >= auditMaxTrackedActionUsers {
 		return

--- a/v2/pkg/dashboard/audit.go
+++ b/v2/pkg/dashboard/audit.go
@@ -13,13 +13,28 @@ import (
 )
 
 const (
-	auditLogPath       = "/data/audit.jsonl"
-	auditMaxSizeMB     = 5
-	auditMaxBackups    = 3
-	auditMaxAgeDays    = 90
-	auditMaxEntries    = 200
-	auditRingCap       = 500
+	auditLogPath    = "/data/audit.jsonl"
+	auditMaxSizeMB  = 5
+	auditMaxBackups = 3
+	auditMaxAgeDays = 90
+	auditMaxEntries = 200
+	auditRingCap    = 500
+	// auditMaxTrackedActionUsers bounds the per-user last-action map so a
+	// pathological stream of unique usernames cannot grow it without bound.
+	// A real hive has a handful of users; this is purely defensive.
+	auditMaxTrackedActionUsers = 500
 )
+
+// auditPseudoUsers are the audit User values that do NOT represent a real
+// person acting in the dashboard: background/system writers ("system"),
+// unauthenticated local access ("local"), and failed identity resolution
+// ("unknown"). Entries by these must never count as user engagement.
+var auditPseudoUsers = map[string]bool{
+	"":        true,
+	"system":  true,
+	"local":   true,
+	"unknown": true,
+}
 
 type AuditEntry struct {
 	Timestamp string `json:"ts"`
@@ -33,11 +48,20 @@ type AuditLog struct {
 	mu     sync.Mutex
 	writer *lumberjack.Logger
 	ring   []AuditEntry
+	// lastAction maps a REAL username (never a pseudo-user; see
+	// auditPseudoUsers) to the timestamp of their most recent audited action —
+	// config saves, agent restarts, ACMM changes, logins, etc. It is the
+	// cheap "did this person actually DO something" signal reported hub-ward
+	// in the heartbeat, updated at write time rather than by scanning the log.
+	// Rebuilt from the on-disk audit log at startup, and the hub keeps the
+	// running maximum per user, so a spoke restart never regresses it there.
+	lastAction map[string]time.Time
 }
 
 func newAuditLog() *AuditLog {
 	a := &AuditLog{
-		ring: make([]AuditEntry, 0, auditRingCap),
+		ring:       make([]AuditEntry, 0, auditRingCap),
+		lastAction: make(map[string]time.Time),
 	}
 
 	dir := "/data"
@@ -69,6 +93,7 @@ func (a *AuditLog) loadFromDisk() {
 		var entry AuditEntry
 		if json.Unmarshal(line, &entry) == nil && entry.Timestamp != "" {
 			a.ring = append(a.ring, entry)
+			a.noteUserAction(entry.User, entry.Timestamp)
 		}
 	}
 	if len(a.ring) > auditRingCap {
@@ -95,12 +120,49 @@ func (a *AuditLog) Log(user, action, detail, agent string) {
 		a.ring = a.ring[1:]
 	}
 	a.ring = append(a.ring, entry)
+	a.noteUserAction(entry.User, entry.Timestamp)
 
 	if a.writer != nil {
 		if data, err := json.Marshal(entry); err == nil {
 			a.writer.Write(append(data, '\n'))
 		}
 	}
+}
+
+// noteUserAction records ts as user's most recent audited action, skipping
+// pseudo-users and never moving a user's timestamp backwards (the on-disk
+// replay in loadFromDisk feeds entries oldest-first, but ordering is not
+// guaranteed across rotated files). Callers must hold a.mu.
+func (a *AuditLog) noteUserAction(user, ts string) {
+	if auditPseudoUsers[user] {
+		return
+	}
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return
+	}
+	prev, known := a.lastAction[user]
+	if !known && len(a.lastAction) >= auditMaxTrackedActionUsers {
+		return
+	}
+	if !known || t.After(prev) {
+		a.lastAction[user] = t
+	}
+}
+
+// LastUserActions returns a copy of the per-user last-audited-action
+// timestamps as RFC3339 strings, keyed by username. Non-secret by
+// construction: bare usernames and timestamps only — no entry details, no
+// tokens. It rides the heartbeat so the hub can tell users who DO things
+// apart from users who merely leave a tab open.
+func (a *AuditLog) LastUserActions() map[string]string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make(map[string]string, len(a.lastAction))
+	for user, t := range a.lastAction {
+		out[user] = t.UTC().Format(time.RFC3339)
+	}
+	return out
 }
 
 func (a *AuditLog) Recent(n int) []AuditEntry {
@@ -150,6 +212,12 @@ func (s *Server) AuditLog(user, action, detail, agent string) {
 // GetAudit returns the underlying AuditLog for use by background goroutines.
 func (s *Server) GetAudit() *AuditLog {
 	return s.audit
+}
+
+// UserLastActions exposes the audit log's per-user last-action timestamps for
+// the heartbeat sender (see AuditLog.LastUserActions for the contract).
+func (s *Server) UserLastActions() map[string]string {
+	return s.audit.LastUserActions()
 }
 
 func auditDetail(kv ...string) string {

--- a/v2/pkg/dashboard/presence.go
+++ b/v2/pkg/dashboard/presence.go
@@ -1,0 +1,93 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"time"
+)
+
+// Focus-aware presence. A live session (a valid hive_session cookie / an open
+// tab) says nothing about whether a human is actually THERE — an idle tab left
+// open over a weekend used to accumulate "time in hive" the whole time. The
+// frontend therefore reports classic idle-detection presence: it pings this
+// endpoint only while the tab is VISIBLE and input (mouse/key/scroll/touch)
+// occurred within the idle window. The absence of pings is what marks a user
+// idle — there is no explicit "idle" message to spoof or to miss.
+//
+// The engaged set feeds the heartbeat (EngagedSessionUsers) so the hub can
+// accumulate honest per-user engaged time next to the back-compat open-tab
+// session time.
+const (
+	// presencePingIntervalSecs is the cadence at which an ENGAGED frontend
+	// pings /api/presence. It must match PRESENCE_PING_MS in static/index.html.
+	presencePingIntervalSecs = 30
+	// presenceFreshness is how long after the last engaged ping a user still
+	// counts as engaged. Three ping intervals absorbs up to two dropped/late
+	// pings before the user is (correctly) demoted to idle.
+	presenceFreshness = 3 * presencePingIntervalSecs * time.Second
+	// maxPresenceBodyBytes caps the beacon's request body. The real payload is
+	// a dozen bytes of JSON; anything bigger is not a presence ping.
+	maxPresenceBodyBytes = 1024
+	// maxPresenceUsers bounds the engaged map so a stream of unique usernames
+	// (misbehaving proxy, forged headers upstream) cannot grow it without
+	// bound. A real hive has a handful of users; purely defensive.
+	maxPresenceUsers = 500
+)
+
+// handlePresence records an engaged-presence ping from the dashboard frontend.
+// Identity comes ONLY from the X-Hive-User header, which the auth middleware
+// either injected from a server-side session or received from the trusted hub
+// proxy — never from the request body. An unidentified caller (open local/dev
+// dashboard with no session) is a silent no-op: there is no user to credit,
+// and inventing one would be the exact dishonesty this feature removes.
+func (s *Server) handlePresence(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Engaged bool `json:"engaged"`
+	}
+	// A malformed body is treated as not-engaged rather than an error: this is
+	// a fire-and-forget beacon and the client ignores the response.
+	r.Body = http.MaxBytesReader(w, r.Body, maxPresenceBodyBytes)
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	user := r.Header.Get("X-Hive-User")
+	if body.Engaged && user != "" {
+		s.markUserEngaged(user, time.Now())
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// markUserEngaged stamps user as engaged as of now. Lazily initializes the map
+// so the zero-value Server used throughout the tests needs no constructor
+// change.
+func (s *Server) markUserEngaged(user string, now time.Time) {
+	s.presenceMu.Lock()
+	defer s.presenceMu.Unlock()
+	if s.presenceEngagedAt == nil {
+		s.presenceEngagedAt = make(map[string]time.Time)
+	}
+	if _, known := s.presenceEngagedAt[user]; !known && len(s.presenceEngagedAt) >= maxPresenceUsers {
+		return
+	}
+	s.presenceEngagedAt[user] = now
+}
+
+// EngagedSessionUsernames returns the DISTINCT usernames whose last engaged
+// presence ping is within presenceFreshness — the users a human is actually
+// behind right now, as opposed to ActiveSessionUsernames' open-tab set. Stale
+// entries are pruned on read so the map cannot grow without bound. Sorted for a
+// stable heartbeat payload. Non-secret: bare usernames only.
+func (s *Server) EngagedSessionUsernames() []string {
+	cutoff := time.Now().Add(-presenceFreshness)
+	s.presenceMu.Lock()
+	defer s.presenceMu.Unlock()
+	out := make([]string, 0, len(s.presenceEngagedAt))
+	for user, seen := range s.presenceEngagedAt {
+		if seen.Before(cutoff) {
+			delete(s.presenceEngagedAt, user)
+			continue
+		}
+		out = append(out, user)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/v2/pkg/dashboard/presence_test.go
+++ b/v2/pkg/dashboard/presence_test.go
@@ -1,0 +1,150 @@
+package dashboard
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestHandlePresenceEngaged covers the focus-aware presence beacon: an engaged
+// ping from an identified user lands them in the engaged set; everything else
+// — not-engaged, unidentified, malformed — is a silent no-op that never
+// invents engagement.
+func TestHandlePresenceEngaged(t *testing.T) {
+	cases := []struct {
+		name        string
+		user        string
+		body        string
+		wantEngaged bool
+	}{
+		{"engaged ping from identified user", "alice", `{"engaged":true}`, true},
+		{"engaged:false never marks", "alice", `{"engaged":false}`, false},
+		{"no identity header is a no-op", "", `{"engaged":true}`, false},
+		{"malformed body reads as not engaged", "alice", `{{{`, false},
+		{"empty body reads as not engaged", "alice", ``, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestServer()
+			req := httptest.NewRequest("POST", "/api/presence", strings.NewReader(tc.body))
+			if tc.user != "" {
+				req.Header.Set("X-Hive-User", tc.user)
+			}
+			rec := httptest.NewRecorder()
+			s.handlePresence(rec, req)
+			if rec.Code != 204 {
+				t.Fatalf("presence beacon must always 204, got %d", rec.Code)
+			}
+			engaged := s.EngagedSessionUsernames()
+			got := len(engaged) == 1 && engaged[0] == tc.user
+			if got != tc.wantEngaged {
+				t.Errorf("engaged set = %v, wantEngaged=%v", engaged, tc.wantEngaged)
+			}
+		})
+	}
+}
+
+// TestEngagedSessionUsernamesFreshness verifies that a user whose last engaged
+// ping is older than presenceFreshness drops out (and is pruned), so a closed
+// laptop stops reading as engaged within seconds, not heartbeats.
+func TestEngagedSessionUsernamesFreshness(t *testing.T) {
+	s := newTestServer()
+	s.markUserEngaged("fresh", time.Now())
+	s.markUserEngaged("stale", time.Now().Add(-2*presenceFreshness))
+
+	got := s.EngagedSessionUsernames()
+	if len(got) != 1 || got[0] != "fresh" {
+		t.Fatalf("engaged = %v, want [fresh] (stale pruned)", got)
+	}
+	s.presenceMu.Lock()
+	_, still := s.presenceEngagedAt["stale"]
+	s.presenceMu.Unlock()
+	if still {
+		t.Error("stale engaged entry must be pruned on read")
+	}
+}
+
+// TestMarkUserEngagedBounded verifies the defensive cap: beyond
+// maxPresenceUsers distinct usernames, NEW names are dropped while existing
+// ones keep refreshing.
+func TestMarkUserEngagedBounded(t *testing.T) {
+	s := newTestServer()
+	now := time.Now()
+	for i := 0; i < maxPresenceUsers; i++ {
+		s.markUserEngaged(fmt.Sprintf("user-%d", i), now)
+	}
+	s.markUserEngaged("overflow", now)
+	s.presenceMu.Lock()
+	_, added := s.presenceEngagedAt["overflow"]
+	size := len(s.presenceEngagedAt)
+	s.presenceMu.Unlock()
+	if added || size != maxPresenceUsers {
+		t.Errorf("cap breached: overflow added=%v size=%d (max %d)", added, size, maxPresenceUsers)
+	}
+	// Existing users still refresh at the cap.
+	s.markUserEngaged("user-0", now.Add(time.Minute))
+	s.presenceMu.Lock()
+	refreshed := s.presenceEngagedAt["user-0"].Equal(now.Add(time.Minute))
+	s.presenceMu.Unlock()
+	if !refreshed {
+		t.Error("an already-tracked user must keep refreshing at the cap")
+	}
+}
+
+// TestAuditLastUserActions covers the cheap last-real-action signal: audit
+// writes by real users update the per-user timestamp at write time, while
+// pseudo-users (system/local/unknown — background jobs, unauthenticated
+// access) never count as engagement.
+func TestAuditLastUserActions(t *testing.T) {
+	s := newTestServer()
+
+	s.audit.Log("alice", "config_save", "", "")
+	s.audit.Log("system", "startup", "", "")
+	s.audit.Log("local", "config_save", "", "")
+	s.audit.Log("unknown", "login_error", "", "")
+	s.audit.Log("", "watcher", "", "") // Log maps "" to "system"
+
+	// Read through the Server wrapper (the heartbeat's entry point). Membership
+	// checks rather than an exact size: on a host with a real /data the audit
+	// log may have replayed prior entries at construction.
+	acts := s.UserLastActions()
+	ts, ok := acts["alice"]
+	if !ok {
+		t.Fatalf("alice's audited action must be tracked, got %v", acts)
+	}
+	when, err := time.Parse(time.RFC3339, ts)
+	if err != nil || time.Since(when) > time.Minute {
+		t.Fatalf("alice's last action %q must be a fresh RFC3339 stamp (err=%v)", ts, err)
+	}
+	for _, pseudo := range []string{"system", "local", "unknown", ""} {
+		if _, tracked := acts[pseudo]; tracked {
+			t.Errorf("pseudo-user %q must never count as engagement", pseudo)
+		}
+	}
+}
+
+// TestNoteUserActionNeverRegresses verifies replaying an OLDER entry (rotated
+// log files, out-of-order load) cannot move a user's last action backwards,
+// and that an unparsable timestamp is ignored.
+func TestNoteUserActionNeverRegresses(t *testing.T) {
+	// A bare in-memory AuditLog (no disk attach) so the assertions are exact.
+	a := &AuditLog{ring: make([]AuditEntry, 0, auditRingCap), lastAction: make(map[string]time.Time)}
+	newer := time.Now().UTC().Format(time.RFC3339)
+	older := time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339)
+
+	a.mu.Lock()
+	a.noteUserAction("alice", newer)
+	a.noteUserAction("alice", older)
+	a.noteUserAction("bob", "not-a-timestamp")
+	a.mu.Unlock()
+
+	acts := a.LastUserActions()
+	if acts["alice"] != newer {
+		t.Errorf("alice = %q, want the newer stamp %q", acts["alice"], newer)
+	}
+	if _, ok := acts["bob"]; ok {
+		t.Error("an unparsable timestamp must not be tracked")
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -143,6 +143,12 @@ type Server struct {
 
 	audit *AuditLog
 
+	// presenceEngagedAt maps a username to the last time their browser
+	// reported ENGAGED presence (tab visible + recent input; see presence.go).
+	// Lazily initialized under presenceMu, freshness-pruned on read.
+	presenceMu        sync.Mutex
+	presenceEngagedAt map[string]time.Time
+
 	// promptHistory stores the fully-expanded kick prompts delivered to each
 	// agent, so an owner can review what their agents were actually told.
 	promptHistory *PromptHistory

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -18956,6 +18956,50 @@ function burnAreaChart() {
 
     connect();
 
+    // Focus-aware presence reporting. An open tab is NOT engagement: the spoke
+    // only learns "a human is actually here" from these pings, which fire on a
+    // fixed cadence and ONLY while the tab is visible AND input (mouse/key/
+    // scroll/touch) happened within the idle window. No ping = idle — there is
+    // no explicit idle message. The spoke's engaged set rides the heartbeat to
+    // the hub, which accumulates honest engaged_seconds next to the legacy
+    // open-tab session_seconds. Failures are swallowed: presence is advisory
+    // and must never surface an error to the user.
+    (function initPresenceReporting() {
+      var PRESENCE_PING_MS = 30000;           // engaged-ping cadence; must match presencePingIntervalSecs (presence.go)
+      var PRESENCE_IDLE_WINDOW_MS = 60000;    // no input for this long => idle, stop pinging
+      var PRESENCE_INPUT_THROTTLE_MS = 5000;  // rate-limit input bookkeeping (mousemove fires constantly)
+      var _presenceLastInput = Date.now();
+      function notePresenceInput() {
+        var now = Date.now();
+        if (now - _presenceLastInput >= PRESENCE_INPUT_THROTTLE_MS) _presenceLastInput = now;
+      }
+      ['mousemove', 'mousedown', 'keydown', 'scroll', 'wheel', 'touchstart'].forEach(function(ev) {
+        window.addEventListener(ev, notePresenceInput, { passive: true, capture: true });
+      });
+      function presenceEngaged() {
+        return document.visibilityState === 'visible' &&
+          (Date.now() - _presenceLastInput) < PRESENCE_IDLE_WINDOW_MS;
+      }
+      function sendPresencePing() {
+        if (!presenceEngaged()) return;
+        fetch('/api/presence', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ engaged: true })
+        }).catch(function() {});
+      }
+      document.addEventListener('visibilitychange', function() {
+        if (document.visibilityState === 'visible') {
+          // Returning to the tab is itself input — restart the idle clock and
+          // report immediately so presence recovers without waiting a cadence.
+          _presenceLastInput = Date.now();
+          sendPresencePing();
+        }
+      });
+      setInterval(sendPresencePing, PRESENCE_PING_MS);
+      sendPresencePing();
+    })();
+
     // Deferred initialization — non-critical fetches staggered after first paint.
     // Each entry returns a promise so anchor scrolling can wait for layout to settle.
     const DEFERRED_INIT_DELAY_MS = 1500;

--- a/v2/pkg/hub/access_hover_test.go
+++ b/v2/pkg/hub/access_hover_test.go
@@ -98,8 +98,10 @@ func TestAccessAvatarTitleCarriesStats(t *testing.T) {
 	for _, snippet := range []string{
 		"if (a.login_count) lines.push('Logins: ' + a.login_count);",
 		"if (a.session_seconds) lines.push('Time in hive: ' + fmtHours(a.session_seconds));",
+		"if (a.engaged_seconds) lines.push('Engaged time: ' + fmtHours(a.engaged_seconds));",
+		"if (a.last_action_at) lines.push('Last real action: ' + fmtUserTS(a.last_action_at));",
 		"var act = userTaskActivity(uname);",
-		"userVerdict({login_count: a.login_count || 0, session_seconds: a.session_seconds || 0}, act, [])",
+		"userVerdict({login_count: a.login_count || 0, session_seconds: a.session_seconds || 0, engaged_seconds: a.engaged_seconds || 0, last_action_at: a.last_action_at || ''}, act, [])",
 		// The "logged in now" line rides in the avatar's own tooltip, not the ring
 		// wrapper, so a live user's identity+stats aren't shadowed.
 		"if (isUserLive(uname)) title = title + '\\n● Logged into their hive now';",

--- a/v2/pkg/hub/engagement_tier.go
+++ b/v2/pkg/hub/engagement_tier.go
@@ -1,0 +1,111 @@
+package hub
+
+import "time"
+
+// User engagement status tiers for the Hub Admin Users table. The old Status
+// column said "active" for every non-blocked user — an open idle tab, a user
+// who never logged in, and a daily driver all rendered identically. The tier
+// replaces that with a classification driven by two honest signals:
+//
+//   - last REAL action: the newest audit-logged user action on any of the
+//     user's hives (SaaSUser.LastActionAt, folded from spoke audit logs), and
+//   - focus-aware engaged presence: time credited only while the user's
+//     browser was visible with recent input (LastEngagedAt / EngagedSeconds,
+//     from the spoke's /api/presence pings).
+//
+// Tiers, most to least engaged:
+//
+//	blocked — admin-blocked; overrides everything (the Block button's state).
+//	live    — connected right now AND engaged (focused tab, recent input).
+//	active  — a real action or engaged presence within engagementActiveWindow.
+//	idle    — seen (login / open session / stale action) within
+//	          engagementDormantWindow, but nothing REAL within the active
+//	          window. This is the idle-open-tab crowd.
+//	dormant — no signal of any kind within engagementDormantWindow.
+//	never   — zero completed logins, ever.
+//
+// Records that predate the new fields have no LastActionAt/LastEngagedAt;
+// absence is treated as NO DATA (the timestamp simply doesn't contribute),
+// never as "engaged as of zero-time" or "engaged as of now". For those users
+// the LastLogin fallback still separates idle from dormant, so old spokes and
+// old records degrade to a coarser-but-honest answer.
+const (
+	// engagementActiveWindow is how recently a REAL signal (audited action or
+	// engaged presence) must have occurred for a user to rank `active`.
+	engagementActiveWindow = 7 * 24 * time.Hour
+	// engagementDormantWindow is how long with NO signal at all (not even a
+	// login or an open tab) before a user ranks `dormant` rather than `idle`.
+	engagementDormantWindow = 30 * 24 * time.Hour
+)
+
+// Tier names — the API surface of the status_tier field; the dashboard JS
+// matches on these strings.
+const (
+	tierBlocked = "blocked"
+	tierLive    = "live"
+	tierActive  = "active"
+	tierIdle    = "idle"
+	tierDormant = "dormant"
+	tierNever   = "never"
+)
+
+// parseEngagementTime parses an RFC3339 field, returning ok=false for the
+// absent/invalid case so callers treat missing data as missing — a record
+// without the field must never behave as if the event happened at zero-time
+// or right now.
+func parseEngagementTime(ts string) (time.Time, bool) {
+	if ts == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// userStatusTier classifies one user. Pure function of the record plus the
+// hub's presence view, so it is directly table-testable:
+//
+//	liveNow    — the user is in the fresh live set (an open session somewhere).
+//	engagedNow — the user is in the fresh ENGAGED set (focused + recent input).
+func userStatusTier(u *SaaSUser, liveNow, engagedNow bool, now time.Time) string {
+	if u.Blocked {
+		return tierBlocked
+	}
+	// Zero logins ever: LoginCount is backfilled to ≥1 on load for anyone with
+	// a LastLogin, so both being empty means the user has never completed a
+	// hub login (e.g. admin-provisioned and never showed up).
+	if u.LoginCount == 0 && u.LastLogin == "" {
+		return tierNever
+	}
+	if liveNow && engagedNow {
+		return tierLive
+	}
+	// lastReal: newest HONEST signal — audited action or engaged presence.
+	var lastReal time.Time
+	if t, ok := parseEngagementTime(u.LastActionAt); ok && t.After(lastReal) {
+		lastReal = t
+	}
+	if t, ok := parseEngagementTime(u.LastEngagedAt); ok && t.After(lastReal) {
+		lastReal = t
+	}
+	if !lastReal.IsZero() && now.Sub(lastReal) <= engagementActiveWindow {
+		return tierActive
+	}
+	// lastSeen: newest signal of ANY kind, including the weak ones — a hub
+	// login, a merely-open session right now, or the stale real signal above.
+	// It only separates idle (recently seen, doing nothing real) from dormant
+	// (gone entirely).
+	lastSeen := lastReal
+	if t, ok := parseEngagementTime(u.LastLogin); ok && t.After(lastSeen) {
+		lastSeen = t
+	}
+	if liveNow {
+		lastSeen = now
+	}
+	if !lastSeen.IsZero() && now.Sub(lastSeen) <= engagementDormantWindow {
+		return tierIdle
+	}
+	return tierDormant
+}

--- a/v2/pkg/hub/engagement_tier_test.go
+++ b/v2/pkg/hub/engagement_tier_test.go
@@ -1,0 +1,244 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// tierAgo is a real-clock RFC3339 stamp d before now, for tier-window math.
+func tierAgo(d time.Duration) string {
+	return time.Now().Add(-d).UTC().Format(time.RFC3339)
+}
+
+// TestUserStatusTier is the table-driven contract for the Users-table Status
+// tier: every tier is reachable, precedence is blocked > never > live >
+// active > idle > dormant, and records missing the new engagement fields are
+// treated as HAVING NO DATA — never as engaged-now, never as engaged-at-zero.
+func TestUserStatusTier(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name       string
+		u          SaaSUser
+		liveNow    bool
+		engagedNow bool
+		want       string
+	}{
+		{
+			name:    "blocked overrides everything",
+			u:       SaaSUser{Blocked: true, LoginCount: 5, LastLogin: tierAgo(time.Hour), LastActionAt: tierAgo(time.Hour)},
+			liveNow: true, engagedNow: true,
+			want: tierBlocked,
+		},
+		{
+			name: "never: zero logins ever",
+			u:    SaaSUser{},
+			want: tierNever,
+		},
+		{
+			name:    "live: connected AND engaged right now",
+			u:       SaaSUser{LoginCount: 1, LastLogin: tierAgo(time.Hour)},
+			liveNow: true, engagedNow: true,
+			want: tierLive,
+		},
+		{
+			name:    "connected but NOT engaged is not live — open tab ranks idle",
+			u:       SaaSUser{LoginCount: 1, LastLogin: tierAgo(10 * 24 * time.Hour)},
+			liveNow: true, engagedNow: false,
+			want: tierIdle,
+		},
+		{
+			name: "active: real audited action within the 7-day window",
+			u:    SaaSUser{LoginCount: 2, LastLogin: tierAgo(20 * 24 * time.Hour), LastActionAt: tierAgo(2 * 24 * time.Hour)},
+			want: tierActive,
+		},
+		{
+			name: "active: focus-engaged presence within the 7-day window",
+			u:    SaaSUser{LoginCount: 2, LastLogin: tierAgo(20 * 24 * time.Hour), LastEngagedAt: tierAgo(3 * 24 * time.Hour)},
+			want: tierActive,
+		},
+		{
+			name: "idle: recent login but no real signal in 7 days (open-tab crowd)",
+			u:    SaaSUser{LoginCount: 4, LastLogin: tierAgo(2 * 24 * time.Hour), SessionSeconds: 100000},
+			want: tierIdle,
+		},
+		{
+			name: "idle: stale real action still counts as seen within 30 days",
+			u:    SaaSUser{LoginCount: 1, LastLogin: tierAgo(60 * 24 * time.Hour), LastActionAt: tierAgo(10 * 24 * time.Hour)},
+			want: tierIdle,
+		},
+		{
+			name: "dormant: nothing at all within 30 days",
+			u:    SaaSUser{LoginCount: 3, LastLogin: tierAgo(45 * 24 * time.Hour), LastActionAt: tierAgo(40 * 24 * time.Hour)},
+			want: tierDormant,
+		},
+		{
+			name: "missing new fields are absent, not zero-now: legacy record with old login is dormant",
+			u:    SaaSUser{LoginCount: 1, LastLogin: tierAgo(90 * 24 * time.Hour), SessionSeconds: 500000},
+			want: tierDormant,
+		},
+		{
+			name: "missing new fields never rank active: fresh login alone is idle",
+			u:    SaaSUser{LoginCount: 1, LastLogin: tierAgo(time.Hour)},
+			want: tierIdle,
+		},
+		{
+			name: "unparsable timestamps are ignored, not treated as now",
+			u:    SaaSUser{LoginCount: 1, LastLogin: tierAgo(45 * 24 * time.Hour), LastActionAt: "garbage", LastEngagedAt: "also-garbage"},
+			want: tierDormant,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := userStatusTier(&tc.u, tc.liveNow, tc.engagedNow, now); got != tc.want {
+				t.Errorf("userStatusTier() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCreditEngagedTime verifies the engaged-time gate: session time accrues
+// for every live session (back-compat), but engaged time and LastEngagedAt
+// accrue ONLY for users the spoke reported as focus-engaged. An idle/hidden
+// tab therefore grows session_seconds and never engaged_seconds.
+func TestCreditEngagedTime(t *testing.T) {
+	s := sessionTestHub()
+	useTempUserDir(t)
+	saveSaaSUser(&SaaSUser{GitHubUsername: "worker"})
+	saveSaaSUser(&SaaSUser{GitHubUsername: "lurker"})
+
+	prev := &RegistryEntry{LastHeartbeat: realAgo(120 * time.Second)}
+	s.creditActiveSessionTime(prev, true, []string{"worker", "lurker"}, []string{"worker"})
+
+	worker := loadSaaSUser("worker")
+	lurker := loadSaaSUser("lurker")
+	if worker.SessionSeconds < 110 || lurker.SessionSeconds < 110 {
+		t.Fatalf("both live users must accrue session time: worker=%d lurker=%d", worker.SessionSeconds, lurker.SessionSeconds)
+	}
+	if worker.EngagedSeconds < 110 || worker.EngagedSeconds > 130 {
+		t.Errorf("engaged user must accrue engaged time, got %d", worker.EngagedSeconds)
+	}
+	if worker.LastEngagedAt == "" {
+		t.Error("engaged user must get LastEngagedAt stamped")
+	}
+	if lurker.EngagedSeconds != 0 || lurker.LastEngagedAt != "" {
+		t.Errorf("idle open tab must NOT accrue engagement: engaged=%d lastEngagedAt=%q", lurker.EngagedSeconds, lurker.LastEngagedAt)
+	}
+}
+
+// TestApplyUserLastActions verifies the hub-side fold of the spoke audit
+// signal: timestamps land on the user record, only ever move FORWARD, and
+// unknown users, bad names, and bad timestamps are skipped without error.
+func TestApplyUserLastActions(t *testing.T) {
+	s := sessionTestHub()
+	useTempUserDir(t)
+	saveSaaSUser(&SaaSUser{GitHubUsername: "alice", LastActionAt: tierAgo(time.Hour)})
+	saveSaaSUser(&SaaSUser{GitHubUsername: "bob"})
+
+	fresh := tierAgo(time.Minute)
+	s.applyUserLastActions(map[string]string{
+		"alice":         fresh,
+		"bob":           "not-a-timestamp",
+		"ghost":         fresh,
+		"../etc/passwd": fresh,
+	})
+	if got := loadSaaSUser("alice").LastActionAt; got != fresh {
+		t.Errorf("alice.LastActionAt = %q, want the newer %q", got, fresh)
+	}
+	if got := loadSaaSUser("bob").LastActionAt; got != "" {
+		t.Errorf("a bad timestamp must be skipped, got %q", got)
+	}
+	if loadSaaSUser("ghost") != nil {
+		t.Error("an unknown user must NOT be auto-created")
+	}
+
+	// An older report (a second hive with a stale audit log) never regresses.
+	s.applyUserLastActions(map[string]string{"alice": tierAgo(48 * time.Hour)})
+	if got := loadSaaSUser("alice").LastActionAt; got != fresh {
+		t.Errorf("alice.LastActionAt regressed to %q, want %q kept", got, fresh)
+	}
+
+	// nil is the old-spoke case: a clean no-op.
+	s.applyUserLastActions(nil)
+}
+
+// TestEngagedHiveUsernames covers the engaged-now presence set: marked from
+// the heartbeat's engaged report, freshness-pruned on read, and queried
+// per-user by isUserEngagedNow (the `live` tier gate).
+func TestEngagedHiveUsernames(t *testing.T) {
+	s := sessionTestHub()
+
+	s.markUsersEngaged([]string{"alice", "../bad", ""})
+	if got := s.engagedHiveUsernames(); len(got) != 1 || got[0] != "alice" {
+		t.Fatalf("engaged = %v, want [alice] (valid names only)", got)
+	}
+	if !s.isUserEngagedNow("alice") {
+		t.Error("alice must read engaged-now right after a report")
+	}
+	if s.isUserEngagedNow("bob") {
+		t.Error("an unreported user must not read engaged-now")
+	}
+
+	// Stale entries drop out and are pruned.
+	s.liveHiveUsersMu.Lock()
+	s.engagedHiveUsers["alice"] = time.Now().Add(-2 * liveHiveUserStaleness)
+	s.liveHiveUsersMu.Unlock()
+	if got := s.engagedHiveUsernames(); len(got) != 0 {
+		t.Errorf("stale engaged entry must be pruned, got %v", got)
+	}
+	if s.isUserEngagedNow("alice") {
+		t.Error("a stale engaged report must not read engaged-now")
+	}
+
+	// nil report (old spoke) is a clean no-op.
+	s.markUsersEngaged(nil)
+}
+
+// TestAdminUsersCarriesStatusTier verifies the admin Users payload includes
+// the hub-computed status_tier for every user, computed from the record plus
+// the hub's live/engaged view — including `live` for a user engaged right now.
+func TestAdminUsersCarriesStatusTier(t *testing.T) {
+	s := sessionTestHub()
+	useTempUserDir(t)
+	saveSaaSUser(&SaaSUser{GitHubUsername: "engaged-now", LoginCount: 1, LastLogin: tierAgo(time.Hour)})
+	saveSaaSUser(&SaaSUser{GitHubUsername: "blocked-user", Blocked: true})
+	saveSaaSUser(&SaaSUser{GitHubUsername: "never-logged-in"})
+	s.markUsersLive([]string{"engaged-now"})
+	s.markUsersEngaged([]string{"engaged-now"})
+
+	rec := httptest.NewRecorder()
+	s.handleAdminUsers(rec, httptest.NewRequest("GET", "/api/saas/admin/users", nil))
+	var resp struct {
+		Users []struct {
+			GitHubUsername string `json:"github_username"`
+			StatusTier     string `json:"status_tier"`
+		} `json:"users"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad admin users payload: %v", err)
+	}
+	want := map[string]string{
+		"engaged-now":     tierLive,
+		"blocked-user":    tierBlocked,
+		"never-logged-in": tierNever,
+	}
+	seen := 0
+	for _, u := range resp.Users {
+		expect, ok := want[u.GitHubUsername]
+		if !ok {
+			continue
+		}
+		seen++
+		if u.StatusTier != expect {
+			t.Errorf("%s: status_tier = %q, want %q", u.GitHubUsername, u.StatusTier, expect)
+		}
+	}
+	if seen != len(want) {
+		t.Errorf("payload covered %d of %d expected users", seen, len(want))
+	}
+	if strings.Contains(rec.Body.String(), "encrypted_token") {
+		t.Error("admin users payload must never carry encrypted tokens")
+	}
+}

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -334,6 +334,24 @@ type HeartbeatPayload struct {
 	// spoke too old to report it, or one with no live sessions, sends nothing —
 	// which the hub reads as "credit no one this beat", never as an error.
 	ActiveSessionUsers []string `json:"active_session_users,omitempty"`
+	// EngagedSessionUsers is the subset of ActiveSessionUsers whose browser
+	// reported ENGAGED presence recently — tab visible AND input within the
+	// idle window (spoke: EngagedSessionUsernames, fed by /api/presence). It is
+	// what separates a human actually using their hive from an idle open tab.
+	// The hub credits these users engaged time and marks them engaged-now.
+	// Non-secret: bare usernames only. omitempty + optional everywhere: a spoke
+	// too old to report it sends nothing, which the hub reads as "no engagement
+	// DATA this beat" — never as an error and never as "everyone idle forever"
+	// (legacy fields keep accumulating regardless).
+	EngagedSessionUsers []string `json:"engaged_session_users,omitempty"`
+	// UserLastActions maps username → RFC3339 timestamp of that user's most
+	// recent audit-logged REAL action on this hive (config save, agent
+	// restart, ACMM change, login, …; pseudo-users like "system" are never
+	// included — spoke: UserLastActions). The hub folds each into the user
+	// record's LastActionAt, keeping the maximum, so spoke restarts and
+	// multi-hive users resolve to the newest action anywhere. Non-secret:
+	// usernames and timestamps only. omitempty/optional for old spokes.
+	UserLastActions map[string]string `json:"user_last_actions,omitempty"`
 	// StartedAt is the spoke process start time (RFC3339). The hub renders it
 	// as an uptime pill so a hive that is quietly crash-looping — 1/1 Running
 	// but restarted 35 times — is visible in My Hives instead of looking

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -83,6 +83,23 @@ type SaaSUser struct {
 	// sum of inter-beat intervals, so it is accurate to roughly the beat interval,
 	// not to the second.
 	SessionSeconds int64 `json:"session_seconds,omitempty"`
+	// EngagedSeconds is the honest subset of SessionSeconds: time accumulated
+	// only on beats where the user's browser reported ENGAGED presence — tab
+	// visible AND input within the idle window (heartbeat EngagedSessionUsers).
+	// An idle open tab grows SessionSeconds but never this. omitempty, and
+	// absent on records that predate the field or whose spokes don't report
+	// presence yet — absence means NO DATA, never "provably unengaged".
+	EngagedSeconds int64 `json:"engaged_seconds,omitempty"`
+	// LastEngagedAt is the RFC3339 time of the most recent beat that credited
+	// EngagedSeconds — when a human was last actually behind this user's
+	// session. Feeds the `active` status tier. Same absence semantics as
+	// EngagedSeconds.
+	LastEngagedAt string `json:"last_engaged_at,omitempty"`
+	// LastActionAt is the RFC3339 time of the user's most recent REAL audited
+	// action on any of their hives (config save, agent restart, ACMM change,
+	// login, …), folded hub-ward from the spoke audit logs (heartbeat
+	// UserLastActions) keeping the per-user maximum. Same absence semantics.
+	LastActionAt string `json:"last_action_at,omitempty"`
 }
 
 // Length caps for the admin-editable contact fields. These are free text
@@ -529,11 +546,34 @@ func (s *HubServer) requireAdmin(next http.HandlerFunc) http.HandlerFunc {
 
 func (s *HubServer) handleAdminUsers(w http.ResponseWriter, r *http.Request) {
 	users := listAllSaaSUsers()
+	// status_tier is computed HUB-side (it needs the hub's live/engaged
+	// presence view and the tier windows) so the dashboard renders and sorts a
+	// server-decided classification instead of re-deriving policy in JS.
+	// See userStatusTier for the tier rules.
+	live := make(map[string]bool)
+	for _, name := range s.liveHiveUsernames() {
+		live[name] = true
+	}
+	engaged := make(map[string]bool)
+	for _, name := range s.engagedHiveUsernames() {
+		engaged[name] = true
+	}
+	now := time.Now()
+	type adminUserView struct {
+		SaaSUser
+		StatusTier string `json:"status_tier"`
+	}
+	views := make([]adminUserView, 0, len(users))
 	for i := range users {
 		users[i].EncryptedToken = ""
+		name := users[i].GitHubUsername
+		views = append(views, adminUserView{
+			SaaSUser:   users[i],
+			StatusTier: userStatusTier(&users[i], live[name], engaged[name], now),
+		})
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"users": users})
+	json.NewEncoder(w).Encode(map[string]any{"users": views})
 }
 
 // handleAdminUpdateUser applies a partial admin edit to one hub user record.
@@ -2183,6 +2223,9 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		// treatment. Presence data about other users → admin-only, same as the
 		// engagement stats it complements.
 		resp["live_hive_users"] = s.liveHiveUsernames()
+		// The honest subset of live_hive_users: users whose browser reported
+		// focused, recent-input presence. live minus engaged = idle open tabs.
+		resp["live_engaged_users"] = s.engagedHiveUsernames()
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -4621,6 +4664,10 @@ type HiveAccessEntry struct {
 	// with no stats round-trips as today's handle — role tooltip.
 	LoginCount     int   `json:"login_count,omitempty"`
 	SessionSeconds int64 `json:"session_seconds,omitempty"`
+	// Honest engagement signals (see SaaSUser for semantics) — admin-only like
+	// the stats above, and omitempty/absent for records without data yet.
+	EngagedSeconds int64  `json:"engaged_seconds,omitempty"`
+	LastActionAt   string `json:"last_action_at,omitempty"`
 }
 
 // accessForHive returns who can sign in to a hive, newest-role-agnostic and
@@ -4646,6 +4693,8 @@ func accessForHive(hiveID string, users []SaaSUser, includeAdminOnly bool) []Hiv
 				entry.Notes = u.Notes
 				entry.LoginCount = u.LoginCount
 				entry.SessionSeconds = u.SessionSeconds
+				entry.EngagedSeconds = u.EngagedSeconds
+				entry.LastActionAt = u.LastActionAt
 			}
 			access = append(access, entry)
 		}
@@ -7891,6 +7940,8 @@ const dashboardHTML = `<!DOCTYPE html>
       // Engagement stats (admin-only; absent → these lines are simply skipped).
       if (a.login_count) lines.push('Logins: ' + a.login_count);
       if (a.session_seconds) lines.push('Time in hive: ' + fmtHours(a.session_seconds));
+      if (a.engaged_seconds) lines.push('Engaged time: ' + fmtHours(a.engaged_seconds));
+      if (a.last_action_at) lines.push('Last real action: ' + fmtUserTS(a.last_action_at));
       var act = userTaskActivity(uname);
       if (act.done || act.failed) lines.push('Tasks: ' + act.done + ' done / ' + act.failed + ' failed');
       // The lifecycle verdict, from the same helper the admin card uses. It reads
@@ -7899,7 +7950,7 @@ const dashboardHTML = `<!DOCTYPE html>
       // the ACMM-graduation refinement is unavailable here. Shown only when there
       // is some signal to classify (any stat present), so a bare face stays bare.
       if (a.login_count || a.session_seconds || act.done) {
-        var verdict = userVerdict({login_count: a.login_count || 0, session_seconds: a.session_seconds || 0}, act, []);
+        var verdict = userVerdict({login_count: a.login_count || 0, session_seconds: a.session_seconds || 0, engaged_seconds: a.engaged_seconds || 0, last_action_at: a.last_action_at || ''}, act, []);
         if (verdict && verdict.label) lines.push(verdict.label);
       }
       return lines.join('\n');
@@ -11003,6 +11054,7 @@ const dashboardHTML = `<!DOCTYPE html>
            the green-dashed avatar border. A Set of lowercased usernames so the
            avatar lookup is case-insensitive, matching GitHub handle semantics. */
         _liveHiveUsers = new Set((data.live_hive_users || []).map(function(n) { return String(n).toLowerCase(); }));
+        _liveEngagedUsers = new Set((data.live_engaged_users || []).map(function(n) { return String(n).toLowerCase(); }));
         /* Alerts ride along on the same payload — see handleMyHives. Normalise
            to the empty summary so every consumer can iterate without guarding. */
         _fleetAlerts = data.alerts || EMPTY_ALERT_SUMMARY;
@@ -13818,6 +13870,9 @@ const dashboardHTML = `<!DOCTYPE html>
     /* Lowercased usernames with a live hive session right now (admin payload).
        Drives the green-dashed avatar border via avatarImg. Empty for non-admins. */
     var _liveHiveUsers = new Set();
+    /* The honest subset of _liveHiveUsers: focused tab + recent input, per the
+       spokes' presence reports. live minus engaged = idle open tabs. */
+    var _liveEngagedUsers = new Set();
     var _userSortKey = 'created_at', _userSortAsc = false;
 
     /* --- Collapsible "Hub Admin — Users" section ---
@@ -13918,8 +13973,8 @@ const dashboardHTML = `<!DOCTYPE html>
           va = Object.keys(a.hives || {}).filter(function(h) { return regIds.has(h); }).length;
           vb = Object.keys(b.hives || {}).filter(function(h) { return regIds.has(h); }).length;
         } else if (key === 'status') {
-          va = a.blocked ? 1 : 0;
-          vb = b.blocked ? 1 : 0;
+          va = userTierRank(a);
+          vb = userTierRank(b);
         } else {
           va = a[key] || ''; vb = b[key] || '';
         }
@@ -14502,9 +14557,45 @@ const dashboardHTML = `<!DOCTYPE html>
        journey snooze/nudge, de-provision) — it changes no state. All inputs are
        admin-only (this table is requireAdmin, and leaderboard is scrubbed for
        non-admins server-side). */
-    var USERSTAT_ACTIVE_LOGIN_MIN = 3;        // logins that count as "engaged"
-    var USERSTAT_ACTIVE_HOURS_MIN = 1;        // hive-hours that count as "engaged"
+    var USERSTAT_ACTIVE_LOGIN_MIN = 3;        // legacy fallback: logins that count as "engaged"
+    var USERSTAT_ACTIVE_HOURS_MIN = 1;        // hive-hours (engaged when available) that count as "engaged"
     var USERSTAT_SECS_PER_HOUR = 3600;
+    var USERSTAT_ACTIVE_WINDOW_MS = 7 * 24 * 3600 * 1000;  // mirrors engagementActiveWindow (7 days) hub-side
+    var USERSTAT_DORMANT_HOURS_MAX = 0.25;    // under this much hive time still reads as "basically none"
+
+    /* Status tier presentation. The tier ITSELF (u.status_tier) is computed
+       hub-side by userStatusTier from the honest signals - last audited real
+       action, focus-engaged presence, live/engaged-now sets - so this map only
+       styles and explains it. Keys mirror the Go tier constants. */
+    var USER_TIER_META = {
+      live:    {color: 'var(--green)', weight: 700, tip: 'Connected right now AND engaged: tab focused with input in the last minute.'},
+      active:  {color: 'var(--green)', weight: 600, tip: 'A real audited action or focus-engaged time within the last 7 days.'},
+      idle:    {color: 'var(--amber)', weight: 600, tip: 'Has logins/sessions - often just an open tab - but nothing real within the last 7 days.'},
+      dormant: {color: 'var(--muted)', weight: 600, tip: 'No signal at all (no login, session, or action) within the last 30 days.'},
+      never:   {color: 'var(--muted)', weight: 400, tip: 'Never completed a hub login.'},
+      blocked: {color: 'var(--red)',   weight: 600, tip: 'Blocked by an admin - cannot sign in. Unblock to restore access.'}
+    };
+    /* Sort order for the Status column: most engaged first on ascending. */
+    var USER_TIER_RANK = {live: 0, active: 1, idle: 2, dormant: 3, never: 4, blocked: 5};
+
+    /* userTier resolves a user's tier with a fallback for a payload that
+       predates status_tier (or a mid-rollout hub): blocked stays blocked and
+       everyone else reads as idle - the honest default when we cannot prove
+       engagement - never as "active". */
+    function userTier(u) {
+      return u.status_tier || (u.blocked ? 'blocked' : 'idle');
+    }
+    function userTierRank(u) {
+      var r = USER_TIER_RANK[userTier(u)];
+      return (r == null) ? USER_TIER_RANK.idle : r;
+    }
+    function statusTierBadge(u) {
+      var tier = userTier(u);
+      var meta = USER_TIER_META[tier] || USER_TIER_META.idle;
+      var label = (tier === 'blocked') ? 'BLOCKED' : tier;
+      return '<span title="' + escAttr(meta.tip) + '" style="color:' + meta.color +
+        ';font-weight:' + meta.weight + ';cursor:help">' + esc(label) + '</span>';
+    }
 
     /* userTaskActivity sums this user's per-hive leaderboard entries across every
        hive in _hiveRegistry, matching on github_username. leaderboard is present
@@ -14548,11 +14639,25 @@ const dashboardHTML = `<!DOCTYPE html>
     function userVerdict(u, act, hives) {
       var logins = u.login_count || 0;
       var hours = (u.session_seconds || 0) / USERSTAT_SECS_PER_HOUR;
+      /* Honest signals, when the record has them: engaged_seconds accrues only
+         while the tab was focused with recent input, and last_action_at is the
+         newest audit-logged real action. Records that predate these fields (or
+         whose spokes do not report presence yet) have NEITHER - for them fall
+         back to the old open-tab inputs rather than treating absence as
+         zero-engagement-now. */
+      var engagedHours = (u.engaged_seconds || 0) / USERSTAT_SECS_PER_HOUR;
+      var lastActionMs = u.last_action_at ? Date.parse(u.last_action_at) : NaN;
+      var actedRecently = !isNaN(lastActionMs) && (Date.now() - lastActionMs) <= USERSTAT_ACTIVE_WINDOW_MS;
+      var hasHonestData = !!(u.engaged_seconds || u.last_action_at);
       var anyDeprovision = hives.some(function(h) { return h.journey && h.journey.severity === 'deprovision-warning'; });
       var anyEarlyStage = hives.some(function(h) { return h.journey && (h.journey.stage === 'github-app' || h.journey.stage === 'method-model'); });
       var anyRestingACMM = hives.some(function(h) { return h.journey && h.journey.stage === 'acmm-level'; });
-      var engaged = logins >= USERSTAT_ACTIVE_LOGIN_MIN && hours >= USERSTAT_ACTIVE_HOURS_MIN;
-      var dormant = hives.length > 0 && logins <= 1 && hours < 0.25 && act.done === 0;
+      var engaged = hasHonestData
+        ? (actedRecently || engagedHours >= USERSTAT_ACTIVE_HOURS_MIN)
+        : (logins >= USERSTAT_ACTIVE_LOGIN_MIN && hours >= USERSTAT_ACTIVE_HOURS_MIN);
+      var dormant = hives.length > 0 && act.done === 0 && (hasHonestData
+        ? (!actedRecently && engagedHours < USERSTAT_DORMANT_HOURS_MAX)
+        : (logins <= 1 && hours < USERSTAT_DORMANT_HOURS_MAX));
 
       if (dormant || anyDeprovision) {
         return {key: 'at-risk', label: 'At risk — pressure or de-provision', color: 'var(--red)',
@@ -14589,9 +14694,20 @@ const dashboardHTML = `<!DOCTYPE html>
       var liveDot = act.activeNow
         ? '<span title="active on a task now" style="display:inline-block;width:7px;height:7px;border-radius:50%;background:var(--green);margin-left:6px;vertical-align:middle"></span>'
         : '';
+      /* "Time in hive" is the legacy open-tab total; the two rows after it are
+         the honest signals - focus-engaged time and the last audit-logged real
+         action - so an admin reading the card sees exactly why the tier is
+         what it is. Presence distinguishes "engaged now" from a merely-open
+         idle tab (the old signal's blind spot). */
+      var unameLower = String(u.github_username || '').toLowerCase();
+      var presenceNow = (_liveEngagedUsers && _liveEngagedUsers.has(unameLower)) ? 'engaged now'
+        : ((_liveHiveUsers && _liveHiveUsers.has(unameLower)) ? 'tab open (idle)' : '—');
       var stats =
         row('Hub logins', esc(String(u.login_count || 0)) + (u.last_login ? ' <span style="color:var(--muted)">(last ' + esc(fmtUserTS(u.last_login)) + ')</span>' : '')) +
         row('Time in hive', esc(fmtHours(u.session_seconds))) +
+        row('Engaged time', esc(fmtHours(u.engaged_seconds))) +
+        row('Last real action', esc(u.last_action_at ? fmtUserTS(u.last_action_at) : '—')) +
+        row('Presence', esc(presenceNow)) +
         row('Joined', esc(fmtUserTS(u.created_at))) +
         row('Tasks', esc(String(act.done)) + ' done / ' + esc(String(act.failed)) + ' failed' + liveDot);
 
@@ -14635,7 +14751,11 @@ const dashboardHTML = `<!DOCTYPE html>
       _lastUsersJSON = sig;
       if (!users.length) { document.getElementById('users-container').innerHTML = '<div class="loading">No users found</div>'; return; }
       var rows = users.map(function(u) {
-        var blocked = u.blocked ? '<span style="color:var(--red);font-weight:600">BLOCKED</span>' : '<span style="color:var(--green)">active</span>';
+        /* Engagement tier, hub-computed (see statusTierBadge / userStatusTier).
+           The old cell rendered "active" for EVERY non-blocked user - an idle
+           open tab, a never-logged-in user, and a daily driver all looked the
+           same. */
+        var statusCell = statusTierBadge(u);
         var avatar = linkedAvatar(u.github_username, TABLE_AVATAR_PX,
           u.github_username + ' — GitHub profile', 'margin-right:6px');
         var isAdmin = u.github_username === 'clubanderson';
@@ -14688,7 +14808,7 @@ const dashboardHTML = `<!DOCTYPE html>
           '<td style="font-size:0.75rem;color:var(--muted)">' + esc(fmtUserTS(u.created_at)) + '</td>' +
           '<td style="font-size:0.75rem;color:var(--muted)">' + esc(fmtUserTS(u.last_login)) + '</td>' +
           '<td style="text-align:left">' + renderContactCell(u) + '</td>' +
-          '<td>' + blocked + '</td>' +
+          '<td>' + statusCell + '</td>' +
           '<td><input type="number" min="0" max="10" value="' + (u.saas_quota || 0) + '" style="width:50px;padding:4px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text);text-align:center" onchange="updateUser(\'' + esc(u.github_username) + '\',{saas_quota:parseInt(this.value)||0})"></td>' +
           '<td>' + (hiveCount > 0 ? '<a href="#" onclick="toggleAdminExpand(\'' + esc(u.github_username) + '\');return false" style="color:var(--blue);font-size:0.8rem">' + hiveCount + ' hive' + (hiveCount > 1 ? 's' : '') + '</a>' : '<span style="color:var(--muted)">0</span>') + '</td>' +
           '<td>' + (isAdmin ? '' : '<button onclick="updateUser(\'' + esc(u.github_username) + '\',{blocked:' + (!u.blocked) + '})" style="padding:3px 10px;background:' + (u.blocked ? 'var(--green)' : 'var(--amber)') + ';color:' + (u.blocked ? '#fff' : '#1a1a1a') + ';border:none;border-radius:4px;cursor:pointer;font-size:0.7rem">' + (u.blocked ? 'Unblock' : 'Block') + '</button> <button onclick="deleteUser(\'' + esc(u.github_username) + '\',' + hiveCount + ')" style="padding:3px 10px;background:#b02a2a;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.7rem">Delete</button>') + '</td>' +

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -646,6 +646,14 @@ type HubServer struct {
 	// beating drops out on its own rather than staying "live" forever.
 	liveHiveUsers   map[string]time.Time
 	liveHiveUsersMu sync.RWMutex
+	// engagedHiveUsers is the same shape as liveHiveUsers but for ENGAGED
+	// presence: username → last time any hive reported the user's browser as
+	// focused with recent input (heartbeat EngagedSessionUsers). The gap
+	// between the two sets is exactly the idle-open-tab crowd. Guarded by
+	// liveHiveUsersMu (always touched on the same paths), freshness-gated on
+	// read like liveHiveUsers. Old spokes never report engaged users, so this
+	// map simply stays empty for them — optional data, never an error.
+	engagedHiveUsers map[string]time.Time
 
 	// usageHistory is the sampled fleet-total token trend, appended on
 	// heartbeat at usageSnapshotInterval and bounded to
@@ -1418,7 +1426,13 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	// it does per-user load-modify-write file I/O and must not serialize behind
 	// the registry write lock. hadPrev==false (a brand-new hive) credits nothing —
 	// there is no prior sample point to measure an interval against.
-	s.creditActiveSessionTime(&prevEntry, hadPrev, payload.ActiveSessionUsers)
+	s.creditActiveSessionTime(&prevEntry, hadPrev, payload.ActiveSessionUsers, payload.EngagedSessionUsers)
+
+	// Fold the spoke's per-user last-real-action timestamps into the user
+	// records. Unlike time crediting this needs no prior beat — a timestamp is
+	// absolute — so it runs even on a hive's first heartbeat. Also after
+	// Unlock(): per-user file I/O.
+	s.applyUserLastActions(payload.UserLastActions)
 
 	// Store heartbeat-reported cluster health so the hub can use it as a
 	// fallback when it cannot reach the cluster directly via kubectl.
@@ -1695,13 +1709,21 @@ const (
 //   - unknown users (no SaaSUser record) are skipped, never auto-created.
 //   - load-modify-write per user so a concurrent contact/quota edit is not clobbered.
 //
+// engagedUsers is the subset of activeUsers whose browser reported focused,
+// recent-input presence (heartbeat EngagedSessionUsers). Those users are
+// additionally credited EngagedSeconds and stamped LastEngagedAt — the honest
+// engagement signals — while SessionSeconds keeps its back-compat open-tab
+// meaning. A nil/empty engagedUsers (old spoke, or genuinely nobody engaged)
+// credits engaged time to no one and is never an error.
+//
 // It runs post-unlock and does its own file I/O; callers must NOT hold s.mu.
-func (s *HubServer) creditActiveSessionTime(prevEntry *RegistryEntry, hadPrev bool, activeUsers []string) {
+func (s *HubServer) creditActiveSessionTime(prevEntry *RegistryEntry, hadPrev bool, activeUsers, engagedUsers []string) {
 	// Mark everyone reported active as live NOW, independent of the time-credit
 	// path below: the "logged in right now" avatar treatment must light up on the
 	// FIRST beat that sees a session (there is no prior sample yet), and must not
 	// depend on a valid prevEntry. Freshness is applied on read.
 	s.markUsersLive(activeUsers)
+	s.markUsersEngaged(engagedUsers)
 	if !hadPrev || prevEntry == nil || prevEntry.LastHeartbeat == "" || len(activeUsers) == 0 {
 		return
 	}
@@ -1722,6 +1744,11 @@ func (s *HubServer) creditActiveSessionTime(prevEntry *RegistryEntry, hadPrev bo
 	}
 	// Dedupe + validate the reported usernames with the same gate the leaderboard
 	// path uses, and bound the work.
+	engaged := make(map[string]struct{}, len(engagedUsers))
+	for _, name := range engagedUsers {
+		engaged[name] = struct{}{}
+	}
+	nowRFC3339 := time.Now().UTC().Format(time.RFC3339)
 	seen := make(map[string]struct{}, len(activeUsers))
 	for _, name := range activeUsers {
 		if len(seen) >= maxActiveSessionUsers {
@@ -1739,8 +1766,54 @@ func (s *HubServer) creditActiveSessionTime(prevEntry *RegistryEntry, hadPrev bo
 			continue // an active session for a user the hub has no record of — skip.
 		}
 		u.SessionSeconds += creditSecs
+		// Engaged time accrues ONLY for users whose browser proved a human is
+		// there this beat. An idle/hidden tab therefore keeps accumulating
+		// session_seconds (back-compat) but never engaged_seconds.
+		if _, isEngaged := engaged[name]; isEngaged {
+			u.EngagedSeconds += creditSecs
+			u.LastEngagedAt = nowRFC3339
+		}
 		if err := saveSaaSUser(u); err != nil {
 			s.logger.Warn("creditActiveSessionTime: save failed", "user", name, "error", err)
+		}
+	}
+}
+
+// applyUserLastActions folds a heartbeat's per-user last-real-action
+// timestamps (spoke audit log; see HeartbeatPayload.UserLastActions) into the
+// user records, keeping the MAXIMUM per user so an older spoke's replayed log,
+// a spoke restart, or a second hive can never move a user's LastActionAt
+// backwards. Unknown users are skipped, never auto-created. nil/empty input
+// (old spoke) is a no-op. Does per-user file I/O; callers must NOT hold s.mu.
+func (s *HubServer) applyUserLastActions(lastActions map[string]string) {
+	if len(lastActions) == 0 {
+		return
+	}
+	applied := 0
+	for name, ts := range lastActions {
+		if applied >= maxActiveSessionUsers {
+			break
+		}
+		if name == "" || !isValidName(name) {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, ts)
+		if err != nil {
+			continue
+		}
+		applied++
+		u := loadSaaSUser(name)
+		if u == nil {
+			continue
+		}
+		if u.LastActionAt != "" {
+			if prev, err := time.Parse(time.RFC3339, u.LastActionAt); err == nil && !t.After(prev) {
+				continue
+			}
+		}
+		u.LastActionAt = t.UTC().Format(time.RFC3339)
+		if err := saveSaaSUser(u); err != nil {
+			s.logger.Warn("applyUserLastActions: save failed", "user", name, "error", err)
 		}
 	}
 }
@@ -1770,6 +1843,27 @@ func (s *HubServer) markUsersLive(activeUsers []string) {
 	s.liveHiveUsersMu.Unlock()
 }
 
+// markUsersEngaged is markUsersLive's twin for the ENGAGED set (focused tab +
+// recent input, per the spoke's presence report). Same mutex, same validation,
+// same freshness-on-read model.
+func (s *HubServer) markUsersEngaged(engagedUsers []string) {
+	if len(engagedUsers) == 0 {
+		return
+	}
+	now := time.Now()
+	s.liveHiveUsersMu.Lock()
+	if s.engagedHiveUsers == nil {
+		s.engagedHiveUsers = make(map[string]time.Time)
+	}
+	for _, name := range engagedUsers {
+		if name == "" || !isValidName(name) {
+			continue
+		}
+		s.engagedHiveUsers[name] = now
+	}
+	s.liveHiveUsersMu.Unlock()
+}
+
 // liveHiveUsernames returns the usernames with a live hive session seen within
 // the staleness window, and opportunistically prunes stale entries so the map
 // cannot grow without bound. Admin-facing (presence data) — the caller gates it.
@@ -1787,6 +1881,36 @@ func (s *HubServer) liveHiveUsernames() []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// engagedHiveUsernames returns the usernames reported ENGAGED (focused +
+// recent input) within the staleness window — liveHiveUsernames' honest
+// subset. Same pruning-on-read; admin-facing, the caller gates it.
+func (s *HubServer) engagedHiveUsernames() []string {
+	cutoff := time.Now().Add(-liveHiveUserStaleness)
+	s.liveHiveUsersMu.Lock()
+	defer s.liveHiveUsersMu.Unlock()
+	out := make([]string, 0, len(s.engagedHiveUsers))
+	for name, seen := range s.engagedHiveUsers {
+		if seen.Before(cutoff) {
+			delete(s.engagedHiveUsers, name)
+			continue
+		}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// isUserEngagedNow reports whether username has a fresh engaged-presence
+// report — the "connected AND a human is actually there" gate for the `live`
+// status tier.
+func (s *HubServer) isUserEngagedNow(username string) bool {
+	cutoff := time.Now().Add(-liveHiveUserStaleness)
+	s.liveHiveUsersMu.RLock()
+	defer s.liveHiveUsersMu.RUnlock()
+	seen, ok := s.engagedHiveUsers[username]
+	return ok && !seen.Before(cutoff)
 }
 
 func (s *HubServer) storePendingGitHubAppConfig(hiveID string, cfg *HeartbeatGitHubAppConfig) {

--- a/v2/pkg/hub/session_seconds_test.go
+++ b/v2/pkg/hub/session_seconds_test.go
@@ -43,7 +43,7 @@ func TestCreditActiveSessionTime(t *testing.T) {
 			t.Fatal(err)
 		}
 		prev := &RegistryEntry{LastHeartbeat: realAgo(120 * time.Second)}
-		s.creditActiveSessionTime(prev, true, []string{"alice"})
+		s.creditActiveSessionTime(prev, true, []string{"alice"}, nil)
 		got := loadSaaSUser("alice").SessionSeconds
 		if got < 110 || got > 130 {
 			t.Errorf("SessionSeconds = %d, want ~120", got)
@@ -54,7 +54,7 @@ func TestCreditActiveSessionTime(t *testing.T) {
 		useTempUserDir(t)
 		saveSaaSUser(&SaaSUser{GitHubUsername: "alice"})
 		prev := &RegistryEntry{LastHeartbeat: realAgo(3 * time.Hour)}
-		s.creditActiveSessionTime(prev, true, []string{"alice"})
+		s.creditActiveSessionTime(prev, true, []string{"alice"}, nil)
 		got := loadSaaSUser("alice").SessionSeconds
 		if got != int64(maxSessionCreditSecs) {
 			t.Errorf("SessionSeconds = %d, want clamp %d (not the full 3h)", got, int64(maxSessionCreditSecs))
@@ -66,7 +66,7 @@ func TestCreditActiveSessionTime(t *testing.T) {
 		saveSaaSUser(&SaaSUser{GitHubUsername: "alice"})
 		saveSaaSUser(&SaaSUser{GitHubUsername: "bob"})
 		prev := &RegistryEntry{LastHeartbeat: realAgo(120 * time.Second)}
-		s.creditActiveSessionTime(prev, true, []string{"alice", "bob", "ghost"})
+		s.creditActiveSessionTime(prev, true, []string{"alice", "bob", "ghost"}, nil)
 		if loadSaaSUser("alice").SessionSeconds < 110 || loadSaaSUser("bob").SessionSeconds < 110 {
 			t.Error("both known users must be credited")
 		}
@@ -78,7 +78,7 @@ func TestCreditActiveSessionTime(t *testing.T) {
 	t.Run("first-ever beat credits nothing", func(t *testing.T) {
 		useTempUserDir(t)
 		saveSaaSUser(&SaaSUser{GitHubUsername: "alice"})
-		s.creditActiveSessionTime(nil, false, []string{"alice"})
+		s.creditActiveSessionTime(nil, false, []string{"alice"}, nil)
 		if got := loadSaaSUser("alice").SessionSeconds; got != 0 {
 			t.Errorf("no prior beat must credit 0, got %d", got)
 		}
@@ -88,7 +88,7 @@ func TestCreditActiveSessionTime(t *testing.T) {
 		useTempUserDir(t)
 		saveSaaSUser(&SaaSUser{GitHubUsername: "alice"})
 		prev := &RegistryEntry{LastHeartbeat: time.Now().UTC().Format(time.RFC3339)}
-		s.creditActiveSessionTime(prev, true, []string{"alice"})
+		s.creditActiveSessionTime(prev, true, []string{"alice"}, nil)
 		if got := loadSaaSUser("alice").SessionSeconds; got > 1 {
 			t.Errorf("elapsed ~0 must credit ~0, got %d", got)
 		}
@@ -98,7 +98,7 @@ func TestCreditActiveSessionTime(t *testing.T) {
 		useTempUserDir(t)
 		prev := &RegistryEntry{LastHeartbeat: realAgo(120 * time.Second)}
 		// Must not panic or create anything for a bad name.
-		s.creditActiveSessionTime(prev, true, []string{"../etc/passwd", ""})
+		s.creditActiveSessionTime(prev, true, []string{"../etc/passwd", ""}, nil)
 	})
 }
 


### PR DESCRIPTION
## The open-tab problem

The Hub Admin → Users **Status** column rendered `active` for every single non-blocked user — a daily driver, a user who never completed a login, and a tab someone left open in March all read identically. The one engagement number behind it, `session_seconds`, is credited to every user with a live dashboard session at heartbeat time, and a "live session" is just a non-expired session cookie — so an idle open tab accumulates "time in hive" around the clock.

## Two honest signals

1. **Real actions** (`last_action_at`): the spoke audit log already records genuine user actions (config saves, agent restarts, ACMM changes, logins) with real usernames. The audit writer now maintains a per-user last-action timestamp at write time — no log-scanning pipeline — rebuilt from the on-disk log at startup, and reports it in the existing heartbeat (`user_last_actions`). The hub folds it into the user record keeping the per-user **maximum**, so spoke restarts and multi-hive users never regress. Pseudo-users (`system`, `local`, `unknown`) never count.

2. **Focus-aware presence** (`engaged_seconds` / `last_engaged_at`): the spoke dashboard frontend does classic idle detection — visibility + recent input (mouse/key/scroll/touch/wheel, throttled to one bookkeeping write per 5s) — and pings `POST /api/presence` every 30s **only while the tab is visible and input occurred within a 60s idle window**. No ping = idle; there is no idle message to spoof or miss. The spoke's fresh engaged set rides the same heartbeat (`engaged_session_users`). The hub keeps crediting `session_seconds` for every live session (back-compat, open-tab meaning) and additionally credits `engaged_seconds` — same inter-beat interval, same clamp — only for engaged users.

No new polling loops: both signals reuse the existing 2-minute heartbeat, adding a small username list and a username→timestamp map.

## Status tiers (computed hub-side, sortable, tooltip on each badge)

| Tier | Rule | Color |
|---|---|---|
| `live` | connected now AND engaged (focused tab, input in the last minute) | green, bold |
| `active` | real audited action or focus-engaged time within **7 days** (`engagementActiveWindow`) | green |
| `idle` | seen (login / open session / stale action) within 30 days but nothing real within 7 — **the open-tab crowd** | amber |
| `dormant` | no signal of any kind within **30 days** (`engagementDormantWindow`) | muted |
| `never` | zero completed hub logins | muted |
| `blocked` | unchanged; Block/Unblock buttons unchanged | red |

`userVerdict()` (hover card + access hover) now judges on `engaged_seconds` + `last_action_at` when present and falls back to the legacy login/session inputs otherwise. The admin stats card shows Engaged time, Last real action, and Presence ("engaged now" vs "tab open (idle)") next to the legacy Time in hive.

## Back-compat

- Every new field is `omitempty`/optional end-to-end. An old spoke reporting no engaged data cannot break the hub — its users keep accruing `session_seconds` and classify from login/live signals (they can reach `idle`/`dormant`/`never`, honestly, but not `live`).
- Existing user records lack the new fields; tier computation treats absence as **no data**, never as zero-now — a record without `last_action_at` is not "acted at epoch".
- `session_seconds` keeps its old meaning and keeps accumulating, so nothing that reads it changes behavior.
- Frontend fallback: if `status_tier` is missing from a payload (mid-rollout), blocked stays blocked and everyone else renders `idle` — never a dishonest `active`.

## Tests

- `userStatusTier` table-driven: all six tiers, precedence, open-tab-is-not-live, missing-fields fallback, garbage timestamps.
- Engaged-time gating: an idle open tab accrues session but not engaged time; `LastEngagedAt` stamped only for engaged users.
- `applyUserLastActions`: forward-only, unknown users skipped (never auto-created), bad names/timestamps skipped, nil no-op.
- Engaged-now presence set: mark, freshness prune, per-user query.
- Admin users payload carries `status_tier` (live/blocked/never verified end-to-end), still no encrypted tokens.
- Spoke: `/api/presence` beacon (engaged / not-engaged / unidentified / malformed), engaged-set freshness + bound, audit last-action tracking (pseudo-users excluded, never regresses).
