### PR TITLE
🐛 Contributors stat: fleet-wide registered total, not active count (no more 0)

### DIFF
--- a/v2/pkg/hub/fleet_stats_test.go
+++ b/v2/pkg/hub/fleet_stats_test.go
@@ -269,6 +269,39 @@ func TestComputeFleetStatsZeroCollectedAtIsTrusted(t *testing.T) {
 	}
 }
 
+// TestComputeFleetStatsContributorsTotal pins the hub-landing-page fix: the
+// "Contributors" tile must show the fleet-wide REGISTERED contributor total
+// (ContributorsTotal, summed from each spoke's ContributorCount), not the
+// currently-active count (Contributors, summed from ActiveContributors) —
+// the active count legitimately drops to 0 whenever nobody happens to be
+// connected at collection time, which made the tile crater to 0. The two
+// totals must be independent: a hive can have many registered contributors
+// and zero active ones right now, and vice versa.
+func TestComputeFleetStatsContributorsTotal(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+	s.registry.Hives = []RegistryEntry{
+		// Registered contributors but nobody active right now — the case that
+		// used to crater the tile to 0.
+		{IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"},
+			ContributorCount: 12, ActiveContributors: 0},
+		// Some active, fewer registered visible in this snapshot — still summed
+		// independently.
+		{IsPublic: true, Online: true, Org: "a", Repos: []string{"r2"},
+			ContributorCount: 3, ActiveContributors: 2},
+		// Offline hives are excluded from both totals, same as every other
+		// fleet-wide count.
+		{IsPublic: true, Online: false, Org: "a", Repos: []string{"r3"},
+			ContributorCount: 100, ActiveContributors: 100},
+	}
+	got := s.computeFleetStats()
+	if got.ContributorsTotal != 15 {
+		t.Errorf("ContributorsTotal = %d, want 15 (12+3, offline hive excluded)", got.ContributorsTotal)
+	}
+	if got.Contributors != 2 {
+		t.Errorf("Contributors = %d, want 2 (active count unaffected by the fix)", got.Contributors)
+	}
+}
+
 // TestFleetStatsTrustworthy is the regression guard for the reported bug: a
 // total assembled from a small minority of the fleet must NOT be presented as
 // a fleet-wide figure. 2 reporting out of 50 eligible is the live shape of the

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -83,6 +83,11 @@ type FleetStatsSnapshot struct {
 	Hives        int `json:"hives"`
 	Reporting    int `json:"reporting"`
 	Eligible     int `json:"eligible"`
+	// ContributorsTotal carries the registered-contributor total (see
+	// FleetStats.ContributorsTotal) into the last-known-good fallback so a
+	// recollecting fleet still serves a stable figure instead of dropping to
+	// 0 while coverage is below the publish threshold.
+	ContributorsTotal int `json:"contributors_total"`
 	// CollectedAt is when this aggregate was computed, i.e. what "as of" means
 	// on the public page.
 	CollectedAt time.Time `json:"collected_at"`
@@ -2092,7 +2097,16 @@ type FleetStats struct {
 	// owner or URL is derivable from them.
 	AgentsRunning int    `json:"agents_running"`
 	Contributors  int    `json:"contributors"`
-	UpdatedAt     string `json:"updated_at"`
+	// ContributorsTotal is the fleet-wide count of REGISTERED (unique) known
+	// contributors, summed from each hive's ContributorCount rather than
+	// ActiveContributors. Contributors above tracks who is CURRENTLY active,
+	// which legitimately drops to 0 whenever nobody happens to be connected —
+	// on the hub landing page that reads as "this fleet has no
+	// contributors", which is false. ContributorsTotal is stable across quiet
+	// periods because a contributor stays registered whether or not they are
+	// active right now, so the public tile should prefer it.
+	ContributorsTotal int    `json:"contributors_total"`
+	UpdatedAt         string `json:"updated_at"`
 	// Reporting is the number of eligible hives that actually contributed a
 	// fresh count to the totals above; Eligible is how many were considered.
 	// Without this pair the totals are indistinguishable from a healthy fleet:
@@ -2220,6 +2234,9 @@ func (s *HubServer) computeFleetStats() FleetStats {
 		fs.Hives++
 		fs.AgentsRunning += h.AgentCount
 		fs.Contributors += h.ActiveContributors
+		// Registered (not active) so the total does not crater to 0 whenever
+		// nobody happens to be connected at collection time.
+		fs.ContributorsTotal += h.ContributorCount
 		for _, r := range h.Repos {
 			if r == "" {
 				continue
@@ -2317,14 +2334,15 @@ func (s *HubServer) fleetStatsLKG() *FleetStatsSnapshot {
 func (s *HubServer) recordFleetStatsLKG(fs FleetStats, collectedAt time.Time) {
 	s.mu.Lock()
 	s.registry.FleetStatsLKG = &FleetStatsSnapshot{
-		ReposManaged: fs.ReposManaged,
-		PRsMerged:    fs.PRsMerged,
-		PRsRejected:  fs.PRsRejected,
-		CVEsClosed:   fs.CVEsClosed,
-		Hives:        fs.Hives,
-		Reporting:    fs.Reporting,
-		Eligible:     fs.Eligible,
-		CollectedAt:  collectedAt.UTC(),
+		ReposManaged:      fs.ReposManaged,
+		PRsMerged:         fs.PRsMerged,
+		PRsRejected:       fs.PRsRejected,
+		CVEsClosed:        fs.CVEsClosed,
+		Hives:             fs.Hives,
+		Reporting:         fs.Reporting,
+		Eligible:          fs.Eligible,
+		ContributorsTotal: fs.ContributorsTotal,
+		CollectedAt:       collectedAt.UTC(),
 	}
 	s.mu.Unlock()
 	s.requestSave()
@@ -2358,6 +2376,7 @@ func (s *HubServer) handleFleetStats(w http.ResponseWriter, r *http.Request) {
 		fs.PRsMerged = lkg.PRsMerged
 		fs.PRsRejected = lkg.PRsRejected
 		fs.CVEsClosed = lkg.CVEsClosed
+		fs.ContributorsTotal = lkg.ContributorsTotal
 		fs.StaleData = true
 		fs.AsOf = lkg.CollectedAt.UTC().Format(time.RFC3339)
 		s.logger.Warn("fleet stats: serving last-known-good totals; live coverage is below the publish threshold",

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -1185,8 +1185,15 @@
         f && typeof f.agents_running === 'number' ? f.agents_running : agents;
       document.getElementById('stat-repos').textContent =
         f && typeof f.repos_managed === 'number' ? f.repos_managed : repos;
+      // Prefer contributors_total (registered, fleet-wide) over contributors
+      // (currently-active, fleet-wide) — the active count legitimately drops
+      // to 0 whenever nobody happens to be connected at collection time,
+      // which read as "no contributors" on this tile. The registered total
+      // is stable across quiet periods. The public-list active sum remains
+      // the last-resort fallback for an older hub / failed poll.
       document.getElementById('stat-contributors').textContent =
-        f && typeof f.contributors === 'number' ? f.contributors : contributors;
+        (f && typeof f.contributors_total === 'number') ? f.contributors_total :
+        (f && typeof f.contributors === 'number' ? f.contributors : contributors);
     }
 
     var _allMainHives = [];


### PR DESCRIPTION
## Bug

On the hub landing page ("Live fleet status" tile), the **Contributors** stat counted *currently-connected/active* contributors, aggregated from each spoke's `ActiveContributors`. It drops to **0** whenever nobody happens to be actively connected at the moment `/api/fleet-stats` collects — which looks like the fleet has no contributors at all, even though it does.

## Fix

- **Server** (`v2/pkg/hub/server.go`): add a new fleet-wide field `contributors_total` to `FleetStats` (and to `FleetStatsSnapshot`, the last-known-good persisted fallback), summed from each spoke's already-reported `ContributorCount` (registered contributor profiles) instead of `ActiveContributors`. The existing `contributors` (active) field is left untouched for any other consumers.
- **Client** (`v2/pkg/hub/static/index.html`): `renderStats` now prefers `contributors_total` when present, falling back to the old active-count logic for an older hub or a failed poll.
- **Tests** (`v2/pkg/hub/fleet_stats_test.go`): new `TestComputeFleetStatsContributorsTotal` asserts `contributors_total` sums `ContributorCount` across online spokes independently of `Contributors`/`ActiveContributors`, and that offline hives are excluded from both.

This only affects the hub landing page's "Live fleet status" tile.