### PR TITLE
🐛 Fix spoke dashboard identity leak

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -433,10 +433,9 @@ func sanitizeFilenameComponent(s string) string {
 func (s *Server) handleRole(w http.ResponseWriter, r *http.Request) {
 	role := r.Header.Get("X-Hive-Role")
 	user := r.Header.Get("X-Hive-User")
-	if user == "" {
-		if cookie, err := r.Cookie("hive_hub_user"); err == nil && cookie.Value != "" {
-			user = cookie.Value
-		}
+	if sess := s.sessionFromRequest(r); sess != nil {
+		user = sess.Username
+		role = sess.Role
 	}
 	if role == "" {
 		role = "owner"
@@ -1589,14 +1588,12 @@ func (s *Server) handleGHUserAuthPoll(w http.ResponseWriter, r *http.Request) {
 	// Issue a per-user session (opaque random id → username+role) instead of a
 	// single shared cookie. Each authenticated user gets their own session so
 	// requests resolve to the user that owns their cookie — never a shared one.
-	if s.authToken != "" {
-		sid := s.createUserSession(username, role)
-		if sid == "" {
-			jsonResponse(w, map[string]interface{}{"status": "error", "error": "failed to create session"})
-			return
-		}
-		setSessionCookie(w, r, sid)
+	sid := s.createUserSession(username, role)
+	if sid == "" {
+		jsonResponse(w, map[string]interface{}{"status": "error", "error": "failed to create session"})
+		return
 	}
+	setSessionCookie(w, r, sid)
 
 	// Audit the successful login with the authenticated GitHub username as the
 	// actor (not the request's X-Hive-User, which has no session yet at this

--- a/v2/pkg/dashboard/api_routes_coverage_test.go
+++ b/v2/pkg/dashboard/api_routes_coverage_test.go
@@ -64,13 +64,18 @@ func TestCovG2_Role(t *testing.T) {
 		t.Errorf("role header = %d", rec.Code)
 	}
 
-	// With hive_hub_user cookie (no user header).
+	// The hub-wide hive_hub_user cookie is intentionally ignored by spoke
+	// dashboards; identity must come from the request headers or hive_session.
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/role", nil)
 	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "bob"})
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Errorf("role cookie = %d", rec.Code)
+	}
+	body := decodeJSON(t, rec)
+	if body["user"] != "" {
+		t.Errorf("role must ignore hive_hub_user cookie, got user %v", body["user"])
 	}
 }
 

--- a/v2/pkg/dashboard/coverage_boost_test.go
+++ b/v2/pkg/dashboard/coverage_boost_test.go
@@ -269,17 +269,22 @@ func TestHandleRole_WithHeaders(t *testing.T) {
 	}
 }
 
-func TestHandleRole_WithCookie(t *testing.T) {
+func TestHandleRole_WithSessionCookie(t *testing.T) {
 	srv := newFullServer(t)
+	sid := srv.createUserSession("session-user", "read")
 	req := httptest.NewRequest("GET", "/api/role", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
 	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "cookie-user"})
 	w := httptest.NewRecorder()
 	srv.handleRole(w, req)
 
 	var result map[string]string
 	json.NewDecoder(w.Body).Decode(&result)
-	if result["user"] != "cookie-user" {
-		t.Errorf("user = %q, want cookie-user", result["user"])
+	if result["user"] != "session-user" {
+		t.Errorf("user = %q, want session-user", result["user"])
+	}
+	if result["role"] != "read" {
+		t.Errorf("role = %q, want read", result["role"])
 	}
 }
 

--- a/v2/pkg/dashboard/spoke_authz_test.go
+++ b/v2/pkg/dashboard/spoke_authz_test.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -155,6 +156,28 @@ func TestMiddleware_DirectRouteSessionResolvesUser(t *testing.T) {
 	}
 	if sawUser != "clubanderson" || sawRole != config.RoleOwner {
 		t.Fatalf("session must inject its own identity, got user=%q role=%q", sawUser, sawRole)
+	}
+}
+
+func TestHandleRoleIgnoresLeakedHubCookie(t *testing.T) {
+	s := newDirectRouteServer(t, "realuser:read")
+	sid := s.createUserSession("realuser", config.RoleRead)
+	req := httptest.NewRequest("GET", "/api/role", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "castrojo"})
+	w := httptest.NewRecorder()
+
+	s.handleRole(w, req)
+
+	var got map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode /api/role: %v; body=%q", err, w.Body.String())
+	}
+	if got["user"] != "realuser" {
+		t.Fatalf("/api/role user = %q, want realuser (must not use hive_hub_user)", got["user"])
+	}
+	if got["role"] != config.RoleRead {
+		t.Fatalf("/api/role role = %q, want read", got["role"])
 	}
 }
 


### PR DESCRIPTION
Fixes #2790

## Summary
- stop spoke /api/role from reading the hub-wide hive_hub_user cookie that is shared across *.hive.kubestellar.io
- resolve /api/role from the per-spoke hive_session before falling back to hub-injected headers
- always mint a per-user hive_session after GitHub device-flow login, even when DASHBOARD_AUTH_TOKEN is empty

## Root cause
The dashboard mixed hub and spoke identity sources: /api/role treated the hub-scoped hive_hub_user cookie as a spoke user, so a cookie from hive.kubestellar.io could make a hosted spoke display another account. Tokenless direct-route device-flow logins also completed without creating a local session, causing the UI to fall back to stale/shared identity paths.

## Validation
- cd v2 && go build ./...
- cd v2 && go test ./pkg/dashboard/ ./pkg/hub/ -count=1

## Notes
The reported "Save failed: Failed to fetch" appears to be a secondary write-side auth/CORS symptom; this PR fixes the displayed identity/session source bug.