### PR TITLE
✨ feat(governor): time-of-day cadence scheduling with timezone support

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1327,7 +1327,7 @@ func main() {
 					continue
 				}
 				if mode.Cadences == nil {
-					mode.Cadences = make(map[string]string)
+					mode.Cadences = make(map[string]config.Cadence)
 				}
 				for agentName, cadence := range agentCadences {
 					mode.Cadences[agentName] = cadence
@@ -4712,10 +4712,10 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 		agents[name] = as
 	}
 
-	cadenceOverrides := make(map[string]map[string]string)
+	cadenceOverrides := make(map[string]map[string]config.Cadence)
 	for modeName, mode := range cfg.Governor.Modes {
 		if len(mode.Cadences) > 0 {
-			cadenceOverrides[modeName] = make(map[string]string, len(mode.Cadences))
+			cadenceOverrides[modeName] = make(map[string]config.Cadence, len(mode.Cadences))
 			for agentName, cadence := range mode.Cadences {
 				cadenceOverrides[modeName][agentName] = cadence
 			}

--- a/v2/docs/agent-configuration.md
+++ b/v2/docs/agent-configuration.md
@@ -185,11 +185,23 @@ governor:
       threshold: 16        # queue depth that activates this mode
       supervisor: 5m       # per-agent kick interval in this mode
       scanner: 15m
+      reviewer:
+        times: ["09:00", "17:00"]
+        days: ["mon", "tue", "wed", "thu", "fri"]
+        tz: America/New_York
+      release:
+        cron: "30 9 * * 1-5"
+        tz: America/New_York
       ci-maintainer: 1h
       architect: pause     # "pause" stops kicks for this agent in this mode
 ```
 
-- **Per-agent, per-mode intervals.** A cadence entry is just `agent-name: duration` under the mode. Anything Go's duration parser accepts works (`5m`, `2h`).
+- **Mutually exclusive modes.** Each per-agent, per-mode cadence is either an interval (`5m`, `2h`, `pause`) or a time-of-day schedule — never both. Config load and API writes reject mixed forms with a 400/error.
+- **Time-of-day schedules.** Use `times: ["HH:MM"]` with optional `days` (`mon` … `sun`) and a required IANA `tz`. The timezone is stored explicitly and displayed with the schedule; it does not float with the viewer.
+- **Advanced cron.** Power users can provide a constrained five-field cron expression plus `tz`. Hive evaluates these with robfig/cron and schedule-local timezone handling.
+- **Governor-mode semantics.** Time-of-day schedules fire at their exact wall-clock times. Governor mode only selects whether that mode's schedule is active; quiet/busy/surge multipliers do not scale exact times. `pause`/`off`, paused agents, on-demand agents, non-kick channels, and budget gates still suppress kicks.
+- **Downtime catch-up.** If Hive was down at a scheduled time, restart/eval grants at most one catch-up kick when the missed occurrence is within the last 10 minutes. Older missed occurrences are skipped and the next future occurrence is used.
+- **Per-agent, per-mode intervals.** Anything Go's duration parser accepts works (`5m`, `2h`) for interval mode.
 - **Pausing.** The value `pause` (or `paused`) suspends an agent for that mode without disabling it.
 - **On-demand agents** (`on_demand: true`) are skipped by the governor timer entirely — they run only when explicitly triggered (the inception workflow drives `brainstorm` this way).
 - **Budget.** When the weekly token budget is exhausted, kicks are suppressed hive-wide (exempt agents excepted) until the period rolls over.

--- a/v2/pkg/config/cadence.go
+++ b/v2/pkg/config/cadence.go
@@ -1,0 +1,404 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	CadenceModeInterval  = "interval"
+	CadenceModeTimes     = "times"
+	CadenceModeCron      = "cron"
+	CadenceCatchUpWindow = 10 * time.Minute
+)
+
+const cadenceObjectPrefix = "tod:"
+
+var cadenceParser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+
+type Cadence string
+
+type cadenceObject struct {
+	Interval string   `yaml:"interval,omitempty" json:"interval,omitempty"`
+	Times    []string `yaml:"times,omitempty" json:"times,omitempty"`
+	Days     []string `yaml:"days,omitempty" json:"days,omitempty"`
+	TZ       string   `yaml:"tz,omitempty" json:"tz,omitempty"`
+	Cron     string   `yaml:"cron,omitempty" json:"cron,omitempty"`
+}
+
+func NewIntervalCadence(interval string) Cadence { return Cadence(strings.TrimSpace(interval)) }
+
+func (c Cadence) object() cadenceObject {
+	raw := string(c)
+	if !strings.HasPrefix(raw, cadenceObjectPrefix) {
+		return cadenceObject{Interval: strings.TrimSpace(raw)}
+	}
+	var obj cadenceObject
+	_ = json.Unmarshal([]byte(strings.TrimPrefix(raw, cadenceObjectPrefix)), &obj)
+	obj.Interval = strings.TrimSpace(obj.Interval)
+	obj.TZ = strings.TrimSpace(obj.TZ)
+	obj.Cron = strings.TrimSpace(obj.Cron)
+	return obj
+}
+
+func (c Cadence) Mode() string {
+	obj := c.object()
+	if obj.Cron != "" {
+		return CadenceModeCron
+	}
+	if len(obj.Times) > 0 {
+		return CadenceModeTimes
+	}
+	return CadenceModeInterval
+}
+
+func (c Cadence) Interval() string { return c.object().Interval }
+
+func (c Cadence) IsPaused() bool {
+	if c.Mode() != CadenceModeInterval {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(c.Interval())) {
+	case "pause", "paused", "off", "0", "on demand":
+		return true
+	default:
+		return false
+	}
+}
+
+func (c Cadence) String() string {
+	if c.Mode() == CadenceModeInterval {
+		return c.Interval()
+	}
+	b, err := yaml.Marshal(c.object())
+	if err != nil {
+		return string(c)
+	}
+	return strings.TrimSpace(string(b))
+}
+
+func (c Cadence) MarshalYAML() (interface{}, error) {
+	if c.Mode() == CadenceModeInterval {
+		return c.Interval(), nil
+	}
+	return c.object(), nil
+}
+
+func (c *Cadence) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		*c = NewIntervalCadence(value.Value)
+		return nil
+	}
+	var obj cadenceObject
+	if err := value.Decode(&obj); err != nil {
+		return err
+	}
+	next, err := cadenceFromObject(obj)
+	if err != nil {
+		return err
+	}
+	*c = next
+	return nil
+}
+
+func (c Cadence) MarshalJSON() ([]byte, error) {
+	if c.Mode() == CadenceModeInterval {
+		return json.Marshal(c.Interval())
+	}
+	return json.Marshal(c.object())
+}
+
+func (c *Cadence) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		*c = NewIntervalCadence(s)
+		return nil
+	}
+	var obj cadenceObject
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return err
+	}
+	next, err := cadenceFromObject(obj)
+	if err != nil {
+		return err
+	}
+	*c = next
+	return nil
+}
+
+func cadenceFromObject(obj cadenceObject) (Cadence, error) {
+	obj.Interval = strings.TrimSpace(obj.Interval)
+	obj.TZ = strings.TrimSpace(obj.TZ)
+	obj.Cron = strings.TrimSpace(obj.Cron)
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return "", err
+	}
+	c := Cadence(cadenceObjectPrefix + string(b))
+	return c, c.Validate()
+}
+
+func (c Cadence) Validate() error {
+	obj := c.object()
+	hasInterval := obj.Interval != ""
+	hasTimes := len(obj.Times) > 0
+	hasCron := obj.Cron != ""
+	modes := 0
+	if hasInterval {
+		modes++
+	}
+	if hasTimes {
+		modes++
+	}
+	if hasCron {
+		modes++
+	}
+	if modes > 1 {
+		return fmt.Errorf("cadence must set exactly one of interval, times, or cron")
+	}
+	if modes == 0 && (strings.HasPrefix(string(c), cadenceObjectPrefix) || obj.TZ != "" || len(obj.Days) > 0) {
+		return fmt.Errorf("cadence object must set interval, non-empty times, or cron")
+	}
+	if !hasTimes && !hasCron {
+		return nil
+	}
+	if obj.TZ == "" {
+		return fmt.Errorf("cadence timezone (tz) is required for times or cron")
+	}
+	if _, err := time.LoadLocation(obj.TZ); err != nil {
+		return fmt.Errorf("invalid cadence timezone %q: %w", obj.TZ, err)
+	}
+	if _, err := normalizedDays(obj.Days); err != nil {
+		return err
+	}
+	if hasTimes {
+		for _, tod := range obj.Times {
+			if _, _, err := parseTimeOfDay(tod); err != nil {
+				return err
+			}
+		}
+		for _, spec := range c.cronSpecs() {
+			if _, err := cadenceParser.Parse(spec); err != nil {
+				return fmt.Errorf("invalid cadence time schedule %q: %w", spec, err)
+			}
+		}
+		return nil
+	}
+	if _, err := cadenceParser.Parse(c.cronSpec(obj.Cron)); err != nil {
+		return fmt.Errorf("invalid cadence cron %q: %w", obj.Cron, err)
+	}
+	return nil
+}
+
+func (c Cadence) NextAfter(after time.Time) (time.Time, bool) {
+	if err := c.Validate(); err != nil {
+		return time.Time{}, false
+	}
+	if c.Mode() == CadenceModeInterval {
+		d, err := time.ParseDuration(c.Interval())
+		if err != nil || d <= 0 {
+			return time.Time{}, false
+		}
+		return after.Add(d), true
+	}
+	var best time.Time
+	for _, spec := range c.cronSpecs() {
+		schedule, err := cadenceParser.Parse(spec)
+		if err != nil {
+			continue
+		}
+		next := schedule.Next(after)
+		if best.IsZero() || next.Before(best) {
+			best = next
+		}
+	}
+	return best, !best.IsZero()
+}
+
+func (c Cadence) DueOccurrence(lastKick time.Time, now time.Time, catchUpWindow time.Duration) (time.Time, bool) {
+	if c.Mode() == CadenceModeInterval {
+		next, ok := c.NextAfter(lastKick)
+		if lastKick.IsZero() {
+			return now, ok
+		}
+		return next, ok && !next.After(now)
+	}
+	if catchUpWindow <= 0 {
+		catchUpWindow = CadenceCatchUpWindow
+	}
+	cursor := now.Add(-catchUpWindow).Add(-time.Nanosecond)
+	for {
+		next, ok := c.NextAfter(cursor)
+		if !ok || next.After(now) {
+			return time.Time{}, false
+		}
+		if lastKick.IsZero() || next.After(lastKick) {
+			return next, true
+		}
+		cursor = next
+	}
+}
+
+func (c Cadence) HumanSummary() string {
+	obj := c.object()
+	switch c.Mode() {
+	case CadenceModeTimes:
+		parts := make([]string, 0, len(obj.Times))
+		for _, tod := range obj.Times {
+			h, m, err := parseTimeOfDay(tod)
+			if err != nil {
+				parts = append(parts, tod)
+				continue
+			}
+			parts = append(parts, time.Date(2000, 1, 1, h, m, 0, 0, time.UTC).Format("3:04 PM"))
+		}
+		return fmt.Sprintf("At %s, %s (%s)", joinHuman(parts), daysSummary(obj.Days), obj.TZ)
+	case CadenceModeCron:
+		return fmt.Sprintf("Cron %q (%s)", obj.Cron, obj.TZ)
+	default:
+		return obj.Interval
+	}
+}
+
+func (c Cadence) ShortLabel(after time.Time) string {
+	obj := c.object()
+	switch c.Mode() {
+	case CadenceModeTimes:
+		tz := c.TimezoneAbbrev(after)
+		if tz == "" {
+			tz = obj.TZ
+		}
+		return "🕘 " + strings.Join(obj.Times, ",") + " " + tz
+	case CadenceModeCron:
+		tz := c.TimezoneAbbrev(after)
+		if tz == "" {
+			tz = obj.TZ
+		}
+		return "🕘 cron " + tz
+	default:
+		return obj.Interval
+	}
+}
+
+func (c Cadence) TimezoneAbbrev(after time.Time) string {
+	next, ok := c.NextAfter(after)
+	if !ok {
+		return ""
+	}
+	return next.Format("MST")
+}
+
+func (c Cadence) cronSpecs() []string {
+	obj := c.object()
+	switch c.Mode() {
+	case CadenceModeTimes:
+		dow := "*"
+		if days, err := normalizedDays(obj.Days); err == nil && len(days) > 0 {
+			dow = strings.Join(days, ",")
+		}
+		specs := make([]string, 0, len(obj.Times))
+		for _, tod := range obj.Times {
+			h, m, err := parseTimeOfDay(tod)
+			if err != nil {
+				continue
+			}
+			specs = append(specs, c.cronSpec(fmt.Sprintf("%d %d * * %s", m, h, dow)))
+		}
+		return specs
+	case CadenceModeCron:
+		return []string{c.cronSpec(obj.Cron)}
+	default:
+		return nil
+	}
+}
+
+func (c Cadence) cronSpec(expr string) string {
+	return fmt.Sprintf("CRON_TZ=%s %s", c.object().TZ, strings.TrimSpace(expr))
+}
+
+func parseTimeOfDay(v string) (int, int, error) {
+	parts := strings.Split(strings.TrimSpace(v), ":")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid cadence time %q (want HH:MM)", v)
+	}
+	h, err := strconv.Atoi(parts[0])
+	if err != nil || h < 0 || h > 23 {
+		return 0, 0, fmt.Errorf("invalid cadence time %q (hour must be 00-23)", v)
+	}
+	m, err := strconv.Atoi(parts[1])
+	if err != nil || m < 0 || m > 59 {
+		return 0, 0, fmt.Errorf("invalid cadence time %q (minute must be 00-59)", v)
+	}
+	return h, m, nil
+}
+
+func normalizedDays(days []string) ([]string, error) {
+	if len(days) == 0 {
+		return nil, nil
+	}
+	seen := map[string]bool{}
+	out := make([]string, 0, len(days))
+	for _, day := range days {
+		key := strings.ToLower(strings.TrimSpace(day))
+		switch key {
+		case "sun", "sunday", "0", "7":
+			key = "0"
+		case "mon", "monday", "1":
+			key = "1"
+		case "tue", "tues", "tuesday", "2":
+			key = "2"
+		case "wed", "wednesday", "3":
+			key = "3"
+		case "thu", "thur", "thurs", "thursday", "4":
+			key = "4"
+		case "fri", "friday", "5":
+			key = "5"
+		case "sat", "saturday", "6":
+			key = "6"
+		default:
+			return nil, fmt.Errorf("invalid cadence day %q", day)
+		}
+		if !seen[key] {
+			seen[key] = true
+			out = append(out, key)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func daysSummary(days []string) string {
+	norm, err := normalizedDays(days)
+	if err != nil || len(norm) == 0 {
+		return "every day"
+	}
+	if strings.Join(norm, ",") == "1,2,3,4,5" {
+		return "Mon–Fri"
+	}
+	names := map[string]string{"0": "Sun", "1": "Mon", "2": "Tue", "3": "Wed", "4": "Thu", "5": "Fri", "6": "Sat"}
+	out := make([]string, 0, len(norm))
+	for _, d := range norm {
+		out = append(out, names[d])
+	}
+	return strings.Join(out, ", ")
+}
+
+func joinHuman(parts []string) string {
+	switch len(parts) {
+	case 0:
+		return ""
+	case 1:
+		return parts[0]
+	case 2:
+		return parts[0] + " and " + parts[1]
+	default:
+		return strings.Join(parts[:len(parts)-1], ", ") + ", and " + parts[len(parts)-1]
+	}
+}

--- a/v2/pkg/config/cadence_test.go
+++ b/v2/pkg/config/cadence_test.go
@@ -1,0 +1,209 @@
+package config
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestCadenceYAMLStringAndObjectForms(t *testing.T) {
+	var mode ModeConfig
+	if err := yaml.Unmarshal([]byte(`
+threshold: 0
+scanner: 15m
+reviewer:
+  times: ["09:00", "17:00"]
+  days: ["mon", "tue", "wed", "thu", "fri"]
+  tz: America/New_York
+quiet:
+  cron: "30 9 * * 1-5"
+  tz: America/New_York
+`), &mode); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if mode.Cadences["scanner"] != "15m" {
+		t.Fatalf("string cadence = %q", mode.Cadences["scanner"])
+	}
+	if got := mode.Cadences["reviewer"].HumanSummary(); !strings.Contains(got, "Mon–Fri") || !strings.Contains(got, "America/New_York") {
+		t.Fatalf("summary = %q", got)
+	}
+	data, err := json.Marshal(mode.Cadences["quiet"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"cron"`) {
+		t.Fatalf("cron cadence did not marshal as object: %s", data)
+	}
+}
+
+func TestCadenceRejectsInvalidForms(t *testing.T) {
+	cases := []string{
+		`{interval: 5m, times: ["09:00"], tz: UTC}`,
+		`{times: ["25:00"], tz: UTC}`,
+		`{times: ["09:00"], tz: Mars/Olympus}`,
+		`{cron: "nope", tz: UTC}`,
+		`{times: [], tz: UTC}`,
+	}
+	for _, tc := range cases {
+		var c Cadence
+		if err := yaml.Unmarshal([]byte(tc), &c); err == nil {
+			t.Fatalf("expected %s to be rejected", tc)
+		}
+	}
+}
+
+func TestCadenceNextOccurrenceTimeZonesAndDays(t *testing.T) {
+	var c Cadence
+	if err := yaml.Unmarshal([]byte(`{times: ["09:00", "17:00"], days: ["mon","tue","wed","thu","fri"], tz: Pacific/Auckland}`), &c); err != nil {
+		t.Fatal(err)
+	}
+	loc, _ := time.LoadLocation("Pacific/Auckland")
+	next, ok := c.NextAfter(time.Date(2026, 8, 7, 16, 0, 0, 0, loc)) // Friday
+	if !ok {
+		t.Fatal("no next")
+	}
+	if next.Weekday() != time.Friday || next.Hour() != 17 {
+		t.Fatalf("next = %v, want same Friday 17:00 NZ", next)
+	}
+	next, _ = c.NextAfter(time.Date(2026, 8, 7, 18, 0, 0, 0, loc))
+	if next.Weekday() != time.Monday || next.Hour() != 9 {
+		t.Fatalf("next = %v, want Monday 09:00 NZ", next)
+	}
+}
+
+func TestCadenceDSTSpringForwardSkipsNonexistentTime(t *testing.T) {
+	var c Cadence
+	if err := yaml.Unmarshal([]byte(`{times: ["02:30"], tz: America/New_York}`), &c); err != nil {
+		t.Fatal(err)
+	}
+	loc, _ := time.LoadLocation("America/New_York")
+	next, ok := c.NextAfter(time.Date(2026, 3, 8, 0, 0, 0, 0, loc))
+	if !ok {
+		t.Fatal("no next")
+	}
+	if next.Day() == 8 {
+		t.Fatalf("spring-forward nonexistent 02:30 should be skipped, got %v", next)
+	}
+}
+
+func TestCadenceDSTFallBackFiresBothRepeatedTimes(t *testing.T) {
+	var c Cadence
+	if err := yaml.Unmarshal([]byte(`{times: ["01:30"], tz: America/New_York}`), &c); err != nil {
+		t.Fatal(err)
+	}
+	loc, _ := time.LoadLocation("America/New_York")
+	first, ok := c.NextAfter(time.Date(2026, 11, 1, 0, 0, 0, 0, loc))
+	if !ok {
+		t.Fatal("no first occurrence")
+	}
+	second, ok := c.NextAfter(first.Add(time.Minute))
+	if !ok {
+		t.Fatal("no second occurrence")
+	}
+	if first.Hour() != 1 || second.Hour() != 1 || !second.After(first) || first.Format("MST") == second.Format("MST") {
+		t.Fatalf("fall-back occurrences = %v then %v, want both 01:30 in different zones", first, second)
+	}
+}
+
+func TestCadenceDueOccurrenceAdvancesPastAlreadyKickedOccurrence(t *testing.T) {
+	var c Cadence
+	if err := yaml.Unmarshal([]byte(`{times: ["09:00", "09:05"], tz: UTC}`), &c); err != nil {
+		t.Fatal(err)
+	}
+	last := time.Date(2026, 8, 7, 9, 0, 2, 0, time.UTC)
+	now := time.Date(2026, 8, 7, 9, 5, 4, 0, time.UTC)
+	occ, ok := c.DueOccurrence(last, now, CadenceCatchUpWindow)
+	if !ok || occ.Hour() != 9 || occ.Minute() != 5 {
+		t.Fatalf("occurrence = %v ok=%v, want 09:05 due", occ, ok)
+	}
+}
+
+func TestCadenceHelpersAndJSONRoundTrip(t *testing.T) {
+	if !NewIntervalCadence("pause").IsPaused() {
+		t.Fatal("pause interval should be paused")
+	}
+	if NewIntervalCadence("15m").IsPaused() {
+		t.Fatal("15m interval should not be paused")
+	}
+	intervalNext, ok := NewIntervalCadence("15m").NextAfter(time.Date(2026, 8, 7, 9, 0, 0, 0, time.UTC))
+	if !ok || intervalNext.Minute() != 15 {
+		t.Fatalf("interval next = %v ok=%v", intervalNext, ok)
+	}
+	occ, ok := NewIntervalCadence("15m").DueOccurrence(time.Time{}, time.Date(2026, 8, 7, 9, 0, 0, 0, time.UTC), 0)
+	if !ok || occ.IsZero() {
+		t.Fatalf("interval first due = %v ok=%v", occ, ok)
+	}
+
+	var c Cadence
+	if err := json.Unmarshal([]byte(`{"times":["09:00","17:00"],"days":["mon","wed"],"tz":"America/New_York"}`), &c); err != nil {
+		t.Fatal(err)
+	}
+	if c.Mode() != CadenceModeTimes || !strings.Contains(c.String(), "times:") {
+		t.Fatalf("unexpected cadence mode/string: %s %q", c.Mode(), c.String())
+	}
+	label := c.ShortLabel(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	if !strings.Contains(label, "🕘") || !strings.Contains(label, "09:00,17:00") {
+		t.Fatalf("short label = %q", label)
+	}
+	ny, _ := time.LoadLocation("America/New_York")
+	if tz := c.TimezoneAbbrev(time.Date(2026, 1, 1, 0, 0, 0, 0, ny)); tz != "EST" {
+		t.Fatalf("timezone abbrev = %q", tz)
+	}
+	data, err := json.Marshal(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"times"`) {
+		t.Fatalf("json = %s", data)
+	}
+
+	var interval Cadence
+	if err := json.Unmarshal([]byte(`"5m"`), &interval); err != nil {
+		t.Fatal(err)
+	}
+	if interval != "5m" {
+		t.Fatalf("interval json = %q", interval)
+	}
+
+	var cron Cadence
+	if err := json.Unmarshal([]byte(`{"cron":"30 9 * * 1-5","tz":"UTC"}`), &cron); err != nil {
+		t.Fatal(err)
+	}
+	if got := cron.HumanSummary(); !strings.Contains(got, "Cron") || !strings.Contains(got, "UTC") {
+		t.Fatalf("cron summary = %q", got)
+	}
+	if label := cron.ShortLabel(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)); !strings.Contains(label, "cron") {
+		t.Fatalf("cron label = %q", label)
+	}
+}
+
+func TestCadenceInvalidJSONAndUtilityBranches(t *testing.T) {
+	var c Cadence
+	if err := json.Unmarshal([]byte(`{"interval":"5m","cron":"30 9 * * *","tz":"UTC"}`), &c); err == nil {
+		t.Fatal("expected JSON mutual exclusion error")
+	}
+	if _, _, err := parseTimeOfDay("xx"); err == nil {
+		t.Fatal("expected malformed time error")
+	}
+	if _, _, err := parseTimeOfDay("24:00"); err == nil {
+		t.Fatal("expected bad hour error")
+	}
+	if _, _, err := parseTimeOfDay("23:99"); err == nil {
+		t.Fatal("expected bad minute error")
+	}
+	if _, err := normalizedDays([]string{"sunday", "7", "tues", "thur", "bad"}); err == nil {
+		t.Fatal("expected bad day error")
+	}
+	if got := daysSummary([]string{"sat", "sun"}); got != "Sun, Sat" {
+		t.Fatalf("days summary = %q", got)
+	}
+	if got := joinHuman([]string{}); got != "" {
+		t.Fatalf("empty join = %q", got)
+	}
+	if got := joinHuman([]string{"a", "b", "c"}); got != "a, b, and c" {
+		t.Fatalf("join = %q", got)
+	}
+}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1265,8 +1265,8 @@ type BudgetConfig struct {
 }
 
 type ModeConfig struct {
-	Threshold int               `yaml:"threshold"`
-	Cadences  map[string]string `yaml:"cadences"`
+	Threshold int                `yaml:"threshold"`
+	Cadences  map[string]Cadence `yaml:"cadences"`
 }
 
 // UnmarshalYAML implements custom unmarshaling for ModeConfig.
@@ -1280,18 +1280,18 @@ type ModeConfig struct {
 // This method separates "threshold" into the Threshold field and collects
 // all other keys into the Cadences map.
 func (m *ModeConfig) UnmarshalYAML(value *yaml.Node) error {
-	var raw map[string]string
+	var raw map[string]Cadence
 	if err := value.Decode(&raw); err != nil {
 		return err
 	}
 
-	m.Cadences = make(map[string]string)
+	m.Cadences = make(map[string]Cadence)
 
 	const thresholdKey = "threshold"
 	if v, ok := raw[thresholdKey]; ok {
 		var t int
-		if _, err := fmt.Sscanf(v, "%d", &t); err != nil {
-			return fmt.Errorf("invalid threshold value %q: %w", v, err)
+		if _, err := fmt.Sscanf(v.Interval(), "%d", &t); err != nil {
+			return fmt.Errorf("invalid threshold value %q: %w", v.Interval(), err)
 		}
 		m.Threshold = t
 	}
@@ -3014,6 +3014,13 @@ func (c *Config) validate() error {
 	}
 	if err := c.Governor.LiteLLM.Validate(); err != nil {
 		return err
+	}
+	for modeName, mode := range c.Governor.Modes {
+		for agentName, cadence := range mode.Cadences {
+			if err := cadence.Validate(); err != nil {
+				return fmt.Errorf("governor mode %s cadence for %s: %w", modeName, agentName, err)
+			}
+		}
 	}
 	for name, agent := range c.Agents {
 		// One gate, shared with the config write path (dashboard agent-config

--- a/v2/pkg/config/config_test.go
+++ b/v2/pkg/config/config_test.go
@@ -895,14 +895,14 @@ func TestApplyDefaults_KnowledgeDefaults(t *testing.T) {
 
 func TestApplyDefaults_ExistingValuesNotOverridden(t *testing.T) {
 	cfg := &Config{
-		Project: ProjectConfig{Org: "o", Repos: []string{"r"}},
-		GitHub:  GitHubConfig{Token: "t"},
-		Agents:  map[string]AgentConfig{"a": {Backend: "claude"}},
+		Project:   ProjectConfig{Org: "o", Repos: []string{"r"}},
+		GitHub:    GitHubConfig{Token: "t"},
+		Agents:    map[string]AgentConfig{"a": {Backend: "claude"}},
 		Dashboard: DashboardConfig{Port: 8080},
 		Governor: GovernorConfig{
 			EvalIntervalS: 600,
-			Labels: LabelsConfig{Exempt: []string{"custom-label"}},
-			Sensing: SensingConfig{TTLSeconds: 1800, PullbackSeconds: 1800},
+			Labels:        LabelsConfig{Exempt: []string{"custom-label"}},
+			Sensing:       SensingConfig{TTLSeconds: 1800, PullbackSeconds: 1800},
 		},
 	}
 	cfg.applyDefaults()
@@ -961,7 +961,7 @@ github:
 	cfg.Project.Repos = append(cfg.Project.Repos, "repo-c")
 	cfg.Governor.Modes["surge"] = ModeConfig{
 		Threshold: 200,
-		Cadences:  map[string]string{"scanner": "pause"},
+		Cadences:  map[string]Cadence{"scanner": "pause"},
 	}
 
 	if err := cfg.Save(); err != nil {

--- a/v2/pkg/dashboard/acmm_roster_reconcile_test.go
+++ b/v2/pkg/dashboard/acmm_roster_reconcile_test.go
@@ -65,7 +65,7 @@ func TestApplyPackReconcilesFullRoster(t *testing.T) {
 				t.Errorf("mode %q: cadence for %q missing after L5 apply", modeName, agent)
 				continue
 			}
-			if got != want {
+			if string(got) != want {
 				t.Errorf("mode %q: cadence for %q = %q, want %q", modeName, agent, got, want)
 			}
 		}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1948,13 +1948,15 @@ func (s *Server) handleAgentConfigGet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Cadences as seconds (int) — frontend expects numbers, not duration strings
-	cadences := map[string]int64{}
+	cadences := map[string]any{}
 	for modeName, modeCfg := range s.deps.Config.Governor.Modes {
 		if c, ok := modeCfg.Cadences[name]; ok {
-			if c == "pause" || c == "off" || c == "0" {
+			if c.Mode() != config.CadenceModeInterval {
+				cadences[modeName] = c
+			} else if c.Interval() == "pause" || c.Interval() == "off" || c.Interval() == "0" {
 				cadences[modeName] = 0
 			} else {
-				d := parseCadenceDuration(c)
+				d := parseCadenceDuration(c.Interval())
 				cadences[modeName] = int64(d.Seconds())
 			}
 		}
@@ -2733,24 +2735,40 @@ func (s *Server) handleAgentConfigCadences(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	var body map[string]int64
+	var body map[string]json.RawMessage
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
 		return
 	}
 
-	for modeName, seconds := range body {
+	for modeName, raw := range body {
 		mode, ok := s.deps.Config.Governor.Modes[modeName]
 		if !ok {
 			continue
 		}
 		if mode.Cadences == nil {
-			mode.Cadences = make(map[string]string)
+			mode.Cadences = make(map[string]config.Cadence)
 		}
-		if seconds <= 0 {
+		var seconds int64
+		var cadence config.Cadence
+		if err := json.Unmarshal(raw, &seconds); err == nil {
+			if seconds <= 0 {
+				cadence = "pause"
+			} else {
+				cadence = config.Cadence(formatCadenceDuration(seconds))
+			}
+		} else if err := json.Unmarshal(raw, &cadence); err != nil {
+			jsonError(w, "invalid cadence for "+modeName+": must be seconds, interval string, or schedule object", http.StatusBadRequest)
+			return
+		}
+		if err := cadence.Validate(); err != nil {
+			jsonError(w, "invalid cadence for "+modeName+": "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if cadence.Mode() == config.CadenceModeInterval && cadence.IsPaused() {
 			mode.Cadences[name] = "pause"
 		} else {
-			mode.Cadences[name] = formatCadenceDuration(seconds)
+			mode.Cadences[name] = cadence
 		}
 		s.deps.Config.Governor.Modes[modeName] = mode
 	}
@@ -3230,7 +3248,7 @@ func (s *Server) handleAgentExport(w http.ResponseWriter, r *http.Request) {
 	cadences := map[string]string{}
 	for modeName, modeCfg := range s.deps.Config.Governor.Modes {
 		if c, ok := modeCfg.Cadences[name]; ok {
-			cadences[modeName] = c
+			cadences[modeName] = c.String()
 		}
 	}
 
@@ -3399,7 +3417,17 @@ func (s *Server) buildExportYAML(name string, cfg config.AgentConfig, cadences m
 		modeOrder := []string{"idle", "quiet", "busy", "surge"}
 		for _, mode := range modeOrder {
 			if c, ok := cadences[mode]; ok {
-				b.WriteString(fmt.Sprintf("    %s: %s\n", mode, c))
+				if strings.Contains(c, "\n") {
+					b.WriteString(fmt.Sprintf("    %s:\n", mode))
+					for _, line := range strings.Split(c, "\n") {
+						if strings.TrimSpace(line) == "" {
+							continue
+						}
+						b.WriteString("      " + line + "\n")
+					}
+				} else {
+					b.WriteString(fmt.Sprintf("    %s: %s\n", mode, c))
+				}
 			}
 		}
 	}

--- a/v2/pkg/dashboard/api_agents_test.go
+++ b/v2/pkg/dashboard/api_agents_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
 // ---------- agentDefinition JSON serialization ----------
@@ -39,7 +41,7 @@ func TestAgentDefinitionJSONTags(t *testing.T) {
 			LaneKeywords:    []string{"bug", "fix"},
 			DetectKeywords:  []string{"error"},
 			Aliases:         []string{"scan"},
-			Cadences:        map[string]string{"busy": "5m"},
+			Cadences:        map[string]config.Cadence{"busy": "5m"},
 			PromptTemplate:  "do the thing",
 		},
 	}

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -84,10 +84,10 @@ func apiServerWithKnowledge(t *testing.T) (*Server, *Dependencies, *httptest.Ser
 		Governor: config.GovernorConfig{
 			EvalIntervalS: 300,
 			Modes: map[string]config.ModeConfig{
-				"idle":  {Threshold: 0, Cadences: map[string]string{"scanner": "15m"}},
-				"quiet": {Threshold: 2, Cadences: map[string]string{"scanner": "10m"}},
-				"busy":  {Threshold: 10, Cadences: map[string]string{"scanner": "5m"}},
-				"surge": {Threshold: 20, Cadences: map[string]string{"scanner": "2m"}},
+				"idle":  {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": "15m"}},
+				"quiet": {Threshold: 2, Cadences: map[string]config.Cadence{"scanner": "10m"}},
+				"busy":  {Threshold: 10, Cadences: map[string]config.Cadence{"scanner": "5m"}},
+				"surge": {Threshold: 20, Cadences: map[string]config.Cadence{"scanner": "2m"}},
 			},
 			Labels: config.LabelsConfig{Exempt: []string{"hold"}},
 		},
@@ -1717,7 +1717,7 @@ func TestLookupCadence_Found(t *testing.T) {
 	cfg := &config.Config{
 		Governor: config.GovernorConfig{
 			Modes: map[string]config.ModeConfig{
-				"idle": {Cadences: map[string]string{"scanner": "15m"}},
+				"idle": {Cadences: map[string]config.Cadence{"scanner": "15m"}},
 			},
 		},
 	}
@@ -1731,7 +1731,7 @@ func TestLookupCadence_NotFound(t *testing.T) {
 	cfg := &config.Config{
 		Governor: config.GovernorConfig{
 			Modes: map[string]config.ModeConfig{
-				"idle": {Cadences: map[string]string{"scanner": "15m"}},
+				"idle": {Cadences: map[string]config.Cadence{"scanner": "15m"}},
 			},
 		},
 	}
@@ -1745,7 +1745,7 @@ func TestLookupCadenceForMode_Busy(t *testing.T) {
 	cfg := &config.Config{
 		Governor: config.GovernorConfig{
 			Modes: map[string]config.ModeConfig{
-				"busy": {Cadences: map[string]string{"scanner": "5m"}},
+				"busy": {Cadences: map[string]config.Cadence{"scanner": "5m"}},
 			},
 		},
 	}
@@ -3018,7 +3018,7 @@ func TestHandleAgentConfigGet_CopilotBackend(t *testing.T) {
 		},
 		Governor: config.GovernorConfig{
 			Modes: map[string]config.ModeConfig{
-				"idle": {Threshold: 0, Cadences: map[string]string{"scanner": "15m"}},
+				"idle": {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": "15m"}},
 			},
 		},
 	}
@@ -3059,7 +3059,7 @@ func TestHandleAgentConfigGet_CustomLaunchCmd(t *testing.T) {
 		},
 		Governor: config.GovernorConfig{
 			Modes: map[string]config.ModeConfig{
-				"idle": {Threshold: 0, Cadences: map[string]string{"scanner": "15m"}},
+				"idle": {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": "15m"}},
 			},
 		},
 	}
@@ -3100,7 +3100,7 @@ func TestHandleAgentConfigGet_DisplayNameAndPauseCadence(t *testing.T) {
 		},
 		Governor: config.GovernorConfig{
 			Modes: map[string]config.ModeConfig{
-				"idle": {Threshold: 0, Cadences: map[string]string{"scanner": "pause"}},
+				"idle": {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": "pause"}},
 			},
 		},
 	}
@@ -3256,7 +3256,7 @@ func TestHandleAgentConfigGet_OffCadence(t *testing.T) {
 		},
 		Governor: config.GovernorConfig{
 			Modes: map[string]config.ModeConfig{
-				"idle": {Threshold: 0, Cadences: map[string]string{"scanner": "off"}},
+				"idle": {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": "off"}},
 			},
 		},
 	}

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -244,13 +244,13 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 		for modeName, agentCadences := range pack.Governor.Cadences {
 			mode := s.deps.Config.Governor.Modes[modeName]
 			if mode.Cadences == nil {
-				mode.Cadences = make(map[string]string)
+				mode.Cadences = make(map[string]config.Cadence)
 			}
 			for agent, interval := range agentCadences {
 				if isFirstApplyOrExpansion {
-					mode.Cadences[agent] = interval
+					mode.Cadences[agent] = config.Cadence(interval)
 				} else if _, exists := mode.Cadences[agent]; !exists {
-					mode.Cadences[agent] = interval
+					mode.Cadences[agent] = config.Cadence(interval)
 				}
 			}
 			s.deps.Config.Governor.Modes[modeName] = mode
@@ -428,9 +428,9 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 			}
 			for modeName, agentCadences := range pack.Governor.Cadences {
 				mode := s.deps.Config.Governor.Modes[modeName]
-				mode.Cadences = make(map[string]string)
+				mode.Cadences = make(map[string]config.Cadence)
 				for agent, interval := range agentCadences {
-					mode.Cadences[agent] = interval
+					mode.Cadences[agent] = config.Cadence(interval)
 				}
 				s.deps.Config.Governor.Modes[modeName] = mode
 			}

--- a/v2/pkg/dashboard/api_test.go
+++ b/v2/pkg/dashboard/api_test.go
@@ -32,10 +32,10 @@ func testDeps(t *testing.T) *Dependencies {
 		Governor: config.GovernorConfig{
 			EvalIntervalS: 300,
 			Modes: map[string]config.ModeConfig{
-				"idle":  {Threshold: 0, Cadences: map[string]string{"scanner": "15m"}},
-				"quiet": {Threshold: 2, Cadences: map[string]string{"scanner": "10m"}},
-				"busy":  {Threshold: 10, Cadences: map[string]string{"scanner": "5m"}},
-				"surge": {Threshold: 20, Cadences: map[string]string{"scanner": "2m"}},
+				"idle":  {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": "15m"}},
+				"quiet": {Threshold: 2, Cadences: map[string]config.Cadence{"scanner": "10m"}},
+				"busy":  {Threshold: 10, Cadences: map[string]config.Cadence{"scanner": "5m"}},
+				"surge": {Threshold: 20, Cadences: map[string]config.Cadence{"scanner": "2m"}},
 			},
 			Labels: config.LabelsConfig{Exempt: []string{"hold"}},
 		},
@@ -557,7 +557,7 @@ func TestHandleAgentConfigGet_MultilineDescription(t *testing.T) {
 		Governor: config.GovernorConfig{
 			EvalIntervalS: 300,
 			Modes: map[string]config.ModeConfig{
-				"busy": {Threshold: 10, Cadences: map[string]string{"scanner": "5m"}},
+				"busy": {Threshold: 10, Cadences: map[string]config.Cadence{"scanner": "5m"}},
 			},
 		},
 	}
@@ -1098,6 +1098,42 @@ func TestHandleAgentConfigCadences_Pause(t *testing.T) {
 	rec := doPut(s, "/api/config/agent/scanner/cadences", body)
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestHandleAgentConfigCadences_StructuredTimesRoundTrip(t *testing.T) {
+	s, _ := apiServer(t)
+	body := map[string]any{"idle": map[string]any{
+		"times": []string{"09:00", "17:00"},
+		"days":  []string{"mon", "tue", "wed", "thu", "fri"},
+		"tz":    "America/New_York",
+	}}
+	rec := doPut(s, "/api/config/agent/scanner/cadences", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	rec = doGet(s, "/api/config/agent/scanner")
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	cadences := got["cadences"].(map[string]any)
+	idle := cadences["idle"].(map[string]any)
+	if idle["tz"] != "America/New_York" || len(idle["times"].([]any)) != 2 {
+		t.Fatalf("idle cadence = %#v", idle)
+	}
+}
+
+func TestHandleAgentConfigCadences_RejectsMutualExclusion(t *testing.T) {
+	s, _ := apiServer(t)
+	body := map[string]any{"idle": map[string]any{
+		"interval": "5m",
+		"times":    []string{"09:00"},
+		"tz":       "UTC",
+	}}
+	rec := doPut(s, "/api/config/agent/scanner/cadences", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
 	}
 }
 

--- a/v2/pkg/dashboard/coverage_boost3_test.go
+++ b/v2/pkg/dashboard/coverage_boost3_test.go
@@ -836,10 +836,10 @@ func newFullServerWithAgents(t *testing.T) *Server {
 		Governor: config.GovernorConfig{
 			EvalIntervalS: 300,
 			Modes: map[string]config.ModeConfig{
-				"idle":  {Threshold: 0, Cadences: map[string]string{"scanner": "15m", "reviewer": "15m"}},
-				"quiet": {Threshold: 2, Cadences: map[string]string{"scanner": "10m", "reviewer": "10m"}},
-				"busy":  {Threshold: 10, Cadences: map[string]string{"scanner": "5m", "reviewer": "5m"}},
-				"surge": {Threshold: 20, Cadences: map[string]string{"scanner": "2m", "reviewer": "2m"}},
+				"idle":  {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": "15m", "reviewer": "15m"}},
+				"quiet": {Threshold: 2, Cadences: map[string]config.Cadence{"scanner": "10m", "reviewer": "10m"}},
+				"busy":  {Threshold: 10, Cadences: map[string]config.Cadence{"scanner": "5m", "reviewer": "5m"}},
+				"surge": {Threshold: 20, Cadences: map[string]config.Cadence{"scanner": "2m", "reviewer": "2m"}},
 			},
 		},
 	}

--- a/v2/pkg/dashboard/coverage_boost4_test.go
+++ b/v2/pkg/dashboard/coverage_boost4_test.go
@@ -416,10 +416,10 @@ func newDeepTestServer(t *testing.T) *Server {
 		Governor: config.GovernorConfig{
 			EvalIntervalS: 300,
 			Modes: map[string]config.ModeConfig{
-				"idle":  {Threshold: 0, Cadences: map[string]string{"scanner": "15m"}},
-				"quiet": {Threshold: 2, Cadences: map[string]string{"scanner": "10m"}},
-				"busy":  {Threshold: 10, Cadences: map[string]string{"scanner": "5m"}},
-				"surge": {Threshold: 20, Cadences: map[string]string{"scanner": "2m"}},
+				"idle":  {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": "15m"}},
+				"quiet": {Threshold: 2, Cadences: map[string]config.Cadence{"scanner": "10m"}},
+				"busy":  {Threshold: 10, Cadences: map[string]config.Cadence{"scanner": "5m"}},
+				"surge": {Threshold: 20, Cadences: map[string]config.Cadence{"scanner": "2m"}},
 			},
 		},
 	}

--- a/v2/pkg/dashboard/coverage_boost_test.go
+++ b/v2/pkg/dashboard/coverage_boost_test.go
@@ -214,7 +214,7 @@ func TestBuildAgentOnlyStatus(t *testing.T) {
 		},
 		Governor: config.GovernorConfig{
 			Modes: map[string]config.ModeConfig{
-				"idle": {Cadences: map[string]string{"scanner": "15m"}},
+				"idle": {Cadences: map[string]config.Cadence{"scanner": "15m"}},
 			},
 		},
 	}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -436,11 +436,15 @@ type FrontendBudget struct {
 }
 
 type FrontendCadence struct {
-	Agent string `json:"agent"`
-	Idle  string `json:"idle"`
-	Quiet string `json:"quiet"`
-	Busy  string `json:"busy"`
-	Surge string `json:"surge"`
+	Agent      string `json:"agent"`
+	Idle       string `json:"idle"`
+	Quiet      string `json:"quiet"`
+	Busy       string `json:"busy"`
+	Surge      string `json:"surge"`
+	IdleTitle  string `json:"idleTitle,omitempty"`
+	QuietTitle string `json:"quietTitle,omitempty"`
+	BusyTitle  string `json:"busyTitle,omitempty"`
+	SurgeTitle string `json:"surgeTitle,omitempty"`
 }
 
 type FrontendHold struct {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6282,6 +6282,7 @@
         const agentOnDemand = agentData && agentData.onDemand === true;
         const cells = modes.map(m => {
           const val = row[m] || '?';
+          const tip = row[`${m}Title`] || `Click to adjust ${aname} ${m} cadence`;
           const isActive = m === currentMode;
           const isOff = val === 'off';
           const showOff = isOff && !agentOnDemand;
@@ -6291,7 +6292,7 @@
           const stateCls = showOnDemand ? ' on-demand' : showOff ? ' off' : showPaused ? ' paused' : '';
           const dot = (isActive && isWorking && !agentPaused && !showOff && !showOnDemand) ? '<span class="active-dot"></span>' : '';
           const badge = showOnDemand ? '<span class="on-demand-badge">on demand</span>' : showOff ? '<span class="off-badge">off</span>' : showPaused ? '<span class="pause-badge">paused</span>' : val;
-          return `<td class="${colCls}${stateCls}">${dot}${badge}</td>`;
+          return `<td class="${colCls}${stateCls}" title="${esc(tip)}">${dot}${badge}</td>`;
         }).join('');
         const nameDot = isWorking ? '<span class="agent-dot"></span>' : '';
         const pauseBadge = agentOnDemand ? '<span class="on-demand-badge">on demand</span>' : agentPaused ? '<span class="pause-badge">paused</span>' : agentOff ? '<span class="off-badge">off</span>' : '';
@@ -16023,19 +16024,90 @@ function burnAreaChart() {
       return Math.round(num * SECONDS_PER_MIN);
     }
 
+    function browserTimeZone() {
+      return (Intl && Intl.DateTimeFormat && Intl.DateTimeFormat().resolvedOptions().timeZone) || 'UTC';
+    }
+    function cadenceModeValue(v) {
+      if (v && typeof v === 'object') return v.cron ? 'cron' : 'times';
+      return 'interval';
+    }
+    function cadenceSummary(v) {
+      if (!v || typeof v !== 'object') return `Every ${cadenceToHuman(v || 0)}`;
+      const tz = v.tz || browserTimeZone();
+      if (v.cron) return `Cron "${v.cron}" (${tz})`;
+      const times = (v.times || []).join(' and ');
+      const days = (v.days || []).join(', ') || 'every day';
+      return `At ${times || '—'}, ${days} (${tz})`;
+    }
+    function readCadenceBuilder(mode) {
+      const kind = document.getElementById(`cad-${mode}-kind`)?.value || 'interval';
+      if (kind === 'interval') return cadenceFromHuman(document.getElementById(`cad-${mode}-interval`)?.value || '30m');
+      if (kind === 'cron') return {
+        cron: (document.getElementById(`cad-${mode}-cron`)?.value || '30 9 * * 1-5').trim(),
+        tz: browserTimeZone()
+      };
+      const days = Array.from(document.querySelectorAll(`[data-cadence-day="${mode}"]:checked`)).map(el => el.value);
+      return {
+        times: (document.getElementById(`cad-${mode}-times`)?.value || '09:00').split(',').map(s => s.trim()).filter(Boolean),
+        days,
+        tz: browserTimeZone()
+      };
+    }
+    function cadenceChanged(mode) {
+      const value = readCadenceBuilder(mode);
+      if (!_configState.data.cadences) _configState.data.cadences = {};
+      _configState.data.cadences[mode] = value;
+      markDirty('cadences', mode, value);
+      const summary = document.getElementById(`cad-${mode}-summary`);
+      if (summary) summary.textContent = cadenceSummary(value);
+    }
+    function cadenceSetPreset(mode, preset) {
+      if (!_configState.data.cadences) _configState.data.cadences = {};
+      let value;
+      if (preset === 'hours') {
+        value = 4 * SECONDS_PER_HOUR;
+      } else {
+        value = { times: ['09:00'], days: preset === 'daily' ? [] : ['mon','tue','wed','thu','fri'], tz: browserTimeZone() };
+      }
+      _configState.data.cadences[mode] = value;
+      markDirty('cadences', mode, value);
+      renderConfigTab(_configState.tab);
+    }
+    function renderCadenceBuilder(mode, value) {
+      const kind = cadenceModeValue(value);
+      const interval = kind === 'interval' ? cadenceToHuman(value || 0) : '30m';
+      const times = kind === 'times' ? (value.times || []).join(',') : '09:00';
+      const cron = kind === 'cron' ? (value.cron || '') : '30 9 * * 1-5';
+      const selectedDays = new Set(kind === 'times' ? (value.days || []) : []);
+      const days = ['mon','tue','wed','thu','fri','sat','sun'].map(d => `<label style="display:inline-flex;gap:3px;align-items:center;margin-right:6px"><input type="checkbox" data-cadence-day="${mode}" value="${d}" ${selectedDays.size===0 || selectedDays.has(d) ? 'checked' : ''} onchange="cadenceChanged('${mode}')">${d}</label>`).join('');
+      return `<div class="config-field" style="border:1px solid var(--border);border-radius:8px;padding:10px">
+        <label>${mode[0].toUpperCase()+mode.slice(1)} cadence</label>
+        <div style="display:flex;gap:6px;flex-wrap:wrap;margin:4px 0 8px">
+          <button type="button" onclick="cadenceSetPreset('${mode}','daily')">Daily at…</button>
+          <button type="button" onclick="cadenceSetPreset('${mode}','weekdays')">Weekdays at…</button>
+          <button type="button" onclick="cadenceSetPreset('${mode}','hours')">Every N hours</button>
+        </div>
+        <select id="cad-${mode}-kind" onchange="cadenceChanged('${mode}');renderConfigTab(_configState.tab)"><option value="interval" ${kind==='interval'?'selected':''}>Interval</option><option value="times" ${kind==='times'?'selected':''}>Times</option><option value="cron" ${kind==='cron'?'selected':''}>Custom cron</option></select>
+        ${kind === 'interval' ? `<input id="cad-${mode}-interval" type="text" value="${esc(interval)}" placeholder="30m, 4h, 0=off" onchange="cadenceChanged('${mode}')">` : ''}
+        ${kind === 'times' ? `<input id="cad-${mode}-times" type="text" value="${esc(times)}" placeholder="09:00,17:00" onchange="cadenceChanged('${mode}')"><div style="margin-top:6px">${days}</div>` : ''}
+        ${kind === 'cron' ? `<input id="cad-${mode}-cron" type="text" value="${esc(cron)}" placeholder="30 9 * * 1-5" onchange="cadenceChanged('${mode}')"><div style="font-size:.7rem;color:var(--muted)">5-field cron. Timezone saved from this browser: ${esc(browserTimeZone())}</div>` : ''}
+        <div id="cad-${mode}-summary" style="font-size:.72rem;color:var(--muted);margin-top:6px">${esc(cadenceSummary(value))}</div>
+      </div>`;
+    }
+
     function renderAgentCadences(c) {
       return `
         <div style="font-size:0.78rem;color:var(--muted);line-height:1.55;background:color-mix(in srgb, var(--accent) 7%, transparent);border:1px solid color-mix(in srgb, var(--accent) 22%, transparent);border-radius:6px;padding:10px 12px;margin-bottom:14px">
           <b>What this is.</b> How often the governor kicks this agent, set separately for each queue-depth mode (idle, quiet, busy, surge).
           <b>Why use it.</b> It lets you run the agent slowly when there's little to do and faster when work piles up, controlling token spend.
           <b>Where it shows up.</b> These intervals drive the governor's kick timing and appear in the Governor cadence table.
-          <b>How to configure.</b> Enter a duration like <code>30m</code> or <code>2h</code> (units <code>m</code>/<code>h</code>) per mode; <code>0</code> disables the agent in that mode.
+          <b>How to configure.</b> Use intervals, exact times in this browser's timezone, or a 5-field cron expression. Interval and time-of-day modes are mutually exclusive.
         </div>
         <div class="config-field-row4">
-          <div class="config-field"><label>Idle <span class="config-info">i<span class="config-tooltip">Kick interval when the governor is in idle mode (0 actionable issues). Set to 0 to disable this agent during idle. Default varies by agent role.</span></span></label><input type="text" value="${cadenceToHuman(c.idle)}" onchange="markDirty('cadences','idle',cadenceFromHuman(this.value));this.value=cadenceToHuman(cadenceFromHuman(this.value))"></div>
-          <div class="config-field"><label>Quiet <span class="config-info">i<span class="config-tooltip">Kick interval when the governor is in quiet mode (few actionable issues). Agents typically run at a moderate pace in this mode.</span></span></label><input type="text" value="${cadenceToHuman(c.quiet)}" onchange="markDirty('cadences','quiet',cadenceFromHuman(this.value));this.value=cadenceToHuman(cadenceFromHuman(this.value))"></div>
-          <div class="config-field"><label>Busy <span class="config-info">i<span class="config-tooltip">Kick interval when the governor is in busy mode (many actionable issues). Agents run more frequently to handle the workload.</span></span></label><input type="text" value="${cadenceToHuman(c.busy)}" onchange="markDirty('cadences','busy',cadenceFromHuman(this.value));this.value=cadenceToHuman(cadenceFromHuman(this.value))"></div>
-          <div class="config-field"><label>Surge <span class="config-info">i<span class="config-tooltip">Kick interval when the governor is in surge mode (critical issue count). Maximum agent activity. Watch your token budget at this pace.</span></span></label><input type="text" value="${cadenceToHuman(c.surge)}" onchange="markDirty('cadences','surge',cadenceFromHuman(this.value));this.value=cadenceToHuman(cadenceFromHuman(this.value))"></div>
+          ${renderCadenceBuilder('idle', c.idle)}
+          ${renderCadenceBuilder('quiet', c.quiet)}
+          ${renderCadenceBuilder('busy', c.busy)}
+          ${renderCadenceBuilder('surge', c.surge)}
         </div>`;
     }
 

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -266,11 +266,12 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 			lastKick = formatHumanTime(*proc.LastKick)
 		}
 
-		cadence := lookupCadenceForMode(name, currentMode, cfg)
-		if cadence == "" {
-			cadence = lookupCadence(name, cfg)
+		cadenceValue := lookupCadenceValueForMode(name, currentMode, cfg)
+		if cadenceValue == "" {
+			cadenceValue = lookupCadenceValue(name, cfg)
 		}
-		nextKick := computeNextKick(proc.LastKick, cadence)
+		cadence := cadenceDisplay(cadenceValue)
+		nextKick := computeNextKickFromCadence(proc.LastKick, cadenceValue)
 
 		// offByCadence: the agent's cadence for the CURRENT governor mode is a
 		// non-kicking value ("pause"/"off"), so the governor will never kick it
@@ -672,6 +673,21 @@ func computeNextKick(lastKick *time.Time, cadence string) string {
 	return formatHumanTime(next)
 }
 
+func computeNextKickFromCadence(lastKick *time.Time, cadence config.Cadence) string {
+	if cadence == "" || cadence.IsPaused() {
+		return ""
+	}
+	base := time.Now()
+	if lastKick != nil && cadence.Mode() == config.CadenceModeInterval {
+		base = *lastKick
+	}
+	next, ok := cadence.NextAfter(base)
+	if !ok {
+		return ""
+	}
+	return formatHumanTime(next)
+}
+
 func parseCadenceDuration(cadence string) time.Duration {
 	cadence = strings.TrimSpace(cadence)
 	if cadence == "" || cadence == "off" || cadence == "pause" || cadence == "on demand" {
@@ -708,12 +724,30 @@ func lookupCadence(agentName string, cfg *config.Config) string {
 }
 
 func lookupCadenceForMode(agentName, modeName string, cfg *config.Config) string {
+	return cadenceDisplay(lookupCadenceValueForMode(agentName, modeName, cfg))
+}
+
+func lookupCadenceValue(agentName string, cfg *config.Config) config.Cadence {
+	return lookupCadenceValueForMode(agentName, "idle", cfg)
+}
+
+func lookupCadenceValueForMode(agentName, modeName string, cfg *config.Config) config.Cadence {
 	if mode, ok := cfg.Governor.Modes[modeName]; ok {
 		if c, ok := mode.Cadences[agentName]; ok {
 			return c
 		}
 	}
 	return ""
+}
+
+func cadenceDisplay(c config.Cadence) string {
+	if c == "" {
+		return ""
+	}
+	if c.Mode() == config.CadenceModeInterval {
+		return c.Interval()
+	}
+	return c.ShortLabel(time.Now())
 }
 
 func buildGovernor(state governor.State, cfg *config.Config) FrontendGovernor {
@@ -1069,7 +1103,9 @@ func buildCadenceMatrix(cfg *config.Config, agentStatuses map[string]*agent.Agen
 		}
 
 		for modeName, mode := range cfg.Governor.Modes {
-			cadence := mode.Cadences[name]
+			rawCadence := mode.Cadences[name]
+			cadence := cadenceDisplay(rawCadence)
+			title := cadenceTooltip(rawCadence)
 			if cadence == "" || cadence == "pause" {
 				cadence = "off"
 			}
@@ -1081,17 +1117,33 @@ func buildCadenceMatrix(cfg *config.Config, agentStatuses map[string]*agent.Agen
 			switch modeName {
 			case "idle":
 				entry.Idle = cadence
+				entry.IdleTitle = title
 			case "quiet":
 				entry.Quiet = cadence
+				entry.QuietTitle = title
 			case "busy":
 				entry.Busy = cadence
+				entry.BusyTitle = title
 			case "surge":
 				entry.Surge = cadence
+				entry.SurgeTitle = title
 			}
 		}
 		matrix = append(matrix, entry)
 	}
+
 	return matrix
+}
+
+func cadenceTooltip(c config.Cadence) string {
+	if c == "" || c.IsPaused() {
+		return ""
+	}
+	next, ok := c.NextAfter(time.Now())
+	if !ok {
+		return c.HumanSummary()
+	}
+	return c.HumanSummary() + " — next: " + formatHumanTime(next)
 }
 
 func buildHold(actionable *github.ActionableResult) FrontendHold {

--- a/v2/pkg/dashboard/status_builder_test.go
+++ b/v2/pkg/dashboard/status_builder_test.go
@@ -81,7 +81,7 @@ func TestLookupCadence(t *testing.T) {
 	cfg := &config.Config{
 		Governor: config.GovernorConfig{
 			Modes: map[string]config.ModeConfig{
-				"idle": {Cadences: map[string]string{"scanner": "15m"}},
+				"idle": {Cadences: map[string]config.Cadence{"scanner": "15m"}},
 			},
 		},
 	}
@@ -100,7 +100,7 @@ func TestLookupCadenceForMode(t *testing.T) {
 	cfg := &config.Config{
 		Governor: config.GovernorConfig{
 			Modes: map[string]config.ModeConfig{
-				"busy": {Cadences: map[string]string{"scanner": "5m"}},
+				"busy": {Cadences: map[string]config.Cadence{"scanner": "5m"}},
 			},
 		},
 	}
@@ -260,10 +260,10 @@ func TestBuildCadenceMatrix(t *testing.T) {
 		},
 		Governor: config.GovernorConfig{
 			Modes: map[string]config.ModeConfig{
-				"idle":  {Cadences: map[string]string{"scanner": "15m", "supervisor": "pause"}},
-				"quiet": {Cadences: map[string]string{"scanner": "10m"}},
-				"busy":  {Cadences: map[string]string{}},
-				"surge": {Cadences: map[string]string{}},
+				"idle":  {Cadences: map[string]config.Cadence{"scanner": "15m", "supervisor": "pause"}},
+				"quiet": {Cadences: map[string]config.Cadence{"scanner": "10m"}},
+				"busy":  {Cadences: map[string]config.Cadence{}},
+				"surge": {Cadences: map[string]config.Cadence{}},
 			},
 		},
 	}
@@ -367,7 +367,7 @@ func TestBuildAgents(t *testing.T) {
 		},
 		Governor: config.GovernorConfig{
 			Modes: map[string]config.ModeConfig{
-				"idle": {Cadences: map[string]string{"scanner": "15m"}},
+				"idle": {Cadences: map[string]config.Cadence{"scanner": "15m"}},
 			},
 		},
 	}
@@ -426,7 +426,7 @@ func TestBuildAgents_OffByCadence(t *testing.T) {
 			Modes: map[string]config.ModeConfig{
 				// SURGE mode pauses scanner but keeps quality on a timer;
 				// brainstorm is paused too but is on-demand, so it must be excluded.
-				"surge": {Cadences: map[string]string{
+				"surge": {Cadences: map[string]config.Cadence{
 					"scanner":    "pause",
 					"quality":    "15m",
 					"brainstorm": "pause",
@@ -460,7 +460,7 @@ func TestBuildFrontendStatus(t *testing.T) {
 		},
 		Governor: config.GovernorConfig{
 			Modes: map[string]config.ModeConfig{
-				"idle": {Cadences: map[string]string{"scanner": "15m"}},
+				"idle": {Cadences: map[string]config.Cadence{"scanner": "15m"}},
 			},
 		},
 		GitHub: config.GitHubConfig{Token: "tok"},
@@ -600,10 +600,10 @@ func TestBuildCadenceMatrix_PausedWithCadence(t *testing.T) {
 		},
 		Governor: config.GovernorConfig{
 			Modes: map[string]config.ModeConfig{
-				"idle":  {Cadences: map[string]string{"scanner": "15m"}},
-				"busy":  {Cadences: map[string]string{"scanner": "5m"}},
-				"quiet": {Cadences: map[string]string{"scanner": "30m"}},
-				"surge": {Cadences: map[string]string{"scanner": "2m"}},
+				"idle":  {Cadences: map[string]config.Cadence{"scanner": "15m"}},
+				"busy":  {Cadences: map[string]config.Cadence{"scanner": "5m"}},
+				"quiet": {Cadences: map[string]config.Cadence{"scanner": "30m"}},
+				"surge": {Cadences: map[string]config.Cadence{"scanner": "2m"}},
 			},
 		},
 	}
@@ -680,7 +680,7 @@ func TestBuildFrontendStatus_WithMetrics(t *testing.T) {
 		Agents:  map[string]config.AgentConfig{"scanner": {Backend: "claude"}},
 		Governor: config.GovernorConfig{
 			Modes: map[string]config.ModeConfig{
-				"idle": {Cadences: map[string]string{"scanner": "15m"}},
+				"idle": {Cadences: map[string]config.Cadence{"scanner": "15m"}},
 			},
 		},
 		GitHub: config.GitHubConfig{Token: "tok"},
@@ -802,10 +802,10 @@ func TestBuildCadenceMatrix_PauseCadence(t *testing.T) {
 		},
 		Governor: config.GovernorConfig{
 			Modes: map[string]config.ModeConfig{
-				"idle":  {Cadences: map[string]string{"scanner": "pause"}},
-				"quiet": {Cadences: map[string]string{"scanner": ""}},
-				"busy":  {Cadences: map[string]string{}},
-				"surge": {Cadences: map[string]string{}},
+				"idle":  {Cadences: map[string]config.Cadence{"scanner": "pause"}},
+				"quiet": {Cadences: map[string]config.Cadence{"scanner": ""}},
+				"busy":  {Cadences: map[string]config.Cadence{}},
+				"surge": {Cadences: map[string]config.Cadence{}},
 			},
 		},
 	}
@@ -880,10 +880,10 @@ func TestBuildCadenceMatrix_PausedAgent(t *testing.T) {
 		},
 		Governor: config.GovernorConfig{
 			Modes: map[string]config.ModeConfig{
-				"idle":  {Cadences: map[string]string{"scanner": "15m"}},
-				"quiet": {Cadences: map[string]string{"scanner": "10m"}},
-				"busy":  {Cadences: map[string]string{"scanner": "5m"}},
-				"surge": {Cadences: map[string]string{"scanner": "2m"}},
+				"idle":  {Cadences: map[string]config.Cadence{"scanner": "15m"}},
+				"quiet": {Cadences: map[string]config.Cadence{"scanner": "10m"}},
+				"busy":  {Cadences: map[string]config.Cadence{"scanner": "5m"}},
+				"surge": {Cadences: map[string]config.Cadence{"scanner": "2m"}},
 			},
 		},
 	}

--- a/v2/pkg/dashboard/time_cadence_ui_test.go
+++ b/v2/pkg/dashboard/time_cadence_ui_test.go
@@ -1,0 +1,26 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTimeOfDayCadenceUIPinning(t *testing.T) {
+	b, err := staticFS.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatalf("reading embedded static/index.html: %v", err)
+	}
+	html := string(b)
+	for _, snippet := range []string{
+		"Daily at…",
+		"Weekdays at…",
+		"Custom cron",
+		"Intl.DateTimeFormat().resolvedOptions().timeZone",
+		"times: (document.getElementById(`cad-${mode}-times`)",
+		"Interval and time-of-day modes are mutually exclusive",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing %q", snippet)
+		}
+	}
+}

--- a/v2/pkg/defsrc/defsrc.go
+++ b/v2/pkg/defsrc/defsrc.go
@@ -125,7 +125,7 @@ type AgentDefinitionSpec struct {
 	LaneKeywords    []string                  `yaml:"laneKeywords,omitempty" json:"laneKeywords,omitempty"`
 	DetectKeywords  []string                  `yaml:"detectKeywords,omitempty" json:"detectKeywords,omitempty"`
 	Aliases         []string                  `yaml:"aliases,omitempty" json:"aliases,omitempty"`
-	Cadences        map[string]string         `yaml:"cadences,omitempty" json:"cadences,omitempty"`
+	Cadences        map[string]config.Cadence `yaml:"cadences,omitempty" json:"cadences,omitempty"`
 	PromptTemplate  string                    `yaml:"promptTemplate,omitempty" json:"promptTemplate,omitempty"`
 	Channels        []config.ChannelConfig    `yaml:"channels,omitempty" json:"channels,omitempty"`
 	Tools           *config.ToolsConfig       `yaml:"tools,omitempty" json:"tools,omitempty"`

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -3,6 +3,7 @@ package governor
 import (
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,9 +20,11 @@ const (
 )
 
 type AgentCadence struct {
-	Agent    string
-	Interval time.Duration
-	Paused   bool
+	Agent          string
+	Interval       time.Duration
+	Schedule       config.Cadence
+	Paused         bool
+	LastOccurrence time.Time
 }
 
 type ModeChange struct {
@@ -188,6 +191,7 @@ type Governor struct {
 	evalHistory []EvalSnapshot
 	kickHistory []KickRecord
 	budget      BudgetInfo
+	now         func() time.Time
 
 	// resumeKicks records the last crash-recovery resume kick granted per
 	// agent (see AllowResumeKick). In-memory only: after a process restart
@@ -223,6 +227,7 @@ func New(cfg config.GovernorConfig, agents map[string]config.AgentConfig, logger
 		evalHistory: make([]EvalSnapshot, 0, evalHistoryCapacity),
 		kickHistory: make([]KickRecord, 0, kickHistoryCapacity),
 		resumeKicks: make(map[string]time.Time),
+		now:         time.Now,
 		budget: BudgetInfo{
 			ByAgent: make(map[string]int64),
 			ByModel: make(map[string]int64),
@@ -280,6 +285,12 @@ func (g *Governor) Evaluate(queueIssues, queuePRs, queueHold, slaViolations int)
 				g.logger.Info("agent cadence: paused by mode",
 					"agent", agentName,
 					"mode", g.state.Mode,
+				)
+			} else if cadence.Schedule.Mode() != config.CadenceModeInterval {
+				g.logger.Info("agent cadence: active time-of-day schedule",
+					"agent", agentName,
+					"mode", g.state.Mode,
+					"schedule", cadence.Schedule.HumanSummary(),
 				)
 			} else if cadence.Interval > 0 {
 				g.logger.Info("agent cadence: active",
@@ -368,15 +379,15 @@ func (g *Governor) updateCadences() {
 	cadences := make(map[string]AgentCadence, len(g.agents))
 
 	for agentName := range g.agents {
-		cadenceStr, ok := g.resolveCadence(modeName, agentName)
-		if !ok || cadenceStr == cadenceValueOff {
+		cadence, ok := g.resolveCadence(modeName, agentName)
+		if !ok || strings.EqualFold(strings.TrimSpace(cadence.Interval()), cadenceValueOff) {
 			// No cadence configured for this agent in this mode (or an
 			// explicit "off"): no timer kicks. Leaving the agent out of the
 			// map — rather than keeping a stale entry — is the fix.
 			continue
 		}
 
-		if cadenceStr == cadenceValuePause || cadenceStr == cadenceValuePaused {
+		if cadence.IsPaused() {
 			cadences[agentName] = AgentCadence{
 				Agent:  agentName,
 				Paused: true,
@@ -384,21 +395,31 @@ func (g *Governor) updateCadences() {
 			continue
 		}
 
-		dur, err := time.ParseDuration(cadenceStr)
-		if err != nil {
-			g.logger.Warn("invalid cadence duration — agent will receive no timer kicks until fixed",
+		if err := cadence.Validate(); err != nil {
+			g.logger.Warn("invalid cadence — agent will receive no timer kicks until fixed",
 				"agent", agentName,
 				"mode", g.state.Mode,
-				"value", cadenceStr,
+				"value", cadence.String(),
 				"error", err,
 			)
 			continue
 		}
 
-		cadences[agentName] = AgentCadence{
-			Agent:    agentName,
-			Interval: dur,
+		entry := AgentCadence{Agent: agentName, Schedule: cadence}
+		if cadence.Mode() == config.CadenceModeInterval {
+			dur, err := time.ParseDuration(cadence.Interval())
+			if err != nil {
+				g.logger.Warn("invalid cadence duration — agent will receive no timer kicks until fixed",
+					"agent", agentName,
+					"mode", g.state.Mode,
+					"value", cadence.Interval(),
+					"error", err,
+				)
+				continue
+			}
+			entry.Interval = dur
 		}
+		cadences[agentName] = entry
 	}
 
 	g.state.Cadences = cadences
@@ -406,7 +427,7 @@ func (g *Governor) updateCadences() {
 
 // resolveCadence returns the configured cadence string for one agent in one
 // mode, falling back to the idle mode's entry when the mode defines none.
-func (g *Governor) resolveCadence(modeName, agentName string) (string, bool) {
+func (g *Governor) resolveCadence(modeName, agentName string) (config.Cadence, bool) {
 	if mode, ok := g.cfg.Modes[modeName]; ok {
 		if c, ok := mode.Cadences[agentName]; ok {
 			return c, true
@@ -431,7 +452,7 @@ func (g *Governor) budgetExhausted() bool {
 }
 
 func (g *Governor) agentsDueForKick() []string {
-	now := time.Now()
+	now := g.now()
 	var due []string
 
 	exhausted := g.budgetExhausted()
@@ -447,7 +468,7 @@ func (g *Governor) agentsDueForKick() []string {
 		if cadence.Paused {
 			continue
 		}
-		if cadence.Interval == 0 {
+		if cadence.Interval == 0 && cadence.Schedule.Mode() == config.CadenceModeInterval {
 			continue
 		}
 		if ac, ok := g.agents[agentName]; ok && ac.OnDemand {
@@ -461,8 +482,21 @@ func (g *Governor) agentsDueForKick() []string {
 			continue
 		}
 
-		lastKick, kicked := g.state.LastKick[agentName]
-		if !kicked || now.Sub(lastKick) >= cadence.Interval {
+		lastKick := g.state.LastKick[agentName]
+		if cadence.Schedule.Mode() != config.CadenceModeInterval {
+			// Time-of-day cadences are exact wall-clock schedules. Governor modes
+			// only decide whether this schedule is active; they never scale the
+			// schedule's times. A short catch-up window grants at most one kick
+			// after downtime, and comparing the scheduled occurrence to LastKick
+			// dedupes repeated governor ticks inside the same minute.
+			if occurrence, ok := cadence.Schedule.DueOccurrence(lastKick, now, config.CadenceCatchUpWindow); ok {
+				cadence.LastOccurrence = occurrence
+				g.state.Cadences[agentName] = cadence
+				due = append(due, agentName)
+			}
+			continue
+		}
+		if lastKick.IsZero() || now.Sub(lastKick) >= cadence.Interval {
 			due = append(due, agentName)
 		}
 	}
@@ -516,7 +550,7 @@ func (g *Governor) AllowResumeKick(agentName string) bool {
 	defer g.mu.Unlock()
 
 	cadence, ok := g.state.Cadences[agentName]
-	if !ok || cadence.Paused || cadence.Interval <= 0 {
+	if !ok || cadence.Paused || (cadence.Interval <= 0 && cadence.Schedule.Mode() == config.CadenceModeInterval) {
 		return false
 	}
 	if ac, ok := g.agents[agentName]; ok && (ac.OnDemand || !ac.UsesGovernorKick()) {
@@ -525,17 +559,20 @@ func (g *Governor) AllowResumeKick(agentName string) bool {
 	if g.budgetExhausted() && !g.budgetExempt(agentName) {
 		return false
 	}
-	if last, ok := g.resumeKicks[agentName]; ok && time.Since(last) < cadence.Interval {
+	if cadence.Schedule.Mode() != config.CadenceModeInterval {
 		return false
 	}
-	g.resumeKicks[agentName] = time.Now()
+	if last, ok := g.resumeKicks[agentName]; ok && g.now().Sub(last) < cadence.Interval {
+		return false
+	}
+	g.resumeKicks[agentName] = g.now()
 	return true
 }
 
 func (g *Governor) RecordKick(agentName string) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	now := time.Now()
+	now := g.now()
 	g.state.LastKick[agentName] = now
 	g.appendKickHistory(KickRecord{Timestamp: now, Agent: agentName})
 }

--- a/v2/pkg/governor/governor_cadence_burn_test.go
+++ b/v2/pkg/governor/governor_cadence_burn_test.go
@@ -29,11 +29,11 @@ const (
 func TestUpdateCadences_NoStaleCarryOverAcrossModes(t *testing.T) {
 	cfg := config.GovernorConfig{
 		Modes: map[string]config.ModeConfig{
-			"idle":  {Threshold: 0, Cadences: map[string]string{"scanner": "6h"}},
-			"quiet": {Threshold: 2, Cadences: map[string]string{"scanner": "6h"}},
+			"idle":  {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": "6h"}},
+			"quiet": {Threshold: 2, Cadences: map[string]config.Cadence{"scanner": "6h"}},
 			// busy defines a short scanner cadence; quiet/idle are 6h.
-			"busy":  {Threshold: 10, Cadences: map[string]string{"scanner": "5m"}},
-			"surge": {Threshold: 20, Cadences: map[string]string{}},
+			"busy":  {Threshold: 10, Cadences: map[string]config.Cadence{"scanner": "5m"}},
+			"surge": {Threshold: 20, Cadences: map[string]config.Cadence{}},
 		},
 	}
 	agents := map[string]config.AgentConfig{
@@ -67,8 +67,8 @@ func TestUpdateCadences_NoStaleCarryOverAcrossModes(t *testing.T) {
 func TestUpdateCadences_MissingModeBlockFallsBackToIdle(t *testing.T) {
 	cfg := config.GovernorConfig{
 		Modes: map[string]config.ModeConfig{
-			"idle": {Threshold: 0, Cadences: map[string]string{"scanner": "4h"}},
-			"busy": {Threshold: 10, Cadences: map[string]string{"scanner": "2m"}},
+			"idle": {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": "4h"}},
+			"busy": {Threshold: 10, Cadences: map[string]config.Cadence{"scanner": "2m"}},
 			// no "quiet" or "surge" blocks at all
 		},
 	}
@@ -90,8 +90,8 @@ func TestUpdateCadences_MissingModeBlockFallsBackToIdle(t *testing.T) {
 func TestUpdateCadences_IdleFallbackRespectsPause(t *testing.T) {
 	cfg := config.GovernorConfig{
 		Modes: map[string]config.ModeConfig{
-			"idle": {Threshold: 0, Cadences: map[string]string{"supervisor": "pause"}},
-			"busy": {Threshold: 10, Cadences: map[string]string{}},
+			"idle": {Threshold: 0, Cadences: map[string]config.Cadence{"supervisor": "pause"}},
+			"busy": {Threshold: 10, Cadences: map[string]config.Cadence{}},
 		},
 	}
 	agents := map[string]config.AgentConfig{
@@ -114,7 +114,7 @@ func TestUpdateCadences_IdleFallbackRespectsPause(t *testing.T) {
 func TestUpdateCadences_OffMeansNoKicks(t *testing.T) {
 	cfg := config.GovernorConfig{
 		Modes: map[string]config.ModeConfig{
-			"idle": {Threshold: 0, Cadences: map[string]string{"scanner": "off"}},
+			"idle": {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": "off"}},
 		},
 	}
 	agents := map[string]config.AgentConfig{
@@ -135,7 +135,7 @@ func resumeTestGovernor(t *testing.T, cadence string) *Governor {
 	t.Helper()
 	cfg := config.GovernorConfig{
 		Modes: map[string]config.ModeConfig{
-			"idle": {Threshold: 0, Cadences: map[string]string{"scanner": cadence}},
+			"idle": {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": config.Cadence(cadence)}},
 		},
 	}
 	agents := map[string]config.AgentConfig{
@@ -190,7 +190,7 @@ func TestAllowResumeKick_DeniedWithoutCadence(t *testing.T) {
 func TestAllowResumeKick_DeniedForOnDemand(t *testing.T) {
 	cfg := config.GovernorConfig{
 		Modes: map[string]config.ModeConfig{
-			"idle": {Threshold: 0, Cadences: map[string]string{"scanner": "1h"}},
+			"idle": {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": "1h"}},
 		},
 	}
 	agents := map[string]config.AgentConfig{

--- a/v2/pkg/governor/governor_extra_test.go
+++ b/v2/pkg/governor/governor_extra_test.go
@@ -10,10 +10,10 @@ import (
 func testGovernor() *Governor {
 	cfg := config.GovernorConfig{
 		Modes: map[string]config.ModeConfig{
-			"idle":  {Threshold: 0, Cadences: map[string]string{"scanner": "15m", "supervisor": "pause"}},
-			"quiet": {Threshold: 2, Cadences: map[string]string{"scanner": "10m"}},
-			"busy":  {Threshold: 10, Cadences: map[string]string{"scanner": "5m"}},
-			"surge": {Threshold: 20, Cadences: map[string]string{"scanner": "2m"}},
+			"idle":  {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": "15m", "supervisor": "pause"}},
+			"quiet": {Threshold: 2, Cadences: map[string]config.Cadence{"scanner": "10m"}},
+			"busy":  {Threshold: 10, Cadences: map[string]config.Cadence{"scanner": "5m"}},
+			"surge": {Threshold: 20, Cadences: map[string]config.Cadence{"scanner": "2m"}},
 		},
 	}
 	agents := map[string]config.AgentConfig{
@@ -282,7 +282,7 @@ func TestAgentsDueForKick(t *testing.T) {
 func TestUpdateCadences_InvalidDuration(t *testing.T) {
 	cfg := config.GovernorConfig{
 		Modes: map[string]config.ModeConfig{
-			"idle": {Threshold: 0, Cadences: map[string]string{"scanner": "not-a-duration"}},
+			"idle": {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": "not-a-duration"}},
 		},
 	}
 	agents := map[string]config.AgentConfig{
@@ -361,7 +361,7 @@ func TestAgentsDueForKick_ZeroInterval(t *testing.T) {
 	// Test that agents with zero cadence interval are skipped
 	cfg := config.GovernorConfig{
 		Modes: map[string]config.ModeConfig{
-			"idle": {Threshold: 0, Cadences: map[string]string{"scanner": "0"}},
+			"idle": {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": "0"}},
 		},
 	}
 	agents := map[string]config.AgentConfig{
@@ -430,7 +430,7 @@ func TestSeedModeHistory_OverCapacity(t *testing.T) {
 func TestUpdateCadences_PausedAgent(t *testing.T) {
 	cfg := config.GovernorConfig{
 		Modes: map[string]config.ModeConfig{
-			"idle": {Threshold: 0, Cadences: map[string]string{"scanner": "paused"}},
+			"idle": {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": "paused"}},
 		},
 	}
 	agents := map[string]config.AgentConfig{

--- a/v2/pkg/governor/governor_test.go
+++ b/v2/pkg/governor/governor_test.go
@@ -23,7 +23,7 @@ func testLogger() *slog.Logger {
 //	QUIET  > 2
 //	IDLE   otherwise
 func standardConfig(agents ...string) (config.GovernorConfig, map[string]config.AgentConfig) {
-	cadences := make(map[string]string, len(agents))
+	cadences := make(map[string]config.Cadence, len(agents))
 	for _, a := range agents {
 		cadences[a] = "15m"
 	}
@@ -244,7 +244,7 @@ func TestEvaluate_ExpiredCadenceIsDue(t *testing.T) {
 		Modes: map[string]config.ModeConfig{
 			"busy": {
 				Threshold: 10,
-				Cadences:  map[string]string{"worker": "1ms"}, // extremely short cadence
+				Cadences:  map[string]config.Cadence{"worker": "1ms"}, // extremely short cadence
 			},
 		},
 	}
@@ -274,7 +274,7 @@ func TestEvaluate_PausedAgentNeverDue(t *testing.T) {
 		Modes: map[string]config.ModeConfig{
 			"busy": {
 				Threshold: 10,
-				Cadences: map[string]string{
+				Cadences: map[string]config.Cadence{
 					"active": "1ms",
 					"paused": "pause",
 				},
@@ -314,7 +314,7 @@ func TestEvaluate_PausedVariantSpelling(t *testing.T) {
 		Modes: map[string]config.ModeConfig{
 			"quiet": {
 				Threshold: 2,
-				Cadences:  map[string]string{"robot": "paused"},
+				Cadences:  map[string]config.Cadence{"robot": "paused"},
 			},
 		},
 	}
@@ -344,7 +344,7 @@ func TestEvaluate_AgentWithNoCadenceInModeNotDue(t *testing.T) {
 		Modes: map[string]config.ModeConfig{
 			"busy": {
 				Threshold: 10,
-				Cadences:  map[string]string{}, // no cadences at all
+				Cadences:  map[string]config.Cadence{}, // no cadences at all
 			},
 		},
 	}

--- a/v2/pkg/governor/governor_time_cadence_test.go
+++ b/v2/pkg/governor/governor_time_cadence_test.go
@@ -1,0 +1,70 @@
+package governor
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"gopkg.in/yaml.v3"
+)
+
+func timeCadenceGovernor(c config.Cadence, now time.Time) *Governor {
+	cfg := config.GovernorConfig{Modes: map[string]config.ModeConfig{
+		"idle": {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": c}},
+	}}
+	g := New(cfg, map[string]config.AgentConfig{"scanner": {Backend: "bob", Enabled: true}}, slog.Default())
+	g.now = func() time.Time { return now }
+	return g
+}
+
+func TestTimeCadenceDueOncePerOccurrence(t *testing.T) {
+	c, err := configFromYAML(`{times: ["09:00"], tz: UTC}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 7, 9, 0, 5, 0, time.UTC)
+	g := timeCadenceGovernor(c, now)
+	if due := g.Evaluate(0, 0, 0, 0); len(due) != 1 || due[0] != "scanner" {
+		t.Fatalf("due at occurrence = %v", due)
+	}
+	g.RecordKick("scanner")
+	if due := g.Evaluate(0, 0, 0, 0); len(due) != 0 {
+		t.Fatalf("same occurrence double-fired: %v", due)
+	}
+}
+
+func TestTimeCadencePausedOffAndCatchUp(t *testing.T) {
+	c, err := configFromYAML(`{times: ["09:00"], tz: UTC}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := timeCadenceGovernor(c, time.Date(2026, 8, 7, 9, 8, 0, 0, time.UTC))
+	g.SeedLastKicks(map[string]time.Time{"scanner": time.Date(2026, 8, 6, 9, 0, 0, 0, time.UTC)})
+	if due := g.Evaluate(0, 0, 0, 0); len(due) != 1 {
+		t.Fatalf("expected catch-up inside window, got %v", due)
+	}
+	g.now = func() time.Time { return time.Date(2026, 8, 7, 9, 11, 0, 0, time.UTC) }
+	if due := g.Evaluate(0, 0, 0, 0); len(due) != 0 {
+		t.Fatalf("expected missed occurrence outside catch-up window to skip, got %v", due)
+	}
+
+	g.cfg.Modes["idle"] = config.ModeConfig{Threshold: 0, Cadences: map[string]config.Cadence{"scanner": "off"}}
+	if due := g.Evaluate(0, 0, 0, 0); len(due) != 0 {
+		t.Fatalf("off agent fired: %v", due)
+	}
+}
+
+func configFromYAML(src string) (config.Cadence, error) {
+	var c config.Cadence
+	err := c.UnmarshalYAML(yamlNode(src))
+	return c, err
+}
+
+func yamlNode(src string) *yaml.Node {
+	var n yaml.Node
+	if err := yaml.Unmarshal([]byte(src), &n); err != nil {
+		panic(err)
+	}
+	return n.Content[0]
+}

--- a/v2/pkg/snapshot/state.go
+++ b/v2/pkg/snapshot/state.go
@@ -6,31 +6,33 @@ import (
 	"log/slog"
 	"os"
 	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
 const maxStateAge = 7 * 24 * time.Hour
 
 type PersistedState struct {
-	SavedAt          time.Time                        `json:"saved_at"`
-	Agents           map[string]AgentState            `json:"agents"`
-	GovernorMode     string                           `json:"governor_mode"`
-	BudgetLimit      int64                            `json:"budget_limit"`
-	BudgetIgnored    []string                         `json:"budget_ignored"`
-	BudgetIgnoreAll  bool                             `json:"budget_ignore_all,omitempty"`
-	CadenceOverrides map[string]map[string]string     `json:"cadence_overrides,omitempty"`
-	LastKicks        map[string]time.Time             `json:"last_kicks,omitempty"`
-	BudgetSpend      int64                            `json:"budget_spend,omitempty"`
-	BudgetResetAt    time.Time                        `json:"budget_reset_at,omitempty"`
-	BudgetByAgent    map[string]int64                 `json:"budget_by_agent,omitempty"`
-	BudgetByModel    map[string]int64                 `json:"budget_by_model,omitempty"`
+	SavedAt          time.Time                            `json:"saved_at"`
+	Agents           map[string]AgentState                `json:"agents"`
+	GovernorMode     string                               `json:"governor_mode"`
+	BudgetLimit      int64                                `json:"budget_limit"`
+	BudgetIgnored    []string                             `json:"budget_ignored"`
+	BudgetIgnoreAll  bool                                 `json:"budget_ignore_all,omitempty"`
+	CadenceOverrides map[string]map[string]config.Cadence `json:"cadence_overrides,omitempty"`
+	LastKicks        map[string]time.Time                 `json:"last_kicks,omitempty"`
+	BudgetSpend      int64                                `json:"budget_spend,omitempty"`
+	BudgetResetAt    time.Time                            `json:"budget_reset_at,omitempty"`
+	BudgetByAgent    map[string]int64                     `json:"budget_by_agent,omitempty"`
+	BudgetByModel    map[string]int64                     `json:"budget_by_model,omitempty"`
 	// BudgetWindowBaseline is the lifetime token total at the start of the
 	// current budget window (see governor.BudgetInfo.WindowBaseline).
-	BudgetWindowBaseline int64                        `json:"budget_window_baseline,omitempty"`
-	KickHistory      []GovKickEntry                   `json:"kick_history,omitempty"`
-	IssueCosts       map[string]int64                 `json:"issue_costs,omitempty"`
-	LastEval         time.Time                        `json:"last_eval,omitempty"`
-	ACMMLevel        *int                             `json:"acmm_level,omitempty"`
-	ConfigOverrides  *ConfigOverrides                 `json:"config_overrides,omitempty"`
+	BudgetWindowBaseline int64            `json:"budget_window_baseline,omitempty"`
+	KickHistory          []GovKickEntry   `json:"kick_history,omitempty"`
+	IssueCosts           map[string]int64 `json:"issue_costs,omitempty"`
+	LastEval             time.Time        `json:"last_eval,omitempty"`
+	ACMMLevel            *int             `json:"acmm_level,omitempty"`
+	ConfigOverrides      *ConfigOverrides `json:"config_overrides,omitempty"`
 }
 
 type ConfigOverrides struct {


### PR DESCRIPTION
## Summary
- Adds backward-compatible structured cadence values: existing interval strings (`5m`, `4h`, `pause`) still load/marshal as strings; time-of-day schedules use `{times, days, tz}` and advanced schedules use `{cron, tz}`.
- Uses `github.com/robfig/cron/v3` with `CRON_TZ=` per schedule for timezone/DST-aware next-occurrence calculation.
- Wires structured cadences through config validation, governor state, persisted snapshot restore, dashboard APIs, agent export/import definitions, status cards, and the cadence matrix.
- Adds a progressive cadence editor with presets, interval/times/cron modes, browser-captured IANA timezone, live summaries, short chips, and server-computed next-run tooltips.

## Semantics
- A cadence cell is mutually exclusive: interval OR times OR cron. Config load and API writes reject mixed forms, invalid HH:MM values, bad timezones, bad cron, and empty structured schedules.
- Time schedules fire at exact wall-clock occurrences. Governor mode gates whether that agent+mode schedule is active; it does not scale times with quiet/busy/surge multipliers.
- `pause`/`off`, paused agents, on-demand agents, non-kick channels, and budget gates still suppress kicks.
- Downtime catch-up is bounded to one kick for a missed occurrence within `10m`; older missed occurrences are skipped.
- DST handling is delegated to robfig/cron and schedule-local IANA locations. Tests cover spring-forward nonexistent times, fall-back repeated times, day filters, multiple times, and Pacific/Auckland.

## UI
- Cadence tab now presents presets first (Daily at…, Weekdays at…, Every N hours), then Interval/Times/Custom cron modes.
- Times mode captures `Intl.DateTimeFormat().resolvedOptions().timeZone` at save time and stores/displays that IANA timezone explicitly.
- Matrix/card cadence labels show time schedules with a clock-prefixed chip and timezone abbreviation; matrix tooltips include the full summary and server-side next run.

## Tests / validation
- `go build ./...`
- `go vet ./...`
- `go test ./pkg/config/ ./pkg/governor/ ./pkg/dashboard/ -count=1`
- `go test ./... -count=1` was run once; all normal packages passed, but the existing `github.com/kubestellar/hive/v2/test` inception suite failed because the external hive endpoint `http://192.168.4.85:3003` was unreachable/timeouts.
