### PR TITLE
fix(security): H3 — shared App-token cache owner-only (0600) + fail-loud fallbacks

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -39,16 +39,26 @@ fi
 
 # Inject GitHub App token for agent gh calls (15k/hr vs PAT's 5k/hr).
 # Contributors keep their personal token — they fork+PR with their own identity.
-GH_APP_TOKEN_CACHE="/var/run/hive-metrics/gh-app-token.cache"
 TOKEN_ACCESS_LOG="/var/run/hive-metrics/token-access.jsonl"
 if [[ "${HIVE_CONTRIBUTOR_MODE:-}" != "true" ]]; then
-  # Per-agent scoped token (Phase 4) — 0600, owned by agent UID, least-privilege.
+  # Per-agent scoped token (Phase 4) — 0640 dev:hive-<agent>, least-privilege,
+  # readable ONLY by the owning agent's private group. This is the ONLY token an
+  # agent may use.
+  #
+  # SECURITY (audit H3, CWE-522/732): there is deliberately NO fallback to the
+  # shared full-privilege installation-token cache
+  # (/var/run/hive-metrics/gh-app-token.cache) nor to the full-token-derived
+  # HIVE_GITHUB_TOKEN env var. Both carry the FULL installation token; falling
+  # back to either would silently escalate every agent to full privilege and
+  # defeat per-agent tier scoping. A missing scoped token must FAIL LOUD so the
+  # operator fixes token delivery — it must never quietly escalate.
   if [[ -n "${HIVE_AGENT_TOKEN_CACHE:-}" && -f "${HIVE_AGENT_TOKEN_CACHE}" ]]; then
     export GH_TOKEN="$(cat "$HIVE_AGENT_TOKEN_CACHE")"
-  elif [[ -f "$GH_APP_TOKEN_CACHE" ]]; then
-    export GH_TOKEN="$(cat "$GH_APP_TOKEN_CACHE")"
-  elif [[ -n "${HIVE_GITHUB_TOKEN:-}" ]]; then
-    export GH_TOKEN="$HIVE_GITHUB_TOKEN"
+  else
+    echo "⛔ BLOCKED: per-agent scoped GitHub token not available (${HIVE_AGENT_TOKEN_CACHE:-HIVE_AGENT_TOKEN_CACHE unset})." >&2
+    echo "   Refusing to fall back to the shared full-privilege App token — that would defeat per-agent tier scoping (audit H3)." >&2
+    echo "   The hive delivers a scoped token per agent; report this to the operator so token delivery is repaired." >&2
+    exit 1
   fi
   printf '{"ts":"%s","agent":"%s","uid":%d,"op":"gh","cmd":"gh %s"}\n' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${HIVE_AGENT:-unknown}" "$(id -u)" "$*" \

--- a/bin/git-credential-hive.sh
+++ b/bin/git-credential-hive.sh
@@ -101,31 +101,24 @@ else
   fi
 fi
 
-TOKEN_FILE="/var/run/hive-metrics/gh-app-token.cache"
-CACHE_MAX_AGE_SECONDS=3300
-
-refresh_token() {
-  if [ -x /usr/local/bin/gh-app-token.sh ]; then
-    /usr/local/bin/gh-app-token.sh >/dev/null 2>&1 || true
-  fi
-}
-
-# Per-agent scoped token takes priority (Phase 4 — least-privilege).
+# Per-agent scoped token ONLY (Phase 4 — least-privilege).
+#
+# SECURITY (audit H3, CWE-522/732): this helper deliberately has NO fallback to
+# the shared full-privilege installation-token cache
+# (/var/run/hive-metrics/gh-app-token.cache). That cache holds the FULL
+# installation token; handing it to an agent's git push would silently escalate
+# the agent to full privilege and defeat per-agent tier scoping. When the
+# per-agent scoped token is absent we FAIL LOUD (exit 1 → git falls through to
+# its normal "no credential" error) so the operator repairs token delivery,
+# rather than quietly escalating. The scoped cache is minted and kept fresh by
+# the hive, so this helper only reads it — it never refreshes the shared cache.
 AGENT_TOKEN_FILE="${HIVE_AGENT_TOKEN_CACHE:-}"
-if [ -n "$AGENT_TOKEN_FILE" ] && [ -f "$AGENT_TOKEN_FILE" ]; then
-  TOKEN_FILE="$AGENT_TOKEN_FILE"
-else
-  if [ ! -f "$TOKEN_FILE" ]; then
-    refresh_token
-  fi
-
-  if [ -f "$TOKEN_FILE" ]; then
-    cache_age=$(( $(date +%s) - $(stat -c %Y "$TOKEN_FILE" 2>/dev/null || echo 0) ))
-    if [ "$cache_age" -gt "$CACHE_MAX_AGE_SECONDS" ]; then
-      refresh_token
-    fi
-  fi
+if [ -z "$AGENT_TOKEN_FILE" ] || [ ! -f "$AGENT_TOKEN_FILE" ]; then
+  echo "⛔ git push blocked: per-agent scoped GitHub token not available (${AGENT_TOKEN_FILE:-HIVE_AGENT_TOKEN_CACHE unset})." >&2
+  echo "⛔ Refusing to fall back to the shared full-privilege App token — that would defeat per-agent tier scoping (audit H3). Report this to the operator so token delivery is repaired." >&2
+  exit 1
 fi
+TOKEN_FILE="$AGENT_TOKEN_FILE"
 
 TOKEN=$(cat "$TOKEN_FILE" 2>/dev/null || true)
 if [ -z "$TOKEN" ]; then

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -728,14 +728,15 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 	if m.appAuth != nil && agent.UID > 0 {
 		tier := m.agentMode(agent).TokenTier()
 		if err := m.appAuth.WriteAgentToken(ctx, agent.Name, tier, agent.UID); err != nil {
-			// Be precise about the blast radius. A shared-cache fallback does
-			// exist (gh-wrapper.sh / git-credential-hive.sh fall back to
-			// /var/run/hive-metrics/gh-app-token.cache), but it is the FULL
-			// installation token, not this agent's tier-scoped one — so the
-			// failure silently escalates privilege rather than degrading
-			// gracefully, and it only works at all if that shared cache is
-			// present and group-readable. Say that, don't imply it's fine.
-			m.logger.Warn("per-agent scoped token NOT delivered — agent falls back to the shared FULL-privilege App token (tier scoping lost); if the shared cache is also missing, all GitHub writes for this agent will fail",
+			// Be precise about the blast radius. Since audit H3 the shared-cache
+			// fallback is GONE: gh-wrapper.sh and git-credential-hive.sh no
+			// longer fall back to /var/run/hive-metrics/gh-app-token.cache (the
+			// FULL installation token, now owner-only 0600). They FAIL LOUD when
+			// the per-agent scoped token is absent rather than silently
+			// escalating this agent to full privilege. So a delivery failure here
+			// means this agent's GitHub writes (gh + git push) will fail until
+			// token delivery is repaired — not a silent privilege escalation.
+			m.logger.Warn("per-agent scoped token NOT delivered — this agent's GitHub writes (gh + git push) will FAIL (no shared-cache fallback by design; see audit H3)",
 				"agent", agent.Name, "tier", tier, "error", err)
 		}
 		// Additionally issue an opt-in short-lived mint token (no-op when the mint

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -21,7 +21,14 @@ const (
 	tokenRefreshBuffer = 20 * time.Minute
 	TokenCachePath     = "/var/run/hive-metrics/gh-app-token.cache"
 	DocsTokenCachePath = "/var/run/hive-metrics/gh-app-token-docs.cache"
-	tokenCachePerms    = 0o640
+	// tokenCachePerms guards the SHARED, FULL-privilege installation-token cache
+	// (TokenCachePath / DocsTokenCachePath). It MUST stay owner-only (0600): the
+	// hive process runs as the "dev" user, and every agent UID is a member of the
+	// shared "node" group, so anything group-readable here would hand every agent
+	// the full-privilege installation token and defeat the per-agent scoped-token
+	// scheme entirely (audit H3, CWE-522/732). Per-agent scoped caches are a
+	// SEPARATE path and use agentTokenCachePerms — do not conflate the two.
+	tokenCachePerms = 0o600
 
 	// Per-agent scoped token caches. entrypoint.sh pre-creates each file as
 	// dev:hive-<agent> mode 0640 so the hive process (dev) can rewrite it in

--- a/v2/pkg/github/app_token_flap_test.go
+++ b/v2/pkg/github/app_token_flap_test.go
@@ -168,3 +168,49 @@ func TestToken_TransientThenRecoveryDoesNotFlap(t *testing.T) {
 		t.Errorf("recovery poll token = %q, want fresh-token", tok)
 	}
 }
+
+// TestToken_SharedCacheIsOwnerOnly locks in audit H3 (CWE-522/732): the SHARED,
+// full-privilege installation-token cache (TokenCachePath / DocsTokenCachePath,
+// written by Token() with tokenCachePerms) MUST be owner-only 0600. The hive
+// process runs as "dev" and every agent UID is in the shared "node" group, so
+// any group/other read bit here would leak the full installation token to every
+// agent and defeat per-agent tier scoping. The per-agent scoped caches are a
+// SEPARATE path (WriteAgentToken / agentTokenCachePerms) and are intentionally
+// 0640 dev:hive-<agent>; this test guards only the shared cache.
+func TestToken_SharedCacheIsOwnerOnly(t *testing.T) {
+	key, _ := generateTestKey(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token":"fresh-token","expires_at":"` +
+			time.Now().Add(time.Hour).Format(time.RFC3339) + `"}`))
+	}))
+	defer server.Close()
+
+	cachePath := t.TempDir() + "/gh-app-token.cache"
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         quietLogger(),
+		apiURL:         server.URL,
+		cachePath:      cachePath,
+		// No cached token → the first call mints and writes the cache.
+	}
+
+	if _, err := auth.Token(context.Background()); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+
+	info, err := os.Stat(cachePath)
+	if err != nil {
+		t.Fatalf("stat shared cache: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("shared full-token cache mode = %o, want 0600 (audit H3: must NOT be readable by the shared 'node' group)", got)
+	}
+	// Belt-and-suspenders: assert no group/other bits regardless of the exact mode.
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Errorf("shared full-token cache mode %o leaks read/write beyond the owner", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
## Security fix — H3 (High, CWE-522/732): full installation token readable by every agent

### The problem
The shared, **full-privilege** GitHub App installation-token cache at
`/var/run/hive-metrics/gh-app-token.cache` was written **0640 under the shared `node` group**,
which contains **every agent UID**. So any agent could `cat` the full installation token and act
with full App privileges — completely defeating the per-agent, tier-scoped token scheme
(`ScopedToken` / `WriteAgentToken`).

Two shell fallbacks made it strictly worse: when an agent's per-agent **scoped** token was missing,
they **silently escalated** to the shared full token instead of failing:
- `bin/gh-wrapper.sh` — fell back to the shared cache, and to the full-token-derived
  `HIVE_GITHUB_TOKEN` env var (which `entrypoint.sh` / `hive-config.sh` populate from that same
  full-token cache and `agent-launch.sh` exports into every agent's environment).
- `bin/git-credential-hive.sh` — fell back to the shared cache (with a refresh path) for `git push`.

The manager itself flagged this: "agent falls back to the shared FULL-privilege App token (tier
scoping lost)" (`v2/pkg/agent/manager.go`).

### The fix
1. **Shared cache is now owner-only `0600`** (`v2/pkg/github/app.go`): `tokenCachePerms` 0640 → 0600.
   This guards **only** the shared full-token cache (`TokenCachePath` / `DocsTokenCachePath`, written
   by `Token()`). The **per-agent scoped caches** are a *separate* path
   (`WriteAgentToken` / `agentTokenCachePerms`, `/var/run/hive-metrics/agent-tokens/gh-token-<agent>.cache`)
   and remain `0640 dev:hive-<agent>` as the audit requires — **untouched**.
2. **Fallbacks deleted — fail loud** (`bin/gh-wrapper.sh`, `bin/git-credential-hive.sh`): a missing
   per-agent scoped token now errors out (`exit 1`) with an explicit H3 message, instead of silently
   escalating to the full token. The normal path (use the per-agent scoped token when present) is
   preserved.
3. **Stale comment corrected** (`v2/pkg/agent/manager.go`): the delivery-failure warning no longer
   claims a shared-cache fallback exists — it now says GitHub writes will fail (by design).

### Verification
- **Go**: added `TestToken_SharedCacheIsOwnerOnly` asserting the shared cache is written `0600` with
  no group/other bits. `go test ./v2/pkg/github/ -run 'Token|Cache|App'` → **ok**. `go build` of
  `pkg/github` and `pkg/agent` → ok. Existing per-agent-cache tests (`0640` / degraded-path `0600`)
  still pass — scoped caches confirmed untouched.
- **Shell** (`git-credential-hive.sh`, manually verified in a shell):
  - scoped token **absent** → exits `1` with the H3 "refusing to fall back" message.
  - scoped token **present** → returns `username=x-access-token` / `password=<scoped token>`, exit `0`.
  - `bash -n` syntax-clean; `shellcheck` clean (no new findings; `gh-wrapper.sh` retains only
    pre-existing info/warning lint unrelated to this change).

Branch off `origin/v4`. **Do not merge** — for review.
