### PR TITLE
🐛 fix(gateway): healthcheck no longer probes IPv6 localhost against an IPv4-only nginx

### DIFF
--- a/v2/deploy/nginx.conf
+++ b/v2/deploy/nginx.conf
@@ -25,6 +25,13 @@ http {
 
     server {
         listen 3001;
+        # Also bind the IPv6 loopback/wildcard. This file is mounted over
+        # /etc/nginx/nginx.conf and has no `include /etc/nginx/conf.d/*.conf`,
+        # so the nginx:alpine 10-listen-on-ipv6-by-default.sh fixup (which only
+        # patches conf.d/default.conf) never reaches this server block. Without
+        # this line, anything resolving "localhost" to ::1 -- container
+        # healthchecks, IPv6 clients -- gets ECONNREFUSED. See issue #2774.
+        listen [::]:3001;
 
         location /api/ {
             proxy_pass http://hive_api;
@@ -71,6 +78,10 @@ stream {
 
     server {
         listen 7681;
+        # Same dual-stack reasoning as the :3001 server block above. The ttyd
+        # stream proxy is IPv4-only today, so any future probe or client that
+        # resolves "localhost" to ::1 would hit the identical trap.
+        listen [::]:7681;
         proxy_pass hive_ttyd;
     }
 }

--- a/v2/pkg/config/gateway_nginx_dualstack_test.go
+++ b/v2/pkg/config/gateway_nginx_dualstack_test.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"os"
+	"regexp"
+	"testing"
+)
+
+// nginxConfPath is the gateway config under test, relative to this package.
+// It is bind-mounted over /etc/nginx/nginx.conf by v2/docker-compose.yaml.
+const nginxConfPath = "../../deploy/nginx.conf"
+
+// Ports that the gateway server blocks listen on. Named rather than inlined so
+// a port change forces a deliberate edit here instead of silently un-covering
+// a block.
+const (
+	gatewayAPIPort  = "3001"
+	gatewayTTYDPort = "7681"
+)
+
+// readNginxConf returns the gateway nginx config text.
+func readNginxConf(t *testing.T) string {
+	t.Helper()
+	src, err := os.ReadFile(nginxConfPath)
+	if err != nil {
+		t.Skipf("nginx.conf not readable from this package: %v", err)
+	}
+	return string(src)
+}
+
+// TestGatewayListensDualStack pins the fix for issue #2774.
+//
+// The gateway healthcheck (and any IPv6 client) resolves "localhost" to ::1 on
+// a dual-stack host. This file is mounted over /etc/nginx/nginx.conf and does
+// NOT include /etc/nginx/conf.d/*.conf, so the nginx:alpine
+// 10-listen-on-ipv6-by-default.sh fixup never applies to these server blocks.
+// If the `listen [::]:PORT;` directives are dropped, nothing binds the IPv6
+// loopback and the probe gets ECONNREFUSED forever.
+func TestGatewayListensDualStack(t *testing.T) {
+	conf := readNginxConf(t)
+
+	for _, port := range []string{gatewayAPIPort, gatewayTTYDPort} {
+		t.Run("port_"+port, func(t *testing.T) {
+			// IPv4 bind must remain.
+			v4 := regexp.MustCompile(`(?m)^\s*listen\s+` + port + `\s*;`)
+			if !v4.MatchString(conf) {
+				t.Errorf("nginx.conf lost the IPv4 `listen %s;` directive", port)
+			}
+			// IPv6 bind must be present alongside it.
+			v6 := regexp.MustCompile(`(?m)^\s*listen\s+\[::\]:` + port + `\s*;`)
+			if !v6.MatchString(conf) {
+				t.Errorf("nginx.conf is missing `listen [::]:%s;` -- IPv6 loopback "+
+					"is unbound, so healthchecks resolving localhost to ::1 will "+
+					"fail forever (issue #2774)", port)
+			}
+		})
+	}
+}
+
+// TestGatewayConfDoesNotRelyOnConfD guards the reason the upstream nginx:alpine
+// IPv6 fixup does not save us: that script only patches conf.d/default.conf. If
+// someone later adds an `include /etc/nginx/conf.d/*.conf;` here, the explicit
+// listen directives above stop being the only thing standing between us and a
+// silent regression, and this test's rationale should be revisited.
+func TestGatewayConfDoesNotRelyOnConfD(t *testing.T) {
+	conf := readNginxConf(t)
+	includeConfD := regexp.MustCompile(`(?m)^\s*include\s+/etc/nginx/conf\.d/`)
+	if includeConfD.MatchString(conf) {
+		t.Skip("nginx.conf now includes conf.d; the upstream IPv6 fixup may apply " +
+			"and the dual-stack rationale in TestGatewayListensDualStack needs review")
+	}
+}


### PR DESCRIPTION
## The report

[#2774](https://github.com/kubestellar/hive/issues/2774), from `castrojo`, running the v2 quadlets unmodified downstream. The gateway served traffic fine for 32 hours while its healthcheck accumulated a `FailingStreak` of **10390** — it had never once passed. His diagnosis:

> `v2/deploy/nginx.conf` binds IPv4 only [...] Inside the container `/etc/hosts` maps `localhost` to **both** families [...] BusyBox `wget` resolves `localhost` to `::1` first. Nothing is listening on `::1:3001`, so the probe gets `ECONNREFUSED` every single time.

And the part that matters most, which is easy to miss:

> `nginx:alpine` ships `/docker-entrypoint.d/10-listen-on-ipv6-by-default.sh` [...] But it only patches `/etc/nginx/conf.d/default.conf`. The quadlet bind-mounts `deploy/nginx.conf` over `/etc/nginx/nginx.conf`, and that config has no `include /etc/nginx/conf.d/*.conf`, so `default.conf` is never loaded and the IPv6 fixup has no effect on the actual server block. The script's success message is misleading here.

## What I confirmed

Verified against the tree rather than taken on faith:

- `v2/deploy/nginx.conf` binds IPv4 only — `listen 3001;` (http) and `listen 7681;` (ttyd stream). No IPv6 listen anywhere in the file.
- The file has **no** `include /etc/nginx/conf.d/*.conf`, so the upstream IPv6 fixup genuinely cannot reach these server blocks. The reporter's subtlest claim holds.
- `v2/docker-compose.yaml` mounts it at `./deploy/nginx.conf:/etc/nginx/nginx.conf:ro`, confirming the override path.

One correction to scope: `v2/quadlets/hive-gateway.container` **does not exist in this repo** — that path is the reporter's downstream deployment. The `HealthCmd=` line he quotes is not ours to change. What is ours is the nginx config, and it is still IPv4-only.

## Why fix (b), not (a)

[#2779](https://github.com/kubestellar/hive/pull/2779) already applied fix (a) — `localhost` → `127.0.0.1` across `docker-compose.yaml`, `docker-compose.architect.yaml`, `blue-green-deploy.sh` and `bin/hive-setup.sh` — and closed #2774. But it never touched `nginx.conf`. So the probes were made unambiguous while the underlying serving gap was left in place: **the gateway still refuses all IPv6 connections.**

That makes (a) alone exactly the papering-over the issue warns about. Fix (a) silences the symptom for probes that we control; it does nothing for a real IPv6 client. This PR adds the missing half:

```nginx
listen 3001;
listen [::]:3001;
```

The reporter also flagged that the ttyd `stream` block on 7681 has the same IPv4-only bind and is the same trap waiting for the next probe added against it, so that block is fixed too. As he put it: fixing the listen directives "inoculates against that; fixing only the probe (1) does not."

Combined with #2779 already in place, the gateway is now dual-stack *and* the probes are unambiguous — both halves, which is what the issue actually asked for.

## Tests

`v2/pkg/config/gateway_nginx_dualstack_test.go`, following the existing `entrypoint_boot_test.go` pattern of asserting against the real deploy file via a relative path (not a paraphrase of it).

- `TestGatewayListensDualStack` — asserts both the IPv4 and the `[::]` listen for 3001 and 7681. Verified it genuinely pins the behavior: with the `listen [::]` lines stripped it fails on both ports; with them it passes.
- `TestGatewayConfDoesNotRelyOnConfD` — guards the *reason* the upstream fixup doesn't save us. If someone later adds an `include /etc/nginx/conf.d/*.conf`, it flags that the rationale needs revisiting.

## Validation

- `go build ./...` — clean
- `go vet ./pkg/config/` — clean
- `go test ./pkg/config/ -run TestGateway` — pass
- `nginx -t` not run locally (no Docker daemon available); leaving config syntax to CI.

Fixes #2774