### PR TITLE
✨ feat(contribute): additive client capability declaration (DECLARE half of #2547)

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -2733,6 +2733,27 @@ async function initAdmin(){
   if(typeof ccRenderQueue==='function')ccRenderQueue();
 }
 
+// capabilityLine renders the client-declared runtime posture (#2547 DECLARE half)
+// as a compact, READ-ONLY sub-line: "declares: podman &middot; linux/arm64 &middot;
+// cli 1.2.3 &middot; proto 1.1 &middot; cred:app". It returns '' when the client
+// declared nothing (an unversioned relay), so those rows look exactly as before.
+// The literal "declares:" prefix and the title tooltip keep the SELF-REPORTED
+// nature visible at the point of use: this data is advisory only and is never used
+// to route, gate, or trust — a client can claim anything (see kubestellar/hive#2547
+// risk section). Purely display; nothing here feeds a dispatch or permission
+// decision.
+function capabilityLine(caps){
+  if(!caps)return '';
+  var parts=[];
+  if(caps.container_runtime)parts.push(esc(caps.container_runtime));
+  var osArch=[caps.os,caps.arch].filter(Boolean).map(esc).join('/');
+  if(osArch)parts.push(osArch);
+  if(caps.agent_cli_version)parts.push('cli '+esc(caps.agent_cli_version));
+  if(caps.relay_protocol_version)parts.push('proto '+esc(caps.relay_protocol_version));
+  if(caps.credential_type)parts.push('cred:'+esc(caps.credential_type));
+  if(!parts.length)return '';
+  return '<div class="clanker-sub clanker-declares" title="Self-declared by the client. Advisory only — the hub records and shows it but never routes, gates, or trusts work on it.">declares: '+parts.join(' &middot; ')+'</div>';
+}
 // #2546: human-readable label for the machine reason a clanker is idle. Keeps the
 // raw reason as a fallback so a new server-side reason still renders legibly.
 function idleReasonLabel(r){
@@ -2766,6 +2787,11 @@ function renderClankers(list){
     var task=c.current_task
       ?('<div class="clanker-sub">on '+esc(c.current_task.repo)+'#'+esc(c.current_task.number)+'</div>')
       :(c.idle_reason?('<div class="clanker-sub">idle: '+esc(idleReasonLabel(c.idle_reason))+'</div>'):'');
+    // #2547 (DECLARE half): the client-declared runtime posture, surfaced READ-ONLY
+    // exactly like cli_backend/model/role above. It is a self-report and is NEVER
+    // used to route or gate work — see capabilityLine() for the "self-declared" note
+    // that keeps that visible at the point of use (per the issue's risk section).
+    var capsLine=capabilityLine(c.capabilities);
     // #2534: owner/read-write get per-contributor admin actions wired to the
     // EXISTING endpoints — set trust tier / promote (PUT /api/contributors/{id}/trust),
     // revoke (POST .../revoke), remove (DELETE .../{id}). Hidden for read viewers.
@@ -2802,7 +2828,7 @@ function renderClankers(list){
     var rowCls='clanker-row'+(isNew?' cc-enter':'');
     return '<div class="'+rowCls+'" data-clanker="'+esc(key)+'"><span class="clanker-dot'+(c.stale?' stale':'')+'"></span>'+av+
       '<div class="clanker-main"><div class="clanker-user">'+esc(user)+statusPill+tierPill+'</div>'+
-      '<div class="clanker-sub">'+(sub||'&mdash;')+'</div>'+task+'</div>'+
+      '<div class="clanker-sub">'+(sub||'&mdash;')+'</div>'+task+capsLine+'</div>'+
       (actions||('<span class="feed-time">'+esc(rel(c.connected_at))+'</span>'))+'</div>';
   }).join('');
 }

--- a/v2/pkg/dashboard/contribute_protocol_test.go
+++ b/v2/pkg/dashboard/contribute_protocol_test.go
@@ -188,6 +188,71 @@ func TestWS_OmittedCapabilitiesUnaffected(t *testing.T) {
 	}
 }
 
+// TestWS_DeclaredCapabilitiesInFleetAPIPayload asserts the #2547 declare half is
+// visible where an operator actually reads it: the /api/contribute/fleet HTTP JSON
+// payload (what the Operations tab hydrates from), not just the in-process
+// FleetSnapshot(). A connected client that declared capabilities has them present
+// under clankers[].capabilities in the served JSON.
+func TestWS_DeclaredCapabilitiesInFleetAPIPayload(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+	token, cid := registerWSUser(t, s, "fleetapi-user")
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{
+		Type:              "auth_response",
+		RegistrationToken: token,
+		CLIBackend:        "claude",
+		Capabilities: &ContributorCapabilities{
+			ContainerRuntime: "podman",
+			OS:               "linux",
+			CredentialType:   "pat",
+		},
+	})
+	if authOK := readMsg(t, conn); authOK.Type != "auth_ok" {
+		t.Fatalf("expected auth_ok, got %s: %s", authOK.Type, authOK.Reason)
+	}
+
+	// Poll the real HTTP endpoint until the connection is registered, then assert
+	// the served JSON carries the declared capabilities under this clanker.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		req := httptest.NewRequest(http.MethodGet, "/api/contribute/fleet", nil)
+		w := httptest.NewRecorder()
+		s.mux.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("fleet endpoint: got %d: %s", w.Code, w.Body.String())
+		}
+		var resp struct {
+			Clankers []FleetClanker `json:"clankers"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("invalid fleet JSON: %v", err)
+		}
+		for i := range resp.Clankers {
+			if resp.Clankers[i].ContributorID != cid {
+				continue
+			}
+			caps := resp.Clankers[i].Capabilities
+			if caps == nil {
+				t.Fatal("declared capabilities missing from /api/contribute/fleet payload")
+			}
+			if caps.ContainerRuntime != "podman" || caps.OS != "linux" || caps.CredentialType != "pat" {
+				t.Fatalf("fleet payload capabilities mismatch: %+v", caps)
+			}
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("clanker not found in /api/contribute/fleet payload")
+}
+
 // TestWS_ProtocolVersionOnlyClientFoldsIn asserts a version-only client (sends a
 // top-level protocol_version but no capabilities object) still has its protocol
 // version stored + surfaced, so an intentionally-degrading newer client is
@@ -229,6 +294,68 @@ func TestWS_ProtocolVersionOnlyClientFoldsIn(t *testing.T) {
 	}
 	if fc.Capabilities.RelayProtocolVersion != "9.9" {
 		t.Fatalf("relay_protocol_version: want 9.9, got %q", fc.Capabilities.RelayProtocolVersion)
+	}
+}
+
+// TestWS_DeclaredCapabilitiesDoNotAlterTrust is the load-bearing guarantee of the
+// #2547 declare half: a self-declared capability map is ADDITIVE and is NEVER a
+// trust signal. A client can claim anything (a privileged-looking credential_type,
+// any runtime), and the hub must grant EXACTLY the trust tier and permissions it
+// would grant a client that declared nothing — the auth_ok tier/permissions derive
+// solely from the persisted profile (TrustTier), never from a client-supplied
+// capability field. This asserts the declaration does not elevate (or change at
+// all) the permission decision.
+func TestWS_DeclaredCapabilitiesDoNotAlterTrust(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	// authOnce connects a freshly-registered newcomer, optionally declaring rich
+	// capabilities, and returns the trust tier + permissions the hub granted.
+	authOnce := func(username string, caps *ContributorCapabilities) (tier string, perms []string) {
+		t.Helper()
+		token, _ := registerWSUser(t, s, username)
+		conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+		defer conn.Close()
+		readMsg(t, conn) // challenge
+		conn.WriteJSON(WSMessage{
+			Type:              "auth_response",
+			RegistrationToken: token,
+			CLIBackend:        "claude",
+			Capabilities:      caps,
+		})
+		authOK := readMsg(t, conn)
+		if authOK.Type != "auth_ok" {
+			t.Fatalf("expected auth_ok, got %s: %s", authOK.Type, authOK.Reason)
+		}
+		return authOK.TrustTier, authOK.Permissions
+	}
+
+	// Baseline: a client that declares nothing (an unversioned relay).
+	baseTier, basePerms := authOnce("notrust-plain", nil)
+
+	// A client that declares a rich, deliberately privileged-LOOKING posture —
+	// "app" credential type, a container runtime, etc. None of this may buy trust.
+	richTier, richPerms := authOnce("notrust-rich", &ContributorCapabilities{
+		ContainerRuntime:     "docker",
+		OS:                   "linux",
+		Arch:                 "amd64",
+		AgentCLIVersion:      "9.9.9",
+		RelayProtocolVersion: "1.1",
+		CredentialType:       "app",
+	})
+
+	if richTier != baseTier {
+		t.Fatalf("declared capabilities altered trust tier: declared=%q, undeclared=%q", richTier, baseTier)
+	}
+	if strings.Join(richPerms, ",") != strings.Join(basePerms, ",") {
+		t.Fatalf("declared capabilities altered permissions: declared=%v, undeclared=%v", richPerms, basePerms)
+	}
+	// Both must be the unprivileged newcomer default — declaring did not elevate.
+	if baseTier != "newcomer" {
+		t.Fatalf("expected a freshly-registered contributor to be newcomer, got %q", baseTier)
 	}
 }
 


### PR DESCRIPTION
## What & why

The **DECLARE half** of #2547: a connected contributor client can tell the hub what it can run, the hub records it as live connection state, and the Operations connected-fleet view shows it read-only.

The DECLARE/ROUTE split from the maintainer response:
- **DECLARE (this PR):** additive client self-description. Recorded and surfaced only.
- **ROUTE (deferred, NOT this PR):** assigning work based on declared capabilities. That is a separate design that still lacks task-side requirements metadata (per the issue), and no assignment/selection logic is touched here.

## Two guarantees (honored)

1. **Additive & backward-compatible.** The declaration rides an optional `capabilities` object on `auth_response`. A client that sends nothing authenticates and runs *exactly* as today and surfaces as nil capabilities. No required field, no stricter default, no "silent = incapable" rule — existing relays are unaffected.
2. **Not a trust signal.** The declaration is self-reported and advisory only. Trust tier and permissions in `auth_ok` derive solely from the persisted profile; a declared capability never elevates or changes them. A regression test asserts this directly (a rich, privileged-looking declaration yields the same newcomer tier/perms as no declaration). The Operations sub-line is labelled "declares:" with a tooltip stating it is self-declared and never routed/gated/trusted, keeping the self-reported nature visible at the point of use.

## What shipped

The wire + storage layer already existed on v2 (`ContributorCapabilities` in `contribute_protocol.go`; `auth_response` parsing, per-connection storage, and `FleetSnapshot`/`FleetClanker` surfacing in `contribute_ws.go`). This PR completes the operator-facing surface and the missing guarantee tests:

- **Operations UI** (`api_contribute.go` `renderClankers`): a compact read-only sub-line per clanker — e.g. `declares: podman · linux/arm64 · cli 1.2.3 · proto 1.1 · cred:app`. Absent for clients that declared nothing. Built with the same quote-concatenation style as the surrounding JS (no template literals inside the `Fprintf` raw string).
- **Tests** (`contribute_protocol_test.go`):
  - `TestWS_DeclaredCapabilitiesDoNotAlterTrust` — the no-trust-signal guarantee.
  - `TestWS_DeclaredCapabilitiesInFleetAPIPayload` — the declaration is present in the actual `/api/contribute/fleet` HTTP JSON the Operations tab hydrates from, not only the in-process snapshot.

## Scope note

`Part of #2547` (not `Fixes`): the issue tracks the whole DECLARE→ROUTE arc and remains open for ROUTE, which stays deferred. Routing remains a follow-up pending task-side requirements metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)