### PR TITLE
security(merge): bind merge authz to target + eligible-list/SHA (F4), restore ACMM hold label (F6)

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -232,7 +232,14 @@ if [ -n "$AGENT_MODE" ]; then
         echo "🔧 BLOCKED: ${AGENT_NAME_GW} is in ISSUES_AND_PRS mode. Merging requires human approval." >&2
         exit 1
       fi
-      # Auto-add hold label for L5 PRs
+      # NOTE (F6): This hold-label block is DEAD for `pr create`. A non-contributor
+      # `gh pr create` is redirected far above via `exec hive-open-pr "$@"` (~line
+      # 160), which REPLACES this process — execution never reaches here for the
+      # create path. The hold label is now applied AUTHORITATIVELY server-side, in
+      # v2/pkg/github/pr_request_watcher.go, after the hive's App-bot opens the PR,
+      # keyed on the real hive ACMM level (L3/L4/L5). Do NOT rely on this line to
+      # gate anything; it is retained only so `args` stays well-formed for any
+      # non-create pr subcommand that still falls through.
       if [ "$ACMM_LEVEL" = "5" ] && [ "$subcmd" = "pr" ] && [ "$action" = "create" ]; then
         args+=("--label" "hold")
       fi

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1235,13 +1235,28 @@ func main() {
 		// authz enforces the SAME per-agent ACMM write-gate + forge-resistance as
 		// the direct `gh pr create` path — the request-file route grants no extra
 		// privilege. A denied request is quarantined, never opened.
-		ghClient.StartPRRequestWatcher(ctx, agentMgr.AuthorizePROpen, nil)
+		// holdLabel (F6): at hold-gated ACMM levels (L3/L4/L5) every agent-opened
+		// PR must carry the "hold" label so the merge gate holds it for human
+		// approval. This is decided server-side from the authoritative hive level
+		// (GetACMMLevel), NOT from a client flag — the gh-wrapper.sh tail that used
+		// to add the label was dead code after `exec hive-open-pr`. L1/L2 open no
+		// agent PRs (manual); L6 auto-merges on green (no hold).
+		holdLabel := func() bool {
+			l := agentMgr.GetACMMLevel()
+			return l >= acmmHoldGatedMinLevel && l <= acmmHoldGatedMaxLevel
+		}
+		ghClient.StartPRRequestWatcher(ctx, agentMgr.AuthorizePROpen, holdLabel, nil)
 		// Merge relay: agents request merges by dropping a file (hive-merge)
 		// instead of calling the GitHub MCP merge_pull_request tool, whose GraphQL
 		// mutation GitHub rejects for App tokens ("Resource not accessible by
 		// integration"). The hive merges over REST with the App token, gated by
 		// the same forge-resistance + a CanMerge ACMM check.
-		ghClient.StartMergeRequestWatcher(ctx, agentMgr.AuthorizeMerge, nil)
+		// bindMergeAuthz layers the F4 target-binding (CWE-863) on top of the
+		// manager's agent/UID/CanMerge check: the merge must name a pinned head
+		// SHA (no unpinned "merge whatever HEAD is now") AND the (repo, number)
+		// must appear in the governor's current merge-eligible list — so an
+		// injected agent cannot land an arbitrary reachable PR of its choosing.
+		ghClient.StartMergeRequestWatcher(ctx, bindMergeAuthz(agentMgr.AuthorizeMerge), nil)
 	}
 
 	// Opt-in mint credential: when mint.enabled, build a Minter from the config
@@ -5059,11 +5074,96 @@ func runEscalationSweep(
 const mergeEligiblePath = "/var/run/hive-metrics/merge-eligible.json"
 const ciFailingPath = "/var/run/hive-metrics/ci-failing.json"
 
+// acmmHoldGatedMinLevel / acmmHoldGatedMaxLevel bracket the ACMM levels whose
+// merge policy is "hold-gated" — every agent-opened PR gets a "hold" label and
+// no agent merges (see v2/pkg/config/packs/level-{3,4,5}.yaml). L1/L2 are
+// "manual" (agents open no PRs) and L6 is "auto-merge on green CI, no hold
+// label", so both fall outside this range. Used by the F6 hold-label decider.
+const (
+	acmmHoldGatedMinLevel = 3
+	acmmHoldGatedMaxLevel = 5
+)
+
 // mergeableJSONUnknown is the explicit wire value for "mergeability was never
 // determined". It is spelled out rather than left as "" so a consumer reading
 // merge-eligible.json cannot mistake an unpopulated field for a definitive
 // "no" — the failure mode that made every PR read as unmergeable.
 const mergeableJSONUnknown = "unknown"
+
+// mergeTargetEligible reports whether (repo, number) currently appears in the
+// governor's merge-eligible.json. It reads the file FRESH on every call (never
+// caches) because eligibility is recomputed each governor cycle — a stale cache
+// could authorize a PR that has since fallen out of the list. On any read/parse
+// error it returns false (FAIL CLOSED): if we cannot prove the target is
+// eligible, we must not authorize the merge.
+//
+// merge-eligible.json stores repos as "owner/repo"; a MergeRequest.Repo may be
+// bare ("repo") or fully qualified ("owner/repo"). We match on the bare repo
+// name (the segment after the last "/") plus the number, so both request forms
+// resolve to the same eligible entry without depending on the org prefix.
+func mergeTargetEligible(repo string, number int) bool {
+	data, err := os.ReadFile(mergeEligiblePath)
+	if err != nil {
+		return false // fail closed: no list ⇒ nothing is eligible
+	}
+	var payload struct {
+		Items []struct {
+			Number int    `json:"number"`
+			Repo   string `json:"repo"`
+		} `json:"merge_eligible"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return false // fail closed: unparseable list ⇒ deny
+	}
+	want := bareRepoName(repo)
+	for _, it := range payload.Items {
+		if it.Number == number && bareRepoName(it.Repo) == want {
+			return true
+		}
+	}
+	return false
+}
+
+// bareRepoName returns the repo segment after the last "/", so "owner/repo" and
+// "repo" compare equal. Used to match a MergeRequest.Repo against the
+// "owner/repo" entries in merge-eligible.json regardless of prefix.
+func bareRepoName(repo string) string {
+	if i := strings.LastIndex(repo, "/"); i >= 0 {
+		return repo[i+1:]
+	}
+	return repo
+}
+
+// bindMergeAuthz wraps the manager's agent/UID/CanMerge authorizer with the
+// F4 target-binding checks (CWE-863). The inner authz owns the "may this agent
+// merge at all" decision; this wrapper owns "is THIS specific target one the
+// governor deemed eligible, at a pinned SHA". Both must pass before MergePR is
+// reached. Ordering: run the agent/UID/CanMerge check first (cheapest, and it
+// gives the clearest denial reason), then the SHA + eligible-list binding.
+func bindMergeAuthz(inner func(agent string, fileUID int) error) github.MergeRequestAuthorizer {
+	return func(agent string, fileUID int, repo string, number int, expectSHA string) error {
+		if err := inner(agent, fileUID); err != nil {
+			return err
+		}
+		// (a) Require a pinned head SHA. An empty expectSHA means "merge whatever
+		// HEAD is now", which is the TOCTOU hole: a PR that was eligible when the
+		// governor last looked could have had a malicious commit pushed since.
+		// MergePR passes expectSHA as the required head SHA, so a moved head fails
+		// cleanly — but only if we insist it is set.
+		if strings.TrimSpace(expectSHA) == "" {
+			return fmt.Errorf("merge target %s#%d has no expected head SHA — refusing to merge an unpinned head (TOCTOU guard)", repo, number)
+		}
+		// (b) Require the target to be in the governor's current merge-eligible
+		// list. This binds authorization to a PR the hive actually deemed
+		// landable this cycle, so an injected agent cannot request landing an
+		// arbitrary reachable PR (e.g. its own) whose required checks happen to
+		// pass. Read fresh + fail closed (see mergeTargetEligible).
+		if !mergeTargetEligible(repo, number) {
+			return fmt.Errorf("merge target %s#%d is not in the current merge-eligible list — only governor-approved PRs may be landed via the merge relay", repo, number)
+		}
+		return nil
+	}
+}
 
 // mergeableJSON renders a tri-state mergeability verdict for the
 // merge-eligible.json marker, mapping the unknown zero value to an explicit

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -36,9 +36,18 @@ type Client struct {
 	// per-agent ACMM write-policy + forge-resistance. nil fails closed. Set by
 	// StartPRRequestWatcher.
 	prAuthz PRRequestAuthorizer
+	// prHoldLabel decides, at PR-creation time, whether a freshly-opened PR must
+	// carry the "hold" label (F6). It is consulted server-side from authoritative
+	// hive config (the ACMM level), NOT trusted from a client flag — the
+	// gh-wrapper.sh tail that used to add the label is dead code (it sits after
+	// `exec hive-open-pr`). nil means "never hold" (backward-compatible no-op).
+	// Set by StartPRRequestWatcher.
+	prHoldLabel func() bool
 	// mergeAuthz gates merge requests from the merge-request watcher against the
-	// per-agent ACMM merge-policy (CanMerge) + forge-resistance. nil fails
-	// closed. Set by StartMergeRequestWatcher.
+	// per-agent ACMM merge-policy (CanMerge) + forge-resistance AND the merge
+	// TARGET (pinned SHA + governor merge-eligible membership; see
+	// MergeRequestAuthorizer / F4). nil fails closed. Set by
+	// StartMergeRequestWatcher.
 	mergeAuthz MergeRequestAuthorizer
 }
 

--- a/v2/pkg/github/merge_request_watcher.go
+++ b/v2/pkg/github/merge_request_watcher.go
@@ -76,17 +76,28 @@ type MergeResponse struct {
 
 // MergeRequestAuthorizer decides whether a merge request may proceed. Like
 // PRRequestAuthorizer it receives the claimed agent NAME and the UID that OWNS
-// the request file, returning nil to authorize. The caller implements the two
-// checks: (1) forge-resistance — the file UID must map to the claimed agent; and
-// (2) the ACMM merge-gate — the agent must be merge-capable (CanMerge) at the
-// hive's current level. A nil authorizer DENIES everything (fail closed).
-type MergeRequestAuthorizer func(agent string, fileUID int) error
+// the request file, PLUS the merge TARGET (repo, number, expectSHA) so the
+// authorization can be bound to the specific PR being landed. Returning nil
+// authorizes. The caller implements the checks:
+//
+//  1. forge-resistance — the file UID must map to the claimed agent;
+//  2. the ACMM merge-gate — the agent must be merge-capable (CanMerge) at the
+//     hive's current level;
+//  3. target-binding (F4, CWE-863) — expectSHA must be non-empty (an empty
+//     expected SHA is a TOCTOU hole: "merge whatever HEAD is now"), and the
+//     (repo, number) pair must currently appear in the governor's
+//     merge-eligible list. Without (3) an injected L6 scanner could request
+//     landing ANY reachable PR whose required checks pass, including its own.
+//
+// A nil authorizer DENIES everything (fail closed).
+type MergeRequestAuthorizer func(agent string, fileUID int, repo string, number int, expectSHA string) error
 
 // StartMergeRequestWatcher runs a loop that merges PRs for request files dropped
 // in MergeRequestDir. It returns immediately; the loop runs until ctx is
 // cancelled. A nil client (no GitHub creds) makes this a no-op. authz enforces
-// the per-agent ACMM merge-gate + forge-resistance; a nil authz fails closed.
-// nowFn is injectable for tests; pass nil for time.Now.
+// the per-agent ACMM merge-gate + forge-resistance AND the F4 target-binding
+// (pinned SHA + merge-eligible membership); a nil authz fails closed. nowFn is
+// injectable for tests; pass nil for time.Now.
 func (c *Client) StartMergeRequestWatcher(ctx context.Context, authz MergeRequestAuthorizer, nowFn func() time.Time) {
 	if c == nil {
 		return
@@ -168,7 +179,7 @@ func (c *Client) handleOneMergeRequest(ctx context.Context, path string, nowFn f
 		c.denyMergeRequest(path, req, "no authorizer configured (fail closed)", nowFn)
 		return
 	}
-	if err := c.mergeAuthz(req.Agent, fileUID); err != nil {
+	if err := c.mergeAuthz(req.Agent, fileUID, req.Repo, req.Number, req.ExpectSHA); err != nil {
 		c.denyMergeRequest(path, req, err.Error(), nowFn)
 		return
 	}

--- a/v2/pkg/github/merge_request_watcher_test.go
+++ b/v2/pkg/github/merge_request_watcher_test.go
@@ -43,7 +43,7 @@ func newMergeMockServer(t *testing.T, failWith int, merges *int) *httptest.Serve
 func testMergeClient(t *testing.T, srvURL string) *Client {
 	t.Helper()
 	c := NewClientForTest(srvURL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	c.mergeAuthz = func(agent string, uid int) error { return nil }
+	c.mergeAuthz = func(agent string, uid int, repo string, number int, expectSHA string) error { return nil }
 	return c
 }
 
@@ -119,7 +119,9 @@ func TestMergeRequestWatcher_AuthzDeny(t *testing.T) {
 	srv := newMergeMockServer(t, 0, &merges)
 	defer srv.Close()
 	c := NewClientForTest(srv.URL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	c.mergeAuthz = func(agent string, uid int) error { return context.DeadlineExceeded }
+	c.mergeAuthz = func(agent string, uid int, repo string, number int, expectSHA string) error {
+		return context.DeadlineExceeded
+	}
 
 	dir := t.TempDir()
 	mergeRequestDirForTest = dir
@@ -133,6 +135,60 @@ func TestMergeRequestWatcher_AuthzDeny(t *testing.T) {
 	}
 	if _, err := os.Stat(reqPath + ".denied"); err != nil {
 		t.Error("denied request should be quarantined as .denied")
+	}
+}
+
+// F4: the authorizer receives the merge TARGET (repo, number, expectSHA), and a
+// denial keyed on any of those (e.g. empty expectSHA or a target not in the
+// eligible list) quarantines the request WITHOUT merging. This asserts the
+// target-binding parameters actually reach the authorizer.
+func TestMergeRequestWatcher_TargetBoundAuthz(t *testing.T) {
+	merges := 0
+	srv := newMergeMockServer(t, 0, &merges)
+	defer srv.Close()
+	c := NewClientForTest(srv.URL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	var gotRepo, gotSHA string
+	var gotNumber int
+	// Stand-in for bindMergeAuthz's SHA guard: deny when expectSHA is empty.
+	c.mergeAuthz = func(agent string, uid int, repo string, number int, expectSHA string) error {
+		gotRepo, gotNumber, gotSHA = repo, number, expectSHA
+		if strings.TrimSpace(expectSHA) == "" {
+			return context.DeadlineExceeded // stand-in denial (TOCTOU guard)
+		}
+		return nil
+	}
+
+	dir := t.TempDir()
+	mergeRequestDirForTest = dir
+	defer func() { mergeRequestDirForTest = "" }()
+
+	// No ExpectSHA → must be denied and quarantined, never merged.
+	reqPath, _ := WriteMergeRequest(dir, MergeRequest{Repo: "o/r", Number: 99, Agent: "scanner"})
+	c.ProcessMergeRequestsOnce(context.Background())
+
+	if gotRepo != "o/r" || gotNumber != 99 || gotSHA != "" {
+		t.Errorf("authorizer did not receive the target: repo=%q number=%d sha=%q", gotRepo, gotNumber, gotSHA)
+	}
+	if merges != 0 {
+		t.Fatalf("unpinned (empty-SHA) merge must be denied, got %d merges", merges)
+	}
+	if _, err := os.Stat(reqPath + ".denied"); err != nil {
+		t.Error("target-bound denial should quarantine the request as .denied")
+	}
+
+	// With a pinned SHA the same target authorizes and merges.
+	merges = 0
+	reqPath2, _ := WriteMergeRequest(dir, MergeRequest{Repo: "o/r", Number: 100, Agent: "scanner", ExpectSHA: "abc123"})
+	c.ProcessMergeRequestsOnce(context.Background())
+	if gotSHA != "abc123" || gotNumber != 100 {
+		t.Errorf("authorizer did not receive pinned target: number=%d sha=%q", gotNumber, gotSHA)
+	}
+	if merges != 1 {
+		t.Fatalf("pinned + authorized merge should proceed, got %d merges", merges)
+	}
+	if _, err := os.Stat(reqPath2); !os.IsNotExist(err) {
+		t.Error("successful merge should consume the request file")
 	}
 }
 

--- a/v2/pkg/github/pr_request_watcher.go
+++ b/v2/pkg/github/pr_request_watcher.go
@@ -88,12 +88,19 @@ type PRRequestAuthorizer func(agent string, fileUID int) error
 // watcher must never open a PR that hasn't been authorized against the same
 // policy as the direct `gh pr create` path.
 //
+// holdLabel (F6) decides server-side, from authoritative hive config (the ACMM
+// level), whether a freshly-opened PR must carry the "hold" label. It is applied
+// AFTER the PR is created, on the path that actually runs — unlike the
+// gh-wrapper.sh tail, which was dead code (it sat after `exec hive-open-pr`), so
+// hold-gated PRs were being opened unlabeled. A nil holdLabel means "never hold".
+//
 // nowFn is injectable for tests; pass nil for time.Now.
-func (c *Client) StartPRRequestWatcher(ctx context.Context, authz PRRequestAuthorizer, nowFn func() time.Time) {
+func (c *Client) StartPRRequestWatcher(ctx context.Context, authz PRRequestAuthorizer, holdLabel func() bool, nowFn func() time.Time) {
 	if c == nil {
 		return
 	}
 	c.prAuthz = authz
+	c.prHoldLabel = holdLabel
 	if nowFn == nil {
 		nowFn = time.Now
 	}
@@ -202,6 +209,27 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 	resp.Number = res.Number
 	resp.URL = res.URL
 	resp.AlreadyExisted = res.AlreadyExisted
+
+	// F6: apply the ACMM "hold" label server-side, from authoritative config, on
+	// the path that actually runs. At hold-gated levels (L3/L4/L5) every
+	// agent-opened PR must be human-approved before merge; the label is what the
+	// merge gate keys on. The old gh-wrapper.sh `args+=("--label" "hold")` was
+	// unreachable (it followed `exec hive-open-pr`), so those PRs were opened
+	// unlabeled and the gate was inert. AddLabels is additive + idempotent, so it
+	// is safe to (re)apply even when we reused an already-open PR.
+	if c.prHoldLabel != nil && c.prHoldLabel() {
+		if lerr := c.AddLabels(ctx, req.Repo, res.Number, []string{"hold"}); lerr != nil {
+			// A missing hold label at a hold-gated level is a policy failure, not a
+			// cosmetic one — surface it loudly so an operator notices, but the PR is
+			// already open so we do not fail the request.
+			c.logger.Warn("pr-request watcher: PR opened but failed to apply hold label (hold-gated level)",
+				slog.String("repo", req.Repo), slog.Int("number", res.Number), slog.String("error", lerr.Error()))
+		} else {
+			c.logger.Info("pr-request watcher: applied hold label (hold-gated ACMM level)",
+				slog.String("repo", req.Repo), slog.Int("number", res.Number))
+		}
+	}
+
 	c.writePRResult(path, resp)
 	// Success (or reuse of an existing PR) — consume the request so it isn't
 	// reprocessed.

--- a/v2/pkg/github/pr_request_watcher_test.go
+++ b/v2/pkg/github/pr_request_watcher_test.go
@@ -16,6 +16,15 @@ import (
 // mock GitHub API for PR create + list. created counts POST /pulls calls.
 func newPRMockServer(t *testing.T, existingHead string, created *int) *httptest.Server {
 	t.Helper()
+	return newPRMockServerLabels(t, existingHead, created, nil)
+}
+
+// newPRMockServerLabels extends newPRMockServer to also mock
+// POST /issues/{n}/labels; when addedLabels != nil it records each labels-add
+// payload (as the JSON array of label names) so a test can assert the "hold"
+// label was (or was not) applied.
+func newPRMockServerLabels(t *testing.T, existingHead string, created *int, addedLabels *[]string) *httptest.Server {
+	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pulls"):
@@ -37,6 +46,15 @@ func newPRMockServer(t *testing.T, existingHead string, created *int) *httptest.
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, `{"number":42,"html_url":"https://github.com/o/r/pull/42","title":"`+
 				strings.ReplaceAll(asString(np["title"]), `"`, `\"`)+`"}`)
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/labels"):
+			body, _ := io.ReadAll(r.Body)
+			var labels []string
+			_ = json.Unmarshal(body, &labels)
+			if addedLabels != nil {
+				*addedLabels = append(*addedLabels, labels...)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[]`)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -191,5 +209,54 @@ func TestPRRequestWatcher_NilAuthzFailsClosed(t *testing.T) {
 
 	if created != 0 {
 		t.Errorf("nil authorizer must fail closed (no PR); got %d", created)
+	}
+}
+
+// F6: the hold label is applied server-side after a PR is opened iff the
+// injected decider says the current ACMM level is hold-gated. This is the check
+// the dead gh-wrapper.sh tail failed to perform (it sat after `exec
+// hive-open-pr`), so hold-gated PRs were opened unlabeled.
+func TestPRRequestWatcher_HoldLabelApplied(t *testing.T) {
+	cases := []struct {
+		name     string
+		holdFn   func() bool
+		wantHold bool
+	}{
+		{"hold-gated level applies hold", func() bool { return true }, true},
+		{"non-hold-gated level applies nothing", func() bool { return false }, false},
+		{"nil decider applies nothing", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			created := 0
+			var added []string
+			srv := newPRMockServerLabels(t, "", &created, &added)
+			defer srv.Close()
+
+			c := NewClientForTest(srv.URL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			c.prAuthz = func(agent string, uid int) error { return nil }
+			c.prHoldLabel = tc.holdFn
+
+			dir := t.TempDir()
+			old := prRequestDirForTest
+			prRequestDirForTest = dir
+			defer func() { prRequestDirForTest = old }()
+
+			_, _ = WritePRRequest(dir, PRRequest{Repo: "o/r", Head: "scanner/hold", Title: "gated PR", Agent: "scanner"})
+			c.ProcessPRRequestsOnce(context.Background())
+
+			if created != 1 {
+				t.Fatalf("expected the PR to be created once, got %d", created)
+			}
+			gotHold := false
+			for _, l := range added {
+				if l == "hold" {
+					gotHold = true
+				}
+			}
+			if gotHold != tc.wantHold {
+				t.Errorf("hold label applied=%v, want %v (labels seen: %v)", gotHold, tc.wantHold, added)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes two verified HIGH findings (Springer 2026-08-05 audit, re-verified against v4 tip). Both are **CWE-863 (Incorrect Authorization)** in the Go merge-authorization path.

## F4 — L6 merge authorization not target-bound

`AuthorizeMerge(agentName, fileUID)` received no repo/PR/SHA, so it could not verify the merge target was actually assigned/eligible. An injected merge-capable agent could request landing **any** reachable PR whose required checks pass — including its own.

**Fix — bind authorization to the target:**
- Extended `MergeRequestAuthorizer` to `func(agent string, fileUID int, repo string, number int, expectSHA string) error`; updated the `mergeAuthz` field, `StartMergeRequestWatcher`, and the call site to pass `req.Repo, req.Number, req.ExpectSHA`.
- `Manager.AuthorizeMerge` stays focused on its existing job (agent/UID/CanMerge). The target-binding lives in a new `bindMergeAuthz` wrapper in `cmd/hive/main.go` — cleanest layering, since reading the governor's `merge-eligible.json` is already a `cmd/hive` concern (that's where the file is written). By the time `MergePR` is reached, both new checks have run:
  - **(a) non-empty expectSHA** — reject if `strings.TrimSpace(expectSHA) == ""`. An empty expected SHA means "merge whatever HEAD is now" — the TOCTOU hole. `MergePR` already passes expectSHA as the required head SHA, so a moved head fails cleanly, but only if we insist it's set.
  - **(b) eligible-list membership** — the `(repo, number)` must appear in `merge-eligible.json` (`{"merge_eligible":[{"repo","number"},...]}`). Read **fresh per authorization** (eligibility changes each governor cycle) and **fail closed** on any read/parse error. Reuses the existing `mergeEligiblePath` const; matches on bare repo name (segment after last `/`) so a bare `repo` or `owner/repo` request both resolve against the `owner/repo` entries.

## F6 — ACMM hold label never applied

`bin/gh-wrapper.sh` does `exec hive-open-pr "$@"` for non-contributor agents, which **replaces the process** — the hold-label block that follows it was dead code. Downstream `pr_request_watcher.go` called `CreatePR(...)` with no labels, so hold-gated PRs were opened **unlabeled** and any gate keyed on the `hold` label was inert.

**Fix — apply the label on the path that actually runs, server-side:**
- Chose approach (b): after `CreatePR` succeeds in `pr_request_watcher.go`, apply `hold` via the existing `Client.AddLabels`. The decision is authoritative — a server-side `holdLabel func() bool` passed into `StartPRRequestWatcher`, wired in `main.go` to `GetACMMLevel()` — **not** a client-supplied flag.
- Verified the hold-gated levels from the ACMM packs: `merge_policy` is hold-gated at **L3, L4, and L5** (`level-{3,4,5}.yaml`); L1/L2 are `manual` (agents open no PRs) and L6 is auto-merge/"No hold label". The decider applies `hold` iff `3 <= level <= 5` (named constants `acmmHoldGatedMinLevel`/`acmmHoldGatedMaxLevel`). Note this corrects the audit's "L3/L5" to the pack-verified **L3/L4/L5**.
- The dead `gh-wrapper.sh` block is **annotated** (pointing to the server-side apply), not relied upon, and left in place since removing it is not load-bearing.

## Tests & coverage

`go test ./pkg/github/ ./pkg/agent/ -short -count=1 -cover` — both pass.
- New `TestMergeRequestWatcher_TargetBoundAuthz`: asserts repo/number/expectSHA reach the authorizer; unpinned (empty-SHA) merge is denied + quarantined `.denied`; pinned + authorized merge proceeds and consumes the request.
- New `TestPRRequestWatcher_HoldLabelApplied` (table): `hold` applied iff the decider says the level is hold-gated (true → labeled; false/nil → not).
- Coverage: `pkg/github` **88.2% → 88.5%** (improved by the F6 test); `pkg/agent` unchanged (no agent code touched). Both floors (github 90 / agent 89) were **already red on the base branch** (88.2% each — the pre-existing shortfall tracked in the coverage-hourly override / #2355), so this is not a regression.

## Residual concerns
- The eligible-list read (F4) is only as trustworthy as `/var/run/hive-metrics/merge-eligible.json`; a process able to forge that file could still self-authorize. It is written by the governor via `atomicWrite` in the hive process; the fail-closed-on-error behavior means a missing/corrupt file denies rather than opens the gate.
- F6 applies the label after the PR is open (a brief unlabeled window). AddLabels failure is logged loudly but does not fail the request (the PR already exists); a hardened variant could retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
