### PR TITLE
contribute: additive capability declare + protocol version + surface identifier (#2547 declare half, #2567)

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -45,6 +45,13 @@ const NETWORK_ERROR_RETRY_DELAY_MS = 5000;
 // (the old silent-nil behaviour) nor busy-loop the hub.
 const TASK_UNAVAILABLE_RETRY_MS = 30000;
 
+// RELAY_PROTOCOL_VERSION is the contributor-protocol version this relay speaks
+// (kubestellar/hive#2567). It is DECLARED to the hub in auth_response (additive,
+// optional — an older hub simply ignores it) and the hub advertises its own
+// version + capability set back on auth_ok. Keep in step with
+// contributorProtocolVersion in v2/pkg/dashboard/contribute_protocol.go.
+const RELAY_PROTOCOL_VERSION = '1.1';
+
 // Per-task CLI-crash retry budget. Issue #2203: a task whose CLI kept dying was
 // reassigned by the hub and failed identically forever (5+ times in ~20min),
 // starving that hub task slot. After MAX_TASK_CLI_RESTARTS crash-restarts for
@@ -90,6 +97,45 @@ function injectGhToken(token) {
 const CLI_READY_POLL_MS = 2000;
 const CLI_READY_TIMEOUT_MS = 600000;
 const CONTAINER_NAME = process.env.HIVE_CONTAINER_NAME || 'hive-contributor';
+
+// detectCapabilities builds the OPTIONAL, client-declared capability object the
+// relay reports in auth_response (kubestellar/hive#2547, declare half). Every
+// entry is a cheap, honest self-report the hub STORES + SURFACES read-only and
+// NEVER routes/gates on. It is best-effort: any probe that throws is simply
+// omitted, so a constrained environment still authenticates unchanged. Computed
+// once at startup and cached.
+let cachedCapabilities = null;
+function detectCapabilities() {
+  if (cachedCapabilities) return cachedCapabilities;
+  const caps = {
+    os: process.platform,
+    arch: process.arch,
+    relay_protocol_version: RELAY_PROTOCOL_VERSION,
+  };
+  // Container runtime: prefer docker, then podman, else none. `command -v` is a
+  // cheap presence check; failure just means the runtime is absent.
+  let runtime = 'none';
+  for (const rt of ['docker', 'podman']) {
+    try {
+      execSync(`command -v ${rt}`, { stdio: 'ignore' });
+      runtime = rt;
+      break;
+    } catch (_) { /* not installed */ }
+  }
+  caps.container_runtime = runtime;
+  // Credential type: the KIND of GitHub credential the relay authenticates with
+  // (never the credential itself). App-token cache present → "app"; an explicit
+  // GH_TOKEN/GITHUB_TOKEN in the environment → "pat"; otherwise leave unset.
+  try {
+    if (fs.existsSync(GH_TOKEN_CACHE)) {
+      caps.credential_type = 'app';
+    } else if (process.env.GH_TOKEN || process.env.GITHUB_TOKEN) {
+      caps.credential_type = 'pat';
+    }
+  } catch (_) { /* ignore */ }
+  cachedCapabilities = caps;
+  return caps;
+}
 
 // Backends that must NOT be given --model, mirroring contributor-agent.sh.
 // amazonq/goose take their model from config/env. bob is excluded because
@@ -713,11 +759,22 @@ function handleMessage(data) {
         registration_token: REG_TOKEN,
         cli_backend: BACKEND,
         model: MODEL,
+        // #2547 declare half + #2567: additive, optional self-report of runtime
+        // posture and protocol version. An older hub ignores these unknown fields.
+        protocol_version: RELAY_PROTOCOL_VERSION,
+        capabilities: detectCapabilities(),
       });
       break;
 
     case 'auth_ok':
       console.log(`Authenticated as ${msg.contributor_id} (tier: ${msg.trust_tier})`);
+      // #2567: the hub advertises its protocol version + capability set here. We
+      // log them (forward-compatible: unknown/absent fields are simply skipped)
+      // so a newer relay can adapt to what the deployed server supports instead
+      // of probing. No behaviour is gated on them today.
+      if (msg.protocol_version || (msg.server_capabilities && msg.server_capabilities.length)) {
+        console.log(`Hub protocol ${msg.protocol_version || 'unversioned'}; capabilities: ${(msg.server_capabilities || []).join(', ') || 'none'}`);
+      }
       reconnectDelay = BASE_RECONNECT_DELAY_MS;
       if (!currentTask) {
         send({ type: 'ready', seq: nextSeq() });

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -2329,12 +2329,37 @@ func (s *Server) handleContributeStatus(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 	s.statusMu.RUnlock()
+	// #2567: identify WHICH surface answered. The Hub discovery front door and a
+	// selected spoke both serve this exact handler with disjoint-looking payloads
+	// and, until now, no discriminator — a wrong-base-URL request returned 200 and
+	// looked valid. Add a "surface" discriminator plus the protocol/api version and
+	// the served git SHA so a client can tell hub from spoke and a wrong URL fails
+	// LOUDLY (identifiable) instead of silently. All fields are ADDITIVE — existing
+	// consumers of the four fields above are unaffected. Also mirror the protocol
+	// version in a response header for cheap client-side checks.
+	w.Header().Set("X-Hive-Contribute-Protocol", contributorProtocolVersion)
 	jsonResponse(w, map[string]any{
 		"hub":                 "online",
 		"active_contributors": active,
 		"total_registered":    len(profiles),
 		"actionable_items":    actionable,
+		"surface":             s.contributeSurface(),
+		"api_version":         contributorProtocolVersion,
+		"served_sha":          versionShort,
 	})
+}
+
+// contributeSurface reports which contributor surface this deployment presents
+// so the /api/contribute/status response can discriminate the Hub discovery
+// front door from a selected spoke (#2567). A hive that sits behind the hub's
+// nginx auth-proxy (HubProxied) is a hosted SPOKE; otherwise it is the hub /
+// standalone discovery surface. Read-only; derived from existing config, adds no
+// new state or configuration.
+func (s *Server) contributeSurface() string {
+	if s.deps != nil && s.deps.Config != nil && s.deps.Config.Dashboard.HubProxied {
+		return surfaceSpoke
+	}
+	return surfaceHub
 }
 
 func (s *Server) handleContributeActivity(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/contribute_protocol.go
+++ b/v2/pkg/dashboard/contribute_protocol.go
@@ -1,0 +1,120 @@
+// Contributor-protocol versioning, capability advertisement, and the
+// surface/schema identifier — the ADDITIVE, backward-compatible contributor
+// handshake extensions from kubestellar/hive#2547 (capability DECLARE half) and
+// kubestellar/hive#2567 (protocol version + server capability set + surface
+// identifier).
+//
+// Design contract — forward/backward compatibility (#2567):
+//
+//   - Every field added by these two issues is OPTIONAL and additive. A client
+//     that omits the new auth_response capability fields authenticates and runs
+//     EXACTLY as before — nothing here gates admission, model acceptance, or
+//     task selection. A client that ignores the new auth_ok fields (an existing
+//     unversioned relay) behaves exactly as today.
+//
+//   - UNKNOWN MESSAGE TYPES ARE IGNORED. The hub read loop (contribute_ws.go)
+//     already drops a message whose "type" it does not recognise via the
+//     switch's implicit default, and the relay's handleMessage does the same.
+//     This is the forward-compatibility rule: a newer peer may introduce a new
+//     message type, and an older peer silently ignores it rather than erroring.
+//     The protocol version + capability set below let a NEWER client degrade
+//     INTENTIONALLY — it can learn from auth_ok what the deployed server
+//     supports (e.g. token_refresh, task_unavailable reasons, prompt preview)
+//     instead of probing and reacting to silence.
+//
+//   - This is the DECLARE half of #2547 only. Clients may DECLARE their runtime
+//     posture (container runtime, OS/arch, agent/relay versions, credential
+//     type); the hub PARSES, STORES, and SURFACES it read-only. It does NOT
+//     ROUTE or gate work on any declared capability — that is the deferred Gate
+//     half and is deliberately out of scope here.
+package dashboard
+
+// contributorProtocolVersion is the contributor WebSocket protocol version this
+// hub speaks. It is advertised to clients on auth_ok (#2567) so a relay can
+// learn the deployed protocol level without probing. Bump ONLY on a wire
+// contract change; new OPTIONAL fields do not require a bump because they are
+// backward-compatible by construction. Semantic: MAJOR.MINOR where a MINOR bump
+// is purely additive and a MAJOR bump would be a breaking change (none is made
+// here).
+const contributorProtocolVersion = "1.1"
+
+// Server capability tokens advertised on auth_ok (#2567). Each names a message
+// type or feature this hub supports so a client can adapt without probing. They
+// are stable identifiers, not free text; add new ones as features land.
+const (
+	// capTokenRefresh: the hub proactively re-mints and pushes a fresh
+	// github_token via a token_refresh message before the old one expires
+	// (see wsTokenRefreshPeriod / #2393 item 2).
+	capTokenRefresh = "token_refresh"
+	// capTaskUnavailableReasons: task_unavailable carries a machine-readable
+	// reason (the taskUnavailable* set, #2436/#2546) rather than silence.
+	capTaskUnavailableReasons = "task_unavailable_reasons"
+	// capPromptPreview: the ops surface can preview the exact assignment prompt
+	// without exposing the minted token (#2539).
+	capPromptPreview = "prompt_preview"
+	// capCapabilityDeclare: the hub accepts, stores, and surfaces client-declared
+	// capabilities in auth_response (#2547 declare half).
+	capCapabilityDeclare = "capability_declare"
+)
+
+// serverCapabilities returns the capability set this hub advertises on auth_ok.
+// It is a fixed list of what the deployed server supports; it is order-stable so
+// the wire payload is deterministic across connections.
+func serverCapabilities() []string {
+	return []string{
+		capTokenRefresh,
+		capTaskUnavailableReasons,
+		capPromptPreview,
+		capCapabilityDeclare,
+	}
+}
+
+// Surface identifiers for the /api/contribute/status response (#2567). Two
+// public deployments of this same binary answer /api/contribute/status with the
+// same handler — the Hub discovery front door and a selected spoke — and until
+// now no field said which one replied, so a wrong-base-URL request returned 200
+// and looked valid (verified live: both 200, no discriminator). The status
+// response now carries one of these so a client can tell which surface answered
+// and a wrong URL fails LOUDLY (identifiable) instead of silently.
+const (
+	surfaceHub   = "hub"
+	surfaceSpoke = "spoke"
+)
+
+// ContributorCapabilities is the OPTIONAL, client-declared runtime posture a
+// contributor relay may report in its auth_response (#2547 declare half). Every
+// field is omitempty: a client that declares nothing sends an absent/empty
+// object and is treated exactly as an unversioned client. The hub STORES this on
+// the connection and SURFACES it read-only (FleetClanker) so the Operations tab
+// COULD show it — it is NEVER used to route or gate work.
+//
+// Fields are honest self-reports the relay can cheaply determine; none is
+// trusted for a security decision (server-side policy still governs what a
+// contributor may do — see the Restrictions reservation in contribute_ws.go).
+type ContributorCapabilities struct {
+	// ContainerRuntime is the container runtime the relay found available:
+	// "docker", "podman", or "none". Advisory only.
+	ContainerRuntime string `json:"container_runtime,omitempty"`
+	// OS and Arch are the client's operating system and CPU architecture
+	// (e.g. "linux"/"amd64"), as the client reports them.
+	OS   string `json:"os,omitempty"`
+	Arch string `json:"arch,omitempty"`
+	// AgentCLIVersion is the version string of the agent CLI backend the relay
+	// drives (claude/codex/goose/…), when the relay can determine it.
+	AgentCLIVersion string `json:"agent_cli_version,omitempty"`
+	// RelayProtocolVersion is the contributor-protocol version the relay speaks.
+	// It lets the hub see, read-only, which protocol level a connected client is
+	// on (the mirror of the version the hub advertises on auth_ok).
+	RelayProtocolVersion string `json:"relay_protocol_version,omitempty"`
+	// CredentialType names the kind of credential the relay authenticates GitHub
+	// with (e.g. "app", "pat", "oauth"), NOT the credential itself. Advisory.
+	CredentialType string `json:"credential_type,omitempty"`
+}
+
+// IsZero reports whether the client declared no capabilities at all, so the hub
+// can store nil (indistinguishable from an unversioned client) rather than an
+// empty struct.
+func (c ContributorCapabilities) IsZero() bool {
+	return c.ContainerRuntime == "" && c.OS == "" && c.Arch == "" &&
+		c.AgentCLIVersion == "" && c.RelayProtocolVersion == "" && c.CredentialType == ""
+}

--- a/v2/pkg/dashboard/contribute_protocol_test.go
+++ b/v2/pkg/dashboard/contribute_protocol_test.go
@@ -1,0 +1,308 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// contribute_protocol_test.go covers the ADDITIVE, backward-compatible
+// contributor-protocol extensions from kubestellar/hive#2547 (capability
+// DECLARE half) and #2567 (protocol version + server capability set + surface
+// identifier). Nothing here exercises routing/gating — those are deliberately
+// out of scope (the deferred Gate half of #2547).
+
+// registerWSUser registers a contributor and returns its registration token +
+// contributor id, mirroring the flow in contribute_ws_test.go.
+func registerWSUser(t *testing.T, s *Server, username string) (token, contributorID string) {
+	t.Helper()
+	body := `{"github_username":"` + username + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &reg); err != nil {
+		t.Fatalf("register unmarshal: %v", err)
+	}
+	return reg["registration_token"], reg["contributor_id"]
+}
+
+// TestWS_AuthOKCarriesVersionAndCapabilities asserts #2567: the server's auth_ok
+// advertises the protocol version and its capability set so a client can learn
+// what the deployed hub supports without probing.
+func TestWS_AuthOKCarriesVersionAndCapabilities(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+	token, _ := registerWSUser(t, s, "ver-user")
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: token, CLIBackend: "claude"})
+	authOK := readMsg(t, conn)
+
+	if authOK.Type != "auth_ok" {
+		t.Fatalf("expected auth_ok, got %s: %s", authOK.Type, authOK.Reason)
+	}
+	if authOK.ProtocolVersion != contributorProtocolVersion {
+		t.Fatalf("auth_ok protocol_version: want %q, got %q", contributorProtocolVersion, authOK.ProtocolVersion)
+	}
+	if len(authOK.ServerCapabilities) == 0 {
+		t.Fatal("auth_ok must advertise server_capabilities")
+	}
+	// The advertised set must include the well-known capability tokens.
+	want := map[string]bool{
+		capTokenRefresh: false, capTaskUnavailableReasons: false,
+		capPromptPreview: false, capCapabilityDeclare: false,
+	}
+	for _, c := range authOK.ServerCapabilities {
+		if _, ok := want[c]; ok {
+			want[c] = true
+		}
+	}
+	for c, seen := range want {
+		if !seen {
+			t.Errorf("auth_ok server_capabilities missing %q", c)
+		}
+	}
+}
+
+// TestWS_ClientDeclaredCapabilitiesStoredAndSurfaced asserts the #2547 declare
+// half: a client that DECLARES capabilities has them stored and surfaced
+// read-only on the fleet snapshot (FleetClanker), consistent with how
+// cli_backend/model/role are surfaced. No routing/gating is asserted.
+func TestWS_ClientDeclaredCapabilitiesStoredAndSurfaced(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+	token, cid := registerWSUser(t, s, "caps-user")
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{
+		Type:              "auth_response",
+		RegistrationToken: token,
+		CLIBackend:        "claude",
+		Capabilities: &ContributorCapabilities{
+			ContainerRuntime:     "podman",
+			OS:                   "linux",
+			Arch:                 "arm64",
+			AgentCLIVersion:      "1.2.3",
+			RelayProtocolVersion: "1.1",
+			CredentialType:       "app",
+		},
+	})
+	if authOK := readMsg(t, conn); authOK.Type != "auth_ok" {
+		t.Fatalf("expected auth_ok, got %s: %s", authOK.Type, authOK.Reason)
+	}
+
+	// Give the hub a moment to register the connection, then read the fleet snapshot.
+	deadline := time.Now().Add(2 * time.Second)
+	var fc *FleetClanker
+	for time.Now().Before(deadline) {
+		snap := s.contributeHub.FleetSnapshot()
+		for i := range snap.Clankers {
+			if snap.Clankers[i].ContributorID == cid {
+				fc = &snap.Clankers[i]
+				break
+			}
+		}
+		if fc != nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if fc == nil {
+		t.Fatal("clanker not found in fleet snapshot")
+	}
+	if fc.Capabilities == nil {
+		t.Fatal("declared capabilities were not surfaced on FleetClanker")
+	}
+	if fc.Capabilities.ContainerRuntime != "podman" ||
+		fc.Capabilities.OS != "linux" ||
+		fc.Capabilities.Arch != "arm64" ||
+		fc.Capabilities.AgentCLIVersion != "1.2.3" ||
+		fc.Capabilities.RelayProtocolVersion != "1.1" ||
+		fc.Capabilities.CredentialType != "app" {
+		t.Fatalf("surfaced capabilities mismatch: %+v", fc.Capabilities)
+	}
+}
+
+// TestWS_OmittedCapabilitiesUnaffected asserts backward compatibility: a client
+// that declares NO capabilities (an existing/unversioned relay) authenticates
+// exactly as before and is surfaced with nil capabilities — nothing changes.
+func TestWS_OmittedCapabilitiesUnaffected(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+	token, cid := registerWSUser(t, s, "legacy-user")
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+	// No Capabilities / ProtocolVersion — exactly today's wire.
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: token, CLIBackend: "claude"})
+	authOK := readMsg(t, conn)
+	if authOK.Type != "auth_ok" {
+		t.Fatalf("expected auth_ok, got %s: %s", authOK.Type, authOK.Reason)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var fc *FleetClanker
+	for time.Now().Before(deadline) {
+		snap := s.contributeHub.FleetSnapshot()
+		for i := range snap.Clankers {
+			if snap.Clankers[i].ContributorID == cid {
+				fc = &snap.Clankers[i]
+				break
+			}
+		}
+		if fc != nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if fc == nil {
+		t.Fatal("clanker not found in fleet snapshot")
+	}
+	if fc.Capabilities != nil {
+		t.Fatalf("a client that declared nothing must surface nil capabilities, got %+v", fc.Capabilities)
+	}
+}
+
+// TestWS_ProtocolVersionOnlyClientFoldsIn asserts a version-only client (sends a
+// top-level protocol_version but no capabilities object) still has its protocol
+// version stored + surfaced, so an intentionally-degrading newer client is
+// recorded. Additive.
+func TestWS_ProtocolVersionOnlyClientFoldsIn(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+	token, cid := registerWSUser(t, s, "veronly-user")
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: token, CLIBackend: "claude", ProtocolVersion: "9.9"})
+	if authOK := readMsg(t, conn); authOK.Type != "auth_ok" {
+		t.Fatalf("expected auth_ok, got %s: %s", authOK.Type, authOK.Reason)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var fc *FleetClanker
+	for time.Now().Before(deadline) {
+		snap := s.contributeHub.FleetSnapshot()
+		for i := range snap.Clankers {
+			if snap.Clankers[i].ContributorID == cid {
+				fc = &snap.Clankers[i]
+				break
+			}
+		}
+		if fc != nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if fc == nil || fc.Capabilities == nil {
+		t.Fatal("version-only client should surface capabilities carrying the protocol version")
+	}
+	if fc.Capabilities.RelayProtocolVersion != "9.9" {
+		t.Fatalf("relay_protocol_version: want 9.9, got %q", fc.Capabilities.RelayProtocolVersion)
+	}
+}
+
+// TestWS_UnknownMessageTypeIgnored asserts forward compatibility: an unknown
+// message type is silently ignored (dropped by the read-loop's default), so a
+// newer peer can introduce new message types without breaking an older peer.
+func TestWS_UnknownMessageTypeIgnored(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+	token, _ := registerWSUser(t, s, "future-user")
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: token, CLIBackend: "claude"})
+	if authOK := readMsg(t, conn); authOK.Type != "auth_ok" {
+		t.Fatalf("expected auth_ok, got %s", authOK.Type)
+	}
+
+	// Send a message type this server has never heard of. It must be ignored, not
+	// close the connection: a subsequent legitimate "ready" must still be served.
+	conn.WriteJSON(map[string]any{"type": "some_future_message_v99", "foo": "bar"})
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 99})
+
+	// The connection is still alive if the hub still counts us active.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if s.contributeHub.ActiveCount() == 1 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("connection dropped after an unknown message type — must be ignored (forward-compatible)")
+}
+
+// TestContributeStatus_CarriesSurfaceAndVersion asserts #2567 on the status
+// response: it now carries a surface discriminator plus the api/protocol version
+// (and a served SHA), while keeping every pre-existing field unchanged
+// (backward-compatible). Default (not hub-proxied) reports "hub".
+func TestContributeStatus_CarriesSurfaceAndVersion(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/status", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	// Pre-existing fields unchanged (backward-compatible).
+	if resp["hub"] != "online" {
+		t.Errorf("expected hub=online, got %v", resp["hub"])
+	}
+	// New additive discriminators.
+	if resp["surface"] != surfaceHub {
+		t.Errorf("expected surface=%q, got %v", surfaceHub, resp["surface"])
+	}
+	if resp["api_version"] != contributorProtocolVersion {
+		t.Errorf("expected api_version=%q, got %v", contributorProtocolVersion, resp["api_version"])
+	}
+	if _, ok := resp["served_sha"]; !ok {
+		t.Error("expected served_sha field to be present")
+	}
+	if got := w.Header().Get("X-Hive-Contribute-Protocol"); got != contributorProtocolVersion {
+		t.Errorf("expected X-Hive-Contribute-Protocol=%q, got %q", contributorProtocolVersion, got)
+	}
+}

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -90,7 +90,13 @@ type ContributorConnection struct {
 	// no-matching-work vs an enforced refusal) instead of an indistinguishable
 	// silence. Cleared when a task is actually assigned. Purely diagnostic.
 	lastIdleReason string
-	mu             sync.Mutex
+	// capabilities is the client-declared runtime posture from auth_response
+	// (#2547 declare half): container runtime, OS/arch, agent/relay versions,
+	// credential type. Nil when the client declared nothing (an unversioned
+	// client). Stored read-only and surfaced on FleetClanker; NEVER used to route
+	// or gate work.
+	capabilities *ContributorCapabilities
+	mu           sync.Mutex
 }
 
 type WSMessage struct {
@@ -119,14 +125,33 @@ type WSMessage struct {
 	// contributor-default.json), so shipping the policy to the client would be
 	// advisory-only and risk drift. Left as omitempty so it never appears on the
 	// wire until a concrete client contract exists. (kubestellar/hive#2393 item 8.)
-	Restrictions   json.RawMessage `json:"restrictions,omitempty"`
-	Role           string          `json:"role,omitempty"`
-	ContribLabels  []string        `json:"contributor_labels,omitempty"`
-	Status         string          `json:"status,omitempty"`
-	Result         string          `json:"result,omitempty"`
-	Summary        string          `json:"summary,omitempty"`
-	TmuxOutput     []string        `json:"tmux_output,omitempty"`
-	AcceptedModels []string        `json:"accepted_models,omitempty"`
+	Restrictions json.RawMessage `json:"restrictions,omitempty"`
+	// Capabilities is the OPTIONAL client-declared runtime posture a contributor
+	// relay may report in its auth_response (kubestellar/hive#2547, declare half).
+	// It is additive and purely advisory: a client that omits it authenticates
+	// and runs exactly as before, and the hub NEVER routes or gates work on it —
+	// it is only stored and surfaced read-only. Distinct from the RESERVED,
+	// server-side-only Restrictions field above: Capabilities flows client→server
+	// as an honest self-report, Restrictions is a reservation that stays empty.
+	Capabilities *ContributorCapabilities `json:"capabilities,omitempty"`
+	// ProtocolVersion is the contributor-protocol version. On auth_ok it carries
+	// the version this HUB speaks (kubestellar/hive#2567) so a client can learn
+	// the deployed protocol level without probing; additive, old clients ignore
+	// it. It is also accepted on auth_response as the client's own reported
+	// version (stored via Capabilities.RelayProtocolVersion).
+	ProtocolVersion string `json:"protocol_version,omitempty"`
+	// ServerCapabilities is the set of message types / features this hub supports
+	// (kubestellar/hive#2567), advertised on auth_ok so a client can adapt without
+	// probing (e.g. token_refresh, task_unavailable_reasons). Additive; old
+	// clients ignore the unknown field.
+	ServerCapabilities []string `json:"server_capabilities,omitempty"`
+	Role               string   `json:"role,omitempty"`
+	ContribLabels      []string `json:"contributor_labels,omitempty"`
+	Status             string   `json:"status,omitempty"`
+	Result             string   `json:"result,omitempty"`
+	Summary            string   `json:"summary,omitempty"`
+	TmuxOutput         []string `json:"tmux_output,omitempty"`
+	AcceptedModels     []string `json:"accepted_models,omitempty"`
 	// PRURL is the pull request the agent opened for this task, reported on
 	// task_complete. It is best-effort: the relay fills it when it can spot a
 	// PR link in the agent's output, and it is empty when the agent went idle
@@ -882,6 +907,12 @@ type FleetClanker struct {
 	// running. It NEVER contains the minted github_token — the token travels on the
 	// task_assign WSMessage separately and is not stored here. Empty when idle.
 	PromptPreview string `json:"prompt_preview,omitempty"`
+	// Capabilities is the client-declared runtime posture from the handshake
+	// (#2547 declare half): container runtime, OS/arch, agent/relay versions,
+	// credential type. Nil when the client declared none (unversioned client).
+	// Surfaced read-only exactly like CLIBackend/Model/Role so the Operations tab
+	// COULD display it; it is NEVER used to route or gate work.
+	Capabilities *ContributorCapabilities `json:"capabilities,omitempty"`
 }
 
 // FleetWorkItem is a read-only view of one in-flight task the fleet is working,
@@ -935,6 +966,12 @@ func (h *ContributeWSHub) FleetSnapshot() FleetSnapshot {
 			ConnectedAt:  c.connectedAt.UTC().Format(time.RFC3339),
 			LastActivity: c.lastPong.UTC().Format(time.RFC3339),
 			Stale:        time.Since(c.lastPong) > wsHeartbeatTimeout,
+		}
+		// #2547: surface the client-declared capabilities read-only (a copy so the
+		// snapshot never aliases live connection state). Nil for unversioned clients.
+		if c.capabilities != nil {
+			capsCopy := *c.capabilities
+			fc.Capabilities = &capsCopy
 		}
 		if c.profile != nil {
 			fc.ContributorID = c.profile.ContributorID
@@ -1163,14 +1200,34 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			}
 			_ = saveContributorProfile(profile)
 
+			// #2547 declare half: capture the client-declared capabilities, if any.
+			// A relay may report its runtime posture either as a nested
+			// "capabilities" object or (for a version-only client) just a top-level
+			// protocol_version; fold the latter in so it is surfaced consistently.
+			// Entirely optional — a client that sends neither leaves caps nil and is
+			// treated exactly as an unversioned client. Never routed/gated on.
+			var caps *ContributorCapabilities
+			declared := ContributorCapabilities{}
+			if msg.Capabilities != nil {
+				declared = *msg.Capabilities
+			}
+			if declared.RelayProtocolVersion == "" && msg.ProtocolVersion != "" {
+				declared.RelayProtocolVersion = msg.ProtocolVersion
+			}
+			if !declared.IsZero() {
+				c := declared
+				caps = &c
+			}
+
 			contributor = &ContributorConnection{
-				ws:          conn,
-				profile:     profile,
-				cliBackend:  msg.CLIBackend,
-				model:       msg.Model,
-				role:        msg.Role,
-				connectedAt: time.Now(),
-				lastPong:    time.Now(),
+				ws:           conn,
+				profile:      profile,
+				cliBackend:   msg.CLIBackend,
+				model:        msg.Model,
+				role:         msg.Role,
+				connectedAt:  time.Now(),
+				lastPong:     time.Now(),
+				capabilities: caps,
 			}
 
 			h.mu.Lock()
@@ -1198,6 +1255,11 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				TrustTier:     profile.TrustTier,
 				Permissions:   perms,
 				Role:          msg.Role,
+				// #2567: advertise the protocol version and the server capability
+				// set so a client can learn what this deployed hub supports without
+				// probing. Additive — an existing client ignores these unknown fields.
+				ProtocolVersion:    contributorProtocolVersion,
+				ServerCapabilities: serverCapabilities(),
 			}); err != nil {
 				h.logger.Warn("[contribute-ws] failed to send auth_ok", "username", profile.GitHubUsername, "error", err)
 				return


### PR DESCRIPTION
## Summary

Implements the **SAFE, ADDITIVE, backward-compatible** halves of two contributor-protocol issues. Everything here is additive only — **no routing, no gating, no breaking change**. A client that omits every new field behaves **exactly as today**.

## `Fixes #2547` — capability DECLARE half (routing deferred as the Gate half)

Only the **declare** half: a connected relay may **DECLARE** its runtime posture in the handshake, and the hub **STORES + SURFACES** it read-only.

- New **OPTIONAL** `capabilities` object on `auth_response` (client→server): `container_runtime` (docker/podman/none), `os`/`arch`, `agent_cli_version`, `relay_protocol_version`, `credential_type`. All omitempty — a client that declares none is unchanged.
- Hub **parses + stores** it on the connection and **exposes** it on `FleetClanker` / the fleet snapshot, consistent with how `cli_backend`/`model`/`role` are already surfaced (so the Operations tab *could* show it — no UI built here).
- **No routing/assignment** is done on any declared capability. Acting on the declaration (choosing work based on it) is the deferred **Gate** half and is deliberately out of scope. This PR does not close that half.

## `Fixes #2567` — protocol/API version + capability set + surface identifier (additive, backward-compatible)

- `auth_ok` (server→client) now advertises a **protocol version** (`protocol_version`) and a **server capability set** (`server_capabilities`: `token_refresh`, `task_unavailable_reasons`, `prompt_preview`, `capability_declare`) so a client can learn what the deployed hub supports **without probing**. Old clients ignore the unknown fields.
- `/api/contribute/status` now carries a **`surface`** discriminator (`"hub"` / `"spoke"`, derived from the existing `HubProxied` config), an **`api_version`**, and a **`served_sha`** (from the existing git-version var), plus an **`X-Hive-Contribute-Protocol`** response header. The Hub discovery front door and a selected spoke both answer this same handler and, until now, no field said which one replied — a wrong base URL returned 200 and looked valid. Now a wrong-base-URL response is **identifiable** (fails loudly) instead of silent.
- Only **ADD** fields to the status response — every pre-existing field (`hub`, `active_contributors`, `total_registered`, `actionable_items`) is unchanged.

## Forward/backward compatibility

- **Unknown message types are ignored** (already the read-loop default on both the hub and the relay) — a newer peer may add a message type and an older peer silently drops it. Documented in `contribute_protocol.go`. The new version/capability fields let a **newer client degrade intentionally** rather than reacting to silence.
- The RESERVED, server-side-only `Restrictions` field (#2393 item 8) is untouched — client-declared `Capabilities` is a separate, advisory client→server field.

## Relay

The shipped `bin/contributor-relay.sh` declares the cheap capabilities it can determine (runtime, os/arch, protocol version, credential type) and logs the hub's advertised protocol/capabilities. All optional; an older hub ignores the unknown fields.

## Constraints honored

- Additive + backward-compatible only; no routing, no gating, no breaking change.
- The only change in the hot `api_contribute.go` is the minimal additive field addition to the status response (+ a small `contributeSurface` helper); no other logic touched there.

## Tests

`go build` / `go vet` clean; full `pkg/dashboard` suite green; `node --check` on the relay clean. New coverage:

- a client declaring capabilities has them stored + surfaced (`FleetClanker`)
- a client omitting them is unaffected (nil, authenticates unchanged)
- a version-only client folds its protocol version in
- `auth_ok` carries version + capability set
- `/api/contribute/status` carries surface + api_version + served_sha + header
- an unknown message type is ignored (old-client / forward compat)