### PR TITLE
✨ User view: Request-a-hive + Register-your-own-hive + Contribute-first public hives + empty-state CTAs

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -7738,6 +7738,18 @@ const dashboardHTML = `<!DOCTYPE html>
       </div>
       <div style="display:flex;gap:8px;align-items:center">
         <button class="btn-primary" id="btn-send-banner-top" style="display:none;background:#d97706" onclick="_bannerTargetHive=null;document.getElementById('banner-modal').style.display='flex';loadBannerHiveList()">Send Banner</button>
+        <!-- Register-your-own-hive: for a user who self-installed a standalone
+             hive and wants to attach it to THIS hub. Points at the existing
+             self-host guide (get-started.html #self-host) whose key step is to
+             set HIVE_HUB_URL — no new backend, no new content. Always available. -->
+        <a class="btn-primary" id="btn-register-hive" href="/get-started#self-host" style="background:var(--surface);color:var(--text);border:1px solid var(--border);text-decoration:none" title="You self-host the hive and attach it to this hub (set HIVE_HUB_URL)">Register your own hive</a>
+        <!-- Request-a-hive: routes to the EXISTING Request-a-Hive wizard at
+             /get-started (files a provision request via POST
+             /api/saas/request-provision). Shown when the user has NO hosted
+             quota (cannot self-create); hidden otherwise. No new modal. -->
+        <a class="btn-primary" id="btn-request-hive" href="/get-started" style="display:none;text-decoration:none" title="We host the hive for you — files a provision request">Request a hive</a>
+        <!-- Self-create path, for users who DO have hosted quota. Hidden when the
+             user has no quota (the Request-a-hive link above takes over). -->
         <button class="btn-primary" id="btn-add-hive" disabled onclick="document.getElementById('create-modal').style.display='flex'">+ Add Hosted Hive</button>
       </div>
     </div>
@@ -11615,9 +11627,17 @@ const dashboardHTML = `<!DOCTYPE html>
         }
         var canCreate = _userQuota < 0 || _userQuota > _userUsed;
         var addBtn = document.getElementById('btn-add-hive');
+        var requestBtn = document.getElementById('btn-request-hive');
         if (addBtn) {
           addBtn.disabled = !canCreate;
           addBtn.title = canCreate ? '' : 'No hosted quota — contact hub admin';
+          /* No hosted quota: hide the dead-end self-create button entirely and
+             surface the active "Request a hive" link in its place. With quota,
+             keep the working + Add Hosted Hive button and hide the request link. */
+          addBtn.style.display = canCreate ? '' : 'none';
+        }
+        if (requestBtn) {
+          requestBtn.style.display = canCreate ? 'none' : '';
         }
         /* Render through sortedDashHives() rather than the raw payload so an
            active sort — whether the operator clicked a column or restored a
@@ -11720,21 +11740,29 @@ const dashboardHTML = `<!DOCTYPE html>
           var repoLink = repoPath ? (repoHref ? '<a href="' + repoHref + '" target="_blank" class="repo-link">' + esc(h.primaryRepo) + '</a>' : '<span class="repo-link">' + esc(h.primaryRepo) + '</span>') : '';
           var actionCell = '';
           var access = accessMap[h.id];
+          // /contribute is a PUBLIC endpoint (see publicPaths) — lending compute
+          // does NOT require access — so Contribute is the PRIMARY action for
+          // EVERYONE on a public hive, regardless of access status. Use the
+          // hive's heartbeat-reported dashboard URL (resolvedBase), NOT a
+          // hardcoded <id>.hive.kubestellar.io host. Firewalled spokes (e.g.
+          // vllm-d on *.apps.fmaas-vllm-d.fmaas.res.ibm.com) live on a different
+          // domain, so the hardcoded host 503'd/failed to resolve.
+          var cBase = resolvedBase(h);
+          var contributeAction = cBase
+            ? '<a href="' + cBase + '/contribute" target="_blank" style="padding:3px 10px;background:rgba(34,197,94,0.15);color:#4ade80;border:1px solid rgba(34,197,94,0.3);border-radius:4px;font-size:0.7rem;text-decoration:none">Contribute</a>'
+            : '<span style="padding:3px 10px;color:var(--muted);font-size:0.7rem" title="hive has not reported its dashboard URL yet">Contribute unavailable</span>';
+          // Access is the SECONDARY, less-prominent action: a small link for the
+          // user who genuinely wants sign-in / manage access. Pending state is
+          // preserved (no re-request while one is outstanding).
+          var accessSecondary;
           if (access && access.status === 'accepted') {
-            // Use the hive's heartbeat-reported dashboard URL (resolvedBase),
-            // NOT a hardcoded <id>.hive.kubestellar.io host. Firewalled spokes
-            // (e.g. vllm-d on *.apps.fmaas-vllm-d.fmaas.res.ibm.com) live on a
-            // different domain, so the hardcoded host 503'd/failed to resolve.
-            var cBase = resolvedBase(h);
-            var actionCell2 = cBase
-              ? '<a href="' + cBase + '/contribute" target="_blank" style="padding:3px 10px;background:rgba(34,197,94,0.15);color:#4ade80;border:1px solid rgba(34,197,94,0.3);border-radius:4px;font-size:0.7rem;text-decoration:none">Contribute</a>'
-              : '<span style="padding:3px 10px;color:var(--muted);font-size:0.7rem" title="hive has not reported its dashboard URL yet">Contribute unavailable</span>';
-            actionCell = actionCell2;
+            accessSecondary = '<span style="font-size:0.65rem;color:var(--green)" title="you have access to this hive">✓ access</span>';
           } else if (access && access.status === 'pending') {
-            actionCell = '<span style="padding:3px 10px;background:rgba(245,158,11,0.15);color:#fbbf24;border:1px solid rgba(245,158,11,0.3);border-radius:4px;font-size:0.7rem">Pending</span>';
+            accessSecondary = '<span style="font-size:0.65rem;color:#fbbf24" title="access request pending">Pending</span>';
           } else {
-            actionCell = '<button onclick="dashRequestAccess(\'' + esc(h.id) + '\',this)" style="padding:3px 10px;background:rgba(59,130,246,0.15);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);border-radius:4px;font-size:0.7rem;cursor:pointer;border:1px solid rgba(59,130,246,0.3)">Request Access</button>';
+            accessSecondary = '<a href="#" onclick="dashRequestAccess(\'' + esc(h.id) + '\',this);return false" style="font-size:0.65rem;color:#60a5fa;text-decoration:none" title="request sign-in / manage access to this hive">Request access</a>';
           }
+          actionCell = '<div style="display:flex;gap:8px;align-items:center;justify-content:flex-end">' + contributeAction + accessSecondary + '</div>';
           return '<tr>' +
             '<td style="text-align:left">' + esc(h.name || h.id) + '</td>' +
             '<td>' + repoLink + '</td>' +
@@ -12122,7 +12150,16 @@ const dashboardHTML = `<!DOCTYPE html>
         document.getElementById('hives-container').innerHTML =
           '<div class="empty-state">' +
           '<p style="font-size:1.2rem;margin-bottom:8px">No hives yet</p>' +
-          '<p>Log in to a local hive dashboard to see it here, or create a hosted hive.</p>' +
+          '<p style="margin-bottom:16px">Get started in one of two ways:</p>' +
+          '<div style="display:flex;gap:12px;justify-content:center;flex-wrap:wrap;margin-bottom:12px">' +
+          /* Request-a-hive → the EXISTING Request-a-Hive wizard at /get-started
+             (POST /api/saas/request-provision). We host it for you. */
+          '<a class="btn-primary" href="/get-started" style="text-decoration:none" title="We host the hive for you">Request a hive</a>' +
+          /* Register-your-own-hive → the EXISTING self-host guide at
+             /get-started#self-host (set HIVE_HUB_URL, hive auto-appears). */
+          '<a class="btn-primary" href="/get-started#self-host" style="background:var(--surface);color:var(--text);border:1px solid var(--border);text-decoration:none" title="You self-host the hive and attach it to this hub">Register your own hive</a>' +
+          '</div>' +
+          '<p style="color:var(--muted);font-size:0.85rem">…or contribute to a public hive below.</p>' +
           '</div>';
         return;
       }

--- a/v2/pkg/hub/saas_dashboard_user_view_test.go
+++ b/v2/pkg/hub/saas_dashboard_user_view_test.go
@@ -1,0 +1,112 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// The user-first hub view (Request-a-hive, Register-your-own-hive,
+// Contribute-first public hives, empty-state CTAs) lives entirely inside the
+// dashboardHTML raw string, so there is no Go function to exercise. These tests
+// pin the wiring: each affordance must reuse an EXISTING page/endpoint
+// (/get-started, /get-started#self-host, /contribute) rather than a new
+// backend, and a refactor that quietly drops one should turn CI red.
+
+// TestDashboardRequestAndRegisterAffordances asserts the top button group
+// carries a Request-a-hive affordance routing to the existing wizard
+// (/get-started) and a distinct Register affordance routing to the existing
+// self-host guide (/get-started#self-host).
+func TestDashboardRequestAndRegisterAffordances(t *testing.T) {
+	html := dashScript(t)
+
+	// (1) Request a hive -> the EXISTING Request-a-Hive wizard.
+	if !strings.Contains(html, `id="btn-request-hive"`) {
+		t.Error(`missing the "Request a hive" button (id="btn-request-hive")`)
+	}
+	if !strings.Contains(html, `id="btn-request-hive" href="/get-started"`) {
+		t.Error(`"Request a hive" must link to the existing wizard at /get-started`)
+	}
+
+	// (2) Register your own hive -> the EXISTING self-host guide.
+	if !strings.Contains(html, `id="btn-register-hive"`) {
+		t.Error(`missing the "Register your own hive" button (id="btn-register-hive")`)
+	}
+	if !strings.Contains(html, `id="btn-register-hive" href="/get-started#self-host"`) {
+		t.Error(`"Register your own hive" must link to /get-started#self-host`)
+	}
+
+	// The Request-a-hive link only appears when the user has NO hosted quota;
+	// with quota the working + Add Hosted Hive button takes over. Pin the
+	// canCreate-driven visibility toggle so the two never show at once.
+	for _, want := range []string{
+		`requestBtn.style.display = canCreate ? 'none' : '';`,
+		`addBtn.style.display = canCreate ? '' : 'none';`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("missing quota-driven visibility toggle: %s", want)
+		}
+	}
+}
+
+// TestPublicHivesContributeIsPrimary asserts Contribute is the PRIMARY action on
+// public hives for everyone (no access required, since /contribute is public),
+// with Request access demoted to a secondary link and Pending preserved.
+func TestPublicHivesContributeIsPrimary(t *testing.T) {
+	html := dashScript(t)
+
+	// Contribute is built from the heartbeat-reported dashboard URL, not a
+	// hardcoded host, and targets the PUBLIC /contribute endpoint.
+	if !strings.Contains(html, `resolvedBase(h)`) {
+		t.Error("public-hives Contribute must resolve the hive's reported dashboard URL")
+	}
+	if !strings.Contains(html, `cBase + '/contribute"`) {
+		t.Error("public-hives Contribute must target the public /contribute endpoint")
+	}
+	if !strings.Contains(html, `var contributeAction = cBase`) {
+		t.Error("Contribute must be the primary action computed for every row, not gated on access")
+	}
+
+	// The unavailable fallback (no reported dashboard URL) is preserved.
+	if !strings.Contains(html, `Contribute unavailable`) {
+		t.Error("public-hives must keep the 'Contribute unavailable' fallback when no dashboard URL")
+	}
+
+	// Request access is still available but SECONDARY, and Pending is preserved.
+	if !strings.Contains(html, `dashRequestAccess(`) {
+		t.Error("Request access must remain available as a secondary action")
+	}
+	if !strings.Contains(html, `>Pending</span>`) {
+		t.Error("Pending access state must be preserved")
+	}
+}
+
+// TestEmptyStateHasCTAs asserts the "No hives yet" empty state carries the two
+// actionable CTAs (Request a hive, Register your own hive) plus the pointer to
+// the Public Hives section, instead of the old flat text.
+func TestEmptyStateHasCTAs(t *testing.T) {
+	html := dashScript(t)
+
+	i := strings.Index(html, "No hives yet")
+	if i < 0 {
+		t.Fatal("could not find the 'No hives yet' empty state")
+	}
+	// Bound the assertion to the empty-state block so an unrelated /get-started
+	// link elsewhere cannot satisfy it.
+	block := html[i:]
+	if end := strings.Index(block, "return;"); end >= 0 {
+		block = block[:end]
+	}
+	for _, want := range []string{
+		`href="/get-started"`,           // Request a hive
+		`href="/get-started#self-host"`, // Register your own hive
+		`contribute to a public hive`,   // pointer to Public Hives section
+	} {
+		if !strings.Contains(block, want) {
+			t.Errorf("empty state is missing CTA content: %s", want)
+		}
+	}
+	// The old dead-end copy must be gone.
+	if strings.Contains(block, "Log in to a local hive dashboard to see it here, or create a hosted hive.") {
+		t.Error("empty state still shows the old flat text instead of actionable CTAs")
+	}
+}


### PR DESCRIPTION
Makes the hub **USER view** actually usable for a user with **no hive and no quota** (verified live by impersonating a real user, `mrbobbytables`, 0 hives / 0 quota). Four related fixes, all in the hub dashboard (`v2/pkg/hub/saas.go`). Every affordance **reuses an existing page/endpoint — no new backend**.

## 1. Request a hive → the existing wizard
Previously the top button group showed a **disabled, greyed `+ Add Hosted Hive`** (dead end) for a user with no quota. Now, when the user **cannot self-create** (`!canCreate`, i.e. no quota), that button is hidden and an active **"Request a hive"** link takes its place, routing to **`/get-started`** — the SAME Request-a-Hive wizard the hub main page uses (files a provision request via `POST /api/saas/request-provision`). When the user **does** have quota, the working `+ Add Hosted Hive` button is kept as-is.

## 2. Register your own hive → the existing self-host guide
A **distinct** button in the same group, always available, linking to **`/get-started#self-host`** — the existing self-host/register guide (its key step: set `HIVE_HUB_URL=https://hive.kubestellar.io` and the hive auto-appears in Active Hives within ~5 min). For a user who self-installed a standalone hive and wants to attach it to this hub. Tooltips clarify the difference: **"Request a hive"** (we host it) vs **"Register your own hive"** (you self-host, attach it here).

## 3. Contribute-first on Public Hives (no access required)
`/contribute` is a **public endpoint** (`publicPaths` includes `/contribute`) — lending compute does **not** require access. Previously the Public Hives table showed **`Request Access`** as the primary action on every row (wrong — you can contribute without access). Now **"Contribute"** is the **primary** action for everyone (built from the hive's heartbeat-reported dashboard URL via `resolvedBase(h)` + `/contribute`, `target=_blank`), regardless of access status. **Request access** is demoted to a small **secondary** link (reusing the existing `dashRequestAccess` modal) for users who genuinely want sign-in / manage access. The **Pending** state and the **"Contribute unavailable"** fallback (no reported dashboard URL) are preserved; the green Contribute styling is kept.

## 4. My-Hives empty-state CTAs
The old flat "No hives yet / Log in to a local hive dashboard…" text is replaced with clear CTAs: a prominent **"Request a hive"** (→`/get-started`), a **"Register your own hive"** (→`/get-started#self-host`), and a line pointing at the Public Hives section ("…or contribute to a public hive below").

## Notes
- **No new backend.** Reuses `/get-started`, `/get-started#self-host`, `/contribute`, the `POST /api/saas/request-provision` provision-request flow, and the existing `dashRequestAccess` for the secondary access action.
- **Contribute needs no access** — it's a public endpoint.
- Tests: dashboard-structure `strings.Contains` pins (`v2/pkg/hub/saas_dashboard_user_view_test.go`) assert the Request/Register affordances link to the right pages, Contribute is the primary public-hive action, and the empty state carries both CTAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)