### PR TITLE
🐛 fix(dashboard): watsonx model discovery only after a valid API key

### DIFF
--- a/v2/pkg/dashboard/gateways.go
+++ b/v2/pkg/dashboard/gateways.go
@@ -426,17 +426,19 @@ func (s *Server) handleGovernorGatewaysDiscover(w http.ResponseWriter, r *http.R
 	}
 	bearer, headers, err := gatewayProbeAuth(kind, key, projectID)
 	if err != nil {
-		// For watsonx a mint failure (no/invalid key yet) still offers the
-		// static Granite list so the Default Model dropdown is never a dead end.
-		if kind == config.GatewayKindWatsonx {
-			jsonResponse(w, map[string]interface{}{"ok": true, "models": watsonx.GraniteFallbackModels, "fallback": true})
-			return
-		}
+		// A watsonx mint failure means the key is missing or invalid — model
+		// population must NOT happen until a valid key is entered, so this is
+		// an error, never a fallback list (operator requirement: discovery and
+		// population only after a valid watsonx.ai API key).
 		jsonResponse(w, map[string]interface{}{"ok": false, "error": redactSecret(err.Error(), key)})
 		return
 	}
 	models, err := fetchModelsWithHeaders(endpoint, bearer, headers)
 	if err != nil {
+		// For watsonx the key has already been VALIDATED (the IAM mint above
+		// succeeded); only the model listing failed. Offering the static
+		// Granite list here keeps the Default Model dropdown usable without
+		// ever populating models for an unvalidated key.
 		if kind == config.GatewayKindWatsonx {
 			jsonResponse(w, map[string]interface{}{"ok": true, "models": watsonx.GraniteFallbackModels, "fallback": true})
 			return

--- a/v2/pkg/dashboard/watsonx_gateway_test.go
+++ b/v2/pkg/dashboard/watsonx_gateway_test.go
@@ -241,6 +241,86 @@ func TestWatsonxUpsert_DerivesEndpointFromRegion(t *testing.T) {
 	}
 }
 
+// Discovery for a watsonx gateway with a missing/invalid API key must FAIL —
+// no model population (not even the static Granite fallback) until a valid
+// watsonx.ai API key is entered. The IAM mint failure is the key-validity
+// verdict here.
+func TestWatsonxDiscover_InvalidKeyReturnsNoModels(t *testing.T) {
+	srv := newFullServer(t)
+	// Minter that always fails the exchange (invalid key).
+	fake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"errorMessage":"Provided API key could not be found"}`, http.StatusBadRequest)
+	}))
+	defer fake.Close()
+	origMinter := watsonx.DefaultMinter
+	watsonx.DefaultMinter = watsonx.NewTokenMinterForTest(fake.URL+"/identity/token", nil)
+	t.Cleanup(func() { watsonx.DefaultMinter = origMinter })
+
+	body := `{"name":"watsonx","kind":"watsonx","endpoint":"` + fake.URL + `/ml/gateway","project_id":"p","api_key":"bad-key-1234567890"}`
+	req := httptest.NewRequest("POST", "/api/config/governor/gateways/discover", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorGatewaysDiscover(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200 (verdict travels in the body)", w.Code)
+	}
+	var out struct {
+		OK     bool     `json:"ok"`
+		Models []string `json:"models"`
+		Error  string   `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.OK {
+		t.Fatalf("ok = true for an invalid key, want an error verdict: %s", w.Body.String())
+	}
+	if len(out.Models) != 0 {
+		t.Fatalf("models populated for an invalid key: %v", out.Models)
+	}
+	if out.Error == "" {
+		t.Fatal("error text missing for an invalid key")
+	}
+	if strings.Contains(w.Body.String(), "bad-key-1234567890") {
+		t.Fatal("response echoed the key")
+	}
+}
+
+// Once the key HAS been validated (IAM mint succeeded), a failure to list
+// models still offers the static Granite fallback so the dropdown is not a
+// dead end — fallback is allowed only behind a validated key.
+func TestWatsonxDiscover_ValidKeyListingFailureFallsBack(t *testing.T) {
+	srv := newFullServer(t)
+	fake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/identity/token") {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "IAM-JWT", "expires_in": 3600})
+			return
+		}
+		http.Error(w, "upstream models outage", http.StatusBadGateway)
+	}))
+	defer fake.Close()
+	origMinter := watsonx.DefaultMinter
+	watsonx.DefaultMinter = watsonx.NewTokenMinterForTest(fake.URL+"/identity/token", nil)
+	t.Cleanup(func() { watsonx.DefaultMinter = origMinter })
+
+	body := `{"name":"watsonx","kind":"watsonx","endpoint":"` + fake.URL + `/ml/gateway","project_id":"p","api_key":"good-key-1234567890"}`
+	req := httptest.NewRequest("POST", "/api/config/governor/gateways/discover", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorGatewaysDiscover(w, req)
+	var out struct {
+		OK       bool     `json:"ok"`
+		Models   []string `json:"models"`
+		Fallback bool     `json:"fallback"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !out.OK || !out.Fallback || len(out.Models) == 0 {
+		t.Fatalf("validated key + listing outage should fall back to Granite list, got: %s", w.Body.String())
+	}
+}
+
 // The static Granite fallback list is non-empty and carries current granite ids,
 // so a watsonx model dropdown is never empty when live discovery cannot run.
 func TestGraniteFallbackNonEmpty(t *testing.T) {


### PR DESCRIPTION
## Problem
Selecting watsonx and opening the Model Gateways form populated the Default Model dropdown with the static Granite list even when **no valid watsonx.ai API key** was entered — the discover endpoint returned `ok:true, fallback:true` on IAM mint failure.

Operator requirement:
> there should be auto-discover and model population only after a valid watsonx.ai api key is entered

This also aligns watsonx with the litellm flow (which errors on a bad key, no population).

## Fix
- IAM mint failure (missing/invalid key) → `ok:false` + redacted error, **no models**.
- Granite fallback list is now offered **only after the key was validated** by a successful IAM mint (models-listing outage case), so the dropdown isn't a dead end for a working key.
- Tests: invalid key ⇒ no models + error; validated key + listing failure ⇒ fallback allowed.

Follows up #2778.