### PR TITLE
🐛 fix(agent): floor-guard killAgentProcesses against root/system UIDs (#2743)

### DIFF
--- a/v2/pkg/agent/kill_floor_guard_test.go
+++ b/v2/pkg/agent/kill_floor_guard_test.go
@@ -1,0 +1,114 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// writeFakeProcEntry creates <root>/<pid>/status with the given owner UID,
+// mimicking the two fields killAgentProcesses reads from a real /proc.
+func writeFakeProcEntry(t *testing.T, root string, pid, ownerUID int) {
+	t.Helper()
+	dir := filepath.Join(root, fmt.Sprintf("%d", pid))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir fake proc entry: %v", err)
+	}
+	// Real /proc status has many lines; killAgentProcesses only parses "Uid:".
+	status := fmt.Sprintf("Name:\tsleep\nPid:\t%d\nUid:\t%d\t%d\t%d\t%d\n", pid, ownerUID, ownerUID, ownerUID, ownerUID)
+	if err := os.WriteFile(filepath.Join(dir, "status"), []byte(status), 0o644); err != nil {
+		t.Fatalf("write fake status: %v", err)
+	}
+}
+
+// withProcRoot points the package-level procRoot at a temp dir for the duration
+// of the test, restoring it afterward.
+func withProcRoot(t *testing.T, root string) {
+	t.Helper()
+	orig := procRoot
+	procRoot = root
+	t.Cleanup(func() { procRoot = orig })
+}
+
+// TestKillAgentProcesses_FloorGuard is the regression for kubestellar/hive#2743
+// (candidate #1): killAgentProcesses(0) and any uid < minAgentUID must kill
+// NOTHING even when a fake /proc contains a process owned by that UID. Before
+// the fix, running as root this SIGKILLed every root-owned process (hive, PID 1,
+// the tmux server). The floor guard makes it a guaranteed no-op.
+func TestKillAgentProcesses_FloorGuard(t *testing.T) {
+	// Spawn a real, long-lived child we can safely try to "kill". If the guard
+	// leaks, this process would receive SIGKILL; if it holds, it stays alive.
+	victim := exec.Command("/bin/sleep", "3600")
+	if err := victim.Start(); err != nil {
+		t.Skipf("could not start victim process: %v", err)
+	}
+	defer func() { _ = victim.Process.Kill() }()
+	victimPID := victim.Process.Pid
+
+	root := t.TempDir()
+	withProcRoot(t, root)
+
+	// Sub-floor UIDs the guard must refuse — including the exploitable root (0).
+	subFloorUIDs := []int{0, 1, proxyUserUID, minAgentUID - 1}
+	for _, uid := range subFloorUIDs {
+		// Make the fake proc entry OWNED by the queried uid, so only the floor
+		// guard — not an ownership mismatch — can prevent the kill.
+		writeFakeProcEntry(t, root, victimPID, uid)
+
+		killed := killAgentProcesses(uid, discardLogger())
+		if killed != 0 {
+			t.Errorf("killAgentProcesses(%d) returned %d, want 0 (floor guard must block)", uid, killed)
+		}
+		if !processAlive(victimPID) {
+			t.Fatalf("killAgentProcesses(%d) SIGKILLed a uid<%d process (pid %d) — floor guard leaked",
+				uid, minAgentUID, victimPID)
+		}
+	}
+}
+
+// TestKillAgentProcesses_SelfSkip ensures the sweep never SIGKILLs the hive
+// process itself, even when our own PID appears in /proc owned by an agent UID.
+func TestKillAgentProcesses_SelfSkip(t *testing.T) {
+	root := t.TempDir()
+	withProcRoot(t, root)
+
+	// Our own PID, reported as owned by a legitimate agent UID (>= minAgentUID).
+	writeFakeProcEntry(t, root, os.Getpid(), minAgentUID)
+
+	killed := killAgentProcesses(minAgentUID, discardLogger())
+	if killed != 0 {
+		t.Errorf("killAgentProcesses matched and killed %d process(es); must self-skip own PID", killed)
+	}
+}
+
+// TestKillAgentProcesses_KillsAgentUID confirms the guard does not over-block:
+// a real per-agent UID (>= minAgentUID) still sweeps a matching process. Uses a
+// spawned child and a fake /proc entry reporting that child's PID.
+func TestKillAgentProcesses_KillsAgentUID(t *testing.T) {
+	victim := exec.Command("/bin/sleep", "3600")
+	if err := victim.Start(); err != nil {
+		t.Skipf("could not start victim process: %v", err)
+	}
+	defer func() { _ = victim.Process.Kill() }()
+	victimPID := victim.Process.Pid
+
+	root := t.TempDir()
+	withProcRoot(t, root)
+	// Report the child as owned by a valid agent UID above the floor.
+	writeFakeProcEntry(t, root, victimPID, minAgentUID+5)
+
+	killed := killAgentProcesses(minAgentUID+5, discardLogger())
+	if killed != 1 {
+		t.Fatalf("killAgentProcesses returned %d, want 1 (should kill the matching agent process)", killed)
+	}
+
+	// Confirm the SIGKILL landed. Wait reaps the zombie; a non-nil error is proof.
+	if waitErr := victim.Wait(); waitErr == nil {
+		t.Errorf("victim exited cleanly; expected SIGKILL from killAgentProcesses")
+	} else if ws, ok := exitSignal(waitErr); ok && ws != syscall.SIGKILL {
+		t.Errorf("victim killed by %v, want SIGKILL", ws)
+	}
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -4010,7 +4010,13 @@ func matchesAuthError(output string) bool {
 func (m *Manager) runCopilotDiagnostic(ctx context.Context, agent *AgentProcess) {
 	m.tmuxSendKeysForAgent(agent, "C-c", "")
 	time.Sleep(paneCaptureSleep)
-	killAgentProcesses(agent.UID, m.logger)
+	// Only sweep by UID when isolation gave this agent a real per-agent UID.
+	// agent.UID==0 (isolation off or agent missing from the UID map) would
+	// otherwise ask killAgentProcesses to match root — the internal floor guard
+	// blocks it, but skipping the call makes the intent explicit.
+	if agent.UID > 0 {
+		killAgentProcesses(agent.UID, m.logger)
+	}
 	_ = m.tmuxCmd(agent, "kill-session", "-t", agent.tmuxSession).Run()
 
 	if err := m.ensureTmuxSession(agent); err != nil {
@@ -4061,7 +4067,9 @@ func (m *Manager) runCopilotDiagnostic(ctx context.Context, agent *AgentProcess)
 				continue
 			}
 
-			killAgentProcesses(agent.UID, m.logger)
+			if agent.UID > 0 {
+				killAgentProcesses(agent.UID, m.logger)
+			}
 			_ = m.tmuxCmd(agent, "kill-session", "-t", agent.tmuxSession).Run()
 			agent.forceRelaunch = true
 			if err := m.Restart(ctx, agent.Name); err != nil {
@@ -5104,9 +5112,10 @@ func (m *Manager) RestartWithBootstrap(ctx context.Context, name, prompt string)
 
 	// Terminate the agent's CLI process(es) before recreating the session.
 	// reapAgentCLI matches by the HIVE_AGENT env marker, so it works whether or
-	// not UID isolation is enabled — killAgentProcesses (UID-based) is a no-op
-	// when agents share the dev UID, which let stale claude processes on old
-	// models survive a model/backend switch and keep hitting the gateway.
+	// not UID isolation is enabled. killAgentProcesses (UID-based) is only safe
+	// to call with a real per-agent UID: it now floor-guards uid < minAgentUID
+	// and refuses to run for system/shared UIDs (as root it would otherwise
+	// SIGKILL root-owned processes), so we gate the call on agent.UID > 0 below.
 	reaped := m.reapAgentCLI(agent)
 	if agent.UID > 0 {
 		// UID isolation on: also sweep any non-CLI helper processes (MCP
@@ -5274,10 +5283,33 @@ func environHasMarker(environ, marker string) bool {
 	return false
 }
 
+// minAgentUID is the lowest UID killAgentProcesses will ever target. Per-agent
+// UIDs are allocated from baseAgentUID (2001) upward, so any uid below this
+// belongs to the system (root=0, the proxy user, etc.). Refusing to match on a
+// sub-range UID guarantees that a stray killAgentProcesses(0) — which happens
+// when UID isolation is off or an agent is missing from the UID map — can never
+// SIGKILL root-owned processes (hive itself, PID 1, the shared tmux server).
+const minAgentUID = baseAgentUID
+
 // killAgentProcesses finds all processes owned by the given UID via /proc and
 // sends SIGKILL to each. Hung copilot binaries ignore SIGINT, so brute-force
 // cleanup is needed to prevent orphan accumulation on the shared SQLite store.
+//
+// The function is EPERM-safe only for unprivileged callers; hive runs as root,
+// so it is NOT inherently a no-op for shared/system UIDs. A floor guard
+// (uid >= minAgentUID) plus a self-skip (never SIGKILL our own PID) are the
+// real defenses that keep uid < minAgentUID from touching system processes.
 func killAgentProcesses(uid int, logger *slog.Logger) int {
+	// Floor guard: refuse to sweep by a system-range UID. uid==0 (root) reaches
+	// here when UID isolation is disabled or LookupByName missed the agent; as
+	// root, matching ownerUID==0 would SIGKILL every root process. This is a real
+	// bug signal, so warn loudly and kill nothing.
+	if uid < minAgentUID {
+		logger.Warn("refusing to kill by uid, would target system/root processes",
+			"uid", uid, "min_agent_uid", minAgentUID)
+		return 0
+	}
+
 	procPath := procRoot
 	entries, err := os.ReadDir(procPath)
 	if err != nil {
@@ -5292,6 +5324,11 @@ func killAgentProcesses(uid int, logger *slog.Logger) int {
 		}
 		pid, err := strconv.Atoi(entry.Name())
 		if err != nil {
+			continue
+		}
+		// Belt-and-suspenders: never SIGKILL the hive process itself, mirroring
+		// reapAgentCLI's self-skip.
+		if pid == os.Getpid() {
 			continue
 		}
 
@@ -5346,9 +5383,10 @@ func (m *Manager) Restart(ctx context.Context, name string) error {
 
 	// Terminate the agent's CLI process(es) before recreating the session.
 	// reapAgentCLI matches by the HIVE_AGENT env marker, so it works whether or
-	// not UID isolation is enabled — killAgentProcesses (UID-based) is a no-op
-	// when agents share the dev UID, which let stale claude processes on old
-	// models survive a model/backend switch and keep hitting the gateway.
+	// not UID isolation is enabled. killAgentProcesses (UID-based) is only safe
+	// to call with a real per-agent UID: it now floor-guards uid < minAgentUID
+	// and refuses to run for system/shared UIDs (as root it would otherwise
+	// SIGKILL root-owned processes), so we gate the call on agent.UID > 0 below.
 	reaped := m.reapAgentCLI(agent)
 	if agent.UID > 0 {
 		// UID isolation on: also sweep any non-CLI helper processes (MCP


### PR DESCRIPTION
## The bug (issue #2743, candidate #1 — the critical exploitable path)

`killAgentProcesses(uid, logger)` in `v2/pkg/agent/manager.go` walked `/proc` and sent `SIGKILL` to **every process whose owner UID == the argument**, with **no floor guard** and **no self-skip**. Two call sites in `runCopilotDiagnostic` invoked it **without** the `agent.UID > 0` guard other sites use.

`agent.UID` is `0` whenever UID isolation is off **or** the agent is missing from the UID map (`LookupByName` returns 0 on a miss, and `NewManager` treats that as normal). Hive's container runs as **root**, so a copilot-backend auth-failure diagnostic → `killAgentProcesses(0)` → SIGKILLed **every uid-0 process**: the shared tmux server (all sessions, including ones hive didn't create and the user's own), hive itself, and **PID 1**. Observed live.

The old comment claiming it was a no-op "when agents share the dev UID" was **false as root** (only true unprivileged, via EPERM). Its sibling `reapAgentCLI` already has an `os.Getpid()` self-skip that `killAgentProcesses` lacked.

## The fix

1. **Floor guard inside `killAgentProcesses`** — refuse to run for `uid < minAgentUID` (`= baseAgentUID`, 2001; per-agent UIDs are allocated from 2001 up). Logs a WARNING (`"refusing to kill by uid, would target system/root processes"`) and returns 0 without killing. Makes `killAgentProcesses(0)` a guaranteed no-op even as root.
2. **Self-skip** — `if pid == os.Getpid() { continue }`, mirroring `reapAgentCLI`; belt-and-suspenders against killing the hive process.
3. **Guard both `runCopilotDiagnostic` call sites** with `if agent.UID > 0 { … }` so intent is explicit and the pointless call is skipped.
4. **Corrected the misleading comment** in `Restart` — it is only EPERM-safe unprivileged, and is now floor-guarded.

## Regression tests

`v2/pkg/agent/kill_floor_guard_test.go` drives `killAgentProcesses` against a **fake `/proc` root** (injected via the existing `procRoot` package var):

- `TestKillAgentProcesses_FloorGuard` — for `uid ∈ {0, 1, proxyUserUID, minAgentUID-1}`, even with a fake `/proc` entry **owned by that UID**, returns 0 and leaves a real spawned process alive.
- `TestKillAgentProcesses_SelfSkip` — with our own PID in the fake `/proc` under a valid agent UID, kills nothing.
- `TestKillAgentProcesses_KillsAgentUID` — a valid per-agent UID (≥ floor) still sweeps its matching process (guard doesn't over-block).

```
go test ./pkg/agent/ -run 'Kill|Diagnostic|Copilot' -v   # all PASS
```

## Scope

Addresses **#2743 (candidate #1)** — the critical, exploitable root-kill path. Candidates #2–5 are separate and remain open; this PR does not close the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)