### PR TITLE
✨ feat(access): merger contributor tier — review + auto-merge queue, never own PRs

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -4910,6 +4910,7 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 		Title  string   `json:"title"`
 		Author string   `json:"author"`
 		Labels []string `json:"labels,omitempty"`
+		Queued bool     `json:"queued,omitempty"`
 		// Mergeable is a tri-state string ("yes"/"no"/"unknown"), not a bool.
 		// A bool here defaulted to false for every PR, because the value was
 		// read from a list endpoint that never returns it.
@@ -4970,11 +4971,15 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 		}
 
 		dco := "unknown"
+		queued := false
 		for _, l := range pr.Labels {
 			if l == "dco-signoff: yes" {
 				dco = "yes"
 			} else if l == "dco-signoff: no" {
 				dco = "no"
+			}
+			if strings.EqualFold(l, github.AutoMergeQueuedLabel) {
+				queued = true
 			}
 		}
 		eligible = append(eligible, eligiblePR{
@@ -4983,6 +4988,7 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 			Title:     pr.Title,
 			Author:    pr.Author,
 			Labels:    pr.Labels,
+			Queued:    queued,
 			Mergeable: mergeableJSON(pr.Mergeable),
 			DCO:       dco,
 		})

--- a/v2/docs/manual-provisioning.md
+++ b/v2/docs/manual-provisioning.md
@@ -568,6 +568,13 @@ hive has no fleet-registry entry (never heartbeated). So a hive with
 `owner: <someone>` in its `meta.json` appears in that person's My Hives (and the
 admin's) as soon as the file exists.
 
+**Contributor tiers.** Manage Access grants four ordered roles:
+`read` < `read-write` < `merger` < `owner`. `merger` inherits read-write
+dashboard access and can approve/queue **other people's** PRs for the hive
+auto-merge-on-green flow. The spoke enforces the self-merge ban against the
+GitHub login bound to the session; owners are exempt because they already have
+repository-level merge authority.
+
 > **`meta.json` requirement is why heartbeats can be accepted but upgrades fail.**
 > The heartbeat path is separate from `loadSaaSHive`. A hive can heartbeat and
 > appear "online" while a missing `meta.json` makes the **Upgrade** button (and

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -2083,7 +2083,31 @@ const (
 	// "cbrooker27:read-write", no lookup could ever match, and every login was
 	// rejected as unauthorized despite the grant being present and correct.
 	RoleReadWrite = "read-write"
+	// RoleMerger can do everything read-write can, plus approve/queue other
+	// people's PRs for the existing auto-merge-on-green sweep. The spoke
+	// enforces the "never your own PR" rule server-side.
+	RoleMerger = "merger"
 )
+
+var roleRanks = map[string]int{
+	RoleRead:      1,
+	RoleReadWrite: 2,
+	RoleMerger:    3,
+	RoleOwner:     4,
+}
+
+// ValidRole reports whether role is one of the hive access tiers.
+func ValidRole(role string) bool {
+	_, ok := roleRanks[strings.ToLower(strings.TrimSpace(role))]
+	return ok
+}
+
+// RoleAtLeast reports whether role includes all capabilities of tier.
+func RoleAtLeast(role, tier string) bool {
+	roleRank, okRole := roleRanks[strings.ToLower(strings.TrimSpace(role))]
+	tierRank, okTier := roleRanks[strings.ToLower(strings.TrimSpace(tier))]
+	return okRole && okTier && roleRank >= tierRank
+}
 
 // AuthorizedRole resolves a GitHub username against the spoke's authorized-users
 // allowlist and returns the user's role and whether they are authorized.
@@ -2141,7 +2165,7 @@ func splitAuthorizedEntry(entry string) (name, role string) {
 	if idx := strings.LastIndex(entry, ":"); idx >= 0 {
 		name = strings.TrimSpace(entry[:idx])
 		role = strings.ToLower(strings.TrimSpace(entry[idx+1:]))
-		if role != RoleOwner && role != RoleRead && role != RoleReadWrite {
+		if !ValidRole(role) {
 			// Unknown role suffix — treat the whole thing as a bare username so
 			// a stray colon can never silently downgrade or escalate access.
 			return strings.TrimSpace(entry), ""

--- a/v2/pkg/config/role_tiers_test.go
+++ b/v2/pkg/config/role_tiers_test.go
@@ -1,0 +1,37 @@
+package config
+
+import "testing"
+
+func TestRoleAtLeastOrdering(t *testing.T) {
+	tests := []struct {
+		role string
+		tier string
+		want bool
+	}{
+		{RoleRead, RoleRead, true},
+		{RoleRead, RoleReadWrite, false},
+		{RoleReadWrite, RoleRead, true},
+		{RoleReadWrite, RoleMerger, false},
+		{RoleMerger, RoleReadWrite, true},
+		{RoleMerger, RoleOwner, false},
+		{RoleOwner, RoleMerger, true},
+		{"MERGER", RoleReadWrite, true},
+		{"unknown", RoleRead, false},
+	}
+	for _, tt := range tests {
+		if got := RoleAtLeast(tt.role, tt.tier); got != tt.want {
+			t.Fatalf("RoleAtLeast(%q, %q) = %v, want %v", tt.role, tt.tier, got, tt.want)
+		}
+	}
+}
+
+func TestValidRoleAcceptsMerger(t *testing.T) {
+	for _, role := range []string{RoleRead, RoleReadWrite, RoleMerger, RoleOwner, " MERGER "} {
+		if !ValidRole(role) {
+			t.Fatalf("ValidRole(%q) = false, want true", role)
+		}
+	}
+	if ValidRole("admin") {
+		t.Fatalf("ValidRole(admin) = true, want false")
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -93,6 +93,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.registerClaudeAuthRoutes()
 	s.registerCopilotAuthRoutes()
 	s.mux.HandleFunc("GET /api/summaries", s.handleSummaries)
+	s.mux.HandleFunc("POST /api/prs/{owner}/{repo}/{number}/queue-automerge", s.handleQueuePRAutoMerge)
 
 	s.mux.HandleFunc("GET /api/config/agent/{name}", s.handleAgentConfigGet)
 	s.mux.HandleFunc("PUT /api/config/agent/{name}/general", s.handleAgentConfigGeneral)
@@ -1889,6 +1890,79 @@ func (s *Server) handleSummaries(w http.ResponseWriter, r *http.Request) {
 		"prs":    allPRs,
 		"hold":   status.Hold.Items,
 	})
+}
+
+func (s *Server) handleQueuePRAutoMerge(w http.ResponseWriter, r *http.Request) {
+	role := r.Header.Get("X-Hive-Role")
+	if role == "" {
+		role = config.RoleOwner
+	}
+	user := strings.TrimSpace(r.Header.Get("X-Hive-User"))
+	if !config.RoleAtLeast(role, config.RoleMerger) {
+		jsonError(w, "merger or owner access required", http.StatusForbidden)
+		return
+	}
+	if !config.RoleAtLeast(role, config.RoleOwner) && user == "" {
+		jsonError(w, "authenticated GitHub user required", http.StatusForbidden)
+		return
+	}
+	if s.deps == nil || s.deps.GHClient == nil {
+		jsonError(w, "GitHub client not configured", http.StatusServiceUnavailable)
+		return
+	}
+	number, err := strconv.Atoi(r.PathValue("number"))
+	if err != nil || number <= 0 {
+		jsonError(w, "invalid pull request number", http.StatusBadRequest)
+		return
+	}
+	owner := strings.TrimSpace(r.PathValue("owner"))
+	repoName := strings.TrimSpace(r.PathValue("repo"))
+	if owner == "" || repoName == "" || strings.Contains(owner, "/") || strings.Contains(repoName, "/") {
+		jsonError(w, "invalid repository", http.StatusBadRequest)
+		return
+	}
+	repo := owner + "/" + repoName
+	if !s.prQueueRepoAllowed(repo) {
+		jsonError(w, "repository is not managed by this hive", http.StatusForbidden)
+		return
+	}
+	author, err := s.deps.GHClient.GetPRAuthor(r.Context(), repo, number)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	if !config.RoleAtLeast(role, config.RoleOwner) && strings.EqualFold(author, user) {
+		jsonError(w, "mergers cannot queue their own pull requests", http.StatusForbidden)
+		return
+	}
+	if err := s.deps.GHClient.QueuePRAutoMerge(r.Context(), repo, number, user); err != nil {
+		jsonError(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	detail := auditDetail("repo", repo, "pr", strconv.Itoa(number), "author", author)
+	s.auditFromRequest(r, "queue-pr-automerge", detail, "")
+	jsonResponse(w, map[string]any{
+		"status": "queued",
+		"repo":   repo,
+		"number": number,
+		"label":  github.AutoMergeQueuedLabel,
+	})
+}
+
+func (s *Server) prQueueRepoAllowed(repo string) bool {
+	if s.deps == nil || s.deps.Config == nil {
+		return false
+	}
+	for _, configured := range s.deps.Config.Project.Repos {
+		full := configured
+		if !strings.Contains(full, "/") {
+			full = s.deps.Config.Project.Org + "/" + full
+		}
+		if strings.EqualFold(full, repo) {
+			return true
+		}
+	}
+	return false
 }
 
 // --- Agent config endpoints ---
@@ -5476,10 +5550,10 @@ func (s *Server) persistGitHubSetupInstallation(r *http.Request, installationID 
 
 func (s *Server) requestHasGitHubSetupAdmin(r *http.Request) bool {
 	if sess := s.sessionFromRequest(r); sess != nil {
-		return sess.Role == "owner" || sess.Role == "read-write"
+		return config.RoleAtLeast(sess.Role, config.RoleReadWrite)
 	}
 	role := r.Header.Get("X-Hive-Role")
-	if role != "owner" && role != "read-write" {
+	if !config.RoleAtLeast(role, config.RoleReadWrite) {
 		return false
 	}
 	if s.directRouteAuthzEnabled() {

--- a/v2/pkg/dashboard/audit.go
+++ b/v2/pkg/dashboard/audit.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kubestellar/hive/v2/pkg/config"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
@@ -192,7 +193,7 @@ func (s *Server) handleAuditLog(w http.ResponseWriter, r *http.Request) {
 	if role == "" {
 		role = "owner"
 	}
-	if role != "owner" && role != "read-write" {
+	if !config.RoleAtLeast(role, config.RoleReadWrite) {
 		http.Error(w, "insufficient access", http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/dashboard/pr_automerge_test.go
+++ b/v2/pkg/dashboard/pr_automerge_test.go
@@ -1,0 +1,116 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+)
+
+func TestQueuePRAutoMergeRoleAndSelfGate(t *testing.T) {
+	tests := []struct {
+		name       string
+		role       string
+		user       string
+		author     string
+		wantStatus int
+	}{
+		{"merger queues other pr", config.RoleMerger, "alice", "bob", http.StatusOK},
+		{"merger cannot queue own pr", config.RoleMerger, "alice", "ALICE", http.StatusForbidden},
+		{"read write forbidden", config.RoleReadWrite, "alice", "bob", http.StatusForbidden},
+		{"read forbidden", config.RoleRead, "alice", "bob", http.StatusForbidden},
+		{"owner can queue own pr", config.RoleOwner, "alice", "alice", http.StatusOK},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var labelAdded, reviewCreated bool
+			api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7":
+					json.NewEncoder(w).Encode(map[string]any{
+						"number": 7,
+						"user":   map[string]string{"login": tt.author},
+					})
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/labels/hive/automerge":
+					http.NotFound(w, r)
+				case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/labels":
+					w.WriteHeader(http.StatusCreated)
+					json.NewEncoder(w).Encode(map[string]any{"name": ghpkg.AutoMergeQueuedLabel})
+				case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/issues/7/labels":
+					labelAdded = true
+					json.NewEncoder(w).Encode([]map[string]any{{"name": ghpkg.AutoMergeQueuedLabel}})
+				case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/pulls/7/reviews":
+					reviewCreated = true
+					w.WriteHeader(http.StatusCreated)
+					json.NewEncoder(w).Encode(map[string]any{"id": 1, "state": "APPROVED"})
+				default:
+					t.Fatalf("unexpected GitHub API call: %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer api.Close()
+
+			s := NewServer(0, slog.Default())
+			s.deps = &Dependencies{
+				GHClient: ghpkg.NewClient("token", "acme", []string{"widget"}, slog.Default(), api.URL),
+				Config:   &config.Config{Project: config.ProjectConfig{Org: "acme", Repos: []string{"widget"}}},
+			}
+			req := httptest.NewRequest(http.MethodPost, "/api/prs/acme/widget/7/queue-automerge", nil)
+			req.Header.Set("X-Hive-Role", tt.role)
+			req.Header.Set("X-Hive-User", tt.user)
+			req.SetPathValue("owner", "acme")
+			req.SetPathValue("repo", "widget")
+			req.SetPathValue("number", "7")
+			rr := httptest.NewRecorder()
+			s.handleQueuePRAutoMerge(rr, req)
+
+			if rr.Code != tt.wantStatus {
+				t.Fatalf("status = %d body %s, want %d", rr.Code, rr.Body.String(), tt.wantStatus)
+			}
+			if tt.wantStatus == http.StatusOK {
+				if !labelAdded || !reviewCreated {
+					t.Fatalf("labelAdded=%v reviewCreated=%v, want both true", labelAdded, reviewCreated)
+				}
+				entries := s.audit.Recent(1)
+				if len(entries) != 1 || entries[0].Action != "queue-pr-automerge" || !strings.Contains(entries[0].Detail, "pr="+strconv.Itoa(7)) {
+					t.Fatalf("audit entry = %#v, want queue-pr-automerge with pr detail", entries)
+				}
+			}
+		})
+	}
+}
+
+func TestQueuePRAutoMergeRejectsRepoOutsideHive(t *testing.T) {
+	called := false
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		t.Fatalf("unexpected GitHub API call for unauthorized repo: %s %s", r.Method, r.URL.Path)
+	}))
+	defer api.Close()
+
+	s := NewServer(0, slog.Default())
+	s.deps = &Dependencies{
+		GHClient: ghpkg.NewClient("token", "acme", []string{"widget"}, slog.Default(), api.URL),
+		Config:   &config.Config{Project: config.ProjectConfig{Org: "acme", Repos: []string{"widget"}}},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/prs/other/secret/7/queue-automerge", nil)
+	req.Header.Set("X-Hive-Role", config.RoleMerger)
+	req.Header.Set("X-Hive-User", "alice")
+	req.SetPathValue("owner", "other")
+	req.SetPathValue("repo", "secret")
+	req.SetPathValue("number", "7")
+	rr := httptest.NewRecorder()
+	s.handleQueuePRAutoMerge(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d body %s, want 403", rr.Code, rr.Body.String())
+	}
+	if called {
+		t.Fatal("GitHub API should not be called for unauthorized repo")
+	}
+}

--- a/v2/pkg/dashboard/pr_automerge_ui_test.go
+++ b/v2/pkg/dashboard/pr_automerge_ui_test.go
@@ -1,0 +1,22 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPRAutoMergeButtonGatingPinned(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		"function dashboardRoleAtLeast(role, tier)",
+		"dashboardRoleAtLeast(window._hiveRole || 'read', 'merger')",
+		"p.author.toLowerCase() === window._hiveUser.toLowerCase()",
+		"Queue auto-merge",
+		"/queue-automerge",
+		"hive/automerge",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Fatalf("dashboard PR auto-merge UI missing snippet %q", snippet)
+		}
+	}
+}

--- a/v2/pkg/dashboard/prompt_history.go
+++ b/v2/pkg/dashboard/prompt_history.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kubestellar/hive/v2/pkg/config"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
@@ -342,7 +343,7 @@ func (s *Server) handlePromptHistory(w http.ResponseWriter, r *http.Request) {
 	if role == "" {
 		role = "owner"
 	}
-	if role != "owner" && role != "read-write" {
+	if !config.RoleAtLeast(role, config.RoleReadWrite) {
 		http.Error(w, "insufficient access", http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -1044,7 +1044,7 @@ func (s *Server) roleEnforcement(next http.Handler) http.Handler {
 		}
 		w.Header().Set("X-Hive-Role", role)
 		w.Header().Set("X-Hive-User", r.Header.Get("X-Hive-User"))
-		if role == "read" && r.Method != http.MethodGet && r.Method != http.MethodHead && r.Method != http.MethodOptions {
+		if config.ValidRole(role) && !config.RoleAtLeast(role, config.RoleReadWrite) && r.Method != http.MethodGet && r.Method != http.MethodHead && r.Method != http.MethodOptions {
 			if !strings.HasPrefix(r.URL.Path, "/api/contribute") && r.URL.Path != "/api/gh-user-auth/status" {
 				http.Error(w, `{"error":"your permissions on this hive are read-only, so changes are not allowed. Contact the owner of this hive to ask for write permissions."}`, http.StatusForbidden)
 				return

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6405,6 +6405,27 @@
       setIfChanged(el, html);
     }
 
+    function dashboardRoleAtLeast(role, tier) {
+      const rank = { 'read': 1, 'read-write': 2, 'merger': 3, 'owner': 4 };
+      return (rank[role] || 0) >= (rank[tier] || 0);
+    }
+
+    async function queuePRAutoMerge(owner, repo, number, btn) {
+      if (btn && btn.dataset.busy === '1') return;
+      if (btn) { btn.dataset.busy = '1'; btn.textContent = 'Queueing…'; }
+      try {
+        const resp = await fetch('/api/prs/' + encodeURIComponent(owner) + '/' + encodeURIComponent(repo) + '/' + number + '/queue-automerge', { method: 'POST' });
+        const data = await resp.json().catch(() => ({}));
+        if (!resp.ok) throw new Error(data.error || ('HTTP ' + resp.status));
+        showToast('Queued #' + number + ' for auto-merge on green CI', 'success');
+        if (btn) { btn.textContent = 'Queued'; btn.disabled = true; }
+        fetch('/api/status').then(r => r.json()).then(render).catch(() => {});
+      } catch (e) {
+        showToast('Queue failed: ' + (e && e.message ? e.message : 'network error'), 'error');
+        if (btn) { btn.dataset.busy = ''; btn.textContent = 'Queue auto-merge'; }
+      }
+    }
+
     function renderRepos(repos) {
       const el = document.getElementById('repos');
       // Definitive single-host badge in the section header: every repo in this
@@ -6443,8 +6464,19 @@
           const mergeIcon = p.mergeable ? '<span class="pill-merge-icon">✓</span>' : '';
           const mergeClass = p.mergeable ? ' mergeable' : '';
           const prAge = pillAge(p.created_at);
-          const prTip = (p.title || '') + (p.author ? ' — @' + p.author : '') + (prAge ? ' (' + prAge + ')' : '') + (p.mergeable ? ' (merge eligible)' : '');
-          return `<a class="repo-pr-pill${mergeClass}" href="${esc(p.url)}" target="_blank" rel="noopener" title="${esc(prTip)}"><span class="pill-num">#${p.number}</span><span class="pill-title">${esc(title)}</span>${mergeIcon}</a>`;
+          const labels = (p.labels || []).map(l => String(l).toLowerCase());
+          const queued = labels.includes('hive/automerge');
+          const prTip = (p.title || '') + (p.author ? ' — @' + p.author : '') + (prAge ? ' (' + prAge + ')' : '') + (p.mergeable ? ' (merge eligible)' : '') + (queued ? ' (queued for auto-merge)' : '');
+          const canQueue = dashboardRoleAtLeast(window._hiveRole || 'read', 'merger') && (window._hiveUser || dashboardRoleAtLeast(window._hiveRole || 'read', 'owner')) && !(p.author && window._hiveUser && p.author.toLowerCase() === window._hiveUser.toLowerCase());
+          const parts = (r.full || r.name || '').split('/');
+          const owner = parts.length > 1 ? parts[0] : '';
+          const repoName = parts.length > 1 ? parts.slice(1).join('/') : (r.name || '');
+          const queueBtn = canQueue
+            ? (queued
+                ? '<span class="repo-pr-pill mergeable" title="Already queued for Hive auto-merge on green CI">Queued</span>'
+                : `<button class="repo-pr-pill" style="cursor:pointer" onclick="event.preventDefault();event.stopPropagation();queuePRAutoMerge(${JSON.stringify(owner)},${JSON.stringify(repoName)},${p.number},this)">Queue auto-merge</button>`)
+            : '';
+          return `<a class="repo-pr-pill${mergeClass}" href="${esc(p.url)}" target="_blank" rel="noopener" title="${esc(prTip)}"><span class="pill-num">#${p.number}</span><span class="pill-title">${esc(title)}</span>${mergeIcon}</a>${queueBtn}`;
         }).join('');
         const allPills = issuePills + prPills;
         const pillsHtml = allPills ? `<div class="repo-issues">${allPills}</div>` : '';
@@ -18450,6 +18482,8 @@ function burnAreaChart() {
     }
 
     function showGHAuthState(loggedIn, username, avatarURL, role) {
+      if (username) window._hiveUser = username;
+      if (role) window._hiveRole = role;
       const banner = document.getElementById('gh-auth-banner');
       const topBtn = document.getElementById('oc-gh-login-btn');
       const avatarWrap = document.getElementById('oc-gh-avatar-wrap');

--- a/v2/pkg/github/automerge_queue_test.go
+++ b/v2/pkg/github/automerge_queue_test.go
@@ -1,0 +1,68 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestQueuePRAutoMergeApprovesThenLabels(t *testing.T) {
+	var sawReview, sawLabel bool
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/labels/hive/automerge":
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/labels":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{"name": AutoMergeQueuedLabel})
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/pulls/7/reviews":
+			if sawLabel {
+				t.Fatal("review must be created before the PR is labeled queued")
+			}
+			sawReview = true
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{"id": 1, "state": "APPROVED"})
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/issues/7/labels":
+			if !sawReview {
+				t.Fatal("label must not be applied before approval succeeds")
+			}
+			sawLabel = true
+			json.NewEncoder(w).Encode([]map[string]any{{"name": AutoMergeQueuedLabel}})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	if err := c.QueuePRAutoMerge(context.Background(), "acme/widget", 7, "alice"); err != nil {
+		t.Fatalf("QueuePRAutoMerge returned error: %v", err)
+	}
+	if !sawReview || !sawLabel {
+		t.Fatalf("sawReview=%v sawLabel=%v, want both true", sawReview, sawLabel)
+	}
+}
+
+func TestGetPRAuthor(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/repos/acme/widget/pulls/7" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"number": 7,
+			"user":   map[string]string{"login": "alice"},
+		})
+	}))
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	author, err := c.GetPRAuthor(context.Background(), "widget", 7)
+	if err != nil {
+		t.Fatalf("GetPRAuthor returned error: %v", err)
+	}
+	if author != "alice" {
+		t.Fatalf("author = %q, want alice", author)
+	}
+}

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"net/url"
 	"regexp"
 	"sort"
@@ -186,6 +187,11 @@ type IssueCluster struct {
 
 var HoldLabels = []string{"hold", "on-hold", "hold/review"}
 var PermanentExemptLabels = []string{"do-not-merge"}
+
+// AutoMergeQueuedLabel is the GitHub label a human merger/owner action applies
+// to mark a PR as approved for the hive's existing auto-merge-on-green sweep.
+const AutoMergeQueuedLabel = "hive/automerge"
+
 var exemptFiles = []string{"ADOPTERS.md", "ADOPTERS.MD"}
 
 const slaThresholdMinutes = 30
@@ -654,6 +660,63 @@ func (c *Client) CreateIssueComment(ctx context.Context, repo string, number int
 	}
 	owner, repoName := c.splitRepo(repo)
 	_, _, err := c.client.Issues.CreateComment(ctx, owner, repoName, number, &gh.IssueComment{Body: gh.Ptr(body)})
+	return err
+}
+
+// GetPRAuthor returns the current author login for an open PR.
+func (c *Client) GetPRAuthor(ctx context.Context, repo string, number int) (string, error) {
+	if c == nil {
+		return "", ErrNoGitHubClient
+	}
+	owner, repoName := c.splitRepo(repo)
+	pr, _, err := c.client.PullRequests.Get(ctx, owner, repoName, number)
+	if err != nil {
+		return "", err
+	}
+	return safeGetLogin(pr.GetUser()), nil
+}
+
+// QueuePRAutoMerge approves a PR as the hive App and marks it for the
+// auto-merge-on-green sweep. The caller enforces role and self-queue policy.
+func (c *Client) QueuePRAutoMerge(ctx context.Context, repo string, number int, queuedBy string) error {
+	if c == nil {
+		return ErrNoGitHubClient
+	}
+	owner, repoName := c.splitRepo(repo)
+	if err := c.ensureLabel(ctx, owner, repoName, AutoMergeQueuedLabel); err != nil {
+		return fmt.Errorf("ensuring %s label: %w", AutoMergeQueuedLabel, err)
+	}
+	body := fmt.Sprintf("Approved by @%s for Hive auto-merge on green CI.", queuedBy)
+	if strings.TrimSpace(queuedBy) == "" {
+		body = "Approved for Hive auto-merge on green CI."
+	}
+	_, _, err := c.client.PullRequests.CreateReview(ctx, owner, repoName, number, &gh.PullRequestReviewRequest{
+		Body:  gh.Ptr(body),
+		Event: gh.Ptr("APPROVE"),
+	})
+	if err != nil {
+		return fmt.Errorf("approving PR: %w", err)
+	}
+	if _, _, err := c.client.Issues.AddLabelsToIssue(ctx, owner, repoName, number, []string{AutoMergeQueuedLabel}); err != nil {
+		return fmt.Errorf("adding %s label: %w", AutoMergeQueuedLabel, err)
+	}
+	return nil
+}
+
+func (c *Client) ensureLabel(ctx context.Context, owner, repo, name string) error {
+	if _, _, err := c.client.Issues.GetLabel(ctx, owner, repo, name); err == nil {
+		return nil
+	} else if ghErr, ok := err.(*gh.ErrorResponse); !ok || ghErr.Response == nil || ghErr.Response.StatusCode != http.StatusNotFound {
+		return err
+	}
+	_, _, err := c.client.Issues.CreateLabel(ctx, owner, repo, &gh.Label{
+		Name:        gh.Ptr(name),
+		Color:       gh.Ptr("8250df"),
+		Description: gh.Ptr("Approved by a Hive merger/owner for auto-merge on green CI"),
+	})
+	if ghErr, ok := err.(*gh.ErrorResponse); ok && ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusUnprocessableEntity {
+		return nil
+	}
 	return err
 }
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2495,7 +2495,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 				result[i].RecentEvents = s.timeline.recent(h.ID, myHivesRecentEventCount)
 			}
 		}
-		if h.Role == "owner" || h.Role == "read-write" || isAdmin {
+		if config.RoleAtLeast(h.Role, config.RoleReadWrite) || isAdmin {
 			reqs := loadAccessRequests(h.ID)
 			var pending []PendingAccessRequest
 			for _, req := range reqs {
@@ -5408,8 +5408,8 @@ func (s *HubServer) handleAccessAdd(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"username and role required"}`, http.StatusBadRequest)
 		return
 	}
-	if body.Role != "read" && body.Role != "read-write" && body.Role != "owner" {
-		http.Error(w, `{"error":"role must be read, read-write, or owner"}`, http.StatusBadRequest)
+	if !config.ValidRole(body.Role) {
+		http.Error(w, `{"error":"role must be read, read-write, merger, or owner"}`, http.StatusBadRequest)
 		return
 	}
 	target := ensureSaaSUser(body.Username)
@@ -5585,7 +5585,7 @@ func (s *HubServer) handleGetRequests(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	role := user.Hives[hiveID]
-	if role != "owner" && role != "read-write" && username != hubAdminUsername {
+	if !config.RoleAtLeast(role, config.RoleReadWrite) && username != hubAdminUsername {
 		http.Error(w, `{"error":"need owner or read-write access"}`, http.StatusForbidden)
 		return
 	}
@@ -5619,7 +5619,7 @@ func (s *HubServer) handleApproveRequest(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	approverRole := approverUser.Hives[hiveID]
-	if approverRole != "owner" && approverRole != "read-write" && approver != hubAdminUsername {
+	if !config.RoleAtLeast(approverRole, config.RoleReadWrite) && approver != hubAdminUsername {
 		http.Error(w, `{"error":"need owner or read-write access"}`, http.StatusForbidden)
 		return
 	}
@@ -5632,8 +5632,11 @@ func (s *HubServer) handleApproveRequest(w http.ResponseWriter, r *http.Request)
 		body.Role = "read"
 	}
 
-	roleRank := map[string]int{"read": 1, "read-write": 2, "owner": 3}
-	if approver != hubAdminUsername && roleRank[body.Role] >= roleRank[approverRole] {
+	if !config.ValidRole(body.Role) {
+		http.Error(w, `{"error":"role must be read, read-write, merger, or owner"}`, http.StatusBadRequest)
+		return
+	}
+	if approver != hubAdminUsername && config.RoleAtLeast(body.Role, approverRole) {
 		http.Error(w, `{"error":"cannot grant a role equal to or higher than your own"}`, http.StatusForbidden)
 		return
 	}
@@ -5674,7 +5677,7 @@ func (s *HubServer) handleDenyRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	denierRole := denierUser.Hives[hiveID]
-	if denierRole != "owner" && denierRole != "read-write" && denier != hubAdminUsername {
+	if !config.RoleAtLeast(denierRole, config.RoleReadWrite) && denier != hubAdminUsername {
 		http.Error(w, `{"error":"need owner or read-write access"}`, http.StatusForbidden)
 		return
 	}
@@ -7851,6 +7854,7 @@ const dashboardHTML = `<!DOCTYPE html>
     .role-owner { background: rgba(244,199,95,0.15); color: var(--amber); border: 1px solid rgba(244,199,95,0.3); }
     .role-read { background: rgba(128,191,255,0.15); color: var(--blue); border: 1px solid rgba(128,191,255,0.3); }
     .role-read-write { background: rgba(116,223,154,0.15); color: var(--green); border: 1px solid rgba(116,223,154,0.3); }
+    .role-merger { background: rgba(163,113,247,0.15); color: #a371f7; border: 1px solid rgba(163,113,247,0.3); }
     /* Editable role pill: a <select> styled to match the role badges. Options
        render in the native menu (dark on most platforms); the closed control
        keeps the role color. */
@@ -8516,7 +8520,7 @@ const dashboardHTML = `<!DOCTYPE html>
       return html;
     }
     function roleBadge(role) {
-      var cls = role === 'owner' ? 'role-owner' : role === 'read-write' ? 'role-read-write' : 'role-read';
+      var cls = role === 'owner' ? 'role-owner' : role === 'merger' ? 'role-merger' : role === 'read-write' ? 'role-read-write' : 'role-read';
       return '<span class="role-badge ' + cls + '">' + esc(role) + '</span>';
     }
 
@@ -8530,10 +8534,14 @@ const dashboardHTML = `<!DOCTYPE html>
 
        Role colours live here and are reused by the hover panel's rows so a
        face in the row and its line in the panel read as the same role. */
-    var ACCESS_ROLE_COLORS = {'owner': '#d29922', 'read-write': '#3fb950'};
+    var ACCESS_ROLE_COLORS = {'owner': '#d29922', 'merger': '#a371f7', 'read-write': '#3fb950'};
     var ACCESS_ROLE_COLOR_DEFAULT = '#6b7280';
     function accessRoleColor(role) {
       return ACCESS_ROLE_COLORS[role] || ACCESS_ROLE_COLOR_DEFAULT;
+    }
+    function roleAtLeast(role, tier) {
+      var rank = {'read': 1, 'read-write': 2, 'merger': 3, 'owner': 4};
+      return (rank[role] || 0) >= (rank[tier] || 0);
     }
 
     /* Faces shown inline before collapsing the rest into a "+N" chip. The hive
@@ -12709,7 +12717,7 @@ const dashboardHTML = `<!DOCTYPE html>
           if (h.role === 'owner') {
             actions += '<br style="margin-bottom:4px"><button onclick="removeLocalHive(\'' + esc(h.id) + '\')" style="margin-top:6px;padding:3px 10px;background:var(--surface);color:var(--muted);border:1px solid var(--border);border-radius:4px;cursor:pointer;font-size:0.65rem;white-space:nowrap" title="Remove from registry (does not delete the hive)">Remove</button>';
           }
-        } else if (isHosted && (h.role === 'owner' || h.role === 'read-write')) {
+        } else if (isHosted && (roleAtLeast(h.role, 'read-write'))) {
           actions = '<button onclick="openAccessModal(\'' + esc(h.id) + '\',\'' + esc(h.dashboardUrl || '') + '\')" style="padding:3px 10px;background:var(--blue);color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.7rem;white-space:nowrap;margin-right:4px">Permissions</button>';
           if (h.role === 'owner') {
             actions += '<button onclick="deleteHive(\'' + esc(h.id) + '\')" style="padding:3px 10px;background:var(--red);color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.7rem;white-space:nowrap">Delete</button>';
@@ -12735,10 +12743,10 @@ const dashboardHTML = `<!DOCTYPE html>
         if (apiBase) menuItems.push('<a href="' + apiBase + '/api/docs" target="_blank" style="' + mi + '">API Docs</a>');
         if (menuItems.length > 0 && (canConvert || isHosted || isLocal)) menuItems.push('<div style="border-top:1px solid #30363d;margin:4px 0"></div>');
         if (canConvert) menuItems.push('<div onclick="openConvert(this)" data-hive-id="' + esc(h.id) + '" data-dash-url="' + esc(h.dashboardUrl||'') + '" data-org="' + esc(h.org) + '" data-repos="' + esc((h.repos||[]).join(', ')) + '" data-primary="' + esc(h.primaryRepo) + '" data-level="' + (h.acmmLevel||1) + '" data-name="' + esc(h.name||'') + '" style="' + mi + '">Convert to Hosted</div>');
-        if (isHosted && (h.role === 'owner' || h.role === 'read-write')) menuItems.push('<div onclick="openAccessModal(\'' + esc(h.id) + '\',\'' + esc(h.dashboardUrl || '') + '\')" style="' + mi + '">Permissions</div>');
+        if (isHosted && (roleAtLeast(h.role, 'read-write'))) menuItems.push('<div onclick="openAccessModal(\'' + esc(h.id) + '\',\'' + esc(h.dashboardUrl || '') + '\')" style="' + mi + '">Permissions</div>');
         /* Timeline is owner-or-admin, matching the API's authorization. */
         if (isHosted && (h.role === 'owner' || _isAdmin)) menuItems.push('<div onclick="openTimelineModal(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">Activity Timeline</div>');
-        if (h.role === 'owner' || h.role === 'read-write' || _isAdmin) menuItems.push('<div onclick="openOpenRouterFundModal(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">⚡ Fund with OpenRouter</div>');
+        if (roleAtLeast(h.role, 'read-write') || _isAdmin) menuItems.push('<div onclick="openOpenRouterFundModal(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">⚡ Fund with OpenRouter</div>');
         if (_isAdmin && isHosted) menuItems.push('<div onclick="openBannerForHive(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">Send Banner</div>');
         /* Reset App clears ONLY the spoke's installation_id, which makes
            HasUsableApp() false and prompts the owner to install the App again.
@@ -12916,11 +12924,11 @@ const dashboardHTML = `<!DOCTYPE html>
            spoke too old to report a SHA) — surface the dot beside the dash so
            folding Drift into Version never hides a signal. */
         } else { versionCell = '<span style="color:var(--muted)">—</span>' + (driftDot ? ' ' + driftDot : ''); }
-        var pendingBadge = (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write'))
+        var pendingBadge = (h.pendingRequestCount > 0 && (roleAtLeast(h.role, 'read-write')))
           ? '<span style="position:absolute;top:-2px;right:-2px;background:var(--blue);color:#fff;border-radius:50%;width:16px;height:16px;font-size:0.6rem;display:flex;align-items:center;justify-content:center;font-weight:700">' + h.pendingRequestCount + '</span>'
           : '';
         var pendingPill = '';
-        if (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write')) {
+        if (h.pendingRequestCount > 0 && (roleAtLeast(h.role, 'read-write'))) {
           pendingPill = '<a href="#" onclick="togglePendingRow(\'' + esc(h.id) + '\');return false" style="display:inline-flex;align-items:center;gap:4px;padding:3px 10px;background:rgba(59,130,246,0.12);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);border-radius:4px;font-size:0.7rem;text-decoration:none;cursor:pointer;white-space:nowrap">&#x1F514; ' + h.pendingRequestCount + ' pending</a>';
         }
         // 12 columns after the 15-to-9 fold. The visible cells are: bulk-select,
@@ -12996,7 +13004,7 @@ const dashboardHTML = `<!DOCTYPE html>
           '<div style="' + STACKED_LINE_STYLE + ';font-size:0.7rem">' + visibilityCell + '</div>' +
           '</div>';
         var pendingExpandRow = '';
-        if (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write') && (h.pending_requests || []).length > 0) {
+        if (h.pendingRequestCount > 0 && (roleAtLeast(h.role, 'read-write')) && (h.pending_requests || []).length > 0) {
           var prItems = (h.pending_requests || []).map(function(pr) {
             var avatar = linkedAvatar(pr.username, LIST_AVATAR_PX, pr.username, 'margin-right:6px');
             var note = (pr.note || '').trim();
@@ -13880,7 +13888,7 @@ const dashboardHTML = `<!DOCTYPE html>
     function renderPendingBanner(hives) {
       var existing = document.getElementById('pending-banner');
       if (existing) existing.remove();
-      var pending = (hives || []).filter(function(h) { return (h.role === 'owner' || h.role === 'read-write') && h.pendingRequestCount > 0; });
+      var pending = (hives || []).filter(function(h) { return (roleAtLeast(h.role, 'read-write')) && h.pendingRequestCount > 0; });
       if (!pending.length) return;
       var total = pending.reduce(function(sum, h) { return sum + h.pendingRequestCount; }, 0);
       var banner = document.createElement('div');
@@ -16725,6 +16733,7 @@ const dashboardHTML = `<!DOCTYPE html>
           <select id="access-role" style="padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
             <option value="read">Read</option>
             <option value="read-write">Read-Write</option>
+            <option value="merger">Merger</option>
             <option value="owner">Owner</option>
           </select>
           <button onclick="addAccess()" class="btn-primary" style="padding:8px 16px;font-size:0.8rem">Add</button>
@@ -16895,7 +16904,7 @@ const dashboardHTML = `<!DOCTYPE html>
             '<div style="display:flex;align-items:center;justify-content:space-between">' +
             '<div>' + avatar + '<span style="font-size:0.85rem">' + esc(r.username) + '</span> <span style="font-size:0.7rem;color:var(--muted)">' + esc(r.requested_at.substring(0,10)) + '</span></div>' +
             '<div style="display:flex;gap:4px">' +
-            '<select id="req-role-' + esc(r.username) + '" style="padding:2px 6px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text);font-size:0.7rem"><option value="read">Read</option><option value="read-write">Read-Write</option></select>' +
+            '<select id="req-role-' + esc(r.username) + '" style="padding:2px 6px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text);font-size:0.7rem"><option value="read">Read</option><option value="read-write">Read-Write</option><option value="merger">Merger</option></select>' +
             '<button onclick="approveRequest(\'' + esc(r.username) + '\')" style="padding:2px 8px;background:var(--green);color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.65rem">Approve</button>' +
             '<button onclick="denyRequest(\'' + esc(r.username) + '\')" style="padding:2px 8px;background:var(--red);color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.65rem">Deny</button>' +
             '</div></div>' + noteHtml + '</div>';
@@ -16969,7 +16978,7 @@ const dashboardHTML = `<!DOCTYPE html>
           // The role pill is an editable dropdown: changing it POSTs the new role
           // (the add endpoint upserts). The last owner's role is locked (shown as
           // a static pill) so the hive can't be left without an owner.
-          var ROLES = ['read', 'read-write', 'owner'];
+          var ROLES = ['read', 'read-write', 'merger', 'owner'];
           var roleControl = isLastOwner ?
             '<span class="role-badge role-' + u.role.replace(' ','-') + '" style="font-size:0.7rem" title="The last owner\'s role cannot be changed">' + esc(u.role) + '</span>' :
             '<select class="role-select role-' + u.role.replace(' ','-') + '" style="font-size:0.7rem;padding:2px 6px;border-radius:9999px;cursor:pointer" title="Change this user\'s permission" onchange="changeAccessRole(\'' + esc(u.username) + '\', this.value, \'' + esc(u.role) + '\')">' +

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1511,14 +1511,11 @@ func countUserHives(username string) int {
 // spoke needs to enforce per-user device-flow authorization on its direct
 // (non-hub-proxied) route. Format: "owner:owner,viewer1:read,viewer2:read".
 //
-// The owner always comes first with role "owner" (read-write). Every OTHER
-// SaaS user the hub granted this hive (any of "owner"/"read-write"/"read") is
-// appended as "read" — a read-only viewer on the direct route. Granting a
-// non-owner write access on the direct route is deliberately deferred (only the
-// single provisioned owner is write-capable there); see the PR notes for the
-// multi-user-grant follow-up. This fails safe: a grant can never widen access
-// beyond read on the direct route. Usernames are sanitized to guard the env
-// value, and the owner is de-duplicated so they appear exactly once.
+// The owner always comes first with role "owner". Every OTHER SaaS user the hub
+// granted this hive is appended with the exact validated role stored in the hub
+// user record, so direct-route spokes enforce the same read/read-write/merger
+// tiers as hub-proxied spokes. Usernames are sanitized to guard the env value,
+// and the owner is de-duplicated so they appear exactly once.
 func authorizedUsersForHive(h *SaaSHive) string {
 	entries := make([]string, 0, 4)
 	seen := map[string]bool{}
@@ -1528,14 +1525,18 @@ func authorizedUsersForHive(h *SaaSHive) string {
 		seen[strings.ToLower(owner)] = true
 	}
 	for _, u := range listAllSaaSUsers() {
-		if _, ok := u.Hives[h.ID]; !ok {
+		role, ok := u.Hives[h.ID]
+		if !ok {
 			continue
+		}
+		if !config.ValidRole(role) {
+			role = saasRoleRead
 		}
 		name := sanitize(u.GitHubUsername)
 		if name == "" || seen[strings.ToLower(name)] {
 			continue
 		}
-		entries = append(entries, name+":"+saasRoleRead)
+		entries = append(entries, name+":"+role)
 		seen[strings.ToLower(name)] = true
 	}
 	return strings.Join(entries, ",")

--- a/v2/pkg/hub/spoke_authz_test.go
+++ b/v2/pkg/hub/spoke_authz_test.go
@@ -56,19 +56,21 @@ func TestAuthorizedUsersForHive_OwnerNotDuplicated(t *testing.T) {
 	}
 }
 
-func TestAuthorizedUsersForHive_GrantedUserGetsReadNotWrite(t *testing.T) {
+func TestAuthorizedUsersForHive_GrantedRolesPropagateToDirectRoute(t *testing.T) {
 	saasUsersDir = t.TempDir()
-	// A non-owner user whose stored role is "owner" for the hive must still be
-	// downgraded to read on the direct route (only the provisioned owner writes).
-	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "escalate", Hives: map[string]string{"abc123": "owner"}}); err != nil {
+	// Direct-route spokes enforce the same role ladder as hub-proxied spokes.
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "maint", Hives: map[string]string{"abc123": "merger"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "coowner", Hives: map[string]string{"abc123": "owner"}}); err != nil {
 		t.Fatal(err)
 	}
 	h := &SaaSHive{ID: "abc123", Owner: "clubanderson"}
 	got := authorizedUsersForHive(h)
-	if !strings.Contains(got, "escalate:read") {
-		t.Fatalf("non-owner grant must be downgraded to read, got %q", got)
+	if !strings.Contains(got, "maint:merger") {
+		t.Fatalf("merger grant must propagate, got %q", got)
 	}
-	if strings.Contains(got, "escalate:owner") {
-		t.Fatalf("non-owner must not get owner role, got %q", got)
+	if !strings.Contains(got, "coowner:owner") {
+		t.Fatalf("co-owner grant must propagate, got %q", got)
 	}
 }

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -558,11 +558,16 @@ func (s *Scheduler) buildMergeEligibleList() string {
 	if err != nil {
 		return "(none)\n"
 	}
+	return formatMergeEligibleData(data)
+}
+
+func formatMergeEligibleData(data []byte) string {
 	var payload struct {
 		Items []struct {
 			Number int    `json:"number"`
 			Repo   string `json:"repo"`
 			Title  string `json:"title"`
+			Queued bool   `json:"queued"`
 		} `json:"merge_eligible"`
 	}
 	if json.Unmarshal(data, &payload) != nil || len(payload.Items) == 0 {
@@ -570,7 +575,11 @@ func (s *Scheduler) buildMergeEligibleList() string {
 	}
 	var b strings.Builder
 	for _, pr := range payload.Items {
-		b.WriteString(fmt.Sprintf("  #%d %s — %s\n", pr.Number, pr.Repo, pr.Title))
+		queued := ""
+		if pr.Queued {
+			queued = " [hive/automerge queued]"
+		}
+		b.WriteString(fmt.Sprintf("  #%d %s%s — %s\n", pr.Number, pr.Repo, queued, pr.Title))
 	}
 	return b.String()
 }
@@ -617,7 +626,7 @@ func (s *Scheduler) ghAuthInstructions(agentName string) string {
 - Writes are authored by the App bot identity, not a personal account. Do not
   set git user.name/user.email to a human, and do not pass 'gh pr create' or
   'git commit' an explicit --author: let the App identity stand.
-- To OPEN A PULL REQUEST, use ` + "`hive-open-pr`" + ` — the hive opens it with the
+- To OPEN A PULL REQUEST, use `+"`hive-open-pr`"+` — the hive opens it with the
   App token so it is authored by the App bot ("<slug>[bot]"), never the login user:
     hive-open-pr --repo <org>/<repo> --head <your-branch> --title "<title>" --body "<body with Fixes #N>"
   Do NOT open PRs with the GitHub MCP (create_pull_request / create_pull_request_with_copilot)
@@ -952,14 +961,14 @@ func keywordSample(keywords []string) string {
 }
 
 var noiseLabels = map[string]bool{
-	"triage/accepted":   true,
-	"ai-fix-requested":  true,
-	"kind/bug":          true,
-	"kind/feature":      true,
-	"kind/task":         true,
-	"good first issue":  true,
-	"help wanted":       true,
-	"hold":              true,
+	"triage/accepted":  true,
+	"ai-fix-requested": true,
+	"kind/bug":         true,
+	"kind/feature":     true,
+	"kind/task":        true,
+	"good first issue": true,
+	"help wanted":      true,
+	"hold":             true,
 }
 
 func isNoiseLabel(label string) bool {

--- a/v2/pkg/scheduler/scheduler_coverage_test.go
+++ b/v2/pkg/scheduler/scheduler_coverage_test.go
@@ -114,6 +114,13 @@ func TestFormatPRList_TruncatesTitle(t *testing.T) {
 	}
 }
 
+func TestFormatMergeEligibleDataShowsQueuedMarker(t *testing.T) {
+	result := formatMergeEligibleData([]byte(`{"merge_eligible":[{"number":7,"repo":"acme/widget","title":"fix it","queued":true}]}`))
+	if !strings.Contains(result, "#7 acme/widget [hive/automerge queued]") {
+		t.Fatalf("queued marker missing from merge-eligible output: %s", result)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // substituteTemplate
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add the new `merger` contributor role between read-write and owner, with shared role validation/order helpers.
- Propagate merger through hub Manage Access, heartbeat/direct-route authorized users, and spoke read/write gates.
- Add a spoke-side PR queue endpoint that requires merger-or-owner access, rejects merger self-queue by session GitHub login, scopes the repo to this hive, approves the PR, labels it `hive/automerge`, and audits the action.
- Add dashboard PR-row queue controls with queued-state display, plus docs and tests.

## Operator requirement
> j0rge: "maybe instead of doing per repo LMM level maybe you just let the contributors in the hive with the right perms automerge? that's ahmed, me, james, and bktelsen at least"
> andy: "Isn't there 4 tiers? Maybe we need one for merge"
> j0rge: "I was thinking maybe lgtm lol, if I see brian's PR I LGTM and back in the queue but trusted and above can only automerge and it can't be yours?"

## Validation
- go test ./pkg/hub/ ./pkg/dashboard/ ./pkg/config/ -count=1
- go build ./...
- go vet ./...