### PR TITLE
📖 docs(contribute): document multi-hub subscription (comma-separated HIVE_HUB)

### DIFF
--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -7,8 +7,9 @@
 # 4. The relay feeds tasks into the tmux session and reports results
 #
 # Environment (from ~/.config/hive/contributor.env):
-#   HIVE_HUB                — WebSocket URL
-#   HIVE_REGISTRATION_TOKEN — contributor's token
+#   HIVE_HUB                — WebSocket URL; comma-separated URLs subscribe to multiple hubs
+#   HIVE_REGISTRATION_TOKEN — contributor's token; for multiple hubs, one comma-separated token
+#                             per hub in the same order as HIVE_HUB
 #   AGENT_BACKEND           — preferred CLI backend
 
 set -euo pipefail

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -6,8 +6,11 @@
 // heartbeat, and reconnection with exponential backoff.
 //
 // Environment:
-//   HIVE_HUB              — WebSocket URL (wss://host:port/contribute)
-//   HIVE_REGISTRATION_TOKEN — contributor's registration token
+//   HIVE_HUB              — WebSocket URL (wss://host:port/contribute);
+//                           comma-separated URLs subscribe to multiple hubs
+//   HIVE_REGISTRATION_TOKEN — contributor's registration token; for multiple
+//                           hubs, provide one comma-separated token per hub in
+//                           the same order as HIVE_HUB
 //   AGENT_BACKEND          — CLI backend name (claude, copilot, gemini, etc.)
 //   AGENT_MODEL            — model override (optional)
 //   HIVE_AGENT_SESSION     — tmux session name for the agent (default: contributor)

--- a/docs/federation-design.md
+++ b/docs/federation-design.md
@@ -96,7 +96,15 @@ The contributor can then target a specific hive:
 HIVE_HUB=wss://drasi-hive.example.com:3001/contribute just contribute-hive
 ```
 
-Or register with multiple hives and switch between them.
+Or register with multiple hives and subscribe to them from one relay session (added by [@hanthor](https://github.com/hanthor) in [#2846](https://github.com/kubestellar/hive/pull/2846)):
+
+```bash
+export HIVE_HUB=wss://drasi-hive.example.com:3001/contribute,wss://keptn-hive.cncf.io:3001/contribute
+export HIVE_REGISTRATION_TOKEN=drasi-token,keptn-token
+just contribute-hive
+```
+
+Keep the tokens in the same order as the hub URLs. The relay uses one CLI/tmux session, keeps a separate WebSocket connection and heartbeat per hub, works on one task at a time, and only round-robins to the next hub when the active hub explicitly reports that no task is available.
 
 ## Federation Architecture
 

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -1479,6 +1479,9 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 <strong style="color:#e6edf3">Kubernetes is the advanced path.</strong> It needs a cluster, a kubeconfig and RBAC &mdash; not a first-timer&rsquo;s happy path. The workload runs the relay <strong>headless</strong> (no TTY), so only headless-capable backends work in a cluster: <strong>Claude Code, LiteLLM, Copilot, Codex</strong>. Other backends will refuse work at pod startup.<br>
 <span style="color:#8b949e">Credential note (interim): the generated Secret stores a long-lived personal <code>GH_TOKEN</code> &mdash; base64, not encrypted, and readable by anyone with <code>get secrets</code> in that namespace or by cluster-scoped operators/backups. That is materially more exposed than a <code>0600</code> file on your laptop. Revoke any time with <code>gh auth logout</code>. Gating the credential on explicit task acceptance is tracked in <a href="https://github.com/kubestellar/hive/issues/2537" target="_blank" rel="noopener" style="color:#58a6ff">#2537</a> and is not solved by this path.</span>
 </div>
+<div id="multi-hub-note" style="margin-bottom:12px;background:#161b22;border:1px solid #30363d;border-left:3px solid #58a6ff;border-radius:6px;padding:12px 14px;font-size:.85rem;color:#c9d1d9;line-height:1.5">
+<strong style="color:#e6edf3">Contribute to multiple hives:</strong> after registering with each hive, set <code>HIVE_HUB</code> to comma-separated WebSocket URLs and <code>HIVE_REGISTRATION_TOKEN</code> to the matching comma-separated tokens in the same order. One relay shares one CLI/tmux session, works on one task at a time, keeps each hub connected with its own heartbeat, and rotates only when the active hub says no task is available. Added by <a href="https://github.com/hanthor" target="_blank" rel="noopener" style="color:#58a6ff">@hanthor</a> in <a href="https://github.com/kubestellar/hive/pull/2846" target="_blank" rel="noopener" style="color:#58a6ff">#2846</a>.
+</div>
 <p style="color:#8b949e;margin-bottom:8px">Copy and paste these commands to get started:</p>
 <div style="margin-top:16px;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:16px;position:relative">
 <button id="copy-btn" style="position:absolute;top:8px;right:8px;background:#238636;color:#fff;border:none;border-radius:4px;padding:4px 12px;cursor:pointer;font-size:.75rem">Copy</button>
@@ -1682,6 +1685,7 @@ function defaultPromptFor(v){
     '  1. Install the prerequisites (just, gh) for my OS.\n'+
     '  2. git clone -b v2 https://github.com/kubestellar/hive && cd hive\n'+
     '  3. export HIVE_HUB='+hubURL+'\n'+
+    '     For multiple hives, HIVE_HUB can be comma-separated when HIVE_REGISTRATION_TOKEN has matching tokens in the same order.\n'+
     '  4. just contribute-setup '+v+'\n'+
     '  5. just contribute-hive\n\n'+
     'Explain what each step does before I run it, and stop if anything looks wrong.';

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -163,6 +163,21 @@ func TestContributeLanding(t *testing.T) {
 	if !bytes.Contains(body, []byte("Default shown: macOS + Claude Code + containerized mode")) {
 		t.Error("server-rendered fallback command block missing default marker comment")
 	}
+
+	// #2846: multi-hub contributor sessions must stay discoverable from the
+	// onboarding page, including the ordering rule for paired tokens.
+	for _, want := range [][]byte{
+		[]byte(`id="multi-hub-note"`),
+		[]byte("Contribute to multiple hives"),
+		[]byte("HIVE_HUB</code> to comma-separated WebSocket URLs"),
+		[]byte("HIVE_REGISTRATION_TOKEN</code> to the matching comma-separated tokens in the same order"),
+		[]byte("one CLI/tmux session"),
+		[]byte("github.com/kubestellar/hive/pull/2846"),
+	} {
+		if !bytes.Contains(body, want) {
+			t.Errorf("landing page missing multi-hub help text %q", want)
+		}
+	}
 }
 
 // TestContributeLandingHasOpsTab pins the additive tab chrome: the landing page


### PR DESCRIPTION
## Summary
- document comma-separated HIVE_HUB / HIVE_REGISTRATION_TOKEN multi-hub contributor setup on /contribute
- add a Contribute page pinning test for the multi-hub help text
- update relay/env docs and federation notes with PR #2846 credit

## Validation
- cd v2 && go build ./...
- cd v2 && go test ./pkg/dashboard/ -run Contribute -count=1