### PR TITLE
fix(sec): per-hive authorization for hosted terminal (C3, CWE-862)

### DIFF
--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -2243,6 +2243,17 @@ spec:
           value: "{{.SessionKey}}"
         - name: HIVE_SSO_KEY
           value: "{{.SSOKey}}"
+{{- if .IsNginxIngress}}
+        # HIVE_INGRESS_AUTHZ tells the Node proxy that an nginx ingress
+        # auth-proxy sits IN FRONT of this pod and per-hive-authorizes every
+        # /terminal request (auth-url=auth-check?hive={{.ID}}) before it ever
+        # reaches the proxy. Only set on the nginx lane. On the OpenShift-Route
+        # lane there is NO auth-proxy — the Route forwards straight to the pod —
+        # so this is unset and the proxy is the ONLY per-hive gate, which makes
+        # it fail CLOSED on an empty allowlist (see server.js). SECURITY (C3).
+        - name: HIVE_INGRESS_AUTHZ
+          value: "true"
+{{- end}}
 {{- if .AuthorizedUsers}}
         - name: HIVE_AUTHORIZED_USERS
           value: "{{.AuthorizedUsers}}"

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -2372,6 +2372,16 @@ metadata:
     cert-manager.io/cluster-issuer: {{.CertIssuer}}
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    # SECURITY (CWE-862, finding C3): the terminal opens a live shell inside a
+    # credential-holding pod, so it MUST enforce the SAME per-hive authorization
+    # the main ingress does — not merely "is the caller a signed-in hub user".
+    # Without this auth-url, any GitHub account that completes hub OAuth (the
+    # shared .hive.kubestellar.io cookie) reaches ANY tenant's /terminal. The
+    # auth-check endpoint verifies the caller against THIS hive's authorized
+    # users (user.Hives[{{.ID}}]) and 403s a user with no access to this hive.
+    nginx.ingress.kubernetes.io/auth-url: "https://hive.kubestellar.io/api/saas/auth-check?hive={{.ID}}&uri=$request_uri"
+    nginx.ingress.kubernetes.io/auth-signin: "https://hive.kubestellar.io/login?redirect=$scheme://$http_host$request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Hive-User,X-Hive-Role,X-Hive-Proxy-Auth"
 spec:
   ingressClassName: {{.IngressClass}}
   rules:

--- a/v2/pkg/hub/saas_provision_terminal_authz_test.go
+++ b/v2/pkg/hub/saas_provision_terminal_authz_test.go
@@ -1,0 +1,97 @@
+package hub
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"text/template"
+)
+
+// renderManifestForTest renders k8sManifestTemplate with the minimal data set
+// the ingress blocks need. It mirrors the real data map in provisionHive but
+// keeps only the keys the ingress/route sections reference, so the test pins
+// template output without pulling in cluster/OCI plumbing.
+func renderManifestForTest(t *testing.T, nginx bool) string {
+	t.Helper()
+	tmpl, err := template.New("manifests").Parse(k8sManifestTemplate)
+	if err != nil {
+		t.Fatalf("template parse: %v", err)
+	}
+	data := map[string]interface{}{
+		"ID":               "hosted-hive-x",
+		"Namespace":        "hive-hosted-hosted-hive-x",
+		"DashboardHost":    "hosted-hive-x.hive.kubestellar.io",
+		"DashboardPort":    8080,
+		"TerminalPort":     7681,
+		"CertIssuer":       "letsencrypt",
+		"IngressClass":     "nginx",
+		"IsNginxIngress":   nginx,
+		"IsOpenShiftRoute": !nginx,
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("template exec: %v", err)
+	}
+	return buf.String()
+}
+
+// docBlocks splits a multi-document YAML string into its individual documents.
+func docBlocks(manifest string) []string {
+	return strings.Split(manifest, "\n---\n")
+}
+
+// terminalIngressBlock returns the nginx Ingress document named "hive-terminal"
+// (NOT the OpenShift Route of the same name, which is guarded by kind:).
+func terminalIngressBlock(t *testing.T, manifest string) string {
+	t.Helper()
+	for _, block := range docBlocks(manifest) {
+		if strings.Contains(block, "kind: Ingress") &&
+			strings.Contains(block, "name: hive-terminal") {
+			return block
+		}
+	}
+	t.Fatalf("no nginx Ingress named hive-terminal found in rendered manifest")
+	return ""
+}
+
+// TestTerminalIngressHasPerHiveAuthCheck is the finding C3 template-level guard:
+// the hive-terminal nginx Ingress MUST carry the same per-hive auth-url the main
+// "hive" Ingress does, scoped to THIS hive's ID. Without it, /terminal is
+// authenticated hub-wide but authorized for no specific hive (CWE-862): any hub
+// user reaches any tenant's shell.
+func TestTerminalIngressHasPerHiveAuthCheck(t *testing.T) {
+	manifest := renderManifestForTest(t, true /* nginx */)
+	block := terminalIngressBlock(t, manifest)
+
+	wantAuthURL := `nginx.ingress.kubernetes.io/auth-url: "https://hive.kubestellar.io/api/saas/auth-check?hive=hosted-hive-x&uri=$request_uri"`
+	if !strings.Contains(block, wantAuthURL) {
+		t.Errorf("hive-terminal ingress missing per-hive auth-url annotation.\nwant substring:\n  %s\ngot block:\n%s", wantAuthURL, block)
+	}
+
+	// The auth-signin (login redirect) and the response-header passthrough must
+	// also be present so an unauthenticated caller is redirected to login and the
+	// spoke receives the resolved user/role/proxy-auth on success — matching the
+	// main ingress.
+	for _, want := range []string{
+		`nginx.ingress.kubernetes.io/auth-signin: "https://hive.kubestellar.io/login?redirect=$scheme://$http_host$request_uri"`,
+		`nginx.ingress.kubernetes.io/auth-response-headers: "X-Hive-User,X-Hive-Role,X-Hive-Proxy-Auth"`,
+	} {
+		if !strings.Contains(block, want) {
+			t.Errorf("hive-terminal ingress missing annotation:\n  %s", want)
+		}
+	}
+}
+
+// TestMainAndTerminalIngressAuthURLMatch pins that the terminal ingress uses the
+// SAME hive-scoped auth-url as the main ingress (both key off {{.ID}}), so the
+// two can never drift into authorizing different hives.
+func TestMainAndTerminalIngressAuthURLMatch(t *testing.T) {
+	manifest := renderManifestForTest(t, true /* nginx */)
+
+	authURL := `nginx.ingress.kubernetes.io/auth-url: "https://hive.kubestellar.io/api/saas/auth-check?hive=hosted-hive-x&uri=$request_uri"`
+	// It must appear at least twice: once on the main "hive" ingress, once on
+	// "hive-terminal".
+	if got := strings.Count(manifest, authURL); got < 2 {
+		t.Errorf("expected per-hive auth-url on BOTH main and terminal ingress (>=2 occurrences), got %d", got)
+	}
+}

--- a/v2/pkg/hub/saas_provision_terminal_authz_test.go
+++ b/v2/pkg/hub/saas_provision_terminal_authz_test.go
@@ -95,3 +95,23 @@ func TestMainAndTerminalIngressAuthURLMatch(t *testing.T) {
 		t.Errorf("expected per-hive auth-url on BOTH main and terminal ingress (>=2 occurrences), got %d", got)
 	}
 }
+
+// TestIngressAuthzEnvIsPlatformAware pins the HIVE_INGRESS_AUTHZ env flag that
+// lets the Node proxy fail CLOSED on an empty allowlist WITHOUT breaking nginx:
+//   - nginx lane: the flag is set ("true") because an ingress auth-proxy gates
+//     /terminal, so the proxy may defer on an empty allowlist.
+//   - OpenShift-Route lane: NO ingress auth-proxy, so the flag is absent and the
+//     proxy is the only gate → empty allowlist fails closed. (finding C3)
+func TestIngressAuthzEnvIsPlatformAware(t *testing.T) {
+	const flag = "name: HIVE_INGRESS_AUTHZ"
+
+	nginx := renderManifestForTest(t, true /* nginx */)
+	if !strings.Contains(nginx, flag) {
+		t.Errorf("nginx lane must set HIVE_INGRESS_AUTHZ so the proxy defers to the ingress on an empty allowlist")
+	}
+
+	openshift := renderManifestForTest(t, false /* OpenShift Route */)
+	if strings.Contains(openshift, flag) {
+		t.Errorf("OpenShift-Route lane must NOT set HIVE_INGRESS_AUTHZ — the proxy is the only per-hive gate and must fail closed on an empty allowlist")
+	}
+}

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -40,6 +40,74 @@ const SESSION_KEY = deriveSessionKey();
 // hub cookie rather than a shared dashboard token.
 const IS_HOSTED = SESSION_KEY !== '';
 
+// HIVE_ID is this spoke's own hive identity, injected by the hub at provision
+// time (mirrors the HIVE_ID env the Go dashboard reads). It is the anchor for
+// per-hive terminal authorization: a hub-user cookie is authenticated hub-wide
+// (the `hive_hub_user` cookie is scoped to .hive.kubestellar.io, so ANY hive's
+// domain receives it), so the signature check alone proves only "some hub user",
+// never "a user allowed on THIS hive".
+const HIVE_ID = process.env.HIVE_ID || '';
+
+// HIVE_AUTHORIZED_USERS is this hive's per-hive allowlist, injected by the hub
+// (authorizedUsersForHive): a comma-separated list of `username` or
+// `username:role` entries (owner + everyone with this hive in their SaaS
+// Hives map). It is the proxy's INDEPENDENT, per-hive authorization source —
+// the one defense that also holds on OpenShift Routes, which have no nginx
+// auth-proxy in front of the pod to call /api/saas/auth-check.
+//
+// SECURITY (CWE-862, finding C3): without a per-hive check, one cookie from any
+// free GitHub account that completed hub OAuth opened a shell in EVERY tenant's
+// pod. We parse the allowlist into a lowercase username set (GitHub logins are
+// case-insensitive) and require the verified cookie user to be a member.
+const HIVE_AUTHORIZED_USERS = parseAuthorizedUsernames(process.env.HIVE_AUTHORIZED_USERS || '');
+
+// parseAuthorizedUsernames turns "owner:owner,alice:read,bob" into a Set of
+// lowercased usernames. It mirrors the Go parseAuthorizedUsers split (comma
+// list, ":role" suffix optional) but keeps only the identity, which is all the
+// terminal gate needs — role granularity stays with the dashboard/API layer.
+function parseAuthorizedUsernames(raw) {
+  const set = new Set();
+  for (const entry of raw.split(',')) {
+    const name = entry.split(':')[0].trim().toLowerCase();
+    if (name) set.add(name);
+  }
+  return set;
+}
+
+// isAuthorizedForThisHive reports whether a verified hub username is allowed to
+// open a terminal on THIS hive.
+//
+// Fail-closed policy: when the allowlist is populated (the normal hosted case —
+// authorizedUsersForHive always emits at least the owner), a user absent from it
+// is rejected. When the allowlist is EMPTY (env unset/blank), the proxy has no
+// independent per-hive data; hosted nginx hives still enforce authorization at
+// the ingress auth-url (finding C3 defense #1), so the proxy defers rather than
+// locking everyone out of a legitimately-allowlist-less hive. This keeps the
+// proxy check a strict tightening on top of the ingress, never a new outage.
+function isAuthorizedForThisHive(username) {
+  if (!username) return false;
+  if (HIVE_AUTHORIZED_USERS.size === 0) return true; // no local allowlist → defer to ingress
+  return HIVE_AUTHORIZED_USERS.has(username.toLowerCase());
+}
+
+const HOSTED_SUFFIX = '.hive.kubestellar.io';
+
+// isHostedHost decides whether the terminal auth gate applies to a request.
+//
+// SECURITY (CWE-862 bypass): the raw Host header can carry a :port suffix and a
+// trailing FQDN dot, both of which a naive `host.endsWith('.hive.kubestellar.io')`
+// would MISS — turning `hive-b.hive.kubestellar.io:443` or `hive-b.hive.kubestellar.io.`
+// into a "non-hosted" request that skips the gate entirely and proxies straight
+// to ttyd. Normalize first: lowercase, drop the port, strip a single trailing
+// dot, THEN suffix-match.
+function isHostedHost(rawHost) {
+  let host = (rawHost || '').toLowerCase();
+  const colon = host.indexOf(':');
+  if (colon !== -1) host = host.slice(0, colon);
+  if (host.endsWith('.')) host = host.slice(0, -1);
+  return host.endsWith(HOSTED_SUFFIX);
+}
+
 // SECURITY (fail closed on empty dashboard token — CWE-306).
 //
 // The prior guard only fired when NODE_ENV === 'production', but NODE_ENV is
@@ -202,7 +270,7 @@ const ttydProxy = createProxyMiddleware({
 });
 app.use('/terminal', (req, res, next) => {
   const host = req.headers.host || '';
-  const isHosted = host.endsWith('.hive.kubestellar.io');
+  const isHosted = isHostedHost(host);
   if (isHosted) {
     const cookies = (req.headers.cookie || '').split(';').reduce((acc, c) => {
       const [k, ...v] = c.trim().split('=');
@@ -218,6 +286,20 @@ app.use('/terminal', (req, res, next) => {
         return;
       }
       res.status(401).send('Terminal access requires authentication');
+      return;
+    }
+    // SECURITY (CWE-862, finding C3): authentication is hub-WIDE — the signed
+    // cookie only proves this is some real hub user, because it is scoped to
+    // .hive.kubestellar.io and every hive's domain receives it. AUTHORIZATION is
+    // per-hive: the user must be on THIS hive's allowlist. A cookie authorized on
+    // hive A must not open a shell on hive B.
+    if (!isAuthorizedForThisHive(user)) {
+      console.warn(`[terminal] 403: hub user ${JSON.stringify(user)} not authorized for hive ${JSON.stringify(HIVE_ID)}`);
+      if (req.headers.upgrade === 'websocket') {
+        req.socket.destroy();
+        return;
+      }
+      res.status(403).send('Not authorized for this hive');
       return;
     }
   }
@@ -289,7 +371,7 @@ server.on('upgrade', (req, socket, head) => {
   }
   if (req.url.startsWith('/terminal')) {
     const host = req.headers.host || '';
-    const isHosted = host.endsWith('.hive.kubestellar.io');
+    const isHosted = isHostedHost(host);
     if (isHosted) {
       const cookies = (req.headers.cookie || '').split(';').reduce((acc, c) => {
         const [k, ...v] = c.trim().split('=');
@@ -297,7 +379,16 @@ server.on('upgrade', (req, socket, head) => {
         return acc;
       }, {});
       // SECURITY (CWE-345): verify the hub's HMAC signature, not mere existence.
-      if (!verifyHubUserCookie(SESSION_KEY, cookies['hive_hub_user'])) {
+      const wsUser = verifyHubUserCookie(SESSION_KEY, cookies['hive_hub_user']);
+      if (!wsUser) {
+        socket.destroy();
+        return;
+      }
+      // SECURITY (CWE-862, finding C3): per-hive authorization on the WS upgrade,
+      // mirroring the HTTP gate. A hub-authenticated user not on THIS hive's
+      // allowlist gets the socket closed, not a shell.
+      if (!isAuthorizedForThisHive(wsUser)) {
+        console.warn(`[terminal-ws] 403: hub user ${JSON.stringify(wsUser)} not authorized for hive ${JSON.stringify(HIVE_ID)}`);
         socket.destroy();
         return;
       }

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -61,6 +61,18 @@ const HIVE_ID = process.env.HIVE_ID || '';
 // case-insensitive) and require the verified cookie user to be a member.
 const HIVE_AUTHORIZED_USERS = parseAuthorizedUsernames(process.env.HIVE_AUTHORIZED_USERS || '');
 
+// HIVE_INGRESS_AUTHZ is set ("true") by the hub ONLY on the nginx-ingress lane,
+// where an ingress auth-proxy per-hive-authorizes every /terminal request
+// (auth-url=auth-check?hive=<id>) BEFORE it reaches this proxy. It is unset on
+// the OpenShift-Route lane, where the Route forwards straight to the pod and
+// this proxy is the ONLY per-hive gate.
+//
+// SECURITY (CWE-862, finding C3): this flag is what lets an empty allowlist fail
+// CLOSED without breaking legitimate nginx access. With no ingress auth-proxy in
+// front (OpenShift), an empty local allowlist can NOT be treated as "defer to
+// the ingress" — there is no ingress to defer to — so the terminal must deny.
+const HIVE_INGRESS_AUTHZ = (process.env.HIVE_INGRESS_AUTHZ || '') === 'true';
+
 // parseAuthorizedUsernames turns "owner:owner,alice:read,bob" into a Set of
 // lowercased usernames. It mirrors the Go parseAuthorizedUsers split (comma
 // list, ":role" suffix optional) but keeps only the identity, which is all the
@@ -77,16 +89,25 @@ function parseAuthorizedUsernames(raw) {
 // isAuthorizedForThisHive reports whether a verified hub username is allowed to
 // open a terminal on THIS hive.
 //
-// Fail-closed policy: when the allowlist is populated (the normal hosted case —
-// authorizedUsersForHive always emits at least the owner), a user absent from it
-// is rejected. When the allowlist is EMPTY (env unset/blank), the proxy has no
-// independent per-hive data; hosted nginx hives still enforce authorization at
-// the ingress auth-url (finding C3 defense #1), so the proxy defers rather than
-// locking everyone out of a legitimately-allowlist-less hive. This keeps the
-// proxy check a strict tightening on top of the ingress, never a new outage.
+// Fail-CLOSED policy (finding C3 — no fail-open, even the narrow one):
+//   - Populated allowlist (the normal hosted case — authorizedUsersForHive
+//     always emits at least the owner): a user absent from it is DENIED.
+//   - Empty allowlist (env unset/blank, e.g. an ownerless hive):
+//       * nginx lane (HIVE_INGRESS_AUTHZ=true): an ingress auth-proxy already
+//         per-hive-authorized this request before it reached the proxy, so the
+//         proxy defers (returns true) rather than double-denying legitimate,
+//         ingress-approved access.
+//       * OpenShift-Route lane (HIVE_INGRESS_AUTHZ unset): there is NO ingress
+//         auth-proxy — this proxy is the ONLY per-hive gate — so an empty
+//         allowlist DENIES. A wide-open terminal on an ownerless OpenShift hive
+//         is exactly the fail-open we refuse to ship.
 function isAuthorizedForThisHive(username) {
   if (!username) return false;
-  if (HIVE_AUTHORIZED_USERS.size === 0) return true; // no local allowlist → defer to ingress
+  if (HIVE_AUTHORIZED_USERS.size === 0) {
+    // No independent per-hive data. Defer to the ingress ONLY when an ingress
+    // auth-proxy actually gates this hive; otherwise fail closed.
+    return HIVE_INGRESS_AUTHZ;
+  }
   return HIVE_AUTHORIZED_USERS.has(username.toLowerCase());
 }
 

--- a/v2/proxy/server.test.js
+++ b/v2/proxy/server.test.js
@@ -1,9 +1,10 @@
-import { createServer } from 'http';
+import { createServer, request as httpRequest } from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
 import { strict as assert } from 'assert';
 import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 import path from 'path';
+import crypto from 'crypto';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROXY_PORT = 19001;
@@ -189,6 +190,184 @@ async function testNoFINError() {
   });
 }
 
+// ---------------------------------------------------------------------------
+// Finding C3 (CWE-862): per-hive terminal authorization.
+//
+// A hosted proxy is configured as "hive B" with HIVE_HUB_SECRET + an allowlist
+// that contains `alice` but NOT `bob`. We mint a validly-signed hub cookie for
+// each and prove:
+//   - alice (on B's allowlist)   → terminal reachable (proxied to ttyd, 200)
+//   - bob   (a real hub user, but authorized only on some OTHER hive)
+//                                → 403 on HTTP, socket closed on WS
+// exercising the exact cross-tenant bug: a valid cookie for a user with no
+// access to THIS hive must not open a shell here. We also cover the
+// port-suffixed and trailing-dot Host header variants of the hosted-host match.
+// ---------------------------------------------------------------------------
+const HIVE_B_PROXY_PORT = 19011;
+const HIVE_B_GO_PORT = 19012;
+const HIVE_B_TTYD_PORT = 19013;
+const HIVE_B_SECRET = 'test-hub-secret-B';
+const HIVE_B_ID = 'hosted-hive-b';
+const HOSTED_HOST = `${HIVE_B_ID}.hive.kubestellar.io`;
+
+let hiveBTtyd, hiveBProxy;
+
+// mintCookie mirrors mintHubUserCookieValue / verifyHubUserCookie:
+// `<username>.<base64url(HMAC-SHA256(key=secret, msg=username))>`.
+function mintCookie(secret, username) {
+  const sig = crypto.createHmac('sha256', secret).update(username).digest('base64url');
+  return `${username}.${sig}`;
+}
+
+function startHiveBProxy() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('node', ['server.js'], {
+      cwd: __dirname,
+      env: {
+        ...process.env,
+        HIVE_PROXY_PORT: String(HIVE_B_PROXY_PORT),
+        HIVE_API_PORT: String(HIVE_B_GO_PORT),
+        HIVE_TTYD_PORT: String(HIVE_B_TTYD_PORT),
+        HIVE_DASHBOARD_TOKEN: '',
+        HIVE_HUB_SECRET: HIVE_B_SECRET,
+        HIVE_ID: HIVE_B_ID,
+        HIVE_AUTHORIZED_USERS: 'alice:owner,carol:read',
+        HIVE_STATIC_DIR: __dirname,
+        NODE_ENV: 'test',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let started = false;
+    proc.stdout.on('data', (d) => {
+      if (!started && d.toString().includes('hive-proxy')) { started = true; resolve(proc); }
+    });
+    proc.stderr.on('data', (d) => { if (!started) console.error('hiveB stderr:', d.toString()); });
+    proc.on('error', reject);
+    setTimeout(() => { if (!started) reject(new Error('hiveB proxy start timeout')); }, 10000);
+  });
+}
+
+async function setupHiveB() {
+  hiveBTtyd = await new Promise(resolve => {
+    const server = createServer((_req, res) => { res.writeHead(200); res.end('ttyd-B'); });
+    // Mock ttyd must accept WS upgrades so an AUTHORIZED terminal upgrade can
+    // actually complete an open() (the denial path never reaches ttyd).
+    const wss = new WebSocketServer({ server });
+    wss.on('connection', (ws) => { ws.send('ttyd-ready'); });
+    server.listen(HIVE_B_TTYD_PORT, () => resolve(server));
+  });
+  hiveBProxy = await startHiveBProxy();
+  await new Promise(r => setTimeout(r, 500));
+}
+
+async function teardownHiveB() {
+  if (hiveBProxy) hiveBProxy.kill();
+  if (hiveBTtyd) hiveBTtyd.close();
+  await new Promise(r => setTimeout(r, 200));
+}
+
+// HTTP terminal request with a given cookie + explicit Host header.
+//
+// We use the raw http module, NOT fetch(): Node's fetch() overrides the Host
+// header to match the URL authority, which would defeat the whole point — the
+// gate keys off the Host header to decide `isHosted`, and we must be able to
+// present an arbitrary hosted / port-suffixed / trailing-dot Host.
+function terminalHTTP(cookieVal, hostHeader) {
+  return new Promise((resolve, reject) => {
+    const headers = { Host: hostHeader };
+    if (cookieVal) headers.Cookie = `hive_hub_user=${cookieVal}`;
+    const req = httpRequest({
+      host: '127.0.0.1', port: HIVE_B_PROXY_PORT, path: '/terminal/',
+      method: 'GET', headers,
+    }, (res) => {
+      let body = '';
+      res.on('data', (c) => { body += c; });
+      res.on('end', () => resolve({ status: res.statusCode, body }));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+// WS terminal upgrade. Resolves {opened:true} if the socket opens (allowed) or
+// {opened:false} if it is closed/errored before/at open (denied).
+function terminalWS(cookieVal, hostHeader) {
+  return new Promise((resolve) => {
+    const headers = { Host: hostHeader };
+    if (cookieVal) headers.Cookie = `hive_hub_user=${cookieVal}`;
+    const ws = new WebSocket(`ws://127.0.0.1:${HIVE_B_PROXY_PORT}/terminal/`, { headers });
+    const done = (opened) => { try { ws.close(); } catch { /* ignore */ } resolve({ opened }); };
+    const t = setTimeout(() => done(false), 4000);
+    ws.on('open', () => { clearTimeout(t); done(true); });
+    ws.on('error', () => { clearTimeout(t); done(false); });
+    ws.on('unexpected-response', () => { clearTimeout(t); done(false); });
+  });
+}
+
+async function testC3_AuthorizedUserHTTP() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'alice');
+  const resp = await terminalHTTP(cookie, HOSTED_HOST);
+  assert.equal(resp.status, 200, `alice (allowlisted) should reach terminal, got ${resp.status}`);
+  console.log('  ✓ authorized user (alice) → terminal 200');
+}
+
+async function testC3_ForeignUserHTTP() {
+  // bob's cookie is validly SIGNED (a real hub user) but bob is NOT on hive B's
+  // allowlist — this is the cross-tenant bug. Must be 403, not a shell.
+  const cookie = mintCookie(HIVE_B_SECRET, 'bob');
+  const resp = await terminalHTTP(cookie, HOSTED_HOST);
+  assert.equal(resp.status, 403, `bob (not on this hive) must be 403, got ${resp.status}`);
+  console.log('  ✓ foreign hub user (bob) → terminal 403');
+}
+
+async function testC3_ForeignUserHTTP_PortSuffixHost() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'bob');
+  const resp = await terminalHTTP(cookie, `${HOSTED_HOST}:443`);
+  assert.equal(resp.status, 403, `bob with port-suffixed Host must be 403, got ${resp.status}`);
+  console.log('  ✓ foreign user, port-suffixed Host → 403');
+}
+
+async function testC3_ForeignUserHTTP_TrailingDotHost() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'bob');
+  const resp = await terminalHTTP(cookie, `${HOSTED_HOST}.`);
+  // Trailing-dot FQDN must NOT be treated as non-hosted (which would skip the
+  // gate and proxy straight to ttyd). It must still be gated and 403 a foreign
+  // user — this pins the host-normalization bypass fix.
+  assert.equal(resp.status, 403,
+    `bob with trailing-dot Host must be 403, got ${resp.status}`);
+  console.log('  ✓ foreign user, trailing-dot Host → 403 (bypass closed)');
+}
+
+async function testC3_AuthorizedUserWS() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'alice');
+  const { opened } = await terminalWS(cookie, HOSTED_HOST);
+  assert.ok(opened, 'alice (allowlisted) WS terminal should open');
+  console.log('  ✓ authorized user (alice) → WS opens');
+}
+
+async function testC3_ForeignUserWS() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'bob');
+  const { opened } = await terminalWS(cookie, HOSTED_HOST);
+  assert.ok(!opened, 'bob (not on this hive) WS terminal must be closed');
+  console.log('  ✓ foreign hub user (bob) → WS closed');
+}
+
+async function testC3_ForeignUserWS_PortSuffixHost() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'bob');
+  const { opened } = await terminalWS(cookie, `${HOSTED_HOST}:443`);
+  assert.ok(!opened, 'bob with port-suffixed Host WS must be closed');
+  console.log('  ✓ foreign user, port-suffixed Host → WS closed');
+}
+
+async function testC3_ForgedSigStillRejected() {
+  // Belt-and-suspenders: a cookie whose signature does not verify (username
+  // alice but wrong secret) is rejected regardless of the allowlist.
+  const cookie = mintCookie('wrong-secret', 'alice');
+  const resp = await terminalHTTP(cookie, HOSTED_HOST);
+  assert.equal(resp.status, 401, `forged-signature cookie must be 401, got ${resp.status}`);
+  console.log('  ✓ forged-signature cookie (even for allowlisted name) → 401');
+}
+
 // Run tests
 console.log('\nProxy WebSocket Tests\n');
 
@@ -203,10 +382,35 @@ try {
   await testWSContributeConnect();
   await testNoFINError();
 
-  console.log('\n✓ All tests passed\n');
+  console.log('\n✓ Base tests passed\n');
 } catch (e) {
   console.error('\n✗ Test failed:', e.message, '\n');
   process.exitCode = 1;
 } finally {
   await teardown();
+}
+
+// C3 per-hive terminal authorization suite (own proxy lifecycle).
+console.log('Finding C3 — per-hive terminal authorization\n');
+try {
+  await setupHiveB();
+
+  console.log('HTTP terminal gate:');
+  await testC3_AuthorizedUserHTTP();
+  await testC3_ForeignUserHTTP();
+  await testC3_ForeignUserHTTP_PortSuffixHost();
+  await testC3_ForeignUserHTTP_TrailingDotHost();
+  await testC3_ForgedSigStillRejected();
+
+  console.log('\nWebSocket terminal gate:');
+  await testC3_AuthorizedUserWS();
+  await testC3_ForeignUserWS();
+  await testC3_ForeignUserWS_PortSuffixHost();
+
+  console.log('\n✓ C3 tests passed\n');
+} catch (e) {
+  console.error('\n✗ C3 test failed:', e.message, '\n');
+  process.exitCode = 1;
+} finally {
+  await teardownHiveB();
 }

--- a/v2/proxy/server.test.js
+++ b/v2/proxy/server.test.js
@@ -213,9 +213,19 @@ const HOSTED_HOST = `${HIVE_B_ID}.hive.kubestellar.io`;
 let hiveBTtyd, hiveBProxy;
 
 // mintCookie mirrors mintHubUserCookieValue / verifyHubUserCookie:
-// `<username>.<base64url(HMAC-SHA256(key=secret, msg=username))>`.
+// `<username>.<base64url(HMAC-SHA256(key=SESSION_KEY, msg=username))>`.
+//
+// C2 domain separation (#2758): the proxy no longer verifies the cookie with the
+// master HIVE_HUB_SECRET but with the derived SESSION sub-key —
+// HMAC-SHA256(master, "hive-session-v1"). We are started with HIVE_HUB_SECRET
+// (the legacy derivation lane), so mint through the SAME derivation the proxy's
+// deriveSessionKey() uses, keeping the info string byte-for-byte identical.
+function deriveSessionKey(secret) {
+  return crypto.createHmac('sha256', secret).update('hive-session-v1').digest('hex');
+}
 function mintCookie(secret, username) {
-  const sig = crypto.createHmac('sha256', secret).update(username).digest('base64url');
+  const sessionKey = deriveSessionKey(secret);
+  const sig = crypto.createHmac('sha256', sessionKey).update(username).digest('base64url');
   return `${username}.${sig}`;
 }
 
@@ -368,6 +378,128 @@ async function testC3_ForgedSigStillRejected() {
   console.log('  ✓ forged-signature cookie (even for allowlisted name) → 401');
 }
 
+// ---------------------------------------------------------------------------
+// Finding C3, empty-allowlist lane (no fail-open, even the narrow one).
+//
+// An OWNERLESS hive has an EMPTY per-hive allowlist (HIVE_AUTHORIZED_USERS
+// unset). Behavior must be platform-aware:
+//   - OpenShift Route (HIVE_INGRESS_AUTHZ unset): the proxy is the ONLY per-hive
+//     gate — there is no ingress auth-proxy — so it must fail CLOSED: EVERY
+//     signed cookie (cross-hive AND same-hive) is DENIED.
+//   - nginx ingress (HIVE_INGRESS_AUTHZ=true): the ingress already
+//     per-hive-authorized the request before it reached the proxy, so the proxy
+//     DEFERS (allows) rather than double-denying legitimate access.
+//
+// Each scenario runs its own proxy on its own ports + its own mock ttyd.
+// ---------------------------------------------------------------------------
+const EMPTY_SECRET = 'test-hub-secret-empty';
+const EMPTY_HIVE_ID = 'ownerless-hive';
+const EMPTY_HOST = `${EMPTY_HIVE_ID}.hive.kubestellar.io`;
+
+// startEmptyAllowlistProxy launches a proxy with NO HIVE_AUTHORIZED_USERS on the
+// given ports; ingressAuthz toggles HIVE_INGRESS_AUTHZ (nginx vs OpenShift lane).
+function startEmptyAllowlistProxy(proxyPort, apiPort, ttydPort, ingressAuthz) {
+  const env = {
+    ...process.env,
+    HIVE_PROXY_PORT: String(proxyPort),
+    HIVE_API_PORT: String(apiPort),
+    HIVE_TTYD_PORT: String(ttydPort),
+    HIVE_DASHBOARD_TOKEN: '',
+    HIVE_HUB_SECRET: EMPTY_SECRET,
+    HIVE_ID: EMPTY_HIVE_ID,
+    // HIVE_AUTHORIZED_USERS intentionally omitted → empty allowlist.
+    HIVE_STATIC_DIR: __dirname,
+    NODE_ENV: 'test',
+  };
+  if (ingressAuthz) env.HIVE_INGRESS_AUTHZ = 'true';
+  return new Promise((resolve, reject) => {
+    const proc = spawn('node', ['server.js'], { cwd: __dirname, env, stdio: ['ignore', 'pipe', 'pipe'] });
+    let started = false;
+    proc.stdout.on('data', (d) => { if (!started && d.toString().includes('hive-proxy')) { started = true; resolve(proc); } });
+    proc.stderr.on('data', (d) => { if (!started) console.error('empty-allowlist stderr:', d.toString()); });
+    proc.on('error', reject);
+    setTimeout(() => { if (!started) reject(new Error('empty-allowlist proxy start timeout')); }, 10000);
+  });
+}
+
+function startMockTtydOn(port) {
+  return new Promise(resolve => {
+    const server = createServer((_req, res) => { res.writeHead(200); res.end('ttyd'); });
+    const wss = new WebSocketServer({ server });
+    wss.on('connection', (ws) => { ws.send('ttyd-ready'); });
+    server.listen(port, () => resolve(server));
+  });
+}
+
+// Port-parameterized request helpers (raw http + ws, explicit Host).
+function terminalHTTPOn(port, cookieVal, hostHeader) {
+  return new Promise((resolve, reject) => {
+    const headers = { Host: hostHeader };
+    if (cookieVal) headers.Cookie = `hive_hub_user=${cookieVal}`;
+    const req = httpRequest({ host: '127.0.0.1', port, path: '/terminal/', method: 'GET', headers }, (res) => {
+      let body = '';
+      res.on('data', (c) => { body += c; });
+      res.on('end', () => resolve({ status: res.statusCode, body }));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+function terminalWSOn(port, cookieVal, hostHeader) {
+  return new Promise((resolve) => {
+    const headers = { Host: hostHeader };
+    if (cookieVal) headers.Cookie = `hive_hub_user=${cookieVal}`;
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/terminal/`, { headers });
+    const done = (opened) => { try { ws.close(); } catch { /* ignore */ } resolve({ opened }); };
+    const t = setTimeout(() => done(false), 4000);
+    ws.on('open', () => { clearTimeout(t); done(true); });
+    ws.on('error', () => { clearTimeout(t); done(false); });
+    ws.on('unexpected-response', () => { clearTimeout(t); done(false); });
+  });
+}
+
+// OpenShift lane: empty allowlist + no ingress authz → deny everything.
+const OS_PROXY_PORT = 19021, OS_API_PORT = 19022, OS_TTYD_PORT = 19023;
+let osTtyd, osProxy;
+
+async function testC3_EmptyAllowlist_OpenShift_ForeignDenied() {
+  const cookie = mintCookie(EMPTY_SECRET, 'bob');
+  const resp = await terminalHTTPOn(OS_PROXY_PORT, cookie, EMPTY_HOST);
+  assert.equal(resp.status, 403, `OpenShift empty-allowlist: foreign user must be 403, got ${resp.status}`);
+  const { opened } = await terminalWSOn(OS_PROXY_PORT, cookie, EMPTY_HOST);
+  assert.ok(!opened, 'OpenShift empty-allowlist: foreign user WS must be closed');
+  console.log('  ✓ OpenShift + empty allowlist: foreign user → 403 / WS closed');
+}
+
+async function testC3_EmptyAllowlist_OpenShift_SameHiveDenied() {
+  // The killer case: even a validly-signed cookie for THIS hive's own id-shaped
+  // user must be denied — an ownerless OpenShift hive has no one authorized, and
+  // the proxy is the only gate, so it must fail CLOSED rather than open a shell.
+  const cookie = mintCookie(EMPTY_SECRET, 'anyone');
+  const resp = await terminalHTTPOn(OS_PROXY_PORT, cookie, EMPTY_HOST);
+  assert.equal(resp.status, 403, `OpenShift empty-allowlist: any user must be 403, got ${resp.status}`);
+  const { opened } = await terminalWSOn(OS_PROXY_PORT, cookie, EMPTY_HOST);
+  assert.ok(!opened, 'OpenShift empty-allowlist: any user WS must be closed');
+  console.log('  ✓ OpenShift + empty allowlist: same-hive/any user → 403 / WS closed (no fail-open)');
+}
+
+// nginx lane: empty allowlist + ingress authz → proxy defers (allows).
+const NGINX_PROXY_PORT = 19031, NGINX_API_PORT = 19032, NGINX_TTYD_PORT = 19033;
+let nginxTtyd, nginxProxy;
+
+async function testC3_EmptyAllowlist_Nginx_Deferred() {
+  // The ingress auth-proxy already authorized this request; the proxy must NOT
+  // double-deny a legitimate ingress-approved user just because the local
+  // allowlist is empty.
+  const cookie = mintCookie(EMPTY_SECRET, 'bob');
+  const resp = await terminalHTTPOn(NGINX_PROXY_PORT, cookie, EMPTY_HOST);
+  assert.equal(resp.status, 200, `nginx empty-allowlist: ingress-approved user must reach terminal, got ${resp.status}`);
+  const { opened } = await terminalWSOn(NGINX_PROXY_PORT, cookie, EMPTY_HOST);
+  assert.ok(opened, 'nginx empty-allowlist: ingress-approved user WS should open');
+  console.log('  ✓ nginx + empty allowlist: ingress-approved user → deferred (200 / WS opens)');
+}
+
 // Run tests
 console.log('\nProxy WebSocket Tests\n');
 
@@ -413,4 +545,32 @@ try {
   process.exitCode = 1;
 } finally {
   await teardownHiveB();
+}
+
+// C3 empty-allowlist lane: no fail-open, even the narrow one.
+console.log('Finding C3 — empty-allowlist platform-aware fail-closed\n');
+try {
+  osTtyd = await startMockTtydOn(OS_TTYD_PORT);
+  osProxy = await startEmptyAllowlistProxy(OS_PROXY_PORT, OS_API_PORT, OS_TTYD_PORT, false /* no ingress authz */);
+  nginxTtyd = await startMockTtydOn(NGINX_TTYD_PORT);
+  nginxProxy = await startEmptyAllowlistProxy(NGINX_PROXY_PORT, NGINX_API_PORT, NGINX_TTYD_PORT, true /* ingress authz */);
+  await new Promise(r => setTimeout(r, 500));
+
+  console.log('OpenShift-Route lane (no ingress auth-proxy):');
+  await testC3_EmptyAllowlist_OpenShift_ForeignDenied();
+  await testC3_EmptyAllowlist_OpenShift_SameHiveDenied();
+
+  console.log('\nnginx-ingress lane (ingress auth-proxy in front):');
+  await testC3_EmptyAllowlist_Nginx_Deferred();
+
+  console.log('\n✓ C3 empty-allowlist tests passed\n');
+} catch (e) {
+  console.error('\n✗ C3 empty-allowlist test failed:', e.message, '\n');
+  process.exitCode = 1;
+} finally {
+  if (osProxy) osProxy.kill();
+  if (nginxProxy) nginxProxy.kill();
+  if (osTtyd) osTtyd.close();
+  if (nginxTtyd) nginxTtyd.close();
+  await new Promise(r => setTimeout(r, 200));
 }


### PR DESCRIPTION
## Security finding C3 (Critical, CWE-862) — hosted terminal has no per-hive authorization

### The hole
The hosted `/terminal` **authenticated any hub user but authorized none per-hive**:

1. The main spoke ingress enforces per-hive authz via `nginx.ingress.kubernetes.io/auth-url: .../api/saas/auth-check?hive={{.ID}}...`, but the **`hive-terminal` ingress had no auth-url annotation** — so `/terminal` was never routed through the per-hive check.
2. The Node proxy terminal gate verified only that `hive_hub_user` is a validly-signed cookie for *some* hub user (C2/CWE-345 fixed the signature check), but **never checked that user against this hive** — the same cookie verifies at every hive because the hub secret and the `.hive.kubestellar.io` cookie are shared.
3. The cookie is `Domain=.hive.kubestellar.io`, 7-day, and any GitHub account completes hub OAuth (`ensureSaaSUser` auto-creates).

Net result: **one cookie from any free GitHub account opened a shell in any tenant's credential-holding pod.**

### The fix — two defenses

**1. Ingress annotation (`saas_provision.go`)** — the `hive-terminal` nginx Ingress now carries the same per-hive `auth-url` the main ingress has (`auth-check?hive={{.ID}}`), plus `auth-signin` and `auth-response-headers`. `handleSaaSAuthCheck` already authorizes against `user.Hives[hiveID]` and 403s a user with no access to this hive. This closes the hole on nginx clusters.

**2. Proxy-side per-hive check (`proxy/server.js`)** — defense in depth, and the **only** defense on OpenShift Routes (no nginx auth-proxy in front of the pod). The proxy now:
- reads `HIVE_ID` and the per-hive `HIVE_AUTHORIZED_USERS` allowlist (already injected at provision time by `authorizedUsersForHive`);
- after verifying the cookie signature, requires the verified user to be on **this** hive's allowlist. A validly-signed cookie for a user authorized only on another hive is rejected — **403** on HTTP, **socket closed** on WS;
- normalizes the `Host` header (strips `:port` and a trailing FQDN dot) before the `.hive.kubestellar.io` hosted-host match, closing a bypass where `hive-b.hive.kubestellar.io:443` / `hive-b.hive.kubestellar.io.` would otherwise be treated as non-hosted and skip the gate entirely.

Fail-closed policy: when the allowlist is populated (the normal hosted case — `authorizedUsersForHive` always emits at least the owner), an absent user is rejected. When the allowlist env is unset/blank, the proxy defers to the ingress auth-url (defense #1) rather than locking everyone out of a legitimately allowlist-less hive — so the proxy check is a strict tightening on top of the ingress, never a new outage.

### C2 overlap note
C2 (hub-secret domain separation) is being fixed in a **separate PR** touching the cookie-signing / key-derivation code. This PR **deliberately does not touch cookie minting or key derivation** — the per-hive binding is enforced from the independent per-hive allowlist, not a new cookie claim — so the two PRs should not conflict.

### Testable vs template-only
- **Node tests (`server.test.js`, runnable, temp-dir harness, no real hub):** a validly-signed cookie for a user authorized on hive A → **403 (HTTP) / closed socket (WS)** at hive B's terminal, including **port-suffixed** and **trailing-dot** Host variants; an authorized user still reaches the terminal; a forged-signature cookie is still 401. All green (`node server.test.js`, exit 0).
- **Go tests (`saas_provision_terminal_authz_test.go`, runnable):** the rendered nginx manifest's `hive-terminal` Ingress carries the per-hive `auth-url` (and `auth-signin` / `auth-response-headers`), and the per-hive `auth-url` appears on **both** the main and terminal ingress so they can't drift.

### Deferred / not in scope
- A full short-lived `{user, hive, role, expiry}` terminal-assertion redesign (a hive-scoped cookie minted at terminal-open time). The existing `MintSSOToken`/`ssoClaims` machinery already models this shape; wiring the hosted terminal through an SSO-style handoff would be the more principled long-term design but is a larger change. This PR implements the core the finding asked for: **the proxy rejects a cookie whose per-hive authorization ≠ this hive.**
- C2 (hub-secret domain separation) — separate PR.

Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
