### PR TITLE
security(H3 follow-up): stop leaking full installation token to agents via HIVE_GITHUB_TOKEN

### DIFF
--- a/bin/agent-launch.sh
+++ b/bin/agent-launch.sh
@@ -20,10 +20,16 @@ set -euo pipefail
 # Agents share /data/home/.copilot — umask 007 ensures new files are group-rw.
 umask 007
 
-# Source hive-config.sh to make HIVE_GITHUB_TOKEN available for gh wrapper.
+# Source hive-config.sh for project/health/outreach config the agent env needs.
 # Do NOT export GH_TOKEN here — Copilot CLI uses GH_TOKEN for its own Copilot
-# API auth, which rejects GitHub App server-to-server tokens. The gh wrapper
-# (/usr/local/bin/gh) injects HIVE_GITHUB_TOKEN on a per-call basis instead.
+# API auth, which rejects GitHub App server-to-server tokens.
+#
+# SECURITY (audit H3 follow-up, CWE-522): sourcing hive-config.sh sets
+# HIVE_GITHUB_TOKEN (the shared FULL installation token) in this process env.
+# Agents must never carry the full token — they use ONLY their per-agent SCOPED
+# token via the gh wrapper (HIVE_AGENT_TOKEN_CACHE → gh-token-<agent>.cache).
+# Unset the full-token env immediately after sourcing, and do NOT re-export it
+# to the CLI below, so it cannot leak into the agent CLI or its children.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HIVE_CONFIG="${SCRIPT_DIR}/hive-config.sh"
 if [[ -f "$HIVE_CONFIG" ]]; then
@@ -32,6 +38,7 @@ elif [[ -f /usr/local/bin/hive-config.sh ]]; then
   source /usr/local/bin/hive-config.sh
 fi
 unset GH_TOKEN
+unset HIVE_GITHUB_TOKEN
 
 # Export agent identity so the gh wrapper can load per-agent restrictions.
 # AGENT_SESSION_NAME is set by the supervisor from the agent's .env file.
@@ -40,7 +47,10 @@ export HIVE_AGENT_ID="${AGENT_SESSION_NAME:-unknown}"
 # Re-export HIVE_ env vars so child processes (gh, etc.) inherit them.
 # These are set as inline prefixes by the Go binary (e.g. HIVE_ACMM_LEVEL=2 agent-launch.sh ...)
 # and need to be exported for gh-wrapper ACMM enforcement to work.
-for var in HIVE_AGENT HIVE_AGENT_DISPLAY_NAME HIVE_ACMM_LEVEL HIVE_ID HIVE_SHA HIVE_ADVISORY_ISSUE HIVE_GITHUB_TOKEN; do
+# NOTE: HIVE_GITHUB_TOKEN (the shared full installation token) is deliberately
+# NOT in this list — agents authenticate with their per-agent SCOPED token via
+# the gh wrapper, never the full token (audit H3 follow-up).
+for var in HIVE_AGENT HIVE_AGENT_DISPLAY_NAME HIVE_ACMM_LEVEL HIVE_ID HIVE_SHA HIVE_ADVISORY_ISSUE; do
   [[ -n "${!var:-}" ]] && export "$var"
 done
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -817,6 +817,17 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 	for _, p := range m.agentEnvPairs(agent) {
 		_ = m.tmuxCmd(agent, "set-environment", "-t", agent.tmuxSession, p.Key, p.Value).Run()
 	}
+	// Strip the shared FULL installation token (HIVE_GITHUB_TOKEN) from EVERY
+	// agent session (audit H3 follow-up, CWE-522). The hive process env carries
+	// HIVE_GITHUB_TOKEN (exported by entrypoint.sh from the full-token cache, and
+	// legitimately read by the hive itself as a config fallback), and a tmux
+	// server started by this process inherits that env — so without this strip it
+	// would leak into every pane the server forks, handing agents the full-
+	// privilege installation token. Agents must use ONLY their per-agent SCOPED
+	// token (gh-token-<agent>.cache via HIVE_AGENT_TOKEN_CACHE + the gh wrapper),
+	// so unset the full-token env in the session for all agents regardless of
+	// push capability. This does not touch the hive process env.
+	_ = m.tmuxCmd(agent, "set-environment", "-t", agent.tmuxSession, "-u", "HIVE_GITHUB_TOKEN").Run()
 	// Strip gh/git tokens from advisory agent sessions.
 	if !m.agentMode(agent).CanPush() {
 		_ = m.tmuxCmd(agent, "set-environment", "-t", agent.tmuxSession, "-u", "GH_TOKEN").Run()


### PR DESCRIPTION
## Security: H3 follow-up — stop leaking the full installation token to agents

Follow-up to the merged H3 PR #2747 (audit finding H3, CWE-522).

### The residual (flagged in #2747)
H3 tightened the shared full-token cache to `0600` and removed the gh wrapper's fallback to the full token. But it left a residual:

> `HIVE_GITHUB_TOKEN` is itself populated from the full-token cache (`entrypoint.sh`, `hive-config.sh`) and exported into every agent env by `agent-launch.sh`. The wrapper's USE of it as a fallback was removed, but the env var still carries the FULL installation token into agent processes — a follow-up (stop exporting it to non-contributor agents) would fully close the env-var vector.

### Where the full token was reaching agents
Two mechanisms carried the **full installation token** (`HIVE_GITHUB_TOKEN`) into hub-managed agent panes:

1. **tmux server-env inheritance (primary vector).** `entrypoint.sh` exports `HIVE_GITHUB_TOKEN` from the full-token cache into the hive process env (the hive itself reads it as a config fallback — `v2/cmd/hive/main.go`). The manager forks per-agent tmux servers with no `cmd.Env` override (`ensureTmuxSession` → `exec.Command("tmux", "new-session", ...)`), so each server inherits the hive process env. A tmux server's ambient env is copied into every pane it forks — so every agent shell saw the full token. The existing strip only unset `GH_TOKEN`/`GITHUB_TOKEN`, and only for advisory (non-push) agents; `HIVE_GITHUB_TOKEN` was never stripped for anyone.
2. **`agent-launch.sh` re-export.** It sourced `hive-config.sh` (which sets `HIVE_GITHUB_TOKEN`) and re-exported `HIVE_GITHUB_TOKEN` into the CLI env via the `HIVE_` re-export loop.

### The fix (agent-scoped; hive process env untouched)
- **`v2/pkg/agent/manager.go`** — in `ensureTmuxSession`, unconditionally `set-environment -u HIVE_GITHUB_TOKEN` on **every** agent session (all agents, regardless of push capability), alongside the existing advisory-only `GH_TOKEN`/`GITHUB_TOKEN` strip. The `respawn-pane -k` that follows forks a fresh pane shell **after** the strip, so no agent pane inherits the full token.
- **`bin/agent-launch.sh`** — `unset HIVE_GITHUB_TOKEN` right after sourcing `hive-config.sh` (defense-in-depth, mirroring the existing `unset GH_TOKEN`), and removed `HIVE_GITHUB_TOKEN` from the `HIVE_` re-export loop so it never reaches the CLI or its children.

Agents authenticate with their **per-agent SCOPED token only** — `gh-token-<agent>.cache` via `HIVE_AGENT_TOKEN_CACHE` + the gh wrapper. The H3 wrapper already fails loud when the scoped token is missing and no longer reads `HIVE_GITHUB_TOKEN` at all, so removing the full-token env is fully consistent: nothing agent-side reads it anymore.

### What was preserved (and why)
- **The hive process** still reads `HIVE_GITHUB_TOKEN` as a config fallback (`v2/cmd/hive/main.go` — `ghToken`, `fleetStatsToken`). This change strips the var only from **agent tmux sessions** (`set-environment -u`), never from the hive process env, so hive-level GitHub auth is unchanged.
- **Contributor agents** run in a separate container (`Dockerfile.contributor`) that never had the installation token — they use their own personal / per-task token (`GH_TOKEN`, credential helper). They were never affected; nothing here changes for them. (This is the "non-contributor agents" the residual note referred to.)
- **Advisory (non-push) agents** keep their existing `GH_TOKEN`/`GITHUB_TOKEN` strip.

### Verification
- Grep confirms no agent-side code sets/reads `HIVE_GITHUB_TOKEN` anymore: `bin/agent-launch.sh` has only comments + the `unset`; `bin/gh-wrapper.sh` has only a comment (H3 already removed the fallback); the manager now `set-environment -u`s it.
- `bash -n bin/agent-launch.sh` passes; `gofmt -l v2/pkg/agent/manager.go` is clean.
- Manual reasoning: agents run on their scoped token (H3 wrapper, fail-loud without it); the full token is no longer in any agent session or process env; the hive process env is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
