### PR TITLE
✨ feat(contribute): triage-level view + PR→issue links + light theming

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -255,6 +255,13 @@ func (s *Server) registerContributeRoutes() {
 	// reads (only counts + already-public usernames; no tokens, no PII). GET only,
 	// no side effects. See contribute_metrics.go.
 	s.mux.HandleFunc("GET /api/contribute/metrics", s.handleContributeMetrics)
+	// Read-only TRIAGE ladder (#2612 part b): the contribute issues grouped into a
+	// Warp-style lifecycle (Triaging → Ready → Implementing → Reviewing → Closed),
+	// DERIVED LIVE from the ready queue + fleet snapshot + the PR→issue link (part
+	// c) — no new persistent store. Public like the other /api/contribute* reads
+	// (only public issue metadata + public PR numbers; no tokens, no PII). Fetched
+	// after page load so a slow GitHub PR-link lookup never delays the page render.
+	s.mux.HandleFunc("GET /api/contribute/triage", s.handleContributeTriage)
 	// Operator priority override for the ready-work queue. Owner/read-write only —
 	// enforced IN-HANDLER via requireContributorWrite because the /api/contribute
 	// prefix is exempt from roleEnforcement's read-only block (see that helper).
@@ -1212,6 +1219,46 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 .me-invite__link{flex:1 1 220px;min-width:0;background:var(--cc-bg-deep);color:var(--cc-text-2);border:1px solid var(--cc-border);border-radius:6px;padding:7px 10px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.76rem}
 .me-invite__copy{background:#238636;color:#fff;border:none;border-radius:6px;padding:7px 12px;font-size:.78rem;font-family:inherit;cursor:pointer}
 .me-invite__hint{width:100%%;margin-top:6px;color:var(--cc-muted);font-size:.74rem;line-height:1.4}
+/* ── Triage ladder (#2612 part b) — a lifecycle view over contribute issues.
+   Themed entirely with the (d) tokens so it flips light/dark with the rest of the
+   page. The ladder is a row of level chips (count per rung); below it, per-level
+   groups list the issues with an optional PR badge (part c). Sober SRE register:
+   muted neutrals, the level accent only on the chip dot + count. */
+.cc-triage-ladder{display:flex;flex-wrap:wrap;gap:8px;padding:14px 20px;border-bottom:1px solid var(--cc-border-2)}
+.cc-triage-chip{display:inline-flex;align-items:center;gap:7px;padding:5px 12px;border-radius:999px;font-size:.76rem;font-weight:600;color:var(--cc-text-2);background:var(--cc-bg);border:1px solid var(--cc-border)}
+.cc-triage-chip .cc-tl-dot{width:8px;height:8px;border-radius:50%%;flex:none;background:var(--cc-muted)}
+.cc-triage-chip .cc-tl-n{font-variant-numeric:tabular-nums;color:var(--cc-text);font-weight:700}
+.cc-triage-chip .cc-tl-lbl{color:var(--cc-muted);font-weight:600}
+/* Per-level accent on the dot only — meaning without shouting. */
+.cc-triage-chip.lv-triaging .cc-tl-dot{background:var(--cc-muted)}
+.cc-triage-chip.lv-ready .cc-tl-dot{background:var(--cc-accent)}
+.cc-triage-chip.lv-implementing .cc-tl-dot{background:var(--cc-accent-fg)}
+.cc-triage-chip.lv-reviewing .cc-tl-dot{background:var(--cc-amber)}
+.cc-triage-chip.lv-closed .cc-tl-dot{background:var(--cc-green)}
+.cc-triage-groups{max-height:520px;overflow-y:auto}
+.cc-tg{border-bottom:1px solid var(--cc-border-2)}
+.cc-tg:last-child{border-bottom:none}
+.cc-tg-head{display:flex;align-items:center;gap:8px;padding:10px 20px;font-size:.74rem;font-weight:700;letter-spacing:.03em;text-transform:uppercase;color:var(--cc-muted);position:sticky;top:0;background:var(--cc-surface);z-index:1}
+.cc-tg-head .cc-tg-dot{width:8px;height:8px;border-radius:50%%;flex:none;background:var(--cc-muted)}
+.cc-tg.lv-ready .cc-tg-dot{background:var(--cc-accent)}
+.cc-tg.lv-implementing .cc-tg-dot{background:var(--cc-accent-fg)}
+.cc-tg.lv-reviewing .cc-tg-dot{background:var(--cc-amber)}
+.cc-tg.lv-closed .cc-tg-dot{background:var(--cc-green)}
+.cc-tg-count{margin-left:auto;color:var(--cc-muted-2);font-weight:600;font-variant-numeric:tabular-nums}
+.cc-tg-item{display:flex;align-items:flex-start;gap:10px;padding:10px 20px;border-top:1px solid var(--cc-border-2)}
+.cc-tg-body{flex:1;min-width:0}
+.cc-tg-repo{font-size:.72rem;color:var(--cc-muted);font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.cc-tg-title{font-size:.86rem;color:var(--cc-text);margin:2px 0 0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.cc-tg-empty{padding:8px 20px 12px;font-size:.76rem;color:var(--cc-muted-2)}
+/* PR→issue badge (#2612 part c) — a small link chip on a queue/triage row telling
+   whether a fixing PR is open or merged. Reuses the status-pill palette so its
+   meaning matches the rest of the page (open = review-amber, merged = done-green). */
+.cc-pr-badge{flex-shrink:0;display:inline-flex;align-items:center;gap:4px;align-self:center;font-size:.68rem;font-weight:600;padding:2px 8px;border-radius:999px;text-decoration:none;border:1px solid transparent;white-space:nowrap}
+.cc-pr-badge.pr-open{background:rgba(210,153,34,.12);color:var(--cc-amber);border-color:rgba(210,153,34,.3)}
+.cc-pr-badge.pr-merged{background:rgba(63,185,80,.12);color:var(--cc-green);border-color:rgba(63,185,80,.3)}
+.cc-pr-badge:hover{filter:brightness(1.1);text-decoration:underline}
+/* Inline PR badge riding on a ready-queue row (smaller, sits after the title). */
+.cc-q-body .cc-pr-badge{margin-top:4px}
 /* ── (#2612 part d) Light-mode fixups for the handful of DARK one-off surfaces
    that are not part of the tokenized neutral ramp (small gradient washes and a
    couple of hover fills baked as literal dark hex). On a light appearance those
@@ -1827,6 +1874,21 @@ update();  // initial paint: copy block + branded UI in sync from first load
 </div>
 </div>
 </div>
+<!-- ── Triage ladder (#2612 part b) — a Warp-style lifecycle view over the hive's
+     contribute issues, grouped Triaging → Ready → Implementing → Reviewing →
+     Closed. Each level is DERIVED LIVE from the ready queue + fleet snapshot +
+     the PR→issue link (part c); there is no persistent per-issue lifecycle store
+     (a future enhancement, out of scope). A SECTION within Operations — NOT a new
+     page/tab. Fetched from /api/contribute/triage after load so a slow GitHub
+     PR-link lookup never delays the page. Full-width card below the ops grid. -->
+<div class="ops-card cc-triage-card" id="cc-triage-card" style="margin-top:20px">
+<div class="ops-card-head"><span class="feed-dot"></span><h3>Issue triage</h3><span class="ops-card-count count-strong" id="cc-triage-total"></span></div>
+<!-- Compact ladder summary: one chip per level with its live count. -->
+<div class="cc-triage-ladder" id="cc-triage-ladder"><div class="ops-empty">Loading triage&hellip;</div></div>
+<!-- Grouped per-level issue lists (each collapsible-ish section, capped). -->
+<div class="cc-triage-groups" id="cc-triage-groups"></div>
+<p class="ops-note" style="padding:10px 20px 14px;margin:0">A live lifecycle view of this hive&rsquo;s contribute issues &mdash; each issue is placed on the ladder from what the hive can observe right now (the ready queue, the fleet&rsquo;s in-flight work, and whether a fixing PR is open or merged). Read-only and recomputed on each load; there is no stored per-issue state.</p>
+</div>
 </div>
 <!-- Dedicated full-height LIVE ACTIVITY RAIL. Holds ONLY the live activity feed
      (moved here out of the former right column). Named "Live Activity" to match
@@ -1976,6 +2038,9 @@ function activateTab(t,push){
     // The dev-log rail collapse/persist wiring is independent too: a throw here must
     // not abort fleet hydration or the SSE feed.
     try{initOpsRail();}catch(e){console.error('initOpsRail failed',e);}
+    // Triage ladder (#2612 part b): fetched after the tab opens so a slow GitHub
+    // PR-link lookup never delays the page. A throw must not abort the panels above.
+    try{ccTriagePoll();}catch(e){console.error('ccTriagePoll failed',e);}
   }
   // Leaderboard hydrates client-side on first open — read-only, no role gate.
   // The personal "Me" card loads alongside the standings; a throw in one must
@@ -3377,9 +3442,13 @@ function ccRenderQueue(flip){
     var mineTag=mine?'<span class="cc-q-mine-tag" title="Matches one of your label interests">for you</span>':'';
     var heldCls=isHeld?' cc-q-held':'';
     var heldTag=isHeld?'<span class="cc-q-held-tag" title="On hold — parked by the operator; not offered until resumed">&#x23F8; on hold</span>':'';
+    // PR→issue badge (#2612 part c): if the triage poll resolved a fixing PR for
+    // this issue (open/merged), show a small link. Absent until ccTriagePoll runs,
+    // and simply omitted when no PR is linked — never blocks the queue render.
+    var prBadge=ccPRBadgeHTML((q.repo||'')+'#'+(q.number||''));
     return '<div class="cc-q-item'+mineCls+heldCls+'"'+(canDrag?' draggable="true"':'')+' data-qkey="'+esc(ccQueueKey(q))+'">'+grip+'<span class="cc-q-idx">'+(i+1)+'</span>'+
       '<div class="cc-q-body"><div class="cc-q-repo">'+ccIssueLinkHTML(q,(q.repo||'')+'#'+(q.number||''))+mineTag+heldTag+'</div>'+
-      '<div class="cc-q-title" title="'+esc(q.title||'')+'">'+esc(q.title||'(untitled)')+'</div>'+labels+'</div>'+next+menu+'</div>';
+      '<div class="cc-q-title" title="'+esc(q.title||'')+'">'+esc(q.title||'(untitled)')+'</div>'+labels+prBadge+'</div>'+next+menu+'</div>';
   }).join('');
   if(filtering&&shown===0){el.innerHTML='<div class="ops-empty">No queued items match &ldquo;'+esc(ccQueueSearch)+'&rdquo;.</div>';}
   ccUpdateFilterNote(shown,total);
@@ -3390,6 +3459,76 @@ function ccRenderQueue(flip){
   // End-of-queue block (#2595): the "all caught up" marker + hive settings + quota.
   // Only when the full list is shown (a filtered view isn't "the end of the queue").
   ccRenderQueueEnd(!filtering);
+}
+// ── Triage ladder (#2612 parts b + c) ─────────────────────────────────────────
+// ccPRLinks maps "repo#number" -> {number,url,state} for issues whose fixing PR the
+// triage endpoint resolved (open/merged). Populated by ccTriagePoll; consumed by
+// the queue-row badge and the triage groups. Empty until the first poll lands, so
+// the queue renders immediately without any PR data.
+var ccPRLinks={};
+// ccPRBadgeHTML returns the small "PR #NNN (open|merged)" link chip for an issue
+// key, or '' when no PR is linked. esc()-guarded; opens the PR on GitHub.
+function ccPRBadgeHTML(key){
+  var pr=ccPRLinks[key];
+  if(!pr||!pr.number)return '';
+  var cls=(pr.state==='merged')?'pr-merged':'pr-open';
+  var label='PR #'+pr.number+' ('+(pr.state==='merged'?'merged':'open')+')';
+  var href=pr.url||'';
+  return '<a class="cc-pr-badge '+cls+'" href="'+esc(href)+'" target="_blank" rel="noopener noreferrer" title="'+esc(label)+'">'+esc(label)+'</a>';
+}
+// CC_TRIAGE_LEVELS pins the ladder's render order + display labels client-side,
+// mirroring triageLevelOrder/triageLevelLabel on the server so the chips/groups
+// render in lifecycle order even if the JSON key order ever changed.
+var CC_TRIAGE_LEVELS=[['triaging','Triaging'],['ready','Ready to implement'],['implementing','Implementing'],['reviewing','Reviewing'],['closed','Closed']];
+// ccTriagePoll fetches the live triage snapshot and renders the ladder + groups,
+// then refreshes ccPRLinks and re-renders the queue so PR badges appear on queue
+// rows too. Best-effort: any failure leaves the "Loading…"/prior state and is
+// retried on the next tab open; it never throws into the ops bootstrap.
+function ccTriagePoll(){
+  fetch('/api/contribute/triage',{headers:{'Accept':'application/json'}})
+    .then(function(r){return r.ok?r.json():null;})
+    .then(function(d){if(d)ccRenderTriage(d);})
+    .catch(function(){/* degrade silently — the panel keeps its last state */});
+}
+// ccRenderTriage paints the ladder summary chips + the per-level issue groups, and
+// harvests the PR links into ccPRLinks so the queue rows can show badges.
+function ccRenderTriage(snap){
+  var groups=(snap&&snap.groups)||[];
+  // Index groups by level for ordered lookup.
+  var byLevel={};for(var i=0;i<groups.length;i++){byLevel[groups[i].level]=groups[i];}
+  // Total count badge.
+  var totEl=document.getElementById('cc-triage-total');
+  if(totEl)totEl.textContent=(snap&&snap.total!=null?snap.total:0)+' issues';
+  // Ladder chips.
+  var ladder=document.getElementById('cc-triage-ladder');
+  if(ladder){
+    ladder.innerHTML=CC_TRIAGE_LEVELS.map(function(lv){
+      var g=byLevel[lv[0]]||{count:0};
+      return '<span class="cc-triage-chip lv-'+lv[0]+'"><span class="cc-tl-dot"></span><span class="cc-tl-n">'+(g.count||0)+'</span><span class="cc-tl-lbl">'+esc(lv[1])+'</span></span>';
+    }).join('');
+  }
+  // Per-level groups with their issue lists.
+  var wrap=document.getElementById('cc-triage-groups');
+  if(wrap){
+    ccPRLinks={};
+    wrap.innerHTML=CC_TRIAGE_LEVELS.map(function(lv){
+      var g=byLevel[lv[0]]||{count:0,issues:[]};
+      var issues=g.issues||[];
+      var rows=issues.map(function(it){
+        var key=(it.repo||'')+'#'+(it.number||'');
+        if(it.pr&&it.pr.number){ccPRLinks[key]=it.pr;}
+        var repoLbl=esc((it.repo||'')+'#'+(it.number||''));
+        var link=it.url?('<a class="cc-issue-link" href="'+esc(it.url)+'" target="_blank" rel="noopener noreferrer">'+repoLbl+'</a>'):repoLbl;
+        var badge=(it.pr&&it.pr.number)?ccPRBadgeHTML(key):'';
+        return '<div class="cc-tg-item"><div class="cc-tg-body"><div class="cc-tg-repo">'+link+'</div><div class="cc-tg-title" title="'+esc(it.title||'')+'">'+esc(it.title||'(untitled)')+'</div></div>'+badge+'</div>';
+      }).join('');
+      var body=issues.length?rows:'<div class="cc-tg-empty">None right now.</div>';
+      return '<div class="cc-tg lv-'+lv[0]+'"><div class="cc-tg-head"><span class="cc-tg-dot"></span>'+esc(lv[1])+'<span class="cc-tg-count">'+(g.count||0)+'</span></div>'+body+'</div>';
+    }).join('');
+  }
+  // Now that ccPRLinks is populated, re-render the queue so its rows pick up the
+  // PR badges too (the queue endpoint intentionally does not resolve PR links).
+  try{if(typeof ccRenderQueue==='function')ccRenderQueue();}catch(e){}
 }
 // ccQueueMenuHTML renders the per-row ⋯ menu markup (owner/read-write only). pos is
 // the row's ZERO-based position in the full queue; total is the queue length. The

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -501,65 +501,130 @@ func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request)
 	fmt.Fprintf(w, `<!DOCTYPE html>
 <html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Contribute to %s</title>
 <style>
+/* ── Theme tokens (#2612 part d) ─────────────────────────────────────────────
+   The /contribute page shipped with a hardcoded GitHub-dark palette and zero
+   light-mode infrastructure. These custom properties name the palette once so
+   the whole sheet can flip to a light appearance without touching any rule. The
+   :root defaults below are the ORIGINAL dark hex values byte-for-byte, so the
+   dark appearance is unchanged; only the neutral surface/border/text ramp is
+   tokenized (accents like blue/green/amber/red read fine on both themes and are
+   pinned by exact-match tests, so they stay literal and are exposed here only as
+   named tokens for the light-mode fixups below).
+   Light mode activates on BOTH signals — the OS preference AND an explicit
+   :root[data-theme="light"] hook — so a future in-page toggle can force it
+   (the toggle itself is out of scope). data-theme="dark" always wins back to
+   dark even under a light OS preference. Values are Primer-light neutrals so the
+   surface blends with the surrounding Docusaurus docs chrome. */
+:root{
+  --cc-bg:#0d1117;
+  --cc-bg-deep:#010409;
+  --cc-surface:#161b22;
+  --cc-border:#30363d;
+  --cc-border-2:#21262d;
+  --cc-text:#e6edf3;
+  --cc-text-2:#c9d1d9;
+  --cc-muted:#8b949e;
+  --cc-muted-2:#6e7681;
+  --cc-code-bg:#0d1117;
+  --cc-accent:#58a6ff;
+  --cc-accent-fg:#1f6feb;
+  --cc-green:#3fb950;
+  --cc-amber:#d29922;
+  --cc-red:#f85149;
+}
+@media(prefers-color-scheme:light){:root:not([data-theme="dark"]){
+  --cc-bg:#ffffff;
+  --cc-bg-deep:#f6f8fa;
+  --cc-surface:#f6f8fa;
+  --cc-border:#d0d7de;
+  --cc-border-2:#eaeef2;
+  --cc-text:#1f2328;
+  --cc-text-2:#32383f;
+  --cc-muted:#636c76;
+  --cc-muted-2:#7d858e;
+  --cc-code-bg:#eff1f3;
+  --cc-accent:#0969da;
+  --cc-accent-fg:#0969da;
+  --cc-green:#1a7f37;
+  --cc-amber:#9a6700;
+  --cc-red:#cf222e;
+}}
+:root[data-theme="light"]{
+  --cc-bg:#ffffff;
+  --cc-bg-deep:#f6f8fa;
+  --cc-surface:#f6f8fa;
+  --cc-border:#d0d7de;
+  --cc-border-2:#eaeef2;
+  --cc-text:#1f2328;
+  --cc-text-2:#32383f;
+  --cc-muted:#636c76;
+  --cc-muted-2:#7d858e;
+  --cc-code-bg:#eff1f3;
+  --cc-accent:#0969da;
+  --cc-accent-fg:#0969da;
+  --cc-green:#1a7f37;
+  --cc-amber:#9a6700;
+  --cc-red:#cf222e;
+}
 *{margin:0;padding:0;box-sizing:border-box}
-body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#0d1117;color:#e6edf3;margin:0;min-height:100vh}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:var(--cc-bg);color:var(--cc-text);margin:0;min-height:100vh}
 .page{display:flex;min-height:100vh;width:100%%}
 .main{flex:3;padding:40px 48px;overflow-y:auto}
-.sidebar{flex:1;background:#161b22;border-left:1px solid #30363d;display:flex;flex-direction:column;position:sticky;top:0;height:100vh;overflow-y:auto}
+.sidebar{flex:1;background:var(--cc-surface);border-left:1px solid var(--cc-border);display:flex;flex-direction:column;position:sticky;top:0;height:100vh;overflow-y:auto}
 h1{font-size:2rem;margin-bottom:8px}
-.subtitle{color:#8b949e;font-size:1.1rem;margin-bottom:32px}
+.subtitle{color:var(--cc-muted);font-size:1.1rem;margin-bottom:32px}
 .stat-row{display:grid;grid-template-columns:repeat(auto-fit,minmax(80px,1fr));gap:10px;margin-bottom:24px}
-.stat{background:#161b22;border:1px solid #30363d;border-radius:10px;padding:14px 8px;text-align:center}
+.stat{background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:10px;padding:14px 8px;text-align:center}
 .stat-num{font-size:1.5rem;font-weight:700;color:#58a6ff}
-.stat-label{font-size:.7rem;color:#8b949e;margin-top:4px}
-.steps{background:#161b22;border:1px solid #30363d;border-radius:12px;padding:24px;margin-top:24px}
+.stat-label{font-size:.7rem;color:var(--cc-muted);margin-top:4px}
+.steps{background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:12px;padding:24px;margin-top:24px}
 .steps h3{margin-top:0;color:#58a6ff}
 .steps ol{padding-left:20px;line-height:2}
-code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
+code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 .how{margin-top:32px}
-.how h3{color:#e6edf3}
-.how p{color:#8b949e;line-height:1.6}
+.how h3{color:var(--cc-text)}
+.how p{color:var(--cc-muted);line-height:1.6}
 .tier-table{width:100%%;border-collapse:collapse;margin-top:16px}
-.tier-table th,.tier-table td{padding:8px 12px;text-align:left;border-bottom:1px solid #30363d;font-size:.85rem}
-.tier-table th{color:#8b949e;font-weight:600}
-.feed-header{padding:20px 20px 12px;border-bottom:1px solid #30363d;display:flex;align-items:center;gap:8px}
-.feed-header h3{font-size:.95rem;color:#e6edf3}
+.tier-table th,.tier-table td{padding:8px 12px;text-align:left;border-bottom:1px solid var(--cc-border);font-size:.85rem}
+.tier-table th{color:var(--cc-muted);font-weight:600}
+.feed-header{padding:20px 20px 12px;border-bottom:1px solid var(--cc-border);display:flex;align-items:center;gap:8px}
+.feed-header h3{font-size:.95rem;color:var(--cc-text)}
 .feed-dot{width:8px;height:8px;border-radius:50%%;background:#3fb950;animation:pulse 2s infinite}
 @keyframes pulse{0%%,100%%{opacity:1}50%%{opacity:.4}}
-.feed-count{font-size:.75rem;color:#8b949e;margin-left:auto}
+.feed-count{font-size:.75rem;color:var(--cc-muted);margin-left:auto}
 .feed-scroll{flex:1;overflow-y:auto;padding:0}
-.feed-entry{padding:10px 20px;border-bottom:1px solid #21262d;font-size:.85rem;animation:fadeIn .3s ease;display:flex;align-items:flex-start;gap:12px}
+.feed-entry{padding:10px 20px;border-bottom:1px solid var(--cc-border-2);font-size:.85rem;animation:fadeIn .3s ease;display:flex;align-items:flex-start;gap:12px}
 @keyframes fadeIn{from{opacity:0;transform:translateY(-4px)}to{opacity:1;transform:translateY(0)}}
 .feed-entry:hover{background:rgba(88,166,255,.04)}
 .feed-text{flex:1;min-width:0}
-.feed-time{color:#8b949e;font-size:.75rem;white-space:nowrap;flex-shrink:0}
+.feed-time{color:var(--cc-muted);font-size:.75rem;white-space:nowrap;flex-shrink:0}
 .feed-role{color:#58a6ff;font-weight:500}
-.feed-cli{color:#8b949e;font-size:.8rem}
-.feed-empty{padding:40px 20px;text-align:center;color:#8b949e;font-size:.85rem}
-@media(max-width:768px){.page{flex-direction:column}.sidebar{border-left:none;border-top:1px solid #30363d;max-width:none;max-height:300px}}
+.feed-cli{color:var(--cc-muted);font-size:.8rem}
+.feed-empty{padding:40px 20px;text-align:center;color:var(--cc-muted);font-size:.85rem}
+@media(max-width:768px){.page{flex-direction:column}.sidebar{border-left:none;border-top:1px solid var(--cc-border);max-width:none;max-height:300px}}
 /* Management & Operations tab chrome — additive, does not touch onboarding content */
-.page-tabs{display:flex;gap:2px;background:#161b22;border-bottom:1px solid #30363d;padding:0 48px}
-.page-tab{background:none;border:none;color:#8b949e;font-size:.95rem;font-weight:500;padding:14px 20px;cursor:pointer;border-bottom:2px solid transparent;font-family:inherit}
-.page-tab:hover{color:#e6edf3}
-.page-tab.active{color:#e6edf3;border-bottom-color:#58a6ff}
+.page-tabs{display:flex;gap:2px;background:var(--cc-surface);border-bottom:1px solid var(--cc-border);padding:0 48px}
+.page-tab{background:none;border:none;color:var(--cc-muted);font-size:.95rem;font-weight:500;padding:14px 20px;cursor:pointer;border-bottom:2px solid transparent;font-family:inherit}
+.page-tab:hover{color:var(--cc-text)}
+.page-tab.active{color:var(--cc-text);border-bottom-color:#58a6ff}
 .tab-panel{display:none}
 .tab-panel.active{display:block}
 .ops{padding:40px 48px;overflow-y:auto}
 .ops h1{font-size:1.7rem;margin-bottom:6px}
 .ops-grid{display:grid;grid-template-columns:340px 1fr;gap:20px;margin-top:24px}
 @media(max-width:900px){.ops-grid{grid-template-columns:1fr}}
-.ops-card{background:#161b22;border:1px solid #30363d;border-radius:12px;padding:0;overflow:hidden}
-.ops-card-head{padding:16px 20px;border-bottom:1px solid #30363d;display:flex;align-items:center;gap:10px}
-.ops-card-head h3{font-size:.95rem;color:#e6edf3;margin:0}
-.ops-card-count{font-size:.75rem;color:#8b949e;margin-left:auto}
-.ops-filters{display:flex;gap:4px;padding:12px 20px;border-bottom:1px solid #21262d;flex-wrap:wrap}
-.ops-filter{background:#0d1117;border:1px solid #30363d;color:#8b949e;font-size:.78rem;padding:4px 12px;border-radius:999px;cursor:pointer;font-family:inherit}
+.ops-card{background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:12px;padding:0;overflow:hidden}
+.ops-card-head{padding:16px 20px;border-bottom:1px solid var(--cc-border);display:flex;align-items:center;gap:10px}
+.ops-card-head h3{font-size:.95rem;color:var(--cc-text);margin:0}
+.ops-card-count{font-size:.75rem;color:var(--cc-muted);margin-left:auto}
+.ops-filters{display:flex;gap:4px;padding:12px 20px;border-bottom:1px solid var(--cc-border-2);flex-wrap:wrap}
+.ops-filter{background:var(--cc-bg);border:1px solid var(--cc-border);color:var(--cc-muted);font-size:.78rem;padding:4px 12px;border-radius:999px;cursor:pointer;font-family:inherit}
 .ops-filter.active{background:#1f6feb;border-color:#1f6feb;color:#fff}
 .work-list{max-height:520px;overflow-y:auto}
-.work-item{padding:14px 20px;border-bottom:1px solid #21262d;cursor:pointer}
+.work-item{padding:14px 20px;border-bottom:1px solid var(--cc-border-2);cursor:pointer}
 .work-item:hover{background:rgba(88,166,255,.04)}
 .work-item.selected{background:rgba(88,166,255,.08)}
-.work-repo{font-size:.75rem;color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.work-repo{font-size:.75rem;color:var(--cc-muted);font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
 /* ── Clickable GitHub issue/PR references (#2616) ────────────────────────────────
    Shared affordance for every repo#number reference on the Operations tab (ready
    queue, my-work, opportunistic-work, dev-log). Deliberately more visible than
@@ -572,14 +637,14 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .cc-issue-link:focus-visible{outline:2px solid #58a6ff;outline-offset:2px}
 .cc-issue-link-ic{flex-shrink:0;opacity:.85}
 .cc-issue-link:hover .cc-issue-link-ic{opacity:1}
-.work-title{font-size:.9rem;color:#e6edf3;margin:2px 0 6px}
-.work-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-size:.75rem;color:#8b949e}
+.work-title{font-size:.9rem;color:var(--cc-text);margin:2px 0 6px}
+.work-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-size:.75rem;color:var(--cc-muted)}
 .pill{display:inline-block;padding:2px 8px;border-radius:999px;font-size:.7rem;font-weight:600;border:1px solid transparent}
 .pill-progress{background:rgba(88,166,255,.12);color:#58a6ff;border-color:rgba(88,166,255,.3)}
 .pill-review{background:rgba(210,153,34,.12);color:#d29922;border-color:rgba(210,153,34,.3)}
 .pill-passed{background:rgba(63,185,80,.12);color:#3fb950;border-color:rgba(63,185,80,.3)}
 .pill-blocked{background:rgba(248,81,73,.12);color:#f85149;border-color:rgba(248,81,73,.3)}
-.pill-idle{background:rgba(139,148,158,.12);color:#8b949e;border-color:rgba(139,148,158,.3)}
+.pill-idle{background:rgba(139,148,158,.12);color:var(--cc-muted);border-color:rgba(139,148,158,.3)}
 /* #2574 (follow-up): the Connected-clankers card is a NARROW column. The old
    layout put the multi-line identity text (.clanker-main) and the inline
    controls (.admin-actions: tier dropdown + Revoke + Remove) in the SAME
@@ -592,44 +657,44 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
    horizontally with the multi-line text. Long repo paths in .clanker-sub wrap
    (overflow-wrap:anywhere) rather than pushing into anything. align-items:start
    keeps the dot/avatar top-aligned with the first text line. */
-.clanker-row{display:grid;grid-template-columns:auto auto minmax(0,1fr);align-items:start;column-gap:10px;row-gap:8px;padding:12px 20px;border-bottom:1px solid #21262d}
+.clanker-row{display:grid;grid-template-columns:auto auto minmax(0,1fr);align-items:start;column-gap:10px;row-gap:8px;padding:12px 20px;border-bottom:1px solid var(--cc-border-2)}
 /* The trailing controls / timestamp: full-width line beneath the identity. It is
    always the LAST grid child, so grid-column:1/-1 drops it below regardless of
    whether it's .admin-actions or the .feed-time fallback. */
 .clanker-row>.admin-actions,.clanker-row>.feed-time{grid-column:1/-1}
-.clanker-av{width:28px;height:28px;border-radius:50%%;flex-shrink:0;background:#30363d}
+.clanker-av{width:28px;height:28px;border-radius:50%%;flex-shrink:0;background:var(--cc-border)}
 .clanker-main{min-width:0}
-.clanker-user{font-size:.88rem;color:#e6edf3;font-weight:500}
-.clanker-sub{font-size:.74rem;color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;overflow-wrap:anywhere;word-break:break-word}
+.clanker-user{font-size:.88rem;color:var(--cc-text);font-weight:500}
+.clanker-sub{font-size:.74rem;color:var(--cc-muted);font-family:ui-monospace,SFMono-Regular,Menlo,monospace;overflow-wrap:anywhere;word-break:break-word}
 /* Row is align-items:start (grid), so nudge the small dot down to sit level with
    the username's first line instead of the very top of the row. */
 .clanker-dot{width:8px;height:8px;border-radius:50%%;background:#3fb950;flex-shrink:0;margin-top:7px}
-.clanker-dot.stale{background:#8b949e}
+.clanker-dot.stale{background:var(--cc-muted)}
 .pipeline{display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin:14px 0}
-.pipe-node{background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:8px 14px;font-size:.82rem;color:#e6edf3}
+.pipe-node{background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:8px;padding:8px 14px;font-size:.82rem;color:var(--cc-text)}
 .pipe-node .lgtm{color:#3fb950;font-size:.72rem}
-.pipe-arrow{color:#8b949e}
-.policy-row{display:flex;justify-content:space-between;gap:12px;padding:8px 0;border-bottom:1px solid #21262d;font-size:.85rem}
+.pipe-arrow{color:var(--cc-muted)}
+.policy-row{display:flex;justify-content:space-between;gap:12px;padding:8px 0;border-bottom:1px solid var(--cc-border-2);font-size:.85rem}
 .policy-row:last-child{border-bottom:none}
-.policy-key{color:#8b949e}
-.policy-val{color:#e6edf3;text-align:right;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;word-break:break-word}
-.ops-empty{padding:32px 20px;text-align:center;color:#8b949e;font-size:.85rem}
-.lb-row{display:grid;grid-template-columns:56px 1fr 120px 70px 70px 80px 72px;align-items:center;gap:8px;padding:10px 20px;border-bottom:1px solid #21262d;font-size:.85rem}
+.policy-key{color:var(--cc-muted)}
+.policy-val{color:var(--cc-text);text-align:right;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;word-break:break-word}
+.ops-empty{padding:32px 20px;text-align:center;color:var(--cc-muted);font-size:.85rem}
+.lb-row{display:grid;grid-template-columns:56px 1fr 120px 70px 70px 80px 72px;align-items:center;gap:8px;padding:10px 20px;border-bottom:1px solid var(--cc-border-2);font-size:.85rem}
 .lb-row:last-child{border-bottom:none}
 /* Subtle self-highlight for the logged-in viewer's own row: a faint tint + a left
    accent border, professional not loud. Readability preserved. */
 .lb-row--me{background:rgba(31,111,235,.09);box-shadow:inset 3px 0 0 0 #1f6feb}
 .lb-you{display:inline-block;margin-left:8px;font-size:.62rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#58a6ff;background:rgba(31,111,235,.14);border:1px solid rgba(31,111,235,.3);border-radius:999px;padding:1px 7px;vertical-align:middle}
-.lb-head{color:#8b949e;font-weight:600;font-size:.72rem;text-transform:uppercase;letter-spacing:.04em;background:#0d1117}
-.lb-rank{color:#8b949e;font-variant-numeric:tabular-nums}
-.lb-name{color:#e6edf3;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.lb-tier{color:#8b949e}
-.lb-stat{text-align:right;color:#c9d1d9;font-variant-numeric:tabular-nums}
-.lb-head .lb-stat,.lb-head .lb-rank{text-align:right;color:#8b949e}
+.lb-head{color:var(--cc-muted);font-weight:600;font-size:.72rem;text-transform:uppercase;letter-spacing:.04em;background:var(--cc-bg)}
+.lb-rank{color:var(--cc-muted);font-variant-numeric:tabular-nums}
+.lb-name{color:var(--cc-text);font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.lb-tier{color:var(--cc-muted)}
+.lb-stat{text-align:right;color:var(--cc-text-2);font-variant-numeric:tabular-nums}
+.lb-head .lb-stat,.lb-head .lb-rank{text-align:right;color:var(--cc-muted)}
 .lb-head .lb-rank{text-align:left}
 /* ── Subtle "ranked/alive" accent pass on Operations + Leaderboard (SUBTLE +
    PROFESSIONAL — light watermarking only). Theme-aware: built entirely from the
-   existing dark palette (#161b22 card / #30363d border / #0d1117 deep). Every
+   existing dark palette (var(--cc-surface) card / var(--cc-border) border / var(--cc-bg) deep). Every
    accent is driven by REAL data (trust tier + real task counts); nothing is
    fabricated. Readability first — text keeps full contrast; the tints are muted,
    never neon. All motion respects the prefers-reduced-motion block below. ───── */
@@ -640,27 +705,27 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
    tier-badge family; the Me-card below reuses it rather than hand-rolling its own
    tier-color helper, so leaderboard rows, ops cards, and the Me-card read as one
    ranked family. */
-.tier-badge{display:inline-flex;align-items:center;gap:5px;font-size:.68rem;font-weight:600;line-height:1;padding:3px 8px 3px 6px;border-radius:999px;border:1px solid #30363d;background:#0d1117;color:#8b949e;text-transform:capitalize;white-space:nowrap}
+.tier-badge{display:inline-flex;align-items:center;gap:5px;font-size:.68rem;font-weight:600;line-height:1;padding:3px 8px 3px 6px;border-radius:999px;border:1px solid var(--cc-border);background:var(--cc-bg);color:var(--cc-muted);text-transform:capitalize;white-space:nowrap}
 .tier-badge::before{content:"";width:8px;height:8px;border-radius:50%%;background:currentColor;box-shadow:inset 0 0 0 1px rgba(1,4,9,.35);flex:none}
 .tier-badge.tier-advisor{border-color:rgba(210,169,85,.45);background:rgba(210,169,85,.10);color:#d0a955}
 .tier-badge.tier-trusted{border-color:rgba(201,162,39,.40);background:rgba(201,162,39,.08);color:#c9a94a}
 .tier-badge.tier-contributor{border-color:rgba(110,163,201,.38);background:rgba(110,163,201,.08);color:#6ea3c9}
-.tier-badge.tier-newcomer{border-color:#30363d;background:#0d1117;color:#8b949e}
+.tier-badge.tier-newcomer{border-color:var(--cc-border);background:var(--cc-bg);color:var(--cc-muted)}
 /* Restrained gradient header band on the accented cards. Very low-contrast wash
    from the deep bg into the card colour — reads as a faint banner, not a loud
    gradient; the bottom border keeps the head crisp. */
-.ops-card.card-accent>.ops-card-head{background:linear-gradient(180deg,#12161d 0%%,#161b22 100%%)}
+.ops-card.card-accent>.ops-card-head{background:linear-gradient(180deg,#12161d 0%%,var(--cc-surface) 100%%)}
 .ops-card.card-accent>.ops-card-head h3{letter-spacing:.01em}
 /* Bold-numeral stat emphasis: the primary "Done" numeral on the leaderboard and
    the key ops counts get heavier weight + slightly larger tabular figures so the
    number reads as the hero of the row without adding chrome. The Me-card's own
    stat numerals reuse this same bold/tabular treatment via .lb-stat.lb-primary. */
-.lb-row .lb-stat.lb-primary{color:#e6edf3;font-weight:700;font-size:.95rem}
-.lb-head .lb-stat.lb-primary{font-weight:600;font-size:.72rem;color:#8b949e}
+.lb-row .lb-stat.lb-primary{color:var(--cc-text);font-weight:700;font-size:.95rem}
+.lb-head .lb-stat.lb-primary{font-weight:600;font-size:.72rem;color:var(--cc-muted)}
 .tier-badge.tier-lb{padding:2px 8px 2px 5px;font-size:.66rem}
 /* Ops "your army" counts + card counts as bold numerals (tabular, no layout shift). */
 .cc-army b{font-weight:700;font-variant-numeric:tabular-nums}
-.ops-card-count.count-strong{color:#e6edf3;font-weight:700;font-variant-numeric:tabular-nums}
+.ops-card-count.count-strong{color:var(--cc-text);font-weight:700;font-variant-numeric:tabular-nums}
 /* Compact tier badge inline next to a connected clanker's identity. */
 .tier-badge.tier-inline{padding:1px 6px 1px 4px;font-size:.62rem;margin-left:6px;vertical-align:middle}
 .tier-badge.tier-inline::before{width:6px;height:6px}
@@ -678,50 +743,50 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
    (.me-card--style1..7) are palette/framing/density variations over the SAME
    real data. Subtle and professional, reduced-motion safe. --me-accent drives
    the per-tier accent wash (medallion ring, chips, stat numerals). */
-.me-card{position:relative;background:#161b22;border:1px solid #30363d;border-radius:14px;overflow:hidden;margin-bottom:20px;--me-accent:#58a6ff;--me-accent-soft:rgba(88,166,255,.14)}
-.me-card__band{position:relative;padding:20px 22px 18px;background:linear-gradient(135deg,var(--me-accent-soft),rgba(22,27,34,0) 70%%);border-bottom:1px solid #21262d}
+.me-card{position:relative;background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:14px;overflow:hidden;margin-bottom:20px;--me-accent:#58a6ff;--me-accent-soft:rgba(88,166,255,.14)}
+.me-card__band{position:relative;padding:20px 22px 18px;background:linear-gradient(135deg,var(--me-accent-soft),rgba(22,27,34,0) 70%%);border-bottom:1px solid var(--cc-border-2)}
 .me-card__toprow{display:flex;align-items:center;gap:16px}
-.me-medallion{position:relative;width:64px;height:64px;flex-shrink:0;border-radius:50%%;display:flex;align-items:center;justify-content:center;background:radial-gradient(circle at 50%% 35%%,var(--me-accent-soft),#0d1117 78%%);border:2px solid var(--me-accent);box-shadow:0 0 0 4px rgba(1,4,9,.35)}
-.me-medallion img{width:52px;height:52px;border-radius:50%%;object-fit:cover;background:#30363d}
+.me-medallion{position:relative;width:64px;height:64px;flex-shrink:0;border-radius:50%%;display:flex;align-items:center;justify-content:center;background:radial-gradient(circle at 50%% 35%%,var(--me-accent-soft),var(--cc-bg) 78%%);border:2px solid var(--me-accent);box-shadow:0 0 0 4px rgba(1,4,9,.35)}
+.me-medallion img{width:52px;height:52px;border-radius:50%%;object-fit:cover;background:var(--cc-border)}
 /* #2595 fix: the tier badge now lives in its OWN layout slot beside the name
    (.me-id__tier), NOT absolutely positioned over the avatar — so the "Contributor"
    / "Trusted" / "Newcomer" pill can never overlap the avatar image. */
 .me-id__tier{margin:4px 0 2px}
 .me-id__tier .tier-badge{position:static;transform:none}
 .me-id{min-width:0;flex:1}
-.me-id__name{font-size:1.25rem;font-weight:700;color:#e6edf3;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.me-id__lead{font-size:.85rem;color:#8b949e;margin-top:2px}
+.me-id__name{font-size:1.25rem;font-weight:700;color:var(--cc-text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.me-id__lead{font-size:.85rem;color:var(--cc-muted);margin-top:2px}
 .me-id__lead b{color:var(--me-accent)}
-.me-rankpill{margin-left:auto;flex-shrink:0;text-align:center;background:#0d1117;border:1px solid #30363d;border-radius:12px;padding:8px 14px}
-.me-rankpill__num{font-size:1.25rem;font-weight:800;color:#e6edf3;font-variant-numeric:tabular-nums;line-height:1}
-.me-rankpill__lbl{font-size:.62rem;color:#8b949e;text-transform:uppercase;letter-spacing:.05em;margin-top:3px}
+.me-rankpill{margin-left:auto;flex-shrink:0;text-align:center;background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:12px;padding:8px 14px}
+.me-rankpill__num{font-size:1.25rem;font-weight:800;color:var(--cc-text);font-variant-numeric:tabular-nums;line-height:1}
+.me-rankpill__lbl{font-size:.62rem;color:var(--cc-muted);text-transform:uppercase;letter-spacing:.05em;margin-top:3px}
 .me-card__body{padding:18px 22px 20px}
 .me-statgrid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px}
-.me-stat{background:#0d1117;border:1px solid #30363d;border-radius:10px;padding:12px 8px;text-align:center}
+.me-stat{background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:10px;padding:12px 8px;text-align:center}
 /* Stat numeral reuses the canonical bold/tabular "hero numeral" treatment
    (same weight/tabular-nums as .lb-stat.lb-primary), tinted by --me-accent. */
 .me-stat .lb-stat.lb-primary{display:block;font-size:1.6rem;color:var(--me-accent);padding:0}
-.me-stat__lbl{font-size:.66rem;color:#8b949e;text-transform:uppercase;letter-spacing:.04em;margin-top:5px}
+.me-stat__lbl{font-size:.66rem;color:var(--cc-muted);text-transform:uppercase;letter-spacing:.04em;margin-top:5px}
 .me-sec{margin-top:18px}
-.me-sec__title{font-size:.72rem;color:#8b949e;text-transform:uppercase;letter-spacing:.05em;font-weight:600;margin-bottom:9px;display:flex;align-items:center;gap:8px}
-.me-sec__title .me-soon{font-size:.6rem;font-weight:600;color:#8b949e;border:1px solid #30363d;border-radius:999px;padding:1px 7px;text-transform:none;letter-spacing:0}
+.me-sec__title{font-size:.72rem;color:var(--cc-muted);text-transform:uppercase;letter-spacing:.05em;font-weight:600;margin-bottom:9px;display:flex;align-items:center;gap:8px}
+.me-sec__title .me-soon{font-size:.6rem;font-weight:600;color:var(--cc-muted);border:1px solid var(--cc-border);border-radius:999px;padding:1px 7px;text-transform:none;letter-spacing:0}
 .me-chips{display:flex;flex-wrap:wrap;gap:7px}
-.me-chip{display:inline-flex;align-items:center;gap:5px;padding:4px 10px;border-radius:999px;font-size:.74rem;font-weight:600;border:1px solid transparent;background:#0d1117;color:#8b949e;border-color:#30363d}
+.me-chip{display:inline-flex;align-items:center;gap:5px;padding:4px 10px;border-radius:999px;font-size:.74rem;font-weight:600;border:1px solid transparent;background:var(--cc-bg);color:var(--cc-muted);border-color:var(--cc-border)}
 .me-chip--got{background:var(--me-accent-soft);color:var(--me-accent);border-color:var(--me-accent)}
-.me-chip--next{background:#0d1117;color:#c9d1d9;border-color:#30363d;border-style:dashed}
-.me-chip--badge{background:#0d1117;color:#8b949e;border-color:#30363d;border-style:dashed;opacity:.85}
+.me-chip--next{background:var(--cc-bg);color:var(--cc-text-2);border-color:var(--cc-border);border-style:dashed}
+.me-chip--badge{background:var(--cc-bg);color:var(--cc-muted);border-color:var(--cc-border);border-style:dashed;opacity:.85}
 .me-hives{display:flex;flex-direction:column;gap:6px}
-.me-hive{display:flex;align-items:center;gap:8px;font-size:.82rem;color:#c9d1d9}
+.me-hive{display:flex;align-items:center;gap:8px;font-size:.82rem;color:var(--cc-text-2)}
 .me-hive__rel{font-size:.66rem;font-weight:700;text-transform:uppercase;letter-spacing:.03em;padding:2px 7px;border-radius:6px;background:var(--me-accent-soft);color:var(--me-accent)}
 .me-hive__rel--owner{background:rgba(210,153,34,.16);color:#d29922}
 .me-actions{display:flex;flex-wrap:wrap;gap:10px;margin-top:18px;align-items:center}
-.me-share{display:inline-flex;align-items:center;gap:7px;padding:9px 16px;border-radius:10px;font-size:.85rem;font-weight:600;text-decoration:none;background:var(--me-accent);color:#0d1117;border:1px solid var(--me-accent);cursor:pointer;font-family:inherit}
+.me-share{display:inline-flex;align-items:center;gap:7px;padding:9px 16px;border-radius:10px;font-size:.85rem;font-weight:600;text-decoration:none;background:var(--me-accent);color:var(--cc-bg);border:1px solid var(--me-accent);cursor:pointer;font-family:inherit}
 .me-share:hover{filter:brightness(1.08)}
 .me-share--ghost{background:transparent;color:var(--me-accent)}
-.me-stylepick{margin-left:auto;display:flex;align-items:center;gap:7px;font-size:.72rem;color:#8b949e}
-.me-stylepick select{background:#0d1117;border:1px solid #30363d;color:#c9d1d9;border-radius:8px;padding:5px 8px;font-size:.78rem;font-family:inherit;cursor:pointer}
-.me-signin{background:#161b22;border:1px dashed #30363d;border-radius:14px;padding:22px;text-align:center;color:#8b949e;font-size:.9rem;margin-bottom:20px}
-.me-signin b{color:#e6edf3}
+.me-stylepick{margin-left:auto;display:flex;align-items:center;gap:7px;font-size:.72rem;color:var(--cc-muted)}
+.me-stylepick select{background:var(--cc-bg);border:1px solid var(--cc-border);color:var(--cc-text-2);border-radius:8px;padding:5px 8px;font-size:.78rem;font-family:inherit;cursor:pointer}
+.me-signin{background:var(--cc-surface);border:1px dashed var(--cc-border);border-radius:14px;padding:22px;text-align:center;color:var(--cc-muted);font-size:.9rem;margin-bottom:20px}
+.me-signin b{color:var(--cc-text)}
 /* ── The 7 profile-style skins (palette / framing / density variations) ────────
    Each is a tasteful, readable, professional variant of the SAME card. They only
    change accent palette, header treatment, medallion framing, and density —
@@ -729,9 +794,9 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .me-card--style2{--me-accent:#3fb950;--me-accent-soft:rgba(63,185,80,.14)}
 .me-card--style3{--me-accent:#d29922;--me-accent-soft:rgba(210,153,34,.15)}
 .me-card--style4{--me-accent:#a371f7;--me-accent-soft:rgba(163,113,247,.15)}
-.me-card--style5{--me-accent:#8b949e;--me-accent-soft:rgba(139,148,158,.12)}     /* minimal / restrained */
-.me-card--style5 .me-card__band{background:#161b22}
-.me-card--style5 .me-medallion{background:#0d1117}
+.me-card--style5{--me-accent:var(--cc-muted);--me-accent-soft:rgba(139,148,158,.12)}     /* minimal / restrained */
+.me-card--style5 .me-card__band{background:var(--cc-surface)}
+.me-card--style5 .me-medallion{background:var(--cc-bg)}
 .me-card--style6{--me-accent:#f778ba;--me-accent-soft:rgba(247,120,186,.14)}
 .me-card--style6 .me-card__band{background:linear-gradient(135deg,var(--me-accent-soft),rgba(22,27,34,0))}
 .me-card--style7{--me-accent:#58a6ff;--me-accent-soft:rgba(88,166,255,.18)}     /* roomy "ranked" */
@@ -741,15 +806,15 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .me-card--style7 .me-medallion img{width:60px;height:60px}
 @media(max-width:520px){.me-card__toprow{flex-wrap:wrap}.me-rankpill{margin-left:0}.me-statgrid{grid-template-columns:1fr}}
 @media(prefers-reduced-motion:reduce){.me-card *{transition:none!important;animation:none!important}}
-.ops-note{color:#6e7681;font-size:.78rem;margin-top:12px;line-height:1.5}
-.ops-note code{background:#0d1117;padding:1px 6px;border-radius:4px}
-.prompt-preview{margin-top:10px;border-top:1px solid #21262d;padding-top:8px}
+.ops-note{color:var(--cc-muted-2);font-size:.78rem;margin-top:12px;line-height:1.5}
+.ops-note code{background:var(--cc-bg);padding:1px 6px;border-radius:4px}
+.prompt-preview{margin-top:10px;border-top:1px solid var(--cc-border-2);padding-top:8px}
 .prompt-preview summary{cursor:pointer;color:#58a6ff;font-size:.78rem;list-style:none}
 .prompt-preview summary::-webkit-details-marker{display:none}
-.prompt-preview summary::before{content:'\25B8 ';color:#8b949e}
+.prompt-preview summary::before{content:'\25B8 ';color:var(--cc-muted)}
 .prompt-preview[open] summary::before{content:'\25BE '}
 .prompt-labels{margin:8px 0 4px;display:flex;flex-wrap:wrap;gap:4px}
-.prompt-text{margin-top:8px;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:12px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.75rem;color:#c9d1d9;white-space:pre-wrap;word-break:break-word;max-height:220px;overflow-y:auto}
+.prompt-text{margin-top:8px;background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:8px;padding:12px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.75rem;color:var(--cc-text-2);white-space:pre-wrap;word-break:break-word;max-height:220px;overflow-y:auto}
 .prompt-preview .ops-note{margin-top:8px}
 /* #2534 Operator admin controls — mirror the Governor Hub config controls into the
    Management & Operations tab. Owner/read-write only; a read viewer never sees them. */
@@ -758,63 +823,63 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .admin-badge{font-size:.68rem;font-weight:600;padding:2px 8px;border-radius:999px;background:rgba(210,153,34,.12);color:#d29922;border:1px solid rgba(210,153,34,.3);margin-left:auto}
 .admin-body{padding:16px 20px}
 .admin-toggle{display:flex;align-items:center;gap:10px;padding:8px 0}
-.admin-switch{width:38px;height:20px;border-radius:999px;background:#30363d;position:relative;cursor:pointer;flex-shrink:0;transition:background .15s}
-.admin-switch::after{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%%;background:#e6edf3;transition:left .15s}
+.admin-switch{width:38px;height:20px;border-radius:999px;background:var(--cc-border);position:relative;cursor:pointer;flex-shrink:0;transition:background .15s}
+.admin-switch::after{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%%;background:var(--cc-text);transition:left .15s}
 .admin-switch.on{background:#1f6feb}
 .admin-switch.on.danger{background:#f85149}
 .admin-switch.on::after{left:20px}
-.admin-toggle-label{font-size:.85rem;color:#e6edf3}
-.admin-toggle-sub{font-size:.74rem;color:#8b949e}
+.admin-toggle-label{font-size:.85rem;color:var(--cc-text)}
+.admin-toggle-sub{font-size:.74rem;color:var(--cc-muted)}
 .admin-field{margin:14px 0}
-.admin-field>label{display:block;font-size:.78rem;color:#8b949e;margin-bottom:6px}
-.admin-modeseg{display:inline-flex;border:1px solid #30363d;border-radius:6px;overflow:hidden;margin-bottom:6px}
-.admin-modeseg button{background:#0d1117;border:none;color:#8b949e;font-size:.72rem;padding:3px 10px;cursor:pointer;font-family:inherit}
+.admin-field>label{display:block;font-size:.78rem;color:var(--cc-muted);margin-bottom:6px}
+.admin-modeseg{display:inline-flex;border:1px solid var(--cc-border);border-radius:6px;overflow:hidden;margin-bottom:6px}
+.admin-modeseg button{background:var(--cc-bg);border:none;color:var(--cc-muted);font-size:.72rem;padding:3px 10px;cursor:pointer;font-family:inherit}
 .admin-modeseg button.on{background:#1f6feb;color:#fff}
 .admin-chips{display:flex;flex-wrap:wrap;gap:4px;margin-bottom:6px}
-.admin-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-size:.72rem;background:rgba(139,148,158,.12);color:#c9d1d9;border:1px solid #30363d}
+.admin-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-size:.72rem;background:rgba(139,148,158,.12);color:var(--cc-text-2);border:1px solid var(--cc-border)}
 .admin-chip .x{cursor:pointer;opacity:.7}
 .admin-chip .x:hover{opacity:1;color:#f85149}
 .admin-addrow{display:flex;gap:4px}
-.admin-addrow input{flex:1;background:#0d1117;border:1px solid #30363d;border-radius:6px;color:#e6edf3;font-size:.78rem;padding:5px 8px;font-family:inherit}
+.admin-addrow input{flex:1;background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:6px;color:var(--cc-text);font-size:.78rem;padding:5px 8px;font-family:inherit}
 .admin-addrow button,.admin-save{background:#238636;border:1px solid #2ea043;color:#fff;font-size:.75rem;padding:5px 12px;border-radius:6px;cursor:pointer;font-family:inherit}
-.admin-addrow button{background:#21262d;border-color:#30363d;color:#c9d1d9}
+.admin-addrow button{background:var(--cc-border-2);border-color:var(--cc-border);color:var(--cc-text-2)}
 .admin-save{margin-top:8px}
 .admin-save:disabled{opacity:.5;cursor:default}
-.admin-hr{border:none;border-top:1px solid #21262d;margin:16px 0}
+.admin-hr{border:none;border-top:1px solid var(--cc-border-2);margin:16px 0}
 /* Repos-for-Contribute enable toggles + Tier rate-limit rows (Management mirror of
    the Governor Hub sections). Subtle, matching the rest of the admin controls. */
 .admin-repos{display:flex;flex-wrap:wrap;gap:8px}
-.admin-repo{display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border:1px solid #30363d;border-radius:8px;background:#0d1117}
+.admin-repo{display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border:1px solid var(--cc-border);border-radius:8px;background:var(--cc-bg)}
 .admin-repo .admin-switch{width:32px;height:18px}
 .admin-repo .admin-switch::after{width:14px;height:14px}
 .admin-repo .admin-switch.on::after{left:16px}
-.admin-repo__name{font-size:.76rem;color:#c9d1d9;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
-.admin-tier{display:grid;grid-template-columns:1fr repeat(3,64px);align-items:center;gap:8px;padding:8px 0;border-bottom:1px solid #21262d}
+.admin-repo__name{font-size:.76rem;color:var(--cc-text-2);font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.admin-tier{display:grid;grid-template-columns:1fr repeat(3,64px);align-items:center;gap:8px;padding:8px 0;border-bottom:1px solid var(--cc-border-2)}
 .admin-tier:last-child{border-bottom:none}
 .admin-tier__head{display:flex;align-items:center;gap:8px;min-width:0}
-.admin-tier__name{font-size:.8rem;color:#e6edf3;text-transform:capitalize}
-.admin-tier input{width:100%%;background:#0d1117;border:1px solid #30363d;border-radius:6px;color:#e6edf3;font:inherit;font-size:.78rem;padding:4px 6px;outline:none;text-align:right}
+.admin-tier__name{font-size:.8rem;color:var(--cc-text);text-transform:capitalize}
+.admin-tier input{width:100%%;background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:6px;color:var(--cc-text);font:inherit;font-size:.78rem;padding:4px 6px;outline:none;text-align:right}
 .admin-tier input:focus{border-color:#1f6feb}
 .admin-tier input:disabled{opacity:.45}
-.admin-tier__col{font-size:.62rem;color:#6e7681;text-align:right;text-transform:uppercase;letter-spacing:.03em}
-.admin-tier--head{border-bottom:1px solid #30363d;padding-bottom:4px}
+.admin-tier__col{font-size:.62rem;color:var(--cc-muted-2);text-align:right;text-transform:uppercase;letter-spacing:.03em}
+.admin-tier--head{border-bottom:1px solid var(--cc-border);padding-bottom:4px}
 /* No margin-left:auto — .admin-actions is now a full-width grid row beneath the
    identity (see .clanker-row grid), left-aligned and wrapping if the buttons
    don't fit the narrow column. */
 .admin-actions{display:flex;gap:6px;flex-wrap:wrap}
-.admin-act{background:#21262d;border:1px solid #30363d;color:#c9d1d9;font-size:.7rem;padding:3px 9px;border-radius:6px;cursor:pointer;font-family:inherit}
-.admin-act:hover{border-color:#8b949e}
+.admin-act{background:var(--cc-border-2);border:1px solid var(--cc-border);color:var(--cc-text-2);font-size:.7rem;padding:3px 9px;border-radius:6px;cursor:pointer;font-family:inherit}
+.admin-act:hover{border-color:var(--cc-muted)}
 .admin-act.danger:hover{border-color:#f85149;color:#f85149}
-.admin-act select{background:#0d1117;border:1px solid #30363d;color:#c9d1d9;font-size:.7rem;border-radius:6px;padding:2px 4px;font-family:inherit}
+.admin-act select{background:var(--cc-bg);border:1px solid var(--cc-border);color:var(--cc-text-2);font-size:.7rem;border-radius:6px;padding:2px 4px;font-family:inherit}
 .admin-modal-back{display:none;position:fixed;inset:0;background:rgba(1,4,9,.7);z-index:1000;align-items:center;justify-content:center}
 .admin-modal-back.show{display:flex}
-.admin-modal{background:#161b22;border:1px solid #30363d;border-radius:12px;max-width:420px;width:90%%;padding:22px}
-.admin-modal h4{margin:0 0 8px;font-size:1rem;color:#e6edf3}
-.admin-modal p{font-size:.85rem;color:#8b949e;line-height:1.5;margin:0 0 18px}
+.admin-modal{background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:12px;max-width:420px;width:90%%;padding:22px}
+.admin-modal h4{margin:0 0 8px;font-size:1rem;color:var(--cc-text)}
+.admin-modal p{font-size:.85rem;color:var(--cc-muted);line-height:1.5;margin:0 0 18px}
 .admin-modal-btns{display:flex;gap:8px;justify-content:flex-end}
-.admin-modal-btns button{font-size:.8rem;padding:6px 14px;border-radius:6px;cursor:pointer;font-family:inherit;border:1px solid #30363d;background:#21262d;color:#c9d1d9}
+.admin-modal-btns button{font-size:.8rem;padding:6px 14px;border-radius:6px;cursor:pointer;font-family:inherit;border:1px solid var(--cc-border);background:var(--cc-border-2);color:var(--cc-text-2)}
 .admin-modal-btns button.confirm{background:#da3633;border-color:#f85149;color:#fff}
-.admin-note{color:#6e7681;font-size:.76rem;margin-top:10px;line-height:1.5}
+.admin-note{color:var(--cc-muted-2);font-size:.76rem;margin-top:10px;line-height:1.5}
 /* ── Operations command center — live SSE-driven queue / travel / dev-log /
    achievements / army framing. Subtle-professional motion only; degrades to the
    existing poll when SSE is unavailable. Additive, read-only. ─────────────── */
@@ -833,24 +898,24 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
    as one state. Left of #cc-live so status (queue live/stale) and posture
    (active/paused) sit as a pair. */
 #queue-suspend-wrap{display:inline-flex;align-items:center;gap:6px;margin-left:auto}
-.queue-suspend-btn{display:inline-flex;align-items:center;justify-content:center;width:26px;height:26px;padding:0;border-radius:999px;border:1px solid #30363d;background:transparent;color:#8b949e;cursor:pointer;line-height:0;transition:background .15s,color .15s,border-color .15s}
+.queue-suspend-btn{display:inline-flex;align-items:center;justify-content:center;width:26px;height:26px;padding:0;border-radius:999px;border:1px solid var(--cc-border);background:transparent;color:var(--cc-muted);cursor:pointer;line-height:0;transition:background .15s,color .15s,border-color .15s}
 /* SVG glyph is centered by the flex-box; currentColor tracks the button state.
    Using an SVG (not a &#10074; bar glyph) so the pause bars sit dead-center —
    the light-vertical-bar character carries font side-bearing that pushed the
    pair off-center inside the circle. */
 .queue-suspend-btn svg{display:block;width:12px;height:12px;fill:currentColor}
-.queue-suspend-btn:hover{background:rgba(139,148,158,.12);color:#c9d1d9}
+.queue-suspend-btn:hover{background:rgba(139,148,158,.12);color:var(--cc-text-2)}
 .queue-suspend-btn.paused{border-color:rgba(248,81,73,.35);color:#f85149;background:rgba(248,81,73,.08)}
 .queue-suspend-btn.paused:hover{background:rgba(248,81,73,.16)}
 .queue-suspend-btn:disabled{opacity:.5;cursor:not-allowed}
 /* Army roster header line under the clanker card */
-.cc-army{display:flex;align-items:center;gap:14px;padding:10px 20px;border-bottom:1px solid #21262d;font-size:.78rem;color:#8b949e}
-.cc-army b{color:#e6edf3;font-weight:600}
+.cc-army{display:flex;align-items:center;gap:14px;padding:10px 20px;border-bottom:1px solid var(--cc-border-2);font-size:.78rem;color:var(--cc-muted)}
+.cc-army b{color:var(--cc-text);font-weight:600}
 .cc-army-stat{display:inline-flex;align-items:center;gap:5px}
 .cc-army-stat .dot{width:7px;height:7px;border-radius:50%%}
 .cc-army-stat.working .dot{background:#58a6ff}
 .cc-army-stat.reviewing .dot{background:#d29922}
-.cc-army-stat.idle .dot{background:#8b949e}
+.cc-army-stat.idle .dot{background:var(--cc-muted)}
 /* Clanker rows: enter pop-in / leave fade so the roster feels alive */
 @keyframes cc-popin{from{opacity:0;transform:translateY(-6px) scale(.98)}to{opacity:1;transform:none}}
 @keyframes cc-fadeout{from{opacity:1}to{opacity:0;transform:translateX(8px)}}
@@ -862,26 +927,26 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .clanker-status{font-size:.68rem;font-weight:600;padding:1px 7px;border-radius:999px;margin-left:6px;border:1px solid transparent}
 .clanker-status.working{background:rgba(88,166,255,.12);color:#58a6ff;border-color:rgba(88,166,255,.3)}
 .clanker-status.reviewing{background:rgba(210,153,34,.12);color:#d29922;border-color:rgba(210,153,34,.3)}
-.clanker-status.idle{background:rgba(139,148,158,.12);color:#8b949e;border-color:rgba(139,148,158,.3)}
+.clanker-status.idle{background:rgba(139,148,158,.12);color:var(--cc-muted);border-color:rgba(139,148,158,.3)}
 /* Ready-work QUEUE — the stack of issues waiting to be picked off. A generous
    max-height keeps a long backlog (up to ~150 items) scrolling inside the card
    instead of stretching the page; the panel scrolls, the page does not. */
 .cc-queue{max-height:560px;overflow-y:auto}
-.cc-q-item{display:flex;align-items:flex-start;gap:10px;padding:11px 20px;border-bottom:1px solid #21262d;animation:cc-popin .35s ease;position:relative}
+.cc-q-item{display:flex;align-items:flex-start;gap:10px;padding:11px 20px;border-bottom:1px solid var(--cc-border-2);animation:cc-popin .35s ease;position:relative}
 .cc-q-item:first-child{background:rgba(88,166,255,.05)}
 /* Drag handle (grab bar) — owner/read-write only. Hidden unless the queue root
    carries .cc-q-draggable (set by initAdmin after /api/role). Reduced-motion and
    pointer friendly. */
-.cc-q-grip{display:none;flex-shrink:0;width:16px;align-self:stretch;cursor:grab;color:#6e7681;font-size:.9rem;line-height:1;align-items:center;justify-content:center;user-select:none;touch-action:none}
-.cc-q-grip:hover{color:#c9d1d9}
+.cc-q-grip{display:none;flex-shrink:0;width:16px;align-self:stretch;cursor:grab;color:var(--cc-muted-2);font-size:.9rem;line-height:1;align-items:center;justify-content:center;user-select:none;touch-action:none}
+.cc-q-grip:hover{color:var(--cc-text-2)}
 .cc-queue.cc-q-draggable .cc-q-grip{display:flex}
 .cc-queue.cc-q-draggable .cc-q-item{cursor:default}
 .cc-q-item.cc-q-dragging{opacity:.5;cursor:grabbing}
 .cc-q-item.cc-q-over{box-shadow:inset 0 2px 0 0 #58a6ff}
-.cc-q-idx{font-size:.7rem;color:#6e7681;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;flex-shrink:0;width:22px;text-align:right;padding-top:2px}
+.cc-q-idx{font-size:.7rem;color:var(--cc-muted-2);font-family:ui-monospace,SFMono-Regular,Menlo,monospace;flex-shrink:0;width:22px;text-align:right;padding-top:2px}
 .cc-q-body{flex:1;min-width:0}
-.cc-q-repo{font-size:.72rem;color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
-.cc-q-title{font-size:.86rem;color:#e6edf3;margin:2px 0 4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.cc-q-repo{font-size:.72rem;color:var(--cc-muted);font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.cc-q-title{font-size:.86rem;color:var(--cc-text);margin:2px 0 4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .cc-q-labels{display:flex;flex-wrap:wrap;gap:4px}
 .cc-q-next{font-size:.62rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#58a6ff;flex-shrink:0;padding-top:2px}
 .cc-q-item.cc-leaving{animation:cc-fadeout .45s ease forwards}
@@ -895,36 +960,36 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
    muted greys, the page's blue accent only on focus/hover, no game-y flourish.
    The search bar is read-only filtering so it shows for everyone; the per-row
    ACTIONS live inside the row menu, which is only rendered for owner/read-write. */
-.cc-q-search{display:flex;align-items:center;gap:8px;padding:10px 20px;border-bottom:1px solid #21262d}
-.cc-q-search-ic{color:#6e7681;font-size:.85rem;flex-shrink:0;line-height:1}
-.cc-q-search input{flex:1;min-width:0;background:#0d1117;border:1px solid #30363d;border-radius:7px;color:#e6edf3;font:inherit;font-size:.82rem;padding:6px 10px;outline:none;transition:border-color .15s,box-shadow .15s}
-.cc-q-search input::placeholder{color:#6e7681}
+.cc-q-search{display:flex;align-items:center;gap:8px;padding:10px 20px;border-bottom:1px solid var(--cc-border-2)}
+.cc-q-search-ic{color:var(--cc-muted-2);font-size:.85rem;flex-shrink:0;line-height:1}
+.cc-q-search input{flex:1;min-width:0;background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:7px;color:var(--cc-text);font:inherit;font-size:.82rem;padding:6px 10px;outline:none;transition:border-color .15s,box-shadow .15s}
+.cc-q-search input::placeholder{color:var(--cc-muted-2)}
 .cc-q-search input:focus{border-color:#1f6feb;box-shadow:0 0 0 3px rgba(31,111,235,.25)}
-.cc-q-search-clear{background:none;border:none;color:#6e7681;cursor:pointer;font-size:1rem;line-height:1;padding:2px 4px;display:none}
+.cc-q-search-clear{background:none;border:none;color:var(--cc-muted-2);cursor:pointer;font-size:1rem;line-height:1;padding:2px 4px;display:none}
 .cc-q-search.has-text .cc-q-search-clear{display:inline-flex}
-.cc-q-search-clear:hover{color:#c9d1d9}
-.cc-q-filternote{padding:6px 20px;font-size:.72rem;color:#6e7681;border-bottom:1px solid #21262d}
+.cc-q-search-clear:hover{color:var(--cc-text-2)}
+.cc-q-filternote{padding:6px 20px;font-size:.72rem;color:var(--cc-muted-2);border-bottom:1px solid var(--cc-border-2)}
 /* ── My label interests (#2637) — contributor-declared label affinity ───────────
    A quiet self-service editor on the queue card: chips for the labels this viewer
    subscribed to, plus an add field. Shown only to a signed-in contributor. Matching
    queue rows are highlighted (.cc-q-mine) and a small "for you" tag explains why.
    Sober palette to match the SRE ops register; the page's green accent marks a
    personal match without shouting. */
-.cc-interests{padding:10px 20px;border-bottom:1px solid #21262d}
+.cc-interests{padding:10px 20px;border-bottom:1px solid var(--cc-border-2)}
 .cc-interests-head{display:flex;flex-wrap:wrap;align-items:baseline;gap:8px;margin-bottom:6px}
-.cc-interests-title{font-size:.74rem;font-weight:700;letter-spacing:.03em;text-transform:uppercase;color:#8b949e}
-.cc-interests-hint{font-size:.68rem;color:#6e7681}
+.cc-interests-title{font-size:.74rem;font-weight:700;letter-spacing:.03em;text-transform:uppercase;color:var(--cc-muted)}
+.cc-interests-hint{font-size:.68rem;color:var(--cc-muted-2)}
 .cc-interests-chips{display:flex;flex-wrap:wrap;gap:5px;margin-bottom:6px}
-.cc-interests-empty{font-size:.72rem;color:#6e7681}
-.cc-interests-empty code{background:#161b22;border:1px solid #30363d;border-radius:4px;padding:0 4px;font-size:.9em}
+.cc-interests-empty{font-size:.72rem;color:var(--cc-muted-2)}
+.cc-interests-empty code{background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:4px;padding:0 4px;font-size:.9em}
 .cc-interest-chip{display:inline-flex;align-items:center;gap:5px;padding:2px 9px;border-radius:999px;font-size:.74rem;background:rgba(46,160,67,.12);color:#3fb950;border:1px solid rgba(46,160,67,.3)}
 .cc-interest-x{cursor:pointer;opacity:.7;font-size:.95rem;line-height:1}
 .cc-interest-x:hover{opacity:1}
 .cc-interests-add{display:flex;gap:6px}
-.cc-interests-add input{flex:1;min-width:0;background:#0d1117;border:1px solid #30363d;border-radius:7px;color:#e6edf3;font:inherit;font-size:.8rem;padding:5px 9px;outline:none;transition:border-color .15s,box-shadow .15s}
-.cc-interests-add input::placeholder{color:#6e7681}
+.cc-interests-add input{flex:1;min-width:0;background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:7px;color:var(--cc-text);font:inherit;font-size:.8rem;padding:5px 9px;outline:none;transition:border-color .15s,box-shadow .15s}
+.cc-interests-add input::placeholder{color:var(--cc-muted-2)}
 .cc-interests-add input:focus{border-color:#1f6feb;box-shadow:0 0 0 3px rgba(31,111,235,.25)}
-.cc-interests-add button{background:#161b22;border:1px solid #30363d;border-radius:7px;color:#c9d1d9;cursor:pointer;font:inherit;font-size:.78rem;padding:5px 12px}
+.cc-interests-add button{background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:7px;color:var(--cc-text-2);cursor:pointer;font:inherit;font-size:.78rem;padding:5px 12px}
 .cc-interests-add button:hover{border-color:#3fb950;color:#3fb950}
 /* A queue row matching one of the viewer's label interests: a soft green rail on
    the leading edge + faint tint. Never hides the row — pure emphasis. */
@@ -934,22 +999,22 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 /* Per-row "⋯" context affordance — owner/read-write only (rendered only when
    adminEnabled). Sits at the row's trailing edge, quiet until hover/open. */
 .cc-q-menu-wrap{position:relative;flex-shrink:0;margin-left:auto;align-self:center}
-.cc-q-menu-btn{background:none;border:none;color:#6e7681;cursor:pointer;font-size:1rem;line-height:1;padding:4px 6px;border-radius:6px}
-.cc-q-menu-btn:hover,.cc-q-menu-btn[aria-expanded=true]{color:#e6edf3;background:#21262d}
-.cc-q-menu{position:absolute;top:100%%;right:0;z-index:40;min-width:190px;background:#161b22;border:1px solid #30363d;border-radius:10px;box-shadow:0 8px 28px rgba(1,4,9,.55);padding:6px;display:none}
+.cc-q-menu-btn{background:none;border:none;color:var(--cc-muted-2);cursor:pointer;font-size:1rem;line-height:1;padding:4px 6px;border-radius:6px}
+.cc-q-menu-btn:hover,.cc-q-menu-btn[aria-expanded=true]{color:var(--cc-text);background:var(--cc-border-2)}
+.cc-q-menu{position:absolute;top:100%%;right:0;z-index:40;min-width:190px;background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:10px;box-shadow:0 8px 28px rgba(1,4,9,.55);padding:6px;display:none}
 .cc-q-menu.open{display:block}
-.cc-q-menu button.cc-q-act{display:flex;align-items:center;gap:8px;width:100%%;background:none;border:none;color:#c9d1d9;font:inherit;font-size:.82rem;text-align:left;padding:7px 9px;border-radius:6px;cursor:pointer}
-.cc-q-menu button.cc-q-act:hover{background:#21262d;color:#e6edf3}
-.cc-q-menu-ic{color:#6e7681;flex-shrink:0;width:16px;text-align:center}
-.cc-q-menu-sep{height:1px;background:#21262d;margin:5px 2px}
+.cc-q-menu button.cc-q-act{display:flex;align-items:center;gap:8px;width:100%%;background:none;border:none;color:var(--cc-text-2);font:inherit;font-size:.82rem;text-align:left;padding:7px 9px;border-radius:6px;cursor:pointer}
+.cc-q-menu button.cc-q-act:hover{background:var(--cc-border-2);color:var(--cc-text)}
+.cc-q-menu-ic{color:var(--cc-muted-2);flex-shrink:0;width:16px;text-align:center}
+.cc-q-menu-sep{height:1px;background:var(--cc-border-2);margin:5px 2px}
 .cc-q-moverow{display:flex;align-items:center;gap:6px;padding:7px 9px}
-.cc-q-moverow label{font-size:.78rem;color:#8b949e;flex:1}
-/* color-scheme:dark makes the native number-input spinner arrows theme-aware, so
-   they render light-on-dark and are VISIBLE against the #0d1117 field + the dark
-   #161b22 menu — previously they were black-on-black and effectively invisible.
-   The explicit background/color are kept as a belt-and-braces fallback for engines
-   that don't honour color-scheme on the control. */
-.cc-q-moverow input[type=number]{width:56px;background:#0d1117;border:1px solid #30363d;border-radius:6px;color:#e6edf3;font:inherit;font-size:.8rem;padding:4px 6px;outline:none;color-scheme:dark}
+.cc-q-moverow label{font-size:.78rem;color:var(--cc-muted);flex:1}
+/* color-scheme makes the native number-input spinner arrows theme-aware, so they
+   render legibly against the field in BOTH appearances (previously black-on-black
+   and effectively invisible on dark). The tokenized background/color are kept as a
+   belt-and-braces fallback for engines that don't honour color-scheme on the
+   control; the field itself flips with the (#2612) light/dark tokens. */
+.cc-q-moverow input[type=number]{width:56px;background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:6px;color:var(--cc-text);font:inherit;font-size:.8rem;padding:4px 6px;outline:none;color-scheme:light dark}
 .cc-q-moverow input:focus{border-color:#1f6feb}
 .cc-q-moverow button{background:#1f6feb;border:none;color:#fff;font:inherit;font-size:.76rem;font-weight:600;padding:5px 10px;border-radius:6px;cursor:pointer}
 .cc-q-moverow button:hover{background:#388bfd}
@@ -963,46 +1028,46 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
    quiet: no loud "recommended!" chrome, just a short curated list with a subtle
    heat dot and an unobtrusive "add to queue" affordance (owner/read-write only). */
 .opp-list{padding:2px 0}
-.opp-item{display:flex;align-items:flex-start;gap:10px;padding:11px 20px;border-bottom:1px solid #21262d}
+.opp-item{display:flex;align-items:flex-start;gap:10px;padding:11px 20px;border-bottom:1px solid var(--cc-border-2)}
 .opp-item:last-child{border-bottom:none}
 .opp-heat{flex-shrink:0;width:8px;height:8px;border-radius:50%%;margin-top:5px;background:#3fb950;box-shadow:0 0 0 3px rgba(63,185,80,.14)}
 .opp-heat.warm{background:#d29922;box-shadow:0 0 0 3px rgba(210,153,34,.14)}
-.opp-heat.cool{background:#6e7681;box-shadow:none}
+.opp-heat.cool{background:var(--cc-muted-2);box-shadow:none}
 .opp-body{flex:1;min-width:0}
-.opp-repo{font-size:.72rem;color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
-.opp-title{font-size:.86rem;color:#e6edf3;margin:2px 0 3px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.opp-reason{font-size:.7rem;color:#6e7681}
-.opp-add{flex-shrink:0;align-self:center;background:none;border:1px solid #30363d;color:#c9d1d9;font:inherit;font-size:.74rem;font-weight:600;padding:5px 11px;border-radius:7px;cursor:pointer;transition:border-color .15s,color .15s,background .15s}
+.opp-repo{font-size:.72rem;color:var(--cc-muted);font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.opp-title{font-size:.86rem;color:var(--cc-text);margin:2px 0 3px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.opp-reason{font-size:.7rem;color:var(--cc-muted-2)}
+.opp-add{flex-shrink:0;align-self:center;background:none;border:1px solid var(--cc-border);color:var(--cc-text-2);font:inherit;font-size:.74rem;font-weight:600;padding:5px 11px;border-radius:7px;cursor:pointer;transition:border-color .15s,color .15s,background .15s}
 .opp-add:hover{border-color:#1f6feb;color:#fff;background:rgba(31,111,235,.15)}
-.opp-add:disabled{opacity:.55;cursor:default;border-color:#30363d;color:#8b949e;background:none}
+.opp-add:disabled{opacity:.55;cursor:default;border-color:var(--cc-border);color:var(--cc-muted);background:none}
 /* ── End-of-queue + hive-settings (#2595) — turn a short queue into an intentional,
    reassuring moment: a calm "all caught up" marker, the managed-queue rate limits
    presented readably, and the viewer's own daily quota. Sober, ranked-family styling. */
 .cc-q-end{padding:18px 20px 6px;text-align:center}
-.cc-q-end-badge{display:inline-flex;align-items:center;gap:8px;font-size:.82rem;color:#8b949e;background:#0d1117;border:1px solid #21262d;border-radius:999px;padding:7px 16px}
+.cc-q-end-badge{display:inline-flex;align-items:center;gap:8px;font-size:.82rem;color:var(--cc-muted);background:var(--cc-bg);border:1px solid var(--cc-border-2);border-radius:999px;padding:7px 16px}
 .cc-q-end-badge .cc-q-end-ic{color:#3fb950;font-size:.95rem;line-height:1}
-.hive-settings{margin:14px 20px 4px;background:#0d1117;border:1px solid #21262d;border-radius:10px;padding:14px 16px}
-.hive-settings h4{margin:0 0 4px;font-size:.78rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#8b949e}
-.hive-settings p.hs-lead{margin:0 0 10px;font-size:.82rem;color:#c9d1d9;line-height:1.5}
+.hive-settings{margin:14px 20px 4px;background:var(--cc-bg);border:1px solid var(--cc-border-2);border-radius:10px;padding:14px 16px}
+.hive-settings h4{margin:0 0 4px;font-size:.78rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:var(--cc-muted)}
+.hive-settings p.hs-lead{margin:0 0 10px;font-size:.82rem;color:var(--cc-text-2);line-height:1.5}
 .hs-tiers{display:flex;flex-wrap:wrap;gap:8px}
-.hs-tier{flex:1 1 130px;min-width:120px;background:#161b22;border:1px solid #30363d;border-radius:8px;padding:9px 11px}
-.hs-tier__name{font-size:.72rem;font-weight:600;text-transform:capitalize;color:#e6edf3;display:flex;align-items:center;gap:6px}
-.hs-tier__lim{font-size:.74rem;color:#8b949e;margin-top:3px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.hs-tier{flex:1 1 130px;min-width:120px;background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:8px;padding:9px 11px}
+.hs-tier__name{font-size:.72rem;font-weight:600;text-transform:capitalize;color:var(--cc-text);display:flex;align-items:center;gap:6px}
+.hs-tier__lim{font-size:.74rem;color:var(--cc-muted);margin-top:3px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
 .hs-tier.is-you{border-color:#1f6feb;box-shadow:0 0 0 2px rgba(31,111,235,.18)}
 .hs-tier__youtag{font-size:.6rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#58a6ff}
 /* Daily quota widget — a slim progress meter, calm. Used at end-of-queue AND on
    the Me card. Fill width is set inline from the REAL used/limit ratio. */
 .quota{margin-top:12px}
 .quota__head{display:flex;align-items:baseline;justify-content:space-between;gap:8px;margin-bottom:6px}
-.quota__lbl{font-size:.76rem;color:#8b949e}
-.quota__val{font-size:.82rem;color:#e6edf3;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
-.quota__bar{height:7px;border-radius:999px;background:#21262d;overflow:hidden}
+.quota__lbl{font-size:.76rem;color:var(--cc-muted)}
+.quota__val{font-size:.82rem;color:var(--cc-text);font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.quota__bar{height:7px;border-radius:999px;background:var(--cc-border-2);overflow:hidden}
 .quota__fill{height:100%%;border-radius:999px;background:linear-gradient(90deg,#1f6feb,#388bfd);transition:width .4s ease}
 .quota__fill.near{background:linear-gradient(90deg,#d29922,#e3b341)}
 .quota__fill.full{background:linear-gradient(90deg,#f85149,#ff7b72)}
-.quota__sub{font-size:.7rem;color:#6e7681;margin-top:5px}
+.quota__sub{font-size:.7rem;color:var(--cc-muted-2);margin-top:5px}
 /* Me-card quota variant — sits inside a me-sec, so it inherits the card padding. */
-.me-quota .quota__lbl{color:#8b949e}
+.me-quota .quota__lbl{color:var(--cc-muted)}
 @media(prefers-reduced-motion:reduce){.quota__fill{transition:none!important}}
 /* Sparklines (#persistent-history): tiny dependency-free inline-SVG trend charts
    fed by /api/contribute/metrics (7-day hourly history). Muted stroke to sit
@@ -1017,39 +1082,39 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
    numerals stay the focus. */
 .lb-spark{display:flex;align-items:center;justify-content:flex-end}
 /* Hive-wide trend strip pinned above the standings. */
-.lb-trend{display:flex;align-items:center;gap:10px;padding:8px 20px 12px;color:#8b949e;font-size:.76rem;border-bottom:1px solid #21262d}
+.lb-trend{display:flex;align-items:center;gap:10px;padding:8px 20px 12px;color:var(--cc-muted);font-size:.76rem;border-bottom:1px solid var(--cc-border-2)}
 .lb-trend .spark{margin-left:auto}
 /* "File an issue on this page" link (#2594) — a subtle footer affordance present
    on every tab. Quiet grey, matches the sober dashboard chrome; an outbound link. */
-.cc-page-foot{padding:26px 48px 34px;border-top:1px solid #21262d;margin-top:28px;display:flex;justify-content:center}
-.cc-report-link{display:inline-flex;align-items:center;gap:7px;color:#8b949e;font-size:.8rem;text-decoration:none;border:1px solid #30363d;border-radius:8px;padding:7px 14px;transition:color .15s,border-color .15s,background .15s}
-.cc-report-link:hover{color:#e6edf3;border-color:#484f58;background:#161b22}
+.cc-page-foot{padding:26px 48px 34px;border-top:1px solid var(--cc-border-2);margin-top:28px;display:flex;justify-content:center}
+.cc-report-link{display:inline-flex;align-items:center;gap:7px;color:var(--cc-muted);font-size:.8rem;text-decoration:none;border:1px solid var(--cc-border);border-radius:8px;padding:7px 14px;transition:color .15s,border-color .15s,background .15s}
+.cc-report-link:hover{color:var(--cc-text);border-color:#484f58;background:var(--cc-surface)}
 .cc-report-link .cc-report-ic{font-size:.9rem;line-height:1}
 /* The travelling token that flies from the queue to a clanker on task_assign */
 .cc-token{position:fixed;z-index:1200;pointer-events:none;background:#1f6feb;color:#fff;font-size:.72rem;font-weight:600;padding:6px 12px;border-radius:999px;box-shadow:0 6px 20px rgba(31,111,235,.5);white-space:nowrap;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;transition:transform .9s cubic-bezier(.5,0,.2,1),opacity .9s ease;will-change:transform,opacity}
 /* Dev-log — a running chat log of the development */
 .cc-log{max-height:360px;overflow-y:auto;padding:4px 0}
-.cc-log-line{display:flex;align-items:flex-start;gap:10px;padding:8px 20px;font-size:.83rem;border-bottom:1px solid #1c2128;animation:cc-logline .45s ease}
+.cc-log-line{display:flex;align-items:flex-start;gap:10px;padding:8px 20px;font-size:.83rem;border-bottom:1px solid var(--cc-border-2);animation:cc-logline .45s ease}
 @keyframes cc-logline{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:none}}
 .cc-log-line:last-child{border-bottom:none}
 .cc-log-ic{flex-shrink:0}
-.cc-log-body{flex:1;min-width:0;color:#c9d1d9;line-height:1.45}
-.cc-log-body b{color:#e6edf3}
+.cc-log-body{flex:1;min-width:0;color:var(--cc-text-2);line-height:1.45}
+.cc-log-body b{color:var(--cc-text)}
 .cc-log-body .who{color:#58a6ff;font-weight:600}
-.cc-log-body .ref{color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.78rem}
+.cc-log-body .ref{color:var(--cc-muted);font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.78rem}
 .cc-log-body a.ref.cc-issue-link{color:#58a6ff}
 .cc-log-body a.ref.cc-issue-link:hover,.cc-log-body a.ref.cc-issue-link:focus-visible{color:#79c0ff}
-.cc-log-time{flex-shrink:0;color:#6e7681;font-size:.72rem;white-space:nowrap;padding-top:1px}
+.cc-log-time{flex-shrink:0;color:var(--cc-muted-2);font-size:.72rem;white-space:nowrap;padding-top:1px}
 /* Achievement pops — tasteful badge toast, top-right, debounced */
 .cc-ach-wrap{position:fixed;top:16px;right:16px;z-index:1150;display:flex;flex-direction:column;gap:8px;pointer-events:none}
-.cc-ach{display:flex;align-items:center;gap:10px;background:linear-gradient(135deg,#161b22,#1c2333);border:1px solid rgba(210,153,34,.4);border-radius:10px;padding:10px 14px;box-shadow:0 8px 28px rgba(1,4,9,.55);animation:cc-ach-in .4s ease;max-width:300px}
+.cc-ach{display:flex;align-items:center;gap:10px;background:linear-gradient(135deg,var(--cc-surface),#1c2333);border:1px solid rgba(210,153,34,.4);border-radius:10px;padding:10px 14px;box-shadow:0 8px 28px rgba(1,4,9,.55);animation:cc-ach-in .4s ease;max-width:300px}
 @keyframes cc-ach-in{from{opacity:0;transform:translateX(24px)}to{opacity:1;transform:none}}
 .cc-ach.cc-ach-out{animation:cc-ach-out .4s ease forwards}
 @keyframes cc-ach-out{to{opacity:0;transform:translateX(24px)}}
 .cc-ach-ic{font-size:1.3rem;flex-shrink:0}
 .cc-ach-txt{min-width:0}
 .cc-ach-h{font-size:.7rem;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:#d29922}
-.cc-ach-s{font-size:.82rem;color:#e6edf3;margin-top:1px}
+.cc-ach-s{font-size:.82rem;color:var(--cc-text);margin-top:1px}
 /* ── Operations two-region shell: MAIN area + full-height DEV-LOG RAIL ──────────
    The main area flexes to fill remaining width; the rail is a fixed-width panel
    pinned to the tab's height. When the rail collapses it shrinks to a thin strip
@@ -1061,17 +1126,17 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 /* The rail: a self-contained chat/notifications panel that runs the tab's height.
    It sticks so the feed stays in view while the (taller) main area scrolls. */
 .ops-rail{flex:0 0 340px;position:sticky;top:0;align-self:flex-start;max-height:calc(100vh - 80px);
-  background:#161b22;border:1px solid #30363d;border-radius:12px;overflow:hidden;
+  background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:12px;overflow:hidden;
   display:flex;flex-direction:column;transition:flex-basis .28s ease}
 .ops-rail-inner{display:flex;flex-direction:column;min-height:0;flex:1 1 auto;opacity:1;transition:opacity .2s ease}
-.ops-rail-head{padding:16px 20px;border-bottom:1px solid #30363d;display:flex;align-items:center;gap:10px;flex-shrink:0}
-.ops-rail-head h3{font-size:.95rem;color:#e6edf3;margin:0}
+.ops-rail-head{padding:16px 20px;border-bottom:1px solid var(--cc-border);display:flex;align-items:center;gap:10px;flex-shrink:0}
+.ops-rail-head h3{font-size:.95rem;color:var(--cc-text);margin:0}
 .ops-rail .cc-log{flex:1 1 auto;max-height:none;min-height:0}
 /* The collapse toggle sits on the rail's leading edge (a slim handle). */
-.ops-rail-toggle{display:flex;align-items:center;gap:6px;width:100%%;background:#0d1117;border:none;
-  border-bottom:1px solid #30363d;color:#8b949e;font-family:inherit;font-size:.74rem;font-weight:600;
+.ops-rail-toggle{display:flex;align-items:center;gap:6px;width:100%%;background:var(--cc-bg);border:none;
+  border-bottom:1px solid var(--cc-border);color:var(--cc-muted);font-family:inherit;font-size:.74rem;font-weight:600;
   letter-spacing:.03em;text-transform:uppercase;padding:9px 14px;cursor:pointer;flex-shrink:0}
-.ops-rail-toggle:hover{color:#e6edf3;background:#161b22}
+.ops-rail-toggle:hover{color:var(--cc-text);background:var(--cc-surface)}
 .ops-rail-chevron{display:inline-block;font-size:1rem;line-height:1;transition:transform .28s ease}
 /* Collapsed: rail narrows to a strip; the toggle label + inner feed hide; the
    chevron flips to point "open" (right) as a "show log" affordance. */
@@ -1098,35 +1163,35 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
    nothing about the copy-block logic changes. CSP-safe (inline assets only),
    theme-consistent with the dark palette, reduced-motion safe. */
 .client-tiles{display:grid;grid-template-columns:repeat(auto-fill,minmax(132px,1fr));gap:8px;margin:4px 0 20px}
-.client-tile{display:flex;align-items:flex-start;gap:9px;background:#161b22;border:1px solid #30363d;border-radius:10px;padding:9px 11px;cursor:pointer;text-align:left;font-family:inherit;color:#e6edf3;font-size:.82rem;transition:border-color .15s,background .15s,transform .1s}
+.client-tile{display:flex;align-items:flex-start;gap:9px;background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:10px;padding:9px 11px;cursor:pointer;text-align:left;font-family:inherit;color:var(--cc-text);font-size:.82rem;transition:border-color .15s,background .15s,transform .1s}
 .client-tile:hover{border-color:#58a6ff;background:#1b2230}
 .client-tile:active{transform:translateY(1px)}
 .client-tile:focus-visible{outline:2px solid #58a6ff;outline-offset:2px}
 .client-tile.sel{border-color:#58a6ff;background:rgba(88,166,255,.10);box-shadow:inset 0 0 0 1px rgba(88,166,255,.35)}
-.client-tile .ct-emblem{width:24px;height:24px;flex:0 0 24px;display:flex;align-items:center;justify-content:center;border-radius:6px;background:#0d1117;overflow:hidden}
+.client-tile .ct-emblem{width:24px;height:24px;flex:0 0 24px;display:flex;align-items:center;justify-content:center;border-radius:6px;background:var(--cc-bg);overflow:hidden}
 .client-tile .ct-emblem svg{width:18px;height:18px;display:block}
 .client-tile .ct-name{font-weight:600;line-height:1.15;min-width:0}
-.client-tile .ct-name small{display:block;font-weight:400;color:#8b949e;font-size:.7rem}
+.client-tile .ct-name small{display:block;font-weight:400;color:var(--cc-muted);font-size:.7rem}
 /* min-width:0 keeps the name ellipsising rather than overflowing the tile. */
 .client-tile .ct-body{display:flex;flex-direction:column;align-items:flex-start;gap:3px;min-width:0}
 /* "Open in <tool>" onboarding affordance — deliberately understated and clearly a
    SETUP helper, never a "contributing" surface. Only rendered for a client with a
    real, vendor-documented deep-link scheme. */
-.openin-row{display:none;align-items:flex-start;gap:10px;background:#0d1117;border:1px solid #30363d;border-left:3px solid #d29922;border-radius:8px;padding:11px 14px;margin:0 0 16px}
+.openin-row{display:none;align-items:flex-start;gap:10px;background:var(--cc-bg);border:1px solid var(--cc-border);border-left:3px solid #d29922;border-radius:8px;padding:11px 14px;margin:0 0 16px}
 .openin-row.show{display:flex}
-.openin-row .oi-body{min-width:0;font-size:.8rem;color:#8b949e;line-height:1.4}
-.openin-row .oi-body strong{color:#e6edf3}
-.openin-link{flex:0 0 auto;display:inline-flex;align-items:center;gap:6px;background:#161b22;border:1px solid #30363d;border-radius:6px;color:#58a6ff;text-decoration:none;font-size:.8rem;padding:6px 12px;font-family:inherit;cursor:pointer}
+.openin-row .oi-body{min-width:0;font-size:.8rem;color:var(--cc-muted);line-height:1.4}
+.openin-row .oi-body strong{color:var(--cc-text)}
+.openin-link{flex:0 0 auto;display:inline-flex;align-items:center;gap:6px;background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:6px;color:#58a6ff;text-decoration:none;font-size:.8rem;padding:6px 12px;font-family:inherit;cursor:pointer}
 .openin-link:hover{border-color:#58a6ff}
 .openin-link svg{width:14px;height:14px}
 .oi-note{color:#d29922;font-weight:600}
 /* Customizable, copy-pasteable per-client PROMPT (kept in an editable block the
    contributor can read/tweak, NOT compressed into a URL). Additive to the shell
    command copy block above it. */
-.prompt-block{margin:18px 0 8px;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:14px 16px 16px;position:relative}
-.prompt-block h4{margin:0 0 6px;font-size:.82rem;color:#e6edf3;font-weight:600}
-.prompt-block p.pb-sub{margin:0 0 10px;color:#8b949e;font-size:.76rem;line-height:1.4}
-.prompt-block textarea{width:100%%;min-height:118px;resize:vertical;background:#010409;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:10px 12px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.8rem;line-height:1.5}
+.prompt-block{margin:18px 0 8px;background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:8px;padding:14px 16px 16px;position:relative}
+.prompt-block h4{margin:0 0 6px;font-size:.82rem;color:var(--cc-text);font-weight:600}
+.prompt-block p.pb-sub{margin:0 0 10px;color:var(--cc-muted);font-size:.76rem;line-height:1.4}
+.prompt-block textarea{width:100%%;min-height:118px;resize:vertical;background:var(--cc-bg-deep);color:var(--cc-text);border:1px solid var(--cc-border);border-radius:6px;padding:10px 12px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.8rem;line-height:1.5}
 .prompt-block textarea:focus{outline:none;border-color:#58a6ff}
 .pb-copy{position:absolute;top:10px;right:12px;background:#238636;color:#fff;border:none;border-radius:4px;padding:4px 12px;cursor:pointer;font-size:.72rem;font-family:inherit}
 @media(prefers-reduced-motion:reduce){
@@ -1135,18 +1200,52 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 /* Trusted invite banner (issue #2598) — shown on onboarding when arriving via an
    attributed invite link. Subtle, informational; makes clear the invitee joins
    as a newcomer. */
-.invite-banner{margin:0 0 20px;padding:11px 15px;border:1px solid #388bfd55;border-radius:8px;background:#1c2f4a55;color:#c9d1d9;font-size:.85rem;line-height:1.45}
-.invite-banner b{color:#e6edf3}
-.invite-banner .invite-tier{color:#8b949e}
+.invite-banner{margin:0 0 20px;padding:11px 15px;border:1px solid #388bfd55;border-radius:8px;background:#1c2f4a55;color:var(--cc-text-2);font-size:.85rem;line-height:1.45}
+.invite-banner b{color:var(--cc-text)}
+.invite-banner .invite-tier{color:var(--cc-muted)}
 /* Trusted "Invite someone" action inside the Me card (issue #2598). */
 .me-invite{margin-top:12px;padding-top:12px;border-top:1px solid #ffffff14}
 .me-invite__btn{display:inline-flex;align-items:center;gap:6px;background:#1f6feb;color:#fff;border:none;border-radius:6px;padding:7px 14px;font-size:.82rem;font-family:inherit;cursor:pointer}
 .me-invite__btn:hover{background:#388bfd}
 .me-invite__row{display:none;margin-top:10px;gap:8px;align-items:center;flex-wrap:wrap}
 .me-invite__row.open{display:flex}
-.me-invite__link{flex:1 1 220px;min-width:0;background:#010409;color:#c9d1d9;border:1px solid #30363d;border-radius:6px;padding:7px 10px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.76rem}
+.me-invite__link{flex:1 1 220px;min-width:0;background:var(--cc-bg-deep);color:var(--cc-text-2);border:1px solid var(--cc-border);border-radius:6px;padding:7px 10px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.76rem}
 .me-invite__copy{background:#238636;color:#fff;border:none;border-radius:6px;padding:7px 12px;font-size:.78rem;font-family:inherit;cursor:pointer}
-.me-invite__hint{width:100%%;margin-top:6px;color:#8b949e;font-size:.74rem;line-height:1.4}
+.me-invite__hint{width:100%%;margin-top:6px;color:var(--cc-muted);font-size:.74rem;line-height:1.4}
+/* ── (#2612 part d) Light-mode fixups for the handful of DARK one-off surfaces
+   that are not part of the tokenized neutral ramp (small gradient washes and a
+   couple of hover fills baked as literal dark hex). On a light appearance those
+   would read as near-black patches, so re-point them at the light tokens. Also a
+   gentle contrast lift on the muted status-pill fills, whose ~12%% dark-tuned
+   rgba washes go faint on white — a gentle solid tint keeps them legible without
+   changing their hue/meaning. Applies under BOTH light signals. */
+@media(prefers-color-scheme:light){:root:not([data-theme="dark"]) .ops-card.card-accent>.ops-card-head{background:linear-gradient(180deg,var(--cc-border-2) 0%%,var(--cc-surface) 100%%)}
+:root:not([data-theme="dark"]) .cc-ach{background:var(--cc-surface)}
+:root:not([data-theme="dark"]) .client-tile:hover{background:var(--cc-border-2)}
+:root:not([data-theme="dark"]) .invite-banner{background:#ddf4ff;border-color:#b6e3ff}
+:root:not([data-theme="dark"]) .cc-report-link:hover{border-color:var(--cc-muted)}
+:root:not([data-theme="dark"]) .pill-progress{background:rgba(9,105,218,.10);color:var(--cc-accent-fg);border-color:rgba(9,105,218,.30)}
+:root:not([data-theme="dark"]) .pill-review,:root:not([data-theme="dark"]) .clanker-status.reviewing{background:rgba(154,103,0,.12);color:var(--cc-amber);border-color:rgba(154,103,0,.30)}
+:root:not([data-theme="dark"]) .pill-passed{background:rgba(26,127,55,.12);color:var(--cc-green);border-color:rgba(26,127,55,.30)}
+:root:not([data-theme="dark"]) .pill-blocked{background:rgba(207,34,46,.10);color:var(--cc-red);border-color:rgba(207,34,46,.30)}
+}
+:root[data-theme="light"] .ops-card.card-accent>.ops-card-head{background:linear-gradient(180deg,var(--cc-border-2) 0%%,var(--cc-surface) 100%%)}
+:root[data-theme="light"] .cc-ach{background:var(--cc-surface)}
+:root[data-theme="light"] .client-tile:hover{background:var(--cc-border-2)}
+:root[data-theme="light"] .invite-banner{background:#ddf4ff;border-color:#b6e3ff}
+:root[data-theme="light"] .cc-report-link:hover{border-color:var(--cc-muted)}
+:root[data-theme="light"] .pill-progress{background:rgba(9,105,218,.10);color:var(--cc-accent-fg);border-color:rgba(9,105,218,.30)}
+:root[data-theme="light"] .pill-review,:root[data-theme="light"] .clanker-status.reviewing{background:rgba(154,103,0,.12);color:var(--cc-amber);border-color:rgba(154,103,0,.30)}
+:root[data-theme="light"] .pill-passed{background:rgba(26,127,55,.12);color:var(--cc-green);border-color:rgba(26,127,55,.30)}
+:root[data-theme="light"] .pill-blocked{background:rgba(207,34,46,.10);color:var(--cc-red);border-color:rgba(207,34,46,.30)}
+/* ── (#2612 part d) Conservative de-crowd: small uniform breathing room on the
+   densest grids (the onboarding stat row and the Operations cards). No card
+   removed, no structural/layout change — just a touch more gap/padding so the
+   packed panels read less cramped, identically in both themes. */
+.stat-row{gap:12px}
+.stat{padding:16px 10px}
+.ops-grid{gap:24px}
+.ops-card-head{padding:18px 20px}
 </style></head><body>
 <div class="page-tabs" role="tablist">
 <button class="page-tab active" role="tab" id="ptab-onboarding" aria-selected="true" data-panel="tab-onboarding">Onboarding</button>

--- a/v2/pkg/dashboard/contribute_prlink.go
+++ b/v2/pkg/dashboard/contribute_prlink.go
@@ -1,0 +1,225 @@
+package dashboard
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// PR→issue linking (#2612 part c). A LIVE, best-effort projection: for a given
+// "owner/repo#number" issue, does a pull request that references it (via a
+// Fixes/Closes/Resolves keyword, or any body/title mention) currently exist, and
+// is it open or already merged? There is NO new persistent store — this is
+// derived on demand from the GitHub data the hive is already authenticated for
+// (Server.deps.GHClient), cached only in-memory with a short TTL so the
+// triage/queue views stay cheap and never hammer the Search API. Every failure
+// degrades to "no linked PR" (nil): a slow or failing GitHub call must never
+// break a page or a panel.
+
+const (
+	// prLinkCacheTTL is how long a resolved (or resolved-empty) PR-link result is
+	// trusted before a re-lookup. Short enough that a freshly opened/merged PR
+	// surfaces within a minute or two, long enough that repeatedly rendering the
+	// triage view for a ~150-issue backlog does not re-hit the Search API on every
+	// request. Mirrors the "cheap cached projection" cadence of the metrics rollup.
+	prLinkCacheTTL = 90 * time.Second
+
+	// prLinkLookupTimeout bounds a single GitHub Search call so one slow response
+	// can never wedge the resolver (and, transitively, the triage endpoint). On
+	// timeout the issue degrades to "no linked PR" for this cycle and is retried
+	// after the TTL, exactly like an error.
+	prLinkLookupTimeout = 4 * time.Second
+
+	// prLinkStateOpen / prLinkStateMerged are the two surfaced link states. A PR
+	// that is closed-but-not-merged is treated as "no active link" (nil) — it did
+	// not land the fix and is not awaiting review — so only these two states ever
+	// reach the UI.
+	prLinkStateOpen   = "open"
+	prLinkStateMerged = "merged"
+)
+
+// prLinkStatus is the resolved fix-PR for one issue, or nil when none is linked.
+// Number/URL/State are the only fields the UI needs to render a small
+// "PR #NNN (open|merged)" badge and to feed the triage-level derivation.
+type prLinkStatus struct {
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+	State  string `json:"state"` // prLinkStateOpen | prLinkStateMerged
+}
+
+// prLinkCacheEntry is one memoised lookup. status may be nil (no linked PR); the
+// nil result is cached too so a genuinely-unlinked issue is not re-searched every
+// render within the TTL window.
+type prLinkCacheEntry struct {
+	status   *prLinkStatus
+	resolved time.Time
+}
+
+// prLinkResolver memoises issue→PR lookups behind a short TTL. It owns ONLY the
+// cache + the GitHub Search call; it holds no issue state of its own, so it is a
+// pure projection over live GitHub data. Safe for concurrent use.
+type prLinkResolver struct {
+	mu    sync.Mutex
+	cache map[string]prLinkCacheEntry
+	// now/lookup are overridable in tests so the resolver can be exercised against
+	// an httptest GitHub fake and a controllable clock without a real Server.
+	now    func() time.Time
+	lookup func(ctx context.Context, repo string, number int) (*prLinkStatus, error)
+}
+
+// newPRLinkResolver builds a resolver whose lookups run against the given
+// go-github client. A nil client yields a resolver that always returns "no linked
+// PR" (the degrade path), so callers never need to nil-check the GitHub wiring.
+func newPRLinkResolver(gc *gh.Client) *prLinkResolver {
+	r := &prLinkResolver{
+		cache: make(map[string]prLinkCacheEntry),
+		now:   time.Now,
+	}
+	r.lookup = func(ctx context.Context, repo string, number int) (*prLinkStatus, error) {
+		return searchLinkedPR(ctx, gc, repo, number)
+	}
+	return r
+}
+
+// prLinkKey is the canonical "owner/repo#number" cache/identity key, matching the
+// key format activeIssueKeys/selectTask use so a triage row and a fleet item line
+// up on the same string.
+func prLinkKey(repo string, number int) string {
+	return fmt.Sprintf("%s#%d", repo, number)
+}
+
+// resolve returns the cached PR-link for an issue, refreshing it through GitHub
+// when the entry is missing or past its TTL. On any lookup error it caches and
+// returns nil ("no linked PR") for the TTL window rather than propagating the
+// error, so a caller rendering a whole queue never fails on one bad issue.
+func (r *prLinkResolver) resolve(ctx context.Context, repo string, number int) *prLinkStatus {
+	if r == nil || repo == "" || number <= 0 {
+		return nil
+	}
+	key := prLinkKey(repo, number)
+
+	r.mu.Lock()
+	if e, ok := r.cache[key]; ok && r.now().Sub(e.resolved) < prLinkCacheTTL {
+		r.mu.Unlock()
+		return e.status
+	}
+	r.mu.Unlock()
+
+	lookup := r.lookup
+	var status *prLinkStatus
+	if lookup != nil {
+		lctx, cancel := context.WithTimeout(ctx, prLinkLookupTimeout)
+		s, err := lookup(lctx, repo, number)
+		cancel()
+		if err == nil {
+			status = s
+		}
+		// err != nil → status stays nil (degrade to "no linked PR"); still cached
+		// below so we don't retry a flapping call on every render within the TTL.
+	}
+
+	r.mu.Lock()
+	r.cache[key] = prLinkCacheEntry{status: status, resolved: r.now()}
+	r.mu.Unlock()
+	return status
+}
+
+// searchLinkedPR asks GitHub which PR (if any) references this issue. It runs ONE
+// Search.Issues query scoped to the issue's repo, matching PRs that mention the
+// issue number — GitHub indexes the Fixes/Closes/Resolves cross-reference as well
+// as any plain "#N" body/title mention, so the closing PR is included. A merged
+// PR wins over a merely-open one (the fix landed), so results are scanned for a
+// merged hit first, then an open one. A nil client or empty result is "no linked
+// PR" (nil, nil) — never an error the caller must handle.
+func searchLinkedPR(ctx context.Context, gc *gh.Client, repo string, number int) (*prLinkStatus, error) {
+	if gc == nil || repo == "" || number <= 0 {
+		return nil, nil
+	}
+	// repo is "owner/name". Scope the search to that repo and to PRs referencing
+	// the issue number. This is the same Search.Issues primitive the fleet-stats
+	// PR counters use; the "#N" qualifier is GitHub's own linked-reference index.
+	query := fmt.Sprintf("repo:%s type:pr %d", repo, number)
+	result, _, err := gc.Search.Issues(ctx, query, &gh.SearchOptions{
+		Sort:        "updated",
+		Order:       "desc",
+		ListOptions: gh.ListOptions{PerPage: prLinkSearchPerPage},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, nil
+	}
+
+	var open *prLinkStatus
+	for _, iss := range result.Issues {
+		if iss == nil || iss.PullRequestLinks == nil {
+			continue // search can return issues too; keep only PRs
+		}
+		if !prReferencesIssue(iss, number) {
+			continue
+		}
+		st := &prLinkStatus{Number: iss.GetNumber(), URL: iss.GetHTMLURL()}
+		// A closed PR that carries a merged_at (via PullRequestLinks) landed the
+		// fix — surface it as merged immediately (it also implies the issue is
+		// Closed in the triage ladder). Prefer it over any open candidate.
+		if iss.PullRequestLinks.MergedAt != nil {
+			st.State = prLinkStateMerged
+			return st, nil
+		}
+		if iss.GetState() == "open" && open == nil {
+			st.State = prLinkStateOpen
+			open = st
+		}
+	}
+	return open, nil
+}
+
+// prLinkSearchPerPage caps how many candidate PRs one lookup inspects. A handful
+// is plenty: a real issue has at most a few referencing PRs, and we only need to
+// know whether an open or merged one exists. Small page keeps the Search call
+// cheap and within a single request.
+const prLinkSearchPerPage = 10
+
+// prReferencesIssue guards against a coincidental number collision: the Search
+// "#N" match is broad, so confirm the PR actually names the issue as a reference
+// (Fixes/Closes/Resolves #N, or a bare #N mention) in its title or body before
+// treating it as the fix-PR. Missing body/title (search omits them on some
+// responses) is treated as a match, since the number qualifier already scoped it.
+func prReferencesIssue(iss *gh.Issue, number int) bool {
+	needle := fmt.Sprintf("#%d", number)
+	body := iss.GetBody()
+	title := iss.GetTitle()
+	if body == "" && title == "" {
+		return true
+	}
+	hay := title + "\n" + body
+	for _, tok := range strings.Fields(hay) {
+		// Trim trailing punctuation so "#123." / "#123," still match.
+		tok = strings.TrimRight(tok, ".,);:")
+		if tok == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// contributePRLinkResolver lazily builds the per-Server resolver, wired to the
+// hive's existing authenticated GitHub client. Guarded by a sync.Once so the
+// zero-value Server needs no constructor change (matching the lazy
+// contributeMetricsStore accessor). A missing GHClient yields a resolver whose
+// lookups degrade to nil, so the triage/queue views still render "no linked PR".
+func (s *Server) contributePRLinkResolver() *prLinkResolver {
+	s.contributePRLinkOnce.Do(func() {
+		var gc *gh.Client
+		if s.deps != nil && s.deps.GHClient != nil {
+			gc = s.deps.GHClient.GoGitHub()
+		}
+		s.contributePRLink = newPRLinkResolver(gc)
+	})
+	return s.contributePRLink
+}

--- a/v2/pkg/dashboard/contribute_queue_hold_test.go
+++ b/v2/pkg/dashboard/contribute_queue_hold_test.go
@@ -236,7 +236,7 @@ func TestQueueMoveToBottomAndHoldControlsPresent(t *testing.T) {
 		`cc-q-held`,                            // dimmed held-row class
 		`cc-q-held-tag`,                        // on-hold badge class
 		`on hold`,                              // badge text
-		`color-scheme:dark`,                    // visible spinner-arrow fix
+		`color-scheme:light dark`,              // theme-aware spinner-arrow fix (visible in both light + dark; #2612)
 		`.cc-q-moverow input[type=number]`,     // spinner fix targets the number input
 	} {
 		if !strings.Contains(body, want) {

--- a/v2/pkg/dashboard/contribute_triage.go
+++ b/v2/pkg/dashboard/contribute_triage.go
@@ -1,0 +1,261 @@
+package dashboard
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"strconv"
+)
+
+// Warp-style triage-level view (#2612 part b). A read-only, LIVE-DERIVED grouping
+// of the hive's contribute issues into a lifecycle ladder — Triaging → Ready to
+// implement → Implementing → Reviewing → Closed — computed on each request from
+// the SAME live signals the Operations tab already shows (the ready-work queue,
+// the fleet snapshot's in-flight work) plus the part-(c) PR→issue link. There is
+// NO persistent per-issue lifecycle store: a persisted lifecycle is a possible
+// future enhancement but is deliberately out of scope here (issues are transient,
+// sourced live from GitHub). The whole projection is recomputed per request and
+// stays cheap because the PR-link lookups it depends on are themselves cached
+// (prLinkResolver, short TTL) and degrade to "no linked PR" on any GitHub error.
+
+// Triage ladder levels. Ordered constants (the slice below fixes render order).
+const (
+	triageTriaging     = "triaging"     // open, unclaimed, no linked PR — awaiting triage
+	triageReady        = "ready"        // admitted to the ready queue, not yet picked up
+	triageImplementing = "implementing" // a clanker holds it, or an open linked PR exists
+	triageReviewing    = "reviewing"    // linked PR is open + not merged (awaiting review)
+	triageClosed       = "closed"       // issue closed, or its linked PR merged
+)
+
+// triageLevelOrder pins the ladder's render/count order (early → late lifecycle).
+var triageLevelOrder = []string{
+	triageTriaging, triageReady, triageImplementing, triageReviewing, triageClosed,
+}
+
+// triageLevelLabel is the human-facing name for each level, shown as the group
+// heading in the view. Kept beside the constants so the mapping is legible.
+var triageLevelLabel = map[string]string{
+	triageTriaging:     "Triaging",
+	triageReady:        "Ready to implement",
+	triageImplementing: "Implementing",
+	triageReviewing:    "Reviewing",
+	triageClosed:       "Closed",
+}
+
+// triageSignals is the live per-issue evidence deriveTriageLevel maps onto a
+// ladder rung. Every field is a projection over data the hive already has — the
+// ready queue, the fleet snapshot, and the (c) PR-link — so the derivation stays
+// a pure function of observable state with no hidden lookups.
+type triageSignals struct {
+	// closed is true when the issue itself is no longer open (GitHub state). The
+	// ready-queue/fleet sources only carry OPEN, admissible issues, so this is set
+	// only when a closed issue is surfaced explicitly (e.g. via a merged PR link).
+	closed bool
+	// inReadyQueue: the issue is admitted to the ready-work queue (ReadyQueue),
+	// i.e. it passed every admission/cooldown filter and is not in flight.
+	inReadyQueue bool
+	// inFleet: a connected clanker currently holds this issue as its task
+	// (FleetSnapshot().Work) — it is actively being implemented.
+	inFleet bool
+	// prLink is the resolved fix-PR for the issue (part c), or nil when none is
+	// linked. A merged link implies the work landed; an open link implies review.
+	prLink *prLinkStatus
+}
+
+// deriveTriageLevel maps live signals onto exactly one Warp-style ladder rung.
+// This is the ONE documented place the mapping lives, so it is legible and unit
+// testable. The precedence is late-lifecycle-first so the most-advanced evidence
+// wins: a merged PR (or a closed issue) is Closed even if the issue also lingers
+// in some stale queue; an open PR is Reviewing; active fleet work (or an open PR
+// with no review signal yet) is Implementing; an admitted-but-unclaimed queue
+// item is Ready; anything else open is Triaging.
+//
+//	Closed:       issue closed OR linked PR merged
+//	Reviewing:    linked PR open + not merged (awaiting review)
+//	Implementing: in-flight in the fleet, OR has an open linked PR
+//	Ready:        admitted to the ready queue, not yet picked up
+//	Triaging:     open, unclaimed, not queued, no linked PR
+func deriveTriageLevel(sig triageSignals) string {
+	// Closed wins outright: the fix landed (merged PR) or the issue is done.
+	if sig.closed || (sig.prLink != nil && sig.prLink.State == prLinkStateMerged) {
+		return triageClosed
+	}
+	// An open linked PR means a fix is up and awaiting review.
+	if sig.prLink != nil && sig.prLink.State == prLinkStateOpen {
+		// A PR that is up is being implemented/reviewed; if the issue is ALSO held
+		// by a clanker it is squarely Implementing, otherwise it is in Reviewing.
+		if sig.inFleet {
+			return triageImplementing
+		}
+		return triageReviewing
+	}
+	// A clanker actively holds it → Implementing.
+	if sig.inFleet {
+		return triageImplementing
+	}
+	// Admitted to the ready queue but not yet picked up → Ready to implement.
+	if sig.inReadyQueue {
+		return triageReady
+	}
+	// Open, unclaimed, unqueued, unlinked → still Triaging.
+	return triageTriaging
+}
+
+// triageIssue is one issue placed on the ladder, carrying just enough metadata to
+// render a row (and its optional PR badge). It is the wire shape the triage
+// endpoint returns and the render helper consumes.
+type triageIssue struct {
+	Repo   string        `json:"repo"`
+	Number int           `json:"number"`
+	Title  string        `json:"title"`
+	URL    string        `json:"url,omitempty"`
+	Level  string        `json:"level"`
+	PR     *prLinkStatus `json:"pr,omitempty"`
+}
+
+// triageGroup is one ladder rung: its level id/label, the issues on it, and the
+// count (== len(Issues), echoed so a client can show a count without the list).
+type triageGroup struct {
+	Level  string        `json:"level"`
+	Label  string        `json:"label"`
+	Count  int           `json:"count"`
+	Issues []triageIssue `json:"issues"`
+}
+
+// triageSnapshot is the full projection: the ordered ladder groups plus the total
+// count of placed issues. Recomputed per request; never persisted.
+type triageSnapshot struct {
+	Groups []triageGroup `json:"groups"`
+	Total  int           `json:"total"`
+}
+
+// maxTriageIssuesPerLevel bounds how many issues each rung lists in the response,
+// so a pathological backlog cannot blow out the JSON/DOM. The count still reflects
+// the true total on the rung; only the enumerated list is capped (matching how the
+// ready-queue caps its own visible list). Generous enough to show a real backlog.
+const maxTriageIssuesPerLevel = 60
+
+// buildTriageSnapshot derives the ladder live from the ready queue + fleet snapshot
+// + the PR-link resolver. It issues a bounded PR-link lookup per candidate issue
+// (cached, short-TTL, degrade-to-nil) — never blocking on GitHub — and groups the
+// results by deriveTriageLevel. Read-only; assigns nothing, persists nothing.
+func (s *Server) buildTriageSnapshot(ctx context.Context) triageSnapshot {
+	snap := triageSnapshot{}
+	if s == nil || s.contributeHub == nil {
+		// Still return the empty ladder (all rungs, zero counts) so the UI renders a
+		// stable, non-error shell.
+		return emptyTriageSnapshot()
+	}
+
+	resolver := s.contributePRLinkResolver()
+
+	// In-flight work (Implementing candidates) from the fleet snapshot, keyed the
+	// same way activeIssueKeys/selectTask key issues so a fleet item and a queue
+	// item line up on the same identity string.
+	fleetKeys := map[string]bool{}
+	fleetItems := map[string]triageIssue{}
+	for _, w := range s.contributeHub.FleetSnapshot().Work {
+		if w.Repo == "" || w.Number <= 0 {
+			continue
+		}
+		key := prLinkKey(w.Repo, w.Number)
+		fleetKeys[key] = true
+		fleetItems[key] = triageIssue{Repo: w.Repo, Number: w.Number, Title: w.Title, URL: issueURLFor(w.Repo, w.Number)}
+	}
+
+	// Ready-work queue (Ready / Reviewing / Implementing-via-PR candidates).
+	byLevel := map[string][]triageIssue{}
+	seen := map[string]bool{}
+
+	place := func(it triageIssue, sig triageSignals) {
+		key := prLinkKey(it.Repo, it.Number)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		it.PR = sig.prLink
+		it.Level = deriveTriageLevel(sig)
+		byLevel[it.Level] = append(byLevel[it.Level], it)
+	}
+
+	for _, q := range s.contributeHub.ReadyQueue(readyQueueDefaultLimit) {
+		key := prLinkKey(q.Repo, q.Number)
+		pr := resolver.resolve(ctx, q.Repo, q.Number)
+		place(triageIssue{Repo: q.Repo, Number: q.Number, Title: q.Title, URL: q.URL}, triageSignals{
+			inReadyQueue: true,
+			inFleet:      fleetKeys[key],
+			prLink:       pr,
+		})
+	}
+
+	// Fleet items not already placed via the queue (an in-flight issue is excluded
+	// from the ready queue by design, so it is surfaced here).
+	for key, it := range fleetItems {
+		if seen[key] {
+			continue
+		}
+		pr := resolver.resolve(ctx, it.Repo, it.Number)
+		place(it, triageSignals{inFleet: true, prLink: pr})
+	}
+
+	// Assemble the ordered ladder. Every rung is always present (even at zero) so
+	// the view is a stable shape; per-rung lists are sorted (repo, number) for a
+	// deterministic render and capped.
+	for _, level := range triageLevelOrder {
+		items := byLevel[level]
+		sort.Slice(items, func(i, j int) bool {
+			if items[i].Repo != items[j].Repo {
+				return items[i].Repo < items[j].Repo
+			}
+			return items[i].Number < items[j].Number
+		})
+		count := len(items)
+		if len(items) > maxTriageIssuesPerLevel {
+			items = items[:maxTriageIssuesPerLevel]
+		}
+		snap.Groups = append(snap.Groups, triageGroup{
+			Level:  level,
+			Label:  triageLevelLabel[level],
+			Count:  count,
+			Issues: items,
+		})
+		snap.Total += count
+	}
+	return snap
+}
+
+// emptyTriageSnapshot returns the ladder with every rung present and empty, used
+// when there is no contribute hub to derive from so the UI still renders a stable
+// (zero-count) shell rather than an error.
+func emptyTriageSnapshot() triageSnapshot {
+	snap := triageSnapshot{}
+	for _, level := range triageLevelOrder {
+		snap.Groups = append(snap.Groups, triageGroup{
+			Level:  level,
+			Label:  triageLevelLabel[level],
+			Count:  0,
+			Issues: []triageIssue{},
+		})
+	}
+	return snap
+}
+
+// issueURLFor builds the canonical GitHub issue URL for a "owner/repo" + number,
+// used when a source (the fleet snapshot) does not already carry a URL so the
+// triage row can still link out.
+func issueURLFor(repo string, number int) string {
+	if repo == "" || number <= 0 {
+		return ""
+	}
+	return "https://github.com/" + repo + "/issues/" + strconv.Itoa(number)
+}
+
+// handleContributeTriage serves the live triage-ladder projection as JSON. GET
+// only, read-only, public within the /api/contribute* surface (same posture as
+// /queue and /fleet — it exposes only public issue metadata + public PR numbers,
+// no tokens, no PII). The Operations-tab triage card fetches this after page load
+// so a slow GitHub PR-link lookup never delays the page render.
+func (s *Server) handleContributeTriage(w http.ResponseWriter, r *http.Request) {
+	snap := s.buildTriageSnapshot(r.Context())
+	jsonResponse(w, snap)
+}

--- a/v2/pkg/dashboard/contribute_triage_test.go
+++ b/v2/pkg/dashboard/contribute_triage_test.go
@@ -1,0 +1,287 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// TestDeriveTriageLevel table-tests the ONE documented mapping from live signals
+// onto the Warp-style ladder, covering every level and the precedence boundaries
+// (merged-PR/closed win over everything; open PR splits Reviewing vs Implementing;
+// fleet vs queue vs neither).
+func TestDeriveTriageLevel(t *testing.T) {
+	openPR := &prLinkStatus{Number: 10, State: prLinkStateOpen}
+	mergedPR := &prLinkStatus{Number: 11, State: prLinkStateMerged}
+
+	cases := []struct {
+		name string
+		sig  triageSignals
+		want string
+	}{
+		{"open unclaimed unqueued no-pr -> triaging", triageSignals{}, triageTriaging},
+		{"admitted to ready queue -> ready", triageSignals{inReadyQueue: true}, triageReady},
+		{"in fleet -> implementing", triageSignals{inFleet: true}, triageImplementing},
+		{"in fleet even if also queued -> implementing", triageSignals{inFleet: true, inReadyQueue: true}, triageImplementing},
+		{"open linked PR, not in fleet -> reviewing", triageSignals{prLink: openPR}, triageReviewing},
+		{"open linked PR while queued -> reviewing", triageSignals{prLink: openPR, inReadyQueue: true}, triageReviewing},
+		{"open linked PR AND in fleet -> implementing", triageSignals{prLink: openPR, inFleet: true}, triageImplementing},
+		{"merged linked PR -> closed", triageSignals{prLink: mergedPR}, triageClosed},
+		{"merged PR wins over fleet+queue -> closed", triageSignals{prLink: mergedPR, inFleet: true, inReadyQueue: true}, triageClosed},
+		{"issue closed -> closed", triageSignals{closed: true}, triageClosed},
+		{"issue closed wins over open PR -> closed", triageSignals{closed: true, prLink: openPR}, triageClosed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := deriveTriageLevel(tc.sig); got != tc.want {
+				t.Errorf("deriveTriageLevel(%+v) = %q, want %q", tc.sig, got, tc.want)
+			}
+		})
+	}
+}
+
+// newPRLinkTestResolver builds a resolver whose lookups hit a go-github client
+// pointed at the given httptest server, with a fixed clock so TTL behaviour is
+// deterministic.
+func newPRLinkTestResolver(serverURL string) *prLinkResolver {
+	gc := ghpkg.NewClientForTest(serverURL, "testorg", []string{"testorg/repo"}, slog.Default()).GoGitHub()
+	r := newPRLinkResolver(gc)
+	fixed := time.Unix(1700000000, 0)
+	r.now = func() time.Time { return fixed }
+	return r
+}
+
+// searchIssuesResponse builds a /search/issues body with the given PR items.
+func searchIssuesResponse(items ...map[string]any) map[string]any {
+	return map[string]any{"total_count": len(items), "items": items}
+}
+
+// TestPRLinkResolver_Open resolves an OPEN linked PR referencing the issue.
+func TestPRLinkResolver_Open(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(searchIssuesResponse(map[string]any{
+			"number":       77,
+			"state":        "open",
+			"title":        "Fix the thing",
+			"body":         "Fixes #123",
+			"html_url":     "https://github.com/testorg/repo/pull/77",
+			"pull_request": map[string]any{"url": "https://api.github.com/repos/testorg/repo/pulls/77"},
+		}))
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	r := newPRLinkTestResolver(ts.URL)
+	got := r.resolve(context.Background(), "testorg/repo", 123)
+	if got == nil {
+		t.Fatal("expected a linked PR, got nil")
+	}
+	if got.Number != 77 || got.State != prLinkStateOpen {
+		t.Errorf("got %+v, want #77 open", got)
+	}
+}
+
+// TestPRLinkResolver_Merged resolves a MERGED linked PR (merged_at set), which
+// must win even if an open PR is also present.
+func TestPRLinkResolver_Merged(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(searchIssuesResponse(
+			map[string]any{
+				"number":       80,
+				"state":        "open",
+				"body":         "Also touches #123",
+				"html_url":     "https://github.com/testorg/repo/pull/80",
+				"pull_request": map[string]any{"url": "x"},
+			},
+			map[string]any{
+				"number":       81,
+				"state":        "closed",
+				"body":         "Closes #123",
+				"html_url":     "https://github.com/testorg/repo/pull/81",
+				"pull_request": map[string]any{"url": "y", "merged_at": "2024-01-02T03:04:05Z"},
+			},
+		))
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	r := newPRLinkTestResolver(ts.URL)
+	got := r.resolve(context.Background(), "testorg/repo", 123)
+	if got == nil {
+		t.Fatal("expected a linked PR, got nil")
+	}
+	if got.Number != 81 || got.State != prLinkStateMerged {
+		t.Errorf("got %+v, want #81 merged", got)
+	}
+}
+
+// TestPRLinkResolver_None returns nil when no PR references the issue (the search
+// hit is a plain issue, not a PR, and/or references a different number).
+func TestPRLinkResolver_None(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		// An item with no pull_request object is an issue, not a PR — must be ignored.
+		_ = json.NewEncoder(w).Encode(searchIssuesResponse(map[string]any{
+			"number": 5, "state": "open", "body": "mentions #123 but is an issue",
+		}))
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	r := newPRLinkTestResolver(ts.URL)
+	if got := r.resolve(context.Background(), "testorg/repo", 123); got != nil {
+		t.Errorf("expected no linked PR, got %+v", got)
+	}
+}
+
+// TestPRLinkResolver_ErrorDegrades proves a GitHub failure degrades gracefully to
+// "no linked PR" (nil) instead of propagating an error or panicking.
+func TestPRLinkResolver_ErrorDegrades(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	r := newPRLinkTestResolver(ts.URL)
+	if got := r.resolve(context.Background(), "testorg/repo", 123); got != nil {
+		t.Errorf("expected nil on GitHub error, got %+v", got)
+	}
+}
+
+// TestPRLinkResolver_NilClientDegrades proves a resolver with no GitHub client
+// (the missing-wiring path) returns nil rather than panicking.
+func TestPRLinkResolver_NilClientDegrades(t *testing.T) {
+	r := newPRLinkResolver(nil)
+	if got := r.resolve(context.Background(), "testorg/repo", 123); got != nil {
+		t.Errorf("expected nil with no GH client, got %+v", got)
+	}
+}
+
+// TestPRLinkResolver_Caches proves a second resolve within the TTL does NOT hit
+// GitHub again (the cached result is reused).
+func TestPRLinkResolver_Caches(t *testing.T) {
+	var calls int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_ = json.NewEncoder(w).Encode(searchIssuesResponse(map[string]any{
+			"number":       9,
+			"state":        "open",
+			"body":         "Fixes #123",
+			"html_url":     "https://github.com/testorg/repo/pull/9",
+			"pull_request": map[string]any{"url": "x"},
+		}))
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	r := newPRLinkTestResolver(ts.URL) // fixed clock -> always within TTL
+	_ = r.resolve(context.Background(), "testorg/repo", 123)
+	_ = r.resolve(context.Background(), "testorg/repo", 123)
+	if calls != 1 {
+		t.Errorf("expected 1 GitHub call (second served from cache), got %d", calls)
+	}
+}
+
+// TestBuildTriageSnapshotEmptyShell proves that with no contribute hub the builder
+// still returns the full ladder (every rung present, zero counts) so the UI has a
+// stable shape.
+func TestBuildTriageSnapshotEmptyShell(t *testing.T) {
+	s := NewServer(0, slog.Default())
+	snap := s.buildTriageSnapshot(context.Background())
+	if len(snap.Groups) != len(triageLevelOrder) {
+		t.Fatalf("expected %d groups, got %d", len(triageLevelOrder), len(snap.Groups))
+	}
+	for i, g := range snap.Groups {
+		if g.Level != triageLevelOrder[i] {
+			t.Errorf("group %d level = %q, want %q", i, g.Level, triageLevelOrder[i])
+		}
+		if g.Count != 0 || len(g.Issues) != 0 {
+			t.Errorf("group %q should be empty, got count=%d issues=%d", g.Level, g.Count, len(g.Issues))
+		}
+	}
+	if snap.Total != 0 {
+		t.Errorf("empty snapshot total = %d, want 0", snap.Total)
+	}
+}
+
+// TestContributeTriageRenderMarkup asserts the triage SECTION (inside Operations,
+// not a new tab) and the PR-badge machinery render into the served page: the card,
+// the ladder container, the per-level groups container, the JS poll + badge
+// helpers, and the triage endpoint wiring.
+func TestContributeTriageRenderMarkup(t *testing.T) {
+	body := renderContributePage(t)
+
+	for _, want := range []string{
+		// Triage card lives INSIDE the Operations tab panel (a section, not a tab).
+		`id="cc-triage-card"`,
+		`<h3>Issue triage</h3>`,
+		`id="cc-triage-ladder"`,
+		`id="cc-triage-groups"`,
+		// Client wiring: the poll + render + PR-badge helpers and the endpoint.
+		`function ccTriagePoll(`,
+		`function ccRenderTriage(`,
+		`function ccPRBadgeHTML(`,
+		`/api/contribute/triage`,
+		// The five ladder levels are named client-side in lifecycle order.
+		`['triaging','Triaging']`,
+		`['ready','Ready to implement']`,
+		`['implementing','Implementing']`,
+		`['reviewing','Reviewing']`,
+		`['closed','Closed']`,
+		// PR badge CSS classes (part c) present for open/merged states.
+		`.cc-pr-badge.pr-open`,
+		`.cc-pr-badge.pr-merged`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("rendered page missing triage/PR-link marker %q", want)
+		}
+	}
+
+	// The triage card must sit inside the Operations panel (#tab-ops), before the
+	// leaderboard panel — i.e. it is a section OF Operations, not a separate tab.
+	ops := strings.Index(body, `id="tab-ops"`)
+	card := strings.Index(body, `id="cc-triage-card"`)
+	lb := strings.Index(body, `id="tab-leaderboard"`)
+	if !(ops >= 0 && card > ops && (lb < 0 || card < lb)) {
+		t.Errorf("triage card is not inside the Operations panel (ops=%d card=%d lb=%d)", ops, card, lb)
+	}
+}
+
+// TestContributeTriageEndpoint hits the JSON endpoint and asserts it returns the
+// full ladder shape (all levels present), read-only, 200.
+func TestContributeTriageEndpoint(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/triage", nil)
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var snap triageSnapshot
+	if err := json.Unmarshal(rec.Body.Bytes(), &snap); err != nil {
+		t.Fatalf("triage response not valid JSON: %v", err)
+	}
+	if len(snap.Groups) != len(triageLevelOrder) {
+		t.Fatalf("expected %d ladder groups, got %d", len(triageLevelOrder), len(snap.Groups))
+	}
+	for i, want := range triageLevelOrder {
+		if snap.Groups[i].Level != want {
+			t.Errorf("group %d = %q, want %q", i, snap.Groups[i].Level, want)
+		}
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -168,6 +168,14 @@ type Server struct {
 	contributeMetricsOnce sync.Once
 	contributeMetrics     *metricsStore
 
+	// contributePRLink is the live, best-effort PR→issue link projection behind the
+	// Operations triage view + queue PR badges (#2612 part c). It memoises "does a
+	// Fixes/Closes PR exist for owner/repo#number, open or merged?" behind a short
+	// TTL over the hive's existing GitHub client — NO new persistent store. Lazily
+	// built via contributePRLinkResolver(); see contribute_prlink.go.
+	contributePRLinkOnce sync.Once
+	contributePRLink     *prLinkResolver
+
 	inferenceMu        sync.RWMutex
 	inferenceEndpoints map[string][]string // backend id → list of base URLs
 


### PR DESCRIPTION
Implements the `/contribute` dashboard improvements requested in #2612, scoped to **(b) Warp-style triage-level view, (c) PR→issue linking, (d) light-mode theming + polish**. Deliberately **not** included: the 3-page dashboard split (option a from the projectbluefin epic) — the maintainer is not comfortable splitting `/contribute` into separate pages yet.

All three parts are **additive** and require **no new persistent store** — the triage ladder and PR links are derived **live** from data the hive already has (the ready queue, the fleet snapshot, and the existing GitHub client).

## (d) Light theming + polish
- Adds a `:root` custom-property palette (`--cc-bg/surface/border/text/muted/…`) whose defaults are the **original dark hex, byte-for-byte**, then mechanically replaces the neutral surface/border/text ramp across the inline `<style>` with `var(--cc-*)`. Dark appearance is unchanged.
- Light mode activates on **both signals**: `@media (prefers-color-scheme: light) :root:not([data-theme="dark"])` **and** `:root[data-theme="light"]`, using Primer-light neutrals that blend with the surrounding Docusaurus docs. `data-theme="dark"` always wins back to dark. (A future in-page toggle can flip `data-theme`; the toggle itself is out of scope.)
- Light-mode fixups for the handful of dark one-off gradient/hover surfaces + a gentle contrast lift on the muted status pills so they stay legible on white. Conservative uniform spacing bump on the densest grids. No card removed, no structural change, no theme toggle.

## (c) PR→issue linking (live, no store)
- A best-effort projection resolving, per issue, whether a **Fixes/Closes PR is open or merged**, over the hive's existing authenticated GitHub client (`Search.Issues`). Memoised behind a short TTL (`prLinkCacheTTL`), bounded per-lookup timeout, and **degrades to "no linked PR"** on any error/timeout — it never blocks a page or panel render, and never logs tokens.
- Surfaced as a small **"PR #NNN (open|merged)"** badge on queue + triage rows.

## (b) Warp-style triage view (live-derived)
- A **section within the existing Operations tab** (not a new page/tab) grouping issues into a ladder: **Triaging → Ready to implement → Implementing → Reviewing → Closed**.
- `deriveTriageLevel()` is the **single documented mapping** over the ready queue + fleet snapshot + the (c) PR-link. The ladder is a read-only projection served by `GET /api/contribute/triage`, recomputed per request and fetched after page load so a slow GitHub call never delays the page.
- A **persisted per-issue lifecycle store is a possible future enhancement, out of scope here** (issues are transient, sourced live from GitHub).

## Also
- Nil-guards `ContributeWSHub.cleanupLoop`'s `c.ws.Close()`: a stale connection with a nil socket could SIGSEGV the whole process from that background goroutine. (Upstream landed the identical guard concurrently; reconciled during rebase.)

## Tests
- `deriveTriageLevel` table test (every level + precedence boundaries).
- PR-link resolver against an httptest GitHub fake: open / merged / none / error-degrades / nil-client / cache-hit.
- Triage endpoint shape + render markup + PR-badge presence; the triage card is asserted to live **inside** the Operations panel.
- `go test -race ./pkg/dashboard/...` green; no shared package-global mutated across tests.

Fixes #2612