### PR TITLE
✨ Configurable contribute cooldown (toggle + adjustable period) in Governor + Management

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1863,6 +1863,26 @@ type HubConfig struct {
 	// themselves (or unassigned) is still eligible. Default false preserves the
 	// prior behavior of handing out issues regardless of assignment (#2357).
 	ContributeSkipAssignedToOthers bool `yaml:"contribute_skip_assigned_to_others"`
+	// ContributeCooldownEnabled toggles the POST-COMPLETION cooldown that keeps a
+	// just-worked issue out of the /contribute queue for a while (see
+	// contribute_ws.go markTaskCompleted / isTaskInCooldown). It is a POINTER so
+	// that an absent value (older on-disk config that predates this toggle) means
+	// "unset" and defaults to ENABLED — the prior, backward-compatible behavior.
+	// A non-nil false explicitly DISABLES cooldown gating (no completed issue is
+	// ever excluded from the queue for cooldown; failure quarantine is unaffected
+	// and stays on). Use IsContributeCooldownEnabled() to resolve the effective
+	// value rather than reading the pointer directly.
+	ContributeCooldownEnabled *bool `yaml:"contribute_cooldown_enabled,omitempty"`
+	// ContributeCooldownHours is the WITH-PR completion cooldown period in hours —
+	// the operator-tunable replacement for the hardcoded default of
+	// contributeCooldownDefaultHours (168h / one week). 0 or unset means "use the
+	// default"; any positive value is clamped to
+	// [contributeCooldownMinHours, contributeCooldownMaxHours] in Normalize.
+	// Resolve with ContributeCooldownHoursOrDefault(), never by reading the raw
+	// field (which may legitimately be 0 == default). The short NO-PR cooldown is
+	// left as its own const and is not tuned here (the operator specifically asked
+	// for the week-long period to be adjustable).
+	ContributeCooldownHours int `yaml:"contribute_cooldown_hours,omitempty"`
 	// ContributeQueueOrder is the OPERATOR PRIORITY OVERRIDE for the ready-work
 	// queue: an ordered list of "owner/repo#number" keys the operator dragged to
 	// the front on the Operations tab. When set, these issues are OFFERED FIRST —
@@ -1879,6 +1899,49 @@ type HubConfig struct {
 	DisabledTiers        []string            `yaml:"disabled_tiers"`
 	TierLimits           map[string]TierRate `yaml:"tier_limits"`
 	SnapshotIntervalMin  int                 `yaml:"snapshot_interval_min"`
+}
+
+// Contribute completion-cooldown defaults and clamp bounds. These live in the
+// config package because both the resolver methods below and the Normalize path
+// reference them; the dashboard keeps its own equal DEFAULT const
+// (completedTaskCooldownHours) as the runtime fallback for hubs built without a
+// Config (e.g. direct-in-test construction).
+const (
+	// contributeCooldownDefaultHours is the with-PR completion cooldown used when
+	// ContributeCooldownHours is unset/0 — one week, matching the historical
+	// hardcoded default.
+	contributeCooldownDefaultHours = 168
+	// contributeCooldownMinHours / contributeCooldownMaxHours clamp an
+	// operator-supplied period to a sane range (one hour .. one year) so a stray
+	// value cannot park an issue effectively forever or disable the cooldown by
+	// rounding to zero.
+	contributeCooldownMinHours = 1
+	contributeCooldownMaxHours = 8760
+)
+
+// IsContributeCooldownEnabled resolves the effective on/off state of the
+// post-completion cooldown. A nil pointer (unset, older config) defaults to
+// ENABLED for backward compatibility; an explicit false disables it.
+func (h HubConfig) IsContributeCooldownEnabled() bool {
+	return h.ContributeCooldownEnabled == nil || *h.ContributeCooldownEnabled
+}
+
+// ContributeCooldownHoursOrDefault resolves the with-PR cooldown PERIOD in
+// hours. A value <= 0 (unset) yields the default (contributeCooldownDefaultHours);
+// a positive value is returned as-is (Normalize has already clamped any stored
+// value to the valid range, and this method re-clamps defensively for callers
+// that build a Hub without running Normalize, e.g. tests).
+func (h HubConfig) ContributeCooldownHoursOrDefault() int {
+	if h.ContributeCooldownHours <= 0 {
+		return contributeCooldownDefaultHours
+	}
+	if h.ContributeCooldownHours < contributeCooldownMinHours {
+		return contributeCooldownMinHours
+	}
+	if h.ContributeCooldownHours > contributeCooldownMaxHours {
+		return contributeCooldownMaxHours
+	}
+	return h.ContributeCooldownHours
 }
 
 type TierRate struct {
@@ -2492,6 +2555,17 @@ func (c *Config) applyDefaults() {
 	c.Hub.ContributeTitlesMode = NormalizeFilterMode(c.Hub.ContributeTitlesMode)
 	c.Hub.ContributeAuthorsMode = NormalizeFilterMode(c.Hub.ContributeAuthorsMode)
 	c.Hub.ContributeLabelsMode = NormalizeFilterMode(c.Hub.ContributeLabelsMode)
+
+	// Contribute completion-cooldown period: leave 0 (== "use default") alone, but
+	// clamp any explicitly-set value to [min,max] so a stray input cannot park an
+	// issue effectively forever or round down to disable the cooldown.
+	if c.Hub.ContributeCooldownHours != 0 {
+		if c.Hub.ContributeCooldownHours < contributeCooldownMinHours {
+			c.Hub.ContributeCooldownHours = contributeCooldownMinHours
+		} else if c.Hub.ContributeCooldownHours > contributeCooldownMaxHours {
+			c.Hub.ContributeCooldownHours = contributeCooldownMaxHours
+		}
+	}
 
 	// One-time migration of the old dual label lists into the single list+mode.
 	// If a legacy allow list was set (and no new label list/mode has been chosen

--- a/v2/pkg/config/contribute_cooldown_test.go
+++ b/v2/pkg/config/contribute_cooldown_test.go
@@ -1,0 +1,84 @@
+package config
+
+import "testing"
+
+// TestIsContributeCooldownEnabled_DefaultsOnWhenUnset pins the backward-compatible
+// default: a nil pointer (config that predates the toggle) resolves to ENABLED,
+// while an explicit false disables it and an explicit true enables it.
+func TestIsContributeCooldownEnabled_DefaultsOnWhenUnset(t *testing.T) {
+	trueVal := true
+	falseVal := false
+	cases := []struct {
+		name string
+		ptr  *bool
+		want bool
+	}{
+		{"nil (unset) defaults on", nil, true},
+		{"explicit true", &trueVal, true},
+		{"explicit false", &falseVal, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := HubConfig{ContributeCooldownEnabled: tc.ptr}
+			if got := h.IsContributeCooldownEnabled(); got != tc.want {
+				t.Errorf("IsContributeCooldownEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestContributeCooldownHoursOrDefault covers the resolver: 0/unset -> default
+// (168), a positive in-range value passes through, and out-of-range values are
+// clamped to [min,max].
+func TestContributeCooldownHoursOrDefault(t *testing.T) {
+	cases := []struct {
+		name  string
+		hours int
+		want  int
+	}{
+		{"unset uses default", 0, contributeCooldownDefaultHours},
+		{"negative uses default", -5, contributeCooldownDefaultHours},
+		{"in-range passes through", 24, 24},
+		{"exactly default", 168, 168},
+		{"at min", contributeCooldownMinHours, contributeCooldownMinHours},
+		{"above max clamps down", contributeCooldownMaxHours + 1000, contributeCooldownMaxHours},
+		{"at max", contributeCooldownMaxHours, contributeCooldownMaxHours},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := HubConfig{ContributeCooldownHours: tc.hours}
+			if got := h.ContributeCooldownHoursOrDefault(); got != tc.want {
+				t.Errorf("ContributeCooldownHoursOrDefault(hours=%d) = %d, want %d", tc.hours, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestContributeCooldownHoursNormalizeClamp verifies applyDefaults clamps a
+// persisted out-of-range value into the valid range while leaving 0 ("use
+// default") untouched.
+func TestContributeCooldownHoursNormalizeClamp(t *testing.T) {
+	// 0 is preserved (means "use default"), so the resolver still yields the default.
+	c := &Config{}
+	c.Hub.ContributeCooldownHours = 0
+	c.applyDefaults()
+	if c.Hub.ContributeCooldownHours != 0 {
+		t.Errorf("zero must be preserved as 'use default', got %d", c.Hub.ContributeCooldownHours)
+	}
+
+	// Above max clamps down.
+	c = &Config{}
+	c.Hub.ContributeCooldownHours = contributeCooldownMaxHours + 500
+	c.applyDefaults()
+	if c.Hub.ContributeCooldownHours != contributeCooldownMaxHours {
+		t.Errorf("over-max should clamp to %d, got %d", contributeCooldownMaxHours, c.Hub.ContributeCooldownHours)
+	}
+
+	// Below min (but non-zero) clamps up.
+	c = &Config{}
+	c.Hub.ContributeCooldownHours = -3
+	c.applyDefaults()
+	if c.Hub.ContributeCooldownHours != contributeCooldownMinHours {
+		t.Errorf("sub-min non-zero should clamp to %d, got %d", contributeCooldownMinHours, c.Hub.ContributeCooldownHours)
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3559,6 +3559,13 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			"contribute_allow_models":            cfg.Hub.ContributeAllowModels,
 			"contribute_reject_unknown_models":   cfg.Hub.ContributeRejectUnknownModels,
 			"contribute_skip_assigned_to_others": cfg.Hub.ContributeSkipAssignedToOthers,
+			// Cooldown toggle + period. contribute_cooldown_enabled is the RESOLVED
+			// on/off (nil pointer -> true) so both UI surfaces render a concrete
+			// switch state; contribute_cooldown_hours is the EFFECTIVE period (the
+			// 168h default surfaces when unset) so the number input shows the value
+			// actually in force.
+			"contribute_cooldown_enabled": cfg.Hub.IsContributeCooldownEnabled(),
+			"contribute_cooldown_hours":   cfg.Hub.ContributeCooldownHoursOrDefault(),
 			"disabled_repos":                     cfg.Hub.DisabledRepos,
 			"disabled_tiers":                     cfg.Hub.DisabledTiers,
 			"tier_limits":                        cfg.Hub.TierLimits,
@@ -3982,6 +3989,8 @@ func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 		ContributeAllowModels          []string                   `json:"contribute_allow_models"`
 		ContributeRejectUnknownModels  *bool                      `json:"contribute_reject_unknown_models"`
 		ContributeSkipAssignedToOthers *bool                      `json:"contribute_skip_assigned_to_others"`
+		ContributeCooldownEnabled      *bool                      `json:"contribute_cooldown_enabled"`
+		ContributeCooldownHours        *int                       `json:"contribute_cooldown_hours"`
 		DisabledRepos                  []string                   `json:"disabled_repos"`
 		DisabledTiers                  []string                   `json:"disabled_tiers"`
 		TierLimits                     map[string]config.TierRate `json:"tier_limits"`
@@ -4042,6 +4051,20 @@ func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 	}
 	if body.ContributeSkipAssignedToOthers != nil {
 		cfg.Hub.ContributeSkipAssignedToOthers = *body.ContributeSkipAssignedToOthers
+	}
+	// Cooldown toggle: store the client's on/off intent as a non-nil pointer so it
+	// is round-tripped exactly (nil would default back to enabled). A client that
+	// omits the field leaves the current value untouched.
+	if body.ContributeCooldownEnabled != nil {
+		v := *body.ContributeCooldownEnabled
+		cfg.Hub.ContributeCooldownEnabled = &v
+	}
+	// Cooldown period (hours): stored as-is; the config resolver
+	// (ContributeCooldownHoursOrDefault) clamps to the valid range at read time and
+	// applyDefaults clamps any persisted value, so a stray input can never park an
+	// issue forever. A client sending 0 means "use the default".
+	if body.ContributeCooldownHours != nil {
+		cfg.Hub.ContributeCooldownHours = *body.ContributeCooldownHours
 	}
 	if body.DisabledRepos != nil {
 		cfg.Hub.DisabledRepos = body.DisabledRepos

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -1475,6 +1475,14 @@ update();  // initial paint: copy block + branded UI in sync from first load
 <div class="admin-switch" id="admin-skip-switch" data-key="contribute_skip_assigned_to_others"></div>
 <div><div class="admin-toggle-label">Skip issues assigned to others</div><div class="admin-toggle-sub">Never serve an issue already assigned to a different GitHub user.</div></div>
 </div>
+<div class="admin-toggle">
+<div class="admin-switch" id="admin-cooldown-switch" data-key="contribute_cooldown_enabled"></div>
+<div><div class="admin-toggle-label">Task cooldown</div><div class="admin-toggle-sub">After a task completes with a verified PR, keep that issue out of the queue for the period below. Off = no cooldown gating. Failure quarantine is separate and always on.</div></div>
+</div>
+<div class="admin-field" id="admin-cooldown-hours-wrap" style="margin-left:50px">
+<label>Cooldown period (hours) <span style="color:#6e7681">— 168 = one week (default). Range 1&ndash;8760.</span></label>
+<input type="number" id="admin-cooldown-hours" min="1" max="8760" style="max-width:120px">
+</div>
 
 <hr class="admin-hr">
 <h3 style="font-size:.9rem;color:#e6edf3;margin:0 0 4px">Admission filters</h3>
@@ -1682,6 +1690,12 @@ update();  // initial paint: copy block + branded UI in sync from first load
 // undefined and threw. Declaring+initializing them here — before any function that
 // uses them can run — makes the ordering explicit and regression-proof.
 var ADMIN_TIER_ORDER=['newcomer','contributor','trusted','advisor'];
+// ADMIN_COOLDOWN_DEFAULT_HOURS mirrors the server default (contributeCooldownDefaultHours,
+// 168h = one week) so the period input shows the effective default when unset.
+// ADMIN_COOLDOWN_MIN/MAX_HOURS mirror the server clamp bounds.
+var ADMIN_COOLDOWN_DEFAULT_HOURS=168;
+var ADMIN_COOLDOWN_MIN_HOURS=1;
+var ADMIN_COOLDOWN_MAX_HOURS=8760;
 var ccActivity=[];       // chronological (oldest→newest) activity backlog for the rail
 var ccActivitySeen={};   // dedupe set keyed by ccActivityKey(); shared by poll + SSE
 // Null-guarded addEventListener: a missing element (not yet parsed, or a markup
@@ -2499,6 +2513,18 @@ function renderAdminControls(){
   document.getElementById('admin-suspend-switch').classList.toggle('danger',!!adminHub.contribute_suspended);
   document.getElementById('admin-skip-switch').classList.toggle('on',!!adminHub.contribute_skip_assigned_to_others);
   document.getElementById('admin-reject-switch').classList.toggle('on',!!adminHub.contribute_reject_unknown_models);
+  // Task cooldown: the GET resolves contribute_cooldown_enabled to a concrete
+  // bool (unset -> true), and contribute_cooldown_hours to the EFFECTIVE period
+  // (168 default surfaces when unset), so we render both directly. The period
+  // input is disabled while cooldown is off.
+  var cdOn=(adminHub.contribute_cooldown_enabled!==false);
+  document.getElementById('admin-cooldown-switch').classList.toggle('on',cdOn);
+  var cdHours=document.getElementById('admin-cooldown-hours');
+  if(cdHours){
+    if(document.activeElement!==cdHours)cdHours.value=adminHub.contribute_cooldown_hours||ADMIN_COOLDOWN_DEFAULT_HOURS;
+    cdHours.disabled=!cdOn;
+    cdHours.style.opacity=cdOn?'1':'0.5';
+  }
   renderQueueSuspendControl(!!adminHub.contribute_suspended);
   // Filters (mirror Governor Hub: titles/authors/labels + modes, allow-models).
   renderAdminFilter('admin-filter-titles','Titles','title','contribute_titles_mode','titles');
@@ -2526,6 +2552,29 @@ function bindImmediateToggle(id){
     var patch={};patch[key]=next;
     adminSaveHub(patch,next?'Enabled '+key.replace(/_/g,' '):'Disabled '+key.replace(/_/g,' ')).then(function(ok){
       if(ok){adminHub[key]=next;renderAdminControls();}
+    });
+  });
+}
+
+// bindCooldownHoursInput persists the Task Cooldown PERIOD immediately on change
+// (like the immediate toggles, not the deferred filter Save), through the same
+// governor-hub PUT. The value is clamped client-side to [min,max]; the server
+// clamps again. On success adminHub is updated and both surfaces re-rendered so
+// the Governor Hub tab picks up the new value on its next poll.
+var cooldownHoursBusy=false;
+function bindCooldownHoursInput(){
+  var inp=document.getElementById('admin-cooldown-hours');
+  if(!inp)return;
+  inp.addEventListener('change',function(){
+    if(cooldownHoursBusy||!adminHub)return;
+    var v=parseInt(inp.value,10);
+    if(isNaN(v)||v<ADMIN_COOLDOWN_MIN_HOURS)v=ADMIN_COOLDOWN_MIN_HOURS;
+    if(v>ADMIN_COOLDOWN_MAX_HOURS)v=ADMIN_COOLDOWN_MAX_HOURS;
+    inp.value=v;
+    cooldownHoursBusy=true;
+    adminSaveHub({contribute_cooldown_hours:v},'Cooldown period set to '+v+'h').then(function(ok){
+      cooldownHoursBusy=false;
+      if(ok){adminHub.contribute_cooldown_hours=v;renderAdminControls();}
     });
   });
 }
@@ -2668,6 +2717,8 @@ async function initAdmin(){
   bindImmediateToggle('admin-suspend-switch');
   bindImmediateToggle('admin-skip-switch');
   bindImmediateToggle('admin-reject-switch');
+  bindImmediateToggle('admin-cooldown-switch');
+  bindCooldownHoursInput();
   try{
     // The Governor config GET is what carries the hub.contribute_* fields the
     // Governor Hub dialog edits (GET /api/config, by contrast, is a thin summary

--- a/v2/pkg/dashboard/contribute_cooldown_config_test.go
+++ b/v2/pkg/dashboard/contribute_cooldown_config_test.go
@@ -1,0 +1,88 @@
+package dashboard
+
+import (
+	"testing"
+	"time"
+)
+
+// TestCooldownDisabled_NeverGatesQueue verifies the operator kill-switch: with
+// contribute cooldown DISABLED, a freshly-completed issue (with a verified PR,
+// which would normally earn the full week-long cooldown) is NOT reported as in
+// cooldown, so it is never excluded from the queue. Completion history is still
+// recorded — this only stops cooldown from gating.
+func TestCooldownDisabled_NeverGatesQueue(t *testing.T) {
+	hub, s := covK2Hub(t)
+
+	disabled := false
+	s.deps.Config.Hub.ContributeCooldownEnabled = &disabled
+
+	hub.markTaskCompleted("myorg/repo1", 10, "https://github.com/myorg/repo1/pull/1")
+	if hub.isTaskInCooldown("myorg/repo1", 10) {
+		t.Fatalf("with cooldown disabled, a completed task must NOT be in cooldown")
+	}
+
+	// The completion history is still recorded even though gating is off.
+	hub.completedMu.Lock()
+	_, recorded := hub.completedTasks["myorg/repo1#10"]
+	hub.completedMu.Unlock()
+	if !recorded {
+		t.Fatalf("completion history must still be recorded when cooldown is disabled")
+	}
+}
+
+// TestCooldownEnabled_HonorsConfiguredHours verifies the configured period is
+// applied: with a 24h cooldown, a task completed 25h ago is NOT in cooldown while
+// one completed 23h ago IS. Uses the per-task recorded cooldown (stamped by
+// markTaskCompleted from the configured value).
+func TestCooldownEnabled_HonorsConfiguredHours(t *testing.T) {
+	hub, s := covK2Hub(t)
+
+	// Enabled + a custom 24h period (well below the 168h default).
+	enabled := true
+	s.deps.Config.Hub.ContributeCooldownEnabled = &enabled
+	const customHours = 24
+	s.deps.Config.Hub.ContributeCooldownHours = customHours
+
+	// Sanity: the resolver yields the custom period.
+	if got := s.deps.Config.Hub.ContributeCooldownHoursOrDefault(); got != customHours {
+		t.Fatalf("resolver = %dh, want %dh", got, customHours)
+	}
+
+	// Task A completed 25h ago (> 24h window) → NOT in cooldown.
+	hub.markTaskCompleted("myorg/repo1", 20, "https://github.com/myorg/repo1/pull/2")
+	hub.completedMu.Lock()
+	hub.completedTasks["myorg/repo1#20"] = time.Now().Add(-(customHours + 1) * time.Hour)
+	hub.completedMu.Unlock()
+	if hub.isTaskInCooldown("myorg/repo1", 20) {
+		t.Fatalf("a task completed %dh ago must be past a %dh cooldown", customHours+1, customHours)
+	}
+
+	// Task B completed 23h ago (< 24h window) → still in cooldown.
+	hub.markTaskCompleted("myorg/repo1", 21, "https://github.com/myorg/repo1/pull/3")
+	hub.completedMu.Lock()
+	hub.completedTasks["myorg/repo1#21"] = time.Now().Add(-(customHours - 1) * time.Hour)
+	hub.completedMu.Unlock()
+	if !hub.isTaskInCooldown("myorg/repo1", 21) {
+		t.Fatalf("a task completed %dh ago must still be within a %dh cooldown", customHours-1, customHours)
+	}
+}
+
+// TestCooldownDefault_WhenUnset verifies that with no config override the with-PR
+// cooldown falls back to the historical default (completedTaskCooldownHours): a
+// task completed just now is in cooldown, and a task aged past the default is not.
+func TestCooldownDefault_WhenUnset(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	// No ContributeCooldownEnabled / Hours set → enabled, default 168h.
+	hub.markTaskCompleted("myorg/repo1", 30, "https://github.com/myorg/repo1/pull/4")
+	if !hub.isTaskInCooldown("myorg/repo1", 30) {
+		t.Fatalf("a just-completed task must be in the default cooldown")
+	}
+
+	hub.completedMu.Lock()
+	hub.completedTasks["myorg/repo1#30"] = time.Now().Add(-(completedTaskCooldownHours + 1) * time.Hour)
+	hub.completedMu.Unlock()
+	if hub.isTaskInCooldown("myorg/repo1", 30) {
+		t.Fatalf("a task aged past the default %dh cooldown must be free", completedTaskCooldownHours)
+	}
+}

--- a/v2/pkg/dashboard/contribute_cooldown_ui_test.go
+++ b/v2/pkg/dashboard/contribute_cooldown_ui_test.go
@@ -1,0 +1,68 @@
+package dashboard
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestGovernorHubTabHasCooldownControl pins the "Task cooldown" control (enable
+// toggle + period number input) in the Governor Config Hub tab (embedded
+// static/index.html), mirroring the existing suspend/skip controls. This is the
+// canonical editor; the Management-tab mirror is pinned separately below.
+func TestGovernorHubTabHasCooldownControl(t *testing.T) {
+	html := indexHTML(t)
+	for _, want := range []string{
+		// Enable toggle wired to the same section/key the PUT round-trips.
+		`data-key="contribute_cooldown_enabled"`,
+		`Task Cooldown`,
+		`toggleCooldownEnabled(this)`,
+		`function toggleCooldownEnabled(`,
+		// Period input, marks the hub section dirty so Save PUTs it.
+		`id="hub-cooldown-hours"`,
+		`markDirty('hub','contribute_cooldown_hours'`,
+		`contribute_cooldown_hours`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("Governor Hub tab missing cooldown control markup %q", want)
+		}
+	}
+}
+
+// TestManagementTabHasCooldownControl pins the mirrored "Task cooldown" control
+// in the clanker Management tab (/contribute page), next to the suspend/skip
+// controls. It writes through the SAME /api/config/governor/hub endpoint, so a
+// change on either surface shows on the other on next poll.
+func TestManagementTabHasCooldownControl(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+
+	for _, want := range []string{
+		// Enable toggle — immediate-apply like suspend/skip.
+		`id="admin-cooldown-switch"`,
+		`data-key="contribute_cooldown_enabled"`,
+		`bindImmediateToggle('admin-cooldown-switch')`,
+		// Period input + its immediate-save binding.
+		`id="admin-cooldown-hours"`,
+		`function bindCooldownHoursInput(`,
+		`bindCooldownHoursInput()`,
+		`contribute_cooldown_hours`,
+		// Persists through the SAME endpoint the Governor dialog uses.
+		`/api/config/governor/hub`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("Management tab missing cooldown control markup %q", want)
+		}
+	}
+}

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -591,7 +591,11 @@ func (h *ContributeWSHub) markTaskCompleted(repo string, number int, prURL strin
 	key := fmt.Sprintf("%s#%d", repo, number)
 	cooldown := completedNoPRCooldownHours * time.Hour
 	if prURL != "" {
-		cooldown = completedTaskCooldownHours * time.Hour
+		// The WITH-PR period is operator-tunable (Config.Hub.ContributeCooldownHours,
+		// default completedTaskCooldownHours). We still RECORD this even when cooldown
+		// is disabled — isTaskInCooldown short-circuits the gating, so the history is
+		// kept for stats/audit but never excludes the issue.
+		cooldown = h.configuredWithPRCooldown()
 	}
 	h.completedMu.Lock()
 	h.completedTasks[key] = time.Now()
@@ -680,20 +684,52 @@ func (h *ContributeWSHub) verifyReportedPR(assignedRepo, prURL, contributorUsern
 	return false
 }
 
+// cooldownEnabled reports whether post-completion cooldown gating is turned on
+// for this hive. It reads the operator toggle (Config.Hub.ContributeCooldownEnabled)
+// through the config resolver, which defaults to ENABLED when unset. A hub built
+// without a Config (direct-in-test construction) is treated as enabled so the
+// historical default behavior is preserved.
+func (h *ContributeWSHub) cooldownEnabled() bool {
+	if h.server == nil || h.server.deps == nil || h.server.deps.Config == nil {
+		return true
+	}
+	return h.server.deps.Config.Hub.IsContributeCooldownEnabled()
+}
+
+// configuredWithPRCooldown returns the operator-configured WITH-PR completion
+// cooldown duration. It reads Config.Hub.ContributeCooldownHoursOrDefault() —
+// which yields the 168h default when unset — and falls back to the
+// completedTaskCooldownHours const when no Config is present (tests). It does NOT
+// consider whether cooldown is enabled; callers gate on cooldownEnabled().
+func (h *ContributeWSHub) configuredWithPRCooldown() time.Duration {
+	if h.server == nil || h.server.deps == nil || h.server.deps.Config == nil {
+		return completedTaskCooldownHours * time.Hour
+	}
+	return time.Duration(h.server.deps.Config.Hub.ContributeCooldownHoursOrDefault()) * time.Hour
+}
+
 // cooldownForLocked returns the cooldown duration to apply to key. Callers must
 // already hold completedMu. When no per-task override was recorded (older
-// on-disk entries, or hubs built directly in tests) it falls back to the full
-// completedTaskCooldownHours — the original, conservative default.
+// on-disk entries, or hubs built directly in tests) it falls back to the
+// operator-configured with-PR cooldown (default completedTaskCooldownHours) — the
+// original, conservative default.
 func (h *ContributeWSHub) cooldownForLocked(key string) time.Duration {
 	if h.completedTaskCooldown != nil {
 		if d, ok := h.completedTaskCooldown[key]; ok {
 			return d
 		}
 	}
-	return completedTaskCooldownHours * time.Hour
+	return h.configuredWithPRCooldown()
 }
 
 func (h *ContributeWSHub) isTaskInCooldown(repo string, number int) bool {
+	// Operator kill-switch: when cooldown is disabled, no completed issue is ever
+	// gated out of the queue for cooldown. Completion HISTORY is still recorded by
+	// markTaskCompleted (stats/audit, #2356 duplicate detection) and failure
+	// quarantine is unaffected — this only stops cooldown from EXCLUDING work.
+	if !h.cooldownEnabled() {
+		return false
+	}
 	key := fmt.Sprintf("%s#%d", repo, number)
 	h.completedMu.Lock()
 	defer h.completedMu.Unlock()

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -15163,6 +15163,15 @@ function burnAreaChart() {
           <span class="config-toggle-label">Skip Issues Assigned to Others <span class="config-info">i<span class="config-tooltip">When on, the contribute queue never serves an issue that is already assigned to a different GitHub user, so contributors don't pick up work a maintainer has claimed. Mirrored on the /contribute Management &amp; Operations tab.</span></span></span>
         </div>
 
+        <div class="config-toggle">
+          <div class="config-toggle-switch ${hub.contribute_cooldown_enabled ? 'on' : ''}" onclick="toggleCooldownEnabled(this)" data-section="hub" data-key="contribute_cooldown_enabled"></div>
+          <span class="config-toggle-label">Task Cooldown <span class="config-info">i<span class="config-tooltip">After a task completes WITH a merged/verified PR, keep that issue out of the queue for the period below (default 168h = one week) so it isn't immediately re-offered. Turn off to disable cooldown gating entirely. Failure quarantine is separate and always on. Mirrored on the /contribute Management tab.</span></span></span>
+        </div>
+        <div class="config-field" style="margin-left:44px" ${hub.contribute_cooldown_enabled ? '' : 'title="Enable Task Cooldown to edit the period"'}>
+          <label>Cooldown Period (hours) <span class="config-info">i<span class="config-tooltip">The with-PR completion cooldown, in hours. 168 = one week (default). Range 1–8760.</span></span></label>
+          <input type="number" id="hub-cooldown-hours" min="1" max="8760" value="${hub.contribute_cooldown_hours || 168}" onchange="markDirty('hub','contribute_cooldown_hours',parseInt(this.value,10)||168)" ${hub.contribute_cooldown_enabled ? '' : 'disabled style="opacity:0.5"'}>
+        </div>
+
         ${renderFilterWithMode({
           label: 'Titles', noun: 'title', unit: 'issue',
           modeKey: 'contribute_titles_mode', listKey: 'contribute_deny_titles',
@@ -15268,6 +15277,20 @@ function burnAreaChart() {
             markDirty('hub', 'snapshot_url', snapUrl);
           }
         }
+      }
+    }
+
+    // toggleCooldownEnabled flips the Task Cooldown switch and live-enables/disables
+    // the paired period input (mirrors toggleAutoSnapshot). Marks the section dirty so
+    // Save PUTs contribute_cooldown_enabled through /api/config/governor/hub.
+    function toggleCooldownEnabled(el) {
+      el.classList.toggle('on');
+      var isOn = el.classList.contains('on');
+      markDirty('hub', 'contribute_cooldown_enabled', isOn);
+      var hoursInput = document.getElementById('hub-cooldown-hours');
+      if (hoursInput) {
+        hoursInput.disabled = !isOn;
+        hoursInput.style.opacity = isOn ? '1' : '0.5';
       }
     }
 


### PR DESCRIPTION
## What

The /contribute queue applies a post-completion cooldown so a just-worked issue isn't immediately re-offered. The durations were **hardcoded consts** in `contribute_ws.go` (`completedTaskCooldownHours = 168`). This PR makes the with-PR cooldown **operator-configurable per hive** — a toggle to enable/disable it and an adjustable period — surfaced (mirrored) in **both** the Governor Config Hub tab and the clanker Management tab, exactly like the existing "Suspend contributions" control.

## Config fields (`v2/pkg/config/config.go`)

- **`ContributeCooldownEnabled *bool`** (`contribute_cooldown_enabled`) — a **pointer** so an absent value ("unset", older config) defaults to **ENABLED** (backward-compatible; `nil = on`). Resolver `IsContributeCooldownEnabled()` returns true when nil; an explicit `false` disables cooldown gating.
- **`ContributeCooldownHours int`** (`contribute_cooldown_hours`) — the **with-PR** cooldown period. `0`/unset means "use the default **168h**" (one week). Resolver `ContributeCooldownHoursOrDefault()` returns 168 when `<=0` and clamps to `[1, 8760]`. `applyDefaults` also clamps any persisted non-zero value.

The short **no-PR** (4h) cooldown is left as its own const and is not tuned here — the operator specifically asked for the week-long period.

## Server

- `markTaskCompleted` stamps the **configured** with-PR period (default 168) instead of the const.
- `cooldownForLocked` falls back to the configured period.
- `isTaskInCooldown` returns **false** when cooldown is disabled (no completed issue is ever excluded from the queue for cooldown). Completion **history is still recorded** for stats/audit; it just never gates.
- The consts are kept as the runtime **default fallback** for hubs built without a Config (tests).
- Round-tripped through GET/PUT `/api/config/governor/hub`.

**Failure quarantine is unchanged** — it stays independent and always on (out of scope).

## UI — both surfaces (mirrored)

- **Governor Config → Hub tab** (`static/index.html`): a "Task Cooldown" enable toggle + a "Cooldown Period (hours)" number input (disabled while the toggle is off), saved via the same Hub PUT.
- **Clanker Management tab** (`api_contribute.go`): the mirrored enable toggle (immediate-apply, like suspend/skip) + period input (immediate-save), writing the **same** `/api/config/governor/hub` endpoint — so a change on either surface shows on the other on next poll.

## Tests

- Config resolvers: `IsContributeCooldownEnabled` nil→true / explicit false→false; `ContributeCooldownHoursOrDefault` 0→168 and clamp of out-of-range; `applyDefaults` clamp.
- `isTaskInCooldown` returns false when disabled; honors a custom 24h period (25h-old task NOT in cooldown, 23h-old IS); default-168 fallback when unset.
- UI structure pins that **both** surfaces render the new control.