### PR TITLE
🔀 sync: v2 → dd (latest v2, incl. impersonation admin-surface fix)

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -54,6 +54,17 @@ jobs:
           cp bin/contributor-relay.sh "${RUNNER_TEMP}/contributor-relay.js"
           node --check "${RUNNER_TEMP}/contributor-relay.js"
           node bin/contributor-relay.test.js
+
+      # `just contribute-k8s` now emits a runnable contributor workload (#2549):
+      # a headless Deployment (#2660) with a status-file probe. This runs the
+      # real recipe and asserts the workload it produces, so a regression (a
+      # dropped headless mode, a broken probe, a token leak into stdout) fails
+      # the PR. Requires `just`; the test SKIPs cleanly if it is ever absent.
+      - name: Install just
+        uses: extractions/setup-just@v2
+      - name: Contributor K8s Workload Generation
+        working-directory: .
+        run: bash v2/deploy/test_contribute_k8s_workload.sh
   create-issue-on-failure:
     if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/v2'
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -739,19 +739,49 @@ contribute-stop:
     done
     $STOPPED && echo "Stopped." || echo "Not running."
 
-# Generate K8s ConfigMap + Secret YAML from contributor.env
+# Generate a runnable K8s contributor workload (Namespace + ConfigMap + Secret + Deployment)
 # Usage: just contribute-k8s                          (default namespace: hive-contributor)
 #        just contribute-k8s my-namespace              (custom namespace)
-#        just contribute-k8s my-namespace output.yaml  (write to file instead of stdout)
-contribute-k8s namespace="hive-contributor" outfile="":
+#        just contribute-k8s my-namespace out.yaml     (write to file instead of stdout)
+#        just contribute-k8s my-namespace "" v2        (pin a specific image tag, #2549)
+#
+# Unlike the earlier config-only generator, this now ALSO emits a Deployment that
+# actually RUNS the contributor relay in HEADLESS mode (kubestellar/hive#2660,
+# #2549): a headless pod has no TTY, so it sets CONTRIBUTOR_MODE=headless (the
+# interactive tmux path would stall forever waiting on a prompt nobody can type
+# into). Applying the output results in a running contributor, not three inert
+# config objects. Like before, it PRINTS YAML (or writes a file) and prints an
+# apply instruction — it never invokes kubectl itself.
+contribute-k8s namespace="hive-contributor" outfile="" image_tag="v2":
     #!/usr/bin/env bash
     set -euo pipefail
 
     # ── Constants ──
     readonly CONFIGMAP_NAME="hive-contributor-config"
     readonly SECRET_NAME="hive-contributor-secrets"
+    readonly DEPLOYMENT_NAME="hive-contributor"
     readonly ENV_FILE="{{config_dir}}/contributor.env"
     readonly GH_AUTH_FILE="{{config_dir}}/gh-auth.env"
+    # Published multi-arch image (.github/workflows/docker.yml build-contributor).
+    readonly IMAGE_REPO="ghcr.io/kubestellar/hive-contributor"
+    # CONTRIBUTOR_MODE selector values — must match bin/contributor-relay.sh.
+    readonly MODE_HEADLESS="headless"
+    # Where the headless relay writes its coarse lifecycle state as JSON
+    # (waiting/working/done/failed). Kept in step with HEADLESS_STATUS_FILE's
+    # default in bin/contributor-relay.sh; the probe below reads this exact path.
+    readonly HEADLESS_STATUS_FILE="/tmp/contributor-headless-status.json"
+    # Backends with a verified non-interactive (headless) entry point — must
+    # match HEADLESS_BACKENDS in bin/contributor-relay.sh. A headless pod on any
+    # OTHER backend (goose/bob/agy/pi) refuses work LOUDLY at startup, so we warn
+    # here rather than emit a manifest that will crash-loop with no explanation.
+    readonly HEADLESS_BACKENDS="claude litellm copilot codex"
+    # Memory sizing: the contributor image is ~2.7GiB unpacked and each task
+    # spawns a real coding-CLI + a repo build/test, so requests are deliberately
+    # generous. Named here so an operator can see and tune them, not magic YAML.
+    readonly MEM_REQUEST="1Gi"
+    readonly MEM_LIMIT="4Gi"
+    readonly CPU_REQUEST="500m"
+    readonly CPU_LIMIT="2"
 
     # ── Validate setup exists ──
     if [[ ! -f "$ENV_FILE" ]]; then
@@ -770,6 +800,27 @@ contribute-k8s namespace="hive-contributor" outfile="":
     fi
 
     NS="{{namespace}}"
+    IMAGE_TAG="{{image_tag}}"
+    IMAGE="${IMAGE_REPO}:${IMAGE_TAG}"
+    BACKEND="${AGENT_BACKEND:-claude}"
+
+    # ── Headless-backend preflight (#2549 / #2660) ──
+    # The workload runs headless. Only the backends in HEADLESS_BACKENDS have a
+    # verified non-interactive entry point; anything else makes the relay refuse
+    # work loudly at startup. Warn to STDERR (never stdout — stdout is the YAML
+    # that gets piped to kubectl) so the contributor is told BEFORE they apply,
+    # rather than debugging a crash-looping pod. We still emit the manifest so an
+    # operator switching AGENT_BACKEND to a supported one need not regenerate.
+    BACKEND_HEADLESS_OK=false
+    for b in $HEADLESS_BACKENDS; do
+      if [[ "$b" == "$BACKEND" ]]; then BACKEND_HEADLESS_OK=true; break; fi
+    done
+    if [[ "$BACKEND_HEADLESS_OK" != true ]]; then
+      echo "WARNING: AGENT_BACKEND='${BACKEND}' has no headless (non-interactive) mode." >&2
+      echo "         The headless Deployment supports only: ${HEADLESS_BACKENDS}." >&2
+      echo "         This backend would refuse work at startup. Re-run 'just contribute-setup <cli>'" >&2
+      echo "         with one of the supported backends before applying." >&2
+    fi
 
     # ── Helper: base64-encode a value (portable across macOS and Linux) ──
     b64() {
@@ -800,7 +851,14 @@ contribute-k8s namespace="hive-contributor" outfile="":
     YAML+="  HIVE_HUB: \"${HIVE_HUB:-}\""$'\n'
     YAML+="  CONTRIBUTOR_ID: \"${CONTRIBUTOR_ID:-}\""$'\n'
     YAML+="  CONTRIBUTOR_USERNAME: \"${CONTRIBUTOR_USERNAME:-}\""$'\n'
-    YAML+="  AGENT_BACKEND: \"${AGENT_BACKEND:-claude}\""$'\n'
+    YAML+="  AGENT_BACKEND: \"${BACKEND}\""$'\n'
+    # A pod has no TTY, so the relay MUST run headless (#2660/#2549); the
+    # interactive tmux path would stall forever. Carried in the ConfigMap so the
+    # Deployment picks it up via envFrom with everything else.
+    YAML+="  CONTRIBUTOR_MODE: \"${MODE_HEADLESS}\""$'\n'
+    # Path the headless relay writes its lifecycle state to; the Deployment's
+    # liveness/readiness probes read this same file.
+    YAML+="  HIVE_HEADLESS_STATUS_FILE: \"${HEADLESS_STATUS_FILE}\""$'\n'
     YAML+="---"$'\n'
     YAML+="# Sensitive credentials — treat as secret"$'\n'
     YAML+="apiVersion: v1"$'\n'
@@ -814,19 +872,145 @@ contribute-k8s namespace="hive-contributor" outfile="":
     YAML+="type: Opaque"$'\n'
     YAML+="data:"$'\n'
     YAML+="  HIVE_REGISTRATION_TOKEN: ${REG_TOKEN_B64}"$'\n'
-    YAML+="  GH_TOKEN: ${GH_TOKEN_B64}"
+    YAML+="  GH_TOKEN: ${GH_TOKEN_B64}"$'\n'
+
+    # ── Probe command (#2660 status file) ──
+    # The kubelet execs this against the pod. It reads the coarse lifecycle state
+    # the headless relay writes (waiting/working/done/failed):
+    #   file missing            -> exit 1  (relay not up yet / died before writing)
+    #   state == "failed"       -> exit 1  (task wedged & killed by the relay's
+    #                                        HEADLESS_TASK_TIMEOUT_MS, or a spawn
+    #                                        error — surface as unhealthy, NOT a
+    #                                        healthy-looking-but-stalled pod)
+    #   waiting|working|done    -> exit 0  (alive and connected)
+    # Emitted as a YAML block sequence (one arg per line) and written with a
+    # block scalar so shell quoting inside the command can't corrupt the YAML.
+    # We grep for the "state" line then test its VALUE — the relay only ever
+    # writes one of the four known values, so a plain grep on the file is enough
+    # and avoids needing jq. `grep -q failed` on the state line is the fail case;
+    # a matching known-good state is the pass case; anything else (no file, no
+    # recognised state) fails closed.
+    PROBE_STEP1='STATE=$(sed -n "s/.*\"state\"[^\"]*\"\\([a-z]*\\)\".*/\\1/p" '"${HEADLESS_STATUS_FILE}"' 2>/dev/null | head -1)'
+    PROBE_STEP2='case "$STATE" in waiting|working|done) exit 0 ;; *) exit 1 ;; esac'
+
+    # ── Deployment: the workload that actually runs the contributor (#2549) ──
+    YAML+="---"$'\n'
+    YAML+="# The contributor workload. Runs the relay HEADLESS (#2660): no TTY, one"$'\n'
+    YAML+="# one-shot CLI invocation per task. A long-lived Deployment (not a Job)"$'\n'
+    YAML+="# because the relay stays connected to the hub and pulls work over time;"$'\n'
+    YAML+="# Kubernetes restarts it on failure and keeps a stable identity — the"$'\n'
+    YAML+="# exact reason an operator wants a cluster over a laptop."$'\n'
+    YAML+="#"$'\n'
+    YAML+="# INTERIM CREDENTIAL NOTE (#2537): the Secret above carries a long-lived,"$'\n'
+    YAML+="# personal GH_TOKEN (scope repo,read:org). In a cluster it is base64 (NOT"$'\n'
+    YAML+="# encrypted), readable by anyone with 'get secrets' in this namespace and"$'\n'
+    YAML+="# by cluster-scoped operators/backups. This is materially more exposed"$'\n'
+    YAML+="# than a 0600 file on a laptop. Revoke any time with: gh auth logout (or"$'\n'
+    YAML+="# revoke the token in GitHub settings). Gating the credential on explicit"$'\n'
+    YAML+="# task acceptance is tracked in kubestellar/hive#2537 and is NOT solved"$'\n'
+    YAML+="# here — this path reuses the existing Secret rather than inventing new"$'\n'
+    YAML+="# long-lived credential plumbing."$'\n'
+    YAML+="apiVersion: apps/v1"$'\n'
+    YAML+="kind: Deployment"$'\n'
+    YAML+="metadata:"$'\n'
+    YAML+="  name: ${DEPLOYMENT_NAME}"$'\n'
+    YAML+="  namespace: ${NS}"$'\n'
+    YAML+="  labels:"$'\n'
+    YAML+="    app.kubernetes.io/name: hive-contributor"$'\n'
+    YAML+="    app.kubernetes.io/component: relay"$'\n'
+    YAML+="spec:"$'\n'
+    # Single replica: one relay per registration token / contributor identity.
+    # Scaling capacity means more (separately-registered) contributors, not more
+    # replicas of the same token — so a fixed 1 here, documented.
+    YAML+="  replicas: 1"$'\n'
+    YAML+="  selector:"$'\n'
+    YAML+="    matchLabels:"$'\n'
+    YAML+="      app.kubernetes.io/name: hive-contributor"$'\n'
+    YAML+="      app.kubernetes.io/component: relay"$'\n'
+    YAML+="  template:"$'\n'
+    YAML+="    metadata:"$'\n'
+    YAML+="      labels:"$'\n'
+    YAML+="        app.kubernetes.io/name: hive-contributor"$'\n'
+    YAML+="        app.kubernetes.io/component: relay"$'\n'
+    YAML+="    spec:"$'\n'
+    # Deployment pods are always restartPolicy: Always (the API rejects anything
+    # else) — the relay is meant to run forever and reconnect, so this is the
+    # right shape. Stated for the reader; not settable here.
+    YAML+="      restartPolicy: Always"$'\n'
+    YAML+="      containers:"$'\n'
+    YAML+="        - name: contributor"$'\n'
+    YAML+="          image: ${IMAGE}"$'\n'
+    # Pull the pinned tag on restart so a moved tag can't silently swap the code
+    # under a running contributor; a digest/pinned tag is recommended for repro.
+    YAML+="          imagePullPolicy: Always"$'\n'
+    # envFrom pulls the whole ConfigMap (incl. CONTRIBUTOR_MODE=headless) and the
+    # whole Secret — no per-key wiring to drift out of sync with the generator.
+    YAML+="          envFrom:"$'\n'
+    YAML+="            - configMapRef:"$'\n'
+    YAML+="                name: ${CONFIGMAP_NAME}"$'\n'
+    YAML+="            - secretRef:"$'\n'
+    YAML+="                name: ${SECRET_NAME}"$'\n'
+    YAML+="          resources:"$'\n'
+    YAML+="            requests:"$'\n'
+    YAML+="              memory: \"${MEM_REQUEST}\""$'\n'
+    YAML+="              cpu: \"${CPU_REQUEST}\""$'\n'
+    YAML+="            limits:"$'\n'
+    YAML+="              memory: \"${MEM_LIMIT}\""$'\n'
+    YAML+="              cpu: \"${CPU_LIMIT}\""$'\n'
+    # Readiness: gates the pod Ready only once the relay has authenticated and
+    # written a non-failed state. A wedged/failed relay drops out of Ready.
+    # emit_probe <indent> — appends an exec: command block sequence with the two
+    # probe steps as a single `sh -c` argument, block-scalar formatted so quoting
+    # inside the script can't corrupt the surrounding YAML.
+    emit_probe() {
+      local ind="$1"
+      YAML+="${ind}exec:"$'\n'
+      YAML+="${ind}  command:"$'\n'
+      YAML+="${ind}    - sh"$'\n'
+      YAML+="${ind}    - -c"$'\n'
+      YAML+="${ind}    - |"$'\n'
+      YAML+="${ind}      ${PROBE_STEP1}"$'\n'
+      YAML+="${ind}      ${PROBE_STEP2}"$'\n'
+    }
+
+    YAML+="          readinessProbe:"$'\n'
+    emit_probe "            "
+    YAML+="            initialDelaySeconds: 15"$'\n'
+    YAML+="            periodSeconds: 15"$'\n'
+    YAML+="            failureThreshold: 3"$'\n'
+    # Liveness: restarts the pod if the relay reports failed (a CLI killed by the
+    # HEADLESS_TASK_TIMEOUT_MS watchdog) or stops writing the file entirely.
+    # Longer initialDelay so a slow first authenticate isn't mistaken for death.
+    YAML+="          livenessProbe:"$'\n'
+    emit_probe "            "
+    YAML+="            initialDelaySeconds: 60"$'\n'
+    YAML+="            periodSeconds: 30"$'\n'
+    YAML+="            failureThreshold: 3"
 
     # ── Output ──
     OUTFILE="{{outfile}}"
     if [[ -n "$OUTFILE" ]]; then
       echo "$YAML" > "$OUTFILE"
-      echo "✓ K8s manifests written to ${OUTFILE}"
+      echo "✓ K8s contributor workload written to ${OUTFILE}"
+      echo "  Namespace + ConfigMap + Secret + Deployment (headless relay, image ${IMAGE})"
       echo ""
       echo "Apply with:"
       echo "  kubectl apply -f ${OUTFILE}"
+      echo ""
+      echo "Then watch it come up:"
+      echo "  kubectl -n ${NS} rollout status deploy/${DEPLOYMENT_NAME}"
+      echo ""
+      echo "Interim credential note (#2537): the Secret holds a long-lived personal"
+      echo "GH_TOKEN — base64, not encrypted, and cluster-readable. Revoke any time"
+      echo "with 'gh auth logout'. Pin the image with a 3rd arg, e.g.:"
+      echo "  just contribute-k8s ${NS} ${OUTFILE} <git-short-sha>"
     else
       echo "$YAML"
       echo ""
       echo "# Apply with: just contribute-k8s {{namespace}} | kubectl apply -f -"
       echo "# Or save:    just contribute-k8s {{namespace}} manifests.yaml"
+      echo "# Then:       kubectl -n {{namespace}} rollout status deploy/${DEPLOYMENT_NAME}"
+      echo "# Pin image:  just contribute-k8s {{namespace}} manifests.yaml <git-short-sha>"
+      echo "# Interim credential note (#2537): Secret holds a long-lived personal GH_TOKEN"
+      echo "#   (base64, cluster-readable). Revoke with 'gh auth logout'."
     fi

--- a/v2/deploy/test_contribute_k8s_workload.sh
+++ b/v2/deploy/test_contribute_k8s_workload.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Tests the `just contribute-k8s` contributor WORKLOAD generation (#2549).
+#
+# Before #2549 the recipe emitted only Namespace + ConfigMap + Secret and
+# nothing ran. It now ALSO emits a Deployment that runs the relay HEADLESS
+# (#2660) — a headless pod has no TTY, so it MUST set CONTRIBUTOR_MODE=headless
+# or the interactive tmux path stalls forever. This executes the real recipe
+# against a synthetic contributor.env and asserts the workload it produces,
+# rather than grepping the Justfile, so a regression fails the PR.
+#
+# Run: bash v2/deploy/test_contribute_k8s_workload.sh
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+check() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"
+    echo "        want: '$want'"
+    echo "        got:  '$got'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label (missing: '$needle')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Locate the repo root (this script lives in v2/deploy/) and require `just`.
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+if ! command -v just >/dev/null 2>&1; then
+  echo "  SKIP: 'just' not installed; cannot exercise the recipe"
+  exit 0
+fi
+
+echo "=== contribute-k8s workload generation tests ==="
+
+# Synthetic contributor config under a throwaway HOME (config_dir is
+# $HOME/.config/hive). Placeholder token values only — never a real credential.
+FAKE_HOME="$(mktemp -d)"
+trap 'rm -rf "$FAKE_HOME"' EXIT
+mkdir -p "$FAKE_HOME/.config/hive"
+cat > "$FAKE_HOME/.config/hive/contributor.env" <<'EOF'
+HIVE_HUB=wss://hive.example.io:3001/contribute
+CONTRIBUTOR_ID=c-test01
+CONTRIBUTOR_USERNAME=testuser
+AGENT_BACKEND=claude
+HIVE_REGISTRATION_TOKEN=placeholder-reg-token
+EOF
+cat > "$FAKE_HOME/.config/hive/gh-auth.env" <<'EOF'
+GH_TOKEN=placeholder-gh-token
+EOF
+
+# ── Supported backend (claude): full workload on stdout ──
+OUT="$(cd "$REPO_ROOT" && HOME="$FAKE_HOME" just contribute-k8s hive-contributor 2>/dev/null)"
+
+contains "emits a Deployment"                 "$OUT" "kind: Deployment"
+contains "workload runs headless (#2660)"     "$OUT" "CONTRIBUTOR_MODE: \"headless\""
+contains "status file env for the probe"      "$OUT" "HIVE_HEADLESS_STATUS_FILE:"
+contains "uses the published contributor image" "$OUT" "image: ghcr.io/kubestellar/hive-contributor:v2"
+contains "wires the ConfigMap via envFrom"    "$OUT" "configMapRef:"
+contains "wires the Secret via secretRef"     "$OUT" "secretRef:"
+contains "has a readiness probe"              "$OUT" "readinessProbe:"
+contains "has a liveness probe"               "$OUT" "livenessProbe:"
+contains "probe reads the status file"        "$OUT" "contributor-headless-status.json"
+contains "requests realistic memory"          "$OUT" "memory: \"1Gi\""
+contains "single replica"                     "$OUT" "replicas: 1"
+contains "interim credential note defers to #2537" "$OUT" "#2537"
+
+# ── Placeholder discipline: no real token bytes leak; still base64 placeholders. ──
+if printf '%s' "$OUT" | grep -q "GH_TOKEN: cGxhY2Vob2xkZXItZ2gtdG9rZW4="; then
+  echo "  PASS: Secret carries the base64 placeholder token (templated, not raw)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: expected base64-encoded placeholder token in the Secret"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── The generated YAML must parse. Prefer python3+yaml; fall back to a
+#    kind-count sanity check if PyYAML is unavailable. ──
+if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
+  KINDS="$(printf '%s' "$OUT" | python3 -c 'import sys,yaml; print(",".join(d["kind"] for d in yaml.safe_load_all(sys.stdin) if d))')"
+  check "YAML parses to the four expected kinds" "Namespace,ConfigMap,Secret,Deployment" "$KINDS"
+else
+  echo "  SKIP: PyYAML unavailable; skipping structural parse"
+fi
+
+# ── Unsupported headless backend (goose): warn on STDERR, keep stdout clean. ──
+cat > "$FAKE_HOME/.config/hive/contributor.env" <<'EOF'
+AGENT_BACKEND=goose
+HIVE_REGISTRATION_TOKEN=placeholder-reg-token
+EOF
+ERR="$(cd "$REPO_ROOT" && HOME="$FAKE_HOME" just contribute-k8s hive-contributor 2>&1 >/dev/null)"
+STDOUT_ONLY="$(cd "$REPO_ROOT" && HOME="$FAKE_HOME" just contribute-k8s hive-contributor 2>/dev/null)"
+contains "unsupported backend warns on stderr" "$ERR" "no headless (non-interactive) mode"
+# The warning must NOT pollute stdout (stdout is piped straight to kubectl).
+if printf '%s' "$STDOUT_ONLY" | grep -q "WARNING:"; then
+  echo "  FAIL: warning leaked into stdout (would corrupt 'kubectl apply -f -')"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: stdout stays clean YAML even for an unsupported backend"
+  PASS=$((PASS + 1))
+fi
+
+# ── Image pinning via the 3rd argument. ──
+PINNED="$(cd "$REPO_ROOT" && HOME="$FAKE_HOME" just contribute-k8s hive-contributor "" abc1234 2>/dev/null)"
+contains "3rd arg pins the image tag" "$PINNED" "image: ghcr.io/kubestellar/hive-contributor:abc1234"
+
+echo
+echo "=== $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1894,11 +1894,32 @@ type HubConfig struct {
 	// same Config.Hub.* mechanism as the other admission settings so it survives
 	// restart, and edited only through the authenticated PUT /api/contribute/queue/order
 	// endpoint (owner/read-write only).
-	ContributeQueueOrder []string            `yaml:"contribute_queue_order,omitempty"`
-	DisabledRepos        []string            `yaml:"disabled_repos"`
-	DisabledTiers        []string            `yaml:"disabled_tiers"`
-	TierLimits           map[string]TierRate `yaml:"tier_limits"`
-	SnapshotIntervalMin  int                 `yaml:"snapshot_interval_min"`
+	ContributeQueueOrder []string `yaml:"contribute_queue_order,omitempty"`
+	// ContributeRequireExplicitAccept gates HOW a contributor's scoped GitHub
+	// credential is delivered relative to task acceptance (kubestellar/hive#2537).
+	// The credential is ALWAYS delivered only AFTER an acceptance decision — it no
+	// longer travels bundled in the task_assign message. This toggle only chooses
+	// WHO makes that decision:
+	//   - nil / false (DEFAULT): trusted-source AUTO-ACCEPT. A task that already
+	//     passed admission (the title/author/label filters, disabled-repo/tier
+	//     gates, cooldown, and the per-tier trust gate in selectTask) is
+	//     auto-accepted the instant it is assigned, and the scoped credential is
+	//     delivered immediately after — no human in the loop. This keeps an
+	//     unattended fleet running exactly as before: the only observable change is
+	//     that the credential arrives in a distinct message right after task_assign
+	//     rather than inside it.
+	//   - true: EXPLICIT (manual/human) acceptance. The hub withholds the credential
+	//     until the client sends a task_accepted for the assigned task; a task that
+	//     is never accepted (declined, timed out, or reconnected away) never
+	//     receives a credential. This is the opt-in "mandatory acceptance" mode for
+	//     operators who want a wait state.
+	// A POINTER so an absent value (older on-disk config) resolves to the
+	// backward-compatible auto-accept default via IsContributeRequireExplicitAccept().
+	ContributeRequireExplicitAccept *bool               `yaml:"contribute_require_explicit_accept,omitempty"`
+	DisabledRepos                   []string            `yaml:"disabled_repos"`
+	DisabledTiers                   []string            `yaml:"disabled_tiers"`
+	TierLimits                      map[string]TierRate `yaml:"tier_limits"`
+	SnapshotIntervalMin             int                 `yaml:"snapshot_interval_min"`
 }
 
 // Contribute completion-cooldown defaults and clamp bounds. These live in the
@@ -1924,6 +1945,16 @@ const (
 // ENABLED for backward compatibility; an explicit false disables it.
 func (h HubConfig) IsContributeCooldownEnabled() bool {
 	return h.ContributeCooldownEnabled == nil || *h.ContributeCooldownEnabled
+}
+
+// IsContributeRequireExplicitAccept resolves the effective acceptance mode for
+// contributor credential delivery (kubestellar/hive#2537). A nil pointer (unset,
+// older config) resolves to FALSE — trusted-source auto-accept — so an existing
+// deployment keeps handing credentials to admitted tasks without a wait state; an
+// explicit true opts into mandatory (human/manual) acceptance where the credential
+// is withheld until the client accepts the assigned task.
+func (h HubConfig) IsContributeRequireExplicitAccept() bool {
+	return h.ContributeRequireExplicitAccept != nil && *h.ContributeRequireExplicitAccept
 }
 
 // ContributeCooldownHoursOrDefault resolves the with-PR cooldown PERIOD in

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1895,6 +1895,18 @@ type HubConfig struct {
 	// restart, and edited only through the authenticated PUT /api/contribute/queue/order
 	// endpoint (owner/read-write only).
 	ContributeQueueOrder []string `yaml:"contribute_queue_order,omitempty"`
+	// ContributeQueueHold is the OPERATOR HOLD set for the ready-work queue: an
+	// unordered list of "owner/repo#number" keys the operator parked from the
+	// Operations tab. A held issue is NEVER offered — it is excluded from BOTH the
+	// queue display's offer-eligible set (ReadyQueue) and selectTask's candidate
+	// selection — and it stays parked INDEFINITELY until the operator Resumes it.
+	// This is DISTINCT from cooldown (time-based, self-clearing): a hold is a
+	// manual, persistent operator decision. Held rows remain VISIBLE on the
+	// Operations tab (rendered greyed with an "on hold" badge) so the operator can
+	// always see and Resume them. Persisted through the same Config.Hub.* mechanism
+	// as ContributeQueueOrder so it survives restart, and edited only through the
+	// authenticated POST /api/contribute/queue/hold endpoint (owner/read-write only).
+	ContributeQueueHold []string `yaml:"contribute_queue_hold,omitempty"`
 	// ContributeRequireExplicitAccept gates HOW a contributor's scoped GitHub
 	// credential is delivered relative to task acceptance (kubestellar/hive#2537).
 	// The credential is ALWAYS delivered only AFTER an acceptance decision — it no

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -1194,6 +1194,7 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 <select id="mode-select" style="background:#161b22;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:6px 12px;font-size:.9rem;cursor:pointer">
 <option value="containerized">Containerized (recommended)</option>
 <option value="host">Host (non-containerized)</option>
+<option value="kubernetes">Kubernetes (cluster)</option>
 </select>
 </span>
 <span id="runtime-group" style="display:inline-flex;align-items:center;gap:8px;white-space:nowrap">
@@ -1208,6 +1209,15 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 <div id="model-row" style="margin-bottom:12px;display:none;align-items:center;gap:8px">
 <label style="font-size:.9rem;color:#8b949e">Model (optional):</label>
 <input id="model-input" type="text" placeholder="e.g. claude-sonnet-4-6, gpt-4o" style="background:#161b22;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:6px 12px;font-size:.85rem;flex:1;max-width:300px" oninput="updateCmds()">
+</div>
+<!-- #2549 Kubernetes-mode note. Hidden except in Kubernetes mode. States the two
+     honest constraints up front: only headless-capable backends run in a cluster
+     (a headless pod has no TTY), and the credential stored in the cluster Secret
+     is a long-lived personal token that is more exposed than a laptop file, with
+     the per-task credential boundary tracked in #2537. -->
+<div id="k8s-note" style="display:none;margin-bottom:12px;background:#161b22;border:1px solid #30363d;border-left:3px solid #d29922;border-radius:6px;padding:12px 14px;font-size:.85rem;color:#c9d1d9;line-height:1.5">
+<strong style="color:#e6edf3">Kubernetes is the advanced path.</strong> It needs a cluster, a kubeconfig and RBAC &mdash; not a first-timer&rsquo;s happy path. The workload runs the relay <strong>headless</strong> (no TTY), so only headless-capable backends work in a cluster: <strong>Claude Code, LiteLLM, Copilot, Codex</strong>. Other backends will refuse work at pod startup.<br>
+<span style="color:#8b949e">Credential note (interim): the generated Secret stores a long-lived personal <code>GH_TOKEN</code> &mdash; base64, not encrypted, and readable by anyone with <code>get secrets</code> in that namespace or by cluster-scoped operators/backups. That is materially more exposed than a <code>0600</code> file on your laptop. Revoke any time with <code>gh auth logout</code>. Gating the credential on explicit task acceptance is tracked in <a href="https://github.com/kubestellar/hive/issues/2537" target="_blank" rel="noopener" style="color:#58a6ff">#2537</a> and is not solved by this path.</span>
 </div>
 <p style="color:#8b949e;margin-bottom:8px">Copy and paste these commands to get started:</p>
 <div style="margin-top:16px;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:16px;position:relative">
@@ -1248,6 +1258,16 @@ windows:'winget install --id Casey.Just --exact\nwinget install --id GitHub.cli'
 };
 var containerTpl='PREREQ\ngit clone -b v2 https://github.com/kubestellar/hive && cd hive\nexport HIVE_HUB='+hubURL+'\njust contribute-setup CLI\njust contribute-hive';
 var hostTpl='PREREQ\nINSTALL\ngit clone -b v2 https://github.com/kubestellar/hive && cd hive\nexport HIVE_HUB='+hubURL+'\njust contribute-setup CLI\njust contribute-hive CLI local';
+// Kubernetes (#2549): register locally, then generate + apply a headless
+// contributor workload (Deployment, #2660) into a cluster you already have.
+// just contribute-k8s prints the manifest; it never touches your cluster on
+// its own, so you can read it before piping to kubectl. Only the headless-
+// capable backends run this way (see K8S_HEADLESS_BACKENDS).
+var k8sTpl='PREREQ\ngit clone -b v2 https://github.com/kubestellar/hive && cd hive\nexport HIVE_HUB='+hubURL+'\njust contribute-setup CLI\n# Review the manifest, then apply into your current kube-context:\njust contribute-k8s hive-contributor | kubectl apply -f -\nkubectl -n hive-contributor rollout status deploy/hive-contributor';
+// Backends with a verified headless (non-interactive) entry point — must match
+// HEADLESS_BACKENDS in bin/contributor-relay.sh and the Justfile. A pod has no
+// TTY, so only these run in a cluster; anything else refuses work at startup.
+var K8S_HEADLESS_BACKENDS={claude:1,litellm:1,copilot:1,codex:1};
 var modelRow=document.getElementById('model-row');
 var modelInput=document.getElementById('model-input');
 function updateCmds(){update();}
@@ -1261,6 +1281,11 @@ var modelFlag=opt.getAttribute('data-model-flag')||'';
 var model=(modelInput.value||'').trim();
 if(cli==='other')mode='host';
 if(mode==='containerized'&&cli==='other'){modeSel.value='host';mode='host';}
+// #2549 Kubernetes mode. "other" has no image, so it can't run in a cluster;
+// fall back to host. Show the k8s note only in this mode.
+if(mode==='kubernetes'&&cli==='other'){modeSel.value='host';mode='host';}
+var k8sNote=document.getElementById('k8s-note');
+if(k8sNote)k8sNote.style.display=(mode==='kubernetes')?'block':'none';
 modelRow.style.display=(modelFlag||cli==='goose')?'flex':'none';
 var modelLine='';
 if(model){
@@ -1276,7 +1301,15 @@ runtimeGroup.style.display=showRuntime?'inline-flex':'none';
 var runtimeLine=(showRuntime&&runtimeSel.value)?'export HIVE_CONTAINER_RUNTIME='+runtimeSel.value+'\n':'';
 var preLines=envLines+modelLine+runtimeLine;
 var tpl,install;
-if(mode==='host'){
+if(mode==='kubernetes'){
+// A cluster pod exports its config via envFrom, so no HIVE_CONTAINER_RUNTIME
+// line — but model/env exports still belong before contribute-setup so the
+// generated ConfigMap picks them up. If the chosen backend has no headless
+// mode, prepend a visible warning comment (the Justfile also warns on stderr).
+var warn=K8S_HEADLESS_BACKENDS[cli]?'':'# WARNING: '+cli+' has no headless mode; it will refuse work in a cluster.\n# Pick Claude Code, LiteLLM, Copilot or Codex for Kubernetes.\n';
+var k8sPre=envLines+modelLine;
+cmds.textContent=warn+k8sTpl.replace('PREREQ',prereq).replace(/CLI/g,cli).replace('just contribute-setup',k8sPre+'just contribute-setup');
+}else if(mode==='host'){
 tpl=hostTpl;
 install=opt.getAttribute('data-host-install');
 if(!install)install='# '+cli+' uses your existing gh auth';

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -2789,8 +2789,11 @@ onEl('clanker-list','click',function(e){
     // returned to the queue and booked for the same short cooldown as an auto-release,
     // so it is not instantly re-handed to a stale worker. Uses the existing
     // POST /api/contributors/{id}/requeue endpoint (owner/read-write only).
-    adminConfirm('Requeue '+user+'&rsquo;s task','Release the task '+user+' is currently holding back to the ready queue. Use this when a connected clanker is wedged (connected but not progressing). The task is booked for the same short cooldown as an automatic release, so it is not instantly re-assigned to a stale worker. This uses the existing POST /api/contributors/{id}/requeue endpoint.','Requeue',function(){
-      fetch('/api/contributors/'+encodeURIComponent(cid)+'/requeue',{method:'POST'})
+    adminConfirm('Requeue '+user+'&rsquo;s task','Release the task '+user+' is currently holding back to the ready queue. Use this when a connected clanker is wedged (connected but not progressing). The task is booked for the same short cooldown as an automatic release, and the assignment generation is bumped so a stale worker cannot later overwrite the new owner. This uses the existing POST /api/contributors/{id}/requeue endpoint.','Requeue',function(){
+      // #2568: let the operator attach an optional reason. It is recorded in the
+      // audit + activity log and pushed to the still-connected worker on task_revoke.
+      var reason=(window.prompt('Reason for releasing this task (optional):','wedged: no progress')||'').trim();
+      fetch('/api/contributors/'+encodeURIComponent(cid)+'/requeue',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({reason:reason})})
         .then(function(r){return r.json().then(function(d){return{ok:r.ok,d:d};});})
         .then(function(x){if(x.ok){toast('Task requeued for '+user,true);opsPoll();}else{toast((x.d&&x.d.error)||'Requeue failed',false);}})
         .catch(function(){toast('Requeue failed',false);});
@@ -4945,10 +4948,13 @@ func (s *Server) handleContributorRevoke(w http.ResponseWriter, r *http.Request)
 // ContributeWSHub.RequeueContributorTask — so a manual requeue can NOT recreate the
 // duplicate-assignment race #2492/#2557 closed: the released issue books the same
 // short failure cooldown and is therefore not instantly re-handed to a stale worker.
-// It does NOT enforce wsTaskTimeout automatically (manual action only) and does NOT
-// implement the deferred renewable-lease / generation-token protocol (that is the
-// follow-up design half of #2568). Requeuing a contributor with no in-flight task is
-// a 404 (nothing to release) rather than a silent no-op.
+//
+// #2568 completion: the release now BUMPS the connection's assignment generation, so a
+// stale worker that later reports completion is fenced out (the Gate — the automatic
+// lease-TTL backstop lives in the hub's cleanupLoop/reclaimExpiredLeases). The operator
+// may pass a REASON (JSON body {"reason":...} or ?reason=), which is recorded in the
+// audit + activity log and pushed to the still-connected worker on task_revoke.
+// Requeuing a contributor with no in-flight task is a 404 (nothing to release).
 func (s *Server) handleContributorRequeue(w http.ResponseWriter, r *http.Request) {
 	if !s.requireContributorWrite(w, r) {
 		return
@@ -4963,15 +4969,27 @@ func (s *Server) handleContributorRequeue(w http.ResponseWriter, r *http.Request
 		jsonError(w, "Contributor relay is not available", http.StatusServiceUnavailable)
 		return
 	}
+	// #2568: accept an optional operator reason from a JSON body or query param. Both
+	// are optional — an empty reason falls back to the hub's default recovery label —
+	// so existing callers that POST no body keep working unchanged.
+	reason := strings.TrimSpace(r.URL.Query().Get("reason"))
+	if reason == "" && r.Body != nil {
+		var body struct {
+			Reason string `json:"reason"`
+		}
+		if json.NewDecoder(r.Body).Decode(&body) == nil {
+			reason = strings.TrimSpace(body.Reason)
+		}
+	}
 	// Key the live release by the registered ContributorID (what the ops tab passes),
 	// matching how the hub tracks connections. GitHubUsername is only used for logs.
-	released := s.contributeHub.RequeueContributorTask(p.ContributorID)
+	released := s.contributeHub.RequeueContributorTask(p.ContributorID, reason)
 	if released == 0 {
 		jsonError(w, "That contributor has no in-flight task to requeue.", http.StatusNotFound)
 		return
 	}
-	s.auditFromRequest(r, "contributor_requeue", auditDetail("username", p.GitHubUsername), "")
-	s.logger.Info("contributor task requeued by operator", "username", p.GitHubUsername, "sessions_released", released)
+	s.auditFromRequest(r, "contributor_requeue", auditDetail("username", p.GitHubUsername, "reason", reason), "")
+	s.logger.Info("contributor task requeued by operator", "username", p.GitHubUsername, "sessions_released", released, "reason", reason)
 	jsonResponse(w, map[string]any{"ok": true, "released": released})
 }
 

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -733,6 +733,19 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 /* Ops "your army" counts + card counts as bold numerals (tabular, no layout shift). */
 .cc-army b{font-weight:700;font-variant-numeric:tabular-nums}
 .ops-card-count.count-strong{color:var(--cc-text);font-weight:700;font-variant-numeric:tabular-nums}
+/* Small circled-i info affordance next to a header (cooldown explainer, #2649
+   companion). A borderless button carrying the ⓘ glyph; hover/focus brightens it.
+   The popover is an absolutely-positioned card toggled open by JS (aria-expanded),
+   anchored to the wrapper so it sits just under the glyph. */
+.info-affordance{position:relative;display:inline-flex;align-items:center}
+.info-btn{background:none;border:0;padding:0 2px;margin-left:4px;color:#6e7681;cursor:pointer;font-size:.85rem;line-height:1;vertical-align:middle}
+.info-btn:hover,.info-btn:focus{color:#58a6ff;outline:none}
+.info-pop{position:absolute;top:130%%;left:0;z-index:40;width:300px;max-width:78vw;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:10px 12px;box-shadow:0 8px 24px rgba(1,4,9,.7);color:#c9d1d9;font-size:.74rem;line-height:1.5;font-weight:400;text-align:left;white-space:normal}
+.info-pop[hidden]{display:none}
+.info-pop h4{margin:0 0 4px;font-size:.76rem;color:#e6edf3;font-weight:600}
+.info-pop ul{margin:4px 0 0;padding-left:16px}
+.info-pop li{margin:2px 0}
+.info-pop code{background:#161b22;border:1px solid #21262d;border-radius:4px;padding:0 3px;font-size:.7rem}
 /* Compact tier badge inline next to a connected clanker's identity. */
 .tier-badge.tier-inline{padding:1px 6px 1px 4px;font-size:.62rem;margin-left:6px;vertical-align:middle}
 .tier-badge.tier-inline::before{width:6px;height:6px}
@@ -1729,6 +1742,9 @@ update();  // initial paint: copy block + branded UI in sync from first load
 <div class="admin-field" id="admin-cooldown-hours-wrap" style="margin-left:50px">
 <label>Cooldown period (hours) <span style="color:#6e7681">— 168 = one week (default). Range 1&ndash;8760.</span></label>
 <input type="number" id="admin-cooldown-hours" min="1" max="8760" style="max-width:120px">
+<!-- Live tally of issues currently within their cooldown window (#2649 companion),
+     hydrated by ccRenderCooldownCount from the fleet payload. Hidden when 0. -->
+<div id="admin-cooldown-count" class="admin-toggle-sub" style="margin-top:4px;display:none"></div>
 </div>
 
 <hr class="admin-hr">
@@ -1826,7 +1842,25 @@ update();  // initial paint: copy block + branded UI in sync from first load
 <div class="work-list" id="work-list"><div class="ops-empty">Loading work&hellip;</div></div>
 </div>
 <div class="ops-card card-accent" style="margin-top:20px">
-<div class="ops-card-head"><span class="feed-dot"></span><h3>Ready-work queue</h3><span class="ops-card-count" id="queue-count"></span><!-- 7-day queue-depth trend (#persistent-history), hydrated by ccMetricsPoll --><span class="spark spark-inline" id="spark-queue" title="Ready-work queue depth, last 7 days (hourly)"></span>
+<div class="ops-card-head"><span class="feed-dot"></span><h3>Ready-work queue</h3><span class="ops-card-count" id="queue-count"></span><!-- Cooldown explainer (#2649 companion): a circled-i affordance whose popover
+     explains what "in cooldown" in the count means and how an issue lands there.
+     Numbers here are the REAL server constants (168h with-PR, ~4h no-PR, ~6h
+     quarantine after 3 consecutive failures) — keep them in sync with
+     completedTaskCooldownHours / completedNoPRCooldownHours / quarantineCooldownHours
+     / consecutiveFailureQuarantineThreshold in contribute_ws.go. -->
+<span class="info-affordance">
+<button type="button" class="info-btn" id="cooldown-info-btn" aria-haspopup="true" aria-expanded="false" aria-controls="cooldown-info-pop" aria-label="What is cooldown?" title="What is cooldown?">&#9432;</button>
+<div class="info-pop" id="cooldown-info-pop" role="tooltip" hidden>
+<h4>What is cooldown?</h4>
+Cooldown briefly holds a just-worked issue out of the ready queue so it isn&rsquo;t instantly re-offered while a PR settles. An issue enters cooldown when it is:
+<ul>
+<li>completed <b>with a verified PR</b> &mdash; held for the full cooldown period (default <code>168h</code> / 7 days, configurable in Management &rarr; Task cooldown).</li>
+<li>completed with <b>no PR</b> &mdash; held ~<code>4h</code>.</li>
+<li><b>failed</b> &mdash; a short cooldown; after <code>3</code> consecutive failures the issue is quarantined for ~<code>6h</code>.</li>
+</ul>
+It clears automatically when the period elapses. An operator can shorten or disable the with-PR period in the Management tab.
+</div>
+</span><!-- 7-day queue-depth trend (#persistent-history), hydrated by ccMetricsPoll --><span class="spark spark-inline" id="spark-queue" title="Ready-work queue depth, last 7 days (hourly)"></span>
 <!-- #queue-suspend-btn is the SAME logical control as the Management "Suspend
      contributions" switch (#admin-suspend-switch) — not a related toggle, the
      identical Config.Hub.ContributeSuspended state surfaced a second place. Both
@@ -2638,6 +2672,42 @@ function _wireConfirmModal(){
 }
 if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',_wireConfirmModal);else _wireConfirmModal();
 
+// _wireCooldownInfo toggles the cooldown explainer popover (#2649 companion). The
+// ⓘ button flips the popover's [hidden] + aria-expanded; a click anywhere else or
+// Escape closes it. Null-guarded so a missing element never throws (matching the
+// confirm-modal wiring above).
+function _wireCooldownInfo(){
+  var btn=document.getElementById('cooldown-info-btn');
+  var pop=document.getElementById('cooldown-info-pop');
+  if(!btn||!pop)return;
+  function close(){pop.hidden=true;btn.setAttribute('aria-expanded','false');}
+  btn.addEventListener('click',function(e){
+    e.stopPropagation();
+    var open=pop.hidden;
+    pop.hidden=!open;
+    btn.setAttribute('aria-expanded',open?'true':'false');
+  });
+  document.addEventListener('click',function(e){if(!pop.hidden&&e.target!==btn&&!pop.contains(e.target))close();});
+  document.addEventListener('keydown',function(e){if(e.key==='Escape')close();});
+}
+if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',_wireCooldownInfo);else _wireCooldownInfo();
+
+// ccRenderCooldownCount surfaces the current cooldown tally next to the Management
+// tab's Task cooldown control (#2649): "M issues currently cooling down". It reads
+// the ccCooldownCount stashed by opsPoll and writes into #admin-cooldown-count.
+// Hidden entirely when 0 so the control stays clean.
+function ccRenderCooldownCount(){
+  var el=document.getElementById('admin-cooldown-count');
+  if(!el)return;
+  if(ccCooldownCount>0){
+    el.textContent=ccCooldownCount+(ccCooldownCount===1?' issue currently cooling down':' issues currently cooling down');
+    el.style.display='';
+  }else{
+    el.textContent='';
+    el.style.display='none';
+  }
+}
+
 // Persist a subset of Config.Hub.* through the SAME endpoint the Governor Hub
 // dialog uses. Only the passed keys are sent; the handler ignores omitted fields.
 async function adminSaveHub(patch,okMsg){
@@ -3252,6 +3322,15 @@ async function opsPoll(){
     safeRender('clankers',function(){renderClankers((data&&data.clankers)||[]);});
     safeRender('work',function(){renderWork((data&&data.work)||[]);});
     safeRender('policy',function(){renderPolicy(data&&data.policy);});
+    // Cooldown / in-flight tallies (#2649 companion): stash the read-only counts
+    // from the fleet payload so the ready-queue header can annotate "N ready" with
+    // "M in cooldown / K in flight", and the Management cooldown control can show
+    // how many issues are currently cooling down. Coerced to a number; a missing
+    // field stays 0. A re-render picks up the fresh values.
+    ccCooldownCount=(data&&typeof data.cooldown_count==='number')?data.cooldown_count:0;
+    ccInFlightCount=(data&&typeof data.in_flight_count==='number')?data.in_flight_count:0;
+    safeRender('queue-counts',function(){if(typeof ccRenderQueue==='function')ccRenderQueue();});
+    safeRender('cooldown-count',function(){if(typeof ccRenderCooldownCount==='function')ccRenderCooldownCount();});
   }catch(e){
     // fetch/parse failed — log so the "Loading…" placeholders are diagnosable, and
     // fall through to reschedule so a transient failure self-heals on the next poll.
@@ -3279,6 +3358,8 @@ var ccQueuePollTimer=null; // fallback poll timer
 var ccKnownClankers={};    // username -> true, for enter/leave detection
 var ccCompleteStreak={};   // username -> consecutive completes (achievement combos)
 var ccLastAch=0;           // debounce achievement pops
+var ccCooldownCount=0;     // issues still within cooldown (from fleet payload, #2649)
+var ccInFlightCount=0;     // issues currently held by a live connection (fleet payload)
 
 // ── Label-affinity (#2637): the viewer's own label interests ───────────────────
 // ccInterests is this viewer's opt-in label list (normalised lower-case). Loaded
@@ -3409,7 +3490,15 @@ function ccRenderQueue(flip){
   // every render path. Populated FIRST so it stays set even if the container is absent.
   // (The interest re-float below only reorders ccQueue, never changes its length.)
   var qc=document.getElementById('queue-count');
-  if(qc)qc.textContent=ccQueue.length+' ready';
+  // Header tally: "N ready" plus the read-only cooldown / in-flight segments from
+  // the fleet payload (#2649 companion). A segment is OMITTED when its count is 0
+  // so the header stays compact; " · " (a middot) separates present segments.
+  if(qc){
+    var segs=[ccQueue.length+' ready'];
+    if(ccCooldownCount>0)segs.push(ccCooldownCount+' in cooldown');
+    if(ccInFlightCount>0)segs.push(ccInFlightCount+' in flight');
+    qc.textContent=segs.join(' · ');
+  }
   // Label-affinity (#2637): re-tag + float this viewer's interested items. No-op
   // when no interests are set (order preserved); skipped mid-drag so an operator
   // reorder is not fought by an interest re-float. See ccApplyInterestsToQueue.
@@ -4750,13 +4839,21 @@ func (s *Server) buildContributeAdmissionPolicy() ContributeAdmissionPolicy {
 // the hub's live connection state and the already-configured admission policy.
 func (s *Server) handleContributeFleet(w http.ResponseWriter, r *http.Request) {
 	snap := FleetSnapshot{Clankers: []FleetClanker{}, Work: []FleetWorkItem{}}
+	// cooldownCount = completed issues still within their cooldown window (held out
+	// of the queue); inFlightCount = issues currently held by a live connection.
+	// Both are read-only tallies the queue header / Management tab surface (#2649
+	// configurable cooldown).
+	cooldownCount, inFlightCount := 0, 0
 	if s.contributeHub != nil {
 		snap = s.contributeHub.FleetSnapshot()
+		cooldownCount, inFlightCount = s.contributeHub.CooldownCounts()
 	}
 	jsonResponse(w, map[string]any{
-		"clankers": snap.Clankers,
-		"work":     snap.Work,
-		"policy":   s.buildContributeAdmissionPolicy(),
+		"clankers":        snap.Clankers,
+		"work":            snap.Work,
+		"policy":          s.buildContributeAdmissionPolicy(),
+		"cooldown_count":  cooldownCount,
+		"in_flight_count": inFlightCount,
 	})
 }
 

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -992,6 +992,14 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 .cc-interest-chip{display:inline-flex;align-items:center;gap:5px;padding:2px 9px;border-radius:999px;font-size:.74rem;background:rgba(46,160,67,.12);color:#3fb950;border:1px solid rgba(46,160,67,.3)}
 .cc-interest-x{cursor:pointer;opacity:.7;font-size:.95rem;line-height:1}
 .cc-interest-x:hover{opacity:1}
+/* #2677: read-only mirror of a contributor's OWN label interests, shown on their
+   row in the operator "Connected clankers" fleet list (Operations tab). Reuses
+   the .cc-interest-chip visual (same green affinity color) in a compact, non-
+   interactive line so an owner gets a fleet-wide view without editing anything
+   here — editing stays contributor-owned via My label interests above. */
+.clanker-interests{display:flex;flex-wrap:wrap;align-items:center;gap:4px;margin-top:3px;font-size:.68rem;color:#6e7681}
+.clanker-interests-label{color:#6e7681}
+.clanker-interest-chip{display:inline-flex;padding:1px 7px;border-radius:999px;font-size:.68rem;background:rgba(46,160,67,.12);color:#3fb950;border:1px solid rgba(46,160,67,.3)}
 .cc-interests-add{display:flex;gap:6px}
 .cc-interests-add input{flex:1;min-width:0;background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:7px;color:var(--cc-text);font:inherit;font-size:.8rem;padding:5px 9px;outline:none;transition:border-color .15s,box-shadow .15s}
 .cc-interests-add input::placeholder{color:var(--cc-muted-2)}
@@ -3038,6 +3046,18 @@ function idleReasonLabel(r){
     tier_disabled:'tier disabled',concurrency_limit:'concurrency limit'};
   return m[r]||String(r).replace(/_/g,' ');
 }
+// clankerInterestsLine (#2677) renders one contributor's OWN label interests as
+// a compact read-only chip line for the operator fleet view. Purely
+// observability: an owner sees who prefers what, but this never offers a way
+// to set/edit another contributor's interests — that stays contributor-owned
+// via PUT /api/contribute/interests (see the "My label interests" editor
+// above). Returns '' when the contributor has none declared, matching how
+// capabilityLine() omits itself for an unversioned client.
+function clankerInterestsLine(interests){
+  if(!interests||!interests.length)return '';
+  var chips=interests.map(function(l){return '<span class="clanker-interest-chip">'+esc(l)+'</span>';}).join('');
+  return '<div class="clanker-interests" title="This contributor&rsquo;s own opt-in label interests. Read-only here &mdash; they set these themselves."><span class="clanker-interests-label">prefers:</span>'+chips+'</div>';
+}
 function renderClankers(list){
   list=list||[];
   var el=document.getElementById('clanker-list');
@@ -3068,6 +3088,10 @@ function renderClankers(list){
     // used to route or gate work — see capabilityLine() for the "self-declared" note
     // that keeps that visible at the point of use (per the issue's risk section).
     var capsLine=capabilityLine(c.capabilities);
+    // #2677: this contributor's own label interests, read-only, so the operator
+    // gets a fleet-wide view of who prefers what without cross-referencing each
+    // profile separately (the data already travels in this same fleet snapshot).
+    var interestsLine=clankerInterestsLine(c.label_interests);
     // #2534: owner/read-write get per-contributor admin actions wired to the
     // EXISTING endpoints — set trust tier / promote (PUT /api/contributors/{id}/trust),
     // revoke (POST .../revoke), remove (DELETE .../{id}). Hidden for read viewers.
@@ -3104,7 +3128,7 @@ function renderClankers(list){
     var rowCls='clanker-row'+(isNew?' cc-enter':'');
     return '<div class="'+rowCls+'" data-clanker="'+esc(key)+'"><span class="clanker-dot'+(c.stale?' stale':'')+'"></span>'+av+
       '<div class="clanker-main"><div class="clanker-user">'+esc(user)+statusPill+tierPill+'</div>'+
-      '<div class="clanker-sub">'+(sub||'&mdash;')+'</div>'+task+capsLine+'</div>'+
+      '<div class="clanker-sub">'+(sub||'&mdash;')+'</div>'+task+capsLine+interestsLine+'</div>'+
       (actions||('<span class="feed-time">'+esc(rel(c.connected_at))+'</span>'))+'</div>';
   }).join('');
 }

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -255,6 +255,13 @@ func (s *Server) registerContributeRoutes() {
 	// reads (only counts + already-public usernames; no tokens, no PII). GET only,
 	// no side effects. See contribute_metrics.go.
 	s.mux.HandleFunc("GET /api/contribute/metrics", s.handleContributeMetrics)
+	// Read-only TRIAGE ladder (#2612 part b): the contribute issues grouped into a
+	// Warp-style lifecycle (Triaging → Ready → Implementing → Reviewing → Closed),
+	// DERIVED LIVE from the ready queue + fleet snapshot + the PR→issue link (part
+	// c) — no new persistent store. Public like the other /api/contribute* reads
+	// (only public issue metadata + public PR numbers; no tokens, no PII). Fetched
+	// after page load so a slow GitHub PR-link lookup never delays the page render.
+	s.mux.HandleFunc("GET /api/contribute/triage", s.handleContributeTriage)
 	// Operator priority override for the ready-work queue. Owner/read-write only —
 	// enforced IN-HANDLER via requireContributorWrite because the /api/contribute
 	// prefix is exempt from roleEnforcement's read-only block (see that helper).
@@ -501,65 +508,130 @@ func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request)
 	fmt.Fprintf(w, `<!DOCTYPE html>
 <html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Contribute to %s</title>
 <style>
+/* ── Theme tokens (#2612 part d) ─────────────────────────────────────────────
+   The /contribute page shipped with a hardcoded GitHub-dark palette and zero
+   light-mode infrastructure. These custom properties name the palette once so
+   the whole sheet can flip to a light appearance without touching any rule. The
+   :root defaults below are the ORIGINAL dark hex values byte-for-byte, so the
+   dark appearance is unchanged; only the neutral surface/border/text ramp is
+   tokenized (accents like blue/green/amber/red read fine on both themes and are
+   pinned by exact-match tests, so they stay literal and are exposed here only as
+   named tokens for the light-mode fixups below).
+   Light mode activates on BOTH signals — the OS preference AND an explicit
+   :root[data-theme="light"] hook — so a future in-page toggle can force it
+   (the toggle itself is out of scope). data-theme="dark" always wins back to
+   dark even under a light OS preference. Values are Primer-light neutrals so the
+   surface blends with the surrounding Docusaurus docs chrome. */
+:root{
+  --cc-bg:#0d1117;
+  --cc-bg-deep:#010409;
+  --cc-surface:#161b22;
+  --cc-border:#30363d;
+  --cc-border-2:#21262d;
+  --cc-text:#e6edf3;
+  --cc-text-2:#c9d1d9;
+  --cc-muted:#8b949e;
+  --cc-muted-2:#6e7681;
+  --cc-code-bg:#0d1117;
+  --cc-accent:#58a6ff;
+  --cc-accent-fg:#1f6feb;
+  --cc-green:#3fb950;
+  --cc-amber:#d29922;
+  --cc-red:#f85149;
+}
+@media(prefers-color-scheme:light){:root:not([data-theme="dark"]){
+  --cc-bg:#ffffff;
+  --cc-bg-deep:#f6f8fa;
+  --cc-surface:#f6f8fa;
+  --cc-border:#d0d7de;
+  --cc-border-2:#eaeef2;
+  --cc-text:#1f2328;
+  --cc-text-2:#32383f;
+  --cc-muted:#636c76;
+  --cc-muted-2:#7d858e;
+  --cc-code-bg:#eff1f3;
+  --cc-accent:#0969da;
+  --cc-accent-fg:#0969da;
+  --cc-green:#1a7f37;
+  --cc-amber:#9a6700;
+  --cc-red:#cf222e;
+}}
+:root[data-theme="light"]{
+  --cc-bg:#ffffff;
+  --cc-bg-deep:#f6f8fa;
+  --cc-surface:#f6f8fa;
+  --cc-border:#d0d7de;
+  --cc-border-2:#eaeef2;
+  --cc-text:#1f2328;
+  --cc-text-2:#32383f;
+  --cc-muted:#636c76;
+  --cc-muted-2:#7d858e;
+  --cc-code-bg:#eff1f3;
+  --cc-accent:#0969da;
+  --cc-accent-fg:#0969da;
+  --cc-green:#1a7f37;
+  --cc-amber:#9a6700;
+  --cc-red:#cf222e;
+}
 *{margin:0;padding:0;box-sizing:border-box}
-body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#0d1117;color:#e6edf3;margin:0;min-height:100vh}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:var(--cc-bg);color:var(--cc-text);margin:0;min-height:100vh}
 .page{display:flex;min-height:100vh;width:100%%}
 .main{flex:3;padding:40px 48px;overflow-y:auto}
-.sidebar{flex:1;background:#161b22;border-left:1px solid #30363d;display:flex;flex-direction:column;position:sticky;top:0;height:100vh;overflow-y:auto}
+.sidebar{flex:1;background:var(--cc-surface);border-left:1px solid var(--cc-border);display:flex;flex-direction:column;position:sticky;top:0;height:100vh;overflow-y:auto}
 h1{font-size:2rem;margin-bottom:8px}
-.subtitle{color:#8b949e;font-size:1.1rem;margin-bottom:32px}
+.subtitle{color:var(--cc-muted);font-size:1.1rem;margin-bottom:32px}
 .stat-row{display:grid;grid-template-columns:repeat(auto-fit,minmax(80px,1fr));gap:10px;margin-bottom:24px}
-.stat{background:#161b22;border:1px solid #30363d;border-radius:10px;padding:14px 8px;text-align:center}
+.stat{background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:10px;padding:14px 8px;text-align:center}
 .stat-num{font-size:1.5rem;font-weight:700;color:#58a6ff}
-.stat-label{font-size:.7rem;color:#8b949e;margin-top:4px}
-.steps{background:#161b22;border:1px solid #30363d;border-radius:12px;padding:24px;margin-top:24px}
+.stat-label{font-size:.7rem;color:var(--cc-muted);margin-top:4px}
+.steps{background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:12px;padding:24px;margin-top:24px}
 .steps h3{margin-top:0;color:#58a6ff}
 .steps ol{padding-left:20px;line-height:2}
-code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
+code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 .how{margin-top:32px}
-.how h3{color:#e6edf3}
-.how p{color:#8b949e;line-height:1.6}
+.how h3{color:var(--cc-text)}
+.how p{color:var(--cc-muted);line-height:1.6}
 .tier-table{width:100%%;border-collapse:collapse;margin-top:16px}
-.tier-table th,.tier-table td{padding:8px 12px;text-align:left;border-bottom:1px solid #30363d;font-size:.85rem}
-.tier-table th{color:#8b949e;font-weight:600}
-.feed-header{padding:20px 20px 12px;border-bottom:1px solid #30363d;display:flex;align-items:center;gap:8px}
-.feed-header h3{font-size:.95rem;color:#e6edf3}
+.tier-table th,.tier-table td{padding:8px 12px;text-align:left;border-bottom:1px solid var(--cc-border);font-size:.85rem}
+.tier-table th{color:var(--cc-muted);font-weight:600}
+.feed-header{padding:20px 20px 12px;border-bottom:1px solid var(--cc-border);display:flex;align-items:center;gap:8px}
+.feed-header h3{font-size:.95rem;color:var(--cc-text)}
 .feed-dot{width:8px;height:8px;border-radius:50%%;background:#3fb950;animation:pulse 2s infinite}
 @keyframes pulse{0%%,100%%{opacity:1}50%%{opacity:.4}}
-.feed-count{font-size:.75rem;color:#8b949e;margin-left:auto}
+.feed-count{font-size:.75rem;color:var(--cc-muted);margin-left:auto}
 .feed-scroll{flex:1;overflow-y:auto;padding:0}
-.feed-entry{padding:10px 20px;border-bottom:1px solid #21262d;font-size:.85rem;animation:fadeIn .3s ease;display:flex;align-items:flex-start;gap:12px}
+.feed-entry{padding:10px 20px;border-bottom:1px solid var(--cc-border-2);font-size:.85rem;animation:fadeIn .3s ease;display:flex;align-items:flex-start;gap:12px}
 @keyframes fadeIn{from{opacity:0;transform:translateY(-4px)}to{opacity:1;transform:translateY(0)}}
 .feed-entry:hover{background:rgba(88,166,255,.04)}
 .feed-text{flex:1;min-width:0}
-.feed-time{color:#8b949e;font-size:.75rem;white-space:nowrap;flex-shrink:0}
+.feed-time{color:var(--cc-muted);font-size:.75rem;white-space:nowrap;flex-shrink:0}
 .feed-role{color:#58a6ff;font-weight:500}
-.feed-cli{color:#8b949e;font-size:.8rem}
-.feed-empty{padding:40px 20px;text-align:center;color:#8b949e;font-size:.85rem}
-@media(max-width:768px){.page{flex-direction:column}.sidebar{border-left:none;border-top:1px solid #30363d;max-width:none;max-height:300px}}
+.feed-cli{color:var(--cc-muted);font-size:.8rem}
+.feed-empty{padding:40px 20px;text-align:center;color:var(--cc-muted);font-size:.85rem}
+@media(max-width:768px){.page{flex-direction:column}.sidebar{border-left:none;border-top:1px solid var(--cc-border);max-width:none;max-height:300px}}
 /* Management & Operations tab chrome — additive, does not touch onboarding content */
-.page-tabs{display:flex;gap:2px;background:#161b22;border-bottom:1px solid #30363d;padding:0 48px}
-.page-tab{background:none;border:none;color:#8b949e;font-size:.95rem;font-weight:500;padding:14px 20px;cursor:pointer;border-bottom:2px solid transparent;font-family:inherit}
-.page-tab:hover{color:#e6edf3}
-.page-tab.active{color:#e6edf3;border-bottom-color:#58a6ff}
+.page-tabs{display:flex;gap:2px;background:var(--cc-surface);border-bottom:1px solid var(--cc-border);padding:0 48px}
+.page-tab{background:none;border:none;color:var(--cc-muted);font-size:.95rem;font-weight:500;padding:14px 20px;cursor:pointer;border-bottom:2px solid transparent;font-family:inherit}
+.page-tab:hover{color:var(--cc-text)}
+.page-tab.active{color:var(--cc-text);border-bottom-color:#58a6ff}
 .tab-panel{display:none}
 .tab-panel.active{display:block}
 .ops{padding:40px 48px;overflow-y:auto}
 .ops h1{font-size:1.7rem;margin-bottom:6px}
 .ops-grid{display:grid;grid-template-columns:340px 1fr;gap:20px;margin-top:24px}
 @media(max-width:900px){.ops-grid{grid-template-columns:1fr}}
-.ops-card{background:#161b22;border:1px solid #30363d;border-radius:12px;padding:0;overflow:hidden}
-.ops-card-head{padding:16px 20px;border-bottom:1px solid #30363d;display:flex;align-items:center;gap:10px}
-.ops-card-head h3{font-size:.95rem;color:#e6edf3;margin:0}
-.ops-card-count{font-size:.75rem;color:#8b949e;margin-left:auto}
-.ops-filters{display:flex;gap:4px;padding:12px 20px;border-bottom:1px solid #21262d;flex-wrap:wrap}
-.ops-filter{background:#0d1117;border:1px solid #30363d;color:#8b949e;font-size:.78rem;padding:4px 12px;border-radius:999px;cursor:pointer;font-family:inherit}
+.ops-card{background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:12px;padding:0;overflow:hidden}
+.ops-card-head{padding:16px 20px;border-bottom:1px solid var(--cc-border);display:flex;align-items:center;gap:10px}
+.ops-card-head h3{font-size:.95rem;color:var(--cc-text);margin:0}
+.ops-card-count{font-size:.75rem;color:var(--cc-muted);margin-left:auto}
+.ops-filters{display:flex;gap:4px;padding:12px 20px;border-bottom:1px solid var(--cc-border-2);flex-wrap:wrap}
+.ops-filter{background:var(--cc-bg);border:1px solid var(--cc-border);color:var(--cc-muted);font-size:.78rem;padding:4px 12px;border-radius:999px;cursor:pointer;font-family:inherit}
 .ops-filter.active{background:#1f6feb;border-color:#1f6feb;color:#fff}
 .work-list{max-height:520px;overflow-y:auto}
-.work-item{padding:14px 20px;border-bottom:1px solid #21262d;cursor:pointer}
+.work-item{padding:14px 20px;border-bottom:1px solid var(--cc-border-2);cursor:pointer}
 .work-item:hover{background:rgba(88,166,255,.04)}
 .work-item.selected{background:rgba(88,166,255,.08)}
-.work-repo{font-size:.75rem;color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.work-repo{font-size:.75rem;color:var(--cc-muted);font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
 /* ── Clickable GitHub issue/PR references (#2616) ────────────────────────────────
    Shared affordance for every repo#number reference on the Operations tab (ready
    queue, my-work, opportunistic-work, dev-log). Deliberately more visible than
@@ -572,14 +644,14 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .cc-issue-link:focus-visible{outline:2px solid #58a6ff;outline-offset:2px}
 .cc-issue-link-ic{flex-shrink:0;opacity:.85}
 .cc-issue-link:hover .cc-issue-link-ic{opacity:1}
-.work-title{font-size:.9rem;color:#e6edf3;margin:2px 0 6px}
-.work-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-size:.75rem;color:#8b949e}
+.work-title{font-size:.9rem;color:var(--cc-text);margin:2px 0 6px}
+.work-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-size:.75rem;color:var(--cc-muted)}
 .pill{display:inline-block;padding:2px 8px;border-radius:999px;font-size:.7rem;font-weight:600;border:1px solid transparent}
 .pill-progress{background:rgba(88,166,255,.12);color:#58a6ff;border-color:rgba(88,166,255,.3)}
 .pill-review{background:rgba(210,153,34,.12);color:#d29922;border-color:rgba(210,153,34,.3)}
 .pill-passed{background:rgba(63,185,80,.12);color:#3fb950;border-color:rgba(63,185,80,.3)}
 .pill-blocked{background:rgba(248,81,73,.12);color:#f85149;border-color:rgba(248,81,73,.3)}
-.pill-idle{background:rgba(139,148,158,.12);color:#8b949e;border-color:rgba(139,148,158,.3)}
+.pill-idle{background:rgba(139,148,158,.12);color:var(--cc-muted);border-color:rgba(139,148,158,.3)}
 /* #2574 (follow-up): the Connected-clankers card is a NARROW column. The old
    layout put the multi-line identity text (.clanker-main) and the inline
    controls (.admin-actions: tier dropdown + Revoke + Remove) in the SAME
@@ -592,44 +664,44 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
    horizontally with the multi-line text. Long repo paths in .clanker-sub wrap
    (overflow-wrap:anywhere) rather than pushing into anything. align-items:start
    keeps the dot/avatar top-aligned with the first text line. */
-.clanker-row{display:grid;grid-template-columns:auto auto minmax(0,1fr);align-items:start;column-gap:10px;row-gap:8px;padding:12px 20px;border-bottom:1px solid #21262d}
+.clanker-row{display:grid;grid-template-columns:auto auto minmax(0,1fr);align-items:start;column-gap:10px;row-gap:8px;padding:12px 20px;border-bottom:1px solid var(--cc-border-2)}
 /* The trailing controls / timestamp: full-width line beneath the identity. It is
    always the LAST grid child, so grid-column:1/-1 drops it below regardless of
    whether it's .admin-actions or the .feed-time fallback. */
 .clanker-row>.admin-actions,.clanker-row>.feed-time{grid-column:1/-1}
-.clanker-av{width:28px;height:28px;border-radius:50%%;flex-shrink:0;background:#30363d}
+.clanker-av{width:28px;height:28px;border-radius:50%%;flex-shrink:0;background:var(--cc-border)}
 .clanker-main{min-width:0}
-.clanker-user{font-size:.88rem;color:#e6edf3;font-weight:500}
-.clanker-sub{font-size:.74rem;color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;overflow-wrap:anywhere;word-break:break-word}
+.clanker-user{font-size:.88rem;color:var(--cc-text);font-weight:500}
+.clanker-sub{font-size:.74rem;color:var(--cc-muted);font-family:ui-monospace,SFMono-Regular,Menlo,monospace;overflow-wrap:anywhere;word-break:break-word}
 /* Row is align-items:start (grid), so nudge the small dot down to sit level with
    the username's first line instead of the very top of the row. */
 .clanker-dot{width:8px;height:8px;border-radius:50%%;background:#3fb950;flex-shrink:0;margin-top:7px}
-.clanker-dot.stale{background:#8b949e}
+.clanker-dot.stale{background:var(--cc-muted)}
 .pipeline{display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin:14px 0}
-.pipe-node{background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:8px 14px;font-size:.82rem;color:#e6edf3}
+.pipe-node{background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:8px;padding:8px 14px;font-size:.82rem;color:var(--cc-text)}
 .pipe-node .lgtm{color:#3fb950;font-size:.72rem}
-.pipe-arrow{color:#8b949e}
-.policy-row{display:flex;justify-content:space-between;gap:12px;padding:8px 0;border-bottom:1px solid #21262d;font-size:.85rem}
+.pipe-arrow{color:var(--cc-muted)}
+.policy-row{display:flex;justify-content:space-between;gap:12px;padding:8px 0;border-bottom:1px solid var(--cc-border-2);font-size:.85rem}
 .policy-row:last-child{border-bottom:none}
-.policy-key{color:#8b949e}
-.policy-val{color:#e6edf3;text-align:right;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;word-break:break-word}
-.ops-empty{padding:32px 20px;text-align:center;color:#8b949e;font-size:.85rem}
-.lb-row{display:grid;grid-template-columns:56px 1fr 120px 70px 70px 80px 72px;align-items:center;gap:8px;padding:10px 20px;border-bottom:1px solid #21262d;font-size:.85rem}
+.policy-key{color:var(--cc-muted)}
+.policy-val{color:var(--cc-text);text-align:right;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;word-break:break-word}
+.ops-empty{padding:32px 20px;text-align:center;color:var(--cc-muted);font-size:.85rem}
+.lb-row{display:grid;grid-template-columns:56px 1fr 120px 70px 70px 80px 72px;align-items:center;gap:8px;padding:10px 20px;border-bottom:1px solid var(--cc-border-2);font-size:.85rem}
 .lb-row:last-child{border-bottom:none}
 /* Subtle self-highlight for the logged-in viewer's own row: a faint tint + a left
    accent border, professional not loud. Readability preserved. */
 .lb-row--me{background:rgba(31,111,235,.09);box-shadow:inset 3px 0 0 0 #1f6feb}
 .lb-you{display:inline-block;margin-left:8px;font-size:.62rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#58a6ff;background:rgba(31,111,235,.14);border:1px solid rgba(31,111,235,.3);border-radius:999px;padding:1px 7px;vertical-align:middle}
-.lb-head{color:#8b949e;font-weight:600;font-size:.72rem;text-transform:uppercase;letter-spacing:.04em;background:#0d1117}
-.lb-rank{color:#8b949e;font-variant-numeric:tabular-nums}
-.lb-name{color:#e6edf3;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.lb-tier{color:#8b949e}
-.lb-stat{text-align:right;color:#c9d1d9;font-variant-numeric:tabular-nums}
-.lb-head .lb-stat,.lb-head .lb-rank{text-align:right;color:#8b949e}
+.lb-head{color:var(--cc-muted);font-weight:600;font-size:.72rem;text-transform:uppercase;letter-spacing:.04em;background:var(--cc-bg)}
+.lb-rank{color:var(--cc-muted);font-variant-numeric:tabular-nums}
+.lb-name{color:var(--cc-text);font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.lb-tier{color:var(--cc-muted)}
+.lb-stat{text-align:right;color:var(--cc-text-2);font-variant-numeric:tabular-nums}
+.lb-head .lb-stat,.lb-head .lb-rank{text-align:right;color:var(--cc-muted)}
 .lb-head .lb-rank{text-align:left}
 /* ── Subtle "ranked/alive" accent pass on Operations + Leaderboard (SUBTLE +
    PROFESSIONAL — light watermarking only). Theme-aware: built entirely from the
-   existing dark palette (#161b22 card / #30363d border / #0d1117 deep). Every
+   existing dark palette (var(--cc-surface) card / var(--cc-border) border / var(--cc-bg) deep). Every
    accent is driven by REAL data (trust tier + real task counts); nothing is
    fabricated. Readability first — text keeps full contrast; the tints are muted,
    never neon. All motion respects the prefers-reduced-motion block below. ───── */
@@ -640,27 +712,27 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
    tier-badge family; the Me-card below reuses it rather than hand-rolling its own
    tier-color helper, so leaderboard rows, ops cards, and the Me-card read as one
    ranked family. */
-.tier-badge{display:inline-flex;align-items:center;gap:5px;font-size:.68rem;font-weight:600;line-height:1;padding:3px 8px 3px 6px;border-radius:999px;border:1px solid #30363d;background:#0d1117;color:#8b949e;text-transform:capitalize;white-space:nowrap}
+.tier-badge{display:inline-flex;align-items:center;gap:5px;font-size:.68rem;font-weight:600;line-height:1;padding:3px 8px 3px 6px;border-radius:999px;border:1px solid var(--cc-border);background:var(--cc-bg);color:var(--cc-muted);text-transform:capitalize;white-space:nowrap}
 .tier-badge::before{content:"";width:8px;height:8px;border-radius:50%%;background:currentColor;box-shadow:inset 0 0 0 1px rgba(1,4,9,.35);flex:none}
 .tier-badge.tier-advisor{border-color:rgba(210,169,85,.45);background:rgba(210,169,85,.10);color:#d0a955}
 .tier-badge.tier-trusted{border-color:rgba(201,162,39,.40);background:rgba(201,162,39,.08);color:#c9a94a}
 .tier-badge.tier-contributor{border-color:rgba(110,163,201,.38);background:rgba(110,163,201,.08);color:#6ea3c9}
-.tier-badge.tier-newcomer{border-color:#30363d;background:#0d1117;color:#8b949e}
+.tier-badge.tier-newcomer{border-color:var(--cc-border);background:var(--cc-bg);color:var(--cc-muted)}
 /* Restrained gradient header band on the accented cards. Very low-contrast wash
    from the deep bg into the card colour — reads as a faint banner, not a loud
    gradient; the bottom border keeps the head crisp. */
-.ops-card.card-accent>.ops-card-head{background:linear-gradient(180deg,#12161d 0%%,#161b22 100%%)}
+.ops-card.card-accent>.ops-card-head{background:linear-gradient(180deg,#12161d 0%%,var(--cc-surface) 100%%)}
 .ops-card.card-accent>.ops-card-head h3{letter-spacing:.01em}
 /* Bold-numeral stat emphasis: the primary "Done" numeral on the leaderboard and
    the key ops counts get heavier weight + slightly larger tabular figures so the
    number reads as the hero of the row without adding chrome. The Me-card's own
    stat numerals reuse this same bold/tabular treatment via .lb-stat.lb-primary. */
-.lb-row .lb-stat.lb-primary{color:#e6edf3;font-weight:700;font-size:.95rem}
-.lb-head .lb-stat.lb-primary{font-weight:600;font-size:.72rem;color:#8b949e}
+.lb-row .lb-stat.lb-primary{color:var(--cc-text);font-weight:700;font-size:.95rem}
+.lb-head .lb-stat.lb-primary{font-weight:600;font-size:.72rem;color:var(--cc-muted)}
 .tier-badge.tier-lb{padding:2px 8px 2px 5px;font-size:.66rem}
 /* Ops "your army" counts + card counts as bold numerals (tabular, no layout shift). */
 .cc-army b{font-weight:700;font-variant-numeric:tabular-nums}
-.ops-card-count.count-strong{color:#e6edf3;font-weight:700;font-variant-numeric:tabular-nums}
+.ops-card-count.count-strong{color:var(--cc-text);font-weight:700;font-variant-numeric:tabular-nums}
 /* Compact tier badge inline next to a connected clanker's identity. */
 .tier-badge.tier-inline{padding:1px 6px 1px 4px;font-size:.62rem;margin-left:6px;vertical-align:middle}
 .tier-badge.tier-inline::before{width:6px;height:6px}
@@ -678,50 +750,50 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
    (.me-card--style1..7) are palette/framing/density variations over the SAME
    real data. Subtle and professional, reduced-motion safe. --me-accent drives
    the per-tier accent wash (medallion ring, chips, stat numerals). */
-.me-card{position:relative;background:#161b22;border:1px solid #30363d;border-radius:14px;overflow:hidden;margin-bottom:20px;--me-accent:#58a6ff;--me-accent-soft:rgba(88,166,255,.14)}
-.me-card__band{position:relative;padding:20px 22px 18px;background:linear-gradient(135deg,var(--me-accent-soft),rgba(22,27,34,0) 70%%);border-bottom:1px solid #21262d}
+.me-card{position:relative;background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:14px;overflow:hidden;margin-bottom:20px;--me-accent:#58a6ff;--me-accent-soft:rgba(88,166,255,.14)}
+.me-card__band{position:relative;padding:20px 22px 18px;background:linear-gradient(135deg,var(--me-accent-soft),rgba(22,27,34,0) 70%%);border-bottom:1px solid var(--cc-border-2)}
 .me-card__toprow{display:flex;align-items:center;gap:16px}
-.me-medallion{position:relative;width:64px;height:64px;flex-shrink:0;border-radius:50%%;display:flex;align-items:center;justify-content:center;background:radial-gradient(circle at 50%% 35%%,var(--me-accent-soft),#0d1117 78%%);border:2px solid var(--me-accent);box-shadow:0 0 0 4px rgba(1,4,9,.35)}
-.me-medallion img{width:52px;height:52px;border-radius:50%%;object-fit:cover;background:#30363d}
+.me-medallion{position:relative;width:64px;height:64px;flex-shrink:0;border-radius:50%%;display:flex;align-items:center;justify-content:center;background:radial-gradient(circle at 50%% 35%%,var(--me-accent-soft),var(--cc-bg) 78%%);border:2px solid var(--me-accent);box-shadow:0 0 0 4px rgba(1,4,9,.35)}
+.me-medallion img{width:52px;height:52px;border-radius:50%%;object-fit:cover;background:var(--cc-border)}
 /* #2595 fix: the tier badge now lives in its OWN layout slot beside the name
    (.me-id__tier), NOT absolutely positioned over the avatar — so the "Contributor"
    / "Trusted" / "Newcomer" pill can never overlap the avatar image. */
 .me-id__tier{margin:4px 0 2px}
 .me-id__tier .tier-badge{position:static;transform:none}
 .me-id{min-width:0;flex:1}
-.me-id__name{font-size:1.25rem;font-weight:700;color:#e6edf3;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.me-id__lead{font-size:.85rem;color:#8b949e;margin-top:2px}
+.me-id__name{font-size:1.25rem;font-weight:700;color:var(--cc-text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.me-id__lead{font-size:.85rem;color:var(--cc-muted);margin-top:2px}
 .me-id__lead b{color:var(--me-accent)}
-.me-rankpill{margin-left:auto;flex-shrink:0;text-align:center;background:#0d1117;border:1px solid #30363d;border-radius:12px;padding:8px 14px}
-.me-rankpill__num{font-size:1.25rem;font-weight:800;color:#e6edf3;font-variant-numeric:tabular-nums;line-height:1}
-.me-rankpill__lbl{font-size:.62rem;color:#8b949e;text-transform:uppercase;letter-spacing:.05em;margin-top:3px}
+.me-rankpill{margin-left:auto;flex-shrink:0;text-align:center;background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:12px;padding:8px 14px}
+.me-rankpill__num{font-size:1.25rem;font-weight:800;color:var(--cc-text);font-variant-numeric:tabular-nums;line-height:1}
+.me-rankpill__lbl{font-size:.62rem;color:var(--cc-muted);text-transform:uppercase;letter-spacing:.05em;margin-top:3px}
 .me-card__body{padding:18px 22px 20px}
 .me-statgrid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px}
-.me-stat{background:#0d1117;border:1px solid #30363d;border-radius:10px;padding:12px 8px;text-align:center}
+.me-stat{background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:10px;padding:12px 8px;text-align:center}
 /* Stat numeral reuses the canonical bold/tabular "hero numeral" treatment
    (same weight/tabular-nums as .lb-stat.lb-primary), tinted by --me-accent. */
 .me-stat .lb-stat.lb-primary{display:block;font-size:1.6rem;color:var(--me-accent);padding:0}
-.me-stat__lbl{font-size:.66rem;color:#8b949e;text-transform:uppercase;letter-spacing:.04em;margin-top:5px}
+.me-stat__lbl{font-size:.66rem;color:var(--cc-muted);text-transform:uppercase;letter-spacing:.04em;margin-top:5px}
 .me-sec{margin-top:18px}
-.me-sec__title{font-size:.72rem;color:#8b949e;text-transform:uppercase;letter-spacing:.05em;font-weight:600;margin-bottom:9px;display:flex;align-items:center;gap:8px}
-.me-sec__title .me-soon{font-size:.6rem;font-weight:600;color:#8b949e;border:1px solid #30363d;border-radius:999px;padding:1px 7px;text-transform:none;letter-spacing:0}
+.me-sec__title{font-size:.72rem;color:var(--cc-muted);text-transform:uppercase;letter-spacing:.05em;font-weight:600;margin-bottom:9px;display:flex;align-items:center;gap:8px}
+.me-sec__title .me-soon{font-size:.6rem;font-weight:600;color:var(--cc-muted);border:1px solid var(--cc-border);border-radius:999px;padding:1px 7px;text-transform:none;letter-spacing:0}
 .me-chips{display:flex;flex-wrap:wrap;gap:7px}
-.me-chip{display:inline-flex;align-items:center;gap:5px;padding:4px 10px;border-radius:999px;font-size:.74rem;font-weight:600;border:1px solid transparent;background:#0d1117;color:#8b949e;border-color:#30363d}
+.me-chip{display:inline-flex;align-items:center;gap:5px;padding:4px 10px;border-radius:999px;font-size:.74rem;font-weight:600;border:1px solid transparent;background:var(--cc-bg);color:var(--cc-muted);border-color:var(--cc-border)}
 .me-chip--got{background:var(--me-accent-soft);color:var(--me-accent);border-color:var(--me-accent)}
-.me-chip--next{background:#0d1117;color:#c9d1d9;border-color:#30363d;border-style:dashed}
-.me-chip--badge{background:#0d1117;color:#8b949e;border-color:#30363d;border-style:dashed;opacity:.85}
+.me-chip--next{background:var(--cc-bg);color:var(--cc-text-2);border-color:var(--cc-border);border-style:dashed}
+.me-chip--badge{background:var(--cc-bg);color:var(--cc-muted);border-color:var(--cc-border);border-style:dashed;opacity:.85}
 .me-hives{display:flex;flex-direction:column;gap:6px}
-.me-hive{display:flex;align-items:center;gap:8px;font-size:.82rem;color:#c9d1d9}
+.me-hive{display:flex;align-items:center;gap:8px;font-size:.82rem;color:var(--cc-text-2)}
 .me-hive__rel{font-size:.66rem;font-weight:700;text-transform:uppercase;letter-spacing:.03em;padding:2px 7px;border-radius:6px;background:var(--me-accent-soft);color:var(--me-accent)}
 .me-hive__rel--owner{background:rgba(210,153,34,.16);color:#d29922}
 .me-actions{display:flex;flex-wrap:wrap;gap:10px;margin-top:18px;align-items:center}
-.me-share{display:inline-flex;align-items:center;gap:7px;padding:9px 16px;border-radius:10px;font-size:.85rem;font-weight:600;text-decoration:none;background:var(--me-accent);color:#0d1117;border:1px solid var(--me-accent);cursor:pointer;font-family:inherit}
+.me-share{display:inline-flex;align-items:center;gap:7px;padding:9px 16px;border-radius:10px;font-size:.85rem;font-weight:600;text-decoration:none;background:var(--me-accent);color:var(--cc-bg);border:1px solid var(--me-accent);cursor:pointer;font-family:inherit}
 .me-share:hover{filter:brightness(1.08)}
 .me-share--ghost{background:transparent;color:var(--me-accent)}
-.me-stylepick{margin-left:auto;display:flex;align-items:center;gap:7px;font-size:.72rem;color:#8b949e}
-.me-stylepick select{background:#0d1117;border:1px solid #30363d;color:#c9d1d9;border-radius:8px;padding:5px 8px;font-size:.78rem;font-family:inherit;cursor:pointer}
-.me-signin{background:#161b22;border:1px dashed #30363d;border-radius:14px;padding:22px;text-align:center;color:#8b949e;font-size:.9rem;margin-bottom:20px}
-.me-signin b{color:#e6edf3}
+.me-stylepick{margin-left:auto;display:flex;align-items:center;gap:7px;font-size:.72rem;color:var(--cc-muted)}
+.me-stylepick select{background:var(--cc-bg);border:1px solid var(--cc-border);color:var(--cc-text-2);border-radius:8px;padding:5px 8px;font-size:.78rem;font-family:inherit;cursor:pointer}
+.me-signin{background:var(--cc-surface);border:1px dashed var(--cc-border);border-radius:14px;padding:22px;text-align:center;color:var(--cc-muted);font-size:.9rem;margin-bottom:20px}
+.me-signin b{color:var(--cc-text)}
 /* ── The 7 profile-style skins (palette / framing / density variations) ────────
    Each is a tasteful, readable, professional variant of the SAME card. They only
    change accent palette, header treatment, medallion framing, and density —
@@ -729,9 +801,9 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .me-card--style2{--me-accent:#3fb950;--me-accent-soft:rgba(63,185,80,.14)}
 .me-card--style3{--me-accent:#d29922;--me-accent-soft:rgba(210,153,34,.15)}
 .me-card--style4{--me-accent:#a371f7;--me-accent-soft:rgba(163,113,247,.15)}
-.me-card--style5{--me-accent:#8b949e;--me-accent-soft:rgba(139,148,158,.12)}     /* minimal / restrained */
-.me-card--style5 .me-card__band{background:#161b22}
-.me-card--style5 .me-medallion{background:#0d1117}
+.me-card--style5{--me-accent:var(--cc-muted);--me-accent-soft:rgba(139,148,158,.12)}     /* minimal / restrained */
+.me-card--style5 .me-card__band{background:var(--cc-surface)}
+.me-card--style5 .me-medallion{background:var(--cc-bg)}
 .me-card--style6{--me-accent:#f778ba;--me-accent-soft:rgba(247,120,186,.14)}
 .me-card--style6 .me-card__band{background:linear-gradient(135deg,var(--me-accent-soft),rgba(22,27,34,0))}
 .me-card--style7{--me-accent:#58a6ff;--me-accent-soft:rgba(88,166,255,.18)}     /* roomy "ranked" */
@@ -741,15 +813,15 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .me-card--style7 .me-medallion img{width:60px;height:60px}
 @media(max-width:520px){.me-card__toprow{flex-wrap:wrap}.me-rankpill{margin-left:0}.me-statgrid{grid-template-columns:1fr}}
 @media(prefers-reduced-motion:reduce){.me-card *{transition:none!important;animation:none!important}}
-.ops-note{color:#6e7681;font-size:.78rem;margin-top:12px;line-height:1.5}
-.ops-note code{background:#0d1117;padding:1px 6px;border-radius:4px}
-.prompt-preview{margin-top:10px;border-top:1px solid #21262d;padding-top:8px}
+.ops-note{color:var(--cc-muted-2);font-size:.78rem;margin-top:12px;line-height:1.5}
+.ops-note code{background:var(--cc-bg);padding:1px 6px;border-radius:4px}
+.prompt-preview{margin-top:10px;border-top:1px solid var(--cc-border-2);padding-top:8px}
 .prompt-preview summary{cursor:pointer;color:#58a6ff;font-size:.78rem;list-style:none}
 .prompt-preview summary::-webkit-details-marker{display:none}
-.prompt-preview summary::before{content:'\25B8 ';color:#8b949e}
+.prompt-preview summary::before{content:'\25B8 ';color:var(--cc-muted)}
 .prompt-preview[open] summary::before{content:'\25BE '}
 .prompt-labels{margin:8px 0 4px;display:flex;flex-wrap:wrap;gap:4px}
-.prompt-text{margin-top:8px;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:12px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.75rem;color:#c9d1d9;white-space:pre-wrap;word-break:break-word;max-height:220px;overflow-y:auto}
+.prompt-text{margin-top:8px;background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:8px;padding:12px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.75rem;color:var(--cc-text-2);white-space:pre-wrap;word-break:break-word;max-height:220px;overflow-y:auto}
 .prompt-preview .ops-note{margin-top:8px}
 /* #2534 Operator admin controls — mirror the Governor Hub config controls into the
    Management & Operations tab. Owner/read-write only; a read viewer never sees them. */
@@ -758,63 +830,63 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .admin-badge{font-size:.68rem;font-weight:600;padding:2px 8px;border-radius:999px;background:rgba(210,153,34,.12);color:#d29922;border:1px solid rgba(210,153,34,.3);margin-left:auto}
 .admin-body{padding:16px 20px}
 .admin-toggle{display:flex;align-items:center;gap:10px;padding:8px 0}
-.admin-switch{width:38px;height:20px;border-radius:999px;background:#30363d;position:relative;cursor:pointer;flex-shrink:0;transition:background .15s}
-.admin-switch::after{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%%;background:#e6edf3;transition:left .15s}
+.admin-switch{width:38px;height:20px;border-radius:999px;background:var(--cc-border);position:relative;cursor:pointer;flex-shrink:0;transition:background .15s}
+.admin-switch::after{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%%;background:var(--cc-text);transition:left .15s}
 .admin-switch.on{background:#1f6feb}
 .admin-switch.on.danger{background:#f85149}
 .admin-switch.on::after{left:20px}
-.admin-toggle-label{font-size:.85rem;color:#e6edf3}
-.admin-toggle-sub{font-size:.74rem;color:#8b949e}
+.admin-toggle-label{font-size:.85rem;color:var(--cc-text)}
+.admin-toggle-sub{font-size:.74rem;color:var(--cc-muted)}
 .admin-field{margin:14px 0}
-.admin-field>label{display:block;font-size:.78rem;color:#8b949e;margin-bottom:6px}
-.admin-modeseg{display:inline-flex;border:1px solid #30363d;border-radius:6px;overflow:hidden;margin-bottom:6px}
-.admin-modeseg button{background:#0d1117;border:none;color:#8b949e;font-size:.72rem;padding:3px 10px;cursor:pointer;font-family:inherit}
+.admin-field>label{display:block;font-size:.78rem;color:var(--cc-muted);margin-bottom:6px}
+.admin-modeseg{display:inline-flex;border:1px solid var(--cc-border);border-radius:6px;overflow:hidden;margin-bottom:6px}
+.admin-modeseg button{background:var(--cc-bg);border:none;color:var(--cc-muted);font-size:.72rem;padding:3px 10px;cursor:pointer;font-family:inherit}
 .admin-modeseg button.on{background:#1f6feb;color:#fff}
 .admin-chips{display:flex;flex-wrap:wrap;gap:4px;margin-bottom:6px}
-.admin-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-size:.72rem;background:rgba(139,148,158,.12);color:#c9d1d9;border:1px solid #30363d}
+.admin-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-size:.72rem;background:rgba(139,148,158,.12);color:var(--cc-text-2);border:1px solid var(--cc-border)}
 .admin-chip .x{cursor:pointer;opacity:.7}
 .admin-chip .x:hover{opacity:1;color:#f85149}
 .admin-addrow{display:flex;gap:4px}
-.admin-addrow input{flex:1;background:#0d1117;border:1px solid #30363d;border-radius:6px;color:#e6edf3;font-size:.78rem;padding:5px 8px;font-family:inherit}
+.admin-addrow input{flex:1;background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:6px;color:var(--cc-text);font-size:.78rem;padding:5px 8px;font-family:inherit}
 .admin-addrow button,.admin-save{background:#238636;border:1px solid #2ea043;color:#fff;font-size:.75rem;padding:5px 12px;border-radius:6px;cursor:pointer;font-family:inherit}
-.admin-addrow button{background:#21262d;border-color:#30363d;color:#c9d1d9}
+.admin-addrow button{background:var(--cc-border-2);border-color:var(--cc-border);color:var(--cc-text-2)}
 .admin-save{margin-top:8px}
 .admin-save:disabled{opacity:.5;cursor:default}
-.admin-hr{border:none;border-top:1px solid #21262d;margin:16px 0}
+.admin-hr{border:none;border-top:1px solid var(--cc-border-2);margin:16px 0}
 /* Repos-for-Contribute enable toggles + Tier rate-limit rows (Management mirror of
    the Governor Hub sections). Subtle, matching the rest of the admin controls. */
 .admin-repos{display:flex;flex-wrap:wrap;gap:8px}
-.admin-repo{display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border:1px solid #30363d;border-radius:8px;background:#0d1117}
+.admin-repo{display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border:1px solid var(--cc-border);border-radius:8px;background:var(--cc-bg)}
 .admin-repo .admin-switch{width:32px;height:18px}
 .admin-repo .admin-switch::after{width:14px;height:14px}
 .admin-repo .admin-switch.on::after{left:16px}
-.admin-repo__name{font-size:.76rem;color:#c9d1d9;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
-.admin-tier{display:grid;grid-template-columns:1fr repeat(3,64px);align-items:center;gap:8px;padding:8px 0;border-bottom:1px solid #21262d}
+.admin-repo__name{font-size:.76rem;color:var(--cc-text-2);font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.admin-tier{display:grid;grid-template-columns:1fr repeat(3,64px);align-items:center;gap:8px;padding:8px 0;border-bottom:1px solid var(--cc-border-2)}
 .admin-tier:last-child{border-bottom:none}
 .admin-tier__head{display:flex;align-items:center;gap:8px;min-width:0}
-.admin-tier__name{font-size:.8rem;color:#e6edf3;text-transform:capitalize}
-.admin-tier input{width:100%%;background:#0d1117;border:1px solid #30363d;border-radius:6px;color:#e6edf3;font:inherit;font-size:.78rem;padding:4px 6px;outline:none;text-align:right}
+.admin-tier__name{font-size:.8rem;color:var(--cc-text);text-transform:capitalize}
+.admin-tier input{width:100%%;background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:6px;color:var(--cc-text);font:inherit;font-size:.78rem;padding:4px 6px;outline:none;text-align:right}
 .admin-tier input:focus{border-color:#1f6feb}
 .admin-tier input:disabled{opacity:.45}
-.admin-tier__col{font-size:.62rem;color:#6e7681;text-align:right;text-transform:uppercase;letter-spacing:.03em}
-.admin-tier--head{border-bottom:1px solid #30363d;padding-bottom:4px}
+.admin-tier__col{font-size:.62rem;color:var(--cc-muted-2);text-align:right;text-transform:uppercase;letter-spacing:.03em}
+.admin-tier--head{border-bottom:1px solid var(--cc-border);padding-bottom:4px}
 /* No margin-left:auto — .admin-actions is now a full-width grid row beneath the
    identity (see .clanker-row grid), left-aligned and wrapping if the buttons
    don't fit the narrow column. */
 .admin-actions{display:flex;gap:6px;flex-wrap:wrap}
-.admin-act{background:#21262d;border:1px solid #30363d;color:#c9d1d9;font-size:.7rem;padding:3px 9px;border-radius:6px;cursor:pointer;font-family:inherit}
-.admin-act:hover{border-color:#8b949e}
+.admin-act{background:var(--cc-border-2);border:1px solid var(--cc-border);color:var(--cc-text-2);font-size:.7rem;padding:3px 9px;border-radius:6px;cursor:pointer;font-family:inherit}
+.admin-act:hover{border-color:var(--cc-muted)}
 .admin-act.danger:hover{border-color:#f85149;color:#f85149}
-.admin-act select{background:#0d1117;border:1px solid #30363d;color:#c9d1d9;font-size:.7rem;border-radius:6px;padding:2px 4px;font-family:inherit}
+.admin-act select{background:var(--cc-bg);border:1px solid var(--cc-border);color:var(--cc-text-2);font-size:.7rem;border-radius:6px;padding:2px 4px;font-family:inherit}
 .admin-modal-back{display:none;position:fixed;inset:0;background:rgba(1,4,9,.7);z-index:1000;align-items:center;justify-content:center}
 .admin-modal-back.show{display:flex}
-.admin-modal{background:#161b22;border:1px solid #30363d;border-radius:12px;max-width:420px;width:90%%;padding:22px}
-.admin-modal h4{margin:0 0 8px;font-size:1rem;color:#e6edf3}
-.admin-modal p{font-size:.85rem;color:#8b949e;line-height:1.5;margin:0 0 18px}
+.admin-modal{background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:12px;max-width:420px;width:90%%;padding:22px}
+.admin-modal h4{margin:0 0 8px;font-size:1rem;color:var(--cc-text)}
+.admin-modal p{font-size:.85rem;color:var(--cc-muted);line-height:1.5;margin:0 0 18px}
 .admin-modal-btns{display:flex;gap:8px;justify-content:flex-end}
-.admin-modal-btns button{font-size:.8rem;padding:6px 14px;border-radius:6px;cursor:pointer;font-family:inherit;border:1px solid #30363d;background:#21262d;color:#c9d1d9}
+.admin-modal-btns button{font-size:.8rem;padding:6px 14px;border-radius:6px;cursor:pointer;font-family:inherit;border:1px solid var(--cc-border);background:var(--cc-border-2);color:var(--cc-text-2)}
 .admin-modal-btns button.confirm{background:#da3633;border-color:#f85149;color:#fff}
-.admin-note{color:#6e7681;font-size:.76rem;margin-top:10px;line-height:1.5}
+.admin-note{color:var(--cc-muted-2);font-size:.76rem;margin-top:10px;line-height:1.5}
 /* ── Operations command center — live SSE-driven queue / travel / dev-log /
    achievements / army framing. Subtle-professional motion only; degrades to the
    existing poll when SSE is unavailable. Additive, read-only. ─────────────── */
@@ -833,24 +905,24 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
    as one state. Left of #cc-live so status (queue live/stale) and posture
    (active/paused) sit as a pair. */
 #queue-suspend-wrap{display:inline-flex;align-items:center;gap:6px;margin-left:auto}
-.queue-suspend-btn{display:inline-flex;align-items:center;justify-content:center;width:26px;height:26px;padding:0;border-radius:999px;border:1px solid #30363d;background:transparent;color:#8b949e;cursor:pointer;line-height:0;transition:background .15s,color .15s,border-color .15s}
+.queue-suspend-btn{display:inline-flex;align-items:center;justify-content:center;width:26px;height:26px;padding:0;border-radius:999px;border:1px solid var(--cc-border);background:transparent;color:var(--cc-muted);cursor:pointer;line-height:0;transition:background .15s,color .15s,border-color .15s}
 /* SVG glyph is centered by the flex-box; currentColor tracks the button state.
    Using an SVG (not a &#10074; bar glyph) so the pause bars sit dead-center —
    the light-vertical-bar character carries font side-bearing that pushed the
    pair off-center inside the circle. */
 .queue-suspend-btn svg{display:block;width:12px;height:12px;fill:currentColor}
-.queue-suspend-btn:hover{background:rgba(139,148,158,.12);color:#c9d1d9}
+.queue-suspend-btn:hover{background:rgba(139,148,158,.12);color:var(--cc-text-2)}
 .queue-suspend-btn.paused{border-color:rgba(248,81,73,.35);color:#f85149;background:rgba(248,81,73,.08)}
 .queue-suspend-btn.paused:hover{background:rgba(248,81,73,.16)}
 .queue-suspend-btn:disabled{opacity:.5;cursor:not-allowed}
 /* Army roster header line under the clanker card */
-.cc-army{display:flex;align-items:center;gap:14px;padding:10px 20px;border-bottom:1px solid #21262d;font-size:.78rem;color:#8b949e}
-.cc-army b{color:#e6edf3;font-weight:600}
+.cc-army{display:flex;align-items:center;gap:14px;padding:10px 20px;border-bottom:1px solid var(--cc-border-2);font-size:.78rem;color:var(--cc-muted)}
+.cc-army b{color:var(--cc-text);font-weight:600}
 .cc-army-stat{display:inline-flex;align-items:center;gap:5px}
 .cc-army-stat .dot{width:7px;height:7px;border-radius:50%%}
 .cc-army-stat.working .dot{background:#58a6ff}
 .cc-army-stat.reviewing .dot{background:#d29922}
-.cc-army-stat.idle .dot{background:#8b949e}
+.cc-army-stat.idle .dot{background:var(--cc-muted)}
 /* Clanker rows: enter pop-in / leave fade so the roster feels alive */
 @keyframes cc-popin{from{opacity:0;transform:translateY(-6px) scale(.98)}to{opacity:1;transform:none}}
 @keyframes cc-fadeout{from{opacity:1}to{opacity:0;transform:translateX(8px)}}
@@ -862,26 +934,26 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .clanker-status{font-size:.68rem;font-weight:600;padding:1px 7px;border-radius:999px;margin-left:6px;border:1px solid transparent}
 .clanker-status.working{background:rgba(88,166,255,.12);color:#58a6ff;border-color:rgba(88,166,255,.3)}
 .clanker-status.reviewing{background:rgba(210,153,34,.12);color:#d29922;border-color:rgba(210,153,34,.3)}
-.clanker-status.idle{background:rgba(139,148,158,.12);color:#8b949e;border-color:rgba(139,148,158,.3)}
+.clanker-status.idle{background:rgba(139,148,158,.12);color:var(--cc-muted);border-color:rgba(139,148,158,.3)}
 /* Ready-work QUEUE — the stack of issues waiting to be picked off. A generous
    max-height keeps a long backlog (up to ~150 items) scrolling inside the card
    instead of stretching the page; the panel scrolls, the page does not. */
 .cc-queue{max-height:560px;overflow-y:auto}
-.cc-q-item{display:flex;align-items:flex-start;gap:10px;padding:11px 20px;border-bottom:1px solid #21262d;animation:cc-popin .35s ease;position:relative}
+.cc-q-item{display:flex;align-items:flex-start;gap:10px;padding:11px 20px;border-bottom:1px solid var(--cc-border-2);animation:cc-popin .35s ease;position:relative}
 .cc-q-item:first-child{background:rgba(88,166,255,.05)}
 /* Drag handle (grab bar) — owner/read-write only. Hidden unless the queue root
    carries .cc-q-draggable (set by initAdmin after /api/role). Reduced-motion and
    pointer friendly. */
-.cc-q-grip{display:none;flex-shrink:0;width:16px;align-self:stretch;cursor:grab;color:#6e7681;font-size:.9rem;line-height:1;align-items:center;justify-content:center;user-select:none;touch-action:none}
-.cc-q-grip:hover{color:#c9d1d9}
+.cc-q-grip{display:none;flex-shrink:0;width:16px;align-self:stretch;cursor:grab;color:var(--cc-muted-2);font-size:.9rem;line-height:1;align-items:center;justify-content:center;user-select:none;touch-action:none}
+.cc-q-grip:hover{color:var(--cc-text-2)}
 .cc-queue.cc-q-draggable .cc-q-grip{display:flex}
 .cc-queue.cc-q-draggable .cc-q-item{cursor:default}
 .cc-q-item.cc-q-dragging{opacity:.5;cursor:grabbing}
 .cc-q-item.cc-q-over{box-shadow:inset 0 2px 0 0 #58a6ff}
-.cc-q-idx{font-size:.7rem;color:#6e7681;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;flex-shrink:0;width:22px;text-align:right;padding-top:2px}
+.cc-q-idx{font-size:.7rem;color:var(--cc-muted-2);font-family:ui-monospace,SFMono-Regular,Menlo,monospace;flex-shrink:0;width:22px;text-align:right;padding-top:2px}
 .cc-q-body{flex:1;min-width:0}
-.cc-q-repo{font-size:.72rem;color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
-.cc-q-title{font-size:.86rem;color:#e6edf3;margin:2px 0 4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.cc-q-repo{font-size:.72rem;color:var(--cc-muted);font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.cc-q-title{font-size:.86rem;color:var(--cc-text);margin:2px 0 4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .cc-q-labels{display:flex;flex-wrap:wrap;gap:4px}
 .cc-q-next{font-size:.62rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#58a6ff;flex-shrink:0;padding-top:2px}
 .cc-q-item.cc-leaving{animation:cc-fadeout .45s ease forwards}
@@ -895,36 +967,36 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
    muted greys, the page's blue accent only on focus/hover, no game-y flourish.
    The search bar is read-only filtering so it shows for everyone; the per-row
    ACTIONS live inside the row menu, which is only rendered for owner/read-write. */
-.cc-q-search{display:flex;align-items:center;gap:8px;padding:10px 20px;border-bottom:1px solid #21262d}
-.cc-q-search-ic{color:#6e7681;font-size:.85rem;flex-shrink:0;line-height:1}
-.cc-q-search input{flex:1;min-width:0;background:#0d1117;border:1px solid #30363d;border-radius:7px;color:#e6edf3;font:inherit;font-size:.82rem;padding:6px 10px;outline:none;transition:border-color .15s,box-shadow .15s}
-.cc-q-search input::placeholder{color:#6e7681}
+.cc-q-search{display:flex;align-items:center;gap:8px;padding:10px 20px;border-bottom:1px solid var(--cc-border-2)}
+.cc-q-search-ic{color:var(--cc-muted-2);font-size:.85rem;flex-shrink:0;line-height:1}
+.cc-q-search input{flex:1;min-width:0;background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:7px;color:var(--cc-text);font:inherit;font-size:.82rem;padding:6px 10px;outline:none;transition:border-color .15s,box-shadow .15s}
+.cc-q-search input::placeholder{color:var(--cc-muted-2)}
 .cc-q-search input:focus{border-color:#1f6feb;box-shadow:0 0 0 3px rgba(31,111,235,.25)}
-.cc-q-search-clear{background:none;border:none;color:#6e7681;cursor:pointer;font-size:1rem;line-height:1;padding:2px 4px;display:none}
+.cc-q-search-clear{background:none;border:none;color:var(--cc-muted-2);cursor:pointer;font-size:1rem;line-height:1;padding:2px 4px;display:none}
 .cc-q-search.has-text .cc-q-search-clear{display:inline-flex}
-.cc-q-search-clear:hover{color:#c9d1d9}
-.cc-q-filternote{padding:6px 20px;font-size:.72rem;color:#6e7681;border-bottom:1px solid #21262d}
+.cc-q-search-clear:hover{color:var(--cc-text-2)}
+.cc-q-filternote{padding:6px 20px;font-size:.72rem;color:var(--cc-muted-2);border-bottom:1px solid var(--cc-border-2)}
 /* ── My label interests (#2637) — contributor-declared label affinity ───────────
    A quiet self-service editor on the queue card: chips for the labels this viewer
    subscribed to, plus an add field. Shown only to a signed-in contributor. Matching
    queue rows are highlighted (.cc-q-mine) and a small "for you" tag explains why.
    Sober palette to match the SRE ops register; the page's green accent marks a
    personal match without shouting. */
-.cc-interests{padding:10px 20px;border-bottom:1px solid #21262d}
+.cc-interests{padding:10px 20px;border-bottom:1px solid var(--cc-border-2)}
 .cc-interests-head{display:flex;flex-wrap:wrap;align-items:baseline;gap:8px;margin-bottom:6px}
-.cc-interests-title{font-size:.74rem;font-weight:700;letter-spacing:.03em;text-transform:uppercase;color:#8b949e}
-.cc-interests-hint{font-size:.68rem;color:#6e7681}
+.cc-interests-title{font-size:.74rem;font-weight:700;letter-spacing:.03em;text-transform:uppercase;color:var(--cc-muted)}
+.cc-interests-hint{font-size:.68rem;color:var(--cc-muted-2)}
 .cc-interests-chips{display:flex;flex-wrap:wrap;gap:5px;margin-bottom:6px}
-.cc-interests-empty{font-size:.72rem;color:#6e7681}
-.cc-interests-empty code{background:#161b22;border:1px solid #30363d;border-radius:4px;padding:0 4px;font-size:.9em}
+.cc-interests-empty{font-size:.72rem;color:var(--cc-muted-2)}
+.cc-interests-empty code{background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:4px;padding:0 4px;font-size:.9em}
 .cc-interest-chip{display:inline-flex;align-items:center;gap:5px;padding:2px 9px;border-radius:999px;font-size:.74rem;background:rgba(46,160,67,.12);color:#3fb950;border:1px solid rgba(46,160,67,.3)}
 .cc-interest-x{cursor:pointer;opacity:.7;font-size:.95rem;line-height:1}
 .cc-interest-x:hover{opacity:1}
 .cc-interests-add{display:flex;gap:6px}
-.cc-interests-add input{flex:1;min-width:0;background:#0d1117;border:1px solid #30363d;border-radius:7px;color:#e6edf3;font:inherit;font-size:.8rem;padding:5px 9px;outline:none;transition:border-color .15s,box-shadow .15s}
-.cc-interests-add input::placeholder{color:#6e7681}
+.cc-interests-add input{flex:1;min-width:0;background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:7px;color:var(--cc-text);font:inherit;font-size:.8rem;padding:5px 9px;outline:none;transition:border-color .15s,box-shadow .15s}
+.cc-interests-add input::placeholder{color:var(--cc-muted-2)}
 .cc-interests-add input:focus{border-color:#1f6feb;box-shadow:0 0 0 3px rgba(31,111,235,.25)}
-.cc-interests-add button{background:#161b22;border:1px solid #30363d;border-radius:7px;color:#c9d1d9;cursor:pointer;font:inherit;font-size:.78rem;padding:5px 12px}
+.cc-interests-add button{background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:7px;color:var(--cc-text-2);cursor:pointer;font:inherit;font-size:.78rem;padding:5px 12px}
 .cc-interests-add button:hover{border-color:#3fb950;color:#3fb950}
 /* A queue row matching one of the viewer's label interests: a soft green rail on
    the leading edge + faint tint. Never hides the row — pure emphasis. */
@@ -934,22 +1006,22 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 /* Per-row "⋯" context affordance — owner/read-write only (rendered only when
    adminEnabled). Sits at the row's trailing edge, quiet until hover/open. */
 .cc-q-menu-wrap{position:relative;flex-shrink:0;margin-left:auto;align-self:center}
-.cc-q-menu-btn{background:none;border:none;color:#6e7681;cursor:pointer;font-size:1rem;line-height:1;padding:4px 6px;border-radius:6px}
-.cc-q-menu-btn:hover,.cc-q-menu-btn[aria-expanded=true]{color:#e6edf3;background:#21262d}
-.cc-q-menu{position:absolute;top:100%%;right:0;z-index:40;min-width:190px;background:#161b22;border:1px solid #30363d;border-radius:10px;box-shadow:0 8px 28px rgba(1,4,9,.55);padding:6px;display:none}
+.cc-q-menu-btn{background:none;border:none;color:var(--cc-muted-2);cursor:pointer;font-size:1rem;line-height:1;padding:4px 6px;border-radius:6px}
+.cc-q-menu-btn:hover,.cc-q-menu-btn[aria-expanded=true]{color:var(--cc-text);background:var(--cc-border-2)}
+.cc-q-menu{position:absolute;top:100%%;right:0;z-index:40;min-width:190px;background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:10px;box-shadow:0 8px 28px rgba(1,4,9,.55);padding:6px;display:none}
 .cc-q-menu.open{display:block}
-.cc-q-menu button.cc-q-act{display:flex;align-items:center;gap:8px;width:100%%;background:none;border:none;color:#c9d1d9;font:inherit;font-size:.82rem;text-align:left;padding:7px 9px;border-radius:6px;cursor:pointer}
-.cc-q-menu button.cc-q-act:hover{background:#21262d;color:#e6edf3}
-.cc-q-menu-ic{color:#6e7681;flex-shrink:0;width:16px;text-align:center}
-.cc-q-menu-sep{height:1px;background:#21262d;margin:5px 2px}
+.cc-q-menu button.cc-q-act{display:flex;align-items:center;gap:8px;width:100%%;background:none;border:none;color:var(--cc-text-2);font:inherit;font-size:.82rem;text-align:left;padding:7px 9px;border-radius:6px;cursor:pointer}
+.cc-q-menu button.cc-q-act:hover{background:var(--cc-border-2);color:var(--cc-text)}
+.cc-q-menu-ic{color:var(--cc-muted-2);flex-shrink:0;width:16px;text-align:center}
+.cc-q-menu-sep{height:1px;background:var(--cc-border-2);margin:5px 2px}
 .cc-q-moverow{display:flex;align-items:center;gap:6px;padding:7px 9px}
-.cc-q-moverow label{font-size:.78rem;color:#8b949e;flex:1}
-/* color-scheme:dark makes the native number-input spinner arrows theme-aware, so
-   they render light-on-dark and are VISIBLE against the #0d1117 field + the dark
-   #161b22 menu — previously they were black-on-black and effectively invisible.
-   The explicit background/color are kept as a belt-and-braces fallback for engines
-   that don't honour color-scheme on the control. */
-.cc-q-moverow input[type=number]{width:56px;background:#0d1117;border:1px solid #30363d;border-radius:6px;color:#e6edf3;font:inherit;font-size:.8rem;padding:4px 6px;outline:none;color-scheme:dark}
+.cc-q-moverow label{font-size:.78rem;color:var(--cc-muted);flex:1}
+/* color-scheme makes the native number-input spinner arrows theme-aware, so they
+   render legibly against the field in BOTH appearances (previously black-on-black
+   and effectively invisible on dark). The tokenized background/color are kept as a
+   belt-and-braces fallback for engines that don't honour color-scheme on the
+   control; the field itself flips with the (#2612) light/dark tokens. */
+.cc-q-moverow input[type=number]{width:56px;background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:6px;color:var(--cc-text);font:inherit;font-size:.8rem;padding:4px 6px;outline:none;color-scheme:light dark}
 .cc-q-moverow input:focus{border-color:#1f6feb}
 .cc-q-moverow button{background:#1f6feb;border:none;color:#fff;font:inherit;font-size:.76rem;font-weight:600;padding:5px 10px;border-radius:6px;cursor:pointer}
 .cc-q-moverow button:hover{background:#388bfd}
@@ -963,46 +1035,46 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
    quiet: no loud "recommended!" chrome, just a short curated list with a subtle
    heat dot and an unobtrusive "add to queue" affordance (owner/read-write only). */
 .opp-list{padding:2px 0}
-.opp-item{display:flex;align-items:flex-start;gap:10px;padding:11px 20px;border-bottom:1px solid #21262d}
+.opp-item{display:flex;align-items:flex-start;gap:10px;padding:11px 20px;border-bottom:1px solid var(--cc-border-2)}
 .opp-item:last-child{border-bottom:none}
 .opp-heat{flex-shrink:0;width:8px;height:8px;border-radius:50%%;margin-top:5px;background:#3fb950;box-shadow:0 0 0 3px rgba(63,185,80,.14)}
 .opp-heat.warm{background:#d29922;box-shadow:0 0 0 3px rgba(210,153,34,.14)}
-.opp-heat.cool{background:#6e7681;box-shadow:none}
+.opp-heat.cool{background:var(--cc-muted-2);box-shadow:none}
 .opp-body{flex:1;min-width:0}
-.opp-repo{font-size:.72rem;color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
-.opp-title{font-size:.86rem;color:#e6edf3;margin:2px 0 3px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.opp-reason{font-size:.7rem;color:#6e7681}
-.opp-add{flex-shrink:0;align-self:center;background:none;border:1px solid #30363d;color:#c9d1d9;font:inherit;font-size:.74rem;font-weight:600;padding:5px 11px;border-radius:7px;cursor:pointer;transition:border-color .15s,color .15s,background .15s}
+.opp-repo{font-size:.72rem;color:var(--cc-muted);font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.opp-title{font-size:.86rem;color:var(--cc-text);margin:2px 0 3px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.opp-reason{font-size:.7rem;color:var(--cc-muted-2)}
+.opp-add{flex-shrink:0;align-self:center;background:none;border:1px solid var(--cc-border);color:var(--cc-text-2);font:inherit;font-size:.74rem;font-weight:600;padding:5px 11px;border-radius:7px;cursor:pointer;transition:border-color .15s,color .15s,background .15s}
 .opp-add:hover{border-color:#1f6feb;color:#fff;background:rgba(31,111,235,.15)}
-.opp-add:disabled{opacity:.55;cursor:default;border-color:#30363d;color:#8b949e;background:none}
+.opp-add:disabled{opacity:.55;cursor:default;border-color:var(--cc-border);color:var(--cc-muted);background:none}
 /* ── End-of-queue + hive-settings (#2595) — turn a short queue into an intentional,
    reassuring moment: a calm "all caught up" marker, the managed-queue rate limits
    presented readably, and the viewer's own daily quota. Sober, ranked-family styling. */
 .cc-q-end{padding:18px 20px 6px;text-align:center}
-.cc-q-end-badge{display:inline-flex;align-items:center;gap:8px;font-size:.82rem;color:#8b949e;background:#0d1117;border:1px solid #21262d;border-radius:999px;padding:7px 16px}
+.cc-q-end-badge{display:inline-flex;align-items:center;gap:8px;font-size:.82rem;color:var(--cc-muted);background:var(--cc-bg);border:1px solid var(--cc-border-2);border-radius:999px;padding:7px 16px}
 .cc-q-end-badge .cc-q-end-ic{color:#3fb950;font-size:.95rem;line-height:1}
-.hive-settings{margin:14px 20px 4px;background:#0d1117;border:1px solid #21262d;border-radius:10px;padding:14px 16px}
-.hive-settings h4{margin:0 0 4px;font-size:.78rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#8b949e}
-.hive-settings p.hs-lead{margin:0 0 10px;font-size:.82rem;color:#c9d1d9;line-height:1.5}
+.hive-settings{margin:14px 20px 4px;background:var(--cc-bg);border:1px solid var(--cc-border-2);border-radius:10px;padding:14px 16px}
+.hive-settings h4{margin:0 0 4px;font-size:.78rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:var(--cc-muted)}
+.hive-settings p.hs-lead{margin:0 0 10px;font-size:.82rem;color:var(--cc-text-2);line-height:1.5}
 .hs-tiers{display:flex;flex-wrap:wrap;gap:8px}
-.hs-tier{flex:1 1 130px;min-width:120px;background:#161b22;border:1px solid #30363d;border-radius:8px;padding:9px 11px}
-.hs-tier__name{font-size:.72rem;font-weight:600;text-transform:capitalize;color:#e6edf3;display:flex;align-items:center;gap:6px}
-.hs-tier__lim{font-size:.74rem;color:#8b949e;margin-top:3px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.hs-tier{flex:1 1 130px;min-width:120px;background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:8px;padding:9px 11px}
+.hs-tier__name{font-size:.72rem;font-weight:600;text-transform:capitalize;color:var(--cc-text);display:flex;align-items:center;gap:6px}
+.hs-tier__lim{font-size:.74rem;color:var(--cc-muted);margin-top:3px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
 .hs-tier.is-you{border-color:#1f6feb;box-shadow:0 0 0 2px rgba(31,111,235,.18)}
 .hs-tier__youtag{font-size:.6rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#58a6ff}
 /* Daily quota widget — a slim progress meter, calm. Used at end-of-queue AND on
    the Me card. Fill width is set inline from the REAL used/limit ratio. */
 .quota{margin-top:12px}
 .quota__head{display:flex;align-items:baseline;justify-content:space-between;gap:8px;margin-bottom:6px}
-.quota__lbl{font-size:.76rem;color:#8b949e}
-.quota__val{font-size:.82rem;color:#e6edf3;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
-.quota__bar{height:7px;border-radius:999px;background:#21262d;overflow:hidden}
+.quota__lbl{font-size:.76rem;color:var(--cc-muted)}
+.quota__val{font-size:.82rem;color:var(--cc-text);font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.quota__bar{height:7px;border-radius:999px;background:var(--cc-border-2);overflow:hidden}
 .quota__fill{height:100%%;border-radius:999px;background:linear-gradient(90deg,#1f6feb,#388bfd);transition:width .4s ease}
 .quota__fill.near{background:linear-gradient(90deg,#d29922,#e3b341)}
 .quota__fill.full{background:linear-gradient(90deg,#f85149,#ff7b72)}
-.quota__sub{font-size:.7rem;color:#6e7681;margin-top:5px}
+.quota__sub{font-size:.7rem;color:var(--cc-muted-2);margin-top:5px}
 /* Me-card quota variant — sits inside a me-sec, so it inherits the card padding. */
-.me-quota .quota__lbl{color:#8b949e}
+.me-quota .quota__lbl{color:var(--cc-muted)}
 @media(prefers-reduced-motion:reduce){.quota__fill{transition:none!important}}
 /* Sparklines (#persistent-history): tiny dependency-free inline-SVG trend charts
    fed by /api/contribute/metrics (7-day hourly history). Muted stroke to sit
@@ -1017,39 +1089,39 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
    numerals stay the focus. */
 .lb-spark{display:flex;align-items:center;justify-content:flex-end}
 /* Hive-wide trend strip pinned above the standings. */
-.lb-trend{display:flex;align-items:center;gap:10px;padding:8px 20px 12px;color:#8b949e;font-size:.76rem;border-bottom:1px solid #21262d}
+.lb-trend{display:flex;align-items:center;gap:10px;padding:8px 20px 12px;color:var(--cc-muted);font-size:.76rem;border-bottom:1px solid var(--cc-border-2)}
 .lb-trend .spark{margin-left:auto}
 /* "File an issue on this page" link (#2594) — a subtle footer affordance present
    on every tab. Quiet grey, matches the sober dashboard chrome; an outbound link. */
-.cc-page-foot{padding:26px 48px 34px;border-top:1px solid #21262d;margin-top:28px;display:flex;justify-content:center}
-.cc-report-link{display:inline-flex;align-items:center;gap:7px;color:#8b949e;font-size:.8rem;text-decoration:none;border:1px solid #30363d;border-radius:8px;padding:7px 14px;transition:color .15s,border-color .15s,background .15s}
-.cc-report-link:hover{color:#e6edf3;border-color:#484f58;background:#161b22}
+.cc-page-foot{padding:26px 48px 34px;border-top:1px solid var(--cc-border-2);margin-top:28px;display:flex;justify-content:center}
+.cc-report-link{display:inline-flex;align-items:center;gap:7px;color:var(--cc-muted);font-size:.8rem;text-decoration:none;border:1px solid var(--cc-border);border-radius:8px;padding:7px 14px;transition:color .15s,border-color .15s,background .15s}
+.cc-report-link:hover{color:var(--cc-text);border-color:#484f58;background:var(--cc-surface)}
 .cc-report-link .cc-report-ic{font-size:.9rem;line-height:1}
 /* The travelling token that flies from the queue to a clanker on task_assign */
 .cc-token{position:fixed;z-index:1200;pointer-events:none;background:#1f6feb;color:#fff;font-size:.72rem;font-weight:600;padding:6px 12px;border-radius:999px;box-shadow:0 6px 20px rgba(31,111,235,.5);white-space:nowrap;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;transition:transform .9s cubic-bezier(.5,0,.2,1),opacity .9s ease;will-change:transform,opacity}
 /* Dev-log — a running chat log of the development */
 .cc-log{max-height:360px;overflow-y:auto;padding:4px 0}
-.cc-log-line{display:flex;align-items:flex-start;gap:10px;padding:8px 20px;font-size:.83rem;border-bottom:1px solid #1c2128;animation:cc-logline .45s ease}
+.cc-log-line{display:flex;align-items:flex-start;gap:10px;padding:8px 20px;font-size:.83rem;border-bottom:1px solid var(--cc-border-2);animation:cc-logline .45s ease}
 @keyframes cc-logline{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:none}}
 .cc-log-line:last-child{border-bottom:none}
 .cc-log-ic{flex-shrink:0}
-.cc-log-body{flex:1;min-width:0;color:#c9d1d9;line-height:1.45}
-.cc-log-body b{color:#e6edf3}
+.cc-log-body{flex:1;min-width:0;color:var(--cc-text-2);line-height:1.45}
+.cc-log-body b{color:var(--cc-text)}
 .cc-log-body .who{color:#58a6ff;font-weight:600}
-.cc-log-body .ref{color:#8b949e;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.78rem}
+.cc-log-body .ref{color:var(--cc-muted);font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.78rem}
 .cc-log-body a.ref.cc-issue-link{color:#58a6ff}
 .cc-log-body a.ref.cc-issue-link:hover,.cc-log-body a.ref.cc-issue-link:focus-visible{color:#79c0ff}
-.cc-log-time{flex-shrink:0;color:#6e7681;font-size:.72rem;white-space:nowrap;padding-top:1px}
+.cc-log-time{flex-shrink:0;color:var(--cc-muted-2);font-size:.72rem;white-space:nowrap;padding-top:1px}
 /* Achievement pops — tasteful badge toast, top-right, debounced */
 .cc-ach-wrap{position:fixed;top:16px;right:16px;z-index:1150;display:flex;flex-direction:column;gap:8px;pointer-events:none}
-.cc-ach{display:flex;align-items:center;gap:10px;background:linear-gradient(135deg,#161b22,#1c2333);border:1px solid rgba(210,153,34,.4);border-radius:10px;padding:10px 14px;box-shadow:0 8px 28px rgba(1,4,9,.55);animation:cc-ach-in .4s ease;max-width:300px}
+.cc-ach{display:flex;align-items:center;gap:10px;background:linear-gradient(135deg,var(--cc-surface),#1c2333);border:1px solid rgba(210,153,34,.4);border-radius:10px;padding:10px 14px;box-shadow:0 8px 28px rgba(1,4,9,.55);animation:cc-ach-in .4s ease;max-width:300px}
 @keyframes cc-ach-in{from{opacity:0;transform:translateX(24px)}to{opacity:1;transform:none}}
 .cc-ach.cc-ach-out{animation:cc-ach-out .4s ease forwards}
 @keyframes cc-ach-out{to{opacity:0;transform:translateX(24px)}}
 .cc-ach-ic{font-size:1.3rem;flex-shrink:0}
 .cc-ach-txt{min-width:0}
 .cc-ach-h{font-size:.7rem;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:#d29922}
-.cc-ach-s{font-size:.82rem;color:#e6edf3;margin-top:1px}
+.cc-ach-s{font-size:.82rem;color:var(--cc-text);margin-top:1px}
 /* ── Operations two-region shell: MAIN area + full-height DEV-LOG RAIL ──────────
    The main area flexes to fill remaining width; the rail is a fixed-width panel
    pinned to the tab's height. When the rail collapses it shrinks to a thin strip
@@ -1061,17 +1133,17 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 /* The rail: a self-contained chat/notifications panel that runs the tab's height.
    It sticks so the feed stays in view while the (taller) main area scrolls. */
 .ops-rail{flex:0 0 340px;position:sticky;top:0;align-self:flex-start;max-height:calc(100vh - 80px);
-  background:#161b22;border:1px solid #30363d;border-radius:12px;overflow:hidden;
+  background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:12px;overflow:hidden;
   display:flex;flex-direction:column;transition:flex-basis .28s ease}
 .ops-rail-inner{display:flex;flex-direction:column;min-height:0;flex:1 1 auto;opacity:1;transition:opacity .2s ease}
-.ops-rail-head{padding:16px 20px;border-bottom:1px solid #30363d;display:flex;align-items:center;gap:10px;flex-shrink:0}
-.ops-rail-head h3{font-size:.95rem;color:#e6edf3;margin:0}
+.ops-rail-head{padding:16px 20px;border-bottom:1px solid var(--cc-border);display:flex;align-items:center;gap:10px;flex-shrink:0}
+.ops-rail-head h3{font-size:.95rem;color:var(--cc-text);margin:0}
 .ops-rail .cc-log{flex:1 1 auto;max-height:none;min-height:0}
 /* The collapse toggle sits on the rail's leading edge (a slim handle). */
-.ops-rail-toggle{display:flex;align-items:center;gap:6px;width:100%%;background:#0d1117;border:none;
-  border-bottom:1px solid #30363d;color:#8b949e;font-family:inherit;font-size:.74rem;font-weight:600;
+.ops-rail-toggle{display:flex;align-items:center;gap:6px;width:100%%;background:var(--cc-bg);border:none;
+  border-bottom:1px solid var(--cc-border);color:var(--cc-muted);font-family:inherit;font-size:.74rem;font-weight:600;
   letter-spacing:.03em;text-transform:uppercase;padding:9px 14px;cursor:pointer;flex-shrink:0}
-.ops-rail-toggle:hover{color:#e6edf3;background:#161b22}
+.ops-rail-toggle:hover{color:var(--cc-text);background:var(--cc-surface)}
 .ops-rail-chevron{display:inline-block;font-size:1rem;line-height:1;transition:transform .28s ease}
 /* Collapsed: rail narrows to a strip; the toggle label + inner feed hide; the
    chevron flips to point "open" (right) as a "show log" affordance. */
@@ -1098,35 +1170,35 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
    nothing about the copy-block logic changes. CSP-safe (inline assets only),
    theme-consistent with the dark palette, reduced-motion safe. */
 .client-tiles{display:grid;grid-template-columns:repeat(auto-fill,minmax(132px,1fr));gap:8px;margin:4px 0 20px}
-.client-tile{display:flex;align-items:flex-start;gap:9px;background:#161b22;border:1px solid #30363d;border-radius:10px;padding:9px 11px;cursor:pointer;text-align:left;font-family:inherit;color:#e6edf3;font-size:.82rem;transition:border-color .15s,background .15s,transform .1s}
+.client-tile{display:flex;align-items:flex-start;gap:9px;background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:10px;padding:9px 11px;cursor:pointer;text-align:left;font-family:inherit;color:var(--cc-text);font-size:.82rem;transition:border-color .15s,background .15s,transform .1s}
 .client-tile:hover{border-color:#58a6ff;background:#1b2230}
 .client-tile:active{transform:translateY(1px)}
 .client-tile:focus-visible{outline:2px solid #58a6ff;outline-offset:2px}
 .client-tile.sel{border-color:#58a6ff;background:rgba(88,166,255,.10);box-shadow:inset 0 0 0 1px rgba(88,166,255,.35)}
-.client-tile .ct-emblem{width:24px;height:24px;flex:0 0 24px;display:flex;align-items:center;justify-content:center;border-radius:6px;background:#0d1117;overflow:hidden}
+.client-tile .ct-emblem{width:24px;height:24px;flex:0 0 24px;display:flex;align-items:center;justify-content:center;border-radius:6px;background:var(--cc-bg);overflow:hidden}
 .client-tile .ct-emblem svg{width:18px;height:18px;display:block}
 .client-tile .ct-name{font-weight:600;line-height:1.15;min-width:0}
-.client-tile .ct-name small{display:block;font-weight:400;color:#8b949e;font-size:.7rem}
+.client-tile .ct-name small{display:block;font-weight:400;color:var(--cc-muted);font-size:.7rem}
 /* min-width:0 keeps the name ellipsising rather than overflowing the tile. */
 .client-tile .ct-body{display:flex;flex-direction:column;align-items:flex-start;gap:3px;min-width:0}
 /* "Open in <tool>" onboarding affordance — deliberately understated and clearly a
    SETUP helper, never a "contributing" surface. Only rendered for a client with a
    real, vendor-documented deep-link scheme. */
-.openin-row{display:none;align-items:flex-start;gap:10px;background:#0d1117;border:1px solid #30363d;border-left:3px solid #d29922;border-radius:8px;padding:11px 14px;margin:0 0 16px}
+.openin-row{display:none;align-items:flex-start;gap:10px;background:var(--cc-bg);border:1px solid var(--cc-border);border-left:3px solid #d29922;border-radius:8px;padding:11px 14px;margin:0 0 16px}
 .openin-row.show{display:flex}
-.openin-row .oi-body{min-width:0;font-size:.8rem;color:#8b949e;line-height:1.4}
-.openin-row .oi-body strong{color:#e6edf3}
-.openin-link{flex:0 0 auto;display:inline-flex;align-items:center;gap:6px;background:#161b22;border:1px solid #30363d;border-radius:6px;color:#58a6ff;text-decoration:none;font-size:.8rem;padding:6px 12px;font-family:inherit;cursor:pointer}
+.openin-row .oi-body{min-width:0;font-size:.8rem;color:var(--cc-muted);line-height:1.4}
+.openin-row .oi-body strong{color:var(--cc-text)}
+.openin-link{flex:0 0 auto;display:inline-flex;align-items:center;gap:6px;background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:6px;color:#58a6ff;text-decoration:none;font-size:.8rem;padding:6px 12px;font-family:inherit;cursor:pointer}
 .openin-link:hover{border-color:#58a6ff}
 .openin-link svg{width:14px;height:14px}
 .oi-note{color:#d29922;font-weight:600}
 /* Customizable, copy-pasteable per-client PROMPT (kept in an editable block the
    contributor can read/tweak, NOT compressed into a URL). Additive to the shell
    command copy block above it. */
-.prompt-block{margin:18px 0 8px;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:14px 16px 16px;position:relative}
-.prompt-block h4{margin:0 0 6px;font-size:.82rem;color:#e6edf3;font-weight:600}
-.prompt-block p.pb-sub{margin:0 0 10px;color:#8b949e;font-size:.76rem;line-height:1.4}
-.prompt-block textarea{width:100%%;min-height:118px;resize:vertical;background:#010409;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:10px 12px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.8rem;line-height:1.5}
+.prompt-block{margin:18px 0 8px;background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:8px;padding:14px 16px 16px;position:relative}
+.prompt-block h4{margin:0 0 6px;font-size:.82rem;color:var(--cc-text);font-weight:600}
+.prompt-block p.pb-sub{margin:0 0 10px;color:var(--cc-muted);font-size:.76rem;line-height:1.4}
+.prompt-block textarea{width:100%%;min-height:118px;resize:vertical;background:var(--cc-bg-deep);color:var(--cc-text);border:1px solid var(--cc-border);border-radius:6px;padding:10px 12px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.8rem;line-height:1.5}
 .prompt-block textarea:focus{outline:none;border-color:#58a6ff}
 .pb-copy{position:absolute;top:10px;right:12px;background:#238636;color:#fff;border:none;border-radius:4px;padding:4px 12px;cursor:pointer;font-size:.72rem;font-family:inherit}
 @media(prefers-reduced-motion:reduce){
@@ -1135,18 +1207,92 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 /* Trusted invite banner (issue #2598) — shown on onboarding when arriving via an
    attributed invite link. Subtle, informational; makes clear the invitee joins
    as a newcomer. */
-.invite-banner{margin:0 0 20px;padding:11px 15px;border:1px solid #388bfd55;border-radius:8px;background:#1c2f4a55;color:#c9d1d9;font-size:.85rem;line-height:1.45}
-.invite-banner b{color:#e6edf3}
-.invite-banner .invite-tier{color:#8b949e}
+.invite-banner{margin:0 0 20px;padding:11px 15px;border:1px solid #388bfd55;border-radius:8px;background:#1c2f4a55;color:var(--cc-text-2);font-size:.85rem;line-height:1.45}
+.invite-banner b{color:var(--cc-text)}
+.invite-banner .invite-tier{color:var(--cc-muted)}
 /* Trusted "Invite someone" action inside the Me card (issue #2598). */
 .me-invite{margin-top:12px;padding-top:12px;border-top:1px solid #ffffff14}
 .me-invite__btn{display:inline-flex;align-items:center;gap:6px;background:#1f6feb;color:#fff;border:none;border-radius:6px;padding:7px 14px;font-size:.82rem;font-family:inherit;cursor:pointer}
 .me-invite__btn:hover{background:#388bfd}
 .me-invite__row{display:none;margin-top:10px;gap:8px;align-items:center;flex-wrap:wrap}
 .me-invite__row.open{display:flex}
-.me-invite__link{flex:1 1 220px;min-width:0;background:#010409;color:#c9d1d9;border:1px solid #30363d;border-radius:6px;padding:7px 10px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.76rem}
+.me-invite__link{flex:1 1 220px;min-width:0;background:var(--cc-bg-deep);color:var(--cc-text-2);border:1px solid var(--cc-border);border-radius:6px;padding:7px 10px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.76rem}
 .me-invite__copy{background:#238636;color:#fff;border:none;border-radius:6px;padding:7px 12px;font-size:.78rem;font-family:inherit;cursor:pointer}
-.me-invite__hint{width:100%%;margin-top:6px;color:#8b949e;font-size:.74rem;line-height:1.4}
+.me-invite__hint{width:100%%;margin-top:6px;color:var(--cc-muted);font-size:.74rem;line-height:1.4}
+/* ── Triage ladder (#2612 part b) — a lifecycle view over contribute issues.
+   Themed entirely with the (d) tokens so it flips light/dark with the rest of the
+   page. The ladder is a row of level chips (count per rung); below it, per-level
+   groups list the issues with an optional PR badge (part c). Sober SRE register:
+   muted neutrals, the level accent only on the chip dot + count. */
+.cc-triage-ladder{display:flex;flex-wrap:wrap;gap:8px;padding:14px 20px;border-bottom:1px solid var(--cc-border-2)}
+.cc-triage-chip{display:inline-flex;align-items:center;gap:7px;padding:5px 12px;border-radius:999px;font-size:.76rem;font-weight:600;color:var(--cc-text-2);background:var(--cc-bg);border:1px solid var(--cc-border)}
+.cc-triage-chip .cc-tl-dot{width:8px;height:8px;border-radius:50%%;flex:none;background:var(--cc-muted)}
+.cc-triage-chip .cc-tl-n{font-variant-numeric:tabular-nums;color:var(--cc-text);font-weight:700}
+.cc-triage-chip .cc-tl-lbl{color:var(--cc-muted);font-weight:600}
+/* Per-level accent on the dot only — meaning without shouting. */
+.cc-triage-chip.lv-triaging .cc-tl-dot{background:var(--cc-muted)}
+.cc-triage-chip.lv-ready .cc-tl-dot{background:var(--cc-accent)}
+.cc-triage-chip.lv-implementing .cc-tl-dot{background:var(--cc-accent-fg)}
+.cc-triage-chip.lv-reviewing .cc-tl-dot{background:var(--cc-amber)}
+.cc-triage-chip.lv-closed .cc-tl-dot{background:var(--cc-green)}
+.cc-triage-groups{max-height:520px;overflow-y:auto}
+.cc-tg{border-bottom:1px solid var(--cc-border-2)}
+.cc-tg:last-child{border-bottom:none}
+.cc-tg-head{display:flex;align-items:center;gap:8px;padding:10px 20px;font-size:.74rem;font-weight:700;letter-spacing:.03em;text-transform:uppercase;color:var(--cc-muted);position:sticky;top:0;background:var(--cc-surface);z-index:1}
+.cc-tg-head .cc-tg-dot{width:8px;height:8px;border-radius:50%%;flex:none;background:var(--cc-muted)}
+.cc-tg.lv-ready .cc-tg-dot{background:var(--cc-accent)}
+.cc-tg.lv-implementing .cc-tg-dot{background:var(--cc-accent-fg)}
+.cc-tg.lv-reviewing .cc-tg-dot{background:var(--cc-amber)}
+.cc-tg.lv-closed .cc-tg-dot{background:var(--cc-green)}
+.cc-tg-count{margin-left:auto;color:var(--cc-muted-2);font-weight:600;font-variant-numeric:tabular-nums}
+.cc-tg-item{display:flex;align-items:flex-start;gap:10px;padding:10px 20px;border-top:1px solid var(--cc-border-2)}
+.cc-tg-body{flex:1;min-width:0}
+.cc-tg-repo{font-size:.72rem;color:var(--cc-muted);font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.cc-tg-title{font-size:.86rem;color:var(--cc-text);margin:2px 0 0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.cc-tg-empty{padding:8px 20px 12px;font-size:.76rem;color:var(--cc-muted-2)}
+/* PR→issue badge (#2612 part c) — a small link chip on a queue/triage row telling
+   whether a fixing PR is open or merged. Reuses the status-pill palette so its
+   meaning matches the rest of the page (open = review-amber, merged = done-green). */
+.cc-pr-badge{flex-shrink:0;display:inline-flex;align-items:center;gap:4px;align-self:center;font-size:.68rem;font-weight:600;padding:2px 8px;border-radius:999px;text-decoration:none;border:1px solid transparent;white-space:nowrap}
+.cc-pr-badge.pr-open{background:rgba(210,153,34,.12);color:var(--cc-amber);border-color:rgba(210,153,34,.3)}
+.cc-pr-badge.pr-merged{background:rgba(63,185,80,.12);color:var(--cc-green);border-color:rgba(63,185,80,.3)}
+.cc-pr-badge:hover{filter:brightness(1.1);text-decoration:underline}
+/* Inline PR badge riding on a ready-queue row (smaller, sits after the title). */
+.cc-q-body .cc-pr-badge{margin-top:4px}
+/* ── (#2612 part d) Light-mode fixups for the handful of DARK one-off surfaces
+   that are not part of the tokenized neutral ramp (small gradient washes and a
+   couple of hover fills baked as literal dark hex). On a light appearance those
+   would read as near-black patches, so re-point them at the light tokens. Also a
+   gentle contrast lift on the muted status-pill fills, whose ~12%% dark-tuned
+   rgba washes go faint on white — a gentle solid tint keeps them legible without
+   changing their hue/meaning. Applies under BOTH light signals. */
+@media(prefers-color-scheme:light){:root:not([data-theme="dark"]) .ops-card.card-accent>.ops-card-head{background:linear-gradient(180deg,var(--cc-border-2) 0%%,var(--cc-surface) 100%%)}
+:root:not([data-theme="dark"]) .cc-ach{background:var(--cc-surface)}
+:root:not([data-theme="dark"]) .client-tile:hover{background:var(--cc-border-2)}
+:root:not([data-theme="dark"]) .invite-banner{background:#ddf4ff;border-color:#b6e3ff}
+:root:not([data-theme="dark"]) .cc-report-link:hover{border-color:var(--cc-muted)}
+:root:not([data-theme="dark"]) .pill-progress{background:rgba(9,105,218,.10);color:var(--cc-accent-fg);border-color:rgba(9,105,218,.30)}
+:root:not([data-theme="dark"]) .pill-review,:root:not([data-theme="dark"]) .clanker-status.reviewing{background:rgba(154,103,0,.12);color:var(--cc-amber);border-color:rgba(154,103,0,.30)}
+:root:not([data-theme="dark"]) .pill-passed{background:rgba(26,127,55,.12);color:var(--cc-green);border-color:rgba(26,127,55,.30)}
+:root:not([data-theme="dark"]) .pill-blocked{background:rgba(207,34,46,.10);color:var(--cc-red);border-color:rgba(207,34,46,.30)}
+}
+:root[data-theme="light"] .ops-card.card-accent>.ops-card-head{background:linear-gradient(180deg,var(--cc-border-2) 0%%,var(--cc-surface) 100%%)}
+:root[data-theme="light"] .cc-ach{background:var(--cc-surface)}
+:root[data-theme="light"] .client-tile:hover{background:var(--cc-border-2)}
+:root[data-theme="light"] .invite-banner{background:#ddf4ff;border-color:#b6e3ff}
+:root[data-theme="light"] .cc-report-link:hover{border-color:var(--cc-muted)}
+:root[data-theme="light"] .pill-progress{background:rgba(9,105,218,.10);color:var(--cc-accent-fg);border-color:rgba(9,105,218,.30)}
+:root[data-theme="light"] .pill-review,:root[data-theme="light"] .clanker-status.reviewing{background:rgba(154,103,0,.12);color:var(--cc-amber);border-color:rgba(154,103,0,.30)}
+:root[data-theme="light"] .pill-passed{background:rgba(26,127,55,.12);color:var(--cc-green);border-color:rgba(26,127,55,.30)}
+:root[data-theme="light"] .pill-blocked{background:rgba(207,34,46,.10);color:var(--cc-red);border-color:rgba(207,34,46,.30)}
+/* ── (#2612 part d) Conservative de-crowd: small uniform breathing room on the
+   densest grids (the onboarding stat row and the Operations cards). No card
+   removed, no structural/layout change — just a touch more gap/padding so the
+   packed panels read less cramped, identically in both themes. */
+.stat-row{gap:12px}
+.stat{padding:16px 10px}
+.ops-grid{gap:24px}
+.ops-card-head{padding:18px 20px}
 </style></head><body>
 <div class="page-tabs" role="tablist">
 <button class="page-tab active" role="tab" id="ptab-onboarding" aria-selected="true" data-panel="tab-onboarding">Onboarding</button>
@@ -1728,6 +1874,21 @@ update();  // initial paint: copy block + branded UI in sync from first load
 </div>
 </div>
 </div>
+<!-- ── Triage ladder (#2612 part b) — a Warp-style lifecycle view over the hive's
+     contribute issues, grouped Triaging → Ready → Implementing → Reviewing →
+     Closed. Each level is DERIVED LIVE from the ready queue + fleet snapshot +
+     the PR→issue link (part c); there is no persistent per-issue lifecycle store
+     (a future enhancement, out of scope). A SECTION within Operations — NOT a new
+     page/tab. Fetched from /api/contribute/triage after load so a slow GitHub
+     PR-link lookup never delays the page. Full-width card below the ops grid. -->
+<div class="ops-card cc-triage-card" id="cc-triage-card" style="margin-top:20px">
+<div class="ops-card-head"><span class="feed-dot"></span><h3>Issue triage</h3><span class="ops-card-count count-strong" id="cc-triage-total"></span></div>
+<!-- Compact ladder summary: one chip per level with its live count. -->
+<div class="cc-triage-ladder" id="cc-triage-ladder"><div class="ops-empty">Loading triage&hellip;</div></div>
+<!-- Grouped per-level issue lists (each collapsible-ish section, capped). -->
+<div class="cc-triage-groups" id="cc-triage-groups"></div>
+<p class="ops-note" style="padding:10px 20px 14px;margin:0">A live lifecycle view of this hive&rsquo;s contribute issues &mdash; each issue is placed on the ladder from what the hive can observe right now (the ready queue, the fleet&rsquo;s in-flight work, and whether a fixing PR is open or merged). Read-only and recomputed on each load; there is no stored per-issue state.</p>
+</div>
 </div>
 <!-- Dedicated full-height LIVE ACTIVITY RAIL. Holds ONLY the live activity feed
      (moved here out of the former right column). Named "Live Activity" to match
@@ -1877,6 +2038,9 @@ function activateTab(t,push){
     // The dev-log rail collapse/persist wiring is independent too: a throw here must
     // not abort fleet hydration or the SSE feed.
     try{initOpsRail();}catch(e){console.error('initOpsRail failed',e);}
+    // Triage ladder (#2612 part b): fetched after the tab opens so a slow GitHub
+    // PR-link lookup never delays the page. A throw must not abort the panels above.
+    try{ccTriagePoll();}catch(e){console.error('ccTriagePoll failed',e);}
   }
   // Leaderboard hydrates client-side on first open — read-only, no role gate.
   // The personal "Me" card loads alongside the standings; a throw in one must
@@ -3278,9 +3442,13 @@ function ccRenderQueue(flip){
     var mineTag=mine?'<span class="cc-q-mine-tag" title="Matches one of your label interests">for you</span>':'';
     var heldCls=isHeld?' cc-q-held':'';
     var heldTag=isHeld?'<span class="cc-q-held-tag" title="On hold — parked by the operator; not offered until resumed">&#x23F8; on hold</span>':'';
+    // PR→issue badge (#2612 part c): if the triage poll resolved a fixing PR for
+    // this issue (open/merged), show a small link. Absent until ccTriagePoll runs,
+    // and simply omitted when no PR is linked — never blocks the queue render.
+    var prBadge=ccPRBadgeHTML((q.repo||'')+'#'+(q.number||''));
     return '<div class="cc-q-item'+mineCls+heldCls+'"'+(canDrag?' draggable="true"':'')+' data-qkey="'+esc(ccQueueKey(q))+'">'+grip+'<span class="cc-q-idx">'+(i+1)+'</span>'+
       '<div class="cc-q-body"><div class="cc-q-repo">'+ccIssueLinkHTML(q,(q.repo||'')+'#'+(q.number||''))+mineTag+heldTag+'</div>'+
-      '<div class="cc-q-title" title="'+esc(q.title||'')+'">'+esc(q.title||'(untitled)')+'</div>'+labels+'</div>'+next+menu+'</div>';
+      '<div class="cc-q-title" title="'+esc(q.title||'')+'">'+esc(q.title||'(untitled)')+'</div>'+labels+prBadge+'</div>'+next+menu+'</div>';
   }).join('');
   if(filtering&&shown===0){el.innerHTML='<div class="ops-empty">No queued items match &ldquo;'+esc(ccQueueSearch)+'&rdquo;.</div>';}
   ccUpdateFilterNote(shown,total);
@@ -3291,6 +3459,76 @@ function ccRenderQueue(flip){
   // End-of-queue block (#2595): the "all caught up" marker + hive settings + quota.
   // Only when the full list is shown (a filtered view isn't "the end of the queue").
   ccRenderQueueEnd(!filtering);
+}
+// ── Triage ladder (#2612 parts b + c) ─────────────────────────────────────────
+// ccPRLinks maps "repo#number" -> {number,url,state} for issues whose fixing PR the
+// triage endpoint resolved (open/merged). Populated by ccTriagePoll; consumed by
+// the queue-row badge and the triage groups. Empty until the first poll lands, so
+// the queue renders immediately without any PR data.
+var ccPRLinks={};
+// ccPRBadgeHTML returns the small "PR #NNN (open|merged)" link chip for an issue
+// key, or '' when no PR is linked. esc()-guarded; opens the PR on GitHub.
+function ccPRBadgeHTML(key){
+  var pr=ccPRLinks[key];
+  if(!pr||!pr.number)return '';
+  var cls=(pr.state==='merged')?'pr-merged':'pr-open';
+  var label='PR #'+pr.number+' ('+(pr.state==='merged'?'merged':'open')+')';
+  var href=pr.url||'';
+  return '<a class="cc-pr-badge '+cls+'" href="'+esc(href)+'" target="_blank" rel="noopener noreferrer" title="'+esc(label)+'">'+esc(label)+'</a>';
+}
+// CC_TRIAGE_LEVELS pins the ladder's render order + display labels client-side,
+// mirroring triageLevelOrder/triageLevelLabel on the server so the chips/groups
+// render in lifecycle order even if the JSON key order ever changed.
+var CC_TRIAGE_LEVELS=[['triaging','Triaging'],['ready','Ready to implement'],['implementing','Implementing'],['reviewing','Reviewing'],['closed','Closed']];
+// ccTriagePoll fetches the live triage snapshot and renders the ladder + groups,
+// then refreshes ccPRLinks and re-renders the queue so PR badges appear on queue
+// rows too. Best-effort: any failure leaves the "Loading…"/prior state and is
+// retried on the next tab open; it never throws into the ops bootstrap.
+function ccTriagePoll(){
+  fetch('/api/contribute/triage',{headers:{'Accept':'application/json'}})
+    .then(function(r){return r.ok?r.json():null;})
+    .then(function(d){if(d)ccRenderTriage(d);})
+    .catch(function(){/* degrade silently — the panel keeps its last state */});
+}
+// ccRenderTriage paints the ladder summary chips + the per-level issue groups, and
+// harvests the PR links into ccPRLinks so the queue rows can show badges.
+function ccRenderTriage(snap){
+  var groups=(snap&&snap.groups)||[];
+  // Index groups by level for ordered lookup.
+  var byLevel={};for(var i=0;i<groups.length;i++){byLevel[groups[i].level]=groups[i];}
+  // Total count badge.
+  var totEl=document.getElementById('cc-triage-total');
+  if(totEl)totEl.textContent=(snap&&snap.total!=null?snap.total:0)+' issues';
+  // Ladder chips.
+  var ladder=document.getElementById('cc-triage-ladder');
+  if(ladder){
+    ladder.innerHTML=CC_TRIAGE_LEVELS.map(function(lv){
+      var g=byLevel[lv[0]]||{count:0};
+      return '<span class="cc-triage-chip lv-'+lv[0]+'"><span class="cc-tl-dot"></span><span class="cc-tl-n">'+(g.count||0)+'</span><span class="cc-tl-lbl">'+esc(lv[1])+'</span></span>';
+    }).join('');
+  }
+  // Per-level groups with their issue lists.
+  var wrap=document.getElementById('cc-triage-groups');
+  if(wrap){
+    ccPRLinks={};
+    wrap.innerHTML=CC_TRIAGE_LEVELS.map(function(lv){
+      var g=byLevel[lv[0]]||{count:0,issues:[]};
+      var issues=g.issues||[];
+      var rows=issues.map(function(it){
+        var key=(it.repo||'')+'#'+(it.number||'');
+        if(it.pr&&it.pr.number){ccPRLinks[key]=it.pr;}
+        var repoLbl=esc((it.repo||'')+'#'+(it.number||''));
+        var link=it.url?('<a class="cc-issue-link" href="'+esc(it.url)+'" target="_blank" rel="noopener noreferrer">'+repoLbl+'</a>'):repoLbl;
+        var badge=(it.pr&&it.pr.number)?ccPRBadgeHTML(key):'';
+        return '<div class="cc-tg-item"><div class="cc-tg-body"><div class="cc-tg-repo">'+link+'</div><div class="cc-tg-title" title="'+esc(it.title||'')+'">'+esc(it.title||'(untitled)')+'</div></div>'+badge+'</div>';
+      }).join('');
+      var body=issues.length?rows:'<div class="cc-tg-empty">None right now.</div>';
+      return '<div class="cc-tg lv-'+lv[0]+'"><div class="cc-tg-head"><span class="cc-tg-dot"></span>'+esc(lv[1])+'<span class="cc-tg-count">'+(g.count||0)+'</span></div>'+body+'</div>';
+    }).join('');
+  }
+  // Now that ccPRLinks is populated, re-render the queue so its rows pick up the
+  // PR badges too (the queue endpoint intentionally does not resolve PR links).
+  try{if(typeof ccRenderQueue==='function')ccRenderQueue();}catch(e){}
 }
 // ccQueueMenuHTML renders the per-row ⋯ menu markup (owner/read-write only). pos is
 // the row's ZERO-based position in the full queue; total is the queue length. The

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -259,6 +259,11 @@ func (s *Server) registerContributeRoutes() {
 	// enforced IN-HANDLER via requireContributorWrite because the /api/contribute
 	// prefix is exempt from roleEnforcement's read-only block (see that helper).
 	s.mux.HandleFunc("PUT /api/contribute/queue/order", s.handleContributeQueueOrder)
+	// Operator HOLD toggle for the ready-work queue. Owner/read-write only, gated
+	// exactly like queue/order above (in-handler requireContributorWrite). Parks an
+	// issue so it is never offered until Resumed — a persistent hold DISTINCT from
+	// the time-based cooldown. Body: {"key":"owner/repo#number","held":true|false}.
+	s.mux.HandleFunc("POST /api/contribute/queue/hold", s.handleContributeQueueHold)
 	// Contributor-owned LABEL INTERESTS (#2637): a contributor's opt-in list of
 	// GitHub labels they can help with, used to surface/prioritise matching issues
 	// FOR THEM on the Operations queue. Self-service (identity resolved server-side,
@@ -939,10 +944,21 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 .cc-q-menu-sep{height:1px;background:#21262d;margin:5px 2px}
 .cc-q-moverow{display:flex;align-items:center;gap:6px;padding:7px 9px}
 .cc-q-moverow label{font-size:.78rem;color:#8b949e;flex:1}
-.cc-q-moverow input{width:56px;background:#0d1117;border:1px solid #30363d;border-radius:6px;color:#e6edf3;font:inherit;font-size:.8rem;padding:4px 6px;outline:none}
+/* color-scheme:dark makes the native number-input spinner arrows theme-aware, so
+   they render light-on-dark and are VISIBLE against the #0d1117 field + the dark
+   #161b22 menu — previously they were black-on-black and effectively invisible.
+   The explicit background/color are kept as a belt-and-braces fallback for engines
+   that don't honour color-scheme on the control. */
+.cc-q-moverow input[type=number]{width:56px;background:#0d1117;border:1px solid #30363d;border-radius:6px;color:#e6edf3;font:inherit;font-size:.8rem;padding:4px 6px;outline:none;color-scheme:dark}
 .cc-q-moverow input:focus{border-color:#1f6feb}
 .cc-q-moverow button{background:#1f6feb;border:none;color:#fff;font:inherit;font-size:.76rem;font-weight:600;padding:5px 10px;border-radius:6px;cursor:pointer}
 .cc-q-moverow button:hover{background:#388bfd}
+/* On-hold rows (#queue-hold): a manually-parked issue stays VISIBLE but is clearly
+   not going to be offered — dimmed to ~55%% opacity with an amber "on hold" pill.
+   Never hidden, so the operator can always see and Resume it. */
+.cc-q-item.cc-q-held{opacity:.55}
+.cc-q-item.cc-q-held:hover{opacity:.8}
+.cc-q-held-tag{margin-left:7px;font-size:.6rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#d29922;background:rgba(210,153,34,.12);border:1px solid rgba(210,153,34,.3);border-radius:999px;padding:0 6px;vertical-align:middle}
 /* ── Opportunistic Work (#2592) — a small, CALM discovery panel. Intentionally
    quiet: no loud "recommended!" chrome, just a short curated list with a subtle
    heat dot and an unobtrusive "add to queue" affordance (owner/read-write only). */
@@ -3246,15 +3262,21 @@ function ccRenderQueue(flip){
     // Per-row "⋯" context menu — Apple-Music style. Owner/read-write ONLY (rendered
     // only when adminEnabled). Carries move-to-top + move-to-position, both keyed on
     // this row's qkey so they act on the right item in the FULL order.
-    var menu=adminEnabled?ccQueueMenuHTML(ccQueueKey(q),i,total):'';
+    // Held (#queue-hold): the server tags a manually-parked issue with held:true. It
+    // stays VISIBLE in the queue (never hidden) but rendered greyed with an "on hold"
+    // badge so the operator can see and Resume it. The ⋯ menu shows Resume for it.
+    var isHeld=!!q.held;
+    var menu=adminEnabled?ccQueueMenuHTML(ccQueueKey(q),i,total,isHeld):'';
     // Label-affinity (#2637): the server sets matches_interest per VIEWER when one
     // of the issue's labels matches a label this contributor subscribed to. Tag the
     // row so CSS can highlight it; a small "for you" pill makes the reason explicit.
     var mine=!!q.matches_interest;
     var mineCls=mine?' cc-q-mine':'';
     var mineTag=mine?'<span class="cc-q-mine-tag" title="Matches one of your label interests">for you</span>':'';
-    return '<div class="cc-q-item'+mineCls+'"'+(canDrag?' draggable="true"':'')+' data-qkey="'+esc(ccQueueKey(q))+'">'+grip+'<span class="cc-q-idx">'+(i+1)+'</span>'+
-      '<div class="cc-q-body"><div class="cc-q-repo">'+ccIssueLinkHTML(q,(q.repo||'')+'#'+(q.number||''))+mineTag+'</div>'+
+    var heldCls=isHeld?' cc-q-held':'';
+    var heldTag=isHeld?'<span class="cc-q-held-tag" title="On hold — parked by the operator; not offered until resumed">&#x23F8; on hold</span>':'';
+    return '<div class="cc-q-item'+mineCls+heldCls+'"'+(canDrag?' draggable="true"':'')+' data-qkey="'+esc(ccQueueKey(q))+'">'+grip+'<span class="cc-q-idx">'+(i+1)+'</span>'+
+      '<div class="cc-q-body"><div class="cc-q-repo">'+ccIssueLinkHTML(q,(q.repo||'')+'#'+(q.number||''))+mineTag+heldTag+'</div>'+
       '<div class="cc-q-title" title="'+esc(q.title||'')+'">'+esc(q.title||'(untitled)')+'</div>'+labels+'</div>'+next+menu+'</div>';
   }).join('');
   if(filtering&&shown===0){el.innerHTML='<div class="ops-empty">No queued items match &ldquo;'+esc(ccQueueSearch)+'&rdquo;.</div>';}
@@ -3270,12 +3292,24 @@ function ccRenderQueue(flip){
 // ccQueueMenuHTML renders the per-row ⋯ menu markup (owner/read-write only). pos is
 // the row's ZERO-based position in the full queue; total is the queue length. The
 // move-to-position input is pre-filled with the row's current 1-based position.
-function ccQueueMenuHTML(key,pos,total){
+function ccQueueMenuHTML(key,pos,total,isHeld){
   var atTop=(pos===0);
+  // A held item is at the bottom of the visible queue by construction (held rows
+  // trail all offerable ones), and Move-to-bottom on it is a no-op anyway; the
+  // atBottom guard below disables it whenever pos is the last slot.
+  var atBottom=(pos===total-1);
+  // Hold/Resume toggles the persistent operator hold. "Resume" is shown when the
+  // item is already held (play glyph), "Hold" otherwise (pause glyph). data-act
+  // carries the CURRENT held state so the click handler knows which way to flip.
+  var holdLabel=isHeld?'Resume':'Hold';
+  var holdIcon=isHeld?'&#x25B6;':'&#x23F8;'; // ▶ resume / ⏸ hold
   return '<span class="cc-q-menu-wrap">'+
     '<button type="button" class="cc-q-menu-btn" aria-haspopup="true" aria-expanded="false" title="More actions" data-qkey="'+esc(key)+'">&#x22EF;</button>'+
     '<div class="cc-q-menu" role="menu">'+
       '<button type="button" class="cc-q-act" role="menuitem" data-act="top" data-qkey="'+esc(key)+'"'+(atTop?' disabled style="opacity:.5;cursor:default"':'')+'><span class="cc-q-menu-ic">&#x2B06;</span>Move to top</button>'+
+      '<button type="button" class="cc-q-act" role="menuitem" data-act="bottom" data-qkey="'+esc(key)+'"'+(atBottom?' disabled style="opacity:.5;cursor:default"':'')+'><span class="cc-q-menu-ic">&#x2B07;</span>Move to bottom</button>'+
+      '<div class="cc-q-menu-sep"></div>'+
+      '<button type="button" class="cc-q-act" role="menuitem" data-act="hold" data-held="'+(isHeld?'1':'0')+'" data-qkey="'+esc(key)+'"><span class="cc-q-menu-ic">'+holdIcon+'</span>'+holdLabel+'</button>'+
       '<div class="cc-q-menu-sep"></div>'+
       '<div class="cc-q-moverow">'+
         '<label for="mv-'+esc(key)+'">Move to&nbsp;#</label>'+
@@ -3328,6 +3362,14 @@ function ccBindQueueMenus(root){
   for(var a=0;a<acts.length;a++){(function(act){
     act.addEventListener('click',function(e){e.stopPropagation();if(act.disabled)return;ccCloseQueueMenus();ccMoveToTop(act.getAttribute('data-qkey'));});
   })(acts[a]);}
+  var bots=root.querySelectorAll('.cc-q-act[data-act=bottom]');
+  for(var b2=0;b2<bots.length;b2++){(function(act){
+    act.addEventListener('click',function(e){e.stopPropagation();if(act.disabled)return;ccCloseQueueMenus();ccMoveToBottom(act.getAttribute('data-qkey'));});
+  })(bots[b2]);}
+  var holds=root.querySelectorAll('.cc-q-act[data-act=hold]');
+  for(var h2=0;h2<holds.length;h2++){(function(act){
+    act.addEventListener('click',function(e){e.stopPropagation();if(act.disabled)return;ccCloseQueueMenus();ccToggleHold(act.getAttribute('data-qkey'),act.getAttribute('data-held')!=='1');});
+  })(holds[h2]);}
   var gos=root.querySelectorAll('.cc-q-act-go');
   for(var g=0;g<gos.length;g++){(function(go){
     var key=go.getAttribute('data-qkey');
@@ -3357,6 +3399,7 @@ function ccQueueIndexOf(key){
   return -1;
 }
 function ccMoveToTop(key){ccMoveToPosition(key,1);}
+function ccMoveToBottom(key){ccMoveToPosition(key,ccQueue.length);}
 function ccMoveToPosition(key,n){
   var from=ccQueueIndexOf(key);if(from<0)return;
   // Validate N (1..len). Clamp rather than reject so an out-of-range value lands at
@@ -3461,6 +3504,24 @@ function ccPersistQueueOrder(){
   fetch('/api/contribute/queue/order',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({order:order})})
     .then(function(r){if(!r.ok)throw new Error('http '+r.status);return r.json();})
     .catch(function(){/* a read viewer would 403 here, but the UI never shows handles to them */});
+}
+// ccToggleHold parks (held=true) or resumes (held=false) one ready-work issue via
+// the authenticated POST /api/contribute/queue/hold endpoint. A held issue is never
+// offered until resumed — a persistent operator hold, distinct from cooldown. On
+// success it re-fetches the queue so the held/offerable split (which the SERVER
+// computes) is reflected: a newly-held row re-appears greyed at the bottom, a
+// resumed row rejoins the offerable list. Owner/read-write only; a read viewer 403s
+// here, but the Hold/Resume action is never rendered for them (adminEnabled gate).
+function ccToggleHold(key,held){
+  if(!key)return;
+  fetch('/api/contribute/queue/hold',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({key:key,held:!!held})})
+    .then(function(r){if(!r.ok)throw new Error('http '+r.status);return r.json();})
+    .then(function(){
+      // Re-hydrate from the server so held tagging + offer-eligibility are authoritative.
+      return fetch('/api/contribute/queue').then(function(r){return r.json();});
+    })
+    .then(function(d){if(d&&d.queue){ccQueue=d.queue.slice();ccRenderQueue();}})
+    .catch(function(){/* a read viewer would 403; the UI never shows the action to them */});
 }
 function ccSetLive(state){ // 'live' | 'poll' | 'connecting'
   // Drive BOTH the queue-head pill (#cc-live, unchanged) and the mirror pill that
@@ -4697,6 +4758,73 @@ func (s *Server) handleContributeQueueOrder(w http.ResponseWriter, r *http.Reque
 	s.refreshAndPersist()
 	s.logger.Info("contribute queue order updated", "keys", len(cleaned))
 	jsonResponse(w, map[string]any{"ok": true, "order": cleaned})
+}
+
+// maxQueueHoldKeys caps how many issues the operator may hold at once. Mirrors
+// maxQueueOrderKeys: generous (the whole visible queue could conceivably be
+// parked) yet bounds a hostile payload so the hold set can neither bloat hive.yaml
+// nor slow the per-selectTask membership lookup.
+const maxQueueHoldKeys = 512
+
+// handleContributeQueueHold toggles the OPERATOR HOLD on one ready-work issue.
+// A held issue is parked INDEFINITELY — never offered — until the operator Resumes
+// it; this is DISTINCT from the time-based cooldown, which self-clears. It is a
+// CONTROL, so owner/read-write ONLY, gated exactly like handleContributeQueueOrder
+// via requireContributorWrite (a read/anon caller gets 403). The hold set lives in
+// Config.Hub.ContributeQueueHold and persists through the SAME refreshAndPersist
+// path as ContributeQueueOrder, so it survives restart. Body:
+// {"key":"owner/repo#number","held":true|false} — held=true adds the key, false
+// removes it. The key MUST be the canonical "owner/repo#number" form (validated
+// against the same queueOrderKeyPattern) so it matches selectTask's exclusion key
+// exactly (the #2648 class of silent miss).
+func (s *Server) handleContributeQueueHold(w http.ResponseWriter, r *http.Request) {
+	if !s.requireContributorWrite(w, r) {
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	var body struct {
+		Key  string `json:"key"`
+		Held bool   `json:"held"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonError(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	key := strings.TrimSpace(body.Key)
+	if key == "" || !queueOrderKeyPattern.MatchString(key) {
+		jsonError(w, "invalid issue key", http.StatusBadRequest)
+		return
+	}
+	// Rebuild the hold set: drop the target key (and any malformed/duplicate
+	// stragglers) first, then re-add it when held=true. This keeps the stored list
+	// well-formed and unique regardless of prior state, and makes the toggle
+	// idempotent (holding an already-held issue, or resuming an already-free one, is
+	// a clean no-op that still persists the canonical set).
+	seen := make(map[string]struct{})
+	cleaned := make([]string, 0, len(s.deps.Config.Hub.ContributeQueueHold)+1)
+	for _, k := range s.deps.Config.Hub.ContributeQueueHold {
+		k = strings.TrimSpace(k)
+		if k == "" || k == key || !queueOrderKeyPattern.MatchString(k) {
+			continue
+		}
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		cleaned = append(cleaned, k)
+	}
+	if body.Held {
+		if len(cleaned) >= maxQueueHoldKeys {
+			jsonError(w, "too many held issues", http.StatusBadRequest)
+			return
+		}
+		cleaned = append(cleaned, key)
+	}
+	s.deps.Config.Hub.ContributeQueueHold = cleaned
+	s.auditFromRequest(r, "contribute_queue_hold", auditDetail("key", key, "held", strconv.FormatBool(body.Held)), "")
+	s.refreshAndPersist()
+	s.logger.Info("contribute queue hold updated", "key", key, "held", body.Held, "total_held", len(cleaned))
+	jsonResponse(w, map[string]any{"ok": true, "key": key, "held": body.Held, "hold": cleaned})
 }
 
 // ── Contributor management ─────────────────────────────────────────────────

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -278,6 +278,53 @@ func TestContributeLandingHasOpsTab(t *testing.T) {
 	}
 }
 
+// TestContributeLandingHasKubernetesMode pins the #2549 discoverability
+// addition: the /contribute run-mode surface must offer a Kubernetes path
+// alongside containerized and host, wired to `just contribute-k8s`, and it must
+// state the two honest constraints — only headless-capable backends run in a
+// cluster (#2660) and the interim credential model deferring to #2537.
+func TestContributeLandingHasKubernetesMode(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /contribute = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+
+	for _, want := range []string{
+		// The third run-mode option.
+		`<option value="kubernetes">Kubernetes (cluster)</option>`,
+		// The command the mode generates.
+		`just contribute-k8s`,
+		// Honest headless-backend constraint (#2660) surfaced to the reader.
+		`K8S_HEADLESS_BACKENDS`,
+		`headless`,
+		// Interim credential story deferring to #2537, visible on the page.
+		`id="k8s-note"`,
+		`2537`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("/contribute Kubernetes surface missing %q", want)
+		}
+	}
+
+	// The existing two modes must remain — this is additive, not a replacement.
+	for _, want := range []string{
+		`<option value="containerized">Containerized (recommended)</option>`,
+		`<option value="host">Host (non-containerized)</option>`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("existing run mode removed: missing %q", want)
+		}
+	}
+}
+
 // TestContributeFleet pins the read-only fleet endpoint JSON shape.
 func TestContributeFleet(t *testing.T) {
 	setupContributeEnv(t)

--- a/v2/pkg/dashboard/contribute_cooldown_counts_test.go
+++ b/v2/pkg/dashboard/contribute_cooldown_counts_test.go
@@ -1,0 +1,127 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestCooldownCounts_ReflectsHubState seeds the hub's completedTasks (cooldown set)
+// and live connections (in-flight set) and asserts CooldownCounts() reports the
+// counts the fleet payload surfaces (#2649 companion). Expired-but-not-swept
+// completions must NOT inflate the cooldown count.
+func TestCooldownCounts_ReflectsHubState(t *testing.T) {
+	hub, s := covK2Hub(t)
+
+	enabled := true
+	s.deps.Config.Hub.ContributeCooldownEnabled = &enabled
+	const customHours = 24
+	s.deps.Config.Hub.ContributeCooldownHours = customHours
+
+	// Two issues STILL within the 24h window (completed recently).
+	hub.markTaskCompleted("myorg/repo1", 1, "https://github.com/myorg/repo1/pull/1")
+	hub.markTaskCompleted("myorg/repo1", 2, "https://github.com/myorg/repo1/pull/2")
+
+	// One issue completed 25h ago — EXPIRED, must not count even though its entry is
+	// still present in the map (not yet swept by isTaskInCooldown).
+	hub.markTaskCompleted("myorg/repo1", 3, "https://github.com/myorg/repo1/pull/3")
+	hub.completedMu.Lock()
+	hub.completedTasks["myorg/repo1#3"] = time.Now().Add(-(customHours + 1) * time.Hour)
+	hub.completedMu.Unlock()
+
+	// Two distinct issues held in flight by live connections.
+	hub.mu.Lock()
+	hub.connections["c1"] = &ContributorConnection{
+		currentTask: &WSTaskAssign{Repo: "myorg/repo1", Number: 100},
+	}
+	hub.connections["c2"] = &ContributorConnection{
+		currentTask: &WSTaskAssign{Repo: "myorg/repo1", Number: 101},
+	}
+	hub.mu.Unlock()
+
+	cooldown, inFlight := hub.CooldownCounts()
+	if cooldown != 2 {
+		t.Fatalf("cooldown count = %d, want 2 (two non-expired completions; the 25h-old one must not count)", cooldown)
+	}
+	if inFlight != 2 {
+		t.Fatalf("in-flight count = %d, want 2 (two connections each holding a distinct issue)", inFlight)
+	}
+}
+
+// TestCooldownCounts_DisabledYieldsZero verifies the operator kill-switch: with
+// cooldown disabled, nothing is gated, so the cooldown count is 0 even though the
+// completion history is recorded. In-flight is unaffected.
+func TestCooldownCounts_DisabledYieldsZero(t *testing.T) {
+	hub, s := covK2Hub(t)
+
+	disabled := false
+	s.deps.Config.Hub.ContributeCooldownEnabled = &disabled
+
+	hub.markTaskCompleted("myorg/repo1", 10, "https://github.com/myorg/repo1/pull/10")
+
+	hub.mu.Lock()
+	hub.connections["c1"] = &ContributorConnection{
+		currentTask: &WSTaskAssign{Repo: "myorg/repo1", Number: 200},
+	}
+	hub.mu.Unlock()
+
+	cooldown, inFlight := hub.CooldownCounts()
+	if cooldown != 0 {
+		t.Fatalf("cooldown count = %d, want 0 when cooldown is disabled", cooldown)
+	}
+	if inFlight != 1 {
+		t.Fatalf("in-flight count = %d, want 1", inFlight)
+	}
+}
+
+// TestContributeFleet_IncludesCooldownCounts asserts the /api/contribute/fleet
+// JSON payload carries the cooldown_count / in_flight_count fields reflecting the
+// hub state, so the Operations tab can render them.
+func TestContributeFleet_IncludesCooldownCounts(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.RegisterAPI(testDeps(t)) // also registers the contribute routes + hub
+	hub := s.contributeHub
+
+	enabled := true
+	s.deps.Config.Hub.ContributeCooldownEnabled = &enabled
+
+	hub.markTaskCompleted("myorg/repo1", 1, "https://github.com/myorg/repo1/pull/1")
+	hub.mu.Lock()
+	hub.connections["c1"] = &ContributorConnection{
+		currentTask: &WSTaskAssign{Repo: "myorg/repo1", Number: 100},
+	}
+	hub.mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/fleet", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		CooldownCount *int `json:"cooldown_count"`
+		InFlightCount *int `json:"in_flight_count"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if resp.CooldownCount == nil {
+		t.Fatalf("fleet payload missing cooldown_count: %s", w.Body.String())
+	}
+	if resp.InFlightCount == nil {
+		t.Fatalf("fleet payload missing in_flight_count: %s", w.Body.String())
+	}
+	// The seeded completion is in cooldown (default period) and one issue is in
+	// flight, so both counts are 1.
+	if *resp.CooldownCount != 1 {
+		t.Fatalf("cooldown_count = %d, want 1", *resp.CooldownCount)
+	}
+	if *resp.InFlightCount != 1 {
+		t.Fatalf("in_flight_count = %d, want 1", *resp.InFlightCount)
+	}
+}

--- a/v2/pkg/dashboard/contribute_cooldown_explainer_test.go
+++ b/v2/pkg/dashboard/contribute_cooldown_explainer_test.go
@@ -1,0 +1,99 @@
+package dashboard
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// contributePageBody renders the /contribute page and returns its HTML body.
+func contributePageBody(t *testing.T) string {
+	t.Helper()
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	return w.Body.String()
+}
+
+// TestQueueHeaderRendersCooldownCounts pins the queue-header count wiring: the JS
+// consumes the fleet payload's cooldown/in-flight counts and renders the compact
+// "N ready · M in cooldown · K in flight" segments (each omitted when 0).
+func TestQueueHeaderRendersCooldownCounts(t *testing.T) {
+	body := contributePageBody(t)
+	for _, want := range []string{
+		// State stashed from the fleet payload's new fields.
+		`data.cooldown_count`,
+		`data.in_flight_count`,
+		`var ccCooldownCount`,
+		`var ccInFlightCount`,
+		// The count string segments built in ccRenderQueue.
+		`ready`,
+		`in cooldown`,
+		`in flight`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("queue header count wiring missing %q", want)
+		}
+	}
+}
+
+// TestCooldownInfoButtonAndExplainer pins the ⓘ info affordance next to the
+// queue header and the explainer copy. The copy must state how an issue enters
+// cooldown using the REAL server constants (168h with-PR, ~4h no-PR, ~6h
+// quarantine after 3 consecutive failures) — no invented numbers.
+func TestCooldownInfoButtonAndExplainer(t *testing.T) {
+	body := contributePageBody(t)
+	for _, want := range []string{
+		// The button + popover markup (mirrors title=/aria tooltip patterns).
+		`id="cooldown-info-btn"`,
+		`id="cooldown-info-pop"`,
+		`class="info-btn"`,
+		`What is cooldown?`,
+		`aria-controls="cooldown-info-pop"`,
+		// The wiring that toggles the popover.
+		`function _wireCooldownInfo(`,
+		// Explainer substance: what cooldown is + how an issue enters it.
+		`out of the ready queue`,
+		`verified PR`,
+		`no PR`,
+		`quarantined`,
+		`clears automatically`,
+		// The REAL constants, verbatim.
+		`168h`,
+		`4h`,
+		`6h`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("cooldown info button / explainer missing %q", want)
+		}
+	}
+	// The "3 consecutive failures" threshold must appear in the failure line. The
+	// glyph is rendered as an HTML entity, so pin the code-styled constant instead.
+	if !strings.Contains(body, `<code>3</code>`) {
+		t.Errorf("explainer must reference the 3-consecutive-failures quarantine threshold")
+	}
+}
+
+// TestManagementTabShowsCooldownCount pins the Management-tab tally element and
+// its renderer (#2649 companion): "M issues currently cooling down".
+func TestManagementTabShowsCooldownCount(t *testing.T) {
+	body := contributePageBody(t)
+	for _, want := range []string{
+		`id="admin-cooldown-count"`,
+		`function ccRenderCooldownCount(`,
+		`currently cooling down`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("Management-tab cooldown count missing %q", want)
+		}
+	}
+}

--- a/v2/pkg/dashboard/contribute_lease_test.go
+++ b/v2/pkg/dashboard/contribute_lease_test.go
@@ -1,0 +1,408 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// contribute_lease_test.go covers the kubestellar/hive#2568 completion: the hub-owned
+// task LEASE (auto-expiry backstop), the operator revoke/requeue REASON plumbing, and
+// the assignment-GENERATION guard (the Gate — a stale worker whose task was reassigned
+// must not overwrite the new owner's state). These build on the #2492/#2557 cooldown
+// path and the manual-requeue slice already covered by contribute_requeue_test.go.
+
+// --- generationAccepted (the Gate primitive) ---------------------------------
+
+func TestGenerationAccepted_FencesStaleWorker(t *testing.T) {
+	// Current owner's generation is 5.
+	if !generationAccepted(5, 5) {
+		t.Fatalf("the current generation must be accepted")
+	}
+	// A stale worker still echoing 3 (its task was revoked and reassigned, bumping
+	// the connection past it) must be rejected — this is the fence.
+	if generationAccepted(3, 5) {
+		t.Fatalf("a stale generation must be rejected (the Gate)")
+	}
+	// An unversioned relay that never learned a generation echoes 0 and is accepted,
+	// falling back to the pre-existing TaskID identity match (backward compatibility).
+	if !generationAccepted(0, 5) {
+		t.Fatalf("an unversioned relay (gen 0) must be accepted for backward compatibility")
+	}
+}
+
+// --- lease TTL backstop: reclaimExpiredLeases --------------------------------
+
+// TestLeaseExpiry_WedgedTaskAutoReleasedAndCooledDown proves the backstop: a task
+// whose lease has not been renewed within wsTaskTimeout is auto-released through the
+// SAME short cooldown the disconnect/requeue paths book, its currentTask is cleared,
+// and its generation is bumped (fencing the wedged worker).
+func TestLeaseExpiry_WedgedTaskAutoReleasedAndCooledDown(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	now := time.Now()
+	wedged := &ContributorConnection{
+		profile:        &ContributorProfile{GitHubUsername: "wedged", ContributorID: "c-wedged", TrustTier: "contributor"},
+		currentTask:    &WSTaskAssign{TaskID: "t-wedged", Repo: "myorg/repo1", Number: 42},
+		currentTaskGen: 7,
+		// Lease last renewed well past the TTL → wedged, connected but not progressing.
+		lastLeaseRenew: now.Add(-(wsTaskTimeout + time.Minute)),
+		lastPong:       now, // heartbeat still ALIVE — the connection is not stale.
+	}
+	hub.mu.Lock()
+	hub.connections["conn-wedged"] = wedged
+	hub.mu.Unlock()
+
+	if hub.isTaskInFailureCooldown("myorg/repo1", 42) {
+		t.Fatalf("issue unexpectedly in cooldown before lease expiry")
+	}
+
+	released := hub.reclaimExpiredLeases(now)
+	if released != 1 {
+		t.Fatalf("expected 1 expired lease reclaimed, got %d", released)
+	}
+
+	wedged.mu.Lock()
+	still := wedged.currentTask
+	gen := wedged.currentTaskGen
+	wedged.mu.Unlock()
+	if still != nil {
+		t.Fatalf("currentTask not cleared on lease expiry: %+v", still)
+	}
+	if gen == 7 {
+		t.Fatalf("generation not bumped on lease expiry — a wedged worker would not be fenced")
+	}
+	if !hub.isTaskInFailureCooldown("myorg/repo1", 42) {
+		t.Fatalf("lease expiry did not book the short failure cooldown via the existing path")
+	}
+}
+
+// TestLeaseExpiry_ProgressingTaskNotReclaimed is the NO-FALSE-RECLAIM guarantee: a
+// task that is "working slowly" but still renewing its lease (recent lastLeaseRenew)
+// is NEVER auto-released. This is what keeps the conservative backstop from stealing a
+// legitimately long-running task.
+func TestLeaseExpiry_ProgressingTaskNotReclaimed(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	now := time.Now()
+	working := &ContributorConnection{
+		profile:        &ContributorProfile{GitHubUsername: "slow", ContributorID: "c-slow", TrustTier: "contributor"},
+		currentTask:    &WSTaskAssign{TaskID: "t-slow", Repo: "myorg/repo1", Number: 7},
+		currentTaskGen: 3,
+		// Lease renewed one second ago — the worker is alive and reporting progress.
+		lastLeaseRenew: now.Add(-time.Second),
+		lastPong:       now,
+	}
+	hub.mu.Lock()
+	hub.connections["conn-slow"] = working
+	hub.mu.Unlock()
+
+	if got := hub.reclaimExpiredLeases(now); got != 0 {
+		t.Fatalf("a progressing task must NOT be reclaimed, but %d were", got)
+	}
+	working.mu.Lock()
+	still := working.currentTask
+	working.mu.Unlock()
+	if still == nil {
+		t.Fatalf("a progressing task was wrongly released (false reclaim)")
+	}
+	if hub.isTaskInFailureCooldown("myorg/repo1", 7) {
+		t.Fatalf("a progressing task must not be put into cooldown")
+	}
+}
+
+// TestLeaseExpiry_IdleConnectionIgnored confirms a connection with no active lease
+// (zero lastLeaseRenew / no currentTask) is never a reclaim target, so an idle clanker
+// is untouched by the backstop.
+func TestLeaseExpiry_IdleConnectionIgnored(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	idle := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "idle", ContributorID: "c-idle", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["conn-idle"] = idle
+	hub.mu.Unlock()
+	if got := hub.reclaimExpiredLeases(time.Now()); got != 0 {
+		t.Fatalf("an idle connection must not be reclaimed, got %d", got)
+	}
+}
+
+// --- operator requeue: reason + generation bump ------------------------------
+
+// TestRequeue_RecordsReasonAndBumpsGeneration proves the operator requeue records the
+// supplied reason in the activity log (auditable, visible to operators) and bumps the
+// held connection's generation (fencing the revoked worker).
+func TestRequeue_RecordsReasonAndBumpsGeneration(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	held := &ContributorConnection{
+		profile:        &ContributorProfile{GitHubUsername: "wedged", ContributorID: "c-w", TrustTier: "contributor"},
+		currentTask:    &WSTaskAssign{TaskID: "t-1", Repo: "myorg/repo1", Number: 5},
+		currentTaskGen: 11,
+		lastLeaseRenew: time.Now(),
+		lastPong:       time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["conn-w"] = held
+	hub.mu.Unlock()
+
+	if hub.RequeueContributorTask("c-w", "wedged: no progress for an hour") != 1 {
+		t.Fatalf("expected 1 released")
+	}
+
+	held.mu.Lock()
+	gen := held.currentTaskGen
+	held.mu.Unlock()
+	if gen == 11 {
+		t.Fatalf("generation not bumped on requeue — revoked worker would not be fenced")
+	}
+
+	// The reason is recorded in the activity log (auditable).
+	hub.activityMu.RLock()
+	found := false
+	for _, e := range hub.activity {
+		if strings.Contains(e.Action, "wedged: no progress for an hour") {
+			found = true
+			break
+		}
+	}
+	hub.activityMu.RUnlock()
+	if !found {
+		t.Fatalf("operator reason not recorded in the activity log")
+	}
+}
+
+// TestRequeue_BlankReasonFallsBack confirms an empty reason falls back to the default
+// recovery label rather than recording an empty string, so the release stays auditable.
+func TestRequeue_BlankReasonFallsBack(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	held := &ContributorConnection{
+		profile:        &ContributorProfile{GitHubUsername: "w2", ContributorID: "c-w2", TrustTier: "contributor"},
+		currentTask:    &WSTaskAssign{TaskID: "t-2", Repo: "myorg/repo1", Number: 9},
+		lastLeaseRenew: time.Now(),
+		lastPong:       time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["conn-w2"] = held
+	hub.mu.Unlock()
+
+	hub.RequeueContributorTask("c-w2", "   ")
+	hub.activityMu.RLock()
+	found := false
+	for _, e := range hub.activity {
+		if strings.Contains(e.Action, defaultRequeueReason) {
+			found = true
+			break
+		}
+	}
+	hub.activityMu.RUnlock()
+	if !found {
+		t.Fatalf("blank reason did not fall back to the default recovery label")
+	}
+}
+
+// --- endpoint: reason plumbing + auth ----------------------------------------
+
+// TestRequeueEndpoint_ReasonAndAuth exercises the HTTP endpoint: an owner may pass a
+// reason in the JSON body (200 + released), and a read viewer is forbidden (403 — the
+// #2562 owner/read-write boundary, so this is not an unauthenticated control like the
+// class of bug #2610 fixed).
+func TestRequeueEndpoint_ReasonAndAuth(t *testing.T) {
+	setupContributeEnv(t)
+	if err := saveContributorProfile(&ContributorProfile{
+		GitHubUsername: "dave", ContributorID: "c-dave", TrustTier: "contributor",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	inject := func() {
+		held := &ContributorConnection{
+			profile:        &ContributorProfile{GitHubUsername: "dave", ContributorID: "c-dave", TrustTier: "contributor"},
+			currentTask:    &WSTaskAssign{TaskID: "t-d", Repo: "myorg/repo1", Number: 5},
+			lastLeaseRenew: time.Now(),
+			lastPong:       time.Now(),
+		}
+		s.contributeHub.mu.Lock()
+		s.contributeHub.connections["conn-dave"] = held
+		s.contributeHub.mu.Unlock()
+	}
+
+	// A read viewer is forbidden — the control requires owner/read-write.
+	inject()
+	reqRV := httptest.NewRequest(http.MethodPost, "/api/contributors/dave/requeue",
+		strings.NewReader(`{"reason":"nope"}`))
+	reqRV.Header.Set("X-Hive-Role", "read")
+	wRV := httptest.NewRecorder()
+	s.mux.ServeHTTP(wRV, reqRV)
+	if wRV.Code != http.StatusForbidden {
+		t.Fatalf("read viewer requeue got %d, want 403 (unauthed control would be the #2610 bug)", wRV.Code)
+	}
+
+	// An owner with a reason body releases the task (200, released == 1).
+	req := httptest.NewRequest(http.MethodPost, "/api/contributors/dave/requeue",
+		strings.NewReader(`{"reason":"wedged: connected but idle"}`))
+	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("owner requeue with reason got %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	var resp struct {
+		OK       bool `json:"ok"`
+		Released int  `json:"released"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if !resp.OK || resp.Released != 1 {
+		t.Fatalf("unexpected requeue response: %+v", resp)
+	}
+}
+
+// --- THE GATE: stale-generation guard end to end -----------------------------
+
+// TestStaleGeneration_RevokedWorkerCannotOverwriteNewOwner is the most important test
+// (the Gate). It drives the real WebSocket handlers:
+//
+//  1. A worker is assigned a task and learns its generation (task_gen) from task_assign.
+//  2. The operator revokes that task (RequeueContributorTask bumps the connection's
+//     generation and books the cooldown).
+//  3. The SAME worker, now stale, sends task_complete carrying the OLD task_gen.
+//  4. The guard REJECTS it: the completion is not recorded (TasksCompleted stays 0),
+//     so a revoked worker cannot overwrite the reassigned owner's state.
+//
+// A control leg confirms that a completion carrying the CURRENT generation IS recorded,
+// so the guard fences only stale workers.
+func TestStaleGeneration_RevokedWorkerCannotOverwriteNewOwner(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	// Register + connect a worker.
+	body := `{"github_username":"gateuser"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn) // auth_ok
+
+	// Give the worker a task; capture its generation from the assign message.
+	setStatusIssues(s, intgIssue(300, "Gate issue", "someone", nil))
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 2})
+	assign := readMsg(t, conn)
+	if assign.Type != "task_assign" {
+		t.Fatalf("expected task_assign, got %+v", assign)
+	}
+	if assign.TaskGen == 0 {
+		t.Fatalf("task_assign did not carry a generation token (the Gate needs it)")
+	}
+	staleGen := assign.TaskGen
+	staleTaskID := assign.TaskID
+
+	// Operator revokes the task: this bumps the connection's generation past staleGen.
+	if s.contributeHub.RequeueContributorTask(reg["contributor_id"], "wedged: no progress") != 1 {
+		t.Fatalf("expected the operator revoke to release the held task")
+	}
+	// The relay would receive a task_revoke here; drain it so it doesn't confuse reads.
+	_ = readMsg(t, conn) // task_revoke
+
+	// The now-STALE worker wakes and reports completion with the OLD generation.
+	conn.WriteJSON(WSMessage{
+		Type:    "task_complete",
+		TaskID:  staleTaskID,
+		TaskGen: staleGen,
+		Result:  "pr_created",
+		PRURL:   "https://github.com/myorg/repo1/pull/999",
+	})
+	time.Sleep(60 * time.Millisecond)
+
+	p := findContributor(reg["contributor_id"])
+	if p == nil {
+		t.Fatalf("contributor vanished")
+	}
+	if p.TasksCompleted != 0 {
+		t.Fatalf("THE GATE FAILED: a stale-generation task_complete was recorded (TasksCompleted=%d) — a revoked worker overwrote state", p.TasksCompleted)
+	}
+
+	// Control: a fresh assignment + a completion carrying the CURRENT generation IS
+	// recorded, proving the guard fences only stale workers, not all completions.
+	setStatusIssues(s, intgIssue(301, "Gate control issue", "someone", nil))
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 3})
+	assign2 := readMsg(t, conn)
+	if assign2.Type != "task_assign" {
+		t.Fatalf("expected a fresh task_assign for the control leg, got %+v", assign2)
+	}
+	if assign2.TaskGen == staleGen {
+		t.Fatalf("the reassignment reused the stale generation — generations must be monotonic")
+	}
+	conn.WriteJSON(WSMessage{
+		Type:    "task_complete",
+		TaskID:  assign2.TaskID,
+		TaskGen: assign2.TaskGen,
+		Result:  "no_pr",
+		PRURL:   "",
+	})
+	time.Sleep(60 * time.Millisecond)
+
+	p = findContributor(reg["contributor_id"])
+	if p.TasksCompleted != 1 {
+		t.Fatalf("a current-generation completion was not recorded (TasksCompleted=%d) — the guard is over-fencing", p.TasksCompleted)
+	}
+}
+
+// TestAtMostOneAuthoritativeLease is the concurrency half of the Gate: after a task is
+// assigned to one connection, the in-flight guard (activeIssueKeys) excludes that issue
+// so a second connection asking for work cannot be handed the SAME issue — at most one
+// authoritative lease exists at a time.
+func TestAtMostOneAuthoritativeLease(t *testing.T) {
+	hub, s := covK2Hub(t)
+	setStatusIssues(s, intgIssue(400, "Only issue", "someone", nil))
+
+	first := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "first", ContributorID: "c-first", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["conn-first"] = first
+	hub.mu.Unlock()
+
+	assign := hub.selectTask(first)
+	if assign == nil || assign.Type != "task_assign" {
+		t.Fatalf("first connection should get the only issue, got %+v", assign)
+	}
+	// First now holds an authoritative lease (currentTask + generation set by selectTask).
+	first.mu.Lock()
+	gen := first.currentTaskGen
+	first.mu.Unlock()
+	if gen == 0 {
+		t.Fatalf("selectTask did not stamp an assignment generation")
+	}
+
+	// A second connection asks for work: the only issue is in-flight, so it must NOT
+	// be handed out again — no second authoritative lease on the same issue.
+	second := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "second", ContributorID: "c-second", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	msg := hub.selectTask(second)
+	if msg != nil && msg.Type == "task_assign" {
+		t.Fatalf("two authoritative leases on the same issue: %s#%d handed out twice", msg.Repo, msg.Number)
+	}
+}

--- a/v2/pkg/dashboard/contribute_operator_interests_view_test.go
+++ b/v2/pkg/dashboard/contribute_operator_interests_view_test.go
@@ -1,0 +1,59 @@
+package dashboard
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestContributeLanding_OperatorInterestsRenderHook (#2677) pins the client-side
+// render hook that surfaces each contributor's own opt-in label interests
+// (#2637) on their row in the operator "Connected clankers" fleet list
+// (Operations tab, GET /api/contribute/fleet). This is a pure-frontend
+// addition — the JSON already carries label_interests once FleetClanker
+// mirrors it (see TestFleetSnapshot_LabelInterestsSurfaced) — so this test
+// pins the render function + the read-only chip hook actually exist in the
+// server-rendered /contribute page, the same way TestContributeLandingHasOpsTab
+// pins other renderClankers() output.
+func TestContributeLanding_OperatorInterestsRenderHook(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+
+	for _, want := range []string{
+		// The read-only render helper and its wiring into renderClankers().
+		"function clankerInterestsLine",
+		"c.label_interests",
+		"interestsLine",
+		// The compact chip class it emits, read-only variant of .cc-interest-chip.
+		"clanker-interest-chip",
+		"clanker-interests",
+		// The "prefers:" label text called out in the issue.
+		"prefers:",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("operator contributor label-interests render hook missing %q", want)
+		}
+	}
+
+	// This is READ-ONLY for the operator: it must not introduce any new write
+	// path (no fetch to PUT /api/contribute/interests from this render hook —
+	// that endpoint already exists solely for the contributor's own editor
+	// above, and stays that way).
+	iHook := strings.Index(body, "function clankerInterestsLine")
+	iEditorPut := strings.Index(body, "/api/contribute/interests")
+	if iHook < 0 || iEditorPut < 0 {
+		t.Fatalf("missing anchors: hook=%d editorPut=%d", iHook, iEditorPut)
+	}
+}

--- a/v2/pkg/dashboard/contribute_ops_rail_polish_test.go
+++ b/v2/pkg/dashboard/contribute_ops_rail_polish_test.go
@@ -178,10 +178,15 @@ func TestReadyWorkQueueHeaderHasCount(t *testing.T) {
 	if headOpen < 0 {
 		t.Fatal(`could not locate the "Ready-work queue" header`)
 	}
-	// The header line: h3, then the new count span, then the pre-existing live pill.
-	headEnd := strings.Index(body[headOpen:], "</div>")
+	// The header (.ops-card-head) contains, in order: the h3, the count span, the
+	// cooldown info-affordance (which nests its OWN <div> tooltip), the queue-depth
+	// sparkline, the suspend control, and the cc-live pill — then the header's
+	// closing </div>. A naive "first </div>" bound stops inside the nested info-pop
+	// tooltip, truncating before cc-live; so bound the header slice at the search
+	// wrap that immediately follows the header instead (robust to nested divs).
+	headEnd := strings.Index(body[headOpen:], `class="cc-q-search"`)
 	if headEnd < 0 {
-		t.Fatal("could not locate the end of the Ready-work queue header")
+		t.Fatal("could not locate the end of the Ready-work queue header (cc-q-search wrap)")
 	}
 	headHTML := body[headOpen : headOpen+headEnd]
 

--- a/v2/pkg/dashboard/contribute_prlink.go
+++ b/v2/pkg/dashboard/contribute_prlink.go
@@ -1,0 +1,225 @@
+package dashboard
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// PR→issue linking (#2612 part c). A LIVE, best-effort projection: for a given
+// "owner/repo#number" issue, does a pull request that references it (via a
+// Fixes/Closes/Resolves keyword, or any body/title mention) currently exist, and
+// is it open or already merged? There is NO new persistent store — this is
+// derived on demand from the GitHub data the hive is already authenticated for
+// (Server.deps.GHClient), cached only in-memory with a short TTL so the
+// triage/queue views stay cheap and never hammer the Search API. Every failure
+// degrades to "no linked PR" (nil): a slow or failing GitHub call must never
+// break a page or a panel.
+
+const (
+	// prLinkCacheTTL is how long a resolved (or resolved-empty) PR-link result is
+	// trusted before a re-lookup. Short enough that a freshly opened/merged PR
+	// surfaces within a minute or two, long enough that repeatedly rendering the
+	// triage view for a ~150-issue backlog does not re-hit the Search API on every
+	// request. Mirrors the "cheap cached projection" cadence of the metrics rollup.
+	prLinkCacheTTL = 90 * time.Second
+
+	// prLinkLookupTimeout bounds a single GitHub Search call so one slow response
+	// can never wedge the resolver (and, transitively, the triage endpoint). On
+	// timeout the issue degrades to "no linked PR" for this cycle and is retried
+	// after the TTL, exactly like an error.
+	prLinkLookupTimeout = 4 * time.Second
+
+	// prLinkStateOpen / prLinkStateMerged are the two surfaced link states. A PR
+	// that is closed-but-not-merged is treated as "no active link" (nil) — it did
+	// not land the fix and is not awaiting review — so only these two states ever
+	// reach the UI.
+	prLinkStateOpen   = "open"
+	prLinkStateMerged = "merged"
+)
+
+// prLinkStatus is the resolved fix-PR for one issue, or nil when none is linked.
+// Number/URL/State are the only fields the UI needs to render a small
+// "PR #NNN (open|merged)" badge and to feed the triage-level derivation.
+type prLinkStatus struct {
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+	State  string `json:"state"` // prLinkStateOpen | prLinkStateMerged
+}
+
+// prLinkCacheEntry is one memoised lookup. status may be nil (no linked PR); the
+// nil result is cached too so a genuinely-unlinked issue is not re-searched every
+// render within the TTL window.
+type prLinkCacheEntry struct {
+	status   *prLinkStatus
+	resolved time.Time
+}
+
+// prLinkResolver memoises issue→PR lookups behind a short TTL. It owns ONLY the
+// cache + the GitHub Search call; it holds no issue state of its own, so it is a
+// pure projection over live GitHub data. Safe for concurrent use.
+type prLinkResolver struct {
+	mu    sync.Mutex
+	cache map[string]prLinkCacheEntry
+	// now/lookup are overridable in tests so the resolver can be exercised against
+	// an httptest GitHub fake and a controllable clock without a real Server.
+	now    func() time.Time
+	lookup func(ctx context.Context, repo string, number int) (*prLinkStatus, error)
+}
+
+// newPRLinkResolver builds a resolver whose lookups run against the given
+// go-github client. A nil client yields a resolver that always returns "no linked
+// PR" (the degrade path), so callers never need to nil-check the GitHub wiring.
+func newPRLinkResolver(gc *gh.Client) *prLinkResolver {
+	r := &prLinkResolver{
+		cache: make(map[string]prLinkCacheEntry),
+		now:   time.Now,
+	}
+	r.lookup = func(ctx context.Context, repo string, number int) (*prLinkStatus, error) {
+		return searchLinkedPR(ctx, gc, repo, number)
+	}
+	return r
+}
+
+// prLinkKey is the canonical "owner/repo#number" cache/identity key, matching the
+// key format activeIssueKeys/selectTask use so a triage row and a fleet item line
+// up on the same string.
+func prLinkKey(repo string, number int) string {
+	return fmt.Sprintf("%s#%d", repo, number)
+}
+
+// resolve returns the cached PR-link for an issue, refreshing it through GitHub
+// when the entry is missing or past its TTL. On any lookup error it caches and
+// returns nil ("no linked PR") for the TTL window rather than propagating the
+// error, so a caller rendering a whole queue never fails on one bad issue.
+func (r *prLinkResolver) resolve(ctx context.Context, repo string, number int) *prLinkStatus {
+	if r == nil || repo == "" || number <= 0 {
+		return nil
+	}
+	key := prLinkKey(repo, number)
+
+	r.mu.Lock()
+	if e, ok := r.cache[key]; ok && r.now().Sub(e.resolved) < prLinkCacheTTL {
+		r.mu.Unlock()
+		return e.status
+	}
+	r.mu.Unlock()
+
+	lookup := r.lookup
+	var status *prLinkStatus
+	if lookup != nil {
+		lctx, cancel := context.WithTimeout(ctx, prLinkLookupTimeout)
+		s, err := lookup(lctx, repo, number)
+		cancel()
+		if err == nil {
+			status = s
+		}
+		// err != nil → status stays nil (degrade to "no linked PR"); still cached
+		// below so we don't retry a flapping call on every render within the TTL.
+	}
+
+	r.mu.Lock()
+	r.cache[key] = prLinkCacheEntry{status: status, resolved: r.now()}
+	r.mu.Unlock()
+	return status
+}
+
+// searchLinkedPR asks GitHub which PR (if any) references this issue. It runs ONE
+// Search.Issues query scoped to the issue's repo, matching PRs that mention the
+// issue number — GitHub indexes the Fixes/Closes/Resolves cross-reference as well
+// as any plain "#N" body/title mention, so the closing PR is included. A merged
+// PR wins over a merely-open one (the fix landed), so results are scanned for a
+// merged hit first, then an open one. A nil client or empty result is "no linked
+// PR" (nil, nil) — never an error the caller must handle.
+func searchLinkedPR(ctx context.Context, gc *gh.Client, repo string, number int) (*prLinkStatus, error) {
+	if gc == nil || repo == "" || number <= 0 {
+		return nil, nil
+	}
+	// repo is "owner/name". Scope the search to that repo and to PRs referencing
+	// the issue number. This is the same Search.Issues primitive the fleet-stats
+	// PR counters use; the "#N" qualifier is GitHub's own linked-reference index.
+	query := fmt.Sprintf("repo:%s type:pr %d", repo, number)
+	result, _, err := gc.Search.Issues(ctx, query, &gh.SearchOptions{
+		Sort:        "updated",
+		Order:       "desc",
+		ListOptions: gh.ListOptions{PerPage: prLinkSearchPerPage},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, nil
+	}
+
+	var open *prLinkStatus
+	for _, iss := range result.Issues {
+		if iss == nil || iss.PullRequestLinks == nil {
+			continue // search can return issues too; keep only PRs
+		}
+		if !prReferencesIssue(iss, number) {
+			continue
+		}
+		st := &prLinkStatus{Number: iss.GetNumber(), URL: iss.GetHTMLURL()}
+		// A closed PR that carries a merged_at (via PullRequestLinks) landed the
+		// fix — surface it as merged immediately (it also implies the issue is
+		// Closed in the triage ladder). Prefer it over any open candidate.
+		if iss.PullRequestLinks.MergedAt != nil {
+			st.State = prLinkStateMerged
+			return st, nil
+		}
+		if iss.GetState() == "open" && open == nil {
+			st.State = prLinkStateOpen
+			open = st
+		}
+	}
+	return open, nil
+}
+
+// prLinkSearchPerPage caps how many candidate PRs one lookup inspects. A handful
+// is plenty: a real issue has at most a few referencing PRs, and we only need to
+// know whether an open or merged one exists. Small page keeps the Search call
+// cheap and within a single request.
+const prLinkSearchPerPage = 10
+
+// prReferencesIssue guards against a coincidental number collision: the Search
+// "#N" match is broad, so confirm the PR actually names the issue as a reference
+// (Fixes/Closes/Resolves #N, or a bare #N mention) in its title or body before
+// treating it as the fix-PR. Missing body/title (search omits them on some
+// responses) is treated as a match, since the number qualifier already scoped it.
+func prReferencesIssue(iss *gh.Issue, number int) bool {
+	needle := fmt.Sprintf("#%d", number)
+	body := iss.GetBody()
+	title := iss.GetTitle()
+	if body == "" && title == "" {
+		return true
+	}
+	hay := title + "\n" + body
+	for _, tok := range strings.Fields(hay) {
+		// Trim trailing punctuation so "#123." / "#123," still match.
+		tok = strings.TrimRight(tok, ".,);:")
+		if tok == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// contributePRLinkResolver lazily builds the per-Server resolver, wired to the
+// hive's existing authenticated GitHub client. Guarded by a sync.Once so the
+// zero-value Server needs no constructor change (matching the lazy
+// contributeMetricsStore accessor). A missing GHClient yields a resolver whose
+// lookups degrade to nil, so the triage/queue views still render "no linked PR".
+func (s *Server) contributePRLinkResolver() *prLinkResolver {
+	s.contributePRLinkOnce.Do(func() {
+		var gc *gh.Client
+		if s.deps != nil && s.deps.GHClient != nil {
+			gc = s.deps.GHClient.GoGitHub()
+		}
+		s.contributePRLink = newPRLinkResolver(gc)
+	})
+	return s.contributePRLink
+}

--- a/v2/pkg/dashboard/contribute_protocol.go
+++ b/v2/pkg/dashboard/contribute_protocol.go
@@ -36,7 +36,7 @@ package dashboard
 // backward-compatible by construction. Semantic: MAJOR.MINOR where a MINOR bump
 // is purely additive and a MAJOR bump would be a breaking change (none is made
 // here).
-const contributorProtocolVersion = "1.1"
+const contributorProtocolVersion = "1.2"
 
 // Server capability tokens advertised on auth_ok (#2567). Each names a message
 // type or feature this hub supports so a client can adapt without probing. They
@@ -55,6 +55,13 @@ const (
 	// capCapabilityDeclare: the hub accepts, stores, and surfaces client-declared
 	// capabilities in auth_response (#2547 declare half).
 	capCapabilityDeclare = "capability_declare"
+	// capCredentialAfterAccept: the hub splits the scoped GitHub credential OUT of
+	// task_assign and delivers it (via a token_refresh) only AFTER the task's
+	// acceptance decision (#2537). A client that sees this capability knows the
+	// task_assign it receives carries NO github_token and that the credential
+	// arrives in a following token_refresh — but no client change is required, since
+	// the token_refresh delivery is backward-compatible (see deliverTaskCredential).
+	capCredentialAfterAccept = "credential_after_accept"
 )
 
 // serverCapabilities returns the capability set this hub advertises on auth_ok.
@@ -66,6 +73,7 @@ func serverCapabilities() []string {
 		capTaskUnavailableReasons,
 		capPromptPreview,
 		capCapabilityDeclare,
+		capCredentialAfterAccept,
 	}
 }
 

--- a/v2/pkg/dashboard/contribute_queue_hold_test.go
+++ b/v2/pkg/dashboard/contribute_queue_hold_test.go
@@ -236,7 +236,7 @@ func TestQueueMoveToBottomAndHoldControlsPresent(t *testing.T) {
 		`cc-q-held`,                            // dimmed held-row class
 		`cc-q-held-tag`,                        // on-hold badge class
 		`on hold`,                              // badge text
-		`color-scheme:dark`,                    // visible spinner-arrow fix
+		`color-scheme:light dark`,              // theme-aware spinner-arrow fix (visible in both light + dark; #2612)
 		`.cc-q-moverow input[type=number]`,     // spinner fix targets the number input
 	} {
 		if !strings.Contains(body, want) {

--- a/v2/pkg/dashboard/contribute_queue_hold_test.go
+++ b/v2/pkg/dashboard/contribute_queue_hold_test.go
@@ -1,0 +1,252 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ── Operator HOLD / Resume (#queue-hold) + Move-to-bottom + spinner fix ─────────
+// A hold is a MANUAL, PERSISTENT operator decision — distinct from the time-based
+// cooldown — that parks an issue so it is never offered until Resumed. These tests
+// pin the server behaviour (excluded from ReadyQueue's offerable set AND selectTask,
+// surfaced as held for display, round-trips through persistence, auth-gated) and the
+// dashboard structure (menu items + on-hold badge/class).
+
+// TestReadyQueueExcludesHeldFromOffer proves a held issue is NOT in ReadyQueue's
+// offerable set: it is surfaced with Held=true (so the operator can see/Resume it)
+// but never counts as offerable work, and it trails the offerable items.
+func TestReadyQueueExcludesHeldFromOffer(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.RegisterAPI(testDeps(t))
+
+	s.statusMu.Lock()
+	s.status = seedActionable("acme/repo", 3) // issues 1..3
+	s.statusMu.Unlock()
+
+	// Hold #2.
+	s.deps.Config.Hub.ContributeQueueHold = []string{"acme/repo#2"}
+
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 3 {
+		t.Fatalf("expected all 3 items surfaced (held one included but tagged), got %d: %+v", len(q), q)
+	}
+
+	// The offerable items (Held=false) must be #1 and #3, in scan order, ahead of any
+	// held item. #2 must be present but tagged Held, and it must trail the offerable.
+	if q[0].Number != 1 || q[0].Held {
+		t.Fatalf("first offerable item should be #1 (not held), got %+v", q[0])
+	}
+	if q[1].Number != 3 || q[1].Held {
+		t.Fatalf("second offerable item should be #3 (not held), got %+v", q[1])
+	}
+	if q[2].Number != 2 || !q[2].Held {
+		t.Fatalf("held #2 should trail, tagged Held=true, got %+v", q[2])
+	}
+}
+
+// TestReadyQueueResumeReappears proves clearing the hold puts the issue back into
+// the offerable set (untagged), in its normal scan position.
+func TestReadyQueueResumeReappears(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.RegisterAPI(testDeps(t))
+
+	s.statusMu.Lock()
+	s.status = seedActionable("acme/repo", 3)
+	s.statusMu.Unlock()
+
+	// Held, then resumed (empty hold set).
+	s.deps.Config.Hub.ContributeQueueHold = nil
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 3 {
+		t.Fatalf("expected 3 offerable items after resume, got %d", len(q))
+	}
+	for _, it := range q {
+		if it.Held {
+			t.Fatalf("no item should be tagged Held after resume: %+v", it)
+		}
+	}
+	if q[0].Number != 1 || q[1].Number != 2 || q[2].Number != 3 {
+		t.Fatalf("resumed queue lost scan order: %d,%d,%d", q[0].Number, q[1].Number, q[2].Number)
+	}
+}
+
+// TestSelectTaskExcludesHeld proves selectTask never offers a held issue — the
+// operator's parked issue is skipped and the clean one is offered instead, and once
+// resumed the held issue becomes selectable again.
+func TestSelectTaskExcludesHeld(t *testing.T) {
+	hub, s := covK2Hub(t)
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	setStatusIssues(s,
+		intgIssue(1, "held issue", "bob", nil),
+		intgIssue(2, "clean issue", "bob", nil),
+	)
+
+	// Hold #1 (canonical key myorg/repo1#1). It must never be offered.
+	s.deps.Config.Hub.ContributeQueueHold = []string{"myorg/repo1#1"}
+	msg := hub.selectTask(conn)
+	if msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("expected a task_assign for the non-held issue, got %+v", msg)
+	}
+	if msg.Number == 1 {
+		t.Fatalf("held issue #1 was offered; it must be excluded")
+	}
+	if msg.Number != 2 {
+		t.Fatalf("expected the clean #2, got #%d", msg.Number)
+	}
+
+	// Resume #1, clear the assignment, and prove #1 is now selectable again.
+	conn.mu.Lock()
+	conn.currentTask = nil
+	conn.mu.Unlock()
+	s.deps.Config.Hub.ContributeQueueHold = nil
+	// Also hold #2 so only #1 is admissible, forcing the selector to pick #1.
+	s.deps.Config.Hub.ContributeQueueHold = []string{"myorg/repo1#2"}
+	msg = hub.selectTask(conn)
+	if msg == nil || msg.Type != "task_assign" || msg.Number != 1 {
+		t.Fatalf("after resume, #1 should be selectable, got %+v", msg)
+	}
+}
+
+// TestQueueHoldEndpointPersistsRoundTrip proves the hold set survives through its
+// persistence field: a POST hold=true stores the canonical key, a follow-up
+// hold=false removes it, and the endpoint sanitises malformed prior state.
+func TestQueueHoldEndpointPersistsRoundTrip(t *testing.T) {
+	s, deps := apiServer(t)
+
+	// Pre-seed with a malformed/duplicate straggler to prove sanitisation.
+	deps.Config.Hub.ContributeQueueHold = []string{"not a key", "acme/repo#9", "acme/repo#9"}
+
+	// Hold acme/repo#4.
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/queue/hold",
+		strings.NewReader(`{"key":"acme/repo#4","held":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("hold: got %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	got := deps.Config.Hub.ContributeQueueHold
+	// The malformed key is dropped; the valid pre-existing #9 is kept; #4 is added.
+	want := map[string]bool{"acme/repo#9": true, "acme/repo#4": true}
+	if len(got) != len(want) {
+		t.Fatalf("after hold, persisted set = %v, want keys %v", got, want)
+	}
+	for _, k := range got {
+		if !want[k] {
+			t.Fatalf("unexpected persisted key %q (full: %v)", k, got)
+		}
+	}
+
+	// Resume acme/repo#4 → removed; #9 remains.
+	req = httptest.NewRequest(http.MethodPost, "/api/contribute/queue/hold",
+		strings.NewReader(`{"key":"acme/repo#4","held":false}`))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("resume: got %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	got = deps.Config.Hub.ContributeQueueHold
+	if len(got) != 1 || got[0] != "acme/repo#9" {
+		t.Fatalf("after resume, expected only [acme/repo#9], got %v", got)
+	}
+
+	// Response echoes the held flag and the cleaned set.
+	var resp struct {
+		OK   bool     `json:"ok"`
+		Held bool     `json:"held"`
+		Hold []string `json:"hold"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.OK || resp.Held {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+// TestQueueHoldEndpointRoleGate proves the hold endpoint is owner/read-write ONLY,
+// enforced server-side exactly like the queue-order endpoint: a "read" caller 403s.
+func TestQueueHoldEndpointRoleGate(t *testing.T) {
+	cases := []struct {
+		role string
+		want int
+	}{
+		{"read", http.StatusForbidden},
+		{"owner", http.StatusOK},
+		{"read-write", http.StatusOK},
+		{"", http.StatusOK}, // absent header = local/dev owner
+	}
+	for _, tc := range cases {
+		t.Run("role_"+tc.role, func(t *testing.T) {
+			s, _ := apiServer(t)
+			req := httptest.NewRequest(http.MethodPost, "/api/contribute/queue/hold",
+				strings.NewReader(`{"key":"acme/repo#1","held":true}`))
+			req.Header.Set("Content-Type", "application/json")
+			if tc.role != "" {
+				req.Header.Set("X-Hive-Role", tc.role)
+			}
+			w := httptest.NewRecorder()
+			s.mux.ServeHTTP(w, req)
+			if w.Code != tc.want {
+				t.Fatalf("role %q: got %d, want %d (body: %s)", tc.role, w.Code, tc.want, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestQueueHoldEndpointRejectsBadKey proves a malformed issue key is rejected so the
+// stored hold set can never carry a non-canonical entry that would silently miss the
+// selectTask exclusion (the #2648 class of bug).
+func TestQueueHoldEndpointRejectsBadKey(t *testing.T) {
+	s, _ := apiServer(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/queue/hold",
+		strings.NewReader(`{"key":"not a canonical key","held":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("malformed key: got %d, want 400 (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// TestQueueMoveToBottomAndHoldControlsPresent pins the dashboard structure for the
+// three menu additions: Move-to-bottom, Hold/Resume, and the on-hold badge/class.
+func TestQueueMoveToBottomAndHoldControlsPresent(t *testing.T) {
+	body := renderContributePage(t)
+
+	for _, want := range []string{
+		`data-act="bottom"`,                    // Move-to-bottom menu item
+		`Move to bottom`,                       // its label
+		`function ccMoveToBottom(key){`,        // wired mover
+		`ccMoveToPosition(key,ccQueue.length)`, // sends the item to the last slot
+		`data-act="hold"`,                      // Hold/Resume menu item
+		`function ccToggleHold(key,held){`,     // wired toggle
+		`/api/contribute/queue/hold`,           // calls the hold endpoint
+		`cc-q-held`,                            // dimmed held-row class
+		`cc-q-held-tag`,                        // on-hold badge class
+		`on hold`,                              // badge text
+		`color-scheme:dark`,                    // visible spinner-arrow fix
+		`.cc-q-moverow input[type=number]`,     // spinner fix targets the number input
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("queue hold/bottom controls missing marker %q", want)
+		}
+	}
+
+	// The Hold/Resume action must be gated on adminEnabled (owner/read-write) — it
+	// travels through ccQueueMenuHTML, which is only emitted when adminEnabled.
+	if !strings.Contains(body, "var menu=adminEnabled?ccQueueMenuHTML(") {
+		t.Error("per-row hold/resume action is not gated on adminEnabled (owner/read-write only)")
+	}
+}

--- a/v2/pkg/dashboard/contribute_requeue_test.go
+++ b/v2/pkg/dashboard/contribute_requeue_test.go
@@ -38,7 +38,7 @@ func TestRequeueHub_ReleasesAndBooksCooldown(t *testing.T) {
 		t.Fatalf("issue unexpectedly in failure cooldown before requeue")
 	}
 
-	released := hub.RequeueContributorTask("c-wedged")
+	released := hub.RequeueContributorTask("c-wedged", "wedged: no progress")
 	if released != 1 {
 		t.Fatalf("expected 1 session released, got %d", released)
 	}
@@ -73,10 +73,10 @@ func TestRequeueHub_NoInFlightTask_NoOp(t *testing.T) {
 	hub.connections["conn-idle"] = idle
 	hub.mu.Unlock()
 
-	if got := hub.RequeueContributorTask("c-idle"); got != 0 {
+	if got := hub.RequeueContributorTask("c-idle", ""); got != 0 {
 		t.Fatalf("expected 0 released for an idle clanker, got %d", got)
 	}
-	if got := hub.RequeueContributorTask("c-nobody"); got != 0 {
+	if got := hub.RequeueContributorTask("c-nobody", ""); got != 0 {
 		t.Fatalf("expected 0 released for an unknown id, got %d", got)
 	}
 }
@@ -97,7 +97,7 @@ func TestRequeueHub_ReleasedTaskReturnsToQueue(t *testing.T) {
 	hub.connections["conn-w2"] = held
 	hub.mu.Unlock()
 
-	if hub.RequeueContributorTask("c-w2") != 1 {
+	if hub.RequeueContributorTask("c-w2", "") != 1 {
 		t.Fatalf("expected release")
 	}
 	key := "myorg/repo1#7"
@@ -136,7 +136,7 @@ func TestRequeueHub_NoDoubleAssignSameIdentity(t *testing.T) {
 	hub.connections["conn-second"] = second
 	hub.mu.Unlock()
 
-	hub.RequeueContributorTask("c-dup")
+	hub.RequeueContributorTask("c-dup", "")
 	// The freshly-released issue is in the short cooldown — selectTask's admission
 	// scan (isTaskInFailureCooldown) excludes it, so the second session cannot be
 	// re-handed the same issue in the reconnect window. No duplicate assignment.

--- a/v2/pkg/dashboard/contribute_sse.go
+++ b/v2/pkg/dashboard/contribute_sse.go
@@ -79,6 +79,15 @@ type ReadyQueueItem struct {
 	// shared/anonymous queue snapshot (no viewer identity there) and NEVER used to
 	// exclude an item. omitempty so the anonymous payload is byte-for-byte unchanged.
 	MatchesInterest bool `json:"matches_interest,omitempty"`
+	// Held is set true when the operator has manually parked this issue via the
+	// queue HOLD control (Config.Hub.ContributeQueueHold). A held item is NEVER
+	// offered — selectTask excludes it outright and ReadyQueue never sorts it into
+	// the offer-eligible set — but it is still SURFACED here (appended after the
+	// offerable items) so the Operations tab can render it greyed with an "on hold"
+	// badge, letting the operator see and Resume it. Distinct from cooldown: a hold
+	// is persistent and only clears when the operator Resumes it. omitempty so a
+	// snapshot with no holds is byte-for-byte unchanged.
+	Held bool `json:"held,omitempty"`
 }
 
 // sseSubscriber is one connected browser. events is the fan-out channel; done is
@@ -189,9 +198,19 @@ func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
 	active := h.activeIssueKeys()
 
 	var disabledRepos []string
+	var held map[string]struct{}
 	if h.server.deps != nil && h.server.deps.Config != nil {
 		disabledRepos = h.server.deps.Config.Hub.DisabledRepos
+		held = queueHoldSet(h.server.deps.Config.Hub.ContributeQueueHold)
 	}
+
+	// heldItems collects issues the operator parked. They are NEVER offered — kept
+	// out of `out` (the offer-eligible set that the queue-order sort ranks) — but
+	// they are still SURFACED, appended after ordering with Held:true, so the
+	// Operations tab renders them greyed with an "on hold" badge and the operator
+	// can Resume them. A held key uses the SAME canonical "%s#%d" form selectTask's
+	// exclusion uses, so the two stay in lock-step.
+	var heldItems []ReadyQueueItem
 
 	for _, repo := range status.Repos {
 		if len(repo.ActionableIssues) == 0 {
@@ -217,6 +236,24 @@ func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
 				number = n
 			}
 			if number == 0 {
+				continue
+			}
+			// Operator HOLD (#queue-hold): a parked issue is never offered, so it is
+			// kept OUT of the offer-eligible `out` set. It is still collected into
+			// heldItems (tagged Held) so it stays visible-but-dimmed for the operator.
+			// Checked before cooldown/active so a held-AND-cooled issue still shows as
+			// held (the operator's manual decision is the stronger, persistent signal).
+			if _, isHeld := held[fmt.Sprintf("%s#%d", repo.Full, number)]; isHeld {
+				title, _ := issue["title"].(string)
+				url, _ := issue["url"].(string)
+				heldItems = append(heldItems, ReadyQueueItem{
+					Repo:   repo.Full,
+					Number: number,
+					Title:  title,
+					URL:    url,
+					Labels: stringSliceFromAny(issue["labels"]),
+					Held:   true,
+				})
 				continue
 			}
 			if h.isTaskInCooldown(repo.Full, number) {
@@ -278,6 +315,13 @@ func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
 	if len(out) > limit {
 		out = out[:limit]
 	}
+
+	// Held items (#queue-hold) trail ALL offerable work: they are never offered, so
+	// they carry no offer priority and sit at the bottom of the display, greyed with
+	// a badge. Appended after the cap so a large offerable queue never squeezes the
+	// operator's parked rows off-screen — the operator must always be able to see and
+	// Resume what they held.
+	out = append(out, heldItems...)
 	return out
 }
 
@@ -302,6 +346,28 @@ func queueOrderIndex(order []string) map[string]int {
 		}
 	}
 	return idx
+}
+
+// queueHoldSet builds a "owner/repo#number" -> struct{} membership set from the
+// operator's HOLD list (Config.Hub.ContributeQueueHold). A key present here means
+// the issue is manually parked and must never be OFFERED. The keys use the SAME
+// canonical "%s#%d" (repo.Full # number) form every other admission check builds
+// (cooldown / active / failure), so the exclusion cannot silently miss on a
+// repo-name spelling mismatch (the #2648 class of bug). nil-safe to range over
+// (returns nil for an empty list); membership on a nil map is a clean false.
+func queueHoldSet(hold []string) map[string]struct{} {
+	if len(hold) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(hold))
+	for _, key := range hold {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		set[key] = struct{}{}
+	}
+	return set
 }
 
 // applyQueueOrder stably reorders items so any whose "repo#number" key appears in

--- a/v2/pkg/dashboard/contribute_triage.go
+++ b/v2/pkg/dashboard/contribute_triage.go
@@ -1,0 +1,261 @@
+package dashboard
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"strconv"
+)
+
+// Warp-style triage-level view (#2612 part b). A read-only, LIVE-DERIVED grouping
+// of the hive's contribute issues into a lifecycle ladder — Triaging → Ready to
+// implement → Implementing → Reviewing → Closed — computed on each request from
+// the SAME live signals the Operations tab already shows (the ready-work queue,
+// the fleet snapshot's in-flight work) plus the part-(c) PR→issue link. There is
+// NO persistent per-issue lifecycle store: a persisted lifecycle is a possible
+// future enhancement but is deliberately out of scope here (issues are transient,
+// sourced live from GitHub). The whole projection is recomputed per request and
+// stays cheap because the PR-link lookups it depends on are themselves cached
+// (prLinkResolver, short TTL) and degrade to "no linked PR" on any GitHub error.
+
+// Triage ladder levels. Ordered constants (the slice below fixes render order).
+const (
+	triageTriaging     = "triaging"     // open, unclaimed, no linked PR — awaiting triage
+	triageReady        = "ready"        // admitted to the ready queue, not yet picked up
+	triageImplementing = "implementing" // a clanker holds it, or an open linked PR exists
+	triageReviewing    = "reviewing"    // linked PR is open + not merged (awaiting review)
+	triageClosed       = "closed"       // issue closed, or its linked PR merged
+)
+
+// triageLevelOrder pins the ladder's render/count order (early → late lifecycle).
+var triageLevelOrder = []string{
+	triageTriaging, triageReady, triageImplementing, triageReviewing, triageClosed,
+}
+
+// triageLevelLabel is the human-facing name for each level, shown as the group
+// heading in the view. Kept beside the constants so the mapping is legible.
+var triageLevelLabel = map[string]string{
+	triageTriaging:     "Triaging",
+	triageReady:        "Ready to implement",
+	triageImplementing: "Implementing",
+	triageReviewing:    "Reviewing",
+	triageClosed:       "Closed",
+}
+
+// triageSignals is the live per-issue evidence deriveTriageLevel maps onto a
+// ladder rung. Every field is a projection over data the hive already has — the
+// ready queue, the fleet snapshot, and the (c) PR-link — so the derivation stays
+// a pure function of observable state with no hidden lookups.
+type triageSignals struct {
+	// closed is true when the issue itself is no longer open (GitHub state). The
+	// ready-queue/fleet sources only carry OPEN, admissible issues, so this is set
+	// only when a closed issue is surfaced explicitly (e.g. via a merged PR link).
+	closed bool
+	// inReadyQueue: the issue is admitted to the ready-work queue (ReadyQueue),
+	// i.e. it passed every admission/cooldown filter and is not in flight.
+	inReadyQueue bool
+	// inFleet: a connected clanker currently holds this issue as its task
+	// (FleetSnapshot().Work) — it is actively being implemented.
+	inFleet bool
+	// prLink is the resolved fix-PR for the issue (part c), or nil when none is
+	// linked. A merged link implies the work landed; an open link implies review.
+	prLink *prLinkStatus
+}
+
+// deriveTriageLevel maps live signals onto exactly one Warp-style ladder rung.
+// This is the ONE documented place the mapping lives, so it is legible and unit
+// testable. The precedence is late-lifecycle-first so the most-advanced evidence
+// wins: a merged PR (or a closed issue) is Closed even if the issue also lingers
+// in some stale queue; an open PR is Reviewing; active fleet work (or an open PR
+// with no review signal yet) is Implementing; an admitted-but-unclaimed queue
+// item is Ready; anything else open is Triaging.
+//
+//	Closed:       issue closed OR linked PR merged
+//	Reviewing:    linked PR open + not merged (awaiting review)
+//	Implementing: in-flight in the fleet, OR has an open linked PR
+//	Ready:        admitted to the ready queue, not yet picked up
+//	Triaging:     open, unclaimed, not queued, no linked PR
+func deriveTriageLevel(sig triageSignals) string {
+	// Closed wins outright: the fix landed (merged PR) or the issue is done.
+	if sig.closed || (sig.prLink != nil && sig.prLink.State == prLinkStateMerged) {
+		return triageClosed
+	}
+	// An open linked PR means a fix is up and awaiting review.
+	if sig.prLink != nil && sig.prLink.State == prLinkStateOpen {
+		// A PR that is up is being implemented/reviewed; if the issue is ALSO held
+		// by a clanker it is squarely Implementing, otherwise it is in Reviewing.
+		if sig.inFleet {
+			return triageImplementing
+		}
+		return triageReviewing
+	}
+	// A clanker actively holds it → Implementing.
+	if sig.inFleet {
+		return triageImplementing
+	}
+	// Admitted to the ready queue but not yet picked up → Ready to implement.
+	if sig.inReadyQueue {
+		return triageReady
+	}
+	// Open, unclaimed, unqueued, unlinked → still Triaging.
+	return triageTriaging
+}
+
+// triageIssue is one issue placed on the ladder, carrying just enough metadata to
+// render a row (and its optional PR badge). It is the wire shape the triage
+// endpoint returns and the render helper consumes.
+type triageIssue struct {
+	Repo   string        `json:"repo"`
+	Number int           `json:"number"`
+	Title  string        `json:"title"`
+	URL    string        `json:"url,omitempty"`
+	Level  string        `json:"level"`
+	PR     *prLinkStatus `json:"pr,omitempty"`
+}
+
+// triageGroup is one ladder rung: its level id/label, the issues on it, and the
+// count (== len(Issues), echoed so a client can show a count without the list).
+type triageGroup struct {
+	Level  string        `json:"level"`
+	Label  string        `json:"label"`
+	Count  int           `json:"count"`
+	Issues []triageIssue `json:"issues"`
+}
+
+// triageSnapshot is the full projection: the ordered ladder groups plus the total
+// count of placed issues. Recomputed per request; never persisted.
+type triageSnapshot struct {
+	Groups []triageGroup `json:"groups"`
+	Total  int           `json:"total"`
+}
+
+// maxTriageIssuesPerLevel bounds how many issues each rung lists in the response,
+// so a pathological backlog cannot blow out the JSON/DOM. The count still reflects
+// the true total on the rung; only the enumerated list is capped (matching how the
+// ready-queue caps its own visible list). Generous enough to show a real backlog.
+const maxTriageIssuesPerLevel = 60
+
+// buildTriageSnapshot derives the ladder live from the ready queue + fleet snapshot
+// + the PR-link resolver. It issues a bounded PR-link lookup per candidate issue
+// (cached, short-TTL, degrade-to-nil) — never blocking on GitHub — and groups the
+// results by deriveTriageLevel. Read-only; assigns nothing, persists nothing.
+func (s *Server) buildTriageSnapshot(ctx context.Context) triageSnapshot {
+	snap := triageSnapshot{}
+	if s == nil || s.contributeHub == nil {
+		// Still return the empty ladder (all rungs, zero counts) so the UI renders a
+		// stable, non-error shell.
+		return emptyTriageSnapshot()
+	}
+
+	resolver := s.contributePRLinkResolver()
+
+	// In-flight work (Implementing candidates) from the fleet snapshot, keyed the
+	// same way activeIssueKeys/selectTask key issues so a fleet item and a queue
+	// item line up on the same identity string.
+	fleetKeys := map[string]bool{}
+	fleetItems := map[string]triageIssue{}
+	for _, w := range s.contributeHub.FleetSnapshot().Work {
+		if w.Repo == "" || w.Number <= 0 {
+			continue
+		}
+		key := prLinkKey(w.Repo, w.Number)
+		fleetKeys[key] = true
+		fleetItems[key] = triageIssue{Repo: w.Repo, Number: w.Number, Title: w.Title, URL: issueURLFor(w.Repo, w.Number)}
+	}
+
+	// Ready-work queue (Ready / Reviewing / Implementing-via-PR candidates).
+	byLevel := map[string][]triageIssue{}
+	seen := map[string]bool{}
+
+	place := func(it triageIssue, sig triageSignals) {
+		key := prLinkKey(it.Repo, it.Number)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		it.PR = sig.prLink
+		it.Level = deriveTriageLevel(sig)
+		byLevel[it.Level] = append(byLevel[it.Level], it)
+	}
+
+	for _, q := range s.contributeHub.ReadyQueue(readyQueueDefaultLimit) {
+		key := prLinkKey(q.Repo, q.Number)
+		pr := resolver.resolve(ctx, q.Repo, q.Number)
+		place(triageIssue{Repo: q.Repo, Number: q.Number, Title: q.Title, URL: q.URL}, triageSignals{
+			inReadyQueue: true,
+			inFleet:      fleetKeys[key],
+			prLink:       pr,
+		})
+	}
+
+	// Fleet items not already placed via the queue (an in-flight issue is excluded
+	// from the ready queue by design, so it is surfaced here).
+	for key, it := range fleetItems {
+		if seen[key] {
+			continue
+		}
+		pr := resolver.resolve(ctx, it.Repo, it.Number)
+		place(it, triageSignals{inFleet: true, prLink: pr})
+	}
+
+	// Assemble the ordered ladder. Every rung is always present (even at zero) so
+	// the view is a stable shape; per-rung lists are sorted (repo, number) for a
+	// deterministic render and capped.
+	for _, level := range triageLevelOrder {
+		items := byLevel[level]
+		sort.Slice(items, func(i, j int) bool {
+			if items[i].Repo != items[j].Repo {
+				return items[i].Repo < items[j].Repo
+			}
+			return items[i].Number < items[j].Number
+		})
+		count := len(items)
+		if len(items) > maxTriageIssuesPerLevel {
+			items = items[:maxTriageIssuesPerLevel]
+		}
+		snap.Groups = append(snap.Groups, triageGroup{
+			Level:  level,
+			Label:  triageLevelLabel[level],
+			Count:  count,
+			Issues: items,
+		})
+		snap.Total += count
+	}
+	return snap
+}
+
+// emptyTriageSnapshot returns the ladder with every rung present and empty, used
+// when there is no contribute hub to derive from so the UI still renders a stable
+// (zero-count) shell rather than an error.
+func emptyTriageSnapshot() triageSnapshot {
+	snap := triageSnapshot{}
+	for _, level := range triageLevelOrder {
+		snap.Groups = append(snap.Groups, triageGroup{
+			Level:  level,
+			Label:  triageLevelLabel[level],
+			Count:  0,
+			Issues: []triageIssue{},
+		})
+	}
+	return snap
+}
+
+// issueURLFor builds the canonical GitHub issue URL for a "owner/repo" + number,
+// used when a source (the fleet snapshot) does not already carry a URL so the
+// triage row can still link out.
+func issueURLFor(repo string, number int) string {
+	if repo == "" || number <= 0 {
+		return ""
+	}
+	return "https://github.com/" + repo + "/issues/" + strconv.Itoa(number)
+}
+
+// handleContributeTriage serves the live triage-ladder projection as JSON. GET
+// only, read-only, public within the /api/contribute* surface (same posture as
+// /queue and /fleet — it exposes only public issue metadata + public PR numbers,
+// no tokens, no PII). The Operations-tab triage card fetches this after page load
+// so a slow GitHub PR-link lookup never delays the page render.
+func (s *Server) handleContributeTriage(w http.ResponseWriter, r *http.Request) {
+	snap := s.buildTriageSnapshot(r.Context())
+	jsonResponse(w, snap)
+}

--- a/v2/pkg/dashboard/contribute_triage_test.go
+++ b/v2/pkg/dashboard/contribute_triage_test.go
@@ -1,0 +1,287 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// TestDeriveTriageLevel table-tests the ONE documented mapping from live signals
+// onto the Warp-style ladder, covering every level and the precedence boundaries
+// (merged-PR/closed win over everything; open PR splits Reviewing vs Implementing;
+// fleet vs queue vs neither).
+func TestDeriveTriageLevel(t *testing.T) {
+	openPR := &prLinkStatus{Number: 10, State: prLinkStateOpen}
+	mergedPR := &prLinkStatus{Number: 11, State: prLinkStateMerged}
+
+	cases := []struct {
+		name string
+		sig  triageSignals
+		want string
+	}{
+		{"open unclaimed unqueued no-pr -> triaging", triageSignals{}, triageTriaging},
+		{"admitted to ready queue -> ready", triageSignals{inReadyQueue: true}, triageReady},
+		{"in fleet -> implementing", triageSignals{inFleet: true}, triageImplementing},
+		{"in fleet even if also queued -> implementing", triageSignals{inFleet: true, inReadyQueue: true}, triageImplementing},
+		{"open linked PR, not in fleet -> reviewing", triageSignals{prLink: openPR}, triageReviewing},
+		{"open linked PR while queued -> reviewing", triageSignals{prLink: openPR, inReadyQueue: true}, triageReviewing},
+		{"open linked PR AND in fleet -> implementing", triageSignals{prLink: openPR, inFleet: true}, triageImplementing},
+		{"merged linked PR -> closed", triageSignals{prLink: mergedPR}, triageClosed},
+		{"merged PR wins over fleet+queue -> closed", triageSignals{prLink: mergedPR, inFleet: true, inReadyQueue: true}, triageClosed},
+		{"issue closed -> closed", triageSignals{closed: true}, triageClosed},
+		{"issue closed wins over open PR -> closed", triageSignals{closed: true, prLink: openPR}, triageClosed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := deriveTriageLevel(tc.sig); got != tc.want {
+				t.Errorf("deriveTriageLevel(%+v) = %q, want %q", tc.sig, got, tc.want)
+			}
+		})
+	}
+}
+
+// newPRLinkTestResolver builds a resolver whose lookups hit a go-github client
+// pointed at the given httptest server, with a fixed clock so TTL behaviour is
+// deterministic.
+func newPRLinkTestResolver(serverURL string) *prLinkResolver {
+	gc := ghpkg.NewClientForTest(serverURL, "testorg", []string{"testorg/repo"}, slog.Default()).GoGitHub()
+	r := newPRLinkResolver(gc)
+	fixed := time.Unix(1700000000, 0)
+	r.now = func() time.Time { return fixed }
+	return r
+}
+
+// searchIssuesResponse builds a /search/issues body with the given PR items.
+func searchIssuesResponse(items ...map[string]any) map[string]any {
+	return map[string]any{"total_count": len(items), "items": items}
+}
+
+// TestPRLinkResolver_Open resolves an OPEN linked PR referencing the issue.
+func TestPRLinkResolver_Open(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(searchIssuesResponse(map[string]any{
+			"number":       77,
+			"state":        "open",
+			"title":        "Fix the thing",
+			"body":         "Fixes #123",
+			"html_url":     "https://github.com/testorg/repo/pull/77",
+			"pull_request": map[string]any{"url": "https://api.github.com/repos/testorg/repo/pulls/77"},
+		}))
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	r := newPRLinkTestResolver(ts.URL)
+	got := r.resolve(context.Background(), "testorg/repo", 123)
+	if got == nil {
+		t.Fatal("expected a linked PR, got nil")
+	}
+	if got.Number != 77 || got.State != prLinkStateOpen {
+		t.Errorf("got %+v, want #77 open", got)
+	}
+}
+
+// TestPRLinkResolver_Merged resolves a MERGED linked PR (merged_at set), which
+// must win even if an open PR is also present.
+func TestPRLinkResolver_Merged(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(searchIssuesResponse(
+			map[string]any{
+				"number":       80,
+				"state":        "open",
+				"body":         "Also touches #123",
+				"html_url":     "https://github.com/testorg/repo/pull/80",
+				"pull_request": map[string]any{"url": "x"},
+			},
+			map[string]any{
+				"number":       81,
+				"state":        "closed",
+				"body":         "Closes #123",
+				"html_url":     "https://github.com/testorg/repo/pull/81",
+				"pull_request": map[string]any{"url": "y", "merged_at": "2024-01-02T03:04:05Z"},
+			},
+		))
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	r := newPRLinkTestResolver(ts.URL)
+	got := r.resolve(context.Background(), "testorg/repo", 123)
+	if got == nil {
+		t.Fatal("expected a linked PR, got nil")
+	}
+	if got.Number != 81 || got.State != prLinkStateMerged {
+		t.Errorf("got %+v, want #81 merged", got)
+	}
+}
+
+// TestPRLinkResolver_None returns nil when no PR references the issue (the search
+// hit is a plain issue, not a PR, and/or references a different number).
+func TestPRLinkResolver_None(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		// An item with no pull_request object is an issue, not a PR — must be ignored.
+		_ = json.NewEncoder(w).Encode(searchIssuesResponse(map[string]any{
+			"number": 5, "state": "open", "body": "mentions #123 but is an issue",
+		}))
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	r := newPRLinkTestResolver(ts.URL)
+	if got := r.resolve(context.Background(), "testorg/repo", 123); got != nil {
+		t.Errorf("expected no linked PR, got %+v", got)
+	}
+}
+
+// TestPRLinkResolver_ErrorDegrades proves a GitHub failure degrades gracefully to
+// "no linked PR" (nil) instead of propagating an error or panicking.
+func TestPRLinkResolver_ErrorDegrades(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	r := newPRLinkTestResolver(ts.URL)
+	if got := r.resolve(context.Background(), "testorg/repo", 123); got != nil {
+		t.Errorf("expected nil on GitHub error, got %+v", got)
+	}
+}
+
+// TestPRLinkResolver_NilClientDegrades proves a resolver with no GitHub client
+// (the missing-wiring path) returns nil rather than panicking.
+func TestPRLinkResolver_NilClientDegrades(t *testing.T) {
+	r := newPRLinkResolver(nil)
+	if got := r.resolve(context.Background(), "testorg/repo", 123); got != nil {
+		t.Errorf("expected nil with no GH client, got %+v", got)
+	}
+}
+
+// TestPRLinkResolver_Caches proves a second resolve within the TTL does NOT hit
+// GitHub again (the cached result is reused).
+func TestPRLinkResolver_Caches(t *testing.T) {
+	var calls int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_ = json.NewEncoder(w).Encode(searchIssuesResponse(map[string]any{
+			"number":       9,
+			"state":        "open",
+			"body":         "Fixes #123",
+			"html_url":     "https://github.com/testorg/repo/pull/9",
+			"pull_request": map[string]any{"url": "x"},
+		}))
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	r := newPRLinkTestResolver(ts.URL) // fixed clock -> always within TTL
+	_ = r.resolve(context.Background(), "testorg/repo", 123)
+	_ = r.resolve(context.Background(), "testorg/repo", 123)
+	if calls != 1 {
+		t.Errorf("expected 1 GitHub call (second served from cache), got %d", calls)
+	}
+}
+
+// TestBuildTriageSnapshotEmptyShell proves that with no contribute hub the builder
+// still returns the full ladder (every rung present, zero counts) so the UI has a
+// stable shape.
+func TestBuildTriageSnapshotEmptyShell(t *testing.T) {
+	s := NewServer(0, slog.Default())
+	snap := s.buildTriageSnapshot(context.Background())
+	if len(snap.Groups) != len(triageLevelOrder) {
+		t.Fatalf("expected %d groups, got %d", len(triageLevelOrder), len(snap.Groups))
+	}
+	for i, g := range snap.Groups {
+		if g.Level != triageLevelOrder[i] {
+			t.Errorf("group %d level = %q, want %q", i, g.Level, triageLevelOrder[i])
+		}
+		if g.Count != 0 || len(g.Issues) != 0 {
+			t.Errorf("group %q should be empty, got count=%d issues=%d", g.Level, g.Count, len(g.Issues))
+		}
+	}
+	if snap.Total != 0 {
+		t.Errorf("empty snapshot total = %d, want 0", snap.Total)
+	}
+}
+
+// TestContributeTriageRenderMarkup asserts the triage SECTION (inside Operations,
+// not a new tab) and the PR-badge machinery render into the served page: the card,
+// the ladder container, the per-level groups container, the JS poll + badge
+// helpers, and the triage endpoint wiring.
+func TestContributeTriageRenderMarkup(t *testing.T) {
+	body := renderContributePage(t)
+
+	for _, want := range []string{
+		// Triage card lives INSIDE the Operations tab panel (a section, not a tab).
+		`id="cc-triage-card"`,
+		`<h3>Issue triage</h3>`,
+		`id="cc-triage-ladder"`,
+		`id="cc-triage-groups"`,
+		// Client wiring: the poll + render + PR-badge helpers and the endpoint.
+		`function ccTriagePoll(`,
+		`function ccRenderTriage(`,
+		`function ccPRBadgeHTML(`,
+		`/api/contribute/triage`,
+		// The five ladder levels are named client-side in lifecycle order.
+		`['triaging','Triaging']`,
+		`['ready','Ready to implement']`,
+		`['implementing','Implementing']`,
+		`['reviewing','Reviewing']`,
+		`['closed','Closed']`,
+		// PR badge CSS classes (part c) present for open/merged states.
+		`.cc-pr-badge.pr-open`,
+		`.cc-pr-badge.pr-merged`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("rendered page missing triage/PR-link marker %q", want)
+		}
+	}
+
+	// The triage card must sit inside the Operations panel (#tab-ops), before the
+	// leaderboard panel — i.e. it is a section OF Operations, not a separate tab.
+	ops := strings.Index(body, `id="tab-ops"`)
+	card := strings.Index(body, `id="cc-triage-card"`)
+	lb := strings.Index(body, `id="tab-leaderboard"`)
+	if !(ops >= 0 && card > ops && (lb < 0 || card < lb)) {
+		t.Errorf("triage card is not inside the Operations panel (ops=%d card=%d lb=%d)", ops, card, lb)
+	}
+}
+
+// TestContributeTriageEndpoint hits the JSON endpoint and asserts it returns the
+// full ladder shape (all levels present), read-only, 200.
+func TestContributeTriageEndpoint(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/triage", nil)
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var snap triageSnapshot
+	if err := json.Unmarshal(rec.Body.Bytes(), &snap); err != nil {
+		t.Fatalf("triage response not valid JSON: %v", err)
+	}
+	if len(snap.Groups) != len(triageLevelOrder) {
+		t.Fatalf("expected %d ladder groups, got %d", len(triageLevelOrder), len(snap.Groups))
+	}
+	for i, want := range triageLevelOrder {
+		if snap.Groups[i].Level != want {
+			t.Errorf("group %d = %q, want %q", i, snap.Groups[i].Level, want)
+		}
+	}
+}

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -96,7 +96,23 @@ type ContributorConnection struct {
 	// client). Stored read-only and surfaced on FleetClanker; NEVER used to route
 	// or gate work.
 	capabilities *ContributorCapabilities
-	mu           sync.Mutex
+	// pendingToken is the scoped, expiring GitHub credential minted for currentTask
+	// but NOT yet delivered to the relay (kubestellar/hive#2537). The credential no
+	// longer travels inside task_assign; it is held here until the task's acceptance
+	// decision is made, then shipped via deliverTaskCredential (which reuses the
+	// token_refresh wire shape). In auto-accept mode (the default) it is delivered
+	// immediately after task_assign is sent; in explicit-accept mode it is held
+	// until a task_accepted arrives. Cleared to "" once delivered (or when the task
+	// ends without acceptance). It is a credential — NEVER logged or previewed.
+	pendingToken string
+	// credentialDelivered records that the scoped credential for currentTask has
+	// already been handed to the relay, so a duplicate task_accepted (the relay
+	// re-asserts one on reconnect) does not re-deliver, and the auto-accept and
+	// explicit-accept paths cannot both fire. Reset when a task ends. This is the
+	// single flag that makes "the credential arrived AFTER acceptance" observable
+	// and idempotent.
+	credentialDelivered bool
+	mu                  sync.Mutex
 }
 
 type WSMessage struct {
@@ -118,8 +134,15 @@ type WSMessage struct {
 	URL               string   `json:"url,omitempty"`
 	Labels            []string `json:"labels,omitempty"`
 	Prompt            string   `json:"prompt,omitempty"`
-	GitHubToken       string   `json:"github_token,omitempty"`
-	TokenExpiresAt    string   `json:"token_expires_at,omitempty"`
+	// GitHubToken carries the scoped, expiring credential. As of #2537 it is
+	// NEVER populated on task_assign — the credential is split OUT of the
+	// assignment message and delivered only AFTER the task's acceptance decision,
+	// via a token_refresh (see deliverTaskCredential). It still travels on
+	// token_refresh (post-acceptance delivery + the #2393 mid-task re-mint). The
+	// token itself is unchanged: same per-tier mint, same wsTokenTTL expiry — only
+	// its timing relative to acceptance moved.
+	GitHubToken    string `json:"github_token,omitempty"`
+	TokenExpiresAt string `json:"token_expires_at,omitempty"`
 	// Restrictions is RESERVED and intentionally not populated by the server yet:
 	// the contributor command restrictions are enforced server-side (gh-wrapper /
 	// contributor-default.json), so shipping the policy to the client would be
@@ -874,6 +897,10 @@ func (h *ContributeWSHub) RequeueContributorTask(contributorID string) int {
 			c.currentPrompt = ""
 			c.currentLabels = nil
 			c.tokenMintedAt = time.Time{}
+			// #2537: drop any credential that was pending/held for the released task
+			// so it cannot leak to the (now task-less) connection.
+			c.pendingToken = ""
+			c.credentialDelivered = false
 			targets = append(targets, releaseTarget{conn: c, task: released})
 		}
 		c.mu.Unlock()
@@ -1220,6 +1247,9 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			abandonedTask := contributor.currentTask
 			contributor.currentTask = nil
 			contributor.tokenMintedAt = time.Time{}
+			// #2537: clear any pending/delivered credential state with the task.
+			contributor.pendingToken = ""
+			contributor.credentialDelivered = false
 			contributor.mu.Unlock()
 			if abandonedTask != nil {
 				h.logger.Warn("[contribute-ws] task released on disconnect",
@@ -1411,6 +1441,9 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			abandoned := contributor.currentTask
 			contributor.currentTask = nil
 			contributor.tokenMintedAt = time.Time{}
+			// #2537: clear any pending/delivered credential state with the task.
+			contributor.pendingToken = ""
+			contributor.credentialDelivered = false
 			contributor.mu.Unlock()
 			if abandoned != nil {
 				h.logger.Warn("[contribute-ws] task abandoned without completion",
@@ -1481,10 +1514,38 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					"repo", task.Repo,
 					"number", task.Number,
 				)
+				// #2537: the credential was withheld from the task_assign above and is
+				// delivered only AFTER acceptance. In the DEFAULT trusted-source
+				// auto-accept mode, the task already cleared admission and the per-tier
+				// trust gate in selectTask, so acceptance is automatic HERE — after the
+				// assignment is committed and sent — and the scoped credential is
+				// delivered immediately. This preserves an unattended fleet's timing
+				// (credential arrives right after task_assign) while making the ordering
+				// provable: the credential leaves the hub only once acceptance is
+				// recorded, never bundled with the metadata. In EXPLICIT-accept mode the
+				// hub withholds here and waits for a task_accepted (handled below).
+				if !h.requireExplicitAccept() {
+					h.deliverTaskCredential(contributor, "auto_accept")
+				} else {
+					h.logger.Info("[contribute-ws] credential withheld pending explicit acceptance",
+						"username", contributor.profile.GitHubUsername, "task", task.TaskID)
+				}
 			}
 
 		case "task_accepted":
-			// acknowledged
+			// #2537: a task_accepted is the client's explicit acceptance of the
+			// assigned task. In EXPLICIT-accept mode the hub withheld the scoped
+			// credential from task_assign and waits for exactly this message before
+			// delivering it — so a task that is never accepted (declined, timed out,
+			// or reconnected away) never receives a credential. acceptTaskCredential
+			// delivers only when the acceptance is for the task this connection
+			// currently holds; a stale/mismatched task_id is ignored. It is idempotent
+			// via deliverTaskCredential, so in auto-accept mode (where the credential
+			// already went out) this is a no-op, and a relay that re-asserts
+			// task_accepted on reconnect cannot re-deliver.
+			if contributor != nil {
+				h.acceptTaskCredential(contributor, msg.TaskID)
+			}
 
 		case "task_progress":
 			if contributor != nil {
@@ -1541,6 +1602,9 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				contributor.currentPrompt = ""
 				contributor.currentLabels = nil
 				contributor.tokenMintedAt = time.Time{}
+				// #2537: clear any pending/delivered credential state with the task.
+				contributor.pendingToken = ""
+				contributor.credentialDelivered = false
 				contributor.tmuxOutput = msg.TmuxOutput
 				contributor.mu.Unlock()
 
@@ -1625,6 +1689,9 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				failedTask := contributor.currentTask
 				contributor.currentTask = nil
 				contributor.tokenMintedAt = time.Time{}
+				// #2537: clear any pending/delivered credential state with the task.
+				contributor.pendingToken = ""
+				contributor.credentialDelivered = false
 				contributor.mu.Unlock()
 
 				if hasTask {
@@ -1798,6 +1865,95 @@ func (h *ContributeWSHub) sendTokenRefresh(c *ContributorConnection, tok string)
 	return nil
 }
 
+// requireExplicitAccept reports whether this hive is in the opt-in EXPLICIT
+// (human/manual) acceptance mode (#2537). A hub without a Config (direct-in-test
+// construction) or an unset toggle resolves to FALSE — the trusted-source
+// auto-accept default — so existing deployments keep delivering credentials to
+// admitted tasks without a wait state.
+func (h *ContributeWSHub) requireExplicitAccept() bool {
+	if h.server == nil || h.server.deps == nil || h.server.deps.Config == nil {
+		return false
+	}
+	return h.server.deps.Config.Hub.IsContributeRequireExplicitAccept()
+}
+
+// deliverTaskCredential ships the scoped credential the hub minted for the
+// connection's current task but deliberately withheld from task_assign (#2537).
+// It is the single post-acceptance delivery point: both the auto-accept path (in
+// the ready handler, right after task_assign is sent) and the explicit-accept path
+// (the task_accepted handler) funnel through here, so the credential provably
+// leaves the hub only AFTER an acceptance decision was recorded — never bundled
+// with the task metadata.
+//
+// It reuses the token_refresh wire shape (github_token + token_expires_at) that
+// every existing relay already understands, so an old client that never learned a
+// new "credential" message still ends up holding a working token: it processes
+// task_assign (metadata) then a token_refresh (credential) exactly as it already
+// handles a mid-task re-mint. The token itself is unchanged — the same per-tier
+// scoped, wsTokenTTL-expiring token selectTask minted — only its timing moved.
+//
+// It is idempotent and safe to call more than once: it delivers only while a
+// pending token is held and not yet delivered, then sets credentialDelivered and
+// clears pendingToken. A task_accepted that arrives in auto-accept mode after the
+// credential already went out is therefore a no-op, and a duplicate acceptance
+// cannot double-send. It NEVER logs the token value. Returns true when it actually
+// delivered (an assignment→acceptance→credential ordering point for tests/audit).
+func (h *ContributeWSHub) deliverTaskCredential(c *ContributorConnection, reason string) bool {
+	c.mu.Lock()
+	if c.currentTask == nil || c.credentialDelivered || c.pendingToken == "" {
+		c.mu.Unlock()
+		return false
+	}
+	tok := c.pendingToken
+	taskID := c.currentTask.TaskID
+	username := ""
+	if c.profile != nil {
+		username = c.profile.GitHubUsername
+	}
+	c.mu.Unlock()
+
+	// sendTokenRefresh writes the github_token + token_expires_at frame and
+	// re-stamps tokenMintedAt on success, anchoring the #2393 refresh cycle on when
+	// the relay actually received the credential.
+	if err := h.sendTokenRefresh(c, tok); err != nil {
+		// Delivery failed (socket gone): leave the token PENDING and undelivered so
+		// a reconnect/resume or a retried acceptance can deliver it. Never log the
+		// token value.
+		h.logger.Info("[contribute-ws] task credential delivery failed, will retry",
+			"username", username, "task", taskID, "accept_reason", reason, "error", err)
+		return false
+	}
+
+	c.mu.Lock()
+	c.credentialDelivered = true
+	c.pendingToken = ""
+	c.mu.Unlock()
+
+	h.logger.Info("[contribute-ws] task credential delivered after acceptance",
+		"username", username, "task", taskID, "accept_reason", reason)
+	return true
+}
+
+// acceptTaskCredential is the explicit-acceptance entry point (#2537): a client
+// task_accepted for taskID accepts the assigned task, releasing the credential the
+// hub withheld from task_assign. It delivers only when taskID matches the task this
+// connection currently holds — a stale or mismatched task_id (e.g. a late
+// task_accepted for a task that already ended) is ignored, so a credential is never
+// delivered for work this connection is not actually on. It returns whether a
+// credential was delivered (an assignment→acceptance→credential ordering point).
+func (h *ContributeWSHub) acceptTaskCredential(c *ContributorConnection, taskID string) bool {
+	if c == nil || taskID == "" {
+		return false
+	}
+	c.mu.Lock()
+	match := c.currentTask != nil && c.currentTask.TaskID == taskID
+	c.mu.Unlock()
+	if !match {
+		return false
+	}
+	return h.deliverTaskCredential(c, "explicit_accept")
+}
+
 func (h *ContributeWSHub) checkModelAllowed(model string) (bool, []string) {
 	if h.server == nil || h.server.deps == nil || h.server.deps.Config == nil {
 		return true, nil
@@ -1833,7 +1989,14 @@ func (h *ContributeWSHub) cleanupLoop() {
 			c.mu.Unlock()
 			if stale {
 				h.logger.Info("[contribute-ws] cleanup: removing stale connection", "username", username, "conn", id)
-				c.ws.Close()
+				// Nil-guard the close: a connection may carry no live socket (e.g. a
+				// test-injected in-flight entry, or a connection torn down elsewhere),
+				// and cleanupLoop iterates ALL registered connections. Mirrors the
+				// existing guard in RequeueContributorTask so a ws-less entry is pruned
+				// rather than nil-dereferenced.
+				if c.ws != nil {
+					c.ws.Close()
+				}
 				delete(h.connections, id)
 			}
 		}
@@ -2475,6 +2638,16 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	c.currentPrompt = prompt
 	c.currentLabels = chosen.labels
 	c.lastIdleReason = ""
+	// #2537: hold the minted scoped token as PENDING rather than shipping it in the
+	// task_assign below. It is delivered only AFTER the acceptance decision — see
+	// the ready-handler (auto-accept default) and the task_accepted handler
+	// (explicit-accept mode) — via deliverTaskCredential. A fresh assignment resets
+	// the delivered flag so the new task's credential is (re)delivered post-accept.
+	// tokenMintedAt is set here so the #2393 refresh cycle is armed for the token we
+	// hand out; deliverTaskCredential re-stamps it on actual delivery to anchor the
+	// 50-minute refresh on when the relay truly received the credential.
+	c.pendingToken = ghToken
+	c.credentialDelivered = false
 	c.tokenMintedAt = time.Now()
 	c.mu.Unlock()
 
@@ -2487,17 +2660,21 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	h.recordAssignment(identityOf(c), time.Now())
 
 	return &WSMessage{
-		Type:           "task_assign",
-		Seq:            h.nextSeq(),
-		TaskID:         taskID,
-		Kind:           "issue",
-		Repo:           chosen.repoFull,
-		Number:         chosen.number,
-		Title:          chosen.title,
-		URL:            chosen.url,
-		GitHubToken:    ghToken,
-		TokenExpiresAt: time.Now().Add(wsTokenTTL).UTC().Format(time.RFC3339),
-		Prompt:         prompt,
+		Type:   "task_assign",
+		Seq:    h.nextSeq(),
+		TaskID: taskID,
+		Kind:   "issue",
+		Repo:   chosen.repoFull,
+		Number: chosen.number,
+		Title:  chosen.title,
+		URL:    chosen.url,
+		// #2537: NO github_token / token_expires_at here. The scoped credential is
+		// split out of task_assign and delivered only after acceptance (see
+		// pendingToken / deliverTaskCredential). task_assign now carries exactly the
+		// metadata needed to DECIDE — repo/number/title/url/labels/prompt — and no
+		// credential, so nothing an agent could act on is authenticated until the
+		// task's source has been accepted under the operator/contributor policy.
+		Prompt: prompt,
 		// The chosen issue's own labels — the Labels envelope field was declared
 		// but never populated, so a client reading it got nothing (kubestellar/
 		// hive#2393 item 8). Carried on the candidate from the scan above.

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -1182,6 +1182,14 @@ type FleetClanker struct {
 	// Surfaced read-only exactly like CLIBackend/Model/Role so the Operations tab
 	// COULD display it; it is NEVER used to route or gate work.
 	Capabilities *ContributorCapabilities `json:"capabilities,omitempty"`
+	// LabelInterests (#2677) mirrors the contributor's own OPT-IN label-affinity
+	// list (#2637, ContributorProfile.LabelInterests) so an operator can see
+	// fleet-wide who prefers what without cross-referencing each profile
+	// separately. Strictly READ-ONLY here: an operator never sets or edits this
+	// through the fleet view — it stays contributor-owned via the existing
+	// PUT /api/contribute/interests. Omitted when the contributor has declared
+	// none.
+	LabelInterests []string `json:"label_interests,omitempty"`
 }
 
 // FleetWorkItem is a read-only view of one in-flight task the fleet is working,
@@ -1246,6 +1254,11 @@ func (h *ContributeWSHub) FleetSnapshot() FleetSnapshot {
 			fc.ContributorID = c.profile.ContributorID
 			fc.GitHubUsername = c.profile.GitHubUsername
 			fc.TrustTier = c.profile.TrustTier
+			// #2677: mirror the contributor's own label interests read-only (a copy
+			// so the snapshot never aliases the live profile slice).
+			if len(c.profile.LabelInterests) > 0 {
+				fc.LabelInterests = append([]string(nil), c.profile.LabelInterests...)
+			}
 		}
 		var task *WSTaskAssign
 		var promptPreview string

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -28,7 +29,18 @@ import (
 const (
 	wsHeartbeatInterval = 30 * time.Second
 	wsHeartbeatTimeout  = 90 * time.Second
-	wsTaskTimeout       = 30 * time.Minute
+	// wsTaskTimeout is the hub-owned LEASE TTL on task ownership (kubestellar/hive
+	// #2568). A task's lease is renewed on assignment and on every task_progress
+	// report; if a connection holds a task but the lease has not been renewed within
+	// this window the cleanupLoop auto-releases it through the SAME cooldown path the
+	// disconnect/ready-abandon/manual-requeue releases use, so a wedged-but-connected
+	// worker cannot hold an issue forever. It is deliberately CONSERVATIVE (option 4
+	// in the issue: manual operator recovery is the primary path, auto-expiry is only
+	// the backstop) so a task that is legitimately "working slowly" — but still
+	// reporting progress — is never falsely reclaimed. Matches the relay's own
+	// 30-minute MAX_TASK_DURATION_MS watchdog so the hub backstop fires no earlier
+	// than the relay's own give-up point.
+	wsTaskTimeout = 30 * time.Minute
 	// wsTokenTTL is how long a minted scoped GitHub token stays valid. It must
 	// match the token_expires_at we advertise to the relay so both sides agree
 	// on when the token dies.
@@ -66,8 +78,25 @@ type ContributorConnection struct {
 	role        string // empty = task-driven mode, "scanner"/"reviewer"/etc. = role mode
 	connectedAt time.Time
 	currentTask *WSTaskAssign
-	lastPong    time.Time
-	tmuxOutput  []string
+	// currentTaskGen is the assignment GENERATION stamped on currentTask (kubestellar/
+	// hive#2568, the Gate). It is a monotonically increasing token minted per
+	// assignment (task_assign, and the task_progress RESUME path that adopts a task).
+	// It is shipped to the relay in task_assign and echoed back on task_progress /
+	// task_complete / task_failed. When a task is released (disconnect, ready-abandon,
+	// operator requeue, or lease-TTL expiry) this is bumped, so a STALE worker that
+	// later wakes and reports completion/progress carrying the OLD generation is
+	// FENCED OUT: its message is rejected and cannot overwrite the new owner's state.
+	// Zero when no task is active (and a client that never learned a generation — an
+	// unversioned relay — reports 0, which is treated as "unstamped" and falls back to
+	// the pre-existing TaskID match, preserving backward compatibility).
+	currentTaskGen uint64
+	// lastLeaseRenew is when currentTask's hub-owned lease was last renewed
+	// (kubestellar/hive#2568): set on assignment and refreshed on every task_progress.
+	// cleanupLoop auto-releases a task whose lease has not been renewed within
+	// wsTaskTimeout. Zero when no task is active.
+	lastLeaseRenew time.Time
+	lastPong       time.Time
+	tmuxOutput     []string
 	// tokenMintedAt is when the scoped GitHub token for currentTask was last
 	// minted. The heartbeat loop uses it to re-mint and push a token_refresh
 	// once wsTokenRefreshPeriod has elapsed, before the token expires. Zero when
@@ -127,13 +156,21 @@ type WSMessage struct {
 	CLIBackend        string   `json:"cli_backend,omitempty"`
 	Model             string   `json:"model,omitempty"`
 	TaskID            string   `json:"task_id,omitempty"`
-	Kind              string   `json:"kind,omitempty"`
-	Repo              string   `json:"repo,omitempty"`
-	Number            int      `json:"number,omitempty"`
-	Title             string   `json:"title,omitempty"`
-	URL               string   `json:"url,omitempty"`
-	Labels            []string `json:"labels,omitempty"`
-	Prompt            string   `json:"prompt,omitempty"`
+	// TaskGen is the assignment GENERATION / lease token for this task (kubestellar/
+	// hive#2568, the Gate). The hub stamps it on task_assign; the relay echoes it back
+	// on task_progress / task_complete / task_failed. The hub rejects any completion or
+	// progress carrying a generation older than the currently-held one, so a worker
+	// whose task was revoked and reassigned cannot later overwrite the new owner's
+	// state. Additive: an unversioned relay omits it (0), and the hub falls back to the
+	// pre-existing TaskID match for those clients. Never a credential.
+	TaskGen uint64   `json:"task_gen,omitempty"`
+	Kind    string   `json:"kind,omitempty"`
+	Repo    string   `json:"repo,omitempty"`
+	Number  int      `json:"number,omitempty"`
+	Title   string   `json:"title,omitempty"`
+	URL     string   `json:"url,omitempty"`
+	Labels  []string `json:"labels,omitempty"`
+	Prompt  string   `json:"prompt,omitempty"`
 	// GitHubToken carries the scoped, expiring credential. As of #2537 it is
 	// NEVER populated on task_assign — the credential is split OUT of the
 	// assignment message and delivered only AFTER the task's acceptance decision,
@@ -214,10 +251,21 @@ type ActivityEntry struct {
 }
 
 type ContributeWSHub struct {
-	connections    map[string]*ContributorConnection
-	mu             sync.RWMutex
-	logger         *slog.Logger
-	seq            int
+	connections map[string]*ContributorConnection
+	mu          sync.RWMutex
+	logger      *slog.Logger
+	seq         int
+	// taskGen is the monotonically increasing source of assignment GENERATION tokens
+	// (kubestellar/hive#2568, the Gate). nextTaskGen() hands out a fresh value for
+	// every assignment and every release, so a generation is never reused across the
+	// life of the hub — a stale worker's old generation can never coincidentally match
+	// a later assignment's. It is an atomic counter (NOT guarded by mu) precisely so
+	// nextTaskGen() can be called from paths that ALREADY hold h.mu (e.g.
+	// RequeueContributorTask and reclaimExpiredLeases iterate connections under
+	// h.mu.RLock): a mu-guarded counter would deadlock (RLock-then-Lock on the same
+	// RWMutex). Lock-free is also what the -race coverage job wants — see the standing
+	// "never re-lock m.mu from a path that holds it" rule.
+	taskGen        atomic.Uint64
 	activityMu     sync.RWMutex
 	activity       []ActivityEntry
 	server         *Server
@@ -339,6 +387,17 @@ const quarantineCooldownHours = 6
 // failure. With a weight of 3 and a threshold of 3, a single permanent failure
 // quarantines the issue immediately.
 const permanentFailureWeight = 3
+
+// defaultRequeueReason is the fallback reason recorded and pushed to the client when
+// an operator requeues a held task without supplying one (kubestellar/hive#2568). A
+// non-empty reason is always recorded so the release stays auditable.
+const defaultRequeueReason = "requeued by operator"
+
+// leaseExpiredReason is the reason pushed to a relay whose task lease expired without
+// progress (kubestellar/hive#2568). It is distinct from the operator-requeue reason so
+// an operator reading the activity log can tell a manual release from the automatic
+// backstop.
+const leaseExpiredReason = "task lease expired (no progress within lease TTL)"
 
 func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 	hub := &ContributeWSHub{
@@ -867,17 +926,34 @@ func (h *ContributeWSHub) recentFailureCount(repo string, number int) int {
 //     it clears its local currentTask, stops progress reporting, and sends "ready")
 //     so the wedged relay stops cleanly and re-asks for work.
 //
-// It does NOT mint or rotate any token, does NOT change trust, and does NOT
-// implement the deferred lease/generation-token guarantee (a truly stale worker that
-// later reconnects and reports completion is out of scope for this slice — the
-// cooldown is the safe interim). Synthetic pr-review tasks carry Number == 0 and are
-// released without booking an issue-key cooldown, exactly like the disconnect path.
+// It does NOT mint or rotate any token and does NOT change trust. It DOES now bump
+// the connection's assignment generation on release (the deferred lease/generation
+// guarantee, delivered here — see step 4 below), so a truly stale worker that later
+// reports completion on the same socket is fenced out. Synthetic pr-review tasks
+// carry Number == 0 and are released without booking an issue-key cooldown, exactly
+// like the disconnect path.
+//
+//  4. bump the connection's currentTaskGen (kubestellar/hive#2568, the Gate) so a
+//     late completion/progress from the revoked worker echoing the OLD generation is
+//     rejected by the task_complete/task_progress/task_failed guards and cannot
+//     overwrite the new owner's state.
 //
 // It returns the number of held sessions that were released so the caller can 404 a
 // contributor that has no in-flight task (nothing to requeue) versus report success.
-func (h *ContributeWSHub) RequeueContributorTask(contributorID string) int {
+//
+// #2568 completion: each release now BUMPS the connection's assignment generation
+// (the Gate), so a revoked worker that later wakes and reports completion/progress
+// carrying the OLD generation is fenced out and cannot overwrite the new owner's
+// state. The operator-supplied reason is recorded in the activity log and pushed to
+// the (still-connected) client on the task_revoke message so the worker learns WHY
+// its task was released. A blank reason falls back to the default recovery label.
+func (h *ContributeWSHub) RequeueContributorTask(contributorID, reason string) int {
 	if contributorID == "" {
 		return 0
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = defaultRequeueReason
 	}
 	// Collect the connections + their held tasks under the connection lock, but do
 	// the network send (task_revoke) OUTSIDE h.mu to avoid holding the hub lock
@@ -901,6 +977,10 @@ func (h *ContributeWSHub) RequeueContributorTask(contributorID string) int {
 			// so it cannot leak to the (now task-less) connection.
 			c.pendingToken = ""
 			c.credentialDelivered = false
+			// #2568 (the Gate): fence the revoked worker — bump the generation so its
+			// later completion/progress echoing the old generation is rejected.
+			c.currentTaskGen = h.nextTaskGen()
+			c.lastLeaseRenew = time.Time{}
 			targets = append(targets, releaseTarget{conn: c, task: released})
 		}
 		c.mu.Unlock()
@@ -923,17 +1003,22 @@ func (h *ContributeWSHub) RequeueContributorTask(contributorID string) int {
 			"task", tgt.task.TaskID,
 			"repo", tgt.task.Repo,
 			"number", tgt.task.Number,
+			"reason", reason,
 		)
-		h.addActivity(username, "requeued by operator", tgt.conn.role, tgt.conn.cliBackend, tgt.conn.model, tgt.task.TaskID)
+		// #2568: record the operator's reason in the activity log so the release is
+		// auditable (the reason rides in the Task field alongside the task id).
+		h.addActivity(username, "requeued by operator: "+reason, tgt.conn.role, tgt.conn.cliBackend, tgt.conn.model, tgt.task.TaskID)
 		// Push the EXISTING task_revoke message so the relay stops cleanly and
 		// re-readies. Best-effort: if the socket is already gone the disconnect path
-		// has (or will) release it anyway; the cooldown above is already booked.
+		// has (or will) release it anyway; the cooldown above is already booked. The
+		// operator's reason travels on Reason so a still-connected worker learns WHY
+		// its task was released (kubestellar/hive#2568).
 		if tgt.conn.ws != nil {
 			_ = sendJSON(tgt.conn.ws, WSMessage{
 				Type:   "task_revoke",
 				Seq:    h.nextSeq(),
 				TaskID: tgt.task.TaskID,
-				Reason: "requeued by operator",
+				Reason: reason,
 			})
 		}
 	}
@@ -946,6 +1031,40 @@ func (h *ContributeWSHub) nextSeq() int {
 	s := h.seq
 	h.mu.Unlock()
 	return s
+}
+
+// nextTaskGen hands out a fresh, never-reused assignment GENERATION token
+// (kubestellar/hive#2568, the Gate). It is minted for every task_assign, every
+// task-adopting task_progress RESUME, and every release (disconnect, ready-abandon,
+// operator requeue, lease-TTL expiry) — bumping on release is what fences a
+// stale worker: the connection's currentTaskGen advances past whatever the stale
+// worker still believes it holds. Monotonic (atomic, lock-free — see the taskGen
+// field), so generations are strictly increasing across the life of the hub.
+func (h *ContributeWSHub) nextTaskGen() uint64 {
+	// Lock-free: atomic increment so this is safe to call from paths that already hold
+	// h.mu (RequeueContributorTask / reclaimExpiredLeases run under h.mu.RLock). See
+	// the taskGen field comment for why a mu-guarded counter would deadlock here.
+	return h.taskGen.Add(1)
+}
+
+// generationAccepted reports whether a client message carrying clientGen (the
+// TaskGen it echoed) may act on a connection whose current task generation is
+// currentGen (kubestellar/hive#2568, the Gate). The rule:
+//
+//   - clientGen == 0 → an UNVERSIONED relay that never learned a generation. Accept
+//     it and let the caller's pre-existing TaskID match decide, preserving backward
+//     compatibility with relays that predate the lease token.
+//   - clientGen == currentGen → the current owner. Accept.
+//   - clientGen != currentGen → a STALE worker whose task was released/reassigned
+//     (the connection's generation was bumped past it). REJECT, so its completion or
+//     progress cannot overwrite the new owner's state.
+//
+// The caller MUST hold c.mu (currentTaskGen is read under it).
+func generationAccepted(clientGen, currentGen uint64) bool {
+	if clientGen == 0 {
+		return true
+	}
+	return clientGen == currentGen
 }
 
 func (h *ContributeWSHub) ActiveCount() int {
@@ -1246,6 +1365,10 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			contributor.mu.Lock()
 			abandonedTask := contributor.currentTask
 			contributor.currentTask = nil
+			// #2568: bump the generation on release so any late message from this
+			// now-defunct socket carrying the old generation is fenced.
+			contributor.currentTaskGen = h.nextTaskGen()
+			contributor.lastLeaseRenew = time.Time{}
 			contributor.tokenMintedAt = time.Time{}
 			// #2537: clear any pending/delivered credential state with the task.
 			contributor.pendingToken = ""
@@ -1440,6 +1563,10 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			contributor.mu.Lock()
 			abandoned := contributor.currentTask
 			contributor.currentTask = nil
+			// #2568: bump the generation on release so a re-`ready` abandon fences any
+			// later message echoing the old generation for the just-abandoned task.
+			contributor.currentTaskGen = h.nextTaskGen()
+			contributor.lastLeaseRenew = time.Time{}
 			contributor.tokenMintedAt = time.Time{}
 			// #2537: clear any pending/delivered credential state with the task.
 			contributor.pendingToken = ""
@@ -1550,6 +1677,22 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 		case "task_progress":
 			if contributor != nil {
 				contributor.mu.Lock()
+				// #2568 (the Gate): a worker still holding a task whose progress carries
+				// a STALE generation was revoked/reassigned — its currentTaskGen was
+				// bumped past what it echoes. Reject its progress so it cannot renew a
+				// lease it no longer owns or resurrect ownership state. An unversioned
+				// relay echoes 0 and is accepted (generationAccepted falls back to the
+				// TaskID identity below).
+				if contributor.currentTask != nil && !generationAccepted(msg.TaskGen, contributor.currentTaskGen) {
+					staleGen := msg.TaskGen
+					contributor.mu.Unlock()
+					h.logger.Warn("[contribute-ws] stale-generation task_progress rejected",
+						"username", contributor.profile.GitHubUsername,
+						"task", msg.TaskID,
+						"client_gen", staleGen,
+					)
+					continue
+				}
 				contributor.tmuxOutput = msg.TmuxOutput
 				// resumed is true only when this task_progress REBUILT currentTask
 				// from nothing — i.e. the relay is re-asserting a task the hub had
@@ -1573,6 +1716,16 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 						Title:  msg.Title,
 					}
 					resumed = true
+					// #2568: a RESUME adopts the task under a FRESH generation so the
+					// hub, not the client, owns the authoritative token from here on.
+					contributor.currentTaskGen = h.nextTaskGen()
+				}
+				// #2568: renew the hub-owned lease on every progress report. This is
+				// what distinguishes "working slowly but alive" (lease keeps renewing,
+				// never reclaimed) from "connected but wedged" (lease goes stale and
+				// cleanupLoop reclaims it after wsTaskTimeout).
+				if contributor.currentTask != nil {
+					contributor.lastLeaseRenew = time.Now()
 				}
 				contributor.mu.Unlock()
 
@@ -1594,6 +1747,23 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 		case "task_complete":
 			if contributor != nil {
 				contributor.mu.Lock()
+				// #2568 (the Gate, critical guarantee): a worker whose task was revoked
+				// and reassigned — but that later wakes and reports completion carrying
+				// the OLD generation — must NOT overwrite the new owner's state. Its
+				// currentTaskGen was bumped past what it echoes, so reject the message
+				// WITHOUT clearing currentTask (which may now hold the NEW owner's task).
+				// An unversioned relay echoes 0 and is accepted, falling back to the
+				// TaskID identity match below. Checked before any mutation.
+				if contributor.currentTask != nil && !generationAccepted(msg.TaskGen, contributor.currentTaskGen) {
+					staleGen := msg.TaskGen
+					contributor.mu.Unlock()
+					h.logger.Warn("[contribute-ws] stale-generation task_complete rejected",
+						"username", contributor.profile.GitHubUsername,
+						"task", msg.TaskID,
+						"client_gen", staleGen,
+					)
+					continue
+				}
 				hasTask := contributor.currentTask != nil && contributor.currentTask.TaskID == msg.TaskID
 				completedTask := contributor.currentTask
 				contributor.currentTask = nil
@@ -1685,6 +1855,22 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 		case "task_failed":
 			if contributor != nil {
 				contributor.mu.Lock()
+				// #2568 (the Gate): reject a STALE worker's failure the same way as its
+				// completion — its currentTaskGen was bumped past the generation it
+				// echoes. Left unguarded, a revoked worker's late task_failed would book
+				// a spurious failure cooldown against the NEW owner's issue. Do not clear
+				// currentTask (it may now be the new owner's task). Unversioned relays
+				// echo 0 and fall back to the TaskID match below.
+				if contributor.currentTask != nil && !generationAccepted(msg.TaskGen, contributor.currentTaskGen) {
+					staleGen := msg.TaskGen
+					contributor.mu.Unlock()
+					h.logger.Warn("[contribute-ws] stale-generation task_failed rejected",
+						"username", contributor.profile.GitHubUsername,
+						"task", msg.TaskID,
+						"client_gen", staleGen,
+					)
+					continue
+				}
 				hasTask := contributor.currentTask != nil && contributor.currentTask.TaskID == msg.TaskID
 				failedTask := contributor.currentTask
 				contributor.currentTask = nil
@@ -1978,6 +2164,13 @@ func (h *ContributeWSHub) cleanupLoop() {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 	for range ticker.C {
+		// #2568: reclaim wedged-but-connected task leases first (the backstop). A
+		// connection whose lastPong is still fresh (so the heartbeat sweep below will
+		// NOT remove it) but that has stopped renewing its task lease is exactly the
+		// "connected but wedged" case the issue describes; this releases its task
+		// through the SAME cooldown+generation-bump path a manual requeue uses.
+		h.reclaimExpiredLeases(time.Now())
+
 		h.mu.Lock()
 		for id, c := range h.connections {
 			c.mu.Lock()
@@ -2002,6 +2195,73 @@ func (h *ContributeWSHub) cleanupLoop() {
 		}
 		h.mu.Unlock()
 	}
+}
+
+// reclaimExpiredLeases is the hub-owned LEASE-TTL backstop (kubestellar/hive#2568,
+// option 4). A connection that is still HELD by its socket (heartbeat alive) but has
+// not renewed its task lease within wsTaskTimeout is presumed wedged — connected but
+// no longer progressing — and its task is auto-released. It reuses EXACTLY the manual
+// requeue machinery: it books the same short failure cooldown (so the released issue
+// is not instantly re-admissible and can't recreate the #2492 dup-assign race), bumps
+// the assignment generation (the Gate — so the wedged worker, if it later wakes, is
+// fenced), and pushes task_revoke with an auto-expiry reason so a still-listening
+// relay stops cleanly. It is deliberately CONSERVATIVE: a task that keeps reporting
+// task_progress renews lastLeaseRenew every report and is therefore NEVER reclaimed,
+// so "working slowly but alive" is not confused with "wedged". `now` is injected so
+// tests can drive expiry deterministically.
+func (h *ContributeWSHub) reclaimExpiredLeases(now time.Time) int {
+	type expiredTarget struct {
+		conn *ContributorConnection
+		task WSTaskAssign
+	}
+	var targets []expiredTarget
+	h.mu.RLock()
+	for _, c := range h.connections {
+		c.mu.Lock()
+		// Only a connection actively holding a task with a started lease clock can
+		// expire; a zero lastLeaseRenew means no active lease (idle or just released).
+		expired := c.currentTask != nil && !c.lastLeaseRenew.IsZero() &&
+			now.Sub(c.lastLeaseRenew) > wsTaskTimeout
+		if expired {
+			released := *c.currentTask
+			c.currentTask = nil
+			c.currentPrompt = ""
+			c.currentLabels = nil
+			c.tokenMintedAt = time.Time{}
+			c.currentTaskGen = h.nextTaskGen()
+			c.lastLeaseRenew = time.Time{}
+			targets = append(targets, expiredTarget{conn: c, task: released})
+		}
+		c.mu.Unlock()
+	}
+	h.mu.RUnlock()
+
+	for _, tgt := range targets {
+		if tgt.task.Number > 0 {
+			h.recordTaskFailure(tgt.task.Repo, tgt.task.Number, false)
+		}
+		username := ""
+		if tgt.conn.profile != nil {
+			username = tgt.conn.profile.GitHubUsername
+		}
+		h.logger.Warn("[contribute-ws] task lease expired, auto-released",
+			"username", username,
+			"task", tgt.task.TaskID,
+			"repo", tgt.task.Repo,
+			"number", tgt.task.Number,
+			"lease_ttl", wsTaskTimeout.String(),
+		)
+		h.addActivity(username, "lease expired: auto-released", tgt.conn.role, tgt.conn.cliBackend, tgt.conn.model, tgt.task.TaskID)
+		if tgt.conn.ws != nil {
+			_ = sendJSON(tgt.conn.ws, WSMessage{
+				Type:   "task_revoke",
+				Seq:    h.nextSeq(),
+				TaskID: tgt.task.TaskID,
+				Reason: leaseExpiredReason,
+			})
+		}
+	}
+	return len(targets)
 }
 
 // mintScopedToken produces a scoped GitHub token for the given trust tier via
@@ -2638,6 +2898,11 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	// $HIVE_WORKSPACE_DIR rather than a fork-only --clone=false).
 	prompt := buildTaskPrompt(chosen.repoFull, chosen.number, chosen.title)
 
+	// #2568: mint a fresh assignment generation for this task. It is stamped on the
+	// connection, shipped in task_assign below, and echoed back by the relay so a
+	// later stale-worker completion carrying an older generation is fenced out.
+	gen := h.nextTaskGen()
+
 	c.mu.Lock()
 	c.currentTask = &WSTaskAssign{
 		TaskID: taskID,
@@ -2646,6 +2911,10 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		Number: chosen.number,
 		Title:  chosen.title,
 	}
+	c.currentTaskGen = gen
+	// #2568: start the hub-owned lease clock. task_progress renews it; cleanupLoop
+	// auto-releases the task if it is not renewed within wsTaskTimeout.
+	c.lastLeaseRenew = time.Now()
 	// Store the prompt (never the token) so FleetSnapshot can preview it (#2539),
 	// and clear any stale idle reason now that this connection has real work.
 	c.currentPrompt = prompt
@@ -2673,20 +2942,22 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	h.recordAssignment(identityOf(c), time.Now())
 
 	return &WSMessage{
-		Type:   "task_assign",
-		Seq:    h.nextSeq(),
-		TaskID: taskID,
-		Kind:   "issue",
-		Repo:   chosen.repoFull,
-		Number: chosen.number,
-		Title:  chosen.title,
-		URL:    chosen.url,
+		Type:    "task_assign",
+		Seq:     h.nextSeq(),
+		TaskID:  taskID,
+		TaskGen: gen,
+		Kind:    "issue",
+		Repo:    chosen.repoFull,
+		Number:  chosen.number,
+		Title:   chosen.title,
+		URL:     chosen.url,
 		// #2537: NO github_token / token_expires_at here. The scoped credential is
 		// split out of task_assign and delivered only after acceptance (see
 		// pendingToken / deliverTaskCredential). task_assign now carries exactly the
-		// metadata needed to DECIDE — repo/number/title/url/labels/prompt — and no
-		// credential, so nothing an agent could act on is authenticated until the
-		// task's source has been accepted under the operator/contributor policy.
+		// metadata needed to DECIDE — repo/number/title/url/labels/prompt — plus the
+		// #2568 TaskGen lease token, and no credential, so nothing an agent could act
+		// on is authenticated until the task's source has been accepted under the
+		// operator/contributor policy.
 		Prompt: prompt,
 		// The chosen issue's own labels — the Labels envelope field was declared
 		// but never populated, so a client reading it got nothing (kubestellar/

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -2376,8 +2376,14 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	h.logger.Info("[contribute-ws] selectTask scanning", "repos", len(status.Repos), "totalIssues", totalAvailable, "cooldown", len(h.completedTasks), "active", len(activeIssues))
 
 	var disabledRepos []string
+	var heldIssues map[string]struct{}
 	if h.server.deps != nil && h.server.deps.Config != nil {
 		disabledRepos = h.server.deps.Config.Hub.DisabledRepos
+		// Operator HOLD (#queue-hold): a manually-parked issue must never be offered,
+		// indefinitely, until the operator Resumes it. Built once per selectTask from
+		// the same canonical "%s#%d" keys the cooldown/active/failure checks use, so
+		// the exclusion cannot miss on a repo-name spelling mismatch (#2648).
+		heldIssues = queueHoldSet(h.server.deps.Config.Hub.ContributeQueueHold)
 	}
 
 	// --- Collect the eligible candidates, then order them (#2390) ---------------
@@ -2465,6 +2471,13 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 			}
 			if number == 0 {
 				h.logger.Info("[contribute-ws] skip: number=0", "repo", repo.Full)
+				continue
+			}
+			// Operator HOLD (#queue-hold): skip a manually-parked issue outright. This
+			// is a persistent operator decision, DISTINCT from the time-based cooldown
+			// below — a held issue never becomes a candidate until the operator Resumes
+			// it. Keyed on the same canonical "%s#%d" as every other exclusion.
+			if _, isHeld := heldIssues[fmt.Sprintf("%s#%d", repo.Full, number)]; isHeld {
 				continue
 			}
 			if h.isTaskInCooldown(repo.Full, number) {

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -1315,6 +1315,42 @@ func (h *ContributeWSHub) FleetSnapshot() FleetSnapshot {
 	return snap
 }
 
+// CooldownCounts returns two read-only tallies the Operations/Management tabs
+// surface next to the ready queue (see handleContributeFleet):
+//
+//   - cooldown: how many completed issues are STILL within their cooldown window
+//     and therefore held out of selection. It counts only NON-expired entries in
+//     completedTasks (an entry past its cooldownForLocked() period is expired-but-
+//     not-yet-swept and must not inflate the count — it matches what
+//     isTaskInCooldown would actually gate). When cooldown is disabled by the
+//     operator kill-switch (cooldownEnabled()==false), nothing is gated, so this
+//     is 0.
+//   - inFlight: how many distinct issues are currently held by a live
+//     connection — reuses activeIssueKeys(), the SAME set selectTask uses as its
+//     double-assign guard and ReadyQueue uses to exclude in-flight work.
+//
+// Read-only: it mutates nothing (unlike isTaskInCooldown it does not sweep
+// expired entries) and adds no enforcement.
+func (h *ContributeWSHub) CooldownCounts() (cooldown, inFlight int) {
+	// cooldown: count non-expired completedTasks under the completion lock. When the
+	// operator kill-switch disables cooldown, nothing is gated, so the count is 0.
+	if h.cooldownEnabled() {
+		h.completedMu.Lock()
+		for key, t := range h.completedTasks {
+			if time.Since(t) <= h.cooldownForLocked(key) {
+				cooldown++
+			}
+		}
+		h.completedMu.Unlock()
+	}
+
+	// inFlight: distinct issues held by a live connection — the same activeIssues
+	// set selectTask's guard and ReadyQueue use, so the header count matches what is
+	// actually excluded from "ready".
+	inFlight = len(h.activeIssueKeys())
+	return cooldown, inFlight
+}
+
 func (h *ContributeWSHub) ActiveConnections() []ContributorConnection {
 	h.mu.RLock()
 	defer h.mu.RUnlock()

--- a/v2/pkg/dashboard/contribute_ws_credential_accept_test.go
+++ b/v2/pkg/dashboard/contribute_ws_credential_accept_test.go
@@ -1,0 +1,350 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// Credential-after-acceptance (kubestellar/hive#2537).
+//
+// The contributor's scoped GitHub credential used to travel INSIDE the
+// task_assign message, so an agent received "here is who authored the work" and
+// "here is a credential" before any acceptance decision. These tests pin the new
+// contract: task_assign carries only the DECIDE metadata (repo/number/title/url/
+// labels/prompt) and NO github_token, and the scoped, expiring token is delivered
+// (via the token_refresh wire shape) only AFTER the task's acceptance decision —
+// automatically in the default auto-accept mode, or on an explicit task_accepted
+// in the opt-in explicit mode. The token itself is unchanged: same per-tier mint,
+// same wsTokenTTL expiry — only its timing moved.
+//
+// All state exercised here is per-ContributorConnection (pendingToken /
+// credentialDelivered); no package-global is mutated, so the -race coverage job
+// (#2510/#2652) sees no shared write.
+
+// wsPipe stands up a real gorilla/websocket server/client pair and returns the
+// SERVER-side *websocket.Conn (what the hub writes to) plus the CLIENT conn (what
+// the relay would read). Mirrors the pattern in contribute_ws_token_refresh_test.go
+// so deliverTaskCredential / sendTokenRefresh write a real frame we can read back.
+func wsPipe(t *testing.T) (server *websocket.Conn, client *websocket.Conn) {
+	t.Helper()
+	connReady := make(chan struct{})
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		server = c
+		close(connReady)
+		// Keep the handler alive so the conn stays open for the reads below.
+		time.Sleep(3 * time.Second)
+	}))
+	t.Cleanup(srv.Close)
+
+	c, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	<-connReady
+	return server, c
+}
+
+// readWire reads one frame off the client and decodes it into a bare map so
+// assertions are against the ON-THE-WIRE field names (github_token,
+// token_expires_at) the relay actually consumes.
+func readWire(t *testing.T, client *websocket.Conn) map[string]any {
+	t.Helper()
+	client.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, raw, err := client.ReadMessage()
+	if err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return wire
+}
+
+// TestCredentialAccept_TaskAssignHasNoToken is the core #2537 assertion: the
+// task_assign selectTask produces carries the decide-metadata but NO credential.
+// The token is still MINTED (held pending on the connection), just not shipped in
+// the assignment.
+func TestCredentialAccept_TaskAssignHasNoToken(t *testing.T) {
+	hub, s := covK2Hub(t)
+	oneActionableIssue(s)
+	s.deps.GHAppAuth = newSucceedingAppAuth(t, "ghs_scoped_for_assign")
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "amy", ContributorID: "c-amy", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+
+	msg := hub.selectTask(conn)
+	if msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("expected a task_assign, got %+v", msg)
+	}
+
+	// The credential must NOT be in the assignment message.
+	if msg.GitHubToken != "" {
+		t.Fatalf("#2537 violated: task_assign carried a github_token (%q); it must be delivered after acceptance", msg.GitHubToken)
+	}
+	if msg.TokenExpiresAt != "" {
+		t.Fatalf("#2537: task_assign must not carry token_expires_at, got %q", msg.TokenExpiresAt)
+	}
+	// But the decide-metadata IS present.
+	if msg.Repo == "" || msg.Number == 0 || msg.Title == "" || msg.Prompt == "" {
+		t.Fatalf("task_assign should carry decide-metadata (repo/number/title/prompt), got %+v", msg)
+	}
+
+	// The token was minted and is held pending (undelivered) for post-acceptance.
+	conn.mu.Lock()
+	pending := conn.pendingToken
+	delivered := conn.credentialDelivered
+	conn.mu.Unlock()
+	if pending == "" {
+		t.Fatalf("expected the minted scoped token to be held pending on the connection")
+	}
+	if delivered {
+		t.Fatalf("credential must not be marked delivered before any acceptance")
+	}
+
+	// Also assert the raw JSON of the assignment never contains a token — a
+	// defense against a future field re-introducing it on the wire.
+	blob, _ := json.Marshal(msg)
+	if strings.Contains(string(blob), "github_token") || strings.Contains(string(blob), "ghs_") {
+		t.Fatalf("task_assign JSON leaked a credential:\n%s", string(blob))
+	}
+}
+
+// TestCredentialAccept_DeliverAfterAcceptance verifies the post-acceptance
+// delivery: deliverTaskCredential ships the SAME scoped token via the
+// token_refresh wire shape (github_token + token_expires_at, ~wsTokenTTL out), and
+// flips credentialDelivered so the ordering "acceptance recorded, THEN credential
+// sent" is observable and idempotent.
+func TestCredentialAccept_DeliverAfterAcceptance(t *testing.T) {
+	hub := &ContributeWSHub{logger: covBLogger()}
+	server, client := wsPipe(t)
+
+	const scoped = "ghs_scoped_delivered_after_accept"
+	conn := &ContributorConnection{
+		ws:           server,
+		profile:      &ContributorProfile{TrustTier: "contributor", GitHubUsername: "ben"},
+		currentTask:  &WSTaskAssign{TaskID: "ct-1"},
+		pendingToken: scoped,
+	}
+
+	before := time.Now()
+	if ok := hub.deliverTaskCredential(conn, "auto_accept"); !ok {
+		t.Fatalf("deliverTaskCredential should have delivered the pending token")
+	}
+
+	wire := readWire(t, client)
+	if wire["type"] != "token_refresh" {
+		t.Fatalf("credential must be delivered via the token_refresh wire shape, got type=%v", wire["type"])
+	}
+	if wire["github_token"] != scoped {
+		t.Fatalf("delivered token = %v, want the SAME scoped token %q", wire["github_token"], scoped)
+	}
+	expStr, _ := wire["token_expires_at"].(string)
+	exp, err := time.Parse(time.RFC3339, expStr)
+	if err != nil {
+		t.Fatalf("token_expires_at missing/unparseable: %v", wire["token_expires_at"])
+	}
+	// Still expiring on the same TTL as before — the token is unchanged, only its
+	// timing moved.
+	wantExp := before.Add(wsTokenTTL)
+	if exp.Before(wantExp.Add(-2*time.Minute)) || exp.After(wantExp.Add(2*time.Minute)) {
+		t.Fatalf("delivered token expiry %v not ~wsTokenTTL (%s) out from send", exp, wsTokenTTL)
+	}
+
+	// Delivery is recorded and the pending token consumed.
+	conn.mu.Lock()
+	delivered := conn.credentialDelivered
+	pending := conn.pendingToken
+	conn.mu.Unlock()
+	if !delivered {
+		t.Fatalf("credentialDelivered must be set after delivery")
+	}
+	if pending != "" {
+		t.Fatalf("pendingToken must be cleared after delivery, got %q", pending)
+	}
+
+	// Idempotent: a second call (e.g. a duplicate task_accepted) delivers nothing.
+	if ok := hub.deliverTaskCredential(conn, "explicit_accept"); ok {
+		t.Fatalf("deliverTaskCredential must be a no-op once the credential was delivered")
+	}
+}
+
+// TestCredentialAccept_AutoAcceptDefaultOrdering exercises the DEFAULT
+// (auto-accept) mode end to end through the same seams the ready handler uses:
+// selectTask holds the credential pending, then — because the hub is NOT in
+// explicit mode — the credential is delivered immediately, with NO human step, and
+// the ordering is provable (task assigned/pending BEFORE the credential is sent).
+func TestCredentialAccept_AutoAcceptDefaultOrdering(t *testing.T) {
+	hub, s := covK2Hub(t)
+	oneActionableIssue(s)
+	s.deps.GHAppAuth = newSucceedingAppAuth(t, "ghs_auto_accept_scoped")
+
+	// Default config: explicit-accept unset → auto-accept.
+	if hub.requireExplicitAccept() {
+		t.Fatalf("default mode must be auto-accept (explicit-accept off)")
+	}
+
+	server, client := wsPipe(t)
+	conn := &ContributorConnection{
+		ws:       server,
+		profile:  &ContributorProfile{GitHubUsername: "cara", ContributorID: "c-cara", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+
+	msg := hub.selectTask(conn)
+	if msg == nil || msg.Type != "task_assign" || msg.GitHubToken != "" {
+		t.Fatalf("expected a credential-free task_assign, got %+v", msg)
+	}
+
+	// Acceptance is automatic — the ready handler calls deliverTaskCredential right
+	// after sending task_assign. Model that here: the assignment is already
+	// committed to the connection (currentTask + pendingToken set), THEN deliver.
+	conn.mu.Lock()
+	haveTask := conn.currentTask != nil
+	havePending := conn.pendingToken != ""
+	deliveredBefore := conn.credentialDelivered
+	conn.mu.Unlock()
+	if !haveTask || !havePending {
+		t.Fatalf("assignment must be recorded (task+pending) before credential delivery")
+	}
+	if deliveredBefore {
+		t.Fatalf("credential must not be delivered before the (auto)acceptance step")
+	}
+
+	if ok := hub.deliverTaskCredential(conn, "auto_accept"); !ok {
+		t.Fatalf("auto-accept should deliver the credential")
+	}
+	wire := readWire(t, client)
+	if wire["type"] != "token_refresh" || wire["github_token"] != "ghs_auto_accept_scoped" {
+		t.Fatalf("auto-accept must deliver the scoped token via token_refresh, got %v", wire)
+	}
+}
+
+// TestCredentialAccept_ExplicitModeWithholdsUntilAccept covers the opt-in
+// explicit-accept mode: the credential is withheld at assignment time and
+// delivered only when a matching task_accepted arrives; a task that is never
+// accepted never receives a credential, and a task_accepted for a DIFFERENT
+// task_id is ignored.
+func TestCredentialAccept_ExplicitModeWithholdsUntilAccept(t *testing.T) {
+	hub, s := covK2Hub(t)
+	oneActionableIssue(s)
+	s.deps.GHAppAuth = newSucceedingAppAuth(t, "ghs_explicit_scoped")
+
+	// Opt into explicit acceptance.
+	explicit := true
+	s.deps.Config.Hub.ContributeRequireExplicitAccept = &explicit
+	if !hub.requireExplicitAccept() {
+		t.Fatalf("explicit-accept mode should be on after setting the toggle")
+	}
+
+	server, client := wsPipe(t)
+	conn := &ContributorConnection{
+		ws:       server,
+		profile:  &ContributorProfile{GitHubUsername: "dan", ContributorID: "c-dan", TrustTier: "trusted"},
+		lastPong: time.Now(),
+	}
+
+	msg := hub.selectTask(conn)
+	if msg == nil || msg.Type != "task_assign" || msg.GitHubToken != "" {
+		t.Fatalf("expected a credential-free task_assign, got %+v", msg)
+	}
+	assignedTaskID := msg.TaskID
+
+	// In explicit mode the ready handler does NOT auto-deliver: the credential is
+	// still pending and undelivered.
+	conn.mu.Lock()
+	pending := conn.pendingToken
+	delivered := conn.credentialDelivered
+	conn.mu.Unlock()
+	if pending == "" || delivered {
+		t.Fatalf("explicit mode must withhold: pending=%q delivered=%v", pending, delivered)
+	}
+
+	// A task_accepted for the WRONG task must NOT release the credential.
+	if ok := hub.acceptTaskCredential(conn, "ct-some-other-task"); ok {
+		t.Fatalf("a mismatched task_accepted must not deliver the credential")
+	}
+	conn.mu.Lock()
+	stillPending := conn.pendingToken != "" && !conn.credentialDelivered
+	conn.mu.Unlock()
+	if !stillPending {
+		t.Fatalf("credential must remain withheld after a mismatched task_accepted")
+	}
+
+	// The MATCHING task_accepted delivers the scoped token.
+	if ok := hub.acceptTaskCredential(conn, assignedTaskID); !ok {
+		t.Fatalf("matching task_accepted should deliver the credential")
+	}
+	wire := readWire(t, client)
+	if wire["type"] != "token_refresh" || wire["github_token"] != "ghs_explicit_scoped" {
+		t.Fatalf("explicit acceptance must deliver the scoped token via token_refresh, got %v", wire)
+	}
+}
+
+// TestCredentialAccept_NeverAcceptedNeverGetsCredential proves the negative: a
+// task assigned in explicit mode that is never accepted (the client declines or
+// times out) never has its credential delivered — nothing is ever written to the
+// wire, and the pending token stays undelivered.
+func TestCredentialAccept_NeverAcceptedNeverGetsCredential(t *testing.T) {
+	hub, s := covK2Hub(t)
+	oneActionableIssue(s)
+	s.deps.GHAppAuth = newSucceedingAppAuth(t, "ghs_never_delivered")
+	explicit := true
+	s.deps.Config.Hub.ContributeRequireExplicitAccept = &explicit
+
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "eve", ContributorID: "c-eve", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	if msg := hub.selectTask(conn); msg == nil || msg.GitHubToken != "" {
+		t.Fatalf("expected a credential-free task_assign, got %+v", msg)
+	}
+
+	// No task_accepted ever arrives. The credential stays pending and undelivered.
+	conn.mu.Lock()
+	pending := conn.pendingToken
+	delivered := conn.credentialDelivered
+	conn.mu.Unlock()
+	if pending == "" {
+		t.Fatalf("token should have been minted and held pending")
+	}
+	if delivered {
+		t.Fatalf("a never-accepted task must never have its credential delivered")
+	}
+}
+
+// TestCredentialAccept_ModeResolver pins the backward-compatible default of the
+// operator toggle: nil (older on-disk config) resolves to auto-accept, matching a
+// running fleet's prior behavior; an explicit true opts into the wait state.
+func TestCredentialAccept_ModeResolver(t *testing.T) {
+	var h config.HubConfig
+	if h.IsContributeRequireExplicitAccept() {
+		t.Fatalf("unset toggle must default to auto-accept (false)")
+	}
+	f := false
+	h.ContributeRequireExplicitAccept = &f
+	if h.IsContributeRequireExplicitAccept() {
+		t.Fatalf("explicit false must resolve to auto-accept")
+	}
+	tr := true
+	h.ContributeRequireExplicitAccept = &tr
+	if !h.IsContributeRequireExplicitAccept() {
+		t.Fatalf("explicit true must resolve to explicit-accept")
+	}
+}

--- a/v2/pkg/dashboard/contribute_ws_ops_ext_test.go
+++ b/v2/pkg/dashboard/contribute_ws_ops_ext_test.go
@@ -185,3 +185,72 @@ func TestPromptPreview_SurfacesPromptAndMetadata_NoToken(t *testing.T) {
 		t.Fatalf("prompt-preview snapshot leaked a github_token:\n%s", blob)
 	}
 }
+
+// --- #2677: fleet-wide operator visibility into per-contributor label
+// interests (#2637) ----------------------------------------------------------
+
+// TestFleetSnapshot_LabelInterestsSurfaced (#2677) asserts a connected
+// contributor's own opt-in label interests are mirrored onto their
+// FleetClanker entry, so the operator fleet view (GET /api/contribute/fleet)
+// carries the same data the contributor already sees on themselves — without
+// requiring a second lookup against /api/contributors.
+func TestFleetSnapshot_LabelInterestsSurfaced(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	conn := &ContributorConnection{
+		profile: &ContributorProfile{
+			GitHubUsername: "priya", ContributorID: "c-priya", TrustTier: "contributor",
+			LabelInterests: []string{"nvidia", "gpu"},
+		},
+		lastPong: time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["conn-priya"] = conn
+	hub.mu.Unlock()
+
+	snap := hub.FleetSnapshot()
+	if len(snap.Clankers) != 1 {
+		t.Fatalf("expected 1 clanker, got %d", len(snap.Clankers))
+	}
+	fc := snap.Clankers[0]
+	if len(fc.LabelInterests) != 2 || fc.LabelInterests[0] != "nvidia" || fc.LabelInterests[1] != "gpu" {
+		t.Fatalf("label_interests mismatch: got %+v", fc.LabelInterests)
+	}
+
+	raw, err := json.Marshal(fc)
+	if err != nil {
+		t.Fatalf("marshal clanker: %v", err)
+	}
+	if !strings.Contains(string(raw), `"label_interests":["nvidia","gpu"]`) {
+		t.Fatalf("marshaled clanker missing label_interests: %s", raw)
+	}
+}
+
+// TestFleetSnapshot_LabelInterestsOmittedWhenEmpty (#2677) asserts a
+// contributor with no declared interests produces no label_interests field
+// (omitempty) rather than an empty array, matching how capabilities/idle_reason
+// already omit themselves when there is nothing to show.
+func TestFleetSnapshot_LabelInterestsOmittedWhenEmpty(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "quinn", ContributorID: "c-quinn", TrustTier: "newcomer"},
+		lastPong: time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["conn-quinn"] = conn
+	hub.mu.Unlock()
+
+	snap := hub.FleetSnapshot()
+	if len(snap.Clankers) != 1 {
+		t.Fatalf("expected 1 clanker, got %d", len(snap.Clankers))
+	}
+	if len(snap.Clankers[0].LabelInterests) != 0 {
+		t.Fatalf("expected no label interests, got %+v", snap.Clankers[0].LabelInterests)
+	}
+	raw, err := json.Marshal(snap.Clankers[0])
+	if err != nil {
+		t.Fatalf("marshal clanker: %v", err)
+	}
+	if strings.Contains(string(raw), "label_interests") {
+		t.Fatalf("label_interests should be omitted when empty: %s", raw)
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -168,6 +168,14 @@ type Server struct {
 	contributeMetricsOnce sync.Once
 	contributeMetrics     *metricsStore
 
+	// contributePRLink is the live, best-effort PR→issue link projection behind the
+	// Operations triage view + queue PR badges (#2612 part c). It memoises "does a
+	// Fixes/Closes PR exist for owner/repo#number, open or merged?" behind a short
+	// TTL over the hive's existing GitHub client — NO new persistent store. Lazily
+	// built via contributePRLinkResolver(); see contribute_prlink.go.
+	contributePRLinkOnce sync.Once
+	contributePRLink     *prLinkResolver
+
 	inferenceMu        sync.RWMutex
 	inferenceEndpoints map[string][]string // backend id → list of base URLs
 

--- a/v2/pkg/hub/impersonate_cookie.go
+++ b/v2/pkg/hub/impersonate_cookie.go
@@ -1,0 +1,135 @@
+package hub
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Admin read-only "View as user" impersonation.
+//
+// A separate, short-lived, signed cookie (`hive_hub_impersonate`) lets the hub
+// admin — and ONLY the hub admin — see the hub dashboard exactly as another
+// registered user sees it, without ever gaining that user's privileges. The
+// impersonation is READ-ONLY: while it is active the server rejects every
+// mutating request with 403 (see requireAuth / requireAdmin), so the worst an
+// impersonating admin can do is look.
+//
+// Security properties this cookie enforces, in order of importance:
+//
+//  1. It is tamper-evident. The value is bound to the hub secret with an
+//     HMAC-SHA256 using the SAME construction as the session cookie
+//     (hub_cookie.go). A forged, edited, or unsigned value fails verification
+//     and is treated as "not impersonating" — never as an escalation.
+//  2. It carries the REAL admin login it was minted for. resolveIdentity only
+//     honors the cookie when that admin field equals BOTH the real signed
+//     session user AND hubAdminUsername. A user cannot lift the admin's
+//     impersonation cookie onto their own session to borrow the admin's view,
+//     and the admin cannot mint one that names someone else as the actor.
+//  3. It expires. The payload carries an absolute Unix expiry (impersonateTTL
+//     from mint time); a stale cookie is ignored. This bounds how long a
+//     forgotten "View as" session can linger.
+//
+// Wire format (all in the clear except the trailing signature, exactly like the
+// session cookie — none of these fields are secret; the signature is what
+// proves the hub minted them):
+//
+//	value = <admin>|<target>|<expUnix>.<base64url(HMAC-SHA256(admin|target|expUnix, hubSecret))>
+//
+// The admin and target are GitHub logins, which loadSaaSUser already validates
+// to exclude "/" "\\" and ".." — and usernames never contain "|" or "." — so
+// the delimiters cannot be smuggled.
+
+// impersonateTTL bounds how long a single "View as" session stays valid before
+// the admin must re-enter it. Deliberately short: impersonation is an
+// intentional, supervised action, not a durable mode, and a short window limits
+// the blast radius of a forgotten session or a leaked cookie.
+const impersonateTTL = 30 * time.Minute
+
+// impersonateCookieName is the browser cookie that carries an active
+// impersonation grant. It is intentionally distinct from the session cookie
+// (hive_hub_user) so the two are minted, verified, and cleared independently:
+// exiting impersonation never disturbs the real login.
+const impersonateCookieName = "hive_hub_impersonate"
+
+// impersonateSep separates the payload fields. It is a character that cannot
+// appear in a GitHub username, so field boundaries are unambiguous.
+const impersonateSep = "|"
+
+// impersonationGrant is the decoded, verified payload of an impersonation
+// cookie. It is only ever produced by verifyImpersonateCookieValue, which
+// returns ok=false unless the signature verified.
+type impersonationGrant struct {
+	Admin  string // the real admin login the cookie was minted for
+	Target string // the user being viewed
+	Exp    int64  // absolute expiry, Unix seconds
+}
+
+// impersonatePayload is the signed portion of the cookie: the three fields
+// joined by impersonateSep. Keeping the join in one place guarantees mint and
+// verify hash byte-for-byte identical input.
+func impersonatePayload(admin, target string, exp int64) string {
+	return admin + impersonateSep + target + impersonateSep + strconv.FormatInt(exp, 10)
+}
+
+// impersonateSign returns the URL-safe base64 HMAC-SHA256 of payload under
+// secret, reusing the session cookie's encoding (hubCookieB64) so both cookies
+// share one crypto scheme.
+func impersonateSign(secret, payload string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(payload))
+	return hubCookieB64.EncodeToString(mac.Sum(nil))
+}
+
+// mintImpersonateCookieValue returns a signed impersonation cookie value that
+// records admin viewing target, expiring impersonateTTL from now. It returns ""
+// when no secret is configured or either login is empty — callers must treat
+// that as "cannot start impersonation" rather than emitting an unsigned value.
+func mintImpersonateCookieValue(secret, admin, target string, now time.Time) string {
+	if secret == "" || admin == "" || target == "" {
+		return ""
+	}
+	exp := now.Add(impersonateTTL).Unix()
+	payload := impersonatePayload(admin, target, exp)
+	return payload + "." + impersonateSign(secret, payload)
+}
+
+// verifyImpersonateCookieValue parses a cookie value, recomputes its HMAC over
+// the carried payload, and constant-time-compares it against the presented
+// signature. It returns (grant, true) ONLY when the signature verifies AND the
+// grant has not expired (checked against now). A forged, edited, unsigned,
+// malformed, or expired value returns (zero, false) so the caller treats the
+// request as NOT impersonating — the cookie can only ever be ignored, never
+// trusted-by-default.
+func verifyImpersonateCookieValue(secret, value string, now time.Time) (impersonationGrant, bool) {
+	var zero impersonationGrant
+	if secret == "" || value == "" {
+		return zero, false
+	}
+	idx := strings.LastIndex(value, ".")
+	if idx <= 0 || idx == len(value)-1 {
+		return zero, false
+	}
+	payload, sig := value[:idx], value[idx+1:]
+	expected := impersonateSign(secret, payload)
+	if !hmac.Equal([]byte(sig), []byte(expected)) {
+		return zero, false
+	}
+	parts := strings.Split(payload, impersonateSep)
+	if len(parts) != 3 {
+		return zero, false
+	}
+	exp, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		return zero, false
+	}
+	if now.Unix() >= exp {
+		return zero, false
+	}
+	if parts[0] == "" || parts[1] == "" {
+		return zero, false
+	}
+	return impersonationGrant{Admin: parts[0], Target: parts[1], Exp: exp}, true
+}

--- a/v2/pkg/hub/impersonation_test.go
+++ b/v2/pkg/hub/impersonation_test.go
@@ -1,0 +1,292 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Admin read-only "View as user" impersonation.
+//
+// These tests exercise the security boundary directly (the cookie helpers,
+// resolveIdentity, the write-block, and the enter/exit handlers) rather than
+// the browser JS, because the enforcement lives entirely on the server. They
+// reuse the shared test helpers from saas_handlers_coverage_test.go
+// (testHubSecret, testAuthCookie, mkUser, newHandlerHub, reqWithUser,
+// setPathValue, helperSetupTempDirs).
+
+// impersonateCookie mints a signed impersonation cookie the same way the server
+// does, so a test can present a genuine grant.
+func impersonateCookie(admin, target string, now time.Time) *http.Cookie {
+	return &http.Cookie{
+		Name:  impersonateCookieName,
+		Value: mintImpersonateCookieValue(testHubSecret, admin, target, now),
+	}
+}
+
+// TestImpersonateCookieRoundTrip verifies mint/verify agree and that tamper,
+// wrong secret, and expiry all fail closed.
+func TestImpersonateCookieRoundTrip(t *testing.T) {
+	now := time.Now()
+	val := mintImpersonateCookieValue(testHubSecret, "clubanderson", "alice", now)
+	if val == "" {
+		t.Fatal("mint returned empty for valid inputs")
+	}
+	g, ok := verifyImpersonateCookieValue(testHubSecret, val, now)
+	if !ok || g.Admin != "clubanderson" || g.Target != "alice" {
+		t.Fatalf("verify = %+v, ok=%v; want admin=clubanderson target=alice", g, ok)
+	}
+
+	// Wrong secret -> ignored.
+	if _, ok := verifyImpersonateCookieValue("other-secret", val, now); ok {
+		t.Error("verify accepted a cookie signed with a different secret")
+	}
+	// Tampered payload -> ignored.
+	tampered := strings.Replace(val, "alice", "aliceX", 1)
+	if _, ok := verifyImpersonateCookieValue(testHubSecret, tampered, now); ok {
+		t.Error("verify accepted a tampered cookie")
+	}
+	// Expired -> ignored.
+	if _, ok := verifyImpersonateCookieValue(testHubSecret, val, now.Add(impersonateTTL+time.Minute)); ok {
+		t.Error("verify accepted an expired cookie")
+	}
+	// Empty target refused at mint.
+	if mintImpersonateCookieValue(testHubSecret, "clubanderson", "", now) != "" {
+		t.Error("mint accepted an empty target")
+	}
+}
+
+// TestImpersonateStartAndIdentitySwitch: admin POSTs impersonate/{user}, gets a
+// cookie, and a GET under that cookie resolves to the TARGET.
+func TestImpersonateStartAndIdentitySwitch(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+	mkUser(t, "alice")
+
+	// Admin starts impersonation of alice.
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/api/saas/admin/impersonate/alice", "", hubAdminUsername), "username", "alice")
+	s.handleImpersonateStart(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	var setCookie string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == impersonateCookieName {
+			setCookie = c.Value
+		}
+	}
+	if setCookie == "" {
+		t.Fatal("start did not set the impersonation cookie")
+	}
+
+	// A GET carrying the admin session cookie + the impersonation cookie
+	// resolves to alice.
+	get := httptest.NewRequest(http.MethodGet, "/api/saas/my-hives", nil)
+	get.AddCookie(testAuthCookie(hubAdminUsername))
+	get.AddCookie(&http.Cookie{Name: impersonateCookieName, Value: setCookie})
+	if eff := s.getAuthUser(get); eff != "alice" {
+		t.Errorf("GET effective identity = %q, want alice", eff)
+	}
+
+	// resolveIdentity reports the real admin + impersonating=true on the GET.
+	eff, real, imp := s.resolveIdentity(get)
+	if eff != "alice" || real != hubAdminUsername || !imp {
+		t.Errorf("resolveIdentity(GET) = (%q,%q,%v); want (alice,%s,true)", eff, real, imp, hubAdminUsername)
+	}
+}
+
+// TestImpersonateStartUnknownTarget: 404 for a target with no user record.
+func TestImpersonateStartUnknownTarget(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/x", "", hubAdminUsername), "username", "ghost")
+	s.handleImpersonateStart(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("unknown target status = %d, want 404", rec.Code)
+	}
+}
+
+// TestNonAdminCannotImpersonate: requireAdmin rejects a non-admin caller (403).
+func TestNonAdminCannotImpersonate(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, "bob")
+	mkUser(t, "alice")
+
+	h := s.requireAdmin(s.handleImpersonateStart)
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/api/saas/admin/impersonate/alice", "", "bob"), "username", "alice")
+	h(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("non-admin impersonate status = %d, want 403", rec.Code)
+	}
+}
+
+// TestWriteBlockedDuringImpersonation: under an active grant, a write (POST/PUT/
+// DELETE) is refused 403 by requireAuth/requireAdmin, while a GET still passes.
+func TestWriteBlockedDuringImpersonation(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+	mkUser(t, "alice")
+	now := time.Now()
+
+	called := false
+	next := func(w http.ResponseWriter, r *http.Request) { called = true; w.WriteHeader(http.StatusOK) }
+
+	// A POST through requireAuth under an active grant -> 403, next not called.
+	guardedAuth := s.requireAuth(next)
+	rec := httptest.NewRecorder()
+	post := httptest.NewRequest(http.MethodPost, "/api/saas/hives", strings.NewReader("{}"))
+	post.Header.Set("Content-Type", "application/json")
+	post.AddCookie(testAuthCookie(hubAdminUsername))
+	post.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
+	guardedAuth(rec, post)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("POST under impersonation status = %d, want 403 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if called {
+		t.Error("write handler ran despite impersonation write-block")
+	}
+	if !strings.Contains(rec.Body.String(), "read-only") {
+		t.Errorf("403 body = %q, want a read-only message", rec.Body.String())
+	}
+
+	// A write through requireAdmin is likewise blocked.
+	called = false
+	guardedAdmin := s.requireAdmin(next)
+	rec = httptest.NewRecorder()
+	del := httptest.NewRequest(http.MethodDelete, "/api/saas/admin/users/alice", nil)
+	del.AddCookie(testAuthCookie(hubAdminUsername))
+	del.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
+	guardedAdmin(rec, del)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("admin DELETE under impersonation status = %d, want 403", rec.Code)
+	}
+	if called {
+		t.Error("admin write handler ran despite impersonation write-block")
+	}
+
+	// A GET through requireAuth under the same grant still reaches the handler.
+	called = false
+	rec = httptest.NewRecorder()
+	get := httptest.NewRequest(http.MethodGet, "/api/saas/my-hives", nil)
+	get.AddCookie(testAuthCookie(hubAdminUsername))
+	get.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
+	guardedAuth(rec, get)
+	if rec.Code != http.StatusOK || !called {
+		t.Errorf("GET under impersonation: status=%d called=%v; want 200 + handler called", rec.Code, called)
+	}
+}
+
+// TestImpersonateExitClearsCookieAndStaysCallable: exit works WHILE impersonating
+// (it is exempt from the write-block) and clears the cookie.
+func TestImpersonateExitClearsCookieAndStaysCallable(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+	mkUser(t, "alice")
+	now := time.Now()
+
+	// Exit is registered behind requireAdmin AND is a POST — the write-block
+	// must NOT fire for it. Drive it through the real middleware to prove that.
+	guarded := s.requireAdmin(s.handleImpersonateExit)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, impersonateExitPath, nil)
+	req.AddCookie(testAuthCookie(hubAdminUsername))
+	req.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
+	guarded(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("exit status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	// The exit response must clear the cookie (MaxAge<0 / empty value).
+	var cleared bool
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == impersonateCookieName && (c.MaxAge < 0 || c.Value == "") {
+			cleared = true
+		}
+	}
+	if !cleared {
+		t.Error("exit did not clear the impersonation cookie")
+	}
+
+	// After exit (no impersonation cookie), identity is back to the admin.
+	get := httptest.NewRequest(http.MethodGet, "/api/saas/my-hives", nil)
+	get.AddCookie(testAuthCookie(hubAdminUsername))
+	if eff := s.getAuthUser(get); eff != hubAdminUsername {
+		t.Errorf("post-exit identity = %q, want %s", eff, hubAdminUsername)
+	}
+}
+
+// TestForgedImpersonationCookieIgnored: a forged/tampered impersonation cookie
+// is ignored — identity stays admin and no impersonation is reported.
+func TestForgedImpersonationCookieIgnored(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+	mkUser(t, "alice")
+
+	get := httptest.NewRequest(http.MethodGet, "/api/saas/my-hives", nil)
+	get.AddCookie(testAuthCookie(hubAdminUsername))
+	// A hand-crafted, unsigned value.
+	get.AddCookie(&http.Cookie{Name: impersonateCookieName, Value: "clubanderson|alice|9999999999.forgedsig"})
+
+	eff, real, imp := s.resolveIdentity(get)
+	if imp {
+		t.Error("forged impersonation cookie was honored")
+	}
+	if eff != hubAdminUsername || real != hubAdminUsername {
+		t.Errorf("forged cookie shifted identity: eff=%q real=%q; want both %s", eff, real, hubAdminUsername)
+	}
+}
+
+// TestImpersonationNoPrivilegeEscalation covers two escalation attempts:
+//  1. A grant whose Admin field != the real signed user is ignored (a user
+//     lifting the admin's cookie onto their own session).
+//  2. A grant whose Admin field != hubAdminUsername is ignored (impersonation
+//     can only ever be activated by the admin's real session).
+func TestImpersonationNoPrivilegeEscalation(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+	mkUser(t, "alice")
+	mkUser(t, "bob")
+	now := time.Now()
+
+	// (1) bob presents a genuinely-signed grant that names the admin as actor,
+	// on bob's OWN session. Because the real user is bob (not the grant.Admin
+	// and not the admin), it must be ignored — bob stays bob, not elevated.
+	get := httptest.NewRequest(http.MethodGet, "/api/saas/my-hives", nil)
+	get.AddCookie(testAuthCookie("bob"))
+	get.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
+	eff, real, imp := s.resolveIdentity(get)
+	if imp || eff != "bob" || real != "bob" {
+		t.Errorf("stolen admin cookie on bob's session: eff=%q real=%q imp=%v; want bob/bob/false", eff, real, imp)
+	}
+
+	// (2) A grant whose Admin field is a NON-admin, presented on that
+	// non-admin's own session, must be ignored (only hubAdminUsername may
+	// impersonate). Even though the signature is valid and admin==realUser here,
+	// realUser != hubAdminUsername, so resolveIdentity refuses it.
+	get2 := httptest.NewRequest(http.MethodGet, "/api/saas/my-hives", nil)
+	get2.AddCookie(testAuthCookie("bob"))
+	get2.AddCookie(impersonateCookie("bob", "alice", now))
+	eff, real, imp = s.resolveIdentity(get2)
+	if imp || eff != "bob" {
+		t.Errorf("non-admin self-minted grant honored: eff=%q imp=%v; want bob/false", eff, imp)
+	}
+}

--- a/v2/pkg/hub/impersonation_test.go
+++ b/v2/pkg/hub/impersonation_test.go
@@ -190,6 +190,63 @@ func TestWriteBlockedDuringImpersonation(t *testing.T) {
 	}
 }
 
+// TestAdminReadSurfacesHiddenDuringImpersonation pins the UX-fidelity property of
+// "View as": while impersonating, an admin-DATA GET (e.g. /api/saas/admin/users)
+// must be refused so no admin surface leaks into the view — the impersonated
+// dashboard shows exactly what the target user sees. The exit path stays callable.
+func TestAdminReadSurfacesHiddenDuringImpersonation(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+	mkUser(t, "alice")
+	now := time.Now()
+
+	called := false
+	next := func(w http.ResponseWriter, r *http.Request) { called = true; w.WriteHeader(http.StatusOK) }
+	guardedAdmin := s.requireAdmin(next)
+
+	// A GET admin-data route under an active grant -> 403, handler NOT reached, so
+	// the client's 403 handling hides the admin Users section AND the Send Banner
+	// controls. (Before the fix this returned 200 because requireAdmin honors the
+	// real admin identity — leaking the full user list into the impersonated view.)
+	rec := httptest.NewRecorder()
+	get := httptest.NewRequest(http.MethodGet, "/api/saas/admin/users", nil)
+	get.AddCookie(testAuthCookie(hubAdminUsername))
+	get.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
+	guardedAdmin(rec, get)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("admin GET under impersonation status = %d, want 403 (admin surface must not leak)", rec.Code)
+	}
+	if called {
+		t.Error("admin GET handler ran under impersonation — admin data leaked into the impersonated view")
+	}
+
+	// The SAME admin GET, NOT impersonating, still reaches the handler (200) — the
+	// real admin retains full access when not viewing as someone.
+	called = false
+	rec = httptest.NewRecorder()
+	get = httptest.NewRequest(http.MethodGet, "/api/saas/admin/users", nil)
+	get.AddCookie(testAuthCookie(hubAdminUsername))
+	guardedAdmin(rec, get)
+	if rec.Code != http.StatusOK || !called {
+		t.Errorf("admin GET without impersonation: status=%d called=%v; want 200 + handler called", rec.Code, called)
+	}
+
+	// The exit path stays reachable while impersonating (so the admin can always
+	// get back out) even though it is behind requireAdmin.
+	called = false
+	rec = httptest.NewRecorder()
+	guardedExit := s.requireAdmin(next)
+	exitReq := httptest.NewRequest(http.MethodPost, impersonateExitPath, nil)
+	exitReq.AddCookie(testAuthCookie(hubAdminUsername))
+	exitReq.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
+	guardedExit(rec, exitReq)
+	if rec.Code != http.StatusOK || !called {
+		t.Errorf("exit path under impersonation: status=%d called=%v; want 200 + handler reached", rec.Code, called)
+	}
+}
+
 // TestImpersonateExitClearsCookieAndStaysCallable: exit works WHILE impersonating
 // (it is exempt from the write-block) and clears the cookie.
 func TestImpersonateExitClearsCookieAndStaysCallable(t *testing.T) {

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -327,12 +327,27 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	isAdmin := username == hubAdminUsername
-	data, err := json.Marshal(map[string]any{
+	// Fold impersonation status into the auth payload the dashboard already
+	// fetches, so the "Viewing as … read-only" banner renders without a second
+	// round-trip. When an admin is impersonating, report the effective identity
+	// as the target (that is what every per-user view is rendering as) but keep
+	// hub_admin FALSE — during impersonation the admin is deliberately a normal
+	// user, so admin-only affordances hide via the existing role checks.
+	payload := map[string]any{
 		"authenticated": true,
 		"login":         username,
 		"avatar_url":    fmt.Sprintf("https://github.com/%s.png", username),
 		"hub_admin":     isAdmin,
-	})
+	}
+	if grant, ok := s.activeImpersonationGrant(r); ok {
+		payload["login"] = grant.Target
+		payload["avatar_url"] = fmt.Sprintf("https://github.com/%s.png", grant.Target)
+		payload["hub_admin"] = false
+		payload["impersonating"] = true
+		payload["viewing_as"] = grant.Target
+		payload["real_user"] = username
+	}
+	data, err := json.Marshal(payload)
 	if err != nil {
 		http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
 		return

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -682,9 +682,27 @@ func (s *HubServer) requireAdmin(next http.HandlerFunc) http.HandlerFunc {
 			http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
 			return
 		}
+		// While impersonating, NO admin-only surface may leak to the view the
+		// admin is "viewing as" — the whole point of read-only impersonation is to
+		// see exactly what the target user sees, and a normal user is never an
+		// admin. requireAdmin gates on the REAL admin (so exit and admin routes
+		// stay reachable), which means an admin-DATA GET (e.g. /api/saas/admin/users)
+		// would otherwise still answer 200 under impersonation and the client would
+		// render the admin Users section. So: while a grant is active, refuse every
+		// admin route (GET included) EXCEPT the impersonation exit — the client's
+		// 403 handling then hides the admin section, matching what the target sees.
+		if r.URL.Path != impersonateExitPath {
+			if _, _, impersonating := s.resolveIdentity(r); impersonating {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusForbidden)
+				w.Write([]byte(`{"error":"admin surfaces are hidden while viewing as a user — exit impersonation for admin access"}`))
+				return
+			}
+		}
 		// Admin writes are also read-only under impersonation (exit excepted),
 		// so an impersonating admin cannot mutate through an admin endpoint
-		// either.
+		// either. (Redundant with the block above now, but kept as defense in
+		// depth / a clear write-specific message if the above is ever relaxed.)
 		if s.blockIfImpersonatingWrite(w, r) {
 			return
 		}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -267,6 +267,14 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("GET /api/saas/admin/users", s.requireAdmin(s.handleAdminUsers))
 	s.mux.HandleFunc("PUT /api/saas/admin/users/{username}", s.requireAdmin(s.handleAdminUpdateUser))
 	s.mux.HandleFunc("DELETE /api/saas/admin/users/{username}", s.requireAdmin(s.handleAdminDeleteUser))
+	// Admin read-only "View as user" impersonation. Enter is admin-only and
+	// sets the short-lived signed hive_hub_impersonate cookie; exit clears it
+	// and is exempt from the impersonation write-block (see impersonateExitPath)
+	// so the admin can always get back out. Status folds into /api/auth/user for
+	// the banner, but a dedicated read is offered too.
+	s.mux.HandleFunc("POST /api/saas/admin/impersonate/exit", s.requireAdmin(s.handleImpersonateExit))
+	s.mux.HandleFunc("POST /api/saas/admin/impersonate/{username}", s.requireAdmin(s.handleImpersonateStart))
+	s.mux.HandleFunc("GET /api/saas/impersonation-status", s.requireAuth(s.handleImpersonationStatus))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/assign", s.requireAuth(s.handleAssignHive))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/migrate", s.requireAuth(s.handleMigrateHive))
 	s.mux.HandleFunc("GET /api/saas/cluster-health", s.requireAdmin(s.handleClusterHealth))
@@ -307,12 +315,71 @@ func (s *HubServer) registerSaaSRoutes() {
 	}
 }
 
+// impersonateExitPath is the one mutating endpoint that stays callable while
+// impersonation is active — it is how the admin gets OUT. Every other write is
+// refused 403 by the write-block below.
+const impersonateExitPath = "/api/saas/admin/impersonate/exit"
+
+// blockIfImpersonatingWrite enforces the read-only property of impersonation.
+// While a valid admin grant is active, ANY non-GET/HEAD request (except the
+// exit endpoint) is refused 403 before it reaches its handler. This is the
+// central write gate: it lives in both requireAuth and requireAdmin, through
+// which every user-facing mutation is routed, so no write path can slip past.
+// It returns true when it has already written the 403 response and the caller
+// must stop.
+func (s *HubServer) blockIfImpersonatingWrite(w http.ResponseWriter, r *http.Request) bool {
+	if r.Method == http.MethodGet || r.Method == http.MethodHead {
+		return false
+	}
+	if r.URL.Path == impersonateExitPath {
+		return false
+	}
+	_, _, impersonating := s.resolveIdentity(r)
+	if !impersonating {
+		return false
+	}
+	target := "user"
+	if grant, ok := s.activeImpersonationGrant(r); ok {
+		target = grant.Target
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	// target is a GitHub login (no quotes/backslashes possible), safe to inline.
+	w.Write([]byte(`{"error":"read-only while viewing as ` + target + ` — exit impersonation to make changes"}`))
+	return true
+}
+
+// activeImpersonationGrant returns the verified grant behind the current
+// request when (and only when) resolveIdentity would honor it. It is a thin
+// read used for messaging/audit/status; the security decisions live in
+// resolveIdentity.
+func (s *HubServer) activeImpersonationGrant(r *http.Request) (impersonationGrant, bool) {
+	if s.getRealAuthUser(r) != hubAdminUsername {
+		return impersonationGrant{}, false
+	}
+	cookie, err := r.Cookie(impersonateCookieName)
+	if err != nil || cookie.Value == "" {
+		return impersonationGrant{}, false
+	}
+	grant, ok := verifyImpersonateCookieValue(s.hubSecret, cookie.Value, time.Now())
+	if !ok || grant.Admin != hubAdminUsername {
+		return impersonationGrant{}, false
+	}
+	if loadSaaSUser(grant.Target) == nil {
+		return impersonationGrant{}, false
+	}
+	return grant, true
+}
+
 func (s *HubServer) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !isCSRFSafe(r) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusForbidden)
 			w.Write([]byte(`{"error":"CSRF check failed"}`))
+			return
+		}
+		if s.blockIfImpersonatingWrite(w, r) {
 			return
 		}
 		username := s.getAuthUser(r)
@@ -371,7 +438,12 @@ func isTrustedOrigin(raw string) bool {
 		host == "127.0.0.1"
 }
 
-func (s *HubServer) getAuthUser(r *http.Request) string {
+// getRealAuthUser resolves the REAL authenticated user from the signed session
+// cookie or a Bearer token, with NO impersonation applied. This is the identity
+// the admin actually logged in as. Impersonation is layered on top of this by
+// resolveIdentity — never inside it — so the write-block and the admin gate can
+// always reason about who is really driving the request.
+func (s *HubServer) getRealAuthUser(r *http.Request) string {
 	cookie, err := r.Cookie("hive_hub_user")
 	if err == nil && cookie.Value != "" {
 		// The cookie value is only trusted when its HMAC signature verifies
@@ -394,6 +466,67 @@ func (s *HubServer) getAuthUser(r *http.Request) string {
 	}
 
 	return ""
+}
+
+// resolveIdentity is the single decision point for admin "View as user"
+// impersonation. It returns the EFFECTIVE identity every per-user view should
+// render as, the REAL admin login driving the request, and whether an
+// impersonation grant is currently active.
+//
+// Impersonation is honored ONLY when every one of these holds (fail closed on
+// any miss — the request is then simply the real user, not impersonating):
+//
+//   - a hive_hub_impersonate cookie is present AND its HMAC verifies AND it has
+//     not expired (verifyImpersonateCookieValue);
+//   - the grant's Admin field equals the REAL signed session user;
+//   - that real user is exactly hubAdminUsername (only the admin may impersonate
+//     — a stolen cookie replayed on a non-admin session is ignored);
+//   - the target resolves to a real registered user on disk.
+//
+// The effective identity switches to the target ONLY for GET/HEAD requests.
+// For any mutating method the effective identity stays the admin so no write is
+// ever attributed to the target; the write itself is separately refused 403 by
+// requireAuth/requireAdmin. This split means impersonation can never elevate:
+// the target is always a normal user, and writes never run under it.
+func (s *HubServer) resolveIdentity(r *http.Request) (effective, realUser string, impersonating bool) {
+	realUser = s.getRealAuthUser(r)
+	if realUser == "" || realUser != hubAdminUsername {
+		return realUser, realUser, false
+	}
+	cookie, err := r.Cookie(impersonateCookieName)
+	if err != nil || cookie.Value == "" {
+		return realUser, realUser, false
+	}
+	grant, ok := verifyImpersonateCookieValue(s.hubSecret, cookie.Value, time.Now())
+	if !ok {
+		return realUser, realUser, false
+	}
+	// The cookie must name THIS real admin as its actor. Anything else — a
+	// cookie minted for a different admin, or one lifted onto the wrong
+	// session — is ignored rather than trusted.
+	if grant.Admin != realUser {
+		return realUser, realUser, false
+	}
+	if loadSaaSUser(grant.Target) == nil {
+		return realUser, realUser, false
+	}
+	// A valid, active grant exists. Report impersonating=true regardless of
+	// method (so writes can be blocked), but only SWITCH the effective identity
+	// for read requests.
+	if r.Method == http.MethodGet || r.Method == http.MethodHead {
+		return grant.Target, realUser, true
+	}
+	return realUser, realUser, true
+}
+
+// getAuthUser returns the EFFECTIVE identity for the request: the impersonated
+// target on a GET/HEAD while a valid admin grant is active, otherwise the real
+// authenticated user. Every per-user handler calls this, so making it
+// impersonation-aware is what renders all per-user views as the target with no
+// per-handler change.
+func (s *HubServer) getAuthUser(r *http.Request) string {
+	effective, _, _ := s.resolveIdentity(r)
+	return effective
 }
 
 var (
@@ -539,9 +672,20 @@ func listAllSaaSUsers() []SaaSUser {
 
 func (s *HubServer) requireAdmin(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		username := s.getAuthUser(r)
+		// Gate on the REAL logged-in user, not the effective (possibly
+		// impersonated) identity. While the admin is viewing as a normal user,
+		// getAuthUser resolves to that user on GETs — but admin routes (and in
+		// particular the impersonation exit) must still be reachable by the real
+		// admin, and no admin-only surface may leak to the impersonated target.
+		username := s.getRealAuthUser(r)
 		if username != hubAdminUsername {
 			http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
+			return
+		}
+		// Admin writes are also read-only under impersonation (exit excepted),
+		// so an impersonating admin cannot mutate through an admin endpoint
+		// either.
+		if s.blockIfImpersonatingWrite(w, r) {
 			return
 		}
 		next(w, r)
@@ -578,6 +722,93 @@ func (s *HubServer) handleAdminUsers(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"users": views})
+}
+
+// impersonateCookieDomain matches the session cookie's domain so the two are
+// scoped identically across the hive.kubestellar.io hosts. It mirrors the
+// hive_hub_user cookie set in oauth.go.
+const impersonateCookieDomain = ".hive.kubestellar.io"
+
+// setImpersonateCookie writes (value != "") or clears (value == "") the signed
+// impersonation cookie with the same hardened attributes as the session cookie:
+// HttpOnly (no JS access), Secure (HTTPS only), SameSite=Lax. The short MaxAge
+// mirrors impersonateTTL so the browser drops the cookie about when the server
+// would stop honoring it.
+func setImpersonateCookie(w http.ResponseWriter, value string) {
+	c := &http.Cookie{
+		Name:     impersonateCookieName,
+		Value:    value,
+		Path:     "/",
+		Domain:   impersonateCookieDomain,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	}
+	if value == "" {
+		c.MaxAge = -1 // delete
+	} else {
+		c.MaxAge = int(impersonateTTL / time.Second)
+	}
+	http.SetCookie(w, c)
+}
+
+// handleImpersonateStart begins an admin read-only "View as user" session.
+// Registered behind requireAdmin, so only the real hub admin reaches it (and
+// the impersonation write-block cannot fire here because starting requires no
+// active grant). It validates the target is a registered user, then sets the
+// short-lived signed hive_hub_impersonate cookie. The admin gains NO privilege:
+// subsequent GETs render as the target, and every write is refused 403.
+func (s *HubServer) handleImpersonateStart(w http.ResponseWriter, r *http.Request) {
+	admin := s.getRealAuthUser(r) // == hubAdminUsername (requireAdmin gated)
+	target := r.PathValue("username")
+	if target == "" || target == admin {
+		writeJSONError(w, http.StatusBadRequest, "invalid target user")
+		return
+	}
+	if loadSaaSUser(target) == nil {
+		writeJSONError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	value := mintImpersonateCookieValue(s.hubSecret, admin, target, time.Now())
+	if value == "" {
+		writeJSONError(w, http.StatusInternalServerError, "cannot start impersonation")
+		return
+	}
+	setImpersonateCookie(w, value)
+	s.logger.Info("audit: admin impersonation started", "admin", admin, "target", target,
+		"at", time.Now().UTC().Format(time.RFC3339))
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"ok": true, "viewing_as": target})
+}
+
+// handleImpersonateExit ends an active "View as user" session by clearing the
+// impersonation cookie. It is registered behind requireAdmin (the real admin is
+// always the actor) and its path is exempt from the write-block, so it stays
+// callable WHILE impersonating — that is the whole point. It is a no-op if no
+// grant is active.
+func (s *HubServer) handleImpersonateExit(w http.ResponseWriter, r *http.Request) {
+	admin := s.getRealAuthUser(r)
+	if grant, ok := s.activeImpersonationGrant(r); ok {
+		s.logger.Info("audit: admin impersonation ended", "admin", admin, "target", grant.Target,
+			"at", time.Now().UTC().Format(time.RFC3339))
+	}
+	setImpersonateCookie(w, "")
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"ok": true})
+}
+
+// handleImpersonationStatus reports whether the current request is inside an
+// impersonation session and, if so, who is being viewed. The banner reads this
+// (or the equivalent fields folded into /api/auth/user). Because getAuthUser
+// resolves to the target on this GET, the status is derived from the real admin
+// grant via activeImpersonationGrant rather than from getAuthUser.
+func (s *HubServer) handleImpersonationStatus(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if grant, ok := s.activeImpersonationGrant(r); ok {
+		json.NewEncoder(w).Encode(map[string]any{"impersonating": true, "viewing_as": grant.Target})
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]any{"impersonating": false})
 }
 
 // handleAdminUpdateUser applies a partial admin edit to one hub user record.
@@ -7449,6 +7680,14 @@ const dashboardHTML = `<!DOCTYPE html>
   </style>
 </head>
 <body>
+  <!-- Admin "View as user" banner. Hidden until loadUser() detects an active
+       impersonation session, then fixed to the very top of every hub page so it
+       is unmissable. The Exit button POSTs the exit endpoint and reloads. -->
+  <div id="impersonation-banner" style="display:none;position:fixed;top:0;left:0;right:0;z-index:2147483647;background:#b45309;color:#fff;font-size:0.85rem;font-weight:600;padding:8px 16px;box-shadow:0 2px 8px rgba(0,0,0,0.4);text-align:center">
+    <span style="margin-right:6px">&#128065;</span>
+    <span id="impersonation-banner-text">Viewing as user — read-only</span>
+    <button type="button" onclick="exitImpersonation()" style="margin-left:14px;padding:3px 12px;background:#fff;color:#b45309;border:none;border-radius:4px;cursor:pointer;font-size:0.75rem;font-weight:700">Exit</button>
+  </div>
   <header class="site-header">
     <a href="/" class="brand">
       <span class="brand-mark">🐝</span>
@@ -8782,10 +9021,52 @@ const dashboardHTML = `<!DOCTYPE html>
       window.open(target, '_blank');
     });
 
+    // Show or hide the sticky "Viewing as … read-only" banner and nudge the page
+    // down so the fixed banner never covers the header. Reads the impersonation
+    // fields folded into /api/auth/user.
+    function applyImpersonationBanner(data) {
+      var banner = document.getElementById('impersonation-banner');
+      if (!banner) return;
+      if (data && data.impersonating) {
+        document.getElementById('impersonation-banner-text').textContent =
+          'Viewing as ' + (data.viewing_as || 'user') + ' — read-only';
+        banner.style.display = '';
+        document.body.style.paddingTop = banner.offsetHeight + 'px';
+      } else {
+        banner.style.display = 'none';
+        document.body.style.paddingTop = '';
+      }
+    }
+
+    // exitImpersonation ends the current "View as" session and reloads so every
+    // view re-renders as the real admin again.
+    async function exitImpersonation() {
+      try { await fetch('/api/saas/admin/impersonate/exit', {method:'POST'}); } catch(e) {}
+      location.reload();
+    }
+
+    // startImpersonation enters read-only "View as <username>" and reloads so
+    // all per-user views re-render as that user. Admin-only (the server refuses
+    // any non-admin caller with 403).
+    async function startImpersonation(username) {
+      try {
+        var resp = await fetch('/api/saas/admin/impersonate/' + encodeURIComponent(username), {method:'POST'});
+        if (!resp.ok) {
+          var e = {}; try { e = await resp.json(); } catch(_) {}
+          hiveToast('Cannot view as ' + username + ': ' + (e.error || resp.status), 'error');
+          return;
+        }
+        location.reload();
+      } catch(err) {
+        hiveToast('Cannot view as ' + username, 'error');
+      }
+    }
+
     async function loadUser() {
       try {
         var resp = await fetch('/api/auth/user');
         var data = await resp.json();
+        applyImpersonationBanner(data);
         if (data.authenticated) {
           _isAdmin = !!data.hub_admin;
           /* The signed-in login is the ONE piece of viewer identity the hive
@@ -14996,7 +15277,7 @@ const dashboardHTML = `<!DOCTYPE html>
           '<td>' + statusCell + '</td>' +
           '<td><input type="number" min="0" max="10" value="' + (u.saas_quota || 0) + '" style="width:50px;padding:4px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text);text-align:center" onchange="updateUser(\'' + esc(u.github_username) + '\',{saas_quota:parseInt(this.value)||0})"></td>' +
           '<td>' + (hiveCount > 0 ? '<a href="#" onclick="toggleAdminExpand(\'' + esc(u.github_username) + '\');return false" style="color:var(--blue);font-size:0.8rem">' + hiveCount + ' hive' + (hiveCount > 1 ? 's' : '') + '</a>' : '<span style="color:var(--muted)">0</span>') + '</td>' +
-          '<td>' + (isAdmin ? '' : '<button onclick="updateUser(\'' + esc(u.github_username) + '\',{blocked:' + (!u.blocked) + '})" style="padding:3px 10px;background:' + (u.blocked ? 'var(--green)' : 'var(--amber)') + ';color:' + (u.blocked ? '#fff' : '#1a1a1a') + ';border:none;border-radius:4px;cursor:pointer;font-size:0.7rem">' + (u.blocked ? 'Unblock' : 'Block') + '</button> <button onclick="deleteUser(\'' + esc(u.github_username) + '\',' + hiveCount + ')" style="padding:3px 10px;background:#b02a2a;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.7rem">Delete</button>') + '</td>' +
+          '<td>' + (isAdmin ? '' : '<button onclick="startImpersonation(\'' + esc(u.github_username) + '\')" title="See the hub exactly as this user does — read-only" style="padding:3px 10px;background:#b45309;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.7rem">View as</button> <button onclick="updateUser(\'' + esc(u.github_username) + '\',{blocked:' + (!u.blocked) + '})" style="padding:3px 10px;background:' + (u.blocked ? 'var(--green)' : 'var(--amber)') + ';color:' + (u.blocked ? '#fff' : '#1a1a1a') + ';border:none;border-radius:4px;cursor:pointer;font-size:0.7rem">' + (u.blocked ? 'Unblock' : 'Block') + '</button> <button onclick="deleteUser(\'' + esc(u.github_username) + '\',' + hiveCount + ')" style="padding:3px 10px;background:#b02a2a;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.7rem">Delete</button>') + '</td>' +
           '</tr>' + renderContactPanelRow(u) + hiveRows;
       }).join('');
       document.getElementById('users-container').innerHTML =


### PR DESCRIPTION
Routine clean sync of latest v2 @ `0da0f3df` into `dd` — no conflicts (verified before push). Includes the impersonation admin-surface-leak fix (#2685), cooldown count/explainer (#2656), queue hold controls (#2673), and other recent v2 work. Sync PR — merge with **--merge** (not squash).