### PR TITLE
fix(hub): heartbeat responses dead-lettered by synchronous vanity-URL repair — claims to heartbeat-only spokes never delivered

### DIFF
--- a/v2/pkg/hub/heartbeat_vanity_async_test.go
+++ b/v2/pkg/hub/heartbeat_vanity_async_test.go
@@ -1,0 +1,246 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ============================================================
+// server.go / saas_provision.go — the vanity-URL repair must NEVER block the
+// heartbeat response.
+//
+// Live failure this guards against (vllmd-14, and vllmd-13 / EPM before it):
+// the repair's kubectl calls hang ~90s per beat against an unreachable
+// (heartbeat-only) cluster, the spoke's heartbeat client times out at 10s
+// (heartbeatTimeout), so the response carrying the claimed-project config —
+// the only channel that reaches such a spoke — is written to a dead
+// connection. The claim never lands and the assignStuckResetTimeout sweep
+// resets the assignment at 15m, forever.
+// ============================================================
+
+// waitTimeout bounds how long these tests wait for what should be an
+// immediate response; generous so slow CI never flakes it, tiny next to the
+// minutes a blocked kubectl would take.
+const waitTimeout = 5 * time.Second
+
+// newBlockedVanityHub builds a hub whose vanity-servability seam blocks until
+// the returned release func is called — standing in for kubectl hanging
+// against an unreachable cluster. The cluster has a Domain so the repair has
+// a host to derive (i.e. it genuinely reaches the blocking call).
+func newBlockedVanityHub(t *testing.T) (s *HubServer, entered *atomic.Int32, release func()) {
+	t.Helper()
+	s = newHeartbeatHub()
+	s.clusters["vllm-d"] = ClusterConfig{
+		ID:          "vllm-d",
+		Name:        "vllm-d",
+		Domain:      "apps.fmaas-vllm-d.example.com",
+		IngressType: "nginx",
+	}
+	blocked := make(chan struct{})
+	var once atomic.Bool
+	release = func() {
+		if once.CompareAndSwap(false, true) {
+			close(blocked)
+		}
+	}
+	t.Cleanup(release)
+	entered = &atomic.Int32{}
+	s.vanityHostServable = func(_, _ string, _ *ClusterConfig) error {
+		entered.Add(1)
+		<-blocked
+		// After release the repair must treat the attempt as "not servable"
+		// and keep the placeholder (errNotServableForTest lives in
+		// url_reachability_test.go).
+		return errNotServableForTest
+	}
+	return s, entered, release
+}
+
+// assignedVllmdHive is a freshly assigned placeholder on the unreachable
+// cluster: complete claim, no vanity URL — exactly the record whose repair
+// used to stall the heartbeat.
+func assignedVllmdHive(id string) *SaaSHive {
+	return &SaaSHive{
+		ID: id, Owner: "AKippins", Status: statusAssigned,
+		Org: "z-innersource", Repos: []string{"AutoIPL"}, PrimaryRepo: "AutoIPL",
+		ACMMLevel: 1, RequestedACMMLevel: 1, ClusterID: "vllm-d",
+	}
+}
+
+// The heartbeat response — carrying the claimed-project config — must come
+// back within the spoke's client timeout even while the vanity repair is
+// blocked on an unreachable cluster. With the old synchronous call this test
+// hangs on the seam and times out.
+func TestHeartbeatDeliversClaimWhileVanityRepairBlocked(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s, _, _ := newBlockedVanityHub(t)
+
+	const id = "hosted-available-vllmd-14"
+	if err := saveSaaSHive(assignedVllmdHive(id)); err != nil {
+		t.Fatal(err)
+	}
+
+	// The spoke still reports its placeholder identity, so the hub must push
+	// the claim in the response.
+	body := `{"hive_id":"` + id + `","org":"available-vllmd-14","acmm_level":2}`
+
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() { done <- postHeartbeat(t, s, body) }()
+
+	select {
+	case rec := <-done:
+		if rec.Code != 200 {
+			t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+		}
+		var resp HeartbeatResponse
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if resp.ProjectConfig == nil {
+			t.Fatal("response carried no project config for a fresh assignment")
+		}
+		if resp.ProjectConfig.Org != "z-innersource" || resp.ProjectConfig.PrimaryRepo != "AutoIPL" {
+			t.Errorf("project config = %+v, want org z-innersource primary AutoIPL", resp.ProjectConfig)
+		}
+	case <-time.After(waitTimeout):
+		t.Fatal("heartbeat response blocked behind the vanity repair — the spoke's 10s client timeout would drop it and the claim would never be delivered")
+	}
+}
+
+// While one background repair attempt is stuck against the cluster, further
+// heartbeats must not stack additional attempts; once it finishes, a later
+// beat may try again.
+func TestVanityRepairKickDedupesInFlightAttempts(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s, entered, release := newBlockedVanityHub(t)
+
+	const id = "hosted-available-vllmd-15"
+	if err := saveSaaSHive(assignedVllmdHive(id)); err != nil {
+		t.Fatal(err)
+	}
+
+	s.kickVanityURLRepairAsync(id)
+	// Wait for the first attempt to reach the blocking seam.
+	deadline := time.Now().Add(waitTimeout)
+	for entered.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if entered.Load() != 1 {
+		t.Fatalf("first kick: seam entered %d times, want 1", entered.Load())
+	}
+
+	// Beats keep arriving while the attempt is stuck — none may stack.
+	s.kickVanityURLRepairAsync(id)
+	s.kickVanityURLRepairAsync(id)
+	time.Sleep(50 * time.Millisecond)
+	if got := entered.Load(); got != 1 {
+		t.Fatalf("in-flight dedupe failed: seam entered %d times, want 1", got)
+	}
+
+	// Release the stuck attempt; once it drains, a new kick may run again.
+	release()
+	deadline = time.Now().Add(waitTimeout)
+	for time.Now().Before(deadline) {
+		if _, inFlight := s.vanityRepairInFlight.Load(id); !inFlight {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	s.kickVanityURLRepairAsync(id)
+	deadline = time.Now().Add(waitTimeout)
+	for entered.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := entered.Load(); got != 2 {
+		t.Fatalf("post-release kick: seam entered %d times, want 2", got)
+	}
+}
+
+// The kick must spawn nothing for records the repair would no-op on: the
+// common case stays goroutine-free, and unclaimed placeholders stay untouched.
+func TestVanityRepairKickInlineGuards(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s, entered, _ := newBlockedVanityHub(t)
+
+	cases := []*SaaSHive{
+		nil, // no record at all
+		{ID: "hosted-unclaimed", Status: statusAvailable, Org: "available-x", ClusterID: "vllm-d"},
+		func() *SaaSHive { // already has a vanity URL
+			h := assignedVllmdHive("hosted-has-vanity")
+			h.VanityURL = "https://already.example.com"
+			return h
+		}(),
+		func() *SaaSHive { // incomplete claim — nothing to derive a host from
+			h := assignedVllmdHive("hosted-no-primary")
+			h.PrimaryRepo = ""
+			return h
+		}(),
+	}
+	for _, h := range cases {
+		id := "hosted-missing"
+		if h != nil {
+			id = h.ID
+			if err := saveSaaSHive(h); err != nil {
+				t.Fatal(err)
+			}
+		}
+		s.kickVanityURLRepairAsync(id)
+		if _, inFlight := s.vanityRepairInFlight.Load(id); inFlight {
+			t.Errorf("%s: kick spawned a background repair for a no-op record", id)
+		}
+	}
+	time.Sleep(50 * time.Millisecond)
+	if got := entered.Load(); got != 0 {
+		t.Errorf("no-op kicks reached the servability seam %d times, want 0", got)
+	}
+}
+
+// A successful repair must not write through a record loaded before its slow
+// kubectl window: fields the heartbeat path latched meanwhile (ClaimDelivered
+// here) survive the vanity save.
+func TestVanityRepairReloadsHiveBeforeSave(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+	s.clusters["vllm-d"] = ClusterConfig{
+		ID: "vllm-d", Name: "vllm-d",
+		Domain: "apps.fmaas-vllm-d.example.com", IngressType: "nginx",
+	}
+
+	const id = "hosted-available-vllmd-16"
+	if err := saveSaaSHive(assignedVllmdHive(id)); err != nil {
+		t.Fatal(err)
+	}
+
+	// The seam stands in for the minutes-long kubectl window: while the repair
+	// is "making the host servable", the heartbeat path latches the claim.
+	s.vanityHostServable = func(hiveID, _ string, _ *ClusterConfig) error {
+		h := loadSaaSHive(hiveID)
+		h.ClaimDelivered = true
+		if err := saveSaaSHive(h); err != nil {
+			t.Errorf("mid-repair save: %v", err)
+		}
+		return nil
+	}
+
+	if !s.repairVanityURLForHive(id) {
+		t.Fatal("repair reported no change for a claimed hive without a vanity URL")
+	}
+	got := loadSaaSHive(id)
+	if got.VanityURL == "" {
+		t.Error("repair did not mint a vanity URL")
+	}
+	if !got.ClaimDelivered {
+		t.Error("vanity save reverted ClaimDelivered latched during the repair's kubectl window (stale load-modify-write)")
+	}
+	if !strings.HasPrefix(got.VanityURL, "https://hosted-z-innersource-autoipl-") {
+		t.Errorf("vanity URL %q not derived from the claimed project", got.VanityURL)
+	}
+}

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1100,8 +1100,12 @@ const gitHubAppStillRequiredNote = "github_host repaired; a hive still carrying 
 //     the spoke, so that call fails and the hive correctly keeps its working
 //     placeholder host.
 //
-// Called on each heartbeat, so it must be cheap and silent in the overwhelmingly
-// common no-op case — every guard below returns before any network call or write.
+// Kicked from each heartbeat via kickVanityURLRepairAsync — in the BACKGROUND,
+// never on the request path: the kubectl calls below can hang for minutes
+// against an unreachable cluster, and a heartbeat response delayed past the
+// spoke's 10s client timeout is a response the spoke never sees (which is how
+// claim delivery to vllm-d silently broke). The guards below still return
+// before any network call or write in the overwhelmingly common no-op case.
 func (s *HubServer) repairVanityURLForHive(hiveID string) bool {
 	h := loadSaaSHive(hiveID)
 	if h == nil {
@@ -1141,6 +1145,19 @@ func (s *HubServer) repairVanityURLForHive(hiveID string) bool {
 			"hive", hiveID, "host", vanityHost, "cluster", cluster.ID, "error", err)
 		return false
 	}
+	// Re-load before writing. makeVanityHostServable (and existingVanityHost
+	// above) can block for minutes in kubectl against a slow/unreachable
+	// cluster, and the heartbeat path keeps load-modify-writing this hive's
+	// record meanwhile — adoptSpokeProjectConfig latching ClaimDelivered /
+	// ACMMDelivered, the forge handshakes. Saving through the record loaded
+	// before that window would silently revert every field written during it.
+	h = loadSaaSHive(hiveID)
+	if h == nil {
+		return false
+	}
+	if h.VanityURL != "" {
+		return false // another path minted one while we were blocked — keep it
+	}
 	h.VanityURL = "https://" + vanityHost
 	if err := saveSaaSHive(h); err != nil {
 		s.logger.Error("vanity url repair: failed to save hive", "hive", hiveID, "error", err)
@@ -1150,6 +1167,44 @@ func (s *HubServer) repairVanityURLForHive(hiveID string) bool {
 		"hive", hiveID, "org", h.Org, "primary_repo", h.PrimaryRepo,
 		"cluster", cluster.ID, "vanity_url", h.VanityURL)
 	return true
+}
+
+// kickVanityURLRepairAsync runs repairVanityURLForHive in the background, at
+// most one attempt per hive at a time.
+//
+// It exists because the repair is only cheap on its NO-OP paths. When it
+// actually has work to do it shells out to kubectl against the hive's cluster
+// (existingVanityHost, then addVanityHostToIngress), and against a cluster the
+// hub cannot reach — vllm-d is heartbeat-only — those calls hang until their
+// TCP dials time out: ~90 seconds per attempt observed live. Called
+// synchronously from handleHeartbeat, that stall pushed every heartbeat
+// response past the spoke's 10s client timeout (heartbeatTimeout), so the
+// claimed-project config the response carried never reached the spoke and
+// fresh assignments on heartbeat-only clusters could never complete (the
+// vllmd-14 / vllmd-13 / EPM wedge).
+//
+// The same cheap guards repairVanityURLForHive starts with run inline here, so
+// the overwhelmingly common no-op case (already has a vanity URL, unclaimed
+// placeholder, incomplete claim, no cluster domain) spawns no goroutine at all.
+func (s *HubServer) kickVanityURLRepairAsync(hiveID string) {
+	h := loadSaaSHive(hiveID)
+	if h == nil || h.Status == statusAvailable || h.VanityURL != "" ||
+		h.Org == "" || h.PrimaryRepo == "" {
+		return
+	}
+	if cluster := s.clusterForHive(h); cluster == nil || cluster.Domain == "" {
+		return
+	}
+	// One in-flight attempt per hive: beats arrive every ~2 min while a failing
+	// attempt can take minutes, and stacking attempts would pile goroutines up
+	// against the same dead cluster for no benefit.
+	if _, inFlight := s.vanityRepairInFlight.LoadOrStore(hiveID, struct{}{}); inFlight {
+		return
+	}
+	go func() {
+		defer s.vanityRepairInFlight.Delete(hiveID)
+		s.repairVanityURLForHive(hiveID)
+	}()
 }
 
 // existingVanityHost returns the host an already-created vanity route/ingress

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -690,8 +690,15 @@ type HubServer struct {
 	// the real addVanityHostToIngress runs; set by tests, which have no cluster to
 	// kubectl to.
 	vanityHostServable func(hiveID, vanityHost string, cluster *ClusterConfig) error
-	heartbeatHealth    map[string]*HeartbeatHealthEntry // cluster ID → latest health from spoke heartbeat
-	heartbeatHealthMu  sync.RWMutex
+	// vanityRepairInFlight tracks hive IDs whose retroactive vanity-URL repair
+	// is currently running in the background (kickVanityURLRepairAsync), so the
+	// heartbeat path starts at most one per hive. On an unreachable cluster a
+	// single repair attempt spends minutes in kubectl dial timeouts while beats
+	// keep arriving every ~2 min; without this guard the attempts pile up
+	// goroutines all hanging against the same dead cluster.
+	vanityRepairInFlight sync.Map                         // hive ID → struct{}
+	heartbeatHealth      map[string]*HeartbeatHealthEntry // cluster ID → latest health from spoke heartbeat
+	heartbeatHealthMu    sync.RWMutex
 
 	// liveHiveUsers maps a GitHub username → the last time any hive reported it as
 	// having a live dashboard session. It powers the "logged into their hive right
@@ -1622,13 +1629,26 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	s.adoptSpokeForge(payload.HiveID, payload.GitHubHost)
 
 	// Retroactively mint the vanity host for a hive CLAIMED BEFORE the vanity
-	// feature existed, also BEFORE building the project config, so the URL-only
-	// push below delivers it on this very beat. VanityURL is otherwise written
-	// only at assign time, so those hives would display and open their raw
-	// placeholder host forever. No-op (and silent) for unclaimed placeholders,
-	// hives that already have a vanity URL, and hives whose vanity host the hub
-	// cannot make servable (heartbeat-only clusters keep their placeholder).
-	s.repairVanityURLForHive(payload.HiveID)
+	// feature existed. VanityURL is otherwise written only at assign time, so
+	// those hives would display and open their raw placeholder host forever.
+	// No-op for unclaimed placeholders and hives that already have a vanity URL.
+	//
+	// ASYNC, deliberately. The repair shells out to kubectl against the hive's
+	// cluster (existingVanityHost, then addVanityHostToIngress), and on a
+	// cluster the hub cannot reach (vllm-d is heartbeat-only/firewalled) each
+	// call blocks until its TCP dial times out — ~90s per beat observed live.
+	// The spoke's heartbeat client gives up after heartbeatTimeout (10s), so
+	// running the repair synchronously here meant EVERY response built below —
+	// including the claimed-project config that is the ONLY channel by which an
+	// assignment can reach a heartbeat-only spoke — was written to a connection
+	// the spoke had already abandoned. The claim never landed, the spoke kept
+	// reporting its placeholder org, and the assignStuckResetTimeout sweep
+	// auto-reset the assignment at 15m, every time (the vllmd-14 wedge; EPM and
+	// vllmd-13 before it). Backgrounding the repair trades the same-beat URL
+	// push (the URL now lands on a later beat, once minted) for a response the
+	// spoke actually receives — and on unreachable clusters the repair never
+	// succeeded anyway.
+	s.kickVanityURLRepairAsync(payload.HiveID)
 
 	if projCfg := projectConfigForHiveID(payload.HiveID, payload.Org, payload.Repos, payload.PrimaryRepo, payload.ACMMLevel, payload.DashboardURL, payload.GitHubAPIURL); projCfg != nil {
 		resp.ProjectConfig = projCfg


### PR DESCRIPTION
## Live symptom

`hosted-available-vllmd-14` (vllm-d, heartbeat-only cluster) assigned to `z-innersource` sat in "Assigning… claim pending" until the 15m `assignStuckResetTimeout` sweep reset it. Recurring class: same wedge previously hit EPM (task #94) and vllmd-13.

## Root cause (with live evidence)

The hub **was** building and "sending" the claim every beat — 90 seconds too late, to a connection the spoke had already abandoned.

- Spoke heartbeats arrive every ~2 min (`audit: hub heartbeat received` at :15.6, spoke still reporting placeholder org `available-vllmd-14`).
- `handleHeartbeat` calls `repairVanityURLForHive` **synchronously** before building the response (`v2/pkg/hub/server.go`). For a claimed hive with an empty `vanity_url` on a cluster the hub cannot kubectl-reach (vllm-d is heartbeat-only/firewalled), its two kubectl calls (`existingVanityHost` → `makeVanityHostServable`/`addVanityHostToIngress`, built with plain `exec.Command`, no context) each hang until TCP dial timeout.
- Hub logs show the smoking gun, three consecutive beats, exactly +90s each:
  - beat 00:09:15.60 → `vanity url repair: host is not servable yet` 00:10:45.818 → `heartbeat: delivering claimed project config to spoke` 00:10:45.819
  - beat 00:11:15.61 → same pair at 00:12:45.8
  - beat 00:13:15 → same pair at 00:14:45.8
  - (also note the vanity host churns a fresh random suffix each attempt: `-cd9o` → `-7wuz` → `-kqzs`)
- The spoke's heartbeat client times out at **10s** (`heartbeatTimeout`, `v2/pkg/hub/heartbeat.go:18`) and drops the connection; the `ProjectConfig` in the response — the ONLY channel that reaches a heartbeat-only spoke — is never received, so the identity-adoption path in `cmd/hive/main.go` never runs, `ClaimDelivered` never latches, and the sweep resets the slot at 15m. Forever.

Not the #2713 forge-set regression: the spoke never receives the payload at all, so no adoption guard is ever exercised. Spoke-side logs are consistent (its `hub heartbeat unreachable` is Debug-level, hence silent).

## Fix

- `kickVanityURLRepairAsync` (new, `v2/pkg/hub/saas_provision.go`): the heartbeat path now kicks the vanity repair in the **background**. Cheap no-op guards run inline so the common case spawns no goroutine; a per-hive in-flight guard (`vanityRepairInFlight` `sync.Map`) stops attempts stacking against a dead cluster while beats keep arriving.
- `repairVanityURLForHive` now **re-loads** the hive record after the potentially minutes-long servability call before saving, so a successful repair can no longer revert fields the heartbeat path latched during that window (`ClaimDelivered`/`ACMMDelivered`/forge handshakes) — a stale load-modify-write hazard that existed even when synchronous.

Trade-off: the vanity URL-only push can land one beat later than the mint (previously same-beat). On unreachable clusters the mint never succeeded anyway.

## Tests

`v2/pkg/hub/heartbeat_vanity_async_test.go`:
- heartbeat response carries the claimed project config promptly while the servability seam is blocked (regression test — hangs with the old synchronous call)
- in-flight dedupe: repeated kicks during a stuck attempt don't stack; a new attempt is allowed after it drains
- inline guards: no-op records spawn no goroutine
- reload-before-save: `ClaimDelivered` latched mid-repair survives the vanity save

## Operational note

vllmd-14 will be auto-reset by the 15m sweep; after this rolls to the hub, the operator should re-assign the slot — the claim should then land on the first beat (<2 min). This also un-dead-letters every other heartbeat response field (upgrades, authorized users, gateways, app config) for claimed vllm-d hives without a vanity URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)