### PR TITLE
✨ feat(leaderboard): custom stylesheet from a public GitHub repo via ?style= param

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -91,6 +91,19 @@ project:
   ai_author: your-bot-user
 ```
 
+### Leaderboard custom stylesheet
+
+The ClankeR leaderboard accepts a shareable custom stylesheet parameter:
+
+`/contribute/leaderboard?style=owner/repo/path/to/theme.css@ref`
+
+The `@ref` suffix is optional and defaults to the repo's `HEAD`. Hive only
+accepts the `owner/repo/path.css` triplet form, fetches public GitHub raw content
+server-side without credentials, sanitizes CSS, strips external imports/URLs, and
+serves it from `/api/leaderboard/style` with a 128 KiB size cap. The sanitizer
+also scopes selectors to the leaderboard tab and removes legacy executable CSS
+vectors and CSS escape sequences.
+
 ## Agents
 
 Seven agents ship as defaults (scanner, ci-maintainer, quality, architect, supervisor, outreach, sec-check). Enable or disable each in config:

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -12,6 +12,7 @@ import (
 	"html"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -295,6 +296,7 @@ func (s *Server) registerContributeRoutes() {
 
 	s.mux.HandleFunc("GET /leaderboard", s.handleLeaderboardPage)
 	s.mux.HandleFunc("GET /api/leaderboard", s.handleLeaderboardAPI)
+	s.mux.HandleFunc("GET /api/leaderboard/style", s.handleLeaderboardStyle)
 	// Central per-user "Me" profile — a HUB endpoint returning one contributor's
 	// cross-hive profile (identity/tier/stats/milestones/hives/rank), aggregated
 	// from central hub data (contributor store + LeaderboardForHub + federation
@@ -518,6 +520,24 @@ func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request)
 			`<tr><td>Trusted</td><td>~%d PR tasks, then granted by a maintainer</td><td>Extra review scope (checks:read)</td></tr>`,
 		contributorAutoPromoteAt, contributorTrustedAt,
 	)
+
+	customStyleHeadHTML := ""
+	customStyleNoticeHTML := ""
+	if rawStyle := strings.TrimSpace(r.URL.Query().Get("style")); rawStyle != "" {
+		if _, src, err := getLeaderboardCustomStyle(r.Context(), rawStyle); err == nil {
+			styleKey := leaderboardCustomStyleCacheKey(src)
+			escapedSrc := html.EscapeString(styleKey)
+			styleKeyJSON, _ := json.Marshal(styleKey)
+			customStyleHeadHTML = fmt.Sprintf(
+				`<link id="leaderboard-custom-style-link" rel="stylesheet" href="/api/leaderboard/style?src=%s"><script>window.HIVE_LEADERBOARD_CUSTOM_STYLE_SRC=%s;</script>`,
+				url.QueryEscape(styleKey),
+				string(styleKeyJSON),
+			)
+			customStyleNoticeHTML = fmt.Sprintf(`<div class="lb-custom-style-note" id="leaderboard-custom-style-note" role="status">Custom style active: <code>%s</code></div>`, escapedSrc)
+		} else {
+			customStyleNoticeHTML = `<div class="lb-custom-style-note lb-custom-style-note--warn" id="leaderboard-custom-style-note" role="status">Custom style could not be loaded — using default <button type="button" onclick="this.parentElement.remove()">Dismiss</button></div>`
+		}
+	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	fmt.Fprintf(w, `<!DOCTYPE html>
@@ -1361,7 +1381,11 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 .stat{padding:16px 10px}
 .ops-grid{gap:24px}
 .ops-card-head{padding:18px 20px}
-</style></head><body>
+.lb-custom-style-note{margin:0 0 16px;padding:10px 12px;border:1px solid rgba(88,166,255,.35);border-radius:8px;background:rgba(88,166,255,.10);color:var(--cc-text);font-size:.86rem}
+.lb-custom-style-note code{color:var(--cc-accent)}
+.lb-custom-style-note--warn{border-color:rgba(210,153,34,.45);background:rgba(210,153,34,.12)}
+.lb-custom-style-note button{margin-left:8px;background:transparent;border:1px solid var(--cc-border);border-radius:6px;color:var(--cc-text);padding:2px 8px;cursor:pointer}
+</style>%s</head><body>
 <div class="page-tabs" role="tablist">
 <button class="page-tab active" role="tab" id="ptab-onboarding" aria-selected="true" data-panel="tab-onboarding">Onboarding</button>
 <button class="page-tab" role="tab" id="ptab-ops" aria-selected="false" data-panel="tab-ops">Operations</button>
@@ -2042,6 +2066,7 @@ It clears automatically when the period elapses. An operator can shorten or disa
 <div class="ops">
 <h1>Leaderboard</h1>
 <p class="subtitle" style="font-size:.95rem">Ranked by tasks completed. Human contributors and donated-compute contributors appear here; the hive&rsquo;s own internal agents and revoked contributors are excluded.</p>
+%s
 <!-- Personal "Me" card. Pinned ABOVE the full standings. Hydrated from the HUB
      profile endpoint (/api/leaderboard/contributor/{username}) once we know the
      logged-in username (from /api/gh-user-auth/status). For an anonymous / unknown
@@ -2348,6 +2373,23 @@ function meStyleClass(){
   if(!(n>=1&&n<=ME_STYLE_COUNT))n=1;
   return n;
 }
+function leaderboardCustomStyleLabel(src){
+  var base=String(src||'').split('@')[0].split('/');
+  return base.length>=2?(base[0]+'/'+base[1]):'custom';
+}
+function clearLeaderboardCustomStyleParam(){
+  try{
+    var u=new URL(window.location.href);
+    if(!u.searchParams.has('style'))return;
+    u.searchParams.delete('style');
+    history.replaceState(null,'',u.pathname+(u.searchParams.toString()?('?'+u.searchParams.toString()):'')+u.hash);
+  }catch(e){}
+  window.HIVE_LEADERBOARD_CUSTOM_STYLE_SRC='';
+  var link=document.getElementById('leaderboard-custom-style-link');
+  if(link)link.remove();
+  var note=document.getElementById('leaderboard-custom-style-note');
+  if(note)note.remove();
+}
 
 function loadMeCard(){
   var mount=document.getElementById('me-card-mount');
@@ -2518,9 +2560,11 @@ function renderMeCard(mount,p){
     +((p.rank&&p.total)?(' — ranked #'+p.rank+' of '+p.total+' on this hive'):'')+'.';
 
   var styleOpts='';
+  var customStyleSrc=window.HIVE_LEADERBOARD_CUSTOM_STYLE_SRC||'';
   for(var i=1;i<=ME_STYLE_COUNT;i++){
-    styleOpts+='<option value="'+i+'"'+(i===styleN?' selected':'')+'>'+esc(ME_STYLE_NAMES[i-1]||('Style '+i))+'</option>';
+    styleOpts+='<option value="'+i+'"'+(!customStyleSrc&&i===styleN?' selected':'')+'>'+esc(ME_STYLE_NAMES[i-1]||('Style '+i))+'</option>';
   }
+  if(customStyleSrc)styleOpts+='<option value="custom" selected>Custom ('+esc(leaderboardCustomStyleLabel(customStyleSrc))+')</option>';
 
   var html=''
   +'<div class="me-card me-card--style'+styleN+'" id="me-card">'
@@ -2558,8 +2602,12 @@ function renderMeCard(mount,p){
 
   var sel=document.getElementById('me-style-select');
   if(sel)sel.addEventListener('change',function(){
+    if(sel.value==='custom')return;
     var v=parseInt(sel.value,10);if(!(v>=1&&v<=ME_STYLE_COUNT))v=1;
     localStorage.setItem(ME_STYLE_KEY,String(v));
+    clearLeaderboardCustomStyleParam();
+    var customOpt=sel.querySelector('option[value="custom"]');
+    if(customOpt)customOpt.remove();
     var card=document.getElementById('me-card');
     if(card){for(var k=1;k<=ME_STYLE_COUNT;k++)card.classList.remove('me-card--style'+k);card.classList.add('me-card--style'+v);}
   });
@@ -4760,7 +4808,7 @@ fetch('/api/version').then(function(r){return r.json()}).then(function(d){
   el.innerHTML=dot+' Hive v'+d.version+' ('+d.short+')' + (d.behind?' · <span style="color:#d29922">update available</span>':' · up to date');
 }).catch(function(){});
 </script>
-</body></html>`, projectName, projectName, len(profiles), tierBoxes.String(), hubURL, hubURL, tierTableRows)
+</body></html>`, projectName, customStyleHeadHTML, projectName, len(profiles), tierBoxes.String(), hubURL, hubURL, tierTableRows, customStyleNoticeHTML)
 }
 
 // ── Registration ───────────────────────────────────────────────────────────
@@ -6174,7 +6222,11 @@ func (s *Server) countAgentActivity(agentName string) (prs, issues, findings int
 // query form still works on load for back-compat, but the canonical shareable
 // URL is now the path form.)
 func (s *Server) handleLeaderboardPage(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/contribute/leaderboard", http.StatusFound)
+	target := "/contribute/leaderboard"
+	if r.URL.RawQuery != "" {
+		target += "?" + r.URL.RawQuery
+	}
+	http.Redirect(w, r, target, http.StatusFound)
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────

--- a/v2/pkg/dashboard/api_leaderboard_style.go
+++ b/v2/pkg/dashboard/api_leaderboard_style.go
@@ -1,0 +1,293 @@
+package dashboard
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	leaderboardCustomStyleMaxBytes   = 128 * 1024
+	leaderboardCustomStyleCacheTTL   = 5 * time.Minute
+	leaderboardCustomStyleMaxCache   = 64
+	leaderboardCustomStyleFetchTTL   = 10 * time.Second
+	leaderboardCustomStyleDefaultRef = "HEAD"
+)
+
+var leaderboardCustomStyleRawBaseURL = "https://raw.githubusercontent.com"
+
+type leaderboardCustomStyleSource struct {
+	Owner string
+	Repo  string
+	Path  string
+	Ref   string
+}
+
+type leaderboardCustomStyleCacheEntry struct {
+	css       []byte
+	expiresAt time.Time
+}
+
+var (
+	leaderboardCustomStyleCacheMu sync.Mutex
+	leaderboardCustomStyleCache   = map[string]leaderboardCustomStyleCacheEntry{}
+	leaderboardCustomStyleClient  = &http.Client{Timeout: leaderboardCustomStyleFetchTTL}
+)
+
+var (
+	githubOwnerNameRE = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$`)
+	githubRepoNameRE  = regexp.MustCompile(`^[A-Za-z0-9._-]{1,100}$`)
+	githubRefNameRE   = regexp.MustCompile(`^[A-Za-z0-9._/-]{1,100}$`)
+	githubCSSPathRE   = regexp.MustCompile(`^[A-Za-z0-9._/-]+$`)
+	cssImportRE       = regexp.MustCompile(`(?is)@import\b[^;]*(;|$)`)
+	cssURLRE          = regexp.MustCompile(`(?is)url\(\s*(['"]?)([^'")]+)['"]?\s*\)`)
+)
+
+func validateLeaderboardCustomStyleSource(src string) (leaderboardCustomStyleSource, error) {
+	src = strings.TrimSpace(src)
+	if src == "" {
+		return leaderboardCustomStyleSource{}, fmt.Errorf("style source is required")
+	}
+	if strings.Contains(src, "://") || strings.HasPrefix(src, "//") {
+		return leaderboardCustomStyleSource{}, fmt.Errorf("use owner/repo/path.css, not a full URL")
+	}
+	ref := leaderboardCustomStyleDefaultRef
+	if at := strings.LastIndex(src, "@"); at >= 0 {
+		if at == len(src)-1 {
+			return leaderboardCustomStyleSource{}, fmt.Errorf("ref is empty")
+		}
+		ref = src[at+1:]
+		src = src[:at]
+	}
+	parts := strings.Split(src, "/")
+	if len(parts) < 3 {
+		return leaderboardCustomStyleSource{}, fmt.Errorf("style source must be owner/repo/path.css")
+	}
+	owner, repo := parts[0], parts[1]
+	cssPath := strings.Join(parts[2:], "/")
+	if !githubOwnerNameRE.MatchString(owner) {
+		return leaderboardCustomStyleSource{}, fmt.Errorf("invalid owner")
+	}
+	if !githubRepoNameRE.MatchString(repo) || repo == "." || repo == ".." {
+		return leaderboardCustomStyleSource{}, fmt.Errorf("invalid repo")
+	}
+	if err := validateLeaderboardCustomStylePath(cssPath); err != nil {
+		return leaderboardCustomStyleSource{}, err
+	}
+	if ref != leaderboardCustomStyleDefaultRef {
+		if !githubRefNameRE.MatchString(ref) || strings.Contains(ref, "..") || strings.HasPrefix(ref, "/") || strings.HasSuffix(ref, "/") {
+			return leaderboardCustomStyleSource{}, fmt.Errorf("invalid ref")
+		}
+	}
+	return leaderboardCustomStyleSource{Owner: owner, Repo: repo, Path: cssPath, Ref: ref}, nil
+}
+
+func validateLeaderboardCustomStylePath(cssPath string) error {
+	if cssPath == "" || strings.HasPrefix(cssPath, "/") || strings.Contains(cssPath, "\\") || strings.Contains(cssPath, "://") {
+		return fmt.Errorf("invalid path")
+	}
+	if !githubCSSPathRE.MatchString(cssPath) {
+		return fmt.Errorf("path contains unsupported characters")
+	}
+	if !strings.HasSuffix(strings.ToLower(cssPath), ".css") {
+		return fmt.Errorf("path must end in .css")
+	}
+	for _, segment := range strings.Split(cssPath, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return fmt.Errorf("path traversal is not allowed")
+		}
+	}
+	return nil
+}
+
+func leaderboardCustomStyleCacheKey(src leaderboardCustomStyleSource) string {
+	return src.Owner + "/" + src.Repo + "/" + src.Path + "@" + src.Ref
+}
+
+func leaderboardCustomStyleRawURL(src leaderboardCustomStyleSource) string {
+	parts := []string{strings.TrimRight(leaderboardCustomStyleRawBaseURL, "/"), pathEscape(src.Owner), pathEscape(src.Repo), pathEscape(src.Ref)}
+	for _, segment := range strings.Split(src.Path, "/") {
+		parts = append(parts, pathEscape(segment))
+	}
+	return strings.Join(parts, "/")
+}
+
+func pathEscape(s string) string {
+	return strings.ReplaceAll(url.PathEscape(s), "%2F", "/")
+}
+
+func getLeaderboardCustomStyle(ctx context.Context, rawSrc string) ([]byte, leaderboardCustomStyleSource, error) {
+	src, err := validateLeaderboardCustomStyleSource(rawSrc)
+	if err != nil {
+		return nil, leaderboardCustomStyleSource{}, err
+	}
+	key := leaderboardCustomStyleCacheKey(src)
+	now := time.Now()
+	leaderboardCustomStyleCacheMu.Lock()
+	if entry, ok := leaderboardCustomStyleCache[key]; ok && now.Before(entry.expiresAt) {
+		css := append([]byte(nil), entry.css...)
+		leaderboardCustomStyleCacheMu.Unlock()
+		return css, src, nil
+	}
+	leaderboardCustomStyleCacheMu.Unlock()
+
+	css, err := fetchAndSanitizeLeaderboardCustomStyle(ctx, src)
+	if err != nil {
+		return nil, src, err
+	}
+	leaderboardCustomStyleCacheMu.Lock()
+	if len(leaderboardCustomStyleCache) >= leaderboardCustomStyleMaxCache {
+		for k := range leaderboardCustomStyleCache {
+			delete(leaderboardCustomStyleCache, k)
+			break
+		}
+	}
+	leaderboardCustomStyleCache[key] = leaderboardCustomStyleCacheEntry{css: append([]byte(nil), css...), expiresAt: now.Add(leaderboardCustomStyleCacheTTL)}
+	leaderboardCustomStyleCacheMu.Unlock()
+	return css, src, nil
+}
+
+func fetchAndSanitizeLeaderboardCustomStyle(ctx context.Context, src leaderboardCustomStyleSource) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, leaderboardCustomStyleRawURL(src), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := leaderboardCustomStyleClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, errLeaderboardStyleNotFound
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("style fetch failed")
+	}
+	ct := strings.ToLower(resp.Header.Get("Content-Type"))
+	if ct != "" && !strings.Contains(ct, "text/css") && !strings.Contains(ct, "text/plain") {
+		return nil, fmt.Errorf("style response is not CSS")
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, leaderboardCustomStyleMaxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	return sanitizeLeaderboardCustomStyle(body)
+}
+
+var errLeaderboardStyleNotFound = fmt.Errorf("style not found")
+
+func sanitizeLeaderboardCustomStyle(css []byte) ([]byte, error) {
+	if len(css) > leaderboardCustomStyleMaxBytes {
+		return nil, fmt.Errorf("style exceeds %d byte limit", leaderboardCustomStyleMaxBytes)
+	}
+	s := cssImportRE.ReplaceAllString(string(css), "")
+	s = cssURLRE.ReplaceAllStringFunc(s, sanitizeCSSURLToken)
+	var kept []string
+	for _, line := range strings.Split(s, "\n") {
+		lower := strings.ToLower(line)
+		if strings.Contains(line, `\`) {
+			continue
+		}
+		if strings.Contains(lower, "://") || strings.Contains(lower, "image-set(") {
+			continue
+		}
+		if strings.Contains(lower, "expression(") || strings.Contains(lower, "-moz-binding") || strings.Contains(lower, "behavior:") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return []byte(scopeLeaderboardCustomStyle(strings.Join(kept, "\n"))), nil
+}
+
+func scopeLeaderboardCustomStyle(css string) string {
+	var out strings.Builder
+	remaining := css
+	for {
+		open := strings.Index(remaining, "{")
+		if open < 0 {
+			break
+		}
+		selector := strings.TrimSpace(remaining[:open])
+		remaining = remaining[open+1:]
+		close := strings.Index(remaining, "}")
+		if close < 0 {
+			break
+		}
+		body := remaining[:close]
+		remaining = remaining[close+1:]
+		if selector == "" || strings.Contains(selector, "@") {
+			continue
+		}
+		scoped := scopeLeaderboardSelectors(selector)
+		if scoped == "" {
+			continue
+		}
+		out.WriteString(scoped)
+		out.WriteString("{")
+		out.WriteString(body)
+		out.WriteString("}\n")
+	}
+	return out.String()
+}
+
+func scopeLeaderboardSelectors(selector string) string {
+	parts := strings.Split(selector, ",")
+	scoped := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if part == "#tab-leaderboard" {
+			scoped = append(scoped, part)
+			continue
+		}
+		scoped = append(scoped, "#tab-leaderboard "+part)
+	}
+	return strings.Join(scoped, ", ")
+}
+
+func sanitizeCSSURLToken(token string) string {
+	matches := cssURLRE.FindStringSubmatch(token)
+	if len(matches) < 3 {
+		return ""
+	}
+	raw := strings.TrimSpace(matches[2])
+	raw = strings.Trim(raw, `"'`)
+	lower := strings.ToLower(raw)
+	if strings.HasPrefix(lower, "data:image/") {
+		return "url(" + raw + ")"
+	}
+	if colon := strings.Index(raw, ":"); colon >= 0 {
+		slash := strings.IndexAny(raw, "/?#")
+		if slash == -1 || colon < slash {
+			return "url(\"\")"
+		}
+	}
+	if strings.HasPrefix(raw, "//") || strings.Contains(lower, "://") || strings.HasPrefix(lower, "data:") {
+		return "url(\"\")"
+	}
+	return "url(" + raw + ")"
+}
+
+func (s *Server) handleLeaderboardStyle(w http.ResponseWriter, r *http.Request) {
+	src := r.URL.Query().Get("src")
+	css, _, err := getLeaderboardCustomStyle(r.Context(), src)
+	if err != nil {
+		status := http.StatusUnprocessableEntity
+		if err == errLeaderboardStyleNotFound {
+			status = http.StatusNotFound
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+	w.Header().Set("Content-Type", "text/css; charset=utf-8")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	_, _ = w.Write(css)
+}

--- a/v2/pkg/dashboard/api_leaderboard_style_test.go
+++ b/v2/pkg/dashboard/api_leaderboard_style_test.go
@@ -1,0 +1,187 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func resetLeaderboardStyleTestState(t *testing.T) {
+	t.Helper()
+	origBase := leaderboardCustomStyleRawBaseURL
+	leaderboardCustomStyleCacheMu.Lock()
+	origCache := leaderboardCustomStyleCache
+	leaderboardCustomStyleCache = map[string]leaderboardCustomStyleCacheEntry{}
+	leaderboardCustomStyleCacheMu.Unlock()
+	t.Cleanup(func() {
+		leaderboardCustomStyleRawBaseURL = origBase
+		leaderboardCustomStyleCacheMu.Lock()
+		leaderboardCustomStyleCache = origCache
+		leaderboardCustomStyleCacheMu.Unlock()
+	})
+}
+
+func TestValidateLeaderboardCustomStyleSource(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr bool
+	}{
+		{"simple", "owner/repo/path/theme.css", false},
+		{"with ref", "owner/repo/path/theme.css@main", false},
+		{"full url rejected", "https://github.com/owner/repo/theme.css", true},
+		{"protocol relative rejected", "//github.com/owner/repo/theme.css", true},
+		{"path traversal rejected", "owner/repo/../theme.css", true},
+		{"script path rejected", "owner/repo/</script><script>alert(1)</script>.css", true},
+		{"non css rejected", "owner/repo/theme.txt", true},
+		{"oversized ref rejected", "owner/repo/theme.css@" + strings.Repeat("a", 101), true},
+		{"bad owner chars rejected", "bad_owner/repo/theme.css", true},
+		{"leading owner dash rejected", "-owner/repo/theme.css", true},
+		{"repo punctuation allowed", "owner/repo.name_theme/theme.css", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validateLeaderboardCustomStyleSource(tt.src)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateLeaderboardCustomStyleSource(%q) error = %v, wantErr %v", tt.src, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSanitizeLeaderboardCustomStyle(t *testing.T) {
+	css := []byte(`
+@import url("https://evil.example/x.css");
+@\69mport "https://evil.example/escaped.css";
+.external{background:url(https://evil.example/pixel.png)}
+.proto{background:url(//evil.example/pixel.png)}
+.escaped{background:url(https\3a//evil.example/pixel.png)}
+.multiline{background:url(
+https://evil.example/wrap.png
+)}
+.imageset{background-image:image-set("https://evil.example/pixel.png" 1x)}
+.scheme{background:url(javascript:alert(1))}
+body{display:none}
+.a,.b{color:blue}
+#tab-leaderboard ~ footer{display:none}
+.data{background:url(data:image/png;base64,abc)}
+.relative{background:url(/assets/bg.png)}
+.dot{background:url(./bg.png)}
+.expr{width:expression(alert(1))}
+.moz{-moz-binding:url(/x.xml)}
+.behavior{behavior:url(/x.htc)}
+`)
+	got, err := sanitizeLeaderboardCustomStyle(css)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(got)
+	for _, bad := range []string{"@import", "mport", "evil.example", `\3a`, "image-set(", "javascript:", "expression(", "-moz-binding", "behavior:"} {
+		if strings.Contains(out, bad) {
+			t.Fatalf("sanitized CSS still contains %q:\n%s", bad, out)
+		}
+	}
+	for _, good := range []string{"url(data:image/png;base64,abc)", "url(/assets/bg.png)", "url(./bg.png)"} {
+		if !strings.Contains(out, good) {
+			t.Fatalf("sanitized CSS missing %q:\n%s", good, out)
+		}
+	}
+	for _, scoped := range []string{"#tab-leaderboard body{display:none}", "#tab-leaderboard .a, #tab-leaderboard .b{color:blue}", "#tab-leaderboard #tab-leaderboard ~ footer{display:none}"} {
+		if !strings.Contains(out, scoped) {
+			t.Fatalf("sanitized CSS missing scoped selector %q:\n%s", scoped, out)
+		}
+	}
+	if _, err := sanitizeLeaderboardCustomStyle([]byte(strings.Repeat("a", leaderboardCustomStyleMaxBytes+1))); err == nil {
+		t.Fatal("oversized CSS did not fail")
+	}
+}
+
+func TestHandleLeaderboardStyleFetchesSanitizesAndCaches(t *testing.T) {
+	resetLeaderboardStyleTestState(t)
+	hits := 0
+	raw := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if r.URL.Path != "/owner/repo/main/lb/theme.css" {
+			t.Fatalf("raw path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/css")
+		_, _ = w.Write([]byte(`.ok{color:red}.bad{background:url(https://evil.example/pixel.png)}`))
+	}))
+	defer raw.Close()
+	leaderboardCustomStyleRawBaseURL = raw.URL
+
+	srv := newFullServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/leaderboard/style?src=owner/repo/lb/theme.css@main", nil)
+	rec := httptest.NewRecorder()
+	srv.handleLeaderboardStyle(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "text/css") {
+		t.Fatalf("Content-Type = %q", ct)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "#tab-leaderboard .ok{color:red}") || strings.Contains(body, "evil.example") {
+		t.Fatalf("unexpected sanitized body: %s", body)
+	}
+
+	rec = httptest.NewRecorder()
+	srv.handleLeaderboardStyle(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("cached status = %d", rec.Code)
+	}
+	if hits != 1 {
+		t.Fatalf("raw hits = %d, want cache hit after first fetch", hits)
+	}
+}
+
+func TestHandleLeaderboardStyle404(t *testing.T) {
+	resetLeaderboardStyleTestState(t)
+	raw := httptest.NewServer(http.NotFoundHandler())
+	defer raw.Close()
+	leaderboardCustomStyleRawBaseURL = raw.URL
+
+	srv := newFullServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/leaderboard/style?src=owner/repo/theme.css@main", nil)
+	rec := httptest.NewRecorder()
+	srv.handleLeaderboardStyle(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestContributeLeaderboardCustomStyleMarkup(t *testing.T) {
+	resetLeaderboardStyleTestState(t)
+	raw := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/css")
+		_, _ = w.Write([]byte(`.lb-row{border-color:hotpink}`))
+	}))
+	defer raw.Close()
+	leaderboardCustomStyleRawBaseURL = raw.URL
+
+	srv := newFullServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/contribute/leaderboard?style=owner/repo/lb/theme.css@main", nil)
+	rec := httptest.NewRecorder()
+	srv.handleContributeLanding(rec, req)
+	html := rec.Body.String()
+	for _, snippet := range []string{
+		`id="leaderboard-custom-style-link" rel="stylesheet" href="/api/leaderboard/style?src=owner%2Frepo%2Flb%2Ftheme.css%40main"`,
+		`window.HIVE_LEADERBOARD_CUSTOM_STYLE_SRC="owner/repo/lb/theme.css@main";`,
+		`Custom (` + `'+esc(leaderboardCustomStyleLabel(customStyleSrc))+'` + `)`,
+		`clearLeaderboardCustomStyleParam();`,
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Fatalf("contribute HTML missing %q", snippet)
+		}
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/contribute?tab=leaderboard&style=owner/repo/missing.css@main", nil)
+	rec = httptest.NewRecorder()
+	missingRaw := httptest.NewServer(http.NotFoundHandler())
+	defer missingRaw.Close()
+	leaderboardCustomStyleRawBaseURL = missingRaw.URL
+	srv.handleContributeLanding(rec, req)
+	if !strings.Contains(rec.Body.String(), "Custom style could not be loaded — using default") {
+		t.Fatal("missing custom style fallback notice")
+	}
+}


### PR DESCRIPTION
## Summary
- Add shareable ClankeR leaderboard custom styles via `?style=owner/repo/path/to/theme.css@ref` (ref optional, defaults to HEAD)
- Add `GET /api/leaderboard/style?src=...` for server-side unauthenticated public GitHub raw fetches with 5-minute in-memory cache
- Preserve `/leaderboard?style=...` redirects and wire the Me-card style dropdown to show Custom (owner/repo); choosing a built-in style clears the param
- Document the param format and security constraints in README

## Security model
- No full URLs accepted; only validated owner/repo/path.css triplets with optional @ref
- Server fetches from raw.githubusercontent.com (test-overridable base) without tokens; no client-side third-party fetch
- CSS is capped at 128 KiB, stripped of @import, external url(...), image-set(), legacy expression/-moz-binding/behavior vectors, CSS escape lines, and scoped to #tab-leaderboard
- Served back as text/css from same-origin /api/leaderboard/style, so the existing CSP style-src 'self' 'unsafe-inline' remains unchanged
- Hub-side /api/hub/leaderboard is a separate JSON consumer; this PR scopes UI stylesheet support to the spoke ClankeR /contribute leaderboard and leaves kubestellar.io hub presentation as follow-up

## Validation
- `go build ./...`
- `go vet ./...`
- `go test ./pkg/dashboard/ -count=1`