### PR TITLE
✨ feat(sandbox): credential-free sandbox runner + trusted push broker (phase 1)

### DIFF
--- a/v2/docs/sandbox-isolation.md
+++ b/v2/docs/sandbox-isolation.md
@@ -1,0 +1,26 @@
+# Credential-free sandbox isolation (phase 1)
+
+## Threat model
+
+Hive agents are untrusted code executors: prompts, tool output, and cloned repositories can all contain hostile instructions. The safe target is therefore **no credentials and no network inside the agent sandbox**. If an agent is compromised, it can only modify its mounted workspace; it cannot call GitHub directly, exfiltrate tokens, or bypass the outer MITM policy.
+
+## Phase-1 scope
+
+This phase adds the reusable plumbing, while tmux remains the default runner:
+
+- `pkg/sandbox` builds and runs rootless Podman specs with `--network=none`, `--userns=keep-id`, a workspace mount, and an explicit environment allowlist. GitHub/token-like environment variables are filtered even if requested.
+- `agent_sandbox:` is a disabled-by-default global config gate. Individual agents opt in with `agents.<name>.sandbox.enabled: true` plus optional image/env allowlist overrides.
+- `pkg/pushbroker` is the trusted post-step. It inspects committed workspace changes, rejects token-like secrets using the shared `logscrub` token detector, rejects guardrail-critical paths (`.github/workflows/`, gh wrapper paths, `policies/`, `OWNERS`), mints a short-lived scoped GitHub App token outside the workspace, and pushes with a sanitized environment.
+- Push broker results are structured for audit logs: repo, branch, commit, changed files, rejection reason, and push status. Tokens are never recorded.
+
+## Deferred wiring
+
+Full migration off tmux is intentionally deferred. The next phases should:
+
+1. Prepare per-kick workspaces for sandboxed agents instead of reusing long-lived tmux panes.
+2. Execute the agent kick through `pkg/sandbox.Launcher` and collect stdout/stderr/artifacts.
+3. Run `pkg/pushbroker.Broker` automatically after sandbox completion when commits exist on the work branch.
+4. Extend PR creation/commenting into the same trusted post-step so no GitHub credential is ever present in the sandbox.
+5. Add live Podman CI on a runner with rootless Podman available; current package tests skip live execution when Podman is absent.
+
+This keeps phase 1 safe and reviewable: the security-critical broker and sandbox contract are complete and tested, while production agents continue to use the existing tmux path unless explicitly wired in a later phase.

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -59,6 +59,9 @@ type Config struct {
 	Escalation EscalationConfig `yaml:"escalation,omitempty" json:"escalation,omitempty"`
 	Retro      RetroConfig      `yaml:"retro,omitempty" json:"retro,omitempty"`
 	Review     ReviewConfig     `yaml:"review,omitempty" json:"review,omitempty"`
+	// AgentSandbox configures the phase-1 credential-free sandbox runner. It is
+	// disabled by default and agents must opt in individually.
+	AgentSandbox AgentSandboxConfig `yaml:"agent_sandbox,omitempty" json:"agent_sandbox,omitempty"`
 
 	// RemovedAgents are agent names an operator deliberately deleted. It is a
 	// TOMBSTONE list, and it exists because deletion had no durable record
@@ -171,6 +174,21 @@ type MintConfig struct {
 	// MaxTTLSeconds bounds a minted token's lifetime. 0 uses the package default
 	// (15m). The value is clamped to the package hard cap (1h) regardless.
 	MaxTTLSeconds int `yaml:"max_ttl_seconds,omitempty"`
+}
+
+// AgentSandboxConfig controls the podman-rootless sandbox launcher. The top-
+// level block is a global gate; per-agent config can opt specific agents in.
+type AgentSandboxConfig struct {
+	Enabled      bool     `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Image        string   `yaml:"image,omitempty" json:"image,omitempty"`
+	EnvAllowlist []string `yaml:"env_allowlist,omitempty" json:"env_allowlist,omitempty"`
+}
+
+// AgentSandboxOverride is the per-agent sandbox opt-in block.
+type AgentSandboxOverride struct {
+	Enabled      *bool    `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Image        string   `yaml:"image,omitempty" json:"image,omitempty"`
+	EnvAllowlist []string `yaml:"env_allowlist,omitempty" json:"env_allowlist,omitempty"`
 }
 
 // IoscanConfig gates the pkg/ioscan input/output security scanner (prompt-
@@ -678,6 +696,9 @@ type AgentConfig struct {
 	Mode             string                  `yaml:"mode" json:"mode,omitempty"`
 	OnDemand         bool                    `yaml:"on_demand" json:"on_demand,omitempty"`
 	CavemanMode      string                  `yaml:"caveman_mode" json:"caveman_mode,omitempty"`
+	// Sandbox opts this agent into phase-1 sandbox execution when the global
+	// agent_sandbox.enabled gate is also true.
+	Sandbox *AgentSandboxOverride `yaml:"sandbox,omitempty" json:"sandbox,omitempty"`
 
 	// Channels declares how this agent gets triggered (kick, webhook, discord, schedule, bead).
 	// When nil/empty, the agent uses governor timer kicks by default (implicit kick channel).
@@ -744,6 +765,32 @@ func (a *AgentConfig) ShouldIncludeRepos() bool {
 		return *a.IncludeRepos
 	}
 	return true
+}
+
+// SandboxEnabled reports whether an agent's per-agent sandbox block opts it in
+// under the global phase-1 gate.
+func (a *AgentConfig) SandboxEnabled(global AgentSandboxConfig) bool {
+	if !global.Enabled || a == nil || a.Sandbox == nil || a.Sandbox.Enabled == nil {
+		return false
+	}
+	return *a.Sandbox.Enabled
+}
+
+// SandboxImage returns the per-agent image override, then the global default.
+func (a *AgentConfig) SandboxImage(global AgentSandboxConfig) string {
+	if a != nil && a.Sandbox != nil && a.Sandbox.Image != "" {
+		return a.Sandbox.Image
+	}
+	return global.Image
+}
+
+// SandboxEnvAllowlist returns the per-agent env allowlist when set; otherwise
+// the global allowlist. Credentials are still filtered by pkg/sandbox.
+func (a *AgentConfig) SandboxEnvAllowlist(global AgentSandboxConfig) []string {
+	if a != nil && a.Sandbox != nil && len(a.Sandbox.EnvAllowlist) > 0 {
+		return append([]string(nil), a.Sandbox.EnvAllowlist...)
+	}
+	return append([]string(nil), global.EnvAllowlist...)
 }
 
 // GetBeadRole returns the bead role, defaulting to "worker".

--- a/v2/pkg/config/sandbox_config_test.go
+++ b/v2/pkg/config/sandbox_config_test.go
@@ -1,0 +1,32 @@
+package config
+
+import "testing"
+
+func TestAgentSandboxOptInRequiresGlobalGateAndAgentOverride(t *testing.T) {
+	yes := true
+	no := false
+	global := AgentSandboxConfig{Enabled: true, Image: "global", EnvAllowlist: []string{"PATH"}}
+	if (&AgentConfig{}).SandboxEnabled(global) {
+		t.Fatal("missing agent override enabled sandbox")
+	}
+	if (&AgentConfig{Sandbox: &AgentSandboxOverride{Enabled: &no}}).SandboxEnabled(global) {
+		t.Fatal("explicit false enabled sandbox")
+	}
+	if (&AgentConfig{Sandbox: &AgentSandboxOverride{Enabled: &yes}}).SandboxEnabled(AgentSandboxConfig{}) {
+		t.Fatal("global disabled enabled sandbox")
+	}
+	agent := &AgentConfig{Sandbox: &AgentSandboxOverride{Enabled: &yes, Image: "agent", EnvAllowlist: []string{"HOME"}}}
+	if !agent.SandboxEnabled(global) {
+		t.Fatal("agent opt-in was not honored")
+	}
+	if got := agent.SandboxImage(global); got != "agent" {
+		t.Fatalf("image=%q", got)
+	}
+	if got := agent.SandboxEnvAllowlist(global); len(got) != 1 || got[0] != "HOME" {
+		t.Fatalf("allowlist=%v", got)
+	}
+	plain := &AgentConfig{Sandbox: &AgentSandboxOverride{Enabled: &yes}}
+	if got := plain.SandboxImage(global); got != "global" {
+		t.Fatalf("global image=%q", got)
+	}
+}

--- a/v2/pkg/pushbroker/pushbroker.go
+++ b/v2/pkg/pushbroker/pushbroker.go
@@ -1,0 +1,285 @@
+// Package pushbroker performs the trusted, credentialed post-step for sandboxed agents.
+package pushbroker
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+	"github.com/kubestellar/hive/v2/pkg/logscrub"
+)
+
+const (
+	DefaultRemote = "origin"
+	DefaultTier   = "contributor"
+)
+
+var DefaultProtectedPaths = []string{
+	".github/workflows/",
+	"bin/gh-wrapper.sh",
+	"deploy/bin/gh-wrapper.sh",
+	"policies/",
+	"OWNERS",
+	".github/OWNERS",
+}
+
+var credentialEnvPrefixes = []string{
+	"GITHUB_TOKEN=", "GH_TOKEN=", "HIVE_GITHUB_TOKEN=", "COPILOT_GITHUB_TOKEN=",
+	"GIT_ASKPASS=", "SSH_ASKPASS=",
+}
+
+type TokenMinter interface {
+	MintPushToken(ctx context.Context, repo string) (string, error)
+}
+
+type CommandRunner interface {
+	Run(ctx context.Context, dir string, env []string, name string, args ...string) ([]byte, error)
+}
+
+type ExecRunner struct{}
+
+func (ExecRunner) Run(ctx context.Context, dir string, env []string, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	return cmd.CombinedOutput()
+}
+
+type GitHubAppMinter struct {
+	Auth *ghpkg.AppAuth
+	Tier string
+}
+
+func (m GitHubAppMinter) MintPushToken(ctx context.Context, repo string) (string, error) {
+	if m.Auth == nil {
+		return "", errors.New("pushbroker: nil GitHub App auth")
+	}
+	tier := strings.TrimSpace(m.Tier)
+	if tier == "" {
+		tier = DefaultTier
+	}
+	repos := []string(nil)
+	if _, name, ok := strings.Cut(strings.TrimSpace(repo), "/"); ok && name != "" {
+		repos = []string{name}
+	}
+	return m.Auth.ScopedTokenForRepos(ctx, tier, repos)
+}
+
+type Broker struct {
+	Workspace      string
+	Branch         string
+	Repo           string
+	Remote         string
+	ProtectedPaths []string
+	Minter         TokenMinter
+	Runner         CommandRunner
+	Logger         *slog.Logger
+	Now            func() time.Time
+}
+
+type Result struct {
+	Workspace       string    `json:"workspace"`
+	Repo            string    `json:"repo"`
+	Branch          string    `json:"branch"`
+	Remote          string    `json:"remote"`
+	Commit          string    `json:"commit,omitempty"`
+	ChangedFiles    []string  `json:"changed_files,omitempty"`
+	ProtectedReject []string  `json:"protected_reject,omitempty"`
+	SecretRejected  bool      `json:"secret_rejected"`
+	Pushed          bool      `json:"pushed"`
+	Error           string    `json:"error,omitempty"`
+	StartedAt       time.Time `json:"started_at"`
+	FinishedAt      time.Time `json:"finished_at"`
+}
+
+func (b *Broker) Run(ctx context.Context) (Result, error) {
+	res := Result{Workspace: b.Workspace, Repo: b.Repo, Branch: b.Branch, Remote: b.remote(), StartedAt: b.now()}
+	defer func() { res.FinishedAt = b.now() }()
+	if err := b.validate(); err != nil {
+		res.Error = err.Error()
+		return res, err
+	}
+	commit, err := b.git(ctx, "rev-parse", "HEAD")
+	if err != nil {
+		return b.fail(res, fmt.Errorf("reading HEAD: %w", err))
+	}
+	res.Commit = strings.TrimSpace(string(commit))
+
+	files, err := b.changedFiles(ctx)
+	if err != nil {
+		return b.fail(res, err)
+	}
+	res.ChangedFiles = files
+	if len(files) == 0 {
+		return b.fail(res, errors.New("pushbroker: no committed changes to push"))
+	}
+	if rejected := ProtectedPathViolations(files, b.protectedPaths()); len(rejected) > 0 {
+		res.ProtectedReject = rejected
+		return b.fail(res, fmt.Errorf("pushbroker: protected paths changed: %s", strings.Join(rejected, ", ")))
+	}
+	diff, err := b.outgoingDiff(ctx)
+	if err != nil {
+		return b.fail(res, err)
+	}
+	if loc := logscrub.TokenPattern.FindString(diff); loc != "" {
+		res.SecretRejected = true
+		return b.fail(res, errors.New("pushbroker: outgoing diff contains a token-like secret"))
+	}
+	token, err := b.Minter.MintPushToken(ctx, b.Repo)
+	if err != nil {
+		return b.fail(res, fmt.Errorf("minting push token: %w", err))
+	}
+	if strings.TrimSpace(token) == "" {
+		return b.fail(res, errors.New("pushbroker: minter returned empty token"))
+	}
+	args := []string{"-c", "http.extraHeader=Authorization: Bearer " + token, "push", b.remote(), "HEAD:refs/heads/" + b.Branch}
+	if _, err := b.runner().Run(ctx, b.Workspace, PushEnv(os.Environ()), "git", args...); err != nil {
+		return b.fail(res, fmt.Errorf("git push failed: %w", err))
+	}
+	res.Pushed = true
+	return res, nil
+}
+
+func (b *Broker) validate() error {
+	if strings.TrimSpace(b.Workspace) == "" || strings.TrimSpace(b.Branch) == "" || strings.TrimSpace(b.Repo) == "" {
+		return errors.New("pushbroker: workspace, branch, and repo are required")
+	}
+	if b.Minter == nil {
+		return errors.New("pushbroker: token minter is required")
+	}
+	info, err := os.Stat(b.Workspace)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("pushbroker: workspace is not a directory: %w", err)
+	}
+	gitDir := filepath.Join(b.Workspace, ".git")
+	if info, err := os.Stat(gitDir); err != nil || !info.IsDir() {
+		return fmt.Errorf("pushbroker: workspace is not a git repository")
+	}
+	return nil
+}
+
+func (b *Broker) changedFiles(ctx context.Context) ([]string, error) {
+	base := b.remoteRef()
+	if _, err := b.git(ctx, "rev-parse", "--verify", base); err == nil {
+		out, err := b.git(ctx, "diff", "--name-only", base+"...HEAD")
+		return splitLines(out), err
+	}
+	out, err := b.git(ctx, "diff-tree", "--root", "--no-commit-id", "--name-only", "-r", "HEAD")
+	return splitLines(out), err
+}
+
+func (b *Broker) outgoingDiff(ctx context.Context) (string, error) {
+	base := b.remoteRef()
+	if _, err := b.git(ctx, "rev-parse", "--verify", base); err == nil {
+		out, err := b.git(ctx, "diff", "--no-ext-diff", base+"...HEAD")
+		return string(out), err
+	}
+	out, err := b.git(ctx, "show", "--format=", "--no-ext-diff", "HEAD")
+	return string(out), err
+}
+
+func (b *Broker) git(ctx context.Context, args ...string) ([]byte, error) {
+	out, err := b.runner().Run(ctx, b.Workspace, PushEnv(os.Environ()), "git", args...)
+	if err != nil {
+		return out, fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}
+
+func (b *Broker) fail(res Result, err error) (Result, error) {
+	res.Error = err.Error()
+	res.FinishedAt = b.now()
+	if b.Logger != nil {
+		b.Logger.Warn("pushbroker rejected workspace", "repo", res.Repo, "branch", res.Branch, "error", err)
+	}
+	return res, err
+}
+
+func (b *Broker) runner() CommandRunner {
+	if b.Runner != nil {
+		return b.Runner
+	}
+	return ExecRunner{}
+}
+func (b *Broker) remote() string {
+	if b.Remote != "" {
+		return b.Remote
+	}
+	return DefaultRemote
+}
+func (b *Broker) remoteRef() string { return "refs/remotes/" + b.remote() + "/" + b.Branch }
+func (b *Broker) protectedPaths() []string {
+	if len(b.ProtectedPaths) > 0 {
+		return b.ProtectedPaths
+	}
+	return DefaultProtectedPaths
+}
+func (b *Broker) now() time.Time {
+	if b.Now != nil {
+		return b.Now()
+	}
+	return time.Now().UTC()
+}
+
+func PushEnv(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		blocked := false
+		for _, prefix := range credentialEnvPrefixes {
+			if strings.HasPrefix(entry, prefix) {
+				blocked = true
+				break
+			}
+		}
+		if !blocked {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+func ProtectedPathViolations(files, protected []string) []string {
+	var rejected []string
+	for _, file := range files {
+		clean := strings.TrimPrefix(filepath.ToSlash(filepath.Clean(file)), "./")
+		for _, guard := range protected {
+			g := strings.TrimPrefix(filepath.ToSlash(filepath.Clean(guard)), "./")
+			if strings.HasSuffix(guard, "/") || strings.HasSuffix(g, "/") {
+				g = strings.TrimSuffix(g, "/") + "/"
+				if strings.HasPrefix(clean, g) {
+					rejected = append(rejected, clean)
+					break
+				}
+				continue
+			}
+			if clean == g || strings.HasPrefix(clean, strings.TrimSuffix(g, "/")+"/") && strings.HasSuffix(guard, "/") {
+				rejected = append(rejected, clean)
+				break
+			}
+		}
+	}
+	return rejected
+}
+
+func splitLines(out []byte) []string {
+	trimmed := bytes.TrimSpace(out)
+	if len(trimmed) == 0 {
+		return nil
+	}
+	parts := strings.Split(string(trimmed), "\n")
+	files := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			files = append(files, p)
+		}
+	}
+	return files
+}

--- a/v2/pkg/pushbroker/pushbroker_test.go
+++ b/v2/pkg/pushbroker/pushbroker_test.go
@@ -1,0 +1,123 @@
+package pushbroker
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+type fakeMinter struct{ token string }
+
+func (f fakeMinter) MintPushToken(context.Context, string) (string, error) { return f.token, nil }
+
+type recordingRunner struct {
+	envOnPush  []string
+	argsOnPush []string
+}
+
+func (r *recordingRunner) Run(ctx context.Context, dir string, env []string, name string, args ...string) ([]byte, error) {
+	if name == "git" && slices.Contains(args, "push") {
+		r.envOnPush = append([]string(nil), env...)
+		r.argsOnPush = append([]string(nil), args...)
+		return []byte("ok"), nil
+	}
+	return ExecRunner{}.Run(ctx, dir, env, name, args...)
+}
+
+func TestBrokerRejectsTokenLikeSecretInOutgoingDiff(t *testing.T) {
+	dir := initRepo(t)
+	writeCommit(t, dir, "secret.txt", "token=ghp_abcdefghijklmnopqrstuvwxyz\n")
+	res, err := (&Broker{Workspace: dir, Branch: "work", Repo: "kubestellar/hive", Minter: fakeMinter{"ghs_pushbroker"}}).Run(context.Background())
+	if err == nil {
+		t.Fatal("expected secret rejection")
+	}
+	if !res.SecretRejected {
+		t.Fatalf("SecretRejected=false, err=%v", err)
+	}
+}
+
+func TestBrokerRejectsProtectedPaths(t *testing.T) {
+	dir := initRepo(t)
+	writeCommit(t, dir, ".github/workflows/ci.yaml", "name: ci\n")
+	res, err := (&Broker{Workspace: dir, Branch: "work", Repo: "kubestellar/hive", Minter: fakeMinter{"ghs_pushbroker"}}).Run(context.Background())
+	if err == nil {
+		t.Fatal("expected protected path rejection")
+	}
+	if len(res.ProtectedReject) != 1 || res.ProtectedReject[0] != ".github/workflows/ci.yaml" {
+		t.Fatalf("ProtectedReject=%v", res.ProtectedReject)
+	}
+}
+
+func TestBrokerPushSanitizesCredentialEnvironmentAndWorkspace(t *testing.T) {
+	dir := initRepo(t)
+	writeCommit(t, dir, "safe.txt", "hello\n")
+	r := &recordingRunner{}
+	t.Setenv("GITHUB_TOKEN", "ghp_should_not_leave_hive")
+	t.Setenv("HIVE_GITHUB_TOKEN", "ghp_full_token")
+	res, err := (&Broker{Workspace: dir, Branch: "work", Repo: "kubestellar/hive", Minter: fakeMinter{"ghs_minted_push_token"}, Runner: r}).Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v (res=%+v)", err, res)
+	}
+	if !res.Pushed {
+		t.Fatal("Pushed=false")
+	}
+	for _, env := range r.envOnPush {
+		if strings.Contains(env, "should_not_leave_hive") || strings.Contains(env, "full_token") || strings.HasPrefix(env, "GITHUB_TOKEN=") || strings.HasPrefix(env, "HIVE_GITHUB_TOKEN=") {
+			t.Fatalf("credential leaked into push env: %q", env)
+		}
+	}
+	filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		data, _ := os.ReadFile(path)
+		if strings.Contains(string(data), "ghs_minted_push_token") {
+			t.Fatalf("minted token written to workspace file %s", path)
+		}
+		return nil
+	})
+}
+
+func TestProtectedPathViolationsTable(t *testing.T) {
+	files := []string{"policies/guard.yaml", "OWNERS", "pkg/safe.go"}
+	got := ProtectedPathViolations(files, DefaultProtectedPaths)
+	if strings.Join(got, ",") != "policies/guard.yaml,OWNERS" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func initRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "work")
+	runGit(t, dir, "config", "user.email", "hive@example.com")
+	runGit(t, dir, "config", "user.name", "Hive Test")
+	return dir
+}
+
+func writeCommit(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	path := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", rel)
+	runGit(t, dir, "commit", "-m", "test")
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, out)
+	}
+}

--- a/v2/pkg/sandbox/sandbox.go
+++ b/v2/pkg/sandbox/sandbox.go
@@ -1,0 +1,146 @@
+// Package sandbox launches agent work in credential-free rootless Podman sandboxes.
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	DefaultWorkspaceMount = "/workspace"
+	PodmanBinary          = "podman"
+)
+
+var credentialEnvNames = map[string]struct{}{
+	"GITHUB_TOKEN": {}, "GH_TOKEN": {}, "HIVE_GITHUB_TOKEN": {}, "COPILOT_GITHUB_TOKEN": {},
+	"GIT_ASKPASS": {}, "SSH_ASKPASS": {},
+}
+
+type LaunchSpec struct {
+	Image          string
+	Name           string
+	Workspace      string
+	WorkspaceMount string
+	WorkDir        string
+	Command        []string
+	Env            map[string]string
+	EnvAllowlist   []string
+	NetworkNone    bool
+	ReadOnly       bool
+}
+
+type Result struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+type Launcher interface {
+	Run(ctx context.Context, spec LaunchSpec) (Result, error)
+}
+
+type PodmanLauncher struct{ Binary string }
+
+func (l PodmanLauncher) Run(ctx context.Context, spec LaunchSpec) (Result, error) {
+	bin := l.Binary
+	if bin == "" {
+		bin = PodmanBinary
+	}
+	if _, err := exec.LookPath(bin); err != nil {
+		return Result{}, fmt.Errorf("sandbox: podman is required but was not found in PATH: %w", err)
+	}
+	args, err := PodmanArgs(spec)
+	if err != nil {
+		return Result{}, err
+	}
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Env = SanitizedEnv(os.Environ(), spec.EnvAllowlist, spec.Env)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	res := Result{Stdout: stdout.String(), Stderr: stderr.String()}
+	if cmd.ProcessState != nil {
+		res.ExitCode = cmd.ProcessState.ExitCode()
+	}
+	if err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+func PodmanArgs(spec LaunchSpec) ([]string, error) {
+	if strings.TrimSpace(spec.Image) == "" {
+		return nil, errors.New("sandbox: image is required")
+	}
+	if strings.TrimSpace(spec.Workspace) == "" {
+		return nil, errors.New("sandbox: workspace is required")
+	}
+	mount := spec.WorkspaceMount
+	if mount == "" {
+		mount = DefaultWorkspaceMount
+	}
+	workdir := spec.WorkDir
+	if workdir == "" {
+		workdir = mount
+	}
+	args := []string{"run", "--rm"}
+	if spec.Name != "" {
+		args = append(args, "--name", spec.Name)
+	}
+	if spec.NetworkNone {
+		args = append(args, "--network=none")
+	}
+	if spec.ReadOnly {
+		args = append(args, "--read-only")
+	}
+	args = append(args, "--userns=keep-id")
+	args = append(args, "-v", filepath.Clean(spec.Workspace)+":"+mount+":Z")
+	args = append(args, "--workdir", workdir)
+	for k, v := range spec.Env {
+		if !isCredentialName(k) {
+			args = append(args, "--env", k+"="+v)
+		}
+	}
+	args = append(args, spec.Image)
+	args = append(args, spec.Command...)
+	return args, nil
+}
+
+func SanitizedEnv(base []string, allowlist []string, explicit map[string]string) []string {
+	allowed := map[string]struct{}{}
+	for _, key := range allowlist {
+		if !isCredentialName(key) {
+			allowed[key] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(allowed)+len(explicit))
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok || isCredentialName(key) {
+			continue
+		}
+		if _, ok := allowed[key]; ok {
+			out = append(out, entry)
+		}
+	}
+	for key, value := range explicit {
+		if !isCredentialName(key) {
+			out = append(out, key+"="+value)
+		}
+	}
+	return out
+}
+
+func Available() bool { _, err := exec.LookPath(PodmanBinary); return err == nil }
+
+func isCredentialName(name string) bool {
+	_, ok := credentialEnvNames[name]
+	return ok || strings.Contains(name, "TOKEN") || strings.Contains(name, "SECRET")
+}

--- a/v2/pkg/sandbox/sandbox_test.go
+++ b/v2/pkg/sandbox/sandbox_test.go
@@ -1,0 +1,46 @@
+package sandbox
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestPodmanArgsUseCredentialFreeNetworklessDefaults(t *testing.T) {
+	args, err := PodmanArgs(LaunchSpec{Image: "agent:latest", Workspace: "/workspace-src", Command: []string{"echo", "ok"}, NetworkNone: true, Env: map[string]string{"SAFE": "1", "GITHUB_TOKEN": "nope"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(args, " ")
+	for _, want := range []string{"--network=none", "--userns=keep-id", "-v /workspace-src:/workspace:Z", "--workdir /workspace", "agent:latest", "echo ok"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("args %q missing %q", joined, want)
+		}
+	}
+	if strings.Contains(joined, "GITHUB_TOKEN") || strings.Contains(joined, "nope") {
+		t.Fatalf("credential env in args: %q", joined)
+	}
+}
+
+func TestSanitizedEnvAllowlistDropsCredentials(t *testing.T) {
+	env := SanitizedEnv([]string{"PATH=/bin", "HOME=/home/dev", "GITHUB_TOKEN=secret", "MY_TOKEN=secret"}, []string{"PATH", "HOME", "GITHUB_TOKEN", "MY_TOKEN"}, map[string]string{"SAFE": "1", "GH_TOKEN": "nope"})
+	if !slices.Contains(env, "PATH=/bin") || !slices.Contains(env, "HOME=/home/dev") || !slices.Contains(env, "SAFE=1") {
+		t.Fatalf("missing allowed env: %v", env)
+	}
+	for _, entry := range env {
+		if strings.Contains(entry, "secret") || strings.HasPrefix(entry, "GITHUB_TOKEN=") || strings.HasPrefix(entry, "GH_TOKEN=") || strings.HasPrefix(entry, "MY_TOKEN=") {
+			t.Fatalf("credential leaked: %v", env)
+		}
+	}
+}
+
+func TestPodmanRunSkippedWhenUnavailable(t *testing.T) {
+	if !Available() {
+		t.Skip("podman not available")
+	}
+	res, err := (PodmanLauncher{}).Run(context.Background(), LaunchSpec{Image: "docker.io/library/alpine:latest", Workspace: t.TempDir(), Command: []string{"sh", "-c", "test -d /workspace"}, NetworkNone: true})
+	if err != nil {
+		t.Fatalf("Run: %v stderr=%s", err, res.Stderr)
+	}
+}


### PR DESCRIPTION
Part of #2804.

## Summary
- add pkg/pushbroker trusted post-step for secret scan, protected-path rejection, scoped token push, and structured audit result
- add pkg/sandbox rootless Podman launcher abstraction with network-none specs and env allowlist sanitization
- add disabled-by-default agent_sandbox config gate with per-agent opt-in helpers
- document phase-1 threat model and follow-up wiring plan

## Deferred wiring
- tmux remains the default runner in this phase
- per-kick workspace preparation and automatic sandbox execution are deferred
- trusted PR/comment creation after sandbox completion is deferred
- live Podman CI is deferred beyond skip-when-absent package tests

## Validation
- cd v2 && go build ./...
- cd v2 && go test ./pkg/pushbroker/... ./pkg/sandbox/... ./pkg/config -count=1
- cd v2 && go vet ./pkg/pushbroker/... ./pkg/sandbox/... ./pkg/config