### PR TITLE
📖 docs: public roadmap, landscape comparison, and docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ flowchart LR
 
 **See [v2/docs/architecture.md](v2/docs/architecture.md) for the full reference architecture** — process model, the governor loop, the deterministic pipeline, layered guardrails, ACMM, beads, hub & spoke, and an end-to-end walkthrough, with Mermaid diagrams throughout.
 
+See also the [v2 docs index](v2/docs/README.md), [public roadmap](v2/docs/roadmap.md), and [landscape comparison](v2/docs/landscape.md) for community-facing documentation and positioning.
+
 ## Contribute to a Hive
 
 Community members can contribute compute to any hive through **ClankeR**, the

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -1,0 +1,61 @@
+# Hive v2 documentation
+
+This index organizes the versioned Hive docs under `v2/docs/`. It is the
+precursor to a published docs site.
+
+## Getting Started
+
+- [Agent configuration](agent-configuration.md) — configure lanes, models,
+  channels, policy modes, and ACMM packs.
+- [Hive CLI](hivectl.md) — inspect agents, beads, events, config, knowledge, and
+  lite enrollment.
+- [Hive lite enrollment](lite-enrollment.md) — five-minute, zero-secret advisory
+  enrollment for a repository.
+- [Credly badges](credly-badges.md) — public badge/credential surfaces.
+
+## Architecture
+
+- [Reference architecture](architecture.md) — process model, governor,
+  deterministic pipeline, guardrails, ACMM, beads, hub/spoke, model backends,
+  and observability.
+- [CNCF reference architecture](cncf-reference-architecture.md) — cloud-native
+  framing for Hive's components and security boundaries.
+- [ACMM policy matrix](acmm-policy-matrix.md) — autonomy levels mapped to agent
+  policy modes.
+- [Configuration layering](config-layering.md) — seed, overlay, dashboard, and
+  hub/spoke configuration precedence.
+- [Planning intelligence](planning-intelligence.md) — goal decomposition, plan
+  review, and stall-replan concepts.
+- [Knowledge system design](design/knowledge-system.md) — layered knowledge,
+  primers, and extraction design.
+
+## Security
+
+- [Security threat model](security-threat-model.md) — actors, boundaries,
+  layered defenses, known gaps, and reporting.
+- [Architecture Decision Records](adr/README.md) — lightweight ADR process and
+  records 0001-0010.
+- [Intent verification](intent-verification.md) — tier-based change
+  authorization for merge eligibility.
+- [Trajectory review](trajectory-review.md) — drift detection and agent pause
+  semantics.
+- [Rootless Podman CI seam](podman-rootless-ci.md) — documented test intent and
+  static contract for contributor-container runtime handling.
+
+## Operations
+
+- [Manual provisioning](manual-provisioning.md) — hub/spoke provisioning paths,
+  authentication modes, and troubleshooting.
+- [Cross-cluster migration](cross-cluster-migration.md) — moving spokes across
+  clusters, including heartbeat-only clusters.
+- [Retro lane](retro-lane.md) — deterministic post-completion analysis and
+  advisory beads.
+- [Review swarm](review-swarm.md) — structured review perspectives, verdicts,
+  and merge-gate integration.
+
+## Roadmap & Positioning
+
+- [Public roadmap](roadmap.md) — Now / Next / Later direction for v4 catch-up and
+  follow-on work.
+- [Landscape and positioning](landscape.md) — comparison with Fullsend,
+  single-agent tools, hosted services, and research harnesses.

--- a/v2/docs/architecture.md
+++ b/v2/docs/architecture.md
@@ -383,9 +383,12 @@ flowchart TB
 
 ---
 
-*See also: [agent-configuration.md](agent-configuration.md) ·
+*See also: [docs index](README.md) ·
+[agent-configuration.md](agent-configuration.md) ·
 [acmm-policy-matrix.md](acmm-policy-matrix.md) ·
 [security-threat-model.md](security-threat-model.md) ·
 [ADR index](adr/README.md) ·
+[roadmap.md](roadmap.md) ·
+[landscape.md](landscape.md) ·
 [trajectory-review.md](trajectory-review.md) ·
 [design/knowledge-system.md](design/knowledge-system.md)*

--- a/v2/docs/landscape.md
+++ b/v2/docs/landscape.md
@@ -1,0 +1,106 @@
+# Hive landscape and positioning
+
+> **Conducted: 2026-08-07. This document will rot.** Agentic software-delivery
+> tools are moving quickly; treat product details as time-sensitive and update
+> this page by PR when public docs change.
+
+Hive is an operations plane for AI-agent fleets: one operator-controlled system
+runs multiple coding/review agents, applies deterministic policy before and
+after model judgment, and exposes live dashboard, cost, hub/spoke, and
+contributor-compute surfaces. This page positions that design against nearby
+agentic orchestration tools.
+
+## Fullsend
+
+Public references: [fullsend.sh](https://fullsend.sh),
+[fullsend-ai/fullsend](https://github.com/fullsend-ai/fullsend),
+[Fullsend architecture](https://github.com/fullsend-ai/fullsend/blob/main/docs/architecture.md),
+[Fullsend roadmap](https://github.com/fullsend-ai/fullsend/blob/main/docs/roadmap.md),
+[Fullsend runtimes](https://github.com/fullsend-ai/fullsend/blob/main/docs/runtimes.md),
+[Fullsend intent representation](https://github.com/fullsend-ai/fullsend/blob/main/docs/problems/intent-representation.md).
+
+Fullsend is the most directly comparable open-source project. Its public README
+positions it as autonomous agentic software development for Git-hosted
+organizations, including GitHub, GitLab, and Forgejo. Its docs emphasize a
+repo-visible coordination model: target repositories carry `.fullsend/`
+configuration, GitHub installations use shim/reusable workflows and OIDC-minted
+GitHub App tokens, and GitLab support is being built through native CI triggers
+and polling. Its architecture names a vertical execution stack of dispatch,
+infrastructure, sandbox, harness, and runtime; production runtime docs currently
+list Claude Code as the production runtime and `dummy` for behavior tests, while
+future runtimes are tracked separately.
+
+Fullsend is also notably strong in public design discipline: many ADRs, a public
+roadmap, security and governance problem documents, and a thoughtful intent
+model. Its intent docs discuss git as an intent ledger and tiered authorization,
+which directly influenced Hive's catch-up work in [#2812](https://github.com/kubestellar/hive/issues/2812).
+
+### Where Hive differs
+
+| Dimension | Fullsend, fairly summarized | Hive, today or in-flight |
+| --- | --- | --- |
+| Control plane | Repo-centered install and workflow dispatch, especially strong for GitHub Actions-native adoption. | A live fleet operations plane with governor modes, dashboard/SSE, terminal access, budget tracking, hub/spoke heartbeats, and contributor compute. |
+| Execution model | Short-lived, workflow/sandbox-oriented agent runs; production docs currently center Claude Code. | Long-lived tmux-managed agents today, with multiple backends documented in config: Claude, Copilot, Gemini, Goose, and OpenAI-compatible gateways. |
+| Autonomy model | Public docs discuss shadow/autonomous and intent-tier concepts. | ACMM L1-L6 maps operator-selected maturity to deterministic per-agent modes and merge authority. |
+| Security enforcement | Sandbox, harness, scanner, and OIDC-mint controls are first-class in the docs. | Defense-in-depth combines CLI tool denial, scoped tokens, per-UID attribution, and a runtime-agnostic MITM proxy that enforces GitHub writes at the network boundary. |
+| Fleet topology | Per-repo install is the public deployment model. | Hub/spoke registry, callbacks, leaderboard, SaaS/manual provisioning paths, and ClankeR contributor-compute relay are built into the product shape. |
+
+Neither approach is inherently better for every team. Fullsend-style tooling is
+lighter when the target is one repo or one GitHub organization, GitHub Actions is
+already the trusted execution substrate, and the team wants minimal standing
+infrastructure. Hive is a better fit when operators need live fleet visibility,
+multiple runtimes, graduated autonomy, hub-managed spokes, contributor compute,
+or network-level enforcement independent of agent runtime hooks.
+
+## Single-agent and service-oriented tools
+
+### GitHub Copilot coding agent
+
+GitHub Copilot's coding agent is a hosted, GitHub-native way to assign issues or
+PR follow-ups to an agent. It is the lowest-friction option for teams already in
+GitHub that want a single background agent without operating their own control
+plane. Hive differs by coordinating a fleet of specialized agents, enforcing
+ACMM-derived permissions, aggregating fleet cost/status, and supporting
+non-Copilot runtimes.
+
+### Devin-class hosted services
+
+Hosted software-engineering agents such as Devin-class services optimize for
+outsourcing a task to a capable autonomous worker with a managed environment and
+product UX. They can be a better fit when a team wants a vendor-operated agent
+and does not want to run orchestration infrastructure. Hive is more appropriate
+when the organization needs open-source control, explicit policy, self-hosted
+operation, or integration with Kubernetes/hub/spoke workflows.
+
+### SWE-agent and research harnesses
+
+SWE-agent-style projects are excellent for benchmarking, experiments, and
+single-task repair loops where the research question is the agent's ability to
+solve an issue. Hive is not primarily a benchmark harness; it is an operating
+system for repeated project maintenance, policy-bound merge decisions, and
+multi-agent fleet operation.
+
+## When to choose what
+
+- Choose **GitHub Copilot coding agent** when you need the quickest hosted path
+  for GitHub issues and do not need a separate fleet governor or custom policy
+  plane.
+- Choose **Fullsend-style tooling** when you have a small number of repos, want
+  GitHub Actions or native CI to be the execution substrate, prefer repo-visible
+  `.fullsend/` configuration, and want little or no always-on infrastructure.
+- Choose **Devin-class services** when managed autonomy and vendor UX matter more
+  than self-hosted controls or open implementation details.
+- Choose **SWE-agent/research harnesses** when the goal is evaluation,
+  reproducible experiments, or one-off issue repair rather than operations.
+- Choose **Hive** when the problem is operating a live AI-agent fleet: multiple
+  runtimes, ACMM maturity gates, deterministic merge policy, hub/spoke
+  provisioning, contributor compute, cost visibility, and network-level MITM
+  enforcement.
+
+## Hive claims checked against this repo
+
+- Live fleet operations plane: [architecture](architecture.md#3-the-governor-loop--from-queue-depth-to-a-kick), [dashboard and observability](architecture.md#10-dashboard--observability).
+- Multi-runtime model: [architecture](architecture.md#9-model-backends--cost), [agent configuration](agent-configuration.md).
+- ACMM autonomy: [architecture](architecture.md#6-acmm--controlling-agent-autonomy), [ACMM matrix](acmm-policy-matrix.md).
+- Hub/spoke and contributor compute: [architecture](architecture.md#8-hub--spoke), [manual provisioning](manual-provisioning.md).
+- MITM enforcement: [architecture](architecture.md#5-layered-guardrails-defense-in-depth), [ADR-0002](adr/0002-mitm-proxy-network-enforcement.md).

--- a/v2/docs/roadmap.md
+++ b/v2/docs/roadmap.md
@@ -1,0 +1,47 @@
+# Hive public roadmap
+
+> **Directional, not a promise.** This roadmap reflects the public v4 direction as
+> of **2026-08-07**. It is maintained by pull request and can change as issues,
+> security reviews, and operator feedback change the order of work. The umbrella
+> tracking issue is [#2812](https://github.com/kubestellar/hive/issues/2812);
+> this page is part of [#2811](https://github.com/kubestellar/hive/issues/2811).
+
+Hive's roadmap is organized as **Now / Next / Later**: near-term work already in
+flight, likely follow-ups, and longer-horizon bets. Items are listed in planning
+order, not priority rank.
+
+## Now
+
+| Work | Outcome | Tracking |
+| --- | --- | --- |
+| Prompt-injection defense-in-depth | Canary-token checks, output redaction, and fail-closed scanning build on the existing deterministic `ioscan` kick-path redaction. | [#2805](https://github.com/kubestellar/hive/issues/2805), [security threat model](security-threat-model.md), [ADR-0008](adr/0008-ioscan-untrusted-input.md) |
+| Intent verification | Tier-based change authorization is in the merge-gate path; trajectory-integrated intent-alignment review remains the next slice. | [#2803](https://github.com/kubestellar/hive/issues/2803), [intent verification](intent-verification.md) |
+| Review fan-out | Structured review reports and deterministic aggregation are in place; scheduler fan-out to parallel review perspectives is the deferred wiring. | [#2807](https://github.com/kubestellar/hive/issues/2807), [review swarm](review-swarm.md) |
+| Credential-free sandbox kick path | Move agent execution toward no live token and no direct network in the sandbox, with trusted host-side post-steps retaining the MITM proxy as an outer layer. | [#2804](https://github.com/kubestellar/hive/issues/2804), [security threat model](security-threat-model.md#known-gaps-and-roadmap) |
+| Hub-hosted lite execution | Extend the current zero-secret `hivectl enroll OWNER/REPO` advisory enrollment into hub-hosted execution for low-friction adoption. | [#2808](https://github.com/kubestellar/hive/issues/2808), [lite enrollment](lite-enrollment.md) |
+| Retrospective learning lane | Build from deterministic post-completion advisory beads toward LLM-assisted retro summaries and knowledge extraction. | [#2809](https://github.com/kubestellar/hive/issues/2809), [retro lane](retro-lane.md) |
+
+## Next
+
+| Work | Outcome | Tracking |
+| --- | --- | --- |
+| Model-based injection classifier | Add a probabilistic classifier beside deterministic `ioscan`, with fail-closed policy choices for high-risk inputs. | [#2805](https://github.com/kubestellar/hive/issues/2805), [security threat model](security-threat-model.md#known-gaps-and-roadmap) |
+| ADR back-fill for remaining subsystems | Capture decisions for the knowledge system, skill registry, CEL/channel triggers, and hub/spoke mechanics so architecture docs stay auditable. | [#2811](https://github.com/kubestellar/hive/issues/2811), [ADR index](adr/README.md), [knowledge design](design/knowledge-system.md), [agent configuration](agent-configuration.md) |
+| Docs site publication | Turn `v2/docs/` into a published, navigable documentation site. This PR creates the index; the MkDocs/site pipeline remains deferred. | [#2811](https://github.com/kubestellar/hive/issues/2811), [docs index](README.md) |
+| GitLab through `pkg/forge` | Move more GitHub-specific operations behind the forge abstraction and add GitLab support incrementally rather than forking the scheduler. | [ADR-0005](adr/0005-forge-abstraction.md), [#2812](https://github.com/kubestellar/hive/issues/2812) |
+
+## Later
+
+| Work | Outcome | Tracking |
+| --- | --- | --- |
+| Cross-forge orchestration | Coordinate issues, merge requests, policy, and evidence across GitHub, GitLab, and Forgejo/Gitea-style forges. | [ADR-0005](adr/0005-forge-abstraction.md) |
+| Memory and learning maturation | Turn retro findings and curated knowledge into durable, testable priming without hidden or unauditable agent memory. | [knowledge design](design/knowledge-system.md), [retro lane](retro-lane.md) |
+| Kubernetes-native agent sandboxes | Graduate from tmux/container execution toward k8s-native, policy-isolated agent workloads where that complexity is justified. | [architecture](architecture.md), [security threat model](security-threat-model.md) |
+
+## Reading this roadmap
+
+- **Now** does not mean all work is complete; it means active phase-2 work or
+  freshly merged foundations with known wiring still in progress.
+- **Next** items are expected follow-ups, not release commitments.
+- **Later** items are strategic directions that may split into narrower issues
+  before implementation.


### PR DESCRIPTION
## Summary
- add v2/docs/roadmap.md with directional Now / Next / Later roadmap tied to #2812 and tracked catch-up issues
- add v2/docs/landscape.md comparing Hive with Fullsend, single-agent tools, hosted services, and research harnesses
- add v2/docs/README.md as a community-facing docs index and link roadmap/landscape from architecture.md and the root README

Part of #2811.

Deferred: MkDocs/docs-site publication pipeline.

## Validation
- verified local markdown links in README.md, v2/docs/architecture.md, v2/docs/README.md, v2/docs/roadmap.md, and v2/docs/landscape.md
- ran git diff --check