### PR TITLE
🐛 Drain async vanity repairs in hub tests

### DIFF
--- a/v2/pkg/hub/heartbeat_vanity_async_test.go
+++ b/v2/pkg/hub/heartbeat_vanity_async_test.go
@@ -78,7 +78,8 @@ func assignedVllmdHive(id string) *SaaSHive {
 func TestHeartbeatDeliversClaimWhileVanityRepairBlocked(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s, _, _ := newBlockedVanityHub(t)
+	s, _, release := newBlockedVanityHub(t)
+	defer release()
 
 	const id = "hosted-available-vllmd-14"
 	if err := saveSaaSHive(assignedVllmdHive(id)); err != nil {

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1165,7 +1165,8 @@ func (s *HubServer) repairVanityURLForHive(hiveID string) bool {
 }
 
 // kickVanityURLRepairAsync runs repairVanityURLForHive in the background, at
-// most one attempt per hive at a time.
+// most one attempt per hive at a time, registered with provisionWG so tests can
+// drain it before swapping the package-level saas*Dir vars.
 //
 // It exists because the repair is only cheap on its NO-OP paths. When it
 // actually has work to do it shells out to kubectl against the hive's cluster
@@ -1196,7 +1197,9 @@ func (s *HubServer) kickVanityURLRepairAsync(hiveID string) {
 	if _, inFlight := s.vanityRepairInFlight.LoadOrStore(hiveID, struct{}{}); inFlight {
 		return
 	}
+	provisionWG.Add(1)
 	go func() {
+		defer provisionWG.Done()
 		defer s.vanityRepairInFlight.Delete(hiveID)
 		s.repairVanityURLForHive(hiveID)
 	}()


### PR DESCRIPTION
Fixes #2734

## Root cause
- `kickVanityURLRepairAsync` spawned an untracked background goroutine. Hub tests swap package-level SaaS data paths, so cleanup could restore those globals while the vanity repair goroutine was still reading them under `-race`.

## Fix
- Register async vanity repair goroutines with `provisionWG` so test cleanup drains them before path globals are restored.
- Release the blocked vanity repair seam in `TestHeartbeatDeliversClaimWhileVanityRepairBlocked` before cleanup waits.

## Verification
- `go test ./pkg/hub -run TestHeartbeatDeliversClaimWhileVanityRepairBlocked -count=5`
- `go test ./pkg/hub -run TestHeartbeatDeliversClaimWhileVanityRepairBlocked -race -count=10`
- `go test ./pkg/hub -run 'TestHeartbeatDeliversClaimWhileVanityRepairBlocked|TestVanityRepairKickDedupesInFlightAttempts|TestVanityRepairKickInlineGuards|TestVanityRepairReloadsHiveBeforeSave' -race -count=10`\n- `go build ./...`\n\nNote: full `go test ./pkg/hub -race -count=1` currently fails locally on unrelated `TestHandleOAuthCallbackSuccess` cookie verification before this fix.