### PR TITLE
🐛 fix(contribute): flip ready-work queue ⋯ menu up when it would clip past the scroll border

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -1062,6 +1062,13 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 .cc-q-menu-btn:hover,.cc-q-menu-btn[aria-expanded=true]{color:var(--cc-text);background:var(--cc-border-2)}
 .cc-q-menu{position:absolute;top:100%%;right:0;z-index:40;min-width:190px;background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:10px;box-shadow:0 8px 28px rgba(1,4,9,.55);padding:6px;display:none}
 .cc-q-menu.open{display:block}
+/* Flip-up variant: for rows near the BOTTOM of the scrolling .cc-queue, the
+   default drop-down menu (top:100%%) would extend past the container's overflow
+   boundary and get clipped ("Optional hold reason" cut off). ccBindQueueMenus
+   measures on open and adds .cc-q-menu-up when there is more room above than
+   below, anchoring the menu to the button's TOP so it opens upward and stays
+   inside the visible card. */
+.cc-q-menu.cc-q-menu-up{top:auto;bottom:100%%}
 .cc-q-menu button.cc-q-act{display:flex;align-items:center;gap:8px;width:100%%;background:none;border:none;color:var(--cc-text-2);font:inherit;font-size:.82rem;text-align:left;padding:7px 9px;border-radius:6px;cursor:pointer}
 .cc-q-menu button.cc-q-act:hover{background:var(--cc-border-2);color:var(--cc-text)}
 .cc-q-menu-ic{color:var(--cc-muted-2);flex-shrink:0;width:16px;text-align:center}
@@ -3891,7 +3898,7 @@ function ccUpdateFilterNote(shown,total){
 // in the FULL ccQueue regardless of any active search filter.
 function ccCloseQueueMenus(){
   var open=document.querySelectorAll('.cc-q-menu.open');
-  for(var i=0;i<open.length;i++)open[i].classList.remove('open');
+  for(var i=0;i<open.length;i++){open[i].classList.remove('open');open[i].classList.remove('cc-q-menu-up');}
   var btns=document.querySelectorAll('.cc-q-menu-btn[aria-expanded=true]');
   for(var j=0;j<btns.length;j++)btns[j].setAttribute('aria-expanded','false');
   // No-blink guard companion: a poll re-render that arrived while a menu was open was
@@ -3917,7 +3924,26 @@ function ccBindQueueMenus(root){
       var menu=btn.parentNode.querySelector('.cc-q-menu');
       var isOpen=menu.classList.contains('open');
       ccCloseQueueMenus();
-      if(!isOpen){menu.classList.add('open');btn.setAttribute('aria-expanded','true');}
+      if(!isOpen){
+        // Decide direction BEFORE it paints so it never flashes clipped: if the
+        // menu (once shown) would extend past the bottom of the scrolling
+        // .cc-queue container, flip it to open upward. Compare the button's
+        // position to the container's viewport box, not the window, so it tracks
+        // the actual clip boundary (the queue's overflow-y:auto edge).
+        menu.classList.remove('cc-q-menu-up');
+        menu.classList.add('open');
+        var clip=btn.closest('.cc-queue');
+        if(clip){
+          var bBot=btn.getBoundingClientRect().bottom;
+          var cBox=clip.getBoundingClientRect();
+          var menuH=menu.offsetHeight||220; // measured now that it is display:block
+          // Flip up when there isn't room below within the clip AND there is more room above.
+          if(bBot+menuH>cBox.bottom && (btn.getBoundingClientRect().top-cBox.top)>(cBox.bottom-bBot)){
+            menu.classList.add('cc-q-menu-up');
+          }
+        }
+        btn.setAttribute('aria-expanded','true');
+      }
     });
   })(btns[i]);}
   var acts=root.querySelectorAll('.cc-q-act[data-act=top]');

--- a/v2/pkg/dashboard/contribute_queue_menu_flip_test.go
+++ b/v2/pkg/dashboard/contribute_queue_menu_flip_test.go
@@ -1,0 +1,33 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestContributeQueueMenuFlipsUp guards the fix for the ready-work queue's per-row
+// "⋯" menu being clipped by the .cc-queue scroll container (overflow-y:auto) when a
+// row near the BOTTOM opens its menu — the operator reported the move/hold menu was
+// "behind the scroll borders" ("Optional hold reason" cut off). The fix: a
+// .cc-q-menu-up variant anchored to bottom:100%, applied by the open handler when
+// the menu would extend past the container's clip boundary.
+func TestContributeQueueMenuFlipsUp(t *testing.T) {
+	body := renderContributePage(t)
+	mustContain := []string{
+		// The flip-up CSS variant exists and anchors upward.
+		".cc-q-menu.cc-q-menu-up{top:auto;bottom:100%",
+		// The open handler measures against the scrolling .cc-queue clip box.
+		"btn.closest('.cc-queue')",
+		// ...and applies the up-variant class when there's no room below.
+		"menu.classList.add('cc-q-menu-up')",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(body, s) {
+			t.Errorf("contribute page missing queue-menu flip-up snippet %q", s)
+		}
+	}
+	// Closing a menu must also clear the up-variant so a reopened row isn't stuck flipped.
+	if !strings.Contains(body, "classList.remove('cc-q-menu-up')") {
+		t.Errorf("ccCloseQueueMenus must clear cc-q-menu-up on close")
+	}
+}


### PR DESCRIPTION
## Bug

On the clanker **Operations** tab, the ready-work queue's per-row **⋯ menu** (Move to top / Move to bottom / Hold / optional hold reason) is clipped for rows near the **bottom** of the queue — it renders "behind the scroll borders," with "Optional hold reason" cut off.

**Cause:** the menu is `position:absolute; top:100%` inside `.cc-queue { overflow-y:auto }`. An absolute child can't escape the scroll container's overflow box, so a downward menu on a bottom row is clipped.

## Fix

- Add a **`.cc-q-menu-up`** variant (`top:auto; bottom:100%`) that opens the menu **upward**.
- The open handler measures the button against the `.cc-queue` clip box and applies `.cc-q-menu-up` when the menu would extend past the container bottom (and there's more room above) — decided **before paint**, so no clipped flash.
- Clears the up-variant on close so a reopened lower row isn't stuck flipped.
- Guard test: up-variant CSS, clip-box measurement, close-time cleanup.

Pure UI positioning fix; no behavior/data change. Verified the test passes locally.