### PR TITLE
✨ Admin read-only user impersonation ("View as user") for the hub

### DIFF
--- a/v2/pkg/hub/impersonate_cookie.go
+++ b/v2/pkg/hub/impersonate_cookie.go
@@ -1,0 +1,135 @@
+package hub
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Admin read-only "View as user" impersonation.
+//
+// A separate, short-lived, signed cookie (`hive_hub_impersonate`) lets the hub
+// admin — and ONLY the hub admin — see the hub dashboard exactly as another
+// registered user sees it, without ever gaining that user's privileges. The
+// impersonation is READ-ONLY: while it is active the server rejects every
+// mutating request with 403 (see requireAuth / requireAdmin), so the worst an
+// impersonating admin can do is look.
+//
+// Security properties this cookie enforces, in order of importance:
+//
+//  1. It is tamper-evident. The value is bound to the hub secret with an
+//     HMAC-SHA256 using the SAME construction as the session cookie
+//     (hub_cookie.go). A forged, edited, or unsigned value fails verification
+//     and is treated as "not impersonating" — never as an escalation.
+//  2. It carries the REAL admin login it was minted for. resolveIdentity only
+//     honors the cookie when that admin field equals BOTH the real signed
+//     session user AND hubAdminUsername. A user cannot lift the admin's
+//     impersonation cookie onto their own session to borrow the admin's view,
+//     and the admin cannot mint one that names someone else as the actor.
+//  3. It expires. The payload carries an absolute Unix expiry (impersonateTTL
+//     from mint time); a stale cookie is ignored. This bounds how long a
+//     forgotten "View as" session can linger.
+//
+// Wire format (all in the clear except the trailing signature, exactly like the
+// session cookie — none of these fields are secret; the signature is what
+// proves the hub minted them):
+//
+//	value = <admin>|<target>|<expUnix>.<base64url(HMAC-SHA256(admin|target|expUnix, hubSecret))>
+//
+// The admin and target are GitHub logins, which loadSaaSUser already validates
+// to exclude "/" "\\" and ".." — and usernames never contain "|" or "." — so
+// the delimiters cannot be smuggled.
+
+// impersonateTTL bounds how long a single "View as" session stays valid before
+// the admin must re-enter it. Deliberately short: impersonation is an
+// intentional, supervised action, not a durable mode, and a short window limits
+// the blast radius of a forgotten session or a leaked cookie.
+const impersonateTTL = 30 * time.Minute
+
+// impersonateCookieName is the browser cookie that carries an active
+// impersonation grant. It is intentionally distinct from the session cookie
+// (hive_hub_user) so the two are minted, verified, and cleared independently:
+// exiting impersonation never disturbs the real login.
+const impersonateCookieName = "hive_hub_impersonate"
+
+// impersonateSep separates the payload fields. It is a character that cannot
+// appear in a GitHub username, so field boundaries are unambiguous.
+const impersonateSep = "|"
+
+// impersonationGrant is the decoded, verified payload of an impersonation
+// cookie. It is only ever produced by verifyImpersonateCookieValue, which
+// returns ok=false unless the signature verified.
+type impersonationGrant struct {
+	Admin  string // the real admin login the cookie was minted for
+	Target string // the user being viewed
+	Exp    int64  // absolute expiry, Unix seconds
+}
+
+// impersonatePayload is the signed portion of the cookie: the three fields
+// joined by impersonateSep. Keeping the join in one place guarantees mint and
+// verify hash byte-for-byte identical input.
+func impersonatePayload(admin, target string, exp int64) string {
+	return admin + impersonateSep + target + impersonateSep + strconv.FormatInt(exp, 10)
+}
+
+// impersonateSign returns the URL-safe base64 HMAC-SHA256 of payload under
+// secret, reusing the session cookie's encoding (hubCookieB64) so both cookies
+// share one crypto scheme.
+func impersonateSign(secret, payload string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(payload))
+	return hubCookieB64.EncodeToString(mac.Sum(nil))
+}
+
+// mintImpersonateCookieValue returns a signed impersonation cookie value that
+// records admin viewing target, expiring impersonateTTL from now. It returns ""
+// when no secret is configured or either login is empty — callers must treat
+// that as "cannot start impersonation" rather than emitting an unsigned value.
+func mintImpersonateCookieValue(secret, admin, target string, now time.Time) string {
+	if secret == "" || admin == "" || target == "" {
+		return ""
+	}
+	exp := now.Add(impersonateTTL).Unix()
+	payload := impersonatePayload(admin, target, exp)
+	return payload + "." + impersonateSign(secret, payload)
+}
+
+// verifyImpersonateCookieValue parses a cookie value, recomputes its HMAC over
+// the carried payload, and constant-time-compares it against the presented
+// signature. It returns (grant, true) ONLY when the signature verifies AND the
+// grant has not expired (checked against now). A forged, edited, unsigned,
+// malformed, or expired value returns (zero, false) so the caller treats the
+// request as NOT impersonating — the cookie can only ever be ignored, never
+// trusted-by-default.
+func verifyImpersonateCookieValue(secret, value string, now time.Time) (impersonationGrant, bool) {
+	var zero impersonationGrant
+	if secret == "" || value == "" {
+		return zero, false
+	}
+	idx := strings.LastIndex(value, ".")
+	if idx <= 0 || idx == len(value)-1 {
+		return zero, false
+	}
+	payload, sig := value[:idx], value[idx+1:]
+	expected := impersonateSign(secret, payload)
+	if !hmac.Equal([]byte(sig), []byte(expected)) {
+		return zero, false
+	}
+	parts := strings.Split(payload, impersonateSep)
+	if len(parts) != 3 {
+		return zero, false
+	}
+	exp, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		return zero, false
+	}
+	if now.Unix() >= exp {
+		return zero, false
+	}
+	if parts[0] == "" || parts[1] == "" {
+		return zero, false
+	}
+	return impersonationGrant{Admin: parts[0], Target: parts[1], Exp: exp}, true
+}

--- a/v2/pkg/hub/impersonation_test.go
+++ b/v2/pkg/hub/impersonation_test.go
@@ -1,0 +1,292 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Admin read-only "View as user" impersonation.
+//
+// These tests exercise the security boundary directly (the cookie helpers,
+// resolveIdentity, the write-block, and the enter/exit handlers) rather than
+// the browser JS, because the enforcement lives entirely on the server. They
+// reuse the shared test helpers from saas_handlers_coverage_test.go
+// (testHubSecret, testAuthCookie, mkUser, newHandlerHub, reqWithUser,
+// setPathValue, helperSetupTempDirs).
+
+// impersonateCookie mints a signed impersonation cookie the same way the server
+// does, so a test can present a genuine grant.
+func impersonateCookie(admin, target string, now time.Time) *http.Cookie {
+	return &http.Cookie{
+		Name:  impersonateCookieName,
+		Value: mintImpersonateCookieValue(testHubSecret, admin, target, now),
+	}
+}
+
+// TestImpersonateCookieRoundTrip verifies mint/verify agree and that tamper,
+// wrong secret, and expiry all fail closed.
+func TestImpersonateCookieRoundTrip(t *testing.T) {
+	now := time.Now()
+	val := mintImpersonateCookieValue(testHubSecret, "clubanderson", "alice", now)
+	if val == "" {
+		t.Fatal("mint returned empty for valid inputs")
+	}
+	g, ok := verifyImpersonateCookieValue(testHubSecret, val, now)
+	if !ok || g.Admin != "clubanderson" || g.Target != "alice" {
+		t.Fatalf("verify = %+v, ok=%v; want admin=clubanderson target=alice", g, ok)
+	}
+
+	// Wrong secret -> ignored.
+	if _, ok := verifyImpersonateCookieValue("other-secret", val, now); ok {
+		t.Error("verify accepted a cookie signed with a different secret")
+	}
+	// Tampered payload -> ignored.
+	tampered := strings.Replace(val, "alice", "aliceX", 1)
+	if _, ok := verifyImpersonateCookieValue(testHubSecret, tampered, now); ok {
+		t.Error("verify accepted a tampered cookie")
+	}
+	// Expired -> ignored.
+	if _, ok := verifyImpersonateCookieValue(testHubSecret, val, now.Add(impersonateTTL+time.Minute)); ok {
+		t.Error("verify accepted an expired cookie")
+	}
+	// Empty target refused at mint.
+	if mintImpersonateCookieValue(testHubSecret, "clubanderson", "", now) != "" {
+		t.Error("mint accepted an empty target")
+	}
+}
+
+// TestImpersonateStartAndIdentitySwitch: admin POSTs impersonate/{user}, gets a
+// cookie, and a GET under that cookie resolves to the TARGET.
+func TestImpersonateStartAndIdentitySwitch(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+	mkUser(t, "alice")
+
+	// Admin starts impersonation of alice.
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/api/saas/admin/impersonate/alice", "", hubAdminUsername), "username", "alice")
+	s.handleImpersonateStart(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	var setCookie string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == impersonateCookieName {
+			setCookie = c.Value
+		}
+	}
+	if setCookie == "" {
+		t.Fatal("start did not set the impersonation cookie")
+	}
+
+	// A GET carrying the admin session cookie + the impersonation cookie
+	// resolves to alice.
+	get := httptest.NewRequest(http.MethodGet, "/api/saas/my-hives", nil)
+	get.AddCookie(testAuthCookie(hubAdminUsername))
+	get.AddCookie(&http.Cookie{Name: impersonateCookieName, Value: setCookie})
+	if eff := s.getAuthUser(get); eff != "alice" {
+		t.Errorf("GET effective identity = %q, want alice", eff)
+	}
+
+	// resolveIdentity reports the real admin + impersonating=true on the GET.
+	eff, real, imp := s.resolveIdentity(get)
+	if eff != "alice" || real != hubAdminUsername || !imp {
+		t.Errorf("resolveIdentity(GET) = (%q,%q,%v); want (alice,%s,true)", eff, real, imp, hubAdminUsername)
+	}
+}
+
+// TestImpersonateStartUnknownTarget: 404 for a target with no user record.
+func TestImpersonateStartUnknownTarget(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/x", "", hubAdminUsername), "username", "ghost")
+	s.handleImpersonateStart(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("unknown target status = %d, want 404", rec.Code)
+	}
+}
+
+// TestNonAdminCannotImpersonate: requireAdmin rejects a non-admin caller (403).
+func TestNonAdminCannotImpersonate(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, "bob")
+	mkUser(t, "alice")
+
+	h := s.requireAdmin(s.handleImpersonateStart)
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/api/saas/admin/impersonate/alice", "", "bob"), "username", "alice")
+	h(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("non-admin impersonate status = %d, want 403", rec.Code)
+	}
+}
+
+// TestWriteBlockedDuringImpersonation: under an active grant, a write (POST/PUT/
+// DELETE) is refused 403 by requireAuth/requireAdmin, while a GET still passes.
+func TestWriteBlockedDuringImpersonation(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+	mkUser(t, "alice")
+	now := time.Now()
+
+	called := false
+	next := func(w http.ResponseWriter, r *http.Request) { called = true; w.WriteHeader(http.StatusOK) }
+
+	// A POST through requireAuth under an active grant -> 403, next not called.
+	guardedAuth := s.requireAuth(next)
+	rec := httptest.NewRecorder()
+	post := httptest.NewRequest(http.MethodPost, "/api/saas/hives", strings.NewReader("{}"))
+	post.Header.Set("Content-Type", "application/json")
+	post.AddCookie(testAuthCookie(hubAdminUsername))
+	post.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
+	guardedAuth(rec, post)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("POST under impersonation status = %d, want 403 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if called {
+		t.Error("write handler ran despite impersonation write-block")
+	}
+	if !strings.Contains(rec.Body.String(), "read-only") {
+		t.Errorf("403 body = %q, want a read-only message", rec.Body.String())
+	}
+
+	// A write through requireAdmin is likewise blocked.
+	called = false
+	guardedAdmin := s.requireAdmin(next)
+	rec = httptest.NewRecorder()
+	del := httptest.NewRequest(http.MethodDelete, "/api/saas/admin/users/alice", nil)
+	del.AddCookie(testAuthCookie(hubAdminUsername))
+	del.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
+	guardedAdmin(rec, del)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("admin DELETE under impersonation status = %d, want 403", rec.Code)
+	}
+	if called {
+		t.Error("admin write handler ran despite impersonation write-block")
+	}
+
+	// A GET through requireAuth under the same grant still reaches the handler.
+	called = false
+	rec = httptest.NewRecorder()
+	get := httptest.NewRequest(http.MethodGet, "/api/saas/my-hives", nil)
+	get.AddCookie(testAuthCookie(hubAdminUsername))
+	get.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
+	guardedAuth(rec, get)
+	if rec.Code != http.StatusOK || !called {
+		t.Errorf("GET under impersonation: status=%d called=%v; want 200 + handler called", rec.Code, called)
+	}
+}
+
+// TestImpersonateExitClearsCookieAndStaysCallable: exit works WHILE impersonating
+// (it is exempt from the write-block) and clears the cookie.
+func TestImpersonateExitClearsCookieAndStaysCallable(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+	mkUser(t, "alice")
+	now := time.Now()
+
+	// Exit is registered behind requireAdmin AND is a POST — the write-block
+	// must NOT fire for it. Drive it through the real middleware to prove that.
+	guarded := s.requireAdmin(s.handleImpersonateExit)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, impersonateExitPath, nil)
+	req.AddCookie(testAuthCookie(hubAdminUsername))
+	req.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
+	guarded(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("exit status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	// The exit response must clear the cookie (MaxAge<0 / empty value).
+	var cleared bool
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == impersonateCookieName && (c.MaxAge < 0 || c.Value == "") {
+			cleared = true
+		}
+	}
+	if !cleared {
+		t.Error("exit did not clear the impersonation cookie")
+	}
+
+	// After exit (no impersonation cookie), identity is back to the admin.
+	get := httptest.NewRequest(http.MethodGet, "/api/saas/my-hives", nil)
+	get.AddCookie(testAuthCookie(hubAdminUsername))
+	if eff := s.getAuthUser(get); eff != hubAdminUsername {
+		t.Errorf("post-exit identity = %q, want %s", eff, hubAdminUsername)
+	}
+}
+
+// TestForgedImpersonationCookieIgnored: a forged/tampered impersonation cookie
+// is ignored — identity stays admin and no impersonation is reported.
+func TestForgedImpersonationCookieIgnored(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+	mkUser(t, "alice")
+
+	get := httptest.NewRequest(http.MethodGet, "/api/saas/my-hives", nil)
+	get.AddCookie(testAuthCookie(hubAdminUsername))
+	// A hand-crafted, unsigned value.
+	get.AddCookie(&http.Cookie{Name: impersonateCookieName, Value: "clubanderson|alice|9999999999.forgedsig"})
+
+	eff, real, imp := s.resolveIdentity(get)
+	if imp {
+		t.Error("forged impersonation cookie was honored")
+	}
+	if eff != hubAdminUsername || real != hubAdminUsername {
+		t.Errorf("forged cookie shifted identity: eff=%q real=%q; want both %s", eff, real, hubAdminUsername)
+	}
+}
+
+// TestImpersonationNoPrivilegeEscalation covers two escalation attempts:
+//  1. A grant whose Admin field != the real signed user is ignored (a user
+//     lifting the admin's cookie onto their own session).
+//  2. A grant whose Admin field != hubAdminUsername is ignored (impersonation
+//     can only ever be activated by the admin's real session).
+func TestImpersonationNoPrivilegeEscalation(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+	mkUser(t, "alice")
+	mkUser(t, "bob")
+	now := time.Now()
+
+	// (1) bob presents a genuinely-signed grant that names the admin as actor,
+	// on bob's OWN session. Because the real user is bob (not the grant.Admin
+	// and not the admin), it must be ignored — bob stays bob, not elevated.
+	get := httptest.NewRequest(http.MethodGet, "/api/saas/my-hives", nil)
+	get.AddCookie(testAuthCookie("bob"))
+	get.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
+	eff, real, imp := s.resolveIdentity(get)
+	if imp || eff != "bob" || real != "bob" {
+		t.Errorf("stolen admin cookie on bob's session: eff=%q real=%q imp=%v; want bob/bob/false", eff, real, imp)
+	}
+
+	// (2) A grant whose Admin field is a NON-admin, presented on that
+	// non-admin's own session, must be ignored (only hubAdminUsername may
+	// impersonate). Even though the signature is valid and admin==realUser here,
+	// realUser != hubAdminUsername, so resolveIdentity refuses it.
+	get2 := httptest.NewRequest(http.MethodGet, "/api/saas/my-hives", nil)
+	get2.AddCookie(testAuthCookie("bob"))
+	get2.AddCookie(impersonateCookie("bob", "alice", now))
+	eff, real, imp = s.resolveIdentity(get2)
+	if imp || eff != "bob" {
+		t.Errorf("non-admin self-minted grant honored: eff=%q imp=%v; want bob/false", eff, imp)
+	}
+}

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -327,12 +327,27 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	isAdmin := username == hubAdminUsername
-	data, err := json.Marshal(map[string]any{
+	// Fold impersonation status into the auth payload the dashboard already
+	// fetches, so the "Viewing as … read-only" banner renders without a second
+	// round-trip. When an admin is impersonating, report the effective identity
+	// as the target (that is what every per-user view is rendering as) but keep
+	// hub_admin FALSE — during impersonation the admin is deliberately a normal
+	// user, so admin-only affordances hide via the existing role checks.
+	payload := map[string]any{
 		"authenticated": true,
 		"login":         username,
 		"avatar_url":    fmt.Sprintf("https://github.com/%s.png", username),
 		"hub_admin":     isAdmin,
-	})
+	}
+	if grant, ok := s.activeImpersonationGrant(r); ok {
+		payload["login"] = grant.Target
+		payload["avatar_url"] = fmt.Sprintf("https://github.com/%s.png", grant.Target)
+		payload["hub_admin"] = false
+		payload["impersonating"] = true
+		payload["viewing_as"] = grant.Target
+		payload["real_user"] = username
+	}
+	data, err := json.Marshal(payload)
 	if err != nil {
 		http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
 		return

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -267,6 +267,14 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("GET /api/saas/admin/users", s.requireAdmin(s.handleAdminUsers))
 	s.mux.HandleFunc("PUT /api/saas/admin/users/{username}", s.requireAdmin(s.handleAdminUpdateUser))
 	s.mux.HandleFunc("DELETE /api/saas/admin/users/{username}", s.requireAdmin(s.handleAdminDeleteUser))
+	// Admin read-only "View as user" impersonation. Enter is admin-only and
+	// sets the short-lived signed hive_hub_impersonate cookie; exit clears it
+	// and is exempt from the impersonation write-block (see impersonateExitPath)
+	// so the admin can always get back out. Status folds into /api/auth/user for
+	// the banner, but a dedicated read is offered too.
+	s.mux.HandleFunc("POST /api/saas/admin/impersonate/exit", s.requireAdmin(s.handleImpersonateExit))
+	s.mux.HandleFunc("POST /api/saas/admin/impersonate/{username}", s.requireAdmin(s.handleImpersonateStart))
+	s.mux.HandleFunc("GET /api/saas/impersonation-status", s.requireAuth(s.handleImpersonationStatus))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/assign", s.requireAuth(s.handleAssignHive))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/migrate", s.requireAuth(s.handleMigrateHive))
 	s.mux.HandleFunc("GET /api/saas/cluster-health", s.requireAdmin(s.handleClusterHealth))
@@ -307,12 +315,71 @@ func (s *HubServer) registerSaaSRoutes() {
 	}
 }
 
+// impersonateExitPath is the one mutating endpoint that stays callable while
+// impersonation is active — it is how the admin gets OUT. Every other write is
+// refused 403 by the write-block below.
+const impersonateExitPath = "/api/saas/admin/impersonate/exit"
+
+// blockIfImpersonatingWrite enforces the read-only property of impersonation.
+// While a valid admin grant is active, ANY non-GET/HEAD request (except the
+// exit endpoint) is refused 403 before it reaches its handler. This is the
+// central write gate: it lives in both requireAuth and requireAdmin, through
+// which every user-facing mutation is routed, so no write path can slip past.
+// It returns true when it has already written the 403 response and the caller
+// must stop.
+func (s *HubServer) blockIfImpersonatingWrite(w http.ResponseWriter, r *http.Request) bool {
+	if r.Method == http.MethodGet || r.Method == http.MethodHead {
+		return false
+	}
+	if r.URL.Path == impersonateExitPath {
+		return false
+	}
+	_, _, impersonating := s.resolveIdentity(r)
+	if !impersonating {
+		return false
+	}
+	target := "user"
+	if grant, ok := s.activeImpersonationGrant(r); ok {
+		target = grant.Target
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	// target is a GitHub login (no quotes/backslashes possible), safe to inline.
+	w.Write([]byte(`{"error":"read-only while viewing as ` + target + ` — exit impersonation to make changes"}`))
+	return true
+}
+
+// activeImpersonationGrant returns the verified grant behind the current
+// request when (and only when) resolveIdentity would honor it. It is a thin
+// read used for messaging/audit/status; the security decisions live in
+// resolveIdentity.
+func (s *HubServer) activeImpersonationGrant(r *http.Request) (impersonationGrant, bool) {
+	if s.getRealAuthUser(r) != hubAdminUsername {
+		return impersonationGrant{}, false
+	}
+	cookie, err := r.Cookie(impersonateCookieName)
+	if err != nil || cookie.Value == "" {
+		return impersonationGrant{}, false
+	}
+	grant, ok := verifyImpersonateCookieValue(s.hubSecret, cookie.Value, time.Now())
+	if !ok || grant.Admin != hubAdminUsername {
+		return impersonationGrant{}, false
+	}
+	if loadSaaSUser(grant.Target) == nil {
+		return impersonationGrant{}, false
+	}
+	return grant, true
+}
+
 func (s *HubServer) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !isCSRFSafe(r) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusForbidden)
 			w.Write([]byte(`{"error":"CSRF check failed"}`))
+			return
+		}
+		if s.blockIfImpersonatingWrite(w, r) {
 			return
 		}
 		username := s.getAuthUser(r)
@@ -371,7 +438,12 @@ func isTrustedOrigin(raw string) bool {
 		host == "127.0.0.1"
 }
 
-func (s *HubServer) getAuthUser(r *http.Request) string {
+// getRealAuthUser resolves the REAL authenticated user from the signed session
+// cookie or a Bearer token, with NO impersonation applied. This is the identity
+// the admin actually logged in as. Impersonation is layered on top of this by
+// resolveIdentity — never inside it — so the write-block and the admin gate can
+// always reason about who is really driving the request.
+func (s *HubServer) getRealAuthUser(r *http.Request) string {
 	cookie, err := r.Cookie("hive_hub_user")
 	if err == nil && cookie.Value != "" {
 		// The cookie value is only trusted when its HMAC signature verifies
@@ -394,6 +466,67 @@ func (s *HubServer) getAuthUser(r *http.Request) string {
 	}
 
 	return ""
+}
+
+// resolveIdentity is the single decision point for admin "View as user"
+// impersonation. It returns the EFFECTIVE identity every per-user view should
+// render as, the REAL admin login driving the request, and whether an
+// impersonation grant is currently active.
+//
+// Impersonation is honored ONLY when every one of these holds (fail closed on
+// any miss — the request is then simply the real user, not impersonating):
+//
+//   - a hive_hub_impersonate cookie is present AND its HMAC verifies AND it has
+//     not expired (verifyImpersonateCookieValue);
+//   - the grant's Admin field equals the REAL signed session user;
+//   - that real user is exactly hubAdminUsername (only the admin may impersonate
+//     — a stolen cookie replayed on a non-admin session is ignored);
+//   - the target resolves to a real registered user on disk.
+//
+// The effective identity switches to the target ONLY for GET/HEAD requests.
+// For any mutating method the effective identity stays the admin so no write is
+// ever attributed to the target; the write itself is separately refused 403 by
+// requireAuth/requireAdmin. This split means impersonation can never elevate:
+// the target is always a normal user, and writes never run under it.
+func (s *HubServer) resolveIdentity(r *http.Request) (effective, realUser string, impersonating bool) {
+	realUser = s.getRealAuthUser(r)
+	if realUser == "" || realUser != hubAdminUsername {
+		return realUser, realUser, false
+	}
+	cookie, err := r.Cookie(impersonateCookieName)
+	if err != nil || cookie.Value == "" {
+		return realUser, realUser, false
+	}
+	grant, ok := verifyImpersonateCookieValue(s.hubSecret, cookie.Value, time.Now())
+	if !ok {
+		return realUser, realUser, false
+	}
+	// The cookie must name THIS real admin as its actor. Anything else — a
+	// cookie minted for a different admin, or one lifted onto the wrong
+	// session — is ignored rather than trusted.
+	if grant.Admin != realUser {
+		return realUser, realUser, false
+	}
+	if loadSaaSUser(grant.Target) == nil {
+		return realUser, realUser, false
+	}
+	// A valid, active grant exists. Report impersonating=true regardless of
+	// method (so writes can be blocked), but only SWITCH the effective identity
+	// for read requests.
+	if r.Method == http.MethodGet || r.Method == http.MethodHead {
+		return grant.Target, realUser, true
+	}
+	return realUser, realUser, true
+}
+
+// getAuthUser returns the EFFECTIVE identity for the request: the impersonated
+// target on a GET/HEAD while a valid admin grant is active, otherwise the real
+// authenticated user. Every per-user handler calls this, so making it
+// impersonation-aware is what renders all per-user views as the target with no
+// per-handler change.
+func (s *HubServer) getAuthUser(r *http.Request) string {
+	effective, _, _ := s.resolveIdentity(r)
+	return effective
 }
 
 var (
@@ -539,9 +672,20 @@ func listAllSaaSUsers() []SaaSUser {
 
 func (s *HubServer) requireAdmin(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		username := s.getAuthUser(r)
+		// Gate on the REAL logged-in user, not the effective (possibly
+		// impersonated) identity. While the admin is viewing as a normal user,
+		// getAuthUser resolves to that user on GETs — but admin routes (and in
+		// particular the impersonation exit) must still be reachable by the real
+		// admin, and no admin-only surface may leak to the impersonated target.
+		username := s.getRealAuthUser(r)
 		if username != hubAdminUsername {
 			http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
+			return
+		}
+		// Admin writes are also read-only under impersonation (exit excepted),
+		// so an impersonating admin cannot mutate through an admin endpoint
+		// either.
+		if s.blockIfImpersonatingWrite(w, r) {
 			return
 		}
 		next(w, r)
@@ -578,6 +722,93 @@ func (s *HubServer) handleAdminUsers(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"users": views})
+}
+
+// impersonateCookieDomain matches the session cookie's domain so the two are
+// scoped identically across the hive.kubestellar.io hosts. It mirrors the
+// hive_hub_user cookie set in oauth.go.
+const impersonateCookieDomain = ".hive.kubestellar.io"
+
+// setImpersonateCookie writes (value != "") or clears (value == "") the signed
+// impersonation cookie with the same hardened attributes as the session cookie:
+// HttpOnly (no JS access), Secure (HTTPS only), SameSite=Lax. The short MaxAge
+// mirrors impersonateTTL so the browser drops the cookie about when the server
+// would stop honoring it.
+func setImpersonateCookie(w http.ResponseWriter, value string) {
+	c := &http.Cookie{
+		Name:     impersonateCookieName,
+		Value:    value,
+		Path:     "/",
+		Domain:   impersonateCookieDomain,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	}
+	if value == "" {
+		c.MaxAge = -1 // delete
+	} else {
+		c.MaxAge = int(impersonateTTL / time.Second)
+	}
+	http.SetCookie(w, c)
+}
+
+// handleImpersonateStart begins an admin read-only "View as user" session.
+// Registered behind requireAdmin, so only the real hub admin reaches it (and
+// the impersonation write-block cannot fire here because starting requires no
+// active grant). It validates the target is a registered user, then sets the
+// short-lived signed hive_hub_impersonate cookie. The admin gains NO privilege:
+// subsequent GETs render as the target, and every write is refused 403.
+func (s *HubServer) handleImpersonateStart(w http.ResponseWriter, r *http.Request) {
+	admin := s.getRealAuthUser(r) // == hubAdminUsername (requireAdmin gated)
+	target := r.PathValue("username")
+	if target == "" || target == admin {
+		writeJSONError(w, http.StatusBadRequest, "invalid target user")
+		return
+	}
+	if loadSaaSUser(target) == nil {
+		writeJSONError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	value := mintImpersonateCookieValue(s.hubSecret, admin, target, time.Now())
+	if value == "" {
+		writeJSONError(w, http.StatusInternalServerError, "cannot start impersonation")
+		return
+	}
+	setImpersonateCookie(w, value)
+	s.logger.Info("audit: admin impersonation started", "admin", admin, "target", target,
+		"at", time.Now().UTC().Format(time.RFC3339))
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"ok": true, "viewing_as": target})
+}
+
+// handleImpersonateExit ends an active "View as user" session by clearing the
+// impersonation cookie. It is registered behind requireAdmin (the real admin is
+// always the actor) and its path is exempt from the write-block, so it stays
+// callable WHILE impersonating — that is the whole point. It is a no-op if no
+// grant is active.
+func (s *HubServer) handleImpersonateExit(w http.ResponseWriter, r *http.Request) {
+	admin := s.getRealAuthUser(r)
+	if grant, ok := s.activeImpersonationGrant(r); ok {
+		s.logger.Info("audit: admin impersonation ended", "admin", admin, "target", grant.Target,
+			"at", time.Now().UTC().Format(time.RFC3339))
+	}
+	setImpersonateCookie(w, "")
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"ok": true})
+}
+
+// handleImpersonationStatus reports whether the current request is inside an
+// impersonation session and, if so, who is being viewed. The banner reads this
+// (or the equivalent fields folded into /api/auth/user). Because getAuthUser
+// resolves to the target on this GET, the status is derived from the real admin
+// grant via activeImpersonationGrant rather than from getAuthUser.
+func (s *HubServer) handleImpersonationStatus(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if grant, ok := s.activeImpersonationGrant(r); ok {
+		json.NewEncoder(w).Encode(map[string]any{"impersonating": true, "viewing_as": grant.Target})
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]any{"impersonating": false})
 }
 
 // handleAdminUpdateUser applies a partial admin edit to one hub user record.
@@ -7449,6 +7680,14 @@ const dashboardHTML = `<!DOCTYPE html>
   </style>
 </head>
 <body>
+  <!-- Admin "View as user" banner. Hidden until loadUser() detects an active
+       impersonation session, then fixed to the very top of every hub page so it
+       is unmissable. The Exit button POSTs the exit endpoint and reloads. -->
+  <div id="impersonation-banner" style="display:none;position:fixed;top:0;left:0;right:0;z-index:2147483647;background:#b45309;color:#fff;font-size:0.85rem;font-weight:600;padding:8px 16px;box-shadow:0 2px 8px rgba(0,0,0,0.4);text-align:center">
+    <span style="margin-right:6px">&#128065;</span>
+    <span id="impersonation-banner-text">Viewing as user — read-only</span>
+    <button type="button" onclick="exitImpersonation()" style="margin-left:14px;padding:3px 12px;background:#fff;color:#b45309;border:none;border-radius:4px;cursor:pointer;font-size:0.75rem;font-weight:700">Exit</button>
+  </div>
   <header class="site-header">
     <a href="/" class="brand">
       <span class="brand-mark">🐝</span>
@@ -8782,10 +9021,52 @@ const dashboardHTML = `<!DOCTYPE html>
       window.open(target, '_blank');
     });
 
+    // Show or hide the sticky "Viewing as … read-only" banner and nudge the page
+    // down so the fixed banner never covers the header. Reads the impersonation
+    // fields folded into /api/auth/user.
+    function applyImpersonationBanner(data) {
+      var banner = document.getElementById('impersonation-banner');
+      if (!banner) return;
+      if (data && data.impersonating) {
+        document.getElementById('impersonation-banner-text').textContent =
+          'Viewing as ' + (data.viewing_as || 'user') + ' — read-only';
+        banner.style.display = '';
+        document.body.style.paddingTop = banner.offsetHeight + 'px';
+      } else {
+        banner.style.display = 'none';
+        document.body.style.paddingTop = '';
+      }
+    }
+
+    // exitImpersonation ends the current "View as" session and reloads so every
+    // view re-renders as the real admin again.
+    async function exitImpersonation() {
+      try { await fetch('/api/saas/admin/impersonate/exit', {method:'POST'}); } catch(e) {}
+      location.reload();
+    }
+
+    // startImpersonation enters read-only "View as <username>" and reloads so
+    // all per-user views re-render as that user. Admin-only (the server refuses
+    // any non-admin caller with 403).
+    async function startImpersonation(username) {
+      try {
+        var resp = await fetch('/api/saas/admin/impersonate/' + encodeURIComponent(username), {method:'POST'});
+        if (!resp.ok) {
+          var e = {}; try { e = await resp.json(); } catch(_) {}
+          hiveToast('Cannot view as ' + username + ': ' + (e.error || resp.status), 'error');
+          return;
+        }
+        location.reload();
+      } catch(err) {
+        hiveToast('Cannot view as ' + username, 'error');
+      }
+    }
+
     async function loadUser() {
       try {
         var resp = await fetch('/api/auth/user');
         var data = await resp.json();
+        applyImpersonationBanner(data);
         if (data.authenticated) {
           _isAdmin = !!data.hub_admin;
           /* The signed-in login is the ONE piece of viewer identity the hive
@@ -14996,7 +15277,7 @@ const dashboardHTML = `<!DOCTYPE html>
           '<td>' + statusCell + '</td>' +
           '<td><input type="number" min="0" max="10" value="' + (u.saas_quota || 0) + '" style="width:50px;padding:4px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text);text-align:center" onchange="updateUser(\'' + esc(u.github_username) + '\',{saas_quota:parseInt(this.value)||0})"></td>' +
           '<td>' + (hiveCount > 0 ? '<a href="#" onclick="toggleAdminExpand(\'' + esc(u.github_username) + '\');return false" style="color:var(--blue);font-size:0.8rem">' + hiveCount + ' hive' + (hiveCount > 1 ? 's' : '') + '</a>' : '<span style="color:var(--muted)">0</span>') + '</td>' +
-          '<td>' + (isAdmin ? '' : '<button onclick="updateUser(\'' + esc(u.github_username) + '\',{blocked:' + (!u.blocked) + '})" style="padding:3px 10px;background:' + (u.blocked ? 'var(--green)' : 'var(--amber)') + ';color:' + (u.blocked ? '#fff' : '#1a1a1a') + ';border:none;border-radius:4px;cursor:pointer;font-size:0.7rem">' + (u.blocked ? 'Unblock' : 'Block') + '</button> <button onclick="deleteUser(\'' + esc(u.github_username) + '\',' + hiveCount + ')" style="padding:3px 10px;background:#b02a2a;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.7rem">Delete</button>') + '</td>' +
+          '<td>' + (isAdmin ? '' : '<button onclick="startImpersonation(\'' + esc(u.github_username) + '\')" title="See the hub exactly as this user does — read-only" style="padding:3px 10px;background:#b45309;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.7rem">View as</button> <button onclick="updateUser(\'' + esc(u.github_username) + '\',{blocked:' + (!u.blocked) + '})" style="padding:3px 10px;background:' + (u.blocked ? 'var(--green)' : 'var(--amber)') + ';color:' + (u.blocked ? '#fff' : '#1a1a1a') + ';border:none;border-radius:4px;cursor:pointer;font-size:0.7rem">' + (u.blocked ? 'Unblock' : 'Block') + '</button> <button onclick="deleteUser(\'' + esc(u.github_username) + '\',' + hiveCount + ')" style="padding:3px 10px;background:#b02a2a;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.7rem">Delete</button>') + '</td>' +
           '</tr>' + renderContactPanelRow(u) + hiveRows;
       }).join('');
       document.getElementById('users-container').innerHTML =


### PR DESCRIPTION
## Admin read-only "View as user" impersonation

The hub admin can now see the hub dashboard **exactly as any registered user sees it** — strictly **READ-ONLY** and **server-enforced** (not just hidden UI), with a persistent banner and explicit enter/exit. This is a diagnostic/support affordance; it **cannot escalate privilege**.

### The security boundary (server)

**Signed, short-lived impersonation cookie** — a separate `hive_hub_impersonate` cookie, HMAC-bound to the hub secret with the *same* construction as the existing `hive_hub_user` session cookie (no new crypto). Payload encodes `{admin, target, exp}` with a 30-minute TTL (`impersonateTTL`). `HttpOnly`, `Secure`, `SameSite=Lax`, same domain as the session cookie.

**GET-only identity switch, gated on the real admin** — `resolveIdentity(r)` returns `(effective, realAdmin, impersonating)`. A grant is honored **only** when it is HMAC-verified, unexpired, its `admin` field equals the **real signed session user**, that user is exactly `hubAdminUsername`, **and** the target resolves to a real registered user. The effective identity switches to the target **only for GET/HEAD**; for any mutating method it stays the admin. Because every per-user handler already derives its view from `getAuthUser`, this one change renders all per-user views as the target with no per-view edits.

**Central write-block (403)** — while a grant is active, any non-GET/HEAD request is refused `403 {"error":"read-only while viewing as <user> …"}`. The check lives in **both** `requireAuth` and `requireAdmin` (through which every user-facing mutation is routed), so no write path can slip past. The exit endpoint is the one exemption. `requireAdmin` now gates on the **real** admin identity so admin routes — including exit — stay reachable while impersonating, and no admin surface leaks to the target.

**Enter / exit endpoints**
- `POST /api/saas/admin/impersonate/{username}` (requireAdmin) — validates the target is registered, sets the signed cookie, `200`; `404` for an unknown target.
- `POST /api/saas/admin/impersonate/exit` — clears the cookie; **write-block exempt**, so it works while impersonating.
- `GET /api/saas/impersonation-status` → `{impersonating, viewing_as}`; also folded into `/api/auth/user` for the banner.

**Audit** — enter and exit are logged through the existing `audit:` logger path with the real admin, target, and timestamp.

### Client
- **"View as" button** on each admin Users-table row (admin-only table).
- **Sticky top banner** on every hub page: `Viewing as <user> — read-only` + **Exit**, fixed to the top and visually distinct.
- While impersonating, `/api/auth/user` reports `hub_admin: false`, so the admin section and other admin-only affordances hide via the existing role checks (defense-in-depth; the 403 is the real gate).

### Tests (`impersonation_test.go`)
- Admin enters and a GET resolves to the **target**; `resolveIdentity` reports the real admin + impersonating.
- Non-admin cannot impersonate → **403**.
- A write (POST/PUT/DELETE) under an active grant → **403**; a GET still passes.
- Exit clears the cookie and identity returns to the admin (and exit is callable *while* impersonating).
- Forged / tampered / expired / wrong-secret cookie is **ignored** (identity stays admin).
- A grant whose `admin` != real user, or != `hubAdminUsername`, is **ignored** — no privilege escalation.

### Security properties
- **Admin-only enter** — `requireAdmin` + `grant.admin == realUser == hubAdminUsername`.
- **GET-only identity switch** — writes never run under the target.
- **Writes 403'd** — central block in `requireAuth`/`requireAdmin`.
- **Forged cookie ignored** — HMAC + expiry fail closed.
- **No privilege escalation** — the target is always a normal user; a stolen/self-minted grant on a non-admin session is refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
