### PR TITLE
🔇 fix: advisory digests never @-mention humans (notification spam)

### DIFF
--- a/v2/pkg/advisory/advisory.go
+++ b/v2/pkg/advisory/advisory.go
@@ -380,7 +380,7 @@ func FormatDigestMarkdown(d *Digest, org, primaryRepo string) string {
 		b.WriteString("This comment is updated periodically.\n\n")
 		b.WriteString("**Findings:** 0 — all previously reported findings are resolved. ✅\n\n")
 		writeRecentlyResolved(&b, d, org, primaryRepo)
-		return b.String()
+		return NeutralizeMentions(b.String())
 	}
 
 	var all []Finding
@@ -437,7 +437,11 @@ func FormatDigestMarkdown(d *Digest, org, primaryRepo string) string {
 
 	writeRecentlyResolved(&b, d, org, primaryRepo)
 
-	return b.String()
+	// Findings quote agent output verbatim and routinely name humans
+	// ("PR #665, by @omerap12"). The digest comment is rewritten every cycle,
+	// so any raw mention would re-notify that person on every refresh —
+	// neutralize the whole body before it goes anywhere near GitHub.
+	return NeutralizeMentions(b.String())
 }
 
 // writeRecentlyResolved renders the "Recently Resolved" digest section. Shared

--- a/v2/pkg/advisory/sanitize.go
+++ b/v2/pkg/advisory/sanitize.go
@@ -1,0 +1,73 @@
+package advisory
+
+import (
+	"regexp"
+	"strings"
+)
+
+// mentionPattern matches a GitHub @mention at a mention-valid position. The @
+// must be preceded by start-of-text or a non-alphanumeric character so email
+// addresses (user@example.com) are never touched. A preceding backtick is
+// excluded so already-neutralized text stays stable (idempotency), and a
+// preceding slash is excluded so an @ inside a URL path is never rewritten.
+// The username part follows GitHub's rules: alphanumeric with interior
+// hyphens, never starting or ending with a hyphen.
+var mentionPattern = regexp.MustCompile("(^|[^A-Za-z0-9`/])@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)")
+
+const codeFenceMarker = "```"
+
+// NeutralizeMentions rewrites every GitHub @mention in text so it can never
+// notify anyone. Advisory output is posted to GitHub and the digest comment is
+// REWRITTEN on every update cycle — a raw "@username" anywhere in it re-pings
+// that human on every refresh, which reads as notification spam from the hive
+// (see llm-d-incubation/llm-d-fast-model-actuation#580).
+//
+// Outside code, "@username" becomes "`username`": it renders cleanly, stays
+// greppable, and never triggers a notification. Inside inline code spans and
+// fenced code blocks only the "@" is dropped (backtick-wrapping there would
+// corrupt the span), which still guarantees the invariant that the final body
+// contains no mention-position "@username" anywhere.
+//
+// The function is idempotent: running it on already-neutralized text returns
+// it unchanged. Email addresses, bare issue/PR refs (#123), and URLs are left
+// untouched.
+func NeutralizeMentions(text string) string {
+	if !strings.Contains(text, "@") {
+		return text
+	}
+	lines := strings.Split(text, "\n")
+	inFence := false
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), codeFenceMarker) {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			// Fenced code block: dropping the @ is the only safe rewrite.
+			lines[i] = mentionPattern.ReplaceAllString(line, "$1$2")
+			continue
+		}
+		lines[i] = neutralizeLine(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// neutralizeLine applies the mention rewrite to a single non-fence line,
+// treating inline code spans separately: splitting on backticks alternates
+// between text outside spans (even indices — wrap the username in backticks)
+// and text inside spans (odd indices — drop the @ only, so the span is not
+// double-wrapped).
+func neutralizeLine(line string) string {
+	if !strings.Contains(line, "@") {
+		return line
+	}
+	segs := strings.Split(line, "`")
+	for i, seg := range segs {
+		if i%2 == 0 {
+			segs[i] = mentionPattern.ReplaceAllString(seg, "$1`$2`")
+		} else {
+			segs[i] = mentionPattern.ReplaceAllString(seg, "$1$2")
+		}
+	}
+	return strings.Join(segs, "`")
+}

--- a/v2/pkg/advisory/sanitize_test.go
+++ b/v2/pkg/advisory/sanitize_test.go
@@ -1,0 +1,170 @@
+package advisory
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNeutralizeMentions(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "plain mention neutralized",
+			in:   "PR #665 (open, by @omerap12) adds a setUpController() test helper",
+			want: "PR #665 (open, by `omerap12`) adds a setUpController() test helper",
+		},
+		{
+			name: "mention at start of line",
+			in:   "@omerap12 should look at this",
+			want: "`omerap12` should look at this",
+		},
+		{
+			name: "mention mid line",
+			in:   "as noted by @some-user earlier",
+			want: "as noted by `some-user` earlier",
+		},
+		{
+			name: "mention at end of line",
+			in:   "review requested from @omerap12",
+			want: "review requested from `omerap12`",
+		},
+		{
+			name: "multiple mentions on one line",
+			in:   "cc @alice and @bob-2",
+			want: "cc `alice` and `bob-2`",
+		},
+		{
+			name: "email address untouched",
+			in:   "contact user@example.com for details",
+			want: "contact user@example.com for details",
+		},
+		{
+			name: "already sanitized text unchanged (idempotent)",
+			in:   "PR #665 (open, by `omerap12`) adds a helper",
+			want: "PR #665 (open, by `omerap12`) adds a helper",
+		},
+		{
+			name: "mention inside inline code span not double-wrapped",
+			in:   "the handle `@omerap12` appears in the config",
+			want: "the handle `omerap12` appears in the config",
+		},
+		{
+			name: "issue ref untouched",
+			in:   "see #123 and repo#456 for context",
+			want: "see #123 and repo#456 for context",
+		},
+		{
+			name: "URL untouched",
+			in:   "see https://github.com/org/repo/issues/123 and https://example.com/@profile",
+			want: "see https://github.com/org/repo/issues/123 and https://example.com/@profile",
+		},
+		{
+			name: "mention after punctuation",
+			in:   "(thanks, @alice!)",
+			want: "(thanks, `alice`!)",
+		},
+		{
+			name: "mention inside fenced code block loses only the @",
+			in:   "```\nreviewers: @alice\n```",
+			want: "```\nreviewers: alice\n```",
+		},
+		{
+			name: "bare @ with no username untouched",
+			in:   "an @ sign alone and a trailing @",
+			want: "an @ sign alone and a trailing @",
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "multi-line mixed content",
+			in:   "- **[bug]** found by @alice #12\n  > details from bob@example.com about @carol",
+			want: "- **[bug]** found by `alice` #12\n  > details from bob@example.com about `carol`",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NeutralizeMentions(tt.in)
+			if got != tt.want {
+				t.Errorf("NeutralizeMentions(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+			// Idempotency: a second pass must be a no-op for every case.
+			if again := NeutralizeMentions(got); again != got {
+				t.Errorf("not idempotent: second pass changed %q to %q", got, again)
+			}
+		})
+	}
+}
+
+func TestFormatDigestMarkdownContainsNoRawMentions(t *testing.T) {
+	now := time.Now()
+	findings := []Finding{
+		{
+			Agent:     "quality",
+			Timestamp: now,
+			Type:      "advisory",
+			Severity:  "high",
+			Title:     "PR #665 (open, by @omerap12) adds a setUpController() test helper",
+			Detail:    "Discussed with @some-user; contact maintainer@example.com with questions.",
+		},
+		{
+			Agent:     "security",
+			Timestamp: now,
+			Type:      "bug",
+			Severity:  "medium",
+			Title:     "@alice flagged repo#42 as risky",
+			File:      "gh-42",
+		},
+	}
+	d := BuildDigest(findings, "advisory")
+	d.RecentlyResolved = []ResolvedFinding{
+		{Agent: "quality", Title: "fix suggested by @bob-2 landed", ClosedAt: now},
+	}
+
+	md := FormatDigestMarkdown(d, "testorg", "testrepo")
+
+	if mentionPattern.MatchString(md) {
+		t.Errorf("digest body contains a raw @mention:\n%s", md)
+	}
+	if !strings.Contains(md, "`omerap12`") {
+		t.Errorf("expected neutralized `omerap12` in digest body:\n%s", md)
+	}
+	if !strings.Contains(md, "`alice`") {
+		t.Errorf("expected neutralized `alice` in digest body:\n%s", md)
+	}
+	if !strings.Contains(md, "`bob-2`") {
+		t.Errorf("expected neutralized `bob-2` in Recently Resolved section:\n%s", md)
+	}
+	if !strings.Contains(md, "maintainer@example.com") {
+		t.Errorf("email address must survive sanitization:\n%s", md)
+	}
+	// Sanitization must not disturb ref linkification.
+	if !strings.Contains(md, "[repo#42](https://github.com/testorg/repo/issues/42)") {
+		t.Errorf("expected repo#42 linkified in digest body:\n%s", md)
+	}
+}
+
+func TestFormatDigestMarkdownZeroFindingsNoRawMentions(t *testing.T) {
+	d := &Digest{
+		GeneratedAt: time.Now(),
+		Mode:        "advisory",
+		ByAgent:     map[string][]Finding{},
+		TotalCount:  0,
+		RecentlyResolved: []ResolvedFinding{
+			{Agent: "quality", Title: "issue reported by @carol resolved", ClosedAt: time.Now()},
+		},
+	}
+	md := FormatDigestMarkdown(d, "testorg", "testrepo")
+	if mentionPattern.MatchString(md) {
+		t.Errorf("all-clear digest body contains a raw @mention:\n%s", md)
+	}
+	if !strings.Contains(md, "`carol`") {
+		t.Errorf("expected neutralized `carol` in all-clear digest:\n%s", md)
+	}
+}

--- a/v2/pkg/github/advisory.go
+++ b/v2/pkg/github/advisory.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	gh "github.com/google/go-github/v72/github"
+	"github.com/kubestellar/hive/v2/pkg/advisory"
 )
 
 const (
@@ -102,6 +103,13 @@ func (c *Client) PostAdvisoryDigest(ctx context.Context, repo string, issueNum i
 	}
 	owner, repoName := c.splitRepo(repo)
 
+	// Belt-and-suspenders enforcement: no advisory body may ever carry a raw
+	// @mention. The digest comment is rewritten every update cycle, so a
+	// single "@username" in any of its findings would re-notify that human on
+	// every refresh. FormatDigestMarkdown already neutralizes mentions at
+	// render time; NeutralizeMentions is idempotent, so applying it again here
+	// guarantees the invariant for every caller of this post path.
+	digest = advisory.NeutralizeMentions(digest)
 	digest = truncateDigest(digest)
 
 	commentID, err := c.findDigestComment(ctx, owner, repoName, issueNum)

--- a/v2/pkg/github/advisory_test.go
+++ b/v2/pkg/github/advisory_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -632,6 +633,57 @@ func TestPostAdvisoryDigest_FindCommentError_StillCreates(t *testing.T) {
 	}
 	if !created {
 		t.Error("expected comment to be created after find error")
+	}
+}
+
+// TestPostAdvisoryDigest_NeutralizesMentions asserts the invariant that no
+// body posted through the advisory digest path ever carries a raw @mention —
+// even when a caller bypasses FormatDigestMarkdown and hands over unsanitized
+// text. The digest comment is rewritten every cycle, so a single raw mention
+// would re-notify that human on every refresh.
+func TestPostAdvisoryDigest_NeutralizesMentions(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	var postedBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/10/comments", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			json.NewEncoder(w).Encode([]map[string]any{})
+			return
+		}
+		if r.Method == "POST" {
+			var payload struct {
+				Body string `json:"body"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Errorf("decoding comment payload: %v", err)
+			}
+			postedBody = payload.Body
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{"id": 1})
+		}
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	raw := "## 🐝 Advisory Digest\n- PR #665 (open, by @omerap12) adds a helper\n- ping user@example.com about @some-user"
+	if err := c.PostAdvisoryDigest(context.Background(), repo, 10, raw); err != nil {
+		t.Fatalf("PostAdvisoryDigest: %v", err)
+	}
+	// A mention-position "@username" (@ at start of text or after a
+	// non-alphanumeric character other than ` or /) must never survive.
+	rawMention := regexp.MustCompile("(^|[^A-Za-z0-9`/])@[A-Za-z0-9]")
+	if rawMention.MatchString(postedBody) {
+		t.Errorf("posted digest body contains a raw @mention:\n%s", postedBody)
+	}
+	if !strings.Contains(postedBody, "`omerap12`") {
+		t.Errorf("expected neutralized `omerap12` in posted body:\n%s", postedBody)
+	}
+	if !strings.Contains(postedBody, "`some-user`") {
+		t.Errorf("expected neutralized `some-user` in posted body:\n%s", postedBody)
+	}
+	if !strings.Contains(postedBody, "user@example.com") {
+		t.Errorf("email address must survive sanitization:\n%s", postedBody)
 	}
 }
 


### PR DESCRIPTION
## Problem

The 🐝 Advisory Digest comment the governor posts on a repo's "Hive Advisory Report" issue embeds raw `@username` mentions in finding text (e.g. "PR #665 (open, by @omerap12) adds a setUpController() test helper..."). The digest comment is **rewritten on every update cycle**, so every refresh re-notifies every human mentioned anywhere in the (400+ finding) digest.

An external maintainer (omerap12, on llm-d-incubation/llm-d-fast-model-actuation#580) has complained twice about the notification spam and is now blocking the thread. Hand-editing the comment does not stick — the next digest update re-adds the mention.

## Fix

New `advisory.NeutralizeMentions` sanitizer, applied to the **entire digest body**:

- **Render time** — `FormatDigestMarkdown` (both the normal path and the all-clear / recently-resolved path) in `v2/pkg/advisory/advisory.go`
- **Post time (enforcement)** — `PostAdvisoryDigest` in `v2/pkg/github/advisory.go`, so no body posted through the digest path (App client or user-fallback client — both go through this method) can ever carry a raw mention, even if a caller hands over unsanitized text

### Sanitizer behavior

- `@omerap12` → `omerap12` wrapped in backticks — renders clean, still greppable, **never notifies**
- Inside inline code spans and fenced code blocks only the `@` is dropped, so existing spans are not double-wrapped
- **Idempotent**: re-running on already-sanitized text is a no-op, which makes the render-time + post-time double application safe
- Email addresses (`user@example.com`) untouched — `@` must be at a mention-valid position (start of text or after a non-alphanumeric character)
- Bare `#123` refs, `repo#123` linkification, and URLs (including `/@path` segments) untouched

**Scope is intentionally minimal**: issue/PR references, links, and all other digest rendering are left exactly as they were — the only change is that no `@username` can ever notify.

## Tests

- Table test for `NeutralizeMentions` (start/mid/end of line, multiple mentions, emails, idempotency, code spans, fenced blocks, `#123`/URLs untouched), with a second-pass idempotency assertion on every case
- Digest-assembly tests asserting `FormatDigestMarkdown` output (normal and zero-findings paths) contains no mention-position `@username` while keeping `repo#42` linkification intact
- `PostAdvisoryDigest` httptest asserting the actual posted JSON body is sanitized even for a raw, unformatted input

🤖 Generated with [Claude Code](https://claude.com/claude-code)