### PR TITLE
📝 docs(hub): self-host attach needs an operator-issued HIVE_HUB_SECRET

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -8058,10 +8058,17 @@ const dashboardHTML = `<!DOCTYPE html>
       <div style="display:flex;gap:8px;align-items:center">
         <button class="btn-primary" id="btn-send-banner-top" style="display:none;background:#d97706" onclick="_bannerTargetHive=null;document.getElementById('banner-modal').style.display='flex';loadBannerHiveList()">Send Banner</button>
         <!-- Register-your-own-hive: for a user who self-installed a standalone
-             hive and wants to attach it to THIS hub. Points at the existing
-             self-host guide (get-started.html #self-host) whose key step is to
-             set HIVE_HUB_URL — no new backend, no new content. Always available. -->
-        <a class="btn-primary" id="btn-register-hive" href="/get-started#self-host" style="background:var(--surface);color:var(--text);border:1px solid var(--border);text-decoration:none" title="You self-host the hive and attach it to this hub (set HIVE_HUB_URL)">Register your own hive</a>
+             hive and wants to attach it to THIS hub. Points at the self-host
+             guide (get-started.html #self-host).
+
+             NOTE: attaching a self-hosted hive is NOT self-service. Setting
+             HIVE_HUB_URL alone does not register anything — handleHeartbeat
+             rejects every unauthenticated beat with 401 whenever the hub has a
+             HIVE_HUB_SECRET configured (deliberate, #1077: "prevents registry
+             pollution from unauthenticated sources"). The operator must issue
+             the spoke a secret. The guide this links to now says so; keep the
+             two in step if either changes. -->
+        <a class="btn-primary" id="btn-register-hive" href="/get-started#self-host" style="background:var(--surface);color:var(--text);border:1px solid var(--border);text-decoration:none" title="You self-host the hive and attach it to this hub (requires a HIVE_HUB_SECRET issued by the hub operator)">Register your own hive</a>
         <!-- Request-a-hive: routes to the EXISTING Request-a-Hive wizard at
              /get-started (files a provision request via POST
              /api/saas/request-provision). Shown when the user has NO hosted
@@ -12699,7 +12706,9 @@ const dashboardHTML = `<!DOCTYPE html>
              (POST /api/saas/request-provision). We host it for you. */
           '<a class="btn-primary" href="/get-started" style="text-decoration:none" title="We host the hive for you">Request a hive</a>' +
           /* Register-your-own-hive → the EXISTING self-host guide at
-             /get-started#self-host (set HIVE_HUB_URL, hive auto-appears). */
+             /get-started#self-host. Not self-service: the operator must issue
+             the spoke a HIVE_HUB_SECRET or its heartbeats 401 (see #1077 and
+             the note on the other copy of this CTA above). */
           '<a class="btn-primary" href="/get-started#self-host" style="background:var(--surface);color:var(--text);border:1px solid var(--border);text-decoration:none" title="You self-host the hive and attach it to this hub">Register your own hive</a>' +
           '</div>' +
           '<p style="color:var(--muted);font-size:0.85rem">…or contribute to a public hive below.</p>' +

--- a/v2/pkg/hub/static/api-docs.html
+++ b/v2/pkg/hub/static/api-docs.html
@@ -297,6 +297,7 @@ curl -b "hive_hub_user=YOUR_USERNAME" \
   dashboard_url: http://YOUR_IP:3001
   snapshot_url: https://your-snapshot-url</code></pre>
           <p>Or set the environment variable: <code>HIVE_HUB_URL=https://hive.kubestellar.io</code></p>
+          <p style="margin-bottom:0"><strong>Authentication is required.</strong> <code>POST /api/heartbeat</code> rejects any beat without a valid <code>Authorization: Bearer &lt;HIVE_HUB_SECRET&gt;</code> header when the hub has a secret configured, so the settings above only take effect once the hub operator has issued your spoke a <code>HIVE_HUB_SECRET</code>. A spoke configured without one logs <code>hub heartbeat rejected status=401</code> every beat and never appears in the registry.</p>
         </div>
 
         <h2>Rate Limits</h2>

--- a/v2/pkg/hub/static/get-started.html
+++ b/v2/pkg/hub/static/get-started.html
@@ -461,7 +461,8 @@ docker compose up -d
 
 # Open the dashboard
 open http://localhost:3001</code></pre>
-      <p style="margin-bottom:0">To register with hive.kubestellar.io, set <code>HIVE_HUB_URL=https://hive.kubestellar.io</code> in your environment. Your hive will appear in the <a href="/#hives" style="color:var(--blue)">Active Hives</a> table within 5 minutes.</p>
+      <p>A self-hosted hive is fully functional on its own &mdash; it does not need to be attached to hive.kubestellar.io.</p>
+      <p style="margin-bottom:0">Listing a hive you host yourself in the <a href="/#hives" style="color:var(--blue)">Active Hives</a> table is a separate, operator-mediated step. Setting <code>HIVE_HUB_URL</code> on its own is <strong>not</strong> sufficient: the hub authenticates every heartbeat against <code>HIVE_HUB_SECRET</code>, which is issued by the hub operator &mdash; unauthenticated registration was deliberately removed to prevent registry pollution. To get a self-hosted hive listed, <a href="https://github.com/kubestellar/hive/issues/new" style="color:var(--blue)">open an issue</a>. If you would rather not run the infrastructure at all, use the hosted-hive wizard at the top of this page and the hub will provision and list one for you.</p>
     </div>
   </section>
 


### PR DESCRIPTION
Fixes #2847.

## The problem

`get-started.html` has told self-hosters since 2026-06-04:

> "To register with hive.kubestellar.io, set `HIVE_HUB_URL=https://hive.kubestellar.io` in your environment. Your hive will appear in the Active Hives table within 5 minutes."

That stopped being true **one day later**. #1077 (2026-06-05) added the Bearer-token gate to `handleHeartbeat` — explicitly to *"prevent registry pollution from unauthenticated sources"* — and the docs were never updated. #2693 (2026-08-05) then added a prominent **"Register your own hive"** CTA pointing at the stale guide, with a comment asserting the flow is *"Always available"*.

Net effect: a self-hoster who follows the documented steps gets `hub heartbeat rejected status=401` on every beat, forever, with nothing on the page explaining why. (That's how I hit this — my own spoke has been 401ing for days.)

## Why this corrects the docs instead of reopening the endpoint

I opened #2847 suggesting one option might be to exempt self-hosted spokes from the `hubSecret` check. **Having since read the history, that would be wrong** — the gate is a deliberate security control, and it's load-bearing for more than pollution:

- The heartbeat *response* can carry `HeartbeatGitHubAppConfig.PrivateKey` (a GitHub App private key) and `PendingGateway` (a funded gateway secret). An unauthenticated `/api/heartbeat` would therefore be a **credential-disclosure** vector, not merely a spam one — anyone who knew or guessed a `hive_id` could receive that hive's App key.
- `HIVE_HUB_SECRET` is a fleet-wide *master* secret: `hub_keys.go` derives the SSO Ed25519 signing seed and the session-cookie key from it. So it can't simply be handed to self-hosters either.
- `v2/docs/manual-provisioning.md` already documents the secret as **REQUIRED** ("Gotcha — `HIVE_HUB_SECRET` is REQUIRED or the hive is permanently offline"). The operator-facing docs were right all along; only the public pages were stale.

So the honest fix is to stop promising a flow that was closed on purpose, and say what the actual path is.

## Changes

- **`get-started.html`** — state plainly that a self-hosted hive is fully functional standalone, that listing on the public hub is a separate operator-mediated step, that `HIVE_HUB_URL` alone is not sufficient and why, and how to ask for a listing. Also points people who'd rather not run infra at all at the hosted-hive wizard.
- **`api-docs.html`** — note the `Authorization: Bearer <HIVE_HUB_SECRET>` requirement on `POST /api/heartbeat` directly beneath the hub config block, including the exact `status=401` symptom so it's greppable.
- **`saas.go`** — correct both "Register your own hive" CTA comments (one still said "Always available", the other "set HIVE_HUB_URL, hive auto-appears") and the button tooltip.

Docs/comments only — no behaviour change.

## Testing

- `go build ./...` clean
- `go test ./pkg/hub/` — ok (37.8s)
- `gofmt -l pkg/hub/saas.go` clean

## Open question for maintainers

Is there an intended self-service path for listing a genuinely self-hosted (BYO) hive? I couldn't find one — the secret is only injected operator-side at provisioning time (`saas_provision.go`), and nothing ever returns it to a caller. I've written the docs to say "open an issue"; happy to change that to whatever the real process is. If a sandboxed community-listing tier (unauthenticated beats accepted, but registration limited to unclaimed IDs and the response stripped of all secrets/commands) would be welcome, I'm glad to take that on as a follow-up — but that's a trust-model decision that seemed worth asking about rather than assuming.