### PR TITLE
sec(C2 follow-up): make SSO handoff asymmetric (Ed25519) — spokes cannot mint

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1701,20 +1701,22 @@ func (s *Server) handleSSO(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// SSO verification uses the derived SSO sub-key (C2 domain separation): a
-	// hub-hosted spoke is injected HIVE_SSO_KEY and never the master secret, so a
-	// spoke operator cannot mint SSO-as-any-owner tokens. SpokeSSOKey falls back to
-	// deriving from HIVE_HUB_SECRET for self-hosted/legacy spokes that still hold
-	// the master, so verification succeeds against the hub-minted token either way.
-	secret := hub.SpokeSSOKey()
-	if secret == "" {
-		// No shared secret → SSO cannot be verified. Terminate with an
+	// SSO verification uses the hub's Ed25519 PUBLIC key (C2 follow-up: SSO is
+	// asymmetric). A hub-hosted spoke is injected HIVE_SSO_PUBLIC_KEY and never the
+	// master or any signing seed, so a spoke operator who reads its pod env cannot
+	// mint SSO-as-any-owner tokens — only the hub, holding the private seed, can
+	// sign. SpokeSSOPublicKey falls back to deriving the public key from
+	// HIVE_HUB_SECRET for self-hosted/legacy spokes that still hold the master, so
+	// verification succeeds against the hub-minted token either way.
+	pubKey := hub.SpokeSSOPublicKey()
+	if pubKey == "" {
+		// No verification key → SSO cannot be verified. Terminate with an
 		// explanation. Redirecting to "/" here is what produced the historical
 		// infinite bounce: "/" is auth-gated, sends the user back to the hub
 		// login, the hub sees a valid session and hands off to /sso again.
 		writeSSOError(w, r, http.StatusServiceUnavailable, ssoErrNoSecret,
-			"This hive has no hub shared secret configured, so single sign-on from the hub cannot be verified.",
-			"Ask the hive operator to set HIVE_HUB_SECRET (or HIVE_SSO_KEY) on this hive. In the meantime you can sign in directly with GitHub using the button below.")
+			"This hive has no hub SSO verification key configured, so single sign-on from the hub cannot be verified.",
+			"Ask the hive operator to set HIVE_HUB_SECRET (or HIVE_SSO_PUBLIC_KEY) on this hive. In the meantime you can sign in directly with GitHub using the button below.")
 		return
 	}
 
@@ -1731,7 +1733,7 @@ func (s *Server) handleSSO(w http.ResponseWriter, r *http.Request) {
 		hiveID = s.deps.Config.HiveID
 	}
 
-	username, tokenRole, err := hub.VerifySSOToken(secret, token, hiveID, time.Now())
+	username, tokenRole, err := hub.VerifySSOToken(pubKey, token, hiveID, time.Now())
 	if err != nil {
 		if s.deps != nil && s.deps.Logger != nil {
 			s.deps.Logger.Warn("sso handoff rejected", "error", err.Error())

--- a/v2/pkg/dashboard/auth_deviceflow_coverage_test.go
+++ b/v2/pkg/dashboard/auth_deviceflow_coverage_test.go
@@ -331,7 +331,7 @@ func TestCovDF_SSO_ValidNoAllowlist(t *testing.T) {
 	t.Setenv("HIVE_HUB_SECRET", secret)
 	s, deps, _ := dfServer(t, "complete", "octocat")
 	deps.Config.HiveID = "hive-abc"
-	tok := hub.MintSSOToken(hub.SpokeSSOKey(), "alice", config.RoleOwner, "hive-abc", time.Now())
+	tok := hub.MintSSOToken(hub.SSOSigningSeedFromMaster(secret), "alice", config.RoleOwner, "hive-abc", time.Now())
 	rec := doGet(s, "/sso?token="+tok)
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("valid sso: want 303, got %d (%s)", rec.Code, rec.Body.String())
@@ -348,7 +348,7 @@ func TestCovDF_SSO_ValidWithAllowlist(t *testing.T) {
 	deps.Config.HiveID = "hive-abc"
 	deps.Config.Dashboard.AuthorizedUsers = []string{"owner1:owner", "alice:read"}
 	deps.Config.Dashboard.HubProxied = false
-	tok := hub.MintSSOToken(hub.SpokeSSOKey(), "alice", config.RoleOwner, "hive-abc", time.Now())
+	tok := hub.MintSSOToken(hub.SSOSigningSeedFromMaster(secret), "alice", config.RoleOwner, "hive-abc", time.Now())
 	rec := doGet(s, "/sso?token="+tok)
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("allowlisted sso: want 303, got %d", rec.Code)
@@ -362,7 +362,7 @@ func TestCovDF_SSO_NotAuthorized(t *testing.T) {
 	deps.Config.HiveID = "hive-abc"
 	deps.Config.Dashboard.AuthorizedUsers = []string{"someoneelse"}
 	deps.Config.Dashboard.HubProxied = false
-	tok := hub.MintSSOToken(hub.SpokeSSOKey(), "alice", config.RoleOwner, "hive-abc", time.Now())
+	tok := hub.MintSSOToken(hub.SSOSigningSeedFromMaster(secret), "alice", config.RoleOwner, "hive-abc", time.Now())
 	rec := doGet(s, "/sso?token="+tok)
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("unauthorized sso: want 403, got %d", rec.Code)

--- a/v2/pkg/dashboard/sso_handoff_test.go
+++ b/v2/pkg/dashboard/sso_handoff_test.go
@@ -109,7 +109,7 @@ func TestSSOHandoff_ValidTokenLandsOnRootWithSession(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			s := newSSOServer(t, tc.hubProxied, tc.authToken, tc.authorized...)
-			tok := hub.MintSSOToken(hub.SpokeSSOKey(), "clubanderson", config.RoleOwner, testHiveID, time.Now())
+			tok := hub.MintSSOToken(hub.SSOSigningSeedFromMaster(testHubSecret), "clubanderson", config.RoleOwner, testHiveID, time.Now())
 			if tok == "" {
 				t.Fatal("failed to mint handoff token")
 			}
@@ -183,7 +183,7 @@ func TestSSOHandoff_LandingRequestIsAuthenticated(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			s := newSSOServer(t, tc.hubProxied, tc.authToken, tc.authorized...)
-			tok := hub.MintSSOToken(hub.SpokeSSOKey(), "clubanderson", config.RoleOwner, testHiveID, time.Now())
+			tok := hub.MintSSOToken(hub.SSOSigningSeedFromMaster(testHubSecret), "clubanderson", config.RoleOwner, testHiveID, time.Now())
 			w := ssoGet(t, s, "token="+tok)
 			c := sessionCookie(w)
 			if c == nil {
@@ -214,7 +214,7 @@ func TestSSOHandoff_LandingRequestIsAuthenticated(t *testing.T) {
 // of them may emit a redirect, because a redirect is what spins the browser.
 func TestSSOHandoff_FailuresTerminateWithoutRedirecting(t *testing.T) {
 	validTok := func() string {
-		return hub.MintSSOToken(hub.SpokeSSOKey(), "clubanderson", config.RoleOwner, testHiveID, time.Now())
+		return hub.MintSSOToken(hub.SSOSigningSeedFromMaster(testHubSecret), "clubanderson", config.RoleOwner, testHiveID, time.Now())
 	}
 
 	tests := []struct {
@@ -243,11 +243,13 @@ func TestSSOHandoff_FailuresTerminateWithoutRedirecting(t *testing.T) {
 			wantCode:   ssoErrBadToken,
 		},
 		{
-			name:       "token signed with the wrong secret",
+			name:       "token signed with the wrong key",
 			hubProxied: true,
 			hubSecret:  testHubSecret,
 			query: func() string {
-				return "token=" + hub.MintSSOToken("a-different-secret", "clubanderson", config.RoleOwner, testHiveID, time.Now())
+				// A validly-signed token, but under a DIFFERENT hub master's seed:
+				// its Ed25519 signature must not verify against this spoke's key.
+				return "token=" + hub.MintSSOToken(hub.SSOSigningSeedFromMaster("a-different-master"), "clubanderson", config.RoleOwner, testHiveID, time.Now())
 			},
 			wantStatus: http.StatusUnauthorized,
 			wantCode:   ssoErrBadToken,
@@ -257,7 +259,7 @@ func TestSSOHandoff_FailuresTerminateWithoutRedirecting(t *testing.T) {
 			hubProxied: true,
 			hubSecret:  testHubSecret,
 			query: func() string {
-				return "token=" + hub.MintSSOToken(hub.SpokeSSOKey(), "clubanderson", config.RoleOwner, "some-other-hive", time.Now())
+				return "token=" + hub.MintSSOToken(hub.SSOSigningSeedFromMaster(testHubSecret), "clubanderson", config.RoleOwner, "some-other-hive", time.Now())
 			},
 			wantStatus: http.StatusUnauthorized,
 			wantCode:   ssoErrBadToken,
@@ -269,7 +271,7 @@ func TestSSOHandoff_FailuresTerminateWithoutRedirecting(t *testing.T) {
 			query: func() string {
 				// Minted far enough in the past that any sane TTL has lapsed.
 				const wellPastAnyTTL = -24 * time.Hour
-				return "token=" + hub.MintSSOToken(hub.SpokeSSOKey(), "clubanderson", config.RoleOwner, testHiveID, time.Now().Add(wellPastAnyTTL))
+				return "token=" + hub.MintSSOToken(hub.SSOSigningSeedFromMaster(testHubSecret), "clubanderson", config.RoleOwner, testHiveID, time.Now().Add(wellPastAnyTTL))
 			},
 			wantStatus: http.StatusUnauthorized,
 			wantCode:   ssoErrBadToken,
@@ -349,7 +351,7 @@ func TestSSOHandoff_FailuresTerminateWithoutRedirecting(t *testing.T) {
 func TestSSOHandoff_HopCounterAdvances(t *testing.T) {
 	for hop := 0; hop < maxSSOHops; hop++ {
 		s := newSSOServer(t, true, "shared-secret-token")
-		tok := hub.MintSSOToken(hub.SpokeSSOKey(), "clubanderson", config.RoleOwner, testHiveID, time.Now())
+		tok := hub.MintSSOToken(hub.SSOSigningSeedFromMaster(testHubSecret), "clubanderson", config.RoleOwner, testHiveID, time.Now())
 		w := ssoGet(t, s, "token="+tok+"&"+ssoHopParam+"="+strconv.Itoa(hop))
 		if w.Code != http.StatusSeeOther {
 			t.Fatalf("hop=%d: status = %d, want 303 (still under the limit)", hop, w.Code)

--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"crypto/ed25519"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -42,6 +43,14 @@ const (
 	infoSessionKey     = "hive-session-v1"
 	infoSSOKey         = "hive-sso-v1"
 	infoImpersonateKey = "hive-impersonate-v1"
+
+	// infoSSOEd25519Seed derives the SSO signing SEED for the C2 follow-up: SSO is
+	// now ASYMMETRIC. deriveDomainKey(master, infoSSOEd25519Seed) yields a 32-byte
+	// (hex) value used verbatim as the Ed25519 seed (ed25519.SeedSize == 32, and a
+	// SHA-256 HMAC is exactly 32 bytes), so the hub's SSO keypair is deterministic
+	// in the existing master — no new secret, no rotation. Distinct label from the
+	// legacy symmetric infoSSOKey so the two can never derive to the same bytes.
+	infoSSOEd25519Seed = "hive-sso-ed25519-v1"
 )
 
 // deriveDomainKey returns a domain-separated sub-key of master for the given
@@ -69,12 +78,34 @@ func (s *HubServer) sessionKey() string {
 	return deriveDomainKey(s.hubSecret, infoSessionKey)
 }
 
-func (s *HubServer) ssoKey() string {
-	return deriveDomainKey(s.hubSecret, infoSSOKey)
+// ssoSigningSeed returns the hex-encoded 32-byte Ed25519 SEED the hub signs SSO
+// handoff tokens with (C2 follow-up: SSO is asymmetric). This is PRIVATE-key
+// material and must NEVER be injected into a spoke — spokes get only the public
+// key (SpokeSSOPublicKey / provisionSSOPublicKey). Returns "" for an empty master
+// so minting stays fail-closed.
+func (s *HubServer) ssoSigningSeed() string {
+	return deriveDomainKey(s.hubSecret, infoSSOEd25519Seed)
 }
 
 func (s *HubServer) impersonateKey() string {
 	return deriveDomainKey(s.hubSecret, infoImpersonateKey)
+}
+
+// ssoPublicKeyFromSeed expands a hex Ed25519 seed into the hex-encoded 32-byte
+// public key. Returns "" if seedHex is not a valid 32-byte seed. Used by both the
+// hub-side public-key accessor and provisioning so the spoke and hub agree on the
+// exact public key derived from one master.
+func ssoPublicKeyFromSeed(seedHex string) string {
+	seed, err := hex.DecodeString(strings.TrimSpace(seedHex))
+	if err != nil || len(seed) != ed25519.SeedSize {
+		return ""
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		return ""
+	}
+	return hex.EncodeToString(pub)
 }
 
 // Dedicated spoke-side env vars. A hub-hosted spoke is provisioned with ONLY the
@@ -84,7 +115,14 @@ func (s *HubServer) impersonateKey() string {
 const (
 	EnvHeartbeatKey = "HIVE_HEARTBEAT_KEY"
 	EnvSessionKey   = "HIVE_SESSION_KEY"
-	EnvSSOKey       = "HIVE_SSO_KEY"
+	// EnvSSOPublicKey carries the Ed25519 PUBLIC key a spoke verifies SSO handoff
+	// tokens with (C2 follow-up). It replaces the old symmetric HIVE_SSO_KEY: a
+	// spoke holding only the public key can verify hub-minted tokens but CANNOT mint
+	// any. EnvSSOKeyLegacy is still read for one release so spokes rolling on an old
+	// Deployment (symmetric HIVE_SSO_KEY, pre-cutover hub) keep working until the hub
+	// re-provisions them with the public key.
+	EnvSSOPublicKey = "HIVE_SSO_PUBLIC_KEY"
+	EnvSSOKeyLegacy = "HIVE_SSO_KEY"
 )
 
 // spokeDomainKey resolves a domain sub-key for spoke-side code. It prefers the
@@ -111,9 +149,39 @@ func SpokeHeartbeatKey() string { return spokeDomainKey(EnvHeartbeatKey, infoHea
 // `hive_hub_user` session/terminal cookie. It signs nothing on the spoke.
 func SpokeSessionKey() string { return spokeDomainKey(EnvSessionKey, infoSessionKey) }
 
-// SpokeSSOKey returns the key a spoke uses to VERIFY a hub-minted SSO handoff
-// token. It signs nothing on the spoke.
-func SpokeSSOKey() string { return spokeDomainKey(EnvSSOKey, infoSSOKey) }
+// SpokeSSOPublicKey returns the Ed25519 PUBLIC key a spoke uses to VERIFY a
+// hub-minted SSO handoff token (C2 follow-up: SSO is asymmetric). It signs nothing
+// on the spoke and — unlike the old symmetric key — cannot be used to mint a token
+// even by a hostile spoke operator who reads it from the pod env.
+//
+// Resolution order:
+//  1. HIVE_SSO_PUBLIC_KEY — the modern, least-privilege injection (public key only).
+//  2. Derive from HIVE_HUB_SECRET — for self-hosted hives whose operator legitimately
+//     holds the master and points SSO at their own hub, and for any spoke rolling on
+//     an OLD Deployment that injected the master before the C2 change. The spoke
+//     derives the SAME public key the hub signs against, so verification succeeds.
+//
+// It deliberately does NOT fall back to the legacy symmetric HIVE_SSO_KEY: that key
+// is not an Ed25519 public key, so it can neither verify a -v2 token nor be turned
+// into the correct public key without the master. A spoke that still holds only the
+// legacy symmetric key will get "" here and fail SSO closed until the hub
+// re-provisions it with HIVE_SSO_PUBLIC_KEY (the mint side moved to -v2 in lockstep).
+func SpokeSSOPublicKey() string {
+	if v := strings.TrimSpace(os.Getenv(EnvSSOPublicKey)); v != "" {
+		return v
+	}
+	return ssoPublicKeyFromSeed(SSOSigningSeedFromMaster(strings.TrimSpace(os.Getenv("HIVE_HUB_SECRET"))))
+}
+
+// SSOSigningSeedFromMaster derives the hex Ed25519 signing SEED from a master
+// secret. This is PRIVATE-key material: it can mint SSO tokens, so it must only be
+// used where the caller legitimately holds the master (the hub itself, or a
+// self-hosted operator's own tooling/tests). It intentionally requires the master
+// — a spoke, which holds only the public key, can never produce this seed. Returns
+// "" for an empty master (fail-closed).
+func SSOSigningSeedFromMaster(master string) string {
+	return deriveDomainKey(master, infoSSOEd25519Seed)
+}
 
 // provisionMasterSecret resolves the hub's MASTER secret at provision time, the
 // same way NewHubServer does: prefer HIVE_HUB_SECRET, else the persisted

--- a/v2/pkg/hub/hub_keys_test.go
+++ b/v2/pkg/hub/hub_keys_test.go
@@ -43,7 +43,7 @@ func TestSpokeHeartbeatKeyCannotForgeOtherDomains(t *testing.T) {
 
 	// What the hub verifies with, per domain.
 	sessionKey := deriveDomainKey(master, infoSessionKey)
-	ssoKey := deriveDomainKey(master, infoSSOKey)
+	ssoPubKey := ssoPublicKeyFromSeed(SSOSigningSeedFromMaster(master))
 	impersonateKey := deriveDomainKey(master, infoImpersonateKey)
 
 	// What a spoke actually holds (all it is injected).
@@ -56,10 +56,12 @@ func TestSpokeHeartbeatKeyCannotForgeOtherDomains(t *testing.T) {
 		t.Error("spoke heartbeat key forged a valid hub SESSION cookie")
 	}
 
-	// 2. SSO token: a token minted with the spoke's heartbeat key must NOT verify
-	//    against the hub's SSO key.
+	// 2. SSO token: a token the spoke tries to mint using its heartbeat key as a
+	//    signing seed must NOT verify against the hub's SSO PUBLIC key. (SSO is now
+	//    asymmetric: the spoke holds only the public key and no signing seed at all,
+	//    so this also stands in for "spoke has no private material to sign with".)
 	forgedSSO := MintSSOToken(spokeHeartbeatKey, "victim-owner", "owner", "hive-x", now)
-	if _, _, err := VerifySSOToken(ssoKey, forgedSSO, "hive-x", now); err == nil {
+	if _, _, err := VerifySSOToken(ssoPubKey, forgedSSO, "hive-x", now); err == nil {
 		t.Error("spoke heartbeat key forged a valid SSO handoff token")
 	}
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2856,7 +2856,7 @@ func (s *HubServer) handleOpenHive(w http.ResponseWriter, r *http.Request) {
 	// Mint the handoff token. Without a hub secret we can't sign one, so fall
 	// back to a plain dashboard redirect (spoke will prompt for login).
 	if s.hubSecret != "" {
-		if tok := MintSSOToken(s.ssoKey(), username, role, id, time.Now()); tok != "" {
+		if tok := MintSSOToken(s.ssoSigningSeed(), username, role, id, time.Now()); tok != "" {
 			http.Redirect(w, r, base+"/sso?token="+url.QueryEscape(tok), http.StatusSeeOther)
 			return
 		}

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1423,16 +1423,20 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 			return hex.EncodeToString(b)
 		}(),
 		// C2 domain separation (CWE-321/798): the spoke Deployment is injected ONLY
-		// the derived sub-keys it needs — the heartbeat bearer, plus the session and
-		// SSO verification keys — and NEVER the master HIVE_HUB_SECRET. A spoke
-		// operator can read its pod env, but those keys can only prove
-		// "I am a provisioned spoke" / verify hub-minted cookies and tokens; they
-		// cannot mint an admin session, an SSO-as-any-owner token, or an
+		// the derived sub-keys it needs — the heartbeat bearer, plus the session
+		// verification key and the SSO PUBLIC key — and NEVER the master
+		// HIVE_HUB_SECRET. A spoke operator can read its pod env, but those keys can
+		// only prove "I am a provisioned spoke" / VERIFY hub-minted cookies and
+		// tokens; they cannot mint an admin session, an SSO-as-any-owner token, or an
 		// impersonation grant (the impersonation key is hub-only and never derived
 		// here). The master, which could sign all of the above, stays on the hub.
+		//
+		// C2 follow-up: SSO is asymmetric — the spoke gets only the Ed25519 PUBLIC
+		// key (SSOPublicKey), derived from the same master seed the hub signs with,
+		// so even a hostile spoke operator holding this value cannot mint a token.
 		"HeartbeatKey": deriveDomainKey(provisionMasterSecret(), infoHeartbeatKey),
 		"SessionKey":   deriveDomainKey(provisionMasterSecret(), infoSessionKey),
-		"SSOKey":       deriveDomainKey(provisionMasterSecret(), infoSSOKey),
+		"SSOPublicKey": ssoPublicKeyFromSeed(deriveDomainKey(provisionMasterSecret(), infoSSOEd25519Seed)),
 		// Cluster-aware fields.
 		"DashboardHost":      dashboardHost,
 		"DashboardURL":       dashboardURL,
@@ -2234,23 +2238,26 @@ spec:
           value: https://hive.kubestellar.io
         # C2 domain separation: derived per-domain sub-keys ONLY — never the
         # master HIVE_HUB_SECRET. HEARTBEAT authenticates beats to the hub;
-        # SESSION/SSO verify hub-minted cookies and handoff tokens. None of these
-        # can forge a hub admin session, an SSO-as-any-owner token, or an
-        # impersonation grant.
+        # SESSION verifies hub-minted cookies. SSO is ASYMMETRIC (C2 follow-up):
+        # the spoke gets the Ed25519 PUBLIC key and can only VERIFY hub-minted
+        # handoff tokens — it cannot mint one. None of these can forge a hub admin
+        # session, an SSO-as-any-owner token, or an impersonation grant.
         - name: HIVE_HEARTBEAT_KEY
           value: "{{.HeartbeatKey}}"
         - name: HIVE_SESSION_KEY
           value: "{{.SessionKey}}"
-        - name: HIVE_SSO_KEY
-          value: "{{.SSOKey}}"
+        # C2 asymmetric SSO: spokes receive only the Ed25519 PUBLIC key and
+        # therefore cannot mint SSO tokens (only the hub, holding the private
+        # seed, can). Replaces the earlier symmetric HIVE_SSO_KEY.
+        - name: HIVE_SSO_PUBLIC_KEY
+          value: "{{.SSOPublicKey}}"
 {{- if .IsNginxIngress}}
         # HIVE_INGRESS_AUTHZ tells the Node proxy that an nginx ingress
         # auth-proxy sits IN FRONT of this pod and per-hive-authorizes every
         # /terminal request (auth-url=auth-check?hive={{.ID}}) before it ever
-        # reaches the proxy. Only set on the nginx lane. On the OpenShift-Route
-        # lane there is NO auth-proxy — the Route forwards straight to the pod —
-        # so this is unset and the proxy is the ONLY per-hive gate, which makes
-        # it fail CLOSED on an empty allowlist (see server.js). SECURITY (C3).
+        # reaches the proxy. On the OpenShift-Route lane there is NO auth-proxy,
+        # so this is unset and the proxy fails CLOSED on an empty allowlist
+        # (see server.js). SECURITY (C3).
         - name: HIVE_INGRESS_AUTHZ
           value: "true"
 {{- end}}

--- a/v2/pkg/hub/small_gaps_coverage_test.go
+++ b/v2/pkg/hub/small_gaps_coverage_test.go
@@ -92,51 +92,53 @@ func TestReadingListMediumSource(t *testing.T) {
 // ============================================================
 
 func TestVerifySSOTokenBranches(t *testing.T) {
-	secret := "shared"
+	seed := SSOSigningSeedFromMaster("shared")
+	pub := ssoPublicKeyFromSeed(seed)
+	otherPub := ssoPublicKeyFromSeed(SSOSigningSeedFromMaster("other"))
 	now := time.Now()
-	tok := MintSSOToken(secret, "alice", "owner", "hiveA", now)
+	tok := MintSSOToken(seed, "alice", "owner", "hiveA", now)
 	if tok == "" {
 		t.Fatal("mint failed")
 	}
 
-	// Wrong secret -> bad signature.
-	if _, _, err := VerifySSOToken("other", tok, "hiveA", now); err == nil {
-		t.Error("expected bad signature with wrong secret")
+	// Wrong key -> bad signature.
+	if _, _, err := VerifySSOToken(otherPub, tok, "hiveA", now); err == nil {
+		t.Error("expected bad signature with the wrong public key")
 	}
-	// Empty secret -> no shared secret error.
+	// Empty key -> no verification key error.
 	if _, _, err := VerifySSOToken("", tok, "hiveA", now); err == nil {
-		t.Error("expected error with empty secret")
+		t.Error("expected error with empty public key")
 	}
 	// Malformed token.
-	if _, _, err := VerifySSOToken(secret, "no-dot", "hiveA", now); err == nil {
+	if _, _, err := VerifySSOToken(pub, "no-dot", "hiveA", now); err == nil {
 		t.Error("expected malformed token error")
 	}
 	// Wrong hive.
-	if _, _, err := VerifySSOToken(secret, tok, "hiveB", now); err == nil {
+	if _, _, err := VerifySSOToken(pub, tok, "hiveB", now); err == nil {
 		t.Error("expected wrong-hive error")
 	}
 	// Expired.
-	if _, _, err := VerifySSOToken(secret, tok, "hiveA", now.Add(10*time.Minute)); err == nil {
+	if _, _, err := VerifySSOToken(pub, tok, "hiveA", now.Add(10*time.Minute)); err == nil {
 		t.Error("expected expired error")
 	}
 	// Not yet valid.
-	if _, _, err := VerifySSOToken(secret, tok, "hiveA", now.Add(-10*time.Minute)); err == nil {
+	if _, _, err := VerifySSOToken(pub, tok, "hiveA", now.Add(-10*time.Minute)); err == nil {
 		t.Error("expected not-yet-valid error")
 	}
 	// Valid round trip.
-	u, role, err := VerifySSOToken(secret, tok, "hiveA", now)
+	u, role, err := VerifySSOToken(pub, tok, "hiveA", now)
 	if err != nil || u != "alice" || role != "owner" {
 		t.Errorf("valid verify failed: u=%q role=%q err=%v", u, role, err)
 	}
 
 	// Mint refuses empty inputs.
 	if MintSSOToken("", "a", "r", "h", now) != "" {
-		t.Error("mint should refuse empty secret")
+		t.Error("mint should refuse empty seed")
 	}
-	if MintSSOToken(secret, "", "r", "h", now) != "" {
+	if MintSSOToken(seed, "", "r", "h", now) != "" {
 		t.Error("mint should refuse empty username")
 	}
-	if MintSSOToken(secret, "a", "r", "", now) != "" {
+	if MintSSOToken(seed, "a", "r", "", now) != "" {
 		t.Error("mint should refuse empty hive")
 	}
 }

--- a/v2/pkg/hub/sso.go
+++ b/v2/pkg/hub/sso.go
@@ -1,28 +1,40 @@
 package hub
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
+	"crypto/ed25519"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
 )
 
-// SSO handoff: the hub mints a short-lived, HMAC-signed token that lets an
-// already-hub-authenticated admin/user open a direct-route spoke (e.g. a
-// firewalled vllm-d hive) WITHOUT a second GitHub device-flow login. The spoke
-// verifies the token with the SAME shared secret it already uses for heartbeat
-// auth (HIVE_HUB_SECRET), confirms the carried user is in its authorized_users
-// allowlist, and mints a local session. No secret ever leaves the two trusted
-// endpoints; only a signed, expiring, single-hive-scoped assertion travels in
-// the redirect URL.
+// SSO handoff: the hub mints a short-lived, ASYMMETRICALLY-signed token that lets
+// an already-hub-authenticated admin/user open a direct-route spoke (e.g. a
+// firewalled vllm-d hive) WITHOUT a second GitHub device-flow login. The hub signs
+// the token with an Ed25519 PRIVATE key that never leaves the hub; the spoke
+// verifies it with only the corresponding PUBLIC key. The spoke confirms the
+// carried user is in its authorized_users allowlist and mints a local session.
+// Only a signed, expiring, single-hive-scoped assertion travels in the redirect
+// URL — and, unlike the earlier symmetric HMAC design, the verifying spoke holds
+// NO material that could mint a token.
+//
+// C2 follow-up — why asymmetric (residual of #2758): #2758's HKDF domain
+// separation stopped cross-domain forgery and kept the master off spokes, but the
+// SSO sub-key was still SYMMETRIC — the same derived key both minted (hub) and
+// verified (spoke). A spoke operator who read HIVE_SSO_KEY from the pod env could
+// therefore mint an SSO-as-any-owner token for its OWN hive. Ed25519 closes that:
+// the spoke is injected the PUBLIC key only, so "verify hub-minted tokens" no
+// longer implies "can mint tokens". The signing seed is still derived
+// deterministically from the existing master (see ssoSigningSeed), so no new
+// secret is provisioned and the keypair is stable across restarts — there is no
+// key rotation, only a change of algorithm.
 //
 // The token is deliberately minimal and stateless (no server-side store): it
-// binds {username, role, hiveID, expiry} under HMAC-SHA256. It is NOT a bearer
-// credential for arbitrary API calls — the spoke exchanges it exactly once for
-// a normal per-user session cookie and never accepts it again for API auth.
+// binds {username, role, hiveID, expiry} under an Ed25519 signature. It is NOT a
+// bearer credential for arbitrary API calls — the spoke exchanges it exactly once
+// for a normal per-user session cookie and never accepts it again for API auth.
 
 const (
 	// ssoTokenTTL bounds how long a freshly-minted handoff token is valid. Kept
@@ -35,8 +47,10 @@ const (
 	ssoClockSkew = 30 * time.Second
 
 	// ssoTokenVersion namespaces the signed payload so the format can evolve
-	// without a verifier ever accepting an old/foreign shape.
-	ssoTokenVersion = "hive-sso-v1"
+	// without a verifier ever accepting an old/foreign shape. Bumped to -v2 for the
+	// Ed25519 cutover: a -v1 (symmetric HMAC) token can never be replayed against a
+	// -v2 verifier and vice versa.
+	ssoTokenVersion = "hive-sso-v2"
 )
 
 // ssoClaims is the signed payload of an SSO handoff token.
@@ -53,13 +67,24 @@ type ssoClaims struct {
 var ssoB64 = base64.RawURLEncoding
 
 // MintSSOToken creates a signed handoff token for username/role scoped to a
-// single hiveID, valid for ssoTokenTTL. `now` is passed in so callers can use a
-// single consistent clock (and tests are deterministic). Returns "" if secret
-// is empty — the hub must have a configured HIVE_HUB_SECRET to mint tokens.
-func MintSSOToken(secret, username, role, hiveID string, now time.Time) string {
-	if secret == "" || username == "" || hiveID == "" {
+// single hiveID, valid for ssoTokenTTL. `seedHex` is the hex-encoded 32-byte
+// Ed25519 SEED (the hub-only private-key material from ssoSigningSeed); the token
+// is signed with the private key it expands to. `now` is passed in so callers can
+// use a single consistent clock (and tests are deterministic). Returns "" if
+// seedHex is empty/not a valid 32-byte seed, or if username/hiveID are empty — a
+// caller holding only a PUBLIC key (or no key) therefore cannot produce a token.
+func MintSSOToken(seedHex, username, role, hiveID string, now time.Time) string {
+	if seedHex == "" || username == "" || hiveID == "" {
 		return ""
 	}
+	seed, err := hex.DecodeString(strings.TrimSpace(seedHex))
+	if err != nil || len(seed) != ed25519.SeedSize {
+		// Not private-key material (e.g. a public key was passed by mistake, or a
+		// truncated/garbage value): fail closed rather than sign with junk.
+		return ""
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+
 	claims := ssoClaims{
 		Version:  ssoTokenVersion,
 		Username: username,
@@ -73,28 +98,38 @@ func MintSSOToken(secret, username, role, hiveID string, now time.Time) string {
 		return ""
 	}
 	body := ssoB64.EncodeToString(payload)
-	sig := ssoSign(secret, body)
+	sig := ssoB64.EncodeToString(ed25519.Sign(priv, []byte(body)))
 	return body + "." + sig
 }
 
-// VerifySSOToken validates a handoff token against secret and the spoke's own
-// hiveID, returning the carried username and role. It fails closed on any
-// mismatch: bad signature, wrong version, expired/not-yet-valid, or a hiveID
-// that does not match THIS spoke (so a token minted for hive A can never open
-// hive B). `now` is the verifier's clock.
-func VerifySSOToken(secret, token, expectedHiveID string, now time.Time) (username, role string, err error) {
-	if secret == "" {
-		return "", "", fmt.Errorf("sso: no shared secret configured")
+// VerifySSOToken validates a handoff token against an Ed25519 PUBLIC key and the
+// spoke's own hiveID, returning the carried username and role. `pubHex` is the
+// hex-encoded 32-byte Ed25519 public key (from SpokeSSOPublicKey). It fails closed
+// on any mismatch: bad signature, wrong version, expired/not-yet-valid, or a
+// hiveID that does not match THIS spoke (so a token minted for hive A can never
+// open hive B). Because verification needs only the public key, a spoke that holds
+// pubHex cannot mint a token. `now` is the verifier's clock.
+func VerifySSOToken(pubHex, token, expectedHiveID string, now time.Time) (username, role string, err error) {
+	if pubHex == "" {
+		return "", "", fmt.Errorf("sso: no verification key configured")
+	}
+	pub, err := hex.DecodeString(strings.TrimSpace(pubHex))
+	if err != nil || len(pub) != ed25519.PublicKeySize {
+		return "", "", fmt.Errorf("sso: invalid verification key")
 	}
 	parts := strings.SplitN(token, ".", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return "", "", fmt.Errorf("sso: malformed token")
 	}
-	body, sig := parts[0], parts[1]
+	body, sigB64 := parts[0], parts[1]
 
-	// Constant-time signature check BEFORE trusting any payload bytes.
-	expected := ssoSign(secret, body)
-	if !hmac.Equal([]byte(sig), []byte(expected)) {
+	// Verify the Ed25519 signature BEFORE trusting any payload bytes. ed25519.Verify
+	// is constant-time and safe on attacker-controlled input.
+	sig, err := ssoB64.DecodeString(sigB64)
+	if err != nil || len(sig) != ed25519.SignatureSize {
+		return "", "", fmt.Errorf("sso: bad signature")
+	}
+	if !ed25519.Verify(ed25519.PublicKey(pub), []byte(body), sig) {
 		return "", "", fmt.Errorf("sso: bad signature")
 	}
 
@@ -124,11 +159,4 @@ func VerifySSOToken(secret, token, expectedHiveID string, now time.Time) (userna
 		return "", "", fmt.Errorf("sso: token expired")
 	}
 	return claims.Username, claims.Role, nil
-}
-
-// ssoSign returns the URL-safe base64 HMAC-SHA256 of body under secret.
-func ssoSign(secret, body string) string {
-	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(body))
-	return ssoB64.EncodeToString(mac.Sum(nil))
 }

--- a/v2/pkg/hub/sso_test.go
+++ b/v2/pkg/hub/sso_test.go
@@ -5,14 +5,23 @@ import (
 	"time"
 )
 
+// ssoTestKeypair derives a matching {signing seed, public key} pair the way the
+// hub does from a master. mint uses the seed (private material, hub-only); verify
+// uses the public key (what a spoke is injected).
+func ssoTestKeypair(master string) (seedHex, pubHex string) {
+	seedHex = SSOSigningSeedFromMaster(master)
+	pubHex = ssoPublicKeyFromSeed(seedHex)
+	return seedHex, pubHex
+}
+
 func TestSSOTokenRoundTrip(t *testing.T) {
-	secret := "shared-hub-secret-abc123"
+	seed, pub := ssoTestKeypair("shared-hub-secret-abc123")
 	now := time.Unix(1_700_000_000, 0)
-	tok := MintSSOToken(secret, "alice", "owner", "hosted-hive-1", now)
+	tok := MintSSOToken(seed, "alice", "owner", "hosted-hive-1", now)
 	if tok == "" {
 		t.Fatal("expected a token")
 	}
-	user, role, err := VerifySSOToken(secret, tok, "hosted-hive-1", now)
+	user, role, err := VerifySSOToken(pub, tok, "hosted-hive-1", now)
 	if err != nil {
 		t.Fatalf("verify failed: %v", err)
 	}
@@ -21,38 +30,63 @@ func TestSSOTokenRoundTrip(t *testing.T) {
 	}
 }
 
-func TestSSOTokenRejectsWrongHive(t *testing.T) {
-	secret := "s"
+// TestSSOSpokeWithPublicKeyCannotMint is the core C2 follow-up guarantee: a spoke
+// holds ONLY the Ed25519 public key. Handing that public key to the mint path must
+// NOT produce a token that verifies — the spoke has no private material to sign
+// with, so it cannot forge an SSO-as-any-owner handoff for its own hive.
+func TestSSOSpokeWithPublicKeyCannotMint(t *testing.T) {
+	seed, pub := ssoTestKeypair("the-hub-master")
 	now := time.Unix(1_700_000_000, 0)
-	tok := MintSSOToken(secret, "alice", "owner", "hive-A", now)
-	if _, _, err := VerifySSOToken(secret, tok, "hive-B", now); err == nil {
+
+	// A spoke, holding only `pub`, attempts to mint. Whatever comes out must not
+	// verify against the real public key.
+	forged := MintSSOToken(pub, "attacker", "owner", "hive-x", now)
+	if _, _, err := VerifySSOToken(pub, forged, "hive-x", now); err == nil {
+		t.Fatal("a token minted with only the public key must NOT verify")
+	}
+
+	// Sanity: the real private seed DOES mint a token the public key verifies, so
+	// the negative above is about lacking the private key, not a broken primitive.
+	good := MintSSOToken(seed, "alice", "owner", "hive-x", now)
+	if _, _, err := VerifySSOToken(pub, good, "hive-x", now); err != nil {
+		t.Fatalf("hub-minted token failed to verify with the public key: %v", err)
+	}
+}
+
+func TestSSOTokenRejectsWrongHive(t *testing.T) {
+	seed, pub := ssoTestKeypair("s")
+	now := time.Unix(1_700_000_000, 0)
+	tok := MintSSOToken(seed, "alice", "owner", "hive-A", now)
+	if _, _, err := VerifySSOToken(pub, tok, "hive-B", now); err == nil {
 		t.Fatal("expected rejection for a token minted for a different hive")
 	}
 }
 
-func TestSSOTokenRejectsWrongSecret(t *testing.T) {
+func TestSSOTokenRejectsWrongKey(t *testing.T) {
+	seed1, _ := ssoTestKeypair("secret-1")
+	_, pub2 := ssoTestKeypair("secret-2")
 	now := time.Unix(1_700_000_000, 0)
-	tok := MintSSOToken("secret-1", "alice", "owner", "hive-1", now)
-	if _, _, err := VerifySSOToken("secret-2", tok, "hive-1", now); err == nil {
-		t.Fatal("expected rejection under a different secret")
+	tok := MintSSOToken(seed1, "alice", "owner", "hive-1", now)
+	if _, _, err := VerifySSOToken(pub2, tok, "hive-1", now); err == nil {
+		t.Fatal("expected rejection under a different keypair's public key")
 	}
 }
 
 func TestSSOTokenRejectsExpired(t *testing.T) {
-	secret := "s"
+	seed, pub := ssoTestKeypair("s")
 	now := time.Unix(1_700_000_000, 0)
-	tok := MintSSOToken(secret, "alice", "owner", "hive-1", now)
+	tok := MintSSOToken(seed, "alice", "owner", "hive-1", now)
 	// Verify well past expiry (TTL + skew).
 	later := now.Add(ssoTokenTTL + ssoClockSkew + time.Second)
-	if _, _, err := VerifySSOToken(secret, tok, "hive-1", later); err == nil {
+	if _, _, err := VerifySSOToken(pub, tok, "hive-1", later); err == nil {
 		t.Fatal("expected rejection for an expired token")
 	}
 }
 
 func TestSSOTokenRejectsTamper(t *testing.T) {
-	secret := "s"
+	seed, pub := ssoTestKeypair("s")
 	now := time.Unix(1_700_000_000, 0)
-	tok := MintSSOToken(secret, "alice", "read", "hive-1", now)
+	tok := MintSSOToken(seed, "alice", "read", "hive-1", now)
 	// Flip a byte in the payload; signature must no longer match.
 	b := []byte(tok)
 	// mutate an early char that is part of the payload, not the '.' separator
@@ -61,23 +95,28 @@ func TestSSOTokenRejectsTamper(t *testing.T) {
 	} else {
 		b[0] = 'A'
 	}
-	if _, _, err := VerifySSOToken(secret, string(b), "hive-1", now); err == nil {
+	if _, _, err := VerifySSOToken(pub, string(b), "hive-1", now); err == nil {
 		t.Fatal("expected rejection for a tampered token")
 	}
 }
 
 func TestSSOTokenEmptyInputs(t *testing.T) {
+	seed, pub := ssoTestKeypair("s")
 	now := time.Unix(1_700_000_000, 0)
 	if MintSSOToken("", "alice", "owner", "hive-1", now) != "" {
-		t.Fatal("empty secret must not mint a token")
+		t.Fatal("empty seed must not mint a token")
 	}
-	if MintSSOToken("s", "", "owner", "hive-1", now) != "" {
+	if MintSSOToken(seed, "", "owner", "hive-1", now) != "" {
 		t.Fatal("empty username must not mint a token")
 	}
-	if _, _, err := VerifySSOToken("", "x.y", "hive-1", now); err == nil {
-		t.Fatal("empty secret must not verify")
+	// A non-seed value (not 32-byte hex) must fail closed on mint.
+	if MintSSOToken("not-a-valid-seed", "alice", "owner", "hive-1", now) != "" {
+		t.Fatal("a non-seed value must not mint a token")
 	}
-	if _, _, err := VerifySSOToken("s", "malformed", "hive-1", now); err == nil {
+	if _, _, err := VerifySSOToken("", "x.y", "hive-1", now); err == nil {
+		t.Fatal("empty public key must not verify")
+	}
+	if _, _, err := VerifySSOToken(pub, "malformed", "hive-1", now); err == nil {
 		t.Fatal("malformed token must not verify")
 	}
 }


### PR DESCRIPTION
Follow-up to the merged C2 domain-separation (#2758). Converts the SSO handoff from symmetric HMAC to **asymmetric Ed25519**: hub signs with a seed derived deterministically from the master (no key rotation), spokes receive only the PUBLIC key and therefore **cannot mint** SSO tokens (verified by `TestSSOSpokeWithPublicKeyCannotMint`). Rebased onto v4 after #2758 merged (the original #2761 auto-closed when its base branch was deleted). No key rotation — code-only.