### PR TITLE
✨ feat(access): make the merger auto-merge label configurable, default lgtm

### DIFF
--- a/v2/cmd/hive/automerge_label_test.go
+++ b/v2/cmd/hive/automerge_label_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/github"
+)
+
+func TestNormalizedAutoMergeLabel(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		label string
+		want  string
+	}{
+		{name: "configured", label: "ship-it", want: "ship-it"},
+		{name: "trims", label: "  ship-it  ", want: "ship-it"},
+		{name: "blank falls back", label: " \t\n ", want: github.AutoMergeQueuedLabel},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizedAutoMergeLabel(tt.label); got != tt.want {
+				t.Fatalf("normalizedAutoMergeLabel(%q) = %q, want %q", tt.label, got, tt.want)
+			}
+		})
+	}
+}

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -4092,7 +4092,7 @@ func runEvalCycle(
 		atomicWrite("/data/last-actionable.json", data)
 	}
 
-	writeMergeEligible(actionable, actionable.Hold, cfg.Project.Org, logger)
+	writeMergeEligible(actionable, actionable.Hold, cfg.Project.Org, cfg.Governor.Labels.AutoMerge, logger)
 
 	shaResult, shaErr := ghClient.EnforceSHAHold(ctx, github.SHAHoldConfig{
 		PrimaryRepo:     cfg.Project.PrimaryRepo,
@@ -4934,12 +4934,13 @@ func applyDuplicatePRGuard(
 	github.ApplyDuplicatePRGuard(ctx, ghClient, claimLedger, hiveIdentity(cfg), actionable, logger)
 }
 
-func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldResult, org string, logger *slog.Logger) {
+func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldResult, org, autoMergeLabel string, logger *slog.Logger) {
 	holdSet := make(map[string]bool)
 	for _, h := range hold.Items {
 		key := fmt.Sprintf("%s/%d", h.Repo, h.Number)
 		holdSet[key] = true
 	}
+	autoMergeLabel = normalizedAutoMergeLabel(autoMergeLabel)
 
 	type eligiblePR struct {
 		Number int      `json:"number"`
@@ -5015,7 +5016,7 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 			} else if l == "dco-signoff: no" {
 				dco = "no"
 			}
-			if strings.EqualFold(l, github.AutoMergeQueuedLabel) {
+			if l == autoMergeLabel {
 				queued = true
 			}
 		}
@@ -5055,6 +5056,13 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 		return
 	}
 	atomicWrite(ciFailingPath, failData)
+}
+
+func normalizedAutoMergeLabel(label string) string {
+	if label = strings.TrimSpace(label); label != "" {
+		return label
+	}
+	return github.AutoMergeQueuedLabel
 }
 
 func atomicWrite(path string, data []byte) {

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -937,6 +937,7 @@ func main() {
 	appAuthState := ghAuth.State
 	if ghClient != nil && len(cfg.Governor.Labels.Exempt) > 0 {
 		ghClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
+		ghClient.SetAutoMergeLabel(cfg.Governor.Labels.AutoMerge)
 	}
 	// Load user token for advisory posting (comments on issues as the logged-in user)
 	var userGHClient atomic.Pointer[github.Client]
@@ -1388,6 +1389,7 @@ func main() {
 			ghClient.SetRepos(cfg.Project.Repos)
 			if len(cfg.Governor.Labels.Exempt) > 0 {
 				ghClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
+				ghClient.SetAutoMergeLabel(cfg.Governor.Labels.AutoMerge)
 			}
 			if uc := userGHClient.Load(); uc != nil {
 				uc.SetRepos(cfg.Project.Repos)
@@ -1977,6 +1979,7 @@ func main() {
 			newClient := github.NewClientFromApp(newAppAuth, cfg.Project.Org, cfg.Project.Repos, logger)
 			if len(cfg.Governor.Labels.Exempt) > 0 {
 				newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
+				newClient.SetAutoMergeLabel(cfg.Governor.Labels.AutoMerge)
 			}
 
 			ghClient = newClient
@@ -2364,6 +2367,7 @@ func main() {
 					newClient := github.NewClientFromApp(newAppAuth, cfg.Project.Org, cfg.Project.Repos, logger)
 					if len(cfg.Governor.Labels.Exempt) > 0 {
 						newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
+						newClient.SetAutoMergeLabel(cfg.Governor.Labels.AutoMerge)
 					}
 					ghClient = newClient
 					appAuth = newAppAuth
@@ -3452,6 +3456,7 @@ func main() {
 				newClient := github.NewClientFromApp(newAppAuth, cfg.Project.Org, cfg.Project.Repos, logger)
 				if len(cfg.Governor.Labels.Exempt) > 0 {
 					newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
+					newClient.SetAutoMergeLabel(cfg.Governor.Labels.AutoMerge)
 				}
 				ghClient = newClient
 				appAuth = newAppAuth

--- a/v2/docs/manual-provisioning.md
+++ b/v2/docs/manual-provisioning.md
@@ -575,6 +575,21 @@ auto-merge-on-green flow. The spoke enforces the self-merge ban against the
 GitHub login bound to the session; owners are exempt because they already have
 repository-level merge authority.
 
+Queueing a PR approves it as the hive App and applies a label. That label is
+configurable, because it is applied in a repository the hive does not own and
+whose review conventions already exist:
+
+```yaml
+governor:
+  labels:
+    automerge: lgtm
+```
+
+It defaults to `lgtm`, the long-standing Prow/Kubernetes label for "a second
+person signed off", which is the decision the merger tier records. Set it to
+whatever the managed repositories already use — the label is created on demand
+if it does not exist.
+
 > **`meta.json` requirement is why heartbeats can be accepted but upgrades fail.**
 > The heartbeat path is separate from `loadSaaSHive`. A hive can heartbeat and
 > appear "online" while a missing `meta.json` makes the **Upgrade** button (and

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1242,6 +1242,14 @@ func (c *LiteLLMConfig) Validate() error {
 
 type LabelsConfig struct {
 	Exempt []string `yaml:"exempt"`
+	// AutoMerge is the label a merger/owner queue action applies to a PR.
+	// Configurable because the label has to live in someone else's
+	// repository, where the local convention already exists: Prow-style
+	// projects have used `lgtm` for exactly this decision for years, and a
+	// hive that hard-codes its own name either collides with that or forces
+	// every managed repo to grow a second label meaning the same thing.
+	// Defaults to DefaultAutoMergeLabel.
+	AutoMerge string `yaml:"automerge"`
 }
 
 type SensingConfig struct {
@@ -2089,6 +2097,13 @@ const (
 	RoleMerger = "merger"
 )
 
+// DefaultAutoMergeLabel is the label applied when a hive does not configure
+// `governor.labels.automerge`. `lgtm` is the long-standing Prow/Kubernetes
+// convention for "a second person signed off on this", which is exactly the
+// decision the merger tier records, so a managed repository usually already
+// has it and already understands it.
+const DefaultAutoMergeLabel = "lgtm"
+
 var roleRanks = map[string]int{
 	RoleRead:      1,
 	RoleReadWrite: 2,
@@ -2714,6 +2729,9 @@ func (c *Config) applyDefaults() {
 			"auto-qa-tuning-report", "adopters",
 			"changes-requested", "waiting-on-author",
 		}
+	}
+	if strings.TrimSpace(c.Governor.Labels.AutoMerge) == "" {
+		c.Governor.Labels.AutoMerge = DefaultAutoMergeLabel
 	}
 	if len(c.Governor.Sensing.GHRatePatterns) == 0 {
 		c.Governor.Sensing.GHRatePatterns = []string{

--- a/v2/pkg/config/config_test.go
+++ b/v2/pkg/config/config_test.go
@@ -844,6 +844,9 @@ func TestApplyDefaults_AllGovernorDefaults(t *testing.T) {
 	if len(cfg.Governor.Labels.Exempt) == 0 {
 		t.Error("expected default exempt labels")
 	}
+	if cfg.Governor.Labels.AutoMerge != DefaultAutoMergeLabel {
+		t.Errorf("automerge label = %q, want %q", cfg.Governor.Labels.AutoMerge, DefaultAutoMergeLabel)
+	}
 	if cfg.Governor.Sensing.TTLSeconds != defaultSensingTTLSeconds {
 		t.Errorf("sensing_ttl = %d", cfg.Governor.Sensing.TTLSeconds)
 	}
@@ -901,7 +904,7 @@ func TestApplyDefaults_ExistingValuesNotOverridden(t *testing.T) {
 		Dashboard: DashboardConfig{Port: 8080},
 		Governor: GovernorConfig{
 			EvalIntervalS: 600,
-			Labels:        LabelsConfig{Exempt: []string{"custom-label"}},
+			Labels:        LabelsConfig{Exempt: []string{"custom-label"}, AutoMerge: "ship-it"},
 			Sensing:       SensingConfig{TTLSeconds: 1800, PullbackSeconds: 1800},
 		},
 	}
@@ -915,6 +918,9 @@ func TestApplyDefaults_ExistingValuesNotOverridden(t *testing.T) {
 	}
 	if len(cfg.Governor.Labels.Exempt) != 1 || cfg.Governor.Labels.Exempt[0] != "custom-label" {
 		t.Errorf("exempt = %v", cfg.Governor.Labels.Exempt)
+	}
+	if cfg.Governor.Labels.AutoMerge != "ship-it" {
+		t.Errorf("automerge label = %q, want ship-it", cfg.Governor.Labels.AutoMerge)
 	}
 	if cfg.Governor.Sensing.TTLSeconds != 1800 {
 		t.Errorf("ttl = %d", cfg.Governor.Sensing.TTLSeconds)

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -441,7 +441,23 @@ func (s *Server) handleRole(w http.ResponseWriter, r *http.Request) {
 	if role == "" {
 		role = "owner"
 	}
-	jsonResponse(w, map[string]string{"role": role, "user": user})
+	jsonResponse(w, map[string]string{
+		"role": role,
+		"user": user,
+		// The queue label is server-configured, so the dashboard must be told
+		// it rather than hard-coding a name that a hive may have changed.
+		"automerge_label": s.autoMergeLabel(),
+	})
+}
+
+// autoMergeLabel reports the configured queue label. /api/role is served
+// before GitHub credentials are required, so deps and the client may both be
+// nil here even though handleQueuePRAutoMerge rejects that state outright.
+func (s *Server) autoMergeLabel() string {
+	if s == nil || s.deps == nil {
+		return github.AutoMergeQueuedLabel
+	}
+	return s.deps.GHClient.AutoMergeLabel()
 }
 
 func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
@@ -1945,7 +1961,7 @@ func (s *Server) handleQueuePRAutoMerge(w http.ResponseWriter, r *http.Request) 
 		"status": "queued",
 		"repo":   repo,
 		"number": number,
-		"label":  github.AutoMergeQueuedLabel,
+		"label":  s.deps.GHClient.AutoMergeLabel(),
 	})
 }
 

--- a/v2/pkg/dashboard/pr_automerge_test.go
+++ b/v2/pkg/dashboard/pr_automerge_test.go
@@ -37,7 +37,7 @@ func TestQueuePRAutoMergeRoleAndSelfGate(t *testing.T) {
 						"number": 7,
 						"user":   map[string]string{"login": tt.author},
 					})
-				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/labels/hive/automerge":
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/labels/"+ghpkg.AutoMergeQueuedLabel:
 					http.NotFound(w, r)
 				case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/labels":
 					w.WriteHeader(http.StatusCreated)
@@ -112,5 +112,14 @@ func TestQueuePRAutoMergeRejectsRepoOutsideHive(t *testing.T) {
 	}
 	if called {
 		t.Fatal("GitHub API should not be called for unauthorized repo")
+	}
+}
+
+// /api/role is served before GitHub credentials exist, so the label lookup it
+// performs must survive a nil deps/client rather than panicking the dashboard.
+func TestAutoMergeLabelNilDeps(t *testing.T) {
+	s := &Server{}
+	if got := s.autoMergeLabel(); got != ghpkg.AutoMergeQueuedLabel {
+		t.Fatalf("nil-deps label = %q, want %q", got, ghpkg.AutoMergeQueuedLabel)
 	}
 }

--- a/v2/pkg/dashboard/pr_automerge_ui_test.go
+++ b/v2/pkg/dashboard/pr_automerge_ui_test.go
@@ -13,7 +13,7 @@ func TestPRAutoMergeButtonGatingPinned(t *testing.T) {
 		"p.author.toLowerCase() === window._hiveUser.toLowerCase()",
 		"Queue auto-merge",
 		"/queue-automerge",
-		"hive/automerge",
+		"_hiveAutoMergeLabel",
 	} {
 		if !strings.Contains(html, snippet) {
 			t.Fatalf("dashboard PR auto-merge UI missing snippet %q", snippet)

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6488,8 +6488,8 @@
           const mergeIcon = p.mergeable ? '<span class="pill-merge-icon">✓</span>' : '';
           const mergeClass = p.mergeable ? ' mergeable' : '';
           const prAge = pillAge(p.created_at);
-          const labels = (p.labels || []).map(l => String(l).toLowerCase());
-          const queued = labels.includes((window._hiveAutoMergeLabel || 'lgtm').toLowerCase());
+          const labels = (p.labels || []).map(l => String(l));
+          const queued = labels.includes(window._hiveAutoMergeLabel || 'lgtm');
           const prTip = (p.title || '') + (p.author ? ' — @' + p.author : '') + (prAge ? ' (' + prAge + ')' : '') + (p.mergeable ? ' (merge eligible)' : '') + (queued ? ' (queued for auto-merge)' : '');
           const canQueue = dashboardRoleAtLeast(window._hiveRole || 'read', 'merger') && (window._hiveUser || dashboardRoleAtLeast(window._hiveRole || 'read', 'owner')) && !(p.author && window._hiveUser && p.author.toLowerCase() === window._hiveUser.toLowerCase());
           const parts = (r.full || r.name || '').split('/');

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6489,7 +6489,7 @@
           const mergeClass = p.mergeable ? ' mergeable' : '';
           const prAge = pillAge(p.created_at);
           const labels = (p.labels || []).map(l => String(l).toLowerCase());
-          const queued = labels.includes('hive/automerge');
+          const queued = labels.includes((window._hiveAutoMergeLabel || 'lgtm').toLowerCase());
           const prTip = (p.title || '') + (p.author ? ' — @' + p.author : '') + (prAge ? ' (' + prAge + ')' : '') + (p.mergeable ? ' (merge eligible)' : '') + (queued ? ' (queued for auto-merge)' : '');
           const canQueue = dashboardRoleAtLeast(window._hiveRole || 'read', 'merger') && (window._hiveUser || dashboardRoleAtLeast(window._hiveRole || 'read', 'owner')) && !(p.author && window._hiveUser && p.author.toLowerCase() === window._hiveUser.toLowerCase());
           const parts = (r.full || r.name || '').split('/');
@@ -18709,6 +18709,7 @@ function burnAreaChart() {
         const roleResp = await fetch('/api/role');
         const roleData = await roleResp.json();
         if (roleData.user) {
+          if (roleData.automerge_label) window._hiveAutoMergeLabel = roleData.automerge_label;
           showGHAuthState(true, roleData.user, 'https://github.com/' + roleData.user + '.png', roleData.role);
           return;
         }

--- a/v2/pkg/github/automerge_label_test.go
+++ b/v2/pkg/github/automerge_label_test.go
@@ -1,0 +1,59 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// The queue label lands in someone else's repository, so a hive has to be able
+// to name it. These pin the fallback chain rather than the literal, so a hive
+// that changes the default does not have to change the tests too.
+
+func TestAutoMergeLabelDefaultsWhenUnset(t *testing.T) {
+	c := NewClient("fake", "acme", nil, nil, "")
+	if got := c.AutoMergeLabel(); got != config.DefaultAutoMergeLabel {
+		t.Fatalf("unconfigured client label = %q, want %q", got, config.DefaultAutoMergeLabel)
+	}
+}
+
+func TestAutoMergeLabelHonoursConfiguration(t *testing.T) {
+	c := NewClient("fake", "acme", nil, nil, "")
+	c.SetAutoMergeLabel("ship-it")
+	if got := c.AutoMergeLabel(); got != "ship-it" {
+		t.Fatalf("configured label = %q, want %q", got, "ship-it")
+	}
+}
+
+// A partially-populated config must not be able to produce an unnamed label:
+// AddLabelsToIssue with "" is a 422, which would surface as a queue action that
+// approves the PR and then fails, leaving it approved but never queued.
+func TestAutoMergeLabelIgnoresBlank(t *testing.T) {
+	c := NewClient("fake", "acme", nil, nil, "")
+	c.SetAutoMergeLabel("ship-it")
+	for _, blank := range []string{"", "   ", "\t\n"} {
+		c.SetAutoMergeLabel(blank)
+		if got := c.AutoMergeLabel(); got != "ship-it" {
+			t.Fatalf("SetAutoMergeLabel(%q) cleared the label to %q", blank, got)
+		}
+	}
+}
+
+func TestAutoMergeLabelTrimsWhitespace(t *testing.T) {
+	c := NewClient("fake", "acme", nil, nil, "")
+	c.SetAutoMergeLabel("  lgtm  ")
+	if got := c.AutoMergeLabel(); got != "lgtm" {
+		t.Fatalf("label = %q, want %q", got, "lgtm")
+	}
+}
+
+// A hive that booted without GitHub credentials runs with a nil *Client for the
+// life of the process, and the dashboard still reports the label to the client
+// via /api/role. Both accessors must survive that.
+func TestAutoMergeLabelNilReceiver(t *testing.T) {
+	var c *Client
+	if got := c.AutoMergeLabel(); got != config.DefaultAutoMergeLabel {
+		t.Fatalf("nil client label = %q, want %q", got, config.DefaultAutoMergeLabel)
+	}
+	c.SetAutoMergeLabel("ship-it") // must not panic
+}

--- a/v2/pkg/github/automerge_queue_test.go
+++ b/v2/pkg/github/automerge_queue_test.go
@@ -12,7 +12,7 @@ func TestQueuePRAutoMergeApprovesThenLabels(t *testing.T) {
 	var sawReview, sawLabel bool
 	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/labels/hive/automerge":
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/labels/"+AutoMergeQueuedLabel:
 			http.NotFound(w, r)
 		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/labels":
 			w.WriteHeader(http.StatusCreated)

--- a/v2/pkg/github/automerge_queue_test.go
+++ b/v2/pkg/github/automerge_queue_test.go
@@ -45,6 +45,54 @@ func TestQueuePRAutoMergeApprovesThenLabels(t *testing.T) {
 	}
 }
 
+func TestQueuePRAutoMergeUsesConfiguredLabel(t *testing.T) {
+	const label = "ship-it"
+	var sawLabel bool
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/labels/"+label:
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/labels":
+			var req struct {
+				Name string `json:"name"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode create-label request: %v", err)
+			}
+			if req.Name != label {
+				t.Fatalf("created label %q, want %q", req.Name, label)
+			}
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{"name": label})
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/pulls/7/reviews":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{"id": 1, "state": "APPROVED"})
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/issues/7/labels":
+			var got []string
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode add-label request: %v", err)
+			}
+			if len(got) != 1 || got[0] != label {
+				t.Fatalf("added labels = %v, want [%s]", got, label)
+			}
+			sawLabel = true
+			json.NewEncoder(w).Encode([]map[string]any{{"name": label}})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	c.SetAutoMergeLabel(label)
+	if err := c.QueuePRAutoMerge(context.Background(), "acme/widget", 7, "alice"); err != nil {
+		t.Fatalf("QueuePRAutoMerge returned error: %v", err)
+	}
+	if !sawLabel {
+		t.Fatal("configured label was not applied")
+	}
+}
+
 func TestGetPRAuthor(t *testing.T) {
 	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || r.URL.Path != "/repos/acme/widget/pulls/7" {

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	gh "github.com/google/go-github/v72/github"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
 // ErrNoGitHubClient is returned by *Client methods invoked on a nil receiver.
@@ -31,6 +33,10 @@ type Client struct {
 	reposMu      sync.RWMutex
 	repos        []string
 	exemptLabels []string
+	// autoMergeLabel is the configured merger-queue label. Guarded because
+	// config reload re-applies it while request handlers read it.
+	autoMergeLabelMu sync.RWMutex
+	autoMergeLabel   string
 	logger       *slog.Logger
 	appAuth      *AppAuth // nil for token-authenticated clients
 	// prAuthz gates PR-open requests from the request-file watcher against the
@@ -188,9 +194,11 @@ type IssueCluster struct {
 var HoldLabels = []string{"hold", "on-hold", "hold/review"}
 var PermanentExemptLabels = []string{"do-not-merge"}
 
-// AutoMergeQueuedLabel is the GitHub label a human merger/owner action applies
-// to mark a PR as approved for the hive's existing auto-merge-on-green sweep.
-const AutoMergeQueuedLabel = "hive/automerge"
+// AutoMergeQueuedLabel is the fallback label a merger/owner queue action
+// applies when a hive has not configured `governor.labels.automerge`. Prefer
+// Client.AutoMergeLabel(), which honours that configuration; this constant
+// exists so a nil or unconfigured client still has a sane value.
+const AutoMergeQueuedLabel = config.DefaultAutoMergeLabel
 
 var exemptFiles = []string{"ADOPTERS.md", "ADOPTERS.MD"}
 
@@ -683,8 +691,9 @@ func (c *Client) QueuePRAutoMerge(ctx context.Context, repo string, number int, 
 		return ErrNoGitHubClient
 	}
 	owner, repoName := c.splitRepo(repo)
-	if err := c.ensureLabel(ctx, owner, repoName, AutoMergeQueuedLabel); err != nil {
-		return fmt.Errorf("ensuring %s label: %w", AutoMergeQueuedLabel, err)
+	label := c.AutoMergeLabel()
+	if err := c.ensureLabel(ctx, owner, repoName, label); err != nil {
+		return fmt.Errorf("ensuring %s label: %w", label, err)
 	}
 	body := fmt.Sprintf("Approved by @%s for Hive auto-merge on green CI.", queuedBy)
 	if strings.TrimSpace(queuedBy) == "" {
@@ -697,8 +706,8 @@ func (c *Client) QueuePRAutoMerge(ctx context.Context, repo string, number int, 
 	if err != nil {
 		return fmt.Errorf("approving PR: %w", err)
 	}
-	if _, _, err := c.client.Issues.AddLabelsToIssue(ctx, owner, repoName, number, []string{AutoMergeQueuedLabel}); err != nil {
-		return fmt.Errorf("adding %s label: %w", AutoMergeQueuedLabel, err)
+	if _, _, err := c.client.Issues.AddLabelsToIssue(ctx, owner, repoName, number, []string{label}); err != nil {
+		return fmt.Errorf("adding %s label: %w", label, err)
 	}
 	return nil
 }
@@ -781,6 +790,36 @@ func (c *Client) SetExemptLabels(labels []string) {
 		return
 	}
 	c.exemptLabels = labels
+}
+
+// SetAutoMergeLabel is nil-receiver safe for the same reason as SetRepos. An
+// empty or whitespace-only value keeps the default rather than clearing it,
+// so a partially-populated config cannot produce an unnamed label.
+func (c *Client) SetAutoMergeLabel(label string) {
+	if c == nil {
+		return
+	}
+	if strings.TrimSpace(label) == "" {
+		return
+	}
+	c.autoMergeLabelMu.Lock()
+	defer c.autoMergeLabelMu.Unlock()
+	c.autoMergeLabel = strings.TrimSpace(label)
+}
+
+// AutoMergeLabel returns the configured queue label, falling back to the
+// default when unset. Nil-receiver safe so callers can report the label even
+// when the hive booted without GitHub credentials.
+func (c *Client) AutoMergeLabel() string {
+	if c == nil {
+		return AutoMergeQueuedLabel
+	}
+	c.autoMergeLabelMu.RLock()
+	defer c.autoMergeLabelMu.RUnlock()
+	if c.autoMergeLabel == "" {
+		return AutoMergeQueuedLabel
+	}
+	return c.autoMergeLabel
 }
 
 func (c *Client) isExempt(labels []string) bool {

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -577,7 +577,7 @@ func formatMergeEligibleData(data []byte) string {
 	for _, pr := range payload.Items {
 		queued := ""
 		if pr.Queued {
-			queued = " [hive/automerge queued]"
+			queued = " [queued for auto-merge]"
 		}
 		b.WriteString(fmt.Sprintf("  #%d %s%s — %s\n", pr.Number, pr.Repo, queued, pr.Title))
 	}

--- a/v2/pkg/scheduler/scheduler_coverage_test.go
+++ b/v2/pkg/scheduler/scheduler_coverage_test.go
@@ -116,7 +116,7 @@ func TestFormatPRList_TruncatesTitle(t *testing.T) {
 
 func TestFormatMergeEligibleDataShowsQueuedMarker(t *testing.T) {
 	result := formatMergeEligibleData([]byte(`{"merge_eligible":[{"number":7,"repo":"acme/widget","title":"fix it","queued":true}]}`))
-	if !strings.Contains(result, "#7 acme/widget [hive/automerge queued]") {
+	if !strings.Contains(result, "#7 acme/widget [queued for auto-merge]") {
 		t.Fatalf("queued marker missing from merge-eligible output: %s", result)
 	}
 }


### PR DESCRIPTION
Follow-up to #2825.

## Why

`QueuePRAutoMerge` applies a hard-coded `hive/automerge` label. That label is applied in a repository the hive does **not** own, and those repositories usually already have a convention for "a second person signed off on this" — Prow/Kubernetes projects have used `lgtm` for exactly this decision for years. A fixed name either collides with the existing one or forces every managed repo to grow a second label that means the same thing.

The operator ask on #2825 was literally this:

> j0rge: "I was thinking maybe lgtm lol, if I see brian's PR I LGTM and back in the queue but trusted and above can only automerge and it can't be yours?"

## What

- New `governor.labels.automerge`, beside the existing `governor.labels.exempt`.
- Defaults to `config.DefaultAutoMergeLabel` = **`lgtm`**.
- Threaded through exactly like the exempt list: a nil-safe `SetAutoMergeLabel`/`AutoMergeLabel` pair on `github.Client`, applied at all five `SetExemptLabels` call sites in `cmd/hive` so a config reload re-applies it.
- The dashboard is **told** the label via `/api/role` rather than hard-coding it.
- The scheduler's merge-eligible line now reads `[queued for auto-merge]` instead of naming the label, since it renders for every hive regardless of config.

**On the default:** I set it to `lgtm` because that was the stated ask and because #2825 is hours old, so there is no installed base to migrate — this is the only moment when changing it is free. If you would rather keep `hive/automerge`, it is a one-line change to `DefaultAutoMergeLabel`. The configurability is the substance here; the default is a trivially-flippable detail and entirely your call.

## Two edge cases worth a look

- **Blank config keeps the default rather than clearing it.** `AddLabelsToIssue` with an empty name is a 422, which would surface as a queue action that *approves the PR and then fails* — leaving it approved but never queued, which is the worst of both.
- **`/api/role` is served before GitHub credentials are required**, so its label lookup is guarded against a nil `deps`/client. `handleQueuePRAutoMerge` already rejects that state explicitly; `handleRole` did not, and adding an unguarded `s.deps.GHClient` there would have panicked the dashboard on a hive that booted without GitHub creds.

## Tests

New in `pkg/github/automerge_label_test.go`: fallback-when-unset, honours-configuration, blank/whitespace rejection, whitespace trimming, nil receiver. Plus a nil-`deps` test for the dashboard helper.

Four existing tests asserted the literal `hive/automerge`; they now assert the constant or the rendered fallback, so a hive that changes the default does not have to change the tests too.

## Validation

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./pkg/github/ ./pkg/config/ ./pkg/dashboard/ ./pkg/scheduler/ -count=1` — all pass

**Not validated:** a live queue action against real GitHub. That needs hive App credentials I do not have, so the API call sequence (ensureLabel → CreateReview APPROVE → AddLabelsToIssue) is exercised only against the existing httptest fakes.

## One question, separate from this PR

While tracing this I could not find the consumer of the label. `QueuePRAutoMerge`'s comment says it marks the PR "for the hive's existing auto-merge-on-green sweep", but grepping `v2/` for `PullRequests.Merge`, `EnableAutoMerge` and similar finds nothing, and there is no automerge workflow in `.github/`. Is the sweep external to this repo (an app or a workflow in the managed repos), or still to come? Happy to file that separately — it affects what a downstream has to provide to actually use the tier, and it is not a blocker for this change either way.