### PR TITLE
✨ feat(dashboard): GitHub App setup-URL callback auto-configures the installation ID

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -242,6 +242,11 @@ github:
   # key_file: /secrets/gh-app-key.pem
 ```
 
+For GitHub App setup, configure the app's **Setup URL** to
+`https://<hive-host>/gh-setup` and enable **Redirect on update**. After an
+operator installs the app from the dashboard banner, GitHub redirects back and
+the hive verifies and saves the installation ID automatically.
+
 ## Build from Source
 
 ```bash

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -5103,6 +5103,24 @@ func (s *Server) handleGitHubAppInstallClicked(w http.ResponseWriter, r *http.Re
 
 // --- GitHub config endpoint ---
 
+type githubConfigUpdate struct {
+	AppID          *int64
+	InstallationID *int64
+	KeyFile        string
+	PrivateKey     string
+}
+
+type githubConfigUpdateError struct {
+	message string
+	code    int
+}
+
+func (e *githubConfigUpdateError) Error() string { return e.message }
+
+func newGitHubConfigUpdateError(message string, code int) *githubConfigUpdateError {
+	return &githubConfigUpdateError{message: message, code: code}
+}
+
 func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		AppID          *int64 `json:"app_id"`
@@ -5120,6 +5138,28 @@ func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	result, err := s.applyGitHubConfigUpdate(r, githubConfigUpdate{
+		AppID:          body.AppID,
+		InstallationID: body.InstallationID,
+		KeyFile:        body.KeyFile,
+		PrivateKey:     body.PrivateKey,
+	})
+	if err != nil {
+		code := http.StatusInternalServerError
+		if updateErr, ok := err.(*githubConfigUpdateError); ok {
+			code = updateErr.code
+		}
+		jsonError(w, err.Error(), code)
+		return
+	}
+	jsonResponse(w, result)
+}
+
+func (s *Server) applyGitHubConfigUpdate(r *http.Request, body githubConfigUpdate) (map[string]interface{}, error) {
+	if s.deps == nil || s.deps.Config == nil {
+		return nil, newGitHubConfigUpdateError("config not available", http.StatusInternalServerError)
+	}
+
 	s.githubConfigMu.Lock()
 	defer s.githubConfigMu.Unlock()
 
@@ -5131,8 +5171,7 @@ func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
 	// Refuse up front, before mutating anything, and name the cause.
 	if cfg.SourcePath == "" {
 		s.logger.Error("github config update rejected: config has no source path, save would be an in-memory no-op")
-		jsonError(w, "config not persisted: config has no source path, so the change would be lost on restart", http.StatusInternalServerError)
-		return
+		return nil, newGitHubConfigUpdateError("config not persisted: config has no source path, so the change would be lost on restart", http.StatusInternalServerError)
 	}
 
 	if body.PrivateKey != "" {
@@ -5142,13 +5181,11 @@ func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
 		}
 		if err := os.MkdirAll(filepath.Dir(keyPath), 0o755); err != nil {
 			s.logger.Warn("could not create key directory", "path", keyPath, "error", err)
-			jsonError(w, fmt.Sprintf("failed to create key directory: %v", err), http.StatusInternalServerError)
-			return
+			return nil, newGitHubConfigUpdateError(fmt.Sprintf("failed to create key directory: %v", err), http.StatusInternalServerError)
 		}
 		const keyFileMode = 0o600
 		if err := os.WriteFile(keyPath, []byte(body.PrivateKey), keyFileMode); err != nil {
-			jsonError(w, fmt.Sprintf("failed to write key file: %v", err), http.StatusInternalServerError)
-			return
+			return nil, newGitHubConfigUpdateError(fmt.Sprintf("failed to write key file: %v", err), http.StatusInternalServerError)
 		}
 		cfg.GitHub.KeyFile = keyPath
 		s.logger.Info("github app private key written", "path", keyPath)
@@ -5167,14 +5204,12 @@ func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if strings.Contains(err.Error(), "source path") {
 			s.logger.Error("github config update rejected: config has no source path, save would be an in-memory no-op")
-			jsonError(w, "config not persisted: config has no source path, so the change would be lost on restart", http.StatusInternalServerError)
-			return
+			return nil, newGitHubConfigUpdateError("config not persisted: config has no source path, so the change would be lost on restart", http.StatusInternalServerError)
 		}
 		s.logger.Error("failed to persist github config", "error", err)
-		jsonError(w, "failed to save config", http.StatusInternalServerError)
-		return
+		return nil, newGitHubConfigUpdateError("failed to save config", http.StatusInternalServerError)
 	}
-	jsonResponse(w, result)
+	return result, nil
 }
 
 func requestAuditUser(r *http.Request) string {
@@ -5294,6 +5329,115 @@ func (s *Server) AutoDiscoverGitHubInstallationID(ctx context.Context, force boo
 	}
 	s.logger.Info("github app installation auto-discovered", "org", org, "installation_id", id)
 	return id, nil
+}
+
+func (s *Server) handleGitHubAppSetupCallback(w http.ResponseWriter, r *http.Request) {
+	redirect := func(flag string) {
+		http.Redirect(w, r, "/?ghSetup="+flag, http.StatusSeeOther)
+	}
+
+	action := strings.TrimSpace(r.URL.Query().Get("setup_action"))
+	switch action {
+	case "request":
+		s.logger.Info("github app setup callback recorded pending approval request")
+		redirect("requested")
+		return
+	case "install", "update":
+	default:
+		s.logger.Warn("github app setup callback rejected: unsupported setup_action", "setup_action", action)
+		redirect("error")
+		return
+	}
+
+	rawID := strings.TrimSpace(r.URL.Query().Get("installation_id"))
+	installationID, err := strconv.ParseInt(rawID, 10, 64)
+	if err != nil || installationID <= 0 {
+		s.logger.Warn("github app setup callback rejected: invalid installation_id", "installation_id", rawID)
+		redirect("error")
+		return
+	}
+
+	if err := s.verifyGitHubSetupInstallation(r, installationID); err != nil {
+		s.logger.Warn("github app setup callback rejected", "installation_id", installationID, "error", err)
+		redirect("error")
+		return
+	}
+
+	if err := s.persistGitHubSetupInstallation(r, installationID); err != nil {
+		s.logger.Warn("github app setup callback failed to persist installation", "installation_id", installationID, "error", err)
+		redirect("error")
+		return
+	}
+
+	redirect("ok")
+}
+
+func (s *Server) verifyGitHubSetupInstallation(r *http.Request, installationID int64) error {
+	if s.deps == nil || s.deps.Config == nil {
+		return fmt.Errorf("config not available")
+	}
+	cfg := s.deps.Config
+	if cfg.GitHub.InstallationID != 0 && cfg.GitHub.InstallationID != installationID && !s.requestHasGitHubSetupAdmin(r) {
+		return fmt.Errorf("installation_id is already configured; authenticated admin required to replace it")
+	}
+	if !cfg.GitHub.HasApp() {
+		return fmt.Errorf("github app_id is not configured")
+	}
+	keyFile := cfg.GitHub.KeyFile
+	if s.deps.ResolveAppKeyFileFunc != nil {
+		keyFile = s.deps.ResolveAppKeyFileFunc(cfg.GitHub.KeyFile, cfg.GitHub.AppID)
+	}
+	if strings.TrimSpace(keyFile) == "" {
+		return fmt.Errorf("github app key file is not configured")
+	}
+	auth, err := github.NewAppAuth(cfg.GitHub.AppID, installationID, keyFile, s.logger, cfg.GitHub.ResolvedAPIURL())
+	if err != nil {
+		return err
+	}
+	ctx := r.Context()
+	if s.deps.Ctx != nil {
+		ctx = s.deps.Ctx
+	}
+	// /gh-setup is public because GitHub redirects a fresh browser here without
+	// a hive session. We still do not trust the query string: the App JWT call
+	// below proves the ID exists for this App and that its account is exactly
+	// this hive's configured org, preventing installation hijacking.
+	return auth.VerifyInstallationForOrg(ctx, installationID, cfg.Project.Org)
+}
+
+func (s *Server) persistGitHubSetupInstallation(r *http.Request, installationID int64) error {
+	s.githubConfigMu.Lock()
+	defer s.githubConfigMu.Unlock()
+
+	cfg := s.deps.Config
+	if cfg.GitHub.InstallationID != 0 && cfg.GitHub.InstallationID != installationID && !s.requestHasGitHubSetupAdmin(r) {
+		return fmt.Errorf("installation_id is already configured; authenticated admin required to replace it")
+	}
+	cfg.GitHub.InstallationID = installationID
+	result, err := s.finishGitHubConfigUpdateLocked(requestAuditUser(r),
+		auditDetail("source", "setup_url", "installation_id", strconv.FormatInt(installationID, 10)))
+	if err != nil {
+		return err
+	}
+	if result["reinit"] == "failed" {
+		return fmt.Errorf("reinitializing github client after setup callback: %v", result["reinit_error"])
+	}
+	return nil
+}
+
+func (s *Server) requestHasGitHubSetupAdmin(r *http.Request) bool {
+	if sess := s.sessionFromRequest(r); sess != nil {
+		return sess.Role == "owner" || sess.Role == "read-write"
+	}
+	role := r.Header.Get("X-Hive-Role")
+	if role != "owner" && role != "read-write" {
+		return false
+	}
+	if s.directRouteAuthzEnabled() {
+		return false
+	}
+	proof := r.Header.Get(proxyAuthHeader)
+	return s.authToken != "" && proof != "" && secureCompare(proof, s.authToken)
 }
 
 // --- Sidebar endpoints ---

--- a/v2/pkg/dashboard/api_config_github_test.go
+++ b/v2/pkg/dashboard/api_config_github_test.go
@@ -226,3 +226,161 @@ func TestAutoDiscoverGitHubInstallationIDPersistsLikeManualSetID(t *testing.T) {
 			gotAppID, gotInstallationID, gotKeyFile, testHubDeliveredAppID, testHubDeliveredInstallationID, keyFile)
 	}
 }
+func TestGitHubSetupCallback_ValidInstallConfigures(t *testing.T) {
+	s, deps, api := setupCallbackServer(t, "myorg")
+	defer api.Close()
+
+	var gotInstallationID int64
+	deps.ReinitGitHubFunc = func(appID, installationID int64, keyFile string) error {
+		gotInstallationID = installationID
+		return nil
+	}
+
+	rec := doGet(s, "/gh-setup?setup_action=install&installation_id=4242")
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("setup callback: want 303, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if loc := rec.Header().Get("Location"); loc != "/?ghSetup=ok" {
+		t.Fatalf("redirect = %q, want /?ghSetup=ok", loc)
+	}
+	if deps.Config.GitHub.InstallationID != 4242 {
+		t.Fatalf("installation_id = %d, want 4242", deps.Config.GitHub.InstallationID)
+	}
+	if gotInstallationID != 4242 {
+		t.Fatalf("reinit installation_id = %d, want 4242", gotInstallationID)
+	}
+	if entries := s.GetAudit().Recent(1); len(entries) != 1 || entries[0].Action != "config_github" {
+		t.Fatalf("audit entry = %#v, want config_github", entries)
+	}
+}
+
+func TestGitHubSetupCallback_RequestDoesNotConfigure(t *testing.T) {
+	s, deps, api := setupCallbackServer(t, "myorg")
+	defer api.Close()
+
+	rec := doGet(s, "/gh-setup?setup_action=request")
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("setup request: want 303, got %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/?ghSetup=requested" {
+		t.Fatalf("redirect = %q, want /?ghSetup=requested", loc)
+	}
+	if deps.Config.GitHub.InstallationID != 0 {
+		t.Fatalf("installation_id = %d, want unchanged 0", deps.Config.GitHub.InstallationID)
+	}
+}
+
+func TestGitHubSetupCallback_MismatchedOrgRejected(t *testing.T) {
+	s, deps, api := setupCallbackServer(t, "other-org")
+	defer api.Close()
+
+	rec := doGet(s, "/gh-setup?setup_action=install&installation_id=4242")
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("setup callback: want 303, got %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/?ghSetup=error" {
+		t.Fatalf("redirect = %q, want /?ghSetup=error", loc)
+	}
+	if deps.Config.GitHub.InstallationID != 0 {
+		t.Fatalf("installation_id = %d, want unchanged 0", deps.Config.GitHub.InstallationID)
+	}
+}
+
+func TestGitHubSetupCallback_NonNumericIDRejected(t *testing.T) {
+	s, deps, api := setupCallbackServer(t, "myorg")
+	defer api.Close()
+
+	rec := doGet(s, "/gh-setup?setup_action=install&installation_id=abc")
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("setup callback: want 303, got %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/?ghSetup=error" {
+		t.Fatalf("redirect = %q, want /?ghSetup=error", loc)
+	}
+	if deps.Config.GitHub.InstallationID != 0 {
+		t.Fatalf("installation_id = %d, want unchanged 0", deps.Config.GitHub.InstallationID)
+	}
+}
+
+func TestGitHubSetupCallback_AlreadyConfiguredUnauthenticatedRejected(t *testing.T) {
+	s, deps, api := setupCallbackServer(t, "myorg")
+	defer api.Close()
+	deps.Config.GitHub.InstallationID = 1111
+
+	rec := doGet(s, "/gh-setup?setup_action=install&installation_id=4242")
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("setup callback: want 303, got %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/?ghSetup=error" {
+		t.Fatalf("redirect = %q, want /?ghSetup=error", loc)
+	}
+	if deps.Config.GitHub.InstallationID != 1111 {
+		t.Fatalf("installation_id = %d, want unchanged 1111", deps.Config.GitHub.InstallationID)
+	}
+}
+
+func TestGitHubSetupCallback_UpdateForSameInstallationAllowed(t *testing.T) {
+	s, deps, api := setupCallbackServer(t, "myorg")
+	defer api.Close()
+	deps.Config.GitHub.InstallationID = 4242
+
+	rec := doGet(s, "/gh-setup?setup_action=update&installation_id=4242")
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("setup callback: want 303, got %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/?ghSetup=ok" {
+		t.Fatalf("redirect = %q, want /?ghSetup=ok", loc)
+	}
+	if deps.Config.GitHub.InstallationID != 4242 {
+		t.Fatalf("installation_id = %d, want unchanged 4242", deps.Config.GitHub.InstallationID)
+	}
+}
+
+func setupCallbackServer(t *testing.T, accountLogin string) (*Server, *Dependencies, *httptest.Server) {
+	t.Helper()
+
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/app/installations/4242" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": 4242,
+			"account": map[string]any{
+				"login": accountLogin,
+				"type":  "Organization",
+			},
+		})
+	}))
+
+	s, deps := apiServer(t)
+	deps.Config.SourcePath = filepath.Join(t.TempDir(), "hive.yaml")
+	deps.Config.Project.Org = "myorg"
+	deps.Config.GitHub.AppID = testHubDeliveredAppID
+	deps.Config.GitHub.InstallationID = 0
+	deps.Config.GitHub.APIURL = api.URL
+	deps.Config.GitHub.KeyFile = writeTestAppKey(t)
+	return s, deps, api
+}
+
+func writeTestAppKey(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating RSA key: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "gh-app-key.pem")
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		t.Fatalf("creating key file: %v", err)
+	}
+	if err := pem.Encode(f, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
+		_ = f.Close()
+		t.Fatalf("writing key PEM: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("closing key file: %v", err)
+	}
+	return path
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -668,6 +668,7 @@ func (s *Server) registerCoreRoutes() {
 	s.mux.HandleFunc("GET /api/events", s.handleSSE)
 	s.mux.HandleFunc("POST /api/github-app/recheck", s.handleGitHubAppRecheck)
 	s.mux.HandleFunc("POST /api/github-app/install-clicked", s.handleGitHubAppInstallClicked)
+	s.mux.HandleFunc("GET /gh-setup", s.handleGitHubAppSetupCallback)
 	// SSO handoff: exchange a hub-minted, HMAC-signed token for a local session
 	// so a hub-authenticated user opens this (direct-route) spoke without a
 	// second GitHub device-flow login. Public path (see isPublicPath) because
@@ -906,6 +907,11 @@ func isPublicPath(path string) bool {
 		// token IS the credential. The handler itself verifies the token and
 		// the authorized_users allowlist before minting a session, so exposing
 		// the path unauthenticated does not weaken the allowlist gate.
+		return true
+	case path == "/gh-setup":
+		// GitHub App Setup URL return: GitHub redirects a fresh browser here
+		// after install, often without a hive session. The handler accepts only
+		// IDs verified by an App-JWT lookup against this app and this hive's org.
 		return true
 	default:
 		return false

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2546,7 +2546,7 @@
           <li>Set the permissions below, then click "Create GitHub App"</li>
           <li>On the app page, note the <strong>App ID</strong> and <strong>Client ID</strong></li>
           <li>Generate a private key (.pem file) and save it to <code>./secrets/gh-app-key.pem</code></li>
-          <li>Install the app on your org/repos and note the <strong>Installation ID</strong> (from the URL after install)</li>
+          <li>Install the app on your org/repos. If the app's <strong>Setup URL</strong> is set to this hive's <code>/gh-setup</code> URL, finishing the install in the same browser configures the Installation ID automatically; otherwise note the <strong>Installation ID</strong> from the URL after install.</li>
           <li>Update <code>hive.yaml</code>:</li>
         </ol>
         <pre style="background:var(--panel-strong);color:var(--text);padding:12px;border-radius:6px;font-size:0.75rem;overflow-x:auto">github:
@@ -12259,6 +12259,22 @@ function burnAreaChart() {
       setTimeout(() => dismissToast(el), TOAST_DURATION_MS);
       return el;
     }
+    function handleGitHubSetupToast() {
+      if (!window.URL || !window.URLSearchParams || !history.replaceState) return;
+      const url = new URL(window.location.href);
+      const flag = url.searchParams.get('ghSetup');
+      if (!flag) return;
+      if (flag === 'ok') {
+        showToast('GitHub App installed and configured automatically', 'success');
+      } else if (flag === 'requested') {
+        showToast('Install requested — an org admin must approve; this hive will configure itself once approved', 'info');
+      } else {
+        showToast('GitHub App setup could not be completed automatically. Check the Installation ID and app org.', 'error');
+      }
+      url.searchParams.delete('ghSetup');
+      history.replaceState({}, document.title, url.pathname + (url.search ? url.search : '') + url.hash);
+    }
+    handleGitHubSetupToast();
     // dismissToast removes a toast, or (with newMsg) rewrites an in-flight
     // toast into its result. `force` bypasses stickiness for the user-initiated
     // click/× path, so a sticky error can still be dismissed on demand.

--- a/v2/pkg/github/app_discovery.go
+++ b/v2/pkg/github/app_discovery.go
@@ -202,6 +202,45 @@ func (a *AppAuth) discoverInstallationUncached(ctx context.Context, org string) 
 	return 0, fmt.Errorf("%w: app %d has no installation for %q (direct lookup: %v)", ErrNoInstallationForOrg, a.appID, org, directErr)
 }
 
+// VerifyInstallationForOrg verifies that installationID is an installation of
+// this GitHub App whose account login matches org. It uses an App JWT, not an
+// installation token, so it is safe to call before the hive has accepted or
+// configured the installation ID.
+func (a *AppAuth) VerifyInstallationForOrg(ctx context.Context, installationID int64, org string) error {
+	if a == nil {
+		return fmt.Errorf("no app auth configured")
+	}
+	if a.key == nil {
+		return fmt.Errorf("app private key not loaded")
+	}
+	org = strings.TrimSpace(org)
+	if org == "" {
+		return fmt.Errorf("target org is empty")
+	}
+	if installationID <= 0 {
+		return fmt.Errorf("installation ID must be positive")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, tokenMintTimeout)
+	defer cancel()
+
+	jwtToken, err := a.generateJWT()
+	if err != nil {
+		return fmt.Errorf("generating JWT: %w", err)
+	}
+	inst, _, err := a.newJWTClient(jwtToken).Apps.GetInstallation(ctx, installationID)
+	if err != nil {
+		return fmt.Errorf("getting app installation %d: %w", installationID, err)
+	}
+	if inst == nil || inst.GetID() != installationID {
+		return fmt.Errorf("%w: installation %d was not returned by GitHub", ErrNoInstallationForOrg, installationID)
+	}
+	if acct := inst.GetAccount().GetLogin(); acct == "" || !strings.EqualFold(acct, org) {
+		return fmt.Errorf("%w: installation %d belongs to %q, not %q", ErrNoInstallationForOrg, installationID, inst.GetAccount().GetLogin(), org)
+	}
+	return nil
+}
+
 // AppID returns the configured GitHub App ID.
 func (a *AppAuth) AppID() int64 { return a.appID }
 

--- a/v2/pkg/github/app_verify_test.go
+++ b/v2/pkg/github/app_verify_test.go
@@ -1,0 +1,112 @@
+package github
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVerifyInstallationForOrg(t *testing.T) {
+	tests := []struct {
+		name       string
+		account    string
+		id         int64
+		wantErrSub string
+	}{
+		{name: "matches org case insensitively", account: "MyOrg", id: 4242},
+		{name: "rejects mismatched org", account: "OtherOrg", id: 4242, wantErrSub: "no installation"},
+		{name: "rejects nonpositive id", account: "MyOrg", id: 0, wantErrSub: "positive"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/app/installations/4242" {
+					http.NotFound(w, r)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id": 4242,
+					"account": map[string]any{
+						"login": tt.account,
+						"type":  "Organization",
+					},
+				})
+			}))
+			defer api.Close()
+
+			auth := newVerifyTestAppAuth(t, 1234, 0, api.URL)
+			err := auth.VerifyInstallationForOrg(context.Background(), tt.id, "myorg")
+			if tt.wantErrSub == "" {
+				if err != nil {
+					t.Fatalf("VerifyInstallationForOrg: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErrSub) {
+				t.Fatalf("VerifyInstallationForOrg error = %v, want substring %q", err, tt.wantErrSub)
+			}
+		})
+	}
+}
+
+func TestVerifyInstallationForOrgRejectsInvalidInputs(t *testing.T) {
+	if err := (*AppAuth)(nil).VerifyInstallationForOrg(context.Background(), 1, "myorg"); err == nil || !strings.Contains(err.Error(), "no app auth") {
+		t.Fatalf("nil auth error = %v, want no app auth", err)
+	}
+	auth := &AppAuth{}
+	if err := auth.VerifyInstallationForOrg(context.Background(), 1, "myorg"); err == nil || !strings.Contains(err.Error(), "private key") {
+		t.Fatalf("missing key error = %v, want private key", err)
+	}
+	auth = newVerifyTestAppAuth(t, 1234, 0, "https://api.github.com")
+	if err := auth.VerifyInstallationForOrg(context.Background(), 1, " "); err == nil || !strings.Contains(err.Error(), "target org") {
+		t.Fatalf("empty org error = %v, want target org", err)
+	}
+}
+
+func TestVerifyInstallationForOrgRejectsMissingInstallation(t *testing.T) {
+	api := httptest.NewServer(http.NotFoundHandler())
+	defer api.Close()
+
+	auth := newVerifyTestAppAuth(t, 1234, 0, api.URL)
+	err := auth.VerifyInstallationForOrg(context.Background(), 9999, "myorg")
+	if err == nil || !strings.Contains(err.Error(), "getting app installation 9999") {
+		t.Fatalf("missing installation error = %v, want lookup error", err)
+	}
+}
+
+func newVerifyTestAppAuth(t *testing.T, appID, installationID int64, apiURL string) *AppAuth {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating RSA key: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "gh-app-key.pem")
+	f, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		t.Fatalf("creating key: %v", err)
+	}
+	if err := pem.Encode(f, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
+		_ = f.Close()
+		t.Fatalf("writing key: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("closing key: %v", err)
+	}
+	auth, err := NewAppAuth(appID, installationID, keyPath, slog.New(slog.NewTextHandler(os.Stderr, nil)), apiURL)
+	if err != nil {
+		t.Fatalf("NewAppAuth: %v", err)
+	}
+	return auth
+}


### PR DESCRIPTION
## Summary
- add public GET /gh-setup for GitHub App Setup URL redirects
- verify claimed installation IDs with an App JWT and org match before persisting
- persist through the existing /api/config/github code path so save, reinit, audit, refresh all stay shared
- show dashboard toasts for setup success/request/error and document Setup URL configuration

## Security model
The callback can be unauthenticated because GitHub may redirect a fresh browser. The server does not trust the query string: it mints an App JWT from the spoke's configured app_id/key and calls GET /app/installations/{installation_id}, accepting only installations owned by the configured hive org. A configured hive will not switch to a different installation unless the requester has an authenticated admin/write session; same-ID update redirects are allowed.

## Validation
- go build ./...
- go vet ./...
- go test ./pkg/dashboard/ ./pkg/github/ -count=1