### PR TITLE
⚡ hive-contributor image: low-risk size/update-cost improvements (#2613)

### DIFF
--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -4,19 +4,34 @@ FROM debian:bookworm-slim
 
 ARG NODE_MAJOR=24
 
+# Layering below is deliberately stable-to-mutable (issue #2613, Observation 2):
+# base apt packages change rarely, Node changes occasionally, and each agent
+# CLI is pinned/bumped independently and far more often. Splitting them into
+# separate RUNs means a single CLI version bump only invalidates (and a
+# contributor only re-pulls) that CLI's own layer, instead of also re-pulling
+# the base packages and Node toolchain underneath it. Total image size is
+# unchanged; only the update/re-pull cost per bump is reduced.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash curl git jq tmux python3 ca-certificates gnupg openssh-client \
-  && mkdir -p /etc/apt/keyrings \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/apt/keyrings \
   && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
     | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
   && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
     > /etc/apt/sources.list.d/nodesource.list \
   && apt-get update && apt-get install -y nodejs \
-  # codex is pinned for reproducibility (matching the copilot pin convention
-  # in v2/Dockerfile): its model catalog is baked into the binary per version,
-  # and the dashboard's static fallback list tracks 0.146.0.
-  && npm install -g @anthropic-ai/claude-code @github/copilot @openai/codex@0.146.0 \
   && rm -rf /var/lib/apt/lists/*
+
+# codex is pinned for reproducibility (matching the copilot pin convention
+# in v2/Dockerfile): its model catalog is baked into the binary per version,
+# and the dashboard's static fallback list tracks 0.146.0.
+#
+# npm cache is cleaned in the same layer it's populated (issue #2613,
+# Observation 2 "also minor") so the cache doesn't linger in this layer's
+# diff, mirroring the cleanup already done for the bobshell install below.
+RUN npm install -g @anthropic-ai/claude-code @github/copilot @openai/codex@0.146.0 \
+  && npm cache clean --force
 
 # Install bobshell (IBM "bob"). Mirrors Layer 9 of v2/Dockerfile so the
 # containerized contributor relay can actually run the bob backend — without


### PR DESCRIPTION
Addresses #2613

Downstream field notes from `projectbluefin/review` proposed three independent, low-risk options scoped to `v2/Dockerfile.contributor`. Here's the disposition of each:

## Observation 1 — musl Goose binary (L53) — **skipped**

The issue itself frames this as needing a verification gate before acceptance: "one contributor task per architecture completing end to end on a musl build, since `aarch64` is the case we have not exercised." The reporter's own testing only covered the Goose backend on `linux/amd64`. Since `goose` is an actual runtime binary executed by contributors (not just a build-time artifact), swapping the libc it's linked against is a behavior-affecting change, not a pure layer/ordering tweak, and I don't want to merge it without the cross-arch, end-to-end verification the issue explicitly asks for as a precondition. Happy to take the reporter up on their offer to build and verify both `linux/amd64` and `linux/arm64` with a real contributor task on each — once that comes back clean this is a good follow-up PR.

The related aside (silent `|| echo "... skipped"` fallback for Goose/Pi installs) is also left alone here — it's a separate, broader question (matching the bobshell layer's fail-hard philosophy) that deserves its own issue/PR rather than being folded into this size/update-cost change.

## Observation 2 — stable-to-mutable layer ordering — **applied**

Split the single RUN combining base apt packages + NodeSource setup + agent CLI `npm install` into three RUN layers: base packages, then Node, then the agent CLIs (`claude-code`, `copilot`, `codex`). The agent CLIs are pinned/bumped far more often than Node, and Node changes far more often than the base packages, so previously every CLI version bump invalidated (and forced a re-pull of) the whole combined layer. Now a CLI bump only re-pulls its own layer.

Also cleaned `npm cache` in the same layer as the `npm install -g` that populates it (the issue's "also minor" note), matching the cleanup already done for the bobshell install layer.

Total image size is unchanged — this only reduces the bytes re-pulled on routine CLI bumps. No functional/runtime change: same packages, same install commands, same final `rm -rf /var/lib/apt/lists/*` cleanup, just reordered into separate layers.

## Observation 3 — Go toolchain size (281 M) — **no action**

The issue explicitly does not recommend removing Go ("we are not suggesting you remove it") and offers no concrete low-risk change — just cost data plus a menu of tradeoffs (leave as-is / `-go` variant tag / install on demand) that depend on task-mix decisions outside the scope of a low-risk PR. Leaving as-is; noting here for visibility per the issue's ask.

---

All backend support (`claude-code`, `copilot`, `codex`, `bobshell`/Bob, `gh`, Goose, Pi, Go) is preserved unchanged. Runtime behavior is unchanged — this PR only reorders Dockerfile layers and cleans the npm cache in-layer; no packages, versions, or install logic were altered.
