### PR TITLE
✨ feat(github): auto-discover the GitHub App installation ID

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -552,12 +552,10 @@ func initGitHubAuth(ctx context.Context, cfg *config.Config, logger *slog.Logger
 	var out githubAuth
 	appKeyFile := resolveAppKeyFile(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), cfg.GitHub.AppID)
 
-	// HasUsableApp() rejects config.PlaceholderAppID. A placeholder paired with
-	// a real installation_id — exactly what happens the instant an owner
-	// installs the App on a pre-provisioned hive — used to satisfy a bare
-	// `AppID != 0` test and commit this process to App auth it could never
-	// perform.
-	if cfg.GitHub.HasUsableApp() {
+	// HasApp() rejects config.PlaceholderAppID. Build AppAuth as soon as a real
+	// app_id and key are present, even when installation_id is still empty: the
+	// App JWT is exactly what automatic installation-ID discovery needs.
+	if cfg.GitHub.HasApp() {
 		appAuth, err := github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, appKeyFile, logger, cfg.GitHub.ResolvedAPIURL())
 		if err != nil {
 			// A genuinely-configured App whose key is missing or malformed is a
@@ -585,6 +583,12 @@ func initGitHubAuth(ctx context.Context, cfg *config.Config, logger *slog.Logger
 
 	if out.AppAuth != nil {
 		logger.Info("using GitHub App authentication", "app_id", cfg.GitHub.AppID)
+		if cfg.GitHub.InstallationID == 0 {
+			out.Failure = "The GitHub App is configured but has no installation. Install the app on your org; this hive will discover the installation automatically."
+			out.State = github.AppStateNotInstalled
+			logger.Warn("GitHub App configured without installation_id — starting in dashboard-only mode while auto-discovery polls")
+			return out
+		}
 		// Correct a stale/wrong installation_id BEFORE building the client, so
 		// the very first token this process mints is scoped to the right org
 		// rather than 403ing on every write until the self-heal tick runs.
@@ -2098,6 +2102,33 @@ func main() {
 		}
 	}
 
+	// If the App credentials are present but github.installation_id is still
+	// empty, discover it automatically. This covers the delayed approval path:
+	// a non-admin requests installation, an org admin approves later, and the
+	// spoke adopts the installation ID without requiring anyone to paste it.
+	{
+		const githubAppDiscoveryInterval = 5 * time.Minute
+		tryDiscover := func() {
+			if cfg.GitHub.InstallationID != 0 {
+				return
+			}
+			_, _ = dashSrv.AutoDiscoverGitHubInstallationID(ctx, false)
+		}
+		go func() {
+			tryDiscover()
+			ticker := time.NewTicker(githubAppDiscoveryInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					tryDiscover()
+				}
+			}
+		}()
+	}
+
 	// Self-heal the "GitHub App not installed" banner. This handles:
 	// 1. GitHub App credentials arrived after startup (via heartbeat/webhook)
 	// 2. ReinitGitHubFunc succeeded but cleared githubAppRequired before
@@ -2138,6 +2169,7 @@ func main() {
 						if !dashSrv.IsGitHubAppRequired() {
 							continue
 						}
+						_, _ = dashSrv.AutoDiscoverGitHubInstallationID(ctx, false)
 						// Re-run the same read+write verification the manual
 						// Re-check button uses. It clears the flag on success
 						// (installed AND write-verified) and leaves it set on a

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -5120,6 +5120,9 @@ func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.githubConfigMu.Lock()
+	defer s.githubConfigMu.Unlock()
+
 	cfg := s.deps.Config
 
 	// saveConfig() silently no-ops when the config has no source path, so
@@ -5160,10 +5163,38 @@ func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
 		cfg.GitHub.InstallationID = *body.InstallationID
 	}
 
-	if err := s.saveConfig(); err != nil {
+	result, err := s.finishGitHubConfigUpdateLocked(requestAuditUser(r), "")
+	if err != nil {
+		if strings.Contains(err.Error(), "source path") {
+			s.logger.Error("github config update rejected: config has no source path, save would be an in-memory no-op")
+			jsonError(w, "config not persisted: config has no source path, so the change would be lost on restart", http.StatusInternalServerError)
+			return
+		}
 		s.logger.Error("failed to persist github config", "error", err)
 		jsonError(w, "failed to save config", http.StatusInternalServerError)
 		return
+	}
+	jsonResponse(w, result)
+}
+
+func requestAuditUser(r *http.Request) string {
+	user := r.Header.Get("X-Hive-User")
+	if user == "" {
+		return "local"
+	}
+	return user
+}
+
+// finishGitHubConfigUpdateLocked is the shared tail of the manual
+// PUT /api/config/github flow and automatic installation-ID discovery. The
+// caller must hold githubConfigMu and must have already mutated s.deps.Config.
+func (s *Server) finishGitHubConfigUpdateLocked(auditUser, detail string) (map[string]interface{}, error) {
+	cfg := s.deps.Config
+	if cfg.SourcePath == "" {
+		return nil, fmt.Errorf("config has no source path")
+	}
+	if err := s.saveConfig(); err != nil {
+		return nil, err
 	}
 
 	result := map[string]interface{}{
@@ -5201,9 +5232,68 @@ func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	s.auditFromRequest(r, "config_github", "", "")
+	s.AuditLog(auditUser, "config_github", detail, "")
 	s.refreshAndPersist()
-	jsonResponse(w, result)
+	return result, nil
+}
+
+// AutoDiscoverGitHubInstallationID tries to fill an empty github.installation_id
+// from the App-level GitHub API, then persists and reinitializes through the
+// same path used by PUT /api/config/github. All failures are soft; callers keep
+// showing the manual installation-ID flow.
+func (s *Server) AutoDiscoverGitHubInstallationID(ctx context.Context, force bool) (int64, error) {
+	if s == nil || s.deps == nil || s.deps.Config == nil || s.deps.GHAppAuth == nil || !s.deps.GHAppAuth.HasKey() {
+		return 0, nil
+	}
+	cfg := s.deps.Config
+	if cfg.GitHub.InstallationID != 0 {
+		return 0, nil
+	}
+	org := strings.TrimSpace(cfg.Project.Org)
+	if org == "" {
+		return 0, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if force {
+		s.deps.GHAppAuth.ForgetInstallationDiscovery(org)
+	}
+
+	id, err := s.deps.GHAppAuth.DiscoverInstallationID(ctx, org)
+	if err != nil {
+		s.logger.Warn("github app installation auto-discovery failed; manual installation ID entry remains available",
+			"org", org, "error", err)
+		return 0, err
+	}
+	if id == 0 {
+		return 0, nil
+	}
+
+	s.githubConfigMu.Lock()
+	defer s.githubConfigMu.Unlock()
+	if cfg.GitHub.InstallationID != 0 {
+		return 0, nil
+	}
+	cfg.GitHub.InstallationID = id
+	result, err := s.finishGitHubConfigUpdateLocked("system",
+		auditDetail("source", "auto_discovery", "org", org, "installation_id", strconv.FormatInt(id, 10)))
+	if err != nil {
+		cfg.GitHub.InstallationID = 0
+		s.logger.Warn("github app installation auto-discovered but could not be persisted; manual installation ID entry remains available",
+			"org", org, "installation_id", id, "error", err)
+		return 0, err
+	}
+	if result["reinit"] == "failed" {
+		cfg.GitHub.InstallationID = 0
+		if saveErr := s.saveConfig(); saveErr != nil {
+			s.logger.Warn("github app installation auto-discovery reinit failed and rollback could not be persisted",
+				"org", org, "installation_id", id, "reinit_error", result["reinit_error"], "rollback_error", saveErr)
+		}
+		return 0, fmt.Errorf("reinitializing github client after auto-discovery: %v", result["reinit_error"])
+	}
+	s.logger.Info("github app installation auto-discovered", "org", org, "installation_id", id)
+	return id, nil
 }
 
 // --- Sidebar endpoints ---

--- a/v2/pkg/dashboard/api_config_github_test.go
+++ b/v2/pkg/dashboard/api_config_github_test.go
@@ -5,11 +5,20 @@ package dashboard
 // hub-delivered to the per-app-id path with key_file deliberately left empty.
 
 import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
 )
 
 // Live values from the spoke the bug was observed on (hosted-available-
@@ -145,5 +154,75 @@ func TestConfigGitHub_UnpersistableSaveIsAnError(t *testing.T) {
 	}
 	if reinitCalls != 0 {
 		t.Fatalf("reinit attempted despite refused save: %d calls", reinitCalls)
+	}
+}
+
+func TestAutoDiscoverGitHubInstallationIDPersistsLikeManualSetID(t *testing.T) {
+	ghpkg.ResetInstallationDiscoveryCache()
+	s, deps := apiServer(t)
+	deps.Config.SourcePath = filepath.Join(t.TempDir(), "hive.yaml")
+	deps.Config.Project.Org = "open-source"
+	deps.Config.GitHub.AppID = testHubDeliveredAppID
+	deps.Config.GitHub.InstallationID = 0
+	deps.Config.GitHub.KeyFile = ""
+
+	keyFile := filepath.Join(t.TempDir(), "gh-app-key.pem")
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	if err := os.WriteFile(keyFile, keyPEM, 0o600); err != nil {
+		t.Fatalf("writing key: %v", err)
+	}
+
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/app/installations" && r.URL.Path != "/orgs/open-source/installation" {
+			t.Fatalf("unexpected discovery path %s", r.URL.Path)
+		}
+		if r.URL.Path == "/orgs/open-source/installation" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"id": testHubDeliveredInstallationID, "account": map[string]any{"login": "open-source"}},
+		})
+	}))
+	defer api.Close()
+
+	auth, err := ghpkg.NewAppAuth(testHubDeliveredAppID, 0, keyFile, deps.Logger, api.URL)
+	if err != nil {
+		t.Fatalf("NewAppAuth: %v", err)
+	}
+	deps.GHAppAuth = auth
+	deps.ResolveAppKeyFileFunc = func(configured string, appID int64) string {
+		return keyFile
+	}
+	var gotAppID, gotInstallationID int64
+	var gotKeyFile string
+	reinitCalls := 0
+	deps.ReinitGitHubFunc = func(appID, installationID int64, keyFile string) error {
+		reinitCalls++
+		gotAppID, gotInstallationID, gotKeyFile = appID, installationID, keyFile
+		return nil
+	}
+
+	id, err := s.AutoDiscoverGitHubInstallationID(context.Background(), false)
+	if err != nil {
+		t.Fatalf("AutoDiscoverGitHubInstallationID: %v", err)
+	}
+	if id != testHubDeliveredInstallationID {
+		t.Fatalf("id = %d, want %d", id, testHubDeliveredInstallationID)
+	}
+	if deps.Config.GitHub.InstallationID != testHubDeliveredInstallationID {
+		t.Fatalf("config installation_id = %d, want %d", deps.Config.GitHub.InstallationID, testHubDeliveredInstallationID)
+	}
+	if reinitCalls != 1 {
+		t.Fatalf("ReinitGitHubFunc calls = %d, want 1", reinitCalls)
+	}
+	if gotAppID != testHubDeliveredAppID || gotInstallationID != testHubDeliveredInstallationID || gotKeyFile != keyFile {
+		t.Fatalf("reinit args = (%d, %d, %q), want (%d, %d, %q)",
+			gotAppID, gotInstallationID, gotKeyFile, testHubDeliveredAppID, testHubDeliveredInstallationID, keyFile)
 	}
 }

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -188,6 +188,7 @@ type Server struct {
 	readyAt time.Time
 
 	githubAppMu         sync.RWMutex
+	githubConfigMu      sync.Mutex
 	githubAppRequired   bool
 	githubAppInstallURL string
 	githubAppPermIssue  string // non-empty when app is installed but lacks required permissions
@@ -1362,6 +1363,11 @@ func (s *Server) handleGitHubAppRecheck(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "recheck not configured", http.StatusNotImplemented)
 		return
 	}
+	ctx := r.Context()
+	if s.deps != nil && s.deps.Ctx != nil {
+		ctx = s.deps.Ctx
+	}
+	_, _ = s.AutoDiscoverGitHubInstallationID(ctx, true)
 	ok := s.RecheckGitHubApp()
 	w.Header().Set("Content-Type", "application/json")
 	if ok {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2789,7 +2789,7 @@
     <span style="font-size:1.5rem">&#9888;&#65039;</span>
     <div style="flex:1">
       <div class="gh-app-title">GitHub App Not Installed</div>
-      <div class="gh-app-desc">This hive cannot create issues or advisory reports. Install the Hive Hub GitHub App on your repository to enable full functionality.</div>
+      <div class="gh-app-desc">This hive cannot create issues or advisory reports. Install the Hive Hub GitHub App on your repository; this hive checks every few minutes and will configure itself, or you can paste the Installation ID below.</div>
     </div>
     <!-- autocomplete=off + name-less: Firefox form history would otherwise
          offer/refill a stored value and, on Linux, could clear the field on a
@@ -5951,8 +5951,8 @@
           var isGHE = data.githubBaseURL && data.githubBaseURL !== 'https://github.com';
           if (title) title.textContent = isGHE ? 'GitHub App Not Installed on ' + data.githubBaseURL.replace('https://', '') : 'GitHub App Not Installed';
           if (desc) desc.textContent = isGHE
-            ? 'This hive cannot post advisory reports. Install the GitHub App on your GHE org to enable full functionality.'
-            : 'This hive cannot create issues or advisory reports. Install the Hive Hub GitHub App on your repository to enable full functionality.';
+            ? 'This hive cannot post advisory reports. Install the GitHub App on your GHE org; this hive checks every few minutes and will configure itself, or you can paste the Installation ID below.'
+            : 'This hive cannot create issues or advisory reports. Install the Hive Hub GitHub App on your repository; this hive checks every few minutes and will configure itself, or you can paste the Installation ID below.';
           /* A GitHub Enterprise host whose App slug was never configured yields
              an EMPTY install URL from the server, deliberately: the public
              "kubestellar-hive" slug names no App on an enterprise host, so a

--- a/v2/pkg/github/app_discovery.go
+++ b/v2/pkg/github/app_discovery.go
@@ -19,9 +19,9 @@ const (
 	// heartbeat cadence while the App banner is showing), but the self-heal
 	// tick would otherwise re-discover on EVERY beat for a hive whose App is
 	// genuinely not installed on the org — burning App-JWT rate limit forever.
-	// One hour is far shorter than any realistic "admin installs the App"
-	// turnaround and far longer than the heartbeat.
-	InstallationDiscoveryTTL = 1 * time.Hour
+	// Five minutes matches the spoke's slow auto-discovery poll, so delayed org
+	// admin approval is picked up promptly without hammering the App API.
+	InstallationDiscoveryTTL = 5 * time.Minute
 
 	// discoveryListPerPage is the page size used when falling back to
 	// GET /app/installations. GitHub caps per_page at 100.
@@ -63,6 +63,19 @@ func ResetInstallationDiscoveryCache() {
 	discoveryCacheMu.Lock()
 	defer discoveryCacheMu.Unlock()
 	discoveryCache = map[string]discoveryCacheEntry{}
+}
+
+// ForgetInstallationDiscovery removes this App/org discovery result from the
+// cache. Use it for explicit operator-driven checks so a recent negative poll
+// cannot mask an installation an org admin just approved.
+func (a *AppAuth) ForgetInstallationDiscovery(org string) {
+	if a == nil {
+		return
+	}
+	key := discoveryCacheKey(a.apiURL, a.appID, org)
+	discoveryCacheMu.Lock()
+	defer discoveryCacheMu.Unlock()
+	delete(discoveryCache, key)
 }
 
 // ErrNoInstallationForOrg means the App JWT authenticated fine but no
@@ -155,6 +168,8 @@ func (a *AppAuth) discoverInstallationUncached(ctx context.Context, org string) 
 		directErr = fmt.Errorf("direct org lookup: not found")
 	}
 
+	var matchedID int64
+	matches := 0
 	opts := &gh.ListOptions{PerPage: discoveryListPerPage}
 	for page := 0; page < discoveryMaxPages; page++ {
 		installs, listResp, listErr := jwtClient.Apps.ListInstallations(ctx, opts)
@@ -167,7 +182,8 @@ func (a *AppAuth) discoverInstallationUncached(ctx context.Context, org string) 
 			}
 			if strings.EqualFold(in.GetAccount().GetLogin(), org) {
 				if id := in.GetID(); id != 0 {
-					return id, nil
+					matchedID = id
+					matches++
 				}
 			}
 		}
@@ -175,6 +191,12 @@ func (a *AppAuth) discoverInstallationUncached(ctx context.Context, org string) 
 			break
 		}
 		opts.Page = listResp.NextPage
+	}
+	if matches == 1 {
+		return matchedID, nil
+	}
+	if matches > 1 {
+		return 0, fmt.Errorf("%w: app %d has %d installations for %q", ErrNoInstallationForOrg, a.appID, matches, org)
 	}
 
 	return 0, fmt.Errorf("%w: app %d has no installation for %q (direct lookup: %v)", ErrNoInstallationForOrg, a.appID, org, directErr)

--- a/v2/pkg/github/app_discovery_test.go
+++ b/v2/pkg/github/app_discovery_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -37,6 +38,7 @@ type discoveryServerOpts struct {
 	orgInstall     map[string]int64
 	orgInstallCode int // status for a miss; 0 => 404
 	listInstalls   []map[string]any
+	listPages      [][]map[string]any
 	listStatus     int // non-zero => fail the listing with this status
 	// getInstallation answers GET /app/installations/{id} (VerifyInstallation).
 	getInstallation map[string]any
@@ -74,6 +76,24 @@ func newDiscoveryServer(t *testing.T, opts discoveryServerOpts, hits *int64) *ht
 			}
 			w.Header().Set("Content-Type", "application/json")
 			list := opts.listInstalls
+			if len(opts.listPages) > 0 {
+				page := 1
+				if got := r.URL.Query().Get("page"); got != "" {
+					fmt.Sscanf(got, "%d", &page)
+				}
+				if page < 1 || page > len(opts.listPages) {
+					list = []map[string]any{}
+				} else {
+					list = opts.listPages[page-1]
+					if page < len(opts.listPages) {
+						next := *r.URL
+						q := next.Query()
+						q.Set("page", fmt.Sprintf("%d", page+1))
+						next.RawQuery = q.Encode()
+						w.Header().Set("Link", `<http://`+r.Host+next.String()+`>; rel="next"`)
+					}
+				}
+			}
 			if list == nil {
 				list = []map[string]any{}
 			}
@@ -138,6 +158,17 @@ func TestDiscoverInstallationID(t *testing.T) {
 			wantID: 77777,
 		},
 		{
+			name: "listing match can be on a later page",
+			opts: discoveryServerOpts{
+				listPages: [][]map[string]any{
+					{installEntry(11111, "someone-else")},
+					{installEntry(22222, "open-source")},
+				},
+			},
+			org:    "open-source",
+			wantID: 22222,
+		},
+		{
 			name: "falls back to listing when direct lookup 405s (old GHE)",
 			opts: discoveryServerOpts{
 				orgInstallCode: http.StatusMethodNotAllowed,
@@ -168,6 +199,18 @@ func TestDiscoverInstallationID(t *testing.T) {
 			wantNoInstall: true,
 		},
 		{
+			name: "multiple matching installations are ambiguous",
+			opts: discoveryServerOpts{
+				listInstalls: []map[string]any{
+					installEntry(10, "open-source"),
+					installEntry(11, "Open-Source"),
+				},
+			},
+			org:           "open-source",
+			wantErr:       true,
+			wantNoInstall: true,
+		},
+		{
 			name: "nil entries in the listing are skipped, not dereferenced",
 			opts: discoveryServerOpts{
 				listInstalls: []map[string]any{
@@ -187,6 +230,16 @@ func TestDiscoverInstallationID(t *testing.T) {
 			wantErr: true,
 			// A 500 is transient — it must NOT be reported as
 			// authoritative "not installed".
+			wantNoInstall: false,
+		},
+		{
+			name: "unauthorized listing is a soft discovery error",
+			opts: discoveryServerOpts{
+				orgInstallCode: http.StatusUnauthorized,
+				listStatus:     http.StatusUnauthorized,
+			},
+			org:           "open-source",
+			wantErr:       true,
 			wantNoInstall: false,
 		},
 	}


### PR DESCRIPTION
## Summary
- discover missing GitHub App installation IDs from the App installations API using existing App credentials
- persist discovered IDs through the same config path as manual Save Installation ID, including live client reinit and audit logging
- retry on startup, every 5 minutes while unconfigured, and on Re-check; update banner copy to explain automatic discovery

## Validation
- cd v2 && go test ./pkg/github/ ./pkg/dashboard/ -count=1
- cd v2 && go build ./... && go vet ./...