### PR TITLE
✨ Surface cooldown/in-flight counts + cooldown explainer on the contribute queue

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -639,6 +639,19 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 /* Ops "your army" counts + card counts as bold numerals (tabular, no layout shift). */
 .cc-army b{font-weight:700;font-variant-numeric:tabular-nums}
 .ops-card-count.count-strong{color:#e6edf3;font-weight:700;font-variant-numeric:tabular-nums}
+/* Small circled-i info affordance next to a header (cooldown explainer, #2649
+   companion). A borderless button carrying the ⓘ glyph; hover/focus brightens it.
+   The popover is an absolutely-positioned card toggled open by JS (aria-expanded),
+   anchored to the wrapper so it sits just under the glyph. */
+.info-affordance{position:relative;display:inline-flex;align-items:center}
+.info-btn{background:none;border:0;padding:0 2px;margin-left:4px;color:#6e7681;cursor:pointer;font-size:.85rem;line-height:1;vertical-align:middle}
+.info-btn:hover,.info-btn:focus{color:#58a6ff;outline:none}
+.info-pop{position:absolute;top:130%%;left:0;z-index:40;width:300px;max-width:78vw;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:10px 12px;box-shadow:0 8px 24px rgba(1,4,9,.7);color:#c9d1d9;font-size:.74rem;line-height:1.5;font-weight:400;text-align:left;white-space:normal}
+.info-pop[hidden]{display:none}
+.info-pop h4{margin:0 0 4px;font-size:.76rem;color:#e6edf3;font-weight:600}
+.info-pop ul{margin:4px 0 0;padding-left:16px}
+.info-pop li{margin:2px 0}
+.info-pop code{background:#161b22;border:1px solid #21262d;border-radius:4px;padding:0 3px;font-size:.7rem}
 /* Compact tier badge inline next to a connected clanker's identity. */
 .tier-badge.tier-inline{padding:1px 6px 1px 4px;font-size:.62rem;margin-left:6px;vertical-align:middle}
 .tier-badge.tier-inline::before{width:6px;height:6px}
@@ -1482,6 +1495,9 @@ update();  // initial paint: copy block + branded UI in sync from first load
 <div class="admin-field" id="admin-cooldown-hours-wrap" style="margin-left:50px">
 <label>Cooldown period (hours) <span style="color:#6e7681">— 168 = one week (default). Range 1&ndash;8760.</span></label>
 <input type="number" id="admin-cooldown-hours" min="1" max="8760" style="max-width:120px">
+<!-- Live tally of issues currently within their cooldown window (#2649 companion),
+     hydrated by ccRenderCooldownCount from the fleet payload. Hidden when 0. -->
+<div id="admin-cooldown-count" class="admin-toggle-sub" style="margin-top:4px;display:none"></div>
 </div>
 
 <hr class="admin-hr">
@@ -1579,7 +1595,25 @@ update();  // initial paint: copy block + branded UI in sync from first load
 <div class="work-list" id="work-list"><div class="ops-empty">Loading work&hellip;</div></div>
 </div>
 <div class="ops-card card-accent" style="margin-top:20px">
-<div class="ops-card-head"><span class="feed-dot"></span><h3>Ready-work queue</h3><span class="ops-card-count" id="queue-count"></span><!-- 7-day queue-depth trend (#persistent-history), hydrated by ccMetricsPoll --><span class="spark spark-inline" id="spark-queue" title="Ready-work queue depth, last 7 days (hourly)"></span>
+<div class="ops-card-head"><span class="feed-dot"></span><h3>Ready-work queue</h3><span class="ops-card-count" id="queue-count"></span><!-- Cooldown explainer (#2649 companion): a circled-i affordance whose popover
+     explains what "in cooldown" in the count means and how an issue lands there.
+     Numbers here are the REAL server constants (168h with-PR, ~4h no-PR, ~6h
+     quarantine after 3 consecutive failures) — keep them in sync with
+     completedTaskCooldownHours / completedNoPRCooldownHours / quarantineCooldownHours
+     / consecutiveFailureQuarantineThreshold in contribute_ws.go. -->
+<span class="info-affordance">
+<button type="button" class="info-btn" id="cooldown-info-btn" aria-haspopup="true" aria-expanded="false" aria-controls="cooldown-info-pop" aria-label="What is cooldown?" title="What is cooldown?">&#9432;</button>
+<div class="info-pop" id="cooldown-info-pop" role="tooltip" hidden>
+<h4>What is cooldown?</h4>
+Cooldown briefly holds a just-worked issue out of the ready queue so it isn&rsquo;t instantly re-offered while a PR settles. An issue enters cooldown when it is:
+<ul>
+<li>completed <b>with a verified PR</b> &mdash; held for the full cooldown period (default <code>168h</code> / 7 days, configurable in Management &rarr; Task cooldown).</li>
+<li>completed with <b>no PR</b> &mdash; held ~<code>4h</code>.</li>
+<li><b>failed</b> &mdash; a short cooldown; after <code>3</code> consecutive failures the issue is quarantined for ~<code>6h</code>.</li>
+</ul>
+It clears automatically when the period elapses. An operator can shorten or disable the with-PR period in the Management tab.
+</div>
+</span><!-- 7-day queue-depth trend (#persistent-history), hydrated by ccMetricsPoll --><span class="spark spark-inline" id="spark-queue" title="Ready-work queue depth, last 7 days (hourly)"></span>
 <!-- #queue-suspend-btn is the SAME logical control as the Management "Suspend
      contributions" switch (#admin-suspend-switch) — not a related toggle, the
      identical Config.Hub.ContributeSuspended state surfaced a second place. Both
@@ -2357,6 +2391,42 @@ function _wireConfirmModal(){
 }
 if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',_wireConfirmModal);else _wireConfirmModal();
 
+// _wireCooldownInfo toggles the cooldown explainer popover (#2649 companion). The
+// ⓘ button flips the popover's [hidden] + aria-expanded; a click anywhere else or
+// Escape closes it. Null-guarded so a missing element never throws (matching the
+// confirm-modal wiring above).
+function _wireCooldownInfo(){
+  var btn=document.getElementById('cooldown-info-btn');
+  var pop=document.getElementById('cooldown-info-pop');
+  if(!btn||!pop)return;
+  function close(){pop.hidden=true;btn.setAttribute('aria-expanded','false');}
+  btn.addEventListener('click',function(e){
+    e.stopPropagation();
+    var open=pop.hidden;
+    pop.hidden=!open;
+    btn.setAttribute('aria-expanded',open?'true':'false');
+  });
+  document.addEventListener('click',function(e){if(!pop.hidden&&e.target!==btn&&!pop.contains(e.target))close();});
+  document.addEventListener('keydown',function(e){if(e.key==='Escape')close();});
+}
+if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',_wireCooldownInfo);else _wireCooldownInfo();
+
+// ccRenderCooldownCount surfaces the current cooldown tally next to the Management
+// tab's Task cooldown control (#2649): "M issues currently cooling down". It reads
+// the ccCooldownCount stashed by opsPoll and writes into #admin-cooldown-count.
+// Hidden entirely when 0 so the control stays clean.
+function ccRenderCooldownCount(){
+  var el=document.getElementById('admin-cooldown-count');
+  if(!el)return;
+  if(ccCooldownCount>0){
+    el.textContent=ccCooldownCount+(ccCooldownCount===1?' issue currently cooling down':' issues currently cooling down');
+    el.style.display='';
+  }else{
+    el.textContent='';
+    el.style.display='none';
+  }
+}
+
 // Persist a subset of Config.Hub.* through the SAME endpoint the Governor Hub
 // dialog uses. Only the passed keys are sent; the handler ignores omitted fields.
 async function adminSaveHub(patch,okMsg){
@@ -2926,6 +2996,15 @@ async function opsPoll(){
     safeRender('clankers',function(){renderClankers((data&&data.clankers)||[]);});
     safeRender('work',function(){renderWork((data&&data.work)||[]);});
     safeRender('policy',function(){renderPolicy(data&&data.policy);});
+    // Cooldown / in-flight tallies (#2649 companion): stash the read-only counts
+    // from the fleet payload so the ready-queue header can annotate "N ready" with
+    // "M in cooldown / K in flight", and the Management cooldown control can show
+    // how many issues are currently cooling down. Coerced to a number; a missing
+    // field stays 0. A re-render picks up the fresh values.
+    ccCooldownCount=(data&&typeof data.cooldown_count==='number')?data.cooldown_count:0;
+    ccInFlightCount=(data&&typeof data.in_flight_count==='number')?data.in_flight_count:0;
+    safeRender('queue-counts',function(){if(typeof ccRenderQueue==='function')ccRenderQueue();});
+    safeRender('cooldown-count',function(){if(typeof ccRenderCooldownCount==='function')ccRenderCooldownCount();});
   }catch(e){
     // fetch/parse failed — log so the "Loading…" placeholders are diagnosable, and
     // fall through to reschedule so a transient failure self-heals on the next poll.
@@ -2953,6 +3032,8 @@ var ccQueuePollTimer=null; // fallback poll timer
 var ccKnownClankers={};    // username -> true, for enter/leave detection
 var ccCompleteStreak={};   // username -> consecutive completes (achievement combos)
 var ccLastAch=0;           // debounce achievement pops
+var ccCooldownCount=0;     // issues still within cooldown (from fleet payload, #2649)
+var ccInFlightCount=0;     // issues currently held by a live connection (fleet payload)
 
 function ccQueueKey(q){return (q.repo||'')+'#'+(q.number||'');}
 
@@ -2973,7 +3054,15 @@ function ccRenderQueue(flip){
   // every render (initial load, SSE queue push, poll fallback, drag-reorder).
   // Populated FIRST so it stays set even if the queue container is absent.
   var qc=document.getElementById('queue-count');
-  if(qc)qc.textContent=ccQueue.length+' ready';
+  // Header tally: "N ready" plus the read-only cooldown / in-flight segments from
+  // the fleet payload (#2649 companion). A segment is OMITTED when its count is 0
+  // so the header stays compact; " · " (a middot) separates present segments.
+  if(qc){
+    var segs=[ccQueue.length+' ready'];
+    if(ccCooldownCount>0)segs.push(ccCooldownCount+' in cooldown');
+    if(ccInFlightCount>0)segs.push(ccInFlightCount+' in flight');
+    qc.textContent=segs.join(' · ');
+  }
   var el=document.getElementById('cc-queue');if(!el)return;
   // reload bridge — overwritten by the next poll, including to empty.
   ccOpsCacheWrite(OPS_CACHE_QUEUE_KEY,ccQueue);
@@ -4180,13 +4269,21 @@ func (s *Server) buildContributeAdmissionPolicy() ContributeAdmissionPolicy {
 // the hub's live connection state and the already-configured admission policy.
 func (s *Server) handleContributeFleet(w http.ResponseWriter, r *http.Request) {
 	snap := FleetSnapshot{Clankers: []FleetClanker{}, Work: []FleetWorkItem{}}
+	// cooldownCount = completed issues still within their cooldown window (held out
+	// of the queue); inFlightCount = issues currently held by a live connection.
+	// Both are read-only tallies the queue header / Management tab surface (#2649
+	// configurable cooldown).
+	cooldownCount, inFlightCount := 0, 0
 	if s.contributeHub != nil {
 		snap = s.contributeHub.FleetSnapshot()
+		cooldownCount, inFlightCount = s.contributeHub.CooldownCounts()
 	}
 	jsonResponse(w, map[string]any{
-		"clankers": snap.Clankers,
-		"work":     snap.Work,
-		"policy":   s.buildContributeAdmissionPolicy(),
+		"clankers":        snap.Clankers,
+		"work":            snap.Work,
+		"policy":          s.buildContributeAdmissionPolicy(),
+		"cooldown_count":  cooldownCount,
+		"in_flight_count": inFlightCount,
 	})
 }
 

--- a/v2/pkg/dashboard/contribute_cooldown_counts_test.go
+++ b/v2/pkg/dashboard/contribute_cooldown_counts_test.go
@@ -1,0 +1,127 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestCooldownCounts_ReflectsHubState seeds the hub's completedTasks (cooldown set)
+// and live connections (in-flight set) and asserts CooldownCounts() reports the
+// counts the fleet payload surfaces (#2649 companion). Expired-but-not-swept
+// completions must NOT inflate the cooldown count.
+func TestCooldownCounts_ReflectsHubState(t *testing.T) {
+	hub, s := covK2Hub(t)
+
+	enabled := true
+	s.deps.Config.Hub.ContributeCooldownEnabled = &enabled
+	const customHours = 24
+	s.deps.Config.Hub.ContributeCooldownHours = customHours
+
+	// Two issues STILL within the 24h window (completed recently).
+	hub.markTaskCompleted("myorg/repo1", 1, "https://github.com/myorg/repo1/pull/1")
+	hub.markTaskCompleted("myorg/repo1", 2, "https://github.com/myorg/repo1/pull/2")
+
+	// One issue completed 25h ago — EXPIRED, must not count even though its entry is
+	// still present in the map (not yet swept by isTaskInCooldown).
+	hub.markTaskCompleted("myorg/repo1", 3, "https://github.com/myorg/repo1/pull/3")
+	hub.completedMu.Lock()
+	hub.completedTasks["myorg/repo1#3"] = time.Now().Add(-(customHours + 1) * time.Hour)
+	hub.completedMu.Unlock()
+
+	// Two distinct issues held in flight by live connections.
+	hub.mu.Lock()
+	hub.connections["c1"] = &ContributorConnection{
+		currentTask: &WSTaskAssign{Repo: "myorg/repo1", Number: 100},
+	}
+	hub.connections["c2"] = &ContributorConnection{
+		currentTask: &WSTaskAssign{Repo: "myorg/repo1", Number: 101},
+	}
+	hub.mu.Unlock()
+
+	cooldown, inFlight := hub.CooldownCounts()
+	if cooldown != 2 {
+		t.Fatalf("cooldown count = %d, want 2 (two non-expired completions; the 25h-old one must not count)", cooldown)
+	}
+	if inFlight != 2 {
+		t.Fatalf("in-flight count = %d, want 2 (two connections each holding a distinct issue)", inFlight)
+	}
+}
+
+// TestCooldownCounts_DisabledYieldsZero verifies the operator kill-switch: with
+// cooldown disabled, nothing is gated, so the cooldown count is 0 even though the
+// completion history is recorded. In-flight is unaffected.
+func TestCooldownCounts_DisabledYieldsZero(t *testing.T) {
+	hub, s := covK2Hub(t)
+
+	disabled := false
+	s.deps.Config.Hub.ContributeCooldownEnabled = &disabled
+
+	hub.markTaskCompleted("myorg/repo1", 10, "https://github.com/myorg/repo1/pull/10")
+
+	hub.mu.Lock()
+	hub.connections["c1"] = &ContributorConnection{
+		currentTask: &WSTaskAssign{Repo: "myorg/repo1", Number: 200},
+	}
+	hub.mu.Unlock()
+
+	cooldown, inFlight := hub.CooldownCounts()
+	if cooldown != 0 {
+		t.Fatalf("cooldown count = %d, want 0 when cooldown is disabled", cooldown)
+	}
+	if inFlight != 1 {
+		t.Fatalf("in-flight count = %d, want 1", inFlight)
+	}
+}
+
+// TestContributeFleet_IncludesCooldownCounts asserts the /api/contribute/fleet
+// JSON payload carries the cooldown_count / in_flight_count fields reflecting the
+// hub state, so the Operations tab can render them.
+func TestContributeFleet_IncludesCooldownCounts(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.RegisterAPI(testDeps(t)) // also registers the contribute routes + hub
+	hub := s.contributeHub
+
+	enabled := true
+	s.deps.Config.Hub.ContributeCooldownEnabled = &enabled
+
+	hub.markTaskCompleted("myorg/repo1", 1, "https://github.com/myorg/repo1/pull/1")
+	hub.mu.Lock()
+	hub.connections["c1"] = &ContributorConnection{
+		currentTask: &WSTaskAssign{Repo: "myorg/repo1", Number: 100},
+	}
+	hub.mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/fleet", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		CooldownCount *int `json:"cooldown_count"`
+		InFlightCount *int `json:"in_flight_count"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if resp.CooldownCount == nil {
+		t.Fatalf("fleet payload missing cooldown_count: %s", w.Body.String())
+	}
+	if resp.InFlightCount == nil {
+		t.Fatalf("fleet payload missing in_flight_count: %s", w.Body.String())
+	}
+	// The seeded completion is in cooldown (default period) and one issue is in
+	// flight, so both counts are 1.
+	if *resp.CooldownCount != 1 {
+		t.Fatalf("cooldown_count = %d, want 1", *resp.CooldownCount)
+	}
+	if *resp.InFlightCount != 1 {
+		t.Fatalf("in_flight_count = %d, want 1", *resp.InFlightCount)
+	}
+}

--- a/v2/pkg/dashboard/contribute_cooldown_explainer_test.go
+++ b/v2/pkg/dashboard/contribute_cooldown_explainer_test.go
@@ -1,0 +1,99 @@
+package dashboard
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// contributePageBody renders the /contribute page and returns its HTML body.
+func contributePageBody(t *testing.T) string {
+	t.Helper()
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	return w.Body.String()
+}
+
+// TestQueueHeaderRendersCooldownCounts pins the queue-header count wiring: the JS
+// consumes the fleet payload's cooldown/in-flight counts and renders the compact
+// "N ready · M in cooldown · K in flight" segments (each omitted when 0).
+func TestQueueHeaderRendersCooldownCounts(t *testing.T) {
+	body := contributePageBody(t)
+	for _, want := range []string{
+		// State stashed from the fleet payload's new fields.
+		`data.cooldown_count`,
+		`data.in_flight_count`,
+		`var ccCooldownCount`,
+		`var ccInFlightCount`,
+		// The count string segments built in ccRenderQueue.
+		`ready`,
+		`in cooldown`,
+		`in flight`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("queue header count wiring missing %q", want)
+		}
+	}
+}
+
+// TestCooldownInfoButtonAndExplainer pins the ⓘ info affordance next to the
+// queue header and the explainer copy. The copy must state how an issue enters
+// cooldown using the REAL server constants (168h with-PR, ~4h no-PR, ~6h
+// quarantine after 3 consecutive failures) — no invented numbers.
+func TestCooldownInfoButtonAndExplainer(t *testing.T) {
+	body := contributePageBody(t)
+	for _, want := range []string{
+		// The button + popover markup (mirrors title=/aria tooltip patterns).
+		`id="cooldown-info-btn"`,
+		`id="cooldown-info-pop"`,
+		`class="info-btn"`,
+		`What is cooldown?`,
+		`aria-controls="cooldown-info-pop"`,
+		// The wiring that toggles the popover.
+		`function _wireCooldownInfo(`,
+		// Explainer substance: what cooldown is + how an issue enters it.
+		`out of the ready queue`,
+		`verified PR`,
+		`no PR`,
+		`quarantined`,
+		`clears automatically`,
+		// The REAL constants, verbatim.
+		`168h`,
+		`4h`,
+		`6h`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("cooldown info button / explainer missing %q", want)
+		}
+	}
+	// The "3 consecutive failures" threshold must appear in the failure line. The
+	// glyph is rendered as an HTML entity, so pin the code-styled constant instead.
+	if !strings.Contains(body, `<code>3</code>`) {
+		t.Errorf("explainer must reference the 3-consecutive-failures quarantine threshold")
+	}
+}
+
+// TestManagementTabShowsCooldownCount pins the Management-tab tally element and
+// its renderer (#2649 companion): "M issues currently cooling down".
+func TestManagementTabShowsCooldownCount(t *testing.T) {
+	body := contributePageBody(t)
+	for _, want := range []string{
+		`id="admin-cooldown-count"`,
+		`function ccRenderCooldownCount(`,
+		`currently cooling down`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("Management-tab cooldown count missing %q", want)
+		}
+	}
+}

--- a/v2/pkg/dashboard/contribute_ops_rail_polish_test.go
+++ b/v2/pkg/dashboard/contribute_ops_rail_polish_test.go
@@ -178,10 +178,15 @@ func TestReadyWorkQueueHeaderHasCount(t *testing.T) {
 	if headOpen < 0 {
 		t.Fatal(`could not locate the "Ready-work queue" header`)
 	}
-	// The header line: h3, then the new count span, then the pre-existing live pill.
-	headEnd := strings.Index(body[headOpen:], "</div>")
+	// The header (.ops-card-head) contains, in order: the h3, the count span, the
+	// cooldown info-affordance (which nests its OWN <div> tooltip), the queue-depth
+	// sparkline, the suspend control, and the cc-live pill — then the header's
+	// closing </div>. A naive "first </div>" bound stops inside the nested info-pop
+	// tooltip, truncating before cc-live; so bound the header slice at the search
+	// wrap that immediately follows the header instead (robust to nested divs).
+	headEnd := strings.Index(body[headOpen:], `class="cc-q-search"`)
 	if headEnd < 0 {
-		t.Fatal("could not locate the end of the Ready-work queue header")
+		t.Fatal("could not locate the end of the Ready-work queue header (cc-q-search wrap)")
 	}
 	headHTML := body[headOpen : headOpen+headEnd]
 

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -1156,6 +1156,42 @@ func (h *ContributeWSHub) FleetSnapshot() FleetSnapshot {
 	return snap
 }
 
+// CooldownCounts returns two read-only tallies the Operations/Management tabs
+// surface next to the ready queue (see handleContributeFleet):
+//
+//   - cooldown: how many completed issues are STILL within their cooldown window
+//     and therefore held out of selection. It counts only NON-expired entries in
+//     completedTasks (an entry past its cooldownForLocked() period is expired-but-
+//     not-yet-swept and must not inflate the count — it matches what
+//     isTaskInCooldown would actually gate). When cooldown is disabled by the
+//     operator kill-switch (cooldownEnabled()==false), nothing is gated, so this
+//     is 0.
+//   - inFlight: how many distinct issues are currently held by a live
+//     connection — reuses activeIssueKeys(), the SAME set selectTask uses as its
+//     double-assign guard and ReadyQueue uses to exclude in-flight work.
+//
+// Read-only: it mutates nothing (unlike isTaskInCooldown it does not sweep
+// expired entries) and adds no enforcement.
+func (h *ContributeWSHub) CooldownCounts() (cooldown, inFlight int) {
+	// cooldown: count non-expired completedTasks under the completion lock. When the
+	// operator kill-switch disables cooldown, nothing is gated, so the count is 0.
+	if h.cooldownEnabled() {
+		h.completedMu.Lock()
+		for key, t := range h.completedTasks {
+			if time.Since(t) <= h.cooldownForLocked(key) {
+				cooldown++
+			}
+		}
+		h.completedMu.Unlock()
+	}
+
+	// inFlight: distinct issues held by a live connection — the same activeIssues
+	// set selectTask's guard and ReadyQueue use, so the header count matches what is
+	// actually excluded from "ready".
+	inFlight = len(h.activeIssueKeys())
+	return cooldown, inFlight
+}
+
 func (h *ContributeWSHub) ActiveConnections() []ContributorConnection {
 	h.mu.RLock()
 	defer h.mu.RUnlock()


### PR DESCRIPTION
Complements #2649 (configurable cooldown). Surfaces the read-only cooldown / in-flight tallies the contribute WS hub already tracks, and adds an ⓘ info affordance explaining what cooldown is and how an issue lands in one.

## Server — new payload fields

`ContributeWSHub.CooldownCounts()` returns `(cooldown, inFlight)`:

- **`cooldown_count`** — completed issues STILL within their cooldown window. Counts only non-expired entries in `completedTasks` (read under `completedMu`, using `cooldownForLocked` expiry) so an expired-but-not-yet-swept entry does not inflate it, matching what `isTaskInCooldown` actually gates. `0` when the operator kill-switch (`cooldownEnabled()==false`) disables cooldown.
- **`in_flight_count`** — distinct issues currently held by a live connection. Reuses `activeIssueKeys()`, the SAME set `selectTask`'s double-assign guard and `ReadyQueue` use, so the header count matches what is actually excluded from "ready".

Both are added to the `GET /api/contribute/fleet` JSON as top-level fields `cooldown_count` / `in_flight_count`. Read-only; mutates nothing.

## UI — Operations tab

Queue header count string (populated in `ccRenderQueue`, hydrated from the fleet poll):

```
N ready · M in cooldown · K in flight
```

Each of the cooldown/in-flight segments is **omitted when its count is 0**, so the header stays compact (a lone "N ready" when nothing is cooling/in-flight).

## UI — ⓘ info button + explainer

A circled-i affordance next to the "Ready-work queue" header toggles a popover (click to open, click-away / Esc to close; `aria-expanded`/`aria-controls`). Copy, using the REAL server constants:

- Cooldown briefly holds a just-worked issue **out of the ready queue** so it isn't instantly re-offered.
- How an issue enters cooldown:
  - completed **with a verified PR** → full cooldown period (default **168h / 7 days**, configurable in Management → Task cooldown)
  - completed with **no PR** → held **~4h**
  - **failed** → short cooldown; after **3** consecutive failures → quarantined **~6h**
- Clears automatically when the period elapses; operator can shorten/disable it in Management.

Numbers mirror `completedTaskCooldownHours` (168), `completedNoPRCooldownHours` (4), `quarantineCooldownHours` (6), `consecutiveFailureQuarantineThreshold` (3).

## UI — Management tab

Next to the #2649 Task cooldown control: **"M issues currently cooling down"** (`ccRenderCooldownCount`), hidden when 0.

## Tests

- **Go**: `CooldownCounts()` reflects seeded `completedTasks`/connections (expired completion excluded; disabled → 0); `/api/contribute/fleet` payload includes `cooldown_count`/`in_flight_count` with the right values.
- **Dashboard-structure**: pins the queue-header count wiring/segments, the ⓘ button + popover markup, the explainer copy incl. the real constants, and the Management-tab tally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)