### PR TITLE
✨ Reset assignment: escape hatch for an assigned-but-unclaimed placeholder

### DIFF
--- a/v2/pkg/hub/reset_assignment_test.go
+++ b/v2/pkg/hub/reset_assignment_test.go
@@ -1,0 +1,323 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// newResetTestHub builds a hub with the hive-oke pool configured and a buffered
+// save channel, matching the shape the approve/assign handler tests use.
+func newResetTestHub() *HubServer {
+	return &HubServer{
+		logger:    slog.Default(),
+		hubSecret: testHubSecret,
+		saveCh:    make(chan struct{}, 1),
+		clusters:  map[string]ClusterConfig{"hive-oke": *dynamicCluster()},
+	}
+}
+
+// stuckPlaceholder returns a placeholder wedged at Status=statusAssigned &&
+// !ClaimDelivered — the exact dead-end the escape hatch targets (EPM /
+// z-innersource class): a project stamped, but the spoke never reported it back.
+func stuckPlaceholder(id string) *SaaSHive {
+	return &SaaSHive{
+		ID:                 id,
+		Owner:              "acme-owner",
+		Org:                "acme",
+		Repos:              []string{"repo-a", "repo-b"},
+		PrimaryRepo:        "repo-a",
+		ProjectName:        "Acme Project",
+		ACMMLevel:          3,
+		RequestedACMMLevel: 3,
+		Status:             statusAssigned,
+		ClaimDelivered:     false,
+		VanityURL:          "https://hosted-acme-repo-a-xxxx.hive.kubestellar.io",
+		ClusterID:          "hive-oke",
+		AssignedAt:         time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+// TestResetAssignmentReturnsPlaceholderToPool is the happy path: an assigned but
+// undelivered placeholder resets to the available-placeholder shape and is
+// re-assignable afterward.
+func TestResetAssignmentReturnsPlaceholderToPool(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+	s := newResetTestHub()
+
+	const id = "hosted-available-oke-11-placeholder-r05x"
+	if err := saveSaaSHive(stuckPlaceholder(id)); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/reset-assignment", "", hubAdminUsername), "id", id)
+	s.handleResetAssignment(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("reset status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	got := loadSaaSHive(id)
+	if got == nil {
+		t.Fatal("hive vanished after reset")
+	}
+	// Available-placeholder shape (inverse of assign).
+	if got.Status != statusAvailable {
+		t.Errorf("Status = %q, want %q", got.Status, statusAvailable)
+	}
+	if got.Owner != hubAdminUsername {
+		t.Errorf("Owner = %q, want admin %q", got.Owner, hubAdminUsername)
+	}
+	if got.Org == "" || got.Org[:len(placeholderOrgPrefix)] != placeholderOrgPrefix {
+		t.Errorf("Org = %q, want %q-prefixed", got.Org, placeholderOrgPrefix)
+	}
+	if len(got.Repos) != 0 {
+		t.Errorf("Repos = %v, want empty", got.Repos)
+	}
+	if got.PrimaryRepo != "" {
+		t.Errorf("PrimaryRepo = %q, want empty", got.PrimaryRepo)
+	}
+	if got.ACMMLevel != defaultAssignACMMLevel {
+		t.Errorf("ACMMLevel = %d, want default %d", got.ACMMLevel, defaultAssignACMMLevel)
+	}
+	if got.RequestedACMMLevel != 0 {
+		t.Errorf("RequestedACMMLevel = %d, want 0", got.RequestedACMMLevel)
+	}
+	if got.ClaimDelivered {
+		t.Error("ClaimDelivered = true, want false after reset")
+	}
+	if got.VanityURL != "" {
+		t.Errorf("VanityURL = %q, want cleared", got.VanityURL)
+	}
+	if got.AssignedAt != "" {
+		t.Errorf("AssignedAt = %q, want cleared", got.AssignedAt)
+	}
+
+	// The whole point: it is an available placeholder again, so the assign path
+	// (which requires statusAvailable) now accepts it.
+	if !isReassignable(id) {
+		t.Error("placeholder is not re-assignable after reset (assign guard would 409)")
+	}
+
+	// A subsequent assign succeeds end to end.
+	assignBody := `{"owner":"newuser","org":"newco","repos":"newrepo","primary_repo":"newrepo","acmm_level":2}`
+	rec2 := httptest.NewRecorder()
+	req2 := setPathValue(reqWithUser(http.MethodPost, "/assign", assignBody, hubAdminUsername), "id", id)
+	s.handleAssignHive(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("re-assign after reset status = %d, want 200 (body=%s)", rec2.Code, rec2.Body.String())
+	}
+	reassigned := loadSaaSHive(id)
+	if reassigned == nil || reassigned.Owner != "newuser" || reassigned.Org != "newco" {
+		t.Fatalf("re-assign did not take: %+v", reassigned)
+	}
+}
+
+// isReassignable mirrors the availability guard handleAssignHive enforces
+// (statusAvailable). It is the machine check behind "re-assignable afterward".
+func isReassignable(id string) bool {
+	h := loadSaaSHive(id)
+	return h != nil && h.Status == statusAvailable
+}
+
+// TestResetAssignmentRefusedWhenClaimDelivered guards a LIVE hive: a fully
+// claimed placeholder (ClaimDelivered==true) must never be reset.
+func TestResetAssignmentRefusedWhenClaimDelivered(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+	s := newResetTestHub()
+
+	const id = "hosted-live-hive"
+	h := stuckPlaceholder(id)
+	h.ClaimDelivered = true // a working, fully-claimed hive
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/reset-assignment", "", hubAdminUsername), "id", id)
+	s.handleResetAssignment(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("reset of a delivered claim status = %d, want 409 (body=%s)", rec.Code, rec.Body.String())
+	}
+	// The live hive is untouched.
+	got := loadSaaSHive(id)
+	if got.Status != statusAssigned || got.Owner != "acme-owner" || !got.ClaimDelivered {
+		t.Errorf("live hive mutated by a refused reset: %+v", got)
+	}
+}
+
+// TestResetAssignmentAlreadyAvailableIsNoOp: resetting an already-available slot
+// is a 409 no-op, not a double reset.
+func TestResetAssignmentAlreadyAvailableIsNoOp(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+	s := newResetTestHub()
+
+	const id = "hosted-available-slot"
+	if err := saveSaaSHive(&SaaSHive{ID: id, Owner: hubAdminUsername, Status: statusAvailable, ClusterID: "hive-oke"}); err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/reset-assignment", "", hubAdminUsername), "id", id)
+	s.handleResetAssignment(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("reset of an available slot status = %d, want 409 (body=%s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestResetAssignmentNotFound: a missing hive 404s.
+func TestResetAssignmentNotFound(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+	s := newResetTestHub()
+
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/reset-assignment", "", hubAdminUsername), "id", "nope")
+	s.handleResetAssignment(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("reset of a missing hive status = %d, want 404 (body=%s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestResetAssignmentNonAdminForbidden: the route is admin-gated. We exercise
+// the requireAdmin wrapper the mux applies, since the handler itself trusts the
+// gate.
+func TestResetAssignmentNonAdminForbidden(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+	mkUser(t, "notadmin")
+	s := newResetTestHub()
+
+	const id = "hosted-stuck"
+	if err := saveSaaSHive(stuckPlaceholder(id)); err != nil {
+		t.Fatal(err)
+	}
+
+	gated := s.requireAdmin(s.handleResetAssignment)
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/reset-assignment", "", "notadmin"), "id", id)
+	gated(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("non-admin reset status = %d, want 403 (body=%s)", rec.Code, rec.Body.String())
+	}
+	// And the hive is untouched.
+	if got := loadSaaSHive(id); got.Status != statusAssigned {
+		t.Errorf("non-admin reset mutated the hive: %+v", got)
+	}
+}
+
+// TestResetAssignmentReopensProvisionRequest: an approved provision request whose
+// AssignedHive points at the reset hive is flipped back to pending so re-approve
+// works end to end.
+func TestResetAssignmentReopensProvisionRequest(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+	s := newResetTestHub()
+
+	const id = "hosted-stuck-with-request"
+	if err := saveSaaSHive(stuckPlaceholder(id)); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveProvisionRequest(&ProvisionRequest{
+		Username:     "bob",
+		Org:          "acme",
+		Repos:        "repo-a",
+		PrimaryRepo:  "repo-a",
+		ACMMLevel:    3,
+		Status:       provisionStatusApproved,
+		DecidedBy:    hubAdminUsername,
+		DecidedAt:    time.Now().UTC().Format(time.RFC3339),
+		AssignedHive: id,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/reset-assignment", "", hubAdminUsername), "id", id)
+	s.handleResetAssignment(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("reset status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad response JSON: %v", err)
+	}
+	if resp["reopened_request_for"] != "bob" {
+		t.Errorf("reopened_request_for = %v, want bob", resp["reopened_request_for"])
+	}
+
+	pr := loadProvisionRequest("bob")
+	if pr == nil {
+		t.Fatal("provision request vanished")
+	}
+	if pr.Status != provisionStatusPending {
+		t.Errorf("request Status = %q, want %q (so re-approve works)", pr.Status, provisionStatusPending)
+	}
+	if pr.AssignedHive != "" {
+		t.Errorf("request AssignedHive = %q, want cleared", pr.AssignedHive)
+	}
+}
+
+// TestSweepStuckAssignments: a placeholder stuck past the timeout is auto-reset;
+// one within the window (and one already delivered) is left alone.
+func TestSweepStuckAssignments(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+	s := newResetTestHub()
+
+	// Stuck long past the timeout -> should be reset.
+	stuck := stuckPlaceholder("hosted-stuck-old")
+	stuck.AssignedAt = time.Now().Add(-2 * assignStuckResetTimeout).UTC().Format(time.RFC3339)
+	if err := saveSaaSHive(stuck); err != nil {
+		t.Fatal(err)
+	}
+
+	// Freshly assigned, within the window -> left alone.
+	fresh := stuckPlaceholder("hosted-stuck-fresh")
+	fresh.AssignedAt = time.Now().UTC().Format(time.RFC3339)
+	if err := saveSaaSHive(fresh); err != nil {
+		t.Fatal(err)
+	}
+
+	// Assigned long ago but claim delivered -> a live hive, must be left alone.
+	live := stuckPlaceholder("hosted-live")
+	live.ClaimDelivered = true
+	live.AssignedAt = time.Now().Add(-2 * assignStuckResetTimeout).UTC().Format(time.RFC3339)
+	if err := saveSaaSHive(live); err != nil {
+		t.Fatal(err)
+	}
+
+	// No AssignedAt stamp (age unknowable) -> left alone even though stuck.
+	unstamped := stuckPlaceholder("hosted-unstamped")
+	unstamped.AssignedAt = ""
+	if err := saveSaaSHive(unstamped); err != nil {
+		t.Fatal(err)
+	}
+
+	s.sweepStuckAssignments()
+
+	if got := loadSaaSHive("hosted-stuck-old"); got.Status != statusAvailable {
+		t.Errorf("stuck-old Status = %q, want auto-reset to %q", got.Status, statusAvailable)
+	}
+	if got := loadSaaSHive("hosted-stuck-fresh"); got.Status != statusAssigned {
+		t.Errorf("stuck-fresh Status = %q, want left assigned (within window)", got.Status)
+	}
+	if got := loadSaaSHive("hosted-live"); got.Status != statusAssigned || !got.ClaimDelivered {
+		t.Errorf("live hive was swept: %+v", got)
+	}
+	if got := loadSaaSHive("hosted-unstamped"); got.Status != statusAssigned {
+		t.Errorf("unstamped hive Status = %q, want left assigned (unknowable age)", got.Status)
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -276,6 +276,10 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("POST /api/saas/admin/impersonate/{username}", s.requireAdmin(s.handleImpersonateStart))
 	s.mux.HandleFunc("GET /api/saas/impersonation-status", s.requireAuth(s.handleImpersonationStatus))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/assign", s.requireAuth(s.handleAssignHive))
+	// Escape hatch: return an assigned-but-unclaimed placeholder to the available
+	// pool so it can be re-armed. Admin-only, and guarded to the wedged middle
+	// state (assigned && !claim_delivered) inside the handler.
+	s.mux.HandleFunc("POST /api/saas/hives/{id}/reset-assignment", s.requireAdmin(s.handleResetAssignment))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/migrate", s.requireAuth(s.handleMigrateHive))
 	s.mux.HandleFunc("GET /api/saas/cluster-health", s.requireAdmin(s.handleClusterHealth))
 	// Acknowledging a fleet alert is an operator action on the operator's own
@@ -1979,6 +1983,15 @@ type MyHiveEntry struct {
 	Assigning   bool   `json:"assigning,omitempty"`
 	AssigningTo string `json:"assigningTo,omitempty"`
 
+	// AssignedUnclaimed marks a placeholder wedged at Status=statusAssigned &&
+	// !ClaimDelivered: a claim was stamped but the spoke never reported the
+	// project back. Unlike Assigning — which is true only while a REACHABLE spoke
+	// is actively reporting a DIFFERENT project — this is true even when the spoke
+	// is offline or silent (the frozen-image / heartbeat-only case), which is
+	// exactly the dead-end the Reset assignment action exists for. It gates that
+	// admin-only action in the row menu.
+	AssignedUnclaimed bool `json:"assignedUnclaimed,omitempty"`
+
 	// Migration tracking (Phase 7).
 	MigrationStatus string `json:"migrationStatus,omitempty"`
 	MigrationFrom   string `json:"migrationFrom,omitempty"`
@@ -2117,6 +2130,11 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		entry.ProvStatus = sh.Status
+		// A placeholder wedged between the two claim paths: assigned but the spoke
+		// never reported the project back. Computed from meta (not the live
+		// registry) so it is true even for an offline/silent spoke — the exact
+		// dead-end the Reset assignment action targets.
+		entry.AssignedUnclaimed = sh.Status == statusAssigned && !sh.ClaimDelivered
 		if sh.Status == statusAvailable || (entry.ACMMLevel == 0 && sh.ACMMLevel > 0) {
 			entry.ACMMLevel = sh.ACMMLevel
 		}
@@ -4376,6 +4394,9 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 	// only ever considers hives with AutoUpgrade enabled, while the flag is set
 	// by the admin and bulk upgrade paths for any hive.
 	s.sweepOrphanedUpgrades()
+	// Auto-reset any placeholder wedged at assigned && !claim_delivered past the
+	// timeout, so an assigned-but-unclaimed slot can never dead-end silently.
+	s.sweepStuckAssignments()
 	ticker := time.NewTicker(latestSHAPollInterval)
 	defer ticker.Stop()
 	for {
@@ -4396,6 +4417,7 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 		// Always check for pending auto-upgrades (retries failed/missed hives).
 		s.triggerAutoUpgrades()
 		s.sweepOrphanedUpgrades()
+		s.sweepStuckAssignments()
 		changed := false
 		for branch, sha := range newSHAs {
 			if sha != "" && sha != oldSHAs[branch] {
@@ -6078,6 +6100,9 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 	// does above. (The assign path — handleAssignHive — already does this.)
 	h.ClaimDelivered = false
 	h.Status = statusAssigned
+	// Stamp when this claim began so the self-heal sweep can age it out if the
+	// spoke never reports the project back (ClaimDelivered stuck false).
+	h.AssignedAt = time.Now().UTC().Format(time.RFC3339)
 	h.Error = ""
 	// Preserve the placeholder's real cluster before ANY cluster-derived
 	// resolution below (host backfill uses s.clusterForHive(h), which silently
@@ -6901,6 +6926,9 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	h.ACMMDelivered = false
 	h.IsPublic = body.IsPublic
 	h.Status = statusAssigned
+	// Stamp when this claim began so the self-heal sweep can age it out if the
+	// spoke never reports the project back (ClaimDelivered stuck false).
+	h.AssignedAt = time.Now().UTC().Format(time.RFC3339)
 	h.Error = ""
 	// A (re)assignment is a new claim payload: reset delivery so the hub pushes
 	// this project to the spoke until it reports the new org/repos back, before
@@ -12244,6 +12272,13 @@ const dashboardHTML = `<!DOCTYPE html>
         var menuItems = [];
         var mi = 'display:block;padding:7px 14px;color:#c9d1d9;text-decoration:none;font-size:0.78rem;cursor:pointer';
         if (_isAdmin && h.provStatus === 'available' && !h.assigning) menuItems.push('<div onclick="openAssignModal(\'' + esc(h.id) + '\')" style="' + mi + ';color:#3fb950;font-weight:600">Assign / Claim</div><div style="border-top:1px solid #30363d;margin:4px 0"></div>');
+        /* Reset assignment: escape hatch for a placeholder wedged at
+           assigned && !claim_delivered (assignedUnclaimed) — its spoke never
+           reported the project back, so it can be neither re-approved (needs a
+           pending request) nor re-assigned (needs an available slot). This
+           returns the slot to the pool so it can be re-armed. Admin-only,
+           mirroring the endpoint's own guard. */
+        if (_isAdmin && h.assignedUnclaimed) menuItems.push('<div onclick="resetAssignment(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + ';color:#d29922;font-weight:600">Reset assignment</div><div style="border-top:1px solid #30363d;margin:4px 0"></div>');
         if (contributeUrl) menuItems.push('<a href="' + contributeUrl + '" target="_blank" style="' + mi + '">Contribute</a>');
         if (h.snapshotUrl) menuItems.push('<a href="' + esc(h.snapshotUrl) + '" target="_blank" style="' + mi + '">Preview</a>');
         var apiBase = rb ? esc(rb) : '';
@@ -13210,6 +13245,30 @@ const dashboardHTML = `<!DOCTYPE html>
         await hiveNotify('Forge App reset armed',
           'Hive: ' + hiveName + '\n' +
           'The spoke clears its installation on the next heartbeat (about 30 seconds), then shows the install prompt.');
+        if (typeof loadHives === 'function') loadHives();
+      } catch (e) {
+        await hiveNotify('Reset failed', String(e));
+      }
+    }
+
+    /* Reset assignment: returns an assigned-but-unclaimed placeholder to the
+       available pool so it can be re-armed. Shown only on a wedged row
+       (assigned && !claim_delivered), matching the endpoint's guard — a
+       delivered claim is a live hive and the server refuses to reset it. */
+    async function resetAssignment(hiveId, hiveName) {
+      var ok = await hiveConfirm('Reset the assignment for "' + hiveName + '"?\n\n' +
+        'This slot was assigned but its spoke never reported the project back, so it is stuck "Assigning" and cannot be re-approved or re-assigned. ' +
+        'Resetting returns it to the available pool — its project, owner and org are cleared — so it can be assigned again cleanly. ' +
+        'A live, fully-claimed hive is never affected.');
+      if (!ok) return;
+      try {
+        var resp = await fetch('/api/saas/hives/' + encodeURIComponent(hiveId) + '/reset-assignment', {method: 'POST'});
+        var data = await resp.json().catch(function() { return {}; });
+        if (!resp.ok) { await hiveNotify('Reset failed', String(data.error || resp.status)); return; }
+        var extra = data.reopened_request_for ? '\nThe provision request for ' + data.reopened_request_for + ' was reopened so you can re-approve it.' : '';
+        await hiveNotify('Assignment reset',
+          'Hive: ' + hiveName + '\n' +
+          'The slot is back in the available pool and can be assigned again.' + extra);
         if (typeof loadHives === 'function') loadHives();
       } catch (e) {
         await hiveNotify('Reset failed', String(e));

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -594,6 +594,17 @@ type SaaSHive struct {
 	MigrationFrom      string `json:"migration_from,omitempty"`       // source cluster ID
 	MigrationTo        string `json:"migration_to,omitempty"`         // target cluster ID
 	MigrationStartedAt string `json:"migration_started_at,omitempty"` // RFC3339 timestamp
+
+	// AssignedAt (RFC3339) records WHEN this placeholder was last claimed — set by
+	// both claim paths (handleApproveProvision, handleAssignHive) the moment they
+	// flip Status to statusAssigned. It exists so the self-heal sweep can measure
+	// how long a placeholder has been stuck at Status=statusAssigned &&
+	// !ClaimDelivered and reset one that never completed its claim (a spoke frozen
+	// on an old image never reports the org/repos back, so ClaimDelivered stays
+	// false forever). Empty on records claimed before this field existed and on
+	// unclaimed placeholders; a zero/absent stamp makes the sweep skip the hive
+	// rather than reset it on an unknowable age.
+	AssignedAt string `json:"assigned_at,omitempty"`
 }
 
 type CreateHiveRequest struct {

--- a/v2/pkg/hub/saas_reset_assignment.go
+++ b/v2/pkg/hub/saas_reset_assignment.go
@@ -1,0 +1,255 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// assignStuckResetTimeout is how long a placeholder may sit at
+// Status=statusAssigned && !ClaimDelivered — measured from AssignedAt — before
+// the self-heal sweep returns it to the available pool automatically. A claim
+// normally completes within a heartbeat or two (tens of seconds); anything
+// still unclaimed after this window has a spoke that will never report the
+// project back (the classic case: a heartbeat-only cluster whose spoke is
+// frozen on an old image), so the slot is a dead-end until it is reset.
+//
+// 15 minutes is deliberately far longer than a healthy claim takes, so a merely
+// slow-to-reconcile spoke is never reset out from under a claim in progress.
+const assignStuckResetTimeout = 15 * time.Minute
+
+// syncRegistryProvStatus updates the in-memory registry entry's ProvStatus for
+// hiveID under the registry lock, and requests a save. The dashboard's My Hives
+// enrichment re-copies ProvStatus from meta.json on every read, but mirroring it
+// here means the change is visible on the very next render without waiting for
+// that pass — the same immediacy the assign paths rely on.
+func (s *HubServer) syncRegistryProvStatus(hiveID, provStatus string) {
+	s.mu.Lock()
+	for i := range s.registry.Hives {
+		if s.registry.Hives[i].ID == hiveID {
+			s.registry.Hives[i].ProvStatus = provStatus
+			break
+		}
+	}
+	s.mu.Unlock()
+	s.requestSave()
+}
+
+// availablePlaceholderProjectName builds the display name an unclaimed
+// placeholder carries in My Hives — "Available slot (private) <id>" for a
+// private pool slot, "Available slot <id>" otherwise. It mirrors the shape a
+// freshly seeded pool slot shows so a reset row is indistinguishable from one
+// that was never claimed.
+func availablePlaceholderProjectName(h *SaaSHive) string {
+	if h.IsPublic {
+		return "Available slot " + h.ID
+	}
+	return "Available slot (private) " + h.ID
+}
+
+// resetHiveToAvailablePlaceholder rewrites a claimed-but-undelivered placeholder
+// back to the AVAILABLE-placeholder shape — the exact inverse of what the assign
+// paths (handleApproveProvision / handleAssignHive) wrote — so the slot can be
+// re-armed and re-assigned cleanly. It mutates h in place; the caller persists.
+//
+// The transitions mirror an unclaimed pool slot: admin-owned, statusAvailable,
+// an "available-"-prefixed org (the prefix isPlaceholderEntry/drift/fleet-stats
+// all key on), empty repos/primary, the placeholder default ACMM level, and the
+// claim/level/forge handshakes re-armed to false so a future assignment delivers
+// cleanly. ClaimDelivered is asserted false (a delivered claim must never reach
+// here — the endpoint and sweep both guard on it).
+func resetHiveToAvailablePlaceholder(h *SaaSHive) {
+	h.Status = statusAvailable
+	h.Owner = hubAdminUsername
+	// The "available-" org prefix is the reliable placeholder signal
+	// (placeholderOrgPrefix); derive it from the immutable hive ID so the slot
+	// reads as available inventory again. The prior tenant's real org is dropped
+	// on purpose — that is the whole point of returning the slot to the pool.
+	h.Org = placeholderOrgPrefix + h.ID
+	h.ProjectName = availablePlaceholderProjectName(h)
+	h.Repos = nil
+	h.PrimaryRepo = ""
+	// Back to the placeholder default level — the level an unclaimed slot shows
+	// and the level the assign paths fall back to when a claim omits one.
+	h.ACMMLevel = defaultAssignACMMLevel
+	h.RequestedACMMLevel = 0
+	// Re-arm every delivery handshake so a subsequent assignment pushes its
+	// payload rather than adopting the reset slot's stale state.
+	h.ClaimDelivered = false
+	h.ACMMDelivered = false
+	h.ForgeDelivered = false
+	h.RequestedGitHubHost = ""
+	// Drop the claimed-project markers so read paths stop advertising the prior
+	// tenant's vanity host and error.
+	h.VanityURL = ""
+	h.Error = ""
+	// No longer in the assigned state, so the assigned-at stamp no longer applies.
+	h.AssignedAt = ""
+}
+
+// clearAssignedRequestForHive finds a provision request whose AssignedHive points
+// at hiveID and returns it to pending so the admin can cleanly re-approve after a
+// reset — without it the request would be orphaned in the "approved" state while
+// its hive is back in the pool, and re-approve (which requires a PENDING request)
+// would 404. Returns the affected username, or "" if no request was linked.
+func clearAssignedRequestForHive(hiveID string) string {
+	for _, pr := range listProvisionRequests() {
+		if pr.AssignedHive != hiveID {
+			continue
+		}
+		// Only a request the assignment actually fulfilled (approved) should be
+		// re-opened; a denied/pending record that merely names the hive is left
+		// alone.
+		if pr.Status != provisionStatusApproved {
+			continue
+		}
+		reopened := pr // copy — loadProvisionRequest returns a fresh value per call
+		reopened.Status = provisionStatusPending
+		reopened.AssignedHive = ""
+		reopened.DecidedBy = ""
+		reopened.DecidedAt = ""
+		if err := saveProvisionRequest(&reopened); err != nil {
+			// Best effort: report the linkage even if the flip failed, so the
+			// operator knows a manual re-open is needed.
+			return reopened.Username
+		}
+		return reopened.Username
+	}
+	return ""
+}
+
+// handleResetAssignment returns an assigned-but-unclaimed placeholder to the
+// AVAILABLE pool (admin-only). It is the escape hatch for a placeholder wedged
+// between the two claim paths: handleApproveProvision requires a PENDING request
+// (this one is already approved) and handleAssignHive requires statusAvailable
+// (this one is statusAssigned), so an assignment whose spoke never reports the
+// project back — ClaimDelivered stuck false — has no other way out.
+//
+// GUARD: it only ever touches a hive at Status=statusAssigned && !ClaimDelivered.
+// A delivered claim (ClaimDelivered==true) is a LIVE hive and is refused (409):
+// resetting it would disrupt a working tenant. An already-available slot is a
+// no-op (409). Both are the conservative choice — reset is strictly for the
+// wedged middle state.
+func (s *HubServer) handleResetAssignment(w http.ResponseWriter, r *http.Request) {
+	hiveID := r.PathValue("id")
+	admin := s.getAuthUser(r) // requireAdmin-gated
+
+	h := loadSaaSHive(hiveID)
+	if h == nil {
+		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
+		return
+	}
+	if h.Status == statusAvailable {
+		http.Error(w, `{"error":"hive is already an available placeholder — nothing to reset"}`, http.StatusConflict)
+		return
+	}
+	if h.ClaimDelivered {
+		http.Error(w, `{"error":"hive claim already delivered — reset would disrupt a live hive; deprovision instead"}`, http.StatusConflict)
+		return
+	}
+	if h.Status != statusAssigned {
+		http.Error(w, `{"error":"only an assigned-but-unclaimed placeholder can be reset"}`, http.StatusConflict)
+		return
+	}
+
+	prevOwner := h.Owner
+	prevOrg := h.Org
+	resetHiveToAvailablePlaceholder(h)
+	if err := saveSaaSHive(h); err != nil {
+		http.Error(w, `{"error":"failed to reset placeholder assignment"}`, http.StatusInternalServerError)
+		return
+	}
+	// Mirror the reset into the in-memory registry so the dashboard reflects the
+	// available slot immediately, not only after the next enrich pass.
+	s.syncRegistryProvStatus(hiveID, statusAvailable)
+
+	// Re-open any provision request this assignment fulfilled so re-approve works
+	// end to end (re-approve requires a PENDING request).
+	reopened := clearAssignedRequestForHive(hiveID)
+
+	s.logger.Info("audit: assignment reset — placeholder returned to available pool",
+		"hive_id", hiveID,
+		"by", admin,
+		"previous_owner", prevOwner,
+		"previous_org", prevOrg,
+		"reopened_request_for", reopened,
+	)
+	s.recordTimeline(hiveID, TimelineOwnership,
+		fmt.Sprintf("assignment reset by %s — slot returned to the available pool (was %s)", admin, prevOwner),
+		admin)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"ok":                   true,
+		"status":               statusAvailable,
+		"id":                   hiveID,
+		"reopened_request_for": reopened,
+	})
+}
+
+// sweepStuckAssignments auto-resets any placeholder stuck at
+// Status=statusAssigned && !ClaimDelivered for longer than
+// assignStuckResetTimeout, so an assigned-but-unclaimed slot can never dead-end
+// silently. It is the automatic counterpart to handleResetAssignment and applies
+// the identical guard and field transitions. Every reset is logged.
+func (s *HubServer) sweepStuckAssignments() {
+	now := time.Now()
+
+	type reset struct {
+		id, owner, org string
+		age            time.Duration
+		reopened       string
+	}
+	var done []reset
+
+	for _, sh := range listSaaSHives() {
+		if sh.Status != statusAssigned || sh.ClaimDelivered {
+			continue
+		}
+		// A hive with no AssignedAt stamp predates the stamp (or was written by an
+		// older path); its age is unknowable, so leave it for the operator's manual
+		// reset rather than reset it on a guessed age.
+		if sh.AssignedAt == "" {
+			continue
+		}
+		assignedAt, err := time.Parse(time.RFC3339, sh.AssignedAt)
+		if err != nil {
+			continue
+		}
+		age := now.Sub(assignedAt)
+		if age < assignStuckResetTimeout {
+			continue
+		}
+
+		h := loadSaaSHive(sh.ID) // reload to mutate the authoritative record
+		if h == nil || h.Status != statusAssigned || h.ClaimDelivered {
+			continue
+		}
+		prevOwner := h.Owner
+		prevOrg := h.Org
+		resetHiveToAvailablePlaceholder(h)
+		if err := saveSaaSHive(h); err != nil {
+			s.logger.Warn("stuck-assignment sweep: failed to reset placeholder",
+				"hive_id", h.ID, "error", err)
+			continue
+		}
+		s.syncRegistryProvStatus(h.ID, statusAvailable)
+		reopened := clearAssignedRequestForHive(h.ID)
+		done = append(done, reset{id: h.ID, owner: prevOwner, org: prevOrg, age: age, reopened: reopened})
+	}
+
+	for _, c := range done {
+		s.logger.Warn("stuck-assignment sweep: auto-reset a placeholder that never completed its claim",
+			"hive_id", c.id,
+			"previous_owner", c.owner,
+			"previous_org", c.org,
+			"stuck_for", roundedDuration(c.age),
+			"reopened_request_for", c.reopened,
+		)
+		s.recordTimeline(c.id, TimelineOwnership,
+			"assignment reset automatically after "+roundedDuration(c.age)+
+				" unclaimed — slot returned to the available pool (was "+c.owner+")",
+			"stuck-assignment-sweep")
+	}
+}


### PR DESCRIPTION
## The dead-end

When an admin approves a provision request, the placeholder is stamped `Owner`/`Org`/`Repos`/`ACMMLevel`/`RequestedACMMLevel`, `ClaimDelivered=false`, `Status=assigned`. The claim only completes when the spoke reports the matching org/repos back and the hub flips `ClaimDelivered=true`.

If that report never arrives — a heartbeat-only cluster whose spoke is frozen on an old image — the slot is wedged, with **no way out**:

- `handleApproveProvision` requires the request to be `pending` (it is already `approved`) → 404.
- `handleAssignHive` requires `Status == statusAvailable` (it is `assigned`) → 409 "hive is not an available placeholder".

So the operator can neither re-approve nor re-assign. Two real hives are stuck here now (EPM, z-innersource/vllmd).

## The reset endpoint

`POST /api/saas/hives/{id}/reset-assignment` (`requireAdmin`, `handleResetAssignment`) — the inverse of assign. It returns an assigned-but-unclaimed placeholder to the AVAILABLE-placeholder shape so it can be re-armed.

**Guard (critical):** only proceeds when `Status == statusAssigned && !ClaimDelivered`.
- `ClaimDelivered == true` → **409** `hive claim already delivered — reset would disrupt a live hive; deprovision instead` (never reset a working, fully-claimed hive).
- already `statusAvailable` → **409** no-op.
- missing → 404.

**Reset transitions** (inverse of what assign wrote):

| field | reset to |
|---|---|
| `Status` | `statusAvailable` |
| `Owner` | `hubAdminUsername` (available placeholders are admin-owned) |
| `Org` | `placeholderOrgPrefix + <id>` (the `available-` prefix drift/fleet-stats key on) |
| `ProjectName` | `Available slot [(private)] <id>` |
| `Repos` / `PrimaryRepo` | empty |
| `ACMMLevel` | `defaultAssignACMMLevel` (2) |
| `RequestedACMMLevel` | 0 |
| `ClaimDelivered` / `ACMMDelivered` / `ForgeDelivered` | false (re-armed) |
| `RequestedGitHubHost` / `VanityURL` / `Error` / `AssignedAt` | cleared |

Persisted via `saveSaaSHive` plus an in-memory registry `ProvStatus` sync so the dashboard reflects the available slot immediately.

**Linked request flip:** any provision request whose `assigned_hive` points at the slot is flipped `approved → pending` (and `assigned_hive` cleared), so the admin can cleanly re-approve end to end. The affected username is returned as `reopened_request_for`.

An audit line and a timeline entry are written on every reset.

## Self-heal sweep

`sweepStuckAssignments` auto-resets any placeholder stuck at `assigned && !claim_delivered` for longer than `assignStuckResetTimeout = 15 * time.Minute`, measured from a new `AssignedAt` stamp set by **both** claim paths (`handleApproveProvision`, `handleAssignHive`). A hive with no stamp (unknowable age) is left for the operator's manual reset. Runs alongside the existing stale-upgrade sweep in the SHA poller loop. Every auto-reset is logged. This ensures the dead-end can never persist silently.

## UI

A **Reset assignment** action on the My Hives / Assigned Hives row, admin-only, shown only on a wedged row (`assignedUnclaimed` — computed from meta so it is true even for an offline/silent spoke, unlike the reachable-spoke-only `Assigning` state). Uses the existing themed `hiveConfirm`/`hiveNotify` pattern (not native `confirm`), explaining the slot returns to the pool. Reloads on success.

## Effect

Re-arms EPM/z-innersource-class wedges: a stuck slot can be reset by hand immediately, and can never dead-end silently thanks to the sweep.

## Tests

`v2/pkg/hub/reset_assignment_test.go`:
- reset of an assigned && !claim_delivered placeholder → available shape, fields cleared, re-assignable (a subsequent `handleAssignHive` succeeds).
- reset REFUSED (409) when `ClaimDelivered == true`; live hive untouched.
- already-available → 409 no-op; missing → 404.
- non-admin → 403 (via `requireAdmin`).
- linked provision request reopened to `pending`.
- sweep: stuck-past-timeout auto-reset; within-window, delivered, and unstamped left alone.

`gofmt -w`, `go build ./pkg/hub/`, and `go vet ./pkg/hub/` all pass.