### PR TITLE
fix: Reset assignment reachable for null-Status org-assigned wedge (vllmd-13 class)

### DIFF
--- a/v2/pkg/hub/reset_assignment_test.go
+++ b/v2/pkg/hub/reset_assignment_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -319,5 +320,235 @@ func TestSweepStuckAssignments(t *testing.T) {
 	}
 	if got := loadSaaSHive("hosted-unstamped"); got.Status != statusAssigned {
 		t.Errorf("unstamped hive Status = %q, want left assigned (unknowable age)", got.Status)
+	}
+}
+
+// nullStatusWedge returns the vllmd-13 class: a placeholder handed a REAL org and
+// primary_repo (org=z-innersource, repo=AutoIPL) but with Status left NULL/"" and
+// ClaimDelivered false — the exact live wedge whose Reset button was HIDDEN before
+// the predicate was broadened, because Status != statusAssigned.
+func nullStatusWedge(id string) *SaaSHive {
+	return &SaaSHive{
+		ID:             id,
+		Owner:          "z-owner",
+		Org:            "z-innersource",
+		Repos:          []string{"AutoIPL"},
+		PrimaryRepo:    "AutoIPL",
+		ProjectName:    "AutoIPL",
+		ACMMLevel:      2,
+		Status:         "", // never persisted as "assigned" — the whole bug
+		ClaimDelivered: false,
+		ClusterID:      "hive-oke",
+		// No AssignedAt (the wedge never got the stamp); CreatedAt is what the sweep
+		// ages it by.
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+// cleanAvailablePlaceholder returns a seeded pool slot: statusAvailable, admin
+// owner, the synthetic "available-<id>" org and no primary_repo. Reset must NEVER
+// offer / act on this — there is nothing to reset.
+func cleanAvailablePlaceholder(id string) *SaaSHive {
+	return &SaaSHive{
+		ID:        id,
+		Owner:     hubAdminUsername,
+		Org:       placeholderOrgPrefix + id,
+		Status:    statusAvailable,
+		ClusterID: "hive-oke",
+	}
+}
+
+// TestAssignedUnclaimedPredicate covers the broadened enrichFromSaaSMeta gate:
+// TRUE for a Status==assigned wedge, a null-Status-but-real-org wedge, and a
+// (defensive) available-status-but-real-org wedge; FALSE for a clean available
+// slot and for a delivered claim.
+func TestAssignedUnclaimedPredicate(t *testing.T) {
+	// The predicate as shipped in enrichFromSaaSMeta, extracted so the test asserts
+	// the exact boolean rather than routing through a full dashboard render.
+	assignedUnclaimed := func(sh *SaaSHive) bool {
+		hasRealOrg := sh.Org != "" && !strings.HasPrefix(sh.Org, placeholderOrgPrefix)
+		notClaimed := !sh.ClaimDelivered
+		hasAssignedIdentity := hasRealOrg || sh.PrimaryRepo != ""
+		isAssignedStatus := sh.Status == statusAssigned
+		isCleanAvailable := sh.Status == statusAvailable && !hasAssignedIdentity
+		return notClaimed && !isCleanAvailable && (isAssignedStatus || hasAssignedIdentity)
+	}
+
+	cases := []struct {
+		name string
+		hive *SaaSHive
+		want bool
+	}{
+		{"assigned+!claim", stuckPlaceholder("a"), true},
+		{"nullStatus+realOrg+!claim", nullStatusWedge("b"), true},
+		{
+			"available-status+realOrg+!claim",
+			&SaaSHive{ID: "c", Org: "z-innersource", PrimaryRepo: "AutoIPL", Status: statusAvailable},
+			true,
+		},
+		{"cleanAvailable", cleanAvailablePlaceholder("d"), false},
+		{
+			"cleanAvailable-emptyOrg",
+			&SaaSHive{ID: "e", Owner: hubAdminUsername, Status: statusAvailable},
+			false,
+		},
+		{
+			"claimDelivered",
+			func() *SaaSHive { h := stuckPlaceholder("f"); h.ClaimDelivered = true; return h }(),
+			false,
+		},
+	}
+	for _, tc := range cases {
+		if got := assignedUnclaimed(tc.hive); got != tc.want {
+			t.Errorf("%s: AssignedUnclaimed = %v, want %v (hive=%+v)", tc.name, got, tc.want, tc.hive)
+		}
+	}
+}
+
+// TestIsResettableWedge asserts the handler/sweep gate matches the UI predicate:
+// same TRUE set, same FALSE set.
+func TestIsResettableWedge(t *testing.T) {
+	cases := []struct {
+		name string
+		hive *SaaSHive
+		want bool
+	}{
+		{"assigned+!claim", stuckPlaceholder("a"), true},
+		{"nullStatus+realOrg+!claim", nullStatusWedge("b"), true},
+		{"cleanAvailable", cleanAvailablePlaceholder("d"), false},
+		{
+			"cleanAvailable-emptyOrg",
+			&SaaSHive{ID: "e", Owner: hubAdminUsername, Status: statusAvailable},
+			false,
+		},
+		{
+			"claimDelivered",
+			func() *SaaSHive { h := stuckPlaceholder("f"); h.ClaimDelivered = true; return h }(),
+			false,
+		},
+	}
+	for _, tc := range cases {
+		if got := isResettableWedge(tc.hive); got != tc.want {
+			t.Errorf("%s: isResettableWedge = %v, want %v (hive=%+v)", tc.name, got, tc.want, tc.hive)
+		}
+	}
+}
+
+// TestResetAssignmentNullStatusWedge is the core fix: the handler now SUCCEEDS on
+// the null-Status-but-real-org wedge and returns it to the clean available shape.
+func TestResetAssignmentNullStatusWedge(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+	s := newResetTestHub()
+
+	const id = "hosted-available-vllmd-13"
+	if err := saveSaaSHive(nullStatusWedge(id)); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/reset-assignment", "", hubAdminUsername), "id", id)
+	s.handleResetAssignment(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("reset of null-Status wedge status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	got := loadSaaSHive(id)
+	if got == nil {
+		t.Fatal("hive vanished after reset")
+	}
+	// Ends up clean/available regardless of the prior NULL status.
+	if got.Status != statusAvailable {
+		t.Errorf("Status = %q, want %q", got.Status, statusAvailable)
+	}
+	if !strings.HasPrefix(got.Org, placeholderOrgPrefix) {
+		t.Errorf("Org = %q, want %q-prefixed", got.Org, placeholderOrgPrefix)
+	}
+	if got.PrimaryRepo != "" || len(got.Repos) != 0 {
+		t.Errorf("repos not cleared: PrimaryRepo=%q Repos=%v", got.PrimaryRepo, got.Repos)
+	}
+	if got.Owner != hubAdminUsername {
+		t.Errorf("Owner = %q, want admin", got.Owner)
+	}
+	if !isReassignable(id) {
+		t.Error("null-Status wedge not re-assignable after reset")
+	}
+}
+
+// TestResetAssignmentRefusedCleanAvailable: a clean available placeholder (real
+// available shape, no assigned identity) is still a 409 no-op after broadening.
+func TestResetAssignmentRefusedCleanAvailable(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+	s := newResetTestHub()
+
+	const id = "hosted-clean-available"
+	if err := saveSaaSHive(cleanAvailablePlaceholder(id)); err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/reset-assignment", "", hubAdminUsername), "id", id)
+	s.handleResetAssignment(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("reset of clean-available status = %d, want 409 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if got := loadSaaSHive(id); !strings.HasPrefix(got.Org, placeholderOrgPrefix) {
+		t.Errorf("clean-available slot mutated: %+v", got)
+	}
+}
+
+// TestSweepStuckAssignmentsNullStatusWedge: the self-heal sweep resets a
+// null-Status wedge once it is older than the timeout (aged by CreatedAt), and
+// leaves a fresh one, a clean-available slot, and a delivered claim alone.
+func TestSweepStuckAssignmentsNullStatusWedge(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+	s := newResetTestHub()
+
+	// Null-status wedge created long ago -> reset (aged by CreatedAt).
+	old := nullStatusWedge("hosted-vllmd-old")
+	old.CreatedAt = time.Now().Add(-2 * assignStuckResetTimeout).UTC().Format(time.RFC3339)
+	if err := saveSaaSHive(old); err != nil {
+		t.Fatal(err)
+	}
+
+	// Null-status wedge created just now -> left alone (within the window). Guards
+	// against yanking a brand-new, legitimately-mid-assignment slot.
+	fresh := nullStatusWedge("hosted-vllmd-fresh")
+	fresh.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	if err := saveSaaSHive(fresh); err != nil {
+		t.Fatal(err)
+	}
+
+	// Clean available slot -> never a sweep target.
+	clean := cleanAvailablePlaceholder("hosted-clean")
+	if err := saveSaaSHive(clean); err != nil {
+		t.Fatal(err)
+	}
+
+	// Delivered claim (real org, old CreatedAt) -> a live hive, left alone.
+	live := nullStatusWedge("hosted-live-null")
+	live.ClaimDelivered = true
+	live.CreatedAt = time.Now().Add(-2 * assignStuckResetTimeout).UTC().Format(time.RFC3339)
+	if err := saveSaaSHive(live); err != nil {
+		t.Fatal(err)
+	}
+
+	s.sweepStuckAssignments()
+
+	if got := loadSaaSHive("hosted-vllmd-old"); got.Status != statusAvailable || !strings.HasPrefix(got.Org, placeholderOrgPrefix) {
+		t.Errorf("old null-status wedge not auto-reset: %+v", got)
+	}
+	if got := loadSaaSHive("hosted-vllmd-fresh"); got.Org != "z-innersource" {
+		t.Errorf("fresh null-status wedge was swept within window: %+v", got)
+	}
+	if got := loadSaaSHive("hosted-clean"); !strings.HasPrefix(got.Org, placeholderOrgPrefix) || got.Status != statusAvailable {
+		t.Errorf("clean-available slot was swept: %+v", got)
+	}
+	if got := loadSaaSHive("hosted-live-null"); !got.ClaimDelivered || got.Org != "z-innersource" {
+		t.Errorf("delivered claim was swept: %+v", got)
 	}
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2130,11 +2130,35 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		entry.ProvStatus = sh.Status
-		// A placeholder wedged between the two claim paths: assigned but the spoke
-		// never reported the project back. Computed from meta (not the live
-		// registry) so it is true even for an offline/silent spoke — the exact
-		// dead-end the Reset assignment action targets.
-		entry.AssignedUnclaimed = sh.Status == statusAssigned && !sh.ClaimDelivered
+		// A placeholder wedged between the two claim paths: it was given a real
+		// identity (org/repo written) but the spoke never reported the project back.
+		// Computed from meta (not the live registry) so it is true even for an
+		// offline/silent spoke — the exact dead-end the Reset assignment action
+		// targets.
+		//
+		// The predicate is deliberately broader than "Status == statusAssigned".
+		// The current assign paths (handleApproveProvision / handleAssignHive) always
+		// stamp Status=statusAssigned alongside the org/repo, but LEGACY/wedged
+		// placeholders exist that carry a REAL org/primary_repo with Status left NULL
+		// or "" (e.g. the live hosted-available-vllmd-13: org=z-innersource,
+		// repo=AutoIPL, status=null) — precisely the wedge the escape hatch was built
+		// to rescue. Keying only on statusAssigned HID the Reset item for exactly
+		// those slots.
+		//
+		// A clean available slot is NOT bare — a seeded/reset placeholder carries the
+		// synthetic "available-<id>" org (placeholderOrgPrefix) and an empty
+		// primary_repo, which is how isPlaceholderEntry recognizes inventory. So "has
+		// a real assigned identity" means a non-empty org that is NOT the placeholder
+		// prefix, or any primary_repo. Treat a placeholder as assigned-unclaimed
+		// whenever it is NOT a delivered claim (that is a LIVE hive) AND is NOT a
+		// clean available slot but HAS been handed a real identity (Status==assigned,
+		// or a real org / primary_repo written under any/no status).
+		hasRealOrg := sh.Org != "" && !strings.HasPrefix(sh.Org, placeholderOrgPrefix)
+		notClaimed := !sh.ClaimDelivered
+		hasAssignedIdentity := hasRealOrg || sh.PrimaryRepo != ""
+		isAssignedStatus := sh.Status == statusAssigned
+		isCleanAvailable := sh.Status == statusAvailable && !hasAssignedIdentity
+		entry.AssignedUnclaimed = notClaimed && !isCleanAvailable && (isAssignedStatus || hasAssignedIdentity)
 		if sh.Status == statusAvailable || (entry.ACMMLevel == 0 && sh.ACMMLevel > 0) {
 			entry.ACMMLevel = sh.ACMMLevel
 		}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2144,11 +2144,35 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		entry.ProvStatus = sh.Status
-		// A placeholder wedged between the two claim paths: assigned but the spoke
-		// never reported the project back. Computed from meta (not the live
-		// registry) so it is true even for an offline/silent spoke — the exact
-		// dead-end the Reset assignment action targets.
-		entry.AssignedUnclaimed = sh.Status == statusAssigned && !sh.ClaimDelivered
+		// A placeholder wedged between the two claim paths: it was given a real
+		// identity (org/repo written) but the spoke never reported the project back.
+		// Computed from meta (not the live registry) so it is true even for an
+		// offline/silent spoke — the exact dead-end the Reset assignment action
+		// targets.
+		//
+		// The predicate is deliberately broader than "Status == statusAssigned".
+		// The current assign paths (handleApproveProvision / handleAssignHive) always
+		// stamp Status=statusAssigned alongside the org/repo, but LEGACY/wedged
+		// placeholders exist that carry a REAL org/primary_repo with Status left NULL
+		// or "" (e.g. the live hosted-available-vllmd-13: org=z-innersource,
+		// repo=AutoIPL, status=null) — precisely the wedge the escape hatch was built
+		// to rescue. Keying only on statusAssigned HID the Reset item for exactly
+		// those slots.
+		//
+		// A clean available slot is NOT bare — a seeded/reset placeholder carries the
+		// synthetic "available-<id>" org (placeholderOrgPrefix) and an empty
+		// primary_repo, which is how isPlaceholderEntry recognizes inventory. So "has
+		// a real assigned identity" means a non-empty org that is NOT the placeholder
+		// prefix, or any primary_repo. Treat a placeholder as assigned-unclaimed
+		// whenever it is NOT a delivered claim (that is a LIVE hive) AND is NOT a
+		// clean available slot but HAS been handed a real identity (Status==assigned,
+		// or a real org / primary_repo written under any/no status).
+		hasRealOrg := sh.Org != "" && !strings.HasPrefix(sh.Org, placeholderOrgPrefix)
+		notClaimed := !sh.ClaimDelivered
+		hasAssignedIdentity := hasRealOrg || sh.PrimaryRepo != ""
+		isAssignedStatus := sh.Status == statusAssigned
+		isCleanAvailable := sh.Status == statusAvailable && !hasAssignedIdentity
+		entry.AssignedUnclaimed = notClaimed && !isCleanAvailable && (isAssignedStatus || hasAssignedIdentity)
 		// Ride the assignment clock and the self-heal threshold ONLY on an
 		// assigned-but-unclaimed row, so the dashboard can tick a "claim pending"
 		// counter and tint it amber as it nears the auto-reset the sweep enforces.

--- a/v2/pkg/hub/saas_reset_assignment.go
+++ b/v2/pkg/hub/saas_reset_assignment.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -141,6 +142,36 @@ func clearAssignedRequestForHive(hiveID string) string {
 	return ""
 }
 
+// hiveHasAssignedIdentity reports whether a placeholder has been handed a REAL
+// tenant identity — a non-placeholder org or any primary_repo. A clean available
+// slot carries only the synthetic "available-<id>" org (placeholderOrgPrefix) and
+// an empty primary_repo, so it returns false. This is the exact mirror of the
+// enrichFromSaaSMeta / dashboard AssignedUnclaimed gate, kept here so the handler
+// and the self-heal sweep accept precisely the states the UI offers Reset for.
+func hiveHasAssignedIdentity(h *SaaSHive) bool {
+	hasRealOrg := h.Org != "" && !strings.HasPrefix(h.Org, placeholderOrgPrefix)
+	return hasRealOrg || h.PrimaryRepo != ""
+}
+
+// isResettableWedge reports whether a placeholder is in the assigned-but-unclaimed
+// wedge that Reset assignment targets: NOT a delivered claim (a delivered claim is
+// a LIVE hive) AND NOT a clean available slot, but either explicitly
+// Status=statusAssigned OR carrying a real assigned identity (org/primary_repo)
+// under any/no status. It broadens the original Status==statusAssigned gate to
+// also cover the null-Status-but-org-set legacy wedge (the live vllmd-13 class),
+// while still refusing a delivered claim and a genuinely-clean available slot.
+func isResettableWedge(h *SaaSHive) bool {
+	if h.ClaimDelivered {
+		return false
+	}
+	hasIdentity := hiveHasAssignedIdentity(h)
+	isCleanAvailable := h.Status == statusAvailable && !hasIdentity
+	if isCleanAvailable {
+		return false
+	}
+	return h.Status == statusAssigned || hasIdentity
+}
+
 // handleResetAssignment returns an assigned-but-unclaimed placeholder to the
 // AVAILABLE pool (admin-only). It is the escape hatch for a placeholder wedged
 // between the two claim paths: handleApproveProvision requires a PENDING request
@@ -148,11 +179,13 @@ func clearAssignedRequestForHive(hiveID string) string {
 // (this one is statusAssigned), so an assignment whose spoke never reports the
 // project back — ClaimDelivered stuck false — has no other way out.
 //
-// GUARD: it only ever touches a hive at Status=statusAssigned && !ClaimDelivered.
-// A delivered claim (ClaimDelivered==true) is a LIVE hive and is refused (409):
-// resetting it would disrupt a working tenant. An already-available slot is a
-// no-op (409). Both are the conservative choice — reset is strictly for the
-// wedged middle state.
+// GUARD: it accepts a hive in the assigned-but-unclaimed wedge (isResettableWedge)
+// — Status=statusAssigned OR a real org/primary_repo written under any/no status
+// (the null-Status legacy wedge, e.g. vllmd-13), and always !ClaimDelivered. A
+// delivered claim (ClaimDelivered==true) is a LIVE hive and is refused (409):
+// resetting it would disrupt a working tenant. A genuinely-clean available slot
+// (no real identity) is a no-op (409). Both refusals are the conservative choice —
+// reset is strictly for the wedged middle state.
 func (s *HubServer) handleResetAssignment(w http.ResponseWriter, r *http.Request) {
 	hiveID := r.PathValue("id")
 	admin := s.getAuthUser(r) // requireAdmin-gated
@@ -162,15 +195,18 @@ func (s *HubServer) handleResetAssignment(w http.ResponseWriter, r *http.Request
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Status == statusAvailable {
-		http.Error(w, `{"error":"hive is already an available placeholder — nothing to reset"}`, http.StatusConflict)
-		return
-	}
 	if h.ClaimDelivered {
 		http.Error(w, `{"error":"hive claim already delivered — reset would disrupt a live hive; deprovision instead"}`, http.StatusConflict)
 		return
 	}
-	if h.Status != statusAssigned {
+	// A clean available slot (statusAvailable with no real assigned identity) has
+	// nothing to reset. A hive that is neither the wedge nor clean-available (e.g.
+	// provisioning/error with no identity) is likewise not a reset target.
+	if !isResettableWedge(h) {
+		if h.Status == statusAvailable {
+			http.Error(w, `{"error":"hive is already an available placeholder — nothing to reset"}`, http.StatusConflict)
+			return
+		}
 		http.Error(w, `{"error":"only an assigned-but-unclaimed placeholder can be reset"}`, http.StatusConflict)
 		return
 	}
@@ -210,11 +246,21 @@ func (s *HubServer) handleResetAssignment(w http.ResponseWriter, r *http.Request
 	})
 }
 
-// sweepStuckAssignments auto-resets any placeholder stuck at
-// Status=statusAssigned && !ClaimDelivered for longer than
-// assignStuckResetTimeout, so an assigned-but-unclaimed slot can never dead-end
-// silently. It is the automatic counterpart to handleResetAssignment and applies
-// the identical guard and field transitions. Every reset is logged.
+// sweepStuckAssignments auto-resets any placeholder stuck in the
+// assigned-but-unclaimed wedge (isResettableWedge && !ClaimDelivered) for longer
+// than assignStuckResetTimeout, so an assigned-but-unclaimed slot can never
+// dead-end silently. It is the automatic counterpart to handleResetAssignment and
+// applies the identical guard and field transitions. Every reset is logged.
+//
+// AGE SOURCE. A proper assign stamps AssignedAt, so its age is the time since that
+// stamp. The null-Status legacy wedge (real org/repo, Status=="", the vllmd-13
+// class) typically has NO AssignedAt — its age is genuinely unknowable. Rather
+// than reset it on a guessed age (which risks yanking a brand-new,
+// legitimately-mid-assignment slot before its first heartbeat), the sweep uses
+// CreatedAt as a conservative floor for such identity-bearing wedges: only a slot
+// created longer ago than the timeout is auto-reset, and a fresh assign always
+// carries an AssignedAt anyway so it takes the precise path. A wedge with neither
+// stamp is left for the operator's manual Reset (still reachable via the UI/API).
 func (s *HubServer) sweepStuckAssignments() {
 	now := time.Now()
 
@@ -226,16 +272,23 @@ func (s *HubServer) sweepStuckAssignments() {
 	var done []reset
 
 	for _, sh := range listSaaSHives() {
-		if sh.Status != statusAssigned || sh.ClaimDelivered {
+		shCopy := sh
+		if !isResettableWedge(&shCopy) {
 			continue
 		}
-		// A hive with no AssignedAt stamp predates the stamp (or was written by an
-		// older path); its age is unknowable, so leave it for the operator's manual
-		// reset rather than reset it on a guessed age.
-		if sh.AssignedAt == "" {
+		// Determine the wedge's age. Prefer AssignedAt (stamped by the current
+		// assign paths); for a null-Status identity wedge that predates the stamp,
+		// fall back to CreatedAt as a conservative floor. A wedge with neither stamp
+		// has an unknowable age, so leave it for the operator's manual reset rather
+		// than reset it on a guessed age.
+		ageStamp := sh.AssignedAt
+		if ageStamp == "" {
+			ageStamp = sh.CreatedAt
+		}
+		if ageStamp == "" {
 			continue
 		}
-		assignedAt, err := time.Parse(time.RFC3339, sh.AssignedAt)
+		assignedAt, err := time.Parse(time.RFC3339, ageStamp)
 		if err != nil {
 			continue
 		}
@@ -245,7 +298,7 @@ func (s *HubServer) sweepStuckAssignments() {
 		}
 
 		h := loadSaaSHive(sh.ID) // reload to mutate the authoritative record
-		if h == nil || h.Status != statusAssigned || h.ClaimDelivered {
+		if h == nil || !isResettableWedge(h) {
 			continue
 		}
 		prevOwner := h.Owner

--- a/v2/pkg/hub/saas_reset_assignment.go
+++ b/v2/pkg/hub/saas_reset_assignment.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -119,6 +120,36 @@ func clearAssignedRequestForHive(hiveID string) string {
 	return ""
 }
 
+// hiveHasAssignedIdentity reports whether a placeholder has been handed a REAL
+// tenant identity — a non-placeholder org or any primary_repo. A clean available
+// slot carries only the synthetic "available-<id>" org (placeholderOrgPrefix) and
+// an empty primary_repo, so it returns false. This is the exact mirror of the
+// enrichFromSaaSMeta / dashboard AssignedUnclaimed gate, kept here so the handler
+// and the self-heal sweep accept precisely the states the UI offers Reset for.
+func hiveHasAssignedIdentity(h *SaaSHive) bool {
+	hasRealOrg := h.Org != "" && !strings.HasPrefix(h.Org, placeholderOrgPrefix)
+	return hasRealOrg || h.PrimaryRepo != ""
+}
+
+// isResettableWedge reports whether a placeholder is in the assigned-but-unclaimed
+// wedge that Reset assignment targets: NOT a delivered claim (a delivered claim is
+// a LIVE hive) AND NOT a clean available slot, but either explicitly
+// Status=statusAssigned OR carrying a real assigned identity (org/primary_repo)
+// under any/no status. It broadens the original Status==statusAssigned gate to
+// also cover the null-Status-but-org-set legacy wedge (the live vllmd-13 class),
+// while still refusing a delivered claim and a genuinely-clean available slot.
+func isResettableWedge(h *SaaSHive) bool {
+	if h.ClaimDelivered {
+		return false
+	}
+	hasIdentity := hiveHasAssignedIdentity(h)
+	isCleanAvailable := h.Status == statusAvailable && !hasIdentity
+	if isCleanAvailable {
+		return false
+	}
+	return h.Status == statusAssigned || hasIdentity
+}
+
 // handleResetAssignment returns an assigned-but-unclaimed placeholder to the
 // AVAILABLE pool (admin-only). It is the escape hatch for a placeholder wedged
 // between the two claim paths: handleApproveProvision requires a PENDING request
@@ -126,11 +157,13 @@ func clearAssignedRequestForHive(hiveID string) string {
 // (this one is statusAssigned), so an assignment whose spoke never reports the
 // project back — ClaimDelivered stuck false — has no other way out.
 //
-// GUARD: it only ever touches a hive at Status=statusAssigned && !ClaimDelivered.
-// A delivered claim (ClaimDelivered==true) is a LIVE hive and is refused (409):
-// resetting it would disrupt a working tenant. An already-available slot is a
-// no-op (409). Both are the conservative choice — reset is strictly for the
-// wedged middle state.
+// GUARD: it accepts a hive in the assigned-but-unclaimed wedge (isResettableWedge)
+// — Status=statusAssigned OR a real org/primary_repo written under any/no status
+// (the null-Status legacy wedge, e.g. vllmd-13), and always !ClaimDelivered. A
+// delivered claim (ClaimDelivered==true) is a LIVE hive and is refused (409):
+// resetting it would disrupt a working tenant. A genuinely-clean available slot
+// (no real identity) is a no-op (409). Both refusals are the conservative choice —
+// reset is strictly for the wedged middle state.
 func (s *HubServer) handleResetAssignment(w http.ResponseWriter, r *http.Request) {
 	hiveID := r.PathValue("id")
 	admin := s.getAuthUser(r) // requireAdmin-gated
@@ -140,15 +173,18 @@ func (s *HubServer) handleResetAssignment(w http.ResponseWriter, r *http.Request
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Status == statusAvailable {
-		http.Error(w, `{"error":"hive is already an available placeholder — nothing to reset"}`, http.StatusConflict)
-		return
-	}
 	if h.ClaimDelivered {
 		http.Error(w, `{"error":"hive claim already delivered — reset would disrupt a live hive; deprovision instead"}`, http.StatusConflict)
 		return
 	}
-	if h.Status != statusAssigned {
+	// A clean available slot (statusAvailable with no real assigned identity) has
+	// nothing to reset. A hive that is neither the wedge nor clean-available (e.g.
+	// provisioning/error with no identity) is likewise not a reset target.
+	if !isResettableWedge(h) {
+		if h.Status == statusAvailable {
+			http.Error(w, `{"error":"hive is already an available placeholder — nothing to reset"}`, http.StatusConflict)
+			return
+		}
 		http.Error(w, `{"error":"only an assigned-but-unclaimed placeholder can be reset"}`, http.StatusConflict)
 		return
 	}
@@ -188,11 +224,21 @@ func (s *HubServer) handleResetAssignment(w http.ResponseWriter, r *http.Request
 	})
 }
 
-// sweepStuckAssignments auto-resets any placeholder stuck at
-// Status=statusAssigned && !ClaimDelivered for longer than
-// assignStuckResetTimeout, so an assigned-but-unclaimed slot can never dead-end
-// silently. It is the automatic counterpart to handleResetAssignment and applies
-// the identical guard and field transitions. Every reset is logged.
+// sweepStuckAssignments auto-resets any placeholder stuck in the
+// assigned-but-unclaimed wedge (isResettableWedge && !ClaimDelivered) for longer
+// than assignStuckResetTimeout, so an assigned-but-unclaimed slot can never
+// dead-end silently. It is the automatic counterpart to handleResetAssignment and
+// applies the identical guard and field transitions. Every reset is logged.
+//
+// AGE SOURCE. A proper assign stamps AssignedAt, so its age is the time since that
+// stamp. The null-Status legacy wedge (real org/repo, Status=="", the vllmd-13
+// class) typically has NO AssignedAt — its age is genuinely unknowable. Rather
+// than reset it on a guessed age (which risks yanking a brand-new,
+// legitimately-mid-assignment slot before its first heartbeat), the sweep uses
+// CreatedAt as a conservative floor for such identity-bearing wedges: only a slot
+// created longer ago than the timeout is auto-reset, and a fresh assign always
+// carries an AssignedAt anyway so it takes the precise path. A wedge with neither
+// stamp is left for the operator's manual Reset (still reachable via the UI/API).
 func (s *HubServer) sweepStuckAssignments() {
 	now := time.Now()
 
@@ -204,16 +250,23 @@ func (s *HubServer) sweepStuckAssignments() {
 	var done []reset
 
 	for _, sh := range listSaaSHives() {
-		if sh.Status != statusAssigned || sh.ClaimDelivered {
+		shCopy := sh
+		if !isResettableWedge(&shCopy) {
 			continue
 		}
-		// A hive with no AssignedAt stamp predates the stamp (or was written by an
-		// older path); its age is unknowable, so leave it for the operator's manual
-		// reset rather than reset it on a guessed age.
-		if sh.AssignedAt == "" {
+		// Determine the wedge's age. Prefer AssignedAt (stamped by the current
+		// assign paths); for a null-Status identity wedge that predates the stamp,
+		// fall back to CreatedAt as a conservative floor. A wedge with neither stamp
+		// has an unknowable age, so leave it for the operator's manual reset rather
+		// than reset it on a guessed age.
+		ageStamp := sh.AssignedAt
+		if ageStamp == "" {
+			ageStamp = sh.CreatedAt
+		}
+		if ageStamp == "" {
 			continue
 		}
-		assignedAt, err := time.Parse(time.RFC3339, sh.AssignedAt)
+		assignedAt, err := time.Parse(time.RFC3339, ageStamp)
 		if err != nil {
 			continue
 		}
@@ -223,7 +276,7 @@ func (s *HubServer) sweepStuckAssignments() {
 		}
 
 		h := loadSaaSHive(sh.ID) // reload to mutate the authoritative record
-		if h == nil || h.Status != statusAssigned || h.ClaimDelivered {
+		if h == nil || !isResettableWedge(h) {
 			continue
 		}
 		prevOwner := h.Owner


### PR DESCRIPTION
## The live symptom

A wedged placeholder `hosted-available-vllmd-13` has `org=z-innersource` and `primary_repo=AutoIPL` written, but its `status` in meta.json is **NULL/empty** (it was never persisted as `assigned`) and `claim_delivered` is null/false. The dashboard row DISPLAYS "Assigning to z-innersource" (derived from org being set), but the **Reset assignment** context-menu item (from #2703) was **HIDDEN** — precisely the wedge the escape hatch was built to rescue.

Root: the escape hatch was gated on `Status == statusAssigned && !ClaimDelivered`, in three places:
- the dashboard UI (`assignedUnclaimed`, `enrichFromSaaSMeta`, saas.go:2137)
- the handler (`handleResetAssignment` — final guard 409'd anything not `statusAssigned`)
- the self-heal sweep (`sweepStuckAssignments` — keyed on `statusAssigned`)

Because `vllmd-13`'s Status is null, `assignedUnclaimed` was false, so the button was hidden — and even if reached, the handler would have 409'd it. Same partial-assignment limbo class that wedged EPM (org/repo written without Status transitioning to `assigned`).

## The fix — broaden all three predicates in lockstep

A placeholder is treated as the assigned-but-unclaimed **wedge** when it is **not** a delivered claim (a delivered claim is a LIVE hive) and **not** a clean available slot, but either `Status==assigned` **or** it carries a **real assigned identity** — a non-placeholder org or any `primary_repo`.

A clean available slot is NOT bare: a seeded/reset placeholder carries the synthetic `available-<id>` org (`placeholderOrgPrefix`) and empty `primary_repo` — that is how `isPlaceholderEntry` recognizes inventory. So "real assigned identity" excludes the `available-` prefix. The **exact predicate shipped**:

```go
hasRealOrg := sh.Org != "" && !strings.HasPrefix(sh.Org, placeholderOrgPrefix)
notClaimed := !sh.ClaimDelivered
hasAssignedIdentity := hasRealOrg || sh.PrimaryRepo != ""
isAssignedStatus := sh.Status == statusAssigned
isCleanAvailable := sh.Status == statusAvailable && !hasAssignedIdentity
entry.AssignedUnclaimed = notClaimed && !isCleanAvailable && (isAssignedStatus || hasAssignedIdentity)
```

- **Part A (UI gate, saas.go)** — `enrichFromSaaSMeta` computes `AssignedUnclaimed` as above. The dashboard JS gate (`if (_isAdmin && h.assignedUnclaimed)`) reads this field unchanged, so the Reset item now shows for the null-Status wedge. Still hidden for a clean available slot and a delivered claim.
- **Part B (handler + sweep, saas_reset_assignment.go)** — added `hiveHasAssignedIdentity` + `isResettableWedge` (the exact mirror of the UI gate). `handleResetAssignment` now accepts the wedge and still **409s a delivered claim and a genuinely-clean available slot**. `resetHiveToAvailablePlaceholder` already unconditionally sets `Status=available` and clears org/owner/repo, so a null-Status wedge ends up clean. The sweep uses `isResettableWedge` too.
  - **Sweep age source:** a proper assign stamps `AssignedAt`; the null-Status legacy wedge typically has none. Rather than reset on a guessed age (which risks yanking a brand-new mid-assignment slot before its first heartbeat), the sweep falls back to **`CreatedAt` as a conservative floor** for identity-bearing wedges — only a slot created longer ago than `assignStuckResetTimeout` (15m) is auto-reset. A wedge with neither stamp is left for the operator's manual Reset (still reachable via the UI/API).

## Part C — root-cause note (no live data touched)

The root cause is placeholders acquiring `org`/`primary_repo` **without** `Status` being set to `assigned`. I grepped every `.Org =` / `.PrimaryRepo =` write in the provision/assign paths:

- **handleApproveProvision** (saas.go:6077-6105) and **handleAssignHive** (saas.go:6876-6928) both stamp `h.Status = statusAssigned` **and** `AssignedAt` in the same save as org/repo. **No omission** in the current assign paths.
- The only other org/repo writer, `adoptSpokeProjectConfig` (saas.go:6468-6479), writes org/repo **only when `ClaimDelivered==true`** — a claimed hive, not the wedge source.

So the current code does **not** create this wedge; `vllmd-13` is a **legacy/pre-existing data condition**. I did **not** hand-edit any live meta.json or touch the cluster. No Status-not-set-on-assign omission was found to fix.

## Tests (`reset_assignment_test.go`)

- `TestAssignedUnclaimedPredicate` — TRUE for {assigned,!claim}, {null-Status,real org,!claim}, {available-status,real org,!claim}; FALSE for clean-available (both `available-` org and empty org) and delivered claim.
- `TestIsResettableWedge` — handler/sweep gate matches the UI gate.
- `TestResetAssignmentNullStatusWedge` — handler SUCCEEDS on the vllmd-13 wedge, returns it clean/available, re-assignable.
- `TestResetAssignmentRefusedCleanAvailable` — clean-available still 409s.
- `TestSweepStuckAssignmentsNullStatusWedge` — sweep resets the aged null-Status wedge (by CreatedAt), leaves a fresh one, a clean-available slot, and a delivered claim alone.

Existing reset/sweep tests unchanged and passing. (Note: `TestRequestProvisionDashboardModalRemoved` fails on the clean base of this branch — pre-existing, unrelated to this change.)