### PR TITLE
fix: persist upgrade-start across retries + honest 'upgrade stuck' timer

### DIFF
--- a/v2/pkg/hub/begin_upgrade_test.go
+++ b/v2/pkg/hub/begin_upgrade_test.go
@@ -1,0 +1,136 @@
+package hub
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// newBeginUpgradeServer returns a HubServer holding a single registry entry so
+// the beginUpgrade / clearUpgradeLatch invariants can be exercised in isolation.
+func newBeginUpgradeServer(e RegistryEntry) *HubServer {
+	s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string)}
+	s.registry.Hives = []RegistryEntry{e}
+	return s
+}
+
+// TestBeginUpgradeStampsFirstStart pins the base case: a hive that is NOT yet
+// upgrading gets Upgrading=true, the target, and a fresh start clock.
+func TestBeginUpgradeStampsFirstStart(t *testing.T) {
+	s := newBeginUpgradeServer(RegistryEntry{ID: "h1"})
+	before := time.Now()
+	s.mu.Lock()
+	s.beginUpgrade(0, "target-a")
+	s.mu.Unlock()
+
+	h := s.registry.Hives[0]
+	if !h.Upgrading {
+		t.Fatal("beginUpgrade must set Upgrading=true")
+	}
+	if h.UpgradeTarget != "target-a" {
+		t.Fatalf("UpgradeTarget = %q, want target-a", h.UpgradeTarget)
+	}
+	if h.UpgradeStartedAt.Before(before) {
+		t.Fatalf("UpgradeStartedAt must be stamped to now, got %v (before test start %v)", h.UpgradeStartedAt, before)
+	}
+}
+
+// TestBeginUpgradeRetrySameTargetPreservesStart is the core of the bug fix: a
+// retry that re-enters while already upgrading toward the SAME target must NOT
+// overwrite UpgradeStartedAt — the elapsed clock has to keep climbing so a
+// thrashing upgrade eventually crosses staleUpgradeTimeout.
+func TestBeginUpgradeRetrySameTargetPreservesStart(t *testing.T) {
+	orig := time.Now().Add(-53 * time.Minute) // the live epm-luiz elapsed, roughly
+	s := newBeginUpgradeServer(RegistryEntry{
+		ID: "h1", Upgrading: true, UpgradeTarget: "target-a", UpgradeStartedAt: orig,
+	})
+
+	s.mu.Lock()
+	s.beginUpgrade(0, "target-a") // a retry toward the same target
+	s.mu.Unlock()
+
+	h := s.registry.Hives[0]
+	if !h.UpgradeStartedAt.Equal(orig) {
+		t.Fatalf("a same-target retry must PRESERVE UpgradeStartedAt (%v), got %v — this is the reset-every-retry bug", orig, h.UpgradeStartedAt)
+	}
+	if !h.Upgrading || h.UpgradeTarget != "target-a" {
+		t.Fatalf("retry must keep Upgrading/target, got upgrading=%v target=%q", h.Upgrading, h.UpgradeTarget)
+	}
+}
+
+// TestBeginUpgradeNewTargetRestamps: a genuinely new upgrade (the target
+// changed) is a fresh upgrade and MUST get a fresh clock, or a hive that
+// upgrades A -> B would show B's progress as if it had been running since A.
+func TestBeginUpgradeNewTargetRestamps(t *testing.T) {
+	orig := time.Now().Add(-2 * time.Hour)
+	s := newBeginUpgradeServer(RegistryEntry{
+		ID: "h1", Upgrading: true, UpgradeTarget: "target-a", UpgradeStartedAt: orig,
+	})
+
+	s.mu.Lock()
+	s.beginUpgrade(0, "target-b") // a different target — a new upgrade
+	s.mu.Unlock()
+
+	h := s.registry.Hives[0]
+	if h.UpgradeStartedAt.Equal(orig) {
+		t.Fatal("a new target must re-stamp UpgradeStartedAt, but the old start survived")
+	}
+	if time.Since(h.UpgradeStartedAt) > time.Minute {
+		t.Fatalf("a new target's clock must start now, got %v old", time.Since(h.UpgradeStartedAt))
+	}
+	if h.UpgradeTarget != "target-b" {
+		t.Fatalf("UpgradeTarget = %q, want target-b", h.UpgradeTarget)
+	}
+}
+
+// TestBeginUpgradeZeroStartSelfHeals: an upgrade latched with a LOST (zero)
+// start time must get a real start on the next re-entry even if the target is
+// unchanged — otherwise the ibm-alchemy wedge (Upgrading=true, zero start) stays
+// unmeasurable forever.
+func TestBeginUpgradeZeroStartSelfHeals(t *testing.T) {
+	s := newBeginUpgradeServer(RegistryEntry{
+		ID: "h1", Upgrading: true, UpgradeTarget: "target-a", // UpgradeStartedAt zero
+	})
+
+	s.mu.Lock()
+	s.beginUpgrade(0, "target-a")
+	s.mu.Unlock()
+
+	h := s.registry.Hives[0]
+	if h.UpgradeStartedAt.IsZero() {
+		t.Fatal("a lost/zero start must be re-stamped so the upgrade becomes measurable")
+	}
+}
+
+// TestClearUpgradeLatchZeroesEverything: completion/cancel/orphan-clear must
+// drop the flag, the target AND the start clock so the next upgrade times from
+// zero.
+func TestClearUpgradeLatchZeroesEverything(t *testing.T) {
+	s := newBeginUpgradeServer(RegistryEntry{
+		ID: "h1", Upgrading: true, UpgradeTarget: "target-a",
+		UpgradeStartedAt: time.Now().Add(-30 * time.Minute),
+	})
+
+	s.mu.Lock()
+	s.clearUpgradeLatch(0)
+	s.mu.Unlock()
+
+	h := s.registry.Hives[0]
+	if h.Upgrading {
+		t.Error("clearUpgradeLatch must clear Upgrading")
+	}
+	if h.UpgradeTarget != "" {
+		t.Errorf("clearUpgradeLatch must clear UpgradeTarget, got %q", h.UpgradeTarget)
+	}
+	if !h.UpgradeStartedAt.IsZero() {
+		t.Errorf("clearUpgradeLatch must zero UpgradeStartedAt, got %v", h.UpgradeStartedAt)
+	}
+
+	// And a fresh upgrade after a clear starts a fresh clock.
+	s.mu.Lock()
+	s.beginUpgrade(0, "target-b")
+	s.mu.Unlock()
+	if time.Since(s.registry.Hives[0].UpgradeStartedAt) > time.Minute {
+		t.Fatal("an upgrade begun after a clear must time from zero")
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -47,6 +47,53 @@ const upgradeKubectlTimeout = 15 * time.Second
 // most once, short enough that a cluster coming back online is picked up soon.
 const clusterUnreachableTTL = 10 * time.Minute
 
+// beginUpgrade marks the registry entry at index i as upgrading toward target
+// and stamps UpgradeStartedAt so the dashboard can show a TRUE elapsed time.
+//
+// The invariant it enforces: UpgradeStartedAt is the moment an upgrade toward a
+// given target FIRST began, and it survives every retry of that same upgrade. A
+// hive that is already Upgrading toward the SAME target keeps its original start
+// time — it is retrying, not starting over. Only a genuinely new upgrade (the
+// hive was not upgrading, or the target actually changed) re-stamps the clock.
+//
+// This is the fix for the reset-every-retry bug: a crash-looping self-upgrade
+// re-enters the arm/retry paths every heartbeat cycle with the SAME target, and
+// each re-stamp of UpgradeStartedAt to time.Now() reset the displayed
+// "Upgrading Ns" back toward zero. The elapsed time therefore never crossed
+// staleUpgradeTimeout, so the row never turned red and the stuck-upgrade alert
+// never fired even while the hive thrashed for hours. Routing every site that
+// sets Upgrading=true through this one helper makes the invariant impossible to
+// violate in one place and not another.
+//
+// The caller MUST hold s.mu. i must be a valid index into s.registry.Hives.
+func (s *HubServer) beginUpgrade(i int, target string) {
+	h := &s.registry.Hives[i]
+	// (Re)stamp the start ONLY on a genuinely new upgrade: the hive was not
+	// already upgrading, or it is now aimed at a different target. A retry
+	// toward the same target keeps the original start so the timer is honest.
+	if !h.Upgrading || h.UpgradeTarget != target || h.UpgradeStartedAt.IsZero() {
+		h.UpgradeStartedAt = time.Now()
+	}
+	h.Upgrading = true
+	h.UpgradeTarget = target
+}
+
+// clearUpgradeLatch drops every trace of an in-flight upgrade on the entry at
+// index i: the Upgrading flag, its target, AND the start clock. Zeroing
+// UpgradeStartedAt on completion/cancel/orphan-clear guarantees the NEXT upgrade
+// starts a fresh timer even if some future path forgot to re-stamp — the
+// stuck-upgrade signal is only as honest as the clock it reads. Callers that
+// clear Upgrading MUST route through this so the invariant (a non-zero
+// UpgradeStartedAt implies an upgrade is genuinely in flight) holds everywhere.
+//
+// The caller MUST hold s.mu. i must be a valid index into s.registry.Hives.
+func (s *HubServer) clearUpgradeLatch(i int) {
+	h := &s.registry.Hives[i]
+	h.Upgrading = false
+	h.UpgradeTarget = ""
+	h.UpgradeStartedAt = time.Time{}
+}
+
 type SaaSUser struct {
 	GitHubUsername string            `json:"github_username"`
 	CreatedAt      string            `json:"created_at"`
@@ -3340,9 +3387,7 @@ func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 				branch = "v2"
 			}
 			latestSHA = getLatestSHAForBranch(branch)
-			s.registry.Hives[i].Upgrading = true
-			s.registry.Hives[i].UpgradeTarget = latestSHA
-			s.registry.Hives[i].UpgradeStartedAt = time.Now()
+			s.beginUpgrade(i, latestSHA)
 			break
 		}
 	}
@@ -3485,9 +3530,7 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 		s.heartbeatSwitchTag[id] = imageTag
 		for i := range s.registry.Hives {
 			if s.registry.Hives[i].ID == id {
-				s.registry.Hives[i].Upgrading = true
-				s.registry.Hives[i].UpgradeTarget = imageTag
-				s.registry.Hives[i].UpgradeStartedAt = time.Now()
+				s.beginUpgrade(i, imageTag)
 				break
 			}
 		}
@@ -3509,9 +3552,7 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 	for i := range s.registry.Hives {
 		if s.registry.Hives[i].ID == id {
-			s.registry.Hives[i].Upgrading = true
-			s.registry.Hives[i].UpgradeTarget = branchToTag(body.Branch) + "-latest"
-			s.registry.Hives[i].UpgradeStartedAt = time.Now()
+			s.beginUpgrade(i, branchToTag(body.Branch)+"-latest")
 			break
 		}
 	}
@@ -3827,9 +3868,7 @@ func (s *HubServer) handleToggleAutoUpgrade(w http.ResponseWriter, r *http.Reque
 			s.mu.Lock()
 			for i := range s.registry.Hives {
 				if s.registry.Hives[i].ID == id {
-					s.registry.Hives[i].Upgrading = true
-					s.registry.Hives[i].UpgradeTarget = latestSHA
-					s.registry.Hives[i].UpgradeStartedAt = time.Now()
+					s.beginUpgrade(i, latestSHA)
 					break
 				}
 			}
@@ -4583,8 +4622,7 @@ func (s *HubServer) triggerAutoUpgrades() {
 				s.mu.Lock()
 				for i := range s.registry.Hives {
 					if s.registry.Hives[i].ID == h.ID {
-						s.registry.Hives[i].Upgrading = false
-						s.registry.Hives[i].UpgradeTarget = ""
+						s.clearUpgradeLatch(i)
 						break
 					}
 				}
@@ -4647,8 +4685,17 @@ func (s *HubServer) triggerAutoUpgrades() {
 					s.mu.Lock()
 					for i := range s.registry.Hives {
 						if s.registry.Hives[i].ID == h.ID {
-							s.registry.Hives[i].UpgradeTarget = recoverTarget
-							s.registry.Hives[i].UpgradeStartedAt = time.Now()
+							// Route through beginUpgrade so the start time
+							// SURVIVES a same-target re-arm (the crash-loop retry
+							// case): re-arming delivery for the same target must
+							// not reset the elapsed clock, or a thrashing upgrade
+							// never crosses staleUpgradeTimeout and the stuck-
+							// upgrade alert never fires. A genuinely advanced
+							// target (recoverTarget != old UpgradeTarget) is a new
+							// upgrade and DOES get a fresh clock. A lost/zero start
+							// is re-stamped either way, which self-heals the
+							// ibm-alchemy zero-timestamp wedge.
+							s.beginUpgrade(i, recoverTarget)
 							break
 						}
 					}
@@ -4756,9 +4803,7 @@ func (s *HubServer) triggerAutoUpgrades() {
 		s.mu.Lock()
 		for i := range s.registry.Hives {
 			if s.registry.Hives[i].ID == h.ID {
-				s.registry.Hives[i].Upgrading = true
-				s.registry.Hives[i].UpgradeTarget = latestSHA
-				s.registry.Hives[i].UpgradeStartedAt = time.Now()
+				s.beginUpgrade(i, latestSHA)
 				break
 			}
 		}

--- a/v2/pkg/hub/saas_bulk.go
+++ b/v2/pkg/hub/saas_bulk.go
@@ -325,9 +325,7 @@ func (s *HubServer) bulkRestartOrUpgrade(h *SaaSHive, id, username, action strin
 		// Only an upgrade advances the target; a plain restart re-pulls the
 		// same tag and must not make the dashboard claim a version change.
 		if action == bulkActionUpgrade && latestSHA != "" {
-			s.registry.Hives[i].Upgrading = true
-			s.registry.Hives[i].UpgradeTarget = latestSHA
-			s.registry.Hives[i].UpgradeStartedAt = time.Now()
+			s.beginUpgrade(i, latestSHA)
 		}
 		break
 	}
@@ -406,9 +404,7 @@ func (s *HubServer) bulkSwitchBranch(h *SaaSHive, id, username, branch string) B
 	}
 	for i := range s.registry.Hives {
 		if s.registry.Hives[i].ID == id {
-			s.registry.Hives[i].Upgrading = true
-			s.registry.Hives[i].UpgradeTarget = imageTag
-			s.registry.Hives[i].UpgradeStartedAt = time.Now()
+			s.beginUpgrade(i, imageTag)
 			break
 		}
 	}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1389,6 +1389,9 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			if floatingAtLatest {
 				entry.Upgrading = false
 				entry.UpgradeTarget = ""
+				// The upgrade is done — drop the start clock so the next one
+				// times from zero, not from this completed rollout.
+				entry.UpgradeStartedAt = time.Time{}
 				entry.OrphanedUpgradeSweeps = 0
 			} else if h.Upgrading && !payload.Upgrading && (sameCommit(payload.GitHash, h.UpgradeTarget) || (registryLatestSHA != "" && sameCommit(payload.GitHash, registryLatestSHA))) {
 				// Non-upgrading heartbeat at the target SHA or at latest —
@@ -1399,6 +1402,9 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				// full SHA and the target/latest was the 7-char short form.
 				entry.Upgrading = false
 				entry.UpgradeTarget = ""
+				// Upgrade landed — clear the start clock so the next upgrade
+				// times from zero.
+				entry.UpgradeStartedAt = time.Time{}
 				// The upgrade landed, so any orphan-sweep retry budget spent
 				// getting here is no longer relevant. Reset it, or a hive that
 				// needed one sweep on each of three separate upgrades would be
@@ -1408,6 +1414,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				// Upgrading with no target (stale flag from config-only restart).
 				entry.Upgrading = false
 				entry.UpgradeTarget = ""
+				entry.UpgradeStartedAt = time.Time{}
 			} else if payload.UpgradeFailed {
 				// The spoke just told us the upgrade FAILED. That is direct
 				// evidence and must beat the inference below, which would
@@ -1416,10 +1423,12 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				// permanent spinner straight back.
 				entry.Upgrading = false
 				entry.UpgradeTarget = ""
+				entry.UpgradeStartedAt = time.Time{}
 			} else if h.Upgrading && h.UpgradeTarget != "" {
 				if entry.GitHash != h.GitHash && entry.GitHash != "" {
 					entry.Upgrading = false
 					entry.UpgradeTarget = ""
+					entry.UpgradeStartedAt = time.Time{}
 				} else {
 					entry.Upgrading = true
 					entry.UpgradeTarget = h.UpgradeTarget
@@ -1666,8 +1675,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			delete(s.heartbeatSwitchTag, payload.HiveID)
 			for i := range s.registry.Hives {
 				if s.registry.Hives[i].ID == payload.HiveID {
-					s.registry.Hives[i].Upgrading = false
-					s.registry.Hives[i].UpgradeTarget = ""
+					s.clearUpgradeLatch(i)
 					break
 				}
 			}

--- a/v2/pkg/hub/stale_upgrade.go
+++ b/v2/pkg/hub/stale_upgrade.go
@@ -211,6 +211,11 @@ func (s *HubServer) sweepOrphanedUpgrades() {
 			sweeps:    h.OrphanedUpgradeSweeps,
 		})
 		h.Upgrading = false
+		// The orphaned attempt is being abandoned — drop its start clock so the
+		// re-armed (or next) upgrade times from zero rather than inheriting this
+		// dead attempt's elapsed. beginUpgrade will stamp a fresh start when the
+		// recovery/heartbeat path re-enters.
+		h.UpgradeStartedAt = time.Time{}
 
 		if exhausted {
 			// Stop retrying. Re-arming again would just reproduce the same

--- a/v2/pkg/hub/upgrade_recovery_test.go
+++ b/v2/pkg/hub/upgrade_recovery_test.go
@@ -125,8 +125,14 @@ func TestTriggerAutoUpgradesRecoversStaleManualUpgrade(t *testing.T) {
 	if !s.registry.Hives[0].Upgrading {
 		t.Error("recovery must keep the durable Upgrading latch until the spoke reports the target")
 	}
-	if age := time.Since(s.registry.Hives[0].UpgradeStartedAt); age > time.Minute {
-		t.Errorf("recovery must refresh UpgradeStartedAt, still %v old", age)
+	// Re-arming delivery for the SAME target must PRESERVE the original start
+	// time, not refresh it. A crash-looping self-upgrade re-enters this recovery
+	// every staleUpgradeTimeout with the same target; refreshing the clock reset
+	// the displayed "Upgrading Ns" each cycle, so the true elapsed never crossed
+	// the stuck threshold and AlertTypeStuckUpgrade never fired. The 30-minute
+	// start this hive began with must survive the re-arm so the elapsed is honest.
+	if age := time.Since(s.registry.Hives[0].UpgradeStartedAt); age < 29*time.Minute {
+		t.Errorf("recovery re-arming the same target must PRESERVE UpgradeStartedAt so the elapsed is honest, but it was refreshed to %v old", age)
 	}
 }
 


### PR DESCRIPTION
## Symptom (live)

On the hub dashboard, a hive stuck upgrading showed an \"Upgrading Ns\" duration that **reset on every failed retry**, so the true elapsed upgrade time was never shown and the existing \"upgrade stuck\" attention alert never fired.

- `epm-luiz` (EPM/cdo-data-model-documentation): `↑ 3` retries but \"Upgrading 53s\"
- `ospo-jj` (open-source): `↑ 2` retries but \"Upgrading 4m\"

Both had actually been thrashing for **hours** (crash-looping on a GHE token stall). The retry arrow climbed but the timer kept resetting, so the elapsed never crossed `staleUpgradeTimeout`.

## Root cause

`UpgradeStartedAt = time.Now()` was reassigned **unconditionally** at every site that set `Upgrading=true` — `saas.go:3345/3490/3514/3832` and, critically, the periodic stale-recovery re-arm in `triggerAutoUpgrades()`, which re-fires a retry every `staleUpgradeTimeout` with the **same target**. Each re-stamp reset the displayed duration (`now - UpgradeStartedAt`) toward zero, so a thrashing upgrade never accumulated past the stuck threshold.

## Fix — one invariant, one place

**`HubServer.beginUpgrade(i, target)`** sets `Upgrading=true` + the target, and (re)stamps `UpgradeStartedAt` **only** on a genuinely new upgrade: not already upgrading, OR the target actually changed, OR the start was lost/zero. A retry toward the **same** target **preserves** the original start, so the elapsed is honest and eventually crosses the stuck threshold. Every `Upgrading=true` site is routed through it:

- `saas.go` — `handleUpgradeHive`; branch-switch (heartbeat fallback + kubectl); auto-upgrade initial trigger; the periodic `triggerAutoUpgrades` stale-recovery re-arm.
- `saas_bulk.go` — both bulk-upgrade sites.

**`HubServer.clearUpgradeLatch(i)`** drops the flag, target, **and** start clock. Every completion / cancel / orphan-clear now zeroes `UpgradeStartedAt` so the next upgrade times from zero:

- `server.go` heartbeat merge branches (completed / no-target / failed / hash-moved) + branch-switch-complete.
- `saas.go` floating-tag-at-latest clear.
- `stale_upgrade.go` orphan sweep.

## The stuck signal already existed — it just never fired

- **Attention-needed panel**: `AlertTypeStuckUpgrade` (`alerts.go`) fires `Upgrading && !UpgradeStartedAt.IsZero() && since(start) > staleUpgradeTimeout` as a **Warning** with an **Acknowledge** action — same aggregation/ack pipeline as Offline / Health-check-failing / Token-burn.
- **Row indicator**: `renderUpgradeElapsed` already turns the counter **red** and relabels it \"wedged\" past `UPGRADE_ELAPSED_RED_MS` (== `staleUpgradeTimeout`).

Both were unreachable only because the clock kept resetting. Feeding them the persistent timestamp is what makes them fire — no new constant or markup needed. **Threshold reused: `staleUpgradeTimeout = 10m`.**

## Not the assignment counter

Distinct from in-flight PR #2712's \"claim pending\" counter, which keys off `AssignedAt` (assignment state). This touches only `UpgradeStartedAt` (upgrade state); no shared markup.

## Tests

- `begin_upgrade_test.go`: first-stamp; same-target-retry preserves; new-target re-stamps; zero-start self-heals; `clearUpgradeLatch` zeroes everything + a post-clear upgrade times from zero.
- `upgrade_recovery_test.go`: the same-target re-arm now asserts the 30-minute start is **preserved**, not refreshed.
- `go build ./...`, `go vet ./pkg/hub/`, and the full `pkg/hub` suite pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)