### PR TITLE
security(proxy): SO_MARK self-exemption so F5 forced egress works on OpenShift/OVN (no xt_owner)

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -6,6 +6,17 @@ export HIVE_API_PORT="${HIVE_API_PORT:-3002}"
 export HIVE_PROXY_PORT="${HIVE_PROXY_PORT:-3001}"
 export HIVE_STATIC_DIR="${HIVE_STATIC_DIR:-/opt/hive/proxy/public}"
 
+# Packet mark (fwmark / SO_MARK) used to exempt the MITM proxy's OWN upstream
+# :443 dials from the forced-egress redirect, so its traffic is not looped back
+# into itself. This is the SINGLE SOURCE OF TRUTH: it is exported here (in both
+# the root and the re-exec'd dev pass) so the iptables `-m mark --mark` exemption
+# below and the Go proxy (which reads HIVE_PROXY_EGRESS_MARK, defaulting to this
+# same 0x1112) stay in lockstep. Unlike `-m owner --uid-owner`, a packet mark
+# needs no xt_owner kernel module, so the exemption works on BOTH OKE and
+# OpenShift/OVN (where xt_owner is absent). Value is arbitrary but must match the
+# Go default (proxy.defaultProxyEgressMark).
+export HIVE_PROXY_EGRESS_MARK="${HIVE_PROXY_EGRESS_MARK:-0x1112}"
+
 # ── Config backup/restore across container recreation ─────────────────
 # When Watchtower recreates the container (pull new image, stop old, start
 # new), the Go binary's config.Save() may write an empty/default config to
@@ -709,13 +720,37 @@ print('[entrypoint] UID map written to /var/run/hive/uid-map.json')
     PROXY_PORT=18443
     PROXY_ADVISORY_OK="${HIVE_PROXY_ADVISORY_OK:-false}"
     _iptables_ok=false
-    if command -v iptables >/dev/null 2>&1; then
-      if iptables -t nat -N HIVE_PROXY 2>/dev/null; then
-        iptables -t nat -A HIVE_PROXY -m owner --uid-owner 0 -j RETURN
-        iptables -t nat -A HIVE_PROXY -m owner --uid-owner "$PROXY_UID" -j RETURN
-        iptables -t nat -A HIVE_PROXY -p tcp --dport 443 -j REDIRECT --to-ports "$PROXY_PORT"
-        iptables -t nat -A OUTPUT -j HIVE_PROXY
-        echo "[entrypoint] iptables: outbound :443 -> :${PROXY_PORT} (proxy UID ${PROXY_UID} exempt)"
+
+    # Select the iptables binary. Both OKE and OpenShift/RHEL9 hosts run the
+    # kernel in nft mode, where the legacy `iptables` (xtables-legacy) backend
+    # cannot write the nat table the node actually consults. Prefer the explicit
+    # nft binary; fall back to plain `iptables` (which on these images is a
+    # symlink to xtables-nft-multi anyway, so it resolves to nft).
+    IPT=""
+    if command -v iptables-nft >/dev/null 2>&1; then
+      IPT="iptables-nft"
+    elif command -v iptables >/dev/null 2>&1; then
+      IPT="iptables"
+    fi
+
+    if [ -n "$IPT" ]; then
+      # Self-exemption is by PACKET MARK only. The Go proxy stamps SO_MARK
+      # (HIVE_PROXY_EGRESS_MARK, exported above) on its own upstream :443 dials,
+      # and this rule RETURNs marked packets before the redirect so the proxy's
+      # traffic is not looped back into itself.
+      #
+      # We deliberately DROP the previous `-m owner --uid-owner` exemptions:
+      # the owner match requires the xt_owner kernel module, which is ABSENT on
+      # OpenShift/OVN nodes. There, `-A ... -m owner` fails (non-zero), which —
+      # because the whole chain build is gated on success below — would flip the
+      # F5 fatal check and crash-loop every OpenShift hive. SO_MARK covers the
+      # self-exemption on BOTH platforms with no owner match, so the ruleset now
+      # succeeds on a host WITHOUT xt_owner.
+      if $IPT -t nat -N HIVE_PROXY 2>/dev/null; then
+        $IPT -t nat -A HIVE_PROXY -m mark --mark "$HIVE_PROXY_EGRESS_MARK" -j RETURN
+        $IPT -t nat -A HIVE_PROXY -p tcp --dport 443 -j REDIRECT --to-ports "$PROXY_PORT"
+        $IPT -t nat -A OUTPUT -j HIVE_PROXY
+        echo "[entrypoint] iptables ($IPT): outbound :443 -> :${PROXY_PORT} (proxy egress mark ${HIVE_PROXY_EGRESS_MARK} exempt)"
         _iptables_ok=true
         # Update uid-map to record iptables active
         python3 -c "

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -19,8 +19,10 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/agent"
@@ -32,7 +34,62 @@ const (
 	InferenceTranslatePort = 18444
 	modeFilePrefix         = "/tmp/.hive-mode-"
 	maxViolationLog        = 1000
+
+	// defaultProxyEgressMark is the fwmark (SO_MARK) the proxy stamps onto its
+	// OWN upstream :443 dials so the forced-egress iptables redirect can exempt
+	// them (via `-m mark --mark <mark> -j RETURN`) and avoid looping the proxy's
+	// traffic back into itself.
+	//
+	// This replaces the `-m owner --uid-owner` self-exemption, which needs the
+	// xt_owner kernel module — absent on OpenShift/OVN nodes. A packet mark works
+	// on both OKE and OpenShift. The value is arbitrary but MUST match the mark
+	// the entrypoint exempts; entrypoint.sh is the single source of truth and
+	// exports HIVE_PROXY_EGRESS_MARK (defaulting to this same value) into the
+	// proxy process, which reads it via proxyEgressMark().
+	defaultProxyEgressMark = 0x1112
+
+	// proxyEgressMarkEnv is the env var the entrypoint exports to keep the proxy
+	// and the iptables rule in sync from one source of truth.
+	proxyEgressMarkEnv = "HIVE_PROXY_EGRESS_MARK"
 )
+
+// proxyEgressMark returns the fwmark to stamp on the proxy's upstream dials,
+// read from HIVE_PROXY_EGRESS_MARK (set by entrypoint.sh) so the Go proxy and
+// the iptables exemption stay in lockstep. Accepts hex (0x1112) or decimal.
+// Falls back to defaultProxyEgressMark when unset or unparseable — that default
+// matches the entrypoint default, so an accidental drift fails safe by staying
+// on the agreed value rather than silently disabling the exemption.
+func proxyEgressMark() int {
+	raw := strings.TrimSpace(os.Getenv(proxyEgressMarkEnv))
+	if raw == "" {
+		return defaultProxyEgressMark
+	}
+	// ParseInt with base 0 honours a 0x prefix (hex) and plain decimal.
+	if v, err := strconv.ParseInt(raw, 0, 64); err == nil && v > 0 {
+		return int(v)
+	}
+	return defaultProxyEgressMark
+}
+
+// markDialer returns a *net.Dialer whose Control hook stamps the proxy egress
+// fwmark (SO_MARK) on the outbound socket before connect. On non-Linux builds
+// setSockMark is a no-op, so the dialer is portable. The optional timeout is
+// applied when non-zero.
+func markDialer(timeout time.Duration) *net.Dialer {
+	mark := proxyEgressMark()
+	return &net.Dialer{
+		Timeout: timeout,
+		Control: func(_, _ string, c syscall.RawConn) error {
+			var sockErr error
+			if err := c.Control(func(fd uintptr) {
+				sockErr = setSockMark(fd, mark)
+			}); err != nil {
+				return err
+			}
+			return sockErr
+		},
+	}
+}
 
 // CACertPath and caKeyPath are the PVC locations of the persisted MITM CA.
 // They are vars rather than consts solely so tests can redirect the CA
@@ -91,7 +148,10 @@ func (p *GitHubProxy) dialCopilotUpstream(host string) (net.Conn, error) {
 	if p.copilotDial != nil {
 		return p.copilotDial(host)
 	}
-	return tls.Dial("tcp", net.JoinHostPort(host, "443"), &tls.Config{ServerName: host})
+	// SO_MARK the outbound socket so the forced-egress redirect exempts the
+	// proxy's own upstream traffic (see proxyEgressMark). The override hook above
+	// still wins when set, so tests are unaffected.
+	return tls.DialWithDialer(markDialer(0), "tcp", net.JoinHostPort(host, "443"), &tls.Config{ServerName: host})
 }
 
 // SetTokenSink wires the inference token sink so the translator can record
@@ -289,8 +349,9 @@ func (p *GitHubProxy) handleTransparentTLS(conn net.Conn, peeked []byte) {
 	}
 
 	if !IsGitHubHost(host) || !NeedsMITM(host) {
-		// Non-GitHub or non-API GitHub host: tunnel directly.
-		upstream, err := net.DialTimeout("tcp", host+":443", transparentProxyTimeout)
+		// Non-GitHub or non-API GitHub host: tunnel directly. SO_MARK the socket
+		// so the forced-egress redirect exempts this proxy-originated dial.
+		upstream, err := markDialer(transparentProxyTimeout).Dial("tcp", host+":443")
 		if err != nil {
 			return
 		}
@@ -327,7 +388,7 @@ func (p *GitHubProxy) handleTransparentTLS(conn net.Conn, peeked []byte) {
 	}
 	defer tlsClientConn.Close()
 
-	upstreamConn, err := tls.Dial("tcp", host+":443", &tls.Config{ServerName: host})
+	upstreamConn, err := tls.DialWithDialer(markDialer(0), "tcp", host+":443", &tls.Config{ServerName: host})
 	if err != nil {
 		p.logger.Error("transparent proxy upstream dial failed", "host", host, "error", err)
 		return
@@ -562,8 +623,9 @@ func (p *GitHubProxy) handleConnectDirect(conn net.Conn, r *http.Request) {
 	}
 	defer tlsClientConn.Close()
 
-	// Connect to the real GitHub server.
-	upstreamConn, err := tls.Dial("tcp", r.Host, &tls.Config{
+	// Connect to the real GitHub server. SO_MARK the socket so the forced-egress
+	// redirect exempts this proxy-originated dial (see proxyEgressMark).
+	upstreamConn, err := tls.DialWithDialer(markDialer(0), "tcp", r.Host, &tls.Config{
 		ServerName: host,
 	})
 	if err != nil {
@@ -709,7 +771,9 @@ func isGitPath(path string) bool {
 // tunnelDirect creates a raw TCP tunnel for non-GitHub CONNECT requests.
 func (p *GitHubProxy) tunnelDirect(conn net.Conn, r *http.Request) {
 	const tunnelDialTimeout = 10 * time.Second
-	upstream, err := net.DialTimeout("tcp", r.Host, tunnelDialTimeout)
+	// SO_MARK the socket so the forced-egress redirect exempts this
+	// proxy-originated tunnel dial (CONNECT targets include :443).
+	upstream, err := markDialer(tunnelDialTimeout).Dial("tcp", r.Host)
 	if err != nil {
 		p.logger.Warn("proxy: CONNECT dial failed", "host", r.Host, "error", err)
 		fmt.Fprintf(conn, "HTTP/1.1 502 Bad Gateway\r\n\r\nconnection failed\n")

--- a/v2/pkg/proxy/somark_linux.go
+++ b/v2/pkg/proxy/somark_linux.go
@@ -1,0 +1,20 @@
+//go:build linux
+
+package proxy
+
+import (
+	"syscall"
+)
+
+// setSockMark sets SO_MARK on the raw socket file descriptor. The kernel then
+// stamps every packet the socket emits with this fwmark, which the entrypoint's
+// iptables nat/OUTPUT rule matches (-m mark --mark <mark> -j RETURN) to exempt
+// the proxy's OWN upstream traffic from the :443 -> :18443 redirect, so it does
+// not loop back into itself.
+//
+// Unlike `-m owner --uid-owner`, packet marks do NOT require the xt_owner kernel
+// module, which is absent on OpenShift/OVN nodes. The mark exemption is the
+// single self-exemption mechanism that works on both OKE and OpenShift.
+func setSockMark(fd uintptr, mark int) error {
+	return syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_MARK, mark)
+}

--- a/v2/pkg/proxy/somark_other.go
+++ b/v2/pkg/proxy/somark_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package proxy
+
+// setSockMark is a no-op on non-Linux platforms: SO_MARK is a Linux-only socket
+// option. The proxy only runs inside the Linux container, but the package must
+// still compile on the CI build matrix (and on developer darwin machines), so
+// this stub keeps the mark-setting dialer portable.
+func setSockMark(fd uintptr, mark int) error {
+	return nil
+}

--- a/v2/pkg/proxy/somark_test.go
+++ b/v2/pkg/proxy/somark_test.go
@@ -1,0 +1,78 @@
+package proxy
+
+import (
+	"errors"
+	"net"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestProxyEgressMarkDefault verifies the mark resolves to the documented
+// default when the env var is unset, keeping the Go proxy and entrypoint in
+// lockstep on the agreed value.
+func TestProxyEgressMarkDefault(t *testing.T) {
+	t.Setenv(proxyEgressMarkEnv, "")
+	if got := proxyEgressMark(); got != defaultProxyEgressMark {
+		t.Fatalf("proxyEgressMark() default = %#x, want %#x", got, defaultProxyEgressMark)
+	}
+}
+
+// TestProxyEgressMarkEnvOverride verifies HIVE_PROXY_EGRESS_MARK overrides the
+// default in both hex and decimal forms, and that a garbage value fails safe
+// back to the default rather than disabling the exemption.
+func TestProxyEgressMarkEnvOverride(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"hex", "0x2223", 0x2223},
+		{"decimal", "8739", 8739},
+		{"garbage falls back", "not-a-number", defaultProxyEgressMark},
+		{"zero falls back", "0", defaultProxyEgressMark},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(proxyEgressMarkEnv, tc.env)
+			if got := proxyEgressMark(); got != tc.want {
+				t.Fatalf("proxyEgressMark(%q) = %#x, want %#x", tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMarkDialerControlRuns exercises the mark dialer's Control hook against a
+// real loopback listener. The Control func must run and set SO_MARK (a no-op on
+// non-Linux) WITHOUT failing the dial — a returned error here would break every
+// upstream connection the proxy makes. This is the default dial path used when
+// copilotDial is unset.
+func TestMarkDialerControlRuns(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		c.Close()
+	}()
+
+	conn, err := markDialer(2*time.Second).Dial("tcp", ln.Addr().String())
+	if err != nil {
+		// Setting SO_MARK requires CAP_NET_ADMIN. Unprivileged CI on Linux will
+		// see EPERM from the Control hook — that still proves the hook ran and
+		// attempted the setsockopt (the whole point). Tolerate ONLY EPERM; any
+		// other error is a real dialer regression. On non-Linux the hook no-ops,
+		// so the dial simply succeeds.
+		if errors.Is(err, syscall.EPERM) {
+			t.Skipf("SO_MARK requires CAP_NET_ADMIN; hook ran but got EPERM (expected unprivileged): %v", err)
+		}
+		t.Fatalf("markDialer Dial failed (Control hook must not break the dial): %v", err)
+	}
+	conn.Close()
+}


### PR DESCRIPTION
## Problem (verified on live OpenShift 4.18 nodes)

The F5 forced-egress control (#2664) redirects all outbound tcp :443 to the MITM proxy on :18443 and must exempt the proxy's OWN upstream :443 dials so its traffic isn't looped back into itself. That self-exemption was done with:

```
iptables -t nat -A HIVE_PROXY -m owner --uid-owner "$PROXY_UID" -j RETURN
```

The `-m owner` match requires the **`xt_owner` kernel module**, which is **absent on OpenShift/OVN nodes**. There the `-A ... -m owner` line fails (non-zero), which flips the F5 `_iptables_ok` fatal check and **crash-loops every OpenShift hive** (see #2674). Forced egress therefore could not roll out beyond OKE.

Probe evidence on the actual nodes: `-m mark --mark 0xNNNN -j RETURN` **works**, and `iptables-nft -t nat -N/-A ... -j REDIRECT` **works**. Only the owner exemption was the blocker.

## Fix: exempt by packet mark (SO_MARK / fwmark)

A packet mark needs **no `xt_owner`** and works identically on OKE and OpenShift/OVN.

### 1. Go proxy stamps SO_MARK on its upstream dials (`v2/pkg/proxy/github_proxy.go`)
- New `markDialer(timeout)` returns a `net.Dialer` whose `Control` hook calls `setSockopt(SO_MARK)` on the outbound socket before connect.
- Mark value comes from `HIVE_PROXY_EGRESS_MARK` (default `0x1112`), read via `proxyEgressMark()` — the **entrypoint is the single source of truth** and exports the same value, so proxy and iptables stay in lockstep. Parses hex or decimal; a garbage/zero value fails safe back to the default.
- Applied to **both cited dial sites** — the Copilot-sniff `tls.Dial` (via `tls.DialWithDialer`) and the transparent-path `net.DialTimeout` — **and** the other proxy-originated upstream dials that also traverse the redirect (transparent-MITM upstream, CONNECT-MITM upstream, and `tunnelDirect`), so no proxy dial loops back.
- **`copilotDial` test override preserved**: the SO_MARK dial is only the DEFAULT path in `dialCopilotUpstream`; when the test seam sets `copilotDial`, it still wins.

### 2. Non-Linux build safety
`SO_MARK` is Linux-only. Split into `somark_linux.go` (`//go:build linux`, real `syscall.SetsockoptInt(SOL_SOCKET, SO_MARK)`) and `somark_other.go` (`//go:build !linux`, no-op stub) so the package compiles on the CI matrix and darwin. arm64-linux is fine (SO_MARK is arch-independent).

### 3. entrypoint.sh (`v2/deploy/entrypoint.sh`)
- Exports `HIVE_PROXY_EGRESS_MARK` (default `0x1112`) at the top so both the root pass (iptables) and the re-exec'd dev pass (the `hive` Go process) inherit the same value.
- Replaces the owner exemptions with the **mark exemption as the SOLE self-exemption mechanism**:
  ```
  $IPT -t nat -A HIVE_PROXY -m mark --mark "$HIVE_PROXY_EGRESS_MARK" -j RETURN
  $IPT -t nat -A HIVE_PROXY -p tcp --dport 443 -j REDIRECT --to-ports "$PROXY_PORT"
  $IPT -t nat -A OUTPUT -j HIVE_PROXY
  ```
  The owner-uid RETURNs are **dropped entirely** — keeping any `-m owner` line would re-break OpenShift, so SO_MARK covers the self-exemption on both platforms. This ruleset **succeeds on a host without xt_owner**.
- Prefers `iptables-nft` for the nat ops (both OKE and OpenShift RHEL9 run the kernel in nft mode; falls back to plain `iptables`, which is a symlink to `xtables-nft-multi` on these images anyway).

## Result
Forced-egress enforcement is now unified across **OKE and OpenShift/OVN** — no more advisory-by-platform gap for the mark exemption.

## Testing
- `go build ./pkg/proxy/` clean; `go test ./pkg/proxy/ -short -cover` passes at **90.4%** (no floor regression).
- New `somark_test.go`: default/env-override mark resolution + `markDialer` Control-hook exercise (tolerates EPERM when unprivileged on Linux, since SO_MARK needs CAP_NET_ADMIN; no-ops on darwin).
- `bash -n v2/deploy/entrypoint.sh` clean.

Refs #2674

🤖 Generated with [Claude Code](https://claude.com/claude-code)