### PR TITLE
✨ feat(hub): reset a live claimed hive back to the unassigned pool (#2748 Phase 2)

### DIFF
--- a/v2/pkg/hub/reset_to_pool_test.go
+++ b/v2/pkg/hub/reset_to_pool_test.go
@@ -1,0 +1,253 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// --- verify / allowlist (the guarantee) --------------------------------------
+
+// TestResetToPoolParseLeftover_FailsClosedOnJunk asserts that a /data tree with
+// arbitrary accreted junk (a bead dir, a tmux socket, a stray creds file, a
+// per-agent CODEX_HOME) is detected as NOT clean — every unexpected entry is
+// surfaced as a leftover, so the reset fails closed. A tree with only the seed
+// (verify prints the clean sentinel) is detected as clean.
+func TestResetToPoolParseLeftover_FailsClosedOnJunk(t *testing.T) {
+	// The verify Job prints one leftover /data path per line (or the clean
+	// sentinel when there is nothing unexpected).
+	dirtyLogs := strings.Join([]string{
+		"/data/beads",
+		"/data/tmux-1001/default",   // a tmux socket dir
+		"/data/gh-user-token",       // a stray credential file
+		"/data/home/.codex-scanner", // a per-agent CODEX_HOME
+		"/data/hive.yaml.dashboard",
+	}, "\n")
+
+	leftover := resetToPoolParseLeftover(dirtyLogs)
+	if len(leftover) != 5 {
+		t.Fatalf("expected 5 leftover entries (fail-closed), got %d: %v", len(leftover), leftover)
+	}
+	// Sanity: the credential file and the per-agent CODEX_HOME must both be caught.
+	found := map[string]bool{}
+	for _, e := range leftover {
+		found[e] = true
+	}
+	for _, must := range []string{"/data/gh-user-token", "/data/home/.codex-scanner"} {
+		if !found[must] {
+			t.Errorf("leftover detection missed %q — would leak", must)
+		}
+	}
+}
+
+// TestResetToPoolParseLeftover_CleanSentinelPasses asserts that the clean
+// sentinel (and only the sentinel) is treated as a clean /data.
+func TestResetToPoolParseLeftover_CleanSentinelPasses(t *testing.T) {
+	if got := resetToPoolParseLeftover(resetToPoolCleanSentinel + "\n"); len(got) != 0 {
+		t.Fatalf("clean sentinel must parse as no leftover, got %v", got)
+	}
+	// Blank/whitespace-only logs are also clean (nothing to wipe).
+	if got := resetToPoolParseLeftover("\n   \n"); len(got) != 0 {
+		t.Fatalf("blank logs must parse as no leftover, got %v", got)
+	}
+}
+
+// TestResetToPoolSeedAllowlistIsEmpty pins the design invariant: the seed
+// allowlist is empty, so the wipe is total and the verify tolerates nothing. If
+// a future change adds a seeded PVC file it must be a deliberate edit here (which
+// this test will flag) so the wipe and verify stay in lockstep.
+func TestResetToPoolSeedAllowlistIsEmpty(t *testing.T) {
+	if len(resetToPoolSeedAllowlist) != 0 {
+		t.Fatalf("seed allowlist must be empty (total wipe); got %v — if intentional, update this test and confirm both wipe and verify honour it", resetToPoolSeedAllowlist)
+	}
+	// With an empty allowlist the find prune expression must be empty, so nothing
+	// is excluded from either the wipe or the verify.
+	if expr := resetToPoolFindPruneExpr(resetToPoolSeedAllowlist); expr != "" {
+		t.Fatalf("empty allowlist must yield an empty prune expr, got %q", expr)
+	}
+}
+
+// TestResetToPoolFindPruneExpr_Allowlisted asserts the prune expression correctly
+// excludes an allowlisted name (used if the allowlist ever becomes non-empty) and
+// shell-quotes it defensively.
+func TestResetToPoolFindPruneExpr_Allowlisted(t *testing.T) {
+	expr := resetToPoolFindPruneExpr([]string{"hive.yaml", "keep me"})
+	if !strings.Contains(expr, "-name 'hive.yaml'") {
+		t.Errorf("prune expr should exclude hive.yaml, got %q", expr)
+	}
+	if !strings.Contains(expr, "-prune -o") {
+		t.Errorf("prune expr should end with -prune -o, got %q", expr)
+	}
+	if !strings.Contains(expr, "'keep me'") {
+		t.Errorf("prune expr should shell-quote names with spaces, got %q", expr)
+	}
+}
+
+// TestResetToPoolWipeScript_TotalWipe asserts the wipe script, with the (empty)
+// seed allowlist, wipes everything under /data and does NOT carry a prune clause.
+func TestResetToPoolWipeScript_TotalWipe(t *testing.T) {
+	script := resetToPoolWipeScript(resetToPoolSeedAllowlist)
+	if !strings.Contains(script, "find /data -mindepth 1 -maxdepth 1  -exec rm -rf {} +") {
+		t.Errorf("wipe script must be a total rm of /data with no prune, got: %s", script)
+	}
+	if strings.Contains(script, "-prune") {
+		t.Errorf("empty-allowlist wipe must not prune anything, got: %s", script)
+	}
+}
+
+// TestResetToPoolVerifyScript_PrintsSentinelWhenClean asserts the verify script
+// prints the clean sentinel when nothing is left, else the leftover list.
+func TestResetToPoolVerifyScript_PrintsSentinelWhenClean(t *testing.T) {
+	script := resetToPoolVerifyScript(resetToPoolSeedAllowlist)
+	if !strings.Contains(script, resetToPoolCleanSentinel) {
+		t.Errorf("verify script must print the clean sentinel, got: %s", script)
+	}
+	if !strings.Contains(script, "find /data -mindepth 1 -maxdepth 1") {
+		t.Errorf("verify script must scan /data top level, got: %s", script)
+	}
+}
+
+// --- Secret reset shape -------------------------------------------------------
+
+// TestResetToPoolPlaceholderSecretKeys pins the exact placeholder Secret key set.
+func TestResetToPoolPlaceholderSecretKeys(t *testing.T) {
+	want := []string{"dashboard-token", "github-token"}
+	got := resetToPoolPlaceholderSecretKeys()
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("placeholder secret keys = %v, want %v", got, want)
+	}
+}
+
+// TestResetToPoolUnexpectedSecretKeys_FailsClosedOnSurvivingCreds asserts that a
+// surviving credential key (e.g. a gh-app-key*.pem, or a copilot token) on the
+// Secret after reset is detected as unexpected — the fail-closed signal. The
+// exact placeholder key set passes.
+func TestResetToPoolUnexpectedSecretKeys_FailsClosedOnSurvivingCreds(t *testing.T) {
+	// A dirty Secret that still carries an App key and a github token PAT.
+	dirty := []string{"dashboard-token", "github-token", "gh-app-key.pem", "gh-app-key-3568013.pem"}
+	extra := resetToPoolUnexpectedSecretKeys(dirty)
+	sort.Strings(extra)
+	want := []string{"gh-app-key-3568013.pem", "gh-app-key.pem"}
+	if !reflect.DeepEqual(extra, want) {
+		t.Fatalf("unexpected keys = %v, want %v (surviving App keys must fail closed)", extra, want)
+	}
+
+	// The exact placeholder shape has no unexpected keys.
+	if extra := resetToPoolUnexpectedSecretKeys(resetToPoolPlaceholderSecretKeys()); len(extra) != 0 {
+		t.Fatalf("placeholder key set must have no unexpected keys, got %v", extra)
+	}
+}
+
+// TestResetToPoolSecretManifest_NoTenantCreds asserts the recreated Secret
+// manifest carries ONLY the placeholder keys — a fresh dashboard-token and the
+// non-secret placeholder github-token — and no gh-app-key / tenant credential.
+func TestResetToPoolSecretManifest_NoTenantCreds(t *testing.T) {
+	m := resetToPoolSecretManifest("hive-hosted-x1", "deadbeef-fresh-token")
+	if !strings.Contains(m, "dashboard-token: 'deadbeef-fresh-token'") {
+		t.Errorf("secret manifest missing fresh dashboard-token, got:\n%s", m)
+	}
+	if !strings.Contains(m, "github-token: '"+resetToPoolPlaceholderToken+"'") {
+		t.Errorf("secret manifest missing placeholder github-token, got:\n%s", m)
+	}
+	if strings.Contains(m, "gh-app-key") {
+		t.Errorf("secret manifest must NOT carry any App key, got:\n%s", m)
+	}
+}
+
+// --- state guard: record reset only after verified clean ----------------------
+
+// TestIsResettableLiveHive gates which hives reset-to-pool targets: a delivered
+// claim (LIVE) is resettable; an unclaimed placeholder is NOT (that uses
+// reset-assignment); a hive already mid-reset is NOT (concurrency latch).
+func TestIsResettableLiveHive(t *testing.T) {
+	cases := []struct {
+		name string
+		h    *SaaSHive
+		want bool
+	}{
+		{"live claimed hive", &SaaSHive{ID: "a", ClaimDelivered: true}, true},
+		{"unclaimed placeholder", &SaaSHive{ID: "b", Status: statusAvailable}, false},
+		{"assigned-but-unclaimed wedge", &SaaSHive{ID: "c", Status: statusAssigned, ClaimDelivered: false}, false},
+		{"already resetting", &SaaSHive{ID: "d", ClaimDelivered: true, ResetToPoolStatus: resetToPoolStatusInProgress}, false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isResettableLiveHive(tc.h); got != tc.want {
+				t.Fatalf("isResettableLiveHive(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResetHiveToAvailablePlaceholder_RecordShape confirms the record-reset half
+// (reused from Phase 1) only ever produces the clean available-placeholder shape,
+// which is what a verified-clean reset flips the record to. This is the record
+// mutation that must NOT run before the wipe is verified clean (the handler
+// sequences it after performResetToPoolWipe returns nil).
+func TestResetHiveToAvailablePlaceholder_RecordShape(t *testing.T) {
+	h := &SaaSHive{
+		ID:             "z9",
+		Owner:          "tenant-owner",
+		Org:            "acme-corp",
+		Repos:          []string{"acme/thing"},
+		PrimaryRepo:    "acme/thing",
+		Status:         statusAssigned,
+		ClaimDelivered: true,
+		VanityURL:      "https://hosted-acme.example",
+		ACMMLevel:      6,
+	}
+	resetHiveToAvailablePlaceholder(h)
+	if h.Status != statusAvailable {
+		t.Errorf("status = %q, want %q", h.Status, statusAvailable)
+	}
+	if h.Owner != hubAdminUsername {
+		t.Errorf("owner = %q, want admin", h.Owner)
+	}
+	if !strings.HasPrefix(h.Org, placeholderOrgPrefix) {
+		t.Errorf("org = %q, want %q-prefixed", h.Org, placeholderOrgPrefix)
+	}
+	if len(h.Repos) != 0 || h.PrimaryRepo != "" || h.VanityURL != "" {
+		t.Errorf("tenant identity not cleared: repos=%v primary=%q vanity=%q", h.Repos, h.PrimaryRepo, h.VanityURL)
+	}
+	if h.ClaimDelivered {
+		t.Errorf("ClaimDelivered must be re-armed to false")
+	}
+}
+
+// --- security helpers ---------------------------------------------------------
+
+// TestResetToPoolSameOrigin exercises the same-origin defense-in-depth check:
+// a trusted hub Origin passes, an untrusted one is rejected, and a request with
+// no Origin/Referer is allowed (the admin + typed-confirm gates still apply).
+func TestResetToPoolSameOrigin(t *testing.T) {
+	mk := func(origin, referer string) bool {
+		r := httptest.NewRequest(http.MethodPost, "/api/saas/hives/x/reset-to-pool", nil)
+		if origin != "" {
+			r.Header.Set("Origin", origin)
+		}
+		if referer != "" {
+			r.Header.Set("Referer", referer)
+		}
+		return resetToPoolSameOrigin(r)
+	}
+	if !mk("https://hive.kubestellar.io", "") {
+		t.Error("trusted Origin must pass")
+	}
+	if mk("https://evil.example", "") {
+		t.Error("untrusted Origin must be rejected")
+	}
+	if !mk("", "https://hive.kubestellar.io/dashboard") {
+		t.Error("trusted Referer (no Origin) must pass")
+	}
+	if mk("", "https://evil.example/x") {
+		t.Error("untrusted Referer must be rejected")
+	}
+	if !mk("", "") {
+		t.Error("no Origin and no Referer must be allowed (same-origin fetch / curl)")
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -353,6 +353,13 @@ func (s *HubServer) registerSaaSRoutes() {
 	// pool so it can be re-armed. Admin-only, and guarded to the wedged middle
 	// state (assigned && !claim_delivered) inside the handler.
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/reset-assignment", s.requireAdmin(s.handleResetAssignment))
+	// Phase 2 of #2748: return a LIVE, claimed hive to the unassigned pool by
+	// wiping its /data + hive-secrets credential-safely IN PLACE (namespace/PVC
+	// kept), verifying the wipe is clean, then flipping the record to available.
+	// Admin-only + typed-confirm + same-origin + dry-run + fail-closed; guarded to
+	// a delivered-claim LIVE hive inside the handler (the inverse of
+	// reset-assignment's gate).
+	s.mux.HandleFunc("POST /api/saas/hives/{id}/reset-to-pool", s.requireAdmin(s.handleResetToPool))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/migrate", s.requireAuth(s.handleMigrateHive))
 	s.mux.HandleFunc("GET /api/saas/cluster-health", s.requireAdmin(s.handleClusterHealth))
 	// Acknowledging a fleet alert is an operator action on the operator's own
@@ -12658,6 +12665,14 @@ const dashboardHTML = `<!DOCTYPE html>
         if (_isAdmin && isHosted) menuItems.push('<div onclick="restartHiveSpoke(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">Restart Spoke</div>');
         if (isLocal && h.role === 'owner') menuItems.push('<div onclick="removeLocalHive(\'' + esc(h.id) + '\')" style="' + mi + '">Remove</div>');
         if (isHosted && h.role === 'owner' && _clusterList && _clusterList.length > 1 && h.migrationStatus !== 'migrating') menuItems.push('<div onclick="openMigrateModal(\'' + esc(h.id) + '\',\'' + esc(h.clusterId || '') + '\')" style="' + mi + '">Move to cluster</div>');
+        /* Reset to pool (Phase 2 of #2748): admin-only destructive wipe that
+           returns a LIVE, claimed hosted hive to the unassigned pool — wipes
+           /data + credentials + agent state IN PLACE (namespace kept), verifies
+           clean, then flips the slot to available. Distinct from Delete (which
+           destroys the namespace). Offered on a plausibly-live hive: hosted, not
+           an available placeholder, and not the assigned-but-unclaimed wedge
+           (that uses Reset assignment). The server re-checks claim_delivered. */
+        if (_isAdmin && isHosted && h.provStatus !== 'available' && !h.assignedUnclaimed) menuItems.push('<div onclick="resetToPool(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + ';color:#d29922;font-weight:600">Reset to pool</div>');
         if (isHosted && h.role === 'owner') menuItems.push('<div style="border-top:1px solid #30363d;margin:4px 0"></div><div onclick="deleteHive(\'' + esc(h.id) + '\')" style="' + mi + ';color:#f85149">Delete</div>');
         var sha = h.gitHash || '';
         /* Drift folded ONTO Version: config drift is overwhelmingly "this hive's
@@ -13630,6 +13645,68 @@ const dashboardHTML = `<!DOCTYPE html>
         if (typeof loadHives === 'function') loadHives();
       } catch (e) {
         await hiveNotify('Reset failed', String(e));
+      }
+    }
+
+    /* Reset to pool (Phase 2 of #2748): admin-only DESTRUCTIVE wipe that returns
+       a LIVE, claimed hive to the unassigned pool. It wipes /data (config,
+       storage, beads, agent state, tmux) AND the hive-secrets Secret (gh token,
+       App keys, inference keys) IN PLACE, verifies the result is clean, then
+       flips the slot to available. FAIL-CLOSED: if the wipe cannot be verified
+       clean, the slot is NOT pooled and the namespace is left intact.
+       Requires typing the exact hive id to enable — the typed-confirm the server
+       also enforces (defeats stray clicks / forged requests). Offers a dry-run
+       preview first so the operator sees exactly what will be wiped. */
+    async function resetToPool(hiveId, hiveName) {
+      /* Dry-run first: show what WOULD be wiped, without deleting anything. */
+      var preview = '';
+      try {
+        var dr = await fetch('/api/saas/hives/' + encodeURIComponent(hiveId) + '/reset-to-pool',
+          {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({dry_run: true})});
+        var drData = await dr.json().catch(function() { return {}; });
+        if (!dr.ok) { await hiveNotify('Reset to pool unavailable', String(drData.error || dr.status)); return; }
+        var dataList = (drData.data_to_wipe || []);
+        var keyList = (drData.secret_keys_to_reset || []);
+        preview = '\n\nNamespace: ' + (drData.namespace || '') +
+          '\n/data entries to wipe: ' + (dataList.length ? dataList.slice(0, 12).join(', ') + (dataList.length > 12 ? ', …' : '') : '(none listed)') +
+          '\nSecret keys to reset: ' + (keyList.length ? keyList.join(', ') : '(none listed)');
+      } catch (e) {
+        /* A dry-run failure should not block the operator, but note it. */
+        preview = '\n\n(could not fetch a dry-run preview: ' + String(e) + ')';
+      }
+      /* Typed confirmation: the operator must type the exact hive id. */
+      var typed = await hivePrompt(
+        'Reset "' + hiveName + '" to the pool?',
+        '',
+        {ok: 'Wipe and return to pool'});
+      if (typed === null) return; /* cancelled */
+      if (typed !== hiveId) {
+        await hiveNotify('Confirmation mismatch',
+          'You must type the exact hive id (' + hiveId + ') to confirm this destructive wipe.' + preview);
+        return;
+      }
+      /* Final explicit confirm naming the destruction. */
+      var ok = await hiveConfirm('This WIPES all config, storage, credentials and agent state for "' + hiveName +
+        '" and returns the namespace to the unassigned pool. This cannot be undone.' + preview +
+        '\n\nProceed?');
+      if (!ok) return;
+      hiveToast('Resetting ' + hiveId + ' to the pool — wiping and verifying…', 'info');
+      try {
+        var resp = await fetch('/api/saas/hives/' + encodeURIComponent(hiveId) + '/reset-to-pool',
+          {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({confirm: hiveId})});
+        var data = await resp.json().catch(function() { return {}; });
+        if (!resp.ok) {
+          await hiveNotify('Reset to pool FAILED (fail-closed)',
+            'The slot was NOT returned to the pool and the namespace was left intact for inspection.\n\n' +
+            String(data.error || resp.status));
+          if (typeof loadHives === 'function') loadHives();
+          return;
+        }
+        await hiveNotify('Reset to pool complete',
+          'Hive: ' + hiveName + '\n/data and credentials were wiped (verified clean) and the slot is back in the available pool.');
+        if (typeof loadHives === 'function') loadHives();
+      } catch (e) {
+        await hiveNotify('Reset to pool failed', String(e));
       }
     }
 

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -553,6 +553,19 @@ type SaaSHive struct {
 	// cannot touch any other way.
 	RequestedRestartAt string `json:"requested_restart_at,omitempty"`
 
+	// ResetToPoolStatus tracks a LIVE-hive reset-to-pool wipe (Phase 2 of #2748).
+	// Empty means no reset is in flight. resetToPoolStatusInProgress is set while
+	// the credential-safe /data + Secret wipe runs and doubles as the concurrency
+	// latch (a second reset request 409s while it is set). resetToPoolStatusFailed
+	// is the FAIL-CLOSED terminal state: a wipe or verify step did not prove the
+	// slot clean, so the record was NOT flipped to available and the namespace is
+	// left intact for manual inspection. ResetToPoolError carries the human reason
+	// for the failure (never a secret value — key names / paths only). Both clear
+	// only on a verified-clean reset, which flips the record to the available
+	// placeholder shape. omitempty keeps existing meta.json records byte-identical.
+	ResetToPoolStatus string `json:"reset_to_pool_status,omitempty"`
+	ResetToPoolError  string `json:"reset_to_pool_error,omitempty"`
+
 	Error           string                 `json:"error,omitempty"`
 	AutoUpgrade     bool                   `json:"auto_upgrade"`
 	IsPublic        bool                   `json:"is_public"`

--- a/v2/pkg/hub/saas_reset_to_pool.go
+++ b/v2/pkg/hub/saas_reset_to_pool.go
@@ -1,0 +1,724 @@
+package hub
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Phase 2 of #2748: return a LIVE, claimed hive to the unassigned pool by
+// wiping its persistent state credential-safely, in place, WITHOUT deleting the
+// namespace or the PVC object (that is deprovisionHive's job). Phase 1 — the
+// record-only escape hatch for an assigned-but-unclaimed placeholder
+// (handleResetAssignment / resetHiveToAvailablePlaceholder) — is reused verbatim
+// for the record half; this file adds the storage wipe + verify + fail-closed
+// state machine that a delivered claim needs.
+//
+// THE GUARANTEE (wipe-by-default, verify-clean, fail-closed):
+//
+// The operator's central concern is "how do we assure there is NO data left —
+// beads, tmux, or anything else?". The answer is NOT an enumerated delete-list
+// (which rots the day a future feature drops /data/newthing). It is an EMPTY
+// seed allowlist:
+//
+//   - On a fresh provision the /data PVC starts COMPLETELY EMPTY. The copy-config
+//     init container seeds the ConfigMap into /etc/hive (an emptyDir), never onto
+//     the PVC (saas_provision.go copy-config step). Everything else on /data is
+//     recreated by entrypoint.sh on boot (idempotent mkdir -p / cp -n / runtime
+//     generation).
+//   - So the wipe destroys EVERYTHING under /data and the VERIFY CONTRACT is
+//     total and trivial: `find /data -mindepth 1` must return NOTHING. Anything
+//     remaining -> FAIL CLOSED (the slot is not returned to the pool).
+//   - The spoke, on restart, re-seeds /data exactly as on a first-ever boot —
+//     byte-for-byte the fresh-provision baseline.
+//
+// resetToPoolSeedAllowlist is that seed set, kept in ONE place shared by the
+// wipe and the verify step so they cannot drift. It is deliberately EMPTY: there
+// is nothing under /data that a fresh PVC carries, so nothing is preserved and
+// nothing can leak by omission. If a future change ever DOES require a seeded
+// file on the PVC, add it here and both the wipe and the verify honour it
+// automatically.
+var resetToPoolSeedAllowlist = []string{}
+
+const (
+	// resetToPoolStatusInProgress is set on the hive record while the wipe runs.
+	// It doubles as the concurrency latch: a second reset request 409s while set.
+	resetToPoolStatusInProgress = "in-progress"
+	// resetToPoolStatusFailed is the FAIL-CLOSED terminal state. The record was
+	// NOT flipped to available; the namespace/PVC are intact for manual inspection.
+	resetToPoolStatusFailed = "failed"
+
+	// hiveDataPVCName is the PVC whose contents the wipe destroys (kept — only its
+	// contents are wiped, never the object). Matches the provision template.
+	hiveDataPVCName = "hive-data"
+	// hiveSecretsName is the K8s Secret holding tenant credentials, reset to the
+	// placeholder shape. Matches the provision template.
+	hiveSecretsName = "hive-secrets"
+	// hiveDeploymentName is the spoke Deployment, scaled to 0 for the wipe and back
+	// to 1 afterwards. Matches the provision template.
+	hiveDeploymentName = "hive"
+
+	// resetToPoolWipeImage is the image the wipe/verify Job runs. It only needs a
+	// POSIX shell + coreutils find/rm, all present in busybox; using the spoke
+	// image would pull a much larger layer for a `find … -delete`. Pinned by
+	// digest-less tag deliberately — this is a throwaway Job, not a long-lived
+	// workload, and busybox:1.36 is a stable, widely-cached tag.
+	resetToPoolWipeImage = "busybox:1.36"
+
+	// resetToPoolJobActiveDeadlineSecs bounds the wipe Job's total runtime. A wipe
+	// of an empty-ish PVC is seconds; a very large accreted tree is still minutes.
+	// The deadline is the fail-closed backstop: if the Job cannot finish in this
+	// window it is failed, and the reset fails closed rather than hanging.
+	resetToPoolJobActiveDeadlineSecs = 600 // 10 minutes
+	// resetToPoolJobBackoffLimit caps Job pod retries. The wipe is idempotent, so a
+	// couple of retries on a transient node error are fine; beyond that we fail
+	// closed rather than loop forever.
+	resetToPoolJobBackoffLimit = 2
+
+	// resetToPoolKubectlTimeout bounds each individual kubectl call the reset makes
+	// (scale, apply, wait, delete). A cluster that cannot answer within this window
+	// is treated as unreachable and the reset fails closed.
+	resetToPoolKubectlTimeout = 90 * time.Second
+	// resetToPoolJobWaitTimeout bounds the `kubectl wait` for the wipe/verify Job
+	// to complete. Slightly longer than the Job's own activeDeadline so the Job's
+	// deadline is what fails a slow wipe, not this wait.
+	resetToPoolJobWaitTimeout = 12 * time.Minute
+	// resetToPoolScaleDownWaitTimeout bounds waiting for the spoke to reach 0
+	// replicas before the wipe starts, so no writer can recreate state mid-wipe.
+	resetToPoolScaleDownWaitTimeout = 3 * time.Minute
+
+	// resetToPoolWipeJobName / resetToPoolVerifyJobName are the fixed Job names in
+	// the hive namespace. Fixed (not random) so a re-run reuses/replaces the same
+	// object rather than leaking Jobs, keeping the reset idempotent.
+	resetToPoolWipeJobName   = "hive-reset-wipe"
+	resetToPoolVerifyJobName = "hive-reset-verify"
+
+	// resetToPoolPlaceholderToken is the non-secret sentinel written to the
+	// recreated Secret's github-token key. The pod's HIVE_GITHUB_TOKEN env is a
+	// secretKeyRef on github-token (provision template, non-App path), so the key
+	// must EXIST or the pod fails to start — but it must carry NO real credential.
+	// This sentinel is deliberately not a valid token: a placeholder slot does no
+	// GitHub work, and any accidental use fails loudly rather than acting as a
+	// stale tenant credential.
+	resetToPoolPlaceholderToken = "placeholder-not-a-real-token"
+
+	// dashboardTokenBytesReset mirrors dashboardTokenBytes for the freshly minted
+	// dashboard-token in the recreated Secret. Named locally to avoid coupling to
+	// the provision constant's scope while keeping the same 32-byte strength.
+	dashboardTokenBytesReset = 32
+)
+
+// resetToPoolResult is the JSON body returned by the reset endpoint (dry-run and
+// real). It never carries secret VALUES — only key NAMES and paths.
+type resetToPoolResult struct {
+	OK        bool   `json:"ok"`
+	DryRun    bool   `json:"dry_run"`
+	HiveID    string `json:"id"`
+	Namespace string `json:"namespace"`
+	Status    string `json:"status,omitempty"`
+	// DataToWipe is the top-level /data entries that WOULD be (dry-run) or WERE
+	// wiped — for operator confirmation. Best-effort; empty when the listing could
+	// not be read (which does not block a real wipe — the wipe is total regardless).
+	DataToWipe []string `json:"data_to_wipe,omitempty"`
+	// SecretKeysToReset is the hive-secrets key NAMES that would be reset (values
+	// never included).
+	SecretKeysToReset []string `json:"secret_keys_to_reset,omitempty"`
+	Error             string   `json:"error,omitempty"`
+}
+
+// resetToPoolRequest is the POST body. Confirm must equal the target hive id
+// (typed-confirmation, mirroring slackBroadcastConfirm) for a real wipe.
+type resetToPoolRequest struct {
+	Confirm string `json:"confirm"`
+	DryRun  bool   `json:"dry_run"`
+}
+
+// isResettableLiveHive reports whether a hive is a LIVE, claimed hosted hive that
+// reset-to-pool may target. It is the exact inverse of the Phase 1 escape hatch's
+// gate: Phase 1 refuses a delivered claim, this REQUIRES one. It also refuses a
+// hive already mid-reset (the concurrency latch) so a double-fire cannot race the
+// wipe Job.
+func isResettableLiveHive(h *SaaSHive) bool {
+	if h == nil {
+		return false
+	}
+	if h.ResetToPoolStatus == resetToPoolStatusInProgress {
+		return false
+	}
+	// A delivered claim is what makes this a LIVE hive with tenant state on /data.
+	return h.ClaimDelivered
+}
+
+// resetToPoolConcurrencyLatchHeld reports whether a reset is already in flight for
+// this hive. Read from the authoritative on-disk record (not a copy) so two racing
+// requests see each other.
+func resetToPoolConcurrencyLatchHeld(hiveID string) bool {
+	h := loadSaaSHive(hiveID)
+	return h != nil && h.ResetToPoolStatus == resetToPoolStatusInProgress
+}
+
+// handleResetToPool wipes a LIVE hive's /data + hive-secrets credential-safely and
+// returns the namespace to the unassigned pool (admin-only). It is fail-closed:
+// the record is flipped to available ONLY after the wipe is VERIFIED clean; any
+// wipe/verify error leaves the hive claimed with ResetToPoolStatus=failed and the
+// namespace intact for manual inspection.
+//
+// SECURITY (defense-in-depth for an irreversible destructive action):
+//   - admin-only (routed through requireAdmin, which also applies the
+//     impersonation write-block — a "View as user" session cannot reach here);
+//   - same-origin check (Origin/Referer host must be a trusted hub host);
+//   - typed confirmation: body.confirm must equal the hive id for a real wipe;
+//   - dry-run: body.dry_run returns what WOULD be wiped and deletes nothing;
+//   - state guard: 409 unless the hive is a resettable LIVE hosted hive;
+//   - concurrency latch: 409 while a reset is already in flight;
+//   - audit on every attempt (success AND fail-closed), secret VALUES never logged.
+func (s *HubServer) handleResetToPool(w http.ResponseWriter, r *http.Request) {
+	admin := s.getAuthUser(r) // requireAdmin-gated; equals hubAdminUsername
+
+	// Same-origin defense-in-depth over SameSite=Lax. Reject a cross-site POST
+	// whose Origin/Referer is not a trusted hub host. An absent Origin AND Referer
+	// (e.g. a same-origin fetch that omits both, or a curl) is allowed — the
+	// admin + typed-confirm gates still apply; this check only REJECTS a present,
+	// untrusted origin.
+	if !resetToPoolSameOrigin(r) {
+		http.Error(w, `{"error":"cross-origin request refused"}`, http.StatusForbidden)
+		return
+	}
+
+	hiveID := r.PathValue("id")
+	h := loadSaaSHive(hiveID)
+	if h == nil {
+		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
+		return
+	}
+	ns := hostedNamespaceForHive(h)
+
+	var body resetToPoolRequest
+	if r.Body != nil {
+		_ = json.NewDecoder(r.Body).Decode(&body) // tolerate empty body for dry-run
+	}
+
+	// State guard: only a LIVE (claim-delivered) hosted hive, not already resetting.
+	if !isResettableLiveHive(h) {
+		s.logger.Info("audit: hive reset-to-pool refused — not a resettable live hive",
+			"hive_id", hiveID, "namespace", ns, "by", admin,
+			"claim_delivered", h.ClaimDelivered, "reset_status", h.ResetToPoolStatus)
+		if h.ResetToPoolStatus == resetToPoolStatusInProgress {
+			http.Error(w, `{"error":"a reset-to-pool is already in progress for this hive"}`, http.StatusConflict)
+			return
+		}
+		http.Error(w, `{"error":"only a live, claimed hive can be reset to the pool — an unclaimed placeholder uses reset-assignment"}`, http.StatusConflict)
+		return
+	}
+
+	cluster := s.clusterForHive(h)
+	if cluster == nil {
+		http.Error(w, `{"error":"no cluster config for this hive"}`, http.StatusInternalServerError)
+		return
+	}
+
+	// Reachability gate: the wipe requires kubectl to the spoke cluster AND the
+	// ability to VERIFY the result there. A heartbeat-only / recently-unreachable
+	// cluster can do neither, so refuse rather than ship an unverifiable wipe (a
+	// wipe we cannot prove completed is exactly the credential-leak #2748 forbids).
+	if s.clusterRecentlyUnreachable(cluster.ID) {
+		s.logger.Warn("audit: hive reset-to-pool refused — cluster unreachable",
+			"hive_id", hiveID, "namespace", ns, "by", admin, "cluster", cluster.ID)
+		http.Error(w, `{"error":"cluster is unreachable — a wipe cannot be verified clean, so reset-to-pool is refused (use Delete for an unreachable hive)"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	// DRY-RUN: report what WOULD be wiped and delete nothing.
+	if body.DryRun {
+		res := resetToPoolResult{
+			OK:                true,
+			DryRun:            true,
+			HiveID:            hiveID,
+			Namespace:         ns,
+			DataToWipe:        s.resetToPoolListData(cluster, ns),
+			SecretKeysToReset: s.resetToPoolListSecretKeys(cluster, ns),
+		}
+		s.logger.Info("audit: hive reset-to-pool dry-run",
+			"hive_id", hiveID, "namespace", ns, "by", admin, "cluster", cluster.ID)
+		writeJSON(w, http.StatusOK, res)
+		return
+	}
+
+	// TYPED CONFIRMATION (mirrors slackBroadcastConfirm): a real wipe requires the
+	// body to echo the exact hive id. Defeats stray clicks, replayed/forged
+	// requests that don't know the target, and fat-finger.
+	if body.Confirm != hiveID {
+		s.logger.Info("audit: hive reset-to-pool refused — confirmation mismatch",
+			"hive_id", hiveID, "namespace", ns, "by", admin)
+		http.Error(w, `{"error":"confirmation required — the request must echo the exact hive id in the confirm field"}`, http.StatusBadRequest)
+		return
+	}
+
+	// CONCURRENCY LATCH: re-check under the authoritative record and set the
+	// in-progress latch before doing any destructive work, so a double-fire 409s.
+	if resetToPoolConcurrencyLatchHeld(hiveID) {
+		http.Error(w, `{"error":"a reset-to-pool is already in progress for this hive"}`, http.StatusConflict)
+		return
+	}
+	h.ResetToPoolStatus = resetToPoolStatusInProgress
+	h.ResetToPoolError = ""
+	if err := saveSaaSHive(h); err != nil {
+		http.Error(w, `{"error":"failed to record reset-in-progress"}`, http.StatusInternalServerError)
+		return
+	}
+	s.syncRegistryProvStatus(hiveID, resetToPoolStatusInProgress)
+
+	s.logger.Info("audit: hive reset-to-pool started",
+		"hive_id", hiveID, "namespace", ns, "by", admin, "cluster", cluster.ID,
+		"previous_owner", h.Owner, "previous_org", h.Org)
+	s.recordTimeline(hiveID, TimelineOwnership,
+		fmt.Sprintf("reset-to-pool started by %s — wiping /data + credentials and returning the slot to the pool", admin),
+		admin)
+
+	// Perform the wipe synchronously (bounded by the per-step kubectl/Job timeouts)
+	// so the operator gets a definitive result. If it fails, fail closed.
+	if err := s.performResetToPoolWipe(h, cluster, ns); err != nil {
+		reason := err.Error()
+		s.markResetToPoolFailed(hiveID, reason)
+		s.logger.Warn("audit: hive reset-to-pool FAILED CLOSED — slot NOT returned to pool",
+			"hive_id", hiveID, "namespace", ns, "by", admin, "reason", reason)
+		s.recordTimeline(hiveID, TimelineOwnership,
+			"reset-to-pool FAILED — slot NOT returned to pool, namespace left intact for inspection: "+reason,
+			admin)
+		writeJSON(w, http.StatusInternalServerError, resetToPoolResult{
+			OK: false, HiveID: hiveID, Namespace: ns, Status: resetToPoolStatusFailed, Error: reason,
+		})
+		return
+	}
+
+	// VERIFIED CLEAN. Now — and only now — flip the record to the available
+	// placeholder shape (Phase 1's inverse-of-claim), reset persisted namespace/
+	// prov status, drop the owner grant, and re-stamp the namespace identity.
+	prevOwner := h.Owner
+	prevOrg := h.Org
+	resetHiveToAvailablePlaceholder(h)
+	h.ResetToPoolStatus = ""
+	h.ResetToPoolError = ""
+	if err := saveSaaSHive(h); err != nil {
+		// The wipe succeeded but the record write failed. Fail closed: the slot is
+		// clean but not yet advertised available. A re-run converges (the wipe is
+		// idempotent) — leave the in-progress latch cleared so a retry is accepted.
+		s.markResetToPoolFailed(hiveID, "wipe verified clean but record reset failed to save — retry to converge")
+		http.Error(w, `{"error":"wipe verified clean but record reset failed to save"}`, http.StatusInternalServerError)
+		return
+	}
+	s.syncRegistryProvStatus(hiveID, statusAvailable)
+	s.resetToPoolDropOwnerGrant(hiveID)
+	reopened := clearAssignedRequestForHive(hiveID)
+
+	// Best-effort namespace identity re-stamp back to placeholder (idempotent).
+	stampHostedNamespaceIdentity(cluster, ns, availablePlaceholderProjectName(h),
+		placeholderOrgPrefix+hiveID, hiveID, s.logger)
+
+	// Bring the spoke back up; it boots fresh from the re-seeded empty /data as an
+	// unclaimed placeholder. Best-effort: if kubectl cannot scale it back up the
+	// slot is still clean+available; the spoke will be reconciled on next
+	// heartbeat/restart.
+	if err := s.resetToPoolScaleDeployment(cluster, ns, 1); err != nil {
+		s.logger.Warn("reset-to-pool: failed to scale spoke back up (slot is clean+available; will reconcile)",
+			"hive_id", hiveID, "namespace", ns, "error", err)
+	}
+
+	s.logger.Info("audit: hive reset-to-pool COMPLETE — slot returned to pool (verified clean)",
+		"hive_id", hiveID, "namespace", ns, "by", admin,
+		"previous_owner", prevOwner, "previous_org", prevOrg, "reopened_request_for", reopened)
+	s.recordTimeline(hiveID, TimelineOwnership,
+		fmt.Sprintf("reset-to-pool complete by %s — /data + credentials wiped (verified clean), slot returned to the available pool (was %s)", admin, prevOwner),
+		admin)
+
+	writeJSON(w, http.StatusOK, resetToPoolResult{
+		OK: true, HiveID: hiveID, Namespace: ns, Status: statusAvailable,
+	})
+}
+
+// markResetToPoolFailed records the FAIL-CLOSED terminal state on the hive record
+// so the UI can surface it and a re-run is possible. Reloads the authoritative
+// record so it does not clobber a concurrent write.
+func (s *HubServer) markResetToPoolFailed(hiveID, reason string) {
+	h := loadSaaSHive(hiveID)
+	if h == nil {
+		return
+	}
+	h.ResetToPoolStatus = resetToPoolStatusFailed
+	h.ResetToPoolError = reason
+	if err := saveSaaSHive(h); err != nil {
+		s.logger.Warn("reset-to-pool: failed to record fail-closed state", "hive_id", hiveID, "error", err)
+		return
+	}
+	s.syncRegistryProvStatus(hiveID, resetToPoolStatusFailed)
+}
+
+// resetToPoolDropOwnerGrant removes the prior owner's Hives[id]="owner" grant so a
+// pooled slot is not still listed under the old tenant. It mirrors
+// handleAccessRevoke's delete(target.Hives, hiveID) and deliberately does NOT
+// touch SaaSQuota — quota is increment-only across the codebase today, and
+// reversing it here is out of scope (called out in the #2748 design comment).
+func (s *HubServer) resetToPoolDropOwnerGrant(hiveID string) {
+	for _, u := range listAllSaaSUsers() {
+		if _, ok := u.Hives[hiveID]; !ok {
+			continue
+		}
+		delete(u.Hives, hiveID)
+		if err := saveSaaSUser(&u); err != nil {
+			s.logger.Warn("reset-to-pool: failed to drop owner grant", "user", u.GitHubUsername, "hive_id", hiveID, "error", err)
+		}
+	}
+}
+
+// resetToPoolSameOrigin reports whether the request's Origin (or Referer, if
+// Origin is absent) is a trusted hub host. A request carrying NEITHER header is
+// allowed (same-origin fetches may omit both, and non-browser clients like curl
+// have no Origin) — the admin + typed-confirm gates remain in force; this check
+// only REJECTS a present-but-untrusted origin.
+func resetToPoolSameOrigin(r *http.Request) bool {
+	if o := strings.TrimSpace(r.Header.Get("Origin")); o != "" {
+		return isTrustedOrigin(o)
+	}
+	if ref := strings.TrimSpace(r.Header.Get("Referer")); ref != "" {
+		return isTrustedOrigin(ref)
+	}
+	return true
+}
+
+// newDashboardTokenReset mints a fresh random dashboard-token for the recreated
+// Secret, the same strength the provision path uses.
+func newDashboardTokenReset() (string, error) {
+	b := make([]byte, dashboardTokenBytesReset)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// resetToPoolPlaceholderSecretKeys is the EXACT key set a freshly-reset Secret
+// carries: a fresh dashboard-token and a placeholder github-token (the two keys a
+// non-App placeholder slot needs to boot). No gh-app-key*.pem, no tenant creds.
+// The verify step asserts the recreated Secret's keys equal this set — any extra
+// key (a surviving App PEM, say) FAILS CLOSED. Sorted for a stable comparison.
+func resetToPoolPlaceholderSecretKeys() []string {
+	keys := []string{"dashboard-token", "github-token"}
+	sort.Strings(keys)
+	return keys
+}
+
+// writeJSON writes v as JSON with the given status.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// --- kubectl-driven wipe primitives -------------------------------------------
+
+// performResetToPoolWipe runs the full fail-closed wipe sequence against a
+// reachable spoke cluster:
+//
+//  1. scale the spoke Deployment to 0 (stop all writers)
+//  2. run the wipe Job (delete everything under /data except the seed allowlist)
+//  3. verify /data is clean (find returns only the allowlist) — else FAIL CLOSED
+//  4. reset the hive-secrets Secret to the placeholder shape and verify its keys
+//
+// Every step is bounded by a timeout and returns an error on any failure, so the
+// caller fails closed. It is idempotent: a re-run re-scales-0, re-applies the Job
+// (fixed name), re-verifies, and re-resets the Secret.
+func (s *HubServer) performResetToPoolWipe(h *SaaSHive, cluster *ClusterConfig, ns string) error {
+	// 1. Scale to 0 and wait, so no agent/tmux/writer recreates state mid-wipe.
+	if err := s.resetToPoolScaleDeployment(cluster, ns, 0); err != nil {
+		return fmt.Errorf("scale spoke to 0: %w", err)
+	}
+	if err := s.resetToPoolWaitForReplicas(cluster, ns, 0); err != nil {
+		return fmt.Errorf("wait for spoke to stop: %w", err)
+	}
+
+	// 2. Wipe Job.
+	if err := s.resetToPoolRunWipeJob(cluster, ns); err != nil {
+		return fmt.Errorf("wipe /data: %w", err)
+	}
+
+	// 3. Verify /data clean — FAIL CLOSED on any leftover.
+	leftover, err := s.resetToPoolVerifyDataClean(cluster, ns)
+	if err != nil {
+		return fmt.Errorf("verify /data clean: %w", err)
+	}
+	if len(leftover) > 0 {
+		return fmt.Errorf("/data not clean after wipe — %d unexpected entr%s remain (e.g. %s)",
+			len(leftover), plural(len(leftover), "y", "ies"), strings.Join(firstN(leftover, 3), ", "))
+	}
+
+	// 4. Reset the Secret to the placeholder shape and verify its key set.
+	if err := s.resetToPoolResetSecret(cluster, ns); err != nil {
+		return fmt.Errorf("reset hive-secrets: %w", err)
+	}
+	extra, err := s.resetToPoolVerifySecretKeys(cluster, ns)
+	if err != nil {
+		return fmt.Errorf("verify hive-secrets keys: %w", err)
+	}
+	if len(extra) > 0 {
+		return fmt.Errorf("hive-secrets has unexpected keys after reset: %s", strings.Join(extra, ", "))
+	}
+	return nil
+}
+
+// resetToPoolScaleDeployment scales the spoke Deployment to replicas.
+func (s *HubServer) resetToPoolScaleDeployment(cluster *ClusterConfig, ns string, replicas int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), resetToPoolKubectlTimeout)
+	defer cancel()
+	cmd := kubectlForClusterContext(ctx, cluster, "scale",
+		"deployment/"+hiveDeploymentName, fmt.Sprintf("--replicas=%d", replicas), "-n", ns)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		s.markClusterUnreachable(cluster.ID)
+		return fmt.Errorf("%s: %w", strings.TrimSpace(string(out)), err)
+	}
+	s.markClusterReachable(cluster.ID)
+	return nil
+}
+
+// resetToPoolWaitForReplicas waits until the Deployment reports the target ready
+// replica count (0 for scale-down). Uses `kubectl wait` on the availableReplicas
+// via a rollout-status-equivalent: for scale-to-0 we poll the deployment's
+// .status.replicas reaching 0.
+func (s *HubServer) resetToPoolWaitForReplicas(cluster *ClusterConfig, ns string, target int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), resetToPoolScaleDownWaitTimeout)
+	defer cancel()
+	// For scale-to-0, wait for .status.replicas == 0 (no pods left). kubectl wait
+	// --for=jsonpath is the bounded, declarative way to do this.
+	cmd := kubectlForClusterContext(ctx, cluster, "wait",
+		"deployment/"+hiveDeploymentName, "-n", ns,
+		fmt.Sprintf("--for=jsonpath={.status.replicas}=%d", target),
+		fmt.Sprintf("--timeout=%ds", int(resetToPoolScaleDownWaitTimeout.Seconds())))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// resetToPoolRunWipeJob applies the wipe Job manifest, waits for it to complete,
+// and returns an error if it did not succeed. The Job (fixed name) is deleted
+// first so a re-run replaces any prior one. The wipe deletes everything under
+// /data except the seed allowlist.
+func (s *HubServer) resetToPoolRunWipeJob(cluster *ClusterConfig, ns string) error {
+	manifest := resetToPoolWipeJobManifest(ns, cluster)
+	if err := s.resetToPoolApplyJob(cluster, ns, resetToPoolWipeJobName, manifest); err != nil {
+		return err
+	}
+	return s.resetToPoolWaitJobComplete(cluster, ns, resetToPoolWipeJobName)
+}
+
+// resetToPoolApplyJob deletes any prior Job of the same name (idempotent re-run)
+// then applies the manifest.
+func (s *HubServer) resetToPoolApplyJob(cluster *ClusterConfig, ns, jobName, manifest string) error {
+	delCtx, delCancel := context.WithTimeout(context.Background(), resetToPoolKubectlTimeout)
+	defer delCancel()
+	// Best-effort delete of a prior Job; ignore-not-found. Wait so the name is free.
+	_, _ = kubectlForClusterContext(delCtx, cluster, "delete", "job", jobName, "-n", ns,
+		"--ignore-not-found", "--wait=true",
+		fmt.Sprintf("--timeout=%ds", int(resetToPoolKubectlTimeout.Seconds()))).CombinedOutput()
+
+	applyCtx, applyCancel := context.WithTimeout(context.Background(), resetToPoolKubectlTimeout)
+	defer applyCancel()
+	cmd := kubectlForClusterContext(applyCtx, cluster, "apply", "-n", ns, "-f", "-")
+	cmd.Stdin = strings.NewReader(manifest)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		s.markClusterUnreachable(cluster.ID)
+		return fmt.Errorf("apply job %s: %s: %w", jobName, strings.TrimSpace(string(out)), err)
+	}
+	s.markClusterReachable(cluster.ID)
+	return nil
+}
+
+// resetToPoolWaitJobComplete waits for the named Job to reach Complete, failing on
+// timeout or on the Job reaching Failed.
+func (s *HubServer) resetToPoolWaitJobComplete(cluster *ClusterConfig, ns, jobName string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), resetToPoolJobWaitTimeout)
+	defer cancel()
+	// Wait for either complete or failed; kubectl wait returns non-zero if the
+	// condition is not met in time, which we surface as a fail-closed error.
+	cmd := kubectlForClusterContext(ctx, cluster, "wait", "job/"+jobName, "-n", ns,
+		"--for=condition=complete",
+		fmt.Sprintf("--timeout=%ds", int(resetToPoolJobWaitTimeout.Seconds())))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		// Distinguish "failed" from "still running/timeout" for a clearer message.
+		if s.resetToPoolJobFailed(cluster, ns, jobName) {
+			return fmt.Errorf("job %s failed", jobName)
+		}
+		return fmt.Errorf("job %s did not complete: %s: %w", jobName, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// resetToPoolJobFailed reports whether the Job has a Failed condition true.
+func (s *HubServer) resetToPoolJobFailed(cluster *ClusterConfig, ns, jobName string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), resetToPoolKubectlTimeout)
+	defer cancel()
+	out, err := kubectlForClusterContext(ctx, cluster, "get", "job/"+jobName, "-n", ns,
+		"-o", "jsonpath={.status.conditions[?(@.type=='Failed')].status}").Output()
+	return err == nil && strings.TrimSpace(string(out)) == "True"
+}
+
+// resetToPoolVerifyDataClean runs a short verify Job that lists /data minus the
+// seed allowlist and returns any leftover top-level entries. A non-empty result
+// (or an error) makes the caller fail closed. The verify Job writes the leftover
+// listing to its logs, which we read back.
+func (s *HubServer) resetToPoolVerifyDataClean(cluster *ClusterConfig, ns string) ([]string, error) {
+	manifest := resetToPoolVerifyJobManifest(ns, cluster)
+	if err := s.resetToPoolApplyJob(cluster, ns, resetToPoolVerifyJobName, manifest); err != nil {
+		return nil, err
+	}
+	if err := s.resetToPoolWaitJobComplete(cluster, ns, resetToPoolVerifyJobName); err != nil {
+		return nil, err
+	}
+	// Read the verify Job's pod logs: each line is a leftover /data entry.
+	logs, err := s.resetToPoolJobLogs(cluster, ns, resetToPoolVerifyJobName)
+	if err != nil {
+		// If we cannot read the verify result, we cannot prove clean -> fail closed.
+		return nil, fmt.Errorf("could not read verify result: %w", err)
+	}
+	return resetToPoolParseLeftover(logs), nil
+}
+
+// resetToPoolJobLogs returns the combined logs of the named Job's pod(s).
+func (s *HubServer) resetToPoolJobLogs(cluster *ClusterConfig, ns, jobName string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), resetToPoolKubectlTimeout)
+	defer cancel()
+	out, err := kubectlForClusterContext(ctx, cluster, "logs", "job/"+jobName, "-n", ns,
+		"--tail=-1").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return string(out), nil
+}
+
+// resetToPoolResetSecret deletes hive-secrets and recreates it in the placeholder
+// shape (fresh dashboard-token + placeholder github-token, no tenant creds).
+func (s *HubServer) resetToPoolResetSecret(cluster *ClusterConfig, ns string) error {
+	dashToken, err := newDashboardTokenReset()
+	if err != nil {
+		return fmt.Errorf("mint dashboard-token: %w", err)
+	}
+	delCtx, delCancel := context.WithTimeout(context.Background(), resetToPoolKubectlTimeout)
+	defer delCancel()
+	if out, err := kubectlForClusterContext(delCtx, cluster, "delete", "secret", hiveSecretsName,
+		"-n", ns, "--ignore-not-found").CombinedOutput(); err != nil {
+		return fmt.Errorf("delete secret: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	manifest := resetToPoolSecretManifest(ns, dashToken)
+	applyCtx, applyCancel := context.WithTimeout(context.Background(), resetToPoolKubectlTimeout)
+	defer applyCancel()
+	cmd := kubectlForClusterContext(applyCtx, cluster, "apply", "-n", ns, "-f", "-")
+	cmd.Stdin = strings.NewReader(manifest)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("apply placeholder secret: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// resetToPoolVerifySecretKeys returns any keys present on the recreated Secret
+// that are NOT in the placeholder key set. A non-empty result fails the reset
+// closed (a surviving gh-app-key*.pem would appear here). Values are never read.
+func (s *HubServer) resetToPoolVerifySecretKeys(cluster *ClusterConfig, ns string) ([]string, error) {
+	keys := s.resetToPoolListSecretKeys(cluster, ns)
+	return resetToPoolUnexpectedSecretKeys(keys), nil
+}
+
+// resetToPoolListSecretKeys lists the hive-secrets Secret's key NAMES (never
+// values). Empty on error. Uses a go-template that iterates .data keys only, so
+// no secret value is ever fetched or logged.
+func (s *HubServer) resetToPoolListSecretKeys(cluster *ClusterConfig, ns string) []string {
+	ctx, cancel := context.WithTimeout(context.Background(), resetToPoolKubectlTimeout)
+	defer cancel()
+	keysOut, err := kubectlForClusterContext(ctx, cluster, "get", "secret", hiveSecretsName, "-n", ns,
+		"-o", `go-template={{range $k, $v := .data}}{{$k}}{{"\n"}}{{end}}`).Output()
+	if err != nil {
+		return nil
+	}
+	var keys []string
+	for _, line := range strings.Split(strings.TrimSpace(string(keysOut)), "\n") {
+		if k := strings.TrimSpace(line); k != "" {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// resetToPoolListData lists the top-level /data entries via a short-lived pod, for
+// the dry-run report. Best-effort — empty on error (a real wipe is total
+// regardless of whether this listing could be read).
+func (s *HubServer) resetToPoolListData(cluster *ClusterConfig, ns string) []string {
+	manifest := resetToPoolVerifyJobManifest(ns, cluster)
+	if err := s.resetToPoolApplyJob(cluster, ns, resetToPoolVerifyJobName, manifest); err != nil {
+		return nil
+	}
+	if err := s.resetToPoolWaitJobComplete(cluster, ns, resetToPoolVerifyJobName); err != nil {
+		return nil
+	}
+	logs, err := s.resetToPoolJobLogs(cluster, ns, resetToPoolVerifyJobName)
+	if err != nil {
+		return nil
+	}
+	return resetToPoolParseLeftover(logs)
+}
+
+// --- pure helpers (unit-tested) -----------------------------------------------
+
+// resetToPoolParseLeftover turns the verify Job's log output (one /data entry per
+// line, absolute paths under /data) into the list of leftover entries, filtering
+// blank lines and any diagnostic markers the Job prints.
+func resetToPoolParseLeftover(logs string) []string {
+	var out []string
+	for _, line := range strings.Split(logs, "\n") {
+		e := strings.TrimSpace(line)
+		if e == "" {
+			continue
+		}
+		// The verify Job prints a sentinel when clean; treat it as "no leftover".
+		if e == resetToPoolCleanSentinel {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// resetToPoolUnexpectedSecretKeys returns the keys present that are NOT in the
+// placeholder key set — the fail-closed signal for the Secret reset.
+func resetToPoolUnexpectedSecretKeys(present []string) []string {
+	allowed := map[string]bool{}
+	for _, k := range resetToPoolPlaceholderSecretKeys() {
+		allowed[k] = true
+	}
+	var extra []string
+	for _, k := range present {
+		if !allowed[strings.TrimSpace(k)] {
+			extra = append(extra, k)
+		}
+	}
+	sort.Strings(extra)
+	return extra
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}
+
+func firstN(xs []string, n int) []string {
+	if len(xs) <= n {
+		return xs
+	}
+	return xs[:n]
+}

--- a/v2/pkg/hub/saas_reset_to_pool_manifests.go
+++ b/v2/pkg/hub/saas_reset_to_pool_manifests.go
@@ -1,0 +1,171 @@
+package hub
+
+import (
+	"fmt"
+	"strings"
+)
+
+// This file builds the throwaway Kubernetes manifests the reset-to-pool wipe
+// applies: the wipe Job, the verify Job, and the placeholder Secret. They are
+// piped to `kubectl apply -f -` via stdin (never written to disk with secret
+// values, mirroring provisionHive which deletes its manifest right after apply).
+//
+// SHARED SEED ALLOWLIST. Both the wipe and the verify Jobs derive their find(1)
+// prune expression from the SAME resetToPoolSeedAllowlist (via
+// resetToPoolFindPruneExpr), so the set of files the wipe KEEPS and the set the
+// verify TOLERATES cannot drift. With an empty allowlist the wipe deletes
+// everything under /data and the verify tolerates nothing.
+
+const (
+	// resetToPoolCleanSentinel is printed by the verify Job when /data contains
+	// only the seed allowlist (i.e. nothing unexpected). The hub treats a log
+	// consisting solely of this sentinel as "verified clean". Any other non-blank
+	// line is a leftover entry -> FAIL CLOSED.
+	resetToPoolCleanSentinel = "RESET_TO_POOL_CLEAN"
+
+	// resetToPoolDataMount is where the PVC is mounted in the wipe/verify Jobs.
+	resetToPoolDataMount = "/data"
+)
+
+// resetToPoolFindPruneExpr builds a find(1) expression fragment that EXCLUDES the
+// seed allowlist from a `find /data -mindepth 1` scan. Each allowlisted entry is
+// matched at the top level (-maxdepth 1 semantics enforced by the caller's find
+// invocation) and pruned. With an empty allowlist this returns "" and nothing is
+// excluded — the wipe is total and the verify tolerates nothing.
+//
+// The allowlist entries are top-level names under /data (e.g. "hive.yaml" would
+// exclude /data/hive.yaml). They are shell-quoted defensively even though they
+// are compile-time constants, so a future entry with an odd character cannot
+// break the expression.
+func resetToPoolFindPruneExpr(allowlist []string) string {
+	if len(allowlist) == 0 {
+		return ""
+	}
+	var parts []string
+	for _, name := range allowlist {
+		parts = append(parts, fmt.Sprintf(`-name %s`, shellSingleQuote(name)))
+	}
+	// ( -name a -o -name b ) -prune -o
+	return "( " + strings.Join(parts, " -o ") + " ) -prune -o "
+}
+
+// shellSingleQuote wraps s in single quotes, escaping any embedded single quotes,
+// for safe inclusion in a /bin/sh command.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// resetToPoolWipeScript is the shell the wipe Job runs. It deletes every top-level
+// entry under /data except the seed allowlist, then re-asserts by listing what
+// remains (should be only the allowlist). Runs under `set -e` so any rm failure
+// fails the Job (and thus the reset, closed).
+//
+// -mindepth 1 -maxdepth 1: operate on top-level entries only; -exec rm -rf {} +
+// recurses INTO each, so nested owner-gated trees (per-agent CODEX_HOME chowned
+// to an agent uid, .copilot group-rw, sqlite locks) are removed because the Job
+// runs as root (uid 0 — see the manifest's securityContext).
+func resetToPoolWipeScript(allowlist []string) string {
+	prune := resetToPoolFindPruneExpr(allowlist)
+	// The wipe: find <mount> -mindepth 1 -maxdepth 1 [prune] -exec rm -rf {} +
+	return "set -e; " +
+		fmt.Sprintf("echo '[reset-wipe] wiping %s (keeping seed allowlist: %s)'; ", resetToPoolDataMount, allowlistForLog(allowlist)) +
+		fmt.Sprintf("find %s -mindepth 1 -maxdepth 1 %s -exec rm -rf {} + ; ", resetToPoolDataMount, prune) +
+		fmt.Sprintf("echo '[reset-wipe] done; remaining top-level entries:'; ls -A %s || true", resetToPoolDataMount)
+}
+
+// resetToPoolVerifyScript is the shell the verify Job runs. It lists every
+// top-level entry under /data that is NOT in the seed allowlist. If there are
+// none it prints the clean sentinel; otherwise it prints each leftover path (one
+// per line) which the hub reads back as the fail-closed signal.
+func resetToPoolVerifyScript(allowlist []string) string {
+	prune := resetToPoolFindPruneExpr(allowlist)
+	// Collect leftover entries; print sentinel if empty, else the entries.
+	return "set -e; " +
+		fmt.Sprintf("LEFT=$(find %s -mindepth 1 -maxdepth 1 %s -print); ", resetToPoolDataMount, prune) +
+		`if [ -z "$LEFT" ]; then echo ` + resetToPoolCleanSentinel + `; else echo "$LEFT"; fi`
+}
+
+func allowlistForLog(allowlist []string) string {
+	if len(allowlist) == 0 {
+		return "(none — total wipe)"
+	}
+	return strings.Join(allowlist, ", ")
+}
+
+// resetToPoolJobManifest builds a Job manifest running `sh -c <script>` against
+// the hive-data PVC, as root, bounded by activeDeadline/backoffLimit. On
+// SCC-gated clusters (OpenShift) the Job uses the hive service account so the
+// anyuid SCC lets it run as uid 0.
+func resetToPoolJobManifest(ns, jobName, script string, cluster *ClusterConfig) string {
+	var sb strings.Builder
+	sb.WriteString("apiVersion: batch/v1\n")
+	sb.WriteString("kind: Job\n")
+	sb.WriteString("metadata:\n")
+	sb.WriteString("  name: " + jobName + "\n")
+	sb.WriteString("  namespace: " + ns + "\n")
+	sb.WriteString("spec:\n")
+	sb.WriteString(fmt.Sprintf("  activeDeadlineSeconds: %d\n", resetToPoolJobActiveDeadlineSecs))
+	sb.WriteString(fmt.Sprintf("  backoffLimit: %d\n", resetToPoolJobBackoffLimit))
+	// ttlSecondsAfterFinished lets the cluster GC the Job so it does not linger;
+	// long enough that the hub can read its logs first.
+	sb.WriteString("  ttlSecondsAfterFinished: 300\n")
+	sb.WriteString("  template:\n")
+	sb.WriteString("    spec:\n")
+	sb.WriteString("      restartPolicy: Never\n")
+	if cluster != nil && cluster.RequiresSCC {
+		sb.WriteString("      serviceAccountName: " + sccServiceAccountName + "\n")
+	}
+	// Run as root so the wipe can remove files owned by the agent uids (2001+).
+	sb.WriteString("      securityContext:\n")
+	sb.WriteString("        runAsUser: 0\n")
+	sb.WriteString("      containers:\n")
+	sb.WriteString("      - name: reset\n")
+	sb.WriteString("        image: " + resetToPoolWipeImage + "\n")
+	sb.WriteString("        command: [\"sh\", \"-c\"]\n")
+	// The script is a YAML flow scalar; single-quote it and escape embedded quotes.
+	sb.WriteString("        args:\n")
+	sb.WriteString("        - " + yamlSingleQuote(script) + "\n")
+	sb.WriteString("        volumeMounts:\n")
+	sb.WriteString("        - name: data\n")
+	sb.WriteString("          mountPath: " + resetToPoolDataMount + "\n")
+	sb.WriteString("      volumes:\n")
+	sb.WriteString("      - name: data\n")
+	sb.WriteString("        persistentVolumeClaim:\n")
+	sb.WriteString("          claimName: " + hiveDataPVCName + "\n")
+	return sb.String()
+}
+
+// resetToPoolWipeJobManifest / resetToPoolVerifyJobManifest are the two concrete
+// Jobs, sharing resetToPoolSeedAllowlist so wipe and verify cannot drift.
+func resetToPoolWipeJobManifest(ns string, cluster *ClusterConfig) string {
+	return resetToPoolJobManifest(ns, resetToPoolWipeJobName, resetToPoolWipeScript(resetToPoolSeedAllowlist), cluster)
+}
+
+func resetToPoolVerifyJobManifest(ns string, cluster *ClusterConfig) string {
+	return resetToPoolJobManifest(ns, resetToPoolVerifyJobName, resetToPoolVerifyScript(resetToPoolSeedAllowlist), cluster)
+}
+
+// resetToPoolSecretManifest builds the placeholder hive-secrets Secret: a fresh
+// dashboard-token and a placeholder github-token, nothing else. This is the EXACT
+// key set a non-App available slot boots with (see resetToPoolPlaceholderSecretKeys).
+// dashboardToken is a freshly minted random value; the github-token is the
+// non-secret sentinel. Both go in stringData so kubectl base64-encodes them.
+func resetToPoolSecretManifest(ns, dashboardToken string) string {
+	var sb strings.Builder
+	sb.WriteString("apiVersion: v1\n")
+	sb.WriteString("kind: Secret\n")
+	sb.WriteString("metadata:\n")
+	sb.WriteString("  name: " + hiveSecretsName + "\n")
+	sb.WriteString("  namespace: " + ns + "\n")
+	sb.WriteString("type: Opaque\n")
+	sb.WriteString("stringData:\n")
+	sb.WriteString("  dashboard-token: " + yamlSingleQuote(dashboardToken) + "\n")
+	sb.WriteString("  github-token: " + yamlSingleQuote(resetToPoolPlaceholderToken) + "\n")
+	return sb.String()
+}
+
+// yamlSingleQuote quotes s as a YAML single-quoted scalar (embedded single quotes
+// doubled), safe for a value that may contain shell/YAML metacharacters.
+func yamlSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}


### PR DESCRIPTION
## Phase 2 of #2748 — reset a LIVE claimed hive back to the unassigned pool (credential-safe /data wipe)

Design comment (reviewable spec): https://github.com/kubestellar/hive/issues/2748#issuecomment-5206903131

Phase 1 (the record-only escape hatch for an assigned-but-unclaimed placeholder) already ships and is reused verbatim for the record half. This PR adds the **storage wipe + verify + fail-closed** state machine a delivered claim needs.

> ⚠️ **Destructive-storage feature — left OPEN for operator review.** Please review the wipe/verify logic and the security model before merging.

### The guarantee: wipe-by-default, verify-clean, fail-closed (NOT a delete-list)

The operator's central concern — *"how do we assure there is NO data left — beads, tmux, or anything else?"* — is answered by an **empty seed allowlist**, not an enumerated delete-list (which rots the day a future feature drops `/data/newthing`).

Code-confirmed: on a fresh provision the `/data` PVC starts **completely empty**. The `copy-config` init container seeds the ConfigMap into `/etc/hive` (an emptyDir), never onto the PVC; everything else on `/data` is recreated by `entrypoint.sh` on boot (idempotent `mkdir -p` / `cp -n` / runtime generation). Therefore:

- **Seed allowlist = ∅.** The wipe destroys everything under `/data`; the verify contract is total and trivial: `find /data -mindepth 1` must return **nothing**. Anything left ⇒ **FAIL CLOSED**.
- The wipe and verify Jobs derive their `find(1)` prune expression from the **same** `resetToPoolSeedAllowlist`, so what the wipe keeps and what the verify tolerates can never drift.
- On restart the spoke re-seeds `/data` exactly as on a first-ever boot — byte-for-byte the fresh-provision baseline.

### Sequence (each step fail-closed; reachable clusters only)

1. **Reachability gate** — a heartbeat-only / unreachable cluster is **refused** (a wipe there cannot be verified; use Delete instead).
2. **Scale the spoke to 0** and wait — no agent/tmux/writer can recreate state mid-wipe.
3. **Wipe Job** — a short-lived root Job mounting the same `hive-data` PVC; `find /data -mindepth 1 -maxdepth 1 -exec rm -rf {} +` (root, so it removes files chowned to the agent uids / `.copilot` group-rw / sqlite locks). Bounded by `activeDeadlineSeconds` + `backoffLimit`; OpenShift SCC honoured.
4. **Verify `/data` clean** — a verify Job lists any leftover top-level entry; non-empty ⇒ **FAIL CLOSED**.
5. **Reset the Secret** — delete + recreate `hive-secrets` in the placeholder shape (fresh `dashboard-token` + placeholder `github-token`; **no** `gh-app-key*.pem`, no tenant creds) and **verify its key set** — any extra key ⇒ **FAIL CLOSED**.
6. **Record reset — only after verified clean** — reuse Phase 1's `resetHiveToAvailablePlaceholder`, drop the owner grant (like access-revoke; quota untouched — it's increment-only in the codebase, called out as deliberate), reopen the provision request, re-stamp the namespace identity to placeholder.
7. **Scale the spoke back to 1** — boots fresh from the re-seeded empty `/data` as an unclaimed placeholder.

**Fail-closed state:** `ResetToPoolStatus` = `in-progress` while running, `failed` (with a reason) on any wipe/verify error. The record flips to `available` **only** on a verified-clean result; on failure the hive stays claimed and the namespace is left intact for manual inspection. Idempotent + re-runnable.

### Security model (defense-in-depth for an irreversible destructive action)

- **Admin-only** (`requireAdmin`, which also applies `blockIfImpersonatingWrite` — a "View as user" session cannot trigger it, 403).
- **Typed confirmation** in the body: `confirm` must equal the hive id (mirrors `slackBroadcastConfirm`); else 400. The UI makes the operator TYPE the hive id.
- **Dry-run**: `dry_run:true` returns what would be wiped (the `/data` listing + Secret key names + namespace) and deletes nothing.
- **Same-origin check** over `SameSite=Lax` (rejects a present-but-untrusted `Origin`/`Referer` via the existing `isTrustedOrigin`).
- **State guard**: 409 unless the hive is a resettable LIVE hosted hive (`ClaimDelivered`).
- **Concurrency latch**: 409 while a reset is already in flight.
- **Audit** on every attempt (success AND fail-closed); **secret values never logged** — key names / paths only.

### Left out as unsafe (reported, not shipped half-done)

- **Heartbeat-only / unreachable clusters** (the vllm-d class): the hub cannot run — or verify — a wipe Job there, so reset-to-pool refuses rather than shipping an unverifiable wipe (exactly the leak #2748 forbids). Reachable clusters (the common case) get the full verified wipe.
- **Quota reversal**: `SaaSQuota` is increment-only across the codebase; this drops the owner's `Hives[id]` grant but does not decrement quota, matching existing behavior.

### Tests

Pure/unit-level (no shared-global mutation, `-race`-safe): the empty-seed verify fails closed on a `/data` tree with a stray bead dir / tmux socket / creds file / per-agent CODEX_HOME and passes on the clean sentinel; the seed-allowlist-is-empty invariant is pinned; the Secret-reset placeholder shape and the surviving-App-key fail-closed detection; the live-hive state guard; the record-reset shape; and the same-origin check (trusted passes, untrusted rejected, absent allowed).

### Files

- `v2/pkg/hub/saas_reset_to_pool.go` — handler, wipe/verify/record state machine, security gates, kubectl primitives.
- `v2/pkg/hub/saas_reset_to_pool_manifests.go` — wipe/verify Job + placeholder Secret manifest builders (shared seed allowlist).
- `v2/pkg/hub/saas.go` — route registration + UI row-menu action + `resetToPool()` JS (dry-run preview, typed confirm, fail-closed surfacing).
- `v2/pkg/hub/saas_provision.go` — `ResetToPoolStatus` / `ResetToPoolError` fields on `SaaSHive`.
- `v2/pkg/hub/reset_to_pool_test.go` — tests.

Fixes #2748

🤖 Generated with [Claude Code](https://claude.com/claude-code)
