### PR TITLE
feat(audit): record PR merges + advisory-digest posts, add author to audit entries

### DIFF
--- a/v2/pkg/github/advisory.go
+++ b/v2/pkg/github/advisory.go
@@ -81,6 +81,7 @@ func (c *Client) EnsureAdvisoryIssue(ctx context.Context, repo string) (int, err
 	c.recordCreationAudit(AuditActionHiveIssueCreated, meta,
 		"repo", owner+"/"+repo,
 		"number", strconv.Itoa(issue.GetNumber()),
+		"author", issue.GetUser().GetLogin(),
 		"url", issue.GetHTMLURL(),
 		"flow", "advisory")
 
@@ -92,6 +93,12 @@ const (
 	advisoryDigestPrefix    = "## 🐝 Advisory Digest"
 	githubCommentCharLimit  = 65536
 	truncationFooterPadding = 200
+	// advisoryDigestAuditInterval is how often (in digest posts) an
+	// advisory_commented audit entry is emitted, in addition to the very first
+	// post. The digest is refreshed ~once a minute; a value of 50 yields roughly
+	// one audit pulse per ~50 minutes, enough to show the loop is alive without
+	// flooding the dashboard audit log.
+	advisoryDigestAuditInterval = 50
 )
 
 // PostAdvisoryDigest updates the existing digest comment on the advisory issue,
@@ -109,21 +116,45 @@ func (c *Client) PostAdvisoryDigest(ctx context.Context, repo string, issueNum i
 		c.logger.Warn("could not search for existing digest comment, creating new", slog.String("error", err.Error()))
 	}
 
+	var author string
 	if commentID > 0 {
-		_, _, err := c.client.Issues.EditComment(ctx, owner, repoName, int64(commentID), &gh.IssueComment{
+		edited, _, err := c.client.Issues.EditComment(ctx, owner, repoName, int64(commentID), &gh.IssueComment{
 			Body: gh.Ptr(digest),
 		})
 		if err != nil {
 			return fmt.Errorf("updating advisory digest comment on %s#%d: %w", repo, issueNum, err)
 		}
-		return nil
+		author = edited.GetUser().GetLogin()
+	} else {
+		comment, _, err := c.client.Issues.CreateComment(ctx, owner, repoName, issueNum, &gh.IssueComment{
+			Body: gh.Ptr(digest),
+		})
+		if err != nil {
+			return fmt.Errorf("posting advisory digest to %s#%d: %w", repo, issueNum, err)
+		}
+		author = comment.GetUser().GetLogin()
 	}
 
-	_, _, err = c.client.Issues.CreateComment(ctx, owner, repoName, issueNum, &gh.IssueComment{
-		Body: gh.Ptr(digest),
-	})
-	if err != nil {
-		return fmt.Errorf("posting advisory digest to %s#%d: %w", repo, issueNum, err)
+	// Audit the FIRST post and every advisoryDigestAuditInterval-th one, not the
+	// ~once-a-minute refreshes in between: auditing every update would flood the
+	// audit log (1000s/day) and evict the discrete create→merge events. A
+	// periodic pulse still proves the advisory loop is alive on the dashboard.
+	c.advisoryMu.Lock()
+	if c.advisoryDigestPosts == nil {
+		c.advisoryDigestPosts = make(map[string]int)
+	}
+	key := fmt.Sprintf("%s/%s#%d", owner, repoName, issueNum)
+	c.advisoryDigestPosts[key]++
+	count := c.advisoryDigestPosts[key]
+	c.advisoryMu.Unlock()
+
+	if count == 1 || count%advisoryDigestAuditInterval == 0 {
+		c.recordCreationAudit(AuditActionAdvisoryCommented, InvocationMeta{Agent: AttributionAgentGovernor},
+			"repo", owner+"/"+repoName,
+			"number", strconv.Itoa(issueNum),
+			"author", author,
+			"post_count", strconv.Itoa(count),
+			"flow", "advisory-digest")
 	}
 	return nil
 }

--- a/v2/pkg/github/attribution.go
+++ b/v2/pkg/github/attribution.go
@@ -44,6 +44,15 @@ const (
 	// AuditActionHiveIssueCreated is the audit action recorded when the hive
 	// itself creates an issue (advisory issue, ACMM-gap issue).
 	AuditActionHiveIssueCreated = "hive_issue_created"
+	// AuditActionPRMerged is the audit action recorded when the hive merges a
+	// PR as the App bot over REST (MergePR). It closes the create→merge loop on
+	// the dashboard audit log: issue created → PR created → PR merged.
+	AuditActionPRMerged = "pr_merged"
+	// AuditActionAdvisoryCommented is the audit action recorded when the hive
+	// FIRST posts the advisory digest comment on the advisory issue. The digest
+	// is refreshed (EditComment) roughly once a minute; those updates are NOT
+	// audited — only the initial creation, a once-per-issue event.
+	AuditActionAdvisoryCommented = "advisory_commented"
 )
 
 // System "agent" names recorded for creations no single coding agent

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -55,6 +55,14 @@ type Client struct {
 	// the PR-request watcher goroutine may already be reading them.
 	attribMu    sync.RWMutex
 	attribution AttributionHooks
+	// advisoryDigestPosts counts how many times the advisory digest has been
+	// (re)posted per "owner/repo#issue" since this process started. The digest
+	// is refreshed ~once a minute, so PostAdvisoryDigest audits only the 1st
+	// post and every advisoryDigestAuditInterval-th one — a periodic pulse that
+	// proves the loop is alive without flooding the audit log. Guarded by
+	// advisoryMu.
+	advisoryMu          sync.Mutex
+	advisoryDigestPosts map[string]int
 }
 
 // GoGitHub returns the underlying go-github client for direct API access.

--- a/v2/pkg/github/pr_request_watcher.go
+++ b/v2/pkg/github/pr_request_watcher.go
@@ -250,6 +250,7 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 	c.recordCreationAudit(AuditActionAgentPRCreated, meta,
 		"repo", req.Repo,
 		"number", strconv.Itoa(res.Number),
+		"author", res.Author,
 		"url", res.URL,
 		"reused", strconv.FormatBool(res.AlreadyExisted))
 	c.writePRResult(path, resp)

--- a/v2/pkg/github/pullrequest.go
+++ b/v2/pkg/github/pullrequest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 
 	gh "github.com/google/go-github/v72/github"
@@ -13,6 +14,10 @@ import (
 type CreatePRResult struct {
 	Number int
 	URL    string
+	// Author is the login GitHub recorded on the created (or pre-existing) PR —
+	// the App bot the hive relayed as (e.g. "kubestellar-hive[bot]"). Taken from
+	// the API response, not assumed, so the audit log records the true author.
+	Author string
 	// AlreadyExisted is true when an open PR for this head branch was already
 	// present, so we returned it instead of opening a duplicate.
 	AlreadyExisted bool
@@ -60,7 +65,7 @@ func (c *Client) CreatePR(ctx context.Context, repo, head, base, title, body str
 	} else if existing != nil {
 		c.logger.Info("CreatePR: open PR already exists for head, reusing",
 			slog.String("repo", repo), slog.String("head", head), slog.Int("number", existing.GetNumber()))
-		return CreatePRResult{Number: existing.GetNumber(), URL: existing.GetHTMLURL(), AlreadyExisted: true}, nil
+		return CreatePRResult{Number: existing.GetNumber(), URL: existing.GetHTMLURL(), Author: existing.GetUser().GetLogin(), AlreadyExisted: true}, nil
 	}
 
 	pr, _, err := c.client.PullRequests.Create(ctx, owner, repo, &gh.NewPullRequest{
@@ -74,14 +79,14 @@ func (c *Client) CreatePR(ctx context.Context, repo, head, base, title, body str
 		// reuse rather than a hard failure.
 		if strings.Contains(err.Error(), "A pull request already exists") {
 			if existing, lookErr := c.findOpenPRForHead(ctx, owner, repo, head); lookErr == nil && existing != nil {
-				return CreatePRResult{Number: existing.GetNumber(), URL: existing.GetHTMLURL(), AlreadyExisted: true}, nil
+				return CreatePRResult{Number: existing.GetNumber(), URL: existing.GetHTMLURL(), Author: existing.GetUser().GetLogin(), AlreadyExisted: true}, nil
 			}
 		}
 		return CreatePRResult{}, fmt.Errorf("creating PR %s/%s %s->%s: %w", owner, repo, head, base, err)
 	}
 	c.logger.Info("CreatePR: opened PR as the App bot",
 		slog.String("repo", repo), slog.String("head", head), slog.Int("number", pr.GetNumber()))
-	return CreatePRResult{Number: pr.GetNumber(), URL: pr.GetHTMLURL()}, nil
+	return CreatePRResult{Number: pr.GetNumber(), URL: pr.GetHTMLURL(), Author: pr.GetUser().GetLogin()}, nil
 }
 
 // MergePRResult is what MergePR returns after a successful merge.
@@ -134,6 +139,15 @@ func (c *Client) MergePR(ctx context.Context, repo string, number int, mergeMeth
 	c.logger.Info("MergePR: merged PR as the App bot over REST",
 		slog.String("repo", owner+"/"+repo), slog.Int("number", number),
 		slog.String("method", mergeMethod), slog.String("sha", res.GetSHA()))
+	// Audit the merge UNCONDITIONALLY so the dashboard audit log shows the full
+	// create→merge loop. The merge is performed by the hive itself (not a single
+	// coding agent), so it is attributed to the governor flow, mirroring the
+	// hive-issue-created attribution in advisory.go.
+	c.recordCreationAudit(AuditActionPRMerged, InvocationMeta{Agent: AttributionAgentGovernor},
+		"repo", owner+"/"+repo,
+		"number", strconv.Itoa(number),
+		"method", mergeMethod,
+		"sha", res.GetSHA())
 	return MergePRResult{SHA: res.GetSHA(), Merged: res.GetMerged(), Message: res.GetMessage()}, nil
 }
 


### PR DESCRIPTION
## What

Extends the dashboard audit log to cover the full agent loop and record authorship.

Previously the audit log tracked only **issue creation** (`hive_issue_created`) and **PR creation** (`agent_pr_created`). This adds the two missing loop events and author attribution:

- **`pr_merged`** — emitted from `MergePR` after a successful App-bot REST merge. Closes the create→merge loop on the audit log (issue created → PR created → PR merged).
- **`advisory_commented`** — emitted on the **first** advisory-digest post and **every 50th** thereafter (`advisoryDigestAuditInterval`). The digest is refreshed ~once a minute (`EditComment`); auditing every update would flood the log (1000s/day) and evict discrete events, so this is a periodic liveness pulse.
- **`author`** added to `hive_issue_created`, `agent_pr_created`, and `advisory_commented` — taken from the actual API response (`.User.Login`), so the log shows the App bot the hive acted as (e.g. `kubestellar-hive[bot]`), not an assumed value.

## Why

Operators soak-testing v4 want to see issue/PR/merge activity on the dashboard audit surface, with the author, without external tooling.

## How

- `CreatePRResult` gains an `Author` field (populated from the create/reuse API response at all three return sites).
- `Client` gains a per-issue `advisoryDigestPosts` counter (guarded by `advisoryMu`) so `PostAdvisoryDigest` can gate the periodic pulse.
- All three new/updated audit calls flow through the existing `recordCreationAudit` → `attribution.Audit` sink → dashboard audit log (`/data/audit.jsonl` + in-memory ring, surfaced at `handleAuditLog`).

No new dependencies. Audit entries remain unconditional (not gated by the attribution-trailer toggle).