### PR TITLE
feat(contribute): Ready-work queue play/pause synced with Suspend Contributions

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -782,6 +782,18 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .cc-live .cc-live-dot{width:7px;height:7px;border-radius:50%%;background:#3fb950;animation:pulse 2s infinite}
 .cc-live.stale{border-color:rgba(210,153,34,.3);background:rgba(210,153,34,.1);color:#d29922}
 .cc-live.stale .cc-live-dot{background:#d29922;animation:none}
+/* Ready-work queue play/pause — the SAME contribute_suspended control as the
+   Management "Suspend contributions" switch, surfaced on the queue header.
+   Quiet by default (bordered ghost button); the danger tint only appears once
+   paused, matching .admin-switch.on.danger's accent so the two placements read
+   as one state. Left of #cc-live so status (queue live/stale) and posture
+   (active/paused) sit as a pair. */
+#queue-suspend-wrap{display:inline-flex;align-items:center;gap:6px;margin-left:auto}
+.queue-suspend-btn{display:inline-flex;align-items:center;justify-content:center;width:26px;height:26px;border-radius:999px;border:1px solid #30363d;background:transparent;color:#8b949e;cursor:pointer;font-size:.7rem;line-height:1;transition:background .15s,color .15s,border-color .15s}
+.queue-suspend-btn:hover{background:rgba(139,148,158,.12);color:#c9d1d9}
+.queue-suspend-btn.paused{border-color:rgba(248,81,73,.35);color:#f85149;background:rgba(248,81,73,.08)}
+.queue-suspend-btn.paused:hover{background:rgba(248,81,73,.16)}
+.queue-suspend-btn:disabled{opacity:.5;cursor:not-allowed}
 /* Army roster header line under the clanker card */
 .cc-army{display:flex;align-items:center;gap:14px;padding:10px 20px;border-bottom:1px solid #21262d;font-size:.78rem;color:#8b949e}
 .cc-army b{color:#e6edf3;font-weight:600}
@@ -991,11 +1003,8 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .client-tile .ct-emblem svg{width:18px;height:18px;display:block}
 .client-tile .ct-name{font-weight:600;line-height:1.15;min-width:0}
 .client-tile .ct-name small{display:block;font-weight:400;color:#8b949e;font-size:.7rem}
-/* Name + First-class badge stack vertically: the badge gets its OWN line below the
-   name/subtitle so it never overlaps them (the #2602 tiles overlapped at narrow
-   widths). min-width:0 keeps the name ellipsising instead of shoving the badge. */
+/* min-width:0 keeps the name ellipsising rather than overflowing the tile. */
 .client-tile .ct-body{display:flex;flex-direction:column;align-items:flex-start;gap:3px;min-width:0}
-.client-tile .ct-parity{align-self:flex-start;font-size:.62rem;color:#3fb950;border:1px solid rgba(63,185,80,.4);border-radius:999px;padding:1px 6px;white-space:nowrap}
 /* "Open in <tool>" onboarding affordance — deliberately understated and clearly a
    SETUP helper, never a "contributing" surface. Only rendered for a client with a
    real, vendor-documented deep-link scheme. */
@@ -1263,7 +1272,8 @@ var promptEdited=false;   // once the user edits, don't clobber on same client
 var promptForClient='';   // which client the current prompt text was generated for
 function tileOrder(){
   // Peers (Claude/Copilot/Pi/Goose/LiteLLM/OpenRouter) first, in select order, then
-  // the rest — so the first-class tools lead the grid rather than being afterthoughts.
+  // the rest — so these tools lead the grid rather than being afterthoughts. This
+  // is an ORDERING signal only; peer status is no longer shown as a visible badge.
   var peers=[],rest=[];
   for(var i=0;i<sel.options.length;i++){
     var v=sel.options[i].value;var c=CLIENTS[v]||{name:v,tag:''};
@@ -1276,13 +1286,9 @@ function buildTiles(){
   tilesEl.innerHTML=tileOrder().map(function(v){
     var c=CLIENTS[v]||{name:v,tag:''};
     var emb=EMB[v]||EMB.other;
-    // First-class badge sits on its OWN line BELOW the name/subtitle (a sibling
-    // block in a flex column), never absolutely positioned over the text — so it
-    // can't overlap the tool name or the vendor subtitle at narrow tile widths.
-    var parity=c.peer?'<span class="ct-parity">First-class</span>':'';
     return '<button type="button" class="client-tile" role="option" data-cli="'+v+'" aria-selected="false" title="'+c.name+'">'+
       '<span class="ct-emblem">'+emb+'</span>'+
-      '<span class="ct-body"><span class="ct-name">'+c.name+(c.tag?'<small>'+c.tag+'</small>':'')+'</span>'+parity+'</span></button>';
+      '<span class="ct-body"><span class="ct-name">'+c.name+(c.tag?'<small>'+c.tag+'</small>':'')+'</span></span></button>';
   }).join('');
 }
 function defaultPromptFor(v){
@@ -1521,7 +1527,19 @@ update();  // initial paint: copy block + branded UI in sync from first load
 <div class="work-list" id="work-list"><div class="ops-empty">Loading work&hellip;</div></div>
 </div>
 <div class="ops-card card-accent" style="margin-top:20px">
-<div class="ops-card-head"><span class="feed-dot"></span><h3>Ready-work queue</h3><span class="ops-card-count" id="queue-count"></span><span class="cc-live stale" id="cc-live"><span class="cc-live-dot"></span><span id="cc-live-label">connecting</span></span></div>
+<div class="ops-card-head"><span class="feed-dot"></span><h3>Ready-work queue</h3><span class="ops-card-count" id="queue-count"></span>
+<!-- #queue-suspend-btn is the SAME logical control as the Management "Suspend
+     contributions" switch (#admin-suspend-switch) — not a related toggle, the
+     identical Config.Hub.ContributeSuspended state surfaced a second place. Both
+     read/write through setContributeSuspended(), which is the single source of
+     truth for the PUT + both render updates (see below). Hidden until initAdmin()
+     resolves owner/read-write; a read viewer still sees the status pill next to it
+     (#queue-suspend-pill), which is read-only info. -->
+<span id="queue-suspend-wrap">
+<span class="pill pill-passed" id="queue-suspend-pill" style="display:none">active</span>
+<button type="button" class="queue-suspend-btn" id="queue-suspend-btn" title="Pause contributions" aria-label="Pause contributions" style="display:none"><span id="queue-suspend-icon">&#10074;&#10074;</span></button>
+</span>
+<span class="cc-live stale" id="cc-live"><span class="cc-live-dot"></span><span id="cc-live-label">connecting</span></span></div>
 <!-- Playlist-style SEARCH (#2592). A pure VIEW filter over the loaded queue
      (repo / number / title / label, case-insensitive, live) — it never changes
      the persisted order, only what is shown. Read-only, so visible to everyone. -->
@@ -2237,6 +2255,57 @@ function renderAdminTierLimits(){
   }).join('');
 }
 
+// renderQueueSuspendControl paints the Ready-work queue's play/pause button +
+// status pill from the SAME contribute_suspended value the Management "Suspend
+// contributions" switch reads (adminHub.contribute_suspended when available, or
+// the read-only policy snapshot as a fallback for a viewer with no adminHub).
+// There is no separate queue-local state — this is a pure render of one shared
+// value, called from every place that value can change (renderAdminControls
+// after a toggle/hub load, and renderPolicy on every opsPoll tick so a change
+// made on the OTHER surface — or by another operator — shows up here too).
+function renderQueueSuspendControl(suspended){
+  var pill=document.getElementById('queue-suspend-pill');
+  if(pill){
+    pill.style.display='';
+    pill.className='pill '+(suspended?'pill-blocked':'pill-passed');
+    pill.textContent=suspended?'paused':'active';
+  }
+  var btn=document.getElementById('queue-suspend-btn');
+  if(!btn)return;
+  if(!adminEnabled){btn.style.display='none';return;} // read viewer: status pill only, no control
+  btn.style.display='';
+  btn.classList.toggle('paused',!!suspended);
+  btn.title=suspended?'Resume contributions':'Pause contributions';
+  btn.setAttribute('aria-label',btn.title);
+  var icon=document.getElementById('queue-suspend-icon');
+  if(icon)icon.innerHTML=suspended?'&#9654;':'&#10074;&#10074;'; // play triangle : pause bars
+}
+
+// setContributeSuspended is the SINGLE handler for the contribute_suspended
+// toggle, shared by the Management "Suspend contributions" switch and the
+// Ready-work queue play/pause button — they are the same logical control
+// surfaced twice, not two independent toggles. It PUTs through the existing
+// governor-hub endpoint (adminSaveHub) and, on success, updates adminHub and
+// re-renders BOTH surfaces so they can never drift apart.
+var contributeSuspendBusy=false;
+function setContributeSuspended(next,source){
+  if(contributeSuspendBusy)return;
+  contributeSuspendBusy=true;
+  adminSaveHub({contribute_suspended:next},next?'Contributions paused':'Contributions resumed').then(function(ok){
+    contributeSuspendBusy=false;
+    if(!ok)return;
+    if(adminHub)adminHub.contribute_suspended=next;
+    renderAdminControls();
+    renderQueueSuspendControl(next);
+  });
+}
+
+onEl('queue-suspend-btn','click',function(){
+  if(!adminEnabled)return;
+  var next=!(adminHub&&adminHub.contribute_suspended);
+  setContributeSuspended(next,'queue');
+});
+
 function renderAdminControls(){
   if(!adminEnabled||!adminHub)return;
   // Immediate toggles.
@@ -2244,6 +2313,7 @@ function renderAdminControls(){
   document.getElementById('admin-suspend-switch').classList.toggle('danger',!!adminHub.contribute_suspended);
   document.getElementById('admin-skip-switch').classList.toggle('on',!!adminHub.contribute_skip_assigned_to_others);
   document.getElementById('admin-reject-switch').classList.toggle('on',!!adminHub.contribute_reject_unknown_models);
+  renderQueueSuspendControl(!!adminHub.contribute_suspended);
   // Filters (mirror Governor Hub: titles/authors/labels + modes, allow-models).
   renderAdminFilter('admin-filter-titles','Titles','title','contribute_titles_mode','titles');
   renderAdminFilter('admin-filter-authors','Authors','author','contribute_authors_mode','authors');
@@ -2263,6 +2333,10 @@ function bindImmediateToggle(id){
   sw.addEventListener('click',function(){
     var key=sw.getAttribute('data-key');
     var next=!(adminHub&&adminHub[key]);
+    // contribute_suspended is the SAME control as the queue play/pause button —
+    // route both through the one shared handler so there is exactly one code
+    // path that PUTs this field and exactly one place that renders both surfaces.
+    if(key==='contribute_suspended'){setContributeSuspended(next,'management');return;}
     var patch={};patch[key]=next;
     adminSaveHub(patch,next?'Enabled '+key.replace(/_/g,' '):'Disabled '+key.replace(/_/g,' ')).then(function(ok){
       if(ok){adminHub[key]=next;renderAdminControls();}
@@ -2562,6 +2636,13 @@ function renderWork(list){
 function renderPolicy(p){
   var el=document.getElementById('policy-body');
   if(!p){el.innerHTML='<div class="ops-empty">Policy unavailable.</div>';return;}
+  // Keep the queue play/pause in sync every poll tick — this is what makes the
+  // two surfaces converge even when the change came from elsewhere (the other
+  // tab, another operator, a page that hasn't loaded adminHub yet). If adminHub
+  // is already loaded, prefer it (freshest, updated synchronously on toggle);
+  // otherwise fall back to this read-only policy snapshot so a read viewer (who
+  // never loads adminHub) still sees the correct paused/active status.
+  renderQueueSuspendControl(adminHub?!!adminHub.contribute_suspended:!!p.suspended);
   function list(a){return (a&&a.length)?a.map(esc).join(', '):'&mdash;';}
   var rows=[
     ['Contribute queue',p.suspended?'<span class="pill pill-blocked">suspended</span>':'<span class="pill pill-passed">active</span>'],

--- a/v2/pkg/dashboard/contribute_branded_entrypoints_test.go
+++ b/v2/pkg/dashboard/contribute_branded_entrypoints_test.go
@@ -6,15 +6,20 @@ import (
 )
 
 // #2548 — branded client entry points (onboarding, additive). These tests pin the
-// rendered /contribute page: per-client visual identity, first-class parity for
-// Claude/Copilot/Pi/Goose, a documented-only "Open in" deep-link that is labeled as
-// onboarding-not-contribution, and a full copy-pasteable customizable prompt — all
-// without breaking the existing CLI/Mode/Runtime/OS selectors or the copy-block.
-// renderContributePage lives in contribute_devlog_rail_test.go.
+// rendered /contribute page: per-client visual identity, first-class ordering for
+// Claude/Copilot/Pi/Goose/LiteLLM/OpenRouter (they lead the tile grid; the visible
+// "First-class" badge itself was removed per operator request — peer:true is now
+// an ORDERING signal only, not a rendered pill), a documented-only "Open in"
+// deep-link labeled as onboarding-not-contribution, and a full copy-pasteable
+// customizable prompt — all without breaking the existing CLI/Mode/Runtime/OS
+// selectors or the copy-block. renderContributePage lives in
+// contribute_devlog_rail_test.go.
 
 // TestBrandedEntryPoints_IdentityAndParity asserts the find-by-sight tile grid, the
 // per-client inline SVG emblems (CSP-safe, no external images), and first-class
-// parity for Claude/Copilot/Pi/Goose are all present.
+// ORDERING for Claude/Copilot/Pi/Goose/LiteLLM/OpenRouter are all present — and
+// that the visible "First-class" pill is gone (removed per operator request; the
+// tiles themselves — emblem + name + vendor subtitle — stay).
 func TestBrandedEntryPoints_IdentityAndParity(t *testing.T) {
 	body := renderContributePage(t)
 
@@ -23,7 +28,6 @@ func TestBrandedEntryPoints_IdentityAndParity(t *testing.T) {
 		`class="client-tiles`, // its styling hook
 		`class="client-tile`,  // per-client tile
 		`ct-emblem`,           // the inline emblem slot
-		`First-class`,         // the parity badge text
 		`var CLIENTS=`,        // the client metadata table
 		`var EMB=`,            // the inline SVG emblem table
 		`buildTiles`,          // tile renderer
@@ -33,9 +37,18 @@ func TestBrandedEntryPoints_IdentityAndParity(t *testing.T) {
 		}
 	}
 
-	// Parity: each of the SIX first-class clients must be marked peer:true in the
-	// CLIENTS table so it leads the grid with a First-class badge, not as an
-	// afterthought (LiteLLM + OpenRouter joined Claude/Copilot/Pi/Goose).
+	// The visible "First-class" pill/badge must be gone — operator asked for it
+	// to be removed from the tiles entirely.
+	if strings.Contains(body, "First-class") {
+		t.Error("the \"First-class\" badge must be removed from the client tiles")
+	}
+	if strings.Contains(body, "ct-parity") {
+		t.Error("the now-unused .ct-parity badge class must be removed, not left dangling")
+	}
+
+	// Ordering: each of the SIX first-class clients must still be marked
+	// peer:true in the CLIENTS table so it leads the grid (tileOrder() puts
+	// peers first) — this is an ordering signal only now, not a rendered badge.
 	for _, peer := range []string{
 		`claude:{name:'Claude Code'`, `copilot:{name:'GitHub Copilot'`, `pi:{name:'Pi'`,
 		`goose:{name:'Goose'`, `litellm:{name:'LiteLLM'`, `openrouter:{name:'OpenRouter'`,
@@ -45,7 +58,7 @@ func TestBrandedEntryPoints_IdentityAndParity(t *testing.T) {
 		}
 	}
 	if strings.Count(body, "peer:true") < 6 {
-		t.Errorf("expected >=6 peer:true (Claude/Copilot/Pi/Goose/LiteLLM/OpenRouter first-class), got %d", strings.Count(body, "peer:true"))
+		t.Errorf("expected >=6 peer:true (Claude/Copilot/Pi/Goose/LiteLLM/OpenRouter lead the grid), got %d", strings.Count(body, "peer:true"))
 	}
 
 	// Emblems must be inline SVG (CSP-safe) — no external <img> smuggled into a tile.

--- a/v2/pkg/dashboard/contribute_bugs_rest_test.go
+++ b/v2/pkg/dashboard/contribute_bugs_rest_test.go
@@ -130,38 +130,51 @@ func TestMeCardRankAmongContributorsOnly(t *testing.T) {
 	}
 }
 
-// TestClientTileFirstClassBadgeNoOverlap proves the "First-class" badge sits in its
-// OWN layout slot (a sibling block on its own line via .ct-body flex column), NOT
-// absolutely positioned over the tile name/subtitle — so it can't overlap the tool
-// name or vendor subtitle at narrow tile widths (#2602 tiles overlapped). Also proves
-// the first-class set now includes LiteLLM + OpenRouter (six peers).
-func TestClientTileFirstClassBadgeNoOverlap(t *testing.T) {
+// TestClientTileFirstClassBadgeRemoved proves the visible "First-class" pill was
+// removed from the client tiles per operator request (Claude Code, GitHub
+// Copilot, Pi, Goose, LiteLLM, OpenRouter all lose the badge; the tiles
+// themselves — emblem + name + vendor subtitle — stay). It also proves the
+// .ct-parity CSS class was cleaned up rather than left dangling, and that
+// peer:true is retained as a pure ORDERING signal (first-class tools still lead
+// the grid via tileOrder()) even though it no longer renders a badge.
+func TestClientTileFirstClassBadgeRemoved(t *testing.T) {
 	body := renderContributePage(t)
 
-	// The badge lives inside .ct-body (the name+badge column), not floated over text.
-	if !strings.Contains(body, `'<span class="ct-body"><span class="ct-name">'+c.name+(c.tag?'<small>'+c.tag+'</small>':'')+'</span>'+parity+'</span></button>'`) {
-		t.Error("First-class badge is not inside the .ct-body layout slot (may overlap the name)")
+	// The badge text/class/JS variable must be gone entirely.
+	if strings.Contains(body, "First-class") {
+		t.Error("the \"First-class\" badge text must be removed from the client tiles")
 	}
-	// .ct-body is a flex COLUMN so the badge stacks below the name; .ct-parity is NOT
-	// absolutely positioned and no longer uses margin-left:auto to sit on the name row.
-	if !strings.Contains(body, ".client-tile .ct-body{display:flex;flex-direction:column;") {
-		t.Error(".ct-body is not a flex column (badge would not get its own line)")
+	if strings.Contains(body, "ct-parity") {
+		t.Error("the now-unused .ct-parity class must be cleaned up, not left dangling")
 	}
-	if strings.Contains(body, ".client-tile .ct-parity{position:absolute") {
-		t.Error("First-class badge is absolutely positioned over the tile text (overlap)")
-	}
-	if strings.Contains(body, ".client-tile .ct-parity{margin-left:auto;") {
-		t.Error("First-class badge still uses margin-left:auto (shares the name's row → overlap)")
+	if strings.Contains(body, "var parity=") {
+		t.Error("the parity badge variable must be removed from buildTiles, not just unused")
 	}
 
-	// The first-class set is now six: LiteLLM + OpenRouter joined the original four.
-	for _, peer := range []string{"litellm:{name:'LiteLLM',tag:'your proxy',peer:true}", "openrouter:{name:'OpenRouter',tag:'your key',peer:true}"} {
+	// The tile markup itself must remain: emblem + name (+ vendor subtitle),
+	// with nothing concatenated after the name span.
+	if !strings.Contains(body, `'<span class="ct-body"><span class="ct-name">'+c.name+(c.tag?'<small>'+c.tag+'</small>':'')+'</span></span></button>'`) {
+		t.Error("tile markup must render emblem+name+subtitle only, with the badge span removed")
+	}
+	// .ct-body stays a flex column (layout for name/subtitle); this is unrelated
+	// to the removed badge and must not have been collapsed by the cleanup.
+	if !strings.Contains(body, ".client-tile .ct-body{display:flex;flex-direction:column;") {
+		t.Error(".ct-body flex-column layout must remain intact after removing the badge")
+	}
+
+	// peer:true is KEPT as an ordering signal — first-class tools still lead the
+	// grid (tileOrder() puts peers first) — for all six first-class clients.
+	for _, peer := range []string{
+		"claude:{name:'Claude Code'", "copilot:{name:'GitHub Copilot',tag:'GitHub',peer:true}",
+		"pi:{name:'Pi',tag:'pi.dev',peer:true}", "goose:{name:'Goose',tag:'Block (Ollama)',peer:true}",
+		"litellm:{name:'LiteLLM',tag:'your proxy',peer:true}", "openrouter:{name:'OpenRouter',tag:'your key',peer:true}",
+	} {
 		if !strings.Contains(body, peer) {
-			t.Errorf("expected new first-class client marked peer:true: %q", peer)
+			t.Errorf("expected first-class client still marked peer:true for ordering: %q", peer)
 		}
 	}
 	if strings.Count(body, "peer:true") < 6 {
-		t.Errorf("expected 6 first-class (peer:true) clients, got %d", strings.Count(body, "peer:true"))
+		t.Errorf("expected 6 peer:true (ordering-only, no badge) clients, got %d", strings.Count(body, "peer:true"))
 	}
 	// The remaining tiles stay non-first-class.
 	for _, nonPeer := range []string{"vllm:{name:'vLLM'", "'llm-d':{name:'llm-d'", "bob:{name:'Bob'", "other:{name:'Other'"} {

--- a/v2/pkg/dashboard/queue_play_pause_test.go
+++ b/v2/pkg/dashboard/queue_play_pause_test.go
@@ -1,0 +1,173 @@
+package dashboard
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Ready-work queue play/pause control (Operations tab). This is NOT a second,
+// independent toggle — it is the SAME contribute_suspended state as the
+// Management "Suspend contributions" switch (#admin-suspend-switch), surfaced a
+// second place on the queue header. Both read/write through the one
+// setContributeSuspended() JS handler, which PUTs the existing
+// PUT /api/config/governor/hub endpoint (the same call the Management switch
+// always used) and re-renders BOTH surfaces from the single result. These tests
+// pin: (1) the markup exists and is wired to the shared handler, not a parallel
+// PUT; (2) the queue's status pill reads from the same policy.suspended field
+// GET /api/contribute/fleet already exposes; (3) the server boundary — a "read"
+// viewer still gets 403 on the governor-hub PUT, matching the Management path.
+
+// TestQueuePlayPauseMarkupPresent asserts the /contribute page ships the queue
+// play/pause button + status pill, and that they are wired to the SAME shared
+// handler and endpoint as the Management suspend switch — not a separate PUT.
+func TestQueuePlayPauseMarkupPresent(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+
+	for _, want := range []string{
+		// The control + the read-only status pill live on the queue card header.
+		`id="queue-suspend-btn"`,
+		`id="queue-suspend-pill"`,
+		`Ready-work queue`,
+		// One shared handler/state, not a parallel implementation: both the
+		// Management switch and the queue button route through this function.
+		`function setContributeSuspended(`,
+		`function renderQueueSuspendControl(`,
+		`onEl('queue-suspend-btn','click'`,
+		// The shared handler persists through the SAME endpoint the Management
+		// switch (and the Governor Hub dialog) already use — no new endpoint.
+		`contribute_suspended:next`,
+		`/api/config/governor/hub`,
+		// The Management switch's own click routes through the shared handler
+		// too (not two independent PUTs for the same field).
+		`key==='contribute_suspended'`,
+		`setContributeSuspended(next,'management')`,
+		// The queue's status is re-derived from the read-only policy snapshot on
+		// every poll tick, so it converges even if the change came from elsewhere.
+		`renderQueueSuspendControl(adminHub?!!adminHub.contribute_suspended:!!p.suspended)`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("queue play/pause markup/wiring missing %q", want)
+		}
+	}
+
+	// The button must start hidden (display:none) — it only appears once
+	// initAdmin() resolves owner/read-write via /api/role, same as the rest of
+	// the admin controls. A read viewer must never get a usable control.
+	i := strings.Index(body, `id="queue-suspend-btn"`)
+	if i < 0 {
+		t.Fatal("queue-suspend-btn not found")
+	}
+	// Look at the tag surrounding the id to confirm it ships hidden by default.
+	tagStart := strings.LastIndex(body[:i], "<button")
+	tagEnd := strings.Index(body[tagStart:], ">")
+	if tagStart < 0 || tagEnd < 0 || !strings.Contains(body[tagStart:tagStart+tagEnd], `style="display:none"`) {
+		t.Error("queue-suspend-btn must start hidden (display:none) until the owner/read-write role check resolves")
+	}
+}
+
+// TestQueuePlayPauseSharesGovernorHubPUT proves the queue control's declared
+// wire path actually round-trips through the real handler: PUTting
+// contribute_suspended via /api/config/governor/hub (exactly what
+// setContributeSuspended's fetch call sends) flips Config.Hub.ContributeSuspended,
+// and GET /api/contribute/fleet's policy.suspended (what renderPolicy uses to
+// re-sync the queue pill every tick) reflects it immediately — proving the queue
+// and Management surfaces read/write the identical field with no separate state.
+func TestQueuePlayPauseSharesGovernorHubPUT(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.Hub.ContributeSuspended = false
+
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/hub",
+		strings.NewReader(`{"contribute_suspended":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.handleGovernorHub(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("governor hub update got %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	if !deps.Config.Hub.ContributeSuspended {
+		t.Fatal("contribute_suspended not persisted by handleGovernorHub")
+	}
+
+	// The policy the queue re-syncs from (buildContributeAdmissionPolicy, served
+	// by /api/contribute/fleet) must reflect the SAME field.
+	p := s.buildContributeAdmissionPolicy()
+	if !p.Suspended {
+		t.Error("ContributeAdmissionPolicy.Suspended did not reflect the governor-hub PUT — queue and Management would show different states")
+	}
+
+	// Flip back through the same endpoint and confirm both sides track it.
+	req2 := httptest.NewRequest(http.MethodPut, "/api/config/governor/hub",
+		strings.NewReader(`{"contribute_suspended":false}`))
+	req2.Header.Set("Content-Type", "application/json")
+	w2 := httptest.NewRecorder()
+	s.handleGovernorHub(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("governor hub resume got %d, want 200 (body: %s)", w2.Code, w2.Body.String())
+	}
+	if deps.Config.Hub.ContributeSuspended {
+		t.Fatal("contribute_suspended still true after resume PUT")
+	}
+	if s.buildContributeAdmissionPolicy().Suspended {
+		t.Error("policy.Suspended still true after resume — queue would show stale paused state")
+	}
+}
+
+// TestQueuePlayPause_ReadViewerForbidden proves the queue control's PUT path
+// (the SAME PUT /api/config/governor/hub the Management switch uses) still 403s
+// a read viewer server-side, independent of the UI hiding the button. This is
+// the same boundary TestGovernorHubSave_ReadViewerForbidden pins for the
+// Management surface; asserting it again here documents that adding a second
+// UI placement did not open a second, weaker path to the same mutation.
+func TestQueuePlayPause_ReadViewerForbidden(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.Hub.ContributeSuspended = false
+
+	h := s.Handler()
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/hub",
+		strings.NewReader(`{"contribute_suspended":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-Role", "read")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("read viewer PUT /api/config/governor/hub got %d, want 403 (body: %s)", w.Code, w.Body.String())
+	}
+	if deps.Config.Hub.ContributeSuspended {
+		t.Error("read viewer mutated Config.Hub.ContributeSuspended via the queue's wire path")
+	}
+}
+
+// TestQueuePlayPause_FleetPolicyExposesSuspendedForReadViewer proves a read /
+// anonymous viewer can still SEE the paused/active status on the queue (it's
+// read-only info per the spec) even though they cannot toggle it: GET
+// /api/contribute/fleet (the endpoint opsPoll() uses, unauthenticated-safe on
+// this public page) must carry policy.suspended.
+func TestQueuePlayPause_FleetPolicyExposesSuspendedForReadViewer(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.Hub.ContributeSuspended = true
+
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/fleet", nil)
+	req.Header.Set("X-Hive-Role", "read")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("read viewer GET /api/contribute/fleet got %d, want 200 (status must be visible to all)", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"suspended":true`) {
+		t.Errorf("fleet response missing suspended:true for read viewer; body: %s", w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

Adds a play/pause control to the Ready-work queue card header (Operations tab). This is not a new, separate toggle — it is the same `contribute_suspended` (`Config.Hub.ContributeSuspended`) state as the Management tab's existing "Suspend contributions" switch, surfaced a second time on the queue where the operator watches the work.

- Both placements read/write the identical state through one shared JS handler, `setContributeSuspended()`, which PUTs the existing `PUT /api/config/governor/hub` endpoint — the same call the Management switch already used. No new endpoint was added.
- The Management switch's click handler now routes through that same shared function instead of issuing its own PUT, so there is exactly one code path that ever writes `contribute_suspended`.
- The queue re-derives its play/pause indicator (button state + an "active"/"paused" status pill) from `policy.suspended`, which `GET /api/contribute/fleet` already exposes and the Operations tab already polls every 4s — so a change made on either surface (or by another operator) converges on both without a manual page refresh.
- The control itself (the button) is owner/read-write only, gated by the existing `/api/role` check (`adminEnabled`), matching every other admin control on this page. A read/anonymous viewer still sees the read-only status pill (active/paused) next to it, but no usable control. Server-side, `PUT /api/config/governor/hub` is already 403'd for a `read` role by the existing `roleEnforcement` middleware — unchanged by this PR.
- Suspend enforcement logic (the hive stops assigning tasks when `ContributeSuspended` is true) is untouched — this only adds a second UI surface plus a visible status indicator.

Also included (small, same file): removed the green "First-class" pill from the onboarding client tiles (Claude Code, GitHub Copilot, Pi, Goose, LiteLLM, OpenRouter) per operator request. The tiles themselves (emblem + name + vendor subtitle) are unchanged, and `peer:true` is kept purely as an ordering signal so these tools still lead the grid — only the visible badge and its now-unused `.ct-parity` CSS were removed.

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [x] `go test ./pkg/dashboard/...` passes (full package, including new tests)
- [x] `node --check` on every extracted `<script>` block in the rendered page
- [x] New tests in `queue_play_pause_test.go`:
  - queue play/pause markup + shared-handler wiring renders, button starts hidden
  - PUT `contribute_suspended` via `/api/config/governor/hub` flips `Config.Hub.ContributeSuspended` and the policy the queue re-syncs from
  - a `read` role viewer gets 403 on that PUT
  - a `read` role viewer still gets `suspended` in `GET /api/contribute/fleet`'s policy (status stays visible)
- [x] Updated `contribute_branded_entrypoints_test.go` and `contribute_bugs_rest_test.go` to assert the "First-class" pill and `.ct-parity` class are gone, while the tile ordering (`peer:true`) is retained