### PR TITLE
fix: assign/approve respond immediately — cluster work moves off the request path

### DIFF
--- a/v2/pkg/hub/assign_async_claim_test.go
+++ b/v2/pkg/hub/assign_async_claim_test.go
@@ -1,0 +1,230 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ============================================================
+// saas.go / saas_provision.go — assign/approve must respond IMMEDIATELY.
+//
+// Live failure this guards against: the assign dialog sat on a pending fetch
+// for ~a minute because handleAssignHive ran makeVanityHostServable (unbounded
+// kubectl against the hive's cluster) and stampHostedNamespaceIdentity (2×15s
+// bounded kubectl) BETWEEN persisting the assignment and writing the HTTP
+// response. On the heartbeat-only vllm-d pool every kubectl call eats a ~45s
+// TCP dial timeout, so the dashboard dialog — which awaits that fetch — hung
+// until the cluster work gave up. Same disease #2730 cured on the heartbeat
+// path; the cure is the same: persist, respond, and kick the cluster work into
+// a guarded background goroutine (kickClaimClusterWorkAsync).
+// ============================================================
+
+// newBlockedClaimHub builds a hub whose vanity-servability seam blocks until
+// release is called and whose kubectl is a fake that blocks until the returned
+// unblockKubectl func is called — standing in for kubectl hanging against an
+// unreachable cluster on BOTH claim-time cluster calls (namespace stamp and
+// vanity mint). seamErr is what the seam returns once released.
+func newBlockedClaimHub(t *testing.T, seamErr error) (s *HubServer, entered *atomic.Int32, release, unblockKubectl func()) {
+	t.Helper()
+
+	// Fake kubectl: block until the sentinel file exists, then succeed. The
+	// stamp's own 15s context bounds it even if the sentinel never appears.
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "kubectl.release")
+	script := `#!/bin/sh
+while [ ! -f "` + sentinel + `" ]; do sleep 0.05; done
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	unblockKubectl = func() { _ = os.WriteFile(sentinel, nil, 0o644) }
+
+	s = &HubServer{
+		logger:                  slog.Default(),
+		hubSecret:               testHubSecret,
+		saveCh:                  make(chan struct{}, 1),
+		clusters:                map[string]ClusterConfig{"hive-oke": *dynamicCluster()},
+		pendingGitHubAppConfigs: make(map[string]*HeartbeatGitHubAppConfig),
+	}
+	blocked := make(chan struct{})
+	var once atomic.Bool
+	release = func() {
+		if once.CompareAndSwap(false, true) {
+			close(blocked)
+		}
+	}
+	entered = &atomic.Int32{}
+	s.vanityHostServable = func(_, _ string, _ *ClusterConfig) error {
+		entered.Add(1)
+		<-blocked
+		return seamErr
+	}
+	return s, entered, release, unblockKubectl
+}
+
+// The assign response must come back immediately — with the assignment fully
+// persisted — while BOTH claim-time cluster calls (namespace stamp, vanity
+// mint) are still blocked. With the old synchronous code this test hangs on
+// the seam and times out. Once the cluster work is released, the background
+// goroutine adopts the vanity host exactly as the inline version did.
+func TestAssignRespondsWhileClusterWorkBlocked(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s, _, release, unblockKubectl := newBlockedClaimHub(t, nil)
+	// LIFO: these run BEFORE cleanup's provisionWG.Wait, so the drained
+	// goroutine can finish and the Wait cannot deadlock on the blocked seam.
+	defer release()
+	defer unblockKubectl()
+	mkUser(t, hubAdminUsername)
+
+	const id = "hosted-avail-fast01"
+	if err := saveSaaSHive(&SaaSHive{ID: id, Owner: hubAdminUsername, Status: statusAvailable, ClusterID: "hive-oke"}); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"owner":"carol","org":"falcon-core","repos":"buddies","primary_repo":"buddies","acmm_level":2,"project_name":"TradingAsBuddies"}`
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		req := setPathValue(reqWithUser(http.MethodPost, "/api/saas/hives/"+id+"/assign", body, hubAdminUsername), "id", id)
+		s.handleAssignHive(rec, req)
+		done <- rec
+	}()
+
+	select {
+	case rec := <-done:
+		if rec.Code != http.StatusOK {
+			t.Fatalf("assign status = %d body=%s", rec.Code, rec.Body.String())
+		}
+	case <-time.After(waitTimeout):
+		t.Fatal("assign response blocked behind cluster work — the dialog would hang on its fetch (the ~1min dialog-hostage bug)")
+	}
+
+	// The response was written with the cluster work still blocked, so the
+	// assignment itself must already be fully persisted — that is what the
+	// heartbeat channel delivers to the spoke, response semantics need nothing
+	// from the cluster calls.
+	h := loadSaaSHive(id)
+	if h == nil {
+		t.Fatal("hive missing after assign")
+	}
+	if h.Status != statusAssigned || h.Owner != "carol" || h.Org != "falcon-core" || h.PrimaryRepo != "buddies" {
+		t.Errorf("assignment not persisted at response time: %+v", h)
+	}
+	if h.VanityURL != "" {
+		t.Errorf("VanityURL = %q before the mint completed — must only be adopted once servable", h.VanityURL)
+	}
+
+	// Release the cluster work; the background goroutine must then adopt the
+	// name-bearing vanity host exactly as the old inline code did.
+	unblockKubectl()
+	release()
+	provisionWG.Wait()
+	h = loadSaaSHive(id)
+	if h == nil || h.VanityURL == "" {
+		t.Fatalf("background mint did not adopt a vanity URL after release: %+v", h)
+	}
+}
+
+// The approve response must likewise come back immediately while the claim's
+// cluster work is blocked — approving assigns a placeholder through the same
+// dialog-awaited fetch.
+func TestApproveRespondsWhileClusterWorkBlocked(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s, _, release, unblockKubectl := newBlockedClaimHub(t, errNotServableForTest)
+	defer release()
+	defer unblockKubectl()
+	mkUser(t, hubAdminUsername)
+
+	if err := saveProvisionRequest(&ProvisionRequest{
+		Username: "bob", Org: "falcon-core", Repos: "buddies", PrimaryRepo: "buddies", ACMMLevel: 2,
+		AuthMethod: "public", RequestedAt: time.Now().UTC().Format(time.RFC3339), Status: provisionStatusPending,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	const id = "hosted-avail-fast02"
+	if err := saveSaaSHive(&SaaSHive{ID: id, Owner: hubAdminUsername, Status: statusAvailable, ClusterID: "hive-oke"}); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		req := setPathValue(reqWithUser(http.MethodPut, "/api/saas/approve-provision/bob", "", hubAdminUsername), "username", "bob")
+		s.handleApproveProvision(rec, req)
+		done <- rec
+	}()
+
+	select {
+	case rec := <-done:
+		if rec.Code != http.StatusOK {
+			t.Fatalf("approve status = %d body=%s", rec.Code, rec.Body.String())
+		}
+	case <-time.After(waitTimeout):
+		t.Fatal("approve response blocked behind cluster work — the dialog would hang on its fetch")
+	}
+
+	// Approval semantics are complete at response time, cluster work or not.
+	h := loadSaaSHive(id)
+	if h == nil || h.Status != statusAssigned || h.Owner != "bob" {
+		t.Fatalf("approval not persisted at response time: %+v", h)
+	}
+	pr := loadProvisionRequest("bob")
+	if pr == nil || pr.Status != provisionStatusApproved || pr.AssignedHive != id {
+		t.Fatalf("provision request not marked approved at response time: %+v", pr)
+	}
+}
+
+// While one claim work-set is stuck against the cluster, further kicks for the
+// same hive must not stack goroutines; once it drains, a later kick may run.
+func TestKickClaimClusterWorkDedupesPerHive(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s, entered, release, unblockKubectl := newBlockedClaimHub(t, errNotServableForTest)
+	defer release()
+	unblockKubectl() // stamp is instant here; only the vanity seam blocks
+
+	const id = "hosted-avail-dedupe01"
+	if err := saveSaaSHive(&SaaSHive{
+		ID: id, Owner: "carol", Status: statusAssigned, ClusterID: "hive-oke",
+		Org: "falcon-core", Repos: []string{"buddies"}, PrimaryRepo: "buddies", ACMMLevel: 2,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s.kickClaimClusterWorkAsync(id)
+	deadline := time.Now().Add(waitTimeout)
+	for entered.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if entered.Load() != 1 {
+		t.Fatalf("first kick: seam entered %d times, want 1", entered.Load())
+	}
+
+	// Retries while the attempt is stuck — none may stack.
+	s.kickClaimClusterWorkAsync(id)
+	s.kickClaimClusterWorkAsync(id)
+	time.Sleep(50 * time.Millisecond)
+	if got := entered.Load(); got != 1 {
+		t.Fatalf("in-flight dedupe failed: seam entered %d times, want 1", got)
+	}
+
+	// Release; the failed (not-servable) attempt leaves VanityURL empty, so a
+	// fresh kick after the drain must reach the seam again.
+	release()
+	provisionWG.Wait()
+	s.kickClaimClusterWorkAsync(id)
+	provisionWG.Wait()
+	if got := entered.Load(); got != 2 {
+		t.Fatalf("post-drain kick: seam entered %d times, want 2", got)
+	}
+}

--- a/v2/pkg/hub/hosted_namespace_identity_test.go
+++ b/v2/pkg/hub/hosted_namespace_identity_test.go
@@ -280,6 +280,9 @@ func TestHandleApproveProvisionStampsNamespaceIdentity(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("approve status = %d body=%s", rec.Code, rec.Body.String())
 	}
+	// The stamp runs in the background now (kickClaimClusterWorkAsync) so the
+	// approve dialog is never held behind kubectl — drain it before asserting.
+	provisionWG.Wait()
 
 	data, err := os.ReadFile(logPath)
 	if err != nil {
@@ -439,6 +442,9 @@ func TestHandleAssignHivePrefersNameBearingVanityHost(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("assign status = %d body=%s", rec.Code, rec.Body.String())
 	}
+	// The mint runs in the background now (kickClaimClusterWorkAsync) so the
+	// assign dialog is never held behind kubectl — drain it before asserting.
+	provisionWG.Wait()
 
 	if !strings.HasPrefix(gotHost, "tradingasbuddies-") {
 		t.Errorf("vanity host = %q, want a name-bearing host prefixed %q", gotHost, "tradingasbuddies-")
@@ -483,6 +489,7 @@ func TestHandleAssignHiveFallsBackToOrgRepoHostWithoutDisplayName(t *testing.T) 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("assign status = %d body=%s", rec.Code, rec.Body.String())
 	}
+	provisionWG.Wait() // background mint — drain before asserting the host
 
 	if !strings.HasPrefix(gotHost, "hosted-acme-widgets-") {
 		t.Errorf("vanity host = %q, want the unchanged org/repo-derived host prefixed %q", gotHost, "hosted-acme-widgets-")
@@ -545,6 +552,7 @@ func TestHandleAssignHiveStampsNamespaceIdentity(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("assign status = %d body=%s", rec.Code, rec.Body.String())
 	}
+	provisionWG.Wait() // background stamp — drain before reading the log
 
 	data, err := os.ReadFile(logPath)
 	if err != nil {

--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -1212,6 +1212,9 @@ func TestHandleAssignHiveWithFilesystem(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
 	}
+	// The vanity mint runs in the background now (kickClaimClusterWorkAsync) —
+	// the response no longer waits for it. Drain before asserting VanityURL.
+	provisionWG.Wait()
 
 	h := loadSaaSHive("hosted-assign-fs")
 	if h == nil {

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -6316,11 +6316,11 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 
 	// Entry point 2/3 for namespace identity: this is the moment a placeholder
 	// gets a real owner/org — the hive's identity is known here for the first
-	// time, so the namespace's labels/annotations MUST be (re)written now
-	// rather than left holding whatever provisionHive stamped at pool-creation
-	// time (typically just hive_id). Best-effort — see
-	// stampHostedNamespaceIdentity's doc comment.
-	stampHostedNamespaceIdentity(s.clusterForHive(h), hostedNamespaceForHive(h), h.ProjectName, h.Org, h.ID, s.logger)
+	// time, so the namespace's labels/annotations must be (re)written. That
+	// stamp is kubectl against the hive's cluster, so it runs in the BACKGROUND
+	// via kickClaimClusterWorkAsync below — inline it held the approve dialog's
+	// fetch behind up to 2×15s of dial timeouts against an unreachable cluster
+	// (the same request-path disease #2730 cured on the heartbeat path).
 
 	// Ensure the user record exists, grant them owner access, and count this
 	// owned hive against a quota.
@@ -6360,6 +6360,14 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 	s.logger.Info("audit: provision request approved via placeholder assignment",
 		"target", targetUsername, "by", approver, "org", pr.Org, "repos", pr.Repos,
 		"hive_id", hiveID, "cluster", clusterIDForHive(h))
+
+	// Everything the response depends on is persisted above — all fast local
+	// ops. The cluster-facing side effects (namespace identity stamp; vanity
+	// mint, which this path previously left to the heartbeat repair) run in the
+	// background so the approve dialog gets its ack immediately; the claim
+	// itself reaches the spoke over the heartbeat channel regardless.
+	s.kickClaimClusterWorkAsync(hiveID)
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{
 		"ok":      true,
@@ -7077,76 +7085,23 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	// this project to the spoke until it reports the new org/repos back, before
 	// letting the spoke's dashboard own them.
 	h.ClaimDelivered = false
-	// Derive a stable, friendly vanity URL from the claimed project so the user
-	// sees hosted-<org>-<repo>-*.<domain> instead of the raw placeholder host.
-	// Compute once (idempotent re-assign keeps the same URL) and only when the
-	// hive's cluster domain is known. The spoke adopts this via the heartbeat
-	// (HeartbeatProjectConfig.DashboardURL) and reports it back, so the hub
-	// registry's dashboardUrl becomes the vanity URL and stays that way.
-	if h.VanityURL == "" {
-		if cluster := s.clusterForHive(h); cluster != nil && cluster.Domain != "" {
-			// Option B (namespace-identity operability): prefer a host built
-			// from the hive's OWN display name (h.ProjectName /
-			// body.ProjectName) when one is set — "TradingAsBuddies" reads as
-			// the hive an operator actually asked for, where
-			// "hosted-acme-repo-*" only reads as org/repo. Falls back to the
-			// existing org/repo-derived host (generateHiveID) when no display
-			// name is set, so a hive claimed without one behaves exactly as
-			// before. Both schemes share the same suffix length and the same
-			// "no route until makeVanityHostServable succeeds" adoption rule
-			// below — this only changes what the label PORTION of the host
-			// says, never the get-or-create/idempotency semantics.
-			vanityHost := hiveNameVanityHost(h.ProjectName, cluster.Domain)
-			if vanityHost == "" {
-				vanityHost = generateHiveID(body.Org, primaryRepo) + "." + cluster.Domain
-			}
-			// Make the vanity host servable, then adopt it. Nothing else creates a
-			// route for this host: provisioning templates a single DashboardHost, so
-			// a vanity URL minted here resolves to no backend and every hub link to
-			// it — including the SSO handoff — returns 503, while the raw placeholder
-			// host works fine. Create the route FIRST, then adopt the URL.
-			//
-			// VanityURL doubles as the "placeholder is claimed" marker
-			// (projectConfigForHiveID keeps pushing until the spoke reports it
-			// back), so it is always set once we have a domain to derive it from —
-			// but a failed create is logged at Warn rather than swallowed, since the
-			// symptom is a 503 on every hub link to this hive until the route is
-			// reconciled (cert-manager on nginx, or the cluster wildcard on the
-			// heartbeat-only OpenShift pool where the hub cannot kubectl to create
-			// it, so the create "fails" yet the *.apps.<domain> wildcard still
-			// serves the host — the vllm-d case).
-			// Goes through the same seam as the retroactive repair so both
-			// adoption paths share one definition of "servable" (and so tests,
-			// which have no kubectl, can exercise the success path).
-			if err := s.makeVanityHostServable(hiveID, vanityHost, cluster); err != nil {
-				// Do NOT adopt a host we could not make servable. This used to
-				// assume an OpenShift cluster wildcard would serve the host
-				// anyway and adopt it regardless; on vllm-d that assumption is
-				// false — only explicitly created *-vanity Routes are served, so
-				// the hub advertised a hostname that returned 503 while the raw
-				// placeholder host worked fine. Leaving VanityURL empty makes
-				// every read path fall back to the working placeholder, and the
-				// heartbeat repair re-attempts adoption once a route exists.
-				s.logger.Warn("vanity host is not served: could not add it to the spoke ingress/route — "+
-					"keeping the working placeholder host; the heartbeat repair will retry",
-					"hive", hiveID, "host", vanityHost, "cluster", cluster.ID, "error", err)
-			} else {
-				h.VanityURL = "https://" + vanityHost
-			}
-		}
-	}
+	// The vanity URL is NOT minted here anymore. It used to be derived and made
+	// servable inline (makeVanityHostServable → kubectl against the hive's
+	// cluster) between this save and the HTTP response, which held the admin's
+	// assign dialog hostage for ~a minute whenever the cluster was slow or
+	// unreachable (each kubectl call eats a ~45s TCP dial timeout on the
+	// heartbeat-only vllm-d pool — the same disease #2730 cured on the
+	// heartbeat path). The mint — same host preference (name-bearing Option B
+	// host, org/repo fallback), same servability seam, same "never adopt an
+	// unservable host" rule — now runs in the background via
+	// kickClaimClusterWorkAsync below, after the response is written. Nothing
+	// about the response depends on it: the claim reaches the spoke over the
+	// heartbeat channel regardless, and a failed mint is retried by the
+	// heartbeat-kicked repair exactly as before.
 	if err := saveSaaSHive(h); err != nil {
 		http.Error(w, `{"error":"failed to save hive assignment"}`, http.StatusInternalServerError)
 		return
 	}
-
-	// Entry point 3/3 for namespace identity: the (re)assignment path. A
-	// claimed placeholder can be reassigned to a different owner/org later
-	// (or an admin can assign directly, bypassing the approve-provision flow
-	// entirely), so the namespace's labels/annotations must be refreshed here
-	// too — same rationale as handleApproveProvision above. Best-effort — see
-	// stampHostedNamespaceIdentity's doc comment.
-	stampHostedNamespaceIdentity(s.clusterForHive(h), hostedNamespaceForHive(h), h.ProjectName, h.Org, h.ID, s.logger)
 
 	// Grant the assignee owner access. handleAccessList builds a hive's access
 	// list by scanning every user record for Hives[hiveID], NOT from h.Owner —
@@ -7211,6 +7166,14 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	s.recordTimeline(hiveID, TimelineOwnership,
 		fmt.Sprintf("hive assigned to %s (%s, ACMM %d)", h.Owner, repoDisplayLine(h.Org, h.PrimaryRepo), h.ACMMLevel),
 		s.getAuthUser(r))
+
+	// Everything the response depends on is persisted above (meta.json, owner
+	// grant, pending App creds, audit/timeline) — all fast local ops. The
+	// cluster-facing work (namespace identity stamp + vanity-host mint, both
+	// kubectl against the hive's cluster) runs in the background so the assign
+	// dialog gets its ack immediately; the row's "claim pending" indicators
+	// track actual delivery, which happens over the heartbeat channel anyway.
+	s.kickClaimClusterWorkAsync(hiveID)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1160,6 +1160,112 @@ func (s *HubServer) kickVanityURLRepairAsync(hiveID string) {
 	}()
 }
 
+// kickClaimClusterWorkAsync runs the cluster-facing side effects of a claim —
+// the namespace identity stamp and the vanity-host mint — in the BACKGROUND,
+// at most one attempt per hive at a time, registered with provisionWG so tests
+// can drain it before swapping the package-level saas*Dir vars (the same
+// contract every other background provision goroutine in this package follows).
+//
+// It exists for exactly the reason kickVanityURLRepairAsync does (#2730):
+// handleAssignHive and handleApproveProvision used to run this work
+// SYNCHRONOUSLY between persisting the assignment and writing the HTTP
+// response. Every call shells out to kubectl against the hive's cluster, and
+// against a cluster the hub cannot reach — vllm-d is heartbeat-only — those
+// calls hang until their TCP dials time out (~45s each, ~90s observed for the
+// vanity mint alone), so the admin's assign dialog sat on a pending fetch for
+// about a minute. Nothing here is needed for the response semantics: the claim
+// itself is persisted before the kick and delivered to the spoke over the
+// heartbeat channel (projectConfigForHiveID), the namespace stamp is
+// best-effort/cosmetic by contract, and a failed vanity mint already has a
+// retry path (the heartbeat-kicked repair above) plus a Warn log.
+//
+// Callers must kick AFTER the assignment is fully persisted: the goroutine
+// re-loads meta.json rather than closing over the handler's copy, so it never
+// writes through a record that predates concurrent heartbeat updates.
+func (s *HubServer) kickClaimClusterWorkAsync(hiveID string) {
+	// One in-flight claim work-set per hive, so an admin double-submitting the
+	// dialog (or re-assigning while a slow attempt is stuck against a dead
+	// cluster) does not stack goroutines against the same unreachable cluster.
+	if _, inFlight := s.claimWorkInFlight.LoadOrStore(hiveID, struct{}{}); inFlight {
+		return
+	}
+	provisionWG.Add(1)
+	go func() {
+		defer provisionWG.Done()
+		defer s.claimWorkInFlight.Delete(hiveID)
+		h := loadSaaSHive(hiveID)
+		if h == nil {
+			return
+		}
+		// Entry points 2/3 for namespace identity (see
+		// hosted_namespace_identity.go): the claim/assign moment is when the
+		// hive's real owner/org become known, so the namespace labels must be
+		// (re)written now. Best-effort and bounded, but the bound is still
+		// 2×15s of kubectl against an unreachable cluster — background-only.
+		stampHostedNamespaceIdentity(s.clusterForHive(h), hostedNamespaceForHive(h), h.ProjectName, h.Org, h.ID, s.logger)
+		// Mint the vanity host under the SAME per-hive guard the heartbeat
+		// repair uses, so a beat-kicked repair and this claim-time mint never
+		// run concurrently against the same hive (concurrent minters would
+		// churn routes and race the adopt write).
+		if _, inFlight := s.vanityRepairInFlight.LoadOrStore(hiveID, struct{}{}); inFlight {
+			return // a repair attempt is already minting — let it win
+		}
+		defer s.vanityRepairInFlight.Delete(hiveID)
+		s.mintClaimVanityURL(hiveID)
+	}()
+}
+
+// mintClaimVanityURL is the vanity-minting half of a claim/(re)assignment —
+// the work handleAssignHive used to do inline before writing its response.
+// Behavior is unchanged from the synchronous version: prefer a name-bearing
+// host built from the hive's display name (Option B — see
+// hosted_namespace_identity.go), fall back to the org/repo-derived host, make
+// it servable through the same seam as the retroactive repair, and only adopt
+// a host that IS servable (the vllm-d 503 rule). On failure VanityURL stays
+// empty, every read path keeps the working placeholder host, and the
+// heartbeat-kicked repair retries later — exactly as before.
+//
+// The one addition over the inline version is the RE-LOAD before the adopt
+// write: this now runs after the handler has already responded, so the slow
+// kubectl window overlaps live heartbeat writes (ClaimDelivered/ACMMDelivered
+// latches, forge handshakes) and saving through a pre-window record would
+// silently revert them — the same hazard repairVanityURLForHive documents.
+func (s *HubServer) mintClaimVanityURL(hiveID string) {
+	h := loadSaaSHive(hiveID)
+	if h == nil || h.Status == statusAvailable || h.VanityURL != "" {
+		return // unclaimed, gone, or already has one (stable-host idempotency)
+	}
+	cluster := s.clusterForHive(h)
+	if cluster == nil || cluster.Domain == "" {
+		return // nothing to derive a host from
+	}
+	vanityHost := hiveNameVanityHost(h.ProjectName, cluster.Domain)
+	if vanityHost == "" {
+		vanityHost = generateHiveID(h.Org, h.PrimaryRepo) + "." + cluster.Domain
+	}
+	if err := s.makeVanityHostServable(hiveID, vanityHost, cluster); err != nil {
+		// Do NOT adopt a host we could not make servable — leaving VanityURL
+		// empty makes every read path fall back to the working placeholder
+		// host, and the heartbeat repair re-attempts adoption once a route
+		// exists (the cluster-wildcard/vllm-d case included).
+		s.logger.Warn("vanity host is not served: could not add it to the spoke ingress/route — "+
+			"keeping the working placeholder host; the heartbeat repair will retry",
+			"hive", hiveID, "host", vanityHost, "cluster", cluster.ID, "error", err)
+		return
+	}
+	h = loadSaaSHive(hiveID)
+	if h == nil {
+		return
+	}
+	if h.VanityURL != "" {
+		return // another path minted one while we were in kubectl — keep it
+	}
+	h.VanityURL = "https://" + vanityHost
+	if err := saveSaaSHive(h); err != nil {
+		s.logger.Error("claim vanity mint: failed to save hive", "hive", hiveID, "error", err)
+	}
+}
+
 // existingVanityHost returns the host an already-created vanity route/ingress
 // on the spoke is serving, or "" when there is none (or the cluster cannot be
 // reached).

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -696,9 +696,16 @@ type HubServer struct {
 	// single repair attempt spends minutes in kubectl dial timeouts while beats
 	// keep arriving every ~2 min; without this guard the attempts pile up
 	// goroutines all hanging against the same dead cluster.
-	vanityRepairInFlight sync.Map                         // hive ID → struct{}
-	heartbeatHealth      map[string]*HeartbeatHealthEntry // cluster ID → latest health from spoke heartbeat
-	heartbeatHealthMu    sync.RWMutex
+	vanityRepairInFlight sync.Map // hive ID → struct{}
+	// claimWorkInFlight tracks hive IDs whose claim-time cluster work
+	// (namespace identity stamp + vanity mint) is currently running in the
+	// background (kickClaimClusterWorkAsync), so assign/approve start at most
+	// one work-set per hive. Same rationale as vanityRepairInFlight above: a
+	// single attempt against an unreachable cluster spends minutes in kubectl
+	// dial timeouts, and stacking attempts piles up goroutines for no benefit.
+	claimWorkInFlight sync.Map                         // hive ID → struct{}
+	heartbeatHealth   map[string]*HeartbeatHealthEntry // cluster ID → latest health from spoke heartbeat
+	heartbeatHealthMu sync.RWMutex
 
 	// liveHiveUsers maps a GitHub username → the last time any hive reported it as
 	// having a live dashboard session. It powers the "logged into their hive right


### PR DESCRIPTION
## Symptom

"When I assign a request, the assignment dialog stays up for about a minute." The assign/approve endpoints ran kubectl against the hive's cluster **between persisting the assignment and writing the HTTP response**, and both dashboard dialogs await that fetch. On a cluster the hub cannot reach (vllm-d is heartbeat-only, `dial tcp ...:6443: i/o timeout`), each kubectl call eats a ~45s TCP dial timeout — the dialog is held hostage for ~1 min.

Same disease #2730 cured on the heartbeat path; this applies the same cure to the request path.

## Blocking calls found (before the response was written)

**`handleAssignHive`** (v2/pkg/hub/saas.go):
- `s.makeVanityHostServable(...)` → `addVanityHostToIngress` (v2/pkg/hub/saas_provision.go): up to 4–6 **unbounded** `kubectlForCluster(...).Output()/Run()` calls (get route/ingress + apply/patch per object). ~45s dial timeout each on an unreachable cluster; ~90s observed live for this path in #2730's investigation.
- `stampHostedNamespaceIdentity(...)` (v2/pkg/hub/hosted_namespace_identity.go): 2 kubectl calls bounded at 15s each — up to 30s more.

**`handleApproveProvision`** (v2/pkg/hub/saas.go):
- `stampHostedNamespaceIdentity(...)`: up to 30s.

Everything else on both paths (meta.json save, owner grant via user record, `storePendingGitHubAppConfig`, provision-request save, audit/timeline) is fast local file/memory work and stays synchronous.

## Fix

- Handlers now: validate → persist → **respond immediately** → `kickClaimClusterWorkAsync(hiveID)`.
- `kickClaimClusterWorkAsync` (v2/pkg/hub/saas_provision.go) runs the namespace-identity stamp + vanity mint in the background:
  - per-hive in-flight guard (`claimWorkInFlight` sync.Map) so dialog retries / double-submits never stack goroutines against a dead cluster — the exact #2730 `kickVanityURLRepairAsync` pattern;
  - registered with `provisionWG` per the established background-provision goroutine contract;
  - the mint additionally takes the **same** per-hive guard the heartbeat repair uses (`vanityRepairInFlight`), so a beat-kicked repair and a claim-time mint never mint concurrently.
- `mintClaimVanityURL` preserves the inline semantics verbatim: name-bearing Option B host preferred, org/repo fallback, same `makeVanityHostServable` seam, **never adopt an unservable host** (the vllm-d 503 rule). One addition: reload-before-adopt, since the slow kubectl window now overlaps live heartbeat writes (same hazard `repairVanityURLForHive` documents).
- Nothing moved off the request path is required for response semantics: the claim is delivered to the spoke over the heartbeat channel (`projectConfigForHiveID`) from the already-persisted record; the stamp is best-effort by contract; a failed mint keeps its existing retry (heartbeat-kicked repair) and Warn surfacing. Bonus: approve now kicks the vanity mint immediately instead of waiting for the next beat.
- Frontend: no change needed — both dialogs already close on fetch resolution (`confirmAssign` / `confirmApprove`); the server latency was the entire bug. The row's existing "Assigning to X / claim pending" indicators (#2712) show delivery progress.

## Tests

- `TestAssignRespondsWhileClusterWorkBlocked` / `TestApproveRespondsWhileClusterWorkBlocked`: both cluster seams blocked (vanity seam + a blocking fake kubectl) — response must arrive immediately, with the assignment/approval fully persisted and VanityURL not yet adopted; after release the background mint adopts the host exactly as inline code did.
- `TestKickClaimClusterWorkDedupesPerHive`: kicks never stack while one work-set is in flight; a fresh kick runs after the drain.
- Existing synchronous-expectation tests updated to drain `provisionWG` before asserting (stamp/vanity assertions in `hosted_namespace_identity_test.go`, `hub_filesystem_test.go`).
