### PR TITLE
📖 docs(contribute): surface custom-CSS help on the leaderboard style picker

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -786,6 +786,8 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 .info-pop ul{margin:4px 0 0;padding-left:16px}
 .info-pop li{margin:2px 0}
 .info-pop code{background:#161b22;border:1px solid #21262d;border-radius:4px;padding:0 3px;font-size:.7rem}
+.custom-css-help .info-btn{font-size:.72rem;font-weight:600;color:#58a6ff}
+.custom-css-example{box-sizing:border-box;width:100%%;margin:6px 0 4px;background:#161b22;border:1px solid #30363d;border-radius:6px;color:#c9d1d9;font:12px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;padding:6px}
 /* Compact tier badge inline next to a connected clanker's identity. */
 .tier-badge.tier-inline{padding:1px 6px 1px 4px;font-size:.62rem;margin-left:6px;vertical-align:middle}
 .tier-badge.tier-inline::before{width:6px;height:6px}
@@ -2600,12 +2602,18 @@ function renderMeCard(mount,p){
   +'<div class="me-actions">'
     +'<a class="me-share" href="'+esc(meLinkedInURL(p))+'" target="_blank" rel="noopener noreferrer">\u{1F4E3} Share achievement on LinkedIn</a>'
     +'<span class="me-stylepick" title="Personalize your card — more customization coming">Profile style <select id="me-style-select" aria-label="Profile style (more customization coming)">'+styleOpts+'</select></span>'
+    +'<span class="info-affordance custom-css-help"><button type="button" class="info-btn" id="custom-css-info-btn" aria-haspopup="true" aria-expanded="false" aria-controls="custom-css-info-pop" aria-label="Custom CSS stylesheet help" title="Custom CSS">Custom CSS</button>'
+    +'<div class="info-pop" id="custom-css-info-pop" role="tooltip" hidden><h4>Custom CSS</h4>'
+    +'Use <code>?style=owner/repo/path/theme.css@ref</code> to load a theme. Example:'
+    +'<input class="custom-css-example" readonly aria-label="Custom CSS example" value="?style=castrojo/themes/lb/bluefin.css@main" onclick="this.select()">'
+    +'Omit <code>@ref</code> to use the repo&rsquo;s <code>HEAD</code>. Public GitHub repos only; CSS is sanitized server-side and capped at <code>128 KiB</code>. The same param works on <code>/</code> and <code>/snapshot</code>.</div></span>'
   +'</div>'
   +meInviteSection(p)
   +'</div></div>';
   mount.innerHTML=html;
 
   wireMeInvite();
+  _wireCustomCSSInfo();
   // #2595 daily-quota widget on the Me card: hydrate from the shared limits read
   // (viewer's real used_day vs their tier's max_per_day). Load lazily if not cached.
   if(typeof ccLimits!=='undefined'&&ccLimits!==null){try{ccRenderMeQuota();}catch(e){}}
@@ -2842,6 +2850,26 @@ function _wireAffinityInfo(){
   document.addEventListener('keydown',function(e){if(e.key==='Escape')close();});
 }
 if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',_wireAffinityInfo);else _wireAffinityInfo();
+
+// _wireCustomCSSInfo toggles the compact custom-stylesheet help next to the
+// Leaderboard/Profile style picker. The element is rendered with the Me card, so
+// renderMeCard() calls this after replacing that fragment.
+function _wireCustomCSSInfo(){
+  var btn=document.getElementById('custom-css-info-btn');
+  var pop=document.getElementById('custom-css-info-pop');
+  if(!btn||!pop||btn.getAttribute('data-wired')==='1')return;
+  btn.setAttribute('data-wired','1');
+  function close(){pop.hidden=true;btn.setAttribute('aria-expanded','false');}
+  btn.addEventListener('click',function(e){
+    e.stopPropagation();
+    var open=pop.hidden;
+    pop.hidden=!open;
+    btn.setAttribute('aria-expanded',open?'true':'false');
+  });
+  pop.addEventListener('click',function(e){e.stopPropagation();});
+  document.addEventListener('click',function(){if(!pop.hidden)close();});
+  document.addEventListener('keydown',function(e){if(e.key==='Escape')close();});
+}
 
 // ccRenderCooldownCount surfaces the current cooldown tally next to the Management
 // tab's Task cooldown control (#2649): "M issues currently cooling down". It reads

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -293,6 +293,37 @@ func TestContributeLandingHasOpsTab(t *testing.T) {
 	}
 }
 
+func TestContributeLandingHasCustomCSSHelp(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/contribute/leaderboard", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /contribute/leaderboard = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+
+	for _, want := range []string{
+		`id="custom-css-info-btn"`,
+		`Custom CSS`,
+		`?style=owner/repo/path/theme.css@ref`,
+		`?style=castrojo/themes/lb/bluefin.css@main`,
+		`repo&rsquo;s <code>HEAD</code>`,
+		`Public GitHub repos only`,
+		`sanitized server-side`,
+		`128 KiB`,
+		`<code>/</code> and <code>/snapshot</code>`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("custom CSS help missing %q", want)
+		}
+	}
+}
+
 // TestContributeLandingHasKubernetesMode pins the #2549 discoverability
 // addition: the /contribute run-mode surface must offer a Kubernetes path
 // alongside containerized and host, wired to `just contribute-k8s`, and it must


### PR DESCRIPTION
## Summary
- add a compact Custom CSS popover beside the contribute leaderboard/profile style picker
- document the style query form, example, HEAD default, public/sanitized/128 KiB constraints, and dashboard/snapshot support
- pin the help text in contribute page tests

## Validation
- go build ./...
- go test ./pkg/dashboard/ -run Contribute -count=1