### PR TITLE
fix(contribute): stop Operations-tab JS init-order crash (empty Live Activity rail + Done-filter throw)

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -1614,6 +1614,19 @@ update();  // initial paint: copy block + branded UI in sync from first load
 </footer>
 <script>
 (function(){
+// ── Init-order hoist (fixes the #2603/#2604/#2606 merge-interleaving regression) ──
+// These were declared FAR below their first use. var hoists the name but not the
+// value, so ADMIN_TIER_ORDER.map / ccActivitySeen[k] / ccActivity.length ran against
+// undefined and threw. Declaring+initializing them here — before any function that
+// uses them can run — makes the ordering explicit and regression-proof.
+var ADMIN_TIER_ORDER=['newcomer','contributor','trusted','advisor'];
+var ccActivity=[];       // chronological (oldest→newest) activity backlog for the rail
+var ccActivitySeen={};   // dedupe set keyed by ccActivityKey(); shared by poll + SSE
+// Null-guarded addEventListener: a missing element (not yet parsed, or a markup
+// change) must never throw at script-eval time — an uncaught throw here aborts the
+// rest of this inline block and un-initializes everything below it (the exact crash
+// this file is fixing). Returns silently if the id is absent.
+function onEl(id,ev,fn,opts){var el=document.getElementById(id);if(el)el.addEventListener(ev,fn,opts);}
 // Tab switching for the /contribute page. Additive: leaves onboarding intact.
 var tabs=document.querySelectorAll('.page-tab');
 var panels=document.querySelectorAll('.tab-panel');
@@ -2112,8 +2125,22 @@ function adminConfirm(title,msg,okLabel,cb){
   _confirmCb=cb;
   document.getElementById('admin-confirm-back').classList.add('show');
 }
-document.getElementById('admin-confirm-cancel').addEventListener('click',function(){document.getElementById('admin-confirm-back').classList.remove('show');_confirmCb=null;});
-document.getElementById('admin-confirm-ok').addEventListener('click',function(){var cb=_confirmCb;document.getElementById('admin-confirm-back').classList.remove('show');_confirmCb=null;if(cb)cb();});
+// The confirm-modal buttons (#admin-confirm-cancel / #admin-confirm-ok) are
+// emitted AFTER this <script> block closes (see #admin-confirm-back near the end
+// of the page), so at script-eval time getElementById returns null here. The old
+// code called .addEventListener on that null directly, which THREW and ABORTED
+// the rest of this inline block — which is where ADMIN_TIER_ORDER, ccActivity and
+// ccActivitySeen are initialized — leaving them undefined for the whole page
+// (empty Live Activity rail + Done-filter throwing every poll). Wire the buttons
+// once the DOM has fully parsed (so the elements actually exist), and null-guard
+// besides, so this block can never again abort mid-way.
+function _wireConfirmModal(){
+  var cancel=document.getElementById('admin-confirm-cancel');
+  if(cancel)cancel.addEventListener('click',function(){var b=document.getElementById('admin-confirm-back');if(b)b.classList.remove('show');_confirmCb=null;});
+  var ok=document.getElementById('admin-confirm-ok');
+  if(ok)ok.addEventListener('click',function(){var cb=_confirmCb;var b=document.getElementById('admin-confirm-back');if(b)b.classList.remove('show');_confirmCb=null;if(cb)cb();});
+}
+if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',_wireConfirmModal);else _wireConfirmModal();
 
 // Persist a subset of Config.Hub.* through the SAME endpoint the Governor Hub
 // dialog uses. Only the passed keys are sent; the handler ignores omitted fields.
@@ -2173,7 +2200,8 @@ function renderAdminModels(){
 // disabled_repos list (the field the backend + Governor Hub both use). available_
 // repos comes from the config GET (the live repo set). Owner/RW only (gated by the
 // enclosing admin controls); persists via the same PUT as the other filters.
-var ADMIN_TIER_ORDER=['newcomer','contributor','trusted','advisor'];
+// NOTE: ADMIN_TIER_ORDER is declared+initialized at the top of this IIFE (init-order
+// hoist) so renderAdminTierLimits() can never see it undefined.
 function renderAdminRepos(){
   var el=document.getElementById('admin-repos');
   if(!el||!adminHub)return;
@@ -2244,7 +2272,7 @@ function bindImmediateToggle(id){
 
 // Delegated handlers for the filter editors (mode switch, add, remove) — mark
 // dirty so nothing is sent until the operator clicks Save.
-document.getElementById('ops-admin').addEventListener('click',function(e){
+onEl('ops-admin','click',function(e){
   var t=e.target;
   var seg=t.closest?t.closest('.admin-modeseg button'):null;
   if(seg){var mk=seg.parentNode.getAttribute('data-mode-key');adminHub[mk]=seg.getAttribute('data-mode');adminDirty=true;renderAdminControls();return;}
@@ -2279,7 +2307,7 @@ document.getElementById('ops-admin').addEventListener('click',function(e){
 // Tier rate-limit numeric edits: update tier_limits[tier][field] and mark dirty. A
 // separate 'input' handler (numbers change on input, not click). Non-negative ints;
 // blank/NaN coerces to 0 (== unlimited), matching the backend's "<=0 = unlimited".
-document.getElementById('ops-admin').addEventListener('input',function(e){
+onEl('ops-admin','input',function(e){
   var t=e.target;
   if(!t.getAttribute||t.getAttribute('data-tier-field')===null||!adminHub)return;
   var tier=t.getAttribute('data-tier'),field=t.getAttribute('data-tier-field');
@@ -2289,12 +2317,12 @@ document.getElementById('ops-admin').addEventListener('input',function(e){
   var save=document.getElementById('admin-save-btn');if(save)save.disabled=false;
 });
 
-document.getElementById('admin-add-model').addEventListener('click',function(){
+onEl('admin-add-model','click',function(){
   var inp=document.getElementById('admin-allow-model-input');
   if(inp&&inp.value.trim()){adminHub.contribute_allow_models=(adminHub.contribute_allow_models||[]).concat([inp.value.trim()]);inp.value='';adminDirty=true;renderAdminControls();}
 });
 
-document.getElementById('admin-save-btn').addEventListener('click',function(){
+onEl('admin-save-btn','click',function(){
   if(!adminDirty||!adminHub)return;
   // Persist the mode + the CANONICAL list field (contribute_deny_*) for each filter.
   // The mode decides allow vs deny; the list lives in the deny-named field in BOTH
@@ -2322,7 +2350,7 @@ document.getElementById('admin-save-btn').addEventListener('click',function(){
 
 // Per-contributor actions (delegated on the clanker list). Each calls an EXISTING
 // endpoint; destructive ones go through the themed confirm.
-document.getElementById('clanker-list').addEventListener('change',function(e){
+onEl('clanker-list','change',function(e){
   var sel=e.target;
   if(!adminEnabled||sel.getAttribute('data-role')!=='tier')return;
   var cid=sel.getAttribute('data-cid'),tier=sel.value;
@@ -2331,7 +2359,7 @@ document.getElementById('clanker-list').addEventListener('change',function(e){
     .then(function(x){if(x.ok){toast('Trust tier set to '+tier,true);opsPoll();}else{toast((x.d&&x.d.error)||'Failed to set tier',false);}})
     .catch(function(){toast('Failed to set tier',false);});
 });
-document.getElementById('clanker-list').addEventListener('click',function(e){
+onEl('clanker-list','click',function(e){
   var b=e.target;
   if(!adminEnabled||b.tagName!=='BUTTON')return;
   var role=b.getAttribute('data-role');
@@ -2984,8 +3012,9 @@ function ccTravel(e){
 // shared deduped store. ccActivity is chronological (oldest→newest); ccActivitySeen
 // keys events by timestamp+username+action+task so an event arriving via BOTH poll
 // and SSE is counted once.
-var ccActivity=[];
-var ccActivitySeen={};
+// NOTE: ccActivity + ccActivitySeen are declared+initialized at the top of this
+// IIFE (init-order hoist) so ccIngestActivity()/ccCompletedWorkItems() — which run
+// via opsPoll long before this line — can never see them undefined.
 var ccActivityCap=200;
 var ccActivityPollTimer=null;
 var ccSSEDelivered=false;

--- a/v2/pkg/dashboard/contribute_ops_init_order_test.go
+++ b/v2/pkg/dashboard/contribute_ops_init_order_test.go
@@ -1,0 +1,187 @@
+package dashboard
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// These tests pin the fix for the Operations-tab init-order crash (the runtime
+// regression from interleaving #2603 / #2604 / #2606). On the served page the
+// confirm-modal buttons (#admin-confirm-cancel / #admin-confirm-ok) are emitted
+// AFTER the command-center <script> block closes, so at script-eval time
+// document.getElementById('admin-confirm-cancel') was null. The old code called
+// .addEventListener on that null directly:
+//
+//	TypeError: null is not an object
+//	  (evaluating 'document.getElementById('admin-confirm-cancel').addEventListener')
+//
+// That uncaught throw ABORTED the rest of the inline block — which is where
+// ADMIN_TIER_ORDER, ccActivity and ccActivitySeen are initialized — leaving them
+// undefined for the whole page. The downstream symptoms were:
+//
+//	ADMIN_TIER_ORDER.map  -> undefined  (renderAdminTierLimits)
+//	ccActivitySeen[k]     -> undefined  (ccIngestActivity, via ccHydrate)
+//	ccActivity.length     -> undefined  (ccCompletedWorkItems, every opsPoll)
+//
+// so the Live Activity rail never populated ("Watching the hive…") and the My-work
+// "Done" filter threw on every poll. The fix is an ordering/guard fix (no feature
+// change): null-guard/defer the listener wiring so the block can never abort, and
+// declare+initialize the shared state at the top of the IIFE, before first use.
+
+// mainOpsScript returns the largest inline <script> block from the served page —
+// the command-center block that owns the ops-tab init.
+func mainOpsScript(t *testing.T) string {
+	t.Helper()
+	body := renderContributePage(t)
+	re := regexp.MustCompile(`(?s)<script>(.*?)</script>`)
+	best := ""
+	for _, mm := range re.FindAllStringSubmatch(body, -1) {
+		if len(mm[1]) > len(best) {
+			best = mm[1]
+		}
+	}
+	if best == "" {
+		t.Fatal("no <script> block found in served /contribute page")
+	}
+	return best
+}
+
+// stripJSComments removes // line comments so a comment that merely MENTIONS a var
+// name or a getElementById call cannot fool the source-order / guard assertions.
+// (Block comments in this file's JS do not wrap code we assert on, so line-comment
+// stripping is sufficient and avoids mis-parsing '*/'-like tokens inside strings.)
+func stripJSComments(src string) string {
+	lines := strings.Split(src, "\n")
+	out := make([]string, 0, len(lines))
+	for _, ln := range lines {
+		if i := strings.Index(ln, "//"); i >= 0 {
+			ln = ln[:i]
+		}
+		out = append(out, ln)
+	}
+	return strings.Join(out, "\n")
+}
+
+// TestOpsConfirmModalListenerNeverThrowsAtEval pins that the confirm-modal buttons
+// are wired safely: never a raw document.getElementById('admin-confirm-cancel')
+// .addEventListener at top level (that is the exact throw), and instead guarded
+// and/or deferred until the element exists.
+func TestOpsConfirmModalListenerNeverThrowsAtEval(t *testing.T) {
+	code := stripJSComments(mainOpsScript(t))
+
+	// The precise fatal call must be gone.
+	for _, forbidden := range []string{
+		`document.getElementById('admin-confirm-cancel').addEventListener`,
+		`document.getElementById('admin-confirm-ok').addEventListener`,
+	} {
+		if strings.Contains(code, forbidden) {
+			t.Errorf("unguarded confirm-modal listener still present (throws at script-eval, aborts block): %q", forbidden)
+		}
+	}
+
+	// The wiring must be deferred until the DOM has parsed AND null-guarded.
+	if !strings.Contains(code, "DOMContentLoaded") {
+		t.Error("confirm-modal wiring is not deferred to DOMContentLoaded")
+	}
+	if !strings.Contains(code, "getElementById('admin-confirm-cancel')") {
+		t.Error("confirm-modal cancel button is no longer wired at all")
+	}
+	// Guard shape: the reference to admin-confirm-cancel must be followed by an
+	// `if(<var>)` guard before .addEventListener (never a direct deref).
+	if !regexp.MustCompile(`var \w+=document\.getElementById\('admin-confirm-cancel'\);\s*if\(\w+\)`).MatchString(code) {
+		t.Error("confirm-modal cancel listener is not null-guarded (expected var x=getElementById(...); if(x)x.addEventListener)")
+	}
+}
+
+// TestOpsNoUnguardedTopLevelListeners pins that NO top-level (column-0, i.e. not
+// inside a function) statement calls document.getElementById('x').addEventListener
+// directly. Any such call throws if x is not yet parsed and aborts the whole inline
+// block — the class of bug this fix eliminates. Guarded helpers (onEl / if-checks)
+// and post-render wiring are fine.
+func TestOpsNoUnguardedTopLevelListeners(t *testing.T) {
+	code := stripJSComments(mainOpsScript(t))
+	// Top-level statements in this IIFE are written flush-left (column 0).
+	unguarded := regexp.MustCompile(`(?m)^document\.getElementById\((['"][^'"]+['"])\)\.(addEventListener|classList|value|checked|innerHTML|textContent|style|src|href|disabled|onclick)`)
+	if locs := unguarded.FindAllString(code, -1); len(locs) > 0 {
+		t.Errorf("found %d unguarded top-level getElementById(...).<prop> access(es) that can throw at eval and abort the block:\n  %s",
+			len(locs), strings.Join(locs, "\n  "))
+	}
+}
+
+// TestOpsSharedStateDeclaredBeforeUse pins the source-order invariant: the var
+// declarations for ccActivity, ccActivitySeen and ADMIN_TIER_ORDER must appear
+// BEFORE their first real (non-declaration) use in the emitted script. This is the
+// structural guard against the value-hoisting trap that made them undefined at use.
+func TestOpsSharedStateDeclaredBeforeUse(t *testing.T) {
+	code := stripJSComments(mainOpsScript(t))
+
+	cases := []struct {
+		name string
+		decl string
+		use  string
+	}{
+		{"ADMIN_TIER_ORDER", "var ADMIN_TIER_ORDER=", "ADMIN_TIER_ORDER.map"},
+		{"ccActivity", "var ccActivity=[]", "ccActivity.length"},
+		{"ccActivitySeen", "var ccActivitySeen={}", "ccActivitySeen[k]"},
+	}
+	for _, c := range cases {
+		decl := strings.Index(code, c.decl)
+		use := strings.Index(code, c.use)
+		if decl < 0 {
+			t.Errorf("%s: declaration %q not found", c.name, c.decl)
+			continue
+		}
+		if use < 0 {
+			t.Errorf("%s: use %q not found", c.name, c.use)
+			continue
+		}
+		if decl >= use {
+			t.Errorf("%s: declaration (@%d) does not precede first use (@%d) — value-hoisting trap can make it undefined at use time",
+				c.name, decl, use)
+		}
+	}
+}
+
+// TestOpsSharedStateDeclaredAtTopOfIIFE pins that the shared state is initialized
+// near the top of the command-center IIFE (before the tab-switching setup), so no
+// reachable code path can run a function that uses it before the value is assigned.
+func TestOpsSharedStateDeclaredAtTopOfIIFE(t *testing.T) {
+	code := stripJSComments(mainOpsScript(t))
+	iife := strings.Index(code, "(function(){")
+	if iife < 0 {
+		t.Fatal("command-center IIFE '(function(){' not found")
+	}
+	tabs := strings.Index(code, "var tabs=document.querySelectorAll('.page-tab')")
+	if tabs < 0 {
+		t.Fatal("tab-switching setup marker not found")
+	}
+	for _, decl := range []string{"var ADMIN_TIER_ORDER=", "var ccActivity=[]", "var ccActivitySeen={}"} {
+		d := strings.Index(code, decl)
+		if d < 0 || d < iife || d > tabs {
+			t.Errorf("%q is not hoisted to the top of the IIFE (iife@%d decl@%d tabs@%d)", decl, iife, d, tabs)
+		}
+	}
+}
+
+// TestOpsRailHydrationChainIntact is a belt-and-suspenders check that the fix left
+// the rail-population chain (ccStart -> ccPollActivity -> ccIngestActivity ->
+// ccRebuildLogFromActivity -> ccRenderLog) and the Done-filter path
+// (ccCompletedWorkItems) wired, so the rail can actually show the backlog and the
+// Done filter no longer throws.
+func TestOpsRailHydrationChainIntact(t *testing.T) {
+	code := mainOpsScript(t)
+	for _, fn := range []string{
+		"function ccStart(",
+		"function ccPollActivity(",
+		"function ccIngestActivity(",
+		"function ccRebuildLogFromActivity(",
+		"function ccRenderLog(",
+		"function ccCompletedWorkItems(",
+		"function renderAdminTierLimits(",
+	} {
+		if !strings.Contains(code, fn) {
+			t.Errorf("rail/Done-filter hydration chain missing %q", fn)
+		}
+	}
+}


### PR DESCRIPTION
## The bug (verified live in the browser console)

On the served `/contribute/operations` page, four `TypeError`s fired:

```
TypeError: null is not an object (evaluating 'document.getElementById('admin-confirm-cancel').addEventListener')   at operations:1643
TypeError: undefined is not an object (evaluating 'ADMIN_TIER_ORDER.map')   renderAdminTierLimits
TypeError: undefined is not an object (evaluating 'ccActivitySeen[k]')       ccIngestActivity (from ccHydrate)
TypeError: undefined is not an object (evaluating 'ccActivity.length')       ccCompletedWorkItems (from renderWork/opsPoll, every poll)
```

**Effect:** the Live Activity rail never populated (stuck on "Watching the hive…") and the My-work **Done** filter threw on every poll.

## Root cause — a single init-order crash

The command-center inline `<script>` wired the confirm-modal buttons at **script-eval time**:

```js
document.getElementById('admin-confirm-cancel').addEventListener(...)
document.getElementById('admin-confirm-ok').addEventListener(...)
```

But `#admin-confirm-cancel` / `#admin-confirm-ok` are emitted **after** that `<script>` block closes (inside `#admin-confirm-back` near the end of the page). So `getElementById` returned `null`, and `.addEventListener` on `null` **threw** — which is the first console error verbatim.

That uncaught throw **aborted the rest of the inline block**, so every declaration below it never executed. `var ADMIN_TIER_ORDER`, `var ccActivity`, and `var ccActivitySeen` stayed `undefined` for the whole page lifetime — cascading into the other three console errors (`ADMIN_TIER_ORDER.map`, `ccActivitySeen[k]`, `ccActivity.length`).

This is the runtime regression from interleaving **#2603** (activity poll), **#2604** (admin tier limits), and **#2606** (features) across separate merges/rebases, which scrambled the init ordering. It passed tests before because the tests asserted presence, not runtime execution order.

## The fix (ordering/guard only — no behavior change)

1. **Stop the fatal throw.** Defer the confirm-modal listener wiring to `DOMContentLoaded` (so the elements exist) **and** null-guard it, so the block can never abort mid-way. The buttons still work.
2. **Guard the other top-level element listeners** (`ops-admin`, `admin-add-model`, `admin-save-btn`, `clanker-list`) through a null-guarded `onEl()` helper, so a missing/late element can never throw at eval.
3. **Hoist `ADMIN_TIER_ORDER` / `ccActivity` / `ccActivitySeen`** to the top of the IIFE, declared+initialized before any function that uses them — no reliance on value-hoisting.

With the block now running to completion, `ccStart → ccPollActivity → ccIngestActivity → ccRebuildLogFromActivity → ccRenderLog` fills the rail from `/api/contribute/activity`, and `ccCompletedWorkItems` (Done filter) no longer throws.

## Verification

- Extracted the full inline `<script>` from the rendered page and executed it in a stubbed DOM that mirrors element availability at eval time (ids parsed **before** the block resolve, later ids return `null`, exactly like the browser). On the **pre-fix** source this reproduces the exact live failure — `Cannot read properties of null (reading 'addEventListener')`, and `ccActivity` / `ccActivitySeen` / `ADMIN_TIER_ORDER` all `undefined`. On the **fixed** source the block runs to completion and all three are defined (`[]`, `{}`, `["newcomer","contributor","trusted","advisor"]`).
- New `contribute_ops_init_order_test.go` pins the fix (fails on pre-fix source, passes after): no unguarded top-level `getElementById(...).addEventListener`; confirm-modal wiring deferred + null-guarded; shared state declared at the top of the IIFE before first use; rail/Done-filter hydration chain intact.
- `go build ./...`, `go vet ./pkg/dashboard/`, full `pkg/dashboard` suite: all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
