### PR TITLE
✨ Queue controls: Hold/Resume (with indicator), Move to bottom, visible spinner arrows

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1894,11 +1894,23 @@ type HubConfig struct {
 	// same Config.Hub.* mechanism as the other admission settings so it survives
 	// restart, and edited only through the authenticated PUT /api/contribute/queue/order
 	// endpoint (owner/read-write only).
-	ContributeQueueOrder []string            `yaml:"contribute_queue_order,omitempty"`
-	DisabledRepos        []string            `yaml:"disabled_repos"`
-	DisabledTiers        []string            `yaml:"disabled_tiers"`
-	TierLimits           map[string]TierRate `yaml:"tier_limits"`
-	SnapshotIntervalMin  int                 `yaml:"snapshot_interval_min"`
+	ContributeQueueOrder []string `yaml:"contribute_queue_order,omitempty"`
+	// ContributeQueueHold is the OPERATOR HOLD set for the ready-work queue: an
+	// unordered list of "owner/repo#number" keys the operator parked from the
+	// Operations tab. A held issue is NEVER offered — it is excluded from BOTH the
+	// queue display's offer-eligible set (ReadyQueue) and selectTask's candidate
+	// selection — and it stays parked INDEFINITELY until the operator Resumes it.
+	// This is DISTINCT from cooldown (time-based, self-clearing): a hold is a
+	// manual, persistent operator decision. Held rows remain VISIBLE on the
+	// Operations tab (rendered greyed with an "on hold" badge) so the operator can
+	// always see and Resume them. Persisted through the same Config.Hub.* mechanism
+	// as ContributeQueueOrder so it survives restart, and edited only through the
+	// authenticated POST /api/contribute/queue/hold endpoint (owner/read-write only).
+	ContributeQueueHold []string            `yaml:"contribute_queue_hold,omitempty"`
+	DisabledRepos       []string            `yaml:"disabled_repos"`
+	DisabledTiers       []string            `yaml:"disabled_tiers"`
+	TierLimits          map[string]TierRate `yaml:"tier_limits"`
+	SnapshotIntervalMin int                 `yaml:"snapshot_interval_min"`
 }
 
 // Contribute completion-cooldown defaults and clamp bounds. These live in the

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -259,6 +259,11 @@ func (s *Server) registerContributeRoutes() {
 	// enforced IN-HANDLER via requireContributorWrite because the /api/contribute
 	// prefix is exempt from roleEnforcement's read-only block (see that helper).
 	s.mux.HandleFunc("PUT /api/contribute/queue/order", s.handleContributeQueueOrder)
+	// Operator HOLD toggle for the ready-work queue. Owner/read-write only, gated
+	// exactly like queue/order above (in-handler requireContributorWrite). Parks an
+	// issue so it is never offered until Resumed — a persistent hold DISTINCT from
+	// the time-based cooldown. Body: {"key":"owner/repo#number","held":true|false}.
+	s.mux.HandleFunc("POST /api/contribute/queue/hold", s.handleContributeQueueHold)
 	// Contributor-owned LABEL INTERESTS (#2637): a contributor's opt-in list of
 	// GitHub labels they can help with, used to surface/prioritise matching issues
 	// FOR THEM on the Operations queue. Self-service (identity resolved server-side,
@@ -939,10 +944,21 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .cc-q-menu-sep{height:1px;background:#21262d;margin:5px 2px}
 .cc-q-moverow{display:flex;align-items:center;gap:6px;padding:7px 9px}
 .cc-q-moverow label{font-size:.78rem;color:#8b949e;flex:1}
-.cc-q-moverow input{width:56px;background:#0d1117;border:1px solid #30363d;border-radius:6px;color:#e6edf3;font:inherit;font-size:.8rem;padding:4px 6px;outline:none}
+/* color-scheme:dark makes the native number-input spinner arrows theme-aware, so
+   they render light-on-dark and are VISIBLE against the #0d1117 field + the dark
+   #161b22 menu — previously they were black-on-black and effectively invisible.
+   The explicit background/color are kept as a belt-and-braces fallback for engines
+   that don't honour color-scheme on the control. */
+.cc-q-moverow input[type=number]{width:56px;background:#0d1117;border:1px solid #30363d;border-radius:6px;color:#e6edf3;font:inherit;font-size:.8rem;padding:4px 6px;outline:none;color-scheme:dark}
 .cc-q-moverow input:focus{border-color:#1f6feb}
 .cc-q-moverow button{background:#1f6feb;border:none;color:#fff;font:inherit;font-size:.76rem;font-weight:600;padding:5px 10px;border-radius:6px;cursor:pointer}
 .cc-q-moverow button:hover{background:#388bfd}
+/* On-hold rows (#queue-hold): a manually-parked issue stays VISIBLE but is clearly
+   not going to be offered — dimmed to ~55%% opacity with an amber "on hold" pill.
+   Never hidden, so the operator can always see and Resume it. */
+.cc-q-item.cc-q-held{opacity:.55}
+.cc-q-item.cc-q-held:hover{opacity:.8}
+.cc-q-held-tag{margin-left:7px;font-size:.6rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#d29922;background:rgba(210,153,34,.12);border:1px solid rgba(210,153,34,.3);border-radius:999px;padding:0 6px;vertical-align:middle}
 /* ── Opportunistic Work (#2592) — a small, CALM discovery panel. Intentionally
    quiet: no loud "recommended!" chrome, just a short curated list with a subtle
    heat dot and an unobtrusive "add to queue" affordance (owner/read-write only). */
@@ -3213,15 +3229,21 @@ function ccRenderQueue(flip){
     // Per-row "⋯" context menu — Apple-Music style. Owner/read-write ONLY (rendered
     // only when adminEnabled). Carries move-to-top + move-to-position, both keyed on
     // this row's qkey so they act on the right item in the FULL order.
-    var menu=adminEnabled?ccQueueMenuHTML(ccQueueKey(q),i,total):'';
+    // Held (#queue-hold): the server tags a manually-parked issue with held:true. It
+    // stays VISIBLE in the queue (never hidden) but rendered greyed with an "on hold"
+    // badge so the operator can see and Resume it. The ⋯ menu shows Resume for it.
+    var isHeld=!!q.held;
+    var menu=adminEnabled?ccQueueMenuHTML(ccQueueKey(q),i,total,isHeld):'';
     // Label-affinity (#2637): the server sets matches_interest per VIEWER when one
     // of the issue's labels matches a label this contributor subscribed to. Tag the
     // row so CSS can highlight it; a small "for you" pill makes the reason explicit.
     var mine=!!q.matches_interest;
     var mineCls=mine?' cc-q-mine':'';
     var mineTag=mine?'<span class="cc-q-mine-tag" title="Matches one of your label interests">for you</span>':'';
-    return '<div class="cc-q-item'+mineCls+'"'+(canDrag?' draggable="true"':'')+' data-qkey="'+esc(ccQueueKey(q))+'">'+grip+'<span class="cc-q-idx">'+(i+1)+'</span>'+
-      '<div class="cc-q-body"><div class="cc-q-repo">'+ccIssueLinkHTML(q,(q.repo||'')+'#'+(q.number||''))+mineTag+'</div>'+
+    var heldCls=isHeld?' cc-q-held':'';
+    var heldTag=isHeld?'<span class="cc-q-held-tag" title="On hold — parked by the operator; not offered until resumed">&#x23F8; on hold</span>':'';
+    return '<div class="cc-q-item'+mineCls+heldCls+'"'+(canDrag?' draggable="true"':'')+' data-qkey="'+esc(ccQueueKey(q))+'">'+grip+'<span class="cc-q-idx">'+(i+1)+'</span>'+
+      '<div class="cc-q-body"><div class="cc-q-repo">'+ccIssueLinkHTML(q,(q.repo||'')+'#'+(q.number||''))+mineTag+heldTag+'</div>'+
       '<div class="cc-q-title" title="'+esc(q.title||'')+'">'+esc(q.title||'(untitled)')+'</div>'+labels+'</div>'+next+menu+'</div>';
   }).join('');
   if(filtering&&shown===0){el.innerHTML='<div class="ops-empty">No queued items match &ldquo;'+esc(ccQueueSearch)+'&rdquo;.</div>';}
@@ -3237,12 +3259,24 @@ function ccRenderQueue(flip){
 // ccQueueMenuHTML renders the per-row ⋯ menu markup (owner/read-write only). pos is
 // the row's ZERO-based position in the full queue; total is the queue length. The
 // move-to-position input is pre-filled with the row's current 1-based position.
-function ccQueueMenuHTML(key,pos,total){
+function ccQueueMenuHTML(key,pos,total,isHeld){
   var atTop=(pos===0);
+  // A held item is at the bottom of the visible queue by construction (held rows
+  // trail all offerable ones), and Move-to-bottom on it is a no-op anyway; the
+  // atBottom guard below disables it whenever pos is the last slot.
+  var atBottom=(pos===total-1);
+  // Hold/Resume toggles the persistent operator hold. "Resume" is shown when the
+  // item is already held (play glyph), "Hold" otherwise (pause glyph). data-act
+  // carries the CURRENT held state so the click handler knows which way to flip.
+  var holdLabel=isHeld?'Resume':'Hold';
+  var holdIcon=isHeld?'&#x25B6;':'&#x23F8;'; // ▶ resume / ⏸ hold
   return '<span class="cc-q-menu-wrap">'+
     '<button type="button" class="cc-q-menu-btn" aria-haspopup="true" aria-expanded="false" title="More actions" data-qkey="'+esc(key)+'">&#x22EF;</button>'+
     '<div class="cc-q-menu" role="menu">'+
       '<button type="button" class="cc-q-act" role="menuitem" data-act="top" data-qkey="'+esc(key)+'"'+(atTop?' disabled style="opacity:.5;cursor:default"':'')+'><span class="cc-q-menu-ic">&#x2B06;</span>Move to top</button>'+
+      '<button type="button" class="cc-q-act" role="menuitem" data-act="bottom" data-qkey="'+esc(key)+'"'+(atBottom?' disabled style="opacity:.5;cursor:default"':'')+'><span class="cc-q-menu-ic">&#x2B07;</span>Move to bottom</button>'+
+      '<div class="cc-q-menu-sep"></div>'+
+      '<button type="button" class="cc-q-act" role="menuitem" data-act="hold" data-held="'+(isHeld?'1':'0')+'" data-qkey="'+esc(key)+'"><span class="cc-q-menu-ic">'+holdIcon+'</span>'+holdLabel+'</button>'+
       '<div class="cc-q-menu-sep"></div>'+
       '<div class="cc-q-moverow">'+
         '<label for="mv-'+esc(key)+'">Move to&nbsp;#</label>'+
@@ -3295,6 +3329,14 @@ function ccBindQueueMenus(root){
   for(var a=0;a<acts.length;a++){(function(act){
     act.addEventListener('click',function(e){e.stopPropagation();if(act.disabled)return;ccCloseQueueMenus();ccMoveToTop(act.getAttribute('data-qkey'));});
   })(acts[a]);}
+  var bots=root.querySelectorAll('.cc-q-act[data-act=bottom]');
+  for(var b2=0;b2<bots.length;b2++){(function(act){
+    act.addEventListener('click',function(e){e.stopPropagation();if(act.disabled)return;ccCloseQueueMenus();ccMoveToBottom(act.getAttribute('data-qkey'));});
+  })(bots[b2]);}
+  var holds=root.querySelectorAll('.cc-q-act[data-act=hold]');
+  for(var h2=0;h2<holds.length;h2++){(function(act){
+    act.addEventListener('click',function(e){e.stopPropagation();if(act.disabled)return;ccCloseQueueMenus();ccToggleHold(act.getAttribute('data-qkey'),act.getAttribute('data-held')!=='1');});
+  })(holds[h2]);}
   var gos=root.querySelectorAll('.cc-q-act-go');
   for(var g=0;g<gos.length;g++){(function(go){
     var key=go.getAttribute('data-qkey');
@@ -3324,6 +3366,7 @@ function ccQueueIndexOf(key){
   return -1;
 }
 function ccMoveToTop(key){ccMoveToPosition(key,1);}
+function ccMoveToBottom(key){ccMoveToPosition(key,ccQueue.length);}
 function ccMoveToPosition(key,n){
   var from=ccQueueIndexOf(key);if(from<0)return;
   // Validate N (1..len). Clamp rather than reject so an out-of-range value lands at
@@ -3428,6 +3471,24 @@ function ccPersistQueueOrder(){
   fetch('/api/contribute/queue/order',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({order:order})})
     .then(function(r){if(!r.ok)throw new Error('http '+r.status);return r.json();})
     .catch(function(){/* a read viewer would 403 here, but the UI never shows handles to them */});
+}
+// ccToggleHold parks (held=true) or resumes (held=false) one ready-work issue via
+// the authenticated POST /api/contribute/queue/hold endpoint. A held issue is never
+// offered until resumed — a persistent operator hold, distinct from cooldown. On
+// success it re-fetches the queue so the held/offerable split (which the SERVER
+// computes) is reflected: a newly-held row re-appears greyed at the bottom, a
+// resumed row rejoins the offerable list. Owner/read-write only; a read viewer 403s
+// here, but the Hold/Resume action is never rendered for them (adminEnabled gate).
+function ccToggleHold(key,held){
+  if(!key)return;
+  fetch('/api/contribute/queue/hold',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({key:key,held:!!held})})
+    .then(function(r){if(!r.ok)throw new Error('http '+r.status);return r.json();})
+    .then(function(){
+      // Re-hydrate from the server so held tagging + offer-eligibility are authoritative.
+      return fetch('/api/contribute/queue').then(function(r){return r.json();});
+    })
+    .then(function(d){if(d&&d.queue){ccQueue=d.queue.slice();ccRenderQueue();}})
+    .catch(function(){/* a read viewer would 403; the UI never shows the action to them */});
 }
 function ccSetLive(state){ // 'live' | 'poll' | 'connecting'
   // Drive BOTH the queue-head pill (#cc-live, unchanged) and the mirror pill that
@@ -4664,6 +4725,73 @@ func (s *Server) handleContributeQueueOrder(w http.ResponseWriter, r *http.Reque
 	s.refreshAndPersist()
 	s.logger.Info("contribute queue order updated", "keys", len(cleaned))
 	jsonResponse(w, map[string]any{"ok": true, "order": cleaned})
+}
+
+// maxQueueHoldKeys caps how many issues the operator may hold at once. Mirrors
+// maxQueueOrderKeys: generous (the whole visible queue could conceivably be
+// parked) yet bounds a hostile payload so the hold set can neither bloat hive.yaml
+// nor slow the per-selectTask membership lookup.
+const maxQueueHoldKeys = 512
+
+// handleContributeQueueHold toggles the OPERATOR HOLD on one ready-work issue.
+// A held issue is parked INDEFINITELY — never offered — until the operator Resumes
+// it; this is DISTINCT from the time-based cooldown, which self-clears. It is a
+// CONTROL, so owner/read-write ONLY, gated exactly like handleContributeQueueOrder
+// via requireContributorWrite (a read/anon caller gets 403). The hold set lives in
+// Config.Hub.ContributeQueueHold and persists through the SAME refreshAndPersist
+// path as ContributeQueueOrder, so it survives restart. Body:
+// {"key":"owner/repo#number","held":true|false} — held=true adds the key, false
+// removes it. The key MUST be the canonical "owner/repo#number" form (validated
+// against the same queueOrderKeyPattern) so it matches selectTask's exclusion key
+// exactly (the #2648 class of silent miss).
+func (s *Server) handleContributeQueueHold(w http.ResponseWriter, r *http.Request) {
+	if !s.requireContributorWrite(w, r) {
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	var body struct {
+		Key  string `json:"key"`
+		Held bool   `json:"held"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonError(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	key := strings.TrimSpace(body.Key)
+	if key == "" || !queueOrderKeyPattern.MatchString(key) {
+		jsonError(w, "invalid issue key", http.StatusBadRequest)
+		return
+	}
+	// Rebuild the hold set: drop the target key (and any malformed/duplicate
+	// stragglers) first, then re-add it when held=true. This keeps the stored list
+	// well-formed and unique regardless of prior state, and makes the toggle
+	// idempotent (holding an already-held issue, or resuming an already-free one, is
+	// a clean no-op that still persists the canonical set).
+	seen := make(map[string]struct{})
+	cleaned := make([]string, 0, len(s.deps.Config.Hub.ContributeQueueHold)+1)
+	for _, k := range s.deps.Config.Hub.ContributeQueueHold {
+		k = strings.TrimSpace(k)
+		if k == "" || k == key || !queueOrderKeyPattern.MatchString(k) {
+			continue
+		}
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		cleaned = append(cleaned, k)
+	}
+	if body.Held {
+		if len(cleaned) >= maxQueueHoldKeys {
+			jsonError(w, "too many held issues", http.StatusBadRequest)
+			return
+		}
+		cleaned = append(cleaned, key)
+	}
+	s.deps.Config.Hub.ContributeQueueHold = cleaned
+	s.auditFromRequest(r, "contribute_queue_hold", auditDetail("key", key, "held", strconv.FormatBool(body.Held)), "")
+	s.refreshAndPersist()
+	s.logger.Info("contribute queue hold updated", "key", key, "held", body.Held, "total_held", len(cleaned))
+	jsonResponse(w, map[string]any{"ok": true, "key": key, "held": body.Held, "hold": cleaned})
 }
 
 // ── Contributor management ─────────────────────────────────────────────────

--- a/v2/pkg/dashboard/contribute_queue_hold_test.go
+++ b/v2/pkg/dashboard/contribute_queue_hold_test.go
@@ -1,0 +1,252 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ── Operator HOLD / Resume (#queue-hold) + Move-to-bottom + spinner fix ─────────
+// A hold is a MANUAL, PERSISTENT operator decision — distinct from the time-based
+// cooldown — that parks an issue so it is never offered until Resumed. These tests
+// pin the server behaviour (excluded from ReadyQueue's offerable set AND selectTask,
+// surfaced as held for display, round-trips through persistence, auth-gated) and the
+// dashboard structure (menu items + on-hold badge/class).
+
+// TestReadyQueueExcludesHeldFromOffer proves a held issue is NOT in ReadyQueue's
+// offerable set: it is surfaced with Held=true (so the operator can see/Resume it)
+// but never counts as offerable work, and it trails the offerable items.
+func TestReadyQueueExcludesHeldFromOffer(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.RegisterAPI(testDeps(t))
+
+	s.statusMu.Lock()
+	s.status = seedActionable("acme/repo", 3) // issues 1..3
+	s.statusMu.Unlock()
+
+	// Hold #2.
+	s.deps.Config.Hub.ContributeQueueHold = []string{"acme/repo#2"}
+
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 3 {
+		t.Fatalf("expected all 3 items surfaced (held one included but tagged), got %d: %+v", len(q), q)
+	}
+
+	// The offerable items (Held=false) must be #1 and #3, in scan order, ahead of any
+	// held item. #2 must be present but tagged Held, and it must trail the offerable.
+	if q[0].Number != 1 || q[0].Held {
+		t.Fatalf("first offerable item should be #1 (not held), got %+v", q[0])
+	}
+	if q[1].Number != 3 || q[1].Held {
+		t.Fatalf("second offerable item should be #3 (not held), got %+v", q[1])
+	}
+	if q[2].Number != 2 || !q[2].Held {
+		t.Fatalf("held #2 should trail, tagged Held=true, got %+v", q[2])
+	}
+}
+
+// TestReadyQueueResumeReappears proves clearing the hold puts the issue back into
+// the offerable set (untagged), in its normal scan position.
+func TestReadyQueueResumeReappears(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.RegisterAPI(testDeps(t))
+
+	s.statusMu.Lock()
+	s.status = seedActionable("acme/repo", 3)
+	s.statusMu.Unlock()
+
+	// Held, then resumed (empty hold set).
+	s.deps.Config.Hub.ContributeQueueHold = nil
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 3 {
+		t.Fatalf("expected 3 offerable items after resume, got %d", len(q))
+	}
+	for _, it := range q {
+		if it.Held {
+			t.Fatalf("no item should be tagged Held after resume: %+v", it)
+		}
+	}
+	if q[0].Number != 1 || q[1].Number != 2 || q[2].Number != 3 {
+		t.Fatalf("resumed queue lost scan order: %d,%d,%d", q[0].Number, q[1].Number, q[2].Number)
+	}
+}
+
+// TestSelectTaskExcludesHeld proves selectTask never offers a held issue — the
+// operator's parked issue is skipped and the clean one is offered instead, and once
+// resumed the held issue becomes selectable again.
+func TestSelectTaskExcludesHeld(t *testing.T) {
+	hub, s := covK2Hub(t)
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	setStatusIssues(s,
+		intgIssue(1, "held issue", "bob", nil),
+		intgIssue(2, "clean issue", "bob", nil),
+	)
+
+	// Hold #1 (canonical key myorg/repo1#1). It must never be offered.
+	s.deps.Config.Hub.ContributeQueueHold = []string{"myorg/repo1#1"}
+	msg := hub.selectTask(conn)
+	if msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("expected a task_assign for the non-held issue, got %+v", msg)
+	}
+	if msg.Number == 1 {
+		t.Fatalf("held issue #1 was offered; it must be excluded")
+	}
+	if msg.Number != 2 {
+		t.Fatalf("expected the clean #2, got #%d", msg.Number)
+	}
+
+	// Resume #1, clear the assignment, and prove #1 is now selectable again.
+	conn.mu.Lock()
+	conn.currentTask = nil
+	conn.mu.Unlock()
+	s.deps.Config.Hub.ContributeQueueHold = nil
+	// Also hold #2 so only #1 is admissible, forcing the selector to pick #1.
+	s.deps.Config.Hub.ContributeQueueHold = []string{"myorg/repo1#2"}
+	msg = hub.selectTask(conn)
+	if msg == nil || msg.Type != "task_assign" || msg.Number != 1 {
+		t.Fatalf("after resume, #1 should be selectable, got %+v", msg)
+	}
+}
+
+// TestQueueHoldEndpointPersistsRoundTrip proves the hold set survives through its
+// persistence field: a POST hold=true stores the canonical key, a follow-up
+// hold=false removes it, and the endpoint sanitises malformed prior state.
+func TestQueueHoldEndpointPersistsRoundTrip(t *testing.T) {
+	s, deps := apiServer(t)
+
+	// Pre-seed with a malformed/duplicate straggler to prove sanitisation.
+	deps.Config.Hub.ContributeQueueHold = []string{"not a key", "acme/repo#9", "acme/repo#9"}
+
+	// Hold acme/repo#4.
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/queue/hold",
+		strings.NewReader(`{"key":"acme/repo#4","held":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("hold: got %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	got := deps.Config.Hub.ContributeQueueHold
+	// The malformed key is dropped; the valid pre-existing #9 is kept; #4 is added.
+	want := map[string]bool{"acme/repo#9": true, "acme/repo#4": true}
+	if len(got) != len(want) {
+		t.Fatalf("after hold, persisted set = %v, want keys %v", got, want)
+	}
+	for _, k := range got {
+		if !want[k] {
+			t.Fatalf("unexpected persisted key %q (full: %v)", k, got)
+		}
+	}
+
+	// Resume acme/repo#4 → removed; #9 remains.
+	req = httptest.NewRequest(http.MethodPost, "/api/contribute/queue/hold",
+		strings.NewReader(`{"key":"acme/repo#4","held":false}`))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("resume: got %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	got = deps.Config.Hub.ContributeQueueHold
+	if len(got) != 1 || got[0] != "acme/repo#9" {
+		t.Fatalf("after resume, expected only [acme/repo#9], got %v", got)
+	}
+
+	// Response echoes the held flag and the cleaned set.
+	var resp struct {
+		OK   bool     `json:"ok"`
+		Held bool     `json:"held"`
+		Hold []string `json:"hold"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.OK || resp.Held {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+// TestQueueHoldEndpointRoleGate proves the hold endpoint is owner/read-write ONLY,
+// enforced server-side exactly like the queue-order endpoint: a "read" caller 403s.
+func TestQueueHoldEndpointRoleGate(t *testing.T) {
+	cases := []struct {
+		role string
+		want int
+	}{
+		{"read", http.StatusForbidden},
+		{"owner", http.StatusOK},
+		{"read-write", http.StatusOK},
+		{"", http.StatusOK}, // absent header = local/dev owner
+	}
+	for _, tc := range cases {
+		t.Run("role_"+tc.role, func(t *testing.T) {
+			s, _ := apiServer(t)
+			req := httptest.NewRequest(http.MethodPost, "/api/contribute/queue/hold",
+				strings.NewReader(`{"key":"acme/repo#1","held":true}`))
+			req.Header.Set("Content-Type", "application/json")
+			if tc.role != "" {
+				req.Header.Set("X-Hive-Role", tc.role)
+			}
+			w := httptest.NewRecorder()
+			s.mux.ServeHTTP(w, req)
+			if w.Code != tc.want {
+				t.Fatalf("role %q: got %d, want %d (body: %s)", tc.role, w.Code, tc.want, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestQueueHoldEndpointRejectsBadKey proves a malformed issue key is rejected so the
+// stored hold set can never carry a non-canonical entry that would silently miss the
+// selectTask exclusion (the #2648 class of bug).
+func TestQueueHoldEndpointRejectsBadKey(t *testing.T) {
+	s, _ := apiServer(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/queue/hold",
+		strings.NewReader(`{"key":"not a canonical key","held":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("malformed key: got %d, want 400 (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// TestQueueMoveToBottomAndHoldControlsPresent pins the dashboard structure for the
+// three menu additions: Move-to-bottom, Hold/Resume, and the on-hold badge/class.
+func TestQueueMoveToBottomAndHoldControlsPresent(t *testing.T) {
+	body := renderContributePage(t)
+
+	for _, want := range []string{
+		`data-act="bottom"`,                    // Move-to-bottom menu item
+		`Move to bottom`,                       // its label
+		`function ccMoveToBottom(key){`,        // wired mover
+		`ccMoveToPosition(key,ccQueue.length)`, // sends the item to the last slot
+		`data-act="hold"`,                      // Hold/Resume menu item
+		`function ccToggleHold(key,held){`,     // wired toggle
+		`/api/contribute/queue/hold`,           // calls the hold endpoint
+		`cc-q-held`,                            // dimmed held-row class
+		`cc-q-held-tag`,                        // on-hold badge class
+		`on hold`,                              // badge text
+		`color-scheme:dark`,                    // visible spinner-arrow fix
+		`.cc-q-moverow input[type=number]`,     // spinner fix targets the number input
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("queue hold/bottom controls missing marker %q", want)
+		}
+	}
+
+	// The Hold/Resume action must be gated on adminEnabled (owner/read-write) — it
+	// travels through ccQueueMenuHTML, which is only emitted when adminEnabled.
+	if !strings.Contains(body, "var menu=adminEnabled?ccQueueMenuHTML(") {
+		t.Error("per-row hold/resume action is not gated on adminEnabled (owner/read-write only)")
+	}
+}

--- a/v2/pkg/dashboard/contribute_sse.go
+++ b/v2/pkg/dashboard/contribute_sse.go
@@ -79,6 +79,15 @@ type ReadyQueueItem struct {
 	// shared/anonymous queue snapshot (no viewer identity there) and NEVER used to
 	// exclude an item. omitempty so the anonymous payload is byte-for-byte unchanged.
 	MatchesInterest bool `json:"matches_interest,omitempty"`
+	// Held is set true when the operator has manually parked this issue via the
+	// queue HOLD control (Config.Hub.ContributeQueueHold). A held item is NEVER
+	// offered — selectTask excludes it outright and ReadyQueue never sorts it into
+	// the offer-eligible set — but it is still SURFACED here (appended after the
+	// offerable items) so the Operations tab can render it greyed with an "on hold"
+	// badge, letting the operator see and Resume it. Distinct from cooldown: a hold
+	// is persistent and only clears when the operator Resumes it. omitempty so a
+	// snapshot with no holds is byte-for-byte unchanged.
+	Held bool `json:"held,omitempty"`
 }
 
 // sseSubscriber is one connected browser. events is the fan-out channel; done is
@@ -189,9 +198,19 @@ func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
 	active := h.activeIssueKeys()
 
 	var disabledRepos []string
+	var held map[string]struct{}
 	if h.server.deps != nil && h.server.deps.Config != nil {
 		disabledRepos = h.server.deps.Config.Hub.DisabledRepos
+		held = queueHoldSet(h.server.deps.Config.Hub.ContributeQueueHold)
 	}
+
+	// heldItems collects issues the operator parked. They are NEVER offered — kept
+	// out of `out` (the offer-eligible set that the queue-order sort ranks) — but
+	// they are still SURFACED, appended after ordering with Held:true, so the
+	// Operations tab renders them greyed with an "on hold" badge and the operator
+	// can Resume them. A held key uses the SAME canonical "%s#%d" form selectTask's
+	// exclusion uses, so the two stay in lock-step.
+	var heldItems []ReadyQueueItem
 
 	for _, repo := range status.Repos {
 		if len(repo.ActionableIssues) == 0 {
@@ -217,6 +236,24 @@ func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
 				number = n
 			}
 			if number == 0 {
+				continue
+			}
+			// Operator HOLD (#queue-hold): a parked issue is never offered, so it is
+			// kept OUT of the offer-eligible `out` set. It is still collected into
+			// heldItems (tagged Held) so it stays visible-but-dimmed for the operator.
+			// Checked before cooldown/active so a held-AND-cooled issue still shows as
+			// held (the operator's manual decision is the stronger, persistent signal).
+			if _, isHeld := held[fmt.Sprintf("%s#%d", repo.Full, number)]; isHeld {
+				title, _ := issue["title"].(string)
+				url, _ := issue["url"].(string)
+				heldItems = append(heldItems, ReadyQueueItem{
+					Repo:   repo.Full,
+					Number: number,
+					Title:  title,
+					URL:    url,
+					Labels: stringSliceFromAny(issue["labels"]),
+					Held:   true,
+				})
 				continue
 			}
 			if h.isTaskInCooldown(repo.Full, number) {
@@ -278,6 +315,13 @@ func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
 	if len(out) > limit {
 		out = out[:limit]
 	}
+
+	// Held items (#queue-hold) trail ALL offerable work: they are never offered, so
+	// they carry no offer priority and sit at the bottom of the display, greyed with
+	// a badge. Appended after the cap so a large offerable queue never squeezes the
+	// operator's parked rows off-screen — the operator must always be able to see and
+	// Resume what they held.
+	out = append(out, heldItems...)
 	return out
 }
 
@@ -302,6 +346,28 @@ func queueOrderIndex(order []string) map[string]int {
 		}
 	}
 	return idx
+}
+
+// queueHoldSet builds a "owner/repo#number" -> struct{} membership set from the
+// operator's HOLD list (Config.Hub.ContributeQueueHold). A key present here means
+// the issue is manually parked and must never be OFFERED. The keys use the SAME
+// canonical "%s#%d" (repo.Full # number) form every other admission check builds
+// (cooldown / active / failure), so the exclusion cannot silently miss on a
+// repo-name spelling mismatch (the #2648 class of bug). nil-safe to range over
+// (returns nil for an empty list); membership on a nil map is a clean false.
+func queueHoldSet(hold []string) map[string]struct{} {
+	if len(hold) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(hold))
+	for _, key := range hold {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		set[key] = struct{}{}
+	}
+	return set
 }
 
 // applyQueueOrder stably reorders items so any whose "repo#number" key appears in

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -2213,8 +2213,14 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	h.logger.Info("[contribute-ws] selectTask scanning", "repos", len(status.Repos), "totalIssues", totalAvailable, "cooldown", len(h.completedTasks), "active", len(activeIssues))
 
 	var disabledRepos []string
+	var heldIssues map[string]struct{}
 	if h.server.deps != nil && h.server.deps.Config != nil {
 		disabledRepos = h.server.deps.Config.Hub.DisabledRepos
+		// Operator HOLD (#queue-hold): a manually-parked issue must never be offered,
+		// indefinitely, until the operator Resumes it. Built once per selectTask from
+		// the same canonical "%s#%d" keys the cooldown/active/failure checks use, so
+		// the exclusion cannot miss on a repo-name spelling mismatch (#2648).
+		heldIssues = queueHoldSet(h.server.deps.Config.Hub.ContributeQueueHold)
 	}
 
 	// --- Collect the eligible candidates, then order them (#2390) ---------------
@@ -2302,6 +2308,13 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 			}
 			if number == 0 {
 				h.logger.Info("[contribute-ws] skip: number=0", "repo", repo.Full)
+				continue
+			}
+			// Operator HOLD (#queue-hold): skip a manually-parked issue outright. This
+			// is a persistent operator decision, DISTINCT from the time-based cooldown
+			// below — a held issue never becomes a candidate until the operator Resumes
+			// it. Keyed on the same canonical "%s#%d" as every other exclusion.
+			if _, isHeld := heldIssues[fmt.Sprintf("%s#%d", repo.Full, number)]; isHeld {
 				continue
 			}
 			if h.isTaskInCooldown(repo.Full, number) {


### PR DESCRIPTION
Three improvements to the Operations **Ready-work queue** ⋯ (more-actions) menu, in one PR.

## 1. Move to bottom
A new menu item right after **Move to top** (down-arrow ⬇ icon, `data-act="bottom"`), disabled when the item is already at the bottom. Wired as `ccMoveToBottom(key){ ccMoveToPosition(key, ccQueue.length); }` and bound in `ccBindQueueMenus` alongside the existing `top` binding.

## 2. Visible spinner arrows (dark-theme fix)
The **"Move to #"** number input's native up/down spinner arrows were black-on-black — invisible against the dark menu. Added `color-scheme: dark` (plus an explicit background/color fallback) to `.cc-q-moverow input[type=number]` so the spinners render light-on-dark and read well on the `#161b22` menu.

## 3. Operator Hold / Resume (with a visible indicator)
A per-issue **manual, persistent operator hold** — the operator parks an issue so it is **not offered to contributors, indefinitely, until they Resume it**. This is **DISTINCT from cooldown** (which is time-based and self-clearing); a hold is a deliberate, persistent operator decision.

**Server**
- New `Config.Hub.ContributeQueueHold` — a set of canonical `owner/repo#number` keys, **persisted through the same `refreshAndPersist` path as `ContributeQueueOrder`** so it survives restart.
- Held issues are **excluded from BOTH `ReadyQueue`** (offerable set) **and `selectTask`** candidate selection, keyed on the exact same canonical `"%s#%d"` (`repo.Full` # number) form every other admission check (cooldown / active / failure) uses — so the exclusion can't silently miss on a repo-name spelling mismatch (the #2648 class of bug).
- New endpoint **`POST /api/contribute/queue/hold`** `{ "key": "owner/repo#number", "held": true|false }`, **owner/read-write only**, gated by `requireContributorWrite` **exactly like** `PUT /api/contribute/queue/order`. It validates the key against the same canonical pattern, sanitises the stored set, persists, and returns `{ok, key, held, hold}`.
- Held state is surfaced on the read-only queue snapshot via a new **`held: true`** field on `ReadyQueueItem`, so the client can render the indicator.

**Client**
- The ⋯ menu shows **"Hold"** (⏸) when the item is not held and **"Resume"** (▶) when it is — a toggle that calls the new endpoint then re-hydrates the queue.
- Held rows stay **VISIBLE** but are rendered **greyed/dimmed** (`.cc-q-held`) with a small **"⏸ on hold"** badge — never hidden, so the operator can always see and Resume them.
- The Hold/Resume action is only rendered for owner/read-write viewers (the existing `adminEnabled` gate, same as the other queue admin controls).

## Tests
- Go: held issue excluded from `ReadyQueue` (surfaced tagged, trailing) and from `selectTask`; resume → reappears; hold set round-trips through its persistence field (save → load); endpoint role-gate (read → 403) and bad-key rejection (400).
- Dashboard-structure: pins the **Move to bottom** item, the **Hold/Resume** action + endpoint call, and the **on-hold** badge/class via `strings.Contains`, plus the `color-scheme:dark` spinner fix.

---
Auto-merges on green (ignore Playwright).