### PR TITLE
✨ feat(tracing): optional OTLP export with GenAI semconv

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -920,20 +920,24 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Initialize OpenTelemetry tracing. Off by default: with no tracing block
-	// (or tracing.enabled=false) this installs a no-op provider with zero
-	// export overhead. Never fatal — a tracing setup error must not stop hive.
+	// Initialize OpenTelemetry tracing. Off by default: with no otel block
+	// (or otel.enabled=false) this installs a no-op provider with zero export
+	// overhead. Never fatal — a tracing setup error must not stop hive.
+	otelCfg := cfg.EffectiveOTel()
 	traceShutdown, traceErr := tracing.Init(ctx, tracing.Config{
-		Enabled:     cfg.Tracing.Enabled,
-		Endpoint:    cfg.Tracing.Endpoint,
-		SampleRatio: cfg.Tracing.SampleRatio,
+		Enabled:     otelCfg.Enabled,
+		Endpoint:    otelCfg.Endpoint,
+		Headers:     otelCfg.Headers,
+		ServiceName: otelCfg.ServiceNameOrDefault(),
+		Insecure:    otelCfg.Insecure,
+		SampleRatio: otelCfg.SampleRatio,
 		HiveID:      cfg.HiveID,
 		Branch:      cfg.Policies.Branch,
 	})
 	if traceErr != nil {
 		logger.Warn("tracing init failed; continuing without tracing", "error", traceErr)
-	} else if cfg.Tracing.Enabled {
-		logger.Info("tracing enabled", "endpoint", cfg.Tracing.Endpoint)
+	} else if otelCfg.Enabled {
+		logger.Info("otel tracing enabled", "endpoint", otelCfg.Endpoint, "service_name", otelCfg.ServiceNameOrDefault())
 	}
 	defer func() {
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), traceShutdownTimeout)
@@ -4053,10 +4057,12 @@ type lifecycleRecorder interface {
 // Record itself is nil-safe. This must never slow or break the eval loop, so it
 // does no I/O and touches only the in-memory bounded ring.
 //
-// TODO(timeline-pr): also record KindPROpened / KindMerged once the eval loop
-// has cheap access to per-issue PR-open and merge transitions (the enumerate
-// result exposes open PRs but not the open→merged edge without extra state).
-func recordEnumeratedIssues(rec lifecycleRecorder, actionable *github.ActionableResult) {
+// PR-open/merge lifecycle spans are emitted by the same tracing mapper when
+// callers record those timeline events; this helper only has enumerated issues.
+func recordEnumeratedIssues(ctx context.Context, rec lifecycleRecorder, actionable *github.ActionableResult) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if rec == nil || actionable == nil {
 		return
 	}
@@ -4070,10 +4076,13 @@ func recordEnumeratedIssues(rec lifecycleRecorder, actionable *github.Actionable
 	}
 	for i := 0; i < limit; i++ {
 		issue := actionable.Issues.Items[i]
-		store.Record(timeline.Event{
+		event := timeline.Event{
 			IssueRef: issueRef(issue.Repo, issue.Number),
 			Kind:     timeline.KindEnumerated,
-		})
+		}
+		_, span := tracing.StartTimelineSpan(ctx, event)
+		store.Record(event)
+		span.End()
 	}
 }
 
@@ -4081,7 +4090,10 @@ func recordEnumeratedIssues(rec lifecycleRecorder, actionable *github.Actionable
 // supplied it records one issue-scoped event per ref so post-completion lanes
 // can reconstruct per-bead kick counts. With no refs, it records one
 // agent-scoped event. Guarded and nil-safe; no I/O.
-func recordKick(rec lifecycleRecorder, agent string, issueRefs ...string) {
+func recordKick(ctx context.Context, rec lifecycleRecorder, agent string, issueRefs ...string) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if rec == nil {
 		return
 	}
@@ -4094,18 +4106,24 @@ func recordKick(rec lifecycleRecorder, agent string, issueRefs ...string) {
 			if ref == "" {
 				continue
 			}
-			store.Record(timeline.Event{
+			event := timeline.Event{
 				IssueRef: ref,
 				Kind:     timeline.KindKicked,
 				Agent:    agent,
-			})
+			}
+			_, span := tracing.StartTimelineSpan(ctx, event)
+			store.Record(event)
+			span.End()
 		}
 		return
 	}
-	store.Record(timeline.Event{
+	event := timeline.Event{
 		Kind:  timeline.KindKicked,
 		Agent: agent,
-	})
+	}
+	_, span := tracing.StartTimelineSpan(ctx, event)
+	store.Record(event)
+	span.End()
 }
 
 // issueRef renders the canonical "repo#number" reference the timeline uses to
@@ -4265,7 +4283,8 @@ func runEvalCycle(
 	// Governor eval-cycle span. When tracing is disabled (the default) this is
 	// a no-op span with no allocation of note and no export — see pkg/tracing.
 	ctx, span := tracing.StartSpan(ctx, "governor.eval_cycle",
-		attribute.String("hive.id", cfg.HiveID))
+		attribute.String("hive.id", cfg.HiveID),
+		attribute.Int(tracing.AttrHiveACMMLevel, inferACMMLevel(cfg)))
 	defer span.End()
 
 	// A hive running without GitHub credentials (placeholder app_id, or a real
@@ -4327,7 +4346,7 @@ func runEvalCycle(
 	// nil store is a no-op (timeline.Store.Record is nil-safe), the loop is
 	// bounded by maxTimelineEnumeratePerCycle so a huge backlog never floods the
 	// bounded ring in one cycle, and no I/O happens on this path.
-	recordEnumeratedIssues(dashSrv, actionable)
+	recordEnumeratedIssues(ctx, dashSrv, actionable)
 
 	escalatedPRs := runEscalationSweep(ctx, cfg, ghClient, actionable, notifier, logger)
 
@@ -4403,6 +4422,12 @@ func runEvalCycle(
 	}
 
 	govState := gov.GetState()
+	span.SetAttributes(
+		attribute.String(tracing.AttrHiveGovernorMode, string(govState.Mode)),
+		attribute.Int("hive.queue.issues", govState.QueueIssues),
+		attribute.Int("hive.queue.prs", govState.QueuePRs),
+		attribute.Int("hive.queue.hold", govState.QueueHold),
+	)
 	logger.Info("governor eval complete",
 		"mode", govState.Mode,
 		"issues", govState.QueueIssues,
@@ -4460,17 +4485,29 @@ func runEvalCycle(
 	if len(agentsDue) > 0 {
 		messages := sched.BuildKickMessages(actionable, agentsDue)
 		for _, msg := range messages {
+			agentCfg := cfg.Agents[msg.Agent]
+			_, kickSpan := tracing.StartSpan(ctx, "agent.kick", tracing.AgentKickAttributes(
+				msg.Agent,
+				agentCfg.Backend,
+				agentCfg.Model,
+				agentCfg.Role,
+				string(govState.Mode),
+				inferACMMLevel(cfg),
+			)...)
 			logger.Info("audit: governor kicking agent", "agent", msg.Agent, "trigger", "governor-eval")
 			if err := agentMgr.SendKick(msg.Agent, msg.Message); err != nil {
+				kickSpan.RecordError(err)
+				kickSpan.End()
 				logger.Warn("failed to send kick", "agent", msg.Agent, "error", err)
 				continue
 			}
+			kickSpan.End()
 			gov.RecordKick(msg.Agent)
 			dashSrv.AuditLog("governor", "kick", "trigger=governor-eval", msg.Agent)
 
 			// Record issue-scoped kicks into the lifecycle timeline. Cheap,
 			// guarded, and nil-safe (Record no-ops on a nil dashboard/store).
-			recordKick(dashSrv, msg.Agent, msg.IssueRefs...)
+			recordKick(ctx, dashSrv, msg.Agent, msg.IssueRefs...)
 
 			// Log token state at time of kick for cost attribution
 			if tokenCollector != nil {

--- a/v2/cmd/hive/timeline_record_test.go
+++ b/v2/cmd/hive/timeline_record_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"testing"
 
 	"github.com/kubestellar/hive/v2/pkg/github"
@@ -27,7 +28,7 @@ func TestRecordEnumeratedIssues(t *testing.T) {
 		},
 	}
 
-	recordEnumeratedIssues(rec, actionable)
+	recordEnumeratedIssues(context.Background(), rec, actionable)
 
 	events := rec.store.Recent(0)
 	if len(events) != 2 {
@@ -53,7 +54,7 @@ func TestRecordEnumeratedIssues_BoundedPerCycle(t *testing.T) {
 	}
 	actionable := &github.ActionableResult{Issues: github.IssueResult{Items: items}}
 
-	recordEnumeratedIssues(rec, actionable)
+	recordEnumeratedIssues(context.Background(), rec, actionable)
 
 	if got := len(rec.store.Recent(0)); got != maxTimelineEnumeratePerCycle {
 		t.Fatalf("recorded %d events, want cap of %d", got, maxTimelineEnumeratePerCycle)
@@ -63,7 +64,7 @@ func TestRecordEnumeratedIssues_BoundedPerCycle(t *testing.T) {
 func TestRecordKick(t *testing.T) {
 	rec := &fakeLifecycleRecorder{store: timeline.NewStore()}
 
-	recordKick(rec, "quality")
+	recordKick(context.Background(), rec, "quality")
 
 	events := rec.store.Recent(0)
 	if len(events) != 1 {
@@ -80,7 +81,7 @@ func TestRecordKick(t *testing.T) {
 func TestRecordKickIssueScoped(t *testing.T) {
 	rec := &fakeLifecycleRecorder{store: timeline.NewStore()}
 
-	recordKick(rec, "scanner", "org/repo#1", "org/repo#2")
+	recordKick(context.Background(), rec, "scanner", "org/repo#1", "org/repo#2")
 
 	events := rec.store.Recent(0)
 	if len(events) != 2 {
@@ -100,22 +101,22 @@ func TestRecordKickIssueScoped(t *testing.T) {
 // and a recorder returning a nil store must all be no-ops (never panic).
 func TestRecordHelpers_NilSafe(t *testing.T) {
 	// nil recorder
-	recordEnumeratedIssues(nil, &github.ActionableResult{})
-	recordKick(nil, "x")
+	recordEnumeratedIssues(context.Background(), nil, &github.ActionableResult{})
+	recordKick(context.Background(), nil, "x")
 
 	// nil actionable
 	rec := &fakeLifecycleRecorder{store: timeline.NewStore()}
-	recordEnumeratedIssues(rec, nil)
+	recordEnumeratedIssues(context.Background(), rec, nil)
 	if got := len(rec.store.Recent(0)); got != 0 {
 		t.Fatalf("nil actionable recorded %d events, want 0", got)
 	}
 
 	// recorder that returns a nil store
 	nilStore := &fakeLifecycleRecorder{store: nil}
-	recordEnumeratedIssues(nilStore, &github.ActionableResult{
+	recordEnumeratedIssues(context.Background(), nilStore, &github.ActionableResult{
 		Issues: github.IssueResult{Items: []github.Issue{{Repo: "r", Number: 1}}},
 	})
-	recordKick(nilStore, "x")
+	recordKick(context.Background(), nilStore, "x")
 }
 
 func TestIssueRef(t *testing.T) {

--- a/v2/docs/architecture.md
+++ b/v2/docs/architecture.md
@@ -337,6 +337,13 @@ flowchart LR
   `livez` probe catches the "HTTP up but eval loop / heartbeat stalled" case.
 - Notifications (`ntfy` / Slack / Discord) fire on budget warnings, SLA breaches,
   trajectory-drift pauses, and other governor events.
+- Optional OpenTelemetry export is configured with an `otel:` block in
+  `hive.yaml` and is off by default. When enabled, Hive exports OTLP/HTTP spans
+  for governor eval cycles, agent kicks, and recorded lifecycle/PR events; agent spans use
+  GenAI semantic convention attributes such as `gen_ai.system`,
+  `gen_ai.request.model`, and token usage fields when that data is available,
+  plus Hive attributes like `hive.agent`, `hive.lane`, `hive.acmm_level`, and
+  `hive.governor.mode`.
 
 ---
 

--- a/v2/hive.yaml.example
+++ b/v2/hive.yaml.example
@@ -226,6 +226,17 @@ notifications:
 #   bot_token: ${DISCORD_BOT_TOKEN}
 #   channel_id: "1234567890"
 
+# OpenTelemetry trace export (optional, off by default). When enabled, Hive
+# exports governor eval cycles, agent kicks, and recorded lifecycle
+# events as OTLP/HTTP spans with GenAI semantic convention attributes for model/backend usage.
+# otel:
+#   enabled: false
+#   endpoint: https://otel-collector.example.com/v1/traces
+#   service_name: hive
+#   insecure: false
+#   headers:
+#     authorization: Bearer ${OTEL_EXPORTER_TOKEN}
+
 # Dashboard — embedded web UI with SSE live updates
 # Security headers (CSP, X-Frame-Options, etc.) are always active.
 # Set auth_token to require Bearer auth on /api/* endpoints (except /api/health).

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -43,7 +44,10 @@ type Config struct {
 	HiveID        string                 `yaml:"hive_id"`
 	ACMMLevel     *int                   `yaml:"acmm_level,omitempty" json:"acmm_level"`
 	Variables     VariablesConfig        `yaml:"variables,omitempty"`
-	Tracing       TracingConfig          `yaml:"tracing,omitempty"`
+	// OTel configures standards-based OTLP trace export. It is the preferred
+	// operator-facing block; Tracing is retained as a legacy alias.
+	OTel    OTelConfig `yaml:"otel,omitempty" json:"otel,omitempty"`
+	Tracing OTelConfig `yaml:"tracing,omitempty"`
 	// Triggers is an additive list of CEL-based declarative agent triggers.
 	// Default empty → existing label/governor triggering is unchanged.
 	Triggers   []TriggerRule    `yaml:"triggers,omitempty" json:"triggers,omitempty"`
@@ -82,23 +86,58 @@ type Config struct {
 	SourcePath string `yaml:"-" json:"-"`
 }
 
-// TracingConfig configures OpenTelemetry distributed tracing. It is additive
-// and OFF by default: a config with no `tracing:` block (or with
-// `tracing.enabled: false`) yields a zero-overhead no-op tracer. When enabled,
-// spans are exported over OTLP/HTTP to Endpoint (or the standard
-// OTEL_EXPORTER_OTLP_ENDPOINT env var when Endpoint is empty).
-type TracingConfig struct {
-	// Enabled turns tracing on. Default false — the zero value keeps every
-	// existing config a no-op with no exporter and no network activity.
-	Enabled bool `yaml:"enabled,omitempty"`
+// DefaultOTelServiceName is the OTLP resource service.name used when the
+// operator does not set otel.service_name.
+const DefaultOTelServiceName = "hive"
+
+// OTelConfig configures OpenTelemetry trace export. It is additive and OFF by
+// default: a config with no `otel:` block (or enabled:false) yields a
+// zero-overhead no-op tracer. When enabled, spans are exported over OTLP/HTTP
+// to Endpoint (or the standard OTEL_EXPORTER_OTLP_ENDPOINT env var when
+// Endpoint is empty).
+type OTelConfig struct {
+	// Enabled turns OTLP trace export on. Default false — the zero value keeps
+	// every existing config a no-op with no exporter and no network activity.
+	Enabled bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	// Endpoint is the OTLP/HTTP collector endpoint (host:port or full URL).
 	// When empty, the exporter falls back to OTEL_EXPORTER_OTLP_ENDPOINT.
-	// Never hardcode a default here — an unset endpoint means "use the env".
-	Endpoint string `yaml:"endpoint,omitempty"`
+	Endpoint string `yaml:"endpoint,omitempty" json:"endpoint,omitempty"`
+	// Headers are optional static OTLP/HTTP headers, commonly used for collector
+	// authentication. Values should come from env interpolation, not literals.
+	Headers map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
+	// ServiceName is recorded as resource service.name. Empty defaults to "hive".
+	ServiceName string `yaml:"service_name,omitempty" json:"service_name,omitempty"`
+	// Insecure disables TLS for OTLP/HTTP. Leave false for https collectors.
+	Insecure bool `yaml:"insecure,omitempty" json:"insecure,omitempty"`
 	// SampleRatio is the head-based sampling ratio in [0.0, 1.0]. The zero
 	// value is treated as "sample everything" (1.0) so an operator who only
 	// sets enabled:true gets full traces; set explicitly to sample less.
-	SampleRatio float64 `yaml:"sample_ratio,omitempty"`
+	SampleRatio float64 `yaml:"sample_ratio,omitempty" json:"sample_ratio,omitempty"`
+}
+
+// ServiceNameOrDefault returns a valid resource service.name.
+func (o OTelConfig) ServiceNameOrDefault() string {
+	if name := strings.TrimSpace(o.ServiceName); name != "" {
+		return name
+	}
+	return DefaultOTelServiceName
+}
+
+// IsZero reports whether the block contains no operator-provided settings.
+func (o OTelConfig) IsZero() bool {
+	return !o.Enabled && o.Endpoint == "" && len(o.Headers) == 0 && o.ServiceName == "" && !o.Insecure && o.SampleRatio == 0
+}
+
+// EffectiveOTel returns the preferred otel block, falling back to the legacy
+// tracing block so existing configs continue to work unchanged.
+func (c *Config) EffectiveOTel() OTelConfig {
+	if c == nil {
+		return OTelConfig{}
+	}
+	if !c.OTel.IsZero() {
+		return c.OTel
+	}
+	return c.Tracing
 }
 
 // TriggerRule is one CEL-based declarative agent trigger. When Expr (a CEL
@@ -2544,6 +2583,13 @@ func LoadWithDashboardOverlay(path string) (*Config, error) {
 	// empty; the ~2-min saver then rewrote every layer tombstone-free and the
 	// deleted agents reappeared on an interval (#2439). Merge already skips and
 	// prunes tombstoned agents, so adopting them early is safe even when we bail.
+	if !overlay.OTel.IsZero() {
+		cfg.OTel = overlay.OTel
+		cfg.Tracing = overlay.OTel
+	} else if !overlay.Tracing.IsZero() {
+		cfg.Tracing = overlay.Tracing
+		cfg.OTel = mergeOTelOverride(cfg.OTel, overlay.Tracing)
+	}
 	if len(overlay.RemovedAgents) > 0 {
 		cfg.RemovedAgents = overlay.RemovedAgents
 		cfg.PruneRemovedAgents()
@@ -3467,7 +3513,7 @@ func (c *Config) saveLocked() error {
 	if err := c.validateSaveGuard(); err != nil {
 		return fmt.Errorf("refusing to save invalid config: %w", err)
 	}
-	data, err := yaml.Marshal(c)
+	data, err := yaml.Marshal(c.redactedForPersist())
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
@@ -3649,7 +3695,76 @@ func (c *Config) dashboardOverlayBytes() ([]byte, error) {
 			break
 		}
 	}
+	cp = *cp.redactedForPersist()
 	return yaml.Marshal(&cp)
+}
+
+func (c *Config) redactedForPersist() *Config {
+	if c == nil {
+		return nil
+	}
+	cp := *c
+	cp.OTel.Headers = envRedactedHeaders(cp.OTel.Headers)
+	cp.Tracing.Headers = envRedactedHeaders(cp.Tracing.Headers)
+	return &cp
+}
+
+func mergeOTelOverride(base, override OTelConfig) OTelConfig {
+	merged := base
+	if override.Enabled {
+		merged.Enabled = true
+	}
+	if override.Endpoint != "" {
+		merged.Endpoint = override.Endpoint
+	}
+	if len(override.Headers) > 0 {
+		merged.Headers = override.Headers
+	}
+	if override.ServiceName != "" {
+		merged.ServiceName = override.ServiceName
+	}
+	if override.Insecure {
+		merged.Insecure = true
+	}
+	if override.SampleRatio != 0 {
+		merged.SampleRatio = override.SampleRatio
+	}
+	return merged
+}
+
+func envRedactedHeaders(headers map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return headers
+	}
+	out := make(map[string]string, len(headers))
+	for k, value := range headers {
+		out[k] = redactEnvExpandedValue(value)
+	}
+	return out
+}
+
+func redactEnvExpandedValue(value string) string {
+	type envValue struct {
+		name  string
+		value string
+	}
+	values := make([]envValue, 0)
+	for _, pair := range os.Environ() {
+		name, val, ok := strings.Cut(pair, "=")
+		if !ok || val == "" {
+			continue
+		}
+		values = append(values, envValue{name: name, value: val})
+	}
+	sort.SliceStable(values, func(i, j int) bool {
+		return len(values[i].value) > len(values[j].value)
+	})
+
+	redacted := value
+	for _, item := range values {
+		redacted = strings.ReplaceAll(redacted, item.value, "${"+item.name+"}")
+	}
+	return redacted
 }
 
 // WildcardMatch checks if text matches a pattern supporting:

--- a/v2/pkg/config/config_save_test.go
+++ b/v2/pkg/config/config_save_test.go
@@ -199,3 +199,61 @@ func TestSaveSkipsDashboardOverlayOutsideK8s(t *testing.T) {
 		t.Errorf("overlay should not be written outside Kubernetes (stat err: %v)", err)
 	}
 }
+
+func TestDashboardOverlayBytes_RedactsOTelHeaders(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_TOKEN", "short7")
+	cfg := &Config{
+		OTel:    OTelConfig{Headers: map[string]string{"authorization": "Bearer short7"}},
+		Tracing: OTelConfig{Headers: map[string]string{"x-api-key": "short7"}},
+	}
+
+	data, err := cfg.dashboardOverlayBytes()
+	if err != nil {
+		t.Fatalf("dashboardOverlayBytes() error = %v", err)
+	}
+	body := string(data)
+	if strings.Contains(body, "short7") {
+		t.Fatalf("overlay leaked OTLP header secret: %s", body)
+	}
+	if !strings.Contains(body, "Bearer ${OTEL_EXPORTER_TOKEN}") || !strings.Contains(body, "${OTEL_EXPORTER_TOKEN}") {
+		t.Fatalf("overlay did not preserve env reference: %s", body)
+	}
+}
+
+func TestRedactEnvExpandedValue_LongestMatchFirst(t *testing.T) {
+	t.Setenv("OTEL_SHORT", "abc")
+	t.Setenv("OTEL_LONG", "abcdef")
+
+	got := redactEnvExpandedValue("Bearer abcdef")
+	if got != "Bearer ${OTEL_LONG}" {
+		t.Fatalf("redactEnvExpandedValue() = %q, want longest env match", got)
+	}
+}
+
+func TestSave_RedactsOTelHeadersInSource(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hive.yaml")
+	t.Setenv("OTEL_EXPORTER_TOKEN", "save-secret")
+	cfg := &Config{
+		SourcePath: path,
+		Project:    ProjectConfig{Org: "testorg", Repos: []string{"repo1"}},
+		GitHub:     GitHubConfig{Token: "ghp_test123456789"},
+		Agents:     map[string]AgentConfig{"scanner": {Backend: "copilot", Enabled: true}},
+		OTel:       OTelConfig{Enabled: true, Headers: map[string]string{"authorization": "Bearer save-secret"}},
+	}
+
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read saved file: %v", err)
+	}
+	body := string(data)
+	if strings.Contains(body, "save-secret") {
+		t.Fatalf("saved config leaked OTLP header secret: %s", body)
+	}
+	if !strings.Contains(body, "Bearer ${OTEL_EXPORTER_TOKEN}") {
+		t.Fatalf("saved config did not preserve OTLP env reference: %s", body)
+	}
+}

--- a/v2/pkg/config/config_test.go
+++ b/v2/pkg/config/config_test.go
@@ -895,14 +895,14 @@ func TestApplyDefaults_KnowledgeDefaults(t *testing.T) {
 
 func TestApplyDefaults_ExistingValuesNotOverridden(t *testing.T) {
 	cfg := &Config{
-		Project: ProjectConfig{Org: "o", Repos: []string{"r"}},
-		GitHub:  GitHubConfig{Token: "t"},
-		Agents:  map[string]AgentConfig{"a": {Backend: "claude"}},
+		Project:   ProjectConfig{Org: "o", Repos: []string{"r"}},
+		GitHub:    GitHubConfig{Token: "t"},
+		Agents:    map[string]AgentConfig{"a": {Backend: "claude"}},
 		Dashboard: DashboardConfig{Port: 8080},
 		Governor: GovernorConfig{
 			EvalIntervalS: 600,
-			Labels: LabelsConfig{Exempt: []string{"custom-label"}},
-			Sensing: SensingConfig{TTLSeconds: 1800, PullbackSeconds: 1800},
+			Labels:        LabelsConfig{Exempt: []string{"custom-label"}},
+			Sensing:       SensingConfig{TTLSeconds: 1800, PullbackSeconds: 1800},
 		},
 	}
 	cfg.applyDefaults()
@@ -1054,5 +1054,51 @@ func TestSave_AllowsValidConfig(t *testing.T) {
 	data, _ := os.ReadFile(path)
 	if string(data) == "old" {
 		t.Error("Save() did not write the new config")
+	}
+}
+
+func TestLoad_OTelConfig(t *testing.T) {
+	yaml := minimalValidYAML("my-org", "ghp_tok") + `
+otel:
+  enabled: true
+  endpoint: https://otel.example.com/v1/traces
+  service_name: hive-dev
+  insecure: true
+  headers:
+    authorization: Bearer ${OTEL_TOKEN}
+`
+	t.Setenv("OTEL_TOKEN", "test-token")
+	path := writeTempConfig(t, yaml)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	got := cfg.EffectiveOTel()
+	if !got.Enabled {
+		t.Fatal("OTel.Enabled = false, want true")
+	}
+	if got.Endpoint != "https://otel.example.com/v1/traces" {
+		t.Errorf("OTel.Endpoint = %q", got.Endpoint)
+	}
+	if got.ServiceNameOrDefault() != "hive-dev" {
+		t.Errorf("service_name = %q", got.ServiceNameOrDefault())
+	}
+	if !got.Insecure {
+		t.Error("OTel.Insecure = false, want true")
+	}
+	if got.Headers["authorization"] != "Bearer test-token" {
+		t.Errorf("authorization header = %q", got.Headers["authorization"])
+	}
+}
+
+func TestEffectiveOTel_LegacyTracingFallback(t *testing.T) {
+	cfg := &Config{Tracing: OTelConfig{Enabled: true, Endpoint: "https://legacy.example.com"}}
+	got := cfg.EffectiveOTel()
+	if !got.Enabled || got.Endpoint != "https://legacy.example.com" {
+		t.Fatalf("legacy tracing fallback = %+v", got)
+	}
+	if got.ServiceNameOrDefault() != DefaultOTelServiceName {
+		t.Errorf("default service name = %q", got.ServiceNameOrDefault())
 	}
 }

--- a/v2/pkg/config/dashboard_overlay_reload_test.go
+++ b/v2/pkg/config/dashboard_overlay_reload_test.go
@@ -117,3 +117,90 @@ agents:
 		t.Errorf("without overlay, seed should win: got %q", got)
 	}
 }
+
+func TestLoadWithDashboardOverlay_OTelSurvivesShortOverlay(t *testing.T) {
+	dir := t.TempDir()
+	seedPath := filepath.Join(dir, "hive.yaml")
+	seed := `
+project:
+  org: testorg
+  repos: [repo1]
+github:
+  token: ghp_test123456789
+agents:
+  scanner:
+    backend: copilot
+`
+	if err := os.WriteFile(seedPath, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	overlayPath := filepath.Join(dir, "hive.yaml.dashboard")
+	overlay := `
+otel:
+  enabled: true
+  endpoint: https://otel.example.com/v1/traces
+  service_name: hive-prod
+`
+	if err := os.WriteFile(overlayPath, []byte(overlay), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origOverlay := DashboardOverlayFile
+	DashboardOverlayFile = overlayPath
+	t.Cleanup(func() { DashboardOverlayFile = origOverlay })
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+
+	cfg, err := LoadWithDashboardOverlay(seedPath)
+	if err != nil {
+		t.Fatalf("LoadWithDashboardOverlay: %v", err)
+	}
+	got := cfg.EffectiveOTel()
+	if !got.Enabled || got.Endpoint != "https://otel.example.com/v1/traces" || got.ServiceName != "hive-prod" {
+		t.Fatalf("overlay otel not adopted: %+v", got)
+	}
+}
+
+func TestLoadWithDashboardOverlay_LegacyTracingMergesIntoPartialSeedOTel(t *testing.T) {
+	dir := t.TempDir()
+	seedPath := filepath.Join(dir, "hive.yaml")
+	seed := `
+project:
+  org: testorg
+  repos: [repo1]
+github:
+  token: ghp_test123456789
+otel:
+  service_name: hive-seed
+agents:
+  scanner:
+    backend: copilot
+`
+	if err := os.WriteFile(seedPath, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	overlayPath := filepath.Join(dir, "hive.yaml.dashboard")
+	overlay := `
+tracing:
+  enabled: true
+  endpoint: https://legacy.example.com/v1/traces
+`
+	if err := os.WriteFile(overlayPath, []byte(overlay), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origOverlay := DashboardOverlayFile
+	DashboardOverlayFile = overlayPath
+	t.Cleanup(func() { DashboardOverlayFile = origOverlay })
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+
+	cfg, err := LoadWithDashboardOverlay(seedPath)
+	if err != nil {
+		t.Fatalf("LoadWithDashboardOverlay: %v", err)
+	}
+	got := cfg.EffectiveOTel()
+	if !got.Enabled || got.Endpoint != "https://legacy.example.com/v1/traces" || got.ServiceName != "hive-seed" {
+		t.Fatalf("legacy tracing overlay did not merge into partial otel: %+v", got)
+	}
+}

--- a/v2/pkg/dashboard/api_governor_features.go
+++ b/v2/pkg/dashboard/api_governor_features.go
@@ -75,14 +75,19 @@ func (s *Server) handleGovernorFeatures(w http.ResponseWriter, r *http.Request) 
 		v := *body.IoscanEnabled
 		cfg.Ioscan.Enabled = &v
 	}
-	if body.TracingEnabled != nil {
-		cfg.Tracing.Enabled = *body.TracingEnabled
-	}
-	if body.TracingEndpoint != nil {
-		cfg.Tracing.Endpoint = strings.TrimSpace(*body.TracingEndpoint)
-	}
-	if body.TracingSampleRatio != nil {
-		cfg.Tracing.SampleRatio = *body.TracingSampleRatio
+	if body.TracingEnabled != nil || body.TracingEndpoint != nil || body.TracingSampleRatio != nil {
+		merged := cfg.EffectiveOTel()
+		if body.TracingEnabled != nil {
+			merged.Enabled = *body.TracingEnabled
+		}
+		if body.TracingEndpoint != nil {
+			merged.Endpoint = strings.TrimSpace(*body.TracingEndpoint)
+		}
+		if body.TracingSampleRatio != nil {
+			merged.SampleRatio = *body.TracingSampleRatio
+		}
+		cfg.OTel = merged
+		cfg.Tracing = merged
 	}
 	if body.MintEnabled != nil {
 		cfg.Mint.Enabled = *body.MintEnabled
@@ -116,11 +121,12 @@ func featuresSectionResponse(cfg *config.Config) map[string]interface{} {
 	if cfg.Planning.PlanFromLabel != nil {
 		planFromLabel = *cfg.Planning.PlanFromLabel
 	}
+	otelCfg := cfg.EffectiveOTel()
 	return map[string]interface{}{
 		"ioscanEnabled":      cfg.Ioscan.IsEnabled(),
-		"tracingEnabled":     cfg.Tracing.Enabled,
-		"tracingEndpoint":    cfg.Tracing.Endpoint,
-		"tracingSampleRatio": cfg.Tracing.SampleRatio,
+		"tracingEnabled":     otelCfg.Enabled,
+		"tracingEndpoint":    otelCfg.Endpoint,
+		"tracingSampleRatio": otelCfg.SampleRatio,
 		"mintEnabled":        cfg.Mint.Enabled,
 		"mintIssuer":         cfg.Mint.Issuer,
 		"planFromLabel":      planFromLabel,

--- a/v2/pkg/dashboard/api_governor_features_test.go
+++ b/v2/pkg/dashboard/api_governor_features_test.go
@@ -49,14 +49,14 @@ func TestCovGov_Features(t *testing.T) {
 	if !cfg.Ioscan.IsEnabled() {
 		t.Errorf("ioscan not enabled")
 	}
-	if !cfg.Tracing.Enabled {
-		t.Errorf("tracing not enabled")
+	if !cfg.Tracing.Enabled || !cfg.OTel.Enabled {
+		t.Errorf("tracing/otel not enabled: tracing=%v otel=%v", cfg.Tracing.Enabled, cfg.OTel.Enabled)
 	}
-	if cfg.Tracing.Endpoint != "https://otel-collector:4318" {
-		t.Errorf("tracing endpoint = %q", cfg.Tracing.Endpoint)
+	if cfg.Tracing.Endpoint != "https://otel-collector:4318" || cfg.OTel.Endpoint != "https://otel-collector:4318" {
+		t.Errorf("tracing endpoint = %q otel endpoint = %q", cfg.Tracing.Endpoint, cfg.OTel.Endpoint)
 	}
-	if cfg.Tracing.SampleRatio != 0.5 {
-		t.Errorf("tracing sample ratio = %v", cfg.Tracing.SampleRatio)
+	if cfg.Tracing.SampleRatio != 0.5 || cfg.OTel.SampleRatio != 0.5 {
+		t.Errorf("tracing sample ratio = %v otel sample ratio = %v", cfg.Tracing.SampleRatio, cfg.OTel.SampleRatio)
 	}
 	if !cfg.Mint.Enabled {
 		t.Errorf("mint not enabled")
@@ -94,5 +94,20 @@ func TestCovGov_Features(t *testing.T) {
 	// Tracing endpoint set earlier must survive the partial update.
 	if cfg.Tracing.Endpoint != "https://otel-collector:4318" {
 		t.Errorf("tracing endpoint lost on partial update: %q", cfg.Tracing.Endpoint)
+	}
+}
+
+func TestCovGov_FeaturesEndpointOnlyPreservesLegacyEnabled(t *testing.T) {
+	s := covApiServer(t)
+	s.deps.Config.Tracing.Enabled = true
+
+	if rec := doPut(s, "/api/config/governor/features", map[string]any{
+		"tracingEndpoint": "https://otel-new:4318",
+	}); rec.Code != http.StatusOK {
+		t.Fatalf("endpoint-only update: %d", rec.Code)
+	}
+
+	if got := s.deps.Config.EffectiveOTel(); !got.Enabled || got.Endpoint != "https://otel-new:4318" {
+		t.Fatalf("effective otel after endpoint-only update = %+v", got)
 	}
 }

--- a/v2/pkg/tracing/semconv.go
+++ b/v2/pkg/tracing/semconv.go
@@ -1,0 +1,134 @@
+package tracing
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/kubestellar/hive/v2/pkg/timeline"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	AttrGenAISystem            = "gen_ai.system"
+	AttrGenAIRequestModel      = "gen_ai.request.model"
+	AttrGenAIUsageInputTokens  = "gen_ai.usage.input_tokens"
+	AttrGenAIUsageOutputTokens = "gen_ai.usage.output_tokens"
+
+	AttrHiveAgent        = "hive.agent"
+	AttrHiveLane         = "hive.lane"
+	AttrHiveACMMLevel    = "hive.acmm_level"
+	AttrHiveGovernorMode = "hive.governor.mode"
+
+	attrEventKind = "hive.timeline.kind"
+	attrEventID   = "event.id"
+	attrIssueRef  = "issue.ref"
+	attrPRNumber  = "pr.number"
+	attrPRURL     = "pr.url"
+)
+
+const (
+	eventAttrSystem       = "gen_ai.system"
+	eventAttrModel        = "model"
+	eventAttrInputTokens  = "input_tokens"
+	eventAttrOutputTokens = "output_tokens"
+	eventAttrLane         = "lane"
+	eventAttrACMMLevel    = "acmm_level"
+	eventAttrGovMode      = "governor_mode"
+	eventAttrPRNumber     = "pr"
+	eventAttrPRURL        = "pr_url"
+)
+
+var timelineSpanNames = map[timeline.Kind]string{
+	timeline.KindEnumerated: "governor.enumerate",
+	timeline.KindClassified: "governor.classify",
+	timeline.KindKicked:     "agent.kick",
+	timeline.KindPROpened:   "pr.opened",
+	timeline.KindMerged:     "pr.merged",
+	timeline.KindBlocked:    "issue.blocked",
+}
+
+// TimelineSpanName returns the canonical span name for a lifecycle event kind.
+func TimelineSpanName(e timeline.Event) string {
+	if name, ok := timelineSpanNames[e.Kind]; ok {
+		return name
+	}
+	return "hive.timeline"
+}
+
+// TimelineSpanAttributes maps hive lifecycle events to OTLP attributes. Agent
+// and model fields use OTel GenAI semantic convention attribute names where the
+// event carries model/backend usage data; hive-specific context uses hive.*.
+func TimelineSpanAttributes(e timeline.Event) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{attribute.String(attrEventKind, string(e.Kind))}
+	if e.ID != "" {
+		attrs = append(attrs, attribute.String(attrEventID, e.ID))
+	}
+	if e.IssueRef != "" {
+		attrs = append(attrs, attribute.String(attrIssueRef, e.IssueRef))
+	}
+	if e.Agent != "" {
+		attrs = append(attrs, attribute.String(AttrHiveAgent, e.Agent))
+	}
+	for k, v := range e.Attrs {
+		switch k {
+		case eventAttrSystem:
+			attrs = append(attrs, attribute.String(AttrGenAISystem, v))
+		case eventAttrModel:
+			attrs = append(attrs, attribute.String(AttrGenAIRequestModel, v))
+		case eventAttrInputTokens:
+			if n, ok := parseIntAttr(v); ok {
+				attrs = append(attrs, attribute.Int(AttrGenAIUsageInputTokens, n))
+			}
+		case eventAttrOutputTokens:
+			if n, ok := parseIntAttr(v); ok {
+				attrs = append(attrs, attribute.Int(AttrGenAIUsageOutputTokens, n))
+			}
+		case eventAttrLane:
+			attrs = append(attrs, attribute.String(AttrHiveLane, v))
+		case eventAttrACMMLevel:
+			if n, ok := parseIntAttr(v); ok {
+				attrs = append(attrs, attribute.Int(AttrHiveACMMLevel, n))
+			}
+		case eventAttrGovMode:
+			attrs = append(attrs, attribute.String(AttrHiveGovernorMode, v))
+		case eventAttrPRNumber:
+			attrs = append(attrs, attribute.String(attrPRNumber, v))
+		case eventAttrPRURL:
+			attrs = append(attrs, attribute.String(attrPRURL, v))
+		}
+	}
+	return attrs
+}
+
+// StartTimelineSpan starts a span for an existing dashboard lifecycle event.
+func StartTimelineSpan(ctx context.Context, e timeline.Event) (context.Context, trace.Span) {
+	return StartSpan(ctx, TimelineSpanName(e), TimelineSpanAttributes(e)...)
+}
+
+// AgentKickAttributes returns common attributes for governor→agent kick spans.
+func AgentKickAttributes(agent, backend, model, lane, governorMode string, acmmLevel int) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{attribute.String(AttrHiveAgent, agent)}
+	if backend != "" {
+		attrs = append(attrs, attribute.String(AttrGenAISystem, backend))
+	}
+	if model != "" {
+		attrs = append(attrs, attribute.String(AttrGenAIRequestModel, model))
+	}
+	if lane != "" {
+		attrs = append(attrs, attribute.String(AttrHiveLane, lane))
+	}
+	if acmmLevel > 0 {
+		attrs = append(attrs, attribute.Int(AttrHiveACMMLevel, acmmLevel))
+	}
+	if governorMode != "" {
+		attrs = append(attrs, attribute.String(AttrHiveGovernorMode, governorMode))
+	}
+	return attrs
+}
+
+func parseIntAttr(v string) (int, bool) {
+	n, err := strconv.Atoi(strings.TrimSpace(v))
+	return n, err == nil
+}

--- a/v2/pkg/tracing/tracing.go
+++ b/v2/pkg/tracing/tracing.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
@@ -25,9 +26,6 @@ import (
 )
 
 const (
-	// serviceName is the OTLP resource service.name for every hive span.
-	serviceName = "hive"
-
 	// instrumentationName is the default instrumentation scope used by the
 	// package-level Tracer() helper.
 	instrumentationName = "github.com/kubestellar/hive/v2/pkg/tracing"
@@ -62,6 +60,12 @@ type Config struct {
 	// SampleRatio is the head-based sampling ratio. Zero (the default) is
 	// treated as 1.0 (sample everything).
 	SampleRatio float64
+	// Headers are optional OTLP/HTTP headers, commonly used for collector auth.
+	Headers map[string]string
+	// ServiceName is the OTLP resource service.name for every hive span.
+	ServiceName string
+	// Insecure disables TLS for OTLP/HTTP, matching the exporter option.
+	Insecure bool
 	// HiveID and Branch are recorded as resource attributes for correlation.
 	HiveID string
 	Branch string
@@ -96,12 +100,22 @@ func Init(ctx context.Context, cfg Config) (func(context.Context) error, error) 
 		// connection errors. Fail closed to a no-op instead of guessing.
 		return noopShutdown, nil
 	}
+	if len(cfg.Headers) > 0 {
+		opts = append(opts, otlptracehttp.WithHeaders(cfg.Headers))
+	}
+	if cfg.Insecure {
+		opts = append(opts, otlptracehttp.WithInsecure())
+	}
 
 	exporter, err := otlptracehttp.New(ctx, opts...)
 	if err != nil {
 		return noopShutdown, err
 	}
 
+	serviceName := strings.TrimSpace(cfg.ServiceName)
+	if serviceName == "" {
+		serviceName = "hive"
+	}
 	res, err := resource.Merge(
 		resource.Default(),
 		resource.NewWithAttributes(
@@ -131,6 +145,7 @@ func Init(ctx context.Context, cfg Config) (func(context.Context) error, error) 
 		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(ratio))),
 	)
 	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
 
 	return tp.Shutdown, nil
 }

--- a/v2/pkg/tracing/tracing_test.go
+++ b/v2/pkg/tracing/tracing_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubestellar/hive/v2/pkg/timeline"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -313,5 +314,76 @@ func TestInit_InvalidEndpointReturnsError(t *testing.T) {
 		if serr := shutdown(context.Background()); serr != nil {
 			t.Errorf("no-op shutdown after error returned: %v", serr)
 		}
+	}
+}
+
+func TestTimelineSpanAttributes_GenAIAndHiveAttrs(t *testing.T) {
+	e := timeline.Event{
+		ID:       "evt-1",
+		IssueRef: "org/repo#7",
+		Kind:     timeline.KindKicked,
+		Agent:    "scanner",
+		Attrs: map[string]string{
+			"gen_ai.system": "claude",
+			"model":         "claude-sonnet-4-6",
+			"input_tokens":  "123",
+			"output_tokens": "45",
+			"lane":          "triage",
+			"acmm_level":    "4",
+			"governor_mode": "BUSY",
+		},
+	}
+
+	attrs := TimelineSpanAttributes(e)
+	strings := map[attribute.Key]string{}
+	ints := map[attribute.Key]int64{}
+	for _, kv := range attrs {
+		switch kv.Value.Type().String() {
+		case "STRING":
+			strings[kv.Key] = kv.Value.AsString()
+		case "INT64":
+			ints[kv.Key] = kv.Value.AsInt64()
+		}
+	}
+
+	if TimelineSpanName(e) != "agent.kick" {
+		t.Fatalf("span name = %q", TimelineSpanName(e))
+	}
+	if strings[AttrGenAISystem] != "claude" {
+		t.Errorf("gen_ai.system = %q", strings[AttrGenAISystem])
+	}
+	if strings[AttrGenAIRequestModel] != "claude-sonnet-4-6" {
+		t.Errorf("gen_ai.request.model = %q", strings[AttrGenAIRequestModel])
+	}
+	if ints[AttrGenAIUsageInputTokens] != 123 || ints[AttrGenAIUsageOutputTokens] != 45 {
+		t.Errorf("token attrs = %d/%d", ints[AttrGenAIUsageInputTokens], ints[AttrGenAIUsageOutputTokens])
+	}
+	if strings[AttrHiveAgent] != "scanner" || strings[AttrHiveLane] != "triage" {
+		t.Errorf("hive attrs = agent %q lane %q", strings[AttrHiveAgent], strings[AttrHiveLane])
+	}
+	if ints[AttrHiveACMMLevel] != 4 || strings[AttrHiveGovernorMode] != "BUSY" {
+		t.Errorf("governor attrs = acmm %d mode %q", ints[AttrHiveACMMLevel], strings[AttrHiveGovernorMode])
+	}
+}
+
+func TestStartTimelineSpan_RecordsMappedSpan(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	_, span := StartTimelineSpan(context.Background(), timeline.Event{
+		Kind:  timeline.KindPROpened,
+		Agent: "reviewer",
+		Attrs: map[string]string{"pr": "42"},
+	})
+	span.End()
+
+	ended := recorder.Ended()
+	if len(ended) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(ended))
+	}
+	if ended[0].Name() != "pr.opened" {
+		t.Fatalf("span name = %q, want pr.opened", ended[0].Name())
 	}
 }


### PR DESCRIPTION
Part of #2810.

## Summary
- Adds an off-by-default `otel:` config block for OTLP/HTTP export with endpoint, headers, service_name, insecure, and legacy tracing fallback.
- Maps timeline/governor/agent kick events to spans with GenAI semantic convention attributes plus hive-specific attributes.
- Wires governor eval cycle parent spans, child agent kick spans, W3C trace-context propagation, docs, and example config.
- Redacts env-expanded OTLP header values on persisted config writes.

## Validation
- `cd v2 && go build ./...`
- `cd v2 && go test ./pkg/... -run . -count=1`
- `cd v2 && go vet ./pkg/tracing ./pkg/config ./pkg/dashboard ./cmd/hive`