### PR TITLE
fix: deliver complete GHE forge atomically on claim (never blank→github.com)

### DIFF
--- a/v2/cmd/hive/identity_set_delivery_test.go
+++ b/v2/cmd/hive/identity_set_delivery_test.go
@@ -71,3 +71,55 @@ func TestIdentityTravelsAsOneSet(t *testing.T) {
 		}
 	})
 }
+
+// TestGHEClaimAdoptedAsWholeSet is the spoke side of the never-blank-for-GHE
+// fix: a placeholder provisioned PUBLIC (app_id 3568013, blank urls) is claimed
+// for a github.ibm.com org, and the hub delivers the COMPLETE GHE set on one
+// beat. The spoke must adopt all four fields together and end up coherent — the
+// EPM symptom was exactly the opposite: it kept the public app_id and blank urls
+// and silently talked to github.com.
+func TestGHEClaimAdoptedAsWholeSet(t *testing.T) {
+	// The starting state of an EPM placeholder before its claim converges.
+	publicStart := config.GitHubConfig{
+		AppID:   config.PublicGitHubAppID,
+		AppSlug: config.PublicGitHubAppSlug,
+		// blank urls == public github.com, the placeholder's provisioned state
+	}
+
+	t.Run("the complete GHE set is coherent and fully adopted", func(t *testing.T) {
+		got := prospectiveGitHubIdentity(publicStart, &hub.HeartbeatGitHubAppConfig{
+			AppID:   config.EnterpriseGitHubAppID,
+			AppSlug: config.EnterpriseGitHubAppSlug,
+			APIURL:  config.EnterpriseGitHubAPIURL,
+			BaseURL: config.EnterpriseGitHubBaseURL,
+		})
+		if got == nil {
+			t.Fatal("a full GHE identity change produced no prospective set")
+		}
+		if got.AppID != config.EnterpriseGitHubAppID ||
+			got.AppSlug != config.EnterpriseGitHubAppSlug ||
+			got.APIURL != config.EnterpriseGitHubAPIURL ||
+			got.BaseURL != config.EnterpriseGitHubBaseURL {
+			t.Fatalf("the GHE set was not adopted whole: %+v", *got)
+		}
+		if err := config.RejectIdentitySet(*got); err != nil {
+			t.Fatalf("the complete GHE set was rejected as incoherent: %v", err)
+		}
+	})
+
+	t.Run("the GHE App WITHOUT its urls is caught as the EPM half-set", func(t *testing.T) {
+		// The regression shape: the GHE app_id/slug arrive but the urls do not, so
+		// the spoke would pair the GHE App with its own blank (public) urls —
+		// app_id 5686 aimed at api.github.com, "404 Integration not found".
+		got := prospectiveGitHubIdentity(publicStart, &hub.HeartbeatGitHubAppConfig{
+			AppID:   config.EnterpriseGitHubAppID,
+			AppSlug: config.EnterpriseGitHubAppSlug,
+		})
+		if got == nil {
+			t.Fatal("expected a prospective set to validate")
+		}
+		if err := config.RejectIdentitySet(*got); err == nil {
+			t.Fatal("a GHE App left on blank/public urls was ACCEPTED — the EPM half-set must be refused so the whole delivery is retried, never half-applied")
+		}
+	})
+}

--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -799,12 +799,22 @@ func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFing
 		hive = hiveOpt[0]
 	}
 	identity := s.appIdentityForHive(hive, clusterID)
-	// Does this cluster's App live on a GitHub Enterprise host? Read from cluster
-	// config, never inferred from the App ID — an App ID is an opaque number and
-	// carries no forge information. Empty github_base_url means public github.com.
+	// Does this cluster's DEFAULT App live on a GitHub Enterprise host? Read from
+	// cluster config, never inferred from the App ID — an App ID is an opaque
+	// number and carries no forge information.
+	//
+	// Judged on clusterDefaultForge, NOT on a bare `github_base_url != ""`. The
+	// flat github_base_url is only one of the two shapes a GHE cluster can take:
+	// the 2026-07-31 rework lets a cluster declare `default_forge` +　a `forges`
+	// map and leave the flat URL blank. A flat-only read then reported such a
+	// cluster as PUBLIC, so the wrong-forge app_id repair below (gated on
+	// clusterIsGHE) never fired for it and a spoke stuck on the public app_id
+	// against github.ibm.com stayed broken — the EPM symptom, on the delivery
+	// side. clusterDefaultForge honours default_forge, so a GHE default is
+	// recognised however it is written.
 	clusterIsGHE := false
 	if c, ok := s.clusters[clusterID]; ok {
-		clusterIsGHE = strings.TrimSpace(c.GitHubBaseURL) != ""
+		clusterIsGHE = !isPublicForgeHost(clusterDefaultForge(&c))
 	}
 	decision := decideAppKeySync(spokeFingerprint, hasPerHiveKey, hivePublicPinned, clusterIsGHE, spokeAppID, identity)
 	// A spoke carrying the sentinel is broken and must be legible even when the
@@ -1157,7 +1167,21 @@ func (s *HubServer) appKeySyncForHeartbeat(payload *HeartbeatPayload) *Heartbeat
 	hivePublicPinned := false
 	if sh != nil {
 		if c, ok := s.clusters[clusterID]; ok {
-			hivePublicPinned = effectiveGitHubBaseURL(sh, &c) == "" && c.GitHubBaseURL != ""
+			// "cluster defaults to GHE" is judged on clusterDefaultForge, not the
+			// flat github_base_url alone, so a GHE cluster written in the
+			// default_forge/forges-map shape is recognised as GHE here too.
+			clusterGHEDefault := !isPublicForgeHost(clusterDefaultForge(&c))
+			// The hive is public-pinned only when it ELECTED public. Judge that on
+			// electedForgeForHive, which reads github_host FIRST (then the
+			// github_base_url "public" sentinel) — NOT on effectiveGitHubBaseURL,
+			// which reads only github_base_url and returns "" for a GHE hive whose
+			// forge lives in github_host with a blank base_url. That blind spot
+			// wrongly flagged every GHE hive on a forge-map cluster as public-pinned
+			// (its base_url is blank there), suppressing the very GHE identity
+			// delivery this reconcile exists to make.
+			elected := electedForgeForHive(sh, &c)
+			hiveElectedPublic := elected != "" && isPublicForgeHost(elected)
+			hivePublicPinned = hiveElectedPublic && clusterGHEDefault
 		}
 	}
 	// The hub does not track installation IDs, and this reconcile is about the

--- a/v2/pkg/hub/ghe_forge_map_shape_test.go
+++ b/v2/pkg/hub/ghe_forge_map_shape_test.go
@@ -1,0 +1,368 @@
+package hub
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// The regression window: a GHE cluster written in the 2026-07-31 shape —
+// `default_forge` + a `forges` map, with the flat github_base_url/github_api_url
+// LEFT BLANK. Before this fix, clusterForgeHost and backfillGitHubHostFromCluster
+// read only the flat fields, so such a cluster resolved to PUBLIC github.com and
+// every hive on it that recorded no host got the public identity (app_id 0 /
+// blank urls) — the EPM placeholder that claimed github.ibm.com yet ran a blank
+// forge against github.com.
+//
+// vllmDForgeMapCluster is that shape. The identity lives only in the map.
+func vllmDForgeMapCluster() *ClusterConfig {
+	return &ClusterConfig{
+		ID:           "vllm-d",
+		DefaultForge: identGHEHost,
+		Forges: map[string]ClusterForgeIdentity{
+			identGHEHost: {AppID: testGHEAppID, AppSlug: identGHESlug},
+		},
+	}
+}
+
+// TestClusterDefaultForgeShapesAgree pins that the resolver's notion of a
+// cluster's default forge matches clusterDefaultForge for BOTH shapes. The split
+// between these two was the bug.
+func TestClusterDefaultForgeShapesAgree(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		cluster *ClusterConfig
+		want    string
+	}{
+		{"flat-field GHE cluster", vllmDCluster(), identGHEHost},
+		{"forge-map GHE cluster (default_forge)", vllmDForgeMapCluster(), identGHEHost},
+		{"public cluster", hiveOKECluster(), publicForgeHost},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clusterForgeHost(tc.cluster); !sameGitHubHost(got, tc.want) {
+				t.Errorf("clusterForgeHost = %q, want %q", got, tc.want)
+			}
+			if got := clusterDefaultForge(tc.cluster); !sameGitHubHost(got, tc.want) {
+				t.Errorf("clusterDefaultForge = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveHiveIdentityForgeMapShape is the core regression assertion: a hive
+// with NO recorded host on a forge-map GHE cluster must resolve to the GHE App
+// and GHE urls — never the public/blank identity that dropped it onto github.com.
+func TestResolveHiveIdentityForgeMapShape(t *testing.T) {
+	cluster := vllmDForgeMapCluster()
+
+	t.Run("no recorded host inherits the GHE default (the EPM case)", func(t *testing.T) {
+		got := ResolveHiveIdentity(&SaaSHive{ID: "hosted-available-vllmd-260731-19h2", Org: "epm"}, cluster)
+		if got.AppID != testGHEAppID {
+			t.Errorf("AppID = %d, want the GHE App %d — a blank-host hive on a forge-map GHE cluster must NOT resolve public", got.AppID, testGHEAppID)
+		}
+		if !sameGitHubHost(got.Forge, identGHEHost) {
+			t.Errorf("Forge = %q, want %q", got.Forge, identGHEHost)
+		}
+		// The atomic set must be COMPLETE and coherent: GHE urls, never blank.
+		if got.APIURL != identGHEAPIURL || got.BaseURL != identGHEBaseURL {
+			t.Errorf("urls did not name the GHE forge: api=%q base=%q — a GHE default must never travel with blank/public urls", got.APIURL, got.BaseURL)
+		}
+		if got.AppSlug != identGHESlug {
+			t.Errorf("AppSlug = %q, want %q", got.AppSlug, identGHESlug)
+		}
+	})
+
+	t.Run("an explicit GHE election still resolves the GHE App", func(t *testing.T) {
+		got := ResolveHiveIdentity(&SaaSHive{ID: "vllmd-x", GitHubHost: identGHEHost}, cluster)
+		if got.AppID != testGHEAppID || !sameGitHubHost(got.Forge, identGHEHost) {
+			t.Errorf("got app=%d forge=%q, want app=%d forge=%s", got.AppID, got.Forge, testGHEAppID, identGHEHost)
+		}
+	})
+
+	t.Run("a public election on the forge-map GHE cluster stays public", func(t *testing.T) {
+		got := ResolveHiveIdentity(&SaaSHive{ID: "elected-public", GitHubHost: publicForgeHost}, cluster)
+		if !sameGitHubHost(got.Forge, publicForgeHost) || !got.FromHiveIntent {
+			t.Errorf("got forge=%q intent=%v, want public election", got.Forge, got.FromHiveIntent)
+		}
+		// The forge-map cluster names no public App, so none is invented.
+		if got.AppID != 0 {
+			t.Errorf("AppID = %d, want 0 — this cluster names no public App to hand out", got.AppID)
+		}
+	})
+}
+
+// TestBackfillGitHubHostForgeMapShape proves the assign/approve-time backfill
+// fills the GHE host for the forge-map shape too, so a fresh GHE claim never
+// lands blank.
+func TestBackfillGitHubHostForgeMapShape(t *testing.T) {
+	cluster := vllmDForgeMapCluster()
+
+	if got := backfillGitHubHostFromCluster(&SaaSHive{}, cluster); got != identGHEHost {
+		t.Errorf("blank-host backfill = %q, want %q — a forge-map GHE cluster must backfill its GHE host", got, identGHEHost)
+	}
+	// The public sentinel still stays public on a forge-map GHE cluster.
+	if got := backfillGitHubHostFromCluster(&SaaSHive{GitHubBaseURL: githubHostPublic}, cluster); got != "" {
+		t.Errorf("public pin backfill = %q, want empty — an explicit public pin must stay public", got)
+	}
+	// And the backfilled host must actually drive a GHE API URL on the heartbeat.
+	if got := gheAPIURLForHost(backfillGitHubHostFromCluster(&SaaSHive{}, cluster)); got != identGHEAPIURL {
+		t.Errorf("gheAPIURLForHost = %q, want %q", got, identGHEAPIURL)
+	}
+}
+
+// TestGuardGHEHiveNotOnPublicForge exercises the never-blank-for-GHE guard: a
+// claimed GHE-cluster hive that is POSITIVELY reporting the public github.com
+// forge is repaired by re-recording the cluster's GHE host, while every
+// legitimate public case is left untouched.
+func TestGuardGHEHiveNotOnPublicForge(t *testing.T) {
+	oldHives := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = oldHives })
+
+	newHub := func() *HubServer {
+		return &HubServer{
+			logger: slog.New(slog.NewTextHandler(nopWriter{}, nil)),
+			clusters: map[string]ClusterConfig{
+				"hive-oke": *hiveOKECluster(),
+				// The GHE cluster in the forge-map shape — the shape that hid the bug.
+				"vllm-d": *vllmDForgeMapCluster(),
+			},
+		}
+	}
+
+	// A spoke report that names the public forge with the public app_id.
+	publicReport := func(id string) *HeartbeatPayload {
+		return &HeartbeatPayload{
+			HiveID:       id,
+			GitHubAPIURL: "", // blank api_url = api.github.com
+			GitHubAppID:  config.PublicGitHubAppID,
+		}
+	}
+
+	run := func(t *testing.T, hive *SaaSHive, payload *HeartbeatPayload) (bool, string) {
+		t.Helper()
+		if err := saveSaaSHive(hive); err != nil {
+			t.Fatal(err)
+		}
+		s := newHub()
+		changed := s.guardGHEHiveNotOnPublicForge(payload)
+		got := ""
+		if reloaded := loadSaaSHive(hive.ID); reloaded != nil {
+			got = reloaded.GitHubHost
+		}
+		return changed, got
+	}
+
+	t.Run("claimed GHE hive running public is repaired to the GHE host", func(t *testing.T) {
+		changed, got := run(t,
+			&SaaSHive{ID: "epm-blank", Status: statusAssigned, ClusterID: "vllm-d", Org: "epm", GitHubHost: ""},
+			publicReport("epm-blank"),
+		)
+		if !changed || got != identGHEHost {
+			t.Errorf("got (changed=%v, host=%q), want (true, %s)", changed, got, identGHEHost)
+		}
+	})
+
+	t.Run("a persisted-but-public github_host on a GHE cluster is repaired", func(t *testing.T) {
+		changed, got := run(t,
+			&SaaSHive{ID: "epm-public", Status: statusAssigned, ClusterID: "vllm-d", Org: "epm", GitHubHost: "github.com"},
+			publicReport("epm-public"),
+		)
+		if !changed || got != identGHEHost {
+			t.Errorf("got (changed=%v, host=%q), want (true, %s)", changed, got, identGHEHost)
+		}
+	})
+
+	t.Run("an explicit public pin is never repaired", func(t *testing.T) {
+		changed, got := run(t,
+			&SaaSHive{ID: "pinned", Status: statusAssigned, ClusterID: "vllm-d", GitHubBaseURL: githubHostPublic, GitHubHost: "github.com"},
+			publicReport("pinned"),
+		)
+		if changed || got != "github.com" {
+			t.Errorf("got (changed=%v, host=%q), want (false, github.com) — a public pin is a decision", changed, got)
+		}
+	})
+
+	t.Run("a GHE hive already recording the GHE host is a no-op (spoke just not converged)", func(t *testing.T) {
+		changed, got := run(t,
+			&SaaSHive{ID: "converging", Status: statusAssigned, ClusterID: "vllm-d", GitHubHost: identGHEHost},
+			publicReport("converging"),
+		)
+		if changed || got != identGHEHost {
+			t.Errorf("got (changed=%v, host=%q), want (false, %s)", changed, got, identGHEHost)
+		}
+	})
+
+	t.Run("an in-flight forge switch is never raced", func(t *testing.T) {
+		changed, got := run(t,
+			&SaaSHive{ID: "switching", Status: statusAssigned, ClusterID: "vllm-d", GitHubHost: "github.com", RequestedGitHubHost: identGHEHost},
+			publicReport("switching"),
+		)
+		if changed || got != "github.com" {
+			t.Errorf("got (changed=%v, host=%q), want (false, github.com) — the switch owns the host", changed, got)
+		}
+	})
+
+	t.Run("a public-cluster hive running public is correct and untouched", func(t *testing.T) {
+		changed, got := run(t,
+			&SaaSHive{ID: "console", Status: statusAssigned, ClusterID: "hive-oke", GitHubHost: ""},
+			publicReport("console"),
+		)
+		if changed || got != "" {
+			t.Errorf("got (changed=%v, host=%q), want (false, \"\") — public cluster running public is fine", changed, got)
+		}
+	})
+
+	t.Run("an unclaimed placeholder is skipped", func(t *testing.T) {
+		changed, got := run(t,
+			&SaaSHive{ID: "placeholder", Status: statusAvailable, ClusterID: "vllm-d", GitHubHost: ""},
+			publicReport("placeholder"),
+		)
+		if changed || got != "" {
+			t.Errorf("got (changed=%v, host=%q), want (false, \"\") — assign owns a placeholder", changed, got)
+		}
+	})
+
+	t.Run("a spoke too old to report (no app_id) is UNKNOWN, never a fault", func(t *testing.T) {
+		changed, got := run(t,
+			&SaaSHive{ID: "old-spoke", Status: statusAssigned, ClusterID: "vllm-d", GitHubHost: ""},
+			&HeartbeatPayload{HiveID: "old-spoke"}, // no api_url, no app_id
+		)
+		if changed || got != "" {
+			t.Errorf("got (changed=%v, host=%q), want (false, \"\") — silence is not evidence", changed, got)
+		}
+	})
+
+	t.Run("nil payload / nil server are safe", func(t *testing.T) {
+		s := newHub()
+		if s.guardGHEHiveNotOnPublicForge(nil) {
+			t.Error("nil payload must be a no-op")
+		}
+		var nilServer *HubServer
+		if nilServer.guardGHEHiveNotOnPublicForge(&HeartbeatPayload{HiveID: "x"}) {
+			t.Error("nil server must be a no-op")
+		}
+	})
+}
+
+// TestGHEClaimDeliversCompleteAtomicSet proves the heartbeat App-config path
+// delivers ALL FOUR forge fields — app_id, app_slug, api_url, base_url —
+// together for a GHE claim, so a spoke stuck on the public app_id converges onto
+// the complete GHE identity rather than a half-set. It runs against the forge-map
+// cluster shape, the shape that used to resolve public.
+func TestGHEClaimDeliversCompleteAtomicSet(t *testing.T) {
+	withTempAppKeyDir(t)
+	oldHives := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = oldHives })
+	storeKeyFor(t, "vllm-d")
+
+	s := &HubServer{
+		logger: appKeyTestLogger(),
+		clusters: map[string]ClusterConfig{
+			"vllm-d": *vllmDForgeMapCluster(),
+		},
+	}
+
+	// A claimed GHE hive whose spoke still carries the PUBLIC app_id (a placeholder
+	// provisioned public, now claimed for a github.ibm.com org).
+	if err := saveSaaSHive(&SaaSHive{
+		ID: "epm-claim", Status: statusAssigned, ClusterID: "vllm-d",
+		Org: "epm", GitHubHost: identGHEHost,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	payload := &HeartbeatPayload{
+		HiveID:      "epm-claim",
+		ClusterID:   "vllm-d",
+		GitHubAppID: config.PublicGitHubAppID, // spoke still on the public App
+	}
+
+	cfg := s.appKeySyncForHeartbeat(payload)
+	if cfg == nil {
+		t.Fatal("no app config delivered — a spoke on the public app_id against a GHE claim must be corrected")
+	}
+	if cfg.AppID != testGHEAppID {
+		t.Errorf("delivered app_id = %d, want the GHE App %d", cfg.AppID, testGHEAppID)
+	}
+	if cfg.AppSlug != identGHESlug {
+		t.Errorf("delivered app_slug = %q, want %q", cfg.AppSlug, identGHESlug)
+	}
+	if cfg.APIURL != identGHEAPIURL {
+		t.Errorf("delivered api_url = %q, want %q — the URL must travel WITH the App, never blank", cfg.APIURL, identGHEAPIURL)
+	}
+	if cfg.BaseURL != identGHEBaseURL {
+		t.Errorf("delivered base_url = %q, want %q — the complete atomic set, never blank", cfg.BaseURL, identGHEBaseURL)
+	}
+	// The delivered set must itself be internally coherent (the write-path guard).
+	if err := config.RejectIdentitySet(config.GitHubConfig{
+		AppID: cfg.AppID, AppSlug: cfg.AppSlug, APIURL: cfg.APIURL, BaseURL: cfg.BaseURL,
+	}); err != nil {
+		t.Errorf("delivered a half-identity: %v", err)
+	}
+}
+
+// TestPublicHiveStillFineWithBlankForge is the don't-break-public guard: a
+// github.com hive on a public cluster, running the public App with blank urls —
+// the ~48-of-51 steady state — must NOT be handed any forge push. Blank stays
+// blank.
+func TestPublicHiveStillFineWithBlankForge(t *testing.T) {
+	withTempAppKeyDir(t)
+	oldHives := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = oldHives })
+	storeKeyFor(t, "hive-oke")
+
+	s := &HubServer{
+		logger:   appKeyTestLogger(),
+		clusters: map[string]ClusterConfig{"hive-oke": *hiveOKECluster()},
+	}
+	if err := saveSaaSHive(&SaaSHive{
+		ID: "console", Status: statusAssigned, ClusterID: "hive-oke",
+		Org: "kubestellar", GitHubHost: publicForgeHost,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// The spoke reports the public App and the cluster key fingerprint already —
+	// fully converged. Nothing should be pushed.
+	pem := loadClusterAppKey("hive-oke")
+	clusterFP, err := config.AppKeyFingerprint(pem)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := &HeartbeatPayload{
+		HiveID:                  "console",
+		ClusterID:               "hive-oke",
+		GitHubAppID:             config.PublicGitHubAppID,
+		GitHubAppKeyFingerprint: clusterFP,
+	}
+	if cfg := s.appKeySyncForHeartbeat(payload); cfg != nil {
+		t.Errorf("a converged public hive was pushed a forge change: app_id=%d api_url=%q base_url=%q — blank must stay blank",
+			cfg.AppID, cfg.APIURL, cfg.BaseURL)
+	}
+	// And the guard must never fire on it.
+	if s.guardGHEHiveNotOnPublicForge(payload) {
+		t.Error("the never-blank-for-GHE guard fired on a legitimate public hive")
+	}
+}
+
+// TestForgeAppsAcrossFleetForgeMapShape proves a forge declared only in the
+// `forges` map is discoverable fleet-wide, so a hive that elects it on a
+// DIFFERENT cluster can still borrow the App.
+func TestForgeAppsAcrossFleetForgeMapShape(t *testing.T) {
+	s := &HubServer{
+		logger: slog.New(slog.NewTextHandler(nopWriter{}, nil)),
+		clusters: map[string]ClusterConfig{
+			"hive-oke": *hiveOKECluster(),       // flat public App
+			"vllm-d":   *vllmDForgeMapCluster(), // GHE App only in the forges map
+		},
+	}
+	apps := s.forgeAppsAcrossFleet()
+	if got := apps[publicForgeHost]; got.AppID != testPublicAppID {
+		t.Errorf("public forge app = %d, want %d", got.AppID, testPublicAppID)
+	}
+	if got := apps[identGHEHost]; got.AppID != testGHEAppID {
+		t.Errorf("GHE forge app = %d, want %d — a forges-map App must be discoverable fleet-wide", got.AppID, testGHEAppID)
+	}
+}

--- a/v2/pkg/hub/hive_identity.go
+++ b/v2/pkg/hub/hive_identity.go
@@ -117,25 +117,41 @@ func ResolveHiveIdentity(h *SaaSHive, cluster *ClusterConfig) HiveIdentity {
 
 	clusterForge := clusterForgeHost(cluster)
 	// Start from the cluster default — rule 2.
+	//
+	// The App/URLs are read for the cluster's DEFAULT forge through
+	// forgesForCluster, NOT from the flat github_app_id/github_* fields directly.
+	// The flat fields are only ONE of the two shapes a cluster's identity can take
+	// since 2026-07-31: a GHE cluster may instead declare `default_forge` plus a
+	// `forges` map and leave the flat fields blank. Reading the flat fields alone
+	// then produced app_id 0 / blank urls for a GHE cluster whose real identity
+	// sat in the map — the half-identity that dropped the EPM placeholder onto
+	// github.com. forgesForCluster merges both shapes, so the default forge's
+	// identity is found however it is written; defaultForgeIdentity falls back to
+	// the flat fields when the map is absent, keeping legacy clusters unchanged.
+	defID := defaultForgeIdentity(cluster, clusterForge)
 	id := HiveIdentity{
-		AppID:   cluster.GitHubAppID,
-		AppSlug: strings.TrimSpace(cluster.GitHubAppSlug),
-		APIURL:  cluster.GitHubAPIURL,
-		BaseURL: cluster.GitHubBaseURL,
+		AppID:   defID.AppID,
+		AppSlug: strings.TrimSpace(defID.AppSlug),
+		APIURL:  defID.APIURL,
+		BaseURL: defID.BaseURL,
 		Forge:   clusterForge,
 	}
-	// DELIBERATELY NOT made explicit here, unlike the elected-forge branch below.
+	// PUBLIC urls are DELIBERATELY left empty here, unlike the elected-forge
+	// branch below.
 	//
-	// A cluster that declares no url fields looks public to clusterForgeHost —
+	// A cluster that declares no forge at all resolves clusterForge to public —
 	// but so does a GHE cluster that simply has not backfilled its urls, and
-	// several real records are in exactly that state. Writing public urls on
-	// that silence would stamp api.github.com onto GHE clusters and break the
-	// repair path this whole design exists to serve. SILENCE IS NOT EVIDENCE.
+	// several real records are in exactly that state. Writing public urls on that
+	// silence would stamp api.github.com onto GHE clusters and break the repair
+	// path this whole design exists to serve. SILENCE IS NOT EVIDENCE, so
+	// defaultForgeIdentity leaves the urls blank whenever clusterForge is public.
 	//
-	// An ELECTION is different: a hive that records github_host is stating its
-	// forge, so the urls can be stated with it. Explicitness is safe where there
-	// is evidence and dangerous where there is only absence — which is the same
-	// unknown-vs-mismatch rule the push flags follow.
+	// A GHE default is the opposite of silence: clusterDefaultForge names a GHE
+	// host only on POSITIVE evidence (an explicit default_forge or a flat GHE
+	// url), so defaultForgeIdentity states the GHE urls with it. That is what
+	// stops a GHE default from ever travelling with blank/public urls — the EPM
+	// half-identity — while a public/under-specified cluster stays untouched. The
+	// same unknown-vs-mismatch rule the push flags follow.
 	//
 	// Filling the slug IS safe: slugOfAppID keys on app_id, which is always
 	// populated, and returns "" for an App this build does not recognise.
@@ -333,19 +349,75 @@ func normalizeHiveForge(h *SaaSHive, cluster *ClusterConfig) bool {
 	return changed
 }
 
-// clusterForgeHost is the forge a cluster defaults to: the host named by its
-// URL fields, else public github.com.
+// clusterForgeHost is the forge a cluster defaults to.
+//
+// It MUST agree with clusterDefaultForge, which is the forge-aware authority
+// (explicit default_forge, then the flat URL fields, then public). Reading only
+// the flat github_base_url/github_api_url — as this used to — silently disagreed
+// with clusterDefaultForge for a cluster that expresses its GHE-ness through the
+// 2026-07-31 `default_forge` + `forges` map shape instead of the flat URL
+// fields: clusterDefaultForge said github.ibm.com while this said github.com.
+//
+// That split is the regression this whole file exists to prevent, reintroduced
+// one layer down. A vllm-d entry written as
+//
+//	{ "default_forge": "github.ibm.com",
+//	  "forges": { "github.ibm.com": { "app_id": 5686, "app_slug": "..." } } }
+//
+// has EMPTY flat github_base_url, so the old form resolved its default forge to
+// public github.com. ResolveHiveIdentity then handed every hive with no recorded
+// host the PUBLIC identity (app_id 0 / blank urls) on a GHE cluster — the EPM
+// placeholder that claimed github.ibm.com yet ran a blank forge against
+// github.com. Routing through clusterDefaultForge closes that gap: one function
+// decides "what forge does this cluster default to", forge-map shape included.
 func clusterForgeHost(c *ClusterConfig) string {
 	if c == nil {
 		return publicForgeHost
 	}
-	if c.GitHubBaseURL != "" {
-		return forgeHostLabel(c.GitHubBaseURL)
+	return clusterDefaultForge(c)
+}
+
+// defaultForgeIdentity returns the App identity (id, slug, urls) a cluster
+// declares for its DEFAULT forge, from whichever shape the cluster is written
+// in.
+//
+// forgesForCluster already merges the legacy flat github_app_id/github_app_slug
+// fields with the explicit per-forge `forges` map, so this one lookup covers a
+// cluster written either way. The URLs are stated explicitly for a GHE default
+// even when the cluster left them blank in the map, because the forge host is
+// enough to derive them (the same derivation the elected-forge branch uses) —
+// and a GHE default whose urls read as blank is precisely the state that let a
+// GHE cluster resolve to github.com.
+//
+// A public default keeps EMPTY urls: that is the correct, coherent public shape
+// (ResolvedAPIURL/ResolvedBaseURL map "" to the two public constants), and
+// stating public urls on a cluster that only IMPLIED public — by declaring
+// nothing — would stamp api.github.com onto GHE clusters that simply have not
+// filled their urls in. Silence is not evidence, exactly as ResolveHiveIdentity
+// documents for its own cluster-default branch.
+func defaultForgeIdentity(c *ClusterConfig, forge string) ClusterForgeIdentity {
+	if c == nil {
+		return ClusterForgeIdentity{}
 	}
-	if c.GitHubAPIURL != "" {
-		return forgeHostLabel(c.GitHubAPIURL)
+	var out ClusterForgeIdentity
+	for host, id := range forgesForCluster(c) {
+		if sameGitHubHost(host, forge) {
+			out = id
+			break
+		}
 	}
-	return publicForgeHost
+	if isPublicForgeHost(forge) {
+		return out // public: empty urls are the coherent shape
+	}
+	// GHE default: state the urls from the forge host when the cluster left them
+	// blank, so a GHE default can never travel with public/blank urls.
+	if strings.TrimSpace(out.BaseURL) == "" {
+		out.BaseURL = "https://" + forge
+	}
+	if strings.TrimSpace(out.APIURL) == "" {
+		out.APIURL = "https://" + forge + gheAPIPathSuffix
+	}
+	return out
 }
 
 // clusterAppForForge returns the App a cluster names on a given forge.
@@ -427,6 +499,13 @@ func (i HiveIdentity) AppIDString() string {
 //
 // Deterministic on collision (two clusters naming different Apps on one forge):
 // clusters are visited in sorted ID order, mirroring appKeysByAppID.
+//
+// It enumerates EVERY forge each cluster serves via forgesForCluster, not just
+// the cluster's flat github_app_id. A GHE cluster written in the 2026-07-31
+// `forges` map shape carries its App under forges.<host> with a blank flat
+// github_app_id, so a flat-only read contributed nothing for it — leaving a
+// hive that elected that forge on a DIFFERENT cluster unable to borrow the App,
+// with the same app_id-0 blank identity this file exists to prevent.
 func (s *HubServer) forgeAppsAcrossFleet() map[string]clusterAppIdentity {
 	out := map[string]clusterAppIdentity{}
 	if s == nil || s.clusters == nil {
@@ -439,16 +518,18 @@ func (s *HubServer) forgeAppsAcrossFleet() map[string]clusterAppIdentity {
 	sort.Strings(ids)
 	for _, id := range ids {
 		c := s.clusters[id]
-		if c.GitHubAppID == 0 {
-			continue
-		}
-		forge := clusterForgeHost(&c)
-		if _, seen := out[forge]; seen {
-			continue // first cluster in sorted order wins
-		}
-		out[forge] = clusterAppIdentity{
-			AppID:   c.GitHubAppID,
-			AppSlug: strings.TrimSpace(c.GitHubAppSlug),
+		for host, fid := range forgesForCluster(&c) {
+			if fid.AppID == 0 {
+				continue
+			}
+			forge := forgeHostLabel(host)
+			if _, seen := out[forge]; seen {
+				continue // first cluster in sorted order wins
+			}
+			out[forge] = clusterAppIdentity{
+				AppID:   fid.AppID,
+				AppSlug: strings.TrimSpace(fid.AppSlug),
+			}
 		}
 	}
 	return out

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -734,11 +734,31 @@ func backfillGitHubHostFromCluster(h *SaaSHive, cluster *ClusterConfig) string {
 	if h == nil || h.GitHubHost != "" || cluster == nil {
 		return ""
 	}
-	base := effectiveGitHubBaseURL(h, cluster)
-	if base == "" {
+	// A per-hive base URL is a stated DECISION and wins outright — including the
+	// "public" sentinel, which effectiveGitHubBaseURL resolves to "" and which
+	// must STAY public (return "") rather than being re-GHE'd from the cluster.
+	// So any non-empty github_base_url short-circuits the cluster fallback: a real
+	// per-hive host is recorded as-is, and the public sentinel records nothing.
+	if strings.TrimSpace(h.GitHubBaseURL) != "" {
+		base := effectiveGitHubBaseURL(h, cluster)
+		if base == "" {
+			return "" // explicit public pin — stay public
+		}
+		return githubHostLabel(base)
+	}
+	// No per-hive host at all: fall back to the cluster's DEFAULT forge, forge-map
+	// shape included. The old code read only the flat github_base_url via
+	// effectiveGitHubBaseURL, so a GHE cluster written as `default_forge` +
+	// `forges` map (blank flat github_base_url) resolved to public here and left
+	// GitHubHost blank — the spoke then kept api.github.com with the public app_id
+	// even though the cluster is GHE (the EPM placeholder). clusterDefaultForge
+	// honours default_forge, so a GHE default now backfills the GHE host however
+	// it is written. A public default still returns "" (nothing to record).
+	forge := clusterDefaultForge(cluster)
+	if isPublicForgeHost(forge) {
 		return "" // public github.com — nothing to record
 	}
-	return githubHostLabel(base)
+	return forge
 }
 
 // repairGitHubHostsFromClusters retroactively fills in a blank GitHubHost on
@@ -822,6 +842,112 @@ func (s *HubServer) repairGitHubHostForHive(hiveID string) bool {
 		"github_host_before", "",
 		"github_host_after", host,
 		"github_api_url_after", gheAPIURLForHost(host),
+		"note", gitHubAppStillRequiredNote)
+	return true
+}
+
+// guardGHEHiveNotOnPublicForge is the never-blank-for-GHE guard. It fires when a
+// CLAIMED hive on a GHE-default cluster is actively reporting that it runs the
+// PUBLIC github.com forge — a blank/api.github.com api_url with the public
+// app_id — while nothing about the hive elected public. That pairing is the EPM
+// symptom: a hive whose org lives on github.ibm.com silently talking to
+// github.com, authenticating as nothing. It reports whether it changed anything.
+//
+// WHY THIS IS DISTINCT FROM THE OTHER TWO REPAIRS
+//
+//	repairGitHubHostForHive       fills a BLANK github_host from cluster defaults.
+//	reconcileGitHubHostFromSpoke  corrects a WRONG github_host from the forge the
+//	                              spoke reports.
+//
+// Neither closes this case. reconcileGitHubHostFromSpoke only trusts a spoke
+// that POSITIVELY reports a GHE host; a spoke running the wrong (public) forge
+// reports github.com, which that function reads as "unknown, stand down". And
+// repairGitHubHostForHive no-ops once github_host is non-blank. So a GHE hive
+// that ended up on github.com — blank host filled to public by an older build,
+// or a stale record — had no repair path at all: it reported public forever and
+// nothing corrected it. This guard is the one writer that treats a positive
+// public report on a GHE cluster as the fault it is.
+//
+// It is deliberately conservative and one-directional, mirroring its siblings:
+//   - Only a CLAIMED hive (assign owns an unclaimed placeholder's host).
+//   - Only when the hive's CLUSTER defaults to GHE (forge-map shape included via
+//     clusterDefaultForge) — a public cluster legitimately runs public.
+//   - NEVER against an explicit public pin (github_base_url "public"/github.com):
+//     that is a deliberate decision, exactly the appKeyReasonPublicHiveOnGHECluster
+//     case, and must keep running github.com.
+//   - NEVER while an operator forge SWITCH is in flight (RequestedGitHubHost set):
+//     the switch path owns the host and could be moving the hive TO public.
+//   - Only when the spoke POSITIVELY reports the public forge. A spoke too old to
+//     report its api_url sends "" — but "" from an old spoke is UNKNOWN, so the
+//     signal is taken only alongside a github.com app_id, which an old spoke does
+//     report. Silence is never evidence.
+//
+// The repair itself is to (re)set github_host to the cluster's GHE default. That
+// is enough: on the next beat ResolveHiveIdentity resolves the GHE App and
+// appKeySyncForHeartbeat delivers the COMPLETE atomic set (app_id, app_slug,
+// api_url, base_url), while projectConfigForHiveID pushes the GHE api_url — the
+// hub re-delivers the cluster forge rather than the spoke silently proceeding on
+// github.com. As with the host repair, the GitHub App must still be installed on
+// the org before auto-discovery can adopt an installation (gitHubAppStillRequiredNote).
+func (s *HubServer) guardGHEHiveNotOnPublicForge(payload *HeartbeatPayload) bool {
+	if s == nil || payload == nil {
+		return false
+	}
+	h := loadSaaSHive(payload.HiveID)
+	if h == nil || h.Status == statusAvailable {
+		return false // unclaimed placeholder — assign owns its host
+	}
+	// An explicit public pin is a decision, not a fault.
+	if h.GitHubBaseURL == githubHostPublic || h.GitHubBaseURL == "https://github.com" {
+		return false
+	}
+	// A forge switch owns the host while it runs — it may be moving TO public.
+	if h.RequestedGitHubHost != "" {
+		return false
+	}
+	cluster := s.clusterForHive(h)
+	if cluster == nil {
+		return false
+	}
+	clusterForge := clusterDefaultForge(cluster)
+	if isPublicForgeHost(clusterForge) {
+		return false // public cluster — running public is correct
+	}
+	// Does the SPOKE positively report it is running the public forge? Judge the
+	// forge it reports, base-or-api. A blank/api.github.com api_url on its own is
+	// ambiguous (an old spoke sends ""), so require the public app_id alongside —
+	// which an old spoke DOES report — before treating this as a positive public
+	// report rather than silence.
+	spokeForge := config.GitHubConfig{
+		BaseURL: strings.TrimSpace(payload.GitHubBaseURL),
+		APIURL:  strings.TrimSpace(payload.GitHubAPIURL),
+	}.HostLabel()
+	spokeOnPublic := isPublicForgeHost(spokeForge) && payload.GitHubAppID == config.PublicGitHubAppID
+	if !spokeOnPublic {
+		return false
+	}
+	// If the hive already records the GHE host, the resolver is already delivering
+	// the GHE identity and the spoke just has not converged yet — do not churn the
+	// record. Only act when the host is blank or itself public.
+	if h.GitHubHost != "" && !isPublicForgeHost(forgeHostLabel(h.GitHubHost)) {
+		return false
+	}
+	before := h.GitHubHost
+	h.GitHubHost = clusterForge
+	if err := saveSaaSHive(h); err != nil {
+		s.logger.Error("github forge guard: failed to save hive",
+			"hive", payload.HiveID, "error", err)
+		return false
+	}
+	s.logger.Warn("github forge guard: a claimed GHE-cluster hive was running the PUBLIC github.com forge — re-delivering the cluster forge",
+		"hive", payload.HiveID,
+		"cluster", cluster.ID,
+		"org", h.Org,
+		"github_host_before", before,
+		"github_host_after", clusterForge,
+		"spoke_app_id", payload.GitHubAppID,
+		"spoke_api_url", strings.TrimSpace(payload.GitHubAPIURL),
+		"github_api_url_after", gheAPIURLForHost(clusterForge),
 		"note", gitHubAppStillRequiredNote)
 	return true
 }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1590,6 +1590,13 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	// never demoting a legit public pin). Closes the vllmd-06 class: meta said
 	// github.com while the spoke ran api_url github.ibm.com.
 	s.reconcileGitHubHostFromSpoke(&payload)
+	// Never-blank-for-GHE guard. The two repairs above trust a blank host or a
+	// GHE-reporting spoke; neither catches a claimed GHE-cluster hive that is
+	// POSITIVELY reporting the public github.com forge (blank api_url + public
+	// app_id) with no public pin — the EPM symptom. Re-deliver the cluster forge
+	// so the spoke stops silently talking to github.com. No-op (and silent) for
+	// every hive not in that exact state.
+	s.guardGHEHiveNotOnPublicForge(&payload)
 
 	// Close the FORGE handshake before building the project config, so the beat
 	// on which the spoke first reports the requested host is also the beat the


### PR DESCRIPTION
## The bug (confirmed live)

A GitHub Enterprise (GHE) cluster placeholder could be claimed for a `github.ibm.com` org yet run a **blank forge → public github.com** (public app_id `3568013`, blank `api_url`), silently authenticating against the wrong host — every token request 404ing on the GHE org.

**Live symptom:** the EPM placeholder `hosted-available-vllmd-260731-19h2` claimed org **EPM** on `github.ibm.com` but ran a blank forge against github.com until it was hand-patched.

## Root cause

The 2026-07-31 forge rework introduced `default_forge` + a per-forge `forges` map as a second way to express a GHE cluster's identity — but the resolver path never learned to read them, leaving **two divergent notions of a cluster's default forge**:

| function | reads | shape it misses |
|---|---|---|
| `clusterDefaultForge` (forge.go authority) | `default_forge` → flat urls → public | — |
| `clusterForgeHost` (hive_identity.go) | **only** flat `github_base_url`/`github_api_url` | `default_forge` |
| `backfillGitHubHostFromCluster` (assign/approve) | **only** flat `github_base_url` | `default_forge` |
| `decideAppKeySync` `clusterIsGHE` / `hivePublicPinned` | **only** flat `github_base_url` | `default_forge` |

For a `vllm-d` entry written as `default_forge: "github.ibm.com"` + a `forges` map with **blank flat urls**, the failure chain was:

1. **Assign/approve** — `backfillGitHubHostFromCluster` → `effectiveGitHubBaseURL` returns the blank flat `github_base_url`, so `github_host` was left **blank** at claim.
2. **Heartbeat resolve** — `ResolveHiveIdentity` used `clusterForgeHost` (→ public) and read the flat `github_app_id` (→ 0 / public), so a blank-host hive resolved to the **public** identity with blank urls.
3. **Delivery** — `decideAppKeySync`'s `clusterIsGHE` was false (flat base_url blank), so the wrong-forge app_id repair never fired; and `hivePublicPinned` was a false-positive for any GHE hive whose forge lives in `github_host` with a blank `base_url`, suppressing the GHE delivery outright.

Net: spoke keeps `app_id 3568013` + blank `api_url` → **github.com**. The EPM symptom.

## Fix (atomic + never-blank-for-GHE)

- `clusterForgeHost` now delegates to `clusterDefaultForge` — the two can no longer disagree.
- `ResolveHiveIdentity` reads the default forge's identity via `forgesForCluster` (new `defaultForgeIdentity` helper), stating GHE urls **explicitly** for a GHE default so the App never travels with blank/public urls. Public / under-specified clusters keep blank urls (silence is not evidence).
- `forgeAppsAcrossFleet` enumerates every forge a cluster serves via `forgesForCluster`, so a forge-map App is discoverable fleet-wide.
- `backfillGitHubHostFromCluster` falls back to `clusterDefaultForge`, filling the GHE host however the cluster is written; an explicit `public` pin still stays public.
- `clusterIsGHE` and `hivePublicPinned` are now forge-aware (`clusterDefaultForge` / `electedForgeForHive`), so the wrong-forge repair fires and a GHE hive is never mistaken for public-pinned.
- **New guard `guardGHEHiveNotOnPublicForge`** (wired into the heartbeat path): a *claimed* GHE-cluster hive **positively** reporting the public forge (blank api_url + public app_id, no public pin) is repaired by re-recording the cluster's GHE host, so the hub **re-delivers the complete cluster forge** rather than the spoke silently proceeding on github.com. Conservative and one-directional: never a public pin, never an in-flight forge switch, never an unclaimed placeholder, never on a silent (too-old) spoke.

**github.com hives keep working with blank `api_url`/`base_url`** — blank stays blank; the guard and the delivery path both no-op on them.

## Tests

- **hub-side** (`pkg/hub/ghe_forge_map_shape_test.go`): forge-map-shape resolution (the EPM case resolves to the complete GHE set), backfill, the guard (8 cases incl. public pin / switch / placeholder / silent spoke), fleet-app discovery, and a **complete-atomic-set delivery** test asserting all four fields (`app_id`, `app_slug`, `api_url`, `base_url`) go out together, plus a "public hive stays fine with blank forge" test.
- **spoke-side** (`cmd/hive/identity_set_delivery_test.go`): a complete GHE set is adopted whole and coherent; a GHE App **without** its urls is caught as the EPM half-set and refused (so the whole delivery is retried, never half-applied).

`go build ./...` and `go vet ./...` clean; affected package tests green.

## Follow-up: one-time repair sweep (not done here — sketch only)

Already-broken GHE spokes now self-heal on their next heartbeat via `repairGitHubHostForHive` (blank → GHE host) and the new guard (public-reporting → GHE host), which then trigger the complete-set delivery. A proactive sweep is therefore **not required**, but if desired an operator-triggered pass could iterate `listSaaSHives()`, and for each claimed hive on a GHE-default cluster with a blank/public `github_host` and no public pin, apply the same `backfillGitHubHostFromCluster` / guard logic once — reusing the existing lazy per-hive functions. **No live spokes or the hub cluster were touched.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)