### PR TITLE
✨ feat(contribute): surface the merger tier in every trust-tier listing

### DIFF
--- a/v2/docs/credly-badges.md
+++ b/v2/docs/credly-badges.md
@@ -45,6 +45,7 @@ attained milestone maps to one Credly badge template:
 | ----------------------------------- | ------------------------------- | ----------------- |
 | `tier-contributor`                  | Reached Contributor (5 PR-tasks)| Contributor badge |
 | `tier-trusted`                      | Reached Trusted (20 PR-tasks)   | Trusted badge     |
+| `tier-merger`                       | Reached Merger (maintainer/owner-granted) | Merger badge |
 | `tier-advisor`                      | Reached Advisor (maintainer-granted) | Advisor badge |
 | `tasks-25`                          | 25 tasks shipped                | 25-task milestone |
 | `tasks-100`                         | 100 tasks shipped               | 100-task milestone|
@@ -58,7 +59,7 @@ Issue a badge **once**, at the moment the milestone is first attained — i.e. o
 
 - **Tier promotion** — when a contributor crosses `newcomer → contributor`
   (auto, `TasksWithPR >= contributorAutoPromoteAt`) or is granted
-  `trusted` / `advisor` by a maintainer.
+  `trusted` / `merger` / `advisor` by a maintainer/owner.
 - **Task-shipped landmark** — when `TasksCompleted` first reaches a landmark in
   `taskShippedMilestones`.
 

--- a/v2/docs/manual-provisioning.md
+++ b/v2/docs/manual-provisioning.md
@@ -568,7 +568,7 @@ hive has no fleet-registry entry (never heartbeated). So a hive with
 `owner: <someone>` in its `meta.json` appears in that person's My Hives (and the
 admin's) as soon as the file exists.
 
-**Contributor tiers.** Manage Access grants four ordered roles:
+**Hub access roles.** Manage Access grants four ordered roles (separate from the ClankeR trust tiers shown on `/contribute`):
 `read` < `read-write` < `merger` < `owner`. `merger` inherits read-write
 dashboard access and can approve/queue **other people's** PRs for the hive
 auto-merge-on-green flow. The spoke enforces the self-merge ban against the

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -2692,12 +2692,19 @@ func (c *Config) applyDefaults() {
 		c.Hub.ContributeAllowLabels = nil
 	}
 
-	if len(c.Hub.TierLimits) == 0 {
-		c.Hub.TierLimits = map[string]TierRate{
-			"newcomer":    {MaxPerHour: 3, MaxPerDay: 10, MaxConcurrent: 1},
-			"contributor": {MaxPerHour: 10, MaxPerDay: 50, MaxConcurrent: 2},
-			"trusted":     {MaxPerHour: 30, MaxPerDay: 200, MaxConcurrent: 5},
-			"advisor":     {MaxPerHour: 0, MaxPerDay: 0, MaxConcurrent: 0},
+	defaultTierLimits := map[string]TierRate{
+		"newcomer":    {MaxPerHour: 3, MaxPerDay: 10, MaxConcurrent: 1},
+		"contributor": {MaxPerHour: 10, MaxPerDay: 50, MaxConcurrent: 2},
+		"trusted":     {MaxPerHour: 30, MaxPerDay: 200, MaxConcurrent: 5},
+		"merger":      {MaxPerHour: 30, MaxPerDay: 200, MaxConcurrent: 5},
+		"advisor":     {MaxPerHour: 0, MaxPerDay: 0, MaxConcurrent: 0},
+	}
+	if c.Hub.TierLimits == nil {
+		c.Hub.TierLimits = map[string]TierRate{}
+	}
+	for tier, limits := range defaultTierLimits {
+		if _, ok := c.Hub.TierLimits[tier]; !ok {
+			c.Hub.TierLimits[tier] = limits
 		}
 	}
 

--- a/v2/pkg/config/merger_tier_defaults_test.go
+++ b/v2/pkg/config/merger_tier_defaults_test.go
@@ -1,0 +1,22 @@
+package config
+
+import "testing"
+
+func TestApplyDefaultsBackfillsMergerTierLimit(t *testing.T) {
+	cfg := &Config{}
+	cfg.Hub.TierLimits = map[string]TierRate{
+		"trusted": {MaxPerHour: 7, MaxPerDay: 8, MaxConcurrent: 9},
+	}
+	cfg.applyDefaults()
+
+	if got := cfg.Hub.TierLimits["trusted"]; got.MaxPerHour != 7 || got.MaxPerDay != 8 || got.MaxConcurrent != 9 {
+		t.Fatalf("applyDefaults overwrote existing trusted limits: %+v", got)
+	}
+	got, ok := cfg.Hub.TierLimits["merger"]
+	if !ok {
+		t.Fatalf("applyDefaults did not backfill merger tier limit: %+v", cfg.Hub.TierLimits)
+	}
+	if got.MaxPerHour != 30 || got.MaxPerDay != 200 || got.MaxConcurrent != 5 {
+		t.Fatalf("merger defaults = %+v, want 30/hr 200/day 5 concurrent", got)
+	}
+}

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -47,10 +47,10 @@ const (
 )
 
 // inviteTrustTiers are the trust tiers permitted to mint an invite link. Only a
-// trusted or advisor contributor may invite; a newcomer/contributor/anonymous
+// trusted, merger, or advisor contributor may invite; a newcomer/contributor/anonymous
 // viewer may not. Enforced server-side (handleContributeInvite) — UI hiding is
 // UX only.
-var inviteTrustTiers = map[string]bool{"trusted": true, "advisor": true}
+var inviteTrustTiers = map[string]bool{"trusted": true, "merger": true, "advisor": true}
 
 var (
 	inviteSecretOnce  sync.Once
@@ -224,7 +224,7 @@ func (s *Server) registerContributeRoutes() {
 	s.mux.HandleFunc("GET /contribute/{tab}", s.handleContributeLanding)
 	s.mux.HandleFunc("GET /api/contribute/ws", s.contributeHub.HandleWS)
 	s.mux.HandleFunc("POST /api/contribute/register", s.handleContributeRegister)
-	// Trusted invite link (issue #2598). A trusted/advisor contributor mints an
+	// Trusted invite link (issue #2598). A trusted/merger/advisor contributor mints an
 	// attributed invite link here; the caller's identity is resolved server-side
 	// and their trust tier is verified IN-HANDLER (403 otherwise) — the /api/
 	// contribute prefix is exempt from roleEnforcement's read-only block, so the
@@ -473,6 +473,7 @@ func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request)
 		{"Newcomer", "#d29922", tierCounts["newcomer"]},
 		{"Contributor", "#58a6ff", tierCounts["contributor"]},
 		{"Trusted", "#3fb950", tierCounts["trusted"]},
+		{"Merger", "#f778ba", tierCounts["merger"]},
 		{"Advisor", "#bc8cff", tierCounts["advisor"]},
 		{"Revoked", "#f85149", tierCounts["revoked"]},
 	}
@@ -513,11 +514,14 @@ func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request)
 	//     contributorTrustedAt is the documented guideline threshold, so we phrase
 	//     it as "~20 PR tasks, then granted by a maintainer" rather than implying an
 	//     automatic unlock. Trusted's scoped token adds checks:read on top of the
-	//     contributor scopes; the merge decision itself is still gated by the
-	//     project's /approve + lgtm automation, so we do not claim "Merge PRs".
+	//     contributor scopes.
+	//   - Merger is the explicit maintainer/owner-granted trust tier for queueing
+	//     others' PRs for auto-merge. The server-side queue endpoint still forbids
+	//     queueing your own PR.
 	tierTableRows := fmt.Sprintf(
 		`<tr><td>Contributor</td><td>%d tasks that produced a PR</td><td>Create PRs, push code</td></tr>`+
-			`<tr><td>Trusted</td><td>~%d PR tasks, then granted by a maintainer</td><td>Extra review scope (checks:read)</td></tr>`,
+			`<tr><td>Trusted</td><td>~%d PR tasks, then granted by a maintainer</td><td>Extra review scope (checks:read)</td></tr>`+
+			`<tr><td>Merger</td><td>Granted by a maintainer/owner</td><td>Queue others' PRs for auto-merge — never your own</td></tr>`,
 		contributorAutoPromoteAt, contributorTrustedAt,
 	)
 
@@ -750,6 +754,7 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 .tier-badge{display:inline-flex;align-items:center;gap:5px;font-size:.68rem;font-weight:600;line-height:1;padding:3px 8px 3px 6px;border-radius:999px;border:1px solid var(--cc-border);background:var(--cc-bg);color:var(--cc-muted);text-transform:capitalize;white-space:nowrap}
 .tier-badge::before{content:"";width:8px;height:8px;border-radius:50%%;background:currentColor;box-shadow:inset 0 0 0 1px rgba(1,4,9,.35);flex:none}
 .tier-badge.tier-advisor{border-color:rgba(210,169,85,.45);background:rgba(210,169,85,.10);color:#d0a955}
+.tier-badge.tier-merger{border-color:rgba(247,120,186,.42);background:rgba(247,120,186,.10);color:#f778ba}
 .tier-badge.tier-trusted{border-color:rgba(201,162,39,.40);background:rgba(201,162,39,.08);color:#c9a94a}
 .tier-badge.tier-contributor{border-color:rgba(110,163,201,.38);background:rgba(110,163,201,.08);color:#6ea3c9}
 .tier-badge.tier-newcomer{border-color:var(--cc-border);background:var(--cc-bg);color:var(--cc-muted)}
@@ -2099,7 +2104,7 @@ It clears automatically when the period elapses. An operator can shorten or disa
 // value, so ADMIN_TIER_ORDER.map / ccActivitySeen[k] / ccActivity.length ran against
 // undefined and threw. Declaring+initializing them here — before any function that
 // uses them can run — makes the ordering explicit and regression-proof.
-var ADMIN_TIER_ORDER=['newcomer','contributor','trusted','advisor'];
+var ADMIN_TIER_ORDER=['newcomer','contributor','trusted','merger','advisor'];
 // ADMIN_COOLDOWN_DEFAULT_HOURS mirrors the server default (contributeCooldownDefaultHours,
 // 168h = one week) so the period input shows the effective default when unset.
 // ADMIN_COOLDOWN_MIN/MAX_HOURS mirror the server clamp bounds.
@@ -2277,12 +2282,12 @@ function loadLeaderboard(){
   });
 }
 // tierBadge renders a small tier medallion / rank badge from a REAL trust tier.
-// The four known tiers each get a muted metal-ish accent class; an unknown/blank
+// The five known tiers each get a muted metal-ish accent class; an unknown/blank
 // tier is treated as newcomer (neutral). extraCls lets callers request the compact
 // leaderboard/inline variants. Nothing here is fabricated — it is a pure visual
 // wrap around the tier string the leaderboard/fleet snapshot already carries.
 function tierBadge(tier,extraCls){
-  var known={newcomer:1,contributor:1,trusted:1,advisor:1};
+  var known={newcomer:1,contributor:1,trusted:1,merger:1,advisor:1};
   var t=String(tier||'').toLowerCase();
   if(!known[t])t='newcomer';
   return '<span class="tier-badge tier-'+t+(extraCls?(' '+extraCls):'')+'">'+esc(t)+'</span>';
@@ -2363,6 +2368,7 @@ var ME_STYLE_NAMES=['Signal blue','Verdant','Amber rank','Violet advisor','Minim
 var ME_CREDLY_MAP={
   'tier-contributor':'Contributor badge',
   'tier-trusted':'Trusted badge',
+  'tier-merger':'Merger badge',
   'tier-advisor':'Advisor badge',
   'tasks-25':'25-task milestone badge',
   'tasks-100':'100-task milestone badge'
@@ -2445,6 +2451,7 @@ function meMilestoneChips(p){
     if(nm.id&&nm.id.indexOf('tasks-')===0){var gap=nm.value-(p.tasks_completed||0);if(gap>0)toGo=' — '+gap+' to go';}
     else if(nm.id==='tier-contributor'){var g2=nm.value-(p.tasks_with_pr||0);if(g2>0)toGo=' — '+g2+' PR-tasks to go';}
     else if(nm.id==='tier-trusted'){var g3=nm.value-(p.tasks_with_pr||0);if(g3>0)toGo=' — '+g3+' PR-tasks to go';}
+    else if(nm.id==='tier-merger'){toGo=' — maintainer grant required';}
     next='<span class="me-chip me-chip--next" title="'+esc(nm.detail||'')+'">○ '+esc(nm.label)+esc(toGo)+'</span>';
   }
   if(!got.length&&!next)return '<span class="me-chip">No milestones yet — ship your first task</span>';
@@ -2485,10 +2492,10 @@ function meHivesRows(p){
 // Trust tiers permitted to invite. Kept in sync with the server's
 // inviteTrustTiers gate; the UI hiding here is UX only — the /api/contribute/
 // invite endpoint independently verifies the caller's tier and 403s otherwise.
-var INVITE_TIERS={trusted:true,advisor:true};
+var INVITE_TIERS={trusted:true,merger:true,advisor:true};
 
 // meInviteSection renders the "Invite someone to contribute" affordance ONLY for
-// a viewer whose real trust tier is trusted/advisor. Any other tier (newcomer /
+// a viewer whose real trust tier is trusted/merger/advisor. Any other tier (newcomer /
 // contributor) — and anonymous viewers never reach renderMeCard — get nothing.
 function meInviteSection(p){
   if(!p||!INVITE_TIERS[p.trust_tier])return '';
@@ -3326,7 +3333,7 @@ function renderClankers(list){
     if(adminEnabled&&c.contributor_id){
       var cid=esc(c.contributor_id);
       var tier=c.trust_tier||'newcomer';
-      var opts=['newcomer','contributor','trusted','advisor'].map(function(t){
+      var opts=['newcomer','contributor','trusted','merger','advisor'].map(function(t){
         return '<option value="'+t+'"'+(t===tier?' selected':'')+'>'+t+'</option>';
       }).join('');
       // Reassign (kubestellar/hive#2568 + follow-up) is only meaningful while the clanker
@@ -4968,7 +4975,7 @@ func (s *Server) resolveContributeCaller(r *http.Request) string {
 
 // handleContributeInvite mints a trusted, attributed invite link (issue #2598).
 // It resolves the caller's identity server-side, loads their contributor
-// profile, and requires their trust tier to be trusted or advisor — a newcomer,
+// profile, and requires their trust tier to be trusted, merger, or advisor — a newcomer,
 // contributor, or anonymous caller gets 403. The returned token encodes the
 // inviter so that whoever registers via the link is attributed to them while
 // still joining as a plain newcomer (the register path never elevates tier).
@@ -4984,7 +4991,7 @@ func (s *Server) handleContributeInvite(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if !inviteTrustTiers[profile.TrustTier] {
-		jsonError(w, "Only trusted or advisor contributors can invite others. Keep shipping to earn trust.", http.StatusForbidden)
+		jsonError(w, "Only trusted, merger, or advisor contributors can invite others. Keep shipping to earn trust.", http.StatusForbidden)
 		return
 	}
 
@@ -5329,7 +5336,7 @@ type tierLimitView struct {
 
 // limitsTierOrder is the trust progression, so the UI lists tiers newcomer→advisor
 // rather than in Go map iteration order (non-deterministic).
-var limitsTierOrder = []string{"newcomer", "contributor", "trusted", "advisor"}
+var limitsTierOrder = []string{"newcomer", "contributor", "trusted", "merger", "advisor"}
 
 // handleContributeLimits serves the hive's per-tier rate limits (#2595) plus the
 // VIEWER's own daily/hourly usage when we can identify them. This makes the managed
@@ -5668,7 +5675,7 @@ func (s *Server) handleContributorTrust(w http.ResponseWriter, r *http.Request) 
 		jsonError(w, "Invalid request", http.StatusBadRequest)
 		return
 	}
-	validTiers := map[string]bool{"newcomer": true, "contributor": true, "trusted": true, "advisor": true, "revoked": true}
+	validTiers := map[string]bool{"newcomer": true, "contributor": true, "trusted": true, "merger": true, "advisor": true, "revoked": true}
 	if !validTiers[req.Tier] {
 		jsonError(w, "Invalid tier", http.StatusBadRequest)
 		return
@@ -6089,6 +6096,8 @@ func trustTierColor(tier string) string {
 		return "#3fb950"
 	case "trusted":
 		return "#d29922"
+	case "merger":
+		return "#f778ba"
 	case "advisor":
 		return "#a371f7"
 	case "revoked":
@@ -6107,6 +6116,8 @@ func trustTierBadgeCSS(tier string) (bg, text, border string) {
 		return "rgba(59,130,246,0.2)", "#60a5fa", "rgba(59,130,246,0.3)"
 	case "trusted":
 		return "rgba(34,197,94,0.2)", "#4ade80", "rgba(34,197,94,0.3)"
+	case "merger":
+		return "rgba(247,120,186,0.2)", "#f778ba", "rgba(247,120,186,0.3)"
 	case "advisor":
 		return "rgba(168,85,247,0.2)", "#c084fc", "rgba(168,85,247,0.3)"
 	case agentTierLabel:

--- a/v2/pkg/dashboard/api_contribute_more_coverage_test.go
+++ b/v2/pkg/dashboard/api_contribute_more_coverage_test.go
@@ -90,14 +90,14 @@ func TestCovK2_ContributeLandingAndGet(t *testing.T) {
 }
 
 func TestCovK2_TrustTierBadgeCSS(t *testing.T) {
-	for _, tier := range []string{"newcomer", "contributor", "trusted", "advisor", "revoked", agentTierLabel, "unknown"} {
+	for _, tier := range []string{"newcomer", "contributor", "trusted", "merger", "advisor", "revoked", agentTierLabel, "unknown"} {
 		bg, text, border := trustTierBadgeCSS(tier)
 		if bg == "" || text == "" || border == "" {
 			t.Fatalf("trustTierBadgeCSS(%q) returned empty component", tier)
 		}
 	}
 	// trustTierColor also has a per-tier switch.
-	for _, tier := range []string{"newcomer", "contributor", "trusted", "advisor", "revoked", "other"} {
+	for _, tier := range []string{"newcomer", "contributor", "trusted", "merger", "advisor", "revoked", "other"} {
 		if trustTierColor(tier) == "" {
 			t.Fatalf("trustTierColor(%q) empty", tier)
 		}

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -665,6 +665,7 @@ func TestTrustTierColor(t *testing.T) {
 		{"newcomer", "#8b949e"},
 		{"contributor", "#3fb950"},
 		{"trusted", "#d29922"},
+		{"merger", "#f778ba"},
 		{"advisor", "#a371f7"},
 		{"revoked", "#f85149"},
 		{"unknown", "#8b949e"},
@@ -685,6 +686,7 @@ func TestTrustTierBadgeCSS(t *testing.T) {
 		{"newcomer", "rgba(107,114,128,0.2)"},
 		{"contributor", "rgba(59,130,246,0.2)"},
 		{"trusted", "rgba(34,197,94,0.2)"},
+		{"merger", "rgba(247,120,186,0.2)"},
 		{"advisor", "rgba(168,85,247,0.2)"},
 		{"revoked", "rgba(239,68,68,0.2)"},
 		{"unknown", "rgba(107,114,128,0.2)"},
@@ -1155,12 +1157,12 @@ func TestContributeTabURLWiring(t *testing.T) {
 	body := w.Body.String()
 
 	for _, needle := range []string{
-		"function tabFromLocation",   // reads location.pathname + ?tab= on load
-		"history.pushState",          // address-bar reflection on tab switch
-		"popstate",                   // Back/Forward navigation
-		"'operations'",               // clean name accepted for Operations
-		"'management'",               // clean name accepted for Management
-		"/contribute/'+slug",         // path-style URL construction
+		"function tabFromLocation", // reads location.pathname + ?tab= on load
+		"history.pushState",        // address-bar reflection on tab switch
+		"popstate",                 // Back/Forward navigation
+		"'operations'",             // clean name accepted for Operations
+		"'management'",             // clean name accepted for Management
+		"/contribute/'+slug",       // path-style URL construction
 	} {
 		if !strings.Contains(body, needle) {
 			t.Errorf("served page missing tab-URL wiring: %q", needle)

--- a/v2/pkg/dashboard/contribute_tab_order_and_styling_test.go
+++ b/v2/pkg/dashboard/contribute_tab_order_and_styling_test.go
@@ -77,7 +77,7 @@ func TestContributeTabOrderSlugMappingIntact(t *testing.T) {
 
 // TestLeaderboardTierBadgesFromRealData asserts the leaderboard rows render a tier
 // medallion built from the REAL trust_tier the /api/leaderboard entry carries (via
-// tierBadge), that the four known tiers each have a per-tier accent class, and that
+// tierBadge), that the five known tiers each have a per-tier accent class, and that
 // the tasks-completed stat is emphasised as a bold numeral. Nothing fabricated.
 func TestLeaderboardTierBadgesFromRealData(t *testing.T) {
 	body := renderContributePage(t)
@@ -92,6 +92,7 @@ func TestLeaderboardTierBadgesFromRealData(t *testing.T) {
 		// Per-tier accent classes exist in the CSS (muted metal-ish tints).
 		`.tier-badge.tier-advisor`,
 		`.tier-badge.tier-trusted`,
+		`.tier-badge.tier-merger`,
 		`.tier-badge.tier-contributor`,
 		`.tier-badge.tier-newcomer`,
 		// Restrained gradient header band + strong count on the leaderboard card.

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -1779,6 +1779,8 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				perms = []string{"issues:write", "contents:write", "pulls:write"}
 			case "trusted":
 				perms = []string{"issues:write", "contents:write", "pulls:write", "checks:read"}
+			case "merger":
+				perms = []string{"issues:write", "contents:write", "pulls:write", "checks:read"}
 			case "advisor":
 				perms = []string{"metadata:read", "pulls:read"}
 			default:

--- a/v2/pkg/dashboard/me_profile.go
+++ b/v2/pkg/dashboard/me_profile.go
@@ -105,8 +105,10 @@ func tierRankValue(tier string) int {
 		return 1
 	case "trusted":
 		return 2
-	case "advisor":
+	case "merger":
 		return 3
+	case "advisor":
+		return 4
 	default:
 		return 0
 	}
@@ -137,6 +139,14 @@ func buildMilestones(p *ContributorProfile) ([]ContributorMilestone, *Contributo
 		Attained: tierRank >= tierRankValue("trusted"),
 		Value:    contributorTrustedAt,
 		Icon:     "🛡️",
+	})
+	out = append(out, ContributorMilestone{
+		ID:       "tier-merger",
+		Label:    "Reached Merger",
+		Detail:   "Granted by a maintainer/owner",
+		Attained: tierRank >= tierRankValue("merger"),
+		Value:    0,
+		Icon:     "🔀",
 	})
 	out = append(out, ContributorMilestone{
 		ID:       "tier-advisor",

--- a/v2/pkg/dashboard/me_profile_test.go
+++ b/v2/pkg/dashboard/me_profile_test.go
@@ -86,7 +86,7 @@ func TestMeProfile_AggregatesSeededContributor(t *testing.T) {
 	if bp.Rank <= p.Rank {
 		t.Fatalf("alice (%d shipped) should rank above bob: alice=#%d bob=#%d", p.TasksCompleted, p.Rank, bp.Rank)
 	}
-	// Milestones: Contributor + Trusted tiers attained (22 >= 20 PR-tasks), Advisor not.
+	// Milestones: Contributor + Trusted tiers attained (22 >= 20 PR-tasks), Merger/Advisor not.
 	got := map[string]bool{}
 	for _, m := range p.Milestones {
 		got[m.ID] = m.Attained
@@ -94,8 +94,8 @@ func TestMeProfile_AggregatesSeededContributor(t *testing.T) {
 	if !got["tier-contributor"] || !got["tier-trusted"] {
 		t.Fatalf("expected Contributor+Trusted milestones attained: %+v", p.Milestones)
 	}
-	if got["tier-advisor"] {
-		t.Fatal("Advisor should NOT be attained for a trusted contributor")
+	if got["tier-merger"] || got["tier-advisor"] {
+		t.Fatal("Merger/Advisor should NOT be attained for a trusted contributor")
 	}
 	// Tasks-shipped milestone: 25 attained (27 >= 25), 50 not.
 	if !got["tasks-25"] || got["tasks-50"] {

--- a/v2/pkg/dashboard/merger_trust_tier_ui_test.go
+++ b/v2/pkg/dashboard/merger_trust_tier_ui_test.go
@@ -1,0 +1,40 @@
+package dashboard
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestContributeTrustTierListingsIncludeMerger(t *testing.T) {
+	body := renderContributePage(t)
+	for _, want := range []string{
+		`<tr><td>Merger</td><td>Granted by a maintainer/owner</td><td>Queue others' PRs for auto-merge — never your own</td></tr>`,
+		`var ADMIN_TIER_ORDER=['newcomer','contributor','trusted','merger','advisor'];`,
+		`.tier-badge.tier-merger`,
+		`var known={newcomer:1,contributor:1,trusted:1,merger:1,advisor:1};`,
+		`var opts=['newcomer','contributor','trusted','merger','advisor'].map(function(t){`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("/contribute missing merger trust-tier UI fragment %q", want)
+		}
+	}
+}
+
+func TestGovernorHubTierListingsIncludeMerger(t *testing.T) {
+	body, err := os.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(body)
+	for _, want := range []string{
+		`const tiers = ['newcomer', 'contributor', 'trusted', 'merger', 'advisor'];`,
+		`merger:{mph:30,mpd:200,mc:5}`,
+		`merger:      'var(--pink, #f778ba)'`,
+		`const CONTRIBUTOR_FILTER_TIERS = ['newcomer', 'contributor', 'trusted', 'merger', 'advisor', 'revoked'];`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("static Governor Hub UI missing merger tier fragment %q", want)
+		}
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1603,6 +1603,7 @@
     .role-owner { background: rgba(244,199,95,0.15); color: var(--amber); border: 1px solid rgba(244,199,95,0.3); }
     .role-read { background: rgba(128,191,255,0.15); color: var(--blue); border: 1px solid rgba(128,191,255,0.3); }
     .role-read-write { background: rgba(116,223,154,0.15); color: var(--green); border: 1px solid rgba(116,223,154,0.3); }
+    .role-merger { background: rgba(247,120,186,0.15); color: #f778ba; border: 1px solid rgba(247,120,186,0.3); }
     .config-list-item {
       display: flex; align-items: center; gap: 8px;
       padding: 6px 10px; background: var(--bg); border: 1px solid var(--border);
@@ -10513,6 +10514,7 @@ function burnAreaChart() {
       newcomer:    'var(--yellow)',
       contributor: 'var(--blue)',
       trusted:     'var(--green)',
+      merger:      'var(--pink, #f778ba)',
       advisor:     'var(--purple)',
       revoked:     'var(--red)',
     };
@@ -10586,7 +10588,7 @@ function burnAreaChart() {
 
     const CONTRIBUTOR_FILTER_ALL = 'all';
     const CONTRIBUTOR_FILTER_ACTIVE = 'active';
-    const CONTRIBUTOR_FILTER_TIERS = ['newcomer', 'contributor', 'trusted', 'advisor', 'revoked'];
+    const CONTRIBUTOR_FILTER_TIERS = ['newcomer', 'contributor', 'trusted', 'merger', 'advisor', 'revoked'];
 
     function renderContributorFilters(contributors) {
       const bar = document.getElementById('contributors-filters');
@@ -10666,7 +10668,7 @@ function burnAreaChart() {
               'ClankeR \u2014 the contributor relay \u2014 lets anyone lend their own machine and AI subscription to this hive. ' +
               'Contributors register with their GitHub account, run a lightweight worker locally, and the hive ' +
               'relays tasks (issue fixes, reviews, docs) to their agents over a secure WebSocket \u2014 their compute, your backlog. ' +
-              'Completed tasks build trust: contributors are promoted automatically from <strong>Newcomer</strong> to <strong>Contributor</strong>, <strong>Trusted</strong>, and <strong>Advisor</strong> tiers.' +
+              'Completed tasks build trust: contributors are promoted automatically from <strong>Newcomer</strong> to <strong>Contributor</strong>, then maintainers can grant <strong>Trusted</strong>, <strong>Merger</strong>, and <strong>Advisor</strong> tiers.' +
             '</div>' +
             '<div style="color:var(--muted);font-size:var(--fs-base);line-height:1.6;margin-bottom:12px">' +
               '<strong style="color:var(--text)">Invite people in three steps:</strong><br>' +
@@ -14505,7 +14507,7 @@ function burnAreaChart() {
           return;
         }
         listEl.innerHTML = users.map(function(u) {
-          var roleCls = u.role === 'owner' ? 'role-owner' : u.role === 'read-write' ? 'role-read-write' : 'role-read';
+          var roleCls = u.role === 'owner' ? 'role-owner' : u.role === 'merger' ? 'role-merger' : u.role === 'read-write' ? 'role-read-write' : 'role-read';
           return '<div class="config-list-item" style="align-items:center;gap:8px">' +
             linkedAvatar(u.username, ACCESS_LIST_AVATAR_PX,
               String(u.username || '') + (u.role ? ' — ' + u.role : ''), '', '') +
@@ -15571,7 +15573,7 @@ function burnAreaChart() {
         const enabled = !(hub.disabled_repos || []).includes(name);
         return {name: name, full: r, enabled: enabled};
       });
-      const tiers = ['newcomer', 'contributor', 'trusted', 'advisor'];
+      const tiers = ['newcomer', 'contributor', 'trusted', 'merger', 'advisor'];
       const denyLabels = (hub.contribute_deny_labels || []);
       const denyTitles = (hub.contribute_deny_titles || []);
       const denyAuthors = (hub.contribute_deny_authors || []);
@@ -15704,7 +15706,7 @@ function burnAreaChart() {
           <label>Tier Access &amp; Rate Limits <span class="config-info">i<span class="config-tooltip">Toggle tiers on/off and set tasks/hour, tasks/day, max concurrent per tier. 0 = unlimited.</span></span></label>
           <div style="display:flex;flex-direction:column;gap:6px">${tiers.map(function(t) {
             const enabled = !(hub.disabled_tiers || []).includes(t);
-            const defaults = {newcomer:{mph:3,mpd:10,mc:1},contributor:{mph:5,mpd:20,mc:2},trusted:{mph:10,mpd:50,mc:3},advisor:{mph:0,mpd:0,mc:0}};
+            const defaults = {newcomer:{mph:3,mpd:10,mc:1},contributor:{mph:10,mpd:50,mc:2},trusted:{mph:30,mpd:200,mc:5},merger:{mph:30,mpd:200,mc:5},advisor:{mph:0,mpd:0,mc:0}};
             const def = defaults[t] || {mph:3,mpd:10,mc:1};
             const limits = (hub.tier_limits || {})[t] || {};
             const mph = limits.max_per_hour != null ? limits.max_per_hour : def.mph;

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -275,7 +275,7 @@ func (a *AppAuth) ScopedToken(ctx context.Context, tier string) (string, error) 
 			PullRequests: gh.Ptr("write"),
 			Metadata:     gh.Ptr("read"),
 		}
-	case "trusted":
+	case "trusted", "merger":
 		perms = &gh.InstallationPermissions{
 			Issues:       gh.Ptr("write"),
 			Contents:     gh.Ptr("write"),

--- a/v2/pkg/github/coverage_boost_test.go
+++ b/v2/pkg/github/coverage_boost_test.go
@@ -281,7 +281,7 @@ func generateTestKey(t *testing.T) (*rsa.PrivateKey, string) {
 }
 
 func TestScopedToken_AllTiers(t *testing.T) {
-	tiers := []string{"newcomer", "contributor", "trusted", "advisor", "unknown-tier", ""}
+	tiers := []string{"newcomer", "contributor", "trusted", "merger", "advisor", "unknown-tier", ""}
 
 	for _, tier := range tiers {
 		t.Run("tier_"+tier, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Chosen model: add `Merger` as a ClankeR trust tier, placed after Trusted and before Advisor. This matches the trust-tier machinery because maintainer/owner-granted tiers are already persisted as `trust_tier`, shown in contributor controls, and governed by tier limits.
- Surface Merger in `/contribute` trust tiers, Management tier limits, Governor Hub tier limits, contributor filters/selectors, badges, Me-card milestones, Credly docs, and scoped GitHub App token permissions.
- Backfill missing `tier_limits.merger` during config defaults so older configs treat it as enabled with 30/hr, 200/day, 5 concurrent limits.

## Validation
- `go build ./...`
- `go vet ./...`
- `go test ./pkg/github ./pkg/dashboard/ ./pkg/hub/ ./pkg/config/ -count=1`

## Notes
Merger can queue others' PRs for auto-merge; the server-side self-queue ban remains enforced.