### PR TITLE
feat(audit): record agent start/stop/failure and method/model changes in the audit log

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2356,6 +2356,15 @@ func main() {
 	// store, before anything is written to the PVC.
 	agentMgr.SetRecordPromptCallback(dashSrv.RecordPrompt)
 
+	// Feed agent lifecycle events (start, stop, launch FAILURE, backend/model
+	// change) into the durable audit store behind the dashboard's Audit Log.
+	// Injected as an interface because pkg/dashboard already imports pkg/agent,
+	// so the manager cannot reach the audit store directly without an import
+	// cycle. Motivating case: an agent configured with a backend its hive image
+	// did not support failed at every launch for a day, visible only as a WARN
+	// line inside the pod.
+	agentMgr.SetAuditSink(dashSrv.AgentAuditSink())
+
 	// Register custom GHE hostnames with the proxy allowlist so mode
 	// enforcement applies to GitHub Enterprise API and web requests.
 	for _, rawURL := range []string{cfg.GitHub.ResolvedAPIURL(), cfg.GitHub.ResolvedBaseURL()} {

--- a/v2/pkg/agent/audit.go
+++ b/v2/pkg/agent/audit.go
@@ -1,0 +1,139 @@
+package agent
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Audit action names recorded for agent lifecycle events. Snake_case to match
+// the dashboard's existing audit vocabulary (add_agent, config_agent_models,
+// …) so the Audit Log UI's free-text/regex filter treats them uniformly.
+const (
+	AuditAgentStarted     = "agent_started"
+	AuditAgentStartFailed = "agent_start_failed"
+	AuditAgentStopped     = "agent_stopped"
+	AuditAgentKicked      = "agent_kicked"
+	AuditAgentPaused      = "agent_paused"
+	AuditAgentResumed     = "agent_resumed"
+	AuditAgentAdded       = "agent_added"
+	AuditAgentRemoved     = "agent_removed"
+	AuditAgentBackendSet  = "agent_backend_changed"
+	AuditAgentModelSet    = "agent_model_changed"
+)
+
+// auditActorSystem attributes an event to the hive process itself rather than
+// to a person. Matches the dashboard's pseudo-user convention (see
+// auditPseudoUsers there): "system" entries never count as user engagement.
+// Lifecycle events originate in the agent manager, which has no HTTP request
+// and therefore no authenticated user, so they are all system-attributed; the
+// human-vs-governor distinction is carried in the detail's trigger= field.
+const auditActorSystem = "system"
+
+// AuditSink receives agent lifecycle events for durable, queryable recording.
+//
+// It exists so pkg/agent can feed the dashboard's audit store WITHOUT
+// importing pkg/dashboard: the dependency already runs the other way
+// (pkg/dashboard imports pkg/agent for agent types and auth), so a direct
+// import here would be an import cycle. The wiring layer (cmd/hive) owns both
+// objects and injects the dashboard's recorder as this interface.
+//
+// Implementations must be safe for concurrent use and must not block: the
+// manager calls Record while holding m.mu on the agent launch path.
+type AuditSink interface {
+	// Record persists one lifecycle event. actor is the responsible user, or
+	// "system" for hive-originated events. fields carries structured context
+	// (backend, model, outcome, error, …) that the sink renders into the
+	// entry's detail.
+	Record(actor, action, agentName string, fields map[string]any)
+}
+
+// SetAuditSink installs the durable audit sink. Safe to leave unset: a nil
+// sink makes every audit call a no-op, which is what unit tests and any
+// non-dashboard embedding of the manager get.
+func (m *Manager) SetAuditSink(sink AuditSink) {
+	m.auditSink.Store(&sink)
+}
+
+// audit records a lifecycle event to the durable audit store, if one is
+// installed. It is deliberately a no-op when no sink is set rather than an
+// error: audit recording must never be able to fail an agent operation.
+//
+// Stored/read via atomic.Pointer rather than under m.mu for the same reason as
+// isGatewayBackend and bobAPIKeyResolver: this is called from the launch path
+// (launchInTmux via Start), which ALREADY holds m.mu.Lock(). Re-locking a
+// non-reentrant RWMutex on the same goroutine would deadlock startup before
+// MarkReady and crash-loop every spoke.
+func (m *Manager) audit(action, agentName string, fields map[string]any) {
+	m.auditWithActor(auditActorSystem, action, agentName, fields)
+}
+
+// auditWithActor is audit with an explicit responsible user, for the paths
+// where an operator's identity is known (dashboard-initiated switches).
+func (m *Manager) auditWithActor(actor, action, agentName string, fields map[string]any) {
+	p := m.auditSink.Load()
+	if p == nil || *p == nil {
+		return
+	}
+	(*p).Record(actor, action, agentName, fields)
+}
+
+// auditFields is a small helper for building the fields map from alternating
+// key/value pairs, mirroring slog's variadic style so a call site can pass the
+// same context to both the logger and the audit sink without restating it.
+// An odd trailing key is dropped. Empty-string values are dropped so an
+// unset backend/model does not render as a noisy "model=" in the UI.
+func auditFields(kv ...any) map[string]any {
+	fields := make(map[string]any, len(kv)/2)
+	for i := 0; i+1 < len(kv); i += 2 {
+		key, ok := kv[i].(string)
+		if !ok {
+			continue
+		}
+		if s, isStr := kv[i+1].(string); isStr && s == "" {
+			continue
+		}
+		fields[key] = kv[i+1]
+	}
+	return fields
+}
+
+// FormatAuditDetail renders a fields map as the stable "k=v, k=v" detail
+// string the Audit Log UI displays and filters over. Keys are sorted so the
+// same event always renders identically (Go map iteration is randomized),
+// except that the conventional lead keys — outcome, backend, model — are
+// hoisted to the front where a reader scans first.
+//
+// Exported because the sink implementation lives in pkg/dashboard and must
+// produce the identical shape.
+func FormatAuditDetail(fields map[string]any) string {
+	if len(fields) == 0 {
+		return ""
+	}
+	leadKeys := []string{"outcome", "backend", "model"}
+	seen := make(map[string]bool, len(leadKeys))
+	ordered := make([]string, 0, len(fields))
+	for _, k := range leadKeys {
+		if _, ok := fields[k]; ok {
+			ordered = append(ordered, k)
+			seen[k] = true
+		}
+	}
+	rest := make([]string, 0, len(fields))
+	for k := range fields {
+		if !seen[k] {
+			rest = append(rest, k)
+		}
+	}
+	sort.Strings(rest)
+	ordered = append(ordered, rest...)
+
+	var b strings.Builder
+	for _, k := range ordered {
+		if b.Len() > 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(&b, "%s=%v", k, fields[k])
+	}
+	return b.String()
+}

--- a/v2/pkg/agent/audit_test.go
+++ b/v2/pkg/agent/audit_test.go
@@ -1,0 +1,288 @@
+package agent
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// recordedAudit is one captured audit event.
+type recordedAudit struct {
+	Actor  string
+	Action string
+	Agent  string
+	Fields map[string]any
+}
+
+// fakeAuditSink captures events for assertions. Concurrency-safe because the
+// manager records from the launch path and from background goroutines.
+type fakeAuditSink struct {
+	mu      sync.Mutex
+	entries []recordedAudit
+}
+
+func (f *fakeAuditSink) Record(actor, action, agentName string, fields map[string]any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.entries = append(f.entries, recordedAudit{Actor: actor, Action: action, Agent: agentName, Fields: fields})
+}
+
+func (f *fakeAuditSink) find(action string) *recordedAudit {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i := range f.entries {
+		if f.entries[i].Action == action {
+			return &f.entries[i]
+		}
+	}
+	return nil
+}
+
+func (f *fakeAuditSink) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.entries)
+}
+
+func testManagerWithSink(t *testing.T) (*Manager, *fakeAuditSink) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	m := NewManager(map[string]config.AgentConfig{}, logger, ProjectContext{})
+	sink := &fakeAuditSink{}
+	m.SetAuditSink(sink)
+	return m, sink
+}
+
+// TestAuditNilSinkIsNoOp is the load-bearing one for every other package: the
+// manager must work with no dashboard attached, which is how all unit tests
+// and any non-dashboard embedding construct it.
+func TestAuditNilSinkIsNoOp(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	m := NewManager(map[string]config.AgentConfig{}, logger, ProjectContext{})
+
+	// No sink ever installed.
+	m.audit(AuditAgentStarted, "nobody", auditFields("backend", "claude"))
+	m.auditWithActor("alice", AuditAgentStopped, "nobody", nil)
+
+	// And explicitly installing a nil interface must also not panic.
+	m.SetAuditSink(nil)
+	m.audit(AuditAgentStartFailed, "nobody", auditFields("error", "boom"))
+}
+
+// TestAuditLaunchFailureRecordsBackendModelAndError is the watsonx incident:
+// an agent whose backend the image does not support must leave a durable,
+// queryable record naming the backend, the model, and the error.
+func TestAuditLaunchFailureRecordsBackendModelAndError(t *testing.T) {
+	m, sink := testManagerWithSink(t)
+
+	m.AddAgent("ci-maintainer", config.AgentConfig{Backend: "watsonx", Model: "granite-3"})
+	m.mu.Lock()
+	ap := m.agents["ci-maintainer"]
+	ap.LastError = "unknown backend: watsonx"
+	m.announceLaunchFailureInPane(ap, "backend watsonx did not launch")
+	m.mu.Unlock()
+
+	e := sink.find(AuditAgentStartFailed)
+	if e == nil {
+		t.Fatalf("no %s event recorded; got %d entries", AuditAgentStartFailed, sink.count())
+	}
+	if e.Agent != "ci-maintainer" {
+		t.Errorf("agent = %q, want ci-maintainer", e.Agent)
+	}
+	if e.Fields["backend"] != "watsonx" {
+		t.Errorf("backend = %v, want watsonx", e.Fields["backend"])
+	}
+	if e.Fields["model"] != "granite-3" {
+		t.Errorf("model = %v, want granite-3", e.Fields["model"])
+	}
+	if e.Fields["outcome"] != "failure" {
+		t.Errorf("outcome = %v, want failure", e.Fields["outcome"])
+	}
+	errText, _ := e.Fields["error"].(string)
+	if !strings.Contains(errText, "unknown backend: watsonx") {
+		t.Errorf("error = %q, want it to contain the launch error text", errText)
+	}
+}
+
+// TestAuditLaunchFailureUsesOverrides proves the audit reports what the agent
+// will ACTUALLY launch with, not just its static config.
+func TestAuditLaunchFailureUsesOverrides(t *testing.T) {
+	m, sink := testManagerWithSink(t)
+
+	m.AddAgent("a1", config.AgentConfig{Backend: "claude", Model: "opus"})
+	m.mu.Lock()
+	ap := m.agents["a1"]
+	ap.BackendOverride = "watsonx"
+	ap.ModelOverride = "granite-4"
+	ap.LastError = "unknown backend: watsonx"
+	m.announceLaunchFailureInPane(ap, "nope")
+	m.mu.Unlock()
+
+	e := sink.find(AuditAgentStartFailed)
+	if e == nil {
+		t.Fatal("no launch failure event recorded")
+	}
+	if e.Fields["backend"] != "watsonx" || e.Fields["model"] != "granite-4" {
+		t.Errorf("got backend=%v model=%v, want the overrides watsonx/granite-4",
+			e.Fields["backend"], e.Fields["model"])
+	}
+}
+
+func TestAuditAddAndRemoveRecordMethodAndModel(t *testing.T) {
+	m, sink := testManagerWithSink(t)
+
+	m.AddAgent("a1", config.AgentConfig{Backend: "copilot", Model: "gpt-5"})
+	added := sink.find(AuditAgentAdded)
+	if added == nil {
+		t.Fatal("no agent_added event")
+	}
+	if added.Fields["backend"] != "copilot" || added.Fields["model"] != "gpt-5" {
+		t.Errorf("added: backend=%v model=%v, want copilot/gpt-5", added.Fields["backend"], added.Fields["model"])
+	}
+	if added.Actor != auditActorSystem {
+		t.Errorf("actor = %q, want %q", added.Actor, auditActorSystem)
+	}
+
+	m.RemoveAgent("a1")
+	removed := sink.find(AuditAgentRemoved)
+	if removed == nil {
+		t.Fatal("no agent_removed event")
+	}
+	if removed.Fields["backend"] != "copilot" || removed.Fields["model"] != "gpt-5" {
+		t.Errorf("removed: backend=%v model=%v, want copilot/gpt-5",
+			removed.Fields["backend"], removed.Fields["model"])
+	}
+}
+
+func TestAuditBackendChangeRecordsOldAndNew(t *testing.T) {
+	m, sink := testManagerWithSink(t)
+	m.AddAgent("a1", config.AgentConfig{Backend: "claude", Model: "opus"})
+
+	if err := m.SetBackendOverride("a1", "copilot"); err != nil {
+		t.Fatalf("SetBackendOverride: %v", err)
+	}
+	e := sink.find(AuditAgentBackendSet)
+	if e == nil {
+		t.Fatal("no agent_backend_changed event")
+	}
+	if e.Fields["previous_backend"] != "claude" {
+		t.Errorf("previous_backend = %v, want claude", e.Fields["previous_backend"])
+	}
+	if e.Fields["backend"] != "copilot" {
+		t.Errorf("backend = %v, want copilot", e.Fields["backend"])
+	}
+}
+
+// TestAuditBackendChangeSkipsNoOp guards the volume decision: only real state
+// transitions are audited, so config reloads re-applying the current value do
+// not flood the ring buffer.
+func TestAuditBackendChangeSkipsNoOp(t *testing.T) {
+	m, sink := testManagerWithSink(t)
+	m.AddAgent("a1", config.AgentConfig{Backend: "claude"})
+
+	if err := m.SetBackendOverride("a1", "claude"); err != nil {
+		t.Fatalf("SetBackendOverride: %v", err)
+	}
+	if e := sink.find(AuditAgentBackendSet); e != nil {
+		t.Errorf("no-op backend set should record nothing, got %+v", e.Fields)
+	}
+}
+
+func TestAuditModelChangeRecordsOldAndNew(t *testing.T) {
+	m, sink := testManagerWithSink(t)
+	m.AddAgent("a1", config.AgentConfig{Backend: "claude", Model: "sonnet"})
+
+	if err := m.SetModelOverride("a1", "opus"); err != nil {
+		t.Fatalf("SetModelOverride: %v", err)
+	}
+	e := sink.find(AuditAgentModelSet)
+	if e == nil {
+		t.Fatal("no agent_model_changed event")
+	}
+	if e.Fields["previous_model"] != "sonnet" {
+		t.Errorf("previous_model = %v, want sonnet", e.Fields["previous_model"])
+	}
+	if e.Fields["model"] != "opus" {
+		t.Errorf("model = %v, want opus", e.Fields["model"])
+	}
+	if e.Fields["backend"] != "claude" {
+		t.Errorf("backend = %v, want claude", e.Fields["backend"])
+	}
+}
+
+func TestAuditModelChangeSkipsNoOp(t *testing.T) {
+	m, sink := testManagerWithSink(t)
+	m.AddAgent("a1", config.AgentConfig{Backend: "claude", Model: "opus"})
+
+	if err := m.SetModelOverride("a1", "opus"); err != nil {
+		t.Fatalf("SetModelOverride: %v", err)
+	}
+	if e := sink.find(AuditAgentModelSet); e != nil {
+		t.Errorf("no-op model set should record nothing, got %+v", e.Fields)
+	}
+}
+
+func TestAuditPinModelRecordsChange(t *testing.T) {
+	m, sink := testManagerWithSink(t)
+	m.AddAgent("a1", config.AgentConfig{Backend: "claude", Model: "sonnet"})
+
+	if err := m.PinModel("a1", "opus"); err != nil {
+		t.Fatalf("PinModel: %v", err)
+	}
+	e := sink.find(AuditAgentModelSet)
+	if e == nil {
+		t.Fatal("no agent_model_changed event for pin")
+	}
+	if e.Fields["previous_model"] != "sonnet" || e.Fields["model"] != "opus" {
+		t.Errorf("got previous=%v model=%v, want sonnet -> opus",
+			e.Fields["previous_model"], e.Fields["model"])
+	}
+	if e.Fields["trigger"] != "pin" {
+		t.Errorf("trigger = %v, want pin", e.Fields["trigger"])
+	}
+}
+
+func TestAuditFieldsDropsEmptyStringsAndOddKey(t *testing.T) {
+	f := auditFields("backend", "claude", "model", "", "count", 3, "dangling")
+	if _, ok := f["model"]; ok {
+		t.Error("empty-string value should be dropped so the UI has no noisy 'model='")
+	}
+	if f["backend"] != "claude" {
+		t.Errorf("backend = %v, want claude", f["backend"])
+	}
+	if f["count"] != 3 {
+		t.Errorf("count = %v, want 3", f["count"])
+	}
+	if _, ok := f["dangling"]; ok {
+		t.Error("odd trailing key should be dropped")
+	}
+}
+
+// TestFormatAuditDetailIsStableAndOrdered pins the detail string shape the
+// Audit Log UI renders and filters over. Go map iteration is randomized, so
+// without the sort the same event would render differently each time.
+func TestFormatAuditDetailIsStableAndOrdered(t *testing.T) {
+	fields := auditFields(
+		"error", "unknown backend: watsonx",
+		"model", "granite-3",
+		"outcome", "failure",
+		"backend", "watsonx",
+	)
+	got := FormatAuditDetail(fields)
+	want := "outcome=failure, backend=watsonx, model=granite-3, error=unknown backend: watsonx"
+	if got != want {
+		t.Errorf("FormatAuditDetail =\n  %q\nwant\n  %q", got, want)
+	}
+	for i := 0; i < 10; i++ {
+		if FormatAuditDetail(fields) != want {
+			t.Fatal("FormatAuditDetail is not stable across calls")
+		}
+	}
+	if FormatAuditDetail(nil) != "" {
+		t.Error("empty fields should render as the empty string")
+	}
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -182,6 +182,14 @@ type Manager struct {
 	// same deadlock reasoning as bobAPIKeyResolver above.
 	bobKeySourceResolver atomic.Pointer[func() string]
 
+	// auditSink, when set, receives agent lifecycle events (start, stop,
+	// launch failure, backend/model change) for durable, queryable recording
+	// in the dashboard's audit store. Nil in tests / non-dashboard setups, in
+	// which case every audit call is a no-op. See pkg/agent/audit.go for why
+	// this is an injected interface rather than a direct pkg/dashboard import,
+	// and why it is an atomic.Pointer rather than m.mu-guarded state.
+	auditSink atomic.Pointer[AuditSink]
+
 	inferenceRouteCallback      func(agentName, backend, model string)
 	clearInferenceRouteCallback func(agentName string)
 
@@ -578,6 +586,16 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 	m.sanitizeGitRemotes(agent)
 
 	if err := m.ensureTmuxSession(agent); err != nil {
+		// No tmux session means no pane to announce into, so this failure
+		// cannot ride announceLaunchFailureInPane like the park-and-return
+		// branches do — record it here or it stays invisible.
+		m.audit(AuditAgentStartFailed, name, auditFields(
+			"outcome", "failure",
+			"backend", agent.effectiveBackend(),
+			"model", agent.effectiveModel(),
+			"error", err.Error(),
+			"stage", "tmux_session",
+		))
 		return err
 	}
 
@@ -1289,6 +1307,12 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		"mode", mode.String(),
 		"session", agent.tmuxSession,
 	)
+	m.audit(AuditAgentStarted, agent.Name, auditFields(
+		"outcome", "success",
+		"backend", backend,
+		"model", model,
+		"mode", mode.String(),
+	))
 
 	agentCtx, cancel := context.WithCancel(ctx)
 	agent.cancel = cancel
@@ -2263,6 +2287,11 @@ func (m *Manager) Stop(name string) error {
 
 	agent.State = StateStopped
 	m.logger.Info("audit: agent stopped", "name", name)
+	m.audit(AuditAgentStopped, name, auditFields(
+		"outcome", "success",
+		"backend", agent.effectiveBackend(),
+		"model", agent.effectiveModel(),
+	))
 
 	return nil
 }
@@ -2300,6 +2329,12 @@ func (m *Manager) AddAgent(name string, cfg config.AgentConfig) {
 	}
 	m.idToName[agentID] = name
 	m.logger.Info("audit: agent added", "name", name, "id", agentID, "uid", agentUID)
+	m.audit(AuditAgentAdded, name, auditFields(
+		"outcome", "success",
+		"backend", cfg.Backend,
+		"model", cfg.Model,
+		"id", agentID,
+	))
 }
 
 // UpdateConfig updates the stored config for a running agent process so that
@@ -2334,6 +2369,12 @@ func (m *Manager) RemoveAgent(name string) {
 	delete(m.idToName, agent.ID)
 	delete(m.agents, name)
 	m.logger.Info("audit: agent removed", "name", name, "id", agent.ID)
+	m.audit(AuditAgentRemoved, name, auditFields(
+		"outcome", "success",
+		"backend", agent.effectiveBackend(),
+		"model", agent.effectiveModel(),
+		"id", agent.ID,
+	))
 }
 
 // inferencePaneCheck pairs an inference agent name with its captured visible
@@ -2866,10 +2907,44 @@ func launchFailureBanner(msg string) string {
 // pane write on the launch path — a missing session must not turn a parked
 // agent into a crashed manager. Caller holds m.mu (same discipline as
 // launchInTmux, which is its only caller).
+// It is also the single chokepoint every park-and-return branch already
+// passes through, so recording the durable audit event here — rather than
+// once per branch — means no launch failure can be added later that silently
+// skips the audit log. This is the watsonx case: an agent configured with a
+// backend the image does not support failed at every launch for a day, WARN-
+// logged inside the pod and invisible in the Audit Log UI.
 func (m *Manager) announceLaunchFailureInPane(agent *AgentProcess, msg string) {
 	agent.lastLaunchFailureBanner = launchFailureBanner(msg)
 	m.tmuxSendLiteralForAgent(agent, agent.lastLaunchFailureBanner)
 	m.tmuxSendKeysForAgent(agent, "Enter")
+
+	m.audit(AuditAgentStartFailed, agent.Name, auditFields(
+		"outcome", "failure",
+		"backend", agent.effectiveBackend(),
+		"model", agent.effectiveModel(),
+		"error", agent.LastError,
+	))
+}
+
+// effectiveBackend is the backend this agent will actually launch with: the
+// per-agent override when set, otherwise its configured backend.
+func (a *AgentProcess) effectiveBackend() string {
+	if a.BackendOverride != "" {
+		return a.BackendOverride
+	}
+	return a.Config.Backend
+}
+
+// effectiveModel is the model this agent will actually launch with: the
+// per-agent override when set, otherwise its configured model. Returns the
+// raw (un-normalized) name — the audit log should show what was ASKED for,
+// since a bad model name is exactly the kind of misconfiguration being
+// audited.
+func (a *AgentProcess) effectiveModel() string {
+	if a.ModelOverride != "" {
+		return a.ModelOverride
+	}
+	return a.Config.Model
 }
 
 // dismissInferencePrompts polls the tmux pane for Claude Code interactive
@@ -3961,6 +4036,12 @@ func (m *Manager) runCopilotDiagnostic(ctx context.Context, agent *AgentProcess)
 			m.logger.Warn("diagnostic: timed out waiting for copilot error output", "agent", agent.Name)
 			agent.LastError = "copilot hung with no output (diagnostic timed out)"
 			agent.State = StateFailed
+			m.audit(AuditAgentStartFailed, agent.Name, auditFields(
+				"outcome", "failure",
+				"backend", agent.effectiveBackend(),
+				"model", agent.effectiveModel(),
+				"error", agent.LastError,
+			))
 			return
 		case <-ticker.C:
 			output := m.captureTmuxPaneForAgent(agent)
@@ -4910,6 +4991,13 @@ func (m *Manager) Pause(name, trigger, reason string) error {
 		"backend", agent.Config.Backend,
 		"restart_count", agent.RestartCount,
 	)
+	m.audit(AuditAgentPaused, name, auditFields(
+		"outcome", "success",
+		"backend", agent.effectiveBackend(),
+		"model", agent.effectiveModel(),
+		"trigger", trigger,
+		"reason", reason,
+	))
 	return nil
 }
 
@@ -4933,6 +5021,11 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 
 	prevTrigger := agent.PausedTrigger
 	prevReason := agent.PausedReason
+	// Snapshot backend/model while m.mu is still held — the audit call below
+	// runs after the deliberate early Unlock, where touching agent fields
+	// would be an unsynchronized read.
+	resumeBackend := agent.effectiveBackend()
+	resumeModel := agent.effectiveModel()
 	agent.Paused = false
 	agent.Config.Paused = false
 	if m.persistPauseCallback != nil {
@@ -4958,6 +5051,13 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 		"prev_trigger", prevTrigger,
 		"prev_reason", prevReason,
 	)
+	m.audit(AuditAgentResumed, name, auditFields(
+		"outcome", "success",
+		"backend", resumeBackend,
+		"model", resumeModel,
+		"trigger", trigger,
+		"reason", reason,
+	))
 	if needsRelaunch {
 		if err := m.ensureTmuxSession(agent); err != nil {
 			return err
@@ -5340,9 +5440,19 @@ func (m *Manager) PinModel(name, model string) error {
 		return fmt.Errorf("agent %s not found", name)
 	}
 
+	prevModel := agent.effectiveModel()
 	agent.PinnedModel = model
 	agent.ModelOverride = model
 	m.logger.Info("agent model pinned", "name", name, "model", model)
+	if prevModel != model {
+		m.audit(AuditAgentModelSet, name, auditFields(
+			"outcome", "success",
+			"backend", agent.effectiveBackend(),
+			"model", model,
+			"previous_model", prevModel,
+			"trigger", "pin",
+		))
+	}
 	return nil
 }
 
@@ -5377,8 +5487,19 @@ func (m *Manager) SetModelOverride(name, model string) error {
 		m.logger.Info("agent model pin retargeted by user switch", "name", name, "model", model)
 	}
 
+	prevModel := agent.effectiveModel()
 	agent.ModelOverride = model
 	m.logger.Info("agent model override set", "name", name, "model", model)
+	// State CHANGES only — the governor re-asserts the current model on every
+	// evaluation cycle, so auditing unchanged writes would flood the ring.
+	if prevModel != model {
+		m.audit(AuditAgentModelSet, name, auditFields(
+			"outcome", "success",
+			"backend", agent.effectiveBackend(),
+			"model", model,
+			"previous_model", prevModel,
+		))
+	}
 
 	effectiveBackend := agent.Config.Backend
 	if agent.BackendOverride != "" {
@@ -5399,8 +5520,20 @@ func (m *Manager) SetBackendOverride(name, backend string) error {
 		return fmt.Errorf("agent %s not found", name)
 	}
 
+	prevBackend := agent.effectiveBackend()
 	agent.BackendOverride = backend
 	m.logger.Info("agent backend override set", "name", name, "backend", backend)
+	// Record only a real transition: /switch/{backend} is also re-applied on
+	// config reload with the value already in effect, and auditing those
+	// no-ops would bury the actual operator changes.
+	if prevBackend != backend {
+		m.audit(AuditAgentBackendSet, name, auditFields(
+			"outcome", "success",
+			"backend", backend,
+			"model", agent.effectiveModel(),
+			"previous_backend", prevBackend,
+		))
+	}
 
 	if m.routableBackend(backend) && m.inferenceRouteCallback != nil {
 		model := agent.ModelOverride

--- a/v2/pkg/dashboard/agent_audit_sink.go
+++ b/v2/pkg/dashboard/agent_audit_sink.go
@@ -1,0 +1,32 @@
+package dashboard
+
+import (
+	"github.com/kubestellar/hive/v2/pkg/agent"
+)
+
+// agentAuditSink adapts the dashboard's AuditLog to agent.AuditSink so the
+// agent manager can record lifecycle events (start, stop, launch failure,
+// backend/model change) into the durable, queryable audit store.
+//
+// The indirection exists because the import direction forbids the obvious
+// call: pkg/dashboard already imports pkg/agent, so pkg/agent cannot import
+// pkg/dashboard back. cmd/hive owns both objects and injects this adapter.
+type agentAuditSink struct {
+	log *AuditLog
+}
+
+// Record implements agent.AuditSink. Fields are rendered with the shared
+// formatter in pkg/agent so the detail column has one canonical shape
+// regardless of which side produced the entry.
+func (s *agentAuditSink) Record(actor, action, agentName string, fields map[string]any) {
+	if s == nil || s.log == nil {
+		return
+	}
+	s.log.Log(actor, action, agent.FormatAuditDetail(fields), agentName)
+}
+
+// AgentAuditSink returns an agent.AuditSink backed by this server's audit log,
+// for injection into the agent manager at wiring time (see cmd/hive/main.go).
+func (s *Server) AgentAuditSink() agent.AuditSink {
+	return &agentAuditSink{log: s.audit}
+}

--- a/v2/pkg/dashboard/agent_audit_sink_test.go
+++ b/v2/pkg/dashboard/agent_audit_sink_test.go
@@ -1,0 +1,117 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/agent"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// TestAgentAuditSinkSatisfiesInterface pins the dependency-inversion contract:
+// the dashboard adapter must remain assignable to agent.AuditSink, which is
+// what lets cmd/hive inject it without pkg/agent importing pkg/dashboard.
+func TestAgentAuditSinkSatisfiesInterface(t *testing.T) {
+	var _ agent.AuditSink = &agentAuditSink{}
+
+	s := &Server{audit: &AuditLog{}}
+	if s.AgentAuditSink() == nil {
+		t.Fatal("AgentAuditSink returned nil")
+	}
+}
+
+func TestAgentAuditSinkNilSafe(t *testing.T) {
+	var s *agentAuditSink
+	s.Record("system", "agent_started", "a1", nil) // must not panic
+
+	(&agentAuditSink{}).Record("system", "agent_started", "a1", nil)
+}
+
+// TestAgentAuditSinkRendersLifecycleEntry checks the entry lands in the store
+// in the shape the Audit Log UI renders: action in Action, agent name in
+// Agent (so it is filterable per agent), and the structured fields flattened
+// into Detail.
+func TestAgentAuditSinkRendersLifecycleEntry(t *testing.T) {
+	log := &AuditLog{}
+	sink := &agentAuditSink{log: log}
+
+	sink.Record("system", agent.AuditAgentStartFailed, "ci-maintainer", map[string]any{
+		"outcome": "failure",
+		"backend": "watsonx",
+		"model":   "granite-3",
+		"error":   "unknown backend: watsonx",
+	})
+
+	entries := log.Recent(10)
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.Action != agent.AuditAgentStartFailed {
+		t.Errorf("Action = %q, want %q", e.Action, agent.AuditAgentStartFailed)
+	}
+	if e.Agent != "ci-maintainer" {
+		t.Errorf("Agent = %q, want ci-maintainer", e.Agent)
+	}
+	if e.User != "system" {
+		t.Errorf("User = %q, want system", e.User)
+	}
+	for _, want := range []string{"outcome=failure", "backend=watsonx", "model=granite-3", "unknown backend: watsonx"} {
+		if !strings.Contains(e.Detail, want) {
+			t.Errorf("Detail %q missing %q", e.Detail, want)
+		}
+	}
+}
+
+// TestAgentAuditSinkSurvivesPersistReload is the durability half of the ask:
+// a lifecycle event must still be there after the hive restarts, since the
+// watsonx agent failed for a day across many launch attempts.
+func TestAgentAuditSinkSurvivesPersistReload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+
+	log := &AuditLog{writer: &lumberjack.Logger{Filename: path}}
+	sink := &agentAuditSink{log: log}
+	sink.Record("system", agent.AuditAgentStartFailed, "ci-maintainer", map[string]any{
+		"outcome": "failure",
+		"backend": "watsonx",
+		"model":   "granite-3",
+		"error":   "unknown backend: watsonx",
+	})
+	if err := log.writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read persisted audit log: %v", err)
+	}
+	line := strings.TrimSpace(string(data))
+	if line == "" {
+		t.Fatal("nothing persisted to disk")
+	}
+
+	// Reload the way loadFromDisk does, and confirm the event round-trips
+	// intact — including the backend/model/error that make it actionable.
+	var reloaded AuditEntry
+	if err := json.Unmarshal([]byte(line), &reloaded); err != nil {
+		t.Fatalf("unmarshal persisted entry: %v", err)
+	}
+	if reloaded.Action != agent.AuditAgentStartFailed {
+		t.Errorf("Action = %q, want %q", reloaded.Action, agent.AuditAgentStartFailed)
+	}
+	if reloaded.Agent != "ci-maintainer" {
+		t.Errorf("Agent = %q, want ci-maintainer", reloaded.Agent)
+	}
+	if !strings.Contains(reloaded.Detail, "backend=watsonx") ||
+		!strings.Contains(reloaded.Detail, "model=granite-3") ||
+		!strings.Contains(reloaded.Detail, "unknown backend: watsonx") {
+		t.Errorf("Detail lost context across the round trip: %q", reloaded.Detail)
+	}
+	if reloaded.Timestamp == "" {
+		t.Error("Timestamp did not survive the round trip")
+	}
+}


### PR DESCRIPTION
## Motivation: the watsonx incident

An agent (`ci-maintainer`) was configured with `backend: watsonx` on a hive whose image didn't support that backend. It failed at **every** launch with `unknown backend: watsonx` and simply never ran — for roughly a day, unnoticed.

The failure existed only as a WARN line inside the pod. Nothing surfaced it in the dashboard's Audit Log, so there was no durable, queryable record that an agent had been failing to start, nor of what method/model it was trying to use.

`pkg/agent/manager.go` already emitted `audit:`-prefixed **slog** lines for started/stopped/kicked/paused/resumed/added/removed — but those are log-only, never reached the audit store, and none of them carried backend/model.

## Approach: interface injection (and why)

`pkg/dashboard` **already imports** `pkg/agent` (agent types, auth helpers), so having the manager call into the audit store directly would be a guaranteed import cycle. Instead, dependency inversion:

- **`pkg/agent/audit.go`** defines the contract:
  ```go
  type AuditSink interface {
      Record(actor, action, agentName string, fields map[string]any)
  }
  ```
- `Manager` holds it as an optional `atomic.Pointer[AuditSink]`, installed via `SetAuditSink`. **A nil sink is a no-op**, so unit tests and any non-dashboard embedding are unaffected.
- `atomic.Pointer` rather than `m.mu`-guarded state, matching the existing discipline for `isGatewayBackend` / `bobAPIKeyResolver`: these are read from the launch path, which already holds `m.mu.Lock()`. Re-locking a non-reentrant `RWMutex` on the same goroutine would deadlock startup before `MarkReady` and crash-loop every spoke.
- **`pkg/dashboard/agent_audit_sink.go`** adapts `*AuditLog` to that interface via `Server.AgentAuditSink()`.
- **Injected in `cmd/hive/main.go`** (~line 2357, beside the existing `SetRecordPromptCallback` wiring), where both the dashboard server and the agent manager are in scope:
  ```go
  agentMgr.SetAuditSink(dashSrv.AgentAuditSink())
  ```

## Events covered

| Event | Action | Notes |
|---|---|---|
| Started | `agent_started` | backend, model, mode |
| **Start failed** | `agent_start_failed` | **the important new one** — backend, model, error text |
| Stopped | `agent_stopped` | |
| Paused / Resumed | `agent_paused` / `agent_resumed` | plus trigger + reason |
| Added / Removed | `agent_added` / `agent_removed` | |
| Backend changed | `agent_backend_changed` | old → new |
| Model changed | `agent_model_changed` | old → new (covers `SetModelOverride` and `PinModel`) |

Every entry carries agent name, `backend`, `model`, `outcome` (success/failure), and on failure the `error` string. Existing slog lines are kept — these are emitted **in addition**, not as a replacement.

**Launch failures are recorded at `announceLaunchFailureInPane`** — the single chokepoint every park-and-return branch (missing backend binary, bob with no API key) already passes through. Recording there rather than once per branch means a failure path added later cannot silently skip the audit log. Two paths that can't reach that chokepoint are covered explicitly: `ensureTmuxSession` failure (no pane to announce into) and the copilot diagnostic timeout.

Backend/model are reported as the **effective** values (override if set, else config), so the log shows what the agent will actually launch with — and the **un-normalized** model name, since a bad model name is exactly the misconfiguration being audited.

## Volume decision

`auditRingCap` is 500 entries, rotated at 5 MB × 3 backups / 90 days. To avoid flooding it:

- **Recorded at full fidelity:** state CHANGES and FAILURES.
- **Skipped:** backend/model writes that don't change the effective value. `/switch/{backend}` is re-applied on config reload and the governor re-asserts the current model every evaluation cycle; auditing those no-ops would bury the real operator changes. Guarded by tests.
- **Left slog-only:** routine successful kicks. A kick fires every governor cycle × N agents and would dominate the ring within minutes. They're already slog'd and separately persisted in full via `recordPrompt` / the per-agent Prompts tab.

No secrets in entries — the bob branch names the missing credential's env var, never its value.

## UI

No UI change needed. The Audit Log renderer treats entries generically (`ts` / `user` / `action` / `agent` / `detail`) with no per-action allowlist, and its free-text + regex filter searches across all five fields. Actions use the existing `snake_case` vocabulary (`add_agent`, `config_agent_models`, …), the agent name goes in the `Agent` column so entries are filterable per agent, and `FormatAuditDetail` renders fields as a stable `outcome=…, backend=…, model=…, error=…` string — sorted, since Go map iteration is randomized and the same event must render identically every time.

Lifecycle events are attributed to the `system` pseudo-user (they originate in the manager, which has no HTTP request and thus no authenticated user); the governor-vs-operator distinction is carried in the detail's `trigger=` field. This matches the existing `auditPseudoUsers` convention, so these entries correctly do **not** count as user engagement in the heartbeat.

## Tests

`pkg/agent/audit_test.go` + `pkg/dashboard/agent_audit_sink_test.go`:

- Launch failure records backend, model, and the error text (the watsonx case, by name)
- Launch failure reports **overrides**, not just static config
- Start/stop/add/remove record method + model
- Backend and model changes record old → new; `PinModel` too
- No-op backend/model writes record **nothing** (the volume guard)
- **Nil sink is a no-op** — no panic, with no dashboard present
- Entries survive the store's persist/reload round-trip with backend/model/error intact
- `FormatAuditDetail` output is stable and ordered

`go build ./...` and `go vet ./...` clean; `go test ./pkg/agent/ ./pkg/dashboard/` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
