### PR TITLE
fix(contribute): goose supports headless via `goose run`

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -772,9 +772,10 @@ contribute-k8s namespace="hive-contributor" outfile="" image_tag="v2":
     readonly HEADLESS_STATUS_FILE="/tmp/contributor-headless-status.json"
     # Backends with a verified non-interactive (headless) entry point — must
     # match HEADLESS_BACKENDS in bin/contributor-relay.sh. A headless pod on any
-    # OTHER backend (goose/bob/agy/pi) refuses work LOUDLY at startup, so we warn
+    # OTHER backend (bob/agy/pi) refuses work LOUDLY at startup, so we warn
     # here rather than emit a manifest that will crash-loop with no explanation.
-    readonly HEADLESS_BACKENDS="claude litellm copilot codex"
+    # goose joined this set in #2828 via its `goose run` one-shot sub-command.
+    readonly HEADLESS_BACKENDS="claude litellm copilot codex goose"
     # Memory sizing: the contributor image is ~2.7GiB unpacked and each task
     # spawns a real coding-CLI + a repo build/test, so requests are deliberately
     # generous. Named here so an operator can see and tune them, not magic YAML.

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -238,14 +238,17 @@ function buildLaunchCommand() {
 // status — the property the headless mode needs. Each entry says how to turn
 // (binary, perm-flags, prompt) into an argv:
 //
-//   flag — the sub-command/flag that selects one-shot mode; the prompt is
-//          passed as the single positional argument that follows it
-//          (`claude -p "<prompt>"`, `codex exec "<prompt>"`).
+//   flag — the sub-command/flag(s) that select one-shot mode. Either a single
+//          token, where the prompt follows as a bare positional
+//          (`claude -p "<prompt>"`, `codex exec "<prompt>"`), or an array of
+//          leading tokens when a sub-command AND a flag both precede the
+//          prompt (`goose run --no-session -t "<prompt>"`). Either way the
+//          prompt is appended as the final, distinct argv element.
 //
-// Backends NOT listed here have no known non-interactive entry point (goose /
-// bob / agy / pi drive an interactive TUI), so headless mode refuses them
-// LOUDLY at task time rather than silently stalling. Extending this table is
-// how a future PR adds a backend once its headless invocation is verified.
+// Backends NOT listed here have no known non-interactive entry point (bob /
+// agy / pi drive an interactive TUI), so headless mode refuses them LOUDLY at
+// task time rather than silently stalling. Extending this table is how a
+// future PR adds a backend once its headless invocation is verified.
 const HEADLESS_BACKENDS = {
   // claude -p "<prompt>" — print mode: runs the prompt non-interactively and
   // exits. Same perm flags as the interactive launch (bypass permissions).
@@ -257,6 +260,15 @@ const HEADLESS_BACKENDS = {
   copilot: { flag: '-p' },
   // codex exec "<prompt>" — Codex's non-interactive execution sub-command.
   codex: { flag: 'exec' },
+  // goose run --no-session -t "<prompt>" — goose's one-shot sub-command. The
+  // bare `goose` binary drives the interactive TUI, but `goose run` is a
+  // documented non-interactive entry point (#2828): `-t` takes the prompt as
+  // its VALUE (not a trailing positional), and --no-session skips creating or
+  // resuming a session file, which one-shot dispatch never needs. Verified
+  // against goose 1.37.0 — the version v2/Dockerfile pins via GOOSE_VERSION —
+  // that `run`, `-t` and `--no-session` all exist and that a failed run exits
+  // non-zero, which is the exit-code contract runHeadlessTask() relies on.
+  goose: { flag: ['run', '--no-session', '-t'] },
 };
 
 // headlessSupportsBackend reports whether the configured backend has a known
@@ -267,17 +279,21 @@ function headlessSupportsBackend() {
 
 // buildHeadlessArgv turns a task prompt into the argv for a one-shot,
 // non-interactive backend invocation: [binary, ...permFlags, ...modelFlag,
-// oneShotFlag, prompt] (order adjusted per promptAsArg). Returns null for an
-// unsupported backend. Never shell-interpolates the prompt — it is passed as a
-// distinct argv element to execFile, so apostrophes/quotes in the prompt (the
-// exact #2203 wedge on the interactive path) cannot break anything here.
+// ...oneShotFlags, prompt]. Returns null for an unsupported backend. Never
+// shell-interpolates the prompt — it is passed as a distinct argv element to
+// execFile, so apostrophes/quotes in the prompt (the exact #2203 wedge on the
+// interactive path) cannot break anything here.
 function buildHeadlessArgv(prompt) {
   const spec = HEADLESS_BACKENDS[BACKEND];
   if (!spec) return null;
   const { cmd, perm } = resolveBackend();
   const permArgs = perm ? perm.split(/\s+/).filter(Boolean) : [];
   const modelArgs = MODEL && !NO_MODEL_FLAG_BACKENDS.includes(BACKEND) ? ['--model', MODEL] : [];
-  const args = [...permArgs, ...modelArgs, spec.flag, prompt];
+  // spec.flag is a single token for most backends, or an array of leading
+  // tokens for backends needing a sub-command plus a flag (goose). Normalize
+  // to an array so both shapes spread the same way ahead of the prompt.
+  const oneShotArgs = Array.isArray(spec.flag) ? spec.flag : [spec.flag];
+  const args = [...permArgs, ...modelArgs, ...oneShotArgs, prompt];
   return { bin: cmd, args };
 }
 

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -611,9 +611,11 @@ test('a headless timeout kill is reported as a failure, not a completion', () =>
 });
 
 test('headless refuses an unsupported backend loudly instead of stalling', () => {
-  const relay = loadRelay({ backend: 'goose', mode: 'headless' });
+  // bob drives an interactive TUI with no known one-shot entry point. (goose
+  // used to be the example here, but it gained one — see the table test below.)
+  const relay = loadRelay({ backend: 'bob', mode: 'headless' });
   try {
-    assert.strictEqual(relay.headlessSupportsBackend(), false, 'goose has no one-shot mode');
+    assert.strictEqual(relay.headlessSupportsBackend(), false, 'bob has no one-shot mode');
     assignHeadlessTask(relay);
     // No CLI was ever spawned...
     assert.strictEqual(relay.__execFileCalls.length, 0, 'an unsupported backend must not spawn a CLI');
@@ -625,26 +627,77 @@ test('headless refuses an unsupported backend loudly instead of stalling', () =>
   } finally { teardown(relay); }
 });
 
+// Enumerates every backend the relay reasons about, so adding one forces an
+// explicit decision about its headless invocation rather than silently
+// inheriting "unsupported". `tail` is the exact trailing argv (one-shot tokens
+// + prompt); null means the backend has no non-interactive entry point.
 test('buildHeadlessArgv maps each supported backend to its one-shot invocation', () => {
-  const claude = loadRelay({ backend: 'claude', mode: 'headless' });
-  try {
-    const a = claude.buildHeadlessArgv('do the thing');
-    assert.strictEqual(a.bin, 'claude');
-    assert.ok(a.args.includes('-p') && a.args[a.args.length - 1] === 'do the thing');
-  } finally { teardown(claude); }
+  const PROMPT = 'do the thing';
+  for (const tc of [
+    { backend: 'claude', tail: ['-p', PROMPT] },
+    { backend: 'litellm', tail: ['-p', PROMPT] },
+    { backend: 'copilot', tail: ['-p', PROMPT] },
+    { backend: 'codex', tail: ['exec', PROMPT] },
+    // goose needs its `run` sub-command AND -t (whose VALUE is the prompt) —
+    // two leading tokens, unlike every other entry (#2828).
+    { backend: 'goose', tail: ['run', '--no-session', '-t', PROMPT] },
+    // Interactive-TUI backends with no known one-shot entry point.
+    { backend: 'bob', tail: null },
+    { backend: 'agy', tail: null },
+    { backend: 'pi', tail: null },
+  ]) {
+    const relay = loadRelay({ backend: tc.backend, mode: 'headless' });
+    try {
+      const got = relay.buildHeadlessArgv(PROMPT);
+      if (tc.tail === null) {
+        assert.strictEqual(got, null, `${tc.backend} has no one-shot mode, so no argv`);
+        assert.strictEqual(relay.headlessSupportsBackend(), false,
+          `${tc.backend} must not report headless support`);
+        continue;
+      }
+      assert.ok(got, `${tc.backend} must build a headless argv`);
+      assert.strictEqual(got.bin, tc.backend, `${tc.backend} should run its own binary`);
+      assert.deepStrictEqual(got.args.slice(-tc.tail.length), tc.tail,
+        `${tc.backend} one-shot argv wrong: ${JSON.stringify(got.args)}`);
+      assert.strictEqual(got.args[got.args.length - 1], PROMPT,
+        `${tc.backend} must pass the prompt as the final distinct argv element`);
+      assert.strictEqual(relay.headlessSupportsBackend(), true,
+        `${tc.backend} must report headless support`);
+    } finally { teardown(relay); }
+  }
+});
 
-  const codex = loadRelay({ backend: 'codex', mode: 'headless' });
+test('goose headless passes the prompt as -t\'s value and skips --model', () => {
+  // goose is in NO_MODEL_FLAG_BACKENDS (it selects its model via GOOSE_MODEL),
+  // so a configured MODEL must not leak in as --model and break the argv.
+  const relay = loadRelay({ backend: 'goose', mode: 'headless', model: 'some-model' });
   try {
-    const a = codex.buildHeadlessArgv('do the thing');
-    assert.strictEqual(a.bin, 'codex');
-    assert.ok(a.args.includes('exec') && a.args[a.args.length - 1] === 'do the thing',
-      `codex must use 'exec' one-shot: ${JSON.stringify(a.args)}`);
-  } finally { teardown(codex); }
+    const a = relay.buildHeadlessArgv("it's a prompt with quotes");
+    assert.ok(!a.args.includes('--model'),
+      `goose must not get --model: ${JSON.stringify(a.args)}`);
+    assert.deepStrictEqual(a.args.slice(-4),
+      ['run', '--no-session', '-t', "it's a prompt with quotes"],
+      'the prompt is -t\'s value, passed verbatim as its own argv element');
+  } finally { teardown(relay); }
+});
 
-  const goose = loadRelay({ backend: 'goose', mode: 'headless' });
+test('goose runs headless end-to-end and reports completion on exit 0', () => {
+  const relay = loadRelay({ backend: 'goose', mode: 'headless' });
   try {
-    assert.strictEqual(goose.buildHeadlessArgv('x'), null, 'unsupported backend has no argv');
-  } finally { teardown(goose); }
+    assignHeadlessTask(relay);
+    assert.strictEqual(relay.__execFileCalls.length, 1, 'expected one one-shot invocation');
+    const call = relay.__execFileCalls[0];
+    assert.strictEqual(call.bin, 'goose');
+    assert.ok(call.args.includes('run') && call.args.includes('-t'),
+      `goose headless must use 'run' with -t: ${JSON.stringify(call.args)}`);
+    assert.ok(call.args[call.args.length - 1].includes('foo/bar#7'),
+      'the task prompt must be the trailing argv element');
+    // Headless completion is the child's exit code, not scraped output.
+    assert.ok(relay.__sent.find(m => m.type === 'task_complete'),
+      'a successful goose one-shot run must report task_complete');
+    assert.ok(!relay.__tmuxSends().some(c => / -l /.test(c)),
+      'headless goose must never type into tmux');
+  } finally { teardown(relay); }
 });
 
 test('interactive mode still delivers via tmux send-keys (unchanged default path)', () => {

--- a/v2/deploy/test_contribute_k8s_workload.sh
+++ b/v2/deploy/test_contribute_k8s_workload.sh
@@ -97,9 +97,11 @@ else
   echo "  SKIP: PyYAML unavailable; skipping structural parse"
 fi
 
-# ── Unsupported headless backend (goose): warn on STDERR, keep stdout clean. ──
+# ── Unsupported headless backend (bob): warn on STDERR, keep stdout clean. ──
+# bob drives an interactive TUI with no known one-shot entry point. goose used
+# to be the example here, but it is headless-capable via `goose run` (#2828).
 cat > "$FAKE_HOME/.config/hive/contributor.env" <<'EOF'
-AGENT_BACKEND=goose
+AGENT_BACKEND=bob
 HIVE_REGISTRATION_TOKEN=placeholder-reg-token
 EOF
 ERR="$(cd "$REPO_ROOT" && HOME="$FAKE_HOME" just contribute-k8s hive-contributor 2>&1 >/dev/null)"

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -1527,7 +1527,7 @@ var k8sTpl='PREREQ\ngit clone -b v2 https://github.com/kubestellar/hive && cd hi
 // Backends with a verified headless (non-interactive) entry point — must match
 // HEADLESS_BACKENDS in bin/contributor-relay.sh and the Justfile. A pod has no
 // TTY, so only these run in a cluster; anything else refuses work at startup.
-var K8S_HEADLESS_BACKENDS={claude:1,litellm:1,copilot:1,codex:1,watsonx:1};
+var K8S_HEADLESS_BACKENDS={claude:1,litellm:1,copilot:1,codex:1,watsonx:1,goose:1};
 var modelRow=document.getElementById('model-row');
 var modelInput=document.getElementById('model-input');
 function updateCmds(){update();}
@@ -1566,7 +1566,7 @@ if(mode==='kubernetes'){
 // line — but model/env exports still belong before contribute-setup so the
 // generated ConfigMap picks them up. If the chosen backend has no headless
 // mode, prepend a visible warning comment (the Justfile also warns on stderr).
-var warn=K8S_HEADLESS_BACKENDS[cli]?'':'# WARNING: '+cli+' has no headless mode; it will refuse work in a cluster.\n# Pick Claude Code, LiteLLM, Copilot or Codex for Kubernetes.\n';
+var warn=K8S_HEADLESS_BACKENDS[cli]?'':'# WARNING: '+cli+' has no headless mode; it will refuse work in a cluster.\n# Pick Claude Code, LiteLLM, Copilot, Codex or Goose for Kubernetes.\n';
 var k8sPre=envLines+modelLine;
 cmds.textContent=warn+k8sTpl.replace('PREREQ',prereq).replace(/CLI/g,cli).replace('just contribute-setup',k8sPre+'just contribute-setup');
 }else if(mode==='host'){

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -357,10 +357,54 @@ func TestContributeLandingHasWatsonxOption(t *testing.T) {
 		// CLIENTS metadata tile.
 		`watsonx:{name:'watsonx.ai',tag:'IBM'}`,
 		// Headless-capable: must be registered so Kubernetes mode does not warn.
-		`K8S_HEADLESS_BACKENDS={claude:1,litellm:1,copilot:1,codex:1,watsonx:1}`,
+		`K8S_HEADLESS_BACKENDS={claude:1,litellm:1,copilot:1,codex:1,watsonx:1,goose:1}`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("/contribute watsonx onboarding surface missing %q", want)
+		}
+	}
+}
+
+// TestContributeK8sHeadlessCapability enumerates every backend the Kubernetes
+// run-mode reasons about and pins whether it is headless-capable, so adding a
+// backend forces an explicit decision here rather than silently defaulting to
+// "no headless mode". goose is capable via its `goose run --no-session -t`
+// one-shot sub-command (#2828); bob/agy/pi drive an interactive TUI with no
+// known non-interactive entry point, so they must keep warning.
+func TestContributeK8sHeadlessCapability(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /contribute = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+
+	for _, tc := range []struct {
+		backend  string
+		headless bool
+		why      string
+	}{
+		{"claude", true, "claude -p print mode"},
+		{"litellm", true, "claude binary against a LiteLLM proxy"},
+		{"copilot", true, "copilot -p programmatic mode"},
+		{"codex", true, "codex exec sub-command"},
+		{"watsonx", true, "OpenAI-compatible endpoint via the claude binary"},
+		{"goose", true, "goose run --no-session -t one-shot sub-command (#2828)"},
+		{"bob", false, "interactive TUI, no known one-shot entry point"},
+		{"agy", false, "interactive TUI, no known one-shot entry point"},
+		{"pi", false, "interactive TUI, no known one-shot entry point"},
+	} {
+		// The capability map is emitted as a JS object literal keyed by backend.
+		present := strings.Contains(body, tc.backend+":1")
+		if present != tc.headless {
+			t.Errorf("K8S_HEADLESS_BACKENDS headless=%v for %q, want %v (%s)",
+				present, tc.backend, tc.headless, tc.why)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #2828.

## The claim

`bin/contributor-relay.sh`'s `HEADLESS_BACKENDS` comment asserted:

> Backends NOT listed here have no known non-interactive entry point (goose / bob / agy / pi drive an interactive TUI), so headless mode refuses them LOUDLY at task time rather than silently stalling.

As @castrojo reported, that is accurate for bob/agy/pi but **not** for goose — and it was load-bearing, not just a comment: `buildHeadlessArgv('x')` was asserted by a passing test to return `null` for goose, so every goose contributor was pushed onto the interactive `checkTmuxIdle()` pane-scraping heuristic instead of headless mode's exit-code completion.

## What I verified about goose's CLI

Checked directly against **goose 1.37.0** — deliberately the version this repo pins in `v2/Dockerfile` (`ARG GOOSE_VERSION=1.37.0`), rather than a newer build, so the invocation matches what actually ships:

- `goose run --help` lists `-t, --text <TEXT>`, `-i, --instructions <FILE>`, `--no-session`, `-q/--quiet`, `--output-format`, `--max-turns`.
- `goose run --no-session -i /nonexistent-abc.txt` exits **1**.

That non-zero exit is the specific property that matters here: `runHeadlessTask()` completes a task on the child's exit code, not by scraping output. `goose run` satisfies the contract.

## The invocation wired

```js
goose: { flag: ['run', '--no-session', '-t'] },
```

goose is the first entry needing **two** leading tokens before the prompt — its `run` sub-command *and* `-t`, whose *value* is the prompt — where `claude -p` / `codex exec` each need one. The old hard-coded `[...permArgs, ...modelArgs, spec.flag, prompt]` could not express that, so `spec.flag` now accepts either shape:

```js
const oneShotArgs = Array.isArray(spec.flag) ? spec.flag : [spec.flag];
const args = [...permArgs, ...modelArgs, ...oneShotArgs, prompt];
```

Behavior is unchanged for the four existing string entries. The prompt is still passed as a distinct argv element to `execFile` (never shell-interpolated), so the #2203 quoting wedge stays fixed. `--no-session` is included because one-shot dispatch has no session to create or resume.

## Sites changed (all five)

The issue named the relay table; the capability set is mirrored in two other files that **explicitly document themselves as having to match it**, so I updated those too rather than leave the set drifting:

| File | Change |
|---|---|
| `bin/contributor-relay.sh` | `HEADLESS_BACKENDS` + `buildHeadlessArgv` array support; stale comment corrected |
| `Justfile` | `HEADLESS_BACKENDS="claude litellm copilot codex goose"` (preflight warning for `just contribute-k8s`) |
| `v2/pkg/dashboard/api_contribute.go` | `K8S_HEADLESS_BACKENDS={…,goose:1}` + the user-facing "Pick Claude Code, LiteLLM, Copilot, Codex or Goose" copy |
| `bin/contributor-relay.test.js` | table test + goose coverage |
| `v2/pkg/dashboard/api_contribute_test.go` | pinned map string + new capability table test |

Without the Justfile and dashboard updates, a goose contributor would still have been told "goose has no headless mode; it will refuse work in a cluster" by the onboarding UI while the relay happily ran it.

I also dropped the `buildHeadlessArgv` doc comment's reference to `promptAsArg` — `grep -rn promptAsArg` matches only that one comment line, so it documents a seam that does not exist.

## Tests

- **`buildHeadlessArgv` is now a table** over every backend the relay reasons about — claude/litellm/copilot/codex/goose with their exact expected trailing argv, and bob/agy/pi asserted to stay `null`. A future backend addition has to declare its headless intent in the table rather than silently inheriting "unsupported".
- **New**: goose end-to-end headless dispatch (spawns `goose run … -t <prompt>`, reports `task_complete` on exit 0, never touches tmux).
- **New**: goose must not receive `--model` — it is in `NO_MODEL_FLAG_BACKENDS` (it selects a model via `GOOSE_MODEL`), and a leaked `--model` would corrupt the argv. Also covers an apostrophe-bearing prompt.
- **New Go table test** `TestContributeK8sHeadlessCapability` pins the same capability decision on the dashboard side.
- **Regression caught**: `v2/deploy/test_contribute_k8s_workload.sh` used `AGENT_BACKEND=goose` as its "unsupported backend warns on stderr" fixture and would have started failing. Switched to `bob`, which genuinely has no one-shot mode, so the coverage is kept rather than lost.

Results: `node bin/contributor-relay.test.js` → **28/28**; `bash v2/deploy/test_contribute_k8s_workload.sh` → **17/17**; `go build ./...`, `go vet ./pkg/dashboard/`, `go test ./pkg/dashboard/ -run TestContribute` all clean.

## Not verified

A live end-to-end headless Hive task cycle against a real goose backend (needs a hub, registration token, and `GOOSE_PROVIDER` credentials). Confirmation here is the CLI's flags and exit-code contract on the pinned version, plus the offline relay/dashboard suites.

## Relationship to #2829

@castrojo opened #2829 with the same core approach (option 1 from the issue, which he validated first — credit for the diagnosis and the shape analysis is his). This PR additionally covers the Justfile and dashboard mirrors, the `test_contribute_k8s_workload.sh` regression, and the backend-enumerating table tests. Maintainers should merge whichever they prefer and close the other — happy to fold these extra sites into #2829 instead if that is the preference.
