### PR TITLE
✨ feat(contribute): hub task lease + operator revoke/requeue with stale-worker guard

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -2773,8 +2773,11 @@ onEl('clanker-list','click',function(e){
     // returned to the queue and booked for the same short cooldown as an auto-release,
     // so it is not instantly re-handed to a stale worker. Uses the existing
     // POST /api/contributors/{id}/requeue endpoint (owner/read-write only).
-    adminConfirm('Requeue '+user+'&rsquo;s task','Release the task '+user+' is currently holding back to the ready queue. Use this when a connected clanker is wedged (connected but not progressing). The task is booked for the same short cooldown as an automatic release, so it is not instantly re-assigned to a stale worker. This uses the existing POST /api/contributors/{id}/requeue endpoint.','Requeue',function(){
-      fetch('/api/contributors/'+encodeURIComponent(cid)+'/requeue',{method:'POST'})
+    adminConfirm('Requeue '+user+'&rsquo;s task','Release the task '+user+' is currently holding back to the ready queue. Use this when a connected clanker is wedged (connected but not progressing). The task is booked for the same short cooldown as an automatic release, and the assignment generation is bumped so a stale worker cannot later overwrite the new owner. This uses the existing POST /api/contributors/{id}/requeue endpoint.','Requeue',function(){
+      // #2568: let the operator attach an optional reason. It is recorded in the
+      // audit + activity log and pushed to the still-connected worker on task_revoke.
+      var reason=(window.prompt('Reason for releasing this task (optional):','wedged: no progress')||'').trim();
+      fetch('/api/contributors/'+encodeURIComponent(cid)+'/requeue',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({reason:reason})})
         .then(function(r){return r.json().then(function(d){return{ok:r.ok,d:d};});})
         .then(function(x){if(x.ok){toast('Task requeued for '+user,true);opsPoll();}else{toast((x.d&&x.d.error)||'Requeue failed',false);}})
         .catch(function(){toast('Requeue failed',false);});
@@ -4817,10 +4820,13 @@ func (s *Server) handleContributorRevoke(w http.ResponseWriter, r *http.Request)
 // ContributeWSHub.RequeueContributorTask — so a manual requeue can NOT recreate the
 // duplicate-assignment race #2492/#2557 closed: the released issue books the same
 // short failure cooldown and is therefore not instantly re-handed to a stale worker.
-// It does NOT enforce wsTaskTimeout automatically (manual action only) and does NOT
-// implement the deferred renewable-lease / generation-token protocol (that is the
-// follow-up design half of #2568). Requeuing a contributor with no in-flight task is
-// a 404 (nothing to release) rather than a silent no-op.
+//
+// #2568 completion: the release now BUMPS the connection's assignment generation, so a
+// stale worker that later reports completion is fenced out (the Gate — the automatic
+// lease-TTL backstop lives in the hub's cleanupLoop/reclaimExpiredLeases). The operator
+// may pass a REASON (JSON body {"reason":...} or ?reason=), which is recorded in the
+// audit + activity log and pushed to the still-connected worker on task_revoke.
+// Requeuing a contributor with no in-flight task is a 404 (nothing to release).
 func (s *Server) handleContributorRequeue(w http.ResponseWriter, r *http.Request) {
 	if !s.requireContributorWrite(w, r) {
 		return
@@ -4835,15 +4841,27 @@ func (s *Server) handleContributorRequeue(w http.ResponseWriter, r *http.Request
 		jsonError(w, "Contributor relay is not available", http.StatusServiceUnavailable)
 		return
 	}
+	// #2568: accept an optional operator reason from a JSON body or query param. Both
+	// are optional — an empty reason falls back to the hub's default recovery label —
+	// so existing callers that POST no body keep working unchanged.
+	reason := strings.TrimSpace(r.URL.Query().Get("reason"))
+	if reason == "" && r.Body != nil {
+		var body struct {
+			Reason string `json:"reason"`
+		}
+		if json.NewDecoder(r.Body).Decode(&body) == nil {
+			reason = strings.TrimSpace(body.Reason)
+		}
+	}
 	// Key the live release by the registered ContributorID (what the ops tab passes),
 	// matching how the hub tracks connections. GitHubUsername is only used for logs.
-	released := s.contributeHub.RequeueContributorTask(p.ContributorID)
+	released := s.contributeHub.RequeueContributorTask(p.ContributorID, reason)
 	if released == 0 {
 		jsonError(w, "That contributor has no in-flight task to requeue.", http.StatusNotFound)
 		return
 	}
-	s.auditFromRequest(r, "contributor_requeue", auditDetail("username", p.GitHubUsername), "")
-	s.logger.Info("contributor task requeued by operator", "username", p.GitHubUsername, "sessions_released", released)
+	s.auditFromRequest(r, "contributor_requeue", auditDetail("username", p.GitHubUsername, "reason", reason), "")
+	s.logger.Info("contributor task requeued by operator", "username", p.GitHubUsername, "sessions_released", released, "reason", reason)
 	jsonResponse(w, map[string]any{"ok": true, "released": released})
 }
 

--- a/v2/pkg/dashboard/contribute_lease_test.go
+++ b/v2/pkg/dashboard/contribute_lease_test.go
@@ -1,0 +1,408 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// contribute_lease_test.go covers the kubestellar/hive#2568 completion: the hub-owned
+// task LEASE (auto-expiry backstop), the operator revoke/requeue REASON plumbing, and
+// the assignment-GENERATION guard (the Gate — a stale worker whose task was reassigned
+// must not overwrite the new owner's state). These build on the #2492/#2557 cooldown
+// path and the manual-requeue slice already covered by contribute_requeue_test.go.
+
+// --- generationAccepted (the Gate primitive) ---------------------------------
+
+func TestGenerationAccepted_FencesStaleWorker(t *testing.T) {
+	// Current owner's generation is 5.
+	if !generationAccepted(5, 5) {
+		t.Fatalf("the current generation must be accepted")
+	}
+	// A stale worker still echoing 3 (its task was revoked and reassigned, bumping
+	// the connection past it) must be rejected — this is the fence.
+	if generationAccepted(3, 5) {
+		t.Fatalf("a stale generation must be rejected (the Gate)")
+	}
+	// An unversioned relay that never learned a generation echoes 0 and is accepted,
+	// falling back to the pre-existing TaskID identity match (backward compatibility).
+	if !generationAccepted(0, 5) {
+		t.Fatalf("an unversioned relay (gen 0) must be accepted for backward compatibility")
+	}
+}
+
+// --- lease TTL backstop: reclaimExpiredLeases --------------------------------
+
+// TestLeaseExpiry_WedgedTaskAutoReleasedAndCooledDown proves the backstop: a task
+// whose lease has not been renewed within wsTaskTimeout is auto-released through the
+// SAME short cooldown the disconnect/requeue paths book, its currentTask is cleared,
+// and its generation is bumped (fencing the wedged worker).
+func TestLeaseExpiry_WedgedTaskAutoReleasedAndCooledDown(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	now := time.Now()
+	wedged := &ContributorConnection{
+		profile:        &ContributorProfile{GitHubUsername: "wedged", ContributorID: "c-wedged", TrustTier: "contributor"},
+		currentTask:    &WSTaskAssign{TaskID: "t-wedged", Repo: "myorg/repo1", Number: 42},
+		currentTaskGen: 7,
+		// Lease last renewed well past the TTL → wedged, connected but not progressing.
+		lastLeaseRenew: now.Add(-(wsTaskTimeout + time.Minute)),
+		lastPong:       now, // heartbeat still ALIVE — the connection is not stale.
+	}
+	hub.mu.Lock()
+	hub.connections["conn-wedged"] = wedged
+	hub.mu.Unlock()
+
+	if hub.isTaskInFailureCooldown("myorg/repo1", 42) {
+		t.Fatalf("issue unexpectedly in cooldown before lease expiry")
+	}
+
+	released := hub.reclaimExpiredLeases(now)
+	if released != 1 {
+		t.Fatalf("expected 1 expired lease reclaimed, got %d", released)
+	}
+
+	wedged.mu.Lock()
+	still := wedged.currentTask
+	gen := wedged.currentTaskGen
+	wedged.mu.Unlock()
+	if still != nil {
+		t.Fatalf("currentTask not cleared on lease expiry: %+v", still)
+	}
+	if gen == 7 {
+		t.Fatalf("generation not bumped on lease expiry — a wedged worker would not be fenced")
+	}
+	if !hub.isTaskInFailureCooldown("myorg/repo1", 42) {
+		t.Fatalf("lease expiry did not book the short failure cooldown via the existing path")
+	}
+}
+
+// TestLeaseExpiry_ProgressingTaskNotReclaimed is the NO-FALSE-RECLAIM guarantee: a
+// task that is "working slowly" but still renewing its lease (recent lastLeaseRenew)
+// is NEVER auto-released. This is what keeps the conservative backstop from stealing a
+// legitimately long-running task.
+func TestLeaseExpiry_ProgressingTaskNotReclaimed(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	now := time.Now()
+	working := &ContributorConnection{
+		profile:        &ContributorProfile{GitHubUsername: "slow", ContributorID: "c-slow", TrustTier: "contributor"},
+		currentTask:    &WSTaskAssign{TaskID: "t-slow", Repo: "myorg/repo1", Number: 7},
+		currentTaskGen: 3,
+		// Lease renewed one second ago — the worker is alive and reporting progress.
+		lastLeaseRenew: now.Add(-time.Second),
+		lastPong:       now,
+	}
+	hub.mu.Lock()
+	hub.connections["conn-slow"] = working
+	hub.mu.Unlock()
+
+	if got := hub.reclaimExpiredLeases(now); got != 0 {
+		t.Fatalf("a progressing task must NOT be reclaimed, but %d were", got)
+	}
+	working.mu.Lock()
+	still := working.currentTask
+	working.mu.Unlock()
+	if still == nil {
+		t.Fatalf("a progressing task was wrongly released (false reclaim)")
+	}
+	if hub.isTaskInFailureCooldown("myorg/repo1", 7) {
+		t.Fatalf("a progressing task must not be put into cooldown")
+	}
+}
+
+// TestLeaseExpiry_IdleConnectionIgnored confirms a connection with no active lease
+// (zero lastLeaseRenew / no currentTask) is never a reclaim target, so an idle clanker
+// is untouched by the backstop.
+func TestLeaseExpiry_IdleConnectionIgnored(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	idle := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "idle", ContributorID: "c-idle", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["conn-idle"] = idle
+	hub.mu.Unlock()
+	if got := hub.reclaimExpiredLeases(time.Now()); got != 0 {
+		t.Fatalf("an idle connection must not be reclaimed, got %d", got)
+	}
+}
+
+// --- operator requeue: reason + generation bump ------------------------------
+
+// TestRequeue_RecordsReasonAndBumpsGeneration proves the operator requeue records the
+// supplied reason in the activity log (auditable, visible to operators) and bumps the
+// held connection's generation (fencing the revoked worker).
+func TestRequeue_RecordsReasonAndBumpsGeneration(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	held := &ContributorConnection{
+		profile:        &ContributorProfile{GitHubUsername: "wedged", ContributorID: "c-w", TrustTier: "contributor"},
+		currentTask:    &WSTaskAssign{TaskID: "t-1", Repo: "myorg/repo1", Number: 5},
+		currentTaskGen: 11,
+		lastLeaseRenew: time.Now(),
+		lastPong:       time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["conn-w"] = held
+	hub.mu.Unlock()
+
+	if hub.RequeueContributorTask("c-w", "wedged: no progress for an hour") != 1 {
+		t.Fatalf("expected 1 released")
+	}
+
+	held.mu.Lock()
+	gen := held.currentTaskGen
+	held.mu.Unlock()
+	if gen == 11 {
+		t.Fatalf("generation not bumped on requeue — revoked worker would not be fenced")
+	}
+
+	// The reason is recorded in the activity log (auditable).
+	hub.activityMu.RLock()
+	found := false
+	for _, e := range hub.activity {
+		if strings.Contains(e.Action, "wedged: no progress for an hour") {
+			found = true
+			break
+		}
+	}
+	hub.activityMu.RUnlock()
+	if !found {
+		t.Fatalf("operator reason not recorded in the activity log")
+	}
+}
+
+// TestRequeue_BlankReasonFallsBack confirms an empty reason falls back to the default
+// recovery label rather than recording an empty string, so the release stays auditable.
+func TestRequeue_BlankReasonFallsBack(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	held := &ContributorConnection{
+		profile:        &ContributorProfile{GitHubUsername: "w2", ContributorID: "c-w2", TrustTier: "contributor"},
+		currentTask:    &WSTaskAssign{TaskID: "t-2", Repo: "myorg/repo1", Number: 9},
+		lastLeaseRenew: time.Now(),
+		lastPong:       time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["conn-w2"] = held
+	hub.mu.Unlock()
+
+	hub.RequeueContributorTask("c-w2", "   ")
+	hub.activityMu.RLock()
+	found := false
+	for _, e := range hub.activity {
+		if strings.Contains(e.Action, defaultRequeueReason) {
+			found = true
+			break
+		}
+	}
+	hub.activityMu.RUnlock()
+	if !found {
+		t.Fatalf("blank reason did not fall back to the default recovery label")
+	}
+}
+
+// --- endpoint: reason plumbing + auth ----------------------------------------
+
+// TestRequeueEndpoint_ReasonAndAuth exercises the HTTP endpoint: an owner may pass a
+// reason in the JSON body (200 + released), and a read viewer is forbidden (403 — the
+// #2562 owner/read-write boundary, so this is not an unauthenticated control like the
+// class of bug #2610 fixed).
+func TestRequeueEndpoint_ReasonAndAuth(t *testing.T) {
+	setupContributeEnv(t)
+	if err := saveContributorProfile(&ContributorProfile{
+		GitHubUsername: "dave", ContributorID: "c-dave", TrustTier: "contributor",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	inject := func() {
+		held := &ContributorConnection{
+			profile:        &ContributorProfile{GitHubUsername: "dave", ContributorID: "c-dave", TrustTier: "contributor"},
+			currentTask:    &WSTaskAssign{TaskID: "t-d", Repo: "myorg/repo1", Number: 5},
+			lastLeaseRenew: time.Now(),
+			lastPong:       time.Now(),
+		}
+		s.contributeHub.mu.Lock()
+		s.contributeHub.connections["conn-dave"] = held
+		s.contributeHub.mu.Unlock()
+	}
+
+	// A read viewer is forbidden — the control requires owner/read-write.
+	inject()
+	reqRV := httptest.NewRequest(http.MethodPost, "/api/contributors/dave/requeue",
+		strings.NewReader(`{"reason":"nope"}`))
+	reqRV.Header.Set("X-Hive-Role", "read")
+	wRV := httptest.NewRecorder()
+	s.mux.ServeHTTP(wRV, reqRV)
+	if wRV.Code != http.StatusForbidden {
+		t.Fatalf("read viewer requeue got %d, want 403 (unauthed control would be the #2610 bug)", wRV.Code)
+	}
+
+	// An owner with a reason body releases the task (200, released == 1).
+	req := httptest.NewRequest(http.MethodPost, "/api/contributors/dave/requeue",
+		strings.NewReader(`{"reason":"wedged: connected but idle"}`))
+	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("owner requeue with reason got %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	var resp struct {
+		OK       bool `json:"ok"`
+		Released int  `json:"released"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if !resp.OK || resp.Released != 1 {
+		t.Fatalf("unexpected requeue response: %+v", resp)
+	}
+}
+
+// --- THE GATE: stale-generation guard end to end -----------------------------
+
+// TestStaleGeneration_RevokedWorkerCannotOverwriteNewOwner is the most important test
+// (the Gate). It drives the real WebSocket handlers:
+//
+//  1. A worker is assigned a task and learns its generation (task_gen) from task_assign.
+//  2. The operator revokes that task (RequeueContributorTask bumps the connection's
+//     generation and books the cooldown).
+//  3. The SAME worker, now stale, sends task_complete carrying the OLD task_gen.
+//  4. The guard REJECTS it: the completion is not recorded (TasksCompleted stays 0),
+//     so a revoked worker cannot overwrite the reassigned owner's state.
+//
+// A control leg confirms that a completion carrying the CURRENT generation IS recorded,
+// so the guard fences only stale workers.
+func TestStaleGeneration_RevokedWorkerCannotOverwriteNewOwner(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	// Register + connect a worker.
+	body := `{"github_username":"gateuser"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn) // auth_ok
+
+	// Give the worker a task; capture its generation from the assign message.
+	setStatusIssues(s, intgIssue(300, "Gate issue", "someone", nil))
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 2})
+	assign := readMsg(t, conn)
+	if assign.Type != "task_assign" {
+		t.Fatalf("expected task_assign, got %+v", assign)
+	}
+	if assign.TaskGen == 0 {
+		t.Fatalf("task_assign did not carry a generation token (the Gate needs it)")
+	}
+	staleGen := assign.TaskGen
+	staleTaskID := assign.TaskID
+
+	// Operator revokes the task: this bumps the connection's generation past staleGen.
+	if s.contributeHub.RequeueContributorTask(reg["contributor_id"], "wedged: no progress") != 1 {
+		t.Fatalf("expected the operator revoke to release the held task")
+	}
+	// The relay would receive a task_revoke here; drain it so it doesn't confuse reads.
+	_ = readMsg(t, conn) // task_revoke
+
+	// The now-STALE worker wakes and reports completion with the OLD generation.
+	conn.WriteJSON(WSMessage{
+		Type:    "task_complete",
+		TaskID:  staleTaskID,
+		TaskGen: staleGen,
+		Result:  "pr_created",
+		PRURL:   "https://github.com/myorg/repo1/pull/999",
+	})
+	time.Sleep(60 * time.Millisecond)
+
+	p := findContributor(reg["contributor_id"])
+	if p == nil {
+		t.Fatalf("contributor vanished")
+	}
+	if p.TasksCompleted != 0 {
+		t.Fatalf("THE GATE FAILED: a stale-generation task_complete was recorded (TasksCompleted=%d) — a revoked worker overwrote state", p.TasksCompleted)
+	}
+
+	// Control: a fresh assignment + a completion carrying the CURRENT generation IS
+	// recorded, proving the guard fences only stale workers, not all completions.
+	setStatusIssues(s, intgIssue(301, "Gate control issue", "someone", nil))
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 3})
+	assign2 := readMsg(t, conn)
+	if assign2.Type != "task_assign" {
+		t.Fatalf("expected a fresh task_assign for the control leg, got %+v", assign2)
+	}
+	if assign2.TaskGen == staleGen {
+		t.Fatalf("the reassignment reused the stale generation — generations must be monotonic")
+	}
+	conn.WriteJSON(WSMessage{
+		Type:    "task_complete",
+		TaskID:  assign2.TaskID,
+		TaskGen: assign2.TaskGen,
+		Result:  "no_pr",
+		PRURL:   "",
+	})
+	time.Sleep(60 * time.Millisecond)
+
+	p = findContributor(reg["contributor_id"])
+	if p.TasksCompleted != 1 {
+		t.Fatalf("a current-generation completion was not recorded (TasksCompleted=%d) — the guard is over-fencing", p.TasksCompleted)
+	}
+}
+
+// TestAtMostOneAuthoritativeLease is the concurrency half of the Gate: after a task is
+// assigned to one connection, the in-flight guard (activeIssueKeys) excludes that issue
+// so a second connection asking for work cannot be handed the SAME issue — at most one
+// authoritative lease exists at a time.
+func TestAtMostOneAuthoritativeLease(t *testing.T) {
+	hub, s := covK2Hub(t)
+	setStatusIssues(s, intgIssue(400, "Only issue", "someone", nil))
+
+	first := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "first", ContributorID: "c-first", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["conn-first"] = first
+	hub.mu.Unlock()
+
+	assign := hub.selectTask(first)
+	if assign == nil || assign.Type != "task_assign" {
+		t.Fatalf("first connection should get the only issue, got %+v", assign)
+	}
+	// First now holds an authoritative lease (currentTask + generation set by selectTask).
+	first.mu.Lock()
+	gen := first.currentTaskGen
+	first.mu.Unlock()
+	if gen == 0 {
+		t.Fatalf("selectTask did not stamp an assignment generation")
+	}
+
+	// A second connection asks for work: the only issue is in-flight, so it must NOT
+	// be handed out again — no second authoritative lease on the same issue.
+	second := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "second", ContributorID: "c-second", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	msg := hub.selectTask(second)
+	if msg != nil && msg.Type == "task_assign" {
+		t.Fatalf("two authoritative leases on the same issue: %s#%d handed out twice", msg.Repo, msg.Number)
+	}
+}

--- a/v2/pkg/dashboard/contribute_requeue_test.go
+++ b/v2/pkg/dashboard/contribute_requeue_test.go
@@ -38,7 +38,7 @@ func TestRequeueHub_ReleasesAndBooksCooldown(t *testing.T) {
 		t.Fatalf("issue unexpectedly in failure cooldown before requeue")
 	}
 
-	released := hub.RequeueContributorTask("c-wedged")
+	released := hub.RequeueContributorTask("c-wedged", "wedged: no progress")
 	if released != 1 {
 		t.Fatalf("expected 1 session released, got %d", released)
 	}
@@ -73,10 +73,10 @@ func TestRequeueHub_NoInFlightTask_NoOp(t *testing.T) {
 	hub.connections["conn-idle"] = idle
 	hub.mu.Unlock()
 
-	if got := hub.RequeueContributorTask("c-idle"); got != 0 {
+	if got := hub.RequeueContributorTask("c-idle", ""); got != 0 {
 		t.Fatalf("expected 0 released for an idle clanker, got %d", got)
 	}
-	if got := hub.RequeueContributorTask("c-nobody"); got != 0 {
+	if got := hub.RequeueContributorTask("c-nobody", ""); got != 0 {
 		t.Fatalf("expected 0 released for an unknown id, got %d", got)
 	}
 }
@@ -97,7 +97,7 @@ func TestRequeueHub_ReleasedTaskReturnsToQueue(t *testing.T) {
 	hub.connections["conn-w2"] = held
 	hub.mu.Unlock()
 
-	if hub.RequeueContributorTask("c-w2") != 1 {
+	if hub.RequeueContributorTask("c-w2", "") != 1 {
 		t.Fatalf("expected release")
 	}
 	key := "myorg/repo1#7"
@@ -136,7 +136,7 @@ func TestRequeueHub_NoDoubleAssignSameIdentity(t *testing.T) {
 	hub.connections["conn-second"] = second
 	hub.mu.Unlock()
 
-	hub.RequeueContributorTask("c-dup")
+	hub.RequeueContributorTask("c-dup", "")
 	// The freshly-released issue is in the short cooldown — selectTask's admission
 	// scan (isTaskInFailureCooldown) excludes it, so the second session cannot be
 	// re-handed the same issue in the reconnect window. No duplicate assignment.

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -28,7 +29,18 @@ import (
 const (
 	wsHeartbeatInterval = 30 * time.Second
 	wsHeartbeatTimeout  = 90 * time.Second
-	wsTaskTimeout       = 30 * time.Minute
+	// wsTaskTimeout is the hub-owned LEASE TTL on task ownership (kubestellar/hive
+	// #2568). A task's lease is renewed on assignment and on every task_progress
+	// report; if a connection holds a task but the lease has not been renewed within
+	// this window the cleanupLoop auto-releases it through the SAME cooldown path the
+	// disconnect/ready-abandon/manual-requeue releases use, so a wedged-but-connected
+	// worker cannot hold an issue forever. It is deliberately CONSERVATIVE (option 4
+	// in the issue: manual operator recovery is the primary path, auto-expiry is only
+	// the backstop) so a task that is legitimately "working slowly" — but still
+	// reporting progress — is never falsely reclaimed. Matches the relay's own
+	// 30-minute MAX_TASK_DURATION_MS watchdog so the hub backstop fires no earlier
+	// than the relay's own give-up point.
+	wsTaskTimeout = 30 * time.Minute
 	// wsTokenTTL is how long a minted scoped GitHub token stays valid. It must
 	// match the token_expires_at we advertise to the relay so both sides agree
 	// on when the token dies.
@@ -66,8 +78,25 @@ type ContributorConnection struct {
 	role        string // empty = task-driven mode, "scanner"/"reviewer"/etc. = role mode
 	connectedAt time.Time
 	currentTask *WSTaskAssign
-	lastPong    time.Time
-	tmuxOutput  []string
+	// currentTaskGen is the assignment GENERATION stamped on currentTask (kubestellar/
+	// hive#2568, the Gate). It is a monotonically increasing token minted per
+	// assignment (task_assign, and the task_progress RESUME path that adopts a task).
+	// It is shipped to the relay in task_assign and echoed back on task_progress /
+	// task_complete / task_failed. When a task is released (disconnect, ready-abandon,
+	// operator requeue, or lease-TTL expiry) this is bumped, so a STALE worker that
+	// later wakes and reports completion/progress carrying the OLD generation is
+	// FENCED OUT: its message is rejected and cannot overwrite the new owner's state.
+	// Zero when no task is active (and a client that never learned a generation — an
+	// unversioned relay — reports 0, which is treated as "unstamped" and falls back to
+	// the pre-existing TaskID match, preserving backward compatibility).
+	currentTaskGen uint64
+	// lastLeaseRenew is when currentTask's hub-owned lease was last renewed
+	// (kubestellar/hive#2568): set on assignment and refreshed on every task_progress.
+	// cleanupLoop auto-releases a task whose lease has not been renewed within
+	// wsTaskTimeout. Zero when no task is active.
+	lastLeaseRenew time.Time
+	lastPong       time.Time
+	tmuxOutput     []string
 	// tokenMintedAt is when the scoped GitHub token for currentTask was last
 	// minted. The heartbeat loop uses it to re-mint and push a token_refresh
 	// once wsTokenRefreshPeriod has elapsed, before the token expires. Zero when
@@ -127,13 +156,21 @@ type WSMessage struct {
 	CLIBackend        string   `json:"cli_backend,omitempty"`
 	Model             string   `json:"model,omitempty"`
 	TaskID            string   `json:"task_id,omitempty"`
-	Kind              string   `json:"kind,omitempty"`
-	Repo              string   `json:"repo,omitempty"`
-	Number            int      `json:"number,omitempty"`
-	Title             string   `json:"title,omitempty"`
-	URL               string   `json:"url,omitempty"`
-	Labels            []string `json:"labels,omitempty"`
-	Prompt            string   `json:"prompt,omitempty"`
+	// TaskGen is the assignment GENERATION / lease token for this task (kubestellar/
+	// hive#2568, the Gate). The hub stamps it on task_assign; the relay echoes it back
+	// on task_progress / task_complete / task_failed. The hub rejects any completion or
+	// progress carrying a generation older than the currently-held one, so a worker
+	// whose task was revoked and reassigned cannot later overwrite the new owner's
+	// state. Additive: an unversioned relay omits it (0), and the hub falls back to the
+	// pre-existing TaskID match for those clients. Never a credential.
+	TaskGen uint64   `json:"task_gen,omitempty"`
+	Kind    string   `json:"kind,omitempty"`
+	Repo    string   `json:"repo,omitempty"`
+	Number  int      `json:"number,omitempty"`
+	Title   string   `json:"title,omitempty"`
+	URL     string   `json:"url,omitempty"`
+	Labels  []string `json:"labels,omitempty"`
+	Prompt  string   `json:"prompt,omitempty"`
 	// GitHubToken carries the scoped, expiring credential. As of #2537 it is
 	// NEVER populated on task_assign — the credential is split OUT of the
 	// assignment message and delivered only AFTER the task's acceptance decision,
@@ -214,10 +251,21 @@ type ActivityEntry struct {
 }
 
 type ContributeWSHub struct {
-	connections    map[string]*ContributorConnection
-	mu             sync.RWMutex
-	logger         *slog.Logger
-	seq            int
+	connections map[string]*ContributorConnection
+	mu          sync.RWMutex
+	logger      *slog.Logger
+	seq         int
+	// taskGen is the monotonically increasing source of assignment GENERATION tokens
+	// (kubestellar/hive#2568, the Gate). nextTaskGen() hands out a fresh value for
+	// every assignment and every release, so a generation is never reused across the
+	// life of the hub — a stale worker's old generation can never coincidentally match
+	// a later assignment's. It is an atomic counter (NOT guarded by mu) precisely so
+	// nextTaskGen() can be called from paths that ALREADY hold h.mu (e.g.
+	// RequeueContributorTask and reclaimExpiredLeases iterate connections under
+	// h.mu.RLock): a mu-guarded counter would deadlock (RLock-then-Lock on the same
+	// RWMutex). Lock-free is also what the -race coverage job wants — see the standing
+	// "never re-lock m.mu from a path that holds it" rule.
+	taskGen        atomic.Uint64
 	activityMu     sync.RWMutex
 	activity       []ActivityEntry
 	server         *Server
@@ -339,6 +387,17 @@ const quarantineCooldownHours = 6
 // failure. With a weight of 3 and a threshold of 3, a single permanent failure
 // quarantines the issue immediately.
 const permanentFailureWeight = 3
+
+// defaultRequeueReason is the fallback reason recorded and pushed to the client when
+// an operator requeues a held task without supplying one (kubestellar/hive#2568). A
+// non-empty reason is always recorded so the release stays auditable.
+const defaultRequeueReason = "requeued by operator"
+
+// leaseExpiredReason is the reason pushed to a relay whose task lease expired without
+// progress (kubestellar/hive#2568). It is distinct from the operator-requeue reason so
+// an operator reading the activity log can tell a manual release from the automatic
+// backstop.
+const leaseExpiredReason = "task lease expired (no progress within lease TTL)"
 
 func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 	hub := &ContributeWSHub{
@@ -867,17 +926,34 @@ func (h *ContributeWSHub) recentFailureCount(repo string, number int) int {
 //     it clears its local currentTask, stops progress reporting, and sends "ready")
 //     so the wedged relay stops cleanly and re-asks for work.
 //
-// It does NOT mint or rotate any token, does NOT change trust, and does NOT
-// implement the deferred lease/generation-token guarantee (a truly stale worker that
-// later reconnects and reports completion is out of scope for this slice — the
-// cooldown is the safe interim). Synthetic pr-review tasks carry Number == 0 and are
-// released without booking an issue-key cooldown, exactly like the disconnect path.
+// It does NOT mint or rotate any token and does NOT change trust. It DOES now bump
+// the connection's assignment generation on release (the deferred lease/generation
+// guarantee, delivered here — see step 4 below), so a truly stale worker that later
+// reports completion on the same socket is fenced out. Synthetic pr-review tasks
+// carry Number == 0 and are released without booking an issue-key cooldown, exactly
+// like the disconnect path.
+//
+//  4. bump the connection's currentTaskGen (kubestellar/hive#2568, the Gate) so a
+//     late completion/progress from the revoked worker echoing the OLD generation is
+//     rejected by the task_complete/task_progress/task_failed guards and cannot
+//     overwrite the new owner's state.
 //
 // It returns the number of held sessions that were released so the caller can 404 a
 // contributor that has no in-flight task (nothing to requeue) versus report success.
-func (h *ContributeWSHub) RequeueContributorTask(contributorID string) int {
+//
+// #2568 completion: each release now BUMPS the connection's assignment generation
+// (the Gate), so a revoked worker that later wakes and reports completion/progress
+// carrying the OLD generation is fenced out and cannot overwrite the new owner's
+// state. The operator-supplied reason is recorded in the activity log and pushed to
+// the (still-connected) client on the task_revoke message so the worker learns WHY
+// its task was released. A blank reason falls back to the default recovery label.
+func (h *ContributeWSHub) RequeueContributorTask(contributorID, reason string) int {
 	if contributorID == "" {
 		return 0
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = defaultRequeueReason
 	}
 	// Collect the connections + their held tasks under the connection lock, but do
 	// the network send (task_revoke) OUTSIDE h.mu to avoid holding the hub lock
@@ -901,6 +977,10 @@ func (h *ContributeWSHub) RequeueContributorTask(contributorID string) int {
 			// so it cannot leak to the (now task-less) connection.
 			c.pendingToken = ""
 			c.credentialDelivered = false
+			// #2568 (the Gate): fence the revoked worker — bump the generation so its
+			// later completion/progress echoing the old generation is rejected.
+			c.currentTaskGen = h.nextTaskGen()
+			c.lastLeaseRenew = time.Time{}
 			targets = append(targets, releaseTarget{conn: c, task: released})
 		}
 		c.mu.Unlock()
@@ -923,17 +1003,22 @@ func (h *ContributeWSHub) RequeueContributorTask(contributorID string) int {
 			"task", tgt.task.TaskID,
 			"repo", tgt.task.Repo,
 			"number", tgt.task.Number,
+			"reason", reason,
 		)
-		h.addActivity(username, "requeued by operator", tgt.conn.role, tgt.conn.cliBackend, tgt.conn.model, tgt.task.TaskID)
+		// #2568: record the operator's reason in the activity log so the release is
+		// auditable (the reason rides in the Task field alongside the task id).
+		h.addActivity(username, "requeued by operator: "+reason, tgt.conn.role, tgt.conn.cliBackend, tgt.conn.model, tgt.task.TaskID)
 		// Push the EXISTING task_revoke message so the relay stops cleanly and
 		// re-readies. Best-effort: if the socket is already gone the disconnect path
-		// has (or will) release it anyway; the cooldown above is already booked.
+		// has (or will) release it anyway; the cooldown above is already booked. The
+		// operator's reason travels on Reason so a still-connected worker learns WHY
+		// its task was released (kubestellar/hive#2568).
 		if tgt.conn.ws != nil {
 			_ = sendJSON(tgt.conn.ws, WSMessage{
 				Type:   "task_revoke",
 				Seq:    h.nextSeq(),
 				TaskID: tgt.task.TaskID,
-				Reason: "requeued by operator",
+				Reason: reason,
 			})
 		}
 	}
@@ -946,6 +1031,40 @@ func (h *ContributeWSHub) nextSeq() int {
 	s := h.seq
 	h.mu.Unlock()
 	return s
+}
+
+// nextTaskGen hands out a fresh, never-reused assignment GENERATION token
+// (kubestellar/hive#2568, the Gate). It is minted for every task_assign, every
+// task-adopting task_progress RESUME, and every release (disconnect, ready-abandon,
+// operator requeue, lease-TTL expiry) — bumping on release is what fences a
+// stale worker: the connection's currentTaskGen advances past whatever the stale
+// worker still believes it holds. Monotonic (atomic, lock-free — see the taskGen
+// field), so generations are strictly increasing across the life of the hub.
+func (h *ContributeWSHub) nextTaskGen() uint64 {
+	// Lock-free: atomic increment so this is safe to call from paths that already hold
+	// h.mu (RequeueContributorTask / reclaimExpiredLeases run under h.mu.RLock). See
+	// the taskGen field comment for why a mu-guarded counter would deadlock here.
+	return h.taskGen.Add(1)
+}
+
+// generationAccepted reports whether a client message carrying clientGen (the
+// TaskGen it echoed) may act on a connection whose current task generation is
+// currentGen (kubestellar/hive#2568, the Gate). The rule:
+//
+//   - clientGen == 0 → an UNVERSIONED relay that never learned a generation. Accept
+//     it and let the caller's pre-existing TaskID match decide, preserving backward
+//     compatibility with relays that predate the lease token.
+//   - clientGen == currentGen → the current owner. Accept.
+//   - clientGen != currentGen → a STALE worker whose task was released/reassigned
+//     (the connection's generation was bumped past it). REJECT, so its completion or
+//     progress cannot overwrite the new owner's state.
+//
+// The caller MUST hold c.mu (currentTaskGen is read under it).
+func generationAccepted(clientGen, currentGen uint64) bool {
+	if clientGen == 0 {
+		return true
+	}
+	return clientGen == currentGen
 }
 
 func (h *ContributeWSHub) ActiveCount() int {
@@ -1246,6 +1365,10 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			contributor.mu.Lock()
 			abandonedTask := contributor.currentTask
 			contributor.currentTask = nil
+			// #2568: bump the generation on release so any late message from this
+			// now-defunct socket carrying the old generation is fenced.
+			contributor.currentTaskGen = h.nextTaskGen()
+			contributor.lastLeaseRenew = time.Time{}
 			contributor.tokenMintedAt = time.Time{}
 			// #2537: clear any pending/delivered credential state with the task.
 			contributor.pendingToken = ""
@@ -1440,6 +1563,10 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			contributor.mu.Lock()
 			abandoned := contributor.currentTask
 			contributor.currentTask = nil
+			// #2568: bump the generation on release so a re-`ready` abandon fences any
+			// later message echoing the old generation for the just-abandoned task.
+			contributor.currentTaskGen = h.nextTaskGen()
+			contributor.lastLeaseRenew = time.Time{}
 			contributor.tokenMintedAt = time.Time{}
 			// #2537: clear any pending/delivered credential state with the task.
 			contributor.pendingToken = ""
@@ -1550,6 +1677,22 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 		case "task_progress":
 			if contributor != nil {
 				contributor.mu.Lock()
+				// #2568 (the Gate): a worker still holding a task whose progress carries
+				// a STALE generation was revoked/reassigned — its currentTaskGen was
+				// bumped past what it echoes. Reject its progress so it cannot renew a
+				// lease it no longer owns or resurrect ownership state. An unversioned
+				// relay echoes 0 and is accepted (generationAccepted falls back to the
+				// TaskID identity below).
+				if contributor.currentTask != nil && !generationAccepted(msg.TaskGen, contributor.currentTaskGen) {
+					staleGen := msg.TaskGen
+					contributor.mu.Unlock()
+					h.logger.Warn("[contribute-ws] stale-generation task_progress rejected",
+						"username", contributor.profile.GitHubUsername,
+						"task", msg.TaskID,
+						"client_gen", staleGen,
+					)
+					continue
+				}
 				contributor.tmuxOutput = msg.TmuxOutput
 				// resumed is true only when this task_progress REBUILT currentTask
 				// from nothing — i.e. the relay is re-asserting a task the hub had
@@ -1573,6 +1716,16 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 						Title:  msg.Title,
 					}
 					resumed = true
+					// #2568: a RESUME adopts the task under a FRESH generation so the
+					// hub, not the client, owns the authoritative token from here on.
+					contributor.currentTaskGen = h.nextTaskGen()
+				}
+				// #2568: renew the hub-owned lease on every progress report. This is
+				// what distinguishes "working slowly but alive" (lease keeps renewing,
+				// never reclaimed) from "connected but wedged" (lease goes stale and
+				// cleanupLoop reclaims it after wsTaskTimeout).
+				if contributor.currentTask != nil {
+					contributor.lastLeaseRenew = time.Now()
 				}
 				contributor.mu.Unlock()
 
@@ -1594,6 +1747,23 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 		case "task_complete":
 			if contributor != nil {
 				contributor.mu.Lock()
+				// #2568 (the Gate, critical guarantee): a worker whose task was revoked
+				// and reassigned — but that later wakes and reports completion carrying
+				// the OLD generation — must NOT overwrite the new owner's state. Its
+				// currentTaskGen was bumped past what it echoes, so reject the message
+				// WITHOUT clearing currentTask (which may now hold the NEW owner's task).
+				// An unversioned relay echoes 0 and is accepted, falling back to the
+				// TaskID identity match below. Checked before any mutation.
+				if contributor.currentTask != nil && !generationAccepted(msg.TaskGen, contributor.currentTaskGen) {
+					staleGen := msg.TaskGen
+					contributor.mu.Unlock()
+					h.logger.Warn("[contribute-ws] stale-generation task_complete rejected",
+						"username", contributor.profile.GitHubUsername,
+						"task", msg.TaskID,
+						"client_gen", staleGen,
+					)
+					continue
+				}
 				hasTask := contributor.currentTask != nil && contributor.currentTask.TaskID == msg.TaskID
 				completedTask := contributor.currentTask
 				contributor.currentTask = nil
@@ -1685,6 +1855,22 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 		case "task_failed":
 			if contributor != nil {
 				contributor.mu.Lock()
+				// #2568 (the Gate): reject a STALE worker's failure the same way as its
+				// completion — its currentTaskGen was bumped past the generation it
+				// echoes. Left unguarded, a revoked worker's late task_failed would book
+				// a spurious failure cooldown against the NEW owner's issue. Do not clear
+				// currentTask (it may now be the new owner's task). Unversioned relays
+				// echo 0 and fall back to the TaskID match below.
+				if contributor.currentTask != nil && !generationAccepted(msg.TaskGen, contributor.currentTaskGen) {
+					staleGen := msg.TaskGen
+					contributor.mu.Unlock()
+					h.logger.Warn("[contribute-ws] stale-generation task_failed rejected",
+						"username", contributor.profile.GitHubUsername,
+						"task", msg.TaskID,
+						"client_gen", staleGen,
+					)
+					continue
+				}
 				hasTask := contributor.currentTask != nil && contributor.currentTask.TaskID == msg.TaskID
 				failedTask := contributor.currentTask
 				contributor.currentTask = nil
@@ -1978,6 +2164,13 @@ func (h *ContributeWSHub) cleanupLoop() {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 	for range ticker.C {
+		// #2568: reclaim wedged-but-connected task leases first (the backstop). A
+		// connection whose lastPong is still fresh (so the heartbeat sweep below will
+		// NOT remove it) but that has stopped renewing its task lease is exactly the
+		// "connected but wedged" case the issue describes; this releases its task
+		// through the SAME cooldown+generation-bump path a manual requeue uses.
+		h.reclaimExpiredLeases(time.Now())
+
 		h.mu.Lock()
 		for id, c := range h.connections {
 			c.mu.Lock()
@@ -2002,6 +2195,73 @@ func (h *ContributeWSHub) cleanupLoop() {
 		}
 		h.mu.Unlock()
 	}
+}
+
+// reclaimExpiredLeases is the hub-owned LEASE-TTL backstop (kubestellar/hive#2568,
+// option 4). A connection that is still HELD by its socket (heartbeat alive) but has
+// not renewed its task lease within wsTaskTimeout is presumed wedged — connected but
+// no longer progressing — and its task is auto-released. It reuses EXACTLY the manual
+// requeue machinery: it books the same short failure cooldown (so the released issue
+// is not instantly re-admissible and can't recreate the #2492 dup-assign race), bumps
+// the assignment generation (the Gate — so the wedged worker, if it later wakes, is
+// fenced), and pushes task_revoke with an auto-expiry reason so a still-listening
+// relay stops cleanly. It is deliberately CONSERVATIVE: a task that keeps reporting
+// task_progress renews lastLeaseRenew every report and is therefore NEVER reclaimed,
+// so "working slowly but alive" is not confused with "wedged". `now` is injected so
+// tests can drive expiry deterministically.
+func (h *ContributeWSHub) reclaimExpiredLeases(now time.Time) int {
+	type expiredTarget struct {
+		conn *ContributorConnection
+		task WSTaskAssign
+	}
+	var targets []expiredTarget
+	h.mu.RLock()
+	for _, c := range h.connections {
+		c.mu.Lock()
+		// Only a connection actively holding a task with a started lease clock can
+		// expire; a zero lastLeaseRenew means no active lease (idle or just released).
+		expired := c.currentTask != nil && !c.lastLeaseRenew.IsZero() &&
+			now.Sub(c.lastLeaseRenew) > wsTaskTimeout
+		if expired {
+			released := *c.currentTask
+			c.currentTask = nil
+			c.currentPrompt = ""
+			c.currentLabels = nil
+			c.tokenMintedAt = time.Time{}
+			c.currentTaskGen = h.nextTaskGen()
+			c.lastLeaseRenew = time.Time{}
+			targets = append(targets, expiredTarget{conn: c, task: released})
+		}
+		c.mu.Unlock()
+	}
+	h.mu.RUnlock()
+
+	for _, tgt := range targets {
+		if tgt.task.Number > 0 {
+			h.recordTaskFailure(tgt.task.Repo, tgt.task.Number, false)
+		}
+		username := ""
+		if tgt.conn.profile != nil {
+			username = tgt.conn.profile.GitHubUsername
+		}
+		h.logger.Warn("[contribute-ws] task lease expired, auto-released",
+			"username", username,
+			"task", tgt.task.TaskID,
+			"repo", tgt.task.Repo,
+			"number", tgt.task.Number,
+			"lease_ttl", wsTaskTimeout.String(),
+		)
+		h.addActivity(username, "lease expired: auto-released", tgt.conn.role, tgt.conn.cliBackend, tgt.conn.model, tgt.task.TaskID)
+		if tgt.conn.ws != nil {
+			_ = sendJSON(tgt.conn.ws, WSMessage{
+				Type:   "task_revoke",
+				Seq:    h.nextSeq(),
+				TaskID: tgt.task.TaskID,
+				Reason: leaseExpiredReason,
+			})
+		}
+	}
+	return len(targets)
 }
 
 // mintScopedToken produces a scoped GitHub token for the given trust tier via
@@ -2625,6 +2885,11 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	// $HIVE_WORKSPACE_DIR rather than a fork-only --clone=false).
 	prompt := buildTaskPrompt(chosen.repoFull, chosen.number, chosen.title)
 
+	// #2568: mint a fresh assignment generation for this task. It is stamped on the
+	// connection, shipped in task_assign below, and echoed back by the relay so a
+	// later stale-worker completion carrying an older generation is fenced out.
+	gen := h.nextTaskGen()
+
 	c.mu.Lock()
 	c.currentTask = &WSTaskAssign{
 		TaskID: taskID,
@@ -2633,6 +2898,10 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		Number: chosen.number,
 		Title:  chosen.title,
 	}
+	c.currentTaskGen = gen
+	// #2568: start the hub-owned lease clock. task_progress renews it; cleanupLoop
+	// auto-releases the task if it is not renewed within wsTaskTimeout.
+	c.lastLeaseRenew = time.Now()
 	// Store the prompt (never the token) so FleetSnapshot can preview it (#2539),
 	// and clear any stale idle reason now that this connection has real work.
 	c.currentPrompt = prompt
@@ -2660,20 +2929,22 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	h.recordAssignment(identityOf(c), time.Now())
 
 	return &WSMessage{
-		Type:   "task_assign",
-		Seq:    h.nextSeq(),
-		TaskID: taskID,
-		Kind:   "issue",
-		Repo:   chosen.repoFull,
-		Number: chosen.number,
-		Title:  chosen.title,
-		URL:    chosen.url,
+		Type:    "task_assign",
+		Seq:     h.nextSeq(),
+		TaskID:  taskID,
+		TaskGen: gen,
+		Kind:    "issue",
+		Repo:    chosen.repoFull,
+		Number:  chosen.number,
+		Title:   chosen.title,
+		URL:     chosen.url,
 		// #2537: NO github_token / token_expires_at here. The scoped credential is
 		// split out of task_assign and delivered only after acceptance (see
 		// pendingToken / deliverTaskCredential). task_assign now carries exactly the
-		// metadata needed to DECIDE — repo/number/title/url/labels/prompt — and no
-		// credential, so nothing an agent could act on is authenticated until the
-		// task's source has been accepted under the operator/contributor policy.
+		// metadata needed to DECIDE — repo/number/title/url/labels/prompt — plus the
+		// #2568 TaskGen lease token, and no credential, so nothing an agent could act
+		// on is authenticated until the task's source has been accepted under the
+		// operator/contributor policy.
 		Prompt: prompt,
 		// The chosen issue's own labels — the Labels envelope field was declared
 		// but never populated, so a client reading it got nothing (kubestellar/


### PR DESCRIPTION
## Summary

Closes the remaining half of #2568: contributor task ownership now has a **hub-enforced lease** with a bounded expiry, a **safe operator revoke/requeue** action that carries a reason, and an **assignment-generation guard** so a stale worker cannot overwrite the new owner's state after its task is reassigned.

The issue's **Gate** — *"at most one current lease may be authoritative, and releasing it must not allow a stale worker to overwrite the new owner's state"* — is delivered by three additions, built on the already-shipped manual-requeue slice and the #2492/#2557/#2649 cooldown machinery (nothing rebuilt).

## The lease model

- `wsTaskTimeout` (30m) was declared but never enforced (the evidence cited in the issue). It now backs a real **hub-owned lease**: `lastLeaseRenew` is set on assignment and renewed on every `task_progress`.
- `cleanupLoop` calls `reclaimExpiredLeases`, which releases a task whose lease has gone stale through the **same** `recordTaskFailure` cooldown + generation-bump path a manual requeue uses.
- **Conservative by design** (option 4 in the issue): a task that keeps reporting progress renews its lease and is **never** reclaimed, so "working slowly but alive" is not confused with "connected but wedged". Manual operator recovery is the primary path; auto-expiry is only the backstop.

## Operator revoke / requeue

- `RequeueContributorTask` now takes a **reason**. The endpoint (`POST /api/contributors/{id}/requeue`) reads it from `?reason=` or a JSON body `{"reason": ...}`.
- The reason is recorded in the audit + activity log and **pushed to a still-connected worker** on `task_revoke`, so the client learns *why* its task was released (as the issue requires).
- The UI prompts the operator for a reason.

## Stale-worker guard (the Gate)

- New `WSMessage.TaskGen` (a monotonic **assignment generation / lease token**) is stamped on each `task_assign` and the `task_progress` RESUME adopt, echoed back by the relay, and checked on `task_complete` / `task_progress` / `task_failed` via `generationAccepted()`.
- A message carrying a generation **older** than the connection's current one is **rejected without clearing `currentTask`** — so a revoked worker that wakes and sends `completion` cannot overwrite the new owner's state.
- **Every** release (disconnect, ready-abandon, operator requeue, lease-TTL expiry) bumps the generation, fencing the revoked worker.
- **Backward compatible**: an unversioned relay echoes `0`, which falls back to the pre-existing `TaskID` identity match, so old clients are unaffected.
- The counter is a **lock-free `atomic.Uint64`** so it is safe to mint from paths already holding `h.mu` (the requeue/reclaim loops run under `h.mu.RLock`); a mutex-guarded counter would deadlock, and lock-free keeps the `-race` job happy.

## Reuse of the #2649 configurable cooldown

Every release routes through `recordTaskFailure`, so recovery honors the same operator-configurable cooldown/quarantine and **cannot recreate the duplicate-assignment race #2492 fixed**. No new cooldown logic was introduced.

## Auth boundary

The requeue endpoint stays **owner/read-write only** (`requireContributorWrite`) — never an unauthenticated control (the class of bug #2610 addressed). A `read` viewer gets 403.

## Tests (`contribute_lease_test.go`)

- `generationAccepted` fences a stale generation, accepts the current one and the unversioned `0`.
- Lease expiry auto-releases + cools down + bumps the generation; a **progressing task is NOT reclaimed** (no false reclaim); an idle connection is ignored.
- Requeue records the reason + bumps the generation; a blank reason falls back to the default label; the endpoint enforces the reason plumbing + auth (read viewer 403).
- **The Gate (WS end-to-end):** assign → learn generation → operator revoke → a stale-generation `task_complete` is **rejected** (`TasksCompleted` stays 0, new owner survives); a control leg confirms a current-generation completion IS recorded. Plus at-most-one-authoritative-lease.
- `-race` clean.

Fixes #2568