### PR TITLE
✨ Queue hold follow-ups: on-hold header count + resume-all + hold reason

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1928,6 +1928,19 @@ type HubConfig struct {
 	// as ContributeQueueOrder so it survives restart, and edited only through the
 	// authenticated POST /api/contribute/queue/hold endpoint (owner/read-write only).
 	ContributeQueueHold []string `yaml:"contribute_queue_hold,omitempty"`
+	// ContributeQueueHoldReasons is an OPTIONAL parallel map (canonical
+	// "owner/repo#number" key -> short operator note) annotating why an issue in
+	// ContributeQueueHold was parked. It is a companion to — not a replacement for —
+	// ContributeQueueHold: the []string set above remains the authoritative source of
+	// truth for WHICH issues are held (every admission check reads it); this map only
+	// carries the human-facing REASON, surfaced in the on-hold badge tooltip. A hold
+	// with no reason simply has no entry here (the badge falls back to its generic
+	// text), so holding without a note works exactly as before. Kept as a parallel
+	// map, rather than folding the reason into ContributeQueueHold, so the many
+	// read sites of the []string set stay untouched. Written only by the same
+	// authenticated POST /api/contribute/queue/hold endpoint that maintains the set,
+	// and pruned to the held keys on every write so it never leaks stale reasons.
+	ContributeQueueHoldReasons map[string]string `yaml:"contribute_queue_hold_reasons,omitempty"`
 	// ContributeRequireExplicitAccept gates HOW a contributor's scoped GitHub
 	// credential is delivered relative to task acceptance (kubestellar/hive#2537).
 	// The credential is ALWAYS delivered only AFTER an acceptance decision — it no

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -271,6 +271,10 @@ func (s *Server) registerContributeRoutes() {
 	// issue so it is never offered until Resumed — a persistent hold DISTINCT from
 	// the time-based cooldown. Body: {"key":"owner/repo#number","held":true|false}.
 	s.mux.HandleFunc("POST /api/contribute/queue/hold", s.handleContributeQueueHold)
+	// Resume-all (bulk clear): drops the ENTIRE operator hold set in one call so an
+	// operator does not have to Resume parked issues one at a time. Same owner/read-
+	// write gate and refreshAndPersist path as the single-issue hold endpoint above.
+	s.mux.HandleFunc("POST /api/contribute/queue/hold/clear", s.handleContributeQueueHoldClear)
 	// Contributor-owned LABEL INTERESTS (#2637): a contributor's opt-in list of
 	// GitHub labels they can help with, used to surface/prioritise matching issues
 	// FOR THEM on the Operations queue. Self-service (identity resolved server-side,
@@ -1073,12 +1077,21 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 .cc-q-moverow input:focus{border-color:#1f6feb}
 .cc-q-moverow button{background:#1f6feb;border:none;color:#fff;font:inherit;font-size:.76rem;font-weight:600;padding:5px 10px;border-radius:6px;cursor:pointer}
 .cc-q-moverow button:hover{background:#388bfd}
+/* Optional hold-reason field (#queue-hold-reason) in the ⋯ menu — a compact inline
+   note the operator can fill before Hold. Empty is fine (holding without a note). */
+.cc-q-holdreason{padding:2px 9px 7px}
+.cc-q-holdreason-input{width:100%%;box-sizing:border-box;background:#0d1117;border:1px solid #30363d;border-radius:6px;color:#e6edf3;font:inherit;font-size:.76rem;padding:4px 7px;outline:none;color-scheme:dark}
+.cc-q-holdreason-input:focus{border-color:#1f6feb}
 /* On-hold rows (#queue-hold): a manually-parked issue stays VISIBLE but is clearly
    not going to be offered — dimmed to ~55%% opacity with an amber "on hold" pill.
    Never hidden, so the operator can always see and Resume it. */
 .cc-q-item.cc-q-held{opacity:.55}
 .cc-q-item.cc-q-held:hover{opacity:.8}
 .cc-q-held-tag{margin-left:7px;font-size:.6rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#d29922;background:rgba(210,153,34,.12);border:1px solid rgba(210,153,34,.3);border-radius:999px;padding:0 6px;vertical-align:middle}
+/* Resume-all (#queue-hold): a small amber header button. Hidden until there is at
+   least one held issue and the viewer is owner/read-write (JS-toggled display). */
+.queue-resume-all-btn{margin-left:8px;font-size:.7rem;font-weight:600;color:#d29922;background:rgba(210,153,34,.1);border:1px solid rgba(210,153,34,.35);border-radius:6px;padding:2px 8px;cursor:pointer;vertical-align:middle;line-height:1.4}
+.queue-resume-all-btn:hover{background:rgba(210,153,34,.2)}
 /* ── Opportunistic Work (#2592) — a small, CALM discovery panel. Intentionally
    quiet: no loud "recommended!" chrome, just a short curated list with a subtle
    heat dot and an unobtrusive "add to queue" affordance (owner/read-write only). */
@@ -1893,7 +1906,9 @@ Contributors subscribe to labels (e.g. <code>nvidia</code>) so matching issues a
 <div class="work-list" id="work-list"><div class="ops-empty">Loading work&hellip;</div></div>
 </div>
 <div class="ops-card card-accent" style="margin-top:20px">
-<div class="ops-card-head"><span class="feed-dot"></span><h3>Ready-work queue</h3><span class="ops-card-count" id="queue-count"></span><!-- Cooldown explainer (#2649 companion): a circled-i affordance whose popover
+<div class="ops-card-head"><span class="feed-dot"></span><h3>Ready-work queue</h3><span class="ops-card-count" id="queue-count"></span><!-- Resume-all (#queue-hold): bulk-clears the operator hold set. Hidden by default;
+     ccRenderResumeAll() reveals it only for an owner/read-write viewer when at least
+     one issue is on hold. Themed confirm (adminConfirm), never native confirm. --><button type="button" class="queue-resume-all-btn" id="queue-resume-all-btn" style="display:none" title="Resume every held issue">&#x25B6; Resume all</button><!-- Cooldown explainer (#2649 companion): a circled-i affordance whose popover
      explains what "in cooldown" in the count means and how an issue lands there.
      Numbers here are the REAL server constants (168h with-PR, ~4h no-PR, ~6h
      quarantine after 3 consecutive failures) — keep them in sync with
@@ -3159,6 +3174,10 @@ async function initAdmin(){
     adminHub=(cd&&cd.hub)?cd.hub:{};
   }catch(e){adminHub={};}
   renderAdminControls();
+  // Resume-all (#queue-hold): wire the header button once, now that we know the viewer
+  // is owner/read-write. Visibility is still driven by ccRenderResumeAll (count-gated).
+  var resumeAllBtn=document.getElementById('queue-resume-all-btn');
+  if(resumeAllBtn&&!resumeAllBtn._wired){resumeAllBtn._wired=true;resumeAllBtn.addEventListener('click',function(e){e.stopPropagation();ccResumeAll();});}
   // The ready-work queue may have rendered before this role check resolved (SSE
   // hello / poll fires immediately on tab open). Re-render now that adminEnabled is
   // true so the grab bars appear for this owner/read-write viewer.
@@ -3461,6 +3480,7 @@ async function opsPoll(){
     // field stays 0. A re-render picks up the fresh values.
     ccCooldownCount=(data&&typeof data.cooldown_count==='number')?data.cooldown_count:0;
     ccInFlightCount=(data&&typeof data.in_flight_count==='number')?data.in_flight_count:0;
+    ccHeldCount=(data&&typeof data.held_count==='number')?data.held_count:0;
     safeRender('queue-counts',function(){if(typeof ccRenderQueue==='function')ccRenderQueue();});
     safeRender('cooldown-count',function(){if(typeof ccRenderCooldownCount==='function')ccRenderCooldownCount();});
   }catch(e){
@@ -3503,6 +3523,7 @@ var ccCompleteStreak={};   // username -> consecutive completes (achievement com
 var ccLastAch=0;           // debounce achievement pops
 var ccCooldownCount=0;     // issues still within cooldown (from fleet payload, #2649)
 var ccInFlightCount=0;     // issues currently held by a live connection (fleet payload)
+var ccHeldCount=0;         // issues manually PARKED by the operator (fleet payload, on-hold tally)
 
 // ── Label-affinity (#2637): the viewer's own label interests ───────────────────
 // ccInterests is this viewer's opt-in label list (normalised lower-case). Loaded
@@ -3640,6 +3661,7 @@ function ccRenderQueue(flip){
     var segs=[ccQueue.length+' ready'];
     if(ccCooldownCount>0)segs.push(ccCooldownCount+' in cooldown');
     if(ccInFlightCount>0)segs.push(ccInFlightCount+' in flight');
+    if(ccHeldCount>0)segs.push(ccHeldCount+' on hold');
     qc.textContent=segs.join(' · ');
   }
   // No-blink guard: if a per-row ⋯ menu / "Move to #" dialog is OPEN and this is a
@@ -3649,6 +3671,10 @@ function ccRenderQueue(flip){
   // hands. We already updated the header tally above so counts stay live; we mark the
   // render DEFERRED so ccCloseQueueMenus replays it the moment the menu closes.
   if(!flip&&document.querySelector('.cc-q-menu.open')){ccQueueRenderDeferred=true;return;}
+  // Resume-all affordance (#queue-hold): a single "Resume all (H)" button next to the
+  // header, shown ONLY to an owner/read-write viewer (adminEnabled) and ONLY when at
+  // least one issue is on hold. Kept in sync with the tally above on every render.
+  ccRenderResumeAll();
   // Label-affinity (#2637): re-tag + float this viewer's interested items. No-op
   // when no interests are set (order preserved); skipped mid-drag so an operator
   // reorder is not fought by an interest re-float. See ccApplyInterestsToQueue.
@@ -3715,7 +3741,12 @@ function ccRenderQueue(flip){
     var mineCls=mine?' cc-q-mine':'';
     var mineTag=mine?'<span class="cc-q-mine-tag" title="Matches one of your label interests">for you</span>':'';
     var heldCls=isHeld?' cc-q-held':'';
-    var heldTag=isHeld?'<span class="cc-q-held-tag" title="On hold — parked by the operator; not offered until resumed">&#x23F8; on hold</span>':'';
+    // On-hold badge tooltip (#queue-hold-reason): when the operator attached a note,
+    // show "On hold — <reason>"; otherwise fall back to the generic text. esc() guards
+    // the operator-supplied reason so it can never inject markup into the title attr.
+    var heldReason=(q.held_reason||'').toString();
+    var heldTitle=heldReason?('On hold — '+heldReason):'On hold — parked by the operator; not offered until resumed';
+    var heldTag=isHeld?'<span class="cc-q-held-tag" title="'+esc(heldTitle)+'">&#x23F8; on hold</span>':'';
     // PR→issue badge (#2612 part c): if the triage poll resolved a fixing PR for
     // this issue (open/merged), show a small link. Absent until ccTriagePoll runs,
     // and simply omitted when no PR is linked — never blocks the queue render.
@@ -3821,6 +3852,14 @@ function ccQueueMenuHTML(key,pos,total,isHeld){
   // carries the CURRENT held state so the click handler knows which way to flip.
   var holdLabel=isHeld?'Resume':'Hold';
   var holdIcon=isHeld?'&#x25B6;':'&#x23F8;'; // ▶ resume / ⏸ hold
+  // Optional hold reason (#queue-hold-reason): an inline note field shown ONLY when the
+  // item is NOT yet held (a reason is attached when parking). The Hold click reads this
+  // input's value and passes it to ccToggleHold. Absent for a held item (Resume needs
+  // no note). Uses a distinct id ('hr-'+key) so it never collides with the mover input.
+  var reasonRow=isHeld?'':(
+    '<div class="cc-q-holdreason">'+
+      '<input type="text" id="hr-'+esc(key)+'" class="cc-q-holdreason-input" maxlength="200" placeholder="Optional hold reason&hellip;" data-qkey="'+esc(key)+'" aria-label="Optional hold reason" autocomplete="off">'+
+    '</div>');
   return '<span class="cc-q-menu-wrap">'+
     '<button type="button" class="cc-q-menu-btn" aria-haspopup="true" aria-expanded="false" title="More actions" data-qkey="'+esc(key)+'">&#x22EF;</button>'+
     '<div class="cc-q-menu" role="menu">'+
@@ -3828,6 +3867,7 @@ function ccQueueMenuHTML(key,pos,total,isHeld){
       '<button type="button" class="cc-q-act" role="menuitem" data-act="bottom" data-qkey="'+esc(key)+'"'+(atBottom?' disabled style="opacity:.5;cursor:default"':'')+'><span class="cc-q-menu-ic">&#x2B07;</span>Move to bottom</button>'+
       '<div class="cc-q-menu-sep"></div>'+
       '<button type="button" class="cc-q-act" role="menuitem" data-act="hold" data-held="'+(isHeld?'1':'0')+'" data-qkey="'+esc(key)+'"><span class="cc-q-menu-ic">'+holdIcon+'</span>'+holdLabel+'</button>'+
+      reasonRow+
       '<div class="cc-q-menu-sep"></div>'+
       '<div class="cc-q-moverow">'+
         '<label for="mv-'+esc(key)+'">Move to&nbsp;#</label>'+
@@ -3890,7 +3930,17 @@ function ccBindQueueMenus(root){
   })(bots[b2]);}
   var holds=root.querySelectorAll('.cc-q-act[data-act=hold]');
   for(var h2=0;h2<holds.length;h2++){(function(act){
-    act.addEventListener('click',function(e){e.stopPropagation();if(act.disabled)return;ccCloseQueueMenus();ccToggleHold(act.getAttribute('data-qkey'),act.getAttribute('data-held')!=='1');});
+    act.addEventListener('click',function(e){
+      e.stopPropagation();if(act.disabled)return;
+      var key=act.getAttribute('data-qkey');
+      var willHold=act.getAttribute('data-held')!=='1';
+      // Read the optional inline reason (present only on the not-yet-held menu) BEFORE
+      // closing the menu tears the input out of the DOM. Ignored on resume (willHold=false).
+      var reason='';
+      if(willHold){var ri=root.querySelector('#'+cssEscRaw('hr-'+key));if(ri)reason=ri.value||'';}
+      ccCloseQueueMenus();
+      ccToggleHold(key,willHold,reason);
+    });
   })(holds[h2]);}
   var gos=root.querySelectorAll('.cc-q-act-go');
   for(var g=0;g<gos.length;g++){(function(go){
@@ -3907,7 +3957,13 @@ function ccBindQueueMenus(root){
 // cssEscId escapes a qkey for use in a querySelector id lookup (the key contains
 // '/' and '#'). Prefer CSS.escape when present; fall back to a manual escape.
 function cssEscId(id){
-  var raw='mv-'+id;
+  return cssEscRaw('mv-'+id);
+}
+// cssEscRaw escapes an ALREADY-PREFIXED id (e.g. 'hr-owner/repo#1') for a
+// querySelector '#'+... lookup. Same escape as cssEscId but without the baked-in
+// 'mv-' prefix, so callers that use a different prefix (the hold-reason input's
+// 'hr-') get a correct selector instead of a doubled 'mv-' that never matches.
+function cssEscRaw(raw){
   if(window.CSS&&CSS.escape)return CSS.escape(raw);
   return raw.replace(/([^a-zA-Z0-9_-])/g,'\\$1');
 }
@@ -4034,9 +4090,13 @@ function ccPersistQueueOrder(){
 // computes) is reflected: a newly-held row re-appears greyed at the bottom, a
 // resumed row rejoins the offerable list. Owner/read-write only; a read viewer 403s
 // here, but the Hold/Resume action is never rendered for them (adminEnabled gate).
-function ccToggleHold(key,held){
+function ccToggleHold(key,held,reason){
   if(!key)return;
-  fetch('/api/contribute/queue/hold',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({key:key,held:!!held})})
+  // reason is OPTIONAL and only meaningful on hold=true; the server ignores it on
+  // resume. Trimmed here so a whitespace-only note is treated as "no reason".
+  var body={key:key,held:!!held};
+  if(held&&reason&&reason.trim())body.reason=reason.trim();
+  fetch('/api/contribute/queue/hold',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)})
     .then(function(r){if(!r.ok)throw new Error('http '+r.status);return r.json();})
     .then(function(){
       // Re-hydrate from the server so held tagging + offer-eligibility are authoritative.
@@ -4044,6 +4104,36 @@ function ccToggleHold(key,held){
     })
     .then(function(d){if(d&&d.queue){ccQueue=d.queue.slice();ccRenderQueue();}})
     .catch(function(){/* a read viewer would 403; the UI never shows the action to them */});
+}
+// ccRenderResumeAll shows/hides the header "Resume all" button. It is visible ONLY
+// when the viewer is owner/read-write (adminEnabled) AND at least one issue is on
+// hold (ccHeldCount>0); otherwise it is hidden. The label carries the live count so
+// the operator sees how many resuming will clear. Called on every ccRenderQueue.
+function ccRenderResumeAll(){
+  var btn=document.getElementById('queue-resume-all-btn');if(!btn)return;
+  if(adminEnabled&&ccHeldCount>0){
+    btn.style.display='';
+    btn.textContent='▶ Resume all ('+ccHeldCount+')'; // ▶ Resume all (N)
+  }else{
+    btn.style.display='none';
+  }
+}
+// ccResumeAll bulk-clears the ENTIRE operator hold set via POST
+// /api/contribute/queue/hold/clear, after a themed confirm (never native confirm).
+// On success it re-fetches the queue so every previously-held row rejoins the
+// offerable list. Owner/read-write only; a read viewer 403s, but the button is never
+// shown to them (adminEnabled gate in ccRenderResumeAll).
+function ccResumeAll(){
+  if(ccHeldCount<=0)return;
+  adminConfirm('Resume all held issues','Resume every issue currently on hold ('+ccHeldCount+') so they can be offered again. This clears the entire operator hold set at once. Individual holds can be re-applied afterwards from each row&rsquo;s ⋯ menu.','Resume all',function(){
+    fetch('/api/contribute/queue/hold/clear',{method:'POST',headers:{'Content-Type':'application/json'}})
+      .then(function(r){if(!r.ok)throw new Error('http '+r.status);return r.json();})
+      .then(function(){
+        return fetch('/api/contribute/queue').then(function(r){return r.json();});
+      })
+      .then(function(d){if(d&&d.queue){ccQueue=d.queue.slice();ccRenderQueue();}toast('Resumed all held issues',true);})
+      .catch(function(){toast('Could not resume all held issues',false);});
+  });
 }
 function ccSetLive(state){ // 'live' | 'poll' | 'connecting'
   // Drive BOTH the queue-head pill (#cc-live, unchanged) and the mirror pill that
@@ -5011,10 +5101,13 @@ func (s *Server) handleContributeFleet(w http.ResponseWriter, r *http.Request) {
 	// of the queue); inFlightCount = issues currently held by a live connection.
 	// Both are read-only tallies the queue header / Management tab surface (#2649
 	// configurable cooldown).
-	cooldownCount, inFlightCount := 0, 0
+	// heldCount = operator-held issues still in the actionable universe (would be
+	// offerable but for the manual hold); the queue header surfaces it as "H on hold".
+	cooldownCount, inFlightCount, heldCount := 0, 0, 0
 	if s.contributeHub != nil {
 		snap = s.contributeHub.FleetSnapshot()
 		cooldownCount, inFlightCount = s.contributeHub.CooldownCounts()
+		heldCount = s.contributeHub.HeldCount()
 	}
 	jsonResponse(w, map[string]any{
 		"clankers":        snap.Clankers,
@@ -5022,6 +5115,7 @@ func (s *Server) handleContributeFleet(w http.ResponseWriter, r *http.Request) {
 		"policy":          s.buildContributeAdmissionPolicy(),
 		"cooldown_count":  cooldownCount,
 		"in_flight_count": inFlightCount,
+		"held_count":      heldCount,
 	})
 }
 
@@ -5296,6 +5390,12 @@ func (s *Server) handleContributeQueueOrder(w http.ResponseWriter, r *http.Reque
 // nor slow the per-selectTask membership lookup.
 const maxQueueHoldKeys = 512
 
+// maxQueueHoldReasonLen bounds the OPTIONAL operator note stored with a hold so a
+// stored reason can never balloon hive.yaml. A hold reason is a short annotation
+// (why this issue is parked), not free-form prose, so a compact cap is plenty; an
+// over-long note is truncated rather than rejected (the hold itself must still succeed).
+const maxQueueHoldReasonLen = 200
+
 // handleContributeQueueHold toggles the OPERATOR HOLD on one ready-work issue.
 // A held issue is parked INDEFINITELY — never offered — until the operator Resumes
 // it; this is DISTINCT from the time-based cooldown, which self-clears. It is a
@@ -5315,6 +5415,11 @@ func (s *Server) handleContributeQueueHold(w http.ResponseWriter, r *http.Reques
 	var body struct {
 		Key  string `json:"key"`
 		Held bool   `json:"held"`
+		// Reason is an OPTIONAL short operator note explaining WHY the issue is being
+		// parked, surfaced in the on-hold badge tooltip. Ignored when held=false (the
+		// reason is dropped alongside the key on resume). Empty means "no note" — the
+		// badge falls back to its generic text, so holding without a reason is unchanged.
+		Reason string `json:"reason"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		jsonError(w, "invalid request", http.StatusBadRequest)
@@ -5324,6 +5429,11 @@ func (s *Server) handleContributeQueueHold(w http.ResponseWriter, r *http.Reques
 	if key == "" || !queueOrderKeyPattern.MatchString(key) {
 		jsonError(w, "invalid issue key", http.StatusBadRequest)
 		return
+	}
+	// Bound the note so a stored reason can never balloon the persisted config.
+	reason := strings.TrimSpace(body.Reason)
+	if len(reason) > maxQueueHoldReasonLen {
+		reason = reason[:maxQueueHoldReasonLen]
 	}
 	// Rebuild the hold set: drop the target key (and any malformed/duplicate
 	// stragglers) first, then re-add it when held=true. This keeps the stored list
@@ -5351,10 +5461,61 @@ func (s *Server) handleContributeQueueHold(w http.ResponseWriter, r *http.Reques
 		cleaned = append(cleaned, key)
 	}
 	s.deps.Config.Hub.ContributeQueueHold = cleaned
+	// Maintain the OPTIONAL parallel reason map (#queue-hold-reason). On hold=true with
+	// a non-empty note, store it under the canonical key; on hold=false (resume) or an
+	// empty note, drop any prior entry. Prune to the current held set so a reason can
+	// never outlive its hold. Built fresh each write (nil-safe) so it stays well-formed.
+	reasons := pruneQueueHoldReasons(s.deps.Config.Hub.ContributeQueueHoldReasons, cleaned)
+	if body.Held && reason != "" {
+		reasons[key] = reason
+	} else {
+		delete(reasons, key)
+	}
+	if len(reasons) == 0 {
+		reasons = nil // omitempty: no reasons => field absent, snapshot unchanged
+	}
+	s.deps.Config.Hub.ContributeQueueHoldReasons = reasons
 	s.auditFromRequest(r, "contribute_queue_hold", auditDetail("key", key, "held", strconv.FormatBool(body.Held)), "")
 	s.refreshAndPersist()
-	s.logger.Info("contribute queue hold updated", "key", key, "held", body.Held, "total_held", len(cleaned))
-	jsonResponse(w, map[string]any{"ok": true, "key": key, "held": body.Held, "hold": cleaned})
+	s.logger.Info("contribute queue hold updated", "key", key, "held", body.Held, "total_held", len(cleaned), "has_reason", body.Held && reason != "")
+	jsonResponse(w, map[string]any{"ok": true, "key": key, "held": body.Held, "hold": cleaned, "reason": reason})
+}
+
+// handleContributeQueueHoldClear RESUMES ALL held issues in one call: it drops the
+// entire operator hold set (ContributeQueueHold) and its parallel reason map, then
+// persists through the SAME refreshAndPersist path as the single-issue hold endpoint.
+// This is the bulk companion to handleContributeQueueHold — same owner/read-write
+// gate (requireContributorWrite; a read/anon caller gets 403), same persistence.
+// Idempotent: clearing an already-empty set is a clean no-op that still persists.
+func (s *Server) handleContributeQueueHoldClear(w http.ResponseWriter, r *http.Request) {
+	if !s.requireContributorWrite(w, r) {
+		return
+	}
+	cleared := len(s.deps.Config.Hub.ContributeQueueHold)
+	s.deps.Config.Hub.ContributeQueueHold = nil
+	s.deps.Config.Hub.ContributeQueueHoldReasons = nil
+	s.auditFromRequest(r, "contribute_queue_hold_clear", auditDetail("cleared", strconv.Itoa(cleared)), "")
+	s.refreshAndPersist()
+	s.logger.Info("contribute queue hold cleared (resume all)", "cleared", cleared)
+	jsonResponse(w, map[string]any{"ok": true, "cleared": cleared, "hold": []string{}})
+}
+
+// pruneQueueHoldReasons returns a fresh copy of src keeping ONLY entries whose key is
+// present in keep (the current held set). It is the invariant that keeps the parallel
+// reason map from leaking a note for an issue that is no longer held. nil-safe: a nil
+// src yields an empty (non-nil) map ready to write into.
+func pruneQueueHoldReasons(src map[string]string, keep []string) map[string]string {
+	held := make(map[string]struct{}, len(keep))
+	for _, k := range keep {
+		held[k] = struct{}{}
+	}
+	out := make(map[string]string, len(keep))
+	for k, v := range src {
+		if _, ok := held[k]; ok && strings.TrimSpace(v) != "" {
+			out[k] = v
+		}
+	}
+	return out
 }
 
 // ── Contributor management ─────────────────────────────────────────────────

--- a/v2/pkg/dashboard/contribute_queue_hold_followup_test.go
+++ b/v2/pkg/dashboard/contribute_queue_hold_followup_test.go
@@ -1,0 +1,237 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ── Queue hold follow-ups: on-hold header count + resume-all + hold reason ───────
+// These pin the three enhancements layered on the operator HOLD feature (#queue-hold):
+//   (1) held_count — the fleet payload tally the header surfaces as "N on hold";
+//   (2) resume-all — POST /api/contribute/queue/hold/clear drops the whole hold set;
+//   (3) hold reason — an OPTIONAL note stored with a hold and surfaced on the badge.
+
+// TestHeldCount_ReflectsActionableHoldSet proves HeldCount() counts only held issues
+// that are STILL in the actionable universe (would be offerable but for the hold),
+// mirroring what ReadyQueue surfaces as Held — a hold key for a no-longer-actionable
+// issue does not inflate the count.
+func TestHeldCount_ReflectsActionableHoldSet(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.RegisterAPI(testDeps(t))
+
+	s.statusMu.Lock()
+	s.status = seedActionable("acme/repo", 3) // issues 1..3
+	s.statusMu.Unlock()
+
+	// Hold #2 (actionable) and a stale key for a non-actionable #99.
+	s.deps.Config.Hub.ContributeQueueHold = []string{"acme/repo#2", "acme/repo#99"}
+
+	if got := s.contributeHub.HeldCount(); got != 1 {
+		t.Fatalf("HeldCount = %d, want 1 (only the actionable #2 counts; stale #99 does not)", got)
+	}
+
+	// No holds → 0.
+	s.deps.Config.Hub.ContributeQueueHold = nil
+	if got := s.contributeHub.HeldCount(); got != 0 {
+		t.Fatalf("HeldCount = %d, want 0 with an empty hold set", got)
+	}
+}
+
+// TestContributeFleet_IncludesHeldCount asserts the /api/contribute/fleet JSON carries
+// the held_count field reflecting the hold set, so the queue header can render "N on hold".
+func TestContributeFleet_IncludesHeldCount(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.RegisterAPI(testDeps(t))
+
+	s.statusMu.Lock()
+	s.status = seedActionable("acme/repo", 3)
+	s.statusMu.Unlock()
+	s.deps.Config.Hub.ContributeQueueHold = []string{"acme/repo#1", "acme/repo#3"}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/fleet", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		HeldCount *int `json:"held_count"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if resp.HeldCount == nil {
+		t.Fatalf("fleet payload missing held_count: %s", w.Body.String())
+	}
+	if *resp.HeldCount != 2 {
+		t.Fatalf("held_count = %d, want 2", *resp.HeldCount)
+	}
+}
+
+// TestQueueHoldClearEndpoint_ClearsAll proves resume-all drops the ENTIRE hold set
+// (and its reason map) and round-trips through persistence.
+func TestQueueHoldClearEndpoint_ClearsAll(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.Hub.ContributeQueueHold = []string{"acme/repo#1", "acme/repo#2"}
+	deps.Config.Hub.ContributeQueueHoldReasons = map[string]string{"acme/repo#1": "flaky"}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/queue/hold/clear", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("clear: got %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	if len(deps.Config.Hub.ContributeQueueHold) != 0 {
+		t.Fatalf("hold set not cleared: %v", deps.Config.Hub.ContributeQueueHold)
+	}
+	if len(deps.Config.Hub.ContributeQueueHoldReasons) != 0 {
+		t.Fatalf("hold reasons not cleared: %v", deps.Config.Hub.ContributeQueueHoldReasons)
+	}
+	var resp struct {
+		OK      bool `json:"ok"`
+		Cleared int  `json:"cleared"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.OK || resp.Cleared != 2 {
+		t.Fatalf("unexpected clear response: %+v", resp)
+	}
+}
+
+// TestQueueHoldClearEndpoint_RoleGate proves resume-all is owner/read-write ONLY:
+// a "read" caller 403s, exactly like the single-issue hold endpoint.
+func TestQueueHoldClearEndpoint_RoleGate(t *testing.T) {
+	cases := []struct {
+		role string
+		want int
+	}{
+		{"read", http.StatusForbidden},
+		{"owner", http.StatusOK},
+		{"read-write", http.StatusOK},
+		{"", http.StatusOK}, // absent header = local/dev owner
+	}
+	for _, tc := range cases {
+		t.Run("role_"+tc.role, func(t *testing.T) {
+			s, _ := apiServer(t)
+			req := httptest.NewRequest(http.MethodPost, "/api/contribute/queue/hold/clear", nil)
+			if tc.role != "" {
+				req.Header.Set("X-Hive-Role", tc.role)
+			}
+			w := httptest.NewRecorder()
+			s.mux.ServeHTTP(w, req)
+			if w.Code != tc.want {
+				t.Fatalf("role %q: got %d, want %d (body: %s)", tc.role, w.Code, tc.want, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestQueueHoldReason_StoreSurfaceClear proves the OPTIONAL hold reason round-trips:
+// a hold=true with a reason stores it under the canonical key and ReadyQueue surfaces
+// it on the held item; resuming (hold=false) drops the reason.
+func TestQueueHoldReason_StoreSurfaceClear(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.RegisterAPI(testDeps(t))
+
+	s.statusMu.Lock()
+	s.status = seedActionable("acme/repo", 3)
+	s.statusMu.Unlock()
+
+	// Hold #2 WITH a reason.
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/queue/hold",
+		strings.NewReader(`{"key":"acme/repo#2","held":true,"reason":"waiting on upstream"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("hold-with-reason: got %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	if r := s.deps.Config.Hub.ContributeQueueHoldReasons["acme/repo#2"]; r != "waiting on upstream" {
+		t.Fatalf("stored reason = %q, want %q", r, "waiting on upstream")
+	}
+
+	// The held ReadyQueueItem must carry the reason.
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	var found bool
+	for _, it := range q {
+		if it.Number == 2 && it.Held {
+			found = true
+			if it.HeldReason != "waiting on upstream" {
+				t.Fatalf("held item HeldReason = %q, want %q", it.HeldReason, "waiting on upstream")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("held #2 not surfaced in ReadyQueue: %+v", q)
+	}
+
+	// Resume #2 → the reason is dropped.
+	req = httptest.NewRequest(http.MethodPost, "/api/contribute/queue/hold",
+		strings.NewReader(`{"key":"acme/repo#2","held":false}`))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("resume: got %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	if _, ok := s.deps.Config.Hub.ContributeQueueHoldReasons["acme/repo#2"]; ok {
+		t.Fatalf("reason for #2 should be dropped on resume, still present: %v", s.deps.Config.Hub.ContributeQueueHoldReasons)
+	}
+}
+
+// TestQueueHoldReason_OptionalNoNote proves holding WITHOUT a reason works exactly as
+// before: the hold is stored and no reason entry is created.
+func TestQueueHoldReason_OptionalNoNote(t *testing.T) {
+	s, deps := apiServer(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/queue/hold",
+		strings.NewReader(`{"key":"acme/repo#5","held":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("hold-no-reason: got %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	if len(deps.Config.Hub.ContributeQueueHold) != 1 || deps.Config.Hub.ContributeQueueHold[0] != "acme/repo#5" {
+		t.Fatalf("hold set = %v, want [acme/repo#5]", deps.Config.Hub.ContributeQueueHold)
+	}
+	if len(deps.Config.Hub.ContributeQueueHoldReasons) != 0 {
+		t.Fatalf("no reason expected, got %v", deps.Config.Hub.ContributeQueueHoldReasons)
+	}
+}
+
+// TestQueueHoldFollowupControlsPresent pins the dashboard structure for the three
+// enhancements: the "on hold" header segment, the resume-all affordance, and the
+// reason input + tooltip wiring.
+func TestQueueHoldFollowupControlsPresent(t *testing.T) {
+	body := renderContributePage(t)
+
+	for _, want := range []string{
+		// (1) on-hold header segment sourced from the fleet payload.
+		`ccHeldCount+' on hold'`,
+		`data.held_count`,
+		// (2) resume-all affordance: button, wired handler, bulk-clear endpoint.
+		`queue-resume-all-btn`,
+		`function ccResumeAll(`,
+		`/api/contribute/queue/hold/clear`,
+		`function ccRenderResumeAll(`,
+		// resume-all is gated on adminEnabled (owner/read-write only).
+		`if(adminEnabled&&ccHeldCount>0)`,
+		// (3) hold reason: inline input, passed to the toggle, surfaced in the tooltip.
+		`cc-q-holdreason-input`,
+		`function ccToggleHold(key,held,reason)`,
+		`q.held_reason`,
+		`'On hold — '+heldReason`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("queue hold follow-up controls missing marker %q", want)
+		}
+	}
+}

--- a/v2/pkg/dashboard/contribute_queue_hold_test.go
+++ b/v2/pkg/dashboard/contribute_queue_hold_test.go
@@ -226,18 +226,18 @@ func TestQueueMoveToBottomAndHoldControlsPresent(t *testing.T) {
 	body := renderContributePage(t)
 
 	for _, want := range []string{
-		`data-act="bottom"`,                    // Move-to-bottom menu item
-		`Move to bottom`,                       // its label
-		`function ccMoveToBottom(key){`,        // wired mover
-		`ccMoveToPosition(key,ccQueue.length)`, // sends the item to the last slot
-		`data-act="hold"`,                      // Hold/Resume menu item
-		`function ccToggleHold(key,held){`,     // wired toggle
-		`/api/contribute/queue/hold`,           // calls the hold endpoint
-		`cc-q-held`,                            // dimmed held-row class
-		`cc-q-held-tag`,                        // on-hold badge class
-		`on hold`,                              // badge text
-		`color-scheme:light dark`,              // theme-aware spinner-arrow fix (visible in both light + dark; #2612)
-		`.cc-q-moverow input[type=number]`,     // spinner fix targets the number input
+		`data-act="bottom"`,                       // Move-to-bottom menu item
+		`Move to bottom`,                          // its label
+		`function ccMoveToBottom(key){`,           // wired mover
+		`ccMoveToPosition(key,ccQueue.length)`,    // sends the item to the last slot
+		`data-act="hold"`,                         // Hold/Resume menu item
+		`function ccToggleHold(key,held,reason){`, // wired toggle (reason is optional, #queue-hold-reason)
+		`/api/contribute/queue/hold`,              // calls the hold endpoint
+		`cc-q-held`,                               // dimmed held-row class
+		`cc-q-held-tag`,                           // on-hold badge class
+		`on hold`,                                 // badge text
+		`color-scheme:light dark`,                 // theme-aware spinner-arrow fix (visible in both light + dark; #2612)
+		`.cc-q-moverow input[type=number]`,        // spinner fix targets the number input
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("queue hold/bottom controls missing marker %q", want)

--- a/v2/pkg/dashboard/contribute_sse.go
+++ b/v2/pkg/dashboard/contribute_sse.go
@@ -88,6 +88,12 @@ type ReadyQueueItem struct {
 	// is persistent and only clears when the operator Resumes it. omitempty so a
 	// snapshot with no holds is byte-for-byte unchanged.
 	Held bool `json:"held,omitempty"`
+	// HeldReason is the OPTIONAL short operator note attached when the issue was
+	// parked (Config.Hub.ContributeQueueHoldReasons). Only ever set on a Held item;
+	// the Operations tab shows it in the on-hold badge tooltip ("On hold — <reason>").
+	// Empty when the operator held with no note, so the badge falls back to its
+	// generic text. omitempty so a hold without a reason is byte-for-byte unchanged.
+	HeldReason string `json:"held_reason,omitempty"`
 }
 
 // sseSubscriber is one connected browser. events is the fan-out channel; done is
@@ -199,9 +205,11 @@ func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
 
 	var disabledRepos []string
 	var held map[string]struct{}
+	var holdReasons map[string]string
 	if h.server.deps != nil && h.server.deps.Config != nil {
 		disabledRepos = h.server.deps.Config.Hub.DisabledRepos
 		held = queueHoldSet(h.server.deps.Config.Hub.ContributeQueueHold)
+		holdReasons = h.server.deps.Config.Hub.ContributeQueueHoldReasons
 	}
 
 	// heldItems collects issues the operator parked. They are NEVER offered — kept
@@ -243,16 +251,18 @@ func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
 			// heldItems (tagged Held) so it stays visible-but-dimmed for the operator.
 			// Checked before cooldown/active so a held-AND-cooled issue still shows as
 			// held (the operator's manual decision is the stronger, persistent signal).
-			if _, isHeld := held[fmt.Sprintf("%s#%d", repo.Full, number)]; isHeld {
+			holdKey := fmt.Sprintf("%s#%d", repo.Full, number)
+			if _, isHeld := held[holdKey]; isHeld {
 				title, _ := issue["title"].(string)
 				url, _ := issue["url"].(string)
 				heldItems = append(heldItems, ReadyQueueItem{
-					Repo:   repo.Full,
-					Number: number,
-					Title:  title,
-					URL:    url,
-					Labels: stringSliceFromAny(issue["labels"]),
-					Held:   true,
+					Repo:       repo.Full,
+					Number:     number,
+					Title:      title,
+					URL:        url,
+					Labels:     stringSliceFromAny(issue["labels"]),
+					Held:       true,
+					HeldReason: holdReasons[holdKey], // "" when no note (map miss) — omitempty
 				})
 				continue
 			}

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -1485,6 +1485,60 @@ func (h *ContributeWSHub) CooldownCounts() (cooldown, inFlight int) {
 	return cooldown, inFlight
 }
 
+// HeldCount returns how many OPERATOR-HELD issues are also present in the current
+// actionable universe — i.e. held issues that WOULD be offerable if not parked. It
+// mirrors what the ready queue actually surfaces as Held (ReadyQueue appends exactly
+// these), so the header "N on hold" tally matches the greyed rows the operator sees,
+// rather than counting stale hold keys for issues no longer actionable. Read-only:
+// it mutates nothing and adds no enforcement. Uses the SAME canonical "%s#%d" key
+// form (repo.Full # number) every admission check builds, so it cannot silently miss
+// on a repo-name spelling mismatch (the #2648 class of bug).
+func (h *ContributeWSHub) HeldCount() int {
+	if h == nil || h.server == nil {
+		return 0
+	}
+	var hold map[string]struct{}
+	if h.server.deps != nil && h.server.deps.Config != nil {
+		hold = queueHoldSet(h.server.deps.Config.Hub.ContributeQueueHold)
+	}
+	if len(hold) == 0 {
+		return 0
+	}
+	h.server.statusMu.RLock()
+	status := h.server.status
+	h.server.statusMu.RUnlock()
+	if status == nil {
+		return 0
+	}
+	count := 0
+	for _, repo := range status.Repos {
+		for _, raw := range repo.ActionableIssues {
+			b, err := json.Marshal(raw)
+			if err != nil {
+				continue
+			}
+			var issue map[string]any
+			if err := json.Unmarshal(b, &issue); err != nil {
+				continue
+			}
+			number := 0
+			switch n := issue["number"].(type) {
+			case float64:
+				number = int(n)
+			case int:
+				number = n
+			}
+			if number == 0 {
+				continue
+			}
+			if _, isHeld := hold[fmt.Sprintf("%s#%d", repo.Full, number)]; isHeld {
+				count++
+			}
+		}
+	}
+	return count
+}
+
 func (h *ContributeWSHub) ActiveConnections() []ContributorConnection {
 	h.mu.RLock()
 	defer h.mu.RUnlock()


### PR DESCRIPTION
Three follow-up enhancements to the ready-work queue **operator HOLD** feature (`#queue-hold`, base hold from #2673).

> **Merge order:** this branch was built on top of #2656 (`feat/cooldown-count-and-explainer`, the "N ready · M in cooldown · K in flight" header tally), because enhancement (1) extends that same tally. Since #2656 is not yet on `v2`, `v2` was merged into this branch so both the tally and the hold code are present. **Please merge this AFTER #2656** — GitHub will collapse #2656's commits out of the delta once it lands; base is set to `v2`.

## The three enhancements

### 1. Held-count header segment
- Server: new `held_count` field on the read-only fleet payload (`handleContributeFleet`), beside `cooldown_count`/`in_flight_count`. Backed by a new `ContributeWSHub.HeldCount()` that counts held keys **still in the actionable universe** (would be offerable but for the hold) — matching exactly what `ReadyQueue` surfaces as `Held`, so the tally lines up with the greyed rows.
- Client: `ccHeldCount` read in the same poll, and a `· H on hold` segment appended after the in-flight segment in `ccRenderQueue`'s `segs`.

### 2. Resume-all
- Server: new `POST /api/contribute/queue/hold/clear` — same `requireContributorWrite` (owner/read-write) gate and `refreshAndPersist` path as the single-issue hold endpoint. Clears the **entire** `ContributeQueueHold` set (and the reason map).
- Client: an admin-only, count-gated **"Resume all (N)"** header button. Hidden when `ccHeldCount==0` or the viewer is non-admin; click → themed `adminConfirm` (never native confirm) → POST clear → re-render.

### 3. Optional hold reason / note
- Server: a **parallel** `ContributeQueueHoldReasons map[string]string` (canonical key → note) — leaves the `[]string` hold set and its many read sites untouched. The hold endpoint accepts an optional `reason` in its body; stored on `held=true`, dropped on `held=false`, and pruned to the held set on every write. Surfaced as `HeldReason` (`json:"held_reason,omitempty"`) on the held `ReadyQueueItem`.
- Client: an inline optional text input in the ⋯ menu's Hold action (not native prompt); the `.cc-q-held-tag` badge `title` shows `On hold — <reason>` when set, generic text otherwise. Holding with no reason is unchanged.

Held keys stay the canonical `repo.Full#number` form via the existing key helper (the #2648 silent-miss class).

## Tests
- `contribute_queue_hold_followup_test.go`: `held_count` reflects the actionable hold set (+ fleet payload carries it); resume-all clears the set and reason map through persistence, non-authorized caller rejected; hold-with-reason stores + surfaces + clears the reason; hold-with-no-reason unchanged; dashboard-structure markers for the on-hold segment, resume-all affordance, and reason tooltip wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)