### PR TITLE
security(identity): default proxy-proof required (F7) + deny ownerless/missing-role config download (F9)

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -624,11 +624,10 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleConfigDownload(w http.ResponseWriter, r *http.Request) {
-	role := r.Header.Get("X-Hive-Role")
-	if role == "" {
-		role = "owner"
-	}
-	if role != "owner" {
+	// F9 (CWE-862): the raw hive.yaml carries secrets, so a MISSING X-Hive-Role
+	// must NOT default to owner on a spoke that has an auth boundary. Least
+	// privilege: only a genuinely open/dev spoke treats an empty role as owner.
+	if !s.requestRoleAllowsOwner(r) {
 		http.Error(w, "owner access required", http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/dashboard/coverage_boost3_test.go
+++ b/v2/pkg/dashboard/coverage_boost3_test.go
@@ -601,10 +601,13 @@ func TestSecurityHeaders_WithAuthToken(t *testing.T) {
 		t.Errorf("internal token: code = %d, want 200", w.Code)
 	}
 
-	// Hub auth headers
+	// Hub auth headers. F7: the fail-closed default requires the hub's proof
+	// header (X-Hive-Proxy-Auth) alongside the identity headers; the real hub
+	// injects it. With a valid proof the request is trusted.
 	req = httptest.NewRequest("GET", "/api/kick/scanner", nil)
 	req.Header.Set("X-Hive-User", "testuser")
 	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(proxyAuthHeader, "secret-token")
 	w = httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {

--- a/v2/pkg/dashboard/dashboard_config_download_test.go
+++ b/v2/pkg/dashboard/dashboard_config_download_test.go
@@ -460,6 +460,61 @@ func TestHandleGitSourcesConnectBadJSON(t *testing.T) {
 	}
 }
 
+// TestHandleConfigDownloadMissingRoleDeniedWithAuthToken pins F9 (CWE-862): on a
+// spoke that HAS an auth boundary (a shared authToken), a request with NO
+// X-Hive-Role must be denied — a missing role must not be silently promoted to
+// owner and hand out the raw hive.yaml. This is the compounding half of the
+// ownerless-config finding.
+func TestHandleConfigDownloadMissingRoleDeniedWithAuthToken(t *testing.T) {
+	srv := newMinimalServer(t)
+	srv.authToken = "shared-secret-token" // gives the spoke an auth boundary
+	req := httptest.NewRequest("GET", "/api/config/download", nil)
+	// No X-Hive-Role header at all.
+	w := httptest.NewRecorder()
+	srv.handleConfigDownload(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("missing role on a token-guarded spoke must be denied; got %d, want 403", w.Code)
+	}
+}
+
+// TestHandleConfigDownloadOwnerRoleAllowed confirms the legitimate owner path is
+// untouched by the F9 fix: an explicit owner role is served even on a
+// token-guarded spoke.
+func TestHandleConfigDownloadOwnerRoleAllowed(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "hive.yaml")
+	os.WriteFile(cfgPath, []byte("project:\n  org: testorg\n"), 0644)
+	t.Setenv("HIVE_CONFIG", cfgPath)
+
+	srv := newMinimalServer(t)
+	srv.authToken = "shared-secret-token"
+	req := httptest.NewRequest("GET", "/api/config/download", nil)
+	req.Header.Set("X-Hive-Role", "owner")
+	w := httptest.NewRecorder()
+	srv.handleConfigDownload(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("explicit owner must still be served; got %d, want 200", w.Code)
+	}
+}
+
+// TestHandleConfigDownloadMissingRoleOpenSpoke confirms the open/dev spoke (no
+// authToken, no allowlist) still treats a missing role as owner — the documented
+// convenience where there is no security boundary to protect.
+func TestHandleConfigDownloadMissingRoleOpenSpoke(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "hive.yaml")
+	os.WriteFile(cfgPath, []byte("project:\n  org: testorg\n"), 0644)
+	t.Setenv("HIVE_CONFIG", cfgPath)
+
+	srv := newMinimalServer(t) // NewServer => authToken=="" and no allowlist
+	req := httptest.NewRequest("GET", "/api/config/download", nil)
+	w := httptest.NewRecorder()
+	srv.handleConfigDownload(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("open/dev spoke should still serve missing-role as owner; got %d, want 200", w.Code)
+	}
+}
+
 func TestHandleConfigDownloadEnvVar(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "custom.yaml")

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -40,13 +40,23 @@ const sessionCookieMaxAge = 30 * 24 * 60 * 60 // 30 days
 // network. See authenticate() (F2). Must match the hub's constant.
 const proxyAuthHeader = "X-Hive-Proxy-Auth"
 
-// proxyProofRequired controls F2 enforcement strictness. Default false =
-// fail-open rollout: a request with no proof header is still trusted on its
-// identity headers (so hosted hives aren't locked out while the hub half rolls
-// out fleet-wide). Set HIVE_PROXY_PROOF_REQUIRED=true (once every hub is
-// confirmed injecting the header) to fail closed: a missing/incorrect proof
-// header is rejected. A WRONG proof header is ALWAYS rejected regardless.
-var proxyProofRequired = os.Getenv("HIVE_PROXY_PROOF_REQUIRED") == "true"
+// proxyProofRequired controls F2 enforcement strictness. It now defaults to
+// TRUE (fail closed): a hub-proxied request that carries identity headers but
+// NO valid X-Hive-Proxy-Auth proof is rejected, so a request forged on the pod
+// network that reaches :3002 directly (bypassing the hub nginx) cannot be
+// trusted on its X-Hive-User/X-Hive-Role alone (F7, CWE-306). The hub half is
+// shipped fleet-wide — its auth-check success path injects X-Hive-Proxy-Auth
+// (see hub saas.go handleSaaSAuthCheck) and its nginx forwards it via the
+// auth-response-headers annotation — so the legitimate proxied path always
+// presents a valid proof and stays trusted.
+//
+// A WRONG proof header is ALWAYS rejected regardless of this flag. The only
+// difference this flag makes is how a MISSING proof is treated: strict (default)
+// rejects it; fail-open trusts the identity headers. Set
+// HIVE_PROXY_PROOF_REQUIRED=false ONLY as a temporary escape hatch if a hub is
+// found not to be injecting the proof (e.g. mid-rollback); it re-opens the F7
+// hole and must not be left set in production.
+var proxyProofRequired = os.Getenv("HIVE_PROXY_PROOF_REQUIRED") != "false"
 
 type Server struct {
 	port       int
@@ -834,12 +844,13 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		// only the trusted proxy can produce. Require it as PROOF the request
 		// transited the hub.
 		//
-		// ROLLOUT SAFETY — fail open until the hub half is everywhere: if the hub
-		// has NOT sent X-Hive-Proxy-Auth (older hub image mid-rollout), fall back
-		// to the pre-F2 behavior (trust the identity headers) so no hosted hive is
-		// locked out. Once the hub half is confirmed deployed fleet-wide, a
-		// follow-up flips proxyProofRequired to make a missing/incorrect proof
-		// header fail closed.
+		// FAIL CLOSED by default (F7): if the hub has NOT sent X-Hive-Proxy-Auth,
+		// the request is rejected — it did not demonstrably transit the hub nginx,
+		// so its identity headers are not trustworthy. The hub half is deployed
+		// fleet-wide, so the legitimate proxied path always carries a valid proof.
+		// The pre-F2 fail-open behavior (trust identity headers when no proof is
+		// present) is available ONLY as a temporary escape hatch by setting
+		// HIVE_PROXY_PROOF_REQUIRED=false; see proxyProofRequired.
 		if !trusted && !directRouteAuthz &&
 			r.Header.Get("X-Hive-User") != "" && r.Header.Get("X-Hive-Role") != "" {
 			proof := r.Header.Get(proxyAuthHeader)
@@ -911,6 +922,34 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 func (s *Server) directRouteAuthzEnabled() bool {
 	return s.deps != nil && s.deps.Config != nil &&
 		s.deps.Config.Dashboard.IsDirectRouteAuthzEnabled()
+}
+
+// requestRoleAllowsOwner reports whether the request should be treated as an
+// owner for owner-gated endpoints. It reads X-Hive-Role, which the authenticate
+// middleware injects from a per-user session or from a proof-verified hub header.
+//
+// SECURITY (F9, CWE-862): a MISSING role must default to LEAST privilege on any
+// spoke that has an auth boundary (a shared token or a direct-route allowlist).
+// On such a spoke an empty role means no identity was established — either a
+// dev/misconfig, or a request that reached the handler without being
+// authenticated — and must NOT be silently promoted to owner (which previously
+// let a missing-header request download the raw hive.yaml verbatim). The
+// legitimate owner always arrives with X-Hive-Role set.
+//
+// The empty-role==owner convenience is preserved ONLY for a genuinely open spoke
+// (no auth_token AND no allowlist), where there is no security boundary at all
+// and the whole dashboard is already admitted anonymously.
+func (s *Server) requestRoleAllowsOwner(r *http.Request) bool {
+	role := r.Header.Get("X-Hive-Role")
+	if role == "owner" {
+		return true
+	}
+	if role == "" {
+		// Least privilege: only an open/dev spoke (no boundary) may treat a
+		// missing role as owner.
+		return s.authToken == "" && !s.directRouteAuthzEnabled()
+	}
+	return false
 }
 
 // hubProxied reports whether this spoke sits behind the hub's nginx, which

--- a/v2/pkg/dashboard/spoke_authz_test.go
+++ b/v2/pkg/dashboard/spoke_authz_test.go
@@ -3,6 +3,7 @@ package dashboard
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -160,6 +161,11 @@ func TestMiddleware_DirectRouteSessionResolvesUser(t *testing.T) {
 
 func TestMiddleware_HubProxiedHeadersStillTrusted(t *testing.T) {
 	// Empty allowlist = hub-proxied hive; nginx-injected headers must still work.
+	// F7: since proxyProofRequired now defaults to true (fail closed), the
+	// legitimate hub path carries the X-Hive-Proxy-Auth proof (the hub's
+	// auth-check sets it fleet-wide). With a valid proof the identity headers are
+	// trusted; without it the request would be rejected (see the no-proof case
+	// below and TestMiddleware_F2ProxyProof).
 	s := newFullServer(t)
 	s.authToken = "shared-secret-token"
 	var sawUser string
@@ -167,13 +173,25 @@ func TestMiddleware_HubProxiedHeadersStillTrusted(t *testing.T) {
 	req := httptest.NewRequest("GET", "/api/config", nil)
 	req.Header.Set("X-Hive-User", "clubanderson")
 	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(proxyAuthHeader, "shared-secret-token") // proof the hub injects
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
-		t.Fatalf("hub-proxied request must be authorized, got %d", w.Code)
+		t.Fatalf("hub-proxied request with valid proof must be authorized, got %d", w.Code)
 	}
 	if sawUser != "clubanderson" {
 		t.Errorf("hub-proxied identity must be preserved, got %q", sawUser)
+	}
+
+	// Same identity headers WITHOUT the proof: now rejected by default (F7). This
+	// is the forged direct-to-:3002 request the fail-closed default blocks.
+	reqNoProof := httptest.NewRequest("GET", "/api/config", nil)
+	reqNoProof.Header.Set("X-Hive-User", "clubanderson")
+	reqNoProof.Header.Set("X-Hive-Role", "owner")
+	wNoProof := httptest.NewRecorder()
+	s.authenticate(recordingHandler(nil, nil)).ServeHTTP(wNoProof, reqNoProof)
+	if wNoProof.Code == http.StatusOK {
+		t.Fatal("forged identity headers with no proof must be rejected under the fail-closed default (F7)")
 	}
 }
 
@@ -222,6 +240,20 @@ func TestMiddleware_F2ProxyProof(t *testing.T) {
 	}
 	if c := run(t, true, ""); c == http.StatusOK {
 		t.Error("missing proof must be rejected in strict mode")
+	}
+}
+
+// TestProxyProofRequiredDefaultsStrict pins F7: the shipped default must be
+// fail-closed. A hub-proxied spoke that receives forged X-Hive-User/X-Hive-Role
+// with NO proof header must be rejected out of the box, not trusted. If someone
+// flips the default back to fail-open, this test breaks.
+func TestProxyProofRequiredDefaultsStrict(t *testing.T) {
+	// Unset means "not =false", which is the production default.
+	if os.Getenv("HIVE_PROXY_PROOF_REQUIRED") == "false" {
+		t.Skip("HIVE_PROXY_PROOF_REQUIRED=false escape hatch set in env; default not under test")
+	}
+	if !proxyProofRequired {
+		t.Fatal("proxyProofRequired must default to true (fail closed) so forged identity headers with no proof are rejected (F7)")
 	}
 }
 

--- a/v2/pkg/hub/hub_coverage_extra_test.go
+++ b/v2/pkg/hub/hub_coverage_extra_test.go
@@ -1153,7 +1153,11 @@ func TestHandleProxyHiveConfigUpstreamError(t *testing.T) {
 
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
+	// Ownerless entry: after the F9 fix the unauthenticated test caller cannot
+	// reach the upstream, so the ownership check (403) preempts any proxy fetch.
+	reached := false
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte("upstream error"))
 	}))
@@ -1161,7 +1165,7 @@ func TestHandleProxyHiveConfigUpstreamError(t *testing.T) {
 
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
-		{ID: "error-hive", DashboardURL: upstream.URL},
+		{ID: "error-hive", DashboardURL: upstream.URL}, // Owner intentionally empty
 	}
 	srv.mu.Unlock()
 
@@ -1171,9 +1175,12 @@ func TestHandleProxyHiveConfigUpstreamError(t *testing.T) {
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
-	// Proxies the upstream status
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("expected 500, got %d", w.Code)
+	// Ownerless hive is refused before the proxy fetch (F9).
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for ownerless hive, got %d", w.Code)
+	}
+	if reached {
+		t.Error("upstream was fetched for an ownerless hive — F9 regression")
 	}
 }
 

--- a/v2/pkg/hub/hub_saas_handlers_test.go
+++ b/v2/pkg/hub/hub_saas_handlers_test.go
@@ -537,7 +537,7 @@ func TestHandleProxyHiveConfigNotInRegistry(t *testing.T) {
 
 func TestHandleProxyHiveConfigWithDashboardURL(t *testing.T) {
 	// The SSRF guard blocks loopback (the httptest server address) in
-	// production; override it here so the proxy pass-through can be exercised.
+	// production; override it here so the ownership check is the only gate.
 	orig := hiveConfigSSRFGuard
 	hiveConfigSSRFGuard = func(context.Context, string) bool { return false }
 	defer func() { hiveConfigSSRFGuard = orig }()
@@ -545,7 +545,14 @@ func TestHandleProxyHiveConfigWithDashboardURL(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
+	// The upstream must NOT be reached: this registry entry is ownerless, and
+	// after the F9 fix an ownerless hive's config is not world-readable. The
+	// unauthenticated test caller (getAuthUser == "") is not the site admin, so
+	// the request is refused before any proxy fetch. A hit here would be a
+	// regression re-opening CWE-862.
+	reached := false
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
 		w.Header().Set("Content-Type", "application/x-yaml")
 		w.Write([]byte("agents:\n  scanner:\n    model: claude-sonnet\n"))
 	}))
@@ -553,7 +560,7 @@ func TestHandleProxyHiveConfigWithDashboardURL(t *testing.T) {
 
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
-		{ID: "config-hive", DashboardURL: upstream.URL},
+		{ID: "config-hive", DashboardURL: upstream.URL}, // Owner intentionally empty
 	}
 	srv.mu.Unlock()
 
@@ -563,8 +570,11 @@ func TestHandleProxyHiveConfigWithDashboardURL(t *testing.T) {
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	if w.Code != http.StatusForbidden {
+		t.Errorf("ownerless hive must be refused; expected 403, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if reached {
+		t.Error("upstream config was fetched for an ownerless hive — F9 regression")
 	}
 }
 
@@ -1127,5 +1137,33 @@ func TestHandleProxyHiveConfigSSRFAndOwnership(t *testing.T) {
 	mux.ServeHTTP(w2, req2)
 	if w2.Code != http.StatusForbidden {
 		t.Errorf("non-owner: expected 403, got %d (%s)", w2.Code, w2.Body.String())
+	}
+}
+
+// TestHandleProxyHiveConfigOwnerlessDenied pins F9 (CWE-862): an OWNERLESS
+// registry entry (Owner == "") must NOT be world-readable. Before the fix the
+// ownership check was gated on `owner != ""`, so an ownerless hive's raw config
+// was fetchable by any authenticated hub user. Now a non-admin caller is refused
+// even for an ownerless hive. The SSRF guard is disabled here so the only thing
+// that can reject the request is the ownership check.
+func TestHandleProxyHiveConfigOwnerlessDenied(t *testing.T) {
+	orig := hiveConfigSSRFGuard
+	hiveConfigSSRFGuard = func(context.Context, string) bool { return false }
+	defer func() { hiveConfigSSRFGuard = orig }()
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv.mu.Lock()
+	// Owner intentionally empty (ownerless), public URL, SSRF disabled.
+	srv.registry.Hives = []RegistryEntry{{ID: "ownerless-hive", DashboardURL: "https://example.com", Owner: ""}}
+	srv.mu.Unlock()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/saas/hive-config/{hiveID}", srv.handleProxyHiveConfig)
+
+	// caller is "" (no auth user in test) → not the admin → must be refused.
+	req := httptest.NewRequest("GET", "/api/saas/hive-config/ownerless-hive", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("ownerless hive must not be world-readable; expected 403, got %d (%s)", w.Code, w.Body.String())
 	}
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4558,7 +4558,13 @@ func (s *HubServer) handleProxyHiveConfig(w http.ResponseWriter, r *http.Request
 	// Ownership: a hive's config is private to its owner (and site admins). This
 	// endpoint proxies a server-side fetch of a self-reported DashboardURL, so
 	// without this any authenticated user could pull any hive's config.
-	if owner != "" && caller != owner && caller != hubAdminUsername {
+	//
+	// F9 (CWE-862): an OWNERLESS registry entry (owner == "") must NOT be treated
+	// as world-readable. Previously the check was gated on `owner != ""`, so a
+	// hive with no owner fell through and its raw config was fetchable by ANY
+	// authenticated hub user. Fail closed: only the site admin may pull an
+	// ownerless hive's config.
+	if caller != hubAdminUsername && (owner == "" || caller != owner) {
 		http.Error(w, `{"error":"not authorized for this hive"}`, http.StatusForbidden)
 		return
 	}


### PR DESCRIPTION
Fixes two verified MEDIUM identity/config-trust findings from the 2026-08-05 audit.

## F7 — :3002 trusted forged `X-Hive-User` / `X-Hive-Role` by default (CWE-306)

`HIVE_PROXY_PROOF_REQUIRED` defaulted `false` (fail-open) and no shipped manifest set it, so a request to the Go dashboard on `:3002` carrying `X-Hive-User` + `X-Hive-Role: owner` with **no proof header** was trusted. The K8s Service exposes 3002 cluster-wide, so anything on the pod network could forge owner identity by hitting the spoke directly and bypassing the hub nginx.

**Fix (audit rec #5):** flip the effective default to fail-closed. `proxyProofRequired` now defaults to `true` (`os.Getenv("HIVE_PROXY_PROOF_REQUIRED") != "false"`), so a hub-proxied request that carries identity headers but no valid `X-Hive-Proxy-Auth` proof is **rejected**.

**Why this is safe for the legitimate hub path:** the hub half is already shipped fleet-wide on this codebase:
- `hub/saas.go` `handleSaaSAuthCheck` sets `X-Hive-Proxy-Auth` (= the hive's dashboard token) on the auth-check success path, alongside the identity headers.
- The provision manifest's nginx annotation `auth-response-headers` includes `X-Hive-Proxy-Auth`, so nginx forwards it to the spoke.

A legitimate proxied request therefore always presents a valid proof and stays trusted. A **wrong** proof was already always rejected; the only behavior this flag changes is how a **missing** proof is treated. `HIVE_PROXY_PROOF_REQUIRED=false` remains as a documented temporary escape hatch (e.g. mid-rollback) but must not be left set in production.

**Residual note (not blocking):** the hub omits the proof header when it cannot resolve the spoke's dashboard token (`spokeProxyAuthToken` returns `""` — e.g. the hive isn't in the registry or its cluster is transiently unreachable). Under the fail-closed default, such transient failures produce a brief 403 that resolves once the token is resolvable (5-minute cache). This is the correct fail-closed behavior for a security boundary, not a lockout of a hub that "doesn't send proof" — the hub always attempts to send it.

## F9 — ownerless hive's raw config downloadable by any authenticated user (CWE-862)

Two halves, both fixed:

1. **`hub/saas.go` `handleProxyHiveConfig`** — the ownership gate was `owner != "" && caller != owner && caller != admin`, so an **ownerless** registry entry (`owner == ""`) skipped the check entirely and its raw config was fetchable by any authenticated hub user. Now: `caller != admin && (owner == "" || caller != owner)` → an ownerless hive's config is refused for everyone but the site admin (fail closed).

2. **`dashboard/api.go` `handleConfigDownload`** — a **missing** `X-Hive-Role` defaulted to `owner`, returning `hive.yaml` verbatim (secrets included). Introduced `requestRoleAllowsOwner`: an empty role is treated as owner **only** on a genuinely open/dev spoke (no `auth_token` and no direct-route allowlist); on any spoke with an auth boundary a missing role is least-privilege and denied. The legitimate owner always arrives with `X-Hive-Role` set by the `authenticate` middleware (from a per-user session or a proof-verified hub header), so the owner path is unaffected. With F7 fixed, a forged direct-to-:3002 request without a valid proof is already rejected at `authenticate` before reaching this handler; this is defense-in-depth.

## Tests

- `TestProxyProofRequiredDefaultsStrict` — pins the F7 fail-closed default.
- `TestMiddleware_HubProxiedHeadersStillTrusted` — updated to carry the proof (valid proof → 200) and assert the no-proof case is now rejected.
- `TestSecurityHeaders_WithAuthToken` — hub-auth case updated to carry the proof.
- `TestHandleConfigDownloadMissingRoleDeniedWithAuthToken` / `...OwnerRoleAllowed` / `...MissingRoleOpenSpoke` — F9 spoke-half: missing role denied on a token-guarded spoke, explicit owner allowed, open/dev spoke still permissive.
- `TestHandleProxyHiveConfigOwnerlessDenied` — F9 hub-half: ownerless hive refused, upstream not reached.
- `TestHandleProxyHiveConfig{WithDashboardURL,UpstreamError}` — updated to assert the ownerless entry is now refused (403) and the upstream is not fetched.

`go test ./pkg/hub/ ./pkg/dashboard/ -short -cover`: dashboard 81.7% (floor 78), hub 89.3% (floor 89). The only failing test, `TestAlertAcksPersistRoundTrip`, fails identically on the untouched `v4` base (pre-existing, environment/`/data`-dependent) and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)