### PR TITLE
fix(gh-wrapper): REAL_GH points at nonexistent /usr/bin/gh — breaks all agent gh calls

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -16,7 +16,13 @@
 
 set -euo pipefail
 
-REAL_GH="/usr/bin/gh"
+# The real gh binary is installed at /opt/hive/bin/gh-real (v2/Dockerfile:74),
+# NOT /usr/bin/gh — which does not exist in the image. A stale /usr/bin/gh path
+# made the guard below fire "gh CLI is not available" for every agent gh call,
+# silently breaking the CLI GitHub workflow (issue/PR view, create, merge). Keep
+# the legacy path as a fallback for any environment that does ship it there.
+REAL_GH="/opt/hive/bin/gh-real"
+[[ -x "$REAL_GH" ]] || REAL_GH="/usr/bin/gh"
 RESTRICTIONS_DIR="/etc/hive/restrictions"
 
 # Guard: if the real gh binary is not installed, tell the agent to use MCP instead.


### PR DESCRIPTION
## The bug

`v2/Dockerfile:74` installs the real gh binary at `/opt/hive/bin/gh-real`. But `bin/gh-wrapper.sh:19` hardcodes `REAL_GH="/usr/bin/gh"` — a path that **does not exist** in the image and is created by no symlink (verified: no `ln -s` in Dockerfile or entrypoint). The wrapper's guard (`[[ ! -x "$REAL_GH" ]]`) therefore fires **"⚠️ gh CLI is not available in this environment"** for every agent `gh` invocation.

Impact: agents can't `gh pr view`, `gh pr create`, `gh pr merge`, or `gh issue` — the CLI GitHub workflow is dead on this image. On the L6 console hive (full loop: triage → PR → auto-merge) this cripples the agents' main GitHub interface. Discovered while investigating why auto-merge was failing on v4.

## Fix

`REAL_GH="/opt/hive/bin/gh-real"` (the actual install path), with `/usr/bin/gh` kept as a fallback.

Verified live: `/opt/hive/bin/gh-real --version` → `gh version 2.74.0`; `/usr/bin/gh` absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)