### PR TITLE
🔒 fix(security): C6 — pin + group-restrict SUID su-exec helper (CWE-250/269)

### DIFF
--- a/.github/workflows/suid-contract.yml
+++ b/.github/workflows/suid-contract.yml
@@ -1,0 +1,39 @@
+name: SUID Helper Contract
+
+# Static contract check that the hive image never ships a world-executable
+# setuid-root helper (security finding C6, CWE-250/269). The image legitimately
+# needs a SUID su-exec for the non-root dev process to switch to per-agent UIDs
+# at runtime; this guard locks in that it stays pinned-by-SHA + SHA256-verified
+# and chmod 4750 root:hive-launch (launcher-group-only), never the old
+# unpinned world-exec 4755 form. See v2/scripts/check-suid-contract.sh.
+
+on:
+  push:
+    branches:
+      - v2
+      - v4
+    paths:
+      - 'v2/Dockerfile'
+      - 'v2/scripts/check-suid-contract.sh'
+      - '.github/workflows/suid-contract.yml'
+  pull_request:
+    branches:
+      - v2
+      - v4
+    paths:
+      - 'v2/Dockerfile'
+      - 'v2/scripts/check-suid-contract.sh'
+      - '.github/workflows/suid-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run SUID helper static contract check
+        run: bash v2/scripts/check-suid-contract.sh v2/Dockerfile

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -41,16 +41,53 @@ COPY --from=tmux-builder /usr/local/bin/tmux /usr/local/bin/tmux
 
 # su-exec: lightweight setuid exec for UID switching from non-root.
 # gosu rejects SUID mode, so we use su-exec (which is designed for it)
-# for the manager's dev→agent UID switches.
-RUN curl -sL -o /tmp/su-exec.c https://raw.githubusercontent.com/ncopa/su-exec/master/su-exec.c \
+# for the manager's dev→agent UID switches (pkg/agent/manager.go,
+# pkg/dashboard/workspace_cleanup.go, deploy/ttyd-tmux.sh — all invoked by the
+# non-root `dev` process AFTER the entrypoint's `exec gosu dev`, so a SUID
+# helper or CAP_SETUID is genuinely required to switch to agent UIDs at runtime).
+#
+# SECURITY (C6, CWE-250/269). Two hardening measures over the old
+# `curl master | gcc | chmod u+s` (which produced a world-executable
+# setuid-root binary, mode 4755, that ANY agent UID could run as
+# `su-exec root sh` → root in the pod holding the org App key + all agent
+# tokens + iptables control):
+#
+#  1. SUPPLY CHAIN: pin su-exec.c by COMMIT SHA (not the moving `master` ref)
+#     and verify its SHA256 before compiling. An upstream force-push or a
+#     MITM'd raw.githubusercontent.com can no longer swap the source under us.
+#
+#  2. PRIVILEGE ISOLATION: the binary is owned root:hive-launch mode 4750, NOT
+#     world-exec 4755. Only root and members of the `hive-launch` group may
+#     exec it. The sole member of hive-launch is `dev` (UID 1001), the process
+#     that legitimately launches agents. Agent UIDs (2001+) are in group `node`
+#     — NOT hive-launch — so an agent trying `su-exec root sh` now gets EACCES
+#     at exec, restoring the per-UID isolation the world-exec bit collapsed.
+#     Note: root:node 4750 would NOT be enough — `dev` AND every agent share
+#     group node, so a node-group SUID is still agent-executable. A dedicated
+#     launcher group is what actually excludes the agents.
+#
+# Full removal of SUID (make dev switch UIDs via CAP_SETUID/CAP_SETGID instead)
+# was considered and rejected — see PR body: it needs ambient/inheritable caps
+# that fight `allowPrivilegeEscalation: false`, and the hub's netadmin_reconcile
+# JSON-Patches the whole securityContext to `{NET_ADMIN}` on drift, silently
+# wiping any SETUID/SETGID grant on live hives.
+ARG SU_EXEC_COMMIT=89c016e6e08749d583efdeda04b9f73e1218e253
+ARG SU_EXEC_SHA256=0c90fe15804f2670037b90e72eb496579fe00d2c15765e5fe2ddec0f5afa35fa
+RUN curl -sL -o /tmp/su-exec.c "https://raw.githubusercontent.com/ncopa/su-exec/${SU_EXEC_COMMIT}/su-exec.c" \
+ && echo "${SU_EXEC_SHA256}  /tmp/su-exec.c" | sha256sum -c - \
  && gcc -Wall -o /usr/local/bin/su-exec /tmp/su-exec.c \
- && chmod u+s /usr/local/bin/su-exec \
  && rm /tmp/su-exec.c \
  && apt-get purge -y gcc libc6-dev && apt-get autoremove -y
 
 # Non-root user for agent processes (Claude Code refuses --dangerously-skip-permissions as root)
-# node:24-slim already has group 1000 (node), so reuse it
-RUN useradd -m -u 1001 -g node -s /bin/bash dev
+# node:24-slim already has group 1000 (node), so reuse it as dev's primary group.
+# `hive-launch` is a dedicated supplementary group whose ONLY member is dev; it
+# gates exec of the SUID su-exec helper (chmod 4750 below) so agent UIDs — which
+# are in group node but NOT hive-launch — cannot run it. See the su-exec C6 note.
+RUN groupadd --system hive-launch \
+ && useradd -m -u 1001 -g node -G hive-launch -s /bin/bash dev \
+ && chown root:hive-launch /usr/local/bin/su-exec \
+ && chmod 4750 /usr/local/bin/su-exec
 
 # --- Layer 2: ttyd (pinned version for reproducible builds) ---
 ARG TTYD_VERSION=1.7.7

--- a/v2/deploy/k8s/deployment.yaml
+++ b/v2/deploy/k8s/deployment.yaml
@@ -30,6 +30,19 @@ spec:
           # scratch state to /tmp, /run and /home — so runAsNonRoot and
           # readOnlyRootFilesystem are intentionally NOT set (they would break
           # agent launch). Everything else is dropped.
+          #
+          # allowPrivilegeEscalation is deliberately NOT set to false (C6): the
+          # agent-UID switch runs through the SUID su-exec helper, and
+          # `allowPrivilegeEscalation: false` sets the kernel no_new_privs bit,
+          # which DISABLES all SUID binaries — it would break agent launch
+          # outright. C6 is instead mitigated in the image (v2/Dockerfile): the
+          # su-exec source is pinned by commit SHA + SHA256-verified, and the
+          # helper is chmod 4750 root:hive-launch (launcher-group-only, not
+          # world-exec 4755), so only the `dev` launcher — not agent UIDs — can
+          # exec it. Fully removing SUID (dev switches UIDs via CAP_SETUID
+          # instead) is not viable here: it needs ambient/inheritable caps that
+          # the hub's netadmin_reconcile would wipe when it JSON-Patch-replaces
+          # the whole securityContext with {NET_ADMIN} on drift. See PR body.
           securityContext:
             seccompProfile:
               type: RuntimeDefault

--- a/v2/scripts/check-suid-contract.sh
+++ b/v2/scripts/check-suid-contract.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# check-suid-contract.sh — static contract check that the hive image never
+# ships a WORLD-EXECUTABLE setuid-root helper (security finding C6,
+# CWE-250/269).
+#
+# Background. The image needs a SUID `su-exec` so the non-root `dev` process can
+# switch to per-agent UIDs at runtime (pkg/agent/manager.go,
+# pkg/dashboard/workspace_cleanup.go, deploy/ttyd-tmux.sh — all run AFTER the
+# entrypoint's `exec gosu dev`). The original build did
+# `curl .../master/su-exec.c | gcc | chmod u+s`, producing a mode-4755
+# setuid-root binary that ANY agent UID could exec as `su-exec root sh` → root
+# in the pod holding the org GitHub App key, every agent token, and iptables
+# control. That collapsed per-UID isolation and the F5 forced-egress guarantee.
+#
+# The fix (Option B — the SUID helper is genuinely required, so it is TIGHTENED,
+# not removed): pin su-exec by commit SHA + verify SHA256, then own it
+# root:hive-launch mode 4750 so only root and the dedicated launcher group (sole
+# member: dev) can exec it. This check locks that invariant in so a future edit
+# can't silently regress back to a world-exec SUID binary or an unpinned source.
+#
+# Invariant (asserted against v2/Dockerfile):
+#   - NO `chmod u+s` / `chmod 4755` / world-exec SUID mode on su-exec.
+#   - su-exec source is pinned by commit SHA (not the moving `master` ref).
+#   - the SHA256 of the pinned source is verified before compiling.
+#   - the installed helper is chmod 4750 and owned by root:hive-launch.
+#
+# Usage: v2/scripts/check-suid-contract.sh [path-to-Dockerfile]
+set -euo pipefail
+
+DOCKERFILE="${1:-v2/Dockerfile}"
+
+if [[ ! -f "$DOCKERFILE" ]]; then
+  echo "ERROR: Dockerfile not found at ${DOCKERFILE}" >&2
+  exit 1
+fi
+
+fail=0
+
+# CODE holds the Dockerfile with comment lines stripped. The forbidden-pattern
+# checks run against CODE so that an explanatory comment mentioning e.g.
+# `chmod u+s` (describing the OLD insecure build) is not itself flagged — only a
+# real instruction would be. The positive checks run against the raw file.
+CODE="$(grep -vE '^[[:space:]]*#' "$DOCKERFILE")"
+
+check() {
+  local desc="$1" pattern="$2"
+  if grep -qE "$pattern" "$DOCKERFILE"; then
+    echo "  ok: ${desc}"
+  else
+    echo "  FAIL: ${desc} (expected to find pattern: ${pattern})"
+    fail=1
+  fi
+}
+
+check_absent() {
+  local desc="$1" pattern="$2"
+  if printf '%s\n' "$CODE" | grep -qE "$pattern"; then
+    echo "  FAIL: ${desc} (found forbidden pattern in a build instruction: ${pattern})"
+    fail=1
+  else
+    echo "  ok: ${desc}"
+  fi
+}
+
+echo "== SUID helper contract check (${DOCKERFILE}) =="
+
+# 1. No world-executable setuid bit may be set on any binary. `chmod u+s`
+# (implicitly 4755 on a 0755 file) and an explicit 4-digit mode whose group/
+# other exec bits are set (47xx / 45xx / 46xx / 47x7 ...) are both forbidden.
+# The permitted form is 4750 (owner+group exec only), asserted positively below.
+check_absent "no 'chmod u+s' (world-exec setuid)" \
+  'chmod[[:space:]]+u\+s'
+check_absent "no world-exec setuid mode (4755/4775/4711/etc.)" \
+  'chmod[[:space:]]+4[0-7][0-7][1-7]'
+
+# 2. su-exec source must be pinned by commit SHA, not the moving master ref.
+check_absent "su-exec source is not fetched from the moving 'master' ref" \
+  'su-exec/master/su-exec\.c'
+check "su-exec source pinned via SU_EXEC_COMMIT arg" \
+  'ARG[[:space:]]+SU_EXEC_COMMIT='
+check "su-exec fetch URL uses the pinned commit" \
+  'su-exec/\$\{SU_EXEC_COMMIT\}/su-exec\.c'
+
+# 3. The pinned source SHA256 must be verified before compiling.
+check "su-exec SHA256 declared" \
+  'ARG[[:space:]]+SU_EXEC_SHA256='
+check "su-exec SHA256 verified with sha256sum -c" \
+  'sha256sum[[:space:]]+-c'
+
+# 4. The installed helper must be group-restricted (4750), owned root:hive-launch.
+check "su-exec installed chmod 4750 (owner+group exec only)" \
+  'chmod[[:space:]]+4750[[:space:]]+/usr/local/bin/su-exec'
+check "su-exec owned root:hive-launch (dedicated launcher group)" \
+  'chown[[:space:]]+root:hive-launch[[:space:]]+/usr/local/bin/su-exec'
+
+# 5. The dedicated launcher group must exist and NOT include agent UIDs. dev is
+# added to it; agent users are created in the entrypoint with `-g node` only, so
+# a `-G hive-launch` on any agent useradd would be a regression.
+check "hive-launch launcher group is created" \
+  'groupadd[[:space:]]+--system[[:space:]]+hive-launch'
+check "dev is a member of hive-launch" \
+  'useradd.*-G[[:space:]]+hive-launch'
+
+if [[ "$fail" -ne 0 ]]; then
+  echo ""
+  echo "SUID helper contract check FAILED — a world-exec or unpinned setuid-root"
+  echo "binary must never ship (security finding C6, CWE-250/269)."
+  exit 1
+fi
+
+echo ""
+echo "SUID helper contract check passed."


### PR DESCRIPTION
## Security finding C6 (Critical, CWE-250/269)

`v2/Dockerfile` built the `su-exec` UID-switch helper with
`curl .../su-exec/master/su-exec.c | gcc | chmod u+s`, producing an
**unpinned, mode-4755 world-executable setuid-root** binary. Any agent UID in
the pod could run `su-exec root sh` and become **root in the container** — the
container that holds the org GitHub **App private key**, every **per-agent
token**, and **iptables** control. That single primitive collapses:

- per-UID agent isolation,
- the F5 forced-egress guarantee (root can flush the iptables redirect),
- proxy attribution (root can bypass the MITM proxy).

Two independent weaknesses: **supply chain** (unpinned `master` ref, compiled
and trusted blindly) and **privilege** (world-exec SUID reachable by every
agent UID).

## Launch-chain analysis (why su-exec cannot simply be removed)

The entrypoint runs as **root**, does all UID/iptables setup, then
`exec gosu dev "$0"` — every runtime process after that is the non-root **dev**
user (UID 1001). The dev process then switches to per-agent UIDs **at runtime**
in five paths, all of which shell out to `su-exec`:

| Path | Call |
|------|------|
| `pkg/agent/manager.go` `tmuxCmd` / `ensureTmuxSession` | launch agent tmux as `hive-<agent>` |
| `pkg/agent/manager.go` (tmux dir chmod) | `su-exec <agent> chmod 710 …` |
| `pkg/agent/manager.go` `setupCodexHome` | `su-exec <agent> mkdir/ln …` |
| `pkg/dashboard/workspace_cleanup.go` `removeTree` | `su-exec <owner> rm -rf …` (EPERM fallback) |
| `v2/deploy/ttyd-tmux.sh` | `su-exec <sock-owner> tmux attach` |

So a way for the **non-root dev process** to switch UIDs at runtime is
mandatory — either a SUID helper or retained CAP_SETUID.

## Which option and why: **Option B (tighten), not A (remove)**

**Option A (remove SUID, dev switches UIDs via CAP_SETUID/CAP_SETGID) was
evaluated and rejected.** It is not viable here:

1. A SUID-free `su-exec`/`setpriv` calling `setuid()` needs CAP_SETUID in the
   process's *effective* set. For the already-dropped-to-dev process that means
   **ambient/inheritable** capabilities, which directly fight
   `allowPrivilegeEscalation: false` and depend on kernel/runtime ambient-cap
   support across both OKE and OpenShift/OVN.
2. The hub's `pkg/hub/netadmin_reconcile.go` issues a JSON-Patch `add` at the
   container `securityContext` path, which **replaces the entire
   securityContext object** with `{capabilities:{add:[NET_ADMIN]}}` on any
   drifted live hive — silently **wiping** any SETUID/SETGID/ambient grant
   Option A would rely on. Making A safe would require rewriting that hub
   reconcile fleet-wide too.

**Option B keeps the required SUID helper but removes both weaknesses:**

- **Supply chain:** pin `su-exec.c` by **commit SHA**
  (`89c016e6e08749d583efdeda04b9f73e1218e253`) and **verify SHA256**
  (`0c90fe15…afa35fa`) with `sha256sum -c` before compiling. A `master`
  force-push or a MITM'd `raw.githubusercontent.com` can no longer swap the
  source.
- **Privilege isolation:** install the helper **`chmod 4750 root:hive-launch`**
  (owner + launcher-group exec only), **not** world-exec 4755. A dedicated
  **`hive-launch`** group whose **only member is `dev`** gates exec. Agent UIDs
  (2001+) are created with `-g node` and are **not** in `hive-launch`, so an
  agent's `su-exec root sh` now **EACCESes at exec**.
  *Note:* `root:node 4750` would **not** be sufficient — `dev` and every agent
  share primary group `node`, so a node-group SUID is still agent-executable. A
  dedicated launcher group is what actually excludes the agents.

## K8s manifest change

`v2/deploy/k8s/deployment.yaml` already dropped ALL caps and adds only the
minimal set (landed in #2178). This PR **documents why
`allowPrivilegeEscalation: false` is deliberately NOT set**: it sets the kernel
`no_new_privs` bit, which **disables all SUID binaries** and would break agent
launch outright. C6 is mitigated in the image (pin + 4750 group-restrict)
rather than by a podspec flag that is incompatible with the required SUID path.

## CI guard

- `v2/scripts/check-suid-contract.sh` — static contract check (mirrors the
  existing `check-podman-contract.sh`) asserting the Dockerfile never ships a
  world-exec/unpinned setuid-root binary: no `chmod u+s`/4755, source pinned by
  SHA, SHA256-verified, installed `4750 root:hive-launch`, `hive-launch` group
  created, `dev` a member. Verified it **passes** on the fixed Dockerfile and
  **fails** on the old insecure form.
- `.github/workflows/suid-contract.yml` — runs it on PRs/pushes to v2 & v4
  touching the Dockerfile or the check.

## Residual risk

- `su-exec` remains SUID-root by necessity — exposure is reduced from *every
  agent UID* to *root + the single `dev` launcher*. Compromising the dev
  process still reaches root (it always could — it is the launcher), but agents
  no longer have that primitive.
- `allowPrivilegeEscalation: false` and `no-new-privileges` remain unset while
  a SUID helper is in the launch path; removing that constraint requires
  Option A + the hub reconcile rework noted above (follow-up).
- The pin must be bumped deliberately if upstream su-exec is ever updated (the
  CI guard forces the SHA + SHA256 to be present, not to a specific value).

## Tests

Focused `go test` for `pkg/agent` (su-exec/tmux/codex-home), `pkg/dashboard`
(workspace_cleanup removeTree), and `pkg/hub` (netadmin) all pass. Contract
check passes on the fix and fails on the pre-fix Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)