### PR TITLE
✨ feat(hub): usage rollup line items link back to hive rows in the fleet table

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -11812,6 +11812,31 @@ const dashboardHTML = `<!DOCTYPE html>
       renderUsagePanel();
     }
 
+    /* jumpToUsageBucket links a usage rollup row back to the fleet table.
+       One contributing hive → jump straight to (and highlight) its row via
+       the same jumpToHiveRow the alerts panel uses. Several → put the bucket
+       key in the hive search box (it matches org, repo, cluster and user)
+       so the table narrows to exactly that bucket's hives, then scroll to
+       the table. Falls back to the first id when the key is the synthetic
+       "(unattributed)" bucket, which the search text would never match. */
+    function jumpToUsageBucket(key, hiveIds) {
+      hiveIds = hiveIds || [];
+      if (hiveIds.length === 1) { jumpToHiveRow(hiveIds[0], key); return; }
+      if (!hiveIds.length) return;
+      var isSynthetic = !key || key.charAt(0) === '(';
+      if (isSynthetic) { jumpToHiveRow(hiveIds[0], key); return; }
+      var el = document.getElementById('hive-search');
+      if (el) el.value = key;
+      _dashSearchQuery = key;
+      /* A search only narrows what is rendered — make sure hidden sections
+         cannot swallow the result, mirroring jumpToHiveRow's widening. */
+      expandAllHiveSections();
+      renderHives(_allDashHives, true);
+      var table = document.querySelector('.hive-table') || document.getElementById('hive-search-row');
+      if (table) table.scrollIntoView({behavior: 'smooth', block: 'start'});
+      hiveToast('Hive list filtered to ' + key + ' (' + hiveIds.length + ' hives) — Clear to reset', 'info');
+    }
+
     /* Renders one rollup dimension as a compact table. rows are already sorted
        by consumption descending server-side. */
     function renderUsageSection(title, rows, key) {
@@ -11827,8 +11852,21 @@ const dashboardHTML = `<!DOCTYPE html>
       for (var i = 0; i < shown; i++) {
         var r = rows[i] || {};
         var pct = Number(r.sharePct) || 0;
+        /* The key cell links back to the fleet table: one hive jumps to its
+           row, several filter the table to the bucket. encodeURIComponent
+           then esc() so a user-influenced key can neither break out of the
+           attribute nor the onclick string. */
+        var ids = r.hiveIds || [];
+        var keyCell;
+        if (ids.length) {
+          keyCell = '<a href="#" onclick="jumpToUsageBucket(decodeURIComponent(\'' + esc(encodeURIComponent(String(r.key || ''))) + '\'),JSON.parse(decodeURIComponent(\'' + esc(encodeURIComponent(JSON.stringify(ids))) + '\')));return false"' +
+            ' style="color:inherit;text-decoration:none;border-bottom:1px dotted var(--muted)"' +
+            ' title="' + esc(r.key) + ' — show ' + (ids.length === 1 ? 'this hive' : 'these ' + ids.length + ' hives') + ' in the table">' + esc(r.key) + '</a>';
+        } else {
+          keyCell = esc(r.key);
+        }
         html += '<tr>' +
-          '<td style="padding:2px 6px 2px 0;max-width:150px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="' + esc(r.key) + '">' + esc(r.key) + '</td>' +
+          '<td style="padding:2px 6px 2px 0;max-width:150px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="' + esc(r.key) + '">' + keyCell + '</td>' +
           '<td style="padding:2px 6px;text-align:right;white-space:nowrap">' + fmtTokens(r.tokens) + '</td>' +
           '<td style="padding:2px 6px;text-align:right;color:var(--muted);white-space:nowrap">' + (Number(r.hives) || 0) + '</td>' +
           /* Inline share bar — cheap visual ranking without a chart library. */
@@ -11888,7 +11926,7 @@ const dashboardHTML = `<!DOCTYPE html>
           var dot = h.online
             ? '<span style="color:#3fb950" title="Online but consuming nothing — idle or stuck">●</span>'
             : '<span style="color:var(--muted)" title="Offline">○</span>';
-          chips += '<span style="display:inline-block;padding:2px 7px;margin:2px 4px 2px 0;background:var(--surface);border:1px solid var(--border);border-radius:10px;font-size:0.7rem" title="' + esc((h.org || '') + (h.owner ? ' · ' + h.owner : '')) + '">' + dot + ' ' + esc(h.name || h.id) + '</span>';
+          chips += '<span onclick="jumpToHiveRow(decodeURIComponent(\'' + esc(encodeURIComponent(String(h.id || ''))) + '\'),decodeURIComponent(\'' + esc(encodeURIComponent(String(h.name || h.id || ''))) + '\'))" style="display:inline-block;padding:2px 7px;margin:2px 4px 2px 0;background:var(--surface);border:1px solid var(--border);border-radius:10px;font-size:0.7rem;cursor:pointer" title="' + esc((h.org || '') + (h.owner ? ' · ' + h.owner : '')) + ' — show this hive in the table">' + dot + ' ' + esc(h.name || h.id) + '</span>';
         }
         var zMore = '';
         if (zero.length > USAGE_ZERO_TOP_N) {

--- a/v2/pkg/hub/usage.go
+++ b/v2/pkg/hub/usage.go
@@ -88,6 +88,11 @@ type UsageBucket struct {
 	// fleet total is zero (avoids a divide-by-zero producing NaN in JSON,
 	// which would be invalid and break the UI parse).
 	SharePct float64 `json:"sharePct"`
+	// HiveIDs are the registry ids of the hives that contributed to this
+	// bucket, so the dashboard can link a rollup row back to its hive rows
+	// in the fleet table. Sorted for deterministic output. The ids are
+	// hub-assigned (not user-controlled), but the UI escapes them anyway.
+	HiveIDs []string `json:"hiveIds,omitempty"`
 }
 
 // UsageHive identifies a single hive in the zero-consumption list.
@@ -169,6 +174,9 @@ func buildUsageBuckets(hives []RegistryEntry, keyOf func(RegistryEntry) string, 
 			b.Tokens += h.TotalTokens24h
 		}
 		b.Hives++
+		if id := strings.TrimSpace(h.ID); id != "" {
+			b.HiveIDs = append(b.HiveIDs, id)
+		}
 	}
 	out := make([]UsageBucket, 0, len(agg))
 	for _, b := range agg {
@@ -177,6 +185,7 @@ func buildUsageBuckets(hives []RegistryEntry, keyOf func(RegistryEntry) string, 
 			// 2^53, so no precision is lost in the ratio.
 			b.SharePct = float64(b.Tokens) / float64(total) * 100
 		}
+		sort.Strings(b.HiveIDs)
 		out = append(out, *b)
 	}
 	sort.Slice(out, func(i, j int) bool {

--- a/v2/pkg/hub/usage_test.go
+++ b/v2/pkg/hub/usage_test.go
@@ -196,6 +196,43 @@ func TestBuildUsageBucketsNilKeyFunc(t *testing.T) {
 	}
 }
 
+// TestBuildUsageBucketsCarryHiveIDs pins the bucket→hive back-links the
+// dashboard uses to jump from a usage row to the hive rows in the fleet
+// table: every contributing hive's id appears (sorted, deterministic), a
+// blank id is dropped rather than emitted as "", and the JSON key is the
+// hiveIds the UI reads.
+func TestBuildUsageBucketsCarryHiveIDs(t *testing.T) {
+	hives := []RegistryEntry{
+		{ID: "h-2", Org: "acme", PrimaryRepo: "widgets", TotalTokens24h: 60},
+		{ID: "h-1", Org: "acme", PrimaryRepo: "widgets", TotalTokens24h: 40},
+		{ID: "", Org: "acme", PrimaryRepo: "widgets"}, // blank id: counted, not linked
+		{ID: "h-3", Org: "other", PrimaryRepo: "app", TotalTokens24h: 100},
+	}
+	got := buildUsageBuckets(hives, usageOrgRepoKey, 200)
+	if len(got) != 2 {
+		t.Fatalf("buckets = %d, want 2 (%+v)", len(got), got)
+	}
+	// acme/widgets sorts first on tokens tie-break? 100 in each bucket — tie
+	// breaks on key ascending, so acme/widgets first.
+	acme := got[0]
+	if acme.Key != "acme/widgets" {
+		t.Fatalf("bucket[0].Key = %q, want acme/widgets", acme.Key)
+	}
+	if len(acme.HiveIDs) != 2 || acme.HiveIDs[0] != "h-1" || acme.HiveIDs[1] != "h-2" {
+		t.Fatalf("acme/widgets HiveIDs = %v, want [h-1 h-2] sorted, blank dropped", acme.HiveIDs)
+	}
+	if acme.Hives != 3 {
+		t.Fatalf("acme/widgets Hives = %d, want 3 (blank-id hive still counts)", acme.Hives)
+	}
+	b, err := json.Marshal(acme)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"hiveIds":["h-1","h-2"]`) {
+		t.Fatalf("bucket JSON missing hiveIds: %s", b)
+	}
+}
+
 // TestUsageInt64NoOverflow proves the fleet sum stays correct at magnitudes
 // that would overflow a 32-bit int.
 func TestUsageInt64NoOverflow(t *testing.T) {


### PR DESCRIPTION
## What
Operator request:
> the line items for the token count for each hive needs to link back to their item in the hub's dashboard table for the hive spokes

## Changes
- **Server** — `UsageBucket` now carries `hiveIds` (sorted, deterministic; blank ids dropped) for every rollup dimension (org/repo, owner, cluster).
- **UI** — each usage row's name is a link:
  - **1 hive** → scrolls to + highlights its row in the fleet table (reuses `jumpToHiveRow`, including the clear-filters fallback when the row is hidden).
  - **N hives** → fills the hive search box with the bucket key (search matches org/repo/cluster/user), expands collapsed sections, scrolls to the table, and toasts how to reset.
  - `(unattributed)` buckets fall back to jumping to the first hive (search text would never match a synthetic key).
- **Zero-consumption chips** are clickable the same way.
- XSS-safe: user-influenced keys are encodeURIComponent + esc()'d into the onclick attribute.

## Tests
- `TestBuildUsageBucketsCarryHiveIDs` pins ids, ordering, blank-id handling, and the `hiveIds` JSON key.
- Full `pkg/hub` suite passes.