### PR TITLE
✨ feat(dashboard): custom stylesheet param for the spoke dashboard and read-only preview

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -91,18 +91,24 @@ project:
   ai_author: your-bot-user
 ```
 
-### Leaderboard custom stylesheet
+### Custom stylesheets
 
-The ClankeR leaderboard accepts a shareable custom stylesheet parameter:
+The ClankeR leaderboard, the spoke dashboard, and the read-only `/snapshot`
+preview accept a shareable custom stylesheet parameter:
 
 `/contribute/leaderboard?style=owner/repo/path/to/theme.css@ref`
+`/?style=owner/repo/path/to/theme.css@ref`
+`/snapshot?style=owner/repo/path/to/theme.css@ref`
 
 The `@ref` suffix is optional and defaults to the repo's `HEAD`. Hive only
 accepts the `owner/repo/path.css` triplet form, fetches public GitHub raw content
 server-side without credentials, sanitizes CSS, strips external imports/URLs, and
-serves it from `/api/leaderboard/style` with a 128 KiB size cap. The sanitizer
-also scopes selectors to the leaderboard tab and removes legacy executable CSS
-vectors and CSS escape sequences.
+serves it from same-origin endpoints with a 128 KiB size cap. The sanitizer
+removes legacy executable CSS vectors and CSS escape sequences. Leaderboard CSS
+is scoped to `#tab-leaderboard`; dashboard and snapshot CSS is scoped to
+`#hive-dashboard-root`, which deliberately leaves login/setup overlays outside
+the custom-theme surface. `/api/style` is public so unauthenticated snapshots can
+load sanitized CSS, and the existing `style-src 'self'` CSP remains sufficient.
 
 ## Agents
 

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -35,6 +35,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.registerContributeRoutes()
 
 	s.mux.HandleFunc("GET /api/version", s.handleVersion)
+	s.mux.HandleFunc("GET /api/style", s.handleStyle)
 	s.mux.HandleFunc("GET /api/config", s.handleConfig)
 	s.mux.HandleFunc("GET /api/config/download", s.handleConfigDownload)
 	s.mux.HandleFunc("GET /api/config/provenance", s.handleConfigProvenance)

--- a/v2/pkg/dashboard/api_leaderboard_style.go
+++ b/v2/pkg/dashboard/api_leaderboard_style.go
@@ -13,31 +13,39 @@ import (
 )
 
 const (
-	leaderboardCustomStyleMaxBytes   = 128 * 1024
-	leaderboardCustomStyleCacheTTL   = 5 * time.Minute
-	leaderboardCustomStyleMaxCache   = 64
-	leaderboardCustomStyleFetchTTL   = 10 * time.Second
-	leaderboardCustomStyleDefaultRef = "HEAD"
+	customStyleMaxBytes   = 128 * 1024
+	customStyleCacheTTL   = 5 * time.Minute
+	customStyleMaxCache   = 64
+	customStyleFetchTTL   = 10 * time.Second
+	customStyleDefaultRef = "HEAD"
+
+	customStyleScopeDashboard   = "dashboard"
+	customStyleScopeLeaderboard = "leaderboard"
 )
 
-var leaderboardCustomStyleRawBaseURL = "https://raw.githubusercontent.com"
+var customStyleRawBaseURL = "https://raw.githubusercontent.com"
 
-type leaderboardCustomStyleSource struct {
+var customStyleAllowedScopes = map[string]string{
+	customStyleScopeDashboard:   "#hive-dashboard-root",
+	customStyleScopeLeaderboard: "#tab-leaderboard",
+}
+
+type customStyleSource struct {
 	Owner string
 	Repo  string
 	Path  string
 	Ref   string
 }
 
-type leaderboardCustomStyleCacheEntry struct {
+type customStyleCacheEntry struct {
 	css       []byte
 	expiresAt time.Time
 }
 
 var (
-	leaderboardCustomStyleCacheMu sync.Mutex
-	leaderboardCustomStyleCache   = map[string]leaderboardCustomStyleCacheEntry{}
-	leaderboardCustomStyleClient  = &http.Client{Timeout: leaderboardCustomStyleFetchTTL}
+	customStyleCacheMu sync.Mutex
+	customStyleCache   = map[string]customStyleCacheEntry{}
+	customStyleClient  = &http.Client{Timeout: customStyleFetchTTL}
 )
 
 var (
@@ -49,46 +57,46 @@ var (
 	cssURLRE          = regexp.MustCompile(`(?is)url\(\s*(['"]?)([^'")]+)['"]?\s*\)`)
 )
 
-func validateLeaderboardCustomStyleSource(src string) (leaderboardCustomStyleSource, error) {
+func validateCustomStyleSource(src string) (customStyleSource, error) {
 	src = strings.TrimSpace(src)
 	if src == "" {
-		return leaderboardCustomStyleSource{}, fmt.Errorf("style source is required")
+		return customStyleSource{}, fmt.Errorf("style source is required")
 	}
 	if strings.Contains(src, "://") || strings.HasPrefix(src, "//") {
-		return leaderboardCustomStyleSource{}, fmt.Errorf("use owner/repo/path.css, not a full URL")
+		return customStyleSource{}, fmt.Errorf("use owner/repo/path.css, not a full URL")
 	}
-	ref := leaderboardCustomStyleDefaultRef
+	ref := customStyleDefaultRef
 	if at := strings.LastIndex(src, "@"); at >= 0 {
 		if at == len(src)-1 {
-			return leaderboardCustomStyleSource{}, fmt.Errorf("ref is empty")
+			return customStyleSource{}, fmt.Errorf("ref is empty")
 		}
 		ref = src[at+1:]
 		src = src[:at]
 	}
 	parts := strings.Split(src, "/")
 	if len(parts) < 3 {
-		return leaderboardCustomStyleSource{}, fmt.Errorf("style source must be owner/repo/path.css")
+		return customStyleSource{}, fmt.Errorf("style source must be owner/repo/path.css")
 	}
 	owner, repo := parts[0], parts[1]
 	cssPath := strings.Join(parts[2:], "/")
 	if !githubOwnerNameRE.MatchString(owner) {
-		return leaderboardCustomStyleSource{}, fmt.Errorf("invalid owner")
+		return customStyleSource{}, fmt.Errorf("invalid owner")
 	}
 	if !githubRepoNameRE.MatchString(repo) || repo == "." || repo == ".." {
-		return leaderboardCustomStyleSource{}, fmt.Errorf("invalid repo")
+		return customStyleSource{}, fmt.Errorf("invalid repo")
 	}
-	if err := validateLeaderboardCustomStylePath(cssPath); err != nil {
-		return leaderboardCustomStyleSource{}, err
+	if err := validateCustomStylePath(cssPath); err != nil {
+		return customStyleSource{}, err
 	}
-	if ref != leaderboardCustomStyleDefaultRef {
+	if ref != customStyleDefaultRef {
 		if !githubRefNameRE.MatchString(ref) || strings.Contains(ref, "..") || strings.HasPrefix(ref, "/") || strings.HasSuffix(ref, "/") {
-			return leaderboardCustomStyleSource{}, fmt.Errorf("invalid ref")
+			return customStyleSource{}, fmt.Errorf("invalid ref")
 		}
 	}
-	return leaderboardCustomStyleSource{Owner: owner, Repo: repo, Path: cssPath, Ref: ref}, nil
+	return customStyleSource{Owner: owner, Repo: repo, Path: cssPath, Ref: ref}, nil
 }
 
-func validateLeaderboardCustomStylePath(cssPath string) error {
+func validateCustomStylePath(cssPath string) error {
 	if cssPath == "" || strings.HasPrefix(cssPath, "/") || strings.Contains(cssPath, "\\") || strings.Contains(cssPath, "://") {
 		return fmt.Errorf("invalid path")
 	}
@@ -106,12 +114,16 @@ func validateLeaderboardCustomStylePath(cssPath string) error {
 	return nil
 }
 
-func leaderboardCustomStyleCacheKey(src leaderboardCustomStyleSource) string {
+func customStyleCacheKey(src customStyleSource, scope string) string {
+	return src.Owner + "/" + src.Repo + "/" + src.Path + "@" + src.Ref + "|" + scope
+}
+
+func customStyleSourceKey(src customStyleSource) string {
 	return src.Owner + "/" + src.Repo + "/" + src.Path + "@" + src.Ref
 }
 
-func leaderboardCustomStyleRawURL(src leaderboardCustomStyleSource) string {
-	parts := []string{strings.TrimRight(leaderboardCustomStyleRawBaseURL, "/"), pathEscape(src.Owner), pathEscape(src.Repo), pathEscape(src.Ref)}
+func customStyleRawURL(src customStyleSource) string {
+	parts := []string{strings.TrimRight(customStyleRawBaseURL, "/"), pathEscape(src.Owner), pathEscape(src.Repo), pathEscape(src.Ref)}
 	for _, segment := range strings.Split(src.Path, "/") {
 		parts = append(parts, pathEscape(segment))
 	}
@@ -122,49 +134,65 @@ func pathEscape(s string) string {
 	return strings.ReplaceAll(url.PathEscape(s), "%2F", "/")
 }
 
-func getLeaderboardCustomStyle(ctx context.Context, rawSrc string) ([]byte, leaderboardCustomStyleSource, error) {
-	src, err := validateLeaderboardCustomStyleSource(rawSrc)
-	if err != nil {
-		return nil, leaderboardCustomStyleSource{}, err
+func normalizeCustomStyleScope(scope string) (string, string, error) {
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
+		scope = customStyleScopeDashboard
 	}
-	key := leaderboardCustomStyleCacheKey(src)
+	root, ok := customStyleAllowedScopes[scope]
+	if !ok {
+		return "", "", fmt.Errorf("invalid style scope")
+	}
+	return scope, root, nil
+}
+
+func getCustomStyle(ctx context.Context, rawSrc, rawScope string) ([]byte, customStyleSource, error) {
+	scope, root, err := normalizeCustomStyleScope(rawScope)
+	if err != nil {
+		return nil, customStyleSource{}, err
+	}
+	src, err := validateCustomStyleSource(rawSrc)
+	if err != nil {
+		return nil, customStyleSource{}, err
+	}
+	key := customStyleCacheKey(src, scope)
 	now := time.Now()
-	leaderboardCustomStyleCacheMu.Lock()
-	if entry, ok := leaderboardCustomStyleCache[key]; ok && now.Before(entry.expiresAt) {
+	customStyleCacheMu.Lock()
+	if entry, ok := customStyleCache[key]; ok && now.Before(entry.expiresAt) {
 		css := append([]byte(nil), entry.css...)
-		leaderboardCustomStyleCacheMu.Unlock()
+		customStyleCacheMu.Unlock()
 		return css, src, nil
 	}
-	leaderboardCustomStyleCacheMu.Unlock()
+	customStyleCacheMu.Unlock()
 
-	css, err := fetchAndSanitizeLeaderboardCustomStyle(ctx, src)
+	css, err := fetchAndSanitizeCustomStyle(ctx, src, root)
 	if err != nil {
 		return nil, src, err
 	}
-	leaderboardCustomStyleCacheMu.Lock()
-	if len(leaderboardCustomStyleCache) >= leaderboardCustomStyleMaxCache {
-		for k := range leaderboardCustomStyleCache {
-			delete(leaderboardCustomStyleCache, k)
+	customStyleCacheMu.Lock()
+	if len(customStyleCache) >= customStyleMaxCache {
+		for k := range customStyleCache {
+			delete(customStyleCache, k)
 			break
 		}
 	}
-	leaderboardCustomStyleCache[key] = leaderboardCustomStyleCacheEntry{css: append([]byte(nil), css...), expiresAt: now.Add(leaderboardCustomStyleCacheTTL)}
-	leaderboardCustomStyleCacheMu.Unlock()
+	customStyleCache[key] = customStyleCacheEntry{css: append([]byte(nil), css...), expiresAt: now.Add(customStyleCacheTTL)}
+	customStyleCacheMu.Unlock()
 	return css, src, nil
 }
 
-func fetchAndSanitizeLeaderboardCustomStyle(ctx context.Context, src leaderboardCustomStyleSource) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, leaderboardCustomStyleRawURL(src), nil)
+func fetchAndSanitizeCustomStyle(ctx context.Context, src customStyleSource, scopeRoot string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, customStyleRawURL(src), nil)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := leaderboardCustomStyleClient.Do(req)
+	resp, err := customStyleClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, errLeaderboardStyleNotFound
+		return nil, errCustomStyleNotFound
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("style fetch failed")
@@ -173,18 +201,18 @@ func fetchAndSanitizeLeaderboardCustomStyle(ctx context.Context, src leaderboard
 	if ct != "" && !strings.Contains(ct, "text/css") && !strings.Contains(ct, "text/plain") {
 		return nil, fmt.Errorf("style response is not CSS")
 	}
-	body, err := io.ReadAll(io.LimitReader(resp.Body, leaderboardCustomStyleMaxBytes+1))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, customStyleMaxBytes+1))
 	if err != nil {
 		return nil, err
 	}
-	return sanitizeLeaderboardCustomStyle(body)
+	return sanitizeCustomStyle(body, scopeRoot)
 }
 
-var errLeaderboardStyleNotFound = fmt.Errorf("style not found")
+var errCustomStyleNotFound = fmt.Errorf("style not found")
 
-func sanitizeLeaderboardCustomStyle(css []byte) ([]byte, error) {
-	if len(css) > leaderboardCustomStyleMaxBytes {
-		return nil, fmt.Errorf("style exceeds %d byte limit", leaderboardCustomStyleMaxBytes)
+func sanitizeCustomStyle(css []byte, scopeRoot string) ([]byte, error) {
+	if len(css) > customStyleMaxBytes {
+		return nil, fmt.Errorf("style exceeds %d byte limit", customStyleMaxBytes)
 	}
 	s := cssImportRE.ReplaceAllString(string(css), "")
 	s = cssURLRE.ReplaceAllStringFunc(s, sanitizeCSSURLToken)
@@ -202,10 +230,10 @@ func sanitizeLeaderboardCustomStyle(css []byte) ([]byte, error) {
 		}
 		kept = append(kept, line)
 	}
-	return []byte(scopeLeaderboardCustomStyle(strings.Join(kept, "\n"))), nil
+	return []byte(scopeCustomStyle(strings.Join(kept, "\n"), scopeRoot)), nil
 }
 
-func scopeLeaderboardCustomStyle(css string) string {
+func scopeCustomStyle(css, scopeRoot string) string {
 	var out strings.Builder
 	remaining := css
 	for {
@@ -224,7 +252,7 @@ func scopeLeaderboardCustomStyle(css string) string {
 		if selector == "" || strings.Contains(selector, "@") {
 			continue
 		}
-		scoped := scopeLeaderboardSelectors(selector)
+		scoped := scopeCustomStyleSelectors(selector, scopeRoot)
 		if scoped == "" {
 			continue
 		}
@@ -236,7 +264,7 @@ func scopeLeaderboardCustomStyle(css string) string {
 	return out.String()
 }
 
-func scopeLeaderboardSelectors(selector string) string {
+func scopeCustomStyleSelectors(selector, scopeRoot string) string {
 	parts := strings.Split(selector, ",")
 	scoped := make([]string, 0, len(parts))
 	for _, part := range parts {
@@ -244,11 +272,25 @@ func scopeLeaderboardSelectors(selector string) string {
 		if part == "" {
 			continue
 		}
-		if part == "#tab-leaderboard" {
+		if part == scopeRoot || (scopeRoot == customStyleAllowedScopes[customStyleScopeDashboard] && (strings.HasPrefix(part, scopeRoot+" ") || strings.HasPrefix(part, scopeRoot+".") || strings.HasPrefix(part, scopeRoot+":"))) {
 			scoped = append(scoped, part)
 			continue
 		}
-		scoped = append(scoped, "#tab-leaderboard "+part)
+		if scopeRoot == customStyleAllowedScopes[customStyleScopeDashboard] {
+			if part == "body" || part == "html" || part == ":root" {
+				scoped = append(scoped, scopeRoot)
+				continue
+			}
+			for _, rootSelector := range []string{"body", "html", ":root"} {
+				if strings.HasPrefix(part, rootSelector+".") || strings.HasPrefix(part, rootSelector+":") || strings.HasPrefix(part, rootSelector+"#") {
+					part = scopeRoot + strings.TrimPrefix(part, rootSelector)
+					scoped = append(scoped, part)
+					goto nextSelector
+				}
+			}
+		}
+		scoped = append(scoped, scopeRoot+" "+part)
+	nextSelector:
 	}
 	return strings.Join(scoped, ", ")
 }
@@ -276,12 +318,11 @@ func sanitizeCSSURLToken(token string) string {
 	return "url(" + raw + ")"
 }
 
-func (s *Server) handleLeaderboardStyle(w http.ResponseWriter, r *http.Request) {
-	src := r.URL.Query().Get("src")
-	css, _, err := getLeaderboardCustomStyle(r.Context(), src)
+func (s *Server) handleStyle(w http.ResponseWriter, r *http.Request) {
+	css, _, err := getCustomStyle(r.Context(), r.URL.Query().Get("src"), r.URL.Query().Get("scope"))
 	if err != nil {
 		status := http.StatusUnprocessableEntity
-		if err == errLeaderboardStyleNotFound {
+		if err == errCustomStyleNotFound {
 			status = http.StatusNotFound
 		}
 		http.Error(w, err.Error(), status)
@@ -290,4 +331,36 @@ func (s *Server) handleLeaderboardStyle(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Type", "text/css; charset=utf-8")
 	w.Header().Set("Cache-Control", "public, max-age=300")
 	_, _ = w.Write(css)
+}
+
+func (s *Server) handleLeaderboardStyle(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	q.Set("scope", customStyleScopeLeaderboard)
+	r.URL.RawQuery = q.Encode()
+	s.handleStyle(w, r)
+}
+
+// Back-compatible leaderboard names kept for the PR #2834 tests and callers.
+type leaderboardCustomStyleSource = customStyleSource
+type leaderboardCustomStyleCacheEntry = customStyleCacheEntry
+
+const (
+	leaderboardCustomStyleMaxBytes   = customStyleMaxBytes
+	leaderboardCustomStyleDefaultRef = customStyleDefaultRef
+)
+
+func validateLeaderboardCustomStyleSource(src string) (leaderboardCustomStyleSource, error) {
+	return validateCustomStyleSource(src)
+}
+
+func leaderboardCustomStyleCacheKey(src leaderboardCustomStyleSource) string {
+	return customStyleSourceKey(src)
+}
+
+func getLeaderboardCustomStyle(ctx context.Context, rawSrc string) ([]byte, leaderboardCustomStyleSource, error) {
+	return getCustomStyle(ctx, rawSrc, customStyleScopeLeaderboard)
+}
+
+func sanitizeLeaderboardCustomStyle(css []byte) ([]byte, error) {
+	return sanitizeCustomStyle(css, customStyleAllowedScopes[customStyleScopeLeaderboard])
 }

--- a/v2/pkg/dashboard/api_leaderboard_style_test.go
+++ b/v2/pkg/dashboard/api_leaderboard_style_test.go
@@ -9,16 +9,16 @@ import (
 
 func resetLeaderboardStyleTestState(t *testing.T) {
 	t.Helper()
-	origBase := leaderboardCustomStyleRawBaseURL
-	leaderboardCustomStyleCacheMu.Lock()
-	origCache := leaderboardCustomStyleCache
-	leaderboardCustomStyleCache = map[string]leaderboardCustomStyleCacheEntry{}
-	leaderboardCustomStyleCacheMu.Unlock()
+	origBase := customStyleRawBaseURL
+	customStyleCacheMu.Lock()
+	origCache := customStyleCache
+	customStyleCache = map[string]customStyleCacheEntry{}
+	customStyleCacheMu.Unlock()
 	t.Cleanup(func() {
-		leaderboardCustomStyleRawBaseURL = origBase
-		leaderboardCustomStyleCacheMu.Lock()
-		leaderboardCustomStyleCache = origCache
-		leaderboardCustomStyleCacheMu.Unlock()
+		customStyleRawBaseURL = origBase
+		customStyleCacheMu.Lock()
+		customStyleCache = origCache
+		customStyleCacheMu.Unlock()
 	})
 }
 
@@ -92,7 +92,7 @@ body{display:none}
 			t.Fatalf("sanitized CSS missing scoped selector %q:\n%s", scoped, out)
 		}
 	}
-	if _, err := sanitizeLeaderboardCustomStyle([]byte(strings.Repeat("a", leaderboardCustomStyleMaxBytes+1))); err == nil {
+	if _, err := sanitizeLeaderboardCustomStyle([]byte(strings.Repeat("a", customStyleMaxBytes+1))); err == nil {
 		t.Fatal("oversized CSS did not fail")
 	}
 }
@@ -109,7 +109,7 @@ func TestHandleLeaderboardStyleFetchesSanitizesAndCaches(t *testing.T) {
 		_, _ = w.Write([]byte(`.ok{color:red}.bad{background:url(https://evil.example/pixel.png)}`))
 	}))
 	defer raw.Close()
-	leaderboardCustomStyleRawBaseURL = raw.URL
+	customStyleRawBaseURL = raw.URL
 
 	srv := newFullServer(t)
 	req := httptest.NewRequest(http.MethodGet, "/api/leaderboard/style?src=owner/repo/lb/theme.css@main", nil)
@@ -139,7 +139,7 @@ func TestHandleLeaderboardStyle404(t *testing.T) {
 	resetLeaderboardStyleTestState(t)
 	raw := httptest.NewServer(http.NotFoundHandler())
 	defer raw.Close()
-	leaderboardCustomStyleRawBaseURL = raw.URL
+	customStyleRawBaseURL = raw.URL
 
 	srv := newFullServer(t)
 	req := httptest.NewRequest(http.MethodGet, "/api/leaderboard/style?src=owner/repo/theme.css@main", nil)
@@ -157,7 +157,7 @@ func TestContributeLeaderboardCustomStyleMarkup(t *testing.T) {
 		_, _ = w.Write([]byte(`.lb-row{border-color:hotpink}`))
 	}))
 	defer raw.Close()
-	leaderboardCustomStyleRawBaseURL = raw.URL
+	customStyleRawBaseURL = raw.URL
 
 	srv := newFullServer(t)
 	req := httptest.NewRequest(http.MethodGet, "/contribute/leaderboard?style=owner/repo/lb/theme.css@main", nil)
@@ -179,9 +179,75 @@ func TestContributeLeaderboardCustomStyleMarkup(t *testing.T) {
 	rec = httptest.NewRecorder()
 	missingRaw := httptest.NewServer(http.NotFoundHandler())
 	defer missingRaw.Close()
-	leaderboardCustomStyleRawBaseURL = missingRaw.URL
+	customStyleRawBaseURL = missingRaw.URL
 	srv.handleContributeLanding(rec, req)
 	if !strings.Contains(rec.Body.String(), "Custom style could not be loaded — using default") {
 		t.Fatal("missing custom style fallback notice")
+	}
+}
+
+func TestHandleDashboardStyleScopesToDashboardRoot(t *testing.T) {
+	resetLeaderboardStyleTestState(t)
+	raw := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/css")
+		_, _ = w.Write([]byte(`:root{--bg:#111}body{background:#111}.card{color:red}#hive-dashboard-root .ready{color:green}`))
+	}))
+	defer raw.Close()
+	customStyleRawBaseURL = raw.URL
+
+	srv := newFullServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/style?src=owner/repo/dashboard/theme.css@main&scope=dashboard", nil)
+	rec := httptest.NewRecorder()
+	srv.handleStyle(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"#hive-dashboard-root{--bg:#111}", "#hive-dashboard-root{background:#111}", "#hive-dashboard-root .card{color:red}", "#hive-dashboard-root .ready{color:green}"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("dashboard CSS missing scoped selector %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "#tab-leaderboard") {
+		t.Fatalf("dashboard CSS used leaderboard scope:\n%s", body)
+	}
+}
+
+func TestHandleDashboardStyleRejectsInvalidScopeAndSource(t *testing.T) {
+	srv := newFullServer(t)
+	for _, path := range []string{
+		"/api/style?src=https://evil.example/theme.css&scope=dashboard",
+		"/api/style?src=owner/repo/theme.txt&scope=dashboard",
+		"/api/style?src=owner/repo/theme.css&scope=login",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		srv.handleStyle(rec, req)
+		if rec.Code != http.StatusUnprocessableEntity {
+			t.Fatalf("%s status = %d, want 422", path, rec.Code)
+		}
+	}
+}
+
+func TestDashboardCustomStyleMarkupAndPreviewSupport(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		`<div id="hive-dashboard-root" class="hive-dashboard-root">`,
+		`link.id='dashboard-custom-style-link';`,
+		`/api/style?src=`,
+		`&scope=`,
+		`id="dashboard-custom-style-note"`,
+		`Custom style active: `,
+		`clearDashboardCustomStyleParam`,
+		`window.hiveURLWithHash`,
+		`window.hiveURLWithHash('#section-' + section)`,
+		`window.hiveURLWithHash(name ? '#' + name : '')`,
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Fatalf("dashboard HTML missing %q", snippet)
+		}
+	}
+	if !isPublicPath("/api/style") {
+		t.Fatal("/api/style must be public so /snapshot read-only previews can load sanitized CSS")
 	}
 }

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -892,6 +892,9 @@ func isPublicPath(path string) bool {
 		return true
 	case strings.HasPrefix(path, "/api/snapshot"):
 		return true
+	case path == "/api/style":
+		// Sanitized, same-origin CSS for public snapshot/read-only preview links.
+		return true
 	case path == "/contribute" || strings.HasPrefix(path, "/contribute/"):
 		return true
 	case strings.HasPrefix(path, "/api/contribute"):

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -308,6 +308,9 @@
       border-radius: 6px; border: 1px solid transparent; transition: all 0.15s;
     }
     .oc-topbar-center .oc-tb-link:hover { background: var(--bg); color: var(--text); border-color: var(--border); }
+    .dashboard-custom-style-note { display: inline-flex; align-items: center; gap: 6px; max-width: 240px; padding: 3px 8px; border: 1px solid rgba(128,191,255,0.35); border-radius: 999px; background: rgba(128,191,255,0.10); color: var(--text); font-size: 0.68rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .dashboard-custom-style-note.warn { border-color: rgba(210,153,34,0.45); background: rgba(210,153,34,0.12); }
+    .dashboard-custom-style-note button { border: 0; background: transparent; color: inherit; cursor: pointer; font-size: 0.75rem; line-height: 1; padding: 0; }
     .oc-topbar-right { display: flex; align-items: center; gap: 14px; }
     .oc-health-badge { --pill-c: var(--green); font-weight: 600; } /* pill recipe at end of style block */
     .oc-topbar-ts { font-size: 0.75rem; color: var(--muted); }
@@ -2492,6 +2495,77 @@
     }
   });
 })();
+(function(){
+  var STYLE_SCOPE = 'dashboard';
+  var STYLE_ROOT_ID = 'hive-dashboard-root';
+  function currentStyleSrc(){
+    try { return new URL(window.location.href).searchParams.get('style') || ''; } catch(e) { return ''; }
+  }
+  function styleLabel(src){
+    var parts=String(src||'').split('@')[0].split('/');
+    return parts.length>=2?(parts[0]+'/'+parts[1]):'custom';
+  }
+  function styleURLWithHash(hash){
+    try {
+      var u=new URL(window.location.href);
+      return u.pathname+u.search+(hash||'');
+    } catch(e) { return (hash || location.pathname); }
+  }
+  window.hiveURLWithHash = styleURLWithHash;
+  window.clearDashboardCustomStyleParam = function(){
+    try {
+      var u=new URL(window.location.href);
+      u.searchParams.delete('style');
+      history.replaceState(null,'',u.pathname+(u.searchParams.toString()?('?'+u.searchParams.toString()):'')+u.hash);
+    } catch(e) {}
+    window.HIVE_DASHBOARD_CUSTOM_STYLE_SRC='';
+    var link=document.getElementById('dashboard-custom-style-link');
+    if(link)link.remove();
+    var note=document.getElementById('dashboard-custom-style-note');
+    if(note)note.style.display='none';
+    var root=document.getElementById(STYLE_ROOT_ID);
+    if(root)root.classList.remove('custom-style-active');
+  };
+  window.showDashboardCustomStyleNotice = function(ok){
+    var note=document.getElementById('dashboard-custom-style-note');
+    if(!note)return;
+    var src=window.HIVE_DASHBOARD_CUSTOM_STYLE_SRC||currentStyleSrc();
+    note.classList.toggle('warn', !ok);
+    note.title=ok?'Custom style active: '+src+' — remove ?style= to reset':'Custom style could not be loaded — using default dashboard styles';
+    note.textContent=ok?'Custom style: '+styleLabel(src):'Custom style failed';
+    var btn=document.createElement('button');
+    btn.type='button';
+    btn.textContent='×';
+    btn.setAttribute('aria-label', ok?'Remove custom style':'Dismiss');
+    btn.onclick=ok?window.clearDashboardCustomStyleParam:function(){note.style.display='none';};
+    note.appendChild(btn);
+    note.style.display='inline-flex';
+    if(typeof showToast==='function')showToast(ok?'Custom style active: '+styleLabel(src):'Custom style could not be loaded — using default dashboard styles', ok?'info':'error');
+  };
+  var src=currentStyleSrc();
+  if(src){
+    window.HIVE_DASHBOARD_CUSTOM_STYLE_SRC=src;
+    var styleState='pending';
+    function renderStyleState(){
+      var root=document.getElementById(STYLE_ROOT_ID);
+      if(styleState==='loaded'){
+        if(root)root.classList.add('custom-style-active');
+        window.showDashboardCustomStyleNotice(true);
+      }else if(styleState==='failed'){
+        if(root)root.classList.remove('custom-style-active');
+        window.showDashboardCustomStyleNotice(false);
+      }
+    }
+    var link=document.createElement('link');
+    link.id='dashboard-custom-style-link';
+    link.rel='stylesheet';
+    link.href='/api/style?src='+encodeURIComponent(src)+'&scope='+encodeURIComponent(STYLE_SCOPE);
+    link.onload=function(){ styleState='loaded'; renderStyleState(); };
+    link.onerror=function(){ styleState='failed'; renderStyleState(); };
+    document.head.appendChild(link);
+    document.addEventListener('DOMContentLoaded', renderStyleState);
+  }
+})();
 
 </script>
 <div id="gh-auth-banner" class="gh-auth-banner" style="display:none">
@@ -2575,6 +2649,7 @@
     <button class="gh-cancel" onclick="document.getElementById('gh-setup-overlay').style.display='none'">Close</button>
   </div>
 </div>
+<div id="hive-dashboard-root" class="hive-dashboard-root">
 <div id="toast-container"></div>
 
 <!-- Hive Chat FAB + Panel -->
@@ -2733,6 +2808,7 @@
     </div>
     <div class="oc-topbar-center">
       <span class="oc-tb-link" onclick="openConfigDialog('governor')" title="Config — governor, agents, thresholds, and all hive settings" aria-label="Config">⚙️</span>
+      <span id="dashboard-custom-style-note" class="dashboard-custom-style-note" style="display:none" role="status"></span>
       <span class="oc-tb-link" onclick="ocNavigate('debug-section')" title="System Diagnostics — health checks and troubleshooting" aria-label="System Diagnostics"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle"><path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"/></svg></span>
       <!-- Agent Logs hidden (redundant with per-agent output) -->
       <button class="layout-toggle" onclick="toggleLayout()" title="Switch to Dark Mode" aria-label="Switch to Dark Mode">☾</button>
@@ -3289,6 +3365,7 @@
       <li><a href="https://medium.com/p/b9381a7e9773" target="_blank" rel="noopener">&#128221; Blog: ACMM Framework</a></li>
     </ul>
   </aside>
+</div><!-- /#hive-dashboard-root -->
 
   <script>
     // Wrap fetch to inject auth token for mutation requests (PUT/POST/PATCH/DELETE)
@@ -3423,6 +3500,8 @@
     function applyLayout(mode) {
       document.body.classList.toggle('light-mode', mode === 'light');
       document.body.classList.add('has-info-sidebar');
+      const customStyleRoot = document.getElementById('hive-dashboard-root');
+      if (customStyleRoot) { customStyleRoot.classList.toggle('light-mode', mode === 'light'); customStyleRoot.classList.toggle('dark-mode', mode !== 'light'); }
       const lbl = LAYOUT_LABELS[mode] || LAYOUT_LABELS.dark;
       const ttl = LAYOUT_TITLES[mode] || LAYOUT_TITLES.dark;
       document.querySelectorAll('.layout-toggle').forEach(btn => {
@@ -3530,7 +3609,7 @@
 
     function ocNavigate(section, skipScroll) {
       _ocSelectedAgent = null;
-      history.replaceState(null, '', '#section-' + section);
+      history.replaceState(null, '', window.hiveURLWithHash ? window.hiveURLWithHash('#section-' + section) : '#section-' + section);
       ocStopPanePoll();
       const detail = document.getElementById('oc-agent-detail');
       if (detail) { detail.classList.remove('active'); detail.innerHTML = ''; }
@@ -3630,7 +3709,7 @@
 
     function ocSelectAgent(name) {
       _ocSelectedAgent = name;
-      history.replaceState(null, '', name ? '#' + name : location.pathname);
+      history.replaceState(null, '', window.hiveURLWithHash ? window.hiveURLWithHash(name ? '#' + name : '') : (name ? '#' + name : location.pathname));
       document.querySelectorAll('.oc-nav-item').forEach(i => i.classList.remove('active'));
       const active = document.querySelector(`.oc-nav-item[data-agent-nav="${name}"]`);
       if (active) active.classList.add('active');
@@ -13690,7 +13769,7 @@ function burnAreaChart() {
       _configModalOpen = false;
       _configState = { type: null, agent: null, tab: null, data: {}, dirty: {}, promptTemplateDirty: false, promptTemplateValue: '' };
       document.getElementById('config-overlay').classList.add('hidden');
-      if (location.hash.startsWith('#config/')) history.replaceState(null, '', location.pathname);
+      if (location.hash.startsWith('#config/')) history.replaceState(null, '', window.hiveURLWithHash ? window.hiveURLWithHash('') : location.pathname);
     }
 
     function handleConfigHash() {
@@ -14059,7 +14138,7 @@ function burnAreaChart() {
       });
       renderConfigTab(tabId);
       const hashTarget = _configState.type === 'governor' ? 'governor' : _configState.agent;
-      if (hashTarget) history.replaceState(null, '', '#config/' + encodeURIComponent(hashTarget) + '/' + encodeURIComponent(tabId));
+      if (hashTarget) history.replaceState(null, '', window.hiveURLWithHash ? window.hiveURLWithHash('#config/' + encodeURIComponent(hashTarget) + '/' + encodeURIComponent(tabId)) : '#config/' + encodeURIComponent(hashTarget) + '/' + encodeURIComponent(tabId));
     }
 
     async function loadConfigData(type, agentName) {


### PR DESCRIPTION
Extends #2834's `?style=owner/repo/path.css[@ref]` custom-CSS support to the **main spoke dashboard** and the **read-only preview**.

- Shared sanitizer/fetch/cache core (leaderboard endpoint unchanged, tests still green)
- `GET /api/style?src=...&scope=...` — server-side raw.githubusercontent fetch, sanitized (no `@import`/external `url()`), 128 KiB cap, scoped to the dashboard root so themes can't restyle the login overlays; CSP untouched
- Dismissible indicator chip + toast; success only reported from `link.onload` (failure can never masquerade as active)
- Operator requirement: 'i want to offer this css option to the hive spoke's dashboard and the read-only preview as well.'