### PR TITLE
feat(contribute): reorder tabs + subtle ranked accents on Operations & Leaderboard

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -463,6 +463,39 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .lb-stat{text-align:right;color:#c9d1d9;font-variant-numeric:tabular-nums}
 .lb-head .lb-stat,.lb-head .lb-rank{text-align:right;color:#8b949e}
 .lb-head .lb-rank{text-align:left}
+/* ── Subtle "ranked/alive" accent pass on Operations + Leaderboard (SUBTLE +
+   PROFESSIONAL — light watermarking only). Theme-aware: built entirely from the
+   existing dark palette (#161b22 card / #30363d border / #0d1117 deep). Every
+   accent is driven by REAL data (trust tier + real task counts); nothing is
+   fabricated. Readability first — text keeps full contrast; the tints are muted,
+   never neon. All motion respects the prefers-reduced-motion block below. ───── */
+/* Tier medallion / rank badge. One class per REAL trust tier; the per-tier tint is
+   a muted metal-ish accent (advisor/trusted = warmer gold-amber, contributor =
+   cooler steel, newcomer = neutral). Small pill with a tiny CSS-drawn medallion
+   dot — no external images (CSP forbids them), no glow. */
+.tier-badge{display:inline-flex;align-items:center;gap:5px;font-size:.68rem;font-weight:600;line-height:1;padding:3px 8px 3px 6px;border-radius:999px;border:1px solid #30363d;background:#0d1117;color:#8b949e;text-transform:capitalize;white-space:nowrap}
+.tier-badge::before{content:"";width:8px;height:8px;border-radius:50%%;background:currentColor;box-shadow:inset 0 0 0 1px rgba(1,4,9,.35);flex:none}
+.tier-badge.tier-advisor{border-color:rgba(210,169,85,.45);background:rgba(210,169,85,.10);color:#d0a955}
+.tier-badge.tier-trusted{border-color:rgba(201,162,39,.40);background:rgba(201,162,39,.08);color:#c9a94a}
+.tier-badge.tier-contributor{border-color:rgba(110,163,201,.38);background:rgba(110,163,201,.08);color:#6ea3c9}
+.tier-badge.tier-newcomer{border-color:#30363d;background:#0d1117;color:#8b949e}
+/* Restrained gradient header band on the accented cards. Very low-contrast wash
+   from the deep bg into the card colour — reads as a faint banner, not a loud
+   gradient; the bottom border keeps the head crisp. */
+.ops-card.card-accent>.ops-card-head{background:linear-gradient(180deg,#12161d 0%%,#161b22 100%%)}
+.ops-card.card-accent>.ops-card-head h3{letter-spacing:.01em}
+/* Bold-numeral stat emphasis: the primary "Done" numeral on the leaderboard and
+   the key ops counts get heavier weight + slightly larger tabular figures so the
+   number reads as the hero of the row without adding chrome. */
+.lb-row .lb-stat.lb-primary{color:#e6edf3;font-weight:700;font-size:.95rem}
+.lb-head .lb-stat.lb-primary{font-weight:600;font-size:.72rem;color:#8b949e}
+.tier-badge.tier-lb{padding:2px 8px 2px 5px;font-size:.66rem}
+/* Ops "your army" counts + card counts as bold numerals (tabular, no layout shift). */
+.cc-army b{font-weight:700;font-variant-numeric:tabular-nums}
+.ops-card-count.count-strong{color:#e6edf3;font-weight:700;font-variant-numeric:tabular-nums}
+/* Compact tier badge inline next to a connected clanker's identity. */
+.tier-badge.tier-inline{padding:1px 6px 1px 4px;font-size:.62rem;margin-left:6px;vertical-align:middle}
+.tier-badge.tier-inline::before{width:6px;height:6px}
 .ops-note{color:#6e7681;font-size:.78rem;margin-top:12px;line-height:1.5}
 .ops-note code{background:#0d1117;padding:1px 6px;border-radius:4px}
 .prompt-preview{margin-top:10px;border-top:1px solid #21262d;padding-top:8px}
@@ -641,8 +674,8 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 </style></head><body>
 <div class="page-tabs" role="tablist">
 <button class="page-tab active" role="tab" id="ptab-onboarding" aria-selected="true" data-panel="tab-onboarding">Onboarding</button>
-<button class="page-tab" role="tab" id="ptab-manage" aria-selected="false" data-panel="tab-manage">Management</button>
 <button class="page-tab" role="tab" id="ptab-ops" aria-selected="false" data-panel="tab-ops">Operations</button>
+<button class="page-tab" role="tab" id="ptab-manage" aria-selected="false" data-panel="tab-manage">Management</button>
 <button class="page-tab" role="tab" id="ptab-leaderboard" aria-selected="false" data-panel="tab-leaderboard">Leaderboard</button>
 </div>
 <div class="tab-panel active" id="tab-onboarding" role="tabpanel" aria-labelledby="ptab-onboarding">
@@ -891,8 +924,8 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 <div class="ops-main">
 <div class="ops-grid">
 <div>
-<div class="ops-card">
-<div class="ops-card-head"><span class="feed-dot"></span><h3>Connected clankers</h3><span class="ops-card-count" id="clanker-count"></span></div>
+<div class="ops-card card-accent">
+<div class="ops-card-head"><span class="feed-dot"></span><h3>Connected clankers</h3><span class="ops-card-count count-strong" id="clanker-count"></span></div>
 <!-- Army roster header: live count + at-a-glance status split, fed by the fleet snapshot. -->
 <div class="cc-army" id="cc-army">
   <span style="color:#e6edf3;font-weight:600">Your army</span>
@@ -934,7 +967,7 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 </div>
 <div class="work-list" id="work-list"><div class="ops-empty">Loading work&hellip;</div></div>
 </div>
-<div class="ops-card" style="margin-top:20px">
+<div class="ops-card card-accent" style="margin-top:20px">
 <div class="ops-card-head"><span class="feed-dot"></span><h3>Ready-work queue</h3><span class="cc-live stale" id="cc-live"><span class="cc-live-dot"></span><span id="cc-live-label">connecting</span></span></div>
 <div class="cc-queue" id="cc-queue"><div class="ops-empty">Loading queue&hellip;</div></div>
 <p class="ops-note" style="padding:10px 20px 14px;margin:0">The stack of admissible issues waiting to be picked off &mdash; top is next up. When a clanker grabs one you&rsquo;ll see it fly from here to that clanker. Derived from this hive&rsquo;s actionable backlog; read-only.</p>
@@ -977,8 +1010,8 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 <div class="ops">
 <h1>Leaderboard</h1>
 <p class="subtitle" style="font-size:.95rem">Ranked by tasks completed. Agents run by this hive and human contributors who donate compute both appear here; revoked contributors are excluded.</p>
-<div class="ops-card">
-<div class="ops-card-head"><span class="feed-dot"></span><h3>Rankings</h3><span class="ops-card-count" id="leaderboard-count"></span></div>
+<div class="ops-card card-accent">
+<div class="ops-card-head"><span class="feed-dot"></span><h3>Rankings</h3><span class="ops-card-count count-strong" id="leaderboard-count"></span></div>
 <div id="leaderboard-list"><div class="ops-empty">Loading leaderboard&hellip;</div></div>
 </div>
 </div>
@@ -1108,18 +1141,31 @@ function loadLeaderboard(){
     if(el)el.innerHTML='<div class="ops-empty">Could not load leaderboard.</div>';
   });
 }
+// tierBadge renders a small tier medallion / rank badge from a REAL trust tier.
+// The four known tiers each get a muted metal-ish accent class; an unknown/blank
+// tier is treated as newcomer (neutral). extraCls lets callers request the compact
+// leaderboard/inline variants. Nothing here is fabricated — it is a pure visual
+// wrap around the tier string the leaderboard/fleet snapshot already carries.
+function tierBadge(tier,extraCls){
+  var known={newcomer:1,contributor:1,trusted:1,advisor:1};
+  var t=String(tier||'').toLowerCase();
+  if(!known[t])t='newcomer';
+  return '<span class="tier-badge tier-'+t+(extraCls?(' '+extraCls):'')+'">'+esc(t)+'</span>';
+}
 function lbRow(e,rank){
   var name=esc(e.github_username||'');
   var badge=e.is_agent?(esc(e.emoji||'\u{1F916}')+' '):'';
-  var tier=esc(e.trust_tier||'');
+  // Tier medallion driven by the REAL trust_tier the /api/leaderboard entry carries.
+  var tier=tierBadge(e.trust_tier,'tier-lb');
   var done=(e.tasks_completed||0);
   var failed=(e.tasks_failed||0);
   var findings=(e.findings||0);
+  // "Done" (tasks_completed) is the hero numeral — real count, just emphasised.
   return '<div class="lb-row">'
     +'<div class="lb-rank">#'+rank+'</div>'
     +'<div class="lb-name">'+badge+name+'</div>'
     +'<div class="lb-tier">'+tier+'</div>'
-    +'<div class="lb-stat">'+done+'</div>'
+    +'<div class="lb-stat lb-primary">'+done+'</div>'
     +'<div class="lb-stat">'+failed+'</div>'
     +'<div class="lb-stat">'+findings+'</div>'
     +'</div>';
@@ -1131,7 +1177,7 @@ function renderLeaderboard(agents,contribs){
   if(cnt)cnt.textContent=total+(total===1?' participant':' participants');
   if(!el)return;
   if(total===0){el.innerHTML='<div class="ops-empty">No participants yet — be the first to contribute!</div>';return;}
-  var html='<div class="lb-head lb-row"><div class="lb-rank">#</div><div class="lb-name">Contributor</div><div class="lb-tier">Tier</div><div class="lb-stat">Done</div><div class="lb-stat">Failed</div><div class="lb-stat">Findings</div></div>';
+  var html='<div class="lb-head lb-row"><div class="lb-rank">#</div><div class="lb-name">Contributor</div><div class="lb-tier">Tier</div><div class="lb-stat lb-primary">Done</div><div class="lb-stat">Failed</div><div class="lb-stat">Findings</div></div>';
   var rank=0,i;
   for(i=0;i<agents.length;i++){rank++;html+=lbRow(agents[i],rank);}
   for(i=0;i<contribs.length;i++){rank++;html+=lbRow(contribs[i],rank);}
@@ -1375,7 +1421,11 @@ function renderClankers(list){
   el.innerHTML=list.map(function(c){
     var user=c.github_username||c.contributor_id||'clanker';
     var av=c.github_username?'<img class="clanker-av" src="https://github.com/'+esc(c.github_username)+'.png" alt="">':'<span class="clanker-av"></span>';
-    var sub=[c.cli_backend,c.model,c.role,c.trust_tier].filter(Boolean).map(esc).join(' &middot; ');
+    // Trust tier is now surfaced as a compact medallion beside the identity (below),
+    // so drop it from the middot sub-line to avoid duplicating the same string.
+    var sub=[c.cli_backend,c.model,c.role].filter(Boolean).map(esc).join(' &middot; ');
+    // Small tier badge from this clanker's REAL trust_tier (defaults to newcomer).
+    var tierPill=tierBadge(c.trust_tier,'tier-inline');
     // #2546: when idle with a known reason, show "idle: no matching work" etc.
     var task=c.current_task
       ?('<div class="clanker-sub">on '+esc(c.current_task.repo)+'#'+esc(c.current_task.number)+'</div>')
@@ -1409,7 +1459,7 @@ function renderClankers(list){
     var isNew=key&&!ccKnownClankers[key];
     var rowCls='clanker-row'+(isNew?' cc-enter':'');
     return '<div class="'+rowCls+'" data-clanker="'+esc(key)+'"><span class="clanker-dot'+(c.stale?' stale':'')+'"></span>'+av+
-      '<div class="clanker-main"><div class="clanker-user">'+esc(user)+statusPill+'</div>'+
+      '<div class="clanker-main"><div class="clanker-user">'+esc(user)+statusPill+tierPill+'</div>'+
       '<div class="clanker-sub">'+(sub||'&mdash;')+'</div>'+task+'</div>'+
       (actions||('<span class="feed-time">'+esc(rel(c.connected_at))+'</span>'))+'</div>';
   }).join('');

--- a/v2/pkg/dashboard/contribute_tab_order_and_styling_test.go
+++ b/v2/pkg/dashboard/contribute_tab_order_and_styling_test.go
@@ -1,0 +1,167 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// This suite pins two changes on the /contribute page:
+//  1. The tab bar order is now Onboarding -> Operations -> Management ->
+//     Leaderboard (Management moved to AFTER Operations). Only the button ORDER
+//     changed; every id / data-panel / slug mapping is intact, so the
+//     URL-addressable-tabs work (#2584) — deep-linking, pushState, popstate — is
+//     unaffected.
+//  2. A SUBTLE, professional "ranked/alive" accent pass on the Operations +
+//     Leaderboard tabs: tier medallions driven by the REAL trust_tier, bold-numeral
+//     stats, and a restrained gradient header band. Presentation only — no data,
+//     endpoint, gating, routing, or behavior change.
+
+// TestContributeTabOrder pins the visual tab order by asserting the button
+// positions in the served markup: Onboarding, then Operations, then Management,
+// then Leaderboard.
+func TestContributeTabOrder(t *testing.T) {
+	body := renderContributePage(t)
+
+	onboarding := strings.Index(body, `id="ptab-onboarding"`)
+	ops := strings.Index(body, `id="ptab-ops"`)
+	manage := strings.Index(body, `id="ptab-manage"`)
+	leaderboard := strings.Index(body, `id="ptab-leaderboard"`)
+
+	if onboarding < 0 || ops < 0 || manage < 0 || leaderboard < 0 {
+		t.Fatalf("missing tab buttons (onboarding=%d ops=%d manage=%d leaderboard=%d)",
+			onboarding, ops, manage, leaderboard)
+	}
+	// The exact required order: Onboarding -> Operations -> Management -> Leaderboard.
+	if !(onboarding < ops && ops < manage && manage < leaderboard) {
+		t.Errorf("tab order wrong: want Onboarding<Operations<Management<Leaderboard, got onboarding=%d ops=%d manage=%d leaderboard=%d",
+			onboarding, ops, manage, leaderboard)
+	}
+}
+
+// TestContributeTabOrderSlugMappingIntact proves the reorder did NOT touch the
+// slug<->panel routing map or the deep-link readers. The clean slugs (operations,
+// management, leaderboard) must still map to their panels, and the legacy short
+// ids (ops, manage) must still resolve, so /contribute/<tab> deep-linking and the
+// address-bar reflection keep working after the button swap.
+func TestContributeTabOrderSlugMappingIntact(t *testing.T) {
+	body := renderContributePage(t)
+
+	for _, want := range []string{
+		// Panel -> slug map (address-bar reflection).
+		`var PANEL_SLUG={'tab-manage':'management','tab-ops':'operations','tab-leaderboard':'leaderboard'}`,
+		// Slug/short-id -> panel map (deep-linking, both clean and legacy forms).
+		`'operations':'tab-ops','ops':'tab-ops'`,
+		`'management':'tab-manage','manage':'tab-manage'`,
+		`'leaderboard':'tab-leaderboard'`,
+		`'onboarding':'tab-onboarding'`,
+		// pushState/popstate + on-load deep-link wiring still present.
+		`function tabFromLocation`,
+		`window.history.pushState`,
+		`popstate`,
+		// data-panel attributes unchanged (buttons keep their ids/panels).
+		`data-panel="tab-onboarding"`,
+		`data-panel="tab-ops"`,
+		`data-panel="tab-manage"`,
+		`data-panel="tab-leaderboard"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("tab reorder disturbed URL routing: missing %q", want)
+		}
+	}
+
+	// Onboarding is the default landing: its button carries the initial active class.
+	if !strings.Contains(body, `class="page-tab active" role="tab" id="ptab-onboarding"`) {
+		t.Error("Onboarding is no longer the default-active tab")
+	}
+}
+
+// TestLeaderboardTierBadgesFromRealData asserts the leaderboard rows render a tier
+// medallion built from the REAL trust_tier the /api/leaderboard entry carries (via
+// tierBadge), that the four known tiers each have a per-tier accent class, and that
+// the tasks-completed stat is emphasised as a bold numeral. Nothing fabricated.
+func TestLeaderboardTierBadgesFromRealData(t *testing.T) {
+	body := renderContributePage(t)
+
+	for _, want := range []string{
+		// tierBadge helper + its use in the leaderboard row (real e.trust_tier).
+		`function tierBadge`,
+		`var tier=tierBadge(e.trust_tier,'tier-lb');`,
+		// The bold "Done" numeral is the real tasks_completed count, just emphasised.
+		`var done=(e.tasks_completed||0);`,
+		`'<div class="lb-stat lb-primary">'+done+'</div>'`,
+		// Per-tier accent classes exist in the CSS (muted metal-ish tints).
+		`.tier-badge.tier-advisor`,
+		`.tier-badge.tier-trusted`,
+		`.tier-badge.tier-contributor`,
+		`.tier-badge.tier-newcomer`,
+		// Restrained gradient header band + strong count on the leaderboard card.
+		`class="ops-card card-accent"`,
+		`.ops-card.card-accent>.ops-card-head{background:linear-gradient`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("leaderboard accent missing/not data-driven: %q", want)
+		}
+	}
+}
+
+// TestOpsAccentStatsAndTierBadges asserts the Operations tab got the restrained
+// accent pass: bold-numeral army/connected counts, a gradient header band on the
+// fleet + queue cards, and a compact tier badge next to each connected clanker
+// reusing its REAL trust_tier. Behavior/ids are unchanged (covered elsewhere).
+func TestOpsAccentStatsAndTierBadges(t *testing.T) {
+	body := renderContributePage(t)
+
+	for _, want := range []string{
+		// Per-clanker tier medallion from the REAL trust_tier in the fleet snapshot.
+		`var tierPill=tierBadge(c.trust_tier,'tier-inline');`,
+		`statusPill+tierPill`,
+		// Bold-numeral treatment: army counts + the connected count badge.
+		`.cc-army b{font-weight:700`,
+		`.ops-card-count.count-strong`,
+		`class="ops-card-count count-strong" id="clanker-count"`,
+		// Gradient header band applied to the fleet + ready-work queue cards.
+		`<div class="ops-card card-accent">
+<div class="ops-card-head"><span class="feed-dot"></span><h3>Connected clankers</h3>`,
+		`<div class="ops-card card-accent" style="margin-top:20px">
+<div class="ops-card-head"><span class="feed-dot"></span><h3>Ready-work queue</h3>`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("operations accent missing/not data-driven: %q", want)
+		}
+	}
+}
+
+// TestTierBadgeAccentReadabilityAndMotion is a guard on the "subtle + professional"
+// constraints: the tier tints are muted (rgba washes, not opaque neon fills), the
+// accent adds no animation that could violate reduced-motion, and no external asset
+// is referenced (CSP forbids remote fonts/images).
+func TestTierBadgeAccentReadabilityAndMotion(t *testing.T) {
+	body := renderContributePage(t)
+
+	// The accent CSS must not introduce any @keyframes/animation of its own — it is
+	// a static treatment, so there is nothing new for reduced-motion to disable.
+	// (Existing motion is already gated; we only assert we didn't add a raw glow.)
+	for _, forbidden := range []string{
+		`.tier-badge{animation`,
+		`.tier-badge{box-shadow:0 0`, // no outer glow on the badge
+	} {
+		if strings.Contains(body, forbidden) {
+			t.Errorf("tier badge is not subtle: found %q", forbidden)
+		}
+	}
+
+	// No external asset in the accent (icons/medallions are pure CSS). Guard that the
+	// tier badge markup never pulls a remote url() — the medallion is a CSS dot.
+	idx := strings.Index(body, `.tier-badge{`)
+	if idx < 0 {
+		t.Fatal("tier-badge CSS missing")
+	}
+	end := strings.Index(body[idx:], `.ops-card.card-accent`)
+	if end < 0 {
+		end = len(body) - idx
+	}
+	block := body[idx : idx+end]
+	if strings.Contains(block, `url(`) {
+		t.Error("tier badge references an external/url() asset; must be pure CSS/inline")
+	}
+}


### PR DESCRIPTION
## Summary

Two changes on the `/contribute` page: a tab reorder and a subtle, professional "ranked/alive" accent pass on the Operations + Leaderboard tabs. Presentation only — no data, endpoint, gating, URL routing, dev-log rail, queue reorder, or travel-animation change. Built on top of the merged Operations panel-swap work (#2586).

## Change 1 — tab reorder

New order: **Onboarding → Operations → Management → Leaderboard** (Management moved to after Operations). Only the button ORDER changed in the DOM — every `id` / `data-panel` / slug mapping is left intact, so the URL-addressable-tabs work (#2584) is unaffected:

- The slug↔panel map (`operations`→`tab-ops`, `management`/`manage`→`tab-manage`, `leaderboard`, `onboarding`) is unchanged.
- Deep-linking (`/contribute/operations`, `/contribute/management`, `/contribute/leaderboard`, plus the legacy `?tab=` form), `pushState`, `popstate`, and address-bar reflection all still work — the routing JS resolves tabs by `id`, not DOM position.
- A default page load still lands on Onboarding.

## Change 2 — subtle ranked accent pass (Operations + Leaderboard)

Restrained, readability-first accents that match the existing sober dark theme — light watermarking only, no heavy textures/glows/loud gradients. Every accent is driven by REAL data already available; nothing is fabricated.

**Leaderboard**
- Each row renders a **tier medallion** built from the entry's real `trust_tier` (newcomer / contributor / trusted / advisor), each with a muted metal-ish accent (advisor/trusted = warmer gold-amber, contributor = cooler steel, newcomer = neutral).
- The real tasks-completed (**Done**) count is emphasised as a **bold numeral**.
- A restrained gradient header band on the leaderboard card.

**Operations**
- Matching gradient header band on the Connected clankers and Ready-work queue cards.
- **Bold-numeral** army (working / reviewing / idle) + connected counts.
- A compact **tier badge** beside each connected clanker, reusing its real `trust_tier` (dropped from the middot sub-line to avoid duplicating the same string).

**Constraints honoured**
- Theme-aware, built from the existing dark palette; text keeps full contrast.
- Self-contained CSS — no external fonts/images (CSP-safe); the medallion is a pure CSS dot.
- The accents are static (no new animation), so they add nothing for `prefers-reduced-motion` to disable; existing motion stays gated.

## Tests

- Pin the new tab order (Onboarding, Operations, Management, Leaderboard).
- Assert the slug/deep-link mapping + pushState/popstate wiring is intact after the reorder, and Onboarding stays the default-active tab.
- Assert the leaderboard renders tier badges from the real `trust_tier` and the Done stat from real `tasks_completed`, and the ops cards render the styled stats + per-clanker tier badges from real `trust_tier`.
- Guard the accent stays subtle (no badge glow/animation) and references no external asset.

`go build`, `go vet`, `gofmt`, and `node --check` (embedded JS) all pass; the full `pkg/dashboard` test package is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
