### PR TITLE
feat(contributor): support subscribing to multiple hubs from one relay session

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -173,8 +173,16 @@ function sendTo(hub, msg) {
 // hub regardless of currentTask/activeHubIndex (auth handshake, rejecting a
 // task from a hub that isn't getting the active slot, per-hub ping/pong) use
 // sendTo() directly.
+// The `|| hubs[activeHubIndex]` fallback is load-bearing, not defensive
+// padding: not every currentTask comes from a task_assign. The synthetic
+// pr-review task built after every PR_REVIEW_EVERY_N completions is assembled
+// locally and has no _hub, so keying strictly off currentTask._hub sent its
+// progress and completion frames to `undefined` — silently dropped, leaving
+// the hub to watch the contributor go mute mid-review and time it out.
+// Falling back to the active hub is also the correct target there: it is the
+// hub whose task we just finished.
 function send(msg) {
-  sendTo(currentTask ? currentTask._hub : hubs[activeHubIndex], msg);
+  sendTo((currentTask && currentTask._hub) || hubs[activeHubIndex], msg);
 }
 
 function injectGhToken(token) {

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -20,8 +20,18 @@ const fs = require('fs');
 const path = require('path');
 
 const rawHub = process.env.HIVE_HUB || 'wss://hive.kubestellar.io:3001/contribute';
-const HUB_URL = rawHub.replace(/\/contribute\/?$/, '/api/contribute/ws');
-const REG_TOKEN = process.env.HIVE_REGISTRATION_TOKEN;
+// Multi-hub (kubestellar/hive#multi-hive): HIVE_HUB and HIVE_REGISTRATION_TOKEN
+// may each be a comma-separated list, one token per hub in the same order, so
+// one relay/CLI session can hold work from more than one hive without running
+// duplicate contributor processes. A single value of each (the common case)
+// behaves exactly as before — this only ever adds hubs, never changes
+// single-hub behaviour.
+const rawHubList = rawHub.split(',').map(s => s.trim()).filter(Boolean);
+const rawTokenList = (process.env.HIVE_REGISTRATION_TOKEN || '').split(',').map(s => s.trim()).filter(Boolean);
+if (rawHubList.length > 1 && rawTokenList.length !== rawHubList.length) {
+  console.error(`FATAL: HIVE_HUB lists ${rawHubList.length} hub(s) but HIVE_REGISTRATION_TOKEN lists ${rawTokenList.length} token(s) — need one registration token per hub, in the same order.`);
+  process.exit(1);
+}
 const BACKEND = process.env.AGENT_BACKEND || 'claude';
 const MODEL = process.env.AGENT_MODEL || process.env.GOOSE_MODEL || '';
 const TMUX_SESSION = process.env.HIVE_AGENT_SESSION || 'contributor';
@@ -116,26 +126,55 @@ const TASK_RESTART_MAX_BACKOFF_MS = 60000;
 // enough that a transient environment fault eventually clears.
 const GIVE_UP_MEMORY_MS = 3600000;
 
-if (!REG_TOKEN) {
+if (rawTokenList.length === 0) {
   console.error('FATAL: HIVE_REGISTRATION_TOKEN not set. Run `just contribute-register` first.');
   process.exit(1);
 }
 
-let ws = null;
+// One entry per hub, each owning its own connection/reconnect/heartbeat
+// state. currentTask, cliReady and everything CLI-facing stay single global
+// values below — there is exactly one CLI/tmux session, shared across
+// whichever hub currently holds the active task or is being polled for work.
+const hubs = rawHubList.map((url, i) => ({
+  url: url.replace(/\/contribute\/?$/, '/api/contribute/ws'),
+  regToken: rawTokenList[i] || rawTokenList[0],
+  ws: null,
+  reconnectDelay: BASE_RECONNECT_DELAY_MS,
+  heartbeatInterval: null,
+  lastPong: Date.now(),
+  connectGeneration: 0,
+  reconnectTimer: null,
+}));
+// Index into hubs[] of the hub we are currently soliciting work from (sent it
+// the last 'ready'), or that owns currentTask. Round-robins forward on an
+// explicit task_unavailable from the active hub; sticks with the same hub
+// across a completed/failed/revoked task rather than switching eagerly, since
+// task_unavailable is the only signal (kubestellar/hive#2436/#2546 — the hub
+// always sends it, never stays silent) that a hub genuinely has no work.
+let activeHubIndex = 0;
+
 let seq = 0;
-let reconnectDelay = BASE_RECONNECT_DELAY_MS;
-let heartbeatInterval = null;
-let lastPong = Date.now();
 let currentTask = null;
 let progressInterval = null;
 let tokenExpiresAt = null;
 
 function nextSeq() { return ++seq; }
 
-function send(msg) {
-  if (ws && ws.readyState === WebSocket.OPEN) {
-    ws.send(JSON.stringify(msg));
+function sendTo(hub, msg) {
+  if (hub && hub.ws && hub.ws.readyState === WebSocket.OPEN) {
+    hub.ws.send(JSON.stringify(msg));
   }
+}
+
+// send() targets whichever hub is relevant right now: the hub that owns the
+// in-flight task, or (idle) the hub currently being polled for work. Every
+// existing interactive/headless/progress/heartbeat call site keeps calling
+// plain send(msg) unchanged — only the messages that must go to a SPECIFIC
+// hub regardless of currentTask/activeHubIndex (auth handshake, rejecting a
+// task from a hub that isn't getting the active slot, per-hub ping/pong) use
+// sendTo() directly.
+function send(msg) {
+  sendTo(currentTask ? currentTask._hub : hubs[activeHubIndex], msg);
 }
 
 function injectGhToken(token) {
@@ -1090,16 +1129,22 @@ function progressTick() {
   }
 }
 
-function handleMessage(data) {
+function handleMessage(data, hub) {
+  // hub defaults to hubs[0] so existing single-hub callers (and the test
+  // harness, which calls handleMessage(json) directly with no hub arg) keep
+  // working unchanged — there is always at least one entry in hubs[].
+  hub = hub || hubs[0];
   let msg;
   try { msg = JSON.parse(data); } catch (_) { return; }
 
   switch (msg.type) {
     case 'auth_challenge':
-      send({
+      // Always replies on the SAME hub that challenged us, regardless of
+      // currentTask/activeHubIndex — send() would route elsewhere.
+      sendTo(hub, {
         type: 'auth_response',
         seq: nextSeq(),
-        registration_token: REG_TOKEN,
+        registration_token: hub.regToken,
         cli_backend: BACKEND,
         model: MODEL,
         // #2547 declare half + #2567: additive, optional self-report of runtime
@@ -1110,7 +1155,7 @@ function handleMessage(data) {
       break;
 
     case 'auth_ok':
-      console.log(`Authenticated as ${msg.contributor_id} (tier: ${msg.trust_tier})`);
+      console.log(`Authenticated with ${hub.url} as ${msg.contributor_id} (tier: ${msg.trust_tier})`);
       // #2567: the hub advertises its protocol version + capability set here. We
       // log them (forward-compatible: unknown/absent fields are simply skipped)
       // so a newer relay can adapt to what the deployed server supports instead
@@ -1118,35 +1163,46 @@ function handleMessage(data) {
       if (msg.protocol_version || (msg.server_capabilities && msg.server_capabilities.length)) {
         console.log(`Hub protocol ${msg.protocol_version || 'unversioned'}; capabilities: ${(msg.server_capabilities || []).join(', ') || 'none'}`);
       }
-      reconnectDelay = BASE_RECONNECT_DELAY_MS;
-      if (!currentTask) {
+      hub.reconnectDelay = BASE_RECONNECT_DELAY_MS;
+      if (currentTask && hub === currentTask._hub) {
+        console.log(`Reconnected while working on ${currentTask.repo}#${currentTask.number} — resuming`);
+        sendTo(hub, { type: 'task_accepted', seq: nextSeq(), task_id: currentTask.task_id });
+        sendTo(hub, { type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, kind: currentTask.kind, repo: currentTask.repo, number: currentTask.number, title: currentTask.title, status: 'working' });
+        startProgressReporting();
+      } else if (!currentTask && hub === hubs[activeHubIndex]) {
+        // Only the hub currently in the poll rotation asks for work. A hub
+        // that authenticates while it's not its turn just sits connected
+        // (heartbeating) until task_unavailable rotates the active slot to it.
         if (!cliReadyFailed) {
-          send({ type: 'ready', seq: nextSeq() });
+          sendTo(hub, { type: 'ready', seq: nextSeq() });
         } else {
           console.log('Authenticated, but CLI readiness previously failed — withholding ready until the CLI recovers');
         }
-      } else {
-        console.log(`Reconnected while working on ${currentTask.repo}#${currentTask.number} — resuming`);
-        send({ type: 'task_accepted', seq: nextSeq(), task_id: currentTask.task_id });
-        send({ type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, kind: currentTask.kind, repo: currentTask.repo, number: currentTask.number, title: currentTask.title, status: 'working' });
-        startProgressReporting();
       }
       break;
 
     case 'auth_failed':
-      console.error(`Authentication failed: ${msg.reason}`);
+      console.error(`Authentication with ${hub.url} failed: ${msg.reason}`);
       if (msg.accepted_models && msg.accepted_models.length > 0) {
         console.error('\nThis hive accepts the following models:');
         msg.accepted_models.forEach(m => console.error('  - ' + m));
         console.error('\nSet your model: export AGENT_MODEL=<model>');
       }
-      process.exit(1);
+      // A bad token for ONE hub must not take down a working connection to
+      // another — only abort the whole process when every configured hub has
+      // failed auth (or there is only one, matching the prior behaviour).
+      hub.authFailed = true;
+      if (hubs.every(h => h.authFailed)) {
+        process.exit(1);
+      } else {
+        console.error(`Continuing with the remaining ${hubs.filter(h => !h.authFailed).length} hub(s).`);
+      }
       break;
 
     case 'task_assign':
       if (currentTask) {
-        console.log(`Rejecting task ${msg.repo}#${msg.number} — already working on ${currentTask.repo}#${currentTask.number}`);
-        send({ type: 'task_failed', seq: nextSeq(), task_id: msg.task_id, reason: 'Already has active task' });
+        console.log(`Rejecting task ${msg.repo}#${msg.number} from ${hub.url} — already working on ${currentTask.repo}#${currentTask.number}`);
+        sendTo(hub, { type: 'task_failed', seq: nextSeq(), task_id: msg.task_id, reason: 'Already has active task' });
         break;
       }
       // A task we already gave up on permanently must not restart the loop if
@@ -1154,12 +1210,20 @@ function handleMessage(data) {
       // and stay available for other work.
       if (isGivenUp(taskKey(msg))) {
         console.log(`Rejecting ${taskKey(msg)} — previously given up on after ${MAX_TASK_CLI_RESTARTS} CLI crashes`);
-        send({ type: 'task_failed', seq: nextSeq(), task_id: msg.task_id, reason: `previously given up on after ${MAX_TASK_CLI_RESTARTS} CLI crashes`, permanent: true });
-        send({ type: 'ready', seq: nextSeq() });
+        sendTo(hub, { type: 'task_failed', seq: nextSeq(), task_id: msg.task_id, reason: `previously given up on after ${MAX_TASK_CLI_RESTARTS} CLI crashes`, permanent: true });
+        sendTo(hub, { type: 'ready', seq: nextSeq() });
         break;
       }
       currentTask = msg;
-      console.log(`Task assigned: ${msg.kind} ${msg.repo}#${msg.number} — ${msg.title}`);
+      // Non-enumerable: currentTask IS msg, and msg gets JSON.stringify'd
+      // wholesale to TASK_FILE a few lines down. hub carries live
+      // setInterval/setTimeout handles (heartbeatInterval, reconnectTimer),
+      // which are circular — a plain assignment here crashed every task
+      // (TypeError: Converting circular structure to JSON), which crashed the
+      // process, on the very first task after adding multi-hub support.
+      Object.defineProperty(currentTask, '_hub', { value: hub, enumerable: false, writable: true, configurable: true });
+      activeHubIndex = hubs.indexOf(hub);
+      console.log(`Task assigned: ${msg.kind} ${msg.repo}#${msg.number} — ${msg.title} (from ${hub.url})`);
       if (msg.github_token) {
         injectGhToken(msg.github_token);
         tokenExpiresAt = msg.token_expires_at ? new Date(msg.token_expires_at).getTime() : null;
@@ -1201,29 +1265,44 @@ function handleMessage(data) {
         headlessChild = null;
         writeHeadlessStatus(HEADLESS_STATE_WAITING);
       }
-      send({ type: 'ready', seq: nextSeq() });
+      // Stay with the hub that just revoked — it's clearly alive and reachable.
+      activeHubIndex = hubs.indexOf(hub);
+      sendTo(hub, { type: 'ready', seq: nextSeq() });
       break;
 
     case 'task_unavailable':
-      // #2436 finding 1/2/3: the hub explicitly declined to assign work and told
-      // us why (reason: no_work / token_mint_failed / tier_disabled /
-      // concurrency_limit). Surface the reason instead of hanging silently, then
-      // re-ask after a delay so a transient condition (a freed slot, a fixed
-      // installation permission) recovers on its own.
-      console.log(`No task assigned — reason: ${msg.reason || 'unspecified'}; retrying in ${TASK_UNAVAILABLE_RETRY_MS / 1000}s`);
+      // #2436 finding 1/2/3 (and #2546): the hub explicitly declined to assign
+      // work and told us why (reason: no_work / token_mint_failed /
+      // tier_disabled / concurrency_limit) — this ack is NEVER silent. Surface
+      // the reason instead of hanging, then re-ask after a delay so a
+      // transient condition (a freed slot, a fixed installation permission)
+      // recovers on its own.
+      //
+      // Multi-hub round-robin: this is the ONLY place the active poll slot
+      // rotates. task_unavailable is a reliable negative-ack (unlike silence,
+      // which could just mean network lag), so rotating on it — rather than
+      // on a guessed timeout — means we never sit idle on a hub with no work
+      // while a different configured hub has some.
+      console.log(`No task assigned on ${hub.url} — reason: ${msg.reason || 'unspecified'}; retrying in ${TASK_UNAVAILABLE_RETRY_MS / 1000}s`);
       setTimeout(() => {
-        if (ws && ws.readyState === WebSocket.OPEN && !currentTask) {
-          send({ type: 'ready', seq: nextSeq() });
+        if (currentTask) return; // picked up work elsewhere in the meantime
+        if (hubs.length > 1 && hub === hubs[activeHubIndex]) {
+          activeHubIndex = (activeHubIndex + 1) % hubs.length;
         }
+        const next = hubs[activeHubIndex];
+        // If `next` isn't connected/authenticated yet, its own auth_ok
+        // handler sends 'ready' once it comes up and finds itself the active
+        // hub (see the auth_ok case above) — self-healing, no extra state.
+        sendTo(next, { type: 'ready', seq: nextSeq() });
       }, TASK_UNAVAILABLE_RETRY_MS);
       break;
 
     case 'ping':
-      send({ type: 'pong', seq: msg.seq });
+      sendTo(hub, { type: 'pong', seq: msg.seq });
       break;
 
     case 'pong':
-      lastPong = Date.now();
+      hub.lastPong = Date.now();
       break;
 
     default:
@@ -1231,55 +1310,60 @@ function handleMessage(data) {
   }
 }
 
-let connectGeneration = 0;
-let reconnectTimer = null;
+function connectHub(hub) {
+  if (hub.reconnectTimer) { clearTimeout(hub.reconnectTimer); hub.reconnectTimer = null; }
+  if (hub.heartbeatInterval) { clearInterval(hub.heartbeatInterval); hub.heartbeatInterval = null; }
+  if (hub.ws) { try { hub.ws.removeAllListeners(); hub.ws.terminate(); } catch (_) {} }
+  const gen = ++hub.connectGeneration;
+  console.log(`Connecting to ${hub.url}...`);
+  hub.ws = new WebSocket(hub.url);
 
-function connect() {
-  cleanup();
-  if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
-  if (ws) { try { ws.removeAllListeners(); ws.terminate(); } catch (_) {} }
-  const gen = ++connectGeneration;
-  console.log(`Connecting to ${HUB_URL}...`);
-  ws = new WebSocket(HUB_URL);
+  hub.ws.on('open', () => {
+    if (gen !== hub.connectGeneration) return;
+    console.log(`Connected to ${hub.url}`);
+    hub.reconnectDelay = BASE_RECONNECT_DELAY_MS;
+    hub.lastPong = Date.now();
 
-  ws.on('open', () => {
-    if (gen !== connectGeneration) return;
-    console.log('Connected to hub');
-    reconnectDelay = BASE_RECONNECT_DELAY_MS;
-    lastPong = Date.now();
-
-    heartbeatInterval = setInterval(() => {
-      if (gen !== connectGeneration) { clearInterval(heartbeatInterval); return; }
-      if (Date.now() - lastPong > HEARTBEAT_TIMEOUT_MS) {
-        console.error('Heartbeat timeout — reconnecting');
-        ws.terminate();
+    hub.heartbeatInterval = setInterval(() => {
+      if (gen !== hub.connectGeneration) { clearInterval(hub.heartbeatInterval); return; }
+      if (Date.now() - hub.lastPong > HEARTBEAT_TIMEOUT_MS) {
+        console.error(`Heartbeat timeout on ${hub.url} — reconnecting`);
+        hub.ws.terminate();
         return;
       }
-      send({ type: 'ping', seq: nextSeq() });
+      sendTo(hub, { type: 'ping', seq: nextSeq() });
     }, HEARTBEAT_INTERVAL_MS);
   });
 
-  ws.on('message', (data) => {
-    if (gen !== connectGeneration) return;
-    handleMessage(data.toString());
+  hub.ws.on('message', (data) => {
+    if (gen !== hub.connectGeneration) return;
+    handleMessage(data.toString(), hub);
   });
 
-  ws.on('close', () => {
-    if (gen !== connectGeneration) return;
-    console.log(`Connection closed. Reconnecting in ${reconnectDelay}ms...`);
-    cleanup();
-    reconnectTimer = setTimeout(connect, reconnectDelay);
-    reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY_MS);
+  hub.ws.on('close', () => {
+    if (gen !== hub.connectGeneration) return;
+    console.log(`Connection to ${hub.url} closed. Reconnecting in ${hub.reconnectDelay}ms...`);
+    if (hub.heartbeatInterval) { clearInterval(hub.heartbeatInterval); hub.heartbeatInterval = null; }
+    hub.reconnectTimer = setTimeout(() => connectHub(hub), hub.reconnectDelay);
+    hub.reconnectDelay = Math.min(hub.reconnectDelay * 2, MAX_RECONNECT_DELAY_MS);
   });
 
-  ws.on('error', (err) => {
-    if (gen !== connectGeneration) return;
-    console.error('WebSocket error:', err.message);
+  hub.ws.on('error', (err) => {
+    if (gen !== hub.connectGeneration) return;
+    console.error(`WebSocket error on ${hub.url}:`, err.message);
   });
 }
 
+function connect() {
+  // Kept as the entry point (bottom of file, SIGTERM/SIGINT) so those call
+  // sites don't need to know about hubs[] — connects every configured hub.
+  hubs.forEach(connectHub);
+}
+
 function cleanup() {
-  if (heartbeatInterval) { clearInterval(heartbeatInterval); heartbeatInterval = null; }
+  hubs.forEach(hub => {
+    if (hub.heartbeatInterval) { clearInterval(hub.heartbeatInterval); hub.heartbeatInterval = null; }
+  });
   if (progressInterval) { clearInterval(progressInterval); progressInterval = null; }
 }
 
@@ -1319,7 +1403,8 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     setCurrentTask: (v) => { currentTask = v; },
     blockingPromptKey,
     getCLIState,
-    setWs: (w) => { ws = w; },
+    setWs: (w) => { hubs[0].ws = w; },
+    getHubs: () => hubs,
     // Headless (non-interactive) mode surface (kubestellar/hive#2538).
     CONTRIBUTOR_MODE,
     MODE_INTERACTIVE,

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -35,10 +35,10 @@ if (rawHubList.length > 1 && rawTokenList.length !== rawHubList.length) {
 const BACKEND = process.env.AGENT_BACKEND || 'claude';
 const MODEL = process.env.AGENT_MODEL || process.env.GOOSE_MODEL || '';
 const TMUX_SESSION = process.env.HIVE_AGENT_SESSION || 'contributor';
-const GH_TOKEN_CACHE = fs.existsSync('/var/run/hive-metrics')
+const GH_TOKEN_CACHE = process.env.HIVE_GH_TOKEN_CACHE || (fs.existsSync('/var/run/hive-metrics')
   ? '/var/run/hive-metrics/gh-app-token.cache'
-  : '/tmp/hive-gh-token.cache';
-const TASK_FILE = '/tmp/contributor-task.json';
+  : '/tmp/hive-gh-token.cache');
+const TASK_FILE = process.env.HIVE_TASK_FILE || '/tmp/contributor-task.json';
 
 // --- Delivery mode (kubestellar/hive#2538) -------------------------------
 // The relay can deliver a task to the backend CLI in one of two ways:
@@ -144,6 +144,8 @@ const hubs = rawHubList.map((url, i) => ({
   lastPong: Date.now(),
   connectGeneration: 0,
   reconnectTimer: null,
+  authenticated: false,
+  authFailed: false,
 }));
 // Index into hubs[] of the hub we are currently soliciting work from (sent it
 // the last 'ready'), or that owns currentTask. Round-robins forward on an
@@ -183,6 +185,23 @@ function sendTo(hub, msg) {
 // hub whose task we just finished.
 function send(msg) {
   sendTo((currentTask && currentTask._hub) || hubs[activeHubIndex], msg);
+}
+
+function currentTaskHub() {
+  return (currentTask && currentTask._hub) || hubs[activeHubIndex];
+}
+
+function advanceActiveHub(fromHub) {
+  const fromIndex = hubs.indexOf(fromHub);
+  const start = fromIndex >= 0 ? fromIndex : activeHubIndex;
+  for (let offset = 1; offset <= hubs.length; offset++) {
+    const idx = (start + offset) % hubs.length;
+    if (!hubs[idx].authFailed) {
+      activeHubIndex = idx;
+      return hubs[idx];
+    }
+  }
+  return null;
 }
 
 function injectGhToken(token) {
@@ -1171,8 +1190,10 @@ function handleMessage(data, hub) {
       if (msg.protocol_version || (msg.server_capabilities && msg.server_capabilities.length)) {
         console.log(`Hub protocol ${msg.protocol_version || 'unversioned'}; capabilities: ${(msg.server_capabilities || []).join(', ') || 'none'}`);
       }
+      hub.authenticated = true;
+      hub.authFailed = false;
       hub.reconnectDelay = BASE_RECONNECT_DELAY_MS;
-      if (currentTask && hub === currentTask._hub) {
+      if (currentTask && hub === currentTaskHub()) {
         console.log(`Reconnected while working on ${currentTask.repo}#${currentTask.number} — resuming`);
         sendTo(hub, { type: 'task_accepted', seq: nextSeq(), task_id: currentTask.task_id });
         sendTo(hub, { type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, kind: currentTask.kind, repo: currentTask.repo, number: currentTask.number, title: currentTask.title, status: 'working' });
@@ -1204,10 +1225,21 @@ function handleMessage(data, hub) {
         process.exit(1);
       } else {
         console.error(`Continuing with the remaining ${hubs.filter(h => !h.authFailed).length} hub(s).`);
+        if (!currentTask && hub === hubs[activeHubIndex]) {
+          const next = advanceActiveHub(hub);
+          if (next && next.authenticated) {
+            sendTo(next, { type: 'ready', seq: nextSeq() });
+          }
+        }
       }
       break;
 
     case 'task_assign':
+      if (!currentTask && hub !== hubs[activeHubIndex]) {
+        console.log(`Rejecting task ${msg.repo}#${msg.number} from ${hub.url} — hub is not the active polling slot`);
+        sendTo(hub, { type: 'task_failed', seq: nextSeq(), task_id: msg.task_id, reason: 'Hub is not the active polling slot' });
+        break;
+      }
       if (currentTask) {
         console.log(`Rejecting task ${msg.repo}#${msg.number} from ${hub.url} — already working on ${currentTask.repo}#${currentTask.number}`);
         sendTo(hub, { type: 'task_failed', seq: nextSeq(), task_id: msg.task_id, reason: 'Already has active task' });
@@ -1253,6 +1285,10 @@ function handleMessage(data, hub) {
       break;
 
     case 'token_refresh':
+      if (!currentTask || currentTaskHub() !== hub) {
+        console.log(`Ignoring token_refresh from ${hub.url} — it does not own the active task`);
+        break;
+      }
       if (msg.github_token) {
         injectGhToken(msg.github_token);
         tokenExpiresAt = msg.token_expires_at ? new Date(msg.token_expires_at).getTime() : null;
@@ -1261,6 +1297,14 @@ function handleMessage(data, hub) {
       break;
 
     case 'task_revoke':
+      if (!currentTask) {
+        console.log(`Ignoring task_revoked from ${hub.url} for ${msg.task_id} — no active task`);
+        break;
+      }
+      if (currentTaskHub() !== hub || currentTask.task_id !== msg.task_id) {
+        console.log(`Ignoring task_revoked from ${hub.url} for ${msg.task_id} — active task belongs to another hub`);
+        break;
+      }
       console.log(`Task revoked: ${msg.task_id} — ${msg.reason}`);
       currentTask = null;
       taskAssignedAt = 0;
@@ -1279,6 +1323,10 @@ function handleMessage(data, hub) {
       break;
 
     case 'task_unavailable':
+      if (hub !== hubs[activeHubIndex]) {
+        console.log(`Ignoring task_unavailable from inactive hub ${hub.url}`);
+        break;
+      }
       // #2436 finding 1/2/3 (and #2546): the hub explicitly declined to assign
       // work and told us why (reason: no_work / token_mint_failed /
       // tier_disabled / concurrency_limit) — this ack is NEVER silent. Surface
@@ -1295,7 +1343,7 @@ function handleMessage(data, hub) {
       setTimeout(() => {
         if (currentTask) return; // picked up work elsewhere in the meantime
         if (hubs.length > 1 && hub === hubs[activeHubIndex]) {
-          activeHubIndex = (activeHubIndex + 1) % hubs.length;
+          advanceActiveHub(hub);
         }
         const next = hubs[activeHubIndex];
         // If `next` isn't connected/authenticated yet, its own auth_ok

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -112,6 +112,8 @@ function loadRelay({ backend = 'copilot', model = '', cliStates = ['ready'], pro
   // clobber a real one and can be asserted on.
   const headlessStatusFile = statusFile || path.join(tmpDir, 'headless-status.json');
   process.env.HIVE_HEADLESS_STATUS_FILE = headlessStatusFile;
+  process.env.HIVE_TASK_FILE = path.join(tmpDir, 'contributor-task.json');
+  process.env.HIVE_GH_TOKEN_CACHE = path.join(tmpDir, 'gh-token.cache');
   if (env) Object.assign(process.env, env);
 
   // node refuses to require a .sh file with the default extension handlers;
@@ -820,6 +822,26 @@ test('only the active hub is sent ready on auth_ok; the other waits its turn', (
   } finally { teardown(relay); }
 });
 
+test('auth_failed on the active hub advances polling to an already-authenticated hub', () => {
+  const relay = loadRelay({ env: {
+    HIVE_HUB: 'wss://hub-a.example/contribute,wss://hub-b.example/contribute',
+    HIVE_REGISTRATION_TOKEN: 'tok-a,tok-b',
+  } });
+  try {
+    const hubs = relay.getHubs();
+    const sentA = [], sentB = [];
+    hubs[0].ws = { readyState: 1, send: p => sentA.push(JSON.parse(p)) };
+    hubs[1].ws = { readyState: 1, send: p => sentB.push(JSON.parse(p)) };
+
+    relay.handleMessage(JSON.stringify({ type: 'auth_ok', contributor_id: 'c1', trust_tier: 'contributor' }), hubs[1]);
+    assert.deepStrictEqual(sentB.map(m => m.type), [], 'non-active hub waits before the active hub fails');
+
+    relay.handleMessage(JSON.stringify({ type: 'auth_failed', reason: 'bad token' }), hubs[0]);
+    assert.deepStrictEqual(sentA.map(m => m.type), []);
+    assert.deepStrictEqual(sentB.map(m => m.type), ['ready'], 'polling moved to the authenticated remaining hub');
+  } finally { teardown(relay); }
+});
+
 test('a task_assign is remembered by hub, and a rejection while busy is routed to the ASKING hub', () => {
   const relay = loadRelay({ env: {
     HIVE_HUB: 'wss://hub-a.example/contribute,wss://hub-b.example/contribute',
@@ -830,6 +852,14 @@ test('a task_assign is remembered by hub, and a rejection while busy is routed t
     const sentA = [], sentB = [];
     hubs[0].ws = { readyState: 1, send: p => sentA.push(JSON.parse(p)) };
     hubs[1].ws = { readyState: 1, send: p => sentB.push(JSON.parse(p)) };
+
+    const origSetTimeout = global.setTimeout;
+    global.setTimeout = (fn) => { fn(); return 0; };
+    try {
+      relay.handleMessage(JSON.stringify({ type: 'task_unavailable', reason: 'no_work' }), hubs[0]);
+    } finally {
+      global.setTimeout = origSetTimeout;
+    }
 
     relay.handleMessage(JSON.stringify({ type: 'task_assign', task_id: 't1', kind: 'issue', repo: 'foo/bar', number: 1, title: 'x' }), hubs[1]);
     const task = relay.getCurrentTask();
@@ -842,6 +872,55 @@ test('a task_assign is remembered by hub, and a rejection while busy is routed t
     assert.ok(sentA.some(m => m.type === 'task_failed' && m.reason === 'Already has active task'),
       'busy-rejection went to the hub that just asked, not silently dropped or misrouted to the active-task hub');
     assert.strictEqual(sentB.filter(m => m.type === 'task_failed').length, 0);
+  } finally { teardown(relay); }
+});
+
+test('an idle non-active hub cannot assign work until the poll slot reaches it', () => {
+  const relay = loadRelay({ env: {
+    HIVE_HUB: 'wss://hub-a.example/contribute,wss://hub-b.example/contribute',
+    HIVE_REGISTRATION_TOKEN: 'tok-a,tok-b',
+  } });
+  try {
+    const hubs = relay.getHubs();
+    const sentB = [];
+    hubs[0].ws = { readyState: 1, send: () => {} };
+    hubs[1].ws = { readyState: 1, send: p => sentB.push(JSON.parse(p)) };
+
+    relay.handleMessage(JSON.stringify({ type: 'task_assign', task_id: 't2', kind: 'issue', repo: 'foo/bar', number: 2, title: 'y' }), hubs[1]);
+
+    assert.strictEqual(relay.getCurrentTask(), null);
+    assert.ok(sentB.some(m => m.type === 'task_failed' && m.reason === 'Hub is not the active polling slot'),
+      'unexpected assignment must be rejected back to the hub that sent it');
+  } finally { teardown(relay); }
+});
+
+test('token_refresh and task_revoke only affect the hub that owns the active task', () => {
+  const relay = loadRelay({ env: {
+    HIVE_HUB: 'wss://hub-a.example/contribute,wss://hub-b.example/contribute',
+    HIVE_REGISTRATION_TOKEN: 'tok-a,tok-b',
+  } });
+  try {
+    const hubs = relay.getHubs();
+    const sentA = [], sentB = [];
+    hubs[0].ws = { readyState: 1, send: p => sentA.push(JSON.parse(p)) };
+    hubs[1].ws = { readyState: 1, send: p => sentB.push(JSON.parse(p)) };
+
+    relay.handleMessage(JSON.stringify({ type: 'task_assign', task_id: 't1', kind: 'issue', repo: 'foo/bar', number: 1, title: 'x' }), hubs[0]);
+    const tokenPath = path.join(relay.__tmpDir, 'gh-token.cache');
+
+    relay.handleMessage(JSON.stringify({ type: 'token_refresh', github_token: 'hub-b-token' }), hubs[1]);
+    assert.strictEqual(fs.existsSync(tokenPath), false, 'non-owning hub must not overwrite the active task token');
+
+    relay.handleMessage(JSON.stringify({ type: 'task_revoke', task_id: 't1', reason: 'wrong hub' }), hubs[1]);
+    assert.strictEqual(relay.getCurrentTask().task_id, 't1', 'non-owning hub must not revoke the active task');
+
+    relay.handleMessage(JSON.stringify({ type: 'token_refresh', github_token: 'hub-a-token' }), hubs[0]);
+    assert.strictEqual(fs.readFileSync(tokenPath, 'utf8'), 'hub-a-token');
+
+    relay.handleMessage(JSON.stringify({ type: 'task_revoke', task_id: 't1', reason: 'owner revoke' }), hubs[0]);
+    assert.strictEqual(relay.getCurrentTask(), null);
+    assert.ok(sentA.some(m => m.type === 'ready'), 'owning hub is asked for work after its revoke');
+    assert.strictEqual(sentB.filter(m => m.type === 'ready').length, 0);
   } finally { teardown(relay); }
 });
 
@@ -890,7 +969,15 @@ test('currentTask stays JSON-serializable after task_assign attaches its owning 
     hubs[0].heartbeatInterval = setInterval(() => {}, 999999);
     hubs[1].reconnectTimer = setTimeout(() => {}, 999999);
     try {
+      const origSetTimeout = global.setTimeout;
+      global.setTimeout = (fn) => { fn(); return 0; };
+      try {
+        relay.handleMessage(JSON.stringify({ type: 'task_unavailable', reason: 'no_work' }), hubs[0]);
+      } finally {
+        global.setTimeout = origSetTimeout;
+      }
       relay.handleMessage(JSON.stringify({ type: 'task_assign', task_id: 't1', kind: 'issue', repo: 'foo/bar', number: 1, title: 'x' }), hubs[1]);
+      assert.ok(relay.getCurrentTask(), 'task was accepted before serializing');
       assert.doesNotThrow(() => JSON.stringify(relay.getCurrentTask()), 'currentTask must serialize even with its _hub set');
     } finally {
       clearInterval(hubs[0].heartbeatInterval);

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -899,6 +899,30 @@ test('currentTask stays JSON-serializable after task_assign attaches its owning 
   } finally { teardown(relay); }
 });
 
+test('a currentTask with no recorded hub still reaches the hub (regression: synthetic pr-review task)', () => {
+  const relay = loadRelay({ env: {
+    HIVE_HUB: 'wss://hub-a.example/contribute,wss://hub-b.example/contribute',
+    HIVE_REGISTRATION_TOKEN: 'tok-a,tok-b',
+  } });
+  try {
+    const hubs = relay.getHubs();
+    const sentA = [];
+    hubs[0].ws = { readyState: 1, send: p => sentA.push(JSON.parse(p)) };
+    hubs[1].ws = { readyState: 1, send: () => {} };
+
+    // The pr-review task the relay builds for itself after every
+    // PR_REVIEW_EVERY_N completions is assembled locally and never carries a
+    // _hub. Routing strictly on currentTask._hub sent its frames to
+    // `undefined`, so the hub saw the contributor go silent mid-review.
+    relay.setCurrentTask({ task_id: 'pr-review-1', kind: 'review', repo: 'foo/bar', number: 0, title: 'Review open PRs' });
+    relay.failCurrentTask('done reviewing');
+
+    assert.ok(sentA.length > 0,
+      'frames for a hubless currentTask must fall back to the active hub, not be dropped');
+    assert.ok(sentA.some(m => m.type === 'task_failed' && m.task_id === 'pr-review-1'));
+  } finally { teardown(relay); }
+});
+
 // ---------------------------------------------------------------------------
 
 let failed = 0;

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -26,7 +26,7 @@ const RELAY_PATH = path.join(__dirname, 'contributor-relay.sh');
 // bash and no WebSocket are ever touched.
 // ---------------------------------------------------------------------------
 
-function loadRelay({ backend = 'copilot', model = '', cliStates = ['ready'], procAlive = true, mode = 'interactive', execFileResult = null, statusFile = null, paneText = null } = {}) {
+function loadRelay({ backend = 'copilot', model = '', cliStates = ['ready'], procAlive = true, mode = 'interactive', execFileResult = null, statusFile = null, paneText = null, env = null } = {}) {
   const commands = [];
   const sent = [];
   // Records every execFile (headless one-shot) invocation: { bin, args, opts }.
@@ -112,6 +112,7 @@ function loadRelay({ backend = 'copilot', model = '', cliStates = ['ready'], pro
   // clobber a real one and can be asserted on.
   const headlessStatusFile = statusFile || path.join(tmpDir, 'headless-status.json');
   process.env.HIVE_HEADLESS_STATUS_FILE = headlessStatusFile;
+  if (env) Object.assign(process.env, env);
 
   // node refuses to require a .sh file with the default extension handlers;
   // register .sh as JavaScript. This must happen BEFORE require.resolve(), and
@@ -777,6 +778,124 @@ test('an ordinary task failure still re-advertises ready (skipReady is opt-in)',
     relay.failCurrentTask('some ordinary failure');
     assert.strictEqual(relay.__sent.filter(m => m.type === 'ready').length, 1,
       'the pre-existing failure path must be unchanged');
+  } finally { teardown(relay); }
+});
+
+// Multi-hub (kubestellar/hive#multi-hive) — one relay/CLI session subscribed
+// to more than one hub via comma-separated HIVE_HUB/HIVE_REGISTRATION_TOKEN.
+// ---------------------------------------------------------------------------
+
+test('HIVE_HUB/HIVE_REGISTRATION_TOKEN comma lists parse into one hub per entry, matched by position', () => {
+  const relay = loadRelay({ env: {
+    HIVE_HUB: 'wss://hub-a.example/contribute,wss://hub-b.example/contribute',
+    HIVE_REGISTRATION_TOKEN: 'tok-a,tok-b',
+  } });
+  try {
+    const hubs = relay.getHubs();
+    assert.strictEqual(hubs.length, 2);
+    assert.ok(hubs[0].url.includes('hub-a.example'));
+    assert.ok(hubs[1].url.includes('hub-b.example'));
+    assert.strictEqual(hubs[0].regToken, 'tok-a');
+    assert.strictEqual(hubs[1].regToken, 'tok-b');
+  } finally { teardown(relay); }
+});
+
+test('only the active hub is sent ready on auth_ok; the other waits its turn', () => {
+  const relay = loadRelay({ env: {
+    HIVE_HUB: 'wss://hub-a.example/contribute,wss://hub-b.example/contribute',
+    HIVE_REGISTRATION_TOKEN: 'tok-a,tok-b',
+  } });
+  try {
+    const hubs = relay.getHubs();
+    const sentA = [], sentB = [];
+    hubs[0].ws = { readyState: 1, send: p => sentA.push(JSON.parse(p)) };
+    hubs[1].ws = { readyState: 1, send: p => sentB.push(JSON.parse(p)) };
+
+    relay.handleMessage(JSON.stringify({ type: 'auth_ok', contributor_id: 'c1', trust_tier: 'contributor' }), hubs[0]);
+    assert.deepStrictEqual(sentA.map(m => m.type), ['ready']);
+    assert.deepStrictEqual(sentB.map(m => m.type), []);
+
+    relay.handleMessage(JSON.stringify({ type: 'auth_ok', contributor_id: 'c1', trust_tier: 'contributor' }), hubs[1]);
+    assert.deepStrictEqual(sentB.map(m => m.type), [], 'non-active hub stays silent on its own auth_ok');
+  } finally { teardown(relay); }
+});
+
+test('a task_assign is remembered by hub, and a rejection while busy is routed to the ASKING hub', () => {
+  const relay = loadRelay({ env: {
+    HIVE_HUB: 'wss://hub-a.example/contribute,wss://hub-b.example/contribute',
+    HIVE_REGISTRATION_TOKEN: 'tok-a,tok-b',
+  } });
+  try {
+    const hubs = relay.getHubs();
+    const sentA = [], sentB = [];
+    hubs[0].ws = { readyState: 1, send: p => sentA.push(JSON.parse(p)) };
+    hubs[1].ws = { readyState: 1, send: p => sentB.push(JSON.parse(p)) };
+
+    relay.handleMessage(JSON.stringify({ type: 'task_assign', task_id: 't1', kind: 'issue', repo: 'foo/bar', number: 1, title: 'x' }), hubs[1]);
+    const task = relay.getCurrentTask();
+    assert.strictEqual(task._hub, hubs[1], 'currentTask remembers which hub assigned it');
+    assert.ok(sentB.some(m => m.type === 'task_accepted'), 'task_accepted went to the assigning hub');
+    assert.strictEqual(sentA.filter(m => m.type === 'task_accepted').length, 0);
+
+    sentA.length = 0;
+    relay.handleMessage(JSON.stringify({ type: 'task_assign', task_id: 't2', kind: 'issue', repo: 'foo/bar', number: 2, title: 'y' }), hubs[0]);
+    assert.ok(sentA.some(m => m.type === 'task_failed' && m.reason === 'Already has active task'),
+      'busy-rejection went to the hub that just asked, not silently dropped or misrouted to the active-task hub');
+    assert.strictEqual(sentB.filter(m => m.type === 'task_failed').length, 0);
+  } finally { teardown(relay); }
+});
+
+test('task_unavailable on the active hub rotates the poll slot to the next hub', () => {
+  const relay = loadRelay({ env: {
+    HIVE_HUB: 'wss://hub-a.example/contribute,wss://hub-b.example/contribute',
+    HIVE_REGISTRATION_TOKEN: 'tok-a,tok-b',
+  } });
+  try {
+    const hubs = relay.getHubs();
+    const sentA = [], sentB = [];
+    hubs[0].ws = { readyState: 1, send: p => sentA.push(JSON.parse(p)) };
+    hubs[1].ws = { readyState: 1, send: p => sentB.push(JSON.parse(p)) };
+
+    relay.handleMessage(JSON.stringify({ type: 'auth_ok', contributor_id: 'c1', trust_tier: 'contributor' }), hubs[0]);
+    assert.deepStrictEqual(sentA.map(m => m.type), ['ready']);
+
+    // task_unavailable's retry delay is a raw setTimeout (not the relay's
+    // test-mode-aware sleepMs), so run it synchronously here rather than
+    // waiting out the real 30s TASK_UNAVAILABLE_RETRY_MS.
+    const origSetTimeout = global.setTimeout;
+    global.setTimeout = (fn) => { fn(); return 0; };
+    try {
+      relay.handleMessage(JSON.stringify({ type: 'task_unavailable', reason: 'no_work' }), hubs[0]);
+    } finally {
+      global.setTimeout = origSetTimeout;
+    }
+    assert.deepStrictEqual(sentB.map(m => m.type), ['ready'], 'rotation sent ready to hub B, not hub A again');
+  } finally { teardown(relay); }
+});
+
+test('currentTask stays JSON-serializable after task_assign attaches its owning hub (regression: circular Timeout handles)', () => {
+  const relay = loadRelay({ env: {
+    HIVE_HUB: 'wss://hub-a.example/contribute,wss://hub-b.example/contribute',
+    HIVE_REGISTRATION_TOKEN: 'tok-a,tok-b',
+  } });
+  try {
+    const hubs = relay.getHubs();
+    hubs[0].ws = { readyState: 1, send: () => {} };
+    hubs[1].ws = { readyState: 1, send: () => {} };
+    // Real per-hub state (heartbeatInterval/reconnectTimer are live Timeout
+    // objects once connected) is what made JSON.stringify(currentTask) throw
+    // "Converting circular structure to JSON" the first time this shipped —
+    // a plain unit test with bare {ws} stubs didn't catch it because it never
+    // populated these fields. Set them for real here.
+    hubs[0].heartbeatInterval = setInterval(() => {}, 999999);
+    hubs[1].reconnectTimer = setTimeout(() => {}, 999999);
+    try {
+      relay.handleMessage(JSON.stringify({ type: 'task_assign', task_id: 't1', kind: 'issue', repo: 'foo/bar', number: 1, title: 'x' }), hubs[1]);
+      assert.doesNotThrow(() => JSON.stringify(relay.getCurrentTask()), 'currentTask must serialize even with its _hub set');
+    } finally {
+      clearInterval(hubs[0].heartbeatInterval);
+      clearTimeout(hubs[1].reconnectTimer);
+    }
   } finally { teardown(relay); }
 });
 


### PR DESCRIPTION
## Summary

Lets one contributor CLI/tmux session hold work from more than one hive, instead of requiring a duplicate container per hub. Comma-separated `HIVE_HUB` + `HIVE_REGISTRATION_TOKEN` (one token per hub, same order). A single value of each — the existing common case — behaves exactly as before.

## Design

- Each hub gets its own WebSocket connection/reconnect/heartbeat state (`hubs[]`); `currentTask`, `cliReady`, and everything CLI-facing stay single global values, since there's exactly one CLI/tmux session shared across whichever hub currently holds the active task.
- Only one hub is "active" (asked for work with `ready`) at a time; the others stay connected + heartbeating, idle.
- The active slot round-robins forward on an explicit `task_unavailable` ack from the active hub. This ack is reliable — the hub always sends it, never silently withholds one (#2436 / #2546) — so rotation is driven by a real signal rather than a guessed timeout, and the relay never sits idle on a hub with no work while a different configured hub has some.
- Completing/failing/reverting a task re-asks the *same* hub that gave it, rather than switching eagerly — round-robin only fires on an explicit "no work here."

## Testing

- `node bin/contributor-relay.test.js` — 31/31 (added 5 new tests covering hub-list parsing, active/idle auth_ok routing, busy-rejection routed to the asking hub not the active-task hub, task_unavailable rotation, and a regression test for a bug this PR shipped and then fixed in the same branch — see below).
- Verified live against `hive.tunaos.org` + the hosted Project Bluefin hive: both hubs connect and authenticate concurrently, round-robin correctly rotates past a rate-limited hub to one with real work, and a real `task_assign` is delivered end-to-end and completed.

## A bug this caught (worth flagging for review)

First pass attached the whole `hub` object to `currentTask._hub` for later routing. Since `currentTask` is the exact object that later gets `JSON.stringify`'d to `TASK_FILE`, and `hub` holds live `setInterval`/`setTimeout` handles (circular references), every task assignment crashed the process (`TypeError: Converting circular structure to JSON`) the moment a real task came in — caught only by running against real hubs, not by the unit tests (which used bare `{ws}` stubs without live timers). Fixed by making `_hub` a non-enumerable property via `Object.defineProperty`, and added a regression test that populates real `setInterval`/`setTimeout` handles on the hub before asserting `JSON.stringify(currentTask)` doesn't throw.