### PR TITLE
fix(hub): merge sweep must trust GitHub's mergeable verdict, not wait on non-required checks (v2 backport)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -4802,6 +4802,24 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 			continue
 		}
 
+		// A PR whose CI is still "pending" is nonetheless merge-eligible when
+		// GitHub itself reports it as mergeable (mergeStateStatus=unstable):
+		// that state means every REQUIRED check has passed and only
+		// non-required checks remain outstanding. Those non-required checks —
+		// a cancelled Mobile Browser Tests, a still-running coverage-report,
+		// perpetually-pending tide — can never complete on their own, so
+		// waiting for CIStatus=="success" (all checks done) leaves cleanly
+		// mergeable PRs frozen out of the sweep indefinitely (observed
+		// 2026-08-04: three green console PRs stuck for hours). The merge step
+		// re-enforces branch protection, so trusting the mergeable verdict here
+		// cannot merge anything GitHub would actually block.
+		if pr.CIStatus == "pending" && pr.Mergeable != github.MergeableYes {
+			// Genuinely not ready: a required check is still running (or
+			// mergeability is unknown/no). Leave it out of both buckets, as
+			// before — it neither merges nor gets a fix dispatched.
+			continue
+		}
+
 		dco := "unknown"
 		for _, l := range pr.Labels {
 			if l == "dco-signoff: yes" {

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -531,7 +531,7 @@ func (c *Client) EnrichCIStatus(ctx context.Context, prs []PullRequest) {
 		allDone := true
 		ciChecksFound := 0
 		for _, cr := range checkRuns.CheckRuns {
-			if cr.GetName() == "tide" {
+			if isMetaCheck(cr.GetName()) {
 				continue
 			}
 			ciChecksFound++
@@ -557,6 +557,116 @@ func (c *Client) EnrichCIStatus(ctx context.Context, prs []PullRequest) {
 			prs[i].CIStatus = ciStatusPending
 		}
 	}
+}
+
+// isMetaCheck reports check runs that are merge-gates or deploy-status
+// mirrors, NOT code CI. They must not drive CIStatus: a stale
+// enforce-guardrails (red-main era) or Netlify status left three
+// actually-green PRs classified ci_failing and invisible to the merge sweep
+// for hours (2026-08-04). The merge step itself re-enforces these gates —
+// counting them here only poisons the eligibility signal.
+func isMetaCheck(name string) bool {
+	switch name {
+	case "tide", "enforce-guardrails":
+		return true
+	}
+	for _, prefix := range []string{"Header rules", "Pages changed", "Redirect rules", "netlify/", "copilot"} {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// Bounds for fetchFailureExcerpt: annotations are fetched for at most
+// excerptMaxRuns failing check runs, keeping at most excerptMaxLines lines and
+// excerptMaxChars characters total. Enough to carry a stack of real errors
+// into a kick prompt without flooding it.
+const (
+	excerptMaxRuns  = 2
+	excerptMaxLines = 8
+	excerptMaxChars = 900
+)
+
+// fetchFailureExcerpt pulls the raw error lines from the annotations of the
+// given failing check runs. Annotations capture workflow ##[error] lines (test
+// failures, compile errors), which is exactly the evidence fix agents never
+// see from a bare "CI failed" status. Works on GitHub and GHE through the
+// client's configured API base; on errors it degrades to "" — the excerpt is
+// an enrichment, never a gate.
+func (c *Client) fetchFailureExcerpt(ctx context.Context, owner, repo string, runIDs []int64, runNames []string) string {
+	var lines []string
+	total := 0
+	seen := map[string]bool{}
+	for idx, id := range runIDs {
+		if idx >= excerptMaxRuns || len(lines) >= excerptMaxLines {
+			break
+		}
+		anns, _, err := c.client.Checks.ListCheckRunAnnotations(ctx, owner, repo, id, &gh.ListOptions{PerPage: 20})
+		if err != nil {
+			continue
+		}
+		name := ""
+		if idx < len(runNames) {
+			name = runNames[idx]
+		}
+		for _, a := range anns {
+			level := a.GetAnnotationLevel()
+			if level != "failure" && level != "warning" {
+				continue
+			}
+			msg := strings.TrimSpace(a.GetMessage())
+			if msg == "" || seen[msg] {
+				continue
+			}
+			seen[msg] = true
+			line := msg
+			if name != "" {
+				line = name + ": " + msg
+			}
+			if nl := strings.IndexByte(line, '\n'); nl > 0 {
+				line = line[:nl]
+			}
+			if len(line) > 300 {
+				line = line[:300]
+			}
+			if total+len(line) > excerptMaxChars {
+				return strings.Join(lines, "\n")
+			}
+			lines = append(lines, line)
+			total += len(line)
+			if len(lines) >= excerptMaxLines {
+				break
+			}
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// CreateIssueComment posts a comment on an issue or PR. The signature mirrors
+// forge.Forge.CreateIssueComment so escalation callers can swap in a neutral
+// forge adapter on non-GitHub hives without changing call sites.
+func (c *Client) CreateIssueComment(ctx context.Context, repo string, number int, body string) error {
+	if c == nil {
+		return ErrNoGitHubClient
+	}
+	owner, repoName := c.splitRepo(repo)
+	_, _, err := c.client.Issues.CreateComment(ctx, owner, repoName, number, &gh.IssueComment{Body: gh.Ptr(body)})
+	return err
+}
+
+// AddLabels adds labels to an issue or PR (no-op for an empty list), mirroring
+// forge.Forge.AddLabels for the same swap-in reason as CreateIssueComment.
+func (c *Client) AddLabels(ctx context.Context, repo string, number int, labels []string) error {
+	if c == nil {
+		return ErrNoGitHubClient
+	}
+	if len(labels) == 0 {
+		return nil
+	}
+	owner, repoName := c.splitRepo(repo)
+	_, _, err := c.client.Issues.AddLabelsToIssue(ctx, owner, repoName, number, labels)
+	return err
 }
 
 func extractLabels(labels []*gh.Label) []string {

--- a/v2/pkg/github/metacheck_actions_test.go
+++ b/v2/pkg/github/metacheck_actions_test.go
@@ -1,0 +1,124 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestCreateIssueComment covers the nil-receiver guard and the happy path
+// through the httptest server (the forge-neutral comment primitive used by
+// the escalation flow).
+func TestCreateIssueComment(t *testing.T) {
+	var nilClient *Client
+	if err := nilClient.CreateIssueComment(context.Background(), "o/r", 1, "hi"); err != ErrNoGitHubClient {
+		t.Fatalf("nil receiver: got %v, want ErrNoGitHubClient", err)
+	}
+
+	var gotBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/o/r/issues/7/comments", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		var payload struct {
+			Body string `json:"body"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		gotBody = payload.Body
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, "o", []string{"o/r"})
+	if err := c.CreateIssueComment(context.Background(), "o/r", 7, "escalation evidence"); err != nil {
+		t.Fatalf("CreateIssueComment: %v", err)
+	}
+	if gotBody != "escalation evidence" {
+		t.Errorf("body = %q, want %q", gotBody, "escalation evidence")
+	}
+}
+
+// TestAddLabels covers the nil-receiver guard, the empty-list no-op, and the
+// happy path.
+func TestAddLabels(t *testing.T) {
+	var nilClient *Client
+	if err := nilClient.AddLabels(context.Background(), "o/r", 1, []string{"x"}); err != ErrNoGitHubClient {
+		t.Fatalf("nil receiver: got %v, want ErrNoGitHubClient", err)
+	}
+
+	c := &Client{} // empty list must short-circuit before any API call
+	if err := c.AddLabels(context.Background(), "o/r", 1, nil); err != nil {
+		t.Fatalf("empty labels should be a no-op, got %v", err)
+	}
+
+	var gotLabels []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/o/r/issues/9/labels", func(w http.ResponseWriter, r *http.Request) {
+		var payload []string
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		gotLabels = payload
+		json.NewEncoder(w).Encode([]map[string]any{{"name": "needs-human"}})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := newTestClient(t, server, "o", []string{"o/r"})
+	if err := client.AddLabels(context.Background(), "o/r", 9, []string{"needs-human"}); err != nil {
+		t.Fatalf("AddLabels: %v", err)
+	}
+	if len(gotLabels) != 1 || gotLabels[0] != "needs-human" {
+		t.Errorf("labels = %v, want [needs-human]", gotLabels)
+	}
+}
+
+// TestFetchFailureExcerpt pulls failure/warning annotations from the given
+// check runs, prefixes each with the run name, dedupes, and bounds the output.
+func TestFetchFailureExcerpt(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/o/r/check-runs/101/annotations", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]map[string]any{
+			{"annotation_level": "failure", "message": "ReferenceError: seedMission is not defined"},
+			{"annotation_level": "notice", "message": "ignored notice"},
+			{"annotation_level": "failure", "message": "ReferenceError: seedMission is not defined"}, // dup
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, "o", []string{"o/r"})
+	got := c.fetchFailureExcerpt(context.Background(), "o", "r", []int64{101}, []string{"Coverage Suite"})
+	if !strings.Contains(got, "seedMission is not defined") {
+		t.Fatalf("excerpt missing the error: %q", got)
+	}
+	if !strings.HasPrefix(got, "Coverage Suite: ") {
+		t.Errorf("excerpt should be prefixed with the run name, got %q", got)
+	}
+	if strings.Count(got, "seedMission") != 1 {
+		t.Errorf("duplicate annotation not deduped: %q", got)
+	}
+	if strings.Contains(got, "ignored notice") {
+		t.Errorf("non-failure annotation leaked into excerpt: %q", got)
+	}
+}
+
+// TestFetchFailureExcerpt_APIErrorDegrades confirms the excerpt is enrichment,
+// never a gate: an annotations API error yields "" rather than blocking.
+func TestFetchFailureExcerpt_APIErrorDegrades(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/o/r/check-runs/500/annotations", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, "o", []string{"o/r"})
+	if got := c.fetchFailureExcerpt(context.Background(), "o", "r", []int64{500}, []string{"x"}); got != "" {
+		t.Errorf("API error should degrade to empty excerpt, got %q", got)
+	}
+}

--- a/v2/pkg/github/metacheck_test.go
+++ b/v2/pkg/github/metacheck_test.go
@@ -1,0 +1,29 @@
+package github
+
+import "testing"
+
+// TestIsMetaCheck locks in that merge-gate and deploy-status checks are
+// excluded from CI classification, so a stale enforce-guardrails run or a
+// Netlify status mirror can never mark an otherwise-green PR as failing.
+func TestIsMetaCheck(t *testing.T) {
+	meta := []string{
+		"tide",
+		"enforce-guardrails",
+		"Header rules - kubestellarconsole",
+		"Pages changed - kubestellarconsole",
+		"Redirect rules - kubestellarconsole",
+		"netlify/kubestellarconsole/deploy-preview",
+		"copilot-pull-request-reviewer",
+	}
+	for _, name := range meta {
+		if !isMetaCheck(name) {
+			t.Errorf("isMetaCheck(%q) = false, want true (merge-gate/deploy mirror)", name)
+		}
+	}
+	code := []string{"build-gate", "coverage-gate", "unit-test", "TypeScript & ESLint", "Test (chromium, shard 1)"}
+	for _, name := range code {
+		if isMetaCheck(name) {
+			t.Errorf("isMetaCheck(%q) = true, want false (real code CI must gate)", name)
+		}
+	}
+}


### PR DESCRIPTION
Backport of #2625 to v2. Eligibility required every non-meta check to pass, so PRs GitHub reports as cleanly mergeable (mergeStateStatus=unstable — all REQUIRED checks green) sat pending and invisible to the sweep for hours behind cancelled/pending non-required checks. Fix: (1) isMetaCheck excludes merge-gate/deploy mirrors from CI classification; (2) a CIStatus==pending PR is eligible when Mergeable==Yes. The merge step re-enforces branch protection, so this cannot merge anything GitHub would block. Cherry-pick conflict (v2 lacked isMetaCheck) resolved by taking the incoming block; verified no fetchFailureExcerpt duplication. Test locks in the classifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)