### PR TITLE
feat(agent): register watsonx as an agent backend + validate backends at config time

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2460,23 +2460,7 @@ func main() {
 					// key (NOT the raw key), and scopes billing/limits by a
 					// project id sent as X-IBM-Project-ID. Mint (cached) and set
 					// both here; every other kind sends the resolved key verbatim.
-					apiKey := gw.ResolveAPIKey()
-					var extraHeaders map[string]string
-					if strings.EqualFold(gw.Kind, config.GatewayKindWatsonx) {
-						token, terr := watsonx.DefaultMinter.Token(context.Background(), apiKey)
-						if terr != nil {
-							logger.Warn("watsonx IAM token mint failed; agent inference will fail until the key/project are valid",
-								"agent", agentName, "gateway", backend, "error", terr.Error())
-							// Leave apiKey as-is (the raw key). watsonx will reject
-							// it, surfacing a clear upstream 401 rather than a
-							// silent success — better than dropping the route.
-						} else {
-							apiKey = token
-						}
-						if gw.ProjectID != "" {
-							extraHeaders = map[string]string{watsonx.ProjectIDHeader: gw.ProjectID}
-						}
-					}
+					apiKey, extraHeaders := resolveGatewayAuth(gw, agentName, backend, logger)
 					githubProxy.SetInferenceRoute(agentName, &proxy.InferenceRoute{
 						Backend:      backend,
 						Endpoint:     endpoint,
@@ -2539,6 +2523,41 @@ func main() {
 						Model:    model,
 						APIKey:   apiKey,
 						CABundle: caBundle,
+					})
+					return
+				}
+				if backend == config.GatewayKindWatsonx {
+					// Built-in "watsonx" backend: the operator set
+					// `backend: watsonx` without a gateway literally NAMED
+					// watsonx (a named one is handled by the gateway branch
+					// above). Resolve the watsonx gateway by KIND so the
+					// endpoint, IBM Cloud key, project id and region all come
+					// from the existing `gateways:` plumbing rather than being
+					// re-derived here.
+					gw := resolveWatsonxGateway(cfg)
+					if gw == nil {
+						logger.Warn("watsonx backend selected but no watsonx gateway is configured; add one under the Model Gateways tab",
+							"agent", agentName, "model", model)
+						return
+					}
+					// Region-only gateways are legal (the guided form can save a
+					// region without an endpoint), so fall back to the shared
+					// region template — the same helper the dashboard preset uses.
+					endpoint := strings.TrimSpace(gw.Endpoint)
+					if endpoint == "" {
+						endpoint = watsonx.EndpointForRegion(gw.Region)
+					}
+					if model == "" {
+						model = gw.DefaultModel
+					}
+					apiKey, extraHeaders := resolveGatewayAuth(gw, agentName, backend, logger)
+					githubProxy.SetInferenceRoute(agentName, &proxy.InferenceRoute{
+						Backend:      backend,
+						Endpoint:     endpoint,
+						Model:        model,
+						APIKey:       apiKey,
+						CABundle:     gw.CABundle,
+						ExtraHeaders: extraHeaders,
 					})
 					return
 				}
@@ -5269,6 +5288,62 @@ func runHub(logger *slog.Logger) {
 		os.Exit(1)
 	}
 	logger.Info("hub server stopped")
+}
+
+// resolveWatsonxGateway finds the gateway backing the built-in "watsonx" agent
+// backend. It prefers a gateway explicitly NAMED watsonx, then falls back to
+// the first gateway of KIND watsonx — so `backend: watsonx` works whether the
+// operator named their gateway "watsonx" or something descriptive like
+// "ibm-granite-prod". Returns nil when no watsonx gateway is configured.
+func resolveWatsonxGateway(cfg *config.Config) *config.GatewayConfig {
+	gws := cfg.Governor.ResolvedGateways()
+	for i := range gws {
+		if strings.EqualFold(gws[i].Name, config.GatewayKindWatsonx) &&
+			strings.EqualFold(gws[i].Kind, config.GatewayKindWatsonx) {
+			gw := gws[i]
+			return &gw
+		}
+	}
+	for i := range gws {
+		if strings.EqualFold(gws[i].Kind, config.GatewayKindWatsonx) {
+			gw := gws[i]
+			return &gw
+		}
+	}
+	return nil
+}
+
+// resolveGatewayAuth resolves the bearer token and non-secret extra headers an
+// agent's inference route should present for a gateway.
+//
+// For every kind except watsonx this is the resolved API key verbatim and no
+// extra headers. watsonx authenticates its OpenAI-compatible model gateway with
+// a SHORT-LIVED IAM bearer minted from the IBM Cloud API key (not the raw key)
+// and scopes billing/limits by a project id sent as X-IBM-Project-ID, so both
+// are set here via the shared process-wide minter (pkg/watsonx.DefaultMinter),
+// whose cache means one token is reused across inference, probes and discovery.
+//
+// Shared by the named-gateway branch and the built-in "watsonx" backend branch
+// so the two cannot authenticate differently. Never logs the key or the token.
+func resolveGatewayAuth(gw *config.GatewayConfig, agentName, backend string, logger *slog.Logger) (string, map[string]string) {
+	apiKey := gw.ResolveAPIKey()
+	if !strings.EqualFold(gw.Kind, config.GatewayKindWatsonx) {
+		return apiKey, nil
+	}
+	if token, err := watsonx.DefaultMinter.Token(context.Background(), apiKey); err != nil {
+		logger.Warn("watsonx IAM token mint failed; agent inference will fail until the key/project are valid",
+			"agent", agentName, "gateway", backend, "error", err.Error())
+		// Leave apiKey as-is (the raw key). watsonx will reject it, surfacing a
+		// clear upstream 401 rather than a silent success — better than dropping
+		// the route entirely.
+	} else {
+		apiKey = token
+	}
+	var extraHeaders map[string]string
+	if gw.ProjectID != "" {
+		extraHeaders = map[string]string{watsonx.ProjectIDHeader: gw.ProjectID}
+	}
+	return apiKey, extraHeaders
 }
 
 func envOrDefault(key, fallback string) string {

--- a/v2/pkg/agent/agent_unit_test.go
+++ b/v2/pkg/agent/agent_unit_test.go
@@ -689,7 +689,7 @@ func TestNormalizeModelNameUnit(t *testing.T) {
 	// outbound gateway "model" field and must match an entitled model exactly.
 	// Rewriting it (e.g. "Azure/gpt-4" -> "Azure/gpt.4") makes the gateway 403
 	// with "team not allowed to access model" even on entitled models.
-	for _, backend := range []string{"litellm", "vllm", "llm-d"} {
+	for _, backend := range config.InferenceBackends {
 		for _, model := range []string{
 			"Azure/gpt-4o",
 			"Azure/gpt-4.1",

--- a/v2/pkg/agent/authprobe.go
+++ b/v2/pkg/agent/authprobe.go
@@ -56,9 +56,11 @@ var interactiveAuthBackends = map[string]bool{
 }
 
 // BackendRequiresInteractiveAuth reports whether a backend authenticates via an
-// interactive login the operator must perform. Inference backends (litellm,
-// vllm, llm-d) authenticate with an API key supplied by config and therefore
-// NEVER require a login — showing them a login badge is always a false alarm.
+// interactive login the operator must perform. Model-gateway backends
+// (config.InferenceBackends: litellm, vllm, llm-d, watsonx) authenticate with
+// an API key supplied by config — watsonx with an IAM bearer minted from that
+// key — and therefore NEVER require a login. Showing them a 🔑 badge is always
+// a false alarm.
 func BackendRequiresInteractiveAuth(backend string) bool {
 	if config.IsInferenceBackend(backend) {
 		return false

--- a/v2/pkg/agent/authprobe_test.go
+++ b/v2/pkg/agent/authprobe_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
 // writeClaudeCreds writes a credentials.json with a non-expired OAuth token at
@@ -54,7 +56,7 @@ func TestAgentAuthState_InferenceBackendNeverNeedsLogin(t *testing.T) {
 	emptySharedPaths(t)
 	m := &Manager{}
 
-	for _, backend := range []string{"litellm", "vllm", "llm-d"} {
+	for _, backend := range config.InferenceBackends {
 		for _, running := range []bool{true, false} {
 			// Even a pane that looks like a login prompt cannot make an
 			// API-key backend "need login" — there is no login to perform.

--- a/v2/pkg/agent/backend_coverage_test.go
+++ b/v2/pkg/agent/backend_coverage_test.go
@@ -1,0 +1,271 @@
+package agent
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// TestAgentCopilotConfigPaths_PerUIDFirst locks down the ORDERING contract of
+// agentCopilotConfigPaths: the per-UID files must be probed before the shared
+// path, because the per-UID file is the one the agent's own CLI writes. If the
+// shared path came first, a stale shared credential would mask a fresh per-agent
+// login and the dashboard would report the wrong auth state.
+func TestAgentCopilotConfigPaths_PerUIDFirst(t *testing.T) {
+	emptySharedPaths(t)
+
+	// A gateway backend routes AgentHome to the per-agent inference home, which
+	// is the case where per-UID paths actually differ from the shared one.
+	paths := agentCopilotConfigPaths("ci-maintainer", 2007, "watsonx")
+	if len(paths) < 2 {
+		t.Fatalf("want per-UID paths plus the shared path, got %v", paths)
+	}
+	home := AgentHome("ci-maintainer", 2007, "watsonx")
+	if home == "" {
+		t.Fatal("AgentHome returned empty for a per-UID gateway agent")
+	}
+	want := []string{
+		filepath.Join(home, ".copilot", "config.json"),
+		filepath.Join(home, ".config", "github-copilot", "apps.json"),
+		filepath.Join(home, ".config", "github-copilot", "hosts.json"),
+	}
+	for i, w := range want {
+		if paths[i] != w {
+			t.Errorf("paths[%d] = %q, want %q", i, paths[i], w)
+		}
+	}
+	// The shared path must be present, and must come LAST.
+	if got := paths[len(paths)-1]; got != sharedCopilotConfigPath {
+		t.Errorf("last path = %q, want the shared path %q", got, sharedCopilotConfigPath)
+	}
+}
+
+// TestAgentCopilotConfigPaths_NoDuplicateSharedPath: when AgentHome resolves to
+// the same place the shared credential lives, the shared path must not be
+// appended twice. containsPath exists precisely to prevent that.
+func TestAgentCopilotConfigPaths_NoDuplicateSharedPath(t *testing.T) {
+	emptySharedPaths(t)
+	for _, backend := range []string{"claude", "copilot", "watsonx", ""} {
+		paths := agentCopilotConfigPaths("ci-maintainer", 2007, backend)
+		seen := map[string]int{}
+		for _, p := range paths {
+			seen[p]++
+		}
+		for p, n := range seen {
+			if n > 1 {
+				t.Errorf("backend %q: path %q appears %d times, want once", backend, p, n)
+			}
+		}
+	}
+}
+
+// TestAgentAuthAvailable_UnknownAgent: the dashboard registers
+// AgentAuthAvailable as a per-agent provider and calls it by name alone. An
+// agent the manager has never heard of must return known=false ("no opinion")
+// so the UI renders NO badge, rather than a false "not authenticated" badge.
+func TestAgentAuthAvailable_UnknownAgent(t *testing.T) {
+	m := &Manager{agents: map[string]*AgentProcess{}}
+	avail, known := m.AgentAuthAvailable("no-such-agent")
+	if known {
+		t.Errorf("known = true for an unknown agent, want false (no badge)")
+	}
+	if avail {
+		t.Errorf("available = true for an unknown agent, want false")
+	}
+}
+
+// TestAgentAuthAvailable_UsesBackendOverride is the substantive behaviour of
+// AgentAuthAvailable: it resolves the agent's EFFECTIVE backend itself. An agent
+// configured for an interactive CLI but overridden onto watsonx authenticates by
+// IAM, so it must read as authenticated — if the override were ignored, a
+// switched agent would show a spurious login badge forever.
+func TestAgentAuthAvailable_UsesBackendOverride(t *testing.T) {
+	emptySharedPaths(t)
+	proc := &AgentProcess{
+		Name:            "ci-maintainer",
+		UID:             2007,
+		State:           StateRunning,
+		BackendOverride: "watsonx",
+	}
+	proc.Config.Backend = "claude"
+	proc.NeedsLogin = true // pane looks like a login prompt; must be ignored
+
+	m := &Manager{agents: map[string]*AgentProcess{"ci-maintainer": proc}}
+
+	avail, known := m.AgentAuthAvailable("ci-maintainer")
+	if !known || !avail {
+		t.Fatalf("watsonx-overridden agent: got (avail=%v, known=%v), want authenticated+known", avail, known)
+	}
+
+	// Sanity: the same result must come from the lower-level call with the
+	// override applied, proving AgentAuthAvailable resolved the override and
+	// not the configured backend.
+	wantAvail, wantKnown := m.AgentAuthState("ci-maintainer", proc.UID, "watsonx", true, true)
+	if avail != wantAvail || known != wantKnown {
+		t.Errorf("AgentAuthAvailable = (%v,%v), AgentAuthState(watsonx) = (%v,%v); override was not applied",
+			avail, known, wantAvail, wantKnown)
+	}
+}
+
+// TestCheckBlockedThrash_TripsOnlyAtThreshold exercises the breaker end to end
+// through checkBlockedThrash (the marker-matching + state-bookkeeping wrapper),
+// not just the pure sliding-window helper. Below the threshold the agent must
+// NOT be paused; the breaker only fires once the loop is established.
+func TestCheckBlockedThrash_TripsOnlyAtThreshold(t *testing.T) {
+	m := &Manager{
+		agents: map[string]*AgentProcess{},
+		logger: discardLogger(),
+	}
+
+	// A line containing no blocked-action marker must be ignored entirely — it
+	// must not even allocate thrash state for the agent.
+	m.checkBlockedThrash("ci-maintainer", "everything is fine, pushing now")
+	if len(m.thrash) != 0 {
+		t.Errorf("a non-blocked line recorded thrash state: %v", m.thrash)
+	}
+
+	// Feed threshold-1 real blocked lines: recorded, but not yet tripped.
+	marker := blockedActionMarkers[0]
+	for i := 0; i < thrashThreshold-1; i++ {
+		m.checkBlockedThrash("ci-maintainer", marker+" refusing to push to main")
+	}
+	st := m.thrash["ci-maintainer"]
+	if st == nil {
+		t.Fatal("blocked lines did not record thrash state")
+	}
+	if len(st.times) != thrashThreshold-1 {
+		t.Errorf("recorded %d blocked lines, want %d", len(st.times), thrashThreshold-1)
+	}
+	if !st.lastTrip.IsZero() {
+		t.Error("breaker tripped before reaching the threshold")
+	}
+}
+
+// TestCheckBlockedThrash_MatchesEveryMarker: every marker in
+// blockedActionMarkers must actually be recognised. A marker that silently
+// stopped matching would disable the breaker for that whole class of block.
+func TestCheckBlockedThrash_MatchesEveryMarker(t *testing.T) {
+	for _, marker := range blockedActionMarkers {
+		m := &Manager{agents: map[string]*AgentProcess{}, logger: discardLogger()}
+		m.checkBlockedThrash("a", "prefix text "+marker+" suffix text")
+		if st := m.thrash["a"]; st == nil || len(st.times) != 1 {
+			t.Errorf("marker %q was not recognised as a blocked-action line", marker)
+		}
+	}
+}
+
+// TestRecordBlockedAndCheck_WindowAndCooldown pins the pure decision function:
+// stale entries fall out of the sliding window, and after a trip the cooldown
+// suppresses a second trip so one bad loop does not pause an agent repeatedly.
+func TestRecordBlockedAndCheck_WindowAndCooldown(t *testing.T) {
+	now := time.Now()
+
+	// Entries older than the window must not count toward the threshold.
+	st := &thrashState{}
+	for i := 0; i < thrashThreshold-1; i++ {
+		st.times = append(st.times, now.Add(-2*thrashWindow))
+	}
+	if recordBlockedAndCheck(st, now, thrashWindow, thrashThreshold, thrashCooldown) {
+		t.Error("tripped on stale entries that should have aged out of the window")
+	}
+	if len(st.times) != 1 {
+		t.Errorf("stale entries were not pruned: %d remain, want 1", len(st.times))
+	}
+
+	// Threshold reached inside the window: must trip.
+	st = &thrashState{}
+	var tripped bool
+	for i := 0; i < thrashThreshold; i++ {
+		tripped = recordBlockedAndCheck(st, now, thrashWindow, thrashThreshold, thrashCooldown)
+	}
+	if !tripped {
+		t.Fatalf("did not trip after %d blocked lines inside the window", thrashThreshold)
+	}
+
+	// Immediately after a trip, the cooldown must suppress another trip.
+	if recordBlockedAndCheck(st, now, thrashWindow, thrashThreshold, thrashCooldown) {
+		t.Error("tripped again inside the cooldown")
+	}
+	// Past the cooldown, it may trip again.
+	later := now.Add(thrashCooldown + time.Second)
+	st.times = nil
+	for i := 0; i < thrashThreshold-1; i++ {
+		st.times = append(st.times, later)
+	}
+	if !recordBlockedAndCheck(st, later, thrashWindow, thrashThreshold, thrashCooldown) {
+		t.Error("did not trip after the cooldown expired")
+	}
+}
+
+// TestBackendBinary_GatewayBackendsAllLaunchClaude pins the derivation added by
+// this PR: every model-gateway backend launches the SAME claude CLI, because the
+// backend name selects the upstream route (via ANTHROPIC_BASE_URL), not the
+// binary. This is what makes adding a backend to config.InferenceBackends
+// sufficient — no second edit in the launcher.
+func TestBackendBinary_GatewayBackendsAllLaunchClaude(t *testing.T) {
+	// backendBinary may return a resolved absolute path (CI installs stub
+	// binaries on PATH), so compare the basename — the identity of the CLI is
+	// what matters here, not where it was found.
+	for _, b := range config.InferenceBackends {
+		got, err := backendBinary(b)
+		if err != nil {
+			t.Errorf("backendBinary(%q) err = %v, want nil", b, err)
+			continue
+		}
+		if filepath.Base(got) != "claude" {
+			t.Errorf("backendBinary(%q) = %q, want the claude CLI (gateways share one binary)", b, got)
+		}
+	}
+	// The agentic CLIs must still map to their own binaries.
+	for backend, want := range map[string]string{
+		"claude": "claude", "copilot": "copilot", "gemini": "gemini",
+		"goose": "goose", "pi": "goose", "bob": "bob",
+	} {
+		got, err := backendBinary(backend)
+		if err != nil || filepath.Base(got) != want {
+			t.Errorf("backendBinary(%q) = (%q, %v), want basename %q with nil error", backend, got, err, want)
+		}
+	}
+}
+
+// TestSetBackendOverride_RejectsUndispatchableBackend covers the door this PR
+// closed: /switch/{backend} used to accept ANY string and set it, so the agent
+// was restarted into a backend the launcher could not start and died with
+// "unknown backend" — with no signal at the moment of the change. The override
+// must be rejected AND left unmodified.
+func TestSetBackendOverride_RejectsUndispatchableBackend(t *testing.T) {
+	proc := &AgentProcess{Name: "ci-maintainer", BackendOverride: "claude"}
+	m := &Manager{
+		agents: map[string]*AgentProcess{"ci-maintainer": proc},
+		logger: discardLogger(),
+	}
+
+	err := m.SetBackendOverride("ci-maintainer", "totally-made-up")
+	if err == nil {
+		t.Fatal("SetBackendOverride accepted a backend the launcher cannot dispatch")
+	}
+	if !strings.Contains(err.Error(), "totally-made-up") {
+		t.Errorf("error %q should name the rejected backend", err.Error())
+	}
+	if proc.BackendOverride != "claude" {
+		t.Errorf("a rejected override mutated state: BackendOverride = %q, want %q unchanged",
+			proc.BackendOverride, "claude")
+	}
+
+	// watsonx — the backend this PR registered — must be ACCEPTED and applied.
+	if err := m.SetBackendOverride("ci-maintainer", "watsonx"); err != nil {
+		t.Fatalf("SetBackendOverride(watsonx) = %v, want nil", err)
+	}
+	if proc.BackendOverride != "watsonx" {
+		t.Errorf("BackendOverride = %q, want \"watsonx\"", proc.BackendOverride)
+	}
+
+	// A missing agent must still be reported as not found, not as a bad backend.
+	if err := m.SetBackendOverride("no-such-agent", "claude"); err == nil ||
+		!strings.Contains(err.Error(), "not found") {
+		t.Errorf("SetBackendOverride on a missing agent = %v, want a 'not found' error", err)
+	}
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -389,6 +389,22 @@ func (m *Manager) routableBackend(backend string) bool {
 	return fnp != nil && *fnp != nil && (*fnp)(backend)
 }
 
+// validateBackendName reports whether backend is one the launcher can actually
+// dispatch: an agentic CLI, a model-gateway backend, or a configured gateway
+// name. An empty backend is valid (it means "the hive default").
+//
+// This is the manager-side half of the accept-then-fail fix. It dispatches on
+// the SAME canonical lists as config.ValidateBackend and backendBinary, so a
+// backend accepted by any write path is one the launch path can start.
+// Safe to call while holding m.mu (routableBackend reads atomically).
+func (m *Manager) validateBackendName(backend string) error {
+	if backend == "" || config.IsCLIBackend(backend) || m.routableBackend(backend) {
+		return nil
+	}
+	return fmt.Errorf("unsupported backend %q (supported: %s; or the name of a configured model gateway)",
+		backend, strings.Join(config.SupportedBackends(), ", "))
+}
+
 // SetAppAuth injects the GitHub App auth provider for per-agent scoped tokens.
 func (m *Manager) SetAppAuth(auth AppTokenMinter) {
 	m.mu.Lock()
@@ -3631,6 +3647,14 @@ func (a *AgentProcess) FilteredPaneLines(n int) []string {
 	return filterPaneOutput(a.lastPaneCapture, n)
 }
 
+// backendBinary maps an agent backend to the CLI binary that is actually
+// exec'd for it. Every model-gateway backend (config.InferenceBackends: vllm,
+// llm-d, litellm, watsonx) launches the SAME claude CLI, pointed at hive's
+// local OpenAI-compatible translator via ANTHROPIC_BASE_URL — the backend name
+// selects the upstream route, not the binary. Those entries are therefore
+// derived from the canonical list rather than written out here, so a backend
+// added to config.InferenceBackends can never again be accepted by config and
+// then rejected at kick time with "unknown backend".
 func backendBinary(backend string) (string, error) {
 	binaries := map[string]string{
 		"claude":  "claude",
@@ -3639,9 +3663,9 @@ func backendBinary(backend string) (string, error) {
 		"goose":   "goose",
 		"pi":      "goose",
 		"bob":     "bob",
-		"vllm":    "claude",
-		"llm-d":   "claude",
-		"litellm": "claude",
+	}
+	for _, b := range config.InferenceBackends {
+		binaries[b] = "claude"
 	}
 
 	binary, ok := binaries[backend]
@@ -5397,6 +5421,16 @@ func (m *Manager) SetBackendOverride(name, backend string) error {
 	agent, ok := m.agents[name]
 	if !ok {
 		return fmt.Errorf("agent %s not found", name)
+	}
+
+	// Refuse a backend the launcher cannot dispatch, at SET time. Previously
+	// any string was accepted here and the agent was then restarted into it,
+	// failing only at launch with "unknown backend: <x>" — the agent stops
+	// working and the operator gets no signal at the moment of the change.
+	// routableBackend covers configured gateway names (resolved live), so a
+	// gateway-named backend still passes.
+	if err := m.validateBackendName(backend); err != nil {
+		return err
 	}
 
 	agent.BackendOverride = backend

--- a/v2/pkg/agent/manager_coverage2_test.go
+++ b/v2/pkg/agent/manager_coverage2_test.go
@@ -1694,7 +1694,7 @@ func TestReadCoveragePreamble_MissingTarget(t *testing.T) {
 
 func TestBackendBinary_InferenceBackends(t *testing.T) {
 	// vllm, llm-d, and litellm should map to claude binary
-	for _, backend := range []string{"vllm", "llm-d", "litellm"} {
+	for _, backend := range config.InferenceBackends {
 		path, err := backendBinary(backend)
 		if err != nil {
 			t.Errorf("backendBinary(%q) error: %v", backend, err)

--- a/v2/pkg/agent/watsonx_backend_test.go
+++ b/v2/pkg/agent/watsonx_backend_test.go
@@ -1,0 +1,147 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// The bug this file locks down:
+//
+// An operator set `backend: watsonx` on a real spoke. The config layer accepted
+// it (watsonx had shipped as a `gateways:` KIND and as an onboarding UI option)
+// but the agent launcher had no case for it, so the agent never started:
+//
+//	HIVE LAUNCH FAILED: backend watsonx did not launch: unknown backend: watsonx.
+//	{"level":"WARN","msg":"failed to send kick","agent":"ci-maintainer",
+//	 "error":"agent ci-maintainer cannot be kicked: it failed to start: unknown backend: watsonx"}
+//
+// watsonx.ai is a MODEL GATEWAY (OpenAI-compatible endpoint + IAM-minted
+// bearer), not an agentic CLI, so it belongs with litellm/vllm/llm-d.
+
+// TestWatsonxIsRecognizedBackend is the direct regression test: the launcher
+// must not reject "watsonx" with "unknown backend".
+func TestWatsonxIsRecognizedBackend(t *testing.T) {
+	if !config.IsInferenceBackend("watsonx") {
+		t.Fatal("watsonx must be an inference backend so the launcher can dispatch it")
+	}
+	if !IsInferenceBackend("watsonx") {
+		t.Fatal("agent.IsInferenceBackend(watsonx) = false, want true")
+	}
+	// backendBinary is the exact site that produced "unknown backend: watsonx".
+	// It may still fail with "not found in PATH" in CI (no claude binary
+	// installed) — that is a DIFFERENT and acceptable error. The one thing that
+	// must never come back is "unknown backend".
+	if _, err := backendBinary("watsonx"); err != nil && strings.Contains(err.Error(), "unknown backend") {
+		t.Fatalf("backendBinary(watsonx) returned %v; watsonx must be a known backend", err)
+	}
+}
+
+// TestBackendBinary_UnknownStillRejected guards the other direction: making
+// watsonx known must not turn backendBinary into a function that accepts
+// anything.
+func TestBackendBinary_UnknownStillRejected(t *testing.T) {
+	_, err := backendBinary("totally-made-up")
+	if err == nil || !strings.Contains(err.Error(), "unknown backend") {
+		t.Fatalf("backendBinary(totally-made-up) err = %v, want 'unknown backend'", err)
+	}
+}
+
+// TestEveryInferenceBackendHasABinary is the anti-drift test. Every backend the
+// config layer will ACCEPT must be one the launcher can dispatch — that gap is
+// precisely what let `backend: watsonx` be saved and then fail at kick time.
+func TestEveryInferenceBackendHasABinary(t *testing.T) {
+	for _, b := range config.InferenceBackends {
+		if _, err := backendBinary(b); err != nil && strings.Contains(err.Error(), "unknown backend") {
+			t.Errorf("backend %q is accepted by config but unknown to the launcher", b)
+		}
+	}
+}
+
+// TestWatsonxNeverRequiresInteractiveAuth: watsonx authenticates with an IBM
+// Cloud API key exchanged for an IAM bearer — there is no interactive login for
+// an operator to perform, so a 🔑 badge on a watsonx agent is always wrong.
+func TestWatsonxNeverRequiresInteractiveAuth(t *testing.T) {
+	if BackendRequiresInteractiveAuth("watsonx") {
+		t.Fatal("BackendRequiresInteractiveAuth(watsonx) = true, want false (API-key/IAM auth, no login)")
+	}
+	// Hold the whole gateway family to the same rule.
+	for _, b := range config.InferenceBackends {
+		if BackendRequiresInteractiveAuth(b) {
+			t.Errorf("BackendRequiresInteractiveAuth(%q) = true, want false", b)
+		}
+	}
+	// The interactive CLIs must still require it, or the badge dies everywhere.
+	for _, b := range []string{"claude", "copilot", "gemini"} {
+		if !BackendRequiresInteractiveAuth(b) {
+			t.Errorf("BackendRequiresInteractiveAuth(%q) = false, want true", b)
+		}
+	}
+}
+
+// TestWatsonxAuthStateNeverNeedsLogin exercises the badge path end to end: even
+// with no credential files and a pane that looks like a login prompt, a watsonx
+// agent must read as authenticated+known (no badge).
+func TestWatsonxAuthStateNeverNeedsLogin(t *testing.T) {
+	emptySharedPaths(t)
+	m := &Manager{}
+	for _, running := range []bool{true, false} {
+		for _, needsLogin := range []bool{true, false} {
+			avail, known := m.AgentAuthState("ci-maintainer", 2007, "watsonx", running, needsLogin)
+			if !known || !avail {
+				t.Fatalf("watsonx running=%v needsLogin=%v: got (avail=%v, known=%v), want authenticated+known",
+					running, needsLogin, avail, known)
+			}
+		}
+	}
+}
+
+// TestWatsonxModelNamePassedThroughVerbatim: gateway backends must never have
+// their model id rewritten — the id has to match what the gateway serves.
+func TestWatsonxModelNamePassedThroughVerbatim(t *testing.T) {
+	for _, model := range []string{
+		"ibm/granite-4-h-small",
+		"ibm/granite-3-3-8b-instruct",
+		"meta-llama/llama-3-3-70b-instruct",
+	} {
+		if got := normalizeModelName(model, "watsonx"); got != model {
+			t.Errorf("normalizeModelName(%q, watsonx) = %q, want verbatim", model, got)
+		}
+	}
+}
+
+// TestValidateBackendName covers the manager-side set-time gate that stops the
+// /switch/{backend} path from accepting a backend the launcher cannot start.
+func TestValidateBackendName(t *testing.T) {
+	m := &Manager{}
+	for _, ok := range []string{"", "claude", "copilot", "litellm", "vllm", "llm-d", "watsonx"} {
+		if err := m.validateBackendName(ok); err != nil {
+			t.Errorf("validateBackendName(%q) = %v, want nil", ok, err)
+		}
+	}
+	err := m.validateBackendName("totally-made-up")
+	if err == nil {
+		t.Fatal("validateBackendName(totally-made-up) = nil, want an error")
+	}
+	// The message must tell the operator what IS valid, not just what is not.
+	for _, want := range []string{"totally-made-up", "claude", "watsonx"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should mention %q", err.Error(), want)
+		}
+	}
+}
+
+// TestGatewayBackendNameStillValidates: a backend naming a configured gateway
+// is legal, and that must survive the new validation.
+func TestGatewayBackendNameStillValidates(t *testing.T) {
+	m := &Manager{}
+	checker := func(backend string) bool { return backend == "ibm-granite-prod" }
+	m.SetGatewayBackendChecker(checker)
+	if err := m.validateBackendName("ibm-granite-prod"); err != nil {
+		t.Fatalf("a configured gateway name must be a valid backend, got %v", err)
+	}
+	if err := m.validateBackendName("some-other-gateway"); err == nil {
+		t.Fatal("an unconfigured gateway name must not validate")
+	}
+}

--- a/v2/pkg/config/backend_validation_test.go
+++ b/v2/pkg/config/backend_validation_test.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// These tests cover the "silent accept-then-fail" half of the watsonx bug: the
+// config layer accepted `backend: watsonx` while the launcher rejected it at
+// kick time. Validation must now happen at SET time, against the same canonical
+// lists the launcher dispatches on.
+
+func TestValidateBackend_AcceptsWatsonx(t *testing.T) {
+	var g GovernorConfig
+	if err := g.ValidateBackend("watsonx"); err != nil {
+		t.Fatalf("ValidateBackend(watsonx) = %v, want nil", err)
+	}
+}
+
+func TestValidateBackend_AcceptsAllSupported(t *testing.T) {
+	var g GovernorConfig
+	// Empty means "hive default" and must stay valid.
+	if err := g.ValidateBackend(""); err != nil {
+		t.Errorf("ValidateBackend(\"\") = %v, want nil", err)
+	}
+	for _, b := range SupportedBackends() {
+		if err := g.ValidateBackend(b); err != nil {
+			t.Errorf("ValidateBackend(%q) = %v, want nil", b, err)
+		}
+	}
+}
+
+func TestValidateBackend_RejectsUnknownWithHelpfulMessage(t *testing.T) {
+	var g GovernorConfig
+	err := g.ValidateBackend("totally-made-up")
+	if err == nil {
+		t.Fatal("ValidateBackend(totally-made-up) = nil, want an error")
+	}
+	msg := err.Error()
+	// The message must name the offender AND enumerate what is valid — the
+	// whole point is that the operator learns this at set time.
+	if !strings.Contains(msg, "totally-made-up") {
+		t.Errorf("error %q should name the rejected backend", msg)
+	}
+	for _, want := range []string{"claude", "litellm", "watsonx"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q should list supported backend %q", msg, want)
+		}
+	}
+}
+
+// A gateway NAME is a valid backend, and the rejection message should point at
+// the configured gateways when there are any.
+func TestValidateBackend_AcceptsConfiguredGatewayName(t *testing.T) {
+	g := GovernorConfig{
+		Gateways: []GatewayConfig{
+			{Name: "ibm-granite-prod", Kind: GatewayKindWatsonx, Endpoint: "https://us-south.ml.cloud.ibm.com/ml/gateway"},
+		},
+	}
+	if err := g.ValidateBackend("ibm-granite-prod"); err != nil {
+		t.Fatalf("a configured gateway name must be a valid backend, got %v", err)
+	}
+	// Case-insensitive, mirroring ResolveGateway.
+	if err := g.ValidateBackend("IBM-Granite-Prod"); err != nil {
+		t.Fatalf("gateway name match must be case-insensitive, got %v", err)
+	}
+	err := g.ValidateBackend("not-a-gateway")
+	if err == nil {
+		t.Fatal("an unconfigured gateway name must be rejected")
+	}
+	if !strings.Contains(err.Error(), "ibm-granite-prod") {
+		t.Errorf("error %q should list the configured gateway names", err.Error())
+	}
+}
+
+// The canonical lists must not overlap: a backend is either an agentic CLI or a
+// model gateway, never both, or callers branching on one will mis-handle it.
+func TestBackendListsAreDisjoint(t *testing.T) {
+	for _, c := range CLIBackends {
+		if IsInferenceBackend(c) {
+			t.Errorf("backend %q is in both CLIBackends and InferenceBackends", c)
+		}
+	}
+	for _, i := range InferenceBackends {
+		if IsCLIBackend(i) {
+			t.Errorf("backend %q is in both InferenceBackends and CLIBackends", i)
+		}
+	}
+}
+
+// validate() must reject a bogus agent backend and accept watsonx — this is the
+// hive.yaml load path, the same gate the dashboard write path now uses.
+func TestValidate_AgentBackendGate(t *testing.T) {
+	base := func(backend string) *Config {
+		return &Config{
+			Project: ProjectConfig{Org: "my-org"},
+			GitHub:  GitHubConfig{Token: "t"},
+			Agents:  map[string]AgentConfig{"ci-maintainer": {Backend: backend}},
+		}
+	}
+	if err := base("watsonx").validate(); err != nil {
+		t.Fatalf("validate() with backend watsonx = %v, want nil", err)
+	}
+	err := base("totally-made-up").validate()
+	if err == nil {
+		t.Fatal("validate() with a bogus backend = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "ci-maintainer") {
+		t.Errorf("error %q should name the offending agent", err.Error())
+	}
+	if !strings.Contains(err.Error(), "watsonx") {
+		t.Errorf("error %q should enumerate supported backends", err.Error())
+	}
+}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -2891,11 +2891,23 @@ func applyKnownAgentDefaults(name string, agent *AgentConfig) {
 	}
 }
 
-// InferenceBackends is the canonical list of self-hosted inference backend
+// InferenceBackends is the canonical list of model-gateway / inference backend
 // IDs. It lives in the config package (a leaf in the import graph) so the
 // agent and proxy packages can share it without an import cycle
 // (proxy → agent → config).
-var InferenceBackends = []string{"vllm", "llm-d", "litellm"}
+//
+// These are NOT agentic CLIs. Every one of them names a model endpoint that
+// hive fronts with its own OpenAI-compatible translator and drives with the
+// claude CLI; auth is an API key (or, for watsonx, an IAM bearer minted from
+// one) supplied by config, never an interactive login.
+//
+// "watsonx" is here because IBM watsonx.ai is a model gateway in exactly that
+// sense. It was previously supported ONLY as a `gateways:` kind and as an
+// onboarding UI option, while the agent launcher had no case for it — so
+// `backend: watsonx` was accepted by config and then rejected hours later at
+// kick time with "unknown backend: watsonx". Anything that enumerates gateway
+// backends must read THIS list rather than repeating the members inline.
+var InferenceBackends = []string{"vllm", "llm-d", "litellm", "watsonx"}
 
 // IsInferenceBackend returns true if the backend name is a self-hosted
 // inference backend rather than a CLI tool.
@@ -2906,6 +2918,72 @@ func IsInferenceBackend(backend string) bool {
 		}
 	}
 	return false
+}
+
+// CLIBackends is the canonical list of agentic-CLI agent backends — backends
+// that launch a real coding CLI binary rather than routing to a model gateway.
+//
+// This exists so the CONFIG VALIDATOR and the LAUNCHER dispatch on one list.
+// They used to keep separate inline sets, which is the drift that let
+// `backend: watsonx` be accepted at config-set time and then fail at kick time
+// with "unknown backend: watsonx". Adding a backend in one place only is now a
+// visible omission rather than a silent accept-then-fail.
+var CLIBackends = []string{"claude", "copilot", "goose", "codex", "pi", "bob", "aider", "gemini"}
+
+// IsCLIBackend returns true if the backend launches an agentic CLI binary.
+func IsCLIBackend(backend string) bool {
+	for _, b := range CLIBackends {
+		if b == backend {
+			return true
+		}
+	}
+	return false
+}
+
+// SupportedBackends returns every backend name valid independent of this
+// hive's configuration: the agentic CLIs plus the model-gateway backends. A
+// configured gateway NAME is additionally valid as a backend, but that is
+// config-dependent and so is checked separately by the validator.
+func SupportedBackends() []string {
+	out := make([]string, 0, len(CLIBackends)+len(InferenceBackends))
+	out = append(out, CLIBackends...)
+	out = append(out, InferenceBackends...)
+	return out
+}
+
+// ValidateBackend reports whether backend is a usable agent backend for this
+// config, returning a descriptive error naming the supported values when it is
+// not. An empty backend is valid (it means "the hive default").
+//
+// This is the single gate the config write path uses so an unsupported backend
+// is refused AT SET TIME with a clear message, instead of being persisted and
+// surfacing later as an agent that silently never launches.
+func (g GovernorConfig) ValidateBackend(backend string) error {
+	if backend == "" {
+		return nil
+	}
+	if IsCLIBackend(backend) || IsInferenceBackend(backend) {
+		return nil
+	}
+	for _, gw := range g.ResolvedGateways() {
+		if gw.Name != "" && strings.EqualFold(gw.Name, backend) {
+			return nil
+		}
+	}
+	var gatewayNames []string
+	for _, gw := range g.ResolvedGateways() {
+		if gw.Name != "" {
+			gatewayNames = append(gatewayNames, gw.Name)
+		}
+	}
+	msg := fmt.Sprintf("unsupported backend %q (supported: %s",
+		backend, strings.Join(SupportedBackends(), ", "))
+	if len(gatewayNames) > 0 {
+		msg += fmt.Sprintf("; or a configured gateway name: %s", strings.Join(gatewayNames, ", "))
+	} else {
+		msg += "; or the name of a gateway configured under the Model Gateways tab"
+	}
+	return fmt.Errorf("%s)", msg)
 }
 
 func (c *Config) validate() error {
@@ -2937,25 +3015,14 @@ func (c *Config) validate() error {
 	if err := c.Governor.LiteLLM.Validate(); err != nil {
 		return err
 	}
-	// A configured gateway name is a valid agent backend: naming a gateway as
-	// the backend routes that agent through it. Names are matched
-	// case-insensitively to mirror ResolveGateway.
-	gatewayNames := map[string]bool{}
-	for _, gw := range c.Governor.ResolvedGateways() {
-		if gw.Name != "" {
-			gatewayNames[strings.ToLower(gw.Name)] = true
-		}
-	}
 	for name, agent := range c.Agents {
-		validBackends := map[string]bool{"claude": true, "copilot": true, "goose": true, "codex": true, "pi": true, "bob": true, "aider": true}
-		// Inference backends (vllm, llm-d, litellm) are valid persisted
-		// agent backends too — they launch the claude CLI routed through
-		// the inference translator.
-		for _, b := range InferenceBackends {
-			validBackends[b] = true
-		}
-		if agent.Backend != "" && !validBackends[agent.Backend] && !gatewayNames[strings.ToLower(agent.Backend)] {
-			return fmt.Errorf("agent %s: invalid backend %q (must be claude, copilot, goose, codex, pi, bob, aider, an inference backend: %s, or a configured gateway name)", name, agent.Backend, strings.Join(InferenceBackends, ", "))
+		// One gate, shared with the config write path (dashboard agent-config
+		// save) and agreeing with what the launcher can actually dispatch. A
+		// configured gateway name is valid too: naming a gateway as the backend
+		// routes that agent through it, matched case-insensitively to mirror
+		// ResolveGateway.
+		if err := c.Governor.ValidateBackend(agent.Backend); err != nil {
+			return fmt.Errorf("agent %s: %w", name, err)
 		}
 		validCavemanModes := map[string]bool{"": true, "lite": true, "full": true, "ultra": true, "wenyan": true}
 		if !validCavemanModes[agent.CavemanMode] {

--- a/v2/pkg/config/config_test.go
+++ b/v2/pkg/config/config_test.go
@@ -385,7 +385,7 @@ agents:
 }
 
 func TestValidate_ValidBackends(t *testing.T) {
-	validBackends := []string{"claude", "copilot", "goose", "codex", "pi", "bob", "aider", "vllm", "llm-d", "litellm"}
+	validBackends := SupportedBackends()
 	for _, backend := range validBackends {
 		t.Run(backend, func(t *testing.T) {
 			yaml := `

--- a/v2/pkg/config/litellm_test.go
+++ b/v2/pkg/config/litellm_test.go
@@ -113,7 +113,7 @@ governor:
 // ---------------------------------------------------------------------------
 
 func TestIsInferenceBackend_Config(t *testing.T) {
-	for _, b := range []string{"vllm", "llm-d", "litellm"} {
+	for _, b := range InferenceBackends {
 		if !IsInferenceBackend(b) {
 			t.Errorf("IsInferenceBackend(%q) = false, want true", b)
 		}

--- a/v2/pkg/dashboard/agent_auth_peruid_test.go
+++ b/v2/pkg/dashboard/agent_auth_peruid_test.go
@@ -28,7 +28,7 @@ func TestAgentCLIUnauthenticated_InferenceBackendNeverNeedsLogin(t *testing.T) {
 	// empty shared credential path produces.
 	probe := func(string) (bool, bool) { return false, true }
 
-	for _, backend := range []string{"litellm", "vllm", "llm-d"} {
+	for _, backend := range config.InferenceBackends {
 		for _, state := range []agent.ProcessState{agent.StateRunning, agent.StateStopped} {
 			p := &agent.AgentProcess{
 				State:  state,

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -2525,7 +2525,15 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 	}
 	if v, ok := body["cliPinValue"]; ok {
 		if str, ok := v.(string); ok && str != "" {
-			agentCfg.Backend = sanitizeString(str)
+			backend := sanitizeString(str)
+			// Validate at set time against the same list the launcher
+			// dispatches on — persisting an unsupported backend produces an
+			// agent that is accepted now and fails to launch later.
+			if err := s.deps.Config.Governor.ValidateBackend(backend); err != nil {
+				jsonError(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			agentCfg.Backend = backend
 			agentCfg.BackendOwner = config.FieldOwnerOperator
 			backendChanged = true
 		}
@@ -2778,7 +2786,16 @@ func (s *Server) handleAgentConfigModels(w http.ResponseWriter, r *http.Request)
 	// Operator edits claim ownership so the pack apply that runs on every
 	// restart cannot reconcile the choice back to the pack default.
 	if body.Backend != "" {
-		agentCfg.Backend = sanitizeString(body.Backend)
+		backend := sanitizeString(body.Backend)
+		// Refuse an unsupported backend HERE, at set time, with a message that
+		// names what is valid. Without this the value is persisted happily and
+		// the failure surfaces hours later as "unknown backend: <x>" on the
+		// kick path, with the agent silently never launching.
+		if err := s.deps.Config.Governor.ValidateBackend(backend); err != nil {
+			jsonError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		agentCfg.Backend = backend
 		agentCfg.BackendOwner = config.FieldOwnerOperator
 	}
 	if body.Model != "" {
@@ -4650,6 +4667,12 @@ func (s *Server) handleGovernorAddAgent(w http.ResponseWriter, r *http.Request) 
 
 	if body.Backend == "" {
 		body.Backend = "claude"
+	}
+	// Reject an unsupported backend before the agent is created, rather than
+	// creating an agent that can never launch.
+	if err := s.deps.Config.Governor.ValidateBackend(body.Backend); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	agentCfg := config.AgentConfig{

--- a/v2/pkg/dashboard/gateways.go
+++ b/v2/pkg/dashboard/gateways.go
@@ -34,14 +34,13 @@ const watsonxProbeMintTimeout = 10 * time.Second
 
 // watsonxEndpointForRegion builds the watsonx model-gateway base URL for a
 // region slug, falling back to the default region when blank. Mirrors how the
-// UI preset fills the endpoint; kept server-side too so the region template has
-// one source of truth.
+// UI preset fills the endpoint.
+//
+// The template itself now lives in pkg/watsonx so the AGENT LAUNCH path can
+// resolve the same endpoint for an agent whose backend is "watsonx"; this is a
+// thin delegate kept for call-site readability inside the dashboard.
 func watsonxEndpointForRegion(region string) string {
-	region = strings.TrimSpace(region)
-	if region == "" {
-		region = watsonxDefaultRegion
-	}
-	return fmt.Sprintf(watsonxBaseURLTemplate, region)
+	return watsonx.EndpointForRegion(region)
 }
 
 // gatewayProbeAuth resolves the bearer + extra request headers a /v1/models
@@ -73,17 +72,12 @@ const (
 	// as the preset endpoint when the UI picks the OpenRouter gateway kind.
 	openRouterBaseURL = "https://openrouter.ai/api/v1"
 
-	// watsonxBaseURLTemplate is the watsonx model-gateway base URL with a
-	// %s placeholder for the region slug (us-south, eu-de, jp-tok, …). hive
-	// appends /v1/models and /v1/chat/completions to reach watsonx's
-	// OpenAI-compatible surface (.../ml/gateway/v1/...). Used as the preset
-	// endpoint when the UI picks the watsonx gateway kind. Mirrors
-	// openRouterBaseURL for consistency.
-	watsonxBaseURLTemplate = "https://%s.ml.cloud.ibm.com/ml/gateway"
-
-	// watsonxDefaultRegion is the region the preset offers when none is chosen,
-	// so the endpoint template resolves to a concrete URL out of the box.
-	watsonxDefaultRegion = "us-south"
+	// watsonxBaseURLTemplate / watsonxDefaultRegion alias the canonical values
+	// in pkg/watsonx. They are NOT redefined here: the agent launch path needs
+	// the same template, and two copies is exactly how the gateway half and the
+	// agent half of watsonx support were able to disagree.
+	watsonxBaseURLTemplate = watsonx.BaseURLTemplate
+	watsonxDefaultRegion   = watsonx.DefaultRegion
 
 	// gatewaySecretFileMode / gatewaySecretDirMode keep gateway key files
 	// owner-only, matching the LiteLLM key store (litellmKeyFileMode).

--- a/v2/pkg/watsonx/endpoint.go
+++ b/v2/pkg/watsonx/endpoint.go
@@ -1,0 +1,34 @@
+package watsonx
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// BaseURLTemplate is the watsonx model-gateway base URL with a %s
+	// placeholder for the region slug (us-south, eu-de, jp-tok, …). hive
+	// appends /v1/models and /v1/chat/completions to reach watsonx's
+	// OpenAI-compatible surface (.../ml/gateway/v1/...).
+	//
+	// This lives in pkg/watsonx (a leaf package) rather than in the dashboard
+	// so that BOTH surfaces that need it — the Model Gateways UI preset and the
+	// AGENT LAUNCH path, which must resolve an endpoint for an agent whose
+	// backend is "watsonx" — derive it from one definition. Duplicating the
+	// template was how the gateway half and the agent half were free to drift.
+	BaseURLTemplate = "https://%s.ml.cloud.ibm.com/ml/gateway"
+
+	// DefaultRegion is the region used when none is configured, so the endpoint
+	// template always resolves to a concrete URL out of the box.
+	DefaultRegion = "us-south"
+)
+
+// EndpointForRegion builds the watsonx model-gateway base URL for a region
+// slug, falling back to DefaultRegion when blank.
+func EndpointForRegion(region string) string {
+	region = strings.TrimSpace(region)
+	if region == "" {
+		region = DefaultRegion
+	}
+	return fmt.Sprintf(BaseURLTemplate, region)
+}

--- a/v2/pkg/watsonx/endpoint_test.go
+++ b/v2/pkg/watsonx/endpoint_test.go
@@ -1,0 +1,47 @@
+package watsonx
+
+import (
+	"strings"
+	"testing"
+)
+
+// The endpoint template moved here from pkg/dashboard so the AGENT LAUNCH path
+// resolves the same URL the Model Gateways UI preset does. Two copies is how
+// the gateway half and the agent half of watsonx support were free to drift.
+
+func TestEndpointForRegion(t *testing.T) {
+	for _, tc := range []struct{ region, want string }{
+		{"us-south", "https://us-south.ml.cloud.ibm.com/ml/gateway"},
+		{"eu-de", "https://eu-de.ml.cloud.ibm.com/ml/gateway"},
+		{"jp-tok", "https://jp-tok.ml.cloud.ibm.com/ml/gateway"},
+		// Blank (and whitespace-only) falls back to the default region so the
+		// template always yields a concrete, usable URL.
+		{"", "https://us-south.ml.cloud.ibm.com/ml/gateway"},
+		{"   ", "https://us-south.ml.cloud.ibm.com/ml/gateway"},
+	} {
+		if got := EndpointForRegion(tc.region); got != tc.want {
+			t.Errorf("EndpointForRegion(%q) = %q, want %q", tc.region, got, tc.want)
+		}
+	}
+}
+
+// hive appends /v1/... to the base, so the base must NOT already carry a
+// version segment or a trailing slash.
+func TestEndpointForRegion_ShapeIsAOpenAIBase(t *testing.T) {
+	ep := EndpointForRegion("us-south")
+	if strings.HasSuffix(ep, "/") {
+		t.Errorf("endpoint %q must not end in a slash", ep)
+	}
+	if strings.Contains(ep, "/v1") {
+		t.Errorf("endpoint %q must not include /v1 — hive appends it", ep)
+	}
+	if !strings.HasPrefix(ep, "https://") {
+		t.Errorf("endpoint %q must be https", ep)
+	}
+}
+
+func TestDefaultRegionIsSubstitutedIntoTemplate(t *testing.T) {
+	if !strings.Contains(EndpointForRegion(DefaultRegion), DefaultRegion) {
+		t.Errorf("EndpointForRegion(DefaultRegion) should contain %q", DefaultRegion)
+	}
+}


### PR DESCRIPTION
## The bug (live, reproduced on a real spoke)

An operator configured agent `ci-maintainer` with `backend: watsonx` (hive `hosted-kubestellar-hive-ojv6`). The agent never launches:

```
HIVE LAUNCH FAILED: backend watsonx did not launch: unknown backend: watsonx.
The CLI for this backend is not installed in this hive image — upgrade the hive image or switch this agent to a different backend.
...
{"level":"WARN","msg":"failed to send kick","agent":"ci-maintainer","error":"agent ci-maintainer cannot be kicked: it failed to start: unknown backend: watsonx"}
```

The pod was bounced onto current `v2-latest` and still fails — **this is not image staleness.** Verified on v2 HEAD: the agent backend registry knew only `claude`, `codex`, `copilot`, `gemini`, `litellm`, `llm-d`, `vllm`. There is no `watsonx`.

### Root cause

watsonx code existed **only on the inference-gateway side**: `v2/pkg/watsonx/`, `v2/pkg/config/config.go`, `v2/pkg/proxy/inference_route.go`, `v2/pkg/dashboard/gateways.go`.

#2701 shipped watsonx as an inference **gateway kind**, and #2709 shipped it as a clanker **onboarding backend option** — but nobody taught the **agent launcher** to launch an agent whose `backend` is `watsonx`. The config layer accepted the value; the launcher rejected it at kick time. Classic silent accept-then-fail: the misconfiguration is invisible at the moment it's made and only surfaces hours later as an agent that quietly never runs.

## Part 1 — register `watsonx` as an agent backend

watsonx.ai is a **model gateway** (OpenAI-compatible endpoint + IAM-minted bearer token), not an agentic CLI, so it belongs with `litellm`/`vllm`/`llm-d` rather than with the CLI backends. It now joins `config.InferenceBackends`, the canonical list every gateway-backend check already reads.

- **Dispatch site extended:** `backendBinary` in `v2/pkg/agent/manager.go` — the exact function that emitted `unknown backend: %s`. Its gateway entries are now **derived from `config.InferenceBackends`** instead of being hardcoded, so a backend accepted by config can never again be unknown to the launcher.
- **Endpoint + auth reuse the existing plumbing, not reimplemented.** The launch path resolves the watsonx gateway by name-then-kind and takes endpoint, IBM Cloud key, project id and region from the configured `gateways:` entry. The IAM mint and `X-IBM-Project-ID` header are factored into a shared `resolveGatewayAuth` used by *both* the named-gateway branch and the new built-in `watsonx` branch, so the two cannot authenticate differently. `watsonx.DefaultMinter` (process-wide token cache) is reused as-is.
- **One endpoint template.** `watsonxEndpointForRegion` + the region/base-URL constants moved from `pkg/dashboard` into `pkg/watsonx` as `EndpointForRegion` / `BaseURLTemplate` / `DefaultRegion`, because the agent launch path needs the same template the UI preset uses. The dashboard helper is now a thin delegate. Two copies of that template is exactly how the gateway half and the agent half were free to drift.
- **No login badge.** `BackendRequiresInteractiveAuth("watsonx") == false` — auth is an API key exchanged for an IAM bearer, so there is no interactive login for an operator to perform and a 🔑 badge is always a false alarm (the rule from #2765).
- Model pinning, token accounting and pause/kick paths all key off `IsInferenceBackend`, so watsonx inherits litellm's behavior automatically.

## Part 2 — stop the silent accept-then-fail

This is the part that prevents the *next* occurrence. Backends are now validated **at set time**, against the same canonical lists the launcher dispatches on:

- **Centralized the list.** Added `config.CLIBackends`, `config.IsCLIBackend`, `config.SupportedBackends()` and `GovernorConfig.ValidateBackend()`. The validator's previously-inline `map[string]bool{"claude": true, ...}` is gone — `validate()` now calls the shared gate.
- **Gated every write path:** `hive.yaml` load (`config.validate`), and all three dashboard handlers that persist a backend (`handleAgentConfigModels`, the `cliPinValue` save, `handleGovernorAddAgent`) now return HTTP 400 with a message naming the offender and enumerating valid backends.
- **Gated `/switch/{backend}`.** `Manager.SetBackendOverride` previously accepted *any* string and restarted the agent into it; it now rejects a backend the launcher cannot dispatch via `validateBackendName`, which honors configured gateway names (resolved live).

Configured gateway *names* remain valid backends everywhere, matched case-insensitively to mirror `ResolveGateway`.

## Tests

- `watsonx` is a recognized backend — launching with `Backend: "watsonx"` never yields `unknown backend`.
- `BackendRequiresInteractiveAuth("watsonx") == false`, and the full auth-state path returns authenticated+known even with no credential files and a login-looking pane.
- Endpoint/region handling asserted against the shared `watsonx.EndpointForRegion` helper (region fallback, no trailing slash, no `/v1` — hive appends it).
- Config validation: `"totally-made-up"` is rejected at set time with a message listing valid backends; `watsonx` is accepted; a configured gateway name is accepted.
- **Anti-drift:** `TestEveryInferenceBackendHasABinary` asserts every backend config accepts is one the launcher can dispatch, and `TestBackendListsAreDisjoint` keeps the CLI and gateway lists from overlapping.
- The existing gateway-backend table tests (in `agent_unit_test.go`, `authprobe_test.go`, `manager_coverage2_test.go`, `config_test.go`, `litellm_test.go`, `agent_auth_peruid_test.go`) now **iterate `config.InferenceBackends`** rather than repeating `{litellm, vllm, llm-d}` inline, so the next backend added is covered everywhere automatically.

## Note on model semantics (follow-up, not this PR)

The reporting spoke had `backend: watsonx` with `model: claude-sonnet-4-6` — almost certainly an operator mis-set, since watsonx serves Granite et al., not Claude. **No model-name validation is added here** (model ids must pass through verbatim; rewriting them is what causes gateway 403s). Worth a follow-up: surface a clear runtime error on the launch path when the gateway rejects an unknown model, so this class of mis-set also fails loudly instead of silently.
