### PR TITLE
fix(contribute): resilient Live Activity rail + correct admission label-filter binding

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -1501,10 +1501,22 @@ async function adminSaveHub(patch,okMsg){
   }catch(e){toast('Save failed: '+(e&&e.message||'network error'),false);return false;}
 }
 
-function renderAdminFilter(fieldId,label,noun,modeKey,listKey){
+// renderAdminFilter renders one admission filter (Titles / Authors / Labels). The
+// CANONICAL list field is contribute_deny_<kind> — despite the "deny" in the name it
+// holds the filter's list in BOTH modes (the mode decides allow vs deny; see
+// config.go: the *DenyTitles/*DenyAuthors/*DenyLabels fields hold the LIST regardless
+// of mode, and the backend filter — LabelsFilterPasses/FilterPasses — reads ONLY that
+// field). So we bind to contribute_deny_<kind> in every mode. Hardcoding a mismatch —
+// an Allow-mode filter whose tags land in a field the backend never reads — was the
+// empty-queue bug: allow-mode ran against an empty effective list and admitted
+// NOTHING. kind is the plural noun ("titles"/"authors"/"labels").
+function adminFilterListKey(kind){return 'contribute_deny_'+kind;}
+function renderAdminFilter(fieldId,label,noun,modeKey,kind){
   var el=document.getElementById(fieldId);
   if(!el||!adminHub)return;
   var mode=(adminHub[modeKey]==='allow')?'allow':'deny';
+  // Bind to the CANONICAL list field the backend actually reads, in every mode.
+  var listKey=adminFilterListKey(kind);
   var list=adminHub[listKey]||[];
   var chips=list.map(function(v){
     return '<span class="admin-chip">'+esc(v)+'<span class="x" data-list="'+listKey+'" data-val="'+esc(v)+'">&times;</span></span>';
@@ -1535,9 +1547,9 @@ function renderAdminControls(){
   document.getElementById('admin-skip-switch').classList.toggle('on',!!adminHub.contribute_skip_assigned_to_others);
   document.getElementById('admin-reject-switch').classList.toggle('on',!!adminHub.contribute_reject_unknown_models);
   // Filters (mirror Governor Hub: titles/authors/labels + modes, allow-models).
-  renderAdminFilter('admin-filter-titles','Titles','title','contribute_titles_mode','contribute_deny_titles');
-  renderAdminFilter('admin-filter-authors','Authors','author','contribute_authors_mode','contribute_deny_authors');
-  renderAdminFilter('admin-filter-labels','Labels','label','contribute_labels_mode','contribute_deny_labels');
+  renderAdminFilter('admin-filter-titles','Titles','title','contribute_titles_mode','titles');
+  renderAdminFilter('admin-filter-authors','Authors','author','contribute_authors_mode','authors');
+  renderAdminFilter('admin-filter-labels','Labels','label','contribute_labels_mode','labels');
   renderAdminModels();
   var save=document.getElementById('admin-save-btn');
   if(save)save.disabled=!adminDirty;
@@ -1584,6 +1596,12 @@ document.getElementById('admin-add-model').addEventListener('click',function(){
 
 document.getElementById('admin-save-btn').addEventListener('click',function(){
   if(!adminDirty||!adminHub)return;
+  // Persist the mode + the CANONICAL list field (contribute_deny_*) for each filter.
+  // The mode decides allow vs deny; the list lives in the deny-named field in BOTH
+  // modes (that is the only field the backend filter reads). Also clear the legacy
+  // allow_labels field so a stale migration remnant can never mask the real list
+  // (the empty-queue bug: an allow-mode filter with a lingering allow_labels value
+  // that the backend never reads). We send it explicitly emptied.
   var patch={
     contribute_titles_mode:adminHub.contribute_titles_mode||'deny',
     contribute_authors_mode:adminHub.contribute_authors_mode||'deny',
@@ -1591,6 +1609,7 @@ document.getElementById('admin-save-btn').addEventListener('click',function(){
     contribute_deny_titles:adminHub.contribute_deny_titles||[],
     contribute_deny_authors:adminHub.contribute_deny_authors||[],
     contribute_deny_labels:adminHub.contribute_deny_labels||[],
+    contribute_allow_labels:[],
     contribute_allow_models:adminHub.contribute_allow_models||[]
   };
   adminSaveHub(patch,'Admission filters saved').then(function(ok){if(ok){adminDirty=false;renderAdminControls();}});
@@ -1784,7 +1803,11 @@ function renderPolicy(p){
     ['Contribute queue',p.suspended?'<span class="pill pill-blocked">suspended</span>':'<span class="pill pill-passed">active</span>'],
     ['Title filter',esc(p.titles_mode||'deny')+': '+list(p.deny_titles)],
     ['Author filter',esc(p.authors_mode||'deny')+': '+list(p.deny_authors)],
-    ['Label filter',esc(p.labels_mode||'deny')+': '+list(p.labels_mode==='allow'?p.allow_labels:p.deny_labels)],
+    /* The canonical label list lives in deny_labels in BOTH modes (the mode name is
+       legacy; the backend filter reads deny_labels regardless of mode). Reading
+       allow_labels in allow-mode showed an empty list even when a real allow-list
+       was configured (the source of the "Allow: (nothing)" + empty-queue confusion). */
+    ['Label filter',esc(p.labels_mode||'deny')+': '+list(p.deny_labels)],
     ['Model allowlist',(p.reject_unknown_models?'strict &middot; ':'')+list(p.allow_models)],
     ['Skip assigned-to-others',p.skip_assigned_to_others?'yes':'no'],
     ['Disabled tiers',list(p.disabled_tiers)],
@@ -2094,21 +2117,79 @@ function ccTravel(e){
   setTimeout(ccRenderQueue,480);
 }
 
+// ── Shared activity store (resilient Live Activity rail) ───────────────────────
+// The rail used to depend SOLELY on the SSE stream, which returns nothing on hosted
+// spokes — so it sat on "Watching the hive…" forever even though /api/contribute/
+// activity (the source Onboarding's Live Activity uses) was full. We now seed + poll
+// the rail from that reliable endpoint and layer SSE on top for liveness, via a
+// shared deduped store. ccActivity is chronological (oldest→newest); ccActivitySeen
+// keys events by timestamp+username+action+task so an event arriving via BOTH poll
+// and SSE is counted once.
+var ccActivity=[];
+var ccActivitySeen={};
+var ccActivityCap=200;
+var ccActivityPollTimer=null;
+var ccSSEDelivered=false;
+function ccActivityKey(e){return (e.timestamp||'')+'|'+(e.username||'')+'|'+(e.action||'')+'|'+(e.task||'');}
+function ccIngestActivity(e){
+  if(!e||!e.action)return false;
+  var k=ccActivityKey(e);
+  if(ccActivitySeen[k])return false;
+  ccActivitySeen[k]=1;
+  ccActivity.push(e);
+  if(ccActivity.length>ccActivityCap){
+    var drop=ccActivity.splice(0,ccActivity.length-ccActivityCap);
+    for(var i=0;i<drop.length;i++)delete ccActivitySeen[ccActivityKey(drop[i])];
+  }
+  return true;
+}
+// Rebuild the rail scrollback from the shared store (newest ccLogCap entries),
+// narrated via the same ccNarrate live events use so the format matches.
+function ccRebuildLogFromActivity(){
+  var src=ccActivity.slice(Math.max(0,ccActivity.length-ccLogCap));
+  ccLogLines=src.map(ccNarrate);
+  ccRenderLog();
+}
+// Poll the reliable activity endpoint, ingest new entries, refresh the rail. This is
+// the resilience layer: the rail is NEVER blank when the endpoint has data, whether
+// or not SSE delivers. Reschedules while the Operations tab is open.
+function ccPollActivity(){
+  fetch('/api/contribute/activity').then(function(r){return r.json();}).then(function(d){
+    var list=(d&&d.activity)||[];
+    var added=false;
+    for(var i=0;i<list.length;i++){if(ccIngestActivity(list[i]))added=true;}
+    if(added)ccRebuildLogFromActivity();
+    else if(!ccLogLines.length&&ccActivity.length)ccRebuildLogFromActivity();
+    // Reflect REAL connectivity: if SSE has never delivered a frame, we are running
+    // on the polling fallback — say so rather than sitting on "connecting" forever.
+    if(!ccSSEDelivered)ccSetLive('poll');
+  }).catch(function(){/* transient; next poll self-heals */});
+  var tab=document.getElementById('tab-ops');
+  if(tab&&tab.classList.contains('active'))ccActivityPollTimer=setTimeout(ccPollActivity,6000);
+}
+
 // ── Consume one activity event from the stream ─────────────────────────────────
 function ccOnActivity(e){
   if(!e||!e.action)return;
-  ccPushLog(e);
-  ccMaybeAchieve(e);
-  if(e.action==='picked up')ccTravel(e);
+  ccSSEDelivered=true;
+  // Route SSE events through the SAME store so they dedupe against the poll and the
+  // rail stays consistent. Only a genuinely-new event narrates/animates.
+  if(ccIngestActivity(e)){
+    ccRebuildLogFromActivity();
+    ccMaybeAchieve(e);
+    if(e.action==='picked up')ccTravel(e);
+  }
 }
 
 // ── SSE lifecycle with graceful fallback ───────────────────────────────────────
 function ccHydrate(payload){
   if(payload.queue){ccQueue=payload.queue.slice();ccRenderQueue();}
   if(payload.replay&&payload.replay.length){
-    payload.replay.forEach(function(e){ccLogLines.push(ccNarrate(e));});
-    if(ccLogLines.length>ccLogCap)ccLogLines=ccLogLines.slice(ccLogLines.length-ccLogCap);
-    ccRenderLog();
+    // Route the SSE replay through the SHARED store so it dedupes against the poll
+    // seed (no double-count of events that arrive via both paths).
+    var added=false;
+    payload.replay.forEach(function(e){if(ccIngestActivity(e))added=true;});
+    if(added)ccRebuildLogFromActivity();
   }
 }
 function ccQueuePoll(){ // fallback when SSE is down: refresh queue only
@@ -2120,6 +2201,11 @@ function ccQueuePoll(){ // fallback when SSE is down: refresh queue only
 function ccStopFallback(){if(ccQueuePollTimer){clearTimeout(ccQueuePollTimer);ccQueuePollTimer=null;}}
 function ccStart(){
   if(ccStarted)return;ccStarted=true;
+  // Seed + poll the Live Activity rail from the RELIABLE polling endpoint (the same
+  // source Onboarding uses) so the rail shows the backlog immediately and stays
+  // current even when the SSE stream delivers nothing (hosted spokes). SSE, when it
+  // works, layers live updates on top via the shared, deduped activity store.
+  try{ccPollActivity();}catch(e){console.error('activity poll init failed',e);}
   if(!('EventSource' in window)){ccSetLive('poll');ccQueuePoll();return;}
   function connect(){
     ccSetLive('connecting');

--- a/v2/pkg/dashboard/contribute_ops_rail_polish_test.go
+++ b/v2/pkg/dashboard/contribute_ops_rail_polish_test.go
@@ -68,16 +68,15 @@ func TestOpsRailHeadingIsLiveActivity(t *testing.T) {
 	}
 }
 
-// TestOpsRailRendersHelloReplay proves the rail's SSE hello handler
-// (ccHydrate) renders hello.replay entries into the log immediately, via the
-// same narration path (ccNarrate) new live events use, so the rail is never
-// blank on load when the hub has buffered activity. Runtime behavior of the
-// inline script is out of reach for a Go test (see TestOpsFleetHydrationIsResilient
-// for the established pattern); `node --check` on the extracted script covers
-// syntax/runtime correctness. This test pins the wiring: ccHydrate consumes
-// payload.replay, feeds each entry through ccNarrate into ccLogLines, and
-// re-renders via ccRenderLog — the same function that also renders live
-// ccPushLog events, so the format matches.
+// TestOpsRailRendersHelloReplay proves the rail's SSE hello handler (ccHydrate)
+// still feeds hello.replay into the rail log — now routed through the SHARED,
+// deduped activity store (ccIngestActivity) and rendered via the same narration
+// path (ccNarrate) + ccRenderLog. The rail's resilience (seed + poll from the
+// reliable /api/contribute/activity endpoint) is asserted separately in
+// TestOpsRailResilientFromActivityPoll; here we pin that the SSE hello path is
+// still wired and consistent with the shared store. Runtime behavior of the inline
+// script is out of reach for a Go test; node --check on the extracted script covers
+// syntax/runtime correctness.
 func TestOpsRailRendersHelloReplay(t *testing.T) {
 	body := renderContributePage(t)
 
@@ -92,13 +91,23 @@ func TestOpsRailRendersHelloReplay(t *testing.T) {
 	hydrateBody := body[hydrateStart : hydrateStart+hydrateEnd]
 
 	for _, want := range []string{
-		"payload.replay",  // reads the hello frame's ring-buffer field
-		"ccNarrate(e)",    // same narration fn live events use (format parity)
-		"ccLogLines.push", // feeds the rail's own log model, not a separate one
-		"ccRenderLog()",   // re-renders the rail log immediately (not deferred to the next live event)
+		"payload.replay",      // reads the hello frame's ring-buffer field
+		"ccIngestActivity(e)", // routes each replay entry through the shared, deduped store
 	} {
 		if !strings.Contains(hydrateBody, want) {
-			t.Errorf("ccHydrate does not replay hello.replay into the rail log: missing %q", want)
+			t.Errorf("ccHydrate does not replay hello.replay into the shared store: missing %q", want)
+		}
+	}
+	// The shared rebuild path must narrate via ccNarrate and re-render via ccRenderLog
+	// (format parity with live events), so the rail log is populated immediately.
+	rebuildStart := strings.Index(body, "function ccRebuildLogFromActivity(){")
+	if rebuildStart < 0 {
+		t.Fatal("ccRebuildLogFromActivity is missing — the shared rail rebuild path was removed")
+	}
+	rebuildBody := body[rebuildStart : rebuildStart+strings.Index(body[rebuildStart:], "\n}")]
+	for _, want := range []string{"ccNarrate", "ccRenderLog()"} {
+		if !strings.Contains(rebuildBody, want) {
+			t.Errorf("ccRebuildLogFromActivity does not narrate/render the rail log: missing %q", want)
 		}
 	}
 
@@ -115,6 +124,46 @@ func TestOpsRailRendersHelloReplay(t *testing.T) {
 	// the rail's only possible state).
 	if !strings.Contains(body, "if(!ccLogLines.length){el.innerHTML='<div class=\"ops-empty\">Watching the hive&hellip;</div>';return;}") {
 		t.Error("ccRenderLog no longer gates the empty state on ccLogLines being genuinely empty")
+	}
+}
+
+// TestOpsRailResilientFromActivityPoll proves the fix for the perpetually-empty
+// rail: it is seeded + kept current from the RELIABLE /api/contribute/activity
+// polling endpoint (the same source Onboarding's Live Activity uses), NOT solely
+// from the SSE stream which returns nothing on hosted spokes. So the rail shows the
+// backlog even when SSE never delivers, and it dedupes events that arrive via both.
+func TestOpsRailResilientFromActivityPoll(t *testing.T) {
+	body := renderContributePage(t)
+
+	// ccStart must kick off the activity poll (the seed + resilience layer).
+	if !strings.Contains(body, "ccPollActivity()") {
+		t.Error("ccStart does not seed/poll the rail from /api/contribute/activity — the rail can go blank when SSE is silent")
+	}
+	// The poll must fetch the reliable activity endpoint.
+	pollStart := strings.Index(body, "function ccPollActivity(){")
+	if pollStart < 0 {
+		t.Fatal("ccPollActivity is missing — the rail's polling resilience was removed")
+	}
+	pollBody := body[pollStart : pollStart+strings.Index(body[pollStart:], "\n}")]
+	if !strings.Contains(pollBody, "/api/contribute/activity") {
+		t.Error("ccPollActivity does not fetch /api/contribute/activity (the reliable source)")
+	}
+	// Dedupe: an event arriving via BOTH poll and SSE must be counted once. The
+	// store keys events by timestamp+username+action+task.
+	keyStart := strings.Index(body, "function ccActivityKey(e){")
+	if keyStart < 0 {
+		t.Fatal("ccActivityKey (dedupe key) is missing")
+	}
+	keyBody := body[keyStart : keyStart+strings.Index(body[keyStart:], "\n}")]
+	for _, want := range []string{"e.timestamp", "e.username", "e.action", "e.task"} {
+		if !strings.Contains(keyBody, want) {
+			t.Errorf("ccActivityKey does not dedupe on %q — double-counting is possible", want)
+		}
+	}
+	// SSE events must route through the SAME shared store (so they dedupe against the
+	// poll), not into a separate rail-only path.
+	if !strings.Contains(body, "ccSSEDelivered=true") || !strings.Contains(body, "if(ccIngestActivity(e)){") {
+		t.Error("SSE onActivity does not route through the shared deduped store")
 	}
 }
 

--- a/v2/pkg/dashboard/contribute_urgent_fixes_test.go
+++ b/v2/pkg/dashboard/contribute_urgent_fixes_test.go
@@ -1,0 +1,158 @@
+package dashboard
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// ── Two urgent live-hive fixes: empty Ready-queue (label-filter binding) and the
+//    perpetually-empty Live Activity rail. ──────────────────────────────────────
+
+// TestLabelFilterBindsCanonicalField proves the admission filter tag list binds to
+// the CANONICAL contribute_deny_<kind> field in BOTH modes — the only field the
+// backend filter reads. Binding an allow-mode filter elsewhere admitted nothing
+// (empty queue). Also proves the policy DISPLAY reads deny_labels in both modes.
+func TestLabelFilterBindsCanonicalField(t *testing.T) {
+	body := renderContributePage(t)
+
+	if !strings.Contains(body, "function adminFilterListKey(kind){return 'contribute_deny_'+kind;}") {
+		t.Error("admin filter does not bind to the canonical contribute_deny_<kind> field")
+	}
+	for _, kind := range []string{"titles", "authors", "labels"} {
+		if !strings.Contains(body, "renderAdminFilter('admin-filter-"+kind+"','") {
+			t.Errorf("filter for kind %q not rendered", kind)
+		}
+		if !strings.Contains(body, "','"+kind+"');") {
+			t.Errorf("filter %q not bound by kind (per-mode canonical binding)", kind)
+		}
+	}
+	// The policy display reads deny_labels in BOTH modes (not allow_labels in allow-mode).
+	if strings.Contains(body, "p.labels_mode==='allow'?p.allow_labels:p.deny_labels") {
+		t.Error("policy display still reads allow_labels in allow-mode (empty on the live hive)")
+	}
+	if !strings.Contains(body, "['Label filter',esc(p.labels_mode||'deny')+': '+list(p.deny_labels)]") {
+		t.Error("policy display does not read the canonical deny_labels list")
+	}
+	// The save patch clears the stale allow_labels remnant.
+	if !strings.Contains(body, "contribute_allow_labels:[]") {
+		t.Error("save patch does not clear the stale allow_labels field")
+	}
+}
+
+// TestLabelFilterAllowModeAdmitsMatching proves the end-to-end behavior: an Allow-mode
+// label filter with `clanker-queue` admits ONLY clanker-queue-labeled issues (the live
+// hive's intended config), and an EMPTY allow-list admits ALL (the footgun-safe
+// default the backend already implements).
+func TestLabelFilterAllowModeAdmitsMatching(t *testing.T) {
+	s, deps := apiServer(t)
+
+	s.statusMu.Lock()
+	s.status = &StatusPayload{Repos: []FrontendRepo{{
+		Name: "acme/repo", Full: "acme/repo",
+		ActionableIssues: []any{
+			map[string]any{"number": float64(1), "title": "queued", "labels": []any{"clanker-queue"}},
+			map[string]any{"number": float64(2), "title": "other", "labels": []any{"docs"}},
+		},
+	}}}
+	s.statusMu.Unlock()
+
+	// Empty allow-list = admit all (footgun-safe).
+	deps.Config.Hub.ContributeLabelsMode = "allow"
+	deps.Config.Hub.ContributeDenyLabels = nil
+	if q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit); len(q) != 2 {
+		t.Fatalf("allow-mode + empty list should admit ALL, got %d", len(q))
+	}
+
+	// Allow + clanker-queue admits only #1.
+	deps.Config.Hub.ContributeDenyLabels = []string{"clanker-queue"}
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 1 || q[0].Number != 1 {
+		t.Fatalf("allow-mode clanker-queue should admit ONLY #1, got %+v", q)
+	}
+}
+
+// TestLabelFilterSaveRoundTripsToDenyField proves the UI Save PUTs the list into the
+// CANONICAL deny_labels field (backend-read) and clears the stale allow_labels — so
+// Allow + a label actually persists and admits.
+func TestLabelFilterSaveRoundTripsToDenyField(t *testing.T) {
+	s, deps := apiServer(t)
+	payload := map[string]any{
+		"contribute_labels_mode":  "allow",
+		"contribute_deny_labels":  []string{"clanker-queue"},
+		"contribute_allow_labels": []string{},
+	}
+	rec := doPut(s, "/api/config/governor/hub", payload)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT governor/hub: got %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	if deps.Config.Hub.ContributeLabelsMode != "allow" {
+		t.Errorf("labels mode = %q, want allow", deps.Config.Hub.ContributeLabelsMode)
+	}
+	if len(deps.Config.Hub.ContributeDenyLabels) != 1 || deps.Config.Hub.ContributeDenyLabels[0] != "clanker-queue" {
+		t.Errorf("canonical deny_labels = %v, want [clanker-queue]", deps.Config.Hub.ContributeDenyLabels)
+	}
+	if len(deps.Config.Hub.ContributeAllowLabels) != 0 {
+		t.Errorf("stale allow_labels should be cleared, got %v", deps.Config.Hub.ContributeAllowLabels)
+	}
+}
+
+// TestLiveActivityRailSeedsFromActivityPoll proves the rail is seeded + kept current
+// from the RELIABLE /api/contribute/activity endpoint (the source Onboarding uses),
+// not solely from the SSE stream which returns nothing on hosted spokes — so the rail
+// shows the backlog even when SSE never delivers, deduping cross-source events.
+func TestLiveActivityRailSeedsFromActivityPoll(t *testing.T) {
+	body := renderContributePage(t)
+
+	// ccStart seeds/polls the rail from the activity endpoint.
+	if !strings.Contains(body, "ccPollActivity()") {
+		t.Error("ccStart does not seed/poll the rail from /api/contribute/activity")
+	}
+	pollStart := strings.Index(body, "function ccPollActivity(){")
+	if pollStart < 0 {
+		t.Fatal("ccPollActivity missing")
+	}
+	pollBody := body[pollStart : pollStart+strings.Index(body[pollStart:], "\n}")]
+	if !strings.Contains(pollBody, "/api/contribute/activity") {
+		t.Error("ccPollActivity does not fetch the reliable activity endpoint")
+	}
+	// The rail rebuild narrates via ccNarrate + renders via ccRenderLog (format parity).
+	rb := body[strings.Index(body, "function ccRebuildLogFromActivity(){"):]
+	rb = rb[:strings.Index(rb, "\n}")]
+	if !strings.Contains(rb, "ccNarrate") || !strings.Contains(rb, "ccRenderLog()") {
+		t.Error("rail rebuild does not use ccNarrate/ccRenderLog")
+	}
+	// Dedupe key covers timestamp+username+action+task.
+	keyBody := body[strings.Index(body, "function ccActivityKey(e){"):]
+	keyBody = keyBody[:strings.Index(keyBody, "\n}")]
+	for _, want := range []string{"e.timestamp", "e.username", "e.action", "e.task"} {
+		if !strings.Contains(keyBody, want) {
+			t.Errorf("ccActivityKey does not dedupe on %q", want)
+		}
+	}
+	// SSE routes through the SAME shared store (dedupe against poll).
+	if !strings.Contains(body, "ccSSEDelivered=true") || !strings.Contains(body, "if(ccIngestActivity(e)){") {
+		t.Error("SSE onActivity does not route through the shared deduped store")
+	}
+	// The empty state stays reachable only for genuinely-zero activity.
+	if !strings.Contains(body, "if(!ccLogLines.length){el.innerHTML='<div class=\"ops-empty\">Watching the hive&hellip;</div>';return;}") {
+		t.Error("the genuine empty-state render was lost")
+	}
+	// The live pill reflects real connectivity: polling when SSE hasn't delivered.
+	if !strings.Contains(body, "if(!ccSSEDelivered)ccSetLive('poll');") {
+		t.Error("live pill does not reflect the polling fallback state")
+	}
+}
+
+// TestLiveActivityRailBackendServesData proves /api/contribute/activity (the rail's
+// reliable source) returns the recorded activity — the data the rail seeds from.
+func TestLiveActivityRailBackendServesData(t *testing.T) {
+	s, _ := apiServer(t)
+	rec := doGet(s, "/api/contribute/activity")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET activity: got %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "activity") {
+		t.Errorf("activity endpoint response missing the activity array: %s", rec.Body.String())
+	}
+}


### PR DESCRIPTION
Two urgent fixes for the most-visible breakages on the live hive: the empty **Live Activity** rail and the empty **Ready-work queue**.

## 1. Live Activity rail perpetually empty ("Watching the hive…")
The Operations rail depended **solely** on the SSE stream `/api/contribute/events`, which returns **zero bytes** on hosted spokes — while `/api/contribute/activity` (the same source the Onboarding "Live Activity" feed uses successfully) is full.

**Fix:** on Operations-tab load, **seed + poll the rail from `/api/contribute/activity`**, narrated through the existing `ccNarrate` / `ccRenderLog`. SSE, when it works, layers live updates on top via a **shared deduped activity store** (events keyed by `timestamp+username+action+task`, so an event arriving via both poll and SSE is counted once). The `live` pill now reflects real connectivity (shows *polling* when SSE hasn't delivered). The genuine "Watching the hive…" empty state stays reachable only when the endpoint truly returns zero events.

## 2. Ready-queue empty — admission label-filter bound to the wrong field
The admission Labels filter persisted its Allow-mode tags to a field the backend never reads, so Allow + `clanker-queue` admitted **nothing** → empty queue.

**Fix:** bind Titles / Authors / Labels to the **canonical `contribute_deny_<kind>` list field in every mode**. Note on the codebase: despite the `deny` in the name, that field holds the filter's list **regardless of mode** (the mode decides allow vs deny), and it is the **only** field the backend filter (`LabelsFilterPasses` / `FilterPasses`) reads — `contribute_allow_labels` is never read by the filter (it exists only for a one-time migration). So the correct fix is to bind to the canonical field per-mode and **clear the stale `allow_labels` remnant** on save; the policy display now reads `deny_labels` in both modes too. Allow-mode + an empty list already means **"admit all"** in the backend (the footgun-safe default), so no config change was needed there. Result: Allow + `clanker-queue` admits the clanker-queue-labeled issues again.

## Tests
- Label filter binds/round-trips to the canonical field and admits the right issues (including empty-allow = admit-all).
- The rail seeds from the activity poll (not SSE-only), dedupes cross-source events, keeps the genuine empty state, and drives the live pill.
- `go build` / `go vet` / `node --check` on the extracted page script all pass.

Two follow-up PRs will carry the remaining Operations bug fixes (My-work Done filter, me-card tier-badge overlap, highlight-me row, Repos + Tier-limits Management mirror, `Fixes #2601` bot-filter) and then the additive features (Apple-Music playlist queue controls, Opportunistic Work `#2592`, file-an-issue `#2594`, hive-settings/quota `#2595`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
