### PR TITLE
🔒 feat(ioscan): canary token exfiltration detection + output secret redaction

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -93,6 +93,7 @@ project:
 ioscan:
   enabled: true        # default: true; scans untrusted text before agent kicks
   fail_mode: open      # open (default) redacts; closed blocks Critical injection kicks
+  canaries: false      # default: false; plant per-kick canaries and audit/block leaks
 ```
 
 ## Agents

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/governor"
 	"github.com/kubestellar/hive/v2/pkg/hub"
 	"github.com/kubestellar/hive/v2/pkg/intent"
+	"github.com/kubestellar/hive/v2/pkg/ioscan"
 	"github.com/kubestellar/hive/v2/pkg/knowledge"
 	"github.com/kubestellar/hive/v2/pkg/logscrub"
 	"github.com/kubestellar/hive/v2/pkg/mint"
@@ -2484,10 +2485,25 @@ func main() {
 
 	dashboard.SetBackendAuthProvider(agentMgr.BackendAuthAvailable)
 
+	canaryLeakHandler := func(leak ioscan.CanaryLeak) {
+		detail := fmt.Sprintf("rule=%s, agent=%s, source=%s", ioscan.CanaryLeakRule, leak.Agent, leak.Source)
+		dashSrv.AuditLog(leak.Agent, "ioscan_canary_leak", detail, leak.Agent)
+		if store, ok := beadStores[leak.Agent]; ok && store != nil {
+			if b, berr := store.Create("Canary token leaked via "+leak.Source, beads.TypeAdvisory, beads.PriorityCritical, leak.Agent, ""); berr == nil {
+				_ = store.SetMetadata(b.ID, "rule", ioscan.CanaryLeakRule)
+				_ = store.SetMetadata(b.ID, "source", leak.Source)
+			}
+		}
+	}
+	if ghClient != nil {
+		ghClient.SetCanaryScanner(cfg.Ioscan.IsEnabled() && cfg.Ioscan.Canaries, cfg.Ioscan.FailClosed(), ioscan.DefaultCanaries, canaryLeakHandler)
+	}
+
 	githubProxy, err := proxy.NewGitHubProxy(logger, cfg.Project.Org, cfg.Project.Repos)
 	if err != nil {
 		logger.Error("failed to create github proxy", "error", err)
 	} else {
+		githubProxy.SetCanaryScanner(cfg.Ioscan.IsEnabled() && cfg.Ioscan.Canaries, cfg.Ioscan.FailClosed(), ioscan.DefaultCanaries, canaryLeakHandler)
 		dashboard.SetProxyViolationsProvider(githubProxy.Violations)
 		// Lets the dashboard narrow the LiteLLM model dropdown to the set the
 		// configured key is entitled to, learned by the proxy from a key-info
@@ -4568,6 +4584,7 @@ func runEvalCycle(
 		if err != nil {
 			logger.Warn("failed to read advisory findings", "error", err)
 		} else if len(findings) > 0 {
+			safeFindings := make([]advisory.Finding, 0, len(findings))
 			// Log each new finding for the audit trail
 			for _, f := range findings {
 				logger.Info("advisory finding ingested",
@@ -4578,8 +4595,28 @@ func runEvalCycle(
 					"file", f.File,
 					"line", f.Line,
 				)
+				blockFinding := false
+				if cfg.Ioscan.IsEnabled() && cfg.Ioscan.Canaries {
+					reportText := strings.Join([]string{f.Title, f.Detail, f.File, f.Type, f.Severity}, "\n")
+					if leak, ok := ioscan.DefaultCanaries.Scan(f.Agent, reportText, "advisory-finding"); ok {
+						detail := fmt.Sprintf("rule=%s, agent=%s, source=%s", ioscan.CanaryLeakRule, leak.Agent, leak.Source)
+						dashSrv.AuditLog(leak.Agent, "ioscan_canary_leak", detail, leak.Agent)
+						if store, ok := beadStores[leak.Agent]; ok && store != nil {
+							if b, berr := store.Create("Canary token leaked via "+leak.Source, beads.TypeAdvisory, beads.PriorityCritical, leak.Agent, ""); berr == nil {
+								_ = store.SetMetadata(b.ID, "rule", ioscan.CanaryLeakRule)
+								_ = store.SetMetadata(b.ID, "source", leak.Source)
+							}
+						}
+						blockFinding = cfg.Ioscan.FailClosed()
+					}
+				}
+				if blockFinding {
+					logger.Warn("ioscan fail-closed blocked advisory finding with canary leak", "agent", f.Agent)
+					continue
+				}
+				safeFindings = append(safeFindings, f)
 			}
-			if persisted := advisory.PersistAsBeads(findings, beadStores); persisted > 0 {
+			if persisted := advisory.PersistAsBeads(safeFindings, beadStores); persisted > 0 {
 				logger.Info("advisory findings persisted as beads", "count", persisted)
 			}
 		}

--- a/v2/docs/adr/0008-ioscan-untrusted-input.md
+++ b/v2/docs/adr/0008-ioscan-untrusted-input.md
@@ -26,6 +26,20 @@ The v4 base also includes the fail-safe default-on mode: absent `ioscan:`
 configuration scans by default, while an explicit `ioscan.enabled: false`
 opts out ([config](../../pkg/config/config.go)).
 
+Operators may additionally enable `ioscan.canaries: true`. Hive then prepends a
+random `HIVE-CANARY-...` marker to each kick with instructions that the agent
+must never repeat it. Active canaries are kept in memory and persisted at
+`/data/ioscan-canaries.json`; the GitHub MITM proxy scans outgoing issue/PR/
+comment writes, and advisory finding ingestion scans collected agent reports. A
+leak records an `ioscan_canary_leak` audit event plus a critical advisory bead;
+with `ioscan.fail_mode: closed`, the proxy rejects the GitHub write with 403.
+Opaque git pushes cannot be inspected safely, so canary fail-closed mode blocks
+`git-receive-pack` pushes rather than allowing an unscannable exfiltration path.
+
+Agent-derived advisory text is also scrubbed with `pkg/logscrub` before GitHub
+publication so GitHub tokens, AWS access keys, bearer tokens, JWTs, and PEM
+private-key blocks are redacted rather than echoed into comments.
+
 ## Consequences
 
 Agents can still see that an issue or label existed, but they do not receive the

--- a/v2/hive.yaml.example
+++ b/v2/hive.yaml.example
@@ -14,6 +14,11 @@ project:
   ai_author: your-bot-user               # GitHub username for AI commits
   primary_repo: repo-one                 # Main repo for priority routing
 
+ioscan:
+  enabled: true                           # default: true; scans untrusted text before agent kicks
+  fail_mode: open                         # open (default) redacts; closed blocks Critical injection kicks and canary leaks
+  canaries: false                         # default: false; plant per-kick exfiltration canaries and scan agent egress
+
 # Agent CLAUDE.md policies from a git config repo (optional).
 # Uncomment and set to your own policy repo if you have custom agent prompts.
 # policies:

--- a/v2/pkg/advisory/advisory.go
+++ b/v2/pkg/advisory/advisory.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/beads"
+	"github.com/kubestellar/hive/v2/pkg/logscrub"
 )
 
 const advisoryDir = "/data/advisory"
@@ -426,10 +427,12 @@ func FormatDigestMarkdown(d *Digest, org, primaryRepo string) string {
 		icon := severityIcon(sev)
 		b.WriteString(fmt.Sprintf("### %s %s (%d)\n\n", icon, strings.ToUpper(sev), len(items)))
 		for _, f := range items {
-			loc := formatFindingRef(f.File, f.Line, org, primaryRepo, f.Title)
-			b.WriteString(fmt.Sprintf("- **[%s]** %s%s _%s_\n", f.Type, linkifyRefs(f.Title, org), loc, f.Agent))
-			if f.Detail != "" {
-				b.WriteString(fmt.Sprintf("  > %s\n", linkifyRefs(f.Detail, org)))
+			loc := formatFindingRef(logscrub.ScrubString(f.File), f.Line, org, primaryRepo, f.Title)
+			title := logscrub.ScrubString(f.Title)
+			detail := logscrub.ScrubString(f.Detail)
+			b.WriteString(fmt.Sprintf("- **[%s]** %s%s _%s_\n", f.Type, linkifyRefs(title, org), loc, f.Agent))
+			if detail != "" {
+				b.WriteString(fmt.Sprintf("  > %s\n", linkifyRefs(detail, org)))
 			}
 		}
 		b.WriteString("\n")
@@ -449,7 +452,7 @@ func writeRecentlyResolved(b *strings.Builder, d *Digest, org, primaryRepo strin
 	b.WriteString(fmt.Sprintf("### ✅ Recently Resolved (%d)\n\n", len(d.RecentlyResolved)))
 	for _, r := range d.RecentlyResolved {
 		loc := formatFindingRef(r.File, 0, org, primaryRepo, r.Title)
-		b.WriteString(fmt.Sprintf("- ~~%s~~%s _%s — resolved %s_\n", linkifyRefs(r.Title, org), loc, r.Agent, r.ClosedAt.Format("Jan 2")))
+		b.WriteString(fmt.Sprintf("- ~~%s~~%s _%s — resolved %s_\n", linkifyRefs(logscrub.ScrubString(r.Title), org), loc, r.Agent, r.ClosedAt.Format("Jan 2")))
 	}
 	b.WriteString("\n")
 }
@@ -517,9 +520,9 @@ func PersistAsBeads(findings []Finding, stores map[string]*beads.Store) (created
 
 		ref := ""
 		if f.File != "" {
-			ref = f.File
+			ref = logscrub.ScrubString(f.File)
 			if f.Line > 0 {
-				ref = fmt.Sprintf("%s:%d", f.File, f.Line)
+				ref = fmt.Sprintf("%s:%d", ref, f.Line)
 			}
 		}
 
@@ -529,10 +532,10 @@ func PersistAsBeads(findings []Finding, stores map[string]*beads.Store) (created
 			"advisory_agent": f.Agent,
 		}
 		if f.Detail != "" {
-			meta["detail"] = f.Detail
+			meta["detail"] = logscrub.ScrubString(f.Detail)
 		}
 
-		b, err := store.Create(f.Title, beads.TypeAdvisory, severityToPriority(f.Severity), f.Agent, ref)
+		b, err := store.Create(logscrub.ScrubString(f.Title), beads.TypeAdvisory, severityToPriority(f.Severity), f.Agent, ref)
 		if err != nil {
 			continue
 		}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -194,6 +194,10 @@ type IoscanConfig struct {
 	// offending text and continue the kick. "closed" blocks the kick and records
 	// an ioscan_fail_closed audit entry. Read via FailClosed().
 	FailMode string `yaml:"fail_mode,omitempty" json:"fail_mode,omitempty"`
+	// Canaries plants per-kick exfiltration markers in agent prompts and scans
+	// agent-visible egress for leaks. Default false: existing hives see no
+	// canary behavior until explicitly enabled.
+	Canaries bool `yaml:"canaries,omitempty" json:"canaries,omitempty"`
 }
 
 // IsEnabled reports whether input/output scanning is active. Absent (nil)

--- a/v2/pkg/config/ioscan_config_test.go
+++ b/v2/pkg/config/ioscan_config_test.go
@@ -47,3 +47,10 @@ func TestIoscanConfig_FailClosed(t *testing.T) {
 		})
 	}
 }
+
+func TestIoscanConfig_CanariesDefaultOff(t *testing.T) {
+	var c IoscanConfig
+	if c.Canaries {
+		t.Fatal("canaries must default off")
+	}
+}

--- a/v2/pkg/forge/github_forge.go
+++ b/v2/pkg/forge/github_forge.go
@@ -7,6 +7,7 @@ import (
 
 	gh "github.com/google/go-github/v72/github"
 	"github.com/kubestellar/hive/v2/pkg/github"
+	"github.com/kubestellar/hive/v2/pkg/logscrub"
 )
 
 // githubReader is the subset of *github.Client the GitHub adapter needs for the
@@ -159,6 +160,7 @@ func (f *gitHubForge) ListOpenChangeRequests(ctx context.Context, repo string) (
 // CreateIssueComment posts a comment on an issue or pull request.
 func (f *gitHubForge) CreateIssueComment(ctx context.Context, repo string, number int, body string) error {
 	owner, name := splitRepo(repo, f.org)
+	body = logscrub.ScrubString(body)
 	_, _, err := f.writer.CreateComment(ctx, owner, name, number, &gh.IssueComment{Body: gh.Ptr(body)})
 	if err != nil {
 		return fmt.Errorf("github: comment on %s/%s#%d: %w", owner, name, number, err)

--- a/v2/pkg/github/advisory.go
+++ b/v2/pkg/github/advisory.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	gh "github.com/google/go-github/v72/github"
+	"github.com/kubestellar/hive/v2/pkg/logscrub"
 )
 
 const (
@@ -109,7 +110,7 @@ func (c *Client) PostAdvisoryDigest(ctx context.Context, repo string, issueNum i
 	}
 	owner, repoName := c.splitRepo(repo)
 
-	digest = truncateDigest(digest)
+	digest = truncateDigest(logscrub.ScrubString(digest))
 
 	commentID, err := c.findDigestComment(ctx, owner, repoName, issueNum)
 	if err != nil {

--- a/v2/pkg/github/canary.go
+++ b/v2/pkg/github/canary.go
@@ -1,0 +1,20 @@
+package github
+
+import "github.com/kubestellar/hive/v2/pkg/ioscan"
+
+func (c *Client) scanCanaryText(text, source string) (ioscan.CanaryLeak, bool) {
+	if c == nil || !c.canariesEnabled || c.canaryRegistry == nil || text == "" {
+		return ioscan.CanaryLeak{}, false
+	}
+	leak, ok := c.canaryRegistry.Scan("", text, source)
+	if !ok {
+		return ioscan.CanaryLeak{}, false
+	}
+	if c.canaryLeakFunc != nil {
+		c.canaryLeakFunc(leak)
+	}
+	if c.logger != nil {
+		c.logger.Warn("ioscan canary leak detected", "agent", leak.Agent, "source", leak.Source)
+	}
+	return leak, true
+}

--- a/v2/pkg/github/canary_test.go
+++ b/v2/pkg/github/canary_test.go
@@ -1,0 +1,33 @@
+package github
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	gh "github.com/google/go-github/v72/github"
+	"github.com/kubestellar/hive/v2/pkg/ioscan"
+)
+
+func TestCreatePRBlocksCanaryWhenFailClosed(t *testing.T) {
+	r := ioscan.NewCanaryRegistry("")
+	cny, err := r.Add("quality")
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	called := false
+	c := &Client{client: gh.NewClient(nil), org: "org"}
+	c.SetCanaryScanner(true, true, r, func(leak ioscan.CanaryLeak) {
+		called = true
+		if leak.Agent != "quality" || !strings.HasPrefix(leak.Source, "hive-open-pr:") {
+			t.Fatalf("leak = %+v", leak)
+		}
+	})
+	_, err = c.CreatePR(context.Background(), "org/repo", "quality/fix", "main", "fix", "body "+cny.Token)
+	if err == nil || !strings.Contains(err.Error(), "ioscan canary leak") {
+		t.Fatalf("CreatePR error = %v, want canary block", err)
+	}
+	if !called {
+		t.Fatal("leak callback was not called")
+	}
+}

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	gh "github.com/google/go-github/v72/github"
+	"github.com/kubestellar/hive/v2/pkg/ioscan"
+	"github.com/kubestellar/hive/v2/pkg/logscrub"
 )
 
 // ErrNoGitHubClient is returned by *Client methods invoked on a nil receiver.
@@ -25,13 +27,17 @@ import (
 var ErrNoGitHubClient = errors.New("no github client configured (hive is running without GitHub credentials)")
 
 type Client struct {
-	client       *gh.Client
-	org          string
-	reposMu      sync.RWMutex
-	repos        []string
-	exemptLabels []string
-	logger       *slog.Logger
-	appAuth      *AppAuth // nil for token-authenticated clients
+	client           *gh.Client
+	org              string
+	reposMu          sync.RWMutex
+	repos            []string
+	exemptLabels     []string
+	logger           *slog.Logger
+	appAuth          *AppAuth // nil for token-authenticated clients
+	canariesEnabled  bool
+	canaryFailClosed bool
+	canaryRegistry   *ioscan.CanaryRegistry
+	canaryLeakFunc   func(ioscan.CanaryLeak)
 	// prAuthz gates PR-open requests from the request-file watcher against the
 	// per-agent ACMM write-policy + forge-resistance. nil fails closed. Set by
 	// StartPRRequestWatcher.
@@ -73,6 +79,16 @@ type Client struct {
 	// advisoryMu.
 	advisoryMu          sync.Mutex
 	advisoryDigestPosts map[string]int
+}
+
+func (c *Client) SetCanaryScanner(enabled, failClosed bool, reg *ioscan.CanaryRegistry, onLeak func(ioscan.CanaryLeak)) {
+	if c == nil {
+		return
+	}
+	c.canariesEnabled = enabled
+	c.canaryFailClosed = failClosed
+	c.canaryRegistry = reg
+	c.canaryLeakFunc = onLeak
 }
 
 // GoGitHub returns the underlying go-github client for direct API access.
@@ -710,6 +726,7 @@ func (c *Client) CreateIssueComment(ctx context.Context, repo string, number int
 	if c == nil {
 		return ErrNoGitHubClient
 	}
+	body = logscrub.ScrubString(body)
 	owner, repoName := c.splitRepo(repo)
 	_, _, err := c.client.Issues.CreateComment(ctx, owner, repoName, number, &gh.IssueComment{Body: gh.Ptr(body)})
 	return err

--- a/v2/pkg/github/pullrequest.go
+++ b/v2/pkg/github/pullrequest.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	gh "github.com/google/go-github/v72/github"
+	"github.com/kubestellar/hive/v2/pkg/logscrub"
 )
 
 // CreatePRResult is what CreatePR returns: the opened (or pre-existing) PR.
@@ -54,6 +55,13 @@ func (c *Client) CreatePR(ctx context.Context, repo, head, base, title, body str
 	if strings.TrimSpace(title) == "" {
 		return CreatePRResult{}, fmt.Errorf("CreatePR: title is required")
 	}
+	if leak, ok := c.scanCanaryText(title+"\n"+body, "hive-open-pr:"+repo); ok {
+		if c.canaryFailClosed {
+			return CreatePRResult{}, fmt.Errorf("ioscan canary leak detected: agent=%s source=%s", leak.Agent, leak.Source)
+		}
+	}
+	title = logscrub.ScrubString(title)
+	body = logscrub.ScrubString(body)
 
 	// Idempotency: don't open a second PR for a branch that already has an open
 	// one. GitHub itself 422s on a duplicate, but checking first lets us return

--- a/v2/pkg/ioscan/canary.go
+++ b/v2/pkg/ioscan/canary.go
@@ -1,0 +1,169 @@
+package ioscan
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	CanaryPrefix      = "HIVE-CANARY-"
+	canaryRandomBytes = 24
+	canaryFilePerm    = 0o600
+	canaryDirPerm     = 0o755
+	DefaultCanaryPath = "/data/ioscan-canaries.json"
+	CanaryLeakRule    = "canary.leak"
+)
+
+type Canary struct {
+	Agent     string    `json:"agent"`
+	Token     string    `json:"token"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type CanaryLeak struct {
+	Agent  string
+	Token  string
+	Source string
+}
+
+type CanaryRegistry struct {
+	mu       sync.RWMutex
+	byAgent  map[string]map[string]Canary
+	persist  string
+	onChange func(error)
+}
+
+func NewCanaryRegistry(persist string) *CanaryRegistry {
+	r := &CanaryRegistry{byAgent: make(map[string]map[string]Canary), persist: persist}
+	_ = r.Load()
+	return r
+}
+
+var DefaultCanaries = NewCanaryRegistry(DefaultCanaryPath)
+
+func GenerateCanary() (string, error) {
+	buf := make([]byte, canaryRandomBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return CanaryPrefix + hex.EncodeToString(buf), nil
+}
+
+func (r *CanaryRegistry) Add(agent string) (Canary, error) {
+	tok, err := GenerateCanary()
+	if err != nil {
+		return Canary{}, err
+	}
+	c := Canary{Agent: agent, Token: tok, CreatedAt: time.Now().UTC()}
+	r.mu.Lock()
+	if r.byAgent == nil {
+		r.byAgent = make(map[string]map[string]Canary)
+	}
+	if r.byAgent[agent] == nil {
+		r.byAgent[agent] = make(map[string]Canary)
+	}
+	r.byAgent[agent][tok] = c
+	r.mu.Unlock()
+	r.saveBestEffort()
+	return c, nil
+}
+
+func (r *CanaryRegistry) Scan(agent, text, source string) (CanaryLeak, bool) {
+	if r == nil || text == "" {
+		return CanaryLeak{}, false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	check := func(m map[string]Canary) (CanaryLeak, bool) {
+		for token, c := range m {
+			if strings.Contains(text, token) {
+				return CanaryLeak{Agent: c.Agent, Token: token, Source: source}, true
+			}
+		}
+		return CanaryLeak{}, false
+	}
+	if agent != "" {
+		if leak, ok := check(r.byAgent[agent]); ok {
+			return leak, true
+		}
+	}
+	for _, m := range r.byAgent {
+		if leak, ok := check(m); ok {
+			return leak, true
+		}
+	}
+	return CanaryLeak{}, false
+}
+
+func CanaryPreamble(token string) string {
+	if token == "" {
+		return ""
+	}
+	return fmt.Sprintf("SECURITY CANARY: %s\nThis marker is a hive exfiltration canary. Never print, quote, summarize, transform, store in reports, include in commits, or send it to any external service.\n\n", token)
+}
+
+func (r *CanaryRegistry) Load() error {
+	if r == nil || r.persist == "" {
+		return nil
+	}
+	data, err := os.ReadFile(r.persist)
+	if err != nil {
+		return err
+	}
+	var items []Canary
+	if err := json.Unmarshal(data, &items); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.byAgent = make(map[string]map[string]Canary)
+	for _, c := range items {
+		if c.Agent == "" || c.Token == "" {
+			continue
+		}
+		if r.byAgent[c.Agent] == nil {
+			r.byAgent[c.Agent] = make(map[string]Canary)
+		}
+		r.byAgent[c.Agent][c.Token] = c
+	}
+	return nil
+}
+
+func (r *CanaryRegistry) saveBestEffort() {
+	if err := r.Save(); err != nil && r.onChange != nil {
+		r.onChange(err)
+	}
+}
+
+func (r *CanaryRegistry) Save() error {
+	if r == nil || r.persist == "" {
+		return nil
+	}
+	r.mu.RLock()
+	items := make([]Canary, 0)
+	for _, m := range r.byAgent {
+		for _, c := range m {
+			items = append(items, c)
+		}
+	}
+	r.mu.RUnlock()
+	data, err := json.MarshalIndent(items, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(r.persist), canaryDirPerm); err != nil {
+		return err
+	}
+	tmp := r.persist + ".tmp"
+	if err := os.WriteFile(tmp, data, canaryFilePerm); err != nil {
+		return err
+	}
+	return os.Rename(tmp, r.persist)
+}

--- a/v2/pkg/ioscan/canary_test.go
+++ b/v2/pkg/ioscan/canary_test.go
@@ -1,0 +1,44 @@
+package ioscan
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateCanaryUniqueHighEntropyPrefix(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		tok, err := GenerateCanary()
+		if err != nil {
+			t.Fatalf("GenerateCanary: %v", err)
+		}
+		if !strings.HasPrefix(tok, CanaryPrefix) {
+			t.Fatalf("token %q missing prefix %q", tok, CanaryPrefix)
+		}
+		if len(tok) != len(CanaryPrefix)+canaryRandomBytes*2 {
+			t.Fatalf("token length = %d, want %d", len(tok), len(CanaryPrefix)+canaryRandomBytes*2)
+		}
+		if seen[tok] {
+			t.Fatalf("duplicate canary generated: %s", tok)
+		}
+		seen[tok] = true
+	}
+}
+
+func TestCanaryRegistryScanByAgent(t *testing.T) {
+	r := NewCanaryRegistry("")
+	c, err := r.Add("scanner")
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, ok := r.Scan("quality", "ordinary report", "artifact"); ok {
+		t.Fatal("unexpected leak in benign text")
+	}
+	leak, ok := r.Scan("scanner", "oops "+c.Token, "artifact")
+	if !ok {
+		t.Fatal("expected canary leak")
+	}
+	if leak.Agent != "scanner" || leak.Source != "artifact" || leak.Token != c.Token {
+		t.Fatalf("leak = %+v, want scanner/artifact/%s", leak, c.Token)
+	}
+}

--- a/v2/pkg/logscrub/handler.go
+++ b/v2/pkg/logscrub/handler.go
@@ -15,8 +15,15 @@ var TokenPattern = regexp.MustCompile(
 		`|eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}`,
 )
 
-// tokenPattern is the unexported alias retained for the handler's internal use.
-var tokenPattern = TokenPattern
+var secretPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`HIVE-CANARY-[A-Fa-f0-9]{48}`),
+	TokenPattern,
+	regexp.MustCompile(`\b(AKIA|ASIA)[0-9A-Z]{16}\b`),
+	regexp.MustCompile(`(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{16,}\b`),
+	regexp.MustCompile(`(?s)-----BEGIN\s+(?:(?:RSA|EC|OPENSSH|DSA)\s+)?PRIVATE\s+KEY-----.*?-----END\s+(?:(?:RSA|EC|OPENSSH|DSA)\s+)?PRIVATE\s+KEY-----`),
+	regexp.MustCompile(`(?s)-----BEGIN\s+ENCRYPTED\s+PRIVATE\s+KEY-----.*?-----END\s+ENCRYPTED\s+PRIVATE\s+KEY-----`),
+	regexp.MustCompile(`(?s)-----BEGIN\s+PGP\s+PRIVATE\s+KEY\s+BLOCK-----.*?-----END\s+PGP\s+PRIVATE\s+KEY\s+BLOCK-----`),
+}
 
 const redacted = "[REDACTED]"
 
@@ -56,7 +63,17 @@ func (h *Handler) WithGroup(name string) slog.Handler {
 }
 
 func scrub(s string) string {
-	return tokenPattern.ReplaceAllString(s, redacted)
+	return ScrubString(s)
+}
+
+// ScrubString redacts credential-shaped substrings from text before it is
+// logged or published. Keep patterns here as the single reusable scrubber for
+// GitHub tokens, AWS access keys, bearer tokens, JWTs, and private-key blocks.
+func ScrubString(s string) string {
+	for _, p := range secretPatterns {
+		s = p.ReplaceAllString(s, redacted)
+	}
+	return s
 }
 
 func scrubAttr(a slog.Attr) slog.Attr {

--- a/v2/pkg/logscrub/scrub_test.go
+++ b/v2/pkg/logscrub/scrub_test.go
@@ -1,0 +1,29 @@
+package logscrub
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScrubStringCredentialPatterns(t *testing.T) {
+	cases := []string{
+		"github ghp_abcdefghijklmnopqrstuvwxyz123456",
+		"oauth gho_abcdefghijklmnopqrstuvwxyz123456",
+		"server ghs_abcdefghijklmnopqrstuvwxyz123456",
+		"aws AKIA1234567890ABCDEF",
+		"auth Bearer abcdefghijklmnopqrstuvwxyz0123456789",
+		"pem -----BEGIN PRIVATE KEY-----\nabc123\n-----END PRIVATE KEY-----",
+		"encrypted -----BEGIN ENCRYPTED PRIVATE KEY-----\nabc123\n-----END ENCRYPTED PRIVATE KEY-----",
+		"pgp -----BEGIN PGP PRIVATE KEY BLOCK-----\nabc123\n-----END PGP PRIVATE KEY BLOCK-----",
+		"canary HIVE-CANARY-0123456789abcdef0123456789abcdef0123456789abcdef",
+	}
+	for _, in := range cases {
+		out := ScrubString(in)
+		if !strings.Contains(out, redacted) {
+			t.Fatalf("%q was not redacted: %q", in, out)
+		}
+		if strings.Contains(out, "abcdefghijklmnopqrstuvwxyz123456") || strings.Contains(out, "AKIA1234567890ABCDEF") || strings.Contains(out, "abc123") {
+			t.Fatalf("secret material leaked after scrub: %q", out)
+		}
+	}
+}

--- a/v2/pkg/proxy/canary_test.go
+++ b/v2/pkg/proxy/canary_test.go
@@ -1,0 +1,116 @@
+package proxy
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/ioscan"
+)
+
+func TestInspectCanaryEgressDetectsGitHubWrites(t *testing.T) {
+	r := ioscan.NewCanaryRegistry("")
+	c, err := r.Add("scanner")
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	var got ioscan.CanaryLeak
+	p := &GitHubProxy{logger: slog.Default()}
+	p.SetCanaryScanner(true, true, r, func(leak ioscan.CanaryLeak) { got = leak })
+	req, _ := http.NewRequest(http.MethodPost, "https://api.github.com/repos/org/repo/issues/1/comments", strings.NewReader(`{"body":"`+c.Token+`"}`))
+	reason, deny, detected := p.inspectCanaryEgress("scanner", req)
+	if !detected || !deny || reason == "" {
+		t.Fatalf("got detected=%v deny=%v reason=%q, want detected deny", detected, deny, reason)
+	}
+	if got.Agent != "scanner" || got.Source == "" {
+		t.Fatalf("callback leak = %+v", got)
+	}
+	body, _ := io.ReadAll(req.Body)
+	if !strings.Contains(string(body), c.Token) {
+		t.Fatalf("request body was not restored: %q", body)
+	}
+}
+
+func TestInspectCanaryEgressAuditOnlyWhenFailOpen(t *testing.T) {
+	r := ioscan.NewCanaryRegistry("")
+	c, err := r.Add("scanner")
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	called := false
+	p := &GitHubProxy{logger: slog.Default()}
+	p.SetCanaryScanner(true, false, r, func(ioscan.CanaryLeak) { called = true })
+	req, _ := http.NewRequest(http.MethodPatch, "https://api.github.com/repos/org/repo/pulls/2", strings.NewReader(`{"body":"`+c.Token+`"}`))
+	_, deny, detected := p.inspectCanaryEgress("scanner", req)
+	if !detected || deny || !called {
+		t.Fatalf("got detected=%v deny=%v called=%v, want detected audit-only", detected, deny, called)
+	}
+}
+
+func TestInspectCanaryEgressIgnoresBenignAndDisabled(t *testing.T) {
+	r := ioscan.NewCanaryRegistry("")
+	if _, err := r.Add("scanner"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	p := &GitHubProxy{logger: slog.Default()}
+	p.SetCanaryScanner(true, true, r, nil)
+	req, _ := http.NewRequest(http.MethodPost, "https://api.github.com/repos/org/repo/issues/1/comments", strings.NewReader(`{"body":"hello"}`))
+	_, _, detected := p.inspectCanaryEgress("scanner", req)
+	if detected {
+		t.Fatal("benign body detected as leak")
+	}
+	p.SetCanaryScanner(false, true, r, nil)
+	req, _ = http.NewRequest(http.MethodPost, "https://api.github.com/repos/org/repo/issues/1/comments", strings.NewReader(`{"body":"hello"}`))
+	_, _, detected = p.inspectCanaryEgress("scanner", req)
+	if detected {
+		t.Fatal("disabled scanner detected leak")
+	}
+}
+
+func TestInspectCanaryEgressBlocksOversizedBodies(t *testing.T) {
+	r := ioscan.NewCanaryRegistry("")
+	p := &GitHubProxy{logger: slog.Default()}
+	p.SetCanaryScanner(true, false, r, nil)
+	req, _ := http.NewRequest(http.MethodPost, "https://api.github.com/repos/org/repo/issues/1/comments", strings.NewReader(strings.Repeat("x", maxGitHubWriteBodyScan+1)))
+	reason, deny, detected := p.inspectCanaryEgress("scanner", req)
+	if !detected || !deny || !strings.Contains(reason, "too large") {
+		t.Fatalf("got detected=%v deny=%v reason=%q, want oversized block", detected, deny, reason)
+	}
+}
+
+func TestInspectCanaryEgressCoversDirectPullCreatePath(t *testing.T) {
+	r := ioscan.NewCanaryRegistry("")
+	c, err := r.Add("quality")
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	p := &GitHubProxy{logger: slog.Default()}
+	p.SetCanaryScanner(true, false, r, nil)
+	req, _ := http.NewRequest(http.MethodPost, "https://api.github.com/repos/org/repo/pulls", strings.NewReader(`{"body":"`+c.Token+`"}`))
+	_, deny, detected := p.inspectCanaryEgress("quality", req)
+	if !detected || deny {
+		t.Fatalf("got detected=%v deny=%v, want audit-only detection on hard-denied path", detected, deny)
+	}
+}
+
+func TestInspectCanaryEgressCoversGitCommitRESTAndBlocksOpaquePush(t *testing.T) {
+	r := ioscan.NewCanaryRegistry("")
+	c, err := r.Add("quality")
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	p := &GitHubProxy{logger: slog.Default()}
+	p.SetCanaryScanner(true, true, r, nil)
+	req, _ := http.NewRequest(http.MethodPost, "https://api.github.com/repos/org/repo/git/commits", strings.NewReader(`{"message":"`+c.Token+`"}`))
+	_, deny, detected := p.inspectCanaryEgress("quality", req)
+	if !detected || !deny {
+		t.Fatalf("REST git commit got detected=%v deny=%v, want fail-closed leak", detected, deny)
+	}
+	pushReq, _ := http.NewRequest(http.MethodPost, "https://api.github.com/org/repo.git/git-receive-pack", strings.NewReader("opaque pack"))
+	reason, deny, detected := p.inspectCanaryEgress("quality", pushReq)
+	if !detected || !deny || !strings.Contains(reason, "git push") {
+		t.Fatalf("git push got detected=%v deny=%v reason=%q, want fail-closed block", detected, deny, reason)
+	}
+}

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/agent"
+	"github.com/kubestellar/hive/v2/pkg/ioscan"
 	"github.com/kubestellar/hive/v2/pkg/tokens"
 )
 
@@ -34,6 +35,7 @@ const (
 	InferenceTranslatePort = 18444
 	modeFilePrefix         = "/tmp/.hive-mode-"
 	maxViolationLog        = 1000
+	maxGitHubWriteBodyScan = 2 << 20
 
 	// defaultProxyEgressMark is the fwmark (SO_MARK) the proxy stamps onto its
 	// OWN upstream :443 dials so the forced-egress iptables redirect can exempt
@@ -174,6 +176,11 @@ type GitHubProxy struct {
 	// a test seam so the CONNECT handler can be driven against a local fake
 	// upstream; production leaves it nil.
 	copilotDial func(host string) (net.Conn, error)
+
+	canariesEnabled  bool
+	canaryFailClosed bool
+	canaryRegistry   *ioscan.CanaryRegistry
+	canaryLeakFunc   func(ioscan.CanaryLeak)
 }
 
 // dialCopilotUpstream connects to the real Copilot host over TLS (or the test
@@ -192,6 +199,13 @@ func (p *GitHubProxy) dialCopilotUpstream(host string) (net.Conn, error) {
 // per-agent usage from upstream OpenAI responses into the shared token store.
 func (p *GitHubProxy) SetTokenSink(sink *tokens.InferenceSink) {
 	p.tokenSink = sink
+}
+
+func (p *GitHubProxy) SetCanaryScanner(enabled, failClosed bool, reg *ioscan.CanaryRegistry, onLeak func(ioscan.CanaryLeak)) {
+	p.canariesEnabled = enabled
+	p.canaryFailClosed = failClosed
+	p.canaryRegistry = reg
+	p.canaryLeakFunc = onLeak
 }
 
 type cachedCert struct {
@@ -792,6 +806,14 @@ func (p *GitHubProxy) proxyHTTP(client net.Conn, upstream net.Conn, agentName st
 			blocked = true
 			blockReason = "repo not in hive config"
 		}
+		if reason, deny, ok := p.inspectCanaryEgress(agentName, req); ok {
+			if deny {
+				blocked = true
+				if blockReason == "" {
+					blockReason = reason
+				}
+			}
+		}
 
 		if blocked {
 			detail := req.URL.Path
@@ -852,6 +874,56 @@ func (p *GitHubProxy) proxyHTTP(client net.Conn, upstream net.Conn, agentName st
 		}
 		resp.Body.Close()
 	}
+}
+
+func (p *GitHubProxy) inspectCanaryEgress(agentName string, req *http.Request) (reason string, deny bool, detected bool) {
+	if p == nil || !p.canariesEnabled || p.canaryRegistry == nil || req == nil || req.Body == nil {
+		return "", false, false
+	}
+	if isGitReceivePack(req.URL.Path) && p.canaryFailClosed {
+		return "ioscan canary scan unavailable for git push", true, true
+	}
+	if !writeMethods[req.Method] || isGitPath(req.URL.Path) || !githubWriteBodyMayLeak(req.Method, req.URL.Path) {
+		return "", false, false
+	}
+	body, err := io.ReadAll(io.LimitReader(req.Body, maxGitHubWriteBodyScan+1))
+	if req.Body != nil {
+		req.Body.Close()
+	}
+	if err != nil {
+		return "", false, false
+	}
+	if len(body) > maxGitHubWriteBodyScan {
+		return "ioscan canary scan body too large", true, true
+	}
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	req.ContentLength = int64(len(body))
+	if leak, ok := p.canaryRegistry.Scan(agentName, string(body), "github:"+req.Method+" "+req.URL.Path); ok {
+		if p.canaryLeakFunc != nil {
+			p.canaryLeakFunc(leak)
+		}
+		p.logger.Warn("ioscan canary leak detected", "agent", leak.Agent, "source", leak.Source)
+		return "ioscan canary leak", p.canaryFailClosed, true
+	}
+	return "", false, false
+}
+
+func githubWriteBodyMayLeak(method, path string) bool {
+	if method != http.MethodPost && method != http.MethodPatch && method != http.MethodPut {
+		return false
+	}
+	if !strings.HasPrefix(path, "/repos/") {
+		return IsGraphQLPath(path)
+	}
+	return strings.Contains(path, "/issues") ||
+		strings.Contains(path, "/pulls") ||
+		strings.Contains(path, "/comments") ||
+		strings.Contains(path, "/reviews") ||
+		strings.Contains(path, "/git/")
+}
+
+func isGitReceivePack(path string) bool {
+	return strings.HasSuffix(path, "/git-receive-pack")
 }
 
 func (p *GitHubProxy) recordViolation(agentName, method, path string) {

--- a/v2/pkg/scheduler/ioscan_canary.go
+++ b/v2/pkg/scheduler/ioscan_canary.go
@@ -1,0 +1,21 @@
+package scheduler
+
+import "github.com/kubestellar/hive/v2/pkg/ioscan"
+
+func (s *Scheduler) canariesEnabled() bool {
+	return s.cfg != nil && s.cfg.Ioscan.IsEnabled() && s.cfg.Ioscan.Canaries
+}
+
+func (s *Scheduler) addCanaryPreamble(agentName, msg string) string {
+	if !s.canariesEnabled() || msg == "" {
+		return msg
+	}
+	c, err := ioscan.DefaultCanaries.Add(agentName)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("ioscan canary generation failed", "agent", agentName, "error", err)
+		}
+		return msg
+	}
+	return ioscan.CanaryPreamble(c.Token) + msg
+}

--- a/v2/pkg/scheduler/ioscan_enforce_test.go
+++ b/v2/pkg/scheduler/ioscan_enforce_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kubestellar/hive/v2/pkg/config"
 	"github.com/kubestellar/hive/v2/pkg/github"
+	"github.com/kubestellar/hive/v2/pkg/ioscan"
 )
 
 // blockingTitle trips injection.ignore_previous at High → blockedInput.
@@ -267,6 +268,18 @@ func TestBuildKickMessages_FailModeClosedBlocksCriticalUnicode(t *testing.T) {
 	}
 	if !sawFailClosed {
 		t.Fatalf("missing fail-closed audit record: %+v", calls)
+	}
+}
+
+func TestBuildKickMessages_CanariesOptIn(t *testing.T) {
+	s := newSchedulerWithIoscanFailMode(true, "open")
+	s.cfg.Ioscan.Canaries = true
+	msgs := s.BuildKickMessages(&github.ActionableResult{}, []string{"scanner"})
+	if len(msgs) != 1 {
+		t.Fatalf("got %d messages, want 1", len(msgs))
+	}
+	if !strings.Contains(msgs[0].Message, ioscan.CanaryPrefix) {
+		t.Fatalf("canary prefix missing from kick: %q", msgs[0].Message)
 	}
 }
 

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -374,6 +374,7 @@ func (s *Scheduler) BuildKickMessages(actionable *github.ActionableResult, agent
 			if includeRepos {
 				msg += "\n" + reposSection
 			}
+			msg = s.addCanaryPreamble(agentName, msg)
 			messages = append(messages, KickMessage{
 				Agent:     agentName,
 				Message:   msg,


### PR DESCRIPTION
Part of #2805\n\n## Summary\n- Add opt-in ioscan canary tokens embedded per kick, persisted under /data, with leak detection for GitHub proxy writes, hive-open-pr PR creation, git commit REST writes, and advisory finding ingestion.\n- Record ioscan_canary_leak audit events and critical advisory beads; fail_mode: closed blocks GitHub writes, hive-open-pr, oversized/unscannable proxy bodies, opaque git pushes, and leaked advisory findings.\n- Extend logscrub redaction for canaries, GitHub/JWT tokens, AWS keys, bearer tokens, and PEM private-key blocks; apply to advisory digest/beads and Hive-authored GitHub comments/PR text.\n- Document ioscan.canaries in README, ADR docs, and hive.yaml.example.\n\n## Validation\n- cd v2 && go test ./pkg/ioscan/... ./pkg/logscrub/... ./pkg/proxy/... ./pkg/advisory/... ./pkg/github/... ./pkg/forge/... ./pkg/scheduler/... ./pkg/config/... -count=1\n- cd v2 && go build ./...\n- cd v2 && go vet ./pkg/ioscan/... ./pkg/logscrub/... ./pkg/proxy/... ./pkg/advisory/... ./pkg/github/... ./pkg/forge/... ./pkg/scheduler/... ./pkg/config/... ./cmd/hive\n\n## Deferred\n- Model-based classifier pass remains deferred from #2805.