### PR TITLE
feat: add agy (antigravity-cli) as fully supported backend

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -147,8 +147,18 @@ contribute-check-backend backend="claude":
         echo "  Claude Code will run with ANTHROPIC_BASE_URL=${HIVE_LITELLM_ENDPOINT}"
         echo "  Set the model your proxy serves: export AGENT_MODEL=<model>"
         ;;
+      agy)
+        if command -v agy &>/dev/null; then
+          echo "agy CLI detected ($(agy --version 2>&1 | head -1))"
+          echo "  Models: gemini-3.6-flash, claude-sonnet-4-6, gpt-oss-120b, and more"
+          echo "  Set model: --model gemini-3.6-flash-high"
+        else
+          echo "ERROR: agy CLI not found. Install: https://antigravity.dev"
+          exit 1
+        fi
+        ;;
       *)
-        echo "ERROR: Unknown backend '{{backend}}'. Supported: claude, copilot, goose, codex, pi, bob, litellm"
+        echo "ERROR: Unknown backend '{{backend}}'. Supported: claude, copilot, goose, codex, pi, bob, agy, litellm"
         exit 1
         ;;
     esac
@@ -531,6 +541,9 @@ contribute-hive backend="" mode="docker": check-version
           ;;
         codex)
           [ -d "${HOME}/.codex" ] && CLI_MOUNTS="-v ${HOME}/.codex:/home/dev/.codex${VOLSUF}"
+          ;;
+        agy)
+          [ -d "${HOME}/.antigravitycli" ] && CLI_MOUNTS="-v ${HOME}/.antigravitycli:/home/dev/.antigravitycli${VOLSUF}"
           ;;
       esac
       CONTAINER_NAME="hive-contributor-${BACKEND}-$(head -c 4 /dev/urandom | od -An -tx1 | tr -d ' ')"

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -218,6 +218,10 @@ function getCLIState() {
       if (/codex>|>\s*$|Codex CLI/.test(text)) return 'ready';
     } else if (BACKEND === 'pi') {
       if (/pi v\d|0\.0%|auto\)|\d+\.\d+%/.test(text)) return 'ready';
+    } else if (BACKEND === 'agy') {
+      // agy shows "? for shortcuts" at the bottom when its interactive prompt
+      // is ready. The generic />\s*$/ fires too early (during the splash).
+      if (/\? for shortcuts/.test(text)) return 'ready';
     } else {
       if (/>\s*$|❯|\$\s*$/.test(text)) return 'ready';
     }
@@ -577,6 +581,12 @@ function checkTmuxIdle() {
       hasIdlePrompt = /pi v\d|0\.0%|auto\)|\d+\.\d+%/.test(text);
       hasCompletionMarker = /completed|done|finished|tokens\)|\d+\.\d+%/i.test(text);
       isWorking = /Reading|Writing|Bash|Editing|thinking|running/i.test(text);
+    } else if (BACKEND === 'agy') {
+      // agy shows "? for shortcuts" at its idle prompt and a model name in
+      // the status line. When working it shows tool names and progress.
+      hasIdlePrompt = /\? for shortcuts/.test(text);
+      hasCompletionMarker = true;
+      isWorking = /Running|Searching|Reading|Writing|Editing/i.test(text);
     } else {
       hasIdlePrompt = />\s*$|\$\s*$/.test(text);
       hasCompletionMarker = /completed|done|finished/i.test(text);

--- a/config/backends.conf
+++ b/config/backends.conf
@@ -75,7 +75,7 @@ backend_perm_flag() {
     bob)     echo "--accept-license --auth-method api-key --approval-mode yolo --trust" ;;
 
     codex)   echo "--dangerously-bypass-approvals-and-sandbox" ;;
-    agy)     echo "" ;;
+    agy)     echo "--dangerously-skip-permissions" ;;
     goose)   echo "" ;;
     pi)      echo "" ;;
     aider)   echo "--yes" ;;


### PR DESCRIPTION
## Summary

Completes the Justfile and relay integration for the **agy** (antigravity-cli) backend so that \`just contribute-setup agy\` and \`just contribute-hive agy\` work end-to-end.

Closes #2643

## Changes

- **Justfile**: Add \`agy)\` case to \`contribute-check-backend\` recipe (preflight detects CLI, shows version and available models)
- **Justfile**: Add \`.antigravitycli\` volume mount in \`contribute-hive\` container mode
- **Justfile**: Add agy to the supported backends error message
- **config/backends.conf**: Set \`--dangerously-skip-permissions\` as the perm flag (enables unattended tool approval for Hive contributor mode)
- **bin/contributor-relay.sh**: Add explicit \`agy\` backend cases to \`getCLIState()\` and \`checkTmuxIdle()\` for proper readiness detection and idle/working state tracking

## Problem

The generic relay fallback regex (\`/>\\s*$/\`) matched agy's \`>\` prompt character during its splash animation, before the input handler was ready. Task prompts typed at that point were rendered as terminal noise rather than processed.

## Fix

Added dedicated \`agy\` backend cases:
- **getCLIState()**: matches \`? for shortcuts\` (agy's bottom status line, only present when fully interactive)
- **checkTmuxIdle()**: detects idle via same marker; working state via tool activity patterns (Running, Searching, Reading, etc.)

## Testing

- \`just contribute-check agy\` passes (detects CLI v1.1.10)
- \`agy --dangerously-skip-permissions --model gemini-3.6-flash-low -p "<task>"\` successfully creates and reads files without interactive prompts
- Live test: relay properly queues task until agy is ready, then delivers it; agy immediately starts executing tools (fork, clone, read issue)
- Running concurrently alongside Pi contributor on same machine — hub dispatches different tasks to each

## agy capabilities

| Feature | Support |
|---------|---------|
| Headless/print mode | \`agy -p "prompt"\` |
| Auto-approve tools | \`--dangerously-skip-permissions\` |
| Model selection | \`--model gemini-3.6-flash-high\` |
| Available models | Gemini 3.6/3.5 Flash, Gemini 3.1 Pro, Claude Sonnet 4.6, Claude Opus 4.6, GPT-OSS 120B |
| Config dir | \`~/.antigravitycli/\` |