### PR TITLE
fix(hub): merge sweep must trust GitHub's mergeable verdict, not wait on non-required checks

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -5188,6 +5188,24 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 			continue
 		}
 
+		// A PR whose CI is still "pending" is nonetheless merge-eligible when
+		// GitHub itself reports it as mergeable (mergeStateStatus=unstable):
+		// that state means every REQUIRED check has passed and only
+		// non-required checks remain outstanding. Those non-required checks —
+		// a cancelled Mobile Browser Tests, a still-running coverage-report,
+		// perpetually-pending tide — can never complete on their own, so
+		// waiting for CIStatus=="success" (all checks done) leaves cleanly
+		// mergeable PRs frozen out of the sweep indefinitely (observed
+		// 2026-08-04: three green console PRs stuck for hours). The merge step
+		// re-enforces branch protection, so trusting the mergeable verdict here
+		// cannot merge anything GitHub would actually block.
+		if pr.CIStatus == "pending" && pr.Mergeable != github.MergeableYes {
+			// Genuinely not ready: a required check is still running (or
+			// mergeability is unknown/no). Leave it out of both buckets, as
+			// before — it neither merges nor gets a fix dispatched.
+			continue
+		}
+
 		dco := "unknown"
 		for _, l := range pr.Labels {
 			if l == "dco-signoff: yes" {

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -538,7 +538,7 @@ func (c *Client) EnrichCIStatus(ctx context.Context, prs []PullRequest) {
 		var failingNames []string
 		var failingIDs []int64
 		for _, cr := range checkRuns.CheckRuns {
-			if cr.GetName() == "tide" {
+			if isMetaCheck(cr.GetName()) {
 				continue
 			}
 			ciChecksFound++
@@ -568,6 +568,25 @@ func (c *Client) EnrichCIStatus(ctx context.Context, prs []PullRequest) {
 			prs[i].CIStatus = ciStatusPending
 		}
 	}
+}
+
+// isMetaCheck reports check runs that are merge-gates or deploy-status
+// mirrors, NOT code CI. They must not drive CIStatus: a stale
+// enforce-guardrails (red-main era) or Netlify status left three
+// actually-green PRs classified ci_failing and invisible to the merge sweep
+// for hours (2026-08-04). The merge step itself re-enforces these gates —
+// counting them here only poisons the eligibility signal.
+func isMetaCheck(name string) bool {
+	switch name {
+	case "tide", "enforce-guardrails":
+		return true
+	}
+	for _, prefix := range []string{"Header rules", "Pages changed", "Redirect rules", "netlify/", "copilot"} {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // Bounds for fetchFailureExcerpt: annotations are fetched for at most

--- a/v2/pkg/github/metacheck_test.go
+++ b/v2/pkg/github/metacheck_test.go
@@ -1,0 +1,29 @@
+package github
+
+import "testing"
+
+// TestIsMetaCheck locks in that merge-gate and deploy-status checks are
+// excluded from CI classification, so a stale enforce-guardrails run or a
+// Netlify status mirror can never mark an otherwise-green PR as failing.
+func TestIsMetaCheck(t *testing.T) {
+	meta := []string{
+		"tide",
+		"enforce-guardrails",
+		"Header rules - kubestellarconsole",
+		"Pages changed - kubestellarconsole",
+		"Redirect rules - kubestellarconsole",
+		"netlify/kubestellarconsole/deploy-preview",
+		"copilot-pull-request-reviewer",
+	}
+	for _, name := range meta {
+		if !isMetaCheck(name) {
+			t.Errorf("isMetaCheck(%q) = false, want true (merge-gate/deploy mirror)", name)
+		}
+	}
+	code := []string{"build-gate", "coverage-gate", "unit-test", "TypeScript & ESLint", "Test (chromium, shard 1)"}
+	for _, name := range code {
+		if isMetaCheck(name) {
+			t.Errorf("isMetaCheck(%q) = true, want false (real code CI must gate)", name)
+		}
+	}
+}


### PR DESCRIPTION
## Root cause of the 'stuck at N' merge slowness

The merge sweep only acts on PRs bucketed `eligible`, and eligibility required `CIStatus==success` — i.e. **every** non-meta check completed and passed. Non-required checks routinely never reach that state: a **cancelled** `Mobile Browser Tests`/`coverage-report`, a still-running non-required job, perpetually-**pending** `tide`. So PRs GitHub itself reported as cleanly mergeable (`mergeStateStatus=unstable` = all **required** checks green) sat `pending` and invisible to the sweep for hours.

**Verified 2026-08-04:** three console PRs (#22196/#22189/#22184) showed `mergeable=MERGEABLE state=UNSTABLE`, only cancelled non-required checks outstanding, `build-gate` (the sole required check) green — each merged **instantly** with a plain squash. The hive's own gate would have waited forever.

## Fix (two complementary parts)

1. **`isMetaCheck`** — exclude merge-gate/deploy mirrors (`tide`, `enforce-guardrails`, Netlify `Header/Pages/Redirect rules`, `netlify/*`, copilot review) from CI classification, so a stale guardrails run can't mark a green PR as *failing* (→ wasted fix dispatch).
2. **Eligibility trusts the mergeable verdict** — a `CIStatus==pending` PR is added to the eligible bucket when `Mergeable==Yes`. That verdict comes from `mergeStateStatus`, which already respects branch protection, so this can never merge anything GitHub would block; it only stops the sweep from waiting on checks that never finish. Genuinely-not-ready PRs (required check still running, mergeability unknown/no) still wait.

Together: eligibility now reflects **'required checks pass'**, matching what the merge step actually enforces. Test locks in the classifier. v2 backport to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)