### PR TITLE
🐛 contribute queue: prevent handing the same issue to multiple contributors (#2644)

### DIFF
--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -1458,7 +1458,15 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					contributor.currentTask = &WSTaskAssign{
 						TaskID: msg.TaskID,
 						Kind:   msg.Kind,
-						Repo:   msg.Repo,
+						// #2644: canonicalise the CLIENT-supplied repo to the same
+						// repo.Full form selectTask assigned it under, so the
+						// activeIssues double-assign guard and the failure/completion
+						// cooldowns — all keyed "repo#number" off currentTask.Repo —
+						// match. Storing msg.Repo verbatim let a relay whose repo
+						// spelling differs from repo.Full slip its resumed task past
+						// the in-flight exclusion, and the SAME issue was handed to a
+						// second contributor (intermittent, and only for that repo).
+						Repo:   h.canonicalRepoKey(msg.Repo),
 						Number: msg.Number,
 						Title:  msg.Title,
 					}
@@ -1927,6 +1935,75 @@ func buildTaskPrompt(repoFull string, number int, title string) string {
 			"Use the GH_TOKEN env var for all gh commands (do NOT use 'unset GITHUB_TOKEN').",
 		repoFull, repoFull, number, title, repoFull, repoFull,
 	)
+}
+
+// canonicalRepoKey maps an arbitrary, possibly client-supplied repo string to the
+// SAME canonical form the server keys everything on: FrontendRepo.Full, i.e. the
+// exact string selectTask's activeIssues guard, the failure/quarantine cooldowns,
+// and the completion cooldown all build their "repo#number" keys from.
+//
+// Why this is load-bearing (#2644): currentTask.Repo is normally set by selectTask
+// to chosen.repoFull (== repo.Full). But the task_progress RESUME path re-populates
+// currentTask from the CLIENT-supplied msg.Repo after a reconnect (the relay keeps
+// its task locally and re-asserts it via task_progress). If the relay reports the
+// repo in ANY other spelling than repo.Full — a bare name where the hub uses
+// "owner/repo", or a differently-cased/prefixed cross-org name — then every
+// server-side "%s#%d" key built from currentTask.Repo silently MISSES:
+//   - the activeIssues double-assign guard no longer excludes the in-flight issue,
+//     so a concurrent selectTask hands the SAME issue to a second contributor; and
+//   - the disconnect/abandon reconnect-window cooldown (recordTaskFailure) is booked
+//     under the wrong key, so it does not protect that issue either.
+//
+// This is exactly the #2356/#2492 duplicate-assignment race re-opened through a key
+// mismatch, and it is intermittent + repo-specific: it only fires for a repo whose
+// relay-reported name differs from the hub's repo.Full, and only across a reconnect
+// that resumes via task_progress — which is why #2644 was seen "only in this repo".
+//
+// Resolution order:
+//  1. Exact match on a known repo's Full (already canonical) → return it unchanged.
+//  2. Match on a known repo's Name (case-insensitive) or its Full (case-insensitive)
+//     → return that repo's Full, adopting the canonical casing/prefix.
+//  3. No status/no match: fall back to the SAME rule buildRepos uses — prefix the
+//     configured Org when the string carries no "owner/" segment — so a bare name
+//     still lands on "org/name". If even the org is unknown, return the raw string
+//     (unchanged behaviour of last resort; never worse than before).
+func (h *ContributeWSHub) canonicalRepoKey(repo string) string {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return repo
+	}
+
+	var status *StatusPayload
+	if h != nil && h.server != nil {
+		h.server.statusMu.RLock()
+		status = h.server.status
+		h.server.statusMu.RUnlock()
+	}
+	if status != nil {
+		// First pass: an exact Full match is already canonical — cheap and common.
+		for _, r := range status.Repos {
+			if r.Full == repo {
+				return r.Full
+			}
+		}
+		// Second pass: reconcile a differently-spelled client value against the
+		// known set by Name or case-insensitive Full, adopting the canonical Full.
+		for _, r := range status.Repos {
+			if strings.EqualFold(r.Name, repo) || strings.EqualFold(r.Full, repo) {
+				return r.Full
+			}
+		}
+	}
+
+	// Fallback mirrors buildRepos: a bare name is qualified with the configured org
+	// so it matches the "org/name" Full the rest of the server builds.
+	if !strings.Contains(repo, "/") &&
+		h != nil && h.server != nil && h.server.deps != nil && h.server.deps.Config != nil {
+		if org := h.server.deps.Config.Project.Org; org != "" {
+			return org + "/" + repo
+		}
+	}
+	return repo
 }
 
 func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {

--- a/v2/pkg/dashboard/contribute_ws_dupe_assign_test.go
+++ b/v2/pkg/dashboard/contribute_ws_dupe_assign_test.go
@@ -1,0 +1,194 @@
+package dashboard
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// singleIssueStatus seeds a status with EXACTLY ONE admissible issue in a repo
+// whose Full (owner/repo) differs from its bare Name. The single-issue candidate
+// set is the deterministic setup for the double-assignment race: if two selections
+// both pick it, the queue handed the same work to two contributors (#2644).
+func singleIssueStatus(s *Server) {
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{
+			{
+				Name: "fsdk-containers",
+				Full: "projectbluefin/fsdk-containers",
+				ActionableIssues: []any{
+					map[string]any{
+						"number": float64(48),
+						"title":  "the only admissible issue",
+						"url":    "https://github.com/projectbluefin/fsdk-containers/issues/48",
+						"author": "someone",
+					},
+				},
+			},
+		},
+	}
+	s.statusMu.Unlock()
+}
+
+// TestDupeAssign_ConcurrentSelectTaskSingleIssue is the #2644 concurrency
+// regression. Two contributors' connections request work at the same instant
+// against a candidate set of exactly ONE issue. selectTask must be atomic
+// offer->claim: it chooses AND records the issue as in-flight under a single
+// lock, so a concurrent selectTask for the second contributor sees the issue is
+// already held and cannot pick it. Exactly one connection gets the issue; the
+// other gets nothing (no_matching_work) — never the SAME issue twice.
+func TestDupeAssign_ConcurrentSelectTaskSingleIssue(t *testing.T) {
+	hub, s := covK2Hub(t)
+	singleIssueStatus(s)
+
+	connA := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "ct-a", ContributorID: "c-a", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	connB := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "ct-b", ContributorID: "c-b", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	// Both connections must be REGISTERED on the hub: selectTask's in-flight scan
+	// reads currentTask across h.connections, so a claim by one is only visible to
+	// the other's scan if both are registered. Committing currentTask on the
+	// connection alone is not enough — it must be reachable from the hub map.
+	hub.mu.Lock()
+	hub.connections["conn-a"] = connA
+	hub.connections["conn-b"] = connB
+	hub.mu.Unlock()
+
+	// Fire both selections concurrently and gate them on a single barrier so they
+	// contend on selectMu as closely as the runtime allows. Repeat a few rounds so
+	// a non-atomic offer->claim would be caught by at least one interleaving.
+	const rounds = 200
+	for round := 0; round < rounds; round++ {
+		// Reset both connections to idle at the top of each round.
+		for _, c := range []*ContributorConnection{connA, connB} {
+			c.mu.Lock()
+			c.currentTask = nil
+			c.mu.Unlock()
+		}
+
+		var start sync.WaitGroup
+		start.Add(1)
+		var done sync.WaitGroup
+		results := make([]*WSMessage, 2)
+		for i, c := range []*ContributorConnection{connA, connB} {
+			done.Add(1)
+			go func(idx int, conn *ContributorConnection) {
+				defer done.Done()
+				start.Wait() // release both goroutines together
+				results[idx] = hub.selectTask(conn)
+			}(i, c)
+		}
+		start.Done()
+		done.Wait()
+
+		assigned := 0
+		var assignedTo string
+		for idx, r := range results {
+			if r != nil && r.Type == "task_assign" {
+				assigned++
+				assignedTo = []string{"ct-a", "ct-b"}[idx]
+				if r.Number != 48 {
+					t.Fatalf("round %d: unexpected issue number %d", round, r.Number)
+				}
+			}
+		}
+		if assigned != 1 {
+			t.Fatalf("round %d: the single issue #48 was handed out %d times (want exactly 1) — the queue double-assigned it (#2644); last winner=%s",
+				round, assigned, assignedTo)
+		}
+
+		// The winner must be recorded as in-flight so the NEXT scan also excludes it.
+		active := hub.activeIssueKeys()
+		if !active["projectbluefin/fsdk-containers#48"] {
+			t.Fatalf("round %d: winner did not register the issue as active — the in-flight guard is not authoritative", round)
+		}
+	}
+}
+
+// TestDupeAssign_CanonicalRepoKeyNormalizesResumedRepo pins the #2644 ROOT CAUSE:
+// the task_progress RESUME path re-populated currentTask.Repo from the raw
+// client-supplied msg.Repo. When a relay reports the repo in any spelling other
+// than the hub's repo.Full, every server key built off currentTask.Repo
+// ("repo#number" — the activeIssues guard AND the cooldowns) missed, so the
+// in-flight issue was NOT excluded and the SAME issue could be handed to a second
+// contributor. canonicalRepoKey maps any client spelling back to repo.Full.
+func TestDupeAssign_CanonicalRepoKeyNormalizesResumedRepo(t *testing.T) {
+	hub, s := covK2Hub(t)
+	singleIssueStatus(s)
+
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"bare name", "fsdk-containers"},
+		{"already full", "projectbluefin/fsdk-containers"},
+		{"case-variant full", "ProjectBluefin/FSDK-Containers"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hub.canonicalRepoKey(tc.input)
+			if got != "projectbluefin/fsdk-containers" {
+				t.Fatalf("canonicalRepoKey(%q) = %q, want the canonical repo.Full %q",
+					tc.input, got, "projectbluefin/fsdk-containers")
+			}
+		})
+	}
+}
+
+// TestDupeAssign_ResumedTaskExcludedFromSelection is the end-to-end #2644 guard:
+// a contributor holds issue #48 whose currentTask.Repo was set on the RESUME path
+// from a bare, non-Full client spelling ("fsdk-containers"). Because that repo is
+// now canonicalised to repo.Full, a SECOND contributor's selectTask must see the
+// issue as in-flight and refuse it (no other issue exists), rather than handing
+// out #48 a second time. Before the fix the bare key never matched the
+// repo.Full-keyed candidate lookup, so #48 was re-offered — the exact bug.
+func TestDupeAssign_ResumedTaskExcludedFromSelection(t *testing.T) {
+	hub, s := covK2Hub(t)
+	singleIssueStatus(s)
+
+	// Holder resumes its task via the task_progress path with a BARE repo spelling,
+	// exactly as the fixed handler does (canonicalRepoKey applied). This mirrors
+	// contribute_ws.go's "task_progress" case.
+	holder := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "holder", ContributorID: "c-h", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	holder.mu.Lock()
+	holder.currentTask = &WSTaskAssign{
+		TaskID: "ct-resumed-48",
+		Kind:   "issue",
+		Repo:   hub.canonicalRepoKey("fsdk-containers"), // bare spelling from the relay
+		Number: 48,
+	}
+	holder.mu.Unlock()
+
+	hub.mu.Lock()
+	hub.connections["conn-holder"] = holder
+	hub.mu.Unlock()
+
+	// The active key the holder registers must be the canonical repo.Full form so
+	// the candidate lookup (also repo.Full-keyed) excludes it.
+	if !hub.activeIssueKeys()["projectbluefin/fsdk-containers#48"] {
+		t.Fatalf("resumed task did not register under the canonical repo.Full key; the in-flight guard would miss it (#2644)")
+	}
+
+	// A second contributor asks for work. #48 is the only issue and it is in-flight,
+	// so the selection must NOT hand it out again.
+	other := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "other", ContributorID: "c-o", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	msg := hub.selectTask(other)
+	if msg != nil && msg.Type == "task_assign" {
+		t.Fatalf("dupe assign: #48 was handed to a second contributor while still held via a resumed task (#2644); got %s#%d",
+			msg.Repo, msg.Number)
+	}
+	if msg == nil || msg.Type != "task_unavailable" {
+		t.Fatalf("expected a task_unavailable no-work ack (the only issue is in-flight), got %+v", msg)
+	}
+}


### PR DESCRIPTION
Fixes #2644

## Confirmed root cause (case 2: key mismatch, via the resume path)

`selectTask`'s offer→claim is already atomic — the whole function runs under the hub-level `selectMu` (contribute_ws.go:1933), and the in-flight scan, candidate pick, and commit to `currentTask` all happen inside that one lock. So cases 1 (non-atomic) and 3 (release-too-early — the disconnect/abandon paths already book a short failure cooldown, #2356/#2435) are not the defect on this branch.

The bug is a **key mismatch introduced on the `task_progress` RESUME path**:

- `contribute_ws.go:1461` (pre-fix) set `currentTask.Repo = msg.Repo` — the **raw, client-supplied** repo string. The relay keeps its task locally across a disconnect and re-asserts it via `task_progress` on reconnect, which is where `currentTask` gets re-populated.
- Every server-side `"repo#number"` key is built off `currentTask.Repo` assuming it equals `repo.Full` (the canonical `owner/repo`):
  - the `activeIssues` double-assign guard — `contribute_ws.go:1993` (stores) vs `:2150` (candidate lookup, keyed on `repo.Full`);
  - the failure/quarantine cooldowns (`recordTaskFailure` at `:1208`/`:1400`/`:852`) and the completion cooldown (`markTaskCompleted` at `:1504`).
- `repo.Full` is `owner/repo` (status_builder.go:862–865), while `issue.Repo` / a relay may carry a bare name or a differently-cased/prefixed cross-org name.

When the relay-reported `msg.Repo` differs from `repo.Full`, the resumed task's key **misses** the `repo.Full`-keyed candidate lookup, so the in-flight issue is **not excluded** and a concurrent `selectTask` hands the SAME issue to a second contributor — the exact #2356/#2492 duplicate re-opened through a key mismatch.

### Why "only in this repo" and intermittent
It only fires (a) across a reconnect that resumes via `task_progress`, and (b) for a repo whose relay-reported name differs from the hub's `repo.Full`. Same-org repos where the relay echoes `owner/repo == Full` are unaffected; a repo like `projectbluefin/fsdk-containers` reported in any other spelling is not de-duplicated. That is precisely the reported symptom — duplicates on `projectbluefin/fsdk-containers#48` only.

## Fix
- Add `canonicalRepoKey(repo)` (contribute_ws.go): maps any client-supplied repo string back to the canonical `repo.Full` — exact-`Full` match, then case-insensitive `Name`/`Full` match against `status.Repos`, then the same org-prefix fallback `buildRepos` uses. Never worse than the raw value as a last resort.
- Apply it on the `task_progress` resume path (`Repo: h.canonicalRepoKey(msg.Repo)`), so the `activeIssues` guard **and** every cooldown key line up with `repo.Full`.

Existing behaviour (cooldowns, skip-assigned, own-work ordering, tier limits) is preserved; only the resumed repo string is normalized.

## Tests (`contribute_ws_dupe_assign_test.go`)
- **`TestDupeAssign_ConcurrentSelectTaskSingleIssue`** — two registered connections call `selectTask` concurrently (gated on a shared barrier) against a candidate set of exactly ONE issue, 200 rounds. Asserts `assigned == 1` every round (the core concurrency assertion) and that the winner registered the canonical active key.
- **`TestDupeAssign_CanonicalRepoKeyNormalizesResumedRepo`** — `canonicalRepoKey` maps bare, full, and case-variant spellings all to `projectbluefin/fsdk-containers`.
- **`TestDupeAssign_ResumedTaskExcludedFromSelection`** — a task resumed with a bare repo spelling is excluded from a second contributor's `selectTask` (returns `task_unavailable`, never a duplicate `task_assign`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)