### PR TITLE
🐛 fix(hub): repair TestAlertAcksPersistRoundTrip on v2

### DIFF
--- a/v2/pkg/hub/alerts_test.go
+++ b/v2/pkg/hub/alerts_test.go
@@ -1119,8 +1119,16 @@ func TestAlertAcksPersistRoundTrip(t *testing.T) {
 	h := baseHive("h1")
 	h.ProvStatus = alertProvStatusError
 
-	evaluateAlerts(s.alerts, []alertHive{h}, nil, fixedNow)
-	if !s.alerts.setAck("h1", AlertTypeProvisionError, "admin", fixedNow) {
+	// The restart path (loadAlertAcks) prunes acks older than alertAckMaxAge
+	// against the real wall clock (time.Now). Anchor the whole scenario to
+	// time.Now so the freshly-created ack is genuinely recent from the load
+	// path's point of view. Using the frozen fixedNow here made the test a
+	// time bomb: once wall time drifted past fixedNow+alertAckMaxAge, load
+	// treated this brand-new ack as expired and dropped it.
+	now := time.Now()
+
+	evaluateAlerts(s.alerts, []alertHive{h}, nil, now)
+	if !s.alerts.setAck("h1", AlertTypeProvisionError, "admin", now) {
 		t.Fatal("setAck failed")
 	}
 	s.saveAlertAcks()
@@ -1132,7 +1140,7 @@ func TestAlertAcksPersistRoundTrip(t *testing.T) {
 	// A fresh server (i.e. a hub restart) must honor the persisted ack.
 	s2 := newTestAlertServer()
 	s2.loadAlertAcks()
-	got := evaluateAlerts(s2.alerts, []alertHive{h}, nil, fixedNow.Add(time.Minute))
+	got := evaluateAlerts(s2.alerts, []alertHive{h}, nil, now.Add(time.Minute))
 	a, ok := findAlert(got.Alerts, "h1", AlertTypeProvisionError)
 	if !ok {
 		t.Fatal("condition should still fire after restart")


### PR DESCRIPTION
## Problem — v2 was RED (coverage gate blocked for every open PR)

The `coverage` / test job on v2 HEAD failed:

```
--- FAIL: TestAlertAcksPersistRoundTrip
    alerts_test.go: an acknowledgement must survive a hub restart
FAIL	github.com/kubestellar/hive/v2/pkg/hub
```

This is on v2 itself, so it blocks the coverage gate for **every open PR** (e.g. #2577).

## Root cause — test-fragile (a time bomb), NOT a production regression

`TestAlertAcksPersistRoundTrip` created and acknowledged a condition at the package-level **frozen** clock `fixedNow = 2026-07-29 12:00 UTC`, persisted it, then simulated a hub restart via `s2.loadAlertAcks()`.

`loadAlertAcks` prunes acks older than `alertAckMaxAge` (**7 days**) against the **real wall clock** (`time.Now()`) — it takes no injected time. Once wall time crossed `fixedNow + 7 days` (i.e. **2026-08-05**), the just-created ack looked expired to the load path and was dropped, so it did not survive the restart and the assertion failed.

The production persistence code is correct: in a running hub, save/load/evaluation all use real `now`, so acks are always recent relative to the load clock. The sibling round-trip test in `alerts_known_types_test.go` drives the real clock end-to-end and was never affected — only this test mixed a frozen creation clock with the real load clock.

## Fix

Anchor the scenario to `time.Now()` so creation, ack, and post-restart evaluation share the same clock reference as `loadAlertAcks`. The test still exercises the full **save → restart → load → evaluate** round trip and asserts the restored ack suppresses the alert count. No production code changed; no assertion loosened.

## Verification (local)

```
go test -race -run TestAlertAcksPersistRoundTrip -count=3 ./pkg/hub/   -> ok
go test ./pkg/hub/                                                     -> ok
```

Once merged, open PRs (#2577 and others) can rebase onto a green v2.