### PR TITLE
🔒 fix(contribute): re-arm token_refresh on task resume after reconnect (#2610)

### DIFF
--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -1490,6 +1490,11 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			if contributor != nil {
 				contributor.mu.Lock()
 				contributor.tmuxOutput = msg.TmuxOutput
+				// resumed is true only when this task_progress REBUILT currentTask
+				// from nothing — i.e. the relay is re-asserting a task the hub had
+				// released on disconnect (the reconnect/resume path), not a routine
+				// progress ping for a task the hub already tracks.
+				resumed := false
 				if contributor.currentTask == nil && msg.TaskID != "" {
 					contributor.currentTask = &WSTaskAssign{
 						TaskID: msg.TaskID,
@@ -1506,8 +1511,23 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 						Number: msg.Number,
 						Title:  msg.Title,
 					}
+					resumed = true
 				}
 				contributor.mu.Unlock()
+
+				// #2610 finding 3: the disconnect defer clears tokenMintedAt, and
+				// this resume path historically rebuilt currentTask WITHOUT re-arming
+				// it. tokenRefreshDue treats a zero tokenMintedAt as "not due", so
+				// maybeRefreshToken on the heartbeat became a permanent no-op for the
+				// resumed connection — the task kept the token minted at its original
+				// assignment and it expired at wsTokenTTL (55m) with no 50-minute
+				// replacement, the exact silent-expiry case the refresh path was added
+				// for (#2393 item 2). Re-mint and push a fresh token_refresh here so
+				// the resumed session both holds a valid token and re-arms the refresh
+				// cycle (resumeTaskToken sets tokenMintedAt on a successful send).
+				if resumed {
+					h.resumeTaskToken(contributor)
+				}
 			}
 
 		case "task_complete":
@@ -1703,6 +1723,39 @@ func (h *ContributeWSHub) maybeRefreshToken(c *ContributorConnection) {
 	}
 
 	h.logger.Info("[contribute-ws] token refreshed for active task",
+		"username", c.profile.GitHubUsername, "tier", tier)
+}
+
+// resumeTaskToken re-mints a scoped GitHub token for a task that has just been
+// re-asserted over a reconnect (task_progress rebuilt currentTask) and pushes it
+// to the relay, which re-arms the heartbeat refresh cycle: sendTokenRefresh
+// records tokenMintedAt on success, so the subsequent maybeRefreshToken calls see
+// a non-zero mint time and fire again. Without this the resumed session's
+// tokenMintedAt stays zero (cleared by the disconnect defer) and refresh never
+// fires again for the life of the connection (#2610 finding 3). A mint failure or
+// an empty token (no App auth / no cache) leaves the relay's existing token in
+// place — the same lenient policy maybeRefreshToken uses — and tokenMintedAt stays
+// zero, so the next reconnect (or a later mint success) can still arm it.
+func (h *ContributeWSHub) resumeTaskToken(c *ContributorConnection) {
+	tier := ""
+	if c.profile != nil {
+		tier = c.profile.TrustTier
+	}
+	tok, err := h.mintScopedToken(tier)
+	if err != nil {
+		h.logger.Warn("[contribute-ws] resume token refresh: mint failed, refresh will re-arm on next resume/heartbeat",
+			"username", c.profile.GitHubUsername, "tier", tier, "error", err)
+		return
+	}
+	if tok == "" {
+		// No new token available: leave the relay's existing token in place.
+		return
+	}
+	if err := h.sendTokenRefresh(c, tok); err != nil {
+		h.logger.Info("[contribute-ws] resume token refresh: send failed", "username", c.profile.GitHubUsername, "error", err)
+		return
+	}
+	h.logger.Info("[contribute-ws] token refreshed on task resume (re-armed refresh cycle)",
 		"username", c.profile.GitHubUsername, "tier", tier)
 }
 

--- a/v2/pkg/dashboard/contribute_ws_token_refresh_test.go
+++ b/v2/pkg/dashboard/contribute_ws_token_refresh_test.go
@@ -1,16 +1,64 @@
 package dashboard
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/gorilla/websocket"
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
 )
+
+// newSucceedingAppAuth builds a real *ghpkg.AppAuth whose JWT generation succeeds
+// (valid RSA key) and whose CreateInstallationToken call hits a stub server that
+// returns the given token, so ScopedToken — and therefore mintScopedToken —
+// yields it deterministically and offline. This is the succeeding counterpart to
+// newFailingAppAuth, used to exercise the mint+send paths (e.g. the #2610 finding
+// 3 resume re-arm) without any real GitHub App.
+func newSucceedingAppAuth(t *testing.T, token string) *ghpkg.AppAuth {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	keyFile := filepath.Join(t.TempDir(), "app-key.pem")
+	if err := os.WriteFile(keyFile, pemBytes, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// POST /app/installations/{id}/access_tokens → an installation token.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		exp := time.Now().Add(wsTokenTTL).UTC().Format(time.RFC3339)
+		fmt.Fprintf(w, `{"token":%q,"expires_at":%q}`, token, exp)
+	}))
+	t.Cleanup(srv.Close)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	auth, err := ghpkg.NewAppAuthWithCache(1, 2, keyFile,
+		filepath.Join(t.TempDir(), "token.cache"), logger, srv.URL)
+	if err != nil {
+		t.Fatalf("NewAppAuthWithCache: %v", err)
+	}
+	return auth
+}
 
 // TestTokenRefreshDue covers the timing decision that gates the heartbeat's
 // token re-mint: only an active task whose token was minted at least
@@ -164,5 +212,91 @@ func TestSendTokenRefreshShape(t *testing.T) {
 	conn.mu.Unlock()
 	if !minted.After(before.Add(-time.Second)) {
 		t.Fatalf("tokenMintedAt not advanced: %s", minted)
+	}
+}
+
+// TestResumeTaskTokenReArmsRefresh reproduces #2610 finding 3 and verifies the
+// fix: after a reconnect the disconnect defer has cleared tokenMintedAt to zero,
+// so tokenRefreshDue is a permanent no-op for the resumed task. resumeTaskToken
+// must re-mint, push the token, and re-arm tokenMintedAt so the very next
+// heartbeat sees refresh as due again.
+func TestResumeTaskTokenReArmsRefresh(t *testing.T) {
+	hub := &ContributeWSHub{logger: slog.Default()}
+
+	// Real websocket pair so resumeTaskToken -> sendTokenRefresh writes a frame.
+	var serverConn *websocket.Conn
+	connReady := make(chan struct{})
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		serverConn = c
+		close(connReady)
+		time.Sleep(2 * time.Second)
+	}))
+	defer srv.Close()
+
+	client, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+	<-connReady
+
+	// Give the hub a real, succeeding App auth so mintScopedToken returns a
+	// non-empty token deterministically and offline (the resume path only re-arms
+	// on a successful mint+send).
+	s := NewServer(0, slog.Default())
+	s.deps = &Dependencies{GHAppAuth: newSucceedingAppAuth(t, "ghs_resume_scoped_token")}
+	hub.server = s
+
+	// State exactly as task_progress leaves it on a reconnect resume: currentTask
+	// rebuilt, tokenMintedAt zeroed by the disconnect defer.
+	conn := &ContributorConnection{
+		ws:            serverConn,
+		profile:       &ContributorProfile{TrustTier: "contributor", GitHubUsername: "resume-user"},
+		currentTask:   &WSTaskAssign{TaskID: "t-resume", Repo: "o/r", Number: 7},
+		tokenMintedAt: time.Time{},
+	}
+
+	// Precondition: with a zero mint time, refresh is NOT due — the bug's steady
+	// state where the resumed session never refreshes again.
+	if _, due := tokenRefreshDue(conn, time.Now().Add(2*wsTokenTTL)); due {
+		t.Fatalf("precondition: refresh should not be due with zero tokenMintedAt")
+	}
+
+	before := time.Now()
+	hub.resumeTaskToken(conn)
+
+	// The relay must receive a token_refresh carrying the fresh token.
+	client.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, raw, err := client.ReadMessage()
+	if err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if wire["type"] != "token_refresh" {
+		t.Fatalf("type = %v, want token_refresh", wire["type"])
+	}
+	if wire["github_token"] != "ghs_resume_scoped_token" {
+		t.Fatalf("github_token = %v, want the resumed scoped token", wire["github_token"])
+	}
+
+	// Postcondition: tokenMintedAt is re-armed, so a later heartbeat sees refresh
+	// as due again — the resumed task no longer silently loses its token.
+	conn.mu.Lock()
+	minted := conn.tokenMintedAt
+	conn.mu.Unlock()
+	if minted.IsZero() || minted.Before(before.Add(-time.Second)) {
+		t.Fatalf("tokenMintedAt not re-armed on resume: %s", minted)
+	}
+	if _, due := tokenRefreshDue(conn, minted.Add(wsTokenRefreshPeriod+time.Second)); !due {
+		t.Fatalf("after re-arm, refresh should be due again past the refresh period")
 	}
 }


### PR DESCRIPTION
## Summary

Issue #2610 (downstream security field-notes from `projectbluefin/review`) reported **three** contributor-protocol hardening items. I verified each against current `v2` HEAD:

| # | Item | State at HEAD |
|---|------|---------------|
| 1 | `contributor.env` written world-readable | **Already fixed** in `039400c` (PR #2615) — all three write paths `chmod 600` + re-tighten for existing users; covered by `TestContributorEnvReTightenTo0600`. |
| 2 | Unauthenticated force token reissue via `register {force:true}` | **Already fixed** in `039400c` (PR #2615) — `handleContributeRegister` now resolves the caller server-side and requires owner identity before rotating; covered by `TestForceRegister_*`. |
| 3 | `token_refresh` never fires again after a reconnect | **Fixed here.** |

This PR lands **item 3**, the only one still live at HEAD.

## Item 3 — root cause

- On disconnect, the defer clears `tokenMintedAt` to zero.
- On reconnect the relay re-asserts its task via `task_progress`, which rebuilt `currentTask` but **never re-armed `tokenMintedAt`** (it is only set at assignment or at a successful refresh).
- `tokenRefreshDue` treats a zero `tokenMintedAt` as *not due*, so `maybeRefreshToken` on the heartbeat became a **permanent no-op** for the resumed connection.
- Consequence: a task that survives one reconnect keeps the token minted at its original assignment, which expires at `wsTokenTTL` (55m) with no 50-minute replacement — the exact silent token-expiry case the refresh path was added for (#2393 item 2).

## Fix

On the `task_progress` resume path (only when it rebuilds `currentTask` from nothing), call the new `resumeTaskToken` helper, which:

1. re-mints a scoped GitHub token for the connection's tier,
2. pushes a fresh `token_refresh` to the relay (same wire shape the relay already consumes), and
3. via `sendTokenRefresh`, records `tokenMintedAt` — **re-arming the heartbeat refresh cycle**.

A mint failure or an empty token (no App auth / no cache) leaves the relay's existing token in place — the same lenient policy `maybeRefreshToken` uses — so a later resume (or a mint success) can still arm it. This is option (a) from the issue's finding-3 options.

## Verification

- `TestResumeTaskTokenReArmsRefresh` reproduces the bug (refresh **not** due with a zero mint time, even 2×TTL later) and verifies the fix: a `token_refresh` frame carrying the fresh token is sent over a real websocket pair, `tokenMintedAt` is re-armed, and `tokenRefreshDue` returns true again past the refresh period.
- Adds `newSucceedingAppAuth` — the succeeding counterpart to the existing `newFailingAppAuth` — for a deterministic, offline scoped-token mint.
- `go vet` clean; existing `Contribute*` / `TokenRefresh` / `ForceRegister` / `ContributorEnv` tests still pass.

Fixes #2610

🤖 Generated with [Claude Code](https://claude.com/claude-code)