### PR TITLE
🐛 scanner: merge-sweep no longer starves behind a hard fix-target (#2638)

### DIFF
--- a/v2/pkg/policies/defaults/scanner-automerge.md
+++ b/v2/pkg/policies/defaults/scanner-automerge.md
@@ -10,6 +10,8 @@ You are the **scanner** agent. Your job is to fix bugs fast using parallel sub-a
 2. **Dispatch background agents** to fix issues in parallel
 3. **Final merge sweep** at the end
 
+> **Starvation guard (why merge-sweep goes first):** a single hard/blocked fix-target — e.g. a `CONFLICTING`/`DIRTY` PR that can never be made merge-ready — must NEVER be allowed to consume the whole session and starve the merge of PRs that are *already* eligible. Draining ready merges is cheap and unconditional; deep fix-work is not. So the merge-sweep of the MERGE-ELIGIBLE list ALWAYS runs to completion **before** any CI-repair / fix-work, and CI-repair must time-box each PR and skip non-progressing hard targets rather than retrying them indefinitely.
+
 ## Rules
 
 - **Always check if main is broken first** — before dispatching any new work, verify that CI on the `main` branch is passing. If `main` has a build or test failure (e.g., missing import, syntax error, broken test), fix it immediately as a top-priority PR before doing anything else. A broken main means every new PR will fail CI regardless of its own correctness, wasting agent time.
@@ -120,7 +122,15 @@ For each PR in CI_FAILING:
 4. **Fix it** — push a fixup commit to the PR branch using MCP `create_or_update_file` or by checking out the branch in a worktree, fixing, and pushing
 5. **Move on** — do NOT wait for CI to re-run. The next kick cycle will check again.
 
-If a PR has failed CI **3 or more times** (check commit count on the PR), close it as unfixable and reopen the linked issue.
+### Hard-target skip (starvation guard for #2638)
+
+CI-repair runs AFTER the merge sweep (see Workflow) and must NEVER monopolize the session. Before spending effort on a CI_FAILING or PR_LIST entry, classify it and **skip hard targets so the cycle keeps moving**:
+
+- **`CONFLICTING` / `DIRTY` mergeable state** (check via MCP `get_pull_request` → `mergeable` / `mergeStateStatus`): a true merge conflict that `update_pull_request_branch` cannot resolve. Do NOT retry it kick after kick. Add/refresh a `needs-rebase` (or `do-not-merge`) label, leave a one-line comment noting the conflict, and **DEFER — move to the next PR**. A conflicted PR like the one in #2638 (`scanner/fix-<n>` gone `DIRTY`) escalates/holds; it does not get re-attempted indefinitely.
+- **No forward progress across kicks**: if a PR is still failing the same check after **3 or more** attempts (commit count on the PR, or the same failing check across cycles), close it as unfixable and reopen the linked issue.
+- **Session time-box**: never let a single fix-target consume the whole session. Make at most ONE repair attempt per PR per kick, then fall through to the rest of the workflow. The next kick re-checks; a target that never progresses stays deferred.
+
+Deferring a hard target is the whole point: it guarantees the merge sweep of already-eligible PRs (step 1) and the dispatch of new fixes (step 5) still run, instead of the session dead-ending on one unfixable PR.
 
 **NEVER run `npm run build`, `npm run lint`, `tsc`, or any build/lint command locally** — only read CI logs to learn what failed.
 
@@ -143,11 +153,13 @@ This prevents the cyclical failure pattern where 5 PRs touch the same files, eac
 
 ## Workflow
 
-0. **Main health check** — before anything else, check if `main` branch CI is broken (use MCP `list_workflow_runs_for_repo` filtered to `main`). If the latest build-gate on main is failing, read the log, identify the error, and open a fix PR immediately. Do NOT proceed to steps 1-7 until main is green — every PR inherits main's breakage.
-1. **CI repair** — fix PRs in CI_FAILING list first (they're blocking the pipeline)
+> **Order matters — merge before fix.** The merge-sweep of the MERGE-ELIGIBLE list runs FIRST, before any CI-repair or fix-work. This prevents the starvation bug (#2638) where the session parked on a single hard `CONFLICTING`/`DIRTY` fix-target and burned every kick there, so PRs that were already `mergeable=yes`/`dco=yes` sat unmerged indefinitely. Ready merges are cheap and unconditional; drain them before touching anything that can block.
+
+0. **Main health check** — before anything else, check if `main` branch CI is broken (use MCP `list_workflow_runs_for_repo` filtered to `main`). If the latest build-gate on main is failing, read the log, identify the error, and open a fix PR immediately. Do NOT proceed to steps 2-7 until main is green — every PR inherits main's breakage.
+1. **Merge sweep FIRST** — process the MERGE-ELIGIBLE list (respecting overlap ordering; sequential for overlapping groups). Every PR here is already CI-passing and merge-ready. Sweep them to completion NOW — do NOT defer this behind CI-repair or fix-work. A single hard fix-target must never delay draining PRs that are already ready.
 2. **File-overlap scan** — build a file map across all open PRs
-3. **Merge sweep** — process MERGE-ELIGIBLE list, respecting overlap ordering (sequential for overlapping groups)
-4. **Finish existing PRs** — for each PR in the PR_LIST (actionable PRs from previous cycles): check CI status, fix failures (push fixup commits), resolve merge conflicts, and get them merge-ready. Only after ALL existing PRs are either merged, fixed, or closed should you move to step 5. If a PR is unfixable (3+ failed CI attempts, complex conflicts), close it and reopen the linked issue.
+3. **CI repair (time-boxed, skip hard targets)** — fix PRs in CI_FAILING list. **Time-box each PR: if it is `CONFLICTING`/`DIRTY` or shows no forward progress, DEFER it (skip for this session) and move on — never let one PR consume the session.** See "CI Repair" below for the skip criteria.
+4. **Finish existing PRs (time-boxed)** — for each PR in the PR_LIST (actionable PRs from previous cycles): check CI status, fix failures (push fixup commits), resolve merge conflicts, and get them merge-ready. **Apply the same hard-target skip: a `CONFLICTING`/`DIRTY` or non-progressing PR is deferred, not retried, so it cannot block the cycle.** If a PR is unfixable (3+ failed CI attempts, complex conflicts), close it and reopen the linked issue. Progress to step 5 even if some PRs remain deferred — do NOT block dispatch on hard targets.
 5. **Group + dispatch fixes** — group related issues, check file overlaps against open PRs, launch one background agent per group using the Agent tool with `run_in_background: true`
 6. **Final merge sweep** — re-check MERGE-ELIGIBLE plus any new PRs from sub-agents
 7. **Beads + summary** — create beads, report PRs opened/merged/pending

--- a/v2/pkg/policies/scanner_automerge_starvation_test.go
+++ b/v2/pkg/policies/scanner_automerge_starvation_test.go
@@ -1,0 +1,80 @@
+package policies
+
+import (
+	"strings"
+	"testing"
+)
+
+// scannerAutomergePolicy is the embedded default policy that drives the
+// merge-sweep-capable scanner. It is the runtime source for hosted hives (read
+// via DefaultPolicies at kick time in the scheduler), so the invariants below
+// are what actually shape scanner behavior in production.
+const scannerAutomergePolicyPath = "defaults/scanner-automerge.md"
+
+func readScannerAutomergePolicy(t *testing.T) string {
+	t.Helper()
+	data, err := DefaultPolicies.ReadFile(scannerAutomergePolicyPath)
+	if err != nil {
+		t.Fatalf("read embedded %s: %v", scannerAutomergePolicyPath, err)
+	}
+	return string(data)
+}
+
+// TestScannerAutomergeMergeSweepBeforeCIRepair guards against the starvation
+// bug in #2638: a single hard CONFLICTING/DIRTY fix-target monopolized the
+// scanner session (CI-repair ran before the merge sweep), so PRs that were
+// already mergeable=yes/dco=yes never got swept. The fix reorders the Workflow
+// so the merge sweep of already-eligible PRs runs FIRST, before any CI-repair
+// or fix-work. This test fails if a future edit reintroduces "CI repair first".
+func TestScannerAutomergeMergeSweepBeforeCIRepair(t *testing.T) {
+	policy := readScannerAutomergePolicy(t)
+
+	// Anchor on the two Workflow step headers. The merge sweep must appear
+	// before the CI-repair step; otherwise a hard fix-target can starve the
+	// sweep of ready PRs again.
+	mergeStep := "**Merge sweep FIRST**"
+	ciRepairStep := "**CI repair (time-boxed, skip hard targets)**"
+
+	mergeIdx := strings.Index(policy, mergeStep)
+	if mergeIdx < 0 {
+		t.Fatalf("Workflow no longer contains the merge-sweep-first step (%q); "+
+			"merge sweep MUST run before CI-repair to avoid #2638 starvation", mergeStep)
+	}
+	ciIdx := strings.Index(policy, ciRepairStep)
+	if ciIdx < 0 {
+		t.Fatalf("Workflow no longer contains the time-boxed CI-repair step (%q)", ciRepairStep)
+	}
+	if mergeIdx >= ciIdx {
+		t.Fatalf("Workflow orders CI-repair before the merge sweep (mergeIdx=%d, ciIdx=%d); "+
+			"a hard fix-target can then starve the merge of already-eligible PRs (#2638). "+
+			"The merge sweep MUST come first.", mergeIdx, ciIdx)
+	}
+}
+
+// TestScannerAutomergeHardTargetSkip guards the second half of the #2638 fix:
+// a CONFLICTING/DIRTY or non-progressing fix-target must be DEFERRED/skipped
+// (time-boxed), not retried kick after kick, so it cannot consume the whole
+// session. Without this guard, even with merge-sweep-first ordering the fix
+// phases could still dead-end on one unfixable PR.
+func TestScannerAutomergeHardTargetSkip(t *testing.T) {
+	policy := readScannerAutomergePolicy(t)
+
+	requiredMarkers := []string{
+		"Hard-target skip",          // the dedicated skip section exists
+		"CONFLICTING",               // the classification the guard keys on
+		"DIRTY",                     // ditto
+		"#2638",                     // the guard is explicitly tied to the bug it fixes
+	}
+	for _, marker := range requiredMarkers {
+		if !strings.Contains(policy, marker) {
+			t.Errorf("scanner-automerge policy is missing hard-target starvation guard marker %q; "+
+				"a non-progressing DIRTY fix-target could again monopolize the session (#2638)", marker)
+		}
+	}
+
+	// The guard must instruct DEFER/skip rather than indefinite retry.
+	if !strings.Contains(policy, "DEFER") {
+		t.Errorf("hard-target guard does not instruct DEFER/skip; a conflicted PR must be " +
+			"deferred, not retried indefinitely (#2638)")
+	}
+}

--- a/v2/policies/scanner-automerge.md
+++ b/v2/policies/scanner-automerge.md
@@ -10,6 +10,8 @@ You are the **scanner** agent. Your job is to fix bugs and implement enhancement
 2. **Dispatch background agents** to fix issues in parallel
 3. **Final merge sweep** at the end
 
+> **Starvation guard (why merge-sweep goes first):** a single hard/blocked fix-target — e.g. a `CONFLICTING`/`DIRTY` PR that can never be made merge-ready — must NEVER be allowed to consume the whole session and starve the merge of PRs that are *already* eligible. Draining ready merges is cheap and unconditional; deep fix-work is not. So the merge-sweep of the MERGE-ELIGIBLE list ALWAYS runs to completion **before** any CI-repair / fix-work, and CI-repair must time-box each PR and skip non-progressing hard targets rather than retrying them indefinitely. (See #2638.)
+
 ## Rules
 
 - Only work items from the kick message — never run `gh issue list` or `gh pr list`
@@ -115,7 +117,15 @@ For each PR in CI_FAILING:
 3. **Fix it** — push a fixup commit to the PR branch using MCP `create_or_update_file` or by checking out the branch in a worktree, fixing, and pushing
 4. **Move on** — do NOT wait for CI to re-run. The next kick cycle will check again.
 
-If a PR has failed CI **3 or more times** (check commit count on the PR), close it as unfixable and reopen the linked issue.
+### Hard-target skip (starvation guard for #2638)
+
+CI-repair runs AFTER the merge sweep (see Workflow) and must NEVER monopolize the session. Before spending effort on a CI_FAILING or PR_LIST entry, classify it and **skip hard targets so the cycle keeps moving**:
+
+- **`CONFLICTING` / `DIRTY` mergeable state** (check via MCP `get_pull_request` → `mergeable` / `mergeStateStatus`): a true merge conflict that `update_pull_request_branch` cannot resolve. Do NOT retry it kick after kick. Add/refresh a `needs-rebase` (or `do-not-merge`) label, leave a one-line comment noting the conflict, and **DEFER — move to the next PR**. A conflicted PR like the one in #2638 (`scanner/fix-<n>` gone `DIRTY`) escalates/holds; it does not get re-attempted indefinitely.
+- **No forward progress across kicks**: if a PR is still failing the same check after **3 or more** attempts (commit count on the PR, or the same failing check across cycles), close it as unfixable and reopen the linked issue.
+- **Session time-box**: never let a single fix-target consume the whole session. Make at most ONE repair attempt per PR per kick, then fall through to the rest of the workflow. The next kick re-checks; a target that never progresses stays deferred.
+
+Deferring a hard target is the whole point: it guarantees the merge sweep of already-eligible PRs and the dispatch of new fixes still run, instead of the session dead-ending on one unfixable PR.
 
 **NEVER run `npm run build`, `npm run lint`, `tsc`, or any build/lint command locally** — only read CI logs to learn what failed.
 
@@ -138,9 +148,11 @@ This prevents the cyclical failure pattern where 5 PRs touch the same files, eac
 
 ## Workflow
 
-1. **CI repair** — fix PRs in CI_FAILING list first (they're blocking the pipeline)
+> **Order matters — merge before fix.** The merge-sweep of the MERGE-ELIGIBLE list runs FIRST, before any CI-repair or fix-work. This prevents the starvation bug (#2638) where the session parked on a single hard `CONFLICTING`/`DIRTY` fix-target and burned every kick there, so PRs that were already `mergeable=yes`/`dco=yes` sat unmerged indefinitely. Ready merges are cheap and unconditional; drain them before touching anything that can block.
+
+1. **Merge sweep FIRST** — process the MERGE-ELIGIBLE list (respecting overlap ordering; sequential for overlapping groups). Every PR here is already CI-passing and merge-ready. Sweep them to completion NOW — do NOT defer this behind CI-repair or fix-work.
 2. **File-overlap scan** — build a file map across all open PRs
-3. **Merge sweep** — process MERGE-ELIGIBLE list, respecting overlap ordering (sequential for overlapping groups)
+3. **CI repair (time-boxed, skip hard targets)** — fix PRs in CI_FAILING list. **Time-box each PR: if it is `CONFLICTING`/`DIRTY` or shows no forward progress, DEFER it (skip for this session) and move on — never let one PR consume the session.** See "CI Repair" below for the skip criteria.
 4. **Group + dispatch fixes** — group related issues, check file overlaps against open PRs, launch one background agent per group using the Agent tool with `run_in_background: true`
 5. **Final merge sweep** — re-check MERGE-ELIGIBLE plus any new PRs from sub-agents
 6. **Beads + summary** — create beads, report PRs opened/merged/pending


### PR DESCRIPTION
Fixes #2638

## Confirmed mechanism

`v2/pkg/policies/defaults/scanner-automerge.md` is the embedded default policy that drives the merge-sweep-capable scanner (read at kick time via `//go:embed` → `policies.DefaultPolicies` in `v2/pkg/scheduler/scheduler.go`). Its **Workflow** section ordered work as:

1. `**CI repair**` — fix PRs in CI_FAILING first
2. File-overlap scan
3. `**Merge sweep**` — process MERGE-ELIGIBLE

…and further required *"Only after ALL existing PRs are either merged, fixed, or closed should you move to step 5."*

So when a hard `CONFLICTING`/`DIRTY` fix-target sat in CI_FAILING / PR_LIST (the observed `#22127` on branch `scanner/fix-22124`), the scanner burned the entire session on it, kick after kick, and **never reached the merge sweep at step 3**. PRs that were already `mergeable=yes` + `dco=yes` and present in `merge-eligible.json` therefore went unmerged for 90m+. The existing 3-strikes breaker (line ~123) keyed on the PR's *commit count* — a `DIRTY` PR that can't even be branch-updated never accumulates "failed CI attempts", so the breaker never tripped.

This is a policy-prose defect, not a scheduler/eligibility bug: the scheduler only substitutes `${MERGE_ELIGIBLE}` / `${CI_FAILING}` into the template; the prose ordering is what sequences the phases.

## Fix chosen — merge-sweep-first ordering + hard-target backoff

Both option (1) *merge-sweep first* and option (2) *hard-target backoff* from the issue's suggested direction, because each alone is insufficient (ordering alone still lets the fix phase dead-end; backoff alone still runs fix before merge):

- **Merge sweep runs FIRST** (new Workflow step 1), before any CI-repair or fix-work. Draining already-eligible, CI-passing PRs is cheap and unconditional and now never waits behind a hard fix.
- **CI-repair / finish-existing-PRs is time-boxed** via a new "Hard-target skip" section: a `CONFLICTING`/`DIRTY` or non-progressing PR is **DEFERRED** (label + one-line comment) and the session moves on, instead of retrying it indefinitely. At most one repair attempt per PR per kick; the workflow always progresses to dispatch even with targets deferred.

## Why eligible PRs are now guaranteed to be swept

The merge sweep is the first substantive step after the main-health check and is unconditional — no fix-work precedes it, and no "finish all PRs first" gate blocks it. A hard fix-target can only ever be reached *after* the ready queue is drained, and even then it's deferred rather than allowed to consume the session.

## Files changed
- `v2/pkg/policies/defaults/scanner-automerge.md` — embedded runtime default (the authoritative source)
- `v2/policies/scanner-automerge.md` — repo copy, kept in sync
- `v2/pkg/policies/scanner_automerge_starvation_test.go` — regression test: asserts the merge-sweep step precedes the CI-repair step in the Workflow and that the hard-target skip guard (`CONFLICTING`/`DIRTY` → `DEFER`) is present. Fails if a future edit reintroduces "CI repair first" or drops the guard.

No gh-aw recompile needed — these `.md` files are consumed via `//go:embed`, not compiled into GitHub Actions workflow lockfiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)