### PR TITLE
🐛 fix(agent): isolate tmux kill paths

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -410,13 +410,12 @@ contribute-hive backend="" mode="docker": check-version
 
       # Start ollama silently if needed for goose
       if [[ "$BACKEND" == "goose" && "${GOOSE_PROVIDER:-}" == "ollama" ]]; then
-        # Kill any existing ollama that might spam logs to this terminal
-        pgrep -u "$(id -u)" -f "ollama serve" 2>/dev/null | while read -r pid; do kill "$pid" 2>/dev/null || true; done
-        sleep 1
-        echo "Starting ollama (silent)..."
-        OLLAMA_FLASH_ATTENTION=1 nohup ollama serve > /dev/null 2>&1 &
-        disown
-        sleep 2
+        if ! curl -sf http://localhost:11434/api/tags > /dev/null 2>&1; then
+          echo "Starting ollama (silent)..."
+          OLLAMA_FLASH_ATTENTION=1 nohup ollama serve > /dev/null 2>&1 &
+          disown
+          sleep 2
+        fi
         if ! curl -sf http://localhost:11434/api/tags > /dev/null 2>&1; then
           echo "WARNING: ollama failed to start. Install: https://ollama.com/download"
         fi

--- a/v2/pkg/agent/branches_coverage_test.go
+++ b/v2/pkg/agent/branches_coverage_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -203,10 +202,10 @@ func TestConfirmMenuOption_NavigatesToOption(t *testing.T) {
 
 	// Title present, but the selected ❯ line does NOT contain the wanted text,
 	// so confirmMenuOption presses navKey and re-reads (up to max steps).
-	exec.Command("tmux", "send-keys", "-t", session, "-l", ": Detected a custom API key").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "-l", "❯ 1. No (recommended)").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
+	testTmuxCommand("send-keys", "-t", session, "-l", ": Detected a custom API key").Run()
+	testTmuxCommand("send-keys", "-t", session, "Enter").Run()
+	testTmuxCommand("send-keys", "-t", session, "-l", "❯ 1. No (recommended)").Run()
+	testTmuxCommand("send-keys", "-t", session, "Enter").Run()
 	time.Sleep(300 * time.Millisecond)
 
 	// Wanted "Yes" is never on the selected line -> exhausts nav steps -> false.

--- a/v2/pkg/agent/crash_coverage_test.go
+++ b/v2/pkg/agent/crash_coverage_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -26,10 +25,10 @@ func TestCheckAndRestartCrashedAgents_BarePaneRestarts(t *testing.T) {
 	m.mu.RUnlock()
 
 	// Create a live session with a bare shell (no CLI marker).
-	if err := exec.Command("tmux", "new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
+	if err := testTmuxCommand("new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
 		t.Skipf("cannot create tmux session: %v", err)
 	}
-	defer exec.Command("tmux", "kill-session", "-t", agent.tmuxSession).Run()
+	defer testTmuxCommand("kill-session", "-t", agent.tmuxSession).Run()
 
 	old := time.Now().Add(-2 * time.Minute) // past cliBootGraceSeconds
 	m.mu.Lock()
@@ -54,10 +53,10 @@ func TestCheckAndRestartCrashedAgents_BootGrace(t *testing.T) {
 	m.mu.RLock()
 	agent := m.agents["cxa"]
 	m.mu.RUnlock()
-	if err := exec.Command("tmux", "new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
+	if err := testTmuxCommand("new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
 		t.Skipf("cannot create tmux session: %v", err)
 	}
-	defer exec.Command("tmux", "kill-session", "-t", agent.tmuxSession).Run()
+	defer testTmuxCommand("kill-session", "-t", agent.tmuxSession).Run()
 
 	recent := time.Now() // within grace
 	m.mu.Lock()
@@ -81,13 +80,13 @@ func TestCheckAndRestartCrashedAgents_InferenceHealthy(t *testing.T) {
 	m.mu.RLock()
 	agent := m.agents["cxa"]
 	m.mu.RUnlock()
-	if err := exec.Command("tmux", "new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
+	if err := testTmuxCommand("new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
 		t.Skipf("cannot create tmux session: %v", err)
 	}
-	defer exec.Command("tmux", "kill-session", "-t", agent.tmuxSession).Run()
+	defer testTmuxCommand("kill-session", "-t", agent.tmuxSession).Run()
 	// Live CLI marker, not a consent screen.
-	exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "-l", ": Claude esc to interrupt").Run()
-	exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "Enter").Run()
+	testTmuxCommand("send-keys", "-t", agent.tmuxSession, "-l", ": Claude esc to interrupt").Run()
+	testTmuxCommand("send-keys", "-t", agent.tmuxSession, "Enter").Run()
 	time.Sleep(400 * time.Millisecond)
 
 	old := time.Now().Add(-2 * time.Minute)
@@ -114,13 +113,13 @@ func TestCheckAndRestartCrashedAgents_ConsentStuck(t *testing.T) {
 	m.mu.RLock()
 	agent := m.agents["cxa"]
 	m.mu.RUnlock()
-	if err := exec.Command("tmux", "new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
+	if err := testTmuxCommand("new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
 		t.Skipf("cannot create tmux session: %v", err)
 	}
-	defer exec.Command("tmux", "kill-session", "-t", agent.tmuxSession).Run()
+	defer testTmuxCommand("kill-session", "-t", agent.tmuxSession).Run()
 	// Render a consent screen: title + default negative option + ❯ menu line.
-	exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "-l", ": Bypass Permissions mode No, exit").Run()
-	exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "Enter").Run()
+	testTmuxCommand("send-keys", "-t", agent.tmuxSession, "-l", ": Bypass Permissions mode No, exit").Run()
+	testTmuxCommand("send-keys", "-t", agent.tmuxSession, "Enter").Run()
 	time.Sleep(400 * time.Millisecond)
 
 	old := time.Now().Add(-2 * time.Minute)

--- a/v2/pkg/agent/dismiss_coverage_test.go
+++ b/v2/pkg/agent/dismiss_coverage_test.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"os/exec"
 	"testing"
 	"time"
 
@@ -23,14 +22,14 @@ func TestDismissInferencePrompts_PressEnter(t *testing.T) {
 	m.mu.RUnlock()
 	agent.tmuxSession = session
 
-	exec.Command("tmux", "send-keys", "-t", session, "-l", ": Press Enter to continue").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
+	testTmuxCommand("send-keys", "-t", session, "-l", ": Press Enter to continue").Run()
+	testTmuxCommand("send-keys", "-t", session, "Enter").Run()
 	time.Sleep(400 * time.Millisecond)
 
 	go func() {
 		time.Sleep(1200 * time.Millisecond)
-		exec.Command("tmux", "send-keys", "-t", session, "-l", ": esc to interrupt").Run()
-		exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
+		testTmuxCommand("send-keys", "-t", session, "-l", ": esc to interrupt").Run()
+		testTmuxCommand("send-keys", "-t", session, "Enter").Run()
 	}()
 
 	done := make(chan struct{})
@@ -57,16 +56,16 @@ func TestDismissInferencePrompts_FixWith(t *testing.T) {
 	agent.tmuxSession = session
 
 	// Selection menu whose selected line begins with "Fix with".
-	exec.Command("tmux", "send-keys", "-t", session, "-l", ": Enter to confirm").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "-l", "❯ Fix with Claude").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
+	testTmuxCommand("send-keys", "-t", session, "-l", ": Enter to confirm").Run()
+	testTmuxCommand("send-keys", "-t", session, "Enter").Run()
+	testTmuxCommand("send-keys", "-t", session, "-l", "❯ Fix with Claude").Run()
+	testTmuxCommand("send-keys", "-t", session, "Enter").Run()
 	time.Sleep(400 * time.Millisecond)
 
 	go func() {
 		time.Sleep(1500 * time.Millisecond)
-		exec.Command("tmux", "send-keys", "-t", session, "-l", ": esc to interrupt").Run()
-		exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
+		testTmuxCommand("send-keys", "-t", session, "-l", ": esc to interrupt").Run()
+		testTmuxCommand("send-keys", "-t", session, "Enter").Run()
 	}()
 
 	done := make(chan struct{})

--- a/v2/pkg/agent/launch_coverage_test.go
+++ b/v2/pkg/agent/launch_coverage_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -26,13 +25,13 @@ func TestStart_CLIAlreadyRunning(t *testing.T) {
 	m.mu.RUnlock()
 
 	// Pre-create the session and render a CLI marker.
-	if err := exec.Command("tmux", "new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
+	if err := testTmuxCommand("new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
 		t.Skipf("cannot create tmux session: %v", err)
 	}
-	defer exec.Command("tmux", "kill-session", "-t", agent.tmuxSession).Run()
+	defer testTmuxCommand("kill-session", "-t", agent.tmuxSession).Run()
 	// Inject a marker; forceRelaunch defaults to false.
-	exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "-l", ": goose is ready").Run()
-	exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "Enter").Run()
+	testTmuxCommand("send-keys", "-t", agent.tmuxSession, "-l", ": goose is ready").Run()
+	testTmuxCommand("send-keys", "-t", agent.tmuxSession, "Enter").Run()
 	time.Sleep(500 * time.Millisecond)
 
 	if err := m.Start(context.Background(), "cxa"); err != nil {
@@ -62,12 +61,12 @@ func TestStart_InferenceCLIAlreadyRunning(t *testing.T) {
 	agent := m.agents["cxa"]
 	m.mu.RUnlock()
 
-	if err := exec.Command("tmux", "new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
+	if err := testTmuxCommand("new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
 		t.Skipf("cannot create tmux session: %v", err)
 	}
-	defer exec.Command("tmux", "kill-session", "-t", agent.tmuxSession).Run()
-	exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "-l", ": esc to interrupt bypass permissions on Claude").Run()
-	exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "Enter").Run()
+	defer testTmuxCommand("kill-session", "-t", agent.tmuxSession).Run()
+	testTmuxCommand("send-keys", "-t", agent.tmuxSession, "-l", ": esc to interrupt bypass permissions on Claude").Run()
+	testTmuxCommand("send-keys", "-t", agent.tmuxSession, "Enter").Run()
 	time.Sleep(500 * time.Millisecond)
 
 	if err := m.Start(context.Background(), "cxa"); err != nil {
@@ -91,12 +90,12 @@ func TestStart_CopilotAdoptsRunning(t *testing.T) {
 	agent := m.agents["cxa"]
 	m.mu.RUnlock()
 
-	if err := exec.Command("tmux", "new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
+	if err := testTmuxCommand("new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
 		t.Skipf("cannot create tmux session: %v", err)
 	}
-	defer exec.Command("tmux", "kill-session", "-t", agent.tmuxSession).Run()
-	exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "-l", ": Copilot ready").Run()
-	exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "Enter").Run()
+	defer testTmuxCommand("kill-session", "-t", agent.tmuxSession).Run()
+	testTmuxCommand("send-keys", "-t", agent.tmuxSession, "-l", ": Copilot ready").Run()
+	testTmuxCommand("send-keys", "-t", agent.tmuxSession, "Enter").Run()
 	time.Sleep(500 * time.Millisecond)
 
 	if err := m.Start(context.Background(), "cxa"); err != nil {
@@ -122,17 +121,17 @@ func TestDismissInferencePrompts_NavigatesNegative(t *testing.T) {
 	agent.tmuxSession = session
 
 	// Render a selection prompt with a negative selected option.
-	exec.Command("tmux", "send-keys", "-t", session, "-l", ": Enter to confirm").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "-l", "❯ 1. No, exit").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
+	testTmuxCommand("send-keys", "-t", session, "-l", ": Enter to confirm").Run()
+	testTmuxCommand("send-keys", "-t", session, "Enter").Run()
+	testTmuxCommand("send-keys", "-t", session, "-l", "❯ 1. No, exit").Run()
+	testTmuxCommand("send-keys", "-t", session, "Enter").Run()
 	time.Sleep(400 * time.Millisecond)
 
 	// Run dismissal briefly; flip the pane to ready shortly after so it returns.
 	go func() {
 		time.Sleep(1500 * time.Millisecond)
-		exec.Command("tmux", "send-keys", "-t", session, "-l", ": esc to interrupt").Run()
-		exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
+		testTmuxCommand("send-keys", "-t", session, "-l", ": esc to interrupt").Run()
+		testTmuxCommand("send-keys", "-t", session, "Enter").Run()
 	}()
 
 	done := make(chan struct{})
@@ -161,16 +160,16 @@ func TestDismissInferencePrompts_BypassConsent(t *testing.T) {
 	m.mu.RUnlock()
 	agent.tmuxSession = session
 
-	exec.Command("tmux", "send-keys", "-t", session, "-l", ": Bypass Permissions mode").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "-l", "❯ 2. Yes, I accept").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
+	testTmuxCommand("send-keys", "-t", session, "-l", ": Bypass Permissions mode").Run()
+	testTmuxCommand("send-keys", "-t", session, "Enter").Run()
+	testTmuxCommand("send-keys", "-t", session, "-l", "❯ 2. Yes, I accept").Run()
+	testTmuxCommand("send-keys", "-t", session, "Enter").Run()
 	time.Sleep(400 * time.Millisecond)
 
 	go func() {
 		time.Sleep(1500 * time.Millisecond)
-		exec.Command("tmux", "send-keys", "-t", session, "-l", ": esc to interrupt").Run()
-		exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
+		testTmuxCommand("send-keys", "-t", session, "-l", ": esc to interrupt").Run()
+		testTmuxCommand("send-keys", "-t", session, "Enter").Run()
 	}()
 
 	done := make(chan struct{})

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -50,6 +50,8 @@ const (
 	proxyCACertPath      = "/data/proxy-ca.pem"
 )
 
+var defaultTmuxSocket string
+
 type AgentProcess struct {
 	Name              string
 	ID                string
@@ -754,41 +756,24 @@ func (m *Manager) tmuxBaseArgs(agent *AgentProcess) []string {
 	if agent.tmuxSocket != "" {
 		return []string{"tmux", "-L", agent.tmuxSocket}
 	}
+	if defaultTmuxSocket != "" {
+		return []string{"tmux", "-L", defaultTmuxSocket}
+	}
 	return []string{"tmux"}
 }
 
-func validTmuxKillSessionTarget(args []string) (string, bool) {
-	if len(args) == 0 || args[0] != "kill-session" {
-		return "", true
-	}
-	for i := 1; i < len(args); i++ {
-		arg := args[i]
-		switch {
-		case arg == "-t":
-			if i+1 >= len(args) {
-				return "", false
-			}
-			target := args[i+1]
-			return target, strings.HasPrefix(target, "hive-")
-		case strings.HasPrefix(arg, "-t="):
-			target := strings.TrimPrefix(arg, "-t=")
-			return target, strings.HasPrefix(target, "hive-")
-		}
-	}
-	return "", false
-}
-
 func (m *Manager) tmuxCmd(agent *AgentProcess, args ...string) *exec.Cmd {
-	if target, ok := validTmuxKillSessionTarget(args); !ok {
+	if err := validateTmuxKillSessionArgs(args); err != nil {
 		agentName := ""
 		if agent != nil {
 			agentName = agent.Name
 		}
 		if m.logger != nil {
-			m.logger.Warn("refusing unsafe tmux kill-session target", "target", target, "agent", agentName)
+			m.logger.Warn("refusing unsafe tmux kill-session", "agent", agentName, "error", err)
 		}
 		return exec.Command("false")
 	}
+
 	base := m.tmuxBaseArgs(agent)
 	tmuxArgs := append(base[1:], args...)
 	if agent.UID > 0 {
@@ -797,6 +782,37 @@ func (m *Manager) tmuxCmd(agent *AgentProcess, args ...string) *exec.Cmd {
 		return exec.Command("su-exec", suExecArgs...)
 	}
 	return exec.Command(base[0], tmuxArgs...)
+}
+
+func validateTmuxKillSessionArgs(args []string) error {
+	if len(args) == 0 || args[0] != "kill-session" {
+		return nil
+	}
+
+	target := ""
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case strings.HasPrefix(arg, "-t="):
+			target = strings.TrimPrefix(arg, "-t=")
+		case strings.HasPrefix(arg, "-target="):
+			target = strings.TrimPrefix(arg, "-target=")
+		case arg == "-t" || arg == "-target":
+			if i+1 < len(args) {
+				target = args[i+1]
+			}
+		case strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") && strings.Contains(strings.TrimPrefix(arg, "-"), "a"):
+			return fmt.Errorf("kill-session -a is not allowed")
+		}
+	}
+
+	if target == "" {
+		return fmt.Errorf("missing target")
+	}
+	if !strings.HasPrefix(target, "hive-") {
+		return fmt.Errorf("target %q is not hive-namespaced", target)
+	}
+	return nil
 }
 
 func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
@@ -816,10 +832,12 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 		tmuxArgs := append(m.tmuxBaseArgs(agent), "new-session", "-d", "-s", agent.tmuxSession, "-c", agentDir)
 		cmd = exec.Command(suExecArgs[0], append(suExecArgs[1:], tmuxArgs...)...)
 	} else {
-		cmd = exec.Command("tmux", "new-session", "-d", "-s", agent.tmuxSession, "-c", agentDir)
+		base := m.tmuxBaseArgs(agent)
+		tmuxArgs := append(base[1:], "new-session", "-d", "-s", agent.tmuxSession, "-c", agentDir)
+		cmd = exec.Command(base[0], tmuxArgs...)
 	}
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("creating tmux session for %s: %w", agent.Name, err)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("creating tmux session for %s: %w: %s", agent.Name, err, strings.TrimSpace(string(out)))
 	}
 
 	// tmux creates /tmp/tmux-{uid}/ with mode 700; ttyd runs as dev (uid 1001,
@@ -921,7 +939,7 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 }
 
 func (m *Manager) tmuxSessionExists(session string) bool {
-	cmd := exec.Command("tmux", "has-session", "-t", session)
+	cmd := m.tmuxRawCmd("has-session", "-t", session)
 	return cmd.Run() == nil
 }
 
@@ -1763,9 +1781,9 @@ func (m *Manager) watchForTrustPrompt(session string, ctx context.Context) {
 			output := m.captureTmuxPane(session)
 			if strings.Contains(output, "Confirm folder trust") || strings.Contains(output, "Do you trust the files") {
 				time.Sleep(paneCaptureSleep)
-				_ = exec.Command("tmux", "send-keys", "-t", session, "2").Run()
+				_ = m.tmuxRawCmd("send-keys", "-t", session, "2").Run()
 				time.Sleep(enterDelay)
-				_ = exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
+				_ = m.tmuxRawCmd("send-keys", "-t", session, "Enter").Run()
 				m.logger.Info("auto-answered folder trust prompt", "session", session)
 				time.Sleep(trustCooldown)
 			}
@@ -2370,13 +2388,19 @@ func (m *Manager) waitForInputPrompt(session string) bool {
 }
 
 func (m *Manager) captureTmuxPane(session string) string {
-	cmd := exec.Command("tmux", "capture-pane", "-t", session, "-p",
+	cmd := m.tmuxRawCmd("capture-pane", "-t", session, "-p",
 		"-S", fmt.Sprintf("-%d", tmuxCaptureLines))
 	out, err := cmd.Output()
 	if err != nil {
 		return ""
 	}
 	return string(out)
+}
+
+func (m *Manager) tmuxRawCmd(args ...string) *exec.Cmd {
+	base := m.tmuxBaseArgs(&AgentProcess{})
+	tmuxArgs := append(base[1:], args...)
+	return exec.Command(base[0], tmuxArgs...)
 }
 
 // captureTmuxPaneForAgent captures pane content using the agent's tmux socket.

--- a/v2/pkg/agent/manager_coverage2_test.go
+++ b/v2/pkg/agent/manager_coverage2_test.go
@@ -1729,37 +1729,37 @@ func TestTmuxBaseArgs_WithSocket(t *testing.T) {
 	}
 }
 
-func TestTmuxBaseArgs_WithoutSocket(t *testing.T) {
+func TestTmuxBaseArgs_WithDefaultSocket(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	agent := &AgentProcess{Name: "test", tmuxSocket: ""}
 	args := m.tmuxBaseArgs(agent)
-	if len(args) != 1 || args[0] != "tmux" {
-		t.Errorf("tmuxBaseArgs without socket = %v, want [tmux]", args)
+	if len(args) != 3 || args[1] != "-L" || args[2] != defaultTmuxSocket {
+		t.Errorf("tmuxBaseArgs with default socket = %v, want [tmux -L %s]", args, defaultTmuxSocket)
 	}
 }
 
-func TestValidTmuxKillSessionTarget(t *testing.T) {
+func TestValidateTmuxKillSessionArgs(t *testing.T) {
 	tests := []struct {
-		name       string
-		args       []string
-		wantOK     bool
-		wantTarget string
+		name    string
+		args    []string
+		wantErr bool
 	}{
-		{name: "non-kill command", args: []string{"has-session", "-t", "user"}, wantOK: true},
-		{name: "hive target", args: []string{"kill-session", "-t", "hive-agent"}, wantOK: true, wantTarget: "hive-agent"},
-		{name: "hive equals target", args: []string{"kill-session", "-t=hive-agent"}, wantOK: true, wantTarget: "hive-agent"},
-		{name: "empty target", args: []string{"kill-session", "-t", ""}, wantOK: false},
-		{name: "missing target", args: []string{"kill-session", "-t"}, wantOK: false},
-		{name: "missing flag", args: []string{"kill-session"}, wantOK: false},
-		{name: "non-hive target", args: []string{"kill-session", "-t", "work"}, wantOK: false, wantTarget: "work"},
+		{name: "non kill command", args: []string{"has-session", "-t", "work"}, wantErr: false},
+		{name: "hive target", args: []string{"kill-session", "-t", "hive-agent"}, wantErr: false},
+		{name: "hive target equals", args: []string{"kill-session", "-t=hive-agent"}, wantErr: false},
+		{name: "missing target", args: []string{"kill-session"}, wantErr: true},
+		{name: "empty target", args: []string{"kill-session", "-t", ""}, wantErr: true},
+		{name: "non hive target", args: []string{"kill-session", "-t", "work"}, wantErr: true},
+		{name: "kill all other sessions", args: []string{"kill-session", "-a", "-t", "hive-agent"}, wantErr: true},
+		{name: "kill all in combined flags", args: []string{"kill-session", "-at", "hive-agent", "-t", "hive-agent"}, wantErr: true},
+		{name: "kill all in reversed combined flags", args: []string{"kill-session", "-ta", "hive-agent"}, wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotTarget, gotOK := validTmuxKillSessionTarget(tt.args)
-			if gotOK != tt.wantOK || gotTarget != tt.wantTarget {
-				t.Fatalf("validTmuxKillSessionTarget(%v) = (%q, %v), want (%q, %v)",
-					tt.args, gotTarget, gotOK, tt.wantTarget, tt.wantOK)
+			err := validateTmuxKillSessionArgs(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateTmuxKillSessionArgs(%v) error = %v, wantErr %v", tt.args, err, tt.wantErr)
 			}
 		})
 	}

--- a/v2/pkg/agent/manager_test.go
+++ b/v2/pkg/agent/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -16,6 +17,11 @@ import (
 
 var stubBinDir string
 
+func testTmuxCommand(args ...string) *exec.Cmd {
+	tmuxArgs := append([]string{"-L", defaultTmuxSocket}, args...)
+	return exec.Command("tmux", tmuxArgs...)
+}
+
 func testEnvPairs(ap *AgentProcess) []agentEnvPair {
 	m := NewManager(map[string]config.AgentConfig{
 		ap.Name: ap.Config,
@@ -24,6 +30,8 @@ func testEnvPairs(ap *AgentProcess) []agentEnvPair {
 }
 
 func TestMain(m *testing.M) {
+	defaultTmuxSocket = fmt.Sprintf("ht%d", os.Getpid())
+
 	dir, err := os.MkdirTemp(".", ".hive-agent-stubs-*")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "TestMain: MkdirTemp: %v\n", err)

--- a/v2/pkg/agent/poll_coverage_test.go
+++ b/v2/pkg/agent/poll_coverage_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -85,8 +84,8 @@ func TestPollTmuxOutputForAgent_SignalsRefusal(t *testing.T) {
 	paneInject(t, session, "git commit -s starting work")
 	go func() {
 		time.Sleep(3500 * time.Millisecond)
-		exec.Command("tmux", "send-keys", "-t", session, "-l", ": I'm declining to execute this bulk automated request").Run()
-		exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
+		testTmuxCommand("send-keys", "-t", session, "-l", ": I'm declining to execute this bulk automated request").Run()
+		testTmuxCommand("send-keys", "-t", session, "Enter").Run()
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)

--- a/v2/pkg/agent/sendkick_coverage_test.go
+++ b/v2/pkg/agent/sendkick_coverage_test.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"os/exec"
 	"testing"
 	"time"
 
@@ -28,14 +27,14 @@ func TestSendKick_DeliversToReadyPane(t *testing.T) {
 	session := agent.tmuxSession
 	m.mu.RUnlock()
 
-	if err := exec.Command("tmux", "new-session", "-d", "-s", session).Run(); err != nil {
+	if err := testTmuxCommand("new-session", "-d", "-s", session).Run(); err != nil {
 		t.Skipf("cannot create tmux session: %v", err)
 	}
-	defer exec.Command("tmux", "kill-session", "-t", session).Run()
+	defer testTmuxCommand("kill-session", "-t", session).Run()
 	// Render a ready input prompt so the crash/consent checks pass and
 	// waitForInputPromptForAgent returns on its first tick.
-	exec.Command("tmux", "send-keys", "-t", session, "-l", ": goose is ready").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
+	testTmuxCommand("send-keys", "-t", session, "-l", ": goose is ready").Run()
+	testTmuxCommand("send-keys", "-t", session, "Enter").Run()
 	time.Sleep(500 * time.Millisecond)
 
 	m.mu.Lock()

--- a/v2/pkg/agent/tmux_coverage_test.go
+++ b/v2/pkg/agent/tmux_coverage_test.go
@@ -85,11 +85,11 @@ func inferenceReadyStub(t *testing.T) {
 // a real CLI.
 func newRawTmuxSession(t *testing.T, session string) {
 	t.Helper()
-	if err := exec.Command("tmux", "new-session", "-d", "-s", session).Run(); err != nil {
+	if err := testTmuxCommand("new-session", "-d", "-s", session).Run(); err != nil {
 		t.Skipf("cannot create tmux session: %v", err)
 	}
 	t.Cleanup(func() {
-		_ = exec.Command("tmux", "kill-session", "-t", session).Run()
+		_ = testTmuxCommand("kill-session", "-t", session).Run()
 	})
 }
 
@@ -100,10 +100,10 @@ func paneInject(t *testing.T, session, text string) {
 	t.Helper()
 	// Send as a literal string; ": " makes bash treat the rest as a no-op arg
 	// so nothing executes but the text is echoed into the visible pane.
-	if err := exec.Command("tmux", "send-keys", "-t", session, "-l", ": "+text).Run(); err != nil {
+	if err := testTmuxCommand("send-keys", "-t", session, "-l", ": "+text).Run(); err != nil {
 		t.Fatalf("send-keys: %v", err)
 	}
-	_ = exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
+	_ = testTmuxCommand("send-keys", "-t", session, "Enter").Run()
 	time.Sleep(400 * time.Millisecond)
 }
 
@@ -111,10 +111,10 @@ func paneInject(t *testing.T, session, text string) {
 func paneInjectLines(t *testing.T, session string, lines ...string) {
 	t.Helper()
 	for _, ln := range lines {
-		if err := exec.Command("tmux", "send-keys", "-t", session, "-l", ": "+ln).Run(); err != nil {
+		if err := testTmuxCommand("send-keys", "-t", session, "-l", ": "+ln).Run(); err != nil {
 			t.Fatalf("send-keys: %v", err)
 		}
-		_ = exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
+		_ = testTmuxCommand("send-keys", "-t", session, "Enter").Run()
 	}
 	time.Sleep(500 * time.Millisecond)
 }
@@ -522,14 +522,14 @@ func TestConfirmMenuOption_SelectsOption(t *testing.T) {
 	// comment prefix so it appears at column 0 (selectedMenuOption requires the
 	// trimmed line to start with "❯"). bash prints a harmless "command not
 	// found" below, but the typed line itself is visible in the pane.
-	if err := exec.Command("tmux", "send-keys", "-t", session, "-l", ": Bypass Permissions mode Enter to confirm").Run(); err != nil {
+	if err := testTmuxCommand("send-keys", "-t", session, "-l", ": Bypass Permissions mode Enter to confirm").Run(); err != nil {
 		t.Fatal(err)
 	}
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-	if err := exec.Command("tmux", "send-keys", "-t", session, "-l", "❯ 2. Yes I accept").Run(); err != nil {
+	testTmuxCommand("send-keys", "-t", session, "Enter").Run()
+	if err := testTmuxCommand("send-keys", "-t", session, "-l", "❯ 2. Yes I accept").Run(); err != nil {
 		t.Fatal(err)
 	}
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
+	testTmuxCommand("send-keys", "-t", session, "Enter").Run()
 	time.Sleep(500 * time.Millisecond)
 	// want "accept" is on the selected ❯ line -> confirm immediately.
 	if !m.confirmMenuOption(agent, "Bypass Permissions mode", "accept", "Down") {


### PR DESCRIPTION
## Summary
- validate tmux kill-session targets before Manager executes them, including rejecting empty/non-hive targets and kill-session -a
- route agent tmux tests through a dedicated per-run tmux socket instead of the developer default server
- stop the contributor Justfile from pkilling unrelated ollama serve processes

## Validation
- cd v2 && go build ./...
- cd v2 && go vet ./...
- cd v2 && go test ./pkg/agent/ -count=1

Part of #2743