### PR TITLE
🎨 fix(hub): move hive namespace from location column into the status hover as "ns:"

### DIFF
--- a/v2/pkg/hub/hive_namespace_overlay_test.go
+++ b/v2/pkg/hub/hive_namespace_overlay_test.go
@@ -76,24 +76,26 @@ func TestHeartbeatOverlaysHostedNamespace(t *testing.T) {
 	})
 }
 
-// TestDashboardRendersHiveNamespace guards that the hive-row namespace
-// affordance stays wired into the dashboard: the row reads h.namespace, offers
-// a click-to-copy handler, and titles it for kubectl exec. A regression that
-// dropped any of these would silently send operators back to `kubectl get ns`.
+// TestDashboardRendersHiveNamespace guards that the hive-row namespace stays
+// surfaced in the STATUS HOVER (not the location column): the hover's lines[]
+// builder derives the namespace via hiveNamespace(h) and pushes it as an "ns:"
+// line. A regression that dropped this would silently send operators back to
+// `kubectl get ns`. The namespace is deliberately NOT a permanent location-
+// column value — it is low-frequency reference metadata for a kubectl -n exec.
 func TestDashboardRendersHiveNamespace(t *testing.T) {
 	snippets := []string{
-		// The row consumes the JSON field the hub now overlays.
-		"if (h.namespace)",
-		// Copy-on-click into the shared clipboard helper.
-		"copyHiveText(",
-		// The helper itself exists.
-		"function copyHiveText(",
-		// The affordance is labelled for its purpose.
-		"kubectl -n ",
+		// The hover derives the namespace client-side from the row.
+		"hiveNamespace(h)",
+		// It is pushed into the hover as an "ns:" line.
+		"lines.push('ns: ' + hns)",
 	}
 	for _, s := range snippets {
 		if !strings.Contains(dashboardHTML, s) {
-			t.Errorf("dashboardHTML is missing the hive-namespace snippet %q", s)
+			t.Errorf("dashboardHTML is missing the hive-namespace hover snippet %q", s)
 		}
+	}
+	// And it must NOT reappear as a permanent location-column render.
+	if strings.Contains(dashboardHTML, "var nsLine =") {
+		t.Errorf("namespace should live in the status hover, not the location column (found nsLine render)")
 	}
 }

--- a/v2/pkg/hub/hosted_namespace_identity_test.go
+++ b/v2/pkg/hub/hosted_namespace_identity_test.go
@@ -521,7 +521,7 @@ func TestStatusHoverRendersNamespace(t *testing.T) {
 		name    string
 		snippet string
 	}{
-		{"namespace line is composed into the hover", "lines.push('Namespace: ' + hns);"},
+		{"namespace line is composed into the hover", "lines.push('ns: ' + hns);"},
 		{"hiveNamespace helper exists", "function hiveNamespace(h)"},
 		{"hiveNamespace derives from hive-hosted- + id", "return 'hive-hosted-' + h.id;"},
 	}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -9096,7 +9096,7 @@ const dashboardHTML = `<!DOCTYPE html>
       // decided; omitted for a non-hosted row, which has no such namespace.
       var hns = hiveNamespace(h);
       if (hns) {
-        lines.push('Namespace: ' + hns);
+        lines.push('ns: ' + hns);
       }
       var access = h.access || [];
       var dotMarkup = '<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + c + '"></span>' +
@@ -12889,24 +12889,14 @@ const dashboardHTML = `<!DOCTYPE html>
            identically wherever it appears. An absent host renders as
            "github.com" rather than a blank chip, which is what an old
            heartbeat-only spoke that cannot yet report its host should show. */
-        /* Kubernetes namespace line: a small, copy-on-click monospace value so an
-           operator can grab "hive-hosted-<id>" for a kubectl -n <ns> exec without
-           re-grepping kubectl get ns on a live cluster. h.namespace is overlaid
-           by the hub from the SaaSHive record (see RegistryEntry.Namespace); it is
-           only present for hub-provisioned hosted hives, so a self-hosted/BYO/local
-           row simply omits the line and is pixel-identical to before. */
-        var nsLine = '';
-        if (h.namespace) {
-          nsLine = '<div style="' + STACKED_LINE_STYLE + ';font-size:0.65rem">' +
-            '<span onclick="copyHiveText(' + jsArg(h.namespace) + ',\'namespace\')" ' +
-            'title="Kubernetes namespace — click to copy (kubectl -n ' + escAttr(h.namespace) + ' exec …)" ' +
-            'style="font-family:ui-monospace,monospace;color:var(--muted);cursor:pointer;border-bottom:1px dotted var(--border)">' +
-            esc(h.namespace) + '</span></div>';
-        }
+        /* The Kubernetes namespace is NOT shown in the location column — it is
+           low-frequency reference metadata (an operator only needs it to build a
+           kubectl -n <ns> exec), so it lives in the status hover as an "ns:" line
+           (see hiveNamespace(h) / the lines[] builder) rather than competing for
+           space in a permanent column. */
         var locationCell = '<div style="' + STACKED_CELL_STYLE + '">' +
           '<div style="' + STACKED_LINE_STYLE + '">' + locationBadge + '</div>' +
           '<div style="' + STACKED_LINE_STYLE + ';font-size:0.7rem">' + visibilityCell + '</div>' +
-          nsLine +
           '</div>';
         var pendingExpandRow = '';
         if (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write') && (h.pending_requests || []).length > 0) {


### PR DESCRIPTION
## Problem

The persisted hosted-hive namespace (#2742) landed as a prominent underlined monospace value in the spoke table's **LOCATION** column, so every hosted row now shows a long `hive-hosted-<id>` string under the cluster pill — cluttering the table with low-frequency reference metadata.

## Change

The namespace is only needed to build a `kubectl -n <ns> exec`, so it belongs in the on-demand **status hover**, not a permanent column.

- Remove the location-column `nsLine` render — the location cell is pixel-identical to pre-#2742 again.
- The status hover already derives the namespace client-side via `hiveNamespace(h)`; relabel its line from `Namespace:` to **`ns:`** (operator's preferred compact label).
- Update the two guarding tests: `TestDashboardRendersHiveNamespace` now asserts the hover `ns:` line (and that no location-column `nsLine` returns); `TestStatusHoverRendersNamespace` asserts the `ns:` label.

No behavior change to the persisted `RegistryEntry.Namespace` data — this is purely where/how it renders.