### PR TITLE
fix(dashboard): install-ID doesn't stick in Firefox on Linux (works in Safari)

### DIFF
--- a/v2/pkg/dashboard/gh_app_banner_test.go
+++ b/v2/pkg/dashboard/gh_app_banner_test.go
@@ -221,3 +221,68 @@ func TestInstallIdHintPopoverHasViewportCollisionHandling(t *testing.T) {
 		t.Error("expected hover (mouseenter) and keyboard-focus (focusin) listeners that also trigger positionInstallIdHint")
 	}
 }
+
+// TestInstallIdInputIsCrossBrowserHardened is the regression guard for the
+// user report that entering the installation ID and clicking "Set ID" worked
+// instantly in Safari but "did not stick" in Firefox on Linux. Since the same
+// backend serves both (Safari proves the API works), the cause is a Firefox
+// client-side input/event/DOM difference. This locks the defensive hardening:
+//
+//   - The Set-ID button is type="button". A <button> with no type defaults to
+//     type=submit; if the banner were ever wrapped in a form (or Firefox
+//     treated an ancestor as one) the click would trigger an implicit submit
+//     that resets the page and clears the field before the handler ran.
+//   - The input has autocomplete="off" so Firefox form history cannot
+//     offer/refill/clear the value.
+//   - Enter in the input also submits, so entry works even if the Set-ID
+//     button is obscured (e.g. the "?" popover) or its click is flaky.
+//   - renderGitHubAppBanner (which runs on every poll) preserves a value the
+//     user is mid-typing, so a background re-render can never wipe it.
+func TestInstallIdInputIsCrossBrowserHardened(t *testing.T) {
+	html := spokeIndexHTML(t)
+
+	// Isolate the Set-ID button's start tag and require an explicit
+	// type="button" — the exact fix for the implicit-submit reset.
+	const setBtnID = `id="gh-app-set-id-btn"`
+	bi := strings.Index(html, setBtnID)
+	if bi < 0 {
+		t.Fatalf("static/index.html no longer contains %s", setBtnID)
+	}
+	btnOpen := strings.LastIndex(html[:bi], "<button")
+	if btnOpen < 0 {
+		t.Fatalf("could not find the opening <button for the Set-ID control")
+	}
+	btnEnd := strings.Index(html[btnOpen:], ">")
+	btnTag := html[btnOpen : btnOpen+btnEnd+1]
+	if !strings.Contains(btnTag, `type="button"`) {
+		t.Errorf("Set-ID button must be type=\"button\" (a default <button> is type=submit and an implicit form submit resets the field in Firefox before submitGitHubInstallationID runs):\n%s", btnTag)
+	}
+
+	// Isolate the install-ID input's start tag: it must disable autocomplete
+	// and wire an Enter-key submit.
+	const inputID = `id="gh-app-install-id-input"`
+	ii := strings.Index(html, inputID)
+	if ii < 0 {
+		t.Fatalf("static/index.html no longer contains %s", inputID)
+	}
+	inOpen := strings.LastIndex(html[:ii], "<input")
+	inEnd := strings.Index(html[inOpen:], ">")
+	inTag := html[inOpen : inOpen+inEnd+1]
+	if !strings.Contains(inTag, `autocomplete="off"`) {
+		t.Errorf("install-ID input must set autocomplete=\"off\" so Firefox form history can't clear/refill the value:\n%s", inTag)
+	}
+	if !strings.Contains(inTag, "submitGitHubInstallationID()") || !strings.Contains(inTag, "Enter") {
+		t.Errorf("install-ID input must submit on Enter so entry works even if the Set-ID button is obscured or its click is flaky in Firefox:\n%s", inTag)
+	}
+
+	// The per-poll banner render must not clobber a value the user is typing.
+	ri := strings.Index(html, "function renderGitHubAppBanner(data)")
+	if ri < 0 {
+		t.Fatal("static/index.html has no renderGitHubAppBanner function")
+	}
+	end := strings.Index(html[ri:], "\n    }")
+	body := html[ri : ri+end]
+	if !strings.Contains(body, "priorIdValue") {
+		t.Error("renderGitHubAppBanner must snapshot/restore the install-ID input value so a background poll re-render can't wipe what the user typed (the Firefox \"doesn't stick\" symptom)")
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2720,7 +2720,14 @@
       <div class="gh-app-title">GitHub App Not Installed</div>
       <div class="gh-app-desc">This hive cannot create issues or advisory reports. Install the Hive Hub GitHub App on your repository to enable full functionality.</div>
     </div>
+    <!-- autocomplete=off + name-less: Firefox form history would otherwise
+         offer/refill a stored value and, on Linux, could clear the field on a
+         re-render. Enter also submits (onkeydown) so entry works even if the
+         Set-ID button is obscured (e.g. the ? popover) or its click is flaky in
+         Firefox — matching Safari, where the flow already worked instantly. -->
     <input id="gh-app-install-id-input" type="text" inputmode="numeric" placeholder="Installation ID"
+      autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false"
+      onkeydown="if(event.key==='Enter'){event.preventDefault();submitGitHubInstallationID();}"
       title="After installing the app, paste the numeric installation_id from the install URL (github.com/settings/installations/&lt;ID&gt;)"
       style="width:120px;padding:6px 8px;margin-right:6px;background:var(--panel);border:1px solid var(--line);border-radius:4px;color:var(--text);font-size:0.8rem" />
     <!-- Where-do-I-find-this hint. Content is injected by
@@ -2734,8 +2741,13 @@
         onclick="toggleInstallIdHint(event)">?</button>
       <span class="gh-idhint-pop" id="gh-app-install-id-hint-pop" role="tooltip"></span>
     </span>
-    <button onclick="submitGitHubInstallationID()" class="gh-app-btn" style="background:transparent;border-color:var(--line);color:var(--text);margin-right:8px" id="gh-app-set-id-btn">Set ID</button>
-    <button onclick="recheckGitHubApp()" class="gh-app-btn" style="background:transparent;border-color:var(--line);color:var(--muted);margin-right:8px" id="gh-app-recheck-btn">Re-check</button>
+    <!-- type=button is explicit: with no type a <button> defaults to
+         type=submit, and if this banner were ever wrapped in a form (or Firefox
+         treated an ancestor as one), the click would trigger an implicit submit
+         that navigates/resets the page and clears the input before the handler
+         ran — a Firefox-vs-Safari difference. type=button removes that path. -->
+    <button type="button" onclick="submitGitHubInstallationID()" class="gh-app-btn" style="background:transparent;border-color:var(--line);color:var(--text);margin-right:8px" id="gh-app-set-id-btn">Set ID</button>
+    <button type="button" onclick="recheckGitHubApp()" class="gh-app-btn" style="background:transparent;border-color:var(--line);color:var(--muted);margin-right:8px" id="gh-app-recheck-btn">Re-check</button>
     <a id="gh-app-install-link" href="" target="_blank" rel="noopener" class="gh-app-btn">Install GitHub App</a>
   </div>
   <div id="hub-banner" style="display:none"></div>
@@ -5685,8 +5697,17 @@
     function renderGitHubAppBanner(data) {
       var banner = document.getElementById('gh-app-install-banner');
       if (!banner) return;
+      /* This render runs on EVERY status poll. It updates title/desc/link only
+         and must never disturb what the user is typing into the install-ID
+         field: in Firefox on Linux a value that "doesn't stick" is consistent
+         with the field being cleared mid-entry. Snapshot the value before the
+         render and restore it after if anything cleared it, unless the user has
+         since typed something new. Harmless in Safari/Chrome (value unchanged). */
+      var idInput = document.getElementById('gh-app-install-id-input');
+      var priorIdValue = idInput ? idInput.value : null;
       /* Keep the hint's host/org in step with whatever this render knows. */
       renderGitHubAppInstallIdHint(data);
+      if (idInput && priorIdValue && !idInput.value) idInput.value = priorIdValue;
       var appState = data ? String(data.githubAppState || '').trim() : '';
       var isOperatorSide = data && data.githubAppRequired && ghAppIsOperatorSide(appState);
 


### PR DESCRIPTION
## The report

On the hive dashboard's "Install App" banner, a user typed the GitHub App **Installation ID** into `#gh-app-install-id-input` and clicked **Set ID** (`#gh-app-set-id-btn`). In **Safari** it worked instantly. In **Firefox on Linux** the ID **"did not stick."**

Both browsers hit the same backend, and Safari succeeding proves the `PUT /api/config/github` path works. So this is a **Firefox-vs-WebKit client-side input/event/DOM difference**, not a server bug.

## What the code showed

- The **Set-ID button had no `type`** — so it defaulted to `type="submit"`. There is no wrapping `<form>` today, but this is exactly the fragile shape that reproduces the symptom: a submit-type button + any (real or Firefox-inferred) form context fires an **implicit submit that resets the page and clears the field** before the click handler runs — and Firefox and Safari differ here.
- The input had **no `autocomplete`** attribute — Firefox form history can offer/refill/mangle the value.
- **No Enter-to-submit** — if the button click is intercepted (e.g. the adjacent `?` help popover overlapping it, which a sibling PR addresses), there was no fallback.
- The submit logic itself (`parseInt` → `PUT /api/config/github` → toast) is correct and the input value is read live at click time, so that part is left untouched.

## Cross-browser hardening applied (all safe in Safari/Chrome)

| Change | Firefox behavior it addresses |
|---|---|
| Set-ID (and Re-check) button → `type="button"` | Removes any implicit-form-submit that would reset the page/clear the field before the handler runs |
| Input → `autocomplete="off"` (+ autocapitalize/autocorrect/spellcheck off) | Stops Firefox form history from offering/refilling/clearing the value |
| Input → **Enter submits** (`onkeydown` Enter → `submitGitHubInstallationID()`) | Entry works even if the button is obscured or its click is flaky |
| `renderGitHubAppBanner` snapshots/restores the value | The per-poll banner re-render can never wipe what the user is mid-typing |

The existing submit logic is unchanged — only the **input/event path** is hardened.

## Tests

Added `TestInstallIdInputIsCrossBrowserHardened` to `gh_app_banner_test.go`: asserts the Set-ID button is `type=button`, the input has `autocomplete=off` and an Enter handler, and `renderGitHubAppBanner` preserves the in-progress value. `node --check` on the dashboard JS and `go build ./...` both pass.

**Defensive note:** Firefox-on-Linux could not be reproduced in CI, so this hardens the flow against each plausible Firefox cause rather than pinpointing one.

Scope: `v2/pkg/dashboard/static/index.html` + its structural test only.