### PR TITLE
🐛 fix(contribute): entrypoint.d hooks can override backend functions (source order)

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -3,10 +3,10 @@ name: v2 CI
 on:
   push:
     branches: [v2]
-    paths: ['v2/**', 'bin/contributor-relay*']
+    paths: ['v2/**', 'bin/contributor-agent*', 'bin/contributor-relay*']
   pull_request:
     branches: [v2]
-    paths: ['v2/**', 'bin/contributor-relay*']
+    paths: ['v2/**', 'bin/contributor-agent*', 'bin/contributor-relay*']
 
 permissions:
   contents: read
@@ -51,6 +51,7 @@ jobs:
       - name: Contributor Relay Syntax + Tests
         working-directory: .
         run: |
+          bash bin/contributor-agent.test.sh
           cp bin/contributor-relay.sh "${RUNNER_TEMP}/contributor-relay.js"
           node --check "${RUNNER_TEMP}/contributor-relay.js"
           node bin/contributor-relay.test.js

--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -49,14 +49,28 @@ export CONTRIBUTOR_MODE
 # Username is extracted from contributor.env (set during registration)
 export HIVE_CONTRIBUTOR_USERNAME="${CONTRIBUTOR_USERNAME:-unknown}"
 
+# Source backends.conf before the downstream hook seam so hooks see the default
+# backend helpers and can deliberately override them before backend detection.
+BACKENDS_CONF="${SCRIPT_DIR}/../config/backends.conf"
+if [[ -f "$BACKENDS_CONF" ]]; then
+  # shellcheck source=../config/backends.conf disable=SC1091
+  source "$BACKENDS_CONF"
+elif [[ -f /usr/local/etc/hive/backends.conf ]]; then
+  # shellcheck source=/usr/local/etc/hive/backends.conf disable=SC1091
+  source /usr/local/etc/hive/backends.conf
+fi
+
 # Extension seam for downstream images (kubestellar/hive#2393 item 4). A derived
 # image (e.g. projectbluefin/donate-clanker) can drop *.sh into
 # /etc/hive/entrypoint.d/ and/or set HIVE_PRE_AGENT_HOOK to run setup here —
-# after the full contributor env is exported, before backend detection and the
-# tmux launch — WITHOUT forking this entrypoint and re-implementing the tmux
-# wait/attach logic. Sourced (not exec'd) so hooks can export env the agent sees.
-if [[ -d /etc/hive/entrypoint.d ]]; then
-  for _hook in /etc/hive/entrypoint.d/*.sh; do
+# after the full contributor env and default backend helpers are available,
+# before backend detection and the tmux launch — WITHOUT forking this entrypoint
+# and re-implementing the tmux wait/attach logic. Sourced (not exec'd) so hooks
+# can export env the agent sees and can override backend_binary(),
+# backend_perm_flag(), or other shell helpers without being clobbered later.
+ENTRYPOINT_HOOK_DIR="${HIVE_ENTRYPOINT_HOOK_DIR:-/etc/hive/entrypoint.d}"
+if [[ -d "$ENTRYPOINT_HOOK_DIR" ]]; then
+  for _hook in "$ENTRYPOINT_HOOK_DIR"/*.sh; do
     [[ -r "$_hook" ]] || continue
     echo "Running entrypoint hook: $_hook"
     # shellcheck source=/dev/null
@@ -66,14 +80,6 @@ fi
 if [[ -n "${HIVE_PRE_AGENT_HOOK:-}" ]]; then
   echo "Running HIVE_PRE_AGENT_HOOK"
   eval "$HIVE_PRE_AGENT_HOOK"
-fi
-
-# Source backends.conf for binary detection
-BACKENDS_CONF="${SCRIPT_DIR}/../config/backends.conf"
-if [[ -f "$BACKENDS_CONF" ]]; then
-  source "$BACKENDS_CONF"
-elif [[ -f /usr/local/etc/hive/backends.conf ]]; then
-  source /usr/local/etc/hive/backends.conf
 fi
 
 # LiteLLM backend: Claude Code pointed at the contributor's own LiteLLM proxy.
@@ -90,6 +96,12 @@ if [[ "$AGENT_BACKEND" == "litellm" ]]; then
   if [[ -n "${HIVE_LITELLM_API_KEY:-}" ]]; then
     export ANTHROPIC_API_KEY="$HIVE_LITELLM_API_KEY"
   fi
+fi
+
+if [[ "${HIVE_CONTRIBUTOR_AGENT_TEST_RESOLVE_BACKEND:-}" == "1" ]]; then
+  echo "backend_binary=$(backend_binary "$AGENT_BACKEND")"
+  echo "backend_perm_flag=$(backend_perm_flag "$AGENT_BACKEND")"
+  exit 0
 fi
 
 # Detect CLI authentication

--- a/bin/contributor-agent.test.sh
+++ b/bin/contributor-agent.test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Regression coverage for kubestellar/hive#2833.
+#
+# Run: bash bin/contributor-agent.test.sh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK_DIR="${ROOT_DIR}/.contributor-agent-test-work-$$"
+HOOK_DIR="${WORK_DIR}/entrypoint.d"
+HOME_DIR="${WORK_DIR}/home"
+
+cleanup() {
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$HOOK_DIR" "$HOME_DIR"
+
+cat >"${HOOK_DIR}/10-backend-override.sh" <<'HOOK'
+backend_binary() {
+  case "$1" in
+    goose) echo "goose-from-entrypoint-hook" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+backend_perm_flag() {
+  case "$1" in
+    goose) echo "--from-entrypoint-hook" ;;
+    *) echo "" ;;
+  esac
+}
+HOOK
+
+run_resolve() {
+  env -i \
+    PATH="${PATH}" \
+    HOME="$HOME_DIR" \
+    HIVE_REGISTRATION_TOKEN="test-token" \
+    HIVE_ENTRYPOINT_HOOK_DIR="$HOOK_DIR" \
+    HIVE_CONTRIBUTOR_AGENT_TEST_RESOLVE_BACKEND=1 \
+    AGENT_BACKEND=goose \
+    bash "${ROOT_DIR}/bin/contributor-agent.sh"
+}
+
+output="$(run_resolve)"
+
+case "$output" in
+  *"backend_binary=goose-from-entrypoint-hook"* ) ;;
+  *)
+    echo "expected entrypoint.d backend_binary override to survive; got:" >&2
+    echo "$output" >&2
+    exit 1
+    ;;
+esac
+
+case "$output" in
+  *"backend_perm_flag=--from-entrypoint-hook"* ) ;;
+  *)
+    echo "expected entrypoint.d backend_perm_flag override to survive; got:" >&2
+    echo "$output" >&2
+    exit 1
+    ;;
+esac
+
+hook_output="$(
+  env -i \
+    PATH="${PATH}" \
+    HOME="$HOME_DIR" \
+    HIVE_REGISTRATION_TOKEN="test-token" \
+    HIVE_ENTRYPOINT_HOOK_DIR="${WORK_DIR}/empty-entrypoint.d" \
+    HIVE_PRE_AGENT_HOOK='backend_binary(){ echo "goose-from-pre-agent-hook"; }; backend_perm_flag(){ echo "--from-pre-agent-hook"; }' \
+    HIVE_CONTRIBUTOR_AGENT_TEST_RESOLVE_BACKEND=1 \
+    AGENT_BACKEND=goose \
+    bash "${ROOT_DIR}/bin/contributor-agent.sh"
+)"
+
+case "$hook_output" in
+  *"backend_binary=goose-from-pre-agent-hook"* ) ;;
+  *)
+    echo "expected HIVE_PRE_AGENT_HOOK backend_binary override to survive; got:" >&2
+    echo "$hook_output" >&2
+    exit 1
+    ;;
+esac
+
+case "$hook_output" in
+  *"backend_perm_flag=--from-pre-agent-hook"* ) ;;
+  *)
+    echo "expected HIVE_PRE_AGENT_HOOK backend_perm_flag override to survive; got:" >&2
+    echo "$hook_output" >&2
+    exit 1
+    ;;
+esac
+
+echo "contributor-agent hook override tests passed"


### PR DESCRIPTION
Fixes #2833

## Summary
- source backends.conf before contributor entrypoint hooks so hook-defined backend helpers survive
- document that hooks can override backend_binary/backend_perm_flag before detection
- add contributor-agent shell regression coverage and include it in v2 CI paths

## Tests
- bash -n bin/contributor-agent.sh bin/contributor-agent.test.sh
- bash bin/contributor-agent.test.sh
- node --check via .contributor-relay-check.js copy
- node bin/contributor-relay.test.js
