### PR TITLE
fix(contribute): secure contributor.env perms + gate force token rotation (#2610)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -292,7 +292,15 @@ contribute-setup backend="claude": check-version (contribute-check-backend backe
     CONTRIBUTOR_USERNAME=${GH_USER}
     AGENT_BACKEND={{backend}}
     EOF
+      # contributor.env holds HIVE_REGISTRATION_TOKEN, the sole long-lived
+      # bearer credential for the contributor WebSocket. Match the 0600 perms
+      # of its sibling secret files (gh-auth.env, claude-config.json) so the
+      # token is not left world-readable at the default umask (0644).
+      chmod 600 "{{config_dir}}/contributor.env"
     fi
+    # Re-tighten on every run: existing users may already have a 0644 file
+    # created before this fix. Fix it in place if present.
+    chmod 600 "{{config_dir}}/contributor.env" 2>/dev/null || true
     echo "${MSG} — ${GH_USER} (${CID})"
     echo ""
 
@@ -307,6 +315,9 @@ contribute-setup backend="claude": check-version (contribute-check-backend backe
       grep -v '^HIVE_LITELLM_ENDPOINT=' "{{config_dir}}/contributor.env" > "{{config_dir}}/contributor.env.tmp" || true
       echo "HIVE_LITELLM_ENDPOINT=${HIVE_LITELLM_ENDPOINT}" >> "{{config_dir}}/contributor.env.tmp"
       mv "{{config_dir}}/contributor.env.tmp" "{{config_dir}}/contributor.env"
+      # The rewrite recreates the file at the default umask (0644), dropping
+      # the 0600 perms. Re-tighten so the token stays owner-only.
+      chmod 600 "{{config_dir}}/contributor.env"
     fi
 
     # Copy CLI config for Docker container (Colima can't bind-mount files)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+The Hive maintainers take the security of this project seriously. Thank you for
+helping keep Hive and its users safe by disclosing vulnerabilities responsibly.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.** Public reports expose users to the very
+weakness being reported before a fix is available.
+
+Instead, use **private vulnerability reporting**:
+
+1. Go to the repository's **Security** tab.
+2. Click **Report a vulnerability** (GitHub's private security advisory flow).
+3. Provide a description of the issue and how to reproduce it.
+
+If private reporting is unavailable to you for any reason, contact a repository
+maintainer directly rather than opening a public issue.
+
+Please include, as much as you can:
+
+- The affected component, branch, and commit (or version).
+- A description of the vulnerability and its potential impact.
+- Step-by-step instructions to reproduce it.
+- Any proof-of-concept, logs, or configuration that help us confirm it.
+
+## What to Expect
+
+- **Acknowledgement:** we aim to acknowledge your report within **5 business
+  days**.
+- **Assessment:** we will investigate, confirm the issue, and keep you informed
+  of our progress.
+- **Fix and disclosure:** we will work on a fix and coordinate a disclosure
+  timeline with you. We ask that you give us a reasonable opportunity to
+  remediate before any public disclosure.
+- **Credit:** with your permission, we are happy to credit you for the report.
+
+## Scope
+
+Reports about the code in this repository are in scope. When in doubt, report it
+privately and let us triage — we would rather hear about a non-issue than miss a
+real one.
+
+Thank you for contributing to the security of Hive.

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -4870,9 +4870,11 @@ a{color:#58a6ff}
 
 <div class="endpoint">
 <span class="method">POST</span><span class="path">/api/contribute/register</span>
-<div class="desc">Register (or re-register with <code>force:true</code> to reissue token)</div>
-<pre>curl -X POST -d '{"github_username":"you","force":true}' %s/api/contribute/register</pre>
+<div class="desc">Register a new contributor (open), or re-register an existing one with <code>force:true</code> to reissue its token. Reissuing an existing token requires proving you own that identity — send <code>Authorization: Bearer &lt;gh-token&gt;</code> — or use <code>/api/contribute/reissue-token</code>.</div>
+<pre>curl -X POST -d '{"github_username":"you"}' %s/api/contribute/register
+# reissue an existing token (authenticated):
+curl -X POST -H "Authorization: Bearer $GH_TOKEN" -d '{"github_username":"you","force":true}' %s/api/contribute/register</pre>
 </div>
 
-</body></html>`, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL)
+</body></html>`, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL)
 }

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -3400,6 +3400,22 @@ func (s *Server) handleContributeRegister(w http.ResponseWriter, r *http.Request
 			return
 		}
 		if req.Force {
+			// SECURITY (#2610): rotating an EXISTING contributor's token is
+			// exactly what POST /api/contribute/reissue-token does, and that
+			// endpoint 401s without a caller identity it can verify server-side.
+			// force:true must enforce the SAME gate, otherwise the reissue-token
+			// auth check is trivially bypassed by rotating through register.
+			// Resolve the caller server-side (never from the request body) and
+			// require it to be the owner of this contributor profile.
+			caller := s.resolveContributeCaller(r)
+			if caller == "" {
+				jsonError(w, "Sign in with GitHub (or send Authorization: Bearer <gh-token>) to reissue an existing contributor's token, or use POST /api/contribute/reissue-token.", http.StatusUnauthorized)
+				return
+			}
+			if !strings.EqualFold(caller, username) {
+				jsonError(w, "You can only reissue your own contributor token.", http.StatusForbidden)
+				return
+			}
 			// Reissue token: generate a new one and invalidate the old
 			newToken := reissueContributorToken(existing)
 			s.logger.Info("contributor token reissued via force register", "username", username, "id", existing.ContributorID)
@@ -3470,6 +3486,36 @@ func (s *Server) resolveViewerUsername(r *http.Request) string {
 		return ""
 	}
 	return user.Login
+}
+
+// resolveContributeCaller returns the server-verified GitHub identity of the
+// caller for contributor mutations, combining the two auth paths already used
+// elsewhere in this file:
+//   - the session / hub-injected identity (resolveViewerUsername), as the
+//     invite handler uses; and
+//   - an Authorization: Bearer <gh-token> validated against GitHub, exactly as
+//     handleContributeReissueToken does.
+//
+// It returns "" when the caller is anonymous. The identity is never taken from
+// the request body, so it cannot be spoofed by a client. Used to gate the
+// register force:true rotation with the same authority as reissue-token (#2610).
+func (s *Server) resolveContributeCaller(r *http.Request) string {
+	if u := s.resolveViewerUsername(r); u != "" {
+		return u
+	}
+	authz := r.Header.Get("Authorization")
+	var token string
+	if strings.HasPrefix(authz, "Bearer ") {
+		const bearerPrefixLen = 7 // len("Bearer ")
+		token = authz[bearerPrefixLen:]
+	} else if strings.HasPrefix(authz, "token ") {
+		const tokenPrefixLen = 6 // len("token ")
+		token = authz[tokenPrefixLen:]
+	}
+	if token == "" {
+		return ""
+	}
+	return validateGitHubToken(token, s.deps.Config.GitHub.OAuthAPIURL())
 }
 
 // handleContributeInvite mints a trusted, attributed invite link (issue #2598).

--- a/v2/pkg/dashboard/api_contribute_force_rotation_test.go
+++ b/v2/pkg/dashboard/api_contribute_force_rotation_test.go
@@ -1,0 +1,137 @@
+package dashboard
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// registerContributor performs a plain (new-contributor) registration and
+// returns the recorder so the caller can assert on it.
+func registerContributor(t *testing.T, s *Server, username string) *httptest.ResponseRecorder {
+	t.Helper()
+	body := `{"github_username":"` + username + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	return w
+}
+
+// forceRegister issues a register force:true call. When caller is non-empty it
+// is supplied via the hub-injected X-Hive-User identity header, which
+// resolveViewerUsername (and thus resolveContributeCaller) honors server-side.
+func forceRegister(t *testing.T, s *Server, username, caller string) *httptest.ResponseRecorder {
+	t.Helper()
+	body := `{"github_username":"` + username + `","force":true}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	if caller != "" {
+		req.Header.Set("X-Hive-User", caller)
+	}
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	return w
+}
+
+// SECURITY (#2610): rotating an EXISTING contributor's token via
+// register force:true must require the SAME authenticated caller-identity check
+// that POST /api/contribute/reissue-token enforces. Unauthenticated force
+// rotation is an auth bypass and must be rejected with 401.
+func TestForceRegister_ExistingContributor_Unauthenticated_401(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	// New contributor exists.
+	if w := registerContributor(t, s, "existinguser"); w.Code != http.StatusOK {
+		t.Fatalf("initial register: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// force:true with no caller identity must be refused.
+	w := forceRegister(t, s, "existinguser", "")
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated force rotation: expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+	// No new token must leak on the rejected path.
+	var resp map[string]string
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["registration_token"] != "" {
+		t.Errorf("rejected force rotation must not return a token, got %q", resp["registration_token"])
+	}
+}
+
+// A caller who authenticates as a DIFFERENT user than the target contributor
+// must not be able to rotate that contributor's token (403 — not the owner).
+func TestForceRegister_ExistingContributor_WrongOwner_403(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	if w := registerContributor(t, s, "victimuser"); w.Code != http.StatusOK {
+		t.Fatalf("initial register: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w := forceRegister(t, s, "victimuser", "attackeruser")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("cross-owner force rotation: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// The owner, authenticated server-side, may rotate their own token via
+// force:true. This preserves the intended recovery path.
+func TestForceRegister_ExistingContributor_Owner_Succeeds(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	reg := registerContributor(t, s, "owneruser")
+	if reg.Code != http.StatusOK {
+		t.Fatalf("initial register: expected 200, got %d: %s", reg.Code, reg.Body.String())
+	}
+	var regResp map[string]string
+	if err := json.Unmarshal(reg.Body.Bytes(), &regResp); err != nil {
+		t.Fatalf("register response: %v", err)
+	}
+	origToken := regResp["registration_token"]
+
+	w := forceRegister(t, s, "owneruser", "owneruser")
+	if w.Code != http.StatusOK {
+		t.Fatalf("owner force rotation: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("rotation response: %v", err)
+	}
+	if resp["registration_token"] == "" {
+		t.Fatal("owner force rotation returned no new token")
+	}
+	if resp["registration_token"] == origToken {
+		t.Error("owner force rotation returned the same token — rotation did not occur")
+	}
+}
+
+// Initial registration of a NEW contributor stays open (no auth required) — the
+// gate only applies to ROTATION of an existing token, not first registration.
+func TestForceRegister_NewContributor_Unauthenticated_Succeeds(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	// force:true for a user with no existing profile is a plain new
+	// registration and must succeed without any caller identity.
+	w := forceRegister(t, s, "brandnewuser", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("new-contributor registration: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("register response: %v", err)
+	}
+	if resp["registration_token"] == "" {
+		t.Error("new-contributor registration returned no token")
+	}
+}

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -707,10 +707,15 @@ func TestRegisterForceReissue(t *testing.T) {
 		t.Error("should not return token without force")
 	}
 
-	// Third registration with force — should reissue a new token
+	// Third registration with force — should reissue a new token, but ONLY for
+	// the authenticated owner (#2610). Supply the owner's identity via the
+	// hub-injected X-Hive-User header, which resolveContributeCaller honors
+	// server-side. Unauthenticated force rotation is covered (and rejected) in
+	// api_contribute_force_rotation_test.go.
 	body = `{"github_username":"force-user","force":true}`
 	req = httptest.NewRequest(http.MethodPost, "/api/contribute/register", bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-User", "force-user")
 	w = httptest.NewRecorder()
 	s.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {

--- a/v2/pkg/dashboard/contributor_env_perms_test.go
+++ b/v2/pkg/dashboard/contributor_env_perms_test.go
@@ -1,0 +1,53 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// SECURITY (#2610): contributor.env holds HIVE_REGISTRATION_TOKEN, the sole
+// long-lived bearer credential for the contributor WebSocket. The Justfile
+// contribute-setup recipe writes it and then re-tightens it to 0600 (matching
+// its sibling secret files gh-auth.env and claude-config.json), including a
+// re-tighten of any pre-existing world-readable file left by an older setup.
+//
+// The chmod lives in the Justfile (shell), so this test asserts the mode
+// semantics the recipe enforces: a token file created at the default umask
+// (0644) must end up owner-only (0600) after the re-tighten step. It guards
+// against a regression where the mode contract silently loosens.
+func TestContributorEnvReTightenTo0600(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "contributor.env")
+
+	// Simulate the pre-fix state: a token file left world-readable at 0644,
+	// as `cat > file` produces under the typical umask 0022.
+	if err := os.WriteFile(path, []byte("HIVE_REGISTRATION_TOKEN=secret\n"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if got := fileMode(t, path); got != 0o644 {
+		t.Fatalf("precondition: seeded mode = %o, want 644", got)
+	}
+
+	// The re-tighten step the Justfile applies: chmod 600 the existing file.
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatalf("re-tighten chmod: %v", err)
+	}
+
+	if got := fileMode(t, path); got != 0o600 {
+		t.Fatalf("after re-tighten: mode = %o, want 600 (owner-only)", got)
+	}
+	// It must NOT be group- or world-readable.
+	if got := fileMode(t, path); got&0o077 != 0 {
+		t.Errorf("token file is group/world-accessible: mode = %o", got)
+	}
+}
+
+func fileMode(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return fi.Mode().Perm()
+}


### PR DESCRIPTION
Addresses the security defects reported in #2610, from a downstream security review of the contributor registration flow. Verified against v2 HEAD `fc3d7179`.

## Finding 1 — `contributor.env` written world-readable — FIXED

`~/.config/hive/contributor.env` holds `HIVE_REGISTRATION_TOKEN`, the sole long-lived, non-expiring bearer credential for the contributor WebSocket. Its two sibling secret files (`gh-auth.env`, `claude-config.json`) get an explicit `chmod 600`, but `contributor.env` did not — so at the typical umask 0022 it landed `0644` (world-readable).

Fixes in `Justfile` `contribute-setup`:
- `chmod 600` at the write site (right after the `cat > contributor.env` heredoc).
- `chmod 600` after the **LiteLLM rewrite path** (`grep -v … > .tmp; mv`), which recreates the file at umask and would otherwise drop it back to 0644.
- An **unconditional re-tighten** (`chmod 600 … 2>/dev/null || true`) on every run, so existing users who already have a 0644 file get it fixed in place on their next `contribute-setup`.

## Finding 2 — unauthenticated token rotation via `register force:true` — FIXED

`POST /api/contribute/reissue-token` resolves the caller's GitHub identity server-side and 401s without it. But `POST /api/contribute/register` with `force:true` performed the **identical** `reissueContributorToken()` rotation of an existing contributor **with no auth** — an auth bypass that defeats the protection on `reissue-token`.

Fix (option (a) — reuse the existing gate): rotation of an existing contributor's token via `force:true` now requires the same server-side caller identity used by `reissue-token`. A new `resolveContributeCaller` helper combines the two auth paths already present in this file — the session / hub-injected `X-Hive-User` identity (`resolveViewerUsername`, as the invite handler uses) and a validated `Authorization: Bearer <gh-token>` (exactly as `handleContributeReissueToken` does). The resolved identity must match the target contributor:
- anonymous caller → **401**
- authenticated but not the owner → **403**
- authenticated owner → rotates as before

Initial registration of a **new** contributor stays open (unauthenticated), as today. `reissue-token` behavior is unchanged.

Tests (`api_contribute_force_rotation_test.go`): unauthenticated force rotation of an existing contributor is 401 (and leaks no token), a non-owner is 403, the authenticated owner succeeds with a fresh token, and new-contributor registration still works unauthenticated. The pre-existing `TestRegisterForceReissue` was updated to supply the owner identity (its old form asserted the now-removed unauthenticated behavior).

## Finding 3 — `token_refresh` never re-fires after reconnect — DEFERRED (design decision)

Confirmed the mechanism: on disconnect `tokenMintedAt` is cleared (`contribute_ws.go` ~L1186), and on reconnect the relay re-asserts `currentTask` via `task_progress` (~L1453-1467) **without** re-arming `tokenMintedAt`. `tokenRefreshDue` then returns false forever because `tokenMintedAt.IsZero()`, so refresh never re-fires — exactly as reported.

This is **not** an unambiguous mechanical re-arm. Re-arming `tokenMintedAt` on the reconnect path decides that a reconnected contributor session *should* receive hub-minted scoped tokens for a token the hub never issued on that connection — which is precisely the design question the report raises (is a contributor session even meant to use the hub-minted scoped token?), entangled with the #2537 narrower-scope direction. Per the report's own framing this is the operator's call, so it is **deferred pending that design decision** rather than guessed at here.

## Repo security hygiene — SECURITY.md added

The reporter noted the repo had no `SECURITY.md` and private vulnerability reporting was disabled, forcing this to be filed in the open. Added `SECURITY.md` at the repo root with a responsible-disclosure policy directing reporters to GitHub's private vulnerability reporting flow.

**Recommended owner action (settings, not code):** enable **private vulnerability reporting** for this repository (Settings → Code security and analysis → Private vulnerability reporting). That is a repository settings change and cannot be done via a code PR.

## Verification
- `go build ./...`, `go vet ./pkg/dashboard/` clean.
- `go test ./pkg/dashboard/` passes (incl. new + updated tests).
- `shellcheck` clean on the Justfile shell changes; `just --list` still parses.

Refs #2610 (findings 1 and 2 fixed; finding 3 deferred to a design decision).

This came from a downstream security review. Thanks for the careful report.