### PR TITLE
🐛 fix(dashboard): installation-ID save control looks like a button and says what it does

### DIFF
--- a/v2/pkg/dashboard/gh_app_banner_test.go
+++ b/v2/pkg/dashboard/gh_app_banner_test.go
@@ -257,6 +257,19 @@ func TestInstallIdInputIsCrossBrowserHardened(t *testing.T) {
 	if !strings.Contains(btnTag, `type="button"`) {
 		t.Errorf("Set-ID button must be type=\"button\" (a default <button> is type=submit and an implicit form submit resets the field in Firefox before submitGitHubInstallationID runs):\n%s", btnTag)
 	}
+	// The save button must LOOK like a button: it inherits the banner's solid
+	// primary .gh-app-btn recipe. An inline transparent override once made it
+	// read as static text — operators typed the ID and never clicked (user
+	// report: "set id does not look like a button").
+	if strings.Contains(btnTag, "background:transparent") {
+		t.Errorf("the save-installation-ID button must not be a transparent ghost — it is the submit affordance:\n%s", btnTag)
+	}
+	// And its label must say what it does with what: "Set ID" told users
+	// neither the verb's object nor that pressing it was required.
+	btnClose := strings.Index(html[btnOpen:], "</button>")
+	if btnLabel := html[btnOpen+btnEnd+1 : btnOpen+btnClose]; !strings.Contains(btnLabel, "Save Installation ID") {
+		t.Errorf("save button label = %q, want %q", btnLabel, "Save Installation ID")
+	}
 
 	// Isolate the install-ID input's start tag: it must disable autocomplete
 	// and wire an Enter-key submit.

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2805,9 +2805,13 @@
          type=submit, and if this banner were ever wrapped in a form (or Firefox
          treated an ancestor as one), the click would trigger an implicit submit
          that navigates/resets the page and clears the input before the handler
-         ran — a Firefox-vs-Safari difference. type=button removes that path. -->
-    <button type="button" onclick="submitGitHubInstallationID()" class="gh-app-btn" style="background:transparent;border-color:var(--line);color:var(--text);margin-right:8px" id="gh-app-set-id-btn">Set ID</button>
-    <button type="button" onclick="recheckGitHubApp()" class="gh-app-btn" style="background:transparent;border-color:var(--line);color:var(--muted);margin-right:8px" id="gh-app-recheck-btn">Re-check</button>
+         ran — a Firefox-vs-Safari difference. type=button removes that path.
+         No inline ghost override: this button SUBMITS the typed ID, so it gets
+         the banner's solid primary recipe (.gh-app-btn). The old transparent
+         style made it read as static text — operators typed the ID and never
+         realized a click was required. -->
+    <button type="button" onclick="submitGitHubInstallationID()" class="gh-app-btn" style="margin-right:8px" id="gh-app-set-id-btn">Save Installation ID</button>
+    <button type="button" onclick="recheckGitHubApp()" class="gh-app-btn" style="background:transparent;border-color:var(--line-strong);color:var(--muted);margin-right:8px" id="gh-app-recheck-btn">Re-check</button>
     <a id="gh-app-install-link" href="" target="_blank" rel="noopener" class="gh-app-btn">Install GitHub App</a>
   </div>
   <div id="hub-banner" style="display:none"></div>
@@ -6068,7 +6072,7 @@
         if (typeof hiveToast === 'function') hiveToast('Enter the numeric installation ID (from github.com/settings/installations/<ID>)', 'error');
         return;
       }
-      if (btn) { btn.disabled = true; btn.textContent = 'Setting...'; }
+      if (btn) { btn.disabled = true; btn.textContent = 'Saving...'; }
       try {
         // Persists installation_id and live-reinits the GitHub client (no
         // restart) via the existing config-github handler.
@@ -6096,7 +6100,7 @@
       } catch(e) {
         if (typeof hiveToast === 'function') hiveToast('Error: ' + e.message, 'error');
       } finally {
-        if (btn) { btn.disabled = false; btn.textContent = 'Set ID'; }
+        if (btn) { btn.disabled = false; btn.textContent = 'Save Installation ID'; }
       }
     }
 


### PR DESCRIPTION
## Problem
Operator report (with screenshot):
> set id does not look like a button. people do not know they need to press it to set the install id. is there a better label? is there a better button style?

The 'Set ID' button carried an inline `background:transparent` override on the banner's `.gh-app-btn` primary recipe, leaving borderless-looking dark text beside an equally ghosted 'Re-check' — no affordance that pressing it is required to persist the installation ID.

## Fix
- **Label**: `Set ID` → **Save Installation ID** (clear verb + object); in-flight text `Setting...` → `Saving...`.
- **Style**: removed the ghost override — the save button now inherits the banner's solid amber primary recipe, matching the 'Install GitHub App' CTA class it already shares. 'Re-check' remains a ghost (secondary) but with the standard visible `--line-strong` border.
- **Pinned**: TestInstallIdInputIsCrossBrowserHardened now rejects a transparent save button and the old label.

Enter-to-submit on the input is unchanged.