### PR TITLE
🐛 fix(hub): drop btn-request-hive from removed-modal test allowlist

### DIFF
--- a/v2/pkg/hub/request_provision_callers_test.go
+++ b/v2/pkg/hub/request_provision_callers_test.go
@@ -158,8 +158,14 @@ func TestRequestProvisionInTreeCallersSendRequiredFields(t *testing.T) {
 // be a second request path, and — being inline JS — invisible to everything
 // except the audit above.
 func TestRequestProvisionDashboardModalRemoved(t *testing.T) {
+	// btn-request-hive is deliberately absent from this list. The retired modal
+	// used that id on a <button onclick="openRequestHiveModal()"> that opened the
+	// inline modal. #2693 reused the id for a plain <a href="/get-started"> link
+	// that routes to the wizard — it opens no modal and posts nothing. The modal's
+	// own symbols below (openRequestHiveModal, submitProvisionRequest, etc.) remain
+	// the real guard; pinning a bare element id would fail on a benign navigation
+	// link that is the opposite of a second request path.
 	removed := []string{
-		"btn-request-hive",
 		"request-modal",
 		"btn-request-go",
 		"openRequestHiveModal",


### PR DESCRIPTION
The scheduled **v2 Tests** job is red on current v2 HEAD (`TestRequestProvisionDashboardModalRemoved`).

## Root cause — stale test, not a source regression

- #2376 retired the inline Request-a-Hive modal and pinned its symbols in the `removed[]` allowlist, including the id `btn-request-hive`, which belonged to the `<button onclick="openRequestHiveModal()">` that *opened* the modal.
- #2693 (current HEAD) reused that same id `btn-request-hive` for a plain `<a href="/get-started">` navigation link. It routes to the single supported get-started wizard — it opens no modal and posts nothing to `/api/saas/request-provision`.
- The nine genuinely modal-specific symbols (`openRequestHiveModal`, `submitProvisionRequest`, `request-modal`, `renderRequestForgeOptions`, …) are all **still absent**, proving the modal itself was **not** reintroduced.

Pinning a bare element id was too broad: it now fires on a benign navigation link that is the *opposite* of a second request path. This drops only that one entry (with an explaining comment) and keeps the nine modal symbols as the real guard. The companion audit `TestRequestProvisionInTreeCallersSendRequiredFields` still passes and remains the guard against untested `fetch()` POST callers (the link is an `<a href>`, not a `fetch`).

Fixes #2681