### PR TITLE
🐛 Contribute queue starved: candidate set ignores contribute label config

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -898,6 +898,11 @@ func main() {
 	if ghClient != nil && len(cfg.Governor.Labels.Exempt) > 0 {
 		ghClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 	}
+	// Sync the contribute label config so the actionable scan can rescue
+	// contribute-queue work the governor would otherwise exempt/hold (fixes the
+	// contribute queue showing 0 with matching issues). No-op unless labels_mode
+	// is "allow" with a non-empty list. Safe on a nil client.
+	ghClient.SetContributeLabels(cfg.Hub.ContributeDenyLabels, cfg.Hub.ContributeLabelsMode)
 	// Load user token for advisory posting (comments on issues as the logged-in user)
 	var userGHClient atomic.Pointer[github.Client]
 	if tokenData, err := os.ReadFile("/data/gh-user-token"); err == nil {
@@ -1349,6 +1354,7 @@ func main() {
 			if len(cfg.Governor.Labels.Exempt) > 0 {
 				ghClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 			}
+			ghClient.SetContributeLabels(cfg.Hub.ContributeDenyLabels, cfg.Hub.ContributeLabelsMode)
 			if uc := userGHClient.Load(); uc != nil {
 				uc.SetRepos(cfg.Project.Repos)
 			}
@@ -1930,6 +1936,7 @@ func main() {
 			if len(cfg.Governor.Labels.Exempt) > 0 {
 				newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 			}
+			newClient.SetContributeLabels(cfg.Hub.ContributeDenyLabels, cfg.Hub.ContributeLabelsMode)
 
 			ghClient = newClient
 			appAuth = newAppAuth
@@ -2259,6 +2266,11 @@ func main() {
 
 		// Re-sync subsystems that cache config values
 		ghClient.SetRepos(cfg.Project.Repos)
+		ghClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
+		// Re-sync contribute label config on reload so an operator toggling the
+		// contribute allow-list / labels_mode immediately affects which exempt/held
+		// issues the scan rescues for the contribute queue.
+		ghClient.SetContributeLabels(cfg.Hub.ContributeDenyLabels, cfg.Hub.ContributeLabelsMode)
 		if uc := userGHClient.Load(); uc != nil {
 			uc.SetRepos(cfg.Project.Repos)
 		}
@@ -2289,6 +2301,7 @@ func main() {
 					if len(cfg.Governor.Labels.Exempt) > 0 {
 						newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 					}
+					newClient.SetContributeLabels(cfg.Hub.ContributeDenyLabels, cfg.Hub.ContributeLabelsMode)
 					ghClient = newClient
 					appAuth = newAppAuth
 					agentMgr.SetAppAuth(newAppAuth)
@@ -3318,6 +3331,7 @@ func main() {
 				if len(cfg.Governor.Labels.Exempt) > 0 {
 					newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 				}
+				newClient.SetContributeLabels(cfg.Hub.ContributeDenyLabels, cfg.Hub.ContributeLabelsMode)
 				ghClient = newClient
 				appAuth = newAppAuth
 				agentMgr.SetAppAuth(newAppAuth)

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4058,6 +4058,14 @@ func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 	cfg.Hub.ContributeTitlesMode = config.NormalizeFilterMode(cfg.Hub.ContributeTitlesMode)
 	cfg.Hub.ContributeAuthorsMode = config.NormalizeFilterMode(cfg.Hub.ContributeAuthorsMode)
 	cfg.Hub.ContributeLabelsMode = config.NormalizeFilterMode(cfg.Hub.ContributeLabelsMode)
+	// Push the (possibly changed) contribute label config into the actionable
+	// scan client so it can rescue contribute-labeled issues the governor would
+	// exempt/hold. Without this the change would only take effect on the next full
+	// config reload / restart, and the contribute queue would stay starved until
+	// then. No-op unless labels_mode is "allow" with a non-empty list.
+	if s.deps != nil && s.deps.GHClient != nil {
+		s.deps.GHClient.SetContributeLabels(cfg.Hub.ContributeDenyLabels, cfg.Hub.ContributeLabelsMode)
+	}
 	s.auditFromRequest(r, "config_governor_hub", auditDetail("section", "hub"), "")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})

--- a/v2/pkg/dashboard/contribute_queue_rescue_test.go
+++ b/v2/pkg/dashboard/contribute_queue_rescue_test.go
@@ -1,0 +1,243 @@
+package dashboard
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// TestReadyQueueSurfacesContributeRescuedIssues is the END-TO-END, DATA-DRIVEN
+// reproduction + fix proof for the "contribute queue shows 0 with dozens of
+// admissible issues" bug on the projectbluefin common hive.
+//
+// Confirmed live scenario this mirrors:
+//   - Every repo toggled ON for contribute (repo scope is not the blocker).
+//   - labels_mode="allow" with "3-clanker-queue" in the list (contribute filter
+//     PASSES these issues).
+//   - Title deny-list includes "epic:*" and "*hive advisory report*".
+//   - skip_assigned_to_others=true.
+//   - ~50 open "3-clanker-queue" issues across enabled repos, yet queue == [].
+//
+// Root cause: the contribute candidate set is the governor's actionable scan,
+// which drops issues carrying a GOVERNOR exempt-label. The operator exempted the
+// contribute label from the governor, so every "3-clanker-queue" issue was
+// dropped upstream and the contribute filters (which only narrow the set) could
+// never surface them. The fix retains such issues in
+// ActionableResult.ContributeExtraIssues; buildRepos merges them into the
+// per-repo ActionableIssues the contribute queue scans.
+//
+// This test builds the candidate set exactly as the FIXED pipeline does
+// (buildRepos merges ContributeExtraIssues), runs it through the REAL ReadyQueue
+// filter chain, and asserts the admissible math end-to-end:
+//
+//	50 rescued issues − 2 title-denied − 4 assigned-to-others = 44 admissible.
+func TestReadyQueueSurfacesContributeRescuedIssues(t *testing.T) {
+	setupContributeEnv(t)
+
+	// Ground-truth per-repo admissible distribution (sums to 44).
+	admissiblePerRepo := map[string]int{
+		"common":          9,
+		"bluefin-lts":     8,
+		"fsdk-containers": 7,
+		"lab":             6,
+		"bonedigger":      4,
+		"finpilot":        4,
+		"dakota":          3,
+		"bluefin":         2,
+		"actions":         1,
+	}
+	repoOrder := []string{
+		"common", "bluefin-lts", "fsdk-containers", "lab",
+		"bonedigger", "finpilot", "dakota", "bluefin", "actions",
+	}
+
+	const org = "projectbluefin"
+	const contributeLabel = "3-clanker-queue"
+
+	// Build the governor scan RESULT as the fixed scan would emit it: every
+	// "3-clanker-queue" issue is governor-exempt, so it arrives via
+	// ContributeExtraIssues (NOT Issues). None of them are in the plain actionable
+	// set — proving the queue is fed by the rescue path, not the governor set.
+	var extra []github.Issue
+	num := 1000
+	created := time.Now().Add(-2 * time.Hour)
+
+	// 44 clean, unassigned, non-title-denied admissible issues.
+	for _, repo := range repoOrder {
+		for i := 0; i < admissiblePerRepo[repo]; i++ {
+			num++
+			extra = append(extra, github.Issue{
+				Repo:      repo,
+				Number:    num,
+				Title:     "clanker work item",
+				Author:    "human-contributor",
+				Labels:    []string{contributeLabel},
+				Assignees: nil,
+				CreatedAt: created,
+				URL:       "https://github.com/" + org + "/" + repo + "/issues/1",
+			})
+		}
+	}
+	if len(extra) != 44 {
+		t.Fatalf("fixture setup error: expected 44 admissible, built %d", len(extra))
+	}
+
+	// +4 issues assigned to OTHERS (must be excluded by skip-assigned).
+	for i := 0; i < 4; i++ {
+		num++
+		extra = append(extra, github.Issue{
+			Repo:      "common",
+			Number:    num,
+			Title:     "assigned clanker work",
+			Author:    "human-contributor",
+			Labels:    []string{contributeLabel},
+			Assignees: []string{"someone-else"},
+			CreatedAt: created,
+		})
+	}
+
+	// +2 title-denied issues (an "epic:" and a "hive advisory report").
+	num++
+	extra = append(extra, github.Issue{
+		Repo: "common", Number: num, Title: "epic: umbrella tracking",
+		Author: "human-contributor", Labels: []string{contributeLabel}, CreatedAt: created,
+	})
+	num++
+	extra = append(extra, github.Issue{
+		Repo: "bluefin", Number: num, Title: "Weekly hive advisory report",
+		Author: "human-contributor", Labels: []string{contributeLabel}, CreatedAt: created,
+	})
+
+	if len(extra) != 50 {
+		t.Fatalf("fixture setup error: expected 50 total rescued, built %d", len(extra))
+	}
+
+	actionable := &github.ActionableResult{
+		// Governor actionable set is EMPTY of clanker issues — the whole point.
+		Issues:                github.IssueResult{Count: 0, Items: nil},
+		ContributeExtraIssues: extra,
+	}
+
+	// Config with every repo enabled (DisabledRepos empty), the contribute allow
+	// label filter, the title deny-list, and skip-assigned ON — matching live.
+	cfg := &config.Config{
+		Project: config.ProjectConfig{Org: org, Repos: repoOrder},
+		Hub: config.HubConfig{
+			ContributeLabelsMode:           config.FilterModeAllow,
+			ContributeDenyLabels:           []string{"clanker-queue", contributeLabel},
+			ContributeTitlesMode:           config.FilterModeDeny,
+			ContributeDenyTitles:           []string{"epic:*", "epic(*", "*hive advisory report*"},
+			ContributeAuthorsMode:          config.FilterModeDeny,
+			ContributeDenyAuthors:          []string{"*[bot]"},
+			ContributeSkipAssignedToOthers: true,
+			DisabledRepos:                  nil,
+		},
+	}
+
+	// Build the per-repo status EXACTLY as production does: buildRepos merges
+	// ContributeExtraIssues into ActionableIssues.
+	repos := buildRepos(cfg, actionable)
+
+	// Sanity: the merge actually placed the rescued issues into ActionableIssues.
+	totalActionable := 0
+	for _, r := range repos {
+		totalActionable += len(r.ActionableIssues)
+	}
+	if totalActionable != 50 {
+		t.Fatalf("buildRepos did not merge rescued issues: ActionableIssues total = %d, want 50", totalActionable)
+	}
+
+	s := NewServer(0, slog.Default())
+	deps := testDeps(t)
+	deps.Config = cfg
+	s.RegisterAPI(deps)
+
+	s.statusMu.Lock()
+	s.status = &StatusPayload{Repos: repos}
+	s.statusMu.Unlock()
+
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+
+	// The core assertion: 50 − 2 title-denied − 4 assigned-to-others = 44.
+	const wantAdmissible = 44
+	if len(q) != wantAdmissible {
+		t.Fatalf("ReadyQueue admissible count = %d, want %d (50 rescued − 2 title − 4 assigned)", len(q), wantAdmissible)
+	}
+
+	// The RIGHT issues survived: none title-denied, none assigned-to-others, all
+	// carry the contribute label.
+	for _, it := range q {
+		if it.Title == "epic: umbrella tracking" || it.Title == "Weekly hive advisory report" {
+			t.Errorf("title-denied issue leaked into queue: %+v", it)
+		}
+		if it.Title == "assigned clanker work" {
+			t.Errorf("assigned-to-others issue leaked into queue: %+v", it)
+		}
+		hasLabel := false
+		for _, l := range it.Labels {
+			if l == contributeLabel {
+				hasLabel = true
+			}
+		}
+		if !hasLabel {
+			t.Errorf("queued issue missing contribute label: %+v", it)
+		}
+	}
+
+	// Per-repo admissible distribution is preserved (the clean 44 only).
+	perRepo := map[string]int{}
+	for _, it := range q {
+		// it.Repo is the full "org/name"; strip the org prefix for comparison.
+		name := it.Repo
+		if idx := len(org) + 1; len(it.Repo) > idx && it.Repo[:len(org)] == org {
+			name = it.Repo[idx:]
+		}
+		perRepo[name]++
+	}
+	for repo, want := range admissiblePerRepo {
+		if perRepo[repo] != want {
+			t.Errorf("repo %q admissible = %d, want %d", repo, perRepo[repo], want)
+		}
+	}
+}
+
+// TestReadyQueueStarvedWithoutRescue is the NEGATIVE control: it proves the bug —
+// without the rescue (ContributeExtraIssues empty, clanker issues absent from the
+// governor actionable set), the very same config yields an EMPTY queue. This is
+// exactly the 0-with-matching-issues symptom the fix eliminates.
+func TestReadyQueueStarvedWithoutRescue(t *testing.T) {
+	setupContributeEnv(t)
+
+	const org = "projectbluefin"
+	cfg := &config.Config{
+		Project: config.ProjectConfig{Org: org, Repos: []string{"common"}},
+		Hub: config.HubConfig{
+			ContributeLabelsMode: config.FilterModeAllow,
+			ContributeDenyLabels: []string{"3-clanker-queue"},
+		},
+	}
+
+	// Governor scan dropped every clanker issue and there is no rescue: the
+	// candidate set is empty even though the issues exist and the filter passes.
+	actionable := &github.ActionableResult{
+		Issues:                github.IssueResult{Count: 0},
+		ContributeExtraIssues: nil,
+	}
+	repos := buildRepos(cfg, actionable)
+
+	s := NewServer(0, slog.Default())
+	deps := testDeps(t)
+	deps.Config = cfg
+	s.RegisterAPI(deps)
+
+	s.statusMu.Lock()
+	s.status = &StatusPayload{Repos: repos}
+	s.statusMu.Unlock()
+
+	if q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit); len(q) != 0 {
+		t.Fatalf("negative control: expected starved (empty) queue without rescue, got %d", len(q))
+	}
+}

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -843,9 +843,30 @@ func buildRepos(cfg *config.Config, actionable *github.ActionableResult) []Front
 
 	issuesByRepo := make(map[string][]any)
 	prsByRepo := make(map[string][]any)
+	// seenByRepo dedupes issue numbers per repo so a contribute-rescued issue
+	// (ContributeExtraIssues) is not double-listed if it also somehow appears in
+	// the governor actionable set. Keyed by "repo\x00number".
+	seenByRepo := make(map[string]bool)
 
 	if actionable != nil {
 		for _, issue := range actionable.Issues.Items {
+			issuesByRepo[issue.Repo] = append(issuesByRepo[issue.Repo], issue)
+			seenByRepo[issue.Repo+"\x00"+strconv.Itoa(issue.Number)] = true
+		}
+		// Merge contribute-rescued issues: open issues the governor scan exempted
+		// or held but which carry a contribute allow-label. They are governed by
+		// the contribute filters downstream (ReadyQueue / selectTask), not by the
+		// governor's exempt/hold predicate, so the contribute queue must see them.
+		// This is the fix for the contribute queue showing 0 items while dozens of
+		// matching (e.g. "3-clanker-queue") issues were open — those issues were
+		// dropped by the governor scan and never reached the candidate set. Deduped
+		// so a rescued issue already in the actionable set is not listed twice.
+		for _, issue := range actionable.ContributeExtraIssues {
+			key := issue.Repo + "\x00" + strconv.Itoa(issue.Number)
+			if seenByRepo[key] {
+				continue
+			}
+			seenByRepo[key] = true
 			issuesByRepo[issue.Repo] = append(issuesByRepo[issue.Repo], issue)
 		}
 		for _, pr := range actionable.PRs.Items {

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -30,7 +30,17 @@ type Client struct {
 	reposMu      sync.RWMutex
 	repos        []string
 	exemptLabels []string
-	logger       *slog.Logger
+	// contributeLabels / contributeLabelsMode mirror the CONTRIBUTE label config
+	// (Hub.ContributeDenyLabels + Hub.ContributeLabelsMode). They exist so the
+	// actionable scan can RESCUE issues the governor would otherwise exempt/hold
+	// but which are explicitly contribute-queue work (a positive label match in
+	// "allow" mode). Without this, an issue carrying a contribute allow-label
+	// that also carries a governor exempt-label never reaches the contribute
+	// queue at all — see contributeRescue below. Guarded by reposMu (set on the
+	// same config-sync paths as repos/exemptLabels).
+	contributeLabels     []string
+	contributeLabelsMode string
+	logger               *slog.Logger
 	appAuth      *AppAuth // nil for token-authenticated clients
 	// prAuthz gates PR-open requests from the request-file watcher against the
 	// per-agent ACMM write-policy + forge-resistance. nil fails closed. Set by
@@ -146,6 +156,14 @@ type ActionableResult struct {
 	Hold        HoldResult            `json:"hold"`
 	Clusters    []IssueCluster        `json:"clusters,omitempty"`
 	TotalByRepo map[string]RepoCounts `json:"total_by_repo,omitempty"`
+	// ContributeExtraIssues are open issues the governor scan EXEMPTED or HELD
+	// but that carry a contribute allow-label (positive match in "allow" mode).
+	// They are excluded from Issues (so governor counts are unaffected) and are
+	// merged into per-repo ActionableIssues by the dashboard so the contribute
+	// ready-queue / selectTask can surface them. Without this, contribute-labeled
+	// issues that are also governor-exempt made the contribute queue show 0 even
+	// with dozens of admissible issues. See Client.contributeRescue.
+	ContributeExtraIssues []Issue `json:"contribute_extra_issues,omitempty"`
 }
 
 type RepoCounts struct {
@@ -268,6 +286,7 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 	}
 
 	var allIssues []Issue
+	var contributeExtra []Issue
 	var allPRs []PullRequest
 	var holdItems []HoldItem
 	totalByRepo := make(map[string]RepoCounts)
@@ -276,7 +295,7 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 	failedRepos := 0
 	var lastFetchErr error
 	for _, repo := range repos {
-		issues, held, issueTotal, err := c.fetchIssues(ctx, repo, now)
+		issues, held, extra, issueTotal, err := c.fetchIssues(ctx, repo, now)
 		if err != nil {
 			c.logger.Warn("failed to fetch issues", "repo", repo, "error", err)
 			failedRepos++
@@ -284,6 +303,7 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 			continue
 		}
 		allIssues = append(allIssues, issues...)
+		contributeExtra = append(contributeExtra, extra...)
 		holdItems = append(holdItems, held...)
 
 		prs, heldPRs, prTotal, err := c.fetchPRs(ctx, repo)
@@ -344,6 +364,11 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 		Items:  holdItems,
 	}
 	result.TotalByRepo = totalByRepo
+	// Issues rescued for the contribute queue only (governor-exempt or held but
+	// carrying a contribute allow-label). Kept OUT of result.Issues so governor
+	// counts/SLA are unchanged; buildRepos merges these into per-repo
+	// ActionableIssues so the contribute queue can see them. See contributeRescue.
+	result.ContributeExtraIssues = contributeExtra
 
 	return result, nil
 }
@@ -357,7 +382,7 @@ func (c *Client) splitRepo(repo string) (owner, repoName string) {
 	return c.org, repo
 }
 
-func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (actionable []Issue, held []HoldItem, totalIssues int, err error) {
+func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (actionable []Issue, held []HoldItem, contributeExtra []Issue, totalIssues int, err error) {
 	owner, repoName := c.splitRepo(repo)
 	opts := &gh.IssueListByRepoOptions{
 		State:       "open",
@@ -368,13 +393,29 @@ func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (a
 	for {
 		issues, resp, err := c.client.Issues.ListByRepo(ctx, owner, repoName, opts)
 		if err != nil {
-			return nil, nil, 0, fmt.Errorf("listing issues for %s/%s: %w", owner, repoName, err)
+			return nil, nil, nil, 0, fmt.Errorf("listing issues for %s/%s: %w", owner, repoName, err)
 		}
 		allIssues = append(allIssues, issues...)
 		if resp.NextPage == 0 {
 			break
 		}
 		opts.ListOptions.Page = resp.NextPage
+	}
+
+	// issueOf builds the transport Issue for one raw GitHub issue.
+	issueOf := func(issue *gh.Issue, labels []string) Issue {
+		return Issue{
+			Repo:       repo,
+			Number:     issue.GetNumber(),
+			Title:      issue.GetTitle(),
+			Author:     safeGetLogin(issue.GetUser()),
+			Labels:     labels,
+			Assignees:  extractAssignees(issue.Assignees),
+			CreatedAt:  issue.GetCreatedAt().Time,
+			AgeMinutes: int(now.Sub(issue.GetCreatedAt().Time).Minutes()),
+			URL:        issue.GetHTMLURL(),
+			IsTracker:  isTracker(issue.GetTitle(), labels),
+		}
 	}
 
 	for _, issue := range allIssues {
@@ -392,30 +433,34 @@ func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (a
 				Title:  issue.GetTitle(),
 				Type:   "issue",
 			})
+			// A held issue that is ALSO explicit contribute-queue work is still
+			// surfaced to the contribute queue (contribute filters, not governor
+			// hold semantics, decide contributor eligibility). Governor counts
+			// are unaffected — held issues never enter `actionable`.
+			if c.contributeRescue(labels) {
+				contributeExtra = append(contributeExtra, issueOf(issue, labels))
+			}
 			continue
 		}
 
 		if c.isExempt(labels) {
+			// Governor-exempt issues are dropped from the actionable set (and
+			// thus its count) exactly as before — but if the issue carries a
+			// contribute allow-label it is contribute-queue work and MUST reach
+			// the contribute queue, which piggybacks on this scan. Retain it in
+			// the separate contributeExtra set so buildRepos can merge it into
+			// ActionableIssues without inflating governor counts. This is the
+			// fix for the "0 items with dozens of matching issues" bug.
+			if c.contributeRescue(labels) {
+				contributeExtra = append(contributeExtra, issueOf(issue, labels))
+			}
 			continue
 		}
 
-		ageMinutes := int(now.Sub(issue.GetCreatedAt().Time).Minutes())
-
-		actionable = append(actionable, Issue{
-			Repo:       repo,
-			Number:     issue.GetNumber(),
-			Title:      issue.GetTitle(),
-			Author:     safeGetLogin(issue.GetUser()),
-			Labels:     labels,
-			Assignees:  extractAssignees(issue.Assignees),
-			CreatedAt:  issue.GetCreatedAt().Time,
-			AgeMinutes: ageMinutes,
-			URL:        issue.GetHTMLURL(),
-			IsTracker:  isTracker(issue.GetTitle(), labels),
-		})
+		actionable = append(actionable, issueOf(issue, labels))
 	}
 
-	return actionable, held, totalIssues, nil
+	return actionable, held, contributeExtra, totalIssues, nil
 }
 
 func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRequest, held []HoldItem, totalPRs int, err error) {
@@ -606,6 +651,100 @@ func (c *Client) SetExemptLabels(labels []string) {
 		return
 	}
 	c.exemptLabels = labels
+}
+
+// SetContributeLabels records the CONTRIBUTE label config (the deny/allow list
+// plus its mode) so the actionable scan can rescue contribute-queue work the
+// governor would otherwise drop. Nil-receiver safe for the same reason as
+// SetExemptLabels. Passing an empty list or a non-"allow" mode disables the
+// rescue (nothing to rescue positively on).
+func (c *Client) SetContributeLabels(labels []string, mode string) {
+	if c == nil {
+		return
+	}
+	c.reposMu.Lock()
+	defer c.reposMu.Unlock()
+	c.contributeLabels = labels
+	c.contributeLabelsMode = mode
+}
+
+// wildcardMatch mirrors config.WildcardMatch (kept local to avoid a
+// github->config import cycle): a "/re/"-delimited pattern is a case-insensitive
+// regex, a "*" pattern is a glob, and a bare pattern is a case-insensitive
+// substring test. Only used by contributeRescue to compare labels against the
+// contribute label list, so the two stay behaviourally identical.
+func wildcardMatch(text, pattern string) bool {
+	text = strings.ToLower(text)
+	pattern = strings.TrimSpace(pattern)
+
+	if strings.HasPrefix(pattern, "/") && strings.HasSuffix(pattern, "/") && len(pattern) >= 2 {
+		re, err := regexp.Compile("(?i)" + pattern[1:len(pattern)-1])
+		if err != nil {
+			return false
+		}
+		return re.MatchString(text)
+	}
+
+	pattern = strings.ToLower(pattern)
+	if strings.Contains(pattern, "*") {
+		parts := strings.Split(pattern, "*")
+		idx := 0
+		for _, part := range parts {
+			if part == "" {
+				continue
+			}
+			found := strings.Index(text[idx:], part)
+			if found < 0 {
+				return false
+			}
+			idx += found + len(part)
+		}
+		if !strings.HasPrefix(pattern, "*") && !strings.HasPrefix(text, parts[0]) {
+			return false
+		}
+		if !strings.HasSuffix(pattern, "*") && !strings.HasSuffix(text, parts[len(parts)-1]) {
+			return false
+		}
+		return true
+	}
+
+	return strings.Contains(text, pattern)
+}
+
+// contributeRescue reports whether an issue that the governor scan would exempt
+// or hold should nevertheless be RETAINED because it is explicitly
+// contribute-queue work: i.e. the contribute label config is in "allow" mode
+// with a non-empty list and at least one of the issue's labels matches it.
+//
+// Why this exists (the 0-with-matching-issues bug): the contribute ready-queue
+// (dashboard.ReadyQueue) and the assignment path (selectTask) both draw their
+// candidate set exclusively from repo.ActionableIssues — the governor's
+// actionable scan. That scan filters by GOVERNOR exempt-labels and hold-labels,
+// which are configured independently of the CONTRIBUTE label allow-list. When
+// an operator marks the contribute label (e.g. "3-clanker-queue") as a governor
+// exempt label — a natural setup so the governor does not auto-work it and it is
+// instead surfaced to human/agent contributors — every such issue is dropped in
+// fetchIssues before it can reach the contribute queue. The contribute filters
+// only NARROW the candidate set, so they can never re-add it: the queue shows 0
+// even with dozens of admissible issues. This rescue lets those issues survive
+// the governor exemption so the contribute filters can then admit them. It is
+// deliberately positive-match-only (allow mode + explicit label hit) so it never
+// resurrects arbitrary exempt issues — only genuine contribute-queue work.
+//
+// Deny mode is intentionally NOT rescued: in deny mode "matching a label" means
+// EXCLUDE, so there is no positive contribute-queue signal to rescue on.
+func (c *Client) contributeRescue(labels []string) bool {
+	if !strings.EqualFold(c.contributeLabelsMode, "allow") || len(c.contributeLabels) == 0 {
+		return false
+	}
+	for _, l := range labels {
+		for _, want := range c.contributeLabels {
+			if wildcardMatch(l, want) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (c *Client) isExempt(labels []string) bool {

--- a/v2/pkg/github/client_test.go
+++ b/v2/pkg/github/client_test.go
@@ -1024,6 +1024,96 @@ func TestIsInternalAuthor(t *testing.T) {
 	}
 }
 
+// TestEnumerateActionable_ContributeRescue is the scan-level reproduction of the
+// "contribute queue shows 0 with many matching issues" bug. The contribute
+// ready-queue draws its candidate set from the governor's actionable scan. When
+// the operator marks the CONTRIBUTE label ("3-clanker-queue") as a GOVERNOR
+// exempt label — a natural setup so the governor does not auto-work it and it is
+// surfaced to contributors instead — the scan dropped every such issue, so the
+// contribute queue was starved even though the contribute filter would pass them.
+//
+// With the fix, an exempt (or held) issue that carries a contribute allow-label
+// is RETAINED in ContributeExtraIssues (kept OUT of Issues so governor counts are
+// unaffected), so the dashboard can merge it into the contribute candidate set.
+func TestEnumerateActionable_ContributeRescue(t *testing.T) {
+	org, repo := "projectbluefin", "common"
+	issues := []wireIssue{
+		// Contribute work that is ALSO governor-exempt: previously vanished.
+		{Number: 100, Title: "clanker work A", User: wireUser{"alice"},
+			Labels: []wireLabel{{Name: "3-clanker-queue"}}, CreatedAt: hoursAgo(2)},
+		// Contribute work that is ALSO held: previously vanished.
+		{Number: 101, Title: "clanker work B (held)", User: wireUser{"bob"},
+			Labels: []wireLabel{{Name: "3-clanker-queue"}, {Name: "hold"}}, CreatedAt: hoursAgo(3)},
+		// Plain governor-actionable issue (no contribute label): stays in Issues.
+		{Number: 102, Title: "ordinary bug", User: wireUser{"carol"},
+			Labels: []wireLabel{{Name: "bug"}}, CreatedAt: hoursAgo(1)},
+		// Governor-exempt WITHOUT a contribute label: must NOT be rescued.
+		{Number: 103, Title: "adopters entry", User: wireUser{"dave"},
+			Labels: []wireLabel{{Name: "3-clanker-queue-lookalike"}, {Name: "adopters"}}, CreatedAt: hoursAgo(1)},
+	}
+
+	mux := buildMux(t, org, repo, issues, nil)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	// Operator exempts the contribute label from the GOVERNOR (plus the default
+	// "adopters"), and configures the CONTRIBUTE label allow-list to that label.
+	c.SetExemptLabels([]string{"3-clanker-queue", "adopters"})
+	c.SetContributeLabels([]string{"clanker-queue", "3-clanker-queue"}, "allow")
+
+	result, err := c.EnumerateActionable(context.Background())
+	if err != nil {
+		t.Fatalf("EnumerateActionable: %v", err)
+	}
+
+	// Governor counts are unchanged: only the plain bug (#102) is actionable; the
+	// two clanker issues are exempt/held, and #103 is exempt via "adopters".
+	if result.Issues.Count != 1 {
+		t.Fatalf("governor Issues.Count = %d, want 1 (rescue must not inflate governor counts)", result.Issues.Count)
+	}
+	if result.Issues.Items[0].Number != 102 {
+		t.Fatalf("unexpected actionable issue: %+v", result.Issues.Items)
+	}
+
+	// Both clanker issues are rescued for the contribute queue; #103 is not.
+	got := map[int]bool{}
+	for _, iss := range result.ContributeExtraIssues {
+		got[iss.Number] = true
+	}
+	if !got[100] || !got[101] {
+		t.Fatalf("ContributeExtraIssues missing rescued clanker issues, got %+v", result.ContributeExtraIssues)
+	}
+	if got[103] {
+		t.Fatalf("exempt non-contribute issue #103 was wrongly rescued")
+	}
+	if len(result.ContributeExtraIssues) != 2 {
+		t.Fatalf("ContributeExtraIssues len = %d, want 2", len(result.ContributeExtraIssues))
+	}
+}
+
+// TestContributeRescue_DisabledWhenNotAllowMode proves the rescue is inert unless
+// the contribute label config is in "allow" mode with a non-empty list — a deny
+// list carries no positive contribute-queue signal to rescue on.
+func TestContributeRescue_DisabledWhenNotAllowMode(t *testing.T) {
+	c := &Client{}
+	c.SetContributeLabels([]string{"3-clanker-queue"}, "deny")
+	if c.contributeRescue([]string{"3-clanker-queue"}) {
+		t.Error("deny mode must not rescue")
+	}
+	c.SetContributeLabels(nil, "allow")
+	if c.contributeRescue([]string{"3-clanker-queue"}) {
+		t.Error("empty allow list must not rescue")
+	}
+	c.SetContributeLabels([]string{"3-clanker-queue"}, "allow")
+	if !c.contributeRescue([]string{"3-clanker-queue"}) {
+		t.Error("allow mode with matching label must rescue")
+	}
+	if c.contributeRescue([]string{"unrelated"}) {
+		t.Error("non-matching label must not rescue")
+	}
+}
+
 func init() {
 	_ = rfc3339Ago // suppress unused-constant warning
 }


### PR DESCRIPTION
## Confirmed evidence (projectbluefin \`common\` hive, live data)

- **11 open issues labeled \`3-clanker-queue\` in projectbluefin/common** (10 unassigned), ~39 more across other enabled repos — yet \`GET /api/contribute/queue\` returns \`{"queue":[]}\`.
- **Every repo is toggled ON for contribute** (common, bluefin, bluefin-lts, actions, testsuite, dakota, server, fsdk-containers, lab, review, bluefinctl, finpilot) — repo scope is not the blocker.
- Live policy: \`labels_mode:"allow"\` with \`deny_labels:["clanker-queue","3-clanker-queue"]\` (legacy field naming; the "allow" mode reads this list), \`skip_assigned_to_others:true\`, the standard title/author deny-lists.
- The contribute **label filter itself PASSES** these issues — \`config.LabelsFilterPasses(labels, list, "allow")\` returns true.
- Toggling **"Skip Issues Assigned to Others" OFF changes nothing** — proof the issues never reach the filter loop; the candidate set is empty *upstream*.

## Traced root cause (option (a): the actionable scan uses different label criteria)

\`ReadyQueue\` (\`v2/pkg/dashboard/contribute_sse.go\`) and \`selectTask\` (\`contribute_ws.go\`) both build their candidate set **only** from \`repo.ActionableIssues\`. That set is the **governor's** actionable scan (\`github.EnumerateActionable\` → \`fetchIssues\`), which drops any issue carrying a **governor exempt-label** (\`Governor.Labels.Exempt\`) or a hold-label — filters configured **independently** of the contribute label allow-list.

When an operator marks the contribute label (\`3-clanker-queue\`) as a **governor exempt label** — a natural setup so the governor does not auto-work it and it is surfaced to contributors instead — every such issue is dropped in \`fetchIssues\` before it can reach the contribute queue. The contribute filters only *narrow* that already-empty set; they can never *re-add* an issue the governor scan excluded. Hence 0 items with dozens of matching, admissible issues.

## Fix

- \`fetchIssues\` now **rescues** issues that positively match the contribute label config (allow mode + explicit label hit) even when the governor would exempt/hold them, into a new **\`ActionableResult.ContributeExtraIssues\`** set — kept **out of** \`Issues\` so governor counts/SLA are unchanged.
- \`buildRepos\` merges \`ContributeExtraIssues\` into per-repo \`ActionableIssues\` (deduped by number), so both \`ReadyQueue\` and \`selectTask\` see them.
- The existing contribute filters (suspend, title/author deny, skip-assigned, cooldown, disabled-repo) **still apply on top** — the rescue only widens the candidate set to genuine contribute-queue work; it never bypasses admission.
- The contribute label config is synced into the scan client at startup, on config reload, on GitHub-client reinit, and when the contribute config is edited via the API (\`SetContributeLabels\`), so a change takes effect on the next scan rather than only on restart.
- Rescue is positive-match-only (allow mode, non-empty list); deny mode carries no positive contribute-queue signal so it is intentionally inert.

## Tests

- **github** — \`TestEnumerateActionable_ContributeRescue\`: runs the real scan; asserts exempt/held contribute-labeled issues land in \`ContributeExtraIssues\` while governor \`Issues.Count\` is unchanged, and a non-contribute exempt issue is *not* rescued. \`TestContributeRescue_DisabledWhenNotAllowMode\` guards the mode/list gating.
- **dashboard** — \`TestReadyQueueSurfacesContributeRescuedIssues\` (data-driven over the real \`buildRepos\` + \`ReadyQueue\` chain): **50 rescued issues − 2 title-denied − 4 assigned-to-others = 44 admissible**, asserts the right issues survive (unassigned, label-matching, non-title-denied) and the per-repo distribution is preserved. \`TestReadyQueueStarvedWithoutRescue\` is the negative control (empty queue without the rescue — the exact bug symptom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)