### PR TITLE
feat(dashboard): selecting watsonx guides to Model Gateways + auto-discovers models on key save

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -5284,7 +5284,7 @@ func (s *Server) handleInferenceModels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	models := fetchModelsFromEndpoints(endpoints, s.inferenceAPIKey(backend))
+	models := s.fetchInferenceModelsForBackend(backend, endpoints)
 	fallback := false
 	if len(models) == 0 {
 		s.logger.Warn("no models found from any endpoint", "backend", backend, "endpoints", len(endpoints))
@@ -5356,6 +5356,72 @@ func intersectEntitled(discovered, entitled []string) []string {
 		}
 	}
 	return out
+}
+
+// fetchInferenceModelsForBackend discovers a backend's models, honouring the
+// AUTH SCHEME of the gateway that backend resolves to. The plain path sends the
+// resolved key as a raw bearer, which is correct for litellm/vllm/llm-d — but a
+// watsonx gateway needs an IAM-minted bearer plus the X-IBM-Project-ID header,
+// so sending the raw IBM Cloud key returns 401 and the dropdown silently fell
+// back to unrelated static aliases. Reuses the same gatewayProbeAuth +
+// fetchModelsWithHeaders pair the Model Gateways tab's discover/test paths use,
+// so the agent's model dropdown and the gateway form agree on what is available.
+// Falls back to the legacy raw-key path whenever no gateway resolves for this
+// name (env-configured vllm/llm-d endpoints), keeping existing behaviour.
+func (s *Server) fetchInferenceModelsForBackend(backend string, endpoints []string) []string {
+	gw := s.resolveGatewayForBackend(backend)
+	if gw == nil || !gatewayKindNeedsProbeAuth(gw.Kind) {
+		return fetchModelsFromEndpoints(endpoints, s.inferenceAPIKey(backend))
+	}
+	bearer, headers, err := gatewayProbeAuth(gw.Kind, gw.ResolveAPIKey(), gw.ProjectID)
+	if err != nil {
+		s.logger.Warn("gateway auth for model discovery failed",
+			"backend", backend, "kind", gw.Kind, "error", err)
+		return nil
+	}
+	seen := make(map[string]bool)
+	var all []string
+	for _, ep := range endpoints {
+		models, err := fetchModelsWithHeaders(ep, bearer, headers)
+		if err != nil {
+			s.logger.Warn("model discovery failed",
+				"backend", backend, "kind", gw.Kind, "endpoint", ep, "error", err)
+			continue
+		}
+		for _, m := range models {
+			if !seen[m] {
+				seen[m] = true
+				all = append(all, m)
+			}
+		}
+	}
+	return all
+}
+
+// gatewayKindNeedsProbeAuth reports whether a gateway kind requires the
+// gatewayProbeAuth path (a minted bearer and/or extra headers) rather than the
+// raw key. Only watsonx does today; keeping it a predicate means a future kind
+// with its own auth scheme is a one-line change here rather than a new branch in
+// every discovery caller.
+func gatewayKindNeedsProbeAuth(kind string) bool {
+	return kind == config.GatewayKindWatsonx
+}
+
+// resolveGatewayForBackend finds the configured gateway an agent backend routes
+// through. Agent backends name a gateway directly (registerGatewayEndpoints
+// keys the endpoint registry by gateway NAME), and the built-in gateway methods
+// share their name with their kind, so match on either.
+func (s *Server) resolveGatewayForBackend(backend string) *config.GatewayConfig {
+	if s.deps == nil || s.deps.Config == nil {
+		return nil
+	}
+	for _, gw := range s.deps.Config.Governor.ResolvedGateways() {
+		if strings.EqualFold(gw.Name, backend) || strings.EqualFold(gw.Kind, backend) {
+			out := gw
+			return &out
+		}
+	}
+	return nil
 }
 
 // inferenceAPIKey returns the bearer key used for a backend's model

--- a/v2/pkg/dashboard/gateway_onboarding_test.go
+++ b/v2/pkg/dashboard/gateway_onboarding_test.go
@@ -1,0 +1,288 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/watsonx"
+)
+
+// writeTempKeyFile stores a gateway key VALUE in a temp file and returns its
+// path, mirroring how the server records keys (api_key_file, never inline).
+func writeTempKeyFile(t *testing.T, key string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "gateway_api_key")
+	if err := os.WriteFile(path, []byte(key), 0o600); err != nil {
+		t.Fatalf("writing key file: %v", err)
+	}
+	return path
+}
+
+// The onboarding flow these tests pin: an operator once set an agent's backend
+// to watsonx with no watsonx gateway configured, and the agent silently failed
+// to launch for a day ("unknown backend: watsonx"). Selecting a gateway-backed
+// method must now route the operator to Model Gateways to supply the key, and
+// once the key is saved model discovery must populate the dropdown.
+
+// The agent-config dialog's method picker must go through the SHARED guard, not
+// a litellm-only check — that hardcoded 'litellm' comparison is exactly what let
+// a watsonx selection through unchallenged.
+func TestCliPinChangeUsesSharedGatewayGuard(t *testing.T) {
+	html := indexHTML(t)
+	if !strings.Contains(html, "if (!(await ensureGatewayMethodConfigured(sel.value))) {") {
+		t.Error("onCliPinChange must gate every method through ensureGatewayMethodConfigured")
+	}
+	// The old litellm-only guards must be gone from all three call sites.
+	if strings.Contains(html, "sel.value === 'litellm' && !(await ensureLiteLLMConfigured())") {
+		t.Error("onCliPinChange still has the litellm-only guard")
+	}
+	if strings.Contains(html, "generalData.cliPinValue === 'litellm' && !(await ensureLiteLLMConfigured())") {
+		t.Error("agent-create save still has the litellm-only guard")
+	}
+	if strings.Contains(html, "dirty.general.cliPinValue === 'litellm' && !(await ensureLiteLLMConfigured())") {
+		t.Error("agent-config save still has the litellm-only guard")
+	}
+}
+
+// The guard mirrors the litellm path rather than reimplementing it: litellm
+// keeps its dedicated endpoint+key prompt, and every other gateway method lands
+// on the Model Gateways tab with the add-form preset to that kind.
+func TestGatewayGuardMirrorsLiteLLMAndOpensModelGateways(t *testing.T) {
+	html := indexHTML(t)
+	cases := []struct {
+		name    string
+		snippet string
+	}{
+		{"delegates litellm to the existing prompt", "if (method === 'litellm') return ensureLiteLLMConfigured();"},
+		{"only guards gateway-backed methods", "if (!GATEWAY_METHODS.includes(method)) return true;"},
+		{"presets the add form to this kind", "_pendingGatewayPresetKind = method;"},
+		{"opens the Model Gateways tab", "openConfigDialog('governor', null, 'Model Gateways');"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(html, tc.snippet) {
+				t.Errorf("ensureGatewayMethodConfigured is missing %q", tc.snippet)
+			}
+		})
+	}
+	// watsonx must be one of the guarded methods (the required case).
+	if !strings.Contains(html, "const GATEWAY_METHODS = ['openrouter', 'litellm', 'vllm', 'llm-d', 'watsonx'];") {
+		t.Error("GATEWAY_METHODS must cover watsonx alongside the other gateway kinds")
+	}
+}
+
+// A gateway that exists but carries no API key must NOT satisfy the guard: a
+// keyless watsonx gateway mints no IAM token, so it fails exactly like a missing
+// one. Conversely a configured+keyed gateway must not interrupt the operator.
+func TestGatewayGuardRequiresKeyNotJustPresence(t *testing.T) {
+	html := indexHTML(t)
+	if !strings.Contains(html, "if (gw && gw.hasKey) return true;") {
+		t.Error("the guard must require hasKey, not merely a gateway of the right kind")
+	}
+	// A live (non-fallback) discovery proves the method works even without a
+	// named gateway (env-configured endpoints) — do not interrupt then.
+	if !strings.Contains(html, "if (cached && !cached.fallback) return true;") {
+		t.Error("a live non-fallback discovery must short-circuit the guard")
+	}
+}
+
+// After the key is saved, discovery must re-run and repaint the agent dropdowns
+// with no manual refresh — the second half of the operator's requirement.
+func TestGatewaySaveTriggersModelDiscoveryAndPopulation(t *testing.T) {
+	html := indexHTML(t)
+	cases := []struct {
+		name    string
+		snippet string
+	}{
+		{"save closes the loop", "refreshMethodModelsAfterGatewaySave(payload.kind, payload.name);"},
+		{"forces a fresh discovery past the TTL cache", "models = await fetchInferenceModels(method, true);"},
+		{"repaints the agent model dropdown", "await updateModelDropdown(a.name, method);"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(html, tc.snippet) {
+				t.Errorf("the post-save discovery path is missing %q", tc.snippet)
+			}
+		})
+	}
+}
+
+// A failed probe must say why, with the server's own error text, instead of
+// rendering an empty dropdown that looks like "this gateway has no models".
+func TestProbeFailureSurfacesErrorNotSilentEmptyList(t *testing.T) {
+	html := indexHTML(t)
+	cases := []struct {
+		name    string
+		snippet string
+	}{
+		{"echoes the server error", "showGatewayFormProbeError(data.error || 'Model discovery failed — check the endpoint and API key.');"},
+		{"explains a connected-but-empty list", "showGatewayFormProbeError('Connected, but the gateway returned no models."},
+		{"reports network failures", "showGatewayFormProbeError('Network error while discovering models: ' + e.message);"},
+		{"flags a fallback list after save", "model discovery did not return a live list"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(html, tc.snippet) {
+				t.Errorf("probe error reporting is missing %q", tc.snippet)
+			}
+		})
+	}
+}
+
+// Model discovery for an agent backend must use the gateway's OWN auth scheme.
+// A watsonx gateway needs an IAM-minted bearer plus X-IBM-Project-ID; sending
+// the raw IBM Cloud key as a bearer 401s, and the dropdown then silently served
+// unrelated static aliases.
+func TestInferenceModelsUsesWatsonxIAMBearer(t *testing.T) {
+	var gotAuth, gotProject string
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotProject = r.Header.Get(watsonx.ProjectIDHeader)
+		if gotAuth != "Bearer IAM-JWT" || gotProject == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]string{{"id": "ibm/granite-4-h-small"}},
+		})
+	}))
+	defer gateway.Close()
+
+	iam := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "IAM-JWT", "expires_in": 3600})
+	}))
+	defer iam.Close()
+	origMinter := watsonx.DefaultMinter
+	watsonx.DefaultMinter = watsonx.NewTokenMinterForTest(iam.URL+"/identity/token", nil)
+	t.Cleanup(func() { watsonx.DefaultMinter = origMinter })
+
+	srv := newFullServer(t)
+	keyFile := writeTempKeyFile(t, "ibm-cloud-key-1234567890")
+	srv.deps.Config.Governor.Gateways = []config.GatewayConfig{{
+		Name:       "watsonx",
+		Kind:       config.GatewayKindWatsonx,
+		Endpoint:   gateway.URL,
+		APIKeyFile: keyFile,
+		ProjectID:  "proj-42",
+	}}
+	srv.registerGatewayEndpoints()
+
+	models := srv.fetchInferenceModelsForBackend("watsonx", []string{gateway.URL})
+	if len(models) != 1 || models[0] != "ibm/granite-4-h-small" {
+		t.Fatalf("models = %v, want the granite id discovered via the IAM bearer", models)
+	}
+	if gotAuth != "Bearer IAM-JWT" {
+		t.Errorf("Authorization = %q, want the minted IAM bearer (not the raw key)", gotAuth)
+	}
+	if gotProject != "proj-42" {
+		t.Errorf("%s = %q, want the configured project id", watsonx.ProjectIDHeader, gotProject)
+	}
+}
+
+// Non-watsonx gateways keep the legacy raw-key discovery path untouched.
+func TestInferenceModelsNonWatsonxUsesRawKeyPath(t *testing.T) {
+	var gotAuth string
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]string{{"id": "gpt-4o"}},
+		})
+	}))
+	defer gateway.Close()
+
+	srv := newFullServer(t)
+	keyFile := writeTempKeyFile(t, "sk-raw-litellm-key")
+	srv.deps.Config.Governor.Gateways = []config.GatewayConfig{{
+		Name:     "litellm",
+		Kind:     config.GatewayKindLiteLLM,
+		Endpoint: gateway.URL,
+	}}
+	// Non-watsonx discovery keeps resolving its key through the legacy
+	// inferenceAPIKey path (governor.litellm), not the gateway entry — pinning
+	// that here is what proves the raw-key path is untouched by this change.
+	srv.deps.Config.Governor.LiteLLM = config.LiteLLMConfig{
+		Endpoint:   gateway.URL,
+		APIKeyFile: keyFile,
+	}
+	srv.registerGatewayEndpoints()
+
+	models := srv.fetchInferenceModelsForBackend("litellm", []string{gateway.URL})
+	if len(models) != 1 || models[0] != "gpt-4o" {
+		t.Fatalf("models = %v, want the discovered litellm model", models)
+	}
+	if gotAuth != "Bearer sk-raw-litellm-key" {
+		t.Errorf("Authorization = %q, want the raw key unchanged for non-watsonx", gotAuth)
+	}
+}
+
+// gatewayKindNeedsProbeAuth is the single predicate deciding which kinds need
+// the minted-bearer path, so a new kind is one edit rather than a new branch in
+// every discovery caller.
+func TestGatewayKindNeedsProbeAuth(t *testing.T) {
+	if !gatewayKindNeedsProbeAuth(config.GatewayKindWatsonx) {
+		t.Error("watsonx must use the gatewayProbeAuth path")
+	}
+	for _, kind := range []string{
+		config.GatewayKindLiteLLM,
+		config.GatewayKindVLLM,
+		config.GatewayKindLLMD,
+		config.GatewayKindOpenRouter,
+		config.GatewayKindCustom,
+	} {
+		if gatewayKindNeedsProbeAuth(kind) {
+			t.Errorf("kind %q must keep the raw-key discovery path", kind)
+		}
+	}
+}
+
+// A backend resolves to its gateway by NAME or by KIND, since agent backends
+// name a gateway directly and the built-in methods share name and kind.
+func TestResolveGatewayForBackend(t *testing.T) {
+	srv := newFullServer(t)
+	srv.deps.Config.Governor.Gateways = []config.GatewayConfig{{
+		Name:     "corp-watsonx",
+		Kind:     config.GatewayKindWatsonx,
+		Endpoint: "https://us-south.ml.cloud.ibm.com/ml/gateway",
+	}}
+	if gw := srv.resolveGatewayForBackend("corp-watsonx"); gw == nil || gw.Kind != config.GatewayKindWatsonx {
+		t.Errorf("lookup by name failed: %+v", gw)
+	}
+	if gw := srv.resolveGatewayForBackend("watsonx"); gw == nil || gw.Name != "corp-watsonx" {
+		t.Errorf("lookup by kind failed: %+v", gw)
+	}
+	if gw := srv.resolveGatewayForBackend("nope"); gw != nil {
+		t.Errorf("unknown backend should resolve to no gateway, got %+v", gw)
+	}
+}
+
+// A watsonx gateway whose key does not mint must yield NO models rather than a
+// misleading list — the caller then marks the dropdown as a fallback.
+func TestInferenceModelsWatsonxMintFailureReturnsNoModels(t *testing.T) {
+	iam := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"errorMessage":"Provided API key could not be found"}`))
+	}))
+	defer iam.Close()
+	origMinter := watsonx.DefaultMinter
+	watsonx.DefaultMinter = watsonx.NewTokenMinterForTest(iam.URL+"/identity/token", nil)
+	t.Cleanup(func() { watsonx.DefaultMinter = origMinter })
+
+	srv := newFullServer(t)
+	keyFile := writeTempKeyFile(t, "bad-key")
+	srv.deps.Config.Governor.Gateways = []config.GatewayConfig{{
+		Name:       "watsonx",
+		Kind:       config.GatewayKindWatsonx,
+		Endpoint:   "https://us-south.ml.cloud.ibm.com/ml/gateway",
+		APIKeyFile: keyFile,
+		ProjectID:  "proj-42",
+	}}
+	if models := srv.fetchInferenceModelsForBackend("watsonx", []string{"https://us-south.ml.cloud.ibm.com/ml/gateway"}); len(models) != 0 {
+		t.Fatalf("models = %v, want none when the IAM mint fails", models)
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -12332,6 +12332,51 @@ function burnAreaChart() {
       dismissToast(toast, `${agent} restart counter reset`, 'success');
     }
 
+    // ensureGatewayMethodConfigured is the SHARED guard for the agent-config
+    // dialog flows (CLI pin / create): picking a gateway-backed method whose
+    // gateway is missing (or has no key) must not silently save a method the
+    // agent cannot actually run — an operator once set backend: watsonx with no
+    // watsonx gateway and the agent failed to launch for a day with only
+    // "unknown backend: watsonx" in the log. litellm keeps its dedicated
+    // endpoint+key prompt (it has a legacy governor.litellm block the others do
+    // not); every other gateway method routes to the Model Gateways tab, which
+    // is where its key is entered. Resolves true when the method is (or has just
+    // been) configured, false when the user backs out — same contract as
+    // ensureLiteLLMConfigured, so all three call sites treat every method alike.
+    async function ensureGatewayMethodConfigured(method) {
+      if (method === 'litellm') return ensureLiteLLMConfigured();
+      if (!GATEWAY_METHODS.includes(method)) return true;
+      // A live (non-fallback) discovery proves the method is genuinely usable
+      // (possibly via HIVE_*_ENDPOINT env, which never appears in the gateway
+      // list) — mirrors the same check maybeOpenMethodConfig makes.
+      const cached = _inferenceModelCache[method];
+      if (cached && !cached.fallback) return true;
+      let gateways = [];
+      try {
+        const r = await fetch('/api/config/governor/gateways');
+        if (!r.ok) return true; // presence check is best-effort — never block on it
+        const d = await r.json();
+        gateways = d.gateways || [];
+      } catch (e) { return true; }
+      // Require BOTH a matching gateway and a key on it: a watsonx gateway saved
+      // without a key mints no IAM token, so model discovery and inference fail
+      // exactly as if no gateway existed at all.
+      const gw = gateways.find(g => g && (g.kind === method || g.name === method));
+      if (gw && gw.hasKey) return true;
+      const why = gw
+        ? `The ${method} gateway has no API key — ${method} needs one before this agent can run.`
+        : `No ${method} gateway is configured — ${method} needs an API key before this agent can run.`;
+      if (!(await hiveConfirm(`${why}\n\nOpen Governor Config → Model Gateways to set it up? Unsaved changes in this dialog will be discarded.`))) {
+        return false;
+      }
+      // Land directly on a NEW gateway form pre-set to this method's kind
+      // (endpoint/preset already filled), consumed once by loadGateways().
+      _pendingGatewayPresetKind = method;
+      closeConfigDialog();
+      openConfigDialog('governor', null, 'Model Gateways');
+      return false;
+    }
+
     // Prompts for the LiteLLM endpoint + API key when litellm is picked in
     // the agent-config dialog flows (CLI pin / create), where navigating to
     // Governor Config would discard unsaved edits. The agent-card METHOD
@@ -14968,6 +15013,64 @@ function burnAreaChart() {
       }
     }
 
+    // refreshMethodModelsAfterGatewaySave re-runs live model discovery for the
+    // method a just-saved gateway backs, then repaints the model dropdown of
+    // every agent already using that method. This is the "once the key is
+    // entered, auto-discovery and population occur" half of the onboarding flow:
+    // without it the operator saves the key and still sees a stale/empty model
+    // list until a manual refresh. Re-uses fetchInferenceModels (force=true to
+    // bypass its TTL cache, since the key that makes discovery succeed was only
+    // just written) and the existing updateModelDropdown repaint path.
+    async function refreshMethodModelsAfterGatewaySave(kind, name) {
+      // A gateway is reachable from an agent under its NAME, and the built-in
+      // methods share their name with their kind — refresh both spellings.
+      const methods = [];
+      [kind, name].forEach(m => {
+        if (m && INFERENCE_BACKENDS.includes(m) && !methods.includes(m)) methods.push(m);
+      });
+      if (!methods.includes(name) && name && _configuredGateways.includes(name)) methods.push(name);
+      for (const method of methods) {
+        let models = [];
+        try {
+          models = await fetchInferenceModels(method, true);
+        } catch (e) { continue; }
+        if (!models.length) continue;
+        const cached = _inferenceModelCache[method];
+        if (cached && cached.fallback) {
+          // Discovery still is not working (bad key/region/project): say so
+          // rather than letting unverified aliases masquerade as discovered.
+          showToast(`${method} gateway saved, but model discovery did not return a live list — check the key and try Test.`, 'error');
+          continue;
+        }
+        showToast(`${method}: ${models.length} model${models.length === 1 ? '' : 's'} discovered`, 'success');
+        // Repaint the dropdown for every agent on this method so a discovered
+        // model can be picked right away.
+        for (const a of (window._lastAgents || []).filter(x => x.cli === method)) {
+          await updateModelDropdown(a.name, method);
+        }
+      }
+    }
+
+    // Inline feedback for the add/edit form's live model discovery, rendered in
+    // the same #gw-form-result strip the save-time probe uses so a discovery
+    // failure and a save failure look alike. Kept separate from showGatewayProbe
+    // because discovery runs while typing (debounced) and must not claim the
+    // gateway was saved.
+    function showGatewayFormProbeError(msg) {
+      const el = document.getElementById('gw-form-result');
+      if (!el) return;
+      el.style.display = 'block';
+      el.style.color = 'var(--red)';
+      el.textContent = msg;
+    }
+
+    function clearGatewayFormProbeError() {
+      const el = document.getElementById('gw-form-result');
+      if (!el) return;
+      el.style.display = 'none';
+      el.textContent = '';
+    }
+
     async function deleteGateway(name) {
       if (!confirm('Delete gateway "' + name + '"? Agents that route through it must be repointed first.')) return;
       try {
@@ -15171,8 +15274,19 @@ function burnAreaChart() {
         });
         const data = await res.json().catch(() => ({}));
         _gatewayFormModels = (res.ok && data.ok && Array.isArray(data.models)) ? data.models : [];
+        // Never show an empty dropdown with no explanation: a bad key, wrong
+        // region/project or an unreachable endpoint must say so, with the
+        // server's own error text, rather than looking like "no models exist".
+        if (!res.ok || !data.ok) {
+          showGatewayFormProbeError(data.error || 'Model discovery failed — check the endpoint and API key.');
+        } else if (!_gatewayFormModels.length) {
+          showGatewayFormProbeError('Connected, but the gateway returned no models. Check the key\'s entitlements' + (kindEl && kindEl.value === 'watsonx' ? ' and the project id.' : '.'));
+        } else {
+          clearGatewayFormProbeError();
+        }
       } catch (e) {
         _gatewayFormModels = [];
+        showGatewayFormProbeError('Network error while discovering models: ' + e.message);
       }
       const host = document.getElementById('gw-default-model-field');
       if (host) host.innerHTML = gatewayDefaultModelFieldHtml(current);
@@ -15225,6 +15339,12 @@ function burnAreaChart() {
         showToast('Gateway "' + payload.name + '" saved', 'success');
         closeGatewayForm();
         loadGateways();
+        // Close the loop back to the agent that sent the operator here: now
+        // that the key is stored, re-run discovery for this method and push the
+        // result into the agent model dropdowns, so a model can be picked
+        // immediately with no manual refresh. Force-bypasses the TTL cache
+        // because the key that makes discovery succeed was just written.
+        refreshMethodModelsAfterGatewaySave(payload.kind, payload.name);
       } catch (e) {
         showToast('Failed to save gateway: ' + e.message, 'error');
       }
@@ -17456,11 +17576,12 @@ function burnAreaChart() {
       return { type: 'github', owner: owner, repo: repo, path: path, ref: ref };
     }
 
-    // onchange handler for the CLI Pin Value select — prompts for the
-    // LiteLLM endpoint (and reverts the selection on cancel) before
-    // recording the change.
+    // onchange handler for the CLI Pin Value select — ensures the selected
+    // gateway method is actually configured (prompting for the LiteLLM
+    // endpoint, or routing to Model Gateways for the others) and reverts the
+    // selection when it is not, before recording the change.
     async function onCliPinChange(sel) {
-      if (sel.value === 'litellm' && !(await ensureLiteLLMConfigured())) {
+      if (!(await ensureGatewayMethodConfigured(sel.value))) {
         sel.value = sel.dataset.prev || 'claude';
         return;
       }
@@ -17806,7 +17927,7 @@ function burnAreaChart() {
           showToast('Name must be lowercase letters, numbers, and hyphens', 'error');
           return;
         }
-        if (generalData.cliPinValue === 'litellm' && !(await ensureLiteLLMConfigured())) return;
+        if (!(await ensureGatewayMethodConfigured(generalData.cliPinValue))) return;
         const agent = {
           backend: generalData.cliPinValue || 'copilot',
           model: generalData.model || '',
@@ -17867,9 +17988,11 @@ function burnAreaChart() {
         showToast('No changes to save', 'info');
         return;
       }
-      // Pinning an agent to litellm requires a configured endpoint —
-      // prompt (and abort the save on cancel) before PUTting the section.
-      if (dirty.general && dirty.general.cliPinValue === 'litellm' && !(await ensureLiteLLMConfigured())) return;
+      // Pinning an agent to a gateway method requires that gateway to be
+      // configured WITH a key — prompt (and abort the save when the operator
+      // backs out or is routed to Model Gateways) before PUTting the section.
+      if (dirty.general && dirty.general.cliPinValue !== undefined &&
+          !(await ensureGatewayMethodConfigured(dirty.general.cliPinValue))) return;
       const base = _configState.type === 'governor' ? '/api/config/governor' : `/api/config/agent/${_configState.agent}`;
       let success = true;
       for (const [section, values] of Object.entries(dirty)) {


### PR DESCRIPTION
## Operator requirement

> "changing to the watsonx method should open the governor config model gateway tab to remind the user to enter an apikey for watson. once that is entered, model auto-discovery and population should occur."

Follow-up scope note from the operator: *"this should match the way litellm method selection would flow."* — so this is a generalization of the existing litellm path, not a parallel watsonx implementation.

## Why

An operator set an agent's `backend: watsonx` with no watsonx gateway configured (no API key). The agent silently failed to launch for **~a day**, with only `unknown backend: watsonx` in the log. Nothing in the UI connected the method choice to the missing key.

Two independent gaps caused that:

1. The agent-config dialog's guard was hardcoded to litellm — `sel.value === 'litellm' && !(await ensureLiteLLMConfigured())` at three call sites. Every other gateway method (watsonx included) was saved unchallenged even with no gateway behind it. (The agent-*card* method dropdown already did the right thing via `maybeOpenMethodConfig`; only the dialog path was missing it.)
2. Even with a gateway saved, `handleInferenceModels` sent the resolved key as a **raw bearer**. watsonx needs an IAM-minted bearer plus `X-IBM-Project-ID`, so discovery 401'd and the dropdown silently fell back to unrelated static aliases (`claude_opus_4.8`, …).

## The litellm flow this mirrors

Traced on v2 HEAD before writing anything:

- `onCliPinChange` (agent-config dialog) → `ensureLiteLLMConfigured()` → if unconfigured, a modal prompts for endpoint + key, PUTs `/api/config/governor/litellm`, and shows the server's save-time `probe` result inline; cancelling reverts the select.
- `switchCli` (agent card) → `maybeOpenMethodConfig(backend)` → for a `GATEWAY_METHODS` member with no matching gateway, sets `_pendingGatewayPresetKind` and calls `openConfigDialog('governor', null, 'Model Gateways')`; `loadGateways()` consumes the preset and auto-opens a pre-filled add form.
- Default-model population: `onGatewayEndpointOrKeyChange()` debounces `probeGatewayFormModels()` → `POST /api/config/governor/gateways/discover` → re-renders `#gw-default-model-field`.
- `updateInferenceModelsFromSSE` re-renders litellm's default-model field on live "models pulled" pushes.

## What changed

**Shared guard (replaces the litellm-only one).** `ensureGatewayMethodConfigured(method)` now backs all three agent-config call sites. `litellm` delegates to the untouched `ensureLiteLLMConfigured()` (it has a legacy `governor.litellm` block the others do not); every other `GATEWAY_METHODS` entry routes to Model Gateways with the add form preset to that kind — reusing `_pendingGatewayPresetKind` + `openConfigDialog(…, 'Model Gateways')`, the same helpers `maybeOpenMethodConfig` uses. A gateway that exists but has **no key** does not satisfy the guard (a keyless watsonx gateway mints no IAM token, so it fails identically to a missing one). A configured+keyed gateway never interrupts, and a live non-fallback discovery short-circuits the check so env-configured vllm/llm-d endpoints are unaffected.

**Discovery honours the gateway's auth scheme.** `fetchInferenceModelsForBackend` reuses `gatewayProbeAuth` + `fetchModelsWithHeaders` — the same pair `handleGovernorGatewaysDiscover` / `gatewayProbeResult` use — so the agent's model dropdown and the Model Gateways form now agree on what is available. Non-watsonx kinds keep the legacy raw-key path, selected by the one-line `gatewayKindNeedsProbeAuth` predicate so a future kind with its own auth scheme is a single edit.

**Key saved → models populate.** `refreshMethodModelsAfterGatewaySave(kind, name)` re-runs `fetchInferenceModels(method, true)` (force past the 30s TTL, since the key that makes discovery succeed was only just written) and repaints the dropdown of every agent on that method via the existing `updateModelDropdown`. No manual refresh click.

**No silent empty lists.** Form discovery failures render the server's own error text in `#gw-form-result` (bad key / wrong region / project id / network), and a post-save discovery that still returns only fallback aliases says so rather than passing them off as discovered.

## Existing helpers reused (nothing rebuilt)

| Reused | From |
|---|---|
| `gatewayProbeAuth(kind, key, projectID)` | `v2/pkg/dashboard/gateways.go` |
| `fetchModelsWithHeaders(baseURL, apiKey, extraHeaders)` | `v2/pkg/dashboard/api.go` |
| `watsonx.DefaultMinter.Token` / `watsonx.ProjectIDHeader` | `v2/pkg/watsonx/iam.go` |
| `ResolvedGateways()` / `ResolveGateway()` / `ResolveAPIKey()` | `v2/pkg/config/config.go` |
| `ensureLiteLLMConfigured`, `maybeOpenMethodConfig`, `openConfigDialog(…, 'Model Gateways')`, `_pendingGatewayPresetKind`, `fetchInferenceModels`, `updateModelDropdown`, `hiveConfirm`, `showToast` | `static/index.html` |

Deliberately did **not** touch `v2/pkg/dashboard/gateways.go` — that is the sibling `feat/watsonx-agent-backend` branch's file, and this PR does not depend on its code.

## Deferred

**Preselecting a default model is deferred.** Discovery populates the dropdown and the gateway's own `default_model` is already persisted, but auto-selecting a Granite id onto the agent would risk overwriting a model the operator typed; the ownership rules for that live in `reconcileModelsAfterDiscovery` / `agent_model_ownership`. Left as an explicit pick.

The Go-side `backendBinary` registration of `watsonx` (the literal `unknown backend: watsonx` error) remains the sibling PR's job — this is the UX half.

## Tests

`v2/pkg/dashboard/gateway_onboarding_test.go` — `strings.Contains` pins on the rendered HTML/JS (repo convention, via the existing `indexHTML(t)` helper) plus Go tests for the server side:

- selecting a gateway method with no configured gateway routes to Model Gateways; with a configured **and keyed** gateway it does not; a keyless gateway does not satisfy the guard
- the three litellm-only guards are gone (asserted absent, so they cannot creep back)
- key save triggers forced discovery + dropdown repaint
- probe failure surfaces an error rather than an empty silent list
- watsonx discovery uses the **minted IAM bearer** + `X-IBM-Project-ID` (fake IAM + gateway servers, no network); non-watsonx keeps the raw key unchanged
- IAM mint failure yields no models rather than a misleading list
- `resolveGatewayForBackend` matches by name and by kind

`go build ./...` clean, `gofmt`/`go vet` clean, `node --check` clean on the extracted inline JS, and `./pkg/dashboard` + `./pkg/config` suites pass locally. CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
