### PR TITLE
fix(dashboard): Governor Hub queue badge shows admissible count, not raw pool

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -15110,9 +15110,16 @@ function burnAreaChart() {
     }
 
     function fetchQueueCount() {
-      fetch('/api/contribute/status').then(function(r) { return r.json(); }).then(function(d) {
+      // Use the same source as the Operations tab's Ready-work queue
+      // (/api/contribute/queue) rather than /api/contribute/status'
+      // actionable_items, which is the raw pre-filter pool and does not
+      // apply the Labels/Titles/Authors admission filters configured in
+      // this dialog. Showing actionable_items here misleadingly implied
+      // that many items were queued when only the filtered subset is
+      // actually admissible.
+      fetch('/api/contribute/queue').then(function(r) { return r.json(); }).then(function(d) {
         var el = document.getElementById('hub-queue-count');
-        if (el) el.textContent = (d.actionable_items || 0) + ' items in queue';
+        if (el) el.textContent = ((d.queue || []).length) + ' items in queue';
       }).catch(function() {
         var el = document.getElementById('hub-queue-count');
         if (el) el.textContent = '—';


### PR DESCRIPTION
## Bug

In the Governor Configuration → Hub tab, the "Contribute Work Queue" section shows a badge like "169 items in queue". This number was wrong: it came from `/api/contribute/status`'s `actionable_items`, the raw pre-filter pool of all actionable issues. It did not apply the admission filters configured in the very same dialog (Labels allow/deny, Titles, Authors), so it could read "169 items in queue" while only ~2 issues actually pass the filters and are admissible — e.g. only 2 carry the `clanker-queue` label when Labels is set to "Allow only: clanker-queue". This disagreed with (and misled relative to) the Operations tab's Ready-work queue count, which correctly applies those filters.

## Fix (Option A: show the true admissible/ready count)

`/api/contribute/queue` already returns the admissible/ready queue (`ReadyQueue()`, same source the Operations tab's Ready-work queue uses) as `{"queue": [...]}`. The badge now fetches that endpoint and uses `queue.length` instead of `actionable_items`, so it matches the Operations tab.

Before:
```js
fetch('/api/contribute/status').then(...).then(function(d) {
  el.textContent = (d.actionable_items || 0) + ' items in queue';
});
```

After:
```js
fetch('/api/contribute/queue').then(...).then(function(d) {
  el.textContent = ((d.queue || []).length) + ' items in queue';
});
```

Example: badge now reads "2 items in queue" instead of "169 items in queue" when only 2 issues pass the configured filters.

## Scope

Small, targeted change to `pkg/dashboard/static/index.html`'s `fetchQueueCount()` only. No changes to the actual filtering/admission logic.

## Testing

- `node --check` on the extracted inline script block: passes.
- `go build ./...`: passes.
- No existing tests pin the "items in queue" string or `actionable_items` usage for this badge.