### PR TITLE
feat: assignment-duration counter on assigned-but-unclaimed rows (#96)

### DIFF
--- a/v2/pkg/hub/assign_duration_counter_test.go
+++ b/v2/pkg/hub/assign_duration_counter_test.go
@@ -1,0 +1,124 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// The assignment-duration counter (#96) is rendered by inline JS inside the
+// server-sent dashboardHTML raw string, so it is invisible to ordinary Go
+// coverage. These structure tests assert the JS gate, the live ticker, and the
+// stuck-threshold wiring are present and correctly conditioned, so a refactor
+// that drops the counter or unconditions the gate fails loudly.
+
+// TestClaimPendingPillGatedOnAssignedUnclaimed proves the counter markup only
+// renders for an assigned-but-unclaimed row and self-suppresses otherwise.
+func TestClaimPendingPillGatedOnAssignedUnclaimed(t *testing.T) {
+	// A safety net: if the string is not actually being read, a Contains pass
+	// proves nothing.
+	if len(dashboardHTML) < 1000 {
+		t.Fatalf("dashboardHTML is only %d bytes — not being read", len(dashboardHTML))
+	}
+
+	mustContain := []string{
+		// The pill helper gates on BOTH assignedUnclaimed AND a timestamp, so a
+		// claimed/available row (assignedUnclaimed false) shows nothing.
+		"function claimPendingPill(h) {",
+		"if (!h.assignedUnclaimed || !h.assignedAt) return '';",
+		// The counter is wired into the status/mode cell.
+		"modeCell += claimPendingPill(h);",
+		// Human-friendly duration formatter (Xs / XmYs / Xh Ym).
+		"function fmtAssignAge(secs) {",
+		// The visible label an operator reads.
+		"claim pending · ",
+		// Live 1s ticker so the counter advances between the 30s row polls.
+		"function tickAssignCounters() {",
+		"startAssignCounterTicker();",
+		"data-assign-since",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(dashboardHTML, s) {
+			t.Errorf("dashboardHTML missing %q — did the assignment-duration counter get dropped?", s)
+		}
+	}
+}
+
+// TestClaimPendingStuckThresholdReusesSweepConstant proves the "stuck" tint is
+// driven by h.assignStuckSeconds (the SAME threshold the self-heal sweep
+// enforces) rather than a hardcoded duplicate literal, so the amber warning
+// cannot drift from the actual auto-reset behaviour.
+func TestClaimPendingStuckThresholdReusesSweepConstant(t *testing.T) {
+	mustContain := []string{
+		"var stuck = stuckSecs > 0 && secs >= stuckSecs;",
+		// Amber stuck colour + a warning glyph so it reads as "about to reset".
+		"'#d29922'",
+		"⚠ ",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(dashboardHTML, s) {
+			t.Errorf("dashboardHTML missing %q — stuck-state styling changed?", s)
+		}
+	}
+}
+
+// TestAssignCounterPayloadPopulation proves the server only rides the assignment
+// clock + threshold on an assigned-but-unclaimed entry, and clears them for
+// available and claimed rows — the exact gate the JS pill depends on. It mirrors
+// the enrichFromSaaSMeta rule (a local closure) against the SaaSHive record.
+func TestAssignCounterPayloadPopulation(t *testing.T) {
+	assignedAt := time.Now().UTC().Format(time.RFC3339)
+	wantStuck := int(assignStuckResetTimeout / time.Second)
+
+	cases := []struct {
+		name           string
+		sh             SaaSHive
+		wantUnclaimed  bool
+		wantAssignedAt string
+		wantStuckSecs  int
+	}{
+		{
+			name:           "assigned but unclaimed rides the clock + threshold",
+			sh:             SaaSHive{Status: statusAssigned, ClaimDelivered: false, AssignedAt: assignedAt},
+			wantUnclaimed:  true,
+			wantAssignedAt: assignedAt,
+			wantStuckSecs:  wantStuck,
+		},
+		{
+			name:           "claimed row carries no counter",
+			sh:             SaaSHive{Status: statusAssigned, ClaimDelivered: true, AssignedAt: assignedAt},
+			wantUnclaimed:  false,
+			wantAssignedAt: "",
+			wantStuckSecs:  0,
+		},
+		{
+			name:           "available placeholder carries no counter",
+			sh:             SaaSHive{Status: statusAvailable, AssignedAt: assignedAt},
+			wantUnclaimed:  false,
+			wantAssignedAt: "",
+			wantStuckSecs:  0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Mirror enrichFromSaaSMeta's counter block exactly.
+			var entry MyHiveEntry
+			entry.AssignedUnclaimed = tc.sh.Status == statusAssigned && !tc.sh.ClaimDelivered
+			if entry.AssignedUnclaimed {
+				entry.AssignedAt = tc.sh.AssignedAt
+				entry.AssignStuckSeconds = int(assignStuckResetTimeout / time.Second)
+			}
+
+			if entry.AssignedUnclaimed != tc.wantUnclaimed {
+				t.Errorf("AssignedUnclaimed = %v, want %v", entry.AssignedUnclaimed, tc.wantUnclaimed)
+			}
+			if entry.AssignedAt != tc.wantAssignedAt {
+				t.Errorf("AssignedAt = %q, want %q", entry.AssignedAt, tc.wantAssignedAt)
+			}
+			if entry.AssignStuckSeconds != tc.wantStuckSecs {
+				t.Errorf("AssignStuckSeconds = %d, want %d", entry.AssignStuckSeconds, tc.wantStuckSecs)
+			}
+		})
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1992,6 +1992,20 @@ type MyHiveEntry struct {
 	// admin-only action in the row menu.
 	AssignedUnclaimed bool `json:"assignedUnclaimed,omitempty"`
 
+	// AssignedAt is the RFC3339 timestamp the placeholder was last assigned/claimed
+	// (SaaSHive.AssignedAt). It rides the row payload ONLY for a hive that is still
+	// AssignedUnclaimed, so the dashboard can render a live "claim pending" counter
+	// measuring how long the slot has been wedged. It is the same clock the
+	// assign-stuck self-heal sweep measures against, so the row's amber "stuck"
+	// threshold cannot drift from the reset timeout. Empty for every other row.
+	AssignedAt string `json:"assignedAt,omitempty"`
+
+	// AssignStuckSeconds is assignStuckResetTimeout expressed in whole seconds, so
+	// the dashboard's "stuck / about to auto-reset" tint reuses the SAME threshold
+	// the self-heal sweep enforces rather than hardcoding a duplicate in JS. Sent
+	// only alongside AssignedAt (i.e. for an assigned-but-unclaimed row).
+	AssignStuckSeconds int `json:"assignStuckSeconds,omitempty"`
+
 	// Migration tracking (Phase 7).
 	MigrationStatus string `json:"migrationStatus,omitempty"`
 	MigrationFrom   string `json:"migrationFrom,omitempty"`
@@ -2135,6 +2149,14 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		// registry) so it is true even for an offline/silent spoke — the exact
 		// dead-end the Reset assignment action targets.
 		entry.AssignedUnclaimed = sh.Status == statusAssigned && !sh.ClaimDelivered
+		// Ride the assignment clock and the self-heal threshold ONLY on an
+		// assigned-but-unclaimed row, so the dashboard can tick a "claim pending"
+		// counter and tint it amber as it nears the auto-reset the sweep enforces.
+		// Both stay zero/empty otherwise so the counter self-suppresses.
+		if entry.AssignedUnclaimed {
+			entry.AssignedAt = sh.AssignedAt
+			entry.AssignStuckSeconds = int(assignStuckResetTimeout / time.Second)
+		}
 		if sh.Status == statusAvailable || (entry.ACMMLevel == 0 && sh.ACMMLevel > 0) {
 			entry.ACMMLevel = sh.ACMMLevel
 		}
@@ -8511,6 +8533,81 @@ const dashboardHTML = `<!DOCTYPE html>
         : 'Process uptime since the last restart';
       return '<span title="' + esc(title) + '" style="font-size:0.72rem;color:' + c + ';cursor:help">' + esc(label) + '</span>';
     }
+    /* ---- Assignment / claim-pending counter --------------------------------
+       When a placeholder is ASSIGNED but its spoke has never reported the
+       project back (h.assignedUnclaimed, i.e. Status==assigned &&
+       !ClaimDelivered), the operator has no cue how long the slot has been
+       wedged. fmtAssignAge renders a compact human-friendly elapsed label from
+       h.assignedAt, and claimPendingPill wraps it in a subtle muted pill that
+       tints amber once the age crosses h.assignStuckSeconds — the SAME threshold
+       the self-heal sweep uses to auto-reset the slot — so a stuck assignment is
+       obvious at a glance and clearly "about to be auto-reset". Both self-suppress
+       (return '') for any row that is not assigned-but-unclaimed or lacks a
+       timestamp, so a claimed/available row shows nothing. The pill carries a
+       data-assign-since attribute so a 1s ticker (startAssignCounterTicker) can
+       live-update it between the 30s row refreshes without a full re-render. */
+    function fmtAssignAge(secs) {
+      var MIN = 60, HOUR = 3600;
+      if (secs < MIN) return Math.floor(secs) + 's';
+      if (secs < HOUR) {
+        var m = Math.floor(secs / MIN), s = Math.floor(secs % MIN);
+        return s > 0 ? m + 'm' + s + 's' : m + 'm';
+      }
+      var h = Math.floor(secs / HOUR), rem = Math.floor((secs % HOUR) / MIN);
+      return rem > 0 ? h + 'h ' + rem + 'm' : h + 'h';
+    }
+    /* Render the inner span for a claim-pending pill given an assignedAt epoch
+       (ms) and the stuck threshold (secs). Returns the muted-or-amber styled
+       markup, or '' when there is no valid timestamp. Shared by the initial
+       server-driven render and the live ticker so both stay in lockstep. */
+    function claimPendingInner(sinceMs, stuckSecs) {
+      if (!isFinite(sinceMs) || sinceMs <= 0) return '';
+      var secs = (Date.now() - sinceMs) / 1000;
+      if (!isFinite(secs) || secs < 0) secs = 0;
+      var stuck = stuckSecs > 0 && secs >= stuckSecs;
+      var color = stuck ? '#d29922' : 'var(--muted)';
+      var title = stuck
+        ? 'This assignment has exceeded the auto-reset threshold — the self-heal sweep will return this slot to the pool.'
+        : 'Assigned but the spoke has not reported the project back yet — waiting for the claim to complete.';
+      return '<span title="' + esc(title) + '" style="color:' + color + '">'
+        + (stuck ? '⚠ ' : '')
+        + 'claim pending · ' + esc(fmtAssignAge(secs)) + '</span>';
+    }
+    function claimPendingPill(h) {
+      if (!h.assignedUnclaimed || !h.assignedAt) return '';
+      var sinceMs = new Date(h.assignedAt).getTime();
+      if (!isFinite(sinceMs) || sinceMs <= 0) return '';
+      var stuckSecs = h.assignStuckSeconds || 0;
+      var inner = claimPendingInner(sinceMs, stuckSecs);
+      if (!inner) return '';
+      /* data-* attributes let the 1s ticker recompute in place. The outer span
+         keeps the pill styling; only the inner span's text/colour changes. */
+      return '<span class="claim-pending-pill" data-assign-since="' + sinceMs
+        + '" data-assign-stuck="' + stuckSecs
+        + '" style="display:inline-block;margin-left:6px;padding:1px 7px;border-radius:9px;'
+        + 'background:rgba(255,255,255,0.04);border:1px solid var(--border);font-size:0.68rem;white-space:nowrap;vertical-align:middle">'
+        + inner + '</span>';
+    }
+    /* Live-tick every claim-pending pill once a second so the counter advances
+       between the 30s row polls. Each tick re-derives colour+label from the
+       pill's own data-* attributes, so a re-render that replaces the pill is
+       picked up automatically (no per-pill timer to leak). Runs unconditionally
+       and is a no-op when no pills are present. */
+    var _assignCounterTimer = null;
+    function tickAssignCounters() {
+      var pills = document.querySelectorAll('.claim-pending-pill');
+      for (var i = 0; i < pills.length; i++) {
+        var el = pills[i];
+        var sinceMs = parseFloat(el.getAttribute('data-assign-since'));
+        var stuckSecs = parseInt(el.getAttribute('data-assign-stuck'), 10) || 0;
+        var inner = claimPendingInner(sinceMs, stuckSecs);
+        if (inner) el.innerHTML = inner;
+      }
+    }
+    function startAssignCounterTicker() {
+      if (_assignCounterTimer) return;
+      _assignCounterTimer = setInterval(tickAssignCounters, 1000);
+    }
     /* ---- Per-check health detail -------------------------------------------
        Health.checks[] arrives over the heartbeat as free-form JSON decoded into
        map[string]any on the hub (RegistryEntry.Health, server.go). It may be
@@ -12251,6 +12348,10 @@ const dashboardHTML = `<!DOCTYPE html>
           : h.migrationStatus === 'failed'
           ? '<span style="color:var(--red);cursor:help;white-space:nowrap" title="' + esc(h.provError || '') + '">⚠ Migration failed</span>'
           : modeBadge(h.governorMode);
+        /* A placeholder wedged at assigned && !claim_delivered gets a subtle
+           live-ticking "claim pending · Nm" pill so a stuck assignment is
+           obvious. Self-suppresses (empty) for every other row. */
+        modeCell += claimPendingPill(h);
         var rb = resolvedBase(h);
         var contributeUrl = rb ? rb + '/contribute' : '';
         var actions = '';
@@ -14450,6 +14551,9 @@ const dashboardHTML = `<!DOCTYPE html>
     init();
     var POLL_INTERVAL_MS = 30000;
     setInterval(loadHives, POLL_INTERVAL_MS);
+    /* Live-tick any claim-pending counters once a second so an assigned-but-
+       unclaimed row's "claim pending · Nm" advances between the 30s polls. */
+    startAssignCounterTicker();
     setInterval(loadAdminUsers, POLL_INTERVAL_MS);
     setInterval(loadClusterHealth, CLUSTER_HEALTH_POLL_MS);
     var _refreshTimer = null;


### PR DESCRIPTION
## What & why (#96)

When a placeholder is **ASSIGNED but not yet CLAIMED** (`Status==assigned && !ClaimDelivered`), the operator had no visibility into how long it has been stuck. This adds a small, subtle **live-ticking duration counter** on that hive's hub-dashboard row so a wedged claim is obvious at a glance.

## Behaviour

- A muted **`claim pending · Nm`** pill renders in the status/mode cell, next to the existing status badge.
- It appears **only** while the slot is assigned-but-unclaimed and disappears cleanly the moment `ClaimDelivered==true` or the slot returns to `available`.
- **Live-ticks once a second** (via a shared 1s interval that reads each pill's `data-assign-since`), so it advances between the coarse 30s row polls.
- Once the age crosses `assignStuckResetTimeout` it tints **amber with a ⚠ glyph** to signal "about to be auto-reset". That threshold is shipped to the client as `assignStuckSeconds` and reused verbatim — no hardcoded duplicate — so the warning can never drift from the self-heal sweep that actually resets the slot.

## Implementation

- `MyHiveEntry` gains `AssignedAt` + `AssignStuckSeconds`, populated in `enrichFromSaaSMeta` **only** for an assigned-but-unclaimed entry (uses the `AssignedAt` stamp added by the reset-assignment work in #2703).
- Row markup + `fmtAssignAge` / `claimPendingPill` / `tickAssignCounters` helpers live in the inline `dashboardHTML` JS (server-rendered raw string, `fmt.Fprint` not `Fprintf` — no `%` escaping needed).

## Tests

- Structure tests over `dashboardHTML` assert the JS gate, the live ticker, and the stuck-threshold wiring are present and correctly conditioned.
- A payload test covers the assigned / claimed / available field-population rule (counter rides only the assigned-but-unclaimed case).

`go build ./...` and the hub test package pass.