### PR TITLE
✨ feat(github): auto-merge sweep consumes the merger queue label

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -3701,6 +3701,7 @@ func main() {
 	lastEvalInterval := cfg.Governor.EvalIntervalS
 	ticker := time.NewTicker(time.Duration(cfg.Governor.EvalIntervalS) * time.Second)
 	defer ticker.Stop()
+	var lastAutoMergeSweep time.Time
 
 	var agentTicker *time.Ticker
 	if cfg.Dashboard.AgentPollIntervalS > 0 {
@@ -3726,6 +3727,7 @@ func main() {
 	gov.ClearLastKicks()
 	logger.Info("cleared last kicks for startup — all eligible agents will be kicked on first eval")
 	runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, &userGHClient, nil, logger)
+	runAutoMergeSweepIfDue(ctx, ghClient, dashSrv, &lastAutoMergeSweep, logger)
 	persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
 
 	agentTickCh := func() <-chan time.Time {
@@ -3766,6 +3768,7 @@ func main() {
 				}
 			}
 			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, &userGHClient, restarted, logger)
+			runAutoMergeSweepIfDue(ctx, ghClient, dashSrv, &lastAutoMergeSweep, logger)
 			// Trajectory review runs after the eval cycle (so kicks/intents are
 			// current) on its own cadence, gated by Due().
 			if trajLane != nil && trajLane.Due(time.Now()) {
@@ -4864,6 +4867,39 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 				atomicWrite("/data/trend-history.json", trendData)
 			}
 		}
+	}
+}
+
+const autoMergeSweepInterval = time.Minute
+
+func runAutoMergeSweepIfDue(ctx context.Context, ghClient *github.Client, dashSrv *dashboard.Server, lastRun *time.Time, logger *slog.Logger) {
+	if ghClient == nil {
+		return
+	}
+	now := time.Now()
+	if lastRun != nil && !lastRun.IsZero() && now.Sub(*lastRun) < autoMergeSweepInterval {
+		return
+	}
+	if lastRun != nil {
+		*lastRun = now
+	}
+	result, err := ghClient.SweepQueuedAutoMerges(ctx, github.AutoMergeSweepOptions{
+		MaxMerges: github.DefaultAutoMergeSweepMaxMerges,
+		Audit: func(event github.AutoMergeSweepEvent) {
+			if dashSrv == nil {
+				return
+			}
+			detail := fmt.Sprintf("repo=%s, pr=%d, author=%s, queued_by=%s, label=%s, head_sha=%s, merge_sha=%s",
+				event.Repo, event.Number, event.Author, event.QueuedBy, event.Label, event.HeadSHA, event.MergeSHA)
+			dashSrv.AuditLog("system", "automerge-sweep-merged", detail, "")
+		},
+	})
+	if err != nil {
+		logger.Warn("automerge sweep failed", "error", err)
+		return
+	}
+	if len(result.Merged) > 0 || result.Seen > 0 {
+		logger.Info("automerge sweep complete", "seen", result.Seen, "merged", len(result.Merged), "skipped", result.Skipped)
 	}
 }
 

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -2092,8 +2092,9 @@ const (
 	// rejected as unauthorized despite the grant being present and correct.
 	RoleReadWrite = "read-write"
 	// RoleMerger can do everything read-write can, plus approve/queue other
-	// people's PRs for the existing auto-merge-on-green sweep. The spoke
-	// enforces the "never your own PR" rule server-side.
+	// people's PRs for Hive's auto-merge-on-green sweep. Both the dashboard
+	// queue endpoint and the sweep enforce the "never your own PR" rule
+	// server-side.
 	RoleMerger = "merger"
 )
 

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1918,7 +1918,7 @@ func (s *Server) handleQueuePRAutoMerge(w http.ResponseWriter, r *http.Request) 
 		jsonError(w, "merger or owner access required", http.StatusForbidden)
 		return
 	}
-	if !config.RoleAtLeast(role, config.RoleOwner) && user == "" {
+	if user == "" {
 		jsonError(w, "authenticated GitHub user required", http.StatusForbidden)
 		return
 	}
@@ -1947,8 +1947,8 @@ func (s *Server) handleQueuePRAutoMerge(w http.ResponseWriter, r *http.Request) 
 		jsonError(w, err.Error(), http.StatusBadGateway)
 		return
 	}
-	if !config.RoleAtLeast(role, config.RoleOwner) && strings.EqualFold(author, user) {
-		jsonError(w, "mergers cannot queue their own pull requests", http.StatusForbidden)
+	if strings.EqualFold(author, user) {
+		jsonError(w, "users cannot queue their own pull requests", http.StatusForbidden)
 		return
 	}
 	if err := s.deps.GHClient.QueuePRAutoMerge(r.Context(), repo, number, user); err != nil {

--- a/v2/pkg/dashboard/pr_automerge_test.go
+++ b/v2/pkg/dashboard/pr_automerge_test.go
@@ -25,7 +25,9 @@ func TestQueuePRAutoMergeRoleAndSelfGate(t *testing.T) {
 		{"merger cannot queue own pr", config.RoleMerger, "alice", "ALICE", http.StatusForbidden},
 		{"read write forbidden", config.RoleReadWrite, "alice", "bob", http.StatusForbidden},
 		{"read forbidden", config.RoleRead, "alice", "bob", http.StatusForbidden},
-		{"owner can queue own pr", config.RoleOwner, "alice", "alice", http.StatusOK},
+		{"owner queues other pr", config.RoleOwner, "alice", "bob", http.StatusOK},
+		{"owner cannot queue own pr", config.RoleOwner, "alice", "ALICE", http.StatusForbidden},
+		{"owner needs authenticated user", config.RoleOwner, "", "bob", http.StatusForbidden},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/v2/pkg/github/automerge_queue_test.go
+++ b/v2/pkg/github/automerge_queue_test.go
@@ -93,6 +93,23 @@ func TestQueuePRAutoMergeUsesConfiguredLabel(t *testing.T) {
 	}
 }
 
+func TestQueuePRAutoMergeRequiresQueuedBy(t *testing.T) {
+	called := false
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		t.Fatalf("unexpected request for missing queuedBy: %s %s", r.Method, r.URL.Path)
+	}))
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	if err := c.QueuePRAutoMerge(context.Background(), "acme/widget", 7, " "); err == nil {
+		t.Fatal("QueuePRAutoMerge returned nil error for blank queuedBy")
+	}
+	if called {
+		t.Fatal("GitHub API should not be called without queuedBy")
+	}
+}
+
 func TestGetPRAuthor(t *testing.T) {
 	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || r.URL.Path != "/repos/acme/widget/pulls/7" {

--- a/v2/pkg/github/automerge_sweep.go
+++ b/v2/pkg/github/automerge_sweep.go
@@ -1,0 +1,273 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+const DefaultAutoMergeSweepMaxMerges = 3
+
+var hiveQueueReviewRE = regexp.MustCompile(`(?i)^Approved by @([A-Za-z0-9-]+) for Hive auto-merge on green CI\.`)
+
+type AutoMergeSweepOptions struct {
+	MaxMerges int
+	Audit     func(AutoMergeSweepEvent)
+}
+
+type AutoMergeSweepEvent struct {
+	Repo     string
+	Number   int
+	Author   string
+	QueuedBy string
+	HeadSHA  string
+	MergeSHA string
+	Label    string
+}
+
+type AutoMergeSweepResult struct {
+	Merged  []AutoMergeSweepEvent
+	Seen    int
+	Skipped int
+}
+
+// SweepQueuedAutoMerges consumes the configured Hive merger-queue label. It
+// only squashes open, labelled, non-draft PRs in managed repos after GitHub
+// reports them mergeable, commit statuses/check-runs are green, and the latest
+// Hive queue approval body proves the queuer is not the PR author.
+func (c *Client) SweepQueuedAutoMerges(ctx context.Context, opts AutoMergeSweepOptions) (*AutoMergeSweepResult, error) {
+	if c == nil {
+		return nil, ErrNoGitHubClient
+	}
+	maxMerges := opts.MaxMerges
+	if maxMerges <= 0 {
+		maxMerges = DefaultAutoMergeSweepMaxMerges
+	}
+	label := c.AutoMergeLabel()
+	result := &AutoMergeSweepResult{}
+
+	for _, repo := range c.getRepos() {
+		if len(result.Merged) >= maxMerges {
+			break
+		}
+		owner, repoName := c.splitRepo(repo)
+		issues, err := c.listQueuedPullRequestIssues(ctx, owner, repoName, label)
+		if err != nil {
+			return result, err
+		}
+		for _, issue := range issues {
+			if len(result.Merged) >= maxMerges {
+				break
+			}
+			if issue == nil || !issue.IsPullRequest() {
+				continue
+			}
+			result.Seen++
+			event, reason, err := c.trySweepQueuedPR(ctx, repo, owner, repoName, issue.GetNumber(), label)
+			if err != nil {
+				c.warn("automerge sweep skipped PR", "repo", repo, "pr", issue.GetNumber(), "reason", reason, "error", err)
+				result.Skipped++
+				continue
+			}
+			if reason != "" {
+				c.info("automerge sweep skipped PR", "repo", repo, "pr", issue.GetNumber(), "reason", reason)
+				result.Skipped++
+				continue
+			}
+			result.Merged = append(result.Merged, event)
+			if opts.Audit != nil {
+				opts.Audit(event)
+			}
+		}
+	}
+	return result, nil
+}
+
+func (c *Client) listQueuedPullRequestIssues(ctx context.Context, owner, repo, label string) ([]*gh.Issue, error) {
+	opts := &gh.IssueListByRepoOptions{
+		State:       "open",
+		Labels:      []string{label},
+		ListOptions: gh.ListOptions{PerPage: 100},
+	}
+	var all []*gh.Issue
+	for {
+		issues, resp, err := c.client.Issues.ListByRepo(ctx, owner, repo, opts)
+		if err != nil {
+			return nil, fmt.Errorf("listing queued PRs for %s/%s: %w", owner, repo, err)
+		}
+		all = append(all, issues...)
+		if resp.NextPage == 0 {
+			return all, nil
+		}
+		opts.ListOptions.Page = resp.NextPage
+	}
+}
+
+func (c *Client) trySweepQueuedPR(ctx context.Context, displayRepo, owner, repo string, number int, label string) (AutoMergeSweepEvent, string, error) {
+	pr, _, err := c.client.PullRequests.Get(ctx, owner, repo, number)
+	if err != nil {
+		if isGitHubStatus(err, http.StatusNotFound) {
+			return AutoMergeSweepEvent{}, "gone", nil
+		}
+		return AutoMergeSweepEvent{}, "fetch-pr", err
+	}
+	if !strings.EqualFold(pr.GetState(), "open") {
+		return AutoMergeSweepEvent{}, "closed", nil
+	}
+	if pr.GetDraft() {
+		return AutoMergeSweepEvent{}, "draft", nil
+	}
+	if !hasLabel(extractPRLabels(pr.Labels), label) {
+		return AutoMergeSweepEvent{}, "label-removed", nil
+	}
+
+	author := safeGetLogin(pr.GetUser())
+	queuedBy, ok, err := c.latestHiveQueueApproval(ctx, owner, repo, number)
+	if err != nil {
+		return AutoMergeSweepEvent{}, "queue-approval-check", err
+	}
+	if !ok {
+		return AutoMergeSweepEvent{}, "no-hive-queue-approval", nil
+	}
+	if strings.EqualFold(author, queuedBy) {
+		return AutoMergeSweepEvent{}, "self-merge-ban", nil
+	}
+
+	mergeable := mergeableFromState(pr.GetMergeableState(), pr.Mergeable)
+	if mergeable != MergeableYes {
+		return AutoMergeSweepEvent{}, "not-mergeable", nil
+	}
+	headSHA := ""
+	if pr.GetHead() != nil {
+		headSHA = pr.GetHead().GetSHA()
+	}
+	if headSHA == "" {
+		return AutoMergeSweepEvent{}, "missing-head-sha", nil
+	}
+	green, reason, err := c.commitGreen(ctx, owner, repo, headSHA)
+	if err != nil {
+		return AutoMergeSweepEvent{}, reason, err
+	}
+	if !green {
+		return AutoMergeSweepEvent{}, reason, nil
+	}
+
+	mergeResult, _, err := c.client.PullRequests.Merge(ctx, owner, repo, number, "", &gh.PullRequestOptions{
+		SHA:         headSHA,
+		MergeMethod: "squash",
+	})
+	if err != nil {
+		return AutoMergeSweepEvent{}, "merge-failed", err
+	}
+	if !mergeResult.GetMerged() {
+		return AutoMergeSweepEvent{}, "merge-not-applied", nil
+	}
+	event := AutoMergeSweepEvent{
+		Repo:     displayRepo,
+		Number:   number,
+		Author:   author,
+		QueuedBy: queuedBy,
+		HeadSHA:  headSHA,
+		MergeSHA: mergeResult.GetSHA(),
+		Label:    label,
+	}
+	c.info("automerge sweep merged PR", "repo", displayRepo, "pr", number, "queued_by", queuedBy, "merge_sha", event.MergeSHA)
+	return event, "", nil
+}
+
+func (c *Client) latestHiveQueueApproval(ctx context.Context, owner, repo string, number int) (string, bool, error) {
+	opts := &gh.ListOptions{PerPage: 100}
+	latest := ""
+	for {
+		reviews, resp, err := c.client.PullRequests.ListReviews(ctx, owner, repo, number, opts)
+		if err != nil {
+			return "", false, err
+		}
+		for _, review := range reviews {
+			if !strings.EqualFold(review.GetState(), "APPROVED") {
+				continue
+			}
+			if queuedBy := parseHiveQueueReview(review.GetBody()); queuedBy != "" {
+				latest = queuedBy
+			}
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return latest, latest != "", nil
+}
+
+func parseHiveQueueReview(body string) string {
+	matches := hiveQueueReviewRE.FindStringSubmatch(strings.TrimSpace(body))
+	if len(matches) != 2 {
+		return ""
+	}
+	return matches[1]
+}
+
+func (c *Client) commitGreen(ctx context.Context, owner, repo, sha string) (bool, string, error) {
+	status, _, err := c.client.Repositories.GetCombinedStatus(ctx, owner, repo, sha, &gh.ListOptions{PerPage: 100})
+	if err != nil {
+		return false, "status-check", err
+	}
+	if status.GetTotalCount() > 0 && (status.GetState() == "failure" || status.GetState() == "error") {
+		return false, "status-" + status.GetState(), nil
+	}
+
+	opts := &gh.ListCheckRunsOptions{ListOptions: gh.ListOptions{PerPage: 100}}
+	for {
+		checkRuns, resp, err := c.client.Checks.ListCheckRunsForRef(ctx, owner, repo, sha, opts)
+		if err != nil {
+			return false, "check-runs", err
+		}
+		for _, cr := range checkRuns.CheckRuns {
+			if isMetaCheck(cr.GetName()) {
+				continue
+			}
+			if cr.GetStatus() != "completed" {
+				continue
+			}
+			switch cr.GetConclusion() {
+			case "success", "neutral", "skipped":
+			default:
+				return false, "check-" + cr.GetConclusion(), nil
+			}
+		}
+		if resp.NextPage == 0 {
+			return true, "", nil
+		}
+		opts.ListOptions.Page = resp.NextPage
+	}
+}
+
+func hasLabel(labels []string, want string) bool {
+	for _, label := range labels {
+		if strings.EqualFold(label, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func isGitHubStatus(err error, status int) bool {
+	ghErr, ok := err.(*gh.ErrorResponse)
+	return ok && ghErr.Response != nil && ghErr.Response.StatusCode == status
+}
+
+func (c *Client) warn(msg string, args ...any) {
+	if c != nil && c.logger != nil {
+		c.logger.Warn(msg, args...)
+	}
+}
+
+func (c *Client) info(msg string, args ...any) {
+	if c != nil && c.logger != nil {
+		c.logger.Info(msg, args...)
+	}
+}

--- a/v2/pkg/github/automerge_sweep_test.go
+++ b/v2/pkg/github/automerge_sweep_test.go
@@ -1,0 +1,492 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+type sweepPR struct {
+	number          int
+	author          string
+	queuedBy        string
+	label           bool
+	draft           bool
+	mergeableState  string
+	statusState     string
+	checkStatus     string
+	checkConclusion string
+}
+
+func TestSweepQueuedAutoMergesMergesLabelledGreenPRAudits(t *testing.T) {
+	var audits []AutoMergeSweepEvent
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{{
+		number:          7,
+		author:          "alice",
+		queuedBy:        "bob",
+		label:           true,
+		mergeableState:  "clean",
+		statusState:     "success",
+		checkStatus:     "completed",
+		checkConclusion: "success",
+	}}, &merged)
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{
+		Audit: func(event AutoMergeSweepEvent) { audits = append(audits, event) },
+	})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(result.Merged) != 1 || len(merged) != 1 || merged[0] != 7 {
+		t.Fatalf("merged result=%v merge calls=%v, want PR 7 merged", result.Merged, merged)
+	}
+	if len(audits) != 1 || audits[0].Repo != "widget" || audits[0].Number != 7 || audits[0].QueuedBy != "bob" {
+		t.Fatalf("audit events = %#v, want PR 7 queued by bob", audits)
+	}
+}
+
+func TestSweepQueuedAutoMergesSkipsRedUnlabelledAndDraft(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{
+		{number: 7, author: "alice", queuedBy: "bob", label: true, mergeableState: "clean", statusState: "failure", checkStatus: "completed", checkConclusion: "success"},
+		{number: 8, author: "carol", queuedBy: "dave", label: false, mergeableState: "clean", statusState: "success", checkStatus: "completed", checkConclusion: "success"},
+		{number: 9, author: "erin", queuedBy: "frank", label: true, draft: true, mergeableState: "clean", statusState: "success", checkStatus: "completed", checkConclusion: "success"},
+	}, &merged)
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(result.Merged) != 0 || len(merged) != 0 {
+		t.Fatalf("merged result=%v merge calls=%v, want no merges", result.Merged, merged)
+	}
+	if result.Seen != 2 {
+		t.Fatalf("seen=%d, want only the two labelled PRs", result.Seen)
+	}
+}
+
+func TestSweepQueuedAutoMergesRespectsCap(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{
+		{number: 7, author: "alice", queuedBy: "bob", label: true, mergeableState: "clean", statusState: "success", checkStatus: "completed", checkConclusion: "success"},
+		{number: 8, author: "carol", queuedBy: "dave", label: true, mergeableState: "clean", statusState: "success", checkStatus: "completed", checkConclusion: "success"},
+	}, &merged)
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{MaxMerges: 1})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(result.Merged) != 1 || len(merged) != 1 || merged[0] != 7 {
+		t.Fatalf("merged result=%v merge calls=%v, want only first PR merged", result.Merged, merged)
+	}
+}
+
+func TestSweepQueuedAutoMergesHonorsConfiguredLabel(t *testing.T) {
+	const label = "ship-it"
+	var merged []int
+	api := newAutoMergeSweepAPI(t, label, []sweepPR{{
+		number: 7, author: "alice", queuedBy: "bob", label: true, mergeableState: "clean",
+		statusState: "success", checkStatus: "completed", checkConclusion: "success",
+	}}, &merged)
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	c.SetAutoMergeLabel(label)
+	if _, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{}); err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(merged) != 1 || merged[0] != 7 {
+		t.Fatalf("merge calls=%v, want custom-labelled PR merged", merged)
+	}
+}
+
+func TestSweepQueuedAutoMergesRechecksSelfMergeBan(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{{
+		number: 7, author: "alice", queuedBy: "ALICE", label: true, mergeableState: "clean",
+		statusState: "success", checkStatus: "completed", checkConclusion: "success",
+	}}, &merged)
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(result.Merged) != 0 || len(merged) != 0 {
+		t.Fatalf("merged result=%v merge calls=%v, want self-queued PR skipped", result.Merged, merged)
+	}
+}
+
+func TestAutoMergeSweepHelpersAndNilClient(t *testing.T) {
+	var nilClient *Client
+	if _, err := nilClient.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{}); err != ErrNoGitHubClient {
+		t.Fatalf("nil sweep error = %v, want ErrNoGitHubClient", err)
+	}
+	if got := parseHiveQueueReview("Approved by @Alice-1 for Hive auto-merge on green CI."); got != "Alice-1" {
+		t.Fatalf("parseHiveQueueReview = %q, want Alice-1", got)
+	}
+	if got := parseHiveQueueReview("Approved for Hive auto-merge on green CI."); got != "" {
+		t.Fatalf("legacy body parsed as %q, want empty", got)
+	}
+	if !hasLabel([]string{"LGTM"}, "lgtm") || hasLabel([]string{"hold"}, "lgtm") {
+		t.Fatal("hasLabel case-insensitive matching failed")
+	}
+	if !isGitHubStatus(&gh.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}}, http.StatusNotFound) {
+		t.Fatal("isGitHubStatus did not match GitHub status")
+	}
+	if isGitHubStatus(context.Canceled, http.StatusNotFound) {
+		t.Fatal("isGitHubStatus matched a non-GitHub error")
+	}
+	c := &Client{}
+	c.warn("ignored")
+	c.info("ignored")
+	c.logger = slog.Default()
+	c.warn("covered")
+	c.info("covered")
+}
+
+func TestCommitGreenStatusAndCheckBranches(t *testing.T) {
+	tests := []struct {
+		name            string
+		statusState     string
+		statusTotal     int
+		checkStatus     string
+		checkConclusion string
+		wantGreen       bool
+		wantReason      string
+	}{
+		{name: "failure status blocks", statusState: "failure", statusTotal: 1, wantReason: "status-failure"},
+		{name: "pending status with no red checks relies on mergeable", statusState: "pending", statusTotal: 1, checkStatus: "queued", wantGreen: true},
+		{name: "check failure blocks", statusState: "success", statusTotal: 1, checkStatus: "completed", checkConclusion: "failure", wantReason: "check-failure"},
+		{name: "no statuses or checks is green after mergeable gate", statusState: "pending", statusTotal: 0, wantGreen: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha/status":
+					json.NewEncoder(w).Encode(map[string]any{"state": tt.statusState, "total_count": tt.statusTotal})
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha/check-runs":
+					runs := []map[string]string{}
+					if tt.checkStatus != "" {
+						runs = append(runs, map[string]string{"name": "build", "status": tt.checkStatus, "conclusion": tt.checkConclusion})
+					}
+					json.NewEncoder(w).Encode(map[string]any{"total_count": len(runs), "check_runs": runs})
+				default:
+					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer api.Close()
+			c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+			green, reason, err := c.commitGreen(context.Background(), "acme", "widget", "sha")
+			if err != nil {
+				t.Fatalf("commitGreen returned error: %v", err)
+			}
+			if green != tt.wantGreen || reason != tt.wantReason {
+				t.Fatalf("commitGreen = (%v,%q), want (%v,%q)", green, reason, tt.wantGreen, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestTrySweepQueuedPRSkipBranches(t *testing.T) {
+	tests := []struct {
+		name     string
+		pr       sweepPR
+		state    string
+		labels   []map[string]string
+		noReview bool
+		want     string
+	}{
+		{name: "closed", pr: sweepPR{number: 7, author: "alice", queuedBy: "bob", label: true}, state: "closed", want: "closed"},
+		{name: "label removed", pr: sweepPR{number: 7, author: "alice", queuedBy: "bob", label: true}, state: "open", labels: nil, want: "label-removed"},
+		{name: "missing queue approval", pr: sweepPR{number: 7, author: "alice", queuedBy: "bob", label: true, mergeableState: "clean"}, state: "open", labels: []map[string]string{{"name": AutoMergeQueuedLabel}}, noReview: true, want: "no-hive-queue-approval"},
+		{name: "not mergeable", pr: sweepPR{number: 7, author: "alice", queuedBy: "bob", label: true, mergeableState: "dirty"}, state: "open", labels: []map[string]string{{"name": AutoMergeQueuedLabel}}, want: "not-mergeable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7":
+					json.NewEncoder(w).Encode(map[string]any{
+						"number":          7,
+						"state":           tt.state,
+						"mergeable_state": tt.pr.mergeableState,
+						"mergeable":       tt.pr.mergeableState == "clean",
+						"user":            map[string]string{"login": tt.pr.author},
+						"head":            map[string]string{"sha": "sha7"},
+						"labels":          tt.labels,
+					})
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7/reviews":
+					if tt.noReview {
+						json.NewEncoder(w).Encode([]map[string]any{})
+					} else {
+						json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": "Approved by @" + tt.pr.queuedBy + " for Hive auto-merge on green CI."}})
+					}
+				default:
+					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer api.Close()
+			c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+			_, reason, err := c.trySweepQueuedPR(context.Background(), "widget", "acme", "widget", 7, AutoMergeQueuedLabel)
+			if err != nil {
+				t.Fatalf("trySweepQueuedPR returned error: %v", err)
+			}
+			if reason != tt.want {
+				t.Fatalf("reason = %q, want %q", reason, tt.want)
+			}
+		})
+	}
+}
+
+func TestTrySweepQueuedPRMissingHeadAndMergeNotApplied(t *testing.T) {
+	tests := []struct {
+		name        string
+		head        map[string]string
+		mergeResult map[string]any
+		want        string
+	}{
+		{name: "missing head", head: nil, want: "missing-head-sha"},
+		{name: "merge not applied", head: map[string]string{"sha": "sha7"}, mergeResult: map[string]any{"merged": false}, want: "merge-not-applied"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7":
+					json.NewEncoder(w).Encode(map[string]any{
+						"number":          7,
+						"state":           "open",
+						"mergeable_state": "clean",
+						"mergeable":       true,
+						"user":            map[string]string{"login": "alice"},
+						"head":            tt.head,
+						"labels":          []map[string]string{{"name": AutoMergeQueuedLabel}},
+					})
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7/reviews":
+					json.NewEncoder(w).Encode([]map[string]any{{"state": "COMMENTED", "body": "noise"}, {"state": "APPROVED", "body": "Approved by @bob for Hive auto-merge on green CI."}})
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/status":
+					json.NewEncoder(w).Encode(map[string]any{"state": "success", "total_count": 1})
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/check-runs":
+					json.NewEncoder(w).Encode(map[string]any{"total_count": 1, "check_runs": []map[string]string{{"name": "build", "status": "completed", "conclusion": "success"}}})
+				case r.Method == http.MethodPut && r.URL.Path == "/repos/acme/widget/pulls/7/merge":
+					json.NewEncoder(w).Encode(tt.mergeResult)
+				default:
+					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer api.Close()
+			c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+			_, reason, err := c.trySweepQueuedPR(context.Background(), "widget", "acme", "widget", 7, AutoMergeQueuedLabel)
+			if err != nil {
+				t.Fatalf("trySweepQueuedPR returned error: %v", err)
+			}
+			if reason != tt.want {
+				t.Fatalf("reason = %q, want %q", reason, tt.want)
+			}
+		})
+	}
+}
+
+func TestTrySweepQueuedPRMergeError(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7":
+			json.NewEncoder(w).Encode(map[string]any{
+				"number": 7, "state": "open", "mergeable_state": "clean", "mergeable": true,
+				"user":   map[string]string{"login": "alice"},
+				"head":   map[string]string{"sha": "sha7"},
+				"labels": []map[string]string{{"name": AutoMergeQueuedLabel}},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7/reviews":
+			json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": "Approved by @bob for Hive auto-merge on green CI."}})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/status":
+			json.NewEncoder(w).Encode(map[string]any{"state": "success", "total_count": 1})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/check-runs":
+			json.NewEncoder(w).Encode(map[string]any{"total_count": 1, "check_runs": []map[string]string{{"name": "build", "status": "completed", "conclusion": "success"}}})
+		case r.Method == http.MethodPut && r.URL.Path == "/repos/acme/widget/pulls/7/merge":
+			http.Error(w, "conflict", http.StatusConflict)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer api.Close()
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	_, reason, err := c.trySweepQueuedPR(context.Background(), "widget", "acme", "widget", 7, AutoMergeQueuedLabel)
+	if err == nil || reason != "merge-failed" {
+		t.Fatalf("trySweepQueuedPR reason=%q err=%v, want merge-failed error", reason, err)
+	}
+}
+
+func TestCommitGreenAPIErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantReason string
+	}{
+		{name: "status error", statusCode: http.StatusInternalServerError, wantReason: "status-check"},
+		{name: "check error", statusCode: http.StatusOK, wantReason: "check-runs"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha/status":
+					if tt.statusCode != http.StatusOK {
+						http.Error(w, "boom", tt.statusCode)
+						return
+					}
+					json.NewEncoder(w).Encode(map[string]any{"state": "success", "total_count": 1})
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha/check-runs":
+					http.Error(w, "boom", http.StatusInternalServerError)
+				default:
+					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer api.Close()
+			c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+			_, reason, err := c.commitGreen(context.Background(), "acme", "widget", "sha")
+			if err == nil || reason != tt.wantReason {
+				t.Fatalf("commitGreen reason=%q err=%v, want %q error", reason, err, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestListQueuedPullRequestIssuesPaginates(t *testing.T) {
+	var base string
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("page") {
+		case "":
+			w.Header().Set("Link", `<`+base+`/repos/acme/widget/issues?page=2>; rel="next"`)
+			json.NewEncoder(w).Encode([]map[string]any{{"number": 1}})
+		case "2":
+			json.NewEncoder(w).Encode([]map[string]any{{"number": 2}})
+		default:
+			t.Fatalf("unexpected page: %s", r.URL.RawQuery)
+		}
+	}))
+	defer api.Close()
+	base = api.URL
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	issues, err := c.listQueuedPullRequestIssues(context.Background(), "acme", "widget", AutoMergeQueuedLabel)
+	if err != nil {
+		t.Fatalf("listQueuedPullRequestIssues returned error: %v", err)
+	}
+	if len(issues) != 2 || issues[0].GetNumber() != 1 || issues[1].GetNumber() != 2 {
+		t.Fatalf("issues = %#v, want pages 1 and 2", issues)
+	}
+}
+
+func newAutoMergeSweepAPI(t *testing.T, expectedLabel string, prs []sweepPR, merged *[]int) *httptest.Server {
+	t.Helper()
+	byNumber := make(map[int]sweepPR, len(prs))
+	for _, pr := range prs {
+		byNumber[pr.number] = pr
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/issues":
+			if got := r.URL.Query().Get("labels"); got != expectedLabel {
+				t.Fatalf("issues labels query = %q, want %q", got, expectedLabel)
+			}
+			var issues []map[string]any
+			for _, pr := range prs {
+				if !pr.label {
+					continue
+				}
+				issues = append(issues, map[string]any{
+					"number":       pr.number,
+					"pull_request": map[string]any{"url": "https://api.example/pr/" + strconv.Itoa(pr.number)},
+				})
+			}
+			json.NewEncoder(w).Encode(issues)
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/repos/acme/widget/pulls/") && strings.HasSuffix(r.URL.Path, "/reviews"):
+			number := pathNumber(t, r.URL.Path, "/repos/acme/widget/pulls/", "/reviews")
+			pr := byNumber[number]
+			body := "Approved by @" + pr.queuedBy + " for Hive auto-merge on green CI."
+			json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": body}})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/repos/acme/widget/pulls/"):
+			number := pathNumber(t, r.URL.Path, "/repos/acme/widget/pulls/", "")
+			pr := byNumber[number]
+			json.NewEncoder(w).Encode(map[string]any{
+				"number":          pr.number,
+				"state":           "open",
+				"draft":           pr.draft,
+				"mergeable_state": pr.mergeableState,
+				"mergeable":       pr.mergeableState == "clean",
+				"user":            map[string]string{"login": pr.author},
+				"head":            map[string]string{"sha": "sha" + strconv.Itoa(pr.number)},
+				"labels":          []map[string]string{{"name": expectedLabel}},
+			})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/repos/acme/widget/commits/") && strings.HasSuffix(r.URL.Path, "/status"):
+			number := shaNumber(t, r.URL.Path)
+			pr := byNumber[number]
+			total := 1
+			json.NewEncoder(w).Encode(map[string]any{"state": pr.statusState, "total_count": total})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/repos/acme/widget/commits/") && strings.HasSuffix(r.URL.Path, "/check-runs"):
+			number := shaNumber(t, r.URL.Path)
+			pr := byNumber[number]
+			json.NewEncoder(w).Encode(map[string]any{
+				"total_count": 1,
+				"check_runs": []map[string]string{{
+					"name":       "build",
+					"status":     pr.checkStatus,
+					"conclusion": pr.checkConclusion,
+				}},
+			})
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/repos/acme/widget/pulls/") && strings.HasSuffix(r.URL.Path, "/merge"):
+			number := pathNumber(t, r.URL.Path, "/repos/acme/widget/pulls/", "/merge")
+			*merged = append(*merged, number)
+			json.NewEncoder(w).Encode(map[string]any{"merged": true, "sha": "merge" + strconv.Itoa(number)})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+}
+
+func pathNumber(t *testing.T, path, prefix, suffix string) int {
+	t.Helper()
+	raw := strings.TrimPrefix(path, prefix)
+	if suffix != "" {
+		raw = strings.TrimSuffix(raw, suffix)
+	}
+	number, err := strconv.Atoi(raw)
+	if err != nil {
+		t.Fatalf("parse number from %q: %v", path, err)
+	}
+	return number
+}
+
+func shaNumber(t *testing.T, path string) int {
+	t.Helper()
+	parts := strings.Split(path, "/")
+	for _, part := range parts {
+		if strings.HasPrefix(part, "sha") {
+			number, err := strconv.Atoi(strings.TrimPrefix(part, "sha"))
+			if err != nil {
+				t.Fatalf("parse sha number from %q: %v", path, err)
+			}
+			return number
+		}
+	}
+	t.Fatalf("sha number not found in %q", path)
+	return 0
+}

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -37,8 +37,8 @@ type Client struct {
 	// config reload re-applies it while request handlers read it.
 	autoMergeLabelMu sync.RWMutex
 	autoMergeLabel   string
-	logger       *slog.Logger
-	appAuth      *AppAuth // nil for token-authenticated clients
+	logger           *slog.Logger
+	appAuth          *AppAuth // nil for token-authenticated clients
 	// prAuthz gates PR-open requests from the request-file watcher against the
 	// per-agent ACMM write-policy + forge-resistance. nil fails closed. Set by
 	// StartPRRequestWatcher.
@@ -684,11 +684,16 @@ func (c *Client) GetPRAuthor(ctx context.Context, repo string, number int) (stri
 	return safeGetLogin(pr.GetUser()), nil
 }
 
-// QueuePRAutoMerge approves a PR as the hive App and marks it for the
-// auto-merge-on-green sweep. The caller enforces role and self-queue policy.
+// QueuePRAutoMerge approves a PR as the hive App and marks it for Hive's
+// auto-merge-on-green sweep. The approval body records who queued the PR so
+// the sweep can re-check the self-merge ban before it squashes anything.
 func (c *Client) QueuePRAutoMerge(ctx context.Context, repo string, number int, queuedBy string) error {
 	if c == nil {
 		return ErrNoGitHubClient
+	}
+	queuedBy = strings.TrimSpace(queuedBy)
+	if queuedBy == "" {
+		return errors.New("queuedBy is required for auto-merge audit and self-merge checks")
 	}
 	owner, repoName := c.splitRepo(repo)
 	label := c.AutoMergeLabel()
@@ -696,9 +701,6 @@ func (c *Client) QueuePRAutoMerge(ctx context.Context, repo string, number int, 
 		return fmt.Errorf("ensuring %s label: %w", label, err)
 	}
 	body := fmt.Sprintf("Approved by @%s for Hive auto-merge on green CI.", queuedBy)
-	if strings.TrimSpace(queuedBy) == "" {
-		body = "Approved for Hive auto-merge on green CI."
-	}
 	_, _, err := c.client.PullRequests.CreateReview(ctx, owner, repoName, number, &gh.PullRequestReviewRequest{
 		Body:  gh.Ptr(body),
 		Event: gh.Ptr("APPROVE"),


### PR DESCRIPTION
Fixes #2840

## Summary
- add a periodic Hive auto-merge sweep that consumes the configured governor.labels.automerge label
- squash-merge only labelled, open, non-draft PRs in managed repos after GitHub reports them mergeable and status/check signals have no failures
- verify the Hive queue approval body and re-check queued-by != PR author before merging
- cap sweeps, rate-limit to once per minute, and audit successful merges as automerge-sweep-merged

## Validation
- go test ./pkg/github/ ./pkg/scheduler/ ./pkg/dashboard/ -count=1
- go build ./...
- go vet ./...