### PR TITLE
✨ feat(config): validate repo targets against forge/org/repo shape with owner call-to-action

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -894,6 +894,25 @@ func main() {
 		"agents", len(cfg.Agents),
 		"hive_id", cfg.HiveID,
 	)
+	startupRepoTargetIssue := config.ValidateRepoTargets(cfg)
+	if startupRepoTargetIssue != nil {
+		logger.Warn("repo target misconfigured — owner action required",
+			"issue", startupRepoTargetIssue.Message,
+			"hive_id", cfg.HiveID,
+			"org", cfg.Project.Org,
+			"repos", cfg.Project.Repos,
+			"primary_repo", cfg.Project.PrimaryRepo,
+		)
+	}
+	repoTargetMisconfigured := func() bool {
+		return config.ValidateRepoTargets(cfg) != nil
+	}
+	repoTargetIssueMessage := func() string {
+		if issue := config.ValidateRepoTargets(cfg); issue != nil {
+			return issue.Message
+		}
+		return ""
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -2847,11 +2866,13 @@ func main() {
 					errMsg, _ := dashSrv.InferenceAuthState()
 					return errMsg
 				}(),
-				Repos:       cfg.Project.Repos,
-				PrimaryRepo: cfg.Project.PrimaryRepo,
-				ACMMLevel:   acmmLvl,
-				Agents:      agents,
-				Governor:    hub.GovernorSummary{Mode: string(govState.Mode), Issues: govState.QueueIssues, PRs: govState.QueuePRs},
+				RepoTargetMisconfigured: repoTargetMisconfigured(),
+				RepoTargetIssue:         repoTargetIssueMessage(),
+				Repos:                   cfg.Project.Repos,
+				PrimaryRepo:             cfg.Project.PrimaryRepo,
+				ACMMLevel:               acmmLvl,
+				Agents:                  agents,
+				Governor:                hub.GovernorSummary{Mode: string(govState.Mode), Issues: govState.QueueIssues, PRs: govState.QueuePRs},
 				// Tokens carries the spoke's authoritative cumulative token
 				// total (same store the dashboard token panel and governor
 				// budget read). It flows to the hub's My Hives token column so
@@ -3133,15 +3154,17 @@ func main() {
 					acmmLvl = *cfg.ACMMLevel
 				}
 				return &hub.HeartbeatPayload{
-					HiveID:    cfg.HiveID,
-					Org:       cfg.Project.Org,
-					ACMMLevel: acmmLvl,
-					Agents:    agents,
-					GitHash:   gitShort,
-					ClusterID: cfg.Hub.ClusterID,
-					HiveType:  cfg.Hub.HiveType,
-					IsPublic:  cfg.Hub.IsPublic,
-					Version:   "3.0.0",
+					HiveID:                  cfg.HiveID,
+					Org:                     cfg.Project.Org,
+					ACMMLevel:               acmmLvl,
+					Agents:                  agents,
+					GitHash:                 gitShort,
+					ClusterID:               cfg.Hub.ClusterID,
+					HiveType:                cfg.Hub.HiveType,
+					IsPublic:                cfg.Hub.IsPublic,
+					Version:                 "3.0.0",
+					RepoTargetMisconfigured: repoTargetMisconfigured(),
+					RepoTargetIssue:         repoTargetIssueMessage(),
 				}
 			}, targetSHA, logger)
 
@@ -3502,6 +3525,15 @@ func main() {
 						logger.Error("failed to save adopted vanity dashboard URL", "error", err)
 					}
 				}
+				return
+			}
+			if issue := config.ValidateProjectRepoTargets(pc.Org, pc.Repos, pc.PrimaryRepo, cfg.GitHub.HostLabel()); issue != nil {
+				logger.Error("REFUSING hub project config: repo target is misconfigured — project left unchanged",
+					"error", issue.Message,
+					"pushed_org", pc.Org,
+					"pushed_repos", pc.Repos,
+					"pushed_primary_repo", pc.PrimaryRepo,
+				)
 				return
 			}
 			curACMM := 0

--- a/v2/pkg/config/repo_target.go
+++ b/v2/pkg/config/repo_target.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"net/url"
+	"strings"
+)
+
+const repoTargetFixCTA = "Fix in Governor Config → Repos."
+
+// RepoTargetIssue is the operator-facing validation result for project.org,
+// project.repos, and project.primary_repo. It is safe to expose in API errors,
+// dashboard status payloads, logs, and hub heartbeat state.
+type RepoTargetIssue struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+// ValidateRepoTargets checks that every configured repository target resolves
+// to exactly org/repo on the configured forge. It deliberately does not rewrite
+// ambiguous shapes; callers should reject writes or surface the returned
+// message so an owner fixes the config.
+func ValidateRepoTargets(cfg *Config) *RepoTargetIssue {
+	if cfg == nil {
+		return nil
+	}
+	return ValidateProjectRepoTargets(cfg.Project.Org, cfg.Project.Repos, cfg.Project.PrimaryRepo, cfg.GitHub.HostLabel())
+}
+
+// ValidateProjectRepoTargets is the testable core used by provisioning and
+// config-save paths before they have a full Config object.
+func ValidateProjectRepoTargets(org string, repos []string, primaryRepo, forgeHost string) *RepoTargetIssue {
+	org = strings.TrimSpace(org)
+	if org == "" {
+		return issue("project.org", "org is empty — expected org/repo")
+	}
+	if looksLikeURL(org) || strings.Contains(org, "/") {
+		return issue("project.org", "org '"+org+"' is not an organization name — expected org/repo")
+	}
+	if looksLikeForgeHost(org, forgeHost) {
+		return issue("project.org", "org '"+org+"' looks like a forge host — expected org/repo")
+	}
+	if len(repos) == 0 {
+		return issue("project.repos", "repo is empty — expected org/repo")
+	}
+	for _, repo := range repos {
+		if repoIssue := validateRepoName("project.repos", repo); repoIssue != nil {
+			return repoIssue
+		}
+	}
+	if strings.TrimSpace(primaryRepo) != "" {
+		if repoIssue := validateRepoName("project.primary_repo", primaryRepo); repoIssue != nil {
+			return repoIssue
+		}
+	}
+	return nil
+}
+
+func validateRepoName(field, repo string) *RepoTargetIssue {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return issue(field, "repo is empty — expected org/repo")
+	}
+	if looksLikeURL(repo) {
+		return issue(field, "repo '"+repo+"' is a URL — expected repo name only so the target resolves to org/repo")
+	}
+	if strings.Contains(repo, "/") {
+		return issue(field, "repo '"+repo+"' contains '/' — expected repo name only so the target resolves to org/repo")
+	}
+	return nil
+}
+
+func issue(field, msg string) *RepoTargetIssue {
+	return &RepoTargetIssue{Field: field, Message: "Repo target misconfigured: " + msg + ". " + repoTargetFixCTA}
+}
+
+func looksLikeURL(s string) bool {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(strings.ToLower(s), "http://") || strings.HasPrefix(strings.ToLower(s), "https://") {
+		return true
+	}
+	u, err := url.Parse(s)
+	return err == nil && u.Scheme != "" && u.Host != ""
+}
+
+func looksLikeForgeHost(value, configuredHost string) bool {
+	value = strings.ToLower(strings.Trim(strings.TrimSpace(value), "/"))
+	configuredHost = strings.ToLower(strings.Trim(strings.TrimSpace(configuredHost), "/"))
+	if value == "" || !strings.Contains(value, ".") {
+		return false
+	}
+	if configuredHost != "" && value == configuredHost {
+		return true
+	}
+	return value == "github.com" || strings.HasPrefix(value, "github.")
+}

--- a/v2/pkg/config/repo_target_test.go
+++ b/v2/pkg/config/repo_target_test.go
@@ -1,0 +1,105 @@
+package config
+
+import "testing"
+
+func TestValidateProjectRepoTargets(t *testing.T) {
+	tests := []struct {
+		name    string
+		org     string
+		repos   []string
+		primary string
+		forge   string
+		want    string
+	}{
+		{name: "public org repo", org: "kubestellar", repos: []string{"hive"}, primary: "hive", forge: "github.com"},
+		{name: "ghe org repo", org: "kcp-dev", repos: []string{"hive"}, primary: "hive", forge: "github.ibm.com"},
+		{
+			name:  "forge host as org",
+			org:   "github.ibm.com",
+			repos: []string{"hive"},
+			forge: "github.ibm.com",
+			want:  "Repo target misconfigured: org 'github.ibm.com' looks like a forge host — expected org/repo. Fix in Governor Config → Repos.",
+		},
+		{
+			name:  "forge host case variant",
+			org:   "GitHub.IBM.com",
+			repos: []string{"hive"},
+			forge: "github.ibm.com",
+			want:  "Repo target misconfigured: org 'GitHub.IBM.com' looks like a forge host — expected org/repo. Fix in Governor Config → Repos.",
+		},
+		{
+			name:  "url pasted in repo",
+			org:   "kubestellar",
+			repos: []string{"https://github.com/kubestellar/hive"},
+			forge: "github.com",
+			want:  "Repo target misconfigured: repo 'https://github.com/kubestellar/hive' is a URL — expected repo name only so the target resolves to org/repo. Fix in Governor Config → Repos.",
+		},
+		{
+			name:  "host org no repo leaves empty repo",
+			org:   "kubestellar",
+			repos: []string{""},
+			forge: "github.com",
+			want:  "Repo target misconfigured: repo is empty — expected org/repo. Fix in Governor Config → Repos.",
+		},
+		{
+			name:  "empty org",
+			org:   "",
+			repos: []string{"hive"},
+			forge: "github.com",
+			want:  "Repo target misconfigured: org is empty — expected org/repo. Fix in Governor Config → Repos.",
+		},
+		{
+			name:  "empty repo list",
+			org:   "kubestellar",
+			repos: nil,
+			forge: "github.com",
+			want:  "Repo target misconfigured: repo is empty — expected org/repo. Fix in Governor Config → Repos.",
+		},
+		{
+			name:  "trailing slash shape",
+			org:   "kubestellar",
+			repos: []string{"hive/"},
+			forge: "github.com",
+			want:  "Repo target misconfigured: repo 'hive/' contains '/' — expected repo name only so the target resolves to org/repo. Fix in Governor Config → Repos.",
+		},
+		{
+			name:  "repo contains slash",
+			org:   "kubestellar",
+			repos: []string{"other/hive"},
+			forge: "github.com",
+			want:  "Repo target misconfigured: repo 'other/hive' contains '/' — expected repo name only so the target resolves to org/repo. Fix in Governor Config → Repos.",
+		},
+		{
+			name:    "primary contains slash",
+			org:     "kubestellar",
+			repos:   []string{"hive"},
+			primary: "kubestellar/hive",
+			forge:   "github.com",
+			want:    "Repo target misconfigured: repo 'kubestellar/hive' contains '/' — expected repo name only so the target resolves to org/repo. Fix in Governor Config → Repos.",
+		},
+		{
+			name:  "full url pasted into org",
+			org:   "https://github.com/kubestellar",
+			repos: []string{"hive"},
+			forge: "github.com",
+			want:  "Repo target misconfigured: org 'https://github.com/kubestellar' is not an organization name — expected org/repo. Fix in Governor Config → Repos.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ValidateProjectRepoTargets(tt.org, tt.repos, tt.primary, tt.forge)
+			if tt.want == "" {
+				if got != nil {
+					t.Fatalf("got issue %q, want nil", got.Message)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("got nil issue, want %q", tt.want)
+			}
+			if got.Message != tt.want {
+				t.Fatalf("message = %q, want %q", got.Message, tt.want)
+			}
+		})
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4845,6 +4845,18 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 	prevPrimary := s.deps.Config.Project.PrimaryRepo
 
 	spokeHost := s.hiveForgeHost()
+	validateRepos := prevRepos
+	if len(body.Repos) > 0 {
+		validateRepos = body.Repos
+	}
+	validatePrimary := prevPrimary
+	if body.PrimaryRepo != nil {
+		validatePrimary = *body.PrimaryRepo
+	}
+	if issue := config.ValidateProjectRepoTargets(org, validateRepos, validatePrimary, spokeHost); issue != nil {
+		jsonError(w, issue.Message, http.StatusBadRequest)
+		return
+	}
 	for _, ref := range body.Repos {
 		if h := repoRefHostLabel(ref); h != "" && !sameForgeHost(h, spokeHost) {
 			jsonError(w, fmt.Sprintf("repo %q is on %s but this hive is on %s — a hive's repos must all be on one GitHub host. Remove the mismatched repo or use a repo on %s.", strings.TrimSpace(ref), h, spokeHost, spokeHost), http.StatusBadRequest)

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -1479,7 +1479,7 @@ func TestHandleGovernorRepos_Success(t *testing.T) {
 	s, _ := apiServer(t)
 	// Replacing the repo set must name a default among the new repos (the
 	// always-exactly-one-default invariant), so send primaryRepo too.
-	rec := doPut(s, "/api/config/governor/repos", map[string]interface{}{"repos": []string{"myorg/repo1", "myorg/repo2"}, "primaryRepo": "repo1"})
+	rec := doPut(s, "/api/config/governor/repos", map[string]interface{}{"repos": []string{"repo1", "repo2"}, "primaryRepo": "repo1"})
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}
@@ -1488,11 +1488,11 @@ func TestHandleGovernorRepos_Success(t *testing.T) {
 func TestHandleGovernorRepos_StripOrg(t *testing.T) {
 	s, deps := apiServer(t)
 	rec := doPut(s, "/api/config/governor/repos", map[string]interface{}{"repos": []string{"myorg/new-repo"}, "primaryRepo": "myorg/new-repo"})
-	if rec.Code != http.StatusOK {
-		t.Errorf("status = %d, want 200", rec.Code)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
 	}
-	if len(deps.Config.Project.Repos) != 1 || deps.Config.Project.Repos[0] != "new-repo" {
-		t.Errorf("repos = %v, want [new-repo]", deps.Config.Project.Repos)
+	if len(deps.Config.Project.Repos) == 1 && deps.Config.Project.Repos[0] == "new-repo" {
+		t.Errorf("repos mutated to stripped value %v despite rejection", deps.Config.Project.Repos)
 	}
 }
 

--- a/v2/pkg/dashboard/api_governor_coverage_test.go
+++ b/v2/pkg/dashboard/api_governor_coverage_test.go
@@ -138,9 +138,9 @@ func TestCovGov_Repos(t *testing.T) {
 	if rec := doPut(s, "/api/config/governor/repos", map[string]any{"repos": []string{"https://github.ibm.com/myorg/repoC"}, "primaryRepo": "repoC"}); rec.Code != http.StatusBadRequest {
 		t.Fatalf("cross-forge repo should be rejected: %d", rec.Code)
 	}
-	// A full same-forge (github.com) URL repo still exercises the URL-parsing
-	// branch and is accepted.
-	if rec := doPut(s, "/api/config/governor/repos", map[string]any{"repos": []string{"https://github.com/myorg/repoC"}, "primaryRepo": "repoC"}); rec.Code != http.StatusOK {
-		t.Fatalf("repos url: %d", rec.Code)
+	// A full same-forge (github.com) URL in the repo field is still rejected:
+	// operators must configure org + bare repo, not rely on silent rewriting.
+	if rec := doPut(s, "/api/config/governor/repos", map[string]any{"repos": []string{"https://github.com/myorg/repoC"}, "primaryRepo": "repoC"}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("repos url should be rejected: %d", rec.Code)
 	}
 }

--- a/v2/pkg/dashboard/api_test.go
+++ b/v2/pkg/dashboard/api_test.go
@@ -499,7 +499,7 @@ func TestHandleGovernorRemoveAgent_NotFound(t *testing.T) {
 func TestHandleGovernorRepos(t *testing.T) {
 	s, _ := apiServer(t)
 	rec := doPut(s, "/api/config/governor/repos",
-		map[string]interface{}{"repos": []string{"myorg/repo1", "myorg/repo2"}, "primaryRepo": "repo1"})
+		map[string]interface{}{"repos": []string{"repo1", "repo2"}, "primaryRepo": "repo1"})
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}

--- a/v2/pkg/dashboard/coverage_boost2_test.go
+++ b/v2/pkg/dashboard/coverage_boost2_test.go
@@ -88,7 +88,7 @@ func TestHandleGovernorRepos_SimpleRepos(t *testing.T) {
 	}
 }
 
-func TestHandleGovernorRepos_URLParsing(t *testing.T) {
+func TestHandleGovernorRepos_URLParsingRejected(t *testing.T) {
 	srv := newFullServer(t)
 	body := `{"repos":["https://github.com/myorg/myrepo"],"primaryRepo":"myrepo"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
@@ -96,11 +96,45 @@ func TestHandleGovernorRepos_URLParsing(t *testing.T) {
 	w := httptest.NewRecorder()
 	srv.handleGovernorRepos(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("code = %d, want 200", w.Code)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400", w.Code)
 	}
-	if srv.deps.Config.Project.Org != "myorg" {
-		t.Errorf("org = %q, want myorg", srv.deps.Config.Project.Org)
+	want := "Repo target misconfigured: repo 'https://github.com/myorg/myrepo' is a URL — expected repo name only so the target resolves to org/repo. Fix in Governor Config → Repos."
+	if !strings.Contains(w.Body.String(), want) {
+		t.Fatalf("body = %q, want %q", w.Body.String(), want)
+	}
+}
+
+func TestHandleStatusCarriesRepoTargetMisconfig(t *testing.T) {
+	srv := newFullServer(t)
+	srv.deps.Config.Project.Org = "github.ibm.com"
+	srv.deps.Config.Project.Repos = []string{"hive"}
+	srv.UpdateStatus(minimalPayload())
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	w := httptest.NewRecorder()
+	srv.handleStatus(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200 body=%s", w.Code, w.Body.String())
+	}
+	var got struct {
+		RepoTargetMisconfigured bool   `json:"repoTargetMisconfigured"`
+		RepoTargetIssue         string `json:"repoTargetIssue"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if !got.RepoTargetMisconfigured {
+		t.Fatal("repoTargetMisconfigured = false, want true")
+	}
+	want := "Repo target misconfigured: org 'github.ibm.com' looks like a forge host — expected org/repo. Fix in Governor Config → Repos."
+	if got.RepoTargetIssue != want {
+		t.Fatalf("repoTargetIssue = %q, want %q", got.RepoTargetIssue, want)
+	}
+	srv.deps.Config.Project.Org = "kubestellar"
+	payload := &StatusPayload{RepoTargetMisconfigured: true, RepoTargetIssue: "stale"}
+	srv.UpdateStatus(payload)
+	if payload.RepoTargetMisconfigured || payload.RepoTargetIssue != "" {
+		t.Fatalf("UpdateStatus did not clear stale repo target issue after fix: %#v", payload)
 	}
 }
 
@@ -314,8 +348,8 @@ func TestHandleGovernorRepos_StripOrgPrefix(t *testing.T) {
 	w := httptest.NewRecorder()
 	srv.handleGovernorRepos(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("code = %d", w.Code)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("code = %d, want 400", w.Code)
 	}
 	repos := srv.deps.Config.Project.Repos
 	for _, r := range repos {

--- a/v2/pkg/dashboard/coverage_boost3_test.go
+++ b/v2/pkg/dashboard/coverage_boost3_test.go
@@ -909,19 +909,18 @@ func TestHealthSummary_WithAgents(t *testing.T) {
 
 func TestHandleGovernorRepos_PrimaryRepoURL(t *testing.T) {
 	srv := newFullServer(t)
-	// The default must be one of the monitored repos, so send the repo alongside
-	// the pasted primary-repo URL (which the handler strips to a bare name).
+	// Full URLs in primary_repo are now rejected instead of silently stripped.
 	body := `{"repos":["otherrepo"],"primaryRepo":"https://github.com/otherorg/otherrepo"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.handleGovernorRepos(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("code = %d", w.Code)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("code = %d, want 400", w.Code)
 	}
-	if srv.deps.Config.Project.PrimaryRepo != "otherrepo" {
-		t.Errorf("primaryRepo = %q, want 'otherrepo'", srv.deps.Config.Project.PrimaryRepo)
+	if srv.deps.Config.Project.PrimaryRepo == "otherrepo" {
+		t.Errorf("primaryRepo changed to %q despite rejection", srv.deps.Config.Project.PrimaryRepo)
 	}
 }
 

--- a/v2/pkg/dashboard/dashboard_handlers_extra_test.go
+++ b/v2/pkg/dashboard/dashboard_handlers_extra_test.go
@@ -681,10 +681,10 @@ func TestHandleGovernorReposStripOrgPrefix(t *testing.T) {
 	w := httptest.NewRecorder()
 	srv.handleGovernorRepos(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d (body: %s)", w.Code, w.Body.String())
 	}
-	// Verify org prefix was stripped
+	// Verify org prefix was not silently stripped
 	repos := srv.deps.Config.Project.Repos
 	for _, r := range repos {
 		if strings.HasPrefix(r, "testorg/") {

--- a/v2/pkg/dashboard/gh_app_install_missing_test.go
+++ b/v2/pkg/dashboard/gh_app_install_missing_test.go
@@ -180,6 +180,23 @@ func TestGitHubAppBannerKeysOffInstallMissingAndAuthState(t *testing.T) {
 	}
 }
 
+func TestRepoTargetBannerPinsFixCTA(t *testing.T) {
+	html := spokeIndexHTML(t)
+	required := []string{
+		`id="repo-target-banner"`,
+		"function renderRepoTargetBanner(data)",
+		"data.repoTargetMisconfigured",
+		"data.repoTargetIssue",
+		"openConfigDialog('governor',null,'Repos')",
+		"Fix in Repos",
+	}
+	for _, snippet := range required {
+		if !strings.Contains(html, snippet) {
+			t.Fatalf("repo target banner missing %q", snippet)
+		}
+	}
+}
+
 // TestForgeAppTabAlwaysOffersInstallAction locks the Forge App tab contract:
 // installation_id 0 (with a real app_id) shows the install link FIRST and by
 // itself; classified not-installed/wrong-installation also trigger it; the

--- a/v2/pkg/dashboard/repo_add_form_test.go
+++ b/v2/pkg/dashboard/repo_add_form_test.go
@@ -15,9 +15,8 @@ import (
 //   - the App-access probe endpoint's single-host + org-resolution behaviour
 //     (requirement #3)
 
-// Requirement #2: a hive on github.com must reject a repo pasted on a different
-// forge — the single-host-per-spoke invariant. newFullServer's testrepo is on
-// public github.com, so a github.ibm.com repo is a mixing attempt.
+// Requirement #2: a hive on github.com must reject a repo pasted as
+// host/org/repo. The canonical target must be configured as org + bare repo.
 func TestGovernorRepos_RejectsCrossForge(t *testing.T) {
 	srv := newFullServer(t)
 	body := `{"repos":["github.ibm.com/acme/widget"],"primaryRepo":"widget"}`
@@ -29,8 +28,8 @@ func TestGovernorRepos_RejectsCrossForge(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("code = %d, want 400 for a cross-forge repo", w.Code)
 	}
-	if !strings.Contains(w.Body.String(), "one GitHub host") {
-		t.Errorf("expected single-host message, got: %s", w.Body.String())
+	if !strings.Contains(w.Body.String(), "expected repo name only so the target resolves to org/repo") {
+		t.Errorf("expected canonical-shape message, got: %s", w.Body.String())
 	}
 	// The hive's forge must be left untouched.
 	if srv.deps.Config.GitHub.BaseURL != "" {
@@ -38,22 +37,25 @@ func TestGovernorRepos_RejectsCrossForge(t *testing.T) {
 	}
 }
 
-// A GHE hive must accept a repo pasted with its OWN GHE host (same forge), and
-// reject a github.com repo (the mirror-image mixing case).
+// A GHE hive still rejects full URLs in repo fields: the forge belongs in the
+// hive GitHub identity, and the repo target must remain org + bare repo.
 func TestGovernorRepos_GHEHiveHostRules(t *testing.T) {
 	srv := newFullServer(t)
 	srv.deps.Config.GitHub.BaseURL = "https://github.ibm.com"
 	srv.deps.Config.GitHub.APIURL = "https://github.ibm.com/api/v3"
 
-	// Same-forge paste (full URL on the hive's own GHE host): accepted. The
-	// handler strips the scheme+host and org prefix down to the bare repo name.
+	// Same-forge full URL paste is still ambiguous in a repo field: rejected
+	// rather than silently rewritten.
 	ok := `{"repos":["https://github.ibm.com/acme/widget"],"primaryRepo":"widget"}`
 	req := httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(ok))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.handleGovernorRepos(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("same-forge add: code = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("same-forge URL add: code = %d, want 400 (body: %s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "is a URL") {
+		t.Fatalf("same-forge URL add body = %s, want URL rejection", w.Body.String())
 	}
 
 	// public github.com paste on a GHE hive: rejected as mixing.

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -258,6 +258,8 @@ type StatusPayload struct {
 	// blank raw fields suppressing the banner while auth was not-installed).
 	GitHubAppInstallMissing bool               `json:"githubAppInstallMissing,omitempty"`
 	GitHubBaseURL           string             `json:"githubBaseURL,omitempty"`
+	RepoTargetMisconfigured bool               `json:"repoTargetMisconfigured,omitempty"`
+	RepoTargetIssue         string             `json:"repoTargetIssue,omitempty"`
 	InferenceBackends       []InferenceBackend `json:"inferenceBackends,omitempty"`
 	SystemAlerts            []SystemAlert      `json:"systemAlerts,omitempty"`
 	HubBanner               *HubBannerState    `json:"hubBanner,omitempty"`
@@ -1059,6 +1061,13 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 		status.ACMMLevel = detectACMMLevel(s.deps.Config)
 		status.ACMMPackAgents = buildACMMPackAgents(s.deps.Config)
 		status.GitHubBaseURL = s.deps.Config.GitHub.ResolvedBaseURL()
+		if issue := config.ValidateRepoTargets(s.deps.Config); issue != nil {
+			status.RepoTargetMisconfigured = true
+			status.RepoTargetIssue = issue.Message
+		} else {
+			status.RepoTargetMisconfigured = false
+			status.RepoTargetIssue = ""
+		}
 	}
 	status.ContributorPool = s.BuildContributorPoolStatus()
 
@@ -2273,6 +2282,11 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 	} else {
 		checks = append(checks, check{Name: "github_auth", Status: "fail", Detail: "no auth"})
 		fails++
+	}
+
+	if status != nil && status.RepoTargetMisconfigured {
+		checks = append(checks, check{Name: "repo_target", Status: "warn", Detail: status.RepoTargetIssue})
+		warns++
 	}
 
 	// 3. Agents

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2825,6 +2825,14 @@
     <button type="button" onclick="recheckGitHubApp()" class="gh-app-btn" style="background:transparent;border-color:var(--line-strong);color:var(--muted);margin-right:8px" id="gh-app-recheck-btn">Re-check</button>
     <a id="gh-app-install-link" href="" target="_blank" rel="noopener" class="gh-app-btn">Install GitHub App</a>
   </div>
+  <div id="repo-target-banner" class="gh-app-install-banner perm-issue" hidden>
+    <span style="font-size:1.5rem">&#9888;&#65039;</span>
+    <div style="flex:1">
+      <div class="gh-app-title">Repo Target Misconfigured</div>
+      <div class="gh-app-desc" id="repo-target-banner-desc">Expected org/repo.</div>
+    </div>
+    <button type="button" class="gh-app-btn" onclick="openConfigDialog('governor',null,'Repos')">Fix in Repos</button>
+  </div>
   <div id="hub-banner" style="display:none"></div>
   <div id="system-alerts-banner" style="display:none"></div>
   <div class="governor" id="governor"></div>
@@ -5985,6 +5993,20 @@
         if (oldDetails) oldDetails.remove();
         banner.setAttribute('hidden', '');
         banner.style.cssText = 'display:none';
+      }
+    }
+
+    function renderRepoTargetBanner(data) {
+      var banner = document.getElementById('repo-target-banner');
+      if (!banner) return;
+      if (data && data.repoTargetMisconfigured) {
+        var desc = document.getElementById('repo-target-banner-desc');
+        if (desc) desc.textContent = data.repoTargetIssue || 'Repo target misconfigured — expected org/repo. Fix in Governor Config → Repos.';
+        banner.removeAttribute('hidden');
+        banner.style.cssText = 'display:flex !important';
+      } else {
+        banner.setAttribute('hidden', '');
+        banner.style.display = 'none';
       }
     }
 
@@ -11068,6 +11090,7 @@ function burnAreaChart() {
       }
       renderGhRateLimits(data.ghRateLimits || {});
       renderGitHubAppBanner(data);
+      renderRepoTargetBanner(data);
       refreshWelcomeAutoChecks(data);
       renderHubBanner(data.hubBanner);
       renderSystemAlerts(data.systemAlerts || []);

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -430,6 +430,11 @@ type HeartbeatPayload struct {
 	Timestamp          string `json:"timestamp"`
 	GitHubAppRequired  bool   `json:"github_app_required,omitempty"`
 	GitHubAppPermIssue string `json:"github_app_perm_issue,omitempty"`
+	// RepoTargetMisconfigured carries an operator-facing config-shape issue
+	// detected by the spoke. It is visibility only: the spoke keeps running and
+	// the hub does not rewrite the project fields.
+	RepoTargetMisconfigured bool   `json:"repo_target_misconfigured,omitempty"`
+	RepoTargetIssue         string `json:"repo_target_issue,omitempty"`
 	// GitHubAppState is the spoke's classification of WHY App auth is failing
 	// (a github.AppAuthState token: "key-missing", "key-invalid",
 	// "not-installed", "wrong-installation", "insufficient-permissions").

--- a/v2/pkg/hub/repo_target_signal_test.go
+++ b/v2/pkg/hub/repo_target_signal_test.go
@@ -1,0 +1,45 @@
+package hub
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestHeartbeatPayloadCarriesRepoTargetMisconfig(t *testing.T) {
+	want := "Repo target misconfigured: org 'github.ibm.com' looks like a forge host — expected org/repo. Fix in Governor Config → Repos."
+	raw, err := json.Marshal(HeartbeatPayload{
+		HiveID:                  "h1",
+		RepoTargetMisconfigured: true,
+		RepoTargetIssue:         want,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got HeartbeatPayload
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !got.RepoTargetMisconfigured || got.RepoTargetIssue != want {
+		t.Fatalf("repo target signal lost: %#v", got)
+	}
+}
+
+func TestMyHivesHealthBadgeShowsRepoTargetMisconfig(t *testing.T) {
+	body, err := os.ReadFile("saas.go")
+	if err != nil {
+		t.Fatalf("read saas.go: %v", err)
+	}
+	html := string(body)
+	for _, snippet := range []string{
+		"h.repoTargetMisconfigured",
+		"h.repoTargetIssue",
+		"var repoTargetBad = !isPlaceholderHive(h) && !!h.repoTargetMisconfigured",
+		"Repo target misconfigured — expected org/repo. Fix in Governor Config → Repos.",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Fatalf("saas health badge missing %q", snippet)
+		}
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -29,6 +29,28 @@ var saasUsersDir = "/data/saas/users"
 
 const hubAdminUsername = "clubanderson"
 
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if p := strings.TrimSpace(part); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func repoTargetForgeHost(baseURL string) string {
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		return "github.com"
+	}
+	if u, err := url.Parse(baseURL); err == nil && u.Host != "" {
+		return strings.ToLower(u.Host)
+	}
+	return strings.ToLower(strings.Trim(strings.TrimPrefix(strings.TrimPrefix(baseURL, "https://"), "http://"), "/"))
+}
+
 // hubUpgradeDebounce is the minimum gap between hub self-upgrade rollout
 // restarts. The behind-latest check runs every SHA-poll cycle, so without this
 // the hub could re-trigger a restart before the previous rollout's new pod
@@ -2757,6 +2779,18 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	reposForValidation := splitCSV(req.Repos)
+	if len(reposForValidation) == 0 {
+		reposForValidation = []string{""}
+	}
+	primaryForValidation := strings.TrimSpace(req.PrimaryRepo)
+	if primaryForValidation == "" && len(reposForValidation) > 0 {
+		primaryForValidation = reposForValidation[0]
+	}
+	if issue := config.ValidateProjectRepoTargets(req.Org, reposForValidation, primaryForValidation, repoTargetForgeHost(req.GitHubBaseURL)); issue != nil {
+		writeJSONError(w, http.StatusBadRequest, issue.Message)
+		return
+	}
 	if req.Org == "" || req.Repos == "" {
 		http.Error(w, `{"error":"org and repos are required"}`, http.StatusBadRequest)
 		return
@@ -7093,6 +7127,14 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"invalid primary repo"}`, http.StatusBadRequest)
 		return
 	}
+	forgeHost := body.GitHubHost
+	if strings.EqualFold(forgeHost, githubHostPublic) || forgeHost == "" {
+		forgeHost = "github.com"
+	}
+	if issue := config.ValidateProjectRepoTargets(body.Org, repos, primaryRepo, forgeHost); issue != nil {
+		writeJSONError(w, http.StatusBadRequest, issue.Message)
+		return
+	}
 
 	acmm := body.ACMMLevel
 	if acmm == 0 {
@@ -8723,7 +8765,8 @@ const dashboardHTML = `<!DOCTYPE html>
          EXCEPT on an unassigned placeholder, where having no usable App is the
          pool's designed state (mirrored here so dot and chip never disagree). */
       var appMissing = !isPlaceholderHive(h) && !!h.githubAppRequired && !h.githubAppPermIssue;
-      var degraded = (!isPlaceholderHive(h) && !!h.githubAppRequired) || st === 'degraded' || st === 'critical';
+      var repoTargetBad = !isPlaceholderHive(h) && !!h.repoTargetMisconfigured;
+      var degraded = repoTargetBad || (!isPlaceholderHive(h) && !!h.githubAppRequired) || st === 'degraded' || st === 'critical';
       /* An offline hive has no live reading at all, so it is not "OK" even if
          its last stored health snapshot said ok. */
       var ok = !degraded && st === 'ok' && !!h.online;
@@ -9098,6 +9141,12 @@ const dashboardHTML = `<!DOCTYPE html>
            auth-class checks (sanitizePlaceholderRows, placeholder_health.go);
            this line says WHY the row is green instead of claiming an App. */
         lines.push('– Unassigned — GitHub auth not configured by design');
+      }
+      else if (h.repoTargetMisconfigured) {
+        lines.push('⚠ ' + (h.repoTargetIssue || 'Repo target misconfigured — expected org/repo. Fix in Governor Config → Repos.'));
+        if (st === 'ok' || st === 'unknown') {
+          st = 'warning'; c = colors.warning; ic = icons.warning; statusLabel = 'Warning'; lines[0] = statusLabel;
+        }
       }
       else if (h.githubAppRequired && ghAppIsOperatorSide(h.githubAppState)) {
         /* Operator-side: the key we distribute has not landed, or is for the

--- a/v2/pkg/hub/saas_handlers2_coverage_test.go
+++ b/v2/pkg/hub/saas_handlers2_coverage_test.go
@@ -71,6 +71,7 @@ func TestHandleCreateHiveValidation_Cov2(t *testing.T) {
 	}{
 		{"bad json", `{`, http.StatusBadRequest},
 		{"missing org", `{"repos":"r","github_token":"ghp_x"}`, http.StatusBadRequest},
+		{"repo target host as org", `{"org":"github.ibm.com","repos":"github.ibm.com/repo","github_token":"ghp_x"}`, http.StatusBadRequest},
 		{"invalid org", `{"org":"bad org!","repos":"r","github_token":"ghp_x"}`, http.StatusBadRequest},
 		{"no creds", `{"org":"acme","repos":"repo"}`, http.StatusBadRequest},
 		{"bad token prefix", `{"org":"acme","repos":"repo","github_token":"xxx"}`, http.StatusBadRequest},
@@ -85,6 +86,24 @@ func TestHandleCreateHiveValidation_Cov2(t *testing.T) {
 				t.Errorf("status = %d, want %d (body=%s)", rec.Code, tc.want, rec.Body.String())
 			}
 		})
+	}
+}
+
+func TestHandleCreateHiveRejectsRepoTargetShapeWithMessage(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	saveSaaSUser(&SaaSUser{GitHubUsername: "alice", Hives: map[string]string{}, SaaSQuota: 5})
+	s := newHandlerHub2()
+
+	rec := httptest.NewRecorder()
+	req := reqWithUser(http.MethodPost, "/api/saas/hives", `{"org":"github.ibm.com","repos":"github.ibm.com/repo","github_token":"ghp_x"}`, "alice")
+	s.handleCreateHive(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 body=%s", rec.Code, rec.Body.String())
+	}
+	want := "Repo target misconfigured: org 'github.ibm.com' looks like a forge host — expected org/repo. Fix in Governor Config → Repos."
+	if !strings.Contains(rec.Body.String(), want) {
+		t.Fatalf("body = %q, want to contain %q", rec.Body.String(), want)
 	}
 }
 

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -222,12 +222,14 @@ type RegistryEntry struct {
 	// re-armed forever, which looks like progress but never is. Past
 	// maxOrphanedUpgradeSweeps the hub stops retrying and records a failure a
 	// human can see. Reset whenever the hive reaches a target.
-	OrphanedUpgradeSweeps int          `json:"orphanedUpgradeSweeps,omitempty"`
-	IssueHistory          []SparkPoint `json:"issueHistory,omitempty"`
-	PRHistory             []SparkPoint `json:"prHistory,omitempty"`
-	GitHubAppRequired     bool         `json:"githubAppRequired,omitempty"`
-	GitHubAppPermIssue    string       `json:"githubAppPermIssue,omitempty"`
-	GitHubAppState        string       `json:"githubAppState,omitempty"`
+	OrphanedUpgradeSweeps   int          `json:"orphanedUpgradeSweeps,omitempty"`
+	IssueHistory            []SparkPoint `json:"issueHistory,omitempty"`
+	PRHistory               []SparkPoint `json:"prHistory,omitempty"`
+	GitHubAppRequired       bool         `json:"githubAppRequired,omitempty"`
+	GitHubAppPermIssue      string       `json:"githubAppPermIssue,omitempty"`
+	GitHubAppState          string       `json:"githubAppState,omitempty"`
+	RepoTargetMisconfigured bool         `json:"repoTargetMisconfigured,omitempty"`
+	RepoTargetIssue         string       `json:"repoTargetIssue,omitempty"`
 	// ConflictingReporters names two spoke instances that are BOTH reporting
 	// as this hive (e.g. "hive-abc… ↔ hive-def…"), set when their beats
 	// alternate. Non-empty is a critical drift signal: every field in this
@@ -1352,6 +1354,8 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		// identifier sanitizer stripped every space out of it.
 		GitHubAppPermIssue:      sanitizeProseField(payload.GitHubAppPermIssue),
 		GitHubAppState:          sanitizeHeartbeatField(payload.GitHubAppState),
+		RepoTargetMisconfigured: payload.RepoTargetMisconfigured,
+		RepoTargetIssue:         sanitizeProseField(payload.RepoTargetIssue),
 		StatusFlipping:          s.noteStatusFlip(payload.HiveID, sanitizeHeartbeatField(payload.GitHubAppState)),
 		GitHubAppID:             payload.GitHubAppID,
 		GitHubAppSlug:           payload.GitHubAppSlug,


### PR DESCRIPTION
## Summary
- Adds shared repo-target shape validation for any configured forge: org must be a real org, repo fields must be bare repo names, and targets must resolve to exactly org/repo.
- Rejects invalid hub provision/assignment and spoke Governor Repos saves with operator-facing 400s instead of silently rewriting ambiguous URLs or slash shapes.
- Surfaces already-broken hives via spoke /api/status + dashboard banner, startup WARN logs, heartbeat fields, and hub My Hives health/attention row details.

## Operator requirement
> "we should have this for any forge - if the url's for a repo do not fit the forge/org/repo then their should be an error and call to action for the owner to fix it"

Earlier live-hive context: org was `github.ibm.com`, repo was actually an org, no real repo — now flagged loudly with a fix path instead of auto-healed.

## Validation
- go build ./...
- go vet ./...
- go test ./pkg/hub/ ./pkg/dashboard/ ./pkg/config/ -count=1
