### PR TITLE
✨ feat(sandbox): wire credential-free sandboxed kick execution with broker push

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -51,6 +51,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/proclock"
 	"github.com/kubestellar/hive/v2/pkg/promptsrc"
 	"github.com/kubestellar/hive/v2/pkg/proxy"
+	"github.com/kubestellar/hive/v2/pkg/pushbroker"
 	"github.com/kubestellar/hive/v2/pkg/retro"
 	"github.com/kubestellar/hive/v2/pkg/review"
 	"github.com/kubestellar/hive/v2/pkg/scheduler"
@@ -1217,14 +1218,16 @@ func main() {
 	}
 
 	projectCtx := agent.ProjectContext{
-		Org:            cfg.Project.Org,
-		Repos:          cfg.Project.Repos,
-		ACMMLevel:      acmmLevel,
-		PRsAllowed:     cfg.Project.PRsAllowed(),
-		PolicyDir:      policyDir,
-		AppAuthoredPRs: cfg.GitHub.AppAuthoredPRsEnabled(),
+		Org:             cfg.Project.Org,
+		Repos:           cfg.Project.Repos,
+		PrimaryRepoName: cfg.Project.PrimaryRepo,
+		ACMMLevel:       acmmLevel,
+		PRsAllowed:      cfg.Project.PRsAllowed(),
+		PolicyDir:       policyDir,
+		AppAuthoredPRs:  cfg.GitHub.AppAuthoredPRsEnabled(),
 	}
 	agentMgr := agent.NewManager(cfg.EnabledAgents(), logger, projectCtx)
+	agentMgr.SetSandboxConfig(cfg.AgentSandbox)
 	// Resolve the bob API key at LAUNCH time, not here: cfg is the live config
 	// pointer (the config watcher swaps its contents in place on reload), so a
 	// key added via the Secret mount, the PVC file, or a config edit takes
@@ -1250,7 +1253,11 @@ func main() {
 	}
 	if appAuth != nil {
 		agentMgr.SetAppAuth(appAuth)
+		agentMgr.SetSandboxPushMinter(pushbroker.GitHubAppMinter{Auth: appAuth})
 		go agentMgr.StartAgentTokenRefresh(ctx)
+	}
+	if ghClient != nil {
+		agentMgr.SetSandboxPRClient(ghClient)
 	}
 
 	// PR-open-as-the-App-bot: agents push their branch (App-token credential
@@ -1494,6 +1501,7 @@ func main() {
 	}
 
 	dashSrv := dashboard.NewServerWithAuth(cfg.Dashboard.Port, cfg.Dashboard.AuthToken, logger)
+	var beadStores map[string]*beads.Store
 
 	// Wire ioscan input enforcement (opt-in via ioscan.enabled) to the dashboard
 	// audit log so a blocked/redacted issue title surfaces in the existing
@@ -1501,6 +1509,16 @@ func main() {
 	// from pkg/dashboard — the scheduler only knows a func(action, detail, agent).
 	sched.SetAuditFunc(func(action, detail, agent string) {
 		dashSrv.AuditLog(agent, action, detail, agent)
+	})
+	agentMgr.SetSandboxAuditCallback(func(agentName, action, detail string) {
+		dashSrv.AuditLog(agentName, action, detail, agentName)
+		if action == "sandbox_broker_rejected" {
+			if store, ok := beadStores[agentName]; ok && store != nil {
+				if b, err := store.Create("Sandbox push broker rejected changes", beads.TypeAdvisory, beads.PriorityHigh, agentName, ""); err == nil {
+					_ = store.SetMetadata(b.ID, "sandbox_broker_rejection", detail)
+				}
+			}
+		}
 	})
 
 	// Persist per-user dashboard sessions on the PVC (/data) so direct-route
@@ -1544,7 +1562,7 @@ func main() {
 		logger.Info("trend history restored", "entries", len(pendingTrendSeed))
 	}
 
-	beadStores := make(map[string]*beads.Store)
+	beadStores = make(map[string]*beads.Store)
 	for name, agentCfg := range cfg.EnabledAgents() {
 		store, err := beads.NewStore(agentCfg.BeadsDir)
 		if err != nil {
@@ -2413,6 +2431,7 @@ func main() {
 			uc.SetRepos(cfg.Project.Repos)
 		}
 		gov.UpdateConfig(cfg.Governor)
+		agentMgr.SetSandboxConfig(cfg.AgentSandbox)
 
 		// Re-apply live agent definitions (definition_source) on reload so an
 		// operator's edit to a linked repo propagates. Merges only operator-safe
@@ -2442,6 +2461,8 @@ func main() {
 					ghClient = newClient
 					appAuth = newAppAuth
 					agentMgr.SetAppAuth(newAppAuth)
+					agentMgr.SetSandboxPushMinter(pushbroker.GitHubAppMinter{Auth: newAppAuth})
+					agentMgr.SetSandboxPRClient(newClient)
 					dashSrv.UpdateGitHubClient(newClient, newAppAuth)
 					logger.Info("github app auth rebuilt after config reload",
 						"app_id", cfg.GitHub.AppID,

--- a/v2/docs/sandbox-isolation.md
+++ b/v2/docs/sandbox-isolation.md
@@ -1,26 +1,41 @@
-# Credential-free sandbox isolation (phase 1)
+# Credential-free sandbox isolation
 
 ## Threat model
 
-Hive agents are untrusted code executors: prompts, tool output, and cloned repositories can all contain hostile instructions. The safe target is therefore **no credentials and no network inside the agent sandbox**. If an agent is compromised, it can only modify its mounted workspace; it cannot call GitHub directly, exfiltrate tokens, or bypass the outer MITM policy.
+Hive agents are untrusted code executors: prompts, tool output, and cloned repositories can all contain hostile instructions. The safe target is therefore **no credentials in the agent sandbox** and a network policy that is as close to default-deny as the configured inference runtime allows. If an agent is compromised, it can only modify its mounted workspace; it cannot receive GitHub tokens or push directly.
 
-## Phase-1 scope
+## Current wiring
 
-This phase adds the reusable plumbing, while tmux remains the default runner:
+Sandbox execution is opt-in and the tmux path remains unchanged for all agents unless both gates are set:
 
-- `pkg/sandbox` builds and runs rootless Podman specs with `--network=none`, `--userns=keep-id`, a workspace mount, and an explicit environment allowlist. GitHub/token-like environment variables are filtered even if requested.
-- `agent_sandbox:` is a disabled-by-default global config gate. Individual agents opt in with `agents.<name>.sandbox.enabled: true` plus optional image/env allowlist overrides.
-- `pkg/pushbroker` is the trusted post-step. It inspects committed workspace changes, rejects token-like secrets using the shared `logscrub` token detector, rejects guardrail-critical paths (`.github/workflows/`, gh wrapper paths, `policies/`, `OWNERS`), mints a short-lived scoped GitHub App token outside the workspace, and pushes with a sanitized environment.
-- Push broker results are structured for audit logs: repo, branch, commit, changed files, rejection reason, and push status. Tokens are never recorded.
+```yaml
+agent_sandbox:
+  enabled: true
+  image: ghcr.io/example/hive-agent:latest
+  # Default is "restricted" so local/proxy inference can still work.
+  # Use "none" for non-inference/test runs that require full network isolation.
+  network_mode: restricted
+  timeout_s: 2700
+agents:
+  scanner:
+    sandbox:
+      enabled: true
+```
 
-## Deferred wiring
+For sandboxed agents, a kick now follows this path:
 
-Full migration off tmux is intentionally deferred. The next phases should:
+1. Hive prepares a per-kick host workspace under the sandbox workspace root by cloning/fetching the primary repo with hive-owned credentials before the sandbox starts. The clone URL and sandbox environment are sanitized so GitHub/token variables are not carried into the workspace or container.
+2. Hive writes the kick prompt to `.hive/kick-prompt.txt` in the workspace and launches `pkg/sandbox.Launcher` with a rootless Podman `LaunchSpec`, workspace mount, explicit env allowlist, and configured network mode.
+3. The manager marks the agent busy while the sandbox runs and returns it to idle or failed when the timeout/completion path finishes. Dashboard status uses the existing agent status structures.
+4. Hive collects the transcript at `.hive/sandbox-transcript.log` and any `agent-report*.json` artifact following `pkg/outputschema` conventions.
+5. If the sandbox produced commits, `pkg/pushbroker.Broker` scans the committed diff for token-like secrets and protected-path edits, mints a short-lived scoped GitHub App token outside the sandbox, pushes the branch, and opens a PR through the existing App-authored GitHub client. Broker rejection records audit detail and nothing is pushed.
 
-1. Prepare per-kick workspaces for sandboxed agents instead of reusing long-lived tmux panes.
-2. Execute the agent kick through `pkg/sandbox.Launcher` and collect stdout/stderr/artifacts.
-3. Run `pkg/pushbroker.Broker` automatically after sandbox completion when commits exist on the work branch.
-4. Extend PR creation/commenting into the same trusted post-step so no GitHub credential is ever present in the sandbox.
-5. Add live Podman CI on a runner with rootless Podman available; current package tests skip live execution when Podman is absent.
+## Network trade-off
 
-This keeps phase 1 safe and reviewable: the security-critical broker and sandbox contract are complete and tested, while production agents continue to use the existing tmux path unless explicitly wired in a later phase.
+`network_mode: none` remains available and maps to Podman's `--network=none`, but it only works for non-inference jobs or runtimes that already expose a local/socket model proxy inside the container. The default sandbox network mode is `restricted`: operators must provide a Podman network/proxy policy that allows only the inference endpoint and MITM proxy required by the selected backend. This is a compromise until every supported backend can run through a credential-free local socket without general egress.
+
+## Remaining gaps
+
+- The default target is the hive primary repo and default base ref; richer per-kick repo/ref selection is still future work.
+- Live Podman execution is covered by skip-when-absent tests; CI still needs a rootless-Podman runner lane for always-on integration coverage.
+- Sandboxed inference depends on an operator-provided restricted network/proxy policy. `none` is stronger but not yet usable for all model backends.

--- a/v2/docs/sandbox-isolation.md
+++ b/v2/docs/sandbox-isolation.md
@@ -1,0 +1,26 @@
+# Credential-free sandbox isolation (phase 1)
+
+## Threat model
+
+Hive agents are untrusted code executors: prompts, tool output, and cloned repositories can all contain hostile instructions. The safe target is therefore **no credentials and no network inside the agent sandbox**. If an agent is compromised, it can only modify its mounted workspace; it cannot call GitHub directly, exfiltrate tokens, or bypass the outer MITM policy.
+
+## Phase-1 scope
+
+This phase adds the reusable plumbing, while tmux remains the default runner:
+
+- `pkg/sandbox` builds and runs rootless Podman specs with `--network=none`, `--userns=keep-id`, a workspace mount, and an explicit environment allowlist. GitHub/token-like environment variables are filtered even if requested.
+- `agent_sandbox:` is a disabled-by-default global config gate. Individual agents opt in with `agents.<name>.sandbox.enabled: true` plus optional image/env allowlist overrides.
+- `pkg/pushbroker` is the trusted post-step. It inspects committed workspace changes, rejects token-like secrets using the shared `logscrub` token detector, rejects guardrail-critical paths (`.github/workflows/`, gh wrapper paths, `policies/`, `OWNERS`), mints a short-lived scoped GitHub App token outside the workspace, and pushes with a sanitized environment.
+- Push broker results are structured for audit logs: repo, branch, commit, changed files, rejection reason, and push status. Tokens are never recorded.
+
+## Deferred wiring
+
+Full migration off tmux is intentionally deferred. The next phases should:
+
+1. Prepare per-kick workspaces for sandboxed agents instead of reusing long-lived tmux panes.
+2. Execute the agent kick through `pkg/sandbox.Launcher` and collect stdout/stderr/artifacts.
+3. Run `pkg/pushbroker.Broker` automatically after sandbox completion when commits exist on the work branch.
+4. Extend PR creation/commenting into the same trusted post-step so no GitHub credential is ever present in the sandbox.
+5. Add live Podman CI on a runner with rootless Podman available; current package tests skip live execution when Podman is absent.
+
+This keeps phase 1 safe and reviewable: the security-critical broker and sandbox contract are complete and tested, while production agents continue to use the existing tmux path unless explicitly wired in a later phase.

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -21,6 +21,8 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/claude"
 	"github.com/kubestellar/hive/v2/pkg/config"
 	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+	"github.com/kubestellar/hive/v2/pkg/pushbroker"
+	"github.com/kubestellar/hive/v2/pkg/sandbox"
 	"github.com/kubestellar/hive/v2/pkg/tracing"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -106,6 +108,11 @@ type AgentProcess struct {
 	lastInferKickMarks int       // no-action watchdog: tool-marker count in pane+scrollback just after kick delivery
 	actionNudgeSent    bool      // no-action watchdog: at most one action nudge per kick
 	ActionNudges       int       // total prose-only-response action nudges sent (surfaced to the dashboard)
+	// sandboxResumeAfterCancel is set when an operator resumes a paused
+	// sandbox agent while the canceled sandbox goroutine is still draining.
+	// The completion handler then turns the expected cancellation into Idle
+	// instead of Failed.
+	sandboxResumeAfterCancel bool
 
 	// awaitingBobKey marks an agent that launchInTmux parked in StateFailed
 	// for the single, fully-recoverable reason "bob backend with no API key".
@@ -138,16 +145,27 @@ func effectiveBackend(agent *AgentProcess) string {
 
 // ProjectContext holds project-level config injected into agent boot prompts.
 type ProjectContext struct {
-	Org        string
-	Repos      []string
-	ACMMLevel  int
-	PRsAllowed bool
-	PolicyDir  string
+	Org             string
+	Repos           []string
+	PrimaryRepoName string
+	ACMMLevel       int
+	PRsAllowed      bool
+	PolicyDir       string
 	// AppAuthoredPRs mirrors config github.app_authored_prs: when true, push-
 	// capable agents get the App installation token as GITHUB_TOKEN so the GitHub
 	// MCP server authors PRs/commits as the App bot. Default false → no token is
 	// injected and behavior is unchanged (opt-in per hive).
 	AppAuthoredPRs bool
+}
+
+func (p ProjectContext) PrimaryRepo() string {
+	if strings.TrimSpace(p.PrimaryRepoName) != "" {
+		return strings.TrimPrefix(p.PrimaryRepoName, p.Org+"/")
+	}
+	if len(p.Repos) > 0 {
+		return strings.TrimPrefix(p.Repos[0], p.Org+"/")
+	}
+	return ""
 }
 
 type Manager struct {
@@ -217,6 +235,12 @@ type Manager struct {
 	// non-reentrant RWMutex, so reading the callback under a second Lock there
 	// would deadlock the kick path.
 	recordPromptCallback atomic.Pointer[func(agent, trigger, prompt string)]
+	sandboxConfig        config.AgentSandboxConfig
+	sandboxLauncher      sandbox.Launcher
+	sandboxRunner        sandboxCommandRunner
+	sandboxPushMinter    pushbroker.TokenMinter
+	sandboxPRClient      PRCreator
+	sandboxAuditCallback atomic.Pointer[func(agent, action, detail string)]
 }
 
 // SetPersistPauseCallback wires a function that persists an agent's paused
@@ -237,6 +261,45 @@ func (m *Manager) SetRecordPromptCallback(fn func(agent, trigger, prompt string)
 		return
 	}
 	m.recordPromptCallback.Store(&fn)
+}
+
+// SetSandboxConfig wires the disabled-by-default sandbox kick executor gate.
+func (m *Manager) SetSandboxConfig(cfg config.AgentSandboxConfig) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sandboxConfig = cfg
+}
+
+func (m *Manager) SetSandboxLauncher(l sandbox.Launcher) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sandboxLauncher = l
+}
+
+func (m *Manager) setSandboxRunnerForTest(r sandboxCommandRunner) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sandboxRunner = r
+}
+
+func (m *Manager) SetSandboxPushMinter(minter pushbroker.TokenMinter) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sandboxPushMinter = minter
+}
+
+func (m *Manager) SetSandboxPRClient(client PRCreator) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sandboxPRClient = client
+}
+
+func (m *Manager) SetSandboxAuditCallback(fn func(agent, action, detail string)) {
+	if fn == nil {
+		m.sandboxAuditCallback.Store(nil)
+		return
+	}
+	m.sandboxAuditCallback.Store(&fn)
 }
 
 // recordPrompt fires the record-prompt callback if one is wired. Safe to call
@@ -688,6 +751,21 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 
 	if agent.State == StateRunning {
 		return fmt.Errorf("agent %s already running", name)
+	}
+
+	if m.agentSandboxEnabledLocked(agent) {
+		if agent.Paused {
+			agent.State = StatePaused
+			m.logger.Info("sandbox agent starting paused", "name", agent.Name, "trigger", agent.PausedTrigger, "persisted", agent.Config.Paused)
+			return nil
+		}
+		now := time.Now()
+		agent.State = StateIdle
+		agent.StartedAt = &now
+		agent.HasLaunched = true
+		agent.LaunchedMode = m.agentMode(agent)
+		m.logger.Info("audit: sandbox agent ready", "name", name)
+		return nil
 	}
 
 	m.sanitizeGitRemotes(agent)
@@ -2545,6 +2623,9 @@ func (m *Manager) CheckAndRestartCrashedAgents(ctx context.Context) []string {
 		if agent.Config.OnDemand {
 			continue
 		}
+		if m.agentSandboxEnabledLocked(agent) {
+			continue
+		}
 		if !m.tmuxSessionExistsForAgent(agent) {
 			var uptimeSeconds float64
 			if agent.StartedAt != nil {
@@ -2823,6 +2904,10 @@ func (m *Manager) SendKick(name string, message string) error {
 		return fmt.Errorf("agent %s not found", name)
 	}
 
+	if m.agentSandboxEnabledLocked(agent) {
+		return m.startSandboxKickLocked(agent, message)
+	}
+
 	if agent.State != StateRunning {
 		return fmt.Errorf("agent %s cannot be kicked: %s", name, notRunningReason(agent))
 	}
@@ -2965,6 +3050,175 @@ func (m *Manager) deliverKickLocked(agent *AgentProcess, message, trigger string
 	// only carry a truncated preview, which is not enough to answer "what was
 	// my agent asked to do?".
 	m.recordPrompt(agent.Name, trigger, message)
+}
+
+func (m *Manager) agentSandboxEnabledLocked(agent *AgentProcess) bool {
+	return agent != nil && agent.Config.SandboxEnabled(m.sandboxConfig)
+}
+
+func (m *Manager) startSandboxKickLocked(agent *AgentProcess, message string) error {
+	if agent.Paused || agent.State == StatePaused {
+		return fmt.Errorf("agent %s cannot be kicked: %s", agent.Name, notRunningReason(agent))
+	}
+	if agent.State == StateStopped {
+		return fmt.Errorf("agent %s cannot be kicked: %s", agent.Name, notRunningReason(agent))
+	}
+	if agent.State == StateRunning {
+		return fmt.Errorf("agent %s cannot be kicked: sandbox execution already running", agent.Name)
+	}
+	if strings.TrimSpace(m.sandboxConfig.Image) == "" && strings.TrimSpace(agent.Config.SandboxImage(m.sandboxConfig)) == "" {
+		return fmt.Errorf("agent %s sandbox image is not configured", agent.Name)
+	}
+	repo := m.project.PrimaryRepo()
+	if repo == "" {
+		return fmt.Errorf("agent %s sandbox execution requires a primary repo", agent.Name)
+	}
+	now := time.Now()
+	agent.State = StateRunning
+	agent.StartedAt = &now
+	agent.LastKick = &now
+	agent.LastKickMessage = message
+	agent.KickRefused = false
+	agent.KickRefusalReason = ""
+	agent.LastError = ""
+	agent.LaunchedMode = m.agentMode(agent)
+	agent.HasLaunched = true
+	snippet := truncateStr(message, 120)
+	if len(agent.KickHistory) >= kickHistoryCapacity {
+		agent.KickHistory = agent.KickHistory[1:]
+	}
+	agent.KickHistory = append(agent.KickHistory, KickRecord{Timestamp: now, Agent: agent.Name, Snippet: snippet})
+	if agent.OutputBuffer != nil {
+		agent.OutputBuffer.Write("sandbox kick started")
+	}
+	m.recordPrompt(agent.Name, "sandbox-kick", message)
+	m.logger.Info("audit: sandbox agent kicked", "name", agent.Name, "repo", repo)
+
+	spec := SandboxKickSpec{
+		Agent: agent.Name,
+		AgentConfig: configSnapshot{
+			Backend:   effectiveBackend(agent),
+			Model:     agent.Config.Model,
+			LaunchCmd: agent.Config.LaunchCmd,
+		},
+		Message:      message,
+		Org:          m.project.Org,
+		Repo:         repo,
+		WorkspaceDir: m.sandboxWorkspaceDirLocked(),
+		Image:        agent.Config.SandboxImage(m.sandboxConfig),
+		EnvAllowlist: agent.Config.SandboxEnvAllowlist(m.sandboxConfig),
+		NetworkMode:  agent.Config.SandboxNetworkMode(m.sandboxConfig),
+		Timeout:      time.Duration(agent.Config.SandboxTimeoutS(m.sandboxConfig)) * time.Second,
+	}
+	runCtx, cancel := context.WithCancel(context.Background())
+	agent.cancel = cancel
+	launcher, runner := m.sandboxLauncher, m.sandboxRunner
+	cloneMinter := m.tieredSandboxMinterLocked(m.agentMode(agent).TokenTier())
+	var pushMinter pushbroker.TokenMinter
+	var prClient PRCreator
+	pushEnabled := false
+	if m.agentMode(agent).CanPush() && m.project.PRsAllowed {
+		pushMinter = cloneMinter
+		prClient = m.sandboxPRClient
+		pushEnabled = true
+	}
+	go m.runSandboxKick(runCtx, agent.Name, spec, launcher, runner, cloneMinter, pushMinter, pushEnabled, prClient)
+	return nil
+}
+
+func (m *Manager) sandboxWorkspaceDirLocked() string {
+	if strings.TrimSpace(m.sandboxConfig.WorkspaceDir) != "" {
+		return m.sandboxConfig.WorkspaceDir
+	}
+	return filepath.Join(m.workDir, "sandbox")
+}
+
+func (m *Manager) tieredSandboxMinterLocked(tier string) pushbroker.TokenMinter {
+	switch minter := m.sandboxPushMinter.(type) {
+	case pushbroker.GitHubAppMinter:
+		minter.Tier = tier
+		return minter
+	case *pushbroker.GitHubAppMinter:
+		if minter == nil {
+			return nil
+		}
+		cp := *minter
+		cp.Tier = tier
+		return cp
+	default:
+		return m.sandboxPushMinter
+	}
+}
+
+func (m *Manager) runSandboxKick(ctx context.Context, name string, spec SandboxKickSpec, launcher sandbox.Launcher, runner sandboxCommandRunner, cloneMinter, minter pushbroker.TokenMinter, pushEnabled bool, prClient PRCreator) {
+	exec := &SandboxExecutor{
+		Launcher:    launcher,
+		Runner:      runner,
+		CloneMinter: cloneMinter,
+		Minter:      minter,
+		PushEnabled: pushEnabled,
+		PRClient:    prClient,
+		Logger:      m.logger,
+	}
+	res, err := exec.Run(ctx, spec)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	agent, ok := m.agents[name]
+	if !ok {
+		return
+	}
+	agent.cancel = nil
+	if err != nil {
+		if agent.sandboxResumeAfterCancel {
+			agent.sandboxResumeAfterCancel = false
+			agent.State = StateIdle
+			agent.LastError = ""
+			if agent.OutputBuffer != nil {
+				agent.OutputBuffer.Write("sandbox kick cancelled during resume")
+			}
+			m.auditSandbox(name, "sandbox_cancelled", "sandbox kick cancelled while resuming")
+			return
+		}
+		if agent.Paused || agent.State == StatePaused {
+			agent.State = StatePaused
+		} else if agent.State != StateStopped {
+			agent.State = StateFailed
+		}
+		agent.LastError = err.Error()
+		if agent.OutputBuffer != nil {
+			agent.OutputBuffer.Write("sandbox kick failed: " + err.Error())
+		}
+		m.auditSandbox(name, "sandbox_failed", err.Error())
+		if res.Broker != nil && res.Broker.Error != "" {
+			m.auditSandbox(name, "sandbox_broker_rejected", res.Broker.Error)
+		}
+		return
+	}
+	agent.sandboxResumeAfterCancel = false
+	if agent.Paused || agent.State == StatePaused {
+		agent.State = StatePaused
+	} else if agent.State != StateStopped {
+		agent.State = StateIdle
+	}
+	agent.LastError = ""
+	if agent.OutputBuffer != nil {
+		msg := fmt.Sprintf("sandbox kick complete: commits=%d", res.CommitCount)
+		if res.PR != nil && res.PR.URL != "" {
+			msg += " pr=" + res.PR.URL
+		}
+		agent.OutputBuffer.Write(msg)
+	}
+	detail := fmt.Sprintf("workspace=%s commits=%d branch=%s", res.Workspace, res.CommitCount, res.Branch)
+	if res.PR != nil && res.PR.URL != "" {
+		detail += " pr=" + res.PR.URL
+	}
+	m.auditSandbox(name, "sandbox_complete", detail)
+}
+
+func (m *Manager) auditSandbox(agent, action, detail string) {
+	if fn := m.sandboxAuditCallback.Load(); fn != nil && *fn != nil {
+		(*fn)(agent, action, detail)
+	}
 }
 
 // deliverStartupKick delivers a bootstrap prompt to a freshly launched agent
@@ -5056,7 +5310,13 @@ func (m *Manager) Pause(name, trigger, reason string) error {
 	agent.PausedReason = reason
 	agent.PausedTrigger = trigger
 	if agent.State == StateRunning {
-		m.tmuxSendKeysForAgent(agent, "C-c", "")
+		if agent.cancel != nil {
+			agent.cancel()
+		}
+		agent.sandboxResumeAfterCancel = false
+		if !m.agentSandboxEnabledLocked(agent) {
+			m.tmuxSendKeysForAgent(agent, "C-c", "")
+		}
 	}
 	agent.State = StatePaused
 	agent.Config.Paused = true
@@ -5102,6 +5362,28 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 	agent.PausedReason = ""
 	agent.PausedTrigger = ""
 	needsRelaunch := agent.State == StatePaused
+	if m.agentSandboxEnabledLocked(agent) {
+		if needsRelaunch {
+			if agent.cancel != nil {
+				agent.sandboxResumeAfterCancel = true
+			} else {
+				agent.State = StateIdle
+				if agent.StartedAt == nil {
+					now := time.Now()
+					agent.StartedAt = &now
+				}
+			}
+		}
+		m.mu.Unlock()
+		m.logger.Info("audit: sandbox agent resumed",
+			"name", name,
+			"trigger", trigger,
+			"reason", reason,
+			"prev_trigger", prevTrigger,
+			"prev_reason", prevReason,
+		)
+		return nil
+	}
 	if needsRelaunch {
 		agent.forceRelaunch = true
 	}

--- a/v2/pkg/agent/sandbox_executor.go
+++ b/v2/pkg/agent/sandbox_executor.go
@@ -1,0 +1,421 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+	"github.com/kubestellar/hive/v2/pkg/outputschema"
+	"github.com/kubestellar/hive/v2/pkg/pushbroker"
+	"github.com/kubestellar/hive/v2/pkg/sandbox"
+)
+
+const (
+	DefaultSandboxKickTimeout = 45 * time.Minute
+	defaultSandboxBaseRef     = "main"
+	defaultSandboxNetworkMode = sandbox.NetworkModeRestricted
+	sandboxPromptRelPath      = ".hive/kick-prompt.txt"
+	sandboxTranscriptRelPath  = ".hive/sandbox-transcript.log"
+)
+
+type sandboxCommandRunner interface {
+	Run(ctx context.Context, dir string, env []string, name string, args ...string) ([]byte, error)
+}
+
+type sandboxExecRunner struct{}
+
+func (sandboxExecRunner) Run(ctx context.Context, dir string, env []string, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	return cmd.CombinedOutput()
+}
+
+type PRCreator interface {
+	CreatePR(ctx context.Context, repo, head, base, title, body string) (ghpkg.CreatePRResult, error)
+}
+
+type SandboxKickSpec struct {
+	Agent        string
+	AgentConfig  configSnapshot
+	Message      string
+	Org          string
+	Repo         string
+	BaseRef      string
+	Branch       string
+	WorkspaceDir string
+	Image        string
+	EnvAllowlist []string
+	NetworkMode  string
+	Timeout      time.Duration
+}
+
+type configSnapshot struct {
+	Backend   string
+	Model     string
+	LaunchCmd string
+}
+
+type SandboxKickResult struct {
+	Workspace      string
+	Branch         string
+	BaseSHA        string
+	HeadSHA        string
+	CommitCount    int
+	ReportPath     string
+	Report         *outputschema.AgentReport
+	TranscriptPath string
+	Sandbox        sandbox.Result
+	Broker         *pushbroker.Result
+	PR             *ghpkg.CreatePRResult
+	TimedOut       bool
+	Error          string
+}
+
+type SandboxExecutor struct {
+	Launcher    sandbox.Launcher
+	Runner      sandboxCommandRunner
+	CloneMinter pushbroker.TokenMinter
+	Minter      pushbroker.TokenMinter
+	PushEnabled bool
+	PRClient    PRCreator
+	Logger      *slog.Logger
+	Now         func() time.Time
+}
+
+func (e *SandboxExecutor) Run(ctx context.Context, spec SandboxKickSpec) (SandboxKickResult, error) {
+	var res SandboxKickResult
+	if spec.Timeout <= 0 {
+		spec.Timeout = DefaultSandboxKickTimeout
+	}
+	if spec.BaseRef == "" {
+		spec.BaseRef = defaultSandboxBaseRef
+	}
+	if spec.NetworkMode == "" {
+		spec.NetworkMode = defaultSandboxNetworkMode
+	}
+	if spec.Branch == "" {
+		spec.Branch = e.branchName(spec.Agent)
+	}
+	workspace, baseSHA, err := e.prepareWorkspace(ctx, spec)
+	if err != nil {
+		res.Error = err.Error()
+		return res, err
+	}
+	res.Workspace, res.Branch, res.BaseSHA = workspace, spec.Branch, baseSHA
+	if err := writeSandboxPrompt(workspace, spec.Message); err != nil {
+		res.Error = err.Error()
+		return res, err
+	}
+	command, err := sandboxCommand(spec.AgentConfig, sandboxPromptRelPath)
+	if err != nil {
+		res.Error = err.Error()
+		return res, err
+	}
+	runCtx, cancel := context.WithTimeout(ctx, spec.Timeout)
+	defer cancel()
+	sres, runErr := e.launcher().Run(runCtx, sandbox.LaunchSpec{
+		Image:          spec.Image,
+		Name:           "hive-" + sanitizeBranchPart(spec.Agent) + "-sandbox",
+		Workspace:      workspace,
+		WorkspaceMount: sandbox.DefaultWorkspaceMount,
+		WorkDir:        sandbox.DefaultWorkspaceMount,
+		Command:        command,
+		EnvAllowlist:   spec.EnvAllowlist,
+		NetworkMode:    spec.NetworkMode,
+	})
+	res.Sandbox = sres
+	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+		res.TimedOut = true
+		runErr = fmt.Errorf("sandbox kick timed out after %s", spec.Timeout)
+	}
+	res.TranscriptPath = filepath.Join(workspace, sandboxTranscriptRelPath)
+	_ = writeTranscript(res.TranscriptPath, sres)
+	res.ReportPath, res.Report = collectAgentReport(workspace)
+	headSHA, count, commitErr := e.commitsSince(ctx, workspace, baseSHA)
+	res.HeadSHA, res.CommitCount = headSHA, count
+	if runErr != nil {
+		res.Error = runErr.Error()
+		return res, runErr
+	}
+	if commitErr != nil {
+		res.Error = commitErr.Error()
+		return res, commitErr
+	}
+	if count == 0 {
+		return res, nil
+	}
+	if !e.PushEnabled {
+		return res, nil
+	}
+	if e.Minter == nil {
+		err := errors.New("sandbox push broker minter is not configured")
+		res.Error = err.Error()
+		return res, err
+	}
+	broker := &pushbroker.Broker{
+		Workspace: workspace,
+		Branch:    spec.Branch,
+		BaseRef:   baseSHA,
+		Repo:      spec.Org + "/" + spec.Repo,
+		Remote:    pushbroker.DefaultRemote,
+		Minter:    e.Minter,
+		Runner:    e.runner(),
+		Logger:    e.Logger,
+	}
+	bres, brokerErr := broker.Run(ctx)
+	res.Broker = &bres
+	if brokerErr != nil {
+		res.Error = brokerErr.Error()
+		return res, brokerErr
+	}
+	if e.PRClient != nil && bres.Pushed {
+		title := fmt.Sprintf("[%s] sandbox changes", spec.Agent)
+		body := fmt.Sprintf("Sandboxed credential-free execution result for agent `%s`.\n\nPart of #2804.", spec.Agent)
+		pr, prErr := e.PRClient.CreatePR(ctx, spec.Org+"/"+spec.Repo, spec.Branch, spec.BaseRef, title, body)
+		res.PR = &pr
+		if prErr != nil {
+			res.Error = prErr.Error()
+			return res, prErr
+		}
+	}
+	return res, nil
+}
+
+func (e *SandboxExecutor) prepareWorkspace(ctx context.Context, spec SandboxKickSpec) (string, string, error) {
+	if strings.TrimSpace(spec.Org) == "" || strings.TrimSpace(spec.Repo) == "" {
+		return "", "", errors.New("sandbox workspace prep requires org and repo")
+	}
+	if strings.TrimSpace(spec.WorkspaceDir) == "" {
+		return "", "", errors.New("sandbox workspace root is required")
+	}
+	if err := os.MkdirAll(spec.WorkspaceDir, 0o770); err != nil {
+		return "", "", err
+	}
+	workspace := filepath.Join(spec.WorkspaceDir, sanitizeBranchPart(spec.Agent)+"-"+fmt.Sprint(e.now().UnixNano()))
+	repoURL := fmt.Sprintf("https://github.com/%s/%s.git", spec.Org, spec.Repo)
+	authArgs, cleanupAuth, err := e.cloneAuthArgs(ctx, spec.Org+"/"+spec.Repo, spec.WorkspaceDir)
+	if err != nil {
+		return "", "", err
+	}
+	defer cleanupAuth()
+	cloneArgs := append(append([]string{}, authArgs...), "clone", "--no-checkout", repoURL, workspace)
+	if out, err := e.runner().Run(ctx, "", pushbroker.PushEnv(os.Environ()), "git", cloneArgs...); err != nil {
+		return "", "", fmt.Errorf("git clone: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	fetchArgs := append(append([]string{}, authArgs...), "fetch", "origin", spec.BaseRef)
+	if out, err := e.runner().Run(ctx, workspace, pushbroker.PushEnv(os.Environ()), "git", fetchArgs...); err != nil {
+		return "", "", fmt.Errorf("git fetch %s: %w: %s", spec.BaseRef, err, strings.TrimSpace(string(out)))
+	}
+	if out, err := e.runner().Run(ctx, workspace, pushbroker.PushEnv(os.Environ()), "git", "checkout", "-B", spec.Branch, "FETCH_HEAD"); err != nil {
+		return "", "", fmt.Errorf("git checkout: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	base, err := e.runner().Run(ctx, workspace, pushbroker.PushEnv(os.Environ()), "git", "rev-parse", "HEAD")
+	if err != nil {
+		return "", "", fmt.Errorf("git rev-parse HEAD: %w", err)
+	}
+	return workspace, strings.TrimSpace(string(base)), nil
+}
+
+func (e *SandboxExecutor) cloneAuthArgs(ctx context.Context, repo, dir string) ([]string, func(), error) {
+	minter := e.CloneMinter
+	if minter == nil {
+		minter = e.Minter
+	}
+	if minter == nil {
+		return nil, func() {}, nil
+	}
+	token, err := minter.MintPushToken(ctx, repo)
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("minting clone token: %w", err)
+	}
+	if strings.TrimSpace(token) == "" {
+		return nil, func() {}, errors.New("sandbox workspace prep: minter returned empty clone token")
+	}
+	path := filepath.Join(dir, ".hive-git-credentials-"+sanitizeBranchPart(repo)+"-"+fmt.Sprint(e.now().UnixNano()))
+	line := "https://x-access-token:" + token + "@github.com\n"
+	if err := os.WriteFile(path, []byte(line), 0o600); err != nil {
+		return nil, func() {}, fmt.Errorf("writing sandbox clone credential helper: %w", err)
+	}
+	cleanup := func() { _ = os.Remove(path) }
+	return []string{"-c", "credential.helper=store --file=" + path}, cleanup, nil
+}
+
+func (e *SandboxExecutor) commitsSince(ctx context.Context, workspace, baseSHA string) (string, int, error) {
+	head, err := e.runner().Run(ctx, workspace, pushbroker.PushEnv(os.Environ()), "git", "rev-parse", "HEAD")
+	if err != nil {
+		return "", 0, err
+	}
+	headSHA := strings.TrimSpace(string(head))
+	if headSHA == baseSHA {
+		return headSHA, 0, nil
+	}
+	countOut, err := e.runner().Run(ctx, workspace, pushbroker.PushEnv(os.Environ()), "git", "rev-list", "--count", baseSHA+"..HEAD")
+	if err != nil {
+		return headSHA, 0, err
+	}
+	var count int
+	_, _ = fmt.Sscanf(strings.TrimSpace(string(countOut)), "%d", &count)
+	return headSHA, count, nil
+}
+
+func sandboxCommand(cfg configSnapshot, promptRel string) ([]string, error) {
+	if strings.TrimSpace(cfg.LaunchCmd) != "" {
+		return []string{"sh", "-lc", cfg.LaunchCmd + " < " + shellQuote(promptRel)}, nil
+	}
+	backend := cfg.Backend
+	if backend == "" {
+		backend = "claude"
+	}
+	binary := sandboxBackendBinary(backend)
+	var cmd string
+	switch backend {
+	case "goose", "pi":
+		cmd = binary + " run -s"
+		if cfg.Model != "" {
+			cmd += " --model " + shellQuote(cfg.Model)
+		}
+	case "copilot":
+		cmd = binary + " --no-auto-update --allow-all"
+		if cfg.Model != "" {
+			cmd += " --model " + shellQuote(cfg.Model)
+		}
+	default:
+		cmd = binary
+		if cfg.Model != "" {
+			cmd += " --model " + shellQuote(cfg.Model)
+		}
+		if backend == "claude" || IsInferenceBackend(backend) {
+			cmd += " --dangerously-skip-permissions"
+		}
+	}
+	return []string{"sh", "-lc", cmd + " < " + shellQuote(promptRel)}, nil
+}
+
+func sandboxBackendBinary(backend string) string {
+	switch backend {
+	case "copilot":
+		return "copilot"
+	case "gemini":
+		return "gemini"
+	case "goose", "pi":
+		return "goose"
+	case "bob":
+		return "bob"
+	default:
+		return "claude"
+	}
+}
+
+func writeSandboxPrompt(workspace, message string) error {
+	path := filepath.Join(workspace, sandboxPromptRelPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o770); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(message), 0o660)
+}
+
+func writeTranscript(path string, res sandbox.Result) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o770); err != nil {
+		return err
+	}
+	var b strings.Builder
+	b.WriteString("stdout:\n")
+	b.WriteString(res.Stdout)
+	b.WriteString("\n\nstderr:\n")
+	b.WriteString(res.Stderr)
+	return os.WriteFile(path, []byte(b.String()), 0o660)
+}
+
+func collectAgentReport(workspace string) (string, *outputschema.AgentReport) {
+	candidates := []string{
+		filepath.Join(workspace, ".hive", "agent-report.json"),
+		filepath.Join(workspace, "agent-report.json"),
+	}
+	_ = filepath.WalkDir(workspace, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if strings.HasPrefix(name, outputschema.AgentReportFilePrefix) && strings.HasSuffix(name, outputschema.AgentReportFileSuffix) {
+			candidates = append(candidates, path)
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	for _, path := range candidates {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		report, err := outputschema.Validate(data)
+		if err == nil {
+			return path, report
+		}
+		var raw map[string]any
+		if json.Unmarshal(data, &raw) == nil {
+			return path, nil
+		}
+	}
+	return "", nil
+}
+
+func (e *SandboxExecutor) launcher() sandbox.Launcher {
+	if e.Launcher != nil {
+		return e.Launcher
+	}
+	return sandbox.PodmanLauncher{}
+}
+
+func (e *SandboxExecutor) runner() sandboxCommandRunner {
+	if e.Runner != nil {
+		return e.Runner
+	}
+	return sandboxExecRunner{}
+}
+
+func (e *SandboxExecutor) now() time.Time {
+	if e.Now != nil {
+		return e.Now()
+	}
+	return time.Now().UTC()
+}
+
+func (e *SandboxExecutor) branchName(agentName string) string {
+	return "hive/" + sanitizeBranchPart(agentName) + "/" + e.now().Format("20060102150405")
+}
+
+func sanitizeBranchPart(s string) string {
+	s = strings.TrimSpace(strings.ToLower(s))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range s {
+		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if ok {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		return "agent"
+	}
+	return out
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}

--- a/v2/pkg/agent/sandbox_executor_test.go
+++ b/v2/pkg/agent/sandbox_executor_test.go
@@ -1,0 +1,408 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+	"github.com/kubestellar/hive/v2/pkg/pushbroker"
+	"github.com/kubestellar/hive/v2/pkg/sandbox"
+)
+
+type sandboxFakeRunner struct {
+	mu       sync.Mutex
+	envs     [][]string
+	pushed   bool
+	commits  int
+	cloneDir string
+	revParse int
+}
+
+func (r *sandboxFakeRunner) Run(ctx context.Context, dir string, env []string, name string, args ...string) ([]byte, error) {
+	r.mu.Lock()
+	r.envs = append(r.envs, append([]string(nil), env...))
+	r.mu.Unlock()
+	if name != "git" {
+		return nil, errors.New("unexpected command")
+	}
+	effective := stripGitConfigArgs(args)
+	joined := strings.Join(effective, " ")
+	switch {
+	case len(effective) >= 4 && effective[0] == "clone":
+		workspace := effective[len(effective)-1]
+		r.cloneDir = workspace
+		if err := os.MkdirAll(filepath.Join(workspace, ".git"), 0o770); err != nil {
+			return nil, err
+		}
+		return nil, os.WriteFile(filepath.Join(workspace, ".git", "config"), []byte("[remote]\nurl = "+effective[len(effective)-2]+"\n"), 0o660)
+	case joined == "fetch origin main", strings.HasPrefix(joined, "checkout -B "):
+		return []byte("ok\n"), nil
+	case joined == "rev-parse HEAD":
+		r.revParse++
+		if r.commits > 0 && r.revParse > 1 {
+			return []byte("headsha\n"), nil
+		}
+		return []byte("basesha\n"), nil
+	case joined == "rev-list --count basesha..HEAD":
+		if r.commits > 0 {
+			return []byte("1\n"), nil
+		}
+		return []byte("0\n"), nil
+	case joined == "rev-parse --verify basesha":
+		return []byte("basesha\n"), nil
+	case joined == "diff --name-only basesha...HEAD":
+		return []byte("file.txt\n"), nil
+	case joined == "diff --no-ext-diff basesha...HEAD":
+		return []byte("diff --git a/file.txt b/file.txt\n"), nil
+	case strings.Contains(joined, "push ") && strings.Contains(joined, " origin HEAD:refs/heads/"):
+		r.pushed = true
+		return []byte("pushed\n"), nil
+	default:
+		return []byte(""), nil
+	}
+}
+
+func stripGitConfigArgs(args []string) []string {
+	out := append([]string(nil), args...)
+	for len(out) >= 2 && out[0] == "-c" {
+		out = out[2:]
+	}
+	return out
+}
+
+type sandboxFakeLauncher struct {
+	waitForCancel bool
+}
+
+func (l sandboxFakeLauncher) Run(ctx context.Context, spec sandbox.LaunchSpec) (sandbox.Result, error) {
+	if l.waitForCancel {
+		<-ctx.Done()
+		return sandbox.Result{Stderr: ctx.Err().Error(), ExitCode: -1}, ctx.Err()
+	}
+	if err := os.WriteFile(filepath.Join(spec.Workspace, "agent-report.json"), []byte(`{"lane":"scanner","kind":"summary","findings":[],"prs_opened":[],"beads_filed":[],"summary":"ok"}`), 0o660); err != nil {
+		return sandbox.Result{}, err
+	}
+	return sandbox.Result{Stdout: "done\n"}, nil
+}
+
+type sandboxFakeMinter struct{}
+
+func (sandboxFakeMinter) MintPushToken(context.Context, string) (string, error) {
+	return "ghs_fake", nil
+}
+
+type sandboxFakePR struct{ called bool }
+
+func (p *sandboxFakePR) CreatePR(context.Context, string, string, string, string, string) (ghpkg.CreatePRResult, error) {
+	p.called = true
+	return ghpkg.CreatePRResult{Number: 1, URL: "https://example.test/pr/1"}, nil
+}
+
+func TestSandboxExecutorWorkspacePrepSanitizesCredentials(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "ghs_secret")
+	t.Setenv("SAFE_ENV", "ok")
+	root := t.TempDir()
+	runner := &sandboxFakeRunner{}
+	exec := &SandboxExecutor{Runner: runner, Launcher: sandboxFakeLauncher{}, Now: func() time.Time { return time.Unix(1, 0) }}
+	res, err := exec.Run(context.Background(), SandboxKickSpec{
+		Agent:        "scanner",
+		AgentConfig:  configSnapshot{Backend: "claude"},
+		Message:      "fix",
+		Org:          "kubestellar",
+		Repo:         "hive",
+		WorkspaceDir: root,
+		Image:        "agent-image",
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Workspace == "" || res.Report == nil || res.TranscriptPath == "" {
+		t.Fatalf("result missing collected artifacts: %+v", res)
+	}
+	for _, env := range runner.envs {
+		for _, pair := range env {
+			if strings.HasPrefix(pair, "GITHUB_TOKEN=") {
+				t.Fatalf("credential leaked to git environment: %q", pair)
+			}
+		}
+	}
+	data, err := os.ReadFile(filepath.Join(res.Workspace, ".git", "config"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "ghs_secret") {
+		t.Fatal("credential leaked into workspace git config")
+	}
+}
+
+func TestSandboxExecutorBrokerHandoff(t *testing.T) {
+	tests := []struct {
+		name       string
+		commits    int
+		wantPush   bool
+		wantPR     bool
+		withBroker bool
+	}{
+		{name: "no commits skips broker", commits: 0},
+		{name: "commits push and open pr", commits: 1, wantPush: true, wantPR: true, withBroker: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &sandboxFakeRunner{commits: tt.commits}
+			pr := &sandboxFakePR{}
+			exec := &SandboxExecutor{Runner: runner, Launcher: sandboxFakeLauncher{}, PRClient: pr, PushEnabled: tt.withBroker}
+			if tt.withBroker {
+				exec.Minter = sandboxFakeMinter{}
+			}
+			_, err := exec.Run(context.Background(), SandboxKickSpec{
+				Agent: "scanner", AgentConfig: configSnapshot{Backend: "claude"}, Message: "fix",
+				Org: "kubestellar", Repo: "hive", WorkspaceDir: t.TempDir(), Image: "agent-image",
+			})
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if runner.pushed != tt.wantPush {
+				t.Fatalf("pushed=%v want %v", runner.pushed, tt.wantPush)
+			}
+			if pr.called != tt.wantPR {
+				t.Fatalf("pr.called=%v want %v", pr.called, tt.wantPR)
+			}
+		})
+	}
+}
+
+func TestSandboxExecutorTimeout(t *testing.T) {
+	runner := &sandboxFakeRunner{}
+	exec := &SandboxExecutor{Runner: runner, Launcher: sandboxFakeLauncher{waitForCancel: true}}
+	res, err := exec.Run(context.Background(), SandboxKickSpec{
+		Agent: "scanner", AgentConfig: configSnapshot{Backend: "claude"}, Message: "fix",
+		Org: "kubestellar", Repo: "hive", WorkspaceDir: t.TempDir(), Image: "agent-image", Timeout: time.Millisecond,
+	})
+	if err == nil || !res.TimedOut {
+		t.Fatalf("expected timeout, got err=%v result=%+v", err, res)
+	}
+}
+
+func TestManagerSandboxStateMachine(t *testing.T) {
+	yes := true
+	cfg := map[string]config.AgentConfig{
+		"scanner": {Backend: "claude", Sandbox: &config.AgentSandboxOverride{Enabled: &yes}},
+	}
+	m := NewManager(cfg, quietTestLogger(), ProjectContext{Org: "kubestellar", Repos: []string{"hive"}})
+	m.SetSandboxConfig(config.AgentSandboxConfig{Enabled: true, Image: "agent-image", WorkspaceDir: t.TempDir()})
+	m.SetSandboxLauncher(sandboxFakeLauncher{})
+	m.setSandboxRunnerForTest(&sandboxFakeRunner{})
+	if err := m.Start(context.Background(), "scanner"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if got := m.AllStatuses()["scanner"].State; got != StateIdle {
+		t.Fatalf("state after Start=%s want idle", got)
+	}
+	if err := m.SendKick("scanner", "fix"); err != nil {
+		t.Fatalf("SendKick: %v", err)
+	}
+	if err := m.SendKick("scanner", "again"); err == nil {
+		t.Fatal("second kick while sandbox is running should be refused")
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if got := m.AllStatuses()["scanner"].State; got == StateIdle {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("sandbox agent did not return to idle: %+v", m.AllStatuses()["scanner"])
+}
+
+func TestManagerSandboxRespectsPause(t *testing.T) {
+	yes := true
+	cfg := map[string]config.AgentConfig{
+		"scanner": {Backend: "claude", Paused: true, Sandbox: &config.AgentSandboxOverride{Enabled: &yes}},
+	}
+	m := NewManager(cfg, quietTestLogger(), ProjectContext{Org: "kubestellar", Repos: []string{"hive"}})
+	m.SetSandboxConfig(config.AgentSandboxConfig{Enabled: true, Image: "agent-image", WorkspaceDir: t.TempDir()})
+	if err := m.Start(context.Background(), "scanner"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if got := m.AllStatuses()["scanner"].State; got != StatePaused {
+		t.Fatalf("state after Start=%s want paused", got)
+	}
+	if err := m.SendKick("scanner", "fix"); err == nil {
+		t.Fatal("paused sandbox agent should reject kicks")
+	}
+	if err := m.Resume(context.Background(), "scanner", "test", "resume"); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if got := m.AllStatuses()["scanner"].State; got != StateIdle {
+		t.Fatalf("state after Resume=%s want idle", got)
+	}
+}
+
+func TestManagerSandboxPauseCancelsRunningKick(t *testing.T) {
+	yes := true
+	cfg := map[string]config.AgentConfig{
+		"scanner": {Backend: "claude", Sandbox: &config.AgentSandboxOverride{Enabled: &yes}},
+	}
+	m := NewManager(cfg, quietTestLogger(), ProjectContext{Org: "kubestellar", Repos: []string{"hive"}})
+	m.SetSandboxConfig(config.AgentSandboxConfig{Enabled: true, Image: "agent-image", WorkspaceDir: t.TempDir()})
+	m.SetSandboxLauncher(sandboxFakeLauncher{waitForCancel: true})
+	m.setSandboxRunnerForTest(&sandboxFakeRunner{})
+	if err := m.Start(context.Background(), "scanner"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := m.SendKick("scanner", "fix"); err != nil {
+		t.Fatalf("SendKick: %v", err)
+	}
+	if err := m.Pause("scanner", "test", "pause while running"); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		m.mu.RLock()
+		done := m.agents["scanner"].cancel == nil && m.agents["scanner"].State == StatePaused
+		m.mu.RUnlock()
+		if done {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("sandbox agent did not stay paused after cancellation: %+v", m.AllStatuses()["scanner"])
+}
+
+func TestManagerSandboxResumeWhileCancelDrainsReturnsIdle(t *testing.T) {
+	yes := true
+	cfg := map[string]config.AgentConfig{
+		"scanner": {Backend: "claude", Sandbox: &config.AgentSandboxOverride{Enabled: &yes}},
+	}
+	m := NewManager(cfg, quietTestLogger(), ProjectContext{Org: "kubestellar", Repos: []string{"hive"}})
+	m.SetSandboxConfig(config.AgentSandboxConfig{Enabled: true, Image: "agent-image", WorkspaceDir: t.TempDir()})
+	m.SetSandboxLauncher(sandboxFakeLauncher{waitForCancel: true})
+	m.setSandboxRunnerForTest(&sandboxFakeRunner{})
+	if err := m.Start(context.Background(), "scanner"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := m.SendKick("scanner", "fix"); err != nil {
+		t.Fatalf("SendKick: %v", err)
+	}
+	if err := m.Pause("scanner", "test", "pause while running"); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+	if err := m.Resume(context.Background(), "scanner", "test", "resume immediately"); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		m.mu.RLock()
+		done := m.agents["scanner"].cancel == nil && m.agents["scanner"].State == StateIdle
+		m.mu.RUnlock()
+		if done {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("sandbox agent did not return idle after resumed cancellation: %+v", m.AllStatuses()["scanner"])
+}
+
+func TestManagerSandboxRunningSkippedByTmuxCrashDetector(t *testing.T) {
+	yes := true
+	cfg := map[string]config.AgentConfig{
+		"scanner": {Backend: "claude", Sandbox: &config.AgentSandboxOverride{Enabled: &yes}},
+	}
+	m := NewManager(cfg, quietTestLogger(), ProjectContext{Org: "kubestellar", Repos: []string{"hive"}})
+	m.SetSandboxConfig(config.AgentSandboxConfig{Enabled: true, Image: "agent-image", WorkspaceDir: t.TempDir()})
+	m.SetSandboxLauncher(sandboxFakeLauncher{waitForCancel: true})
+	m.setSandboxRunnerForTest(&sandboxFakeRunner{})
+	if err := m.Start(context.Background(), "scanner"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := m.SendKick("scanner", "fix"); err != nil {
+		t.Fatalf("SendKick: %v", err)
+	}
+	if restarted := m.CheckAndRestartCrashedAgents(context.Background()); len(restarted) != 0 {
+		t.Fatalf("sandbox agent should not be tmux-restarted: %v", restarted)
+	}
+	if got := m.AllStatuses()["scanner"].State; got != StateRunning {
+		t.Fatalf("state=%s want running", got)
+	}
+	if err := m.Pause("scanner", "test", "cleanup"); err != nil {
+		t.Fatalf("Pause cleanup: %v", err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		m.mu.RLock()
+		done := m.agents["scanner"].cancel == nil
+		m.mu.RUnlock()
+		if done {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("sandbox cleanup did not finish")
+}
+
+func TestManagerSandboxDoesNotPushWhenModeCannotPush(t *testing.T) {
+	yes := true
+	cfg := map[string]config.AgentConfig{
+		"scanner": {Backend: "claude", Sandbox: &config.AgentSandboxOverride{Enabled: &yes}},
+	}
+	runner := &sandboxFakeRunner{commits: 1}
+	pr := &sandboxFakePR{}
+	m := NewManager(cfg, quietTestLogger(), ProjectContext{Org: "kubestellar", Repos: []string{"hive"}, ACMMLevel: 1, PRsAllowed: true})
+	m.SetSandboxConfig(config.AgentSandboxConfig{Enabled: true, Image: "agent-image", WorkspaceDir: t.TempDir()})
+	m.SetSandboxLauncher(sandboxFakeLauncher{})
+	m.setSandboxRunnerForTest(runner)
+	m.SetSandboxPushMinter(sandboxFakeMinter{})
+	m.SetSandboxPRClient(pr)
+	if err := m.Start(context.Background(), "scanner"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := m.SendKick("scanner", "fix"); err != nil {
+		t.Fatalf("SendKick: %v", err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if got := m.AllStatuses()["scanner"].State; got == StateIdle {
+			if runner.pushed || pr.called {
+				t.Fatalf("non-push mode pushed=%v pr=%v", runner.pushed, pr.called)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("sandbox agent did not complete: %+v", m.AllStatuses()["scanner"])
+}
+
+func TestAgentSandboxConfigGating(t *testing.T) {
+	yes := true
+	agent := &config.AgentConfig{Sandbox: &config.AgentSandboxOverride{Enabled: &yes, NetworkMode: "none", TimeoutS: 7}}
+	global := config.AgentSandboxConfig{Enabled: true, NetworkMode: "restricted", TimeoutS: 30}
+	if !agent.SandboxEnabled(global) {
+		t.Fatal("agent should be sandbox-enabled")
+	}
+	if got := agent.SandboxNetworkMode(global); got != "none" {
+		t.Fatalf("network mode=%q", got)
+	}
+	if got := agent.SandboxTimeoutS(global); got != 7 {
+		t.Fatalf("timeout=%d", got)
+	}
+}
+
+func TestSandboxExecutorPodmanIntegrationSkippedWhenUnavailable(t *testing.T) {
+	if !sandbox.Available() {
+		t.Skip("podman not available")
+	}
+}
+
+func quietTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+var _ pushbroker.TokenMinter = sandboxFakeMinter{}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -60,6 +60,9 @@ type Config struct {
 	Retro      RetroConfig      `yaml:"retro,omitempty" json:"retro,omitempty"`
 	Review     ReviewConfig     `yaml:"review,omitempty" json:"review,omitempty"`
 	Lite       LiteConfig       `yaml:"lite,omitempty" json:"lite,omitempty"`
+	// AgentSandbox configures the phase-1 credential-free sandbox runner. It is
+	// disabled by default and agents must opt in individually.
+	AgentSandbox AgentSandboxConfig `yaml:"agent_sandbox,omitempty" json:"agent_sandbox,omitempty"`
 
 	// RemovedAgents are agent names an operator deliberately deleted. It is a
 	// TOMBSTONE list, and it exists because deletion had no durable record
@@ -180,6 +183,21 @@ type MintConfig struct {
 	// MaxTTLSeconds bounds a minted token's lifetime. 0 uses the package default
 	// (15m). The value is clamped to the package hard cap (1h) regardless.
 	MaxTTLSeconds int `yaml:"max_ttl_seconds,omitempty"`
+}
+
+// AgentSandboxConfig controls the podman-rootless sandbox launcher. The top-
+// level block is a global gate; per-agent config can opt specific agents in.
+type AgentSandboxConfig struct {
+	Enabled      bool     `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Image        string   `yaml:"image,omitempty" json:"image,omitempty"`
+	EnvAllowlist []string `yaml:"env_allowlist,omitempty" json:"env_allowlist,omitempty"`
+}
+
+// AgentSandboxOverride is the per-agent sandbox opt-in block.
+type AgentSandboxOverride struct {
+	Enabled      *bool    `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Image        string   `yaml:"image,omitempty" json:"image,omitempty"`
+	EnvAllowlist []string `yaml:"env_allowlist,omitempty" json:"env_allowlist,omitempty"`
 }
 
 // IoscanConfig gates the pkg/ioscan input/output security scanner (prompt-
@@ -695,6 +713,9 @@ type AgentConfig struct {
 	Mode             string                  `yaml:"mode" json:"mode,omitempty"`
 	OnDemand         bool                    `yaml:"on_demand" json:"on_demand,omitempty"`
 	CavemanMode      string                  `yaml:"caveman_mode" json:"caveman_mode,omitempty"`
+	// Sandbox opts this agent into phase-1 sandbox execution when the global
+	// agent_sandbox.enabled gate is also true.
+	Sandbox *AgentSandboxOverride `yaml:"sandbox,omitempty" json:"sandbox,omitempty"`
 
 	// Channels declares how this agent gets triggered (kick, webhook, discord, schedule, bead).
 	// When nil/empty, the agent uses governor timer kicks by default (implicit kick channel).
@@ -761,6 +782,32 @@ func (a *AgentConfig) ShouldIncludeRepos() bool {
 		return *a.IncludeRepos
 	}
 	return true
+}
+
+// SandboxEnabled reports whether an agent's per-agent sandbox block opts it in
+// under the global phase-1 gate.
+func (a *AgentConfig) SandboxEnabled(global AgentSandboxConfig) bool {
+	if !global.Enabled || a == nil || a.Sandbox == nil || a.Sandbox.Enabled == nil {
+		return false
+	}
+	return *a.Sandbox.Enabled
+}
+
+// SandboxImage returns the per-agent image override, then the global default.
+func (a *AgentConfig) SandboxImage(global AgentSandboxConfig) string {
+	if a != nil && a.Sandbox != nil && a.Sandbox.Image != "" {
+		return a.Sandbox.Image
+	}
+	return global.Image
+}
+
+// SandboxEnvAllowlist returns the per-agent env allowlist when set; otherwise
+// the global allowlist. Credentials are still filtered by pkg/sandbox.
+func (a *AgentConfig) SandboxEnvAllowlist(global AgentSandboxConfig) []string {
+	if a != nil && a.Sandbox != nil && len(a.Sandbox.EnvAllowlist) > 0 {
+		return append([]string(nil), a.Sandbox.EnvAllowlist...)
+	}
+	return append([]string(nil), global.EnvAllowlist...)
 }
 
 // GetBeadRole returns the bead role, defaulting to "worker".

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -191,6 +191,9 @@ type AgentSandboxConfig struct {
 	Enabled      bool     `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	Image        string   `yaml:"image,omitempty" json:"image,omitempty"`
 	EnvAllowlist []string `yaml:"env_allowlist,omitempty" json:"env_allowlist,omitempty"`
+	NetworkMode  string   `yaml:"network_mode,omitempty" json:"network_mode,omitempty"`
+	TimeoutS     int      `yaml:"timeout_s,omitempty" json:"timeout_s,omitempty"`
+	WorkspaceDir string   `yaml:"workspace_dir,omitempty" json:"workspace_dir,omitempty"`
 }
 
 // AgentSandboxOverride is the per-agent sandbox opt-in block.
@@ -198,6 +201,8 @@ type AgentSandboxOverride struct {
 	Enabled      *bool    `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	Image        string   `yaml:"image,omitempty" json:"image,omitempty"`
 	EnvAllowlist []string `yaml:"env_allowlist,omitempty" json:"env_allowlist,omitempty"`
+	NetworkMode  string   `yaml:"network_mode,omitempty" json:"network_mode,omitempty"`
+	TimeoutS     int      `yaml:"timeout_s,omitempty" json:"timeout_s,omitempty"`
 }
 
 // IoscanConfig gates the pkg/ioscan input/output security scanner (prompt-
@@ -808,6 +813,24 @@ func (a *AgentConfig) SandboxEnvAllowlist(global AgentSandboxConfig) []string {
 		return append([]string(nil), a.Sandbox.EnvAllowlist...)
 	}
 	return append([]string(nil), global.EnvAllowlist...)
+}
+
+// SandboxNetworkMode returns the per-agent network override, then the global
+// sandbox network mode. Empty lets the executor choose its safe default.
+func (a *AgentConfig) SandboxNetworkMode(global AgentSandboxConfig) string {
+	if a != nil && a.Sandbox != nil && a.Sandbox.NetworkMode != "" {
+		return a.Sandbox.NetworkMode
+	}
+	return global.NetworkMode
+}
+
+// SandboxTimeoutS returns the per-agent timeout override, then the global
+// timeout. Non-positive values let the executor use its default.
+func (a *AgentConfig) SandboxTimeoutS(global AgentSandboxConfig) int {
+	if a != nil && a.Sandbox != nil && a.Sandbox.TimeoutS > 0 {
+		return a.Sandbox.TimeoutS
+	}
+	return global.TimeoutS
 }
 
 // GetBeadRole returns the bead role, defaulting to "worker".

--- a/v2/pkg/config/sandbox_config_test.go
+++ b/v2/pkg/config/sandbox_config_test.go
@@ -1,0 +1,32 @@
+package config
+
+import "testing"
+
+func TestAgentSandboxOptInRequiresGlobalGateAndAgentOverride(t *testing.T) {
+	yes := true
+	no := false
+	global := AgentSandboxConfig{Enabled: true, Image: "global", EnvAllowlist: []string{"PATH"}}
+	if (&AgentConfig{}).SandboxEnabled(global) {
+		t.Fatal("missing agent override enabled sandbox")
+	}
+	if (&AgentConfig{Sandbox: &AgentSandboxOverride{Enabled: &no}}).SandboxEnabled(global) {
+		t.Fatal("explicit false enabled sandbox")
+	}
+	if (&AgentConfig{Sandbox: &AgentSandboxOverride{Enabled: &yes}}).SandboxEnabled(AgentSandboxConfig{}) {
+		t.Fatal("global disabled enabled sandbox")
+	}
+	agent := &AgentConfig{Sandbox: &AgentSandboxOverride{Enabled: &yes, Image: "agent", EnvAllowlist: []string{"HOME"}}}
+	if !agent.SandboxEnabled(global) {
+		t.Fatal("agent opt-in was not honored")
+	}
+	if got := agent.SandboxImage(global); got != "agent" {
+		t.Fatalf("image=%q", got)
+	}
+	if got := agent.SandboxEnvAllowlist(global); len(got) != 1 || got[0] != "HOME" {
+		t.Fatalf("allowlist=%v", got)
+	}
+	plain := &AgentConfig{Sandbox: &AgentSandboxOverride{Enabled: &yes}}
+	if got := plain.SandboxImage(global); got != "global" {
+		t.Fatalf("global image=%q", got)
+	}
+}

--- a/v2/pkg/pushbroker/pushbroker.go
+++ b/v2/pkg/pushbroker/pushbroker.go
@@ -1,0 +1,285 @@
+// Package pushbroker performs the trusted, credentialed post-step for sandboxed agents.
+package pushbroker
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+	"github.com/kubestellar/hive/v2/pkg/logscrub"
+)
+
+const (
+	DefaultRemote = "origin"
+	DefaultTier   = "contributor"
+)
+
+var DefaultProtectedPaths = []string{
+	".github/workflows/",
+	"bin/gh-wrapper.sh",
+	"deploy/bin/gh-wrapper.sh",
+	"policies/",
+	"OWNERS",
+	".github/OWNERS",
+}
+
+var credentialEnvPrefixes = []string{
+	"GITHUB_TOKEN=", "GH_TOKEN=", "HIVE_GITHUB_TOKEN=", "COPILOT_GITHUB_TOKEN=",
+	"GIT_ASKPASS=", "SSH_ASKPASS=",
+}
+
+type TokenMinter interface {
+	MintPushToken(ctx context.Context, repo string) (string, error)
+}
+
+type CommandRunner interface {
+	Run(ctx context.Context, dir string, env []string, name string, args ...string) ([]byte, error)
+}
+
+type ExecRunner struct{}
+
+func (ExecRunner) Run(ctx context.Context, dir string, env []string, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	return cmd.CombinedOutput()
+}
+
+type GitHubAppMinter struct {
+	Auth *ghpkg.AppAuth
+	Tier string
+}
+
+func (m GitHubAppMinter) MintPushToken(ctx context.Context, repo string) (string, error) {
+	if m.Auth == nil {
+		return "", errors.New("pushbroker: nil GitHub App auth")
+	}
+	tier := strings.TrimSpace(m.Tier)
+	if tier == "" {
+		tier = DefaultTier
+	}
+	repos := []string(nil)
+	if _, name, ok := strings.Cut(strings.TrimSpace(repo), "/"); ok && name != "" {
+		repos = []string{name}
+	}
+	return m.Auth.ScopedTokenForRepos(ctx, tier, repos)
+}
+
+type Broker struct {
+	Workspace      string
+	Branch         string
+	Repo           string
+	Remote         string
+	ProtectedPaths []string
+	Minter         TokenMinter
+	Runner         CommandRunner
+	Logger         *slog.Logger
+	Now            func() time.Time
+}
+
+type Result struct {
+	Workspace       string    `json:"workspace"`
+	Repo            string    `json:"repo"`
+	Branch          string    `json:"branch"`
+	Remote          string    `json:"remote"`
+	Commit          string    `json:"commit,omitempty"`
+	ChangedFiles    []string  `json:"changed_files,omitempty"`
+	ProtectedReject []string  `json:"protected_reject,omitempty"`
+	SecretRejected  bool      `json:"secret_rejected"`
+	Pushed          bool      `json:"pushed"`
+	Error           string    `json:"error,omitempty"`
+	StartedAt       time.Time `json:"started_at"`
+	FinishedAt      time.Time `json:"finished_at"`
+}
+
+func (b *Broker) Run(ctx context.Context) (Result, error) {
+	res := Result{Workspace: b.Workspace, Repo: b.Repo, Branch: b.Branch, Remote: b.remote(), StartedAt: b.now()}
+	defer func() { res.FinishedAt = b.now() }()
+	if err := b.validate(); err != nil {
+		res.Error = err.Error()
+		return res, err
+	}
+	commit, err := b.git(ctx, "rev-parse", "HEAD")
+	if err != nil {
+		return b.fail(res, fmt.Errorf("reading HEAD: %w", err))
+	}
+	res.Commit = strings.TrimSpace(string(commit))
+
+	files, err := b.changedFiles(ctx)
+	if err != nil {
+		return b.fail(res, err)
+	}
+	res.ChangedFiles = files
+	if len(files) == 0 {
+		return b.fail(res, errors.New("pushbroker: no committed changes to push"))
+	}
+	if rejected := ProtectedPathViolations(files, b.protectedPaths()); len(rejected) > 0 {
+		res.ProtectedReject = rejected
+		return b.fail(res, fmt.Errorf("pushbroker: protected paths changed: %s", strings.Join(rejected, ", ")))
+	}
+	diff, err := b.outgoingDiff(ctx)
+	if err != nil {
+		return b.fail(res, err)
+	}
+	if loc := logscrub.TokenPattern.FindString(diff); loc != "" {
+		res.SecretRejected = true
+		return b.fail(res, errors.New("pushbroker: outgoing diff contains a token-like secret"))
+	}
+	token, err := b.Minter.MintPushToken(ctx, b.Repo)
+	if err != nil {
+		return b.fail(res, fmt.Errorf("minting push token: %w", err))
+	}
+	if strings.TrimSpace(token) == "" {
+		return b.fail(res, errors.New("pushbroker: minter returned empty token"))
+	}
+	args := []string{"-c", "http.extraHeader=Authorization: Bearer " + token, "push", b.remote(), "HEAD:refs/heads/" + b.Branch}
+	if _, err := b.runner().Run(ctx, b.Workspace, PushEnv(os.Environ()), "git", args...); err != nil {
+		return b.fail(res, fmt.Errorf("git push failed: %w", err))
+	}
+	res.Pushed = true
+	return res, nil
+}
+
+func (b *Broker) validate() error {
+	if strings.TrimSpace(b.Workspace) == "" || strings.TrimSpace(b.Branch) == "" || strings.TrimSpace(b.Repo) == "" {
+		return errors.New("pushbroker: workspace, branch, and repo are required")
+	}
+	if b.Minter == nil {
+		return errors.New("pushbroker: token minter is required")
+	}
+	info, err := os.Stat(b.Workspace)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("pushbroker: workspace is not a directory: %w", err)
+	}
+	gitDir := filepath.Join(b.Workspace, ".git")
+	if info, err := os.Stat(gitDir); err != nil || !info.IsDir() {
+		return fmt.Errorf("pushbroker: workspace is not a git repository")
+	}
+	return nil
+}
+
+func (b *Broker) changedFiles(ctx context.Context) ([]string, error) {
+	base := b.remoteRef()
+	if _, err := b.git(ctx, "rev-parse", "--verify", base); err == nil {
+		out, err := b.git(ctx, "diff", "--name-only", base+"...HEAD")
+		return splitLines(out), err
+	}
+	out, err := b.git(ctx, "diff-tree", "--root", "--no-commit-id", "--name-only", "-r", "HEAD")
+	return splitLines(out), err
+}
+
+func (b *Broker) outgoingDiff(ctx context.Context) (string, error) {
+	base := b.remoteRef()
+	if _, err := b.git(ctx, "rev-parse", "--verify", base); err == nil {
+		out, err := b.git(ctx, "diff", "--no-ext-diff", base+"...HEAD")
+		return string(out), err
+	}
+	out, err := b.git(ctx, "show", "--format=", "--no-ext-diff", "HEAD")
+	return string(out), err
+}
+
+func (b *Broker) git(ctx context.Context, args ...string) ([]byte, error) {
+	out, err := b.runner().Run(ctx, b.Workspace, PushEnv(os.Environ()), "git", args...)
+	if err != nil {
+		return out, fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}
+
+func (b *Broker) fail(res Result, err error) (Result, error) {
+	res.Error = err.Error()
+	res.FinishedAt = b.now()
+	if b.Logger != nil {
+		b.Logger.Warn("pushbroker rejected workspace", "repo", res.Repo, "branch", res.Branch, "error", err)
+	}
+	return res, err
+}
+
+func (b *Broker) runner() CommandRunner {
+	if b.Runner != nil {
+		return b.Runner
+	}
+	return ExecRunner{}
+}
+func (b *Broker) remote() string {
+	if b.Remote != "" {
+		return b.Remote
+	}
+	return DefaultRemote
+}
+func (b *Broker) remoteRef() string { return "refs/remotes/" + b.remote() + "/" + b.Branch }
+func (b *Broker) protectedPaths() []string {
+	if len(b.ProtectedPaths) > 0 {
+		return b.ProtectedPaths
+	}
+	return DefaultProtectedPaths
+}
+func (b *Broker) now() time.Time {
+	if b.Now != nil {
+		return b.Now()
+	}
+	return time.Now().UTC()
+}
+
+func PushEnv(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		blocked := false
+		for _, prefix := range credentialEnvPrefixes {
+			if strings.HasPrefix(entry, prefix) {
+				blocked = true
+				break
+			}
+		}
+		if !blocked {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+func ProtectedPathViolations(files, protected []string) []string {
+	var rejected []string
+	for _, file := range files {
+		clean := strings.TrimPrefix(filepath.ToSlash(filepath.Clean(file)), "./")
+		for _, guard := range protected {
+			g := strings.TrimPrefix(filepath.ToSlash(filepath.Clean(guard)), "./")
+			if strings.HasSuffix(guard, "/") || strings.HasSuffix(g, "/") {
+				g = strings.TrimSuffix(g, "/") + "/"
+				if strings.HasPrefix(clean, g) {
+					rejected = append(rejected, clean)
+					break
+				}
+				continue
+			}
+			if clean == g || strings.HasPrefix(clean, strings.TrimSuffix(g, "/")+"/") && strings.HasSuffix(guard, "/") {
+				rejected = append(rejected, clean)
+				break
+			}
+		}
+	}
+	return rejected
+}
+
+func splitLines(out []byte) []string {
+	trimmed := bytes.TrimSpace(out)
+	if len(trimmed) == 0 {
+		return nil
+	}
+	parts := strings.Split(string(trimmed), "\n")
+	files := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			files = append(files, p)
+		}
+	}
+	return files
+}

--- a/v2/pkg/pushbroker/pushbroker.go
+++ b/v2/pkg/pushbroker/pushbroker.go
@@ -76,6 +76,7 @@ func (m GitHubAppMinter) MintPushToken(ctx context.Context, repo string) (string
 type Broker struct {
 	Workspace      string
 	Branch         string
+	BaseRef        string
 	Repo           string
 	Remote         string
 	ProtectedPaths []string
@@ -140,7 +141,11 @@ func (b *Broker) Run(ctx context.Context) (Result, error) {
 	if strings.TrimSpace(token) == "" {
 		return b.fail(res, errors.New("pushbroker: minter returned empty token"))
 	}
-	args := []string{"-c", "http.extraHeader=Authorization: Bearer " + token, "push", b.remote(), "HEAD:refs/heads/" + b.Branch}
+	args := []string{
+		"-c", "core.hooksPath=/dev/null",
+		"-c", "http.extraHeader=Authorization: Bearer " + token,
+		"push", "--no-verify", b.remote(), "HEAD:refs/heads/" + b.Branch,
+	}
 	if _, err := b.runner().Run(ctx, b.Workspace, PushEnv(os.Environ()), "git", args...); err != nil {
 		return b.fail(res, fmt.Errorf("git push failed: %w", err))
 	}
@@ -167,6 +172,12 @@ func (b *Broker) validate() error {
 }
 
 func (b *Broker) changedFiles(ctx context.Context) ([]string, error) {
+	if base := strings.TrimSpace(b.BaseRef); base != "" {
+		if _, err := b.git(ctx, "rev-parse", "--verify", base); err == nil {
+			out, err := b.git(ctx, "diff", "--name-only", base+"...HEAD")
+			return splitLines(out), err
+		}
+	}
 	base := b.remoteRef()
 	if _, err := b.git(ctx, "rev-parse", "--verify", base); err == nil {
 		out, err := b.git(ctx, "diff", "--name-only", base+"...HEAD")
@@ -177,6 +188,12 @@ func (b *Broker) changedFiles(ctx context.Context) ([]string, error) {
 }
 
 func (b *Broker) outgoingDiff(ctx context.Context) (string, error) {
+	if base := strings.TrimSpace(b.BaseRef); base != "" {
+		if _, err := b.git(ctx, "rev-parse", "--verify", base); err == nil {
+			out, err := b.git(ctx, "diff", "--no-ext-diff", base+"...HEAD")
+			return string(out), err
+		}
+	}
 	base := b.remoteRef()
 	if _, err := b.git(ctx, "rev-parse", "--verify", base); err == nil {
 		out, err := b.git(ctx, "diff", "--no-ext-diff", base+"...HEAD")

--- a/v2/pkg/pushbroker/pushbroker_test.go
+++ b/v2/pkg/pushbroker/pushbroker_test.go
@@ -1,0 +1,123 @@
+package pushbroker
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+type fakeMinter struct{ token string }
+
+func (f fakeMinter) MintPushToken(context.Context, string) (string, error) { return f.token, nil }
+
+type recordingRunner struct {
+	envOnPush  []string
+	argsOnPush []string
+}
+
+func (r *recordingRunner) Run(ctx context.Context, dir string, env []string, name string, args ...string) ([]byte, error) {
+	if name == "git" && slices.Contains(args, "push") {
+		r.envOnPush = append([]string(nil), env...)
+		r.argsOnPush = append([]string(nil), args...)
+		return []byte("ok"), nil
+	}
+	return ExecRunner{}.Run(ctx, dir, env, name, args...)
+}
+
+func TestBrokerRejectsTokenLikeSecretInOutgoingDiff(t *testing.T) {
+	dir := initRepo(t)
+	writeCommit(t, dir, "secret.txt", "token=ghp_abcdefghijklmnopqrstuvwxyz\n")
+	res, err := (&Broker{Workspace: dir, Branch: "work", Repo: "kubestellar/hive", Minter: fakeMinter{"ghs_pushbroker"}}).Run(context.Background())
+	if err == nil {
+		t.Fatal("expected secret rejection")
+	}
+	if !res.SecretRejected {
+		t.Fatalf("SecretRejected=false, err=%v", err)
+	}
+}
+
+func TestBrokerRejectsProtectedPaths(t *testing.T) {
+	dir := initRepo(t)
+	writeCommit(t, dir, ".github/workflows/ci.yaml", "name: ci\n")
+	res, err := (&Broker{Workspace: dir, Branch: "work", Repo: "kubestellar/hive", Minter: fakeMinter{"ghs_pushbroker"}}).Run(context.Background())
+	if err == nil {
+		t.Fatal("expected protected path rejection")
+	}
+	if len(res.ProtectedReject) != 1 || res.ProtectedReject[0] != ".github/workflows/ci.yaml" {
+		t.Fatalf("ProtectedReject=%v", res.ProtectedReject)
+	}
+}
+
+func TestBrokerPushSanitizesCredentialEnvironmentAndWorkspace(t *testing.T) {
+	dir := initRepo(t)
+	writeCommit(t, dir, "safe.txt", "hello\n")
+	r := &recordingRunner{}
+	t.Setenv("GITHUB_TOKEN", "ghp_should_not_leave_hive")
+	t.Setenv("HIVE_GITHUB_TOKEN", "ghp_full_token")
+	res, err := (&Broker{Workspace: dir, Branch: "work", Repo: "kubestellar/hive", Minter: fakeMinter{"ghs_minted_push_token"}, Runner: r}).Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v (res=%+v)", err, res)
+	}
+	if !res.Pushed {
+		t.Fatal("Pushed=false")
+	}
+	for _, env := range r.envOnPush {
+		if strings.Contains(env, "should_not_leave_hive") || strings.Contains(env, "full_token") || strings.HasPrefix(env, "GITHUB_TOKEN=") || strings.HasPrefix(env, "HIVE_GITHUB_TOKEN=") {
+			t.Fatalf("credential leaked into push env: %q", env)
+		}
+	}
+	filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		data, _ := os.ReadFile(path)
+		if strings.Contains(string(data), "ghs_minted_push_token") {
+			t.Fatalf("minted token written to workspace file %s", path)
+		}
+		return nil
+	})
+}
+
+func TestProtectedPathViolationsTable(t *testing.T) {
+	files := []string{"policies/guard.yaml", "OWNERS", "pkg/safe.go"}
+	got := ProtectedPathViolations(files, DefaultProtectedPaths)
+	if strings.Join(got, ",") != "policies/guard.yaml,OWNERS" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func initRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "work")
+	runGit(t, dir, "config", "user.email", "hive@example.com")
+	runGit(t, dir, "config", "user.name", "Hive Test")
+	return dir
+}
+
+func writeCommit(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	path := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", rel)
+	runGit(t, dir, "commit", "-m", "test")
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, out)
+	}
+}

--- a/v2/pkg/pushbroker/pushbroker_test.go
+++ b/v2/pkg/pushbroker/pushbroker_test.go
@@ -65,6 +65,9 @@ func TestBrokerPushSanitizesCredentialEnvironmentAndWorkspace(t *testing.T) {
 	if !res.Pushed {
 		t.Fatal("Pushed=false")
 	}
+	if !slices.Contains(r.argsOnPush, "core.hooksPath=/dev/null") || !slices.Contains(r.argsOnPush, "--no-verify") {
+		t.Fatalf("push did not disable hooks: %v", r.argsOnPush)
+	}
 	for _, env := range r.envOnPush {
 		if strings.Contains(env, "should_not_leave_hive") || strings.Contains(env, "full_token") || strings.HasPrefix(env, "GITHUB_TOKEN=") || strings.HasPrefix(env, "HIVE_GITHUB_TOKEN=") {
 			t.Fatalf("credential leaked into push env: %q", env)

--- a/v2/pkg/sandbox/sandbox.go
+++ b/v2/pkg/sandbox/sandbox.go
@@ -1,0 +1,146 @@
+// Package sandbox launches agent work in credential-free rootless Podman sandboxes.
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	DefaultWorkspaceMount = "/workspace"
+	PodmanBinary          = "podman"
+)
+
+var credentialEnvNames = map[string]struct{}{
+	"GITHUB_TOKEN": {}, "GH_TOKEN": {}, "HIVE_GITHUB_TOKEN": {}, "COPILOT_GITHUB_TOKEN": {},
+	"GIT_ASKPASS": {}, "SSH_ASKPASS": {},
+}
+
+type LaunchSpec struct {
+	Image          string
+	Name           string
+	Workspace      string
+	WorkspaceMount string
+	WorkDir        string
+	Command        []string
+	Env            map[string]string
+	EnvAllowlist   []string
+	NetworkNone    bool
+	ReadOnly       bool
+}
+
+type Result struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+type Launcher interface {
+	Run(ctx context.Context, spec LaunchSpec) (Result, error)
+}
+
+type PodmanLauncher struct{ Binary string }
+
+func (l PodmanLauncher) Run(ctx context.Context, spec LaunchSpec) (Result, error) {
+	bin := l.Binary
+	if bin == "" {
+		bin = PodmanBinary
+	}
+	if _, err := exec.LookPath(bin); err != nil {
+		return Result{}, fmt.Errorf("sandbox: podman is required but was not found in PATH: %w", err)
+	}
+	args, err := PodmanArgs(spec)
+	if err != nil {
+		return Result{}, err
+	}
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Env = SanitizedEnv(os.Environ(), spec.EnvAllowlist, spec.Env)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	res := Result{Stdout: stdout.String(), Stderr: stderr.String()}
+	if cmd.ProcessState != nil {
+		res.ExitCode = cmd.ProcessState.ExitCode()
+	}
+	if err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+func PodmanArgs(spec LaunchSpec) ([]string, error) {
+	if strings.TrimSpace(spec.Image) == "" {
+		return nil, errors.New("sandbox: image is required")
+	}
+	if strings.TrimSpace(spec.Workspace) == "" {
+		return nil, errors.New("sandbox: workspace is required")
+	}
+	mount := spec.WorkspaceMount
+	if mount == "" {
+		mount = DefaultWorkspaceMount
+	}
+	workdir := spec.WorkDir
+	if workdir == "" {
+		workdir = mount
+	}
+	args := []string{"run", "--rm"}
+	if spec.Name != "" {
+		args = append(args, "--name", spec.Name)
+	}
+	if spec.NetworkNone {
+		args = append(args, "--network=none")
+	}
+	if spec.ReadOnly {
+		args = append(args, "--read-only")
+	}
+	args = append(args, "--userns=keep-id")
+	args = append(args, "-v", filepath.Clean(spec.Workspace)+":"+mount+":Z")
+	args = append(args, "--workdir", workdir)
+	for k, v := range spec.Env {
+		if !isCredentialName(k) {
+			args = append(args, "--env", k+"="+v)
+		}
+	}
+	args = append(args, spec.Image)
+	args = append(args, spec.Command...)
+	return args, nil
+}
+
+func SanitizedEnv(base []string, allowlist []string, explicit map[string]string) []string {
+	allowed := map[string]struct{}{}
+	for _, key := range allowlist {
+		if !isCredentialName(key) {
+			allowed[key] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(allowed)+len(explicit))
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok || isCredentialName(key) {
+			continue
+		}
+		if _, ok := allowed[key]; ok {
+			out = append(out, entry)
+		}
+	}
+	for key, value := range explicit {
+		if !isCredentialName(key) {
+			out = append(out, key+"="+value)
+		}
+	}
+	return out
+}
+
+func Available() bool { _, err := exec.LookPath(PodmanBinary); return err == nil }
+
+func isCredentialName(name string) bool {
+	_, ok := credentialEnvNames[name]
+	return ok || strings.Contains(name, "TOKEN") || strings.Contains(name, "SECRET")
+}

--- a/v2/pkg/sandbox/sandbox.go
+++ b/v2/pkg/sandbox/sandbox.go
@@ -15,6 +15,8 @@ import (
 const (
 	DefaultWorkspaceMount = "/workspace"
 	PodmanBinary          = "podman"
+	NetworkModeNone       = "none"
+	NetworkModeRestricted = "restricted"
 )
 
 var credentialEnvNames = map[string]struct{}{
@@ -31,6 +33,7 @@ type LaunchSpec struct {
 	Command        []string
 	Env            map[string]string
 	EnvAllowlist   []string
+	NetworkMode    string
 	NetworkNone    bool
 	ReadOnly       bool
 }
@@ -94,8 +97,12 @@ func PodmanArgs(spec LaunchSpec) ([]string, error) {
 	if spec.Name != "" {
 		args = append(args, "--name", spec.Name)
 	}
-	if spec.NetworkNone {
-		args = append(args, "--network=none")
+	networkMode := strings.TrimSpace(spec.NetworkMode)
+	if networkMode == "" && spec.NetworkNone {
+		networkMode = NetworkModeNone
+	}
+	if networkMode != "" {
+		args = append(args, "--network="+networkMode)
 	}
 	if spec.ReadOnly {
 		args = append(args, "--read-only")

--- a/v2/pkg/sandbox/sandbox_test.go
+++ b/v2/pkg/sandbox/sandbox_test.go
@@ -35,6 +35,20 @@ func TestSanitizedEnvAllowlistDropsCredentials(t *testing.T) {
 	}
 }
 
+func TestPodmanArgsHonorsRestrictedNetworkMode(t *testing.T) {
+	args, err := PodmanArgs(LaunchSpec{Image: "agent:latest", Workspace: "/workspace-src", Command: []string{"true"}, NetworkMode: NetworkModeRestricted, NetworkNone: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--network=restricted") {
+		t.Fatalf("args %q missing restricted network", joined)
+	}
+	if strings.Contains(joined, "--network=none") {
+		t.Fatalf("NetworkMode should override legacy NetworkNone: %q", joined)
+	}
+}
+
 func TestPodmanRunSkippedWhenUnavailable(t *testing.T) {
 	if !Available() {
 		t.Skip("podman not available")

--- a/v2/pkg/sandbox/sandbox_test.go
+++ b/v2/pkg/sandbox/sandbox_test.go
@@ -1,0 +1,46 @@
+package sandbox
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestPodmanArgsUseCredentialFreeNetworklessDefaults(t *testing.T) {
+	args, err := PodmanArgs(LaunchSpec{Image: "agent:latest", Workspace: "/workspace-src", Command: []string{"echo", "ok"}, NetworkNone: true, Env: map[string]string{"SAFE": "1", "GITHUB_TOKEN": "nope"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(args, " ")
+	for _, want := range []string{"--network=none", "--userns=keep-id", "-v /workspace-src:/workspace:Z", "--workdir /workspace", "agent:latest", "echo ok"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("args %q missing %q", joined, want)
+		}
+	}
+	if strings.Contains(joined, "GITHUB_TOKEN") || strings.Contains(joined, "nope") {
+		t.Fatalf("credential env in args: %q", joined)
+	}
+}
+
+func TestSanitizedEnvAllowlistDropsCredentials(t *testing.T) {
+	env := SanitizedEnv([]string{"PATH=/bin", "HOME=/home/dev", "GITHUB_TOKEN=secret", "MY_TOKEN=secret"}, []string{"PATH", "HOME", "GITHUB_TOKEN", "MY_TOKEN"}, map[string]string{"SAFE": "1", "GH_TOKEN": "nope"})
+	if !slices.Contains(env, "PATH=/bin") || !slices.Contains(env, "HOME=/home/dev") || !slices.Contains(env, "SAFE=1") {
+		t.Fatalf("missing allowed env: %v", env)
+	}
+	for _, entry := range env {
+		if strings.Contains(entry, "secret") || strings.HasPrefix(entry, "GITHUB_TOKEN=") || strings.HasPrefix(entry, "GH_TOKEN=") || strings.HasPrefix(entry, "MY_TOKEN=") {
+			t.Fatalf("credential leaked: %v", env)
+		}
+	}
+}
+
+func TestPodmanRunSkippedWhenUnavailable(t *testing.T) {
+	if !Available() {
+		t.Skip("podman not available")
+	}
+	res, err := (PodmanLauncher{}).Run(context.Background(), LaunchSpec{Image: "docker.io/library/alpine:latest", Workspace: t.TempDir(), Command: []string{"sh", "-c", "test -d /workspace"}, NetworkNone: true})
+	if err != nil {
+		t.Fatalf("Run: %v stderr=%s", err, res.Stderr)
+	}
+}


### PR DESCRIPTION
Part of #2804.

Stacked on #2819 — merge that first.

## Summary
- wire opt-in sandbox kicks through per-kick workspace prep, prompt-file execution, timeout/state handling, artifact collection, and dashboard-compatible status updates
- hand committed sandbox output to the trusted push broker with hook-disabled host pushes and App-authored PR creation
- add restricted/none network-mode config, pause/resume/cancel lifecycle handling, and table-driven/unit coverage

## Validation
- cd v2 && go build ./...
- cd v2 && go test ./pkg/sandbox/... ./pkg/pushbroker/... ./pkg/agent/... -count=1
- cd v2 && go vet ./pkg/sandbox ./pkg/pushbroker ./pkg/agent ./pkg/config ./cmd/hive