### PR TITLE
fix(sec): short-lived signed terminal assertion as primary per-hive gate (C3 follow-up)

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1669,6 +1669,11 @@ func (s *Server) handleGHUserAuthPoll(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		setSessionCookie(w, r, sid)
+		// Mint the short-lived per-hive terminal assertion cookie the Node proxy
+		// verifies as its PRIMARY per-hive gate (finding C3 follow-up). Same
+		// {user,hive,role} just authorized for this session, bound to THIS hive
+		// with an expiry. No-op on non-hosted hives.
+		s.setTerminalAssertionCookie(w, r, username, role)
 	}
 
 	// Audit the successful login with the authenticated GitHub username as the
@@ -1782,6 +1787,11 @@ func (s *Server) handleSSO(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	setSessionCookie(w, r, sid)
+	// Mint the short-lived per-hive terminal assertion cookie the Node proxy
+	// verifies as its PRIMARY per-hive gate (finding C3 follow-up). The role here
+	// is the spoke's authoritative allowlist role (resolved above), bound to THIS
+	// hive with an expiry. No-op on non-hosted hives.
+	s.setTerminalAssertionCookie(w, r, username, role)
 	s.audit.Log(username, "login", auditDetail("method", "hub sso handoff", "role", role), "")
 	if s.deps != nil && s.deps.Logger != nil {
 		s.deps.Logger.Info("user authenticated via hub SSO handoff", "username", username, "role", role)

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -34,6 +34,13 @@ const maxSSEClients = 100
 const sessionCookieName = "hive_session"
 const sessionCookieMaxAge = 30 * 24 * 60 * 60 // 30 days
 
+// terminalAssertionCookieName carries the short-lived, HMAC-signed
+// {user,hive,role,exp} assertion the Node proxy verifies as the PRIMARY per-hive
+// terminal gate (finding C3 follow-up). It is Path=/terminal-scoped and NOT
+// domain-widened to .hive.kubestellar.io (unlike the hub-wide hive_hub_user
+// cookie), so the browser only ever sends it to THIS hive's own terminal path.
+const terminalAssertionCookieName = "hive_terminal_assertion"
+
 // proxyAuthHeader is the proof-of-proxy header the hub's auth-check injects
 // (value = this hive's dashboard token) so a hub-proxied spoke can verify a
 // request actually transited the hub nginx rather than being forged on the pod

--- a/v2/pkg/dashboard/session.go
+++ b/v2/pkg/dashboard/session.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"sort"
 	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/hub"
 )
 
 // userSession is a per-user server-side session created after a successful,
@@ -220,6 +222,64 @@ func setSessionCookie(w http.ResponseWriter, r *http.Request, id string) {
 		SameSite: http.SameSiteLaxMode,
 	})
 }
+
+// setTerminalAssertionCookie mints a short-lived, HMAC-signed {user,hive,role,exp}
+// assertion (hub.MintTerminalAssertion) and writes it as the hive_terminal_assertion
+// cookie. This is the C3 follow-up upgrade over the static per-hive username
+// allowlist: instead of the proxy consulting a list injected at PROVISION time,
+// it now verifies a FRESH, EXPIRING, role-carrying grant the spoke minted for
+// THIS user on THIS hive at LOGIN time.
+//
+// Called right after a per-user session is established (device-flow login and
+// hub SSO handoff), where {username, role} are already authoritatively resolved
+// against this hive's own allowlist. A no-op (no cookie) when the hive has no
+// terminal signing key (not hub-hosted / no derivable key) or no HiveID — in that
+// case the proxy simply falls back to the #2756 static-allowlist / ingress path,
+// so there is no regression.
+//
+// The signing key is the SPOKE-LOCAL, SYMMETRIC terminal key (hub.TerminalSigningKey):
+// the spoke mints here and the proxy verifies on the same spoke, so this is NOT
+// the (now-asymmetric, C2 #2761) SSO signing path — it is decoupled from it.
+//
+// The cookie is Path=/terminal-scoped, HttpOnly and Secure — it is a bearer
+// grant for a shell, so it never reaches page JS and never travels in the clear.
+// It is deliberately NOT Domain=.hive.kubestellar.io: unlike the hub-wide
+// hive_hub_user cookie (which every hive's domain receives and which was the root
+// of C3), this assertion is bound to THIS hive by its signed HiveID claim AND
+// only sent to this hive's host.
+func (s *Server) setTerminalAssertionCookie(w http.ResponseWriter, r *http.Request, username, role string) {
+	key := hub.TerminalSigningKey()
+	if key == "" {
+		return
+	}
+	hiveID := ""
+	if s.deps != nil && s.deps.Config != nil {
+		hiveID = s.deps.Config.HiveID
+	}
+	if hiveID == "" {
+		return
+	}
+	tok := hub.MintTerminalAssertion(key, username, role, hiveID, time.Now())
+	if tok == "" {
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     terminalAssertionCookieName,
+		Value:    tok,
+		Path:     "/terminal",
+		MaxAge:   int(terminalAssertionCookieMaxAge.Seconds()),
+		HttpOnly: true,
+		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// terminalAssertionCookieMaxAge caps how long the browser retains the assertion
+// cookie. It matches the signed assertion's own TTL (hub.terminalAssertionTTL,
+// 15 min): the cookie's lifetime and the token's expiry should agree so a stale
+// cookie is dropped by the browser at roughly the same time the proxy would
+// reject it as expired anyway. The proxy's exp check is authoritative regardless.
+const terminalAssertionCookieMaxAge = 15 * time.Minute
 
 // clearSessionCookie expires the per-user session cookie on the client.
 func clearSessionCookie(w http.ResponseWriter) {

--- a/v2/pkg/hub/terminal_assertion.go
+++ b/v2/pkg/hub/terminal_assertion.go
@@ -1,0 +1,202 @@
+package hub
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// Short-lived signed terminal assertion (finding C3 follow-up).
+//
+// This is the principled upgrade over the static per-hive username allowlist
+// that finding C3 (#2756) shipped: instead of "is this hub user statically
+// listed on this hive", the Node proxy in front of ttyd verifies a FRESH,
+// EXPIRING, role-carrying grant the spoke minted for THIS user on THIS hive at
+// session time, binding {user, hive_id, role, expiry}.
+//
+// WHY IT DOES NOT SHARE THE SSO SIGNING PATH (C2 coordination):
+// The SSO handoff token is ASYMMETRIC (Ed25519, C2 follow-up #2761): ONLY the
+// hub may mint it and a spoke holds the PUBLIC key to verify — because an SSO
+// token asserts hub-wide identity and a spoke operator must not be able to mint
+// one. The terminal assertion is a fundamentally DIFFERENT trust shape: it is
+// SYMMETRIC and SPOKE-LOCAL — the spoke both MINTS it (right after it
+// establishes a per-user session) and the proxy VERIFIES it, both on the SAME
+// spoke, with a key the spoke legitimately holds. That is a correct symmetric
+// use, so the terminal assertion has its OWN dedicated HMAC signer
+// (terminalSign) and its OWN derived sub-key, entirely independent of the SSO
+// signing primitive. It deliberately does NOT call the SSO signer (which #2761
+// removes when SSO goes Ed25519), so this code survives that cutover unchanged.
+//
+// It reuses only the pure DATA-SHAPE helpers from sso.go — the ssoClaims struct,
+// the ssoB64 URL-safe base64, and the ssoClockSkew tolerance — none of which is
+// signing material.
+
+const (
+	// terminalAssertionVersion namespaces the signed payload so a verifier accepts
+	// ONLY terminal assertions and can never be tricked into treating an SSO
+	// handoff token (or any other domain's token) as a terminal grant. Distinct
+	// version string from ssoTokenVersion.
+	terminalAssertionVersion = "hive-terminal-v1"
+
+	// terminalAssertionTTL bounds how long a freshly-minted terminal assertion is
+	// valid. Longer than the SSO handoff's TTL because it is not consumed-once on a
+	// redirect — it rides in a cookie the proxy re-checks on the terminal page load
+	// AND the websocket upgrade — but still short so a leaked cookie is a small
+	// window, and the user must re-establish a session to renew it. 15 minutes is
+	// the upper bound the C3 follow-up called for (e.g. 5–15 min).
+	terminalAssertionTTL = 15 * time.Minute
+
+	// infoTerminalKey is the domain-separation label for the terminal assertion's
+	// symmetric signing sub-key. It mirrors the C2 (#2758/#2761) deriveDomainKey
+	// convention — HMAC-SHA256(master, info) rendered as hex — so when C2's
+	// hub_keys.go lands the two derivations are FUNCTIONALLY IDENTICAL and this can
+	// be folded onto deriveDomainKey(master, infoTerminalKey) in a later cleanup.
+	// It is a DISTINCT label from the heartbeat/session/sso sub-keys, so the
+	// terminal key can only ever sign/verify terminal assertions.
+	infoTerminalKey = "hive-terminal-v1"
+
+	// EnvTerminalKey is the dedicated spoke-side env var a least-privilege
+	// provisioning path may inject (mirrors C2's EnvSessionKey / EnvHeartbeatKey).
+	// When unset, terminalSigningKey falls back to the session sub-key the spoke
+	// already holds, then to deriving from HIVE_HUB_SECRET — see terminalSigningKey.
+	EnvTerminalKey = "HIVE_TERMINAL_KEY"
+
+	// envSessionKey / envHubSecret are the fallbacks terminalSigningKey resolves
+	// against. Named as string literals here (not imported from hub_keys.go, which
+	// lives only on the C2 branch) so this file compiles on its own base and after
+	// the C2 merge alike.
+	envSessionKey = "HIVE_SESSION_KEY"
+	envHubSecret  = "HIVE_HUB_SECRET"
+)
+
+// terminalSign returns the URL-safe base64 HMAC-SHA256 of body under key. This is
+// the terminal assertion's OWN signer — identical construction to the pre-C2
+// ssoSign, but deliberately separate so the terminal path does not depend on the
+// SSO signing primitive (which #2761 replaces with Ed25519).
+func terminalSign(key, body string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(body))
+	return ssoB64.EncodeToString(mac.Sum(nil))
+}
+
+// deriveTerminalKeyFrom returns the domain-separated terminal sub-key of master,
+// as lowercase hex — HMAC-SHA256(master, infoTerminalKey). Same formula as C2's
+// deriveDomainKey, kept local (under a distinct name) so it neither depends on
+// nor collides with hub_keys.go's deriveDomainKey when both land. Returns "" for
+// an empty master so an unset secret can never derive a usable key (fail closed).
+func deriveTerminalKeyFrom(master string) string {
+	if master == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, []byte(master))
+	mac.Write([]byte(infoTerminalKey))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// TerminalSigningKey resolves the symmetric key the spoke mints — and the proxy
+// verifies — terminal assertions with. Resolution order (most-to-least specific),
+// matching the spoke-side least-privilege story and surviving the C2 cutover:
+//
+//  1. HIVE_TERMINAL_KEY — a dedicated derived sub-key, if a future provisioning
+//     path injects one (most privilege-minimal).
+//  2. HIVE_SESSION_KEY — the session sub-key a C2-provisioned spoke ALREADY holds
+//     (the spoke both mints and verifies terminal grants, so reusing the
+//     spoke-local session key is a legitimate symmetric use). This is the normal
+//     post-#2761 hosted path: the spoke no longer receives the master.
+//  3. deriveTerminalKeyFrom(HIVE_HUB_SECRET) — self-hosted / pre-#2761 hosted
+//     spokes still hold the master; derive the terminal sub-key from it.
+//
+// Returns "" only when none is configured, preserving fail-closed behavior (no
+// key → no assertion minted → proxy falls back to the #2756 static allowlist).
+// The Node proxy's terminalSigningKey() mirrors this order EXACTLY.
+func TerminalSigningKey() string {
+	if v := strings.TrimSpace(os.Getenv(EnvTerminalKey)); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv(envSessionKey)); v != "" {
+		return v
+	}
+	return deriveTerminalKeyFrom(strings.TrimSpace(os.Getenv(envHubSecret)))
+}
+
+// MintTerminalAssertion creates a short-lived, HMAC-signed assertion binding
+// {username, role, hiveID, expiry} for opening a terminal on a SINGLE hive, using
+// the resolved terminal signing key. Reuses the ssoClaims shape but with
+// terminalAssertionVersion and the dedicated terminalSign. Returns "" if the key
+// is empty or identity is missing.
+func MintTerminalAssertion(key, username, role, hiveID string, now time.Time) string {
+	if key == "" || username == "" || hiveID == "" {
+		return ""
+	}
+	claims := ssoClaims{
+		Version:  terminalAssertionVersion,
+		Username: username,
+		Role:     role,
+		HiveID:   hiveID,
+		IssuedAt: now.Unix(),
+		Expiry:   now.Add(terminalAssertionTTL).Unix(),
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return ""
+	}
+	body := ssoB64.EncodeToString(payload)
+	return body + "." + terminalSign(key, body)
+}
+
+// VerifyTerminalAssertion validates a terminal assertion against key and the
+// verifier's own hiveID, returning the carried username and role. It fails closed
+// on any mismatch: bad signature, wrong version (an SSO handoff token is NOT a
+// terminal grant), expired/not-yet-valid, or a hiveID that is not THIS hive (an
+// assertion minted for hive A can never open a terminal on hive B).
+//
+// This is the Go reference the Node proxy's verifyTerminalAssertion mirrors
+// EXACTLY; keep the two in lockstep. `now` is the verifier's clock.
+func VerifyTerminalAssertion(key, token, expectedHiveID string, now time.Time) (username, role string, err error) {
+	if key == "" {
+		return "", "", fmt.Errorf("terminal-assertion: no signing key configured")
+	}
+	parts := strings.SplitN(token, ".", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("terminal-assertion: malformed token")
+	}
+	body, sig := parts[0], parts[1]
+
+	// Constant-time signature check BEFORE trusting any payload bytes.
+	expected := terminalSign(key, body)
+	if !hmac.Equal([]byte(sig), []byte(expected)) {
+		return "", "", fmt.Errorf("terminal-assertion: bad signature")
+	}
+
+	raw, err := ssoB64.DecodeString(body)
+	if err != nil {
+		return "", "", fmt.Errorf("terminal-assertion: undecodable payload")
+	}
+	var claims ssoClaims
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		return "", "", fmt.Errorf("terminal-assertion: unparseable claims")
+	}
+	if claims.Version != terminalAssertionVersion {
+		return "", "", fmt.Errorf("terminal-assertion: unexpected token version")
+	}
+	if claims.HiveID != expectedHiveID {
+		return "", "", fmt.Errorf("terminal-assertion: assertion is for a different hive")
+	}
+	if claims.Username == "" {
+		return "", "", fmt.Errorf("terminal-assertion: empty username")
+	}
+	nowUnix := now.Unix()
+	skew := int64(ssoClockSkew / time.Second)
+	if claims.IssuedAt > nowUnix+skew {
+		return "", "", fmt.Errorf("terminal-assertion: not yet valid")
+	}
+	if claims.Expiry < nowUnix-skew {
+		return "", "", fmt.Errorf("terminal-assertion: expired")
+	}
+	return claims.Username, claims.Role, nil
+}

--- a/v2/pkg/hub/terminal_assertion_test.go
+++ b/v2/pkg/hub/terminal_assertion_test.go
@@ -1,0 +1,187 @@
+package hub
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestTerminalAssertionRoundTrip(t *testing.T) {
+	secret := "shared-hub-secret-abc123"
+	now := time.Unix(1_700_000_000, 0)
+	tok := MintTerminalAssertion(secret, "alice", "owner", "hosted-hive-1", now)
+	if tok == "" {
+		t.Fatal("expected a token")
+	}
+	user, role, err := VerifyTerminalAssertion(secret, tok, "hosted-hive-1", now)
+	if err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+	if user != "alice" || role != "owner" {
+		t.Fatalf("got user=%q role=%q, want alice/owner", user, role)
+	}
+}
+
+func TestTerminalAssertionRejectsWrongHive(t *testing.T) {
+	secret := "s"
+	now := time.Unix(1_700_000_000, 0)
+	tok := MintTerminalAssertion(secret, "alice", "owner", "hive-A", now)
+	if _, _, err := VerifyTerminalAssertion(secret, tok, "hive-B", now); err == nil {
+		t.Fatal("expected rejection for an assertion minted for a different hive")
+	}
+}
+
+func TestTerminalAssertionRejectsWrongSecret(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	tok := MintTerminalAssertion("secret-1", "alice", "owner", "hive-1", now)
+	if _, _, err := VerifyTerminalAssertion("secret-2", tok, "hive-1", now); err == nil {
+		t.Fatal("expected rejection under a different secret")
+	}
+}
+
+func TestTerminalAssertionRejectsExpired(t *testing.T) {
+	secret := "s"
+	now := time.Unix(1_700_000_000, 0)
+	tok := MintTerminalAssertion(secret, "alice", "owner", "hive-1", now)
+	later := now.Add(terminalAssertionTTL + ssoClockSkew + time.Second)
+	if _, _, err := VerifyTerminalAssertion(secret, tok, "hive-1", later); err == nil {
+		t.Fatal("expected rejection for an expired assertion")
+	}
+}
+
+func TestTerminalAssertionRejectsNotYetValid(t *testing.T) {
+	secret := "s"
+	now := time.Unix(1_700_000_000, 0)
+	// Minted "in the future" relative to the verifier's earlier clock.
+	tok := MintTerminalAssertion(secret, "alice", "owner", "hive-1", now)
+	earlier := now.Add(-(ssoClockSkew + time.Minute))
+	if _, _, err := VerifyTerminalAssertion(secret, tok, "hive-1", earlier); err == nil {
+		t.Fatal("expected rejection for a not-yet-valid assertion")
+	}
+}
+
+func TestTerminalAssertionRejectsTamper(t *testing.T) {
+	secret := "s"
+	now := time.Unix(1_700_000_000, 0)
+	tok := MintTerminalAssertion(secret, "alice", "read-write", "hive-1", now)
+	b := []byte(tok)
+	if b[0] == 'A' {
+		b[0] = 'B'
+	} else {
+		b[0] = 'A'
+	}
+	if _, _, err := VerifyTerminalAssertion(secret, string(b), "hive-1", now); err == nil {
+		t.Fatal("expected rejection for a tampered assertion")
+	}
+}
+
+func TestTerminalAssertionEmptyInputs(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	if MintTerminalAssertion("", "alice", "owner", "hive-1", now) != "" {
+		t.Fatal("empty secret must not mint an assertion")
+	}
+	if MintTerminalAssertion("s", "", "owner", "hive-1", now) != "" {
+		t.Fatal("empty username must not mint an assertion")
+	}
+	if MintTerminalAssertion("s", "alice", "owner", "", now) != "" {
+		t.Fatal("empty hiveID must not mint an assertion")
+	}
+	if _, _, err := VerifyTerminalAssertion("", "x.y", "hive-1", now); err == nil {
+		t.Fatal("empty secret must not verify")
+	}
+	if _, _, err := VerifyTerminalAssertion("s", "malformed", "hive-1", now); err == nil {
+		t.Fatal("malformed assertion must not verify")
+	}
+}
+
+// A terminal assertion must NOT verify as an SSO handoff token: the two are
+// signed by different keys and carry different version strings, so cross-family
+// replay fails. (The reverse — an SSO token verifying as a terminal assertion —
+// cannot even be expressed once SSO is Ed25519, since MintSSOToken then takes a
+// seed, not the terminal's HMAC key; the version-string mismatch is the durable
+// guarantee, exercised by TestTerminalAssertionRejectsForeignVersion.)
+func TestTerminalAssertionNotConfusableWithSSO(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	// A terminal assertion, verified under the SSO path, must be rejected.
+	term := MintTerminalAssertion("terminal-key", "alice", "owner", "hive-1", now)
+	// The SSO verifier on this base takes a secret; even if the same string is
+	// tried, the version ("hive-terminal-v1") is not an SSO version, so it fails.
+	if _, _, err := VerifySSOToken("terminal-key", term, "hive-1", now); err == nil {
+		t.Fatal("a terminal assertion must NOT verify as an SSO handoff token")
+	}
+}
+
+// A token carrying any non-terminal version string is rejected even when signed
+// with the correct terminal key — the version namespace is a hard gate.
+func TestTerminalAssertionRejectsForeignVersion(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	key := "terminal-key"
+	// Hand-mint a well-signed token whose version is an SSO version.
+	forged := forgeTerminalToken(key, ssoClaims{
+		Version: "hive-sso-v2", Username: "alice", Role: "owner", HiveID: "hive-1",
+		IssuedAt: now.Unix(), Expiry: now.Add(terminalAssertionTTL).Unix(),
+	})
+	if _, _, err := VerifyTerminalAssertion(key, forged, "hive-1", now); err == nil {
+		t.Fatal("a correctly-signed token with a foreign version must be rejected")
+	}
+}
+
+// The terminal signing key is a DEDICATED symmetric sub-key, distinct from the
+// master and from the SSO material.
+func TestDeriveTerminalKeyIsDomainSeparated(t *testing.T) {
+	master := "master-secret"
+	got := deriveTerminalKeyFrom(master)
+	if got == "" {
+		t.Fatal("expected a derived key")
+	}
+	if got == master {
+		t.Fatal("derived key must not equal the master")
+	}
+	// Deterministic and equal to the documented formula: HMAC-SHA256(master, info) hex.
+	mac := hmac.New(sha256.New, []byte(master))
+	mac.Write([]byte(infoTerminalKey))
+	if want := hex.EncodeToString(mac.Sum(nil)); got != want {
+		t.Fatalf("derived key = %q, want %q", got, want)
+	}
+	if deriveTerminalKeyFrom("") != "" {
+		t.Fatal("empty master must derive to empty (fail closed)")
+	}
+}
+
+// TerminalSigningKey resolution order: HIVE_TERMINAL_KEY > HIVE_SESSION_KEY >
+// derive(HIVE_HUB_SECRET). Ensures the spoke picks the least-privilege key
+// available and still works pre-#2761 (master only) and post-#2761 (session key).
+func TestTerminalSigningKeyResolutionOrder(t *testing.T) {
+	t.Setenv(EnvTerminalKey, "")
+	t.Setenv(envSessionKey, "")
+	t.Setenv(envHubSecret, "")
+	if TerminalSigningKey() != "" {
+		t.Fatal("no key sources → empty (fail closed)")
+	}
+
+	t.Setenv(envHubSecret, "master")
+	if got, want := TerminalSigningKey(), deriveTerminalKeyFrom("master"); got != want {
+		t.Fatalf("hub-secret fallback: got %q want derived %q", got, want)
+	}
+
+	t.Setenv(envSessionKey, "session-subkey")
+	if TerminalSigningKey() != "session-subkey" {
+		t.Fatal("session key must win over hub-secret derivation")
+	}
+
+	t.Setenv(EnvTerminalKey, "dedicated-terminal-key")
+	if TerminalSigningKey() != "dedicated-terminal-key" {
+		t.Fatal("dedicated terminal key must win over all")
+	}
+}
+
+// forgeTerminalToken signs an arbitrary claims payload with the terminal key —
+// a test-only helper to construct otherwise-valid tokens with a bad version.
+func forgeTerminalToken(key string, claims ssoClaims) string {
+	payload, _ := json.Marshal(claims)
+	body := ssoB64.EncodeToString(payload)
+	return body + "." + terminalSign(key, body)
+}

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -111,6 +111,140 @@ function isAuthorizedForThisHive(username) {
   return HIVE_AUTHORIZED_USERS.has(username.toLowerCase());
 }
 
+// ── Signed terminal assertion (finding C3 follow-up) ──────────────────────────
+//
+// The static HIVE_AUTHORIZED_USERS allowlist above (from #2756) authorizes by a
+// per-hive username list injected at PROVISION time: coarse (no expiry, no role
+// granularity, a re-provision needed to change access). The PRIMARY gate is now
+// a short-lived HMAC-signed assertion the spoke mints at LOGIN time, binding
+// {user, hive_id, role, exp}. This block verifies it, mirroring the Go
+// hub.VerifyTerminalAssertion EXACTLY (keep the two in lockstep).
+//
+// DECOUPLED FROM SSO SIGNING (C2 #2761): the SSO handoff token is now ASYMMETRIC
+// (Ed25519 — only the hub mints, the spoke holds the public key). The terminal
+// assertion is a DIFFERENT trust shape: SYMMETRIC and SPOKE-LOCAL — the spoke
+// mints it (dashboard) and this proxy verifies it, both on the same spoke, with a
+// key the spoke holds. So it has its OWN dedicated HMAC key (TERMINAL_SIGNING_KEY
+// below), independent of the SSO key. This mirrors the Go hub.terminalSign /
+// hub.TerminalSigningKey EXACTLY (keep the two in lockstep).
+
+// TERMINAL_ASSERTION_VERSION must equal the Go terminalAssertionVersion. A token
+// carrying any other version (e.g. an SSO handoff token) is rejected, so the two
+// token families are never confusable.
+const TERMINAL_ASSERTION_VERSION = 'hive-terminal-v1';
+
+// INFO_TERMINAL_KEY is the domain-separation label for the terminal signing
+// sub-key. Must equal the Go infoTerminalKey and match the C2 deriveDomainKey
+// convention (HMAC-SHA256(master, info) as lowercase hex).
+const INFO_TERMINAL_KEY = 'hive-terminal-v1';
+
+// deriveTerminalKeyFrom mirrors the Go deriveTerminalKeyFrom: the hex
+// HMAC-SHA256(master, INFO_TERMINAL_KEY), or '' for an empty master.
+function deriveTerminalKeyFrom(master) {
+  if (!master) return '';
+  return crypto.createHmac('sha256', master).update(INFO_TERMINAL_KEY).digest('hex');
+}
+
+// TERMINAL_SIGNING_KEY resolves the symmetric key the proxy verifies terminal
+// assertions with, mirroring Go hub.TerminalSigningKey's order EXACTLY:
+//   1. HIVE_TERMINAL_KEY   — a dedicated derived sub-key, if provisioned.
+//   2. HIVE_SESSION_KEY    — the session sub-key a C2-provisioned spoke already
+//                            holds (normal post-#2761 hosted path; the spoke no
+//                            longer receives the master).
+//   3. derive from HIVE_HUB_SECRET — self-hosted / pre-#2761 hosted spokes that
+//                            still hold the master.
+// Empty when none is configured → no assertion ever verifies → the terminal gate
+// falls back to the #2756 static allowlist. Computed ONCE at startup like HUB_SECRET.
+const TERMINAL_SIGNING_KEY =
+  (process.env.HIVE_TERMINAL_KEY || '').trim() ||
+  (process.env.HIVE_SESSION_KEY || '').trim() ||
+  deriveTerminalKeyFrom((process.env.HIVE_HUB_SECRET || '').trim());
+
+// TERMINAL_ASSERTION_COOKIE is where the spoke deposits the assertion (see
+// dashboard setTerminalAssertionCookie). Path=/terminal-scoped, HttpOnly.
+const TERMINAL_ASSERTION_COOKIE = 'hive_terminal_assertion';
+
+// TERMINAL_CLOCK_SKEW_S tolerates minor hub/spoke clock drift on the exp / iat
+// bounds. Matches the Go ssoClockSkew (30s).
+const TERMINAL_CLOCK_SKEW_S = 30;
+
+// TERMINAL_ROLES are the roles sufficient to open a shell: owner and read-write.
+// A `read`-only grant authenticates and authorizes the DASHBOARD but is NOT
+// enough for a terminal — the finding asks role sufficiency (owner/operator) be
+// enforced, and a read-only user with shell access would be a privilege
+// escalation. Role strings mirror pkg/config (RoleOwner, RoleReadWrite) and the
+// hub saasRole* constants.
+const TERMINAL_ROLES = new Set(['owner', 'read-write']);
+
+// verifyTerminalAssertion mirrors Go hub.VerifyTerminalAssertion. It returns
+// { username, role } on success, or null on ANY failure (bad signature, wrong
+// version, wrong hive, expired/not-yet-valid, malformed) — fail closed, never
+// trusting payload bytes before the constant-time signature check passes.
+function verifyTerminalAssertion(key, token, expectedHiveID, nowSec) {
+  if (!key || !token || !expectedHiveID) return null;
+  const idx = token.indexOf('.');
+  if (idx <= 0 || idx === token.length - 1) return null;
+  const body = token.slice(0, idx);
+  const sig = token.slice(idx + 1);
+  // Constant-time signature check over the base64url body BEFORE decoding it.
+  const expected = crypto.createHmac('sha256', key).update(body).digest('base64url');
+  const sigBuf = Buffer.from(sig);
+  const expBuf = Buffer.from(expected);
+  if (sigBuf.length !== expBuf.length || !crypto.timingSafeEqual(sigBuf, expBuf)) {
+    return null;
+  }
+  let claims;
+  try {
+    claims = JSON.parse(Buffer.from(body, 'base64url').toString('utf8'));
+  } catch {
+    return null;
+  }
+  if (!claims || typeof claims !== 'object') return null;
+  if (claims.v !== TERMINAL_ASSERTION_VERSION) return null;
+  if (claims.h !== expectedHiveID) return null;
+  if (!claims.u) return null;
+  const iat = Number(claims.iat);
+  const exp = Number(claims.exp);
+  if (!Number.isFinite(iat) || !Number.isFinite(exp)) return null;
+  if (iat > nowSec + TERMINAL_CLOCK_SKEW_S) return null; // not yet valid
+  if (exp < nowSec - TERMINAL_CLOCK_SKEW_S) return null; // expired
+  return { username: String(claims.u), role: String(claims.r || '') };
+}
+
+// authorizeTerminal is the single per-hive terminal decision, combining the new
+// PRIMARY signed-assertion gate with the #2756 static-allowlist FALLBACK.
+//
+//   PRIMARY  — a valid, unexpired, this-hive assertion whose role is sufficient
+//              (owner / read-write) → ALLOW. This is the principled gate: fresh,
+//              expiring, role-checked, minted per-user-per-hive at login.
+//   FALLBACK — no usable assertion (absent / expired / wrong hive / insufficient
+//              role) → defer to isAuthorizedForThisHive(cookieUser): the static
+//              per-hive allowlist plus the OpenShift fail-CLOSED behavior from
+//              #2756. This is defense-in-depth and MUST NOT regress: a hive with
+//              no assertion cookie (older client, direct navigation) still gets
+//              exactly the #2756 decision, and an empty allowlist on an
+//              OpenShift-Route hive still fails closed.
+//
+// cookieUser is the hub-wide-authenticated user from the verified hive_hub_user
+// cookie (already checked by the caller); assertionCookie is the raw
+// hive_terminal_assertion value (may be undefined).
+function authorizeTerminal(cookieUser, assertionCookie) {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const claim = verifyTerminalAssertion(TERMINAL_SIGNING_KEY, assertionCookie, HIVE_ID, nowSec);
+  if (claim && TERMINAL_ROLES.has((claim.role || '').toLowerCase())) {
+    // A valid this-hive assertion with a sufficient role is the primary grant.
+    // Bind it to the SAME user the hub-wide cookie authenticated: an attacker
+    // must present BOTH a validly-signed hub cookie for user X AND a validly-
+    // signed terminal assertion for user X on THIS hive.
+    if (claim.username && cookieUser &&
+        claim.username.toLowerCase() === cookieUser.toLowerCase()) {
+      return true;
+    }
+  }
+  // No usable assertion → fall back to the #2756 static allowlist + fail-closed.
+  return isAuthorizedForThisHive(cookieUser);
+}
+
 const HOSTED_SUFFIX = '.hive.kubestellar.io';
 
 // isHostedHost decides whether the terminal auth gate applies to a request.
@@ -309,12 +443,14 @@ app.use('/terminal', (req, res, next) => {
       res.status(401).send('Terminal access requires authentication');
       return;
     }
-    // SECURITY (CWE-862, finding C3): authentication is hub-WIDE — the signed
-    // cookie only proves this is some real hub user, because it is scoped to
-    // .hive.kubestellar.io and every hive's domain receives it. AUTHORIZATION is
-    // per-hive: the user must be on THIS hive's allowlist. A cookie authorized on
-    // hive A must not open a shell on hive B.
-    if (!isAuthorizedForThisHive(user)) {
+    // SECURITY (CWE-862, finding C3 + follow-up): authentication is hub-WIDE —
+    // the signed hive_hub_user cookie only proves this is some real hub user,
+    // because it is scoped to .hive.kubestellar.io and every hive's domain
+    // receives it. AUTHORIZATION is per-hive. PRIMARY gate: a short-lived signed
+    // {user,hive,role,exp} assertion for THIS hive with a sufficient role.
+    // FALLBACK: the #2756 static allowlist + OpenShift fail-closed. A cookie
+    // authorized on hive A must not open a shell on hive B.
+    if (!authorizeTerminal(user, cookies[TERMINAL_ASSERTION_COOKIE])) {
       console.warn(`[terminal] 403: hub user ${JSON.stringify(user)} not authorized for hive ${JSON.stringify(HIVE_ID)}`);
       if (req.headers.upgrade === 'websocket') {
         req.socket.destroy();
@@ -405,10 +541,12 @@ server.on('upgrade', (req, socket, head) => {
         socket.destroy();
         return;
       }
-      // SECURITY (CWE-862, finding C3): per-hive authorization on the WS upgrade,
-      // mirroring the HTTP gate. A hub-authenticated user not on THIS hive's
-      // allowlist gets the socket closed, not a shell.
-      if (!isAuthorizedForThisHive(wsUser)) {
+      // SECURITY (CWE-862, finding C3 + follow-up): per-hive authorization on the
+      // WS upgrade, mirroring the HTTP gate. PRIMARY: signed {user,hive,role,exp}
+      // assertion for THIS hive; FALLBACK: #2756 static allowlist + fail-closed.
+      // A hub-authenticated user without a usable grant for THIS hive gets the
+      // socket closed, not a shell.
+      if (!authorizeTerminal(wsUser, cookies[TERMINAL_ASSERTION_COOKIE])) {
         console.warn(`[terminal-ws] 403: hub user ${JSON.stringify(wsUser)} not authorized for hive ${JSON.stringify(HIVE_ID)}`);
         socket.destroy();
         return;

--- a/v2/proxy/server.test.js
+++ b/v2/proxy/server.test.js
@@ -229,6 +229,28 @@ function mintCookie(secret, username) {
   return `${username}.${sig}`;
 }
 
+// mintTerminalAssertion mirrors Go hub.MintTerminalAssertion / the proxy's
+// verifyTerminalAssertion: `<base64url(json{v,u,r,h,iat,exp})>.<base64url(HMAC)>`.
+// It signs with the DERIVED terminal sub-key (deriveTerminalKey), not the raw
+// master — matching the proxy's TERMINAL_SIGNING_KEY resolution for a spoke
+// provisioned with only HIVE_HUB_SECRET (its default in these tests). ttlSec and
+// version are overridable so tests can forge expired / wrong-version / wrong-hive
+// assertions. Default: this hive, 15-min TTL, current version.
+const TERMINAL_ASSERTION_VERSION = 'hive-terminal-v1';
+const INFO_TERMINAL_KEY = 'hive-terminal-v1';
+// deriveTerminalKey mirrors the Go deriveTerminalKeyFrom / proxy deriveTerminalKeyFrom.
+function deriveTerminalKey(master) {
+  return crypto.createHmac('sha256', master).update(INFO_TERMINAL_KEY).digest('hex');
+}
+function mintTerminalAssertion(secret, { username, role, hiveID, ttlSec = 900, version = TERMINAL_ASSERTION_VERSION, iatOffsetSec = 0 } = {}) {
+  const key = deriveTerminalKey(secret);
+  const now = Math.floor(Date.now() / 1000) + iatOffsetSec;
+  const claims = { v: version, u: username, r: role, h: hiveID, iat: now, exp: now + ttlSec };
+  const body = Buffer.from(JSON.stringify(claims)).toString('base64url');
+  const sig = crypto.createHmac('sha256', key).update(body).digest('base64url');
+  return `${body}.${sig}`;
+}
+
 function startHiveBProxy() {
   return new Promise((resolve, reject) => {
     const proc = spawn('node', ['server.js'], {
@@ -282,10 +304,13 @@ async function teardownHiveB() {
 // header to match the URL authority, which would defeat the whole point — the
 // gate keys off the Host header to decide `isHosted`, and we must be able to
 // present an arbitrary hosted / port-suffixed / trailing-dot Host.
-function terminalHTTP(cookieVal, hostHeader) {
+function terminalHTTP(cookieVal, hostHeader, assertionVal) {
   return new Promise((resolve, reject) => {
     const headers = { Host: hostHeader };
-    if (cookieVal) headers.Cookie = `hive_hub_user=${cookieVal}`;
+    const cookieParts = [];
+    if (cookieVal) cookieParts.push(`hive_hub_user=${cookieVal}`);
+    if (assertionVal) cookieParts.push(`hive_terminal_assertion=${assertionVal}`);
+    if (cookieParts.length) headers.Cookie = cookieParts.join('; ');
     const req = httpRequest({
       host: '127.0.0.1', port: HIVE_B_PROXY_PORT, path: '/terminal/',
       method: 'GET', headers,
@@ -301,10 +326,13 @@ function terminalHTTP(cookieVal, hostHeader) {
 
 // WS terminal upgrade. Resolves {opened:true} if the socket opens (allowed) or
 // {opened:false} if it is closed/errored before/at open (denied).
-function terminalWS(cookieVal, hostHeader) {
+function terminalWS(cookieVal, hostHeader, assertionVal) {
   return new Promise((resolve) => {
     const headers = { Host: hostHeader };
-    if (cookieVal) headers.Cookie = `hive_hub_user=${cookieVal}`;
+    const cookieParts = [];
+    if (cookieVal) cookieParts.push(`hive_hub_user=${cookieVal}`);
+    if (assertionVal) cookieParts.push(`hive_terminal_assertion=${assertionVal}`);
+    if (cookieParts.length) headers.Cookie = cookieParts.join('; ');
     const ws = new WebSocket(`ws://127.0.0.1:${HIVE_B_PROXY_PORT}/terminal/`, { headers });
     const done = (opened) => { try { ws.close(); } catch { /* ignore */ } resolve({ opened }); };
     const t = setTimeout(() => done(false), 4000);
@@ -376,6 +404,110 @@ async function testC3_ForgedSigStillRejected() {
   const resp = await terminalHTTP(cookie, HOSTED_HOST);
   assert.equal(resp.status, 401, `forged-signature cookie must be 401, got ${resp.status}`);
   console.log('  ✓ forged-signature cookie (even for allowlisted name) → 401');
+}
+
+// ---------------------------------------------------------------------------
+// Finding C3 FOLLOW-UP — short-lived signed {user,hive,role,exp} assertion.
+//
+// Reuses hive B (secret HIVE_B_SECRET, id HIVE_B_ID, static allowlist
+// alice:owner,carol:read). `dave` is deliberately NOT on the static allowlist,
+// so any decision that lets dave in must be coming from the SIGNED ASSERTION —
+// the new PRIMARY gate — and any decision that keeps dave out proves the
+// FALLBACK to the #2756 static allowlist still holds when the assertion is
+// unusable. The hub cookie carries authentication; the assertion carries
+// per-hive authorization.
+// ---------------------------------------------------------------------------
+
+// PRIMARY: a valid, this-hive, sufficient-role assertion admits a user who is
+// NOT on the static allowlist — the whole point of the upgrade.
+async function testC3F_ValidAssertionAdmitsNonAllowlistedUser() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'dave');
+  const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'dave', role: 'owner', hiveID: HIVE_B_ID });
+  const resp = await terminalHTTP(cookie, HOSTED_HOST, assertion);
+  assert.equal(resp.status, 200, `dave with a valid owner assertion should reach terminal, got ${resp.status}`);
+  const { opened } = await terminalWS(cookie, HOSTED_HOST, assertion);
+  assert.ok(opened, 'dave with a valid owner assertion WS should open');
+  console.log('  ✓ valid {user,hive,owner,exp} assertion → terminal opens (primary gate, beyond static list)');
+}
+
+// read-write is a sufficient terminal role too.
+async function testC3F_ReadWriteRoleSufficient() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'dave');
+  const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'dave', role: 'read-write', hiveID: HIVE_B_ID });
+  const resp = await terminalHTTP(cookie, HOSTED_HOST, assertion);
+  assert.equal(resp.status, 200, `dave with a read-write assertion should reach terminal, got ${resp.status}`);
+  console.log('  ✓ read-write role assertion → terminal opens');
+}
+
+// EXPIRED assertion → not usable → falls back to static allowlist → dave denied.
+async function testC3F_ExpiredAssertionDenied() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'dave');
+  // iatOffset -1000s, ttl 600s → issued & expired well before now (beyond skew).
+  const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'dave', role: 'owner', hiveID: HIVE_B_ID, ttlSec: 600, iatOffsetSec: -1000 });
+  const resp = await terminalHTTP(cookie, HOSTED_HOST, assertion);
+  assert.equal(resp.status, 403, `dave with an EXPIRED assertion must fall back and be 403, got ${resp.status}`);
+  const { opened } = await terminalWS(cookie, HOSTED_HOST, assertion);
+  assert.ok(!opened, 'dave with an EXPIRED assertion WS must be closed');
+  console.log('  ✓ expired assertion → denied (fallback: dave not on static list)');
+}
+
+// WRONG-HIVE assertion (minted for another hive id) → not usable → denied.
+async function testC3F_WrongHiveAssertionDenied() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'dave');
+  const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'dave', role: 'owner', hiveID: 'some-other-hive' });
+  const resp = await terminalHTTP(cookie, HOSTED_HOST, assertion);
+  assert.equal(resp.status, 403, `dave with a WRONG-HIVE assertion must be 403, got ${resp.status}`);
+  const { opened } = await terminalWS(cookie, HOSTED_HOST, assertion);
+  assert.ok(!opened, 'dave with a WRONG-HIVE assertion WS must be closed');
+  console.log('  ✓ wrong-hive assertion → denied (hive_id binding enforced)');
+}
+
+// INSUFFICIENT ROLE (read) assertion → not a sufficient terminal grant → falls
+// back to static allowlist → dave denied.
+async function testC3F_InsufficientRoleDenied() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'dave');
+  const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'dave', role: 'read', hiveID: HIVE_B_ID });
+  const resp = await terminalHTTP(cookie, HOSTED_HOST, assertion);
+  assert.equal(resp.status, 403, `dave with a read-only assertion must be 403, got ${resp.status}`);
+  console.log('  ✓ read-only role assertion → denied (owner/read-write required for a shell)');
+}
+
+// FORGED assertion (wrong signing secret) → signature fails → not usable → denied.
+async function testC3F_ForgedAssertionDenied() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'dave');
+  const assertion = mintTerminalAssertion('wrong-secret', { username: 'dave', role: 'owner', hiveID: HIVE_B_ID });
+  const resp = await terminalHTTP(cookie, HOSTED_HOST, assertion);
+  assert.equal(resp.status, 403, `dave with a FORGED-signature assertion must be 403, got ${resp.status}`);
+  console.log('  ✓ forged-signature assertion → denied');
+}
+
+// WRONG-VERSION token (e.g. an SSO handoff "hive-sso-v1") is NOT a terminal grant.
+async function testC3F_WrongVersionDenied() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'dave');
+  const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'dave', role: 'owner', hiveID: HIVE_B_ID, version: 'hive-sso-v1' });
+  const resp = await terminalHTTP(cookie, HOSTED_HOST, assertion);
+  assert.equal(resp.status, 403, `dave with a wrong-version token must be 403, got ${resp.status}`);
+  console.log('  ✓ wrong-version token (SSO handoff shape) → denied (token families not confusable)');
+}
+
+// USER MISMATCH: a valid assertion for alice presented alongside bob's hub
+// cookie must NOT admit bob — the assertion user must equal the authenticated
+// cookie user. (bob is also not on the static allowlist, so it falls through.)
+async function testC3F_UserMismatchDenied() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'bob');
+  const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'alice', role: 'owner', hiveID: HIVE_B_ID });
+  const resp = await terminalHTTP(cookie, HOSTED_HOST, assertion);
+  assert.equal(resp.status, 403, `bob presenting alice's assertion must be 403, got ${resp.status}`);
+  console.log('  ✓ assertion-user ≠ cookie-user → denied (binding to authenticated user)');
+}
+
+// FALLBACK PRESERVED: an allowlisted user with NO assertion cookie still reaches
+// the terminal via the #2756 static allowlist — the upgrade is additive.
+async function testC3F_StaticAllowlistFallbackPreserved() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'alice');
+  const resp = await terminalHTTP(cookie, HOSTED_HOST /* no assertion */);
+  assert.equal(resp.status, 200, `alice (static allowlist) with no assertion must still reach terminal, got ${resp.status}`);
+  console.log('  ✓ no assertion + static allowlist → terminal opens (fallback preserved)');
 }
 
 // ---------------------------------------------------------------------------
@@ -538,6 +670,17 @@ try {
   await testC3_AuthorizedUserWS();
   await testC3_ForeignUserWS();
   await testC3_ForeignUserWS_PortSuffixHost();
+
+  console.log('\nSigned terminal assertion (C3 follow-up):');
+  await testC3F_ValidAssertionAdmitsNonAllowlistedUser();
+  await testC3F_ReadWriteRoleSufficient();
+  await testC3F_ExpiredAssertionDenied();
+  await testC3F_WrongHiveAssertionDenied();
+  await testC3F_InsufficientRoleDenied();
+  await testC3F_ForgedAssertionDenied();
+  await testC3F_WrongVersionDenied();
+  await testC3F_UserMismatchDenied();
+  await testC3F_StaticAllowlistFallbackPreserved();
 
   console.log('\n✓ C3 tests passed\n');
 } catch (e) {


### PR DESCRIPTION
## Security finding C3 follow-up — short-lived signed terminal assertion

> **MERGE ORDER: after BOTH #2756 and #2761.**
> - **DEPENDS ON #2756** (`fix/sec-c3-terminal-per-hive-authz`) — this branch is cut from #2756, so its diff currently includes #2756's changes. When #2756 lands on `v4`, rebase this so the diff is only the ~600-line terminal-assertion delta.
> - **COORDINATES WITH #2761** (`fix/sec-c2-followup-asymmetric-sso`, the C2 asymmetric-SSO PR) — see "C2 coordination" below. This PR is written to survive #2761's Ed25519 cutover; I verified compile + a rebase note in a scratch merge.

### What #2756 shipped, and the gap it deferred
#2756 closed the terminal authz hole (CWE-862) with a static `HIVE_AUTHORIZED_USERS` allowlist injected at provision time, fail-**closed** on OpenShift via `HIVE_INGRESS_AUTHZ`. It deferred the fuller model: a short-lived `{user, hive, role, expiry}` assertion. The static allowlist is coarse — no expiry, no role granularity, a re-provision to change access.

### What this PR does — the assertion becomes the PRIMARY gate
- **`pkg/hub/terminal_assertion.go` (new)** — `MintTerminalAssertion` / `VerifyTerminalAssertion` binding `{user, hive_id, role, exp}`, 15-min TTL, distinct version string (`hive-terminal-v1`) so it is never confusable with an SSO token.
- **`pkg/dashboard`** — the spoke mints the assertion into a `Path=/terminal`-scoped, `HttpOnly`, `Secure`, **non-`Domain`-widened** `hive_terminal_assertion` cookie right after it establishes a per-user session (device-flow login **and** hub SSO handoff), where `{user, hive_id, role}` are already authoritatively resolved against this hive's allowlist.
- **`v2/proxy/server.js`** — `authorizeTerminal()` verifies the assertion as the **PRIMARY** per-hive gate: signature valid, `hive_id == HIVE_ID`, `exp` unexpired, **role sufficient** (owner / read-write — read-only is not enough for a shell), and **assertion-user == authenticated `hive_hub_user`**. Any request without a usable assertion falls back to the **#2756 static allowlist + `HIVE_INGRESS_AUTHZ` OpenShift fail-closed** logic, unchanged.

### C2 coordination — decoupled from SSO signing (the requested change)
#2761 makes SSO signing **asymmetric** (Ed25519) and **removes `ssoSign`**. An earlier revision of this PR reused `ssoSign`; that would not compile after #2761. Fixed by **decoupling the terminal assertion from SSO signing entirely**:

- The terminal assertion is a **different trust shape** from SSO: it is **symmetric and spoke-local** — the spoke both *mints* it (after establishing the session) and the proxy *verifies* it, both on the same spoke, with a key the spoke holds. That is a legitimate symmetric use (unlike SSO, where only the hub may mint, hence Ed25519).
- It therefore has its **own dedicated HMAC signer** (`terminalSign` = HMAC-SHA256, the old `ssoSign` construction) and its **own derived sub-key** — `deriveTerminalKeyFrom(master)` = `HMAC-SHA256(master, "hive-terminal-v1")` hex, matching #2758/#2761's `deriveDomainKey` convention under a distinct label, so it folds onto `deriveDomainKey(master, infoTerminalKey)` in a later cleanup without colliding.
- **Key resolution** (`hub.TerminalSigningKey` in Go and the proxy's `TERMINAL_SIGNING_KEY` mirror each other exactly): `HIVE_TERMINAL_KEY` → **`HIVE_SESSION_KEY`** (the sub-key a C2-provisioned spoke already holds — the normal post-#2761 path, since the spoke no longer receives the master) → `deriveTerminalKeyFrom(HIVE_HUB_SECRET)` (self-hosted / pre-#2761).
- The terminal code reuses only the pure **data-shape** helpers from `sso.go` (`ssoClaims`, `ssoB64`, `ssoClockSkew`) — no SSO signing symbol. **After this change #2762 references no SSO signing symbol and survives #2761's cutover.**

I verified this by a **scratch merge of #2761 into this branch**: the merged tree compiles (Go + `node --check`) and the Go terminal tests pass. The scratch merge also surfaced **one rebase-time reconciliation** for whoever integrates:
- #2761 changes the `hive_hub_user` cookie verification key from the raw master to `SESSION_KEY` (in `server.js`, both terminal gates). On rebase, take #2761's `SESSION_KEY` there (trivial), and update the **#2756 proxy test harness's `mintCookie`** to sign with the derived session key (the #2756 tests mint the `hive_hub_user` cookie with the raw secret; post-#2761 that cookie must be signed with `deriveSessionKey`). My own `mintTerminalAssertion` test helper already derives the terminal key, so the assertion tests are unaffected — only the shared `mintCookie` helper needs the session-key derivation, which is #2761's contract.

### Tests
- **Go (`pkg/hub/terminal_assertion_test.go`, runnable):** round-trip; wrong-hive; wrong-secret; expired; not-yet-valid; tamper; empty-input; **foreign-version rejected** (a correctly-signed token with an SSO version fails); **key domain-separation** (`deriveTerminalKeyFrom` ≠ master, matches the documented HMAC formula, empty→empty); **`TerminalSigningKey` resolution order** (`HIVE_TERMINAL_KEY` > `HIVE_SESSION_KEY` > derive-from-master). `go test ./pkg/hub/ -run 'TerminalAssertion|TerminalSigningKey|DeriveTerminal'` → ok.
- **Proxy (`v2/proxy/server.test.js`, runnable, spawns the real proxy):** a valid `{user,hive,owner,exp}` assertion opens the terminal for a user **not** on the static allowlist (proves the assertion is primary); read-write opens; expired / wrong-hive / insufficient-role / forged / wrong-version / assertion-user≠cookie-user all denied; static-allowlist fallback still opens for an allowlisted user with no assertion; and the **#2756 OpenShift empty-allowlist fail-closed lane still holds**. `node v2/proxy/server.test.js` → exit 0.

### Not in scope / deferred
- Provisioning-time injection of a dedicated `HIVE_TERMINAL_KEY` (today the proxy/spoke derive it or reuse `HIVE_SESSION_KEY`); the resolution order already supports it when a future provisioning path adds it.

Do not merge without review, and not before #2756 and #2761.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
