### PR TITLE
security(egress): make proxy iptables setup fatal by default (F5) + configurable hub admin (F12)

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -692,7 +692,23 @@ print('[entrypoint] UID map written to /var/run/hive/uid-map.json')
 
     # Set up iptables: redirect all outbound :443 to the MITM proxy port,
     # except traffic from the proxy itself (UID 1001 / dev user).
+    #
+    # ── Fail-closed egress enforcement (security-critical: audit F5, CWE-693) ──
+    # The ACMM capability model's binding control is FORCED egress: agents hold
+    # tier-scoped tokens, but the *forced* redirect of outbound :443 to the MITM
+    # proxy is what actually confines a raw token to the proxy's policy. If that
+    # redirect is not established (iptables missing, or NET_ADMIN unavailable),
+    # an agent holding a raw token can reach api.github.com directly and the
+    # entire capability model degrades to advisory-only — a fail-OPEN control.
+    #
+    # Therefore: a failure to establish the redirect is FATAL by default. The
+    # container refuses to start rather than run with unenforced egress. The
+    # ONLY escape hatch is an EXPLICIT operator opt-in via
+    # HIVE_PROXY_ADVISORY_OK=true, for deliberate advisory deployments (local
+    # dev, platforms without NET_ADMIN). We never silently continue.
     PROXY_PORT=18443
+    PROXY_ADVISORY_OK="${HIVE_PROXY_ADVISORY_OK:-false}"
+    _iptables_ok=false
     if command -v iptables >/dev/null 2>&1; then
       if iptables -t nat -N HIVE_PROXY 2>/dev/null; then
         iptables -t nat -A HIVE_PROXY -m owner --uid-owner 0 -j RETURN
@@ -700,6 +716,7 @@ print('[entrypoint] UID map written to /var/run/hive/uid-map.json')
         iptables -t nat -A HIVE_PROXY -p tcp --dport 443 -j REDIRECT --to-ports "$PROXY_PORT"
         iptables -t nat -A OUTPUT -j HIVE_PROXY
         echo "[entrypoint] iptables: outbound :443 -> :${PROXY_PORT} (proxy UID ${PROXY_UID} exempt)"
+        _iptables_ok=true
         # Update uid-map to record iptables active
         python3 -c "
 import json
@@ -710,10 +727,20 @@ with open('/var/run/hive/uid-map.json', 'w') as f:
     json.dump(m, f, indent=2)
 " 2>/dev/null || true
       else
-        echo "[entrypoint] WARN: iptables chain creation failed (need NET_ADMIN capability)"
+        echo "[entrypoint] ERROR: iptables chain creation failed (need NET_ADMIN capability)"
       fi
     else
-      echo "[entrypoint] WARN: iptables not found, proxy enforcement is advisory-only"
+      echo "[entrypoint] ERROR: iptables not found — cannot force proxy egress"
+    fi
+
+    if [ "$_iptables_ok" != "true" ]; then
+      if [ "$PROXY_ADVISORY_OK" = "true" ]; then
+        echo "[entrypoint] WARN: proxy egress enforcement is ADVISORY-ONLY (HIVE_PROXY_ADVISORY_OK=true set). Agents can bypass the MITM proxy — capability model is NOT enforced."
+      else
+        echo "[entrypoint] FATAL: could not establish forced proxy egress (iptables redirect). The ACMM capability model would be advisory-only, allowing agents with raw tokens to bypass the MITM proxy." >&2
+        echo "[entrypoint] FATAL: refusing to start. Grant NET_ADMIN + install iptables, or set HIVE_PROXY_ADVISORY_OK=true to deliberately run in advisory mode." >&2
+        exit 1
+      fi
     fi
   fi
 

--- a/v2/pkg/hub/hub_admin_username_test.go
+++ b/v2/pkg/hub/hub_admin_username_test.go
@@ -1,0 +1,39 @@
+package hub
+
+import (
+	"os"
+	"testing"
+)
+
+// TestResolveHubAdminUsername verifies the fleet-superuser login is
+// configurable via HIVE_HUB_ADMIN_USERNAME with a backward-compatible default
+// (audit F12, CWE-798).
+func TestResolveHubAdminUsername(t *testing.T) {
+	cases := []struct {
+		name  string
+		unset bool
+		env   string
+		want  string
+	}{
+		{name: "unset falls back to default", unset: true, want: defaultHubAdminUsername},
+		{name: "blank falls back to default", env: "", want: defaultHubAdminUsername},
+		{name: "whitespace-only falls back to default", env: "   ", want: defaultHubAdminUsername},
+		{name: "override is honored", env: "fleet-admin", want: "fleet-admin"},
+		{name: "override is trimmed", env: "  padded-admin  ", want: "padded-admin"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// t.Setenv registers cleanup that restores the prior value after
+			// the subtest, so mutating the env here is safe.
+			t.Setenv("HIVE_HUB_ADMIN_USERNAME", tc.env)
+			if tc.unset {
+				if err := os.Unsetenv("HIVE_HUB_ADMIN_USERNAME"); err != nil {
+					t.Fatalf("unset env: %v", err)
+				}
+			}
+			if got := resolveHubAdminUsername(); got != tc.want {
+				t.Fatalf("resolveHubAdminUsername() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -27,7 +27,30 @@ import (
 
 var saasUsersDir = "/data/saas/users"
 
-const hubAdminUsername = "clubanderson"
+// defaultHubAdminUsername is the compile-time fallback fleet-superuser
+// GitHub login, used when HIVE_HUB_ADMIN_USERNAME is not set in the
+// environment. Keeping the historical value as the default preserves
+// backward compatibility for existing deployments.
+const defaultHubAdminUsername = "clubanderson"
+
+// hubAdminUsername is the GitHub login treated as the fleet superuser. It is
+// resolved once at package init from HIVE_HUB_ADMIN_USERNAME (falling back to
+// defaultHubAdminUsername), rather than being a hardcoded constant (audit F12,
+// CWE-798). This lets a deployment override the admin login via config and
+// removes the fragility where a GitHub username rename or release would silently
+// transfer — or forfeit — fleet-superuser privilege. It is set once at startup
+// and treated as read-only thereafter (never mutated at runtime).
+var hubAdminUsername = resolveHubAdminUsername()
+
+// resolveHubAdminUsername reads the admin login from the environment, trimming
+// surrounding whitespace, and falls back to defaultHubAdminUsername when the
+// env var is unset or blank.
+func resolveHubAdminUsername() string {
+	if v := strings.TrimSpace(os.Getenv("HIVE_HUB_ADMIN_USERNAME")); v != "" {
+		return v
+	}
+	return defaultHubAdminUsername
+}
 
 // hubUpgradeDebounce is the minimum gap between hub self-upgrade rollout
 // restarts. The behind-latest check runs every SHA-poll cycle, so without this


### PR DESCRIPTION
Addresses two verified findings from Springer's 2026-08-05 security audit.

## F5 — L5 confinement rested on iptables that failed OPEN (HIGH, CWE-693)

The ACMM capability model's binding control is **forced egress**: iptables redirects outbound `:443` to the MITM proxy so an agent holding a raw token is still confined to the proxy's policy. But `v2/deploy/entrypoint.sh` previously logged a `WARN` and **continued** when iptables was missing or `NET_ADMIN` was unavailable ("iptables not found, proxy enforcement is advisory-only" / "iptables chain creation failed"). In that state an agent could `curl api.github.com` directly and the entire capability model silently degraded to advisory-only — a fail-**OPEN** control.

**Fix (audit rec #6): fatal-by-default.** Failure to establish the outbound `:443 → proxy` redirect is now **FATAL** (`exit 1`; the container refuses to start) rather than continuing in advisory mode.

**Advisory opt-out.** No pre-existing advisory/dev-mode env signal existed for this path, so this PR adds one: **`HIVE_PROXY_ADVISORY_OK`**. Default (`false`) ⇒ fatal on iptables failure. Set to `true` ⇒ deliberate advisory mode (local dev, platforms without `NET_ADMIN`), logging a loud WARN that egress is unenforced. We never silently continue. The check is scoped to the existing per-agent-isolation block (`[ -n "$AGENT_NAMES" ]`) — i.e. it fires exactly when a hive has agents and confinement actually matters.

**Token-scope half — investigated, reported, NOT changed.** The audit's secondary suggestion was to scope the L5 token without `Contents: write`. `v2/pkg/mint/agent.go` documents `ScopeContentsWrite` as "*lets the bearer push branches / open PRs*", and the contributor/trusted tiers grant it (`agent.go:46-47`); the parallel `ScopedToken` App-permission path (`v2/pkg/github/app.go:201-215`) grants `Contents: write` for the same tiers. On GitHub, **pushing branch commits requires `Contents: write`** — `Pull requests: write` alone creates the PR object but cannot push the branch the PR is opened from. The L5 workflow is explicitly "push a branch, then open a PR" (`agentCanWrite`/`CanPush`, `manager.go:4611`; level-6 pack "Agents open issues, create PRs"). **Removing `Contents: write` would break the normal PR-open/push flow, so it was left in place.** Treating this as a design question per the task constraints — see "Residual concerns" below.

## F12 — hubAdminUsername hardcoded fleet superuser (LOW, CWE-798)

`const hubAdminUsername = "clubanderson"` (`v2/pkg/hub/saas.go`) was a hardcoded fleet-superuser login. Not directly spoofable (`getAuthUser` requires an HMAC-verified cookie or a GitHub-validated bearer), so residual risk is account compromise or a GitHub username rename/release silently transferring or forfeiting superuser privilege.

**Fix:** `hubAdminUsername` is now a package-level `var` resolved **once at package init** from `HIVE_HUB_ADMIN_USERNAME`, falling back to the historical `defaultHubAdminUsername = "clubanderson"` when unset/blank (backward-compatible). It is set once at startup and read-only thereafter. All ~60 existing reference sites (production + tests) consume the package var unchanged — no call-site edits needed. A unit test (`hub_admin_username_test.go`) covers unset/blank/whitespace/override/trim behavior.

## Verification

- `bash -n v2/deploy/entrypoint.sh` — clean.
- `gofmt` — clean on both Go files.
- `cd v2 && go test ./pkg/hub/ -short -count=1 -cover` — **89.5%** (above the 89 floor); new test passes. One unrelated failure (`TestAlertAcksPersistRoundTrip`) reproduces on a clean `origin/v4` checkout — pre-existing, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
