### PR TITLE
fix(contribute): C4+H2 — lease-bound resume, repo-scoped tokens, versioned/terminal profile saves

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -175,6 +175,17 @@ type ContributorProfile struct {
 	CurrentTask    *WSTaskAssign  `json:"current_task,omitempty"`
 	ActiveTasks    []WSTaskAssign `json:"active_tasks,omitempty"`
 	Sessions       int            `json:"sessions,omitempty"`
+	// Version is the profile's optimistic-concurrency token (kubestellar/hive H2,
+	// CWE-613/639). It is bumped on every persisted change. A caller that loaded the
+	// profile at version N may only persist its edit if the on-disk version is still
+	// N (saveContributorProfileCAS); a concurrent writer that already advanced the
+	// version wins, and the stale writer must reload and re-apply. Before this, a WS
+	// path holding a profile pointer captured at auth could save it back minutes
+	// later and silently CLOBBER an admin revoke that happened in between —
+	// restoring "contributor" over "revoked" and re-granting write access. Absent
+	// (0) on legacy on-disk profiles, which the CAS treats as "unversioned" and
+	// upgrades on first write. omitempty so existing files are byte-compatible.
+	Version int `json:"version,omitempty"`
 }
 
 type ContributorRateLimits struct {
@@ -335,10 +346,71 @@ func loadContributorProfile(username string) (*ContributorProfile, error) {
 	return &p, nil
 }
 
+// contributorSaveMu serializes profile writes across ALL goroutines (H2,
+// CWE-613/639). Every persisted mutation goes through saveContributorProfile, which
+// reloads the on-disk profile under this lock, reconciles it with the caller's copy,
+// bumps the version, and writes — so two concurrent writers (e.g. a WS stats update
+// and an admin revoke) can never race to clobber each other's change. The lock is
+// process-wide (the store is a single directory on the hive's PVC) and held only for
+// the brief read-reconcile-write window.
+var contributorSaveMu sync.Mutex
+
+// terminalTiers are trust tiers that, once written to disk, are SERVER-AUTHORITATIVE
+// and TERMINAL for non-admin writers (H2). A WS-path save carrying a live in-memory
+// profile pointer must never be able to move the tier OUT of one of these — that was
+// the account-un-revoke primitive: a stale WS save after an admin revoke restored
+// "contributor". Only the admin trust/revoke handlers (which pass adminOverride) may
+// change a terminal tier.
+func isTerminalTier(tier string) bool {
+	return tier == "revoked"
+}
+
 func saveContributorProfile(p *ContributorProfile) error {
+	return saveContributorProfileCAS(p, false)
+}
+
+// saveContributorProfileCAS persists a contributor profile under the global save
+// lock with optimistic-concurrency and the revocation-terminal invariant (H2,
+// CWE-613/639). It:
+//
+//   - reloads the CURRENT on-disk profile (if any) under contributorSaveMu;
+//   - enforces the terminal-tier fence UNLESS adminOverride: if the disk copy is in a
+//     terminal tier (revoked) but the incoming copy is not, the incoming TrustTier is
+//     OVERRIDDEN back to the disk value, so a stale WS save cannot un-revoke an
+//     account. Admin paths (trust/revoke) pass adminOverride=true to intentionally
+//     change a terminal tier;
+//   - detects a lost update: when the caller's Version is non-zero and the disk
+//     Version has advanced past it, the write is rejected with errProfileConflict so
+//     the caller can reload+retry rather than clobber the newer state;
+//   - bumps Version and writes atomically (temp + rename).
+//
+// A first-ever write (no disk file) or a legacy unversioned profile (Version 0)
+// proceeds and is upgraded to version 1+.
+func saveContributorProfileCAS(p *ContributorProfile, adminOverride bool) error {
 	if strings.Contains(p.GitHubUsername, "..") || strings.Contains(p.GitHubUsername, "/") || strings.Contains(p.GitHubUsername, "\\") {
 		return fmt.Errorf("invalid username for save")
 	}
+	contributorSaveMu.Lock()
+	defer contributorSaveMu.Unlock()
+
+	// Reload the authoritative on-disk copy (bypasses any in-memory staleness).
+	if cur, err := loadContributorProfile(p.GitHubUsername); err == nil && cur != nil {
+		// Revocation is server-authoritative and terminal for non-admin writers:
+		// never let a non-admin save move the tier out of a terminal state.
+		if !adminOverride && isTerminalTier(cur.TrustTier) && !isTerminalTier(p.TrustTier) {
+			p.TrustTier = cur.TrustTier
+		}
+		// Optimistic-concurrency: reject a stale writer whose base version is behind
+		// the disk. A zero base version (legacy/unversioned caller) is exempt so
+		// existing call sites keep working; those saves still get the terminal-tier
+		// fence above.
+		if p.Version != 0 && p.Version < cur.Version {
+			return errProfileConflict
+		}
+		p.Version = cur.Version
+	}
+	p.Version++
+
 	ensureDir(getContributorsDir())
 	data, err := json.MarshalIndent(p, "", "  ")
 	if err != nil {
@@ -351,6 +423,11 @@ func saveContributorProfile(p *ContributorProfile) error {
 	}
 	return os.Rename(tmpPath, path)
 }
+
+// errProfileConflict is returned by saveContributorProfileCAS when a stale writer's
+// base version is behind the current on-disk version (H2). The caller should reload
+// the profile, re-apply its intended change, and retry.
+var errProfileConflict = fmt.Errorf("contributor profile version conflict")
 
 func listContributorProfiles() []ContributorProfile {
 	ensureDir(getContributorsDir())
@@ -5251,9 +5328,18 @@ func (s *Server) handleContributorTrust(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	p.TrustTier = req.Tier
-	if err := saveContributorProfile(p); err != nil {
+	// H2: admin path — adminOverride lets this change a terminal (revoked) tier and
+	// wins the CAS reconcile against any concurrent stale WS save. The write is
+	// server-authoritative.
+	if err := saveContributorProfileCAS(p, true); err != nil {
 		jsonError(w, "Failed to save", http.StatusInternalServerError)
 		return
+	}
+	// H2: if this change revokes access, fence any live WebSocket sessions the
+	// contributor holds so an in-flight connection cannot keep working (or keep
+	// saving a stale "contributor" profile) after the revoke.
+	if req.Tier == "revoked" && s.contributeHub != nil {
+		s.contributeHub.DisconnectContributor(p.ContributorID, "contribution access revoked")
 	}
 	s.logger.Info("contributor tier changed", "username", p.GitHubUsername, "tier", req.Tier)
 	jsonResponse(w, map[string]any{"ok": true, "trust_tier": req.Tier})
@@ -5270,7 +5356,19 @@ func (s *Server) handleContributorRevoke(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	p.TrustTier = "revoked"
-	_ = saveContributorProfile(p)
+	// H2: admin path — adminOverride wins the CAS reconcile so this revoke cannot be
+	// silently clobbered by a concurrent stale WS save, and the tier is now
+	// server-authoritative and terminal for any later non-admin write.
+	if err := saveContributorProfileCAS(p, true); err != nil {
+		jsonError(w, "Failed to save", http.StatusInternalServerError)
+		return
+	}
+	// H2: fence live sessions — close any WebSocket connections this contributor
+	// holds so an in-flight session cannot keep working, keep minting credentials, or
+	// keep saving a stale non-revoked profile after the revoke lands.
+	if s.contributeHub != nil {
+		s.contributeHub.DisconnectContributor(p.ContributorID, "contribution access revoked")
+	}
 	s.logger.Info("contributor revoked", "username", p.GitHubUsername)
 	jsonResponse(w, map[string]any{"ok": true})
 }

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/kubestellar/hive/v2/pkg/config"
-	"github.com/kubestellar/hive/v2/pkg/github"
 )
 
 const (
@@ -323,6 +322,133 @@ type ContributeWSHub struct {
 	// the Operations "command center" renders live. It is purely additive: the fan-out
 	// is a NON-BLOCKING send, so it can never back-pressure this WS event path.
 	sse *sseRegistry
+	// leases is the hub-owned, server-authoritative registry of the task the hub
+	// ISSUED to each contributor identity (kubestellar/hive C4). It is keyed by
+	// identity (identityOf: ContributorID, falling back to GitHubUsername) and holds
+	// exactly one lease per identity — the last task selectTask handed that identity.
+	//
+	// It is the ONLY thing a reconnecting relay's task_progress may re-adopt against.
+	// Before this, a task_progress arriving while a (freshly reconnected) connection
+	// had currentTask == nil caused the hub to REBUILD ownership from the client's own
+	// task_id/repo/number fields and mint a fresh scoped credential for it — a client
+	// could therefore assert ANY task_id it liked and be handed a credential for work
+	// the server never assigned. Now a resume must match an active lease here EXACTLY
+	// on {identity, task_id, repo, generation} and be within its expiry, or it is
+	// rejected. A lease is recorded on assignment (recordLease) and revoked on every
+	// release path (revokeLease: disconnect, ready-abandon, complete, fail, operator
+	// requeue, lease-TTL expiry), so a released task can never be re-adopted. Guarded
+	// by leaseMu.
+	leases  map[string]*taskLease
+	leaseMu sync.Mutex
+}
+
+// taskLease is the server-authoritative record of a task the hub issued to a
+// contributor identity (kubestellar/hive C4). It binds the assignment to the
+// {profile, task, repo, generation} tuple and an expiry so a reconnecting relay's
+// task_progress can only RE-ADOPT a task the hub actually assigned to it, under the
+// exact generation it was assigned, and only until the lease expires. It is minted
+// by recordLease at assignment and cleared by revokeLease on every release path; a
+// resume that does not match an unexpired lease here is rejected outright.
+type taskLease struct {
+	identity  string
+	taskID    string
+	repo      string
+	number    int
+	tier      string
+	gen       uint64
+	expiresAt time.Time
+}
+
+// leaseTTL is how long a hub-issued task lease remains re-adoptable after
+// assignment (kubestellar/hive C4). It is deliberately aligned with wsTaskTimeout
+// (the wedged-task backstop): a task that has been reclaimed by the lease-TTL
+// backstop is also past its re-adoption window, so a relay that reconnects after
+// its task was auto-released cannot resurrect ownership from the client side. A
+// resume presented after this window is treated as a stale/forged claim and
+// rejected; the relay simply asks for fresh work via "ready".
+const leaseTTL = wsTaskTimeout
+
+// recordLease registers (or replaces) the server-authoritative lease for an
+// identity when the hub assigns it a task (kubestellar/hive C4). It stores the
+// exact {task, repo, generation, tier} the hub issued plus an expiry, so a later
+// reconnect can be validated against what the server actually handed out — never
+// reconstructed from client-supplied fields. Called from selectTask under the new
+// assignment's generation.
+func (h *ContributeWSHub) recordLease(identity, taskID, repo string, number int, tier string, gen uint64, now time.Time) {
+	if identity == "" || taskID == "" {
+		return
+	}
+	h.leaseMu.Lock()
+	if h.leases == nil {
+		h.leases = make(map[string]*taskLease)
+	}
+	h.leases[identity] = &taskLease{
+		identity:  identity,
+		taskID:    taskID,
+		repo:      repo,
+		number:    number,
+		tier:      tier,
+		gen:       gen,
+		expiresAt: now.Add(leaseTTL),
+	}
+	h.leaseMu.Unlock()
+}
+
+// revokeLease removes the server-authoritative lease for an identity on any release
+// path (kubestellar/hive C4): disconnect, ready-abandon, task_complete, task_failed,
+// operator requeue, and lease-TTL expiry. Once revoked, a reconnecting relay's
+// task_progress for that task no longer matches any lease and cannot re-adopt it —
+// closing the window in which a released task could be resurrected from client
+// fields. It only deletes the entry when the current lease is for taskID, so a race
+// where a NEW lease was already recorded for the same identity is not clobbered.
+func (h *ContributeWSHub) revokeLease(identity, taskID string) {
+	if identity == "" {
+		return
+	}
+	h.leaseMu.Lock()
+	if l, ok := h.leases[identity]; ok && (taskID == "" || l.taskID == taskID) {
+		delete(h.leases, identity)
+	}
+	h.leaseMu.Unlock()
+}
+
+// lookupLease returns the active, unexpired server-issued lease for an identity that
+// EXACTLY matches the resume claim (kubestellar/hive C4): same task_id, same
+// canonical repo, same number, and same assignment generation. Any mismatch — no
+// lease, wrong task, wrong repo/number, wrong (or zero) generation, or an expired
+// lease — returns nil, so a reconnecting relay may only re-adopt the precise task the
+// hub assigned it, under the generation it was assigned, and only within the lease
+// window. It never reconstructs ownership from the client's own fields.
+//
+// clientGen == 0 (an unversioned relay) is deliberately NOT honored here: re-adoption
+// requires proving possession of the server-issued generation token, which an
+// unversioned relay cannot present. Such a relay is asked to re-`ready` for fresh
+// work instead of resurrecting a lease it cannot authenticate.
+func (h *ContributeWSHub) lookupLease(identity, taskID, repo string, number int, clientGen uint64, now time.Time) *taskLease {
+	if identity == "" || taskID == "" || clientGen == 0 {
+		return nil
+	}
+	h.leaseMu.Lock()
+	defer h.leaseMu.Unlock()
+	l, ok := h.leases[identity]
+	if !ok {
+		return nil
+	}
+	if now.After(l.expiresAt) {
+		// Expired: drop it so it can never be re-adopted, and treat as no lease.
+		delete(h.leases, identity)
+		return nil
+	}
+	if l.taskID != taskID || l.gen != clientGen {
+		return nil
+	}
+	if repo != "" && l.repo != repo {
+		return nil
+	}
+	if number != 0 && l.number != number {
+		return nil
+	}
+	return l
 }
 
 // rateLimitHourWindow and rateLimitDayWindow are the trailing (rolling) windows
@@ -408,6 +534,7 @@ func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 		failedTasks:           make(map[string]time.Time),
 		consecutiveFailures:   make(map[string]int),
 		assignmentTimes:       make(map[string][]time.Time),
+		leases:                make(map[string]*taskLease),
 		logger:                logger,
 		server:                server,
 		sse:                   newSSERegistry(),
@@ -988,6 +1115,9 @@ func (h *ContributeWSHub) RequeueContributorTask(contributorID, reason string) i
 	h.mu.RUnlock()
 
 	for _, tgt := range targets {
+		// C4: an operator requeue releases the task — revoke its server-issued lease
+		// so the released worker cannot re-adopt it via a later task_progress.
+		h.revokeLease(identityOf(tgt.conn), tgt.task.TaskID)
 		// Book the SAME short cooldown the disconnect/ready-abandon paths book, so
 		// the released issue is not instantly re-offered. Only real issue tasks are
 		// booked; synthetic pr-review tasks (Number == 0) must not poison an issue key.
@@ -1023,6 +1153,52 @@ func (h *ContributeWSHub) RequeueContributorTask(contributorID, reason string) i
 		}
 	}
 	return len(targets)
+}
+
+// DisconnectContributor closes every live WebSocket session held by the given
+// contributor identity and revokes any server-issued task lease it holds (H2,
+// CWE-613/639). It is called by the admin revoke/trust-downgrade path so a revoked
+// contributor's in-flight sessions cannot keep working, keep the #2393 token-refresh
+// cycle alive, or keep saving a stale non-revoked profile after the revoke lands. It
+// returns the number of sessions closed. The socket close makes each session's read
+// loop return, running its normal disconnect defer (task release + cooldown). We do
+// the actual Close OUTSIDE h.mu, mirroring the other broadcast-ish paths, so a slow
+// socket write never stalls the hub lock.
+func (h *ContributeWSHub) DisconnectContributor(contributorID, reason string) int {
+	if contributorID == "" {
+		return 0
+	}
+	var closing []*ContributorConnection
+	h.mu.RLock()
+	for _, c := range h.connections {
+		c.mu.Lock()
+		match := c.profile != nil && c.profile.ContributorID == contributorID
+		var taskID string
+		if match && c.currentTask != nil {
+			taskID = c.currentTask.TaskID
+		}
+		c.mu.Unlock()
+		if match {
+			// Revoke any server-issued lease so a reconnect cannot re-adopt the task.
+			h.revokeLease(identityOf(c), taskID)
+			closing = append(closing, c)
+		}
+	}
+	h.mu.RUnlock()
+
+	for _, c := range closing {
+		username := ""
+		if c.profile != nil {
+			username = c.profile.GitHubUsername
+		}
+		h.logger.Info("[contribute-ws] disconnecting contributor session", "username", username, "reason", reason)
+		if c.ws != nil {
+			// Best-effort notify then close; the read loop's defer does the release.
+			_ = sendJSON(c.ws, WSMessage{Type: "auth_failed", Seq: h.nextSeq(), Reason: reason})
+			c.ws.Close()
+		}
+	}
+	return len(closing)
 }
 
 func (h *ContributeWSHub) nextSeq() int {
@@ -1622,6 +1798,10 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			contributor.credentialDelivered = false
 			contributor.mu.Unlock()
 			if abandoned != nil {
+				// C4: the relay explicitly gave up this task, so revoke its
+				// server-issued lease — a later task_progress for it must not resurrect
+				// ownership.
+				h.revokeLease(identityOf(contributor), abandoned.TaskID)
 				h.logger.Warn("[contribute-ws] task abandoned without completion",
 					"username", contributor.profile.GitHubUsername,
 					"abandoned_task", abandoned.TaskID,
@@ -1726,13 +1906,88 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 		case "task_progress":
 			if contributor != nil {
 				contributor.mu.Lock()
-				// #2568 (the Gate): a worker still holding a task whose progress carries
-				// a STALE generation was revoked/reassigned — its currentTaskGen was
-				// bumped past what it echoes. Reject its progress so it cannot renew a
-				// lease it no longer owns or resurrect ownership state. An unversioned
-				// relay echoes 0 and is accepted (generationAccepted falls back to the
-				// TaskID identity below).
-				if contributor.currentTask != nil && !generationAccepted(msg.TaskGen, contributor.currentTaskGen) {
+				// C4 (CWE-862/639): a task_progress that arrives while this connection
+				// holds NO task is a RESUME claim. The hub must NOT rebuild ownership
+				// from the client's own task_id/repo/number fields — doing so let a
+				// client assert ANY task and be minted a scoped GitHub credential for
+				// work the server never assigned. A resume is honored ONLY when it
+				// matches a server-issued lease (lookupLease) EXACTLY on
+				// {identity, task_id, repo, number, generation} and is unexpired, and
+				// only after the same admission gates a fresh assignment must pass
+				// (suspension, disabled tier, revocation) still hold. Anything else is
+				// rejected: the relay is told to re-`ready` for fresh work.
+				if contributor.currentTask == nil {
+					if msg.TaskID == "" {
+						contributor.mu.Unlock()
+						continue
+					}
+					identity := identityOf(contributor)
+					canonRepo := h.canonicalRepoKey(msg.Repo)
+					contributor.mu.Unlock()
+
+					lease := h.lookupLease(identity, msg.TaskID, canonRepo, msg.Number, msg.TaskGen, time.Now())
+					if lease == nil {
+						h.logger.Warn("[contribute-ws] task_progress resume rejected: no matching server-issued lease",
+							"username", contributor.profile.GitHubUsername,
+							"task", msg.TaskID,
+							"repo", canonRepo,
+							"client_gen", msg.TaskGen,
+						)
+						// Tell the relay this task is not (or no longer) its to hold, so
+						// it stops reporting and re-asks for work rather than silently
+						// believing it owns something the hub has no record of.
+						_ = sendJSON(conn, WSMessage{Type: "task_revoke", Seq: h.nextSeq(), TaskID: msg.TaskID, Reason: "no active lease for this task"})
+						continue
+					}
+					// C4: re-run the same admission gates a fresh selectTask assignment
+					// must pass. A task assigned before the operator suspended the queue,
+					// disabled the tier, or revoked the contributor must NOT silently
+					// resume (and re-mint a credential) after the gate closed.
+					if reason := h.resumeGateReason(contributor); reason != "" {
+						h.logger.Warn("[contribute-ws] task_progress resume refused by admission gate",
+							"username", contributor.profile.GitHubUsername,
+							"task", msg.TaskID,
+							"reason", reason,
+						)
+						h.revokeLease(identity, msg.TaskID)
+						_ = sendJSON(conn, WSMessage{Type: "task_revoke", Seq: h.nextSeq(), TaskID: msg.TaskID, Reason: reason})
+						continue
+					}
+					// Adopt the task from the AUTHORITATIVE lease record, not the client
+					// fields: repo/number/tier are the server's, and the task keeps its
+					// ORIGINAL generation so it stays fenced against any older-generation
+					// straggler. lastLeaseRenew starts the wedged-task clock.
+					contributor.mu.Lock()
+					contributor.currentTask = &WSTaskAssign{
+						TaskID: lease.taskID,
+						Kind:   msg.Kind,
+						Repo:   lease.repo,
+						Number: lease.number,
+						Title:  msg.Title,
+					}
+					contributor.currentTaskGen = lease.gen
+					contributor.lastLeaseRenew = time.Now()
+					contributor.tmuxOutput = msg.TmuxOutput
+					contributor.mu.Unlock()
+
+					h.logger.Info("[contribute-ws] task resumed from server-issued lease",
+						"username", contributor.profile.GitHubUsername,
+						"task", lease.taskID, "repo", lease.repo, "number", lease.number)
+
+					// #2610 finding 3: re-mint and push a fresh token_refresh so the
+					// resumed session holds a valid token and re-arms the #2393 refresh
+					// cycle. The credential is minted for the LEASE's tier (server-owned),
+					// repository-scoped to the lease's repo (C4).
+					h.resumeTaskToken(contributor, lease)
+					continue
+				}
+
+				// A routine progress ping for a task the hub already tracks on THIS
+				// connection. #2568 (the Gate): reject a STALE generation — a worker
+				// whose task was revoked/reassigned (currentTaskGen bumped past what it
+				// echoes) must not renew a lease it no longer owns. An unversioned relay
+				// echoes 0 and is accepted (generationAccepted falls back to TaskID).
+				if !generationAccepted(msg.TaskGen, contributor.currentTaskGen) {
 					staleGen := msg.TaskGen
 					contributor.mu.Unlock()
 					h.logger.Warn("[contribute-ws] stale-generation task_progress rejected",
@@ -1743,54 +1998,12 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 				contributor.tmuxOutput = msg.TmuxOutput
-				// resumed is true only when this task_progress REBUILT currentTask
-				// from nothing — i.e. the relay is re-asserting a task the hub had
-				// released on disconnect (the reconnect/resume path), not a routine
-				// progress ping for a task the hub already tracks.
-				resumed := false
-				if contributor.currentTask == nil && msg.TaskID != "" {
-					contributor.currentTask = &WSTaskAssign{
-						TaskID: msg.TaskID,
-						Kind:   msg.Kind,
-						// #2644: canonicalise the CLIENT-supplied repo to the same
-						// repo.Full form selectTask assigned it under, so the
-						// activeIssues double-assign guard and the failure/completion
-						// cooldowns — all keyed "repo#number" off currentTask.Repo —
-						// match. Storing msg.Repo verbatim let a relay whose repo
-						// spelling differs from repo.Full slip its resumed task past
-						// the in-flight exclusion, and the SAME issue was handed to a
-						// second contributor (intermittent, and only for that repo).
-						Repo:   h.canonicalRepoKey(msg.Repo),
-						Number: msg.Number,
-						Title:  msg.Title,
-					}
-					resumed = true
-					// #2568: a RESUME adopts the task under a FRESH generation so the
-					// hub, not the client, owns the authoritative token from here on.
-					contributor.currentTaskGen = h.nextTaskGen()
-				}
 				// #2568: renew the hub-owned lease on every progress report. This is
 				// what distinguishes "working slowly but alive" (lease keeps renewing,
 				// never reclaimed) from "connected but wedged" (lease goes stale and
 				// cleanupLoop reclaims it after wsTaskTimeout).
-				if contributor.currentTask != nil {
-					contributor.lastLeaseRenew = time.Now()
-				}
+				contributor.lastLeaseRenew = time.Now()
 				contributor.mu.Unlock()
-
-				// #2610 finding 3: the disconnect defer clears tokenMintedAt, and
-				// this resume path historically rebuilt currentTask WITHOUT re-arming
-				// it. tokenRefreshDue treats a zero tokenMintedAt as "not due", so
-				// maybeRefreshToken on the heartbeat became a permanent no-op for the
-				// resumed connection — the task kept the token minted at its original
-				// assignment and it expired at wsTokenTTL (55m) with no 50-minute
-				// replacement, the exact silent-expiry case the refresh path was added
-				// for (#2393 item 2). Re-mint and push a fresh token_refresh here so
-				// the resumed session both holds a valid token and re-arms the refresh
-				// cycle (resumeTaskToken sets tokenMintedAt on a successful send).
-				if resumed {
-					h.resumeTaskToken(contributor)
-				}
 			}
 
 		case "task_complete":
@@ -1838,6 +2051,12 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					// bar was "a PR was reported", still trusting an unverified field).
 					// verifiedPR is the ONLY value allowed to unlock the PR-gated
 					// rewards below; the raw msg.PRURL is never trusted directly again.
+					// C4: a completion is terminal — revoke the server-issued lease so a
+					// later task_progress for this task cannot resurrect ownership and be
+					// re-minted a credential.
+					if completedTask != nil {
+						h.revokeLease(identityOf(contributor), completedTask.TaskID)
+					}
 					verifiedPR := ""
 					if completedTask != nil && h.verifyReportedPR(completedTask.Repo, msg.PRURL, contributor.profile.GitHubUsername) {
 						verifiedPR = msg.PRURL
@@ -1930,6 +2149,11 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				contributor.mu.Unlock()
 
 				if hasTask {
+					// C4: a failure is terminal — revoke the server-issued lease so a
+					// later task_progress for this task cannot resurrect ownership.
+					if failedTask != nil {
+						h.revokeLease(identityOf(contributor), failedTask.TaskID)
+					}
 					if failedTask != nil {
 						// #2435: record a short failure cooldown (and advance the
 						// consecutive-failure/quarantine counter) so a just-failed
@@ -2002,12 +2226,12 @@ func (h *ContributeWSHub) heartbeatLoop(c *ContributorConnection) {
 // wsTokenTTL. The relay's token_refresh handler consumes github_token +
 // token_expires_at (bin/contributor-relay.sh). See #2393 item 2.
 func (h *ContributeWSHub) maybeRefreshToken(c *ContributorConnection) {
-	tier, due := tokenRefreshDue(c, time.Now())
+	tier, repo, due := tokenRefreshDue(c, time.Now())
 	if !due {
 		return
 	}
 
-	tok, err := h.mintScopedToken(tier)
+	tok, err := h.mintScopedToken(tier, repo)
 	if err != nil {
 		h.logger.Warn("[contribute-ws] token refresh: mint failed, will retry next heartbeat",
 			"username", c.profile.GitHubUsername, "tier", tier, "error", err)
@@ -2038,12 +2262,19 @@ func (h *ContributeWSHub) maybeRefreshToken(c *ContributorConnection) {
 // an empty token (no App auth / no cache) leaves the relay's existing token in
 // place — the same lenient policy maybeRefreshToken uses — and tokenMintedAt stays
 // zero, so the next reconnect (or a later mint success) can still arm it.
-func (h *ContributeWSHub) resumeTaskToken(c *ContributorConnection) {
+func (h *ContributeWSHub) resumeTaskToken(c *ContributorConnection, lease *taskLease) {
+	// C4: mint for the SERVER-issued lease's tier and repository, not the client's
+	// self-report, so a resumed session's credential is scoped to exactly the task the
+	// hub assigned.
 	tier := ""
-	if c.profile != nil {
+	repo := ""
+	if lease != nil {
+		tier = lease.tier
+		repo = lease.repo
+	} else if c.profile != nil {
 		tier = c.profile.TrustTier
 	}
-	tok, err := h.mintScopedToken(tier)
+	tok, err := h.mintScopedToken(tier, repo)
 	if err != nil {
 		h.logger.Warn("[contribute-ws] resume token refresh: mint failed, refresh will re-arm on next resume/heartbeat",
 			"username", c.profile.GitHubUsername, "tier", tier, "error", err)
@@ -2063,21 +2294,23 @@ func (h *ContributeWSHub) resumeTaskToken(c *ContributorConnection) {
 
 // tokenRefreshDue reports whether the connection has an active task whose scoped
 // token was minted at least wsTokenRefreshPeriod ago, meaning it is time to
-// re-mint before wsTokenTTL. It returns the trust tier to mint for. Pure and
-// clock-injectable so the timing can be tested without a real clock.
-func tokenRefreshDue(c *ContributorConnection, now time.Time) (tier string, due bool) {
+// re-mint before wsTokenTTL. It returns the trust tier and the current task's repo
+// to mint a repository-scoped token for (C4). Pure and clock-injectable so the
+// timing can be tested without a real clock.
+func tokenRefreshDue(c *ContributorConnection, now time.Time) (tier, repo string, due bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.currentTask == nil || c.tokenMintedAt.IsZero() {
-		return "", false
+		return "", "", false
 	}
 	if now.Sub(c.tokenMintedAt) < wsTokenRefreshPeriod {
-		return "", false
+		return "", "", false
 	}
 	if c.profile != nil {
 		tier = c.profile.TrustTier
 	}
-	return tier, true
+	repo = c.currentTask.Repo
+	return tier, repo, true
 }
 
 // sendTokenRefresh writes a token_refresh message carrying the new token and its
@@ -2286,6 +2519,9 @@ func (h *ContributeWSHub) reclaimExpiredLeases(now time.Time) int {
 	h.mu.RUnlock()
 
 	for _, tgt := range targets {
+		// C4: the lease-TTL backstop released this task — revoke its server-issued
+		// lease so the wedged worker cannot re-adopt it via a later task_progress.
+		h.revokeLease(identityOf(tgt.conn), tgt.task.TaskID)
 		if tgt.task.Number > 0 {
 			h.recordTaskFailure(tgt.task.Repo, tgt.task.Number, false)
 		}
@@ -2313,25 +2549,51 @@ func (h *ContributeWSHub) reclaimExpiredLeases(now time.Time) int {
 	return len(targets)
 }
 
-// mintScopedToken produces a scoped GitHub token for the given trust tier via
-// the GitHub App auth path, falling back to the on-disk cache when no App auth
-// is configured (dev/single-token deployments). This is the single mint path
-// shared by task_assign and the heartbeat token-refresh, so both advertise
-// tokens minted the same way. See #2393 item 2.
-func (h *ContributeWSHub) mintScopedToken(tier string) (string, error) {
+// mintScopedToken produces a scoped GitHub token for the given trust tier via the
+// GitHub App auth path, scoped to a single repository when repo is non-empty
+// (kubestellar/hive C4). This is the single mint path shared by task_assign and the
+// heartbeat/resume token-refresh, so all three advertise tokens minted the same way.
+// See #2393 item 2.
+//
+// C4 (CWE-862/639): the previous full-cache FALLBACK — when no App auth was
+// configured, returning the hive's own FULL cached installation token — has been
+// DELETED. Handing a contributor relay the hive's installation-wide credential gave
+// it push access to every repo the installation covers, wildly beyond the single
+// issue the contributor was assigned, and it was reachable from the forgeable resume
+// path. When there is no App auth to mint a properly scoped token, mint NOTHING: the
+// caller treats an empty token as "leave the relay's current token in place", and
+// selectTask surfaces token_mint_failed rather than leaking the full credential.
+func (h *ContributeWSHub) mintScopedToken(tier, repo string) (string, error) {
 	if h.server != nil && h.server.deps != nil && h.server.deps.GHAppAuth != nil {
 		ctx := h.server.deps.Ctx
 		if ctx == nil {
 			ctx = context.Background()
 		}
+		// C4: restrict the installation token to the assignment's repository so the
+		// credential cannot touch any other repo the installation covers. repoNameOnly
+		// yields the bare repo name the GitHub API's Repositories option expects; an
+		// empty repo (synthetic/pr-review tasks with no single repo) falls back to the
+		// tier-scoped installation token — still permission-scoped, unchanged behavior.
+		if name := repoNameOnly(repo); name != "" {
+			return h.server.deps.GHAppAuth.ScopedTokenForRepos(ctx, tier, []string{name})
+		}
 		return h.server.deps.GHAppAuth.ScopedToken(ctx, tier)
 	}
-	if tokenBytes, err := os.ReadFile(github.TokenCachePath); err == nil {
-		return string(tokenBytes), nil
-	}
-	// No App auth and no cache: mint nothing rather than fail. Callers treat an
-	// empty token as "leave the relay's current token in place".
+	// No App auth: mint nothing rather than leak a full credential (see the note
+	// above — the cache fallback is deliberately gone).
 	return "", nil
+}
+
+// repoNameOnly returns the bare repository name from an "owner/repo" (or already
+// bare) value, for the GitHub App installation-token Repositories option, which is
+// keyed on the repo name within the installation's org (kubestellar/hive C4). An
+// empty input yields "".
+func repoNameOnly(repo string) string {
+	repo = strings.TrimSpace(repo)
+	if idx := strings.LastIndex(repo, "/"); idx >= 0 {
+		return repo[idx+1:]
+	}
+	return repo
 }
 
 // taskUnavailableReason* are the machine-readable reasons carried on a
@@ -2565,6 +2827,41 @@ func (h *ContributeWSHub) canonicalRepoKey(repo string) string {
 		}
 	}
 	return repo
+}
+
+// resumeGateReason re-runs, for a RESUME (kubestellar/hive C4), the same admission
+// gates a fresh selectTask assignment must clear that are NOT specific to a
+// particular candidate issue: the profile must not be revoked, the whole contribute
+// queue must not be suspended, and the contributor's trust tier must not be
+// operator-disabled. It returns a non-empty machine-readable reason when resume must
+// be REFUSED (so the caller can revoke the lease and tell the relay why), or "" when
+// resume may proceed. It deliberately does NOT re-run the per-candidate cooldown /
+// repo-filter / concurrency-window gates: the lease is for a task the hub already
+// committed to this identity, so re-applying candidate selection would falsely refuse
+// a legitimately in-flight task. The gates checked here are the ones that represent an
+// operator turning access OFF after assignment.
+func (h *ContributeWSHub) resumeGateReason(c *ContributorConnection) string {
+	tier := ""
+	if c != nil && c.profile != nil {
+		if c.profile.TrustTier == "revoked" {
+			return "contribution access revoked"
+		}
+		tier = c.profile.TrustTier
+	}
+	if h.server == nil {
+		return taskUnavailableHubNotReady
+	}
+	if h.server.deps != nil && h.server.deps.Config != nil {
+		if h.server.deps.Config.Hub.ContributeSuspended {
+			return taskUnavailableContributionSuspended
+		}
+		for _, dt := range h.server.deps.Config.Hub.DisabledTiers {
+			if dt == tier {
+				return taskUnavailableTierDisabled
+			}
+		}
+	}
+	return ""
 }
 
 func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
@@ -2921,8 +3218,9 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 
 	// Mint through the shared path so task_assign and the heartbeat token-refresh
 	// advertise tokens minted the same way (#2393 item 2). tokenMintedAt below
-	// arms the refresh ticker for the token we hand out here.
-	ghToken, err := h.mintScopedToken(c.profile.TrustTier)
+	// arms the refresh ticker for the token we hand out here. C4: the token is
+	// scoped to the chosen issue's REPOSITORY, not the whole installation.
+	ghToken, err := h.mintScopedToken(c.profile.TrustTier, chosen.repoFull)
 	if err != nil {
 		// #2436 finding 1: a mint failure previously returned nil, stranding the
 		// contributor with no message (the log even said "skipping task" while
@@ -2981,6 +3279,12 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	c.credentialDelivered = false
 	c.tokenMintedAt = time.Now()
 	c.mu.Unlock()
+
+	// C4: record the SERVER-AUTHORITATIVE lease for this assignment so a later
+	// reconnect can be validated against what the hub actually issued — the exact
+	// {task, repo, generation, tier} bound here — instead of reconstructing ownership
+	// from client-supplied task_progress fields. Revoked on every release path.
+	h.recordLease(identityOf(c), taskID, chosen.repoFull, chosen.number, c.profile.TrustTier, gen, time.Now())
 
 	// #2566: record this assignment against the identity's rolling hourly/daily
 	// windows so the next selectTask enforces tier_limits.max_per_hour /

--- a/v2/pkg/dashboard/contribute_ws_sec_c4_h2_test.go
+++ b/v2/pkg/dashboard/contribute_ws_sec_c4_h2_test.go
@@ -1,0 +1,361 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// contribute_ws_sec_c4_h2_test.go covers the two contributor-auth security findings:
+//
+//   C4 (CWE-862/639): the contributor WebSocket must NOT reconstruct task ownership
+//   from a client task_progress. A fabricated task_progress sent before any
+//   task_assign must be rejected and must NOT mint / push a GitHub credential; a
+//   legitimate resume is honored only against a server-issued lease and re-scopes the
+//   credential to that lease's repo.
+//
+//   H2 (CWE-613/639): profile saves are versioned + revocation is server-authoritative
+//   and terminal. A stale WS-path save cannot un-revoke an account, and a revoke
+//   fences (disconnects) live sessions and denies reconnect.
+
+// drainForToken reads up to a short window looking for a token_refresh, returning
+// true if one arrives. Used to assert a credential was (or was NOT) pushed.
+func drainForToken(t *testing.T, conn *websocket.Conn, window time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(window)
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return false
+		}
+		conn.SetReadDeadline(time.Now().Add(remaining))
+		_, raw, err := conn.ReadMessage()
+		if err != nil {
+			return false
+		}
+		var m WSMessage
+		if json.Unmarshal(raw, &m) != nil {
+			continue
+		}
+		if m.Type == "token_refresh" {
+			return true
+		}
+	}
+}
+
+// registerAndAuth registers a fresh contributor and returns an authenticated,
+// mint-capable connection plus its registration reply.
+func registerAndAuth(t *testing.T, s *Server, ts *httptest.Server, username string) (*websocket.Conn, map[string]string) {
+	t.Helper()
+	body := `{"github_username":"` + username + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &reg); err != nil {
+		t.Fatalf("register decode: %v", err)
+	}
+	if reg["registration_token"] == "" {
+		t.Fatalf("register returned no token: %s", w.Body.String())
+	}
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	readMsg(t, conn) // auth_challenge
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn) // auth_ok
+	return conn, reg
+}
+
+// TestC4_FabricatedTaskProgressMintsNoCredential is the core C4 proof: a client that
+// sends task_progress with a self-asserted task_id BEFORE it was ever assigned a task
+// must be rejected — the hub does NOT rebuild currentTask from the client fields and
+// does NOT mint or push a scoped GitHub credential. A control leg then shows a real
+// assignment DOES yield a credential, proving the App auth is live (so the negative is
+// meaningful, not just "minting is disabled").
+func TestC4_FabricatedTaskProgressMintsNoCredential(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+	// Live, succeeding App auth so a mint WOULD produce an observable token_refresh.
+	s.deps = &Dependencies{GHAppAuth: newSucceedingAppAuth(t, "ghs_c4_scoped")}
+	s.contributeHub.server = s
+
+	conn, reg := registerAndAuth(t, s, ts, "attacker")
+	defer conn.Close()
+
+	// Attack: assert task_progress for a task the server never assigned, echoing a
+	// generation the client just made up. currentTask is nil, so the OLD code would
+	// rebuild ownership from these fields and mint. The fix must reject it.
+	conn.WriteJSON(WSMessage{
+		Type:    "task_progress",
+		TaskID:  "ct-myorg/repo1-1-9999",
+		TaskGen: 424242,
+		Kind:    "issue",
+		Repo:    "myorg/repo1",
+		Number:  1,
+		Title:   "forged",
+	})
+	if drainForToken(t, conn, 400*time.Millisecond) {
+		t.Fatalf("C4: a fabricated task_progress was minted a credential (token_refresh pushed) — ownership was rebuilt from client fields")
+	}
+
+	// The hub must hold NO task for this connection (nothing was adopted).
+	s.contributeHub.mu.RLock()
+	var held bool
+	for _, c := range s.contributeHub.connections {
+		c.mu.Lock()
+		if c.profile != nil && c.profile.ContributorID == reg["contributor_id"] && c.currentTask != nil {
+			held = true
+		}
+		c.mu.Unlock()
+	}
+	s.contributeHub.mu.RUnlock()
+	if held {
+		t.Fatalf("C4: the forged task_progress caused the hub to adopt a task it never assigned")
+	}
+
+	// Control: prove the mint path is genuinely live in this setup, so the negative
+	// above ("no token pushed") reflects the C4 rejection and not a dead mint. A real
+	// assignment records a server lease AND holds a scoped credential pending delivery.
+	setStatusIssues(s, intgIssue(700, "Real issue", "someone", nil))
+	assign := s.contributeHub.selectTask(mustConn(t, s.contributeHub, reg["contributor_id"]))
+	if assign == nil || assign.Type != "task_assign" {
+		t.Fatalf("control: a real selectTask did not assign (got %+v) — cannot prove mint is live", assign)
+	}
+	// The lease was recorded server-side, and a credential is pending (mint succeeded).
+	if s.contributeHub.lookupLease(reg["contributor_id"], assign.TaskID, assign.Repo, assign.Number, assign.TaskGen, time.Now()) == nil {
+		t.Fatalf("control: selectTask did not record a server-issued lease")
+	}
+	holder := mustConn(t, s.contributeHub, reg["contributor_id"])
+	holder.mu.Lock()
+	pending := holder.pendingToken
+	holder.mu.Unlock()
+	if pending == "" {
+		t.Fatalf("control: a real assignment did not mint a scoped credential — the mint path is not live, so the C4 negative is inconclusive")
+	}
+}
+
+// mustConn returns the (single) live connection for a contributor ID, failing if none.
+func mustConn(t *testing.T, h *ContributeWSHub, contributorID string) *ContributorConnection {
+	t.Helper()
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for _, c := range h.connections {
+		if c.profile != nil && c.profile.ContributorID == contributorID {
+			return c
+		}
+	}
+	t.Fatalf("no live connection for %s", contributorID)
+	return nil
+}
+
+// TestC4_ResumeOnlyAgainstServerLease_ExactRepo proves the lease-bound resume: a
+// reconnecting relay may re-adopt ONLY the exact task+repo the hub issued to it, under
+// the issued generation. A resume whose repo/generation does not match a live lease is
+// rejected; a resume that matches is accepted.
+func TestC4_ResumeOnlyAgainstServerLease_ExactRepo(t *testing.T) {
+	hub, s := covK2Hub(t)
+	s.deps = &Dependencies{GHAppAuth: newSucceedingAppAuth(t, "ghs_resume_ok")}
+	hub.server = s
+
+	identity := "c-lease"
+	// Hub issues a lease for repo1#5 at generation 9.
+	hub.recordLease(identity, "ct-1", "myorg/repo1", 5, "contributor", 9, time.Now())
+
+	now := time.Now()
+	// Wrong repo → no match.
+	if hub.lookupLease(identity, "ct-1", "myorg/other", 5, 9, now) != nil {
+		t.Fatalf("C4: a resume for the WRONG repo matched a lease — the credential would be re-scoped to a repo the hub never assigned")
+	}
+	// Wrong generation → no match (a stale/forged generation).
+	if hub.lookupLease(identity, "ct-1", "myorg/repo1", 5, 1, now) != nil {
+		t.Fatalf("C4: a resume echoing a non-issued generation matched a lease")
+	}
+	// Unversioned (gen 0) → no match: re-adoption requires proving the generation.
+	if hub.lookupLease(identity, "ct-1", "myorg/repo1", 5, 0, now) != nil {
+		t.Fatalf("C4: an unversioned resume (gen 0) matched a lease — a client with no generation must not resurrect ownership")
+	}
+	// Wrong task → no match.
+	if hub.lookupLease(identity, "ct-OTHER", "myorg/repo1", 5, 9, now) != nil {
+		t.Fatalf("C4: a resume for a different task_id matched the lease")
+	}
+	// Exact match → adopts.
+	if l := hub.lookupLease(identity, "ct-1", "myorg/repo1", 5, 9, now); l == nil {
+		t.Fatalf("C4: the exact server-issued lease did not match its own resume — a legitimate reconnect would be refused")
+	}
+	// After expiry → no match, and the stale lease is dropped.
+	if hub.lookupLease(identity, "ct-1", "myorg/repo1", 5, 9, now.Add(leaseTTL+time.Minute)) != nil {
+		t.Fatalf("C4: an EXPIRED lease was still re-adoptable")
+	}
+	// Once released (revoked), even an exact resume no longer matches.
+	hub.recordLease(identity, "ct-2", "myorg/repo1", 6, "contributor", 10, now)
+	hub.revokeLease(identity, "ct-2")
+	if hub.lookupLease(identity, "ct-2", "myorg/repo1", 6, 10, now) != nil {
+		t.Fatalf("C4: a released task remained re-adoptable — a released worker could resurrect it")
+	}
+}
+
+// TestC4_ResumeRefusedWhenSuspended proves the resume path re-runs the admission
+// gates: a task with a valid live lease still cannot resume (and re-mint) once the
+// operator has SUSPENDED the contribute queue.
+func TestC4_ResumeRefusedWhenSuspended(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	// Suspended queue → the resume gate must refuse.
+	c := &ContributorConnection{profile: &ContributorProfile{TrustTier: "contributor"}}
+	if got := hub.resumeGateReason(c); got != "" {
+		// covK2Hub's config is unsuspended by default; sanity check.
+		if got != taskUnavailableHubNotReady {
+			t.Fatalf("baseline resume gate unexpectedly refused: %q", got)
+		}
+	}
+	// A revoked profile is refused regardless of queue state.
+	rev := &ContributorConnection{profile: &ContributorProfile{TrustTier: "revoked"}}
+	if hub.resumeGateReason(rev) == "" {
+		t.Fatalf("C4: resume gate admitted a revoked contributor")
+	}
+}
+
+// TestC4_NoFullCacheFallback proves the deleted installation-wide fallback: with NO
+// App auth configured, mintScopedToken returns an EMPTY token (mint nothing) rather
+// than the hive's full cached credential. Previously it returned the whole cache.
+func TestC4_NoFullCacheFallback(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	// No GHAppAuth on deps → the App path is unavailable.
+	if hub.server != nil && hub.server.deps != nil {
+		hub.server.deps.GHAppAuth = nil
+	}
+	tok, err := hub.mintScopedToken("contributor", "myorg/repo1")
+	if err != nil {
+		t.Fatalf("mint returned an error: %v", err)
+	}
+	if tok != "" {
+		t.Fatalf("C4: mintScopedToken returned a non-empty token with no App auth — the full-cache fallback is still leaking a credential")
+	}
+}
+
+// TestC4_RepoNameOnly checks the repo-name extraction used to repository-scope the
+// installation token.
+func TestC4_RepoNameOnly(t *testing.T) {
+	cases := map[string]string{
+		"myorg/repo1":              "repo1",
+		"repo1":                    "repo1",
+		"projectbluefin/fsdk-cont": "fsdk-cont",
+		"":                         "",
+		"  myorg/r  ":              "r",
+	}
+	for in, want := range cases {
+		if got := repoNameOnly(in); got != want {
+			t.Fatalf("repoNameOnly(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// --- H2 ----------------------------------------------------------------------
+
+// TestH2_RevokeIsTerminalAgainstStaleSave is the core H2 proof: after an admin revoke,
+// a stale WS-path save carrying an in-memory "contributor" profile must NOT restore
+// the tier. The revoke is server-authoritative and terminal.
+func TestH2_RevokeIsTerminalAgainstStaleSave(t *testing.T) {
+	setupContributeEnv(t)
+
+	// Seed a contributor and capture a "stale" in-memory copy (as a WS session holds).
+	p, _ := createContributorProfile("victim")
+	stale := *p // value copy: TrustTier "newcomer", version as written
+
+	// Admin revokes (server-authoritative, adminOverride).
+	p.TrustTier = "revoked"
+	if err := saveContributorProfileCAS(p, true); err != nil {
+		t.Fatalf("admin revoke save: %v", err)
+	}
+
+	// The stale WS save tries to persist the OLD non-revoked tier (e.g. a
+	// task_complete stat bump on the pre-revoke pointer).
+	stale.TasksCompleted++
+	_ = saveContributorProfile(&stale) // non-admin path
+
+	// On disk, the tier must still be revoked — the stale save could not un-revoke.
+	got, err := loadContributorProfile("victim")
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.TrustTier != "revoked" {
+		t.Fatalf("H2: a stale WS save restored tier %q over a revoke — account un-revoked", got.TrustTier)
+	}
+}
+
+// TestH2_VersionConflictRejectsLostUpdate proves the optimistic-concurrency guard: a
+// writer whose base version is behind the current on-disk version is rejected, so a
+// lost update cannot silently clobber a newer change.
+func TestH2_VersionConflictRejectsLostUpdate(t *testing.T) {
+	setupContributeEnv(t)
+	p, _ := createContributorProfile("racer")
+
+	// Load two independent copies at the same version (two goroutines / two paths).
+	a, _ := loadContributorProfile("racer")
+	b, _ := loadContributorProfile("racer")
+
+	// Writer A commits first — bumps the on-disk version.
+	a.Model = "sonnet"
+	if err := saveContributorProfileCAS(a, false); err != nil {
+		t.Fatalf("writer A: %v", err)
+	}
+	// Writer B, still at the old version, must be rejected as a lost update.
+	b.Model = "opus"
+	if err := saveContributorProfileCAS(b, false); err != errProfileConflict {
+		t.Fatalf("H2: stale writer B was not rejected (err=%v) — lost update possible", err)
+	}
+	_ = p
+}
+
+// TestH2_RevokeDisconnectsLiveSessionAndDeniesReconnect drives the real WS + admin
+// revoke endpoint: an authenticated session is fenced (disconnected) by a revoke, and
+// a reconnect with the same token is denied at auth.
+func TestH2_RevokeDisconnectsLiveSessionAndDeniesReconnect(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	conn, reg := registerAndAuth(t, s, ts, "gonner")
+
+	// Admin revokes via the real endpoint.
+	revReq := httptest.NewRequest(http.MethodPost, "/api/contributors/"+reg["contributor_id"]+"/revoke", nil)
+	revReq.Header.Set("X-Hive-Role", "owner")
+	revW := httptest.NewRecorder()
+	s.mux.ServeHTTP(revW, revReq)
+	if revW.Code != http.StatusOK {
+		t.Fatalf("revoke got %d, want 200 (body: %s)", revW.Code, revW.Body.String())
+	}
+
+	// The live session is fenced: the socket closes, so a read eventually errors.
+	closed := false
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	for {
+		if _, _, err := conn.ReadMessage(); err != nil {
+			closed = true
+			break
+		}
+	}
+	conn.Close()
+	if !closed {
+		t.Fatalf("H2: the revoked contributor's live session was not disconnected")
+	}
+
+	// Reconnect with the same token is denied at auth (revoked profile).
+	conn2, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial reconnect: %v", err)
+	}
+	defer conn2.Close()
+	readMsg(t, conn2) // auth_challenge
+	conn2.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	reply := readMsg(t, conn2)
+	if reply.Type != "auth_failed" {
+		t.Fatalf("H2: a revoked contributor reconnected successfully (got %s), want auth_failed", reply.Type)
+	}
+}

--- a/v2/pkg/dashboard/contribute_ws_token_refresh_test.go
+++ b/v2/pkg/dashboard/contribute_ws_token_refresh_test.go
@@ -112,7 +112,7 @@ func TestTokenRefreshDue(t *testing.T) {
 				currentTask:   tc.task,
 				tokenMintedAt: tc.mintedAt,
 			}
-			tier, due := tokenRefreshDue(c, tc.now)
+			tier, _, due := tokenRefreshDue(c, tc.now)
 			if due != tc.wantDue {
 				t.Fatalf("due = %v, want %v", due, tc.wantDue)
 			}
@@ -264,12 +264,13 @@ func TestResumeTaskTokenReArmsRefresh(t *testing.T) {
 
 	// Precondition: with a zero mint time, refresh is NOT due — the bug's steady
 	// state where the resumed session never refreshes again.
-	if _, due := tokenRefreshDue(conn, time.Now().Add(2*wsTokenTTL)); due {
+	if _, _, due := tokenRefreshDue(conn, time.Now().Add(2*wsTokenTTL)); due {
 		t.Fatalf("precondition: refresh should not be due with zero tokenMintedAt")
 	}
 
 	before := time.Now()
-	hub.resumeTaskToken(conn)
+	// C4: resume mints for the SERVER-issued lease's tier + repo.
+	hub.resumeTaskToken(conn, &taskLease{taskID: "t-resume", repo: "o/r", number: 7, tier: "contributor", gen: 1})
 
 	// The relay must receive a token_refresh carrying the fresh token.
 	client.SetReadDeadline(time.Now().Add(5 * time.Second))
@@ -296,7 +297,7 @@ func TestResumeTaskTokenReArmsRefresh(t *testing.T) {
 	if minted.IsZero() || minted.Before(before.Add(-time.Second)) {
 		t.Fatalf("tokenMintedAt not re-armed on resume: %s", minted)
 	}
-	if _, due := tokenRefreshDue(conn, minted.Add(wsTokenRefreshPeriod+time.Second)); !due {
+	if _, _, due := tokenRefreshDue(conn, minted.Add(wsTokenRefreshPeriod+time.Second)); !due {
 		t.Fatalf("after re-arm, refresh should be due again past the refresh period")
 	}
 }

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -195,6 +195,20 @@ func (a *AppAuth) mintInstallationToken(ctx context.Context) (token string, expi
 // scoped to a contributor's trust tier. Unlike Token(), this is NOT
 // cached — each call creates a fresh token.
 func (a *AppAuth) ScopedToken(ctx context.Context, tier string) (string, error) {
+	return a.ScopedTokenForRepos(ctx, tier, nil)
+}
+
+// ScopedTokenForRepos creates a short-lived installation token with permissions
+// scoped to a contributor's trust tier AND, when repos is non-empty, restricted to
+// those repositories within the installation (kubestellar/hive C4). Restricting the
+// repository scope means a contributor relay's credential can only touch the single
+// repo its assigned issue lives in, not every repo the installation covers — the
+// difference between a least-privilege, per-task credential and an
+// installation-wide one. repos are bare repository NAMES (not "owner/repo"); an
+// empty/nil slice yields the tier-scoped, installation-wide token (unchanged
+// behavior for callers that do not scope by repo). Like ScopedToken, the token is
+// NOT cached — each call mints fresh.
+func (a *AppAuth) ScopedTokenForRepos(ctx context.Context, tier string, repos []string) (string, error) {
 	jwtToken, err := a.generateJWT()
 	if err != nil {
 		return "", fmt.Errorf("generating JWT: %w", err)
@@ -236,13 +250,19 @@ func (a *AppAuth) ScopedToken(ctx context.Context, tier string) (string, error) 
 	}
 
 	opts := &gh.InstallationTokenOptions{Permissions: perms}
+	// C4: when the caller named repositories, restrict the token to them so it
+	// cannot reach any other repo the installation covers. Repositories is keyed on
+	// the bare repo name within the installation's org.
+	if len(repos) > 0 {
+		opts.Repositories = repos
+	}
 	jwtClient := newJWTClient(jwtToken, a.apiURL)
 	installToken, _, err := jwtClient.Apps.CreateInstallationToken(ctx, a.installationID, opts)
 	if err != nil {
 		return "", fmt.Errorf("creating scoped token for tier %s: %w", tier, err)
 	}
 
-	a.logger.Info("scoped token minted", "tier", tier, "expires_at", installToken.GetExpiresAt().Format(time.RFC3339))
+	a.logger.Info("scoped token minted", "tier", tier, "repos", len(repos), "expires_at", installToken.GetExpiresAt().Format(time.RFC3339))
 	return installToken.GetToken(), nil
 }
 


### PR DESCRIPTION
Fixes two contributor-auth security findings in the ClankeR contributor WebSocket relay (`v2/pkg/dashboard/`). Branch off `v4`.

## C4 (Critical, CWE-862/639) — WS mints credentials for tasks the server never assigned

**The hole:** a client sending `task_progress` with any self-asserted `task_id` while `currentTask == nil` made the hub **reconstruct the task from client fields** (`contribute_ws.go` resume path), then mint + push a scoped GitHub credential via `resumeTaskToken` — no assignment lookup, no lease, no ownership, gates skipped. Non-App hives fell back to the hive's **full cached token**.

**The fix (lease-based):**
- **Never rebuild ownership from client `task_progress`.** A `task_progress` with no held task is a RESUME claim, honored **only** against a hub-owned, server-authoritative `taskLease` bound to `{identity, task, repo, number, generation, expiry}` (`lookupLease`). Any mismatch — no lease, wrong task/repo/number, wrong or **zero** (unversioned) generation, or expired — is rejected and the relay is told to re-`ready`. The adopted task takes repo/number/tier/generation from the **lease record**, not the client message.
- **Leases recorded on assignment** (`recordLease` in `selectTask`) and **revoked on every release path**: ready-abandon, `task_complete`, `task_failed`, operator requeue, lease-TTL expiry, and admin disconnect. A released task can never be re-adopted. (Disconnect deliberately keeps the lease so a *legitimate* reconnect within `leaseTTL` = `wsTaskTimeout` can resume; the wedged-task backstop reclaims it at the same horizon.)
- **Re-run admission gates on resume** (`resumeGateReason`: revoked / suspended / disabled-tier) so a task assigned before an operator closed a gate cannot silently resume and re-mint.
- **Repository-scope installation tokens** to the assignment's repo (`AppAuth.ScopedTokenForRepos`, wiring the go-github `Repositories` option) instead of installation-wide. `selectTask`, resume, and the heartbeat re-mint all pass the task's repo.
- **Deleted the full-cache fallback** in `mintScopedToken`: with no App auth we now mint **nothing** (caller leaves the relay's token in place / surfaces `token_mint_failed`) rather than handing out the hive's full cached credential.

## H2 (High, CWE-613/639) — profile saves clobber admin revoke

**The hole:** `saveContributorProfile` rewrote the whole profile with no lock/version/CAS; WS paths saved stale in-memory pointers; admin revoke loaded+saved separately without fencing live sessions. A stale WS save after an admin revoke restored `contributor` tier.

**The fix:**
- **Versioned CAS** under a process-wide save lock (`saveContributorProfileCAS`): a `Version` token is bumped on every write; a stale writer behind the on-disk version is rejected (`errProfileConflict`). Legacy unversioned (0) callers are exempt from the conflict but still get the fence below.
- **Revocation is server-authoritative and terminal** for non-admin writers: a non-admin save can never move the tier out of `revoked`. Admin trust/revoke pass `adminOverride=true`.
- **Fence live sessions:** admin revoke/downgrade calls `DisconnectContributor` (closes the contributor's WS sessions + revokes their lease). Reconnect for a revoked profile is already denied at auth.

## Tests (`contribute_ws_sec_c4_h2_test.go`)
- C4: fabricated `task_progress` before any `task_assign` → **no** `token_refresh`, no task adopted (control leg proves the mint path is live); resume matches only its exact server-issued lease/generation/repo (wrong repo, wrong/zero gen, wrong task, expired, released all rejected); resume refused when suspended/revoked; no full-cache fallback; repo-name scoping.
- H2: revoke is terminal against a stale save; version conflict rejects a lost update; revoke disconnects the live session **and** denies reconnect.
- Updated `contribute_ws_token_refresh_test.go` for the new `tokenRefreshDue`/`resumeTaskToken` signatures.

`go test ./v2/pkg/dashboard/... ./v2/pkg/github/...` green, incl. `-race` on the contribute suite.

Both findings fixed in one cohesive PR. Do not merge — for review.