### PR TITLE
fix: install-ID hint shows the URL tail at rest — callout pinned to the actual id

### DIFF
--- a/v2/pkg/dashboard/gh_app_banner_test.go
+++ b/v2/pkg/dashboard/gh_app_banner_test.go
@@ -286,3 +286,73 @@ func TestInstallIdInputIsCrossBrowserHardened(t *testing.T) {
 		t.Error("renderGitHubAppBanner must snapshot/restore the install-ID input value so a background poll re-render can't wipe what the user typed (the Firefox \"doesn't stick\" symptom)")
 	}
 }
+
+// cssRule extracts the body of the first CSS rule whose selector line starts
+// with the given prefix, so tests can assert on one rule without matching
+// stray occurrences of a declaration elsewhere in the stylesheet.
+func cssRule(t *testing.T, html, selector string) string {
+	t.Helper()
+	i := strings.Index(html, selector+" {")
+	if i < 0 {
+		t.Fatalf("static/index.html has no %q CSS rule", selector)
+	}
+	end := strings.Index(html[i:], "}")
+	if end < 0 {
+		t.Fatalf("could not find the end of the %q CSS rule", selector)
+	}
+	return html[i : i+end]
+}
+
+// TestInstallIdHintURLTailVisibleAtRest is the regression guard for the
+// follow-up report on the install-ID hint's example URL (post-#2710): the URL
+// row was preserved in a horizontally-scrollable column, but the column
+// rested scrolled to the START of the URL, so the /settings/installations/<id>
+// tail — the entire point of the hint — was scrolled out of view at rest and
+// the right-aligned "↑↑↑ this number" arrow row pointed at the truncation
+// ("…organizations/open-") instead of at the id. Because the org name is
+// dynamic, a separate character-aligned arrow row can never reliably line up
+// under the digits, so the fix is twofold:
+//
+//  1. END-anchor the scroll column (direction: rtl on .gh-idhint-urlcol, with
+//     the URL text restored to direction: ltr as an atomic inline-block) so
+//     the resting view shows "…/settings/installations/<id>".
+//  2. Delete the arrow row entirely and attach the "this number" callout to
+//     the seg-id span itself via CSS ::after — intrinsic to the span, so it
+//     tracks the digits at every scroll position and org-name length.
+func TestInstallIdHintURLTailVisibleAtRest(t *testing.T) {
+	html := spokeIndexHTML(t)
+
+	// 1. End-anchored scroll column.
+	col := cssRule(t, html, ".gh-idhint-urlcol")
+	if !strings.Contains(col, "direction: rtl") {
+		t.Error(".gh-idhint-urlcol is not end-anchored (direction: rtl) — at rest the column shows the URL's start and hides the /installations/<id> tail")
+	}
+	text := cssRule(t, html, ".gh-idhint-urltext")
+	if !strings.Contains(text, "direction: ltr") {
+		t.Error(".gh-idhint-urltext must restore direction: ltr inside the rtl scroll column or the URL renders right-to-left")
+	}
+	if !strings.Contains(text, "inline-block") {
+		t.Error(".gh-idhint-urltext must be an atomic inline-block: a block child of the rtl column overflows to the unreachable side and breaks the end-anchor")
+	}
+
+	// 2. The callout is attached to the id segment itself, not a separate
+	// aligned row.
+	seg := cssRule(t, html, ".gh-idhint-url .seg-id")
+	if !strings.Contains(seg, "position: relative") {
+		t.Error(".seg-id must be position: relative so its ::after callout anchors to the digits")
+	}
+	after := cssRule(t, html, ".gh-idhint-url .seg-id::after")
+	if !strings.Contains(after, "this number") {
+		t.Error(".seg-id::after must carry the \"this number\" label so the callout moves with the digits")
+	}
+	if !strings.Contains(after, "position: absolute") {
+		t.Error(".seg-id::after must be absolutely positioned off the span — any column- or character-based alignment cannot track a dynamic-width URL")
+	}
+
+	// The old arrow row must be gone: it could never align under a dynamic
+	// URL and its right-aligned arrows pointed at whatever happened to be at
+	// the visible column's right edge.
+	if strings.Contains(html, "gh-idhint-caret") {
+		t.Error("the gh-idhint-caret arrow row is back — the callout must be the seg-id ::after label, arrows in a separate row cannot line up under a dynamic-width URL")
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -758,11 +758,14 @@
     /* The URL mock: a rendered browser address bar, not a screenshot.
        .gh-idhint-url is the pill-shaped chrome (rounded ends, lock glyph);
        .gh-idhint-urlcol is the horizontally-scrollable column holding the URL
-       row (.gh-idhint-urltext) and, on a second line, the caret callout. Both
-       live in the SAME scroll container so the arrows stay pinned under the
-       trailing ID segment (seg-id, the last segment on the URL line) even when
-       a long org name scrolls the URL — the arrows point at the END of the
-       URL, where the installation ID actually is, not at the start. */
+       row (.gh-idhint-urltext). The example URL is longer than the popover is
+       wide and its interesting part — /settings/installations/<id> — is the
+       TAIL, so the column is END-anchored at rest (direction: rtl below): a
+       start-anchored scroll showed only "https://host/organizations/org…" and
+       hid the ID entirely (the reported defect). The ID callout ("this
+       number") is attached to the seg-id span itself via ::after, so it moves
+       with the digits at every scroll position and for every org-name length —
+       alignment is intrinsic to the span, never column- or character-based. */
     .gh-idhint-url {
       display: flex; align-items: flex-start; gap: 7px;
       background: var(--bg-soft); border: 1px solid var(--line-strong);
@@ -770,44 +773,60 @@
     }
     /* Lock glyph stands in for the browser's HTTPS padlock. Shrink-to-fit so
        it never gets squeezed by the scrolling URL text next to it. Nudge down
-       to baseline-align with the first (URL) line now that the row is
-       top-aligned to accommodate the caret's second line. */
+       to baseline-align with the URL line now that the row is top-aligned to
+       accommodate the "this number" annotation's second line. */
     .gh-idhint-url .seg-lock {
       flex: 0 0 auto; color: var(--green); font-size: 0.72rem; opacity: 0.9;
       margin-top: 2px;
     }
-    /* Scroll container. inline-block/fit-content so its content width is the
-       URL line's width, which lets the caret (a right-aligned block) land under
-       the trailing ID segment rather than under the URL start. */
+    /* Scroll container. direction: rtl makes the browser rest the scroll
+       position at the content's RIGHT edge — the END of the URL, where the
+       installation ID is — while the user can still scroll left to read the
+       URL's start. Pure CSS end-anchoring: no scrollLeft scripting, so no
+       popover-open timing hazards. The text is NOT rendered right-to-left:
+       the only child is .gh-idhint-urltext, an atomic inline-block that
+       restores direction: ltr for everything inside it. */
     .gh-idhint-urlcol {
       flex: 1 1 auto; min-width: 0;
       overflow-x: auto; white-space: nowrap;
+      direction: rtl;
     }
+    /* inline-block (not block): as an atomic inline in the rtl column it
+       overflows toward the column's inline-end (left), which keeps the rest
+       position at the URL's tail. padding-bottom reserves the second line the
+       seg-id::after annotation renders into — the annotation is absolutely
+       positioned, and overflow-x: auto on the column would otherwise clip it
+       (overflow-y cannot be 'visible' next to a scrolling x-axis). */
     .gh-idhint-urltext {
-      display: block;
+      display: inline-block; direction: ltr;
       font-family: var(--font-mono); font-size: 0.66rem; line-height: 1.6;
       color: var(--muted); white-space: nowrap;
+      padding-bottom: 18px; /* one annotation line: 0.6rem text + 3px gap + slack so overflow-y:auto never shows a vertical scrollbar */
     }
     .gh-idhint-url .seg-host { color: var(--text); }
-    /* The highlighted segment. Digits are MASKED (see ghAppInstallIdHintHtml)
-       so nobody copies the example into the field as their own ID. */
+    /* The highlighted segment IS the callout: an unmissable pill around the
+       digits, clearly distinct from the rest of the URL. Digits are MASKED
+       (see ghAppInstallIdHintHtml) so nobody copies the example into the
+       field as their own ID. position: relative anchors the ::after label. */
     .gh-idhint-url .seg-id {
-      color: var(--amber); font-weight: 700;
-      background: color-mix(in srgb, var(--amber) 18%, transparent);
-      border: 1px solid color-mix(in srgb, var(--amber) 55%, transparent);
+      position: relative;
+      color: var(--amber); font-weight: 700; font-size: 0.72rem;
+      background: color-mix(in srgb, var(--amber) 22%, transparent);
+      border: 1px solid color-mix(in srgb, var(--amber) 60%, transparent);
       border-radius: 3px; padding: 1px 4px;
     }
-    /* Caret callout on its own line directly beneath the URL, pointing up at
-       the trailing ID segment. It lives inside the same scroll column as the
-       URL text (.gh-idhint-urlcol) and is right-aligned to that column's
-       content width; because seg-id is the LAST segment on the URL line, this
-       lands the arrows under the ID at the END of the URL — the actual install
-       ID location — rather than under the start of the URL (the old defect).
-       The caret width tracks the mask length so the arrow run is the width of
-       the ID segment. */
-    .gh-idhint-caret {
-      display: block; text-align: right; color: var(--amber); font-size: 0.6rem;
-      font-family: var(--font-mono); margin-top: 2px;
+    /* "this number" label attached DIRECTLY to the ID segment, rendered on
+       the line below it. Because it is positioned off the span itself it
+       tracks the digits regardless of org-name length or scroll position —
+       unlike the previous right-aligned arrow row, which could never line up
+       under a dynamic-width URL. right: 0 (not centered) so the label extends
+       LEFT over the URL, never past the content's right edge — right-side
+       overflow would be unreachable in the rtl scroll column. */
+    .gh-idhint-url .seg-id::after {
+      content: '↑ this number';
+      position: absolute; top: calc(100% + 3px); right: 0;
+      color: var(--amber); font-size: 0.6rem; font-weight: 600;
+      font-family: var(--font-mono); white-space: nowrap;
     }
     .gh-app-perm-details { font-size: 0.8rem; margin-top: 6px; color: var(--text); }
     .gh-app-perm-details .perm-ok { color: var(--green); }
@@ -5557,9 +5576,10 @@
     }
 
     /* Builds the popover markup: a short lead, a mocked browser address bar
-       (lock glyph + URL) with the ID segment highlighted and MASKED, a caret
-       callout pointing at it, and a footnote. Every interpolated value is
-       escaped — org and host originate from server config. */
+       (lock glyph + URL) with the ID segment highlighted and MASKED — the
+       highlight pill carries its own "this number" label via CSS ::after —
+       and a footnote. Every interpolated value is escaped — org and host
+       originate from server config. */
     function ghAppInstallIdHintHtml(data) {
       var host = escapeHtml(ghAppHintHost(data));
       var org = escapeHtml(ghAppHintOrg());
@@ -5567,12 +5587,15 @@
         + 'at the <strong>end</strong> of the URL — the segment after '
         + '<code>/installations/</code> — in your browser’s address bar on your org’s '
         + 'installed-app settings page:</span>'
-        /* The URL row and the caret callout share one horizontally-scrollable
-           column so the arrows stay pinned under the trailing ID segment even
-           when a long org name scrolls the URL. The caret line is right-aligned
-           to the column's content width, which — because seg-id is the LAST
-           segment on the URL line — lands the arrows directly beneath the ID,
-           not under the start of the URL (the original defect). */
+        /* The URL sits in an END-anchored scroll column (.gh-idhint-urlcol,
+           direction: rtl in CSS): at rest the visible portion is the URL's
+           TAIL — …/settings/installations/<id> — and scrolling left reveals
+           the start. The "this number" callout is a CSS ::after attached to
+           seg-id itself, so it stays under the digits at every scroll
+           position and for any org-name length; the URL is dynamic, so a
+           separate character-aligned arrow row could never line up (the
+           original defect showed the URL's start with arrows pointing at the
+           truncation). */
         + '<span class="gh-idhint-url">'
         +   '<span class="seg-lock" aria-hidden="true">🔒</span>'
         +   '<span class="gh-idhint-urlcol">'
@@ -5581,8 +5604,6 @@
         +       org + '/settings/installations/'
         +       '<span class="seg-id">' + INSTALL_ID_MASK + '</span>'
         +     '</span>'
-        +     '<span class="gh-idhint-caret">' + new Array(INSTALL_ID_MASK_LENGTH + 1).join('↑')
-        +       ' this number</span>'
         +   '</span>'
         + '</span>'
         + '<span class="gh-idhint-foot">Open <strong>' + host + '</strong> → your org → '


### PR DESCRIPTION
Follow-up to #2710, from a live screenshot taken after that merge.

## Symptom

The GHE "Installation ID" help popover renders its example URL in a horizontally scrollable one-line pill — but the column **rests scrolled to the START of the URL**. At rest the pill shows only:

```
https://github.ibm.com/organizations/open-
```

The `/settings/installations/<id>` tail — the entire point of the hint — is scrolled out of view, and the right-aligned `↑↑↑↑↑ this number` arrow row points at the truncation, under "open-", not under any id digits. #2710 preserved the tail in the scrollable column, but hid it at rest.

## Why the arrow row had to go

The URL is dynamic (the org name comes from the hive's config), so a separate character-aligned arrow row can **never** reliably line up under the id. The arrows aligned to the visible column's right edge — i.e. under whatever character happened to be at the truncation point.

## Fix

1. **End-anchor the scroll column** — `direction: rtl` on `.gh-idhint-urlcol` makes the browser rest the scroll at the content's right edge, the URL's tail. Pure CSS: no `scrollLeft` scripting, no popover-open timing hazards. `.gh-idhint-urltext` becomes an atomic `inline-block` with `direction: ltr` so the URL still reads normally and overflows toward the column's reachable side — the user can still scroll left to read the URL's start.
2. **The id segment is now the callout** — the arrow row is deleted; the `seg-id` pill is bolder/slightly larger with a stronger amber tint, and the `↑ this number` label is a CSS `::after` attached to the span itself (`position: relative` + absolute, right-anchored so it can't poke past the rtl column's unreachable edge). Alignment is **intrinsic to the span**: the label tracks the digits at every scroll position and for any org-name length. `padding-bottom` on the URL text reserves the label's line inside the scroller, since `overflow-x: auto` can't coexist with visible y-overflow.

At rest the popover now shows `…rce-at-ibm/settings/installations/` + the masked-digit pill with "this number" directly beneath it.

## Verification

- Rendered the exact CSS/markup in a headless browser: at rest `seg-id` is fully visible with its right edge flush to the column; `scrollLeft` scrolling moves the label with the digits; no vertical scrollbar (0px y-overflow).
- `node --check`-equivalent syntax pass on the inline script blocks; `go build ./...` compiles.
- New regression test `TestInstallIdHintURLTailVisibleAtRest` pins the `direction: rtl` end-anchor, the `ltr` inline-block restore, the `seg-id::after` callout, and the **absence** of the old `gh-idhint-caret` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)