### PR TITLE
📖 feat(hub): link Hive docs from dashboard header

### DIFF
--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -593,6 +593,7 @@
       <a href="/">Hives</a>
       <a href="#how-it-works">How it works</a>
       <a href="/learn">Learn</a>
+      <a href="https://docs.kubestellar.io/docs/hive/overview/introduction" target="_blank" rel="noopener noreferrer">Docs</a>
       <a href="/reading">Reading</a>
       <a href="/get-started">Get Started</a>
       <a href="/dashboard" id="nav-dashboard" style="display:none">My Hives</a>


### PR DESCRIPTION
## Summary\n- Adds a Docs link to the Hive hub header.\n- Points to the Hive section expected from kubestellar/docs#6497: https://docs.kubestellar.io/docs/hive/overview/introduction\n\nThis replaces the earlier separate MkDocs pipeline approach; Hive docs now ride the existing KubeStellar docs site.\n\nReferences #2811 and #2812.\n\n## Validation\n- cd v2 && go test ./pkg/hub/... -count=1 && go vet ./pkg/hub/...