### PR TITLE
🐛 fix(hub): show partial hive-delete as info, not a failure

### DIFF
--- a/v2/pkg/hub/delete_partial_toast_test.go
+++ b/v2/pkg/hub/delete_partial_toast_test.go
@@ -1,0 +1,47 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPartialDeleteRendersAsInfoNotError guards the Thread B UX fix: when the
+// hub returns status "partially_deleted", the delete SUCCEEDED (the registry
+// row is gone) but some cloud resources may survive. The dashboard's deleteHive
+// used to render that outcome with an 'error' toast, so a partial success looked
+// exactly like a failed delete even though the row had vanished. This asserts
+// the partially_deleted branch renders as an 'info' toast, not 'error'.
+func TestPartialDeleteRendersAsInfoNotError(t *testing.T) {
+	// Isolate the partially_deleted branch: from the `if (ok.status ===
+	// 'partially_deleted')` test to the `else` that follows it. Bounding on the
+	// else keeps an unrelated 'error' toast elsewhere in deleteHive (the
+	// !resp.ok path) from masking a regression here.
+	const branchStart = "if (ok.status === 'partially_deleted') {"
+	start := strings.Index(dashboardHTML, branchStart)
+	if start < 0 {
+		t.Fatal("deleteHive no longer handles the partially_deleted status")
+	}
+	rest := dashboardHTML[start+len(branchStart):]
+	end := strings.Index(rest, "} else {")
+	if end < 0 {
+		t.Fatal("could not find the end of the partially_deleted branch")
+	}
+	branch := rest[:end]
+
+	// The branch must render the outcome, and it must NOT be an error toast — a
+	// partial success must not look like a failure.
+	if !strings.Contains(branch, "hiveToast(") {
+		t.Fatal("the partially_deleted branch no longer shows a toast")
+	}
+	if strings.Contains(branch, "'error'") {
+		t.Errorf("partial-delete outcome is rendered as an 'error' toast — a partial "+
+			"success must not look like a failed delete; branch was:\n%s", branch)
+	}
+	if !strings.Contains(branch, "'info'") {
+		t.Errorf("partial-delete outcome should use the 'info' toast type; branch was:\n%s", branch)
+	}
+	// Guard the reassuring copy so the message stays informational, not alarming.
+	if !strings.Contains(branch, "manual cleanup") {
+		t.Errorf("partial-delete toast should mention manual cleanup; branch was:\n%s", branch)
+	}
+}

--- a/v2/pkg/hub/delete_partial_toast_test.go
+++ b/v2/pkg/hub/delete_partial_toast_test.go
@@ -28,20 +28,31 @@ func TestPartialDeleteRendersAsInfoNotError(t *testing.T) {
 	}
 	branch := rest[:end]
 
-	// The branch must render the outcome, and it must NOT be an error toast — a
-	// partial success must not look like a failure.
-	if !strings.Contains(branch, "hiveToast(") {
+	// Assert on the actual hiveToast(...) CALL, not the whole branch text — the
+	// branch's explanatory comment legitimately contains the word 'error' (it
+	// describes the old behaviour being fixed), so scanning the raw branch for
+	// "'error'" false-positives on the comment. Extract the toast call itself
+	// (from `hiveToast(` to the terminating `);`) and check its type argument.
+	callAt := strings.Index(branch, "hiveToast(")
+	if callAt < 0 {
 		t.Fatal("the partially_deleted branch no longer shows a toast")
 	}
-	if strings.Contains(branch, "'error'") {
-		t.Errorf("partial-delete outcome is rendered as an 'error' toast — a partial "+
-			"success must not look like a failed delete; branch was:\n%s", branch)
+	call := branch[callAt:]
+	if semi := strings.Index(call, ");"); semi >= 0 {
+		call = call[:semi+2]
 	}
-	if !strings.Contains(branch, "'info'") {
-		t.Errorf("partial-delete outcome should use the 'info' toast type; branch was:\n%s", branch)
+
+	// The toast type is the last argument; a partial success must be 'info',
+	// never 'error' (which would make it look like a failed delete).
+	if strings.Contains(call, "'error'") {
+		t.Errorf("partial-delete outcome is rendered as an 'error' toast — a partial "+
+			"success must not look like a failed delete; toast call was:\n%s", call)
+	}
+	if !strings.Contains(call, "'info'") {
+		t.Errorf("partial-delete outcome should use the 'info' toast type; toast call was:\n%s", call)
 	}
 	// Guard the reassuring copy so the message stays informational, not alarming.
-	if !strings.Contains(branch, "manual cleanup") {
-		t.Errorf("partial-delete toast should mention manual cleanup; branch was:\n%s", branch)
+	if !strings.Contains(call, "manual cleanup") {
+		t.Errorf("partial-delete toast should mention manual cleanup; toast call was:\n%s", call)
 	}
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -15884,7 +15884,13 @@ const dashboardHTML = `<!DOCTYPE html>
         }
         var ok = await resp.json().catch(function(){ return {}; });
         if (ok.status === 'partially_deleted') {
-          hiveToast('Removed ' + id + ' from the hub, but cleanup was incomplete: ' + (ok.warning || 'cloud resources may need manual removal'), 'error');
+          /* partially_deleted is a SUCCESS, not a failure: the registry row is
+             gone (which is what the user asked for and what they can see), but
+             no cluster config was available to tear down the namespace/PV/OCI
+             storage, so those may survive. Rendering it as an 'error' toast made
+             a partial success look like the delete had failed even though the
+             row vanished. Show it as an informational notice instead. */
+          hiveToast('Removed ' + id + ' from the hub; some cloud resources may need manual cleanup' + (ok.warning ? ' (' + ok.warning + ')' : ''), 'info');
         } else {
           hiveToast('Deleted ' + id, 'success');
         }


### PR DESCRIPTION
## What

Fixes the confusing partial-delete UX (Thread B of #2748): deleting a hive whose cluster config is unavailable returns the **success** status `partially_deleted` (registry row removed — what the user asked for and can see — but namespace/PV/OCI could not be torn down and may need manual cleanup). The dashboard's `deleteHive` rendered that outcome with an **`error`** toast, so a partial success looked exactly like a *failed* delete even though the row had already vanished — the exact "delete failed but the row disappeared" confusion an operator hit deleting `unknown-1`.

## Change

- `v2/pkg/hub/saas.go` (`dashboardHTML` `deleteHive`): render `partially_deleted` as an informational (`'info'`) toast — *"Removed <id> from the hub; some cloud resources may need manual cleanup (…)"* — instead of an `'error'` toast. Keeps the backend warning detail.
- Adds `delete_partial_toast_test.go` asserting the `partially_deleted` branch no longer uses the `'error'` toast type (and uses `'info'`).

No backend behavior change — the handler already returned the correct statuses; only the client-side rendering was wrong.

## Scope note — the "reset to pool" feature is NOT in this PR

#2748 also asks for a "reset a hive back to the unassigned pool (reuse the namespace)" capability. I investigated it and posted a full design + security wipe checklist as a comment on #2748. Verdict: the **SaaSHive-record reset already exists and is safe** (`resetHiveToAvailablePlaceholder` / `handleResetAssignment`), but it only handles *assigned-but-unclaimed* wedges whose `/data` was never populated. Resetting a **live** claimed hive needs a credential-safe `/data` wipe that **does not exist today** and **cannot be made atomic** across the PVC + `hive-secrets` Secret + hub metadata — a half-run wipe would pool a slot still holding the prior tenant's `gh-user-token`/App keys/inference keys, a serious leak. So that half is left for deliberate scoping (recommended as a fail-closed wipe Job), not shipped half-safe.

Relates to #2748
