### PR TITLE
fix: keep install-ID help popover inside the viewport

### DIFF
--- a/v2/pkg/dashboard/gh_app_banner_test.go
+++ b/v2/pkg/dashboard/gh_app_banner_test.go
@@ -168,3 +168,56 @@ func TestGitHubAppBannerStartTagIsClosed(t *testing.T) {
 		t.Errorf("expected the warning <span> to follow the banner div start tag, got: %.80s", strings.TrimSpace(afterTag))
 	}
 }
+
+// TestInstallIdHintPopoverHasViewportCollisionHandling is the regression
+// guard for the reported bug: the install-ID help popover (".gh-idhint-pop")
+// defaults to `bottom: 100%`, anchoring itself above the "?" button. When the
+// GitHub-App-install banner sits near the top of the viewport there isn't
+// enough room above the anchor and the popover overflowed off the top of the
+// browser window, clipping its lead text. The fix adds JS collision handling
+// that measures the anchor via getBoundingClientRect() and flips the popover
+// below the anchor (via the .gh-idhint-pop-below class) when it doesn't fit
+// above, plus a horizontal clamp for left/right edges. This test locks that
+// the flip/clamp machinery — not just the popover markup — is present.
+func TestInstallIdHintPopoverHasViewportCollisionHandling(t *testing.T) {
+	html := spokeIndexHTML(t)
+
+	required := []struct {
+		snippet string
+		why     string
+	}{
+		{"gh-idhint-pop-below", "CSS needs a flip class the JS can toggle to render the popover below its anchor"},
+		{"function positionInstallIdHint", "the collision-handling function must exist"},
+		{"getBoundingClientRect", "positioning must measure the real anchor/popover geometry, not assume it fits"},
+		{"classList.toggle('gh-idhint-pop-below'", "the function must flip the popover by toggling the CSS class"},
+		{"pop.style.left", "the function must also clamp horizontally so it can't run off the left/right edge"},
+	}
+	for _, r := range required {
+		if !strings.Contains(html, r.snippet) {
+			t.Errorf("static/index.html is missing %q — %s", r.snippet, r.why)
+		}
+	}
+
+	// The click/keyboard toggle must trigger positioning when opening the
+	// popover — a flip/clamp function that exists but is never called on
+	// show would leave the original clipping bug in place.
+	i := strings.Index(html, "function toggleInstallIdHint(event)")
+	if i < 0 {
+		t.Fatal("static/index.html has no toggleInstallIdHint function")
+	}
+	end := strings.Index(html[i:], "\n    }")
+	if end < 0 {
+		t.Fatal("could not find the end of toggleInstallIdHint")
+	}
+	body := html[i : i+end]
+	if !strings.Contains(body, "positionInstallIdHint") {
+		t.Error("toggleInstallIdHint does not call positionInstallIdHint — opening the popover via click/keyboard would skip collision handling")
+	}
+
+	// The popover is also shown by pure CSS on hover/focus-within with no
+	// click involved, so hover/focus triggers must run the same positioning
+	// logic or hover users would still see the clipped popover.
+	if !strings.Contains(html, "mouseenter") || !strings.Contains(html, "focusin") {
+		t.Error("expected hover (mouseenter) and keyboard-focus (focusin) listeners that also trigger positionInstallIdHint")
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -739,6 +739,17 @@
       box-shadow: var(--shadow-raised); z-index: 10002;
       text-align: left; white-space: normal; cursor: default;
     }
+    /* Viewport-edge collision handling. When the banner sits near the top of
+       the page there isn't 8px + the panel's own height of room above the
+       anchor, so the default `bottom: 100%` placement pushes the panel off
+       the top of the browser window and clips its first lines. gh-idhint.js
+       (positionInstallIdHint) measures the anchor and the panel on every
+       show and, when it doesn't fit above, adds this class to flip the
+       panel below the anchor instead — same panel, same content, just
+       flipped to the side that has room. */
+    .gh-idhint-pop.gh-idhint-pop-below {
+      bottom: auto; top: calc(100% + 8px);
+    }
     .gh-idhint:hover .gh-idhint-pop,
     .gh-idhint:focus-within .gh-idhint-pop,
     .gh-idhint-btn[aria-expanded="true"] + .gh-idhint-pop { display: block; }
@@ -5549,6 +5560,67 @@
       pop.innerHTML = ghAppInstallIdHintHtml(data);
     }
 
+    /* Viewport-edge collision handling for the install-ID hint popover.
+       The panel's default CSS position is `bottom: 100%` — anchored above
+       the `?` button. That's fine when the banner has room above it, but
+       when the banner sits near the top of the page (e.g. right under the
+       page header) there isn't 8px + the panel's rendered height of space,
+       and the panel overflows off the top of the browser window: its first
+       lines ("...this number") render above y=0 and are clipped.
+
+       This measures the anchor via getBoundingClientRect() on every show
+       and, when there isn't enough room above, toggles
+       .gh-idhint-pop-below (see CSS) to flip the panel to render BELOW the
+       anchor instead — the side that has room. It also clamps the panel
+       horizontally so it can't run off the left/right edge on a narrow
+       viewport or when the banner is near a side edge, the same way the
+       account-menu at #oc-gh-user-menu already clamps via max-width.
+
+       Dependency-free: no popover/positioning library, just
+       getBoundingClientRect + inline style overrides of the CSS defaults. */
+    function positionInstallIdHint() {
+      var pop = document.getElementById('gh-app-install-id-hint-pop');
+      var wrap = document.getElementById('gh-app-install-id-hint');
+      if (!pop || !wrap) return;
+      var POPOVER_EDGE_MARGIN_PX = 8; // matches the `bottom: calc(100% + 8px)` gap in CSS
+      var anchorRect = wrap.getBoundingClientRect();
+      var popRect = pop.getBoundingClientRect();
+      var popHeight = popRect.height || pop.offsetHeight || 0;
+      var viewportWidth = document.documentElement.clientWidth || window.innerWidth || 0;
+
+      /* Flip below when there isn't room above the anchor for the panel
+         plus its margin. getBoundingClientRect() returns 0-height while
+         `display:none`, so read it while CSS already shows it (hover /
+         focus-within / aria-expanded all apply before this runs on the
+         relevant events) — a 0 height then just falls through to "fits". */
+      var fitsAbove = (anchorRect.top - POPOVER_EDGE_MARGIN_PX - popHeight) >= 0;
+      pop.classList.toggle('gh-idhint-pop-below', !fitsAbove);
+
+      /* Horizontal clamp: the panel is centered on the anchor by default
+         (`left: 50%; transform: translateX(-50%)`). If that would push
+         either edge past the viewport, override with a fixed left offset
+         instead of the centered transform so the whole panel stays
+         visible on screen. */
+      var popWidth = popRect.width || pop.offsetWidth || 0;
+      var anchorCenter = anchorRect.left + (anchorRect.width / 2);
+      var idealLeft = anchorCenter - (popWidth / 2);
+      var minLeft = POPOVER_EDGE_MARGIN_PX;
+      var maxLeft = viewportWidth - popWidth - POPOVER_EDGE_MARGIN_PX;
+      if (maxLeft < minLeft) maxLeft = minLeft; // panel wider than viewport minus margins
+      var clampedLeft = Math.min(Math.max(idealLeft, minLeft), maxLeft);
+      if (clampedLeft !== idealLeft) {
+        /* Reposition relative to the anchor, not the viewport, since the
+           panel is `position: absolute` inside `.gh-idhint` (`position:
+           relative`). Convert the clamped viewport-space left back into
+           anchor-space and drop the centering transform. */
+        pop.style.left = (clampedLeft - anchorRect.left) + 'px';
+        pop.style.transform = 'none';
+      } else {
+        pop.style.left = '';
+        pop.style.transform = '';
+      }
+    }
+
     /* Click/keyboard toggle. Enter and Space activate a <button> natively, so
        this one handler serves mouse, touch, and keyboard alike — the panel is
        never hover-only. */
@@ -5558,7 +5630,39 @@
       if (!btn) return;
       var open = btn.getAttribute('aria-expanded') === 'true';
       btn.setAttribute('aria-expanded', open ? 'false' : 'true');
+      if (!open) {
+        /* Panel is about to become visible (CSS reacts to aria-expanded
+           synchronously) — measure and position it now. requestAnimationFrame
+           ensures layout has settled before we read getBoundingClientRect(). */
+        requestAnimationFrame(positionInstallIdHint);
+      }
     }
+
+    /* The panel is also shown by pure CSS on hover/focus-within (see
+       .gh-idhint:hover / :focus-within in the stylesheet), with no JS in the
+       loop at all. Hook those same triggers here so hover users get the same
+       collision handling as click/keyboard users, not just a clipped panel. */
+    (function () {
+      var wrap = document.getElementById('gh-app-install-id-hint');
+      if (!wrap) return;
+      wrap.addEventListener('mouseenter', function () {
+        requestAnimationFrame(positionInstallIdHint);
+      });
+      wrap.addEventListener('focusin', function () {
+        requestAnimationFrame(positionInstallIdHint);
+      });
+      /* The popover's own content is swapped in asynchronously by
+         renderGitHubAppInstallIdHint() (host/org arrive from /api/config
+         after boot), which can change its rendered height. Re-measure on
+         window resize too, since a narrower/shorter viewport can change
+         whether the panel still fits above the anchor. */
+      window.addEventListener('resize', function () {
+        var btn = document.getElementById('gh-app-install-id-hint-btn');
+        if (btn && btn.getAttribute('aria-expanded') === 'true') {
+          positionInstallIdHint();
+        }
+      });
+    })();
 
     /* Dismissal: a click anywhere outside the hint, or Escape, closes it.
        Without this a tapped panel on touch would have no way to close, since


### PR DESCRIPTION
## What

The Install-App banner's Installation-ID field has a `?` help button ("Where do I find my Installation ID?"). Clicking/hovering it opens a popover explaining where to find the ID (a mocked address-bar URL with the ID segment highlighted, a caret callout, and a footnote).

The popover's CSS hard-positioned it above its anchor (`bottom: 100%`). When the GitHub-App-install banner sits near the top of the viewport, there's no room above the anchor for the popover, so it renders above y=0 — overflowing off the top of the browser window and clipping its lead text (the "↑↑↑↑ this number" line and the text above it become unreadable).

## Fix

Positioning/overflow fix only — the popover's content, trigger button, and click/hover/keyboard behavior are unchanged.

Added dependency-free viewport-edge collision handling in vanilla JS/CSS:

- `positionInstallIdHint()` measures the anchor (`#gh-app-install-id-hint`) and the popover with `getBoundingClientRect()` on every show.
- If there isn't enough room above the anchor (`anchorTop - margin - popoverHeight < 0`), it toggles a new `.gh-idhint-pop-below` class that flips the popover to render **below** the anchor instead (`top: calc(100% + 8px)` instead of `bottom: calc(100% + 8px)`) — standard tooltip flip behavior.
- It also clamps the popover horizontally with an inline `left` override (dropping the centering `translateX(-50%)` when needed) so it can't run off the left/right edge on a narrow viewport or when the banner is near a side edge — mirroring the horizontal clamp the existing account menu (`#oc-gh-user-menu`) already does via `max-width: min(280px, calc(100vw - 24px))`.
- Wired into all three ways the popover currently opens: the click/keyboard toggle (`toggleInstallIdHint`), and the CSS-only `:hover`/`:focus-within` triggers (via new `mouseenter`/`focusin` listeners), plus a `resize` listener while open, since the async host/org fill-in from `/api/config` or a viewport resize can change whether it still fits.

## Before / after

- **Before**: banner near the top of the viewport → popover pinned above the anchor → top of the popover renders off-screen, clipped and unreadable.
- **After**: same scenario → popover flips to render below the anchor instead, fully inside the viewport. Banner with room above still opens the popover above the anchor as before (no visible change in the common case). Horizontal placement now also clamps instead of ever running off a side edge.

## Testing

- `node --check` on the extracted inline `<script>` blocks — passes.
- `go build ./...` — passes.
- `go vet ./pkg/dashboard/...` — clean.
- Added `TestInstallIdHintPopoverHasViewportCollisionHandling` to `pkg/dashboard/gh_app_banner_test.go`, following the existing structural-test pattern in that file (asserts the CSS flip class, the JS positioning function, that it's wired into the click/keyboard toggle, and that hover/focus triggers exist too — regression guard against the fix silently being wired to only one of the three open paths).
- `go test ./pkg/dashboard/...` — all passing (29.6s).