### PR TITLE
🐛 Fix IPv4-only healthchecks

### DIFF
--- a/bin/hive-setup.sh
+++ b/bin/hive-setup.sh
@@ -277,7 +277,7 @@ services:
       - NTFY_SERVER=\${NTFY_SERVER}
       - NTFY_TOPIC=\${NTFY_TOPIC}
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:3001/api/health"]
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:3001/api/health"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -312,7 +312,7 @@ run "cd ${HIVE_DIR}/v2/deploy && docker compose -f docker-compose.${TARGET_REPO_
 log "  Waiting for dashboard..."
 HEALTH_OK=false
 for i in $(seq 1 15); do
-  if curl -sf http://localhost:3001/api/health &>/dev/null; then
+  if curl -sf http://127.0.0.1:3001/api/health &>/dev/null; then
     HEALTH_OK=true
     break
   fi

--- a/v2/deploy/blue-green-deploy.sh
+++ b/v2/deploy/blue-green-deploy.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 COMPOSE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$COMPOSE_DIR"
 
-HEALTH_URL="http://localhost:3001/api/health"
+HEALTH_URL="http://127.0.0.1:3001/api/health"
 HEALTH_INTERVAL_S=5
 HEALTH_TIMEOUT_S=180
 
@@ -94,7 +94,7 @@ docker run -d \
     -v "${DATA_VOL}:/data" \
     -v "${SECRETS_DIR}:/secrets:ro" \
     $ENV_ARGS \
-    --health-cmd "curl -sf http://localhost:3001/api/health" \
+    --health-cmd "curl -sf http://127.0.0.1:3001/api/health" \
     --health-interval 10s \
     --health-timeout 5s \
     --health-retries 5 \
@@ -107,7 +107,7 @@ docker run -d \
 log "Waiting for hive-next to become healthy..."
 elapsed=0
 while [ "$elapsed" -lt "$HEALTH_TIMEOUT_S" ]; do
-    if docker exec hive-next curl -sf http://localhost:3001/api/health >/dev/null 2>&1; then
+    if docker exec hive-next curl -sf http://127.0.0.1:3001/api/health >/dev/null 2>&1; then
         log "hive-next is healthy!"
         break
     fi

--- a/v2/deploy/docker-compose.architect.yaml
+++ b/v2/deploy/docker-compose.architect.yaml
@@ -17,7 +17,7 @@ services:
       - HIVE_LEVEL=${HIVE_LEVEL:-}
       - HIVE_REPO=${HIVE_REPO:-}
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3002/api/health"]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3002/api/health"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/v2/docker-compose.yaml
+++ b/v2/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       hive:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:3001/api/health"]
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:3001/api/health"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -48,7 +48,7 @@ services:
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:3002/api/health"]
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:3002/api/health"]
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary
- switch container healthchecks from localhost to 127.0.0.1 to avoid IPv6 loopback resolution failures
- update generated and blue/green deployment health probes consistently

Fixes #2774

## Validation
- bash -n bin/hive-setup.sh v2/deploy/blue-green-deploy.sh
- cd v2 && go build ./...
- cd v2 && docker compose config --quiet
- cd v2/deploy && docker compose -f docker-compose.architect.yaml config --quiet