### PR TITLE
🐛 fix(dashboard): send bobshell User-Agent in bob key probe to pass Cloudflare WAF

### DIFF
--- a/v2/pkg/dashboard/bob_key_probe.go
+++ b/v2/pkg/dashboard/bob_key_probe.go
@@ -60,6 +60,15 @@ const (
 	bobAuthSchemeAPIKey = "Apikey "
 	bobAuthSchemeBearer = "Bearer "
 
+	// bobProbeUserAgent is the User-Agent the probe sends. The Cloudflare WAF
+	// in front of api.us-east.bob.ibm.com fingerprint-blocks generic HTTP
+	// clients: Go's default "Go-http-client/2.0" (and curl's UA) get an HTML
+	// 403 block page before bob's auth ever sees the key, while "bobshell"
+	// — the UA of bob's own CLI — passes through to the backend. Confirmed
+	// live 2026-08-07 from both a hive pod and a workstation: same request,
+	// default UA → Cloudflare 403; "bobshell" UA → backend verdict (200/401).
+	bobProbeUserAgent = "bobshell"
+
 	// bobKeyManageURL is where an operator creates a correctly-scoped key —
 	// surfaced in entitlement-failure details. Keep in sync with
 	// BOB_API_KEY_MANAGE_URL in static/index.html.
@@ -156,6 +165,7 @@ func probeBobAPIKey(key string) (reason, detail string) {
 		return bobTestReasonUnreachable, "building request: " + redactSecret(err.Error(), key)
 	}
 	req.Header.Set("Authorization", bobAuthHeaderValue(key))
+	req.Header.Set("User-Agent", bobProbeUserAgent)
 	client := &http.Client{Timeout: bobProbeTimeout}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/v2/pkg/dashboard/bob_key_probe_test.go
+++ b/v2/pkg/dashboard/bob_key_probe_test.go
@@ -59,10 +59,11 @@ func postBobKeyTest(t *testing.T, s *Server, body string) (*httptest.ResponseRec
 // status ok, and the key is not persisted anywhere.
 func TestBobKeyTest_PastedKeyOK_NotPersisted(t *testing.T) {
 	path := isolateBobKeySources(t)
-	var gotAuth, gotPath string
+	var gotAuth, gotPath, gotUA string
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
 		gotPath = r.URL.Path
+		gotUA = r.Header.Get("User-Agent")
 		if gotAuth != "Apikey "+bobTestKey {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
@@ -88,6 +89,11 @@ func TestBobKeyTest_PastedKeyOK_NotPersisted(t *testing.T) {
 	}
 	if gotPath != bobProbePath {
 		t.Errorf("probe hit %q, want %q", gotPath, bobProbePath)
+	}
+	// The Cloudflare WAF in front of the bob backend blocks Go's default
+	// User-Agent with an HTML 403 — the probe must identify as bobshell.
+	if gotUA != bobProbeUserAgent {
+		t.Errorf("backend saw User-Agent %q, want %q", gotUA, bobProbeUserAgent)
 	}
 	// Pre-save validation must not persist the key or touch config.
 	if _, err := os.Stat(path); err == nil {


### PR DESCRIPTION
## Problem
The **Test key** button in the bob API key dialog always failed with:
> the request was blocked at the network edge (HTML 403 from the CDN/proxy), not by bob's auth — the key was likely never evaluated

even for **valid** keys.

## Root cause
The probe uses Go's default User-Agent (`Go-http-client/2.0`). Cloudflare's WAF in front of `api.us-east.bob.ibm.com` fingerprint-blocks generic HTTP clients and returns an HTML 403 block page before bob's auth sees the key.

Confirmed live (2026-08-07) from both a hive pod (`context-forge`, oke-03) and a workstation:
| User-Agent | Result |
|---|---|
| (Go default / curl) | Cloudflare HTML 403 "Sorry, you have been blocked" |
| `bobshell` | reaches backend — 200 (valid key) / 401 (invalid) |

The saved key on the affected hive tested **200 OK** with the `bobshell` UA.

## Fix
Send `User-Agent: bobshell` (bob's own CLI UA) on the probe request. Added a test asserting the UA reaches the backend.