### PR TITLE
📖 feat(docs): MkDocs Material site pipeline publishing v2/docs

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -1,0 +1,63 @@
+name: docs-site
+
+on:
+  push:
+    branches: [v4]
+    paths:
+      - mkdocs.yml
+      - requirements-docs.txt
+      - v2/docs/**
+      - .github/workflows/docs-site.yml
+  pull_request:
+    branches: [v4]
+    paths:
+      - mkdocs.yml
+      - requirements-docs.txt
+      - v2/docs/**
+      - .github/workflows/docs-site.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+      - name: Install docs dependencies
+        run: pip install -r requirements-docs.txt
+      - name: Build docs
+        run: mkdocs build --strict
+      - name: Configure Pages
+        if: github.event_name == 'push'
+        uses: actions/configure-pages@v5
+      - name: Upload Pages artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+  deploy:
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,95 @@
+site_name: Hive
+site_url: https://kubestellar.github.io/hive/
+repo_url: https://github.com/kubestellar/hive
+repo_name: kubestellar/hive
+docs_dir: v2/docs
+site_dir: site
+
+# Keep the source of truth under v2/docs while placing mkdocs.yml at the
+# repository root so GitHub Pages CI can build with the standard mkdocs command.
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - content.code.copy
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+
+nav:
+  - Home: README.md
+  - Getting Started:
+      - Overview: getting-started.md
+      - Agent configuration: agent-configuration.md
+      - Hive CLI: hivectl.md
+      - Hive lite enrollment: lite-enrollment.md
+      - Credly badges: credly-badges.md
+  - Architecture:
+      - Reference architecture: architecture.md
+      - CNCF reference architecture: cncf-reference-architecture.md
+      - ACMM policy matrix: acmm-policy-matrix.md
+      - Configuration layering: config-layering.md
+      - Planning intelligence: planning-intelligence.md
+      - Design:
+          - Knowledge system design: design/knowledge-system.md
+  - Security:
+      - Security threat model: security-threat-model.md
+      - Intent verification: intent-verification.md
+      - Trajectory review: trajectory-review.md
+      - Rootless Podman CI seam: podman-rootless-ci.md
+      - Architecture Decision Records:
+          - ADR index: adr/README.md
+          - "0001: Record architecture decisions": adr/0001-record-architecture-decisions.md
+          - "0002: MITM proxy network enforcement": adr/0002-mitm-proxy-network-enforcement.md
+          - "0003: ACMM autonomy levels": adr/0003-acmm-autonomy-levels.md
+          - "0004: Beads work ledger": adr/0004-beads-work-ledger.md
+          - "0005: Forge abstraction": adr/0005-forge-abstraction.md
+          - "0006: Planning intelligence": adr/0006-planning-intelligence.md
+          - "0007: Token mint": adr/0007-token-mint.md
+          - "0008: IOScan untrusted input": adr/0008-ioscan-untrusted-input.md
+          - "0009: Trajectory review": adr/0009-trajectory-review.md
+          - "0010: Escalation circuit breaker": adr/0010-escalation-circuit-breaker.md
+          - "0011: Knowledge graph": adr/0011-knowledge-graph.md
+          - "0012: Skill registry": adr/0012-skill-registry.md
+          - "0013: CEL triggers": adr/0013-cel-triggers.md
+          - "0014: Hub spoke": adr/0014-hub-spoke.md
+  - Operations:
+      - Agent configuration: agent-configuration.md
+      - Hive CLI: hivectl.md
+      - Manual provisioning: manual-provisioning.md
+      - Configuration layering: config-layering.md
+      - Cross-cluster migration: cross-cluster-migration.md
+      - Rootless Podman CI seam: podman-rootless-ci.md
+      - Retro lane: retro-lane.md
+      - Review swarm: review-swarm.md
+      - Docs site publishing: docs-site.md
+  - Features:
+      - Planning intelligence: planning-intelligence.md
+      - Trajectory review: trajectory-review.md
+      - Retro lane: retro-lane.md
+      - Review swarm: review-swarm.md
+      - Intent verification: intent-verification.md
+      - Sandbox isolation: sandbox-isolation.md
+      - Hive lite enrollment: lite-enrollment.md
+      - ACMM policy matrix: acmm-policy-matrix.md
+      - Credly badges: credly-badges.md
+  - Roadmap & Positioning:
+      - Public roadmap: roadmap.md
+      - Landscape and positioning: landscape.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+mkdocs==1.6.1
+mkdocs-material==9.6.14
+pymdown-extensions==10.15

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -34,7 +34,7 @@ precursor to a published docs site.
 - [Security threat model](security-threat-model.md) — actors, boundaries,
   layered defenses, known gaps, and reporting.
 - [Architecture Decision Records](adr/README.md) — lightweight ADR process and
-  records 0001-0010.
+  records 0001-0014.
 - [Intent verification](intent-verification.md) — tier-based change
   authorization for merge eligibility.
 - [Trajectory review](trajectory-review.md) — drift detection and agent pause
@@ -52,6 +52,8 @@ precursor to a published docs site.
   advisory beads.
 - [Review swarm](review-swarm.md) — structured review perspectives, verdicts,
   and merge-gate integration.
+- [Docs site publishing](docs-site.md) — MkDocs Material build, Pages
+  deployment, and operator setup checklist.
 
 ## Roadmap & Positioning
 

--- a/v2/docs/adr/0005-forge-abstraction.md
+++ b/v2/docs/adr/0005-forge-abstraction.md
@@ -9,7 +9,7 @@ needs agents and schedulers to reason about work without baking GitHub names
 into every interface. The forge package defines this boundary explicitly: it is
 "not hardcoded to GitHub" and exposes neutral repositories, issues, and change
 requests while concrete adapters handle GitHub, GitLab, and Gitea/Forgejo
-details ([forge package](../../pkg/forge/forge.go)).
+details ([forge package](https://github.com/kubestellar/hive/blob/v4/v2/pkg/forge/forge.go)).
 
 ## Decision
 

--- a/v2/docs/adr/0006-planning-intelligence.md
+++ b/v2/docs/adr/0006-planning-intelligence.md
@@ -11,9 +11,9 @@ architect decomposition, a draft plan hidden from `Ready()`, a plan-review gate,
 and bounded stall replanning
 ([planning intelligence](../planning-intelligence.md)). The package code records
 the same metadata conventions and review transitions
-([decompose](../../pkg/planning/decompose.go),
-[plan review](../../pkg/planning/plan_review.go),
-[stall replan](../../pkg/planning/replan.go)).
+([decompose](https://github.com/kubestellar/hive/blob/v4/v2/pkg/planning/decompose.go),
+[plan review](https://github.com/kubestellar/hive/blob/v4/v2/pkg/planning/plan_review.go),
+[stall replan](https://github.com/kubestellar/hive/blob/v4/v2/pkg/planning/replan.go)).
 
 ## Decision
 

--- a/v2/docs/adr/0007-token-mint.md
+++ b/v2/docs/adr/0007-token-mint.md
@@ -16,12 +16,12 @@ without distributing shared long-lived credentials.
 ## Decision
 
 Introduce the mint as an opt-in short-lived credential issuer
-([mint package](../../pkg/mint/mint.go)). It signs scoped JWTs with bounded TTLs,
+([mint package](https://github.com/kubestellar/hive/blob/v4/v2/pkg/mint/mint.go)). It signs scoped JWTs with bounded TTLs,
 verification that fails closed, and a JWKS endpoint for downstream Workload
 Identity Federation providers. Agent integration maps the same trust tiers used
 by agent modes (`advisor`, `newcomer`, `contributor`, `trusted`) to explicit
 scope strings such as `issues:read`, `contents:write`, and `pulls:merge`
-([agent minting](../../pkg/mint/agent.go)).
+([agent minting](https://github.com/kubestellar/hive/blob/v4/v2/pkg/mint/agent.go)).
 
 The mint supplements, rather than replaces, the existing GitHub App token path.
 When disabled, agent minting is a no-op. When enabled, empty agent identities,

--- a/v2/docs/adr/0008-ioscan-untrusted-input.md
+++ b/v2/docs/adr/0008-ioscan-untrusted-input.md
@@ -9,7 +9,7 @@ may be controlled by an attacker. That text can carry prompt-injection phrases,
 hidden Unicode, base64-encoded instructions, destructive commands, or secret
 shapes. The ioscan package provides a pure scanner for input and output text
 with structured findings and block decisions
-([ioscan scanner](../../pkg/ioscan/ioscan.go)).
+([ioscan scanner](https://github.com/kubestellar/hive/blob/v4/v2/pkg/ioscan/ioscan.go)).
 
 ## Decision
 
@@ -17,14 +17,14 @@ Scan untrusted kick-path text before injection and redact blocked content rather
 than silently dropping the item or passing the raw payload through. `EnforceInput`
 returns benign text byte-for-byte, but replaces blocked text with a visible
 marker of the form `[ioscan: content withheld — ...]` that names the fired rules
-without echoing the payload ([enforcement](../../pkg/ioscan/enforce.go)). The
+without echoing the payload ([enforcement](https://github.com/kubestellar/hive/blob/v4/v2/pkg/ioscan/enforce.go)). The
 scheduler applies this to issue text and labels and writes an audit entry for
 blocked findings when an audit sink is attached
-([scheduler enforcement](../../pkg/scheduler/ioscan_enforce.go)).
+([scheduler enforcement](https://github.com/kubestellar/hive/blob/v4/v2/pkg/scheduler/ioscan_enforce.go)).
 
 The v4 base also includes the fail-safe default-on mode: absent `ioscan:`
 configuration scans by default, while an explicit `ioscan.enabled: false`
-opts out ([config](../../pkg/config/config.go)).
+opts out ([config](https://github.com/kubestellar/hive/blob/v4/v2/pkg/config/config.go)).
 
 Operators may additionally enable `ioscan.canaries: true`. Hive then prepends a
 random `HIVE-CANARY-...` marker to each kick with instructions that the agent

--- a/v2/docs/adr/0009-trajectory-review.md
+++ b/v2/docs/adr/0009-trajectory-review.md
@@ -17,8 +17,8 @@ Run a periodic trajectory-review lane from the governor tick. The lane snapshots
 running, non-exempt agents with their assigned intent and recent transcript,
 sends a bounded transcript tail to a second model through the existing
 OpenAI-compatible/LiteLLM endpoint, and asks for a compact JSON verdict
-([reviewer](../../pkg/trajectory/trajectory.go),
-[lane](../../pkg/trajectory/lane.go)). On divergence, the configured response is
+([reviewer](https://github.com/kubestellar/hive/blob/v4/v2/pkg/trajectory/trajectory.go),
+[lane](https://github.com/kubestellar/hive/blob/v4/v2/pkg/trajectory/lane.go)). On divergence, the configured response is
 to pause the agent and alert by default, or to alert only. The reviewer prompt
 instructs the model to judge direction, not single commands, and to answer
 non-divergent when unsure.

--- a/v2/docs/adr/0010-escalation-circuit-breaker.md
+++ b/v2/docs/adr/0010-escalation-circuit-breaker.md
@@ -8,7 +8,7 @@ Hive agents can repair their own failing PRs, but an unbounded retry loop can
 keep re-dispatching blind fixes without surfacing the root CI error. The
 escalation package records the incident that forced this boundary: a console
 test split kept `main` red for days while scanner fix PRs missed the one-line
-failure in shard logs ([escalation package](../../pkg/escalation/escalation.go)).
+failure in shard logs ([escalation package](https://github.com/kubestellar/hive/blob/v4/v2/pkg/escalation/escalation.go)).
 
 ## Decision
 

--- a/v2/docs/adr/0011-knowledge-graph.md
+++ b/v2/docs/adr/0011-knowledge-graph.md
@@ -15,20 +15,20 @@ needs to work when no external embedding service is available.
 
 Represent reusable lessons as typed facts with confidence, sources, tags,
 relationships, usage counts, and layer metadata
-([knowledge types](../../pkg/knowledge/types.go)). Store local vault pages and
+([knowledge types](https://github.com/kubestellar/hive/blob/v4/v2/pkg/knowledge/types.go)). Store local vault pages and
 remote layer clients behind one `KnowledgeAPI`, and prime agents by formatting a
 bounded set of selected facts into the kick prompt rather than letting agents
-query the store directly ([knowledge API](../../pkg/knowledge/api.go)).
+query the store directly ([knowledge API](https://github.com/kubestellar/hive/blob/v4/v2/pkg/knowledge/api.go)).
 
 Use a deterministic term-frequency embedder as the default semantic signal: text
 is tokenized, feature-hashed into a 256-dimensional vector, and L2-normalized,
 with embeddings cached only for the search/reindex pass
-([TF embedder](../../pkg/knowledge/embedding.go)). Persist fact relationships in
+([TF embedder](https://github.com/kubestellar/hive/blob/v4/v2/pkg/knowledge/embedding.go)). Persist fact relationships in
 a bbolt-backed graph store with SPO/POS/OSP indexes so facts can be traversed by
-subject, predicate, or object ([graph store](../../pkg/knowledge/graphstore.go)).
+subject, predicate, or object ([graph store](https://github.com/kubestellar/hive/blob/v4/v2/pkg/knowledge/graphstore.go)).
 The retro lane ingests model-generated lessons only after length, secret, and
 deduplication gates, then stores them as ordinary project facts derived from the
-source bead or PR ([retro lessons](../../pkg/knowledge/retro_lesson.go)).
+source bead or PR ([retro lessons](https://github.com/kubestellar/hive/blob/v4/v2/pkg/knowledge/retro_lesson.go)).
 
 ## Consequences
 

--- a/v2/docs/adr/0012-skill-registry.md
+++ b/v2/docs/adr/0012-skill-registry.md
@@ -13,7 +13,7 @@ them to internal launcher structures.
 
 Introduce `skillreg` as a concurrency-safe registry of named, versioned skill
 files plus a minimal bring-your-own-agent SDK contract
-([skill registry](../../pkg/skillreg/skillreg.go)). A skill is a Markdown body
+([skill registry](https://github.com/kubestellar/hive/blob/v4/v2/pkg/skillreg/skillreg.go)). A skill is a Markdown body
 with optional YAML front matter for name, version, description, and tags. Missing
 skill directories, unreadable files, and malformed front matter are skipped with
 logs so one bad catalog entry does not prevent Hive from loading.
@@ -25,7 +25,7 @@ caret-major, and greater-than-or-equal constraints, and `InjectionText` renders 
 single Markdown block for the kick path.
 
 Define the BYO-agent contract as `AgentSpec`: name, backend, model, operating
-mode, and default skills ([agent spec](../../pkg/skillreg/agentspec.go)). YAML
+mode, and default skills ([agent spec](https://github.com/kubestellar/hive/blob/v4/v2/pkg/skillreg/agentspec.go)). YAML
 agent specs are strict: malformed YAML, missing name/backend/model, or unknown
 modes fail before an agent can launch silently.
 

--- a/v2/docs/adr/0013-cel-triggers.md
+++ b/v2/docs/adr/0013-cel-triggers.md
@@ -13,7 +13,7 @@ operator writes a bad rule.
 ## Decision
 
 Add CEL-based declarative triggers over a forge-neutral `NormalizedEvent`
-([CEL trigger engine](../../pkg/celtrigger/celtrigger.go)). Forge adapters map
+([CEL trigger engine](https://github.com/kubestellar/hive/blob/v4/v2/pkg/celtrigger/celtrigger.go)). Forge adapters map
 native events onto stable kinds such as `issue.opened`, `pr.labeled`,
 `pr.ready_for_review`, and `comment.created`; CEL expressions see only the
 `event` object with normalized fields such as repo, labels, title, author, body,
@@ -24,7 +24,7 @@ parse errors, type errors, empty expressions, or non-boolean results reject the
 engine at config load. Runtime evaluation errors are treated as no match. Matched
 rules are returned in descending priority, and `MatchAgents` de-duplicates agent
 names before the governor unions them with existing built-in triggers
-([config wiring](../../pkg/celtrigger/wire.go)).
+([config wiring](https://github.com/kubestellar/hive/blob/v4/v2/pkg/celtrigger/wire.go)).
 
 ## Consequences
 

--- a/v2/docs/adr/0014-hub-spoke.md
+++ b/v2/docs/adr/0014-hub-spoke.md
@@ -7,7 +7,7 @@ Status: Accepted (retroactive)
 Hive needs a shared fleet view without requiring every operator's cluster to be
 reachable from the public hub. The architecture defines every hive as a spoke
 and the hosted site as the hub, both running the same image with `HIVE_MODE=hub`
-selecting the role ([architecture §8](../architecture.md#8-hub--spoke)). The hub
+selecting the role ([architecture §8](../architecture.md#8-hub-spoke)). The hub
 must maintain registry, leaderboard, provisioning, and operator controls even
 for firewalled spokes.
 
@@ -17,7 +17,7 @@ Use spoke-initiated heartbeats as the control channel. A spoke posts identity,
 repos, ACMM level, agents, governor state, contributors, leaderboard, health,
 version, image, and related status to `/api/heartbeat`; the hub persists a
 sanitized registry entry and marks the spoke online
-([heartbeat payload](../../pkg/hub/heartbeat.go), [hub registry](../../pkg/hub/server.go)).
+([heartbeat payload](https://github.com/kubestellar/hive/blob/v4/v2/pkg/hub/heartbeat.go), [hub registry](https://github.com/kubestellar/hive/blob/v4/v2/pkg/hub/server.go)).
 The heartbeat response carries callbacks for upgrade, branch switch, GitHub App
 config, banners, visibility, authorized users, project config, gateway config,
 and restart requests, letting the hub act even when it cannot open a connection

--- a/v2/docs/agent-configuration.md
+++ b/v2/docs/agent-configuration.md
@@ -233,7 +233,7 @@ At L5, every agent PR gets a `hold` label automatically. The system proposes; it
 
 Resolution order: the agent's explicit `kick_template` wins; otherwise the ACMM pack's template for that agent at the current level; otherwise convention — `/data/agents/<name>/CLAUDE.md`, then `<name>.md` in the policies checkout, then the embedded default. Pack templates carry the level's policy in their names — `scanner-holdgated.md` is scanner-at-L5; the same scanner at L6 gets `scanner-automerge.md`.
 
-Portable agents bundle everything — config plus a `promptTemplate` — in a single `AgentDefinition` YAML you can import from a URL in the dashboard (see [`v2/examples/agents/customized-agent.yaml`](../examples/agents/customized-agent.yaml)).
+Portable agents bundle everything — config plus a `promptTemplate` — in a single `AgentDefinition` YAML you can import from a URL in the dashboard (see [`v2/examples/agents/customized-agent.yaml`](https://github.com/kubestellar/hive/blob/v4/v2/examples/agents/customized-agent.yaml)).
 
 ## When to add what
 

--- a/v2/docs/docs-site.md
+++ b/v2/docs/docs-site.md
@@ -1,0 +1,19 @@
+# Docs site publishing
+
+Hive publishes this documentation from the repository source of truth under
+`v2/docs/` using MkDocs Material. The root `mkdocs.yml` keeps the standard
+`mkdocs build` entry point at the repository root while pointing `docs_dir` at
+`v2/docs/` so the versioned docs layout does not move.
+
+On pull requests that touch docs, CI runs a strict MkDocs build. On pushes to
+`v4`, the workflow builds the same site and deploys it with GitHub Pages actions
+to <https://kubestellar.github.io/hive/>.
+
+## Operator checklist
+
+1. In repository settings, enable GitHub Pages with **GitHub Actions** as the
+   source.
+2. Confirm the first successful `docs-site` deployment publishes
+   <https://kubestellar.github.io/hive/>.
+3. Optional custom domain: configure `docs.hive.kubestellar.io` in Pages and add
+   the required DNS `CNAME` record pointing at `kubestellar.github.io`.

--- a/v2/docs/getting-started.md
+++ b/v2/docs/getting-started.md
@@ -1,0 +1,16 @@
+# Getting started
+
+Start with the repository quick start and deployment guide in the root
+[`README.md`](https://github.com/kubestellar/hive#quick-start-docker-compose).
+That file stays the source of truth for commands that bootstrap a local Hive or
+Kubernetes deployment.
+
+Common next steps:
+
+- [Agent configuration](agent-configuration.md) for lanes, models, policy modes,
+  and ACMM packs.
+- [Hive CLI](hivectl.md) for inspecting agents, beads, events, config,
+  knowledge, and lite enrollment.
+- [Hive lite enrollment](lite-enrollment.md) for five-minute advisory enrollment
+  without sharing secrets.
+- [Credly badges](credly-badges.md) for public badge and credential surfaces.

--- a/v2/docs/landscape.md
+++ b/v2/docs/landscape.md
@@ -99,8 +99,8 @@ multi-agent fleet operation.
 
 ## Hive claims checked against this repo
 
-- Live fleet operations plane: [architecture](architecture.md#3-the-governor-loop--from-queue-depth-to-a-kick), [dashboard and observability](architecture.md#10-dashboard--observability).
-- Multi-runtime model: [architecture](architecture.md#9-model-backends--cost), [agent configuration](agent-configuration.md).
-- ACMM autonomy: [architecture](architecture.md#6-acmm--controlling-agent-autonomy), [ACMM matrix](acmm-policy-matrix.md).
-- Hub/spoke and contributor compute: [architecture](architecture.md#8-hub--spoke), [manual provisioning](manual-provisioning.md).
+- Live fleet operations plane: [architecture](architecture.md#3-the-governor-loop-from-queue-depth-to-a-kick), [dashboard and observability](architecture.md#10-dashboard-observability).
+- Multi-runtime model: [architecture](architecture.md#9-model-backends-cost), [agent configuration](agent-configuration.md).
+- ACMM autonomy: [architecture](architecture.md#6-acmm-controlling-agent-autonomy), [ACMM matrix](acmm-policy-matrix.md).
+- Hub/spoke and contributor compute: [architecture](architecture.md#8-hub-spoke), [manual provisioning](manual-provisioning.md).
 - MITM enforcement: [architecture](architecture.md#5-layered-guardrails-defense-in-depth), [ADR-0002](adr/0002-mitm-proxy-network-enforcement.md).

--- a/v2/docs/roadmap.md
+++ b/v2/docs/roadmap.md
@@ -17,7 +17,7 @@ order, not priority rank.
 | Prompt-injection defense-in-depth | Canary-token checks, output redaction, and fail-closed scanning build on the existing deterministic `ioscan` kick-path redaction. | [#2805](https://github.com/kubestellar/hive/issues/2805), [security threat model](security-threat-model.md), [ADR-0008](adr/0008-ioscan-untrusted-input.md) |
 | Intent verification | Tier-based change authorization is in the merge-gate path; trajectory-integrated intent-alignment review remains the next slice. | [#2803](https://github.com/kubestellar/hive/issues/2803), [intent verification](intent-verification.md) |
 | Review fan-out | Structured review reports and deterministic aggregation are in place; scheduler fan-out to parallel review perspectives is the deferred wiring. | [#2807](https://github.com/kubestellar/hive/issues/2807), [review swarm](review-swarm.md) |
-| Credential-free sandbox kick path | Move agent execution toward no live token and no direct network in the sandbox, with trusted host-side post-steps retaining the MITM proxy as an outer layer. | [#2804](https://github.com/kubestellar/hive/issues/2804), [security threat model](security-threat-model.md#known-gaps-and-roadmap) |
+| Credential-free sandbox kick path | Move agent execution toward no live token and no direct network in the sandbox, with trusted host-side post-steps retaining the MITM proxy as an outer layer. | [#2804](https://github.com/kubestellar/hive/issues/2804), [security threat model](security-threat-model.md#residual-risks-and-known-gaps) |
 | Hub-hosted lite execution | Extend the current zero-secret `hivectl enroll OWNER/REPO` advisory enrollment into hub-hosted execution for low-friction adoption. | [#2808](https://github.com/kubestellar/hive/issues/2808), [lite enrollment](lite-enrollment.md) |
 | Retrospective learning lane | Build from deterministic post-completion advisory beads toward LLM-assisted retro summaries and knowledge extraction. | [#2809](https://github.com/kubestellar/hive/issues/2809), [retro lane](retro-lane.md) |
 
@@ -25,9 +25,9 @@ order, not priority rank.
 
 | Work | Outcome | Tracking |
 | --- | --- | --- |
-| Model-based injection classifier | Add a probabilistic classifier beside deterministic `ioscan`, with fail-closed policy choices for high-risk inputs. | [#2805](https://github.com/kubestellar/hive/issues/2805), [security threat model](security-threat-model.md#known-gaps-and-roadmap) |
+| Model-based injection classifier | Add a probabilistic classifier beside deterministic `ioscan`, with fail-closed policy choices for high-risk inputs. | [#2805](https://github.com/kubestellar/hive/issues/2805), [security threat model](security-threat-model.md#residual-risks-and-known-gaps) |
 | ADR back-fill for remaining subsystems | Capture decisions for the knowledge system, skill registry, CEL/channel triggers, and hub/spoke mechanics so architecture docs stay auditable. | [#2811](https://github.com/kubestellar/hive/issues/2811), [ADR index](adr/README.md), [knowledge design](design/knowledge-system.md), [agent configuration](agent-configuration.md) |
-| Docs site publication | Turn `v2/docs/` into a published, navigable documentation site. This PR creates the index; the MkDocs/site pipeline remains deferred. | [#2811](https://github.com/kubestellar/hive/issues/2811), [docs index](README.md) |
+| Docs site publication | Publish `v2/docs/` as a navigable MkDocs Material site from repository source on merges to `v4`. | [#2811](https://github.com/kubestellar/hive/issues/2811), [docs index](README.md), [docs site publishing](docs-site.md) |
 | GitLab through `pkg/forge` | Move more GitHub-specific operations behind the forge abstraction and add GitLab support incrementally rather than forking the scheduler. | [ADR-0005](adr/0005-forge-abstraction.md), [#2812](https://github.com/kubestellar/hive/issues/2812) |
 
 ## Later

--- a/v2/docs/sandbox-isolation.md
+++ b/v2/docs/sandbox-isolation.md
@@ -1,0 +1,19 @@
+# Sandbox isolation
+
+Hive uses layered isolation so agent autonomy is earned and bounded even when
+multiple backends run in the same installation.
+
+Current controls include:
+
+- backend-specific tool-deny settings by policy mode;
+- scoped GitHub credentials and token minting;
+- per-agent UID attribution where supported;
+- MITM GitHub proxy rules that enforce write permissions at the network
+  boundary; and
+- trajectory review for post-run drift or escape signals.
+
+See the [security threat model](security-threat-model.md),
+[reference architecture](architecture.md#5-layered-guardrails-defense-in-depth),
+and [ADR-0002](adr/0002-mitm-proxy-network-enforcement.md) for the detailed
+runtime model. The roadmap tracks future work toward credential-free,
+no-network sandbox kicks.

--- a/v2/docs/security-threat-model.md
+++ b/v2/docs/security-threat-model.md
@@ -109,7 +109,7 @@ the threats they reduce.
 ## Reporting vulnerabilities
 
 Do not report suspected vulnerabilities in public issues, pull requests, or
-discussions. Follow the repository [Security Policy](../../SECURITY.md): use
+discussions. Follow the repository [Security Policy](https://github.com/kubestellar/hive/blob/v4/SECURITY.md): use
 GitHub private vulnerability reporting from the repository **Security** tab, or
 contact a maintainer directly if private reporting is unavailable. Include the
 affected component, branch/commit, impact, reproduction steps, and any relevant

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2685,6 +2685,7 @@
       <a class="oc-nav-item" data-section="nous-section" onclick="ocNavigate('nous-section')"><span class="oc-nav-emoji">🧪</span><span class="oc-nav-text">Strategy Lab</span></a>
       <a class="oc-nav-item" data-section="faq-section" onclick="ocNavigate('faq-section')" title="Answers to common first-time questions: the Advisory Digest, ACMM levels, how to advance, and managing cost"><span class="oc-nav-emoji">❓</span><span class="oc-nav-text">FAQ</span></a>
       <a class="oc-nav-item" id="welcome-nav-item" style="display:none" onclick="openWelcomeDialog()" title="Open the Getting Started checklist — one-time setup steps for a new hive"><span class="oc-nav-emoji">🚀</span><span class="oc-nav-text">Getting Started</span></a>
+      <a class="oc-nav-item" href="https://kubestellar.github.io/hive/" target="_blank" rel="noopener noreferrer"><span class="oc-nav-emoji">📖</span><span class="oc-nav-text">Docs</span></a>
       <a class="oc-nav-item" href="/api/docs" target="_blank"><span class="oc-nav-emoji">📘</span><span class="oc-nav-text">API Spec (Redoc)</span></a>
       <a class="oc-nav-item" href="https://github.com/kubestellar/hive/issues" target="_blank" rel="noopener noreferrer"><span class="oc-nav-emoji">🐛</span><span class="oc-nav-text">Report an Issue</span></a>
     </div>

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -593,6 +593,7 @@
       <a href="/">Hives</a>
       <a href="#how-it-works">How it works</a>
       <a href="/learn">Learn</a>
+      <a href="https://kubestellar.github.io/hive/" target="_blank" rel="noopener noreferrer">Docs</a>
       <a href="/reading">Reading</a>
       <a href="/get-started">Get Started</a>
       <a href="/dashboard" id="nav-dashboard" style="display:none">My Hives</a>


### PR DESCRIPTION
Part of #2811 — completes the publishing model.\n\n## Summary\n- Adds a root MkDocs Material config with v2/docs as the docs source of truth and Mermaid support.\n- Adds a docs-site GitHub Actions workflow: strict build on docs PRs, Pages artifact deploy on v4 merges.\n- Adds docs-site, getting-started, and sandbox-isolation pages; fixes strict-build links; adds Docs links in hub and dashboard nav.\n\n## Operator checklist\n- Enable GitHub Pages with GitHub Actions as the source.\n- Confirm the initial Pages URL: https://kubestellar.github.io/hive/\n- Optional custom domain: configure docs.hive.kubestellar.io in Pages and add DNS CNAME to kubestellar.github.io.\n\n## Validation\n- mkdocs build --strict\n- cd v2 && go build ./... && go test ./pkg/hub/... ./pkg/dashboard/... -count=1 && go vet ./pkg/hub/... ./pkg/dashboard/...