### PR TITLE
✨ feat(dashboard): gateway-config redirect for openrouter, vllm and llm-d selection

### DIFF
--- a/v2/pkg/dashboard/gateway_onboarding_test.go
+++ b/v2/pkg/dashboard/gateway_onboarding_test.go
@@ -77,13 +77,18 @@ func TestGatewayGuardMirrorsLiteLLMAndOpensModelGateways(t *testing.T) {
 	}
 }
 
-// A gateway that exists but carries no API key must NOT satisfy the guard: a
-// keyless watsonx gateway mints no IAM token, so it fails exactly like a missing
-// one. Conversely a configured+keyed gateway must not interrupt the operator.
+// A gateway that exists but carries no API key must NOT satisfy the guard for
+// key-requiring kinds: a keyless watsonx gateway mints no IAM token and a
+// keyless openrouter gateway cannot authenticate, so both fail exactly like a
+// missing gateway. Self-hosted vllm/llm-d are commonly unauthenticated, so
+// presence alone satisfies them. A configured+keyed gateway never interrupts.
 func TestGatewayGuardRequiresKeyNotJustPresence(t *testing.T) {
 	html := indexHTML(t)
-	if !strings.Contains(html, "if (gw && gw.hasKey) return true;") {
-		t.Error("the guard must require hasKey, not merely a gateway of the right kind")
+	if !strings.Contains(html, "if (gw && (gw.hasKey || !GATEWAY_KEY_REQUIRED_METHODS.includes(method))) return true;") {
+		t.Error("the guard must require hasKey for key-requiring kinds and accept keyless self-hosted gateways")
+	}
+	if !strings.Contains(html, "const GATEWAY_KEY_REQUIRED_METHODS = ['openrouter', 'watsonx'];") {
+		t.Error("openrouter and watsonx are the key-requiring gateway methods")
 	}
 	// A live (non-fallback) discovery WITH MODELS proves the method works even
 	// without a named gateway (env-configured endpoints) — do not interrupt
@@ -108,9 +113,10 @@ func TestMethodSwitchRedirectFiresWithoutConfiguredGateway(t *testing.T) {
 		snippet string
 	}{
 		{"non-OK discovery is not cached", "if (!resp.ok) {"},
-		{"switch redirect requires a keyed gateway", "if (!gw || !gw.hasKey) {"},
+		{"switch redirect requires a keyed gateway for key-requiring kinds", "if (!gw || (!gw.hasKey && GATEWAY_KEY_REQUIRED_METHODS.includes(backend))) {"},
 		{"cache short-circuit needs actual models", "if (cached && !cached.fallback && cached.models && cached.models.length) return;"},
 		{"keyless gateway names the reason", "'The ' + backend + ' gateway has no API key'"},
+		{"a rejected gateway-method switch routes to the form", "dismissToast(toast, `No ${backend} gateway configured — opening Governor Config → Model Gateways`, 'info');"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -12367,14 +12367,16 @@ function burnAreaChart() {
         const d = await r.json();
         gateways = d.gateways || [];
       } catch (e) { return true; }
-      // Require BOTH a matching gateway and a key on it: a watsonx gateway saved
-      // without a key mints no IAM token, so model discovery and inference fail
-      // exactly as if no gateway existed at all.
+      // Require a matching gateway; for key-requiring kinds (hosted services:
+      // watsonx needs an IAM-minted token, openrouter a bearer key) also
+      // require the key. Self-hosted vllm/llm-d gateways are commonly
+      // unauthenticated, so mere presence (or an env-configured endpoint,
+      // caught by the discovery check above) satisfies them.
       const gw = gateways.find(g => g && (g.kind === method || g.name === method));
-      if (gw && gw.hasKey) return true;
+      if (gw && (gw.hasKey || !GATEWAY_KEY_REQUIRED_METHODS.includes(method))) return true;
       const why = gw
         ? `The ${method} gateway has no API key — ${method} needs one before this agent can run.`
-        : `No ${method} gateway is configured — ${method} needs an API key before this agent can run.`;
+        : `No ${method} gateway is configured — ${method} needs ${GATEWAY_KEY_REQUIRED_METHODS.includes(method) ? 'an endpoint and API key' : 'an endpoint'} before this agent can run.`;
       if (!(await hiveConfirm(`${why}\n\nOpen Governor Config → Model Gateways to set it up? Unsaved changes in this dialog will be discarded.`))) {
         return false;
       }
@@ -12504,6 +12506,11 @@ function burnAreaChart() {
     // Config → Model Gateways). The check is per-method — an openrouter
     // gateway does not satisfy a vllm selection.
     const GATEWAY_METHODS = ['openrouter', 'litellm', 'vllm', 'llm-d', 'watsonx'];
+    // Hosted gateway kinds that cannot work without an API key (watsonx mints
+    // an IAM token from it; openrouter authenticates with a bearer key).
+    // Self-hosted vllm/llm-d endpoints are commonly unauthenticated, so a
+    // configured gateway (or env endpoint) without a key is legitimate there.
+    const GATEWAY_KEY_REQUIRED_METHODS = ['openrouter', 'watsonx'];
 
     // maybeOpenMethodConfig runs AFTER a method switch is saved: the choice is
     // never blocked, but when the selected method's backing config is absent
@@ -12536,11 +12543,12 @@ function burnAreaChart() {
         if (!r.ok) return;
         const d = await r.json();
         // Same contract as ensureGatewayMethodConfigured: the method needs a
-        // matching gateway AND a key on it — a keyless watsonx gateway mints
-        // no IAM token, so discovery/inference fail exactly as if no gateway
-        // existed.
+        // matching gateway, plus a key when the kind requires one (watsonx
+        // mints an IAM token from it, openrouter authenticates with it).
+        // Self-hosted vllm/llm-d are commonly unauthenticated — presence (or
+        // the live-discovery check above) is enough for them.
         const gw = (d.gateways || []).find(g => g && (g.kind === backend || g.name === backend));
-        if (!gw || !gw.hasKey) {
+        if (!gw || (!gw.hasKey && GATEWAY_KEY_REQUIRED_METHODS.includes(backend))) {
           const why = gw ? 'The ' + backend + ' gateway has no API key'
             : 'No ' + backend + ' gateway configured';
           showToast(why + ' — opening Governor Config → Model Gateways', 'info');
@@ -12559,7 +12567,23 @@ function burnAreaChart() {
       const toast = showToast(`Switching ${agent} ${label} → ${backend} (restarting session)...`, 'info', true);
       const res = await fetch(`/api/switch/${agent}/${backend}`, { method: 'POST' });
       const data = await res.json();
-      if (!data.ok) { dismissToast(toast, `Switch failed: ${data.error || 'unknown'}`, 'error'); return; }
+      if (!data.ok) {
+        // A gateway method can FAIL the switch itself when nothing routes it —
+        // openrouter is valid only as a configured gateway NAME (it is not in
+        // the server's InferenceBackends list), so with no openrouter gateway
+        // the server rejects the switch with "unsupported backend". A dead-end
+        // error toast tells the operator nothing actionable; route them to the
+        // Model Gateways form pre-set to this kind instead, like every other
+        // unconfigured gateway method.
+        if (GATEWAY_METHODS.includes(backend)) {
+          dismissToast(toast, `No ${backend} gateway configured — opening Governor Config → Model Gateways`, 'info');
+          _pendingGatewayPresetKind = backend;
+          openConfigDialog('governor', null, 'Model Gateways');
+          return;
+        }
+        dismissToast(toast, `Switch failed: ${data.error || 'unknown'}`, 'error');
+        return;
+      }
       dismissToast(toast, `${agent} ${label} → ${backend} (session restarted)`, 'success');
       // The selection is saved; if its backing config is missing, land the
       // user on the Governor Config tab that fixes it (never blocks).


### PR DESCRIPTION
## What
Operator request: the Model Gateways guided flow (watsonx/litellm, #2778 + #2791) should also fire when selecting **openrouter**, **vllm**, or **llm-d**.

## Changes
1. **openrouter**: with no openrouter gateway configured the server rejects the switch itself (`unsupported backend` — openrouter is only routable as a configured gateway name), so the post-switch redirect never ran. A rejected switch to any gateway method now opens Governor Config → Model Gateways with the form pre-set to that kind, instead of a dead-end error toast.
2. **vllm / llm-d**: the missing-gateway redirect applies, but key presence is only required for hosted kinds that cannot function without one (`GATEWAY_KEY_REQUIRED_METHODS = ['openrouter','watsonx']`). Self-hosted vllm/llm-d endpoints are commonly unauthenticated — demanding hasKey would loop the operator back to the form on a perfectly working keyless gateway.
3. Both guards (agent-card `maybeOpenMethodConfig` and dialog `ensureGatewayMethodConfigured`) share the same contract; pinning tests updated.

Follows up #2778, #2789, #2791.