### PR TITLE
✨ feat(outputschema): structured agent output contract with validated retries

### DIFF
--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -3,10 +3,12 @@ package governor
 import (
 	"fmt"
 	"log/slog"
+	"os"
 	"sync"
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/outputschema"
 )
 
 type Mode string
@@ -58,6 +60,17 @@ type RepoSnapshot struct {
 type KickRecord struct {
 	Timestamp time.Time `json:"timestamp"`
 	Agent     string    `json:"agent"`
+}
+
+type AgentReportRecord struct {
+	Timestamp time.Time `json:"timestamp"`
+	Agent     string    `json:"agent"`
+	Path      string    `json:"path"`
+	Valid     bool      `json:"valid"`
+	Lane      string    `json:"lane,omitempty"`
+	Kind      string    `json:"kind,omitempty"`
+	Summary   string    `json:"summary,omitempty"`
+	Error     string    `json:"error,omitempty"`
 }
 
 type BudgetInfo struct {
@@ -184,10 +197,11 @@ type Governor struct {
 	mu     sync.RWMutex
 	logger *slog.Logger
 
-	modeHistory []ModeChange
-	evalHistory []EvalSnapshot
-	kickHistory []KickRecord
-	budget      BudgetInfo
+	modeHistory  []ModeChange
+	evalHistory  []EvalSnapshot
+	kickHistory  []KickRecord
+	agentReports map[string]AgentReportRecord
+	budget       BudgetInfo
 
 	// resumeKicks records the last crash-recovery resume kick granted per
 	// agent (see AllowResumeKick). In-memory only: after a process restart
@@ -218,11 +232,12 @@ func New(cfg config.GovernorConfig, agents map[string]config.AgentConfig, logger
 			Cadences: make(map[string]AgentCadence),
 			LastKick: make(map[string]time.Time),
 		},
-		logger:      logger,
-		modeHistory: []ModeChange{initialChange},
-		evalHistory: make([]EvalSnapshot, 0, evalHistoryCapacity),
-		kickHistory: make([]KickRecord, 0, kickHistoryCapacity),
-		resumeKicks: make(map[string]time.Time),
+		logger:       logger,
+		modeHistory:  []ModeChange{initialChange},
+		evalHistory:  make([]EvalSnapshot, 0, evalHistoryCapacity),
+		kickHistory:  make([]KickRecord, 0, kickHistoryCapacity),
+		agentReports: make(map[string]AgentReportRecord),
+		resumeKicks:  make(map[string]time.Time),
 		budget: BudgetInfo{
 			ByAgent: make(map[string]int64),
 			ByModel: make(map[string]int64),
@@ -573,11 +588,69 @@ func (g *Governor) AllowResumeKick(agentName string) bool {
 }
 
 func (g *Governor) RecordKick(agentName string) {
+	report, hasReport := g.validateAgentReportIfPresent(agentName)
+
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	now := time.Now()
 	g.state.LastKick[agentName] = now
 	g.appendKickHistory(KickRecord{Timestamp: now, Agent: agentName})
+	if hasReport {
+		g.agentReports[agentName] = report
+	}
+}
+
+func (g *Governor) validateAgentReportIfPresent(agentName string) (AgentReportRecord, bool) {
+	path := outputschema.AgentReportPath(agentName)
+	raw, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return AgentReportRecord{}, false
+	}
+
+	record := AgentReportRecord{
+		Timestamp: time.Now(),
+		Agent:     agentName,
+		Path:      path,
+	}
+	if err != nil {
+		record.Error = err.Error()
+		if g.logger != nil {
+			g.logger.Warn("agent report could not be read", "agent", agentName, "path", path, "error", err)
+		}
+		return record, true
+	}
+
+	report, err := outputschema.Validate(raw)
+	if err != nil {
+		record.Error = err.Error()
+		if g.logger != nil {
+			g.logger.Warn("agent report validation failed",
+				"agent", agentName,
+				"path", path,
+				"error", err,
+				"corrective_prompt", outputschema.CorrectivePrompt(err),
+				"max_retries", outputschema.MaxValidationRetries,
+			)
+		}
+		return record, true
+	}
+
+	record.Valid = true
+	record.Lane = report.Lane
+	record.Kind = string(report.Kind)
+	record.Summary = report.Summary
+	if g.logger != nil {
+		g.logger.Info("agent report validated",
+			"agent", agentName,
+			"path", path,
+			"lane", report.Lane,
+			"kind", report.Kind,
+			"findings", len(report.Findings),
+			"prs_opened", len(report.PRsOpened),
+			"beads_filed", len(report.BeadsFiled),
+		)
+	}
+	return record, true
 }
 
 func (g *Governor) GetState() State {
@@ -773,6 +846,16 @@ func (g *Governor) KickHistory() []KickRecord {
 	defer g.mu.RUnlock()
 	result := make([]KickRecord, len(g.kickHistory))
 	copy(result, g.kickHistory)
+	return result
+}
+
+func (g *Governor) AgentReportRecords() map[string]AgentReportRecord {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	result := make(map[string]AgentReportRecord, len(g.agentReports))
+	for agent, record := range g.agentReports {
+		result[agent] = record
+	}
 	return result
 }
 

--- a/v2/pkg/outputschema/outputschema.go
+++ b/v2/pkg/outputschema/outputschema.go
@@ -1,0 +1,263 @@
+package outputschema
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"unicode"
+)
+
+const (
+	// MaxValidationRetries bounds corrective re-prompt attempts after invalid output.
+	MaxValidationRetries = 3
+
+	AgentReportDir        = "/var/run/hive-metrics"
+	AgentReportFilePrefix = "agent-report-"
+	AgentReportFileSuffix = ".json"
+
+	MaxLaneLength        = 64
+	MaxKindLength        = 64
+	MaxSummaryLength     = 2000
+	MaxFindings          = 100
+	MaxPRsOpened         = 50
+	MaxBeadsFiled        = 50
+	MaxTitleLength       = 200
+	MaxFindingBodyLength = 2000
+	MaxRepoLength        = 200
+	MaxURLLength         = 500
+	MaxBeadIDLength      = 120
+)
+
+type ReportKind string
+
+const (
+	KindFindings ReportKind = "findings"
+	KindFix      ReportKind = "fix"
+	KindReview   ReportKind = "review"
+	KindAdvisory ReportKind = "advisory"
+	KindSummary  ReportKind = "summary"
+)
+
+type Severity string
+
+const (
+	SeverityInfo     Severity = "info"
+	SeverityLow      Severity = "low"
+	SeverityMedium   Severity = "medium"
+	SeverityHigh     Severity = "high"
+	SeverityCritical Severity = "critical"
+)
+
+type BeadType string
+
+const (
+	BeadTypeTask     BeadType = "task"
+	BeadTypeBug      BeadType = "bug"
+	BeadTypeAdvisory BeadType = "advisory"
+	BeadTypeFeature  BeadType = "feature"
+)
+
+type AgentReport struct {
+	Lane       string      `json:"lane"`
+	Kind       ReportKind  `json:"kind"`
+	Findings   []Finding   `json:"findings"`
+	PRsOpened  []PROpened  `json:"prs_opened"`
+	BeadsFiled []BeadFiled `json:"beads_filed"`
+	Summary    string      `json:"summary"`
+}
+
+type Finding struct {
+	Title    string   `json:"title"`
+	Severity Severity `json:"severity"`
+	Summary  string   `json:"summary"`
+	File     string   `json:"file,omitempty"`
+	Line     int      `json:"line,omitempty"`
+}
+
+type PROpened struct {
+	Repo   string `json:"repo"`
+	Number int    `json:"number"`
+	URL    string `json:"url,omitempty"`
+	Title  string `json:"title"`
+}
+
+type BeadFiled struct {
+	ID    string   `json:"id"`
+	Type  BeadType `json:"type"`
+	Title string   `json:"title"`
+	URL   string   `json:"url,omitempty"`
+}
+
+type Violation struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+type ValidationError struct {
+	Violations []Violation `json:"violations"`
+}
+
+func (e *ValidationError) Error() string {
+	if e == nil || len(e.Violations) == 0 {
+		return "agent report validation failed"
+	}
+	parts := make([]string, 0, len(e.Violations))
+	for _, v := range e.Violations {
+		parts = append(parts, fmt.Sprintf("%s: %s", v.Field, v.Message))
+	}
+	return "agent report validation failed: " + strings.Join(parts, "; ")
+}
+
+func Validate(raw []byte) (*AgentReport, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, &ValidationError{Violations: []Violation{{Field: "$", Message: "must be a non-empty JSON object"}}}
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var report AgentReport
+	if err := dec.Decode(&report); err != nil {
+		return nil, fmt.Errorf("decode agent report: %w", err)
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		return nil, &ValidationError{Violations: []Violation{{Field: "$", Message: "must contain exactly one JSON object"}}}
+	}
+
+	if violations := validateReport(report); len(violations) > 0 {
+		return nil, &ValidationError{Violations: violations}
+	}
+	return &report, nil
+}
+
+func validateReport(report AgentReport) []Violation {
+	var violations []Violation
+	violations = append(violations, requireBounded("lane", report.Lane, MaxLaneLength)...)
+	violations = append(violations, requireBounded("kind", string(report.Kind), MaxKindLength)...)
+	if report.Kind != "" && !validKind(report.Kind) {
+		violations = append(violations, Violation{Field: "kind", Message: "must be one of findings, fix, review, advisory, summary"})
+	}
+	if report.Findings == nil {
+		violations = append(violations, Violation{Field: "findings", Message: "is required; use [] when there are no findings"})
+	} else if len(report.Findings) > MaxFindings {
+		violations = append(violations, Violation{Field: "findings", Message: fmt.Sprintf("must contain at most %d items", MaxFindings)})
+	}
+	if report.PRsOpened == nil {
+		violations = append(violations, Violation{Field: "prs_opened", Message: "is required; use [] when no PRs were opened"})
+	} else if len(report.PRsOpened) > MaxPRsOpened {
+		violations = append(violations, Violation{Field: "prs_opened", Message: fmt.Sprintf("must contain at most %d items", MaxPRsOpened)})
+	}
+	if report.BeadsFiled == nil {
+		violations = append(violations, Violation{Field: "beads_filed", Message: "is required; use [] when no beads were filed"})
+	} else if len(report.BeadsFiled) > MaxBeadsFiled {
+		violations = append(violations, Violation{Field: "beads_filed", Message: fmt.Sprintf("must contain at most %d items", MaxBeadsFiled)})
+	}
+	violations = append(violations, requireBounded("summary", report.Summary, MaxSummaryLength)...)
+
+	for i, finding := range report.Findings {
+		prefix := fmt.Sprintf("findings[%d]", i)
+		violations = append(violations, requireBounded(prefix+".title", finding.Title, MaxTitleLength)...)
+		violations = append(violations, requireBounded(prefix+".severity", string(finding.Severity), MaxKindLength)...)
+		if finding.Severity != "" && !validSeverity(finding.Severity) {
+			violations = append(violations, Violation{Field: prefix + ".severity", Message: "must be one of info, low, medium, high, critical"})
+		}
+		violations = append(violations, requireBounded(prefix+".summary", finding.Summary, MaxFindingBodyLength)...)
+		if finding.Line < 0 {
+			violations = append(violations, Violation{Field: prefix + ".line", Message: "must be zero or positive"})
+		}
+	}
+	for i, pr := range report.PRsOpened {
+		prefix := fmt.Sprintf("prs_opened[%d]", i)
+		violations = append(violations, requireBounded(prefix+".repo", pr.Repo, MaxRepoLength)...)
+		violations = append(violations, requireBounded(prefix+".title", pr.Title, MaxTitleLength)...)
+		if pr.Number <= 0 {
+			violations = append(violations, Violation{Field: prefix + ".number", Message: "must be greater than zero"})
+		}
+		violations = append(violations, optionalBounded(prefix+".url", pr.URL, MaxURLLength)...)
+	}
+	for i, bead := range report.BeadsFiled {
+		prefix := fmt.Sprintf("beads_filed[%d]", i)
+		violations = append(violations, requireBounded(prefix+".id", bead.ID, MaxBeadIDLength)...)
+		violations = append(violations, requireBounded(prefix+".type", string(bead.Type), MaxKindLength)...)
+		if bead.Type != "" && !validBeadType(bead.Type) {
+			violations = append(violations, Violation{Field: prefix + ".type", Message: "must be one of task, bug, advisory, feature"})
+		}
+		violations = append(violations, requireBounded(prefix+".title", bead.Title, MaxTitleLength)...)
+		violations = append(violations, optionalBounded(prefix+".url", bead.URL, MaxURLLength)...)
+	}
+	return violations
+}
+
+func CorrectivePrompt(err error) string {
+	if err == nil {
+		return ""
+	}
+	return fmt.Sprintf("Your previous structured agent report was invalid and could not be consumed by Hive. Return exactly one JSON object matching the AgentReport contract: required fields lane, kind, findings, prs_opened, beads_filed, summary. Use [] for empty arrays. Allowed kind values: findings, fix, review, advisory, summary. Fix these validation errors: %s. Hive will retry validation at most %d times.", err.Error(), MaxValidationRetries)
+}
+
+func AgentReportPath(agentName string) string {
+	return filepath.Join(AgentReportDir, AgentReportFilePrefix+safeAgentName(agentName)+AgentReportFileSuffix)
+}
+
+func safeAgentName(agentName string) string {
+	agentName = strings.TrimSpace(agentName)
+	if agentName == "" {
+		return "unknown"
+	}
+	var b strings.Builder
+	for _, r := range agentName {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' || r == '.' {
+			b.WriteRune(r)
+			continue
+		}
+		b.WriteByte('_')
+	}
+	return b.String()
+}
+
+func requireBounded(field, value string, max int) []Violation {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return []Violation{{Field: field, Message: "is required"}}
+	}
+	return optionalBounded(field, value, max)
+}
+
+func optionalBounded(field, value string, max int) []Violation {
+	if value == "" {
+		return nil
+	}
+	if len([]rune(value)) > max {
+		return []Violation{{Field: field, Message: fmt.Sprintf("must be at most %d characters", max)}}
+	}
+	return nil
+}
+
+func validKind(kind ReportKind) bool {
+	switch kind {
+	case KindFindings, KindFix, KindReview, KindAdvisory, KindSummary:
+		return true
+	default:
+		return false
+	}
+}
+
+func validSeverity(severity Severity) bool {
+	switch severity {
+	case SeverityInfo, SeverityLow, SeverityMedium, SeverityHigh, SeverityCritical:
+		return true
+	default:
+		return false
+	}
+}
+
+func validBeadType(beadType BeadType) bool {
+	switch beadType {
+	case BeadTypeTask, BeadTypeBug, BeadTypeAdvisory, BeadTypeFeature:
+		return true
+	default:
+		return false
+	}
+}

--- a/v2/pkg/outputschema/outputschema_test.go
+++ b/v2/pkg/outputschema/outputschema_test.go
@@ -1,0 +1,113 @@
+package outputschema
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	valid := `{
+		"lane":"scanner",
+		"kind":"findings",
+		"findings":[{"title":"racy write","severity":"high","summary":"shared map is written without a lock","file":"pkg/x.go","line":42}],
+		"prs_opened":[{"repo":"kubestellar/hive","number":2806,"title":"structured reports","url":"https://github.com/kubestellar/hive/pull/1"}],
+		"beads_filed":[{"id":"bead-1","type":"task","title":"follow-up"}],
+		"summary":"one finding, one PR, one bead"
+	}`
+
+	longSummary := strings.Repeat("x", MaxSummaryLength+1)
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr []string
+	}{
+		{
+			name: "valid full report",
+			raw:  valid,
+		},
+		{
+			name: "valid empty arrays",
+			raw:  `{"lane":"fixer","kind":"fix","findings":[],"prs_opened":[],"beads_filed":[],"summary":"nothing to report"}`,
+		},
+		{
+			name:    "missing required arrays",
+			raw:     `{"lane":"scanner","kind":"findings","summary":"missing arrays"}`,
+			wantErr: []string{"findings", "prs_opened", "beads_filed"},
+		},
+		{
+			name:    "bad enum values",
+			raw:     `{"lane":"scanner","kind":"other","findings":[{"title":"x","severity":"severe","summary":"y"}],"prs_opened":[],"beads_filed":[{"id":"b","type":"unknown","title":"t"}],"summary":"bad enums"}`,
+			wantErr: []string{"kind", "findings[0].severity", "beads_filed[0].type"},
+		},
+		{
+			name:    "bounded lengths",
+			raw:     `{"lane":"scanner","kind":"summary","findings":[],"prs_opened":[],"beads_filed":[],"summary":"` + longSummary + `"}`,
+			wantErr: []string{"summary", "at most"},
+		},
+		{
+			name:    "invalid nested values",
+			raw:     `{"lane":"scanner","kind":"fix","findings":[{"title":"x","severity":"low","summary":"y","line":-1}],"prs_opened":[{"repo":"kubestellar/hive","number":0,"title":"bad"}],"beads_filed":[],"summary":"bad nested"}`,
+			wantErr: []string{"findings[0].line", "prs_opened[0].number"},
+		},
+		{
+			name:    "unknown field rejected",
+			raw:     `{"lane":"scanner","kind":"summary","findings":[],"prs_opened":[],"beads_filed":[],"summary":"ok","extra":true}`,
+			wantErr: []string{"unknown field"},
+		},
+		{
+			name:    "empty input",
+			raw:     `  `,
+			wantErr: []string{"non-empty JSON object"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report, err := Validate([]byte(tt.raw))
+			if len(tt.wantErr) == 0 {
+				if err != nil {
+					t.Fatalf("Validate() error = %v", err)
+				}
+				if report == nil || report.Lane == "" {
+					t.Fatalf("Validate() returned empty report: %#v", report)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("Validate() error = nil, want error")
+			}
+			got := err.Error()
+			for _, want := range tt.wantErr {
+				if !strings.Contains(got, want) {
+					t.Fatalf("Validate() error %q missing %q", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestCorrectivePrompt(t *testing.T) {
+	prompt := CorrectivePrompt(errors.New("kind: must be one of findings, fix"))
+	for _, want := range []string{
+		"structured agent report was invalid",
+		"lane, kind, findings, prs_opened, beads_filed, summary",
+		"kind: must be one of findings, fix",
+		"3 times",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("CorrectivePrompt() = %q, missing %q", prompt, want)
+		}
+	}
+	if got := CorrectivePrompt(nil); got != "" {
+		t.Fatalf("CorrectivePrompt(nil) = %q, want empty", got)
+	}
+}
+
+func TestAgentReportPathSanitizesAgentName(t *testing.T) {
+	got := AgentReportPath("../scanner one")
+	want := "/var/run/hive-metrics/agent-report-.._scanner_one.json"
+	if got != want {
+		t.Fatalf("AgentReportPath() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Part of #2806. Foundation for the future review-swarm pipeline in #2807.

## Summary
- Add v2/pkg/outputschema with the generic AgentReport envelope and hand-rolled validation for required fields, enums, and bounded lengths/counts.
- Add MaxValidationRetries (3) and corrective re-prompt generation for validation failures.
- Add an optional governor hook that validates /var/run/hive-metrics/agent-report-<agent>.json when present and records/logs the result without changing behavior when absent.

## Validation
- cd v2 && go build ./...
- cd v2 && go test ./pkg/outputschema/... ./pkg/governor
- cd v2 && go vet ./pkg/outputschema/... ./pkg/governor