### PR TITLE
fix: Upgrading badge always carries a start time (spoke-reported + restart-recovery paths)

### DIFF
--- a/v2/pkg/hub/begin_upgrade_test.go
+++ b/v2/pkg/hub/begin_upgrade_test.go
@@ -134,3 +134,79 @@ func TestClearUpgradeLatchZeroesEverything(t *testing.T) {
 		t.Fatal("an upgrade begun after a clear must time from zero")
 	}
 }
+
+// TestStampObservedUpgradeStampsFirstObservation: a spoke-REPORTED upgrade
+// (Upgrading=true with no hub-armed clock and no previous beat to carry one
+// from) must be stamped now — the dashboard badge only renders its elapsed
+// counter, and the stuck-upgrade alert only fires, when the clock is non-zero.
+func TestStampObservedUpgradeStampsFirstObservation(t *testing.T) {
+	e := RegistryEntry{ID: "h1", Upgrading: true}
+	before := time.Now()
+	stampObservedUpgrade(&e, time.Time{})
+	if e.UpgradeStartedAt.IsZero() {
+		t.Fatal("an observed upgrade with no prior clock must be stamped")
+	}
+	if e.UpgradeStartedAt.Before(before) {
+		t.Fatalf("first observation must stamp now, got %v (before test start %v)", e.UpgradeStartedAt, before)
+	}
+}
+
+// TestStampObservedUpgradeCarriesPreviousClockForward: the heartbeat handler
+// rebuilds the registry entry from scratch every beat, so a spoke-reported
+// upgrade's clock lives only in the PREVIOUS entry. It must be carried
+// forward, never re-stamped — a re-stamp per beat would pin the counter near
+// zero for the whole upgrade (the #2725 reset bug in a new coat).
+func TestStampObservedUpgradeCarriesPreviousClockForward(t *testing.T) {
+	prev := time.Now().Add(-20 * time.Minute)
+	e := RegistryEntry{ID: "h1", Upgrading: true}
+	stampObservedUpgrade(&e, prev)
+	if !e.UpgradeStartedAt.Equal(prev) {
+		t.Fatalf("observed upgrade must carry the previous beat's clock forward, got %v want %v", e.UpgradeStartedAt, prev)
+	}
+}
+
+// TestStampObservedUpgradeNeverTouchesALiveClock: an entry whose clock is
+// already set (a hub-armed upgrade stamped by beginUpgrade) must pass through
+// untouched regardless of what the previous beat carried.
+func TestStampObservedUpgradeNeverTouchesALiveClock(t *testing.T) {
+	orig := time.Now().Add(-45 * time.Minute)
+	e := RegistryEntry{ID: "h1", Upgrading: true, UpgradeStartedAt: orig}
+	stampObservedUpgrade(&e, time.Now())
+	if !e.UpgradeStartedAt.Equal(orig) {
+		t.Fatalf("a live clock must never be re-stamped, got %v want %v", e.UpgradeStartedAt, orig)
+	}
+}
+
+// TestStampObservedUpgradeIgnoresNonUpgrading: a hive that is not upgrading
+// must keep a zero clock — the invariant is bidirectional (non-zero clock
+// implies an upgrade genuinely in flight; see clearUpgradeLatch).
+func TestStampObservedUpgradeIgnoresNonUpgrading(t *testing.T) {
+	e := RegistryEntry{ID: "h1"}
+	stampObservedUpgrade(&e, time.Now().Add(-time.Hour))
+	if !e.UpgradeStartedAt.IsZero() {
+		t.Fatalf("a non-upgrading entry must keep a zero clock, got %v", e.UpgradeStartedAt)
+	}
+}
+
+// TestObservedStampThenSameTargetBeginUpgradePreserves: an upgrade first
+// stamped by the observed path, then re-entered by a hub-armed retry toward
+// the SAME target, must keep the observed stamp — the two stamping paths
+// share one invariant, so mixing them must not reset the clock either.
+func TestObservedStampThenSameTargetBeginUpgradePreserves(t *testing.T) {
+	s := newBeginUpgradeServer(RegistryEntry{ID: "h1", Upgrading: true, UpgradeTarget: "target-a"})
+	stampObservedUpgrade(&s.registry.Hives[0], time.Time{})
+	if s.registry.Hives[0].UpgradeStartedAt.IsZero() {
+		t.Fatal("observed stamp must have set the clock")
+	}
+	// Backdate the observed stamp so preserve-vs-restamp is unambiguous.
+	obs := time.Now().Add(-10 * time.Minute)
+	s.registry.Hives[0].UpgradeStartedAt = obs
+
+	s.mu.Lock()
+	s.beginUpgrade(0, "target-a") // same-target retry
+	s.mu.Unlock()
+
+	if !s.registry.Hives[0].UpgradeStartedAt.Equal(obs) {
+		t.Fatalf("a same-target beginUpgrade after an observed stamp must preserve the clock, got %v want %v", s.registry.Hives[0].UpgradeStartedAt, obs)
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -94,6 +94,32 @@ func (s *HubServer) clearUpgradeLatch(i int) {
 	h.UpgradeStartedAt = time.Time{}
 }
 
+// stampObservedUpgrade extends the beginUpgrade invariant to upgrades the hub
+// merely OBSERVES rather than arms: whenever an entry ends up Upgrading=true
+// from ANY source, it must carry a non-zero UpgradeStartedAt — the dashboard
+// row only renders the elapsed counter, and the stuck-upgrade alert only
+// fires, when the clock is non-zero. The spoke-reported path (a heartbeat
+// whose payload says Upgrading with no hub-side target) rebuilt the registry
+// entry from scratch every beat with a zero clock, so the badge rendered
+// without its counter and the alert was blind for the whole upgrade.
+//
+// prevStart is the previous beat's clock for the same entry (zero when there
+// is no previous state, e.g. a first heartbeat). Carrying it forward — never
+// re-stamping a live clock — is what keeps this compatible with the #2725
+// rule that a retry of the same upgrade preserves its original start time.
+// Entries that are not Upgrading, or already carry a clock (the hub-armed
+// paths route through beginUpgrade), are left untouched.
+func stampObservedUpgrade(entry *RegistryEntry, prevStart time.Time) {
+	if !entry.Upgrading || !entry.UpgradeStartedAt.IsZero() {
+		return
+	}
+	if !prevStart.IsZero() {
+		entry.UpgradeStartedAt = prevStart
+		return
+	}
+	entry.UpgradeStartedAt = time.Now()
+}
+
 type SaaSUser struct {
 	GitHubUsername string            `json:"github_username"`
 	CreatedAt      string            `json:"created_at"`

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1465,6 +1465,16 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 					entry.UpgradeStartedAt = h.UpgradeStartedAt
 				}
 			}
+			// A true Upgrading flag must ALWAYS carry a start time. The chain
+			// above only carries the clock forward for HUB-armed upgrades
+			// (h.UpgradeTarget != ""); a spoke-REPORTED upgrade left the
+			// rebuilt entry with a zero clock every beat, so the "Upgrading"
+			// badge rendered without its elapsed counter and the stuck-upgrade
+			// alert (which gates on a non-zero clock) was blind. Carry the
+			// previous beat's clock forward when there is one — re-stamping a
+			// live clock would repeat the #2725 reset-every-retry bug — and
+			// stamp now only when no clock has ever existed.
+			stampObservedUpgrade(&entry, h.UpgradeStartedAt)
 			// Sparkline history: sample every 15 min, keep 7 days (672 points)
 			const sparkSampleInterval = 15 * 60 // seconds
 			const sparkMaxPoints = 672
@@ -1513,6 +1523,10 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		now := time.Now().Unix()
 		entry.IssueHistory = []SparkPoint{{T: now, V: entry.ActionableIssues}}
 		entry.PRHistory = []SparkPoint{{T: now, V: entry.ActionablePRs}}
+		// A brand-new hive whose FIRST heartbeat already reports Upgrading has
+		// no previous beat to carry a clock from — stamp it now so the badge
+		// never renders without its elapsed counter.
+		stampObservedUpgrade(&entry, time.Time{})
 		s.registry.Hives = append(s.registry.Hives, entry)
 	}
 	s.registry.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
@@ -2801,13 +2815,31 @@ func (s *HubServer) loadRegistry() {
 func (s *HubServer) recoverArmedUpgrades() {
 	type armed struct{ id, target string }
 	var recovered []armed
+	stamped := 0
 	s.mu.Lock()
 	if s.heartbeatUpgrade == nil {
 		s.heartbeatUpgrade = make(map[string]string)
 	}
 	for i := range s.registry.Hives {
 		h := &s.registry.Hives[i]
-		if !h.Upgrading || h.UpgradeTarget == "" {
+		if !h.Upgrading {
+			continue
+		}
+		// A true Upgrading flag must always carry a start time — the dashboard
+		// badge and the stuck-upgrade alert both gate their elapsed clock on a
+		// non-zero UpgradeStartedAt. The registry persists the field (json
+		// "upgradeStartedAt"), so a normal restart rehydrates the REAL clock
+		// and this guard does not fire — re-stamping a live clock here would
+		// reset every in-flight upgrade's elapsed time on each hub roll, the
+		// exact #2725 reset bug. Only a latch that never had a clock (armed
+		// before the field existed, or spoke-reported upgrading persisted
+		// before the observed-upgrade stamp) gets one now, instead of the
+		// badge rendering without its counter until the next re-arm.
+		if h.UpgradeStartedAt.IsZero() {
+			h.UpgradeStartedAt = time.Now()
+			stamped++
+		}
+		if h.UpgradeTarget == "" {
 			continue
 		}
 		// A recorded terminal failure must stay terminal — re-arming it would
@@ -2819,6 +2851,12 @@ func (s *HubServer) recoverArmedUpgrades() {
 		recovered = append(recovered, armed{id: h.ID, target: h.UpgradeTarget})
 	}
 	s.mu.Unlock()
+	if stamped > 0 {
+		// Persist the repaired clocks (saveCh is buffered, so a request made
+		// before saveLoop starts is not lost) — otherwise a crash-looping hub
+		// would re-stamp them to now on every restart.
+		s.requestSave()
+	}
 	for _, a := range recovered {
 		s.logger.Info("recovered armed upgrade from registry after restart",
 			"hive_id", a.id, "target", a.target)

--- a/v2/pkg/hub/upgrade_recovery_test.go
+++ b/v2/pkg/hub/upgrade_recovery_test.go
@@ -249,3 +249,87 @@ func TestTriggerAutoUpgradesNotStaleManualRepopulates(t *testing.T) {
 		t.Errorf("in-flight manual upgrade must be re-populated after a hub restart, got %q", got)
 	}
 }
+
+// TestRecoverArmedUpgradesStampsZeroClockPreservesLiveClock covers the restart
+// half of the badge-without-timer bug: the registry persists UpgradeStartedAt
+// (json "upgradeStartedAt"), so recovery must NEVER re-stamp a rehydrated
+// non-zero clock — the hub rolls often, and a re-stamp per roll is the #2725
+// reset bug all over again. Only a latch that never had a clock (armed before
+// the field existed, or a persisted spoke-reported upgrade) gets stamped, so
+// the dashboard badge always carries its elapsed counter and the
+// stuck-upgrade alert is never blind after a restart.
+func TestRecoverArmedUpgradesStampsZeroClockPreservesLiveClock(t *testing.T) {
+	persisted := time.Now().Add(-42 * time.Minute)
+	s := &HubServer{logger: slog.Default()}
+	s.registry.Hives = []RegistryEntry{
+		// Rehydrated from disk with its real clock — must survive untouched.
+		{ID: "with-clock", Upgrading: true, UpgradeTarget: "fc32ae4", UpgradeStartedAt: persisted},
+		// Latched with a lost/never-set clock — must be stamped now.
+		{ID: "zero-clock", Upgrading: true, UpgradeTarget: "fc32ae4"},
+		// Spoke-reported upgrading (no target): nothing to arm, but the badge
+		// still renders, so it must get a clock too.
+		{ID: "spoke-reported", Upgrading: true},
+		// Not upgrading — must keep a zero clock.
+		{ID: "idle"},
+	}
+
+	before := time.Now()
+	s.recoverArmedUpgrades()
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if got := s.registry.Hives[0].UpgradeStartedAt; !got.Equal(persisted) {
+		t.Errorf("recovery must not re-stamp a persisted clock (that resets every in-flight timer on each hub roll), got %v want %v", got, persisted)
+	}
+	if got := s.registry.Hives[1].UpgradeStartedAt; got.IsZero() || got.Before(before) {
+		t.Errorf("a recovered latch with a zero clock must be stamped now, got %v", got)
+	}
+	if got := s.registry.Hives[2].UpgradeStartedAt; got.IsZero() {
+		t.Error("a persisted spoke-reported upgrade must get a clock at recovery")
+	}
+	if got := s.registry.Hives[3].UpgradeStartedAt; !got.IsZero() {
+		t.Errorf("a non-upgrading entry must keep a zero clock, got %v", got)
+	}
+	// Delivery re-arming is unchanged by the stamping.
+	if got := s.heartbeatUpgrade["with-clock"]; got != "fc32ae4" {
+		t.Errorf("with-clock must still be re-armed, got %q", got)
+	}
+	if got := s.heartbeatUpgrade["zero-clock"]; got != "fc32ae4" {
+		t.Errorf("zero-clock must still be re-armed, got %q", got)
+	}
+	if _, armed := s.heartbeatUpgrade["spoke-reported"]; armed {
+		t.Error("a targetless latch must not be armed for delivery")
+	}
+}
+
+// TestUpgradeStartedAtRoundTripsThroughRegistryAndRecovery pins the full
+// restart story: the clock serializes to the registry JSON, deserializes
+// intact, and survives recoverArmedUpgrades — so a hub restart never resets
+// an in-flight upgrade's elapsed time.
+func TestUpgradeStartedAtRoundTripsThroughRegistryAndRecovery(t *testing.T) {
+	started := time.Now().Add(-13 * time.Minute).UTC().Truncate(time.Second)
+	reg := Registry{Hives: []RegistryEntry{{
+		ID: "h1", Upgrading: true, UpgradeTarget: "fc32ae4", UpgradeStartedAt: started,
+	}}}
+	data, err := json.Marshal(reg)
+	if err != nil {
+		t.Fatalf("marshal registry: %v", err)
+	}
+	var loaded Registry
+	if err := json.Unmarshal(data, &loaded); err != nil {
+		t.Fatalf("unmarshal registry: %v", err)
+	}
+	if !loaded.Hives[0].UpgradeStartedAt.Equal(started) {
+		t.Fatalf("UpgradeStartedAt must round-trip through the registry JSON, got %v want %v", loaded.Hives[0].UpgradeStartedAt, started)
+	}
+
+	s := &HubServer{logger: slog.Default()}
+	s.registry = loaded
+	s.recoverArmedUpgrades()
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if !s.registry.Hives[0].UpgradeStartedAt.Equal(started) {
+		t.Fatalf("recovery must keep the rehydrated clock, got %v want %v", s.registry.Hives[0].UpgradeStartedAt, started)
+	}
+}


### PR DESCRIPTION
## Symptom

The hub dashboard's **Upgrading** badge sometimes renders WITHOUT its elapsed-time counter, then the timer pops in a cycle later. The row only shows the counter when `UpgradeStartedAt` is non-zero, and the stuck-upgrade alert (`AlertTypeStuckUpgrade`) gates on the same non-zero timestamp — so during those windows the alert was blind too.

## Root cause: two paths set Upgrading=true with a ZERO clock

Only the hub-armed path stamps `UpgradeStartedAt` (via `beginUpgrade`, #2725). Two others did not:

1. **Spoke-reported upgrading** — the heartbeat handler sets `entry.Upgrading = true` straight from the payload with no stamp. Worse, the entry is rebuilt from scratch every beat and the merge chain only carries the clock forward for HUB-armed upgrades (`h.UpgradeTarget != ""`), so a spoke-reported upgrade's clock stayed zero for its entire duration.
2. **Hub-restart recovery** — `recoverArmedUpgrades` (the `"recovered armed upgrade from registry after restart"` path) re-arms delivery but never touched a zero `UpgradeStartedAt`, leaving the badge clockless until the periodic stale-recovery re-armed via `beginUpgrade`.

## Fix: the zero-guard invariant

**Whenever `Upgrading` flips to true from ANY source and `UpgradeStartedAt` is zero, stamp it now — and NEVER re-stamp a live clock** (a re-stamp would repeat the #2725 reset-every-retry bug; the hub rolls often, so a re-stamp per roll matters).

- New helper `stampObservedUpgrade(entry, prevStart)` in `pkg/hub/saas.go` next to `beginUpgrade`/`clearUpgradeLatch`: carries the previous beat's clock forward, stamps `time.Now()` only when no clock has ever existed, no-ops on non-upgrading entries and live clocks. Called from:
  - the heartbeat merge path (after the upgrade else-if chain), and
  - the first-heartbeat append path (new hive already reporting Upgrading).
- `recoverArmedUpgrades` stamps only latches with a zero clock (including targetless spoke-reported ones — the badge renders for them too) and requests a registry save so a crash-looping hub does not re-stamp on every restart.

## Persistence across hub restarts

`UpgradeStartedAt` is already serialized in the registry (`json:"upgradeStartedAt,omitempty"`, camelCase like its neighbors), so a normal restart rehydrates the REAL clock and the recovery guard does not fire. A round-trip test pins this.

`clearUpgradeLatch` semantics are untouched — completion/cancel still zeroes flag, target, and clock.

## Tests

- Observed stamp: first observation stamps; previous beat's clock carried forward (never re-stamped per beat); live clock never touched; non-upgrading ignored.
- Observed stamp then same-target `beginUpgrade` preserves the clock (mixed-path #2725 compatibility).
- Recovery: persisted non-zero clock preserved, zero clock stamped, targetless latch gets a clock but is not armed for delivery, idle entry untouched.
- Full JSON round-trip through the registry plus recovery keeps the clock.
- Existing #2725 tests (same-target preserve, new-target restamp, clear zeroes) unchanged.