### PR TITLE
fix(sec): C5 — close anonymous contributor-authz bypass (CWE-862)

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -5175,21 +5175,24 @@ func (s *Server) handleContributeQueueHold(w http.ResponseWriter, r *http.Reques
 // contributor mutation endpoints (trust/revoke/delete) that the Management &
 // Operations tab surfaces as admin controls.
 //
-// These handlers live under the /api/contributors/... path. That path shares
-// the "/api/contribute" prefix that roleEnforcement (server.go) intentionally
-// EXEMPTS from its blanket read-only block — that exemption exists so a signed-in
-// contributor can still register/onboard themselves. As a result the middleware
-// does NOT stop a "read" viewer from calling these mutation endpoints, so each
-// mutation handler must enforce the boundary itself. This mirrors the in-handler
-// role check used by handleConfigDownload / handleSelfUpgrade: read X-Hive-Role,
-// treat an absent header as owner (local/dev, no hub nginx), and reject "read".
-// UI hiding on the ops tab is UX; this is the security boundary.
+// These handlers live under the /api/contributors/... path. Each mutation handler
+// must enforce the write boundary itself, because these routes are otherwise only
+// as protected as the surrounding auth layer — and on a direct OpenShift Route or
+// in-cluster (no hub nginx, no NetworkPolicy) there is NO auth layer in front.
+//
+// SECURITY (C5): FAIL CLOSED. An absent/empty X-Hive-Role is treated as NOT
+// authorized (deny), not as owner. The previous code defaulted an absent header to
+// "owner" for "local/dev, no hub nginx" convenience — but that same absence is
+// exactly what an anonymous caller hitting the pod directly (bypassing the hub
+// nginx that would otherwise inject the header) presents. Combined with the
+// prefix-match bug that exempted /api/contributors/... from authentication, an
+// unauthenticated caller could promote/revoke/delete/requeue contributors. Only an
+// explicit owner/read-write role may mutate; everything else (absent, "read", or
+// any unrecognized value) is rejected. UI hiding on the ops tab is UX; this is the
+// security boundary.
 func (s *Server) requireContributorWrite(w http.ResponseWriter, r *http.Request) bool {
 	role := r.Header.Get("X-Hive-Role")
-	if role == "" {
-		role = "owner"
-	}
-	if role == "read" {
+	if role != config.RoleOwner && role != config.RoleReadWrite {
 		jsonError(w, "your permissions on this hive are read-only, so changes are not allowed. Contact the owner of this hive to ask for write permissions.", http.StatusForbidden)
 		return false
 	}

--- a/v2/pkg/dashboard/api_contribute_admin_controls_test.go
+++ b/v2/pkg/dashboard/api_contribute_admin_controls_test.go
@@ -190,9 +190,12 @@ func TestContributorWrite_ReadViewerForbidden(t *testing.T) {
 }
 
 // TestContributorWrite_OwnerAndRWAllowed proves owner and read-write pass the gate
-// (they are not blocked), and that an absent header falls back to owner (local/dev).
+// (they are not blocked). SECURITY (C5): an absent/empty role is NO LONGER allowed
+// here — the gate now fails closed on a missing role (see
+// TestContributorWrite_MissingRoleForbidden), because an absent header is exactly
+// what an unauthenticated caller reaching the pod directly presents.
 func TestContributorWrite_OwnerAndRWAllowed(t *testing.T) {
-	for _, role := range []string{"owner", "read-write", ""} {
+	for _, role := range []string{"owner", "read-write"} {
 		t.Run("trust_"+role, func(t *testing.T) {
 			setupContributeEnv(t)
 			if err := saveContributorProfile(&ContributorProfile{
@@ -218,6 +221,109 @@ func TestContributorWrite_OwnerAndRWAllowed(t *testing.T) {
 				t.Errorf("role %q: tier not promoted: %+v", role, p)
 			}
 		})
+	}
+}
+
+// TestContributorWrite_MissingRoleForbidden pins the C5 fail-closed fix: a request
+// with NO X-Hive-Role header (exactly what an unauthenticated caller reaching the
+// pod directly presents) must be REJECTED with 403 on every contributor mutation
+// endpoint, and must not mutate anything. Before the fix an absent header defaulted
+// to "owner", so anonymous callers could promote/revoke/delete/requeue contributors.
+func TestContributorWrite_MissingRoleForbidden(t *testing.T) {
+	for _, tc := range contributorWriteCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			setupContributeEnv(t)
+			if err := saveContributorProfile(&ContributorProfile{
+				GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "newcomer",
+			}); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			s := NewServer(0, slog.Default())
+			s.registerContributeRoutes()
+
+			var reqBody *strings.Reader
+			if tc.body != "" {
+				reqBody = strings.NewReader(tc.body)
+			} else {
+				reqBody = strings.NewReader("")
+			}
+			req := httptest.NewRequest(tc.method, tc.target, reqBody)
+			// Deliberately set NO X-Hive-Role header.
+			w := httptest.NewRecorder()
+			tc.invoke(s, w, req)
+
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("missing-role request got %d, want 403 (body: %s)", w.Code, w.Body.String())
+			}
+			if p := findContributor("c-alice"); p == nil || p.TrustTier != "newcomer" {
+				t.Errorf("missing-role request mutated the profile: %+v", p)
+			}
+		})
+	}
+}
+
+// TestContributorAdminRoutes_AnonymousDenied_ContributeFlowReachable is the
+// end-to-end C5 regression, driven through the full Handler() middleware chain on a
+// spoke that HAS an auth boundary (a shared authToken, i.e. a hosted/direct-route
+// hive — not local/dev). It proves:
+//
+//  1. The /api/contributors/{id}/... admin mutation routes are NOT public: an
+//     anonymous caller is stopped by authenticate() with 401. Before the fix the
+//     bare HasPrefix("/api/contribute") in isPublicPath also matched
+//     "/api/contributors/...", exempting these routes from auth entirely.
+//  2. The real contribute-flow public routes stay reachable (NOT 401): the WS
+//     upgrade path and POST /api/contribute/register still transit auth as public.
+func TestContributorAdminRoutes_AnonymousDenied_ContributeFlowReachable(t *testing.T) {
+	setupContributeEnv(t)
+	if err := saveContributorProfile(&ContributorProfile{
+		GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "newcomer",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	s := NewServer(0, slog.Default())
+	s.authToken = "shared-secret-token" // gives the spoke a real auth boundary
+	s.registerContributeRoutes()
+	h := s.Handler()
+
+	// 1. Anonymous (no auth, no role) mutation attempts must be blocked by auth.
+	adminMutations := []struct {
+		name, method, path, body string
+	}{
+		{"trust", http.MethodPut, "/api/contributors/alice/trust", `{"tier":"trusted"}`},
+		{"revoke", http.MethodPost, "/api/contributors/alice/revoke", ``},
+		{"requeue", http.MethodPost, "/api/contributors/alice/requeue", ``},
+		{"delete", http.MethodDelete, "/api/contributors/alice", ``},
+	}
+	for _, m := range adminMutations {
+		t.Run("anon_"+m.name, func(t *testing.T) {
+			req := httptest.NewRequest(m.method, m.path, strings.NewReader(m.body))
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			// Must be denied — 401 (blocked at authenticate) or 403 (in-handler gate).
+			if w.Code != http.StatusUnauthorized && w.Code != http.StatusForbidden {
+				t.Fatalf("anonymous %s %s got %d, want 401/403 (body: %s)", m.method, m.path, w.Code, w.Body.String())
+			}
+		})
+	}
+	// The anonymous attempts must not have mutated the profile.
+	if p := findContributor("c-alice"); p == nil || p.TrustTier != "newcomer" {
+		t.Errorf("anonymous admin calls mutated the profile: %+v", p)
+	}
+
+	// 2. The genuine public contribute-flow routes must NOT be blocked by auth.
+	//    A 401 here would mean the boundary fix over-narrowed and broke onboarding.
+	regReq := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(`{}`))
+	regW := httptest.NewRecorder()
+	h.ServeHTTP(regW, regReq)
+	if regW.Code == http.StatusUnauthorized {
+		t.Errorf("public POST /api/contribute/register got 401 — the boundary fix broke onboarding")
+	}
+
+	wsReq := httptest.NewRequest(http.MethodGet, "/api/contribute/ws", nil)
+	wsW := httptest.NewRecorder()
+	h.ServeHTTP(wsW, wsReq)
+	if wsW.Code == http.StatusUnauthorized {
+		t.Errorf("public GET /api/contribute/ws got 401 — the WS upgrade path must stay public")
 	}
 }
 

--- a/v2/pkg/dashboard/api_contribute_coverage_test.go
+++ b/v2/pkg/dashboard/api_contribute_coverage_test.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -17,6 +18,45 @@ func covContribServer(t *testing.T) *Server {
 	s := NewServer(0, logger)
 	s.RegisterAPI(testDeps(t))
 	return s
+}
+
+// doPutOwner / doPostOwner / doDeleteOwner mirror doPut/doPost/doDelete but attach
+// an owner X-Hive-Role. The contributor mutation endpoints fail closed on a missing
+// role (C5 fix in requireContributorWrite), so a test exercising their success/
+// 404/400 logic must present an authorized role.
+func doPutOwner(s *Server, path string, body interface{}) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	var b bytes.Buffer
+	json.NewEncoder(&b).Encode(body)
+	req := httptest.NewRequest(http.MethodPut, path, &b)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-Role", "owner")
+	s.mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func doPostOwner(s *Server, path string, body interface{}) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	var b bytes.Buffer
+	json.NewEncoder(&b).Encode(body)
+	req := httptest.NewRequest(http.MethodPost, path, &b)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-Role", "owner")
+	s.mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func doDeleteOwner(s *Server, path string, body interface{}) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	var b bytes.Buffer
+	if body != nil {
+		json.NewEncoder(&b).Encode(body)
+	}
+	req := httptest.NewRequest(http.MethodDelete, path, &b)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-Role", "owner")
+	s.mux.ServeHTTP(rec, req)
+	return rec
 }
 
 // seedContributor writes a profile JSON into a temp contributors dir and points
@@ -114,19 +154,19 @@ func TestCovH_ContributorTrust(t *testing.T) {
 	s := covContribServer(t)
 
 	// Unknown contributor → 404.
-	rec := doPut(s, "/api/contributors/nope/trust", map[string]string{"tier": "trusted"})
+	rec := doPutOwner(s, "/api/contributors/nope/trust", map[string]string{"tier": "trusted"})
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("trust unknown: expected 404, got %d", rec.Code)
 	}
 
 	// Invalid tier → 400.
-	rec = doPut(s, "/api/contributors/c-carol/trust", map[string]string{"tier": "bogus"})
+	rec = doPutOwner(s, "/api/contributors/c-carol/trust", map[string]string{"tier": "bogus"})
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("trust invalid tier: expected 400, got %d", rec.Code)
 	}
 
 	// Valid tier → 200.
-	rec = doPut(s, "/api/contributors/c-carol/trust", map[string]string{"tier": "trusted"})
+	rec = doPutOwner(s, "/api/contributors/c-carol/trust", map[string]string{"tier": "trusted"})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("trust valid: expected 200, got %d", rec.Code)
 	}
@@ -137,18 +177,18 @@ func TestCovH_ContributorRevokeAndDelete(t *testing.T) {
 	s := covContribServer(t)
 
 	// Revoke unknown → 404, known → 200.
-	if rec := doPost(s, "/api/contributors/nope/revoke", nil); rec.Code != http.StatusNotFound {
+	if rec := doPostOwner(s, "/api/contributors/nope/revoke", nil); rec.Code != http.StatusNotFound {
 		t.Fatalf("revoke unknown: expected 404, got %d", rec.Code)
 	}
-	if rec := doPost(s, "/api/contributors/c-dave/revoke", nil); rec.Code != http.StatusOK {
+	if rec := doPostOwner(s, "/api/contributors/c-dave/revoke", nil); rec.Code != http.StatusOK {
 		t.Fatalf("revoke known: expected 200, got %d", rec.Code)
 	}
 
 	// Delete unknown → 404, known → 200.
-	if rec := doDelete(s, "/api/contributors/nope", nil); rec.Code != http.StatusNotFound {
+	if rec := doDeleteOwner(s, "/api/contributors/nope", nil); rec.Code != http.StatusNotFound {
 		t.Fatalf("delete unknown: expected 404, got %d", rec.Code)
 	}
-	if rec := doDelete(s, "/api/contributors/c-dave", nil); rec.Code != http.StatusOK {
+	if rec := doDeleteOwner(s, "/api/contributors/c-dave", nil); rec.Code != http.StatusOK {
 		t.Fatalf("delete known: expected 200, got %d", rec.Code)
 	}
 }

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -846,10 +846,12 @@ func TestContributorTrust(t *testing.T) {
 
 	cid, _ := registerTestUser(t, s, "trust-test")
 
-	// Valid tier change
+	// Valid tier change (owner role required — mutation endpoint fails closed on
+	// a missing role, see requireContributorWrite / C5 fix).
 	body := `{"tier":"contributor"}`
 	req := httptest.NewRequest(http.MethodPut, "/api/contributors/"+cid+"/trust", bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-Role", "owner")
 	w := httptest.NewRecorder()
 	s.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -860,6 +862,7 @@ func TestContributorTrust(t *testing.T) {
 	body2 := `{"tier":"superadmin"}`
 	req2 := httptest.NewRequest(http.MethodPut, "/api/contributors/"+cid+"/trust", bytes.NewBufferString(body2))
 	req2.Header.Set("Content-Type", "application/json")
+	req2.Header.Set("X-Hive-Role", "owner")
 	w2 := httptest.NewRecorder()
 	s.mux.ServeHTTP(w2, req2)
 	if w2.Code != http.StatusBadRequest {
@@ -875,6 +878,7 @@ func TestContributorDelete(t *testing.T) {
 	cid, _ := registerTestUser(t, s, "delete-test")
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/contributors/"+cid, nil)
+	req.Header.Set("X-Hive-Role", "owner")
 	w := httptest.NewRecorder()
 	s.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -898,6 +902,7 @@ func TestContributorRevoke(t *testing.T) {
 	cid, _ := registerTestUser(t, s, "revoke-test")
 
 	req := httptest.NewRequest(http.MethodPost, "/api/contributors/"+cid+"/revoke", nil)
+	req.Header.Set("X-Hive-Role", "owner")
 	w := httptest.NewRecorder()
 	s.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {

--- a/v2/pkg/dashboard/contribute_queue_hold_test.go
+++ b/v2/pkg/dashboard/contribute_queue_hold_test.go
@@ -126,10 +126,11 @@ func TestQueueHoldEndpointPersistsRoundTrip(t *testing.T) {
 	// Pre-seed with a malformed/duplicate straggler to prove sanitisation.
 	deps.Config.Hub.ContributeQueueHold = []string{"not a key", "acme/repo#9", "acme/repo#9"}
 
-	// Hold acme/repo#4.
+	// Hold acme/repo#4 (owner role — mutation gate fails closed on missing role, C5).
 	req := httptest.NewRequest(http.MethodPost, "/api/contribute/queue/hold",
 		strings.NewReader(`{"key":"acme/repo#4","held":true}`))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-Role", "owner")
 	w := httptest.NewRecorder()
 	s.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -151,6 +152,7 @@ func TestQueueHoldEndpointPersistsRoundTrip(t *testing.T) {
 	req = httptest.NewRequest(http.MethodPost, "/api/contribute/queue/hold",
 		strings.NewReader(`{"key":"acme/repo#4","held":false}`))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-Role", "owner")
 	w = httptest.NewRecorder()
 	s.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -185,7 +187,7 @@ func TestQueueHoldEndpointRoleGate(t *testing.T) {
 		{"read", http.StatusForbidden},
 		{"owner", http.StatusOK},
 		{"read-write", http.StatusOK},
-		{"", http.StatusOK}, // absent header = local/dev owner
+		{"", http.StatusForbidden}, // C5: absent header fails closed (NOT owner)
 	}
 	for _, tc := range cases {
 		t.Run("role_"+tc.role, func(t *testing.T) {
@@ -213,6 +215,7 @@ func TestQueueHoldEndpointRejectsBadKey(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/contribute/queue/hold",
 		strings.NewReader(`{"key":"not a canonical key","held":true}`))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-Role", "owner") // pass the write gate to reach key validation (C5)
 	w := httptest.NewRecorder()
 	s.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusBadRequest {

--- a/v2/pkg/dashboard/contribute_queue_order_test.go
+++ b/v2/pkg/dashboard/contribute_queue_order_test.go
@@ -162,7 +162,7 @@ func TestQueueOrderEndpointRoleGate(t *testing.T) {
 		{"read", http.StatusForbidden},
 		{"owner", http.StatusOK},
 		{"read-write", http.StatusOK},
-		{"", http.StatusOK}, // absent header = local/dev owner
+		{"", http.StatusForbidden}, // C5: absent header fails closed (NOT owner)
 	}
 	for _, tc := range cases {
 		t.Run("role_"+tc.role, func(t *testing.T) {
@@ -191,6 +191,7 @@ func TestQueueOrderEndpointPersistsAndSanitizes(t *testing.T) {
 	body := `{"order":["acme/repo#4"," acme/repo#2 ","not a key","acme/repo#4","","acme/repo#7"]}`
 	req := httptest.NewRequest(http.MethodPut, "/api/contribute/queue/order", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-Role", "owner") // mutation gate fails closed on missing role (C5)
 	w := httptest.NewRecorder()
 	s.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {

--- a/v2/pkg/dashboard/contribute_ws_test.go
+++ b/v2/pkg/dashboard/contribute_ws_test.go
@@ -152,8 +152,10 @@ func TestWSAuthRevoked(t *testing.T) {
 	var reg map[string]string
 	json.Unmarshal(w.Body.Bytes(), &reg)
 
-	// Revoke
+	// Revoke (owner role required — the mutation endpoint fails closed on a
+	// missing role, see requireContributorWrite / C5 fix).
 	revokeReq := httptest.NewRequest(http.MethodPost, "/api/contributors/"+reg["contributor_id"]+"/revoke", nil)
+	revokeReq.Header.Set("X-Hive-Role", "owner")
 	revokeW := httptest.NewRecorder()
 	s.mux.ServeHTTP(revokeW, revokeReq)
 

--- a/v2/pkg/dashboard/coverage_boost4_test.go
+++ b/v2/pkg/dashboard/coverage_boost4_test.go
@@ -695,6 +695,7 @@ func TestHandleContributorTrust_UserNotFound(t *testing.T) {
 	body := `{"username":"nonexistent","tier":"contributor"}`
 	req := httptest.NewRequest("PUT", "/api/contribute/trust", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-Role", "owner") // mutation gate fails closed on a missing role (C5)
 	w := httptest.NewRecorder()
 	srv.handleContributorTrust(w, req)
 

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -1007,7 +1007,16 @@ func isPublicPath(path string) bool {
 		return true
 	case path == "/contribute" || strings.HasPrefix(path, "/contribute/"):
 		return true
-	case strings.HasPrefix(path, "/api/contribute"):
+	case path == "/api/contribute" || strings.HasPrefix(path, "/api/contribute/"):
+		// SECURITY (C5): match ONLY the contribute flow (/api/contribute and its
+		// subtree /api/contribute/...), NOT the sibling admin routes under
+		// /api/contributors/... (trust/revoke/requeue/delete). A bare HasPrefix
+		// of "/api/contribute" also matched "/api/contributors/..." because the
+		// letters after the prefix ("rs/...") don't start with a boundary — so
+		// those mutation routes were exempted from authenticate entirely and were
+		// reachable anonymously on OpenShift Routes / in-cluster (no auth proxy).
+		// The trailing-slash boundary excludes /api/contributors while keeping the
+		// real public routes (register, the WS upgrade, status, etc.) public.
 		return true
 	case path == "/leaderboard" || strings.HasPrefix(path, "/leaderboard/"):
 		return true
@@ -1159,7 +1168,14 @@ func (s *Server) roleEnforcement(next http.Handler) http.Handler {
 		w.Header().Set("X-Hive-Role", role)
 		w.Header().Set("X-Hive-User", r.Header.Get("X-Hive-User"))
 		if role == "read" && r.Method != http.MethodGet && r.Method != http.MethodHead && r.Method != http.MethodOptions {
-			if !strings.HasPrefix(r.URL.Path, "/api/contribute") && r.URL.Path != "/api/gh-user-auth/status" {
+			// SECURITY (C5): use the same trailing-slash boundary as isPublicPath so
+			// the read-only write-gate exemption covers ONLY the contribute flow
+			// (/api/contribute[/...]) and NOT the /api/contributors/... admin
+			// mutation routes. A bare HasPrefix("/api/contribute") also matched
+			// "/api/contributors/...", letting a "read" viewer promote/revoke/delete
+			// contributors past this gate.
+			isContributeFlow := r.URL.Path == "/api/contribute" || strings.HasPrefix(r.URL.Path, "/api/contribute/")
+			if !isContributeFlow && r.URL.Path != "/api/gh-user-auth/status" {
 				http.Error(w, `{"error":"your permissions on this hive are read-only, so changes are not allowed. Contact the owner of this hive to ask for write permissions."}`, http.StatusForbidden)
 				return
 			}


### PR DESCRIPTION
## Security finding C5 (Critical, CWE-862 — Missing Authorization)

Anonymous callers could **promote / revoke / delete / requeue contributors** on any hive that has no auth proxy in front of the dashboard pod — i.e. an OpenShift **Route** (no hub nginx) or **in-cluster** access with no NetworkPolicy. Two independent defects combined:

### Bug 1 — prefix match with no boundary (`server.go`)
Both `isPublicPath` and `roleEnforcement` gated the contribute flow with a bare:

```go
strings.HasPrefix(path, "/api/contribute")
```

That prefix **also matches the sibling admin routes** `PUT/POST /api/contributors/{id}/{trust,revoke,requeue}` and `DELETE /api/contributors/{id}` (the letters after `contribute` are `rs/...`, not a path boundary). As a result those mutation routes were:
- exempted from `authenticate()` entirely (treated as a public path), and
- exempted from the read-only write-gate in `roleEnforcement`.

### Bug 2 — missing role defaults to owner (`api_contribute.go`)
`requireContributorWrite` — the only remaining in-handler boundary — defaulted an **absent/empty `X-Hive-Role` to `"owner"`**. But an absent header is exactly what an anonymous caller reaching the pod directly presents (the hub nginx that would otherwise inject the header is bypassed). So even reachable, the gate waved them through.

Net: unauthenticated → owner-equivalent on the contributor admin endpoints.

## Fixes
1. **Boundary-safe public matching.** Replace the bare prefix with `path == "/api/contribute" || strings.HasPrefix(path, "/api/contribute/")` in **both** `isPublicPath` and `roleEnforcement`. `/api/contributors...` is no longer treated as public/exempt, while every genuinely-public route — `register`, the `ws` upgrade, `status`, etc., all registered under `/api/contribute/` — stays public.
2. **Fail closed on missing role.** `requireContributorWrite` now allows **only** an explicit `config.RoleOwner` or `config.RoleReadWrite`; absent, `"read"`, or any unrecognized value is rejected with **403**.

## Test changes
- `TestContributorWrite_OwnerAndRWAllowed` no longer treats a missing role as allowed (was `""→200`, that case removed).
- **New** `TestContributorWrite_MissingRoleForbidden` — every mutation endpoint with no role → 403, no mutation.
- **New** `TestContributorAdminRoutes_AnonymousDenied_ContributeFlowReachable` — end-to-end through the full `Handler()` chain on a hive **with** an auth boundary: anonymous `/api/contributors/*` mutations are denied (401/403) and do not mutate, while `POST /api/contribute/register` and `GET /api/contribute/ws` stay reachable (not 401).
- Existing functional tests for the endpoints sharing `requireContributorWrite` (trust/revoke/delete, queue hold/order) now present an owner role — matching real authorized callers. The role-gate tables flip the absent-role case from `200` to `403`.

## Regression guarantee
`go test ./v2/pkg/dashboard/` passes in full. The two new tests plus the existing `TestContributorWrite_ReadViewerForbidden` pin: anonymous and read-only callers are denied on every contributor mutation route, and the real public contribute-flow routes remain reachable — so a future re-broadening of either prefix, or a re-introduction of the absent-role default, fails CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)