### PR TITLE
fix(security): C1/N3 — stop heartbeat broadcasting every tenant's App private key (CWE-200/639)

### DIFF
--- a/v2/pkg/hub/app_key_backoff_test.go
+++ b/v2/pkg/hub/app_key_backoff_test.go
@@ -66,50 +66,12 @@ func TestAppKeyDeliveryBackoffOnPrimaryReconcile(t *testing.T) {
 	}
 }
 
-// The additional-keys pass re-delivered every beat too while a broken sender's
-// GitHubAppKeysHeld never reflected the delivery. It shares the per-hive
-// ledger, so it throttles the same way.
-func TestAppKeyDeliveryBackoffOnAdditionalKeys(t *testing.T) {
-	s, _ := twoClusterHub(t)
-	// A GHE-primary hive that never reports holding the github.com key.
-	payload := &HeartbeatPayload{
-		HiveID:      "broken-add",
-		ClusterID:   "vllm-d",
-		GitHubAppID: testGHEAppID,
-	}
-
-	for i := 0; i < appKeyDeliveryImmediateBudget; i++ {
-		var resp HeartbeatResponse
-		s.attachMissingAppKeys(&resp, payload)
-		if resp.GitHubAppConfig == nil || len(resp.GitHubAppConfig.AdditionalKeys) == 0 {
-			t.Fatalf("beat %d: additional key not delivered inside the immediate budget", i+1)
-		}
-	}
-
-	var resp HeartbeatResponse
-	s.attachMissingAppKeys(&resp, payload)
-	if resp.GitHubAppConfig != nil {
-		t.Fatal("additional-keys delivery not suppressed after the budget — key material would ride every beat forever")
-	}
-
-	// A spoke that reports holding the key is converged on this path: nothing
-	// is attached and nothing is counted.
-	held := &HeartbeatPayload{
-		HiveID:      "healthy-add",
-		ClusterID:   "vllm-d",
-		GitHubAppID: testGHEAppID,
-		GitHubAppKeysHeld: map[string]string{
-			"3568013": s.appKeysByAppID()[testGitHubComAppID].Fingerprint,
-		},
-	}
-	for i := 0; i < appKeyDeliveryImmediateBudget+2; i++ {
-		var r HeartbeatResponse
-		s.attachMissingAppKeys(&r, held)
-		if r.GitHubAppConfig != nil {
-			t.Fatalf("beat %d: spoke holding every key still got a delivery", i+1)
-		}
-	}
-}
+// SECURITY (C1/N3, CWE-200/639): the former
+// TestAppKeyDeliveryBackoffOnAdditionalKeys exercised the fleet-wide
+// additional-key broadcast's throttle (attachMissingAppKeys). That delivery lane
+// was removed — it handed every tenant's App private key to any caller — so the
+// test was deleted with it. The primary-key delivery back-off above and the
+// ledger contract below remain the live coverage for the throttle.
 
 // Unit contract of the ledger itself: budget, throttle, reset.
 func TestAppKeyDeliveryLedger(t *testing.T) {

--- a/v2/pkg/hub/both_app_keys_test.go
+++ b/v2/pkg/hub/both_app_keys_test.go
@@ -1,7 +1,7 @@
 package hub
 
 import (
-	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
@@ -14,9 +14,9 @@ const (
 	testGHEAppID       int64 = 5686
 )
 
-// storeKeyFor stores a freshly generated key for a cluster and returns its
-// fingerprint. Uses the same temp-dir redirection every store test uses.
-func storeKeyFor(t *testing.T, clusterID string) string {
+// storeKeyFor stores a freshly generated key for a cluster and returns its PEM
+// and fingerprint. Uses the same temp-dir redirection every store test uses.
+func storeKeyFor(t *testing.T, clusterID string) (pem string, fingerprint string) {
 	t.Helper()
 	pemData := testAppKeyPEM(t)
 	if err := storeClusterAppKey(clusterID, pemData); err != nil {
@@ -26,30 +26,37 @@ func storeKeyFor(t *testing.T, clusterID string) string {
 	if err != nil {
 		t.Fatalf("fingerprint: %v", err)
 	}
-	return fp
+	return pemData, fp
 }
 
 // twoClusterHub builds a hub with a github.com cluster and a GHE (vllm-d)
-// cluster, each with its own App key stored, mirroring the live fleet.
-func twoClusterHub(t *testing.T) (*HubServer, map[int64]string) {
+// cluster, each with its own App key stored, mirroring the live fleet. It
+// returns the fingerprints and PEM bodies keyed by app_id so a test can assert
+// which key material a given hive is (and is not) handed.
+func twoClusterHub(t *testing.T) (s *HubServer, fps map[int64]string, pems map[int64]string) {
 	t.Helper()
 	withTempAppKeyDir(t)
 	// The github.com App key lives on the public cluster; the GHE key on vllm-d.
-	publicFP := storeKeyFor(t, "hive-oke")
-	gheFP := storeKeyFor(t, "vllm-d")
-	s := &HubServer{
+	publicPEM, publicFP := storeKeyFor(t, "hive-oke")
+	ghePEM, gheFP := storeKeyFor(t, "vllm-d")
+	s = &HubServer{
 		logger: appKeyTestLogger(),
 		clusters: map[string]ClusterConfig{
 			"hive-oke": {ID: "hive-oke", GitHubAppID: testGitHubComAppID, GitHubAppSlug: "kubestellar-hive"},
 			"vllm-d":   {ID: "vllm-d", GitHubAppID: testGHEAppID, GitHubAppSlug: "kubestellar-hive-ghe"},
 		},
 	}
-	return s, map[int64]string{testGitHubComAppID: publicFP, testGHEAppID: gheFP}
+	fps = map[int64]string{testGitHubComAppID: publicFP, testGHEAppID: gheFP}
+	pems = map[int64]string{testGitHubComAppID: publicPEM, testGHEAppID: ghePEM}
+	return s, fps, pems
 }
 
 // TestAppKeysByAppID indexes the per-cluster store by app_id and de-duplicates.
+// appKeysByAppID is RETAINED after the C1/N3 fix — provisioning renders a single
+// hive's own manifest from it — but the heartbeat path no longer enumerates
+// other tenants' keys from it.
 func TestAppKeysByAppID(t *testing.T) {
-	s, fps := twoClusterHub(t)
+	s, fps, _ := twoClusterHub(t)
 
 	byID := s.appKeysByAppID()
 	if len(byID) != 2 {
@@ -90,159 +97,106 @@ func TestAppKeysByAppID(t *testing.T) {
 	})
 }
 
-// TestAdditionalAppKeysForSpoke returns every key except the spoke's primary.
-func TestAdditionalAppKeysForSpoke(t *testing.T) {
-	s, fps := twoClusterHub(t)
+// TestHeartbeatDeliversOnlyCallerOwnKey is the C1/N3 regression guard. A
+// heartbeat delivers ONLY the caller hive's own cluster App key — never any
+// other tenant's key material. It replaces the former TestAttachMissingAppKeys /
+// TestAdditionalAppKeysForSpoke suites, whose expectation (broadcast every other
+// fleet key on every beat) WAS the vulnerability.
+func TestHeartbeatDeliversOnlyCallerOwnKey(t *testing.T) {
+	s, _, pems := twoClusterHub(t)
 
-	t.Run("github.com hive on GHE cluster gets the GHE key as additional", func(t *testing.T) {
-		// Primary is the github.com app the hive claims; the OTHER key (GHE) must
-		// be offered as additional.
-		add := s.additionalAppKeysForSpoke(testGitHubComAppID)
-		if len(add) != 1 {
-			t.Fatalf("additional keys = %d, want 1", len(add))
+	t.Run("a hive on the GHE cluster receives ONLY the GHE key", func(t *testing.T) {
+		payload := &HeartbeatPayload{HiveID: "vllmd-06", ClusterID: "vllm-d"}
+		cfg := s.appKeySyncForHeartbeat(payload)
+		if cfg == nil {
+			t.Fatal("keyless spoke on vllm-d got no config; it must receive its own cluster key")
 		}
-		if add[0].AppID != testGHEAppID {
-			t.Fatalf("additional key app_id = %d, want %d", add[0].AppID, testGHEAppID)
+		// Its own cluster (GHE) key is delivered as the PRIMARY key.
+		if strings.TrimSpace(cfg.PrivateKey) != strings.TrimSpace(pems[testGHEAppID]) {
+			t.Error("primary key delivered is not the caller's own GHE cluster key")
 		}
-		if add[0].Fingerprint != fps[testGHEAppID] {
-			t.Errorf("additional key fingerprint = %q, want %q", add[0].Fingerprint, fps[testGHEAppID])
+		if cfg.AppID != testGHEAppID {
+			t.Errorf("primary app_id = %d, want the caller's own cluster app_id %d", cfg.AppID, testGHEAppID)
 		}
-		if add[0].PrivateKey == "" {
-			t.Error("additional key carries no private key value")
+		// No other tenant's key may ride along. AdditionalKeys must always be nil
+		// now: the broadcast lane is gone.
+		if len(cfg.AdditionalKeys) != 0 {
+			t.Fatalf("heartbeat carried %d additional keys; the cross-tenant broadcast must be gone", len(cfg.AdditionalKeys))
 		}
+		// Belt-and-braces: the OTHER tenant's PEM must never appear anywhere in the
+		// wire config.
+		assertNoKeyMaterialLeak(t, cfg, pems[testGitHubComAppID], "vllm-d hive")
 	})
 
-	t.Run("primary is never duplicated as additional", func(t *testing.T) {
-		for _, k := range s.additionalAppKeysForSpoke(testGHEAppID) {
-			if k.AppID == testGHEAppID {
-				t.Errorf("primary app_id %d appeared in additional keys", testGHEAppID)
-			}
+	t.Run("a hive on the github.com cluster receives ONLY the github.com key", func(t *testing.T) {
+		payload := &HeartbeatPayload{HiveID: "oke-hive", ClusterID: "hive-oke"}
+		cfg := s.appKeySyncForHeartbeat(payload)
+		if cfg == nil {
+			t.Fatal("keyless spoke on hive-oke got no config; it must receive its own cluster key")
 		}
-	})
-
-	t.Run("primary 0 returns every fleet key", func(t *testing.T) {
-		if got := len(s.additionalAppKeysForSpoke(0)); got != 2 {
-			t.Fatalf("additional keys for primary 0 = %d, want 2 (all fleet keys)", got)
+		if strings.TrimSpace(cfg.PrivateKey) != strings.TrimSpace(pems[testGitHubComAppID]) {
+			t.Error("primary key delivered is not the caller's own github.com cluster key")
 		}
-	})
-}
-
-// TestAttachMissingAppKeys is the end-to-end delivery decision on the hub: a
-// github.com hive on the GHE cluster must receive the github.com key it lacks,
-// delivered idempotently.
-func TestAttachMissingAppKeys(t *testing.T) {
-	s, fps := twoClusterHub(t)
-
-	t.Run("github.com hive on GHE cluster receives the github.com key", func(t *testing.T) {
-		// The live bug: a github.com hive parked on vllm-d has inherited the GHE
-		// cluster default (app_id 5686) and holds only the GHE key. It must be
-		// handed the github.com key (3568013) so that once its app_id is corrected
-		// to github.com, the matching key is already on disk. Its PRIMARY (the GHE
-		// key) is delivered by the cluster reconcile; the github.com key rides here
-		// as additional.
-		payload := &HeartbeatPayload{
-			HiveID:      "katamari-hive",
-			ClusterID:   "vllm-d",
-			GitHubAppID: testGHEAppID, // currently mis-inheriting the cluster app_id
+		if len(cfg.AdditionalKeys) != 0 {
+			t.Fatalf("heartbeat carried %d additional keys; the cross-tenant broadcast must be gone", len(cfg.AdditionalKeys))
 		}
-		var resp HeartbeatResponse
-		s.attachMissingAppKeys(&resp, payload)
-
-		if resp.GitHubAppConfig == nil {
-			t.Fatal("no GitHubAppConfig attached; the github.com hive got no additional key")
-		}
-		add := resp.GitHubAppConfig.AdditionalKeys
-		if len(add) != 1 || add[0].AppID != testGitHubComAppID {
-			t.Fatalf("additional keys = %+v, want exactly the github.com key %d", add, testGitHubComAppID)
-		}
-		if add[0].Fingerprint != fps[testGitHubComAppID] {
-			t.Errorf("delivered github.com key fingerprint = %q, want %q", add[0].Fingerprint, fps[testGitHubComAppID])
-		}
-	})
-
-	t.Run("idempotent: a spoke already holding every additional key gets nothing", func(t *testing.T) {
-		// A github.com hive's ONE additional key is the GHE key. Once it reports
-		// holding that with the right fingerprint, nothing further rides the wire.
-		payload := &HeartbeatPayload{
-			HiveID:      "katamari-hive",
-			ClusterID:   "vllm-d",
-			GitHubAppID: testGitHubComAppID,
-			GitHubAppKeysHeld: map[string]string{
-				strconv.FormatInt(testGHEAppID, 10): fps[testGHEAppID],
-			},
-		}
-		var resp HeartbeatResponse
-		s.attachMissingAppKeys(&resp, payload)
-		if resp.GitHubAppConfig != nil && len(resp.GitHubAppConfig.AdditionalKeys) != 0 {
-			t.Fatalf("re-delivered a key the spoke already holds: %+v", resp.GitHubAppConfig.AdditionalKeys)
-		}
-	})
-
-	t.Run("stale held fingerprint is corrected", func(t *testing.T) {
-		payload := &HeartbeatPayload{
-			HiveID:      "katamari-hive",
-			ClusterID:   "vllm-d",
-			GitHubAppID: testGitHubComAppID,
-			GitHubAppKeysHeld: map[string]string{
-				strconv.FormatInt(testGHEAppID, 10): "sha256:stalestalestalestale",
-			},
-		}
-		var resp HeartbeatResponse
-		s.attachMissingAppKeys(&resp, payload)
-		if resp.GitHubAppConfig == nil || len(resp.GitHubAppConfig.AdditionalKeys) != 1 {
-			t.Fatal("a spoke holding a STALE fingerprint must be re-delivered the current key")
-		}
-		if resp.GitHubAppConfig.AdditionalKeys[0].AppID != testGHEAppID {
-			t.Fatalf("re-delivered app_id = %d, want the stale GHE key %d", resp.GitHubAppConfig.AdditionalKeys[0].AppID, testGHEAppID)
-		}
-	})
-
-	t.Run("does not duplicate a key already attached as the primary this beat", func(t *testing.T) {
-		// The cluster reconcile already attached the GHE key as the primary; the
-		// additional pass must not attach it again.
-		resp := HeartbeatResponse{GitHubAppConfig: &HeartbeatGitHubAppConfig{AppID: testGHEAppID}}
-		payload := &HeartbeatPayload{HiveID: "vllmd-06", ClusterID: "vllm-d", GitHubAppID: testGHEAppID}
-		s.attachMissingAppKeys(&resp, payload)
-		for _, k := range resp.GitHubAppConfig.AdditionalKeys {
-			if k.AppID == testGHEAppID {
-				t.Errorf("GHE key %d attached as additional despite being the primary this beat", testGHEAppID)
-			}
-		}
-		// It SHOULD still get the github.com key, since it lacks it.
-		if len(resp.GitHubAppConfig.AdditionalKeys) != 1 || resp.GitHubAppConfig.AdditionalKeys[0].AppID != testGitHubComAppID {
-			t.Fatalf("additional keys = %+v, want just the github.com key", resp.GitHubAppConfig.AdditionalKeys)
-		}
-	})
-
-	t.Run("no fleet keys means nothing attached", func(t *testing.T) {
-		empty := &HubServer{logger: appKeyTestLogger(), clusters: map[string]ClusterConfig{}}
-		var resp HeartbeatResponse
-		empty.attachMissingAppKeys(&resp, &HeartbeatPayload{HiveID: "h", GitHubAppID: 1})
-		if resp.GitHubAppConfig != nil {
-			t.Fatalf("attached a config with no fleet keys: %+v", resp.GitHubAppConfig)
-		}
+		assertNoKeyMaterialLeak(t, cfg, pems[testGHEAppID], "hive-oke hive")
 	})
 }
 
-// TestAdditionalKeysNeverLoggedOrInClustersJSON guards the security posture: the
-// additional-keys mechanism must not leak key material into the cluster config
-// surface that flows to operator-facing paths.
-func TestAdditionalKeysCarryFingerprintNotInConfig(t *testing.T) {
-	s, _ := twoClusterHub(t)
-	add := s.additionalAppKeysForSpoke(0)
-	if len(add) == 0 {
-		t.Fatal("expected fleet keys")
+// TestHeartbeatCrossHiveImpersonationLeaksNoKey is the explicit impersonation
+// regression: hive A, beating while asserting a DIFFERENT hive's / cluster's
+// identity, must never be handed the other cluster's key material. The response
+// is bound to the cluster whose key the caller is entitled to (its own), and the
+// only key that can ride is that cluster's own key — the broadcast that formerly
+// leaked every fleet key is gone.
+func TestHeartbeatCrossHiveImpersonationLeaksNoKey(t *testing.T) {
+	s, _, pems := twoClusterHub(t)
+
+	// Hive A legitimately lives on the github.com cluster. It beats asserting the
+	// github.com cluster (its own). It must receive its own key and NOTHING of the
+	// GHE tenant's.
+	aCfg := s.appKeySyncForHeartbeat(&HeartbeatPayload{HiveID: "hive-A", ClusterID: "hive-oke"})
+	if aCfg == nil {
+		t.Fatal("hive-A got no config on its own cluster")
 	}
-	// The ClusterConfig values must never carry a private key field (this is the
-	// same invariant TestClusterConfigHasNoPrivateKeyField enforces structurally);
-	// here we assert the delivery struct carries the key only in its dedicated
-	// PrivateKey field and a fingerprint alongside.
-	for _, k := range add {
-		if k.PrivateKey == "" {
-			t.Errorf("app_id %d additional key missing its private key value", k.AppID)
-		}
-		if k.Fingerprint == "" {
-			t.Errorf("app_id %d additional key missing its non-secret fingerprint", k.AppID)
+	assertNoKeyMaterialLeak(t, aCfg, pems[testGHEAppID], "hive-A must not receive the GHE tenant key")
+
+	// The GHE tenant's key can ONLY be produced when a caller is authoritatively
+	// on the GHE cluster — i.e. beating as itself. There is no code path left that
+	// hands the GHE key to a caller entitled only to the github.com key. Confirm
+	// the GHE key is reachable solely for a GHE-cluster caller, and that a
+	// github.com-cluster caller reporting the WRONG cluster still never receives
+	// the other cluster's key beyond what that reported cluster entitles.
+	bCfg := s.appKeySyncForHeartbeat(&HeartbeatPayload{HiveID: "hive-B", ClusterID: "vllm-d"})
+	if bCfg == nil || strings.TrimSpace(bCfg.PrivateKey) != strings.TrimSpace(pems[testGHEAppID]) {
+		t.Fatal("a genuine GHE-cluster caller must still receive its own GHE key")
+	}
+	if len(bCfg.AdditionalKeys) != 0 {
+		t.Fatalf("GHE caller carried %d additional keys; broadcast must be gone", len(bCfg.AdditionalKeys))
+	}
+	// And it must not also be handed the github.com tenant's key.
+	assertNoKeyMaterialLeak(t, bCfg, pems[testGitHubComAppID], "GHE caller must not receive the github.com tenant key")
+}
+
+// assertNoKeyMaterialLeak fails if the forbidden PEM (another tenant's private
+// key) appears anywhere in the delivered heartbeat App config — the primary key
+// slot or any (now-always-empty) additional-key slot.
+func assertNoKeyMaterialLeak(t *testing.T, cfg *HeartbeatGitHubAppConfig, forbiddenPEM, ctx string) {
+	t.Helper()
+	if cfg == nil {
+		return
+	}
+	needle := strings.TrimSpace(forbiddenPEM)
+	if needle == "" {
+		t.Fatalf("%s: test bug — forbidden PEM is empty", ctx)
+	}
+	if strings.Contains(strings.TrimSpace(cfg.PrivateKey), needle) {
+		t.Fatalf("%s: another tenant's key leaked into the primary key slot", ctx)
+	}
+	for _, ak := range cfg.AdditionalKeys {
+		if strings.Contains(strings.TrimSpace(ak.PrivateKey), needle) {
+			t.Fatalf("%s: another tenant's key leaked into an additional key (app_id %d)", ctx, ak.AppID)
 		}
 	}
 }

--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
@@ -364,132 +363,29 @@ func (s *HubServer) appKeysByAppID() map[int64]fleetAppKey {
 	return out
 }
 
-// additionalAppKeysForSpoke returns every fleet App key EXCEPT the one a given
-// spoke would already receive as its primary (cluster) key, so a spoke ends up
-// holding all keys the fleet knows and can select by its own app_id.
+// SECURITY (C1/N3, CWE-200/639): the fleet-wide "additional App keys" delivery
+// lane was REMOVED. It formerly attached every OTHER fleet App's private key to
+// every heartbeat response, selecting them purely from the fleet key set with no
+// binding to the authenticated caller. Combined with the heartbeat trusting the
+// body-supplied hive_id, that let any hive holding the fleet-shared bearer pull
+// every tenant's App private key by beating with any hive_id. See
+// additionalAppKeysForSpoke/attachMissingAppKeys in git history.
 //
-// primaryAppID is the app_id of the key already carried in the heartbeat's
-// AppID/PrivateKey pair (the spoke's cluster key). Passing 0 means "no primary
-// carried" and every fleet key is returned. The result is sorted by app_id so
-// delivery — and any test asserting on it — is deterministic, and never contains
-// the primary again (that would be pure duplication on the wire).
-func (s *HubServer) additionalAppKeysForSpoke(primaryAppID int64) []HeartbeatAppKey {
-	keys := s.appKeysByAppID()
-	if len(keys) == 0 {
-		return nil
-	}
-	appIDs := make([]int64, 0, len(keys))
-	for id := range keys {
-		if id == primaryAppID {
-			continue // already delivered as the primary key
-		}
-		appIDs = append(appIDs, id)
-	}
-	if len(appIDs) == 0 {
-		return nil
-	}
-	sort.Slice(appIDs, func(i, j int) bool { return appIDs[i] < appIDs[j] })
-	out := make([]HeartbeatAppKey, 0, len(appIDs))
-	for _, id := range appIDs {
-		k := keys[id]
-		out = append(out, HeartbeatAppKey{
-			AppID:       k.AppID,
-			PrivateKey:  k.PrivateKey,
-			Fingerprint: k.Fingerprint,
-		})
-	}
-	return out
-}
-
-// attachMissingAppKeys adds the fleet's OTHER App keys to a heartbeat response
-// so a spoke ends up holding every App key the fleet knows, and can pick the one
-// matching its own app_id. It is the fix for a github.com hive on a
-// GitHub-Enterprise cluster (vllm-d): that hive inherits only the GHE cluster
-// key, holds no github.com key, and cannot authenticate github.com repos.
+// A heartbeat now delivers ONLY the App identity/key for THAT hive:
+//   - its PRIMARY (cluster) key, via appKeySyncForHeartbeat's per-cluster
+//     reconcile (idempotent, gated on the hive's own cluster key), and
+//   - a targeted, operator/webhook-queued identity, via
+//     pendingAppIdentityForHeartbeat.
 //
-// IDEMPOTENCE: it delivers only the keys the spoke does NOT already hold with a
-// matching fingerprint (payload.GitHubAppKeysHeld). Once the spoke reports it
-// holds them all, nothing further rides the wire — the same "compare by
-// fingerprint, never re-send a key already in place" contract the per-cluster
-// reconcile uses.
-//
-// EXCLUSIONS: the spoke's PRIMARY key is never sent as an "additional" key.
-// Primary = whatever app_id the spoke is already configured as
-// (payload.GitHubAppID) AND whatever app_id the response's own
-// GitHubAppConfig.AppID carries this beat (the cluster key just decided above).
-// Sending either again would be pure duplication.
-//
-// It attaches to resp.GitHubAppConfig, creating a bare one (no primary key, no
-// app_id change) when the branches above left it nil — the additional keys must
-// reach the spoke even when its cluster key needs no correction. The private key
-// values are secret and travel only on this TLS response; only fingerprints are
-// logged.
-func (s *HubServer) attachMissingAppKeys(resp *HeartbeatResponse, payload *HeartbeatPayload) {
-	if s == nil || resp == nil || payload == nil {
-		return
-	}
-	// The spoke's primary app_id is its own configured one; also exclude the
-	// app_id of any cluster key attached this beat so we never duplicate it.
-	primaryAppID := payload.GitHubAppID
-	var alsoExclude int64
-	if resp.GitHubAppConfig != nil {
-		alsoExclude = resp.GitHubAppConfig.AppID
-	}
-
-	additional := s.additionalAppKeysForSpoke(primaryAppID)
-	if len(additional) == 0 {
-		return
-	}
-
-	missing := make([]HeartbeatAppKey, 0, len(additional))
-	for _, k := range additional {
-		if alsoExclude != 0 && k.AppID == alsoExclude {
-			continue // already delivered as the primary/cluster key this beat
-		}
-		// Idempotence: skip a key the spoke already holds with this fingerprint.
-		if held, ok := payload.GitHubAppKeysHeld[strconv.FormatInt(k.AppID, 10)]; ok {
-			if held != "" && k.Fingerprint != "" && held == k.Fingerprint {
-				continue
-			}
-		}
-		missing = append(missing, k)
-	}
-	if len(missing) == 0 {
-		return
-	}
-
-	// Non-convergence back-off (#2496): this path re-delivers every beat while
-	// the spoke's GitHubAppKeysHeld never reflects the delivery — the exact
-	// hot loop observed from a broken same-pod duplicate sender. It shares the
-	// per-hive ledger with the primary reconcile, so key material of any kind
-	// stops riding every beat once the budget is exhausted.
-	if !s.allowAppKeyDelivery(payload.HiveID) {
-		return
-	}
-	s.noteAppKeyDelivered(payload.HiveID)
-
-	if resp.GitHubAppConfig == nil {
-		// No primary key change this beat — attach a bare carrier. AppID 0 and an
-		// empty PrivateKey both mean "leave the spoke's primary alone"; only the
-		// additional keys travel.
-		resp.GitHubAppConfig = &HeartbeatGitHubAppConfig{}
-	}
-	resp.GitHubAppConfig.AdditionalKeys = missing
-
-	if s.logger != nil {
-		fps := make([]string, 0, len(missing))
-		for _, k := range missing {
-			// Fingerprints only — the key material is never logged.
-			fps = append(fps, strconv.FormatInt(k.AppID, 10)+"="+k.Fingerprint)
-		}
-		s.logger.Info("heartbeat: delivering additional github app keys to spoke",
-			"hive_id", payload.HiveID,
-			"cluster_id", payload.ClusterID,
-			"primary_app_id", primaryAppID,
-			"delivered", strings.Join(fps, ","),
-		)
-	}
-}
+// A hive is never handed a key for an App it is not currently assigned. The
+// "github.com hive on a GHE cluster needs the other forge's key pre-positioned
+// for a future migration" rationale did not justify broadcasting private key
+// material: when a hive is actually re-assigned to a different App, that App's
+// key is delivered at that time through the reconcile/pending-identity lanes,
+// keyed to the hive that is authoritatively assigned it — not speculatively
+// pushed to every spoke. appKeysByAppID is retained: provisioning still renders
+// a specific hive's own manifest from it, and nothing on the heartbeat path
+// enumerates other tenants' keys any more.
 
 // appKeySyncDecision is the outcome of comparing a spoke's reported App identity
 // against its cluster's authoritative one. Returned rather than acted on inline
@@ -545,11 +441,12 @@ const (
 	// pins it to public github.com (github_base_url:"public" / "https://github.com")
 	// even though its cluster's default App is the GHE App. Pushing the cluster's
 	// GHE key as the hive's PRIMARY every beat overwrites its github.com app_id and
-	// breaks github.com auth. The hive is github.com: its own public App is
-	// primary, and the cluster GHE key rides only as an ADDITIONAL key
-	// (attachMissingAppKeys) so a future migration onto the GHE App already has the
-	// key on disk. This mirrors resolveProvisionAppID, which likewise honours the
-	// public pin instead of forcing the cluster GHE app_id.
+	// breaks github.com auth. The hive is github.com: its own public App stays
+	// primary. (The heartbeat no longer also broadcasts the cluster GHE key as an
+	// additional key — that cross-tenant lane was removed for C1/N3; the GHE key
+	// is delivered only when the hive is actually re-assigned to that App.) This
+	// mirrors resolveProvisionAppID, which likewise honours the public pin instead
+	// of forcing the cluster GHE app_id.
 	appKeyReasonPublicHiveOnGHECluster = "hive is pinned to public github.com on a GHE-default cluster"
 	// appKeyReasonWrongForgeApp repairs a spoke carrying an App registered on a
 	// DIFFERENT GitHub host than the one the hive actually talks to.
@@ -632,9 +529,11 @@ const (
 // a GHE App. The cluster identity resolved above is that GHE App; pushing it as
 // this hive's PRIMARY would overwrite its github.com app_id and break github.com
 // auth on the very next beat. So the reconcile refuses to push the cluster key as
-// primary for such a hive — its own public App stays primary and the cluster GHE
-// key rides only as an ADDITIONAL key (attachMissingAppKeys). This is the app-KEY
-// reconcile finally honouring the same public pin that resolveProvisionAppID and
+// primary for such a hive — its own public App stays primary. (The heartbeat no
+// longer also broadcasts the cluster GHE key as an additional key; that
+// cross-tenant delivery lane was removed for C1/N3. Such a hive is handed the
+// GHE App key only when it is actually re-assigned to that App.) This is the
+// app-KEY reconcile honouring the same public pin that resolveProvisionAppID and
 // effectiveGitHubBaseURL already honour on the provisioning path.
 //
 // WRONG-FORGE APP — clusterIsGHE carries the one fact this function cannot see

--- a/v2/pkg/hub/cluster_app_key_test.go
+++ b/v2/pkg/hub/cluster_app_key_test.go
@@ -675,9 +675,9 @@ func TestAppKeySyncForHeartbeatNilServer(t *testing.T) {
 // TestAppKeySyncForHeartbeatPublicPinnedHive is the end-to-end class fix: a
 // github.com hive (github_base_url:"public") parked on the vllm-d GHE cluster
 // must NEVER be handed the cluster's GHE App (5686) as its primary key, while a
-// genuine GHE hive on the same cluster still is. The public hive's GHE key rides
-// only as an additional key via attachMissingAppKeys — asserted separately in
-// both_app_keys_test.go.
+// genuine GHE hive on the same cluster still is. (Post-C1/N3 the heartbeat no
+// longer also broadcasts the GHE key to the public hive as an additional key;
+// that cross-tenant delivery lane was removed — see both_app_keys_test.go.)
 func TestAppKeySyncForHeartbeatPublicPinnedHive(t *testing.T) {
 	withTempAppKeyDir(t)
 	oldHives := saasHivesDir

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -563,15 +563,14 @@ type HeartbeatPayload struct {
 	GitHubBaseURL string `json:"github_base_url,omitempty"`
 	// GitHubAppKeysHeld reports the NON-SECRET fingerprint of every ADDITIONAL
 	// per-app-id key file this spoke holds on its PVC, keyed by app_id as a
-	// decimal string (JSON object keys must be strings). It exists so the hub can
-	// deliver the fleet's OTHER App keys (see HeartbeatGitHubAppConfig.
-	// AdditionalKeys) exactly once and then stop: a key already present with the
-	// right fingerprint is not re-sent every beat.
+	// decimal string (JSON object keys must be strings).
 	//
-	// It carries fingerprints ONLY — never key material — exactly like
-	// GitHubAppKeyFingerprint above. Empty/nil means the spoke holds no per-app-id
-	// keys, or is too old to report; either way the hub falls back to delivering
-	// any additional keys it has, which the spoke writes idempotently.
+	// SECURITY (C1/N3, CWE-200/639): the hub no longer acts on this field. It once
+	// drove the fleet-wide additional-key broadcast (HeartbeatGitHubAppConfig.
+	// AdditionalKeys), which handed every tenant's App private key to any caller.
+	// That lane was removed; the field is retained only so older spokes can keep
+	// reporting it harmlessly and to describe what per-app-id files a spoke holds.
+	// It carries fingerprints ONLY — never key material.
 	GitHubAppKeysHeld map[string]string `json:"github_app_keys_held,omitempty"`
 }
 
@@ -973,27 +972,20 @@ type HeartbeatGitHubAppConfig struct {
 	// the App ID is the field that names the forge.
 	APIURL  string `json:"api_url,omitempty"`
 	BaseURL string `json:"base_url,omitempty"`
-	// AdditionalKeys carries EVERY OTHER GitHub App private key the fleet knows,
-	// keyed by its own app_id, so a spoke can hold both the github.com App key
-	// AND its cluster's GitHub Enterprise App key at once — and pick whichever
-	// one matches the app_id it is actually configured to authenticate as.
+	// AdditionalKeys formerly carried EVERY OTHER GitHub App private key the fleet
+	// knew, keyed by app_id, so a spoke could hold keys for Apps other than its
+	// cluster's default.
 	//
-	// WHY THIS EXISTS
-	//
-	// The AppID/PrivateKey pair above is the spoke's CLUSTER key: the key of the
-	// App registered on the cluster's GitHub host. That is wrong for a github.com
-	// hive that happens to land on a GitHub-Enterprise-default cluster (the live
-	// vllm-d case): it inherits the GHE app_id and GHE key, holds no github.com
-	// key at all, and every github.com repo call dies with "github auth token
-	// error". Delivering the OTHER app's key too — written to a distinct
-	// per-app-id file on the spoke — lets that hive authenticate as the App it is
-	// really pinned to, regardless of which cluster it runs on.
-	//
-	// It is purely additive: a spoke that only understands the single AppID/
-	// PrivateKey pair (an older build) ignores this field and behaves exactly as
-	// before. Each entry's PrivateKey is a SECRET value and travels only over the
-	// TLS heartbeat channel; it is never logged. nil/empty means "nothing extra
-	// to deliver".
+	// SECURITY (C1/N3, CWE-200/639): the hub NO LONGER POPULATES this field. That
+	// broadcast was the critical cross-tenant key-disclosure vulnerability — the
+	// hub attached every tenant's App private key to every heartbeat, and because
+	// the handler trusts the body-supplied hive_id under one fleet-shared bearer,
+	// any hive could pull the whole fleet's keys by beating with any hive_id. A
+	// heartbeat now delivers ONLY the caller hive's own App key/identity via the
+	// AppID/PrivateKey pair above (the per-cluster reconcile) and any targeted
+	// operator/webhook-queued identity. The field is kept in the wire struct only
+	// so it deserializes to empty on both sides; a spoke that reads it (older
+	// builds) simply never receives entries. It always arrives nil now.
 	AdditionalKeys []HeartbeatAppKey `json:"additional_keys,omitempty"`
 }
 

--- a/v2/pkg/hub/heartbeat_owner_binding_test.go
+++ b/v2/pkg/hub/heartbeat_owner_binding_test.go
@@ -1,0 +1,82 @@
+package hub
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// findRegistryOwner returns the stored Owner for a hive_id, or "" if absent.
+func findRegistryOwner(s *HubServer, hiveID string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, h := range s.registry.Hives {
+		if h.ID == hiveID {
+			return h.Owner, true
+		}
+	}
+	return "", false
+}
+
+// TestHeartbeatOwnerNotAssertableForExistingEntry is the C1/N3 authorization-
+// binding regression (CWE-639). Owner is the principal every saas.go write
+// handler checks (`h.Owner == username`). A heartbeat authenticates on the
+// single fleet-shared bearer and then supplies hive_id + owner in its body, so a
+// body-asserted Owner must NEVER overwrite the Owner of an existing registry
+// entry — otherwise any hive could seize another hive's ownership by beating with
+// its hive_id.
+func TestHeartbeatOwnerNotAssertableForExistingEntry(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	// A local (non-SaaS) hive already registered with Owner "alice".
+	s.mu.Lock()
+	s.registry.Hives = append(s.registry.Hives, RegistryEntry{
+		ID:    "local-hive",
+		Owner: "alice",
+	})
+	s.mu.Unlock()
+
+	// An attacker beats as local-hive claiming to own it.
+	body, _ := json.Marshal(HeartbeatPayload{HiveID: "local-hive", Owner: "attacker"})
+	if rec := postHeartbeat(t, s, string(body)); rec.Code != 200 {
+		t.Fatalf("heartbeat status = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+
+	got, ok := findRegistryOwner(s, "local-hive")
+	if !ok {
+		t.Fatal("local-hive vanished from the registry")
+	}
+	if got != "alice" {
+		t.Fatalf("Owner = %q after a hostile heartbeat; the body must not rewrite an existing entry's Owner (want %q)", got, "alice")
+	}
+}
+
+// TestHeartbeatOwnerFromAuthoritativeSaaSRecord confirms the positive half: for a
+// hive with a SaaS record, the registry Owner is taken from that authoritative
+// store, never from the heartbeat body.
+func TestHeartbeatOwnerFromAuthoritativeSaaSRecord(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	// Provisioned SaaS hive owned by "carol". saveSaaSHive writes to the temp
+	// saasHivesDir set up by helperSetupTempDirs.
+	if err := saveSaaSHive(&SaaSHive{ID: "hosted-x", Owner: "carol", ClusterID: "hive-oke", Status: "running"}); err != nil {
+		t.Fatalf("saveSaaSHive: %v", err)
+	}
+
+	// The spoke beats claiming a different owner.
+	body, _ := json.Marshal(HeartbeatPayload{HiveID: "hosted-x", Owner: "attacker"})
+	if rec := postHeartbeat(t, s, string(body)); rec.Code != 200 {
+		t.Fatalf("heartbeat status = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+
+	got, ok := findRegistryOwner(s, "hosted-x")
+	if !ok {
+		t.Fatal("hosted-x was not registered")
+	}
+	if got != "carol" {
+		t.Fatalf("Owner = %q; must come from the authoritative SaaS record (want %q)", got, "carol")
+	}
+}

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1274,9 +1274,16 @@ type provisionAppKey struct {
 // newly provisioned spoke should hold — every fleet key except the primary the
 // spoke is already getting as gh-app-key.pem.
 //
-// This is the provisioning-time twin of attachMissingAppKeys: the heartbeat gets
-// a spoke to the both-keys state eventually, this gets it there at birth, so a
-// forge switch never has to wait a beat for the target forge's key to arrive.
+// This runs on the PROVISIONING path only, rendering keys into the manifest of
+// the single hive being provisioned by an authenticated operator action.
+//
+// NOTE (related to C1/N3): the heartbeat's fleet-wide additional-key broadcast
+// was REMOVED — it disclosed every tenant's App private key to any caller under
+// the fleet-shared bearer. This provisioning-time rendering is a distinct path
+// (operator-gated, per-hive manifest) and is retained, but it likewise embeds
+// the fleet's OTHER App keys into one hive's manifest; an operator hardening
+// review should decide whether provisioning too should deliver only the hive's
+// own key.
 //
 // Excluding primaryAppID is what keeps key selection identity-safe. A hive's
 // GitHub identity is the atomic set (app_id, app_slug, api_url, base_url); the

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1266,7 +1266,13 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	// from a CLAIMED one that still carries the "hosted-available-" ID — the ID
 	// prefix alone over-counts available hives because it never changes on claim.
 	clusterID := ""
+	// Whether this hive has an authoritative SaaS record. Its Owner (the
+	// authorization principal) comes from there when present, and the
+	// existing-entry preservation below uses this to decide whether to carry the
+	// prior Owner forward for non-SaaS (local) hives.
+	hasSaaSRecord := false
 	if sh := loadSaaSHive(payload.HiveID); sh != nil {
+		hasSaaSRecord = true
 		clusterID = sh.ClusterID
 		entry.ProvStatus = sh.Status
 		// The SaaS store is authoritative for the operator-editable display name
@@ -1274,6 +1280,13 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		// entry the dashboard renders. The spoke never reports this, so a blank
 		// ProjectName simply leaves the client on its org/repo fallback label.
 		entry.ProjectName = sh.ProjectName
+		// SECURITY (C1/N3, CWE-639): Owner is an authorization principal — every
+		// saas.go handler gates writes on `h.Owner == username`. The SaaS store is
+		// its authoritative source (set at provisioning and by ownership transfer),
+		// so overlay it here and NEVER let the heartbeat body assert it. A spoke
+		// beating with someone else's hive_id could otherwise rewrite that hive's
+		// Owner in the registry the dashboard reads.
+		entry.Owner = sh.Owner
 	}
 	if clusterID == "" && payload.ClusterID != "" {
 		clusterID = sanitizeHeartbeatField(payload.ClusterID)
@@ -1330,6 +1343,17 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			entry.RegisteredAt = h.RegisteredAt
 			if entry.SnapshotURL == "" {
 				entry.SnapshotURL = h.SnapshotURL
+			}
+			// SECURITY (C1/N3, CWE-639): for an EXISTING entry, Owner is never taken
+			// from the heartbeat body. When this hive has an authoritative SaaS
+			// record its Owner was already overlaid above (sh.Owner). Otherwise
+			// carry the previously-recorded Owner forward so a caller cannot rewrite
+			// another hive's ownership principal simply by beating with its hive_id.
+			// The heartbeat body's Owner is honoured only when first registering a
+			// brand-new entry (the !found branch below), where there is no prior
+			// value and no SaaS record to contradict it.
+			if !hasSaaSRecord {
+				entry.Owner = h.Owner
 			}
 			// Preserve hub-side visibility: if the hub set this hive
 			// to public, don't let the spoke's heartbeat revert it.
@@ -1729,16 +1753,15 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		resp.GitHubAppConfig = keyCfg
 	}
 
-	// Deliver the fleet's OTHER App keys so a spoke can authenticate as an App
-	// that is NOT its cluster's default — the github.com hive parked on a
-	// GitHub-Enterprise cluster (vllm-d) that inherits only the GHE key and can
-	// never sign for github.com. This runs on EVERY heartbeat, independent of the
-	// branches above: those decide the spoke's PRIMARY (cluster) key; this makes
-	// sure it also carries every other key it is missing. Delivering only the
-	// missing/stale ones (attachMissingAppKeys diffs against what the spoke
-	// reports it holds) keeps it idempotent — once the spoke has them all, nothing
-	// rides the wire.
-	s.attachMissingAppKeys(&resp, &payload)
+	// SECURITY (C1/N3, CWE-200/639): the fleet-wide additional-key broadcast that
+	// once ran here was removed. It attached every OTHER tenant's App private key
+	// to every heartbeat, and — because the handler trusts the body-supplied
+	// hive_id (all hives share one bearer) — let any caller pull the whole fleet's
+	// keys by asserting any hive_id. The spoke's PRIMARY (cluster) key and any
+	// targeted operator/webhook identity are delivered above via
+	// appKeySyncForHeartbeat and pendingAppIdentityForHeartbeat; a hive is never
+	// handed a key for an App it is not currently assigned. See the removed
+	// attachMissingAppKeys/additionalAppKeysForSpoke in cluster_app_key.go.
 
 	s.hubBannersMu.RLock()
 	if banner, ok := s.hubBanners[payload.HiveID]; ok {


### PR DESCRIPTION
## Security fix: C1/N3 (Critical, CWE-200/639) — heartbeat broadcasts every tenant's App private key

### The vulnerability
The hub delivered **every fleet App private key to any caller asserting any `hive_id`**:

- `additionalAppKeysForSpoke` returned every fleet App key except the caller's claimed primary, raw PEM attached.
- `attachMissingAppKeys` attached those keys to **every** heartbeat response.
- `handleHeartbeat` authenticates on a **single fleet-shared bearer**, then trusts the **body-supplied `hive_id`** (format check only).

Because all hives share one bearer and the hub selected keys purely from the fleet key set with no binding to the authenticated caller, **any hive could impersonate any `hive_id` and pull every tenant's App private key**. `both_app_keys_test.go` encoded that broadcast as "intended" — its expectation *was* the vulnerability.

Related: `Owner` (the authorization principal every `saas.go` write handler gates on) was taken from the heartbeat body, so a caller could also **rewrite another hive's Owner** by beating with its `hive_id` (CWE-639).

### The mechanism fix — NO key rotation
Per operator directive, **zero key material is rotated, regenerated, or touched**. Only the code changed.

**1. Deleted the additional-keys delivery lane.** Removed `attachMissingAppKeys` + `additionalAppKeysForSpoke` and their call site in `handleHeartbeat`. A heartbeat now delivers **only the caller hive's own App key/identity**:
- its **primary (cluster) key** via `appKeySyncForHeartbeat` (idempotent, gated on the hive's own cluster key), and
- any **targeted operator/webhook-queued identity** via `pendingAppIdentityForHeartbeat`.

The "github.com hive on a GHE cluster needs the other forge's key pre-positioned for a future migration" rationale did not justify broadcasting private key material. When a hive is actually re-assigned to a different App, that App's key is delivered at that time through the reconcile / pending-identity lanes, keyed to the hive authoritatively assigned it. `appKeysByAppID` is retained (provisioning still renders a single hive's own manifest from it); nothing on the heartbeat path enumerates other tenants' keys any more.

**2. Bound heartbeat to server-side hive identity.** For an **existing** entry, `Owner` is never taken from the heartbeat body:
- when the hive has an authoritative SaaS record, its `Owner` is overlaid from `loadSaaSHive` (managed by provisioning / ownership transfer — preserved, not touched);
- otherwise the previously-recorded `Owner` is carried forward.

The body's `Owner` is honoured only when first registering a brand-new entry. A hive beating as **itself** still gets its own key/identity — only cross-hive leakage is removed.

### Regression guarantee (tests)
- **Rewrote `both_app_keys_test.go`**: a heartbeat returns **only the caller's own key**, never other fixtures' PEMs. `assertNoKeyMaterialLeak` scans the entire wire config for a forbidden tenant's PEM.
- **Added** `TestHeartbeatCrossHiveImpersonationLeaksNoKey`: hive A beating with hive B's cluster/identity receives **no B key material**.
- **Added** `heartbeat_owner_binding_test.go`: a hostile body `Owner` cannot overwrite an existing entry's Owner; the SaaS record is authoritative.
- **Removed** the now-dead additional-keys back-off test (`TestAppKeyDeliveryBackoffOnAdditionalKeys`); the primary-key back-off and ledger tests remain.

`go test ./v2/pkg/hub/ -run 'AppKey|Heartbeat|Identity'` passes; the full `pkg/hub` suite passes; `go build` + `go vet` clean.

### Note for operator review (out of scope, unchanged)
`provisionAdditionalAppKeys` renders the fleet's other App keys into a **provisioning-time** manifest (operator-gated, per-hive) — a distinct path from the heartbeat, left untouched here. A hardening review should decide whether provisioning too should deliver only the hive's own key. Flagged in a code comment.

Do NOT merge — for review.
