### PR TITLE
🐛 Fix GHE org resolution for App setup

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4997,6 +4997,55 @@ func sameForgeHost(a, b string) bool {
 	return norm(a) == norm(b)
 }
 
+func configuredProjectOrgForGitHubApp(cfg *config.Config, logger *slog.Logger) string {
+	if cfg == nil {
+		return ""
+	}
+	org := strings.TrimSpace(cfg.Project.Org)
+	if org == "" {
+		return ""
+	}
+	forgeHost := strings.TrimSpace(cfg.GitHub.HostLabel())
+	if forgeHost == "" {
+		forgeHost = "github.com"
+	}
+	if !strings.Contains(org, ".") || !sameForgeHost(org, forgeHost) {
+		return org
+	}
+
+	primary := strings.TrimSpace(cfg.Project.PrimaryRepo)
+	if primary == "" && len(cfg.Project.Repos) > 0 {
+		primary = strings.TrimSpace(cfg.Project.Repos[0])
+	}
+	derived := firstRepoPathSegment(primary)
+	if derived == "" || strings.EqualFold(derived, org) {
+		return org
+	}
+	if logger != nil {
+		logger.Warn("project org is configured as the GitHub forge host; deriving GitHub App organization from primary repo",
+			"configured_org", org, "derived_org", derived, "primary_repo", primary, "forge_host", forgeHost)
+	}
+	return derived
+}
+
+func firstRepoPathSegment(ref string) string {
+	ref = strings.TrimSpace(ref)
+	ref = strings.TrimPrefix(ref, "https://")
+	ref = strings.TrimPrefix(ref, "http://")
+	ref = strings.Trim(ref, "/")
+	if ref == "" {
+		return ""
+	}
+	parts := strings.Split(ref, "/")
+	if len(parts) > 1 && strings.Contains(parts[0], ".") {
+		parts = parts[1:]
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(parts[0])
+}
+
 // handleGovernorRepoCheckAccess verifies that this hive's GitHub App can access
 // a repo the operator is about to add, and — when it cannot — returns the
 // per-forge App install/authorize URL so the Repos tab can guide the user to
@@ -5284,7 +5333,7 @@ func (s *Server) AutoDiscoverGitHubInstallationID(ctx context.Context, force boo
 	if cfg.GitHub.InstallationID != 0 {
 		return 0, nil
 	}
-	org := strings.TrimSpace(cfg.Project.Org)
+	org := configuredProjectOrgForGitHubApp(cfg, s.logger)
 	if org == "" {
 		return 0, nil
 	}
@@ -5402,7 +5451,7 @@ func (s *Server) verifyGitHubSetupInstallation(r *http.Request, installationID i
 	// a hive session. We still do not trust the query string: the App JWT call
 	// below proves the ID exists for this App and that its account is exactly
 	// this hive's configured org, preventing installation hijacking.
-	return auth.VerifyInstallationForOrg(ctx, installationID, cfg.Project.Org)
+	return auth.VerifyInstallationForOrg(ctx, installationID, configuredProjectOrgForGitHubApp(cfg, s.logger))
 }
 
 func (s *Server) persistGitHubSetupInstallation(r *http.Request, installationID int64) error {

--- a/v2/pkg/dashboard/api_config_github_test.go
+++ b/v2/pkg/dashboard/api_config_github_test.go
@@ -5,12 +5,14 @@ package dashboard
 // hub-delivered to the per-app-id path with key_file deliberately left empty.
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -226,6 +228,61 @@ func TestAutoDiscoverGitHubInstallationIDPersistsLikeManualSetID(t *testing.T) {
 			gotAppID, gotInstallationID, gotKeyFile, testHubDeliveredAppID, testHubDeliveredInstallationID, keyFile)
 	}
 }
+
+func TestAutoDiscoverGitHubInstallationIDDerivesOrgWhenConfigOrgIsForgeHost(t *testing.T) {
+	ghpkg.ResetInstallationDiscoveryCache()
+	s, deps := apiServer(t)
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	s.logger = logger
+	deps.Logger = logger
+
+	deps.Config.SourcePath = filepath.Join(t.TempDir(), "hive.yaml")
+	deps.Config.Project.Org = "github.ibm.com"
+	deps.Config.Project.PrimaryRepo = "lee-cooper/toolkit"
+	deps.Config.GitHub.AppID = testHubDeliveredAppID
+	deps.Config.GitHub.InstallationID = 0
+	deps.Config.GitHub.KeyFile = ""
+	deps.Config.GitHub.BaseURL = "https://github.ibm.com"
+
+	var queriedOrg string
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/orgs/lee-cooper/installation" {
+			t.Fatalf("unexpected discovery path %s", r.URL.Path)
+		}
+		queriedOrg = "lee-cooper"
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": testHubDeliveredInstallationID,
+			"account": map[string]any{
+				"login": "lee-cooper",
+				"type":  "Organization",
+			},
+		})
+	}))
+	defer api.Close()
+	deps.Config.GitHub.APIURL = api.URL
+
+	keyFile := writeTestAppKey(t)
+	auth, err := ghpkg.NewAppAuth(testHubDeliveredAppID, 0, keyFile, deps.Logger, api.URL)
+	if err != nil {
+		t.Fatalf("NewAppAuth: %v", err)
+	}
+	deps.GHAppAuth = auth
+	deps.ResolveAppKeyFileFunc = func(configured string, appID int64) string { return keyFile }
+	deps.ReinitGitHubFunc = func(appID, installationID int64, keyFile string) error { return nil }
+
+	id, err := s.AutoDiscoverGitHubInstallationID(context.Background(), false)
+	if err != nil {
+		t.Fatalf("AutoDiscoverGitHubInstallationID: %v", err)
+	}
+	if id != testHubDeliveredInstallationID || queriedOrg != "lee-cooper" {
+		t.Fatalf("discovery id/org = (%d, %q), want (%d, lee-cooper)", id, queriedOrg, testHubDeliveredInstallationID)
+	}
+	if got := logs.String(); !strings.Contains(got, "configured_org=github.ibm.com") || !strings.Contains(got, "derived_org=lee-cooper") {
+		t.Fatalf("warning log = %q, want configured and derived orgs", got)
+	}
+}
 func TestGitHubSetupCallback_ValidInstallConfigures(t *testing.T) {
 	s, deps, api := setupCallbackServer(t, "myorg")
 	defer api.Close()
@@ -251,6 +308,25 @@ func TestGitHubSetupCallback_ValidInstallConfigures(t *testing.T) {
 	}
 	if entries := s.GetAudit().Recent(1); len(entries) != 1 || entries[0].Action != "config_github" {
 		t.Fatalf("audit entry = %#v, want config_github", entries)
+	}
+}
+
+func TestGitHubSetupCallbackDerivesOrgWhenConfigOrgIsForgeHost(t *testing.T) {
+	s, deps, api := setupCallbackServer(t, "lee-cooper")
+	defer api.Close()
+	deps.Config.Project.Org = "github.ibm.com"
+	deps.Config.Project.PrimaryRepo = "lee-cooper/toolkit"
+	deps.Config.GitHub.BaseURL = "https://github.ibm.com"
+
+	rec := doGet(s, "/gh-setup?setup_action=install&installation_id=4242")
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("setup callback: want 303, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if loc := rec.Header().Get("Location"); loc != "/?ghSetup=ok" {
+		t.Fatalf("redirect = %q, want /?ghSetup=ok", loc)
+	}
+	if deps.Config.GitHub.InstallationID != 4242 {
+		t.Fatalf("installation_id = %d, want 4242", deps.Config.GitHub.InstallationID)
 	}
 }
 

--- a/v2/pkg/github/app_accessors_test.go
+++ b/v2/pkg/github/app_accessors_test.go
@@ -1,0 +1,113 @@
+package github
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func testAppPrivateKeyPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating RSA key: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}))
+}
+
+func TestNewAppAuthFromPEMAndAccessors(t *testing.T) {
+	auth, err := NewAppAuthFromPEM(1234, 5678, testAppPrivateKeyPEM(t), slog.Default(), "https://github.ibm.com/api/v3")
+	if err != nil {
+		t.Fatalf("NewAppAuthFromPEM: %v", err)
+	}
+	if auth.AppID() != 1234 {
+		t.Fatalf("AppID = %d, want 1234", auth.AppID())
+	}
+	if auth.InstallationID() != 5678 {
+		t.Fatalf("InstallationID = %d, want 5678", auth.InstallationID())
+	}
+	if auth.APIURL() != "https://github.ibm.com/api/v3" {
+		t.Fatalf("APIURL = %q", auth.APIURL())
+	}
+	if !auth.HasKey() {
+		t.Fatal("HasKey = false, want true")
+	}
+}
+
+func TestNewAppAuthFromPEMRejectsInvalidKey(t *testing.T) {
+	if _, err := NewAppAuthFromPEM(1, 2, "not pem", slog.Default(), ""); err == nil || !strings.Contains(err.Error(), "PEM") {
+		t.Fatalf("NewAppAuthFromPEM invalid key error = %v, want PEM error", err)
+	}
+}
+
+func TestInstallationAccountLoginRejectsInvalidInputs(t *testing.T) {
+	if _, err := (*AppAuth)(nil).InstallationAccountLogin(context.Background(), 1); err == nil || !strings.Contains(err.Error(), "no app auth") {
+		t.Fatalf("nil auth error = %v", err)
+	}
+	if _, err := (&AppAuth{}).InstallationAccountLogin(context.Background(), 1); err == nil || !strings.Contains(err.Error(), "private key") {
+		t.Fatalf("missing key error = %v", err)
+	}
+	auth, err := NewAppAuthFromPEM(1, 0, testAppPrivateKeyPEM(t), slog.Default(), "")
+	if err != nil {
+		t.Fatalf("NewAppAuthFromPEM: %v", err)
+	}
+	if _, err := auth.InstallationAccountLogin(context.Background(), 0); err == nil || !strings.Contains(err.Error(), "positive") {
+		t.Fatalf("bad installation ID error = %v", err)
+	}
+}
+
+func TestInstallationAccountLoginReturnsAccount(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/app/installations/42" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": 42,
+			"account": map[string]any{
+				"login": "Lee-Cooper",
+				"type":  "Organization",
+			},
+		})
+	}))
+	defer api.Close()
+	auth, err := NewAppAuthFromPEM(1, 0, testAppPrivateKeyPEM(t), slog.Default(), api.URL)
+	if err != nil {
+		t.Fatalf("NewAppAuthFromPEM: %v", err)
+	}
+	login, err := auth.InstallationAccountLogin(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("InstallationAccountLogin: %v", err)
+	}
+	if login != "Lee-Cooper" {
+		t.Fatalf("login = %q, want Lee-Cooper", login)
+	}
+}
+
+func TestForgetInstallationDiscoveryRemovesCachedEntry(t *testing.T) {
+	ResetInstallationDiscoveryCache()
+	auth := &AppAuth{appID: 99, apiURL: "https://github.ibm.com/api/v3"}
+	key := discoveryCacheKey(auth.apiURL, auth.appID, "Lee-Cooper")
+	discoveryCacheMu.Lock()
+	discoveryCache[key] = discoveryCacheEntry{id: 42}
+	discoveryCacheMu.Unlock()
+
+	auth.ForgetInstallationDiscovery("Lee-Cooper")
+
+	discoveryCacheMu.Lock()
+	_, ok := discoveryCache[key]
+	discoveryCacheMu.Unlock()
+	if ok {
+		t.Fatalf("cache entry %q still present after ForgetInstallationDiscovery", key)
+	}
+	(*AppAuth)(nil).ForgetInstallationDiscovery("Lee-Cooper")
+}

--- a/v2/pkg/hub/normalize_org_ghe_host_test.go
+++ b/v2/pkg/hub/normalize_org_ghe_host_test.go
@@ -48,6 +48,40 @@ func TestNormalizeOrgRef_GHEHostOnly(t *testing.T) {
 	}
 }
 
+func TestNormalizeProjectRef_GHEHostDoesNotBecomeOrg(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        string
+		wantHost  string
+		wantOrg   string
+		wantRepos []string
+	}{
+		{"public org repo", "kubestellar/hive", "", "kubestellar", []string{"hive"}},
+		{"ghe host org repo", "github.ibm.com/lee-cooper/toolkit", "github.ibm.com", "lee-cooper", []string{"toolkit"}},
+		{"ghe host org", "github.ibm.com/lee-cooper", "github.ibm.com", "lee-cooper", nil},
+		{"ghe trailing slash", "https://github.ibm.com/lee-cooper/toolkit/", "github.ibm.com", "lee-cooper", []string{"toolkit"}},
+		{"public trailing slash", "kubestellar/hive/", "", "kubestellar", []string{"hive"}},
+		{"dotted org is not host", "my.org/repo", "", "my.org", []string{"repo"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			host, org, repos := normalizeProjectRef(tc.in)
+			if host != tc.wantHost || org != tc.wantOrg {
+				t.Fatalf("normalizeProjectRef(%q) = (%q, %q, %v); want host/org (%q, %q)",
+					tc.in, host, org, repos, tc.wantHost, tc.wantOrg)
+			}
+			if len(repos) != len(tc.wantRepos) {
+				t.Fatalf("normalizeProjectRef(%q) repos = %v; want %v", tc.in, repos, tc.wantRepos)
+			}
+			for i := range repos {
+				if repos[i] != tc.wantRepos[i] {
+					t.Fatalf("normalizeProjectRef(%q) repos = %v; want %v", tc.in, repos, tc.wantRepos)
+				}
+			}
+		})
+	}
+}
+
 // TestAssignHive_RejectsBareGHEHostAsOrg is the end-to-end regression for the
 // exact path that produced hosted-available-vllmd-02 / -09: an admin (or the
 // claim UI) submits a bare GHE forge host in the org field. The assign handler

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2728,6 +2728,35 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if host, org, reposFromOrg := normalizeProjectRef(req.Org); org != "" && (host != "" || len(reposFromOrg) > 0) {
+		if host != "" {
+			req.GitHubBaseURL = "https://" + host
+			req.GitHubAPIURL = gheAPIURLForHost(host)
+		}
+		req.Org = org
+		if len(reposFromOrg) > 0 {
+			prefix := strings.Join(reposFromOrg, "/")
+			if strings.TrimSpace(req.Repos) == "" {
+				req.Repos = prefix
+			}
+			if strings.TrimSpace(req.PrimaryRepo) == "" {
+				req.PrimaryRepo = prefix
+			}
+		}
+	} else if originalFirstRepo := firstCSV(req.Repos); originalFirstRepo != "" {
+		host, org, reposFromShifted := normalizeProjectRef(req.Org + "/" + originalFirstRepo)
+		if host != "" && org != "" && strings.Contains(req.Org, ".") {
+			req.GitHubBaseURL = "https://" + host
+			req.GitHubAPIURL = gheAPIURLForHost(host)
+			req.Org = org
+			repos := replaceFirstCSV(req.Repos, strings.Join(reposFromShifted, "/"))
+			req.Repos = repos
+			if strings.TrimSpace(req.PrimaryRepo) == "" || strings.TrimSpace(req.PrimaryRepo) == originalFirstRepo {
+				req.PrimaryRepo = firstCSV(repos)
+			}
+		}
+	}
+
 	if req.Org == "" || req.Repos == "" {
 		http.Error(w, `{"error":"org and repos are required"}`, http.StatusBadRequest)
 		return

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -469,6 +469,69 @@ func normalizeOrgRef(s string) (host, org string) {
 	return "", parts[0]
 }
 
+// normalizeProjectRef splits a GitHub project reference into forge host, org,
+// and repo path segments. Public GitHub's ordinary "org/repo" shape is left as
+// (host="", org="org", repos=["repo"]); a leading GitHub forge host is stripped,
+// so "github.ibm.com/org/repo" becomes (host="github.ibm.com", org="org",
+// repos=["repo"]). Dotted orgs such as "my.org/repo" remain public org/repo
+// refs, matching normalizeOrgRef's host-vs-org rule.
+func normalizeProjectRef(s string) (host, org string, repos []string) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	s = strings.Trim(s, "/")
+	s = strings.TrimSuffix(s, ".git")
+	if s == "" {
+		return "", "", nil
+	}
+	rawParts := strings.Split(s, "/")
+	parts := make([]string, 0, len(rawParts))
+	for _, p := range rawParts {
+		if p = strings.TrimSpace(p); p != "" {
+			parts = append(parts, p)
+		}
+	}
+	if len(parts) == 0 {
+		return "", "", nil
+	}
+	if looksLikeGitHubForgeHost(parts[0]) {
+		host = parts[0]
+		parts = parts[1:]
+	}
+	if len(parts) == 0 {
+		return host, "", nil
+	}
+	org = parts[0]
+	if len(parts) > 1 {
+		repos = append(repos, parts[1:]...)
+	}
+	return host, org, repos
+}
+
+func firstCSV(s string) string {
+	for _, part := range strings.Split(s, ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			return p
+		}
+	}
+	return ""
+}
+
+func replaceFirstCSV(s, first string) string {
+	parts := strings.Split(s, ",")
+	for i := range parts {
+		if strings.TrimSpace(parts[i]) != "" {
+			if strings.TrimSpace(first) == "" {
+				parts = append(parts[:i], parts[i+1:]...)
+			} else {
+				parts[i] = first
+			}
+			return strings.Join(parts, ",")
+		}
+	}
+	return strings.TrimSpace(first)
+}
+
 // looksLikeGitHubForgeHost reports whether a bare label is a GitHub forge
 // hostname (github.com or a GitHub Enterprise host like github.ibm.com) rather
 // than an org name. GitHub Enterprise hosts are conventionally "github.<org


### PR DESCRIPTION
## Summary
- fix hosted hive creation parsing so github.ibm.com/<org>[/<repo>] is treated as forge + org + repo instead of storing the forge host as project.org
- add dashboard GitHub App org fallback/warning for already-provisioned hives whose project.org equals the forge host
- cover public org/repo, GHE host/org[/repo], trailing slashes, and setup/discovery fallback tests

## Live evidence
On vllm-d namespace hive-hosted-hosted-available-vllmd-09, /data/hive.yaml.runtime had project.org=github.ibm.com with repos/primary_repo=lee-cooper, causing auto-discovery to poll org=github.ibm.com for App 5686 and fail.

## Live remediation
Patched the live hive config to org=Lee-Cooper and repo Bobs-Memory-Palace, restarted the pod, and verified auto-discovery now logs org=Lee-Cooper with the expected no-installation result until the user installs the App.

## Validation
- go build ./...
- go vet ./...
- go test ./pkg/dashboard/ ./pkg/hub/ ./pkg/config/ ./pkg/github/ -count=1