### PR TITLE
hub(v2): dual-path auth so the v2 hub can authenticate v4 spokes

### DIFF
--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -1,0 +1,156 @@
+package hub
+
+import (
+	"crypto/ed25519"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// Domain-separated key derivation for the hub master secret — v2 hub-side
+// backport of the v4 C2 fix (#2758) plus the Ed25519 SSO follow-up (#2771),
+// carried onto v2 so this hub can authenticate a v4 spoke that has moved to
+// derived keys.
+//
+// SCOPE OF THIS BACKPORT (deliberately hub-only): the v2 hub keeps signing the
+// legacy raw-secret heartbeat and symmetric-HMAC SSO for the 33 old hives, and
+// ADDITIONALLY derives the domain-separated keys a v4 spoke self-derives from
+// the SAME master HIVE_HUB_SECRET. It ports ONLY what the hub needs to verify a
+// v4 heartbeat bearer and mint a v4-verifiable SSO token: the four info labels,
+// deriveDomainKey, ssoPublicKeyFromSeed, SSOSigningSeedFromMaster, and the two
+// hub accessors heartbeatKey / ssoSigningSeed. The spoke-side Spoke*/spokeDomainKey/
+// Env* provisioning symbols from v4 are intentionally NOT ported — no spoke change
+// is needed here and the v2 hub never provisions derived keys into a Deployment.
+//
+// Derivation is HMAC-SHA256(master, info) rendered as lowercase hex (an
+// HKDF-Expand-style single-block expansion): deterministic, no new dependency,
+// and byte-identical to what the v4 spoke computes, so the two agree on every
+// derived key given one shared master.
+
+const (
+	// Domain-separator info strings. Each is versioned ("-v1") so the format can
+	// evolve without a verifier ever silently accepting a foreign-domain key.
+	// These constants are the contract shared with the v4 spoke (which self-derives
+	// the same keys from HIVE_HUB_SECRET), so they must match v4 verbatim.
+	infoHeartbeatKey = "hive-heartbeat-v1"
+	infoSessionKey   = "hive-session-v1"
+	infoSSOKey       = "hive-sso-v1"
+
+	// infoSSOEd25519Seed derives the SSO signing SEED for the asymmetric SSO
+	// cutover: deriveDomainKey(master, infoSSOEd25519Seed) yields a 32-byte (hex)
+	// value used verbatim as the Ed25519 seed (ed25519.SeedSize == 32, and a
+	// SHA-256 HMAC is exactly 32 bytes), so the hub's SSO keypair is deterministic
+	// in the existing master — no new secret, no rotation. Distinct label from the
+	// legacy symmetric infoSSOKey so the two can never derive to the same bytes.
+	infoSSOEd25519Seed = "hive-sso-ed25519-v1"
+)
+
+// deriveDomainKey returns a domain-separated sub-key of master for the given
+// info label, as lowercase hex. Returns "" for an empty master so callers keep
+// their existing "no secret configured → feature disabled / fail closed"
+// behavior unchanged (an empty master must never derive to a usable key).
+func deriveDomainKey(master, info string) string {
+	if master == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, []byte(master))
+	mac.Write([]byte(info))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// heartbeatKey returns the derived heartbeat bearer a v4 spoke presents on
+// /api/heartbeat and /api/task-status. The v2 hub accepts this IN ADDITION to
+// the legacy raw s.hubSecret (see heartbeatBearerOK), never instead of it.
+func (s *HubServer) heartbeatKey() string {
+	return deriveDomainKey(s.hubSecret, infoHeartbeatKey)
+}
+
+// ssoSigningSeed returns the hex-encoded 32-byte Ed25519 SEED the hub signs v4
+// SSO handoff tokens with. This is PRIVATE-key material (it can mint tokens) and
+// must never leave the hub. Returns "" for an empty master so minting stays
+// fail-closed.
+func (s *HubServer) ssoSigningSeed() string {
+	return deriveDomainKey(s.hubSecret, infoSSOEd25519Seed)
+}
+
+// ssoPublicKeyFromSeed expands a hex Ed25519 seed into the hex-encoded 32-byte
+// public key. Returns "" if seedHex is not a valid 32-byte seed. Kept for parity
+// with v4 and for tests that assert the hub and a v4 spoke derive the same
+// public key from one master.
+func ssoPublicKeyFromSeed(seedHex string) string {
+	seed, err := hex.DecodeString(strings.TrimSpace(seedHex))
+	if err != nil || len(seed) != ed25519.SeedSize {
+		return ""
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		return ""
+	}
+	return hex.EncodeToString(pub)
+}
+
+// SSOSigningSeedFromMaster derives the hex Ed25519 signing SEED from a master
+// secret. This is PRIVATE-key material: it can mint SSO tokens, so it must only
+// be used where the caller legitimately holds the master (the hub itself). It
+// intentionally requires the master. Returns "" for an empty master (fail-closed).
+func SSOSigningSeedFromMaster(master string) string {
+	return deriveDomainKey(master, infoSSOEd25519Seed)
+}
+
+// ssoEd25519HiveIDs is the transitional allowlist of hive IDs known to run a v4
+// image, i.e. spokes that verify SSO with an Ed25519 PUBLIC key and therefore
+// CANNOT verify the legacy symmetric token. It is seeded with the auto-upgraded
+// console hive; add IDs here as more hives cut over to v4.
+//
+// TRANSITIONAL: this exists only until the whole fleet is v4. The real signal is
+// the heartbeat-reported version/commit (see hiveWantsEd25519SSO), which lets a
+// hive opt in automatically once it reports a v4 build. Until every hive reports
+// a classifiable version, this positive-only allowlist keeps the DEFAULT as the
+// legacy symmetric mint (safe for the 33 old hives) and switches to Ed25519 ONLY
+// for a hive we have positively identified as v4.
+var ssoEd25519HiveIDs = map[string]bool{
+	"hosted-kubestellar-console-4vkt": true,
+}
+
+// hiveWantsEd25519SSO reports whether the hub should mint an ASYMMETRIC (Ed25519)
+// SSO token for this hive instead of the legacy symmetric one. It returns true
+// ONLY on positive identification of a v4 spoke — it fails safe to false (legacy
+// symmetric) for every hive it cannot classify, so the 33 old hives are never
+// broken. Positive signals, in order:
+//
+//  1. The explicit transitional allowlist (ssoEd25519HiveIDs) — currently the
+//     auto-upgraded console hive.
+//  2. A heartbeat-reported version/commit that indicates a v4 image. `entry` is
+//     the hive's RegistryEntry (nil if the hub has no record yet, which stays
+//     legacy). We treat the tracked v4 target commit 12c34e5 as the marker; the
+//     hub records the short git hash the spoke reports (RegistryEntry.GitHash),
+//     and the running image tag (RegistryEntry.ImageRef) is checked too so a hive
+//     pinned to a v4 SHA/tag is caught even before a commit match.
+//
+// This is transitional: once every hive reports a classifiable v4 version the
+// allowlist can be retired and this becomes purely version-driven.
+func hiveWantsEd25519SSO(hiveID string, entry *RegistryEntry) bool {
+	if ssoEd25519HiveIDs[hiveID] {
+		return true
+	}
+	if entry == nil {
+		return false
+	}
+	// ssoEd25519TargetCommit is the v4 all-fixes target the hub tracks. A hive
+	// whose reported commit (or image tag) contains it is running a v4 build that
+	// verifies SSO with Ed25519. Short-hash-safe: RegistryEntry.GitHash is stored
+	// as a short SHA, and the tag may embed the same prefix.
+	const ssoEd25519TargetCommit = "12c34e5"
+	gh := strings.ToLower(strings.TrimSpace(entry.GitHash))
+	// Match either direction so a stored short SHA and the (possibly longer)
+	// target commit still compare equal on their common prefix.
+	if gh != "" && (strings.HasPrefix(ssoEd25519TargetCommit, gh) || strings.HasPrefix(gh, ssoEd25519TargetCommit)) {
+		return true
+	}
+	if img := strings.ToLower(entry.ImageRef); strings.Contains(img, ssoEd25519TargetCommit) {
+		return true
+	}
+	return false
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2978,8 +2978,28 @@ func (s *HubServer) handleOpenHive(w http.ResponseWriter, r *http.Request) {
 
 	// Mint the handoff token. Without a hub secret we can't sign one, so fall
 	// back to a plain dashboard redirect (spoke will prompt for login).
+	//
+	// Dual-mint (transitional v2→v4 backport): a v4 spoke verifies SSO with an
+	// Ed25519 PUBLIC key and CANNOT verify a legacy symmetric HMAC token; the 33
+	// old spokes verify symmetric and CANNOT verify Ed25519. So the hub must mint
+	// the scheme THIS consuming hive can verify. We branch per-hive on a positive
+	// v4 signal (hiveWantsEd25519SSO: the console-hive allowlist plus a
+	// heartbeat-reported v4 commit/image), and DEFAULT to the legacy symmetric
+	// mint for every hive not positively identified as v4 — so the old fleet is
+	// never broken. Once all hives report a v4 version this becomes version-driven
+	// and the allowlist can be retired.
 	if s.hubSecret != "" {
-		if tok := MintSSOToken(s.hubSecret, username, role, id, time.Now()); tok != "" {
+		var tok string
+		if hiveWantsEd25519SSO(id, s.registryEntryCopy(id)) {
+			// v4 spoke: sign with the hub-only Ed25519 seed derived from the same
+			// master. The spoke self-derives the matching public key and verifies.
+			tok = MintSSOTokenEd25519(s.ssoSigningSeed(), username, role, id, time.Now())
+		} else {
+			// Default / all old hives: legacy symmetric HMAC under the raw master,
+			// exactly as before — unchanged path for the other 33 hives.
+			tok = MintSSOToken(s.hubSecret, username, role, id, time.Now())
+		}
+		if tok != "" {
 			http.Redirect(w, r, base+"/sso?token="+url.QueryEscape(tok), http.StatusSeeOther)
 			return
 		}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -650,6 +650,32 @@ func secureCompareHub(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
 
+// heartbeatBearerOK reports whether the Authorization header carries a valid
+// heartbeat bearer, accepting EITHER scheme so this v2 hub authenticates old and
+// new spokes at once (dual-path, additive — never one instead of the other):
+//
+//   - the legacy RAW master s.hubSecret, presented by the 33 existing spokes; and
+//   - the DERIVED heartbeatKey() (HMAC-SHA256(master, "hive-heartbeat-v1")),
+//     presented by a v4 spoke that self-derived it from the same HIVE_HUB_SECRET.
+//
+// Both comparisons are constant-time via secureCompareHub. The caller keeps its
+// outer `if s.hubSecret != ""` guard, so an unconfigured hub still authenticates
+// nothing here — this only widens WHICH bearer a configured hub accepts, and only
+// ever adds the new scheme alongside the old one.
+func (s *HubServer) heartbeatBearerOK(auth string) bool {
+	if !strings.HasPrefix(auth, "Bearer ") {
+		return false
+	}
+	tok := strings.TrimPrefix(auth, "Bearer ")
+	if secureCompareHub(tok, s.hubSecret) {
+		return true
+	}
+	if hk := s.heartbeatKey(); hk != "" && secureCompareHub(tok, hk) {
+		return true
+	}
+	return false
+}
+
 // heartbeatHealthStaleness is the maximum age of heartbeat-reported health
 // data before it is considered stale and displayed with a warning.
 const heartbeatHealthStaleness = 5 * time.Minute
@@ -1067,7 +1093,9 @@ func (s *HubServer) Shutdown(timeout time.Duration) error {
 func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	if s.hubSecret != "" {
 		auth := r.Header.Get("Authorization")
-		if !strings.HasPrefix(auth, "Bearer ") || !secureCompareHub(strings.TrimPrefix(auth, "Bearer "), s.hubSecret) {
+		// Dual-path: accept the legacy raw-secret bearer (old spokes) OR the
+		// derived heartbeat key (v4 spokes). See heartbeatBearerOK.
+		if !s.heartbeatBearerOK(auth) {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -2148,7 +2176,9 @@ func (s *HubServer) handleLeaderboard(w http.ResponseWriter, r *http.Request) {
 func (s *HubServer) handleTaskStatus(w http.ResponseWriter, r *http.Request) {
 	if s.hubSecret != "" {
 		auth := r.Header.Get("Authorization")
-		if !strings.HasPrefix(auth, "Bearer ") || !secureCompareHub(strings.TrimPrefix(auth, "Bearer "), s.hubSecret) {
+		// Dual-path: accept the legacy raw-secret bearer (old spokes) OR the
+		// derived heartbeat key (v4 spokes). See heartbeatBearerOK.
+		if !s.heartbeatBearerOK(auth) {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/v2/pkg/hub/sso.go
+++ b/v2/pkg/hub/sso.go
@@ -1,9 +1,11 @@
 package hub
 
 import (
+	"crypto/ed25519"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -131,4 +133,52 @@ func ssoSign(secret, body string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write([]byte(body))
 	return ssoB64.EncodeToString(mac.Sum(nil))
+}
+
+// ssoTokenVersionEd25519 namespaces the ASYMMETRIC (Ed25519) handoff payload.
+// It is "-v2" (the legacy symmetric token above is "-v1"), so a v4 spoke's
+// Ed25519 verifier accepts ONLY this shape and never a legacy symmetric token,
+// and an old symmetric verifier never accepts this one. The two schemes cannot
+// be confused for each other.
+const ssoTokenVersionEd25519 = "hive-sso-v2"
+
+// MintSSOTokenEd25519 mints an ASYMMETRICALLY-signed SSO handoff token that a v4
+// spoke (which verifies with an Ed25519 PUBLIC key) can accept. This is the v2
+// hub-side backport of the v4 asymmetric-SSO cutover (#2771); it exists ALONGSIDE
+// the legacy symmetric MintSSOToken (untouched above) so the hub can hand each
+// consuming spoke the scheme it can verify — Ed25519 for a v4 spoke, symmetric
+// HMAC for the 33 old spokes.
+//
+// `seedHex` is the hex-encoded 32-byte Ed25519 SEED (hub-only private material
+// from ssoSigningSeed()); the token is signed with the private key it expands to.
+// `now` is passed in for a consistent clock / deterministic tests. Returns "" if
+// seedHex is empty/not a valid 32-byte seed, or if username/hiveID are empty — so
+// a caller holding only a public key (or no key) can never produce a token.
+func MintSSOTokenEd25519(seedHex, username, role, hiveID string, now time.Time) string {
+	if seedHex == "" || username == "" || hiveID == "" {
+		return ""
+	}
+	seed, err := hex.DecodeString(strings.TrimSpace(seedHex))
+	if err != nil || len(seed) != ed25519.SeedSize {
+		// Not private-key material (e.g. a public key or garbage was passed):
+		// fail closed rather than sign with junk.
+		return ""
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+
+	claims := ssoClaims{
+		Version:  ssoTokenVersionEd25519,
+		Username: username,
+		Role:     role,
+		HiveID:   hiveID,
+		IssuedAt: now.Unix(),
+		Expiry:   now.Add(ssoTokenTTL).Unix(),
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return ""
+	}
+	body := ssoB64.EncodeToString(payload)
+	sig := ssoB64.EncodeToString(ed25519.Sign(priv, []byte(body)))
+	return body + "." + sig
 }


### PR DESCRIPTION
## Why

The live hub runs v2 (\`98781c2\`, image \`hive-hub:98781c2\`) and serves 34 hives. The \`kubestellar/console\` spoke auto-upgraded to the v4 all-fixes image, which changed the wire protocol: v4 spokes present a **derived** heartbeat bearer (HMAC-SHA256(master, \`hive-heartbeat-v1\`)) instead of the raw master, and verify SSO with an **Ed25519 public key** instead of a symmetric HMAC. Result: the console spoke's heartbeats 401 and its SSO login fails against the v2 hub.

Hub and spoke share the same master \`HIVE_HUB_SECRET\`, and the v4 spoke self-derives the correct keys — so this is entirely a **v2-hub-side** backport. No spoke change.

## Safety: strictly additive / dual-path

This hub must keep authenticating the **33 old spokes** (raw-secret heartbeat, symmetric-HMAC SSO) while **also** accepting the v4 console spoke. Every change here is additive — the legacy path stays and remains the default; the v4 path is accepted/minted only alongside it. Nothing forces a single scheme fleet-wide.

## Changes (all under \`v2/pkg/hub/\`)

1. **\`hub_keys.go\` (new)** — hub-only port of the v4 domain-key derivation: the info labels, \`deriveDomainKey\`, the Ed25519 seed/public-key helpers, and the \`heartbeatKey()\` / \`ssoSigningSeed()\` accessors. The v4 spoke-side \`Spoke*\`/\`Env*\`/\`spokeDomainKey\` symbols are intentionally **not** ported.
2. **\`server.go\`** — new \`heartbeatBearerOK()\` accepts **either** the raw master \`s.hubSecret\` **or** the derived \`hive-heartbeat-v1\` key, both constant-time. Wired into both \`handleHeartbeat\` and \`handleTaskStatus\`; the outer \`if s.hubSecret != ""\` guard is unchanged.
3. **\`sso.go\` + \`saas.go\`** — new \`MintSSOTokenEd25519()\` (\`hive-sso-v2\`) alongside the untouched symmetric \`MintSSOToken\`. At the \`/open\` mint site the hub **dual-mints per hive**: Ed25519 only when the hive is positively identified as v4 (console-id allowlist seeded with \`hosted-kubestellar-console-4vkt\`, plus a heartbeat-reported v4 commit/image), and the **legacy symmetric mint by default** for every other hive.

Transitional: the console-id allowlist is a positive-only marker until every hive reports a classifiable v4 version over the heartbeat, at which point the classification becomes purely version-driven.

## Legacy paths intact

- Heartbeat: raw \`s.hubSecret\` bearer is still checked first and still accepted.
- SSO: symmetric \`MintSSOToken\` is unchanged and is the default mint for all non-v4 hives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)