### PR TITLE
🐛 fix(contributor): entrypoint.d hooks can override backend_binary

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -39,6 +39,14 @@ jobs:
       - name: Entrypoint runtime-config migration tests
         run: bash deploy/test_entrypoint_runtime_config.sh
 
+      # backends.conf defines the backend tables as bash functions, so whichever
+      # of {backends.conf, entrypoint.d hooks} is sourced last wins. Sourcing it
+      # after the hooks silently discarded a downstream image's override. This
+      # replays the real blocks in the order the entrypoint has them, so putting
+      # backends.conf back below the seam fails the PR.
+      - name: Contributor entrypoint.d hook override tests
+        run: bash deploy/test_contributor_hook_override.sh
+
       - uses: actions/setup-node@v4
         with:
           node-version: '22'

--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -49,12 +49,30 @@ export CONTRIBUTOR_MODE
 # Username is extracted from contributor.env (set during registration)
 export HIVE_CONTRIBUTOR_USERNAME="${CONTRIBUTOR_USERNAME:-unknown}"
 
+# Source backends.conf for binary detection.
+#
+# This MUST stay ABOVE the entrypoint.d hook seam below (kubestellar/hive#2833).
+# backends.conf defines backend_binary() / backend_perm_flag() as bash
+# FUNCTIONS, and sourcing a function definition silently replaces any earlier
+# one. Sourced after the hooks, it clobbered a hook's override with no warning,
+# so the one thing the seam most obviously invites — pointing a backend at a
+# different binary — was the one thing it could not do. Loading it first means
+# the hooks run last and win.
+BACKENDS_CONF="${SCRIPT_DIR}/../config/backends.conf"
+if [[ -f "$BACKENDS_CONF" ]]; then
+  source "$BACKENDS_CONF"
+elif [[ -f /usr/local/etc/hive/backends.conf ]]; then
+  source /usr/local/etc/hive/backends.conf
+fi
+
 # Extension seam for downstream images (kubestellar/hive#2393 item 4). A derived
 # image (e.g. projectbluefin/donate-clanker) can drop *.sh into
 # /etc/hive/entrypoint.d/ and/or set HIVE_PRE_AGENT_HOOK to run setup here —
-# after the full contributor env is exported, before backend detection and the
-# tmux launch — WITHOUT forking this entrypoint and re-implementing the tmux
-# wait/attach logic. Sourced (not exec'd) so hooks can export env the agent sees.
+# after the full contributor env is exported and after backends.conf has
+# defined the backend tables, but before backend detection and the tmux launch —
+# WITHOUT forking this entrypoint and re-implementing the tmux wait/attach
+# logic. Sourced (not exec'd) so hooks can export env the agent sees and can
+# redefine backend_binary()/backend_perm_flag() to add or retarget a backend.
 if [[ -d /etc/hive/entrypoint.d ]]; then
   for _hook in /etc/hive/entrypoint.d/*.sh; do
     [[ -r "$_hook" ]] || continue
@@ -66,14 +84,6 @@ fi
 if [[ -n "${HIVE_PRE_AGENT_HOOK:-}" ]]; then
   echo "Running HIVE_PRE_AGENT_HOOK"
   eval "$HIVE_PRE_AGENT_HOOK"
-fi
-
-# Source backends.conf for binary detection
-BACKENDS_CONF="${SCRIPT_DIR}/../config/backends.conf"
-if [[ -f "$BACKENDS_CONF" ]]; then
-  source "$BACKENDS_CONF"
-elif [[ -f /usr/local/etc/hive/backends.conf ]]; then
-  source /usr/local/etc/hive/backends.conf
 fi
 
 # LiteLLM backend: Claude Code pointed at the contributor's own LiteLLM proxy.

--- a/v2/deploy/test_contributor_hook_override.sh
+++ b/v2/deploy/test_contributor_hook_override.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Tests that entrypoint.d hooks can override the backend tables in
+# bin/contributor-agent.sh (kubestellar/hive#2833).
+#
+# config/backends.conf defines backend_binary() / backend_perm_flag() as bash
+# FUNCTIONS. Sourcing a function definition silently replaces an earlier one,
+# so whichever of {backends.conf, entrypoint.d hooks} is sourced LAST wins.
+# The entrypoint used to source backends.conf after the hooks, which discarded
+# a downstream image's override with no warning — making the documented seam
+# useless for retargeting a backend's binary, its most obvious use.
+#
+# Rather than grepping for the order, this extracts the two real blocks from
+# the shipped entrypoint and executes them, so it fails if the order regresses.
+#
+# Run: bash v2/deploy/test_contributor_hook_override.sh
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+ENTRYPOINT="${REPO_ROOT}/bin/contributor-agent.sh"
+BACKENDS_CONF="${REPO_ROOT}/config/backends.conf"
+
+check() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"
+    echo "        want: '$want'"
+    echo "        got:  '$got'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== contributor entrypoint.d hook override tests ==="
+
+[ -f "$ENTRYPOINT" ]     || { echo "  FAIL: missing $ENTRYPOINT"; exit 1; }
+[ -f "$BACKENDS_CONF" ]  || { echo "  FAIL: missing $BACKENDS_CONF"; exit 1; }
+
+# Extract the two ordered blocks verbatim from the shipped entrypoint, so this
+# tests the real code rather than a copy that can drift away from it.
+# 1. the backends.conf sourcing block
+BACKENDS_BLOCK="$(sed -n '/^BACKENDS_CONF=/,/^fi$/p' "$ENTRYPOINT")"
+# 2. the entrypoint.d hook loop + HIVE_PRE_AGENT_HOOK
+HOOK_BLOCK="$(sed -n '/^if \[\[ -d \/etc\/hive\/entrypoint.d \]\]; then$/,/^fi$/p' "$ENTRYPOINT")"
+PRE_HOOK_BLOCK="$(sed -n '/^if \[\[ -n "${HIVE_PRE_AGENT_HOOK:-}" \]\]; then$/,/^fi$/p' "$ENTRYPOINT")"
+
+[ -n "$BACKENDS_BLOCK" ] || { echo "  FAIL: could not extract backends.conf block"; exit 1; }
+[ -n "$HOOK_BLOCK" ]     || { echo "  FAIL: could not extract entrypoint.d block"; exit 1; }
+[ -n "$PRE_HOOK_BLOCK" ] || { echo "  FAIL: could not extract HIVE_PRE_AGENT_HOOK block"; exit 1; }
+
+# The ordering IS the fix: assert backends.conf is sourced above the hook seam.
+backends_line=$(grep -n '^BACKENDS_CONF=' "$ENTRYPOINT" | head -1 | cut -d: -f1)
+hooks_line=$(grep -n '^if \[\[ -d /etc/hive/entrypoint.d \]\]; then$' "$ENTRYPOINT" | head -1 | cut -d: -f1)
+if [ "$backends_line" -lt "$hooks_line" ]; then
+  check "backends.conf sourced before entrypoint.d hooks" "yes" "yes"
+else
+  check "backends.conf sourced before entrypoint.d hooks" \
+        "backends.conf(<$hooks_line)" "backends.conf(line $backends_line) after hooks(line $hooks_line)"
+fi
+
+# run_entrypoint <hook-body> — replays the real ordered blocks in a sandbox
+# with a fake /etc/hive/entrypoint.d, and prints "<binary>|<permflag>".
+# An empty hook body means "no hook installed".
+run_entrypoint() {
+  local hook_body="$1"
+  local dir
+  dir="$(mktemp -d)"
+
+  mkdir -p "$dir/entrypoint.d"
+  if [ -n "$hook_body" ]; then
+    printf '%s\n' "$hook_body" > "$dir/entrypoint.d/10-override.sh"
+  fi
+
+  # Assemble the blocks in the order they actually appear in the entrypoint --
+  # NOT the order they happen to be listed in this file. The ordering is the
+  # thing under test, so hardcoding it here would make every behavioural case
+  # pass against the buggy entrypoint too.
+  local first second
+  if [ "$backends_line" -lt "$hooks_line" ]; then
+    first="$BACKENDS_BLOCK"
+    second="$(printf '%s\n%s' "$HOOK_BLOCK" "$PRE_HOOK_BLOCK")"
+  else
+    first="$(printf '%s\n%s' "$HOOK_BLOCK" "$PRE_HOOK_BLOCK")"
+    second="$BACKENDS_BLOCK"
+  fi
+
+  # Run in a subshell so redefined functions never leak between cases.
+  (
+    set -euo pipefail
+    # Consumed by the eval'd BACKENDS_BLOCK below, not by this script directly.
+    # shellcheck disable=SC2034
+    SCRIPT_DIR="${REPO_ROOT}/bin"
+    # Point the hook loop at the sandbox instead of the real /etc/hive.
+    local_blocks="$(printf '%s\n%s' "$first" "$second" \
+      | sed "s#/etc/hive/entrypoint.d#${dir}/entrypoint.d#g")"
+    # The blocks echo progress ("Running entrypoint hook: ...") on stdout;
+    # send that to stderr so only the resolved values are captured.
+    eval "$local_blocks" >&2
+    printf '%s|%s' "$(backend_binary goose)" "$(backend_perm_flag goose)"
+  )
+
+  rm -rf "$dir"
+}
+
+# 1. No hook: the stock backends.conf mapping applies.
+got="$(run_entrypoint "")"
+check "default backend_binary goose (no hook)" "goose|" "$got"
+
+# 2. A hook that retargets a backend's binary wins — the bug in #2833.
+got="$(run_entrypoint 'backend_binary() { case "$1" in goose) echo "my-custom-goose-wrapper" ;; *) echo "$1" ;; esac; }')"
+check "hook overrides backend_binary" "my-custom-goose-wrapper|" "$got"
+
+# 3. A hook may also override the permission flags.
+got="$(run_entrypoint 'backend_perm_flag() { echo "--hook-flag"; }')"
+check "hook overrides backend_perm_flag" "goose|--hook-flag" "$got"
+
+# 4. A hook that wraps rather than replaces still sees the upstream table,
+#    which only works if backends.conf was sourced FIRST.
+got="$(run_entrypoint '
+_upstream_backend_binary() { :; }
+eval "_upstream_backend_binary() $(declare -f backend_binary | tail -n +2)"
+backend_binary() { echo "wrapped-$(_upstream_backend_binary "$1")"; }')"
+check "hook can wrap the upstream backend_binary" "wrapped-goose|" "$got"
+
+# 5. HIVE_PRE_AGENT_HOOK gets the same override power as a dropped-in file.
+got="$(HIVE_PRE_AGENT_HOOK='backend_binary() { echo "env-hook-binary"; }' run_entrypoint "")"
+check "HIVE_PRE_AGENT_HOOK overrides backend_binary" "env-hook-binary|" "$got"
+
+echo
+echo "=== $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Fixes #2833

## The report

@castrojo (thanks — the writeup and self-contained repro made this a five-minute diagnosis) reported that `bin/contributor-agent.sh` sources the downstream hook seam **before** `config/backends.conf`:

> `backends.conf` defines `backend_binary()` / `backend_perm_flag()` as bash functions. Because a later `source` of a function definition silently replaces an earlier one, a hook that overrides either function is discarded without warning.

And that this contradicts the seam's own comment, which advertises it as the place to run setup "before backend detection ... WITHOUT forking this entrypoint":

> Overriding which binary a backend resolves to is exactly the kind of setup that seam reads as inviting, but it is the one thing the ordering prevents.

## What I verified

- **The ordering is real and is as reported.** On `v2` HEAD the `entrypoint.d` loop and `HIVE_PRE_AGENT_HOOK` were at `bin/contributor-agent.sh:58-69`, and the `backends.conf` sourcing at `:71-77` — hooks first, config second.
- **These are functions, not variables.** Worth stating explicitly because it rules out a fix that would otherwise be the obvious one: there is no `backend_binary=...` assignment anywhere, so the `: "${backend_binary:=...}"` default-if-unset trick does not apply. Clobbering is at function-definition granularity, so the *only* lever is which side is sourced last.
- **Nothing in `backends.conf` reads hook-set state.** It defines four functions plus `KNOWN_BACKENDS` and consults no environment variable, so sourcing it earlier cannot change what it produces.
- **The seam is unique to this script.** Seven other scripts source `backends.conf` (`hive.sh`, `agent-launch.sh`, `supervisor.sh`, `kick-agents.sh`, `kick-governor.sh`, the `Justfile`, and the relay's own JS parser), but `/etc/hive/entrypoint.d` and `HIVE_PRE_AGENT_HOOK` appear **only** in `contributor-agent.sh`. The blast radius of reordering is one file.
- **No in-repo hook depends on the old order** — there are no `entrypoint.d` files in-tree at all; the directory is purely a downstream drop-point.

## The fix — option 1

I took the reporter's **option 1** (source `backends.conf` first, hooks second), which he flagged as "the most honest to the comment's stated intent".

Option 4 (`declare -F ... || backend_binary() {...}`, i.e. skip-if-defined) was the main alternative, and I rejected it: it makes the upstream table's presence conditional on what a hook did, so a hook that overrides one backend would silently suppress the definitions for *all* the others. Option 3 (a second `backends.d/` directory) buys order-independence at the cost of a second concept, which is not worth it given the seam has exactly one consumer today.

The stated risk of option 1 — a hook relying on running *before* backend detection — is unaffected: hooks still run after the full contributor env is exported and still before `detect_cli` and the tmux launch. The only thing that moved is a block of pure function definitions. Hook semantics are otherwise unchanged.

## Tests

New `v2/deploy/test_contributor_hook_override.sh`, in the style of the existing `test_entrypoint_runtime_config.sh`: it **extracts the real blocks from the shipped entrypoint** rather than grepping or copying them, and — importantly — assembles them **in the order the file actually has them**, so it cannot pass against a regressed entrypoint. Verified it fails 5/6 when pointed at the pre-fix code, with `backend_binary goose` returning the clobbered `goose` exactly as the issue predicted, and passes 6/6 after.

Cases: stock default with no hook; a hook retargeting a binary; a hook overriding the permission flags; a hook that *wraps* the upstream function (only possible if `backends.conf` loaded first); and `HIVE_PRE_AGENT_HOOK`.

Wired into `.github/workflows/v2-ci.yml` next to the existing entrypoint test.

## Collision check

Deliberately avoided the files in flight on #2829/#2831 — those touch `bin/contributor-relay.sh`, `contributor-relay.test.js`, and `test_contribute_k8s_workload.sh`. This PR touches `bin/contributor-agent.sh`, a new test file, and the CI workflow, so there is no overlap. `config/backends.conf` is unmodified, which also means downstreams pinning it verbatim keep doing so.

`go build ./...`, `go vet ./...`, both shell suites, and `bash -n` all clean locally; CI is the gate.