### PR TITLE
🐛 fix(dashboard): Model Gateways dialog opens when selecting watsonx/litellm without a configured gateway

### DIFF
--- a/v2/pkg/dashboard/gateway_onboarding_test.go
+++ b/v2/pkg/dashboard/gateway_onboarding_test.go
@@ -85,10 +85,39 @@ func TestGatewayGuardRequiresKeyNotJustPresence(t *testing.T) {
 	if !strings.Contains(html, "if (gw && gw.hasKey) return true;") {
 		t.Error("the guard must require hasKey, not merely a gateway of the right kind")
 	}
-	// A live (non-fallback) discovery proves the method works even without a
-	// named gateway (env-configured endpoints) — do not interrupt then.
-	if !strings.Contains(html, "if (cached && !cached.fallback) return true;") {
-		t.Error("a live non-fallback discovery must short-circuit the guard")
+	// A live (non-fallback) discovery WITH MODELS proves the method works even
+	// without a named gateway (env-configured endpoints) — do not interrupt
+	// then. The length check matters: a 404 from an unconfigured backend used
+	// to be cached as an empty non-fallback "discovery" that silently skipped
+	// the guard (the Model Gateways redirect never appeared).
+	if !strings.Contains(html, "if (cached && !cached.fallback && cached.models && cached.models.length) return true;") {
+		t.Error("a live non-fallback discovery must short-circuit the guard only when it returned models")
+	}
+}
+
+// The method-switch redirect (big agent card → maybeOpenMethodConfig) must
+// fire when the method's gateway is missing OR keyless, and a non-OK
+// /api/inference/models response (404 for an unconfigured backend) must never
+// be cached as a successful discovery — that combination silently suppressed
+// the Model Gateways dialog when an operator picked watsonx/litellm on a hive
+// with no gateway configured.
+func TestMethodSwitchRedirectFiresWithoutConfiguredGateway(t *testing.T) {
+	html := indexHTML(t)
+	cases := []struct {
+		name    string
+		snippet string
+	}{
+		{"non-OK discovery is not cached", "if (!resp.ok) {"},
+		{"switch redirect requires a keyed gateway", "if (!gw || !gw.hasKey) {"},
+		{"cache short-circuit needs actual models", "if (cached && !cached.fallback && cached.models && cached.models.length) return;"},
+		{"keyless gateway names the reason", "'The ' + backend + ' gateway has no API key'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(html, tc.snippet) {
+				t.Errorf("method-switch redirect path is missing %q", tc.snippet)
+			}
+		})
 	}
 }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6773,6 +6773,15 @@
       }
       try {
         const resp = await fetch(`/api/inference/models/${encodeURIComponent(backend)}`);
+        // A non-OK response (404 for a backend with no registered endpoint —
+        // e.g. watsonx/litellm before any gateway is configured) is NOT a
+        // discovery result. Caching it as {models:[], fallback:false} made the
+        // maybeOpenMethodConfig/ensureGatewayMethodConfigured guards read it
+        // as a successful live discovery and silently skip the Model Gateways
+        // redirect when the operator picked the method (#2778 regression).
+        if (!resp.ok) {
+          return INFERENCE_MODELS[backend] || [];
+        }
         const data = await resp.json();
         // data.fallback: endpoint discovery failed and the server returned
         // static common aliases — mark them as unverified against the key.
@@ -12350,7 +12359,7 @@ function burnAreaChart() {
       // (possibly via HIVE_*_ENDPOINT env, which never appears in the gateway
       // list) — mirrors the same check maybeOpenMethodConfig makes.
       const cached = _inferenceModelCache[method];
-      if (cached && !cached.fallback) return true;
+      if (cached && !cached.fallback && cached.models && cached.models.length) return true;
       let gateways = [];
       try {
         const r = await fetch('/api/config/governor/gateways');
@@ -12522,13 +12531,19 @@ function burnAreaChart() {
         // genuinely configured (possibly via HIVE_*_ENDPOINT env, which never
         // appears in the gateway list) — nothing to fix.
         const cached = _inferenceModelCache[backend];
-        if (cached && !cached.fallback) return;
+        if (cached && !cached.fallback && cached.models && cached.models.length) return;
         const r = await fetch('/api/config/governor/gateways');
         if (!r.ok) return;
         const d = await r.json();
-        const has = (d.gateways || []).some(g => g && (g.kind === backend || g.name === backend));
-        if (!has) {
-          showToast('No ' + backend + ' gateway configured — opening Governor Config → Model Gateways', 'info');
+        // Same contract as ensureGatewayMethodConfigured: the method needs a
+        // matching gateway AND a key on it — a keyless watsonx gateway mints
+        // no IAM token, so discovery/inference fail exactly as if no gateway
+        // existed.
+        const gw = (d.gateways || []).find(g => g && (g.kind === backend || g.name === backend));
+        if (!gw || !gw.hasKey) {
+          const why = gw ? 'The ' + backend + ' gateway has no API key'
+            : 'No ' + backend + ' gateway configured';
+          showToast(why + ' — opening Governor Config → Model Gateways', 'info');
           // Guided jump: land the user directly on a NEW gateway form pre-set to
           // this method's kind (endpoint/preset already filled) instead of an
           // empty list they must then "+ Add" from. Consumed by loadGateways().


### PR DESCRIPTION
## Problem
Operator report: selecting watsonx or litellm on the big agent card for ci-maintainer does not open the Model Gateways dialog — even though #2778 added the guided redirect and the server correctly logs `watsonx backend selected but no watsonx gateway is configured; add one under the Model Gateways tab`.

## Root cause — cache poisoning
1. `/api/inference/models/<backend>` returns **404** when the backend has no registered endpoint (exactly the unconfigured case the redirect exists for).
2. `fetchInferenceModels` never checked `resp.ok` and cached the 404 as `{models: [], fallback: false}` — and it runs for every inference backend at page load.
3. `maybeOpenMethodConfig` / `ensureGatewayMethodConfigured` read that cache entry as a *successful live discovery* (`cached && !cached.fallback`) and returned before checking the gateway list. No toast, no dialog.

## Fix
- Never cache non-OK discovery responses.
- The cache short-circuit now also requires a non-empty model list.
- `maybeOpenMethodConfig` now applies the same contract as the dialog guard: the method needs a matching gateway **with a key** (`gw.hasKey`) — a keyless watsonx gateway mints no IAM token and must redirect too.
- Pinning tests updated/added.

Verified live against hosted-kubestellar-hive-ojv6 (namespace oke-11-placeholder-r05x) logs.

Follows up #2778, #2789.