### PR TITLE
fix: GHE token stall no longer crash-loops spokes or blocks upgrade (no-app hives degrade gracefully)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -639,12 +639,17 @@ func startDocsTokenRefresh(ctx context.Context, cfg *config.Config, appKeyFile s
 		logger.Warn("failed to init docs org token", "error", err)
 		return
 	}
-	if _, err := docsAuth.Token(ctx); err != nil {
-		logger.Warn("failed to generate initial docs org token", "error", err)
-	} else {
-		logger.Info("docs org token cached", "installation_id", cfg.GitHub.DocsInstallationID)
-	}
 	go func() {
+		// Mint the initial docs token in the BACKGROUND, not on the startup
+		// path. The docs org is an add-on; blocking here on a docs-installation
+		// mint that hangs (unreachable/uninstalled GHE) would delay the whole
+		// process reaching MarkReady — the #2439 readiness-stall pattern. The
+		// mint is bounded (tokenMintTimeout) and non-fatal regardless.
+		if _, err := docsAuth.Token(ctx); err != nil {
+			logger.Warn("failed to generate initial docs org token", "error", err)
+		} else {
+			logger.Info("docs org token cached", "installation_id", cfg.GitHub.DocsInstallationID)
+		}
 		const docsTokenRefreshInterval = 45 * time.Minute
 		ticker := time.NewTicker(docsTokenRefreshInterval)
 		defer ticker.Stop()

--- a/v2/pkg/dashboard/server_livez_ghe_noapp_test.go
+++ b/v2/pkg/dashboard/server_livez_ghe_noapp_test.go
@@ -1,0 +1,91 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/hub"
+)
+
+// These tests frame the #2439 production scenario end to end at the probe level:
+// a GHE-hosted spoke whose GitHub App is NOT yet installed. Its App
+// installation-token mint fails/times out, so it can do no GitHub work and never
+// reaches the hub — but its heartbeat loop is still beating (attempts advancing)
+// and its HTTP server is serving. Such a pod must stay Ready and Live so the
+// rolling upgrade completes and the hub stops showing "Upgrading"; it must NOT
+// crash-loop (which a restart can never fix — the app is simply uninstalled).
+
+// TestLivez_NoAppGHE_TokenMintFailing_StaysAlive is the core regression: token
+// minting fails (so no beat ever reaches the hub → success is stale/never), but
+// the loop keeps ATTEMPTING every tick. livez must be 200 — the bug was that a
+// hung mint froze the attempt clock and misclassified this as a wedged loop,
+// killing the pod.
+func TestLivez_NoAppGHE_TokenMintFailing_StaysAlive(t *testing.T) {
+	defer hub.ResetHeartbeatStateForTest()
+	s := healthServer(t)
+	s.MarkReady()
+	s.startedAt = time.Now().Add(-24 * time.Hour) // long past startup grace
+
+	// Attempts advancing NOW (loop alive), but no beat has ever succeeded — the
+	// GHE app is uninstalled so every collect/eval token mint soft-fails and the
+	// hub is unreachable.
+	hub.SetHeartbeatStateForTest(true, time.Now(), time.Time{})
+
+	rec := getLivez(t, s)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("no-app GHE hive with a live (attempting) loop must stay alive: got %d, body %s",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// TestLivez_NoAppGHE_WedgedLoopStillFails guards the other half: if the loop
+// actually stops attempting (a genuinely wedged goroutine, not merely a failing
+// external call), livez must STILL fail so kubelet restarts it. The fix must not
+// weaken this.
+func TestLivez_NoAppGHE_WedgedLoopStillFails(t *testing.T) {
+	defer hub.ResetHeartbeatStateForTest()
+	s := healthServer(t)
+	s.MarkReady()
+
+	stalled := time.Now().Add(-livezHeartbeatStallMax - time.Minute)
+	hub.SetHeartbeatStateForTest(true, stalled, time.Time{})
+
+	if rec := getLivez(t, s); rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("a genuinely wedged loop must still fail liveness even on a no-app hive: got %d", rec.Code)
+	}
+}
+
+// TestReadiness_ReachesReadyWithoutGitHubToken proves Part 2: readiness does not
+// depend on a successful GitHub token mint. healthServer wires the dashboard
+// deps but has NO GitHub App configured and mints no token; MarkReady alone must
+// flip both probes to 200 so a no-app GHE hive can serve and complete a rollout.
+func TestReadiness_ReachesReadyWithoutGitHubToken(t *testing.T) {
+	defer hub.ResetHeartbeatStateForTest()
+	s := healthServer(t) // no GitHub App, no token ever minted
+
+	// A live heartbeat loop, no successes (can't reach hub / no token).
+	hub.SetHeartbeatStateForTest(true, time.Now(), time.Time{})
+	s.startedAt = time.Now()
+
+	// Before MarkReady both gate closed.
+	for _, path := range []string{"/api/health", "/api/livez"} {
+		rec := httptest.NewRecorder()
+		s.mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("%s before MarkReady: want 503, got %d", path, rec.Code)
+		}
+	}
+
+	// MarkReady with no GitHub token available at all must open both gates.
+	s.MarkReady()
+	for _, path := range []string{"/api/health", "/api/livez"} {
+		rec := httptest.NewRecorder()
+		s.mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s after MarkReady (no GitHub token): want 200, got %d, body %s",
+				path, rec.Code, rec.Body.String())
+		}
+	}
+}

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -23,6 +23,22 @@ const (
 	DocsTokenCachePath = "/var/run/hive-metrics/gh-app-token-docs.cache"
 	tokenCachePerms    = 0o640
 
+	// tokenMintTimeout hard-bounds every live App-JWT → installation-token
+	// exchange (CreateInstallationToken / GetInstallation). These calls are made
+	// with a bare gh.NewClient (no per-client Timeout) and are sometimes reached
+	// with an undeadlined process context (startup advisory-issue ensure, docs
+	// token refresh, appTransport.RoundTrip). On a firewalled / GHE-hosted spoke
+	// whose App is not yet installed (github.ibm.com unreachable, or the org has
+	// no installation) the underlying TCP/TLS connect can hang for minutes.
+	//
+	// That hang is the #2439 root cause: it froze the FIRST heartbeat attempt
+	// and blocked readiness (advisory-issue ensure runs before MarkReady), so
+	// livez/health deadline-exceeded, the pod crash-looped, and the hub stayed
+	// stuck "Upgrading" (it never received a fresh heartbeat with the new
+	// version). Bounding the mint turns "hang forever" into a fast, soft error
+	// the caller already treats as "App not usable → show install banner".
+	tokenMintTimeout = 8 * time.Second
+
 	// Per-agent scoped token caches. entrypoint.sh pre-creates each file as
 	// dev:hive-<agent> mode 0640 so the hive process (dev) can rewrite it in
 	// place and ONLY the owning agent's private group can read it — no chown
@@ -90,6 +106,27 @@ func NewAppAuthWithCache(appID, installationID int64, keyFile, cachePath string,
 		cachePath:      cachePath,
 		apiURL:         apiURL,
 	}, nil
+}
+
+// newJWTClient builds a go-github client authenticated with the App JWT for
+// the live token-mint calls. Unlike gh.NewClient(nil) (which serves the
+// timeout-less http.DefaultClient), this client carries tokenMintTimeout so a
+// mint against an unreachable / firewalled GHE endpoint cannot hang past that
+// bound even if the caller passed an undeadlined context.
+func (a *AppAuth) newJWTClient(jwtToken string) *gh.Client {
+	httpClient := &http.Client{Timeout: tokenMintTimeout}
+	client := gh.NewClient(httpClient).WithAuthToken(jwtToken)
+	setBaseURL(client, a.apiURL)
+	return client
+}
+
+// mintContext derives a child context bounded by tokenMintTimeout from the
+// caller's context. It guarantees a deadline even when the caller passed a
+// background/process context with none, so a token mint is a bounded operation
+// end to end (client Timeout AND context deadline). The returned cancel MUST be
+// called by the caller.
+func mintContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, tokenMintTimeout)
 }
 
 func (a *AppAuth) generateJWT() (string, error) {
@@ -173,9 +210,13 @@ func (a *AppAuth) mintInstallationToken(ctx context.Context) (token string, expi
 		return "", time.Time{}, fmt.Errorf("generating JWT: %w", err)
 	}
 
-	jwtClient := gh.NewClient(nil).WithAuthToken(jwtToken)
-	setBaseURL(jwtClient, a.apiURL)
-	installToken, _, err := jwtClient.Apps.CreateInstallationToken(ctx, a.installationID, nil)
+	// Bound the mint end to end: a firewalled/uninstalled GHE endpoint would
+	// otherwise hang for the full TCP/TLS connect (minutes) and freeze whatever
+	// loop reached this — the first heartbeat, readiness, the eval cycle (#2439).
+	mintCtx, cancel := mintContext(ctx)
+	defer cancel()
+	jwtClient := a.newJWTClient(jwtToken)
+	installToken, _, err := jwtClient.Apps.CreateInstallationToken(mintCtx, a.installationID, nil)
 	if err != nil {
 		return "", time.Time{}, fmt.Errorf("creating installation token: %w", err)
 	}
@@ -227,9 +268,10 @@ func (a *AppAuth) ScopedToken(ctx context.Context, tier string) (string, error) 
 	}
 
 	opts := &gh.InstallationTokenOptions{Permissions: perms}
-	jwtClient := gh.NewClient(nil).WithAuthToken(jwtToken)
-	setBaseURL(jwtClient, a.apiURL)
-	installToken, _, err := jwtClient.Apps.CreateInstallationToken(ctx, a.installationID, opts)
+	mintCtx, cancel := mintContext(ctx)
+	defer cancel()
+	jwtClient := a.newJWTClient(jwtToken)
+	installToken, _, err := jwtClient.Apps.CreateInstallationToken(mintCtx, a.installationID, opts)
 	if err != nil {
 		return "", fmt.Errorf("creating scoped token for tier %s: %w", tier, err)
 	}
@@ -332,9 +374,10 @@ func (a *AppAuth) VerifyInstallation(ctx context.Context) (*InstallationInfo, er
 		return nil, fmt.Errorf("generating JWT: %w", err)
 	}
 
-	jwtClient := gh.NewClient(nil).WithAuthToken(jwtToken)
-	setBaseURL(jwtClient, a.apiURL)
-	inst, _, err := jwtClient.Apps.GetInstallation(ctx, a.installationID)
+	mintCtx, cancel := mintContext(ctx)
+	defer cancel()
+	jwtClient := a.newJWTClient(jwtToken)
+	inst, _, err := jwtClient.Apps.GetInstallation(mintCtx, a.installationID)
 	if err != nil {
 		return nil, fmt.Errorf("resolving installation %d: %w", a.installationID, err)
 	}

--- a/v2/pkg/github/app_discovery.go
+++ b/v2/pkg/github/app_discovery.go
@@ -128,8 +128,10 @@ func (a *AppAuth) discoverInstallationUncached(ctx context.Context, org string) 
 	if err != nil {
 		return 0, fmt.Errorf("generating JWT: %w", err)
 	}
-	jwtClient := gh.NewClient(nil).WithAuthToken(jwtToken)
-	setBaseURL(jwtClient, a.apiURL)
+	// Per-request Timeout (belt-and-suspenders with the discoveryTimeout ctx
+	// above): keeps a single hung request against an unreachable GHE endpoint
+	// from consuming the whole discovery budget.
+	jwtClient := a.newJWTClient(jwtToken)
 
 	// Preferred: direct per-org lookup.
 	inst, resp, err := jwtClient.Apps.FindOrganizationInstallation(ctx, org)

--- a/v2/pkg/github/app_mint_timeout_test.go
+++ b/v2/pkg/github/app_mint_timeout_test.go
@@ -1,0 +1,157 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// These tests lock in the #2439 root-cause fix: a GitHub App installation-token
+// mint against an unreachable / firewalled GHE endpoint (github.ibm.com with no
+// installation) must NOT hang. It used to run on a bare gh.NewClient(nil) (no
+// per-client Timeout) and was sometimes reached with an undeadlined process
+// context — so a stuck TCP/TLS connect blocked the caller for minutes. That
+// froze the first heartbeat attempt and readiness, crash-looping the pod and
+// wedging the hub at "Upgrading". Every mint is now bounded by tokenMintTimeout
+// end to end and returns a soft error the caller treats as "App not usable".
+
+// blockingMintServer returns a handler that sleeps past tokenMintTimeout before
+// (never) replying, simulating an endpoint that accepts the connection but never
+// answers — the exact hang the fix must bound.
+func blockingMintServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Sleep past the mint timeout so the client gives up first, but bail the
+		// moment the request context is cancelled (client hangup / test teardown)
+		// so server Close() — which waits for in-flight handlers — returns
+		// promptly and the test stays fast.
+		select {
+		case <-r.Context().Done():
+		case <-time.After(tokenMintTimeout + 2*time.Second):
+		}
+	}))
+}
+
+// TestMintInstallationToken_HungEndpointReturnsBoundedError proves a hung mint
+// endpoint yields an error within a small multiple of tokenMintTimeout even
+// when the caller passes context.Background() (no deadline of its own).
+func TestMintInstallationToken_HungEndpointReturnsBoundedError(t *testing.T) {
+	key, _ := generateTestKey(t)
+	server := blockingMintServer(t)
+	defer server.Close()
+
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         quietLogger(),
+		apiURL:         server.URL,
+		cachePath:      t.TempDir() + "/token-cache",
+	}
+
+	start := time.Now()
+	// Deliberately an undeadlined context: the mint's own bound must apply.
+	_, _, err := auth.mintInstallationToken(context.Background())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("mintInstallationToken returned nil error against a hung endpoint; expected a bounded timeout error")
+	}
+	// Allow generous slack over tokenMintTimeout for CI scheduling, but it MUST
+	// be far under the server's 3x sleep — proving the client, not the server,
+	// ended the call.
+	if elapsed > tokenMintTimeout*2 {
+		t.Fatalf("mintInstallationToken took %v, want < %v (the mint did not honor its bound)", elapsed, tokenMintTimeout*2)
+	}
+}
+
+// TestToken_HungEndpointNoCacheReturnsBoundedError proves the public Token()
+// path (used by appTransport.RoundTrip → EnumerateActionable, the heartbeat/
+// eval loops) also stays bounded: with no cached token and a hung endpoint it
+// errors quickly instead of hanging the loop.
+func TestToken_HungEndpointNoCacheReturnsBoundedError(t *testing.T) {
+	key, _ := generateTestKey(t)
+	server := blockingMintServer(t)
+	defer server.Close()
+
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         quietLogger(),
+		apiURL:         server.URL,
+		cachePath:      t.TempDir() + "/token-cache",
+		// No cached token: Token() must attempt a live mint, which hangs.
+	}
+
+	start := time.Now()
+	_, err := auth.Token(context.Background())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Token() returned nil error against a hung endpoint with no cache; expected a bounded error")
+	}
+	if elapsed > tokenMintTimeout*2 {
+		t.Fatalf("Token() took %v, want < %v (mint did not honor its bound)", elapsed, tokenMintTimeout*2)
+	}
+}
+
+// TestVerifyInstallation_HungEndpointReturnsBoundedError proves the
+// installation-probe path (VerifyInstallation, used by the self-heal / re-check
+// flows) is bounded too.
+func TestVerifyInstallation_HungEndpointReturnsBoundedError(t *testing.T) {
+	key, _ := generateTestKey(t)
+	server := blockingMintServer(t)
+	defer server.Close()
+
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         quietLogger(),
+		apiURL:         server.URL,
+		cachePath:      t.TempDir() + "/token-cache",
+	}
+
+	start := time.Now()
+	_, err := auth.VerifyInstallation(context.Background())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("VerifyInstallation returned nil error against a hung endpoint; expected a bounded error")
+	}
+	if elapsed > tokenMintTimeout*2 {
+		t.Fatalf("VerifyInstallation took %v, want < %v (probe did not honor its bound)", elapsed, tokenMintTimeout*2)
+	}
+}
+
+// TestScopedToken_HungEndpointReturnsBoundedError proves the per-agent scoped
+// token mint (WriteAgentToken → ScopedToken, on the agent-launch path) is
+// bounded, so a GHE stall cannot wedge agent startup either.
+func TestScopedToken_HungEndpointReturnsBoundedError(t *testing.T) {
+	key, _ := generateTestKey(t)
+	server := blockingMintServer(t)
+	defer server.Close()
+
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         quietLogger(),
+		apiURL:         server.URL,
+		cachePath:      t.TempDir() + "/token-cache",
+	}
+
+	start := time.Now()
+	_, err := auth.ScopedToken(context.Background(), "contributor")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("ScopedToken returned nil error against a hung endpoint; expected a bounded error")
+	}
+	if elapsed > tokenMintTimeout*2 {
+		t.Fatalf("ScopedToken took %v, want < %v (mint did not honor its bound)", elapsed, tokenMintTimeout*2)
+	}
+}

--- a/v2/pkg/github/app_state.go
+++ b/v2/pkg/github/app_state.go
@@ -326,9 +326,12 @@ func (a *AppAuth) DiagnoseAppAuth(ctx context.Context, expectedOwner string, key
 		return d
 	}
 
-	jwtClient := gh.NewClient(nil).WithAuthToken(jwtToken)
-	setBaseURL(jwtClient, a.apiURL)
-	inst, resp, err := jwtClient.Apps.GetInstallation(ctx, a.installationID)
+	// Bound the probe: a firewalled/uninstalled GHE endpoint must not hang this
+	// diagnosis (it runs on the startup path before MarkReady, and on Re-check).
+	probeCtx, cancel := mintContext(ctx)
+	defer cancel()
+	jwtClient := a.newJWTClient(jwtToken)
+	inst, resp, err := jwtClient.Apps.GetInstallation(probeCtx, a.installationID)
 	if err != nil {
 		d.State = classifyAPIError(err, resp)
 		d.Err = err

--- a/v2/pkg/hub/heartbeat_attempt_ordering_test.go
+++ b/v2/pkg/hub/heartbeat_attempt_ordering_test.go
@@ -1,0 +1,84 @@
+package hub
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// These tests pin the #2439 invariant: the heartbeat *attempt* clock advances
+// on every tick BEFORE any work that can hang or fail (collecting status,
+// posting to the hub). This is what keeps /api/livez healthy on a GHE-hosted
+// hive whose GitHub App is not installed — the loop is demonstrably alive
+// (attempts advancing) even though it cannot reach the hub or mint a token, so
+// the pod is not restarted and the rollout can finish.
+
+// TestSendHeartbeat_StampsAttemptBeforeCollect proves the attempt timestamp is
+// recorded before collect() runs, so a collect that does slow/failing work (or
+// a hub that is unreachable) never freezes the attempt clock.
+func TestSendHeartbeat_StampsAttemptBeforeCollect(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
+
+	var attemptAtCollect time.Time
+	var hadAttemptAtCollect bool
+
+	collect := func() *HeartbeatPayload {
+		// Observe the attempt clock from INSIDE collect: it must already be set,
+		// proving recordHeartbeatAttempt ran first. Simulate the collect doing
+		// slow external work (the pattern that used to freeze the clock).
+		attemptAtCollect, hadAttemptAtCollect = LastHeartbeatAttempt()
+		time.Sleep(20 * time.Millisecond)
+		// Return nil so sendHeartbeat bails before any network I/O — we only
+		// care that the attempt was already stamped.
+		return nil
+	}
+
+	before := time.Now().Truncate(time.Second)
+	// Unreachable hub URL is irrelevant here: nil payload short-circuits before
+	// the POST. The point is the attempt stamp precedes collect entirely.
+	sendHeartbeat(context.Background(), "http://127.0.0.1:1", collect, nil2Logger())
+
+	if !hadAttemptAtCollect {
+		t.Fatal("attempt clock was NOT set when collect() ran: recordHeartbeatAttempt must precede collect so a slow/failing collect cannot freeze liveness")
+	}
+	if attemptAtCollect.Before(before) {
+		t.Errorf("attempt observed inside collect = %v, want at or after %v", attemptAtCollect, before)
+	}
+
+	got, ok := LastHeartbeatAttempt()
+	if !ok || got.Before(before) {
+		t.Errorf("LastHeartbeatAttempt() = (%v, %v), want a fresh attempt at/after %v", got, ok, before)
+	}
+	if _, ok := LastHeartbeatSuccess(); ok {
+		t.Error("LastHeartbeatSuccess() ok = true, want false: no beat reached the hub")
+	}
+}
+
+// TestSendHeartbeat_UnreachableHubStillAdvancesAttempt is the network-partition
+// (and no-app GHE) case at the send level: the hub POST fails, so no success is
+// recorded, but the attempt clock still advanced — exactly what livez needs to
+// keep the pod alive through an outage.
+func TestSendHeartbeat_UnreachableHubStillAdvancesAttempt(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
+
+	collect := func() *HeartbeatPayload {
+		return &HeartbeatPayload{HiveID: "test-hive"}
+	}
+
+	before := time.Now().Truncate(time.Second)
+	// Port 1 is unreachable; the POST fails, success is never recorded.
+	resp := sendHeartbeat(context.Background(), "http://127.0.0.1:1", collect, nil2Logger())
+	if resp != nil {
+		t.Fatalf("expected nil response from an unreachable hub, got %+v", resp)
+	}
+
+	got, ok := LastHeartbeatAttempt()
+	if !ok || got.Before(before) {
+		t.Errorf("LastHeartbeatAttempt() = (%v, %v), want a fresh attempt at/after %v even though the hub was unreachable", got, ok, before)
+	}
+	if _, ok := LastHeartbeatSuccess(); ok {
+		t.Error("LastHeartbeatSuccess() ok = true, want false when the hub POST failed")
+	}
+}


### PR DESCRIPTION
## Live symptom

GHE-hosted spoke hives (github.ibm.com) whose GitHub App is **not yet installed** on their org crash-loop and get stuck **\"Upgrading\" forever**. Two live examples on the vllm-d cluster:

- `open-source/osscar-application` (ospo-jj, ns `hive-hosted-hosted-open-source-osscar-appli-rc57`)
- `EPM/cdo-data-model-documentation` (epm-luiz)

Both show RESTARTS climbing and:

```
Liveness probe failed: Get ".../api/livez": context deadline exceeded
spoke: level=ERROR msg="failed to enumerate actionable items" ...
       "getting app token: creating installation token: context deadline exceeded
        (Client.Timeout exceeded while awaiting headers)"
```

Hub registry for ospo-jj showed `running: "3.0.0"`, `upgrading: true`, and `lastHeartbeat` **equal to the pod's container start time** — i.e. **zero** heartbeats have reached the hub since boot. The heartbeat loop is blocked from its very first attempt.

A GHE hive with no app installed yet is a **normal, expected** state — it should just show the \"Install GitHub App\" banner. It must not crash-loop the pod or block the hive from upgrading.

## Root cause

The App installation-token mint (`CreateInstallationToken` / `GetInstallation`) ran on a bare `gh.NewClient(nil)` — the timeout-less `http.DefaultClient` — and was reached on the **startup path with the undeadlined process context**: the advisory-issue ensure, the docs-org token mint, and the app-state probe all run **before `MarkReady()`**. On a firewalled / uninstalled GHE endpoint the TCP/TLS connect hangs for minutes.

That hang:
1. **froze the first heartbeat attempt** (the loop never advances its attempt clock), and
2. **blocked readiness** (advisory-issue ensure runs before `MarkReady`).

So `/api/livez` and `/api/health` deadline-exceeded, kubelet crash-looped the pod (a restart can never install an app), and the hub never received a fresh heartbeat reporting the new running version → stuck **\"Upgrading\"**. `handleLivez` then **misclassified** an externally-blocked loop (attempts frozen by the hang) as a genuinely *wedged* one — exactly the anti-pattern its own comment warns about — and kept killing a pod a restart could never fix.

## Fixes

**Part 1 — token mint can never hang.** Every App-JWT mint/probe is now bounded end to end by `tokenMintTimeout` (8s): a bounded `http.Client.Timeout` **and** a derived context deadline, even when the caller passes an undeadlined context. Applied to `mintInstallationToken`, `ScopedToken`, `VerifyInstallation`, `DiagnoseAppAuth`'s probe, and installation discovery. \"No installation / token error\" was already a **soft, expected** condition (`Token()` falls back to a still-valid cache; callers raise the install-app banner) — it just can no longer block.

**Part 2 — upgrade/readiness independent of GHE app status.** The initial docs-org token mint moves off the startup path into its refresh goroutine, so it never delays `MarkReady`. Readiness (`MarkReady`/`handleHealth`) and the heartbeat attempt clock (`recordHeartbeatAttempt` precedes `collect()` and the hub POST) were already GitHub-independent in v2 HEAD; with the mint bounded they now demonstrably flip/advance within seconds regardless of GHE app state, so the rollout finishes and the version arrow clears.

**Preserved:** the genuinely-wedged detection (attempts stalled ⇒ restart) and the network-partition behavior (successes stale but attempts advancing ⇒ stay healthy) are unchanged.

## Tests

- Hung-endpoint mints (`mintInstallationToken` / `Token` / `VerifyInstallation` / `ScopedToken`) return a **bounded soft error** instead of blocking, even under `context.Background()`.
- `sendHeartbeat` stamps the attempt **before** `collect()` and advances it even when the hub is unreachable.
- `handleLivez` returns **200** when attempts advance though the mint/hub fail (no-app GHE), still **503** when attempts genuinely stall past `livezHeartbeatStallMax`.
- Readiness reaches ready with **no** GitHub token minted.

`go build ./...` + `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)