### PR TITLE
fix(contribute): stop periodic CLI reset looping forever after task 3 (#2596)

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -278,7 +278,13 @@ function tmuxSendKeys(text) {
     const ctxPct = checkContextUsage();
     const RESET_EVERY_N = 3;
     const needsClaudeClear = BACKEND === 'claude' && ctxPct >= CLEAR_CONTEXT_THRESHOLD_PCT;
-    const needsCliRestart = BACKEND !== 'claude' && tasksCompletedCount > 0 && tasksCompletedCount % RESET_EVERY_N === 0;
+    // Fire the periodic memory-cleanup restart at most ONCE per threshold
+    // crossing (issue #2596). Requiring tasksCompletedCount !== lastResetAtCount
+    // stops the #2203 readiness guard from re-triggering the restart when it
+    // re-enters tmuxSendKeys() at the same, unchanged count — the re-entry that
+    // otherwise loops forever and starves the next task.
+    const needsCliRestart = BACKEND !== 'claude' && tasksCompletedCount > 0 &&
+      tasksCompletedCount % RESET_EVERY_N === 0 && tasksCompletedCount !== lastResetAtCount;
     if (needsClaudeClear) {
       console.log(`Context at ${ctxPct}% — sending /clear before next task`);
       execSync(`tmux send-keys -t ${TMUX_SESSION} Escape`, { timeout: 15000 });
@@ -291,6 +297,11 @@ function tmuxSendKeys(text) {
       tmuxSendEnters();
       sleepMs(3000);
     } else if (needsCliRestart) {
+      // Record that we serviced this count BEFORE relaunching, so when the
+      // readiness callback flushes the queued prompt back through here the
+      // predicate is already false and we fall through to deliver the next task
+      // instead of restarting again (issue #2596).
+      lastResetAtCount = tasksCompletedCount;
       console.log(`Restarting ${BACKEND} CLI for memory cleanup (task ${tasksCompletedCount})`);
       execSync(`tmux send-keys -t ${TMUX_SESSION} C-c`, { timeout: 15000 });
       sleepMs(1000);
@@ -534,6 +545,17 @@ function checkTmuxIdle() {
 const TASK_GRACE_PERIOD_MS = 180000;
 let taskAssignedAt = 0;
 let tasksCompletedCount = 0;
+// The completed-task count at which the periodic memory-cleanup restart last
+// fired (issue #2596). The restart predicate below is re-entered by the #2203
+// readiness/pending-task guard: the restart queues the prompt, clears cliReady,
+// relaunches, and the readiness callback calls flushPendingTask() ->
+// tmuxSendKeys() again. tasksCompletedCount only changes on an actual
+// completion, so without latching, "count % RESET_EVERY_N === 0" stays true and
+// the CLI restarts forever, never delivering the next task. Latching the count
+// makes the reset one-shot per threshold crossing; a value that no real count
+// reaches keeps the first crossing (count 0 is excluded anyway) from being
+// treated as already-serviced.
+let lastResetAtCount = -1;
 const PR_REVIEW_EVERY_N = 5;
 let taskTimeoutHandle = null;
 let lastProgressTick = 0;
@@ -890,6 +912,10 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     getCliReady: () => cliReady,
     getPendingTask: () => pendingTask,
     setPendingTask: (v) => { pendingTask = v; },
+    setTasksCompletedCount: (v) => { tasksCompletedCount = v; },
+    getTasksCompletedCount: () => tasksCompletedCount,
+    setLastResetAtCount: (v) => { lastResetAtCount = v; },
+    getLastResetAtCount: () => lastResetAtCount,
     getCurrentTask: () => currentTask,
     setWs: (w) => { ws = w; },
   };

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -251,6 +251,122 @@ test('relaunch clears a wedged bash PS2 line before sending the command', () => 
 });
 
 // ---------------------------------------------------------------------------
+// Issue #2596 — the periodic memory-cleanup restart must fire ONCE per
+// threshold crossing, then deliver the next task. Before the fix, the #2203
+// readiness guard re-entered tmuxSendKeys() at the same, unchanged
+// tasksCompletedCount, the "count % RESET_EVERY_N === 0" predicate stayed true,
+// and a non-claude CLI restarted forever after task 3, never delivering task 4.
+// ---------------------------------------------------------------------------
+
+// Number of completed tasks that triggers the memory-cleanup restart. Mirrors
+// RESET_EVERY_N in the relay; the loop only manifests at a multiple of it.
+const RESET_EVERY_N = 3;
+
+// Count the queued-and-then-flushed prompt through the full re-entry cycle the
+// same way production does: tmuxSendKeys() queues + relaunches, the readiness
+// callback flushes, and flushPendingTask() calls tmuxSendKeys() again. A fixed
+// relay restarts once and delivers; the buggy relay restarts on every re-entry.
+function cycleReadyAndFlush(relay, maxCycles) {
+  // Each iteration models "CLI came back ready -> flush the queued prompt".
+  // If flushPendingTask() drains the queue and delivers, we're done. If the
+  // restart predicate re-fires it re-queues the same prompt, and we loop.
+  for (let i = 0; i < maxCycles; i++) {
+    if (!relay.getPendingTask()) return i; // delivered, queue drained
+    relay.setCliReady(true);
+    relay.flushPendingTask();
+  }
+  return maxCycles; // never drained within the budget -> infinite loop
+}
+
+test('non-claude periodic reset fires once at count 3 and then delivers the next task', () => {
+  const relay = loadRelay({ backend: 'goose' });
+  try {
+    relay.setCliReady(true);
+    relay.setPendingTask(null);
+    relay.setTasksCompletedCount(RESET_EVERY_N); // just finished task 3
+    relay.setLastResetAtCount(-1);
+
+    const before = relay.__tmuxSends().length;
+    const NEXT_PROMPT = 'Work on the next task foo/bar#4.';
+
+    // First delivery attempt of task 4: the restart predicate is true, so this
+    // queues the prompt, relaunches, and returns without typing it.
+    relay.tmuxSendKeys(NEXT_PROMPT);
+    assert.strictEqual(relay.getPendingTask(), NEXT_PROMPT,
+      'the restart should queue the next prompt for the readiness callback');
+
+    // Drive the readiness-callback re-entry. A finite budget: if the reset is
+    // not one-shot this never drains and we hit the ceiling.
+    const REENTRY_BUDGET = 20;
+    const cycles = cycleReadyAndFlush(relay, REENTRY_BUDGET);
+    assert.ok(cycles < REENTRY_BUDGET,
+      `the periodic reset re-triggered indefinitely (issue #2596): the queued task was never delivered within ${REENTRY_BUDGET} readiness cycles`);
+
+    // Exactly one memory-cleanup restart happened for this crossing: the latch
+    // records the serviced count so re-entry cannot restart again.
+    assert.strictEqual(relay.getLastResetAtCount(), RESET_EVERY_N,
+      'the reset must latch the count it serviced so it does not re-fire');
+
+    // The next task was actually delivered as literal keystrokes.
+    const literalSends = relay.__tmuxSends().slice(before).filter(c => / -l /.test(c));
+    assert.ok(literalSends.some(c => c.includes('foo/bar#4')),
+      `task 4 must be delivered after the single reset; literal sends: ${JSON.stringify(literalSends)}`);
+    assert.strictEqual(relay.getPendingTask(), null, 'queue must be drained once the task is delivered');
+  } finally { teardown(relay); }
+});
+
+test('the periodic reset does not re-fire while the completed-task count is unchanged', () => {
+  const relay = loadRelay({ backend: 'goose' });
+  try {
+    relay.setCliReady(true);
+    relay.setPendingTask(null);
+    relay.setTasksCompletedCount(RESET_EVERY_N);
+    relay.setLastResetAtCount(RESET_EVERY_N); // reset already serviced for count 3
+
+    const before = relay.__commands.filter(c => /send-keys/.test(c) && /\bC-c\b/.test(c)).length;
+    relay.tmuxSendKeys('Deliver me directly, no restart.');
+
+    const after = relay.__commands.filter(c => /send-keys/.test(c) && /\bC-c\b/.test(c)).length;
+    assert.strictEqual(after, before,
+      'no additional CLI restart may happen once the reset is latched for the current count');
+    const literalSends = relay.__tmuxSends().filter(c => / -l /.test(c));
+    assert.ok(literalSends.some(c => c.includes('Deliver me directly')),
+      'the prompt must be delivered directly when the reset is already latched');
+  } finally { teardown(relay); }
+});
+
+test('a later crossing (count 6) resets again after count 3 was latched', () => {
+  const relay = loadRelay({ backend: 'goose' });
+  try {
+    relay.setCliReady(true);
+    relay.setPendingTask(null);
+    relay.setTasksCompletedCount(2 * RESET_EVERY_N); // count 6 — a new crossing
+    relay.setLastResetAtCount(RESET_EVERY_N);        // last reset was at count 3
+
+    relay.tmuxSendKeys('Task at the second crossing.');
+    assert.strictEqual(relay.getLastResetAtCount(), 2 * RESET_EVERY_N,
+      'a genuinely new threshold crossing must trigger the periodic reset again');
+  } finally { teardown(relay); }
+});
+
+test('claude backend never takes the periodic-reset path', () => {
+  const relay = loadRelay({ backend: 'claude' });
+  try {
+    relay.setCliReady(true);
+    relay.setPendingTask(null);
+    relay.setTasksCompletedCount(RESET_EVERY_N);
+    relay.setLastResetAtCount(-1);
+
+    const beforeCc = relay.__commands.filter(c => /send-keys/.test(c) && /\bC-c\b/.test(c)).length;
+    relay.tmuxSendKeys('Claude task, no memory-cleanup restart.');
+    const afterCc = relay.__commands.filter(c => /send-keys/.test(c) && /\bC-c\b/.test(c)).length;
+    assert.strictEqual(afterCc, beforeCc, 'the periodic CLI restart must never apply to the claude backend');
+    assert.strictEqual(relay.getLastResetAtCount(), -1,
+      'claude must not touch the reset latch');
+  } finally { teardown(relay); }
+});
+
+// ---------------------------------------------------------------------------
 // Bug 3 — bounded retries, permanent give-up, and the relay staying available.
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #2596 — a non-claude contributor backend (e.g. goose) got stuck in an infinite periodic-reset loop after completing task 3 and never received the next assignment. Live evidence was hundreds of alternating lines:

```
CLI ready — accepting tasks
CLI restarted: goose
Restarting goose CLI for memory cleanup (task 3)
```

## Root cause (re-entrant periodic reset)

`tmuxSendKeys()` restarts a non-claude CLI for memory cleanup whenever `tasksCompletedCount % RESET_EVERY_N === 0`:

```js
const needsCliRestart = BACKEND !== 'claude' && tasksCompletedCount > 0 && tasksCompletedCount % RESET_EVERY_N === 0;
```

The restart branch queues the prompt, sets `cliReady = false`, and calls `relaunchCLI()`. The readiness/pending-task guard added in the now-closed #2203 then re-enters this same function: `relaunchCLI()`'s readiness callback sets `cliReady = true` and calls `flushPendingTask()`, which calls `tmuxSendKeys()` again. `tasksCompletedCount` only changes on an actual task completion, so it is **still 3**, `3 % 3 === 0` is **still true**, and the CLI restarts again — forever. The reset never records that it already ran for the current count, so the next task (task 4) is never delivered.

## Fix (fire once per threshold crossing, then deliver)

- Track the completed-task count at which the reset last fired (`lastResetAtCount`, initialised to `-1`).
- Gate the predicate on `tasksCompletedCount !== lastResetAtCount`, and set `lastResetAtCount = tasksCompletedCount` **before** relaunching.
- On the #2203 re-entry the count is unchanged, so the predicate is now false: the relay falls through and delivers the queued next task instead of restarting again.

State transition, complete task 3 → count = 3 → reset fires once (latch = 3) → CLI ready → flush re-enters → predicate false → task 4 delivered. No re-reset at count 3; a genuinely new crossing (count 6) resets again.

Claude backend behaviour is unchanged (the predicate still excludes it), `RESET_EVERY_N` is unchanged, and the periodic memory-cleanup intent is preserved — just once per crossing rather than infinitely.

## Tests

Added regression cases in `bin/contributor-relay.test.js`:
- non-claude periodic reset fires **once** at count 3 and then **delivers** the next task (drives the #2203 readiness re-entry with a finite budget; fails with the old predicate as "re-triggered indefinitely").
- the reset does not re-fire while the completed-task count is unchanged.
- a later crossing (count 6) resets again after count 3 was latched.
- the claude backend never takes the periodic-reset path.

Verified the new test **fails** without the fix and **passes** with it. Full suite: `18/18 passed`. `node --check` clean on the relay (checked via a `.js` copy, exactly as CI does).

_No downstream retry, session recreation, or local relay patch — this is a fix to the relay/task-runtime behaviour itself, per the issue._
