### PR TITLE
🐛 fix(hub): self-check DNS blips are unknown, not dead — stop URL-alert flapping

### DIFF
--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -591,8 +593,11 @@ type HeartbeatPayload struct {
 }
 
 const (
-	PublicURLSelfCheckOK   = "ok"
-	PublicURLSelfCheckFail = "fail"
+	PublicURLSelfCheckOK      = "ok"
+	PublicURLSelfCheckFail    = "fail"
+	PublicURLSelfCheckUnknown = "unknown"
+
+	publicURLSelfCheckMinConsecutiveFailures = 3
 )
 
 // PublicURLSelfCheck reports the spoke's own view of whether its public
@@ -752,9 +757,11 @@ var (
 	}
 	publicURLSelfProbeCache = struct {
 		sync.Mutex
-		url       string
-		nextProbe time.Time
-		result    *PublicURLSelfCheck
+		url                 string
+		nextProbe           time.Time
+		result              *PublicURLSelfCheck
+		stable              *PublicURLSelfCheck
+		consecutiveFailures int
 	}{}
 )
 
@@ -890,7 +897,12 @@ func publicURLSelfCheckFor(ctx context.Context, rawURL string, logger *slog.Logg
 	if publicURLSelfProbeCache.url == rawURL && publicURLSelfProbeCache.result != nil && now.Before(publicURLSelfProbeCache.nextProbe) {
 		return clonePublicURLSelfCheck(publicURLSelfProbeCache.result)
 	}
-	result := publicURLSelfProbe(ctx, rawURL, publicURLSelfProbeClient)
+	if publicURLSelfProbeCache.url != rawURL {
+		publicURLSelfProbeCache.stable = nil
+		publicURLSelfProbeCache.consecutiveFailures = 0
+	}
+	raw := publicURLSelfProbe(ctx, rawURL, publicURLSelfProbeClient)
+	result := gatedPublicURLSelfCheck(raw, &publicURLSelfProbeCache.consecutiveFailures, &publicURLSelfProbeCache.stable)
 	if result.Status == PublicURLSelfCheckFail && logger != nil {
 		logger.Debug("public URL self-check failed", "url", rawURL, "error", result.Error, "status", result.HTTPStatus)
 	}
@@ -906,6 +918,29 @@ func clonePublicURLSelfCheck(in *PublicURLSelfCheck) *PublicURLSelfCheck {
 	}
 	out := *in
 	return &out
+}
+
+func gatedPublicURLSelfCheck(raw PublicURLSelfCheck, consecutiveFailures *int, stable **PublicURLSelfCheck) PublicURLSelfCheck {
+	switch raw.Status {
+	case PublicURLSelfCheckOK:
+		*consecutiveFailures = 0
+		*stable = clonePublicURLSelfCheck(&raw)
+		return raw
+	case PublicURLSelfCheckFail:
+		*consecutiveFailures++
+		if *consecutiveFailures >= publicURLSelfCheckMinConsecutiveFailures {
+			*stable = clonePublicURLSelfCheck(&raw)
+			return raw
+		}
+		if stable != nil && *stable != nil {
+			return *clonePublicURLSelfCheck(*stable)
+		}
+		raw.Status = PublicURLSelfCheckUnknown
+		return raw
+	default:
+		*consecutiveFailures = 0
+		return raw
+	}
 }
 
 func publicURLSelfProbe(ctx context.Context, rawURL string, client *http.Client) PublicURLSelfCheck {
@@ -926,13 +961,40 @@ func publicURLSelfProbe(ctx context.Context, rawURL string, client *http.Client)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return PublicURLSelfCheck{Status: PublicURLSelfCheckFail, CheckedAt: checkedAt, Error: terseProbeError(err)}
+		return PublicURLSelfCheck{Status: publicURLSelfCheckStatusForError(err), CheckedAt: checkedAt, Error: terseProbeError(err)}
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < http.StatusInternalServerError {
 		return PublicURLSelfCheck{Status: PublicURLSelfCheckOK, CheckedAt: checkedAt, HTTPStatus: resp.StatusCode}
 	}
 	return PublicURLSelfCheck{Status: PublicURLSelfCheckFail, CheckedAt: checkedAt, HTTPStatus: resp.StatusCode, Error: "HTTP " + itoa(resp.StatusCode)}
+}
+
+func publicURLSelfCheckStatusForError(err error) string {
+	if err == nil {
+		return PublicURLSelfCheckUnknown
+	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return PublicURLSelfCheckUnknown
+	}
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "no such host") ||
+		strings.Contains(msg, "server misbehaving") ||
+		strings.Contains(msg, "temporary failure in name resolution") {
+		return PublicURLSelfCheckUnknown
+	}
+	if strings.Contains(msg, ":53") && (strings.Contains(msg, "timeout") || strings.Contains(msg, "i/o timeout") || strings.Contains(msg, "server misbehaving")) {
+		return PublicURLSelfCheckUnknown
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return PublicURLSelfCheckUnknown
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return PublicURLSelfCheckUnknown
+	}
+	return PublicURLSelfCheckFail
 }
 
 func terseProbeError(err error) string {

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -3240,7 +3240,7 @@ func sanitizePublicURLSelfCheck(in *PublicURLSelfCheck) *PublicURLSelfCheck {
 		return nil
 	}
 	status := sanitizeHeartbeatField(in.Status)
-	if status != PublicURLSelfCheckOK && status != PublicURLSelfCheckFail {
+	if status != PublicURLSelfCheckOK && status != PublicURLSelfCheckFail && status != PublicURLSelfCheckUnknown {
 		return nil
 	}
 	out := &PublicURLSelfCheck{

--- a/v2/pkg/hub/url_reachability.go
+++ b/v2/pkg/hub/url_reachability.go
@@ -52,6 +52,12 @@ const (
 	// — on a 2-hive cluster a single genuinely broken hive already crosses the
 	// ratio, and rolling it up would hide a real defect.
 	urlClusterOutageMinHives = 3
+
+	// urlUnreachableMinAlertEvaluations is hub-side hysteresis for Critical
+	// URL alerts. A candidate must persist across this many dashboard
+	// evaluations before it reaches the Attention panel; the streak clears on
+	// the first healthy/ambiguous evaluation.
+	urlUnreachableMinAlertEvaluations = 3
 )
 
 // urlHealthyStatus reports whether an HTTP status from a spoke's dashboard URL
@@ -106,12 +112,16 @@ type urlHealthState struct {
 	// lastStatus[hiveID] is the most recent observed status, surfaced in the
 	// alert reason so an operator sees "503" rather than just "unreachable".
 	lastStatus map[string]int
+	// criticalEvaluations[hiveID] counts consecutive hub evaluations where the
+	// Critical URL condition was present. Cleared immediately when absent.
+	criticalEvaluations map[string]int
 }
 
 func newURLHealthState() *urlHealthState {
 	return &urlHealthState{
 		consecutiveFailures: map[string]int{},
 		lastStatus:          map[string]int{},
+		criticalEvaluations: map[string]int{},
 	}
 }
 
@@ -160,6 +170,22 @@ func (u *urlHealthState) forget(known map[string]bool) {
 			delete(u.lastStatus, id)
 		}
 	}
+	for id := range u.criticalEvaluations {
+		if !known[id] {
+			delete(u.criticalEvaluations, id)
+		}
+	}
+}
+
+func (u *urlHealthState) criticalEvaluation(hiveID string, active bool) int {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if !active {
+		delete(u.criticalEvaluations, hiveID)
+		return 0
+	}
+	u.criticalEvaluations[hiveID]++
+	return u.criticalEvaluations[hiveID]
 }
 
 // clusterOutage reports whether a cluster's failures should be rolled up into
@@ -199,7 +225,7 @@ func (s *HubServer) urlUnreachableAlerts(hives []RegistryEntry, now time.Time) [
 	clusterProbed := map[string]int{}
 	clusterFailed := map[string]int{}
 	for _, h := range hives {
-		if h.DashboardURL == "" {
+		if h.DashboardURL == "" || isUnassignedPlaceholder(h.Org, h.ProvStatus) {
 			continue
 		}
 		clusterProbed[h.ClusterID]++
@@ -210,7 +236,16 @@ func (s *HubServer) urlUnreachableAlerts(hives []RegistryEntry, now time.Time) [
 
 	var alerts []Alert
 	for _, h := range hives {
+		if isUnassignedPlaceholder(h.Org, h.ProvStatus) {
+			if s.urlHealth != nil {
+				s.urlHealth.criticalEvaluation(h.ID, false)
+			}
+			continue
+		}
 		if publicURLSelfCheckFailed(h.PublicURLSelfCheck) {
+			if s.urlHealth != nil && s.urlHealth.criticalEvaluation(h.ID, true) < urlUnreachableMinAlertEvaluations {
+				continue
+			}
 			alerts = append(alerts, Alert{
 				HiveID:   h.ID,
 				HiveName: h.Name,
@@ -222,12 +257,21 @@ func (s *HubServer) urlUnreachableAlerts(hives []RegistryEntry, now time.Time) [
 		}
 		n := failures[h.ID]
 		if n < urlUnreachableMinFailures {
+			if s.urlHealth != nil {
+				s.urlHealth.criticalEvaluation(h.ID, false)
+			}
 			continue
 		}
 		if !urlUnreachableEligible(h.RegisteredAt, now) {
+			if s.urlHealth != nil {
+				s.urlHealth.criticalEvaluation(h.ID, false)
+			}
 			continue
 		}
 		if heartbeatFreshForURLCheck(h, now) {
+			if s.urlHealth != nil {
+				s.urlHealth.criticalEvaluation(h.ID, false)
+			}
 			alerts = append(alerts, Alert{
 				HiveID:   h.ID,
 				HiveName: h.Name,
@@ -238,6 +282,9 @@ func (s *HubServer) urlUnreachableAlerts(hives []RegistryEntry, now time.Time) [
 			continue
 		}
 		if !clusterOutage(clusterFailed[h.ClusterID], clusterProbed[h.ClusterID]) {
+			if s.urlHealth != nil && s.urlHealth.criticalEvaluation(h.ID, true) < urlUnreachableMinAlertEvaluations {
+				continue
+			}
 			alerts = append(alerts, Alert{
 				HiveID:   h.ID,
 				HiveName: h.Name,
@@ -247,6 +294,8 @@ func (s *HubServer) urlUnreachableAlerts(hives []RegistryEntry, now time.Time) [
 				Severity: AlertSeverityCritical,
 				Reason:   urlUnreachableReason(h.DashboardURL, statuses[h.ID]),
 			})
+		} else if s.urlHealth != nil {
+			s.urlHealth.criticalEvaluation(h.ID, false)
 		}
 	}
 	return alerts

--- a/v2/pkg/hub/url_reachability_test.go
+++ b/v2/pkg/hub/url_reachability_test.go
@@ -2,11 +2,21 @@ package hub
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
+	"syscall"
 	"testing"
 	"time"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 // A 503 from a routed hostname with no backend is the exact failure that hid
 // behind a green dot: the HTTP exchange SUCCEEDS, so any check based on
@@ -58,6 +68,84 @@ func TestPublicURLSelfProbeStatusSemantics(t *testing.T) {
 	}
 }
 
+func TestPublicURLSelfProbeClassifiesTransportErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "dns lookup server misbehaving is unknown",
+			err: &url.Error{Op: "Get", URL: "https://hive.example.com", Err: &net.DNSError{
+				Err:    "server misbehaving",
+				Name:   "hive.example.com",
+				Server: "10.96.5.5:53",
+			}},
+			want: PublicURLSelfCheckUnknown,
+		},
+		{
+			name: "connection refused is fail",
+			err:  &url.Error{Op: "Get", URL: "https://hive.example.com", Err: &net.OpError{Op: "dial", Net: "tcp", Err: syscall.ECONNREFUSED}},
+			want: PublicURLSelfCheckFail,
+		},
+		{
+			name: "dns timeout on port 53 is unknown",
+			err: &url.Error{Op: "Get", URL: "https://hive.example.com", Err: &net.OpError{
+				Op:   "read",
+				Net:  "udp",
+				Addr: &net.UDPAddr{IP: net.ParseIP("10.96.5.5"), Port: 53},
+				Err:  os.ErrDeadlineExceeded,
+			}},
+			want: PublicURLSelfCheckUnknown,
+		},
+		{
+			name: "tls handshake rejection is fail",
+			err:  &url.Error{Op: "Get", URL: "https://hive.example.com", Err: syscall.ECONNRESET},
+			want: PublicURLSelfCheckFail,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return nil, tc.err
+			})}
+			got := publicURLSelfProbe(context.Background(), "https://hive.example.com", client)
+			if got.Status != tc.want {
+				t.Fatalf("status = %q, want %q (check=%+v)", got.Status, tc.want, got)
+			}
+			if got.Error == "" {
+				t.Fatalf("error should be preserved, got %+v", got)
+			}
+		})
+	}
+}
+
+func TestPublicURLSelfCheckGatesConsecutiveFailures(t *testing.T) {
+	var consecutive int
+	var stable *PublicURLSelfCheck
+	ok := PublicURLSelfCheck{Status: PublicURLSelfCheckOK, HTTPStatus: http.StatusUnauthorized}
+	if got := gatedPublicURLSelfCheck(ok, &consecutive, &stable); got.Status != PublicURLSelfCheckOK {
+		t.Fatalf("initial ok = %+v", got)
+	}
+	fail := PublicURLSelfCheck{Status: PublicURLSelfCheckFail, HTTPStatus: http.StatusBadGateway, Error: "HTTP 502"}
+	for i := 1; i < publicURLSelfCheckMinConsecutiveFailures; i++ {
+		got := gatedPublicURLSelfCheck(fail, &consecutive, &stable)
+		if got.Status != PublicURLSelfCheckOK {
+			t.Fatalf("failure %d should report previous stable ok, got %+v", i, got)
+		}
+	}
+	got := gatedPublicURLSelfCheck(fail, &consecutive, &stable)
+	if got.Status != PublicURLSelfCheckFail {
+		t.Fatalf("confirmed failure = %+v, want fail", got)
+	}
+
+	consecutive = 0
+	stable = nil
+	got = gatedPublicURLSelfCheck(fail, &consecutive, &stable)
+	if got.Status != PublicURLSelfCheckUnknown || got.Error == "" {
+		t.Fatalf("unconfirmed failure with no stable state should be unknown and preserve the error, got %+v", got)
+	}
+}
+
 func TestURLHealthStateCountsConsecutiveFailures(t *testing.T) {
 	u := newURLHealthState()
 	if n := u.observe("h1", urlProbeResult{Status: 503}); n != 1 {
@@ -90,6 +178,19 @@ func TestURLHealthStateForgetDropsRecycledSlots(t *testing.T) {
 	}
 	if failures["kept"] != 1 {
 		t.Error("a hive still in the registry must be retained")
+	}
+}
+
+func TestURLHealthStateCriticalEvaluationsClearImmediately(t *testing.T) {
+	u := newURLHealthState()
+	if n := u.criticalEvaluation("h1", true); n != 1 {
+		t.Fatalf("first critical evaluation = %d, want 1", n)
+	}
+	if n := u.criticalEvaluation("h1", false); n != 0 {
+		t.Fatalf("cleared evaluation = %d, want 0", n)
+	}
+	if n := u.criticalEvaluation("h1", true); n != 1 {
+		t.Fatalf("after clear = %d, want 1", n)
 	}
 }
 
@@ -159,7 +260,10 @@ func TestURLUnreachableAlerts(t *testing.T) {
 	for i := 0; i < urlUnreachableMinFailures; i++ {
 		s.urlHealth.observe("broken", urlProbeResult{Status: 503})
 	}
-	alerts := s.urlUnreachableAlerts(hives, now)
+	var alerts []Alert
+	for i := 0; i < urlUnreachableMinAlertEvaluations; i++ {
+		alerts = s.urlUnreachableAlerts(hives, now)
+	}
 	if len(alerts) != 1 || alerts[0].HiveID != "broken" {
 		t.Fatalf("want exactly one alert for the broken hive, got %+v", alerts)
 	}
@@ -207,9 +311,9 @@ func TestURLReachabilityDecisionMatrix(t *testing.T) {
 		{"hub ok self ok", false, true, &PublicURLSelfCheck{Status: PublicURLSelfCheckOK}, "", ""},
 		{"hub ok self fail", false, true, &PublicURLSelfCheck{Status: PublicURLSelfCheckFail, Error: "HTTP 503", HTTPStatus: 503}, AlertTypeURLUnreachable, AlertSeverityCritical},
 		{"hub fail fresh self ok", true, true, &PublicURLSelfCheck{Status: PublicURLSelfCheckOK, HTTPStatus: 401}, AlertTypeURLPrivateNetwork, AlertSeverityInfo},
-		{"hub fail fresh self unknown", true, true, nil, AlertTypeURLPrivateNetwork, AlertSeverityInfo},
+		{"hub fail fresh self unknown", true, true, &PublicURLSelfCheck{Status: PublicURLSelfCheckUnknown, Error: "lookup failed"}, AlertTypeURLPrivateNetwork, AlertSeverityInfo},
 		{"hub fail fresh self fail", true, true, &PublicURLSelfCheck{Status: PublicURLSelfCheckFail, Error: "HTTP 503", HTTPStatus: 503}, AlertTypeURLUnreachable, AlertSeverityCritical},
-		{"hub fail stale self unknown", true, false, nil, AlertTypeURLUnreachable, AlertSeverityCritical},
+		{"hub fail stale self unknown", true, false, &PublicURLSelfCheck{Status: PublicURLSelfCheckUnknown, Error: "lookup failed"}, AlertTypeURLUnreachable, AlertSeverityCritical},
 		{"hub fail stale self ok", true, false, &PublicURLSelfCheck{Status: PublicURLSelfCheckOK, HTTPStatus: 401}, AlertTypeURLUnreachable, AlertSeverityCritical},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -233,7 +337,10 @@ func TestURLReachabilityDecisionMatrix(t *testing.T) {
 				h.LastHeartbeat = fresh
 				h.Online = true
 			}
-			got := s.urlUnreachableAlerts([]RegistryEntry{h}, now)
+			var got []Alert
+			for i := 0; i < urlUnreachableMinAlertEvaluations; i++ {
+				got = s.urlUnreachableAlerts([]RegistryEntry{h}, now)
+			}
 			if tc.wantType == "" {
 				if len(got) != 0 {
 					t.Fatalf("want no alerts, got %+v", got)
@@ -247,6 +354,61 @@ func TestURLReachabilityDecisionMatrix(t *testing.T) {
 				t.Fatalf("alert = (%s,%s), want (%s,%s): %+v", got[0].Type, got[0].Severity, tc.wantType, tc.wantLevel, got[0])
 			}
 		})
+	}
+}
+
+func TestURLUnreachableCriticalFlapSuppression(t *testing.T) {
+	now := time.Now()
+	oldEnough := now.Add(-urlUnreachableMinAge - time.Hour).Format(time.RFC3339)
+	stale := now.Add(-maxHeartbeatAge - time.Minute).UTC().Format(time.RFC3339)
+	s := &HubServer{urlHealth: newURLHealthState()}
+	for i := 0; i < urlUnreachableMinFailures; i++ {
+		s.urlHealth.observe("h1", urlProbeResult{Status: 503})
+	}
+	h := RegistryEntry{ID: "h1", Name: "org/repo", ClusterID: "c1", RegisteredAt: oldEnough, DashboardURL: "https://dead.example.com", LastHeartbeat: stale}
+	for i := 1; i < urlUnreachableMinAlertEvaluations; i++ {
+		if got := s.urlUnreachableAlerts([]RegistryEntry{h}, now); len(got) != 0 {
+			t.Fatalf("evaluation %d should be suppressed, got %+v", i, got)
+		}
+	}
+	if got := s.urlUnreachableAlerts([]RegistryEntry{h}, now); len(got) != 1 {
+		t.Fatalf("persistent condition should alert, got %+v", got)
+	}
+	s.urlHealth.observe("h1", urlProbeResult{Status: 302, Healthy: true})
+	if got := s.urlUnreachableAlerts([]RegistryEntry{h}, now); len(got) != 0 {
+		t.Fatalf("first success should clear immediately, got %+v", got)
+	}
+	for i := 0; i < urlUnreachableMinFailures; i++ {
+		s.urlHealth.observe("h1", urlProbeResult{Status: 503})
+	}
+	if got := s.urlUnreachableAlerts([]RegistryEntry{h}, now); len(got) != 0 {
+		t.Fatalf("after clear the hysteresis should restart, got %+v", got)
+	}
+}
+
+func TestURLUnreachableSuppressesUnassignedPlaceholders(t *testing.T) {
+	now := time.Now()
+	oldEnough := now.Add(-urlUnreachableMinAge - time.Hour).Format(time.RFC3339)
+	stale := now.Add(-maxHeartbeatAge - time.Minute).UTC().Format(time.RFC3339)
+	s := &HubServer{urlHealth: newURLHealthState()}
+	for i := 0; i < urlUnreachableMinFailures; i++ {
+		s.urlHealth.observe("ph", urlProbeResult{Status: 503})
+	}
+	ph := RegistryEntry{
+		ID:                 "ph",
+		Name:               "available-oke-13/placeholder",
+		Org:                "available-oke-13",
+		ProvStatus:         "available",
+		ClusterID:          "c1",
+		RegisteredAt:       oldEnough,
+		DashboardURL:       "https://placeholder.example.com",
+		LastHeartbeat:      stale,
+		PublicURLSelfCheck: &PublicURLSelfCheck{Status: PublicURLSelfCheckFail, Error: "HTTP 503", HTTPStatus: 503},
+	}
+	for i := 0; i < urlUnreachableMinAlertEvaluations; i++ {
+		if got := s.urlUnreachableAlerts([]RegistryEntry{ph}, now); len(got) != 0 {
+			t.Fatalf("placeholder URL alerts should be suppressed, got %+v", got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Live evidence
After PR #2853 deployed on the hub, the Attention panel showed Critical “Dashboard URL unreachable” alerts for kubestellar/hive and available-oke placeholders. The spoke self-check errors were transient in-cluster CoreDNS failures such as `lookup hosted-kubestellar-hive-ojv6.hive.kubestellar.io on 10.96.5.5:53: server misbehaving`, while an in-pod `nslookup` immediately resolved and the public URL was externally reachable.

## New matrix
- Spoke self-check classifies DNS/path-ambiguous transport failures (`no such host`, CoreDNS `server misbehaving`, timeout on `:53`, generic timeout) as `unknown` with the error preserved.
- Genuine endpoint failures still report `fail`: connection refused, TLS/endpoint rejection, and HTTP >= 500.
- Spoke `fail` reporting requires 3 consecutive failed self-probes; early failures report the previous stable state or `unknown`.
- Hub Critical URL alerts require either a confirmed spoke self-check `fail`, or stale heartbeat plus repeated hub probe failure. `unknown` never escalates to Critical by itself.
- Hub Critical URL alerts require 3 consecutive hub evaluations and clear immediately on the first non-critical evaluation.
- Unassigned placeholders (`available-*` / `provStatus=available`) suppress Dashboard URL Criticals entirely; private-URL info chips for claimed hives remain intact.

## Validation
- `go build ./...`
- `go vet ./...`
- `go test ./pkg/hub/ ./pkg/dashboard/ -count=1`