### PR TITLE
✨ feat(retro): post-completion retro lane filing advisory beads

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -49,6 +49,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/proclock"
 	"github.com/kubestellar/hive/v2/pkg/promptsrc"
 	"github.com/kubestellar/hive/v2/pkg/proxy"
+	"github.com/kubestellar/hive/v2/pkg/retro"
 	"github.com/kubestellar/hive/v2/pkg/scheduler"
 	"github.com/kubestellar/hive/v2/pkg/snapshot"
 	"github.com/kubestellar/hive/v2/pkg/timeline"
@@ -1561,6 +1562,19 @@ func main() {
 			store.SetHiveID(cfg.HiveID)
 			beadStores[name] = store
 			logger.Info("orphan beads store loaded from disk", "agent", name, "count", store.Count())
+		}
+	}
+
+	if cfg.Retro.Enabled {
+		if _, exists := beadStores[retro.Actor]; !exists {
+			retroStore, err := beads.NewStore(filepath.Join(beadsRootDir, retro.Actor))
+			if err != nil {
+				logger.Warn("failed to init retro beads store", "error", err)
+			} else {
+				retroStore.SetHiveID(cfg.HiveID)
+				beadStores[retro.Actor] = retroStore
+				logger.Info("retro beads store initialized", "count", retroStore.Count())
+			}
 		}
 	}
 
@@ -3692,6 +3706,27 @@ func main() {
 			"max_replans", rc.MaxReplans)
 	}
 
+	var retroLane *retro.Lane
+	if cfg.Retro.Enabled {
+		retroStore := beadStores[retro.Actor]
+		escalationStoreOnce.Do(func() {
+			escalationStore = escalation.Load(escalationLedgerPath)
+		})
+		retroLane = retro.NewLane(beadStores, retroStore, dashSrv.LifecycleTimeline(), escalationStore, retro.Config{
+			Enabled:             cfg.Retro.Enabled,
+			ScanIntervalS:       cfg.Retro.ScanIntervalS,
+			MaxFixAttempts:      cfg.Retro.MaxFixAttempts,
+			MaxKicks:            cfg.Retro.MaxKicks,
+			LongStallDays:       cfg.Retro.LongStallDays,
+			RecentClosedWindowS: cfg.Retro.RecentClosedWindowS,
+		}, logger)
+		logger.Info("retro lane enabled",
+			"scan_interval_s", cfg.Retro.ScanIntervalS,
+			"max_fix_attempts", cfg.Retro.MaxFixAttempts,
+			"max_kicks", cfg.Retro.MaxKicks,
+			"long_stall_days", cfg.Retro.LongStallDays)
+	}
+
 	logger.Info("entering governor loop", "interval_seconds", cfg.Governor.EvalIntervalS)
 	lastEvalInterval := cfg.Governor.EvalIntervalS
 	ticker := time.NewTicker(time.Duration(cfg.Governor.EvalIntervalS) * time.Second)
@@ -3772,6 +3807,11 @@ func main() {
 			if replanLane != nil && replanLane.Due(time.Now()) {
 				if n := replanLane.Run(ctx); n > 0 {
 					logger.Info("stall-replan lane re-kicked stalled plans", "replans", n)
+				}
+			}
+			if retroLane != nil && retroLane.Due(time.Now()) {
+				if n := retroLane.Run(ctx); n > 0 {
+					logger.Info("retro lane filed advisory beads", "findings", n)
 				}
 			}
 			persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
@@ -4028,14 +4068,29 @@ func recordEnumeratedIssues(rec lifecycleRecorder, actionable *github.Actionable
 	}
 }
 
-// recordKick records a KindKicked event for the given agent. Guarded and
-// nil-safe; no I/O.
-func recordKick(rec lifecycleRecorder, agent string) {
+// recordKick records KindKicked events for the given agent. When issue refs are
+// supplied it records one issue-scoped event per ref so post-completion lanes
+// can reconstruct per-bead kick counts. With no refs, it records one
+// agent-scoped event. Guarded and nil-safe; no I/O.
+func recordKick(rec lifecycleRecorder, agent string, issueRefs ...string) {
 	if rec == nil {
 		return
 	}
 	store := rec.LifecycleTimeline()
 	if store == nil {
+		return
+	}
+	if len(issueRefs) > 0 {
+		for _, ref := range issueRefs {
+			if ref == "" {
+				continue
+			}
+			store.Record(timeline.Event{
+				IssueRef: ref,
+				Kind:     timeline.KindKicked,
+				Agent:    agent,
+			})
+		}
 		return
 	}
 	store.Record(timeline.Event{
@@ -4384,11 +4439,9 @@ func runEvalCycle(
 			gov.RecordKick(msg.Agent)
 			dashSrv.AuditLog("governor", "kick", "trigger=governor-eval", msg.Agent)
 
-			// Record the kick into the lifecycle timeline. Cheap, guarded, and
-			// nil-safe (Record no-ops on a nil dashboard/store). A kick is not
-			// tied to a single issue at this layer, so IssueRef is left empty;
-			// the event still records which agent was kicked and when.
-			recordKick(dashSrv, msg.Agent)
+			// Record issue-scoped kicks into the lifecycle timeline. Cheap,
+			// guarded, and nil-safe (Record no-ops on a nil dashboard/store).
+			recordKick(dashSrv, msg.Agent, msg.IssueRefs...)
 
 			// Log token state at time of kick for cost attribution
 			if tokenCollector != nil {

--- a/v2/cmd/hive/timeline_record_test.go
+++ b/v2/cmd/hive/timeline_record_test.go
@@ -77,6 +77,25 @@ func TestRecordKick(t *testing.T) {
 	}
 }
 
+func TestRecordKickIssueScoped(t *testing.T) {
+	rec := &fakeLifecycleRecorder{store: timeline.NewStore()}
+
+	recordKick(rec, "scanner", "org/repo#1", "org/repo#2")
+
+	events := rec.store.Recent(0)
+	if len(events) != 2 {
+		t.Fatalf("recorded %d events, want 2", len(events))
+	}
+	if events[0].IssueRef != "org/repo#2" || events[1].IssueRef != "org/repo#1" {
+		t.Fatalf("issue refs = %q, %q", events[0].IssueRef, events[1].IssueRef)
+	}
+	for _, e := range events {
+		if e.Kind != timeline.KindKicked || e.Agent != "scanner" {
+			t.Fatalf("bad kick event: %+v", e)
+		}
+	}
+}
+
 // TestRecordHelpers_NilSafe confirms the guards: nil recorder, nil actionable,
 // and a recorder returning a nil store must all be no-ops (never panic).
 func TestRecordHelpers_NilSafe(t *testing.T) {

--- a/v2/docs/retro-lane.md
+++ b/v2/docs/retro-lane.md
@@ -1,0 +1,30 @@
+# Retro lane
+
+The retro lane is a deterministic, post-completion analysis pass for Hive work. It is disabled by default (`retro.enabled: false`) so existing hives see no behavior change unless operators opt in.
+
+When enabled, the lane runs from the governor tick on its own scan interval. It scans done/closed beads that have a closed or merged PR association in bead metadata or the lifecycle timeline, reconstructs a compact `RetroRecord`, and applies rule-based pattern detection only. It does not call an LLM and it does not post to GitHub.
+
+## Reconstructed record
+
+For each eligible bead the lane combines local ledgers:
+
+- bead metadata: issue/bead identity, PR reference/state, claim/close times, explicit counters when present;
+- lifecycle timeline: kicks, PR-open/merge events, and trajectory drift/pause markers;
+- escalation ledger when still available: failed fix-attempt count for the PR.
+
+The compact record tracks bead metadata, issue/PR refs, kicks received, CI failures/fix attempts, drift pauses, and wall-clock time from claim to close.
+
+## Deterministic findings
+
+Named threshold defaults are:
+
+- excessive fix attempts: `>= 3`;
+- excessive kicks before completion: `>= 5`;
+- long stall: claim-to-close `> 7 days`;
+- drift pause occurred: any trajectory drift/pause marker.
+
+Each finding is filed as an `advisory` bead attributed to actor `retro`, using the existing advisory-bead digest path. Source beads are marked with `retro_analyzed_at` after analysis to avoid duplicate findings.
+
+## Follow-ups
+
+LLM-powered retrospective summaries and durable knowledge-graph lesson extraction are intentionally deferred. This PR provides the deterministic foundation and local advisory-bead feedback loop only.

--- a/v2/hive.yaml.example
+++ b/v2/hive.yaml.example
@@ -190,6 +190,17 @@ governor:
   #   api_key_env: HIVE_BOB_API_KEY       # env var NAME holding the key (default)
   #   api_key_file: /secrets/bob_api_key  # or a mounted key file (default path)
 
+# Retro lane — deterministic post-completion analysis. Disabled by default;
+# when enabled it scans recently completed beads with closed/merged PR metadata
+# and files rule-based findings as local advisory beads (no GitHub posts).
+# retro:
+#   enabled: false
+#   scan_interval_s: 3600
+#   max_fix_attempts: 3
+#   max_kicks: 5
+#   long_stall_days: 7
+#   recent_closed_window_s: 604800
+
 # GitHub authentication — use ONE of these methods
 github:
   # Option 1: Personal access token (simplest)

--- a/v2/pkg/beads/beads.go
+++ b/v2/pkg/beads/beads.go
@@ -212,8 +212,14 @@ func (s *Store) Update(id string, fn func(b *Bead)) error {
 		return fmt.Errorf("bead %s not found", id)
 	}
 
+	wasTerminal := b.Status == StatusDone || b.Status == StatusClosed
 	fn(b)
-	b.UpdatedAt = flexTime{time.Now().UTC()}
+	now := flexTime{time.Now().UTC()}
+	isTerminal := b.Status == StatusDone || b.Status == StatusClosed
+	if isTerminal && !wasTerminal && b.ClosedAt == nil {
+		b.ClosedAt = &now
+	}
+	b.UpdatedAt = now
 
 	return s.persist(b)
 }

--- a/v2/pkg/beads/beads_test.go
+++ b/v2/pkg/beads/beads_test.go
@@ -9,8 +9,8 @@ import (
 
 // ptr helpers
 
-func statusPtr(s Status) *Status   { return &s }
-func strPtr(s string) *string      { return &s }
+func statusPtr(s Status) *Status { return &s }
+func strPtr(s string) *string    { return &s }
 
 // TestNewStore_CreatesDirectoryAndEmptyStore verifies that NewStore creates the
 // target directory if it does not exist and starts with an empty ledger.
@@ -70,6 +70,7 @@ func TestCreate_CorrectFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
+
 	after := time.Now().UTC().Add(time.Second)
 
 	if b.ID == "" {
@@ -113,6 +114,43 @@ func TestCreate_CorrectFields(t *testing.T) {
 	beadsFile := filepath.Join(dir, "beads.json")
 	if _, err := os.Stat(beadsFile); err != nil {
 		t.Fatalf("beads.json not created: %v", err)
+	}
+}
+
+func TestUpdate_TransitionToDoneStampsClosedAt(t *testing.T) {
+	s, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	b, err := s.Create("finish me", TypeTask, PriorityMedium, "scanner", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if b.ClosedAt != nil {
+		t.Fatal("new bead should not have ClosedAt")
+	}
+	if err := s.Update(b.ID, func(b *Bead) {
+		b.Status = StatusDone
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	got, err := s.Get(b.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ClosedAt == nil {
+		t.Fatal("transition to done should stamp ClosedAt")
+	}
+	firstClosed := got.ClosedAt.Time
+	if err := s.SetMetadata(b.ID, "later", "value"); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+	got, err = s.Get(b.ID)
+	if err != nil {
+		t.Fatalf("Get after metadata: %v", err)
+	}
+	if !got.ClosedAt.Equal(firstClosed) {
+		t.Fatalf("ClosedAt changed after metadata update: got %s want %s", got.ClosedAt.Time, firstClosed)
 	}
 }
 

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	Classifier ClassifierConfig `yaml:"classifier,omitempty" json:"classifier,omitempty"`
 	Planning   PlanningConfig   `yaml:"planning,omitempty" json:"planning,omitempty"`
 	Escalation EscalationConfig `yaml:"escalation,omitempty" json:"escalation,omitempty"`
+	Retro      RetroConfig      `yaml:"retro,omitempty" json:"retro,omitempty"`
 
 	// RemovedAgents are agent names an operator deliberately deleted. It is a
 	// TOMBSTONE list, and it exists because deletion had no durable record
@@ -169,6 +170,20 @@ type PlanningConfig struct {
 	// true is a no-op below L5, because the architect that decomposes the minted
 	// epics is not scheduled there.
 	PlanFromLabel *bool `yaml:"plan_from_label,omitempty" json:"plan_from_label,omitempty"`
+}
+
+// RetroConfig gates the deterministic post-completion retro lane. It is off by
+// default: an absent `retro:` block or `enabled: false` yields zero behavior
+// change. When enabled, the lane periodically scans done/closed beads that have
+// a closed/merged PR association, reconstructs a compact trajectory from local
+// ledgers, and files rule-based findings as advisory beads.
+type RetroConfig struct {
+	Enabled             bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	ScanIntervalS       int  `yaml:"scan_interval_s,omitempty" json:"scan_interval_s,omitempty"`
+	MaxFixAttempts      int  `yaml:"max_fix_attempts,omitempty" json:"max_fix_attempts,omitempty"`
+	MaxKicks            int  `yaml:"max_kicks,omitempty" json:"max_kicks,omitempty"`
+	LongStallDays       int  `yaml:"long_stall_days,omitempty" json:"long_stall_days,omitempty"`
+	RecentClosedWindowS int  `yaml:"recent_closed_window_s,omitempty" json:"recent_closed_window_s,omitempty"`
 }
 
 // planFromLabelMinACMM is the lowest ACMM level at which the label trigger fires

--- a/v2/pkg/retro/retro.go
+++ b/v2/pkg/retro/retro.go
@@ -1,0 +1,521 @@
+// Package retro implements a deterministic post-completion retro lane.
+package retro
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/beads"
+	"github.com/kubestellar/hive/v2/pkg/escalation"
+	"github.com/kubestellar/hive/v2/pkg/timeline"
+)
+
+const (
+	Actor = "retro"
+
+	DefaultScanIntervalS        = 60 * 60
+	DefaultMaxFixAttempts       = 3
+	DefaultMaxKicks             = 5
+	DefaultLongStallDays        = 7
+	defaultLongStallHours       = DefaultLongStallDays * 24
+	metadataAnalyzedAt          = "retro_analyzed_at"
+	metadataFindingType         = "finding_type"
+	metadataAdvisoryAgent       = "advisory_agent"
+	metadataSeverity            = "severity"
+	metadataDetail              = "detail"
+	metadataSourceBead          = "retro_source_bead"
+	metadataSourceActor         = "retro_source_actor"
+	metadataSourcePR            = "retro_source_pr"
+	metadataSourceIssue         = "retro_source_issue"
+	metadataPattern             = "retro_pattern"
+	metadataRecordWallClock     = "retro_wall_clock"
+	PatternExcessiveFixAttempts = "excessive_fix_attempts"
+	PatternExcessiveKicks       = "excessive_kicks"
+	PatternLongStall            = "long_stall"
+	PatternDriftPause           = "drift_pause"
+)
+
+type Config struct {
+	Enabled             bool
+	ScanIntervalS       int
+	MaxFixAttempts      int
+	MaxKicks            int
+	LongStallDays       int
+	RecentClosedWindowS int
+}
+
+type Thresholds struct {
+	MaxFixAttempts int
+	MaxKicks       int
+	LongStall      time.Duration
+}
+
+type RetroRecord struct {
+	BeadID         string
+	Title          string
+	Type           beads.BeadType
+	Status         beads.Status
+	Actor          string
+	ExternalRef    string
+	IssueRef       string
+	PRRef          string
+	PRState        string
+	KicksReceived  int
+	CIFailureCount int
+	FixAttempts    int
+	DriftPauses    int
+	ClaimedAt      time.Time
+	ClosedAt       time.Time
+	ClaimToClose   time.Duration
+}
+
+type Finding struct {
+	Pattern  string
+	Title    string
+	Detail   string
+	Severity string
+}
+
+type AttemptReader interface {
+	Attempts(repo string, number int) int
+}
+
+type Lane struct {
+	stores        map[string]*beads.Store
+	advisoryStore *beads.Store
+	timeline      *timeline.Store
+	attempts      AttemptReader
+	logger        *slog.Logger
+	interval      time.Duration
+	thresholds    Thresholds
+	lastRun       time.Time
+	recentWindow  time.Duration
+}
+
+func NewLane(stores map[string]*beads.Store, advisoryStore *beads.Store, tl *timeline.Store, attempts AttemptReader, cfg Config, logger *slog.Logger) *Lane {
+	intervalS := cfg.ScanIntervalS
+	if intervalS <= 0 {
+		intervalS = DefaultScanIntervalS
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Lane{
+		stores:        stores,
+		advisoryStore: advisoryStore,
+		timeline:      tl,
+		attempts:      attempts,
+		logger:        logger,
+		interval:      time.Duration(intervalS) * time.Second,
+		thresholds:    thresholdsFromConfig(cfg),
+		recentWindow:  time.Duration(cfg.RecentClosedWindowS) * time.Second,
+	}
+}
+
+func (l *Lane) Due(now time.Time) bool {
+	return l.lastRun.IsZero() || now.Sub(l.lastRun) >= l.interval
+}
+
+func (l *Lane) Run(ctx context.Context) int {
+	l.lastRun = time.Now()
+	if l.advisoryStore == nil {
+		return 0
+	}
+	created := 0
+	for storeName, store := range l.stores {
+		if ctx.Err() != nil {
+			return created
+		}
+		if store == nil || store == l.advisoryStore {
+			continue
+		}
+		for _, b := range store.AllClosed() {
+			if ctx.Err() != nil {
+				return created
+			}
+			if !l.eligible(b, l.lastRun) {
+				continue
+			}
+			record := Reconstruct(b, l.timeline, l.attempts)
+			if !record.HasAssociatedClosedPR() {
+				continue
+			}
+			findings := Detect(record, l.thresholds)
+			for _, f := range findings {
+				if l.createAdvisory(record, f) {
+					created++
+				}
+			}
+			if err := store.SetMetadata(b.ID, metadataAnalyzedAt, l.lastRun.UTC().Format(time.RFC3339)); err != nil {
+				l.logger.Warn("retro: failed to mark bead analyzed", "store", storeName, "bead", b.ID, "error", err)
+			}
+		}
+	}
+	return created
+}
+
+func (l *Lane) eligible(b *beads.Bead, now time.Time) bool {
+	if b == nil || b.Type == beads.TypeAdvisory {
+		return false
+	}
+	if b.Status != beads.StatusClosed && b.Status != beads.StatusDone {
+		return false
+	}
+	if b.Metadata != nil {
+		if _, ok := b.Metadata[metadataAnalyzedAt]; ok {
+			return false
+		}
+	}
+	if l.recentWindow > 0 {
+		completed := completedAt(b)
+		if !completed.IsZero() && now.Sub(completed) > l.recentWindow {
+			return false
+		}
+	}
+	return true
+}
+
+func completedAt(b *beads.Bead) time.Time {
+	if b == nil {
+		return time.Time{}
+	}
+	if b.ClosedAt != nil {
+		return b.ClosedAt.Time
+	}
+	if t := parseTime(metaString(b, "closed_at")); !t.IsZero() {
+		return t
+	}
+	if b.Status == beads.StatusDone || b.Status == beads.StatusClosed {
+		return b.UpdatedAt.Time
+	}
+	return time.Time{}
+}
+
+func (l *Lane) createAdvisory(r RetroRecord, f Finding) bool {
+	if l.openDuplicate(f.Title) {
+		return false
+	}
+	b, err := l.advisoryStore.Create(f.Title, beads.TypeAdvisory, severityToPriority(f.Severity), Actor, r.PRRef)
+	if err != nil {
+		l.logger.Warn("retro: failed to create advisory bead", "pattern", f.Pattern, "source_bead", r.BeadID, "error", err)
+		return false
+	}
+	meta := map[string]string{
+		metadataSeverity:        f.Severity,
+		metadataFindingType:     "retro",
+		metadataAdvisoryAgent:   Actor,
+		metadataDetail:          f.Detail,
+		metadataSourceBead:      r.BeadID,
+		metadataSourceActor:     r.Actor,
+		metadataSourcePR:        r.PRRef,
+		metadataSourceIssue:     r.IssueRef,
+		metadataPattern:         f.Pattern,
+		metadataRecordWallClock: r.ClaimToClose.String(),
+	}
+	for k, v := range meta {
+		if v != "" {
+			_ = l.advisoryStore.SetMetadata(b.ID, k, v)
+		}
+	}
+	return true
+}
+
+func (l *Lane) openDuplicate(title string) bool {
+	for _, b := range l.advisoryStore.List(beads.ListFilter{}) {
+		if b.Type == beads.TypeAdvisory && b.Title == title && b.Status != beads.StatusClosed && b.Status != beads.StatusDone {
+			return true
+		}
+	}
+	return false
+}
+
+func Reconstruct(b *beads.Bead, tl *timeline.Store, attempts AttemptReader) RetroRecord {
+	if b == nil {
+		return RetroRecord{}
+	}
+	r := RetroRecord{
+		BeadID:      b.ID,
+		Title:       b.Title,
+		Type:        b.Type,
+		Status:      b.Status,
+		Actor:       b.Actor,
+		ExternalRef: b.ExternalRef,
+		IssueRef:    firstNonEmpty(metaString(b, "issue_ref"), canonicalIssueRef(b.ExternalRef)),
+		PRRef:       firstNonEmpty(metaString(b, "pr_ref"), metaString(b, "pull_request"), metaString(b, "github_pr")),
+		PRState:     strings.ToLower(firstNonEmpty(metaString(b, "pr_state"), metaString(b, "pull_request_state"))),
+		ClaimedAt:   parseTime(firstNonEmpty(metaString(b, "claimed_at"), metaString(b, "claim_at"), metaString(b, "started_at"))),
+		ClosedAt:    closedAt(b),
+	}
+	if r.IssueRef == "" {
+		r.IssueRef = canonicalIssueRef(r.PRRef)
+	}
+	applyNumericMetadata(b, &r)
+	applyTimeline(tl, &r)
+	applyPRMetadata(b, &r)
+	if attempts != nil {
+		if repo, number, ok := splitPRRef(r.PRRef); ok {
+			if n := attempts.Attempts(repo, number); n > r.FixAttempts {
+				r.FixAttempts = n
+			}
+		}
+	}
+	if r.CIFailureCount < r.FixAttempts {
+		r.CIFailureCount = r.FixAttempts
+	}
+	if r.ClaimedAt.IsZero() {
+		r.ClaimedAt = b.CreatedAt.Time
+	}
+	if !r.ClaimedAt.IsZero() && !r.ClosedAt.IsZero() && r.ClosedAt.After(r.ClaimedAt) {
+		r.ClaimToClose = r.ClosedAt.Sub(r.ClaimedAt)
+	}
+	return r
+}
+
+func (r RetroRecord) HasAssociatedClosedPR() bool {
+	if r.PRRef == "" {
+		return false
+	}
+	state := strings.ToLower(r.PRState)
+	return state == "merged" || state == "closed" || state == "close" || state == "done"
+}
+
+func Detect(r RetroRecord, t Thresholds) []Finding {
+	t = thresholdsWithDefaults(t)
+	var findings []Finding
+	if r.FixAttempts >= t.MaxFixAttempts {
+		findings = append(findings, Finding{Pattern: PatternExcessiveFixAttempts, Severity: "medium", Title: fmt.Sprintf("Retro: %s needed %d fix attempts", r.BeadID, r.FixAttempts), Detail: fmt.Sprintf("PR %s required %d failed CI/fix attempt(s), meeting the threshold of %d.", r.PRRef, r.FixAttempts, t.MaxFixAttempts)})
+	}
+	if r.KicksReceived >= t.MaxKicks {
+		findings = append(findings, Finding{Pattern: PatternExcessiveKicks, Severity: "low", Title: fmt.Sprintf("Retro: %s needed %d kicks before completion", r.BeadID, r.KicksReceived), Detail: fmt.Sprintf("Bead %s received %d kicks before completion, meeting the threshold of %d.", r.BeadID, r.KicksReceived, t.MaxKicks)})
+	}
+	if r.ClaimToClose > t.LongStall {
+		findings = append(findings, Finding{Pattern: PatternLongStall, Severity: "medium", Title: fmt.Sprintf("Retro: %s stalled for %s", r.BeadID, roundDuration(r.ClaimToClose)), Detail: fmt.Sprintf("Bead %s took %s from claim to close, exceeding %s.", r.BeadID, roundDuration(r.ClaimToClose), roundDuration(t.LongStall))})
+	}
+	if r.DriftPauses > 0 {
+		findings = append(findings, Finding{Pattern: PatternDriftPause, Severity: "medium", Title: fmt.Sprintf("Retro: %s had trajectory drift pause", r.BeadID), Detail: fmt.Sprintf("Trajectory review paused or flagged drift %d time(s) during PR %s.", r.DriftPauses, r.PRRef)})
+	}
+	return findings
+}
+
+func thresholdsFromConfig(c Config) Thresholds {
+	longStallDays := c.LongStallDays
+	if longStallDays <= 0 {
+		longStallDays = DefaultLongStallDays
+	}
+	return thresholdsWithDefaults(Thresholds{MaxFixAttempts: c.MaxFixAttempts, MaxKicks: c.MaxKicks, LongStall: time.Duration(longStallDays) * 24 * time.Hour})
+}
+
+func thresholdsWithDefaults(t Thresholds) Thresholds {
+	if t.MaxFixAttempts <= 0 {
+		t.MaxFixAttempts = DefaultMaxFixAttempts
+	}
+	if t.MaxKicks <= 0 {
+		t.MaxKicks = DefaultMaxKicks
+	}
+	if t.LongStall <= 0 {
+		t.LongStall = defaultLongStallHours * time.Hour
+	}
+	return t
+}
+
+func applyNumericMetadata(b *beads.Bead, r *RetroRecord) {
+	r.KicksReceived = maxInt(r.KicksReceived, metaInt(b, "kicks_received"), metaInt(b, "kick_count"), metaInt(b, "kicks"))
+	r.CIFailureCount = maxInt(r.CIFailureCount, metaInt(b, "ci_failure_count"), metaInt(b, "ci_failures"), metaInt(b, "failing_checks"))
+	r.FixAttempts = maxInt(r.FixAttempts, metaInt(b, "fix_attempts"), metaInt(b, "failed_fix_attempts"))
+	r.DriftPauses = maxInt(r.DriftPauses, metaInt(b, "drift_pauses"), metaInt(b, "trajectory_pauses"), metaInt(b, "trajectory_drift_pauses"))
+}
+
+func applyPRMetadata(b *beads.Bead, r *RetroRecord) {
+	if r.PRRef == "" {
+		repo := firstNonEmpty(metaString(b, "pr_repo"), repoPart(r.IssueRef))
+		if n := metaInt(b, "pr_number"); repo != "" && n > 0 {
+			r.PRRef = fmt.Sprintf("%s#%d", repo, n)
+		}
+	}
+	if r.PRState == "" {
+		if metaBool(b, "pr_merged") || metaString(b, "merged_at") != "" {
+			r.PRState = "merged"
+		} else if metaString(b, "pr_closed_at") != "" || metaString(b, "closed_pr_at") != "" {
+			r.PRState = "closed"
+		}
+	}
+}
+
+func applyTimeline(tl *timeline.Store, r *RetroRecord) {
+	if tl == nil || r.IssueRef == "" {
+		return
+	}
+	events := tl.ByIssue(r.IssueRef)
+	for i := len(events) - 1; i >= 0; i-- {
+		e := events[i]
+		switch e.Kind {
+		case timeline.KindKicked:
+			r.KicksReceived++
+			if r.ClaimedAt.IsZero() {
+				r.ClaimedAt = time.UnixMilli(e.At)
+			}
+		case timeline.KindPROpened:
+			if r.PRRef == "" {
+				r.PRRef = firstNonEmpty(attr(e, "pr_ref"), attr(e, "pr"), prRefFromAttrs(e.Attrs, r.IssueRef))
+			}
+		case timeline.KindMerged:
+			if r.PRRef == "" {
+				r.PRRef = firstNonEmpty(attr(e, "pr_ref"), attr(e, "pr"), prRefFromAttrs(e.Attrs, r.IssueRef))
+			}
+			r.PRState = "merged"
+		}
+		if isDriftPause(e) {
+			r.DriftPauses++
+		}
+		if state := strings.ToLower(firstNonEmpty(attr(e, "pr_state"), attr(e, "state"))); state == "closed" || state == "merged" {
+			r.PRState = state
+		}
+	}
+}
+
+func isDriftPause(e timeline.Event) bool {
+	text := strings.ToLower(strings.Join([]string{string(e.Kind), e.Agent, attr(e, "action"), attr(e, "trigger"), attr(e, "reason")}, " "))
+	return strings.Contains(text, "trajectory") && (strings.Contains(text, "drift") || strings.Contains(text, "pause"))
+}
+
+func attr(e timeline.Event, key string) string {
+	if e.Attrs == nil {
+		return ""
+	}
+	return e.Attrs[key]
+}
+
+func prRefFromAttrs(attrs map[string]string, issueRef string) string {
+	if len(attrs) == 0 {
+		return ""
+	}
+	repo := firstNonEmpty(attrs["pr_repo"], repoPart(issueRef))
+	if repo == "" {
+		return ""
+	}
+	for _, key := range []string{"pr_number", "number", "pr"} {
+		if n, err := strconv.Atoi(strings.TrimPrefix(attrs[key], "#")); err == nil && n > 0 {
+			return fmt.Sprintf("%s#%d", repo, n)
+		}
+	}
+	return ""
+}
+
+func closedAt(b *beads.Bead) time.Time {
+	return completedAt(b)
+}
+
+func canonicalIssueRef(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if strings.Count(ref, "#") == 1 && !strings.HasPrefix(ref, "#") {
+		return ref
+	}
+	return ""
+}
+
+func splitPRRef(ref string) (string, int, bool) {
+	parts := strings.Split(strings.TrimSpace(ref), "#")
+	if len(parts) != 2 || parts[0] == "" {
+		return "", 0, false
+	}
+	n, err := strconv.Atoi(parts[1])
+	return parts[0], n, err == nil && n > 0
+}
+
+func repoPart(ref string) string {
+	if repo, _, ok := splitPRRef(ref); ok {
+		return repo
+	}
+	return ""
+}
+
+func metaString(b *beads.Bead, key string) string {
+	if b == nil || b.Metadata == nil {
+		return ""
+	}
+	v, ok := b.Metadata[key]
+	if !ok || v == nil {
+		return ""
+	}
+	switch x := v.(type) {
+	case string:
+		return strings.TrimSpace(x)
+	case fmt.Stringer:
+		return strings.TrimSpace(x.String())
+	default:
+		return strings.TrimSpace(fmt.Sprintf("%v", x))
+	}
+}
+
+func metaInt(b *beads.Bead, key string) int {
+	s := metaString(b, key)
+	if s == "" {
+		return 0
+	}
+	n, _ := strconv.Atoi(s)
+	return n
+}
+
+func metaBool(b *beads.Bead, key string) bool {
+	s := strings.ToLower(metaString(b, key))
+	return s == "true" || s == "yes" || s == "1"
+}
+
+func parseTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02T15:04Z", "2006-01-02"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+func severityToPriority(sev string) beads.Priority {
+	switch strings.ToLower(sev) {
+	case "critical":
+		return beads.PriorityCritical
+	case "high":
+		return beads.PriorityHigh
+	case "medium":
+		return beads.PriorityMedium
+	case "low":
+		return beads.PriorityLow
+	default:
+		return beads.PriorityMinor
+	}
+}
+
+func roundDuration(d time.Duration) time.Duration {
+	if d < time.Hour {
+		return d.Round(time.Minute)
+	}
+	return d.Round(time.Hour)
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func maxInt(vals ...int) int {
+	m := 0
+	for _, v := range vals {
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}
+
+var _ AttemptReader = (*escalation.Store)(nil)

--- a/v2/pkg/retro/retro_test.go
+++ b/v2/pkg/retro/retro_test.go
@@ -1,0 +1,253 @@
+package retro
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/beads"
+	"github.com/kubestellar/hive/v2/pkg/timeline"
+)
+
+type fakeAttempts map[string]int
+
+func (f fakeAttempts) Attempts(repo string, number int) int {
+	return f[repo+"#"+itoa(number)]
+}
+
+func TestReconstruct(t *testing.T) {
+	base := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name     string
+		metadata map[string]interface{}
+		timeline []timeline.Event
+		attempts fakeAttempts
+		want     RetroRecord
+	}{
+		{
+			name: "metadata and timeline assemble compact record",
+			metadata: map[string]interface{}{
+				"claimed_at":       base.Format(time.RFC3339),
+				"pr_ref":           "kubestellar/hive#42",
+				"pr_state":         "closed",
+				"ci_failure_count": "2",
+				"drift_pauses":     "1",
+			},
+			timeline: []timeline.Event{
+				{IssueRef: "kubestellar/hive#2809", Kind: timeline.KindKicked, At: base.Add(time.Hour).UnixMilli()},
+				{IssueRef: "kubestellar/hive#2809", Kind: timeline.KindKicked, At: base.Add(2 * time.Hour).UnixMilli()},
+			},
+			attempts: fakeAttempts{"kubestellar/hive#42": 3},
+			want: RetroRecord{
+				IssueRef:       "kubestellar/hive#2809",
+				PRRef:          "kubestellar/hive#42",
+				PRState:        "closed",
+				KicksReceived:  2,
+				CIFailureCount: 3,
+				FixAttempts:    3,
+				DriftPauses:    1,
+				ClaimToClose:   9 * 24 * time.Hour,
+			},
+		},
+		{
+			name: "timeline merged event supplies pr state and ref",
+			timeline: []timeline.Event{
+				{IssueRef: "kubestellar/hive#2810", Kind: timeline.KindKicked, At: base.Add(time.Hour).UnixMilli()},
+				{IssueRef: "kubestellar/hive#2810", Kind: timeline.KindMerged, At: base.Add(2 * time.Hour).UnixMilli(), Attrs: map[string]string{"pr_number": "77"}},
+				{IssueRef: "kubestellar/hive#2810", Kind: timeline.KindBlocked, At: base.Add(3 * time.Hour).UnixMilli(), Attrs: map[string]string{"trigger": "trajectory-review", "reason": "drift pause"}},
+			},
+			want: RetroRecord{
+				IssueRef:      "kubestellar/hive#2810",
+				PRRef:         "kubestellar/hive#77",
+				PRState:       "merged",
+				KicksReceived: 1,
+				DriftPauses:   1,
+				ClaimToClose:  9*24*time.Hour - time.Hour,
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newStore(t, tt.name+"-source")
+			b, err := store.Create("retro source", beads.TypeTask, beads.PriorityMedium, "scanner", tt.want.IssueRef)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := store.Update(b.ID, func(bd *beads.Bead) {
+				bd.Status = beads.StatusClosed
+				bd.Metadata = tt.metadata
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if err := store.Update(b.ID, func(bd *beads.Bead) { bd.ClosedAt = nil }); err != nil {
+				t.Fatal(err)
+			}
+			if err := store.SetMetadata(b.ID, "closed_at", base.Add(9*24*time.Hour).Format(time.RFC3339)); err != nil {
+				t.Fatal(err)
+			}
+			gotBead, err := store.Get(b.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tl := timeline.NewStoreWithCap(20)
+			for _, e := range tt.timeline {
+				tl.Record(e)
+			}
+			got := Reconstruct(gotBead, tl, tt.attempts)
+			if got.IssueRef != tt.want.IssueRef || got.PRRef != tt.want.PRRef || got.PRState != tt.want.PRState {
+				t.Fatalf("refs/state = (%q,%q,%q), want (%q,%q,%q)", got.IssueRef, got.PRRef, got.PRState, tt.want.IssueRef, tt.want.PRRef, tt.want.PRState)
+			}
+			if got.KicksReceived != tt.want.KicksReceived || got.CIFailureCount != tt.want.CIFailureCount || got.FixAttempts != tt.want.FixAttempts || got.DriftPauses != tt.want.DriftPauses {
+				t.Fatalf("counts = kicks %d ci %d fix %d drift %d, want kicks %d ci %d fix %d drift %d", got.KicksReceived, got.CIFailureCount, got.FixAttempts, got.DriftPauses, tt.want.KicksReceived, tt.want.CIFailureCount, tt.want.FixAttempts, tt.want.DriftPauses)
+			}
+			if got.ClaimToClose != tt.want.ClaimToClose {
+				t.Fatalf("claim-to-close = %s, want %s", got.ClaimToClose, tt.want.ClaimToClose)
+			}
+		})
+	}
+}
+
+func TestDetect(t *testing.T) {
+	thresholds := Thresholds{MaxFixAttempts: 3, MaxKicks: 5, LongStall: 7 * 24 * time.Hour}
+	cases := []struct {
+		name string
+		rec  RetroRecord
+		want []string
+	}{
+		{"none below thresholds", RetroRecord{PRRef: "o/r#1", FixAttempts: 2, KicksReceived: 4, ClaimToClose: 7 * 24 * time.Hour}, nil},
+		{"fix attempts at threshold", RetroRecord{BeadID: "b1", PRRef: "o/r#1", FixAttempts: 3}, []string{PatternExcessiveFixAttempts}},
+		{"kicks at threshold", RetroRecord{BeadID: "b2", PRRef: "o/r#2", KicksReceived: 5}, []string{PatternExcessiveKicks}},
+		{"long stall strictly greater", RetroRecord{BeadID: "b3", PRRef: "o/r#3", ClaimToClose: 7*24*time.Hour + time.Second}, []string{PatternLongStall}},
+		{"drift pause", RetroRecord{BeadID: "b4", PRRef: "o/r#4", DriftPauses: 1}, []string{PatternDriftPause}},
+		{"all patterns stable order", RetroRecord{BeadID: "b5", PRRef: "o/r#5", FixAttempts: 4, KicksReceived: 6, ClaimToClose: 8 * 24 * time.Hour, DriftPauses: 2}, []string{PatternExcessiveFixAttempts, PatternExcessiveKicks, PatternLongStall, PatternDriftPause}},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFindings := Detect(tt.rec, thresholds)
+			got := make([]string, len(gotFindings))
+			for i, f := range gotFindings {
+				got[i] = f.Pattern
+			}
+			if len(got) == 0 {
+				got = nil
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("patterns = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReconstructDoneBeadUsesUpdatedAtAsCompletion(t *testing.T) {
+	store := newStore(t, "done-updated-at")
+	claimed := time.Now().UTC().Add(-8 * 24 * time.Hour)
+	b, err := store.Create("done source", beads.TypeTask, beads.PriorityMedium, "scanner", "kubestellar/hive#2809")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Update(b.ID, func(bd *beads.Bead) {
+		bd.Status = beads.StatusDone
+		bd.Metadata = map[string]interface{}{
+			"claimed_at": claimed.Format(time.RFC3339),
+			"pr_ref":     "kubestellar/hive#42",
+			"pr_state":   "merged",
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	gotBead, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := Reconstruct(gotBead, nil, nil)
+	if got.ClosedAt.IsZero() {
+		t.Fatal("done bead should use UpdatedAt as completion time")
+	}
+	if got.ClaimToClose < 7*24*time.Hour {
+		t.Fatalf("claim-to-close = %s, want at least 7d", got.ClaimToClose)
+	}
+}
+
+func TestLaneFilesAdvisoryOnceAndMarksAnalyzed(t *testing.T) {
+	source := newStore(t, "lane-source")
+	retroStore := newStore(t, "lane-retro")
+	b, err := source.Create("hard issue", beads.TypeTask, beads.PriorityMedium, "scanner", "kubestellar/hive#2809")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := source.Update(b.ID, func(bd *beads.Bead) {
+		bd.Status = beads.StatusClosed
+		bd.Metadata = map[string]interface{}{
+			"pr_ref":       "kubestellar/hive#42",
+			"pr_state":     "merged",
+			"fix_attempts": "3",
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	lane := NewLane(map[string]*beads.Store{"scanner": source, Actor: retroStore}, retroStore, nil, nil, Config{ScanIntervalS: 1}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if created := lane.Run(context.Background()); created != 1 {
+		t.Fatalf("created = %d, want 1", created)
+	}
+	if created := lane.Run(context.Background()); created != 0 {
+		t.Fatalf("second run created = %d, want 0", created)
+	}
+	advisories := retroStore.List(beads.ListFilter{})
+	if len(advisories) != 1 {
+		t.Fatalf("advisories = %d, want 1", len(advisories))
+	}
+	if advisories[0].Actor != Actor || advisories[0].Type != beads.TypeAdvisory {
+		t.Fatalf("advisory bead actor/type = %s/%s", advisories[0].Actor, advisories[0].Type)
+	}
+	got, err := source.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Meta(metadataAnalyzedAt) == "" {
+		t.Fatalf("source bead missing %s", metadataAnalyzedAt)
+	}
+}
+
+func newStore(t *testing.T, name string) *beads.Store {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(wd, ".retro-test", sanitizeName(t.Name()+"-"+name))
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(wd, ".retro-test")) })
+	store, err := beads.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func sanitizeName(s string) string {
+	repl := strings.NewReplacer("/", "-", " ", "-", "#", "-")
+	return repl.Replace(s)
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -327,8 +327,9 @@ func (s *Scheduler) buildAgentListAndRoles() (list, roles string) {
 }
 
 type KickMessage struct {
-	Agent   string
-	Message string
+	Agent     string
+	Message   string
+	IssueRefs []string
 }
 
 func (s *Scheduler) BuildKickMessages(actionable *github.ActionableResult, agentsDue []string) []KickMessage {
@@ -349,12 +350,37 @@ func (s *Scheduler) BuildKickMessages(actionable *github.ActionableResult, agent
 				msg += "\n" + reposSection
 			}
 			messages = append(messages, KickMessage{
-				Agent:   agentName,
-				Message: msg,
+				Agent:     agentName,
+				Message:   msg,
+				IssueRefs: issueRefsForAgent(agentName, classifiedIssues),
 			})
 		}
 	}
 	return messages
+}
+
+func issueRefsForAgent(agentName string, issues []github.Issue) []string {
+	agentIssues := issues
+	if agentName != "scanner" {
+		agentIssues = filterByLane(issues, agentName)
+	}
+	if len(agentIssues) > maxIssuesPerKick {
+		agentIssues = agentIssues[:maxIssuesPerKick]
+	}
+	refs := make([]string, 0, len(agentIssues))
+	seen := make(map[string]bool, len(agentIssues))
+	for _, issue := range agentIssues {
+		if issue.Repo == "" || issue.Number <= 0 {
+			continue
+		}
+		ref := fmt.Sprintf("%s#%d", issue.Repo, issue.Number)
+		if seen[ref] {
+			continue
+		}
+		seen[ref] = true
+		refs = append(refs, ref)
+	}
+	return refs
 }
 
 // BuildAgentMessageFromLastActionable builds a kick message for the named


### PR DESCRIPTION
Part of #2809

## Summary
- Add opt-in deterministic retro lane that scans completed beads with closed/merged PR associations and files advisory beads as actor `retro`.
- Reconstruct compact retro records from bead metadata, lifecycle timeline kicks/PR events, and reachable escalation fix-attempt data.
- Add rule-based findings for fix attempts, kicks, long stalls, and trajectory drift pauses.
- Add `retro:` config, example YAML, tests, and design docs.

## Deferred
- LLM-powered retro analysis.
- Knowledge-graph lesson feeding.
- GitHub issue/comment posting.

## Validation
- `cd v2 && go build ./...`
- `cd v2 && go test ./pkg/retro/... ./pkg/beads ./pkg/config ./pkg/scheduler ./cmd/hive -count=1`
- `cd v2 && go vet ./pkg/retro ./pkg/beads ./pkg/config ./pkg/scheduler ./cmd/hive`