### PR TITLE
✨ feat(hub): route GitHub App setup-URL redirects to the owning spoke

### DIFF
--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -79,10 +79,43 @@ func NewAppAuthWithCache(appID, installationID int64, keyFile, cachePath string,
 	if err != nil {
 		return nil, fmt.Errorf("reading app key %s: %w", keyFile, err)
 	}
+	key, err := parseAppPrivateKey(keyData)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", keyFile, err)
+	}
 
+	return &AppAuth{
+		appID:          appID,
+		installationID: installationID,
+		key:            key,
+		logger:         logger,
+		cachePath:      cachePath,
+		apiURL:         apiURL,
+	}, nil
+}
+
+// NewAppAuthFromPEM constructs App authentication from an in-memory PEM private
+// key. It is for hub-side flows that already hold the fleet App key in memory
+// and must not write it to a temporary file just to authenticate as the App.
+func NewAppAuthFromPEM(appID, installationID int64, privateKeyPEM string, logger *slog.Logger, apiURL string) (*AppAuth, error) {
+	key, err := parseAppPrivateKey([]byte(privateKeyPEM))
+	if err != nil {
+		return nil, err
+	}
+	return &AppAuth{
+		appID:          appID,
+		installationID: installationID,
+		key:            key,
+		logger:         logger,
+		cachePath:      TokenCachePath,
+		apiURL:         apiURL,
+	}, nil
+}
+
+func parseAppPrivateKey(keyData []byte) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode(keyData)
 	if block == nil {
-		return nil, fmt.Errorf("no PEM block found in %s", keyFile)
+		return nil, fmt.Errorf("no PEM block found")
 	}
 
 	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
@@ -97,15 +130,7 @@ func NewAppAuthWithCache(appID, installationID int64, keyFile, cachePath string,
 			return nil, fmt.Errorf("PKCS8 key is not RSA")
 		}
 	}
-
-	return &AppAuth{
-		appID:          appID,
-		installationID: installationID,
-		key:            key,
-		logger:         logger,
-		cachePath:      cachePath,
-		apiURL:         apiURL,
-	}, nil
+	return key, nil
 }
 
 // newJWTClient builds a go-github client authenticated with the App JWT for

--- a/v2/pkg/github/app_discovery.go
+++ b/v2/pkg/github/app_discovery.go
@@ -241,6 +241,41 @@ func (a *AppAuth) VerifyInstallationForOrg(ctx context.Context, installationID i
 	return nil
 }
 
+// InstallationAccountLogin returns the account login that owns installationID.
+// It authenticates as the App with a JWT and does not mint or persist an
+// installation token.
+func (a *AppAuth) InstallationAccountLogin(ctx context.Context, installationID int64) (string, error) {
+	if a == nil {
+		return "", fmt.Errorf("no app auth configured")
+	}
+	if a.key == nil {
+		return "", fmt.Errorf("app private key not loaded")
+	}
+	if installationID <= 0 {
+		return "", fmt.Errorf("installation ID must be positive")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, tokenMintTimeout)
+	defer cancel()
+
+	jwtToken, err := a.generateJWT()
+	if err != nil {
+		return "", fmt.Errorf("generating JWT: %w", err)
+	}
+	inst, _, err := a.newJWTClient(jwtToken).Apps.GetInstallation(ctx, installationID)
+	if err != nil {
+		return "", fmt.Errorf("getting app installation %d: %w", installationID, err)
+	}
+	if inst == nil || inst.GetID() != installationID {
+		return "", fmt.Errorf("%w: installation %d was not returned by GitHub", ErrNoInstallationForOrg, installationID)
+	}
+	login := strings.TrimSpace(inst.GetAccount().GetLogin())
+	if login == "" {
+		return "", fmt.Errorf("%w: installation %d has no account login", ErrNoInstallationForOrg, installationID)
+	}
+	return login, nil
+}
+
 // AppID returns the configured GitHub App ID.
 func (a *AppAuth) AppID() int64 { return a.appID }
 

--- a/v2/pkg/hub/gh_setup.go
+++ b/v2/pkg/hub/gh_setup.go
@@ -1,0 +1,142 @@
+package hub
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	ghauth "github.com/kubestellar/hive/v2/pkg/github"
+)
+
+const ghSetupPath = "/gh-setup"
+
+func (s *HubServer) handleGitHubAppSetupRouter(w http.ResponseWriter, r *http.Request) {
+	action := strings.TrimSpace(r.URL.Query().Get("setup_action"))
+	rawInstallationID := strings.TrimSpace(r.URL.Query().Get("installation_id"))
+	if rawInstallationID == "" {
+		s.renderGitHubSetupInfo(w, http.StatusOK, "Install requested", "Install requested/received. Your hive will configure itself automatically within a few minutes.")
+		return
+	}
+
+	installationID, err := strconv.ParseInt(rawInstallationID, 10, 64)
+	if err != nil || installationID <= 0 || strconv.FormatInt(installationID, 10) != rawInstallationID {
+		s.logger.Warn("rejected GitHub App setup callback with invalid installation_id")
+		s.renderGitHubSetupInfo(w, http.StatusBadRequest, "Invalid setup callback", "This GitHub App setup callback could not be routed. Please return to your hive and try the install link again.")
+		return
+	}
+
+	org, err := s.lookupGitHubInstallationAccount(r.Context(), installationID)
+	if err != nil {
+		s.logger.Warn("could not resolve GitHub App installation for setup callback", "installation_id", installationID, "setup_action", action, "error", err)
+		s.renderGitHubSetupInfo(w, http.StatusOK, "Install received", "Install requested/received. Your hive will configure itself automatically within a few minutes.")
+		return
+	}
+
+	matches := s.githubSetupMatches(org)
+	switch len(matches) {
+	case 0:
+		s.renderGitHubSetupInfo(w, http.StatusOK, "No matching hive yet", fmt.Sprintf("No hive registered for org %s — auto-discovery will configure the right hive within minutes once it registers.", org))
+	case 1:
+		target, ok := spokeGitHubSetupURL(matches[0], r.URL.RawQuery)
+		if !ok {
+			s.logger.Warn("matching hive has no routable dashboard URL for GitHub App setup", "hive", matches[0].ID, "org", org)
+			s.renderGitHubSetupInfo(w, http.StatusOK, "Install received", "Install requested/received. Your hive will configure itself automatically within a few minutes.")
+			return
+		}
+		http.Redirect(w, r, target, http.StatusFound)
+	default:
+		s.renderGitHubSetupChooser(w, matches, r.URL.RawQuery)
+	}
+}
+
+func (s *HubServer) lookupGitHubInstallationAccount(ctx context.Context, installationID int64) (string, error) {
+	if s.githubInstallationAccount != nil {
+		return s.githubInstallationAccount(ctx, installationID)
+	}
+	key := s.appKeysByAppID()[config.PublicGitHubAppID]
+	if key.PrivateKey == "" {
+		return "", fmt.Errorf("public GitHub App key is not available")
+	}
+	auth, err := ghauth.NewAppAuthFromPEM(config.PublicGitHubAppID, 0, key.PrivateKey, s.logger, "")
+	if err != nil {
+		return "", fmt.Errorf("loading public GitHub App key: %w", err)
+	}
+	return auth.InstallationAccountLogin(ctx, installationID)
+}
+
+func (s *HubServer) githubSetupMatches(org string) []RegistryEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var matches []RegistryEntry
+	for _, hive := range s.registry.Hives {
+		if !strings.EqualFold(strings.TrimSpace(hive.Org), strings.TrimSpace(org)) {
+			continue
+		}
+		if hive.GitHubAppID != 0 && hive.GitHubAppID != config.PublicGitHubAppID {
+			continue
+		}
+		if hive.GitHubHost != "" && !sameGitHubHost(hive.GitHubHost, publicGitHubHost) {
+			continue
+		}
+		if hive.GitHubBaseURL != "" && !sameGitHubHost(githubHostLabel(hive.GitHubBaseURL), publicGitHubHost) {
+			continue
+		}
+		matches = append(matches, hive)
+	}
+	return matches
+}
+
+func spokeGitHubSetupURL(hive RegistryEntry, rawQuery string) (string, bool) {
+	base := strings.TrimSpace(hive.DashboardURL)
+	if base == "" {
+		base = strings.TrimSpace(hive.SnapshotURL)
+	}
+	if base == "" {
+		return "", false
+	}
+	if !strings.Contains(base, "://") {
+		base = "https://" + base
+	}
+	u, err := url.Parse(base)
+	if err != nil || u.Host == "" {
+		return "", false
+	}
+	u.Path = ghSetupPath
+	u.RawPath = ""
+	u.RawQuery = rawQuery
+	u.Fragment = ""
+	return u.String(), true
+}
+
+func (s *HubServer) renderGitHubSetupInfo(w http.ResponseWriter, status int, title, message string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+	fmt.Fprintf(w, `<!doctype html><html><head><meta charset="utf-8"><title>%s</title><meta name="viewport" content="width=device-width,initial-scale=1"></head><body style="font-family:system-ui,sans-serif;max-width:720px;margin:3rem auto;padding:0 1rem;line-height:1.5"><h1>%s</h1><p>%s</p></body></html>`,
+		html.EscapeString(title), html.EscapeString(title), html.EscapeString(message))
+}
+
+func (s *HubServer) renderGitHubSetupChooser(w http.ResponseWriter, matches []RegistryEntry, rawQuery string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, `<!doctype html><html><head><meta charset="utf-8"><title>Choose hive</title><meta name="viewport" content="width=device-width,initial-scale=1"></head><body style="font-family:system-ui,sans-serif;max-width:720px;margin:3rem auto;padding:0 1rem;line-height:1.5"><h1>Choose a hive</h1><p>More than one registered hive matches this GitHub organization. Choose the hive to finish setup.</p><ul>`)
+	for _, hive := range matches {
+		target, ok := spokeGitHubSetupURL(hive, rawQuery)
+		if !ok {
+			continue
+		}
+		label := strings.TrimSpace(hive.ProjectName)
+		if label == "" {
+			label = strings.TrimSpace(hive.Name)
+		}
+		if label == "" {
+			label = strings.TrimSpace(hive.ID)
+		}
+		fmt.Fprintf(w, `<li><a href="%s">%s</a></li>`, html.EscapeString(target), html.EscapeString(label))
+	}
+	fmt.Fprint(w, `</ul></body></html>`)
+}

--- a/v2/pkg/hub/gh_setup_test.go
+++ b/v2/pkg/hub/gh_setup_test.go
@@ -1,0 +1,145 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newGitHubSetupTestServer(resolve func(context.Context, int64) (string, error), hives ...RegistryEntry) *HubServer {
+	return &HubServer{
+		mux:                       http.NewServeMux(),
+		logger:                    slog.Default(),
+		registry:                  Registry{Hives: hives},
+		githubInstallationAccount: resolve,
+	}
+}
+
+func TestGitHubAppSetupRouterRedirectsMatchingSpoke(t *testing.T) {
+	s := newGitHubSetupTestServer(func(_ context.Context, id int64) (string, error) {
+		if id != 12345 {
+			t.Fatalf("installation id = %d, want 12345", id)
+		}
+		return "AcmeOrg", nil
+	}, RegistryEntry{ID: "h1", Org: "acmeorg", DashboardURL: "https://spoke.example.com/dashboard"})
+
+	req := httptest.NewRequest("GET", "/gh-setup?installation_id=12345&setup_action=install&state=abc", nil)
+	w := httptest.NewRecorder()
+	s.handleGitHubAppSetupRouter(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusFound, w.Body.String())
+	}
+	want := "https://spoke.example.com/gh-setup?installation_id=12345&setup_action=install&state=abc"
+	if got := w.Header().Get("Location"); got != want {
+		t.Fatalf("Location = %q, want %q", got, want)
+	}
+}
+
+func TestGitHubAppSetupRouterSkipsEnterpriseHiveWithSameOrg(t *testing.T) {
+	s := newGitHubSetupTestServer(func(context.Context, int64) (string, error) {
+		return "acme", nil
+	},
+		RegistryEntry{ID: "ghe", Org: "acme", GitHubHost: "github.ibm.com", DashboardURL: "https://ghe.example.com"},
+		RegistryEntry{ID: "public", Org: "acme", GitHubHost: "github.com", DashboardURL: "https://public.example.com"},
+	)
+
+	req := httptest.NewRequest("GET", "/gh-setup?installation_id=55&setup_action=install", nil)
+	w := httptest.NewRecorder()
+	s.handleGitHubAppSetupRouter(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusFound, w.Body.String())
+	}
+	want := "https://public.example.com/gh-setup?installation_id=55&setup_action=install"
+	if got := w.Header().Get("Location"); got != want {
+		t.Fatalf("Location = %q, want %q", got, want)
+	}
+}
+
+func TestGitHubAppSetupRouterRequestRendersFriendlyPage(t *testing.T) {
+	s := newGitHubSetupTestServer(func(context.Context, int64) (string, error) {
+		t.Fatal("resolver should not be called for a pure request callback")
+		return "", nil
+	})
+
+	req := httptest.NewRequest("GET", "/gh-setup?setup_action=request", nil)
+	w := httptest.NewRecorder()
+	s.handleGitHubAppSetupRouter(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Install requested/received") {
+		t.Fatalf("friendly page missing expected text: %s", w.Body.String())
+	}
+}
+
+func TestGitHubAppSetupRouterUnknownOrgRendersNoMatch(t *testing.T) {
+	s := newGitHubSetupTestServer(func(context.Context, int64) (string, error) {
+		return "missing-org", nil
+	}, RegistryEntry{ID: "h1", Org: "other", DashboardURL: "https://spoke.example.com"})
+
+	req := httptest.NewRequest("GET", "/gh-setup?installation_id=99&setup_action=install", nil)
+	w := httptest.NewRecorder()
+	s.handleGitHubAppSetupRouter(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "No hive registered for org missing-org") {
+		t.Fatalf("no-match page missing expected text: %s", w.Body.String())
+	}
+}
+
+func TestGitHubAppSetupRouterRejectsNonNumericInstallationID(t *testing.T) {
+	called := false
+	s := newGitHubSetupTestServer(func(context.Context, int64) (string, error) {
+		called = true
+		return "", errors.New("unexpected")
+	})
+
+	req := httptest.NewRequest("GET", "/gh-setup?installation_id=abc&setup_action=install", nil)
+	w := httptest.NewRecorder()
+	s.handleGitHubAppSetupRouter(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	if called {
+		t.Fatal("resolver called for invalid installation id")
+	}
+}
+
+func TestGitHubAppSetupRouterMultipleMatchesRendersChooser(t *testing.T) {
+	s := newGitHubSetupTestServer(func(context.Context, int64) (string, error) {
+		return "acme", nil
+	},
+		RegistryEntry{ID: "h1", Name: "First hive", Org: "acme", DashboardURL: "https://one.example.com"},
+		RegistryEntry{ID: "h2", ProjectName: "Second project", Org: "ACME", DashboardURL: "two.example.com/root"},
+	)
+
+	req := httptest.NewRequest("GET", "/gh-setup?installation_id=7&setup_action=install", nil)
+	w := httptest.NewRecorder()
+	s.handleGitHubAppSetupRouter(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		"Choose a hive",
+		`https://one.example.com/gh-setup?installation_id=7&amp;setup_action=install`,
+		`https://two.example.com/gh-setup?installation_id=7&amp;setup_action=install`,
+		"First hive",
+		"Second project",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("chooser missing %q: %s", want, body)
+		}
+	}
+}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -872,6 +872,11 @@ type HubServer struct {
 	// which already probes those URLs. Carries its own leaf mutex and is never
 	// touched while s.mu is held — see url_reachability.go.
 	urlHealth *urlHealthState
+
+	// githubInstallationAccount resolves a GitHub App installation ID to its
+	// owning account login. Nil means use the fleet App key. Tests replace it
+	// with a fake API.
+	githubInstallationAccount func(context.Context, int64) (string, error)
 }
 
 // HubBannerEntry stores an admin banner targeted at a specific hive.
@@ -1030,6 +1035,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 	s.mux.HandleFunc("GET /api/contribute/status", s.handleContributeStatus)
 	s.mux.HandleFunc("GET /api/contribute/ws", s.handleContributeWSProxy)
 	s.mux.HandleFunc("POST /api/github/webhook", s.handleGitHubWebhook)
+	s.mux.HandleFunc("GET /gh-setup", s.handleGitHubAppSetupRouter)
 	s.mux.HandleFunc("GET /learn", s.serveStatic("static/learn.html"))
 	s.mux.HandleFunc("GET /get-started", s.serveStatic("static/get-started.html"))
 	s.mux.HandleFunc("GET /api/docs", s.serveStatic("static/api-docs.html"))


### PR DESCRIPTION
## Summary
- Add public hub `GET /gh-setup` for the shared kubestellar-hive GitHub App Setup URL.
- Resolve `installation_id` with the hub-held public App key via `GET /app/installations/{installation_id}`, match registered public-GitHub hives by org, and redirect to the owning spoke `/gh-setup` with query params preserved.
- Render friendly HTML fallbacks for request callbacks, invalid IDs, lookup failures, missing hives, and ambiguous matches.

## Context
Live hub testing showed `https://hive.kubestellar.io/gh-setup` returned 404 after PR #2798 added only the spoke callback. GitHub allows one fixed Setup URL for the shared App, so the hub now routes callbacks to the correct spoke while leaving verified persistence to the spoke.

## Validation
- `go build ./...`
- `go vet ./...`
- `go test ./pkg/hub/ -count=1`