### PR TITLE
✨ feat(review): multi-perspective review verdicts with capped fix loop (phase 1)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -51,6 +51,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/promptsrc"
 	"github.com/kubestellar/hive/v2/pkg/proxy"
 	"github.com/kubestellar/hive/v2/pkg/retro"
+	"github.com/kubestellar/hive/v2/pkg/review"
 	"github.com/kubestellar/hive/v2/pkg/scheduler"
 	"github.com/kubestellar/hive/v2/pkg/snapshot"
 	"github.com/kubestellar/hive/v2/pkg/timeline"
@@ -4332,7 +4333,7 @@ func runEvalCycle(
 	escalatedPRs := runEscalationSweep(ctx, cfg, ghClient, actionable, notifier, logger)
 
 	intentVerdicts := writeIntentVerdicts(ctx, cfg, ghClient, actionable, beadStores, logger)
-	writeMergeEligible(actionable, actionable.Hold, cfg.Project.Org, escalatedPRs, cfg.Intent.Enforce, intentVerdicts, logger)
+	writeMergeEligible(actionable, actionable.Hold, cfg.Project.Org, escalatedPRs, cfg.Intent.Enforce, intentVerdicts, cfg.Review.RequireApproval, logger)
 
 	// Stuck-PR reaper (backstop): re-dispatch a fix for any hive-authored PR
 	// that is red on a required check AND stale (its red head SHA unchanged past
@@ -5785,7 +5786,7 @@ func fullRepoName(repo, org string) string {
 	return org + "/" + repo
 }
 
-func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldResult, org string, escalatedPRs map[string]bool, enforceIntent bool, intentVerdicts map[string]intent.Verdict, logger *slog.Logger) {
+func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldResult, org string, escalatedPRs map[string]bool, enforceIntent bool, intentVerdicts map[string]intent.Verdict, requireReviewApproval bool, logger *slog.Logger) {
 	holdSet := make(map[string]bool)
 	for _, h := range hold.Items {
 		key := fmt.Sprintf("%s/%d", h.Repo, h.Number)
@@ -5828,6 +5829,17 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 
 	var eligible []eligiblePR
 	var failing []failingPR
+	var reviewArtifact review.Artifact
+	reviewLoaded := false
+	if requireReviewApproval {
+		var err error
+		reviewArtifact, err = review.LoadArtifact("")
+		if err != nil {
+			logger.Warn("review approval required but review-verdicts.json is unavailable; merge eligibility will fail closed", "error", err)
+		} else {
+			reviewLoaded = true
+		}
+	}
 	for _, pr := range actionable.PRs.Items {
 		if pr.Draft {
 			continue
@@ -5883,6 +5895,9 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 			} else if l == "dco-signoff: no" {
 				dco = "no"
 			}
+		}
+		if requireReviewApproval && (!reviewLoaded || !reviewArtifact.HasAggregateApproval(fullRepo, pr.Number, pr.HeadSHA)) {
+			continue
 		}
 		eligible = append(eligible, eligiblePR{
 			Number:    pr.Number,

--- a/v2/docs/review-swarm.md
+++ b/v2/docs/review-swarm.md
@@ -1,0 +1,54 @@
+# Review swarm (phase 1)
+
+Hive's review swarm adds a structured review-to-fix decision point for pull requests. Phase 1 implements the data model, prompt construction, verdict collector, and optional merge-gate integration; governor fan-out to parallel review agents is deferred.
+
+## Perspectives
+
+The `pkg/review` package defines five review perspectives:
+
+- `correctness`
+- `security`
+- `intent-alignment`
+- `style`
+- `docs-currency`
+
+Each reviewer returns a JSON object that extends the `pkg/outputschema.AgentReport` contract. Required AgentReport fields remain `lane`, `kind`, `findings`, `prs_opened`, `beads_filed`, and `summary`; review reports add `perspective`, `verdict`, `repo`, `number`, and optional `head_sha`. `kind` must be `review`.
+
+Allowed verdicts are `approve`, `changes_requested`, `requires_human`, and `reject`. Finding severities reuse `outputschema.Severity`: `info`, `low`, `medium`, `high`, and `critical`.
+
+## Verdict flow
+
+The collector reads review report artifacts from `/var/run/hive-metrics/review-report-*.json`, validates the AgentReport envelope plus review fields, aggregates by PR, and writes `/var/run/hive-metrics/review-verdicts.json`.
+
+Aggregation rules are deterministic:
+
+1. Any `reject` recommends closing the PR.
+2. Any finding at or above the human threshold defaults to `requires_human`.
+3. Any explicit `requires_human` yields `requires_human`.
+4. Any `changes_requested` enters a fix cycle while below the fix cap.
+5. All five default perspectives approving yields a merge-eligible aggregate.
+6. Missing perspectives or any other non-unanimous result requires human review.
+
+The default human threshold is `high`. Review-triggered fix cycles use the same cap value as the escalation re-engagement circuit breaker (`escalation.MaxReEngagements`) so bot loops remain bounded.
+
+## Configuration
+
+Merge-gate use is opt-in and preserves existing behavior by default:
+
+```yaml
+review:
+  require_approval: true
+```
+
+When `review.require_approval` is false or omitted, `merge-eligible.json` is produced as before. When true, a PR is included only if `review-verdicts.json` contains an aggregate `approve` for the same repo, PR number, and head SHA.
+
+## Prompt construction
+
+`pkg/review` provides prompt builders for one prompt per perspective plus a sequential fallback prompt. These prompts instruct review-capable agents to emit the extended AgentReport JSON shape above.
+
+## Deferred work
+
+- Wire governor/scheduler fan-out so the five perspective prompts run in parallel review-capable agents.
+- Feed `changes_requested` aggregates directly into an auto-fix kick lane.
+- Map aggregate verdicts to labels/comments (`hold`, `needs-human`, close recommendation) once fan-out exists.
+- Add dashboard visibility for review verdict artifacts.

--- a/v2/hive.yaml.example
+++ b/v2/hive.yaml.example
@@ -201,6 +201,12 @@ governor:
 #   long_stall_days: 7
 #   recent_closed_window_s: 604800
 
+# Review swarm merge gate — optional structured multi-perspective PR review.
+# Default is false to preserve existing merge eligibility behavior; when true,
+# merge-eligible.json requires an aggregate approve in review-verdicts.json.
+# review:
+#   require_approval: false
+
 # GitHub authentication — use ONE of these methods
 github:
   # Option 1: Personal access token (simplest)

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	Intent     IntentConfig     `yaml:"intent,omitempty" json:"intent,omitempty"`
 	Escalation EscalationConfig `yaml:"escalation,omitempty" json:"escalation,omitempty"`
 	Retro      RetroConfig      `yaml:"retro,omitempty" json:"retro,omitempty"`
+	Review     ReviewConfig     `yaml:"review,omitempty" json:"review,omitempty"`
 
 	// RemovedAgents are agent names an operator deliberately deleted. It is a
 	// TOMBSTONE list, and it exists because deletion had no durable record
@@ -3787,6 +3788,13 @@ type EscalationConfig struct {
 	// Threshold is the distinct-red-attempt count that triggers escalation.
 	// Zero means DefaultEscalationThreshold.
 	Threshold int `yaml:"threshold,omitempty" json:"threshold,omitempty"`
+}
+
+// ReviewConfig gates the optional structured review-swarm merge gate. The zero
+// value preserves existing behavior: merge eligibility does not require a
+// review-verdicts.json aggregate approval unless an operator opts in.
+type ReviewConfig struct {
+	RequireApproval bool `yaml:"require_approval,omitempty" json:"require_approval,omitempty"`
 }
 
 // DefaultEscalationThreshold matches escalation.DefaultThreshold; duplicated

--- a/v2/pkg/review/prompts.go
+++ b/v2/pkg/review/prompts.go
@@ -1,0 +1,78 @@
+package review
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type PullRequest struct {
+	Repo    string
+	Number  int
+	Title   string
+	Author  string
+	HeadSHA string
+	URL     string
+}
+
+func BuildPerspectivePrompt(p Perspective, pr PullRequest) string {
+	focus := map[Perspective]string{
+		PerspectiveCorrectness:     "correctness, regressions, edge cases, data races, and test adequacy",
+		PerspectiveSecurity:        "exploitable vulnerabilities, unsafe permissions, injection, secrets, and trust-boundary regressions",
+		PerspectiveIntentAlignment: "whether the diff solves the linked issue without unrelated scope creep",
+		PerspectiveStyle:           "maintainability, conventions, readability, and repository idioms",
+		PerspectiveDocsCurrency:    "documentation, examples, generated docs, and operator-facing text that must change with behavior",
+	}[p]
+	if focus == "" {
+		focus = "the named review perspective"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "[review-perspective:%s]\n", p)
+	fmt.Fprintf(&b, "Review PR %s#%d", pr.Repo, pr.Number)
+	if pr.Title != "" {
+		fmt.Fprintf(&b, " — %s", pr.Title)
+	}
+	b.WriteString(".\n")
+	if pr.URL != "" {
+		fmt.Fprintf(&b, "URL: %s\n", pr.URL)
+	}
+	if pr.HeadSHA != "" {
+		fmt.Fprintf(&b, "Head SHA: %s\n", pr.HeadSHA)
+	}
+	if pr.Author != "" {
+		fmt.Fprintf(&b, "Author: @%s\n", strings.TrimPrefix(pr.Author, "@"))
+	}
+	fmt.Fprintf(&b, "Focus ONLY on %s. Do not duplicate other perspectives unless the issue is severe.\n\n", focus)
+	b.WriteString("Return exactly one JSON object: the standard outputschema AgentReport fields plus perspective, verdict, repo, number, and head_sha.\n")
+	b.WriteString("Required AgentReport fields: lane, kind, findings, prs_opened, beads_filed, summary. Set kind to \"review\" and lane to \"review-swarm\". Use [] for empty arrays.\n")
+	b.WriteString("Allowed verdicts: approve, changes_requested, requires_human, reject. Finding severities: info, low, medium, high, critical.\n")
+	b.WriteString("Use approve only when this perspective finds no blocker. Use changes_requested for agent-fixable issues. Use requires_human for ambiguous/high-risk judgment. Use reject for fundamentally unsuitable or harmful PRs.\n")
+	return b.String()
+}
+
+func BuildPerspectivePrompts(pr PullRequest, perspectives []Perspective) map[Perspective]string {
+	if len(perspectives) == 0 {
+		perspectives = DefaultPerspectives
+	}
+	out := make(map[Perspective]string, len(perspectives))
+	for _, p := range perspectives {
+		out[p] = BuildPerspectivePrompt(p, pr)
+	}
+	return out
+}
+
+func BuildSequentialPrompt(pr PullRequest, perspectives []Perspective) string {
+	prompts := BuildPerspectivePrompts(pr, perspectives)
+	keys := make([]string, 0, len(prompts))
+	for p := range prompts {
+		keys = append(keys, string(p))
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString("Run the following review perspectives sequentially. In production the governor may fan these out to parallel review-capable agents; this prompt is the phase-1 sequential fallback.\n\n")
+	for _, k := range keys {
+		b.WriteString(prompts[Perspective(k)])
+		b.WriteString("\n---\n")
+	}
+	return b.String()
+}

--- a/v2/pkg/review/review.go
+++ b/v2/pkg/review/review.go
@@ -1,0 +1,375 @@
+// Package review models Hive's structured multi-perspective PR review verdicts.
+package review
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/escalation"
+	"github.com/kubestellar/hive/v2/pkg/outputschema"
+)
+
+const (
+	PerspectiveCorrectness     Perspective = "correctness"
+	PerspectiveSecurity        Perspective = "security"
+	PerspectiveIntentAlignment Perspective = "intent-alignment"
+	PerspectiveStyle           Perspective = "style"
+	PerspectiveDocsCurrency    Perspective = "docs-currency"
+)
+
+var DefaultPerspectives = []Perspective{
+	PerspectiveCorrectness,
+	PerspectiveSecurity,
+	PerspectiveIntentAlignment,
+	PerspectiveStyle,
+	PerspectiveDocsCurrency,
+}
+
+type Perspective string
+
+type Verdict string
+
+const (
+	VerdictApprove          Verdict = "approve"
+	VerdictChangesRequested Verdict = "changes_requested"
+	VerdictRequiresHuman    Verdict = "requires_human"
+	VerdictReject           Verdict = "reject"
+)
+
+const (
+	// DefaultHumanThreshold is the first finding severity that promotes an
+	// aggregate review to requires_human even when perspective verdicts agree.
+	DefaultHumanThreshold = outputschema.SeverityHigh
+
+	// DefaultFixCycleCap mirrors escalation.MaxReEngagements so review-triggered
+	// bot fix iterations share the same bounded-loop policy as CI re-engagements.
+	DefaultFixCycleCap = escalation.MaxReEngagements
+
+	ReviewReportFilePrefix = "review-report-"
+	ReviewReportFileSuffix = ".json"
+	ReviewVerdictsFile     = "review-verdicts.json"
+)
+
+var ReviewVerdictsPath = filepath.Join(outputschema.AgentReportDir, ReviewVerdictsFile)
+
+type PerspectiveReport struct {
+	outputschema.AgentReport
+	Perspective Perspective `json:"perspective"`
+	Verdict     Verdict     `json:"verdict"`
+	Repo        string      `json:"repo"`
+	Number      int         `json:"number"`
+	HeadSHA     string      `json:"head_sha,omitempty"`
+}
+
+type AggregateOptions struct {
+	HumanThreshold outputschema.Severity
+	FixAttempts    int
+	MaxFixAttempts int
+}
+
+type Aggregate struct {
+	Repo             string                  `json:"repo"`
+	Number           int                     `json:"number"`
+	HeadSHA          string                  `json:"head_sha,omitempty"`
+	Verdict          Verdict                 `json:"verdict"`
+	MergeEligible    bool                    `json:"merge_eligible"`
+	FixCycle         bool                    `json:"fix_cycle"`
+	RequiresHuman    bool                    `json:"requires_human"`
+	CloseRecommended bool                    `json:"close_recommended"`
+	FixAttempts      int                     `json:"fix_attempts,omitempty"`
+	MaxFixAttempts   int                     `json:"max_fix_attempts,omitempty"`
+	Threshold        outputschema.Severity   `json:"human_threshold"`
+	Reasons          []string                `json:"reasons,omitempty"`
+	Findings         []PerspectiveFinding    `json:"findings,omitempty"`
+	Perspectives     map[Perspective]Verdict `json:"perspectives"`
+}
+
+type PerspectiveFinding struct {
+	Perspective Perspective          `json:"perspective"`
+	Finding     outputschema.Finding `json:"finding"`
+}
+
+type Artifact struct {
+	GeneratedAt time.Time   `json:"generated_at"`
+	Items       []Aggregate `json:"items"`
+}
+
+func ValidateReport(raw []byte) (*PerspectiveReport, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, fmt.Errorf("review report must be a non-empty JSON object")
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var report PerspectiveReport
+	if err := dec.Decode(&report); err != nil {
+		return nil, fmt.Errorf("decode review report: %w", err)
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		return nil, fmt.Errorf("review report must contain exactly one JSON object")
+	}
+	if _, err := outputschema.Validate(agentReportJSON(report.AgentReport)); err != nil {
+		return nil, err
+	}
+	if report.Kind != outputschema.KindReview {
+		return nil, fmt.Errorf("kind must be %q", outputschema.KindReview)
+	}
+	if !validPerspective(report.Perspective) {
+		return nil, fmt.Errorf("perspective must be one of %s", joinPerspectives(DefaultPerspectives))
+	}
+	if !validVerdict(report.Verdict) {
+		return nil, fmt.Errorf("verdict must be one of approve, changes_requested, requires_human, reject")
+	}
+	if strings.TrimSpace(report.Repo) == "" {
+		return nil, fmt.Errorf("repo is required")
+	}
+	if !strings.Contains(strings.TrimSpace(report.Repo), "/") {
+		return nil, fmt.Errorf("repo must be fully qualified as owner/name")
+	}
+	if report.Number <= 0 {
+		return nil, fmt.Errorf("number must be greater than zero")
+	}
+	return &report, nil
+}
+
+func AggregateReports(reports []PerspectiveReport, opts AggregateOptions) Aggregate {
+	threshold := opts.HumanThreshold
+	if threshold == "" {
+		threshold = DefaultHumanThreshold
+	}
+	maxFix := opts.MaxFixAttempts
+	if maxFix <= 0 {
+		maxFix = DefaultFixCycleCap
+	}
+	agg := Aggregate{
+		Threshold:      threshold,
+		FixAttempts:    opts.FixAttempts,
+		MaxFixAttempts: maxFix,
+		Perspectives:   map[Perspective]Verdict{},
+	}
+	if len(reports) == 0 {
+		agg.Verdict = VerdictRequiresHuman
+		agg.RequiresHuman = true
+		agg.Reasons = []string{"no review reports were collected"}
+		return agg
+	}
+	seenVerdicts := map[Verdict]bool{}
+	for _, r := range reports {
+		if agg.Repo == "" {
+			agg.Repo, agg.Number, agg.HeadSHA = r.Repo, r.Number, r.HeadSHA
+		}
+		agg.Perspectives[r.Perspective] = r.Verdict
+		seenVerdicts[r.Verdict] = true
+		for _, f := range r.Findings {
+			agg.Findings = append(agg.Findings, PerspectiveFinding{Perspective: r.Perspective, Finding: f})
+			if severityAtLeast(f.Severity, threshold) {
+				agg.Reasons = append(agg.Reasons, fmt.Sprintf("%s finding %q is %s (threshold %s)", r.Perspective, f.Title, f.Severity, threshold))
+			}
+		}
+	}
+	sortReasons(agg.Reasons)
+
+	if seenVerdicts[VerdictReject] {
+		agg.Verdict = VerdictReject
+		agg.CloseRecommended = true
+		return agg
+	}
+	if len(agg.Reasons) > 0 || seenVerdicts[VerdictRequiresHuman] {
+		agg.Verdict = VerdictRequiresHuman
+		agg.RequiresHuman = true
+		return agg
+	}
+	if seenVerdicts[VerdictChangesRequested] {
+		if opts.FixAttempts >= maxFix {
+			agg.Verdict = VerdictRequiresHuman
+			agg.RequiresHuman = true
+			agg.Reasons = []string{fmt.Sprintf("fix cycle cap reached (%d/%d)", opts.FixAttempts, maxFix)}
+			return agg
+		}
+		agg.Verdict = VerdictChangesRequested
+		agg.FixCycle = true
+		return agg
+	}
+	if len(seenVerdicts) == 1 && seenVerdicts[VerdictApprove] && hasAllDefaultPerspectives(agg.Perspectives) {
+		agg.Verdict = VerdictApprove
+		agg.MergeEligible = true
+		return agg
+	}
+	agg.Verdict = VerdictRequiresHuman
+	agg.RequiresHuman = true
+	agg.Reasons = []string{"review perspectives did not unanimously approve"}
+	return agg
+}
+
+func Collect(dir string, opts AggregateOptions) (Artifact, error) {
+	if dir == "" {
+		dir = outputschema.AgentReportDir
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return Artifact{}, err
+	}
+	groups := map[string][]PerspectiveReport{}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasPrefix(name, ReviewReportFilePrefix) || !strings.HasSuffix(name, ReviewReportFileSuffix) {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return Artifact{}, err
+		}
+		report, err := ValidateReport(raw)
+		if err != nil {
+			return Artifact{}, fmt.Errorf("%s: %w", name, err)
+		}
+		groups[reviewKey(report.Repo, report.Number, report.HeadSHA)] = append(groups[reviewKey(report.Repo, report.Number, report.HeadSHA)], *report)
+	}
+	artifact := Artifact{GeneratedAt: time.Now().UTC()}
+	for _, key := range sortedKeys(groups) {
+		artifact.Items = append(artifact.Items, AggregateReports(groups[key], opts))
+	}
+	return artifact, nil
+}
+
+func WriteArtifact(path string, artifact Artifact) error {
+	if path == "" {
+		path = ReviewVerdictsPath
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(artifact, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func CollectAndWrite(dir, path string, opts AggregateOptions) (Artifact, error) {
+	artifact, err := Collect(dir, opts)
+	if err != nil {
+		return Artifact{}, err
+	}
+	return artifact, WriteArtifact(path, artifact)
+}
+
+func LoadArtifact(path string) (Artifact, error) {
+	if path == "" {
+		path = ReviewVerdictsPath
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Artifact{}, err
+	}
+	var artifact Artifact
+	if err := json.Unmarshal(data, &artifact); err != nil {
+		return Artifact{}, err
+	}
+	return artifact, nil
+}
+
+func (a Artifact) HasAggregateApproval(repo string, number int, headSHA string) bool {
+	wantRepo := strings.TrimSpace(repo)
+	wantSHA := strings.TrimSpace(headSHA)
+	for _, item := range a.Items {
+		if item.Number != number || strings.TrimSpace(item.Repo) != wantRepo || !item.MergeEligible || item.Verdict != VerdictApprove {
+			continue
+		}
+		if strings.TrimSpace(item.HeadSHA) == wantSHA {
+			return true
+		}
+	}
+	return false
+}
+
+func agentReportJSON(r outputschema.AgentReport) []byte {
+	data, _ := json.Marshal(r)
+	return data
+}
+
+func validPerspective(p Perspective) bool {
+	for _, want := range DefaultPerspectives {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}
+
+func validVerdict(v Verdict) bool {
+	switch v {
+	case VerdictApprove, VerdictChangesRequested, VerdictRequiresHuman, VerdictReject:
+		return true
+	default:
+		return false
+	}
+}
+
+func severityAtLeast(got, threshold outputschema.Severity) bool {
+	return severityRank(got) >= severityRank(threshold)
+}
+
+func severityRank(s outputschema.Severity) int {
+	switch s {
+	case outputschema.SeverityInfo:
+		return 1
+	case outputschema.SeverityLow:
+		return 2
+	case outputschema.SeverityMedium:
+		return 3
+	case outputschema.SeverityHigh:
+		return 4
+	case outputschema.SeverityCritical:
+		return 5
+	default:
+		return 0
+	}
+}
+
+func hasAllDefaultPerspectives(got map[Perspective]Verdict) bool {
+	if len(got) != len(DefaultPerspectives) {
+		return false
+	}
+	for _, p := range DefaultPerspectives {
+		if got[p] != VerdictApprove {
+			return false
+		}
+	}
+	return true
+}
+
+func joinPerspectives(ps []Perspective) string {
+	parts := make([]string, 0, len(ps))
+	for _, p := range ps {
+		parts = append(parts, string(p))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func sortReasons(reasons []string) {
+	sort.Strings(reasons)
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func reviewKey(repo string, number int, headSHA string) string {
+	return fmt.Sprintf("%s#%d@%s", repo, number, headSHA)
+}

--- a/v2/pkg/review/review_test.go
+++ b/v2/pkg/review/review_test.go
@@ -1,0 +1,149 @@
+package review
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/outputschema"
+)
+
+const testSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+func baseReport(p Perspective, v Verdict, findings ...outputschema.Finding) PerspectiveReport {
+	if findings == nil {
+		findings = []outputschema.Finding{}
+	}
+	return PerspectiveReport{
+		AgentReport: outputschema.AgentReport{
+			Lane:       "review-swarm",
+			Kind:       outputschema.KindReview,
+			Findings:   findings,
+			PRsOpened:  []outputschema.PROpened{},
+			BeadsFiled: []outputschema.BeadFiled{},
+			Summary:    string(p) + " summary",
+		},
+		Perspective: p,
+		Verdict:     v,
+		Repo:        "kubestellar/hive",
+		Number:      2807,
+		HeadSHA:     testSHA,
+	}
+}
+
+func allApprove() []PerspectiveReport {
+	out := make([]PerspectiveReport, 0, len(DefaultPerspectives))
+	for _, p := range DefaultPerspectives {
+		out = append(out, baseReport(p, VerdictApprove))
+	}
+	return out
+}
+
+func TestAggregateReportsMatrix(t *testing.T) {
+	highFinding := outputschema.Finding{Title: "risky", Severity: outputschema.SeverityHigh, Summary: "needs a human"}
+	tests := []struct {
+		name  string
+		reps  []PerspectiveReport
+		opts  AggregateOptions
+		want  Verdict
+		merge bool
+		fix   bool
+		human bool
+		close bool
+	}{
+		{name: "unanimous approve is merge eligible", reps: allApprove(), want: VerdictApprove, merge: true},
+		{name: "changes requested enters fix cycle", reps: append(allApprove()[:1], baseReport(PerspectiveSecurity, VerdictChangesRequested)), want: VerdictChangesRequested, fix: true},
+		{name: "severity threshold requires human", reps: []PerspectiveReport{baseReport(PerspectiveSecurity, VerdictApprove, highFinding)}, want: VerdictRequiresHuman, human: true},
+		{name: "explicit requires human wins", reps: []PerspectiveReport{baseReport(PerspectiveCorrectness, VerdictApprove), baseReport(PerspectiveSecurity, VerdictRequiresHuman)}, want: VerdictRequiresHuman, human: true},
+		{name: "reject recommends close", reps: []PerspectiveReport{baseReport(PerspectiveCorrectness, VerdictReject)}, want: VerdictReject, close: true},
+		{name: "fix cap requires human", reps: []PerspectiveReport{baseReport(PerspectiveCorrectness, VerdictChangesRequested)}, opts: AggregateOptions{FixAttempts: DefaultFixCycleCap}, want: VerdictRequiresHuman, human: true},
+		{name: "missing perspectives is disagreement", reps: []PerspectiveReport{baseReport(PerspectiveCorrectness, VerdictApprove)}, want: VerdictRequiresHuman, human: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AggregateReports(tt.reps, tt.opts)
+			if got.Verdict != tt.want || got.MergeEligible != tt.merge || got.FixCycle != tt.fix || got.RequiresHuman != tt.human || got.CloseRecommended != tt.close {
+				t.Fatalf("aggregate = verdict:%s merge:%v fix:%v human:%v close:%v", got.Verdict, got.MergeEligible, got.FixCycle, got.RequiresHuman, got.CloseRecommended)
+			}
+		})
+	}
+}
+
+func TestPromptBuilders(t *testing.T) {
+	pr := PullRequest{Repo: "kubestellar/hive", Number: 2807, Title: "review swarm", Author: "bot", HeadSHA: testSHA, URL: "https://example.invalid/pr/2807"}
+	prompt := BuildPerspectivePrompt(PerspectiveSecurity, pr)
+	for _, want := range []string{"[review-perspective:security]", "kubestellar/hive#2807", "kind to \"review\"", "Allowed verdicts", testSHA} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	prompts := BuildPerspectivePrompts(pr, nil)
+	if len(prompts) != len(DefaultPerspectives) {
+		t.Fatalf("default prompts = %d, want %d", len(prompts), len(DefaultPerspectives))
+	}
+	seq := BuildSequentialPrompt(pr, []Perspective{PerspectiveDocsCurrency, PerspectiveCorrectness})
+	if !strings.Contains(seq, "phase-1 sequential fallback") || !strings.Contains(seq, "review-perspective:docs-currency") {
+		t.Fatalf("sequential prompt missing expected text: %s", seq)
+	}
+}
+
+func TestValidateRoundTripAndCollect(t *testing.T) {
+	dir := t.TempDir()
+	reports := allApprove()
+	for _, r := range reports {
+		raw, err := json.Marshal(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		parsed, err := ValidateReport(raw)
+		if err != nil {
+			t.Fatalf("ValidateReport(%s): %v", r.Perspective, err)
+		}
+		if parsed.Perspective != r.Perspective || parsed.Verdict != VerdictApprove {
+			t.Fatalf("round-trip mismatch: %+v", parsed)
+		}
+		path := filepath.Join(dir, ReviewReportFilePrefix+string(r.Perspective)+ReviewReportFileSuffix)
+		if err := os.WriteFile(path, raw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	artifact, err := Collect(dir, AggregateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(artifact.Items) != 1 || !artifact.HasAggregateApproval("kubestellar/hive", 2807, testSHA) {
+		t.Fatalf("unexpected artifact: %+v", artifact)
+	}
+	out := filepath.Join(dir, ReviewVerdictsFile)
+	if err := WriteArtifact(out, artifact); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadArtifact(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.HasAggregateApproval("kubestellar/hive", 2807, testSHA) {
+		t.Fatalf("loaded artifact missing approval: %+v", loaded)
+	}
+	if loaded.HasAggregateApproval("other/hive", 2807, testSHA) {
+		t.Fatal("approval must not cross repository owners")
+	}
+}
+
+func TestValidateRejectsBadExtension(t *testing.T) {
+	r := baseReport(PerspectiveSecurity, VerdictApprove)
+	raw, _ := json.Marshal(r)
+	raw = []byte(strings.Replace(string(raw), `"perspective":"security"`, `"perspective":"unknown"`, 1))
+	if _, err := ValidateReport(raw); err == nil {
+		t.Fatal("expected invalid perspective to fail")
+	}
+
+	r = baseReport(PerspectiveSecurity, VerdictApprove)
+	r.Repo = "hive"
+	raw, _ = json.Marshal(r)
+	if _, err := ValidateReport(raw); err == nil {
+		t.Fatal("expected bare repo to fail")
+	}
+}


### PR DESCRIPTION
Part of #2807

## Summary
- Add v2/pkg/review with perspectives, verdict aggregation, AgentReport-based validation, artifact collection, and prompt builders.
- Add capped fix-cycle aggregation using the escalation re-engagement cap.
- Add optional merge-gate wiring via review.require_approval (default false) and document review-verdicts.json flow.

## Deferred work
- Governor/scheduler fan-out to run perspective prompts in parallel review-capable agents.
- Direct auto-fix kick dispatch from changes_requested aggregates.
- Verdict-to-label/comment/close-recommendation automation and dashboard visibility.

## Validation
- cd v2 && go build ./...
- cd v2 && go test ./pkg/review/... ./pkg/config ./cmd/hive -count=1
- cd v2 && go vet ./pkg/review/... ./pkg/config ./cmd/hive