### PR TITLE
fix: install banner keys off auth state (not raw base_url) + Forge App tab always offers install link

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1795,7 +1795,8 @@ func (g GitHubConfig) AppAuthoredPRsEnabled() bool {
 // For GHE: {base_url}/github-apps/{slug}/installations/new
 // For github.com: https://github.com/apps/{slug}/installations/new
 //
-// It returns "" for a GitHub Enterprise host whose App slug is not configured.
+// It returns "" for a GitHub Enterprise host whose App slug is neither
+// configured nor derivable from the forge-identity table.
 //
 // # WHY EMPTY RATHER THAN A BEST-EFFORT URL
 //
@@ -1807,16 +1808,28 @@ func (g GitHubConfig) AppAuthoredPRsEnabled() bool {
 // reads as "this product is broken", and it sent a real user to
 // github.ibm.com/github-apps/kubestellar-hive/installations/new.
 //
-// The empty string is the honest answer — "this host's App slug was never
-// recorded" — and callers render it as a legible message naming the missing
-// config instead of a button that 404s. Public github.com keeps the default,
-// where it is correct by construction.
+// A KNOWN forge is different: forgeIdentities records the slug of the App
+// actually registered on that host, so deriving from the table can never build
+// the public-slug 404 above. This matters after a "Reset Forge App": the raw
+// app_slug/base_url go blank while the resolved identity (what the Forge App
+// tab displays) still names github.ibm.com — and returning "" here suppressed
+// the install banner on exactly the hive that needed it (vllmd-13).
+//
+// For a GHE host OUTSIDE the table the empty string remains the honest answer
+// — "this host's App slug was never recorded" — and callers render it as a
+// legible message naming the missing config instead of a button that 404s.
+// Public github.com keeps the default, where it is correct by construction.
 func (g GitHubConfig) AppInstallURL() string {
 	base := strings.TrimRight(g.ResolvedBaseURL(), "/")
 	if g.IsGHE() {
-		// No default is admissible here: only an explicitly configured slug can
-		// name an App on this enterprise host.
+		// An explicit slug wins; otherwise only the forge-identity table may
+		// supply one — never DefaultGitHubAppSlug, which names no App here.
 		slug := strings.TrimSpace(g.AppSlug)
+		if slug == "" {
+			if id, ok := forgeIdentities[g.Forge()]; ok {
+				slug = id.AppSlug
+			}
+		}
 		if slug == "" {
 			return ""
 		}

--- a/v2/pkg/config/config_uncovered_coverage_test.go
+++ b/v2/pkg/config/config_uncovered_coverage_test.go
@@ -294,6 +294,20 @@ func TestGitHubConfig_AppInstallURL_BlankBaseGHEApi(t *testing.T) {
 	}
 }
 
+// TestGitHubConfig_AppInstallURL_PostResetDerivesFromForge is the vllmd-13
+// shape after an operator "Reset Forge App": raw base_url AND app_slug both
+// blank, with only the GHE api_url naming the forge. The RESOLVED identity
+// (base https://github.ibm.com, slug kubestellar-hive-ghe — exactly what the
+// Forge App tab displays) must still build the install link; returning ""
+// here is what suppressed the install banner while auth was not-installed.
+func TestGitHubConfig_AppInstallURL_PostResetDerivesFromForge(t *testing.T) {
+	g := GitHubConfig{APIURL: "https://github.ibm.com/api/v3"}
+	want := "https://github.ibm.com/github-apps/" + EnterpriseGitHubAppSlug + "/installations/new"
+	if got := g.AppInstallURL(); got != want {
+		t.Errorf("AppInstallURL() = %q, want %q", got, want)
+	}
+}
+
 func TestGitHubConfig_ResolvedAppSlug(t *testing.T) {
 	g := GitHubConfig{}
 	if got := g.ResolvedAppSlug(); got != DefaultGitHubAppSlug {
@@ -350,12 +364,22 @@ func TestGitHubConfig_AppInstallURL_Table(t *testing.T) {
 			want:    "https://github.com/apps/acme-hive/installations/new",
 		},
 		{
-			// The public default names an App that exists ONLY on github.com. On a
-			// GHE host it produced github.ibm.com/github-apps/kubestellar-hive/...,
+			// A KNOWN forge derives its slug from the forge-identity table, so
+			// a blank raw app_slug (the post-"Reset Forge App" shape) still
+			// builds the real install link instead of suppressing the banner.
+			// The table records the App actually registered on github.ibm.com,
+			// so this can never be the public-slug 404.
+			name:    "known GHE forge with no configured slug derives the slug from the forge table",
+			baseURL: "https://github.ibm.com",
+			want:    "https://github.ibm.com/github-apps/" + EnterpriseGitHubAppSlug + "/installations/new",
+		},
+		{
+			// The public default names an App that exists ONLY on github.com. On
+			// an UNKNOWN GHE host it produced <host>/github-apps/kubestellar-hive/...,
 			// a live 404 a real user hit. Empty is the honest answer and callers
 			// render it as "install link unavailable" plus the missing config.
-			name:    "GHE host with no configured slug yields no link, not a 404",
-			baseURL: "https://github.ibm.com",
+			name:    "unknown GHE host with no configured slug yields no link, not a 404",
+			baseURL: "https://github.mycorp.com",
 			want:    "",
 		},
 		{
@@ -371,8 +395,14 @@ func TestGitHubConfig_AppInstallURL_Table(t *testing.T) {
 			want:    "https://github.cisco.com/github-apps/acme-ghe/installations/new",
 		},
 		{
-			name:    "GHE slug that is only whitespace is treated as unset",
+			name:    "GHE slug that is only whitespace is treated as unset (falls back to the forge table)",
 			baseURL: "https://github.ibm.com",
+			appSlug: "   ",
+			want:    "https://github.ibm.com/github-apps/" + EnterpriseGitHubAppSlug + "/installations/new",
+		},
+		{
+			name:    "unknown GHE host with a whitespace slug still yields no link",
+			baseURL: "https://github.mycorp.com",
 			appSlug: "   ",
 			want:    "",
 		},

--- a/v2/pkg/dashboard/forge_apps.go
+++ b/v2/pkg/dashboard/forge_apps.go
@@ -55,8 +55,15 @@ type forgeActiveApp struct {
 	// no classification has run). This is a debugging surface — do not
 	// prettify it here.
 	AuthState string `json:"auth_state"`
-	Forge     string `json:"forge"`
-	Editable  bool   `json:"editable"`
+	// InstallURL is the server-built App install link
+	// (config.AppInstallURL(): <resolved base>/github-apps/<slug>/installations/new
+	// on GHE, /apps/<slug>/installations/new on github.com — "" only when a
+	// GHE host outside the forge table has no configured slug). The tab must
+	// use THIS rather than composing its own URL, so the banner and the tab
+	// can never drift onto two URL schemes.
+	InstallURL string `json:"install_url"`
+	Forge      string `json:"forge"`
+	Editable   bool   `json:"editable"`
 }
 
 type forgeAppsResponse struct {
@@ -132,6 +139,7 @@ func (s *Server) handleConfigGitHubForgeApps(w http.ResponseWriter, r *http.Requ
 			KeyFile:        keyFile,
 			KeyFingerprint: fingerprint,
 			AuthState:      s.GetGitHubAppState(),
+			InstallURL:     g.AppInstallURL(),
 			Forge:          appForge,
 			Editable:       forgeAppEditable(appForge, reposForge),
 		},

--- a/v2/pkg/dashboard/forge_apps_test.go
+++ b/v2/pkg/dashboard/forge_apps_test.go
@@ -223,3 +223,32 @@ func TestForgeApps_NoProvider(t *testing.T) {
 		t.Errorf("held_keys = %v, want empty without a provider", held)
 	}
 }
+
+// TestForgeApps_InstallURLIsServerBuilt locks the tab's install affordance to
+// the server-side builder (config.AppInstallURL — the same one the install
+// banner uses). The post-reset shape matters most: raw base_url/app_slug
+// blank, forge known only via api_url, installation_id 0 — the exact vllmd-13
+// state in which the tab used to be a dead end.
+func TestForgeApps_InstallURLIsServerBuilt(t *testing.T) {
+	srv := newFullServer(t)
+	srv.deps.Config.GitHub = config.GitHubConfig{
+		AppID:          config.EnterpriseGitHubAppID,
+		InstallationID: 0,
+		APIURL:         "https://github.ibm.com/api/v3",
+	}
+	rec, body := getForgeApps(t, srv)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	active, ok := body["active"].(map[string]any)
+	if !ok {
+		t.Fatalf("no active object in response: %v", body)
+	}
+	want := "https://github.ibm.com/github-apps/" + config.EnterpriseGitHubAppSlug + "/installations/new"
+	if got, _ := active["install_url"].(string); got != want {
+		t.Errorf("active.install_url = %q, want %q (resolved forge, despite blank raw base_url/app_slug)", got, want)
+	}
+	if got, _ := active["installation_id"].(float64); got != 0 {
+		t.Errorf("active.installation_id = %v, want 0 (the trigger for the tab's install link)", got)
+	}
+}

--- a/v2/pkg/dashboard/gh_app_install_missing_test.go
+++ b/v2/pkg/dashboard/gh_app_install_missing_test.go
@@ -1,0 +1,244 @@
+package dashboard
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// These tests lock the fix for the vllmd-13 dead-end: after an operator
+// "Reset Forge App", the raw github.base_url/app_slug go blank while the
+// RESOLVED forge (what the Forge App tab displays) is still github.ibm.com.
+// The install banner's visibility was gated on a non-empty
+// githubAppInstallURL — empty exactly then, because AppInstallURL() refused
+// to derive a GHE slug — so the banner stayed hidden while the auth state was
+// literally "not-installed" and the Forge App tab offered no install action.
+//
+// PRIMARY RULE (checked first, sufficient by itself): a real App (app_id set,
+// not the placeholder) with installation_id 0 lights the banner and the Forge
+// App tab's install link immediately — no auth-state classification, recheck
+// round-trip, or raw-URL sniffing may gate it.
+
+// gheAppPostResetConfig is the exact on-disk shape vllmd-13 held after the
+// reset: a real GHE app_id, installation_id 0, and ONLY api_url naming the
+// forge (base_url and app_slug blank).
+func gheAppPostResetConfig() config.GitHubConfig {
+	return config.GitHubConfig{
+		AppID:          config.EnterpriseGitHubAppID,
+		InstallationID: 0,
+		APIURL:         "https://github.ibm.com/api/v3",
+		BaseURL:        "",
+		AppSlug:        "",
+	}
+}
+
+// TestUpdateStatus_InstallMissingFromConfigTruth: blank installation_id alone
+// must mark the payload, force the requirement on, classify not-installed,
+// and carry the RESOLVED forge's install URL + base URL — with no probe
+// having run at all.
+func TestUpdateStatus_InstallMissingFromConfigTruth(t *testing.T) {
+	s := newFullServer(t)
+	s.deps.Config.GitHub = gheAppPostResetConfig()
+
+	status := &StatusPayload{}
+	s.UpdateStatus(status)
+
+	if !status.GitHubAppInstallMissing {
+		t.Error("GitHubAppInstallMissing = false; a real app_id with installation_id 0 must set it — this is the primary trigger and needs no auth probe")
+	}
+	if !status.GitHubAppRequired {
+		t.Error("GitHubAppRequired = false; config truth (installation_id 0) must force the banner requirement on")
+	}
+	if status.GitHubAppState != "not-installed" {
+		t.Errorf("GitHubAppState = %q, want not-installed filled from config truth", status.GitHubAppState)
+	}
+	wantURL := "https://github.ibm.com/github-apps/" + config.EnterpriseGitHubAppSlug + "/installations/new"
+	if status.GitHubAppInstallURL != wantURL {
+		t.Errorf("GitHubAppInstallURL = %q, want %q (RESOLVED forge, not the blank raw fields)", status.GitHubAppInstallURL, wantURL)
+	}
+	if status.GitHubBaseURL != "https://github.ibm.com" {
+		t.Errorf("GitHubBaseURL = %q, want the resolved https://github.ibm.com", status.GitHubBaseURL)
+	}
+}
+
+// TestUpdateStatus_InstallMissingPreservesOperatorState: the config-truth
+// override may only FILL an empty classification. An operator-side state
+// (key-missing/key-invalid) must survive, or the banner would send a user to
+// an install page for a failure only the hub operator can fix.
+func TestUpdateStatus_InstallMissingPreservesOperatorState(t *testing.T) {
+	s := newFullServer(t)
+	s.deps.Config.GitHub = gheAppPostResetConfig()
+	s.SetGitHubAppRequired(true)
+	s.SetGitHubAppState("key-missing")
+
+	status := &StatusPayload{}
+	s.UpdateStatus(status)
+
+	if status.GitHubAppState != "key-missing" {
+		t.Errorf("GitHubAppState = %q, want the operator-side key-missing preserved", status.GitHubAppState)
+	}
+	if !status.GitHubAppInstallMissing {
+		t.Error("GitHubAppInstallMissing must still report config truth alongside an operator-side state")
+	}
+}
+
+// TestUpdateStatus_NoInstallMissingWhenInstalled: an installation present and
+// no probe failure → nothing lights up (the banner-hidden case).
+func TestUpdateStatus_NoInstallMissingWhenInstalled(t *testing.T) {
+	s := newFullServer(t)
+	g := gheAppPostResetConfig()
+	g.InstallationID = 12345678
+	s.deps.Config.GitHub = g
+
+	status := &StatusPayload{}
+	s.UpdateStatus(status)
+
+	if status.GitHubAppInstallMissing {
+		t.Error("GitHubAppInstallMissing = true with a non-zero installation_id")
+	}
+	if status.GitHubAppRequired {
+		t.Error("GitHubAppRequired = true; config truth must not force the banner when an installation is present")
+	}
+	if status.GitHubAppState != "" {
+		t.Errorf("GitHubAppState = %q, want empty when nothing classified anything", status.GitHubAppState)
+	}
+}
+
+// TestUpdateStatus_PlaceholderAppNeverInstallMissing: the placeholder app_id
+// means "no real App yet" — an operator-side condition with its own banner.
+// It must never read as a user-fixable missing installation.
+func TestUpdateStatus_PlaceholderAppNeverInstallMissing(t *testing.T) {
+	s := newFullServer(t)
+	g := gheAppPostResetConfig()
+	g.AppID = config.PlaceholderAppID
+	s.deps.Config.GitHub = g
+
+	status := &StatusPayload{}
+	s.UpdateStatus(status)
+
+	if status.GitHubAppInstallMissing {
+		t.Error("GitHubAppInstallMissing = true for the placeholder app_id — installing cannot help a hive with no real App assigned")
+	}
+}
+
+// TestGitHubAppInstallMissingFieldIsExposed proves the primary trigger
+// actually reaches the browser under the name the banner JS reads.
+func TestGitHubAppInstallMissingFieldIsExposed(t *testing.T) {
+	f, ok := reflect.TypeOf(StatusPayload{}).FieldByName("GitHubAppInstallMissing")
+	if !ok {
+		t.Fatal("StatusPayload has no GitHubAppInstallMissing field — the banner's primary trigger would be dead code")
+	}
+	if got := f.Tag.Get("json"); !strings.HasPrefix(got, "githubAppInstallMissing") {
+		t.Errorf("GitHubAppInstallMissing json tag = %q, want it to serialise as githubAppInstallMissing", got)
+	}
+}
+
+// TestGitHubAppBannerKeysOffInstallMissingAndAuthState locks the client-side
+// gating: visibility must key off the missing installation (first) and the
+// classified auth state — never off a non-empty install URL alone, which is
+// the raw-field sniffing that suppressed the banner on vllmd-13.
+func TestGitHubAppBannerKeysOffInstallMissingAndAuthState(t *testing.T) {
+	html := spokeIndexHTML(t)
+
+	i := strings.Index(html, "function renderGitHubAppBanner(data)")
+	if i < 0 {
+		t.Fatal("static/index.html has no renderGitHubAppBanner function")
+	}
+	end := strings.Index(html[i:], "\n    }")
+	if end < 0 {
+		t.Fatal("could not find the end of renderGitHubAppBanner")
+	}
+	body := html[i : i+end]
+
+	required := []struct {
+		snippet string
+		why     string
+	}{
+		{"data.githubAppInstallMissing", "the banner must read the config-truth missing-installation flag"},
+		{"var isInstallMissing", "the missing installation must be its own named trigger, evaluated before any URL check"},
+		{"isNotInstalled || data.githubAppInstallURL || isPermIssue", "visibility must accept the auth/config trigger BEFORE requiring an install URL — an empty URL alone must never hide the banner"},
+		{"(data.githubAppRequired || isInstallMissing)", "a missing installation must show the banner even if no probe has set the required flag yet"},
+		{"GH_APP_STATE_WRONG_INSTALLATION", "wrong-installation is user-actionable and must trigger the install banner"},
+	}
+	for _, r := range required {
+		if !strings.Contains(body, r.snippet) {
+			t.Errorf("renderGitHubAppBanner is missing %q — %s", r.snippet, r.why)
+		}
+	}
+	if !strings.Contains(html, "GH_APP_STATE_WRONG_INSTALLATION = 'wrong-installation'") {
+		t.Error("the wrong-installation wire token must match github.AppStateWrongInstallation.String()")
+	}
+
+	// The primary trigger must be sufficient by itself: the old gate began
+	// with `data.githubAppRequired && (data.githubAppInstallURL || ...` which
+	// is exactly the shape that hid the banner. Its return would be a
+	// regression.
+	if strings.Contains(body, "if (data.githubAppRequired && (data.githubAppInstallURL || isPermIssue)) {") {
+		t.Error("the old URL-gated visibility condition is back — a blank raw config would suppress the banner again")
+	}
+}
+
+// TestForgeAppTabAlwaysOffersInstallAction locks the Forge App tab contract:
+// installation_id 0 (with a real app_id) shows the install link FIRST and by
+// itself; classified not-installed/wrong-installation also trigger it; the
+// URL comes from the server-built install_url (the banner's builder, never a
+// client-composed second scheme); a Re-check sits beside it; and a healthy
+// installed config gets a subtle View App settings link instead.
+func TestForgeAppTabAlwaysOffersInstallAction(t *testing.T) {
+	html := spokeIndexHTML(t)
+
+	i := strings.Index(html, "function forgeAppNeedsInstall(a)")
+	if i < 0 {
+		t.Fatal("static/index.html has no forgeAppNeedsInstall function — the Forge App tab is a dead end again")
+	}
+	end := strings.Index(html[i:], "\n    }")
+	body := html[i : i+end]
+	if !strings.Contains(body, "if (a.app_id && !a.installation_id) return true;") {
+		t.Error("forgeAppNeedsInstall must check the missing installation_id FIRST and return true on it alone — no dependence on auth_state")
+	}
+	if !strings.Contains(body, "GH_APP_STATE_NOT_INSTALLED") || !strings.Contains(body, "GH_APP_STATE_WRONG_INSTALLATION") {
+		t.Error("forgeAppNeedsInstall must also trigger on the classified not-installed / wrong-installation states")
+	}
+
+	ai := strings.Index(html, "function forgeAppActions(a)")
+	if ai < 0 {
+		t.Fatal("static/index.html has no forgeAppActions function")
+	}
+	aend := strings.Index(html[ai:], "\n    }")
+	abody := html[ai : ai+aend]
+	for _, r := range []struct{ snippet, why string }{
+		{"a.install_url", "the tab must use the SERVER-built install URL (config.AppInstallURL, the banner's builder) — never compose its own"},
+		{"Install GitHub App", "the install affordance must be a visible, labelled action"},
+		{"forgeAppRecheck", "the Re-check affordance must sit next to the install link"},
+		{"View App settings", "a healthy installed config gets the subtle settings link instead"},
+		{"github.app_slug", "an unknown-forge GHE host with no slug must name the missing config rather than render a dead end"},
+	} {
+		if !strings.Contains(abody, r.snippet) {
+			t.Errorf("forgeAppActions is missing %q — %s", r.snippet, r.why)
+		}
+	}
+
+	// The actions row must actually be rendered inside the Active config card.
+	ri := strings.Index(html, "function renderForgeApps(data)")
+	if ri < 0 {
+		t.Fatal("static/index.html has no renderForgeApps function")
+	}
+	rend := strings.Index(html[ri:], "\n    }")
+	rbody := html[ri : ri+rend]
+	if !strings.Contains(rbody, "forgeAppActions(a)") {
+		t.Error("renderForgeApps does not render forgeAppActions — the affordance would be dead code")
+	}
+
+	// Re-check must reuse the banner's endpoint, not grow a second one.
+	if !strings.Contains(html, "async function forgeAppRecheck") {
+		t.Fatal("static/index.html has no forgeAppRecheck function")
+	}
+	fi := strings.Index(html, "async function forgeAppRecheck")
+	fend := strings.Index(html[fi:], "\n    }")
+	fbody := html[fi : fi+fend]
+	if !strings.Contains(fbody, "/api/github-app/recheck") {
+		t.Error("forgeAppRecheck must POST the existing /api/github-app/recheck endpoint")
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -249,10 +249,17 @@ type StatusPayload struct {
 	GitHubAppInstallURL string                 `json:"githubAppInstallURL,omitempty"`
 	GitHubAppPermIssue  string                 `json:"githubAppPermIssue,omitempty"`
 	GitHubAppState      string                 `json:"githubAppState,omitempty"`
-	GitHubBaseURL       string                 `json:"githubBaseURL,omitempty"`
-	InferenceBackends   []InferenceBackend     `json:"inferenceBackends,omitempty"`
-	SystemAlerts        []SystemAlert          `json:"systemAlerts,omitempty"`
-	HubBanner           *HubBannerState        `json:"hubBanner,omitempty"`
+	// GitHubAppInstallMissing is CONFIG TRUTH, independent of any auth probe
+	// or classification: a real App is named (app_id set, not the placeholder)
+	// but installation_id is 0. That state alone means every token is a
+	// countdown, so the install banner keys off this field FIRST — no recheck,
+	// classification, or raw-URL sniffing may gate it (the vllmd-13 reset left
+	// blank raw fields suppressing the banner while auth was not-installed).
+	GitHubAppInstallMissing bool               `json:"githubAppInstallMissing,omitempty"`
+	GitHubBaseURL           string             `json:"githubBaseURL,omitempty"`
+	InferenceBackends       []InferenceBackend `json:"inferenceBackends,omitempty"`
+	SystemAlerts            []SystemAlert      `json:"systemAlerts,omitempty"`
+	HubBanner               *HubBannerState    `json:"hubBanner,omitempty"`
 }
 
 // HubBannerState is a banner message from the hub admin displayed on spoke dashboards.
@@ -1054,6 +1061,30 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 	status.GitHubAppPermIssue = s.githubAppPermIssue
 	status.GitHubAppState = s.githubAppState
 	s.githubAppMu.RUnlock()
+
+	// CONFIG-TRUTH OVERRIDE, applied last so no probe-derived field can veto
+	// it: a real App with installation_id 0 must light the install banner the
+	// moment the page loads. The recheck loop's SetGitHubAppRequired state is
+	// probe-derived and can lag (or, after a "Reset Forge App", hold an empty
+	// install URL because the raw app_slug/base_url went blank); the RESOLVED
+	// config — the same values the Forge App tab displays — is what the banner
+	// must render. Operator-side classifications (key-missing/key-invalid/
+	// no-app-assigned) are preserved: only an empty state is filled in, and
+	// the placeholder app_id never reaches here (ConfiguredButUninstalled
+	// requires a real App).
+	if s.deps != nil && s.deps.Config != nil {
+		g := s.deps.Config.GitHub
+		if g.ConfiguredButUninstalled() {
+			status.GitHubAppInstallMissing = true
+			status.GitHubAppRequired = true
+			if status.GitHubAppState == "" {
+				status.GitHubAppState = githubAppStateNotInstalledToken
+			}
+		}
+		if status.GitHubAppRequired && status.GitHubAppInstallURL == "" {
+			status.GitHubAppInstallURL = g.AppInstallURL()
+		}
+	}
 
 	status.InferenceBackends = s.buildInferenceBackends()
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5510,6 +5510,11 @@
        perform. Kept out of GH_APP_OPERATOR_STATES: installing is the user's
        job, not the operator's. */
     var GH_APP_STATE_NOT_INSTALLED = 'not-installed';
+    /* User-actionable like not-installed: an installation ID is present but
+       names an installation this App does not have (typically another org's).
+       The fix is the same install/re-check flow, so the banner treats it as
+       an install trigger rather than a permission problem. */
+    var GH_APP_STATE_WRONG_INSTALLATION = 'wrong-installation';
     /* Operator-side: this hive still carries the placeholder app_id and was
        never assigned a real App. It is NOT 'not-installed' — the App may well be
        installed and the installation ID correct (it usually is), but an app_id
@@ -5815,9 +5820,22 @@
          githubAppState (added with the operator/user classification) is the
          authoritative signal, so an explicitly not-installed state is never
          treated as a permission problem. */
-      var isNotInstalled = appState === GH_APP_STATE_NOT_INSTALLED;
+      /* PRIMARY trigger, checked FIRST and sufficient BY ITSELF: config truth
+         says a real App is named but installation_id is 0/empty
+         (githubAppInstallMissing, computed server-side from the RESOLVED
+         config). No auth-state classification, recheck round-trip, or install
+         URL may gate it: after a "Reset Forge App" the raw base_url/app_slug
+         go blank, and keying visibility off those raw fields (via an empty
+         githubAppInstallURL) kept this banner hidden on a hive whose auth
+         state was literally not-installed (vllmd-13). */
+      var isInstallMissing = !!data.githubAppInstallMissing;
+      /* Classified auth states remain an ADDITIONAL trigger — they cover the
+         id-present-but-invalid case the config test cannot see. */
+      var isNotInstalled = isInstallMissing
+        || appState === GH_APP_STATE_NOT_INSTALLED
+        || appState === GH_APP_STATE_WRONG_INSTALLATION;
       var isPermIssue = data.githubAppRequired && data.githubAppPermIssue && !isNotInstalled;
-      if (data.githubAppRequired && (data.githubAppInstallURL || isPermIssue)) {
+      if ((data.githubAppRequired || isInstallMissing) && (isNotInstalled || data.githubAppInstallURL || isPermIssue)) {
         var link = document.getElementById('gh-app-install-link');
         var title = document.querySelector('#gh-app-install-banner .gh-app-title');
         var desc = document.querySelector('#gh-app-install-banner .gh-app-desc');
@@ -14550,6 +14568,7 @@ function burnAreaChart() {
           ${forgeAppRow('Key file', esc(a.key_file || '—'))}
           ${forgeAppRow('Key fingerprint', a.key_fingerprint ? '<code style="font-size:0.74rem">' + esc(a.key_fingerprint) + '</code>' : '<span style="color:var(--muted)">— (no usable key)</span>')}
           ${forgeAppRow('Auth state', stateHtml)}
+          ${forgeAppActions(a)}
           ${a.editable ? forgeAppEditForm(a) : ''}
         </div>`;
       html += '<div style="font-weight:600;font-size:0.85rem;margin:14px 0 6px">Per-app-id keys on disk</div>';
@@ -14568,6 +14587,61 @@ function burnAreaChart() {
           </div>`).join('');
       }
       host.innerHTML = html;
+    }
+
+    // forgeAppNeedsInstall: PRIMARY rule, checked FIRST and sufficient BY
+    // ITSELF — a real App (app_id set) with no installation_id needs
+    // installing, full stop. No auth-state classification or recheck is
+    // required before offering the link: a blank id after a "Reset Forge App"
+    // must light the install affordance immediately on page load. The
+    // classified states are an ADDITIONAL trigger for the case where an id
+    // exists but names the wrong (or a vanished) installation.
+    function forgeAppNeedsInstall(a) {
+      if (a.app_id && !a.installation_id) return true;
+      return a.auth_state === GH_APP_STATE_NOT_INSTALLED
+        || a.auth_state === GH_APP_STATE_WRONG_INSTALLATION;
+    }
+
+    // forgeAppActions renders the install/settings affordance under the
+    // Active config table, so the tab is never a dead end. The URL is the
+    // SERVER-built install_url (config.AppInstallURL(), the same builder the
+    // install banner uses) — the tab must never compose its own URL scheme.
+    // When an installation is present and nothing is classified as broken, a
+    // subtle "View App settings" link renders instead (GitHub redirects the
+    // installations/new page to the App's settings when already installed —
+    // the same behavior the banner's View App Settings action relies on).
+    function forgeAppActions(a) {
+      const hostLabel = esc(String(a.base_url || 'https://github.com').replace(/^https?:\/\//, ''));
+      const recheckBtn = '<button type="button" onclick="forgeAppRecheck(this)" style="padding:6px 14px;border:1px solid var(--border);border-radius:6px;background:transparent;color:var(--muted);cursor:pointer;font-size:0.76rem">Re-check</button>';
+      if (forgeAppNeedsInstall(a)) {
+        if (a.install_url) {
+          return `<div id="forge-app-actions" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;border-top:1px solid var(--border);margin-top:10px;padding-top:10px">
+              <a href="${esc(a.install_url)}" target="_blank" rel="noopener noreferrer" style="display:inline-block;padding:7px 16px;border:none;border-radius:6px;background:var(--cyan);color:var(--bg);font-weight:600;font-size:0.8rem;text-decoration:none">Install GitHub App on ${hostLabel}</a>
+              ${recheckBtn}
+              <span style="font-size:0.74rem;color:var(--muted)">No installation is linked${a.installation_id ? '' : ' (Installation ID is 0)'} — install the App, then Re-check.</span>
+            </div>`;
+        }
+        return `<div id="forge-app-actions" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;border-top:1px solid var(--border);margin-top:10px;padding-top:10px">
+            <span style="font-size:0.76rem;color:var(--yellow)">The GitHub App is not installed, and no install link can be built: the App slug for ${hostLabel} is not configured. Ask your hub operator to set github.app_slug for this cluster.</span>
+            ${recheckBtn}
+          </div>`;
+      }
+      if (a.install_url && a.installation_id) {
+        return `<div id="forge-app-actions" style="border-top:1px solid var(--border);margin-top:10px;padding-top:10px">
+            <a href="${esc(a.install_url)}" target="_blank" rel="noopener noreferrer" style="font-size:0.76rem;color:var(--muted);text-decoration:underline">View App settings on ${hostLabel}</a>
+          </div>`;
+      }
+      return '';
+    }
+
+    // forgeAppRecheck reuses the banner's recheck endpoint, then re-renders
+    // the tab from server truth (auth_state/installation_id may have moved).
+    async function forgeAppRecheck(btn) {
+      if (btn) { btn.disabled = true; btn.textContent = 'Checking…'; }
+      try {
+        await fetch('/api/github-app/recheck', { method: 'POST' });
+      } catch (e) { /* the reload below reports current truth either way */ }
+      loadForgeApps();
     }
 
     function forgeAppEditForm(a) {


### PR DESCRIPTION
## Live evidence (vllmd-13 spoke)

After an operator **Reset Forge App**, the spoke's Governor Configuration → Forge App tab showed: Active config `github.ibm.com`, App ID 5686, App slug `kubestellar-hive-ghe`, Installation ID **0**, **Auth state: not-installed**; deep health `github_auth` failing with "GitHub App not installed — no installation for this org". Yet:

1. The big "GitHub App Not Installed on github.ibm.com" install banner did **not** render on the dashboard.
2. The Forge App tab displayed the failing auth state but offered **no install link/button** — a dead end.

## Root cause

The banner's visibility gate was `data.githubAppRequired && (data.githubAppInstallURL || isPermIssue)`, and `config.AppInstallURL()` returns `""` on GHE unless the **raw** `app_slug` is explicitly configured. After a reset the raw `app_slug`/`base_url` go blank while the **resolved** identity (what the Forge App tab displays, derived from the forge table / `api_url`) is still `github.ibm.com` — so the empty raw-field-derived URL suppressed the banner exactly while auth was literally `not-installed`.

## Fix

**Primary rule (config truth, checked first, sufficient by itself):** a real `app_id` with `installation_id` 0 lights the install banner and the Forge App tab's install link immediately — no auth-state classification, recheck round-trip, or raw-URL sniffing may gate it. Classified `not-installed` / `wrong-installation` remain an additional trigger (id present but invalid).

- `config.AppInstallURL()`: a **known** forge derives its slug from the forge-identity table when the raw `app_slug` is blank, so the resolved install link (`https://github.ibm.com/github-apps/kubestellar-hive-ghe/installations/new`) survives a reset. Unknown GHE hosts still return `""` (never a public-slug 404 link).
- `StatusPayload` gains `githubAppInstallMissing`, computed in `UpdateStatus` from `ConfiguredButUninstalled()` (resolved config truth). The install URL and `not-installed` state are filled from the resolved config when the probe left them empty; operator-side states (`key-missing`/`key-invalid`/`no-app-assigned`) are preserved.
- Banner gating is now `(required || installMissing) && (notInstalled || installURL || permIssue)` — an empty install URL alone can never hide it; the banner host text keeps using the resolved `githubBaseURL`.
- Forge App tab: renders a prominent **Install GitHub App on \<host\>** link (server-built `install_url` — the exact same `AppInstallURL()` builder the banner uses, no second URL scheme) plus the existing **Re-check** (`POST /api/github-app/recheck`) whenever `app_id` is set and `installation_id` is 0 **or** auth state is `not-installed`/`wrong-installation`; a subtle **View App settings** link when an installation is present and healthy.

## Tests

- `TestUpdateStatus_InstallMissingFromConfigTruth` — post-reset shape (blank raw fields, GHE `api_url`, installation_id 0) → payload lights up with the resolved forge URL/host; installed → nothing lights up; placeholder app_id never triggers; operator-side states preserved.
- `TestGitHubAppBannerKeysOffInstallMissingAndAuthState` — locks the new gating and forbids the old URL-gated condition from returning.
- `TestForgeAppTabAlwaysOffersInstallAction` — installation_id 0 checked first and alone sufficient; install/Re-check/View-App-settings affordances present; server-built `install_url` used.
- `TestForgeApps_InstallURLIsServerBuilt`, `TestGitHubConfig_AppInstallURL_PostResetDerivesFromForge` + updated `AppInstallURL` table (known forge derives slug; unknown GHE still yields no link).