### PR TITLE
🐛 onboarding: inference-agnostic copy (#2635) + pi config mount in Justfile (#2639)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -542,6 +542,9 @@ contribute-hive backend="" mode="docker": check-version
         codex)
           [ -d "${HOME}/.codex" ] && CLI_MOUNTS="-v ${HOME}/.codex:/home/dev/.codex${VOLSUF}"
           ;;
+        pi)
+          [ -d "${HOME}/.pi" ] && CLI_MOUNTS="-v ${HOME}/.pi:/home/dev/.pi${VOLSUF}"
+          ;;
         agy)
           [ -d "${HOME}/.antigravitycli" ] && CLI_MOUNTS="-v ${HOME}/.antigravitycli:/home/dev/.antigravitycli${VOLSUF}"
           ;;

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -1100,7 +1100,7 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 <h1>🐝 Contribute to %s</h1>
 <div id="invite-banner" class="invite-banner" hidden role="status"></div>
 <p class="subtitle">Donate your CLI + API tokens to help this project's AI agent swarm.</p>
-<p class="subtitle" style="font-size:.95rem;margin-top:-24px;margin-bottom:32px">Powered by <strong style="color:#e6edf3">ClankeR</strong>, the contributor relay &mdash; it hands tasks from this hive's backlog to the agent running on your machine. Your compute, their backlog.</p>
+<p class="subtitle" style="font-size:.95rem;margin-top:-24px;margin-bottom:32px">Powered by <strong style="color:#e6edf3">ClankeR</strong>, the contributor relay &mdash; it hands tasks from this hive's backlog to the agent running on your machine. Your compute, their backlog. Bring your own inference &mdash; how you want to contribute is up to you.</p>
 <div class="stat-row">
 <div class="stat"><div class="stat-num" style="color:#58a6ff">%d</div><div class="stat-label">Total</div></div>
 %s


### PR DESCRIPTION
## Summary

- **Issue #2635**: Appended inference-agnostic message to the ClankeR tagline on the /contribute Onboarding tab to clarify that contributors can bring their own inference method
- **Issue #2639**: Added `pi` backend case to Justfile's CLI config directory mount section (lines 545–547), mirroring the existing `codex` case

## Files changed

- `v2/pkg/dashboard/api_contribute.go` (line 1103)
- `Justfile` (lines 545–547)

Fixes #2635
Fixes #2639