### PR TITLE
✨ feat(review): parallel review fan-out and bounded auto-fix dispatch

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -4352,6 +4352,7 @@ func runEvalCycle(
 	escalatedPRs := runEscalationSweep(ctx, cfg, ghClient, actionable, notifier, logger)
 
 	intentVerdicts := writeIntentVerdicts(ctx, cfg, ghClient, actionable, beadStores, logger)
+	refreshReviewVerdicts(cfg, logger)
 	writeMergeEligible(actionable, actionable.Hold, cfg.Project.Org, escalatedPRs, cfg.Intent.Enforce, intentVerdicts, cfg.Review.RequireApproval, logger)
 
 	// Stuck-PR reaper (backstop): re-dispatch a fix for any hive-authored PR
@@ -4483,8 +4484,19 @@ func runEvalCycle(
 	}
 
 	sched.SetLastActionable(actionable)
-	if len(agentsDue) > 0 {
-		messages := sched.BuildKickMessages(actionable, agentsDue)
+	reviewPlan := planReviewDispatch(cfg, actionable, agentMgr, logger)
+	messages := sched.BuildKickMessages(actionable, agentsDue)
+	reviewKickByMessage := map[string]review.DispatchKick{}
+	for _, k := range append(reviewPlan.ReviewKicks, reviewPlan.FixKicks...) {
+		if !gov.AgentEligibleForCELKick(k.Agent) || agentMgr.IsPaused(k.Agent) {
+			logger.Info("review swarm kick suppressed by governor gate", "agent", k.Agent, "pr", k.PRRef)
+			continue
+		}
+		messages = append(messages, scheduler.KickMessage{Agent: k.Agent, Message: k.Message, IssueRefs: []string{k.PRRef}})
+		reviewKickByMessage[k.Agent+"\x00"+k.Message] = k
+	}
+	var deliveredReviewKicks []review.DispatchKick
+	if len(messages) > 0 {
 		for _, msg := range messages {
 			agentCfg := cfg.Agents[msg.Agent]
 			_, kickSpan := tracing.StartSpan(ctx, "agent.kick", tracing.AgentKickAttributes(
@@ -4501,6 +4513,10 @@ func runEvalCycle(
 				kickSpan.End()
 				logger.Warn("failed to send kick", "agent", msg.Agent, "error", err)
 				continue
+			}
+			if k, ok := reviewKickByMessage[msg.Agent+"\x00"+msg.Message]; ok {
+				deliveredReviewKicks = append(deliveredReviewKicks, k)
+				persistReviewDispatchState(reviewPlan, deliveredReviewKicks, logger)
 			}
 			kickSpan.End()
 			gov.RecordKick(msg.Agent)
@@ -4524,6 +4540,7 @@ func runEvalCycle(
 			}
 		}
 	}
+	persistReviewDispatchState(reviewPlan, deliveredReviewKicks, logger)
 
 	if actionable.Issues.SLAViolations > 0 {
 		const doubleSLAMinutes = 60
@@ -5972,6 +5989,86 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 		return
 	}
 	atomicWrite(ciFailingPath, failData)
+}
+
+func planReviewDispatch(cfg *config.Config, actionable *github.ActionableResult, agentMgr *agent.Manager, logger *slog.Logger) review.DispatchPlan {
+	if cfg == nil || actionable == nil || !cfg.Review.RequireApproval || !cfg.Review.FanOut {
+		return review.DispatchPlan{}
+	}
+	state, err := review.LoadDispatchState("")
+	if err != nil && !os.IsNotExist(err) {
+		logger.Warn("review dispatch state unavailable; starting fresh", "error", err)
+	}
+	artifact, err := review.LoadArtifact("")
+	if err != nil && !os.IsNotExist(err) {
+		logger.Warn("review verdict artifact unavailable for dispatch planning", "error", err)
+	}
+	prs := make([]review.PullRequest, 0, len(actionable.PRs.Items))
+	for _, pr := range actionable.PRs.Items {
+		lane := classify.Classify(github.Issue{Title: pr.Title, Labels: pr.Labels}).Lane
+		prs = append(prs, review.PullRequest{
+			Repo:    pr.Repo,
+			Number:  pr.Number,
+			Title:   pr.Title,
+			Author:  pr.Author,
+			HeadSHA: pr.HeadSHA,
+			URL:     pr.URL,
+			Lane:    string(lane),
+		})
+	}
+	agents := make([]review.AgentCapability, 0, len(cfg.Agents))
+	for name, ac := range cfg.EnabledAgents() {
+		agents = append(agents, review.AgentCapability{
+			Name:           name,
+			Enabled:        true,
+			Paused:         ac.Paused || (agentMgr != nil && agentMgr.IsPaused(name)),
+			OnDemand:       ac.OnDemand,
+			UsesKick:       ac.UsesGovernorKick(),
+			Role:           ac.Role,
+			LaneKeywords:   ac.LaneKeywords,
+			DetectKeywords: ac.DetectKeywords,
+			Aliases:        ac.Aliases,
+		})
+	}
+	plan := review.PlanDispatch(prs, artifact, state, review.DispatchOptions{
+		RequireApproval:    cfg.Review.RequireApproval,
+		FanOut:             cfg.Review.FanOut,
+		MaxParallelReviews: cfg.Review.EffectiveMaxParallelReviews(),
+		ReviewerAgents:     cfg.Review.ReviewerAgents,
+		FixerAgent:         cfg.Review.FixerAgent,
+		ProjectOrg:         cfg.Project.Org,
+		AIAuthor:           cfg.EffectiveAIAuthor(),
+		Agents:             agents,
+	})
+	if len(plan.ReviewKicks)+len(plan.FixKicks) > 0 {
+		logger.Info("review swarm dispatch planned", "review_kicks", len(plan.ReviewKicks), "fix_kicks", len(plan.FixKicks))
+	}
+	return plan
+}
+
+func refreshReviewVerdicts(cfg *config.Config, logger *slog.Logger) {
+	if cfg == nil || !cfg.Review.RequireApproval {
+		return
+	}
+	artifact, err := review.CollectAndWrite("", "", review.AggregateOptions{})
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logger.Warn("failed to refresh review verdicts", "error", err)
+		}
+		return
+	}
+	logger.Info("review verdict artifact refreshed", "aggregates", len(artifact.Items))
+}
+
+func persistReviewDispatchState(plan review.DispatchPlan, delivered []review.DispatchKick, logger *slog.Logger) {
+	planned := append(append([]review.DispatchKick(nil), plan.ReviewKicks...), plan.FixKicks...)
+	if plan.State.GeneratedAt.IsZero() && len(planned) == 0 {
+		return
+	}
+	state := review.ConfirmDelivered(plan.State, planned, delivered)
+	if err := review.WriteDispatchState("", state); err != nil {
+		logger.Warn("failed to persist review dispatch state", "error", err)
+	}
 }
 
 func atomicWrite(path string, data []byte) {

--- a/v2/docs/review-swarm.md
+++ b/v2/docs/review-swarm.md
@@ -1,6 +1,6 @@
-# Review swarm (phase 1)
+# Review swarm
 
-Hive's review swarm adds a structured review-to-fix decision point for pull requests. Phase 1 implements the data model, prompt construction, verdict collector, and optional merge-gate integration; governor fan-out to parallel review agents is deferred.
+Hive's review swarm adds a structured review-to-fix decision point for pull requests. It includes the review data model, prompt construction, verdict collector, optional merge-gate integration, governor fan-out to review-capable agents, and a bounded auto-fix cycle for review findings.
 
 ## Perspectives
 
@@ -33,22 +33,30 @@ The default human threshold is `high`. Review-triggered fix cycles use the same 
 
 ## Configuration
 
-Merge-gate use is opt-in and preserves existing behavior by default:
+Merge-gate and fan-out use are opt-in and preserve existing behavior by default:
 
 ```yaml
 review:
   require_approval: true
+  fan_out: true
+  max_parallel_reviews: 5
+  reviewer_agents: [reviewer-a, reviewer-b] # optional; otherwise agents with review role/keywords are selected
+  fixer_agent: scanner                      # optional; defaults to the PR lane, then scanner
 ```
 
 When `review.require_approval` is false or omitted, `merge-eligible.json` is produced as before. When true, a PR is included only if `review-verdicts.json` contains an aggregate `approve` for the same repo, PR number, and head SHA.
 
-## Prompt construction
+`review.fan_out` is separately defaulted to false. When both `require_approval` and `fan_out` are true, the governor eval cycle plans review kicks for agent-authored PRs that do not yet have a fresh aggregate verdict for their current head SHA.
+
+## Dispatch and prompt construction
 
 `pkg/review` provides prompt builders for one prompt per perspective plus a sequential fallback prompt. These prompts instruct review-capable agents to emit the extended AgentReport JSON shape above.
 
+Phase 2 adds dispatch state in `/var/run/hive-metrics/review-dispatch-state.json`. Pending review kicks are scoped by repo, PR number, perspective, and head SHA; when a PR head changes, stale pending entries are pruned and the new head must be reviewed again. Multiple review-capable agents receive perspective prompts in parallel up to `max_parallel_reviews`; a single reviewer receives one perspective per eval round.
+
+When an aggregate verdict is `changes_requested`, Hive builds a review-fix kick containing the aggregate findings and sends it to `review.fixer_agent`, the classified PR lane, or `scanner`. Fix dispatches are capped by `escalation.MaxReEngagements`; once exhausted, dispatch state records a `requires_human` hold for the PR head so the automated loop stops.
+
 ## Deferred work
 
-- Wire governor/scheduler fan-out so the five perspective prompts run in parallel review-capable agents.
-- Feed `changes_requested` aggregates directly into an auto-fix kick lane.
 - Map aggregate verdicts to labels/comments (`hold`, `needs-human`, close recommendation) once fan-out exists.
 - Add dashboard visibility for review verdict artifacts.

--- a/v2/hive.yaml.example
+++ b/v2/hive.yaml.example
@@ -206,6 +206,10 @@ governor:
 # merge-eligible.json requires an aggregate approve in review-verdicts.json.
 # review:
 #   require_approval: false
+#   fan_out: false
+#   max_parallel_reviews: 5
+#   reviewer_agents: [] # optional explicit list; otherwise agents with review role/keywords are used
+#   fixer_agent: ""     # optional override; defaults to the PR lane, then scanner
 
 # GitHub authentication — use ONE of these methods
 github:

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -3909,12 +3909,28 @@ type EscalationConfig struct {
 // value preserves existing behavior: merge eligibility does not require a
 // review-verdicts.json aggregate approval unless an operator opts in.
 type ReviewConfig struct {
-	RequireApproval bool `yaml:"require_approval,omitempty" json:"require_approval,omitempty"`
+	RequireApproval    bool     `yaml:"require_approval,omitempty" json:"require_approval,omitempty"`
+	FanOut             bool     `yaml:"fan_out,omitempty" json:"fan_out,omitempty"`
+	MaxParallelReviews int      `yaml:"max_parallel_reviews,omitempty" json:"max_parallel_reviews,omitempty"`
+	ReviewerAgents     []string `yaml:"reviewer_agents,omitempty" json:"reviewer_agents,omitempty"`
+	FixerAgent         string   `yaml:"fixer_agent,omitempty" json:"fixer_agent,omitempty"`
 }
 
 // DefaultEscalationThreshold matches escalation.DefaultThreshold; duplicated
 // here (a constant, checked by test) to avoid a config→escalation import.
 const DefaultEscalationThreshold = 3
+
+// DefaultMaxParallelReviews matches review.DefaultMaxParallelReviews; duplicated
+// here to avoid a config→review import cycle.
+const DefaultMaxParallelReviews = 5
+
+// EffectiveMaxParallelReviews resolves the review fan-out width.
+func (r ReviewConfig) EffectiveMaxParallelReviews() int {
+	if r.MaxParallelReviews > 0 {
+		return r.MaxParallelReviews
+	}
+	return DefaultMaxParallelReviews
+}
 
 // EffectiveThreshold resolves the configured threshold with its default.
 func (e EscalationConfig) EffectiveThreshold() int {

--- a/v2/pkg/review/dispatch.go
+++ b/v2/pkg/review/dispatch.go
@@ -1,0 +1,436 @@
+package review
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/escalation"
+	"github.com/kubestellar/hive/v2/pkg/outputschema"
+)
+
+const (
+	DefaultMaxParallelReviews = 5
+	ReviewDispatchStateFile   = "review-dispatch-state.json"
+	DefaultFixerAgent         = "scanner"
+	reviewRoleToken           = "review"
+)
+
+var ReviewDispatchStatePath = filepath.Join(outputschema.AgentReportDir, ReviewDispatchStateFile)
+
+type AgentCapability struct {
+	Name           string
+	Enabled        bool
+	Paused         bool
+	OnDemand       bool
+	UsesKick       bool
+	Role           string
+	LaneKeywords   []string
+	DetectKeywords []string
+	Aliases        []string
+}
+
+type DispatchOptions struct {
+	RequireApproval    bool
+	FanOut             bool
+	MaxParallelReviews int
+	ReviewerAgents     []string
+	FixerAgent         string
+	ProjectOrg         string
+	AIAuthor           string
+	Agents             []AgentCapability
+	Now                time.Time
+}
+
+type DispatchState struct {
+	GeneratedAt time.Time         `json:"generated_at"`
+	Pending     []PendingReview   `json:"pending_reviews,omitempty"`
+	Fixes       []PendingFix      `json:"pending_fixes,omitempty"`
+	Human       []HumanReviewHold `json:"requires_human,omitempty"`
+}
+
+type PendingReview struct {
+	Repo        string      `json:"repo"`
+	Number      int         `json:"number"`
+	HeadSHA     string      `json:"head_sha,omitempty"`
+	Perspective Perspective `json:"perspective"`
+	Agent       string      `json:"agent"`
+	Dispatched  time.Time   `json:"dispatched_at"`
+}
+
+type PendingFix struct {
+	Repo       string    `json:"repo"`
+	Number     int       `json:"number"`
+	HeadSHA    string    `json:"head_sha,omitempty"`
+	Agent      string    `json:"agent"`
+	Attempts   int       `json:"attempts"`
+	Dispatched time.Time `json:"dispatched_at"`
+}
+
+type HumanReviewHold struct {
+	Repo      string    `json:"repo"`
+	Number    int       `json:"number"`
+	HeadSHA   string    `json:"head_sha,omitempty"`
+	Reason    string    `json:"reason"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type DispatchKick struct {
+	Agent       string
+	Message     string
+	PRRef       string
+	Kind        string
+	Repo        string
+	Number      int
+	HeadSHA     string
+	Perspective Perspective
+}
+
+type DispatchPlan struct {
+	ReviewKicks []DispatchKick
+	FixKicks    []DispatchKick
+	State       DispatchState
+}
+
+func LoadDispatchState(path string) (DispatchState, error) {
+	if path == "" {
+		path = ReviewDispatchStatePath
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return DispatchState{}, err
+	}
+	var state DispatchState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return DispatchState{}, err
+	}
+	return state, nil
+}
+
+func WriteDispatchState(path string, state DispatchState) error {
+	if path == "" {
+		path = ReviewDispatchStatePath
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func PlanDispatch(prs []PullRequest, artifact Artifact, state DispatchState, opts DispatchOptions) DispatchPlan {
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	state.GeneratedAt = now
+	state = pruneState(state, prs, opts.ProjectOrg)
+	plan := DispatchPlan{State: state}
+	if !opts.RequireApproval || !opts.FanOut {
+		return plan
+	}
+	reviewers := reviewCapableAgents(opts)
+	maxParallel := opts.MaxParallelReviews
+	if maxParallel <= 0 {
+		maxParallel = DefaultMaxParallelReviews
+	}
+	availableSlots := maxParallel
+	for _, pr := range prs {
+		pr.Repo = fullRepoName(pr.Repo, opts.ProjectOrg)
+		if pr.Number <= 0 || pr.Repo == "" || !isAgentAuthored(pr.Author, opts.AIAuthor) {
+			continue
+		}
+		if agg, ok := artifact.AggregateFor(pr.Repo, pr.Number, pr.HeadSHA); ok {
+			plan.State.Pending = removePendingForHead(plan.State.Pending, pr)
+			if agg.Verdict == VerdictChangesRequested {
+				plan.dispatchFix(pr, agg, opts, now)
+			}
+			continue
+		}
+		if len(reviewers) == 0 || availableSlots <= 0 {
+			continue
+		}
+		missing := pendingMissingPerspectives(plan.State, pr)
+		if len(missing) == 0 {
+			continue
+		}
+		limit := len(missing)
+		if len(reviewers) == 1 && limit > 1 {
+			limit = 1
+		}
+		if limit > availableSlots {
+			limit = availableSlots
+		}
+		for i := 0; i < limit; i++ {
+			agent := reviewers[i%len(reviewers)].Name
+			perspective := missing[i]
+			msg := BuildPerspectivePrompt(perspective, pr)
+			plan.ReviewKicks = append(plan.ReviewKicks, DispatchKick{Agent: agent, Message: msg, PRRef: fmt.Sprintf("%s#%d", pr.Repo, pr.Number), Kind: "review", Repo: pr.Repo, Number: pr.Number, HeadSHA: pr.HeadSHA, Perspective: perspective})
+			plan.State.Pending = append(plan.State.Pending, PendingReview{Repo: pr.Repo, Number: pr.Number, HeadSHA: pr.HeadSHA, Perspective: perspective, Agent: agent, Dispatched: now})
+			availableSlots--
+		}
+	}
+	return plan
+}
+
+func (p *DispatchPlan) dispatchFix(pr PullRequest, agg Aggregate, opts DispatchOptions, now time.Time) {
+	idx := fixIndex(p.State.Fixes, pr.Repo, pr.Number, pr.HeadSHA)
+	if idx >= 0 {
+		return
+	}
+	attempts := maxFixAttemptsForPR(p.State.Fixes, pr.Repo, pr.Number)
+	if attempts >= escalation.MaxReEngagements {
+		p.State.Human = upsertHuman(p.State.Human, HumanReviewHold{Repo: pr.Repo, Number: pr.Number, HeadSHA: pr.HeadSHA, Reason: fmt.Sprintf("review fix cap reached (%d/%d)", attempts, escalation.MaxReEngagements), UpdatedAt: now})
+		return
+	}
+	agent := selectFixerAgent(pr, opts)
+	if agent == "" {
+		p.State.Human = upsertHuman(p.State.Human, HumanReviewHold{Repo: pr.Repo, Number: pr.Number, HeadSHA: pr.HeadSHA, Reason: "no enabled kick-capable fixer agent is available", UpdatedAt: now})
+		return
+	}
+	attempts++
+	msg := BuildFixPrompt(pr, agg, attempts, escalation.MaxReEngagements)
+	p.FixKicks = append(p.FixKicks, DispatchKick{Agent: agent, Message: msg, PRRef: fmt.Sprintf("%s#%d", pr.Repo, pr.Number), Kind: "fix", Repo: pr.Repo, Number: pr.Number, HeadSHA: pr.HeadSHA})
+	p.State.Fixes = append(p.State.Fixes, PendingFix{Repo: pr.Repo, Number: pr.Number, HeadSHA: pr.HeadSHA, Agent: agent, Attempts: attempts, Dispatched: now})
+}
+
+func selectFixerAgent(pr PullRequest, opts DispatchOptions) string {
+	candidates := []string{strings.TrimSpace(opts.FixerAgent), strings.TrimSpace(pr.Lane), DefaultFixerAgent}
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		for _, a := range opts.Agents {
+			if a.Name == candidate && a.Enabled && !a.Paused && !a.OnDemand && a.UsesKick {
+				return candidate
+			}
+		}
+	}
+	return ""
+}
+
+func ConfirmDelivered(state DispatchState, planned, delivered []DispatchKick) DispatchState {
+	deliveredSet := map[string]bool{}
+	for _, k := range delivered {
+		deliveredSet[dispatchKickKey(k)] = true
+	}
+	undelivered := map[string]bool{}
+	for _, k := range planned {
+		if !deliveredSet[dispatchKickKey(k)] {
+			undelivered[dispatchKickKey(k)] = true
+		}
+	}
+	var pending []PendingReview
+	for _, p := range state.Pending {
+		k := DispatchKick{Kind: "review", Agent: p.Agent, Repo: p.Repo, Number: p.Number, HeadSHA: p.HeadSHA, Perspective: p.Perspective}
+		if !undelivered[dispatchKickKey(k)] {
+			pending = append(pending, p)
+		}
+	}
+	state.Pending = pending
+	var fixes []PendingFix
+	for _, f := range state.Fixes {
+		k := DispatchKick{Kind: "fix", Agent: f.Agent, Repo: f.Repo, Number: f.Number, HeadSHA: f.HeadSHA}
+		if !undelivered[dispatchKickKey(k)] {
+			fixes = append(fixes, f)
+		}
+	}
+	state.Fixes = fixes
+	return state
+}
+
+func BuildFixPrompt(pr PullRequest, agg Aggregate, attempt, maxAttempts int) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "[review-fix:%s#%d]\n", pr.Repo, pr.Number)
+	fmt.Fprintf(&b, "Fix review findings for PR %s#%d", pr.Repo, pr.Number)
+	if pr.Title != "" {
+		fmt.Fprintf(&b, " — %s", pr.Title)
+	}
+	b.WriteString(".\n")
+	if pr.URL != "" {
+		fmt.Fprintf(&b, "URL: %s\n", pr.URL)
+	}
+	if pr.HeadSHA != "" {
+		fmt.Fprintf(&b, "Head SHA: %s\n", pr.HeadSHA)
+	}
+	fmt.Fprintf(&b, "Auto-fix attempt %d of %d. Stay narrowly scoped to the review findings below; push a new commit to the PR branch.\n\n", attempt, maxAttempts)
+	b.WriteString("Aggregated review findings:\n")
+	if len(agg.Findings) == 0 && len(agg.Reasons) == 0 {
+		b.WriteString("- Review requested changes but did not include structured findings; inspect the PR conversation and latest diff.\n")
+	}
+	for _, reason := range agg.Reasons {
+		fmt.Fprintf(&b, "- %s\n", reason)
+	}
+	for _, f := range agg.Findings {
+		fmt.Fprintf(&b, "- [%s/%s] %s: %s\n", f.Perspective, f.Finding.Severity, f.Finding.Title, f.Finding.Summary)
+	}
+	b.WriteString("\nReturn the standard fix AgentReport when done. If the findings are unsafe or ambiguous, request human review instead of guessing.\n")
+	return b.String()
+}
+
+func (a Artifact) AggregateFor(repo string, number int, headSHA string) (Aggregate, bool) {
+	wantRepo := strings.TrimSpace(repo)
+	wantSHA := strings.TrimSpace(headSHA)
+	for _, item := range a.Items {
+		if item.Number == number && strings.TrimSpace(item.Repo) == wantRepo && strings.TrimSpace(item.HeadSHA) == wantSHA {
+			return item, true
+		}
+	}
+	return Aggregate{}, false
+}
+
+func reviewCapableAgents(opts DispatchOptions) []AgentCapability {
+	allowed := map[string]bool{}
+	for _, name := range opts.ReviewerAgents {
+		if n := strings.TrimSpace(name); n != "" {
+			allowed[n] = true
+		}
+	}
+	var out []AgentCapability
+	for _, a := range opts.Agents {
+		if a.Name == "" || !a.Enabled || a.Paused || a.OnDemand || !a.UsesKick {
+			continue
+		}
+		if len(allowed) > 0 {
+			if allowed[a.Name] {
+				out = append(out, a)
+			}
+			continue
+		}
+		if hasReviewCapability(a) {
+			out = append(out, a)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func hasReviewCapability(a AgentCapability) bool {
+	fields := append([]string{a.Name, a.Role}, a.Aliases...)
+	fields = append(fields, a.LaneKeywords...)
+	fields = append(fields, a.DetectKeywords...)
+	for _, f := range fields {
+		if strings.Contains(strings.ToLower(f), reviewRoleToken) {
+			return true
+		}
+	}
+	return false
+}
+
+func pendingMissingPerspectives(state DispatchState, pr PullRequest) []Perspective {
+	pending := map[Perspective]bool{}
+	for _, p := range state.Pending {
+		if samePRHead(p.Repo, p.Number, p.HeadSHA, pr.Repo, pr.Number, pr.HeadSHA) {
+			pending[p.Perspective] = true
+		}
+	}
+	var missing []Perspective
+	for _, p := range DefaultPerspectives {
+		if !pending[p] {
+			missing = append(missing, p)
+		}
+	}
+	return missing
+}
+
+func removePendingForHead(pending []PendingReview, pr PullRequest) []PendingReview {
+	out := pending[:0]
+	for _, p := range pending {
+		if !samePRHead(p.Repo, p.Number, p.HeadSHA, pr.Repo, pr.Number, pr.HeadSHA) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func pruneState(state DispatchState, prs []PullRequest, org string) DispatchState {
+	openHeads := map[string]bool{}
+	openPRs := map[string]bool{}
+	for _, pr := range prs {
+		repo := fullRepoName(pr.Repo, org)
+		openHeads[reviewKey(repo, pr.Number, pr.HeadSHA)] = true
+		openPRs[fmt.Sprintf("%s#%d", repo, pr.Number)] = true
+	}
+	var pending []PendingReview
+	for _, p := range state.Pending {
+		if openHeads[reviewKey(p.Repo, p.Number, p.HeadSHA)] {
+			pending = append(pending, p)
+		}
+	}
+	state.Pending = pending
+	var fixes []PendingFix
+	for _, f := range state.Fixes {
+		if openPRs[fmt.Sprintf("%s#%d", f.Repo, f.Number)] {
+			fixes = append(fixes, f)
+		}
+	}
+	state.Fixes = fixes
+	var human []HumanReviewHold
+	for _, h := range state.Human {
+		if openHeads[reviewKey(h.Repo, h.Number, h.HeadSHA)] {
+			human = append(human, h)
+		}
+	}
+	state.Human = human
+	return state
+}
+
+func fullRepoName(repo, org string) string {
+	if repo == "" || strings.Contains(repo, "/") || org == "" {
+		return repo
+	}
+	return org + "/" + repo
+}
+
+func isAgentAuthored(author, aiAuthor string) bool {
+	author = strings.TrimSpace(author)
+	return author != "" && (strings.EqualFold(author, strings.TrimSpace(aiAuthor)) || strings.HasSuffix(author, "[bot]"))
+}
+
+func samePRHead(repo string, number int, sha string, wantRepo string, wantNumber int, wantSHA string) bool {
+	return number == wantNumber && strings.TrimSpace(repo) == strings.TrimSpace(wantRepo) && strings.TrimSpace(sha) == strings.TrimSpace(wantSHA)
+}
+
+func fixIndex(fixes []PendingFix, repo string, number int, headSHA string) int {
+	for i, f := range fixes {
+		if samePRHead(f.Repo, f.Number, f.HeadSHA, repo, number, headSHA) {
+			return i
+		}
+	}
+	return -1
+}
+
+func maxFixAttemptsForPR(fixes []PendingFix, repo string, number int) int {
+	max := 0
+	for _, f := range fixes {
+		if f.Repo == repo && f.Number == number && f.Attempts > max {
+			max = f.Attempts
+		}
+	}
+	return max
+}
+
+func upsertHuman(items []HumanReviewHold, item HumanReviewHold) []HumanReviewHold {
+	for i := range items {
+		if samePRHead(items[i].Repo, items[i].Number, items[i].HeadSHA, item.Repo, item.Number, item.HeadSHA) {
+			items[i] = item
+			return items
+		}
+	}
+	return append(items, item)
+}
+
+func dispatchKickKey(k DispatchKick) string {
+	return fmt.Sprintf("%s|%s|%s#%d@%s|%s", k.Kind, k.Agent, strings.TrimSpace(k.Repo), k.Number, strings.TrimSpace(k.HeadSHA), k.Perspective)
+}

--- a/v2/pkg/review/dispatch_test.go
+++ b/v2/pkg/review/dispatch_test.go
@@ -1,0 +1,135 @@
+package review
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/escalation"
+	"github.com/kubestellar/hive/v2/pkg/outputschema"
+)
+
+func reviewer(name string) AgentCapability {
+	return AgentCapability{Name: name, Enabled: true, UsesKick: true, Role: "reviewer"}
+}
+
+func dispatchPR(sha string) PullRequest {
+	return PullRequest{Repo: "hive", Number: 7, Title: "fix bug", Author: "hive-bot[bot]", HeadSHA: sha, URL: "https://example.invalid/pr/7", Lane: "quality"}
+}
+
+func TestPlanDispatchStateMachine(t *testing.T) {
+	now := time.Date(2026, 8, 7, 1, 2, 3, 0, time.UTC)
+	tests := []struct {
+		name        string
+		opts        DispatchOptions
+		state       DispatchState
+		artifact    Artifact
+		wantReviews int
+		wantPending int
+	}{
+		{name: "fan out disabled is no-op", opts: DispatchOptions{RequireApproval: true, FanOut: false, Agents: []AgentCapability{reviewer("r1")}}, wantReviews: 0, wantPending: 0},
+		{name: "parallel reviewers dispatch up to cap", opts: DispatchOptions{RequireApproval: true, FanOut: true, MaxParallelReviews: 3, Agents: []AgentCapability{reviewer("r1"), reviewer("r2"), reviewer("r3")}}, wantReviews: 3, wantPending: 3},
+		{name: "single reviewer dispatches one sequential round", opts: DispatchOptions{RequireApproval: true, FanOut: true, Agents: []AgentCapability{reviewer("r1")}}, wantReviews: 1, wantPending: 1},
+		{name: "fresh aggregate suppresses duplicate review", opts: DispatchOptions{RequireApproval: true, FanOut: true, Agents: []AgentCapability{reviewer("r1"), reviewer("r2")}}, artifact: Artifact{Items: []Aggregate{{Repo: "acme/hive", Number: 7, HeadSHA: "sha1", Verdict: VerdictApprove}}}, wantReviews: 0, wantPending: 0},
+		{name: "pending same head suppresses duplicate perspective", opts: DispatchOptions{RequireApproval: true, FanOut: true, MaxParallelReviews: 5, Agents: []AgentCapability{reviewer("r1"), reviewer("r2")}}, state: DispatchState{Pending: []PendingReview{{Repo: "acme/hive", Number: 7, HeadSHA: "sha1", Perspective: PerspectiveCorrectness, Agent: "r1"}}}, wantReviews: 4, wantPending: 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.opts.ProjectOrg = "acme"
+			tt.opts.Now = now
+			plan := PlanDispatch([]PullRequest{dispatchPR("sha1")}, tt.artifact, tt.state, tt.opts)
+			if len(plan.ReviewKicks) != tt.wantReviews || len(plan.State.Pending) != tt.wantPending {
+				t.Fatalf("reviews=%d pending=%d, want %d/%d", len(plan.ReviewKicks), len(plan.State.Pending), tt.wantReviews, tt.wantPending)
+			}
+		})
+	}
+}
+
+func TestPlanDispatchSHAInvalidation(t *testing.T) {
+	state := DispatchState{Pending: []PendingReview{{Repo: "acme/hive", Number: 7, HeadSHA: "old", Perspective: PerspectiveSecurity, Agent: "r1"}}}
+	plan := PlanDispatch([]PullRequest{dispatchPR("new")}, Artifact{}, state, DispatchOptions{RequireApproval: true, FanOut: true, ProjectOrg: "acme", Agents: []AgentCapability{reviewer("r1"), reviewer("r2")}})
+	if len(plan.State.Pending) != DefaultMaxParallelReviews {
+		t.Fatalf("old head pending reviews were not invalidated: %+v", plan.State.Pending)
+	}
+	for _, p := range plan.State.Pending {
+		if p.HeadSHA != "new" {
+			t.Fatalf("stale pending entry survived: %+v", p)
+		}
+	}
+}
+
+func TestConfirmDeliveredRollsBackFailedKicks(t *testing.T) {
+	planned := []DispatchKick{
+		{Kind: "review", Agent: "r1", Repo: "acme/hive", Number: 7, HeadSHA: "sha1", Perspective: PerspectiveCorrectness},
+		{Kind: "review", Agent: "r2", Repo: "acme/hive", Number: 7, HeadSHA: "sha1", Perspective: PerspectiveSecurity},
+		{Kind: "fix", Agent: "quality", Repo: "acme/hive", Number: 7, HeadSHA: "sha1"},
+	}
+	state := DispatchState{
+		Pending: []PendingReview{
+			{Repo: "acme/hive", Number: 7, HeadSHA: "sha1", Perspective: PerspectiveCorrectness, Agent: "r1"},
+			{Repo: "acme/hive", Number: 7, HeadSHA: "sha1", Perspective: PerspectiveSecurity, Agent: "r2"},
+		},
+		Fixes: []PendingFix{{Repo: "acme/hive", Number: 7, HeadSHA: "sha1", Agent: "quality", Attempts: 1}},
+	}
+	got := ConfirmDelivered(state, planned, planned[:1])
+	if len(got.Pending) != 1 || got.Pending[0].Perspective != PerspectiveCorrectness {
+		t.Fatalf("undelivered review was not rolled back: %+v", got.Pending)
+	}
+	if len(got.Fixes) != 0 {
+		t.Fatalf("undelivered fix was not rolled back: %+v", got.Fixes)
+	}
+}
+
+func TestBuildFixPromptAndCapExhaustion(t *testing.T) {
+	finding := PerspectiveFinding{Perspective: PerspectiveCorrectness, Finding: outputschema.Finding{Title: "nil panic", Severity: outputschema.SeverityMedium, Summary: "guard nil input"}}
+	agg := Aggregate{Repo: "acme/hive", Number: 7, HeadSHA: "sha1", Verdict: VerdictChangesRequested, Findings: []PerspectiveFinding{finding}}
+	pr := dispatchPR("sha1")
+	pr.Repo = "acme/hive"
+	prompt := BuildFixPrompt(pr, agg, 1, escalation.MaxReEngagements)
+	if !strings.Contains(prompt, "nil panic") || !strings.Contains(prompt, "attempt 1") || !strings.Contains(prompt, "acme/hive#7") {
+		t.Fatalf("fix prompt missing expected context:\n%s", prompt)
+	}
+	state := DispatchState{}
+	for i := 1; i <= escalation.MaxReEngagements; i++ {
+		state.Fixes = append(state.Fixes, PendingFix{Repo: "acme/hive", Number: 7, HeadSHA: "old", Attempts: i})
+	}
+	plan := PlanDispatch([]PullRequest{pr}, Artifact{Items: []Aggregate{agg}}, state, DispatchOptions{RequireApproval: true, FanOut: true, ProjectOrg: "acme", Agents: []AgentCapability{reviewer("r1")}})
+	if len(plan.FixKicks) != 0 || len(plan.State.Human) != 1 || !strings.Contains(plan.State.Human[0].Reason, "cap reached") {
+		t.Fatalf("cap exhaustion did not require human: kicks=%d human=%+v", len(plan.FixKicks), plan.State.Human)
+	}
+}
+
+func TestFixDispatchFallsBackToAvailableScanner(t *testing.T) {
+	agg := Aggregate{Repo: "acme/hive", Number: 7, HeadSHA: "sha1", Verdict: VerdictChangesRequested}
+	pr := dispatchPR("sha1")
+	pr.Repo = "acme/hive"
+	pr.Lane = "quality"
+	plan := PlanDispatch([]PullRequest{pr}, Artifact{Items: []Aggregate{agg}}, DispatchState{}, DispatchOptions{
+		RequireApproval: true,
+		FanOut:          true,
+		ProjectOrg:      "acme",
+		Agents: []AgentCapability{
+			{Name: "quality", Enabled: false, UsesKick: true},
+			{Name: DefaultFixerAgent, Enabled: true, UsesKick: true},
+			reviewer("r1"),
+		},
+	})
+	if len(plan.FixKicks) != 1 || plan.FixKicks[0].Agent != DefaultFixerAgent {
+		t.Fatalf("fixer fallback = %+v, want scanner", plan.FixKicks)
+	}
+}
+
+func TestConfigReviewDefaults(t *testing.T) {
+	var cfg config.ReviewConfig
+	if cfg.FanOut || cfg.RequireApproval {
+		t.Fatalf("review fan-out/approval must default off: %+v", cfg)
+	}
+	if got := cfg.EffectiveMaxParallelReviews(); got != config.DefaultMaxParallelReviews {
+		t.Fatalf("default max parallel = %d, want %d", got, config.DefaultMaxParallelReviews)
+	}
+	cfg.MaxParallelReviews = 2
+	if got := cfg.EffectiveMaxParallelReviews(); got != 2 {
+		t.Fatalf("configured max parallel = %d, want 2", got)
+	}
+}

--- a/v2/pkg/review/prompts.go
+++ b/v2/pkg/review/prompts.go
@@ -13,6 +13,7 @@ type PullRequest struct {
 	Author  string
 	HeadSHA string
 	URL     string
+	Lane    string
 }
 
 func BuildPerspectivePrompt(p Perspective, pr PullRequest) string {


### PR DESCRIPTION
Part of #2807.

## Summary
- Add persisted review dispatch state for per-head, per-perspective fan-out with SHA invalidation and parallel/sequential reviewer selection.
- Wire governor eval to refresh review verdict artifacts, dispatch review kicks through existing scheduler/agent kick delivery, and persist only successfully delivered review/fix kicks.
- Add bounded auto-fix prompts with aggregate findings, fixer fallback, cap exhaustion to requires-human state, config defaults, and docs.

## Validation
- cd v2 && go build ./...
- cd v2 && go test ./pkg/review/... ./pkg/governor/... ./pkg/scheduler/... -count=1
- cd v2 && go vet ./pkg/review/... ./pkg/config ./cmd/hive