### PR TITLE
security(proxy): fail closed on empty dashboard token (F2) + verify terminal cookie HMAC (F3)

### DIFF
--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -14,9 +14,27 @@ const TTYD_PORT = parseInt(process.env.HIVE_TTYD_PORT || '7681', 10);
 const TTYD_URL = `http://127.0.0.1:${TTYD_PORT}`;
 const DASHBOARD_TOKEN = process.env.HIVE_DASHBOARD_TOKEN || '';
 const STATIC_DIR = process.env.HIVE_STATIC_DIR || path.join(__dirname, 'public');
+// HIVE_HUB_SECRET is present ONLY on hub-hosted hives (injected by the hub at
+// provision time). Its presence is the boot-time signal that this hive runs
+// hosted, where per-request identity comes from the hub-minted, HMAC-signed
+// `hive_hub_user` cookie (verified below) rather than a shared dashboard token.
+const HUB_SECRET = process.env.HIVE_HUB_SECRET || '';
 
-if (!DASHBOARD_TOKEN && process.env.NODE_ENV === 'production') {
-  console.error('[SECURITY] HIVE_DASHBOARD_TOKEN is not set — all mutations are unauthenticated!');
+// SECURITY (fail closed on empty dashboard token — CWE-306).
+//
+// The prior guard only fired when NODE_ENV === 'production', but NODE_ENV is
+// never set in any deploy manifest, so it was dead code: every shipped
+// self-hosted deploy ran with unauthenticated mutation endpoints. Reverse the
+// polarity — the guard now fires in every real deploy and only the unit test
+// (which sets NODE_ENV=test) opts out.
+//
+// Hosted hives INTENTIONALLY run with HIVE_DASHBOARD_TOKEN unset: identity is
+// carried by the hub cookie, so a missing token is expected there and the proxy
+// must still boot. HUB_SECRET being set proves hosted mode. Only a self-hosted
+// deploy with neither a token nor a hub secret is truly unauthenticated, and
+// that is what we refuse to start.
+if (!DASHBOARD_TOKEN && !HUB_SECRET && process.env.NODE_ENV !== 'test') {
+  console.error('[SECURITY] HIVE_DASHBOARD_TOKEN is not set and this hive is not hub-hosted (HIVE_HUB_SECRET unset) — all mutation endpoints would be unauthenticated. Refusing to start. Set HIVE_DASHBOARD_TOKEN.');
   process.exit(1);
 }
 
@@ -34,6 +52,35 @@ function requireAuth(req, res, next) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
   next();
+}
+
+// verifyHubUserCookie mirrors verifyHubUserCookieValue in v2/pkg/hub/hub_cookie.go
+// EXACTLY. The `hive_hub_user` cookie value is `<username>.<sig>` where sig is
+// base64url-unpadded HMAC-SHA256(key=HUB_SECRET, msg=username). The proxy holds
+// no other secret and must not merely check that the cookie is non-empty (that
+// was CWE-345: any `Cookie: hive_hub_user=x` yielded a shell in a
+// credential-holding container). We recompute the HMAC and constant-time-compare
+// the signature; a forged, edited, or legacy-unsigned cookie fails closed.
+//
+// Returns the verified username on success, or '' when the signature does not
+// verify / the secret is unset / the value is malformed.
+function verifyHubUserCookie(secret, value) {
+  if (!secret || !value) return '';
+  // SplitN from the right: the final segment is the signature.
+  const idx = value.lastIndexOf('.');
+  if (idx <= 0 || idx === value.length - 1) return '';
+  const username = value.slice(0, idx);
+  const sig = value.slice(idx + 1);
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(username)
+    .digest('base64url'); // base64url is unpadded, matching Go's RawURLEncoding
+  const suppliedBuf = Buffer.from(sig);
+  const expectedBuf = Buffer.from(expected);
+  if (suppliedBuf.length !== expectedBuf.length || !crypto.timingSafeEqual(suppliedBuf, expectedBuf)) {
+    return '';
+  }
+  return username;
 }
 
 app.use((req, res, next) => {
@@ -142,7 +189,9 @@ app.use('/terminal', (req, res, next) => {
       if (k) acc[k] = v.join('=');
       return acc;
     }, {});
-    const user = cookies['hive_hub_user'];
+    // SECURITY (CWE-345): the cookie is HMAC-signed by the hub. Verify the
+    // signature — a non-empty value is NOT proof of authentication.
+    const user = verifyHubUserCookie(HUB_SECRET, cookies['hive_hub_user']);
     if (!user) {
       if (req.headers.upgrade === 'websocket') {
         req.socket.destroy();
@@ -227,7 +276,8 @@ server.on('upgrade', (req, socket, head) => {
         if (k) acc[k] = v.join('=');
         return acc;
       }, {});
-      if (!cookies['hive_hub_user']) {
+      // SECURITY (CWE-345): verify the hub's HMAC signature, not mere existence.
+      if (!verifyHubUserCookie(HUB_SECRET, cookies['hive_hub_user'])) {
         socket.destroy();
         return;
       }


### PR DESCRIPTION
Fixes two verified CRITICAL findings from Jonathan Springer's 2026-08-05 proxy audit, both re-verified against v4 tip `d7de0165` and both in `v2/proxy/server.js`. Minimal, surgical; self-hosted token auth is untouched.

## F2 — Dead auth guard (CWE-306, Missing Authentication for Critical Function)

The empty-token guard fired only when `NODE_ENV === 'production'`, but `NODE_ENV` is set in **no** deploy manifest (it appears only at `server.js:18` and `server.test.js`), so the guard was dead code — **every shipped self-hosted deploy ran with unauthenticated mutation endpoints.**

**Fix:** reverse the polarity so the guard fires in every real deploy and only opts out under `NODE_ENV=test` (the sole caller that sets it, in the unit test).

**Hosted vs self-hosted nuance:** hosted hives *intentionally* run with `HIVE_DASHBOARD_TOKEN` unset — identity there comes from the hub-minted `hive_hub_user` cookie, not a shared token — and the proxy must still boot. The clean boot-time hosted signal is `HIVE_HUB_SECRET`, injected into the pod only on hub-hosted hives (`saas_provision.go` env block) and absent on self-hosted. So the guard fails closed **only** when a deploy has neither a dashboard token nor a hub secret — the genuinely-unauthenticated self-hosted case. Self-hosted operators must set `HIVE_DASHBOARD_TOKEN` (the k8s deployment already wires it from the `hive-secrets` secret).

Truth table (verified in isolation):
| token | HIVE_HUB_SECRET | NODE_ENV | boots? |
|---|---|---|---|
| unset | unset | unset | **no — exit 1** |
| unset | set (hosted) | unset | yes |
| set | unset | unset | yes |
| unset | unset | test | yes |

## F3 — Terminal cookie existence-only check (CWE-345, Insufficient Verification of Data Authenticity)

`/terminal` on hosted hives was gated by checking only that `cookies['hive_hub_user']` was **non-empty** — on both the HTTP handler (~L145) and the WebSocket upgrade (~L230). The cookie is HMAC-signed by the hub, but the proxy never verified it, so `Cookie: hive_hub_user=x` yielded a **shell in a credential-holding container**. This is the whole security boundary for terminal access on hosted hives: the `hive-terminal` Ingress (`saas_provision.go`) has **no** `auth-url` annotation, so unlike the main dashboard Ingress it does **not** pass through the hub's nginx `auth-check` — traffic hits the proxy's terminal port directly.

**Approach chosen — reimplement the verify in the proxy (the audit's fallback), not delegate to the Go API.** The audit's preferred option was to delegate to a Go endpoint that returns authenticated-status by verifying the cookie HMAC. I checked the candidates and **none of the local spoke Go endpoints actually verify the cookie HMAC**: `/api/gh-user-auth/status` trusts the hub-injected `X-Hive-User` header (or falls back to a persisted token), and `/api/role` reads the cookie value **raw** — both existence-only, and neither is reachable through the hub's cookie verifier from the proxy's 127.0.0.1 hop. `verifyHubUserCookieValue` runs only in the `hub` package (hub side), which the proxy cannot reach on the terminal path. Delegating would have reproduced the exact vulnerability, and the audit is explicit: confirm the endpoint verifies the HMAC before relying on it.

So I took the documented fallback: `HIVE_HUB_SECRET` is **already** plumbed to the proxy container (no `entrypoint.sh` change needed), so I added `verifyHubUserCookie()` — a byte-for-byte JS port of `verifyHubUserCookieValue` in `v2/pkg/hub/hub_cookie.go`:

- scheme `username.base64url_unpadded(HMAC-SHA256(key=secret, msg=username))`
- Node `.digest('base64url')` == Go `base64.RawURLEncoding` (unpadded, URL-safe)
- constant-time compare via `crypto.timingSafeEqual`
- rejects forged, edited, legacy-unsigned (no `.`), trailing-dot, wrong-secret, and no-secret values → returns `''`

**Cross-checked against the real Go implementation:** for `secret=test-hub-secret, username=alice` both produce `alice.VcqEFsR69FPzX8JMDBglj2M3p9Px-Tzdxv8Czs7naPo`, so real hub-minted cookies verify and the `Cookie: hive_hub_user=x` attack now returns `''` → HTTP 401 / socket destroy. Applied to **both** the HTTP `/terminal` middleware and the WS-upgrade path.

## Validation
- `node --check v2/proxy/server.js` passes (build/lint/tests left to CI per repo policy).
- F2 guard boolean and F3 verify were unit-tested in isolation (all cases pass; see truth table + the rejection set above).

## Residual concerns
- **`handleRole` (`api.go:449`) reads `hive_hub_user` raw** — same existence-only class as F3, but it only echoes a role/username string, not a shell. Out of scope for this PR; worth a follow-up to route it (and any other raw cookie readers) through the verifier or the hub-injected header.
- **Self-hosted deploys with an empty token now fail to start** (by design). Operators running tokenless self-hosted must set `HIVE_DASHBOARD_TOKEN`; the k8s deployment already wires it from `hive-secrets`.
- F3 depends on `HIVE_HUB_SECRET` being present on every hosted hive (it is, per the provisioning template); if it were ever unset on a hosted hive, terminal access fails closed (401) — the safe direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
