### PR TITLE
✨ feat(contribute): label-affinity queue — surface matching issues to interested contributors

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -161,10 +161,20 @@ type ContributorProfile struct {
 	LastActive        string                `json:"last_active,omitempty"`
 	LastCompletedTask *WSTaskAssign         `json:"last_completed_task,omitempty"`
 	RateLimits        ContributorRateLimits `json:"rate_limits"`
-	Active            bool                  `json:"active,omitempty"`
-	CurrentTask       *WSTaskAssign         `json:"current_task,omitempty"`
-	ActiveTasks       []WSTaskAssign        `json:"active_tasks,omitempty"`
-	Sessions          int                   `json:"sessions,omitempty"`
+	// LabelInterests is the contributor's OPT-IN list of GitHub issue labels they
+	// want to help with (issue #2637) — e.g. a contributor with an NVIDIA machine
+	// subscribes to "nvidia" so nvidia-labelled work surfaces first for them. It is
+	// a SOFT signal only: the Operations ready-work queue highlights and sorts
+	// matching issues to the front FOR THIS VIEWER, but never hard-filters the
+	// queue, so a contributor with no interests set (or an issue with no labels) is
+	// never starved of work. Matching is exact on the label NAME, case-insensitive.
+	// Stored here (the existing per-contributor profile store) rather than in a new
+	// subsystem; empty/omitted for contributors who set none.
+	LabelInterests []string       `json:"label_interests,omitempty"`
+	Active         bool           `json:"active,omitempty"`
+	CurrentTask    *WSTaskAssign  `json:"current_task,omitempty"`
+	ActiveTasks    []WSTaskAssign `json:"active_tasks,omitempty"`
+	Sessions       int            `json:"sessions,omitempty"`
 }
 
 type ContributorRateLimits struct {
@@ -249,6 +259,13 @@ func (s *Server) registerContributeRoutes() {
 	// enforced IN-HANDLER via requireContributorWrite because the /api/contribute
 	// prefix is exempt from roleEnforcement's read-only block (see that helper).
 	s.mux.HandleFunc("PUT /api/contribute/queue/order", s.handleContributeQueueOrder)
+	// Contributor-owned LABEL INTERESTS (#2637): a contributor's opt-in list of
+	// GitHub labels they can help with, used to surface/prioritise matching issues
+	// FOR THEM on the Operations queue. Self-service (identity resolved server-side,
+	// never a client param), so a contributor reads/writes only their OWN interests;
+	// it is a preference, not an operator control. GET reads, PUT replaces.
+	s.mux.HandleFunc("GET /api/contribute/interests", s.handleContributeInterests)
+	s.mux.HandleFunc("PUT /api/contribute/interests", s.handleContributeInterests)
 	s.mux.HandleFunc("GET /api/contributors", s.handleContributorsList)
 	s.mux.HandleFunc("GET /api/contributors/{id}", s.handleContributorGet)
 	s.mux.HandleFunc("PUT /api/contributors/{id}/trust", s.handleContributorTrust)
@@ -882,6 +899,33 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .cc-q-search.has-text .cc-q-search-clear{display:inline-flex}
 .cc-q-search-clear:hover{color:#c9d1d9}
 .cc-q-filternote{padding:6px 20px;font-size:.72rem;color:#6e7681;border-bottom:1px solid #21262d}
+/* ── My label interests (#2637) — contributor-declared label affinity ───────────
+   A quiet self-service editor on the queue card: chips for the labels this viewer
+   subscribed to, plus an add field. Shown only to a signed-in contributor. Matching
+   queue rows are highlighted (.cc-q-mine) and a small "for you" tag explains why.
+   Sober palette to match the SRE ops register; the page's green accent marks a
+   personal match without shouting. */
+.cc-interests{padding:10px 20px;border-bottom:1px solid #21262d}
+.cc-interests-head{display:flex;flex-wrap:wrap;align-items:baseline;gap:8px;margin-bottom:6px}
+.cc-interests-title{font-size:.74rem;font-weight:700;letter-spacing:.03em;text-transform:uppercase;color:#8b949e}
+.cc-interests-hint{font-size:.68rem;color:#6e7681}
+.cc-interests-chips{display:flex;flex-wrap:wrap;gap:5px;margin-bottom:6px}
+.cc-interests-empty{font-size:.72rem;color:#6e7681}
+.cc-interests-empty code{background:#161b22;border:1px solid #30363d;border-radius:4px;padding:0 4px;font-size:.9em}
+.cc-interest-chip{display:inline-flex;align-items:center;gap:5px;padding:2px 9px;border-radius:999px;font-size:.74rem;background:rgba(46,160,67,.12);color:#3fb950;border:1px solid rgba(46,160,67,.3)}
+.cc-interest-x{cursor:pointer;opacity:.7;font-size:.95rem;line-height:1}
+.cc-interest-x:hover{opacity:1}
+.cc-interests-add{display:flex;gap:6px}
+.cc-interests-add input{flex:1;min-width:0;background:#0d1117;border:1px solid #30363d;border-radius:7px;color:#e6edf3;font:inherit;font-size:.8rem;padding:5px 9px;outline:none;transition:border-color .15s,box-shadow .15s}
+.cc-interests-add input::placeholder{color:#6e7681}
+.cc-interests-add input:focus{border-color:#1f6feb;box-shadow:0 0 0 3px rgba(31,111,235,.25)}
+.cc-interests-add button{background:#161b22;border:1px solid #30363d;border-radius:7px;color:#c9d1d9;cursor:pointer;font:inherit;font-size:.78rem;padding:5px 12px}
+.cc-interests-add button:hover{border-color:#3fb950;color:#3fb950}
+/* A queue row matching one of the viewer's label interests: a soft green rail on
+   the leading edge + faint tint. Never hides the row — pure emphasis. */
+.cc-q-item.cc-q-mine{background:rgba(46,160,67,.06);box-shadow:inset 3px 0 0 0 #2ea043}
+.cc-q-item.cc-q-mine:first-child{background:rgba(46,160,67,.1)}
+.cc-q-mine-tag{margin-left:7px;font-size:.6rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#3fb950;background:rgba(46,160,67,.12);border:1px solid rgba(46,160,67,.3);border-radius:999px;padding:0 6px;vertical-align:middle}
 /* Per-row "⋯" context affordance — owner/read-write only (rendered only when
    adminEnabled). Sits at the row's trailing edge, quiet until hover/open. */
 .cc-q-menu-wrap{position:relative;flex-shrink:0;margin-left:auto;align-self:center}
@@ -1601,6 +1645,22 @@ update();  // initial paint: copy block + branded UI in sync from first load
   <button type="button" class="cc-q-search-clear" id="cc-q-search-clear" aria-label="Clear filter" title="Clear filter">&times;</button>
 </div>
 <div class="cc-q-filternote" id="cc-q-filternote" style="display:none"></div>
+<!-- My label interests (#2637): a signed-in contributor's OPT-IN set of labels they
+     can help with. Matching issues are highlighted and floated to the top of THIS
+     viewer's queue. Soft signal — nothing is filtered out, so leaving it empty just
+     shows the shared queue. Hidden until the viewer is known to have a contributor
+     profile (populated by ccApplyInterests from the /api/contribute/queue response). -->
+<div class="cc-interests" id="cc-interests" style="display:none">
+  <div class="cc-interests-head">
+    <span class="cc-interests-title">My label interests</span>
+    <span class="cc-interests-hint">Issues with these labels are highlighted and shown first for you. Soft signal &mdash; nothing else is hidden.</span>
+  </div>
+  <div class="cc-interests-chips" id="cc-interests-chips"></div>
+  <div class="cc-interests-add">
+    <input type="text" id="cc-interests-input" placeholder="e.g. nvidia" aria-label="Add a label interest" autocomplete="off" spellcheck="false">
+    <button type="button" id="cc-interests-add-btn">Add</button>
+  </div>
+</div>
 <div class="cc-queue" id="cc-queue"><div class="ops-empty">Loading queue&hellip;</div></div>
 <!-- End-of-queue block (#2595): a calm "all caught up" marker + the hive's managed
      rate-limit settings + the viewer's daily quota. Rendered by ccRenderQueueEnd()
@@ -2954,6 +3014,116 @@ var ccKnownClankers={};    // username -> true, for enter/leave detection
 var ccCompleteStreak={};   // username -> consecutive completes (achievement combos)
 var ccLastAch=0;           // debounce achievement pops
 
+// ── Label-affinity (#2637): the viewer's own label interests ───────────────────
+// ccInterests is this viewer's opt-in label list (normalised lower-case). Loaded
+// from /api/contribute/queue's "interests" echo (and the dedicated interests GET)
+// when the viewer has a contributor profile; null means "not a known contributor"
+// (or not loaded yet) so we hide the editor. It is a SOFT signal: we re-tag the
+// queue client-side so matches highlight/float even on the anonymous SSE snapshot,
+// but we NEVER drop a row — a viewer with no interests sees the shared queue as-is.
+var ccInterests=null;
+// ccInterestSet mirrors ccInterests as a lookup set for O(1) per-label matching.
+var ccInterestSet={};
+function ccRebuildInterestSet(){
+  ccInterestSet={};
+  (ccInterests||[]).forEach(function(l){var n=(l||'').trim().toLowerCase();if(n)ccInterestSet[n]=true;});
+}
+// ccItemMatchesInterests tags one queue item with matches_interest by comparing its
+// labels (exact, case-insensitive) against the viewer's interest set. Mirrors the
+// server rule so the client view agrees with a personalised /api/contribute/queue.
+function ccItemMatchesInterests(q){
+  var labels=q.labels||[];
+  for(var i=0;i<labels.length;i++){
+    if(ccInterestSet[(labels[i]||'').trim().toLowerCase()])return true;
+  }
+  return false;
+}
+// ccApplyInterestsToQueue re-tags every item's matches_interest and STABLY floats
+// matches to the front — mirroring the server's personalizeQueueByInterests so the
+// view is identical whether the queue arrived via the personalised poll or the
+// anonymous SSE snapshot. No-op (order untouched) when the viewer set no interests:
+// the anti-starvation guarantee holds client-side too.
+function ccApplyInterestsToQueue(){
+  for(var i=0;i<ccQueue.length;i++){ccQueue[i].matches_interest=ccItemMatchesInterests(ccQueue[i]);}
+  var keys=Object.keys(ccInterestSet);
+  if(!keys.length)return; // nothing to promote; leave order exactly as-is
+  // Stable partition: matches first, keeping each group's relative order.
+  var matched=[],rest=[];
+  for(var j=0;j<ccQueue.length;j++){(ccQueue[j].matches_interest?matched:rest).push(ccQueue[j]);}
+  ccQueue=matched.concat(rest);
+}
+
+// ── My-label-interests editor (#2637) ──────────────────────────────────────────
+// The editor is shown ONLY to a viewer with a contributor profile (ccInterests is
+// a real array, even if empty). ccApplyInterestsFromResponse is called with the
+// "interests" field the personalised /api/contribute/queue returns; a present array
+// means "known contributor" → show + render the editor.
+function ccApplyInterestsFromResponse(interests){
+  if(!Array.isArray(interests))return; // anonymous / no profile: leave hidden
+  ccInterests=interests.slice();
+  ccRebuildInterestSet();
+  ccRenderInterests();
+}
+function ccRenderInterests(){
+  var wrap=document.getElementById('cc-interests');if(!wrap)return;
+  if(ccInterests===null){wrap.style.display='none';return;}
+  wrap.style.display='';
+  var chips=document.getElementById('cc-interests-chips');
+  if(chips){
+    if(!ccInterests.length){
+      chips.innerHTML='<span class="cc-interests-empty">No interests yet &mdash; add a label (like <code>nvidia</code>) to have matching issues surfaced first for you.</span>';
+    }else{
+      chips.innerHTML=ccInterests.map(function(l){
+        return '<span class="cc-interest-chip">'+esc(l)+'<span class="cc-interest-x" data-label="'+esc(l)+'" title="Remove" role="button" aria-label="Remove '+esc(l)+'">&times;</span></span>';
+      }).join('');
+      var xs=chips.querySelectorAll('.cc-interest-x');
+      for(var i=0;i<xs.length;i++){(function(x){x.addEventListener('click',function(){ccRemoveInterest(x.getAttribute('data-label'));});})(xs[i]);}
+    }
+  }
+}
+function ccAddInterestFromInput(){
+  var inp=document.getElementById('cc-interests-input');if(!inp)return;
+  var v=(inp.value||'').trim().toLowerCase();
+  inp.value='';
+  if(!v||ccInterests===null)return;
+  if(ccInterests.indexOf(v)>=0)return; // already present
+  var next=ccInterests.concat([v]);
+  ccSaveInterests(next);
+}
+function ccRemoveInterest(label){
+  if(ccInterests===null)return;
+  var next=ccInterests.filter(function(l){return l!==label;});
+  ccSaveInterests(next);
+}
+// ccSaveInterests PUTs the new set and, on success, adopts the server-sanitised
+// result (the server is the authority on normalisation/dedupe/cap), then re-renders
+// the editor AND the queue so highlights/order update immediately.
+function ccSaveInterests(next){
+  fetch('/api/contribute/interests',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({interests:next})})
+    .then(function(r){return r.ok?r.json():null;})
+    .then(function(d){
+      if(d&&Array.isArray(d.interests)){ccInterests=d.interests.slice();}
+      else{ccInterests=next;} // optimistic fallback if the body was unexpected
+      ccRebuildInterestSet();
+      ccRenderInterests();
+      ccRenderQueue(); // re-tag + re-float with the new interests
+    })
+    .catch(function(){});
+}
+function ccInitInterestsEditor(){
+  var btn=document.getElementById('cc-interests-add-btn');
+  if(btn)btn.addEventListener('click',ccAddInterestFromInput);
+  var inp=document.getElementById('cc-interests-input');
+  if(inp)inp.addEventListener('keydown',function(e){if(e.key==='Enter'){e.preventDefault();ccAddInterestFromInput();}});
+  // Seed interests from the personalised queue endpoint (which echoes them for a
+  // known contributor). A dedicated GET is unnecessary — the queue we already poll
+  // carries them — but this initial fetch guarantees the editor appears even before
+  // the first SSE/poll render.
+  fetch('/api/contribute/queue').then(function(r){return r.json();}).then(function(d){
+    if(d)ccApplyInterestsFromResponse(d.interests);
+  }).catch(function(){});
+}
+
 function ccQueueKey(q){return (q.repo||'')+'#'+(q.number||'');}
 
 // ccQueueSearch is the current VIEW filter text (lower-cased). It changes only what
@@ -2970,10 +3140,14 @@ function ccQueueMatches(q){
 }
 function ccRenderQueue(flip){
   // Item count badge, same style as "My work"'s #work-count — kept in sync on
-  // every render (initial load, SSE queue push, poll fallback, drag-reorder).
-  // Populated FIRST so it stays set even if the queue container is absent.
+  // every render path. Populated FIRST so it stays set even if the container is absent.
+  // (The interest re-float below only reorders ccQueue, never changes its length.)
   var qc=document.getElementById('queue-count');
   if(qc)qc.textContent=ccQueue.length+' ready';
+  // Label-affinity (#2637): re-tag + float this viewer's interested items. No-op
+  // when no interests are set (order preserved); skipped mid-drag so an operator
+  // reorder is not fought by an interest re-float. See ccApplyInterestsToQueue.
+  if(!flip){try{ccApplyInterestsToQueue();}catch(e){}}
   var el=document.getElementById('cc-queue');if(!el)return;
   // reload bridge — overwritten by the next poll, including to empty.
   ccOpsCacheWrite(OPS_CACHE_QUEUE_KEY,ccQueue);
@@ -3014,8 +3188,14 @@ function ccRenderQueue(flip){
     // only when adminEnabled). Carries move-to-top + move-to-position, both keyed on
     // this row's qkey so they act on the right item in the FULL order.
     var menu=adminEnabled?ccQueueMenuHTML(ccQueueKey(q),i,total):'';
-    return '<div class="cc-q-item"'+(canDrag?' draggable="true"':'')+' data-qkey="'+esc(ccQueueKey(q))+'">'+grip+'<span class="cc-q-idx">'+(i+1)+'</span>'+
-      '<div class="cc-q-body"><div class="cc-q-repo">'+ccIssueLinkHTML(q,(q.repo||'')+'#'+(q.number||''))+'</div>'+
+    // Label-affinity (#2637): the server sets matches_interest per VIEWER when one
+    // of the issue's labels matches a label this contributor subscribed to. Tag the
+    // row so CSS can highlight it; a small "for you" pill makes the reason explicit.
+    var mine=!!q.matches_interest;
+    var mineCls=mine?' cc-q-mine':'';
+    var mineTag=mine?'<span class="cc-q-mine-tag" title="Matches one of your label interests">for you</span>':'';
+    return '<div class="cc-q-item'+mineCls+'"'+(canDrag?' draggable="true"':'')+' data-qkey="'+esc(ccQueueKey(q))+'">'+grip+'<span class="cc-q-idx">'+(i+1)+'</span>'+
+      '<div class="cc-q-body"><div class="cc-q-repo">'+ccIssueLinkHTML(q,(q.repo||'')+'#'+(q.number||''))+mineTag+'</div>'+
       '<div class="cc-q-title" title="'+esc(q.title||'')+'">'+esc(q.title||'(untitled)')+'</div>'+labels+'</div>'+next+menu+'</div>';
   }).join('');
   if(filtering&&shown===0){el.innerHTML='<div class="ops-empty">No queued items match &ldquo;'+esc(ccQueueSearch)+'&rdquo;.</div>';}
@@ -3520,7 +3700,11 @@ function ccHydrate(payload){
 }
 function ccQueuePoll(){ // fallback when SSE is down: refresh queue only
   fetch('/api/contribute/queue').then(function(r){return r.json();}).then(function(d){
-    if(d&&d.queue){ccQueue=d.queue.slice();ccRenderQueue();}
+    if(!d)return;
+    // Adopt the viewer's interests the personalised endpoint echoes (#2637) so the
+    // editor + highlights stay current even without a separate fetch.
+    ccApplyInterestsFromResponse(d.interests);
+    if(d.queue){ccQueue=d.queue.slice();ccRenderQueue();}
   }).catch(function(){});
   ccQueuePollTimer=setTimeout(ccQueuePoll,6000);
 }
@@ -3541,6 +3725,7 @@ function ccStart(){
   // poll. Both are independent of the SSE lifecycle: a throw here must not block the
   // live queue stream, so each is guarded.
   try{ccInitQueueSearch();}catch(e){console.error('queue search init failed',e);}
+  try{ccInitInterestsEditor();}catch(e){console.error('interests editor init failed',e);}
   try{ccStartOpportunistic();}catch(e){console.error('opportunistic init failed',e);}
   if(!('EventSource' in window)){ccSetLive('poll');ccQueuePoll();return;}
   function connect(){
@@ -4200,7 +4385,106 @@ func (s *Server) handleContributeQueue(w http.ResponseWriter, r *http.Request) {
 	if s.contributeHub != nil {
 		queue = s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
 	}
-	jsonResponse(w, map[string]any{"queue": queue})
+	resp := map[string]any{"queue": queue}
+	// Label-affinity (#2637): if we can identify the viewer server-side and they
+	// have declared label interests, personalise THIS response — tag matching
+	// issues and float them to the front for them. Soft signal only: nothing is
+	// filtered out, so a viewer with no interests (or none identifiable) gets the
+	// exact shared queue. Resolved from session / X-Hive-User (never a client
+	// param), so a viewer only ever personalises with their OWN interests.
+	if username := s.resolveViewerUsername(r); username != "" {
+		if profile := findContributor(username); profile != nil {
+			personalizeQueueByInterests(queue, profile.LabelInterests)
+			// Echo the viewer's own interests so the Operations tab can render the
+			// editor pre-filled without a second round-trip.
+			resp["interests"] = profile.LabelInterests
+		}
+	}
+	jsonResponse(w, resp)
+}
+
+// maxLabelInterests caps how many label interests one contributor may declare. It
+// is generous (a contributor could reasonably follow many hardware/area labels)
+// yet bounds a hostile payload so a single profile file cannot be bloated. A
+// submission over the cap is truncated, not rejected, so the save still succeeds.
+const maxLabelInterests = 64
+
+// maxLabelInterestLen bounds a single label string. GitHub labels are short; this
+// is well above any real label yet stops a pathological entry from bloating the
+// stored profile. Over-length entries are dropped.
+const maxLabelInterestLen = 128
+
+// handleContributeInterests is the contributor-owned read/write for their OWN
+// label interests (#2637). GET returns the caller's current interests; PUT
+// replaces them. Identity is resolved server-side (session / X-Hive-User / owner
+// token / Bearer gh-token) via resolveContributeCaller — NEVER from the body — so
+// a contributor can only ever read or write THEIR OWN interests, and an anonymous
+// caller gets 401. This is a self-service PREFERENCE, not an operator control, so
+// it deliberately does NOT require write-tier; any registered contributor may set
+// what work they want surfaced to them.
+func (s *Server) handleContributeInterests(w http.ResponseWriter, r *http.Request) {
+	username := s.resolveContributeCaller(r)
+	if username == "" {
+		jsonError(w, "Sign in with GitHub to set your label interests.", http.StatusUnauthorized)
+		return
+	}
+	profile := findContributor(username)
+	if profile == nil {
+		jsonError(w, "You need a contributor profile on this hive before you can set label interests.", http.StatusForbidden)
+		return
+	}
+
+	if r.Method == http.MethodGet {
+		interests := profile.LabelInterests
+		if interests == nil {
+			interests = []string{}
+		}
+		jsonResponse(w, map[string]any{"interests": interests})
+		return
+	}
+
+	// PUT: replace the caller's interests with the submitted (sanitised) set.
+	var body struct {
+		Interests []string `json:"interests"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonError(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	cleaned := sanitizeLabelInterests(body.Interests)
+	profile.LabelInterests = cleaned
+	if err := saveContributorProfile(profile); err != nil {
+		s.logger.Error("failed to save contributor label interests", "username", username, "error", err)
+		jsonError(w, "could not save label interests", http.StatusInternalServerError)
+		return
+	}
+	s.logger.Info("contributor label interests updated", "username", username, "count", len(cleaned))
+	jsonResponse(w, map[string]any{"interests": cleaned})
+}
+
+// sanitizeLabelInterests normalises a submitted interest list: trims/lower-cases
+// each entry (so matching is predictable and case-insensitive), drops blanks and
+// over-length entries, de-duplicates while preserving first-seen order, and caps
+// the total. It never errors — a hostile or messy payload is cleaned into a safe
+// stored set rather than rejected.
+func sanitizeLabelInterests(in []string) []string {
+	out := make([]string, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for _, raw := range in {
+		n := normalizeLabelInterest(raw)
+		if n == "" || len(n) > maxLabelInterestLen {
+			continue
+		}
+		if _, dup := seen[n]; dup {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+		if len(out) >= maxLabelInterests {
+			break
+		}
+	}
+	return out
 }
 
 // handleContributeOpportunistic serves the read-only OPPORTUNISTIC WORK list

--- a/v2/pkg/dashboard/contribute_label_affinity_test.go
+++ b/v2/pkg/dashboard/contribute_label_affinity_test.go
@@ -1,0 +1,413 @@
+package dashboard
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// ── Label-affinity (#2637) tests ───────────────────────────────────────────────
+//
+// These cover the matching/sort logic (pure, no HTTP), the personalised queue
+// endpoint, and the contributor-owned interests endpoint. The invariant under
+// test throughout is the SOFT-SIGNAL contract: matches are highlighted and floated
+// to the front, but nothing is ever removed — a no-interests viewer and a
+// no-labels issue are never starved.
+
+// qItem is a tiny helper to build a ReadyQueueItem with labels for the pure tests.
+func qItem(repo string, number int, labels ...string) ReadyQueueItem {
+	return ReadyQueueItem{Repo: repo, Number: number, Title: "issue", Labels: labels}
+}
+
+// keysOf renders the queue as "repo#number" keys so order assertions read clearly.
+func keysOf(items []ReadyQueueItem) []string {
+	out := make([]string, len(items))
+	for i, it := range items {
+		out[i] = itKey(it)
+	}
+	return out
+}
+
+func itKey(it ReadyQueueItem) string {
+	return it.Repo + "#" + strconv.Itoa(it.Number)
+}
+
+// TestIssueMatchesInterests_ExactCaseInsensitive proves the matching rule: exact
+// label-name match, case-insensitive and whitespace-trimmed — NOT substring.
+func TestIssueMatchesInterests_ExactCaseInsensitive(t *testing.T) {
+	set := labelInterestSet([]string{"nvidia", "  Good First Issue "})
+
+	cases := []struct {
+		name   string
+		labels []string
+		want   bool
+	}{
+		{"exact match", []string{"nvidia"}, true},
+		{"case-insensitive match", []string{"NVIDIA"}, true},
+		{"whitespace-trimmed interest matches", []string{"good first issue"}, true},
+		{"no match", []string{"amd"}, false},
+		{"substring must NOT match", []string{"nvidia-docs"}, false},
+		{"issue with no labels never matches", nil, false},
+		{"one of several labels matches", []string{"amd", "nvidia"}, true},
+	}
+	for _, c := range cases {
+		if got := issueMatchesInterests(c.labels, set); got != c.want {
+			t.Errorf("%s: issueMatchesInterests(%v) = %v, want %v", c.name, c.labels, got, c.want)
+		}
+	}
+}
+
+// TestIssueMatchesInterests_EmptyInterestsNeverMatches proves an empty interest set
+// matches nothing (the seed of the anti-starvation guarantee).
+func TestIssueMatchesInterests_EmptyInterestsNeverMatches(t *testing.T) {
+	empty := labelInterestSet(nil)
+	if issueMatchesInterests([]string{"nvidia"}, empty) {
+		t.Fatal("empty interest set must not match any label")
+	}
+	if issueMatchesInterests(nil, empty) {
+		t.Fatal("empty interest set + no labels must not match")
+	}
+}
+
+// TestPersonalizeQueue_FloatsMatchesStably proves matching issues are tagged and
+// STABLY floated to the front, with both the matching and non-matching groups
+// keeping their prior relative order (a pure view reorder).
+func TestPersonalizeQueue_FloatsMatchesStably(t *testing.T) {
+	q := []ReadyQueueItem{
+		qItem("r", 1, "amd"),
+		qItem("r", 2, "nvidia"),
+		qItem("r", 3), // no labels
+		qItem("r", 4, "docs", "nvidia"),
+		qItem("r", 5, "amd"),
+	}
+	personalizeQueueByInterests(q, []string{"nvidia"})
+
+	got := keysOf(q)
+	want := []string{"r#2", "r#4", "r#1", "r#3", "r#5"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v", got, want)
+		}
+	}
+	// The two matching items carry the flag; the rest do not.
+	if !q[0].MatchesInterest || !q[1].MatchesInterest {
+		t.Error("floated items must be tagged MatchesInterest")
+	}
+	for _, it := range q[2:] {
+		if it.MatchesInterest {
+			t.Errorf("non-matching item %s must not be tagged", itKey(it))
+		}
+	}
+}
+
+// TestPersonalizeQueue_EmptyInterestsNoStarvation proves the anti-starvation
+// contract on the sort path: a viewer with no interests gets the queue UNCHANGED
+// (same items, same order) — nothing is dropped or reordered.
+func TestPersonalizeQueue_EmptyInterestsNoStarvation(t *testing.T) {
+	orig := []ReadyQueueItem{
+		qItem("r", 1, "amd"),
+		qItem("r", 2, "nvidia"),
+		qItem("r", 3),
+	}
+	q := append([]ReadyQueueItem(nil), orig...)
+	personalizeQueueByInterests(q, nil)
+
+	if len(q) != len(orig) {
+		t.Fatalf("no-interests must not change queue length: got %d want %d", len(q), len(orig))
+	}
+	for i := range orig {
+		if itKey(q[i]) != itKey(orig[i]) {
+			t.Fatalf("no-interests must preserve order: got %v want %v", keysOf(q), keysOf(orig))
+		}
+		if q[i].MatchesInterest {
+			t.Errorf("no-interests must not tag any item (%s tagged)", itKey(q[i]))
+		}
+	}
+}
+
+// TestPersonalizeQueue_NoLabelIssueStaysEligible proves a label-less issue is never
+// removed by personalisation — it just sorts behind matches, still present.
+func TestPersonalizeQueue_NoLabelIssueStaysEligible(t *testing.T) {
+	q := []ReadyQueueItem{
+		qItem("r", 1), // no labels
+		qItem("r", 2, "nvidia"),
+	}
+	personalizeQueueByInterests(q, []string{"nvidia"})
+	if len(q) != 2 {
+		t.Fatalf("no item may be dropped: got %d want 2", len(q))
+	}
+	found := false
+	for _, it := range q {
+		if it.Number == 1 {
+			found = true
+			if it.MatchesInterest {
+				t.Error("label-less issue must not be tagged as a match")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("label-less issue was starved (removed) — anti-starvation violated")
+	}
+}
+
+// TestSanitizeLabelInterests normalises, dedupes, caps, and drops bad entries.
+func TestSanitizeLabelInterests(t *testing.T) {
+	in := []string{"NVIDIA", "  nvidia ", "", "   ", "amd", "AMD"}
+	got := sanitizeLabelInterests(in)
+	want := []string{"nvidia", "amd"}
+	if len(got) != len(want) {
+		t.Fatalf("sanitize = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sanitize = %v, want %v", got, want)
+		}
+	}
+
+	// Cap: more than maxLabelInterests entries are truncated.
+	big := make([]string, maxLabelInterests+10)
+	for i := range big {
+		big[i] = "label-" + strconv.Itoa(i)
+	}
+	if n := len(sanitizeLabelInterests(big)); n != maxLabelInterests {
+		t.Fatalf("cap not enforced: got %d want %d", n, maxLabelInterests)
+	}
+
+	// Over-length entries are dropped.
+	long := make([]byte, maxLabelInterestLen+1)
+	for i := range long {
+		long[i] = 'x'
+	}
+	if n := len(sanitizeLabelInterests([]string{string(long)})); n != 0 {
+		t.Fatalf("over-length label not dropped: got %d", n)
+	}
+}
+
+// ── HTTP: personalised queue + interests endpoints ─────────────────────────────
+
+// seedLabeledActionable builds a status where each issue carries the given label
+// set, so the personalised queue endpoint has real labels to match against.
+func seedLabeledActionable(repo string, labelsByNumber map[int][]string) *StatusPayload {
+	issues := make([]any, 0, len(labelsByNumber))
+	// Deterministic scan order: numbers ascending.
+	for n := 1; n <= len(labelsByNumber); n++ {
+		labs, ok := labelsByNumber[n]
+		if !ok {
+			continue
+		}
+		anyLabs := make([]any, len(labs))
+		for i, l := range labs {
+			anyLabs[i] = l
+		}
+		issues = append(issues, map[string]any{
+			"number": float64(n),
+			"title":  "issue " + strconv.Itoa(n),
+			"labels": anyLabs,
+		})
+	}
+	return &StatusPayload{Repos: []FrontendRepo{{Name: repo, Full: repo, ActionableIssues: issues}}}
+}
+
+func seedInterestProfile(t *testing.T, username string, interests []string) {
+	t.Helper()
+	p := &ContributorProfile{
+		GitHubUsername: username,
+		ContributorID:  "c-" + username,
+		TrustTier:      "newcomer",
+		RegisteredAt:   time.Now().UTC().Format(time.RFC3339),
+		LabelInterests: interests,
+	}
+	if err := saveContributorProfile(p); err != nil {
+		t.Fatalf("save profile: %v", err)
+	}
+}
+
+// TestQueueEndpoint_PersonalisedForViewer proves the queue endpoint floats a
+// signed-in contributor's interested issues to the front and echoes their
+// interests, while an ANONYMOUS caller gets the plain shared order (no starvation,
+// no personalisation leak).
+func TestQueueEndpoint_PersonalisedForViewer(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	s.statusMu.Lock()
+	s.status = seedLabeledActionable("projectbluefin/common", map[int][]string{
+		1: {"amd"},
+		2: {"nvidia"},
+		3: {}, // no labels
+	})
+	s.statusMu.Unlock()
+
+	seedInterestProfile(t, "gpuperson", []string{"nvidia"})
+
+	// Signed-in viewer: nvidia issue floats first, interests echoed.
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/queue", nil)
+	req.Header.Set("X-Hive-User", "gpuperson")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Queue     []ReadyQueueItem `json:"queue"`
+		Interests []string         `json:"interests"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(resp.Queue) != 3 {
+		t.Fatalf("no item may be dropped by personalisation: got %d want 3", len(resp.Queue))
+	}
+	if resp.Queue[0].Number != 2 || !resp.Queue[0].MatchesInterest {
+		t.Fatalf("nvidia issue must float first and be tagged; got %+v", resp.Queue[0])
+	}
+	if len(resp.Interests) != 1 || resp.Interests[0] != "nvidia" {
+		t.Fatalf("interests must be echoed: got %v", resp.Interests)
+	}
+
+	// Anonymous viewer: plain shared scan order (1,2,3), no matches_interest.
+	anon := httptest.NewRequest(http.MethodGet, "/api/contribute/queue", nil)
+	aw := httptest.NewRecorder()
+	s.mux.ServeHTTP(aw, anon)
+	var ar struct {
+		Queue     []ReadyQueueItem `json:"queue"`
+		Interests []string         `json:"interests"`
+	}
+	if err := json.Unmarshal(aw.Body.Bytes(), &ar); err != nil {
+		t.Fatalf("invalid anon JSON: %v", err)
+	}
+	if len(ar.Queue) != 3 {
+		t.Fatalf("anon queue must have all 3 items, got %d", len(ar.Queue))
+	}
+	if ar.Queue[0].Number != 1 {
+		t.Fatalf("anon queue must be plain scan order (1 first), got %d", ar.Queue[0].Number)
+	}
+	for _, it := range ar.Queue {
+		if it.MatchesInterest {
+			t.Error("anon queue must never carry matches_interest")
+		}
+	}
+	if len(ar.Interests) != 0 {
+		t.Errorf("anon response must not echo interests, got %v", ar.Interests)
+	}
+}
+
+// TestQueueEndpoint_NoInterestsNoStarvation proves a signed-in contributor who set
+// NO interests still gets the full queue in the plain shared order.
+func TestQueueEndpoint_NoInterestsNoStarvation(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	s.statusMu.Lock()
+	s.status = seedLabeledActionable("projectbluefin/common", map[int][]string{
+		1: {"amd"}, 2: {"nvidia"}, 3: {},
+	})
+	s.statusMu.Unlock()
+	seedInterestProfile(t, "noprefs", nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/queue", nil)
+	req.Header.Set("X-Hive-User", "noprefs")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var resp struct {
+		Queue []ReadyQueueItem `json:"queue"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Queue) != 3 {
+		t.Fatalf("no-interests contributor must see all 3 items, got %d", len(resp.Queue))
+	}
+	if resp.Queue[0].Number != 1 {
+		t.Fatalf("no-interests contributor must see plain scan order, got first=%d", resp.Queue[0].Number)
+	}
+}
+
+// TestInterestsEndpoint_GetPutRoundTrip proves a contributor can read and replace
+// their OWN interests, and that the store persists a sanitised set.
+func TestInterestsEndpoint_GetPutRoundTrip(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+	seedInterestProfile(t, "editor", nil)
+
+	// PUT a messy set; server sanitises (lower-case, dedupe).
+	put := httptest.NewRequest(http.MethodPut, "/api/contribute/interests",
+		bytes.NewBufferString(`{"interests":["NVIDIA"," nvidia ","amd"]}`))
+	put.Header.Set("Content-Type", "application/json")
+	put.Header.Set("X-Hive-User", "editor")
+	pw := httptest.NewRecorder()
+	s.mux.ServeHTTP(pw, put)
+	if pw.Code != http.StatusOK {
+		t.Fatalf("PUT expected 200, got %d: %s", pw.Code, pw.Body.String())
+	}
+	var pr struct {
+		Interests []string `json:"interests"`
+	}
+	_ = json.Unmarshal(pw.Body.Bytes(), &pr)
+	if len(pr.Interests) != 2 || pr.Interests[0] != "nvidia" || pr.Interests[1] != "amd" {
+		t.Fatalf("PUT must return sanitised set, got %v", pr.Interests)
+	}
+
+	// It persisted to the profile store.
+	prof := findContributor("editor")
+	if prof == nil || len(prof.LabelInterests) != 2 {
+		t.Fatalf("interests not persisted to profile: %+v", prof)
+	}
+
+	// GET reads them back.
+	get := httptest.NewRequest(http.MethodGet, "/api/contribute/interests", nil)
+	get.Header.Set("X-Hive-User", "editor")
+	gw := httptest.NewRecorder()
+	s.mux.ServeHTTP(gw, get)
+	if gw.Code != http.StatusOK {
+		t.Fatalf("GET expected 200, got %d", gw.Code)
+	}
+	var gr struct {
+		Interests []string `json:"interests"`
+	}
+	_ = json.Unmarshal(gw.Body.Bytes(), &gr)
+	if len(gr.Interests) != 2 {
+		t.Fatalf("GET must return the 2 stored interests, got %v", gr.Interests)
+	}
+}
+
+// TestInterestsEndpoint_AnonymousRejected proves an anonymous caller cannot read or
+// write interests (identity is server-side, never a body param).
+func TestInterestsEndpoint_AnonymousRejected(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/contribute/interests",
+		bytes.NewBufferString(`{"interests":["nvidia"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("anonymous PUT must be 401, got %d", w.Code)
+	}
+}
+
+// TestInterestsEndpoint_NoProfileForbidden proves a signed-in caller WITHOUT a
+// contributor profile is told to register first (403), not silently no-op'd.
+func TestInterestsEndpoint_NoProfileForbidden(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/contribute/interests",
+		bytes.NewBufferString(`{"interests":["nvidia"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-User", "stranger")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("no-profile PUT must be 403, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/v2/pkg/dashboard/contribute_sse.go
+++ b/v2/pkg/dashboard/contribute_sse.go
@@ -72,6 +72,13 @@ type ReadyQueueItem struct {
 	Title  string   `json:"title"`
 	URL    string   `json:"url,omitempty"`
 	Labels []string `json:"labels,omitempty"`
+	// MatchesInterest is set true, per VIEWER, when at least one of the issue's
+	// labels exactly matches (case-insensitive) a label the viewing contributor
+	// declared interest in (issue #2637). It is a SOFT signal the Operations tab
+	// uses to highlight and float this row for that viewer; it is NEVER set on the
+	// shared/anonymous queue snapshot (no viewer identity there) and NEVER used to
+	// exclude an item. omitempty so the anonymous payload is byte-for-byte unchanged.
+	MatchesInterest bool `json:"matches_interest,omitempty"`
 }
 
 // sseSubscriber is one connected browser. events is the fan-out channel; done is
@@ -439,4 +446,89 @@ func sortReadyQueue(items []ReadyQueueItem) {
 		}
 		return items[i].Number < items[j].Number
 	})
+}
+
+// ── Label-affinity: contributor-declared label interests (#2637) ───────────────
+//
+// A contributor opts in to a set of label names they can help with (e.g. an
+// NVIDIA-machine owner subscribes to "nvidia"). The Operations ready-work queue
+// then, FOR THAT VIEWER ONLY, tags matching issues and floats them to the front.
+// This is a SOFT signal — a personalised VIEW over the same admissible set — never
+// a filter: nothing is removed, so a contributor with no interests, or an issue
+// with no labels, is never starved. The shared/anonymous queue is untouched.
+//
+// Matching rule (chosen for predictability): an issue matches when at least one of
+// its GitHub labels equals — case-insensitively, after trimming surrounding
+// whitespace — a label the viewer declared. Exact NAME match, not substring, so a
+// "gpu" interest does not silently sweep in "gpu-docs" and the contributor gets
+// exactly the labels they asked for.
+
+// normalizeLabelInterest lower-cases and trims one label string so interest
+// matching is case-insensitive and whitespace-insensitive. Empty after trimming
+// means "not a real interest" and callers drop it.
+func normalizeLabelInterest(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// labelInterestSet builds a lookup set of normalised interest labels from a
+// contributor's declared list, dropping blanks and de-duplicating. A nil/empty
+// input yields an empty (non-nil) set, so callers can range/lookup without a nil
+// guard and "no interests" naturally matches nothing (→ no reordering).
+func labelInterestSet(interests []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(interests))
+	for _, in := range interests {
+		if n := normalizeLabelInterest(in); n != "" {
+			set[n] = struct{}{}
+		}
+	}
+	return set
+}
+
+// issueMatchesInterests reports whether any of an issue's labels exactly matches
+// (case-insensitively) a label in the interest set. An empty interest set or a
+// label-less issue returns false — the anti-starvation contract: a non-match is
+// never excluded, it simply is not promoted.
+func issueMatchesInterests(labels []string, interests map[string]struct{}) bool {
+	if len(interests) == 0 {
+		return false
+	}
+	for _, l := range labels {
+		if _, ok := interests[normalizeLabelInterest(l)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// personalizeQueueByInterests annotates each item with MatchesInterest for the
+// given viewer and STABLY floats matching items to the front, preserving the
+// established (operator-pinned + scan) relative order WITHIN the matching group and
+// WITHIN the non-matching group. It mutates items in place and returns the same
+// slice for convenience.
+//
+// Soft-signal guarantees:
+//   - Empty interests → no item matches → order is unchanged (stable sort with a
+//     constant key is a no-op), so a contributor who set nothing sees the exact
+//     shared queue: NO STARVATION.
+//   - A label-less issue never matches, but is never removed — it keeps its place
+//     behind any matches and remains fully eligible.
+//   - Only OFFER PRIORITY in THIS VIEWER'S view changes; the persisted operator
+//     order and every other viewer's queue are untouched (this runs per-request on
+//     a copy the handler owns). A matching item may rise above an operator-pinned
+//     non-match for this viewer — that is the intended personalisation and is
+//     view-only, never written back.
+func personalizeQueueByInterests(items []ReadyQueueItem, interests []string) []ReadyQueueItem {
+	set := labelInterestSet(interests)
+	for i := range items {
+		items[i].MatchesInterest = issueMatchesInterests(items[i].Labels, set)
+	}
+	if len(set) == 0 {
+		return items // fast path: nothing to promote, order untouched
+	}
+	// Stable partition: matches first, everything else after, each group keeping its
+	// prior relative order. SliceStable with a boolean "!match" key does exactly this.
+	sort.SliceStable(items, func(i, j int) bool {
+		return items[i].MatchesInterest && !items[j].MatchesInterest
+	})
+	return items
 }


### PR DESCRIPTION
Fixes #2637

## What & why

The reporter (an AMD-machine owner) wants the contribute Operations queue to prioritise work by hardware/area label — e.g. `nvidia`-labelled issues surfaced to contributors with NVIDIA hardware. Their own suggestion: *"tell the contributors to subscribe to certain labels and hive takes that into account."*

This PR implements exactly that contributor-side slice: a contributor declares an **opt-in list of label interests**, and the Operations **Ready-work queue** highlights and floats matching issues to the front **for that viewer**.

## Design (soft signal, no starvation)

- **Soft signal, never a hard filter.** Matching issues are tagged and sorted to the front *for that viewer only*; nothing is ever removed. A contributor with **no interests set**, or an issue with **no labels**, is never excluded — no one is starved of work. The persisted operator order and every other viewer's queue are untouched (personalisation is per-request on the response).
- **Matching rule:** exact match on the label **name**, case-insensitive and whitespace-trimmed. Chosen over substring for predictability — a `gpu` interest does not silently sweep in `gpu-docs`.
- **Personalisation seam:** the shared SSE `hello` snapshot is anonymous (broadcast), so it's untouched. `GET /api/contribute/queue` resolves the viewer server-side (session / `X-Hive-User`, never a client param — same pattern as `/api/contribute/limits`) and personalises there; the Operations tab re-applies the same rule client-side so highlights are consistent regardless of transport.

## Extended vs added

**Extended (no new persistence subsystem):**
- `ContributorProfile` gains `LabelInterests []string`, stored in the existing per-contributor profile store.
- `ReadyQueueItem` gains `MatchesInterest bool` (`omitempty`; never set on the anonymous snapshot, so that payload is unchanged).
- `GET /api/contribute/queue` personalises for an identifiable viewer and echoes their interests.

**Added:**
- `personalizeQueueByInterests` + matching helpers (`contribute_sse.go`) — pure, stable, in-place.
- `GET`/`PUT /api/contribute/interests` — self-service; identity resolved server-side via `resolveContributeCaller` (never the body), so a contributor reads/writes only **their own** interests. It's a preference, not an operator control, so it doesn't require write-tier — any registered contributor may set it. Anonymous → 401; signed-in without a profile → 403. Submissions are sanitised (lower-cased, trimmed, de-duped, length- and count-capped).

## Operations UI addition

On the **Ready-work queue** card, below the search filter, a small **"My label interests"** panel (shown only to a signed-in contributor): green chips per subscribed label with an inline remove, plus an add field. Matching rows get a soft green leading rail and a "for you" pill. Composes with the existing drag/⋯ reorder controls (#2644/#2648 dedupe untouched — this reorders the *view*, never assignment).

## Out of scope (follow-up)

A **hive-manager-driven routing/assignment** version (the manager *ensures* nvidia issues go to nvidia contributors, touching `selectTask`) is a larger change. This slice is the contributor-side, opt-in affinity the reporter proposed, surfaced read-only in the queue view — it never gates or assigns work.

## Tests

`contribute_label_affinity_test.go`:
- Matching rule: exact / case-insensitive / whitespace-trimmed; substring must NOT match; empty interests and label-less issues never match.
- Sort: matches float stably to the front; **empty interests → order unchanged** (no starvation); **label-less issue stays eligible** (never dropped).
- Sanitisation: normalise, dedupe, cap, drop over-length.
- HTTP: personalised queue for a signed-in viewer (nvidia floats first + interests echoed) vs anonymous (plain order, no `matches_interest`, no echo); no-interests contributor sees the full plain queue; interests GET/PUT round-trip + persistence; anonymous 401; no-profile 403.

Full `go test ./pkg/dashboard/...` passes.
