### PR TITLE
🔒 Impersonation: show the user's EXACT UX — hide all admin surfaces (user list, Send Banner) while viewing as a user

### DIFF
--- a/v2/pkg/hub/impersonation_test.go
+++ b/v2/pkg/hub/impersonation_test.go
@@ -190,6 +190,63 @@ func TestWriteBlockedDuringImpersonation(t *testing.T) {
 	}
 }
 
+// TestAdminReadSurfacesHiddenDuringImpersonation pins the UX-fidelity property of
+// "View as": while impersonating, an admin-DATA GET (e.g. /api/saas/admin/users)
+// must be refused so no admin surface leaks into the view — the impersonated
+// dashboard shows exactly what the target user sees. The exit path stays callable.
+func TestAdminReadSurfacesHiddenDuringImpersonation(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+	mkUser(t, "alice")
+	now := time.Now()
+
+	called := false
+	next := func(w http.ResponseWriter, r *http.Request) { called = true; w.WriteHeader(http.StatusOK) }
+	guardedAdmin := s.requireAdmin(next)
+
+	// A GET admin-data route under an active grant -> 403, handler NOT reached, so
+	// the client's 403 handling hides the admin Users section AND the Send Banner
+	// controls. (Before the fix this returned 200 because requireAdmin honors the
+	// real admin identity — leaking the full user list into the impersonated view.)
+	rec := httptest.NewRecorder()
+	get := httptest.NewRequest(http.MethodGet, "/api/saas/admin/users", nil)
+	get.AddCookie(testAuthCookie(hubAdminUsername))
+	get.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
+	guardedAdmin(rec, get)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("admin GET under impersonation status = %d, want 403 (admin surface must not leak)", rec.Code)
+	}
+	if called {
+		t.Error("admin GET handler ran under impersonation — admin data leaked into the impersonated view")
+	}
+
+	// The SAME admin GET, NOT impersonating, still reaches the handler (200) — the
+	// real admin retains full access when not viewing as someone.
+	called = false
+	rec = httptest.NewRecorder()
+	get = httptest.NewRequest(http.MethodGet, "/api/saas/admin/users", nil)
+	get.AddCookie(testAuthCookie(hubAdminUsername))
+	guardedAdmin(rec, get)
+	if rec.Code != http.StatusOK || !called {
+		t.Errorf("admin GET without impersonation: status=%d called=%v; want 200 + handler called", rec.Code, called)
+	}
+
+	// The exit path stays reachable while impersonating (so the admin can always
+	// get back out) even though it is behind requireAdmin.
+	called = false
+	rec = httptest.NewRecorder()
+	guardedExit := s.requireAdmin(next)
+	exitReq := httptest.NewRequest(http.MethodPost, impersonateExitPath, nil)
+	exitReq.AddCookie(testAuthCookie(hubAdminUsername))
+	exitReq.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
+	guardedExit(rec, exitReq)
+	if rec.Code != http.StatusOK || !called {
+		t.Errorf("exit path under impersonation: status=%d called=%v; want 200 + handler reached", rec.Code, called)
+	}
+}
+
 // TestImpersonateExitClearsCookieAndStaysCallable: exit works WHILE impersonating
 // (it is exempt from the write-block) and clears the cookie.
 func TestImpersonateExitClearsCookieAndStaysCallable(t *testing.T) {

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -682,9 +682,27 @@ func (s *HubServer) requireAdmin(next http.HandlerFunc) http.HandlerFunc {
 			http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
 			return
 		}
+		// While impersonating, NO admin-only surface may leak to the view the
+		// admin is "viewing as" — the whole point of read-only impersonation is to
+		// see exactly what the target user sees, and a normal user is never an
+		// admin. requireAdmin gates on the REAL admin (so exit and admin routes
+		// stay reachable), which means an admin-DATA GET (e.g. /api/saas/admin/users)
+		// would otherwise still answer 200 under impersonation and the client would
+		// render the admin Users section. So: while a grant is active, refuse every
+		// admin route (GET included) EXCEPT the impersonation exit — the client's
+		// 403 handling then hides the admin section, matching what the target sees.
+		if r.URL.Path != impersonateExitPath {
+			if _, _, impersonating := s.resolveIdentity(r); impersonating {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusForbidden)
+				w.Write([]byte(`{"error":"admin surfaces are hidden while viewing as a user — exit impersonation for admin access"}`))
+				return
+			}
+		}
 		// Admin writes are also read-only under impersonation (exit excepted),
 		// so an impersonating admin cannot mutate through an admin endpoint
-		// either.
+		// either. (Redundant with the block above now, but kept as defense in
+		// depth / a clear write-specific message if the above is ever relaxed.)
 		if s.blockIfImpersonatingWrite(w, r) {
 			return
 		}


### PR DESCRIPTION
**Bug (found via "View as"):** while an admin impersonated a user (read-only), the impersonated dashboard still rendered the **"Hub Admin — Users"** list (all 89 users) and the **"Send Banner"** controls. A normal user must never see either — and the whole point of "View as" is to see the user's **exact UX**, so any leaked admin surface makes the impersonated view wrong.

**Root cause:** `requireAdmin` gates on the **real** admin identity (`getRealAuthUser`) so the exit path and admin routes stay reachable. That's correct for exit — but it meant admin-**data GETs** (e.g. `GET /api/saas/admin/users`) still returned **200** under impersonation. The client keys the admin section (and the banner controls) off that endpoint's 403, so a 200 rendered them into the impersonated view. `blockIfImpersonatingWrite` only covered **writes**.

**Fix:** `requireAdmin` now refuses **every** admin route (GET included) while an impersonation grant is active, **except** the impersonation exit path. The client's existing 403 handling then hides `admin-section`, `hub-banner-section`, and the Send Banner button — so "View as" shows exactly what the target user sees. Writes were already blocked; this extends the same "no admin surface leaks to the target" guarantee to reads.

**Scope:** impersonation-only. A real non-admin was already 403'd by `requireAdmin` (no general leak) — verified. The per-hive access/"add to hive" dialog is a separate path and does not read `/api/saas/admin/users`.

Test `TestAdminReadSurfacesHiddenDuringImpersonation`: admin GET → 403 under impersonation (handler not reached), → 200 when not impersonating, and the exit path stays reachable. All existing impersonation tests still pass.