### PR TITLE
🐛 fix(proxy): don't abort upstream dial when SO_MARK fails (agents can't authenticate)

### DIFF
--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -75,20 +75,54 @@ func proxyEgressMark() int {
 // fwmark (SO_MARK) on the outbound socket before connect. On non-Linux builds
 // setSockMark is a no-op, so the dialer is portable. The optional timeout is
 // applied when non-zero.
+//
+// SO_MARK is a BEST-EFFORT egress hint, never a hard requirement: it exists so
+// the forced-egress iptables redirect can exempt the proxy's own upstream dials
+// via `-m mark`. But setsockopt(SO_MARK) needs CAP_NET_ADMIN in the process's
+// EFFECTIVE set, and the hive Go process runs as a non-root user (entrypoint
+// drops from root to `dev` via gosu, which strips all capabilities). So the mark
+// call fails with EPERM ("operation not permitted") on exactly the deployments
+// that run non-root — which is all of them. Returning that error from the
+// Control hook ABORTS the dial, so every proxy upstream dial fails and agents
+// can't reach GitHub at all. That is a regression: on OKE the `-m owner
+// --uid-owner` exemption already covers the proxy's uid dials, so an unmarked
+// dial succeeds; on OpenShift (no xt_owner) the mark is the only exemption, but
+// there too, failing the dial helps nothing. So we log the mark failure ONCE and
+// proceed unmarked rather than killing the connection.
 func markDialer(timeout time.Duration) *net.Dialer {
 	mark := proxyEgressMark()
 	return &net.Dialer{
 		Timeout: timeout,
 		Control: func(_, _ string, c syscall.RawConn) error {
-			var sockErr error
+			// A failure to enter the raw-conn control context is a real dial
+			// problem (the fd is unusable) — propagate it.
 			if err := c.Control(func(fd uintptr) {
-				sockErr = setSockMark(fd, mark)
+				if markErr := setSockMark(fd, mark); markErr != nil {
+					warnSockMarkOnce(mark, markErr)
+				}
 			}); err != nil {
 				return err
 			}
-			return sockErr
+			// Deliberately do NOT propagate a setSockMark failure: the mark is a
+			// best-effort exemption hint, and the owner-UID iptables RETURN
+			// already exempts the proxy's own uid on OKE, so an unmarked dial
+			// still reaches GitHub.
+			return nil
 		},
 	}
+}
+
+// warnSockMarkOnce logs the first SO_MARK failure at WARN and every subsequent
+// one at DEBUG, so a non-CAP_NET_ADMIN deployment (the common non-root case)
+// does not flood the log with one line per dial while still surfacing the
+// condition once.
+var sockMarkWarnOnce sync.Once
+
+func warnSockMarkOnce(mark int, err error) {
+	sockMarkWarnOnce.Do(func() {
+		slog.Warn("proxy egress SO_MARK unavailable — dialing unmarked (owner-UID exemption still applies on OKE); this is expected when the hive runs non-root without CAP_NET_ADMIN in its effective set",
+			"mark", mark, "error", err)
+	})
 }
 
 // CACertPath and caKeyPath are the PVC locations of the persisted MITM CA.

--- a/v2/pkg/proxy/somark_test.go
+++ b/v2/pkg/proxy/somark_test.go
@@ -43,10 +43,21 @@ func TestProxyEgressMarkEnvOverride(t *testing.T) {
 }
 
 // TestMarkDialerControlRuns exercises the mark dialer's Control hook against a
-// real loopback listener. The Control func must run and set SO_MARK (a no-op on
-// non-Linux) WITHOUT failing the dial — a returned error here would break every
-// upstream connection the proxy makes. This is the default dial path used when
-// copilotDial is unset.
+// real loopback listener. The Control func must run and attempt SO_MARK (a no-op
+// on non-Linux) WITHOUT failing the dial — a returned error here would break
+// every upstream connection the proxy makes. This is the default dial path used
+// when copilotDial is unset.
+//
+// CRITICALLY: the dial must SUCCEED even when SO_MARK fails with EPERM. The hive
+// Go process runs as a non-root user (entrypoint drops from root to `dev` via
+// gosu, which strips CAP_NET_ADMIN from the effective set), so setsockopt(SO_MARK)
+// returns EPERM on every real deployment. Before this was fixed, the Control hook
+// propagated that EPERM and aborted the dial — so every proxy upstream dial to
+// GitHub failed with "operation not permitted" and agents could not authenticate
+// (they got empty replies through the proxy). SO_MARK is a best-effort egress
+// hint (the owner-UID iptables exemption already covers the proxy's uid on OKE),
+// so a mark failure must NOT break the connection. This test now asserts success
+// rather than skipping on EPERM — the skip previously masked the regression.
 func TestMarkDialerControlRuns(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -64,13 +75,11 @@ func TestMarkDialerControlRuns(t *testing.T) {
 
 	conn, err := markDialer(2*time.Second).Dial("tcp", ln.Addr().String())
 	if err != nil {
-		// Setting SO_MARK requires CAP_NET_ADMIN. Unprivileged CI on Linux will
-		// see EPERM from the Control hook — that still proves the hook ran and
-		// attempted the setsockopt (the whole point). Tolerate ONLY EPERM; any
-		// other error is a real dialer regression. On non-Linux the hook no-ops,
-		// so the dial simply succeeds.
+		// A SO_MARK EPERM (unprivileged, the common non-root case) must NOT reach
+		// here: the Control hook is expected to swallow it and dial unmarked. If we
+		// see EPERM, the regression is back.
 		if errors.Is(err, syscall.EPERM) {
-			t.Skipf("SO_MARK requires CAP_NET_ADMIN; hook ran but got EPERM (expected unprivileged): %v", err)
+			t.Fatalf("markDialer aborted the dial on SO_MARK EPERM — the non-fatal-mark fix regressed: %v", err)
 		}
 		t.Fatalf("markDialer Dial failed (Control hook must not break the dial): %v", err)
 	}


### PR DESCRIPTION
## What

The proxy's `markDialer` Control hook **propagated a `setsockopt(SO_MARK)` failure**, which aborts the dial. This broke **every** proxy upstream dial to GitHub, so all Copilot agents got empty replies and could not authenticate.

## Root cause (verified live on the affected pod)

`SO_MARK` requires **CAP_NET_ADMIN in the process's EFFECTIVE set**. The hive Go process runs as a **non-root user** — the entrypoint drops from root to `dev` via `gosu`, which strips all capabilities (`CapEff: 0000000000000000`, confirmed on the live pod). So `setsockopt(SO_MARK)` returns **EPERM ("operation not permitted")** on every real deployment, and the Control hook returned it — aborting the dial.

Symptom in the pod logs:
```
ERROR transparent proxy upstream dial failed host=api.github.com error="dial tcp 140.82.114.6:443: operation not permitted"
```
Agent-side: `error sending request for url (https://api.github.com/copilot_internal/user)` → "Authentication token found but could not be validated".

## Fix

`SO_MARK` is a **best-effort egress hint**, not a hard requirement:
- On **OKE** the `-m owner --uid-owner` iptables RETURN already exempts the proxy's own uid dials — an unmarked dial reaches GitHub. **Verified live: uid-1001 dial without the mark = HTTP 200.**
- On **OpenShift** (no `xt_owner`) the mark is the only exemption, but aborting the dial helps nothing there either.

So the Control hook now **swallows a `setSockMark` failure** (logged once via `sync.Once`) and proceeds unmarked, instead of killing the connection.

## Live validation (test before PR)

A standalone repro built for the pod's arch and run **as the hive user (uid 1001, no NET_ADMIN)** against the real endpoint:
```
OLD (propagate mark err): FAILED -> dial tcp 140.82.112.6:443: operation not permitted
NEW (ignore mark err):    connected -> 140.82.113.6:443
```
As root (has NET_ADMIN) both connect — so the fix doesn't regress the capable case.

## Test

`TestMarkDialerControlRuns` now **asserts the dial succeeds on SO_MARK EPERM** — it previously **SKIPPED** on EPERM, which masked this exact regression. Full `pkg/proxy` suite passes.

## Relationship to #2735

Companion to #2735 (ClientHello reassembly). #2735 fixed the server-side `bad record MAC` handshake; **this** fixes the upstream-dial `operation not permitted`. **Both** are required for agents to authenticate through the forced-egress proxy — #2735 alone was necessary but not sufficient.