### PR TITLE
feat(contribute): clickable GitHub issue/PR links on Operations tab

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -532,6 +532,18 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .work-item:hover{background:rgba(88,166,255,.04)}
 .work-item.selected{background:rgba(88,166,255,.08)}
 .work-repo{font-size:.75rem;color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+/* ── Clickable GitHub issue/PR references (#2616) ────────────────────────────────
+   Shared affordance for every repo#number reference on the Operations tab (ready
+   queue, my-work, opportunistic-work, dev-log). Deliberately more visible than
+   the surrounding muted-grey monospace text — link-blue + underline-on-hover +
+   a small external-link glyph — so it reads as an obvious "open on GitHub"
+   action, not decoration. Inherits the host element's font (monospace repo#num,
+   or inline log text) so it drops into any of those contexts unchanged. */
+.cc-issue-link{display:inline-flex;align-items:center;gap:3px;color:#58a6ff;text-decoration:none;font:inherit;border-radius:4px;transition:color .15s}
+.cc-issue-link:hover,.cc-issue-link:focus-visible{color:#79c0ff;text-decoration:underline}
+.cc-issue-link:focus-visible{outline:2px solid #58a6ff;outline-offset:2px}
+.cc-issue-link-ic{flex-shrink:0;opacity:.85}
+.cc-issue-link:hover .cc-issue-link-ic{opacity:1}
 .work-title{font-size:.9rem;color:#e6edf3;margin:2px 0 6px}
 .work-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-size:.75rem;color:#8b949e}
 .pill{display:inline-block;padding:2px 8px;border-radius:999px;font-size:.7rem;font-weight:600;border:1px solid transparent}
@@ -923,6 +935,8 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .cc-log-body b{color:#e6edf3}
 .cc-log-body .who{color:#58a6ff;font-weight:600}
 .cc-log-body .ref{color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.78rem}
+.cc-log-body a.ref.cc-issue-link{color:#58a6ff}
+.cc-log-body a.ref.cc-issue-link:hover,.cc-log-body a.ref.cc-issue-link:focus-visible{color:#79c0ff}
 .cc-log-time{flex-shrink:0;color:#6e7681;font-size:.72rem;white-space:nowrap;padding-top:1px}
 /* Achievement pops — tasteful badge toast, top-right, debounced */
 .cc-ach-wrap{position:fixed;top:16px;right:16px;z-index:1150;display:flex;flex-direction:column;gap:8px;pointer-events:none}
@@ -2095,6 +2109,42 @@ document.querySelectorAll('.ops-filter').forEach(function(f){f.addEventListener(
 });});
 
 function esc(s){var d=document.createElement('div');d.textContent=(s==null?'':String(s));return d.innerHTML;}
+
+// ── Clickable GitHub issue/PR references (#2616) ────────────────────────────────
+// The Operations tab shows plenty of "repo#number" references (ready-work queue,
+// my-work, opportunistic-work, dev-log) but until now they were plain monospace
+// text — Jorge's ask is to make them real, obvious links to GitHub so this page
+// can actually be used to manage work, not just read about it.
+//
+// ccIssueURL prefers the item's own "url" field (the backend's canonical
+// issue/PR link — ReadyQueueItem/OpportunisticItem both carry it) and only
+// constructs a fallback when it's absent. GitHub's /issues/<n> route redirects
+// to /pull/<n> automatically when the number is actually a PR, so the
+// constructed fallback works for both without knowing which one it is.
+function ccIssueURL(item){
+  if(item&&item.url)return item.url;
+  if(item&&item.repo&&item.number)return 'https://github.com/'+item.repo+'/issues/'+item.number;
+  return '';
+}
+// ccIssueLinkHTML renders the repo#number reference as an <a> with an obvious
+// "go to GitHub" affordance: link-blue text, an external-link glyph, and a
+// title tooltip. stopPropagation on click/mousedown keeps the click from ever
+// reaching a row's drag/select handlers (queue drag-reorder in particular) —
+// opening the issue must never start a drag. Opens in a new tab; rel carries
+// noopener+noreferrer since target=_blank hands the new tab a window.opener
+// handle otherwise. Returns a plain esc'd span (no link) when no URL can be
+// produced, so a malformed item never renders a dead/empty link.
+function ccIssueLinkHTML(item,label,extraClass){
+  var url=ccIssueURL(item);
+  if(!url)return '<span class="'+(extraClass||'')+'">'+esc(label)+'</span>';
+  return '<a class="cc-issue-link '+(extraClass||'')+'" href="'+esc(url)+'" target="_blank" rel="noopener noreferrer" '+
+    'title="Open on GitHub" onclick="event.stopPropagation();" onmousedown="event.stopPropagation();">'+
+    esc(label)+
+    '<svg class="cc-issue-link-ic" viewBox="0 0 16 16" width="11" height="11" aria-hidden="true" focusable="false">'+
+    '<path fill="currentColor" d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z"/>'+
+    '<path fill="currentColor" d="M3.75 3A1.75 1.75 0 0 0 2 4.75v7.5c0 .966.784 1.75 1.75 1.75h7.5A1.75 1.75 0 0 0 13 12.25v-3.5a.75.75 0 0 0-1.5 0v3.5a.25.25 0 0 1-.25.25h-7.5a.25.25 0 0 1-.25-.25v-7.5a.25.25 0 0 1 .25-.25h3.5a.75.75 0 0 0 0-1.5h-3.5Z"/>'+
+    '</svg></a>';
+}
 function rel(ts){if(!ts)return '';var d=new Date(ts);if(isNaN(d))return '';var s=Math.floor((Date.now()-d.getTime())/1000);if(s<60)return s+'s ago';var m=Math.floor(s/60);if(m<60)return m+'m ago';var h=Math.floor(m/60);if(h<24)return h+'h ago';return Math.floor(h/24)+'d ago';}
 
 // ── #2534 Operator admin controls (mirror of the Governor Hub config) ──────────
@@ -2554,7 +2604,8 @@ function renderWork(list){
         '<pre class="prompt-text">'+esc(w.prompt_preview)+'</pre>'+
         '<p class="ops-note">Read-only. This is the instruction the agent receives; the scoped GitHub token is delivered separately and is never shown here.</p></details>')
       :'';
-    return '<div class="work-item"><div class="work-repo">'+esc(w.repo||'')+(w.number?('#'+esc(w.number)):'')+'</div>'+
+    var repoLabel=(w.repo||'')+(w.number?('#'+w.number):'');
+    return '<div class="work-item"><div class="work-repo">'+ccIssueLinkHTML(w,repoLabel)+'</div>'+
       '<div class="work-title">'+esc(w.title||'(untitled task)')+'</div>'+
       '<div class="work-meta">'+statusPill(w.status)+who+cli+'</div>'+preview+'</div>';
   }).join('');
@@ -2676,7 +2727,7 @@ function ccRenderQueue(flip){
     // this row's qkey so they act on the right item in the FULL order.
     var menu=adminEnabled?ccQueueMenuHTML(ccQueueKey(q),i,total):'';
     return '<div class="cc-q-item"'+(canDrag?' draggable="true"':'')+' data-qkey="'+esc(ccQueueKey(q))+'">'+grip+'<span class="cc-q-idx">'+(i+1)+'</span>'+
-      '<div class="cc-q-body"><div class="cc-q-repo">'+esc(q.repo||'')+'#'+esc(q.number||'')+'</div>'+
+      '<div class="cc-q-body"><div class="cc-q-repo">'+ccIssueLinkHTML(q,(q.repo||'')+'#'+(q.number||''))+'</div>'+
       '<div class="cc-q-title" title="'+esc(q.title||'')+'">'+esc(q.title||'(untitled)')+'</div>'+labels+'</div>'+next+menu+'</div>';
   }).join('');
   if(filtering&&shown===0){el.innerHTML='<div class="ops-empty">No queued items match &ldquo;'+esc(ccQueueSearch)+'&rdquo;.</div>';}
@@ -2915,16 +2966,28 @@ function initOpsRail(){
 }
 
 // ── Dev-log narration: build a human-readable line from an ActivityEntry ───────
+// ccTaskRefLink turns the "picked up" activity's task string — always built
+// server-side as "<kind> <repo>#<number>: <title>" (contribute_ws.go taskDesc)
+// — into a clickable GitHub link when it matches that exact shape. "completed"/
+// "failed" carry an opaque internal task ID (ct-<repo>-<number>-<ts>), not
+// repo#number, so those are deliberately left as plain text rather than risk a
+// wrong/broken link from a shape this code doesn't control.
+function ccTaskRefLink(task){
+  var m=/^\S+\s+([\w.-]+\/[\w.-]+)#(\d+):/.exec(task||'');
+  if(!m)return '<span class="ref">'+esc(task)+'</span>';
+  return ccIssueLinkHTML({repo:m[1],number:m[2]},task,'ref');
+}
 function ccNarrate(e){
   var icons={joined:'🟢',left:'⚪',"picked up":'🔧',completed:'✅',failed:'❌',promoted:'🎖️'};
   var ic=icons[e.action]||'⚡';
   var who='<span class="who">'+esc(e.username||'someone')+'</span>';
   var ref=e.task?' <span class="ref">'+esc(e.task)+'</span>':'';
+  var pickedRef=e.task?' '+ccTaskRefLink(e.task):'';
   var body;
   switch(e.action){
     case 'joined': body=who+' entered the hive'+(e.cli?' <span class="ref">via '+esc(e.cli)+'</span>':''); break;
     case 'left': body=who+' left the hive'; break;
-    case 'picked up': body=who+' grabbed'+ref; break;
+    case 'picked up': body=who+' grabbed'+pickedRef; break;
     case 'completed': body=who+' completed'+ref; break;
     case 'failed': body=who+' hit a snag on'+ref; break;
     case 'promoted': body=who+' was promoted to <b>'+esc(e.task||e.role||'contributor')+'</b>'; break;
@@ -3199,7 +3262,7 @@ function ccRenderOpportunistic(){
     var add=adminEnabled?('<button type="button" class="opp-add" data-oppkey="'+esc(key)+'" title="Add to the top of the ready-work queue">Add to queue</button>'):'';
     return '<div class="opp-item">'+
       '<span class="opp-heat '+ccOppHeatClass(o.heat)+'" aria-hidden="true"></span>'+
-      '<div class="opp-body"><div class="opp-repo">'+esc(key)+'</div>'+
+      '<div class="opp-body"><div class="opp-repo">'+ccIssueLinkHTML(o,key)+'</div>'+
       '<div class="opp-title" title="'+esc(o.title||'')+'">'+esc(o.title||'(untitled)')+'</div>'+reason+'</div>'+
       add+'</div>';
   }).join('');

--- a/v2/pkg/dashboard/contribute_ops_issue_links_test.go
+++ b/v2/pkg/dashboard/contribute_ops_issue_links_test.go
@@ -1,0 +1,151 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// ── Clickable GitHub issue/PR references on the Operations tab (#2616) ─────────
+//
+// Jorge's ask: the "repo#number" references on Ready-work queue / My work /
+// Opportunistic work were plain monospace text — make them real, obviously
+// clickable links to the actual GitHub issue/PR so the page can be used to
+// manage work directly.
+//
+// This file pins:
+//   - the shared ccIssueURL/ccIssueLinkHTML helpers exist and prefer the
+//     item's own url field, falling back to constructing
+//     https://github.com/<repo>/issues/<number>
+//   - each of the three render functions (ccRenderQueue, renderWork,
+//     ccRenderOpportunistic) wires its repo#number cell through the helper
+//   - the link markup carries target=_blank + rel=noopener noreferrer and an
+//     external-link icon (the "obvious affordance")
+//   - the link's click/mousedown handlers stop propagation so opening the
+//     issue never starts the queue's drag-reorder or any other row handler
+//
+// Runtime DOM behavior of the inline script is out of reach for a Go test
+// (no headless browser here); node --check on the extracted script is the
+// separate syntax/runtime gate. These tests assert the generated markup and
+// wiring are correct by construction.
+
+func TestIssueLinkHelpersExistAndPreferURLField(t *testing.T) {
+	body := renderContributePage(t)
+
+	if !strings.Contains(body, "function ccIssueURL(item){") {
+		t.Fatal("ccIssueURL helper is missing")
+	}
+	urlStart := strings.Index(body, "function ccIssueURL(item){")
+	urlBody := body[urlStart : urlStart+strings.Index(body[urlStart:], "\n}")]
+	if !strings.Contains(urlBody, "item.url") {
+		t.Error("ccIssueURL does not prefer the item's own url field")
+	}
+	if !strings.Contains(urlBody, "https://github.com/'+item.repo+'/issues/'+item.number") {
+		t.Error("ccIssueURL does not construct the github.com/<repo>/issues/<number> fallback")
+	}
+
+	if !strings.Contains(body, "function ccIssueLinkHTML(item,label,extraClass){") {
+		t.Fatal("ccIssueLinkHTML helper is missing")
+	}
+	linkStart := strings.Index(body, "function ccIssueLinkHTML(item,label,extraClass){")
+	linkBody := body[linkStart : linkStart+strings.Index(body[linkStart:], "\n}")]
+	for _, want := range []string{
+		`target="_blank"`,
+		`rel="noopener noreferrer"`,
+		`title="Open on GitHub"`,
+		"event.stopPropagation();",
+		"cc-issue-link-ic", // the external-link icon
+	} {
+		if !strings.Contains(linkBody, want) {
+			t.Errorf("ccIssueLinkHTML missing %q", want)
+		}
+	}
+}
+
+func TestReadyQueueRepoCellUsesIssueLink(t *testing.T) {
+	body := renderContributePage(t)
+	rqStart := strings.Index(body, "function ccRenderQueue(flip){")
+	if rqStart < 0 {
+		t.Fatal("ccRenderQueue is missing")
+	}
+	rqEnd := strings.Index(body[rqStart:], "\nfunction ccQueueMenuHTML")
+	if rqEnd < 0 {
+		t.Fatal("could not bound ccRenderQueue")
+	}
+	rqBody := body[rqStart : rqStart+rqEnd]
+	if !strings.Contains(rqBody, `'<div class="cc-q-body"><div class="cc-q-repo">'+ccIssueLinkHTML(q,`) {
+		t.Error("ccRenderQueue's .cc-q-repo cell does not route through ccIssueLinkHTML")
+	}
+}
+
+func TestMyWorkRepoCellUsesIssueLink(t *testing.T) {
+	body := renderContributePage(t)
+	rwStart := strings.Index(body, "function renderWork(list){")
+	if rwStart < 0 {
+		t.Fatal("renderWork is missing")
+	}
+	rwEnd := strings.Index(body[rwStart:], "\nfunction renderPolicy")
+	if rwEnd < 0 {
+		t.Fatal("could not bound renderWork")
+	}
+	rwBody := body[rwStart : rwStart+rwEnd]
+	if !strings.Contains(rwBody, `'<div class="work-item"><div class="work-repo">'+ccIssueLinkHTML(w,repoLabel)+'</div>'`) {
+		t.Error("renderWork's .work-repo cell does not route through ccIssueLinkHTML")
+	}
+}
+
+func TestOpportunisticRepoCellUsesIssueLink(t *testing.T) {
+	body := renderContributePage(t)
+	oStart := strings.Index(body, "function ccRenderOpportunistic(){")
+	if oStart < 0 {
+		t.Fatal("ccRenderOpportunistic is missing")
+	}
+	oEnd := strings.Index(body[oStart:], "\nfunction ccBindOppAdd")
+	if oEnd < 0 {
+		t.Fatal("could not bound ccRenderOpportunistic")
+	}
+	oBody := body[oStart : oStart+oEnd]
+	if !strings.Contains(oBody, `'<div class="opp-body"><div class="opp-repo">'+ccIssueLinkHTML(o,key)+'</div>'`) {
+		t.Error("ccRenderOpportunistic's .opp-repo cell does not route through ccIssueLinkHTML")
+	}
+}
+
+func TestDevLogPickedUpRefUsesIssueLinkWhenParseable(t *testing.T) {
+	body := renderContributePage(t)
+	if !strings.Contains(body, "function ccTaskRefLink(task){") {
+		t.Fatal("ccTaskRefLink helper is missing")
+	}
+	refStart := strings.Index(body, "function ccTaskRefLink(task){")
+	refBody := body[refStart : refStart+strings.Index(body[refStart:], "\n}")]
+	if !strings.Contains(refBody, "ccIssueLinkHTML({repo:m[1],number:m[2]},task,'ref')") {
+		t.Error("ccTaskRefLink does not build a link via ccIssueLinkHTML from the parsed repo/number")
+	}
+
+	narrateStart := strings.Index(body, "function ccNarrate(e){")
+	if narrateStart < 0 {
+		t.Fatal("ccNarrate is missing")
+	}
+	narrateBody := body[narrateStart : narrateStart+strings.Index(body[narrateStart:], "\nfunction ccRenderLog")]
+	if !strings.Contains(narrateBody, "who+' grabbed'+pickedRef") {
+		t.Error(`ccNarrate's "picked up" case does not use the linked pickedRef`)
+	}
+}
+
+// TestIssueLinkClickStopsPropagation guards the drag-vs-click contract directly:
+// the anchor markup itself carries the stopPropagation handlers, so a click on
+// the link can never bubble to a parent's dragstart/click listener (the queue
+// row is draggable="true" and binds its own click/drag handlers in
+// ccBindQueueDrag / ccBindQueueMenus).
+func TestIssueLinkClickStopsPropagation(t *testing.T) {
+	body := renderContributePage(t)
+	linkStart := strings.Index(body, "function ccIssueLinkHTML(item,label,extraClass){")
+	if linkStart < 0 {
+		t.Fatal("ccIssueLinkHTML is missing")
+	}
+	linkBody := body[linkStart : linkStart+strings.Index(body[linkStart:], "\n}")]
+	if !strings.Contains(linkBody, `onclick="event.stopPropagation();"`) {
+		t.Error("issue link does not stop click propagation — clicking it could trigger a parent row handler")
+	}
+	if !strings.Contains(linkBody, `onmousedown="event.stopPropagation();"`) {
+		t.Error("issue link does not stop mousedown propagation — clicking it could start a drag (dragstart begins on mousedown+move)")
+	}
+}


### PR DESCRIPTION
Fixes #2616

The `repo#number` references on the Operations tab (Ready-work queue, My work, Opportunistic work) rendered as plain monospace text — no way to jump to the actual GitHub issue/PR. This wraps them in real, obviously-clickable links.

## What changed

- **Clickable links** on the three `repo#number` surfaces:
  - Ready-work queue (`ccRenderQueue` / `.cc-q-repo`)
  - My work (`renderWork` / `.work-repo`)
  - Opportunistic work (`ccRenderOpportunistic` / `.opp-repo`)
  - Dev-log's "picked up" reference, when the task string matches the well-defined `"<kind> <repo>#<number>: <title>"` shape it's always built from server-side. `completed`/`failed` carry an opaque internal task ID (not `repo#number`), so those are deliberately left as plain text rather than risk a wrong link.
- **URL sourcing**: prefers the item's own `url` field (`ReadyQueueItem`/`OpportunisticItem` already carry it from the backend); falls back to constructing `https://github.com/<repo>/issues/<number>` when absent — GitHub redirects `/issues/<n>` to `/pull/<n>` automatically, so this works for both issues and PRs without knowing which.
- **Obvious affordance**: link-blue color, hover/focus-visible states, and a small inline external-link SVG glyph (CSP-safe, no external assets) plus a "Open on GitHub" tooltip — so it clearly reads as a "go to GitHub" action rather than decoration, per the ask to make this an actual work-management surface.
- **Click-doesn't-drag**: the link's `onclick`/`onmousedown` stop propagation, so opening an issue from the ready-work queue never starts the row's drag-reorder (or any other row handler). Links open in a new tab with `rel="noopener noreferrer"`.
- Shared helpers `ccIssueURL(item)` / `ccIssueLinkHTML(item,label,extraClass)` so all four surfaces stay consistent.

## Testing

- New `contribute_ops_issue_links_test.go`: asserts the helpers exist and prefer the URL field with the correct fallback construction, that each render function's repo cell routes through the helper, that the link markup carries `target=_blank rel="noopener noreferrer"` + the icon, and that click/mousedown propagation is stopped.
- `go build ./...`, `go vet ./...`, and `go test ./pkg/dashboard/...` all pass.
- `node --check` on the extracted inline script (after unescaping the template's `%%` literals) passes.
- No changes to drag-reorder, search filter, travel animation, play/pause, or other tabs.