### PR TITLE
🐛 fix(hub): raise spoke memory 8Gi→16Gi so the agent fleet doesn't OOM

### DIFF
--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -29,8 +29,17 @@ const (
 	provisionTimeout      = 5 * time.Minute
 	cpuRequest            = "500m"
 	cpuLimit              = "2000m"
-	memRequest            = "2Gi"
-	memLimit              = "8Gi"
+	// memRequest/memLimit size the spoke pod for the WHOLE agent fleet, not just
+	// the Go hive process. Each active coding agent (Copilot/Claude CLI) grows to
+	// ~2GB RSS, and an L6 hive runs 5-6 concurrently plus the hive process, so an
+	// 8Gi limit is exceeded and the kernel OOM-kills agents one-by-one. Because a
+	// dead agent's tmux SESSION lingers, the liveness check (has-session) still
+	// reports it "running" and it is never relaunched — the fleet silently dies
+	// and the PR pipeline stalls (observed 2026-08-06: 9 OOM kills, whole fleet
+	// down ~4.5h on console-4vkt). 16Gi gives each agent headroom; OKE nodes have
+	// ~90GiB allocatable, so this is comfortably schedulable.
+	memRequest            = "4Gi"
+	memLimit              = "16Gi"
 	nfsStorageCapacity    = "50Gi"
 	nfsMountTargetIP      = "10.0.10.30"
 	nfsExportPathPrefix   = "/hive-"


### PR DESCRIPTION
## What
Raise the spoke pod memory: limit **8Gi→16Gi**, request **2Gi→4Gi**, in the hub provision template (`saas_provision.go`).

## Root cause (diagnosed live on console-4vkt, 2026-08-06)
The 8Gi limit sized for the Go hive process, **not the whole agent fleet**. Each active coding agent (Copilot/Claude CLI) grows to ~2GB RSS; an L6 hive runs 5-6 concurrently plus the hive process → exceeds 8Gi → kernel OOM-kills agents one-by-one.

**The failure is silent and unrecoverable:**
- `dmesg`: `Memory cgroup out of memory: Killed process ... UID:2007` (scanner) — **9 OOM kills total**, scanner killed 3×.
- When an agent is OOM-killed, its **tmux session lingers**, so the liveness check (`tmux has-session`) still reports it 'running' → the governor never relaunches it.
- Result: the entire agent fleet died off over ~4.5h (0 hive-bot PRs merged in 2h), while the dashboard only showed 'degraded' because the hive **core** stayed healthy (ready ✓, github_auth ✓). The 'queue flow' was the GitHub-Actions auto-QA, not the agents.

## Why 16Gi
OKE nodes have **~90GiB allocatable** — 16Gi is comfortably schedulable with room for the fleet's peak. Memory usage right after the live patch: ~1.1GB, so 16Gi gives large headroom for 6 agents × ~2GB.

## Why this is the durable fix
The hub **re-templates the spoke deploy on every provision/upgrade** ([[hosted config precedence]]), so a live `kubectl patch` to 16Gi (which I applied for immediate recovery) is **reverted on the next roll**. The template constant is the authoritative source.

## Follow-up (not in this PR)
The deeper bug is that the liveness check keys on **tmux-session-exists**, not **agent-process-alive** — so a dead-but-session-present agent is never relaunched. Worth a separate fix so OOM (or any agent crash) self-heals even under the current limit. Filing/left as a note.

No test changes needed (the `8Gi` strings in tests are node-allocatable fixtures + a byte-parser case, unrelated to this constant).