### PR TITLE
🐛 Fix tmux launch for agents without passwd entries

### DIFF
--- a/v2/deploy/ttyd-tmux.sh
+++ b/v2/deploy/ttyd-tmux.sh
@@ -29,16 +29,20 @@ if [ ! -S "$TMUX_SOCKET" ]; then
   exit 1
 fi
 
-# Derive the socket owner so we can su-exec as them (tmux requires it).
-SOCK_OWNER=$(stat -c '%U' "$TMUX_SOCKET" 2>/dev/null || echo "")
-CURRENT_USER=$(id -un)
+# Derive the socket owner so we can su-exec as them (tmux requires it). Use the
+# numeric uid:gid from stat so dynamically added agents do not require a passwd
+# entry in this already-running container.
+SOCK_OWNER_UID=$(stat -c '%u' "$TMUX_SOCKET" 2>/dev/null || echo "")
+SOCK_OWNER_GID=$(stat -c '%g' "$TMUX_SOCKET" 2>/dev/null || echo "")
+SOCK_OWNER_SPEC="${SOCK_OWNER_UID}:${SOCK_OWNER_GID}"
+CURRENT_UID=$(id -u)
 
-if [ -n "$SOCK_OWNER" ] && [ "$SOCK_OWNER" != "$CURRENT_USER" ] && command -v su-exec >/dev/null 2>&1; then
-  PREV_MOUSE=$(su-exec "$SOCK_OWNER" tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")
-  su-exec "$SOCK_OWNER" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse off 2>/dev/null || true
+if [ -n "$SOCK_OWNER_UID" ] && [ "$SOCK_OWNER_UID" != "$CURRENT_UID" ] && command -v su-exec >/dev/null 2>&1; then
+  PREV_MOUSE=$(su-exec "$SOCK_OWNER_SPEC" tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")
+  su-exec "$SOCK_OWNER_SPEC" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse off 2>/dev/null || true
   EXIT_CODE=0
-  su-exec "$SOCK_OWNER" tmux -S "$TMUX_SOCKET" attach-session -t "$SESSION" || EXIT_CODE=$?
-  su-exec "$SOCK_OWNER" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse "$PREV_MOUSE" 2>/dev/null || true
+  su-exec "$SOCK_OWNER_SPEC" tmux -S "$TMUX_SOCKET" attach-session -t "$SESSION" || EXIT_CODE=$?
+  su-exec "$SOCK_OWNER_SPEC" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse "$PREV_MOUSE" 2>/dev/null || true
   exit $EXIT_CODE
 else
   PREV_MOUSE=$(tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")

--- a/v2/pkg/agent/branches_coverage_test.go
+++ b/v2/pkg/agent/branches_coverage_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -150,15 +152,52 @@ func TestTmuxCmd_SocketBranch(t *testing.T) {
 }
 
 func TestTmuxCmd_SuExecBranch(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{"a": {Backend: "claude"}}, discardLogger(), ProjectContext{})
+	agentName := "definitely-missing-agent-user"
+	m := NewManager(map[string]config.AgentConfig{agentName: {Backend: "claude"}}, discardLogger(), ProjectContext{})
 	m.mu.RLock()
-	agent := m.agents["a"]
+	agent := m.agents[agentName]
 	m.mu.RUnlock()
 	agent.UID = 2001
-	agent.tmuxSocket = "hive-a"
+	agent.tmuxSocket = "hive-" + agentName
 	cmd := m.tmuxCmd(agent, "has-session")
 	if cmd.Args[0] != "su-exec" {
 		t.Errorf("UID>0 tmux cmd should run via su-exec, got %q", cmd.Args[0])
+	}
+	wantUserSpec := "2001:" + strconv.Itoa(os.Getgid())
+	if cmd.Args[1] != wantUserSpec {
+		t.Errorf("UID>0 tmux cmd should fall back to numeric uid:gid %q, got %q", wantUserSpec, cmd.Args[1])
+	}
+}
+
+func TestEnsureTmuxSession_IncludesStderr(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "su-exec")
+	script := `#!/bin/sh
+case "$*" in
+  *has-session*) exit 1 ;;
+  *new-session*) echo "su-exec: getpwnam(hive-architect): Success" >&2; exit 1 ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("HIVE_WORK_DIR", filepath.Join(dir, "agents"))
+
+	m := NewManager(map[string]config.AgentConfig{"architect": {Backend: "claude"}}, discardLogger(), ProjectContext{})
+	m.mu.Lock()
+	agent := m.agents["architect"]
+	agent.UID = 2006
+	agent.tmuxSocket = "hive-architect"
+	agent.tmuxSession = "hive-architect"
+	err := m.ensureTmuxSession(agent)
+	m.mu.Unlock()
+	if err == nil {
+		t.Fatal("ensureTmuxSession returned nil, want tmux creation error")
+	}
+	if got := err.Error(); !strings.Contains(got, "getpwnam") {
+		t.Fatalf("ensureTmuxSession error %q does not include tmux stderr", got)
 	}
 }
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -674,12 +675,30 @@ func (m *Manager) tmuxBaseArgs(agent *AgentProcess) []string {
 	return []string{"tmux"}
 }
 
+func (m *Manager) agentExecUserSpec(agent *AgentProcess) string {
+	if agent.UID <= 0 {
+		return ""
+	}
+	agentUser := fmt.Sprintf("hive-%s", agent.Name)
+	if _, err := user.Lookup(agentUser); err == nil {
+		return agentUser
+	}
+	return fmt.Sprintf("%d:%d", agent.UID, os.Getgid())
+}
+
+func outputErr(prefix string, err error, output []byte) error {
+	msg := strings.TrimSpace(string(output))
+	if msg == "" {
+		return fmt.Errorf("%s: %w", prefix, err)
+	}
+	return fmt.Errorf("%s: %w: %s", prefix, err, msg)
+}
+
 func (m *Manager) tmuxCmd(agent *AgentProcess, args ...string) *exec.Cmd {
 	base := m.tmuxBaseArgs(agent)
 	tmuxArgs := append(base[1:], args...)
 	if agent.UID > 0 {
-		agentUser := fmt.Sprintf("hive-%s", agent.Name)
-		suExecArgs := append([]string{agentUser, base[0]}, tmuxArgs...)
+		suExecArgs := append([]string{m.agentExecUserSpec(agent), base[0]}, tmuxArgs...)
 		return exec.Command("su-exec", suExecArgs...)
 	}
 	return exec.Command(base[0], tmuxArgs...)
@@ -697,15 +716,14 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 
 	var cmd *exec.Cmd
 	if agent.UID > 0 {
-		agentUser := fmt.Sprintf("hive-%s", agent.Name)
-		suExecArgs := []string{"su-exec", agentUser}
+		suExecArgs := []string{"su-exec", m.agentExecUserSpec(agent)}
 		tmuxArgs := append(m.tmuxBaseArgs(agent), "new-session", "-d", "-s", agent.tmuxSession, "-c", agentDir)
 		cmd = exec.Command(suExecArgs[0], append(suExecArgs[1:], tmuxArgs...)...)
 	} else {
 		cmd = exec.Command("tmux", "new-session", "-d", "-s", agent.tmuxSession, "-c", agentDir)
 	}
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("creating tmux session for %s: %w", agent.Name, err)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return outputErr(fmt.Sprintf("creating tmux session for %s", agent.Name), err, output)
 	}
 
 	// tmux creates /tmp/tmux-{uid}/ with mode 700; ttyd runs as dev (uid 1001,
@@ -714,8 +732,7 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 	// agent user who owns the directory. Use su-exec to chmod as the agent.
 	if agent.UID > 0 {
 		tmuxDir := fmt.Sprintf("/tmp/tmux-%d", agent.UID)
-		agentUser := fmt.Sprintf("hive-%s", agent.Name)
-		_ = exec.Command("su-exec", agentUser, "chmod", "710", tmuxDir).Run()
+		_ = exec.Command("su-exec", m.agentExecUserSpec(agent), "chmod", "710", tmuxDir).Run()
 	}
 
 	// Pre-create the agent-owned CODEX_HOME before launch (codex won't create
@@ -4301,7 +4318,7 @@ func (m *Manager) setupCodexHome(agent *AgentProcess) {
 		return
 	}
 	dir := codexHomePath(agent.Name)
-	agentUser := fmt.Sprintf("hive-%s", agent.Name)
+	agentUser := m.agentExecUserSpec(agent)
 	if err := exec.Command("su-exec", agentUser, "mkdir", "-p", dir).Run(); err != nil {
 		m.logger.Warn("failed to pre-create codex home", "agent", agent.Name, "dir", dir, "error", err)
 	}


### PR DESCRIPTION
## Summary
- Restore tmux launches when UID-isolated agents do not have hive-<agent> passwd entries in an already-running spoke.
- Include tmux/su-exec stderr in session creation errors instead of returning only exit status 1.
- Make ttyd attach by numeric socket owner so terminals work for numeric-only agent UIDs.

## Live diagnosis and restore
On hive hosted-projectbluefin-common-nmq5 (namespace hive-hosted-hosted-projectbluefin-knuckle-gjvq), uid-map.json only contained ci-maintainer, quality, scanner, sec-check, and supervisor. Architect and strategist were allocated UIDs 2006/2007 in memory, but /etc/passwd had no hive-architect or hive-strategist entries. Reproducing the manager command showed: su-exec: getpwnam(hive-architect): Success (rc=1), and same for strategist. I added the missing passwd entries, added architect/strategist to /var/run/hive/uid-map.json, chowned their agent dirs to 2006/2007, and restarted both via the dashboard API with DASHBOARD_AUTH_TOKEN. Logs then showed tmux session created and audit: agent started/restarted for both agents.

## Validation
- cd v2 && go build ./...
- cd v2 && go vet ./...
- cd v2 && go test ./pkg/agent/ -count=1