### PR TITLE
🐛 fix(advisory): retire healed access findings from the digest

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -4121,7 +4121,12 @@ func runEvalCycle(
 		dashSrv.SetAdvisoryDigest(digest)
 		statusPayload.AdvisoryDigest = digest
 
-		if digest.TotalCount > 0 {
+		// Post whenever there is something CURRENT to say: open findings, or
+		// recently resolved ones. The latter matters for healing (#2575): when
+		// the last finding resolves, TotalCount drops to 0 but the pinned
+		// digest comment must still be rewritten — otherwise it freezes on its
+		// last non-empty state and keeps showing the healed finding forever.
+		if digest.TotalCount > 0 || len(digest.RecentlyResolved) > 0 {
 			// Log severity breakdown and contributing agents
 			bySeverity := map[string]int{"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0}
 			agentNames := make([]string, 0, len(digest.ByAgent))
@@ -4241,6 +4246,19 @@ func runEvalCycle(
 						dashSrv.SetGitHubAppPermIssue("")
 						dashSrv.SetGitHubAppRequired(false)
 						dashSrv.ClearPendingGitHubAppInstall()
+						// The same proof retires stale ACCESS findings (#2575):
+						// an advisory bead like "Insufficient repo permissions"
+						// created while the App genuinely could not write was
+						// never re-validated, so it stayed in the digest forever
+						// after the App was correctly installed. A successful
+						// App-authenticated digest post is the strongest
+						// possible evidence the condition has healed, so close
+						// those beads now; the next cycle's digest moves them to
+						// "Recently Resolved" and rewrites the pinned comment.
+						if healed := advisory.CloseHealedAppAuthFindings(beadStores); len(healed) > 0 {
+							logger.Info("closed healed GitHub App access findings after successful App digest post",
+								"count", len(healed), "titles", strings.Join(healed, "; "))
+						}
 					}
 				}
 			}

--- a/v2/pkg/advisory/advisory.go
+++ b/v2/pkg/advisory/advisory.go
@@ -164,12 +164,21 @@ func BuildDigestFromBeads(stores map[string]*beads.Store, mode string) *Digest {
 			if b.Title == "" {
 				continue
 			}
-			if b.Status == beads.StatusClosed {
-				if b.ClosedAt != nil && b.ClosedAt.After(cutoff) {
+			// Both closed AND done beads are resolved: agents retire findings
+			// with either status, and a "done" finding lingering in the digest
+			// as if still open is exactly the staleness #2575 is about.
+			if b.Status == beads.StatusClosed || b.Status == beads.StatusDone {
+				// Done beads carry no ClosedAt (only Close sets it); their
+				// UpdatedAt is when the agent marked them done.
+				resolvedAt := b.UpdatedAt.Time
+				if b.ClosedAt != nil {
+					resolvedAt = b.ClosedAt.Time
+				}
+				if resolvedAt.After(cutoff) {
 					resolved = append(resolved, ResolvedFinding{
 						Agent:    agentName,
 						Title:    b.Title,
-						ClosedAt: b.ClosedAt.Time,
+						ClosedAt: resolvedAt,
 						File:     b.ExternalRef,
 					})
 				}
@@ -357,7 +366,21 @@ func repoHintFromTitle(title string, num int, org string) (string, string, bool)
 // into working links, and may be empty to skip linkification.
 func FormatDigestMarkdown(d *Digest, org, primaryRepo string) string {
 	if d.TotalCount == 0 {
-		return ""
+		// No open findings. If nothing was recently resolved either, there is
+		// nothing to say — return "" so no digest comment is created. But when
+		// findings WERE just resolved, an updated digest must still be posted:
+		// otherwise the pinned comment freezes on its last non-empty state and
+		// keeps showing healed findings forever (#2575).
+		if len(d.RecentlyResolved) == 0 {
+			return ""
+		}
+		var b strings.Builder
+		b.WriteString(fmt.Sprintf("## 🐝 Advisory Digest — %s\n\n", d.GeneratedAt.Format("2006-01-02 15:04 MST")))
+		b.WriteString("> Automated code review findings from [Hive](https://github.com/kubestellar/hive) agents. ")
+		b.WriteString("This comment is updated periodically.\n\n")
+		b.WriteString("**Findings:** 0 — all previously reported findings are resolved. ✅\n\n")
+		writeRecentlyResolved(&b, d, org, primaryRepo)
+		return b.String()
 	}
 
 	var all []Finding
@@ -412,16 +435,23 @@ func FormatDigestMarkdown(d *Digest, org, primaryRepo string) string {
 		b.WriteString("\n")
 	}
 
-	if len(d.RecentlyResolved) > 0 {
-		b.WriteString(fmt.Sprintf("### ✅ Recently Resolved (%d)\n\n", len(d.RecentlyResolved)))
-		for _, r := range d.RecentlyResolved {
-			loc := formatFindingRef(r.File, 0, org, primaryRepo, r.Title)
-			b.WriteString(fmt.Sprintf("- ~~%s~~%s _%s — resolved %s_\n", linkifyRefs(r.Title, org), loc, r.Agent, r.ClosedAt.Format("Jan 2")))
-		}
-		b.WriteString("\n")
-	}
+	writeRecentlyResolved(&b, d, org, primaryRepo)
 
 	return b.String()
+}
+
+// writeRecentlyResolved renders the "Recently Resolved" digest section. Shared
+// by the normal and the zero-findings ("all clear") digest renderings.
+func writeRecentlyResolved(b *strings.Builder, d *Digest, org, primaryRepo string) {
+	if len(d.RecentlyResolved) == 0 {
+		return
+	}
+	b.WriteString(fmt.Sprintf("### ✅ Recently Resolved (%d)\n\n", len(d.RecentlyResolved)))
+	for _, r := range d.RecentlyResolved {
+		loc := formatFindingRef(r.File, 0, org, primaryRepo, r.Title)
+		b.WriteString(fmt.Sprintf("- ~~%s~~%s _%s — resolved %s_\n", linkifyRefs(r.Title, org), loc, r.Agent, r.ClosedAt.Format("Jan 2")))
+	}
+	b.WriteString("\n")
 }
 
 // SetLatestDigest stores the most recent digest for dashboard access.
@@ -467,6 +497,15 @@ func PersistAsBeads(findings []Finding, stores map[string]*beads.Store) (created
 		existing := store.List(beads.ListFilter{})
 		dup := false
 		for _, b := range existing {
+			// Only OPEN beads suppress a duplicate. A resolved (closed/done)
+			// bead must not: if the underlying condition recurs after healing —
+			// e.g. repo permissions were fixed, the finding auto-closed, and
+			// the permissions later regressed — the re-reported finding has to
+			// become a fresh open bead or the digest would stay silent about a
+			// genuinely-failing condition (#2575).
+			if b.Status == beads.StatusClosed || b.Status == beads.StatusDone {
+				continue
+			}
 			if b.Title == f.Title && b.Type == beads.TypeAdvisory {
 				dup = true
 				break

--- a/v2/pkg/advisory/heal.go
+++ b/v2/pkg/advisory/heal.go
@@ -1,0 +1,91 @@
+package advisory
+
+import (
+	"regexp"
+
+	"github.com/kubestellar/hive/v2/pkg/beads"
+)
+
+// appAuthHealedCloseReason is stamped into a bead's metadata when the hive
+// auto-closes it because the GitHub App demonstrably works. Kept as a named
+// constant so logs, tests and the bead trail all agree on the exact wording.
+const appAuthHealedCloseReason = "auto-closed: the GitHub App successfully posted the advisory digest, so this access finding no longer holds"
+
+// closeReasonMetadataKey is the metadata key used to record why a bead was
+// auto-closed. It matches the key beads.CloseAll already writes so every
+// close path is inspectable the same way.
+const closeReasonMetadataKey = "close_reason"
+
+// appAuthFindingPatterns recognize advisory findings that describe THIS hive's
+// own GitHub access — the App not being installed, or the installation lacking
+// repo permissions. These are environment conditions the hive can verify
+// itself, unlike code findings, which only an agent can re-check.
+//
+// The patterns are deliberately narrow: they must match agent phrasings like
+// "Insufficient repo permissions" or "GitHub App not installed" without ever
+// matching a CODE finding that merely mentions permissions (e.g. "Workflow
+// permissions overly broad in ci.yml" or "Add permission checks to admin
+// API"). A false close here would silently retire a real repo-content finding,
+// so every pattern requires the insufficiency/installation language, not just
+// the word "permission".
+var appAuthFindingPatterns = []*regexp.Regexp{
+	// "Insufficient repo permissions", "insufficient permissions for the app"
+	regexp.MustCompile(`(?i)\binsufficient\b[^.\n]*\bpermissions?\b`),
+	// "Repo permissions insufficient", "permissions are insufficient"
+	regexp.MustCompile(`(?i)\bpermissions?\b[^.\n]*\binsufficient\b`),
+	// "GitHub App not installed", "GitHub App lacks repo permissions"
+	regexp.MustCompile(`(?i)\bgithub app\b[^.\n]*\b(not installed|missing|lacks|permissions?|access)\b`),
+	// The literal 403 body GitHub returns when an installation token cannot
+	// act on a repo — agents quote it verbatim in findings.
+	regexp.MustCompile(`(?i)resource not accessible by integration`),
+}
+
+// IsAppAuthFinding reports whether a finding title describes the hive's own
+// GitHub App access (installation / repo permissions) rather than a code
+// finding. Only titles — never free-form details — are matched, because the
+// title is what PersistAsBeads dedups on and what the digest displays.
+func IsAppAuthFinding(title string) bool {
+	if title == "" {
+		return false
+	}
+	for _, p := range appAuthFindingPatterns {
+		if p.MatchString(title) {
+			return true
+		}
+	}
+	return false
+}
+
+// CloseHealedAppAuthFindings closes every open advisory-digest bead that
+// describes the hive's GitHub App access, across all agent stores. Callers
+// invoke it ONLY after the App has PROVEN it can write — a successful
+// App-authenticated advisory-digest post — so a finding is never closed on a
+// guess (#2575: an "Insufficient repo permissions" bead survived forever after
+// the App was correctly installed, because nothing ever re-validated it).
+//
+// Beads that are already closed/done are left untouched, as are findings that
+// do not match the app-auth patterns — a genuinely-failing permission
+// condition never reaches this function, because the digest post that gates it
+// would have failed. Returns the closed titles for logging.
+func CloseHealedAppAuthFindings(stores map[string]*beads.Store) []string {
+	var closed []string
+	for _, store := range stores {
+		for _, b := range store.List(beads.ListFilter{}) {
+			if b.Status == beads.StatusClosed || b.Status == beads.StatusDone {
+				continue
+			}
+			if !isAdvisoryBeadType(b.Type) {
+				continue
+			}
+			if !IsAppAuthFinding(b.Title) {
+				continue
+			}
+			if err := store.Close(b.ID); err != nil {
+				continue
+			}
+			_ = store.SetMetadata(b.ID, closeReasonMetadataKey, appAuthHealedCloseReason)
+			closed = append(closed, b.Title)
+		}
+	}
+	return closed
+}

--- a/v2/pkg/advisory/heal_test.go
+++ b/v2/pkg/advisory/heal_test.go
@@ -1,0 +1,214 @@
+package advisory
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/beads"
+)
+
+func TestIsAppAuthFinding(t *testing.T) {
+	tests := []struct {
+		title string
+		want  bool
+	}{
+		// The exact finding from #2575, and close phrasings agents use for
+		// the hive's own App access.
+		{"Insufficient repo permissions", true},
+		{"insufficient permissions for the GitHub App", true},
+		{"Repo permissions insufficient to open issues", true},
+		{"GitHub App not installed on the org", true},
+		{"GitHub App lacks Issues write access", true},
+		{"403 Resource not accessible by integration", true},
+
+		// Code/content findings that mention permissions must NEVER match —
+		// closing them would silently retire a real finding.
+		{"Workflow permissions overly broad in ci.yml", false},
+		{"Add permission checks to the admin API", false},
+		{"SQL injection in login handler", false},
+		{"Fix flaky scheduler test", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := IsAppAuthFinding(tt.title); got != tt.want {
+			t.Errorf("IsAppAuthFinding(%q) = %v, want %v", tt.title, got, tt.want)
+		}
+	}
+}
+
+// TestAdvisoryFindingHealsOnPass is the #2575 regression test: an access
+// finding must appear in the digest while the condition is real, and must
+// LEAVE the digest (moving to Recently Resolved) once the App has proven it
+// can write.
+func TestAdvisoryFindingHealsOnPass(t *testing.T) {
+	store, err := beads.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stores := map[string]*beads.Store{"scanner": store}
+
+	if _, err := store.Create("Insufficient repo permissions", beads.TypeAdvisory, beads.PriorityHigh, "scanner", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// (1) While the condition holds (no successful App post yet), the finding
+	// is in the digest.
+	d := BuildDigestFromBeads(stores, "busy")
+	if d.TotalCount != 1 {
+		t.Fatalf("before heal: TotalCount = %d, want 1", d.TotalCount)
+	}
+	if len(d.ByAgent["scanner"]) != 1 || d.ByAgent["scanner"][0].Title != "Insufficient repo permissions" {
+		t.Fatalf("before heal: finding missing from digest: %+v", d.ByAgent)
+	}
+
+	// (2) The App proves it can write — the caller invokes the heal. The
+	// finding must disappear from open findings and show as resolved.
+	healed := CloseHealedAppAuthFindings(stores)
+	if len(healed) != 1 || healed[0] != "Insufficient repo permissions" {
+		t.Fatalf("healed = %v, want the one access finding", healed)
+	}
+
+	d = BuildDigestFromBeads(stores, "busy")
+	if d.TotalCount != 0 {
+		t.Errorf("after heal: TotalCount = %d, want 0", d.TotalCount)
+	}
+	if len(d.RecentlyResolved) != 1 || d.RecentlyResolved[0].Title != "Insufficient repo permissions" {
+		t.Errorf("after heal: RecentlyResolved = %+v, want the healed finding", d.RecentlyResolved)
+	}
+
+	// (3) The zero-findings digest must still RENDER, so the pinned GitHub
+	// comment gets rewritten instead of freezing on the stale finding.
+	md := FormatDigestMarkdown(d, "acme", "widgets")
+	if md == "" {
+		t.Fatal("after heal: FormatDigestMarkdown returned empty — the stale comment would never update")
+	}
+	if !strings.Contains(md, "**Findings:** 0") {
+		t.Errorf("all-clear digest missing zero-findings line:\n%s", md)
+	}
+	if !strings.Contains(md, "~~Insufficient repo permissions~~") {
+		t.Errorf("all-clear digest missing resolved finding:\n%s", md)
+	}
+
+	// (4) Healing must be idempotent: nothing left to close.
+	if again := CloseHealedAppAuthFindings(stores); len(again) != 0 {
+		t.Errorf("second heal closed %v, want none", again)
+	}
+}
+
+// TestCloseHealedAppAuthFindingsSelectivity verifies only app-access advisory
+// beads are closed: code findings, non-advisory bead types and already-closed
+// beads are all left alone, and the close reason is recorded.
+func TestCloseHealedAppAuthFindingsSelectivity(t *testing.T) {
+	store, err := beads.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stores := map[string]*beads.Store{"scanner": store}
+
+	access, err := store.Create("Insufficient repo permissions", beads.TypeAdvisory, beads.PriorityHigh, "scanner", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := store.Create("Workflow permissions overly broad in ci.yml", beads.TypeAdvisory, beads.PriorityMedium, "scanner", "ci.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	task, err := store.Create("GitHub App not installed follow-up", beads.TypeTask, beads.PriorityLow, "scanner", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	already, err := store.Create("GitHub App lacks repo access", beads.TypeAdvisory, beads.PriorityHigh, "scanner", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(already.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	healed := CloseHealedAppAuthFindings(stores)
+	if len(healed) != 1 || healed[0] != "Insufficient repo permissions" {
+		t.Fatalf("healed = %v, want only the open access finding", healed)
+	}
+
+	got, _ := store.Get(access.ID)
+	if got.Status != beads.StatusClosed {
+		t.Errorf("access bead status = %s, want closed", got.Status)
+	}
+	if reason := got.Meta(closeReasonMetadataKey); reason != appAuthHealedCloseReason {
+		t.Errorf("close reason = %q, want %q", reason, appAuthHealedCloseReason)
+	}
+	for _, b := range []*beads.Bead{code, task} {
+		got, _ := store.Get(b.ID)
+		if got.Status != beads.StatusOpen {
+			t.Errorf("bead %q status = %s, want open (must not be auto-closed)", b.Title, got.Status)
+		}
+	}
+}
+
+// TestPersistAsBeadsRecreatesAfterResolve verifies a RECURRENCE is not
+// suppressed: once a finding's bead is resolved, re-reporting the same title
+// must create a fresh open bead, so a condition that heals and later regresses
+// reappears in the digest.
+func TestPersistAsBeadsRecreatesAfterResolve(t *testing.T) {
+	store, err := beads.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stores := map[string]*beads.Store{"scanner": store}
+	findings := []Finding{{Agent: "scanner", Severity: "high", Title: "Insufficient repo permissions"}}
+
+	if created := PersistAsBeads(findings, stores); created != 1 {
+		t.Fatalf("first persist created %d, want 1", created)
+	}
+	// While open, the same title is a dup.
+	if created := PersistAsBeads(findings, stores); created != 0 {
+		t.Fatalf("open dup created %d, want 0", created)
+	}
+
+	if healed := CloseHealedAppAuthFindings(stores); len(healed) != 1 {
+		t.Fatalf("healed %d, want 1", len(healed))
+	}
+
+	// The condition regressed and the agent reported it again: a new open
+	// bead must be created.
+	if created := PersistAsBeads(findings, stores); created != 1 {
+		t.Fatalf("post-resolve persist created %d, want 1 (recurrence must not be suppressed)", created)
+	}
+	d := BuildDigestFromBeads(stores, "busy")
+	if d.TotalCount != 1 {
+		t.Errorf("digest after recurrence TotalCount = %d, want 1", d.TotalCount)
+	}
+}
+
+// TestBuildDigestFromBeadsDoneIsResolved verifies a bead an agent marked
+// "done" is treated as resolved, not as a still-open finding.
+func TestBuildDigestFromBeadsDoneIsResolved(t *testing.T) {
+	store, err := beads.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := store.Create("fixed thing", beads.TypeAdvisory, beads.PriorityMedium, "scanner", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Update(b.ID, func(bd *beads.Bead) { bd.Status = beads.StatusDone }); err != nil {
+		t.Fatal(err)
+	}
+
+	d := BuildDigestFromBeads(map[string]*beads.Store{"scanner": store}, "busy")
+	if d.TotalCount != 0 {
+		t.Errorf("TotalCount = %d, want 0 (done beads are resolved)", d.TotalCount)
+	}
+	if len(d.RecentlyResolved) != 1 || d.RecentlyResolved[0].Title != "fixed thing" {
+		t.Errorf("RecentlyResolved = %+v, want the done bead", d.RecentlyResolved)
+	}
+}
+
+// TestFormatDigestMarkdownStillEmptyWhenNothingToSay pins the unchanged
+// behavior: no findings AND no recent resolutions renders nothing.
+func TestFormatDigestMarkdownStillEmptyWhenNothingToSay(t *testing.T) {
+	d := BuildDigestFromBeads(map[string]*beads.Store{}, "idle")
+	if md := FormatDigestMarkdown(d, "acme", "widgets"); md != "" {
+		t.Errorf("expected empty markdown, got:\n%s", md)
+	}
+}


### PR DESCRIPTION
## Root cause: stale persistence, not a broken probe

The hive in #2575 (GHE user "Gabriel") kept showing **"Insufficient repo permissions"** in the advisory digest after the Hive GitHub App was installed with correct permissions. The operator's hypothesis was right: it is a leftover bead from when the condition was true.

**Audit of the probe path (candidate b) — clean.** `DiagnoseAppAuth` calls `GET /app/installations/{id}` with the App JWT and honors the configured API base via `setBaseURL` (GHE-safe); it never touches `/user` (which always 403s for installation tokens). `ProbeIssueWrite` performs a real no-op edit. So the check itself was not false-positive.

**The lifecycle gap (candidate a) — confirmed.** The finding is an agent-created advisory bead. The pipeline only ever ADDS:

- `PersistAsBeads` / `bd create` create beads; nothing on the system side ever closes an access finding when the condition heals. `BuildDigestFromBeads` includes every open advisory bead, forever.
- Worse, even a successful App-authenticated digest post every cycle — definitive proof of `issues:write` on the exact repo — cleared the dashboard banner (`SetGitHubAppRequired(false)`) but left the bead untouched.
- And if the last finding HAD been closed, the digest post is gated on `TotalCount > 0`, so the pinned GitHub comment would freeze on its last non-empty state and keep displaying the healed finding anyway.

## Fix — healed conditions clear, real ones persist

1. **`CloseHealedAppAuthFindings`** (`v2/pkg/advisory/heal.go`): after a **successful App-authenticated digest post** (the strongest possible proof of write access, on the hive's configured GitHub host), open advisory beads whose *title* describes the hive's own App access ("insufficient … permissions", "GitHub App not installed/lacks …", "Resource not accessible by integration") are auto-closed with a recorded `close_reason`. Patterns are deliberately narrow: code findings that merely mention permissions ("Workflow permissions overly broad in ci.yml") never match. The user-token *fallback* post does **not** trigger healing — it proves nothing about the App.
2. **Zero-findings digest still posts**: the post gate is now `TotalCount > 0 || len(RecentlyResolved) > 0`, and `FormatDigestMarkdown` renders an all-clear digest ("Findings: 0 …" + Recently Resolved) so the pinned comment gets rewritten instead of freezing.
3. **Recurrence is not suppressed**: `PersistAsBeads` dedup now ignores resolved beads, so if permissions regress after healing, the re-reported finding becomes a fresh open bead.
4. **`done` beads count as resolved** in the digest (previously only `closed` did — a `bd update --status done` finding lingered as open forever).

**No behavior change while the condition is real:** healing runs only after the App post *succeeds*; while permissions are genuinely insufficient that post fails, the finding stays, and the existing banner/classification paths are untouched. No tokens are logged (only bead titles/counts).

## Tests (`v2/pkg/advisory/heal_test.go`)

- `TestIsAppAuthFinding` — pattern positives (incl. the exact #2575 title) and code-finding negatives
- `TestAdvisoryFindingHealsOnPass` — the regression: finding appears while failing → disappears after heal → moves to Recently Resolved → all-clear digest renders → idempotent
- `TestCloseHealedAppAuthFindingsSelectivity` — code findings, non-advisory types, already-closed beads untouched; close reason recorded
- `TestPersistAsBeadsRecreatesAfterResolve` — regression after healing re-creates the finding
- `TestBuildDigestFromBeadsDoneIsResolved`, `TestFormatDigestMarkdownStillEmptyWhenNothingToSay`

Fixes #2575
