### PR TITLE
✨ Persistent sparklines on Operations + Leaderboard (7-day hourly history)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1531,6 +1531,14 @@ func main() {
 	fleetStatsCollector.EnablePersistence("/data/fleet-stats.json")
 	go fleetStatsCollector.Start(ctx)
 
+	// Persistent hourly metrics behind the Operations + Leaderboard sparklines
+	// (queue depth, tasks/hour, fleet size, per-contributor completions). The
+	// store loads any prior 7-day history from the /data PVC on first use and the
+	// rollup goroutine samples + buckets hourly, so a rolling upgrade resumes the
+	// trend instead of flattening it. Bound to ctx so it shuts down cleanly with
+	// the rest of the background loops (no goroutine leak). See contribute_metrics.go.
+	dashSrv.StartContributeMetrics(ctx)
+
 	var lastActionable atomic.Pointer[github.ActionableResult]
 	refreshDashboard := func() {
 		actionable := lastActionable.Load()

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -2918,13 +2918,14 @@ function ccQueueMatches(q){
   return hay.indexOf(ccQueueSearch)>=0;
 }
 function ccRenderQueue(flip){
+  // Item count badge, same style as "My work"'s #work-count — kept in sync on
+  // every render (initial load, SSE queue push, poll fallback, drag-reorder).
+  // Populated FIRST so it stays set even if the queue container is absent.
+  var qc=document.getElementById('queue-count');
+  if(qc)qc.textContent=ccQueue.length+' ready';
   var el=document.getElementById('cc-queue');if(!el)return;
   // reload bridge — overwritten by the next poll, including to empty.
   ccOpsCacheWrite(OPS_CACHE_QUEUE_KEY,ccQueue);
-  // Item count badge, same style as "My work"'s #work-count — kept in sync on
-  // every render (initial load, SSE queue push, poll fallback, drag-reorder).
-  var qc=document.getElementById('queue-count');
-  if(qc)qc.textContent=ccQueue.length+' ready';
   // flip=true (set only from the drag-drop / move handlers) records each row's rect
   // BEFORE the rebuild so ccFlipPlay can glide displaced rows to their new slots
   // instead of a hard jump. Every other caller (initial load, SSE queue push, poll

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -2783,6 +2783,8 @@ function statusPill(s){
 }
 function renderWork(list){
   lastWork=list;
+  // reload bridge — overwritten by the next poll, including to empty.
+  ccOpsCacheWrite(OPS_CACHE_WORK_KEY,lastWork);
   // "Done" is special: the fleet work array holds ONLY in-flight tasks, so a naive
   // status filter is always empty. Instead, source "Done" from the completed activity
   // events (the real completion history). All/Active/Review keep filtering the
@@ -2902,6 +2904,8 @@ function ccQueueMatches(q){
 }
 function ccRenderQueue(flip){
   var el=document.getElementById('cc-queue');if(!el)return;
+  // reload bridge — overwritten by the next poll, including to empty.
+  ccOpsCacheWrite(OPS_CACHE_QUEUE_KEY,ccQueue);
   // Item count badge, same style as "My work"'s #work-count — kept in sync on
   // every render (initial load, SSE queue push, poll fallback, drag-reorder).
   var qc=document.getElementById('queue-count');
@@ -3174,6 +3178,58 @@ var OPS_RAIL_KEY='hive.ops.devlog.collapsed';
 var opsRailInit=false;
 function ccRailRead(){try{return localStorage.getItem(OPS_RAIL_KEY)==='1';}catch(e){return false;}}
 function ccRailWrite(collapsed){try{if(collapsed)localStorage.setItem(OPS_RAIL_KEY,'1');else localStorage.removeItem(OPS_RAIL_KEY);}catch(e){}}
+
+// ── Ops panel reload-bridge cache ───────────────────────────────────────────────
+// On a page refresh the ready-work queue, opportunistic work, and my-work panels
+// sit on their "Loading…" placeholders until the first poll/SSE frame returns,
+// which reads as a flash of empty. To bridge that gap we mirror each panel's DATA
+// (the arrays, never rendered HTML) into localStorage as it renders and hydrate
+// from it on load. The cache is ONLY a reload bridge: the very next successful
+// poll overwrites both the DOM and the cache — INCLUDING overwriting to a
+// genuinely-empty result — so stale work can never persist. Fresh window is short
+// (OPS_CACHE_TTL_MS) so a long-closed tab does not resurrect ancient state.
+var OPS_CACHE_QUEUE_KEY='hive.ops.cache.queue';
+var OPS_CACHE_WORK_KEY='hive.ops.cache.work';
+var OPS_CACHE_OPP_KEY='hive.ops.cache.opp';
+var OPS_CACHE_TTL_MS=5*60*1000; // 5 minutes: the cache is a reload bridge, not a store
+// ccOpsCacheWrite stores an array under key with a timestamp. Guarded like the
+// rail helpers: private mode / quota errors degrade silently. Called on every
+// render, so an empty array is persisted too (the next poll's empty overwrites the
+// previous non-empty cache — no phantom work).
+function ccOpsCacheWrite(key,arr){
+  try{localStorage.setItem(key,JSON.stringify({t:new Date().getTime(),d:arr||[]}));}catch(e){}
+}
+// ccOpsCacheRead returns the cached array if present and fresher than the TTL,
+// else null. Any parse/storage error yields null (degrade to placeholders).
+function ccOpsCacheRead(key){
+  try{
+    var raw=localStorage.getItem(key);if(!raw)return null;
+    var o=JSON.parse(raw);
+    if(!o||typeof o.t!=='number'||!o.d)return null;
+    if((new Date().getTime()-o.t)>OPS_CACHE_TTL_MS)return null;
+    return o.d;
+  }catch(e){return null;}
+}
+// ccHydrateOpsFromCache paints the three panels from the reload-bridge cache
+// BEFORE the first poll returns, so a refresh shows the previous content instead
+// of an empty flash. It sets the same state vars the live path uses (ccQueue /
+// lastWork / ccOppItems) then calls the existing render fns, so the next poll
+// overwrites them cleanly (including to empty). Every step is guarded so a bad
+// cache entry can never block the live wiring that follows in ccStart().
+function ccHydrateOpsFromCache(){
+  try{
+    var q=ccOpsCacheRead(OPS_CACHE_QUEUE_KEY);
+    if(q&&q.length){ccQueue=q.slice();ccRenderQueue();}
+  }catch(e){}
+  try{
+    var w=ccOpsCacheRead(OPS_CACHE_WORK_KEY);
+    if(w&&w.length){renderWork(w);}
+  }catch(e){}
+  try{
+    var o=ccOpsCacheRead(OPS_CACHE_OPP_KEY);
+    if(o&&o.length){ccOppItems=o.slice();ccRenderOpportunistic();}
+  }catch(e){}
+}
 function ccRailApply(rail,btn,collapsed){
   rail.classList.toggle('collapsed',collapsed);
   if(btn){
@@ -3404,6 +3460,11 @@ function ccQueuePoll(){ // fallback when SSE is down: refresh queue only
 function ccStopFallback(){if(ccQueuePollTimer){clearTimeout(ccQueuePollTimer);ccQueuePollTimer=null;}}
 function ccStart(){
   if(ccStarted)return;ccStarted=true;
+  // Paint the queue / opportunistic / my-work panels from the reload-bridge cache
+  // FIRST, before any poll returns, so a refresh shows the previous content instead
+  // of an empty flash. The next successful poll overwrites both DOM and cache
+  // (including to empty), so this is purely a bridge across the reload gap.
+  try{ccHydrateOpsFromCache();}catch(e){console.error('ops cache hydrate failed',e);}
   // Seed + poll the Live Activity rail from the RELIABLE polling endpoint (the same
   // source Onboarding uses) so the rail shows the backlog immediately and stays
   // current even when the SSE stream delivers nothing (hosted spokes). SSE, when it
@@ -3481,6 +3542,8 @@ function ccOppPoll(){
 function ccOppHeatClass(h){h=h||0;if(h>=6)return '';if(h>=3)return 'warm';return 'cool';}
 function ccRenderOpportunistic(){
   var el=document.getElementById('opp-list');if(!el)return;
+  // reload bridge — overwritten by the next poll, including to empty.
+  ccOpsCacheWrite(OPS_CACHE_OPP_KEY,ccOppItems);
   var cnt=document.getElementById('opp-count');
   if(cnt)cnt.textContent=ccOppItems.length?(ccOppItems.length+' found'):'';
   if(!ccOppItems.length){el.innerHTML='<div class="ops-empty">Nothing fresh to surface right now &mdash; the backlog is quiet.</div>';return;}

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -239,6 +239,12 @@ func (s *Server) registerContributeRoutes() {
 	// block is resolved server-side from the session / X-Hive-User header (never a
 	// client-supplied username) so a viewer only ever sees their OWN usage.
 	s.mux.HandleFunc("GET /api/contribute/limits", s.handleContributeLimits)
+	// Read-only persistent hourly metrics (7-day, 168 buckets) feeding the
+	// Operations + Leaderboard sparklines: queue depth, tasks/hour, fleet size,
+	// and per-contributor completions. Public like the other /api/contribute*
+	// reads (only counts + already-public usernames; no tokens, no PII). GET only,
+	// no side effects. See contribute_metrics.go.
+	s.mux.HandleFunc("GET /api/contribute/metrics", s.handleContributeMetrics)
 	// Operator priority override for the ready-work queue. Owner/read-write only —
 	// enforced IN-HANDLER via requireContributorWrite because the /api/contribute
 	// prefix is exempt from roleEnforcement's read-only block (see that helper).
@@ -586,7 +592,7 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .policy-key{color:#8b949e}
 .policy-val{color:#e6edf3;text-align:right;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;word-break:break-word}
 .ops-empty{padding:32px 20px;text-align:center;color:#8b949e;font-size:.85rem}
-.lb-row{display:grid;grid-template-columns:56px 1fr 120px 70px 70px 80px;align-items:center;gap:8px;padding:10px 20px;border-bottom:1px solid #21262d;font-size:.85rem}
+.lb-row{display:grid;grid-template-columns:56px 1fr 120px 70px 70px 80px 72px;align-items:center;gap:8px;padding:10px 20px;border-bottom:1px solid #21262d;font-size:.85rem}
 .lb-row:last-child{border-bottom:none}
 /* Subtle self-highlight for the logged-in viewer's own row: a faint tint + a left
    accent border, professional not loud. Readability preserved. */
@@ -934,6 +940,21 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 /* Me-card quota variant — sits inside a me-sec, so it inherits the card padding. */
 .me-quota .quota__lbl{color:#8b949e}
 @media(prefers-reduced-motion:reduce){.quota__fill{transition:none!important}}
+/* Sparklines (#persistent-history): tiny dependency-free inline-SVG trend charts
+   fed by /api/contribute/metrics (7-day hourly history). Muted stroke to sit
+   quietly in the dark theme; static — no animation, so nothing to gate behind
+   prefers-reduced-motion. The SVG scales to its slot via width/height attrs. */
+.spark{display:inline-block;vertical-align:middle;line-height:0}
+.spark svg{display:block;overflow:visible}
+.spark-inline{margin-left:8px}
+/* Header-adjacent sparkline sits next to a panel title/count without shoving it. */
+.ops-card-head .spark{margin-left:auto}
+/* Leaderboard per-row sparkline: occupies its own narrow column, muted so the
+   numerals stay the focus. */
+.lb-spark{display:flex;align-items:center;justify-content:flex-end}
+/* Hive-wide trend strip pinned above the standings. */
+.lb-trend{display:flex;align-items:center;gap:10px;padding:8px 20px 12px;color:#8b949e;font-size:.76rem;border-bottom:1px solid #21262d}
+.lb-trend .spark{margin-left:auto}
 /* "File an issue on this page" link (#2594) — a subtle footer affordance present
    on every tab. Quiet grey, matches the sober dashboard chrome; an outbound link. */
 .cc-page-foot{padding:26px 48px 34px;border-top:1px solid #21262d;margin-top:28px;display:flex;justify-content:center}
@@ -1503,7 +1524,7 @@ update();  // initial paint: copy block + branded UI in sync from first load
 <div class="ops-grid">
 <div>
 <div class="ops-card card-accent">
-<div class="ops-card-head"><span class="feed-dot"></span><h3>Connected clankers</h3><span class="ops-card-count count-strong" id="clanker-count"></span></div>
+<div class="ops-card-head"><span class="feed-dot"></span><h3>Connected clankers</h3><span class="ops-card-count count-strong" id="clanker-count"></span><!-- 7-day fleet-size trend (#persistent-history) --><span class="spark spark-inline" id="spark-fleet" title="Connected clankers, last 7 days (hourly)"></span></div>
 <!-- Army roster header: live count + at-a-glance status split, fed by the fleet snapshot. -->
 <div class="cc-army" id="cc-army">
   <span style="color:#e6edf3;font-weight:600">Your army</span>
@@ -1514,7 +1535,7 @@ update();  // initial paint: copy block + branded UI in sync from first load
 <div id="clanker-list"><div class="ops-empty">Loading fleet&hellip;</div></div>
 </div>
 <div class="ops-card" style="margin-top:20px">
-<div class="ops-card-head"><h3>Pipeline &amp; policy</h3></div>
+<div class="ops-card-head"><h3>Pipeline &amp; policy</h3><!-- Tasks-completed/hour throughput trend (#persistent-history) --><span class="spark spark-inline" id="spark-throughput" title="Tasks completed per hour, last 7 days"></span></div>
 <div style="padding:16px 20px">
 <div class="pipeline">
 <span class="pipe-node">opened</span><span class="pipe-arrow">&rarr;</span>
@@ -1546,7 +1567,7 @@ update();  // initial paint: copy block + branded UI in sync from first load
 <div class="work-list" id="work-list"><div class="ops-empty">Loading work&hellip;</div></div>
 </div>
 <div class="ops-card card-accent" style="margin-top:20px">
-<div class="ops-card-head"><span class="feed-dot"></span><h3>Ready-work queue</h3><span class="ops-card-count" id="queue-count"></span>
+<div class="ops-card-head"><span class="feed-dot"></span><h3>Ready-work queue</h3><span class="ops-card-count" id="queue-count"></span><!-- 7-day queue-depth trend (#persistent-history), hydrated by ccMetricsPoll --><span class="spark spark-inline" id="spark-queue" title="Ready-work queue depth, last 7 days (hourly)"></span>
 <!-- #queue-suspend-btn is the SAME logical control as the Management "Suspend
      contributions" switch (#admin-suspend-switch) — not a related toggle, the
      identical Config.Hub.ContributeSuspended state surfaced a second place. Both
@@ -1815,6 +1836,10 @@ function loadLeaderboard(){
     // human + donated-compute contributors are not buried under the bots.
     var contribs=(d&&d.leaderboard)||[];
     renderLeaderboard(contribs);
+    // Ensure the per-row + hive-wide sparklines have data even when the Ops tab
+    // was never opened (opsPoll never ran). Reuses this hive's metrics endpoint;
+    // Ops-only spark slots simply no-op when absent. See #persistent-history.
+    ccMetricsPoll();
   }).catch(function(){
     var el=document.getElementById('leaderboard-list');
     if(el)el.innerHTML='<div class="ops-empty">Could not load leaderboard.</div>';
@@ -1857,6 +1882,11 @@ function lbRow(e,rank){
     +'<div class="lb-stat lb-primary">'+done+'</div>'
     +'<div class="lb-stat">'+failed+'</div>'
     +'<div class="lb-stat">'+findings+'</div>'
+    // Per-contributor completion sparkline (#persistent-history). Filled in by
+    // ccRenderLeaderboardSparklines from this hive's /api/contribute/metrics
+    // per_user_done, matched on github_username via data-user. Empty until metrics
+    // load (renders a flat baseline), never fabricated.
+    +'<div class="lb-spark" data-user="'+esc(uname)+'"></div>'
     +'</div>';
 }
 var lbLastData=null; // cache the last standings so a late username resolve can re-mark the me-row
@@ -1874,10 +1904,17 @@ function renderLeaderboard(contribs){
   if(cnt)cnt.textContent=total+(total===1?' contributor':' contributors');
   if(!el)return;
   if(total===0){el.innerHTML='<div class="ops-empty">No contributors yet — be the first to contribute!</div>';return;}
-  var html='<div class="lb-head lb-row"><div class="lb-rank">#</div><div class="lb-name">Contributor</div><div class="lb-tier">Tier</div><div class="lb-stat lb-primary">Done</div><div class="lb-stat">Failed</div><div class="lb-stat">Findings</div></div>';
+  // Hive-wide total-tasks trend (#persistent-history) pinned above the standings —
+  // the sum of tasks_done per hour over the last 7 days. Hydrated by
+  // ccRenderLeaderboardSparklines; empty (flat) until metrics load.
+  var trend='<div class="lb-trend"><span>Hive throughput &middot; last 7 days</span><span class="spark" id="spark-lb-trend" title="Total tasks completed per hour, last 7 days"></span></div>';
+  var html=trend+'<div class="lb-head lb-row"><div class="lb-rank">#</div><div class="lb-name">Contributor</div><div class="lb-tier">Tier</div><div class="lb-stat lb-primary">Done</div><div class="lb-stat">Failed</div><div class="lb-stat">Findings</div><div class="lb-stat">Trend</div></div>';
   var rank=0,i;
   for(i=0;i<contribs.length;i++){rank++;html+=lbRow(contribs[i],rank);}
   el.innerHTML=html;
+  // Paint sparklines now that the rows exist (metrics may already be cached from a
+  // prior opsPoll tick; if not, the next tick fills them in).
+  ccRenderLeaderboardSparklines();
 }
 
 // ── Personal "Me" card ───────────────────────────────────────────────────────
@@ -2132,6 +2169,93 @@ document.querySelectorAll('.ops-filter').forEach(function(f){f.addEventListener(
 });});
 
 function esc(s){var d=document.createElement('div');d.textContent=(s==null?'':String(s));return d.innerHTML;}
+
+// ── Sparklines (#persistent-history) ───────────────────────────────────────────
+// A dependency-free, CSP-safe inline-SVG trend renderer. Given an array of
+// numbers it returns an <svg> polyline string sized w x h in the given colour.
+// No external library, no canvas, no animation (static by nature — nothing to
+// gate behind prefers-reduced-motion). Degrades gracefully: an empty or single-
+// point array renders a flat baseline rather than a NaN path, so a brand-new hive
+// with no history yet shows a calm flat line instead of a broken chart.
+var SPARK_W=64;   // default sparkline width in px
+var SPARK_H=18;   // default sparkline height in px
+var SPARK_PAD=2;  // top/bottom padding so the stroke is not clipped at extremes
+function sparkline(values,w,h,color){
+  values=values||[];
+  w=w||SPARK_W;h=h||SPARK_H;color=color||'#8b949e';
+  var innerH=h-SPARK_PAD*2;
+  if(innerH<1)innerH=1;
+  var pts=[];
+  // Flat baseline for empty / single-point series: a centred horizontal line.
+  if(values.length<2){
+    var y=SPARK_PAD+innerH/2;
+    pts=[[0,y],[w,y]];
+  }else{
+    var min=values[0],max=values[0],i;
+    for(i=1;i<values.length;i++){if(values[i]<min)min=values[i];if(values[i]>max)max=values[i];}
+    var range=max-min;
+    var stepX=w/(values.length-1);
+    for(i=0;i<values.length;i++){
+      var x=i*stepX;
+      // Invert Y (SVG origin is top-left) and flatten a zero-range series to the
+      // vertical centre so a constant value reads as a steady line, not a spike.
+      var norm=range>0?(values[i]-min)/range:0.5;
+      var yy=SPARK_PAD+(1-norm)*innerH;
+      pts.push([x,yy]);
+    }
+  }
+  var d='';
+  for(var j=0;j<pts.length;j++){
+    d+=(j===0?'M':'L')+pts[j][0].toFixed(1)+' '+pts[j][1].toFixed(1);
+  }
+  return '<span class="spark" aria-hidden="true"><svg width="'+w+'" height="'+h+'" viewBox="0 0 '+w+' '+h+'" preserveAspectRatio="none">'+
+    '<path d="'+d+'" fill="none" stroke="'+color+'" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"/>'+
+    '</svg></span>';
+}
+// setSpark injects a sparkline into the element with the given id, if present.
+function setSpark(id,values,w,h,color){
+  var el=document.getElementById(id);
+  if(el)el.innerHTML=sparkline(values,w,h,color);
+}
+// ccMetrics caches the last /api/contribute/metrics payload so the leaderboard
+// render (which runs independently of opsPoll) can read per-user history without
+// its own fetch. Null until the first successful poll.
+var ccMetrics=null;
+// ccMetricsPoll fetches the persistent hourly series and paints the four Ops-tab
+// sparklines. Called from opsPoll() on its existing cadence — hourly data does
+// not need a fast dedicated timer, so every opsPoll tick is more than enough.
+function ccMetricsPoll(){
+  return fetch('/api/contribute/metrics').then(function(r){return r.json();}).then(function(d){
+    ccMetrics=d||{};
+    // (a) Ready-work queue header → queue-depth trend.
+    setSpark('spark-queue',ccMetrics.queue_depth,SPARK_W,SPARK_H,'#388bfd');
+    // (b) Tasks-completed / hour throughput.
+    setSpark('spark-throughput',ccMetrics.tasks_done,SPARK_W,SPARK_H,'#3fb950');
+    // (c) Connected-clanker fleet-size trend.
+    setSpark('spark-fleet',ccMetrics.fleet_size,SPARK_W,SPARK_H,'#d29922');
+    // (d) Your daily-quota usage trend — the viewer's own per-hour completions.
+    if(ccMeUsername&&ccMetrics.per_user_done&&ccMetrics.per_user_done[ccMeUsername]){
+      setSpark('spark-quota',ccMetrics.per_user_done[ccMeUsername],SPARK_W,SPARK_H,'#388bfd');
+    }
+    // Leaderboard hive-wide trend + per-row sparklines, if the tab is rendered.
+    ccRenderLeaderboardSparklines();
+  }).catch(function(e){console.error('metrics poll failed',e);});
+}
+// ccRenderLeaderboardSparklines paints the hive-wide total-tasks trend strip and
+// each per-contributor row sparkline from the cached metrics. Safe to call any
+// time — it no-ops when the leaderboard is not on screen or metrics are absent.
+function ccRenderLeaderboardSparklines(){
+  if(!ccMetrics)return;
+  var trend=document.getElementById('spark-lb-trend');
+  if(trend)trend.innerHTML=sparkline(ccMetrics.tasks_done,120,20,'#3fb950');
+  var pud=ccMetrics.per_user_done||{};
+  var rows=document.querySelectorAll('.lb-spark[data-user]');
+  for(var i=0;i<rows.length;i++){
+    var u=rows[i].getAttribute('data-user');
+    var series=(u&&pud[u])?pud[u]:[];
+    rows[i].innerHTML=sparkline(series,60,16,'#8b949e');
+  }
+}
 
 // ── Clickable GitHub issue/PR references (#2616) ────────────────────────────────
 // The Operations tab shows plenty of "repo#number" references (ready-work queue,
@@ -2739,6 +2863,10 @@ async function opsPoll(){
     // fall through to reschedule so a transient failure self-heals on the next poll.
     console.error('opsPoll fetch failed',e);
   }
+  // Persistent hourly sparklines (#persistent-history). Independent of the fleet
+  // fetch above (its own try/catch inside ccMetricsPoll) so a metrics hiccup never
+  // stalls the panels. Hourly data on the opsPoll cadence is plenty — no fast timer.
+  ccMetricsPoll();
   var tab=document.getElementById('tab-ops');
   if(tab&&tab.classList.contains('active'))setTimeout(opsPoll,4000);
 }
@@ -3465,6 +3593,11 @@ function ccQuotaHTML(variant){
   var remaining=Math.max(0,max-used);
   return '<div class="quota '+(variant||'')+'">'+
     '<div class="quota__head"><span class="quota__lbl">Your daily quota ('+esc(ccTierLabel(you.tier))+' set)</span><span class="quota__val">'+used+' / '+max+' tasks</span></div>'+
+    // Your usage trend (#persistent-history): the viewer's own per-hour completions
+    // over the last 7 days, hydrated by ccMetricsPoll once metrics + identity load.
+    // Only on the end-of-queue variant (variant==='') so the id stays unique — the
+    // Me-card renders the same quota widget with a different variant.
+    ((variant||'')===''?'<div class="quota__sub" style="text-align:right;margin-top:2px"><span class="spark" id="spark-quota" title="Your completions per hour, last 7 days"></span></div>':'')+
     '<div class="quota__bar"><div class="quota__fill '+cls+'" style="width:'+pct+'%%"></div></div>'+
     '<div class="quota__sub">'+(remaining>0?(remaining+' left in your allowance today.'):'You&rsquo;ve used your daily allowance — it refreshes on a rolling 24h window.')+'</div>'+
   '</div>';

--- a/v2/pkg/dashboard/contribute_metrics.go
+++ b/v2/pkg/dashboard/contribute_metrics.go
@@ -1,0 +1,369 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Persistent hourly time-series feeding the Operations-tab and Leaderboard
+// sparklines (#persistent-history). Four series are kept, each a ring of the
+// most-recent hourly buckets on the spoke PVC so the trend survives restarts and
+// rolling upgrades instead of resetting to a flat line on every deploy:
+//   - queue_depth   : length of the admitted ready-work queue, SAMPLED hourly
+//   - tasks_done    : task completions counted in each hour (delta of cumulative)
+//   - fleet_size    : number of connected clankers, SAMPLED hourly
+//   - per_user_done : per-contributor (github_username) completions per hour
+//
+// The store owns ONLY the counting + persistence. Sampling reads live values
+// from the contribute hub; the deltas come from the cumulative per-contributor
+// TasksCompleted counters that already persist per user, so a restart mid-hour
+// cannot double-count (a bucket is the difference between two cumulative reads).
+
+const (
+	// metricsRetentionBuckets is how many hourly buckets each series keeps: 168
+	// hours == 7 days. Old buckets fall off the front of the ring. Seven days is
+	// enough to show a week-over-week trend in a tiny sparkline while keeping the
+	// on-disk file and the JSON payload trivially small.
+	metricsRetentionBuckets = 168
+
+	// defaultMetricsFile is where the hourly series are mirrored on the spoke PVC
+	// (same /data volume as the contributor store and fleet-stats). Overridable
+	// via HIVE_METRICS_FILE so tests can point it at a temp dir, matching how the
+	// contributor dir / federation registry are made overridable.
+	defaultMetricsFile = "/data/metrics.json"
+)
+
+// metricsRollupInterval is how often the rollup goroutine samples + rolls a
+// bucket. A var (not const) so tests can inject a short interval to exercise the
+// bucketing without waiting an hour. Production keeps a 1-hour cadence, matching
+// the "bucket":"hour" contract of the endpoint.
+var metricsRollupInterval = time.Hour
+
+// getMetricsFile resolves the PVC path for the persisted series, overridable for
+// tests via HIVE_METRICS_FILE (mirrors getContributorsDir / federation registry).
+func getMetricsFile() string {
+	if v := os.Getenv("HIVE_METRICS_FILE"); v != "" {
+		return v
+	}
+	return defaultMetricsFile
+}
+
+// metricsPersistShape is the on-disk / wire JSON shape. Field names are the
+// stable contract the client sparklines read; keep them in sync with the
+// endpoint response and the client fetch.
+type metricsPersistShape struct {
+	QueueDepth  []int            `json:"queue_depth"`
+	TasksDone   []int            `json:"tasks_done"`
+	FleetSize   []int            `json:"fleet_size"`
+	PerUserDone map[string][]int `json:"per_user_done"`
+	Bucket      string           `json:"bucket"`
+	CollectedAt string           `json:"collected_at"`
+}
+
+// metricsStore is a concurrency-safe ring of hourly buckets per series. Every
+// series is capped at metricsRetentionBuckets; per_user_done is a map of
+// username -> its own capped ring. lastTotals holds the previous cumulative
+// per-user completion counts so each tick can derive the hour's delta.
+type metricsStore struct {
+	mu sync.Mutex
+
+	queueDepth  []int
+	tasksDone   []int
+	fleetSize   []int
+	perUserDone map[string][]int
+
+	// lastTotals is the cumulative TasksCompleted per user as of the previous
+	// rollup, used to compute this hour's completion delta. Not persisted: it is
+	// re-seeded from the live profiles on the first tick after a restart, so the
+	// first post-restart bucket may under-count a partial hour rather than
+	// mistaking the whole cumulative total for a single hour's work.
+	lastTotals map[string]int
+
+	// seededTotals guards the first-tick seed so a restart does not book the
+	// entire historical cumulative count as one hour of completions.
+	seededTotals bool
+
+	collectedAt time.Time
+	path        string
+	logger      *slog.Logger
+}
+
+// newMetricsStore builds an empty store. Call load() to restore prior history
+// from the PVC and Start() to run the hourly rollup.
+func newMetricsStore(path string, logger *slog.Logger) *metricsStore {
+	return &metricsStore{
+		perUserDone: make(map[string][]int),
+		lastTotals:  make(map[string]int),
+		path:        path,
+		logger:      logger,
+	}
+}
+
+// capRing trims a series to the most-recent metricsRetentionBuckets tail so the
+// ring never grows without bound. Returns the (possibly reused) slice.
+func capRing(s []int) []int {
+	if len(s) > metricsRetentionBuckets {
+		return s[len(s)-metricsRetentionBuckets:]
+	}
+	return s
+}
+
+// load restores the series from the PVC file. A missing file is a clean no-op
+// (first boot). A corrupt/unreadable file is logged and ignored — the store
+// starts empty rather than crashing, matching the tombstone/fleet-stats loaders'
+// resilience contract (never panic on a bad /data file).
+func (m *metricsStore) load() {
+	if m == nil || m.path == "" {
+		return
+	}
+	data, err := os.ReadFile(m.path)
+	if err != nil {
+		if !os.IsNotExist(err) && m.logger != nil {
+			m.logger.Warn("metrics store unreadable — starting with empty history",
+				"path", m.path, "error", err)
+		}
+		return
+	}
+	var stored metricsPersistShape
+	if err := json.Unmarshal(data, &stored); err != nil {
+		if m.logger != nil {
+			m.logger.Warn("metrics store corrupt — starting with empty history",
+				"path", m.path, "error", err)
+		}
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.queueDepth = capRing(stored.QueueDepth)
+	m.tasksDone = capRing(stored.TasksDone)
+	m.fleetSize = capRing(stored.FleetSize)
+	m.perUserDone = make(map[string][]int, len(stored.PerUserDone))
+	for user, ring := range stored.PerUserDone {
+		m.perUserDone[user] = capRing(ring)
+	}
+	if t, err := time.Parse(time.RFC3339, stored.CollectedAt); err == nil {
+		m.collectedAt = t
+	}
+	if m.logger != nil {
+		m.logger.Info("restored contribute metrics from PVC",
+			"buckets", len(m.tasksDone), "users", len(m.perUserDone), "path", m.path)
+	}
+}
+
+// snapshot returns a copy-on-read wire shape so callers (the endpoint) cannot
+// mutate the rings. Safe for concurrent use.
+func (m *metricsStore) snapshot() metricsPersistShape {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := metricsPersistShape{
+		QueueDepth:  append([]int(nil), m.queueDepth...),
+		TasksDone:   append([]int(nil), m.tasksDone...),
+		FleetSize:   append([]int(nil), m.fleetSize...),
+		PerUserDone: make(map[string][]int, len(m.perUserDone)),
+		Bucket:      "hour",
+	}
+	for user, ring := range m.perUserDone {
+		out.PerUserDone[user] = append([]int(nil), ring...)
+	}
+	if !m.collectedAt.IsZero() {
+		out.CollectedAt = m.collectedAt.UTC().Format(time.RFC3339)
+	}
+	return out
+}
+
+// persistLocked mirrors the current series to the PVC atomically (temp file +
+// rename, matching the fleet-stats / session store writers). Callers must hold
+// m.mu. 0600 keeps every PVC-persisted dashboard file in one trust domain; the
+// contents are only counts + already-public usernames, never secrets.
+func (m *metricsStore) persistLocked() {
+	if m.path == "" {
+		return
+	}
+	shape := metricsPersistShape{
+		QueueDepth:  m.queueDepth,
+		TasksDone:   m.tasksDone,
+		FleetSize:   m.fleetSize,
+		PerUserDone: m.perUserDone,
+		Bucket:      "hour",
+	}
+	if !m.collectedAt.IsZero() {
+		shape.CollectedAt = m.collectedAt.UTC().Format(time.RFC3339)
+	}
+	data, err := json.Marshal(shape)
+	if err != nil {
+		return
+	}
+	ensureDir(filepath.Dir(m.path))
+	tmp := m.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		if m.logger != nil {
+			m.logger.Warn("failed to write metrics store", "path", m.path, "error", err)
+		}
+		return
+	}
+	if err := os.Rename(tmp, m.path); err != nil && m.logger != nil {
+		m.logger.Warn("failed to replace metrics store", "path", m.path, "error", err)
+	}
+}
+
+// rollupSample is the live data one rollup tick observes: the current admitted
+// queue depth, the current connected fleet size, and the current CUMULATIVE
+// per-user completion totals. The store converts the cumulative totals into a
+// per-hour delta internally.
+type rollupSample struct {
+	queueDepth int
+	fleetSize  int
+	// userTotals maps github_username -> cumulative TasksCompleted so far. The
+	// store diffs this against the previous tick to get the hour's completions.
+	userTotals map[string]int
+	// now is the wall clock for this tick, truncated to the hour for bucketing.
+	now time.Time
+}
+
+// rollup folds one sample into a new bucket for every series and persists. It is
+// the single place a bucket is appended, so the four rings stay index-aligned by
+// construction. queue_depth and fleet_size are point SAMPLES; tasks_done and
+// per_user_done are DELTAS derived from the cumulative per-user totals.
+func (m *metricsStore) rollup(s rollupSample) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Seed the baseline on the first tick after a (re)start so we book only the
+	// completions that happen AFTER we start watching, never the whole historical
+	// cumulative total as a single hour's work.
+	if !m.seededTotals {
+		m.lastTotals = make(map[string]int, len(s.userTotals))
+		for user, total := range s.userTotals {
+			m.lastTotals[user] = total
+		}
+		m.seededTotals = true
+	}
+
+	hourTasks := 0
+	for user, total := range s.userTotals {
+		delta := total - m.lastTotals[user]
+		if delta < 0 {
+			// A profile reset / re-registration lowered the cumulative count.
+			// Treat as zero for this hour rather than a negative bucket.
+			delta = 0
+		}
+		if delta > 0 {
+			m.perUserDone[user] = capRing(append(m.perUserDone[user], delta))
+			hourTasks += delta
+		}
+		m.lastTotals[user] = total
+	}
+
+	m.queueDepth = capRing(append(m.queueDepth, s.queueDepth))
+	m.fleetSize = capRing(append(m.fleetSize, s.fleetSize))
+	m.tasksDone = capRing(append(m.tasksDone, hourTasks))
+	m.collectedAt = s.now.Truncate(time.Hour)
+
+	m.persistLocked()
+}
+
+// metricsSampler is the minimal live-data surface the rollup needs, so the store
+// stays testable without a full Server. The Server satisfies it via
+// sampleMetricsInputs.
+type metricsSampler interface {
+	sampleMetricsInputs() rollupSample
+}
+
+// Start runs the hourly rollup loop until ctx is cancelled. It ticks on
+// metricsRollupInterval; the ticker takes ctx and is stopped on return so there
+// is no uncancellable timer leak (matching the fleet-stats collector contract).
+func (m *metricsStore) Start(ctx context.Context, sampler metricsSampler) {
+	if m == nil || sampler == nil {
+		return
+	}
+	ticker := time.NewTicker(metricsRollupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.rollup(sampler.sampleMetricsInputs())
+		}
+	}
+}
+
+// contributeMetricsStore lazily builds the per-Server metrics store, loading any
+// prior history from the PVC on first use. Guarded by contributeMetricsOnce so
+// the zero-value Server needs no constructor change (matching the token/fact/cost
+// history accessors' lazy pattern).
+func (s *Server) contributeMetricsStore() *metricsStore {
+	s.contributeMetricsOnce.Do(func() {
+		s.contributeMetrics = newMetricsStore(getMetricsFile(), s.logger)
+		s.contributeMetrics.load()
+	})
+	return s.contributeMetrics
+}
+
+// sampleMetricsInputs reads the live values the rollup buckets: the admitted
+// ready-work queue length, the connected clanker count, and each contributor's
+// cumulative completion total. All reads are cheap and side-effect-free.
+func (s *Server) sampleMetricsInputs() rollupSample {
+	sample := rollupSample{
+		userTotals: make(map[string]int),
+		now:        time.Now(),
+	}
+	if s.contributeHub != nil {
+		// Admitted ready-work queue length — the SAME admissible set the
+		// /api/contribute/queue endpoint serves (ReadyQueue), so the sparkline
+		// tracks exactly what the operator sees in the queue panel.
+		sample.queueDepth = len(s.contributeHub.ReadyQueue(readyQueueDefaultLimit))
+		// Connected clankers — distinct connected contributors, the same count the
+		// Operations "Connected clankers" panel shows.
+		sample.fleetSize = s.contributeHub.ActiveCount()
+	}
+	for _, p := range listContributorProfiles() {
+		if p.GitHubUsername == "" {
+			continue
+		}
+		sample.userTotals[p.GitHubUsername] = p.TasksCompleted
+	}
+	return sample
+}
+
+// StartContributeMetrics wires the hourly rollup goroutine to ctx, so it shuts
+// down cleanly when the process context is cancelled (no goroutine leak). Call
+// once at startup, like the other background collectors (fleet-stats, metrics).
+func (s *Server) StartContributeMetrics(ctx context.Context) {
+	store := s.contributeMetricsStore()
+	go store.Start(ctx, s)
+}
+
+// handleContributeMetrics serves the persisted hourly series for the sparklines.
+// GET only, read-only, no side effects. Public within the contribute surface
+// (the /api/contribute* prefix is treated as public by isPublicPath, exactly
+// like /api/contribute/fleet and /queue), because it exposes only counts and the
+// github_usernames already shown on the public leaderboard — no tokens, no PII.
+func (s *Server) handleContributeMetrics(w http.ResponseWriter, r *http.Request) {
+	snap := s.contributeMetricsStore().snapshot()
+	// Sort per-user keys for a stable payload (aids caching/diffing and tests).
+	users := make([]string, 0, len(snap.PerUserDone))
+	for u := range snap.PerUserDone {
+		users = append(users, u)
+	}
+	sort.Strings(users)
+	ordered := make(map[string][]int, len(snap.PerUserDone))
+	for _, u := range users {
+		ordered[u] = snap.PerUserDone[u]
+	}
+	jsonResponse(w, map[string]any{
+		"queue_depth":   snap.QueueDepth,
+		"tasks_done":    snap.TasksDone,
+		"fleet_size":    snap.FleetSize,
+		"per_user_done": ordered,
+		"bucket":        "hour",
+		"collected_at":  snap.CollectedAt,
+	})
+}

--- a/v2/pkg/dashboard/contribute_metrics_endpoint_test.go
+++ b/v2/pkg/dashboard/contribute_metrics_endpoint_test.go
@@ -1,0 +1,69 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestContributeMetricsEndpointRegistered pins that GET /api/contribute/metrics
+// is wired and returns the four series with the "hour" bucket contract the client
+// sparklines depend on. An empty store must still return well-formed (empty)
+// arrays, never 404 or a nil-map panic.
+func TestContributeMetricsEndpointRegistered(t *testing.T) {
+	setupContributeEnv(t)
+	t.Setenv("HIVE_METRICS_FILE", filepath.Join(t.TempDir(), "metrics.json"))
+
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	rec := doGet(s, "/api/contribute/metrics")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/contribute/metrics = %d, want 200", rec.Code)
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response not JSON: %v", err)
+	}
+	for _, key := range []string{"queue_depth", "tasks_done", "fleet_size", "per_user_done", "bucket", "collected_at"} {
+		if _, ok := body[key]; !ok {
+			t.Errorf("metrics response missing key %q", key)
+		}
+	}
+	var bucket string
+	if err := json.Unmarshal(body["bucket"], &bucket); err != nil || bucket != "hour" {
+		t.Errorf("bucket = %q (err %v), want \"hour\"", bucket, err)
+	}
+}
+
+// TestContributeMetricsSparklineClientWired pins the client-side pieces on the
+// rendered /contribute page: the dependency-free SVG sparkline renderer, the
+// metrics fetch, and every sparkline home (queue header, throughput, fleet,
+// quota, plus the leaderboard per-row + hive-wide trend). Mirrors the
+// contribute_devlog_rail_test.go strings.Contains pin style so the feature
+// cannot silently regress.
+func TestContributeMetricsSparklineClientWired(t *testing.T) {
+	body := renderContributePage(t)
+
+	for _, want := range []string{
+		"function sparkline(",              // the dependency-free SVG renderer
+		"<svg width=",                      // renders an inline SVG (CSP-safe, no lib)
+		"/api/contribute/metrics",          // the fetch target
+		"function ccMetricsPoll(",          // the poll driver, called from opsPoll
+		"ccMetricsPoll();",                 // actually invoked
+		`id="spark-queue"`,                 // (a) ready-work queue header trend
+		`id="spark-throughput"`,            // (b) tasks/hour throughput
+		`id="spark-fleet"`,                 // (c) connected-clanker fleet trend
+		`id="spark-quota"`,                 // (d) your daily-quota usage trend
+		`id="spark-lb-trend"`,              // (f) hive-wide total-tasks trend
+		`class="lb-spark" data-user=`,      // (e) leaderboard per-row sparkline slot
+		"function ccRenderLeaderboardSparklines(", // leaderboard painter
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("rendered contribute page missing sparkline marker %q", want)
+		}
+	}
+}

--- a/v2/pkg/dashboard/contribute_metrics_test.go
+++ b/v2/pkg/dashboard/contribute_metrics_test.go
@@ -1,0 +1,228 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// fakeSampler feeds deterministic values into a rollup tick so the bucketing can
+// be exercised without a live hub or a real hour passing.
+type fakeSampler struct {
+	queue  int
+	fleet  int
+	totals map[string]int
+	now    time.Time
+}
+
+func (f *fakeSampler) sampleMetricsInputs() rollupSample {
+	tot := make(map[string]int, len(f.totals))
+	for k, v := range f.totals {
+		tot[k] = v
+	}
+	return rollupSample{queueDepth: f.queue, fleetSize: f.fleet, userTotals: tot, now: f.now}
+}
+
+// TestMetricsStoreRoundTrip saves a store to the JSON file and reloads it,
+// asserting the series survive the trip through /data (the PVC persistence path).
+func TestMetricsStoreRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "metrics.json")
+	s := newMetricsStore(path, slog.Default())
+
+	// One rollup with a couple of completions, a queue depth, and a fleet size.
+	s.rollup(rollupSample{
+		queueDepth: 7,
+		fleetSize:  3,
+		userTotals: map[string]int{}, // first tick seeds the baseline (no deltas)
+		now:        time.Now(),
+	})
+	s.rollup(rollupSample{
+		queueDepth: 9,
+		fleetSize:  4,
+		userTotals: map[string]int{"alice": 2, "bob": 1},
+		now:        time.Now(),
+	})
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected metrics file written, stat err: %v", err)
+	}
+
+	// Reload into a fresh store and compare.
+	s2 := newMetricsStore(path, slog.Default())
+	s2.load()
+	snap := s2.snapshot()
+
+	if got := len(snap.QueueDepth); got != 2 {
+		t.Fatalf("queue_depth buckets = %d, want 2", got)
+	}
+	if snap.QueueDepth[1] != 9 || snap.FleetSize[1] != 4 {
+		t.Fatalf("restored latest bucket wrong: queue=%v fleet=%v", snap.QueueDepth, snap.FleetSize)
+	}
+	// alice completed 2, bob 1 in the second bucket; the tasks_done total for that
+	// bucket is 3.
+	if snap.TasksDone[1] != 3 {
+		t.Fatalf("tasks_done[1] = %d, want 3", snap.TasksDone[1])
+	}
+	if len(snap.PerUserDone["alice"]) == 0 || snap.PerUserDone["alice"][len(snap.PerUserDone["alice"])-1] != 2 {
+		t.Fatalf("per_user_done[alice] wrong: %v", snap.PerUserDone["alice"])
+	}
+	if snap.Bucket != "hour" {
+		t.Fatalf("bucket = %q, want hour", snap.Bucket)
+	}
+}
+
+// TestMetricsRingRetention asserts every series caps at metricsRetentionBuckets
+// (168) so a long-running spoke never grows the file without bound.
+func TestMetricsRingRetention(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "metrics.json")
+	s := newMetricsStore(path, slog.Default())
+
+	// Push well past the cap. Each tick raises alice's cumulative total by 1 so
+	// every bucket after the first records a delta of 1.
+	const ticks = metricsRetentionBuckets + 50
+	for i := 0; i < ticks; i++ {
+		s.rollup(rollupSample{
+			queueDepth: i,
+			fleetSize:  1,
+			userTotals: map[string]int{"alice": i},
+			now:        time.Now(),
+		})
+	}
+	snap := s.snapshot()
+	if len(snap.QueueDepth) != metricsRetentionBuckets {
+		t.Fatalf("queue_depth len = %d, want cap %d", len(snap.QueueDepth), metricsRetentionBuckets)
+	}
+	if len(snap.TasksDone) != metricsRetentionBuckets {
+		t.Fatalf("tasks_done len = %d, want cap %d", len(snap.TasksDone), metricsRetentionBuckets)
+	}
+	if len(snap.PerUserDone["alice"]) > metricsRetentionBuckets {
+		t.Fatalf("per_user_done[alice] len = %d exceeds cap %d", len(snap.PerUserDone["alice"]), metricsRetentionBuckets)
+	}
+	// The most-recent queue_depth bucket must be the last value pushed.
+	if snap.QueueDepth[len(snap.QueueDepth)-1] != ticks-1 {
+		t.Fatalf("latest queue_depth = %d, want %d", snap.QueueDepth[len(snap.QueueDepth)-1], ticks-1)
+	}
+}
+
+// TestMetricsStoreCorruptFile asserts a corrupt /data file yields an empty store
+// with no panic — the resilience contract the tombstone/fleet-stats loaders keep.
+func TestMetricsStoreCorruptFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "metrics.json")
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s := newMetricsStore(path, slog.Default())
+	s.load() // must not panic
+	snap := s.snapshot()
+	if len(snap.QueueDepth) != 0 || len(snap.TasksDone) != 0 || len(snap.PerUserDone) != 0 {
+		t.Fatalf("corrupt file should leave an empty store, got %+v", snap)
+	}
+}
+
+// TestMetricsStoreMissingFile asserts a missing file is a clean no-op (first boot).
+func TestMetricsStoreMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist.json")
+	s := newMetricsStore(path, slog.Default())
+	s.load() // must not panic
+	if len(s.snapshot().QueueDepth) != 0 {
+		t.Fatalf("missing file should leave an empty store")
+	}
+}
+
+// TestMetricsRollupBuckets drives the rollup goroutine with an injected short
+// interval and asserts it buckets a tick correctly, keyed by the truncated hour.
+func TestMetricsRollupBuckets(t *testing.T) {
+	origInterval := metricsRollupInterval
+	metricsRollupInterval = 5 * time.Millisecond
+	t.Cleanup(func() { metricsRollupInterval = origInterval })
+
+	path := filepath.Join(t.TempDir(), "metrics.json")
+	store := newMetricsStore(path, slog.Default())
+
+	sampler := &fakeSampler{
+		queue:  5,
+		fleet:  2,
+		totals: map[string]int{"carol": 4},
+		now:    time.Now(),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { store.Start(ctx, sampler); close(done) }()
+
+	// Wait for at least two ticks so the seed tick + a delta tick both land.
+	deadline := time.After(2 * time.Second)
+	for {
+		if len(store.snapshot().QueueDepth) >= 2 {
+			break
+		}
+		select {
+		case <-deadline:
+			cancel()
+			t.Fatal("rollup did not produce buckets in time")
+		case <-time.After(2 * time.Millisecond):
+		}
+	}
+	cancel()
+	<-done // Start must return promptly on ctx cancel (no goroutine leak).
+
+	snap := store.snapshot()
+	if snap.QueueDepth[0] != 5 || snap.FleetSize[0] != 2 {
+		t.Fatalf("sampled point values wrong: queue=%v fleet=%v", snap.QueueDepth, snap.FleetSize)
+	}
+	// collected_at must be truncated to the hour boundary.
+	ct, err := time.Parse(time.RFC3339, snap.CollectedAt)
+	if err != nil {
+		t.Fatalf("collected_at not RFC3339: %q (%v)", snap.CollectedAt, err)
+	}
+	if !ct.Equal(ct.Truncate(time.Hour)) {
+		t.Fatalf("collected_at %v is not truncated to the hour", ct)
+	}
+}
+
+// TestMetricsStoreSeedNoBackfill asserts the first tick after a (re)start does
+// NOT book the whole historical cumulative total as one hour of completions.
+func TestMetricsStoreSeedNoBackfill(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "metrics.json")
+	s := newMetricsStore(path, slog.Default())
+
+	// First tick sees a large pre-existing cumulative total. It must be treated as
+	// the baseline (delta 0), not booked as 100 completions this hour.
+	s.rollup(rollupSample{userTotals: map[string]int{"dave": 100}, now: time.Now()})
+	snap := s.snapshot()
+	if snap.TasksDone[0] != 0 {
+		t.Fatalf("first tick booked %d tasks, want 0 (baseline seed)", snap.TasksDone[0])
+	}
+	// A subsequent +3 must be booked as exactly 3.
+	s.rollup(rollupSample{userTotals: map[string]int{"dave": 103}, now: time.Now()})
+	snap = s.snapshot()
+	if snap.TasksDone[1] != 3 {
+		t.Fatalf("second tick booked %d tasks, want 3", snap.TasksDone[1])
+	}
+}
+
+// TestMetricsPersistShapeStable pins the on-disk JSON keys the client sparklines
+// depend on, so a rename can't silently break the fetch contract.
+func TestMetricsPersistShapeStable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "metrics.json")
+	s := newMetricsStore(path, slog.Default())
+	s.rollup(rollupSample{queueDepth: 1, fleetSize: 1, userTotals: map[string]int{}, now: time.Now()})
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"queue_depth", "tasks_done", "fleet_size", "per_user_done", "bucket"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("persisted metrics missing key %q", key)
+		}
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -160,6 +160,14 @@ type Server struct {
 
 	contributeHub *ContributeWSHub
 
+	// contributeMetrics holds the persistent hourly time-series behind the
+	// Operations + Leaderboard sparklines (queue depth, tasks/hour, fleet size,
+	// per-user completions). Lazily built via contributeMetricsStore() so the
+	// zero-value Server needs no constructor change; the rollup goroutine is
+	// started by StartContributeMetrics(ctx). See contribute_metrics.go.
+	contributeMetricsOnce sync.Once
+	contributeMetrics     *metricsStore
+
 	inferenceMu        sync.RWMutex
 	inferenceEndpoints map[string][]string // backend id → list of base URLs
 


### PR DESCRIPTION
## What

Adds persistent-history **sparklines** to the contributor dashboard's Operations tab and Leaderboard, backed by a new PVC-persisted hourly time-series store. The trend survives restarts and rolling upgrades instead of flattening on every deploy.

## Metrics store (`v2/pkg/dashboard/contribute_metrics.go`)

A concurrency-safe ring of **168 hourly buckets (7-day retention)** per series, mirrored on the spoke PVC:

- `queue_depth` — admitted ready-work queue length, **sampled** hourly (same `ReadyQueue` set the queue panel shows)
- `tasks_done` — completions per hour, derived as a **delta** of the cumulative per-contributor `TasksCompleted` counters (robust across mid-hour restarts; first tick seeds a baseline so history is never back-filled as one hour)
- `fleet_size` — connected clankers (`ActiveCount`), sampled hourly
- `per_user_done` — per-contributor (`github_username`) completions per hour

Persistence follows the existing `FleetStatsCollector` pattern: atomic write (temp + rename) to `/data/metrics.json` (overridable via `HIVE_METRICS_FILE` for tests), resilient load (missing file = clean first-boot no-op, corrupt file = logged + empty, **never panics**). The rollup goroutine ticks on `metricsRollupInterval` (a `var` so tests inject a short one), buckets by `time.Now().Truncate(time.Hour)`, and is **bound to the process `ctx`** so it shuts down cleanly with the other background loops — no goroutine leak. Retention `168` and the 1-hour bucket are named constants with comments.

## Endpoint

`GET /api/contribute/metrics` → `{ queue_depth:[…], tasks_done:[…], fleet_size:[…], per_user_done:{user:[…]}, bucket:"hour", collected_at:"…" }`

Registered beside the other `/api/contribute/*` routes; read-only, no side effects. Public within the contribute surface (same `isPublicPath` treatment as `/api/contribute/fleet` and `/queue`) — it exposes only counts and the usernames already shown on the public leaderboard. No tokens, no PII.

## Sparklines (dependency-free, CSP-safe inline SVG)

A tiny `sparkline(values,w,h,color)` renderer returns an `<svg>` polyline — no external library, no canvas, static (nothing to animate, so nothing to gate behind `prefers-reduced-motion`). Empty / single-point arrays render a flat baseline, never a NaN path. Fetched on the existing `opsPoll` cadence (hourly data needs no fast timer).

Homes:
- **Operations:** (a) Ready-work queue header → queue-depth trend; (b) tasks/hour throughput (Pipeline & policy header); (c) connected-clanker fleet-size trend; (d) your daily-quota usage trend (in the quota widget).
- **Leaderboard:** (e) a per-contributor row sparkline; (f) a hive-wide total-tasks trend strip pinned above the standings.

## Leaderboard per-user history — scoped limitation

The Rankings list is served by the HUB (`/api/leaderboard`, aggregated across spokes), but the per-user **history** arrays are **not** carried on that aggregation path. Rather than invade the hub aggregation (or fabricate history), the Leaderboard sparklines are scoped to **this hive's own** `/api/contribute/metrics` `per_user_done`, matched to rows by `github_username`. Consequence: a row's sparkline reflects the completions **this spoke recorded** (up to 7 days), and a federated contributor's cross-hive history is not shown. Rows with no local history render a calm flat baseline — never fabricated data. Widening this to true cross-hive per-user history would require threading the arrays through the hub's leaderboard aggregation and is left as a follow-up.

## Tests

- `contribute_metrics_test.go`: JSON round-trip (save→load), 168-bucket retention cap, corrupt-file and missing-file resilience (no panic), injected short-interval rollup bucketing with clean ctx-cancel shutdown, seed-no-backfill, and a persisted-key pin.
- `contribute_metrics_endpoint_test.go`: endpoint registration + response contract, and a rendered-page pin for the SVG renderer, the fetch, and every sparkline home (devlog-rail test style).