### PR TITLE
contribute: preflight backend before credential write; document Podman posture + CI seam

### DIFF
--- a/.github/workflows/podman-contract.yml
+++ b/.github/workflows/podman-contract.yml
@@ -1,0 +1,36 @@
+name: Podman Rootless Contract
+
+# Static contract check for the rootless-Podman handling in Justfile's
+# contribute-hive recipe (#2535 Option C — CI seam, not a live rootless run).
+# See v2/docs/podman-rootless-ci.md for what this covers and what a future
+# live-runner test would add. Does NOT change the runtime auto-detect
+# default (Option A is explicitly deferred pending broader coverage).
+
+on:
+  push:
+    branches:
+      - v2
+    paths:
+      - 'Justfile'
+      - 'v2/scripts/check-podman-contract.sh'
+      - 'v2/docs/podman-rootless-ci.md'
+  pull_request:
+    branches:
+      - v2
+    paths:
+      - 'Justfile'
+      - 'v2/scripts/check-podman-contract.sh'
+      - 'v2/docs/podman-rootless-ci.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run rootless-Podman static contract check
+        run: bash v2/scripts/check-podman-contract.sh Justfile

--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,14 @@
 # Justfile — KubeStellar Hive contributor commands, for ClankeR (the contributor relay)
 #
 # Install just: brew install just (macOS) or cargo install just
-# Usage: just contribute-setup claude && just contribute-hive
+# Usage: just contribute-check claude (optional, read-only preflight) && \
+#        just contribute-setup claude && just contribute-hive
+#
+# Ordering (#2543): contribute-setup runs the backend-CLI preflight FIRST —
+# before the GH token is written to disk and before hub registration — so a
+# machine that isn't ready fails before it costs a credential write or a
+# contributor slot. `just contribute-check <cli>` runs the same preflight
+# standalone, any time, with zero side effects.
 
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
@@ -9,7 +16,9 @@ hive_image := env("HIVE_CONTRIBUTOR_IMAGE", "ghcr.io/kubestellar/hive-contributo
 hive_hub := env("HIVE_HUB", "wss://hive.kubestellar.io/contribute")
 config_dir := env("HOME") + "/.config/hive"
 # Container runtime for containerized mode. Empty = auto-detect (docker, then
-# podman). Set HIVE_CONTAINER_RUNTIME=podman to force podman.
+# podman — Docker wins on discovery order, not isolation posture; see the
+# posture note above the detect logic in contribute-hive, and #2535).
+# Set HIVE_CONTAINER_RUNTIME=podman to force rootless podman, or =docker.
 container_runtime := env("HIVE_CONTAINER_RUNTIME", "")
 
 # Show available commands
@@ -31,137 +40,16 @@ check-version skip="false":
     fi
     echo "✓ Up to date (${LOCAL})"
 
-# One-time setup: register with hub + authenticate GitHub + authenticate CLI
-contribute-setup backend="claude": check-version
+# Read-only preflight: is this machine ready to contribute? Checks the
+# agent backend CLI (the thing most likely to fail) BEFORE any credential is
+# written to disk or a contributor slot is registered with the hub. Safe to
+# run as many times as you like — it writes nothing.
+# Usage: just contribute-check claude
+[private]
+contribute-check-backend backend="claude":
     #!/usr/bin/env bash
     set -euo pipefail
-    if [[ "{{hive_hub}}" == "wss://hive.kubestellar.io/contribute" ]]; then
-      echo "HIVE_HUB not set — looking up your hives..."
-      echo ""
-      _TOKEN=$(gh auth token 2>/dev/null || echo "")
-      HIVE_LIST=""
-      if [[ -n "$_TOKEN" ]]; then
-        MY_HIVES=$(curl -sf -H "Authorization: Bearer ${_TOKEN}" "https://hive.kubestellar.io/api/saas/my-hives" 2>/dev/null || echo "")
-        if [[ -n "$MY_HIVES" ]]; then
-          HIVE_LIST=$(echo "$MY_HIVES" | jq -r '.hives[]? // .[] | "\(.id)|\(.name // .project_name)"' 2>/dev/null)
-        fi
-      fi
-      if [[ -z "$HIVE_LIST" ]]; then
-        HIVES_JSON=$(curl -sf "https://hive.kubestellar.io/api/registry" 2>/dev/null) || {
-          echo "ERROR: Could not reach hive.kubestellar.io"
-          echo "Set HIVE_HUB manually: export HIVE_HUB=wss://<hive>/contribute"
-          exit 1
-        }
-        HIVE_LIST=$(echo "$HIVES_JSON" | jq -r '.hives[] | select(.online==true) | "\(.id)|\(.name)"' 2>/dev/null)
-      fi
-      if [[ -z "$HIVE_LIST" ]]; then
-        echo "No hives available. Check https://hive.kubestellar.io"
-        exit 1
-      fi
-      echo "Your hives:"
-      echo ""
-      i=1
-      declare -a HIVE_IDS
-      while IFS='|' read -r hid hname; do
-        HIVE_IDS+=("$hid")
-        printf "  %d) %s (%s)\n" "$i" "$hname" "$hid"
-        i=$((i+1))
-      done <<< "$HIVE_LIST"
-      echo ""
-      read -p "Select a hive [1-$((i-1))]: " CHOICE
-      if [[ -z "$CHOICE" || "$CHOICE" -lt 1 || "$CHOICE" -gt $((i-1)) ]] 2>/dev/null; then
-        echo "Invalid selection."
-        exit 1
-      fi
-      SELECTED="${HIVE_IDS[$((CHOICE-1))]}"
-      if [[ "$SELECTED" == hosted-* ]]; then
-        export HIVE_HUB="wss://${SELECTED}.hive.kubestellar.io/contribute"
-      else
-        DASH_URL=$(echo "$HIVES_JSON" | jq -r --arg id "$SELECTED" '.hives[] | select(.id==$id) | .dashboardUrl' 2>/dev/null || echo "")
-        if [[ -n "$DASH_URL" ]]; then
-          DASH_URL=$(echo "$DASH_URL" | sed 's|^http://|ws://|;s|^https://|wss://|')
-          export HIVE_HUB="${DASH_URL}/contribute"
-        else
-          export HIVE_HUB="wss://${SELECTED}.hive.kubestellar.io/contribute"
-        fi
-      fi
-      echo ""
-      echo "Selected: ${HIVE_HUB}"
-      echo "TIP: Next time, run: export HIVE_HUB=${HIVE_HUB}"
-      echo ""
-    fi
-    mkdir -p "{{config_dir}}"
-    echo "=== Hive Contributor Setup (ClankeR) ==="
-    echo ""
-
-    # ── Step 1: GitHub authentication ──
-    echo "── Step 1/3: GitHub Authentication ──"
-    if ! command -v gh &>/dev/null; then
-      echo "ERROR: gh CLI not found. Install: brew install gh"
-      exit 1
-    fi
-    if gh auth status &>/dev/null; then
-      GH_USER=$(gh api user --jq '.login' 2>/dev/null || echo "")
-      echo "Already authenticated as: ${GH_USER}"
-    else
-      echo "Logging into GitHub..."
-      gh auth login --web --scopes "repo,read:org"
-      GH_USER=$(gh api user --jq '.login' 2>/dev/null || echo "")
-      echo "Authenticated as: ${GH_USER}"
-    fi
-    GH_TOKEN=$(gh auth token 2>/dev/null || echo "")
-    if [[ -n "$GH_TOKEN" ]]; then
-      echo "GH_TOKEN=${GH_TOKEN}" > "{{config_dir}}/gh-auth.env"
-      chmod 600 "{{config_dir}}/gh-auth.env"
-    fi
-    echo ""
-
-    # ── Step 2: Register with hive hub ──
-    echo "── Step 2/3: Hive Registration ──"
-    _HUB="${HIVE_HUB:-{{hive_hub}}}"
-    HUB_HTTP=$(echo "$_HUB" | sed 's|^wss://|https://|;s|^ws://|http://|;s|/contribute$||')
-    RESPONSE=$(curl -sf --max-time 15 -X POST "${HUB_HTTP}/api/contribute/register" \
-      -H "Content-Type: application/json" \
-      -H "Authorization: Bearer ${GH_TOKEN}" \
-      -d "{\"github_username\": \"${GH_USER}\"}" 2>/dev/null) || {
-        echo "ERROR: Registration failed. Is the hub running at ${HUB_HTTP}?"
-        echo "  Check: curl -sf ${HUB_HTTP}/api/contribute/status"
-        exit 1
-    }
-    if ! echo "$RESPONSE" | jq empty 2>/dev/null; then
-      echo "ERROR: Hub returned invalid response: ${RESPONSE:0:200}"
-      exit 1
-    fi
-    TOKEN=$(echo "$RESPONSE" | jq -r '.registration_token')
-    CID=$(echo "$RESPONSE" | jq -r '.contributor_id')
-    MSG=$(echo "$RESPONSE" | jq -r '.message')
-    if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
-      if echo "$MSG" | grep -qi "already registered"; then
-        if [[ -f "{{config_dir}}/contributor.env" ]]; then
-          source "{{config_dir}}/contributor.env"
-          echo "Already registered — ${GH_USER} (${CONTRIBUTOR_ID:-unknown})"
-        else
-          echo "ERROR: Already registered but no local config found."
-          exit 1
-        fi
-      else
-        echo "ERROR: ${MSG:-No token received}"
-        exit 1
-      fi
-    else
-      cat > "{{config_dir}}/contributor.env" <<EOF
-    HIVE_REGISTRATION_TOKEN=${TOKEN}
-    HIVE_HUB=${_HUB}
-    CONTRIBUTOR_ID=${CID}
-    CONTRIBUTOR_USERNAME=${GH_USER}
-    AGENT_BACKEND={{backend}}
-    EOF
-    fi
-    echo "${MSG} — ${GH_USER} (${CID})"
-    echo ""
-
-    # ── Step 3: CLI authentication ──
-    echo "── Step 3/3: {{backend}} CLI Authentication ──"
+    echo "── Preflight: {{backend}} CLI ──"
     case "{{backend}}" in
       claude)
         if ! command -v claude &>/dev/null; then
@@ -175,7 +63,7 @@ contribute-setup backend="claude": check-version
           echo "Claude Code needs authentication."
           echo "Run:  claude"
           echo "Then type /login and follow the prompts."
-          echo "Once logged in, exit Claude (Ctrl+C) and re-run this setup."
+          echo "Once logged in, exit Claude (Ctrl+C) and re-run this check."
           exit 1
         fi
         ;;
@@ -189,7 +77,7 @@ contribute-setup backend="claude": check-version
         ;;
       gemini)
         if command -v gemini &>/dev/null; then
-          gemini auth login 2>/dev/null || echo "Gemini login complete (or already authenticated)"
+          echo "Gemini CLI detected — run 'gemini auth login' if not already authenticated."
         else
           echo "ERROR: Gemini CLI not installed."
           exit 1
@@ -264,6 +152,155 @@ contribute-setup backend="claude": check-version
         exit 1
         ;;
     esac
+    echo "✓ {{backend}} preflight passed."
+
+# Read-only preflight you can run standalone, any time, before setup — checks
+# the agent backend CLI without writing a credential or registering with the
+# hub. Run this FIRST if you're not sure your machine is ready.
+# Usage: just contribute-check claude
+contribute-check backend="claude": (contribute-check-backend backend)
+    @echo ""
+    @echo "✓ Machine looks ready for 'just contribute-setup {{backend}}'."
+
+# One-time setup: register with hub + authenticate GitHub + authenticate CLI
+# Ordering note (#2543): the backend-readiness preflight runs FIRST, before
+# any credential is written to disk or a contributor slot is registered —
+# so a machine that isn't ready fails before it costs a GH token write or a
+# hub registration. check-version still gates everything (it already did).
+contribute-setup backend="claude": check-version (contribute-check-backend backend)
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "{{hive_hub}}" == "wss://hive.kubestellar.io/contribute" ]]; then
+      echo "HIVE_HUB not set — looking up your hives..."
+      echo ""
+      _TOKEN=$(gh auth token 2>/dev/null || echo "")
+      HIVE_LIST=""
+      if [[ -n "$_TOKEN" ]]; then
+        MY_HIVES=$(curl -sf -H "Authorization: Bearer ${_TOKEN}" "https://hive.kubestellar.io/api/saas/my-hives" 2>/dev/null || echo "")
+        if [[ -n "$MY_HIVES" ]]; then
+          HIVE_LIST=$(echo "$MY_HIVES" | jq -r '.hives[]? // .[] | "\(.id)|\(.name // .project_name)"' 2>/dev/null)
+        fi
+      fi
+      if [[ -z "$HIVE_LIST" ]]; then
+        HIVES_JSON=$(curl -sf "https://hive.kubestellar.io/api/registry" 2>/dev/null) || {
+          echo "ERROR: Could not reach hive.kubestellar.io"
+          echo "Set HIVE_HUB manually: export HIVE_HUB=wss://<hive>/contribute"
+          exit 1
+        }
+        HIVE_LIST=$(echo "$HIVES_JSON" | jq -r '.hives[] | select(.online==true) | "\(.id)|\(.name)"' 2>/dev/null)
+      fi
+      if [[ -z "$HIVE_LIST" ]]; then
+        echo "No hives available. Check https://hive.kubestellar.io"
+        exit 1
+      fi
+      echo "Your hives:"
+      echo ""
+      i=1
+      declare -a HIVE_IDS
+      while IFS='|' read -r hid hname; do
+        HIVE_IDS+=("$hid")
+        printf "  %d) %s (%s)\n" "$i" "$hname" "$hid"
+        i=$((i+1))
+      done <<< "$HIVE_LIST"
+      echo ""
+      read -p "Select a hive [1-$((i-1))]: " CHOICE
+      if [[ -z "$CHOICE" || "$CHOICE" -lt 1 || "$CHOICE" -gt $((i-1)) ]] 2>/dev/null; then
+        echo "Invalid selection."
+        exit 1
+      fi
+      SELECTED="${HIVE_IDS[$((CHOICE-1))]}"
+      if [[ "$SELECTED" == hosted-* ]]; then
+        export HIVE_HUB="wss://${SELECTED}.hive.kubestellar.io/contribute"
+      else
+        DASH_URL=$(echo "$HIVES_JSON" | jq -r --arg id "$SELECTED" '.hives[] | select(.id==$id) | .dashboardUrl' 2>/dev/null || echo "")
+        if [[ -n "$DASH_URL" ]]; then
+          DASH_URL=$(echo "$DASH_URL" | sed 's|^http://|ws://|;s|^https://|wss://|')
+          export HIVE_HUB="${DASH_URL}/contribute"
+        else
+          export HIVE_HUB="wss://${SELECTED}.hive.kubestellar.io/contribute"
+        fi
+      fi
+      echo ""
+      echo "Selected: ${HIVE_HUB}"
+      echo "TIP: Next time, run: export HIVE_HUB=${HIVE_HUB}"
+      echo ""
+    fi
+    mkdir -p "{{config_dir}}"
+    echo "=== Hive Contributor Setup (ClankeR) ==="
+    echo "✓ Preflight passed — {{backend}} CLI is ready. Proceeding to credential + registration."
+    echo ""
+
+    # ── Step 1: GitHub authentication ──
+    echo "── Step 1/2: GitHub Authentication ──"
+    if ! command -v gh &>/dev/null; then
+      echo "ERROR: gh CLI not found. Install: brew install gh"
+      exit 1
+    fi
+    if gh auth status &>/dev/null; then
+      GH_USER=$(gh api user --jq '.login' 2>/dev/null || echo "")
+      echo "Already authenticated as: ${GH_USER}"
+    else
+      echo "Logging into GitHub..."
+      gh auth login --web --scopes "repo,read:org"
+      GH_USER=$(gh api user --jq '.login' 2>/dev/null || echo "")
+      echo "Authenticated as: ${GH_USER}"
+    fi
+    GH_TOKEN=$(gh auth token 2>/dev/null || echo "")
+    if [[ -n "$GH_TOKEN" ]]; then
+      echo "GH_TOKEN=${GH_TOKEN}" > "{{config_dir}}/gh-auth.env"
+      chmod 600 "{{config_dir}}/gh-auth.env"
+    fi
+    echo ""
+
+    # ── Step 2: Register with hive hub ──
+    echo "── Step 2/2: Hive Registration ──"
+    _HUB="${HIVE_HUB:-{{hive_hub}}}"
+    HUB_HTTP=$(echo "$_HUB" | sed 's|^wss://|https://|;s|^ws://|http://|;s|/contribute$||')
+    RESPONSE=$(curl -sf --max-time 15 -X POST "${HUB_HTTP}/api/contribute/register" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${GH_TOKEN}" \
+      -d "{\"github_username\": \"${GH_USER}\"}" 2>/dev/null) || {
+        echo "ERROR: Registration failed. Is the hub running at ${HUB_HTTP}?"
+        echo "  Check: curl -sf ${HUB_HTTP}/api/contribute/status"
+        exit 1
+    }
+    if ! echo "$RESPONSE" | jq empty 2>/dev/null; then
+      echo "ERROR: Hub returned invalid response: ${RESPONSE:0:200}"
+      exit 1
+    fi
+    TOKEN=$(echo "$RESPONSE" | jq -r '.registration_token')
+    CID=$(echo "$RESPONSE" | jq -r '.contributor_id')
+    MSG=$(echo "$RESPONSE" | jq -r '.message')
+    if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
+      if echo "$MSG" | grep -qi "already registered"; then
+        if [[ -f "{{config_dir}}/contributor.env" ]]; then
+          source "{{config_dir}}/contributor.env"
+          echo "Already registered — ${GH_USER} (${CONTRIBUTOR_ID:-unknown})"
+        else
+          echo "ERROR: Already registered but no local config found."
+          exit 1
+        fi
+      else
+        echo "ERROR: ${MSG:-No token received}"
+        exit 1
+      fi
+    else
+      cat > "{{config_dir}}/contributor.env" <<EOF
+    HIVE_REGISTRATION_TOKEN=${TOKEN}
+    HIVE_HUB=${_HUB}
+    CONTRIBUTOR_ID=${CID}
+    CONTRIBUTOR_USERNAME=${GH_USER}
+    AGENT_BACKEND={{backend}}
+    EOF
+    fi
+    echo "${MSG} — ${GH_USER} (${CID})"
+    echo ""
+
+    # ── {{backend}} CLI readiness was already verified in the preflight
+    # above, before the credential was written and before this registration
+    # ran (see #2543). Nothing left to check here — just finalize backend-
+    # specific local state.
+    echo "✓ {{backend}} CLI: verified during preflight."
 
     # Persist the LiteLLM endpoint (never the API key) for later runs
     if [[ "{{backend}}" == "litellm" && -f "{{config_dir}}/contributor.env" ]]; then
@@ -291,7 +328,8 @@ contribute-setup backend="claude": check-version
 # Usage: just contribute-hive              (container, default CLI from setup)
 #        just contribute-hive copilot      (container, copilot backend)
 #        just contribute-hive claude local  (native mode, claude)
-# Runtime: auto-detects docker then podman; force with HIVE_CONTAINER_RUNTIME=podman
+# Runtime: auto-detects docker then podman (discovery order, not posture —
+# see v2/docs/podman-rootless-ci.md); force with HIVE_CONTAINER_RUNTIME=podman
 contribute-hive backend="" mode="docker": check-version
     #!/usr/bin/env bash
     set -euo pipefail
@@ -428,6 +466,18 @@ contribute-hive backend="" mode="docker": check-version
       # docker, else podman. Podman gets --userns=keep-id (rootless UID
       # mapping so the container's dev user can read the mounted configs)
       # and SELinux-friendly volume labels (,Z).
+      #
+      # Posture (#2535, Option B — this is a documentation note, the
+      # detect order below is UNCHANGED): when both engines are present,
+      # Docker wins by discovery order, not by isolation posture. Docker's
+      # daemon here runs rootful — docker-group membership is effectively
+      # root on the host. Podman here runs rootless, in a user namespace.
+      # A contributor who wants rootless-by-default should set
+      # HIVE_CONTAINER_RUNTIME=podman explicitly; the page selector does
+      # the same. Rootless Podman handling is exercised by hand, not yet
+      # by CI — see v2/docs/podman-rootless-ci.md (#2535 Option C) for the
+      # test-intent seam. We are deliberately NOT re-ordering this detect
+      # to prefer Podman (that's Option A) until that CI coverage exists.
       RUNTIME="{{container_runtime}}"
       if [[ -z "$RUNTIME" ]]; then
         if command -v docker >/dev/null 2>&1; then RUNTIME=docker

--- a/v2/docs/podman-rootless-ci.md
+++ b/v2/docs/podman-rootless-ci.md
@@ -1,0 +1,93 @@
+# Rootless Podman: CI seam (#2535, Option C)
+
+## Why this doc exists
+
+Issue [#2535](https://github.com/kubestellar/hive/issues/2535) raises three options for
+container-runtime auto-detect:
+
+- **Option A** — re-order auto-detect to prefer rootless Podman over Docker when both are
+  present.
+- **Option B** — leave the detect order alone, but make the privilege implication of each
+  runtime legible at the point of choice (done: see the posture note above the runtime
+  detect logic in `Justfile`, in the `container_runtime` doc comment, and in the page copy
+  in `v2/pkg/dashboard/api_contribute.go`).
+- **Option C** — make rootless Podman a *tested* path in CI, so the handling doesn't
+  silently regress, before A is even considered.
+
+The reporter's stated position: **"B now, C before A."** This doc plus the CI job it
+describes is Option C's seam. **It does not change the auto-detect default** — Docker
+still wins when both engines are present (see `Justfile`, the `contribute-hive` recipe's
+runtime-resolution block). A default flip (Option A) is explicitly out of scope until this
+seam has run long enough to be trusted, per the reporter's own downstream experience
+(`projectbluefin/review`'s ten-commit `--userns=keep-id` regression history, cited in
+#2535).
+
+## What "rootless Podman handling" means here
+
+The parts of Hive that change behavior specifically for Podman, all in the `contribute-hive`
+recipe of `Justfile`:
+
+1. `--userns=keep-id` — rootless UID mapping, so the container's `dev` user can read
+   bind-mounted host config (`~/.config/hive`, `~/.claude`, `~/.config/gh`, etc.) without
+   a UID mismatch.
+2. `:Z` / `:ro,Z` volume-mount suffixes — SELinux relabeling so the container can actually
+   access those same bind mounts on an SELinux-enforcing host.
+3. The macOS carve-out — `podman machine`'s "host" is the Podman VM, not the Mac itself, so
+   `--network host` is dropped on Darwin for Podman (Docker Desktop on macOS has the same
+   constraint and is handled the same way).
+4. No engine socket is ever mounted into the contributor container
+   (`/var/run/docker.sock`, `/run/podman/podman.sock`) — already true, and covered by the
+   marker check below so it stays true if a future PR touches the mount list.
+
+Any of these four regressing would reproduce exactly the failure mode #2535 cites from
+`projectbluefin/review`: correct-looking code that silently stops doing rootless mapping,
+SELinux labeling, or socket confinement.
+
+## The seam: what should be tested, and how
+
+This PR does not attempt the full "spin up rootless Podman + SELinux on a runner" matrix —
+that is real infrastructure work (GitHub-hosted runners are not SELinux-enforcing by
+default, and rootless Podman-in-CI has its own sandboxing wrinkles). Per #2535, "even a
+lightweight CI job or a documented test-intent" is the bar for Option C. What's in place:
+
+- **A static contract check** (`v2/scripts/check-podman-contract.sh`, wired into
+  `.github/workflows/podman-contract.yml`) that greps the `Justfile`'s `contribute-hive`
+  recipe and asserts, on every push/PR touching `Justfile`:
+  - `--userns=keep-id` is present in the Podman branch.
+  - `:Z` is present in the Podman volume-suffix variables.
+  - The macOS network carve-out still special-cases Podman (`darwin` + network flags).
+  - Neither `/var/run/docker.sock` nor `/run/podman/podman.sock` appears anywhere in the
+    recipe (mirrors the same static-contract-test idea `projectbluefin/review` uses in
+    `tests/image-contract.sh`, cited in #2535 as "the test outlived the refactor").
+
+  This catches the exact regression pattern #2535 describes ("kept regressing until the
+  invariant was pinned by a test") without requiring a live rootless-Podman runner. It is
+  cheap, fast, and runs on every PR.
+
+- **Documented test-intent for the live path** (this section) — the next increment beyond
+  the static check, for whoever picks up full Option C coverage:
+  1. A self-hosted or container-in-container runner with rootless Podman + an
+     SELinux-enforcing filesystem (GitHub-hosted `ubuntu-latest` runners are not
+     SELinux-enforcing, so this can't run there as-is).
+  2. Actually invoke `just contribute-hive <backend> ` with `HIVE_CONTAINER_RUNTIME=podman`
+     forced, using a throwaway `HIVE_HUB` / fixture credentials, and assert the container
+     starts, the bind mounts are readable inside it (proves `keep-id` + `:Z` both worked),
+     and it exits cleanly.
+  3. Track flakiness separately from the static contract check — a live rootless
+     container test is inherently noisier than a grep-based one, and conflating the two
+     would make the fast static gate less trustworthy.
+
+  Steps 1-3 are the "before A" work; this PR establishes the static seam (bar cleared per
+  #2535's "even a lightweight CI job or a documented test-intent") and leaves the live
+  runner work as a tracked follow-up rather than guessing at infrastructure this PR can't
+  validate.
+
+## Non-goals (explicitly, per #2535)
+
+- **No default flip.** `contribute-hive`'s runtime auto-detect still tries `docker` before
+  `podman`. `HIVE_CONTAINER_RUNTIME` and the dashboard runtime selector remain the only way
+  to force Podman.
+- **No `--network host` change.** #2535 flags this as "a separate, smaller question rather
+  than an ask" — out of scope here.
+- **No full SELinux CI matrix.** #2535 explicitly says a lightweight seam is sufficient for
+  now: "Do NOT need a full rootless-SELinux CI matrix; establish the seam + document it."

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -907,7 +907,7 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 })();
 </script>
 </div>
-<p style="color:#6e7681;font-size:.78rem;margin-top:8px">Containerized mode auto-detects docker, then podman &mdash; force one with <code>export HIVE_CONTAINER_RUNTIME=podman</code>. Rootless podman (keep-id, SELinux labels) is handled automatically.</p>
+<p style="color:#6e7681;font-size:.78rem;margin-top:8px">Containerized mode auto-detects docker, then podman &mdash; when both are present, Docker wins. Docker's daemon runs rootful (docker-group membership is effectively root on the host); Podman here runs rootless (user namespace via <code>--userns=keep-id</code>, SELinux labels). Force either explicitly with <code>export HIVE_CONTAINER_RUNTIME=podman</code> (or <code>docker</code>). Rootless Podman handling is best-effort today, not yet covered by CI &mdash; see <a href="https://github.com/kubestellar/hive/blob/v2/v2/docs/podman-rootless-ci.md" target="_blank" style="color:#58a6ff">docs/podman-rootless-ci.md</a>.</p>
 <p style="color:#6e7681;font-size:.78rem;margin-top:8px">Don't see your CLI? <a href="https://github.com/kubestellar/hive/issues/new?title=CLI+request:+&labels=enhancement" target="_blank" style="color:#58a6ff">Open an issue</a> and we'll add support for it.</p>
 <div style="margin-top:20px;display:flex;gap:12px;flex-wrap:wrap">
 <button type="button" id="goto-leaderboard-tab" style="display:inline-block;padding:8px 20px;background:#161b22;border:1px solid #30363d;border-radius:8px;color:#58a6ff;text-decoration:none;font-size:.9rem;font-family:inherit;cursor:pointer">🏆 View Leaderboard</button>

--- a/v2/scripts/check-podman-contract.sh
+++ b/v2/scripts/check-podman-contract.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# check-podman-contract.sh — static contract check for rootless-Podman
+# handling in the Justfile's contribute-hive recipe.
+#
+# Part of #2535 Option C (CI seam for the rootless-Podman path). This is a
+# grep-based static check, not a live rootless-Podman run — see
+# v2/docs/podman-rootless-ci.md for what this covers and what a future live
+# test would add. It does NOT touch the runtime auto-detect default (that's
+# Option A, explicitly deferred).
+#
+# Usage: v2/scripts/check-podman-contract.sh [path-to-Justfile]
+set -euo pipefail
+
+JUSTFILE="${1:-Justfile}"
+
+if [[ ! -f "$JUSTFILE" ]]; then
+  echo "ERROR: Justfile not found at ${JUSTFILE}" >&2
+  exit 1
+fi
+
+fail=0
+
+check() {
+  local desc="$1" pattern="$2"
+  if grep -qE "$pattern" "$JUSTFILE"; then
+    echo "  ok: ${desc}"
+  else
+    echo "  FAIL: ${desc} (expected to find pattern: ${pattern})"
+    fail=1
+  fi
+}
+
+check_absent() {
+  local desc="$1" pattern="$2"
+  if grep -qE "$pattern" "$JUSTFILE"; then
+    echo "  FAIL: ${desc} (found forbidden pattern: ${pattern})"
+    fail=1
+  else
+    echo "  ok: ${desc}"
+  fi
+}
+
+echo "== Podman rootless contract check (${JUSTFILE}) =="
+
+# 1. Rootless UID mapping must still be wired for the podman branch.
+check "rootless UID mapping (--userns=keep-id) present" \
+  '\-\-userns=keep-id'
+
+# 2. SELinux-friendly volume labels must still be applied for podman mounts.
+check "SELinux volume label (:Z) present" \
+  ':Z'
+
+# 3. The macOS carve-out must still special-case Podman + Darwin together.
+check "macOS network carve-out still references darwin" \
+  'OSTYPE.*darwin'
+
+# 4. No engine socket should ever be mounted into the contributor container —
+# mirrors the static contract test projectbluefin/review uses for the same
+# invariant (cited in #2535).
+check_absent "no docker.sock mount" \
+  '/var/run/docker\.sock'
+check_absent "no podman.sock mount" \
+  '/run/podman/podman\.sock'
+
+# 5. The auto-detect default must remain docker-then-podman — this check
+# exists so a future PR can't silently flip Option A in here. If you are
+# HERE to intentionally implement Option A, update this check deliberately
+# alongside v2/docs/podman-rootless-ci.md, don't just delete it.
+check "auto-detect still tries docker before podman" \
+  'command -v docker.*RUNTIME=docker'
+
+if [[ "$fail" -ne 0 ]]; then
+  echo ""
+  echo "Rootless Podman contract check FAILED — see v2/docs/podman-rootless-ci.md"
+  exit 1
+fi
+
+echo ""
+echo "Rootless Podman contract check passed."


### PR DESCRIPTION
Fixes #2543
Refs #2535

## #2543 — preflight-before-credential ordering

`contribute-setup` ran: write GH token to disk (step 1) -> register with
the hub (step 2) -> check the agent-backend CLI (step 3, the check most
likely to fail). A contributor who failed step 3 had already moved a
credential and taken a contributor slot.

This PR extracts the step-3 backend-CLI check into a read-only preflight
(`contribute-check-backend`, private) that `contribute-setup` now runs
FIRST — before the GH token is written and before hub registration.
`check-version` still gates everything, unchanged. The same preflight is
also exposed standalone as `just contribute-check <cli>`, so a contributor
can verify readiness before running setup at all.

Happy path is unchanged: a ready machine still completes the same steps,
just reordered (preflight, then Step 1/2 GitHub auth, Step 2/2 hub
registration — was 1/3, 2/3, 3/3).

One incidental fix while extracting this: the `gemini` branch previously
called `gemini auth login` (an interactive/mutating call) as part of the
"check"; since preflight must be read-only, this now just reports whether
the CLI is present.

## #2535 — Options B + C only (not the default flip)

Per the reporter's stated position ("B now, C before A"), this PR does
**Option B** and the **Option C seam**, and explicitly does **NOT** change
the auto-detect default.

- **Option B (posture legible):** the dashboard's containerized-mode copy
  and the Justfile's runtime-detect comments now say plainly that Docker
  wins on discovery order (not isolation posture) when both engines are
  present, that rootful Docker (docker-group ~ root on host) vs rootless
  Podman (user namespace) is a real privilege difference, and that
  `HIVE_CONTAINER_RUNTIME=podman|docker` (or the page selector) is how to
  choose explicitly. Also states plainly that rootless Podman handling is
  best-effort today, not yet CI-covered.
- **Option C (CI seam):** `v2/docs/podman-rootless-ci.md` documents what a
  rootless-Podman test should cover and why a full SELinux CI matrix isn't
  attempted here (matches the issue's "even a lightweight CI job or a
  documented test-intent" bar). `v2/scripts/check-podman-contract.sh` +
  `.github/workflows/podman-contract.yml` add a lightweight static
  contract check that runs on every Justfile change and asserts
  `--userns=keep-id`, `:Z` volume labels, the macOS network carve-out, no
  engine-socket mounts, and the docker-first default all remain intact —
  so a regression is caught by CI instead of a contributor report.

**The `contribute-hive` runtime auto-detect (docker, then podman) is
UNCHANGED.** `HIVE_CONTAINER_RUNTIME` and the dashboard runtime selector
remain the only way to force a specific engine. A default flip (Option A)
is explicitly deferred until the live-runner half of the CI seam exists,
per the reporter's own downstream regression history with this class of
change.

## Verification

- `just --list` / `just --evaluate`: Justfile parses cleanly.
- `shellcheck` on the extracted recipe bodies: clean (remaining findings
  are pre-existing `{{just_var}}` templating artifacts, not introduced by
  this change).
- `go build ./pkg/dashboard/...`: compiles.
- `gofmt -l v2/pkg/dashboard/api_contribute.go`: no diff.
- `v2/scripts/check-podman-contract.sh Justfile`: passes against this
  branch's Justfile.
- Did not run a full local `contribute-setup`/`contribute-hive` (needs
  real GitHub/hub/CLI credentials per house rules).