### PR TITLE
🐛 fix(contributor): recover instead of stalling when the CLI never becomes ready

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1120,7 +1120,11 @@ function handleMessage(data) {
       }
       reconnectDelay = BASE_RECONNECT_DELAY_MS;
       if (!currentTask) {
-        send({ type: 'ready', seq: nextSeq() });
+        if (!cliReadyFailed) {
+          send({ type: 'ready', seq: nextSeq() });
+        } else {
+          console.log('Authenticated, but CLI readiness previously failed — withholding ready until the CLI recovers');
+        }
       } else {
         console.log(`Reconnected while working on ${currentTask.repo}#${currentTask.number} — resuming`);
         send({ type: 'task_accepted', seq: nextSeq(), task_id: currentTask.task_id });
@@ -1303,6 +1307,8 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     MAX_TASK_CLI_RESTARTS,
     setCliReady: (v) => { cliReady = v; },
     getCliReady: () => cliReady,
+    setCliReadyFailed: (v) => { cliReadyFailed = v; },
+    getCliReadyFailed: () => cliReadyFailed,
     getPendingTask: () => pendingTask,
     setPendingTask: (v) => { pendingTask = v; },
     setTasksCompletedCount: (v) => { tasksCompletedCount = v; },

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -378,13 +378,46 @@ function recoverWedgedShell() {
   } catch (_) {}
 }
 
-function getCLIState() {
+// capturePaneText returns the current pane contents, or "" if tmux can't be
+// reached. Extracted so the readiness classifier and the blocking-prompt
+// dismissal can look at the SAME text without capturing twice, and so the
+// dismissal can see WHICH prompt is on screen rather than re-deriving it from
+// a state enum that has already thrown that detail away.
+function capturePaneText() {
   try {
-    const output = execSync(
+    return execSync(
       `tmux capture-pane -t ${TMUX_SESSION} -p 2>/dev/null`,
       { encoding: 'utf8', timeout: 15000 }
-    );
-    const text = output.toString();
+    ).toString();
+  } catch (_) {
+    return '';
+  }
+}
+
+// blockingPromptKey returns the keystroke that dismisses whatever modal prompt
+// is on screen, or null meaning "a bare Enter is the right answer".
+//
+// Some CLIs gate startup behind a NUMBERED menu rather than a yes/no confirm.
+// For those a bare Enter does nothing useful — it just re-renders the menu — so
+// the relay would "dismiss" in a loop until CLI_READY_TIMEOUT_MS and the task
+// would be dropped. Each entry names the exact prompt it answers, so an
+// unrelated menu is never blind-fired at.
+function blockingPromptKey(text) {
+  // codex: "Do you trust the contents of this directory?" → 1. Yes, continue
+  if (/Do you trust the contents of this directory/.test(text)) return '1';
+  // codex: "✨ Update available! x -> y" → 3. Skip until next version.
+  // Deliberately NOT "1. Update now": that shells out to `npm install -g`
+  // inside the container — slow, needs network, can fail half-way, and drifts
+  // the CLI version out from under the image. "Skip until next version" also
+  // persists, so this prompt stops coming back on every restart the way a
+  // plain "Skip" would.
+  if (/Update available!/.test(text) && /Skip until next version/.test(text)) return '3';
+  return null;
+}
+
+function getCLIState() {
+  try {
+    const text = capturePaneText();
     if (BACKEND === 'claude') {
       if (/Not logged in|Please run \/login/.test(text)) return 'needs-login';
       if (/bypass permissions|Welcome back|Try "how does|medium.*effort|@gmail\.com|@.*\.com.*Organization/.test(text)) return 'ready';
@@ -412,6 +445,13 @@ function getCLIState() {
       // that happened to end in a '>' — including partially drawn frames.
       if (/Enter your prompt, \/ for commands|Auto-approve:|Tokens left:/.test(text)) return 'ready';
     } else if (BACKEND === 'codex') {
+      // Order matters, as it does for bob above: codex draws its version banner
+      // and input chrome BEHIND a modal prompt, so the 'ready' patterns below
+      // match a pane that is actually blocked on a menu. Classifying the modals
+      // first is what stops the relay from typing a task prompt into a
+      // "1. Yes, continue / 2. No, quit" list, where it is swallowed.
+      if (/Do you trust the contents of this directory/.test(text)) return 'onboarding';
+      if (/Update available!/.test(text) && /Skip until next version/.test(text)) return 'onboarding';
       if (/codex>|>\s*$|Codex CLI/.test(text)) return 'ready';
     } else if (BACKEND === 'pi') {
       if (/pi v\d|0\.0%|auto\)|\d+\.\d+%/.test(text)) return 'ready';
@@ -438,8 +478,15 @@ function waitForCLI() {
         console.log('CLI ready — accepting tasks');
         resolve();
       } else if (state === 'onboarding') {
-        console.log('Auto-dismissing trust/onboarding dialog...');
-        try { execSync(`tmux send-keys -t ${TMUX_SESSION} Enter`, { timeout: 15000 }); } catch (_) {}
+        // A numbered menu needs its option typed before Enter; a yes/no confirm
+        // takes a bare Enter. blockingPromptKey() tells the two apart from the
+        // pane text, so this no longer loops uselessly on menu-shaped prompts.
+        const key = blockingPromptKey(capturePaneText());
+        console.log(`Auto-dismissing trust/onboarding dialog${key ? ` (selecting "${key}")` : ''}...`);
+        try {
+          if (key) execSync(`tmux send-keys -t ${TMUX_SESSION} ${key} Enter`, { timeout: 15000 });
+          else execSync(`tmux send-keys -t ${TMUX_SESSION} Enter`, { timeout: 15000 });
+        } catch (_) {}
         setTimeout(check, CLI_READY_POLL_MS);
       } else if (state === 'needs-login' && !loginMessageShown) {
         loginMessageShown = true;
@@ -466,6 +513,10 @@ function waitForCLI() {
 
 let cliReady = false;
 let pendingTask = null;
+// True once a CLI-readiness wait has timed out and we handed its task back.
+// Used so the eventual recovery re-advertises availability to the hub, which
+// we deliberately withheld at failure time (see armCLIReadyWait).
+let cliReadyFailed = false;
 
 if (CONTRIBUTOR_MODE === MODE_HEADLESS) {
   // Headless mode has no tmux pane to scrape for readiness. Each task spawns
@@ -483,10 +534,49 @@ if (CONTRIBUTOR_MODE === MODE_HEADLESS) {
     writeHeadlessStatus(HEADLESS_STATE_WAITING);
   }
 } else {
+  armCLIReadyWait();
+}
+
+// armCLIReadyWait waits for the CLI to reach its prompt and, crucially, does
+// something sane when it never does.
+//
+// The old code was `.catch(e => console.error(e.message))`. That silently
+// abandoned the task: cliReady stayed false, pendingTask kept holding the
+// prompt, and the HUB WAS NEVER TOLD — so from the hub's side this contributor
+// was still working on the issue, and the slot stayed held until the hub's own
+// timeout eventually revoked it. Any cause of an unresponsive backend (an
+// unrecognized modal prompt, a crashed pane, a half-finished login, a hung
+// update) produced the same black hole.
+//
+// Now the task is handed straight back so another contributor can pick it up,
+// and the relay keeps waiting rather than declaring itself available: it does
+// NOT re-advertise 'ready' until the CLI genuinely reaches its prompt.
+// Otherwise it would immediately accept another task it still cannot run and
+// churn one task per timeout window forever.
+function armCLIReadyWait() {
+  const hadFailed = cliReadyFailed;
   waitForCLI().then(() => {
     cliReady = true;
+    cliReadyFailed = false;
+    // Only re-advertise if we previously withdrew by failing a task; the normal
+    // startup path is already advertised by the auth_ok handler.
+    if (hadFailed) send({ type: 'ready', seq: nextSeq() });
     flushPendingTask();
-  }).catch(e => console.error(e.message));
+  }).catch(e => {
+    cliReadyFailed = true;
+    console.error(e.message);
+    // Drop the queued prompt first: if the CLI later recovers, flushing a
+    // prompt for a task the hub has already reassigned would have this
+    // contributor silently working on someone else's issue.
+    pendingTask = null;
+    if (currentTask) {
+      failCurrentTask(`CLI never became ready: ${e.message}`, { skipReady: true });
+    }
+    // Keep waiting. The CLI may still come up (a slow login, an operator
+    // attaching to clear a prompt we don't recognize), and when it does the
+    // handler above re-advertises availability.
+    armCLIReadyWait();
+  });
 }
 
 const ENTER_COUNT = 3;
@@ -703,10 +793,9 @@ function relaunchCLI() {
   // classifier positively confirms it, or a task prompt sent in the meantime
   // is typed as literal keystrokes into a bare shell (issue #2203, bug 2).
   cliReady = false;
-  waitForCLI().then(() => {
-    cliReady = true;
-    flushPendingTask();
-  }).catch(e => console.error(`CLI did not become ready after relaunch: ${e.message}`));
+  // Same recovery contract as the startup path: a relaunch that never reaches
+  // a prompt must hand its task back rather than sit on it silently.
+  armCLIReadyWait();
   return launchCmd;
 }
 
@@ -868,7 +957,13 @@ function failCurrentTask(reason, opts) {
   taskAssignedAt = 0;
   if (progressInterval) { clearInterval(progressInterval); progressInterval = null; }
   if (taskTimeoutHandle) { clearTimeout(taskTimeoutHandle); taskTimeoutHandle = null; }
-  send({ type: 'ready', seq: nextSeq() });
+  // skipReady: the caller knows this contributor cannot run anything right now
+  // (the CLI never reached its prompt), so it hands the task back WITHOUT
+  // claiming to be free. Advertising 'ready' here would just pull in another
+  // task the CLI still cannot run. The caller re-advertises on recovery.
+  if (!(opts && opts.skipReady)) {
+    send({ type: 'ready', seq: nextSeq() });
+  }
 }
 
 function startProgressReporting() {
@@ -1215,6 +1310,9 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     setLastResetAtCount: (v) => { lastResetAtCount = v; },
     getLastResetAtCount: () => lastResetAtCount,
     getCurrentTask: () => currentTask,
+    setCurrentTask: (v) => { currentTask = v; },
+    blockingPromptKey,
+    getCLIState,
     setWs: (w) => { ws = w; },
     // Headless (non-interactive) mode surface (kubestellar/hive#2538).
     CONTRIBUTOR_MODE,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -26,7 +26,7 @@ const RELAY_PATH = path.join(__dirname, 'contributor-relay.sh');
 // bash and no WebSocket are ever touched.
 // ---------------------------------------------------------------------------
 
-function loadRelay({ backend = 'copilot', model = '', cliStates = ['ready'], procAlive = true, mode = 'interactive', execFileResult = null, statusFile = null } = {}) {
+function loadRelay({ backend = 'copilot', model = '', cliStates = ['ready'], procAlive = true, mode = 'interactive', execFileResult = null, statusFile = null, paneText = null } = {}) {
   const commands = [];
   const sent = [];
   // Records every execFile (headless one-shot) invocation: { bin, args, opts }.
@@ -40,6 +40,10 @@ function loadRelay({ backend = 'copilot', model = '', cliStates = ['ready'], pro
     if (/backend_binary/.test(cmd)) return `${backend}\n`;
     if (/backend_perm_flag/.test(cmd)) return '--allow-all\n';
     if (/capture-pane/.test(cmd)) {
+      // paneText, when given, is returned verbatim — for tests that need a
+      // REAL pane rendering (e.g. a codex modal menu) rather than one of the
+      // three synthetic states below.
+      if (paneText !== null) return paneText;
       const state = cliStates[Math.min(stateIdx++, cliStates.length - 1)];
       // Panes that getCLIState()/checkTmuxIdle() classify per backend.
       if (state === 'ready') return '/ commands for help\n';
@@ -657,6 +661,110 @@ test('interactive mode still delivers via tmux send-keys (unchanged default path
     const literalSends = relay.__tmuxSends().filter(c => / -l /.test(c));
     assert.ok(literalSends.some(c => c.includes('foo/bar#7')),
       'interactive mode must still type the prompt into tmux');
+  } finally { teardown(relay); }
+});
+
+// ---------------------------------------------------------------------------
+// Unresponsive-backend recovery: blocking modal prompts must be classified and
+// dismissed with the RIGHT key, and a CLI that never reaches its prompt must
+// hand its task back instead of silently holding it.
+// ---------------------------------------------------------------------------
+
+// Real captures from a running ghcr.io/kubestellar/hive-contributor container.
+// Note both keep codex's banner chrome ("OpenAI Codex (v0.146.0)", the "›"
+// input marker) on screen BEHIND the modal — which is exactly why the ready
+// patterns have to be checked after the modal patterns, not before.
+const CODEX_TRUST_PANE = [
+  'dev@codex-contributor:~/workspace$ codex --dangerously-bypass-approvals-and-sandbox',
+  '> You are in /home/dev/workspace',
+  '',
+  '  Do you trust the contents of this directory? Working with untrusted contents comes with higher risk of prompt injection.',
+  '',
+  '› 1. Yes, continue',
+  '  2. No, quit',
+  '',
+  '  Press enter to continue',
+  '╭─────────────────────────────────────────────────────╮',
+  '│ >_ OpenAI Codex (v0.146.0)                          │',
+  '╰─────────────────────────────────────────────────────╯',
+].join('\n');
+
+const CODEX_UPDATE_PANE = [
+  'dev@codex-contributor:~/workspace$ codex --dangerously-bypass-approvals-and-sandbox',
+  '  ✨ Update available! 0.146.0 -> 0.147.0',
+  '  Release notes: https://github.com/openai/codex/releases/latest',
+  '› 1. Update now (runs `npm install -g @openai/codex`)',
+  '  2. Skip',
+  '  3. Skip until next version',
+  '  Press enter to continue',
+].join('\n');
+
+test('codex trust prompt is classified as onboarding, not ready, despite the banner behind it', () => {
+  const relay = loadRelay({ backend: 'codex', paneText: CODEX_TRUST_PANE });
+  try {
+    assert.strictEqual(relay.getCLIState(), 'onboarding',
+      'a pane blocked on the trust menu must not be reported ready — a task prompt typed there is swallowed by the menu');
+  } finally { teardown(relay); }
+});
+
+test('codex update nudge is classified as onboarding, not ready', () => {
+  const relay = loadRelay({ backend: 'codex', paneText: CODEX_UPDATE_PANE });
+  try {
+    assert.strictEqual(relay.getCLIState(), 'onboarding');
+  } finally { teardown(relay); }
+});
+
+test('numbered menus get an explicit selection, not a bare Enter', () => {
+  const relay = loadRelay({ backend: 'codex', paneText: CODEX_TRUST_PANE });
+  try {
+    // "1. Yes, continue" — Enter alone just re-renders the menu forever.
+    assert.strictEqual(relay.blockingPromptKey(CODEX_TRUST_PANE), '1');
+    // "3. Skip until next version" — deliberately NOT "1. Update now", which
+    // would run npm install -g inside the container.
+    assert.strictEqual(relay.blockingPromptKey(CODEX_UPDATE_PANE), '3');
+    // A plain yes/no confirm still takes a bare Enter.
+    assert.strictEqual(relay.blockingPromptKey('Do you trust this folder? (y/n)'), null);
+  } finally { teardown(relay); }
+});
+
+test('a CLI that never becomes ready hands its task BACK to the hub instead of silently holding it', () => {
+  const relay = loadRelay({ backend: 'copilot', cliStates: ['starting'] });
+  try {
+    relay.setCliReady(false);
+    relay.setCurrentTask({ task_id: 'ct-stuck-1', kind: 'issue', repo: 'foo/bar', number: 5, title: 'stuck' });
+    relay.setPendingTask('a queued prompt');
+    relay.__sent.length = 0;
+
+    // What armCLIReadyWait's catch path does on CLI_READY_TIMEOUT_MS.
+    relay.failCurrentTask('CLI never became ready: CLI did not become ready within timeout', { skipReady: true });
+
+    const failures = relay.__sent.filter(m => m.type === 'task_failed');
+    assert.strictEqual(failures.length, 1, 'the hub must be told, or the slot is held until the hub times out');
+    assert.strictEqual(failures[0].task_id, 'ct-stuck-1');
+    assert.match(failures[0].reason, /never became ready/);
+    assert.strictEqual(relay.getCurrentTask(), null, 'task must be released locally too');
+  } finally { teardown(relay); }
+});
+
+test('handing back a task from a wedged CLI does NOT re-advertise ready', () => {
+  const relay = loadRelay({ backend: 'copilot', cliStates: ['starting'] });
+  try {
+    relay.setCurrentTask({ task_id: 'ct-stuck-2', kind: 'issue', repo: 'foo/bar', number: 6, title: 'stuck' });
+    relay.__sent.length = 0;
+    relay.failCurrentTask('CLI never became ready', { skipReady: true });
+    assert.strictEqual(relay.__sent.filter(m => m.type === 'ready').length, 0,
+      'claiming to be free while the CLI is still wedged would pull in another unrunnable task every timeout window');
+  } finally { teardown(relay); }
+});
+
+test('an ordinary task failure still re-advertises ready (skipReady is opt-in)', () => {
+  const relay = loadRelay({ backend: 'copilot' });
+  try {
+    relay.setCurrentTask({ task_id: 'ct-normal', kind: 'issue', repo: 'foo/bar', number: 7, title: 'x' });
+    relay.__sent.length = 0;
+    relay.failCurrentTask('some ordinary failure');
+    assert.strictEqual(relay.__sent.filter(m => m.type === 'ready').length, 1,
+      'the pre-existing failure path must be unchanged');
   } finally { teardown(relay); }
 });
 

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -757,6 +757,18 @@ test('handing back a task from a wedged CLI does NOT re-advertise ready', () => 
   } finally { teardown(relay); }
 });
 
+test('reconnect while wedged also withholds ready until CLI recovery', () => {
+  const relay = loadRelay({ backend: 'copilot', cliStates: ['starting'] });
+  try {
+    relay.setCliReady(false);
+    relay.setCliReadyFailed(true);
+    relay.__sent.length = 0;
+    relay.handleMessage(JSON.stringify({ type: 'auth_ok', contributor_id: 'c1', trust_tier: 'trusted' }));
+    assert.strictEqual(relay.__sent.filter(m => m.type === 'ready').length, 0,
+      'auth_ok must not bypass skipReady after a readiness failure; recovery re-advertises ready');
+  } finally { teardown(relay); }
+});
+
 test('an ordinary task failure still re-advertises ready (skipReady is opt-in)', () => {
   const relay = loadRelay({ backend: 'copilot' });
   try {


### PR DESCRIPTION
Three compounding faults let a contributor hold a task indefinitely without ever running it. I hit all three on a codex-backend contributor, but **fault 1 is backend-agnostic** — it black-holes a task for *any* cause of an unresponsive CLI.

## 1. A readiness timeout silently abandoned the task (the important one)

```js
waitForCLI().then(() => { cliReady = true; flushPendingTask(); })
            .catch(e => console.error(e.message));   // ← that's all
```

On `CLI_READY_TIMEOUT_MS`: `cliReady` stays false, `pendingTask` keeps holding the prompt, and **the hub is never told**. From the hub's side the contributor is still working the issue, so the slot stays held until the hub's own timeout revokes it. Unrecognized modal prompt, crashed pane, half-finished login, hung update — every one produces the same black hole. This is the same slot-starvation class as #2203.

Now the task is handed back with `task_failed` so it can be reassigned immediately, and the relay keeps waiting for the CLI.

Importantly it does **not** re-advertise `ready` while still wedged (new opt-in `skipReady`). Sending `ready` there would pull in another task it still cannot run and churn one task per timeout window — strictly worse than the bug. Availability is re-advertised only once the CLI genuinely reaches its prompt.

## 2. codex modals were never classified — and matched as *ready*

codex had no `onboarding` branch at all, so its prompts were never dismissed. Worse, codex draws its version banner and input chrome **behind** the modal, so the existing `ready` patterns (`/codex>|>\s*$|Codex CLI/`) match a pane that is actually blocked — the relay types the task prompt into a menu, where it's swallowed.

Modal patterns are now checked **before** the ready patterns, exactly as they already are for `bob` (whose comment explains the same hazard).

## 3. Dismissal only ever sent a bare Enter

Which does nothing to a **numbered menu** but re-render it — so the "auto-dismiss" looped until the timeout above. `blockingPromptKey()` now picks the right key from the pane text:

- `1` for codex's directory-trust menu (`1. Yes, continue`)
- `3` for its update nudge (`3. Skip until next version`) — deliberately **not** `1. Update now`, which shells out to `npm install -g` inside the container: slow, needs network, can fail half-way, and drifts the CLI version out from under the image. "Skip until next version" also persists, so it stops recurring on every restart.

A plain yes/no confirm still gets a bare Enter, so existing backends are untouched.

## Testing

`node bin/contributor-relay.test.js` — 32/32 (26 pre-existing + 6 new). The pane fixtures are **real captures** from a running `ghcr.io/kubestellar/hive-contributor` container, including the chrome-behind-the-modal rendering that defeats the ready patterns.

Verified live: codex sat at the update menu until the relay timed out and dropped `projectbluefin/fsdk-containers#89`; with this patch bind-mounted it auto-selects `3` and proceeds to its prompt.

## Relationship to #2845

#2845 fixes the same codex trust prompt one layer up, in `contributor-agent.sh`'s launcher loop. Both loops scrape the pane independently, so both need the fix — but they're separate files with separate failure windows and are reviewable independently. Happy to combine them if you'd prefer one PR.