### PR TITLE
feat(contribute): add goose to HEADLESS_BACKENDS

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -238,14 +238,16 @@ function buildLaunchCommand() {
 // status — the property the headless mode needs. Each entry says how to turn
 // (binary, perm-flags, prompt) into an argv:
 //
-//   flag — the sub-command/flag that selects one-shot mode; the prompt is
-//          passed as the single positional argument that follows it
-//          (`claude -p "<prompt>"`, `codex exec "<prompt>"`).
+//   flag — the sub-command/flag(s) that select one-shot mode, as a single
+//          token (`claude -p "<prompt>"`, `codex exec "<prompt>"`) or an
+//          array of tokens when a subcommand and a flag both precede the
+//          prompt (`goose run --no-session -t "<prompt>"`). The prompt is
+//          always appended as the final, distinct argv element.
 //
-// Backends NOT listed here have no known non-interactive entry point (goose /
-// bob / agy / pi drive an interactive TUI), so headless mode refuses them
-// LOUDLY at task time rather than silently stalling. Extending this table is
-// how a future PR adds a backend once its headless invocation is verified.
+// Backends NOT listed here have no known non-interactive entry point (bob /
+// agy / pi drive an interactive TUI), so headless mode refuses them LOUDLY at
+// task time rather than silently stalling. Extending this table is how a
+// future PR adds a backend once its headless invocation is verified.
 const HEADLESS_BACKENDS = {
   // claude -p "<prompt>" — print mode: runs the prompt non-interactively and
   // exits. Same perm flags as the interactive launch (bypass permissions).
@@ -257,6 +259,16 @@ const HEADLESS_BACKENDS = {
   copilot: { flag: '-p' },
   // codex exec "<prompt>" — Codex's non-interactive execution sub-command.
   codex: { flag: 'exec' },
+  // goose run --no-session -t "<prompt>" — `run` is goose's one-shot
+  // sub-command (the bare `goose` binary alone drives the interactive TUI);
+  // --no-session skips creating/resuming a session file, which headless
+  // dispatch never needs; -t takes the prompt as its value rather than as a
+  // trailing positional. Exits 0 on success, non-zero on error. Verified
+  // directly against `goose 1.45.0-canary+eea5609`: `goose run --no-session
+  // -t "<prompt>"` printed the response and exited 0; `goose run --no-session
+  // -i <missing-file>` exited 1. Not yet exercised through a live headless
+  // Hive task cycle — see kubestellar/hive#2828.
+  goose: { flag: ['run', '--no-session', '-t'] },
 };
 
 // headlessSupportsBackend reports whether the configured backend has a known
@@ -267,17 +279,18 @@ function headlessSupportsBackend() {
 
 // buildHeadlessArgv turns a task prompt into the argv for a one-shot,
 // non-interactive backend invocation: [binary, ...permFlags, ...modelFlag,
-// oneShotFlag, prompt] (order adjusted per promptAsArg). Returns null for an
-// unsupported backend. Never shell-interpolates the prompt — it is passed as a
-// distinct argv element to execFile, so apostrophes/quotes in the prompt (the
-// exact #2203 wedge on the interactive path) cannot break anything here.
+// ...oneShotFlags, prompt]. Returns null for an unsupported backend. Never
+// shell-interpolates the prompt — it is passed as a distinct argv element to
+// execFile, so apostrophes/quotes in the prompt (the exact #2203 wedge on the
+// interactive path) cannot break anything here.
 function buildHeadlessArgv(prompt) {
   const spec = HEADLESS_BACKENDS[BACKEND];
   if (!spec) return null;
   const { cmd, perm } = resolveBackend();
   const permArgs = perm ? perm.split(/\s+/).filter(Boolean) : [];
   const modelArgs = MODEL && !NO_MODEL_FLAG_BACKENDS.includes(BACKEND) ? ['--model', MODEL] : [];
-  const args = [...permArgs, ...modelArgs, spec.flag, prompt];
+  const oneShotArgs = Array.isArray(spec.flag) ? spec.flag : [spec.flag];
+  const args = [...permArgs, ...modelArgs, ...oneShotArgs, prompt];
   return { bin: cmd, args };
 }
 

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -544,6 +544,26 @@ test('interactive is the default mode; headless is opt-in via CONTRIBUTOR_MODE',
   } finally { teardown(head); }
 });
 
+test('goose runs headless via its one-shot `run` sub-command and reports completion', () => {
+  const relay = loadRelay({ backend: 'goose', mode: 'headless' });
+  try {
+    assignHeadlessTask(relay);
+
+    assert.strictEqual(relay.__execFileCalls.length, 1, 'expected exactly one one-shot invocation');
+    const call = relay.__execFileCalls[0];
+    assert.strictEqual(call.bin, 'goose', 'goose backend should run the goose binary');
+    assert.ok(call.args.includes('run'), `goose headless must use its 'run' sub-command: ${JSON.stringify(call.args)}`);
+    assert.ok(call.args.includes('-t'), `goose headless must pass the prompt via -t: ${JSON.stringify(call.args)}`);
+    assert.ok(call.args[call.args.length - 1].includes('foo/bar#7'),
+      'the prompt must be the trailing argv element (passed to execFile, never shell-quoted)');
+
+    // A default (exit-0, empty stdout) execFile result reports completion —
+    // exercising the exit-code contract runHeadlessTask() relies on.
+    const complete = relay.__sent.find(m => m.type === 'task_complete');
+    assert.ok(complete, 'a successful goose one-shot invocation must report task_complete');
+  } finally { teardown(relay); }
+});
+
 test('headless dispatch runs a one-shot execFile and never types into tmux', () => {
   const relay = loadRelay({ backend: 'claude', mode: 'headless' });
   try {
@@ -611,9 +631,11 @@ test('a headless timeout kill is reported as a failure, not a completion', () =>
 });
 
 test('headless refuses an unsupported backend loudly instead of stalling', () => {
-  const relay = loadRelay({ backend: 'goose', mode: 'headless' });
+  // bob drives an interactive TUI with no known one-shot entry point (unlike
+  // goose, which gained one — see the buildHeadlessArgv test below).
+  const relay = loadRelay({ backend: 'bob', mode: 'headless' });
   try {
-    assert.strictEqual(relay.headlessSupportsBackend(), false, 'goose has no one-shot mode');
+    assert.strictEqual(relay.headlessSupportsBackend(), false, 'bob has no one-shot mode');
     assignHeadlessTask(relay);
     // No CLI was ever spawned...
     assert.strictEqual(relay.__execFileCalls.length, 0, 'an unsupported backend must not spawn a CLI');
@@ -641,10 +663,20 @@ test('buildHeadlessArgv maps each supported backend to its one-shot invocation',
       `codex must use 'exec' one-shot: ${JSON.stringify(a.args)}`);
   } finally { teardown(codex); }
 
-  const goose = loadRelay({ backend: 'goose', mode: 'headless' });
+  const goose = loadRelay({ backend: 'goose', mode: 'headless', model: 'some-model' });
   try {
-    assert.strictEqual(goose.buildHeadlessArgv('x'), null, 'unsupported backend has no argv');
+    const a = goose.buildHeadlessArgv('do the thing');
+    assert.strictEqual(a.bin, 'goose');
+    const tail = a.args.slice(-4);
+    assert.deepStrictEqual(tail, ['run', '--no-session', '-t', 'do the thing'],
+      `goose must run its one-shot sub-command with the prompt as -t's value: ${JSON.stringify(a.args)}`);
+    assert.ok(!a.args.includes('--model'), 'goose is in NO_MODEL_FLAG_BACKENDS and must not get --model');
   } finally { teardown(goose); }
+
+  const bob = loadRelay({ backend: 'bob', mode: 'headless' });
+  try {
+    assert.strictEqual(bob.buildHeadlessArgv('x'), null, 'unsupported backend has no argv');
+  } finally { teardown(bob); }
 });
 
 test('interactive mode still delivers via tmux send-keys (unchanged default path)', () => {


### PR DESCRIPTION
Fixes #2828.

## What

`HEADLESS_BACKENDS`' comment claimed goose has "no known non-interactive entry point" because it "drive[s] an interactive TUI", and `buildHeadlessArgv('x')` was asserted (by a passing test) to return `null` for goose. That claim is stale: `goose run --no-session -t "<prompt>"` is a documented one-shot invocation that exits 0 on success and non-zero on error. Full evidence, the exact flags/version tested, and the impact are in #2828 — this PR is the fix that issue proposes as option 1.

## The shape difference this required

The existing `HEADLESS_BACKENDS` entries (`claude -p`, `codex exec`) each need exactly **one** leading token before the prompt, and `buildHeadlessArgv` hard-coded that: `[...permArgs, ...modelArgs, spec.flag, prompt]`. goose needs **two**: its `run` sub-command *and* a flag (`-t`) whose value is the prompt. So `spec.flag` now accepts either a string (unchanged behavior for the four existing entries) or an array of leading tokens:

```js
goose: { flag: ['run', '--no-session', '-t'] },
```

```js
const oneShotArgs = Array.isArray(spec.flag) ? spec.flag : [spec.flag];
const args = [...permArgs, ...modelArgs, ...oneShotArgs, prompt];
```

I also dropped the doc comment's reference to a `promptAsArg` notion — I couldn't find any implementation of it in the current code (`buildHeadlessArgv` only ever appends the prompt as the trailing element), so it looked like stale documentation rather than an existing seam I should be using. Happy to be corrected if I missed where it lives.

## Tests

Extends `bin/contributor-relay.test.js`:
- New: `goose runs headless via its one-shot 'run' sub-command and reports completion` — full dispatch: `execFile` called with `goose`/`run`/`-t`/prompt, and a default (exit-0) result reports `task_complete`.
- Extended: `buildHeadlessArgv maps each supported backend to its one-shot invocation` — asserts goose's exact trailing argv (`['run', '--no-session', '-t', prompt]`) and that it does NOT get `--model` (goose is already in `NO_MODEL_FLAG_BACKENDS`).
- Changed: the two tests that used goose as the "backend with no one-shot mode" example (`headless refuses an unsupported backend loudly instead of stalling`, and half of `buildHeadlessArgv maps each supported backend...`) now use `bob`, which still has no known one-shot mode, so that coverage isn't lost.

`node bin/contributor-relay.test.js` → **27/27 passed** (26 existing + 1 new).

## What I verified vs. did not

- **Verified directly**, against the `goose` binary (`1.45.0-canary+eea5609`, and re-confirmed against a local `1.45.0` build for this PR): `goose run --help`'s documented flags, `goose run --no-session -t "<prompt>"` printing the response and exiting 0, and `goose run --no-session -i <missing-file>` exiting 1.
- **Verified**: the full relay unit test suite offline (no tmux, no real CLI, no network — `child_process`/`ws` are stubbed, per the existing harness in `contributor-relay.test.js`).
- **Not verified**: an end-to-end live headless Hive task cycle with a real goose backend. That needs a running hub, a registration token, and `GOOSE_PROVIDER`/model credentials I don't have set up here. If a maintainer can run one, the thing worth confirming is that a real task prompt (as opposed to the test harness's canned prompt) round-trips through `goose run --no-session -t` correctly and that `runHeadlessTask()`'s exit-code handling behaves the same against the real binary as it does against the stub.

## Not in scope here

`--output-format stream-json` for structured progress reporting instead of a raw output tail is mentioned as a possible future idea in #2828 — not implemented in this PR, to keep this change to the table addition + the minimal `buildHeadlessArgv` extension it requires.
