### PR TITLE
fix(hub): OAuth callback cookie verifies again (unblocks coverage gate)

### DIFF
--- a/v2/pkg/hub/oauth_provision_coverage_test.go
+++ b/v2/pkg/hub/oauth_provision_coverage_test.go
@@ -106,7 +106,14 @@ func TestHandleOAuthCallbackSuccess(t *testing.T) {
 	if sessionCookie.Value == "octocat" {
 		t.Error("session cookie must be signed, not the raw username")
 	}
-	if user, ok := verifyHubUserCookieValue(testHubSecret, sessionCookie.Value); !ok || user != "octocat" {
+	// Verify through the SAME production verifier the hub uses on every cookie
+	// read path (handleAuthUser / getRealAuthUser), not the raw master directly:
+	// since #2775 the login path mints with the derived session key
+	// (s.sessionCookieKey) so a v4 spoke's proxy can verify the cookie too, and
+	// verifyHubUserDual is what accepts that derived-key signature (plus legacy
+	// raw-master cookies). Asserting against the raw secret here would re-pin the
+	// test to a key the hub no longer mints with.
+	if user, ok := s.verifyHubUserDual(sessionCookie.Value); !ok || user != "octocat" {
 		t.Errorf("minted cookie did not verify: (%q, %v)", user, ok)
 	}
 }


### PR DESCRIPTION
## Verdict: test drift, NOT a shipped auth bug

Production hub logins were never broken. Details below.

## Repro on clean v2 (no PR changes)

At v2 HEAD `610f5937`, with no local modifications:

```
$ go test ./pkg/hub/ -run TestHandleOAuthCallbackSuccess -count=1
--- FAIL: TestHandleOAuthCallbackSuccess (0.01s)
    oauth_provision_coverage_test.go:110: minted cookie did not verify: ("", false)
FAIL	github.com/kubestellar/hive/v2/pkg/hub	0.866s
```

The CI `coverage` job runs the full test suite, so `hub: TESTS FAILING` was
failing the gate on **every open PR** — including PRs touching neither OAuth
nor `pkg/hub` (e.g. #2777, #2778). This was the single thing gating the merge
queue.

## Root cause

Offending commit: **067f8f19** — "fix(hub): sign hive_hub_user with derived
session key so v4 spoke /terminal verifies (dual-verify)" (#2775).

That commit moved the session-cookie mint from the raw master secret to the
domain-separated derived session key, so a v4 spoke's Node proxy — which
self-derives `deriveDomainKey(master, "hive-session-v1")` from the same master —
can verify the hub's cookie:

```go
// oauth.go:272
cookieValue := mintHubUserCookieValue(s.sessionCookieKey(), user.Login)
```

It correctly updated **both** production verify sites to `verifyHubUserDual`,
which tries the derived session key first and falls back to the raw master so
legacy cookies already sitting in browsers keep working. But it changed only
`hub_keys.go`, `oauth.go`, and `saas.go` — **no test file**. So this assertion
stayed pinned to the key the hub no longer mints with:

```go
verifyHubUserCookieValue(testHubSecret, sessionCookie.Value)  // raw master
```

Mint with derived key, verify with raw master → `("", false)`, exactly as seen.

## Which side was wrong: the test

I audited every mint/verify call site before touching anything, because the
alternative (production minting with key A and verifying with key B) would have
been a shipped auth regression breaking hub logins in production.

Production is self-consistent:

- **One** mint site: `oauth.go:272`, derived session key.
- **Both** read sites go through the dual verifier: `saas.go:530`
  (`getRealAuthUser`) and `oauth.go:323` (`handleAuthUser`).
- `verifyHubUserDual` is additive — it accepts the derived-key signature and
  still accepts legacy raw-master cookies, so it never rejects a value the old
  single-key check would have accepted.

So real browsers verify fine and hub logins were unaffected. Only the test was
left behind.

Other tests calling `mintHubUserCookieValue` with a raw test secret are
unaffected: they either unit-test the mint/verify pair against a matching key,
or mint a request cookie that `verifyHubUserDual` still accepts via its legacy
raw-master fallback.

## The fix

Assert through `s.verifyHubUserDual` — the same production verifier that
validates these cookies on every hub read path — instead of the raw master.
Per review guidance, this reuses the production verifier rather than
hand-rolling a second one in the test, so the test now tracks whatever key the
hub actually mints with and won't drift again on the next key change.

## Verification

- `go test ./pkg/hub/ -run TestHandleOAuthCallbackSuccess -count=1` → **ok**
- `go test ./pkg/hub/ -count=1` (full suite) → **ok, 45.1s**
- `go build ./...` → clean
- `go vet ./...` → clean
