### PR TITLE
✨ feat(contribute): first-class Kubernetes contributor workload (headless Deployment + /contribute discoverability)

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -54,6 +54,17 @@ jobs:
           cp bin/contributor-relay.sh "${RUNNER_TEMP}/contributor-relay.js"
           node --check "${RUNNER_TEMP}/contributor-relay.js"
           node bin/contributor-relay.test.js
+
+      # `just contribute-k8s` now emits a runnable contributor workload (#2549):
+      # a headless Deployment (#2660) with a status-file probe. This runs the
+      # real recipe and asserts the workload it produces, so a regression (a
+      # dropped headless mode, a broken probe, a token leak into stdout) fails
+      # the PR. Requires `just`; the test SKIPs cleanly if it is ever absent.
+      - name: Install just
+        uses: extractions/setup-just@v2
+      - name: Contributor K8s Workload Generation
+        working-directory: .
+        run: bash v2/deploy/test_contribute_k8s_workload.sh
   create-issue-on-failure:
     if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/v2'
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -739,19 +739,49 @@ contribute-stop:
     done
     $STOPPED && echo "Stopped." || echo "Not running."
 
-# Generate K8s ConfigMap + Secret YAML from contributor.env
+# Generate a runnable K8s contributor workload (Namespace + ConfigMap + Secret + Deployment)
 # Usage: just contribute-k8s                          (default namespace: hive-contributor)
 #        just contribute-k8s my-namespace              (custom namespace)
-#        just contribute-k8s my-namespace output.yaml  (write to file instead of stdout)
-contribute-k8s namespace="hive-contributor" outfile="":
+#        just contribute-k8s my-namespace out.yaml     (write to file instead of stdout)
+#        just contribute-k8s my-namespace "" v2        (pin a specific image tag, #2549)
+#
+# Unlike the earlier config-only generator, this now ALSO emits a Deployment that
+# actually RUNS the contributor relay in HEADLESS mode (kubestellar/hive#2660,
+# #2549): a headless pod has no TTY, so it sets CONTRIBUTOR_MODE=headless (the
+# interactive tmux path would stall forever waiting on a prompt nobody can type
+# into). Applying the output results in a running contributor, not three inert
+# config objects. Like before, it PRINTS YAML (or writes a file) and prints an
+# apply instruction — it never invokes kubectl itself.
+contribute-k8s namespace="hive-contributor" outfile="" image_tag="v2":
     #!/usr/bin/env bash
     set -euo pipefail
 
     # ── Constants ──
     readonly CONFIGMAP_NAME="hive-contributor-config"
     readonly SECRET_NAME="hive-contributor-secrets"
+    readonly DEPLOYMENT_NAME="hive-contributor"
     readonly ENV_FILE="{{config_dir}}/contributor.env"
     readonly GH_AUTH_FILE="{{config_dir}}/gh-auth.env"
+    # Published multi-arch image (.github/workflows/docker.yml build-contributor).
+    readonly IMAGE_REPO="ghcr.io/kubestellar/hive-contributor"
+    # CONTRIBUTOR_MODE selector values — must match bin/contributor-relay.sh.
+    readonly MODE_HEADLESS="headless"
+    # Where the headless relay writes its coarse lifecycle state as JSON
+    # (waiting/working/done/failed). Kept in step with HEADLESS_STATUS_FILE's
+    # default in bin/contributor-relay.sh; the probe below reads this exact path.
+    readonly HEADLESS_STATUS_FILE="/tmp/contributor-headless-status.json"
+    # Backends with a verified non-interactive (headless) entry point — must
+    # match HEADLESS_BACKENDS in bin/contributor-relay.sh. A headless pod on any
+    # OTHER backend (goose/bob/agy/pi) refuses work LOUDLY at startup, so we warn
+    # here rather than emit a manifest that will crash-loop with no explanation.
+    readonly HEADLESS_BACKENDS="claude litellm copilot codex"
+    # Memory sizing: the contributor image is ~2.7GiB unpacked and each task
+    # spawns a real coding-CLI + a repo build/test, so requests are deliberately
+    # generous. Named here so an operator can see and tune them, not magic YAML.
+    readonly MEM_REQUEST="1Gi"
+    readonly MEM_LIMIT="4Gi"
+    readonly CPU_REQUEST="500m"
+    readonly CPU_LIMIT="2"
 
     # ── Validate setup exists ──
     if [[ ! -f "$ENV_FILE" ]]; then
@@ -770,6 +800,27 @@ contribute-k8s namespace="hive-contributor" outfile="":
     fi
 
     NS="{{namespace}}"
+    IMAGE_TAG="{{image_tag}}"
+    IMAGE="${IMAGE_REPO}:${IMAGE_TAG}"
+    BACKEND="${AGENT_BACKEND:-claude}"
+
+    # ── Headless-backend preflight (#2549 / #2660) ──
+    # The workload runs headless. Only the backends in HEADLESS_BACKENDS have a
+    # verified non-interactive entry point; anything else makes the relay refuse
+    # work loudly at startup. Warn to STDERR (never stdout — stdout is the YAML
+    # that gets piped to kubectl) so the contributor is told BEFORE they apply,
+    # rather than debugging a crash-looping pod. We still emit the manifest so an
+    # operator switching AGENT_BACKEND to a supported one need not regenerate.
+    BACKEND_HEADLESS_OK=false
+    for b in $HEADLESS_BACKENDS; do
+      if [[ "$b" == "$BACKEND" ]]; then BACKEND_HEADLESS_OK=true; break; fi
+    done
+    if [[ "$BACKEND_HEADLESS_OK" != true ]]; then
+      echo "WARNING: AGENT_BACKEND='${BACKEND}' has no headless (non-interactive) mode." >&2
+      echo "         The headless Deployment supports only: ${HEADLESS_BACKENDS}." >&2
+      echo "         This backend would refuse work at startup. Re-run 'just contribute-setup <cli>'" >&2
+      echo "         with one of the supported backends before applying." >&2
+    fi
 
     # ── Helper: base64-encode a value (portable across macOS and Linux) ──
     b64() {
@@ -800,7 +851,14 @@ contribute-k8s namespace="hive-contributor" outfile="":
     YAML+="  HIVE_HUB: \"${HIVE_HUB:-}\""$'\n'
     YAML+="  CONTRIBUTOR_ID: \"${CONTRIBUTOR_ID:-}\""$'\n'
     YAML+="  CONTRIBUTOR_USERNAME: \"${CONTRIBUTOR_USERNAME:-}\""$'\n'
-    YAML+="  AGENT_BACKEND: \"${AGENT_BACKEND:-claude}\""$'\n'
+    YAML+="  AGENT_BACKEND: \"${BACKEND}\""$'\n'
+    # A pod has no TTY, so the relay MUST run headless (#2660/#2549); the
+    # interactive tmux path would stall forever. Carried in the ConfigMap so the
+    # Deployment picks it up via envFrom with everything else.
+    YAML+="  CONTRIBUTOR_MODE: \"${MODE_HEADLESS}\""$'\n'
+    # Path the headless relay writes its lifecycle state to; the Deployment's
+    # liveness/readiness probes read this same file.
+    YAML+="  HIVE_HEADLESS_STATUS_FILE: \"${HEADLESS_STATUS_FILE}\""$'\n'
     YAML+="---"$'\n'
     YAML+="# Sensitive credentials — treat as secret"$'\n'
     YAML+="apiVersion: v1"$'\n'
@@ -814,19 +872,145 @@ contribute-k8s namespace="hive-contributor" outfile="":
     YAML+="type: Opaque"$'\n'
     YAML+="data:"$'\n'
     YAML+="  HIVE_REGISTRATION_TOKEN: ${REG_TOKEN_B64}"$'\n'
-    YAML+="  GH_TOKEN: ${GH_TOKEN_B64}"
+    YAML+="  GH_TOKEN: ${GH_TOKEN_B64}"$'\n'
+
+    # ── Probe command (#2660 status file) ──
+    # The kubelet execs this against the pod. It reads the coarse lifecycle state
+    # the headless relay writes (waiting/working/done/failed):
+    #   file missing            -> exit 1  (relay not up yet / died before writing)
+    #   state == "failed"       -> exit 1  (task wedged & killed by the relay's
+    #                                        HEADLESS_TASK_TIMEOUT_MS, or a spawn
+    #                                        error — surface as unhealthy, NOT a
+    #                                        healthy-looking-but-stalled pod)
+    #   waiting|working|done    -> exit 0  (alive and connected)
+    # Emitted as a YAML block sequence (one arg per line) and written with a
+    # block scalar so shell quoting inside the command can't corrupt the YAML.
+    # We grep for the "state" line then test its VALUE — the relay only ever
+    # writes one of the four known values, so a plain grep on the file is enough
+    # and avoids needing jq. `grep -q failed` on the state line is the fail case;
+    # a matching known-good state is the pass case; anything else (no file, no
+    # recognised state) fails closed.
+    PROBE_STEP1='STATE=$(sed -n "s/.*\"state\"[^\"]*\"\\([a-z]*\\)\".*/\\1/p" '"${HEADLESS_STATUS_FILE}"' 2>/dev/null | head -1)'
+    PROBE_STEP2='case "$STATE" in waiting|working|done) exit 0 ;; *) exit 1 ;; esac'
+
+    # ── Deployment: the workload that actually runs the contributor (#2549) ──
+    YAML+="---"$'\n'
+    YAML+="# The contributor workload. Runs the relay HEADLESS (#2660): no TTY, one"$'\n'
+    YAML+="# one-shot CLI invocation per task. A long-lived Deployment (not a Job)"$'\n'
+    YAML+="# because the relay stays connected to the hub and pulls work over time;"$'\n'
+    YAML+="# Kubernetes restarts it on failure and keeps a stable identity — the"$'\n'
+    YAML+="# exact reason an operator wants a cluster over a laptop."$'\n'
+    YAML+="#"$'\n'
+    YAML+="# INTERIM CREDENTIAL NOTE (#2537): the Secret above carries a long-lived,"$'\n'
+    YAML+="# personal GH_TOKEN (scope repo,read:org). In a cluster it is base64 (NOT"$'\n'
+    YAML+="# encrypted), readable by anyone with 'get secrets' in this namespace and"$'\n'
+    YAML+="# by cluster-scoped operators/backups. This is materially more exposed"$'\n'
+    YAML+="# than a 0600 file on a laptop. Revoke any time with: gh auth logout (or"$'\n'
+    YAML+="# revoke the token in GitHub settings). Gating the credential on explicit"$'\n'
+    YAML+="# task acceptance is tracked in kubestellar/hive#2537 and is NOT solved"$'\n'
+    YAML+="# here — this path reuses the existing Secret rather than inventing new"$'\n'
+    YAML+="# long-lived credential plumbing."$'\n'
+    YAML+="apiVersion: apps/v1"$'\n'
+    YAML+="kind: Deployment"$'\n'
+    YAML+="metadata:"$'\n'
+    YAML+="  name: ${DEPLOYMENT_NAME}"$'\n'
+    YAML+="  namespace: ${NS}"$'\n'
+    YAML+="  labels:"$'\n'
+    YAML+="    app.kubernetes.io/name: hive-contributor"$'\n'
+    YAML+="    app.kubernetes.io/component: relay"$'\n'
+    YAML+="spec:"$'\n'
+    # Single replica: one relay per registration token / contributor identity.
+    # Scaling capacity means more (separately-registered) contributors, not more
+    # replicas of the same token — so a fixed 1 here, documented.
+    YAML+="  replicas: 1"$'\n'
+    YAML+="  selector:"$'\n'
+    YAML+="    matchLabels:"$'\n'
+    YAML+="      app.kubernetes.io/name: hive-contributor"$'\n'
+    YAML+="      app.kubernetes.io/component: relay"$'\n'
+    YAML+="  template:"$'\n'
+    YAML+="    metadata:"$'\n'
+    YAML+="      labels:"$'\n'
+    YAML+="        app.kubernetes.io/name: hive-contributor"$'\n'
+    YAML+="        app.kubernetes.io/component: relay"$'\n'
+    YAML+="    spec:"$'\n'
+    # Deployment pods are always restartPolicy: Always (the API rejects anything
+    # else) — the relay is meant to run forever and reconnect, so this is the
+    # right shape. Stated for the reader; not settable here.
+    YAML+="      restartPolicy: Always"$'\n'
+    YAML+="      containers:"$'\n'
+    YAML+="        - name: contributor"$'\n'
+    YAML+="          image: ${IMAGE}"$'\n'
+    # Pull the pinned tag on restart so a moved tag can't silently swap the code
+    # under a running contributor; a digest/pinned tag is recommended for repro.
+    YAML+="          imagePullPolicy: Always"$'\n'
+    # envFrom pulls the whole ConfigMap (incl. CONTRIBUTOR_MODE=headless) and the
+    # whole Secret — no per-key wiring to drift out of sync with the generator.
+    YAML+="          envFrom:"$'\n'
+    YAML+="            - configMapRef:"$'\n'
+    YAML+="                name: ${CONFIGMAP_NAME}"$'\n'
+    YAML+="            - secretRef:"$'\n'
+    YAML+="                name: ${SECRET_NAME}"$'\n'
+    YAML+="          resources:"$'\n'
+    YAML+="            requests:"$'\n'
+    YAML+="              memory: \"${MEM_REQUEST}\""$'\n'
+    YAML+="              cpu: \"${CPU_REQUEST}\""$'\n'
+    YAML+="            limits:"$'\n'
+    YAML+="              memory: \"${MEM_LIMIT}\""$'\n'
+    YAML+="              cpu: \"${CPU_LIMIT}\""$'\n'
+    # Readiness: gates the pod Ready only once the relay has authenticated and
+    # written a non-failed state. A wedged/failed relay drops out of Ready.
+    # emit_probe <indent> — appends an exec: command block sequence with the two
+    # probe steps as a single `sh -c` argument, block-scalar formatted so quoting
+    # inside the script can't corrupt the surrounding YAML.
+    emit_probe() {
+      local ind="$1"
+      YAML+="${ind}exec:"$'\n'
+      YAML+="${ind}  command:"$'\n'
+      YAML+="${ind}    - sh"$'\n'
+      YAML+="${ind}    - -c"$'\n'
+      YAML+="${ind}    - |"$'\n'
+      YAML+="${ind}      ${PROBE_STEP1}"$'\n'
+      YAML+="${ind}      ${PROBE_STEP2}"$'\n'
+    }
+
+    YAML+="          readinessProbe:"$'\n'
+    emit_probe "            "
+    YAML+="            initialDelaySeconds: 15"$'\n'
+    YAML+="            periodSeconds: 15"$'\n'
+    YAML+="            failureThreshold: 3"$'\n'
+    # Liveness: restarts the pod if the relay reports failed (a CLI killed by the
+    # HEADLESS_TASK_TIMEOUT_MS watchdog) or stops writing the file entirely.
+    # Longer initialDelay so a slow first authenticate isn't mistaken for death.
+    YAML+="          livenessProbe:"$'\n'
+    emit_probe "            "
+    YAML+="            initialDelaySeconds: 60"$'\n'
+    YAML+="            periodSeconds: 30"$'\n'
+    YAML+="            failureThreshold: 3"
 
     # ── Output ──
     OUTFILE="{{outfile}}"
     if [[ -n "$OUTFILE" ]]; then
       echo "$YAML" > "$OUTFILE"
-      echo "✓ K8s manifests written to ${OUTFILE}"
+      echo "✓ K8s contributor workload written to ${OUTFILE}"
+      echo "  Namespace + ConfigMap + Secret + Deployment (headless relay, image ${IMAGE})"
       echo ""
       echo "Apply with:"
       echo "  kubectl apply -f ${OUTFILE}"
+      echo ""
+      echo "Then watch it come up:"
+      echo "  kubectl -n ${NS} rollout status deploy/${DEPLOYMENT_NAME}"
+      echo ""
+      echo "Interim credential note (#2537): the Secret holds a long-lived personal"
+      echo "GH_TOKEN — base64, not encrypted, and cluster-readable. Revoke any time"
+      echo "with 'gh auth logout'. Pin the image with a 3rd arg, e.g.:"
+      echo "  just contribute-k8s ${NS} ${OUTFILE} <git-short-sha>"
     else
       echo "$YAML"
       echo ""
       echo "# Apply with: just contribute-k8s {{namespace}} | kubectl apply -f -"
       echo "# Or save:    just contribute-k8s {{namespace}} manifests.yaml"
+      echo "# Then:       kubectl -n {{namespace}} rollout status deploy/${DEPLOYMENT_NAME}"
+      echo "# Pin image:  just contribute-k8s {{namespace}} manifests.yaml <git-short-sha>"
+      echo "# Interim credential note (#2537): Secret holds a long-lived personal GH_TOKEN"
+      echo "#   (base64, cluster-readable). Revoke with 'gh auth logout'."
     fi

--- a/v2/deploy/test_contribute_k8s_workload.sh
+++ b/v2/deploy/test_contribute_k8s_workload.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Tests the `just contribute-k8s` contributor WORKLOAD generation (#2549).
+#
+# Before #2549 the recipe emitted only Namespace + ConfigMap + Secret and
+# nothing ran. It now ALSO emits a Deployment that runs the relay HEADLESS
+# (#2660) — a headless pod has no TTY, so it MUST set CONTRIBUTOR_MODE=headless
+# or the interactive tmux path stalls forever. This executes the real recipe
+# against a synthetic contributor.env and asserts the workload it produces,
+# rather than grepping the Justfile, so a regression fails the PR.
+#
+# Run: bash v2/deploy/test_contribute_k8s_workload.sh
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+check() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"
+    echo "        want: '$want'"
+    echo "        got:  '$got'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label (missing: '$needle')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Locate the repo root (this script lives in v2/deploy/) and require `just`.
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+if ! command -v just >/dev/null 2>&1; then
+  echo "  SKIP: 'just' not installed; cannot exercise the recipe"
+  exit 0
+fi
+
+echo "=== contribute-k8s workload generation tests ==="
+
+# Synthetic contributor config under a throwaway HOME (config_dir is
+# $HOME/.config/hive). Placeholder token values only — never a real credential.
+FAKE_HOME="$(mktemp -d)"
+trap 'rm -rf "$FAKE_HOME"' EXIT
+mkdir -p "$FAKE_HOME/.config/hive"
+cat > "$FAKE_HOME/.config/hive/contributor.env" <<'EOF'
+HIVE_HUB=wss://hive.example.io:3001/contribute
+CONTRIBUTOR_ID=c-test01
+CONTRIBUTOR_USERNAME=testuser
+AGENT_BACKEND=claude
+HIVE_REGISTRATION_TOKEN=placeholder-reg-token
+EOF
+cat > "$FAKE_HOME/.config/hive/gh-auth.env" <<'EOF'
+GH_TOKEN=placeholder-gh-token
+EOF
+
+# ── Supported backend (claude): full workload on stdout ──
+OUT="$(cd "$REPO_ROOT" && HOME="$FAKE_HOME" just contribute-k8s hive-contributor 2>/dev/null)"
+
+contains "emits a Deployment"                 "$OUT" "kind: Deployment"
+contains "workload runs headless (#2660)"     "$OUT" "CONTRIBUTOR_MODE: \"headless\""
+contains "status file env for the probe"      "$OUT" "HIVE_HEADLESS_STATUS_FILE:"
+contains "uses the published contributor image" "$OUT" "image: ghcr.io/kubestellar/hive-contributor:v2"
+contains "wires the ConfigMap via envFrom"    "$OUT" "configMapRef:"
+contains "wires the Secret via secretRef"     "$OUT" "secretRef:"
+contains "has a readiness probe"              "$OUT" "readinessProbe:"
+contains "has a liveness probe"               "$OUT" "livenessProbe:"
+contains "probe reads the status file"        "$OUT" "contributor-headless-status.json"
+contains "requests realistic memory"          "$OUT" "memory: \"1Gi\""
+contains "single replica"                     "$OUT" "replicas: 1"
+contains "interim credential note defers to #2537" "$OUT" "#2537"
+
+# ── Placeholder discipline: no real token bytes leak; still base64 placeholders. ──
+if printf '%s' "$OUT" | grep -q "GH_TOKEN: cGxhY2Vob2xkZXItZ2gtdG9rZW4="; then
+  echo "  PASS: Secret carries the base64 placeholder token (templated, not raw)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: expected base64-encoded placeholder token in the Secret"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── The generated YAML must parse. Prefer python3+yaml; fall back to a
+#    kind-count sanity check if PyYAML is unavailable. ──
+if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
+  KINDS="$(printf '%s' "$OUT" | python3 -c 'import sys,yaml; print(",".join(d["kind"] for d in yaml.safe_load_all(sys.stdin) if d))')"
+  check "YAML parses to the four expected kinds" "Namespace,ConfigMap,Secret,Deployment" "$KINDS"
+else
+  echo "  SKIP: PyYAML unavailable; skipping structural parse"
+fi
+
+# ── Unsupported headless backend (goose): warn on STDERR, keep stdout clean. ──
+cat > "$FAKE_HOME/.config/hive/contributor.env" <<'EOF'
+AGENT_BACKEND=goose
+HIVE_REGISTRATION_TOKEN=placeholder-reg-token
+EOF
+ERR="$(cd "$REPO_ROOT" && HOME="$FAKE_HOME" just contribute-k8s hive-contributor 2>&1 >/dev/null)"
+STDOUT_ONLY="$(cd "$REPO_ROOT" && HOME="$FAKE_HOME" just contribute-k8s hive-contributor 2>/dev/null)"
+contains "unsupported backend warns on stderr" "$ERR" "no headless (non-interactive) mode"
+# The warning must NOT pollute stdout (stdout is piped straight to kubectl).
+if printf '%s' "$STDOUT_ONLY" | grep -q "WARNING:"; then
+  echo "  FAIL: warning leaked into stdout (would corrupt 'kubectl apply -f -')"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: stdout stays clean YAML even for an unsupported backend"
+  PASS=$((PASS + 1))
+fi
+
+# ── Image pinning via the 3rd argument. ──
+PINNED="$(cd "$REPO_ROOT" && HOME="$FAKE_HOME" just contribute-k8s hive-contributor "" abc1234 2>/dev/null)"
+contains "3rd arg pins the image tag" "$PINNED" "image: ghcr.io/kubestellar/hive-contributor:abc1234"
+
+echo
+echo "=== $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -1194,6 +1194,7 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 <select id="mode-select" style="background:#161b22;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:6px 12px;font-size:.9rem;cursor:pointer">
 <option value="containerized">Containerized (recommended)</option>
 <option value="host">Host (non-containerized)</option>
+<option value="kubernetes">Kubernetes (cluster)</option>
 </select>
 </span>
 <span id="runtime-group" style="display:inline-flex;align-items:center;gap:8px;white-space:nowrap">
@@ -1208,6 +1209,15 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 <div id="model-row" style="margin-bottom:12px;display:none;align-items:center;gap:8px">
 <label style="font-size:.9rem;color:#8b949e">Model (optional):</label>
 <input id="model-input" type="text" placeholder="e.g. claude-sonnet-4-6, gpt-4o" style="background:#161b22;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:6px 12px;font-size:.85rem;flex:1;max-width:300px" oninput="updateCmds()">
+</div>
+<!-- #2549 Kubernetes-mode note. Hidden except in Kubernetes mode. States the two
+     honest constraints up front: only headless-capable backends run in a cluster
+     (a headless pod has no TTY), and the credential stored in the cluster Secret
+     is a long-lived personal token that is more exposed than a laptop file, with
+     the per-task credential boundary tracked in #2537. -->
+<div id="k8s-note" style="display:none;margin-bottom:12px;background:#161b22;border:1px solid #30363d;border-left:3px solid #d29922;border-radius:6px;padding:12px 14px;font-size:.85rem;color:#c9d1d9;line-height:1.5">
+<strong style="color:#e6edf3">Kubernetes is the advanced path.</strong> It needs a cluster, a kubeconfig and RBAC &mdash; not a first-timer&rsquo;s happy path. The workload runs the relay <strong>headless</strong> (no TTY), so only headless-capable backends work in a cluster: <strong>Claude Code, LiteLLM, Copilot, Codex</strong>. Other backends will refuse work at pod startup.<br>
+<span style="color:#8b949e">Credential note (interim): the generated Secret stores a long-lived personal <code>GH_TOKEN</code> &mdash; base64, not encrypted, and readable by anyone with <code>get secrets</code> in that namespace or by cluster-scoped operators/backups. That is materially more exposed than a <code>0600</code> file on your laptop. Revoke any time with <code>gh auth logout</code>. Gating the credential on explicit task acceptance is tracked in <a href="https://github.com/kubestellar/hive/issues/2537" target="_blank" rel="noopener" style="color:#58a6ff">#2537</a> and is not solved by this path.</span>
 </div>
 <p style="color:#8b949e;margin-bottom:8px">Copy and paste these commands to get started:</p>
 <div style="margin-top:16px;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:16px;position:relative">
@@ -1248,6 +1258,16 @@ windows:'winget install --id Casey.Just --exact\nwinget install --id GitHub.cli'
 };
 var containerTpl='PREREQ\ngit clone -b v2 https://github.com/kubestellar/hive && cd hive\nexport HIVE_HUB='+hubURL+'\njust contribute-setup CLI\njust contribute-hive';
 var hostTpl='PREREQ\nINSTALL\ngit clone -b v2 https://github.com/kubestellar/hive && cd hive\nexport HIVE_HUB='+hubURL+'\njust contribute-setup CLI\njust contribute-hive CLI local';
+// Kubernetes (#2549): register locally, then generate + apply a headless
+// contributor workload (Deployment, #2660) into a cluster you already have.
+// just contribute-k8s prints the manifest; it never touches your cluster on
+// its own, so you can read it before piping to kubectl. Only the headless-
+// capable backends run this way (see K8S_HEADLESS_BACKENDS).
+var k8sTpl='PREREQ\ngit clone -b v2 https://github.com/kubestellar/hive && cd hive\nexport HIVE_HUB='+hubURL+'\njust contribute-setup CLI\n# Review the manifest, then apply into your current kube-context:\njust contribute-k8s hive-contributor | kubectl apply -f -\nkubectl -n hive-contributor rollout status deploy/hive-contributor';
+// Backends with a verified headless (non-interactive) entry point — must match
+// HEADLESS_BACKENDS in bin/contributor-relay.sh and the Justfile. A pod has no
+// TTY, so only these run in a cluster; anything else refuses work at startup.
+var K8S_HEADLESS_BACKENDS={claude:1,litellm:1,copilot:1,codex:1};
 var modelRow=document.getElementById('model-row');
 var modelInput=document.getElementById('model-input');
 function updateCmds(){update();}
@@ -1261,6 +1281,11 @@ var modelFlag=opt.getAttribute('data-model-flag')||'';
 var model=(modelInput.value||'').trim();
 if(cli==='other')mode='host';
 if(mode==='containerized'&&cli==='other'){modeSel.value='host';mode='host';}
+// #2549 Kubernetes mode. "other" has no image, so it can't run in a cluster;
+// fall back to host. Show the k8s note only in this mode.
+if(mode==='kubernetes'&&cli==='other'){modeSel.value='host';mode='host';}
+var k8sNote=document.getElementById('k8s-note');
+if(k8sNote)k8sNote.style.display=(mode==='kubernetes')?'block':'none';
 modelRow.style.display=(modelFlag||cli==='goose')?'flex':'none';
 var modelLine='';
 if(model){
@@ -1276,7 +1301,15 @@ runtimeGroup.style.display=showRuntime?'inline-flex':'none';
 var runtimeLine=(showRuntime&&runtimeSel.value)?'export HIVE_CONTAINER_RUNTIME='+runtimeSel.value+'\n':'';
 var preLines=envLines+modelLine+runtimeLine;
 var tpl,install;
-if(mode==='host'){
+if(mode==='kubernetes'){
+// A cluster pod exports its config via envFrom, so no HIVE_CONTAINER_RUNTIME
+// line — but model/env exports still belong before contribute-setup so the
+// generated ConfigMap picks them up. If the chosen backend has no headless
+// mode, prepend a visible warning comment (the Justfile also warns on stderr).
+var warn=K8S_HEADLESS_BACKENDS[cli]?'':'# WARNING: '+cli+' has no headless mode; it will refuse work in a cluster.\n# Pick Claude Code, LiteLLM, Copilot or Codex for Kubernetes.\n';
+var k8sPre=envLines+modelLine;
+cmds.textContent=warn+k8sTpl.replace('PREREQ',prereq).replace(/CLI/g,cli).replace('just contribute-setup',k8sPre+'just contribute-setup');
+}else if(mode==='host'){
 tpl=hostTpl;
 install=opt.getAttribute('data-host-install');
 if(!install)install='# '+cli+' uses your existing gh auth';

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -278,6 +278,53 @@ func TestContributeLandingHasOpsTab(t *testing.T) {
 	}
 }
 
+// TestContributeLandingHasKubernetesMode pins the #2549 discoverability
+// addition: the /contribute run-mode surface must offer a Kubernetes path
+// alongside containerized and host, wired to `just contribute-k8s`, and it must
+// state the two honest constraints — only headless-capable backends run in a
+// cluster (#2660) and the interim credential model deferring to #2537.
+func TestContributeLandingHasKubernetesMode(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /contribute = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+
+	for _, want := range []string{
+		// The third run-mode option.
+		`<option value="kubernetes">Kubernetes (cluster)</option>`,
+		// The command the mode generates.
+		`just contribute-k8s`,
+		// Honest headless-backend constraint (#2660) surfaced to the reader.
+		`K8S_HEADLESS_BACKENDS`,
+		`headless`,
+		// Interim credential story deferring to #2537, visible on the page.
+		`id="k8s-note"`,
+		`2537`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("/contribute Kubernetes surface missing %q", want)
+		}
+	}
+
+	// The existing two modes must remain — this is additive, not a replacement.
+	for _, want := range []string{
+		`<option value="containerized">Containerized (recommended)</option>`,
+		`<option value="host">Host (non-containerized)</option>`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("existing run mode removed: missing %q", want)
+		}
+	}
+}
+
 // TestContributeFleet pins the read-only fleet endpoint JSON shape.
 func TestContributeFleet(t *testing.T) {
 	setupContributeEnv(t)


### PR DESCRIPTION
Closes the packaging + discoverability layer requested in #2549, built directly on the headless relay from #2660.

## What was missing
`just contribute-k8s` emitted only a `Namespace` + `ConfigMap` + `Secret` — a contributor applied it and **nothing ran** — and the Kubernetes path was invisible on `/contribute`. This PR fixes both.

## The workload it emits (and why)
A **Deployment** (single replica), not a Job. The contributor relay is a long-running process that stays connected to the hub and pulls work over time — Kubernetes restarts it on failure and gives it a stable identity, which is exactly the operator (P5/P4) profile the issue describes. A Job would be run-to-completion, which is the wrong shape.

- Image `ghcr.io/kubestellar/hive-contributor` (tag pinnable via a 3rd recipe arg — acceptance criterion 4, reproducible/pinned deploy).
- Sets **`CONTRIBUTOR_MODE=headless`** (#2660): a pod has no TTY, so the interactive tmux path would stall forever waiting on a prompt nobody can type — the exact #2538/#2549 failure. Carried in the ConfigMap, consumed via `envFrom` (ConfigMap + Secret) so no per-key wiring can drift.
- Realistic resources (image ~2.7GiB unpacked): requests `1Gi`/`500m`, limits `4Gi`/`2`.

## How it uses #2660's headless mode + status file
Liveness **and** readiness probes `exec` a small `sh -c` that reads `HIVE_HEADLESS_STATUS_FILE` and maps the relay's coarse lifecycle state:

| state | probe |
|---|---|
| file missing (not up yet / died before writing) | fail |
| `failed` (CLI wedged & killed by `HEADLESS_TASK_TIMEOUT_MS`, or spawn error) | fail |
| `waiting` / `working` / `done` | pass |

So a wedged CLI surfaces as **unhealthy** instead of a healthy-looking-but-stalled pod — the whole point of the #2660 → #2549 ordering. The probe uses `sed`/`grep` (no `jq` dependency) and is emitted as a YAML block sequence + block scalar so shell quoting can't corrupt the manifest.

## Backend honesty
Only the headless-capable backends run in a cluster: **claude / litellm / copilot / codex** (matches `HEADLESS_BACKENDS` in `bin/contributor-relay.sh`). If `AGENT_BACKEND` is anything else, the recipe **warns on STDERR** (never stdout — stdout is piped straight to `kubectl`) and the manifest is still emitted so switching backend needs no regeneration.

## /contribute discoverability
Adds a **"Kubernetes (cluster)"** run mode next to containerized/host (`api_contribute.go`, the server-rendered `fmt.Fprintf` block), wired to `just contribute-k8s | kubectl apply -f -` with a `rollout status` follow-up. An honest note labels it the advanced path, lists the headless-capable backends, and — if a non-headless CLI is selected — annotates the command block with a warning.

## Interim credential note (defers to #2537, NOT solved here)
Reuses the **existing** Secret the generator already produces — no new long-lived credential plumbing. A clear note in both the manifest and the `/contribute` surface states that a long-lived personal `GH_TOKEN` in a cluster is base64 (not encrypted) and readable by anyone with `get secrets` / cluster-scoped operators / backups — materially more exposed than a `0600` laptop file — with the per-task credential boundary tracked in **#2537**. This satisfies acceptance criteria 6 & 7 without prejudicing #2537.

## Tests
- `v2/deploy/test_contribute_k8s_workload.sh` (wired into `v2-ci.yml`) runs the real recipe and asserts: the Deployment, `CONTRIBUTOR_MODE=headless`, both probes reading the status file, `envFrom`/`secretRef`, realistic memory, single replica, the `#2537` note, image pinning, the stderr-only unsupported-backend warning (and that stdout stays clean), and that the YAML parses to the four expected kinds.
- `TestContributeLandingHasKubernetesMode` pins the `/contribute` run-mode surface (option present, `just contribute-k8s`, headless-backend constraint, `#2537` credential note) while asserting the existing two modes remain.

## Scope
Ships **the artifact + the discoverability** (the issue's stated preference). Cloud "Deploy to" buttons are deliberately out of scope — reach, not capability — per the issue's own ranking.

Fixes #2549

🤖 Generated with [Claude Code](https://claude.com/claude-code)