### PR TITLE
fix(hub): stop perpetual upgrade loop for floating-tag hives (commit-pin target never matches)

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4135,7 +4135,7 @@ func (s *HubServer) triggerAutoUpgrades() {
 	hives := listSaaSHives()
 	for _, h := range hives {
 		s.mu.RLock()
-		var currentSHA, branch, upgradeTarget string
+		var currentSHA, branch, upgradeTarget, imageRef string
 		var alreadyUpgrading bool
 		var upgradeStartedAt time.Time
 		for _, reg := range s.registry.Hives {
@@ -4145,6 +4145,7 @@ func (s *HubServer) triggerAutoUpgrades() {
 				alreadyUpgrading = reg.Upgrading
 				upgradeTarget = reg.UpgradeTarget
 				upgradeStartedAt = reg.UpgradeStartedAt
+				imageRef = reg.ImageRef
 				break
 			}
 		}
@@ -4153,6 +4154,34 @@ func (s *HubServer) triggerAutoUpgrades() {
 			branch = "v2"
 		}
 		if alreadyUpgrading {
+			// Floating-tag convergence. A hive whose Deployment tracks a MUTABLE
+			// tag (…-latest) has no stable target commit: a restart re-pulls the
+			// tag and lands on whatever CI last published, so its reported GitHash
+			// chases an ever-moving branch HEAD and can never equal the SPECIFIC
+			// commit the hub armed. Left to the stale-recovery path below, that
+			// hive is re-armed and rolled every staleUpgradeTimeout forever —
+			// restarting the spoke pod each cycle for no benefit. Once such a hive
+			// reports it is running the image-verified latest for its branch, it IS
+			// up to date; clear the latch here instead of advancing the target.
+			// Commit-pinned hives are unaffected — their tag resolves to exactly
+			// one build, so the specific-target check still governs them.
+			registryLatestSHA := getLatestSHAForBranch(branch)
+			if imageTagIsMutable(imageRef) && registryLatestSHA != "" &&
+				sameCommit(currentSHA, registryLatestSHA) {
+				s.mu.Lock()
+				for i := range s.registry.Hives {
+					if s.registry.Hives[i].ID == h.ID {
+						s.registry.Hives[i].Upgrading = false
+						s.registry.Hives[i].UpgradeTarget = ""
+						break
+					}
+				}
+				delete(s.heartbeatUpgrade, h.ID)
+				s.mu.Unlock()
+				s.logger.Info("clearing upgrade latch — floating-tag hive is at latest",
+					"hive", h.ID, "branch", branch, "sha", currentSHA, "image_ref", imageRef)
+				continue
+			}
 			// Latched-upgrade recovery runs for EVERY hive, deliberately BEFORE
 			// the AutoUpgrade gate below (#2476). The registry latch
 			// (Upgrading/UpgradeTarget/UpgradeStartedAt) is durable, but

--- a/v2/pkg/hub/self_upgrade.go
+++ b/v2/pkg/hub/self_upgrade.go
@@ -218,11 +218,18 @@ const selfUpgradeTargetAnnotation = "hive.kubestellar.io/upgrade-target-sha"
 //
 // This narrows but does not eliminate the race: if CI republishes the tag
 // between the hub choosing a target and the kubelet pulling, the pod still
-// lands on the newer build. That is benign and self-correcting — the hub
-// accepts "at target OR at registry-latest" as success (server.go), so an
-// overshoot completes the upgrade rather than wedging it. What it must never do
-// again is silently land on the WRONG build with no record of what was asked
-// for; the annotation is that record.
+// lands on the newer build. That overshoot is benign only because the hub no
+// longer judges a floating-tag hive by whether it reached a SPECIFIC commit —
+// a floating tag has no stable target, so that test could never converge while
+// the branch kept moving (the pod would report a SHA that is neither the old
+// nor the requested one, stay latched "Upgrading", and be re-armed and
+// re-rolled by the stale-upgrade sweep every staleUpgradeTimeout). Instead the
+// hub treats a floating-tag hive's non-upgrading heartbeat as completion
+// (server.go completion check) and, in the sweep, clears the latch once such a
+// hive reports the image-verified latest for its branch rather than advancing
+// the target (saas.go triggerAutoUpgrades). What this function must never do is
+// silently land on the WRONG build with no record of what was asked for; the
+// annotation is that record.
 func upgradeSelfMutableToSHA(logger *slog.Logger, current, targetSHA string) (needsRestart bool, err error) {
 	if targetSHA == "" {
 		// No target to record. Fall back to the historical behaviour rather

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1304,7 +1304,25 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 					entry.UpgradeFailedAt = h.UpgradeFailedAt
 				}
 			}
-			if h.Upgrading && !payload.Upgrading && (sameCommit(payload.GitHash, h.UpgradeTarget) || (registryLatestSHA != "" && sameCommit(payload.GitHash, registryLatestSHA))) {
+			// A floating-tag deployment (…-latest) pulls the tag on every
+			// rollout and therefore CANNOT land on a specific historical
+			// commit — it lands on whatever CI last published. So its reported
+			// GitHash chases an ever-advancing branch HEAD and may equal
+			// neither the armed target NOR the poller's registryLatestSHA at the
+			// instant this beat arrives (the two caches can be a commit apart
+			// while CI is active). Comparing SHAs at all is the wrong test for
+			// these hives: a non-upgrading heartbeat is itself proof the rollout
+			// finished onto the latest tag. Treat that as complete, or the hive
+			// stays latched "Upgrading" and the stale-upgrade sweep re-arms and
+			// re-rolls its pod every staleUpgradeTimeout forever. Commit-pinned
+			// hives keep the exact-SHA test below — their tag resolves to one
+			// build, so "did it reach the target" is a meaningful question.
+			floatingAtLatest := h.Upgrading && !payload.Upgrading && imageTagIsMutable(payload.ImageRef)
+			if floatingAtLatest {
+				entry.Upgrading = false
+				entry.UpgradeTarget = ""
+				entry.OrphanedUpgradeSweeps = 0
+			} else if h.Upgrading && !payload.Upgrading && (sameCommit(payload.GitHash, h.UpgradeTarget) || (registryLatestSHA != "" && sameCommit(payload.GitHash, registryLatestSHA))) {
 				// Non-upgrading heartbeat at the target SHA or at latest —
 				// upgrade completed (image may have advanced past the
 				// original target before the spoke pulled it). sameCommit

--- a/v2/pkg/hub/stale_upgrade.go
+++ b/v2/pkg/hub/stale_upgrade.go
@@ -70,7 +70,17 @@ type upgradeAttemptEvidence struct {
 // Elapsed time alone is NOT sufficient and is not used alone here: a slow image
 // pull looks identical to an orphan if you only look at the clock. Both
 // conditions must hold.
-func evaluateOrphanedUpgrade(entry *RegistryEntry, now time.Time) upgradeAttemptEvidence {
+// latestSHA is the image-verified latest short SHA for entry's branch (empty
+// when unknown). It exists solely to recognise a FLOATING-TAG hive that has
+// already converged: such a hive tracks a mutable …-latest tag, so a restart
+// re-pulls the tag and it can only ever land on the newest build — never on the
+// SPECIFIC historical commit the hub armed as UpgradeTarget. Judged by the
+// exact-target test below, it would look orphaned on every sweep, get re-armed
+// and re-rolled (restarting its pod) up to maxOrphanedUpgradeSweeps, then be
+// wrongly reported as a permanent UpgradeFailed — while it was up to date the
+// whole time. Passing latestSHA lets the evaluation see "floating tag already
+// at latest" and treat it as converged, not orphaned.
+func evaluateOrphanedUpgrade(entry *RegistryEntry, now time.Time, latestSHA string) upgradeAttemptEvidence {
 	var ev upgradeAttemptEvidence
 
 	if !entry.Upgrading {
@@ -80,6 +90,15 @@ func evaluateOrphanedUpgrade(entry *RegistryEntry, now time.Time) upgradeAttempt
 	// heartbeat path, which clears Upgrading and records the cause. Leave that
 	// terminal state alone — it carries a known reason this sweep would erase.
 	if entry.UpgradeFailed {
+		return ev
+	}
+	// Floating-tag hive already on the latest build for its branch: converged,
+	// not orphaned. A mutable tag has no stable target commit, so the exact
+	// UpgradeTarget test further down can never confirm it and would keep
+	// sweeping/re-rolling it forever. The heartbeat completion path clears the
+	// latch, so leave it alone here.
+	if imageTagIsMutable(entry.ImageRef) && latestSHA != "" &&
+		sameCommit(entry.GitHash, latestSHA) {
 		return ev
 	}
 	// A zero UpgradeStartedAt with Upgrading still latched is not a fresh
@@ -169,7 +188,14 @@ func (s *HubServer) sweepOrphanedUpgrades() {
 	s.mu.Lock()
 	for i := range s.registry.Hives {
 		h := &s.registry.Hives[i]
-		ev := evaluateOrphanedUpgrade(h, now)
+		// Resolve the image-verified latest for this hive's branch so the
+		// evaluation can recognise a floating-tag hive that is already at latest
+		// (and must not be swept/re-rolled toward a specific historical target).
+		branch := h.GitBranch
+		if branch == "" {
+			branch = "v2"
+		}
+		ev := evaluateOrphanedUpgrade(h, now, getLatestSHAForBranch(branch))
 		if !ev.orphaned {
 			continue
 		}

--- a/v2/pkg/hub/stale_upgrade_test.go
+++ b/v2/pkg/hub/stale_upgrade_test.go
@@ -19,10 +19,63 @@ func TestEvaluateOrphanedUpgrade(t *testing.T) {
 	started := fixedSweepNow.Add(-68 * time.Minute)
 
 	cases := []struct {
-		name     string
-		entry    RegistryEntry
-		orphaned bool
+		name      string
+		entry     RegistryEntry
+		latestSHA string
+		orphaned  bool
 	}{
+		{
+			// The floating-tag loop this fix closes: a hive tracking a mutable
+			// …-latest tag reports the CURRENT latest build, which is a different
+			// commit than the specific UpgradeTarget the hub armed. The old
+			// exact-target test called this orphaned and swept/re-rolled it every
+			// cycle; with the image ref known to be mutable and the reported SHA
+			// equal to the branch-latest, it is converged, not orphaned.
+			name: "not orphaned: floating-tag hive already on branch-latest (different from armed target)",
+			entry: RegistryEntry{
+				Upgrading:        true,
+				UpgradeStartedAt: started,
+				GitHash:          "9999abc",
+				UpgradeTarget:    "fc32ae4",
+				ImageRef:         "ghcr.io/kubestellar/hive:v4-latest",
+				LastHeartbeat:    rfc3339(fixedSweepNow.Add(-30 * time.Second)),
+			},
+			latestSHA: "9999abc",
+			orphaned:  false,
+		},
+		{
+			// A floating-tag hive that is NOT yet at latest is still a real
+			// orphan — mutability alone is not a free pass, only mutability PLUS
+			// being on the current build.
+			name: "orphaned: floating-tag hive behind branch-latest",
+			entry: RegistryEntry{
+				Upgrading:        true,
+				UpgradeStartedAt: started,
+				GitHash:          "c11643a",
+				UpgradeTarget:    "fc32ae4",
+				ImageRef:         "ghcr.io/kubestellar/hive:v4-latest",
+				LastHeartbeat:    rfc3339(fixedSweepNow.Add(-30 * time.Second)),
+			},
+			latestSHA: "9999abc",
+			orphaned:  true,
+		},
+		{
+			// A COMMIT-PINNED hive on branch-latest is unaffected by the floating
+			// short-circuit: its tag resolves to one build, so "did it reach the
+			// target" stays the governing question. Here it is still on the old
+			// SHA, so it remains a genuine orphan.
+			name: "orphaned: commit-pinned hive on old SHA even though branch-latest advanced",
+			entry: RegistryEntry{
+				Upgrading:        true,
+				UpgradeStartedAt: started,
+				GitHash:          "c11643a",
+				UpgradeTarget:    "fc32ae4",
+				ImageRef:         "ghcr.io/kubestellar/hive:c11643a",
+				LastHeartbeat:    rfc3339(fixedSweepNow.Add(-30 * time.Second)),
+			},
+			latestSHA: "9999abc",
+			orphaned:  true,
+		},
 		{
 			name: "orphaned: alive and heartbeating past the threshold on the old SHA",
 			entry: RegistryEntry{
@@ -137,7 +190,7 @@ func TestEvaluateOrphanedUpgrade(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := evaluateOrphanedUpgrade(&tc.entry, fixedSweepNow)
+			got := evaluateOrphanedUpgrade(&tc.entry, fixedSweepNow, tc.latestSHA)
 			if got.orphaned != tc.orphaned {
 				t.Fatalf("orphaned = %v, want %v (reason %q)", got.orphaned, tc.orphaned, got.reason)
 			}
@@ -280,6 +333,57 @@ func TestSweepBelowBudgetStillReArms(t *testing.T) {
 	}
 	if got := s.heartbeatUpgrade["first-orphan"]; got != "fc32ae4" {
 		t.Errorf("below the budget the upgrade must still be re-armed, got %q", got)
+	}
+}
+
+// TestSweepDoesNotReRollFloatingTagAtLatest is the acceptance test for the
+// perpetual floating-tag upgrade loop. A hive tracking a mutable …-latest tag,
+// already running the branch-latest build, must NOT be swept: not re-armed for
+// delivery, not counted toward the fault budget, and — after repeated cycles —
+// never marked UpgradeFailed. Left unfixed this hive was re-armed and
+// rolloutRestart-ed every staleUpgradeTimeout, restarting its spoke pod forever,
+// then falsely reported as a permanent upgrade failure.
+func TestSweepDoesNotReRollFloatingTagAtLatest(t *testing.T) {
+	latestSHAMu.Lock()
+	prev := latestSHAByBranch["v4"]
+	latestSHAByBranch["v4"] = branchSHAInfo{SHA: "9999abc"}
+	latestSHAMu.Unlock()
+	t.Cleanup(func() {
+		latestSHAMu.Lock()
+		latestSHAByBranch["v4"] = prev
+		latestSHAMu.Unlock()
+	})
+
+	s := &HubServer{
+		logger:           slog.Default(),
+		heartbeatUpgrade: make(map[string]string),
+	}
+	s.registry.Hives = []RegistryEntry{{
+		ID:            "floating-at-latest",
+		GitBranch:     "v4",
+		GitHash:       "9999abc", // == branch-latest
+		UpgradeTarget: "fc32ae4", // an older armed commit the tag never lands on
+		ImageRef:      "ghcr.io/kubestellar/hive:v4-latest",
+	}}
+
+	// Run more cycles than the fault budget: a broken hive would be marked
+	// UpgradeFailed by now. A converged floating-tag hive must survive all of them.
+	for i := 0; i < maxOrphanedUpgradeSweeps+2; i++ {
+		s.registry.Hives[0].Upgrading = true
+		s.registry.Hives[0].UpgradeStartedAt = time.Now().Add(-68 * time.Minute)
+		s.registry.Hives[0].LastHeartbeat = rfc3339(time.Now().Add(-30 * time.Second))
+		s.sweepOrphanedUpgrades()
+
+		if _, armed := s.heartbeatUpgrade["floating-at-latest"]; armed {
+			t.Fatalf("cycle %d: floating-tag hive at latest must NOT be re-armed for a rollout", i)
+		}
+		if s.registry.Hives[0].OrphanedUpgradeSweeps != 0 {
+			t.Fatalf("cycle %d: converged floating-tag hive must not accrue orphan sweeps, got %d",
+				i, s.registry.Hives[0].OrphanedUpgradeSweeps)
+		}
+	}
+	if s.registry.Hives[0].UpgradeFailed {
+		t.Error("a floating-tag hive at latest must never be reported as a permanent upgrade failure")
 	}
 }
 

--- a/v2/pkg/hub/upgrade_recovery_test.go
+++ b/v2/pkg/hub/upgrade_recovery_test.go
@@ -176,6 +176,48 @@ func TestTriggerAutoUpgradesRecoversStaleDailyModeHiveHeldBySchedule(t *testing.
 	}
 }
 
+// TestTriggerAutoUpgradesClearsFloatingTagAtLatest is the triggerAutoUpgrades
+// half of the floating-tag fix. A floating-tag hive that is already on its
+// branch-latest build but latched Upgrading toward an older specific target
+// must have the latch CLEARED — not advanced to a newer target and re-rolled.
+// This is the branch of the arm→stale→advance→rollout loop that kept restarting
+// the spoke pod: the target advance and rolloutRestartHive lived here.
+func TestTriggerAutoUpgradesClearsFloatingTagAtLatest(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	remote := ClusterConfig{ID: "remote", InCluster: false, KubeconfigPath: "/tmp/kc", Context: "ctx"}
+	saveSaaSHive(&SaaSHive{ID: "floating-1", Owner: "alice", AutoUpgrade: true, Status: "running", ClusterID: "remote"})
+	resetSHACaches(t)
+	latestSHAMu.Lock()
+	latestSHAByBranch["v4"] = branchSHAInfo{SHA: "9999abc"}
+	latestSHAMu.Unlock()
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string), clusters: map[string]ClusterConfig{"remote": remote}}
+	s.registry.Hives = []RegistryEntry{{
+		ID: "floating-1", GitBranch: "v4", GitHash: "9999abc", // already at branch-latest
+		ImageRef:      "ghcr.io/kubestellar/hive:v4-latest",
+		Upgrading:     true,
+		UpgradeTarget: "fc32ae4", // older armed target the floating tag never lands on
+		// Stale on purpose: without the fix this triggers the advance+rollout.
+		UpgradeStartedAt: time.Now().Add(-30 * time.Minute),
+	}}
+
+	s.triggerAutoUpgrades()
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.registry.Hives[0].Upgrading {
+		t.Error("floating-tag hive at latest must have its Upgrading latch cleared")
+	}
+	if s.registry.Hives[0].UpgradeTarget != "" {
+		t.Errorf("cleared floating-tag hive must drop its stale target, got %q", s.registry.Hives[0].UpgradeTarget)
+	}
+	if got, armed := s.heartbeatUpgrade["floating-1"]; armed {
+		t.Errorf("floating-tag hive at latest must NOT be re-armed for a rollout, got %q", got)
+	}
+}
+
 // TestTriggerAutoUpgradesNotStaleManualRepopulates covers the hub-restart case
 // before the stale threshold: a latched manual upgrade on a remote cluster is
 // re-populated into heartbeatUpgrade even when it is not yet stale, exactly as


### PR DESCRIPTION
## The loop

A hive whose Deployment tracks a **mutable/floating tag** (e.g. `ghcr.io/kubestellar/hive:v4-latest`) pulls whatever commit that tag currently resolves to — which will **not** equal the specific historical **commit** the hub armed as `UpgradeTarget` (the hub advances targets: 549c415 → 692c7d2 → …).

The hub marked an auto-upgrade "complete" only when the spoke's heartbeat `GitHash` matched the armed target commit (`server.go` completion check). A floating-tag spoke re-pulls `-latest` on every rollout and lands on whatever CI last published, so its reported `GitHash` chases an **ever-advancing branch HEAD** and never equals the specific armed commit. Result:

1. Hub arms target = commit N. Floating spoke rolls, lands on N (or N+1 if CI moved), reports that.
2. `sameCommit(GitHash, target)` never matches → hive stays latched **Upgrading**.
3. The stale-upgrade sweep (`saas.go` `triggerAutoUpgrades`, `staleUpgradeTimeout` = 10m) fires: **advances the target to the new latest, re-arms heartbeat delivery, and issues a `kubectl rollout restart`** — restarting the spoke pod.
4. Repeat forever while the branch is active. The version badge is wrong the whole time, and each cycle **restarts the spoke pod**.

Separately, `sweepOrphanedUpgrades` / `evaluateOrphanedUpgrade` used the same exact-target test and escalated the same hive to a **false permanent `UpgradeFailed`** after `maxOrphanedUpgradeSweeps`.

The code already documented this exact failure (`self_upgrade.go`): "gitHash against upgradeTarget never matches, and the hive sits Upgrading."

## Root cause

`registryLatestSHA` was **not** the gap — it is computed correctly (image-verified branch HEAD, the same SHA `-latest` resolves to), and the completion check already had a `sameCommit(GitHash, registryLatestSHA)` fallback. But that fallback only **narrowed** the window: the two SHA caches can be a commit apart while CI is active, and — critically — the **target-advance and both sweep paths still re-armed and re-rolled the pod**. The real defect is conceptual: **"reached a specific target commit" is the wrong definition of up-to-date for a floating tag**, which by construction has no stable target.

## The fix

Recognise a floating-tag hive as up to date and **stop re-rolling it**. Floating-vs-pinned is detected with the existing `imageTagIsMutable(ImageRef)`; `ImageRef` already rides the heartbeat payload.

- **`server.go` completion check:** a floating-tag hive's non-upgrading heartbeat is itself proof the rollout finished onto the latest tag → treat as complete, regardless of exact SHA. Commit-pinned hives keep the exact-SHA test.
- **`triggerAutoUpgrades` stale-recovery:** for a floating-tag hive already on the image-verified branch-latest, **clear the latch** instead of advancing the target and calling `rolloutRestartHive`.
- **`evaluateOrphanedUpgrade` / `sweepOrphanedUpgrades`:** treat a floating-tag hive at branch-latest as **converged, not orphaned** — never swept, re-armed, or marked `UpgradeFailed`.

## Acceptance criterion

A floating-tag hive on the current latest image reaches a **stable up-to-date** state and the `kubectl`-fallback rollout loop **stops** — no repeated spoke pod restarts, no false permanent-failure.

## Tests

- Extended `TestEvaluateOrphanedUpgrade` with floating-at-latest, floating-behind, and commit-pinned cases.
- `TestSweepDoesNotReRollFloatingTagAtLatest` — survives more cycles than the fault budget, never re-armed, never marked failed.
- `TestTriggerAutoUpgradesClearsFloatingTagAtLatest` — the latch is cleared, target dropped, delivery not re-armed.
- `pkg/hub` coverage 89.3% (above the 89 floor). The only failing test is the pre-existing `/data`-dependent `TestAlertAcksPersistRoundTrip`, which also fails on unchanged `origin/v4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)