### PR TITLE
fix: forge election is per-hive host, installation_id joins the atomic set (repairs #2713 fleet regression)

### DIFF
--- a/v2/pkg/config/provenance.go
+++ b/v2/pkg/config/provenance.go
@@ -290,6 +290,12 @@ func forgeOfAppID(appID int64) string {
 	return ""
 }
 
+// ForgeOfAppID is the exported form of forgeOfAppID, for callers outside this
+// package (the hub's wrong-forge repair) that need the one reliably populated
+// identity marker — the app_id — mapped to the forge that registered it. Same
+// contract: "" for an unrecognised App ID, and unknown is never a mismatch.
+func ForgeOfAppID(appID int64) string { return forgeOfAppID(appID) }
+
 // slugOfAppID returns the ONE slug a known App ID may carry.
 //
 // A GitHub App's slug is its URL name, fixed at registration — an App has

--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -552,7 +552,7 @@ const (
 	// public pin instead of forcing the cluster GHE app_id.
 	appKeyReasonPublicHiveOnGHECluster = "hive is pinned to public github.com on a GHE-default cluster"
 	// appKeyReasonWrongForgeApp repairs a spoke carrying an App registered on a
-	// DIFFERENT GitHub host than the one the hive actually talks to.
+	// DIFFERENT GitHub host than the one the HIVE ITSELF talks to.
 	//
 	// appKeyReasonDifferentApp protects a deliberate pin, and that protection is
 	// right whenever both Apps live on the same forge — an operator may genuinely
@@ -568,11 +568,15 @@ const (
 	// host. That is exactly how a live GHE hive ended up emitting an install link
 	// for the github.com App slug and 404ing on GitHub Enterprise.
 	//
-	// The discriminator is narrow and evidence-based: the hive is NOT public-pinned
-	// (that case is already handled above and must keep its github.com App), its
-	// cluster declares a GHE base URL, and the spoke's app_id differs from the
-	// cluster's. Under those three conditions the spoke's App cannot be the
-	// cluster's forge's App, so the cluster identity is the only workable one.
+	// The discriminator is narrow, evidence-based and — since the 2026-08-05
+	// fleet regression — PER-HIVE, never per-cluster: the spoke's own reported
+	// app_id names a forge (config.ForgeOfAppID / the fleet's forge-app map)
+	// that is not the forge the HIVE's own recorded host elects. It fires in
+	// BOTH directions: a GHE-host hive whose spoke runs the public App (the EPM
+	// class), and a public-host hive whose spoke was wrongly flipped onto the
+	// GHE App (the alchemy class, mis-flipped by the cluster-keyed guard #2713
+	// shipped). Judging it on the CLUSTER's forge instead is exactly what
+	// force-flipped every github.com project on the vllm-d cluster to app 5686.
 	appKeyReasonWrongForgeApp = "hive carries an app_id registered on a different github host"
 )
 
@@ -637,13 +641,17 @@ const (
 // reconcile finally honouring the same public pin that resolveProvisionAppID and
 // effectiveGitHubBaseURL already honour on the provisioning path.
 //
-// WRONG-FORGE APP — clusterIsGHE carries the one fact this function cannot see
-// for itself: whether the cluster's App lives on a GitHub Enterprise host rather
-// than public github.com. Combined with a non-public-pinned hive whose app_id
-// differs from the cluster's, that proves the spoke's App was issued by a
-// different forge and therefore names nothing on the host this hive uses. See
-// appKeyReasonWrongForgeApp.
-func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned, clusterIsGHE bool, spokeAppID int64, cluster *clusterAppIdentity) appKeySyncDecision {
+// WRONG-FORGE APP — spokeOnWrongForge carries the one fact this function cannot
+// see for itself: that the App the spoke reports was issued by a DIFFERENT forge
+// than the one this HIVE's own recorded host elects (computed by the caller from
+// the spoke's app_id via the app-id→forge map, against the hive's resolved
+// forge). Combined with a non-zero spoke app_id that differs from the identity
+// being delivered, that proves the spoke's App names nothing on the host this
+// hive uses. It is judged on the HIVE's forge, never the cluster's: a cluster
+// hosts hives of BOTH forges (vllm-d carries github.ibm.com projects beside
+// github.com ones), so cluster membership alone proves nothing about any one
+// hive. See appKeyReasonWrongForgeApp.
+func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned, spokeOnWrongForge bool, spokeAppID int64, cluster *clusterAppIdentity) appKeySyncDecision {
 	if cluster == nil {
 		return appKeySyncDecision{Reason: appKeyReasonNoClusterKey, FromFingerprint: spokeFingerprint}
 	}
@@ -696,12 +704,16 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned, 
 	//
 	// Requires a POSITIVE, non-zero app_id disagreement: zero means "too old to
 	// report", and silence is never evidence of a fault (same contract as the
-	// per-hive exception above).
+	// per-hive exception above). spokeOnWrongForge is itself only ever true on
+	// positive evidence — a spoke app_id whose issuing forge is KNOWN and differs
+	// from the forge the hive's own recorded host elects — so an unrecognised
+	// App ID (a third forge, a self-hosted deployment) stays protected as a
+	// deliberate pin.
 	//
 	// Like the sentinel repair this does NOT require the hub to hold the cluster's
 	// key — correcting a cross-forge app_id/app_slug is a non-secret change and is
 	// the whole fix for a hive whose owner has yet to install the App at all.
-	if clusterIsGHE && spokeAppID != 0 && spokeAppID != cluster.AppID {
+	if spokeOnWrongForge && spokeAppID != 0 && spokeAppID != cluster.AppID {
 		return appKeySyncDecision{
 			Push:            true,
 			PushKey:         cluster.HasKey(),
@@ -799,24 +811,57 @@ func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFing
 		hive = hiveOpt[0]
 	}
 	identity := s.appIdentityForHive(hive, clusterID)
-	// Does this cluster's DEFAULT App live on a GitHub Enterprise host? Read from
-	// cluster config, never inferred from the App ID — an App ID is an opaque
-	// number and carries no forge information.
+	// Is the SPOKE running an App from a forge other than the one this HIVE's
+	// own recorded host elects? Judged per-hive, never per-cluster.
 	//
-	// Judged on clusterDefaultForge, NOT on a bare `github_base_url != ""`. The
-	// flat github_base_url is only one of the two shapes a GHE cluster can take:
-	// the 2026-07-31 rework lets a cluster declare `default_forge` +　a `forges`
-	// map and leave the flat URL blank. A flat-only read then reported such a
-	// cluster as PUBLIC, so the wrong-forge app_id repair below (gated on
-	// clusterIsGHE) never fired for it and a spoke stuck on the public app_id
-	// against github.ibm.com stayed broken — the EPM symptom, on the delivery
-	// side. clusterDefaultForge honours default_forge, so a GHE default is
-	// recognised however it is written.
-	clusterIsGHE := false
-	if c, ok := s.clusters[clusterID]; ok {
-		clusterIsGHE = !isPublicForgeHost(clusterDefaultForge(&c))
+	// The 2026-08-05 fleet regression is why this is emphatically NOT
+	// "clusterIsGHE": #2713 shipped this branch keyed on clusterDefaultForge, so
+	// every hive on the GHE-default vllm-d cluster whose spoke reported the
+	// public App — including the github.com projects that cluster also hosts
+	// (ibm/alchemy-logging: org "ibm" lives on public github.com) — was
+	// "repaired" onto app 5686 / github.ibm.com and 404'd on every token mint.
+	// A cluster hosts hives of BOTH forges; cluster membership proves nothing
+	// about any one hive's forge.
+	//
+	// The per-hive signal needs two pieces of POSITIVE evidence:
+	//   - the hive's own forge is known: it recorded a host (electedForgeForHive)
+	//     or it is a CLAIMED hive, whose empty github_host means public
+	//     github.com by the field's own contract. A nil record or an unclaimed
+	//     placeholder yields no evidence and the repair stands down.
+	//   - the spoke's reported app_id maps to a KNOWN forge (forgeOfSpokeAppID)
+	//     that differs from the forge of the identity resolved FOR THIS HIVE.
+	//     An unrecognised App ID is a deliberate pin, not evidence.
+	//
+	// This also gives the repair its REVERSE direction: a public-host hive whose
+	// spoke reports the GHE App (the mis-flipped alchemy class) resolves a
+	// public identity above, its spoke's app_id maps to the GHE forge, and the
+	// same branch flips it back.
+	spokeOnWrongForge := false
+	hiveForgeKnown := false
+	if hive != nil {
+		var cl *ClusterConfig
+		if c, ok := s.clusters[clusterID]; ok {
+			cl = &c
+		}
+		hiveForgeKnown = electedForgeForHive(hive, cl) != "" || hiveClaimed(hive)
 	}
-	decision := decideAppKeySync(spokeFingerprint, hasPerHiveKey, hivePublicPinned, clusterIsGHE, spokeAppID, identity)
+	if hiveForgeKnown && identity != nil && identity.Forge != "" {
+		if spokeForge := s.forgeOfSpokeAppID(spokeAppID); spokeForge != "" && !sameGitHubHost(spokeForge, identity.Forge) {
+			spokeOnWrongForge = true
+		}
+	}
+	// The public pin is honoured BY the per-hive identity now: a public-pinned
+	// hive resolves the PUBLIC App above, so delivering that identity is the pin
+	// being enforced, not violated. Suppressing delivery on the pin (the old
+	// behaviour, from when this path could only answer with the cluster's GHE
+	// App) would leave a public-pinned spoke that was wrongly flipped onto the
+	// GHE App broken forever — the hub would hold the right answer and refuse to
+	// send it. Only a GHE identity may still be suppressed by the pin, and the
+	// per-hive resolver can no longer produce one for a public-pinned hive.
+	if hivePublicPinned && identity != nil && isPublicForgeHost(identity.Forge) {
+		hivePublicPinned = false
+	}
+	decision := decideAppKeySync(spokeFingerprint, hasPerHiveKey, hivePublicPinned, spokeOnWrongForge, spokeAppID, identity)
 	// A spoke carrying the sentinel is broken and must be legible even when the
 	// hub can do nothing about it — that silence is what made this bug cost days
 	// of debugging while the dashboard blamed the installation ID. Logged BEFORE
@@ -922,6 +967,40 @@ func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFing
 		return nil
 	}
 
+	// installation_id IS PART OF THE ATOMIC SET. An installation belongs to ONE
+	// App: whenever the delivered identity CHANGES the spoke's app_id, the old
+	// installation_id is the previous App's and can never mint a token under the
+	// new one — reused, it 404s on POST /app/installations/<id>/access_tokens,
+	// which is exactly how the 2026-08-05 delivery (app swap with the old
+	// installation_id left in place) degraded 9 spokes at 23:56Z. So an
+	// app-changing delivery carries an explicit ResetInstallation: the spoke
+	// drops the stale id, HasUsableApp() goes false, the "Install GitHub App /
+	// Set ID" banner is raised, and the 2-minute self-heal ticker's
+	// RediscoverAndAdopt re-establishes the correct installation for the
+	// delivered App (automatically, when the App is already installed on the
+	// org — the flip-back case, where the old id becomes discoverable again).
+	//
+	// Conservative on silence, as everywhere: a zero spoke app_id (too old to
+	// report) never resets, and the placeholder sentinel never does either —
+	// a sentinel hive's installation_id was entered by its owner FOR the real
+	// App being delivered, not for a previous App, and must be preserved.
+	// When the app_id is UNCHANGED, installation_id is left strictly alone.
+	resetInstallation := spokeAppID != 0 &&
+		spokeAppID != config.PlaceholderAppID &&
+		identity.AppID != spokeAppID
+	deliveredInstallationID := installationID
+	if resetInstallation {
+		deliveredInstallationID = 0
+	}
+	if resetInstallation && logger != nil {
+		logger.Info("heartbeat: delivered app identity changes the spoke's app_id — resetting installation_id with it (atomic set)",
+			"hive_id", hiveID,
+			"cluster_id", clusterID,
+			"spoke_app_id", spokeAppID,
+			"to_app_id", identity.AppID,
+		)
+	}
+
 	// Emit the COMPLETE set. The guard above validated app_id/app_slug against
 	// the forge URLs this hive resolved to; sending the App without those URLs
 	// would ship a set the spoke cannot reassemble, and leave it to be completed
@@ -932,13 +1011,40 @@ func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFing
 	// election resolves to empty URLs, which the spoke reads as "unchanged" —
 	// correct, because empty is also how every healthy public spoke is stored.
 	return &HeartbeatGitHubAppConfig{
-		AppID:          identity.AppID,
-		InstallationID: installationID,
-		PrivateKey:     privateKey,
-		AppSlug:        identity.AppSlug,
-		APIURL:         identity.APIURL,
-		BaseURL:        identity.BaseURL,
+		AppID:             identity.AppID,
+		InstallationID:    deliveredInstallationID,
+		ResetInstallation: resetInstallation,
+		PrivateKey:        privateKey,
+		AppSlug:           identity.AppSlug,
+		APIURL:            identity.APIURL,
+		BaseURL:           identity.BaseURL,
 	}
+}
+
+// forgeOfSpokeAppID maps a spoke-reported app_id to the forge that issued it,
+// or "" when the App is unknown to this hub.
+//
+// Two sources, both positive evidence only: the build's own forge-identity
+// table (config.ForgeOfAppID — the public and known-GHE Apps), then the fleet's
+// cluster configs (forgeAppsAcrossFleet — an App any cluster names on any
+// forge, forge-map shape included). Zero and the placeholder sentinel map to
+// nothing: silence is never evidence.
+func (s *HubServer) forgeOfSpokeAppID(appID int64) string {
+	if appID == 0 || appID == config.PlaceholderAppID {
+		return ""
+	}
+	if f := config.ForgeOfAppID(appID); f != "" {
+		return forgeHostLabel(f)
+	}
+	if s == nil {
+		return ""
+	}
+	for host, app := range s.forgeAppsAcrossFleet() {
+		if app.AppID == appID {
+			return forgeHostLabel(host)
+		}
+	}
+	return ""
 }
 
 // clusterAPIURLForIdentity and clusterBaseURLForIdentity read the cluster's
@@ -1209,6 +1315,14 @@ func (s *HubServer) appKeySyncForHeartbeat(payload *HeartbeatPayload) *Heartbeat
 		if strings.TrimSpace(payload.GitHubAppKeyFingerprint) != "" {
 			s.noteAppKeyConverged(payload.HiveID)
 		}
+		if cfg == nil {
+			// Nothing else to deliver: check for the one fault a converged app
+			// identity can still hide — a stale installation_id left behind by an
+			// app swap that predates the atomic-set rule above (the 2026-08-05
+			// deliveries swapped app_id and left each spoke's old installation_id
+			// in place). See staleInstallationResetForHeartbeat.
+			cfg = s.staleInstallationResetForHeartbeat(payload, sh, clusterID)
+		}
 		return cfg
 	}
 	if !s.allowAppKeyDelivery(payload.HiveID) {
@@ -1219,4 +1333,87 @@ func (s *HubServer) appKeySyncForHeartbeat(payload *HeartbeatPayload) *Heartbeat
 	}
 	s.noteAppKeyDelivered(payload.HiveID)
 	return cfg
+}
+
+// Spoke-reported App auth states this hub acts on. They mirror the stable wire
+// tokens of github.AppAuthState.String() — declared here as named constants so
+// the heartbeat consumers do not depend on a literal typed twice.
+const (
+	// spokeAppStateNotInstalled is what a spoke reports after a 404 from GitHub
+	// on an App endpoint — including POST /app/installations/<id>/access_tokens
+	// with an installation_id that does not belong to the configured App.
+	spokeAppStateNotInstalled = "not-installed"
+	// spokeAppStateWrongInstallation is the spoke's classification when the App
+	// authenticated but the installation resolves to a different account.
+	spokeAppStateWrongInstallation = "wrong-installation"
+)
+
+// staleInstallationResetForHeartbeat repairs the one fault a CONVERGED App
+// identity can still hide: an installation_id that belongs to a PREVIOUS App.
+//
+// An installation is issued for exactly one App. A delivery that swaps a
+// spoke's app_id while leaving its installation_id in place (what the
+// 2026-08-05 forge deliveries did, before installation_id joined the atomic
+// set) leaves a spoke whose every field looks coherent — app_id, slug, urls all
+// name one forge — while every token mint dies with
+// "POST .../app/installations/<id>/access_tokens: 404 Not Found". On later
+// beats the app_id matches what the hub would deliver, so the ordinary
+// reconcile sees nothing to do, and the spoke stays degraded forever.
+//
+// This is the standing, automatic form of the operator's "Reset App" button
+// (handleResetApp / RequestedAppReset), gated on POSITIVE evidence only:
+//
+//   - the spoke reports a NON-ZERO installation_id (zero would make the reset a
+//     no-op, and is also the read-back that stops re-delivery — idempotence),
+//   - the spoke's own app_id MATCHES the identity the hub resolves for this
+//     hive (the app is converged; the installation is the last stale piece —
+//     an app-id mismatch is the wrong-forge/mismatch repair's job, which now
+//     carries its own reset),
+//   - the spoke POSITIVELY reports failing App auth: github_app_required is
+//     raised AND its classified state is not-installed / wrong-installation —
+//     the two classifications a stale installation produces (404 / wrong
+//     account). A healthy spoke clears the flag on its next successful write,
+//     and silence (an old spoke reporting neither field) never triggers.
+//   - the hive is CLAIMED and no operator flow owns the field: an armed
+//     RequestedAppReset already delivers this, and an in-flight forge switch
+//     (RequestedGitHubHost) owns the whole identity.
+//
+// Clearing the installation makes HasUsableApp() false on the spoke, raising
+// the "Install GitHub App / Set ID" banner and starting the RediscoverAndAdopt
+// self-heal ticker, which adopts the correct installation automatically when
+// the delivered App is already installed on the org.
+func (s *HubServer) staleInstallationResetForHeartbeat(payload *HeartbeatPayload, sh *SaaSHive, clusterID string) *HeartbeatGitHubAppConfig {
+	if s == nil || payload == nil {
+		return nil
+	}
+	if payload.GitHubInstallationID == 0 || payload.GitHubAppID == 0 {
+		return nil
+	}
+	if !hiveClaimed(sh) {
+		return nil
+	}
+	if sh.RequestedAppReset || sh.RequestedGitHubHost != "" {
+		return nil // an operator flow owns this field right now
+	}
+	if !payload.GitHubAppRequired {
+		return nil
+	}
+	state := strings.TrimSpace(payload.GitHubAppState)
+	if state != spokeAppStateNotInstalled && state != spokeAppStateWrongInstallation {
+		return nil
+	}
+	identity := s.appIdentityForHive(sh, clusterID)
+	if identity == nil || identity.AppID == 0 || identity.AppID != payload.GitHubAppID {
+		return nil // not converged on the hub's answer — other repairs own this
+	}
+	if s.logger != nil {
+		s.logger.Warn("heartbeat: spoke's app identity is converged but its installation_id cannot mint tokens — resetting it so the install/rediscover flow re-establishes it",
+			"hive_id", payload.HiveID,
+			"cluster_id", clusterID,
+			"app_id", payload.GitHubAppID,
+			"stale_installation_id", payload.GitHubInstallationID,
+			"spoke_app_state", state,
+		)
+	}
+	return &HeartbeatGitHubAppConfig{ResetInstallation: true}
 }

--- a/v2/pkg/hub/ghe_forge_map_shape_test.go
+++ b/v2/pkg/hub/ghe_forge_map_shape_test.go
@@ -90,6 +90,43 @@ func TestResolveHiveIdentityForgeMapShape(t *testing.T) {
 			t.Errorf("AppID = %d, want 0 — this cluster names no public App to hand out", got.AppID)
 		}
 	})
+
+	// FORGE IS PER-HIVE (the 2026-08-05 regression). A CLAIMED hive that records
+	// no host means public github.com — the field's documented meaning — and
+	// must NOT inherit its cluster's GHE forge: vllm-d hosts github.com projects
+	// (ibm/alchemy-logging) beside its github.ibm.com ones.
+	t.Run("a CLAIMED hive with no recorded host is public, even on the GHE cluster (alchemy)", func(t *testing.T) {
+		got := ResolveHiveIdentity(&SaaSHive{
+			ID: "alchemy", Status: statusAssigned, Org: "ibm",
+		}, cluster)
+		if !sameGitHubHost(got.Forge, publicForgeHost) {
+			t.Fatalf("Forge = %q, want public — a claimed hive's empty github_host means github.com, never the cluster's forge", got.Forge)
+		}
+		if got.AppID == testGHEAppID {
+			t.Errorf("a claimed blank-host hive was handed the GHE App %d — the exact flip that degraded 9 spokes", testGHEAppID)
+		}
+		// The public election must carry EXPLICIT public urls so a spoke wrongly
+		// sitting on GHE urls is moved off them (empty would mean "unchanged").
+		if got.APIURL != config.DefaultGitHubAPIURL || got.BaseURL != config.DefaultGitHubBaseURL {
+			t.Errorf("public election urls = api=%q base=%q, want explicit public urls", got.APIURL, got.BaseURL)
+		}
+	})
+
+	t.Run("a CLAIMED hive recording github.com stays public on the GHE cluster", func(t *testing.T) {
+		got := ResolveHiveIdentity(&SaaSHive{
+			ID: "alchemy-explicit", Status: statusAssigned, Org: "ibm", GitHubHost: publicForgeHost,
+		}, cluster)
+		if !sameGitHubHost(got.Forge, publicForgeHost) || got.AppID == testGHEAppID {
+			t.Errorf("got forge=%q app=%d — an explicit github.com host must never be overridden by the cluster", got.Forge, got.AppID)
+		}
+	})
+
+	t.Run("an UNCLAIMED placeholder still inherits the cluster default", func(t *testing.T) {
+		got := ResolveHiveIdentity(&SaaSHive{ID: "pool-1", Status: statusAvailable}, cluster)
+		if got.AppID != testGHEAppID || !sameGitHubHost(got.Forge, identGHEHost) {
+			t.Errorf("got app=%d forge=%q, want the cluster default — the placeholder pool serves the cluster's forge", got.AppID, got.Forge)
+		}
+	})
 }
 
 // TestBackfillGitHubHostForgeMapShape proves the assign/approve-time backfill
@@ -111,139 +148,285 @@ func TestBackfillGitHubHostForgeMapShape(t *testing.T) {
 	}
 }
 
-// TestGuardGHEHiveNotOnPublicForge exercises the never-blank-for-GHE guard: a
-// claimed GHE-cluster hive that is POSITIVELY reporting the public github.com
-// forge is repaired by re-recording the cluster's GHE host, while every
-// legitimate public case is left untouched.
-func TestGuardGHEHiveNotOnPublicForge(t *testing.T) {
+// TestNoClusterKeyedForgeFlip pins the 2026-08-05 regression closed: a CLAIMED
+// hive on a GHE-default cluster whose spoke reports the public forge must NEVER
+// have its github_host rewritten to the cluster's forge, and must never be
+// delivered the GHE App — unless its OWN recorded host is the GHE host. The
+// vllm-d cluster hosts github.com projects (ibm/alchemy-logging) beside its
+// github.ibm.com ones; cluster membership proves nothing about one hive.
+func TestNoClusterKeyedForgeFlip(t *testing.T) {
+	withTempAppKeyDir(t)
 	oldHives := saasHivesDir
 	saasHivesDir = t.TempDir()
 	t.Cleanup(func() { saasHivesDir = oldHives })
+	storeKeyFor(t, "vllm-d")
 
 	newHub := func() *HubServer {
 		return &HubServer{
 			logger: slog.New(slog.NewTextHandler(nopWriter{}, nil)),
 			clusters: map[string]ClusterConfig{
 				"hive-oke": *hiveOKECluster(),
-				// The GHE cluster in the forge-map shape — the shape that hid the bug.
-				"vllm-d": *vllmDForgeMapCluster(),
+				"vllm-d":   *vllmDForgeMapCluster(),
 			},
 		}
 	}
 
-	// A spoke report that names the public forge with the public app_id.
+	// A healthy github.com spoke: public forge, public App.
 	publicReport := func(id string) *HeartbeatPayload {
 		return &HeartbeatPayload{
 			HiveID:       id,
+			ClusterID:    "vllm-d",
 			GitHubAPIURL: "", // blank api_url = api.github.com
 			GitHubAppID:  config.PublicGitHubAppID,
 		}
 	}
 
-	run := func(t *testing.T, hive *SaaSHive, payload *HeartbeatPayload) (bool, string) {
-		t.Helper()
-		if err := saveSaaSHive(hive); err != nil {
+	for _, hive := range []*SaaSHive{
+		// The alchemy class: claimed for a github.com org, host recorded public.
+		{ID: "alchemy-explicit", Status: statusAssigned, ClusterID: "vllm-d", Org: "ibm", GitHubHost: "github.com"},
+		// Same class, host never recorded — empty means public github.com.
+		{ID: "alchemy-blank", Status: statusAssigned, ClusterID: "vllm-d", Org: "ibm", GitHubHost: ""},
+	} {
+		t.Run(hive.ID, func(t *testing.T) {
+			if err := saveSaaSHive(hive); err != nil {
+				t.Fatal(err)
+			}
+			s := newHub()
+			payload := publicReport(hive.ID)
+
+			// The full heartbeat repair surface must leave the record alone…
+			s.reconcileGitHubHostFromSpoke(payload)
+			s.repairMisflippedForgeFromRequest(payload)
+			if got := loadSaaSHive(hive.ID); got == nil || got.GitHubHost != hive.GitHubHost {
+				t.Fatalf("github_host was rewritten to %q — the cluster-keyed flip is back", got.GitHubHost)
+			}
+			// …and the identity delivery must not hand it the GHE App.
+			if cfg := s.appKeySyncForHeartbeat(payload); cfg != nil && cfg.AppID == testGHEAppID {
+				t.Fatalf("a github.com project on the GHE cluster was delivered the GHE App %d — the exact 9-spoke regression", testGHEAppID)
+			}
+		})
+	}
+
+	t.Run("REVERSE: a public-host hive whose spoke was flipped onto the GHE App is delivered its public identity back", func(t *testing.T) {
+		if err := saveSaaSHive(&SaaSHive{
+			ID: "alchemy-flipped", Status: statusAssigned, ClusterID: "vllm-d",
+			Org: "ibm", GitHubHost: publicForgeHost,
+		}); err != nil {
 			t.Fatal(err)
 		}
 		s := newHub()
-		changed := s.guardGHEHiveNotOnPublicForge(payload)
+		// The 23:56Z state: the spoke adopted app 5686 + GHE urls, but kept its
+		// old PUBLIC installation_id — which 404s under the GHE App.
+		cfg := s.appKeySyncForHeartbeat(&HeartbeatPayload{
+			HiveID:               "alchemy-flipped",
+			ClusterID:            "vllm-d",
+			GitHubAPIURL:         identGHEAPIURL,
+			GitHubBaseURL:        identGHEBaseURL,
+			GitHubAppID:          testGHEAppID,
+			GitHubInstallationID: 146551814,
+		})
+		if cfg == nil || cfg.AppID != testPublicAppID {
+			t.Fatalf("the mis-flipped spoke must be delivered its public App back, got %+v", cfg)
+		}
+		// EXPLICIT public urls: the spoke sits on GHE urls, and empty means
+		// "unchanged" on the wire — the set would half-apply and be refused.
+		if cfg.APIURL != config.DefaultGitHubAPIURL || cfg.BaseURL != config.DefaultGitHubBaseURL {
+			t.Errorf("public restore urls = api=%q base=%q, want explicit public urls", cfg.APIURL, cfg.BaseURL)
+		}
+		// The app_id changes (GHE -> public), so the installation resets with it;
+		// RediscoverAndAdopt then re-adopts the old public installation, which is
+		// valid again under app %d.
+		if !cfg.ResetInstallation || cfg.InstallationID != 0 {
+			t.Errorf("reverse delivery must reset installation_id (got reset=%v id=%d)", cfg.ResetInstallation, cfg.InstallationID)
+		}
+	})
+
+	t.Run("a GHE-host hive whose spoke runs public IS still repaired (EPM, delivery-side)", func(t *testing.T) {
+		if err := saveSaaSHive(&SaaSHive{
+			ID: "epm", Status: statusAssigned, ClusterID: "vllm-d", Org: "epm", GitHubHost: identGHEHost,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		s := newHub()
+		cfg := s.appKeySyncForHeartbeat(publicReport("epm"))
+		if cfg == nil || cfg.AppID != testGHEAppID {
+			t.Fatalf("a hive whose OWN host is GHE must still be moved off the public App, got %+v", cfg)
+		}
+		// The app_id changes, so the stale public installation_id must be reset
+		// with it — it belongs to the previous App and would 404 under this one.
+		if !cfg.ResetInstallation || cfg.InstallationID != 0 {
+			t.Errorf("app-changing delivery must reset installation_id (got reset=%v id=%d)", cfg.ResetInstallation, cfg.InstallationID)
+		}
+	})
+}
+
+// TestRepairMisflippedForgeFromRequest exercises the restore for records the
+// removed cluster-keyed guard STOMPED: hub meta and spoke both say GHE, the
+// spoke is failing auth on it, and the hive's own provision request records
+// public github.com — the one surviving record of the org's real host.
+func TestRepairMisflippedForgeFromRequest(t *testing.T) {
+	oldHives := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = oldHives })
+	oldReqs := provisionRequestsDir
+	provisionRequestsDir = t.TempDir()
+	t.Cleanup(func() { provisionRequestsDir = oldReqs })
+
+	newHub := func() *HubServer {
+		return &HubServer{
+			logger:   slog.New(slog.NewTextHandler(nopWriter{}, nil)),
+			clusters: map[string]ClusterConfig{"vllm-d": *vllmDForgeMapCluster()},
+		}
+	}
+
+	// The mis-flipped state: meta stomped to GHE, spoke adopted the GHE forge
+	// and is dying on it (404 on token mint -> not-installed + banner).
+	misflipped := func(id string) *SaaSHive {
+		return &SaaSHive{
+			ID: id, Status: statusAssigned, ClusterID: "vllm-d",
+			Owner: "alchemist", Org: "ibm", GitHubHost: identGHEHost,
+		}
+	}
+	brokenGHEReport := func(id string) *HeartbeatPayload {
+		return &HeartbeatPayload{
+			HiveID:            id,
+			ClusterID:         "vllm-d",
+			GitHubAPIURL:      identGHEAPIURL,
+			GitHubBaseURL:     identGHEBaseURL,
+			GitHubAppID:       testGHEAppID,
+			GitHubAppRequired: true,
+			GitHubAppState:    spokeAppStateNotInstalled,
+		}
+	}
+	publicRequest := func(id string) *ProvisionRequest {
+		return &ProvisionRequest{
+			Username: "alchemist", Org: "ibm", GitHubHost: githubHostPublic,
+			Status: provisionStatusApproved, AssignedHive: id,
+		}
+	}
+
+	run := func(t *testing.T, h *SaaSHive, req *ProvisionRequest, payload *HeartbeatPayload) (bool, string) {
+		t.Helper()
+		if err := saveSaaSHive(h); err != nil {
+			t.Fatal(err)
+		}
+		if req != nil {
+			if err := saveProvisionRequest(req); err != nil {
+				t.Fatal(err)
+			}
+		}
+		changed := newHub().repairMisflippedForgeFromRequest(payload)
 		got := ""
-		if reloaded := loadSaaSHive(hive.ID); reloaded != nil {
+		if reloaded := loadSaaSHive(h.ID); reloaded != nil {
 			got = reloaded.GitHubHost
 		}
 		return changed, got
 	}
 
-	t.Run("claimed GHE hive running public is repaired to the GHE host", func(t *testing.T) {
-		changed, got := run(t,
-			&SaaSHive{ID: "epm-blank", Status: statusAssigned, ClusterID: "vllm-d", Org: "epm", GitHubHost: ""},
-			publicReport("epm-blank"),
-		)
-		if !changed || got != identGHEHost {
-			t.Errorf("got (changed=%v, host=%q), want (true, %s)", changed, got, identGHEHost)
+	t.Run("the mis-flipped alchemy hive is restored to public", func(t *testing.T) {
+		changed, got := run(t, misflipped("flip-1"), publicRequest("flip-1"), brokenGHEReport("flip-1"))
+		if !changed || got != publicForgeHost {
+			t.Fatalf("got (changed=%v, host=%q), want (true, %s)", changed, got, publicForgeHost)
 		}
 	})
 
-	t.Run("a persisted-but-public github_host on a GHE cluster is repaired", func(t *testing.T) {
-		changed, got := run(t,
-			&SaaSHive{ID: "epm-public", Status: statusAssigned, ClusterID: "vllm-d", Org: "epm", GitHubHost: "github.com"},
-			publicReport("epm-public"),
-		)
-		if !changed || got != identGHEHost {
-			t.Errorf("got (changed=%v, host=%q), want (true, %s)", changed, got, identGHEHost)
-		}
-	})
-
-	t.Run("an explicit public pin is never repaired", func(t *testing.T) {
-		changed, got := run(t,
-			&SaaSHive{ID: "pinned", Status: statusAssigned, ClusterID: "vllm-d", GitHubBaseURL: githubHostPublic, GitHubHost: "github.com"},
-			publicReport("pinned"),
-		)
-		if changed || got != "github.com" {
-			t.Errorf("got (changed=%v, host=%q), want (false, github.com) — a public pin is a decision", changed, got)
-		}
-	})
-
-	t.Run("a GHE hive already recording the GHE host is a no-op (spoke just not converged)", func(t *testing.T) {
-		changed, got := run(t,
-			&SaaSHive{ID: "converging", Status: statusAssigned, ClusterID: "vllm-d", GitHubHost: identGHEHost},
-			publicReport("converging"),
-		)
+	t.Run("a request naming the GHE host restores nothing (genuine GHE hive)", func(t *testing.T) {
+		req := publicRequest("flip-2")
+		req.GitHubHost = identGHEHost
+		changed, got := run(t, misflipped("flip-2"), req, brokenGHEReport("flip-2"))
 		if changed || got != identGHEHost {
-			t.Errorf("got (changed=%v, host=%q), want (false, %s)", changed, got, identGHEHost)
+			t.Errorf("got (changed=%v, host=%q) — a GHE request must keep its GHE host", changed, got)
 		}
 	})
 
-	t.Run("an in-flight forge switch is never raced", func(t *testing.T) {
-		changed, got := run(t,
-			&SaaSHive{ID: "switching", Status: statusAssigned, ClusterID: "vllm-d", GitHubHost: "github.com", RequestedGitHubHost: identGHEHost},
-			publicReport("switching"),
-		)
-		if changed || got != "github.com" {
-			t.Errorf("got (changed=%v, host=%q), want (false, github.com) — the switch owns the host", changed, got)
+	t.Run("a silent (pre-host-field) request is UNKNOWN, never evidence", func(t *testing.T) {
+		req := publicRequest("flip-3")
+		req.GitHubHost = ""
+		changed, got := run(t, misflipped("flip-3"), req, brokenGHEReport("flip-3"))
+		if changed || got != identGHEHost {
+			t.Errorf("got (changed=%v, host=%q) — silence must not flip a hive public", changed, got)
 		}
 	})
 
-	t.Run("a public-cluster hive running public is correct and untouched", func(t *testing.T) {
-		changed, got := run(t,
-			&SaaSHive{ID: "console", Status: statusAssigned, ClusterID: "hive-oke", GitHubHost: ""},
-			publicReport("console"),
-		)
-		if changed || got != "" {
-			t.Errorf("got (changed=%v, host=%q), want (false, \"\") — public cluster running public is fine", changed, got)
+	t.Run("a HEALTHY spoke on GHE is never touched, whatever the paperwork says", func(t *testing.T) {
+		payload := brokenGHEReport("flip-4")
+		payload.GitHubAppRequired = false
+		payload.GitHubAppState = ""
+		changed, got := run(t, misflipped("flip-4"), publicRequest("flip-4"), payload)
+		if changed || got != identGHEHost {
+			t.Errorf("got (changed=%v, host=%q) — a working hive must not be flipped", changed, got)
 		}
 	})
 
-	t.Run("an unclaimed placeholder is skipped", func(t *testing.T) {
-		changed, got := run(t,
-			&SaaSHive{ID: "placeholder", Status: statusAvailable, ClusterID: "vllm-d", GitHubHost: ""},
-			publicReport("placeholder"),
-		)
-		if changed || got != "" {
-			t.Errorf("got (changed=%v, host=%q), want (false, \"\") — assign owns a placeholder", changed, got)
+	t.Run("an operator forge switch outranks the request record", func(t *testing.T) {
+		h := misflipped("flip-5")
+		h.ForgeDelivered = true // a completed deliberate switch to GHE
+		changed, got := run(t, h, publicRequest("flip-5"), brokenGHEReport("flip-5"))
+		if changed || got != identGHEHost {
+			t.Errorf("got (changed=%v, host=%q) — a completed switch is a decision", changed, got)
 		}
 	})
 
-	t.Run("a spoke too old to report (no app_id) is UNKNOWN, never a fault", func(t *testing.T) {
-		changed, got := run(t,
-			&SaaSHive{ID: "old-spoke", Status: statusAssigned, ClusterID: "vllm-d", GitHubHost: ""},
-			&HeartbeatPayload{HiveID: "old-spoke"}, // no api_url, no app_id
-		)
-		if changed || got != "" {
-			t.Errorf("got (changed=%v, host=%q), want (false, \"\") — silence is not evidence", changed, got)
+	t.Run("a request assigned to a DIFFERENT hive is no authority", func(t *testing.T) {
+		req := publicRequest("some-other-hive")
+		changed, got := run(t, misflipped("flip-6"), req, brokenGHEReport("flip-6"))
+		if changed || got != identGHEHost {
+			t.Errorf("got (changed=%v, host=%q) — another hive's request proves nothing here", changed, got)
 		}
 	})
 
 	t.Run("nil payload / nil server are safe", func(t *testing.T) {
 		s := newHub()
-		if s.guardGHEHiveNotOnPublicForge(nil) {
+		if s.repairMisflippedForgeFromRequest(nil) {
 			t.Error("nil payload must be a no-op")
 		}
 		var nilServer *HubServer
-		if nilServer.guardGHEHiveNotOnPublicForge(&HeartbeatPayload{HiveID: "x"}) {
+		if nilServer.repairMisflippedForgeFromRequest(&HeartbeatPayload{HiveID: "x"}) {
 			t.Error("nil server must be a no-op")
 		}
 	})
+}
+
+// TestBrokenSpokeForgeReportNotAdopted pins the reconcile stand-down: a spoke
+// FAILING App auth on the GHE forge it reports must not have that forge adopted
+// into the hive record — adopting it would launder a mis-delivery into meta and
+// fight the restore above.
+func TestBrokenSpokeForgeReportNotAdopted(t *testing.T) {
+	oldHives := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = oldHives })
+
+	s := &HubServer{
+		logger:   slog.New(slog.NewTextHandler(nopWriter{}, nil)),
+		clusters: map[string]ClusterConfig{"vllm-d": *vllmDForgeMapCluster()},
+	}
+	if err := saveSaaSHive(&SaaSHive{
+		ID: "restored", Status: statusAssigned, ClusterID: "vllm-d",
+		Owner: "alchemist", Org: "ibm", GitHubHost: publicForgeHost,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	payload := &HeartbeatPayload{
+		HiveID:            "restored",
+		ClusterID:         "vllm-d",
+		GitHubHost:        identGHEHost,
+		GitHubAPIURL:      identGHEAPIURL,
+		GitHubAppID:       testGHEAppID,
+		GitHubAppRequired: true,
+		GitHubAppState:    spokeAppStateNotInstalled,
+	}
+	if s.reconcileGitHubHostFromSpoke(payload) {
+		t.Fatal("a failing spoke's forge report was adopted — the restore would be undone on the next beat")
+	}
+	if h := loadSaaSHive("restored"); h == nil || h.GitHubHost != publicForgeHost {
+		t.Fatalf("github_host = %q, want %q", h.GitHubHost, publicForgeHost)
+	}
+	// The same report from a HEALTHY spoke still repairs public→GHE (vllmd-06).
+	payload.GitHubAppRequired = false
+	payload.GitHubAppState = ""
+	if !s.reconcileGitHubHostFromSpoke(payload) {
+		t.Fatal("a healthy spoke's positive GHE report must still be adopted (the vllmd-06 repair)")
+	}
 }
 
 // TestGHEClaimDeliversCompleteAtomicSet proves the heartbeat App-config path
@@ -301,6 +484,51 @@ func TestGHEClaimDeliversCompleteAtomicSet(t *testing.T) {
 	}); err != nil {
 		t.Errorf("delivered a half-identity: %v", err)
 	}
+	// installation_id is PART of the atomic set: the delivery changes the app_id
+	// (public -> GHE), so the spoke's public installation_id — valid only under
+	// the public App — must be reset with it, never retained to 404 on
+	// /app/installations/<id>/access_tokens.
+	if !cfg.ResetInstallation {
+		t.Error("app-changing delivery did not reset installation_id — the 2026-08-05 9-spoke 404")
+	}
+	if cfg.InstallationID != 0 {
+		t.Errorf("app-changing delivery carried installation_id %d, want 0", cfg.InstallationID)
+	}
+}
+
+// TestSameAppDeliveryPreservesInstallation is the other half of the atomic-set
+// rule: a delivery that does NOT change the spoke's app_id (a key-only repair)
+// must leave installation_id strictly alone.
+func TestSameAppDeliveryPreservesInstallation(t *testing.T) {
+	withTempAppKeyDir(t)
+	oldHives := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = oldHives })
+	storeKeyFor(t, "vllm-d")
+
+	s := &HubServer{
+		logger:   appKeyTestLogger(),
+		clusters: map[string]ClusterConfig{"vllm-d": *vllmDForgeMapCluster()},
+	}
+	if err := saveSaaSHive(&SaaSHive{
+		ID: "ghe-keyless", Status: statusAssigned, ClusterID: "vllm-d",
+		Org: "epm", GitHubHost: identGHEHost,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// The spoke already runs the RIGHT App but holds no key: a key-only push.
+	cfg := s.appKeySyncForHeartbeat(&HeartbeatPayload{
+		HiveID:               "ghe-keyless",
+		ClusterID:            "vllm-d",
+		GitHubAppID:          testGHEAppID,
+		GitHubInstallationID: 12345,
+	})
+	if cfg == nil {
+		t.Fatal("expected a key delivery for a keyless spoke")
+	}
+	if cfg.ResetInstallation {
+		t.Error("a same-app delivery reset installation_id — a key-only fault must never clear a working installation")
+	}
 }
 
 // TestPublicHiveStillFineWithBlankForge is the don't-break-public guard: a
@@ -341,9 +569,77 @@ func TestPublicHiveStillFineWithBlankForge(t *testing.T) {
 		t.Errorf("a converged public hive was pushed a forge change: app_id=%d api_url=%q base_url=%q — blank must stay blank",
 			cfg.AppID, cfg.APIURL, cfg.BaseURL)
 	}
-	// And the guard must never fire on it.
-	if s.guardGHEHiveNotOnPublicForge(payload) {
-		t.Error("the never-blank-for-GHE guard fired on a legitimate public hive")
+	// And no repair may touch its record.
+	if s.repairMisflippedForgeFromRequest(payload) {
+		t.Error("the mis-flip restore fired on a legitimate public hive")
+	}
+}
+
+// TestStaleInstallationReset covers the self-heal for the genuine-GHE half of
+// the 2026-08-05 fleet: spokes whose app identity is fully converged on the GHE
+// App but whose installation_id still belongs to the PREVIOUS (public) App —
+// the pre-atomic-set deliveries swapped app_id and left the old id in place, so
+// every token mint 404s while every config field looks right.
+func TestStaleInstallationReset(t *testing.T) {
+	withTempAppKeyDir(t)
+	oldHives := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = oldHives })
+
+	s := &HubServer{
+		logger:   appKeyTestLogger(),
+		clusters: map[string]ClusterConfig{"vllm-d": *vllmDForgeMapCluster()},
+	}
+	if err := saveSaaSHive(&SaaSHive{
+		ID: "certus", Status: statusAssigned, ClusterID: "vllm-d",
+		Org: "certus", GitHubHost: identGHEHost,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	broken := func() *HeartbeatPayload {
+		return &HeartbeatPayload{
+			HiveID:               "certus",
+			ClusterID:            "vllm-d",
+			GitHubAPIURL:         identGHEAPIURL,
+			GitHubBaseURL:        identGHEBaseURL,
+			GitHubAppID:          testGHEAppID, // converged on the hub's own answer
+			GitHubInstallationID: 146551814,    // the old PUBLIC App's installation
+			GitHubAppRequired:    true,
+			GitHubAppState:       spokeAppStateNotInstalled, // 404 on token mint
+		}
+	}
+
+	cfg := s.appKeySyncForHeartbeat(broken())
+	if cfg == nil || !cfg.ResetInstallation {
+		t.Fatalf("converged-app + failing-auth + stale installation must deliver a reset, got %+v", cfg)
+	}
+	if cfg.AppID != 0 || cfg.PrivateKey != "" {
+		t.Errorf("the reset must ride bare — app identity is already correct (got app_id=%d has_key=%v)", cfg.AppID, cfg.PrivateKey != "")
+	}
+
+	// Read-back idempotence: once the spoke reports installation 0, nothing more.
+	confirmed := broken()
+	confirmed.GitHubInstallationID = 0
+	if cfg := s.appKeySyncForHeartbeat(confirmed); cfg != nil && cfg.ResetInstallation {
+		t.Error("reset re-delivered after the spoke confirmed installation 0")
+	}
+
+	// A HEALTHY converged spoke is never reset, whatever id it holds.
+	healthy := broken()
+	healthy.GitHubAppRequired = false
+	healthy.GitHubAppState = ""
+	if cfg := s.appKeySyncForHeartbeat(healthy); cfg != nil && cfg.ResetInstallation {
+		t.Error("a healthy spoke's installation was reset — positive failure evidence is required")
+	}
+
+	// An operator-armed reset outranks this path (delivered elsewhere).
+	h := loadSaaSHive("certus")
+	h.RequestedAppReset = true
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+	if cfg := s.appKeySyncForHeartbeat(broken()); cfg != nil && cfg.ResetInstallation {
+		t.Error("automatic reset fired while an operator reset owns the field")
 	}
 }
 

--- a/v2/pkg/hub/github_host_assignment_test.go
+++ b/v2/pkg/hub/github_host_assignment_test.go
@@ -195,76 +195,51 @@ func TestApprovePrefersRequestGitHubHost(t *testing.T) {
 	}
 }
 
-// TestRepairGitHubHostsFromClusters covers the retroactive repair: it fixes an
-// already-assigned hive with a blank host on a GHE cluster, refuses to touch an
-// explicit host, an explicit public override, a public cluster, or an unclaimed
-// placeholder — and is idempotent on a second run.
-func TestRepairGitHubHostsFromClusters(t *testing.T) {
+// TestNoPerBeatClusterHostFill pins the removal of the per-beat
+// blank-host-from-cluster fill. FORGE IS PER-HIVE: a claimed hive's empty
+// github_host means public github.com (the field's documented meaning), and a
+// GHE cluster hosts github.com projects beside its GHE ones — so nothing on the
+// heartbeat path may materialise the CLUSTER's forge into a hive's record. The
+// only remaining github_host writers are claim-time recording (assign/approve,
+// covered above), a HEALTHY spoke's own positive report
+// (reconcileGitHubHostFromSpoke), and the mis-flip restore
+// (repairMisflippedForgeFromRequest).
+func TestNoPerBeatClusterHostFill(t *testing.T) {
 	useTempHiveDir(t)
 	s := newGHETestHub()
 
-	seed := []*SaaSHive{
-		// The vllm-d case: assigned, blank host, GHE cluster.
-		{ID: "hosted-blank-ghe", Owner: "taylormgeorge91", Org: "katamari",
-			Repos: []string{"ibm-aiops-orchestrator"}, PrimaryRepo: "ibm-aiops-orchestrator",
-			ACMMLevel: 2, ClusterID: defaultClusterID},
-		// Explicitly set to a DIFFERENT host — must never be clobbered.
-		{ID: "hosted-explicit", Owner: "a", Org: "o", GitHubHost: "github.explicit.com",
-			Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 1, ClusterID: defaultClusterID},
-		// Explicit public override on a GHE cluster — must stay public.
-		{ID: "hosted-public-override", Owner: "a", Org: "o", GitHubBaseURL: githubHostPublic,
-			Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 1, ClusterID: defaultClusterID},
-		// Public cluster — nothing to record.
-		{ID: "hosted-public-cluster", Owner: "a", Org: "o",
-			Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 1, ClusterID: "public-cluster"},
-		// Unclaimed placeholder — assign owns it, repair must skip it.
-		{ID: "hosted-available-x", Owner: hubAdminUsername, Status: statusAvailable,
-			ClusterID: defaultClusterID},
-	}
-	for _, h := range seed {
-		if err := saveSaaSHive(h); err != nil {
-			t.Fatal(err)
-		}
+	// A claimed hive with a blank host on the GHE cluster — the shape the old
+	// per-beat fill rewrote to the cluster forge, flipping github.com projects.
+	h := &SaaSHive{ID: "hosted-blank", Owner: "a", Org: "ibm", Status: statusAssigned,
+		Repos: []string{"alchemy-logging"}, PrimaryRepo: "alchemy-logging",
+		ACMMLevel: 2, ClusterID: defaultClusterID}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
 	}
 
-	const wantRepaired = 1 // only hosted-blank-ghe qualifies
-	if got := s.repairGitHubHostsFromClusters(); got != wantRepaired {
-		t.Errorf("repairGitHubHostsFromClusters() = %d, want %d", got, wantRepaired)
+	// A beat from a healthy public spoke must leave the record blank (=public).
+	payload := &HeartbeatPayload{HiveID: h.ID, ClusterID: defaultClusterID}
+	s.reconcileGitHubHostFromSpoke(payload)
+	s.repairMisflippedForgeFromRequest(payload)
+	if got := loadSaaSHive(h.ID); got == nil || got.GitHubHost != "" {
+		t.Errorf("GitHubHost = %q, want blank — the cluster's forge must never be written into a claimed hive's record on a heartbeat", got.GitHubHost)
 	}
 
-	want := map[string]string{
-		"hosted-blank-ghe":       gheTestHost,
-		"hosted-explicit":        "github.explicit.com",
-		"hosted-public-override": "",
-		"hosted-public-cluster":  "",
-		"hosted-available-x":     "",
-	}
-	for id, wantHost := range want {
-		h := loadSaaSHive(id)
-		if h == nil {
-			t.Fatalf("hive %s disappeared", id)
-		}
-		if h.GitHubHost != wantHost {
-			t.Errorf("%s: GitHubHost = %q, want %q", id, h.GitHubHost, wantHost)
-		}
-	}
-
-	// Idempotent: a second sweep over an already-repaired fleet changes nothing.
-	if got := s.repairGitHubHostsFromClusters(); got != 0 {
-		t.Errorf("second repair sweep changed %d hives, want 0", got)
-	}
-	if h := loadSaaSHive("hosted-blank-ghe"); h == nil || h.GitHubHost != gheTestHost {
-		t.Errorf("repaired host did not survive a second sweep: %+v", h)
+	// And the per-hive resolver reads that blank as PUBLIC, not as the cluster.
+	cluster := s.clusters[defaultClusterID]
+	if id := ResolveHiveIdentity(loadSaaSHive(h.ID), &cluster); !sameGitHubHost(id.Forge, publicForgeHost) {
+		t.Errorf("resolved forge = %q, want public — empty github_host on a claimed hive means github.com", id.Forge)
 	}
 }
 
-// TestRepairedHostReachesSpokeViaHeartbeat is the end-to-end trace that makes
-// the repair worth anything: filling GitHubHost on an ALREADY-DELIVERED claim
-// must actually cause projectConfigForHiveID to push the GHE API URL.
+// TestRepairedHostReachesSpokeViaHeartbeat is the end-to-end trace for a
+// recorded GHE host: once a hive's OWN github_host names the GHE forge (set at
+// claim time, by a healthy spoke's report, or by an operator), the heartbeat
+// must push the GHE API URL to a spoke still reporting the public one.
 //
 // Before the needGHEAPIPush gate this failed: ClaimDelivered == true and a
 // matching vanity URL made every push condition false, so the reconcile
-// returned nil forever and the repaired host never left the hub.
+// returned nil forever and the recorded host never left the hub.
 func TestRepairedHostReachesSpokeViaHeartbeat(t *testing.T) {
 	useTempHiveDir(t)
 	s := newGHETestHub()
@@ -284,18 +259,18 @@ func TestRepairedHostReachesSpokeViaHeartbeat(t *testing.T) {
 	// publicAPIURL is what a misconfigured GHE spoke reports today.
 	const publicAPIURL = "https://api.github.com"
 
-	// Before the repair the hub has nothing to say.
+	// With no recorded host the hub has nothing to say — and, per-hive doctrine,
+	// nothing on the beat path fills one in from the cluster.
 	if pc := projectConfigForHiveID(h.ID, h.Org, h.Repos, h.PrimaryRepo, h.ACMMLevel, "", publicAPIURL); pc != nil {
-		t.Fatalf("expected no push before repair, got %+v", pc)
+		t.Fatalf("expected no push before the host is recorded, got %+v", pc)
 	}
 
-	// This is the entry point the heartbeat handler calls, per hive, per beat.
-	if !s.repairGitHubHostForHive(h.ID) {
-		t.Fatal("per-hive repair reported no change for a blank host on a GHE cluster")
-	}
-	// Idempotent on the next beat — the heartbeat calls this every time.
-	if s.repairGitHubHostForHive(h.ID) {
-		t.Error("per-hive repair changed an already-repaired hive on a second beat")
+	// A HEALTHY spoke positively reporting the GHE forge records the host — the
+	// per-hive evidence path that replaced the cluster-default fill.
+	if !s.reconcileGitHubHostFromSpoke(&HeartbeatPayload{
+		HiveID: h.ID, ClusterID: defaultClusterID, GitHubHost: gheTestHost, GitHubAPIURL: gheTestAPIURL,
+	}) {
+		t.Fatal("a healthy spoke's positive GHE report did not record the host")
 	}
 
 	// After the repair the very next heartbeat must carry the GHE API URL.

--- a/v2/pkg/hub/hive_identity.go
+++ b/v2/pkg/hub/hive_identity.go
@@ -160,6 +160,27 @@ func ResolveHiveIdentity(h *SaaSHive, cluster *ClusterConfig) HiveIdentity {
 	}
 
 	elected := electedForgeForHive(h, cluster)
+	// FORGE IS PER-HIVE, NOT PER-CLUSTER. A CLAIMED hive that records no host
+	// defaults to PUBLIC github.com — the documented meaning of an empty
+	// github_host ("empty means public github.com", SaaSHive) — NOT to its
+	// cluster's forge. The vllm-d cluster hosts BOTH github.ibm.com projects
+	// (certus, EPM, …) AND github.com projects (ibm/alchemy-logging: the org
+	// "ibm" lives on public github.com). Inheriting the CLUSTER's GHE forge for
+	// a claimed hive that never recorded a GHE host is what force-flipped every
+	// github.com project on that cluster onto app 5686 / github.ibm.com at
+	// 23:56Z on 2026-08-05 and degraded 9 spokes with
+	// "404 Not Found on /app/installations/<id>/access_tokens".
+	//
+	// The cluster default (rule 2) still applies where it is legitimate: an
+	// UNCLAIMED placeholder (its pool exists to serve the cluster's forge) and a
+	// nil/status-less record (silence about the hive is not evidence about its
+	// forge). A claimed hive's forge comes only from its own recorded host —
+	// and a genuinely-GHE hive always has one: assign records it from the pasted
+	// org URL, backfillGitHubHostFromCluster fills it at claim time, and
+	// reconcileGitHubHostFromSpoke adopts it from a healthy spoke's own report.
+	if elected == "" && hiveClaimed(h) {
+		elected = publicForgeHost
+	}
 	if elected == "" || sameGitHubHost(elected, clusterForge) {
 		return id
 	}
@@ -250,6 +271,18 @@ func ResolveHiveIdentityInFleet(h *SaaSHive, cluster *ClusterConfig, forgeApps m
 		}
 	}
 	return id
+}
+
+// hiveClaimed reports whether a hive record is a CLAIMED hive — one with a real
+// owner/org whose forge is a per-hive fact — as opposed to an unclaimed
+// placeholder (statusAvailable) whose identity legitimately follows its
+// cluster's default until assign records the real host.
+//
+// An empty Status is treated as NOT claimed: hives claimed by pre-#2333 code
+// carry "", and "" is indistinguishable from "unknown", so the conservative
+// reading (keep the previous cluster-default behaviour) is the safe one.
+func hiveClaimed(h *SaaSHive) bool {
+	return h != nil && h.Status != "" && h.Status != statusAvailable
 }
 
 // electedForgeForHive returns the forge a hive has RECORDED for itself, or ""

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -772,208 +772,150 @@ func backfillGitHubHostFromCluster(h *SaaSHive, cluster *ClusterConfig) string {
 	return forge
 }
 
-// repairGitHubHostsFromClusters retroactively fills in a blank GitHubHost on
-// hives that were ALREADY assigned, using their cluster's GHE defaults.
+// FORGE IS PER-HIVE. Two repairs used to live here that keyed a hive's forge on
+// its CLUSTER's default — repairGitHubHostForHive (filled a blank github_host
+// from the cluster forge on every beat) and guardGHEHiveNotOnPublicForge
+// (rewrote a blank-or-public github_host to the cluster's GHE host whenever the
+// spoke reported the public forge). Both are gone, on purpose.
 //
-// backfillGitHubHostFromCluster only runs at assign time, so every hive claimed
-// before that fix keeps GitHubHost == "" forever — and with it an empty
-// github_api_url pushed on every heartbeat, which the spoke reads as "leave
-// mine alone". Those hives sit on a github.ibm.com cluster while talking to
-// api.github.com (hosted-available-vllmd-01 in org "katamari" is the live
-// example). Nothing else ever repairs them.
+// A cluster hosts hives of BOTH forges: vllm-d carries github.ibm.com projects
+// (certus, EPM, …) beside github.com projects (ibm/alchemy-logging — the org
+// "ibm" lives on public github.com). At 23:56Z on 2026-08-05, minutes after the
+// cluster-keyed guard shipped, it rewrote github_host on every vllm-d hive whose
+// spoke reported the public App — github.com projects included — and the
+// delivery that followed flipped their spokes onto app 5686 / github.ibm.com,
+// degrading 9 of them with "404 Not Found" on every token mint. Cluster
+// membership proves nothing about any one hive's forge; only the hive's own
+// recorded github_host (empty = public github.com, the field's documented
+// meaning) does.
 //
-// It is deliberately conservative and idempotent:
-//   - It only ever fills a BLANK GitHubHost. An explicitly set host is never
-//     overwritten, and neither is an explicit "public" override — that resolves
-//     to an empty effective base URL, which backfillGitHubHostFromCluster
-//     already refuses to record.
-//   - It changes nothing when the hive's cluster has no GHE host configured.
-//   - Unclaimed placeholders are skipped: assign owns those, and it now
-//     backfills the host itself.
-//   - Every change is logged with before/after.
-//
-// Returns the number of hives changed.
-//
-// It runs LAZILY, per hive, from the heartbeat path (repairGitHubHostForHive)
-// rather than as a startup sweep. A goroutine at hub start would walk the hive
-// directory concurrently with the first heartbeats already writing to it, for
-// no benefit: a hive that never beats does not need repairing, and one that
-// does gets repaired on its very next beat.
-//
-// NOTE: this repairs the HOST only. A hive that also carries the public
-// app_id/installation_id is NOT fixed by this — the GitHub App still has to be
-// installed on the target org before installation auto-discovery can self-heal
-// it. See gitHubAppStillRequiredNote.
-func (s *HubServer) repairGitHubHostsFromClusters() int {
-	repaired := 0
-	for _, h := range listSaaSHives() {
-		if s.repairGitHubHostForHive(h.ID) {
-			repaired++
-		}
-	}
-	if repaired > 0 {
-		s.logger.Info("github host repair: complete", "hives_repaired", repaired,
-			"note", gitHubAppStillRequiredNote)
-	}
-	return repaired
-}
+// What remains, all keyed on per-hive evidence:
+//   - assign/approve record github_host from the pasted org URL (and
+//     backfillGitHubHostFromCluster fills it ONCE, at claim time, for legacy
+//     requests that named no host);
+//   - reconcileGitHubHostFromSpoke adopts the forge a HEALTHY spoke positively
+//     reports it runs;
+//   - repairMisflippedForgeFromRequest (below) restores a github_host the
+//     cluster-keyed guard stomped, from the provision request's own record;
+//   - the wrong-forge identity repair (decideAppKeySync /
+//     appKeyReasonWrongForgeApp) re-delivers the hive's OWN forge — in both
+//     directions — when the spoke's app_id provably belongs to another forge.
 
-// repairGitHubHostForHive applies the retroactive host repair to a SINGLE hive,
-// reporting whether it changed anything. Called on each heartbeat, so it must
-// be cheap and silent in the overwhelmingly common no-op case — every guard
-// below returns before any write.
-func (s *HubServer) repairGitHubHostForHive(hiveID string) bool {
-	h := loadSaaSHive(hiveID)
-	if h == nil {
-		return false
-	}
-	if h.Status == statusAvailable {
-		return false // unclaimed placeholder — assign backfills it at claim time
-	}
-	if h.GitHubHost != "" {
-		return false // explicitly set — never clobber
-	}
-	// backfillGitHubHostFromCluster also returns "" for an explicit "public"
-	// override (effectiveGitHubBaseURL resolves the sentinel to public) and for
-	// a cluster with no GHE host, so both are covered by this one check.
-	host := backfillGitHubHostFromCluster(h, s.clusterForHive(h))
-	if host == "" {
-		return false
-	}
-	h.GitHubHost = host
-	if err := saveSaaSHive(h); err != nil {
-		s.logger.Error("github host repair: failed to save hive",
-			"hive", hiveID, "error", err)
-		return false
-	}
-	s.logger.Info("github host repair: filled blank github_host from cluster defaults",
-		"hive", hiveID,
-		"cluster", clusterIDForHive(h),
-		"org", h.Org,
-		"github_host_before", "",
-		"github_host_after", host,
-		"github_api_url_after", gheAPIURLForHost(host),
-		"note", gitHubAppStillRequiredNote)
-	return true
-}
-
-// guardGHEHiveNotOnPublicForge is the never-blank-for-GHE guard. It fires when a
-// CLAIMED hive on a GHE-default cluster is actively reporting that it runs the
-// PUBLIC github.com forge — a blank/api.github.com api_url with the public
-// app_id — while nothing about the hive elected public. That pairing is the EPM
-// symptom: a hive whose org lives on github.ibm.com silently talking to
-// github.com, authenticating as nothing. It reports whether it changed anything.
+// repairMisflippedForgeFromRequest restores a claimed hive's github_host after
+// the 2026-08-05 cluster-keyed guard stomped it, using the hive's own provision
+// request — the surviving record of which forge the org actually lives on — as
+// the authority. It reports whether it changed anything.
 //
-// WHY THIS IS DISTINCT FROM THE OTHER TWO REPAIRS
+// THE STATE IT REPAIRS. The removed guard rewrote github_host from blank /
+// "github.com" to the cluster's GHE host, and the delivery that followed
+// flipped the spoke's whole github block onto the GHE App. Hub record and spoke
+// now AGREE on the wrong forge, so no drift-based repair can see the fault; the
+// only remaining evidence of the hive's true forge is the provision request the
+// owner filed, which records the org's host explicitly ("public" or a pasted
+// GHE host — the onboarding form always sends one).
 //
-//	repairGitHubHostForHive       fills a BLANK github_host from cluster defaults.
-//	reconcileGitHubHostFromSpoke  corrects a WRONG github_host from the forge the
-//	                              spoke reports.
+// Every gate is positive evidence, and ALL must hold:
+//   - the hive is CLAIMED, with no operator flow owning the host: no in-flight
+//     forge switch (RequestedGitHubHost) and no COMPLETED one either
+//     (ForgeDelivered — a deliberate later switch outranks the original
+//     request);
+//   - its recorded github_host is currently a GHE host;
+//   - its own provision request (matched by AssignedHive) EXPLICITLY records
+//     public github.com. A blank request host is treated as unknown — requests
+//     filed before the host field existed carry "", and flipping a genuine GHE
+//     hive public on that silence would recreate this incident in reverse;
+//   - the spoke POSITIVELY reports it is running that same GHE forge (it
+//     adopted the mis-delivery) AND reports failing App auth
+//     (spokeAppAuthFailing) — a healthy hive is never touched, whatever the
+//     paperwork says.
 //
-// Neither closes this case. reconcileGitHubHostFromSpoke only trusts a spoke
-// that POSITIVELY reports a GHE host; a spoke running the wrong (public) forge
-// reports github.com, which that function reads as "unknown, stand down". And
-// repairGitHubHostForHive no-ops once github_host is non-blank. So a GHE hive
-// that ended up on github.com — blank host filled to public by an older build,
-// or a stale record — had no repair path at all: it reported public forever and
-// nothing corrected it. This guard is the one writer that treats a positive
-// public report on a GHE cluster as the fault it is.
-//
-// It is deliberately conservative and one-directional, mirroring its siblings:
-//   - Only a CLAIMED hive (assign owns an unclaimed placeholder's host).
-//   - Only when the hive's CLUSTER defaults to GHE (forge-map shape included via
-//     clusterDefaultForge) — a public cluster legitimately runs public.
-//   - NEVER against an explicit public pin (github_base_url "public"/github.com):
-//     that is a deliberate decision, exactly the appKeyReasonPublicHiveOnGHECluster
-//     case, and must keep running github.com.
-//   - NEVER while an operator forge SWITCH is in flight (RequestedGitHubHost set):
-//     the switch path owns the host and could be moving the hive TO public.
-//   - Only when the spoke POSITIVELY reports the public forge. A spoke too old to
-//     report its api_url sends "" — but "" from an old spoke is UNKNOWN, so the
-//     signal is taken only alongside a github.com app_id, which an old spoke does
-//     report. Silence is never evidence.
-//
-// The repair itself is to (re)set github_host to the cluster's GHE default. That
-// is enough: on the next beat ResolveHiveIdentity resolves the GHE App and
-// appKeySyncForHeartbeat delivers the COMPLETE atomic set (app_id, app_slug,
-// api_url, base_url), while projectConfigForHiveID pushes the GHE api_url — the
-// hub re-delivers the cluster forge rather than the spoke silently proceeding on
-// github.com. As with the host repair, the GitHub App must still be installed on
-// the org before auto-discovery can adopt an installation (gitHubAppStillRequiredNote).
-func (s *HubServer) guardGHEHiveNotOnPublicForge(payload *HeartbeatPayload) bool {
+// The write restores github_host to public github.com. The same beat's identity
+// reconcile then resolves the hive's public App (per-hive election), the
+// wrong-forge repair delivers the complete public set — explicit public urls,
+// public app_id, and an installation reset riding with the app change — and the
+// spoke's RediscoverAndAdopt re-adopts its old public installation, which is
+// valid again under the restored app_id.
+func (s *HubServer) repairMisflippedForgeFromRequest(payload *HeartbeatPayload) bool {
 	if s == nil || payload == nil {
 		return false
 	}
 	h := loadSaaSHive(payload.HiveID)
-	if h == nil || h.Status == statusAvailable {
-		return false // unclaimed placeholder — assign owns its host
+	if !hiveClaimed(h) {
+		return false // unclaimed placeholder (or no record) — assign owns its host
 	}
-	// An explicit public pin is a decision, not a fault.
-	if h.GitHubBaseURL == githubHostPublic || h.GitHubBaseURL == "https://github.com" {
-		return false
+	if h.RequestedGitHubHost != "" || h.ForgeDelivered {
+		return false // an operator forge switch owns (or deliberately set) the host
 	}
-	// A forge switch owns the host while it runs — it may be moving TO public.
-	if h.RequestedGitHubHost != "" {
-		return false
+	current := forgeHostLabel(h.GitHubHost)
+	if h.GitHubHost == "" || isPublicForgeHost(current) {
+		return false // nothing GHE recorded — nothing to restore
 	}
-	cluster := s.clusterForHive(h)
-	if cluster == nil {
-		return false
+	req := loadProvisionRequest(h.Owner)
+	if req == nil || req.AssignedHive != h.ID {
+		return false // no surviving request record for THIS hive — no authority
 	}
-	clusterForge := clusterDefaultForge(cluster)
-	if isPublicForgeHost(clusterForge) {
-		return false // public cluster — running public is correct
+	reqHost := strings.TrimSpace(req.GitHubHost)
+	requestSaysPublic := strings.EqualFold(reqHost, githubHostPublic) ||
+		(reqHost != "" && isPublicForgeHost(forgeHostLabel(reqHost)))
+	if !requestSaysPublic {
+		return false // request names GHE, or is silent — silence is not evidence
 	}
-	// Does the SPOKE positively report it is running the public forge? Judge the
-	// forge it reports, base-or-api. A blank/api.github.com api_url on its own is
-	// ambiguous (an old spoke sends ""), so require the public app_id alongside —
-	// which an old spoke DOES report — before treating this as a positive public
-	// report rather than silence.
+	// The spoke must have adopted the mis-delivered GHE forge AND be failing on
+	// it. A spoke still on public, or one that is healthy, is not this fault.
 	spokeForge := config.GitHubConfig{
 		BaseURL: strings.TrimSpace(payload.GitHubBaseURL),
 		APIURL:  strings.TrimSpace(payload.GitHubAPIURL),
 	}.HostLabel()
-	spokeOnPublic := isPublicForgeHost(spokeForge) && payload.GitHubAppID == config.PublicGitHubAppID
-	if !spokeOnPublic {
+	if !sameGitHubHost(forgeHostLabel(spokeForge), current) {
 		return false
 	}
-	// If the hive already records the GHE host, the resolver is already delivering
-	// the GHE identity and the spoke just has not converged yet — do not churn the
-	// record. Only act when the host is blank or itself public.
-	if h.GitHubHost != "" && !isPublicForgeHost(forgeHostLabel(h.GitHubHost)) {
+	if !spokeAppAuthFailing(payload) {
 		return false
 	}
 	before := h.GitHubHost
-	h.GitHubHost = clusterForge
+	h.GitHubHost = publicForgeHost
 	if err := saveSaaSHive(h); err != nil {
-		s.logger.Error("github forge guard: failed to save hive",
+		s.logger.Error("github forge restore: failed to save hive",
 			"hive", payload.HiveID, "error", err)
 		return false
 	}
-	s.logger.Warn("github forge guard: a claimed GHE-cluster hive was running the PUBLIC github.com forge — re-delivering the cluster forge",
+	s.logger.Warn("github forge restore: a public-github.com hive was mis-flipped onto its cluster's GHE forge — restoring the host its provision request records",
 		"hive", payload.HiveID,
-		"cluster", cluster.ID,
 		"org", h.Org,
+		"owner", h.Owner,
 		"github_host_before", before,
-		"github_host_after", clusterForge,
+		"github_host_after", publicForgeHost,
+		"request_github_host", reqHost,
 		"spoke_app_id", payload.GitHubAppID,
-		"spoke_api_url", strings.TrimSpace(payload.GitHubAPIURL),
-		"github_api_url_after", gheAPIURLForHost(clusterForge),
-		"note", gitHubAppStillRequiredNote)
+		"spoke_app_state", strings.TrimSpace(payload.GitHubAppState),
+	)
 	return true
+}
+
+// spokeAppAuthFailing reports whether a spoke POSITIVELY reports that its
+// GitHub App auth is not working: the app-required banner is raised and its own
+// classification names a credential/installation fault. Silence — an old spoke
+// reporting neither field — is never read as failure.
+func spokeAppAuthFailing(payload *HeartbeatPayload) bool {
+	if payload == nil || !payload.GitHubAppRequired {
+		return false
+	}
+	switch strings.TrimSpace(payload.GitHubAppState) {
+	case spokeAppStateNotInstalled, spokeAppStateWrongInstallation, "key-invalid", "key-missing":
+		return true
+	}
+	return false
 }
 
 // reconcileGitHubHostFromSpoke repairs a persisted github_host that is not merely
 // BLANK but WRONG, using the forge the spoke actually reports it is running
 // against. It reports whether it changed anything.
 //
-// Why, on top of the blank-fill: repairGitHubHostForHive only ever fills a BLANK
-// host from cluster defaults; it
-// refuses to touch an already-set value. But a hive can carry a persisted host
-// that is set AND wrong: assigned from a pasted github.com URL, or seeded with a
-// stale record, while the repo actually lives on GitHub Enterprise (vllmd-06 is
-// the live example — meta said github.com but the spoke ran api_url
-// github.ibm.com). Nothing repaired those; each needed a hand-edit.
+// Why: a hive can carry a persisted host that is set AND wrong — assigned from
+// a pasted github.com URL, or seeded with a stale record, while the repo
+// actually lives on GitHub Enterprise (vllmd-06 is the live example — meta said
+// github.com but the spoke ran api_url github.ibm.com). Nothing repaired those;
+// each needed a hand-edit.
 //
 // The spoke's OWN reported forge is authoritative: it is what the running hive is
 // actually configured against. Read it base-or-api across the two reported fields
@@ -1026,6 +968,17 @@ func (s *HubServer) reconcileGitHubHostFromSpoke(payload *HeartbeatPayload) bool
 	// An explicit public pin is a DECISION, not a fault: leave it alone even if the
 	// spoke momentarily reports a GHE host (its cluster default leaking through).
 	if h.GitHubBaseURL == githubHostPublic || h.GitHubBaseURL == "https://github.com" {
+		return false
+	}
+	// A BROKEN spoke's forge report is not evidence of intent. A spoke whose App
+	// auth is failing may be running a forge it was mis-delivered (the
+	// 2026-08-05 flip left 9 spokes positively reporting github.ibm.com they
+	// could not authenticate against); adopting that report would launder the
+	// mis-delivery into the hive's record and fight the restore that
+	// repairMisflippedForgeFromRequest performs. Only a spoke that is actually
+	// WORKING on the forge it reports (the vllmd-06 class this reconcile exists
+	// for) is authoritative about it.
+	if spokeAppAuthFailing(payload) {
 		return false
 	}
 	current := githubHostLabel(h.GitHubHost) // normalize for a like-for-like compare

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1594,24 +1594,27 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	// bug. (No-op for unclaimed placeholders and for empty/zero reported values.)
 	s.adoptSpokeProjectConfig(payload.HiveID, payload.Org, payload.Repos, payload.PrimaryRepo, clampInt(payload.ACMMLevel, 0, 6))
 
-	// Retroactively fill a blank github_host from this hive's cluster BEFORE
-	// building the project config, so a hive assigned before assign-time
-	// backfill existed starts receiving its GitHub Enterprise API URL on this
-	// very beat. No-op (and silent) for every hive that already has a host, is
-	// an unclaimed placeholder, or sits on a non-GHE cluster.
-	s.repairGitHubHostForHive(payload.HiveID)
-	// Beyond filling a BLANK host, repair a persisted host that is set but WRONG
-	// from the forge the spoke actually reports it runs against (public→GHE only,
-	// never demoting a legit public pin). Closes the vllmd-06 class: meta said
-	// github.com while the spoke ran api_url github.ibm.com.
+	// FORGE IS PER-HIVE: a hive's forge comes from its own recorded github_host
+	// (empty = public github.com), never from its cluster's default — a cluster
+	// hosts hives of both forges. The per-beat blank-fill-from-cluster and the
+	// cluster-keyed "GHE guard" that used to run here are gone: on 2026-08-05
+	// the guard rewrote github_host on every vllm-d hive whose spoke reported
+	// the public App — github.com projects included — and 9 spokes were flipped
+	// onto an App that 404'd every token mint.
+	//
+	// Repair a persisted host that is set but WRONG from the forge the spoke
+	// actually reports it runs against (public→GHE only, never demoting a legit
+	// public pin, and never trusting a spoke whose App auth is failing). Closes
+	// the vllmd-06 class: meta said github.com while the spoke ran api_url
+	// github.ibm.com.
 	s.reconcileGitHubHostFromSpoke(&payload)
-	// Never-blank-for-GHE guard. The two repairs above trust a blank host or a
-	// GHE-reporting spoke; neither catches a claimed GHE-cluster hive that is
-	// POSITIVELY reporting the public github.com forge (blank api_url + public
-	// app_id) with no public pin — the EPM symptom. Re-deliver the cluster forge
-	// so the spoke stops silently talking to github.com. No-op (and silent) for
-	// every hive not in that exact state.
-	s.guardGHEHiveNotOnPublicForge(&payload)
+	// Restore a github_host the cluster-keyed guard STOMPED: a claimed hive
+	// whose provision request explicitly records public github.com, whose meta
+	// now says GHE, and whose spoke is failing App auth on that GHE forge, gets
+	// its recorded host set back to github.com — after which the per-hive
+	// identity reconcile below re-delivers its public App on this same beat.
+	// No-op (and silent) for every hive not in that exact state.
+	s.repairMisflippedForgeFromRequest(&payload)
 
 	// Close the FORGE handshake before building the project config, so the beat
 	// on which the spoke first reports the requested host is also the beat the


### PR DESCRIPTION
## URGENT: repairs the #2713 fleet regression (9 spokes degraded)

### Timeline
- **~23:09Z 2026-08-05** — #2713 (`fix/ghe-forge-atomic-delivery`) merged; hub rolled `be8c36e` at **23:44Z**.
- **23:56–23:58Z** — minutes after the roll, the `github:` block on **ALL vllm-d-cluster spokes** was rewritten to `app_id 5686` / `app_slug kubestellar-hive-ghe` / `api_url https://github.ibm.com/api/v3` / `base_url https://github.ibm.com`.
- **Since then** — 9 spokes show `Degraded — github_auth: token error: creating installation token: POST https://github.ibm.com/api/v3/app/installations/<id>/access_tokens: 404 Not Found`.

### Bug 1 — forge is PER-HIVE (the project's GitHub host), not per-cluster
The vllm-d cluster hosts **both** github.ibm.com projects (certus, EPM, kellyaa, …) **and** github.com projects (`ibm/alchemy-logging` — the org `ibm` lives on **public github.com**). #2713's guard (`guardGHEHiveNotOnPublicForge`) and delivery keyed forge election on the **cluster's** default forge, so every hive whose spoke reported the public App — github.com projects included — had its `github_host` rewritten to `github.ibm.com` and its spoke force-flipped onto an App its host never issued.

**Fix:**
- `ResolveHiveIdentity`: a **claimed** hive that records no host elects **public github.com** (the documented meaning of an empty `github_host`) — never the cluster forge. Unclaimed placeholders / nil records keep the cluster default (the pool serves the cluster's forge; assign records the real host at claim).
- The wrong-forge repair (`decideAppKeySync` / `appKeyReasonWrongForgeApp`) is now keyed on the **hive's own elected forge** vs the forge the spoke's `app_id` provably belongs to (`config.ForgeOfAppID` + fleet forge map) — and fires in **both directions**: a GHE-host hive stuck on the public App (the EPM class #2713 targeted) **and** a public-host hive wrongly flipped onto the GHE App (the alchemy class this regression created). Unknown app_ids remain protected as deliberate pins.
- The cluster-keyed guard and the per-beat `repairGitHubHostForHive` blank-fill-from-cluster are **removed** — a heartbeat may never materialise the cluster's forge into a hive's record.
- New `repairMisflippedForgeFromRequest`: restores a `github_host` the guard stomped, using the hive's own **provision request** (which explicitly records the org's host) as authority — gated on the spoke actually **failing** App auth on the flipped forge, no in-flight/completed operator forge switch, and an explicit (non-blank) public host on the request.
- `reconcileGitHubHostFromSpoke` now stands down for a spoke whose App auth is failing, so a mis-delivered forge can't be laundered back into meta and fight the restore.

### Bug 2 — `installation_id` is part of the atomic set
The 23:56 delivery swapped `app_id`/`app_slug`/`api_url`/`base_url` but **left each spoke's old installation_id in place**. An installation id belongs to ONE app; reused under app 5686 it 404s on `/app/installations/<id>/access_tokens`.

**Fix:** any delivery whose `app_id` differs from what the spoke reports now carries `ResetInstallation: true` (+ `installation_id: 0`). The spoke drops the stale id, `HasUsableApp()` goes false, the existing "Install GitHub App / Set ID" banner is raised, and the 2-minute `RediscoverAndAdopt` ticker re-establishes the correct installation. A **same-app** delivery leaves `installation_id` strictly alone; the placeholder sentinel never resets (its id was entered by the owner *for* the incoming real App); a zero/silent spoke app_id never resets.

### How the 9 spokes recover (next beats, no manual edits)
- **github.com projects (alchemy class):** the request-record restore (or an intact public/blank `github_host`) re-elects public → the reverse wrong-forge repair delivers app **3568013** with **explicit** public URLs (empty would mean "unchanged" and half-apply against the spoke's GHE URLs) plus the installation reset → rediscovery re-adopts their old public installations, which are valid again under the restored app_id.
- **genuine GHE hives (certus/EPM/kellyaa class):** app identity is already converged on 5686, so the new `staleInstallationResetForHeartbeat` fires — converged app + non-zero installation + spoke-reported `not-installed`/`wrong-installation` + banner raised → reset-to-0 → the install banner / rediscovery flow re-establishes a real GHE installation. Idempotent on read-back (stops once the spoke reports 0); an operator-armed `RequestedAppReset` outranks it.

### Tests
- Per-hive election: claimed blank-host and `github.com`-host hives keep the public forge **on the GHE cluster**; unclaimed placeholders keep the cluster default; explicit GHE host still resolves the GHE App.
- Regression pins: no repair path rewrites a claimed public/blank-host hive's record from cluster membership; no GHE App is ever delivered to one.
- Both wrong-forge directions, including the reverse delivery with explicit public URLs + reset.
- App-change delivery resets `installation_id`; same-app (key-only) delivery preserves it.
- Request-record restore: all gates (GHE request, silent request, healthy spoke, completed forge switch, wrong hive's request, nil-safety).
- Broken-spoke reconcile stand-down (healthy vllmd-06-class repair still works).
- Stale-installation reset with read-back idempotence.

`go build ./...` and `go vet ./...` clean; `go test ./pkg/hub/ ./pkg/config/ ./cmd/hive/` pass locally.
