### PR TITLE
fix(hub): sign hive_hub_user with derived session key so v4 spoke /terminal verifies (dual-verify)

### DIFF
--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -66,6 +66,27 @@ func (s *HubServer) heartbeatKey() string {
 	return deriveDomainKey(s.hubSecret, infoHeartbeatKey)
 }
 
+// sessionCookieKey returns the derived session key the hub signs the
+// hive_hub_user cookie with after the C2 session-key cutover. A v4 spoke's Node
+// proxy verifies the cookie against deriveDomainKey(master, infoSessionKey), so
+// the hub must mint with the SAME derived key (not the raw master) for the
+// spoke's standalone /terminal to accept the session. Returns "" for an empty
+// master, so mintHubUserCookieValue stays fail-closed (no unsigned cookie).
+func (s *HubServer) sessionCookieKey() string {
+	return deriveDomainKey(s.hubSecret, infoSessionKey)
+}
+
+// verifyHubUserDual verifies the hive_hub_user cookie against the derived
+// session key (how cookies are minted after the C2 session-key cutover) OR
+// the raw master (legacy cookies still in browsers). Additive: never rejects
+// a value the single-key check would have accepted.
+func (s *HubServer) verifyHubUserDual(value string) (string, bool) {
+	if u, ok := verifyHubUserCookieValue(s.sessionCookieKey(), value); ok {
+		return u, true
+	}
+	return verifyHubUserCookieValue(s.hubSecret, value)
+}
+
 // ssoSigningSeed returns the hex-encoded 32-byte Ed25519 SEED the hub signs v4
 // SSO handoff tokens with. This is PRIVATE-key material (it can mint tokens) and
 // must never leave the hub. Returns "" for an empty master so minting stays

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -269,7 +269,7 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	// Set the session cookie to a signed, tamper-evident value so it cannot be
 	// forged. If the hub has no secret to sign with, fail the login rather than
 	// emit an unsigned (trusted-by-default) cookie.
-	cookieValue := mintHubUserCookieValue(s.hubSecret, user.Login)
+	cookieValue := mintHubUserCookieValue(s.sessionCookieKey(), user.Login)
 	if cookieValue == "" {
 		s.logger.Warn("OAuth: cannot mint signed session cookie", "user", user.Login)
 		http.Error(w, "session unavailable", http.StatusInternalServerError)
@@ -320,7 +320,7 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 	}
 	// Trust the carried username only when its signature verifies; a legacy
 	// unsigned or forged cookie reports unauthenticated, prompting a re-login.
-	username, ok := verifyHubUserCookieValue(s.hubSecret, cookie.Value)
+	username, ok := s.verifyHubUserDual(cookie.Value)
 	if !ok || loadSaaSUser(username) == nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"authenticated":false}`))

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -527,7 +527,7 @@ func (s *HubServer) getRealAuthUser(r *http.Request) string {
 		// against the hub secret. A legacy unsigned cookie or a forged value
 		// fails here and is treated as logged out, so the user re-authenticates
 		// through the normal login flow (which re-mints a signed cookie).
-		if username, ok := verifyHubUserCookieValue(s.hubSecret, cookie.Value); ok {
+		if username, ok := s.verifyHubUserDual(cookie.Value); ok {
 			if loadSaaSUser(username) != nil {
 				return username
 			}


### PR DESCRIPTION
## Problem

The kubestellar/console spoke runs the v4 image; this hub runs v2. The v4 spoke's Node proxy (`v2/proxy/server.js`) gates `/terminal` by verifying the `hive_hub_user` cookie against a **derived** session key: `deriveDomainKey(master, "hive-session-v1")`. But the v2 hub **mints** `hive_hub_user` with the **raw** master `s.hubSecret`. Raw != derived, so the proxy's verify fails and `/terminal` returns `401 Terminal access requires authentication`.

This is the **3rd C2 domain** (session cookie). PR #2773 covered heartbeat + SSO but not the session cookie. Hub and spoke share the same `HIVE_HUB_SECRET`, so the derived keys match once the hub uses the derived key.

## Change (hub-only, all in `v2/pkg/hub/`)

Additive / dual-path — never breaks cookies already in browsers, never breaks the 33 old v2 spokes:

1. **New accessor** `sessionCookieKey()` = `deriveDomainKey(s.hubSecret, infoSessionKey)` (reuses the `deriveDomainKey` + `infoSessionKey="hive-session-v1"` that landed with #2773).
2. **Mint** (`oauth.go`): mint `hive_hub_user` with the **derived** session key so the v4 spoke proxy can verify it. Fail-closed preserved (empty secret → "" → mint returns "").
3. **Verify** (`oauth.go handleAuthUser` + `saas.go getRealAuthUser`): new `verifyHubUserDual` accepts **either** the derived key **or** the raw master, so freshly-minted derived cookies verify AND legacy raw cookies already in browsers keep verifying during the transition.

Does **not** touch `hub_cookie.go` internals, `proxy/server.js`, the spoke, or any impersonate/session/SSO cookie path — only the `hive_hub_user` cookie.

## Verification
- `infoSessionKey == "hive-session-v1"` matches the proxy's `INFO_SESSION_KEY`.
- Only 3 `hive_hub_user` mint/verify call sites exist; all handled (mint→derived, both verifies→dual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)