### PR TITLE
✨ Editable hive name (renames project) + org/repo primary-repo line on hub rows

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -225,6 +225,10 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/switch-branch", s.requireAuth(s.handleSwitchBranch))
 	s.mux.HandleFunc("PUT /api/saas/hives/{id}/visibility", s.requireAuth(s.handleToggleVisibility))
 	s.mux.HandleFunc("PUT /api/saas/hives/{id}/auto-upgrade", s.requireAuth(s.handleToggleAutoUpgrade))
+	// Rename a hive's display name (its ProjectName). requireAuth plus an inner
+	// owner-or-admin check, exactly like visibility/auto-upgrade above — the
+	// gate is the security boundary, not just the hidden UI affordance.
+	s.mux.HandleFunc("PUT /api/saas/hives/{id}/name", s.requireAuth(s.handleRenameHive))
 	// Move a hive between forges (github.com <-> a GitHub Enterprise host).
 	// requireAuth plus an inner owner-or-admin check, exactly like
 	// switch-branch and auto-upgrade above.
@@ -3292,6 +3296,101 @@ func (s *HubServer) handleToggleVisibility(w http.ResponseWriter, r *http.Reques
 
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprintf(w, `{"ok":true,"is_public":%t}`, body.IsPublic)
+}
+
+// maxHiveDisplayNameLen bounds a hive's operator-set display name (ProjectName).
+// It matches maxContactNameLen's order of magnitude — a human-readable label,
+// not a document — and guards both the persisted meta.json and the vanity-host
+// label derived from it (hiveNameHostLabel truncates to a DNS label anyway, so
+// this only stops an absurdly long value from ever being stored).
+const maxHiveDisplayNameLen = 100
+
+// handleRenameHive renames a hive by rewriting its persisted ProjectName. The
+// operator explicitly accepted that ProjectName is load-bearing — it feeds the
+// namespace identity annotation and (at claim time) the vanity host — so this
+// is a rename of the hive's real identity, NOT a separate display_name field.
+//
+// AUTHORIZATION mirrors handleToggleVisibility exactly: requireAuth on the
+// route, then an owner-or-admin check here that is the true security boundary
+// (a non-owner is rejected 403 regardless of what the UI shows).
+//
+// Derived-surface handling on rename:
+//   - Namespace identity is RE-STAMPED here (idempotent, best-effort) so the
+//     hive.kubestellar.io/display-name annotation tracks the new name.
+//   - The vanity host is NOT recomputed. It is set-once at claim time (the
+//     assign path only mints one when VanityURL is empty) and doubles as the
+//     "placeholder is claimed" marker; minting a fresh random host on every
+//     rename would churn URLs and orphan routes. So the vanity host keeps its
+//     original label — a known, documented staleness, not a silent one.
+func (s *HubServer) handleRenameHive(w http.ResponseWriter, r *http.Request) {
+	origin := r.Header.Get("Origin")
+	if isTrustedOrigin(origin) {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		w.Header().Set("Access-Control-Allow-Methods", "PUT, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	}
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	id := r.PathValue("id")
+	username := s.getAuthUser(r)
+
+	h := loadSaaSHive(id)
+	if h == nil {
+		http.Error(w, `{"error":"hive not found — only hosted hives can be renamed from here"}`, http.StatusNotFound)
+		return
+	}
+	if h.Owner != username && username != hubAdminUsername {
+		http.Error(w, `{"error":"only the owner can rename this hive"}`, http.StatusForbidden)
+		return
+	}
+
+	var body struct {
+		ProjectName string `json:"project_name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Trim and cap. A blank value is a legitimate "clear the custom name" — the
+	// dashboard then falls back to today's org/repo-derived label (hiveLabel).
+	name := strings.TrimSpace(body.ProjectName)
+	if len(name) > maxHiveDisplayNameLen {
+		http.Error(w, `{"error":"name too long"}`, http.StatusBadRequest)
+		return
+	}
+	name = sanitizeField(name)
+
+	h.ProjectName = name
+	if err := saveSaaSHive(h); err != nil {
+		http.Error(w, `{"error":"failed to save"}`, http.StatusInternalServerError)
+		return
+	}
+
+	// Overlay the new name onto the in-memory registry immediately so the change
+	// is visible before the next heartbeat re-overlays it from the SaaS store.
+	s.mu.Lock()
+	for i := range s.registry.Hives {
+		if s.registry.Hives[i].ID == id {
+			s.registry.Hives[i].ProjectName = name
+			break
+		}
+	}
+	s.mu.Unlock()
+
+	// Re-stamp namespace identity so the display-name annotation tracks the
+	// rename. Best-effort — see stampHostedNamespaceIdentity's doc comment; a
+	// failed cosmetic patch must not fail the rename.
+	stampHostedNamespaceIdentity(s.clusterForHive(h), hostedNamespaceForHive(h), h.ProjectName, h.Org, h.ID, s.logger)
+
+	s.logger.Info("audit: hive renamed", "hive_id", id, "project_name", name, "by", username)
+	s.recordTimeline(id, TimelineRenamed, fmt.Sprintf("hive renamed to %q", name), username)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"ok": true, "project_name": name})
 }
 
 // pushVisibilityToSpoke best-effort notifies a hosted hive's own governor
@@ -10666,6 +10765,48 @@ const dashboardHTML = `<!DOCTYPE html>
       });
     }
 
+    /* nameEditAffordance renders the inline pencil that lets an OWNER (or the hub
+       admin) rename a hive from its top line. It is a display-only convenience —
+       the server's owner-or-admin gate on PUT /name is the real boundary — so a
+       non-owner simply gets no pencil, and even if they forged the request the
+       handler rejects it 403. Empty string for anyone who cannot rename, so those
+       rows are pixel-identical to today. Gated the same way as the row's other
+       owner-only actions (h.role === 'owner' || _isAdmin — see isBulkEligible).
+       stopPropagation keeps the click from triggering the row's own open/SSO. */
+    function canRenameHive(h) {
+      return !!h && (h.role === 'owner' || _isAdmin);
+    }
+    function nameEditAffordance(h) {
+      if (!canRenameHive(h)) return '';
+      return ' <span onclick="event.stopPropagation();dashRenameHive(' + jsArg(h.id) + ')" ' +
+        'title="Rename this hive" role="button" tabindex="0" ' +
+        'style="cursor:pointer;opacity:0.45;font-size:0.75rem;vertical-align:middle;margin-left:2px">' +
+        '&#9998;</span>';
+    }
+
+    /* dashRenameHive prompts for a new name and PUTs it to the rename endpoint.
+       A blank submission clears the custom name (the row falls back to the
+       org/repo label), which the server accepts deliberately. Cancel (null)
+       leaves the hive untouched. On success we reload so every viewer-derived
+       surface (label, sort value) re-renders from the fresh registry. */
+    async function dashRenameHive(id) {
+      var h = (_allDashHives || []).reduce(function(m, x) { return x && x.id === id ? x : m; }, null) || {};
+      var current = (h.projectName || h.project_name || '');
+      var next = await hivePrompt('Rename hive', current, {ok: 'Rename'});
+      if (next === null) return; /* cancelled */
+      try {
+        var resp = await fetch('/api/saas/hives/' + encodeURIComponent(id) + '/name', {
+          method: 'PUT',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({project_name: next})
+        });
+        var data = await resp.json();
+        if (!resp.ok) { hiveToast(data.error || 'Failed to rename hive', 'error'); loadHives(); return; }
+        hiveToast(next ? ('Renamed to ' + next) : 'Name cleared', 'success');
+        loadHives();
+      } catch(e) { hiveToast('Error: ' + e.message, 'error'); loadHives(); }
+    }
+
     /* hiveLabel derives the two-line name-cell label from the hive's PROJECT
        (org + primary repo) rather than by splitting h.name.
 
@@ -10697,12 +10838,27 @@ const dashboardHTML = `<!DOCTYPE html>
       if (!h) return { line1: '', line2: '' };
       var org = h.org || '';
       var repo = h.primaryRepo || '';
-      if (org && repo) return { line1: org, line2: repo };
-      /* Exactly one half of the project is known — show it alone, on the
-         bold line, rather than emitting 'org/' or '/repo'. */
-      if (org || repo) return { line1: org || repo, line2: '' };
-      /* No project at all. Fall back to whatever identity the row carries. */
-      return { line1: h.name || h.id || '', line2: '' };
+      /* Second line is now the PRIMARY REPO rendered as org/repo (not the bare
+         repo), so the row states the full project path. Fall back to org/repos[0]
+         when primaryRepo is unset, and never emit a dangling slash: with only one
+         half known, show that half alone; with neither, leave line2 empty. */
+      var repoLine = '';
+      if (org && repo) { repoLine = org + '/' + repo; }
+      else if (org && (h.repos || []).length) { repoLine = org + '/' + h.repos[0]; }
+      else if (org || repo) { repoLine = org || repo; }
+      /* Top line is the operator-editable hive name (project_name / projectName)
+         when set. Blank keeps EXACTLY today's fallback: the org, else the repo,
+         else the synthesized name, else the id — so an un-renamed hive is
+         pixel-identical to before this feature. */
+      var custom = String(h.projectName || h.project_name || '').trim();
+      if (custom) return { line1: custom, line2: repoLine };
+      var fallback = org || repo || h.name || h.id || '';
+      /* When line1 falls back to the org/repo identity, avoid repeating org on
+         both lines: if the fallback IS the org and we already have a repoLine,
+         line1 keeps the org and line2 shows org/repo — the same two facts the
+         old label showed (org on top, repo below), just with the repo now
+         qualified by its org. */
+      return { line1: fallback, line2: (repoLine === fallback ? '' : repoLine) };
     }
 
     /* hiveNameSortValue is the value the Hive column SORTS on. It must track
@@ -11995,7 +12151,7 @@ const dashboardHTML = `<!DOCTYPE html>
         return '<tr id="' + escAttr(hiveRowDomId(h.id)) + '">' +
           bulkCheckboxCell(h, section || 'all') +
           '<td class="hive-menu-cell" style="position:relative;width:30px;text-align:center;overflow:visible">' + (h.migrationStatus === 'migrating' ? '<span style="font-size:1.1rem;color:var(--border);user-select:none;cursor:not-allowed" title="Disabled during migration">⋮</span>' : '<span style="cursor:pointer;font-size:1.1rem;color:var(--muted);user-select:none">⋮</span>' + pendingBadge + '<div class="hive-menu-dropdown" style="display:none;position:absolute;left:0;bottom:auto;background:#1c2128;border:1px solid #30363d;border-radius:8px;min-width:160px;padding:4px 0;z-index:1000;box-shadow:0 8px 24px rgba(0,0,0,0.5)">' + menuItems.join('') + '</div>') + '</td>' +
-          '<td style="text-align:left;line-height:1.4">' + (function() { var isHostedRow = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'))); var dh = isHostedRow && h.id ? ('/api/saas/hives/' + encodeURIComponent(h.id) + '/open') : (rb ? esc(rb) : ''); /* Label derived from the PROJECT (org + primary repo), not by splitting h.name — see hiveLabel. */ var label = hiveLabel(h); var orgName = label.line1; var repoName = label.line2; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var rpHref = ghRepoURL(h.github_host, h.org, h.primaryRepo); var ghIcon = (rp && rpHref) ? '<a href="' + rpHref + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : (rp ? '<span style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></span>' : ''); /* vanityDisplay is the friendly host shown in the status bar on hover. rb is resolvedBase(h), which the hub has already overlaid with the claimed vanity_url; it is only a DISPLAY url here, never the click target — see ssoDisplayLink. Empty for a row with no vanity host, which falls back to today's /open href. Only meaningful on hosted rows: a non-hosted row's dh IS rb already. */ var vanityDisplay = isHostedRow && rb ? rb : ''; /* vanityDisplay is the friendly host shown in the status bar on hover. rb is resolvedBase(h), which the hub has already overlaid with the claimed vanity_url; it is only a DISPLAY url here, never the click target — see ssoDisplayLink. Empty for a row with no vanity host, which falls back to today's /open href. Only meaningful on hosted rows: a non-hosted row's dh IS rb already. */ var vanityDisplay = isHostedRow && rb ? rb : ''; var link = function(text, bold) { if (dh) { return ssoDisplayLink(dh, vanityDisplay, text, bold ? 'hive-name-link' : 'hive-sub-link'); } var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName, true); var fcPill = h.online ? failingCheckSummary(h) : ''; /* Advisory-staleness pill sits right beside the failing-check pill: both are "something is quietly wrong with this working hive" signals, and advisoryStaleSummary already self-suppresses (empty string) unless the hub flagged the digest stale, so unaffected rows are pixel-identical. */ var advPill = h.online ? advisoryStaleSummary(h) : ''; /* Dead-link pill is deliberately NOT gated on h.online: the entire point is a hive that IS online and heartbeating while its public URL is broken, so gating it the way the other pills are gated would hide exactly the case it exists to surface. */ var dlPill = deadLinkSummary(h); /* Inference-auth pill: like the dead-link pill it is NOT gated on h.online, because the hive being online while every inference call 401s is exactly the case it surfaces. */ var iaPill = inferenceAuthSummary(h); /* Inline access faces sit on the name cell's second line, immediately after this row's own role badge: the badge already answers "what am I on this hive", so the co-members read as the natural continuation of the same thought, in the one cell that is left-aligned and has room to grow. It also keeps them out of the 16 dense metric columns, none of which is about people. Empty string when the viewer is the only member, so those rows are pixel-identical to today. */ var accessFaces = hiveAccessAvatars(h); /* Keyed off repoName, not orgName: line 1 now always carries SOME identity, so the presence of a second line is decided purely by whether there is a repo to put on it. Without a repo the row still shows the GitHub icon, role badge, faces and failing-check pill on the compact variant. */ var line2 = repoName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + dlPill + iaPill + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + dlPill + iaPill + '</div>'; var line3 = pendingPill ? '<div style="margin-top:4px;padding-left:18px">' + pendingPill + '</div>' : ''; return line1 + line2 + line3; })() + '</td>' +
+          '<td style="text-align:left;line-height:1.4">' + (function() { var isHostedRow = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'))); var dh = isHostedRow && h.id ? ('/api/saas/hives/' + encodeURIComponent(h.id) + '/open') : (rb ? esc(rb) : ''); /* Label derived from the PROJECT (org + primary repo), not by splitting h.name — see hiveLabel. */ var label = hiveLabel(h); var orgName = label.line1; var repoName = label.line2; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var rpHref = ghRepoURL(h.github_host, h.org, h.primaryRepo); var ghIcon = (rp && rpHref) ? '<a href="' + rpHref + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : (rp ? '<span style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></span>' : ''); /* vanityDisplay is the friendly host shown in the status bar on hover. rb is resolvedBase(h), which the hub has already overlaid with the claimed vanity_url; it is only a DISPLAY url here, never the click target — see ssoDisplayLink. Empty for a row with no vanity host, which falls back to today's /open href. Only meaningful on hosted rows: a non-hosted row's dh IS rb already. */ var vanityDisplay = isHostedRow && rb ? rb : ''; /* vanityDisplay is the friendly host shown in the status bar on hover. rb is resolvedBase(h), which the hub has already overlaid with the claimed vanity_url; it is only a DISPLAY url here, never the click target — see ssoDisplayLink. Empty for a row with no vanity host, which falls back to today's /open href. Only meaningful on hosted rows: a non-hosted row's dh IS rb already. */ var vanityDisplay = isHostedRow && rb ? rb : ''; var link = function(text, bold) { if (dh) { return ssoDisplayLink(dh, vanityDisplay, text, bold ? 'hive-name-link' : 'hive-sub-link'); } var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName, true) + nameEditAffordance(h); var fcPill = h.online ? failingCheckSummary(h) : ''; /* Advisory-staleness pill sits right beside the failing-check pill: both are "something is quietly wrong with this working hive" signals, and advisoryStaleSummary already self-suppresses (empty string) unless the hub flagged the digest stale, so unaffected rows are pixel-identical. */ var advPill = h.online ? advisoryStaleSummary(h) : ''; /* Dead-link pill is deliberately NOT gated on h.online: the entire point is a hive that IS online and heartbeating while its public URL is broken, so gating it the way the other pills are gated would hide exactly the case it exists to surface. */ var dlPill = deadLinkSummary(h); /* Inference-auth pill: like the dead-link pill it is NOT gated on h.online, because the hive being online while every inference call 401s is exactly the case it surfaces. */ var iaPill = inferenceAuthSummary(h); /* Inline access faces sit on the name cell's second line, immediately after this row's own role badge: the badge already answers "what am I on this hive", so the co-members read as the natural continuation of the same thought, in the one cell that is left-aligned and has room to grow. It also keeps them out of the 16 dense metric columns, none of which is about people. Empty string when the viewer is the only member, so those rows are pixel-identical to today. */ var accessFaces = hiveAccessAvatars(h); /* Keyed off repoName, not orgName: line 1 now always carries SOME identity, so the presence of a second line is decided purely by whether there is a repo to put on it. Without a repo the row still shows the GitHub icon, role badge, faces and failing-check pill on the compact variant. */ var line2 = repoName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + dlPill + iaPill + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + advPill + dlPill + iaPill + '</div>'; var line3 = pendingPill ? '<div style="margin-top:4px;padding-left:18px">' + pendingPill + '</div>' : ''; return line1 + line2 + line3; })() + '</td>' +
           '<td>' + locationCell + '</td>' +
           '<td style="white-space:nowrap">' + uptimeCell(h) + '</td>' +
           /* No white-space:nowrap on the cell itself: the stacked lines each

--- a/v2/pkg/hub/saas_rename_hive_test.go
+++ b/v2/pkg/hub/saas_rename_hive_test.go
@@ -1,0 +1,105 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHandleRenameHive covers the editable-hive-name endpoint
+// (PUT /api/saas/hives/{id}/name): owner-or-admin gate, persistence of the
+// renamed ProjectName, a blank value clearing the custom name, and the
+// validation/CORS edges — mirroring TestHandleToggleVisibility's shape.
+func TestHandleRenameHive(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, "alice")
+	mkUser(t, hubAdminUsername)
+
+	// OPTIONS preflight -> 204, no auth needed.
+	rec := httptest.NewRecorder()
+	req := reqWithUser(http.MethodOptions, "/name", "", "alice")
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
+	s.handleRenameHive(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("OPTIONS status = %d, want 204", rec.Code)
+	}
+
+	// Hive not found -> 404.
+	rec = httptest.NewRecorder()
+	req = setPathValue(reqWithUser(http.MethodPut, "/name", `{"project_name":"X"}`, "alice"), "id", "missing")
+	s.handleRenameHive(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("missing hive status = %d, want 404", rec.Code)
+	}
+
+	// Non-owner, non-admin -> 403 (the security boundary), and the hive is
+	// NOT renamed on disk.
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "bob", ProjectName: "original"})
+	rec = httptest.NewRecorder()
+	req = setPathValue(reqWithUser(http.MethodPut, "/name", `{"project_name":"hijacked"}`, "alice"), "id", "h1")
+	s.handleRenameHive(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("non-owner status = %d, want 403", rec.Code)
+	}
+	if got := loadSaaSHive("h1"); got == nil || got.ProjectName != "original" {
+		t.Errorf("non-owner request must not persist a rename; got %+v", got)
+	}
+
+	// Owner renames -> 200 and the new name persists.
+	saveSaaSHive(&SaaSHive{ID: "h2", Owner: "alice", ProjectName: "old-name"})
+	rec = httptest.NewRecorder()
+	req = setPathValue(reqWithUser(http.MethodPut, "/name", `{"project_name":"  Fancy Name  "}`, "alice"), "id", "h2")
+	s.handleRenameHive(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("owner rename status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if got := loadSaaSHive("h2"); got == nil || got.ProjectName != "Fancy Name" {
+		t.Errorf("rename not persisted (trimmed); got %+v", got)
+	}
+
+	// Admin can rename any hive.
+	saveSaaSHive(&SaaSHive{ID: "h3", Owner: "bob", ProjectName: "x"})
+	rec = httptest.NewRecorder()
+	req = setPathValue(reqWithUser(http.MethodPut, "/name", `{"project_name":"admin-set"}`, hubAdminUsername), "id", "h3")
+	s.handleRenameHive(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("admin rename status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if got := loadSaaSHive("h3"); got == nil || got.ProjectName != "admin-set" {
+		t.Errorf("admin rename not persisted; got %+v", got)
+	}
+
+	// Blank clears the custom name (falls back to the org/repo label).
+	saveSaaSHive(&SaaSHive{ID: "h4", Owner: "alice", ProjectName: "to-be-cleared"})
+	rec = httptest.NewRecorder()
+	req = setPathValue(reqWithUser(http.MethodPut, "/name", `{"project_name":"   "}`, "alice"), "id", "h4")
+	s.handleRenameHive(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("blank rename status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if got := loadSaaSHive("h4"); got == nil || got.ProjectName != "" {
+		t.Errorf("blank must clear ProjectName; got %+v", got)
+	}
+
+	// Too long -> 400.
+	saveSaaSHive(&SaaSHive{ID: "h5", Owner: "alice"})
+	long := `{"project_name":"` + strings.Repeat("a", maxHiveDisplayNameLen+1) + `"}`
+	rec = httptest.NewRecorder()
+	req = setPathValue(reqWithUser(http.MethodPut, "/name", long, "alice"), "id", "h5")
+	s.handleRenameHive(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("too-long status = %d, want 400", rec.Code)
+	}
+
+	// Bad JSON body from owner -> 400.
+	saveSaaSHive(&SaaSHive{ID: "h6", Owner: "alice"})
+	rec = httptest.NewRecorder()
+	req = setPathValue(reqWithUser(http.MethodPut, "/name", `{bad`, "alice"), "id", "h6")
+	s.handleRenameHive(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("bad body status = %d, want 400", rec.Code)
+	}
+}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -93,6 +93,13 @@ type RegistryEntry struct {
 	Name  string   `json:"name"`
 	Org   string   `json:"org"`
 	Repos []string `json:"repos"`
+	// ProjectName is the hive's operator-editable display name, overlaid onto the
+	// registry entry from the authoritative SaaSHive record (sh.ProjectName) on
+	// the heartbeat path — NOT reported by the spoke. It is what the My Hives row
+	// renders as the editable top line; when empty the client falls back to the
+	// org/repo-derived label (see hiveLabel in the dashboard JS), exactly as
+	// before this field existed. handleRenameHive is the only writer.
+	ProjectName string `json:"projectName,omitempty"`
 	// AIAuthor is the GitHub account this hive's agents open PRs as, as
 	// reported by the spoke. The hub needs it to echo project config back
 	// without blanking it, and it is the author the fleet-stats counts are
@@ -1208,6 +1215,11 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	if sh := loadSaaSHive(payload.HiveID); sh != nil {
 		clusterID = sh.ClusterID
 		entry.ProvStatus = sh.Status
+		// The SaaS store is authoritative for the operator-editable display name
+		// (handleRenameHive persists it here), so overlay it onto the registry
+		// entry the dashboard renders. The spoke never reports this, so a blank
+		// ProjectName simply leaves the client on its org/repo fallback label.
+		entry.ProjectName = sh.ProjectName
 	}
 	if clusterID == "" && payload.ClusterID != "" {
 		clusterID = sanitizeHeartbeatField(payload.ClusterID)

--- a/v2/pkg/hub/timeline.go
+++ b/v2/pkg/hub/timeline.go
@@ -75,6 +75,7 @@ const (
 	TimelineAccess           = "access"
 	TimelineOwnership        = "ownership"
 	TimelineAdmin            = "admin"
+	TimelineRenamed          = "renamed"
 )
 
 // timelineDir is the directory holding one JSON file per hive. It follows the


### PR DESCRIPTION
## What

On the hub **My Hives / Assigned Hives** rows, make the top-line **name editable** and change the **second line to the primary repo as `org/repo`**.

### (a) Inline owner-only rename → persisted `ProjectName`

- The top line gains an inline **pencil affordance** shown only to the hive's **owner** (or the hub admin). Clicking it opens a rename prompt.
- Submitting PUTs to a **new endpoint** which rewrites the hive's real `ProjectName` — **no separate `display_name` field**. This renames the load-bearing identity, per the operator's explicit acceptance of the blast radius.
- **New endpoint: `PUT /api/saas/hives/{id}/name`** — `requireAuth` on the route plus an inner **owner-or-admin gate** in the handler, mirroring `handleToggleVisibility` exactly. **The server gate is the security boundary**: a non-owner gets `403` regardless of whether the UI shows the pencil.
- Persists to `meta.json` via `saveSaaSHive` (survives restart), overlays the new name onto the in-memory registry immediately, and records a timeline event.
- **Blank value clears** the custom name and the row falls back to today's `org`/`org/repo` label.
- `RegistryEntry` gains a `ProjectName` field, overlaid from the SaaS store on the heartbeat path (the spoke never reports it). The dashboard `hiveLabel` prefers it, else uses today's fallback — so an un-renamed hive is pixel-identical to before.

#### Derived-surface behavior on rename

`ProjectName` also feeds two derived surfaces:

- **Namespace identity — RE-STAMPED on rename.** The handler calls `stampHostedNamespaceIdentity` (idempotent, best-effort) so the `hive.kubestellar.io/display-name` annotation tracks the new name.
- **Vanity host — NOT recomputed (updates lazily / stays as-is).** The vanity host is **set-once at claim time** (the assign path only mints one when `VanityURL` is empty) and doubles as the "placeholder is claimed" marker. Minting a fresh random host on every rename would churn URLs and orphan routes, so it deliberately keeps its original label — a **documented** staleness, not a silent one.

### (b) Second line now `org/repo` from `PrimaryRepo`

- Second line renders `<org>/<primary_repo>` (not the bare repo). Falls back to `org/repos[0]` when `PrimaryRepo` is empty, and **never renders a dangling slash** — with only one half known it shows that half alone; with neither it hides the line.

## Accepted blast radius

Renaming `ProjectName` is a rename of the hive's real identity: it affects the namespace-identity display-name annotation (re-stamped here) and, for hives claimed *after* the rename, any name-derived vanity host. Existing vanity hosts keep their original label. This was explicitly accepted.

## Tests

`TestHandleRenameHive`: owner renames (persists, trimmed), **non-owner rejected `403` with no persistence**, admin can rename any hive, blank clears the name, too-long and bad-JSON bodies `400`, OPTIONS preflight `204`, missing hive `404`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)