### PR TITLE
fix: Acknowledge matches active alerts (scoped-poll eviction) + survives corrupt ack store

### DIFF
--- a/v2/pkg/hub/alerts.go
+++ b/v2/pkg/hub/alerts.go
@@ -236,9 +236,20 @@ type alertAck struct {
 	ConditionFirstSeen time.Time `json:"conditionFirstSeen"`
 }
 
+// alertAckKeySep separates hive ID from alert type inside an alertAckKey. NUL
+// because it can appear in neither a hive ID nor an alert type, so the key can
+// always be split back apart unambiguously.
+const alertAckKeySep = "\x00"
+
 // alertAckKey is the map key for an acknowledgement: one per (hive, type).
 func alertAckKey(hiveID, alertType string) string {
-	return hiveID + "\x00" + alertType
+	return hiveID + alertAckKeySep + alertType
+}
+
+// alertAckKeyHive recovers the hive ID from an alertAckKey.
+func alertAckKeyHive(key string) string {
+	hiveID, _, _ := strings.Cut(key, alertAckKeySep)
+	return hiveID
 }
 
 // alertState is the hub's observation memory for alert evaluation. Alerts are
@@ -344,15 +355,32 @@ func (a *alertState) markCondition(hiveID, alertType string, now time.Time) time
 // condition goes away its FirstSeen is forgotten, so when it returns it gets a
 // fresh FirstSeen that no stored ack matches.
 //
-// active is the set of currently-firing alertAckKey values.
-func (a *alertState) retainConditions(active map[string]bool) {
+// active is the set of currently-firing alertAckKey values. evaluated is the
+// set of hive IDs that were actually PRESENT in the snapshot this evaluation
+// ran over — and eviction is limited to those hives. That scoping is the fix
+// for the bug that made Acknowledge fail with "no active alert of that type
+// for this hive" on every click: evaluateAlerts runs against the CALLER's
+// visible hives (handleMyHives scopes the list per user), but this state is
+// shared hub-wide. A non-admin's dashboard poll, whose snapshot legitimately
+// omits every hive it cannot see, used to evict the firstSeen entries (and
+// stored acks) for ALL of those hives — so by the time the admin's ack POST
+// arrived, the condition it targeted had been wiped from shared state and
+// setAck refused it. A hive that is absent from the snapshot is no evidence
+// its condition cleared; only a hive that was evaluated and did NOT fire is.
+func (a *alertState) retainConditions(evaluated, active map[string]bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	for key := range a.firstSeen {
-		if !active[key] {
-			delete(a.firstSeen, key)
-			delete(a.acks, key)
+		if active[key] {
+			continue
 		}
+		if !evaluated[alertAckKeyHive(key)] {
+			// This hive was outside the evaluated snapshot (a scoped caller
+			// cannot see it) — leave its state for an evaluation that can.
+			continue
+		}
+		delete(a.firstSeen, key)
+		delete(a.acks, key)
 	}
 }
 
@@ -721,6 +749,11 @@ func evaluateAlerts(state *alertState, hives []alertHive, driftAlerts []Alert, n
 	// active tracks every condition firing this pass, so retainConditions can
 	// forget (and un-acknowledge) the ones that have cleared.
 	active := make(map[string]bool)
+	// evaluated tracks which hives this snapshot actually contained, so
+	// retention never evicts state for a hive a SCOPED caller simply could not
+	// see (see retainConditions). Drift-sourced alerts count too: their hive
+	// fired, so it was observed this pass.
+	evaluated := make(map[string]bool, len(hives))
 
 	add := func(hiveID, hiveName, alertType, severity, reason string) {
 		firstSeen := state.markCondition(hiveID, alertType, now)
@@ -746,6 +779,7 @@ func evaluateAlerts(state *alertState, hives []alertHive, driftAlerts []Alert, n
 		if h.ID == "" {
 			continue
 		}
+		evaluated[h.ID] = true
 
 		// --- Rule: provisioning errored. Applies to placeholders too: a pool
 		// slot that failed to provision is exactly the admin's problem. ---
@@ -908,12 +942,15 @@ func evaluateAlerts(state *alertState, hives []alertHive, driftAlerts []Alert, n
 		if d.HiveID == "" || d.Type == "" {
 			continue
 		}
+		evaluated[d.HiveID] = true
 		add(d.HiveID, d.HiveName, d.Type, d.Severity, d.Reason)
 	}
 
-	// Conditions that did not fire this pass are forgotten, which also clears
-	// their acknowledgement so a re-occurrence is not permanently silenced.
-	state.retainConditions(active)
+	// Conditions that were evaluated this pass but did not fire are forgotten,
+	// which also clears their acknowledgement so a re-occurrence is not
+	// permanently silenced. Hives OUTSIDE this snapshot are untouched — a
+	// scoped caller must never evict shared state for hives it cannot see.
+	state.retainConditions(evaluated, active)
 
 	// Most urgent first; within a severity, group by type then hive so the list
 	// is stable across polls.
@@ -1051,6 +1088,15 @@ func (s *HubServer) fleetAlerts(entries []MyHiveEntry) AlertSummary {
 	return evaluateAlerts(s.alerts, hives, s.urlUnreachableAlerts(regs, now), now)
 }
 
+// alertAcksFileMu serialises writers of the acks file. Two concurrent ack
+// POSTs used to run saveAlertAcks concurrently, and both wrote the SAME tmp
+// path with os.WriteFile — the second open truncates while the first is
+// mid-write, so the interleaved bytes that got renamed into place were not
+// JSON. That is exactly the corruption the live hub logged ("failed to parse
+// persisted alert acks: invalid character ..."), which then cost every
+// persisted ack on the next restart.
+var alertAcksFileMu sync.Mutex
+
 // saveAlertAcks persists acknowledgements to the PVC so a silenced alert stays
 // silenced across a hub restart or upgrade. Mirrors saveHubBanners: atomic
 // tmp+rename, failures logged not fatal (a lost ack merely un-silences an
@@ -1059,6 +1105,8 @@ func (s *HubServer) saveAlertAcks() {
 	if s == nil || s.alerts == nil {
 		return
 	}
+	alertAcksFileMu.Lock()
+	defer alertAcksFileMu.Unlock()
 	snapshot := s.alerts.snapshotAcks()
 	data, err := json.MarshalIndent(snapshot, "", "  ")
 	if err != nil {
@@ -1079,8 +1127,21 @@ func (s *HubServer) saveAlertAcks() {
 	}
 }
 
+// alertAcksQuarantineSuffix is appended to alertAcksPath when the file on disk
+// is not parseable, so the bad bytes are preserved for inspection instead of
+// being silently overwritten — and so the ack system starts FRESH rather than
+// staying wedged. Only the most recent corrupt file is kept: repeated
+// corruption overwrites the previous quarantine rather than growing the PVC.
+const alertAcksQuarantineSuffix = ".corrupt"
+
 // loadAlertAcks reads persisted acknowledgements on startup, dropping expired
 // ones and rewriting the file if any were pruned. A missing file is normal.
+//
+// A CORRUPT file must not disable acking: the stored acks are a convenience
+// (they only re-silence alerts across a restart), so the recovery is to
+// quarantine the bad file and continue with an empty ack store — the next ack
+// writes a fresh, valid file. Before this, the parse failure left the corrupt
+// bytes in place and the error re-logged on every boot.
 func (s *HubServer) loadAlertAcks() {
 	if s == nil || s.alerts == nil {
 		return
@@ -1094,7 +1155,14 @@ func (s *HubServer) loadAlertAcks() {
 	}
 	var stored map[string]alertAck
 	if err := json.Unmarshal(data, &stored); err != nil {
-		s.logger.Error("failed to parse persisted alert acks", "error", err)
+		quarantine := alertAcksPath + alertAcksQuarantineSuffix
+		if renameErr := os.Rename(alertAcksPath, quarantine); renameErr != nil {
+			s.logger.Error("failed to quarantine corrupt alert acks file",
+				"error", renameErr, "parseError", err)
+			return
+		}
+		s.logger.Error("persisted alert acks were corrupt — quarantined and starting fresh",
+			"error", err, "quarantined", quarantine)
 		return
 	}
 	if s.alerts.loadAcks(stored, time.Now()) {

--- a/v2/pkg/hub/alerts_test.go
+++ b/v2/pkg/hub/alerts_test.go
@@ -1606,3 +1606,312 @@ func TestAlertHiveFromEntry_CarriesAdvisoryStaleness(t *testing.T) {
 		t.Fatalf("advisory staleness not projected: %+v", got)
 	}
 }
+
+// --- Regression: Acknowledge vs scoped polls (the "never worked" bug) ---
+//
+// evaluateAlerts runs against the CALLER's visible hives (handleMyHives scopes
+// the list per user) but mutates SHARED hub state. Retention used to evict the
+// firstSeen entry — and any stored ack — for every (hive, type) key not firing
+// in the caller's snapshot, so any non-admin poll wiped the conditions for all
+// hives outside its scope. By the time the admin's ack POST arrived, setAck
+// found no live condition and the handler answered "no active alert of that
+// type for this hive" — on every click, for every alert row.
+
+// ackViaHandler POSTs to handleAlertAck exactly the identifiers the dashboard
+// sends: renderAlertRows wires ackAlert(a.hiveId, a.type, false) from the
+// summary JSON, so the body here is built from the summary's own wire form.
+func ackViaHandler(t *testing.T, s *HubServer, summary AlertSummary, alertType string) *httptest.ResponseRecorder {
+	t.Helper()
+	wire, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Alerts []struct {
+			HiveID string `json:"hiveId"`
+			Type   string `json:"type"`
+		} `json:"alerts"`
+	}
+	if err := json.Unmarshal(wire, &doc); err != nil {
+		t.Fatal(err)
+	}
+	for _, a := range doc.Alerts {
+		if a.Type != alertType {
+			continue
+		}
+		body, err := json.Marshal(map[string]any{"hiveId": a.HiveID, "type": a.Type, "clear": false})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/saas/admin/alert-ack", strings.NewReader(string(body)))
+		s.handleAlertAck(rec, req)
+		return rec
+	}
+	t.Fatalf("no %q alert in the summary to acknowledge: %+v", alertType, summary.Alerts)
+	return nil
+}
+
+func TestAlertAckSucceedsAfterAnotherCallersScopedPoll(t *testing.T) {
+	dir := t.TempDir()
+	orig := alertAcksPath
+	alertAcksPath = filepath.Join(dir, "acks.json")
+	defer func() { alertAcksPath = orig }()
+
+	s := newTestAlertServer()
+	now := time.Now()
+	h1 := baseHive("h1")
+	h1.ProvStatus = alertProvStatusError
+	h2 := baseHive("h2")
+
+	// Admin poll: full visible set. The panel renders h1's alert row.
+	adminView := evaluateAlerts(s.alerts, []alertHive{h1, h2}, nil, now)
+	before, ok := findAlert(adminView.Alerts, "h1", AlertTypeProvisionError)
+	if !ok {
+		t.Fatalf("expected a provision-error alert, got %+v", adminView.Alerts)
+	}
+
+	// Another user's poll lands in between: they can only see h2, so h1 is
+	// simply absent from their snapshot. This must NOT evict h1's condition.
+	evaluateAlerts(s.alerts, []alertHive{h2}, nil, now.Add(time.Second))
+
+	// The admin clicks Acknowledge on the row already on screen.
+	rec := ackViaHandler(t, s, adminView, AlertTypeProvisionError)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ack status = %d, want 200 (body: %s) — the scoped poll evicted the condition", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "no active alert") {
+		t.Fatalf("hit the no-active-alert path: %s", rec.Body.String())
+	}
+
+	// The next admin poll shows the row acknowledged, against the SAME
+	// occurrence (FirstSeen unchanged — a scoped poll must not re-mint it).
+	after := evaluateAlerts(s.alerts, []alertHive{h1, h2}, nil, now.Add(2*time.Second))
+	a, ok := findAlert(after.Alerts, "h1", AlertTypeProvisionError)
+	if !ok {
+		t.Fatal("condition should still fire")
+	}
+	if !a.Acknowledged {
+		t.Fatal("the alert must be acknowledged")
+	}
+	if !a.FirstSeen.Equal(before.FirstSeen) {
+		t.Fatalf("FirstSeen churned across a scoped poll: %v -> %v", before.FirstSeen, a.FirstSeen)
+	}
+}
+
+func TestExistingAckSurvivesAnotherCallersScopedPoll(t *testing.T) {
+	dir := t.TempDir()
+	orig := alertAcksPath
+	alertAcksPath = filepath.Join(dir, "acks.json")
+	defer func() { alertAcksPath = orig }()
+
+	s := newTestAlertServer()
+	now := time.Now()
+	h1 := baseHive("h1")
+	h1.ProvStatus = alertProvStatusError
+	h2 := baseHive("h2")
+
+	adminView := evaluateAlerts(s.alerts, []alertHive{h1, h2}, nil, now)
+	if rec := ackViaHandler(t, s, adminView, AlertTypeProvisionError); rec.Code != http.StatusOK {
+		t.Fatalf("ack failed: %d %s", rec.Code, rec.Body.String())
+	}
+
+	// A scoped poll from a user who cannot see h1 must not clear the ack.
+	evaluateAlerts(s.alerts, []alertHive{h2}, nil, now.Add(time.Second))
+
+	after := evaluateAlerts(s.alerts, []alertHive{h1, h2}, nil, now.Add(2*time.Second))
+	a, ok := findAlert(after.Alerts, "h1", AlertTypeProvisionError)
+	if !ok {
+		t.Fatal("condition should still fire")
+	}
+	if !a.Acknowledged {
+		t.Fatal("a stored ack must survive another caller's scoped poll")
+	}
+	if after.Total != 0 {
+		t.Fatalf("Total = %d, want 0 — the ack must keep suppressing the count", after.Total)
+	}
+}
+
+func TestAckStillClearsWhenConditionResolvesInScope(t *testing.T) {
+	// The flip side of the scoping fix: a hive that IS in the snapshot and no
+	// longer fires must still have its condition (and ack) forgotten, so a
+	// recurrence re-alerts instead of being permanently silenced.
+	dir := t.TempDir()
+	orig := alertAcksPath
+	alertAcksPath = filepath.Join(dir, "acks.json")
+	defer func() { alertAcksPath = orig }()
+
+	s := newTestAlertServer()
+	now := time.Now()
+	h1 := baseHive("h1")
+	h1.ProvStatus = alertProvStatusError
+
+	view := evaluateAlerts(s.alerts, []alertHive{h1}, nil, now)
+	if rec := ackViaHandler(t, s, view, AlertTypeProvisionError); rec.Code != http.StatusOK {
+		t.Fatalf("ack failed: %d %s", rec.Code, rec.Body.String())
+	}
+
+	// The provisioning error clears — h1 is present and healthy.
+	healed := baseHive("h1")
+	evaluateAlerts(s.alerts, []alertHive{healed}, nil, now.Add(time.Second))
+
+	// It errors again: a NEW occurrence must alert, unsilenced.
+	again := evaluateAlerts(s.alerts, []alertHive{h1}, nil, now.Add(2*time.Second))
+	a, ok := findAlert(again.Alerts, "h1", AlertTypeProvisionError)
+	if !ok {
+		t.Fatal("the recurrence must alert")
+	}
+	if a.Acknowledged {
+		t.Fatal("an ack for a resolved occurrence must not silence a recurrence")
+	}
+}
+
+// --- Round-trip acks for every alert category the panel renders ---
+
+func TestAlertAckRoundTripPerCategory(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name      string
+		alertType string
+		// establish drives the evaluator until the condition is live, and
+		// returns the summary whose wire JSON the "UI" acks from.
+		establish func(s *HubServer) AlertSummary
+	}{
+		{
+			name:      "crash-looping",
+			alertType: AlertTypeCrashLoop,
+			establish: func(s *HubServer) AlertSummary {
+				h := baseHive("h1")
+				// Three distinct start times inside the window, current uptime
+				// under the ceiling — the rule's own firing conditions.
+				h.StartedAt = rfc3339(now.Add(-30 * time.Minute))
+				evaluateAlerts(s.alerts, []alertHive{h}, nil, now.Add(-20*time.Minute))
+				h.StartedAt = rfc3339(now.Add(-10 * time.Minute))
+				evaluateAlerts(s.alerts, []alertHive{h}, nil, now.Add(-9*time.Minute))
+				h.StartedAt = rfc3339(now.Add(-2 * time.Minute))
+				return evaluateAlerts(s.alerts, []alertHive{h}, nil, now)
+			},
+		},
+		{
+			name:      "health check failing",
+			alertType: AlertTypeHealthCheckFailing,
+			establish: func(s *HubServer) AlertSummary {
+				h := baseHive("h1")
+				h.Health = map[string]any{"checks": []any{
+					map[string]any{"name": "governor", "status": "fail"},
+				}}
+				return evaluateAlerts(s.alerts, []alertHive{h}, nil, now)
+			},
+		},
+		{
+			name:      "token burn",
+			alertType: AlertTypeTokenBurn,
+			establish: func(s *HubServer) AlertSummary {
+				h := baseHive("h1")
+				// The zero-spend variant: online, registered long ago, no burn.
+				h.TotalTokens24h = 0
+				return evaluateAlerts(s.alerts, []alertHive{h}, nil, now)
+			},
+		},
+		{
+			name:      "stuck upgrade",
+			alertType: AlertTypeStuckUpgrade,
+			establish: func(s *HubServer) AlertSummary {
+				h := baseHive("h1")
+				h.Upgrading = true
+				h.UpgradeStartedAt = now.Add(-staleUpgradeTimeout - time.Minute)
+				return evaluateAlerts(s.alerts, []alertHive{h}, nil, now)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			orig := alertAcksPath
+			alertAcksPath = filepath.Join(dir, "acks.json")
+			defer func() { alertAcksPath = orig }()
+
+			s := newTestAlertServer()
+			summary := tc.establish(s)
+			if !hasAlert(summary.Alerts, "h1", tc.alertType) {
+				t.Fatalf("test setup did not raise %q: %+v", tc.alertType, summary.Alerts)
+			}
+
+			rec := ackViaHandler(t, s, summary, tc.alertType)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("ack status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+			}
+			if strings.Contains(rec.Body.String(), "no active alert") {
+				t.Fatalf("hit the no-active-alert path: %s", rec.Body.String())
+			}
+		})
+	}
+}
+
+// --- Regression: a corrupt acks file must not disable acking ---
+
+func TestCorruptAcksFileIsQuarantinedAndAckingContinues(t *testing.T) {
+	dir := t.TempDir()
+	orig := alertAcksPath
+	alertAcksPath = filepath.Join(dir, "hub-alert-acks.json")
+	defer func() { alertAcksPath = orig }()
+
+	// The exact live failure mode: bytes at the acks path that are not JSON
+	// ("invalid character ... looking for beginning of object key string").
+	garbage := []byte("{not json\nnope")
+	if err := os.WriteFile(alertAcksPath, garbage, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newTestAlertServer()
+	s.loadAlertAcks()
+
+	// The corrupt file is quarantined, not left in place to fail every boot.
+	quarantine := alertAcksPath + alertAcksQuarantineSuffix
+	kept, err := os.ReadFile(quarantine)
+	if err != nil {
+		t.Fatalf("corrupt acks file was not quarantined: %v", err)
+	}
+	if string(kept) != string(garbage) {
+		t.Fatal("quarantine must preserve the corrupt bytes for inspection")
+	}
+	if _, err := os.Stat(alertAcksPath); !os.IsNotExist(err) {
+		t.Fatalf("corrupt file must be moved out of the acks path, stat err = %v", err)
+	}
+
+	// Acking still works end-to-end on the fresh store.
+	now := time.Now()
+	h := baseHive("h1")
+	h.ProvStatus = alertProvStatusError
+	summary := evaluateAlerts(s.alerts, []alertHive{h}, nil, now)
+	if rec := ackViaHandler(t, s, summary, AlertTypeProvisionError); rec.Code != http.StatusOK {
+		t.Fatalf("ack after quarantine failed: %d %s", rec.Code, rec.Body.String())
+	}
+
+	// A fresh, VALID file was written in place of the corrupt one...
+	raw, err := os.ReadFile(alertAcksPath)
+	if err != nil {
+		t.Fatalf("no fresh acks file was written: %v", err)
+	}
+	var rewritten map[string]alertAck
+	if err := json.Unmarshal(raw, &rewritten); err != nil {
+		t.Fatalf("rewritten acks file is not valid JSON: %v", err)
+	}
+	if len(rewritten) != 1 {
+		t.Fatalf("rewritten file has %d entries, want 1", len(rewritten))
+	}
+
+	// ...and a restart honors the ack made after recovery.
+	s2 := newTestAlertServer()
+	s2.loadAlertAcks()
+	got := evaluateAlerts(s2.alerts, []alertHive{h}, nil, now.Add(time.Minute))
+	a, ok := findAlert(got.Alerts, "h1", AlertTypeProvisionError)
+	if !ok {
+		t.Fatal("condition should still fire after restart")
+	}
+	if !a.Acknowledged {
+		t.Fatal("the post-recovery ack must survive a restart")
+	}
+}


### PR DESCRIPTION
## The bug

Clicking **Acknowledge** on any row of the hub dashboard's "Attention needed" panel always failed with the toast **"no active alert of that type for this hive"** — it has never worked.

## Root cause

The client side was fine: the panel POSTs exactly the server's own identifiers (`v2/pkg/hub/saas.go:10473-10476` wires `ackAlert(a.hiveId, a.type, ...)` from the summary JSON; `ackAlert` at `saas.go:10231` sends `{hiveId, type, clear}`).

The mismatch is server-side, between **whose snapshot evaluated the alerts** and **the shared state the ack handler checks**:

- `handleMyHives` (`v2/pkg/hub/saas.go:2575`) computes `s.fleetAlerts(result)` over the **caller's visible hives only** — a non-admin sees just their own hives.
- `evaluateAlerts` then called `state.retainConditions(active)` (`v2/pkg/hub/alerts.go`, formerly line ~916) on the **shared, hub-wide** `alertState`, deleting the `firstSeen` entry **and any stored ack** for every `(hive, type)` key not firing in that caller's snapshot.
- So every poll from any user whose view omits a hive evicted that hive's live conditions from shared state. On a hub with multiple auto-refreshing dashboards, the admin's conditions were wiped within seconds of every re-mint — by the time the ack POST arrived, `setAck` (`alerts.go`) found no `firstSeen` entry and `handleAlertAck` answered 409 `no active alert of that type for this hive` (`alerts.go:1149` pre-fix). It also churned `FirstSeen` (alert ages reset constantly) and deleted any ack that did land.

## The fix

`retainConditions(evaluated, active)` now also takes the set of hive IDs actually **present** in the evaluated snapshot and only evicts conditions for those hives. A hive absent from a scoped caller's view is no evidence its condition cleared; a hive that IS in scope and stops firing still has its condition and ack forgotten, so a recurrence re-alerts (the designed `ConditionFirstSeen` semantic is untouched, as is the 7-day `alertAckMaxAge` resurface).

## Corrupt ack store recovery

The live hub logged `failed to parse persisted alert acks error="invalid character 'n' looking for beginning of object key string"` — the on-disk `hub-alert-acks.json` was corrupt, and `loadAlertAcks` left the bad file in place to re-fail every boot.

- `loadAlertAcks` now **quarantines** an unparseable file (renames it aside with a `.corrupt` suffix, preserving the bytes for inspection) and starts fresh — a corrupt file never disables acking.
- Likely corruption source fixed too: `saveAlertAcks` is now serialised by a mutex. Two concurrent ack POSTs both ran `os.WriteFile` on the **same** tmp path; the second open truncates while the first is mid-write, and the interleaved bytes get renamed into place.

## Before / after

- Before: Acknowledge always 409'd; alert ages churned; any ack that landed was silently evicted by the next scoped poll; a corrupt acks file wedged persistence forever.
- After: Acknowledge works for every alert category in the panel, the row moves to the acknowledged state, the ack persists across hub restarts, clears when the condition resolves so recurrences re-alert, and a corrupt store self-heals.

## Tests

- Ack round-trip per panel category — crash-loop, health-check-failing, token-burn, stuck-upgrade — POSTing exactly the summary's wire identifiers, asserting the "no active alert" path is not hit.
- Regression: ack succeeds after another caller's scoped poll; an existing ack survives a scoped poll; `FirstSeen` does not churn.
- Flip side: a condition that resolves **in scope** still clears its ack, so recurrences re-alert.
- Corrupt acks file: quarantined (bytes preserved), acking continues, fresh valid file written, post-recovery ack survives a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)