### PR TITLE
fix: clear Upgrading when a floating-tag spoke reports at/ahead of a stale target

### DIFF
--- a/v2/pkg/hub/commit_order.go
+++ b/v2/pkg/hub/commit_order.go
@@ -1,0 +1,181 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+// ============================================================================
+// COMMIT ORDER — "has this spoke reached (or surpassed) its armed target?"
+// ============================================================================
+//
+// Every upgrade-completion check in this package used to be an EQUALITY test:
+// the spoke's reported GitHash had to equal either the armed UpgradeTarget or
+// the poller's current branch latest. That test has a hole a floating-tag hive
+// falls straight through: the hub captures a target SHA, the branch advances
+// before the spoke re-pulls its …-latest tag, and the spoke lands on a commit
+// that is AHEAD of the target but — if the branch has advanced again by the
+// time the beat arrives — also behind the poller's current latest. Its
+// reported hash then equals NOTHING the hub compares against, so the upgrade
+// that in fact completed is never recognised:
+//
+//   - the heartbeat completion branch never clears the Upgrading latch,
+//   - the armed s.heartbeatUpgrade fallback never drains, so the hub keeps
+//     re-instructing the same stale, unreachable commit pin on every beat,
+//   - the spoke dutifully re-attempts, re-rolling its pod and re-latching
+//     Upgrading via SendUpgradingHeartbeat, forever.
+//
+// This is the vllmd-13 wedge (the residue of the #2691 class): target 89d4bcc
+// was armed, the spoke pulled v2-latest and came back on be8c36e (3 commits
+// ahead of the target), and the "Upgrading" badge never cleared.
+//
+// The missing primitive is ORDER, not equality: a spoke whose reported commit
+// is a DESCENDANT of the armed target has reached-or-surpassed it, and the
+// upgrade is complete. SHAs carry no order, but GitHub's compare API knows the
+// ancestry, and ancestry is immutable — one answer per (target, reported) pair
+// is correct forever, so a tiny permanent cache makes this effectively free.
+//
+// Concurrency contract: commitAtOrAheadOfTarget is CACHE-ONLY and never blocks
+// — several callers hold s.mu (the heartbeat registry scan, the orphan sweep).
+// An unknown pair kicks one deduplicated background resolve and reports false
+// for now; the next beat (or sweep cycle) sees the cached answer. A wedged
+// hive therefore clears within one heartbeat interval of the single API call
+// resolving, instead of never.
+
+// commitOrderCacheMax bounds the resolved-ancestry cache. Entries are tiny and
+// ancestry never changes, but an unbounded map keyed by attacker-influencable
+// SHAs (spokes report GitHash) must not grow forever. On overflow the whole
+// cache is dropped: ancestry is re-resolvable on demand, so eviction costs one
+// API call per pair still in use — simpler and safer than an LRU here.
+const commitOrderCacheMax = 512
+
+// commitCompareTimeout bounds one GitHub compare API round-trip. Resolution
+// runs in a background goroutine, so this is a resource bound, not a latency
+// bound on any heartbeat.
+const commitCompareTimeout = 10 * time.Second
+
+// commitOrderKey identifies one immutable ancestry question:
+// "is `reported` at or ahead of `target`?" Both are canonical short SHAs.
+type commitOrderKey struct {
+	target   string
+	reported string
+}
+
+var (
+	commitOrderMu sync.Mutex
+	// commitOrderCache maps a resolved pair to its answer (true = reported is
+	// the same commit as, or a descendant of, target). Only definitive API
+	// answers are cached; errors are not, so a transient failure retries on
+	// the next call instead of poisoning the pair forever.
+	commitOrderCache = map[commitOrderKey]bool{}
+	// commitOrderInFlight dedupes background resolves so a hive heartbeating
+	// every couple of minutes cannot stack up parallel identical API calls.
+	commitOrderInFlight = map[commitOrderKey]bool{}
+)
+
+// fetchCommitCompareStatus asks GitHub how `head` relates to `base` and
+// returns the compare status: "identical", "ahead", "behind" or "diverged"
+// ("ahead" means head is a strict descendant of base). A var so tests can
+// stub the network round-trip; stub and restore it only while holding
+// commitOrderMu (commitAtOrAheadOfTarget captures it under that mutex).
+var fetchCommitCompareStatus = func(base, head string, logger *slog.Logger) (string, error) {
+	client := &http.Client{Timeout: commitCompareTimeout}
+	compareURL := fmt.Sprintf("%s/repos/kubestellar/hive/compare/%s...%s",
+		githubAPIBase, url.PathEscape(base), url.PathEscape(head))
+	req, err := http.NewRequest(http.MethodGet, compareURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("compare %s...%s: HTTP %d", base, head, resp.StatusCode)
+	}
+	var result struct {
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	if result.Status == "" {
+		return "", fmt.Errorf("compare %s...%s: empty status", base, head)
+	}
+	return result.Status, nil
+}
+
+// commitAtOrAheadOfTarget reports whether `reported` (a spoke's GitHash) is
+// the same commit as `target` or a descendant of it — i.e. the target was
+// reached or surpassed. It is safe to call while holding s.mu: it answers
+// from the cache (plus the trivial same-commit case) and NEVER performs I/O
+// inline. An unresolved pair returns false and starts one deduplicated
+// background resolve, so the caller's next pass gets the real answer.
+//
+// Empty inputs are false: an unknown state must never read as "complete".
+// logger may be nil.
+func commitAtOrAheadOfTarget(reported, target string, logger *slog.Logger) bool {
+	if sameCommit(reported, target) {
+		return true
+	}
+	reported = shortSHA(reported)
+	target = shortSHA(target)
+	if reported == "" || target == "" {
+		return false
+	}
+	key := commitOrderKey{target: target, reported: reported}
+
+	commitOrderMu.Lock()
+	if atOrAhead, ok := commitOrderCache[key]; ok {
+		commitOrderMu.Unlock()
+		return atOrAhead
+	}
+	if commitOrderInFlight[key] {
+		commitOrderMu.Unlock()
+		return false
+	}
+	commitOrderInFlight[key] = true
+	// Capture the fetcher under the same mutex tests use to stub it, so a
+	// background resolve can never race a reassignment of the package var.
+	fetch := fetchCommitCompareStatus
+	commitOrderMu.Unlock()
+
+	go resolveCommitOrder(key, fetch, logger)
+	return false
+}
+
+// resolveCommitOrder performs the one compare API call for key and stores the
+// definitive answer. Errors are logged and NOT cached, so the pair is retried
+// on a later commitAtOrAheadOfTarget call.
+func resolveCommitOrder(key commitOrderKey, fetch func(base, head string, logger *slog.Logger) (string, error), logger *slog.Logger) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	status, err := fetch(key.target, key.reported, logger)
+
+	commitOrderMu.Lock()
+	defer commitOrderMu.Unlock()
+	delete(commitOrderInFlight, key)
+	if err != nil {
+		logger.Debug("commit-order resolve failed (will retry on a later beat)",
+			"target", key.target, "reported", key.reported, "error", err)
+		return
+	}
+	if len(commitOrderCache) >= commitOrderCacheMax {
+		// See commitOrderCacheMax: reset rather than LRU — ancestry is
+		// immutable and cheap to re-resolve for pairs still in use.
+		commitOrderCache = map[commitOrderKey]bool{}
+	}
+	atOrAhead := status == "ahead" || status == "identical"
+	commitOrderCache[key] = atOrAhead
+	logger.Info("commit-order resolved",
+		"target", key.target, "reported", key.reported,
+		"status", status, "at_or_ahead", atOrAhead)
+}

--- a/v2/pkg/hub/commit_order_test.go
+++ b/v2/pkg/hub/commit_order_test.go
@@ -1,0 +1,327 @@
+package hub
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ============================================================
+// commit_order.go — ancestry cache + the vllmd-13 stale-target wedge
+// ============================================================
+
+// resetCommitOrderState clears the ancestry cache/in-flight maps and restores
+// the real compare fetcher after the test. All fetcher writes happen under
+// commitOrderMu — the mutex commitAtOrAheadOfTarget captures the var under —
+// so a background resolve leaked from another test can never race them.
+func resetCommitOrderState(t *testing.T) {
+	t.Helper()
+	commitOrderMu.Lock()
+	origFetch := fetchCommitCompareStatus
+	commitOrderCache = map[commitOrderKey]bool{}
+	commitOrderInFlight = map[commitOrderKey]bool{}
+	commitOrderMu.Unlock()
+	t.Cleanup(func() {
+		commitOrderMu.Lock()
+		fetchCommitCompareStatus = origFetch
+		commitOrderCache = map[commitOrderKey]bool{}
+		commitOrderInFlight = map[commitOrderKey]bool{}
+		commitOrderMu.Unlock()
+	})
+}
+
+// stubCommitCompare swaps the compare fetcher under commitOrderMu.
+func stubCommitCompare(fn func(base, head string, logger *slog.Logger) (string, error)) {
+	commitOrderMu.Lock()
+	fetchCommitCompareStatus = fn
+	commitOrderMu.Unlock()
+}
+
+// seedCommitOrder marks (reported at-or-ahead-of target) = v in the cache, as
+// a completed background resolve would.
+func seedCommitOrder(reported, target string, v bool) {
+	commitOrderMu.Lock()
+	commitOrderCache[commitOrderKey{target: shortSHA(target), reported: shortSHA(reported)}] = v
+	commitOrderMu.Unlock()
+}
+
+func TestCommitAtOrAheadOfTargetSameCommitNoFetch(t *testing.T) {
+	resetCommitOrderState(t)
+	fetchRan := false
+	stubCommitCompare(func(base, head string, logger *slog.Logger) (string, error) {
+		fetchRan = true
+		return "", errors.New("unexpected")
+	})
+	// Short/full mismatch is still the same commit.
+	if !commitAtOrAheadOfTarget("be8c36eb1234567", "be8c36e", nil) {
+		t.Error("same commit (short/full) should be at-or-ahead without any fetch")
+	}
+	// Empty inputs never read as complete.
+	if commitAtOrAheadOfTarget("", "aaaaaaa", nil) || commitAtOrAheadOfTarget("bbbbbbb", "", nil) {
+		t.Error("empty SHA must never be at-or-ahead")
+	}
+	if fetchRan {
+		t.Error("fetch must not run for same-commit or empty pairs")
+	}
+}
+
+func TestResolveCommitOrderStatuses(t *testing.T) {
+	cases := []struct {
+		status string
+		want   bool
+	}{
+		{"ahead", true},
+		{"identical", true},
+		{"behind", false},
+		{"diverged", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.status, func(t *testing.T) {
+			resetCommitOrderState(t)
+			key := commitOrderKey{target: "aaaaaaa", reported: "bbbbbbb"}
+			resolveCommitOrder(key, func(base, head string, logger *slog.Logger) (string, error) {
+				return tc.status, nil
+			}, nil)
+			if got := commitAtOrAheadOfTarget("bbbbbbb", "aaaaaaa", nil); got != tc.want {
+				t.Errorf("status %q: at-or-ahead = %v, want %v", tc.status, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveCommitOrderErrorNotCached(t *testing.T) {
+	resetCommitOrderState(t)
+	key := commitOrderKey{target: "aaaaaaa", reported: "bbbbbbb"}
+	resolveCommitOrder(key, func(base, head string, logger *slog.Logger) (string, error) {
+		return "", errors.New("rate limited")
+	}, nil)
+	commitOrderMu.Lock()
+	_, cached := commitOrderCache[key]
+	inFlight := commitOrderInFlight[key]
+	commitOrderMu.Unlock()
+	if cached {
+		t.Error("a failed resolve must not be cached (it must retry later)")
+	}
+	if inFlight {
+		t.Error("a failed resolve must clear the in-flight marker so retries can start")
+	}
+}
+
+func TestResolveCommitOrderCacheBounded(t *testing.T) {
+	resetCommitOrderState(t)
+	commitOrderMu.Lock()
+	for i := 0; i < commitOrderCacheMax; i++ {
+		commitOrderCache[commitOrderKey{target: "t", reported: string(rune(i))}] = false
+	}
+	commitOrderMu.Unlock()
+	key := commitOrderKey{target: "aaaaaaa", reported: "bbbbbbb"}
+	resolveCommitOrder(key, func(base, head string, logger *slog.Logger) (string, error) {
+		return "ahead", nil
+	}, nil)
+	commitOrderMu.Lock()
+	size := len(commitOrderCache)
+	v := commitOrderCache[key]
+	commitOrderMu.Unlock()
+	if size != 1 || !v {
+		t.Errorf("overflowing cache should reset and keep only the new answer; size=%d v=%v", size, v)
+	}
+}
+
+// The exact vllmd-13 scenario, step 1 (regression for the already-merged
+// clears): Upgrading=true toward shaA; the spoke re-pulled its FLOATING tag
+// and reports shaB where shaB == registry latest != shaA. Both the row latch
+// and the armed heartbeat fallback must drain.
+func TestHandleHeartbeatFloatingTagLandedOnLatestNotTarget(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	resetCommitOrderState(t)
+	resetSHACaches(t)
+	s := newHeartbeatHub()
+
+	latestSHAMu.Lock()
+	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "bbbbbbb"}
+	latestSHAMu.Unlock()
+
+	s.registry.Hives = []RegistryEntry{{
+		ID: "h1", Upgrading: true, UpgradeTarget: "aaaaaaa", GitHash: "old0000",
+		UpgradeStartedAt: time.Now().Add(-10 * time.Minute),
+	}}
+	s.heartbeatUpgrade["h1"] = "aaaaaaa"
+
+	rec := postHeartbeat(t, s,
+		`{"hive_id":"h1","git_hash":"bbbbbbb","git_branch":"v2","upgrading":false,"image_ref":"ghcr.io/kubestellar/hive:v2-latest"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	s.mu.RLock()
+	entry := s.registry.Hives[0]
+	_, armed := s.heartbeatUpgrade["h1"]
+	s.mu.RUnlock()
+	if entry.Upgrading || entry.UpgradeTarget != "" || !entry.UpgradeStartedAt.IsZero() {
+		t.Errorf("expected latch fully cleared, got %+v", entry)
+	}
+	if armed {
+		t.Error("expected armed heartbeat fallback drained once the spoke is at latest")
+	}
+	if strings.Contains(rec.Body.String(), "upgrade_to") {
+		t.Errorf("hub must not re-instruct a completed upgrade, got %s", rec.Body.String())
+	}
+}
+
+// The exact vllmd-13 WEDGE (the condition that blocked every merged clear):
+// the branch advanced AGAIN after the spoke pulled, so the reported shaB
+// equals NEITHER the armed target shaA NOR the current registry latest shaC,
+// and the stored row already carries shaB (so the hash-changed clear can
+// never fire either). Only ancestry can prove shaB surpassed shaA. With the
+// pair resolved as "ahead", the badge must clear and the stale UpgradeTo
+// re-instruct loop must stop.
+func TestHandleHeartbeatClearsWhenReportedAheadOfStaleTarget(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	resetCommitOrderState(t)
+	resetSHACaches(t)
+	s := newHeartbeatHub()
+
+	latestSHAMu.Lock()
+	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "ccccccc"} // advanced again
+	latestSHAMu.Unlock()
+
+	// Stored row already saw the spoke on shaB (steady wedge state) and no
+	// image_ref is on the wire, so pre-fix NOTHING cleared this.
+	s.registry.Hives = []RegistryEntry{{
+		ID: "h1", Upgrading: true, UpgradeTarget: "aaaaaaa", GitHash: "bbbbbbb",
+		UpgradeStartedAt: time.Now().Add(-time.Hour),
+	}}
+	s.heartbeatUpgrade["h1"] = "aaaaaaa"
+	seedCommitOrder("bbbbbbb", "aaaaaaa", true) // resolved: shaB is ahead of shaA
+
+	rec := postHeartbeat(t, s,
+		`{"hive_id":"h1","git_hash":"bbbbbbb","git_branch":"v2","upgrading":false}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	s.mu.RLock()
+	entry := s.registry.Hives[0]
+	_, armed := s.heartbeatUpgrade["h1"]
+	s.mu.RUnlock()
+	if entry.Upgrading || entry.UpgradeTarget != "" || !entry.UpgradeStartedAt.IsZero() {
+		t.Errorf("expected latch cleared for a spoke AHEAD of its stale target, got %+v", entry)
+	}
+	if armed {
+		t.Error("expected stale heartbeat fallback drained — re-instructing it re-rolls the spoke forever")
+	}
+	if strings.Contains(rec.Body.String(), "upgrade_to") {
+		t.Errorf("hub must not re-instruct a surpassed target, got %s", rec.Body.String())
+	}
+}
+
+// Same wedge but the ancestry is UNRESOLVED: the hub must keep its previous
+// (latched + instructing) behaviour rather than guess — clearing on an
+// unknown pair would cancel genuinely undelivered upgrades.
+func TestHandleHeartbeatKeepsLatchWhileAncestryUnresolved(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	resetCommitOrderState(t)
+	resetSHACaches(t)
+	// The unknown pair kicks a background resolve; stub it so the test never
+	// touches the network.
+	stubCommitCompare(func(base, head string, logger *slog.Logger) (string, error) {
+		return "", errors.New("stubbed offline")
+	})
+	s := newHeartbeatHub()
+
+	latestSHAMu.Lock()
+	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "ccccccc"}
+	latestSHAMu.Unlock()
+
+	s.registry.Hives = []RegistryEntry{{
+		ID: "h1", Upgrading: true, UpgradeTarget: "aaaaaaa", GitHash: "bbbbbbb",
+		UpgradeStartedAt: time.Now().Add(-time.Hour),
+	}}
+	s.heartbeatUpgrade["h1"] = "aaaaaaa"
+
+	rec := postHeartbeat(t, s,
+		`{"hive_id":"h1","git_hash":"bbbbbbb","git_branch":"v2","upgrading":false}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	s.mu.RLock()
+	entry := s.registry.Hives[0]
+	s.mu.RUnlock()
+	if !entry.Upgrading || entry.UpgradeTarget != "aaaaaaa" {
+		t.Errorf("unresolved ancestry must not clear the latch, got %+v", entry)
+	}
+	if !strings.Contains(rec.Body.String(), "upgrade_to") {
+		t.Errorf("unresolved ancestry keeps the instruction on the wire, got %s", rec.Body.String())
+	}
+}
+
+// The orphan sweep must treat a spoke at-or-ahead of its target as NOT
+// orphaned — pre-fix it swept, re-armed and (after maxOrphanedUpgradeSweeps)
+// reported a false permanent UpgradeFailed for an upgrade that had landed.
+func TestEvaluateOrphanedUpgradeAheadOfTargetNotOrphaned(t *testing.T) {
+	resetCommitOrderState(t)
+	stubCommitCompare(func(base, head string, logger *slog.Logger) (string, error) {
+		return "", errors.New("stubbed offline")
+	})
+	now := time.Now()
+	entry := &RegistryEntry{
+		ID: "h1", Upgrading: true, UpgradeTarget: "aaaaaaa", GitHash: "bbbbbbb",
+		UpgradeStartedAt: now.Add(-3 * orphanedUpgradeClearAfter),
+		LastHeartbeat:    now.Add(-time.Minute).UTC().Format(time.RFC3339),
+	}
+
+	// Unresolved ancestry: liveness + wrong SHA still reads as orphaned.
+	if ev := evaluateOrphanedUpgrade(entry, now, "ccccccc"); !ev.orphaned {
+		t.Fatal("sanity: unresolved ancestry should still evaluate as orphaned")
+	}
+
+	// Resolved ahead: converged, not orphaned.
+	seedCommitOrder("bbbbbbb", "aaaaaaa", true)
+	if ev := evaluateOrphanedUpgrade(entry, now, "ccccccc"); ev.orphaned {
+		t.Errorf("a spoke ahead of its target is converged, not orphaned: %+v", ev)
+	}
+}
+
+// triggerAutoUpgrades' stale-recovery must CLEAR a manual upgrade whose spoke
+// surpassed the armed target instead of re-arming the original stale pin
+// forever (manual upgrades never advance their target, so pre-fix this
+// re-stamped Upgrading/UpgradeTarget and re-instructed the same stale SHA
+// every cycle).
+func TestTriggerAutoUpgradesClearsSurpassedManualTarget(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	resetCommitOrderState(t)
+	resetSHACaches(t)
+
+	remote := ClusterConfig{ID: "remote", InCluster: false, KubeconfigPath: "/tmp/kc", Context: "ctx"}
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", AutoUpgrade: false, Status: "running", ClusterID: "remote"})
+	latestSHAMu.Lock()
+	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "ccccccc"}
+	latestSHAMu.Unlock()
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret,
+		heartbeatUpgrade: map[string]string{"h1": "aaaaaaa"},
+		clusters:         map[string]ClusterConfig{"remote": remote}}
+	s.registry.Hives = []RegistryEntry{{
+		ID: "h1", GitBranch: "v2", GitHash: "bbbbbbb", Upgrading: true,
+		UpgradeTarget: "aaaaaaa", UpgradeStartedAt: time.Now().Add(-2 * time.Hour),
+	}}
+	seedCommitOrder("bbbbbbb", "aaaaaaa", true)
+
+	s.triggerAutoUpgrades()
+
+	s.mu.RLock()
+	entry := s.registry.Hives[0]
+	_, armed := s.heartbeatUpgrade["h1"]
+	s.mu.RUnlock()
+	if entry.Upgrading || entry.UpgradeTarget != "" {
+		t.Errorf("expected surpassed-target latch cleared, got %+v", entry)
+	}
+	if armed {
+		t.Error("expected stale heartbeat fallback drained, not re-armed")
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4664,6 +4664,33 @@ func (s *HubServer) triggerAutoUpgrades() {
 					"hive", h.ID, "branch", branch, "sha", currentSHA, "image_ref", imageRef)
 				continue
 			}
+			// Target reached or SURPASSED. The equality checks above cannot see
+			// a spoke that landed AHEAD of the armed target: a floating-tag
+			// re-pull delivers whatever CI last published, so when the branch
+			// advanced between arming and pulling — and again before this cycle
+			// — the reported hash equals neither the target nor the current
+			// latest. Without this ancestry check the stale-recovery below
+			// re-arms the ORIGINAL stale pin forever (manual upgrades never
+			// advance their target), re-stamping the registry latch and
+			// re-instructing a commit the spoke can never report — the
+			// vllmd-13 wedge. Cache-only + background resolve, so this loop
+			// never blocks on the network; an unresolved pair clears on a
+			// later cycle.
+			if upgradeTarget != "" && currentSHA != "" &&
+				commitAtOrAheadOfTarget(currentSHA, upgradeTarget, s.logger) {
+				s.mu.Lock()
+				for i := range s.registry.Hives {
+					if s.registry.Hives[i].ID == h.ID {
+						s.clearUpgradeLatch(i)
+						break
+					}
+				}
+				delete(s.heartbeatUpgrade, h.ID)
+				s.mu.Unlock()
+				s.logger.Info("clearing upgrade latch — hive is at or ahead of its armed target",
+					"hive", h.ID, "branch", branch, "sha", currentSHA, "target", upgradeTarget)
+				continue
+			}
 			// Latched-upgrade recovery runs for EVERY hive, deliberately BEFORE
 			// the AutoUpgrade gate below (#2476). The registry latch
 			// (Upgrading/UpgradeTarget/UpgradeStartedAt) is durable, but

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1399,13 +1399,20 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				// times from zero, not from this completed rollout.
 				entry.UpgradeStartedAt = time.Time{}
 				entry.OrphanedUpgradeSweeps = 0
-			} else if h.Upgrading && !payload.Upgrading && (sameCommit(payload.GitHash, h.UpgradeTarget) || (registryLatestSHA != "" && sameCommit(payload.GitHash, registryLatestSHA))) {
-				// Non-upgrading heartbeat at the target SHA or at latest —
-				// upgrade completed (image may have advanced past the
-				// original target before the spoke pulled it). sameCommit
-				// tolerates short/full SHA length mismatch — a raw == left the
-				// Upgrading badge spinning forever when the spoke reported a
-				// full SHA and the target/latest was the 7-char short form.
+			} else if h.Upgrading && !payload.Upgrading && (sameCommit(payload.GitHash, h.UpgradeTarget) || (registryLatestSHA != "" && sameCommit(payload.GitHash, registryLatestSHA)) || commitAtOrAheadOfTarget(payload.GitHash, h.UpgradeTarget, s.logger)) {
+				// Non-upgrading heartbeat at the target SHA, at latest, or at
+				// a commit AHEAD of the target — upgrade completed (image may
+				// have advanced past the original target before the spoke
+				// pulled it). sameCommit tolerates short/full SHA length
+				// mismatch — a raw == left the Upgrading badge spinning
+				// forever when the spoke reported a full SHA and the
+				// target/latest was the 7-char short form. The at-or-ahead
+				// check closes the remaining gap (the vllmd-13 wedge): a
+				// floating-tag spoke that pulled a build NEWER than the armed
+				// target while the branch advanced yet again reports a hash
+				// that equals neither the target nor the current latest, and
+				// only commit ANCESTRY can prove it surpassed the target.
+				// Cache-only under s.mu — see commit_order.go.
 				entry.Upgrading = false
 				entry.UpgradeTarget = ""
 				// Upgrade landed — clear the start clock so the next upgrade
@@ -1695,11 +1702,17 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				"hive_id", payload.HiveID, "tag", switchTag)
 		}
 	}
-	if hbTarget != "" && (sameCommit(payload.GitHash, hbTarget) || (latestSHA != "" && sameCommit(payload.GitHash, latestSHA))) {
-		// Spoke already at the target or at latest — clear the fallback entry.
-		// sameCommit tolerates short/full SHA length mismatch (hub stores a
-		// 7-char short SHA; a spoke may report a longer one) so a hive already
-		// at HEAD is not told to upgrade forever.
+	if hbTarget != "" && (sameCommit(payload.GitHash, hbTarget) || (latestSHA != "" && sameCommit(payload.GitHash, latestSHA)) || commitAtOrAheadOfTarget(payload.GitHash, hbTarget, s.logger)) {
+		// Spoke already at the target, at latest, or at a commit AHEAD of the
+		// target — clear the fallback entry. sameCommit tolerates short/full
+		// SHA length mismatch (hub stores a 7-char short SHA; a spoke may
+		// report a longer one) so a hive already at HEAD is not told to
+		// upgrade forever. The at-or-ahead ancestry check is what actually
+		// drains a STALE pin for a floating-tag hive: its re-pull landed past
+		// the target while the branch advanced again, so its hash matches
+		// neither target nor latest, and without this the hub re-sends the
+		// same unreachable UpgradeTo on every beat — the spoke re-rolls its
+		// pod and re-latches "Upgrading" forever (the vllmd-13 wedge).
 		s.mu.Lock()
 		delete(s.heartbeatUpgrade, payload.HiveID)
 		s.mu.Unlock()

--- a/v2/pkg/hub/stale_upgrade.go
+++ b/v2/pkg/hub/stale_upgrade.go
@@ -137,9 +137,14 @@ func evaluateOrphanedUpgrade(entry *RegistryEntry, now time.Time, latestSHA stri
 	}
 
 	// The spoke is alive and post-dates the instruction. If it is already on the
-	// target, the flag is merely lagging and the heartbeat path clears it; only
-	// a spoke still on a DIFFERENT SHA is genuinely un-upgraded.
-	if entry.UpgradeTarget != "" && sameCommit(entry.GitHash, entry.UpgradeTarget) {
+	// target — or AHEAD of it (a floating-tag re-pull lands on whatever CI last
+	// published, which can surpass a stale target; only ancestry can prove
+	// that) — the flag is merely lagging and the heartbeat path clears it; only
+	// a spoke still on a SHA behind the target is genuinely un-upgraded.
+	// commitAtOrAheadOfTarget is cache-only (the sweep holds s.mu), so an
+	// unresolved pair is treated as "behind" this cycle and re-evaluated next.
+	if entry.UpgradeTarget != "" && (sameCommit(entry.GitHash, entry.UpgradeTarget) ||
+		commitAtOrAheadOfTarget(entry.GitHash, entry.UpgradeTarget, nil)) {
 		return ev
 	}
 


### PR DESCRIPTION
## The live bug (hosted-available-vllmd-13)

Timeline, verified end-to-end on the vllm-d cluster:

1. The operator triggered an upgrade. The hub armed the then-current v2 latest **89d4bcc** as `UpgradeTarget` and (vllm-d being heartbeat-only) put it in `s.heartbeatUpgrade`.
2. The spoke annotated its Deployment (`hive.kubestellar.io/upgrade-target-sha: 89d4bcc`) and rolled. The new pod pulled the **floating tag** `ghcr.io/kubestellar/hive:v2-latest`, which by then resolved to **be8c36e** — 3 commits AHEAD of the armed target.
3. The spoke now reports `git_hash: be8c36e`, but the registry still shows `"upgrading": true, "upgradeTarget": "89d4bcc"`. The spoke can never report 89d4bcc, so the badge never clears.

## Why none of the merged clears (#2691 / #2725) fired

Every completion check in the hub is an **equality** test, and the wedge state matches none of them:

- `sameCommit(reported, UpgradeTarget)` — never true: `be8c36e != 89d4bcc`, and a floating tag can never travel back to a historical pin.
- `sameCommit(reported, registryLatestSHA)` — only true during the window where the poller's latest still equals what the spoke pulled. v2 advanced again before the beat arrived, so `latest` moved past `be8c36e` and the window closed **permanently**: the reported hash is now *between* target and latest, matching neither.
- `floatingAtLatest` clears the registry row but **never drains `s.heartbeatUpgrade`** — there is no `delete` on that path, and the only drain (heartbeat handler, `hbTarget` check) uses the same two equality tests above. So the armed stale pin survives every clear.
- The hub therefore re-sends `UpgradeTo: 89d4bcc` on **every beat**; the spoke re-attempts, sends `SendUpgradingHeartbeat` (`upgrading: true`, which re-latches the row via `entry.Upgrading = true`), re-annotates and re-rolls. `triggerAutoUpgrades`' stale recovery makes it durable: for a **manual** upgrade it never advances the target, so it re-stamps the row with the original 89d4bcc via `beginUpgrade` and re-arms `heartbeatUpgrade` every cycle — exactly the persisted state observed.
- The "hash changed → landed" fallback in the heartbeat scan can't fire either: after the first post-roll beat the stored row already carries `be8c36e`, so `entry.GitHash == h.GitHash` forever.
- End state without this fix: the orphan sweep/marker budget eventually declares a **false permanent `UpgradeFailed`** for an upgrade that actually landed — after re-rolling the pod for hours.

The missing primitive is **order, not equality**: `be8c36e` is a *descendant* of `89d4bcc` — target reached and surpassed — but nothing in the hub could know that from two opaque SHAs.

## The fix

New `pkg/hub/commit_order.go`: `commitAtOrAheadOfTarget(reported, target)` answers "is the reported commit the same as, or a descendant of, the target?" via GitHub's compare API (`status: ahead|identical`). Ancestry is immutable, so one deduplicated background resolve per pair feeds a permanent bounded cache; the function itself is **cache-only and never blocks** (several callers hold `s.mu`). An unresolved pair reports `false`, keeping today's behaviour — an undelivered upgrade is never cancelled on a guess; the wedge clears on the next beat after the single API call resolves.

Wired into every completion check that previously required equality:

- **`handleHeartbeat` completion branch** (`pkg/hub/server.go`): clears the `Upgrading` latch when the reported hash is at/ahead of the target.
- **`handleHeartbeat` `hbTarget` drain** (`pkg/hub/server.go`): drops the armed `heartbeatUpgrade` pin when the spoke is at/ahead of it — this is what actually ends the re-instruct → re-roll → re-latch loop.
- **`triggerAutoUpgrades` stale recovery** (`pkg/hub/saas.go`): clears a surpassed manual target (+ drains the pin) instead of re-arming the original stale pin every cycle.
- **`evaluateOrphanedUpgrade`** (`pkg/hub/stale_upgrade.go`): a spoke at/ahead of its target is converged, not orphaned — no more false permanent `UpgradeFailed` after `maxOrphanedUpgradeSweeps`.

## Tests

`pkg/hub/commit_order_test.go`:
- ancestry cache unit tests (ahead/identical/behind/diverged, error-not-cached, bounded cache, same-commit short-circuit, no network in tests);
- the exact scenario asked for: `Upgrading=true`, `UpgradeTarget=shaA`, spoke reports `shaB == registryLatest != shaA`, mutable tag → row latch AND armed fallback both clear, no `upgrade_to` re-instruct;
- the exact wedge condition found: `shaB` equals **neither** target **nor** latest, row already carries `shaB`, no `image_ref` on the wire → pre-fix nothing cleared; with ancestry resolved "ahead" everything clears and the instruction leaves the wire;
- unresolved ancestry keeps the latch + instruction (no guessing);
- orphan-sweep and `triggerAutoUpgrades` variants of the same.

## Note: the 3x-repeated registry fields

The dump showing the vllmd-13 upgrading/upgradeTarget fields repeated 3x was checked against the code: `s.registry.Hives` has exactly one append site, guarded by a full-scan `found` check under `s.mu`, and the heartbeat/upgrade/sweep paths all match by ID — in-code writes cannot create duplicate rows. If the on-disk registry really contains duplicate rows for one hive (e.g. legacy corruption), heartbeats update only the FIRST row (`break`) while the sweep iterates ALL rows — worth a dedupe-on-load in a separate PR; not changed here.
