### PR TITLE
✨ feat(intent): tier-based change authorization gating merge eligibility

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/github"
 	"github.com/kubestellar/hive/v2/pkg/governor"
 	"github.com/kubestellar/hive/v2/pkg/hub"
+	"github.com/kubestellar/hive/v2/pkg/intent"
 	"github.com/kubestellar/hive/v2/pkg/knowledge"
 	"github.com/kubestellar/hive/v2/pkg/logscrub"
 	"github.com/kubestellar/hive/v2/pkg/mint"
@@ -4275,7 +4276,8 @@ func runEvalCycle(
 
 	escalatedPRs := runEscalationSweep(ctx, cfg, ghClient, actionable, notifier, logger)
 
-	writeMergeEligible(actionable, actionable.Hold, cfg.Project.Org, escalatedPRs, logger)
+	intentVerdicts := writeIntentVerdicts(ctx, cfg, ghClient, actionable, beadStores, logger)
+	writeMergeEligible(actionable, actionable.Hold, cfg.Project.Org, escalatedPRs, cfg.Intent.Enforce, intentVerdicts, logger)
 
 	// Stuck-PR reaper (backstop): re-dispatch a fix for any hive-authored PR
 	// that is red on a required check AND stale (its red head SHA unchanged past
@@ -5323,7 +5325,10 @@ func runEscalationSweep(
 // mergeTargetEligible at a temp file; production never reassigns it.
 var mergeEligiblePath = "/var/run/hive-metrics/merge-eligible.json"
 
-const ciFailingPath = "/var/run/hive-metrics/ci-failing.json"
+const (
+	ciFailingPath      = "/var/run/hive-metrics/ci-failing.json"
+	intentVerdictsPath = "/var/run/hive-metrics/intent-verdicts.json"
+)
 
 // acmmHoldGatedMinLevel / acmmHoldGatedMaxLevel bracket the ACMM levels whose
 // merge policy is "hold-gated" — every agent-opened PR gets a "hold" label and
@@ -5532,7 +5537,202 @@ func claimingPRRedStale(cfg *config.Config, actionable *github.ActionableResult)
 	}
 }
 
-func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldResult, org string, escalatedPRs map[string]bool, logger *slog.Logger) {
+func writeIntentVerdicts(
+	ctx context.Context,
+	cfg *config.Config,
+	ghClient *github.Client,
+	actionable *github.ActionableResult,
+	beadStores map[string]*beads.Store,
+	logger *slog.Logger,
+) map[string]intent.Verdict {
+	verdicts := make(map[string]intent.Verdict)
+	if cfg == nil || actionable == nil {
+		return verdicts
+	}
+	_ = os.MkdirAll("/var/run/hive-metrics", 0o755)
+	aiAuthor := strings.TrimSpace(cfg.EffectiveAIAuthor())
+	intentCfg := intent.Config{
+		TestPathPatterns:      cfg.Intent.TestPathPatterns,
+		DocsPathPatterns:      cfg.Intent.DocsPathPatterns,
+		GuardrailPathPatterns: cfg.Intent.GuardrailPathPatterns,
+		FeatureSignals:        cfg.Intent.FeatureSignals,
+	}
+	type verdictRecord struct {
+		Repo       string         `json:"repo"`
+		Number     int            `json:"number"`
+		Title      string         `json:"title"`
+		Author     string         `json:"author"`
+		Enforced   bool           `json:"enforced"`
+		Verdict    intent.Verdict `json:"verdict"`
+		Classify   string         `json:"classification_reason"`
+		FetchError string         `json:"fetch_error,omitempty"`
+	}
+	records := make([]verdictRecord, 0, len(actionable.PRs.Items))
+	for _, pr := range actionable.PRs.Items {
+		fullRepo := fullRepoName(pr.Repo, cfg.Project.Org)
+		key := fmt.Sprintf("%s/%d", fullRepo, pr.Number)
+		agentPR := aiAuthor != "" && strings.EqualFold(pr.Author, aiAuthor)
+		record := verdictRecord{
+			Repo:     fullRepo,
+			Number:   pr.Number,
+			Title:    pr.Title,
+			Author:   pr.Author,
+			Enforced: cfg.Intent.Enforce,
+		}
+		if !agentPR {
+			class := intent.Classify(intent.PR{Title: pr.Title, Labels: pr.Labels, Author: pr.Author, AgentAuthor: false}, intentCfg)
+			verdict := intent.Evaluate(class, intent.Evidence{})
+			verdicts[key] = verdict
+			record.Verdict = verdict
+			record.Classify = class.Reason
+			records = append(records, record)
+			continue
+		}
+		body, files, approved, err := fetchIntentPREvidence(ctx, ghClient, fullRepo, pr.Number)
+		if err != nil {
+			verdict := intent.Verdict{
+				Tier:       intent.Tier1,
+				Authorized: false,
+				Reason:     "intent evidence unavailable: " + err.Error(),
+				AgentPR:    true,
+			}
+			verdicts[key] = verdict
+			record.Verdict = verdict
+			record.FetchError = err.Error()
+			records = append(records, record)
+			logger.Warn("intent verification evidence fetch failed", "repo", fullRepo, "number", pr.Number, "error", err)
+			continue
+		}
+		class := intent.Classify(intent.PR{
+			Title:       pr.Title,
+			Body:        body,
+			Labels:      pr.Labels,
+			Files:       files,
+			Author:      pr.Author,
+			AgentAuthor: true,
+		}, intentCfg)
+		evidence := intent.BuildEvidenceForRepo(body, fullRepo, beadStores, approved)
+		verdict := intent.Evaluate(class, evidence)
+		verdicts[key] = verdict
+		record.Verdict = verdict
+		record.Classify = class.Reason
+		records = append(records, record)
+		if !verdict.Authorized {
+			logger.Info("intent authorization denied", "repo", fullRepo, "number", pr.Number, "tier", verdict.Tier, "reason", verdict.Reason, "enforce", cfg.Intent.Enforce)
+		}
+	}
+	payload := map[string]any{
+		"generated_at": time.Now().UTC().Format(time.RFC3339),
+		"enforced":     cfg.Intent.Enforce,
+		"verdicts":     records,
+	}
+	if data, err := json.Marshal(payload); err == nil {
+		atomicWrite(intentVerdictsPath, data)
+	} else {
+		logger.Warn("failed to marshal intent verdicts", "error", err)
+	}
+	return verdicts
+}
+
+func fetchIntentPREvidence(ctx context.Context, ghClient *github.Client, repo string, number int) (string, []intent.ChangedFile, bool, error) {
+	if ghClient == nil || ghClient.GoGitHub() == nil {
+		return "", nil, false, github.ErrNoGitHubClient
+	}
+	owner, repoName, ok := strings.Cut(repo, "/")
+	if !ok || owner == "" || repoName == "" {
+		return "", nil, false, fmt.Errorf("invalid repo %q", repo)
+	}
+	client := ghClient.GoGitHub()
+	pr, _, err := client.PullRequests.Get(ctx, owner, repoName, number)
+	if err != nil {
+		return "", nil, false, fmt.Errorf("getting PR: %w", err)
+	}
+	var files []intent.ChangedFile
+	fileOpts := &gh.ListOptions{PerPage: 100}
+	for {
+		page, resp, err := client.PullRequests.ListFiles(ctx, owner, repoName, number, fileOpts)
+		if err != nil {
+			return "", nil, false, fmt.Errorf("listing PR files: %w", err)
+		}
+		for _, f := range page {
+			files = append(files, intent.ChangedFile{
+				Filename:  f.GetFilename(),
+				Status:    f.GetStatus(),
+				Additions: f.GetAdditions(),
+				Deletions: f.GetDeletions(),
+			})
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		fileOpts.Page = resp.NextPage
+	}
+	approved, err := hasMaintainerApproval(ctx, client, owner, repoName, number)
+	if err != nil {
+		return "", nil, false, err
+	}
+	return pr.GetBody(), files, approved, nil
+}
+
+func hasMaintainerApproval(ctx context.Context, client *gh.Client, owner, repo string, number int) (bool, error) {
+	opts := &gh.ListOptions{PerPage: 100}
+	latest := make(map[string]string)
+	maintainer := make(map[string]bool)
+	for {
+		reviews, resp, err := client.PullRequests.ListReviews(ctx, owner, repo, number, opts)
+		if err != nil {
+			return false, fmt.Errorf("listing PR reviews: %w", err)
+		}
+		for _, review := range reviews {
+			login := review.GetUser().GetLogin()
+			if login == "" {
+				continue
+			}
+			if maintainerAssociation(review.GetAuthorAssociation()) {
+				switch review.GetState() {
+				case "APPROVED", "CHANGES_REQUESTED", "DISMISSED":
+					latest[login] = review.GetState()
+				}
+				maintainer[login] = true
+			}
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	approved := false
+	for login, state := range latest {
+		if !maintainer[login] {
+			continue
+		}
+		switch state {
+		case "CHANGES_REQUESTED":
+			return false, nil
+		case "APPROVED":
+			approved = true
+		}
+	}
+	return approved, nil
+}
+
+func maintainerAssociation(association string) bool {
+	switch strings.ToUpper(strings.TrimSpace(association)) {
+	case "OWNER", "MEMBER", "COLLABORATOR":
+		return true
+	default:
+		return false
+	}
+}
+
+func fullRepoName(repo, org string) string {
+	if strings.Contains(repo, "/") || org == "" {
+		return repo
+	}
+	return org + "/" + repo
+}
+
+func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldResult, org string, escalatedPRs map[string]bool, enforceIntent bool, intentVerdicts map[string]intent.Verdict, logger *slog.Logger) {
 	holdSet := make(map[string]bool)
 	for _, h := range hold.Items {
 		key := fmt.Sprintf("%s/%d", h.Repo, h.Number)
@@ -5583,9 +5783,12 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 		if holdSet[key] {
 			continue
 		}
-		fullRepo := pr.Repo
-		if !strings.Contains(fullRepo, "/") && org != "" {
-			fullRepo = org + "/" + fullRepo
+		fullRepo := fullRepoName(pr.Repo, org)
+		if enforceIntent {
+			if verdict, ok := intentVerdicts[fmt.Sprintf("%s/%d", fullRepo, pr.Number)]; ok && verdict.AgentPR && !verdict.Authorized {
+				logger.Info("excluding PR from merge-eligible due to intent authorization", "repo", fullRepo, "number", pr.Number, "tier", verdict.Tier, "reason", verdict.Reason)
+				continue
+			}
 		}
 
 		if pr.CIStatus == "failure" {

--- a/v2/docs/intent-verification.md
+++ b/v2/docs/intent-verification.md
@@ -1,0 +1,51 @@
+# Intent verification
+
+Intent verification adds a deterministic authorization layer between “CI is green” and “Hive may merge this PR”. Phase 1 classifies agent-authored PRs into change tiers, gathers authorization evidence, and reports a verdict for the merge gate. The trajectory-based intent-alignment diff review is deferred to a follow-up.
+
+## Change tiers
+
+| Tier | Change shape | Authorization rule |
+| --- | --- | --- |
+| Tier 0 | Additive docs-only or test-only changes (`*.md`, test directories, `*_test.go`, `*.test.*`, `*.spec.*`) | Pre-authorized |
+| Tier 1 | Bugfix/chore/default code changes, including test weakening | Requires a linked issue |
+| Tier 2 | Feature/enhancement changes | Requires an approved plan or maintainer approval |
+| Tier 3 | Strategic or guardrail-critical changes | Requires maintainer approval |
+
+Test-only changes are Tier 0 only when additive. Deleted test files or deleted lines in test files are treated as test weakening and escalated to Tier 1.
+
+Tier 3 applies when a PR touches guardrail-critical paths such as GitHub workflows, the `gh` wrapper, proxy rules, `policies/`, `hive.yaml`, `OWNERS`, or `CODEOWNERS`. These patterns have built-in defaults and can be overridden in configuration.
+
+## Evidence rules
+
+- **Linked issue**: a PR body closing reference such as `Fixes #123`, `Closes owner/repo#123`, or a bead with an external issue reference.
+- **Approved plan**: a bead lineage carrying `plan_status=approved`, matching the planning-intelligence plan-review record.
+- **Human approval**: an explicit `APPROVED` pull-request review from a maintainer association (`OWNER`, `MEMBER`, or `COLLABORATOR`).
+
+Authorization evaluates the tier and evidence into an `authorized` boolean plus a human-readable reason. Non-agent PRs are reported but are not gated by this phase.
+
+## Report-only vs enforce
+
+Intent verification is report-only by default. With no `intent:` block, Hive writes `/var/run/hive-metrics/intent-verdicts.json` and logs denials, but `merge-eligible.json` is unchanged.
+
+To enforce intent authorization in the merge gate:
+
+```yaml
+intent:
+  enforce: true
+```
+
+When enforcement is enabled, unauthorized agent-authored PRs are excluded from `/var/run/hive-metrics/merge-eligible.json`, so the merge relay denies them through the existing merge-eligible binding.
+
+Optional pattern overrides:
+
+```yaml
+intent:
+  test_path_patterns: ["**/*_test.go", "tests/**"]
+  docs_path_patterns: ["**/*.md"]
+  guardrail_path_patterns: [".github/workflows/**", "policies/**", "hive.yaml", "OWNERS", "CODEOWNERS"]
+  feature_signals: ["feat", "feature", "enhancement"]
+```
+
+## Deferred alignment check
+
+This phase does not compare the final diff against the issue, bead, or approved plan text. That trajectory-integrated intent-alignment check is intentionally deferred to a follow-up so Phase 1 remains deterministic and merge-gate focused.

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	Ioscan     IoscanConfig     `yaml:"ioscan,omitempty" json:"ioscan,omitempty"`
 	Classifier ClassifierConfig `yaml:"classifier,omitempty" json:"classifier,omitempty"`
 	Planning   PlanningConfig   `yaml:"planning,omitempty" json:"planning,omitempty"`
+	Intent     IntentConfig     `yaml:"intent,omitempty" json:"intent,omitempty"`
 	Escalation EscalationConfig `yaml:"escalation,omitempty" json:"escalation,omitempty"`
 
 	// RemovedAgents are agent names an operator deliberately deleted. It is a
@@ -222,6 +223,17 @@ type ClassifierConfig struct {
 	// ComplexSignals are title substrings that classify an issue as Tier
 	// "Complex" (→ opus). Empty keeps the built-in default set.
 	ComplexSignals []string `yaml:"complex_signals,omitempty" json:"complex_signals,omitempty"`
+}
+
+// IntentConfig controls intent-verification reporting and merge-gate
+// enforcement. The zero value is report-only with built-in path patterns, so an
+// absent intent: block preserves existing merge eligibility behavior.
+type IntentConfig struct {
+	Enforce               bool     `yaml:"enforce,omitempty" json:"enforce,omitempty"`
+	TestPathPatterns      []string `yaml:"test_path_patterns,omitempty" json:"test_path_patterns,omitempty"`
+	DocsPathPatterns      []string `yaml:"docs_path_patterns,omitempty" json:"docs_path_patterns,omitempty"`
+	GuardrailPathPatterns []string `yaml:"guardrail_path_patterns,omitempty" json:"guardrail_path_patterns,omitempty"`
+	FeatureSignals        []string `yaml:"feature_signals,omitempty" json:"feature_signals,omitempty"`
 }
 
 // VariablesConfig declares operator-defined ${VAR} substitutions and the trust

--- a/v2/pkg/intent/intent.go
+++ b/v2/pkg/intent/intent.go
@@ -1,0 +1,357 @@
+package intent
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/kubestellar/hive/v2/pkg/beads"
+)
+
+// Tier is the change-authorization tier assigned to an agent-authored PR.
+type Tier int
+
+const (
+	Tier0 Tier = iota
+	Tier1
+	Tier2
+	Tier3
+)
+
+const (
+	ReasonTier0Additive      = "tier 0 additive docs/test-only change"
+	ReasonTestWeakening      = "test weakening detected"
+	ReasonTier3Guardrail     = "guardrail-critical path touched"
+	ReasonTier2FeatureSignal = "feature signal detected"
+	ReasonTier1Default       = "bugfix/chore default"
+	ReasonLinkedIssue        = "linked issue evidence present"
+	ReasonApprovedPlan       = "approved plan evidence present"
+	ReasonHumanApproval      = "human approval evidence present"
+	ReasonTier3NeedsApproval = "tier 3 requires human approval"
+	ReasonTier2NeedsPlan     = "tier 2 requires approved plan or human approval"
+	ReasonTier1NeedsIssue    = "tier 1 requires linked issue"
+)
+
+const (
+	BeadPlanStatusKey      = "plan_status"
+	BeadPlanApprovedStatus = "approved"
+)
+
+const linkedIssuePattern = `(?i)\b(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?)\s+(?:(?:([\w.-]+/[\w.-]+)#)|#)(\d+)\b`
+
+var linkedIssueRE = regexp.MustCompile(linkedIssuePattern)
+
+var defaultTestPathPatterns = []string{
+	"**/*_test.go",
+	"**/*.test.*",
+	"**/*.spec.*",
+	"**/test/**",
+	"**/tests/**",
+	"test/**",
+	"tests/**",
+}
+
+var defaultDocsPathPatterns = []string{
+	"**/*.md",
+}
+
+var defaultGuardrailPathPatterns = []string{
+	".github/workflows/**",
+	"**/.github/workflows/**",
+	"**/gh-wrapper*",
+	"**/gh_wrapper*",
+	"**/proxy/rules*",
+	"policies/**",
+	"**/policies/**",
+	"hive.yaml",
+	"**/hive.yaml",
+	"OWNERS",
+	"**/OWNERS",
+	"CODEOWNERS",
+	"**/CODEOWNERS",
+	"**/CODEOWNERS/**",
+}
+
+var defaultFeatureSignals = []string{"feat", "feature", "enhancement", "new capability", "proposal", "rfc"}
+
+// Config customizes tier path matching. Empty slices keep sane defaults.
+type Config struct {
+	TestPathPatterns      []string
+	DocsPathPatterns      []string
+	GuardrailPathPatterns []string
+	FeatureSignals        []string
+}
+
+// ChangedFile is the PR file evidence used for tier classification.
+type ChangedFile struct {
+	Filename  string
+	Status    string
+	Additions int
+	Deletions int
+}
+
+type PR struct {
+	Title       string
+	Body        string
+	Labels      []string
+	Files       []ChangedFile
+	Author      string
+	AgentAuthor bool
+}
+
+type Classification struct {
+	Tier    Tier   `json:"tier"`
+	Reason  string `json:"reason"`
+	AgentPR bool   `json:"agent_pr"`
+}
+
+type Evidence struct {
+	LinkedIssue   bool
+	ApprovedPlan  bool
+	HumanApproval bool
+}
+
+type Verdict struct {
+	Tier       Tier     `json:"tier"`
+	Authorized bool     `json:"authorized"`
+	Reason     string   `json:"reason"`
+	Evidence   Evidence `json:"evidence"`
+	AgentPR    bool     `json:"agent_pr"`
+}
+
+func Classify(pr PR, cfg Config) Classification {
+	if !pr.AgentAuthor {
+		return Classification{Tier: Tier0, Reason: "non-agent PR", AgentPR: false}
+	}
+	cfg = withDefaults(cfg)
+	if touchesAny(pr.Files, cfg.GuardrailPathPatterns) {
+		return Classification{Tier: Tier3, Reason: ReasonTier3Guardrail, AgentPR: true}
+	}
+	if allDocsOrTests(pr.Files, cfg) {
+		if weakensTests(pr.Files, cfg.TestPathPatterns) {
+			return Classification{Tier: Tier1, Reason: ReasonTestWeakening, AgentPR: true}
+		}
+		return Classification{Tier: Tier0, Reason: ReasonTier0Additive, AgentPR: true}
+	}
+	if hasFeatureSignal(pr.Title, pr.Labels, cfg.FeatureSignals) {
+		return Classification{Tier: Tier2, Reason: ReasonTier2FeatureSignal, AgentPR: true}
+	}
+	return Classification{Tier: Tier1, Reason: ReasonTier1Default, AgentPR: true}
+}
+
+func Evaluate(class Classification, evidence Evidence) Verdict {
+	if !class.AgentPR {
+		return Verdict{Tier: class.Tier, Authorized: true, Reason: "non-agent PR not subject to intent authorization", Evidence: evidence, AgentPR: false}
+	}
+	switch class.Tier {
+	case Tier0:
+		return Verdict{Tier: class.Tier, Authorized: true, Reason: ReasonTier0Additive, Evidence: evidence, AgentPR: true}
+	case Tier1:
+		if evidence.LinkedIssue {
+			return Verdict{Tier: class.Tier, Authorized: true, Reason: ReasonLinkedIssue, Evidence: evidence, AgentPR: true}
+		}
+		return Verdict{Tier: class.Tier, Authorized: false, Reason: ReasonTier1NeedsIssue, Evidence: evidence, AgentPR: true}
+	case Tier2:
+		if evidence.ApprovedPlan {
+			return Verdict{Tier: class.Tier, Authorized: true, Reason: ReasonApprovedPlan, Evidence: evidence, AgentPR: true}
+		}
+		if evidence.HumanApproval {
+			return Verdict{Tier: class.Tier, Authorized: true, Reason: ReasonHumanApproval, Evidence: evidence, AgentPR: true}
+		}
+		return Verdict{Tier: class.Tier, Authorized: false, Reason: ReasonTier2NeedsPlan, Evidence: evidence, AgentPR: true}
+	case Tier3:
+		if evidence.HumanApproval {
+			return Verdict{Tier: class.Tier, Authorized: true, Reason: ReasonHumanApproval, Evidence: evidence, AgentPR: true}
+		}
+		return Verdict{Tier: class.Tier, Authorized: false, Reason: ReasonTier3NeedsApproval, Evidence: evidence, AgentPR: true}
+	default:
+		return Verdict{Tier: class.Tier, Authorized: false, Reason: fmt.Sprintf("unknown tier %d", class.Tier), Evidence: evidence, AgentPR: true}
+	}
+}
+
+func BuildEvidence(body string, stores map[string]*beads.Store, humanApproval bool) Evidence {
+	return BuildEvidenceForRepo(body, "", stores, humanApproval)
+}
+
+func BuildEvidenceForRepo(body, defaultRepo string, stores map[string]*beads.Store, humanApproval bool) Evidence {
+	refs := LinkedIssueRefs(body, defaultRepo)
+	linked := LinkedIssueInBody(body) || LinkedIssueInBeads(stores, refs)
+	return Evidence{LinkedIssue: linked, ApprovedPlan: ApprovedPlanInBeads(stores, refs), HumanApproval: humanApproval}
+}
+
+func LinkedIssueInBody(body string) bool { return linkedIssueRE.MatchString(body) }
+
+func LinkedIssueNumbers(body string) []int {
+	refs := LinkedIssueRefs(body, "")
+	out := make([]int, 0, len(refs))
+	for _, ref := range refs {
+		out = append(out, ref.Number)
+	}
+	return out
+}
+
+type IssueRef struct {
+	Repo   string
+	Number int
+}
+
+func LinkedIssueRefs(body, defaultRepo string) []IssueRef {
+	matches := linkedIssueRE.FindAllStringSubmatch(body, -1)
+	refs := make([]IssueRef, 0, len(matches))
+	for _, m := range matches {
+		if len(m) < 3 {
+			continue
+		}
+		n, err := strconv.Atoi(m[2])
+		if err == nil {
+			repo := strings.TrimSpace(m[1])
+			if repo == "" {
+				repo = strings.TrimSpace(defaultRepo)
+			}
+			refs = append(refs, IssueRef{Repo: repo, Number: n})
+		}
+	}
+	return refs
+}
+
+func LinkedIssueInBeads(stores map[string]*beads.Store, refs []IssueRef) bool {
+	if len(refs) == 0 {
+		return false
+	}
+	for _, b := range allBeads(stores) {
+		if externalRefMatchesIssue(b.ExternalRef, refs) {
+			return true
+		}
+	}
+	return false
+}
+
+func ApprovedPlanInBeads(stores map[string]*beads.Store, refs []IssueRef) bool {
+	if len(refs) == 0 {
+		return false
+	}
+	for _, b := range allBeads(stores) {
+		if b.Meta(BeadPlanStatusKey) == BeadPlanApprovedStatus && externalRefMatchesIssue(b.ExternalRef, refs) {
+			return true
+		}
+	}
+	return false
+}
+
+func externalRefMatchesIssue(ref string, refs []IssueRef) bool {
+	ref = strings.TrimPrefix(strings.TrimSpace(ref), "gh-")
+	for _, issue := range refs {
+		suffix := "#" + strconv.Itoa(issue.Number)
+		if issue.Repo != "" {
+			suffix = strings.TrimSpace(issue.Repo) + suffix
+		}
+		if strings.HasSuffix(ref, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func withDefaults(cfg Config) Config {
+	if len(cfg.TestPathPatterns) == 0 {
+		cfg.TestPathPatterns = defaultTestPathPatterns
+	}
+	if len(cfg.DocsPathPatterns) == 0 {
+		cfg.DocsPathPatterns = defaultDocsPathPatterns
+	}
+	if len(cfg.GuardrailPathPatterns) == 0 {
+		cfg.GuardrailPathPatterns = defaultGuardrailPathPatterns
+	}
+	if len(cfg.FeatureSignals) == 0 {
+		cfg.FeatureSignals = defaultFeatureSignals
+	}
+	return cfg
+}
+
+func allDocsOrTests(files []ChangedFile, cfg Config) bool {
+	if len(files) == 0 {
+		return false
+	}
+	for _, f := range files {
+		if !matchesAny(f.Filename, cfg.DocsPathPatterns) && !matchesAny(f.Filename, cfg.TestPathPatterns) {
+			return false
+		}
+	}
+	return true
+}
+
+func weakensTests(files []ChangedFile, testPatterns []string) bool {
+	for _, f := range files {
+		if matchesAny(f.Filename, testPatterns) && (strings.EqualFold(f.Status, "removed") || f.Deletions > 0) {
+			return true
+		}
+	}
+	return false
+}
+
+func touchesAny(files []ChangedFile, patterns []string) bool {
+	for _, f := range files {
+		if matchesAny(f.Filename, patterns) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasFeatureSignal(title string, labels, signals []string) bool {
+	haystack := strings.ToLower(title + " " + strings.Join(labels, " "))
+	for _, signal := range signals {
+		if s := strings.ToLower(strings.TrimSpace(signal)); s != "" && strings.Contains(haystack, s) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesAny(path string, patterns []string) bool {
+	path = filepath.ToSlash(strings.TrimPrefix(path, "./"))
+	for _, pattern := range patterns {
+		if globMatch(filepath.ToSlash(pattern), path) {
+			return true
+		}
+	}
+	return false
+}
+
+func globMatch(pattern, path string) bool {
+	if ok, _ := filepath.Match(pattern, path); ok {
+		return true
+	}
+	if strings.HasPrefix(pattern, "**/*") {
+		return strings.HasSuffix(path, strings.TrimPrefix(pattern, "**/*"))
+	}
+	if strings.HasPrefix(pattern, "**/") {
+		trimmed := strings.TrimPrefix(pattern, "**/")
+		if ok, _ := filepath.Match(trimmed, path); ok {
+			return true
+		}
+		return globMatch(trimmed, path)
+	}
+	if strings.HasSuffix(pattern, "/**") {
+		prefix := strings.TrimSuffix(pattern, "/**")
+		return path == prefix || strings.HasPrefix(path, prefix+"/") || strings.Contains(path, "/"+prefix+"/")
+	}
+	if strings.Contains(pattern, "**/") {
+		parts := strings.SplitN(pattern, "**/", 2)
+		return strings.HasPrefix(path, parts[0]) && strings.Contains(path, strings.TrimPrefix(parts[1], "/"))
+	}
+	return false
+}
+
+func allBeads(stores map[string]*beads.Store) []*beads.Bead {
+	var out []*beads.Bead
+	for _, store := range stores {
+		if store == nil {
+			continue
+		}
+		out = append(out, store.List(beads.ListFilter{})...)
+	}
+	return out
+}

--- a/v2/pkg/intent/intent_test.go
+++ b/v2/pkg/intent/intent_test.go
@@ -1,0 +1,83 @@
+package intent
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/beads"
+)
+
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		name string
+		pr   PR
+		want Tier
+	}{
+		{"docs only", PR{AgentAuthor: true, Files: []ChangedFile{{Filename: "docs/readme.md", Additions: 3}}}, Tier0},
+		{"test additive", PR{AgentAuthor: true, Files: []ChangedFile{{Filename: "pkg/foo/foo_test.go", Additions: 8}}}, Tier0},
+		{"test deletion escalates", PR{AgentAuthor: true, Files: []ChangedFile{{Filename: "pkg/foo/foo_test.go", Additions: 1, Deletions: 1}}}, Tier1},
+		{"removed test escalates", PR{AgentAuthor: true, Files: []ChangedFile{{Filename: "tests/e2e_test.go", Status: "removed"}}}, Tier1},
+		{"guardrail workflow", PR{AgentAuthor: true, Files: []ChangedFile{{Filename: ".github/workflows/ci.yml"}}}, Tier3},
+		{"guardrail owners", PR{AgentAuthor: true, Files: []ChangedFile{{Filename: "OWNERS"}}}, Tier3},
+		{"feature label", PR{AgentAuthor: true, Title: "add widget", Labels: []string{"enhancement"}, Files: []ChangedFile{{Filename: "pkg/widget/widget.go"}}}, Tier2},
+		{"default bugfix chore", PR{AgentAuthor: true, Files: []ChangedFile{{Filename: "pkg/foo/foo.go"}}}, Tier1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Classify(tt.pr, Config{}); got.Tier != tt.want {
+				t.Fatalf("Tier = %d (%s), want %d", got.Tier, got.Reason, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvaluate(t *testing.T) {
+	tests := []struct {
+		name string
+		tier Tier
+		ev   Evidence
+		want bool
+	}{
+		{"tier0 allowed", Tier0, Evidence{}, true},
+		{"tier1 needs issue", Tier1, Evidence{}, false},
+		{"tier1 linked issue", Tier1, Evidence{LinkedIssue: true}, true},
+		{"tier2 needs plan", Tier2, Evidence{LinkedIssue: true}, false},
+		{"tier2 approved plan", Tier2, Evidence{ApprovedPlan: true}, true},
+		{"tier2 human approval", Tier2, Evidence{HumanApproval: true}, true},
+		{"tier3 ignores plan", Tier3, Evidence{ApprovedPlan: true}, false},
+		{"tier3 human approval", Tier3, Evidence{HumanApproval: true}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Evaluate(Classification{Tier: tt.tier, AgentPR: true}, tt.ev)
+			if got.Authorized != tt.want {
+				t.Fatalf("Authorized = %v (%s), want %v", got.Authorized, got.Reason, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvidence(t *testing.T) {
+	if !LinkedIssueInBody("Fixes #2803") || !LinkedIssueInBody("Closes kubestellar/hive#2803") {
+		t.Fatal("expected closing issue refs to be detected")
+	}
+	store, err := beads.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	epic, _ := store.Create("epic", beads.TypeEpic, beads.PriorityHigh, "architect", "gh-kubestellar/hive#2803")
+	if err := store.SetMetadata(epic.ID, BeadPlanStatusKey, BeadPlanApprovedStatus); err != nil {
+		t.Fatal(err)
+	}
+	ev := BuildEvidenceForRepo("Fixes #2803", "kubestellar/hive", map[string]*beads.Store{"architect": store}, false)
+	if !ev.LinkedIssue || !ev.ApprovedPlan {
+		t.Fatalf("evidence = %+v, want linked issue and approved plan", ev)
+	}
+	unrelated := BuildEvidenceForRepo("Fixes #9999", "kubestellar/hive", map[string]*beads.Store{"architect": store}, false)
+	if unrelated.ApprovedPlan {
+		t.Fatalf("unrelated approved plan should not authorize PR evidence: %+v", unrelated)
+	}
+	otherRepoSameNumber := BuildEvidenceForRepo("Fixes #2803", "other/repo", map[string]*beads.Store{"architect": store}, false)
+	if otherRepoSameNumber.ApprovedPlan {
+		t.Fatalf("same issue number in another repo should not match approved plan: %+v", otherRepoSameNumber)
+	}
+}


### PR DESCRIPTION
Part of #2803.

## Summary
- Add v2/pkg/intent with tier classification for agent-authored PRs and authorization evaluation.
- Emit intent-verdicts.json from the merge-gate path and exclude unauthorized agent PRs from merge-eligible.json only when intent.enforce is true.
- Add docs for tiers, evidence rules, report-only vs enforce mode, and note that intent-alignment diff checking is deferred.

## Validation
- cd v2 && go build ./...
- cd v2 && go test ./pkg/intent ./cmd/hive ./pkg/config -count=1
- cd v2 && go vet ./pkg/intent ./cmd/hive ./pkg/config

Intent-alignment diff checking / trajectory integration remains a follow-up.