### PR TITLE
🐛 Harden tmux and process cleanup

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -407,7 +407,7 @@ contribute-hive backend="" mode="docker": check-version
       # Start ollama silently if needed for goose
       if [[ "$BACKEND" == "goose" && "${GOOSE_PROVIDER:-}" == "ollama" ]]; then
         # Kill any existing ollama that might spam logs to this terminal
-        pkill -f "ollama serve" 2>/dev/null || true
+        pgrep -u "$(id -u)" -f "ollama serve" 2>/dev/null | while read -r pid; do kill "$pid" 2>/dev/null || true; done
         sleep 1
         echo "Starting ollama (silent)..."
         OLLAMA_FLASH_ATTENTION=1 nohup ollama serve > /dev/null 2>&1 &

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -640,7 +640,38 @@ func (m *Manager) tmuxBaseArgs(agent *AgentProcess) []string {
 	return []string{"tmux"}
 }
 
+func validTmuxKillSessionTarget(args []string) (string, bool) {
+	if len(args) == 0 || args[0] != "kill-session" {
+		return "", true
+	}
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-t":
+			if i+1 >= len(args) {
+				return "", false
+			}
+			target := args[i+1]
+			return target, strings.HasPrefix(target, "hive-")
+		case strings.HasPrefix(arg, "-t="):
+			target := strings.TrimPrefix(arg, "-t=")
+			return target, strings.HasPrefix(target, "hive-")
+		}
+	}
+	return "", false
+}
+
 func (m *Manager) tmuxCmd(agent *AgentProcess, args ...string) *exec.Cmd {
+	if target, ok := validTmuxKillSessionTarget(args); !ok {
+		agentName := ""
+		if agent != nil {
+			agentName = agent.Name
+		}
+		if m.logger != nil {
+			m.logger.Warn("refusing unsafe tmux kill-session target", "target", target, "agent", agentName)
+		}
+		return exec.Command("false")
+	}
 	base := m.tmuxBaseArgs(agent)
 	tmuxArgs := append(base[1:], args...)
 	if agent.UID > 0 {
@@ -3930,7 +3961,9 @@ func matchesAuthError(output string) bool {
 func (m *Manager) runCopilotDiagnostic(ctx context.Context, agent *AgentProcess) {
 	m.tmuxSendKeysForAgent(agent, "C-c", "")
 	time.Sleep(paneCaptureSleep)
-	killAgentProcesses(agent.UID, m.logger)
+	if agent.UID > 0 {
+		killAgentProcesses(agent.UID, m.logger)
+	}
 	_ = m.tmuxCmd(agent, "kill-session", "-t", agent.tmuxSession).Run()
 
 	if err := m.ensureTmuxSession(agent); err != nil {
@@ -3981,7 +4014,9 @@ func (m *Manager) runCopilotDiagnostic(ctx context.Context, agent *AgentProcess)
 				continue
 			}
 
-			killAgentProcesses(agent.UID, m.logger)
+			if agent.UID > 0 {
+				killAgentProcesses(agent.UID, m.logger)
+			}
 			_ = m.tmuxCmd(agent, "kill-session", "-t", agent.tmuxSession).Run()
 			agent.forceRelaunch = true
 			if err := m.Restart(ctx, agent.Name); err != nil {
@@ -5181,6 +5216,12 @@ func environHasMarker(environ, marker string) bool {
 // sends SIGKILL to each. Hung copilot binaries ignore SIGINT, so brute-force
 // cleanup is needed to prevent orphan accumulation on the shared SQLite store.
 func killAgentProcesses(uid int, logger *slog.Logger) int {
+	if uid <= 0 {
+		if logger != nil {
+			logger.Warn("refusing unsafe UID process cleanup", "uid", uid)
+		}
+		return 0
+	}
 	procPath := procRoot
 	entries, err := os.ReadDir(procPath)
 	if err != nil {
@@ -5195,6 +5236,9 @@ func killAgentProcesses(uid int, logger *slog.Logger) int {
 		}
 		pid, err := strconv.Atoi(entry.Name())
 		if err != nil {
+			continue
+		}
+		if pid == os.Getpid() {
 			continue
 		}
 

--- a/v2/pkg/agent/manager_coverage2_test.go
+++ b/v2/pkg/agent/manager_coverage2_test.go
@@ -1539,8 +1539,8 @@ func TestConfigHasTokens_MissingField(t *testing.T) {
 func TestClearExpiredTokens_Logic(t *testing.T) {
 	// Test the JSON manipulation clearExpiredTokens does
 	input := map[string]interface{}{
-		"copilotTokens":  map[string]interface{}{"user1": "token"},
-		"loggedInUsers":  []interface{}{"user1"},
+		"copilotTokens":    map[string]interface{}{"user1": "token"},
+		"loggedInUsers":    []interface{}{"user1"},
 		"lastLoggedInUser": "user1",
 		"otherSetting":     "keep",
 	}
@@ -1735,6 +1735,33 @@ func TestTmuxBaseArgs_WithoutSocket(t *testing.T) {
 	args := m.tmuxBaseArgs(agent)
 	if len(args) != 1 || args[0] != "tmux" {
 		t.Errorf("tmuxBaseArgs without socket = %v, want [tmux]", args)
+	}
+}
+
+func TestValidTmuxKillSessionTarget(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantOK     bool
+		wantTarget string
+	}{
+		{name: "non-kill command", args: []string{"has-session", "-t", "user"}, wantOK: true},
+		{name: "hive target", args: []string{"kill-session", "-t", "hive-agent"}, wantOK: true, wantTarget: "hive-agent"},
+		{name: "hive equals target", args: []string{"kill-session", "-t=hive-agent"}, wantOK: true, wantTarget: "hive-agent"},
+		{name: "empty target", args: []string{"kill-session", "-t", ""}, wantOK: false},
+		{name: "missing target", args: []string{"kill-session", "-t"}, wantOK: false},
+		{name: "missing flag", args: []string{"kill-session"}, wantOK: false},
+		{name: "non-hive target", args: []string{"kill-session", "-t", "work"}, wantOK: false, wantTarget: "work"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTarget, gotOK := validTmuxKillSessionTarget(tt.args)
+			if gotOK != tt.wantOK || gotTarget != tt.wantTarget {
+				t.Fatalf("validTmuxKillSessionTarget(%v) = (%q, %v), want (%q, %v)",
+					tt.args, gotTarget, gotOK, tt.wantTarget, tt.wantOK)
+			}
+		})
 	}
 }
 

--- a/v2/pkg/agent/manager_test.go
+++ b/v2/pkg/agent/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -23,12 +24,30 @@ func testEnvPairs(ap *AgentProcess) []agentEnvPair {
 }
 
 func TestMain(m *testing.M) {
-	dir, err := os.MkdirTemp("", "hive-agent-stubs-*")
+	dir, err := os.MkdirTemp(".", ".hive-agent-stubs-*")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "TestMain: MkdirTemp: %v\n", err)
 		os.Exit(1)
 	}
-	defer os.RemoveAll(dir)
+	dir, err = filepath.Abs(dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "TestMain: Abs: %v\n", err)
+		os.Exit(1)
+	}
+
+	tmuxDir, err := os.MkdirTemp(".", ".hive-agent-tmux-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "TestMain: tmux MkdirTemp: %v\n", err)
+		_ = os.RemoveAll(dir)
+		os.Exit(1)
+	}
+	tmuxDir, err = filepath.Abs(tmuxDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "TestMain: tmux Abs: %v\n", err)
+		_ = os.RemoveAll(dir)
+		_ = os.RemoveAll(tmuxDir)
+		os.Exit(1)
+	}
 
 	stubBinDir = dir
 
@@ -43,10 +62,29 @@ func TestMain(m *testing.M) {
 	}
 
 	originalPath := os.Getenv("PATH")
+	originalTMUX := os.Getenv("TMUX")
+	originalTMUXTmpDir := os.Getenv("TMUX_TMPDIR")
 	os.Setenv("PATH", dir+":"+originalPath)
-	defer os.Setenv("PATH", originalPath)
+	os.Unsetenv("TMUX")
+	os.Setenv("TMUX_TMPDIR", tmuxDir)
 
-	os.Exit(m.Run())
+	code := m.Run()
+
+	os.Setenv("PATH", originalPath)
+	if originalTMUX == "" {
+		os.Unsetenv("TMUX")
+	} else {
+		os.Setenv("TMUX", originalTMUX)
+	}
+	if originalTMUXTmpDir == "" {
+		os.Unsetenv("TMUX_TMPDIR")
+	} else {
+		os.Setenv("TMUX_TMPDIR", originalTMUXTmpDir)
+	}
+	_ = os.RemoveAll(dir)
+	_ = os.RemoveAll(tmuxDir)
+
+	os.Exit(code)
 }
 
 func discardLogger() *slog.Logger {

--- a/v2/pkg/agent/proc_coverage_test.go
+++ b/v2/pkg/agent/proc_coverage_test.go
@@ -122,6 +122,30 @@ func TestKillAgentProcesses_FakeProc(t *testing.T) {
 	}
 }
 
+func TestKillAgentProcesses_RefusesUnsafeUID(t *testing.T) {
+	root := t.TempDir()
+	withFakeProc(t, root)
+
+	writeProcEntry(t, root, os.Getpid(), "hive\x00test", "", 0)
+	if killed := killAgentProcesses(0, discardLogger()); killed != 0 {
+		t.Errorf("uid 0 cleanup should be refused, got %d kills", killed)
+	}
+	if killed := killAgentProcesses(-1, discardLogger()); killed != 0 {
+		t.Errorf("negative uid cleanup should be refused, got %d kills", killed)
+	}
+}
+
+func TestKillAgentProcesses_SkipsCurrentProcess(t *testing.T) {
+	root := t.TempDir()
+	withFakeProc(t, root)
+
+	const targetUID = 4242
+	writeProcEntry(t, root, os.Getpid(), "hive\x00test", "", targetUID)
+	if killed := killAgentProcesses(targetUID, discardLogger()); killed != 0 {
+		t.Errorf("current process should be skipped, got %d kills", killed)
+	}
+}
+
 func TestKillAgentProcesses_ReadDirError(t *testing.T) {
 	withFakeProc(t, filepath.Join(t.TempDir(), "missing"))
 	if killed := killAgentProcesses(1, discardLogger()); killed != 0 {

--- a/v2/pkg/agent/tmux_coverage_test.go
+++ b/v2/pkg/agent/tmux_coverage_test.go
@@ -80,9 +80,9 @@ func inferenceReadyStub(t *testing.T) {
 	overrideStub(t, "claude", "bypass permissions on")
 }
 
-// newRawTmuxSession creates a bare tmux session (UID 0, shared server) and
-// registers cleanup. Returns the session name. Used to drive pane-inspection
-// helpers without spawning a real CLI.
+// newRawTmuxSession creates a bare tmux session on the package test tmux server
+// and registers cleanup. Used to drive pane-inspection helpers without spawning
+// a real CLI.
 func newRawTmuxSession(t *testing.T, session string) {
 	t.Helper()
 	if err := exec.Command("tmux", "new-session", "-d", "-s", session).Run(); err != nil {


### PR DESCRIPTION
## Summary
- guard Copilot diagnostic UID sweeps and make killAgentProcesses refuse uid <= 0 while skipping the hive process
- validate tmux kill-session targets so only non-empty hive-* sessions can be killed through tmuxCmd
- isolate agent package tmux tests from the developer default server via a package-private TMUX_TMPDIR
- scope local ollama cleanup to processes owned by the current user

## Validation
- cd v2 && go build ./...
- cd v2 && go test ./pkg/agent/ -count=1
- cd v2 && go vet ./...

Fixes #2743