### PR TITLE
✨ feat(contribute): headless (non-interactive) contributor relay mode

### DIFF
--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -35,6 +35,17 @@ export HIVE_AGENT_SESSION="$TMUX_SESSION"
 export HIVE_AGENT_ID="contributor"
 export HIVE_CONTRIBUTOR_MODE="true"
 export HIVE_CONTRIBUTOR_CLI="$AGENT_BACKEND"
+
+# Task-delivery mode (kubestellar/hive#2538). "interactive" (default) launches
+# the CLI in a tmux pane and the relay types tasks into it; "headless" skips the
+# tmux/CLI launch entirely and the relay drives a one-shot CLI per task with no
+# TTY — suitable for an unattended / future Kubernetes contributor (#2549).
+# Only the two literals are accepted; anything else falls back to interactive.
+CONTRIBUTOR_MODE="${CONTRIBUTOR_MODE:-interactive}"
+if [[ "$CONTRIBUTOR_MODE" != "headless" ]]; then
+  CONTRIBUTOR_MODE="interactive"
+fi
+export CONTRIBUTOR_MODE
 # Username is extracted from contributor.env (set during registration)
 export HIVE_CONTRIBUTOR_USERNAME="${CONTRIBUTOR_USERNAME:-unknown}"
 
@@ -294,9 +305,14 @@ esac
 export HIVE_WORKSPACE_DIR="${HIVE_WORKSPACE_DIR:-${HOME}/workspace}"
 mkdir -p "$HIVE_WORKSPACE_DIR"
 
-# Create tmux session for the agent
-tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
-tmux new-session -d -s "$TMUX_SESSION" -c "$HIVE_WORKSPACE_DIR" -x 200 -y 50
+# Create the tmux session for the agent — INTERACTIVE mode only. In headless
+# mode (kubestellar/hive#2538) the relay spawns a one-shot CLI per task and
+# there is no persistent pane to attach to or type into, so we skip the session
+# entirely rather than leave an idle tmux CLI sitting at a prompt.
+if [[ "$CONTRIBUTOR_MODE" == "interactive" ]]; then
+  tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+  tmux new-session -d -s "$TMUX_SESSION" -c "$HIVE_WORKSPACE_DIR" -x 200 -y 50
+fi
 
 # Start the relay in the background
 echo "Starting ClankeR relay connection to hub..."
@@ -361,38 +377,51 @@ PYEOF
   chmod 600 "${HOME}/.claude.json" 2>/dev/null || true
 fi
 
-tmux send-keys -t "$TMUX_SESSION" "$CMD $PERM_FLAG $MODEL_FLAG" Enter
+# Launch the interactive CLI and auto-dismiss its startup prompts — INTERACTIVE
+# mode only. Headless mode (kubestellar/hive#2538) has no persistent pane; the
+# relay launches a one-shot CLI per task, and one-shot invocations do not draw
+# the trust/theme/onboarding dialogs this loop dismisses.
+if [[ "$CONTRIBUTOR_MODE" == "interactive" ]]; then
+  tmux send-keys -t "$TMUX_SESSION" "$CMD $PERM_FLAG $MODEL_FLAG" Enter
 
-# Auto-dismiss startup prompts (workspace trust, theme picker, etc.)
-AUTO_DISMISS_ATTEMPTS=10
-AUTO_DISMISS_INTERVAL=3
-(
-  for i in $(seq 1 $AUTO_DISMISS_ATTEMPTS); do
-    sleep "$AUTO_DISMISS_INTERVAL"
-    PANE=$(tmux capture-pane -t "$TMUX_SESSION" -p -S -10 2>/dev/null || true)
-    if echo "$PANE" | grep -q "trust this folder\|trust the files\|Confirm folder trust\|Enter to confirm"; then
-      tmux send-keys -t "$TMUX_SESSION" Enter 2>/dev/null || true
-    elif echo "$PANE" | grep -q "Choose the text style"; then
-      tmux send-keys -t "$TMUX_SESSION" "1" Enter 2>/dev/null || true
-    elif echo "$PANE" | grep -q "Share anonymous usage data\|help improve goose\|Would you like"; then
-      tmux send-keys -t "$TMUX_SESSION" Enter 2>/dev/null || true
-    elif echo "$PANE" | grep -q "Choose a provider\|Select.*provider\|Which provider"; then
-      tmux send-keys -t "$TMUX_SESSION" Enter 2>/dev/null || true
-    elif echo "$PANE" | grep -qi "custom API key"; then
-      # Claude Code asks whether to use ANTHROPIC_API_KEY (litellm backend)
-      tmux send-keys -t "$TMUX_SESSION" "1" Enter 2>/dev/null || true
-    elif echo "$PANE" | grep -q "bypass permissions\|autopilot\|goose>\|G >\|❯\|/ commands\|> *$"; then
-      break
-    fi
-  done
-) &
+  # Auto-dismiss startup prompts (workspace trust, theme picker, etc.)
+  AUTO_DISMISS_ATTEMPTS=10
+  AUTO_DISMISS_INTERVAL=3
+  (
+    for i in $(seq 1 $AUTO_DISMISS_ATTEMPTS); do
+      sleep "$AUTO_DISMISS_INTERVAL"
+      PANE=$(tmux capture-pane -t "$TMUX_SESSION" -p -S -10 2>/dev/null || true)
+      if echo "$PANE" | grep -q "trust this folder\|trust the files\|Confirm folder trust\|Enter to confirm"; then
+        tmux send-keys -t "$TMUX_SESSION" Enter 2>/dev/null || true
+      elif echo "$PANE" | grep -q "Choose the text style"; then
+        tmux send-keys -t "$TMUX_SESSION" "1" Enter 2>/dev/null || true
+      elif echo "$PANE" | grep -q "Share anonymous usage data\|help improve goose\|Would you like"; then
+        tmux send-keys -t "$TMUX_SESSION" Enter 2>/dev/null || true
+      elif echo "$PANE" | grep -q "Choose a provider\|Select.*provider\|Which provider"; then
+        tmux send-keys -t "$TMUX_SESSION" Enter 2>/dev/null || true
+      elif echo "$PANE" | grep -qi "custom API key"; then
+        # Claude Code asks whether to use ANTHROPIC_API_KEY (litellm backend)
+        tmux send-keys -t "$TMUX_SESSION" "1" Enter 2>/dev/null || true
+      elif echo "$PANE" | grep -q "bypass permissions\|autopilot\|goose>\|G >\|❯\|/ commands\|> *$"; then
+        break
+      fi
+    done
+  ) &
+fi
 
 echo ""
 CONTAINER_NAME="${HIVE_CONTAINER_NAME:-hive-contributor}"
 echo "Contributor agent is running."
+echo "  Mode:    $CONTRIBUTOR_MODE"
 echo "  CLI:     $CMD"
 echo "  ClankeR: PID $RELAY_PID"
-echo "  Tmux:    docker exec -it $CONTAINER_NAME tmux attach -t $TMUX_SESSION"
+if [[ "$CONTRIBUTOR_MODE" == "interactive" ]]; then
+  echo "  Tmux:    docker exec -it $CONTAINER_NAME tmux attach -t $TMUX_SESSION"
+else
+  # Headless: no pane to attach to. The relay drives a one-shot CLI per task and
+  # writes its lifecycle state (waiting/working/done/failed) here for a probe.
+  echo "  Status:  ${HIVE_HEADLESS_STATUS_FILE:-/tmp/contributor-headless-status.json}"
+fi
 echo ""
 
 # Keep running until interrupted

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -30,6 +30,50 @@ const GH_TOKEN_CACHE = fs.existsSync('/var/run/hive-metrics')
   : '/tmp/hive-gh-token.cache';
 const TASK_FILE = '/tmp/contributor-task.json';
 
+// --- Delivery mode (kubestellar/hive#2538) -------------------------------
+// The relay can deliver a task to the backend CLI in one of two ways:
+//
+//   interactive (default) — the legacy path: type the prompt into a live
+//     tmux pane with `tmux send-keys` and scrape the pane for readiness,
+//     progress and completion. Requires an attached-or-attachable TTY and is
+//     unchanged by this feature.
+//
+//   headless — the non-interactive path added for #2538: drive the backend
+//     CLI in a one-shot / print invocation (`claude -p`, `copilot -p`,
+//     `codex exec`, …), capture its stdout/stderr, and report completion or a
+//     REAL error back over the same WebSocket channel. No tmux, no pane
+//     scraping, no waiting on an invisible prompt — so a K8s Job/Deployment
+//     running this mode either runs to completion or fails loudly (the exact
+//     "healthy-looking but stalled pod" failure #2538 warns about), and it
+//     never needs a human to attach and type `/login`.
+//
+// This is opt-in and additive: absent/any-other value keeps the interactive
+// path exactly as before. K8s manifests (#2549) and the credential boundary
+// (#2537) are the explicit follow-ons and are NOT built here.
+const MODE_INTERACTIVE = 'interactive';
+const MODE_HEADLESS = 'headless';
+const CONTRIBUTOR_MODE = process.env.CONTRIBUTOR_MODE === MODE_HEADLESS
+  ? MODE_HEADLESS
+  : MODE_INTERACTIVE;
+
+// Where the headless runner records its current lifecycle state as JSON, so a
+// supervising process (or a future K8s liveness/readiness probe reading the
+// file) can distinguish waiting / working / done / failed — instead of a pod
+// that merely looks alive. Best-effort: a write failure never aborts a task.
+const HEADLESS_STATUS_FILE = process.env.HIVE_HEADLESS_STATUS_FILE || '/tmp/contributor-headless-status.json';
+
+// Coarse lifecycle states reported by the headless runner. Named so probes and
+// logs agree on the vocabulary rather than matching free text.
+const HEADLESS_STATE_WAITING = 'waiting'; // authenticated, no task in flight
+const HEADLESS_STATE_WORKING = 'working'; // one-shot CLI invocation running
+const HEADLESS_STATE_DONE = 'done';       // last task completed (exit 0)
+const HEADLESS_STATE_FAILED = 'failed';   // last task failed (non-zero/spawn error)
+
+// Cap on captured child output kept in memory / sent to the hub, so a chatty
+// CLI cannot grow the buffer without bound. The tail is what matters for an
+// audit trail, mirroring TMUX_TAIL_LINES on the interactive path.
+const HEADLESS_MAX_OUTPUT_BYTES = 1048576; // 1 MiB
+
 const TMUX_TAIL_LINES = 15;
 const HEARTBEAT_INTERVAL_MS = 30000;
 const HEARTBEAT_TIMEOUT_MS = 90000;
@@ -38,6 +82,12 @@ const MAX_RECONNECT_DELAY_MS = 60000;
 const BASE_RECONNECT_DELAY_MS = 1000;
 const TOKEN_REFRESH_MARGIN_MS = 300000;
 const MAX_TASK_DURATION_MS = 1800000;
+// Hard ceiling on a single headless one-shot invocation (kubestellar/hive#2538).
+// The interactive path bounds a task with MAX_TASK_DURATION_MS via a
+// tmux-scraping watchdog; the headless child gets the SAME bound enforced
+// directly on the process, so a wedged CLI is killed and reported failed rather
+// than hanging the pod forever.
+const HEADLESS_TASK_TIMEOUT_MS = MAX_TASK_DURATION_MS;
 const NETWORK_ERROR_RETRY_DELAY_MS = 5000;
 // After the hub sends an explicit task_unavailable negative-ack (no admissible
 // work, a disabled tier, a concurrency limit, or a token-mint failure — see
@@ -150,9 +200,15 @@ const NO_MODEL_FLAG_BACKENDS = ['amazonq', 'goose', 'bob'];
 // inline, silently dropping the resolved model for the rest of the container's
 // life. Build it once here and reuse it everywhere so the paths cannot drift.
 let cachedLaunchCommand = null;
+let cachedBackendResolution = null;
 
-function buildLaunchCommand() {
-  if (cachedLaunchCommand) return cachedLaunchCommand;
+// resolveBackend() returns the { cmd, perm } pair backends.conf maps this
+// backend to (binary + permission flags). Shared by the interactive launch
+// command and the headless argv builder so the two paths cannot drift on which
+// binary/flags a backend uses. Result cached — the resolution is a couple of
+// bash sub-shells and never changes for the life of the process.
+function resolveBackend() {
+  if (cachedBackendResolution) return cachedBackendResolution;
   const confPaths = ['/usr/local/etc/hive/backends.conf', path.join(process.cwd(), 'config/backends.conf')];
   const confPath = confPaths.find(p => fs.existsSync(p)) || confPaths[0];
   let cmd = BACKEND;
@@ -163,9 +219,150 @@ function buildLaunchCommand() {
   } catch (e) {
     console.error(`Could not resolve backend flags from ${confPath}: ${e.message}`);
   }
+  cachedBackendResolution = { cmd, perm };
+  return cachedBackendResolution;
+}
+
+function buildLaunchCommand() {
+  if (cachedLaunchCommand) return cachedLaunchCommand;
+  const { cmd, perm } = resolveBackend();
   const modelFlag = MODEL && !NO_MODEL_FLAG_BACKENDS.includes(BACKEND) ? `--model ${MODEL}` : '';
   cachedLaunchCommand = [cmd, perm, modelFlag].filter(Boolean).join(' ');
   return cachedLaunchCommand;
+}
+
+// --- Headless (non-interactive) one-shot dispatch (kubestellar/hive#2538) ---
+//
+// Backends whose CLI supports a one-shot / print invocation that takes the
+// prompt on the command line, runs to completion, and EXITS with a meaningful
+// status — the property the headless mode needs. Each entry says how to turn
+// (binary, perm-flags, prompt) into an argv:
+//
+//   flag — the sub-command/flag that selects one-shot mode; the prompt is
+//          passed as the single positional argument that follows it
+//          (`claude -p "<prompt>"`, `codex exec "<prompt>"`).
+//
+// Backends NOT listed here have no known non-interactive entry point (goose /
+// bob / agy / pi drive an interactive TUI), so headless mode refuses them
+// LOUDLY at task time rather than silently stalling. Extending this table is
+// how a future PR adds a backend once its headless invocation is verified.
+const HEADLESS_BACKENDS = {
+  // claude -p "<prompt>" — print mode: runs the prompt non-interactively and
+  // exits. Same perm flags as the interactive launch (bypass permissions).
+  claude: { flag: '-p' },
+  // litellm is the claude binary pointed at a LiteLLM proxy, so the same
+  // print-mode invocation applies.
+  litellm: { flag: '-p' },
+  // copilot -p "<prompt>" — non-interactive programmatic mode.
+  copilot: { flag: '-p' },
+  // codex exec "<prompt>" — Codex's non-interactive execution sub-command.
+  codex: { flag: 'exec' },
+};
+
+// headlessSupportsBackend reports whether the configured backend has a known
+// one-shot invocation. Used to fail fast at startup and per task.
+function headlessSupportsBackend() {
+  return Object.prototype.hasOwnProperty.call(HEADLESS_BACKENDS, BACKEND);
+}
+
+// buildHeadlessArgv turns a task prompt into the argv for a one-shot,
+// non-interactive backend invocation: [binary, ...permFlags, ...modelFlag,
+// oneShotFlag, prompt] (order adjusted per promptAsArg). Returns null for an
+// unsupported backend. Never shell-interpolates the prompt — it is passed as a
+// distinct argv element to execFile, so apostrophes/quotes in the prompt (the
+// exact #2203 wedge on the interactive path) cannot break anything here.
+function buildHeadlessArgv(prompt) {
+  const spec = HEADLESS_BACKENDS[BACKEND];
+  if (!spec) return null;
+  const { cmd, perm } = resolveBackend();
+  const permArgs = perm ? perm.split(/\s+/).filter(Boolean) : [];
+  const modelArgs = MODEL && !NO_MODEL_FLAG_BACKENDS.includes(BACKEND) ? ['--model', MODEL] : [];
+  const args = [...permArgs, ...modelArgs, spec.flag, prompt];
+  return { bin: cmd, args };
+}
+
+// writeHeadlessStatus records the runner's coarse lifecycle state so a
+// supervising process / K8s probe can read it. Best-effort: a failed write is
+// logged-by-omission and never aborts the task.
+function writeHeadlessStatus(state, extra) {
+  const payload = Object.assign({
+    mode: MODE_HEADLESS,
+    backend: BACKEND,
+    state,
+    updated_at: new Date().toISOString(),
+  }, extra || {});
+  try {
+    fs.writeFileSync(HEADLESS_STATUS_FILE, JSON.stringify(payload, null, 2));
+  } catch (_) { /* probe file is advisory; never fail a task on it */ }
+  return payload;
+}
+
+// Reference to the in-flight headless child, so a revoke/shutdown can kill it.
+let headlessChild = null;
+
+// runHeadlessTask drives a single task to completion WITHOUT tmux: it spawns the
+// one-shot CLI, captures (bounded) output, and on exit reports task_complete
+// (exit 0) or task_failed (non-zero / spawn error / timeout) over the existing
+// WebSocket channel — then announces `ready` for the next task. This is the
+// headless analogue of the interactive progressTick() completion path.
+function runHeadlessTask(task) {
+  const prompt = task.prompt || `Work on ${task.kind} ${task.repo}#${task.number}: ${task.title}`;
+  if (!headlessSupportsBackend()) {
+    // No non-interactive entry point for this backend: fail LOUDLY rather than
+    // stall. This is the #2538 guarantee — a headless run never waits silently.
+    const reason = `backend '${BACKEND}' has no headless (non-interactive) mode; supported: ${Object.keys(HEADLESS_BACKENDS).join(', ')}`;
+    console.error(`Headless dispatch refused: ${reason}`);
+    writeHeadlessStatus(HEADLESS_STATE_FAILED, { task_id: task.task_id, reason });
+    failCurrentTask(reason, { permanent: true });
+    return;
+  }
+
+  const { bin, args } = buildHeadlessArgv(prompt);
+  console.log(`Headless: running ${bin} (one-shot) for ${task.repo}#${task.number}`);
+  writeHeadlessStatus(HEADLESS_STATE_WORKING, { task_id: task.task_id, repo: task.repo, number: task.number });
+  send({ type: 'task_progress', seq: nextSeq(), task_id: task.task_id, kind: task.kind, repo: task.repo, number: task.number, title: task.title, status: 'working' });
+
+  let settled = false;
+  const finish = (fn) => { if (settled) return; settled = true; fn(); };
+
+  headlessChild = execFile(bin, args, {
+    timeout: HEADLESS_TASK_TIMEOUT_MS,
+    maxBuffer: HEADLESS_MAX_OUTPUT_BYTES,
+    killSignal: 'SIGKILL',
+    cwd: process.env.HIVE_WORKSPACE_DIR || process.cwd(),
+  }, (err, stdout, stderr) => {
+    headlessChild = null;
+    // Tokens can appear in agent output; redact before the tail leaves the host.
+    const outTail = redactTokens(String(stdout || '') + String(stderr || ''))
+      .split('\n').slice(-TMUX_TAIL_LINES);
+    if (err) {
+      // A non-zero exit, a spawn failure (ENOENT), or the timeout kill all land
+      // here. err.killed && err.signal signals the timeout; report a real
+      // failure either way so the hub can reassign — never a silent hang.
+      const timedOut = err.killed === true;
+      const reason = timedOut
+        ? `headless task exceeded ${HEADLESS_TASK_TIMEOUT_MS / 60000}min and was killed`
+        : `headless CLI exited with error: ${err.code !== undefined ? `code ${err.code}` : err.message}`;
+      finish(() => {
+        console.error(`Headless task ${task.task_id} failed: ${reason}`);
+        writeHeadlessStatus(HEADLESS_STATE_FAILED, { task_id: task.task_id, reason });
+        failCurrentTask(reason, { permanent: false });
+      });
+      return;
+    }
+    finish(() => {
+      console.log(`Headless task ${task.task_id} completed (exit 0)`);
+      const prURL = detectPRURL(outTail, task.repo);
+      if (prURL) console.log(`Detected PR for ${task.task_id}: ${prURL}`);
+      writeHeadlessStatus(HEADLESS_STATE_DONE, { task_id: task.task_id, pr_url: prURL });
+      send({ type: 'task_complete', seq: nextSeq(), task_id: task.task_id, result: 'completed', summary: 'Headless one-shot invocation exited 0', tmux_output: outTail, pr_url: prURL });
+      currentTask = null;
+      taskAssignedAt = 0;
+      tasksCompletedCount++;
+      writeHeadlessStatus(HEADLESS_STATE_WAITING);
+      send({ type: 'ready', seq: nextSeq() });
+    });
+  });
 }
 
 // A tmux pane can be left in bash's PS2 continuation state ("> ") when task
@@ -270,10 +467,27 @@ function waitForCLI() {
 let cliReady = false;
 let pendingTask = null;
 
-waitForCLI().then(() => {
+if (CONTRIBUTOR_MODE === MODE_HEADLESS) {
+  // Headless mode has no tmux pane to scrape for readiness. Each task spawns
+  // its own one-shot CLI process on demand, so there is nothing to "become
+  // ready" — the relay is ready to accept work as soon as it authenticates.
+  // Fail fast on an unsupported backend so a K8s pod reports a real error at
+  // startup instead of accepting a task it can never run.
   cliReady = true;
-  flushPendingTask();
-}).catch(e => console.error(e.message));
+  if (!headlessSupportsBackend()) {
+    console.error(`FATAL: CONTRIBUTOR_MODE=headless but backend '${BACKEND}' has no non-interactive mode. Supported: ${Object.keys(HEADLESS_BACKENDS).join(', ')}`);
+    writeHeadlessStatus(HEADLESS_STATE_FAILED, { reason: `unsupported headless backend: ${BACKEND}` });
+    if (process.env.HIVE_RELAY_TEST_MODE !== '1') process.exit(1);
+  } else {
+    console.log(`Headless mode: backend '${BACKEND}' will run one-shot per task (no tmux).`);
+    writeHeadlessStatus(HEADLESS_STATE_WAITING);
+  }
+} else {
+  waitForCLI().then(() => {
+    cliReady = true;
+    flushPendingTask();
+  }).catch(e => console.error(e.message));
+}
 
 const ENTER_COUNT = 3;
 const ENTER_DELAY_MS = 300;
@@ -851,11 +1065,18 @@ function handleMessage(data) {
       }
       fs.writeFileSync(TASK_FILE, JSON.stringify(msg, null, 2));
       send({ type: 'task_accepted', seq: nextSeq(), task_id: msg.task_id });
-      const taskPrompt = msg.prompt || `Work on ${msg.kind} ${msg.repo}#${msg.number}: ${msg.title}`;
-      // tmuxSendKeys() itself queues when the CLI is not confirmed ready, so
-      // there is a single gate rather than two that can disagree.
-      tmuxSendKeys(taskPrompt);
-      startProgressReporting();
+      if (CONTRIBUTOR_MODE === MODE_HEADLESS) {
+        // Non-interactive path (kubestellar/hive#2538): drive a one-shot CLI
+        // invocation and report completion/failure from its exit status — no
+        // tmux, no pane scraping, no watchdog waiting on an invisible prompt.
+        runHeadlessTask(msg);
+      } else {
+        const taskPrompt = msg.prompt || `Work on ${msg.kind} ${msg.repo}#${msg.number}: ${msg.title}`;
+        // tmuxSendKeys() itself queues when the CLI is not confirmed ready, so
+        // there is a single gate rather than two that can disagree.
+        tmuxSendKeys(taskPrompt);
+        startProgressReporting();
+      }
       break;
 
     case 'token_refresh':
@@ -871,6 +1092,14 @@ function handleMessage(data) {
       currentTask = null;
       taskAssignedAt = 0;
       if (progressInterval) { clearInterval(progressInterval); progressInterval = null; }
+      // Headless mode: kill the in-flight one-shot child so the revoked task's
+      // process does not keep running (and holding the credential) after the
+      // hub took the work back.
+      if (CONTRIBUTOR_MODE === MODE_HEADLESS && headlessChild) {
+        try { headlessChild.kill('SIGKILL'); } catch (_) {}
+        headlessChild = null;
+        writeHeadlessStatus(HEADLESS_STATE_WAITING);
+      }
       send({ type: 'ready', seq: nextSeq() });
       break;
 
@@ -985,6 +1214,19 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     getLastResetAtCount: () => lastResetAtCount,
     getCurrentTask: () => currentTask,
     setWs: (w) => { ws = w; },
+    // Headless (non-interactive) mode surface (kubestellar/hive#2538).
+    CONTRIBUTOR_MODE,
+    MODE_INTERACTIVE,
+    MODE_HEADLESS,
+    HEADLESS_BACKENDS,
+    HEADLESS_STATE_WAITING,
+    HEADLESS_STATE_WORKING,
+    HEADLESS_STATE_DONE,
+    HEADLESS_STATE_FAILED,
+    headlessSupportsBackend,
+    buildHeadlessArgv,
+    runHeadlessTask,
+    getHeadlessChild: () => headlessChild,
   };
 } else {
   connect();

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -26,9 +26,11 @@ const RELAY_PATH = path.join(__dirname, 'contributor-relay.sh');
 // bash and no WebSocket are ever touched.
 // ---------------------------------------------------------------------------
 
-function loadRelay({ backend = 'copilot', model = '', cliStates = ['ready'], procAlive = true } = {}) {
+function loadRelay({ backend = 'copilot', model = '', cliStates = ['ready'], procAlive = true, mode = 'interactive', execFileResult = null, statusFile = null } = {}) {
   const commands = [];
   const sent = [];
+  // Records every execFile (headless one-shot) invocation: { bin, args, opts }.
+  const execFileCalls = [];
   let stateIdx = 0;
   // Guard against a runaway loop in the code under test eating all memory.
   const MAX_RECORDED_COMMANDS = 10000;
@@ -53,10 +55,27 @@ function loadRelay({ backend = 'copilot', model = '', cliStates = ['ready'], pro
     return '';
   };
 
+  // Headless mode drives the CLI through execFile (one-shot), not tmux. The stub
+  // records the invocation and synchronously fires the completion callback with
+  // the outcome the test asked for (default: exit 0). It returns a fake child
+  // with a kill() so revoke/shutdown paths can be exercised.
+  const fakeExecFile = (bin, args, opts, cb) => {
+    const callback = typeof opts === 'function' ? opts : cb;
+    execFileCalls.push({ bin, args, opts: typeof opts === 'function' ? {} : opts });
+    const child = { killed: false, kill() { this.killed = true; } };
+    const r = execFileResult || {};
+    if (callback) {
+      // Mirror execFile's async contract closely enough for the relay's logic:
+      // callback(err, stdout, stderr).
+      callback(r.err || null, r.stdout || '', r.stderr || '');
+    }
+    return child;
+  };
+
   const stubs = {
     child_process: {
       execSync: fakeExecSync,
-      execFile: () => {},
+      execFile: fakeExecFile,
     },
     ws: class FakeWebSocket {
       static get OPEN() { return 1; }
@@ -81,9 +100,14 @@ function loadRelay({ backend = 'copilot', model = '', cliStates = ['ready'], pro
   process.env.AGENT_MODEL = model;
   process.env.GOOSE_MODEL = '';
   process.env.HIVE_AGENT_SESSION = 'contributor';
+  process.env.CONTRIBUTOR_MODE = mode;
 
   // Keep the relay's task-file write out of the real /tmp path used in prod.
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-test-'));
+  // Point the headless status file at the test's tmp dir so probe writes don't
+  // clobber a real one and can be asserted on.
+  const headlessStatusFile = statusFile || path.join(tmpDir, 'headless-status.json');
+  process.env.HIVE_HEADLESS_STATUS_FILE = headlessStatusFile;
 
   // node refuses to require a .sh file with the default extension handlers;
   // register .sh as JavaScript. This must happen BEFORE require.resolve(), and
@@ -108,6 +132,11 @@ function loadRelay({ backend = 'copilot', model = '', cliStates = ['ready'], pro
   relay.__commands = commands;
   relay.__sent = sent;
   relay.__tmpDir = tmpDir;
+  relay.__execFileCalls = execFileCalls;
+  relay.__headlessStatusFile = headlessStatusFile;
+  relay.__readHeadlessStatus = () => {
+    try { return JSON.parse(fs.readFileSync(headlessStatusFile, 'utf8')); } catch (_) { return null; }
+  };
   relay.__tmuxSends = () => commands.filter(c => /send-keys/.test(c));
   return relay;
 }
@@ -478,6 +507,156 @@ test('restart backoff grows and is capped', () => {
     assert.ok(b2 > b1 && b3 > b2, `backoff must grow: ${b1}, ${b2}, ${b3}`);
     assert.strictEqual(relay.restartBackoffMs(50), relay.restartBackoffMs(60),
       'backoff must saturate at the cap');
+  } finally { teardown(relay); }
+});
+
+// ---------------------------------------------------------------------------
+// kubestellar/hive#2538 — headless (non-interactive) delivery mode.
+//
+// A task must reach the backend CLI through a one-shot invocation (execFile),
+// never tmux send-keys; the exit status must drive task_complete / task_failed;
+// mode selection must be honoured; an error must be reported, never hung on.
+// ---------------------------------------------------------------------------
+
+function assignHeadlessTask(relay, overrides = {}) {
+  relay.handleMessage(JSON.stringify(Object.assign({
+    type: 'task_assign',
+    task_id: 'ct-h-1',
+    kind: 'issue',
+    repo: 'foo/bar',
+    number: 7,
+    title: 'headless task',
+    prompt: "Work on foo/bar#7. Fork with 'gh repo fork foo/bar' first.",
+  }, overrides)));
+}
+
+test('interactive is the default mode; headless is opt-in via CONTRIBUTOR_MODE', () => {
+  const def = loadRelay({ backend: 'claude' });
+  try {
+    assert.strictEqual(def.CONTRIBUTOR_MODE, def.MODE_INTERACTIVE,
+      'absent CONTRIBUTOR_MODE must select the interactive path');
+  } finally { teardown(def); }
+
+  const head = loadRelay({ backend: 'claude', mode: 'headless' });
+  try {
+    assert.strictEqual(head.CONTRIBUTOR_MODE, head.MODE_HEADLESS,
+      'CONTRIBUTOR_MODE=headless must select the headless path');
+  } finally { teardown(head); }
+});
+
+test('headless dispatch runs a one-shot execFile and never types into tmux', () => {
+  const relay = loadRelay({ backend: 'claude', mode: 'headless' });
+  try {
+    assignHeadlessTask(relay);
+
+    // The prompt went to a one-shot CLI invocation...
+    assert.strictEqual(relay.__execFileCalls.length, 1, 'expected exactly one one-shot invocation');
+    const call = relay.__execFileCalls[0];
+    assert.strictEqual(call.bin, 'claude', 'claude backend should run the claude binary');
+    assert.ok(call.args.includes('-p'), `claude headless must use print mode: ${JSON.stringify(call.args)}`);
+    assert.ok(call.args[call.args.length - 1].includes('foo/bar#7'),
+      'the prompt must be the trailing argv element (passed to execFile, never shell-quoted)');
+
+    // ...and NOT into a tmux pane. No literal send-keys on the headless path.
+    const literalSends = relay.__tmuxSends().filter(c => / -l /.test(c));
+    assert.deepStrictEqual(literalSends, [], `headless mode must not send-keys into tmux: ${literalSends}`);
+  } finally { teardown(relay); }
+});
+
+test('a successful headless run reports task_complete then ready, and status=done', () => {
+  const relay = loadRelay({ backend: 'claude', mode: 'headless', execFileResult: { stdout: 'opened https://github.com/foo/bar/pull/9\n' } });
+  try {
+    assignHeadlessTask(relay);
+    const complete = relay.__sent.find(m => m.type === 'task_complete');
+    assert.ok(complete, 'exit 0 must report task_complete');
+    assert.strictEqual(complete.task_id, 'ct-h-1');
+    assert.strictEqual(complete.pr_url, 'https://github.com/foo/bar/pull/9',
+      'a PR URL in the captured output should be reported');
+    assert.ok(relay.__sent.some(m => m.type === 'ready'), 'a completed headless task must free the relay for more work');
+    assert.strictEqual(relay.getCurrentTask(), null, 'currentTask must clear on completion');
+
+    const status = relay.__readHeadlessStatus();
+    assert.ok(status, 'a headless status file must be written for probes');
+    assert.strictEqual(status.state, relay.HEADLESS_STATE_WAITING,
+      'after completion the runner returns to the waiting state');
+  } finally { teardown(relay); }
+});
+
+test('a failing headless run reports task_failed rather than hanging', () => {
+  const err = new Error('boom'); err.code = 2;
+  const relay = loadRelay({ backend: 'copilot', mode: 'headless', execFileResult: { err, stderr: 'fatal: something\n' } });
+  try {
+    assignHeadlessTask(relay);
+    const failure = relay.__sent.find(m => m.type === 'task_failed');
+    assert.ok(failure, 'a non-zero exit must report task_failed (never a silent stall)');
+    assert.match(failure.reason, /exited with error|code 2/i);
+    assert.ok(relay.__sent.some(m => m.type === 'ready'), 'the relay must stay available after a failed headless task');
+    assert.strictEqual(relay.getCurrentTask(), null, 'currentTask must clear on failure');
+
+    const status = relay.__readHeadlessStatus();
+    assert.strictEqual(status.state, relay.HEADLESS_STATE_FAILED, 'status must record the failure for a probe');
+  } finally { teardown(relay); }
+});
+
+test('a headless timeout kill is reported as a failure, not a completion', () => {
+  const err = new Error('timeout'); err.killed = true; err.signal = 'SIGKILL';
+  const relay = loadRelay({ backend: 'claude', mode: 'headless', execFileResult: { err } });
+  try {
+    assignHeadlessTask(relay);
+    const failure = relay.__sent.find(m => m.type === 'task_failed');
+    assert.ok(failure, 'a timed-out headless child must report task_failed');
+    assert.match(failure.reason, /exceeded.*min|killed/i);
+    assert.ok(!relay.__sent.some(m => m.type === 'task_complete'), 'a killed task must never look completed');
+  } finally { teardown(relay); }
+});
+
+test('headless refuses an unsupported backend loudly instead of stalling', () => {
+  const relay = loadRelay({ backend: 'goose', mode: 'headless' });
+  try {
+    assert.strictEqual(relay.headlessSupportsBackend(), false, 'goose has no one-shot mode');
+    assignHeadlessTask(relay);
+    // No CLI was ever spawned...
+    assert.strictEqual(relay.__execFileCalls.length, 0, 'an unsupported backend must not spawn a CLI');
+    // ...and the task was failed permanently rather than left hanging.
+    const failure = relay.__sent.find(m => m.type === 'task_failed');
+    assert.ok(failure, 'an unsupported backend must fail the task, not silently accept it');
+    assert.strictEqual(failure.permanent, true, 'no other contributor with this backend can run it either');
+    assert.match(failure.reason, /no headless|non-interactive/i);
+  } finally { teardown(relay); }
+});
+
+test('buildHeadlessArgv maps each supported backend to its one-shot invocation', () => {
+  const claude = loadRelay({ backend: 'claude', mode: 'headless' });
+  try {
+    const a = claude.buildHeadlessArgv('do the thing');
+    assert.strictEqual(a.bin, 'claude');
+    assert.ok(a.args.includes('-p') && a.args[a.args.length - 1] === 'do the thing');
+  } finally { teardown(claude); }
+
+  const codex = loadRelay({ backend: 'codex', mode: 'headless' });
+  try {
+    const a = codex.buildHeadlessArgv('do the thing');
+    assert.strictEqual(a.bin, 'codex');
+    assert.ok(a.args.includes('exec') && a.args[a.args.length - 1] === 'do the thing',
+      `codex must use 'exec' one-shot: ${JSON.stringify(a.args)}`);
+  } finally { teardown(codex); }
+
+  const goose = loadRelay({ backend: 'goose', mode: 'headless' });
+  try {
+    assert.strictEqual(goose.buildHeadlessArgv('x'), null, 'unsupported backend has no argv');
+  } finally { teardown(goose); }
+});
+
+test('interactive mode still delivers via tmux send-keys (unchanged default path)', () => {
+  const relay = loadRelay({ backend: 'copilot' }); // default interactive
+  try {
+    relay.setCliReady(true);
+    assignHeadlessTask(relay); // reuse the task shape; mode is interactive here
+    // Interactive path uses tmux, not execFile.
+    assert.strictEqual(relay.__execFileCalls.length, 0, 'interactive mode must not use the one-shot runner');
+    const literalSends = relay.__tmuxSends().filter(c => / -l /.test(c));
+    assert.ok(literalSends.some(c => c.includes('foo/bar#7')),
+      'interactive mode must still type the prompt into tmux');
   } finally { teardown(relay); }
 });
 

--- a/config/contributor.env.example
+++ b/config/contributor.env.example
@@ -10,3 +10,14 @@ HIVE_HUB=wss://hive.kubestellar.io:3001/contribute
 
 # Preferred CLI backend (claude, copilot, gemini, goose, bob)
 AGENT_BACKEND=claude
+
+# Task-delivery mode (kubestellar/hive#2538). Default: interactive.
+#   interactive — types tasks into an attached tmux pane (needs a TTY; the
+#                 classic `just contribute-run` container).
+#   headless    — drives the backend CLI in a one-shot / print invocation
+#                 (claude -p, copilot -p, codex exec) and reports the exit
+#                 status back to the hub. No tmux, no attaching to type
+#                 `/login` — suitable for a future unattended / Kubernetes
+#                 contributor (#2549). Only claude/litellm/copilot/codex are
+#                 supported headlessly today; other backends refuse loudly.
+# CONTRIBUTOR_MODE=interactive

--- a/v2/compose-contributor.yaml
+++ b/v2/compose-contributor.yaml
@@ -17,3 +17,9 @@ services:
       - HIVE_HUB=${HIVE_HUB:-wss://hive.kubestellar.io:3001/contribute}
       - AGENT_BACKEND=${AGENT_BACKEND:-claude}
       - AGENT_MODEL=${AGENT_MODEL:-}
+      # Task-delivery mode (kubestellar/hive#2538): interactive (default, tmux)
+      # or headless (one-shot CLI, no TTY). This compose file keeps stdin/tty on
+      # for the default interactive path; a headless deployment (a future K8s
+      # Job/Deployment, #2549) would set CONTRIBUTOR_MODE=headless and needs no
+      # TTY.
+      - CONTRIBUTOR_MODE=${CONTRIBUTOR_MODE:-interactive}


### PR DESCRIPTION
## The interactive-only mechanism today

Every task reaches the contributor's backend CLI through **`tmux send-keys`** into a live pane. `bin/contributor-relay.sh`'s `tmuxSendKeys()` clears the pane and types the prompt as literal keystrokes (`send-keys -l`), and `getCLIState()`/`checkTmuxIdle()` scrape the pane to know when the CLI is ready, working, or done. `bin/contributor-agent.sh` launches the CLI into a tmux session and the compose file sets `stdin_open: true` / `tty: true`. The documented auth-recovery path is literally "attach to tmux and type `/login`".

That makes the contributor **interactive-only**: a headless Kubernetes pod (#2549) has no attachable terminal, so it would start, reach a prompt it cannot satisfy, and stall — a pod that looks healthy while doing nothing. That is the exact failure #2538 warns about, and it is the prerequisite the maintainers ordered *before* K8s packaging (#2549) and the credential boundary (#2537).

## The headless mode this PR adds

An **opt-in, additive** `CONTRIBUTOR_MODE` selector (named constants `interactive` (default) / `headless`):

- **Which backends:** `claude` / `litellm` (`-p` print mode), `copilot` (`-p`), `codex` (`exec`) — the backends with a verified one-shot/print invocation. `goose` / `bob` / `agy` / `pi` drive interactive TUIs with no known non-interactive entry point and are **refused loudly** at startup and per task rather than accepted and stalled. `HEADLESS_BACKENDS` is a single table; adding a backend later is one entry.
- **How it avoids `tmux send-keys`:** on `task_assign`, headless mode calls `runHeadlessTask()`, which spawns the one-shot CLI via `execFile(bin, [...permFlags, ...modelFlag, oneShotFlag, prompt])` — the prompt is a distinct argv element (never shell-interpolated, so the #2203 apostrophe wedge cannot happen), captures bounded, token-redacted output, and reports back over the **same** protocol (`task_progress` → `task_complete`/`task_failed` → `ready`). No tmux session, no pane scraping, no readiness wait. The entrypoint skips the tmux session + CLI launch + auto-dismiss entirely in headless mode.
- **Status reporting:** a per-task process timeout (`HEADLESS_TASK_TIMEOUT_MS`, = the existing `MAX_TASK_DURATION_MS`) kills a wedged CLI and reports a real failure — never a silent hang. `runHeadlessTask` writes a status file (`HIVE_HEADLESS_STATUS_FILE`) with a coarse lifecycle state — `waiting` / `working` / `done` / `failed` — so a supervising process or a future K8s liveness/readiness probe can distinguish "working" from "stalled" from cluster state alone.

## Opt-in / default-unchanged

Absent or any-other `CONTRIBUTOR_MODE` value keeps the interactive tmux path **exactly** as before. The interactive readiness/queueing/give-up/#2596 machinery is untouched, and this builds alongside #2557 (real workspace, slot release on abandon) without undoing it. Compose keeps `tty`/`stdin` on for the default path; a headless deployment sets `CONTRIBUTOR_MODE=headless` and needs no TTY.

## Tests

Extends `bin/contributor-relay.test.js` (now 26/26 passing) with the headless dispatch path via the existing test seams: mode selection honored (interactive default, headless opt-in); task in → one-shot `execFile` → `task_complete`+`ready`+status=`waiting`; a non-zero exit → `task_failed` (not a hang); a timeout kill → failure, never a bogus completion; an unsupported backend → loud permanent failure with no CLI spawned; per-backend argv mapping (`claude -p`, `codex exec`); and a regression that interactive mode still delivers via tmux and never uses the one-shot runner.

## Deferred follow-ons (explicit maintainer ordering)

- **#2549** — K8s Job/Deployment manifests. NOT built here.
- **#2537** — credential boundary (gate token delivery on task acceptance; narrower scope for a cluster-resident workload). NOT built here.

`Part of #2538` — this is a first useful slice, not the whole epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)