### PR TITLE
fix(contributor): auto-dismiss codex's directory-trust prompt

### DIFF
--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -393,6 +393,12 @@ if [[ "$CONTRIBUTOR_MODE" == "interactive" ]]; then
       PANE=$(tmux capture-pane -t "$TMUX_SESSION" -p -S -10 2>/dev/null || true)
       if echo "$PANE" | grep -q "trust this folder\|trust the files\|Confirm folder trust\|Enter to confirm"; then
         tmux send-keys -t "$TMUX_SESSION" Enter 2>/dev/null || true
+      elif echo "$PANE" | grep -q "Do you trust the contents of this directory"; then
+        # Codex's own directory-trust prompt: a numbered menu ("1. Yes,
+        # continue" / "2. No, quit"), distinct wording and shape from the
+        # generic "trust this folder" pattern above — needs an explicit "1"
+        # selection, not a bare Enter (Enter alone just re-renders the menu).
+        tmux send-keys -t "$TMUX_SESSION" "1" Enter 2>/dev/null || true
       elif echo "$PANE" | grep -q "Choose the text style"; then
         tmux send-keys -t "$TMUX_SESSION" "1" Enter 2>/dev/null || true
       elif echo "$PANE" | grep -q "Share anonymous usage data\|help improve goose\|Would you like"; then
@@ -402,7 +408,7 @@ if [[ "$CONTRIBUTOR_MODE" == "interactive" ]]; then
       elif echo "$PANE" | grep -qi "custom API key"; then
         # Claude Code asks whether to use ANTHROPIC_API_KEY (litellm backend)
         tmux send-keys -t "$TMUX_SESSION" "1" Enter 2>/dev/null || true
-      elif echo "$PANE" | grep -q "bypass permissions\|autopilot\|goose>\|G >\|❯\|/ commands\|> *$"; then
+      elif echo "$PANE" | grep -q "bypass permissions\|autopilot\|goose>\|G >\|❯\|›\|/ commands\|> *$"; then
         break
       fi
     done


### PR DESCRIPTION
Codex's own trust prompt ("Do you trust the contents of this directory?" / numbered "1. Yes, continue" menu) has different wording and shape than the generic "trust this folder" pattern the interactive auto-dismiss loop already handles in bin/contributor-agent.sh, and needs an explicit "1" selection rather than a bare Enter (which just re-renders the menu).

Without this fix, a codex-backend contributor hangs indefinitely on first launch waiting for a human — which unattended/headless deployments (a systemd quadlet, a k8s pod) don't have. Found this live running a codex contributor against a self-hosted hive.

Also adds codex's ready-state marker (›) to the loop's break condition, so it recognizes codex reaching its input prompt and stops polling instead of exhausting all 10 dismiss attempts.

## Test plan
- Ran a codex-backend contributor interactively (podman quadlet) against a real hive; confirmed the pre-fix prompt wording verbatim
- Manually verified the new grep pattern matches that exact prompt text
- Would appreciate a maintainer/CI check against a fresh codex trust-prompt render, since I validated the pattern match by hand rather than via an image rebuild