### PR TITLE
✨ feat(contribute): add watsonx.ai as a clanker onboarding backend option

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -1385,6 +1385,7 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 <option value="vllm" data-install="" data-host-install="npm i -g @anthropic-ai/claude-code" data-model-flag="--model" data-default-model="" data-env="# vLLM — self-hosted OpenAI-compatible server\nexport HIVE_LITELLM_ENDPOINT=http://your-vllm-host:8000/v1\nexport HIVE_LITELLM_API_KEY=sk-your-vllm-key  # only if your server needs one">vLLM (self-hosted)</option>
 <option value="llm-d" data-install="" data-host-install="npm i -g @anthropic-ai/claude-code" data-model-flag="--model" data-default-model="" data-env="# llm-d — self-hosted OpenAI-compatible endpoint\nexport HIVE_LITELLM_ENDPOINT=http://your-llm-d-host:8000/v1\nexport HIVE_LITELLM_API_KEY=sk-your-llm-d-key  # only if your endpoint needs one">llm-d (self-hosted)</option>
 <option value="bob" data-install="" data-host-install="curl -fsSL https://bob.ibm.com/download/bobshell.sh | bash" data-model-flag="" data-default-model="" data-env="# Bob (IBM bobshell) — get a key at https://bob.ibm.com (Scope: Inference).\n# Exported locally, never sent to the hive.\nexport BOBSHELL_API_KEY=your-bob-api-key">Bob</option>
+<option value="watsonx" data-install="" data-host-install="npm i -g @anthropic-ai/claude-code" data-model-flag="--model" data-default-model="" data-env="# IBM watsonx.ai — OpenAI-compatible gateway, bring your own project + key.\n# watsonx auth is an IAM-minted JWT, not a raw bearer key — your local\n# Claude-Code setup or a small local proxy handles the token exchange.\n# Exported locally, never sent to the hive.\nexport HIVE_LITELLM_ENDPOINT=https://us-south.ml.cloud.ibm.com/ml/gateway/v1\nexport HIVE_LITELLM_API_KEY=your-ibm-cloud-api-key\nexport WATSONX_PROJECT_ID=your-watsonx-project-id">watsonx.ai (IBM Granite + your key)</option>
 <option value="other" data-install="" data-host-install="# Install your CLI tool" data-model-flag="" data-default-model="">Other (host only)</option>
 </select>
 </span>
@@ -1466,7 +1467,7 @@ var k8sTpl='PREREQ\ngit clone -b v2 https://github.com/kubestellar/hive && cd hi
 // Backends with a verified headless (non-interactive) entry point — must match
 // HEADLESS_BACKENDS in bin/contributor-relay.sh and the Justfile. A pod has no
 // TTY, so only these run in a cluster; anything else refuses work at startup.
-var K8S_HEADLESS_BACKENDS={claude:1,litellm:1,copilot:1,codex:1};
+var K8S_HEADLESS_BACKENDS={claude:1,litellm:1,copilot:1,codex:1,watsonx:1};
 var modelRow=document.getElementById('model-row');
 var modelInput=document.getElementById('model-input');
 function updateCmds(){update();}
@@ -1560,6 +1561,7 @@ openrouter:'<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 12h4l3-4 3 8
 vllm:'<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 5l4 14 3-9 3 9 4-14" fill="none" stroke="#f0b429" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>',
 'llm-d':'<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="4" y="5" width="16" height="14" rx="2" fill="none" stroke="#4d9375" stroke-width="1.5"/><path d="M8 9h4a3 3 0 0 1 0 6H8V9Z" fill="none" stroke="#4d9375" stroke-width="1.5" stroke-linejoin="round"/></svg>',
 bob:'<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="4" width="14" height="16" rx="2" fill="none" stroke="#1f70c1" stroke-width="1.5"/><path d="M9 8h3.5a2 2 0 0 1 0 4H9V8ZM9 12h4a2 2 0 0 1 0 4H9v-4Z" fill="none" stroke="#1f70c1" stroke-width="1.3" stroke-linejoin="round"/></svg>',
+watsonx:'<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="8" fill="none" stroke="#1f70c1" stroke-width="1.5"/><path d="M12 7v10M8.5 9.5l7 5M15.5 9.5l-7 5" stroke="#1f70c1" stroke-width="1.4" stroke-linecap="round"/></svg>',
 other:'<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="4" y="6" width="16" height="12" rx="2" fill="none" stroke="#8b949e" stroke-width="1.5"/><path d="M8 12h.01M12 12h.01M16 12h.01" stroke="#8b949e" stroke-width="2.2" stroke-linecap="round"/></svg>'
 };
 var CLIENTS={
@@ -1577,6 +1579,7 @@ openrouter:{name:'OpenRouter',tag:'your key',peer:true},
 vllm:{name:'vLLM',tag:'self-hosted'},
 'llm-d':{name:'llm-d',tag:'self-hosted'},
 bob:{name:'Bob',tag:'IBM'},
+watsonx:{name:'watsonx.ai',tag:'IBM'},
 other:{name:'Other',tag:'host only'}
 };
 var tilesEl=document.getElementById('client-tiles');

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -325,6 +325,46 @@ func TestContributeLandingHasKubernetesMode(t *testing.T) {
 	}
 }
 
+// TestContributeLandingHasWatsonxOption pins the clanker-side watsonx.ai
+// onboarding option: a contributor bringing their own watsonx OpenAI-compatible
+// endpoint + key gets a labeled, guided CLI choice (instead of "Other"), and
+// the backend is headless-capable so it does not trip the Kubernetes-mode
+// no-headless-mode warning. This is onboarding UX only — the hub never sees
+// the contributor's watsonx endpoint or key.
+func TestContributeLandingHasWatsonxOption(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /contribute = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+
+	for _, want := range []string{
+		// The CLI select option: labeled, guided, own-endpoint-and-key.
+		`value="watsonx"`,
+		`watsonx.ai (IBM Granite + your key)`,
+		// The env block routes through the OpenAI-compatible gateway, same
+		// pattern as vllm/llm-d, and stays local (never sent to the hive).
+		`ml.cloud.ibm.com/ml/gateway/v1`,
+		`WATSONX_PROJECT_ID`,
+		`never sent to the hive`,
+		// CLIENTS metadata tile.
+		`watsonx:{name:'watsonx.ai',tag:'IBM'}`,
+		// Headless-capable: must be registered so Kubernetes mode does not warn.
+		`K8S_HEADLESS_BACKENDS={claude:1,litellm:1,copilot:1,codex:1,watsonx:1}`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("/contribute watsonx onboarding surface missing %q", want)
+		}
+	}
+}
+
 // TestContributeFleet pins the read-only fleet endpoint JSON shape.
 func TestContributeFleet(t *testing.T) {
 	setupContributeEnv(t)


### PR DESCRIPTION
## Summary
Adds IBM watsonx.ai as a first-class **contributor (clanker) onboarding backend option** on the /contribute page. This is the CLANKER side, distinct from the hub gateway (#2701, already merged): a clanker brings its OWN watsonx endpoint + key; the hub never sees them.

This PR is **onboarding UX only** — no hub-credential or gateway code involved.

## Context
- /contribute is server-rendered Go in `v2/pkg/dashboard/api_contribute.go`.
- The hub does NOT allowlist the contributor's reported CLI backend — `contribute_ws.go` only validates the *model*, and stores `CLIBackend` as a read-only self-report string. A watsonx clanker can already connect today; this PR just gives contributors a labeled, guided option with correct env setup instead of picking 'Other'. No server-side backend allowlist added.
- watsonx has an OpenAI-compatible gateway (`https://<region>.ml.cloud.ibm.com/ml/gateway/v1`, verified against IBM apidocs in #2701) — same Claude-Code-+-your-endpoint pattern as vllm/llm-d/litellm/openrouter (`HIVE_LITELLM_ENDPOINT`/`HIVE_LITELLM_API_KEY`).

## Changes
1. New `<option value="watsonx">` after `bob`, mirroring bob (IBM, bring-your-own-key) crossed with llm-d (OpenAI-compat endpoint + data-env). Notes that watsonx auth is an IAM-minted JWT, not a raw bearer key, so the contributor's local Claude-Code setup or a small proxy handles the token exchange. Env stays local, never sent to the hive.
2. watsonx SVG icon (IBM blue `#1f70c1`, matching bob) in the client icon map.
3. `CLIENTS` metadata: `watsonx:{name:'watsonx.ai',tag:'IBM'}` — no `peer:true` (matches vllm/llm-d/bob; peer badge is for Anthropic/GitHub/Block).
4. `watsonx:1` added to `K8S_HEADLESS_BACKENDS` — the watsonx path runs Claude Code non-interactively, so it's headless-capable and shouldn't trip the Kubernetes-mode no-headless warning.
5. New test `TestContributeLandingHasWatsonxOption` pinning the option, label, env block, CLIENTS entry, and K8S_HEADLESS_BACKENDS registration on the served /contribute HTML.

Fixes #2708

🤖 Generated with [Claude Code](https://claude.com/claude-code)