### PR TITLE
feat: latch auto-upgrade off while a spoke's claim is in flight (#95)

### DIFF
--- a/v2/pkg/hub/assignment_upgrade_latch_test.go
+++ b/v2/pkg/hub/assignment_upgrade_latch_test.go
@@ -1,0 +1,177 @@
+package hub
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// #95: an auto-upgrade must be LATCHED OFF while a spoke's claim is in flight
+// (Status==assigned && !ClaimDelivered). Rolling the spoke pod mid-claim can
+// wedge it — the EPM dead-end (task #94). These tests drive triggerAutoUpgrades
+// end to end and assert on the registry latch it sets: an upgrade that STARTS
+// flips Upgrading=true and records UpgradeTarget; a deferred one leaves both
+// untouched.
+
+// latchTestHub builds a hub pointed at a single REMOTE (not in-cluster) pool, so
+// triggerAutoUpgrades never takes the in-cluster self-upgrade path. The registry
+// entry, not kubectl, is what we assert on.
+func latchTestHub() *HubServer {
+	remote := ClusterConfig{ID: "remote", InCluster: false, KubeconfigPath: "/tmp/kc", Context: "ctx"}
+	return &HubServer{
+		logger:           slog.Default(),
+		hubSecret:        testHubSecret,
+		heartbeatUpgrade: make(map[string]string),
+		clusters:         map[string]ClusterConfig{"remote": remote},
+	}
+}
+
+// upgradeStarted reports whether triggerAutoUpgrades armed a new upgrade for id —
+// the registry latch it writes when (and only when) it decides to upgrade.
+func upgradeStarted(s *HubServer, id string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, e := range s.registry.Hives {
+		if e.ID == id {
+			return e.Upgrading && e.UpgradeTarget != ""
+		}
+	}
+	return false
+}
+
+// primeBehindLatest seeds the SHA cache so every hive on branch v2 is one commit
+// behind latest — the precondition that makes an eligible hive upgrade.
+func primeBehindLatest(t *testing.T) {
+	resetSHACaches(t)
+	latestSHAMu.Lock()
+	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "newsha95"}
+	latestSHAMu.Unlock()
+}
+
+// registryBehind returns a v2 registry entry parked one commit behind latest and
+// not currently upgrading — the state a fresh eligibility decision reads.
+func registryBehind(id string) RegistryEntry {
+	return RegistryEntry{ID: id, GitBranch: "v2", GitHash: "oldsha95"}
+}
+
+// TestAutoUpgradeLatchedWhileClaimInFlight is the core guarantee: an
+// assigned-but-unclaimed hive (claim in flight) is NOT told to upgrade even
+// though it is behind latest and has AutoUpgrade on.
+func TestAutoUpgradeLatchedWhileClaimInFlight(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	primeBehindLatest(t)
+
+	const id = "hosted-inflight-95"
+	saveSaaSHive(&SaaSHive{
+		ID: id, Owner: "acme", AutoUpgrade: true, ClusterID: "remote",
+		Status: statusAssigned, ClaimDelivered: false,
+		AssignedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+
+	s := latchTestHub()
+	s.registry.Hives = []RegistryEntry{registryBehind(id)}
+	s.triggerAutoUpgrades()
+
+	if upgradeStarted(s, id) {
+		t.Error("assigned-but-unclaimed hive was told to upgrade; the claim-in-flight latch must defer it (#95)")
+	}
+	s.mu.RLock()
+	_, armed := s.heartbeatUpgrade[id]
+	s.mu.RUnlock()
+	if armed {
+		t.Error("heartbeatUpgrade armed for an in-flight claim; no upgrade directive should reach the spoke")
+	}
+}
+
+// TestAutoUpgradeResumesAfterClaimDelivered proves the latch RELEASES: the same
+// hive, once ClaimDelivered flips true, is eligible again and upgrades.
+func TestAutoUpgradeResumesAfterClaimDelivered(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	primeBehindLatest(t)
+
+	const id = "hosted-delivered-95"
+	saveSaaSHive(&SaaSHive{
+		ID: id, Owner: "acme", AutoUpgrade: true, ClusterID: "remote",
+		Status: statusAssigned, ClaimDelivered: true, // claim landed
+		AssignedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+
+	s := latchTestHub()
+	s.registry.Hives = []RegistryEntry{registryBehind(id)}
+	s.triggerAutoUpgrades()
+
+	if !upgradeStarted(s, id) {
+		t.Error("a claimed hive (ClaimDelivered=true) was NOT told to upgrade; the latch should have released")
+	}
+}
+
+// TestAutoUpgradeAvailablePlaceholderUpgrades guards against over-latching: an
+// AVAILABLE placeholder is not assigned, so it is not in-flight and upgrades
+// normally.
+func TestAutoUpgradeAvailablePlaceholderUpgrades(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	primeBehindLatest(t)
+
+	const id = "hosted-available-95"
+	saveSaaSHive(&SaaSHive{
+		ID: id, Owner: hubAdminUsername, AutoUpgrade: true, ClusterID: "remote",
+		Status: statusAvailable, ClaimDelivered: false,
+	})
+
+	s := latchTestHub()
+	s.registry.Hives = []RegistryEntry{registryBehind(id)}
+	s.triggerAutoUpgrades()
+
+	if !upgradeStarted(s, id) {
+		t.Error("an available placeholder was not upgraded; only assigned-but-unclaimed hives should be latched")
+	}
+}
+
+// TestAutoUpgradeLiveClaimedHiveUpgrades is the ordinary case: a live, fully
+// claimed hive (status set, ClaimDelivered=true) upgrades normally.
+func TestAutoUpgradeLiveClaimedHiveUpgrades(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	primeBehindLatest(t)
+
+	const id = "hosted-live-95"
+	saveSaaSHive(&SaaSHive{
+		ID: id, Owner: "acme", AutoUpgrade: true, ClusterID: "remote",
+		Status: statusAssigned, ClaimDelivered: true,
+	})
+
+	s := latchTestHub()
+	s.registry.Hives = []RegistryEntry{registryBehind(id)}
+	s.triggerAutoUpgrades()
+
+	if !upgradeStarted(s, id) {
+		t.Error("a live claimed hive was not upgraded; the latch must only apply while the claim is in flight")
+	}
+}
+
+// TestAssignmentInFlightPredicate pins the helper's truth table directly.
+func TestAssignmentInFlightPredicate(t *testing.T) {
+	cases := []struct {
+		name           string
+		status         string
+		claimDelivered bool
+		want           bool
+	}{
+		{"assigned + undelivered = in flight", statusAssigned, false, true},
+		{"assigned + delivered = live", statusAssigned, true, false},
+		{"available + undelivered = pool slot", statusAvailable, false, false},
+		{"available + delivered = odd but not in flight", statusAvailable, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &SaaSHive{Status: tc.status, ClaimDelivered: tc.claimDelivered}
+			if got := assignmentInFlight(h); got != tc.want {
+				t.Errorf("assignmentInFlight(status=%q, delivered=%v) = %v, want %v",
+					tc.status, tc.claimDelivered, got, tc.want)
+			}
+		})
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4665,6 +4665,23 @@ func (s *HubServer) triggerAutoUpgrades() {
 		if !h.AutoUpgrade {
 			continue
 		}
+		// Claim-in-flight latch (#95). A placeholder that has just been ASSIGNED
+		// but whose claim has not yet been delivered (Status==assigned &&
+		// !ClaimDelivered) is mid-wiring: the spoke is receiving its org/repos/
+		// ACMM over successive heartbeats. Rolling its pod onto a new image now
+		// can wedge it — the classic EPM dead-end (task #94). DEFER (do not
+		// cancel) the auto-upgrade until the claim lands. This is self-limiting:
+		// it releases the moment ClaimDelivered flips true, and if the claim
+		// never completes, sweepStuckAssignments returns the slot to available
+		// after assignStuckResetTimeout — either way this latch clears and the
+		// next cycle upgrades normally. A hard image pin is unaffected: pins are
+		// delivered via UpgradeTarget through the recovery path ABOVE this gate,
+		// not started here, so a pin still wins.
+		if assignmentInFlight(&h) {
+			s.logger.Debug("auto-upgrade deferred — claim in flight",
+				"hive_id", h.ID, "status", h.Status, "assigned_at", h.AssignedAt)
+			continue
+		}
 		// Scheduling gate. Instant-mode hives (and every legacy record, whose
 		// mode is empty) pass straight through, so this changes nothing for the
 		// existing fleet. Daily-mode hives are held until the first cycle at or

--- a/v2/pkg/hub/saas_reset_assignment.go
+++ b/v2/pkg/hub/saas_reset_assignment.go
@@ -19,6 +19,28 @@ import (
 // slow-to-reconcile spoke is never reset out from under a claim in progress.
 const assignStuckResetTimeout = 15 * time.Minute
 
+// assignmentInFlight reports whether a hive is mid-claim: it has been ASSIGNED
+// to an owner but the spoke has not yet reported the project back
+// (ClaimDelivered still false). During this window the placeholder is being
+// wired up — org/repos/ACMM are being delivered to the spoke over successive
+// heartbeats — and an auto-upgrade that rolls the spoke pod partway through can
+// wedge it: the pod restarts onto a new image before the claim completes, the
+// in-flight delivery is lost, and the slot dead-ends assigned-but-unclaimed.
+// This was a root cause of the EPM wedge (task #94). triggerAutoUpgrades uses
+// it as a LATCH to DEFER (never cancel) an auto-upgrade until the claim lands.
+//
+// SELF-LIMITING — this latch cannot hold forever. It releases the instant the
+// claim completes (ClaimDelivered flips true; see saas.go where org/repos/
+// primary match) OR the slot is returned to the pool. The slot cannot stay
+// wedged either: sweepStuckAssignments auto-resets any placeholder still at
+// Status=statusAssigned && !ClaimDelivered after assignStuckResetTimeout
+// (measured from AssignedAt), which clears Status back to statusAvailable and
+// so also clears this predicate. Every hive this returns true for is therefore
+// on a bounded path to false.
+func assignmentInFlight(h *SaaSHive) bool {
+	return h.Status == statusAssigned && !h.ClaimDelivered
+}
+
 // syncRegistryProvStatus updates the in-memory registry entry's ProvStatus for
 // hiveID under the registry lock, and requests a save. The dashboard's My Hives
 // enrichment re-copies ProvStatus from meta.json on every read, but mirroring it


### PR DESCRIPTION
## What & why (#95)

Hives auto-upgrade to the latest image (~60s, hub-managed). A placeholder that has just been **assigned** but whose claim has **not yet been delivered** (`Status==assigned && !ClaimDelivered`) is mid-wiring — the spoke is receiving its org/repos/ACMM over successive heartbeats. When an auto-upgrade rolls the spoke pod partway through that claim, the in-flight delivery is lost and the slot can dead-end assigned-but-unclaimed.

**This was a root cause of the EPM wedge (task #94).**

## The latch

- New helper `assignmentInFlight(h) bool` → `h.Status == statusAssigned && !h.ClaimDelivered` (in `saas_reset_assignment.go`, co-located with the sweep that releases it).
- `triggerAutoUpgrades` (`v2/pkg/hub/saas.go`, upgrade-start section) **DEFERS** (never cancels) the auto-upgrade for an in-flight hive.
- The gate is placed **after** the `!AutoUpgrade` gate and **after** the latched-upgrade recovery path — which must stay ahead of it (#2476). A **hard image pin still wins**: pins are delivered via `UpgradeTarget` through the recovery path above the gate, not started here.

## Self-limiting — it cannot latch forever

- Releases the instant `ClaimDelivered` flips true.
- If the claim never completes, `sweepStuckAssignments` returns the slot to `available` after `assignStuckResetTimeout` (measured from `AssignedAt`), which clears `Status` and so also clears the predicate.
- **No new magic numbers** — reuses the existing reset timeout; the release is documented in the helper.

## Tests

`v2/pkg/hub/assignment_upgrade_latch_test.go`, driving `triggerAutoUpgrades` end to end:

- assigned-but-unclaimed hive is **NOT** told to upgrade (no `Upgrading` latch, no `heartbeatUpgrade` arm);
- same hive after `ClaimDelivered==true` **IS** eligible again;
- an available placeholder upgrades normally;
- a live claimed hive upgrades normally;
- plus the `assignmentInFlight` truth table.

`go build ./...` and `go vet ./pkg/hub/` clean locally; CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)