### PR TITLE
✨ feat(hub): persist hosted-hive Kubernetes namespace in registry

### DIFF
--- a/v2/pkg/hub/hive_namespace_overlay_test.go
+++ b/v2/pkg/hub/hive_namespace_overlay_test.go
@@ -1,0 +1,99 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// namespaceRegistryEntry drives handleHeartbeat exactly as the spoke does (via
+// the shared postHeartbeat helper), asserts a 200, and returns the freshly-
+// stored registry entry for the hive.
+func namespaceRegistryEntry(t *testing.T, srv *HubServer, hiveID string) RegistryEntry {
+	t.Helper()
+	rec := postHeartbeat(t, srv, `{"hive_id":"`+hiveID+`","org":"testorg","git_hash":"sha1"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("heartbeat returned %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	for _, h := range srv.registry.Hives {
+		if h.ID == hiveID {
+			return h
+		}
+	}
+	t.Fatalf("no registry entry stored for hive %q after heartbeat", hiveID)
+	return RegistryEntry{}
+}
+
+// TestHeartbeatOverlaysHostedNamespace covers the RegistryEntry.Namespace
+// overlay on the authoritative heartbeat path: when a SaaSHive record exists the
+// entry is stamped with the derived "hive-hosted-<id>" namespace (the value an
+// operator needs for `kubectl -n <ns> exec` without re-grepping the cluster),
+// and when no SaaSHive record exists the namespace is left empty — never guessed
+// for a self-hosted/BYO spoke.
+func TestHeartbeatOverlaysHostedNamespace(t *testing.T) {
+	useTempHiveDir(t) // restored via t.Cleanup — no leaked global for -race to catch
+
+	t.Run("hosted hive with a SaaSHive record gets hive-hosted-<id>", func(t *testing.T) {
+		srv := NewHubServer(0, slog.Default(), "test", "v2")
+		srv.hubSecret = ""
+
+		const hiveID = "hosted-available-oke-07-placeholder-a1b2"
+		if err := saveSaaSHive(&SaaSHive{
+			ID:        hiveID,
+			Owner:     hubAdminUsername,
+			Status:    statusAvailable,
+			ClusterID: defaultClusterID,
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		entry := namespaceRegistryEntry(t, srv, hiveID)
+
+		want := hiveHostedNamespacePrefix + hiveID
+		if entry.Namespace != want {
+			t.Errorf("Namespace = %q, want %q", entry.Namespace, want)
+		}
+		// The ID never changes on claim, so the derived namespace stays correct
+		// across reassignment — this is the whole reason it is safe to persist.
+		if entry.Namespace != "hive-hosted-"+hiveID {
+			t.Errorf("Namespace not the stable hive-hosted-<id> form: %q", entry.Namespace)
+		}
+	})
+
+	t.Run("hive with no SaaSHive record keeps Namespace empty", func(t *testing.T) {
+		srv := NewHubServer(0, slog.Default(), "test", "v2")
+		srv.hubSecret = ""
+
+		// No saveSaaSHive: this is a self-hosted/BYO spoke the hub did not
+		// provision, so it does not run in a hive-hosted-<id> namespace and the
+		// hub must not fabricate one.
+		entry := namespaceRegistryEntry(t, srv, "byo-selfhosted-hive")
+
+		if entry.Namespace != "" {
+			t.Errorf("Namespace = %q for a hive with no SaaSHive record, want empty (must not be guessed)", entry.Namespace)
+		}
+	})
+}
+
+// TestDashboardRendersHiveNamespace guards that the hive-row namespace
+// affordance stays wired into the dashboard: the row reads h.namespace, offers
+// a click-to-copy handler, and titles it for kubectl exec. A regression that
+// dropped any of these would silently send operators back to `kubectl get ns`.
+func TestDashboardRendersHiveNamespace(t *testing.T) {
+	snippets := []string{
+		// The row consumes the JSON field the hub now overlays.
+		"if (h.namespace)",
+		// Copy-on-click into the shared clipboard helper.
+		"copyHiveText(",
+		// The helper itself exists.
+		"function copyHiveText(",
+		// The affordance is labelled for its purpose.
+		"kubectl -n ",
+	}
+	for _, s := range snippets {
+		if !strings.Contains(dashboardHTML, s) {
+			t.Errorf("dashboardHTML is missing the hive-namespace snippet %q", s)
+		}
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2217,6 +2217,11 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		entry.ProvStatus = sh.Status
+		// Overlay the hosted namespace at read time too, so a placeholder or a
+		// hive whose live registry entry predates the field still shows
+		// "hive-hosted-<id>" in My Hives. Derived from the SaaSHive record, same
+		// as the heartbeat path — the value the operator needs for kubectl exec.
+		entry.Namespace = hostedNamespaceForHive(sh)
 		// A placeholder wedged between the two claim paths: it was given a real
 		// identity (org/repo written) but the spoke never reported the project back.
 		// Computed from meta (not the live registry) so it is true even for an
@@ -2388,6 +2393,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 						PrimaryRepo: sh.PrimaryRepo,
 						ACMMLevel:   sh.ACMMLevel,
 						HiveType:    "hosted",
+						Namespace:   hostedNamespaceForHive(sh),
 						ClusterID:   clusterIDForSaaSHive(*sh),
 						ClusterName: s.clusterNameForID(clusterIDForSaaSHive(*sh)),
 					},
@@ -2421,6 +2427,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 					PrimaryRepo: sh.PrimaryRepo,
 					ACMMLevel:   sh.ACMMLevel,
 					HiveType:    "hosted",
+					Namespace:   hostedNamespaceForHive(&sh),
 					ClusterID:   clusterIDForSaaSHive(sh),
 					ClusterName: s.clusterNameForID(clusterIDForSaaSHive(sh)),
 				},
@@ -8271,6 +8278,38 @@ const dashboardHTML = `<!DOCTYPE html>
       setTimeout(function() { t.remove(); }, 4000);
     }
 
+    /* copyHiveText copies a plain string to the clipboard for the small
+       copy-on-click affordances in the hive rows (e.g. the Kubernetes
+       namespace). Prefers the async Clipboard API and falls back to a hidden
+       textarea + execCommand for older/insecure-context browsers, so the copy
+       works whether or not the dashboard is served over HTTPS. Always shows a
+       toast so the (silent) copy is confirmed. */
+    function copyHiveText(text, label) {
+      var msg = 'Copied ' + (label || 'value');
+      function ok() { hiveToast(msg, 'success'); }
+      function fail() { hiveToast('Copy failed — select and copy manually', 'error'); }
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(ok, function() {
+          if (!legacyCopy(text)) fail(); else ok();
+        });
+        return;
+      }
+      if (legacyCopy(text)) ok(); else fail();
+    }
+    function legacyCopy(text) {
+      try {
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+        var okc = document.execCommand('copy');
+        ta.remove();
+        return okc;
+      } catch (e) { return false; }
+    }
+
     function hiveConfirm(msg, rawHTML) {
       return new Promise(function(resolve) {
         var overlay = document.createElement('div');
@@ -12850,9 +12889,24 @@ const dashboardHTML = `<!DOCTYPE html>
            identically wherever it appears. An absent host renders as
            "github.com" rather than a blank chip, which is what an old
            heartbeat-only spoke that cannot yet report its host should show. */
+        /* Kubernetes namespace line: a small, copy-on-click monospace value so an
+           operator can grab "hive-hosted-<id>" for a kubectl -n <ns> exec without
+           re-grepping kubectl get ns on a live cluster. h.namespace is overlaid
+           by the hub from the SaaSHive record (see RegistryEntry.Namespace); it is
+           only present for hub-provisioned hosted hives, so a self-hosted/BYO/local
+           row simply omits the line and is pixel-identical to before. */
+        var nsLine = '';
+        if (h.namespace) {
+          nsLine = '<div style="' + STACKED_LINE_STYLE + ';font-size:0.65rem">' +
+            '<span onclick="copyHiveText(' + jsArg(h.namespace) + ',\'namespace\')" ' +
+            'title="Kubernetes namespace — click to copy (kubectl -n ' + escAttr(h.namespace) + ' exec …)" ' +
+            'style="font-family:ui-monospace,monospace;color:var(--muted);cursor:pointer;border-bottom:1px dotted var(--border)">' +
+            esc(h.namespace) + '</span></div>';
+        }
         var locationCell = '<div style="' + STACKED_CELL_STYLE + '">' +
           '<div style="' + STACKED_LINE_STYLE + '">' + locationBadge + '</div>' +
           '<div style="' + STACKED_LINE_STYLE + ';font-size:0.7rem">' + visibilityCell + '</div>' +
+          nsLine +
           '</div>';
         var pendingExpandRow = '';
         if (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write') && (h.pending_requests || []).length > 0) {

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -150,7 +150,19 @@ type RegistryEntry struct {
 	Owner              string `json:"owner,omitempty"`
 	ClusterID          string `json:"clusterId,omitempty"`
 	ClusterName        string `json:"clusterName,omitempty"`
-	HiveType           string `json:"hiveType,omitempty"`
+	// Namespace is the Kubernetes namespace this hive's spoke runs in. For a
+	// hub-provisioned (hosted) hive it is hostedNamespaceForHive(sh) —
+	// "hive-hosted-<id>" — overlaid from the authoritative SaaSHive record on
+	// the heartbeat path (NOT reported by the spoke), so operators can
+	// `kubectl -n <ns> exec …` straight from My Hives without re-grepping
+	// `kubectl get ns` on a live cluster. It is derived, not renamed: a claimed
+	// placeholder keeps its "hive-hosted-<placeholder-id>" namespace forever
+	// (the ID never changes on claim — see hosted_namespace_identity.go), so
+	// this stays correct across reassignment. Empty for a self-hosted/BYO hive
+	// that does not run in a hub-provisioned namespace, or for a hive with no
+	// SaaSHive record (old spoke) — never guessed for those.
+	Namespace string `json:"namespace,omitempty"`
+	HiveType  string `json:"hiveType,omitempty"`
 	// ProvStatus is the authoritative provisioning status copied from the hive's
 	// SaaSHive record (sh.Status) on the heartbeat path — statusAvailable
 	// ("available") for a genuinely-unclaimed pool placeholder, else a claimed
@@ -1288,6 +1300,14 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		// entry the dashboard renders. The spoke never reports this, so a blank
 		// ProjectName simply leaves the client on its org/repo fallback label.
 		entry.ProjectName = sh.ProjectName
+		// Persist the hosted namespace ("hive-hosted-<id>") the same way — the
+		// hub already derives it deterministically from the (stable) hive ID, so
+		// storing it here makes it authoritative, self-healing across a claim/
+		// reassign, and available to My Hives + kubectl-exec without a live
+		// `kubectl get ns` hunt. Only set when a SaaSHive record exists, so a
+		// self-hosted/BYO hive keeps Namespace empty rather than being wrongly
+		// labelled with a namespace it does not run in.
+		entry.Namespace = hostedNamespaceForHive(sh)
 	}
 	if clusterID == "" && payload.ClusterID != "" {
 		clusterID = sanitizeHeartbeatField(payload.ClusterID)


### PR DESCRIPTION
Fixes #2741

## Problem

Operators re-grep `kubectl get ns` on a live cluster every time they need to `kubectl exec` into a hosted hive's spoke, because the hub never persisted the hive→namespace mapping — even though it already derives it deterministically via `hostedNamespaceForHive` (`hive-hosted-<id>`). That live cluster query is slow and can hang against an unreachable/slow API server.

## Change

Purely persist + expose an already-known value. No change to namespace naming/derivation, the identity-stamp logic, or provisioning.

- **`RegistryEntry.Namespace`** (`v2/pkg/hub/server.go`): new `json:"namespace,omitempty"` field.
- **Populated on the authoritative heartbeat overlay path** (`handleHeartbeat`) from the `SaaSHive` record via `hostedNamespaceForHive(sh)`, right where `ProvStatus`/`ProjectName` are already overlaid. Derived and self-healing: the hive ID is stable across a claim/reassign, so a claimed placeholder keeps its `hive-hosted-<placeholder-id>` namespace. Empty for a self-hosted/BYO hive with no `SaaSHive` record — never guessed.
- Also overlaid on the **My Hives read paths** (`enrichFromSaaSMeta` and the two SaaSHive-built fallback entries) so placeholders / pre-field registry entries still show it.
- **Dashboard**: the hive row shows the namespace as a small copy-on-click monospace value under the Location cell, titled for `kubectl -n <ns> exec …`, via a new shared `copyHiveText` clipboard helper (Clipboard API + `execCommand` fallback for insecure contexts). Unobtrusive: a non-hosted/local row omits the line and is pixel-identical to before.

### Namespace source
**Derived-only** from the `SaaSHive` record. The heartbeat payload carries no spoke-reported namespace, so wiring a spoke-reported value would mean a new heartbeat field — out of scope to keep this small; a BYO hive therefore keeps `Namespace` empty rather than being mislabelled.

## Tests
- `TestHeartbeatOverlaysHostedNamespace`: drives `handleHeartbeat` and asserts `Namespace == "hive-hosted-<id>"` when a `SaaSHive` record exists, and stays empty when there is none. Uses `useTempHiveDir` (per-test isolation, restored via `t.Cleanup` — no leaked global) and reuses the existing `postHeartbeat` helper. Passes under `-race`.
- `TestDashboardRendersHiveNamespace`: asserts the row consumes `h.namespace`, wires the copy handler, and titles it for kubectl exec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)