### PR TITLE
🔒 feat(contribute): deliver contributor credential only after task acceptance (auto-accept default)

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1894,11 +1894,32 @@ type HubConfig struct {
 	// same Config.Hub.* mechanism as the other admission settings so it survives
 	// restart, and edited only through the authenticated PUT /api/contribute/queue/order
 	// endpoint (owner/read-write only).
-	ContributeQueueOrder []string            `yaml:"contribute_queue_order,omitempty"`
-	DisabledRepos        []string            `yaml:"disabled_repos"`
-	DisabledTiers        []string            `yaml:"disabled_tiers"`
-	TierLimits           map[string]TierRate `yaml:"tier_limits"`
-	SnapshotIntervalMin  int                 `yaml:"snapshot_interval_min"`
+	ContributeQueueOrder []string `yaml:"contribute_queue_order,omitempty"`
+	// ContributeRequireExplicitAccept gates HOW a contributor's scoped GitHub
+	// credential is delivered relative to task acceptance (kubestellar/hive#2537).
+	// The credential is ALWAYS delivered only AFTER an acceptance decision — it no
+	// longer travels bundled in the task_assign message. This toggle only chooses
+	// WHO makes that decision:
+	//   - nil / false (DEFAULT): trusted-source AUTO-ACCEPT. A task that already
+	//     passed admission (the title/author/label filters, disabled-repo/tier
+	//     gates, cooldown, and the per-tier trust gate in selectTask) is
+	//     auto-accepted the instant it is assigned, and the scoped credential is
+	//     delivered immediately after — no human in the loop. This keeps an
+	//     unattended fleet running exactly as before: the only observable change is
+	//     that the credential arrives in a distinct message right after task_assign
+	//     rather than inside it.
+	//   - true: EXPLICIT (manual/human) acceptance. The hub withholds the credential
+	//     until the client sends a task_accepted for the assigned task; a task that
+	//     is never accepted (declined, timed out, or reconnected away) never
+	//     receives a credential. This is the opt-in "mandatory acceptance" mode for
+	//     operators who want a wait state.
+	// A POINTER so an absent value (older on-disk config) resolves to the
+	// backward-compatible auto-accept default via IsContributeRequireExplicitAccept().
+	ContributeRequireExplicitAccept *bool               `yaml:"contribute_require_explicit_accept,omitempty"`
+	DisabledRepos                   []string            `yaml:"disabled_repos"`
+	DisabledTiers                   []string            `yaml:"disabled_tiers"`
+	TierLimits                      map[string]TierRate `yaml:"tier_limits"`
+	SnapshotIntervalMin             int                 `yaml:"snapshot_interval_min"`
 }
 
 // Contribute completion-cooldown defaults and clamp bounds. These live in the
@@ -1924,6 +1945,16 @@ const (
 // ENABLED for backward compatibility; an explicit false disables it.
 func (h HubConfig) IsContributeCooldownEnabled() bool {
 	return h.ContributeCooldownEnabled == nil || *h.ContributeCooldownEnabled
+}
+
+// IsContributeRequireExplicitAccept resolves the effective acceptance mode for
+// contributor credential delivery (kubestellar/hive#2537). A nil pointer (unset,
+// older config) resolves to FALSE — trusted-source auto-accept — so an existing
+// deployment keeps handing credentials to admitted tasks without a wait state; an
+// explicit true opts into mandatory (human/manual) acceptance where the credential
+// is withheld until the client accepts the assigned task.
+func (h HubConfig) IsContributeRequireExplicitAccept() bool {
+	return h.ContributeRequireExplicitAccept != nil && *h.ContributeRequireExplicitAccept
 }
 
 // ContributeCooldownHoursOrDefault resolves the with-PR cooldown PERIOD in

--- a/v2/pkg/dashboard/contribute_protocol.go
+++ b/v2/pkg/dashboard/contribute_protocol.go
@@ -36,7 +36,7 @@ package dashboard
 // backward-compatible by construction. Semantic: MAJOR.MINOR where a MINOR bump
 // is purely additive and a MAJOR bump would be a breaking change (none is made
 // here).
-const contributorProtocolVersion = "1.1"
+const contributorProtocolVersion = "1.2"
 
 // Server capability tokens advertised on auth_ok (#2567). Each names a message
 // type or feature this hub supports so a client can adapt without probing. They
@@ -55,6 +55,13 @@ const (
 	// capCapabilityDeclare: the hub accepts, stores, and surfaces client-declared
 	// capabilities in auth_response (#2547 declare half).
 	capCapabilityDeclare = "capability_declare"
+	// capCredentialAfterAccept: the hub splits the scoped GitHub credential OUT of
+	// task_assign and delivers it (via a token_refresh) only AFTER the task's
+	// acceptance decision (#2537). A client that sees this capability knows the
+	// task_assign it receives carries NO github_token and that the credential
+	// arrives in a following token_refresh — but no client change is required, since
+	// the token_refresh delivery is backward-compatible (see deliverTaskCredential).
+	capCredentialAfterAccept = "credential_after_accept"
 )
 
 // serverCapabilities returns the capability set this hub advertises on auth_ok.
@@ -66,6 +73,7 @@ func serverCapabilities() []string {
 		capTaskUnavailableReasons,
 		capPromptPreview,
 		capCapabilityDeclare,
+		capCredentialAfterAccept,
 	}
 }
 

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -96,7 +96,23 @@ type ContributorConnection struct {
 	// client). Stored read-only and surfaced on FleetClanker; NEVER used to route
 	// or gate work.
 	capabilities *ContributorCapabilities
-	mu           sync.Mutex
+	// pendingToken is the scoped, expiring GitHub credential minted for currentTask
+	// but NOT yet delivered to the relay (kubestellar/hive#2537). The credential no
+	// longer travels inside task_assign; it is held here until the task's acceptance
+	// decision is made, then shipped via deliverTaskCredential (which reuses the
+	// token_refresh wire shape). In auto-accept mode (the default) it is delivered
+	// immediately after task_assign is sent; in explicit-accept mode it is held
+	// until a task_accepted arrives. Cleared to "" once delivered (or when the task
+	// ends without acceptance). It is a credential — NEVER logged or previewed.
+	pendingToken string
+	// credentialDelivered records that the scoped credential for currentTask has
+	// already been handed to the relay, so a duplicate task_accepted (the relay
+	// re-asserts one on reconnect) does not re-deliver, and the auto-accept and
+	// explicit-accept paths cannot both fire. Reset when a task ends. This is the
+	// single flag that makes "the credential arrived AFTER acceptance" observable
+	// and idempotent.
+	credentialDelivered bool
+	mu                  sync.Mutex
 }
 
 type WSMessage struct {
@@ -118,8 +134,15 @@ type WSMessage struct {
 	URL               string   `json:"url,omitempty"`
 	Labels            []string `json:"labels,omitempty"`
 	Prompt            string   `json:"prompt,omitempty"`
-	GitHubToken       string   `json:"github_token,omitempty"`
-	TokenExpiresAt    string   `json:"token_expires_at,omitempty"`
+	// GitHubToken carries the scoped, expiring credential. As of #2537 it is
+	// NEVER populated on task_assign — the credential is split OUT of the
+	// assignment message and delivered only AFTER the task's acceptance decision,
+	// via a token_refresh (see deliverTaskCredential). It still travels on
+	// token_refresh (post-acceptance delivery + the #2393 mid-task re-mint). The
+	// token itself is unchanged: same per-tier mint, same wsTokenTTL expiry — only
+	// its timing relative to acceptance moved.
+	GitHubToken    string `json:"github_token,omitempty"`
+	TokenExpiresAt string `json:"token_expires_at,omitempty"`
 	// Restrictions is RESERVED and intentionally not populated by the server yet:
 	// the contributor command restrictions are enforced server-side (gh-wrapper /
 	// contributor-default.json), so shipping the policy to the client would be
@@ -874,6 +897,10 @@ func (h *ContributeWSHub) RequeueContributorTask(contributorID string) int {
 			c.currentPrompt = ""
 			c.currentLabels = nil
 			c.tokenMintedAt = time.Time{}
+			// #2537: drop any credential that was pending/held for the released task
+			// so it cannot leak to the (now task-less) connection.
+			c.pendingToken = ""
+			c.credentialDelivered = false
 			targets = append(targets, releaseTarget{conn: c, task: released})
 		}
 		c.mu.Unlock()
@@ -1220,6 +1247,9 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			abandonedTask := contributor.currentTask
 			contributor.currentTask = nil
 			contributor.tokenMintedAt = time.Time{}
+			// #2537: clear any pending/delivered credential state with the task.
+			contributor.pendingToken = ""
+			contributor.credentialDelivered = false
 			contributor.mu.Unlock()
 			if abandonedTask != nil {
 				h.logger.Warn("[contribute-ws] task released on disconnect",
@@ -1411,6 +1441,9 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			abandoned := contributor.currentTask
 			contributor.currentTask = nil
 			contributor.tokenMintedAt = time.Time{}
+			// #2537: clear any pending/delivered credential state with the task.
+			contributor.pendingToken = ""
+			contributor.credentialDelivered = false
 			contributor.mu.Unlock()
 			if abandoned != nil {
 				h.logger.Warn("[contribute-ws] task abandoned without completion",
@@ -1481,10 +1514,38 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					"repo", task.Repo,
 					"number", task.Number,
 				)
+				// #2537: the credential was withheld from the task_assign above and is
+				// delivered only AFTER acceptance. In the DEFAULT trusted-source
+				// auto-accept mode, the task already cleared admission and the per-tier
+				// trust gate in selectTask, so acceptance is automatic HERE — after the
+				// assignment is committed and sent — and the scoped credential is
+				// delivered immediately. This preserves an unattended fleet's timing
+				// (credential arrives right after task_assign) while making the ordering
+				// provable: the credential leaves the hub only once acceptance is
+				// recorded, never bundled with the metadata. In EXPLICIT-accept mode the
+				// hub withholds here and waits for a task_accepted (handled below).
+				if !h.requireExplicitAccept() {
+					h.deliverTaskCredential(contributor, "auto_accept")
+				} else {
+					h.logger.Info("[contribute-ws] credential withheld pending explicit acceptance",
+						"username", contributor.profile.GitHubUsername, "task", task.TaskID)
+				}
 			}
 
 		case "task_accepted":
-			// acknowledged
+			// #2537: a task_accepted is the client's explicit acceptance of the
+			// assigned task. In EXPLICIT-accept mode the hub withheld the scoped
+			// credential from task_assign and waits for exactly this message before
+			// delivering it — so a task that is never accepted (declined, timed out,
+			// or reconnected away) never receives a credential. acceptTaskCredential
+			// delivers only when the acceptance is for the task this connection
+			// currently holds; a stale/mismatched task_id is ignored. It is idempotent
+			// via deliverTaskCredential, so in auto-accept mode (where the credential
+			// already went out) this is a no-op, and a relay that re-asserts
+			// task_accepted on reconnect cannot re-deliver.
+			if contributor != nil {
+				h.acceptTaskCredential(contributor, msg.TaskID)
+			}
 
 		case "task_progress":
 			if contributor != nil {
@@ -1541,6 +1602,9 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				contributor.currentPrompt = ""
 				contributor.currentLabels = nil
 				contributor.tokenMintedAt = time.Time{}
+				// #2537: clear any pending/delivered credential state with the task.
+				contributor.pendingToken = ""
+				contributor.credentialDelivered = false
 				contributor.tmuxOutput = msg.TmuxOutput
 				contributor.mu.Unlock()
 
@@ -1625,6 +1689,9 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				failedTask := contributor.currentTask
 				contributor.currentTask = nil
 				contributor.tokenMintedAt = time.Time{}
+				// #2537: clear any pending/delivered credential state with the task.
+				contributor.pendingToken = ""
+				contributor.credentialDelivered = false
 				contributor.mu.Unlock()
 
 				if hasTask {
@@ -1798,6 +1865,95 @@ func (h *ContributeWSHub) sendTokenRefresh(c *ContributorConnection, tok string)
 	return nil
 }
 
+// requireExplicitAccept reports whether this hive is in the opt-in EXPLICIT
+// (human/manual) acceptance mode (#2537). A hub without a Config (direct-in-test
+// construction) or an unset toggle resolves to FALSE — the trusted-source
+// auto-accept default — so existing deployments keep delivering credentials to
+// admitted tasks without a wait state.
+func (h *ContributeWSHub) requireExplicitAccept() bool {
+	if h.server == nil || h.server.deps == nil || h.server.deps.Config == nil {
+		return false
+	}
+	return h.server.deps.Config.Hub.IsContributeRequireExplicitAccept()
+}
+
+// deliverTaskCredential ships the scoped credential the hub minted for the
+// connection's current task but deliberately withheld from task_assign (#2537).
+// It is the single post-acceptance delivery point: both the auto-accept path (in
+// the ready handler, right after task_assign is sent) and the explicit-accept path
+// (the task_accepted handler) funnel through here, so the credential provably
+// leaves the hub only AFTER an acceptance decision was recorded — never bundled
+// with the task metadata.
+//
+// It reuses the token_refresh wire shape (github_token + token_expires_at) that
+// every existing relay already understands, so an old client that never learned a
+// new "credential" message still ends up holding a working token: it processes
+// task_assign (metadata) then a token_refresh (credential) exactly as it already
+// handles a mid-task re-mint. The token itself is unchanged — the same per-tier
+// scoped, wsTokenTTL-expiring token selectTask minted — only its timing moved.
+//
+// It is idempotent and safe to call more than once: it delivers only while a
+// pending token is held and not yet delivered, then sets credentialDelivered and
+// clears pendingToken. A task_accepted that arrives in auto-accept mode after the
+// credential already went out is therefore a no-op, and a duplicate acceptance
+// cannot double-send. It NEVER logs the token value. Returns true when it actually
+// delivered (an assignment→acceptance→credential ordering point for tests/audit).
+func (h *ContributeWSHub) deliverTaskCredential(c *ContributorConnection, reason string) bool {
+	c.mu.Lock()
+	if c.currentTask == nil || c.credentialDelivered || c.pendingToken == "" {
+		c.mu.Unlock()
+		return false
+	}
+	tok := c.pendingToken
+	taskID := c.currentTask.TaskID
+	username := ""
+	if c.profile != nil {
+		username = c.profile.GitHubUsername
+	}
+	c.mu.Unlock()
+
+	// sendTokenRefresh writes the github_token + token_expires_at frame and
+	// re-stamps tokenMintedAt on success, anchoring the #2393 refresh cycle on when
+	// the relay actually received the credential.
+	if err := h.sendTokenRefresh(c, tok); err != nil {
+		// Delivery failed (socket gone): leave the token PENDING and undelivered so
+		// a reconnect/resume or a retried acceptance can deliver it. Never log the
+		// token value.
+		h.logger.Info("[contribute-ws] task credential delivery failed, will retry",
+			"username", username, "task", taskID, "accept_reason", reason, "error", err)
+		return false
+	}
+
+	c.mu.Lock()
+	c.credentialDelivered = true
+	c.pendingToken = ""
+	c.mu.Unlock()
+
+	h.logger.Info("[contribute-ws] task credential delivered after acceptance",
+		"username", username, "task", taskID, "accept_reason", reason)
+	return true
+}
+
+// acceptTaskCredential is the explicit-acceptance entry point (#2537): a client
+// task_accepted for taskID accepts the assigned task, releasing the credential the
+// hub withheld from task_assign. It delivers only when taskID matches the task this
+// connection currently holds — a stale or mismatched task_id (e.g. a late
+// task_accepted for a task that already ended) is ignored, so a credential is never
+// delivered for work this connection is not actually on. It returns whether a
+// credential was delivered (an assignment→acceptance→credential ordering point).
+func (h *ContributeWSHub) acceptTaskCredential(c *ContributorConnection, taskID string) bool {
+	if c == nil || taskID == "" {
+		return false
+	}
+	c.mu.Lock()
+	match := c.currentTask != nil && c.currentTask.TaskID == taskID
+	c.mu.Unlock()
+	if !match {
+		return false
+	}
+	return h.deliverTaskCredential(c, "explicit_accept")
+}
+
 func (h *ContributeWSHub) checkModelAllowed(model string) (bool, []string) {
 	if h.server == nil || h.server.deps == nil || h.server.deps.Config == nil {
 		return true, nil
@@ -1833,7 +1989,14 @@ func (h *ContributeWSHub) cleanupLoop() {
 			c.mu.Unlock()
 			if stale {
 				h.logger.Info("[contribute-ws] cleanup: removing stale connection", "username", username, "conn", id)
-				c.ws.Close()
+				// Nil-guard the close: a connection may carry no live socket (e.g. a
+				// test-injected in-flight entry, or a connection torn down elsewhere),
+				// and cleanupLoop iterates ALL registered connections. Mirrors the
+				// existing guard in RequeueContributorTask so a ws-less entry is pruned
+				// rather than nil-dereferenced.
+				if c.ws != nil {
+					c.ws.Close()
+				}
 				delete(h.connections, id)
 			}
 		}
@@ -2475,6 +2638,16 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	c.currentPrompt = prompt
 	c.currentLabels = chosen.labels
 	c.lastIdleReason = ""
+	// #2537: hold the minted scoped token as PENDING rather than shipping it in the
+	// task_assign below. It is delivered only AFTER the acceptance decision — see
+	// the ready-handler (auto-accept default) and the task_accepted handler
+	// (explicit-accept mode) — via deliverTaskCredential. A fresh assignment resets
+	// the delivered flag so the new task's credential is (re)delivered post-accept.
+	// tokenMintedAt is set here so the #2393 refresh cycle is armed for the token we
+	// hand out; deliverTaskCredential re-stamps it on actual delivery to anchor the
+	// 50-minute refresh on when the relay truly received the credential.
+	c.pendingToken = ghToken
+	c.credentialDelivered = false
 	c.tokenMintedAt = time.Now()
 	c.mu.Unlock()
 
@@ -2487,17 +2660,21 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	h.recordAssignment(identityOf(c), time.Now())
 
 	return &WSMessage{
-		Type:           "task_assign",
-		Seq:            h.nextSeq(),
-		TaskID:         taskID,
-		Kind:           "issue",
-		Repo:           chosen.repoFull,
-		Number:         chosen.number,
-		Title:          chosen.title,
-		URL:            chosen.url,
-		GitHubToken:    ghToken,
-		TokenExpiresAt: time.Now().Add(wsTokenTTL).UTC().Format(time.RFC3339),
-		Prompt:         prompt,
+		Type:   "task_assign",
+		Seq:    h.nextSeq(),
+		TaskID: taskID,
+		Kind:   "issue",
+		Repo:   chosen.repoFull,
+		Number: chosen.number,
+		Title:  chosen.title,
+		URL:    chosen.url,
+		// #2537: NO github_token / token_expires_at here. The scoped credential is
+		// split out of task_assign and delivered only after acceptance (see
+		// pendingToken / deliverTaskCredential). task_assign now carries exactly the
+		// metadata needed to DECIDE — repo/number/title/url/labels/prompt — and no
+		// credential, so nothing an agent could act on is authenticated until the
+		// task's source has been accepted under the operator/contributor policy.
+		Prompt: prompt,
 		// The chosen issue's own labels — the Labels envelope field was declared
 		// but never populated, so a client reading it got nothing (kubestellar/
 		// hive#2393 item 8). Carried on the candidate from the scan above.

--- a/v2/pkg/dashboard/contribute_ws_credential_accept_test.go
+++ b/v2/pkg/dashboard/contribute_ws_credential_accept_test.go
@@ -1,0 +1,350 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// Credential-after-acceptance (kubestellar/hive#2537).
+//
+// The contributor's scoped GitHub credential used to travel INSIDE the
+// task_assign message, so an agent received "here is who authored the work" and
+// "here is a credential" before any acceptance decision. These tests pin the new
+// contract: task_assign carries only the DECIDE metadata (repo/number/title/url/
+// labels/prompt) and NO github_token, and the scoped, expiring token is delivered
+// (via the token_refresh wire shape) only AFTER the task's acceptance decision —
+// automatically in the default auto-accept mode, or on an explicit task_accepted
+// in the opt-in explicit mode. The token itself is unchanged: same per-tier mint,
+// same wsTokenTTL expiry — only its timing moved.
+//
+// All state exercised here is per-ContributorConnection (pendingToken /
+// credentialDelivered); no package-global is mutated, so the -race coverage job
+// (#2510/#2652) sees no shared write.
+
+// wsPipe stands up a real gorilla/websocket server/client pair and returns the
+// SERVER-side *websocket.Conn (what the hub writes to) plus the CLIENT conn (what
+// the relay would read). Mirrors the pattern in contribute_ws_token_refresh_test.go
+// so deliverTaskCredential / sendTokenRefresh write a real frame we can read back.
+func wsPipe(t *testing.T) (server *websocket.Conn, client *websocket.Conn) {
+	t.Helper()
+	connReady := make(chan struct{})
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		server = c
+		close(connReady)
+		// Keep the handler alive so the conn stays open for the reads below.
+		time.Sleep(3 * time.Second)
+	}))
+	t.Cleanup(srv.Close)
+
+	c, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	<-connReady
+	return server, c
+}
+
+// readWire reads one frame off the client and decodes it into a bare map so
+// assertions are against the ON-THE-WIRE field names (github_token,
+// token_expires_at) the relay actually consumes.
+func readWire(t *testing.T, client *websocket.Conn) map[string]any {
+	t.Helper()
+	client.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, raw, err := client.ReadMessage()
+	if err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return wire
+}
+
+// TestCredentialAccept_TaskAssignHasNoToken is the core #2537 assertion: the
+// task_assign selectTask produces carries the decide-metadata but NO credential.
+// The token is still MINTED (held pending on the connection), just not shipped in
+// the assignment.
+func TestCredentialAccept_TaskAssignHasNoToken(t *testing.T) {
+	hub, s := covK2Hub(t)
+	oneActionableIssue(s)
+	s.deps.GHAppAuth = newSucceedingAppAuth(t, "ghs_scoped_for_assign")
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "amy", ContributorID: "c-amy", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+
+	msg := hub.selectTask(conn)
+	if msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("expected a task_assign, got %+v", msg)
+	}
+
+	// The credential must NOT be in the assignment message.
+	if msg.GitHubToken != "" {
+		t.Fatalf("#2537 violated: task_assign carried a github_token (%q); it must be delivered after acceptance", msg.GitHubToken)
+	}
+	if msg.TokenExpiresAt != "" {
+		t.Fatalf("#2537: task_assign must not carry token_expires_at, got %q", msg.TokenExpiresAt)
+	}
+	// But the decide-metadata IS present.
+	if msg.Repo == "" || msg.Number == 0 || msg.Title == "" || msg.Prompt == "" {
+		t.Fatalf("task_assign should carry decide-metadata (repo/number/title/prompt), got %+v", msg)
+	}
+
+	// The token was minted and is held pending (undelivered) for post-acceptance.
+	conn.mu.Lock()
+	pending := conn.pendingToken
+	delivered := conn.credentialDelivered
+	conn.mu.Unlock()
+	if pending == "" {
+		t.Fatalf("expected the minted scoped token to be held pending on the connection")
+	}
+	if delivered {
+		t.Fatalf("credential must not be marked delivered before any acceptance")
+	}
+
+	// Also assert the raw JSON of the assignment never contains a token — a
+	// defense against a future field re-introducing it on the wire.
+	blob, _ := json.Marshal(msg)
+	if strings.Contains(string(blob), "github_token") || strings.Contains(string(blob), "ghs_") {
+		t.Fatalf("task_assign JSON leaked a credential:\n%s", string(blob))
+	}
+}
+
+// TestCredentialAccept_DeliverAfterAcceptance verifies the post-acceptance
+// delivery: deliverTaskCredential ships the SAME scoped token via the
+// token_refresh wire shape (github_token + token_expires_at, ~wsTokenTTL out), and
+// flips credentialDelivered so the ordering "acceptance recorded, THEN credential
+// sent" is observable and idempotent.
+func TestCredentialAccept_DeliverAfterAcceptance(t *testing.T) {
+	hub := &ContributeWSHub{logger: covBLogger()}
+	server, client := wsPipe(t)
+
+	const scoped = "ghs_scoped_delivered_after_accept"
+	conn := &ContributorConnection{
+		ws:           server,
+		profile:      &ContributorProfile{TrustTier: "contributor", GitHubUsername: "ben"},
+		currentTask:  &WSTaskAssign{TaskID: "ct-1"},
+		pendingToken: scoped,
+	}
+
+	before := time.Now()
+	if ok := hub.deliverTaskCredential(conn, "auto_accept"); !ok {
+		t.Fatalf("deliverTaskCredential should have delivered the pending token")
+	}
+
+	wire := readWire(t, client)
+	if wire["type"] != "token_refresh" {
+		t.Fatalf("credential must be delivered via the token_refresh wire shape, got type=%v", wire["type"])
+	}
+	if wire["github_token"] != scoped {
+		t.Fatalf("delivered token = %v, want the SAME scoped token %q", wire["github_token"], scoped)
+	}
+	expStr, _ := wire["token_expires_at"].(string)
+	exp, err := time.Parse(time.RFC3339, expStr)
+	if err != nil {
+		t.Fatalf("token_expires_at missing/unparseable: %v", wire["token_expires_at"])
+	}
+	// Still expiring on the same TTL as before — the token is unchanged, only its
+	// timing moved.
+	wantExp := before.Add(wsTokenTTL)
+	if exp.Before(wantExp.Add(-2*time.Minute)) || exp.After(wantExp.Add(2*time.Minute)) {
+		t.Fatalf("delivered token expiry %v not ~wsTokenTTL (%s) out from send", exp, wsTokenTTL)
+	}
+
+	// Delivery is recorded and the pending token consumed.
+	conn.mu.Lock()
+	delivered := conn.credentialDelivered
+	pending := conn.pendingToken
+	conn.mu.Unlock()
+	if !delivered {
+		t.Fatalf("credentialDelivered must be set after delivery")
+	}
+	if pending != "" {
+		t.Fatalf("pendingToken must be cleared after delivery, got %q", pending)
+	}
+
+	// Idempotent: a second call (e.g. a duplicate task_accepted) delivers nothing.
+	if ok := hub.deliverTaskCredential(conn, "explicit_accept"); ok {
+		t.Fatalf("deliverTaskCredential must be a no-op once the credential was delivered")
+	}
+}
+
+// TestCredentialAccept_AutoAcceptDefaultOrdering exercises the DEFAULT
+// (auto-accept) mode end to end through the same seams the ready handler uses:
+// selectTask holds the credential pending, then — because the hub is NOT in
+// explicit mode — the credential is delivered immediately, with NO human step, and
+// the ordering is provable (task assigned/pending BEFORE the credential is sent).
+func TestCredentialAccept_AutoAcceptDefaultOrdering(t *testing.T) {
+	hub, s := covK2Hub(t)
+	oneActionableIssue(s)
+	s.deps.GHAppAuth = newSucceedingAppAuth(t, "ghs_auto_accept_scoped")
+
+	// Default config: explicit-accept unset → auto-accept.
+	if hub.requireExplicitAccept() {
+		t.Fatalf("default mode must be auto-accept (explicit-accept off)")
+	}
+
+	server, client := wsPipe(t)
+	conn := &ContributorConnection{
+		ws:       server,
+		profile:  &ContributorProfile{GitHubUsername: "cara", ContributorID: "c-cara", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+
+	msg := hub.selectTask(conn)
+	if msg == nil || msg.Type != "task_assign" || msg.GitHubToken != "" {
+		t.Fatalf("expected a credential-free task_assign, got %+v", msg)
+	}
+
+	// Acceptance is automatic — the ready handler calls deliverTaskCredential right
+	// after sending task_assign. Model that here: the assignment is already
+	// committed to the connection (currentTask + pendingToken set), THEN deliver.
+	conn.mu.Lock()
+	haveTask := conn.currentTask != nil
+	havePending := conn.pendingToken != ""
+	deliveredBefore := conn.credentialDelivered
+	conn.mu.Unlock()
+	if !haveTask || !havePending {
+		t.Fatalf("assignment must be recorded (task+pending) before credential delivery")
+	}
+	if deliveredBefore {
+		t.Fatalf("credential must not be delivered before the (auto)acceptance step")
+	}
+
+	if ok := hub.deliverTaskCredential(conn, "auto_accept"); !ok {
+		t.Fatalf("auto-accept should deliver the credential")
+	}
+	wire := readWire(t, client)
+	if wire["type"] != "token_refresh" || wire["github_token"] != "ghs_auto_accept_scoped" {
+		t.Fatalf("auto-accept must deliver the scoped token via token_refresh, got %v", wire)
+	}
+}
+
+// TestCredentialAccept_ExplicitModeWithholdsUntilAccept covers the opt-in
+// explicit-accept mode: the credential is withheld at assignment time and
+// delivered only when a matching task_accepted arrives; a task that is never
+// accepted never receives a credential, and a task_accepted for a DIFFERENT
+// task_id is ignored.
+func TestCredentialAccept_ExplicitModeWithholdsUntilAccept(t *testing.T) {
+	hub, s := covK2Hub(t)
+	oneActionableIssue(s)
+	s.deps.GHAppAuth = newSucceedingAppAuth(t, "ghs_explicit_scoped")
+
+	// Opt into explicit acceptance.
+	explicit := true
+	s.deps.Config.Hub.ContributeRequireExplicitAccept = &explicit
+	if !hub.requireExplicitAccept() {
+		t.Fatalf("explicit-accept mode should be on after setting the toggle")
+	}
+
+	server, client := wsPipe(t)
+	conn := &ContributorConnection{
+		ws:       server,
+		profile:  &ContributorProfile{GitHubUsername: "dan", ContributorID: "c-dan", TrustTier: "trusted"},
+		lastPong: time.Now(),
+	}
+
+	msg := hub.selectTask(conn)
+	if msg == nil || msg.Type != "task_assign" || msg.GitHubToken != "" {
+		t.Fatalf("expected a credential-free task_assign, got %+v", msg)
+	}
+	assignedTaskID := msg.TaskID
+
+	// In explicit mode the ready handler does NOT auto-deliver: the credential is
+	// still pending and undelivered.
+	conn.mu.Lock()
+	pending := conn.pendingToken
+	delivered := conn.credentialDelivered
+	conn.mu.Unlock()
+	if pending == "" || delivered {
+		t.Fatalf("explicit mode must withhold: pending=%q delivered=%v", pending, delivered)
+	}
+
+	// A task_accepted for the WRONG task must NOT release the credential.
+	if ok := hub.acceptTaskCredential(conn, "ct-some-other-task"); ok {
+		t.Fatalf("a mismatched task_accepted must not deliver the credential")
+	}
+	conn.mu.Lock()
+	stillPending := conn.pendingToken != "" && !conn.credentialDelivered
+	conn.mu.Unlock()
+	if !stillPending {
+		t.Fatalf("credential must remain withheld after a mismatched task_accepted")
+	}
+
+	// The MATCHING task_accepted delivers the scoped token.
+	if ok := hub.acceptTaskCredential(conn, assignedTaskID); !ok {
+		t.Fatalf("matching task_accepted should deliver the credential")
+	}
+	wire := readWire(t, client)
+	if wire["type"] != "token_refresh" || wire["github_token"] != "ghs_explicit_scoped" {
+		t.Fatalf("explicit acceptance must deliver the scoped token via token_refresh, got %v", wire)
+	}
+}
+
+// TestCredentialAccept_NeverAcceptedNeverGetsCredential proves the negative: a
+// task assigned in explicit mode that is never accepted (the client declines or
+// times out) never has its credential delivered — nothing is ever written to the
+// wire, and the pending token stays undelivered.
+func TestCredentialAccept_NeverAcceptedNeverGetsCredential(t *testing.T) {
+	hub, s := covK2Hub(t)
+	oneActionableIssue(s)
+	s.deps.GHAppAuth = newSucceedingAppAuth(t, "ghs_never_delivered")
+	explicit := true
+	s.deps.Config.Hub.ContributeRequireExplicitAccept = &explicit
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "eve", ContributorID: "c-eve", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	if msg := hub.selectTask(conn); msg == nil || msg.GitHubToken != "" {
+		t.Fatalf("expected a credential-free task_assign, got %+v", msg)
+	}
+
+	// No task_accepted ever arrives. The credential stays pending and undelivered.
+	conn.mu.Lock()
+	pending := conn.pendingToken
+	delivered := conn.credentialDelivered
+	conn.mu.Unlock()
+	if pending == "" {
+		t.Fatalf("token should have been minted and held pending")
+	}
+	if delivered {
+		t.Fatalf("a never-accepted task must never have its credential delivered")
+	}
+}
+
+// TestCredentialAccept_ModeResolver pins the backward-compatible default of the
+// operator toggle: nil (older on-disk config) resolves to auto-accept, matching a
+// running fleet's prior behavior; an explicit true opts into the wait state.
+func TestCredentialAccept_ModeResolver(t *testing.T) {
+	var h config.HubConfig
+	if h.IsContributeRequireExplicitAccept() {
+		t.Fatalf("unset toggle must default to auto-accept (false)")
+	}
+	f := false
+	h.ContributeRequireExplicitAccept = &f
+	if h.IsContributeRequireExplicitAccept() {
+		t.Fatalf("explicit false must resolve to auto-accept")
+	}
+	tr := true
+	h.ContributeRequireExplicitAccept = &tr
+	if !h.IsContributeRequireExplicitAccept() {
+		t.Fatalf("explicit true must resolve to explicit-accept")
+	}
+}


### PR DESCRIPTION
## The ordering defect

A contributor agent received the task's **repo/author/labels/prompt AND a GitHub credential in the same `task_assign` message** — before any acceptance decision. There was no step between "here is who wrote this work" and "here is a credential." This is the credential-delivery-timing property [#2537](https://github.com/kubestellar/hive/issues/2537) asks for: *no contributor credential should become available to an agent until that task's repository, author, labels, and prompt have been accepted under an explicit operator or contributor policy.*

## The accept-then-credential flow

- **`task_assign` no longer carries `github_token` / `token_expires_at`.** It carries only the metadata needed to DECIDE: repo, number, title, url, labels, prompt.
- `selectTask` still mints the **same** per-tier, `wsTokenTTL`-expiring scoped token, but holds it **pending** on the connection (`pendingToken`) instead of shipping it.
- `deliverTaskCredential` ships the credential **after** the acceptance decision, reusing the existing **`token_refresh`** wire shape (`github_token` + `token_expires_at`). A `credentialDelivered` flag makes the ordering — *acceptance recorded, THEN credential sent* — provable and idempotent.

## Auto-accept default (fleet-safe) vs opt-in explicit mode

- **Auto-accept (DEFAULT):** the task already cleared admission (title/author/label filters, disabled-repo/tier gates, cooldown) and the per-tier trust gate in `selectTask`, so acceptance is automatic in the ready handler — right after `task_assign` is sent — and the credential is delivered immediately. **No human in the loop.** A running unattended fleet is unchanged except the credential now arrives in a distinct following message rather than bundled in the assignment.
- **Explicit-accept (opt-in):** operator sets `contribute_require_explicit_accept: true`. The hub withholds the credential until a matching `task_accepted` arrives (the relay already sends this). A task that is never accepted — declined, timed out, reconnected away — or a `task_accepted` for a mismatched `task_id` **never receives a credential.**

## Backward compatibility

- `ContributeRequireExplicitAccept` is a `*bool`: **nil (older on-disk config) → auto-accept**, so existing deployments don't stall waiting for acceptance.
- The credential is delivered via the **existing `token_refresh` message** every relay already understands (it injects on `token_refresh` for the #2393 mid-task re-mint), so an old containerized contributor ends up holding a working token unchanged — it processes `task_assign` (metadata) then a `token_refresh` (credential).
- Protocol MINOR bump **1.1 → 1.2** and a new server capability **`credential_after_accept`** advertised on `auth_ok` (per #2567) so a newer client can learn the deployed behavior without probing. Additive; old clients ignore both.

## The token is unchanged — only its timing moved

Same per-tier mint path, same `wsTokenTTL` expiry, same `token_refresh` re-mint cycle (#2393). This PR changes **WHEN** the credential is sent, not **WHAT** is sent. **Server-side enforcement is untouched** — the reserved `Restrictions` envelope field stays empty; no policy is shipped to the client.

## Tests

`contribute_ws_credential_accept_test.go` (per-connection state only — no package-global, safe for `-race`):
- `task_assign` carries no `github_token` (asserts absent from the message AND its raw JSON), while the token is minted and held pending.
- Post-acceptance delivery is the same scoped token, still `~wsTokenTTL`-expiring, via `token_refresh`, and idempotent (a second delivery is a no-op).
- Auto-accept default: assignment recorded (task + pending) BEFORE credential sent; delivered with no human step.
- Explicit mode: credential withheld until a matching `task_accepted`; a mismatched `task_id` does not release it.
- A never-accepted task never has its credential delivered.
- Mode resolver: nil → auto-accept, explicit true → explicit.

Also nil-guards `cleanupLoop`'s `c.ws.Close()` (a `ws`-less registered connection otherwise nil-derefs under `-race`), mirroring the existing guard in `RequeueContributorTask`.

Fixes #2537

🤖 Generated with [Claude Code](https://claude.com/claude-code)