### PR TITLE
fix(security): C2 — domain-separate the hub master secret (CWE-321/798)

### DIFF
--- a/v2/docs/manual-provisioning.md
+++ b/v2/docs/manual-provisioning.md
@@ -429,6 +429,17 @@ spec:
         # HIVE_HUB_SECRET authenticates every heartbeat to the hub. WITHOUT it,
         # the hub rejects the spoke's heartbeats with 401 and the hive shows
         # OFFLINE forever (see the gotcha below). HIVE_HUB_URL points at the hub.
+        #
+        # SECURITY (C2 domain separation): the hub no longer signs everything with
+        # this one key. It derives a distinct sub-key per trust domain
+        # (heartbeat / session cookie / SSO), so a spoke never needs the master.
+        # Automated hub-hosted provisioning injects ONLY the derived keys
+        # (HIVE_HEARTBEAT_KEY, HIVE_SESSION_KEY, HIVE_SSO_KEY) and NEVER
+        # HIVE_HUB_SECRET. Manual provisioning MAY still set HIVE_HUB_SECRET as
+        # shown below: the spoke derives the same sub-keys from it locally, so
+        # heartbeats/SSO keep working. If you prefer least privilege, set the three
+        # HIVE_*_KEY vars instead (each = HMAC-SHA256(master, "hive-<domain>-v1")
+        # rendered as lowercase hex) and omit HIVE_HUB_SECRET entirely.
         - { name: HIVE_HUB_SECRET, value: "${HUB_SECRET}" }
         - { name: HIVE_HUB_URL,    value: "https://hive.kubestellar.io" }
         # startupProbe keeps the liveness clock from starting until boot

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1701,7 +1701,12 @@ func (s *Server) handleSSO(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	secret := os.Getenv("HIVE_HUB_SECRET")
+	// SSO verification uses the derived SSO sub-key (C2 domain separation): a
+	// hub-hosted spoke is injected HIVE_SSO_KEY and never the master secret, so a
+	// spoke operator cannot mint SSO-as-any-owner tokens. SpokeSSOKey falls back to
+	// deriving from HIVE_HUB_SECRET for self-hosted/legacy spokes that still hold
+	// the master, so verification succeeds against the hub-minted token either way.
+	secret := hub.SpokeSSOKey()
 	if secret == "" {
 		// No shared secret → SSO cannot be verified. Terminate with an
 		// explanation. Redirecting to "/" here is what produced the historical
@@ -1709,7 +1714,7 @@ func (s *Server) handleSSO(w http.ResponseWriter, r *http.Request) {
 		// login, the hub sees a valid session and hands off to /sso again.
 		writeSSOError(w, r, http.StatusServiceUnavailable, ssoErrNoSecret,
 			"This hive has no hub shared secret configured, so single sign-on from the hub cannot be verified.",
-			"Ask the hive operator to set HIVE_HUB_SECRET on this hive. In the meantime you can sign in directly with GitHub using the button below.")
+			"Ask the hive operator to set HIVE_HUB_SECRET (or HIVE_SSO_KEY) on this hive. In the meantime you can sign in directly with GitHub using the button below.")
 		return
 	}
 

--- a/v2/pkg/dashboard/auth_deviceflow_coverage_test.go
+++ b/v2/pkg/dashboard/auth_deviceflow_coverage_test.go
@@ -331,7 +331,7 @@ func TestCovDF_SSO_ValidNoAllowlist(t *testing.T) {
 	t.Setenv("HIVE_HUB_SECRET", secret)
 	s, deps, _ := dfServer(t, "complete", "octocat")
 	deps.Config.HiveID = "hive-abc"
-	tok := hub.MintSSOToken(secret, "alice", config.RoleOwner, "hive-abc", time.Now())
+	tok := hub.MintSSOToken(hub.SpokeSSOKey(), "alice", config.RoleOwner, "hive-abc", time.Now())
 	rec := doGet(s, "/sso?token="+tok)
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("valid sso: want 303, got %d (%s)", rec.Code, rec.Body.String())
@@ -348,7 +348,7 @@ func TestCovDF_SSO_ValidWithAllowlist(t *testing.T) {
 	deps.Config.HiveID = "hive-abc"
 	deps.Config.Dashboard.AuthorizedUsers = []string{"owner1:owner", "alice:read"}
 	deps.Config.Dashboard.HubProxied = false
-	tok := hub.MintSSOToken(secret, "alice", config.RoleOwner, "hive-abc", time.Now())
+	tok := hub.MintSSOToken(hub.SpokeSSOKey(), "alice", config.RoleOwner, "hive-abc", time.Now())
 	rec := doGet(s, "/sso?token="+tok)
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("allowlisted sso: want 303, got %d", rec.Code)
@@ -362,7 +362,7 @@ func TestCovDF_SSO_NotAuthorized(t *testing.T) {
 	deps.Config.HiveID = "hive-abc"
 	deps.Config.Dashboard.AuthorizedUsers = []string{"someoneelse"}
 	deps.Config.Dashboard.HubProxied = false
-	tok := hub.MintSSOToken(secret, "alice", config.RoleOwner, "hive-abc", time.Now())
+	tok := hub.MintSSOToken(hub.SpokeSSOKey(), "alice", config.RoleOwner, "hive-abc", time.Now())
 	rec := doGet(s, "/sso?token="+tok)
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("unauthorized sso: want 403, got %d", rec.Code)

--- a/v2/pkg/dashboard/sso_handoff_test.go
+++ b/v2/pkg/dashboard/sso_handoff_test.go
@@ -109,7 +109,7 @@ func TestSSOHandoff_ValidTokenLandsOnRootWithSession(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			s := newSSOServer(t, tc.hubProxied, tc.authToken, tc.authorized...)
-			tok := hub.MintSSOToken(testHubSecret, "clubanderson", config.RoleOwner, testHiveID, time.Now())
+			tok := hub.MintSSOToken(hub.SpokeSSOKey(), "clubanderson", config.RoleOwner, testHiveID, time.Now())
 			if tok == "" {
 				t.Fatal("failed to mint handoff token")
 			}
@@ -183,7 +183,7 @@ func TestSSOHandoff_LandingRequestIsAuthenticated(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			s := newSSOServer(t, tc.hubProxied, tc.authToken, tc.authorized...)
-			tok := hub.MintSSOToken(testHubSecret, "clubanderson", config.RoleOwner, testHiveID, time.Now())
+			tok := hub.MintSSOToken(hub.SpokeSSOKey(), "clubanderson", config.RoleOwner, testHiveID, time.Now())
 			w := ssoGet(t, s, "token="+tok)
 			c := sessionCookie(w)
 			if c == nil {
@@ -214,7 +214,7 @@ func TestSSOHandoff_LandingRequestIsAuthenticated(t *testing.T) {
 // of them may emit a redirect, because a redirect is what spins the browser.
 func TestSSOHandoff_FailuresTerminateWithoutRedirecting(t *testing.T) {
 	validTok := func() string {
-		return hub.MintSSOToken(testHubSecret, "clubanderson", config.RoleOwner, testHiveID, time.Now())
+		return hub.MintSSOToken(hub.SpokeSSOKey(), "clubanderson", config.RoleOwner, testHiveID, time.Now())
 	}
 
 	tests := []struct {
@@ -257,7 +257,7 @@ func TestSSOHandoff_FailuresTerminateWithoutRedirecting(t *testing.T) {
 			hubProxied: true,
 			hubSecret:  testHubSecret,
 			query: func() string {
-				return "token=" + hub.MintSSOToken(testHubSecret, "clubanderson", config.RoleOwner, "some-other-hive", time.Now())
+				return "token=" + hub.MintSSOToken(hub.SpokeSSOKey(), "clubanderson", config.RoleOwner, "some-other-hive", time.Now())
 			},
 			wantStatus: http.StatusUnauthorized,
 			wantCode:   ssoErrBadToken,
@@ -269,7 +269,7 @@ func TestSSOHandoff_FailuresTerminateWithoutRedirecting(t *testing.T) {
 			query: func() string {
 				// Minted far enough in the past that any sane TTL has lapsed.
 				const wellPastAnyTTL = -24 * time.Hour
-				return "token=" + hub.MintSSOToken(testHubSecret, "clubanderson", config.RoleOwner, testHiveID, time.Now().Add(wellPastAnyTTL))
+				return "token=" + hub.MintSSOToken(hub.SpokeSSOKey(), "clubanderson", config.RoleOwner, testHiveID, time.Now().Add(wellPastAnyTTL))
 			},
 			wantStatus: http.StatusUnauthorized,
 			wantCode:   ssoErrBadToken,
@@ -349,7 +349,7 @@ func TestSSOHandoff_FailuresTerminateWithoutRedirecting(t *testing.T) {
 func TestSSOHandoff_HopCounterAdvances(t *testing.T) {
 	for hop := 0; hop < maxSSOHops; hop++ {
 		s := newSSOServer(t, true, "shared-secret-token")
-		tok := hub.MintSSOToken(testHubSecret, "clubanderson", config.RoleOwner, testHiveID, time.Now())
+		tok := hub.MintSSOToken(hub.SpokeSSOKey(), "clubanderson", config.RoleOwner, testHiveID, time.Now())
 		w := ssoGet(t, s, "token="+tok+"&"+ssoHopParam+"="+strconv.Itoa(hop))
 		if w.Code != http.StatusSeeOther {
 			t.Fatalf("hop=%d: status = %d, want 303 (still under the limit)", hop, w.Code)

--- a/v2/pkg/hub/forge_test.go
+++ b/v2/pkg/hub/forge_test.go
@@ -324,7 +324,7 @@ func postForgeSwitch(t *testing.T, s *HubServer, hiveID, username, body string) 
 	if username != "" {
 		req.AddCookie(&http.Cookie{
 			Name:  "hive_hub_user",
-			Value: mintHubUserCookieValue(forgeTestSecret, username),
+			Value: mintHubUserCookieValue(deriveDomainKey(forgeTestSecret, infoSessionKey), username),
 		})
 	}
 	rec := httptest.NewRecorder()

--- a/v2/pkg/hub/grantable_users_test.go
+++ b/v2/pkg/hub/grantable_users_test.go
@@ -50,9 +50,11 @@ func getGrantableUsers(t *testing.T, s *HubServer, username string) *httptest.Re
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, "/api/saas/grantable-users", nil)
 	if username != "" {
+		// Sign with the derived SESSION sub-key (C2 domain separation), the same
+		// key the hub verifies session cookies with.
 		req.AddCookie(&http.Cookie{
 			Name:  "hive_hub_user",
-			Value: mintHubUserCookieValue(grantableTestSecret, username),
+			Value: mintHubUserCookieValue(deriveDomainKey(grantableTestSecret, infoSessionKey), username),
 		})
 	}
 	rec := httptest.NewRecorder()

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
 	"regexp"
 	"runtime/debug"
 	"sync/atomic"
@@ -790,7 +789,7 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 		return nil
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if secret := os.Getenv("HIVE_HUB_SECRET"); secret != "" {
+	if secret := SpokeHeartbeatKey(); secret != "" {
 		req.Header.Set("Authorization", "Bearer "+secret)
 	}
 
@@ -856,7 +855,7 @@ func SendUpgradingHeartbeat(hubURL string, collect StatusCollector, targetSHA st
 		return
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if secret := os.Getenv("HIVE_HUB_SECRET"); secret != "" {
+	if secret := SpokeHeartbeatKey(); secret != "" {
 		req.Header.Set("Authorization", "Bearer "+secret)
 	}
 
@@ -908,7 +907,7 @@ func ReportUpgradeFailure(hubURL, hiveID, targetSHA, currentSHA, cause string, l
 		return
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if secret := os.Getenv("HIVE_HUB_SECRET"); secret != "" {
+	if secret := SpokeHeartbeatKey(); secret != "" {
 		req.Header.Set("Authorization", "Bearer "+secret)
 	}
 
@@ -1205,7 +1204,7 @@ func StartTaskStatusPush(ctx context.Context, hubURL string, collect TaskStatusC
 				continue
 			}
 			req.Header.Set("Content-Type", "application/json")
-			if secret := os.Getenv("HIVE_HUB_SECRET"); secret != "" {
+			if secret := SpokeHeartbeatKey(); secret != "" {
 				req.Header.Set("Authorization", "Bearer "+secret)
 			}
 			resp, err := http.DefaultClient.Do(req)

--- a/v2/pkg/hub/heartbeat_handler_coverage_test.go
+++ b/v2/pkg/hub/heartbeat_handler_coverage_test.go
@@ -82,7 +82,7 @@ func TestHandleHeartbeatUnauthorized(t *testing.T) {
 	// With the correct bearer token it should succeed.
 	req = httptest.NewRequest(http.MethodPost, "/api/heartbeat", strings.NewReader(`{"hive_id":"h1"}`))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer top-secret")
+	req.Header.Set("Authorization", heartbeatBearer("top-secret"))
 	rec = httptest.NewRecorder()
 	s.handleHeartbeat(rec, req)
 	if rec.Code != http.StatusOK {

--- a/v2/pkg/hub/hub_coverage_boost_test.go
+++ b/v2/pkg/hub/hub_coverage_boost_test.go
@@ -524,7 +524,7 @@ func TestHandleHeartbeatValidPayload(t *testing.T) {
 	body, _ := json.Marshal(payload)
 
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body)))
-	req.Header.Set("Authorization", "Bearer test-secret")
+	req.Header.Set("Authorization", heartbeatBearer("test-secret"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -540,7 +540,7 @@ func TestHandleHeartbeatEmptyHiveID(t *testing.T) {
 
 	payload := `{"hive_id":"","org":"test"}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
-	req.Header.Set("Authorization", "Bearer test-secret")
+	req.Header.Set("Authorization", heartbeatBearer("test-secret"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -558,7 +558,7 @@ func TestHandleHeartbeatInvalidHiveID(t *testing.T) {
 	longID := strings.Repeat("a", 101)
 	payload := fmt.Sprintf(`{"hive_id":"%s"}`, longID)
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
-	req.Header.Set("Authorization", "Bearer test-secret")
+	req.Header.Set("Authorization", heartbeatBearer("test-secret"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -574,7 +574,7 @@ func TestHandleHeartbeatInvalidOrg(t *testing.T) {
 
 	payload := `{"hive_id":"valid-id","org":"bad org name!"}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
-	req.Header.Set("Authorization", "Bearer test-secret")
+	req.Header.Set("Authorization", heartbeatBearer("test-secret"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -592,7 +592,7 @@ func TestHandleHeartbeatInvalidRepo(t *testing.T) {
 	longRepo := strings.Repeat("r", 101)
 	payload := fmt.Sprintf(`{"hive_id":"valid-id","primary_repo":"%s"}`, longRepo)
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
-	req.Header.Set("Authorization", "Bearer test-secret")
+	req.Header.Set("Authorization", heartbeatBearer("test-secret"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -608,7 +608,7 @@ func TestHandleHeartbeatInvalidRepoInList(t *testing.T) {
 
 	payload := `{"hive_id":"valid-id","repos":["good-repo","bad repo!"]}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
-	req.Header.Set("Authorization", "Bearer test-secret")
+	req.Header.Set("Authorization", heartbeatBearer("test-secret"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -624,7 +624,7 @@ func TestHandleHeartbeatBadDashboardURL(t *testing.T) {
 
 	payload := `{"hive_id":"valid-id","dashboard_url":"ftp://bad-scheme.com"}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
-	req.Header.Set("Authorization", "Bearer test-secret")
+	req.Header.Set("Authorization", heartbeatBearer("test-secret"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -640,7 +640,7 @@ func TestHandleHeartbeatBadSnapshotURL(t *testing.T) {
 
 	payload := `{"hive_id":"valid-id","snapshot_url":"ftp://bad.com"}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
-	req.Header.Set("Authorization", "Bearer test-secret")
+	req.Header.Set("Authorization", heartbeatBearer("test-secret"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -656,7 +656,7 @@ func TestHandleHeartbeatInvalidAgentName(t *testing.T) {
 
 	payload := `{"hive_id":"valid-id","agents":[{"name":"bad agent!","state":"running"}]}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
-	req.Header.Set("Authorization", "Bearer test-secret")
+	req.Header.Set("Authorization", heartbeatBearer("test-secret"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -672,7 +672,7 @@ func TestHandleHeartbeatInvalidLeaderboardUsername(t *testing.T) {
 
 	payload := `{"hive_id":"valid-id","leaderboard":[{"github_username":"bad user!"}]}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
-	req.Header.Set("Authorization", "Bearer test-secret")
+	req.Header.Set("Authorization", heartbeatBearer("test-secret"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -747,7 +747,7 @@ func TestHandleHeartbeatLocalHiveType(t *testing.T) {
 	payload := `{"hive_id":"my-local-hive","hive_type":"local"}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+secret)
+	req.Header.Set("Authorization", heartbeatBearer(secret))
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
 
@@ -780,7 +780,7 @@ func TestHandleHeartbeatHostedHiveRejectedWithoutSaaS(t *testing.T) {
 	payload := `{"hive_id":"hosted-test-nosaas"}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+secret)
+	req.Header.Set("Authorization", heartbeatBearer(secret))
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
 
@@ -820,7 +820,7 @@ func TestHandleTaskStatusValid(t *testing.T) {
 
 	payload := `{"hive_id":"task-hive","leaderboard":[{"github_username":"user1","tasks_completed":3}],"contributors":{"registered":5,"active":2}}`
 	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader(payload))
-	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Authorization", heartbeatBearer("secret"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -835,7 +835,7 @@ func TestHandleTaskStatusBadJSON(t *testing.T) {
 	srv.hubSecret = "secret"
 
 	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader("not json"))
-	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Authorization", heartbeatBearer("secret"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -850,7 +850,7 @@ func TestHandleTaskStatusEmptyHiveID(t *testing.T) {
 	srv.hubSecret = "secret"
 
 	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader(`{"hive_id":""}`))
-	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Authorization", heartbeatBearer("secret"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -871,7 +871,7 @@ func TestHandleTaskStatusOfflineHive(t *testing.T) {
 	srv.mu.Unlock()
 
 	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader(`{"hive_id":"offline-hive"}`))
-	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Authorization", heartbeatBearer("secret"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)

--- a/v2/pkg/hub/hub_coverage_extra_test.go
+++ b/v2/pkg/hub/hub_coverage_extra_test.go
@@ -1228,7 +1228,7 @@ func TestHandleHeartbeatSaaSHivePrefix(t *testing.T) {
 	payload := `{"hive_id":"saas-test-nosaas"}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+secret)
+	req.Header.Set("Authorization", heartbeatBearer(secret))
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
 

--- a/v2/pkg/hub/hub_heartbeat_test.go
+++ b/v2/pkg/hub/hub_heartbeat_test.go
@@ -211,8 +211,16 @@ func TestSendHeartbeatWithSecret(t *testing.T) {
 		return &HeartbeatPayload{HiveID: "test"}
 	}, slog.Default())
 
-	if gotAuth != "Bearer test-secret-123" {
-		t.Errorf("Authorization header = %q, want 'Bearer test-secret-123'", gotAuth)
+	// C2 domain separation: the spoke must present the DERIVED heartbeat sub-key,
+	// NOT the raw master. Sending "Bearer test-secret-123" here would mean the
+	// spoke still leaks the master — the whole vulnerability. Assert the derived
+	// value and, defensively, that the master itself never appears on the wire.
+	wantAuth := heartbeatBearer("test-secret-123")
+	if gotAuth != wantAuth {
+		t.Errorf("Authorization header = %q, want %q", gotAuth, wantAuth)
+	}
+	if gotAuth == "Bearer test-secret-123" {
+		t.Error("spoke leaked the master HIVE_HUB_SECRET as the heartbeat bearer")
 	}
 }
 

--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -1,0 +1,130 @@
+package hub
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"strings"
+)
+
+// Domain-separated key derivation for the hub master secret (CWE-321/798, C2).
+//
+// Historically ONE symmetric key, HIVE_HUB_SECRET, signed EVERYTHING: the
+// heartbeat bearer, the session cookie, the SSO handoff token, and the
+// impersonation cookie — and that same master was injected in plaintext into
+// every spoke Deployment. Any spoke operator could read it from the pod env and
+// forge admin session cookies, mint SSO-as-any-owner tokens, or emit
+// impersonation grants. The signing material for browser/admin trust lived on
+// machines whose operators are NOT trusted with that authority.
+//
+// The fix keeps a single master secret but derives a DISTINCT sub-key per trust
+// domain. A holder of one domain's sub-key learns nothing about the master or
+// the other domains' keys (HMAC is a PRF), so a sub-key can only ever sign/verify
+// within its own domain. Crucially this lets the hub hand a spoke ONLY the
+// sub-keys it actually needs (heartbeat + session + sso verification) while the
+// impersonation key — and the master itself — never leave the hub.
+//
+// Derivation is HMAC-SHA256(master, info) rendered as lowercase hex. This is a
+// standard HKDF-Expand-style single-block expansion: deterministic, no extra
+// dependency (x/crypto/hkdf is not a direct module dependency), and more than
+// sufficient for domain separation since each info string is a fixed, unique
+// label. The output is hex so every derived key is a safe ASCII value for an env
+// var, a Bearer token, and an HMAC key on both the Go and Node sides.
+
+const (
+	// Domain-separator info strings. Each is versioned ("-v1") so the format can
+	// evolve without a verifier ever silently accepting a foreign-domain key.
+	// These constants are the contract shared with the spoke (which receives the
+	// already-derived keys) and with the Node proxy (v2/proxy/server.js), so they
+	// must NOT change without a coordinated rollout.
+	infoHeartbeatKey   = "hive-heartbeat-v1"
+	infoSessionKey     = "hive-session-v1"
+	infoSSOKey         = "hive-sso-v1"
+	infoImpersonateKey = "hive-impersonate-v1"
+)
+
+// deriveDomainKey returns a domain-separated sub-key of master for the given
+// info label, as lowercase hex. Returns "" for an empty master so callers keep
+// their existing "no secret configured → feature disabled / fail closed"
+// behavior unchanged (an empty master must never derive to a usable key).
+func deriveDomainKey(master, info string) string {
+	if master == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, []byte(master))
+	mac.Write([]byte(info))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// The four per-domain accessors below are the ONLY way hub code should obtain
+// signing material. Nothing outside the heartbeat verify path should ever touch
+// s.hubSecret (the master) directly again.
+
+func (s *HubServer) heartbeatKey() string {
+	return deriveDomainKey(s.hubSecret, infoHeartbeatKey)
+}
+
+func (s *HubServer) sessionKey() string {
+	return deriveDomainKey(s.hubSecret, infoSessionKey)
+}
+
+func (s *HubServer) ssoKey() string {
+	return deriveDomainKey(s.hubSecret, infoSSOKey)
+}
+
+func (s *HubServer) impersonateKey() string {
+	return deriveDomainKey(s.hubSecret, infoImpersonateKey)
+}
+
+// Dedicated spoke-side env vars. A hub-hosted spoke is provisioned with ONLY the
+// derived sub-keys it needs (heartbeat + session + sso); it never receives the
+// master HIVE_HUB_SECRET. Impersonation is a hub-only capability, so no spoke key
+// exists for it — a spoke simply cannot mint or verify an impersonation grant.
+const (
+	EnvHeartbeatKey = "HIVE_HEARTBEAT_KEY"
+	EnvSessionKey   = "HIVE_SESSION_KEY"
+	EnvSSOKey       = "HIVE_SSO_KEY"
+)
+
+// spokeDomainKey resolves a domain sub-key for spoke-side code. It prefers the
+// dedicated per-domain env var (the modern, least-privilege provisioning path).
+// If that is empty it falls back to deriving the sub-key from HIVE_HUB_SECRET —
+// the backward-compatible path for (a) self-hosted hives whose operator legitimately
+// holds the master and points heartbeats at their own hub, and (b) any spoke still
+// rolling on an OLD Deployment that injected the master before this change. In the
+// fallback the spoke still gets the CORRECT domain-separated key, so hub verification
+// (which now expects the derived key) succeeds either way. Returns "" only when
+// neither source is configured, preserving each caller's fail-closed behavior.
+func spokeDomainKey(envVar, info string) string {
+	if v := strings.TrimSpace(os.Getenv(envVar)); v != "" {
+		return v
+	}
+	return deriveDomainKey(strings.TrimSpace(os.Getenv("HIVE_HUB_SECRET")), info)
+}
+
+// SpokeHeartbeatKey returns the bearer a spoke presents on /api/heartbeat and
+// /api/task-status. Exported for use from the dashboard/heartbeat call sites.
+func SpokeHeartbeatKey() string { return spokeDomainKey(EnvHeartbeatKey, infoHeartbeatKey) }
+
+// SpokeSessionKey returns the key a spoke uses to VERIFY the hub-minted
+// `hive_hub_user` session/terminal cookie. It signs nothing on the spoke.
+func SpokeSessionKey() string { return spokeDomainKey(EnvSessionKey, infoSessionKey) }
+
+// SpokeSSOKey returns the key a spoke uses to VERIFY a hub-minted SSO handoff
+// token. It signs nothing on the spoke.
+func SpokeSSOKey() string { return spokeDomainKey(EnvSSOKey, infoSSOKey) }
+
+// provisionMasterSecret resolves the hub's MASTER secret at provision time, the
+// same way NewHubServer does: prefer HIVE_HUB_SECRET, else the persisted
+// /data/saas/hub-secret.key. Used ONLY to derive the per-domain sub-keys that get
+// injected into a spoke — the master itself is never placed in the Deployment.
+func provisionMasterSecret() string {
+	if s := strings.TrimSpace(os.Getenv("HIVE_HUB_SECRET")); s != "" {
+		return s
+	}
+	if data, err := os.ReadFile("/data/saas/hub-secret.key"); err == nil {
+		return strings.TrimSpace(string(data))
+	}
+	return ""
+}

--- a/v2/pkg/hub/hub_keys_test.go
+++ b/v2/pkg/hub/hub_keys_test.go
@@ -1,0 +1,107 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDomainKeysAreDistinct pins the C2 guarantee at the primitive level: the
+// four per-domain sub-keys derived from one master are all different from each
+// other AND from the master itself. If any two collided, a holder of one domain's
+// key could operate in another's.
+func TestDomainKeysAreDistinct(t *testing.T) {
+	const master = "master-secret-under-test"
+	keys := map[string]string{
+		"heartbeat":   deriveDomainKey(master, infoHeartbeatKey),
+		"session":     deriveDomainKey(master, infoSessionKey),
+		"sso":         deriveDomainKey(master, infoSSOKey),
+		"impersonate": deriveDomainKey(master, infoImpersonateKey),
+	}
+	seen := map[string]string{master: "master"}
+	for name, k := range keys {
+		if k == "" {
+			t.Fatalf("%s key derived empty", name)
+		}
+		if prev, dup := seen[k]; dup {
+			t.Fatalf("%s key collides with %s", name, prev)
+		}
+		seen[k] = name
+	}
+	// An empty master must never yield a usable key (fail-closed).
+	if deriveDomainKey("", infoSessionKey) != "" {
+		t.Fatal("empty master must derive to empty key")
+	}
+}
+
+// TestSpokeHeartbeatKeyCannotForgeOtherDomains is the heart of the fix: the ONLY
+// signing material a spoke holds is the heartbeat sub-key. This test proves that
+// key cannot be used to mint OR verify anything in the session, SSO, or
+// impersonation domains — the exact forgeries the single-key design allowed.
+func TestSpokeHeartbeatKeyCannotForgeOtherDomains(t *testing.T) {
+	const master = "the-hub-master-secret"
+	now := time.Now()
+
+	// What the hub verifies with, per domain.
+	sessionKey := deriveDomainKey(master, infoSessionKey)
+	ssoKey := deriveDomainKey(master, infoSSOKey)
+	impersonateKey := deriveDomainKey(master, infoImpersonateKey)
+
+	// What a spoke actually holds (all it is injected).
+	spokeHeartbeatKey := deriveDomainKey(master, infoHeartbeatKey)
+
+	// 1. Session cookie: a cookie signed with the spoke's heartbeat key must NOT
+	//    verify against the hub's session key.
+	forgedSession := mintHubUserCookieValue(spokeHeartbeatKey, "attacker-admin")
+	if _, ok := verifyHubUserCookieValue(sessionKey, forgedSession); ok {
+		t.Error("spoke heartbeat key forged a valid hub SESSION cookie")
+	}
+
+	// 2. SSO token: a token minted with the spoke's heartbeat key must NOT verify
+	//    against the hub's SSO key.
+	forgedSSO := MintSSOToken(spokeHeartbeatKey, "victim-owner", "owner", "hive-x", now)
+	if _, _, err := VerifySSOToken(ssoKey, forgedSSO, "hive-x", now); err == nil {
+		t.Error("spoke heartbeat key forged a valid SSO handoff token")
+	}
+
+	// 3. Impersonation cookie: minted with the heartbeat key must NOT verify
+	//    against the hub's impersonation key. (Spokes never even hold this key.)
+	forgedImp := mintImpersonateCookieValue(spokeHeartbeatKey, hubAdminUsername, "victim", now)
+	if _, ok := verifyImpersonateCookieValue(impersonateKey, forgedImp, now); ok {
+		t.Error("spoke heartbeat key forged a valid impersonation grant")
+	}
+
+	// Sanity: each domain's own key DOES round-trip, so the negatives above are
+	// about domain separation, not a broken primitive.
+	if v := mintHubUserCookieValue(sessionKey, "alice"); v == "" {
+		t.Fatal("session key failed to mint")
+	} else if u, ok := verifyHubUserCookieValue(sessionKey, v); !ok || u != "alice" {
+		t.Fatal("session key round-trip failed")
+	}
+}
+
+// TestSpokeKeyResolutionPrefersExplicitEnv confirms the spoke helpers use the
+// dedicated per-domain env var when present, and otherwise derive from the master
+// — so both the modern (least-privilege) and legacy provisioning paths yield the
+// key the hub expects.
+func TestSpokeKeyResolutionPrefersExplicitEnv(t *testing.T) {
+	const master = "legacy-master"
+
+	// Legacy path: only the master is present → derive.
+	t.Setenv("HIVE_HUB_SECRET", master)
+	t.Setenv(EnvHeartbeatKey, "")
+	if got, want := SpokeHeartbeatKey(), deriveDomainKey(master, infoHeartbeatKey); got != want {
+		t.Errorf("legacy heartbeat key = %q, want derived %q", got, want)
+	}
+
+	// Modern path: explicit key wins over any master-derivation.
+	t.Setenv(EnvHeartbeatKey, "explicit-injected-key")
+	if got := SpokeHeartbeatKey(); got != "explicit-injected-key" {
+		t.Errorf("explicit heartbeat key = %q, want the injected value", got)
+	}
+
+	// The master itself is NOT a valid spoke bearer: the hub verifies the derived
+	// key, so presenting the raw master would fail. Prove they differ.
+	if SpokeHeartbeatKey() == master {
+		t.Error("spoke bearer must never equal the raw master secret")
+	}
+}

--- a/v2/pkg/hub/impersonation_test.go
+++ b/v2/pkg/hub/impersonation_test.go
@@ -18,11 +18,14 @@ import (
 // setPathValue, helperSetupTempDirs).
 
 // impersonateCookie mints a signed impersonation cookie the same way the server
-// does, so a test can present a genuine grant.
+// does, so a test can present a genuine grant. It signs with the derived
+// IMPERSONATE sub-key (C2 domain separation) — the same key the hub verifies
+// impersonation cookies with. This key is HUB-ONLY: it is never derived for or
+// injected into a spoke.
 func impersonateCookie(admin, target string, now time.Time) *http.Cookie {
 	return &http.Cookie{
 		Name:  impersonateCookieName,
-		Value: mintImpersonateCookieValue(testHubSecret, admin, target, now),
+		Value: mintImpersonateCookieValue(deriveDomainKey(testHubSecret, infoImpersonateKey), admin, target, now),
 	}
 }
 

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -269,7 +269,7 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	// Set the session cookie to a signed, tamper-evident value so it cannot be
 	// forged. If the hub has no secret to sign with, fail the login rather than
 	// emit an unsigned (trusted-by-default) cookie.
-	cookieValue := mintHubUserCookieValue(s.hubSecret, user.Login)
+	cookieValue := mintHubUserCookieValue(s.sessionKey(), user.Login)
 	if cookieValue == "" {
 		s.logger.Warn("OAuth: cannot mint signed session cookie", "user", user.Login)
 		http.Error(w, "session unavailable", http.StatusInternalServerError)
@@ -320,7 +320,7 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 	}
 	// Trust the carried username only when its signature verifies; a legacy
 	// unsigned or forged cookie reports unauthenticated, prompting a re-login.
-	username, ok := verifyHubUserCookieValue(s.hubSecret, cookie.Value)
+	username, ok := verifyHubUserCookieValue(s.sessionKey(), cookie.Value)
 	if !ok || loadSaaSUser(username) == nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"authenticated":false}`))

--- a/v2/pkg/hub/oauth_provision_coverage_test.go
+++ b/v2/pkg/hub/oauth_provision_coverage_test.go
@@ -106,7 +106,7 @@ func TestHandleOAuthCallbackSuccess(t *testing.T) {
 	if sessionCookie.Value == "octocat" {
 		t.Error("session cookie must be signed, not the raw username")
 	}
-	if user, ok := verifyHubUserCookieValue(testHubSecret, sessionCookie.Value); !ok || user != "octocat" {
+	if user, ok := verifyHubUserCookieValue(deriveDomainKey(testHubSecret, infoSessionKey), sessionCookie.Value); !ok || user != "octocat" {
 		t.Errorf("minted cookie did not verify: (%q, %v)", user, ok)
 	}
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -384,7 +384,7 @@ func (s *HubServer) activeImpersonationGrant(r *http.Request) (impersonationGran
 	if err != nil || cookie.Value == "" {
 		return impersonationGrant{}, false
 	}
-	grant, ok := verifyImpersonateCookieValue(s.hubSecret, cookie.Value, time.Now())
+	grant, ok := verifyImpersonateCookieValue(s.impersonateKey(), cookie.Value, time.Now())
 	if !ok || grant.Admin != hubAdminUsername {
 		return impersonationGrant{}, false
 	}
@@ -473,7 +473,7 @@ func (s *HubServer) getRealAuthUser(r *http.Request) string {
 		// against the hub secret. A legacy unsigned cookie or a forged value
 		// fails here and is treated as logged out, so the user re-authenticates
 		// through the normal login flow (which re-mints a signed cookie).
-		if username, ok := verifyHubUserCookieValue(s.hubSecret, cookie.Value); ok {
+		if username, ok := verifyHubUserCookieValue(s.sessionKey(), cookie.Value); ok {
 			if loadSaaSUser(username) != nil {
 				return username
 			}
@@ -520,7 +520,7 @@ func (s *HubServer) resolveIdentity(r *http.Request) (effective, realUser string
 	if err != nil || cookie.Value == "" {
 		return realUser, realUser, false
 	}
-	grant, ok := verifyImpersonateCookieValue(s.hubSecret, cookie.Value, time.Now())
+	grant, ok := verifyImpersonateCookieValue(s.impersonateKey(), cookie.Value, time.Now())
 	if !ok {
 		return realUser, realUser, false
 	}
@@ -810,7 +810,7 @@ func (s *HubServer) handleImpersonateStart(w http.ResponseWriter, r *http.Reques
 		writeJSONError(w, http.StatusNotFound, "user not found")
 		return
 	}
-	value := mintImpersonateCookieValue(s.hubSecret, admin, target, time.Now())
+	value := mintImpersonateCookieValue(s.impersonateKey(), admin, target, time.Now())
 	if value == "" {
 		writeJSONError(w, http.StatusInternalServerError, "cannot start impersonation")
 		return
@@ -2856,7 +2856,7 @@ func (s *HubServer) handleOpenHive(w http.ResponseWriter, r *http.Request) {
 	// Mint the handoff token. Without a hub secret we can't sign one, so fall
 	// back to a plain dashboard redirect (spoke will prompt for login).
 	if s.hubSecret != "" {
-		if tok := MintSSOToken(s.hubSecret, username, role, id, time.Now()); tok != "" {
+		if tok := MintSSOToken(s.ssoKey(), username, role, id, time.Now()); tok != "" {
 			http.Redirect(w, r, base+"/sso?token="+url.QueryEscape(tok), http.StatusSeeOther)
 			return
 		}

--- a/v2/pkg/hub/saas_handlers_coverage_test.go
+++ b/v2/pkg/hub/saas_handlers_coverage_test.go
@@ -23,11 +23,22 @@ import (
 // server recomputes matches the one baked into the cookie.
 const testHubSecret = "test-hub-secret-f4"
 
-// testAuthCookie mints a signed hive_hub_user cookie for username using
-// testHubSecret, matching the production cookie format so getAuthUser /
-// handleAuthUser accept it.
+// testAuthCookie mints a signed hive_hub_user cookie for username using the
+// derived SESSION sub-key of testHubSecret (C2 domain separation) — the same key
+// the hub now verifies session cookies with. A cookie signed with the raw master
+// no longer verifies (that is the whole point of the fix), so tests must sign
+// with the session sub-key to match getAuthUser / handleAuthUser.
 func testAuthCookie(username string) *http.Cookie {
-	return &http.Cookie{Name: "hive_hub_user", Value: mintHubUserCookieValue(testHubSecret, username)}
+	sessionKey := deriveDomainKey(testHubSecret, infoSessionKey)
+	return &http.Cookie{Name: "hive_hub_user", Value: mintHubUserCookieValue(sessionKey, username)}
+}
+
+// heartbeatBearer returns the derived HEARTBEAT-domain bearer for a given master
+// secret (C2 domain separation). The hub verifies /api/heartbeat and
+// /api/task-status against this sub-key, NOT the raw master, so tests that hit
+// those handlers with an explicit hubSecret must send this value.
+func heartbeatBearer(master string) string {
+	return "Bearer " + deriveDomainKey(master, infoHeartbeatKey)
 }
 
 // mkUser writes a SaaS user to the temp dir so getAuthUser resolves the cookie.

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1415,15 +1415,17 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 			}
 			return hex.EncodeToString(b)
 		}(),
-		"HubSecret": func() string {
-			if s := os.Getenv("HIVE_HUB_SECRET"); s != "" {
-				return s
-			}
-			if data, err := os.ReadFile("/data/saas/hub-secret.key"); err == nil {
-				return strings.TrimSpace(string(data))
-			}
-			return ""
-		}(),
+		// C2 domain separation (CWE-321/798): the spoke Deployment is injected ONLY
+		// the derived sub-keys it needs — the heartbeat bearer, plus the session and
+		// SSO verification keys — and NEVER the master HIVE_HUB_SECRET. A spoke
+		// operator can read its pod env, but those keys can only prove
+		// "I am a provisioned spoke" / verify hub-minted cookies and tokens; they
+		// cannot mint an admin session, an SSO-as-any-owner token, or an
+		// impersonation grant (the impersonation key is hub-only and never derived
+		// here). The master, which could sign all of the above, stays on the hub.
+		"HeartbeatKey": deriveDomainKey(provisionMasterSecret(), infoHeartbeatKey),
+		"SessionKey":   deriveDomainKey(provisionMasterSecret(), infoSessionKey),
+		"SSOKey":       deriveDomainKey(provisionMasterSecret(), infoSSOKey),
 		// Cluster-aware fields.
 		"DashboardHost":      dashboardHost,
 		"DashboardURL":       dashboardURL,
@@ -2223,8 +2225,17 @@ spec:
           value: "{{.ACMMLevel}}"
         - name: HIVE_HUB_URL
           value: https://hive.kubestellar.io
-        - name: HIVE_HUB_SECRET
-          value: "{{.HubSecret}}"
+        # C2 domain separation: derived per-domain sub-keys ONLY — never the
+        # master HIVE_HUB_SECRET. HEARTBEAT authenticates beats to the hub;
+        # SESSION/SSO verify hub-minted cookies and handoff tokens. None of these
+        # can forge a hub admin session, an SSO-as-any-owner token, or an
+        # impersonation grant.
+        - name: HIVE_HEARTBEAT_KEY
+          value: "{{.HeartbeatKey}}"
+        - name: HIVE_SESSION_KEY
+          value: "{{.SessionKey}}"
+        - name: HIVE_SSO_KEY
+          value: "{{.SSOKey}}"
 {{- if .AuthorizedUsers}}
         - name: HIVE_AUTHORIZED_USERS
           value: "{{.AuthorizedUsers}}"

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1039,9 +1039,13 @@ func (s *HubServer) Shutdown(timeout time.Duration) error {
 }
 
 func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
+	// Heartbeats authenticate with the derived HEARTBEAT sub-key, not the master
+	// secret — the master never leaves the hub (C2 domain separation). Spokes are
+	// injected only this sub-key, so a spoke operator's bearer can prove
+	// "I am a provisioned spoke" but cannot sign a session/SSO/impersonation value.
 	if s.hubSecret != "" {
 		auth := r.Header.Get("Authorization")
-		if !strings.HasPrefix(auth, "Bearer ") || !secureCompareHub(strings.TrimPrefix(auth, "Bearer "), s.hubSecret) {
+		if !strings.HasPrefix(auth, "Bearer ") || !secureCompareHub(strings.TrimPrefix(auth, "Bearer "), s.heartbeatKey()) {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -2054,9 +2058,11 @@ func (s *HubServer) handleLeaderboard(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *HubServer) handleTaskStatus(w http.ResponseWriter, r *http.Request) {
+	// Same derived HEARTBEAT sub-key as /api/heartbeat (task-status is the spoke's
+	// other beat channel); the master secret is never accepted here.
 	if s.hubSecret != "" {
 		auth := r.Header.Get("Authorization")
-		if !strings.HasPrefix(auth, "Bearer ") || !secureCompareHub(strings.TrimPrefix(auth, "Bearer "), s.hubSecret) {
+		if !strings.HasPrefix(auth, "Bearer ") || !secureCompareHub(strings.TrimPrefix(auth, "Bearer "), s.heartbeatKey()) {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/v2/pkg/hub/slack_test.go
+++ b/v2/pkg/hub/slack_test.go
@@ -21,7 +21,7 @@ func postSlack(t *testing.T, username, body string, path string, pathVals map[st
 	if username != "" {
 		req.AddCookie(&http.Cookie{
 			Name:  "hive_hub_user",
-			Value: mintHubUserCookieValue(slackTestSecret, username),
+			Value: mintHubUserCookieValue(deriveDomainKey(slackTestSecret, infoSessionKey), username),
 		})
 	}
 	rec := httptest.NewRecorder()

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -14,11 +14,31 @@ const TTYD_PORT = parseInt(process.env.HIVE_TTYD_PORT || '7681', 10);
 const TTYD_URL = `http://127.0.0.1:${TTYD_PORT}`;
 const DASHBOARD_TOKEN = process.env.HIVE_DASHBOARD_TOKEN || '';
 const STATIC_DIR = process.env.HIVE_STATIC_DIR || path.join(__dirname, 'public');
-// HIVE_HUB_SECRET is present ONLY on hub-hosted hives (injected by the hub at
-// provision time). Its presence is the boot-time signal that this hive runs
-// hosted, where per-request identity comes from the hub-minted, HMAC-signed
-// `hive_hub_user` cookie (verified below) rather than a shared dashboard token.
-const HUB_SECRET = process.env.HIVE_HUB_SECRET || '';
+// C2 domain separation: the proxy verifies the hub-minted `hive_hub_user`
+// session/terminal cookie, which is HMAC'd with the derived SESSION sub-key —
+// NOT the master hub secret. A hub-hosted hive is injected HIVE_SESSION_KEY and
+// never the master, so a spoke operator cannot forge a session cookie.
+//
+// SESSION_KEY resolution mirrors the Go SpokeSessionKey() helper:
+//   1. HIVE_SESSION_KEY (modern least-privilege provisioning) if set, else
+//   2. derive it from HIVE_HUB_SECRET via HMAC-SHA256(master, "hive-session-v1")
+//      — the backward-compatible path for self-hosted/legacy spokes that still
+//      hold the master. Both yield the identical key the hub signs with.
+// The info string MUST stay byte-for-byte identical to infoSessionKey in
+// v2/pkg/hub/hub_keys.go.
+const INFO_SESSION_KEY = 'hive-session-v1';
+function deriveSessionKey() {
+  const explicit = (process.env.HIVE_SESSION_KEY || '').trim();
+  if (explicit) return explicit;
+  const master = (process.env.HIVE_HUB_SECRET || '').trim();
+  if (!master) return '';
+  return crypto.createHmac('sha256', master).update(INFO_SESSION_KEY).digest('hex');
+}
+const SESSION_KEY = deriveSessionKey();
+// Boot-time "am I hub-hosted?" signal. Either the injected session key (modern)
+// or a master secret (legacy) proves hosted mode, where identity comes from the
+// hub cookie rather than a shared dashboard token.
+const IS_HOSTED = SESSION_KEY !== '';
 
 // SECURITY (fail closed on empty dashboard token — CWE-306).
 //
@@ -30,11 +50,11 @@ const HUB_SECRET = process.env.HIVE_HUB_SECRET || '';
 //
 // Hosted hives INTENTIONALLY run with HIVE_DASHBOARD_TOKEN unset: identity is
 // carried by the hub cookie, so a missing token is expected there and the proxy
-// must still boot. HUB_SECRET being set proves hosted mode. Only a self-hosted
-// deploy with neither a token nor a hub secret is truly unauthenticated, and
-// that is what we refuse to start.
-if (!DASHBOARD_TOKEN && !HUB_SECRET && process.env.NODE_ENV !== 'test') {
-  console.error('[SECURITY] HIVE_DASHBOARD_TOKEN is not set and this hive is not hub-hosted (HIVE_HUB_SECRET unset) — all mutation endpoints would be unauthenticated. Refusing to start. Set HIVE_DASHBOARD_TOKEN.');
+// must still boot. A resolved SESSION_KEY (IS_HOSTED) proves hosted mode. Only a
+// self-hosted deploy with neither a token nor a session key is truly
+// unauthenticated, and that is what we refuse to start.
+if (!DASHBOARD_TOKEN && !IS_HOSTED && process.env.NODE_ENV !== 'test') {
+  console.error('[SECURITY] HIVE_DASHBOARD_TOKEN is not set and this hive is not hub-hosted (no HIVE_SESSION_KEY / HIVE_HUB_SECRET) — all mutation endpoints would be unauthenticated. Refusing to start. Set HIVE_DASHBOARD_TOKEN.');
   process.exit(1);
 }
 
@@ -56,7 +76,7 @@ function requireAuth(req, res, next) {
 
 // verifyHubUserCookie mirrors verifyHubUserCookieValue in v2/pkg/hub/hub_cookie.go
 // EXACTLY. The `hive_hub_user` cookie value is `<username>.<sig>` where sig is
-// base64url-unpadded HMAC-SHA256(key=HUB_SECRET, msg=username). The proxy holds
+// base64url-unpadded HMAC-SHA256(key=SESSION_KEY, msg=username). The proxy holds
 // no other secret and must not merely check that the cookie is non-empty (that
 // was CWE-345: any `Cookie: hive_hub_user=x` yielded a shell in a
 // credential-holding container). We recompute the HMAC and constant-time-compare
@@ -191,7 +211,7 @@ app.use('/terminal', (req, res, next) => {
     }, {});
     // SECURITY (CWE-345): the cookie is HMAC-signed by the hub. Verify the
     // signature — a non-empty value is NOT proof of authentication.
-    const user = verifyHubUserCookie(HUB_SECRET, cookies['hive_hub_user']);
+    const user = verifyHubUserCookie(SESSION_KEY, cookies['hive_hub_user']);
     if (!user) {
       if (req.headers.upgrade === 'websocket') {
         req.socket.destroy();
@@ -277,7 +297,7 @@ server.on('upgrade', (req, socket, head) => {
         return acc;
       }, {});
       // SECURITY (CWE-345): verify the hub's HMAC signature, not mere existence.
-      if (!verifyHubUserCookie(HUB_SECRET, cookies['hive_hub_user'])) {
+      if (!verifyHubUserCookie(SESSION_KEY, cookies['hive_hub_user'])) {
         socket.destroy();
         return;
       }


### PR DESCRIPTION
## C2 (Critical, CWE-321/798): one hub secret signed everything

A single symmetric key — `HIVE_HUB_SECRET` — signed **all** of these trust domains:

- **Heartbeat bearer** (`server.go` `handleHeartbeat` / `handleTaskStatus` verify; `heartbeat.go` senders)
- **Session cookie** HMAC (`hub_cookie.go`, minted in `oauth.go`, verified in `saas.go` `resolveIdentity`)
- **SSO handoff token** (`sso.go`, minted in `saas.go`, verified on the spoke in `dashboard/api.go`)
- **Impersonation cookie** (`impersonate_cookie.go`, minted/verified in `saas.go`)
- **Spoke terminal/session cookie** verify (`proxy/server.js` `verifyHubUserCookie`)

…and the **same master was injected in plaintext into every spoke Deployment** (`saas_provision.go`). Any spoke operator could read it from pod env and **forge admin session cookies, SSO-as-any-owner tokens, heartbeats, and impersonation grants**. Signing material for hub/browser/admin trust lived on machines whose operators are not trusted with that authority.

## Fix: HKDF-style domain separation

Keep one master secret, derive a **distinct sub-key per domain** and use each only within its domain:

```
key = HMAC-SHA256(master, info)   // lowercase hex
  heartbeat   = derive(master, "hive-heartbeat-v1")
  session     = derive(master, "hive-session-v1")
  sso         = derive(master, "hive-sso-v1")
  impersonate = derive(master, "hive-impersonate-v1")
```

Single-block HMAC expansion (no new dependency — `x/crypto/hkdf` is not a direct module dep; a fixed unique info label makes this sufficient for domain separation). New file `pkg/hub/hub_keys.go` holds the derivation + the four hub-side accessors and the spoke-side helpers. HMAC is a PRF, so holding one sub-key reveals nothing about the master or the other sub-keys.

### The 5 call sites (hub side — `s.hubSecret` is the master)
1. **Session cookie** mint/verify → `s.sessionKey()` (`oauth.go` ×2, `saas.go` `resolveIdentity`)
2. **Impersonation** mint/verify → `s.impersonateKey()` (`saas.go` ×3)
3. **SSO** mint → `s.ssoKey()` (`saas.go`)
4. **Heartbeat/task-status** bearer verify → `s.heartbeatKey()` (`server.go` ×2)
5. **Spoke terminal/session cookie** verify → derived session key (`proxy/server.js`)

### What spokes now receive (the most important part)
Provisioning (`saas_provision.go`) injects **only** the derived keys the spoke actually needs — and **never the master, never the impersonation key**:

```
- name: HIVE_HEARTBEAT_KEY   # bearer for /api/heartbeat + /api/task-status
- name: HIVE_SESSION_KEY     # verify hub-minted hive_hub_user cookie (Go proxy + Node)
- name: HIVE_SSO_KEY         # verify hub-minted SSO handoff token
```

Spoke-side code reads these via `hub.SpokeHeartbeatKey()` / `SpokeSessionKey()` / `SpokeSSOKey()` (`heartbeat.go` senders, `dashboard/api.go` SSO verify, `proxy/server.js` cookie verify). Each helper **falls back to deriving from `HIVE_HUB_SECRET`** when the dedicated var is absent, so **self-hosted hives and any spoke still on an old Deployment keep working** — they just derive the same domain key the hub expects.

A spoke can now prove "I am a provisioned spoke" (heartbeat) and verify hub-minted cookies/tokens, but **cannot mint an admin session, an SSO-as-any-owner token, or an impersonation grant** — the cross-domain forgeries the old design allowed.

## What is deferred / out of scope
- **SSO stays symmetric** (shared derived key, hub mints / spoke verifies) rather than moving to asymmetric hub-signs / spoke-verifies-with-public-key. HKDF domain separation already removes the cross-domain forgery and keeps the master off spokes; full asymmetric SSO is a larger follow-up.
- **`api_contribute.go` invite-token signing** still reads `HIVE_HUB_SECRET` as a convenience seed. Invite tokens are **spoke-local** (minted AND verified on the same spoke) — not hub-trust material, so no cross-domain forgery. On a hosted spoke (which no longer has the master) it falls back to its existing per-instance random secret; left unchanged to preserve invite-link semantics.

## No secret rotation
This is a **code change only**. The master `HIVE_HUB_SECRET` is unchanged; only the set of domains it directly signs is split. No secrets were generated or rotated.

## Tests
- New `pkg/hub/hub_keys_test.go`:
  - `TestDomainKeysAreDistinct` — the four sub-keys and the master are all distinct; empty master → empty key (fail-closed).
  - `TestSpokeHeartbeatKeyCannotForgeOtherDomains` — the spoke's heartbeat key cannot mint/verify a session cookie, SSO token, or impersonation grant.
  - `TestSpokeKeyResolutionPrefersExplicitEnv` — dedicated env var wins; else derive from master; spoke bearer never equals the raw master.
- Existing cookie/SSO/impersonation/heartbeat tests updated to sign with the correct **derived** sub-key (they still round-trip end-to-end because they derive from the same master). Notably `TestSendHeartbeatWithSecret` now asserts the spoke sends the **derived** key and **not** the raw master.
- `go test ./v2/pkg/hub/ ./v2/pkg/dashboard/` — **all pass**. `node --check proxy/server.js` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
