### PR TITLE
✨ feat(hivectl): clusterless lite enrollment with zero repo secrets (phase 1)

### DIFF
--- a/v2/docs/hivectl.md
+++ b/v2/docs/hivectl.md
@@ -13,6 +13,9 @@ go build -o bin/hivectl ./cmd/hivectl
 # via an environment variable, never as a flag value.
 export HIVE_DASHBOARD_TOKEN="..."
 bin/hivectl system status
+
+# Enroll a repository in clusterless, zero-secret Hive lite mode.
+bin/hivectl enroll kubestellar/hive
 ```
 
 ## Running against a local Hive
@@ -132,6 +135,19 @@ hivectl observe history
 hivectl observe timeline
 hivectl observe trends --range week        # or --hours 12 (1-720); not both
 ```
+
+### enroll — clusterless lite repo enrollment
+
+```bash
+hivectl enroll OWNER/REPO
+hivectl enroll OWNER/REPO --acmm-level 1
+hivectl enroll OWNER/REPO --installation-id 123456
+```
+
+`enroll` verifies local `gh` authentication and repository access, then asks the
+hub to create a lite enrollment record. Lite mode is advisory-only and capped at
+ACMM L2. It writes no repository PAT or long-lived secret; GitHub access is via
+the hub's GitHub App installation and scoped token minting.
 
 ## Input and safety
 

--- a/v2/docs/lite-enrollment.md
+++ b/v2/docs/lite-enrollment.md
@@ -1,0 +1,49 @@
+# Hive lite enrollment
+
+Hive lite is the five-minute, clusterless on-ramp for a repository. It creates a
+hub-side enrollment record and starter advisory config without deploying a spoke
+or putting a PAT in the enrolled repository.
+
+## Prerequisites
+
+- `gh` is installed and logged in for the target GitHub host.
+- The Hive GitHub App is installed on the repo owner, or you know the
+  installation ID. If the hub has the App key, it can auto-discover the
+  installation ID.
+- A hub login/token that can call the dashboard API.
+
+## Enroll
+
+```bash
+export HIVE_DASHBOARD_TOKEN="$(unset GITHUB_TOKEN && gh auth token)"
+hivectl --server https://hive.kubestellar.io enroll OWNER/REPO
+```
+
+Optional:
+
+```bash
+hivectl enroll OWNER/REPO --acmm-level 1
+hivectl enroll OWNER/REPO --installation-id 123456
+```
+
+The command verifies `gh auth`, checks that the repo is reachable, registers the
+repo with the hub, and prints the dashboard URL and next steps.
+
+## What lite mode does
+
+- Records the repo as `lite` in the hub registry.
+- Stores a starter config for advisory lanes at ACMM L1-L2.
+- Uses the hub's GitHub App installation plus `pkg/mint` scoped tokens.
+- Keeps the enrolled repo zero-secret: no PAT, private key, or long-lived token.
+
+## What lite mode does not do yet
+
+- No hub-hosted execution loop in this phase.
+- No workflow shim is installed in the repository.
+- No ACMM L3+ behavior; lite is capped at L2 advisory mode.
+
+## Graduation path
+
+Use lite mode until advisory findings are useful and low-noise. Graduate to a
+full spoke when the repo needs execution, private runtime access, custom
+in-cluster dependencies, or ACMM levels above L2.

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -65,15 +65,10 @@ func NewAppAuth(appID, installationID int64, keyFile string, logger *slog.Logger
 	return NewAppAuthWithCache(appID, installationID, keyFile, TokenCachePath, logger, apiURL)
 }
 
-func NewAppAuthWithCache(appID, installationID int64, keyFile, cachePath string, logger *slog.Logger, apiURL string) (*AppAuth, error) {
-	keyData, err := os.ReadFile(keyFile)
-	if err != nil {
-		return nil, fmt.Errorf("reading app key %s: %w", keyFile, err)
-	}
-
+func NewAppAuthFromPEM(appID, installationID int64, keyData []byte, logger *slog.Logger, apiURL string) (*AppAuth, error) {
 	block, _ := pem.Decode(keyData)
 	if block == nil {
-		return nil, fmt.Errorf("no PEM block found in %s", keyFile)
+		return nil, fmt.Errorf("no PEM block found")
 	}
 
 	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
@@ -94,9 +89,22 @@ func NewAppAuthWithCache(appID, installationID int64, keyFile, cachePath string,
 		installationID: installationID,
 		key:            key,
 		logger:         logger,
-		cachePath:      cachePath,
 		apiURL:         apiURL,
 	}, nil
+}
+
+func NewAppAuthWithCache(appID, installationID int64, keyFile, cachePath string, logger *slog.Logger, apiURL string) (*AppAuth, error) {
+	keyData, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading app key %s: %w", keyFile, err)
+	}
+
+	auth, err := NewAppAuthFromPEM(appID, installationID, keyData, logger, apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", keyFile, err)
+	}
+	auth.cachePath = cachePath
+	return auth, nil
 }
 
 func (a *AppAuth) generateJWT() (string, error) {

--- a/v2/pkg/hivectl/client.go
+++ b/v2/pkg/hivectl/client.go
@@ -86,10 +86,22 @@ func NewClient(server, token string, timeout time.Duration) (*Client, error) {
 }
 
 func (c *Client) Do(ctx context.Context, method, apiPath string, query url.Values, body any) (any, error) {
-	data, contentType, err := c.do(ctx, method, apiPath, query, body)
+	data, contentType, err := c.do(ctx, method, apiPath, query, body, nil)
 	if err != nil {
 		return nil, err
 	}
+	return decodeResponse(data, contentType)
+}
+
+func (c *Client) DoWithHeaders(ctx context.Context, method, apiPath string, query url.Values, body any, headers http.Header) (any, error) {
+	data, contentType, err := c.do(ctx, method, apiPath, query, body, headers)
+	if err != nil {
+		return nil, err
+	}
+	return decodeResponse(data, contentType)
+}
+
+func decodeResponse(data []byte, contentType string) (any, error) {
 	if len(bytes.TrimSpace(data)) == 0 {
 		return map[string]any{}, nil
 	}
@@ -104,11 +116,11 @@ func (c *Client) Do(ctx context.Context, method, apiPath string, query url.Value
 }
 
 func (c *Client) Raw(ctx context.Context, method, apiPath string, query url.Values, body any) ([]byte, string, error) {
-	return c.do(ctx, method, apiPath, query, body)
+	return c.do(ctx, method, apiPath, query, body, nil)
 }
 
 func (c *Client) StreamSSE(ctx context.Context, apiPath string, query url.Values, output io.Writer) error {
-	req, err := c.request(ctx, http.MethodGet, apiPath, query, nil)
+	req, err := c.request(ctx, http.MethodGet, apiPath, query, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -174,8 +186,8 @@ func (c *Client) StreamSSE(ctx context.Context, apiPath string, query url.Values
 	return ctx.Err()
 }
 
-func (c *Client) do(ctx context.Context, method, apiPath string, query url.Values, body any) ([]byte, string, error) {
-	req, err := c.request(ctx, method, apiPath, query, body)
+func (c *Client) do(ctx context.Context, method, apiPath string, query url.Values, body any, headers http.Header) ([]byte, string, error) {
+	req, err := c.request(ctx, method, apiPath, query, body, headers)
 	if err != nil {
 		return nil, "", err
 	}
@@ -197,7 +209,7 @@ func (c *Client) do(ctx context.Context, method, apiPath string, query url.Value
 	return data, resp.Header.Get("Content-Type"), nil
 }
 
-func (c *Client) request(ctx context.Context, method, apiPath string, query url.Values, body any) (*http.Request, error) {
+func (c *Client) request(ctx context.Context, method, apiPath string, query url.Values, body any, headers http.Header) (*http.Request, error) {
 	target := *c.baseURL
 	target.Path = strings.TrimRight(c.baseURL.Path, "/") + "/" + strings.TrimLeft(apiPath, "/")
 	target.RawQuery = query.Encode()
@@ -225,6 +237,11 @@ func (c *Client) request(ctx context.Context, method, apiPath string, query url.
 		req.Header.Set("Authorization", "Bearer "+c.token)
 	}
 	req.Header.Set("User-Agent", "hivectl/0.1")
+	for key, values := range headers {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
 	return req, nil
 }
 

--- a/v2/pkg/hivectl/commands/enroll.go
+++ b/v2/pkg/hivectl/commands/enroll.go
@@ -1,0 +1,209 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/kubestellar/hive/v2/pkg/hivectl"
+	"github.com/spf13/cobra"
+)
+
+type enrollOptions struct {
+	acmmLevel      int
+	installationID int64
+	githubHost     string
+}
+
+type enrollHubClient interface {
+	DoWithHeaders(ctx context.Context, method, apiPath string, query url.Values, body any, headers http.Header) (any, error)
+}
+
+type ghVerifier interface {
+	Verify(ctx context.Context, host, repo string) (string, error)
+}
+
+type ghCLI struct{}
+
+func newEnrollCommand(env *commandEnv) *cobra.Command {
+	opts := &enrollOptions{acmmLevel: 2, githubHost: "github.com"}
+	cmd := &cobra.Command{
+		Use:   "enroll <owner/repo>",
+		Short: "Enroll a repo in clusterless Hive lite mode",
+		Example: `  hivectl enroll kubestellar/hive
+  hivectl enroll kubestellar/hive --acmm-level 1
+  hivectl enroll kubestellar/hive --installation-id 123456`,
+		Args: argsExact(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return env.runEnrollCommand(cmd, args[0], opts, ghCLI{})
+		},
+	}
+	cmd.Flags().IntVar(&opts.acmmLevel, "acmm-level", 2, "requested ACMM level for lite mode (capped at L2)")
+	cmd.Flags().Int64Var(&opts.installationID, "installation-id", 0, "GitHub App installation ID (optional when the hub can auto-discover it)")
+	cmd.Flags().StringVar(&opts.githubHost, "github-host", "github.com", "GitHub hostname")
+	return cmd
+}
+
+func (e *commandEnv) runEnrollCommand(cmd *cobra.Command, repo string, opts *enrollOptions, gh ghVerifier) error {
+	if !validOutput(e.options.output) {
+		return &usageError{message: fmt.Sprintf("invalid --output %q; expected table, json, yaml, or jsonl", e.options.output)}
+	}
+	repo = strings.TrimSpace(repo)
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" || strings.Contains(parts[1], "/") {
+		return &usageError{message: "repo must be in owner/repo form"}
+	}
+	if opts.acmmLevel < 1 {
+		return &usageError{message: "--acmm-level must be at least 1"}
+	}
+	capped := opts.acmmLevel
+	if capped > 2 {
+		capped = 2
+	}
+
+	repoToken, err := gh.Verify(cmd.Context(), opts.githubHost, repo)
+	if err != nil {
+		return err
+	}
+	hubToken := ""
+	if e.options.tokenEnv != "" {
+		hubToken = os.Getenv(e.options.tokenEnv)
+	}
+	if hubToken == "" {
+		if !strings.EqualFold(opts.githubHost, "github.com") {
+			return &usageError{message: "set HIVE_DASHBOARD_TOKEN (or --token-env) for non-github.com enrollment; the GitHub Enterprise token is used only to verify repo access"}
+		}
+		hubToken = repoToken
+	}
+	client, err := hivectl.NewClient(e.options.server, hubToken, e.options.timeout)
+	if err != nil {
+		return &usageError{message: err.Error()}
+	}
+	resp, err := runEnroll(cmd.Context(), client, liteEnrollRequest{
+		Owner:          parts[0],
+		Repo:           parts[1],
+		InstallationID: opts.installationID,
+		ACMMLevel:      capped,
+		GitHubHost:     opts.githubHost,
+	}, repoToken)
+	if err != nil {
+		return err
+	}
+	if e.options.output != "table" {
+		return e.print(cmd, resp)
+	}
+	printEnrollSummary(cmd, repo, capped, opts.acmmLevel, resp)
+	return nil
+}
+
+type liteEnrollRequest struct {
+	Owner          string `json:"owner"`
+	Repo           string `json:"repo"`
+	InstallationID int64  `json:"installation_id,omitempty"`
+	ACMMLevel      int    `json:"acmm_level,omitempty"`
+	GitHubHost     string `json:"github_host,omitempty"`
+}
+
+func runEnroll(ctx context.Context, client enrollHubClient, req liteEnrollRequest, repoToken string) (map[string]any, error) {
+	headers := http.Header{}
+	if repoToken != "" {
+		headers.Set("X-Hive-GitHub-Token", repoToken)
+	}
+	result, err := client.DoWithHeaders(ctx, http.MethodPost, "/api/saas/lite/enroll", nil, req, headers)
+	if err != nil {
+		return nil, err
+	}
+	if m, ok := result.(map[string]any); ok {
+		return m, nil
+	}
+	return map[string]any{"result": result}, nil
+}
+
+func printEnrollSummary(cmd *cobra.Command, repo string, acmm, requested int, resp map[string]any) {
+	out := cmd.OutOrStdout()
+	id, _ := resp["id"].(string)
+	dashboard, _ := resp["dashboard_url"].(string)
+	fmt.Fprintf(out, "✓ Enrolled %s in Hive lite (%s)\n", repo, id)
+	if requested > acmm {
+		fmt.Fprintf(out, "  requested ACMM L%d capped to L%d for lite mode\n", requested, acmm)
+	}
+	if installation := numberString(resp["installation_id"]); installation != "" {
+		fmt.Fprintf(out, "  GitHub App installation: %s\n", installation)
+	}
+	if dashboard != "" {
+		fmt.Fprintf(out, "  Dashboard: %s\n", dashboard)
+	}
+	fmt.Fprintln(out, "\nStarter config: advisory-only lanes at ACMM L1-L2; no repository PAT or long-lived secret is written.")
+	fmt.Fprintln(out, "\nNext steps:")
+	fmt.Fprintln(out, "  1. Open the dashboard and review advisory findings.")
+	fmt.Fprintln(out, "  2. Raise ACMM from L1 to L2 only after advisory noise is acceptable.")
+	fmt.Fprintln(out, "  3. Graduate to a full spoke for execution, private runtime, or ACMM L3+.")
+	fmt.Fprintln(out, "\nDeferred: hub-hosted execution and optional workflow shim.")
+}
+
+func numberString(v any) string {
+	switch n := v.(type) {
+	case float64:
+		if n == 0 {
+			return ""
+		}
+		return strconv.FormatInt(int64(n), 10)
+	case int64:
+		if n == 0 {
+			return ""
+		}
+		return strconv.FormatInt(n, 10)
+	case string:
+		return n
+	default:
+		return ""
+	}
+}
+
+func (ghCLI) Verify(ctx context.Context, host, repo string) (string, error) {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		host = "github.com"
+	}
+	if _, err := runGH(ctx, "auth", "status", "--hostname", host); err != nil {
+		return "", fmt.Errorf("gh auth check failed for %s: %w", host, err)
+	}
+	target := repo
+	if !strings.EqualFold(host, "github.com") {
+		target = "https://" + strings.TrimRight(host, "/") + "/" + repo
+	}
+	if _, err := runGH(ctx, "repo", "view", target, "--json", "nameWithOwner", "--jq", ".nameWithOwner"); err != nil {
+		return "", fmt.Errorf("cannot access GitHub repo %s with gh: %w", repo, err)
+	}
+	token, err := runGH(ctx, "auth", "token", "--hostname", host)
+	if err != nil {
+		return "", fmt.Errorf("gh auth token unavailable: %w", err)
+	}
+	return strings.TrimSpace(token), nil
+}
+
+var runGH = func(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd.Env = withoutGitHubToken(os.Environ())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%s", strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
+func withoutGitHubToken(env []string) []string {
+	out := env[:0]
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "GITHUB_TOKEN=") || strings.HasPrefix(kv, "GH_TOKEN=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}

--- a/v2/pkg/hivectl/commands/enroll_test.go
+++ b/v2/pkg/hivectl/commands/enroll_test.go
@@ -1,0 +1,154 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+type fakeEnrollClient struct {
+	req       liteEnrollRequest
+	repoToken string
+}
+
+func (f *fakeEnrollClient) DoWithHeaders(_ context.Context, method, path string, _ url.Values, body any, headers http.Header) (any, error) {
+	if method != "POST" || path != "/api/saas/lite/enroll" {
+		return nil, errors.New("unexpected request")
+	}
+	f.req = body.(liteEnrollRequest)
+	f.repoToken = headers.Get("X-Hive-GitHub-Token")
+	return map[string]any{
+		"id":              "lite-o-r",
+		"installation_id": float64(123),
+		"dashboard_url":   "https://hub.example/dashboard",
+	}, nil
+}
+
+type fakeGHVerifier struct {
+	err error
+}
+
+func (f fakeGHVerifier) Verify(context.Context, string, string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return "gho-test", nil
+}
+
+func TestRunEnrollValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		repo string
+		opts enrollOptions
+		gh   ghVerifier
+		want string
+	}{
+		{name: "repo form required", repo: "owner", opts: enrollOptions{acmmLevel: 2, githubHost: "github.com"}, gh: fakeGHVerifier{}, want: "owner/repo"},
+		{name: "acmm positive", repo: "o/r", opts: enrollOptions{acmmLevel: 0, githubHost: "github.com"}, gh: fakeGHVerifier{}, want: "at least 1"},
+		{name: "gh failure", repo: "o/r", opts: enrollOptions{acmmLevel: 2, githubHost: "github.com"}, gh: fakeGHVerifier{err: errors.New("no auth")}, want: "no auth"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := &commandEnv{options: &rootOptions{server: "http://127.0.0.1:1", output: "table"}}
+			cmd := NewRootCommand(strings.NewReader(""), &strings.Builder{}, &strings.Builder{})
+			err := env.runEnrollCommand(cmd, tt.repo, &tt.opts, tt.gh)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunEnrollPostsCappedRequest(t *testing.T) {
+	client := &fakeEnrollClient{}
+	got, err := runEnroll(context.Background(), client, liteEnrollRequest{
+		Owner:          "kubestellar",
+		Repo:           "hive",
+		InstallationID: 456,
+		ACMMLevel:      2,
+		GitHubHost:     "github.com",
+	}, "repo-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["id"] != "lite-o-r" {
+		t.Fatalf("response = %#v", got)
+	}
+	if client.req.Owner != "kubestellar" || client.req.Repo != "hive" || client.req.InstallationID != 456 || client.req.ACMMLevel != 2 {
+		t.Fatalf("request = %#v", client.req)
+	}
+	if client.repoToken != "repo-token" {
+		t.Fatalf("repo token header = %q", client.repoToken)
+	}
+}
+
+func TestEnrollCommandHappyPathCapsACMM(t *testing.T) {
+	t.Setenv("HIVE_DASHBOARD_TOKEN", "")
+	oldRunGH := runGH
+	t.Cleanup(func() { runGH = oldRunGH })
+	runGH = func(_ context.Context, args ...string) (string, error) {
+		if len(args) >= 2 && args[0] == "auth" && args[1] == "token" {
+			return "gho-test\n", nil
+		}
+		return "ok", nil
+	}
+
+	var body liteEnrollRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/saas/lite/enroll" || r.Method != http.MethodPost {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer gho-test" {
+			t.Fatalf("authorization = %q", r.Header.Get("Authorization"))
+		}
+		if r.Header.Get("X-Hive-GitHub-Token") != "gho-test" {
+			t.Fatalf("repo token header = %q", r.Header.Get("X-Hive-GitHub-Token"))
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":              "lite-kubestellar-hive",
+			"installation_id": 123,
+			"dashboard_url":   "https://hub.example/dashboard",
+		})
+	}))
+	defer server.Close()
+
+	stdout, _, err := execute(t, server, "", "enroll", "kubestellar/hive", "--acmm-level", "5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body.ACMMLevel != 2 {
+		t.Fatalf("ACMMLevel = %d, want capped L2", body.ACMMLevel)
+	}
+	if !strings.Contains(stdout, "capped to L2") || !strings.Contains(stdout, "no repository PAT") {
+		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
+func TestGHVerifierUsesHostQualifiedRepoForGHE(t *testing.T) {
+	oldRunGH := runGH
+	t.Cleanup(func() { runGH = oldRunGH })
+	var repoViewTarget string
+	runGH = func(_ context.Context, args ...string) (string, error) {
+		if len(args) >= 3 && args[0] == "repo" && args[1] == "view" {
+			repoViewTarget = args[2]
+		}
+		if len(args) >= 2 && args[0] == "auth" && args[1] == "token" {
+			return "ghe-token\n", nil
+		}
+		return "ok", nil
+	}
+	if _, err := (ghCLI{}).Verify(context.Background(), "github.example.com", "org/repo"); err != nil {
+		t.Fatal(err)
+	}
+	if repoViewTarget != "https://github.example.com/org/repo" {
+		t.Fatalf("repo view target = %q", repoViewTarget)
+	}
+}

--- a/v2/pkg/hivectl/commands/root.go
+++ b/v2/pkg/hivectl/commands/root.go
@@ -70,6 +70,7 @@ func NewRootCommand(in io.Reader, out, errOut io.Writer) *cobra.Command {
 	root.AddCommand(newBeadCommand(env))
 	root.AddCommand(newGovernorCommand(env))
 	root.AddCommand(newObserveCommand(env))
+	root.AddCommand(newEnrollCommand(env))
 	return root
 }
 

--- a/v2/pkg/hub/lite_enrollment.go
+++ b/v2/pkg/hub/lite_enrollment.go
@@ -1,0 +1,315 @@
+package hub
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	hivegithub "github.com/kubestellar/hive/v2/pkg/github"
+)
+
+const (
+	liteDefaultACMMLevel = 2
+	liteMaxACMMLevel     = 2
+)
+
+type LiteEnrollmentConfig struct {
+	Mode        string   `json:"mode"`
+	ACMMLevel   int      `json:"acmmLevel"`
+	Lanes       []string `json:"lanes"`
+	Agents      []string `json:"agents"`
+	Advisory    bool     `json:"advisory"`
+	ZeroSecrets bool     `json:"zeroSecrets"`
+}
+
+type LiteEnrollmentRequest struct {
+	Owner          string `json:"owner"`
+	Repo           string `json:"repo"`
+	InstallationID int64  `json:"installation_id,omitempty"`
+	ACMMLevel      int    `json:"acmm_level,omitempty"`
+	GitHubHost     string `json:"github_host,omitempty"`
+}
+
+type LiteEnrollmentResponse struct {
+	ID             string               `json:"id"`
+	Mode           string               `json:"mode"`
+	Owner          string               `json:"owner"`
+	Repo           string               `json:"repo"`
+	InstallationID int64                `json:"installation_id,omitempty"`
+	ACMMLevel      int                  `json:"acmm_level"`
+	DashboardURL   string               `json:"dashboard_url"`
+	Config         LiteEnrollmentConfig `json:"config"`
+	Existing       bool                 `json:"existing"`
+	NextSteps      []string             `json:"next_steps"`
+	Deferred       []string             `json:"deferred"`
+}
+
+var verifyLiteRepoAccess = verifyGitHubRepoAccess
+
+func (s *HubServer) handleLiteEnroll(w http.ResponseWriter, r *http.Request) {
+	username := s.getAuthUser(r)
+	if username == "" {
+		writeJSONError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+	user := ensureSaaSUser(username)
+	if user == nil || user.Blocked {
+		writeJSONError(w, http.StatusForbidden, "account blocked or not found")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 64*1024)
+	var req LiteEnrollmentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	req.Owner = strings.TrimSpace(req.Owner)
+	req.Repo = normalizeRepoRef(req.Repo)
+	if req.Owner == "" || req.Repo == "" {
+		writeJSONError(w, http.StatusBadRequest, "owner and repo are required")
+		return
+	}
+	if !isValidName(req.Owner) || !isValidRepoRef(req.Repo) {
+		writeJSONError(w, http.StatusBadRequest, "invalid repo")
+		return
+	}
+	host := githubHostLabel(req.GitHubHost)
+	if host == "" {
+		host = publicGitHubHost
+	}
+	if !isValidName(host) {
+		writeJSONError(w, http.StatusBadRequest, "invalid github_host")
+		return
+	}
+	token := bearerTokenFromRequest(r)
+	if token == "" {
+		writeJSONError(w, http.StatusUnauthorized, "hivectl enroll requires a GitHub bearer token so the hub can verify repo admin access")
+		return
+	}
+	ok, err := verifyLiteRepoAccess(r.Context(), token, host, req.Owner, req.Repo)
+	if err != nil {
+		writeJSONError(w, http.StatusForbidden, err.Error())
+		return
+	}
+	if !ok {
+		writeJSONError(w, http.StatusForbidden, "GitHub token does not have admin or maintain access to the repo")
+		return
+	}
+	acmm := req.ACMMLevel
+	if acmm <= 0 {
+		acmm = liteDefaultACMMLevel
+	}
+	if acmm > liteMaxACMMLevel {
+		acmm = liteMaxACMMLevel
+	}
+
+	installationID := req.InstallationID
+	if installationID == 0 {
+		discovered, err := s.discoverLiteInstallation(r.Context(), req.Owner)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		installationID = discovered
+	}
+
+	id := liteHiveID(host, req.Owner, req.Repo)
+	now := time.Now().UTC().Format(time.RFC3339)
+	cfg := defaultLiteEnrollmentConfig(acmm)
+	entry := RegistryEntry{
+		ID:                   id,
+		Name:                 req.Owner + "/" + req.Repo,
+		Org:                  req.Owner,
+		Repos:                []string{req.Repo},
+		PrimaryRepo:          req.Repo,
+		ACMMLevel:            acmm,
+		GovernorMode:         "ADVISORY",
+		Owner:                username,
+		HiveType:             "lite",
+		Lite:                 true,
+		LiteConfig:           &cfg,
+		IsPublic:             false,
+		RegisteredAt:         now,
+		GitHubHost:           host,
+		GitHubInstallationID: installationID,
+		Online:               false,
+	}
+
+	existing := false
+	s.mu.Lock()
+	for i := range s.registry.Hives {
+		h := &s.registry.Hives[i]
+		if h.ID != id {
+			continue
+		}
+		if !h.Lite && h.HiveType != "lite" {
+			s.mu.Unlock()
+			writeJSONError(w, http.StatusConflict, "a non-lite hive already uses this enrollment id")
+			return
+		}
+		if h.Owner != "" && h.Owner != username && username != hubAdminUsername {
+			s.mu.Unlock()
+			writeJSONError(w, http.StatusForbidden, "lite enrollment already belongs to another user")
+			return
+		}
+		entry.RegisteredAt = h.RegisteredAt
+		if entry.RegisteredAt == "" {
+			entry.RegisteredAt = now
+		}
+		s.registry.Hives[i] = entry
+		existing = true
+		break
+	}
+	if !existing {
+		s.registry.Hives = append(s.registry.Hives, entry)
+	}
+	s.registry.UpdatedAt = now
+	s.mu.Unlock()
+
+	user.Hives[id] = "owner"
+	_ = saveSaaSUser(user)
+	s.requestSave()
+
+	resp := LiteEnrollmentResponse{
+		ID:             id,
+		Mode:           "lite",
+		Owner:          req.Owner,
+		Repo:           req.Repo,
+		InstallationID: installationID,
+		ACMMLevel:      acmm,
+		DashboardURL:   s.dashboardURLForRequest(r),
+		Config:         cfg,
+		Existing:       existing,
+		NextSteps: []string{
+			"Open the dashboard and watch advisory findings for this repo.",
+			"Raise ACMM from L1 to L2 only after advisory noise is acceptable.",
+			"Graduate to a full spoke when you need execution, private runtime, or higher ACMM levels.",
+		},
+		Deferred: []string{"hub-hosted execution", "optional workflow shim"},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+func defaultLiteEnrollmentConfig(acmm int) LiteEnrollmentConfig {
+	return LiteEnrollmentConfig{
+		Mode:        "lite",
+		ACMMLevel:   acmm,
+		Lanes:       []string{"security", "quality", "maintenance"},
+		Agents:      []string{"advisor", "triage"},
+		Advisory:    true,
+		ZeroSecrets: true,
+	}
+}
+
+func liteHiveID(host, owner, repo string) string {
+	host = strings.ToLower(host)
+	owner = strings.ToLower(owner)
+	repo = strings.ToLower(repo)
+	prefix := "lite-"
+	if host != "" && !strings.EqualFold(host, publicGitHubHost) {
+		prefix += host + "-"
+	}
+	base := prefix + owner + "-" + repo
+	base = strings.NewReplacer("/", "-", "_", "-", ".", "-").Replace(base)
+	sum := sha256.Sum256([]byte(host + "/" + owner + "/" + repo))
+	suffix := hex.EncodeToString(sum[:])[:8]
+	if len(base) > 81 {
+		base = base[:81]
+	}
+	return base + "-" + suffix
+}
+
+func (s *HubServer) discoverLiteInstallation(ctx context.Context, owner string) (int64, error) {
+	clusterID := defaultClusterID
+	identity := s.appIdentityForCluster(clusterID)
+	if identity == nil || identity.AppID == 0 || identity.PrivateKey == "" {
+		return 0, fmt.Errorf("installation_id is required because the hub has no GitHub App key for auto-discovery")
+	}
+	auth, err := hivegithub.NewAppAuthFromPEM(identity.AppID, 0, []byte(identity.PrivateKey), s.logger, identity.APIURL)
+	if err != nil {
+		return 0, fmt.Errorf("hub GitHub App key is not usable for discovery: %w", err)
+	}
+	id, err := auth.DiscoverInstallationID(ctx, owner)
+	if err != nil {
+		return 0, fmt.Errorf("GitHub App installation not found for %s: %w", owner, err)
+	}
+	return id, nil
+}
+
+func (s *HubServer) dashboardURLForRequest(r *http.Request) string {
+	proto := r.Header.Get("X-Forwarded-Proto")
+	if proto == "" {
+		if r.TLS != nil {
+			proto = "https"
+		} else {
+			proto = "http"
+		}
+	}
+	host := r.Header.Get("X-Forwarded-Host")
+	if host == "" {
+		host = r.Host
+	}
+	if host == "" {
+		return "/dashboard"
+	}
+	return proto + "://" + host + "/dashboard"
+}
+
+func bearerTokenFromRequest(r *http.Request) string {
+	if token := strings.TrimSpace(r.Header.Get("X-Hive-GitHub-Token")); token != "" {
+		return token
+	}
+	auth := r.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "Bearer ") {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(auth, "Bearer "))
+}
+
+func verifyGitHubRepoAccess(ctx context.Context, token, host, owner, repo string) (bool, error) {
+	apiBase := "https://api.github.com"
+	if host != "" && host != publicGitHubHost {
+		apiBase = "https://" + host + "/api/v3"
+	}
+	u, err := url.JoinPath(apiBase, "repos", owner, repo)
+	if err != nil {
+		return false, fmt.Errorf("invalid GitHub API URL")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return false, fmt.Errorf("build GitHub repo access check: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("GitHub repo access check failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
+		return false, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return false, fmt.Errorf("GitHub repo access check returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	var payload struct {
+		Permissions struct {
+			Admin    bool `json:"admin"`
+			Maintain bool `json:"maintain"`
+		} `json:"permissions"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return false, fmt.Errorf("decode GitHub repo access check: %w", err)
+	}
+	return payload.Permissions.Admin || payload.Permissions.Maintain, nil
+}

--- a/v2/pkg/hub/lite_enrollment_test.go
+++ b/v2/pkg/hub/lite_enrollment_test.go
@@ -1,0 +1,175 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newLiteTestHub(t *testing.T) (*HubServer, func()) {
+	t.Helper()
+	oldVerify := verifyLiteRepoAccess
+	verifyLiteRepoAccess = func(context.Context, string, string, string, string) (bool, error) {
+		return true, nil
+	}
+	t.Cleanup(func() { verifyLiteRepoAccess = oldVerify })
+	cleanup := helperSetupTempDirs(t)
+	dir := t.TempDir()
+	s := &HubServer{
+		logger:       slog.Default(),
+		hubSecret:    testHubSecret,
+		saveCh:       make(chan struct{}, 1),
+		registryPath: filepath.Join(dir, "registry.json"),
+		clusters:     map[string]ClusterConfig{defaultClusterID: {ID: defaultClusterID}},
+	}
+	mkUser(t, "lite-user")
+	return s, cleanup
+}
+
+func liteReqWithUser(method, target, body, username string) *http.Request {
+	req := reqWithUser(method, target, body, username)
+	req.Header.Set("Authorization", "Bearer ghp-test")
+	return req
+}
+
+func TestHandleLiteEnrollTable(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+		check      func(t *testing.T, s *HubServer, rec *httptest.ResponseRecorder)
+	}{
+		{
+			name:       "happy path caps to L2 and persists lite marker",
+			body:       `{"owner":"kubestellar","repo":"hive","installation_id":123,"acmm_level":5}`,
+			wantStatus: http.StatusOK,
+			check: func(t *testing.T, s *HubServer, rec *httptest.ResponseRecorder) {
+				var resp LiteEnrollmentResponse
+				if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+					t.Fatal(err)
+				}
+				if resp.ACMMLevel != 2 || resp.InstallationID != 123 || resp.Mode != "lite" {
+					t.Fatalf("response = %#v", resp)
+				}
+				if len(s.registry.Hives) != 1 || !s.registry.Hives[0].Lite || s.registry.Hives[0].HiveType != "lite" || s.registry.Hives[0].IsPublic {
+					t.Fatalf("registry = %#v", s.registry.Hives)
+				}
+			},
+		},
+		{
+			name:       "invalid repo rejected",
+			body:       `{"owner":"bad/owner","repo":"hive","installation_id":123}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "installation required without hub app key",
+			body:       `{"owner":"kubestellar","repo":"hive"}`,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, cleanup := newLiteTestHub(t)
+			defer cleanup()
+			rec := httptest.NewRecorder()
+			req := liteReqWithUser(http.MethodPost, "/api/saas/lite/enroll", tt.body, "lite-user")
+			s.handleLiteEnroll(rec, req)
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d body=%s, want %d", rec.Code, rec.Body.String(), tt.wantStatus)
+			}
+			if tt.check != nil {
+				tt.check(t, s, rec)
+			}
+		})
+	}
+}
+
+func TestHandleLiteEnrollDuplicateIdempotent(t *testing.T) {
+	s, cleanup := newLiteTestHub(t)
+	defer cleanup()
+	body := `{"owner":"kubestellar","repo":"hive","installation_id":123,"acmm_level":2}`
+	for i := 0; i < 2; i++ {
+		rec := httptest.NewRecorder()
+		req := liteReqWithUser(http.MethodPost, "/api/saas/lite/enroll", body, "lite-user")
+		s.handleLiteEnroll(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("attempt %d status = %d body=%s", i, rec.Code, rec.Body.String())
+		}
+	}
+	if len(s.registry.Hives) != 1 {
+		t.Fatalf("duplicate enrollment created %d entries", len(s.registry.Hives))
+	}
+}
+
+func TestHandleLiteEnrollDuplicateRejectsDifferentOwner(t *testing.T) {
+	s, cleanup := newLiteTestHub(t)
+	defer cleanup()
+	mkUser(t, "other-user")
+	s.registry.Hives = []RegistryEntry{{
+		ID:          liteHiveID(publicGitHubHost, "kubestellar", "hive"),
+		Org:         "kubestellar",
+		PrimaryRepo: "hive",
+		Repos:       []string{"hive"},
+		Owner:       "other-user",
+		HiveType:    "lite",
+		Lite:        true,
+	}}
+	rec := httptest.NewRecorder()
+	req := liteReqWithUser(http.MethodPost, "/api/saas/lite/enroll", `{"owner":"kubestellar","repo":"hive","installation_id":123}`, "lite-user")
+	s.handleLiteEnroll(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d body=%s, want 403", rec.Code, rec.Body.String())
+	}
+	if s.registry.Hives[0].Owner != "other-user" {
+		t.Fatalf("owner changed to %q", s.registry.Hives[0].Owner)
+	}
+}
+
+func TestLiteHiveIDIncludesNonPublicHost(t *testing.T) {
+	publicID := liteHiveID(publicGitHubHost, "org", "repo")
+	gheID := liteHiveID("github.example.com", "org", "repo")
+	if publicID == gheID {
+		t.Fatalf("public and GHE IDs collided: %q", publicID)
+	}
+	if !strings.HasPrefix(publicID, "lite-org-repo-") {
+		t.Fatalf("public ID = %q", publicID)
+	}
+	if !strings.HasPrefix(gheID, "lite-github-example-com-org-repo") {
+		t.Fatalf("GHE ID = %q", gheID)
+	}
+	if mixed := liteHiveID("GitHub.Example.Com", "Org", "Repo"); mixed != gheID {
+		t.Fatalf("case variant ID = %q, want %q", mixed, gheID)
+	}
+}
+
+func TestWebhookMatcherSkipsLiteEntries(t *testing.T) {
+	s, cleanup := newLiteTestHub(t)
+	defer cleanup()
+	s.registry.Hives = []RegistryEntry{
+		{ID: "lite", Org: "org", Repos: []string{"repo"}, PrimaryRepo: "repo", Lite: true, HiveType: "lite"},
+		{ID: "spoke", Org: "org", Repos: []string{"repo"}, PrimaryRepo: "repo", HiveType: "hosted"},
+	}
+	got := s.findHiveByOrgRepos("org", []string{"repo"})
+	if got == nil || got.ID != "spoke" {
+		t.Fatalf("matched %#v, want spoke", got)
+	}
+}
+
+func TestLiteEnrollRouteRequiresAuth(t *testing.T) {
+	s, cleanup := newLiteTestHub(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/saas/lite/enroll", s.requireAuth(s.handleLiteEnroll))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/lite/enroll", strings.NewReader(`{"owner":"o","repo":"r","installation_id":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d body=%s, want 401", rec.Code, rec.Body.String())
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -236,6 +236,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	// non-admin legitimately sees their OWN hives' usage; the handler scopes
 	// fleet-wide data to admins itself.
 	s.mux.HandleFunc("GET /api/saas/usage", s.requireAuth(s.handleUsage))
+	s.mux.HandleFunc("POST /api/saas/lite/enroll", s.requireAuth(s.handleLiteEnroll))
 	s.mux.HandleFunc("POST /api/saas/hives", s.requireAuth(s.handleCreateHive))
 	s.mux.HandleFunc("GET /api/saas/hives/{id}/status", s.requireAuth(s.handleHiveStatus))
 	// /open is a browser NAVIGATION endpoint (the SSO handoff), not an API call.

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -135,22 +135,24 @@ type RegistryEntry struct {
 	// alert (AlertTypeInferenceAuthFailed) and, on an advisory-participating
 	// hive, also trips advisory staleness immediately with this cause. Self-
 	// clears when inference recovers. Never carries key material.
-	InferenceAuthError string `json:"inferenceAuthError,omitempty"`
-	PrimaryRepo        string `json:"primaryRepo"`
-	DashboardURL       string `json:"dashboardUrl"`
-	SnapshotURL        string `json:"snapshotUrl,omitempty"`
-	ACMMLevel          int    `json:"acmmLevel"`
-	AgentCount         int    `json:"agentCount"`
-	GovernorMode       string `json:"governorMode"`
-	TotalTokens24h     int64  `json:"totalTokens24h"`
-	ActionableIssues   int    `json:"actionableIssues"`
-	ActionablePRs      int    `json:"actionablePRs"`
-	ContributorCount   int    `json:"contributorCount"`
-	ActiveContributors int    `json:"activeContributors"`
-	Owner              string `json:"owner,omitempty"`
-	ClusterID          string `json:"clusterId,omitempty"`
-	ClusterName        string `json:"clusterName,omitempty"`
-	HiveType           string `json:"hiveType,omitempty"`
+	InferenceAuthError string                `json:"inferenceAuthError,omitempty"`
+	PrimaryRepo        string                `json:"primaryRepo"`
+	DashboardURL       string                `json:"dashboardUrl"`
+	SnapshotURL        string                `json:"snapshotUrl,omitempty"`
+	ACMMLevel          int                   `json:"acmmLevel"`
+	AgentCount         int                   `json:"agentCount"`
+	GovernorMode       string                `json:"governorMode"`
+	TotalTokens24h     int64                 `json:"totalTokens24h"`
+	ActionableIssues   int                   `json:"actionableIssues"`
+	ActionablePRs      int                   `json:"actionablePRs"`
+	ContributorCount   int                   `json:"contributorCount"`
+	ActiveContributors int                   `json:"activeContributors"`
+	Owner              string                `json:"owner,omitempty"`
+	ClusterID          string                `json:"clusterId,omitempty"`
+	ClusterName        string                `json:"clusterName,omitempty"`
+	HiveType           string                `json:"hiveType,omitempty"`
+	Lite               bool                  `json:"lite,omitempty"`
+	LiteConfig         *LiteEnrollmentConfig `json:"liteConfig,omitempty"`
 	// ProvStatus is the authoritative provisioning status copied from the hive's
 	// SaaSHive record (sh.Status) on the heartbeat path — statusAvailable
 	// ("available") for a genuinely-unclaimed pool placeholder, else a claimed

--- a/v2/pkg/hub/webhook.go
+++ b/v2/pkg/hub/webhook.go
@@ -177,6 +177,9 @@ func (s *HubServer) findHiveByOrgRepos(org string, repos []string) *RegistryEntr
 	var orgMatch *RegistryEntry
 	for i := range s.registry.Hives {
 		h := &s.registry.Hives[i]
+		if h.Lite || h.HiveType == "lite" {
+			continue
+		}
 		if !strings.EqualFold(h.Org, org) {
 			continue
 		}


### PR DESCRIPTION
Part of #2808

## Summary
- Add `hivectl enroll <owner/repo>` with gh auth/repo verification, hub registration, ACMM L1-L2 lite config, and clear next steps.
- Add a hub lite enrollment endpoint that verifies GitHub repo admin/maintain access, records private-by-default lite registry entries with a lite marker/config, and is idempotent for the owner.
- Document the 5-minute zero-secret lite flow and graduation path.

## Validation
- `cd v2 && go build ./...`
- `cd v2 && go test ./pkg/hivectl/... ./pkg/hub/... ./pkg/github/... -count=1`
- `cd v2 && go vet ./pkg/hivectl/... ./pkg/hub/... ./pkg/github/...`

## Deferred work
- Hub-hosted execution for lite repos.
- Optional workflow shim installation.
- ACMM L3+ / full-spoke execution path remains graduation work.