### PR TITLE
✨ feat(inference): add IBM watsonx.ai as a first-class gateway kind (Granite)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -50,6 +50,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/snapshot"
 	"github.com/kubestellar/hive/v2/pkg/tokens"
 	"github.com/kubestellar/hive/v2/pkg/trajectory"
+	"github.com/kubestellar/hive/v2/pkg/watsonx"
 )
 
 var (
@@ -2434,12 +2435,35 @@ func main() {
 					if model == "" {
 						model = gw.DefaultModel
 					}
+					// watsonx authenticates the OpenAI-compatible model gateway
+					// with a short-lived IAM bearer minted from the IBM Cloud API
+					// key (NOT the raw key), and scopes billing/limits by a
+					// project id sent as X-IBM-Project-ID. Mint (cached) and set
+					// both here; every other kind sends the resolved key verbatim.
+					apiKey := gw.ResolveAPIKey()
+					var extraHeaders map[string]string
+					if strings.EqualFold(gw.Kind, config.GatewayKindWatsonx) {
+						token, terr := watsonx.DefaultMinter.Token(context.Background(), apiKey)
+						if terr != nil {
+							logger.Warn("watsonx IAM token mint failed; agent inference will fail until the key/project are valid",
+								"agent", agentName, "gateway", backend, "error", terr.Error())
+							// Leave apiKey as-is (the raw key). watsonx will reject
+							// it, surfacing a clear upstream 401 rather than a
+							// silent success — better than dropping the route.
+						} else {
+							apiKey = token
+						}
+						if gw.ProjectID != "" {
+							extraHeaders = map[string]string{watsonx.ProjectIDHeader: gw.ProjectID}
+						}
+					}
 					githubProxy.SetInferenceRoute(agentName, &proxy.InferenceRoute{
-						Backend:  backend,
-						Endpoint: endpoint,
-						Model:    model,
-						APIKey:   gw.ResolveAPIKey(),
-						CABundle: gw.CABundle,
+						Backend:      backend,
+						Endpoint:     endpoint,
+						Model:        model,
+						APIKey:       apiKey,
+						CABundle:     gw.CABundle,
+						ExtraHeaders: extraHeaders,
 					})
 					return
 				}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -618,19 +618,39 @@ type GatewayConfig struct {
 	// "openrouter", "corp-litellm"). Must be non-empty and unique per hive.
 	Name string `yaml:"name" json:"name"`
 	// Kind drives preset defaults + labeling: openrouter | litellm | vllm |
-	// llm-d | custom. Purely descriptive at runtime (all are OpenAI-compatible);
-	// the endpoint is what actually routes.
+	// llm-d | watsonx | custom. Purely descriptive at runtime (all are
+	// OpenAI-compatible); the endpoint is what actually routes. The one
+	// exception is "watsonx", which additionally needs an IAM-minted bearer
+	// (not the raw key) and a project_id header — see ProjectID below and the
+	// watsonx token minter (pkg/watsonx).
 	Kind string `yaml:"kind" json:"kind,omitempty"`
 	// Endpoint is the OpenAI-compatible base URL, e.g. https://openrouter.ai/api/v1.
+	// For a watsonx gateway this is the model-gateway base
+	// https://<region>.ml.cloud.ibm.com/ml/gateway — hive appends /v1/models and
+	// /v1/chat/completions to reach watsonx's OpenAI-compatible surface
+	// (.../ml/gateway/v1/models, .../ml/gateway/v1/chat/completions).
 	Endpoint string `yaml:"endpoint" json:"endpoint"`
 	// APIKeyEnv / APIKeyFile resolve this gateway's key (env var NAME and/or file
 	// PATH — never the value). Empty is allowed for keyless endpoints (some vLLM).
+	// For watsonx this resolves the IBM Cloud API key that is exchanged for a
+	// short-lived IAM token; the raw key is never sent as the bearer.
 	APIKeyEnv  string `yaml:"api_key_env" json:"api_key_env,omitempty"`
 	APIKeyFile string `yaml:"api_key_file" json:"api_key_file,omitempty"`
 	// DefaultModel is used when an agent routed through this gateway selects none.
 	DefaultModel string `yaml:"default_model" json:"default_model,omitempty"`
 	// CABundle is an optional PEM path for a private CA (never disables verify).
 	CABundle string `yaml:"ca_bundle" json:"ca_bundle,omitempty"`
+	// ProjectID is the watsonx project (or space) id an OpenAI client does not
+	// send but watsonx requires for billing/limits. It is sent as the
+	// X-IBM-Project-ID header on outbound requests to a watsonx gateway. Only
+	// meaningful for Kind == watsonx; omitempty keeps existing gateways
+	// byte-identical in hive.yaml. Not a secret (an identifier, not a
+	// credential), so unlike the key it is stored inline.
+	ProjectID string `yaml:"project_id,omitempty" json:"project_id,omitempty"`
+	// Region is the watsonx region slug (e.g. us-south, eu-de, jp-tok) the UI
+	// preset uses to build the endpoint template. Purely a convenience for the
+	// preset; Endpoint is authoritative. Only meaningful for Kind == watsonx.
+	Region string `yaml:"region,omitempty" json:"region,omitempty"`
 }
 
 // gatewayKind values.
@@ -639,6 +659,7 @@ const (
 	GatewayKindLiteLLM    = "litellm"
 	GatewayKindVLLM       = "vllm"
 	GatewayKindLLMD       = "llm-d"
+	GatewayKindWatsonx    = "watsonx"
 	GatewayKindCustom     = "custom"
 
 	// legacyLiteLLMGatewayName is the name of the implicit gateway synthesized

--- a/v2/pkg/config/watsonx_gateway_test.go
+++ b/v2/pkg/config/watsonx_gateway_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// A watsonx gateway parses from YAML with its kind, endpoint, project_id, and a
+// key reference, and resolves its key from the referenced file — exactly like
+// any other gateway. project_id/region are plain (non-secret) inline fields.
+func TestWatsonxGatewayParse(t *testing.T) {
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "wx_api_key")
+	if err := os.WriteFile(keyFile, []byte("ibm-cloud-key-VALUE\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	y := `
+name: watsonx
+kind: watsonx
+endpoint: https://us-south.ml.cloud.ibm.com/ml/gateway
+project_id: 63dc4cf1-252f-424b-b52d-5cdd9814987f
+region: us-south
+api_key_file: ` + keyFile + `
+default_model: ibm/granite-4-h-small
+`
+	var gw GatewayConfig
+	if err := yaml.Unmarshal([]byte(y), &gw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if gw.Kind != GatewayKindWatsonx {
+		t.Fatalf("kind = %q, want %q", gw.Kind, GatewayKindWatsonx)
+	}
+	if gw.ProjectID != "63dc4cf1-252f-424b-b52d-5cdd9814987f" {
+		t.Fatalf("project_id = %q", gw.ProjectID)
+	}
+	if gw.Region != "us-south" {
+		t.Fatalf("region = %q", gw.Region)
+	}
+	if gw.Endpoint != "https://us-south.ml.cloud.ibm.com/ml/gateway" {
+		t.Fatalf("endpoint = %q", gw.Endpoint)
+	}
+	if got := gw.ResolveAPIKey(); got != "ibm-cloud-key-VALUE" {
+		t.Fatalf("ResolveAPIKey = %q, want the file's key", got)
+	}
+}
+
+// omitempty keeps project_id/region out of the serialized gateway for non-watsonx
+// kinds, so existing gateways round-trip byte-identical (backward compatibility).
+func TestNonWatsonxGatewayOmitsWatsonxFields(t *testing.T) {
+	gw := GatewayConfig{
+		Name:     "openrouter",
+		Kind:     GatewayKindOpenRouter,
+		Endpoint: "https://openrouter.ai/api/v1",
+	}
+	out, err := yaml.Marshal(gw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	if strings.Contains(s, "project_id") || strings.Contains(s, "region") {
+		t.Fatalf("non-watsonx gateway serialized watsonx-only fields:\n%s", s)
+	}
+}
+
+// A watsonx gateway name is accepted as a valid agent backend by validate(),
+// just like any other gateway (routing resolves it via ResolveGateway).
+func TestWatsonxGatewayNameValidAsBackend(t *testing.T) {
+	c := &Config{
+		Project: ProjectConfig{Org: "acme"},
+		GitHub:  GitHubConfig{Token: "x"},
+		Agents: map[string]AgentConfig{
+			"granite-scanner": {Backend: "watsonx"},
+		},
+		Governor: GovernorConfig{
+			Gateways: []GatewayConfig{
+				{
+					Name:      "watsonx",
+					Kind:      GatewayKindWatsonx,
+					Endpoint:  "https://us-south.ml.cloud.ibm.com/ml/gateway",
+					ProjectID: "proj-1",
+				},
+			},
+		},
+	}
+	if err := c.validate(); err != nil {
+		t.Fatalf("watsonx gateway name should be a valid backend, got: %v", err)
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3566,9 +3566,9 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			// actually in force.
 			"contribute_cooldown_enabled": cfg.Hub.IsContributeCooldownEnabled(),
 			"contribute_cooldown_hours":   cfg.Hub.ContributeCooldownHoursOrDefault(),
-			"disabled_repos":                     cfg.Hub.DisabledRepos,
-			"disabled_tiers":                     cfg.Hub.DisabledTiers,
-			"tier_limits":                        cfg.Hub.TierLimits,
+			"disabled_repos":              cfg.Hub.DisabledRepos,
+			"disabled_tiers":              cfg.Hub.DisabledTiers,
+			"tier_limits":                 cfg.Hub.TierLimits,
 			// available_repos is the READ-ONLY list of repo full-names the hive knows
 			// about (from the live status snapshot), so the Management tab can render
 			// a per-repo enable toggle mirror of the Governor Hub "Repos for Contribute"
@@ -4146,6 +4146,14 @@ func redactLiteLLMKeyMaterial(s string) string {
 // so the UI can show e.g. LiteLLM's "token not found" instead of a bare
 // status code.
 func probeLiteLLMModels(endpoint, apiKey string) (int, error) {
+	return probeModelsWithHeaders(endpoint, apiKey, nil)
+}
+
+// probeModelsWithHeaders is probeLiteLLMModels with an optional set of extra
+// request headers (e.g. watsonx's X-IBM-Project-ID). apiKey, when non-empty, is
+// still sent as the Bearer — for watsonx the caller passes the minted IAM token
+// as apiKey, not the raw key.
+func probeModelsWithHeaders(endpoint, apiKey string, extraHeaders map[string]string) (int, error) {
 	modelsURL := strings.TrimRight(endpoint, "/") + "/v1/models"
 	req, err := http.NewRequest("GET", modelsURL, nil)
 	if err != nil {
@@ -4153,6 +4161,11 @@ func probeLiteLLMModels(endpoint, apiKey string) (int, error) {
 	}
 	if apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	for k, v := range extraHeaders {
+		if v != "" {
+			req.Header.Set(k, v)
+		}
 	}
 	client := &http.Client{Timeout: litellmProbeTimeout}
 	resp, err := client.Do(req)
@@ -5443,6 +5456,13 @@ func fetchModelsFromEndpoints(endpoints []string, apiKey string) []string {
 }
 
 func fetchModelsFromEndpoint(baseURL, apiKey string) ([]string, error) {
+	return fetchModelsWithHeaders(baseURL, apiKey, nil)
+}
+
+// fetchModelsWithHeaders is fetchModelsFromEndpoint with optional extra request
+// headers (e.g. watsonx's X-IBM-Project-ID). apiKey, when non-empty, is sent as
+// the Bearer; for watsonx the caller passes the minted IAM token as apiKey.
+func fetchModelsWithHeaders(baseURL, apiKey string, extraHeaders map[string]string) ([]string, error) {
 	modelsURL := strings.TrimRight(baseURL, "/") + "/v1/models"
 	client := &http.Client{Timeout: inferenceModelQueryTimeout}
 	req, err := http.NewRequest("GET", modelsURL, nil)
@@ -5451,6 +5471,11 @@ func fetchModelsFromEndpoint(baseURL, apiKey string) ([]string, error) {
 	}
 	if apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	for k, v := range extraHeaders {
+		if v != "" {
+			req.Header.Set(k, v)
+		}
 	}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/v2/pkg/dashboard/gateways.go
+++ b/v2/pkg/dashboard/gateways.go
@@ -32,6 +32,18 @@ import (
 // dashboard request. Independent of the probe's own HTTP timeout.
 const watsonxProbeMintTimeout = 10 * time.Second
 
+// watsonxEndpointForRegion builds the watsonx model-gateway base URL for a
+// region slug, falling back to the default region when blank. Mirrors how the
+// UI preset fills the endpoint; kept server-side too so the region template has
+// one source of truth.
+func watsonxEndpointForRegion(region string) string {
+	region = strings.TrimSpace(region)
+	if region == "" {
+		region = watsonxDefaultRegion
+	}
+	return fmt.Sprintf(watsonxBaseURLTemplate, region)
+}
+
 // gatewayProbeAuth resolves the bearer + extra request headers a /v1/models
 // probe (or model discovery) should present for a gateway. For every kind
 // except watsonx this is just the resolved key as the Bearer and no extra
@@ -60,6 +72,18 @@ const (
 	// openRouterBaseURL is the OpenAI-compatible base URL for OpenRouter. Used
 	// as the preset endpoint when the UI picks the OpenRouter gateway kind.
 	openRouterBaseURL = "https://openrouter.ai/api/v1"
+
+	// watsonxBaseURLTemplate is the watsonx model-gateway base URL with a
+	// %s placeholder for the region slug (us-south, eu-de, jp-tok, …). hive
+	// appends /v1/models and /v1/chat/completions to reach watsonx's
+	// OpenAI-compatible surface (.../ml/gateway/v1/...). Used as the preset
+	// endpoint when the UI picks the watsonx gateway kind. Mirrors
+	// openRouterBaseURL for consistency.
+	watsonxBaseURLTemplate = "https://%s.ml.cloud.ibm.com/ml/gateway"
+
+	// watsonxDefaultRegion is the region the preset offers when none is chosen,
+	// so the endpoint template resolves to a concrete URL out of the box.
+	watsonxDefaultRegion = "us-south"
 
 	// gatewaySecretFileMode / gatewaySecretDirMode keep gateway key files
 	// owner-only, matching the LiteLLM key store (litellmKeyFileMode).
@@ -175,6 +199,16 @@ func (s *Server) handleGovernorGatewaysUpsert(w http.ResponseWriter, r *http.Req
 	}
 
 	endpoint := strings.TrimSpace(body.Endpoint)
+	// A watsonx gateway may be configured by REGION alone (the guided form can
+	// send a region, not a URL): derive the model-gateway base from the region
+	// template so the user never has to hand-type the endpoint.
+	if endpoint == "" && kind == config.GatewayKindWatsonx {
+		region := ""
+		if body.Region != nil {
+			region = strings.TrimSpace(*body.Region)
+		}
+		endpoint = watsonxEndpointForRegion(region)
+	}
 	if endpoint == "" {
 		jsonError(w, "endpoint is required", http.StatusBadRequest)
 		return

--- a/v2/pkg/dashboard/gateways.go
+++ b/v2/pkg/dashboard/gateways.go
@@ -14,15 +14,47 @@ package dashboard
 // hive.yaml — the key value never enters hive.yaml, logs, or API responses.
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/watsonx"
 )
+
+// watsonxProbeMintTimeout bounds the IAM token mint done just to run a
+// save-time/discover /v1/models probe, so a slow IAM endpoint cannot stall the
+// dashboard request. Independent of the probe's own HTTP timeout.
+const watsonxProbeMintTimeout = 10 * time.Second
+
+// gatewayProbeAuth resolves the bearer + extra request headers a /v1/models
+// probe (or model discovery) should present for a gateway. For every kind
+// except watsonx this is just the resolved key as the Bearer and no extra
+// headers — identical to the prior behavior. For watsonx it mints (and caches)
+// an IAM token from the resolved IBM Cloud API key and adds the X-IBM-Project-ID
+// header; a mint failure is returned so the probe surfaces a real error instead
+// of silently sending the raw key. Never logs the key or token.
+func gatewayProbeAuth(kind, key, projectID string) (bearer string, headers map[string]string, err error) {
+	if kind != config.GatewayKindWatsonx {
+		return key, nil, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), watsonxProbeMintTimeout)
+	defer cancel()
+	token, err := watsonx.DefaultMinter.Token(ctx, key)
+	if err != nil {
+		return "", nil, err
+	}
+	headers = map[string]string{}
+	if projectID != "" {
+		headers[watsonx.ProjectIDHeader] = projectID
+	}
+	return token, headers, nil
+}
 
 const (
 	// openRouterBaseURL is the OpenAI-compatible base URL for OpenRouter. Used
@@ -46,6 +78,7 @@ var validGatewayKinds = map[string]bool{
 	config.GatewayKindLiteLLM:    true,
 	config.GatewayKindVLLM:       true,
 	config.GatewayKindLLMD:       true,
+	config.GatewayKindWatsonx:    true,
 	config.GatewayKindCustom:     true,
 }
 
@@ -67,8 +100,13 @@ func gatewaySectionResponse(gw config.GatewayConfig) map[string]interface{} {
 		"api_key_file":  gw.APIKeyFile,
 		"default_model": gw.DefaultModel,
 		"ca_bundle":     gw.CABundle,
-		"hasKey":        key != "",
-		"keyHint":       keyHint,
+		// watsonx-only identifiers (not secrets) — empty for other kinds and
+		// omitted from hive.yaml via omitempty, so existing gateways are
+		// unaffected.
+		"project_id": gw.ProjectID,
+		"region":     gw.Region,
+		"hasKey":     key != "",
+		"keyHint":    keyHint,
 	}
 }
 
@@ -103,6 +141,8 @@ func (s *Server) handleGovernorGatewaysUpsert(w http.ResponseWriter, r *http.Req
 		APIKeyFile   *string `json:"api_key_file"`
 		DefaultModel *string `json:"default_model"`
 		CABundle     *string `json:"ca_bundle"`
+		ProjectID    *string `json:"project_id"`
+		Region       *string `json:"region"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
@@ -130,7 +170,7 @@ func (s *Server) handleGovernorGatewaysUpsert(w http.ResponseWriter, r *http.Req
 		kind = config.GatewayKindCustom
 	}
 	if !validGatewayKinds[kind] {
-		jsonError(w, fmt.Sprintf("invalid gateway kind %q (openrouter, litellm, vllm, llm-d, custom)", kind), http.StatusBadRequest)
+		jsonError(w, fmt.Sprintf("invalid gateway kind %q (openrouter, litellm, vllm, llm-d, watsonx, custom)", kind), http.StatusBadRequest)
 		return
 	}
 
@@ -183,6 +223,8 @@ func (s *Server) handleGovernorGatewaysUpsert(w http.ResponseWriter, r *http.Req
 		gw.APIKeyFile = gws[idx].APIKeyFile
 		gw.DefaultModel = gws[idx].DefaultModel
 		gw.CABundle = gws[idx].CABundle
+		gw.ProjectID = gws[idx].ProjectID
+		gw.Region = gws[idx].Region
 	}
 	if body.APIKeyEnv != nil {
 		gw.APIKeyEnv = strings.TrimSpace(*body.APIKeyEnv)
@@ -196,9 +238,36 @@ func (s *Server) handleGovernorGatewaysUpsert(w http.ResponseWriter, r *http.Req
 	if body.CABundle != nil {
 		gw.CABundle = strings.TrimSpace(*body.CABundle)
 	}
+	if body.ProjectID != nil {
+		gw.ProjectID = strings.TrimSpace(*body.ProjectID)
+	}
+	if body.Region != nil {
+		gw.Region = strings.TrimSpace(*body.Region)
+	}
+
+	submittedKey := strings.TrimSpace(body.APIKey)
+
+	// watsonx needs two things an ordinary OpenAI-compatible gateway does not:
+	// a project id (scopes billing/limits; sent as the X-IBM-Project-ID header)
+	// and an IBM Cloud API key (exchanged for a short-lived IAM bearer — the raw
+	// key is never sent). Reject a watsonx gateway missing either so the failure
+	// is a clear config error now, not an opaque 401/400 at agent inference time.
+	// Checked BEFORE the key is written to disk so an invalid watsonx config
+	// never leaves a stray secret file behind.
+	if kind == config.GatewayKindWatsonx {
+		if gw.ProjectID == "" {
+			jsonError(w, "watsonx gateway requires a project_id (the watsonx project or space id)", http.StatusBadRequest)
+			return
+		}
+		// A key is present if one was just submitted or a prior reference
+		// resolves to a value.
+		if submittedKey == "" && gw.ResolveAPIKey() == "" {
+			jsonError(w, "watsonx gateway requires an IBM Cloud API key", http.StatusBadRequest)
+			return
+		}
+	}
 
 	// Store a submitted key VALUE outside hive.yaml and point api_key_file at it.
-	submittedKey := strings.TrimSpace(body.APIKey)
 	if submittedKey != "" {
 		path, err := s.storeGatewayAPIKey(name, submittedKey)
 		if err != nil {
@@ -289,9 +358,11 @@ func (s *Server) handleGovernorGatewaysDelete(w http.ResponseWriter, r *http.Req
 // key. Returns {ok, models:[...]} or {ok:false, error}.
 func (s *Server) handleGovernorGatewaysDiscover(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Name     string `json:"name"`
-		Endpoint string `json:"endpoint"`
-		APIKey   string `json:"api_key"`
+		Name      string `json:"name"`
+		Endpoint  string `json:"endpoint"`
+		APIKey    string `json:"api_key"`
+		Kind      string `json:"kind"`
+		ProjectID string `json:"project_id"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
@@ -307,17 +378,46 @@ func (s *Server) handleGovernorGatewaysDiscover(w http.ResponseWriter, r *http.R
 		return
 	}
 	key := strings.TrimSpace(body.APIKey)
-	if key == "" {
-		// Fall back to the stored key for an existing gateway of this name, so
-		// editing an existing gateway populates its models without retyping.
+	kind := strings.ToLower(strings.TrimSpace(body.Kind))
+	projectID := strings.TrimSpace(body.ProjectID)
+	// For fields the form did not send (editing an existing gateway without
+	// retyping the key, or a kind/project the client omitted), fall back to the
+	// stored gateway of this name.
+	if key == "" || kind == "" || projectID == "" {
 		if gw := s.deps.Config.Governor.ResolveGateway(strings.TrimSpace(body.Name)); gw != nil {
-			key = gw.ResolveAPIKey()
+			if key == "" {
+				key = gw.ResolveAPIKey()
+			}
+			if kind == "" {
+				kind = gw.Kind
+			}
+			if projectID == "" {
+				projectID = gw.ProjectID
+			}
 		}
 	}
-	models, err := fetchModelsFromEndpoint(endpoint, key)
+	bearer, headers, err := gatewayProbeAuth(kind, key, projectID)
 	if err != nil {
+		// For watsonx a mint failure (no/invalid key yet) still offers the
+		// static Granite list so the Default Model dropdown is never a dead end.
+		if kind == config.GatewayKindWatsonx {
+			jsonResponse(w, map[string]interface{}{"ok": true, "models": watsonx.GraniteFallbackModels, "fallback": true})
+			return
+		}
 		jsonResponse(w, map[string]interface{}{"ok": false, "error": redactSecret(err.Error(), key)})
 		return
+	}
+	models, err := fetchModelsWithHeaders(endpoint, bearer, headers)
+	if err != nil {
+		if kind == config.GatewayKindWatsonx {
+			jsonResponse(w, map[string]interface{}{"ok": true, "models": watsonx.GraniteFallbackModels, "fallback": true})
+			return
+		}
+		jsonResponse(w, map[string]interface{}{"ok": false, "error": redactSecret(redactSecret(err.Error(), key), bearer)})
+		return
+	}
+	if len(models) == 0 && kind == config.GatewayKindWatsonx {
+		models = watsonx.GraniteFallbackModels
 	}
 	jsonResponse(w, map[string]interface{}{"ok": true, "models": models})
 }
@@ -353,9 +453,15 @@ func (s *Server) gatewayProbeResult(gw config.GatewayConfig, overrideKey string)
 	if probeKey == "" {
 		probeKey = gw.ResolveAPIKey()
 	}
-	n, err := probeLiteLLMModels(ep, probeKey)
+	bearer, headers, err := gatewayProbeAuth(gw.Kind, probeKey, gw.ProjectID)
 	if err != nil {
 		return map[string]interface{}{"ok": false, "error": redactSecret(err.Error(), probeKey)}
+	}
+	n, err := probeModelsWithHeaders(ep, bearer, headers)
+	if err != nil {
+		// Redact both the raw key and the minted bearer (watsonx) from any
+		// echoed upstream error body.
+		return map[string]interface{}{"ok": false, "error": redactSecret(redactSecret(err.Error(), probeKey), bearer)}
 	}
 	return map[string]interface{}{"ok": true, "model_count": n}
 }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -14406,6 +14406,10 @@ function burnAreaChart() {
       { kind: 'litellm',    label: 'LiteLLM',    endpoint: '' },
       { kind: 'vllm',       label: 'vLLM',       endpoint: '' },
       { kind: 'llm-d',      label: 'llm-d',      endpoint: '' },
+      // watsonx: the OpenAI-compatible model-gateway base. hive appends
+      // /v1/models and /v1/chat/completions to reach .../ml/gateway/v1/...
+      // Replace <region> with your watsonx region (us-south, eu-de, jp-tok, …).
+      { kind: 'watsonx',    label: 'watsonx',    endpoint: 'https://us-south.ml.cloud.ibm.com/ml/gateway' },
       { kind: 'custom',     label: 'Custom',     endpoint: '' },
     ];
 
@@ -14415,6 +14419,7 @@ function burnAreaChart() {
       litellm:    { label: 'LiteLLM',    color: 'var(--accent)' },
       vllm:       { label: 'vLLM',       color: 'var(--green)' },
       'llm-d':    { label: 'llm-d',      color: 'var(--purple, #a78bfa)' },
+      watsonx:    { label: 'watsonx',    color: 'var(--blue, #3b82f6)' },
       custom:     { label: 'Custom',     color: 'var(--muted)' },
     };
 
@@ -14804,7 +14809,7 @@ function burnAreaChart() {
       const host = document.getElementById('gateways-form-host');
       if (!host) return;
       const isEdit = !!existing;
-      const gw = existing || { name: '', kind: 'custom', endpoint: '', default_model: '', hasKey: false };
+      const gw = existing || { name: '', kind: 'custom', endpoint: '', default_model: '', hasKey: false, project_id: '' };
       const presetButtons = GATEWAY_PRESETS.map(function(p) {
         const active = gw.kind === p.kind;
         return `<button type="button" onclick="applyGatewayPreset('${p.kind}')" data-gw-preset="${p.kind}" style="padding:5px 12px;border:1px solid ${active ? 'var(--cyan)' : 'var(--border)'};border-radius:6px;background:${active ? 'var(--cyan)' : 'var(--bg)'};color:${active ? 'var(--bg)' : 'var(--fg)'};cursor:pointer;font-size:0.74rem;font-weight:600">${esc(p.label)}</button>`;
@@ -14824,6 +14829,11 @@ function burnAreaChart() {
           <div class="config-field" style="margin-bottom:10px">
             <label>Endpoint URL</label>
             <input type="text" id="gw-endpoint" value="${esc(gw.endpoint || '')}" placeholder="https://…/v1" onchange="onGatewayEndpointOrKeyChange()">
+          </div>
+          <div class="config-field" id="gw-project-id-field" style="margin-bottom:10px;display:${(gw.kind === 'watsonx') ? 'block' : 'none'}">
+            <label>watsonx Project ID</label>
+            <input type="text" id="gw-project-id" value="${esc(gw.project_id || '')}" placeholder="e.g. 63dc4cf1-252f-424b-b52d-5cdd9814987f" onchange="onGatewayEndpointOrKeyChange()">
+            <div style="font-size:0.7rem;margin-top:3px;color:var(--muted)">Required for watsonx — sent as the X-IBM-Project-ID header. Your API key is exchanged for a short-lived IAM token; the raw key is never sent.</div>
           </div>
           <div class="config-field" style="margin-bottom:10px">
             <label>API Key</label>
@@ -14861,6 +14871,9 @@ function burnAreaChart() {
       // Only overwrite the endpoint when the preset carries one, so switching
       // to Custom doesn't wipe a URL the user already typed.
       if (epEl && preset.endpoint) epEl.value = preset.endpoint;
+      // The watsonx project-id field is only relevant for the watsonx kind.
+      const projField = document.getElementById('gw-project-id-field');
+      if (projField) projField.style.display = (preset.kind === 'watsonx') ? 'block' : 'none';
       // Re-render the preset button row so the active highlight follows.
       document.querySelectorAll('[data-gw-preset]').forEach(function(btn) {
         const active = btn.getAttribute('data-gw-preset') === preset.kind;
@@ -14936,6 +14949,8 @@ function burnAreaChart() {
       const nameEl = document.getElementById('gw-name');
       const epEl = document.getElementById('gw-endpoint');
       const keyEl = document.getElementById('gw-apikey');
+      const kindEl = document.getElementById('gw-kind');
+      const projEl = document.getElementById('gw-project-id');
       const endpoint = epEl ? epEl.value.trim() : '';
       if (!endpoint) return;
       // Preserve whatever the user has currently chosen before re-rendering.
@@ -14947,7 +14962,11 @@ function burnAreaChart() {
           body: JSON.stringify({
             name: nameEl ? nameEl.value.trim() : '',
             endpoint: endpoint,
-            api_key: keyEl ? keyEl.value.trim() : ''
+            api_key: keyEl ? keyEl.value.trim() : '',
+            // watsonx discovery needs the kind + project id to mint the IAM
+            // token and set X-IBM-Project-ID; harmless for other kinds.
+            kind: kindEl ? kindEl.value : '',
+            project_id: projEl ? projEl.value.trim() : ''
           })
         });
         const data = await res.json().catch(() => ({}));
@@ -14967,15 +14986,20 @@ function burnAreaChart() {
       const kind = (document.getElementById('gw-kind') || {}).value || 'custom';
       const endpoint = (document.getElementById('gw-endpoint') || {}).value || '';
       const apiKey = (document.getElementById('gw-apikey') || {}).value || '';
+      const projectId = (document.getElementById('gw-project-id') || {}).value || '';
       const defaultModel = gatewayCurrentDefaultModel();
       const resultEl = document.getElementById('gw-form-result');
       if (!name.trim()) { showToast('Gateway name is required', 'error'); return; }
       if (!endpoint.trim()) { showToast('Endpoint is required', 'error'); return; }
+      if (kind === 'watsonx' && !projectId.trim()) { showToast('watsonx requires a Project ID', 'error'); return; }
       const payload = {
         name: name.trim(),
         kind: kind,
         endpoint: endpoint.trim(),
         default_model: defaultModel,
+        // Always sent so clearing the field on a non-watsonx gateway persists;
+        // omitempty on the server keeps it out of hive.yaml when blank.
+        project_id: projectId.trim(),
       };
       // Only send api_key when the user typed one (empty = keep existing key).
       if (apiKey.trim()) payload.api_key = apiKey.trim();

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6443,9 +6443,9 @@
     // 'openrouter' is a first-class inference method (an OpenAI-compatible gateway
     // preset), so it appears in every backend/method picker even before a matching
     // Model Gateway is configured — the user picks it, then funds/configures it.
-    const KNOWN_BACKENDS = ['claude', 'copilot', 'bob', 'gemini', 'codex', 'amazonq', 'goose', 'aider', 'vllm', 'llm-d', 'litellm', 'openrouter'];
+    const KNOWN_BACKENDS = ['claude', 'copilot', 'bob', 'gemini', 'codex', 'amazonq', 'goose', 'aider', 'vllm', 'llm-d', 'litellm', 'openrouter', 'watsonx'];
     const FREE_BACKENDS = ['copilot', 'goose'];
-    const INFERENCE_BACKENDS = ['vllm', 'llm-d', 'litellm', 'openrouter'];
+    const INFERENCE_BACKENDS = ['vllm', 'llm-d', 'litellm', 'openrouter', 'watsonx'];
     // Names of Model Gateways configured under Governor Config → Model Gateways
     // (e.g. 'openrouter'). Agent routing already resolves a gateway name, but
     // the backend pickers only listed KNOWN_BACKENDS — so a configured gateway
@@ -12334,7 +12334,7 @@ function burnAreaChart() {
     // methods need a Model Gateway configured FOR THAT method (Governor
     // Config → Model Gateways). The check is per-method — an openrouter
     // gateway does not satisfy a vllm selection.
-    const GATEWAY_METHODS = ['openrouter', 'litellm', 'vllm', 'llm-d'];
+    const GATEWAY_METHODS = ['openrouter', 'litellm', 'vllm', 'llm-d', 'watsonx'];
 
     // maybeOpenMethodConfig runs AFTER a method switch is saved: the choice is
     // never blocked, but when the selected method's backing config is absent
@@ -12369,6 +12369,10 @@ function burnAreaChart() {
         const has = (d.gateways || []).some(g => g && (g.kind === backend || g.name === backend));
         if (!has) {
           showToast('No ' + backend + ' gateway configured — opening Governor Config → Model Gateways', 'info');
+          // Guided jump: land the user directly on a NEW gateway form pre-set to
+          // this method's kind (endpoint/preset already filled) instead of an
+          // empty list they must then "+ Add" from. Consumed by loadGateways().
+          _pendingGatewayPresetKind = backend;
           openConfigDialog('governor', null, 'Model Gateways');
         }
       } catch (e) { /* presence check is best-effort; never surface as a switch error */ }
@@ -14431,6 +14435,10 @@ function burnAreaChart() {
     // the models discovered for the add/edit form's endpoint+key.
     let _gateways = [];
     let _gatewayFormModels = [];
+    // Set by maybeOpenMethodConfig when a method switch jumps the user here to
+    // configure a missing gateway; consumed once by loadGateways to auto-open a
+    // preset add-form. null when the tab was opened normally.
+    let _pendingGatewayPresetKind = null;
 
     function gatewayKindMeta(kind) {
       return GATEWAY_KIND_META[kind] || GATEWAY_KIND_META.custom;
@@ -14711,6 +14719,16 @@ function burnAreaChart() {
           .map(g => g.name)
           .filter(name => name && !KNOWN_BACKENDS.includes(name));
         renderGatewaysList();
+        // Guided jump from a method switch (maybeOpenMethodConfig): if we were
+        // sent here to configure a specific kind, open a fresh add-form already
+        // preset to it (endpoint/preset filled) so the user lands on the form,
+        // not the empty list. One-shot: cleared after consuming.
+        if (_pendingGatewayPresetKind) {
+          const presetKind = _pendingGatewayPresetKind;
+          _pendingGatewayPresetKind = null;
+          openGatewayForm(null);
+          applyGatewayPreset(presetKind);
+        }
       } catch (e) {
         if (host) host.innerHTML = `<div style="color:var(--red);font-size:0.8rem">Failed to load gateways: ${esc(e.message)}</div>`;
       }
@@ -14871,6 +14889,14 @@ function burnAreaChart() {
       // Only overwrite the endpoint when the preset carries one, so switching
       // to Custom doesn't wipe a URL the user already typed.
       if (epEl && preset.endpoint) epEl.value = preset.endpoint;
+      // Default the (still-empty) name to the kind so a guided add-form is
+      // ready to save — a gateway named after its kind is exactly what an
+      // agent whose backend is that method resolves to. Never clobbers a name
+      // the user already typed, nor the readonly name in edit mode.
+      const nameEl = document.getElementById('gw-name');
+      if (nameEl && !nameEl.readOnly && !nameEl.value.trim() && preset.kind !== 'custom') {
+        nameEl.value = preset.kind;
+      }
       // The watsonx project-id field is only relevant for the watsonx kind.
       const projField = document.getElementById('gw-project-id-field');
       if (projField) projField.style.display = (preset.kind === 'watsonx') ? 'block' : 'none';
@@ -15001,6 +15027,12 @@ function burnAreaChart() {
         // omitempty on the server keeps it out of hive.yaml when blank.
         project_id: projectId.trim(),
       };
+      // Persist the watsonx region (the preset derives the endpoint from it and
+      // the server can too when the endpoint is blank).
+      if (kind === 'watsonx') {
+        const regionForEndpoint = (endpoint.trim().match(/^https:\/\/([^.]+)\.ml\.cloud\.ibm\.com/) || [])[1];
+        if (regionForEndpoint) payload.region = regionForEndpoint;
+      }
       // Only send api_key when the user typed one (empty = keep existing key).
       if (apiKey.trim()) payload.api_key = apiKey.trim();
       try {

--- a/v2/pkg/dashboard/watsonx_gateway_test.go
+++ b/v2/pkg/dashboard/watsonx_gateway_test.go
@@ -192,6 +192,55 @@ func TestGatewayProbeAuthNonWatsonxPassthrough(t *testing.T) {
 	}
 }
 
+// The region template builds the watsonx model-gateway base URL, and a blank
+// region falls back to the default so the endpoint always resolves.
+func TestWatsonxEndpointForRegion(t *testing.T) {
+	if got := watsonxEndpointForRegion("eu-de"); got != "https://eu-de.ml.cloud.ibm.com/ml/gateway" {
+		t.Fatalf("eu-de endpoint = %q", got)
+	}
+	if got := watsonxEndpointForRegion("  "); got != "https://us-south.ml.cloud.ibm.com/ml/gateway" {
+		t.Fatalf("blank region should fall back to the default region, got %q", got)
+	}
+}
+
+// A watsonx gateway configured by REGION alone (no endpoint URL) derives its
+// endpoint from the region template — the guided form can send just region +
+// project + key.
+func TestWatsonxUpsert_DerivesEndpointFromRegion(t *testing.T) {
+	srv := newFullServer(t)
+	dir := t.TempDir()
+	orig := gatewaySecretsDir
+	gatewaySecretsDir = dir
+	t.Cleanup(func() { gatewaySecretsDir = orig })
+
+	// Point the shared minter + gateway at a fake so the save-time probe never
+	// hits the network.
+	fake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/identity/token") {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "IAM-JWT", "expires_in": 3600})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": []map[string]string{}})
+	}))
+	defer fake.Close()
+	origMinter := watsonx.DefaultMinter
+	watsonx.DefaultMinter = watsonx.NewTokenMinterForTest(fake.URL+"/identity/token", nil)
+	t.Cleanup(func() { watsonx.DefaultMinter = origMinter })
+
+	body := `{"name":"watsonx","kind":"watsonx","endpoint":"","region":"eu-de","project_id":"p","api_key":"ibm-cloud-key-1234567890"}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/gateways", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorGatewaysUpsert(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200 (body %s)", w.Code, w.Body.String())
+	}
+	gw := srv.deps.Config.Governor.Gateways[0]
+	if gw.Endpoint != "https://eu-de.ml.cloud.ibm.com/ml/gateway" {
+		t.Fatalf("endpoint = %q, want the region-derived URL", gw.Endpoint)
+	}
+}
+
 // The static Granite fallback list is non-empty and carries current granite ids,
 // so a watsonx model dropdown is never empty when live discovery cannot run.
 func TestGraniteFallbackNonEmpty(t *testing.T) {

--- a/v2/pkg/dashboard/watsonx_gateway_test.go
+++ b/v2/pkg/dashboard/watsonx_gateway_test.go
@@ -1,0 +1,213 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/watsonx"
+)
+
+// A watsonx gateway upsert missing the project_id is rejected (400) and leaves
+// config untouched — the failure is a clear config error now, not an opaque
+// upstream error at agent inference time.
+func TestWatsonxUpsert_RejectsMissingProjectID(t *testing.T) {
+	srv := newFullServer(t)
+	body := `{"name":"watsonx","kind":"watsonx","endpoint":"https://us-south.ml.cloud.ibm.com/ml/gateway","api_key":"ibm-cloud-key-1234567890"}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/gateways", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorGatewaysUpsert(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 (body %s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "project_id") {
+		t.Errorf("error should mention project_id: %s", w.Body.String())
+	}
+	if len(srv.deps.Config.Governor.Gateways) != 0 {
+		t.Errorf("config mutated on validation failure")
+	}
+}
+
+// A watsonx gateway upsert missing an API key is rejected (400).
+func TestWatsonxUpsert_RejectsMissingKey(t *testing.T) {
+	srv := newFullServer(t)
+	body := `{"name":"watsonx","kind":"watsonx","endpoint":"https://us-south.ml.cloud.ibm.com/ml/gateway","project_id":"proj-1"}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/gateways", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorGatewaysUpsert(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 (body %s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "API key") {
+		t.Errorf("error should mention the API key: %s", w.Body.String())
+	}
+	if len(srv.deps.Config.Governor.Gateways) != 0 {
+		t.Errorf("config mutated on validation failure")
+	}
+}
+
+// A watsonx gateway with both project_id and a key is accepted; the key is
+// stored as a file ref (never inlined) and project_id/region persist inline.
+func TestWatsonxUpsert_StoresGateway(t *testing.T) {
+	srv := newFullServer(t)
+	dir := t.TempDir()
+	orig := gatewaySecretsDir
+	gatewaySecretsDir = dir
+	t.Cleanup(func() { gatewaySecretsDir = orig })
+
+	// The upsert runs a save-time probe that, for watsonx, mints an IAM token.
+	// Point the shared minter at a fake IAM+models server so the test never
+	// touches the network (and stays deterministic under -race).
+	fake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/identity/token") {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "IAM-JWT", "expires_in": 3600})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": []map[string]string{{"id": "ibm/granite-4-h-small"}}})
+	}))
+	defer fake.Close()
+	origMinter := watsonx.DefaultMinter
+	watsonx.DefaultMinter = watsonx.NewTokenMinterForTest(fake.URL+"/identity/token", nil)
+	t.Cleanup(func() { watsonx.DefaultMinter = origMinter })
+
+	const secret = "ibm-cloud-key-super-secret-1234567890"
+	body := `{"name":"watsonx","kind":"watsonx","endpoint":"` + fake.URL + `/ml/gateway","project_id":"proj-42","region":"us-south","api_key":"` + secret + `","default_model":"ibm/granite-4-h-small"}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/gateways", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorGatewaysUpsert(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200 (body %s)", w.Code, w.Body.String())
+	}
+	gws := srv.deps.Config.Governor.Gateways
+	if len(gws) != 1 {
+		t.Fatalf("gateways = %d, want 1", len(gws))
+	}
+	gw := gws[0]
+	if gw.Kind != config.GatewayKindWatsonx || gw.ProjectID != "proj-42" || gw.Region != "us-south" {
+		t.Fatalf("gateway = %+v", gw)
+	}
+	// The key VALUE must never be inlined into config.
+	if strings.Contains(gw.APIKeyFile, "ibm-cloud-key") || gw.APIKeyEnv == secret {
+		t.Fatalf("secret leaked into config: %+v", gw)
+	}
+	if !strings.HasPrefix(gw.APIKeyFile, dir) {
+		t.Fatalf("api_key_file = %q, want a path under %s", gw.APIKeyFile, dir)
+	}
+	// The response must not echo the raw key.
+	if strings.Contains(w.Body.String(), secret) {
+		t.Errorf("upsert response echoed the secret value")
+	}
+}
+
+// watsonx model discovery hits the gateway's OpenAI-compatible /v1/models with
+// the minted IAM bearer AND the X-IBM-Project-ID header, and parses the returned
+// list — verified against a fake gateway. The endpoint the operator configures
+// (.../ml/gateway) plus hive's /v1/models suffix must reach the gateway's models
+// path.
+func TestWatsonxModelDiscovery(t *testing.T) {
+	var gotAuth, gotProject, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotProject = r.Header.Get(watsonx.ProjectIDHeader)
+		gotPath = r.URL.Path
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]string{
+				{"id": "ibm/granite-4-h-small"},
+				{"id": "ibm/granite-3-3-8b-instruct"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	headers := map[string]string{watsonx.ProjectIDHeader: "proj-123"}
+	models, err := fetchModelsWithHeaders(srv.URL, "IAM-JWT-token", headers)
+	if err != nil {
+		t.Fatalf("fetchModelsWithHeaders: %v", err)
+	}
+	if len(models) != 2 || models[0] != "ibm/granite-4-h-small" {
+		t.Fatalf("models = %v, want the two granite ids", models)
+	}
+	if gotAuth != "Bearer IAM-JWT-token" {
+		t.Fatalf("Authorization = %q, want the minted bearer", gotAuth)
+	}
+	if gotProject != "proj-123" {
+		t.Fatalf("%s = %q, want the project id", watsonx.ProjectIDHeader, gotProject)
+	}
+	if !strings.HasSuffix(gotPath, "/v1/models") {
+		t.Fatalf("path = %q, want a /v1/models suffix", gotPath)
+	}
+}
+
+// The save-time probe against a watsonx gateway sends the project header and the
+// bearer; when discovery fails the probe reports not-ok (never masquerading as
+// success). Here we drive probeModelsWithHeaders directly (the IAM-minting
+// wrapper is covered in the watsonx package).
+func TestWatsonxProbeCountsModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(watsonx.ProjectIDHeader) == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"missing project"}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]string{{"id": "ibm/granite-4-h-small"}},
+		})
+	}))
+	defer srv.Close()
+
+	// With the project header the probe succeeds and counts the model.
+	n, err := probeModelsWithHeaders(srv.URL, "bearer", map[string]string{watsonx.ProjectIDHeader: "p"})
+	if err != nil {
+		t.Fatalf("probe with project: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("model_count = %d, want 1", n)
+	}
+	// Without it the gateway 400s and the probe returns an error, not a false
+	// "0 models available" success.
+	if _, err := probeModelsWithHeaders(srv.URL, "bearer", nil); err == nil {
+		t.Fatal("probe without project should error, not report success")
+	}
+}
+
+// gatewayProbeAuth passes non-watsonx kinds through unchanged (raw key as
+// bearer, no extra headers) so existing gateways are unaffected by the watsonx
+// wiring.
+func TestGatewayProbeAuthNonWatsonxPassthrough(t *testing.T) {
+	bearer, headers, err := gatewayProbeAuth(config.GatewayKindOpenRouter, "sk-raw-key", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bearer != "sk-raw-key" {
+		t.Fatalf("bearer = %q, want the raw key unchanged for non-watsonx", bearer)
+	}
+	if len(headers) != 0 {
+		t.Fatalf("headers = %v, want none for non-watsonx", headers)
+	}
+}
+
+// The static Granite fallback list is non-empty and carries current granite ids,
+// so a watsonx model dropdown is never empty when live discovery cannot run.
+func TestGraniteFallbackNonEmpty(t *testing.T) {
+	if len(watsonx.GraniteFallbackModels) == 0 {
+		t.Fatal("Granite fallback list must not be empty")
+	}
+	foundGranite4 := false
+	for _, m := range watsonx.GraniteFallbackModels {
+		if strings.Contains(m, "granite-4") {
+			foundGranite4 = true
+		}
+		if !strings.HasPrefix(m, "ibm/granite") {
+			t.Fatalf("fallback id %q should be an ibm/granite foundation-model id", m)
+		}
+	}
+	if !foundGranite4 {
+		t.Fatal("fallback should include a granite-4 series id")
+	}
+}

--- a/v2/pkg/proxy/inference_route.go
+++ b/v2/pkg/proxy/inference_route.go
@@ -25,6 +25,11 @@ type InferenceRoute struct {
 	Preamble      string // prepended to the system prompt for inference backends; empty = use DefaultInferencePreamble
 	APIKey        string // optional bearer token for the upstream (litellm requires auth); never logged
 	CABundle      string // optional PEM path for a private CA; verification is never disabled
+	// ExtraHeaders are additional headers set on every upstream request for
+	// this route. Used for watsonx, which needs X-IBM-Project-ID (an OpenAI
+	// client would not send it). Empty for all other backends. Header VALUES
+	// here are identifiers, not secrets (the bearer stays in APIKey).
+	ExtraHeaders map[string]string
 }
 
 // DefaultInferencePreamble is injected at the top of the system prompt when
@@ -196,6 +201,14 @@ func IsInferenceBackend(backend string) bool {
 func applyInferenceAuth(req *http.Request, route *InferenceRoute) {
 	if route.APIKey != "" {
 		req.Header.Set("Authorization", "Bearer "+route.APIKey)
+	}
+	// Non-secret per-route headers (watsonx X-IBM-Project-ID). Set after auth so
+	// a route never overrides the Authorization header via ExtraHeaders.
+	for k, v := range route.ExtraHeaders {
+		if k == "" || strings.EqualFold(k, "Authorization") || v == "" {
+			continue
+		}
+		req.Header.Set(k, v)
 	}
 }
 

--- a/v2/pkg/watsonx/iam.go
+++ b/v2/pkg/watsonx/iam.go
@@ -1,0 +1,205 @@
+// Package watsonx handles IBM watsonx.ai-specific concerns that the generic
+// OpenAI-compatible gateway path cannot: exchanging an IBM Cloud API key for a
+// short-lived IAM bearer token (watsonx's model gateway authenticates with an
+// IAM access token, NOT the raw API key), and the small constants (Granite
+// fallback ids, the project-id header) the gateway wiring shares.
+//
+// The model gateway (https://<region>.ml.cloud.ibm.com/ml/gateway/v1) is
+// OpenAI-compatible for /chat/completions and /models, so once a valid IAM
+// bearer is minted, hive's existing OpenAI-compatible inference and discovery
+// paths work unchanged. This package supplies only the bearer + the project-id
+// header; it does not translate requests.
+package watsonx
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"encoding/json"
+)
+
+const (
+	// IAMTokenURL is IBM Cloud's IAM token endpoint. A POST here exchanges an
+	// IBM Cloud API key for a short-lived access token (JWT). This host is the
+	// same across watsonx regions (only the ml.cloud.ibm.com data-plane host is
+	// regional), so it is a constant rather than derived from the gateway URL.
+	IAMTokenURL = "https://iam.cloud.ibm.com/identity/token"
+
+	// iamAPIKeyGrantType is the OAuth grant type that exchanges an IBM Cloud API
+	// key for an IAM access token.
+	iamAPIKeyGrantType = "urn:ibm:params:oauth:grant-type:apikey"
+
+	// iamTokenRequestTimeout bounds the token-exchange HTTP call. The IAM
+	// endpoint is fast; this is generous headroom, not a tuned value.
+	iamTokenRequestTimeout = 10 * time.Second
+
+	// iamTokenExpirySkew is subtracted from a cached token's expiry before it is
+	// reused: a token within this window of expiring is treated as already
+	// expired so an in-flight request cannot 401 on a token that lapses mid
+	// round-trip. IAM tokens live ~1h, so this margin costs at most one extra
+	// mint per skew window.
+	iamTokenExpirySkew = 5 * time.Minute
+
+	// iamTokenFallbackTTL is used only if the IAM response omits expires_in
+	// (it never should). Deliberately short so a missing TTL re-mints often
+	// rather than serving a token past its real (unknown) lifetime.
+	iamTokenFallbackTTL = 10 * time.Minute
+
+	// iamErrBodyLimit caps how much of an IAM error body is folded into the
+	// returned error. IAM error bodies are small JSON; this only guards against
+	// a pathological upstream. The API key is never echoed by IAM, but we still
+	// bound the text.
+	iamErrBodyLimit = 512
+
+	// ProjectIDHeader is the header watsonx reads the project (or space) id
+	// from on gateway requests — the id an OpenAI client would not otherwise
+	// send. Verified against IBM's watsonx-ai API reference
+	// (https://cloud.ibm.com/apidocs/watsonx-ai), where project-scoped
+	// operations take X-IBM-Project-ID.
+	ProjectIDHeader = "X-IBM-Project-ID"
+)
+
+// GraniteFallbackModels is the small static list offered when live model
+// discovery against the watsonx gateway cannot run (no key/project configured
+// yet) or fails, so the Model Gateway dropdown is never empty. Live discovery
+// via the gateway /v1/models is strongly preferred; this is only a floor.
+// Current IBM Granite instruct ids (as of 2026-08), verified against IBM's
+// Granite docs and watsonx model catalog. hive-owned models carry the "ibm/"
+// provider prefix watsonx uses for its foundation models.
+var GraniteFallbackModels = []string{
+	"ibm/granite-4-h-small",
+	"ibm/granite-4-h-micro",
+	"ibm/granite-3-3-8b-instruct",
+	"ibm/granite-3-3-2b-instruct",
+}
+
+// iamToken is a cached, minted IAM access token with its effective expiry.
+type iamToken struct {
+	token  string
+	expiry time.Time
+}
+
+// TokenMinter exchanges an IBM Cloud API key for an IAM access token and caches
+// the result per API key until it nears expiry. It is safe for concurrent use.
+// One minter instance is shared process-wide (see DefaultMinter) so a single
+// token is reused across every watsonx request rather than re-minted per call.
+type TokenMinter struct {
+	mu    sync.Mutex
+	cache map[string]iamToken // keyed by API key; value is the minted token
+
+	// endpoint and now are seams so tests can point the exchange at an httptest
+	// server and control the clock without touching real IAM or wall time.
+	endpoint string
+	now      func() time.Time
+	client   *http.Client
+}
+
+// NewTokenMinter builds a minter that talks to the real IBM IAM endpoint.
+func NewTokenMinter() *TokenMinter {
+	return &TokenMinter{
+		cache:    make(map[string]iamToken),
+		endpoint: IAMTokenURL,
+		now:      time.Now,
+		client:   &http.Client{Timeout: iamTokenRequestTimeout},
+	}
+}
+
+// DefaultMinter is the process-wide minter. Using one shared instance means the
+// cached IAM token is reused across all watsonx gateway requests (inference,
+// probes, discovery) instead of each caller minting its own.
+var DefaultMinter = NewTokenMinter()
+
+// NewTokenMinterForTest builds a minter whose token exchange targets endpoint
+// instead of the real IBM IAM host, so tests (including callers in other
+// packages that swap DefaultMinter) can exercise the watsonx auth path without
+// touching the network. A nil client uses a default-timeout client. This is a
+// test-only seam; production code uses NewTokenMinter / DefaultMinter.
+func NewTokenMinterForTest(endpoint string, client *http.Client) *TokenMinter {
+	if client == nil {
+		client = &http.Client{Timeout: iamTokenRequestTimeout}
+	}
+	return &TokenMinter{
+		cache:    make(map[string]iamToken),
+		endpoint: endpoint,
+		now:      time.Now,
+		client:   client,
+	}
+}
+
+// Token returns a valid IAM bearer for apiKey, minting a fresh one only when
+// the cache is empty or the cached token is within iamTokenExpirySkew of
+// expiring. The apiKey is never logged and never returned; only the minted
+// bearer is. A blank apiKey is an error (a watsonx gateway requires a key).
+func (m *TokenMinter) Token(ctx context.Context, apiKey string) (string, error) {
+	if strings.TrimSpace(apiKey) == "" {
+		return "", fmt.Errorf("watsonx: no IBM Cloud API key configured")
+	}
+
+	m.mu.Lock()
+	if tok, ok := m.cache[apiKey]; ok && m.now().Add(iamTokenExpirySkew).Before(tok.expiry) {
+		t := tok.token
+		m.mu.Unlock()
+		return t, nil
+	}
+	m.mu.Unlock()
+
+	tok, err := m.mint(ctx, apiKey)
+	if err != nil {
+		return "", err
+	}
+
+	m.mu.Lock()
+	m.cache[apiKey] = tok
+	m.mu.Unlock()
+	return tok.token, nil
+}
+
+// mint performs the IAM token exchange for apiKey. It never logs or echoes the
+// key; IAM error bodies (which do not contain the key) are truncated.
+func (m *TokenMinter) mint(ctx context.Context, apiKey string) (iamToken, error) {
+	form := url.Values{}
+	form.Set("grant_type", iamAPIKeyGrantType)
+	form.Set("apikey", apiKey)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, m.endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return iamToken{}, fmt.Errorf("watsonx: build IAM token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return iamToken{}, fmt.Errorf("watsonx: IAM token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, iamErrBodyLimit))
+		return iamToken{}, fmt.Errorf("watsonx: IAM token exchange returned HTTP %d: %s",
+			resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var parsed struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return iamToken{}, fmt.Errorf("watsonx: decode IAM token response: %w", err)
+	}
+	if parsed.AccessToken == "" {
+		return iamToken{}, fmt.Errorf("watsonx: IAM token response had no access_token")
+	}
+
+	ttl := time.Duration(parsed.ExpiresIn) * time.Second
+	if ttl <= 0 {
+		ttl = iamTokenFallbackTTL
+	}
+	return iamToken{token: parsed.AccessToken, expiry: m.now().Add(ttl)}, nil
+}

--- a/v2/pkg/watsonx/iam_test.go
+++ b/v2/pkg/watsonx/iam_test.go
@@ -1,0 +1,155 @@
+package watsonx
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newTestMinter builds a minter pointed at a fake IAM server, with a
+// controllable clock. Returns the minter and a pointer to the current fake time
+// the caller can advance.
+func newTestMinter(endpoint string) (*TokenMinter, *int64) {
+	var nowNanos int64 = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano()
+	m := &TokenMinter{
+		cache:    make(map[string]iamToken),
+		endpoint: endpoint,
+		now:      func() time.Time { return time.Unix(0, atomic.LoadInt64(&nowNanos)) },
+		client:   &http.Client{Timeout: iamTokenRequestTimeout},
+	}
+	return m, &nowNanos
+}
+
+// Success: the exchange sends the apikey grant and returns the access_token as
+// the bearer. The API key never appears in the returned value.
+func TestTokenMintSuccess(t *testing.T) {
+	var gotGrant, gotKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotGrant = r.Form.Get("grant_type")
+		gotKey = r.Form.Get("apikey")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "IAM-JWT-abc",
+			"expires_in":   3600,
+		})
+	}))
+	defer srv.Close()
+
+	m, _ := newTestMinter(srv.URL)
+	tok, err := m.Token(context.Background(), "my-ibm-key")
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "IAM-JWT-abc" {
+		t.Fatalf("token = %q, want the minted access_token", tok)
+	}
+	if gotGrant != iamAPIKeyGrantType {
+		t.Fatalf("grant_type = %q, want %q", gotGrant, iamAPIKeyGrantType)
+	}
+	if gotKey != "my-ibm-key" {
+		t.Fatalf("apikey sent = %q, want the api key", gotKey)
+	}
+	if strings.Contains(tok, "my-ibm-key") {
+		t.Fatal("returned bearer must never contain the raw API key")
+	}
+}
+
+// Caching: a second Token call within the token's lifetime reuses the cached
+// bearer and does NOT hit the IAM server again.
+func TestTokenMintCaches(t *testing.T) {
+	var mints int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&mints, 1)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": fmt.Sprintf("IAM-JWT-%d", atomic.LoadInt32(&mints)),
+			"expires_in":   3600,
+		})
+	}))
+	defer srv.Close()
+
+	m, _ := newTestMinter(srv.URL)
+	first, err := m.Token(context.Background(), "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := m.Token(context.Background(), "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatalf("cached call returned a different token (%q vs %q)", first, second)
+	}
+	if got := atomic.LoadInt32(&mints); got != 1 {
+		t.Fatalf("expected exactly 1 mint (second served from cache), got %d", got)
+	}
+}
+
+// Expiry re-mint: once the cached token nears expiry (clock advanced past
+// lifetime minus skew), the next call mints a fresh token.
+func TestTokenMintReMintsOnExpiry(t *testing.T) {
+	var mints int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&mints, 1)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": fmt.Sprintf("IAM-JWT-%d", n),
+			"expires_in":   3600, // 1h
+		})
+	}))
+	defer srv.Close()
+
+	m, nowNanos := newTestMinter(srv.URL)
+	first, err := m.Token(context.Background(), "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Advance past (lifetime - skew) so the cached token is treated as expired.
+	atomic.AddInt64(nowNanos, int64(time.Hour-iamTokenExpirySkew+time.Minute))
+	second, err := m.Token(context.Background(), "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatal("expected a fresh token after expiry, got the same cached one")
+	}
+	if got := atomic.LoadInt32(&mints); got != 2 {
+		t.Fatalf("expected 2 mints (initial + re-mint), got %d", got)
+	}
+}
+
+// A blank API key is rejected without an HTTP call (a watsonx gateway must have
+// a key).
+func TestTokenMintRejectsBlankKey(t *testing.T) {
+	m, _ := newTestMinter("http://unused.invalid")
+	if _, err := m.Token(context.Background(), "   "); err == nil {
+		t.Fatal("blank api key must error")
+	}
+}
+
+// An IAM error response surfaces as an error (with the status), and the error
+// text never contains the API key.
+func TestTokenMintUpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"errorMessage":"Provided API key could not be found."}`))
+	}))
+	defer srv.Close()
+
+	m, _ := newTestMinter(srv.URL)
+	_, err := m.Token(context.Background(), "secret-key-XYZ")
+	if err == nil {
+		t.Fatal("expected an error on IAM 400")
+	}
+	if strings.Contains(err.Error(), "secret-key-XYZ") {
+		t.Fatalf("error text leaked the API key: %v", err)
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Fatalf("error should carry the status: %v", err)
+	}
+}

--- a/v2/pkg/watsonx/iam_test.go
+++ b/v2/pkg/watsonx/iam_test.go
@@ -153,3 +153,92 @@ func TestTokenMintUpstreamError(t *testing.T) {
 		t.Fatalf("error should carry the status: %v", err)
 	}
 }
+
+// A malformed IAM response body surfaces as a decode error (not a panic or a
+// silent empty token).
+func TestTokenMintMalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{not json`))
+	}))
+	defer srv.Close()
+
+	m, _ := newTestMinter(srv.URL)
+	if _, err := m.Token(context.Background(), "k"); err == nil {
+		t.Fatal("malformed IAM JSON must error")
+	}
+}
+
+// A 200 with no access_token is an error, never a blank bearer treated as valid.
+func TestTokenMintMissingAccessToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"expires_in": 3600})
+	}))
+	defer srv.Close()
+
+	m, _ := newTestMinter(srv.URL)
+	_, err := m.Token(context.Background(), "k")
+	if err == nil {
+		t.Fatal("missing access_token must error")
+	}
+	if !strings.Contains(err.Error(), "access_token") {
+		t.Fatalf("error should name the missing field: %v", err)
+	}
+}
+
+// When the IAM response omits expires_in, the token is cached with the short
+// fallback TTL rather than an immediately-expired (or never-expiring) one: a
+// second call within the fallback window is served from cache.
+func TestTokenMintFallbackTTL(t *testing.T) {
+	var mints int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&mints, 1)
+		// No expires_in field at all.
+		_, _ = w.Write([]byte(`{"access_token":"IAM-JWT-fallback"}`))
+	}))
+	defer srv.Close()
+
+	m, nowNanos := newTestMinter(srv.URL)
+	first, err := m.Token(context.Background(), "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != "IAM-JWT-fallback" {
+		t.Fatalf("token = %q", first)
+	}
+	// Within the fallback TTL (minus skew) → cached, no re-mint.
+	atomic.AddInt64(nowNanos, int64(iamTokenFallbackTTL-iamTokenExpirySkew-time.Minute))
+	if _, err := m.Token(context.Background(), "k"); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&mints); got != 1 {
+		t.Fatalf("expected the fallback-TTL token to be cached (1 mint), got %d", got)
+	}
+}
+
+// A transport-level failure (unreachable endpoint) surfaces as an error.
+func TestTokenMintTransportError(t *testing.T) {
+	// Port 0 on a closed address: Do() fails without an HTTP response.
+	m := NewTokenMinterForTest("http://127.0.0.1:0/identity/token", &http.Client{Timeout: iamTokenRequestTimeout})
+	if _, err := m.Token(context.Background(), "k"); err == nil {
+		t.Fatal("unreachable IAM endpoint must error")
+	}
+}
+
+// NewTokenMinterForTest builds a working minter against a custom endpoint (the
+// seam other packages use to avoid the network) — exercised directly here.
+func TestNewTokenMinterForTest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "seam-JWT", "expires_in": 3600})
+	}))
+	defer srv.Close()
+
+	m := NewTokenMinterForTest(srv.URL, nil) // nil client → default-timeout client
+	tok, err := m.Token(context.Background(), "k")
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "seam-JWT" {
+		t.Fatalf("token = %q, want the minted seam token", tok)
+	}
+}


### PR DESCRIPTION
## What

Adds **IBM watsonx.ai** as a first-class inference gateway kind (`watsonx`), alongside `vllm` / `llm-d` / `openrouter` / `litellm` / `custom`, so hive agents can run **IBM Granite** (and other watsonx-hosted) models.

Fixes #2700

## Research — the three facts, with evidence

**1. Endpoint (OpenAI-compatible surface).** watsonx.ai ships an OpenAI-compatible **model gateway** at `https://<region>.ml.cloud.ibm.com/ml/gateway/v1`. Verified directly against **IBM's own watsonx-ai API reference** (https://cloud.ibm.com/apidocs/watsonx-ai): the `Model Gateway` operations include `POST /ml/gateway/v1/chat/completions`, `GET /ml/gateway/v1/models`, `/ml/gateway/v1/embeddings`, `/ml/gateway/v1/providers`, and the chat/completions responses are OpenAI-shaped (`object: chat.completion`, `choices`, `usage`). All Model-Gateway ops declare `security: [{ Bearer: [] }]`.

Design consequence: the operator configures the endpoint as `.../ml/gateway` and hive's existing `strings.TrimRight(endpoint,"/") + "/v1/models"` / `+ "/v1/chat/completions"` suffixing reaches `.../ml/gateway/v1/models` and `.../ml/gateway/v1/chat/completions` **unchanged** — no special URL handling. The UI preset fills this base for `us-south`.

**2. Auth — IAM token mint (implemented).** The gateway's `Bearer` scheme is defined in the apidocs as *"an access token obtained from the authentication endpoint"* (`bearerFormat: JWT`) — i.e. an **IAM access token**, minted from an IBM Cloud API key via `POST https://iam.cloud.ibm.com/identity/token` with `grant_type=urn:ibm:params:oauth:grant-type:apikey&apikey=<key>` (corroborated by heidloff.net's watsonx REST walkthrough and the ibm-watsonx SDKs; the native `/ml/v1/text/*` API also requires this token). So hive **mints and caches** the IAM token rather than sending the raw key.

`pkg/watsonx` implements the exchange with per-key caching to the token's `expires_in` (minus a 5-min skew margin; all TTLs/timeouts are named consts), re-minting on expiry. The API key and the minted token are **never logged**; IAM/upstream error bodies are redacted of both.

**3. project_id — `X-IBM-Project-ID` header (implemented).** watsonx scopes billing/limits by a `project_id` (or `space_id`) an OpenAI client does not send. The apidocs use the `X-IBM-Project-ID` header for project-scoped operations. Added optional `GatewayConfig.ProjectID` (+ `Region` for the preset), sent as `X-IBM-Project-ID` on every outbound gateway request (inference, probe, discovery). `omitempty` keeps existing gateways byte-identical in `hive.yaml`.

## Implementation

- **`config.go`**: `GatewayKindWatsonx` const; optional `ProjectID` / `Region` fields (secrets stay env-NAME/file-PATH only; project_id/region are non-secret identifiers stored inline).
- **`pkg/watsonx/iam.go`**: IAM `TokenMinter` (exchange + cache), the `X-IBM-Project-ID` header const, and a current static **Granite fallback** list.
- **`gateways.go`**: watsonx in `validGatewayKinds`; validation rejects a watsonx gateway missing `project_id` or a key (checked **before** any secret is written); header-aware `/v1/models` probe + discovery that mints the IAM bearer and sets the project header, degrading to the static Granite list so the model dropdown is never empty.
- **`api.go`**: `probeModelsWithHeaders` / `fetchModelsWithHeaders` (existing signatures kept as thin wrappers — no churn at other call sites).
- **`cmd/hive/main.go`**: the named-gateway route builder mints the IAM token and sets `ExtraHeaders` (project id) for watsonx; every other kind sends the resolved key verbatim.
- **`proxy/inference_route.go`**: `InferenceRoute.ExtraHeaders`, applied on all three inference request paths (`applyInferenceAuth`) without ever overriding `Authorization`.
- **UI (`static/index.html`)**: watsonx preset (base URL template + kind badge) and a project-id field shown for the watsonx kind, threaded into discovery + save.

## Granite model ids (static fallback)

Live discovery via the gateway `/v1/models` is preferred; the floor list (so the dropdown is never empty) uses current IBM Granite instruct ids:
`ibm/granite-4-h-small`, `ibm/granite-4-h-micro`, `ibm/granite-3-3-8b-instruct`, `ibm/granite-3-3-2b-instruct`.

## Operator configuration (example)

```yaml
governor:
  gateways:
    - name: watsonx
      kind: watsonx
      endpoint: https://us-south.ml.cloud.ibm.com/ml/gateway
      region: us-south
      project_id: 63dc4cf1-252f-424b-b52d-5cdd9814987f
      api_key_file: /data/secrets/gateway_watsonx_api_key   # IBM Cloud API key
      default_model: ibm/granite-4-h-small
```

An agent routes through it with `backend: watsonx`. hive exchanges the API key for an IAM token, sends it as the bearer, and adds `X-IBM-Project-ID` on every request. (In the dashboard, the Model Gateways tab writes the key file for you.)

## Tests

- **config**: watsonx gateway parse (kind/endpoint/project_id/region/key ref); `omitempty` keeps watsonx fields out of other gateways; name valid as an agent backend.
- **auth (`pkg/watsonx`)**: IAM exchange via httptest — success (grant + key sent, bearer returned), caching (one mint reused), expiry re-mint, blank-key reject, upstream-error path; the API key never appears in the returned bearer or error text.
- **discovery/validation (dashboard)**: watsonx `/v1/models` discovery sends the minted bearer + `X-IBM-Project-ID` and parses the list; probe reports not-ok on failure (never a false success); non-watsonx passthrough unchanged; static Granite fallback non-empty; upsert rejects missing project_id / key and stores the key as a file ref.
- No shared package-global mutated across tests without restore (the DefaultMinter swap uses a test-only seam + `t.Cleanup`, mirroring the existing `gatewaySecretsDir` pattern). `-race` clean on `pkg/watsonx`.

## Backward compatibility

New fields are optional (`omitempty`); existing gateways and the legacy `litellm:` block are untouched. The native `/ml/v1/text/*` API is intentionally **not** targeted — the OpenAI-compatible model gateway is the correct drop-in surface, so no request-translation shim is needed.
