### PR TITLE
🐛 fix(scheduler): stop backend token burn beyond configured cadences

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -3976,17 +3976,28 @@ func runEvalCycle(
 		actionable.Issues.SLAViolations,
 	)
 
-	// Restarted agents need a kick even if the governor wouldn't schedule one this cycle.
+	// Crash-restarted agents may get a "resume" kick ahead of their cadence
+	// slot so work interrupted mid-task resumes promptly — but ONLY through
+	// the governor's gate (#2573). Unconditionally kicking every restarted
+	// agent meant a crash-looping CLI was kicked on every eval cycle,
+	// burning backend tokens far faster than any configured cadence and
+	// bypassing the budget gate; AllowResumeKick bounds resume kicks to one
+	// per cadence interval and respects mode pauses and the budget.
 	if len(restartedAgents) > 0 {
 		dueSet := make(map[string]bool, len(agentsDue))
 		for _, a := range agentsDue {
 			dueSet[a] = true
 		}
 		for _, a := range restartedAgents {
-			if !dueSet[a] {
-				agentsDue = append(agentsDue, a)
-				logger.Info("adding restarted agent to kick list", "agent", a)
+			if dueSet[a] {
+				continue
 			}
+			if !gov.AllowResumeKick(a) {
+				logger.Info("restarted agent NOT resume-kicked (cadence/budget gate); it will be kicked at its next scheduled slot", "agent", a)
+				continue
+			}
+			agentsDue = append(agentsDue, a)
+			logger.Info("adding restarted agent to kick list", "agent", a)
 		}
 	}
 
@@ -4010,6 +4021,14 @@ func runEvalCycle(
 			continue
 		}
 		if onDemandSet[name] {
+			continue
+		}
+		// Operator-paused agents must consume NOTHING (#2573). SendKick
+		// would reject the kick anyway (paused ⇒ not running), but skipping
+		// here keeps paused agents out of BuildKickMessages and the audit
+		// log, and avoids a spurious "failed to send kick" error every eval
+		// cycle for a deliberate pause.
+		if agentMgr.IsPaused(name) {
 			continue
 		}
 		filteredDue = append(filteredDue, name)

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -161,6 +161,22 @@ const (
 	kickHistoryCapacity = 500
 )
 
+// Cadence sentinel values the config layer emits. "pause"/"paused" mark an
+// agent the operator does not want timer-kicked in a mode; "off" is the
+// dashboard's spelling for the same thing. Kept as named constants so the
+// governor and the dashboard's display logic agree on the exact strings.
+const (
+	cadenceValuePause  = "pause"
+	cadenceValuePaused = "paused"
+	cadenceValueOff    = "off"
+)
+
+// idleModeKey is the mode whose cadence entries serve as the per-agent
+// fallback when the current mode defines none. This mirrors the dashboard's
+// display chain (current mode → idle), so the interval the governor actually
+// kicks on is always the interval the agent card shows.
+const idleModeKey = "idle"
+
 type Governor struct {
 	cfg    config.GovernorConfig
 	agents map[string]config.AgentConfig
@@ -172,6 +188,12 @@ type Governor struct {
 	evalHistory []EvalSnapshot
 	kickHistory []KickRecord
 	budget      BudgetInfo
+
+	// resumeKicks records the last crash-recovery resume kick granted per
+	// agent (see AllowResumeKick). In-memory only: after a process restart
+	// the startup path re-kicks every eligible agent anyway, so persisting
+	// this would not tighten the bound.
+	resumeKicks map[string]time.Time
 
 	// One-shot alert flags for the current budget window; reset when the
 	// window rolls so each window alerts at most once per threshold.
@@ -200,6 +222,7 @@ func New(cfg config.GovernorConfig, agents map[string]config.AgentConfig, logger
 		modeHistory: []ModeChange{initialChange},
 		evalHistory: make([]EvalSnapshot, 0, evalHistoryCapacity),
 		kickHistory: make([]KickRecord, 0, kickHistoryCapacity),
+		resumeKicks: make(map[string]time.Time),
 		budget: BudgetInfo{
 			ByAgent: make(map[string]int64),
 			ByModel: make(map[string]int64),
@@ -329,21 +352,32 @@ func (g *Governor) thresholdFor(modeName string) int {
 	}
 }
 
+// updateCadences recomputes every agent's effective cadence for the current
+// mode. Resolution chain per agent: current-mode entry → idle-mode entry →
+// none (no timer kicks) — the same chain the dashboard uses to display the
+// agent's interval, so kick timing and the "next run" card always agree.
+//
+// The result REPLACES the previous cadence state. Before #2573 an agent
+// missing from the current mode's cadence map silently KEPT the interval
+// from whichever mode last defined one, so a hive leaving a short-cadence
+// mode kept kicking on the short interval while the dashboard displayed the
+// configured (longer) one — burning backend tokens faster than any cadence
+// the operator could see or set.
 func (g *Governor) updateCadences() {
 	modeName := modeToConfigKey(g.state.Mode)
-	modeConfig, ok := g.cfg.Modes[modeName]
-	if !ok {
-		return
-	}
+	cadences := make(map[string]AgentCadence, len(g.agents))
 
 	for agentName := range g.agents {
-		cadenceStr, ok := modeConfig.Cadences[agentName]
-		if !ok {
+		cadenceStr, ok := g.resolveCadence(modeName, agentName)
+		if !ok || cadenceStr == cadenceValueOff {
+			// No cadence configured for this agent in this mode (or an
+			// explicit "off"): no timer kicks. Leaving the agent out of the
+			// map — rather than keeping a stale entry — is the fix.
 			continue
 		}
 
-		if cadenceStr == "pause" || cadenceStr == "paused" {
-			g.state.Cadences[agentName] = AgentCadence{
+		if cadenceStr == cadenceValuePause || cadenceStr == cadenceValuePaused {
+			cadences[agentName] = AgentCadence{
 				Agent:  agentName,
 				Paused: true,
 			}
@@ -352,7 +386,7 @@ func (g *Governor) updateCadences() {
 
 		dur, err := time.ParseDuration(cadenceStr)
 		if err != nil {
-			g.logger.Warn("invalid cadence duration",
+			g.logger.Warn("invalid cadence duration — agent will receive no timer kicks until fixed",
 				"agent", agentName,
 				"mode", g.state.Mode,
 				"value", cadenceStr,
@@ -361,11 +395,32 @@ func (g *Governor) updateCadences() {
 			continue
 		}
 
-		g.state.Cadences[agentName] = AgentCadence{
+		cadences[agentName] = AgentCadence{
 			Agent:    agentName,
 			Interval: dur,
 		}
 	}
+
+	g.state.Cadences = cadences
+}
+
+// resolveCadence returns the configured cadence string for one agent in one
+// mode, falling back to the idle mode's entry when the mode defines none.
+func (g *Governor) resolveCadence(modeName, agentName string) (string, bool) {
+	if mode, ok := g.cfg.Modes[modeName]; ok {
+		if c, ok := mode.Cadences[agentName]; ok {
+			return c, true
+		}
+	}
+	if modeName == idleModeKey {
+		return "", false
+	}
+	if mode, ok := g.cfg.Modes[idleModeKey]; ok {
+		if c, ok := mode.Cadences[agentName]; ok {
+			return c, true
+		}
+	}
+	return "", false
 }
 
 // budgetExhausted reports whether the weekly budget gate is closed.
@@ -421,6 +476,60 @@ func (g *Governor) agentsDueForKick() []string {
 	}
 
 	return due
+}
+
+// budgetExempt reports whether the named agent is on the budget exemption
+// list (kicked even when the weekly budget is exhausted). Caller must hold g.mu.
+func (g *Governor) budgetExempt(agentName string) bool {
+	for _, name := range g.budget.IgnoredAgents {
+		if name == agentName {
+			return true
+		}
+	}
+	return false
+}
+
+// AllowResumeKick reports whether a crash-restarted agent may receive an
+// immediate "resume" kick ahead of its scheduled cadence slot, and records
+// the grant. The early kick exists so an agent whose CLI crashed mid-task
+// resumes promptly instead of idling until the next scheduled kick.
+//
+// Before #2573 this was UNCONDITIONAL: every crash restart earned a kick, so
+// a crash-looping CLI was restarted AND kicked on every governor eval cycle
+// (default 5 minutes) — burning backend tokens ("Bob coins") continuously on
+// agents the operator had set to multi-hour cadences, and bypassing the
+// budget gate as well. The gates, in order:
+//
+//   - the agent must have an active cadence in the current mode: a mode
+//     "pause"/"off" (or no cadence at all) means the operator wants no timer
+//     work, and a crash must not override that;
+//   - on-demand and non-kick-channel agents never get resume kicks (they are
+//     never timer-kicked at all);
+//   - the budget gate must be open for the agent, with the same exemption
+//     list as scheduled kicks;
+//   - at most ONE resume kick per cadence interval: a crash loop gets its
+//     first resume, then waits for the next scheduled slot, bounding worst-
+//     case kick frequency at two per interval (one scheduled + one resume)
+//     instead of one per eval cycle.
+func (g *Governor) AllowResumeKick(agentName string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	cadence, ok := g.state.Cadences[agentName]
+	if !ok || cadence.Paused || cadence.Interval <= 0 {
+		return false
+	}
+	if ac, ok := g.agents[agentName]; ok && (ac.OnDemand || !ac.UsesGovernorKick()) {
+		return false
+	}
+	if g.budgetExhausted() && !g.budgetExempt(agentName) {
+		return false
+	}
+	if last, ok := g.resumeKicks[agentName]; ok && time.Since(last) < cadence.Interval {
+		return false
+	}
+	g.resumeKicks[agentName] = time.Now()
+	return true
 }
 
 func (g *Governor) RecordKick(agentName string) {

--- a/v2/pkg/governor/governor_cadence_burn_test.go
+++ b/v2/pkg/governor/governor_cadence_burn_test.go
@@ -1,0 +1,226 @@
+package governor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// Regression tests for #2573: the hive burned backend tokens ("Bob coins")
+// faster than any configured cadence because (a) stale cadences from a
+// previous mode were silently retained when the current mode had no entry,
+// and (b) crash-restarted agents were force-kicked unconditionally on every
+// eval cycle.
+
+// queue depths chosen to land the test governor in a specific mode
+// (thresholds: quiet=2, busy=10, surge=20).
+const (
+	queueDepthIdle  = 0
+	queueDepthQuiet = 3
+	queueDepthBusy  = 15
+	queueDepthSurge = 25
+)
+
+// TestUpdateCadences_NoStaleCarryOverAcrossModes is the core #2573
+// regression: an agent with an entry in one mode but not another must NOT
+// keep the old mode's (shorter) interval after the mode changes — it must
+// fall back to the idle-mode entry, exactly like the dashboard displays.
+func TestUpdateCadences_NoStaleCarryOverAcrossModes(t *testing.T) {
+	cfg := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{
+			"idle":  {Threshold: 0, Cadences: map[string]string{"scanner": "6h"}},
+			"quiet": {Threshold: 2, Cadences: map[string]string{"scanner": "6h"}},
+			// busy defines a short scanner cadence; quiet/idle are 6h.
+			"busy":  {Threshold: 10, Cadences: map[string]string{"scanner": "5m"}},
+			"surge": {Threshold: 20, Cadences: map[string]string{}},
+		},
+	}
+	agents := map[string]config.AgentConfig{
+		"scanner": {Backend: "bob", Enabled: true},
+	}
+	g := New(cfg, agents, testLogger())
+
+	// Enter BUSY: scanner runs at 5m.
+	g.Evaluate(queueDepthBusy, 0, 0, 0)
+	if c := g.GetState().Cadences["scanner"]; c.Interval != 5*time.Minute {
+		t.Fatalf("busy cadence = %v, want 5m", c.Interval)
+	}
+
+	// Drop back to QUIET: scanner must run at quiet's 6h, not busy's stale 5m.
+	g.Evaluate(queueDepthQuiet, 0, 0, 0)
+	if c := g.GetState().Cadences["scanner"]; c.Interval != 6*time.Hour {
+		t.Errorf("quiet cadence = %v, want 6h (stale busy cadence retained)", c.Interval)
+	}
+
+	// Enter SURGE (no scanner entry): falls back to IDLE's 6h — the value the
+	// dashboard shows — not busy's stale 5m.
+	g.Evaluate(queueDepthSurge, 0, 0, 0)
+	if c := g.GetState().Cadences["scanner"]; c.Interval != 6*time.Hour {
+		t.Errorf("surge cadence = %v, want idle fallback 6h", c.Interval)
+	}
+}
+
+// TestUpdateCadences_MissingModeBlockFallsBackToIdle covers the whole-mode
+// gap: before the fix a missing mode block returned early and kept EVERY
+// agent's previous cadence.
+func TestUpdateCadences_MissingModeBlockFallsBackToIdle(t *testing.T) {
+	cfg := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{
+			"idle": {Threshold: 0, Cadences: map[string]string{"scanner": "4h"}},
+			"busy": {Threshold: 10, Cadences: map[string]string{"scanner": "2m"}},
+			// no "quiet" or "surge" blocks at all
+		},
+	}
+	agents := map[string]config.AgentConfig{
+		"scanner": {Backend: "bob", Enabled: true},
+	}
+	g := New(cfg, agents, testLogger())
+
+	g.Evaluate(queueDepthBusy, 0, 0, 0) // busy: 2m
+	// quiet has no block (threshold defaults apply: quiet>2) — idle fallback.
+	g.Evaluate(queueDepthQuiet, 0, 0, 0)
+	if c := g.GetState().Cadences["scanner"]; c.Interval != 4*time.Hour {
+		t.Errorf("cadence with missing mode block = %v, want idle fallback 4h", c.Interval)
+	}
+}
+
+// TestUpdateCadences_IdleFallbackRespectsPause: an idle-mode "pause" must
+// carry into modes with no entry, keeping the agent un-kicked.
+func TestUpdateCadences_IdleFallbackRespectsPause(t *testing.T) {
+	cfg := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{
+			"idle": {Threshold: 0, Cadences: map[string]string{"supervisor": "pause"}},
+			"busy": {Threshold: 10, Cadences: map[string]string{}},
+		},
+	}
+	agents := map[string]config.AgentConfig{
+		"supervisor": {Backend: "claude", Enabled: true},
+	}
+	g := New(cfg, agents, testLogger())
+
+	g.Evaluate(queueDepthBusy, 0, 0, 0)
+	c, ok := g.GetState().Cadences["supervisor"]
+	if !ok || !c.Paused {
+		t.Errorf("supervisor cadence = %+v (ok=%v), want Paused via idle fallback", c, ok)
+	}
+	if due := g.agentsDueForKick(); len(due) != 0 {
+		t.Errorf("paused-by-fallback agent listed as due: %v", due)
+	}
+}
+
+// TestUpdateCadences_OffMeansNoKicks: the "off" sentinel removes the agent
+// from timer kicking entirely rather than warning about an unparsable value.
+func TestUpdateCadences_OffMeansNoKicks(t *testing.T) {
+	cfg := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{
+			"idle": {Threshold: 0, Cadences: map[string]string{"scanner": "off"}},
+		},
+	}
+	agents := map[string]config.AgentConfig{
+		"scanner": {Backend: "bob", Enabled: true},
+	}
+	g := New(cfg, agents, testLogger())
+
+	g.Evaluate(queueDepthIdle, 0, 0, 0)
+	if _, ok := g.GetState().Cadences["scanner"]; ok {
+		t.Error("agent with cadence 'off' should have no cadence entry")
+	}
+	if due := g.agentsDueForKick(); len(due) != 0 {
+		t.Errorf("agent with cadence 'off' listed as due: %v", due)
+	}
+}
+
+func resumeTestGovernor(t *testing.T, cadence string) *Governor {
+	t.Helper()
+	cfg := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{
+			"idle": {Threshold: 0, Cadences: map[string]string{"scanner": cadence}},
+		},
+	}
+	agents := map[string]config.AgentConfig{
+		"scanner": {Backend: "bob", Enabled: true},
+	}
+	g := New(cfg, agents, testLogger())
+	g.Evaluate(queueDepthIdle, 0, 0, 0) // populate state.Cadences
+	return g
+}
+
+// TestAllowResumeKick_OncePerInterval: the first crash restart earns a
+// resume kick; a crash loop inside the same cadence interval does not.
+func TestAllowResumeKick_OncePerInterval(t *testing.T) {
+	g := resumeTestGovernor(t, "6h")
+
+	if !g.AllowResumeKick("scanner") {
+		t.Fatal("first resume kick should be allowed")
+	}
+	if g.AllowResumeKick("scanner") {
+		t.Error("second resume kick within the cadence interval should be denied")
+	}
+
+	// Simulate the interval elapsing: backdate the recorded resume kick.
+	g.mu.Lock()
+	g.resumeKicks["scanner"] = time.Now().Add(-7 * time.Hour)
+	g.mu.Unlock()
+	if !g.AllowResumeKick("scanner") {
+		t.Error("resume kick should be allowed again after the interval elapses")
+	}
+}
+
+// TestAllowResumeKick_DeniedWhenModePaused: a mode-level "pause" means the
+// operator wants no work — a crash restart must not override it.
+func TestAllowResumeKick_DeniedWhenModePaused(t *testing.T) {
+	g := resumeTestGovernor(t, "pause")
+	if g.AllowResumeKick("scanner") {
+		t.Error("resume kick should be denied when the mode cadence is 'pause'")
+	}
+}
+
+// TestAllowResumeKick_DeniedWithoutCadence: an agent with no cadence entry
+// (unknown agent, or cadence "off") never gets resume kicks.
+func TestAllowResumeKick_DeniedWithoutCadence(t *testing.T) {
+	g := resumeTestGovernor(t, "6h")
+	if g.AllowResumeKick("no-such-agent") {
+		t.Error("resume kick should be denied for an agent with no cadence entry")
+	}
+}
+
+// TestAllowResumeKick_DeniedForOnDemand: on-demand agents are only ever
+// triggered explicitly.
+func TestAllowResumeKick_DeniedForOnDemand(t *testing.T) {
+	cfg := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{
+			"idle": {Threshold: 0, Cadences: map[string]string{"scanner": "1h"}},
+		},
+	}
+	agents := map[string]config.AgentConfig{
+		"scanner": {Backend: "bob", Enabled: true, OnDemand: true},
+	}
+	g := New(cfg, agents, testLogger())
+	g.Evaluate(queueDepthIdle, 0, 0, 0)
+	if g.AllowResumeKick("scanner") {
+		t.Error("resume kick should be denied for an on-demand agent")
+	}
+}
+
+// TestAllowResumeKick_RespectsBudget: an exhausted budget suppresses resume
+// kicks exactly like scheduled kicks, honoring the exemption list.
+func TestAllowResumeKick_RespectsBudget(t *testing.T) {
+	g := resumeTestGovernor(t, "1h")
+	const (
+		weeklyLimit = 1000
+		overspend   = 2000
+	)
+	g.SetBudgetLimit(weeklyLimit)
+	g.UpdateBudgetFromTotals(0, nil, nil) // open the window at baseline 0
+	g.UpdateBudgetFromTotals(overspend, nil, nil)
+
+	if g.AllowResumeKick("scanner") {
+		t.Error("resume kick should be denied when the budget is exhausted")
+	}
+
+	g.SetBudgetIgnored([]string{"scanner"})
+	if !g.AllowResumeKick("scanner") {
+		t.Error("budget-exempt agent should still get a resume kick")
+	}
+}


### PR DESCRIPTION
> **Retargeting note (maintainer):** Investigation on the reporting hive (hosted-available-vllmd-12, vLLM-d cluster) via kubectl exec showed **neither bug in this PR occurred there**: the hive never left IDLE mode (mode-history has a single startup->IDLE entry, so stale-cadence carry-over could not fire), the pod has **0 restarts** (crash-restart re-kick could not fire), pause is working (every eval-cycle kick to a paused agent is rejected with `it is paused`), and hive's own `token-summary.json` reads all zeros. The two bugs fixed here are **real and worth landing** — they would burn coins on a hive that flips governor modes or crash-loops — but they are **not** the reporter's root cause, so this PR intentionally does not close #2573. The bob-idle-session theory was also checked and is **unsupported by IBM Bob's public docs**, which describe strictly action-based Bobcoin billing. #2573 stays open pending evidence of whether the reporter's coins still drain with agents paused (i.e. a consumer outside hive's kick path).

## Summary

The reporter had the supervisor paused and every other agent on a 4h/6h cadence, yet Bob coin (token) usage kept climbing and the dashboard's "next run" implied runs more frequent than the configured cadences. Burn only stopped once ALL agents were paused. This PR maps every code path that can prompt an agent backend, and fixes the two that could legitimately produce exactly that symptom.

## Consumer map (every path that can prompt a backend)

| Path | Respects pause? | Respects cadence? | Verdict |
|---|---|---|---|
| Governor scheduled kicks (`runEvalCycle` → `SendKick`) | Yes — `Pause()` sets `StatePaused`, `SendKick` rejects non-running agents | **NO — bug 1** (stale cadence carry-over across modes) | **Fixed** |
| Crash-recovery force kicks (`restartedAgents` append in `runEvalCycle`) | Yes (crash scan skips paused agents) | **NO — bug 2** (unconditional, every eval cycle, also bypassed the budget gate) | **Fixed** |
| Startup bootstrap prompt (`deliverStartupKick` on every launch/restart) | Yes (`Start()` returns early for paused agents) | Rides on restart frequency — bounded once bug 2 stops the restart-kick loop from being profitable | OK after fix |
| Startup `ClearLastKicks` (every pod boot kicks all eligible agents once) | Yes | One kick per agent per pod restart, by design | Surfaced here, unchanged |
| Stall/action nudges (`nudgeIfKickStalled`) | Yes (scan skips paused) | Inference backends only (NOT bob); max 2 per kick | OK |
| Inception/brainstorm re-kick | Yes (via `SendKick`/`RestartWithBootstrap` paths on brainstorm only) | On-demand agent, active inception only | OK |
| Trajectory review lane | Yes (skips non-running agents) | Own interval, floored by governor interval; consumes the reviewer backend, not the agent's | OK |
| Manual dashboard kick (`/api/agent/{name}/kick`) | Operator-initiated | Operator-initiated | OK |
| `bin/kick-agents.sh` / `kick-governor.sh` / `supervisor-kick.sh` | No pause check | Fixed systemd timers | Legacy **host-install** path only — no systemd in the v2 container; not reachable in hosted hives |
| bob idle self-consumption | n/a | n/a | Residual, see below |

## Root causes

### 1. Stale cadence carry-over across governor modes

`Governor.updateCadences()` only **overwrote** entries present in the current mode's cadence map. An agent missing from that map — or a whole missing mode block, which returned early — silently kept the interval from whichever mode last defined one. So a hive leaving a short-cadence mode (e.g. a busy/surge mode entered because open PRs now count toward queue pressure) kept kicking on the short interval **forever**, while the dashboard's agent card displayed the configured longer cadence (its display chain falls back current mode → idle). Actual kick timing and the displayed "interval"/"next run" could permanently disagree — the reporter's exact symptom.

**Fix:** cadence state is rebuilt from scratch on every eval using the *same* resolution chain the dashboard displays: current-mode entry → idle-mode entry → none (no timer kicks). Stale entries can no longer survive a mode change, and `"off"` is honored as a no-kick sentinel instead of warned about as an unparsable duration (which previously also left a stale entry in place).

### 2. Unconditional crash-restart kicks

`runEvalCycle` appended every crash-restarted agent to the kick list — "restarted agents need a kick even if the governor wouldn't schedule one this cycle" — with no cadence, pause-mode, or budget check, and each such kick reset `LastKick`. A CLI that crash-loops (bob's Ink UI is the documented offender — its crashes surface as React reconciler stack traces) was therefore restarted **and re-kicked every 5-minute eval cycle indefinitely**, burning coins on agents configured for 4h/6h cadences. This path also bypassed budget-exhaustion suppression.

**Fix:** resume kicks now go through `Governor.AllowResumeKick`, which requires an active (non-paused, non-"off") cadence in the current mode, denies on-demand/non-kick-channel agents, honors the budget gate and its exemption list, and grants **at most one resume kick per cadence interval**. An isolated mid-task crash still resumes promptly; a crash loop gets one resume and then waits for its scheduled slot — worst case one scheduled + one resume kick per interval instead of one kick per eval cycle.

### Hygiene: paused agents in the kick loop

Operator-paused agents were still returned as "due", built into kick messages, and logged as `failed to send kick` errors every cycle (`SendKick` rejected them, so no tokens were burned — but the audit trail was noise). The eval loop now skips them explicitly alongside on-demand agents.

## Cadence-contract determination

Cadences in this codebase are **per-mode operator settings**: the agent config dialog exposes idle/quiet/busy/surge fields, and the governor's mode selects *among those operator-configured values* — it does not override an explicit user cadence with an internal multiplier. The current mode is surfaced in the governor panel and the card shows the current mode's interval. Under that contract, a user-set 6h being run more often is always a bug, and both bugs above are fixed accordingly. After this PR the interval the governor actually kicks on is by construction the interval the dashboard shows (`updateCadences` and the dashboard's `lookupCadenceForMode`/`lookupCadence` now implement the same chain).

Two bounded, intentional exceptions remain and are stated here honestly:
- **Pod restart**: `ClearLastKicks` at startup kicks every eligible agent once per boot, by design (post-restart state is stale). One kick per agent per restart.
- **Crash resume**: at most one early resume kick per cadence interval (this PR's bound), so interrupted work isn't lost for a full multi-hour cadence.

## Residual burner (out of our control)

An idle bob TUI session may consume a small amount on its own (banner/model warm-up on launch). We cannot change bob's internals; what this PR removes is the hive-side loop that made bob relaunches and re-prompts happen every eval cycle. If idle-session consumption is ever measured as material, terminating bob sessions between cadence runs would be the follow-up — filed separately if needed.

Note: the repo-permissions advisory visible in the reporter's second screenshot is #2575 (separate agent/PR); intentionally untouched here.

## Tests

- `TestUpdateCadences_NoStaleCarryOverAcrossModes` — the core regression: busy 5m must not survive into quiet/surge; idle fallback applies.
- `TestUpdateCadences_MissingModeBlockFallsBackToIdle` — whole-mode gap no longer retains all previous cadences.
- `TestUpdateCadences_IdleFallbackRespectsPause`, `TestUpdateCadences_OffMeansNoKicks` — sentinels through the fallback chain.
- `TestAllowResumeKick_OncePerInterval`, `_DeniedWhenModePaused`, `_DeniedWithoutCadence`, `_DeniedForOnDemand`, `_RespectsBudget` — the full resume-kick gate.

Relates to #2573 (does NOT close it — see note below)

