### PR TITLE
fix(proxy,hub): close direct-merge bypass (H1) and TOCTOU head-SHA hole (M4)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -5172,7 +5172,10 @@ func runEscalationSweep(
 	return escalated
 }
 
-const mergeEligiblePath = "/var/run/hive-metrics/merge-eligible.json"
+// mergeEligiblePath is a var (not a const) only so tests can point
+// mergeTargetEligible at a temp file; production never reassigns it.
+var mergeEligiblePath = "/var/run/hive-metrics/merge-eligible.json"
+
 const ciFailingPath = "/var/run/hive-metrics/ci-failing.json"
 
 // acmmHoldGatedMinLevel / acmmHoldGatedMaxLevel bracket the ACMM levels whose
@@ -5192,34 +5195,47 @@ const (
 const mergeableJSONUnknown = "unknown"
 
 // mergeTargetEligible reports whether (repo, number) currently appears in the
-// governor's merge-eligible.json. It reads the file FRESH on every call (never
-// caches) because eligibility is recomputed each governor cycle — a stale cache
-// could authorize a PR that has since fallen out of the list. On any read/parse
-// error it returns false (FAIL CLOSED): if we cannot prove the target is
-// eligible, we must not authorize the merge.
+// governor's merge-eligible.json AT the expected head SHA. It reads the file
+// FRESH on every call (never caches) because eligibility is recomputed each
+// governor cycle — a stale cache could authorize a PR that has since fallen out
+// of the list. On any read/parse error it returns false (FAIL CLOSED): if we
+// cannot prove the target is eligible, we must not authorize the merge.
+//
+// M4 (CWE-367, TOCTOU): the governor records the head SHA it observed when it
+// deemed the PR eligible (eligiblePR.HeadSHA). A branch can move between that
+// review and the merge relay firing, so matching (repo, number) alone would let
+// a moved head merge at a commit the governor never vetted. We therefore also
+// require the entry's stored head_sha to equal expectSHA. A mismatch — or a
+// stored SHA that is empty (governor could not observe it) — fails closed; the
+// relay's SHA pin then fails the merge cleanly if a stale request slips through.
 //
 // merge-eligible.json stores repos as "owner/repo"; a MergeRequest.Repo may be
 // bare ("repo") or fully qualified ("owner/repo"). We match on the bare repo
 // name (the segment after the last "/") plus the number, so both request forms
 // resolve to the same eligible entry without depending on the org prefix.
-func mergeTargetEligible(repo string, number int) bool {
+func mergeTargetEligible(repo string, number int, expectSHA string) bool {
 	data, err := os.ReadFile(mergeEligiblePath)
 	if err != nil {
 		return false // fail closed: no list ⇒ nothing is eligible
 	}
 	var payload struct {
 		Items []struct {
-			Number int    `json:"number"`
-			Repo   string `json:"repo"`
+			Number  int    `json:"number"`
+			Repo    string `json:"repo"`
+			HeadSHA string `json:"head_sha"`
 		} `json:"merge_eligible"`
 	}
 	if err := json.Unmarshal(data, &payload); err != nil {
 		return false // fail closed: unparseable list ⇒ deny
 	}
 	want := bareRepoName(repo)
+	wantSHA := strings.TrimSpace(expectSHA)
 	for _, it := range payload.Items {
 		if it.Number == number && bareRepoName(it.Repo) == want {
-			return true
+			// M4: bind authorization to the governor-observed head. An empty
+			// stored SHA cannot be proven to match, so it fails closed rather
+			// than authorizing an unpinned head.
+			return strings.TrimSpace(it.HeadSHA) != "" && strings.TrimSpace(it.HeadSHA) == wantSHA
 		}
 	}
 	return false
@@ -5255,12 +5271,14 @@ func bindMergeAuthz(inner func(agent string, fileUID int) error) github.MergeReq
 			return fmt.Errorf("merge target %s#%d has no expected head SHA — refusing to merge an unpinned head (TOCTOU guard)", repo, number)
 		}
 		// (b) Require the target to be in the governor's current merge-eligible
-		// list. This binds authorization to a PR the hive actually deemed
-		// landable this cycle, so an injected agent cannot request landing an
-		// arbitrary reachable PR (e.g. its own) whose required checks happen to
-		// pass. Read fresh + fail closed (see mergeTargetEligible).
-		if !mergeTargetEligible(repo, number) {
-			return fmt.Errorf("merge target %s#%d is not in the current merge-eligible list — only governor-approved PRs may be landed via the merge relay", repo, number)
+		// list AT the expected head SHA. This binds authorization to a PR the
+		// hive actually deemed landable this cycle, at the exact commit it
+		// reviewed, so an injected agent cannot request landing an arbitrary
+		// reachable PR (e.g. its own) whose required checks happen to pass, nor
+		// land an eligible PR at a head that moved after review (M4, CWE-367).
+		// Read fresh + fail closed (see mergeTargetEligible).
+		if !mergeTargetEligible(repo, number, expectSHA) {
+			return fmt.Errorf("merge target %s#%d is not in the current merge-eligible list at head %s — only governor-approved PRs may be landed via the merge relay, and only at the reviewed head SHA", repo, number, expectSHA)
 		}
 		return nil
 	}
@@ -5342,6 +5360,11 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 		// read from a list endpoint that never returns it.
 		Mergeable string `json:"mergeable"`
 		DCO       string `json:"dco"`
+		// HeadSHA is the governor-observed head commit at the moment eligibility
+		// was decided. mergeTargetEligible compares the relay's expected SHA
+		// against this value (M4, CWE-367): a branch that moved after review
+		// no longer matches and fails closed.
+		HeadSHA string `json:"head_sha,omitempty"`
 	}
 
 	type failingPR struct {
@@ -5423,6 +5446,7 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 			Labels:    pr.Labels,
 			Mergeable: mergeableJSON(pr.Mergeable),
 			DCO:       dco,
+			HeadSHA:   pr.HeadSHA,
 		})
 	}
 

--- a/v2/cmd/hive/merge_target_eligible_test.go
+++ b/v2/cmd/hive/merge_target_eligible_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeEligibleFixture points mergeEligiblePath at a temp file containing the
+// given merge-eligible.json body and restores the original path on cleanup.
+func writeEligibleFixture(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "merge-eligible.json")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+	orig := mergeEligiblePath
+	mergeEligiblePath = path
+	t.Cleanup(func() { mergeEligiblePath = orig })
+}
+
+// TestMergeTargetEligible_SHABinding covers M4 (CWE-367): the governor-observed
+// head_sha stored in merge-eligible.json must equal the relay's expected SHA.
+// An exact match authorizes; a moved head (mismatch), a missing stored SHA, or
+// a target absent from the list all fail closed.
+func TestMergeTargetEligible_SHABinding(t *testing.T) {
+	const goodSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const movedSHA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	body := `{
+		"generated_at": "2026-08-06T00:00:00Z",
+		"merge_eligible": [
+			{"number": 42, "repo": "kubestellar/hive", "head_sha": "` + goodSHA + `"},
+			{"number": 7, "repo": "kubestellar/console", "head_sha": ""}
+		]
+	}`
+	writeEligibleFixture(t, body)
+
+	tests := []struct {
+		name      string
+		repo      string
+		number    int
+		expectSHA string
+		want      bool
+	}{
+		{"exact match allows (fully-qualified repo)", "kubestellar/hive", 42, goodSHA, true},
+		{"exact match allows (bare repo)", "hive", 42, goodSHA, true},
+		{"moved head denied (SHA mismatch)", "kubestellar/hive", 42, movedSHA, false},
+		{"empty expected SHA denied", "kubestellar/hive", 42, "", false},
+		{"whitespace expected SHA denied", "kubestellar/hive", 42, "   ", false},
+		{"stored SHA empty denied", "kubestellar/console", 7, movedSHA, false},
+		{"number not in list denied", "kubestellar/hive", 999, goodSHA, false},
+		{"repo mismatch denied", "kubestellar/other", 42, goodSHA, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mergeTargetEligible(tt.repo, tt.number, tt.expectSHA); got != tt.want {
+				t.Errorf("mergeTargetEligible(%q, %d, %q) = %v, want %v",
+					tt.repo, tt.number, tt.expectSHA, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMergeTargetEligible_FailClosed confirms the fail-closed reads: a missing
+// or unparseable list authorizes nothing, even with a plausible expected SHA.
+func TestMergeTargetEligible_FailClosed(t *testing.T) {
+	const someSHA = "cccccccccccccccccccccccccccccccccccccccc"
+
+	t.Run("missing file denies", func(t *testing.T) {
+		orig := mergeEligiblePath
+		mergeEligiblePath = filepath.Join(t.TempDir(), "does-not-exist.json")
+		t.Cleanup(func() { mergeEligiblePath = orig })
+		if mergeTargetEligible("kubestellar/hive", 42, someSHA) {
+			t.Error("missing merge-eligible.json must deny (fail closed)")
+		}
+	})
+
+	t.Run("unparseable file denies", func(t *testing.T) {
+		writeEligibleFixture(t, "{ this is not json")
+		if mergeTargetEligible("kubestellar/hive", 42, someSHA) {
+			t.Error("unparseable merge-eligible.json must deny (fail closed)")
+		}
+	})
+}

--- a/v2/pkg/proxy/proxy_coverage_test.go
+++ b/v2/pkg/proxy/proxy_coverage_test.go
@@ -25,8 +25,12 @@ func TestAllowedByModeMerge(t *testing.T) {
 	if AllowedByMode(agent.ModeIssuesAndPRs, "PUT", "/repos/org/repo/pulls/123/merge") {
 		t.Error("ISSUES_AND_PRS should NOT allow merge")
 	}
-	if !AllowedByMode(agent.ModeIssuesPRsMerge, "PUT", "/repos/org/repo/pulls/123/merge") {
-		t.Error("ISSUES_PRS_MERGE should allow merge")
+	// H1 (CWE-863): direct PUT /pulls/{n}/merge is now a HARD DENY for EVERY
+	// mode, including merge mode — agents must route through the bound hive-merge
+	// relay. Merge mode still authorizes the merge via the relay's authorizer,
+	// not via a direct proxy PUT.
+	if AllowedByMode(agent.ModeIssuesPRsMerge, "PUT", "/repos/org/repo/pulls/123/merge") {
+		t.Error("ISSUES_PRS_MERGE must NOT allow a direct proxy merge (use hive-merge relay)")
 	}
 }
 
@@ -45,6 +49,20 @@ func TestAllowedByModePROperations(t *testing.T) {
 	}
 	if msg, denied := DeniedMessage("POST", "/repos/org/repo/pulls"); !denied || !strings.Contains(msg, "hive-open-pr") {
 		t.Errorf("POST /pulls should carry a hive-open-pr deny message; got denied=%v msg=%q", denied, msg)
+	}
+	// H1 (CWE-863): direct PR merge (PUT /pulls/{n}/merge) is a HARD DENY for
+	// every mode — agents route through the bound hive-merge relay, not
+	// `gh api -X PUT .../merge`. Even merge mode cannot call it directly.
+	if AllowedByMode(agent.ModeIssuesPRsMerge, "PUT", "/repos/org/repo/pulls/42/merge") {
+		t.Error("PUT /pulls/{n}/merge must be denied even for merge mode (use hive-merge relay)")
+	}
+	if msg, denied := DeniedMessage("PUT", "/repos/org/repo/pulls/42/merge"); !denied || !strings.Contains(msg, "hive-merge") {
+		t.Errorf("PUT /pulls/{n}/merge should carry a hive-merge deny message; got denied=%v msg=%q", denied, msg)
+	}
+	// The relay's own branch-sync (PUT /pulls/{n}/update-branch) is NOT denied —
+	// only the merge itself is hard-denied.
+	if !AllowedByMode(agent.ModeIssuesPRsMerge, "PUT", "/repos/org/repo/pulls/42/update-branch") {
+		t.Error("PUT /pulls/{n}/update-branch should still be allowed at merge mode")
 	}
 	if !AllowedByMode(agent.ModeIssuesAndPRs, "PATCH", "/repos/org/repo/pulls/42") {
 		t.Error("ISSUES_AND_PRS should allow patching PRs")

--- a/v2/pkg/proxy/proxy_extra_test.go
+++ b/v2/pkg/proxy/proxy_extra_test.go
@@ -268,9 +268,10 @@ func TestAllowedByModeComprehensive(t *testing.T) {
 		{agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/issues", true},
 		{agent.ModeIssuesAndPRs, "PUT", "/repos/org/repo/pulls/1/merge", false},
 
-		// IssuesPRsMerge can merge + create issues, but still cannot POST /pulls
-		// directly (direct PR creation is denied for every mode).
-		{agent.ModeIssuesPRsMerge, "PUT", "/repos/org/repo/pulls/1/merge", true},
+		// IssuesPRsMerge can create issues, but cannot merge directly (PUT merge
+		// is a hard deny for every mode — H1, use the hive-merge relay) nor POST
+		// /pulls directly (direct PR creation is denied for every mode).
+		{agent.ModeIssuesPRsMerge, "PUT", "/repos/org/repo/pulls/1/merge", false},
 		{agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/pulls", false},
 		{agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/issues", true},
 	}

--- a/v2/pkg/proxy/proxy_test.go
+++ b/v2/pkg/proxy/proxy_test.go
@@ -51,7 +51,9 @@ func TestAllowedByModeExtended(t *testing.T) {
 		{"issues-and-prs can push", agent.ModeIssuesAndPRs, "POST", "/repos/org/repo.git/git-receive-pack", true},
 		{"issues-and-prs cannot merge", agent.ModeIssuesAndPRs, "PUT", "/repos/org/repo/pulls/1/merge", false},
 
-		{"merge mode can merge", agent.ModeIssuesPRsMerge, "PUT", "/repos/org/repo/pulls/1/merge", true},
+		// H1 (CWE-863): merge mode cannot merge directly either — PUT /pulls/{n}/merge
+		// is a hard deny for every mode; agents route through the hive-merge relay.
+		{"merge mode cannot merge directly (use hive-merge relay)", agent.ModeIssuesPRsMerge, "PUT", "/repos/org/repo/pulls/1/merge", false},
 		{"merge mode cannot create PRs directly (use hive-open-pr)", agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/pulls", false},
 
 		{"git upload-pack always allowed", agent.ModeAdvisory, "POST", "/repos/org/repo.git/git-upload-pack", true},

--- a/v2/pkg/proxy/rules.go
+++ b/v2/pkg/proxy/rules.go
@@ -93,9 +93,12 @@ var rules = []ProxyRule{
 	{regexp.MustCompile(`^/login/device/code$`), "POST", agent.ModeAdvisory},
 	{regexp.MustCompile(`^/login/oauth/access_token$`), "POST", agent.ModeAdvisory},
 
-	// ── Merge — ISSUES_PRS_MERGE only ──
-	// Must come before the generic pulls PATCH/PUT rules.
-	{regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/\d+/merge$`), "PUT", agent.ModeIssuesPRsMerge},
+	// ── Merge — HARD DENY for every mode (see denyRules) ──
+	// NOTE: direct merge (PUT /pulls/{n}/merge) is NOT here — it is a HARD DENY
+	// for every mode, handled by denyRules below, so agents route through the
+	// bound `hive-merge` relay (SHA-pinned + merge-eligible binding) instead of
+	// `gh api -X PUT .../merge`. This mirrors the GraphQL mergePullRequest deny
+	// (GraphQLAllowed) so neither REST nor GraphQL is an agent-reachable bypass.
 
 	// Updating a PR branch from its base is part of landing a PR: an
 	// auto-merging agent hits it whenever the base has moved on. Without a rule
@@ -145,19 +148,39 @@ type denyRule struct {
 	Msg         string // agent-facing directive surfaced in the 403 body
 }
 
-// denyRules are checked BEFORE the mode rules. The canonical (and currently only)
-// case is direct PR creation: a POST /repos/*/pulls — whether from `gh pr create`
-// or the GitHub MCP create_pull_request/create_pull_request_with_copilot tool —
-// authors the PR as the Copilot login user, not the App bot. Blocking it here
-// forces agents to use `hive-open-pr`, which the hive fulfills with the App token
-// so the PR is authored by the App bot. This closes the MCP path the gh-wrapper
-// redirect cannot see. The hive's OWN CreatePR call does not traverse this agent
-// proxy, so it is unaffected.
+// denyRules are checked BEFORE the mode rules. Two cases are hard-denied for
+// EVERY agent mode:
+//
+//  1. Direct PR creation: a POST /repos/*/pulls — whether from `gh pr create`
+//     or the GitHub MCP create_pull_request/create_pull_request_with_copilot
+//     tool — authors the PR as the Copilot login user, not the App bot.
+//     Blocking it here forces agents to use `hive-open-pr`, which the hive
+//     fulfills with the App token so the PR is authored by the App bot. This
+//     closes the MCP path the gh-wrapper redirect cannot see.
+//
+//  2. Direct PR merge: a PUT /repos/*/pulls/{n}/merge (H1, CWE-863). Permitting
+//     this at ModeIssuesPRsMerge on a UID-derived mode check ALONE let an
+//     injected merge-mode agent `gh api -X PUT .../merge` any reachable PR,
+//     bypassing the bound merge relay's fail-closed SHA pin + merge-eligible
+//     binding (see bindMergeAuthz). Hard-denying it forces ALL agent-initiated
+//     merges through `hive-merge`, which the hive fulfills as the App over REST
+//     with those bindings enforced. This mirrors the GraphQL mergePullRequest
+//     deny (GraphQLAllowed treats it as a mutation), so neither REST nor GraphQL
+//     is an agent-reachable merge bypass.
+//
+// In BOTH cases the hive's OWN call (CreatePR / MergePR) does NOT traverse this
+// agent proxy — it originates from the hive process (owner UID), which the
+// forced-egress iptables redirect exempts — so the relay is unaffected.
 var denyRules = []denyRule{
 	{
 		PathPattern: regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls$`),
 		Method:      "POST",
 		Msg:         "direct PR creation is disabled for agents — use `hive-open-pr --repo <owner/repo> --head <branch> --title <t> --body <b>` so the hive opens the PR as the App bot (never the login user). Do NOT use `gh pr create` or the GitHub MCP create_pull_request/create_pull_request_with_copilot.",
+	},
+	{
+		PathPattern: regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/\d+/merge$`),
+		Method:      "PUT",
+		Msg:         "direct PR merge is disabled for agents — use `hive-merge --repo <owner/repo> --number <n> --expect-sha <head-sha>` so the hive merges as the App bot with the SHA-pin + merge-eligible binding enforced. Do NOT use `gh api -X PUT .../merge`, `gh pr merge`, or the GitHub MCP merge_pull_request.",
 	},
 }
 

--- a/v2/pkg/proxy/rules_test.go
+++ b/v2/pkg/proxy/rules_test.go
@@ -55,7 +55,11 @@ func TestAllowedByMode(t *testing.T) {
 		{"merge allows POST issue", agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/issues", true},
 		// Even merge mode cannot POST /pulls directly — hive-open-pr is the only path.
 		{"merge blocks direct POST pull", agent.ModeIssuesPRsMerge, "POST", "/repos/org/repo/pulls", false},
-		{"merge allows PUT merge", agent.ModeIssuesPRsMerge, "PUT", "/repos/org/repo/pulls/42/merge", true},
+		// H1 (CWE-863): even merge mode cannot PUT /pulls/{n}/merge directly — it
+		// is a hard deny for every mode, so agents route through the bound
+		// hive-merge relay (SHA-pin + merge-eligible binding) instead.
+		{"merge blocks direct PUT merge", agent.ModeIssuesPRsMerge, "PUT", "/repos/org/repo/pulls/42/merge", false},
+		{"merge allows PUT update-branch", agent.ModeIssuesPRsMerge, "PUT", "/repos/org/repo/pulls/42/update-branch", true},
 		{"merge allows git push", agent.ModeIssuesPRsMerge, "POST", "/org/repo.git/git-receive-pack", true},
 
 		// ── Default deny: unknown operations ──


### PR DESCRIPTION
## Security fix: H1 (CWE-863) + M4 (CWE-367) — merge-path binding

Closes two related residual holes in the agent merge path. Both are about ensuring an injected agent cannot land a PR outside the bound, SHA-pinned, merge-eligible-checked `hive-merge` relay.

### H1 (CWE-863) — direct-merge bypass

`PUT /repos/{o}/{r}/pulls/{n}/merge` was in the **mode-gated** rules table at `ModeIssuesPRsMerge` — a UID-derived mode check **only**, with no expected-SHA and no merge-eligible binding. An injected L6/merge-mode agent could `gh api -X PUT .../merge` **any reachable PR** (e.g. its own), bypassing the bound relay entirely. The relay path (`bindMergeAuthz`) was already fixed (fail-closed SHA pin + eligibility), but this direct REST PUT was the leftover door. The GraphQL `mergePullRequest` mutation is already hard-denied for exactly this reason — the REST PUT should be treated the same.

**Fix:** moved the merge PUT from the allowed `rules` table to the proxy **hard-deny table** (`denyRules`), mirroring the existing `POST /pulls` deny and the GraphQL deny. All agent-initiated merges now route through `hive-merge`. The deny message points agents at `hive-merge --repo … --number … --expect-sha …`.

**Relay confirmed unaffected.** Traced how `hive-merge` actually merges:
- `bin/hive-merge.sh` drops a request file that the hive's `MergeRequestWatcher` consumes.
- The watcher calls `Client.MergePR` (`v2/pkg/github/pullrequest.go`), which merges as the **App over REST from the hive process** using the hive's own go-github client.
- That client runs as the **owner UID**, which the forced-egress iptables redirect (owner-UID RETURN + SO_MARK, see `github_proxy.go` / `somark_linux.go`) **exempts** — so the hive's own upstream dials never enter `proxyHTTP` and are never subject to `AllowedByMode`/`DeniedMessage`.

This is the identical arrangement that already lets the hive's own `CreatePR` work while `POST /pulls` is hard-denied for agents. So hard-denying the agent-proxy PUT does **not** break the relay.

### M4 (CWE-367) — TOCTOU head-SHA hole

`mergeTargetEligible` matched only `(repo, number)` against `merge-eligible.json`. A branch that moved **after** eligibility review could still be merged at the moved head. The governor already records `head_sha` for failing PRs, but the **eligible** entries did not carry it and it was never compared.

**Fix (two parts):**
1. `writeMergeEligible` now stores `head_sha` on each **eligible** entry (`eligiblePR.HeadSHA` = `pr.HeadSHA`) — previously only the failing bucket stored it.
2. `mergeTargetEligible(repo, number, expectSHA)` now requires the stored `head_sha` to equal the relay's `expectSHA`. A moved head (mismatch) or an empty stored SHA **fails closed**. Caller in `bindMergeAuthz` passes `expectSHA` through.

`mergeEligiblePath` changed from `const` to `var` solely so tests can point it at a temp file; production never reassigns it.

### Tests

- **Proxy** (`pkg/proxy`): `PUT /pulls/{n}/merge` is DENIED at **every** mode including merge mode, and `DeniedMessage` carries a `hive-merge` directive; `PUT /pulls/{n}/update-branch` remains allowed (only the merge itself is denied). Flipped the three prior assertions that expected merge mode to allow the direct PUT.
- **Hub** (`cmd/hive`, new `merge_target_eligible_test.go`): exact SHA match allows (fully-qualified and bare repo); mismatch / empty expected SHA / empty stored SHA / target-not-in-list all deny; missing and unparseable list fail closed.

Ran `go test ./pkg/proxy/` (full package) and `go test ./cmd/hive/ -run MergeTargetEligible` — both green. `go build` on both packages clean.

### Mooots H5

This **moots H5** (wrapper `gh pr merge --repo` gate bypass): with the direct REST PUT hard-denied at the proxy, there is no agent-reachable path to a merge **except** the bound relay — the wrapper-level gate is no longer the last line of defense for that path.
