### PR TITLE
fix: wrong-forge repair targets the hive's elected forge, not the cluster app

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -188,6 +188,17 @@ func prospectiveGitHubIdentity(cur config.GitHubConfig, ghCfg *hub.HeartbeatGitH
 //	                     hub does not track; reading that as a clear would blank
 //	                     a working installation fleet-wide and turn a key-only
 //	                     fault into a total auth outage.
+//
+// docs_installation_id is DELIBERATELY untouched by all three cases. It is the
+// optional docs-org add-on installation, has no rediscovery flow (zero simply
+// disables the docs token refresh, permanently), and a stale value is
+// non-fatal: the periodic docs mint warns and retries. After an app-changing
+// delivery it can therefore briefly equal the PREVIOUS app's installation id —
+// which looks like the old installation_id was "parked" there, but is just the
+// provisioned docs value (public hives commonly provision both fields with the
+// same installation) surviving a reset that correctly cleared only
+// installation_id. On a flip-back to the original App it becomes valid again
+// on its own.
 func nextInstallationID(current int64, ghCfg *hub.HeartbeatGitHubAppConfig) (next int64, reset bool) {
 	if ghCfg == nil {
 		return current, false

--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -261,6 +261,23 @@ func (s *HubServer) appIdentityForHive(h *SaaSHive, clusterID string) *clusterAp
 		return nil
 	}
 	resolved := ResolveHiveIdentityInFleet(h, &c, s.forgeAppsAcrossFleet())
+	// A hive that ELECTED a forge no cluster entry names an App on still has a
+	// real App when that forge's App is a build constant (public github.com, the
+	// known GHE instance). Without this, a public-elected hive on a GHE-only
+	// fleet resolved AppID 0, this function returned nil, and the wrong-forge
+	// repair could never deliver — the hub held the right answer (github_host
+	// restored to github.com) and answered nothing, beat after beat, which is
+	// how six restored public hives stayed on the GHE App on 2026-08-05.
+	// Scoped to FromHiveIntent: a cluster-default resolution that names no App
+	// still yields nil, so no cluster gets an identity invented for it.
+	if resolved.AppID == 0 && resolved.FromHiveIntent && resolved.Forge != "" {
+		if appID, slug := builtinAppOfForge(resolved.Forge); appID != 0 {
+			resolved.AppID = appID
+			if resolved.AppSlug == "" {
+				resolved.AppSlug = slug
+			}
+		}
+	}
 	if resolved.AppID == 0 {
 		return nil
 	}
@@ -596,7 +613,7 @@ const (
 // are distinguishable without heuristics. A GitHub App JWT is signed by the
 // private key and presented alongside an app_id; GitHub verifies the signature
 // against the public key registered for THAT app_id. So for a hive reporting
-// app_id == cluster.AppID with a key fingerprint != cluster.Fingerprint, the
+// app_id == identity.AppID with a key fingerprint != identity.Fingerprint, the
 // credential pair is provably unusable — not "probably stale", not "differently
 // configured", but arithmetically incapable of producing a token. That is
 // exactly the state three live GHE hives are in: they carry the PUBLIC
@@ -651,8 +668,20 @@ const (
 // hosts hives of BOTH forges (vllm-d carries github.ibm.com projects beside
 // github.com ones), so cluster membership alone proves nothing about any one
 // hive. See appKeyReasonWrongForgeApp.
-func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned, spokeOnWrongForge bool, spokeAppID int64, cluster *clusterAppIdentity) appKeySyncDecision {
-	if cluster == nil {
+//
+// THE identity PARAMETER IS THE HIVE'S RESOLVED IDENTITY, NOT THE CLUSTER'S.
+// It is the App of the hive's ELECTED forge (appIdentityForHive /
+// ResolveHiveIdentityInFleet), which coincides with the cluster's App only for
+// hives that elected nothing or elected their cluster's own forge. The caller
+// (appKeyConfigForHeartbeat) guarantees that whenever spokeOnWrongForge is
+// true the identity's App genuinely belongs to the elected forge. That
+// guarantee is load-bearing for the wrong-forge gate below: comparing the
+// spoke's App against the CLUSTER's App instead is exactly what made the
+// repair unreachable for a public-elected hive mis-flipped onto its GHE
+// cluster's own App (5686 == 5686 — the gate saw the spoke's broken App on
+// both sides and stood down, every beat, for six live hives on 2026-08-05).
+func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned, spokeOnWrongForge bool, spokeAppID int64, identity *clusterAppIdentity) appKeySyncDecision {
+	if identity == nil {
 		return appKeySyncDecision{Reason: appKeyReasonNoClusterKey, FromFingerprint: spokeFingerprint}
 	}
 	if hivePublicPinned {
@@ -662,7 +691,7 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned, 
 		return appKeySyncDecision{
 			Reason:          appKeyReasonPublicHiveOnGHECluster,
 			FromFingerprint: strings.TrimSpace(spokeFingerprint),
-			ToFingerprint:   cluster.Fingerprint,
+			ToFingerprint:   identity.Fingerprint,
 		}
 	}
 	fp := strings.TrimSpace(spokeFingerprint)
@@ -689,10 +718,10 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned, 
 	if spokeAppID == config.PlaceholderAppID {
 		return appKeySyncDecision{
 			Push:            true,
-			PushKey:         cluster.HasKey(),
+			PushKey:         identity.HasKey(),
 			Reason:          appKeyReasonPlaceholderAppID,
 			FromFingerprint: fp,
-			ToFingerprint:   cluster.Fingerprint,
+			ToFingerprint:   identity.Fingerprint,
 		}
 	}
 	// A spoke holding an App from ANOTHER forge is broken for the same reason the
@@ -713,20 +742,27 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned, 
 	// Like the sentinel repair this does NOT require the hub to hold the cluster's
 	// key — correcting a cross-forge app_id/app_slug is a non-secret change and is
 	// the whole fix for a hive whose owner has yet to install the App at all.
-	if spokeOnWrongForge && spokeAppID != 0 && spokeAppID != cluster.AppID {
+	//
+	// The third clause compares the spoke's App against the HIVE'S ELECTED
+	// forge's App — identity is the per-hive resolution, never the raw cluster
+	// record. For a coherent identity it is implied by spokeOnWrongForge (the
+	// spoke's App is another forge's, the identity's is the elected forge's, and
+	// no App ID belongs to two forges); it stays as a guard so an incoherent
+	// caller can never make this branch push a spoke's own broken App back at it.
+	if spokeOnWrongForge && spokeAppID != 0 && spokeAppID != identity.AppID {
 		return appKeySyncDecision{
 			Push:            true,
-			PushKey:         cluster.HasKey(),
+			PushKey:         identity.HasKey(),
 			Reason:          appKeyReasonWrongForgeApp,
 			FromFingerprint: fp,
-			ToFingerprint:   cluster.Fingerprint,
+			ToFingerprint:   identity.Fingerprint,
 		}
 	}
 	// Beyond the sentinel repair every remaining decision is about REPLACING the
 	// spoke's key, which the hub cannot do without holding one. Stopping here
 	// keeps a keyless cluster from reporting a "mismatch" against an empty
 	// fingerprint and pushing a blank key over a working one.
-	if !cluster.HasKey() {
+	if !identity.HasKey() {
 		return appKeySyncDecision{
 			Reason:          appKeyReasonNoClusterKey,
 			FromFingerprint: fp,
@@ -737,33 +773,33 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned, 
 		// there is nothing to decide and nothing to send. Checking this ahead of
 		// the app_id logic also means a hive whose provisioned key happens to be
 		// correct never enters the exception path at all.
-		if fp != "" && fp == cluster.Fingerprint {
+		if fp != "" && fp == identity.Fingerprint {
 			return appKeySyncDecision{
 				Reason:          appKeyReasonMatch,
 				FromFingerprint: fp,
-				ToFingerprint:   cluster.Fingerprint,
+				ToFingerprint:   identity.Fingerprint,
 			}
 		}
 		// The exception: the hive claims this cluster's App but cannot sign for
 		// it. Requires a POSITIVE app_id match — zero (unknown) and any other
 		// App both fall through to the protected override below.
-		if spokeAppID != 0 && spokeAppID == cluster.AppID && fp != "" && fp != cluster.Fingerprint {
+		if spokeAppID != 0 && spokeAppID == identity.AppID && fp != "" && fp != identity.Fingerprint {
 			return appKeySyncDecision{
 				Push:            true,
 				PushKey:         true,
 				Reason:          appKeyReasonPerHiveUnusable,
 				FromFingerprint: fp,
-				ToFingerprint:   cluster.Fingerprint,
+				ToFingerprint:   identity.Fingerprint,
 			}
 		}
 		reason := appKeyReasonPerHiveOverride
-		if spokeAppID != 0 && spokeAppID != cluster.AppID {
+		if spokeAppID != 0 && spokeAppID != identity.AppID {
 			reason = appKeyReasonDifferentApp
 		}
 		return appKeySyncDecision{
 			Reason:          reason,
 			FromFingerprint: fp,
-			ToFingerprint:   cluster.Fingerprint,
+			ToFingerprint:   identity.Fingerprint,
 		}
 	}
 	if fp == "" {
@@ -771,22 +807,22 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey, hivePublicPinned, 
 			Push:          true,
 			PushKey:       true,
 			Reason:        appKeyReasonSpokeHasNoKey,
-			ToFingerprint: cluster.Fingerprint,
+			ToFingerprint: identity.Fingerprint,
 		}
 	}
-	if fp != cluster.Fingerprint {
+	if fp != identity.Fingerprint {
 		return appKeySyncDecision{
 			Push:            true,
 			PushKey:         true,
 			Reason:          appKeyReasonMismatch,
 			FromFingerprint: fp,
-			ToFingerprint:   cluster.Fingerprint,
+			ToFingerprint:   identity.Fingerprint,
 		}
 	}
 	return appKeySyncDecision{
 		Reason:          appKeyReasonMatch,
 		FromFingerprint: fp,
-		ToFingerprint:   cluster.Fingerprint,
+		ToFingerprint:   identity.Fingerprint,
 	}
 }
 
@@ -848,6 +884,51 @@ func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFing
 	if hiveForgeKnown && identity != nil && identity.Forge != "" {
 		if spokeForge := s.forgeOfSpokeAppID(spokeAppID); spokeForge != "" && !sameGitHubHost(spokeForge, identity.Forge) {
 			spokeOnWrongForge = true
+		}
+	}
+	// THE REPAIR DELIVERS THE ELECTED FORGE'S APP — NEVER ANOTHER FORGE'S.
+	//
+	// The identity resolved above is supposed to be the hive's elected forge's
+	// App, but two config shapes can leak a wrong-forge App into it: a cluster
+	// record whose flat github_app_id names the GHE App while its blank urls
+	// default the record to public (the App lands keyed under the hive's OWN
+	// forge), and any equivalent drift in a forges map. Delivering that identity
+	// would push the spoke's broken App straight back at it — and the delivery
+	// gate below, comparing the spoke's App against the SAME wrong App
+	// (5686 == 5686), would instead stand down and deliver nothing forever.
+	// That dead gate is why six public hives whose hub meta was correctly
+	// restored to github_host=github.com received no re-delivery across many
+	// heartbeats on 2026-08-05 and had to be hand-restored from backups.
+	//
+	// So when the spoke is provably on the wrong forge, verify the identity
+	// being delivered is provably NOT: an App whose issuing forge is known
+	// (config.ForgeOfAppID) must agree with the hive's elected forge, else it is
+	// rebuilt from the build's own App for that forge — with the key looked up
+	// by the App it belongs to, and the urls stated explicitly so the spoke is
+	// moved off the wrong forge's urls in the same atomic set. If the build
+	// cannot name an App on the elected forge either, the repair stands down
+	// rather than deliver another forge's App.
+	if spokeOnWrongForge {
+		if f := config.ForgeOfAppID(identity.AppID); f != "" && !sameGitHubHost(f, identity.Forge) {
+			if appID, slug := builtinAppOfForge(identity.Forge); appID != 0 {
+				identity.AppID = appID
+				identity.AppSlug = slug
+				// The key must follow the App: whatever key rode in with the
+				// leaked identity signs for the WRONG App. Empty means "leave
+				// the spoke's key alone", which is the safe floor.
+				identity.PrivateKey, identity.Fingerprint = "", ""
+				if k, found := s.appKeysByAppID()[appID]; found && k.PrivateKey != "" {
+					identity.PrivateKey, identity.Fingerprint = k.PrivateKey, k.Fingerprint
+				}
+				if isPublicForgeHost(identity.Forge) {
+					identity.APIURL, identity.BaseURL = config.DefaultGitHubAPIURL, config.DefaultGitHubBaseURL
+				} else {
+					identity.BaseURL = "https://" + forgeHostLabel(identity.Forge)
+					identity.APIURL = identity.BaseURL + gheAPIPathSuffix
+				}
+			} else {
+				spokeOnWrongForge = false
+			}
 		}
 	}
 	// The public pin is honoured BY the per-hive identity now: a public-pinned

--- a/v2/pkg/hub/ghe_forge_map_shape_test.go
+++ b/v2/pkg/hub/ghe_forge_map_shape_test.go
@@ -643,6 +643,185 @@ func TestStaleInstallationReset(t *testing.T) {
 	}
 }
 
+// TestWrongForgeRepairTargetsElectedForge pins the residual 2026-08-05 gate bug
+// closed: the wrong-forge repair must deliver the App of the HIVE'S ELECTED
+// forge, never compare the spoke against the CLUSTER's App.
+//
+// The live failure: six public hives (llm-d wva, llm-d-incubation, kellyaa,
+// kalantar, ai-native, alchemy) had their hub meta correctly restored to
+// github_host=github.com after the #2713 mis-flip, but their spokes stayed on
+// the GHE cluster's own App 5686. The delivery gate compared the spoke's app_id
+// against the cluster's (5686 == 5686) and stood down — zero re-deliveries
+// across many heartbeats, until each spoke was hand-restored from its
+// /data/hive.yaml.bak. The gate must instead compare against — and deliver —
+// the elected forge's App (public 3568013), with #2732's installation-reset
+// semantics (app change → ResetInstallation → rediscovery re-adopts the org's
+// existing public installation).
+func TestWrongForgeRepairTargetsElectedForge(t *testing.T) {
+	withTempAppKeyDir(t)
+	oldHives := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = oldHives })
+	storeKeyFor(t, "vllm-d")
+
+	// The 2026-08-05 spoke state: mis-flipped onto the GHE cluster's own App,
+	// GHE urls adopted, old public installation_id still in place (it 404s
+	// under App 5686).
+	misflippedReport := func(id string) *HeartbeatPayload {
+		return &HeartbeatPayload{
+			HiveID:               id,
+			ClusterID:            "vllm-d",
+			GitHubAPIURL:         identGHEAPIURL,
+			GitHubBaseURL:        identGHEBaseURL,
+			GitHubAppID:          testGHEAppID,
+			GitHubInstallationID: 146551814,
+		}
+	}
+	publicHive := func(id string) *SaaSHive {
+		return &SaaSHive{
+			ID: id, Status: statusAssigned, ClusterID: "vllm-d",
+			Org: "llm-d", GitHubHost: publicForgeHost,
+		}
+	}
+	assertPublicRestore := func(t *testing.T, cfg *HeartbeatGitHubAppConfig) {
+		t.Helper()
+		if cfg == nil {
+			t.Fatal("NO delivery — the exact live symptom: six restored hives sat on the wrong GHE identity across many heartbeats")
+		}
+		if cfg.AppID != testPublicAppID {
+			t.Fatalf("delivered app_id = %d, want the elected forge's public App %d — never the cluster's %d", cfg.AppID, testPublicAppID, testGHEAppID)
+		}
+		// Explicit public urls: the spoke sits on GHE urls and empty means
+		// "unchanged" on the wire.
+		if cfg.APIURL != config.DefaultGitHubAPIURL || cfg.BaseURL != config.DefaultGitHubBaseURL {
+			t.Errorf("restore urls = api=%q base=%q, want explicit public urls", cfg.APIURL, cfg.BaseURL)
+		}
+		// #2732's atomic-set rule: the app changes, so the stale id resets and
+		// rediscovery re-adopts the org's existing public installation.
+		if !cfg.ResetInstallation || cfg.InstallationID != 0 {
+			t.Errorf("app-changing delivery must reset installation_id (got reset=%v id=%d)", cfg.ResetInstallation, cfg.InstallationID)
+		}
+	}
+
+	// The exact live case, hardest form: NO cluster in the fleet names a public
+	// App at all, so the elected forge's App can only come from the build's own
+	// constant. Before the fix appIdentityForHive resolved AppID 0 → nil → the
+	// repair was structurally unreachable.
+	t.Run("public-elected hive mis-flipped onto the cluster App is restored (no public App in fleet)", func(t *testing.T) {
+		s := &HubServer{
+			logger:   appKeyTestLogger(),
+			clusters: map[string]ClusterConfig{"vllm-d": *vllmDForgeMapCluster()},
+		}
+		if err := saveSaaSHive(publicHive("wva")); err != nil {
+			t.Fatal(err)
+		}
+		assertPublicRestore(t, s.appKeySyncForHeartbeat(misflippedReport("wva")))
+	})
+
+	// The literal 5686 == 5686 gate: an under-specified cluster record (flat GHE
+	// app_id, no urls, no default_forge) keys the GHE App under PUBLIC in the
+	// fleet's forge map. The resolver then answered the hive's public election
+	// with the GHE App itself, and the delivery gate compared the spoke's broken
+	// App against the same broken App and stood down forever.
+	t.Run("a leaked cluster App under the public forge label cannot dead-end the gate", func(t *testing.T) {
+		s := &HubServer{
+			logger: appKeyTestLogger(),
+			clusters: map[string]ClusterConfig{
+				// Sorts before vllm-d, so its poisoned public entry wins the map.
+				"a-underspecified": {ID: "a-underspecified", GitHubAppID: testGHEAppID, GitHubAppSlug: identGHESlug},
+				"vllm-d":           *vllmDForgeMapCluster(),
+			},
+		}
+		if err := saveSaaSHive(publicHive("kellyaa")); err != nil {
+			t.Fatal(err)
+		}
+		assertPublicRestore(t, s.appKeySyncForHeartbeat(misflippedReport("kellyaa")))
+	})
+
+	// Regression guard for #2732's original direction (the EPM class): a
+	// GHE-elected hive whose spoke runs the public App must still be moved onto
+	// the GHE identity — in the same minimal one-cluster fleet.
+	t.Run("GHE-elected hive on the public App still gets the GHE identity", func(t *testing.T) {
+		s := &HubServer{
+			logger:   appKeyTestLogger(),
+			clusters: map[string]ClusterConfig{"vllm-d": *vllmDForgeMapCluster()},
+		}
+		if err := saveSaaSHive(&SaaSHive{
+			ID: "epm-guard", Status: statusAssigned, ClusterID: "vllm-d",
+			Org: "epm", GitHubHost: identGHEHost,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		cfg := s.appKeySyncForHeartbeat(&HeartbeatPayload{
+			HiveID:               "epm-guard",
+			ClusterID:            "vllm-d",
+			GitHubAppID:          testPublicAppID,
+			GitHubInstallationID: 146551814,
+		})
+		if cfg == nil || cfg.AppID != testGHEAppID {
+			t.Fatalf("a GHE-elected hive on the public App must be delivered the GHE identity, got %+v", cfg)
+		}
+		if !cfg.ResetInstallation || cfg.InstallationID != 0 {
+			t.Errorf("app-changing delivery must reset installation_id (got reset=%v id=%d)", cfg.ResetInstallation, cfg.InstallationID)
+		}
+	})
+
+	// The healthy case stays untouched: a hive whose elected forge IS its
+	// cluster's forge, converged on that App and key, gets nothing.
+	t.Run("spoke on the cluster App of a cluster-forge hive is never touched", func(t *testing.T) {
+		s := &HubServer{
+			logger:   appKeyTestLogger(),
+			clusters: map[string]ClusterConfig{"vllm-d": *vllmDForgeMapCluster()},
+		}
+		if err := saveSaaSHive(&SaaSHive{
+			ID: "certus-healthy", Status: statusAssigned, ClusterID: "vllm-d",
+			Org: "certus", GitHubHost: identGHEHost,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		clusterFP, err := config.AppKeyFingerprint(loadClusterAppKey("vllm-d"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		cfg := s.appKeySyncForHeartbeat(&HeartbeatPayload{
+			HiveID:                  "certus-healthy",
+			ClusterID:               "vllm-d",
+			GitHubAPIURL:            identGHEAPIURL,
+			GitHubBaseURL:           identGHEBaseURL,
+			GitHubAppID:             testGHEAppID,
+			GitHubInstallationID:    777,
+			GitHubAppKeyFingerprint: clusterFP,
+		})
+		if cfg != nil {
+			t.Fatalf("a converged cluster-forge hive was pushed a change: %+v", cfg)
+		}
+	})
+
+	// An App this build does not recognise is a deliberate pin, not evidence of
+	// a wrong forge: silence never triggers the repair.
+	t.Run("unknown spoke App stays protected as a deliberate pin", func(t *testing.T) {
+		s := &HubServer{
+			logger:   appKeyTestLogger(),
+			clusters: map[string]ClusterConfig{"vllm-d": *vllmDForgeMapCluster()},
+		}
+		if err := saveSaaSHive(publicHive("visual")); err != nil {
+			t.Fatal(err)
+		}
+		const thirdPartyAppID = 4240368 // daviddiaz0317-visual-hive: real fleet shape
+		cfg := s.appKeySyncForHeartbeat(&HeartbeatPayload{
+			HiveID:                  "visual",
+			ClusterID:               "vllm-d",
+			GitHubAppID:             thirdPartyAppID,
+			GitHubInstallationID:    888,
+			GitHubAppKeyPerHive:     true,
+			GitHubAppKeyFingerprint: "sha256:cccccccccccccccccccccccccccccccc",
+		})
+		if cfg != nil {
+			t.Fatalf("an unrecognised App was 'repaired' — unknown is never a mismatch: %+v", cfg)
+		}
+	})
+}
+
 // TestForgeAppsAcrossFleetForgeMapShape proves a forge declared only in the
 // `forges` map is discoverable fleet-wide, so a hive that elects it on a
 // DIFFERENT cluster can still borrow the App.

--- a/v2/pkg/hub/ghe_forge_map_shape_test.go
+++ b/v2/pkg/hub/ghe_forge_map_shape_test.go
@@ -421,11 +421,21 @@ func TestBrokenSpokeForgeReportNotAdopted(t *testing.T) {
 	if h := loadSaaSHive("restored"); h == nil || h.GitHubHost != publicForgeHost {
 		t.Fatalf("github_host = %q, want %q", h.GitHubHost, publicForgeHost)
 	}
-	// The same report from a HEALTHY spoke still repairs public→GHE (vllmd-06).
+	// The same report from a spoke that LOOKS healthy (fresh boot: no failure
+	// reported yet) must not be adopted either — an explicit recorded host is
+	// never overwritten from a spoke report. This is the second half of the
+	// 2026-08-05 loop: the restored meta was re-stomped by a freshly-booted
+	// spoke still carrying the mis-delivered GHE identity, and the wrong-forge
+	// repair then re-delivered the GHE App against the re-stomped record.
 	payload.GitHubAppRequired = false
 	payload.GitHubAppState = ""
-	if !s.reconcileGitHubHostFromSpoke(payload) {
-		t.Fatal("a healthy spoke's positive GHE report must still be adopted (the vllmd-06 repair)")
+	payload.GitHubAppID = testGHEAppID
+	payload.GitHubInstallationID = 146551814 // stale public id a pre-atomic-set flip left behind
+	if s.reconcileGitHubHostFromSpoke(payload) {
+		t.Fatal("a spoke report overwrote an explicit github_host — the hand-repair revert loop is back")
+	}
+	if h := loadSaaSHive("restored"); h == nil || h.GitHubHost != publicForgeHost {
+		t.Fatalf("github_host = %q, want %q — the restored record must hold", h.GitHubHost, publicForgeHost)
 	}
 }
 
@@ -820,6 +830,96 @@ func TestWrongForgeRepairTargetsElectedForge(t *testing.T) {
 			t.Fatalf("an unrecognised App was 'repaired' — unknown is never a mismatch: %+v", cfg)
 		}
 	})
+}
+
+// TestHandRepairDoesNotRevert pins the FULL 2026-08-05 feedback loop closed, as
+// observed on hosted-kalantar-msb-soft-reflect-jsro:
+//
+//  1. operator restores hub meta github_host -> github.com and the spoke to the
+//     public App;
+//  2. the spoke reboots (or beats) still carrying — or re-delivered — the GHE
+//     identity, and reports it BEFORE its first token mint fails, so it looks
+//     healthy; reconcileGitHubHostFromSpoke re-stomped meta back to
+//     github.ibm.com from that report;
+//  3. with meta back at GHE and the spoke on the public App, the EPM-class
+//     wrong-forge branch fired and re-delivered the GHE identity with an
+//     installation reset.
+//
+// Every hand-repair reverted within minutes; all six restored metas were
+// re-stomped within ~30 minutes. The loop must be broken at step 2 (a spoke
+// report never overwrites an explicit meta host) while step 3's delivery — now
+// derived from the intact meta — moves the SPOKE back to public instead.
+func TestHandRepairDoesNotRevert(t *testing.T) {
+	withTempAppKeyDir(t)
+	oldHives := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = oldHives })
+	storeKeyFor(t, "vllm-d")
+
+	s := &HubServer{
+		logger:   appKeyTestLogger(),
+		clusters: map[string]ClusterConfig{"vllm-d": *vllmDForgeMapCluster()},
+	}
+	// The hand-restored record: meta explicitly public.
+	if err := saveSaaSHive(&SaaSHive{
+		ID: "kalantar", Status: statusAssigned, ClusterID: "vllm-d",
+		Org: "kalantar", GitHubHost: publicForgeHost,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 2's beat: a freshly-booted spoke still on the mis-delivered GHE
+	// identity — GHE urls, the cluster's App, a leftover non-zero installation —
+	// reporting NO failure yet (its first github call has not happened).
+	freshBootGHE := &HeartbeatPayload{
+		HiveID:               "kalantar",
+		ClusterID:            "vllm-d",
+		GitHubHost:           identGHEHost,
+		GitHubAPIURL:         identGHEAPIURL,
+		GitHubBaseURL:        identGHEBaseURL,
+		GitHubAppID:          testGHEAppID,
+		GitHubInstallationID: 146551814,
+	}
+
+	// The record must hold against the full heartbeat repair surface.
+	if s.reconcileGitHubHostFromSpoke(freshBootGHE) {
+		t.Fatal("a fresh-boot spoke report overwrote the hand-restored github_host — the revert loop's step 2")
+	}
+	s.repairMisflippedForgeFromRequest(freshBootGHE)
+	if h := loadSaaSHive("kalantar"); h == nil || h.GitHubHost != publicForgeHost {
+		t.Fatalf("github_host = %q, want %q — the hand-repair reverted", h.GitHubHost, publicForgeHost)
+	}
+
+	// And the SAME beat's delivery must move the spoke back to public — never
+	// re-deliver the GHE identity (the loop's step 3).
+	cfg := s.appKeySyncForHeartbeat(freshBootGHE)
+	if cfg == nil {
+		t.Fatal("no delivery — the mis-flipped spoke must be moved back onto the public App")
+	}
+	if cfg.AppID == testGHEAppID {
+		t.Fatalf("the GHE identity was re-delivered against a public meta — the loop's step 3: %+v", cfg)
+	}
+	if cfg.AppID != testPublicAppID || !cfg.ResetInstallation || cfg.InstallationID != 0 {
+		t.Fatalf("want the public App %d with an installation reset, got %+v", testPublicAppID, cfg)
+	}
+
+	// Once the spoke converges on the public identity, everything goes quiet:
+	// no further delivery, and its public report never touches the record.
+	converged := &HeartbeatPayload{
+		HiveID:               "kalantar",
+		ClusterID:            "vllm-d",
+		GitHubAppID:          testPublicAppID,
+		GitHubInstallationID: 146551814, // rediscovery re-adopted the old public installation
+	}
+	if s.reconcileGitHubHostFromSpoke(converged) {
+		t.Error("a converged public report rewrote the record")
+	}
+	if cfg := s.appKeySyncForHeartbeat(converged); cfg != nil && (cfg.AppID != 0 || cfg.ResetInstallation) {
+		t.Errorf("a converged spoke was pushed an identity change: %+v", cfg)
+	}
+	if h := loadSaaSHive("kalantar"); h == nil || h.GitHubHost != publicForgeHost {
+		t.Fatalf("github_host = %q after convergence, want %q", h.GitHubHost, publicForgeHost)
+	}
 }
 
 // TestForgeAppsAcrossFleetForgeMapShape proves a forge declared only in the

--- a/v2/pkg/hub/github_host_assignment_test.go
+++ b/v2/pkg/hub/github_host_assignment_test.go
@@ -265,12 +265,15 @@ func TestRepairedHostReachesSpokeViaHeartbeat(t *testing.T) {
 		t.Fatalf("expected no push before the host is recorded, got %+v", pc)
 	}
 
-	// A HEALTHY spoke positively reporting the GHE forge records the host — the
-	// per-hive evidence path that replaced the cluster-default fill.
+	// A WORKING spoke coherently reporting the GHE forge — GHE urls, the GHE
+	// App, a live installation — backfills the still-empty host: the per-hive
+	// evidence path that replaced the cluster-default fill. (Urls alone no
+	// longer qualify: they are exactly what a mis-delivery leaves behind.)
 	if !s.reconcileGitHubHostFromSpoke(&HeartbeatPayload{
 		HiveID: h.ID, ClusterID: defaultClusterID, GitHubHost: gheTestHost, GitHubAPIURL: gheTestAPIURL,
+		GitHubAppID: testGHEAppID, GitHubInstallationID: 42,
 	}) {
-		t.Fatal("a healthy spoke's positive GHE report did not record the host")
+		t.Fatal("a working spoke's coherent GHE report did not backfill the empty host")
 	}
 
 	// After the repair the very next heartbeat must carry the GHE API URL.

--- a/v2/pkg/hub/github_host_backfill_test.go
+++ b/v2/pkg/hub/github_host_backfill_test.go
@@ -6,9 +6,12 @@ import (
 	"log/slog"
 )
 
-// reconcileGitHubHostFromSpoke must repair a persisted host that is set but WRONG
-// (public→GHE) from the forge the spoke reports, while never demoting a legit
-// public pin and never firing on an unknown/blank report.
+// reconcileGitHubHostFromSpoke must backfill an EMPTY github_host from a spoke
+// whose whole github block coherently, workingly names a forge — and must NEVER
+// overwrite an explicit recorded host from a spoke report (the report is
+// downstream of hub delivery: adopting a contradiction launders a mis-delivery
+// back into the record, the 2026-08-05 revert loop), never demote a legit
+// public pin, and never fire on an unknown/blank report.
 func TestReconcileGitHubHostFromSpoke(t *testing.T) {
 	oldHives := saasHivesDir
 	saasHivesDir = t.TempDir()
@@ -34,15 +37,98 @@ func TestReconcileGitHubHostFromSpoke(t *testing.T) {
 		return changed, got
 	}
 
-	t.Run("wrong github.com host is corrected to spoke-reported GHE (base-or-api)", func(t *testing.T) {
-		// The vllmd-06 class: meta says github.com, spoke reports blank base_url but
-		// a GHE api_url. base-or-api must still recognise GHE.
+	t.Run("an explicit recorded host is NEVER overwritten from a spoke report", func(t *testing.T) {
+		// Even a fully coherent, working-looking GHE report cannot overwrite an
+		// explicitly recorded github.com host: the spoke's github block is
+		// downstream of hub delivery, so a contradiction is at best a
+		// mis-delivery echoing back. Adopting it is the 2026-08-05 revert loop:
+		// hand-restored metas were re-stomped GHE within ~30 minutes by exactly
+		// this path, and the wrong-forge repair then re-delivered the GHE App.
+		// The vllmd-06 class (meta github.com, repo genuinely on GHE) is now
+		// operator/forge-switch territory, deliberately.
 		changed, got := run(t,
 			&SaaSHive{ID: "vllmd-06", Status: "claimed", GitHubHost: "github.com"},
-			&HeartbeatPayload{HiveID: "vllmd-06", GitHubHost: "", GitHubAPIURL: "https://github.ibm.com/api/v3"},
+			&HeartbeatPayload{
+				HiveID:               "vllmd-06",
+				GitHubHost:           "github.ibm.com",
+				GitHubAPIURL:         "https://github.ibm.com/api/v3",
+				GitHubAppID:          testGHEAppID,
+				GitHubInstallationID: 42,
+			},
+		)
+		if changed || got != "github.com" {
+			t.Errorf("got (changed=%v, host=%q), want (false, github.com) — the recorded host is the authority", changed, got)
+		}
+	})
+
+	t.Run("an EMPTY host is backfilled from a coherent working GHE report", func(t *testing.T) {
+		// base-or-api: blank base_url with a GHE api_url still recognises GHE.
+		// Positive evidence complete: an App of that forge, live installation.
+		changed, got := run(t,
+			&SaaSHive{ID: "blank-working", Status: "claimed"},
+			&HeartbeatPayload{
+				HiveID:               "blank-working",
+				GitHubHost:           "",
+				GitHubAPIURL:         "https://github.ibm.com/api/v3",
+				GitHubAppID:          testGHEAppID,
+				GitHubInstallationID: 42,
+			},
 		)
 		if !changed || got != "github.ibm.com" {
 			t.Errorf("got (changed=%v, host=%q), want (true, github.ibm.com)", changed, got)
+		}
+	})
+
+	t.Run("empty host: a fresh-boot report with installation 0 is not evidence", func(t *testing.T) {
+		// The fresh-boot gap: a just-booted mis-delivered spoke has not failed
+		// yet, so "not failing" alone must not admit it. A zeroed installation
+		// is a repair in flight (ResetInstallation), never a forge election.
+		changed, got := run(t,
+			&SaaSHive{ID: "blank-reset", Status: "claimed"},
+			&HeartbeatPayload{
+				HiveID:               "blank-reset",
+				GitHubAPIURL:         "https://github.ibm.com/api/v3",
+				GitHubAppID:          testGHEAppID,
+				GitHubInstallationID: 0,
+			},
+		)
+		if changed || got != "" {
+			t.Errorf("got (changed=%v, host=%q), want (false, \"\") — a mid-reset spoke proves nothing", changed, got)
+		}
+	})
+
+	t.Run("empty host: GHE urls beside the PUBLIC App are a mis-delivery artifact", func(t *testing.T) {
+		// The github block must coherently name ONE forge: leftover GHE urls
+		// with the public app_id are exactly what a half-applied mis-delivery
+		// (or a half-completed restore) looks like.
+		changed, got := run(t,
+			&SaaSHive{ID: "blank-incoherent", Status: "claimed"},
+			&HeartbeatPayload{
+				HiveID:               "blank-incoherent",
+				GitHubAPIURL:         "https://github.ibm.com/api/v3",
+				GitHubAppID:          testGitHubComAppID,
+				GitHubInstallationID: 42,
+			},
+		)
+		if changed || got != "" {
+			t.Errorf("got (changed=%v, host=%q), want (false, \"\") — an incoherent block is not a forge", changed, got)
+		}
+	})
+
+	t.Run("empty host: an auth-failing spoke is never adopted", func(t *testing.T) {
+		changed, got := run(t,
+			&SaaSHive{ID: "blank-failing", Status: "claimed"},
+			&HeartbeatPayload{
+				HiveID:               "blank-failing",
+				GitHubAPIURL:         "https://github.ibm.com/api/v3",
+				GitHubAppID:          testGHEAppID,
+				GitHubInstallationID: 42,
+				GitHubAppRequired:    true,
+				GitHubAppState:       spokeAppStateNotInstalled,
+			},
+		)
+		if changed || got != "" {
+			t.Errorf("got (changed=%v, host=%q), want (false, \"\") — a failing spoke's forge is not its forge", changed, got)
 		}
 	})
 

--- a/v2/pkg/hub/hive_identity.go
+++ b/v2/pkg/hub/hive_identity.go
@@ -262,15 +262,52 @@ func ResolveHiveIdentityInFleet(h *SaaSHive, cluster *ClusterConfig, forgeApps m
 		return id
 	}
 	for host, app := range forgeApps {
-		if sameGitHubHost(forgeHostLabel(host), id.Forge) && app.AppID != 0 {
-			id.AppID = app.AppID
-			if id.AppSlug == "" {
-				id.AppSlug = strings.TrimSpace(app.AppSlug)
-			}
-			return id
+		if !sameGitHubHost(forgeHostLabel(host), id.Forge) || app.AppID == 0 {
+			continue
 		}
+		// COHERENCE, not just the map key. forgesForCluster synthesises a
+		// cluster's flat github_app_id under that cluster's DEFAULT forge, and an
+		// under-specified GHE record — flat app_id, no urls, no default_forge —
+		// defaults to PUBLIC, so the fleet map can carry the GHE App keyed under
+		// "github.com". Adopting that entry would hand a public-elected hive the
+		// very wrong-forge App the repair exists to remove — and, worse, make the
+		// wrong-forge delivery gate compare the spoke's broken App against ITSELF
+		// (5686 == 5686) and stand down forever, which is exactly how six restored
+		// public hives sat undelivered across many heartbeats on 2026-08-05.
+		//
+		// So an App whose issuing forge is POSITIVELY known (config.ForgeOfAppID)
+		// must agree with the elected forge before it is borrowed. An App the
+		// build does not recognise (a third forge, self-hosted) is still adopted
+		// exactly as before: unknown is never a mismatch.
+		if f := config.ForgeOfAppID(app.AppID); f != "" && !sameGitHubHost(f, id.Forge) {
+			continue
+		}
+		id.AppID = app.AppID
+		if id.AppSlug == "" {
+			id.AppSlug = strings.TrimSpace(app.AppSlug)
+		}
+		return id
 	}
 	return id
+}
+
+// builtinAppOfForge returns the App this BUILD itself can name on a forge —
+// the two compile-time App identities (public github.com and the known GHE
+// instance) — or 0 for any other forge.
+//
+// A GitHub App ID is a per-forge constant: the public App is the SAME App for
+// every hive on github.com, so answering with the constant is positive
+// knowledge, not invention. This exists for the delivery path, where a repair
+// needs an actual App to move a spoke onto even when no cluster entry in
+// clusters.json happens to name one on the hive's elected forge.
+func builtinAppOfForge(forge string) (int64, string) {
+	switch {
+	case isPublicForgeHost(forge):
+		return config.PublicGitHubAppID, config.PublicGitHubAppSlug
+	case sameGitHubHost(forge, forgeHostLabel(config.EnterpriseGitHubBaseURL)):
+		return config.EnterpriseGitHubAppID, config.EnterpriseGitHubAppSlug
+	}
+	return 0, ""
 }
 
 // hiveClaimed reports whether a hive record is a CLAIMED hive — one with a real

--- a/v2/pkg/hub/hive_identity.go
+++ b/v2/pkg/hub/hive_identity.go
@@ -177,7 +177,8 @@ func ResolveHiveIdentity(h *SaaSHive, cluster *ClusterConfig) HiveIdentity {
 	// forge). A claimed hive's forge comes only from its own recorded host —
 	// and a genuinely-GHE hive always has one: assign records it from the pasted
 	// org URL, backfillGitHubHostFromCluster fills it at claim time, and
-	// reconcileGitHubHostFromSpoke adopts it from a healthy spoke's own report.
+	// reconcileGitHubHostFromSpoke backfills a still-empty record from a
+	// coherently working spoke's own report.
 	if elected == "" && hiveClaimed(h) {
 		elected = publicForgeHost
 	}

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -793,8 +793,10 @@ func backfillGitHubHostFromCluster(h *SaaSHive, cluster *ClusterConfig) string {
 //   - assign/approve record github_host from the pasted org URL (and
 //     backfillGitHubHostFromCluster fills it ONCE, at claim time, for legacy
 //     requests that named no host);
-//   - reconcileGitHubHostFromSpoke adopts the forge a HEALTHY spoke positively
-//     reports it runs;
+//   - reconcileGitHubHostFromSpoke backfills an EMPTY github_host from a spoke
+//     whose whole github block coherently, workingly names a forge — it never
+//     overwrites an explicit record (a spoke's report is downstream of hub
+//     delivery, so a contradiction is a mis-delivery echo, not evidence);
 //   - repairMisflippedForgeFromRequest (below) restores a github_host the
 //     cluster-keyed guard stomped, from the provision request's own record;
 //   - the wrong-forge identity repair (decideAppKeySync /
@@ -907,28 +909,51 @@ func spokeAppAuthFailing(payload *HeartbeatPayload) bool {
 	return false
 }
 
-// reconcileGitHubHostFromSpoke repairs a persisted github_host that is not merely
-// BLANK but WRONG, using the forge the spoke actually reports it is running
-// against. It reports whether it changed anything.
+// reconcileGitHubHostFromSpoke BACKFILLS an EMPTY persisted github_host from
+// the forge a demonstrably WORKING spoke reports it is running against. It
+// reports whether it changed anything.
 //
-// Why: a hive can carry a persisted host that is set AND wrong — assigned from
-// a pasted github.com URL, or seeded with a stale record, while the repo
-// actually lives on GitHub Enterprise (vllmd-06 is the live example — meta said
-// github.com but the spoke ran api_url github.ibm.com). Nothing repaired those;
-// each needed a hand-edit.
+// THE RECORDED HOST IS THE AUTHORITY; A SPOKE'S REPORT IS DOWNSTREAM OF IT.
+// A spoke's github block is whatever the hub last delivered (plus whatever a
+// mis-delivery left behind), so a spoke report can NEVER be treated as
+// independent evidence against an explicitly recorded host — adopting it just
+// launders the hub's own mis-delivery back into the record. That laundering is
+// exactly the feedback loop observed live on 2026-08-05
+// (hosted-kalantar-msb-soft-reflect-jsro, threatened on all 9): an operator
+// restored meta github_host to github.com and the spoke to the public App;
+// this reconcile then re-adopted github.ibm.com from a freshly-booted spoke
+// still carrying the mis-delivered GHE identity — a just-booted spoke has not
+// FAILED yet, so the auth-failing stand-down alone did not protect it — and
+// with meta back at GHE the wrong-forge repair re-delivered the GHE App with
+// an installation reset on the next beat. Every hand-repair reverted within
+// minutes; all six restored metas were re-stomped within ~30 minutes.
 //
-// The spoke's OWN reported forge is authoritative: it is what the running hive is
-// actually configured against. Read it base-or-api across the two reported fields
+// So this function now writes ONLY into an EMPTY github_host. An explicit
+// recorded host that contradicts the spoke is operator/request territory: the
+// forge-switch flow (RequestedGitHubHost) and the request-based restore
+// (repairMisflippedForgeFromRequest) are the paths allowed to change a
+// recorded host, and the wrong-forge delivery repair moves the SPOKE to match
+// the record — never the record to match the spoke. The former public→GHE
+// correction of an explicitly recorded github.com host (the vllmd-06 hand-edit
+// class) is deliberately no longer automatic: it was indistinguishable, from
+// the hub's side, from the mis-delivery laundering above.
+//
+// POSITIVE EVIDENCE ONLY for the empty-host backfill — "not failing yet" is
+// not "working" (the fresh-boot gap above), so adoption requires the spoke's
+// whole github block to coherently name the observed forge AND show a live
+// installation:
+//   - the spoke's reported app_id maps to the SAME forge it reports running
+//     (forgeOfSpokeAppID — leftover urls beside another forge's App are a
+//     mis-delivery artifact, not a forge);
+//   - a NON-ZERO installation_id (a spoke mid-reset/rediscovery is not
+//     evidence);
+//   - no positively reported auth failure (spokeAppAuthFailing).
+//
+// The spoke's forge is read base-or-api across the two reported fields
 // (GitHubHost from base_url, GitHubAPIURL from api_url) so a GHE spoke with a
-// blank base_url — the common state — is still recognised as GHE.
-//
-// CONSERVATIVE, ONE DIRECTION ONLY. It repairs public→GHE: a persisted github.com
-// host that the spoke reports as a GHE host is corrected to that GHE host. It does
-// NOT demote GHE→public, because a hive legitimately pinned to public github.com
-// on a GHE cluster (the appKeyReasonPublicHiveOnGHECluster case) reports
-// github.com by design, and overwriting a GHE record from a transient public read
-// could fight that pin. A blank/unknown spoke report changes nothing (silence is
-// not a mismatch — the same rule the heartbeat fields already follow). Every
+// blank base_url — the common state — is still recognised as GHE. A
+// blank/unknown report changes nothing, and public is never adopted (an empty
+// recorded host already means public github.com for a claimed hive). Every
 // change is logged with before/after.
 func (s *HubServer) reconcileGitHubHostFromSpoke(payload *HeartbeatPayload) bool {
 	if s == nil || payload == nil {
@@ -970,25 +995,40 @@ func (s *HubServer) reconcileGitHubHostFromSpoke(payload *HeartbeatPayload) bool
 	if h.GitHubBaseURL == githubHostPublic || h.GitHubBaseURL == "https://github.com" {
 		return false
 	}
+	// AN EXPLICIT RECORDED HOST IS NEVER OVERWRITTEN FROM A SPOKE REPORT.
+	// The record (assign/approve, operator forge switch, request-based restore)
+	// is the authority; the spoke's github block is downstream of hub delivery,
+	// so a contradicting report is at best a mis-delivery echoing back — the
+	// 2026-08-05 loop that re-stomped six hand-restored metas within ~30
+	// minutes. If the record and the spoke disagree, the wrong-forge delivery
+	// repair moves the SPOKE onto the recorded forge; nothing here moves the
+	// record onto the spoke's.
+	if h.GitHubHost != "" {
+		return false
+	}
+	// EMPTY-host backfill, on positive working evidence only. "Has not failed"
+	// is not "working": a freshly-booted mis-delivered spoke reports the wrong
+	// forge's urls before its first token mint fails, so absence of a failure
+	// report proves nothing (the fresh-boot gap in the old stand-down).
+	//
 	// A BROKEN spoke's forge report is not evidence of intent. A spoke whose App
 	// auth is failing may be running a forge it was mis-delivered (the
 	// 2026-08-05 flip left 9 spokes positively reporting github.ibm.com they
 	// could not authenticate against); adopting that report would launder the
 	// mis-delivery into the hive's record and fight the restore that
-	// repairMisflippedForgeFromRequest performs. Only a spoke that is actually
-	// WORKING on the forge it reports (the vllmd-06 class this reconcile exists
-	// for) is authoritative about it.
+	// repairMisflippedForgeFromRequest performs.
 	if spokeAppAuthFailing(payload) {
 		return false
 	}
-	current := githubHostLabel(h.GitHubHost) // normalize for a like-for-like compare
-	if current == observed {
-		return false // already correct — nothing to do
+	// The whole github block must coherently name the observed forge: an App of
+	// that forge, with a live (non-zero) installation. A spoke carrying GHE urls
+	// beside the public App — or beside a freshly-reset installation_id 0 — is a
+	// mis-delivery artifact or a repair in flight, never a forge election.
+	if payload.GitHubInstallationID == 0 {
+		return false
 	}
-	// Only repair public→GHE. If the persisted host is already some other GHE host,
-	// do not overwrite it from a single beat — that is an operator concern, not a
-	// safe automatic flip.
-	if h.GitHubHost != "" && current != config.DefaultGitHubBaseURL[len("https://"):] {
+	spokeAppForge := s.forgeOfSpokeAppID(payload.GitHubAppID)
+	if spokeAppForge == "" || !sameGitHubHost(spokeAppForge, observed) {
 		return false
 	}
 	before := h.GitHubHost
@@ -998,12 +1038,14 @@ func (s *HubServer) reconcileGitHubHostFromSpoke(payload *HeartbeatPayload) bool
 			"hive", payload.HiveID, "error", err)
 		return false
 	}
-	s.logger.Info("github host reconcile: corrected wrong github_host from spoke-reported forge",
+	s.logger.Info("github host reconcile: backfilled empty github_host from a working spoke's coherent forge report",
 		"hive", payload.HiveID,
 		"org", h.Org,
 		"github_host_before", before,
 		"github_host_after", observed,
 		"github_api_url_reported", strings.TrimSpace(payload.GitHubAPIURL),
+		"spoke_app_id", payload.GitHubAppID,
+		"spoke_installation_id", payload.GitHubInstallationID,
 		"note", gitHubAppStillRequiredNote)
 	return true
 }


### PR DESCRIPTION
## The residual bug (proven live 2026-08-05) — two halves, one root cause

The hive's forge record lacked a single authoritative source: the delivery gate compared against the CLUSTER's App instead of the hive's elected forge's, and spoke reports could overwrite the meta record they were themselves downstream of. Together they produced (1) a dead repair gate and (2) a feedback loop that reverted every hand-repair within minutes.

### Half 1: the dead delivery gate

PR #2732's wrong-forge repair gate in `v2/pkg/hub/cluster_app_key.go` `decideAppKeySync` (~line 716) was:

```go
if spokeOnWrongForge && spokeAppID != 0 && spokeAppID != cluster.AppID
```

For a PUBLIC-github.com hive on the GHE cluster whose spoke was mis-flipped onto the CLUSTER's own App (5686), the identity handed to the gate leaked the cluster's App, so the comparison saw the spoke's broken App on both sides (**5686 == 5686**) and never fired — even though `spokeOnWrongForge` was true. **Live evidence:** six public hives (llm-d wva, llm-d-incubation, kellyaa, kalantar, ai-native, alchemy) with meta correctly restored to `github_host=github.com` received **zero re-deliveries** across many heartbeats. Both leak paths reproduce in tests that fail on `origin/v2`:

1. **No cluster names a public App** → resolver produced AppID 0 → `appIdentityForHive` returned nil → repair structurally unreachable.
2. **A leaked cluster App under the public label** — an under-specified cluster record (flat GHE app_id, no urls, no default_forge) defaults to public, so `forgesForCluster` keys the GHE App under `github.com` → the literal 5686 == 5686 dead gate.

**Fix:** the repair compares against — and delivers — the App of the **hive's elected forge**:
- `ResolveHiveIdentityInFleet` refuses to borrow a fleet App whose issuing forge (`config.ForgeOfAppID`) provably differs from the elected forge (unknown Apps still adopted — silence is never evidence).
- `appIdentityForHive` falls back to the build's own App constant for the elected forge (`builtinAppOfForge`: public 3568013 / GHE 5686) when no cluster entry names one — scoped to `FromHiveIntent`.
- `appKeyConfigForHeartbeat` verifies, whenever `spokeOnWrongForge` is true, that the delivered identity genuinely belongs to the elected forge; a leaked wrong-forge App is rebuilt (key looked up by the App it belongs to, urls stated explicitly) or the repair stands down.
- `decideAppKeySync`'s parameter renamed `cluster` → `identity`; the gate now genuinely reads `spokeAppID != identity.AppID` where identity = the elected forge's App (implied by `spokeOnWrongForge` for a coherent identity; kept as a guard).

### Half 2: the hand-repair revert loop

Observed on `hosted-kalantar-msb-soft-reflect-jsro` and threatened on all 9 — **all six hand-restored metas were re-stomped github.com → github.ibm.com within ~30 minutes**:

1. Operator restores meta `github_host` → github.com and the spoke to the public App.
2. `reconcileGitHubHostFromSpoke` re-adopts github.ibm.com from a spoke report made while the spoke was still (or again) on the GHE identity — the stand-down only covered AUTH-FAILING spokes, and a freshly-booted spoke reports before its first github call fails, so it looked healthy.
3. With meta back at GHE and the spoke on public, the EPM-class branch fires (3568013 ≠ 5686) and re-delivers the GHE identity with `ResetInstallation`. Loop complete.

**Fix — the meta host is operator/request truth; a spoke's report is downstream of hub delivery and never independent evidence:**
- `reconcileGitHubHostFromSpoke` **never overwrites a non-empty `github_host`**. Contradictions are resolved by moving the SPOKE onto the recorded forge (the wrong-forge delivery repair), never the record onto the spoke's. The old public→GHE correction of an explicit github.com record (vllmd-06 class) is deliberately no longer automatic — it was indistinguishable from mis-delivery laundering.
- The EMPTY-host backfill requires **positive working evidence**, not absence-of-failure (the fresh-boot gap): the spoke's reported app_id must map to the same forge as its urls, with a non-zero installation_id and no reported auth failure.

### docs_installation_id artifact

Verified: the delivery path never writes `docs_installation_id`. The observed "old public installation parked in docs_installation_id (146551814)" is the provisioned docs-org add-on value (commonly provisioned equal to `installation_id` on public hives) surviving a reset that correctly cleared only `installation_id`. Stale is non-fatal (docs token mint warns and retries) and it becomes valid again on a flip-back; clearing it would permanently disable docs tokens since it has no rediscovery flow. Documented on `nextInstallationID`.

### Both directions + the loop verified

- GHE-host hive + spoke on public App → GHE identity delivered (EPM class) ✔
- public-host hive + spoke on GHE/cluster App → public identity with reset ✔
- elected forge == cluster forge, converged → no delivery ✔
- unknown spoke App → protected as a deliberate pin ✔
- **full loop** (`TestHandRepairDoesNotRevert`): restored meta + fresh-boot GHE report → record holds, same beat delivers the public App back, convergence goes quiet ✔

Tests: `TestWrongForgeRepairTargetsElectedForge` (5 subtests), `TestHandRepairDoesNotRevert`, hardened `TestReconcileGitHubHostFromSpoke` (12 subtests), extended `TestBrokenSpokeForgeReportNotAdopted`. `go build`/`go vet` clean; full `pkg/hub` + `cmd/hive` + `pkg/config` suites pass.

Code only — no live cluster changes.