### PR TITLE
fix(dashboard): render paused agents truthfully + make pause/resume toggle server-authoritative

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -67,6 +67,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("POST /api/model/{agent}/{model}", s.handleModelSet)
 	s.mux.HandleFunc("POST /api/pause/{agent}", s.handlePause)
 	s.mux.HandleFunc("POST /api/resume/{agent}", s.handleResume)
+	s.mux.HandleFunc("GET /api/agent-state/{agent}", s.handleAgentState)
 	s.mux.HandleFunc("POST /api/pin/{agent}/{dimension}", s.handlePin)
 	s.mux.HandleFunc("POST /api/unpin/{agent}/{dimension}", s.handleUnpin)
 	s.mux.HandleFunc("POST /api/restart/{agent}", s.handleRestart)
@@ -1184,8 +1185,52 @@ func (s *Server) handleModelSet(w http.ResponseWriter, r *http.Request) {
 	okResponse(w, map[string]string{"status": "model_set", "agent": name, "model": model})
 }
 
+// pauseStateLabel names the authoritative pause-dimension state reported by
+// the pause/resume/agent-state endpoints. It deliberately says nothing about
+// process health — "running" here means "not operator-paused" (the governor
+// will kick it), matching what the pause/resume toggle controls.
+const (
+	pauseStatePaused  = "paused"
+	pauseStateRunning = "running"
+)
+
+func pauseStateLabel(paused bool) string {
+	if paused {
+		return pauseStatePaused
+	}
+	return pauseStateRunning
+}
+
+// pauseToggleResponse is the shared response shape for pause/resume. `changed`
+// distinguishes a real transition from a no-op: pausing an already-paused
+// agent used to return the same undifferentiated success as a real pause,
+// which let a dashboard with a stale belief silently re-pause an agent the
+// operator was trying to START (audit showed pause-pairs seconds apart while
+// the agent stayed paused indefinitely). `state` is the authoritative
+// post-request pause state the client must render from.
+func pauseToggleResponse(w http.ResponseWriter, status, agent string, changed, paused bool) {
+	jsonResponse(w, map[string]interface{}{
+		"ok":      true,
+		"status":  status,
+		"agent":   agent,
+		"changed": changed,
+		"state":   pauseStateLabel(paused),
+	})
+}
+
 func (s *Server) handlePause(w http.ResponseWriter, r *http.Request) {
 	name := s.resolveAgentParam(r.PathValue("agent"))
+
+	// No-op guard: the agent is already paused. Do NOT call Pause again —
+	// that would clobber the original PausedAt/reason/trigger — and tell the
+	// client explicitly so it can correct its stale UI instead of believing
+	// it just paused a running agent. An unknown agent falls through to
+	// Pause, which returns the same 400 as before.
+	if proc, err := s.deps.AgentMgr.GetStatus(name); err == nil && proc != nil && proc.Paused {
+		s.auditFromRequest(r, "pause", auditDetail("result", "noop-already-paused"), name)
+		pauseToggleResponse(w, "paused", name, false, true)
+		return
+	}
 
 	if err := s.deps.AgentMgr.Pause(name, "dashboard-api", "manual pause"); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
@@ -1194,11 +1239,19 @@ func (s *Server) handlePause(w http.ResponseWriter, r *http.Request) {
 
 	s.auditFromRequest(r, "pause", "", name)
 	s.refreshAndPersist()
-	okResponse(w, map[string]string{"status": "paused", "agent": name})
+	pauseToggleResponse(w, "paused", name, true, true)
 }
 
 func (s *Server) handleResume(w http.ResponseWriter, r *http.Request) {
 	name := s.resolveAgentParam(r.PathValue("agent"))
+
+	// No-op guard, mirror of handlePause: resuming an agent that is not
+	// paused must report changed:false with the authoritative state.
+	if proc, err := s.deps.AgentMgr.GetStatus(name); err == nil && proc != nil && !proc.Paused {
+		s.auditFromRequest(r, "resume", auditDetail("result", "noop-not-paused"), name)
+		pauseToggleResponse(w, "resumed", name, false, false)
+		return
+	}
 
 	if err := s.deps.AgentMgr.Resume(s.deps.Ctx, name, "dashboard-api", "manual resume"); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
@@ -1207,7 +1260,27 @@ func (s *Server) handleResume(w http.ResponseWriter, r *http.Request) {
 
 	s.auditFromRequest(r, "resume", "", name)
 	s.refreshAndPersist()
-	okResponse(w, map[string]string{"status": "resumed", "agent": name})
+	pauseToggleResponse(w, "resumed", name, true, false)
+}
+
+// handleAgentState is a lightweight authoritative pause-state probe. The
+// dashboard's pause/resume toggle calls it immediately before acting so the
+// action derives from the SERVER's persisted state rather than a stale DOM
+// dataset — the belt to the response contract's suspenders above.
+func (s *Server) handleAgentState(w http.ResponseWriter, r *http.Request) {
+	name := s.resolveAgentParam(r.PathValue("agent"))
+	proc, err := s.deps.AgentMgr.GetStatus(name)
+	if err != nil || proc == nil {
+		jsonError(w, "agent not found", http.StatusNotFound)
+		return
+	}
+	jsonResponse(w, map[string]interface{}{
+		"ok":        true,
+		"agent":     name,
+		"paused":    proc.Paused,
+		"state":     pauseStateLabel(proc.Paused),
+		"procState": string(proc.State),
+	})
 }
 
 func (s *Server) handlePin(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/api_pause_toggle_test.go
+++ b/v2/pkg/dashboard/api_pause_toggle_test.go
@@ -1,0 +1,138 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// These tests pin the server-authoritative pause/resume contract: a no-op
+// transition (pausing an already-paused agent, resuming a running one) must
+// return ok:true with changed:false and the authoritative state, so a client
+// with a stale belief can correct itself instead of silently re-pausing an
+// agent the operator was trying to start.
+
+func decodeToggleBody(t *testing.T, body []byte) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("response is not JSON: %v (body=%s)", err, body)
+	}
+	return m
+}
+
+func TestHandlePause_RealTransitionReportsChangedTrue(t *testing.T) {
+	s, _ := apiServer(t)
+	rec := doPost(s, "/api/pause/scanner", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	m := decodeToggleBody(t, rec.Body.Bytes())
+	if m["ok"] != true {
+		t.Errorf("ok = %v, want true", m["ok"])
+	}
+	if m["changed"] != true {
+		t.Errorf("changed = %v, want true on a real pause transition", m["changed"])
+	}
+	if m["state"] != "paused" {
+		t.Errorf("state = %v, want %q", m["state"], "paused")
+	}
+}
+
+func TestHandlePause_NoopReturnsChangedFalse(t *testing.T) {
+	s, _ := apiServer(t)
+	if rec := doPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
+		t.Fatalf("first pause status = %d, want 200", rec.Code)
+	}
+	rec := doPost(s, "/api/pause/scanner", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second pause status = %d, want 200 (ok:true is part of the contract)", rec.Code)
+	}
+	m := decodeToggleBody(t, rec.Body.Bytes())
+	if m["ok"] != true {
+		t.Errorf("ok = %v, want true even on a no-op", m["ok"])
+	}
+	if m["changed"] != false {
+		t.Errorf("changed = %v, want false when pausing an already-paused agent", m["changed"])
+	}
+	if m["state"] != "paused" {
+		t.Errorf("state = %v, want %q", m["state"], "paused")
+	}
+}
+
+func TestHandleResume_NoopReturnsChangedFalse(t *testing.T) {
+	s, _ := apiServer(t)
+	// scanner starts un-paused: resuming it is a no-op.
+	rec := doPost(s, "/api/resume/scanner", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (no-op resume must not touch tmux)", rec.Code)
+	}
+	m := decodeToggleBody(t, rec.Body.Bytes())
+	if m["ok"] != true {
+		t.Errorf("ok = %v, want true even on a no-op", m["ok"])
+	}
+	if m["changed"] != false {
+		t.Errorf("changed = %v, want false when resuming a non-paused agent", m["changed"])
+	}
+	if m["state"] != "running" {
+		t.Errorf("state = %v, want %q", m["state"], "running")
+	}
+}
+
+func TestHandleResume_RealTransitionReportsChangedTrue(t *testing.T) {
+	s, _ := apiServer(t)
+	if rec := doPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
+		t.Fatalf("pause status = %d, want 200", rec.Code)
+	}
+	rec := doPost(s, "/api/resume/scanner", nil)
+	// A real resume relaunches the agent session; in environments without a
+	// working tmux this legitimately fails with 400 (same tolerance as
+	// TestHandleResume). The contract under test is: when it DOES succeed,
+	// it must report changed:true with the authoritative state.
+	if rec.Code != http.StatusOK && rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 200 or 400", rec.Code)
+	}
+	if rec.Code == http.StatusOK {
+		m := decodeToggleBody(t, rec.Body.Bytes())
+		if m["changed"] != true {
+			t.Errorf("changed = %v, want true on a real resume transition", m["changed"])
+		}
+		if m["state"] != "running" {
+			t.Errorf("state = %v, want %q", m["state"], "running")
+		}
+	}
+}
+
+func TestHandleAgentState_ReflectsAuthoritativePause(t *testing.T) {
+	s, _ := apiServer(t)
+
+	rec := doGet(s, "/api/agent-state/scanner")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	m := decodeToggleBody(t, rec.Body.Bytes())
+	if m["paused"] != false || m["state"] != "running" {
+		t.Errorf("fresh agent: paused = %v, state = %v; want false/running", m["paused"], m["state"])
+	}
+
+	if rec := doPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
+		t.Fatalf("pause status = %d, want 200", rec.Code)
+	}
+
+	rec = doGet(s, "/api/agent-state/scanner")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status after pause = %d, want 200", rec.Code)
+	}
+	m = decodeToggleBody(t, rec.Body.Bytes())
+	if m["paused"] != true || m["state"] != "paused" {
+		t.Errorf("paused agent: paused = %v, state = %v; want true/paused", m["paused"], m["state"])
+	}
+}
+
+func TestHandleAgentState_UnknownAgent404(t *testing.T) {
+	s, _ := apiServer(t)
+	rec := doGet(s, "/api/agent-state/nonexistent")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3805,7 +3805,11 @@
     let _ocSummaryScrollTop = null;
 
     function pauseInfoIcon(a) {
-      if (!a.paused || a.offByCadence) return '';
+      // A manual/persisted pause carries its reason/trigger even when the
+      // current governor mode's cadence is also pause/off — the operator
+      // pause is the state that needs explaining, so never hide the icon
+      // behind offByCadence.
+      if (!a.paused) return '';
       const reason = a.pausedReason || 'unknown';
       const trigger = a.pausedTrigger || 'unknown';
       const at = a.pausedAt ? new Date(a.pausedAt).toLocaleString() : 'unknown';
@@ -3859,9 +3863,15 @@
       if (!a) { detail.classList.remove('active'); return; }
       detail.classList.add('active');
 
-      const isOff = a.offByCadence === true;
       const isOnDemand = a.onDemand === true;
-      const isPaused = a.paused === true && !isOff && !isOnDemand;
+      // Manual/persisted pause WINS over the governor's per-mode cadence.
+      // The old `paused && !offByCadence` derivation let an operator-paused
+      // agent whose current-mode cadence was also pause/off fall through to
+      // the off-healthy (hollow GREEN) styling with a "▶ start" button —
+      // the operator could not see it was paused, and the toggle then sent
+      // a no-op re-pause instead of the intended resume.
+      const isPaused = a.paused === true && !isOnDemand;
+      const isOff = a.offByCadence === true && !isPaused && !isOnDemand;
       // Down = process not alive ('stopped', 'failed', …) — anything but
       // 'running'. Matching only 'stopped' let 'failed' agents render the
       // green idle styling here (#2465).
@@ -4143,9 +4153,11 @@
     }
 
     function _sidebarRenderAgent(a) {
-      const isOff = a.offByCadence === true;
       const isOnDemand = a.onDemand === true;
-      const isPaused = a.paused === true && !isOff && !isOnDemand;
+      // Manual/persisted pause wins over offByCadence — see the agent-detail
+      // renderer for the incident this ordering prevents.
+      const isPaused = a.paused === true && !isOnDemand;
+      const isOff = a.offByCadence === true && !isPaused && !isOnDemand;
       // Down = the PROCESS is not alive ('stopped', 'failed', or never
       // launched — anything but 'running'). The dot used to read only the
       // 'stopped' state, so a failed/crash-looping agent fell through to the
@@ -5538,9 +5550,11 @@
       });
       const { sorted: sortedAgents } = _sortAgentsBySidebar(agents);
       const cards = sortedAgents.map(a => {
-        const isOff = a.offByCadence === true;
         const isOnDemand = a.onDemand === true;
-        const isPaused = a.paused === true && !isOff && !isOnDemand;
+        // Manual/persisted pause wins over offByCadence — see the agent-detail
+        // renderer for the incident this ordering prevents.
+        const isPaused = a.paused === true && !isOnDemand;
+        const isOff = a.offByCadence === true && !isPaused && !isOnDemand;
         // Down = process not alive — anything but 'running'. 'stopped'-only
         // matching rendered crash-looping ('failed') agents green (#2465).
         const isStopped = a.state !== 'running' && !isPaused && !isOff && !isOnDemand;
@@ -6379,8 +6393,11 @@
         if (!row) return '';
         const agentData = agents.find(a => a.name === aname);
         const isWorking = agentData && agentData.busy === 'working';
-        const agentPaused = agentData && agentData.paused === true && !agentData.offByCadence;
-        const agentOff = agentData && agentData.offByCadence === true;
+        // Manual/persisted pause wins over offByCadence (matches the card/
+        // sidebar/detail renderers) — the row badge must say "paused", not
+        // "off", when the operator paused the agent.
+        const agentPaused = agentData && agentData.paused === true;
+        const agentOff = agentData && agentData.offByCadence === true && !agentPaused;
         const agentOnDemand = agentData && agentData.onDemand === true;
         const cells = modes.map(m => {
           const val = row[m] || '?';
@@ -12446,18 +12463,36 @@ function burnAreaChart() {
     }
 
     async function toggleAgent(agent, currentlyPaused) {
-      const action = currentlyPaused ? 'resume' : 'pause';
-      const label = currentlyPaused ? 'Resuming' : 'Pausing';
+      // Server-authoritative toggle. The caller's belief (a stale DOM
+      // dataset) once inverted the action: a persisted-paused agent rendered
+      // un-paused, so the operator's "start it" click sent a silent no-op
+      // re-pause and the agent stayed paused indefinitely. Two defenses:
+      // (1) re-sync the real state from /api/agent-state before choosing
+      // pause-vs-resume, (2) render from the response's authoritative
+      // state/changed fields instead of assuming the action succeeded as
+      // intended.
+      let believedPaused = currentlyPaused;
+      try {
+        const st = await (await fetch(`/api/agent-state/${agent}`)).json();
+        if (st && st.ok === true && typeof st.paused === 'boolean') believedPaused = st.paused;
+      } catch (e) { /* best-effort — fall back to the caller's belief */ }
+      const action = believedPaused ? 'resume' : 'pause';
+      const label = believedPaused ? 'Resuming' : 'Pausing';
       const toast = showToast(`${label} ${agent}...`, 'info', true);
       const res = await fetch(`/api/${action}/${agent}`, { method: 'POST' });
       const data = await res.json();
       if (!data.ok) { dismissToast(toast, `${action} failed: ${data.error || 'unknown'}`, 'error'); return; }
-      // Optimistic DOM update — reflect state immediately without waiting for SSE
+      // Authoritative post-request state from the server. Older servers that
+      // omit `state` fall back to the pre-fix assumption.
+      const nowPaused = (data.state === 'paused' || data.state === 'running')
+        ? data.state === 'paused'
+        : action === 'pause';
+      // DOM update from the AUTHORITATIVE state (not a blind optimistic
+      // assumption) — reflect it immediately without waiting for SSE.
       const cards = document.querySelectorAll('.agent-card');
       for (const card of cards) {
         const nameEl = card.querySelector('.agent-name');
         if (!nameEl || !nameEl.textContent.includes(agent)) continue;
-        const nowPaused = action === 'pause';
         card.className = card.className.replace(/\b(paused|off|idle|working|stopped)\b/g, '').trim() + (nowPaused ? ' paused' : ' idle');
         const stateEl = card.querySelector('.agent-state');
         if (stateEl) { stateEl.className = `agent-state ${nowPaused ? 'paused' : 'idle'}`; stateEl.textContent = nowPaused ? 'paused' : 'idle'; }
@@ -12474,7 +12509,7 @@ function burnAreaChart() {
       }
       // Update in-memory agent state so cadence table re-renders correctly
       const agentObj = (window._lastAgents || []).find(a => a.name === agent);
-      if (agentObj) { agentObj.paused = (action === 'pause'); }
+      if (agentObj) { agentObj.paused = nowPaused; }
       // The focused agent-detail panel renders its own toggle button — the
       // .agent-card loop above never reaches it, so re-render it from the
       // just-updated state or the button stays stale until navigation.
@@ -12484,7 +12519,16 @@ function burnAreaChart() {
         renderGovernor(lastData.governor, lastData.cadenceMatrix || [], lastData);
       }
       renderDebugSection();
-      dismissToast(toast, `${agent} ${action}d`, 'success');
+      if (data.changed === false) {
+        // No-op transition: tell the operator the REAL state so the next
+        // click does the right thing (the button above was just re-rendered
+        // from that state).
+        dismissToast(toast, nowPaused
+          ? `${agent} was already paused — click ▶ resume to start it`
+          : `${agent} was already running — click ⏸ pause to stop it`, 'info');
+      } else {
+        dismissToast(toast, `${agent} ${action}d`, 'success');
+      }
     }
 
     async function restartAgent(agent) {


### PR DESCRIPTION
## Incident

On a v2 hosted spoke, a persisted-paused scanner rendered with the same GREEN/healthy indicator as running agents. The operator, unable to see it was paused, clicked the toggle intending to start it — the client derived the action from its own stale belief and sent `POST /api/pause`, a silent no-op re-pause that returned an undifferentiated `ok:true`. Audit shows pause-pairs seconds apart from a real browser; the agent stayed paused indefinitely.

## Fix 1 — render paused truthfully (UI bug, not the feed)

The status feeds (full `/api/status` and the fast `agent-status` SSE, both via `buildAgents`) already send the authoritative `paused` flag from `proc.Paused` — the same flag the governor checks to skip paused agents. The UI masked it: every renderer derived `isPaused = paused && !offByCadence`, so an operator pause vanished whenever the current governor mode's cadence was also pause/off, and the agent fell through to the **off-healthy hollow-GREEN** styling with a `▶ start` button whose `data-paused=false` sent a pause.

Changed (v2/pkg/dashboard/static/index.html):
- Agent detail panel, sidebar, agent cards, and cadence-matrix row badge now derive `isPaused` first and gate `isOff` on `!isPaused` — manual/persisted pause wins. Paused agents get the paused dot, the literal **paused** label, and a **▶ resume** toggle everywhere.
- `pauseInfoIcon` no longer hides the pause reason/trigger behind `offByCadence`.

## Fix 2 — server-authoritative pause/resume

New response contract (ok:true kept for existing consumers):
- `POST /api/pause/{agent}` / `POST /api/resume/{agent}` → `{ok:true, status, agent, changed:bool, state:"paused"|"running"}`. No-op transitions (pause of an already-paused agent, resume of a running one) return `changed:false` **without** re-invoking Pause/Resume — a redundant Pause also clobbered the original PausedAt/reason/trigger — and are audited as `noop-already-paused` / `noop-not-paused`.
- New lightweight `GET /api/agent-state/{agent}` → `{ok, agent, paused, state, procState}` from the manager's authoritative snapshot.

Client `toggleAgent`:
- Pre-flight re-sync: fetches `/api/agent-state` and derives pause-vs-resume from the server's state, not the stale DOM dataset.
- Renders the DOM from the response's authoritative `state` (replacing the blind optimistic update).
- On `changed:false`, shows a toast with the real state ("was already paused — click ▶ resume to start it") and re-renders the button so the next click does the right thing.

## Tests

`v2/pkg/dashboard/api_pause_toggle_test.go`: changed:true on real pause/resume transitions, changed:false + authoritative state on no-op pause and no-op resume, `/api/agent-state` reflects pause state, 404 on unknown agent. Existing pause/resume tests (api_coverage_test.go, api_test.go, coverage_boost3_test.go, spoke_authz_test.go) assert only status codes / middleware behavior and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)