### PR TITLE
📖 docs(adr): back-fill ADRs 0011-0014 (knowledge, skillreg, celtrigger, hub-spoke)

### DIFF
--- a/v2/docs/adr/0011-knowledge-graph.md
+++ b/v2/docs/adr/0011-knowledge-graph.md
@@ -1,0 +1,41 @@
+# ADR-0011: Durable knowledge graph for agent context
+
+Status: Accepted (retroactive)
+
+## Context
+
+Hive agents need project memory that outlives a single chat session, but prompt
+context is scarce and unsafe to fill with every past note. The knowledge design
+keeps that memory layered by scope and privacy — personal, project, org, and
+community — and merges only relevant facts when preparing an agent kick
+([knowledge design](../design/knowledge-system.md)). The implementation also
+needs to work when no external embedding service is available.
+
+## Decision
+
+Represent reusable lessons as typed facts with confidence, sources, tags,
+relationships, usage counts, and layer metadata
+([knowledge types](../../pkg/knowledge/types.go)). Store local vault pages and
+remote layer clients behind one `KnowledgeAPI`, and prime agents by formatting a
+bounded set of selected facts into the kick prompt rather than letting agents
+query the store directly ([knowledge API](../../pkg/knowledge/api.go)).
+
+Use a deterministic term-frequency embedder as the default semantic signal: text
+is tokenized, feature-hashed into a 256-dimensional vector, and L2-normalized,
+with embeddings cached only for the search/reindex pass
+([TF embedder](../../pkg/knowledge/embedding.go)). Persist fact relationships in
+a bbolt-backed graph store with SPO/POS/OSP indexes so facts can be traversed by
+subject, predicate, or object ([graph store](../../pkg/knowledge/graphstore.go)).
+The retro lane ingests model-generated lessons only after length, secret, and
+deduplication gates, then stores them as ordinary project facts derived from the
+source bead or PR ([retro lessons](../../pkg/knowledge/retro_lesson.go)).
+
+## Consequences
+
+Agents can receive durable, source-backed context without depending on an LLM's
+conversation memory or a hosted embedding API. Layer precedence and explicit
+promotion preserve the privacy boundary described by the design while still
+letting community and org knowledge flow down. The trade-off is a deliberately
+simple retrieval model: hashed term-frequency vectors and tag/graph edges are
+portable and inspectable, but lower quality than model embeddings, and stale or
+incorrect facts still need curation rather than blind injection.

--- a/v2/docs/adr/0012-skill-registry.md
+++ b/v2/docs/adr/0012-skill-registry.md
@@ -1,0 +1,39 @@
+# ADR-0012: Skill registry and BYO-agent contract
+
+Status: Accepted (retroactive)
+
+## Context
+
+`AGENTS.md` can carry repo-local skill snippets, but inline snippets do not give
+Hive a shareable catalog, version metadata, search, or a stable contract for
+third-party agents. Hive also needs custom agents to be declared without binding
+them to internal launcher structures.
+
+## Decision
+
+Introduce `skillreg` as a concurrency-safe registry of named, versioned skill
+files plus a minimal bring-your-own-agent SDK contract
+([skill registry](../../pkg/skillreg/skillreg.go)). A skill is a Markdown body
+with optional YAML front matter for name, version, description, and tags. Missing
+skill directories, unreadable files, and malformed front matter are skipped with
+logs so one bad catalog entry does not prevent Hive from loading.
+
+Resolve requested skills by preferring the curated registry over inline
+`AGENTS.md` snippets, while falling back to repo-local skills the registry does
+not know about. Version resolution supports latest, exact versions, wildcard,
+caret-major, and greater-than-or-equal constraints, and `InjectionText` renders a
+single Markdown block for the kick path.
+
+Define the BYO-agent contract as `AgentSpec`: name, backend, model, operating
+mode, and default skills ([agent spec](../../pkg/skillreg/agentspec.go)). YAML
+agent specs are strict: malformed YAML, missing name/backend/model, or unknown
+modes fail before an agent can launch silently.
+
+## Consequences
+
+Skills become portable and discoverable without removing simple repo-local
+snippets. Custom agents get a small, stable interface that catalogs and launchers
+can share. The trade-off is that registry skills intentionally override inline
+snippets, so catalog governance matters; and the current registry helper is a
+contract and rendering layer, not a full package manager or deep launcher
+integration.

--- a/v2/docs/adr/0013-cel-triggers.md
+++ b/v2/docs/adr/0013-cel-triggers.md
@@ -1,0 +1,36 @@
+# ADR-0013: CEL triggers over normalized forge events
+
+Status: Accepted (retroactive)
+
+## Context
+
+Hive's built-in label and governor triggers cover common flows, but operators
+need repo-specific trigger policy without hard-coding GitHub webhook details or
+forking the governor. The trigger language must be expressive enough for labels,
+branches, authors, draft status, and comments, while failing safely when an
+operator writes a bad rule.
+
+## Decision
+
+Add CEL-based declarative triggers over a forge-neutral `NormalizedEvent`
+([CEL trigger engine](../../pkg/celtrigger/celtrigger.go)). Forge adapters map
+native events onto stable kinds such as `issue.opened`, `pr.labeled`,
+`pr.ready_for_review`, and `comment.created`; CEL expressions see only the
+`event` object with normalized fields such as repo, labels, title, author, body,
+state, branches, assignees, and comment.
+
+Compile every rule before use and require a boolean expression. Unknown fields,
+parse errors, type errors, empty expressions, or non-boolean results reject the
+engine at config load. Runtime evaluation errors are treated as no match. Matched
+rules are returned in descending priority, and `MatchAgents` de-duplicates agent
+names before the governor unions them with existing built-in triggers
+([config wiring](../../pkg/celtrigger/wire.go)).
+
+## Consequences
+
+Operators can add declarative, forge-neutral trigger policy without changing Go
+code, and bad rules fail closed before they can crash a running fleet. The same
+normalized event model keeps the path open for GitLab or other forge adapters.
+The trade-off is that CEL only sees fields Hive normalizes; new trigger needs may
+require extending `NormalizedEvent`, and a malformed rule currently blocks the
+whole configured CEL engine rather than being partially ignored.

--- a/v2/docs/adr/0014-hub-spoke.md
+++ b/v2/docs/adr/0014-hub-spoke.md
@@ -1,0 +1,42 @@
+# ADR-0014: Hub/spoke fleet over heartbeat callbacks
+
+Status: Accepted (retroactive)
+
+## Context
+
+Hive needs a shared fleet view without requiring every operator's cluster to be
+reachable from the public hub. The architecture defines every hive as a spoke
+and the hosted site as the hub, both running the same image with `HIVE_MODE=hub`
+selecting the role ([architecture §8](../architecture.md#8-hub--spoke)). The hub
+must maintain registry, leaderboard, provisioning, and operator controls even
+for firewalled spokes.
+
+## Decision
+
+Use spoke-initiated heartbeats as the control channel. A spoke posts identity,
+repos, ACMM level, agents, governor state, contributors, leaderboard, health,
+version, image, and related status to `/api/heartbeat`; the hub persists a
+sanitized registry entry and marks the spoke online
+([heartbeat payload](../../pkg/hub/heartbeat.go), [hub registry](../../pkg/hub/server.go)).
+The heartbeat response carries callbacks for upgrade, branch switch, GitHub App
+config, banners, visibility, authorized users, project config, gateway config,
+and restart requests, letting the hub act even when it cannot open a connection
+back to the cluster.
+
+Keep hub and spoke roles in one deployable image, and report the spoke's actual
+image reference so the hub can detect pinned or stale deployments. Merge public
+spoke leaderboards centrally while excluding agent identities, and use
+contributor counts plus active leaderboard tasks as evidence that the ClankeR
+contributor relay is carrying work. Contributor relay credentials remain on the
+contributor's machine; the hub sees trust tier, task counts, and current task
+metadata, not the user's credential material.
+
+## Consequences
+
+The fleet works through firewalls and NAT because all routine control flows ride
+spoke-initiated HTTP. Operators get one registry, fleet-stats surface, and
+leaderboard while individual hives retain local runtime state. The trade-off is
+that heartbeat freshness and callback delivery become critical infrastructure:
+missed beats make hives appear offline, callback actions are eventually delivered
+rather than immediate, and the shared hub must carefully sanitize and bound every
+spoke-reported field.

--- a/v2/docs/adr/README.md
+++ b/v2/docs/adr/README.md
@@ -46,3 +46,7 @@ What becomes easier, harder, safer, or riskier because of this decision?
 - [ADR-0008: Redact untrusted kick input with visible markers](0008-ioscan-untrusted-input.md)
 - [ADR-0009: Trajectory review lane](0009-trajectory-review.md)
 - [ADR-0010: Escalation circuit breaker for CI fix loops](0010-escalation-circuit-breaker.md)
+- [ADR-0011: Durable knowledge graph for agent context](0011-knowledge-graph.md)
+- [ADR-0012: Skill registry and BYO-agent contract](0012-skill-registry.md)
+- [ADR-0013: CEL triggers over normalized forge events](0013-cel-triggers.md)
+- [ADR-0014: Hub/spoke fleet over heartbeat callbacks](0014-hub-spoke.md)


### PR DESCRIPTION
Part of #2811 — completes the planned ADR back-fill.

Adds retroactive ADRs for:
- ADR-0011: Durable knowledge graph for agent context
- ADR-0012: Skill registry and BYO-agent contract
- ADR-0013: CEL triggers over normalized forge events
- ADR-0014: Hub/spoke fleet over heartbeat callbacks

Validation: docs-only link check confirmed referenced files exist.