### PR TITLE
✨ Hub: blue glowing/blinking status dot while a hive is upgrading

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -7552,7 +7552,7 @@ const dashboardHTML = `<!DOCTYPE html>
     .online-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 6px; }
     .online-dot.on { background: var(--green); box-shadow: 0 0 6px rgba(116,223,154,0.5); }
     .online-dot.off { background: #6b7280; }
-    /* Upgrading state: replace the normal health dot with a 50%-bigger (12px) blue
+    /* Upgrading state: replace the normal health dot with a 50% larger (12px) blue
        dot that glows and blinks slowly, so a rollout-in-progress reads at a glance
        and is unmistakable versus the ok/degraded/critical/unknown health colors. */
     .online-dot.upgrading { width: 12px; height: 12px; background: #58a6ff; box-shadow: 0 0 8px rgba(88,166,255,0.9), 0 0 3px rgba(88,166,255,0.7); animation: hiveUpgradePulse 1.8s ease-in-out infinite; }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -10876,7 +10876,12 @@ const dashboardHTML = `<!DOCTYPE html>
         }
       }
 
-      if (!hivesWithDrift) {
+      // Hide the strip only when there is nothing to attend to AND no attention
+      // filter is currently applied. If a filter IS active (e.g. the user clicked
+      // "upgrading" and the count has since dropped to 0), the strip MUST stay so
+      // its chip + "Show all" escape remain reachable — otherwise the filter keeps
+      // narrowing the list with no visible way to turn it off.
+      if (!hivesWithDrift && !_dashDriftFilter) {
         el.style.display = 'none';
         el.innerHTML = '';
         return;
@@ -10893,6 +10898,15 @@ const dashboardHTML = `<!DOCTYPE html>
         if (kindCounts[b] !== kindCounts[a]) return kindCounts[b] - kindCounts[a];
         return driftKindLabel(a).localeCompare(driftKindLabel(b));
       });
+      // Keep the ACTIVE filter's chip listed even after its count falls to 0, so
+      // it can always be clicked off (mirrors renderFailingCheckFacetGroup). Without
+      // this the chip vanishes the moment its last hive clears while the filter is
+      // still applied, stranding the user on an empty, un-clearable filtered view.
+      if (_dashDriftFilter && kinds.indexOf(_dashDriftFilter) === -1) {
+        kinds.unshift(_dashDriftFilter);
+        if (kindCounts[_dashDriftFilter] == null) kindCounts[_dashDriftFilter] = 0;
+        if (kindWorst[_dashDriftFilter] == null) kindWorst[_dashDriftFilter] = 'info';
+      }
 
       var chips = kinds.map(function(k) {
         var color = DRIFT_SEVERITY_COLORS[kindWorst[k]] || DRIFT_SEVERITY_COLORS.info;

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -7552,6 +7552,12 @@ const dashboardHTML = `<!DOCTYPE html>
     .online-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 6px; }
     .online-dot.on { background: var(--green); box-shadow: 0 0 6px rgba(116,223,154,0.5); }
     .online-dot.off { background: #6b7280; }
+    /* Upgrading state: replace the normal health dot with a 50%-bigger (12px) blue
+       dot that glows and blinks slowly, so a rollout-in-progress reads at a glance
+       and is unmistakable versus the ok/degraded/critical/unknown health colors. */
+    .online-dot.upgrading { width: 12px; height: 12px; background: #58a6ff; box-shadow: 0 0 8px rgba(88,166,255,0.9), 0 0 3px rgba(88,166,255,0.7); animation: hiveUpgradePulse 1.8s ease-in-out infinite; }
+    @keyframes hiveUpgradePulse { 0%, 100% { opacity: 1; box-shadow: 0 0 10px rgba(88,166,255,1), 0 0 4px rgba(88,166,255,0.8); } 50% { opacity: 0.4; box-shadow: 0 0 4px rgba(88,166,255,0.4); } }
+    @media (prefers-reduced-motion: reduce) { .online-dot.upgrading { animation: none; } }
     .hive-name { font-weight: 600; color: var(--text); }
     .hive-org { font-size: 0.75rem; color: var(--muted); }
 
@@ -12129,7 +12135,13 @@ const dashboardHTML = `<!DOCTYPE html>
       syncBulkSelection(hives);
       var repoPath = function(h) { return h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : h.primaryRepo || ''; };
       var buildRow = function(h, i, section) {
-        var dot = h.online ? healthBadge(h) : '<span class="online-dot off"></span>';
+        // While a rollout is in flight, the status dot becomes the distinct
+        // blue glowing/slow-blinking "upgrading" dot (see .online-dot.upgrading) —
+        // it outranks the normal online/offline health dot so an upgrade reads at
+        // a glance and is never mistaken for the ok/degraded/critical/unknown state.
+        var dot = h.upgrading
+          ? '<span class="online-dot upgrading" title="Upgrading \u2014 a rollout is in progress"></span>'
+          : (h.online ? healthBadge(h) : '<span class="online-dot off"></span>');
         var rp = repoPath(h);
         // Link on the hive's own GitHub instance (github_host) so a GHE repo
         // points at github.ibm.com, not 404 on github.com.


### PR DESCRIPTION
On a hive row, while a rollout is in flight (`h.upgrading`) the leading status dot now becomes a **50%-bigger (8px → 12px) blue dot that glows and blinks slowly** (`.online-dot.upgrading`), instead of the usual green/red/yellow/gray-"?" health dot.

An upgrade-in-progress now reads at a glance and is unmistakable versus the ok/degraded/critical/unknown health colors. The upgrading state outranks the normal online/offline dot. Honors `prefers-reduced-motion` (no blink for users who opt out).

`go build ./pkg/hub/` passes.