### PR TITLE
✨ feat(retro): LLM root-cause analysis feeding the knowledge graph

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -3733,12 +3733,19 @@ func main() {
 			MaxKicks:            cfg.Retro.MaxKicks,
 			LongStallDays:       cfg.Retro.LongStallDays,
 			RecentClosedWindowS: cfg.Retro.RecentClosedWindowS,
+			AnalysisModel:       cfg.Retro.AnalysisModel,
+			AnalysisEndpoint:    cfg.Governor.LiteLLM.ResolveEndpoint(),
+			AnalysisAPIKey:      cfg.Governor.LiteLLM.ResolveAPIKey(),
 		}, logger)
+		if knowledgeAPI != nil {
+			retroLane.SetKnowledgeSink(knowledgeAPI)
+		}
 		logger.Info("retro lane enabled",
 			"scan_interval_s", cfg.Retro.ScanIntervalS,
 			"max_fix_attempts", cfg.Retro.MaxFixAttempts,
 			"max_kicks", cfg.Retro.MaxKicks,
-			"long_stall_days", cfg.Retro.LongStallDays)
+			"long_stall_days", cfg.Retro.LongStallDays,
+			"analysis_enabled", cfg.Retro.AnalysisModel != "")
 	}
 
 	logger.Info("entering governor loop", "interval_seconds", cfg.Governor.EvalIntervalS)

--- a/v2/docs/retro-lane.md
+++ b/v2/docs/retro-lane.md
@@ -1,8 +1,8 @@
 # Retro lane
 
-The retro lane is a deterministic, post-completion analysis pass for Hive work. It is disabled by default (`retro.enabled: false`) so existing hives see no behavior change unless operators opt in.
+The retro lane is a post-completion analysis pass for Hive work. It is disabled by default (`retro.enabled: false`) so existing hives see no behavior change unless operators opt in. LLM analysis is separately opt-in with `retro.analysis_model`; the empty default preserves phase-1 deterministic-only behavior.
 
-When enabled, the lane runs from the governor tick on its own scan interval. It scans done/closed beads that have a closed or merged PR association in bead metadata or the lifecycle timeline, reconstructs a compact `RetroRecord`, and applies rule-based pattern detection only. It does not call an LLM and it does not post to GitHub.
+When enabled, the lane runs from the governor tick on its own scan interval. It scans done/closed beads that have a closed or merged PR association in bead metadata or the lifecycle timeline, reconstructs a compact `RetroRecord`, and applies rule-based pattern detection. It does not post to GitHub.
 
 ## Reconstructed record
 
@@ -25,6 +25,23 @@ Named threshold defaults are:
 
 Each finding is filed as an `advisory` bead attributed to actor `retro`, using the existing advisory-bead digest path. Source beads are marked with `retro_analyzed_at` after analysis to avoid duplicate findings.
 
-## Follow-ups
+## Optional LLM analysis
 
-LLM-powered retrospective summaries and durable knowledge-graph lesson extraction are intentionally deferred. This PR provides the deterministic foundation and local advisory-bead feedback loop only.
+Set `retro.analysis_model` to a model served by `governor.litellm` to enable bounded model analysis. The lane only calls the model for records that already triggered deterministic findings, keeping cost proportional to actionable anomalies. The prompt contains the compact record and finding types/details with hard truncation bounds.
+
+The model must return structured JSON:
+
+- `root_cause_hypothesis`
+- `process_improvement`
+- `generalizable`
+- `generalizable_lesson`
+
+Invalid JSON is retried up to the shared structured-output retry bound. Transport, timeout, or validation failures fail open: deterministic advisory beads are still filed without model enrichment.
+
+When analysis succeeds, advisory bead notes include a clearly marked “Model-generated retro analysis” section with the root-cause hypothesis and actionable process improvement.
+
+## Knowledge graph feeding
+
+If the model marks a lesson generalizable, Hive quality-gates it before ingestion: length bounds are enforced and secret-like token patterns are rejected with the shared log-scrub detector. Accepted lessons are stored as `pattern` facts tagged `retro` and `lesson`, attributed to source `retro` with the source bead and PR reference. Existing knowledge search/vault deduplication is checked first; when no matching fact exists, the normalized lesson hash keys the fact slug to avoid duplicates.
+
+If a graph store is attached (`/data/graph/knowledge.db`), the fact gets a `derived_from` edge to the retro source reference. The fact is then available to the primer like other knowledge entries.

--- a/v2/hive.yaml.example
+++ b/v2/hive.yaml.example
@@ -190,9 +190,11 @@ governor:
   #   api_key_env: HIVE_BOB_API_KEY       # env var NAME holding the key (default)
   #   api_key_file: /secrets/bob_api_key  # or a mounted key file (default path)
 
-# Retro lane — deterministic post-completion analysis. Disabled by default;
+# Retro lane — post-completion analysis. Disabled by default;
 # when enabled it scans recently completed beads with closed/merged PR metadata
 # and files rule-based findings as local advisory beads (no GitHub posts).
+# Optional analysis_model enables bounded LLM root-cause/improvement analysis
+# via governor.litellm and feeds generalized lessons into the knowledge graph.
 # retro:
 #   enabled: false
 #   scan_interval_s: 3600
@@ -200,6 +202,7 @@ governor:
 #   max_kicks: 5
 #   long_stall_days: 7
 #   recent_closed_window_s: 604800
+#   analysis_model: ""   # empty disables all LLM calls (default)
 
 # Review swarm merge gate — optional structured multi-perspective PR review.
 # Default is false to preserve existing merge eligibility behavior; when true,

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -227,18 +227,21 @@ type PlanningConfig struct {
 	PlanFromLabel *bool `yaml:"plan_from_label,omitempty" json:"plan_from_label,omitempty"`
 }
 
-// RetroConfig gates the deterministic post-completion retro lane. It is off by
+// RetroConfig gates the post-completion retro lane. It is off by
 // default: an absent `retro:` block or `enabled: false` yields zero behavior
 // change. When enabled, the lane periodically scans done/closed beads that have
 // a closed/merged PR association, reconstructs a compact trajectory from local
-// ledgers, and files rule-based findings as advisory beads.
+// ledgers, and files rule-based findings as advisory beads. analysis_model is
+// additionally opt-in; when empty, no model is called and only deterministic
+// phase-1 behavior runs.
 type RetroConfig struct {
-	Enabled             bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
-	ScanIntervalS       int  `yaml:"scan_interval_s,omitempty" json:"scan_interval_s,omitempty"`
-	MaxFixAttempts      int  `yaml:"max_fix_attempts,omitempty" json:"max_fix_attempts,omitempty"`
-	MaxKicks            int  `yaml:"max_kicks,omitempty" json:"max_kicks,omitempty"`
-	LongStallDays       int  `yaml:"long_stall_days,omitempty" json:"long_stall_days,omitempty"`
-	RecentClosedWindowS int  `yaml:"recent_closed_window_s,omitempty" json:"recent_closed_window_s,omitempty"`
+	Enabled             bool   `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	ScanIntervalS       int    `yaml:"scan_interval_s,omitempty" json:"scan_interval_s,omitempty"`
+	MaxFixAttempts      int    `yaml:"max_fix_attempts,omitempty" json:"max_fix_attempts,omitempty"`
+	MaxKicks            int    `yaml:"max_kicks,omitempty" json:"max_kicks,omitempty"`
+	LongStallDays       int    `yaml:"long_stall_days,omitempty" json:"long_stall_days,omitempty"`
+	RecentClosedWindowS int    `yaml:"recent_closed_window_s,omitempty" json:"recent_closed_window_s,omitempty"`
+	AnalysisModel       string `yaml:"analysis_model,omitempty" json:"analysis_model,omitempty"`
 }
 
 // planFromLabelMinACMM is the lowest ACMM level at which the label trigger fires

--- a/v2/pkg/knowledge/retro_lesson.go
+++ b/v2/pkg/knowledge/retro_lesson.go
@@ -1,0 +1,181 @@
+package knowledge
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/logscrub"
+)
+
+const (
+	RetroLessonMinChars   = 25
+	RetroLessonMaxChars   = 500
+	retroLessonConfidence = 0.7
+	retroLessonLayer      = "project"
+	retroLessonSearchCap  = 5
+)
+
+// RetroLesson is a durable, model-generated process lesson produced by the
+// retro lane from a completed bead/PR trajectory.
+type RetroLesson struct {
+	Lesson     string
+	SourceBead string
+	SourcePR   string
+	SourceDate time.Time
+}
+
+// IngestRetroLesson quality-gates, deduplicates, and stores one retro lesson
+// as a normal knowledge fact. It returns created=false for rejected or duplicate
+// lessons so retro analysis can fail open without affecting deterministic beads.
+func (k *KnowledgeAPI) IngestRetroLesson(ctx context.Context, lesson RetroLesson) (slug string, created bool, err error) {
+	if k == nil {
+		return "", false, nil
+	}
+	body := strings.TrimSpace(lesson.Lesson)
+	if !ValidRetroLesson(body) {
+		return "", false, nil
+	}
+	key := normalizedRetroLessonKey(body)
+	slug = "retro-lesson-" + shortHash(key)
+	if _, err := k.VaultFact(slug); err == nil {
+		return slug, false, nil
+	}
+	for _, existing := range k.SearchAllWithVaults(ctx, body, "", retroLessonSearchCap) {
+		if nearRetroLessonKey(normalizedRetroLessonKey(existing.Body), key) || nearRetroLessonKey(normalizedRetroLessonKey(existing.Title), key) {
+			return existing.Slug, false, nil
+		}
+	}
+
+	title := retroLessonTitle(body)
+	fact := ExtractedFact{
+		Title:      title,
+		Body:       body,
+		Type:       FactPattern,
+		Confidence: retroLessonConfidence,
+		Tags:       []string{"retro", "lesson"},
+		SourcePR:   retroSource(lesson),
+		SourceDate: lesson.SourceDate,
+	}
+	if fact.SourceDate.IsZero() {
+		fact.SourceDate = time.Now().UTC()
+	}
+
+	if client := k.clientForLayer(LayerType(retroLessonLayer)); client != nil {
+		if err := client.IngestFacts(ctx, []ExtractedFact{fact}); err != nil {
+			return "", false, err
+		}
+		k.addRetroGraphTriple(slug, lesson)
+		return slug, true, nil
+	}
+
+	if err := k.writeRetroLessonFile(slug, fact); err != nil {
+		return "", false, err
+	}
+	k.addRetroGraphTriple(slug, lesson)
+	return slug, true, nil
+}
+
+func ValidRetroLesson(lesson string) bool {
+	lesson = strings.TrimSpace(lesson)
+	n := len([]rune(lesson))
+	if n < RetroLessonMinChars || n > RetroLessonMaxChars {
+		return false
+	}
+	return !logscrub.TokenPattern.MatchString(lesson)
+}
+
+func (k *KnowledgeAPI) writeRetroLessonFile(slug string, fact ExtractedFact) error {
+	dir := filepath.Join(localKnowledgeDir, retroLessonLayer)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating retro lesson dir: %w", err)
+	}
+	path := filepath.Join(dir, strings.ReplaceAll(slug+".md", "/", "_"))
+	var buf strings.Builder
+	buf.WriteString("---\n")
+	fmt.Fprintf(&buf, "title: %s\n", fact.Title)
+	fmt.Fprintf(&buf, "type: %s\n", string(fact.Type))
+	fmt.Fprintf(&buf, "layer: %s\n", retroLessonLayer)
+	fmt.Fprintf(&buf, "confidence: %.2f\n", fact.Confidence)
+	fmt.Fprintf(&buf, "tags: [%s]\n", strings.Join(fact.Tags, ", "))
+	fmt.Fprintf(&buf, "source: %s\n", fact.SourcePR)
+	fmt.Fprintf(&buf, "synthesized: %s\n", fact.SourceDate.UTC().Format(time.RFC3339))
+	buf.WriteString("---\n\n")
+	buf.WriteString(fact.Body)
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, []byte(buf.String()), 0o644); err != nil {
+		return fmt.Errorf("writing retro lesson file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("renaming retro lesson file: %w", err)
+	}
+	k.triggerVaultReindex(dir)
+	return nil
+}
+
+func (k *KnowledgeAPI) addRetroGraphTriple(slug string, lesson RetroLesson) {
+	gs := k.GraphStore()
+	if gs == nil {
+		return
+	}
+	source := strings.TrimSpace(lesson.SourcePR)
+	if source == "" {
+		source = strings.TrimSpace(lesson.SourceBead)
+	}
+	if source == "" {
+		return
+	}
+	if err := gs.AddTriple(Triple{Subject: slug, Predicate: PredicateDerivedFrom, Object: "retro:" + source}); err != nil {
+		k.logger.Warn("failed to add retro lesson graph triple", "slug", slug, "source", source, "error", err)
+	}
+}
+
+func retroLessonTitle(body string) string {
+	words := strings.Fields(body)
+	if len(words) > 12 {
+		words = words[:12]
+	}
+	title := strings.Join(words, " ")
+	title = strings.Trim(title, " .")
+	if title == "" {
+		title = "Generalized retro lesson"
+	}
+	return "Retro lesson: " + title
+}
+
+var nonAlphaNum = regexp.MustCompile(`[^a-z0-9]+`)
+
+func normalizedRetroLessonKey(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = nonAlphaNum.ReplaceAllString(s, " ")
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func nearRetroLessonKey(existing, candidate string) bool {
+	if existing == "" || candidate == "" {
+		return false
+	}
+	return existing == candidate || strings.Contains(existing, candidate) || strings.Contains(candidate, existing)
+}
+
+func shortHash(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])[:12]
+}
+
+func retroSource(lesson RetroLesson) string {
+	parts := []string{"retro"}
+	if lesson.SourceBead != "" {
+		parts = append(parts, "bead:"+lesson.SourceBead)
+	}
+	if lesson.SourcePR != "" {
+		parts = append(parts, "pr:"+lesson.SourcePR)
+	}
+	return strings.Join(parts, " ")
+}

--- a/v2/pkg/knowledge/retro_lesson_test.go
+++ b/v2/pkg/knowledge/retro_lesson_test.go
@@ -1,0 +1,75 @@
+package knowledge
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestValidRetroLessonGatesLengthAndSecrets(t *testing.T) {
+	if ValidRetroLesson("too short") {
+		t.Fatal("short lesson should be rejected")
+	}
+	if ValidRetroLesson("Store this token ghp_abcdefghijklmnopqrstuvwxyz in documentation for retries") {
+		t.Fatal("secret-like lesson should be rejected")
+	}
+	if !ValidRetroLesson("Run targeted validation before opening PRs for CI-sensitive changes.") {
+		t.Fatal("valid process lesson should pass")
+	}
+}
+
+func TestIngestRetroLessonDeduplicates(t *testing.T) {
+	var ingests int
+	var stored []ExtractedFact
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/search":
+			if len(stored) == 0 {
+				_ = json.NewEncoder(w).Encode(searchResponse{Results: []searchResult{}})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(searchResponse{Results: []searchResult{{
+				Slug:       "retro-lesson-existing",
+				Title:      stored[0].Title,
+				Snippet:    stored[0].Body,
+				Type:       string(stored[0].Type),
+				Confidence: stored[0].Confidence,
+			}}})
+		case "/api/ingest":
+			ingests++
+			body, _ := io.ReadAll(r.Body)
+			if err := json.Unmarshal(body, &stored); err != nil {
+				t.Fatalf("decode ingest: %v", err)
+			}
+			w.WriteHeader(http.StatusCreated)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	api := NewKnowledgeAPI([]LayerConfig{{Type: LayerProject, URL: srv.URL}}, KnowledgeConfig{Enabled: true}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	lesson := RetroLesson{
+		Lesson:     "Run targeted validation before opening PRs when changes affect CI-sensitive code paths.",
+		SourceBead: "bead-1",
+		SourcePR:   "kubestellar/hive#42",
+		SourceDate: time.Now().UTC(),
+	}
+	if _, created, err := api.IngestRetroLesson(context.Background(), lesson); err != nil || !created {
+		t.Fatalf("first ingest created=%v err=%v", created, err)
+	}
+	if len(stored) != 1 || stored[0].SourcePR != "retro bead:bead-1 pr:kubestellar/hive#42" {
+		t.Fatalf("stored payload = %#v", stored)
+	}
+	if _, created, err := api.IngestRetroLesson(context.Background(), lesson); err != nil || created {
+		t.Fatalf("second ingest created=%v err=%v, want duplicate skip", created, err)
+	}
+	if ingests != 1 {
+		t.Fatalf("ingests = %d, want 1", ingests)
+	}
+}

--- a/v2/pkg/retro/analysis.go
+++ b/v2/pkg/retro/analysis.go
@@ -1,0 +1,233 @@
+package retro
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/outputschema"
+)
+
+const (
+	DefaultAnalysisMaxTokens = 350
+
+	analysisTimeout       = 30 * time.Second
+	maxRecordTitleChars   = 180
+	maxFindingDetailChars = 240
+	maxPromptChars        = 6000
+
+	MaxAnalysisFieldChars = 500
+	MinLessonChars        = 25
+	MaxLessonChars        = 500
+)
+
+// Analysis is the structured model-generated retrospective for a deterministic
+// retro finding set.
+type Analysis struct {
+	RootCauseHypothesis string `json:"root_cause_hypothesis"`
+	ProcessImprovement  string `json:"process_improvement"`
+	Generalizable       bool   `json:"generalizable"`
+	GeneralizableLesson string `json:"generalizable_lesson"`
+}
+
+type analysisClient interface {
+	Complete(ctx context.Context, messages []chatMessage, maxTokens int) (string, error)
+}
+
+type Analyzer struct {
+	client analysisClient
+	model  string
+}
+
+func NewAnalyzer(endpoint, apiKey, model string) (*Analyzer, error) {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return nil, nil
+	}
+	endpoint = strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	if endpoint == "" {
+		return nil, fmt.Errorf("retro analysis: no model endpoint resolved")
+	}
+	return &Analyzer{client: &openAIChatClient{endpoint: endpoint, apiKey: apiKey, model: model, http: &http.Client{Timeout: analysisTimeout}}, model: model}, nil
+}
+
+func newAnalyzerWithClient(model string, client analysisClient) *Analyzer {
+	return &Analyzer{model: strings.TrimSpace(model), client: client}
+}
+
+func (a *Analyzer) Analyze(ctx context.Context, record RetroRecord, findings []Finding) (Analysis, error) {
+	if a == nil || a.client == nil || strings.TrimSpace(a.model) == "" {
+		return Analysis{}, nil
+	}
+	messages := buildAnalysisPrompt(record, findings)
+	var lastErr error
+	for attempt := 0; attempt <= outputschema.MaxValidationRetries; attempt++ {
+		reply, err := a.client.Complete(ctx, messages, DefaultAnalysisMaxTokens)
+		if err != nil {
+			return Analysis{}, err
+		}
+		analysis, err := ParseAnalysis(reply)
+		if err == nil {
+			return analysis, nil
+		}
+		lastErr = err
+		messages = append(messages, chatMessage{Role: "user", Content: correctiveAnalysisPrompt(err)})
+	}
+	return Analysis{}, lastErr
+}
+
+func buildAnalysisPrompt(record RetroRecord, findings []Finding) []chatMessage {
+	system := "You are Hive's retro analyst. Analyze only the supplied compact post-completion record and deterministic finding types. " +
+		"Return ONLY one JSON object with keys root_cause_hypothesis, process_improvement, generalizable, generalizable_lesson. " +
+		"Use concise, non-secret, process-level language. Do not invent facts. If the lesson is too specific to this bead, set generalizable=false and generalizable_lesson=\"\"."
+	var b strings.Builder
+	fmt.Fprintf(&b, "RETRO_RECORD\nbead_id: %s\ntitle: %s\ntype: %s\nactor: %s\nissue: %s\npr: %s\npr_state: %s\nkicks_received: %d\nci_failures: %d\nfix_attempts: %d\ndrift_pauses: %d\nclaim_to_close: %s\n\n",
+		record.BeadID, truncate(record.Title, maxRecordTitleChars), record.Type, record.Actor, record.IssueRef, record.PRRef, record.PRState,
+		record.KicksReceived, record.CIFailureCount, record.FixAttempts, record.DriftPauses, record.ClaimToClose.String())
+	b.WriteString("DETERMINISTIC_FINDINGS\n")
+	for _, f := range findings {
+		fmt.Fprintf(&b, "- pattern: %s\n  severity: %s\n  detail: %s\n", f.Pattern, f.Severity, truncate(f.Detail, maxFindingDetailChars))
+	}
+	user := truncate(b.String(), maxPromptChars)
+	return []chatMessage{{Role: "system", Content: system}, {Role: "user", Content: user}}
+}
+
+func ParseAnalysis(content string) (Analysis, error) {
+	raw := extractJSONObject(content)
+	if raw == "" {
+		return Analysis{}, fmt.Errorf("no JSON object in retro analysis reply")
+	}
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var a Analysis
+	if err := dec.Decode(&a); err != nil {
+		return Analysis{}, fmt.Errorf("parse retro analysis: %w", err)
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		return Analysis{}, fmt.Errorf("retro analysis must contain exactly one JSON object")
+	}
+	a.RootCauseHypothesis = strings.TrimSpace(a.RootCauseHypothesis)
+	a.ProcessImprovement = strings.TrimSpace(a.ProcessImprovement)
+	a.GeneralizableLesson = strings.TrimSpace(a.GeneralizableLesson)
+	if a.RootCauseHypothesis == "" {
+		return Analysis{}, fmt.Errorf("root_cause_hypothesis is required")
+	}
+	if a.ProcessImprovement == "" {
+		return Analysis{}, fmt.Errorf("process_improvement is required")
+	}
+	if runeLen(a.RootCauseHypothesis) > MaxAnalysisFieldChars {
+		return Analysis{}, fmt.Errorf("root_cause_hypothesis must be at most %d characters", MaxAnalysisFieldChars)
+	}
+	if runeLen(a.ProcessImprovement) > MaxAnalysisFieldChars {
+		return Analysis{}, fmt.Errorf("process_improvement must be at most %d characters", MaxAnalysisFieldChars)
+	}
+	if a.Generalizable {
+		if runeLen(a.GeneralizableLesson) < MinLessonChars {
+			return Analysis{}, fmt.Errorf("generalizable_lesson must be at least %d characters when generalizable", MinLessonChars)
+		}
+		if runeLen(a.GeneralizableLesson) > MaxLessonChars {
+			return Analysis{}, fmt.Errorf("generalizable_lesson must be at most %d characters", MaxLessonChars)
+		}
+	} else {
+		a.GeneralizableLesson = ""
+	}
+	return a, nil
+}
+
+func correctiveAnalysisPrompt(err error) string {
+	return fmt.Sprintf("Your previous retro analysis was invalid: %s. Return exactly one JSON object with required string fields root_cause_hypothesis and process_improvement, boolean generalizable, and string generalizable_lesson. Keep each string within documented bounds. Hive will retry validation at most %d times.", err, outputschema.MaxValidationRetries)
+}
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openAIChatClient struct {
+	endpoint string
+	apiKey   string
+	model    string
+	http     *http.Client
+}
+
+func (c *openAIChatClient) Complete(ctx context.Context, messages []chatMessage, maxTokens int) (string, error) {
+	body, err := json.Marshal(chatRequest{Model: c.model, Messages: messages, Temperature: 0, MaxTokens: maxTokens})
+	if err != nil {
+		return "", fmt.Errorf("marshal retro analysis request: %w", err)
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, analysisTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, c.endpoint+"/v1/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("build retro analysis request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("retro analysis request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("retro analyzer returned %d", resp.StatusCode)
+	}
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("read retro analysis response: %w", err)
+	}
+	var cr chatResponse
+	if err := json.Unmarshal(respBody, &cr); err != nil {
+		return "", fmt.Errorf("decode retro analysis response: %w", err)
+	}
+	if len(cr.Choices) == 0 {
+		return "", fmt.Errorf("retro analyzer returned no choices")
+	}
+	return cr.Choices[0].Message.Content, nil
+}
+
+type chatRequest struct {
+	Model       string        `json:"model,omitempty"`
+	Messages    []chatMessage `json:"messages"`
+	Temperature float64       `json:"temperature"`
+	MaxTokens   int           `json:"max_tokens"`
+}
+
+type chatResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+}
+
+func extractJSONObject(s string) string {
+	start := strings.IndexByte(s, '{')
+	end := strings.LastIndexByte(s, '}')
+	if start < 0 || end < 0 || end < start {
+		return ""
+	}
+	return s[start : end+1]
+}
+
+func truncate(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if max <= 0 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max])
+}
+
+func runeLen(s string) int {
+	return len([]rune(strings.TrimSpace(s)))
+}

--- a/v2/pkg/retro/retro.go
+++ b/v2/pkg/retro/retro.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kubestellar/hive/v2/pkg/beads"
 	"github.com/kubestellar/hive/v2/pkg/escalation"
+	"github.com/kubestellar/hive/v2/pkg/knowledge"
 	"github.com/kubestellar/hive/v2/pkg/timeline"
 )
 
@@ -33,6 +34,9 @@ const (
 	metadataSourceIssue         = "retro_source_issue"
 	metadataPattern             = "retro_pattern"
 	metadataRecordWallClock     = "retro_wall_clock"
+	metadataAnalysisRootCause   = "retro_analysis_root_cause"
+	metadataAnalysisImprovement = "retro_analysis_improvement"
+	metadataLessonSlug          = "retro_lesson_slug"
 	PatternExcessiveFixAttempts = "excessive_fix_attempts"
 	PatternExcessiveKicks       = "excessive_kicks"
 	PatternLongStall            = "long_stall"
@@ -46,6 +50,9 @@ type Config struct {
 	MaxKicks            int
 	LongStallDays       int
 	RecentClosedWindowS int
+	AnalysisModel       string
+	AnalysisEndpoint    string
+	AnalysisAPIKey      string
 }
 
 type Thresholds struct {
@@ -84,11 +91,17 @@ type AttemptReader interface {
 	Attempts(repo string, number int) int
 }
 
+type KnowledgeSink interface {
+	IngestRetroLesson(ctx context.Context, lesson knowledge.RetroLesson) (slug string, created bool, err error)
+}
+
 type Lane struct {
 	stores        map[string]*beads.Store
 	advisoryStore *beads.Store
 	timeline      *timeline.Store
 	attempts      AttemptReader
+	analyzer      *Analyzer
+	knowledge     KnowledgeSink
 	logger        *slog.Logger
 	interval      time.Duration
 	thresholds    Thresholds
@@ -104,16 +117,29 @@ func NewLane(stores map[string]*beads.Store, advisoryStore *beads.Store, tl *tim
 	if logger == nil {
 		logger = slog.Default()
 	}
+	analyzer, err := NewAnalyzer(cfg.AnalysisEndpoint, cfg.AnalysisAPIKey, cfg.AnalysisModel)
+	if err != nil {
+		logger.Warn("retro: LLM analysis disabled", "error", err)
+	}
 	return &Lane{
 		stores:        stores,
 		advisoryStore: advisoryStore,
 		timeline:      tl,
 		attempts:      attempts,
+		analyzer:      analyzer,
 		logger:        logger,
 		interval:      time.Duration(intervalS) * time.Second,
 		thresholds:    thresholdsFromConfig(cfg),
 		recentWindow:  time.Duration(cfg.RecentClosedWindowS) * time.Second,
 	}
+}
+
+func (l *Lane) SetAnalyzer(analyzer *Analyzer) {
+	l.analyzer = analyzer
+}
+
+func (l *Lane) SetKnowledgeSink(sink KnowledgeSink) {
+	l.knowledge = sink
 }
 
 func (l *Lane) Due(now time.Time) bool {
@@ -145,8 +171,10 @@ func (l *Lane) Run(ctx context.Context) int {
 				continue
 			}
 			findings := Detect(record, l.thresholds)
+			analysis := l.analyze(ctx, record, findings)
+			l.ingestLesson(ctx, record, analysis)
 			for _, f := range findings {
-				if l.createAdvisory(record, f) {
+				if l.createAdvisory(record, f, analysis) {
 					created++
 				}
 			}
@@ -195,7 +223,38 @@ func completedAt(b *beads.Bead) time.Time {
 	return time.Time{}
 }
 
-func (l *Lane) createAdvisory(r RetroRecord, f Finding) bool {
+func (l *Lane) analyze(ctx context.Context, r RetroRecord, findings []Finding) *Analysis {
+	if len(findings) == 0 || l.analyzer == nil {
+		return nil
+	}
+	analysis, err := l.analyzer.Analyze(ctx, r, findings)
+	if err != nil {
+		l.logger.Warn("retro: LLM analysis skipped", "source_bead", r.BeadID, "error", err)
+		return nil
+	}
+	return &analysis
+}
+
+func (l *Lane) ingestLesson(ctx context.Context, r RetroRecord, analysis *Analysis) {
+	if analysis == nil || !analysis.Generalizable || l.knowledge == nil {
+		return
+	}
+	slug, created, err := l.knowledge.IngestRetroLesson(ctx, knowledge.RetroLesson{
+		Lesson:     analysis.GeneralizableLesson,
+		SourceBead: r.BeadID,
+		SourcePR:   r.PRRef,
+		SourceDate: r.ClosedAt,
+	})
+	if err != nil {
+		l.logger.Warn("retro: lesson ingestion skipped", "source_bead", r.BeadID, "error", err)
+		return
+	}
+	if created {
+		l.logger.Info("retro: lesson ingested", "source_bead", r.BeadID, "slug", slug)
+	}
+}
+
+func (l *Lane) createAdvisory(r RetroRecord, f Finding, analysis *Analysis) bool {
 	if l.openDuplicate(f.Title) {
 		return false
 	}
@@ -216,12 +275,35 @@ func (l *Lane) createAdvisory(r RetroRecord, f Finding) bool {
 		metadataPattern:         f.Pattern,
 		metadataRecordWallClock: r.ClaimToClose.String(),
 	}
+	if analysis != nil {
+		meta[metadataAnalysisRootCause] = analysis.RootCauseHypothesis
+		meta[metadataAnalysisImprovement] = analysis.ProcessImprovement
+	}
 	for k, v := range meta {
 		if v != "" {
 			_ = l.advisoryStore.SetMetadata(b.ID, k, v)
 		}
 	}
+	if analysis != nil {
+		_ = l.advisoryStore.Update(b.ID, func(bd *beads.Bead) {
+			bd.Notes = advisoryNotes(f, analysis)
+		})
+	}
 	return true
+}
+
+func advisoryNotes(f Finding, analysis *Analysis) string {
+	var b strings.Builder
+	b.WriteString(f.Detail)
+	if analysis == nil {
+		return b.String()
+	}
+	b.WriteString("\n\nModel-generated retro analysis:\n")
+	b.WriteString("- Root-cause hypothesis: ")
+	b.WriteString(analysis.RootCauseHypothesis)
+	b.WriteString("\n- Actionable process improvement: ")
+	b.WriteString(analysis.ProcessImprovement)
+	return b.String()
 }
 
 func (l *Lane) openDuplicate(title string) bool {

--- a/v2/pkg/retro/retro_test.go
+++ b/v2/pkg/retro/retro_test.go
@@ -2,6 +2,7 @@ package retro
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/beads"
+	"github.com/kubestellar/hive/v2/pkg/knowledge"
 	"github.com/kubestellar/hive/v2/pkg/timeline"
 )
 
@@ -212,6 +214,132 @@ func TestLaneFilesAdvisoryOnceAndMarksAnalyzed(t *testing.T) {
 	}
 	if got.Meta(metadataAnalyzedAt) == "" {
 		t.Fatalf("source bead missing %s", metadataAnalyzedAt)
+	}
+}
+
+func TestBuildAnalysisPromptBounds(t *testing.T) {
+	rec := RetroRecord{
+		BeadID:         "b1",
+		Title:          strings.Repeat("title ", 200),
+		Type:           beads.TypeTask,
+		Actor:          "scanner",
+		IssueRef:       "o/r#1",
+		PRRef:          "o/r#2",
+		PRState:        "merged",
+		KicksReceived:  6,
+		CIFailureCount: 5,
+		FixAttempts:    4,
+		DriftPauses:    1,
+		ClaimToClose:   9 * 24 * time.Hour,
+	}
+	findings := []Finding{{Pattern: PatternExcessiveFixAttempts, Severity: "medium", Detail: strings.Repeat("detail ", 2000)}}
+	msgs := buildAnalysisPrompt(rec, findings)
+	if len(msgs) != 2 {
+		t.Fatalf("messages = %d, want 2", len(msgs))
+	}
+	if len([]rune(msgs[1].Content)) > maxPromptChars {
+		t.Fatalf("prompt length = %d, want <= %d", len([]rune(msgs[1].Content)), maxPromptChars)
+	}
+	if strings.Contains(msgs[1].Content, strings.Repeat("title ", 50)) {
+		t.Fatal("record title was not compacted")
+	}
+}
+
+type fakeAnalysisClient struct {
+	replies []string
+	err     error
+	calls   int
+}
+
+func (f *fakeAnalysisClient) Complete(context.Context, []chatMessage, int) (string, error) {
+	f.calls++
+	if f.err != nil {
+		return "", f.err
+	}
+	if f.calls > len(f.replies) {
+		return f.replies[len(f.replies)-1], nil
+	}
+	return f.replies[f.calls-1], nil
+}
+
+func TestAnalysisRetriesInvalidJSON(t *testing.T) {
+	client := &fakeAnalysisClient{replies: []string{
+		`{"root_cause_hypothesis":"","process_improvement":"x","generalizable":false,"generalizable_lesson":""}`,
+		`{"root_cause_hypothesis":"CI failures were discovered late.","process_improvement":"Add pre-submit checks before opening PRs.","generalizable":true,"generalizable_lesson":"Run the same validation locally before opening PRs so repeated CI-only failures are caught earlier."}`,
+	}}
+	analyzer := newAnalyzerWithClient("m", client)
+	got, err := analyzer.Analyze(context.Background(), RetroRecord{BeadID: "b"}, []Finding{{Pattern: PatternExcessiveFixAttempts}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.calls != 2 {
+		t.Fatalf("calls = %d, want 2", client.calls)
+	}
+	if !got.Generalizable || got.GeneralizableLesson == "" {
+		t.Fatalf("unexpected analysis: %#v", got)
+	}
+}
+
+func TestLaneFailOpenOnAnalysisError(t *testing.T) {
+	source := newStore(t, "analysis-error-source")
+	retroStore := newStore(t, "analysis-error-retro")
+	b, err := source.Create("hard issue", beads.TypeTask, beads.PriorityMedium, "scanner", "kubestellar/hive#2809")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := source.Update(b.ID, func(bd *beads.Bead) {
+		bd.Status = beads.StatusClosed
+		bd.Metadata = map[string]interface{}{"pr_ref": "kubestellar/hive#42", "pr_state": "merged", "fix_attempts": "3"}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	lane := NewLane(map[string]*beads.Store{"scanner": source, Actor: retroStore}, retroStore, nil, nil, Config{ScanIntervalS: 1}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	lane.SetAnalyzer(newAnalyzerWithClient("m", &fakeAnalysisClient{err: errors.New("model down")}))
+	if created := lane.Run(context.Background()); created != 1 {
+		t.Fatalf("created = %d, want deterministic advisory despite model error", created)
+	}
+	advisories := retroStore.List(beads.ListFilter{})
+	if advisories[0].Meta(metadataAnalysisRootCause) != "" || strings.Contains(advisories[0].Notes, "Model-generated") {
+		t.Fatalf("advisory should not be enriched on model error: %#v", advisories[0])
+	}
+}
+
+type fakeKnowledgeSink struct {
+	lessons []knowledge.RetroLesson
+}
+
+func (f *fakeKnowledgeSink) IngestRetroLesson(_ context.Context, lesson knowledge.RetroLesson) (string, bool, error) {
+	f.lessons = append(f.lessons, lesson)
+	return "retro-lesson-test", true, nil
+}
+
+func TestLaneEnrichesAdvisoryAndFeedsKnowledge(t *testing.T) {
+	source := newStore(t, "analysis-source")
+	retroStore := newStore(t, "analysis-retro")
+	b, err := source.Create("hard issue", beads.TypeTask, beads.PriorityMedium, "scanner", "kubestellar/hive#2809")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := source.Update(b.ID, func(bd *beads.Bead) {
+		bd.Status = beads.StatusClosed
+		bd.Metadata = map[string]interface{}{"pr_ref": "kubestellar/hive#42", "pr_state": "merged", "fix_attempts": "3"}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	client := &fakeAnalysisClient{replies: []string{`{"root_cause_hypothesis":"Validation ran too late.","process_improvement":"Run targeted checks before opening a PR.","generalizable":true,"generalizable_lesson":"Run targeted validation before opening PRs when changes affect CI-sensitive code paths."}`}}
+	sink := &fakeKnowledgeSink{}
+	lane := NewLane(map[string]*beads.Store{"scanner": source, Actor: retroStore}, retroStore, nil, nil, Config{ScanIntervalS: 1}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	lane.SetAnalyzer(newAnalyzerWithClient("m", client))
+	lane.SetKnowledgeSink(sink)
+	if created := lane.Run(context.Background()); created != 1 {
+		t.Fatalf("created = %d, want 1", created)
+	}
+	advisory := retroStore.List(beads.ListFilter{})[0]
+	if advisory.Meta(metadataAnalysisRootCause) == "" || !strings.Contains(advisory.Notes, "Model-generated retro analysis") {
+		t.Fatalf("advisory not enriched: %#v", advisory)
+	}
+	if len(sink.lessons) != 1 || sink.lessons[0].SourcePR != "kubestellar/hive#42" {
+		t.Fatalf("lessons = %#v, want one sourced lesson", sink.lessons)
 	}
 }
 


### PR DESCRIPTION
Part of #2809

## Summary
- Add opt-in `retro.analysis_model` LLM analysis for deterministic retro findings only.
- Enrich retro advisory beads with model-generated root-cause and process-improvement notes while failing open on model errors.
- Feed quality-gated generalized lessons into knowledge facts with retro attribution and deduplication.

## Validation
- `cd v2 && go build ./...`
- `cd v2 && go test ./pkg/retro/... ./pkg/knowledge/... -count=1`
- `cd v2 && go vet ./pkg/retro ./pkg/knowledge ./pkg/config ./cmd/hive`