### PR TITLE
📝 docs(provisioning): placeholders run at replicas:1 with a unique org (not scaled-to-0 / literal placeholder)

### DIFF
--- a/v2/docs/manual-provisioning.md
+++ b/v2/docs/manual-provisioning.md
@@ -257,9 +257,10 @@ metadata: { name: hive-config, namespace: ${NS}, labels: { app: hive } }
 data:
   hive.yaml: |
     project:
-      org: myorg                      # a POOL PLACEHOLDER uses the literal "placeholder" for
-      repos: [myrepo]                 # org / repos / primary_repo (matching its meta.json)
-      primary_repo: myrepo            # until it is claimed — see Placeholder pools below
+      org: myorg                      # a POOL PLACEHOLDER can seed any bootstrap org here; the
+      repos: [myrepo]                 # AUTHORITATIVE identity is the meta.json org
+      primary_repo: myrepo            # (available-vllmd-<date>-<suffix>), which is what the hub
+                                      # renders — see Placeholder pools below
     agents:
       guide:   { backend: copilot, model: claude-sonnet-4-6, enabled: true }
       scanner: { backend: copilot, model: claude-sonnet-4-6, enabled: true }
@@ -630,9 +631,9 @@ so a request for access is satisfied in seconds instead of the full 5–10 minut
 provision. Two pools, one per method type:
 
 - **vllm-d** placeholders serve **private** methods — provisioned manually
-  (Path B), then **scaled to 0**.
+  (Path B) and left running at **`replicas: 1`**.
 - **hive-oke** placeholders serve **public** methods — provisioned via the API
-  (Path A), then **scaled to 0**.
+  (Path A) and left running at **`replicas: 1`**.
 
 > **Gotcha — placeholder IDs are date + random suffix, NOT sequential integers.**
 > The live pool uses `hosted-available-vllmd-<YYMMDD>-<suffix>`, where `<suffix>`
@@ -656,24 +657,30 @@ provision. Two pools, one per method type:
 > kubectl --context vllm-d get ns | grep hive-hosted-hosted-available-vllmd        # existing namespaces
 > ```
 
-Provision each placeholder as above (at `replicas: 0` — a placeholder never
-boots until claimed, so there is nothing to test by scaling it up; see the
-verification below), then, for the automated path only, scale it down:
+Provision each placeholder as above at **`replicas: 1`**. The pod boots
+immediately, lands on the `anyuid` SCC, and heartbeats to the hub as an
+available slot ready to be claimed. Both pools stay at `replicas: 1`:
 
 ```bash
-# manual (vllm-d): set replicas: 0 in the Deployment from the start (it never boots)
-# — if you applied it at replicas: 1, scale it to 0:
-kubectl --context vllm-d -n "$NS" scale deploy/hive --replicas=0
+# manual (vllm-d): apply the Deployment at replicas: 1 (it boots and heartbeats).
+# If you applied it at 0, scale it up:
+kubectl --context vllm-d -n "$NS" scale deploy/hive --replicas=1
 
-# automated (hive-oke): the API provisions at replicas=1 — scale it down
-kubectl --context hive-oke -n "hive-hosted-$ID" scale deploy/hive --replicas=0
+# automated (hive-oke): the API already provisions at replicas=1 — leave it there.
 ```
 
+> **Gotcha — do NOT scale placeholders to 0.** A `replicas: 0` slot is **not
+> assignable**: the claim/assign path delivers the claimant's config to a
+> **running, heartbeating** spoke, so a slot that isn't booted can never be
+> claimed. Every assignable slot in the live pool runs at `replicas: 1`,
+> `ready 1/1`. (Earlier guidance to "scale to 0" was incorrect.)
+
 Give every placeholder a `meta.json` with **`owner: clubanderson`** (admin-only
-visibility), **`status: "available"`**, and **`acmm_level: 2`**. The live pool's
-placeholder `meta.json` uses the literal string `"placeholder"` for
-`org`/`repos`/`primary_repo` (they stay that way until the hive is claimed), and
-carries `github_host` because vllm-d placeholders target GitHub Enterprise
+visibility), **`status: "available"`**, and **`acmm_level: 2`**. Set `org` to a
+**unique** value per slot — `available-vllmd-<YYMMDD>-<suffix>` mirroring the
+`id`'s date-suffix — with **empty** `repos: []` and `primary_repo: ""` (they get
+their real values when the slot is claimed). The `meta.json` also carries
+`github_host` because vllm-d placeholders target GitHub Enterprise
 (`github.ibm.com`), not `github.com`:
 
 ```json
@@ -681,13 +688,13 @@ carries `github_host` because vllm-d placeholders target GitHub Enterprise
   "id": "hosted-available-vllmd-260806-1bo3",
   "owner": "clubanderson",
   "project_name": "Available slot (private) 260806-1bo3",
-  "org": "placeholder",
-  "repos": ["placeholder"],
-  "primary_repo": "placeholder",
+  "org": "available-vllmd-260806-1bo3",
+  "repos": [],
+  "primary_repo": "",
   "acmm_level": 2,
   "status": "available",
   "created_at": "",
-  "subdomain": "",
+  "subdomain": "hosted-available-vllmd-260806-1bo3.apps.fmaas-vllm-d.fmaas.res.ibm.com",
   "claim_delivered": false,
   "auto_upgrade": true,
   "is_public": false,
@@ -696,37 +703,45 @@ carries `github_host` because vllm-d placeholders target GitHub Enterprise
 }
 ```
 
+> **The `org` must be unique per slot** (mirror the `id`'s date-suffix) so each
+> renders as a distinct **"Available slot (private) `<date>-<suffix>`"** row in
+> the hub. A literal shared `org: "placeholder"` (with `repos: ["placeholder"]`)
+> makes every slot render identically as "placeholder / placeholder" —
+> indistinguishable — and is wrong.
+
 ### Verify a provisioned placeholder
 
-A correct vllm-d placeholder is `replicas: 0`, its `hive-anyuid` binding points
-at its **own** namespace, its PVC is `Bound`, and its hub `meta.json` exists.
-This exact set verified all ten placeholders in the 2026-08-06 batch:
+A correct vllm-d placeholder runs at `replicas: 1` with its pod up (`Running`,
+`ready`, `restartCount: 0`) on the `anyuid` SCC, its `hive-anyuid` binding points
+at its **own** namespace, its PVC is `Bound`, its `livez` returns 200, and its hub
+`meta.json` exists. This set verified all ten placeholders in the 2026-08-06 batch:
 
 ```bash
 ID=hosted-available-vllmd-<date>-<suffix>; NS=hive-hosted-$ID
-kubectl --context vllm-d -n $NS get deploy hive -o jsonpath='{.spec.replicas}'          # must be 0
+kubectl --context vllm-d -n $NS get deploy hive -o jsonpath='{.spec.replicas}'          # must be 1
+POD=$(kubectl --context vllm-d -n $NS get pod -l app=hive -o jsonpath='{.items[0].metadata.name}')
+kubectl --context vllm-d -n $NS get pod $POD -o jsonpath='{.status.phase}'              # must be Running
+kubectl --context vllm-d -n $NS get pod $POD -o jsonpath='{.metadata.annotations.openshift\.io/scc}'  # must be anyuid
+kubectl --context vllm-d -n $NS get pod $POD -o jsonpath='{.status.containerStatuses[0].ready}'       # must be true
+kubectl --context vllm-d -n $NS get pod $POD -o jsonpath='{.status.containerStatuses[0].restartCount}' # must be 0
+kubectl --context vllm-d -n $NS exec $POD -c hive -- curl -s -o /dev/null -w '%{http_code}' localhost:3002/api/livez  # must be 200
 kubectl --context vllm-d -n $NS get rolebinding hive-anyuid -o jsonpath='{.subjects[0].namespace}'  # must equal $NS
 kubectl --context vllm-d -n $NS get pvc hive-data -o jsonpath='{.status.phase}'         # must be Bound
 kubectl --context hive-oke -n hive-hub exec $HUB_POD -- test -f /data/saas/hives/$ID/meta.json  # must exist
 ```
 
-> **The `hive-anyuid` subject-namespace check is the load-bearing one** (it is
-> the same `restricted-v2` crash-loop gotcha from B.2). For a `replicas: 0`
-> placeholder it is **sufficient** SCC verification: because a placeholder never
-> boots until claimed, you do **not** need to scale it up to confirm the `anyuid`
-> SCC — a correct subject namespace guarantees the pod will land on `anyuid` the
-> moment it is scaled to 1 at claim time.
+> **The `hive-anyuid` subject-namespace check is still load-bearing at apply
+> time** (it is the same `restricted-v2` crash-loop gotcha from B.2): a wrong
+> subject namespace means the pod can't get the `anyuid` SCC. But because a
+> placeholder now **boots at `replicas: 1`**, you confirm the SCC directly —
+> verify the pod reaches `phase=Running`, `scc=anyuid`, `ready=true`,
+> `restartCount=0`, and `livez` == 200.
 
-> **Gotcha — automated placeholders leave a fleet-registry entry.** Because the
-> API provisions at `replicas=1`, an hive-oke placeholder heartbeats once before
-> you scale it down, leaving a registry entry that pins its version and
-> last-known ACMM and shows it "online" for `staleThreshold` (15 min). A
-> manually-provisioned placeholder created at `replicas=0` never heartbeats and
-> has no registry entry. To make the two pools render identically (no version,
-> no online dot, ACMM from `meta.json`), remove the placeholder's registry entry:
-> scale the hub to 0, edit `/data/hub-registry.json` on the hub PVC to drop the
-> entry, then scale the hub back up. (The hub holds the registry in memory and
-> rewrites the file, so a live edit is clobbered — you must stop it first.)
+> **Note — placeholders carry a fleet-registry entry.** Because both pools run
+> at `replicas: 1`, every placeholder heartbeats and holds a registry entry that
+> pins its version and last-known ACMM and shows it "online". This is expected
+> and required: the claim/assign path delivers config to the running, heartbeating
+> spoke, so the entry is what makes the slot assignable — do **not** strip it.
 
 ### Claiming a placeholder
 
@@ -738,8 +753,9 @@ Until the dashboard "assign" flow lands, claiming is manual:
    real `project.org` / `repos`, and the claimant's GitHub App `app_id` /
    `installation_id`.
 3. Install the GitHub App key (owner does this from the dashboard's *Install
-   GitHub App* flow once the hive is awake).
-4. Scale the deployment to 1.
+   GitHub App* flow — the hive is already awake at `replicas: 1`).
+4. Roll the pod so it picks up the new config (`kubectl rollout restart
+   deploy/hive`) — it is already running, so there is nothing to scale up.
 
 ---
 
@@ -887,4 +903,4 @@ kubectl --context hive-oke -n hive-hub exec "$HUB_POD" -- \
 | ConfigMap edits have no effect | PVC overlay is authoritative | Edit `/data/hive.yaml.dashboard`, not the ConfigMap |
 | User has `read-write` in Manage Access but login fails with `device-flow login rejected: user not authorized` | Grant written to `/data/hive.yaml.dashboard` after the pod booted; the running authorizer only rebuilds `authorized_users` at startup (common right after provisioning / cross-cluster migration onto a fresh PVC) | Confirm the user is in the pod's `/etc/hive/hive.yaml`, then `rollout restart deploy/hive` so the authorizer rebuilds |
 | Admission warnings on apply | Cluster requires an `owner` label | Add `owner: <login>` to every `metadata.labels` |
-| Placeholder shows a version / "online" dot | It heartbeated once (automated path) | Remove its `/data/hub-registry.json` entry (hub scaled to 0) |
+| Placeholder rows all render as "placeholder / placeholder" | `meta.json` used the literal `org: "placeholder"` | Give each slot a unique `org: available-vllmd-<date>-<suffix>` with `repos: []` |


### PR DESCRIPTION
Corrects two errors introduced by #2768 in `v2/docs/manual-provisioning.md`, verified against the live vllm-d pool on 2026-08-06.

## Error 1 — placeholders run at `replicas: 1`, not scaled to 0
A `replicas: 0` slot is **not assignable**: the claim/assign path delivers the claimant's config to a running, heartbeating spoke, so a slot that isn't booted can never be claimed. Every assignable slot in the live pool (260731-fikn/sl58/fbo1/gzlo, vllmd-15, the ten new 260806-* slots) runs at `replicas: 1`, `ready 1/1`.

- Pool description + provision block: both pools left at `replicas: 1`; removed the "scale to 0" instructions; added a Gotcha (do NOT scale to 0).
- "Verify a provisioned placeholder": asserts `replicas==1` and now boots the pod — confirms `phase=Running`, `scc=anyuid`, `ready=true`, `restartCount=0`, `livez==200`. The `hive-anyuid` subject-namespace check still matters at apply time.
- Corrected the registry-entry gotcha, the claim steps (roll the pod, don't scale up), and the troubleshooting table.

## Error 2 — placeholder `meta.json` org must be unique per slot
A shared literal `org: "placeholder"` makes every row render identically as "placeholder / placeholder", indistinguishable in the hub. The real slots use a distinct `org` per slot with empty repos:
- `org: available-vllmd-<YYMMDD>-<suffix>` (mirrors the id's suffix), `repos: []`, `primary_repo: ""`.
- Added a note explaining the uniqueness requirement.

## ConfigMap note (B.4)
Clarified that the ConfigMap seed's `project.org` is a bootstrap value; the authoritative identity is the meta.json org (`available-vllmd-<date>-<suffix>`), which is what the hub renders.

Docs-only.