### PR TITLE
✨ feat(dashboard): security section in config dialog with posture summary and coherence warnings

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -128,6 +128,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("PUT /api/config/governor/litellm", s.handleGovernorLiteLLM)
 	s.mux.HandleFunc("PUT /api/config/governor/trajectory", s.handleGovernorTrajectory)
 	s.mux.HandleFunc("PUT /api/config/governor/features", s.handleGovernorFeatures)
+	s.mux.HandleFunc("PUT /api/config/governor/security", s.handleGovernorSecurity)
 	// bob API key: PUT sets/replaces, DELETE revokes. Both are non-GET, so the
 	// roleEnforcement middleware already 403s a read-only role — no separate
 	// authorization rule is needed or wanted here.
@@ -2195,6 +2196,8 @@ func (s *Server) handleAgentConfigGet(w http.ResponseWriter, r *http.Request) {
 			"detectKeywords":   agentCfg.DetectKeywords,
 			"aliases":          agentCfg.Aliases,
 			"cavemanMode":      agentCfg.CavemanMode,
+			"sandboxEnabled":   agentCfg.Sandbox != nil && agentCfg.Sandbox.Enabled != nil && *agentCfg.Sandbox.Enabled,
+			"sandboxEffective": agentCfg.SandboxEnabled(s.deps.Config.AgentSandbox),
 		},
 		"cadences":       cadences,
 		"models":         models,
@@ -2799,6 +2802,15 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 				}
 			}
 			agentCfg.Aliases = a
+		}
+	}
+	if v, ok := body["sandboxEnabled"]; ok {
+		if b, ok := v.(bool); ok {
+			if agentCfg.Sandbox == nil {
+				agentCfg.Sandbox = &config.AgentSandboxOverride{}
+			}
+			bb := b
+			agentCfg.Sandbox.Enabled = &bb
 		}
 	}
 	if v, ok := body["cavemanMode"]; ok {
@@ -3753,6 +3765,7 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 		"trajectory": trajectorySectionResponse(&cfg.Governor),
 		"classifier": classifierSectionResponse(),
 		"features":   featuresSectionResponse(cfg),
+		"security":   securitySectionResponse(cfg),
 		"attribution": map[string]interface{}{
 			// Effective value (default ON when unset) — the UI renders the
 			// switch from this, so an untouched hive shows it on.

--- a/v2/pkg/dashboard/api_governor_features.go
+++ b/v2/pkg/dashboard/api_governor_features.go
@@ -16,11 +16,13 @@ const (
 	maxTracingSampleRatio = 1.0
 )
 
-// handleGovernorFeatures toggles four already-functional opt-in features from
-// the Governor config dialog so operators do not have to hand-edit hive.yaml:
+// handleGovernorFeatures updates non-security-posture feature/observability
+// settings from the Governor config dialog so operators do not have to hand-edit
+// hive.yaml:
 //
-//   - ioscan            (Config.Ioscan.Enabled — *bool, nil defaults ON)
-//   - tracing           (Config.Tracing.Enabled + Endpoint + SampleRatio)
+//   - ioscan            (legacy API compatibility; UI moved to Security)
+//   - otel/tracing      (Config.OTel/Tracing Enabled + advanced exporter fields)
+//   - retro             (Config.Retro enabled + analysis model)
 //   - mint              (Config.Mint.Enabled + Issuer — NOT KeyPath: the signing
 //     key is a secret/PEM path and the dashboard overlay is deliberately
 //     secret-free)
@@ -37,9 +39,18 @@ func (s *Server) handleGovernorFeatures(w http.ResponseWriter, r *http.Request) 
 	var body struct {
 		IoscanEnabled *bool `json:"ioscanEnabled"`
 
-		TracingEnabled     *bool    `json:"tracingEnabled"`
-		TracingEndpoint    *string  `json:"tracingEndpoint"`
-		TracingSampleRatio *float64 `json:"tracingSampleRatio"`
+		TracingEnabled     *bool              `json:"tracingEnabled"`
+		TracingEndpoint    *string            `json:"tracingEndpoint"`
+		TracingSampleRatio *float64           `json:"tracingSampleRatio"`
+		OTelEnabled        *bool              `json:"otelEnabled"`
+		OTelEndpoint       *string            `json:"otelEndpoint"`
+		OTelServiceName    *string            `json:"otelServiceName"`
+		OTelInsecure       *bool              `json:"otelInsecure"`
+		OTelSampleRatio    *float64           `json:"otelSampleRatio"`
+		OTelHeaders        *map[string]string `json:"otelHeaders"`
+
+		RetroEnabled       *bool   `json:"retroEnabled"`
+		RetroAnalysisModel *string `json:"retroAnalysisModel"`
 
 		MintEnabled *bool   `json:"mintEnabled"`
 		MintIssuer  *string `json:"mintIssuer"`
@@ -52,19 +63,21 @@ func (s *Server) handleGovernorFeatures(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// --- validate before mutating anything ---
-	if body.TracingEndpoint != nil {
-		ep := strings.TrimSpace(*body.TracingEndpoint)
+	endpoint := firstStringPtr(body.OTelEndpoint, body.TracingEndpoint)
+	if endpoint != nil {
+		ep := strings.TrimSpace(*endpoint)
 		if ep != "" {
 			u, err := url.Parse(ep)
 			if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
-				jsonError(w, "tracing endpoint must be empty or an http(s) URL", http.StatusBadRequest)
+				jsonError(w, "otel endpoint must be empty or an http(s) URL", http.StatusBadRequest)
 				return
 			}
 		}
 	}
-	if body.TracingSampleRatio != nil {
-		if *body.TracingSampleRatio < minTracingSampleRatio || *body.TracingSampleRatio > maxTracingSampleRatio {
-			jsonError(w, "tracing sample_ratio must be between 0.0 and 1.0", http.StatusBadRequest)
+	sampleRatio := firstFloatPtr(body.OTelSampleRatio, body.TracingSampleRatio)
+	if sampleRatio != nil {
+		if *sampleRatio < minTracingSampleRatio || *sampleRatio > maxTracingSampleRatio {
+			jsonError(w, "otel sample_ratio must be between 0.0 and 1.0", http.StatusBadRequest)
 			return
 		}
 	}
@@ -75,19 +88,35 @@ func (s *Server) handleGovernorFeatures(w http.ResponseWriter, r *http.Request) 
 		v := *body.IoscanEnabled
 		cfg.Ioscan.Enabled = &v
 	}
-	if body.TracingEnabled != nil || body.TracingEndpoint != nil || body.TracingSampleRatio != nil {
+	otelEnabled := firstBoolPtr(body.OTelEnabled, body.TracingEnabled)
+	if otelEnabled != nil || endpoint != nil || body.OTelServiceName != nil || body.OTelInsecure != nil || sampleRatio != nil || body.OTelHeaders != nil {
 		merged := cfg.EffectiveOTel()
-		if body.TracingEnabled != nil {
-			merged.Enabled = *body.TracingEnabled
+		if otelEnabled != nil {
+			merged.Enabled = *otelEnabled
 		}
-		if body.TracingEndpoint != nil {
-			merged.Endpoint = strings.TrimSpace(*body.TracingEndpoint)
+		if endpoint != nil {
+			merged.Endpoint = strings.TrimSpace(*endpoint)
 		}
-		if body.TracingSampleRatio != nil {
-			merged.SampleRatio = *body.TracingSampleRatio
+		if body.OTelServiceName != nil {
+			merged.ServiceName = strings.TrimSpace(*body.OTelServiceName)
+		}
+		if body.OTelInsecure != nil {
+			merged.Insecure = *body.OTelInsecure
+		}
+		if sampleRatio != nil {
+			merged.SampleRatio = *sampleRatio
+		}
+		if body.OTelHeaders != nil {
+			merged.Headers = sanitizedHeaderMap(*body.OTelHeaders)
 		}
 		cfg.OTel = merged
 		cfg.Tracing = merged
+	}
+	if body.RetroEnabled != nil {
+		cfg.Retro.Enabled = *body.RetroEnabled
+	}
+	if body.RetroAnalysisModel != nil {
+		cfg.Retro.AnalysisModel = strings.TrimSpace(*body.RetroAnalysisModel)
 	}
 	if body.MintEnabled != nil {
 		cfg.Mint.Enabled = *body.MintEnabled
@@ -127,8 +156,37 @@ func featuresSectionResponse(cfg *config.Config) map[string]interface{} {
 		"tracingEnabled":     otelCfg.Enabled,
 		"tracingEndpoint":    otelCfg.Endpoint,
 		"tracingSampleRatio": otelCfg.SampleRatio,
+		"otelEnabled":        otelCfg.Enabled,
+		"otelEndpoint":       otelCfg.Endpoint,
+		"otelServiceName":    otelCfg.ServiceName,
+		"otelInsecure":       otelCfg.Insecure,
+		"otelSampleRatio":    otelCfg.SampleRatio,
+		"otelHasHeaders":     len(otelCfg.Headers) > 0,
+		"retroEnabled":       cfg.Retro.Enabled,
+		"retroAnalysisModel": cfg.Retro.AnalysisModel,
 		"mintEnabled":        cfg.Mint.Enabled,
 		"mintIssuer":         cfg.Mint.Issuer,
 		"planFromLabel":      planFromLabel,
 	}
+}
+
+func firstBoolPtr(primary, fallback *bool) *bool {
+	if primary != nil {
+		return primary
+	}
+	return fallback
+}
+
+func firstFloatPtr(primary, fallback *float64) *float64 {
+	if primary != nil {
+		return primary
+	}
+	return fallback
+}
+
+func firstStringPtr(primary, fallback *string) *string {
+	if primary != nil {
+		return primary
+	}
+	return fallback
 }

--- a/v2/pkg/dashboard/api_governor_features_test.go
+++ b/v2/pkg/dashboard/api_governor_features_test.go
@@ -30,6 +30,11 @@ func TestCovGov_Features(t *testing.T) {
 	}); rec.Code != http.StatusBadRequest {
 		t.Fatalf("bad sample ratio: expected 400, got %d", rec.Code)
 	}
+	if rec := doPut(s, "/api/config/governor/features", map[string]any{
+		"otelEndpoint": "ftp://collector:4318",
+	}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("bad otel endpoint: expected 400, got %d", rec.Code)
+	}
 
 	// Set every field in one valid PUT.
 	planTrue := true
@@ -38,6 +43,11 @@ func TestCovGov_Features(t *testing.T) {
 		"tracingEnabled":     true,
 		"tracingEndpoint":    "https://otel-collector:4318",
 		"tracingSampleRatio": 0.5,
+		"otelServiceName":    "hive-ui",
+		"otelInsecure":       true,
+		"otelHeaders":        map[string]string{"authorization": "${OTEL_TOKEN}"},
+		"retroEnabled":       true,
+		"retroAnalysisModel": "claude-sonnet",
 		"mintEnabled":        true,
 		"mintIssuer":         "https://mint.example.com",
 		"planFromLabel":      planTrue,
@@ -57,6 +67,12 @@ func TestCovGov_Features(t *testing.T) {
 	}
 	if cfg.Tracing.SampleRatio != 0.5 || cfg.OTel.SampleRatio != 0.5 {
 		t.Errorf("tracing sample ratio = %v otel sample ratio = %v", cfg.Tracing.SampleRatio, cfg.OTel.SampleRatio)
+	}
+	if cfg.OTel.ServiceName != "hive-ui" || !cfg.OTel.Insecure || cfg.OTel.Headers["authorization"] != "${OTEL_TOKEN}" {
+		t.Errorf("advanced otel fields not set: %+v", cfg.OTel)
+	}
+	if !cfg.Retro.Enabled || cfg.Retro.AnalysisModel != "claude-sonnet" {
+		t.Errorf("retro fields not set: %+v", cfg.Retro)
 	}
 	if !cfg.Mint.Enabled {
 		t.Errorf("mint not enabled")

--- a/v2/pkg/dashboard/api_governor_security.go
+++ b/v2/pkg/dashboard/api_governor_security.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
@@ -9,14 +10,25 @@ import (
 
 func (s *Server) handleGovernorSecurity(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		IoscanEnabled       *bool   `json:"ioscanEnabled"`
-		IoscanFailMode      *string `json:"ioscanFailMode"`
-		IoscanCanaries      *bool   `json:"ioscanCanaries"`
-		IntentEnforce       *bool   `json:"intentEnforce"`
-		ReviewRequire       *bool   `json:"reviewRequireApproval"`
-		ReviewFanOut        *bool   `json:"reviewFanOut"`
-		RetroEnabled        *bool   `json:"retroEnabled"`
-		AgentSandboxEnabled *bool   `json:"agentSandboxEnabled"`
+		IoscanEnabled        *bool              `json:"ioscanEnabled"`
+		IoscanFailMode       *string            `json:"ioscanFailMode"`
+		IoscanCanaries       *bool              `json:"ioscanCanaries"`
+		IntentEnforce        *bool              `json:"intentEnforce"`
+		IntentAlignmentModel *string            `json:"intentAlignmentModel"`
+		ReviewRequire        *bool              `json:"reviewRequireApproval"`
+		ReviewFanOut         *bool              `json:"reviewFanOut"`
+		ReviewMaxParallel    *int               `json:"reviewMaxParallelReviews"`
+		ReviewReviewerAgents *[]string          `json:"reviewReviewerAgents"`
+		ReviewFixerAgent     *string            `json:"reviewFixerAgent"`
+		RetroEnabled         *bool              `json:"retroEnabled"`
+		RetroAnalysisModel   *string            `json:"retroAnalysisModel"`
+		OTelEnabled          *bool              `json:"otelEnabled"`
+		OTelEndpoint         *string            `json:"otelEndpoint"`
+		OTelServiceName      *string            `json:"otelServiceName"`
+		OTelInsecure         *bool              `json:"otelInsecure"`
+		OTelSampleRatio      *float64           `json:"otelSampleRatio"`
+		OTelHeaders          *map[string]string `json:"otelHeaders"`
+		AgentSandboxEnabled  *bool              `json:"agentSandboxEnabled"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
@@ -28,6 +40,25 @@ func (s *Server) handleGovernorSecurity(w http.ResponseWriter, r *http.Request) 
 			jsonError(w, "ioscan fail_mode must be open or closed", http.StatusBadRequest)
 			return
 		}
+	}
+
+	if body.ReviewMaxParallel != nil && (*body.ReviewMaxParallel < 0 || *body.ReviewMaxParallel > 64) {
+		jsonError(w, "review max_parallel_reviews must be between 0 and 64", http.StatusBadRequest)
+		return
+	}
+	if body.OTelEndpoint != nil {
+		ep := strings.TrimSpace(*body.OTelEndpoint)
+		if ep != "" {
+			u, err := url.Parse(ep)
+			if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+				jsonError(w, "otel endpoint must be empty or an http(s) URL", http.StatusBadRequest)
+				return
+			}
+		}
+	}
+	if body.OTelSampleRatio != nil && (*body.OTelSampleRatio < minTracingSampleRatio || *body.OTelSampleRatio > maxTracingSampleRatio) {
+		jsonError(w, "otel sample_ratio must be between 0.0 and 1.0", http.StatusBadRequest)
+		return
 	}
 
 	cfg := s.deps.Config
@@ -48,14 +79,52 @@ func (s *Server) handleGovernorSecurity(w http.ResponseWriter, r *http.Request) 
 	if body.IntentEnforce != nil {
 		cfg.Intent.Enforce = *body.IntentEnforce
 	}
+	if body.IntentAlignmentModel != nil {
+		cfg.Intent.AlignmentModel = strings.TrimSpace(*body.IntentAlignmentModel)
+	}
 	if body.ReviewRequire != nil {
 		cfg.Review.RequireApproval = *body.ReviewRequire
 	}
 	if body.ReviewFanOut != nil {
 		cfg.Review.FanOut = *body.ReviewFanOut
 	}
+	if body.ReviewMaxParallel != nil {
+		cfg.Review.MaxParallelReviews = *body.ReviewMaxParallel
+	}
+	if body.ReviewReviewerAgents != nil {
+		cfg.Review.ReviewerAgents = sanitizeStringSlice(*body.ReviewReviewerAgents)
+	}
+	if body.ReviewFixerAgent != nil {
+		cfg.Review.FixerAgent = sanitizeString(strings.TrimSpace(*body.ReviewFixerAgent))
+	}
 	if body.RetroEnabled != nil {
 		cfg.Retro.Enabled = *body.RetroEnabled
+	}
+	if body.RetroAnalysisModel != nil {
+		cfg.Retro.AnalysisModel = strings.TrimSpace(*body.RetroAnalysisModel)
+	}
+	if body.OTelEnabled != nil || body.OTelEndpoint != nil || body.OTelServiceName != nil || body.OTelInsecure != nil || body.OTelSampleRatio != nil || body.OTelHeaders != nil {
+		merged := cfg.EffectiveOTel()
+		if body.OTelEnabled != nil {
+			merged.Enabled = *body.OTelEnabled
+		}
+		if body.OTelEndpoint != nil {
+			merged.Endpoint = strings.TrimSpace(*body.OTelEndpoint)
+		}
+		if body.OTelServiceName != nil {
+			merged.ServiceName = strings.TrimSpace(*body.OTelServiceName)
+		}
+		if body.OTelInsecure != nil {
+			merged.Insecure = *body.OTelInsecure
+		}
+		if body.OTelSampleRatio != nil {
+			merged.SampleRatio = *body.OTelSampleRatio
+		}
+		if body.OTelHeaders != nil {
+			merged.Headers = sanitizedHeaderMap(*body.OTelHeaders)
+		}
+		cfg.OTel = merged
+		cfg.Tracing = merged
 	}
 	if body.AgentSandboxEnabled != nil {
 		cfg.AgentSandbox.Enabled = *body.AgentSandboxEnabled
@@ -84,17 +153,55 @@ func securitySectionResponse(cfg *config.Config) map[string]interface{} {
 			reviewCapable++
 		}
 	}
+	otelCfg := cfg.EffectiveOTel()
 	return map[string]interface{}{
-		"ioscanEnabled":         cfg.Ioscan.IsEnabled(),
-		"ioscanFailMode":        failMode,
-		"ioscanCanaries":        cfg.Ioscan.Canaries,
-		"intentEnforce":         cfg.Intent.Enforce,
-		"reviewRequireApproval": cfg.Review.RequireApproval,
-		"reviewFanOut":          cfg.Review.FanOut,
-		"reviewCapableAgents":   reviewCapable,
-		"retroEnabled":          cfg.Retro.Enabled,
-		"agentSandboxEnabled":   cfg.AgentSandbox.Enabled,
-		"sandboxedAgents":       sandboxed,
-		"totalAgents":           len(cfg.Agents),
+		"ioscanEnabled":                    cfg.Ioscan.IsEnabled(),
+		"ioscanFailMode":                   failMode,
+		"ioscanCanaries":                   cfg.Ioscan.Canaries,
+		"intentEnforce":                    cfg.Intent.Enforce,
+		"intentAlignmentModel":             cfg.Intent.AlignmentModel,
+		"reviewRequireApproval":            cfg.Review.RequireApproval,
+		"reviewFanOut":                     cfg.Review.FanOut,
+		"reviewMaxParallelReviews":         cfg.Review.EffectiveMaxParallelReviews(),
+		"reviewReviewerAgents":             cfg.Review.ReviewerAgents,
+		"reviewFixerAgent":                 cfg.Review.FixerAgent,
+		"reviewCapableAgents":              reviewCapable,
+		"reviewSeverityThresholdAvailable": false,
+		"retroEnabled":                     cfg.Retro.Enabled,
+		"retroAnalysisModel":               cfg.Retro.AnalysisModel,
+		"otelEnabled":                      otelCfg.Enabled,
+		"otelEndpoint":                     otelCfg.Endpoint,
+		"otelServiceName":                  otelCfg.ServiceName,
+		"otelInsecure":                     otelCfg.Insecure,
+		"otelSampleRatio":                  otelCfg.SampleRatio,
+		"otelHasHeaders":                   len(otelCfg.Headers) > 0,
+		"agentSandboxEnabled":              cfg.AgentSandbox.Enabled,
+		"sandboxedAgents":                  sandboxed,
+		"totalAgents":                      len(cfg.Agents),
 	}
+}
+
+func sanitizeStringSlice(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, item := range in {
+		if s := strings.TrimSpace(sanitizeString(item)); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func sanitizedHeaderMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		key := strings.TrimSpace(sanitizeString(k))
+		if key == "" {
+			continue
+		}
+		out[key] = strings.TrimSpace(v)
+	}
+	return out
 }

--- a/v2/pkg/dashboard/api_governor_security.go
+++ b/v2/pkg/dashboard/api_governor_security.go
@@ -2,7 +2,6 @@ package dashboard
 
 import (
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
@@ -10,25 +9,17 @@ import (
 
 func (s *Server) handleGovernorSecurity(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		IoscanEnabled        *bool              `json:"ioscanEnabled"`
-		IoscanFailMode       *string            `json:"ioscanFailMode"`
-		IoscanCanaries       *bool              `json:"ioscanCanaries"`
-		IntentEnforce        *bool              `json:"intentEnforce"`
-		IntentAlignmentModel *string            `json:"intentAlignmentModel"`
-		ReviewRequire        *bool              `json:"reviewRequireApproval"`
-		ReviewFanOut         *bool              `json:"reviewFanOut"`
-		ReviewMaxParallel    *int               `json:"reviewMaxParallelReviews"`
-		ReviewReviewerAgents *[]string          `json:"reviewReviewerAgents"`
-		ReviewFixerAgent     *string            `json:"reviewFixerAgent"`
-		RetroEnabled         *bool              `json:"retroEnabled"`
-		RetroAnalysisModel   *string            `json:"retroAnalysisModel"`
-		OTelEnabled          *bool              `json:"otelEnabled"`
-		OTelEndpoint         *string            `json:"otelEndpoint"`
-		OTelServiceName      *string            `json:"otelServiceName"`
-		OTelInsecure         *bool              `json:"otelInsecure"`
-		OTelSampleRatio      *float64           `json:"otelSampleRatio"`
-		OTelHeaders          *map[string]string `json:"otelHeaders"`
-		AgentSandboxEnabled  *bool              `json:"agentSandboxEnabled"`
+		IoscanEnabled        *bool     `json:"ioscanEnabled"`
+		IoscanFailMode       *string   `json:"ioscanFailMode"`
+		IoscanCanaries       *bool     `json:"ioscanCanaries"`
+		IntentEnforce        *bool     `json:"intentEnforce"`
+		IntentAlignmentModel *string   `json:"intentAlignmentModel"`
+		ReviewRequire        *bool     `json:"reviewRequireApproval"`
+		ReviewFanOut         *bool     `json:"reviewFanOut"`
+		ReviewMaxParallel    *int      `json:"reviewMaxParallelReviews"`
+		ReviewReviewerAgents *[]string `json:"reviewReviewerAgents"`
+		ReviewFixerAgent     *string   `json:"reviewFixerAgent"`
+		AgentSandboxEnabled  *bool     `json:"agentSandboxEnabled"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
@@ -44,20 +35,6 @@ func (s *Server) handleGovernorSecurity(w http.ResponseWriter, r *http.Request) 
 
 	if body.ReviewMaxParallel != nil && (*body.ReviewMaxParallel < 0 || *body.ReviewMaxParallel > 64) {
 		jsonError(w, "review max_parallel_reviews must be between 0 and 64", http.StatusBadRequest)
-		return
-	}
-	if body.OTelEndpoint != nil {
-		ep := strings.TrimSpace(*body.OTelEndpoint)
-		if ep != "" {
-			u, err := url.Parse(ep)
-			if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
-				jsonError(w, "otel endpoint must be empty or an http(s) URL", http.StatusBadRequest)
-				return
-			}
-		}
-	}
-	if body.OTelSampleRatio != nil && (*body.OTelSampleRatio < minTracingSampleRatio || *body.OTelSampleRatio > maxTracingSampleRatio) {
-		jsonError(w, "otel sample_ratio must be between 0.0 and 1.0", http.StatusBadRequest)
 		return
 	}
 
@@ -97,35 +74,6 @@ func (s *Server) handleGovernorSecurity(w http.ResponseWriter, r *http.Request) 
 	if body.ReviewFixerAgent != nil {
 		cfg.Review.FixerAgent = sanitizeString(strings.TrimSpace(*body.ReviewFixerAgent))
 	}
-	if body.RetroEnabled != nil {
-		cfg.Retro.Enabled = *body.RetroEnabled
-	}
-	if body.RetroAnalysisModel != nil {
-		cfg.Retro.AnalysisModel = strings.TrimSpace(*body.RetroAnalysisModel)
-	}
-	if body.OTelEnabled != nil || body.OTelEndpoint != nil || body.OTelServiceName != nil || body.OTelInsecure != nil || body.OTelSampleRatio != nil || body.OTelHeaders != nil {
-		merged := cfg.EffectiveOTel()
-		if body.OTelEnabled != nil {
-			merged.Enabled = *body.OTelEnabled
-		}
-		if body.OTelEndpoint != nil {
-			merged.Endpoint = strings.TrimSpace(*body.OTelEndpoint)
-		}
-		if body.OTelServiceName != nil {
-			merged.ServiceName = strings.TrimSpace(*body.OTelServiceName)
-		}
-		if body.OTelInsecure != nil {
-			merged.Insecure = *body.OTelInsecure
-		}
-		if body.OTelSampleRatio != nil {
-			merged.SampleRatio = *body.OTelSampleRatio
-		}
-		if body.OTelHeaders != nil {
-			merged.Headers = sanitizedHeaderMap(*body.OTelHeaders)
-		}
-		cfg.OTel = merged
-		cfg.Tracing = merged
-	}
 	if body.AgentSandboxEnabled != nil {
 		cfg.AgentSandbox.Enabled = *body.AgentSandboxEnabled
 	}
@@ -153,7 +101,6 @@ func securitySectionResponse(cfg *config.Config) map[string]interface{} {
 			reviewCapable++
 		}
 	}
-	otelCfg := cfg.EffectiveOTel()
 	return map[string]interface{}{
 		"ioscanEnabled":                    cfg.Ioscan.IsEnabled(),
 		"ioscanFailMode":                   failMode,
@@ -167,14 +114,6 @@ func securitySectionResponse(cfg *config.Config) map[string]interface{} {
 		"reviewFixerAgent":                 cfg.Review.FixerAgent,
 		"reviewCapableAgents":              reviewCapable,
 		"reviewSeverityThresholdAvailable": false,
-		"retroEnabled":                     cfg.Retro.Enabled,
-		"retroAnalysisModel":               cfg.Retro.AnalysisModel,
-		"otelEnabled":                      otelCfg.Enabled,
-		"otelEndpoint":                     otelCfg.Endpoint,
-		"otelServiceName":                  otelCfg.ServiceName,
-		"otelInsecure":                     otelCfg.Insecure,
-		"otelSampleRatio":                  otelCfg.SampleRatio,
-		"otelHasHeaders":                   len(otelCfg.Headers) > 0,
 		"agentSandboxEnabled":              cfg.AgentSandbox.Enabled,
 		"sandboxedAgents":                  sandboxed,
 		"totalAgents":                      len(cfg.Agents),

--- a/v2/pkg/dashboard/api_governor_security.go
+++ b/v2/pkg/dashboard/api_governor_security.go
@@ -1,0 +1,100 @@
+package dashboard
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+func (s *Server) handleGovernorSecurity(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		IoscanEnabled       *bool   `json:"ioscanEnabled"`
+		IoscanFailMode      *string `json:"ioscanFailMode"`
+		IoscanCanaries      *bool   `json:"ioscanCanaries"`
+		IntentEnforce       *bool   `json:"intentEnforce"`
+		ReviewRequire       *bool   `json:"reviewRequireApproval"`
+		ReviewFanOut        *bool   `json:"reviewFanOut"`
+		RetroEnabled        *bool   `json:"retroEnabled"`
+		AgentSandboxEnabled *bool   `json:"agentSandboxEnabled"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	if body.IoscanFailMode != nil {
+		mode := strings.ToLower(strings.TrimSpace(*body.IoscanFailMode))
+		if mode != "" && mode != "open" && mode != "closed" {
+			jsonError(w, "ioscan fail_mode must be open or closed", http.StatusBadRequest)
+			return
+		}
+	}
+
+	cfg := s.deps.Config
+	if body.IoscanEnabled != nil {
+		v := *body.IoscanEnabled
+		cfg.Ioscan.Enabled = &v
+	}
+	if body.IoscanFailMode != nil {
+		mode := strings.ToLower(strings.TrimSpace(*body.IoscanFailMode))
+		if mode == "open" {
+			mode = ""
+		}
+		cfg.Ioscan.FailMode = mode
+	}
+	if body.IoscanCanaries != nil {
+		cfg.Ioscan.Canaries = *body.IoscanCanaries
+	}
+	if body.IntentEnforce != nil {
+		cfg.Intent.Enforce = *body.IntentEnforce
+	}
+	if body.ReviewRequire != nil {
+		cfg.Review.RequireApproval = *body.ReviewRequire
+	}
+	if body.ReviewFanOut != nil {
+		cfg.Review.FanOut = *body.ReviewFanOut
+	}
+	if body.RetroEnabled != nil {
+		cfg.Retro.Enabled = *body.RetroEnabled
+	}
+	if body.AgentSandboxEnabled != nil {
+		cfg.AgentSandbox.Enabled = *body.AgentSandboxEnabled
+	}
+
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after security update", "error", err)
+	}
+	s.auditFromRequest(r, "config_governor_security", auditDetail("section", "security"), "")
+	s.refreshAndPersist()
+	okResponse(w, map[string]string{"status": "updated"})
+}
+
+func securitySectionResponse(cfg *config.Config) map[string]interface{} {
+	failMode := "open"
+	if cfg.Ioscan.FailClosed() {
+		failMode = "closed"
+	}
+	sandboxed := 0
+	reviewCapable := 0
+	for name, a := range cfg.Agents {
+		if a.SandboxEnabled(cfg.AgentSandbox) {
+			sandboxed++
+		}
+		if dashboardAgentReviewCapable(name, a, cfg.Review.ReviewerAgents) {
+			reviewCapable++
+		}
+	}
+	return map[string]interface{}{
+		"ioscanEnabled":         cfg.Ioscan.IsEnabled(),
+		"ioscanFailMode":        failMode,
+		"ioscanCanaries":        cfg.Ioscan.Canaries,
+		"intentEnforce":         cfg.Intent.Enforce,
+		"reviewRequireApproval": cfg.Review.RequireApproval,
+		"reviewFanOut":          cfg.Review.FanOut,
+		"reviewCapableAgents":   reviewCapable,
+		"retroEnabled":          cfg.Retro.Enabled,
+		"agentSandboxEnabled":   cfg.AgentSandbox.Enabled,
+		"sandboxedAgents":       sandboxed,
+		"totalAgents":           len(cfg.Agents),
+	}
+}

--- a/v2/pkg/dashboard/api_governor_security_test.go
+++ b/v2/pkg/dashboard/api_governor_security_test.go
@@ -12,14 +12,25 @@ func TestGovernorSecurityEndpointUpdatesOverlayFields(t *testing.T) {
 	deps.Config.Agents["reviewer"] = config.AgentConfig{Enabled: true, Role: "reviewer"}
 
 	rec := doPut(s, "/api/config/governor/security", map[string]any{
-		"ioscanEnabled":         false,
-		"ioscanFailMode":        "closed",
-		"ioscanCanaries":        true,
-		"intentEnforce":         true,
-		"reviewRequireApproval": true,
-		"reviewFanOut":          true,
-		"retroEnabled":          true,
-		"agentSandboxEnabled":   true,
+		"ioscanEnabled":            false,
+		"ioscanFailMode":           "closed",
+		"ioscanCanaries":           true,
+		"intentEnforce":            true,
+		"intentAlignmentModel":     "gpt-4o",
+		"reviewRequireApproval":    true,
+		"reviewFanOut":             true,
+		"reviewMaxParallelReviews": 3,
+		"reviewReviewerAgents":     []string{"reviewer"},
+		"reviewFixerAgent":         "scanner",
+		"retroEnabled":             true,
+		"retroAnalysisModel":       "claude-sonnet",
+		"otelEnabled":              true,
+		"otelEndpoint":             "https://otel.example.com:4318",
+		"otelServiceName":          "hive-sec",
+		"otelInsecure":             true,
+		"otelSampleRatio":          0.5,
+		"otelHeaders":              map[string]string{"authorization": "${OTEL_TOKEN}"},
+		"agentSandboxEnabled":      true,
 	})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("PUT security = %d, want 200: %s", rec.Code, rec.Body.String())
@@ -34,13 +45,22 @@ func TestGovernorSecurityEndpointUpdatesOverlayFields(t *testing.T) {
 		t.Fatalf("security settings not updated: intent=%+v review=%+v retro=%+v sandbox=%+v",
 			deps.Config.Intent, deps.Config.Review, deps.Config.Retro, deps.Config.AgentSandbox)
 	}
+	if deps.Config.Intent.AlignmentModel != "gpt-4o" || deps.Config.Review.MaxParallelReviews != 3 ||
+		deps.Config.Review.FixerAgent != "scanner" || deps.Config.Retro.AnalysisModel != "claude-sonnet" ||
+		!deps.Config.OTel.Enabled || deps.Config.OTel.Endpoint != "https://otel.example.com:4318" ||
+		deps.Config.OTel.ServiceName != "hive-sec" || !deps.Config.OTel.Insecure ||
+		deps.Config.OTel.SampleRatio != 0.5 || deps.Config.OTel.Headers["authorization"] != "${OTEL_TOKEN}" {
+		t.Fatalf("advanced security settings not updated: intent=%+v review=%+v retro=%+v otel=%+v",
+			deps.Config.Intent, deps.Config.Review, deps.Config.Retro, deps.Config.OTel)
+	}
 
 	body := decodeJSON(t, doGet(s, "/api/config/governor"))
 	sec, ok := body["security"].(map[string]any)
 	if !ok {
 		t.Fatalf("security section missing: %#v", body["security"])
 	}
-	if sec["ioscanFailMode"] != "closed" || sec["reviewCapableAgents"].(float64) != 1 {
+	if sec["ioscanFailMode"] != "closed" || sec["reviewCapableAgents"].(float64) != 1 ||
+		sec["intentAlignmentModel"] != "gpt-4o" || sec["otelHasHeaders"] != true {
 		t.Fatalf("security section wrong: %#v", sec)
 	}
 }
@@ -53,6 +73,26 @@ func TestGovernorSecurityRejectsInvalidFailMode(t *testing.T) {
 	}
 	if deps.Config.Ioscan.FailMode != "" {
 		t.Fatalf("invalid fail mode mutated config: %q", deps.Config.Ioscan.FailMode)
+	}
+}
+
+func TestGovernorSecurityRejectsInvalidAdvancedValues(t *testing.T) {
+	tests := []struct {
+		name string
+		body map[string]any
+	}{
+		{name: "bad otel endpoint", body: map[string]any{"otelEndpoint": "ftp://otel.example.com"}},
+		{name: "bad otel sample", body: map[string]any{"otelSampleRatio": 1.5}},
+		{name: "bad review max", body: map[string]any{"reviewMaxParallelReviews": 65}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := apiServer(t)
+			rec := doPut(s, "/api/config/governor/security", tt.body)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", rec.Code)
+			}
+		})
 	}
 }
 

--- a/v2/pkg/dashboard/api_governor_security_test.go
+++ b/v2/pkg/dashboard/api_governor_security_test.go
@@ -1,0 +1,69 @@
+package dashboard
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+func TestGovernorSecurityEndpointUpdatesOverlayFields(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.Agents["reviewer"] = config.AgentConfig{Enabled: true, Role: "reviewer"}
+
+	rec := doPut(s, "/api/config/governor/security", map[string]any{
+		"ioscanEnabled":         false,
+		"ioscanFailMode":        "closed",
+		"ioscanCanaries":        true,
+		"intentEnforce":         true,
+		"reviewRequireApproval": true,
+		"reviewFanOut":          true,
+		"retroEnabled":          true,
+		"agentSandboxEnabled":   true,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT security = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if deps.Config.Ioscan.IsEnabled() {
+		t.Fatal("ioscan enabled was not persisted as explicit false")
+	}
+	if !deps.Config.Ioscan.FailClosed() || !deps.Config.Ioscan.Canaries {
+		t.Fatalf("ioscan settings not updated: %+v", deps.Config.Ioscan)
+	}
+	if !deps.Config.Intent.Enforce || !deps.Config.Review.RequireApproval || !deps.Config.Review.FanOut || !deps.Config.Retro.Enabled || !deps.Config.AgentSandbox.Enabled {
+		t.Fatalf("security settings not updated: intent=%+v review=%+v retro=%+v sandbox=%+v",
+			deps.Config.Intent, deps.Config.Review, deps.Config.Retro, deps.Config.AgentSandbox)
+	}
+
+	body := decodeJSON(t, doGet(s, "/api/config/governor"))
+	sec, ok := body["security"].(map[string]any)
+	if !ok {
+		t.Fatalf("security section missing: %#v", body["security"])
+	}
+	if sec["ioscanFailMode"] != "closed" || sec["reviewCapableAgents"].(float64) != 1 {
+		t.Fatalf("security section wrong: %#v", sec)
+	}
+}
+
+func TestGovernorSecurityRejectsInvalidFailMode(t *testing.T) {
+	s, deps := apiServer(t)
+	rec := doPut(s, "/api/config/governor/security", map[string]any{"ioscanFailMode": "panic"})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid fail mode status = %d, want 400", rec.Code)
+	}
+	if deps.Config.Ioscan.FailMode != "" {
+		t.Fatalf("invalid fail mode mutated config: %q", deps.Config.Ioscan.FailMode)
+	}
+}
+
+func TestAgentConfigGeneralPersistsSandboxOptIn(t *testing.T) {
+	s, deps := apiServer(t)
+	rec := doPut(s, "/api/config/agent/scanner/general", map[string]any{"sandboxEnabled": true})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT agent general = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	got := deps.Config.Agents["scanner"].Sandbox
+	if got == nil || got.Enabled == nil || !*got.Enabled {
+		t.Fatalf("sandbox opt-in not persisted: %#v", got)
+	}
+}

--- a/v2/pkg/dashboard/api_governor_security_test.go
+++ b/v2/pkg/dashboard/api_governor_security_test.go
@@ -22,14 +22,6 @@ func TestGovernorSecurityEndpointUpdatesOverlayFields(t *testing.T) {
 		"reviewMaxParallelReviews": 3,
 		"reviewReviewerAgents":     []string{"reviewer"},
 		"reviewFixerAgent":         "scanner",
-		"retroEnabled":             true,
-		"retroAnalysisModel":       "claude-sonnet",
-		"otelEnabled":              true,
-		"otelEndpoint":             "https://otel.example.com:4318",
-		"otelServiceName":          "hive-sec",
-		"otelInsecure":             true,
-		"otelSampleRatio":          0.5,
-		"otelHeaders":              map[string]string{"authorization": "${OTEL_TOKEN}"},
 		"agentSandboxEnabled":      true,
 	})
 	if rec.Code != http.StatusOK {
@@ -41,17 +33,14 @@ func TestGovernorSecurityEndpointUpdatesOverlayFields(t *testing.T) {
 	if !deps.Config.Ioscan.FailClosed() || !deps.Config.Ioscan.Canaries {
 		t.Fatalf("ioscan settings not updated: %+v", deps.Config.Ioscan)
 	}
-	if !deps.Config.Intent.Enforce || !deps.Config.Review.RequireApproval || !deps.Config.Review.FanOut || !deps.Config.Retro.Enabled || !deps.Config.AgentSandbox.Enabled {
-		t.Fatalf("security settings not updated: intent=%+v review=%+v retro=%+v sandbox=%+v",
-			deps.Config.Intent, deps.Config.Review, deps.Config.Retro, deps.Config.AgentSandbox)
+	if !deps.Config.Intent.Enforce || !deps.Config.Review.RequireApproval || !deps.Config.Review.FanOut || !deps.Config.AgentSandbox.Enabled {
+		t.Fatalf("security settings not updated: intent=%+v review=%+v sandbox=%+v",
+			deps.Config.Intent, deps.Config.Review, deps.Config.AgentSandbox)
 	}
 	if deps.Config.Intent.AlignmentModel != "gpt-4o" || deps.Config.Review.MaxParallelReviews != 3 ||
-		deps.Config.Review.FixerAgent != "scanner" || deps.Config.Retro.AnalysisModel != "claude-sonnet" ||
-		!deps.Config.OTel.Enabled || deps.Config.OTel.Endpoint != "https://otel.example.com:4318" ||
-		deps.Config.OTel.ServiceName != "hive-sec" || !deps.Config.OTel.Insecure ||
-		deps.Config.OTel.SampleRatio != 0.5 || deps.Config.OTel.Headers["authorization"] != "${OTEL_TOKEN}" {
-		t.Fatalf("advanced security settings not updated: intent=%+v review=%+v retro=%+v otel=%+v",
-			deps.Config.Intent, deps.Config.Review, deps.Config.Retro, deps.Config.OTel)
+		deps.Config.Review.FixerAgent != "scanner" {
+		t.Fatalf("advanced security settings not updated: intent=%+v review=%+v",
+			deps.Config.Intent, deps.Config.Review)
 	}
 
 	body := decodeJSON(t, doGet(s, "/api/config/governor"))
@@ -60,7 +49,7 @@ func TestGovernorSecurityEndpointUpdatesOverlayFields(t *testing.T) {
 		t.Fatalf("security section missing: %#v", body["security"])
 	}
 	if sec["ioscanFailMode"] != "closed" || sec["reviewCapableAgents"].(float64) != 1 ||
-		sec["intentAlignmentModel"] != "gpt-4o" || sec["otelHasHeaders"] != true {
+		sec["intentAlignmentModel"] != "gpt-4o" {
 		t.Fatalf("security section wrong: %#v", sec)
 	}
 }
@@ -81,8 +70,6 @@ func TestGovernorSecurityRejectsInvalidAdvancedValues(t *testing.T) {
 		name string
 		body map[string]any
 	}{
-		{name: "bad otel endpoint", body: map[string]any{"otelEndpoint": "ftp://otel.example.com"}},
-		{name: "bad otel sample", body: map[string]any{"otelSampleRatio": 1.5}},
 		{name: "bad review max", body: map[string]any{"reviewMaxParallelReviews": 65}},
 	}
 	for _, tt := range tests {

--- a/v2/pkg/dashboard/bob_key_store_test.go
+++ b/v2/pkg/dashboard/bob_key_store_test.go
@@ -392,7 +392,7 @@ func TestBobKeyUILivesOnGovernorTab(t *testing.T) {
 		snippet string
 	}{
 		{"tab name constant", "const GOVERNOR_BOB_TAB = 'Bob';"},
-		{"tab is in the governor strip", "'Model Gateways', GOVERNOR_BOB_TAB, 'Variables', 'Access'"},
+		{"tab is in the governor strip", "'Model Gateways', GOVERNOR_BOB_TAB, 'Variables', 'Security'"},
 		{"tab is wired into render dispatch", "case GOVERNOR_BOB_TAB: return renderGovBob();"},
 		{"tab renderer exists", "function renderGovBob() {"},
 		{"status loader exists", "async function loadBobKeyStatus() {"},

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -303,6 +303,8 @@ type FrontendSecurity struct {
 	ReviewRequireApproval bool   `json:"reviewRequireApproval"`
 	ReviewFanOut          bool   `json:"reviewFanOut"`
 	ReviewCapableAgents   int    `json:"reviewCapableAgents"`
+	RetroEnabled          bool   `json:"retroEnabled"`
+	OTelEnabled           bool   `json:"otelEnabled"`
 	SandboxEnabled        bool   `json:"sandboxEnabled"`
 	SandboxedAgents       int    `json:"sandboxedAgents"`
 	TotalAgents           int    `json:"totalAgents"`

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -291,6 +291,21 @@ type StatusPayload struct {
 	// nil-safe: a github-only, mint-off hive with no skills dir still gets a
 	// populated (all-zero) block, so existing status output is unchanged.
 	Platform *FrontendPlatform `json:"platform,omitempty"`
+	Security *FrontendSecurity `json:"security,omitempty"`
+}
+
+// FrontendSecurity summarizes the effective operator security posture for compact dashboard display.
+type FrontendSecurity struct {
+	IntentEnforced        bool   `json:"intentEnforced"`
+	IoscanEnabled         bool   `json:"ioscanEnabled"`
+	IoscanFailMode        string `json:"ioscanFailMode"`
+	IoscanCanaries        bool   `json:"ioscanCanaries"`
+	ReviewRequireApproval bool   `json:"reviewRequireApproval"`
+	ReviewFanOut          bool   `json:"reviewFanOut"`
+	ReviewCapableAgents   int    `json:"reviewCapableAgents"`
+	SandboxEnabled        bool   `json:"sandboxEnabled"`
+	SandboxedAgents       int    `json:"sandboxedAgents"`
+	TotalAgents           int    `json:"totalAgents"`
 }
 
 // FrontendPlatform reports the v4 spoke capabilities (forge, mint, skills) for
@@ -403,6 +418,7 @@ type FrontendAgent struct {
 	NeedsRestart     bool   `json:"needsRestart,omitempty"`
 	ProxyViolations  int    `json:"proxyViolations"`
 	OnDemand         bool   `json:"onDemand,omitempty"`
+	Sandboxed        bool   `json:"sandboxed,omitempty"`
 	LastError        string `json:"lastError,omitempty"`
 	StallNudges      int    `json:"stallNudges,omitempty"`
 	ActionNudges     int    `json:"actionNudges,omitempty"`

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4146,7 +4146,7 @@
       detail.innerHTML = `
         <div class="oc-agent-detail-header">
           <span class="status-dot ${dotState}"${dotTitle ? ` title="${esc(dotTitle)}"` : ''}></span>
-          <span class="agent-name-big">${esc(a.displayName || a.name)}</span>${needsLoginDown ? '<span title="CLI needs login" style="margin-left:6px">\uD83D\uDD11</span>' : ''}
+          <span class="agent-name-big">${esc(a.displayName || a.name)}</span>${a.sandboxed ? ' <span class="status-badge done" title="Sandboxed runner active">sandboxed</span>' : ''}${needsLoginDown ? '<span title="CLI needs login" style="margin-left:6px">\uD83D\uDD11</span>' : ''}
           <span style="font-size:0.78rem;color:var(--muted);margin-left:auto">${stateLabel}${pauseInfoIcon(a)}</span>
         </div>
         <div class="oc-detail-actions">
@@ -4322,7 +4322,7 @@
       const label = a.displayName || a.name;
       const emojiHtml = a.emoji ? `<span class="oc-nav-emoji">${a.emoji}</span>` : '';
       const modeHtml = (a.modeEmoji || a.mode) ? `<span class="oc-nav-mode" title="${esc(a.mode || '')}">${a.modeEmoji || modeEmoji(a.mode)}</span>` : '';
-      return `<a class="oc-nav-item${isActive}" data-agent-nav="${esc(a.name)}" draggable="true" data-action="ocSelectAgent" data-agent="${esc(a.name)}" title="${esc(agentDesc)}"><span class="oc-agent-dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${emojiHtml}<span class="oc-nav-text">${esc(label)}</span>${needsLoginDown ? '<span class="oc-nav-key" title="CLI needs login">\uD83D\uDD11</span>' : ''}${modeHtml}<span class="oc-nav-actions"><button data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure">⚙</button><button class="oc-nav-delete" data-action="deleteAgentFromConfig" data-agent="${esc(a.name)}" title="Delete">✕</button></span></a>`;
+      return `<a class="oc-nav-item${isActive}" data-agent-nav="${esc(a.name)}" draggable="true" data-action="ocSelectAgent" data-agent="${esc(a.name)}" title="${esc(agentDesc)}"><span class="oc-agent-dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${emojiHtml}<span class="oc-nav-text">${esc(label)}</span>${needsLoginDown ? '<span class="oc-nav-key" title="CLI needs login">\uD83D\uDD11</span>' : ''}${a.sandboxed ? '<span class="status-badge done" title="Sandboxed">S</span>' : ''}${modeHtml}<span class="oc-nav-actions"><button data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure">⚙</button><button class="oc-nav-delete" data-action="deleteAgentFromConfig" data-agent="${esc(a.name)}" title="Delete">✕</button></span></a>`;
     }
 
     function _sidebarBuildGroups(agents) {
@@ -5733,7 +5733,7 @@
         const compactCls = isAgentCompact(a.name) ? ' compact' : '';
         return `<div class="agent-card ${cls}${compactCls}" data-agent="${esc(a.name)}">
           <span class="working-indicator"></span>
-          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''} ${toggleBtn} <button class="compact-toggle" onclick="event.stopPropagation();toggleAgentCompact('${esc(a.name)}')" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure ${esc(a.displayName || a.name)}">⚙️</button></div>
+          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''}${a.sandboxed ? ' <span class="status-badge done" title="Sandboxed runner active">sandboxed</span>' : ''} ${toggleBtn} <button class="compact-toggle" onclick="event.stopPropagation();toggleAgentCompact('${esc(a.name)}')" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure ${esc(a.displayName || a.name)}">⚙️</button></div>
           <div class="agent-state ${isOnDemand ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}${pauseInfoIcon(a)}${(() => {
             if (a.structuredStatus === 'BLOCKED') return '<span class="status-badge blocked" title="' + esc(a.statusEvidence) + '">blocked</span>';
             if (a.structuredStatus === 'NEEDS_CONTEXT') return '<span class="status-badge needs-context" title="' + esc(a.statusEvidence) + '">needs context</span>';
@@ -14194,7 +14194,7 @@ function burnAreaChart() {
     // hub-synced user/role data. It sits next to Model Gateways because both
     // are backend configuration.
     const GOVERNOR_BOB_TAB = 'Bob';
-    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Features', 'Hub', 'Forge App', 'Model Gateways', GOVERNOR_BOB_TAB, 'Variables', 'Access'];
+    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Security', 'Features', 'Hub', 'Forge App', 'Model Gateways', GOVERNOR_BOB_TAB, 'Variables', 'Access'];
     const PIPELINE_STAGES = ['resolve-beads', 'track-prs', 'stale-check', 'repo-scan', 'coverage-gate', 'prompt-compose', 'budget-check', 'api-collect', 'final-compose'];
     const PIPELINE_STAGE_TIPS = {
       'resolve-beads': 'Fetch and inject knowledge beads (facts, patterns, gotchas) relevant to the agent\'s current task context.',
@@ -14795,6 +14795,7 @@ function burnAreaChart() {
         case 'Health': return renderGovHealth(d.health || {});
         case 'Sensing': return renderGovSensing(d.sensing || {});
         case 'Logging': return renderGovLogging(d.logging || {});
+        case 'Security': return renderGovSecurity(d.security || {});
         case 'Features': return renderGovFeatures(d.features || {});
         case 'Hub': return renderGovHub(d.hub || {});
         case 'Forge App': return renderGovForgeApp();
@@ -16554,6 +16555,10 @@ function burnAreaChart() {
           <input type="text" id="cfg-launch-cmd" value="${esc(g.launchCmd || '')}" onchange="markDirty('general','launchCmd',this.value)">
         </div>
         <div class="config-toggle">
+          <div class="config-toggle-switch ${g.sandboxEnabled ? 'on' : ''}" id="cfg-agent-sandbox" data-action="toggleConfigSwitch" data-section="general" data-key="sandboxEnabled"></div>
+          <span class="config-toggle-label">Run in sandbox <span class="config-info">i<span class="config-tooltip">Opt this agent into the credential-free sandbox runner. Requires the hive-wide sandbox gate in Governor → Security to be enabled.</span></span>${g.sandboxEffective ? ' <span class="status-badge done">sandboxed</span>' : ''}</span>
+        </div>
+        <div class="config-toggle">
           <div class="config-toggle-switch ${g.clearOnKick !== false ? 'on' : ''}" id="cfg-clear-on-kick" data-action="toggleConfigSwitch" data-section="general" data-key="clearOnKick"></div>
           <span class="config-toggle-label">Clear on Kick <span class="config-info">i<span class="config-tooltip">Send /clear before each governor kick to reset conversation context. Prevents stale context buildup across runs. On by default for all agents.</span></span></span>
         </div>
@@ -17653,6 +17658,7 @@ function burnAreaChart() {
             <button class="btn" onclick="closeConfigDialog();openACMMDialog()" title="Open the ACMM maturity level selector">Change&hellip;</button>
           </div>
           <span style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:block">Each level applies a curated agent pack. Change&hellip; opens the level selector.</span>
+          <div style="margin-top:8px">${securityPostureStripHtml()}</div>
         </div>
         <div class="config-toggle" style="margin-top:14px">
           <div class="config-toggle-switch ${attribOn ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="attribution" data-key="attributionTrailer"></div>
@@ -17757,17 +17763,28 @@ function burnAreaChart() {
     }
 
     function renderGovAgents(agents) {
-      const list = agents.map(a =>
-        `<li><span class="agent-link" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a)}">${esc(a)}</span><button class="remove-agent" data-action="removeAgent" data-agent="${esc(a)}">✕</button></li>`
-      ).join('');
+      const sec = (_configState.data || {}).security || {};
+      const live = window._lastAgents || [];
+      const liveMap = {};
+      live.forEach(a => { liveMap[a.name] = a; });
+      const list = agents.map(a => {
+        const name = typeof a === 'string' ? a : (a && a.name) || '';
+        const sandboxed = (liveMap[name] && liveMap[name].sandboxed) || false;
+        const badge = sandboxed ? ' <span class="status-badge done" title="This agent is opted into the sandbox and the global sandbox gate is on">sandboxed</span>' : '';
+        return `<li><span class="agent-link" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(name)}">${esc(name)}</span>${badge}<button class="remove-agent" data-action="removeAgent" data-agent="${esc(name)}">✕</button></li>`;
+      }).join('');
+      const sandboxNote = sec.agentSandboxEnabled
+        ? `${sec.sandboxedAgents || 0}/${sec.totalAgents || agents.length} agents sandboxed`
+        : 'Sandbox global gate is off — per-agent opt-ins are staged but not active.';
       return `
-        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Managed agents. Click name to configure.</p>
+        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px">Managed agents. Click name to configure.</p>
+        <div style="font-size:0.72rem;color:var(--muted);margin-bottom:10px">${esc(sandboxNote)}</div>
         <ul class="config-agent-list">${list}</ul>
         <div class="config-list-add" style="margin-top:12px">
           <input type="text" id="cfg-new-agent" placeholder="agent name" title="Internal name for the new agent. Used as the tmux session name and config file name. Use lowercase with no spaces (e.g. scanner, code-reviewer).">
           <select id="cfg-copy-from" style="margin-left:6px;font-size:0.75rem;background:var(--surface);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:4px 6px" title="Optionally copy configuration from an existing agent. Select 'blank' to start with default settings.">
             <option value="">blank</option>
-            ${agents.map(a => '<option value="' + esc(a) + '">copy ' + esc(a) + '</option>').join('')}
+            ${agents.map(a => { const name = typeof a === 'string' ? a : (a && a.name) || ''; return '<option value="' + esc(name) + '">copy ' + esc(name) + '</option>'; }).join('')}
           </select>
           <button onclick="addAgent()" title="Create the new agent with the specified name and optional copied config">+ Add Agent</button>
         </div>`;
@@ -18277,6 +18294,84 @@ function burnAreaChart() {
         </div>`;
     }
 
+    function securityPostureStripHtml() {
+      const sec = ((window._lastStatus || {}).security) || ((_configState.data || {}).security) || {};
+      const level = (window._lastStatus || {}).acmmLevel || 0;
+      const parts = [
+        level > 0 ? ('L' + level) : 'L?',
+        sec.intentEnforced || sec.intentEnforce ? 'intent enforced' : 'intent report-only',
+        'ioscan fail-' + ((sec.ioscanFailMode || 'open') === 'closed' ? 'closed' : 'open'),
+        (sec.ioscanCanaries ? 'canaries on' : 'canaries off'),
+        'sandbox ' + (sec.sandboxedAgents || 0) + '/' + (sec.totalAgents || 0) + ' agents',
+      ];
+      return '<div style="display:inline-flex;align-items:center;gap:8px;flex-wrap:wrap;padding:6px 10px;border:1px solid var(--border);border-radius:999px;background:var(--surface);font-size:0.72rem;color:var(--muted)" title="Effective security posture from the dashboard overlay and running config">' + esc(parts.join(' · ')) + '</div>';
+    }
+
+    function securityWarningsHtml(sec) {
+      const level = (window._lastStatus || {}).acmmLevel || 0;
+      const warnings = [];
+      if (level >= 6 && !sec.intentEnforce) warnings.push('L6 is fully autonomous; intent enforcement is recommended before merge automation.');
+      if (level >= 5 && (sec.ioscanFailMode || 'open') === 'open') warnings.push('L5+ with ioscan fail-open keeps work flowing, but fail-closed gives stronger prompt-injection protection.');
+      if (sec.reviewRequireApproval && (sec.reviewCapableAgents || 0) === 0) warnings.push('Review approval is required, but no enabled review-capable agents were detected.');
+      if (!warnings.length) return '';
+      return '<div style="border:1px solid color-mix(in srgb, var(--amber) 45%, transparent);background:color-mix(in srgb, var(--amber) 10%, transparent);border-radius:8px;padding:10px 12px;margin:0 0 14px;color:var(--amber);font-size:0.76rem;line-height:1.5"><strong>Coherence warnings (non-blocking)</strong><ul style="margin:6px 0 0 18px;padding:0">' + warnings.map(w => '<li>' + esc(w) + '</li>').join('') + '</ul></div>';
+    }
+
+    function renderGovSecurity(sec) {
+      sec = sec || {};
+      const failMode = sec.ioscanFailMode || 'open';
+      const classifierToggle = Object.prototype.hasOwnProperty.call(sec, 'classifierEnabled')
+        ? `<div class="config-toggle">
+            <div class="config-toggle-switch ${sec.classifierEnabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="classifierEnabled"></div>
+            <span class="config-toggle-label">Classifier enabled <span class="config-info">i<span class="config-tooltip">Enable the optional classifier security control when this backend supports it.</span></span></span>
+          </div>`
+        : '';
+      return `
+        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:10px">Operator security controls saved through the dashboard overlay.</p>
+        <div style="margin-bottom:14px">${securityPostureStripHtml()}</div>
+        ${securityWarningsHtml(sec)}
+        <div class="config-toggle">
+          <div class="config-toggle-switch ${sec.ioscanEnabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="ioscanEnabled"></div>
+          <span class="config-toggle-label">Input/Output scanning (ioscan) <span class="config-info">i<span class="config-tooltip">Scan untrusted issue/PR text for prompt-injection and dangerous directives before agent kicks.</span></span></span>
+        </div>
+        <div class="config-field">
+          <label>ioscan fail mode <span class="config-info">i<span class="config-tooltip">open redacts and continues; closed blocks kicks with critical injection findings.</span></span></label>
+          <select onchange="markDirty('security','ioscanFailMode',this.value)">
+            <option value="open" ${failMode === 'open' ? 'selected' : ''}>open — redact and continue</option>
+            <option value="closed" ${failMode === 'closed' ? 'selected' : ''}>closed — block critical findings</option>
+          </select>
+        </div>
+        <div class="config-toggle">
+          <div class="config-toggle-switch ${sec.ioscanCanaries ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="ioscanCanaries"></div>
+          <span class="config-toggle-label">ioscan canaries <span class="config-info">i<span class="config-tooltip">Plant per-kick exfiltration markers and scan egress for leaks.</span></span></span>
+        </div>
+        ${classifierToggle}
+        <hr style="border-color:var(--border);margin:16px 0">
+        <div class="config-toggle">
+          <div class="config-toggle-switch ${sec.intentEnforce ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="intentEnforce"></div>
+          <span class="config-toggle-label">Enforce intent authorization on merges</span>
+        </div>
+        <div class="config-toggle">
+          <div class="config-toggle-switch ${sec.reviewRequireApproval ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="reviewRequireApproval"></div>
+          <span class="config-toggle-label">Require structured review approval before merge</span>
+        </div>
+        <div class="config-toggle">
+          <div class="config-toggle-switch ${sec.reviewFanOut ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="reviewFanOut"></div>
+          <span class="config-toggle-label">Fan out review work to review-capable agents</span>
+        </div>
+        <div class="config-toggle">
+          <div class="config-toggle-switch ${sec.agentSandboxEnabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="agentSandboxEnabled"></div>
+          <span class="config-toggle-label">Enable agent sandbox runner <span class="config-info">i<span class="config-tooltip">Global gate for per-agent sandbox opt-ins. Agents still opt in from their own General tab.</span></span></span>
+        </div>
+        <div style="margin-top:18px;padding-top:14px;border-top:1px solid var(--border)">
+          <div style="font-size:0.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px">Quality loops</div>
+          <div class="config-toggle">
+            <div class="config-toggle-switch ${sec.retroEnabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="retroEnabled"></div>
+            <span class="config-toggle-label">Retro loop enabled</span>
+          </div>
+        </div>`;
+    }
+
     // renderGovFeatures renders the "Features" tab: four already-functional
     // opt-in capabilities exposed as toggles so operators need not hand-edit
     // hive.yaml. Each control marks the shared 'features' dirty section, which
@@ -18774,6 +18869,7 @@ function burnAreaChart() {
         if (_configState.promptTemplateDirty && _configState.promptTemplateValue) {
           agent.kick_template = _configState.promptTemplateValue;
         }
+        if (generalData.sandboxEnabled !== undefined) agent.sandbox = { enabled: generalData.sandboxEnabled };
         const ps = collectPromptSource();
         if (ps) agent.prompt_source = ps;
         try {
@@ -18870,6 +18966,7 @@ function burnAreaChart() {
             if (savedGeneral.emoji !== undefined) liveAgent.emoji = savedGeneral.emoji;
             if (savedGeneral.color !== undefined) liveAgent.color = savedGeneral.color;
             if (savedGeneral.sortOrder !== undefined) liveAgent.sortOrder = savedGeneral.sortOrder;
+            if (savedGeneral.sandboxEnabled !== undefined) liveAgent.sandboxed = savedGeneral.sandboxEnabled && (((window._lastStatus || {}).security || {}).sandboxEnabled !== false);
           }
         }
         _configState.dirty = {};

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1667,7 +1667,7 @@
     .config-info:hover .config-tooltip { display: block; }
 
     .config-list { margin-bottom: 14px; }
-    /* Role pills for the Access tab (read-only authorized-users view). */
+    /* Role pills for the Security tab Access subsection (read-only authorized-users view). */
     .role-badge { display: inline-block; padding: 2px 10px; border-radius: 9999px; font-weight: 600; white-space: nowrap; }
     .role-owner { background: rgba(244,199,95,0.15); color: var(--amber); border: 1px solid rgba(244,199,95,0.3); }
     .role-read { background: rgba(128,191,255,0.15); color: var(--blue); border: 1px solid rgba(128,191,255,0.3); }
@@ -11106,7 +11106,7 @@ function burnAreaChart() {
 
     /* Rendered avatar sizes, in CSS pixels. The contributor cards and the
        leaderboard rows share a size because they are the same kind of roster;
-       the Access tab's allowlist is a denser config list. */
+       the Security tab's Access subsection allowlist is a denser config list. */
     const CONTRIBUTOR_AVATAR_PX = 28;
     const ACCESS_LIST_AVATAR_PX = 20;
 
@@ -14190,11 +14190,11 @@ function burnAreaChart() {
     // It is deliberately NOT part of 'Model Gateways': a gateway is an
     // OpenAI-compatible inference ENDPOINT (endpoint + default_model, routed
     // to by name), whereas the bob key authenticates a binary running in this
-    // pod and has neither. It is also not 'Access', which is read-only
-    // hub-synced user/role data. It sits next to Model Gateways because both
-    // are backend configuration.
+    // pod and has neither. It is also not the Security tab's Access subsection,
+    // which is read-only hub-synced user/role data. It sits next to Model
+    // Gateways because both are backend configuration.
     const GOVERNOR_BOB_TAB = 'Bob';
-    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Security', 'Features', 'Hub', 'Forge App', 'Model Gateways', GOVERNOR_BOB_TAB, 'Variables', 'Access'];
+    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Features', 'Hub', 'Forge App', 'Model Gateways', GOVERNOR_BOB_TAB, 'Variables', 'Security'];
     const PIPELINE_STAGES = ['resolve-beads', 'track-prs', 'stale-check', 'repo-scan', 'coverage-gate', 'prompt-compose', 'budget-check', 'api-collect', 'final-compose'];
     const PIPELINE_STAGE_TIPS = {
       'resolve-beads': 'Fetch and inject knowledge beads (facts, patterns, gotchas) relevant to the agent\'s current task context.',
@@ -14233,8 +14233,10 @@ function burnAreaChart() {
       } else {
         const configKey = type === 'governor' ? '__governor__' : agentName;
         const savedTab = _configTabMemory[configKey];
-        const overrideTab = _configState.initialTabOverride;
-        const initialTab = (overrideTab && tabs.includes(overrideTab)) ? overrideTab : (savedTab && tabs.includes(savedTab) ? savedTab : tabs[0]);
+        let overrideTab = _configState.initialTabOverride;
+        if (type === 'governor' && overrideTab === 'Access') overrideTab = 'Security';
+        const rememberedTab = type === 'governor' && savedTab === 'Access' ? 'Security' : savedTab;
+        const initialTab = (overrideTab && tabs.includes(overrideTab)) ? overrideTab : (rememberedTab && tabs.includes(rememberedTab) ? rememberedTab : tabs[0]);
         document.getElementById('config-body').innerHTML = '<div style="text-align:center;padding:40px;color:var(--muted)">Loading…</div>';
         loadConfigData(type, agentName).finally(() => {
           if (!_configModalOpen) return;
@@ -14796,13 +14798,13 @@ function burnAreaChart() {
         case 'Sensing': return renderGovSensing(d.sensing || {});
         case 'Logging': return renderGovLogging(d.logging || {});
         case 'Security': return renderGovSecurity(d.security || {});
+        case 'Access': return renderGovSecurity(d.security || {});
         case 'Features': return renderGovFeatures(d.features || {});
         case 'Hub': return renderGovHub(d.hub || {});
         case 'Forge App': return renderGovForgeApp();
         case 'Model Gateways': return renderGovGateways();
         case GOVERNOR_BOB_TAB: return renderGovBob();
         case 'Variables': return renderGovVariables();
-        case 'Access': return renderGovAccess();
         default: return '';
       }
     }
@@ -14943,7 +14945,7 @@ function burnAreaChart() {
     // variables can be added/edited/deleted here; script and http variables are
     // shown read-only because they can execute code or reach the network and are
     // therefore seed-only (GitOps), enforced server-side.
-    // ── Access tab: read-only view of who can log in to this hive ──
+    // ── Security tab / Access subsection: read-only view of who can log in to this hive ──
     // Reads GET /api/config/authorized-users. Access is granted on the HUB
     // (Manage Access) and propagated to the spoke via heartbeat, so this view is
     // intentionally read-only — it shows the current allowlist, not an editor.
@@ -18335,6 +18337,10 @@ function burnAreaChart() {
       return '<input type="text" list="security-model-options" value="' + esc(value || '') + '" placeholder="' + esc(placeholder || 'model id') + '" onchange="markDirty(\'security\',\'' + key + '\',this.value.trim())">';
     }
 
+    function featureModelInput(key, value, placeholder) {
+      return '<input type="text" list="security-model-options" value="' + esc(value || '') + '" placeholder="' + esc(placeholder || 'model id') + '" onchange="markDirty(\'features\',\'' + key + '\',this.value.trim())">';
+    }
+
     function parseSecurityList(value) {
       return String(value || '').split(',').map(s => s.trim()).filter(Boolean);
     }
@@ -18348,7 +18354,13 @@ function burnAreaChart() {
         if (idx <= 0) return;
         headers[trimmed.slice(0, idx).trim()] = trimmed.slice(idx + 1).trim();
       });
-      markDirty('security', 'otelHeaders', headers);
+      markDirty('features', 'otelHeaders', headers);
+    }
+
+    function renderSecuritySection(title, html) {
+      return '<section style="margin-top:18px;padding-top:14px;border-top:1px solid var(--border)">' +
+        '<div style="font-size:0.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:8px">' + esc(title) + '</div>' +
+        html + '</section>';
     }
 
     function renderGovSecurity(sec) {
@@ -18363,12 +18375,8 @@ function burnAreaChart() {
             <div class="config-field"><label>Block threshold</label><input type="number" min="0" max="1" step="0.01" value="${(sec.ioscanClassifier || {}).blockThreshold ?? ''}" onchange="markDirty('security','ioscanClassifierBlockThreshold',Number(this.value))"></div>
           </div>`
         : '<p style="font-size:0.72rem;color:var(--muted);margin:8px 0 0">ioscan classifier fields are not present in this v4 backend yet; this disclosure will render them automatically when the API reports support.</p>';
-      return `
-        ${securityModelDatalistHtml()}${agentList}
-        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:10px">Operator security controls saved through the dashboard overlay.</p>
-        <div style="margin-bottom:14px">${securityPostureStripHtml()}</div>
-        ${securityWarningsHtml(sec)}
 
+      const inputDefense = `
         <div class="config-toggle">
           <div class="config-toggle-switch ${sec.ioscanEnabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="ioscanEnabled"></div>
           <span class="config-toggle-label">Input/Output scanning (ioscan) <span class="config-info">i<span class="config-tooltip">Scan untrusted issue/PR text for prompt-injection and dangerous directives before agent kicks.</span></span></span>
@@ -18384,9 +18392,9 @@ function burnAreaChart() {
           <div class="config-toggle-switch ${sec.ioscanCanaries ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="ioscanCanaries"></div>
           <span class="config-toggle-label">ioscan canaries <span class="config-info">i<span class="config-tooltip">Plant per-kick exfiltration markers and scan egress for leaks.</span></span></span>
         </div>
-        <details style="margin:10px 0 18px"><summary style="cursor:pointer;color:var(--muted);font-size:0.78rem;font-weight:600">Advanced ioscan classifier</summary>${classifierAdvanced}</details>
+        <details style="margin:10px 0 0"><summary style="cursor:pointer;color:var(--muted);font-size:0.78rem;font-weight:600">Advanced ioscan classifier</summary>${classifierAdvanced}</details>`;
 
-        <hr style="border-color:var(--border);margin:16px 0">
+      const mergeGates = `
         <div class="config-toggle">
           <div class="config-toggle-switch ${sec.intentEnforce ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="intentEnforce"></div>
           <span class="config-toggle-label">Enforce intent authorization on merges</span>
@@ -18403,78 +18411,73 @@ function burnAreaChart() {
           <div class="config-toggle-switch ${sec.reviewFanOut ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="reviewFanOut"></div>
           <span class="config-toggle-label">Fan out review work to review-capable agents</span>
         </div>
-        <details style="margin:10px 0 18px"><summary style="cursor:pointer;color:var(--muted);font-size:0.78rem;font-weight:600">Advanced review gate</summary>
+        <details style="margin:10px 0 0"><summary style="cursor:pointer;color:var(--muted);font-size:0.78rem;font-weight:600">Advanced review gate</summary>
           <div class="config-field-row">
             <div class="config-field"><label>Max parallel reviews</label><input type="number" min="0" max="64" value="${sec.reviewMaxParallelReviews || 0}" onchange="markDirty('security','reviewMaxParallelReviews',Number(this.value))"><span style="font-size:0.65rem;color:var(--muted)">0 uses the default (${sec.reviewMaxParallelReviews || 5}).</span></div>
             <div class="config-field"><label>Fixer agent</label><input type="text" list="security-agent-options" value="${esc(sec.reviewFixerAgent || '')}" placeholder="scanner" onchange="markDirty('security','reviewFixerAgent',this.value.trim())"></div>
           </div>
           <div class="config-field"><label>Reviewer agents <span style="font-weight:400;color:var(--muted)">(comma-separated allowlist)</span></label><input type="text" value="${esc((sec.reviewReviewerAgents || []).join(', '))}" placeholder="leave blank to auto-detect review-capable agents" onchange="markDirty('security','reviewReviewerAgents',parseSecurityList(this.value))"></div>
           <p style="font-size:0.72rem;color:var(--muted);margin:6px 0 0">Review severity threshold is not present in this v4 backend config yet, so there is no safe field to persist.</p>
-        </details>
+        </details>`;
 
-        <div style="margin-top:18px;padding-top:14px;border-top:1px solid var(--border)">
-          <div style="font-size:0.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px">Quality loops</div>
-          <div class="config-toggle">
-            <div class="config-toggle-switch ${sec.retroEnabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="retroEnabled"></div>
-            <span class="config-toggle-label">Retro loop enabled</span>
-          </div>
-          <details style="margin:10px 0 0"><summary style="cursor:pointer;color:var(--muted);font-size:0.78rem;font-weight:600">Advanced retro</summary>
-            <div class="config-field"><label>Analysis model</label>${securityModelInput('retroAnalysisModel', sec.retroAnalysisModel || '', 'leave empty for deterministic only')}</div>
-          </details>
-        </div>
-
-        <div style="margin-top:18px;padding-top:14px;border-top:1px solid var(--border)">
-          <div class="config-toggle">
-            <div class="config-toggle-switch ${sec.otelEnabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="otelEnabled"></div>
-            <span class="config-toggle-label">OpenTelemetry export enabled</span>
-          </div>
-          <details style="margin:10px 0 18px"><summary style="cursor:pointer;color:var(--muted);font-size:0.78rem;font-weight:600">Advanced OpenTelemetry</summary>
-            <div class="config-field"><label>Endpoint</label><input type="text" value="${esc(sec.otelEndpoint || '')}" placeholder="https://otel-collector:4318" onchange="markDirty('security','otelEndpoint',this.value.trim())"></div>
-            <div class="config-field-row">
-              <div class="config-field"><label>Service name</label><input type="text" value="${esc(sec.otelServiceName || '')}" placeholder="hive" onchange="markDirty('security','otelServiceName',this.value.trim())"></div>
-              <div class="config-field"><label>Sample ratio</label><input type="number" min="0" max="1" step="0.01" value="${sec.otelSampleRatio || 0}" onchange="markDirty('security','otelSampleRatio',Number(this.value))"><span style="font-size:0.65rem;color:var(--muted)">0 means sample all.</span></div>
-            </div>
-            <div class="config-toggle"><div class="config-toggle-switch ${sec.otelInsecure ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="otelInsecure"></div><span class="config-toggle-label">Allow insecure OTLP transport</span></div>
-            <div class="config-field"><label>Headers <span style="font-weight:400;color:var(--muted)">(write-only, one key=value per line)</span></label><textarea rows="3" style="width:100%;resize:vertical;font-family:var(--font-mono);font-size:0.74rem" placeholder="authorization=\${OTEL_EXPORTER_TOKEN}" onchange="parseOtelHeaders(this.value)"></textarea><div style="font-size:0.68rem;color:var(--muted);margin-top:4px">${sec.otelHasHeaders ? 'Headers are configured; values are never echoed back.' : 'No headers configured.'} <button type="button" onclick="markDirty('security','otelHeaders',{});showToast('OTel headers will be cleared on Save','info')" style="margin-left:8px;font-size:0.68rem;padding:2px 8px;border:1px solid var(--border);background:var(--bg);color:var(--muted);border-radius:4px;cursor:pointer">Clear saved headers</button></div></div>
-          </details>
-        </div>
-
+      const isolation = `
         <div class="config-toggle">
           <div class="config-toggle-switch ${sec.agentSandboxEnabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="agentSandboxEnabled"></div>
           <span class="config-toggle-label">Enable agent sandbox runner <span class="config-info">i<span class="config-tooltip">Global gate for per-agent sandbox opt-ins. Agents still opt in from their own General tab.</span></span></span>
-        </div>`;
+        </div>
+        <p style="font-size:0.72rem;color:var(--muted);margin:6px 0 0">Per-agent opt-in lives on each agent's General tab. Current effective posture: ${Number(sec.sandboxedAgents || 0)}/${Number(sec.totalAgents || 0)} agents sandboxed.</p>`;
+
+      return `
+        ${securityModelDatalistHtml()}${agentList}
+        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:10px">Security posture and access controls saved through the dashboard overlay.</p>
+        <div style="margin-bottom:14px">${securityPostureStripHtml()}</div>
+        ${securityWarningsHtml(sec)}
+        ${renderSecuritySection('Access', renderGovAccess())}
+        ${renderSecuritySection('Input Defense', inputDefense)}
+        ${renderSecuritySection('Merge Gates', mergeGates)}
+        ${renderSecuritySection('Isolation', isolation)}`;
     }
 
-    // renderGovFeatures renders the "Features" tab: four already-functional
-    // opt-in capabilities exposed as toggles so operators need not hand-edit
-    // hive.yaml. Each control marks the shared 'features' dirty section, which
-    // saveConfig() PUTs to /api/config/governor/features as a single body whose
-    // keys match the handler's JSON fields (ioscanEnabled, tracingEnabled,
-    // tracingEndpoint, mintEnabled, mintIssuer, planFromLabel). The mint signing
-    // key is intentionally NOT surfaced — the overlay is secret-free.
+    // renderGovFeatures renders operational features that are not security posture
+    // controls. ioscan moved to Security/Input Defense; OpenTelemetry and retro
+    // stay here as observability/quality-loop settings.
     function renderGovFeatures(f) {
       f = f || {};
-      // planFromLabel is a tri-state on the wire: null = "default (ACMM gate)",
-      // true/false = explicit. The toggle shows on only for an explicit true.
       const planOn = f.planFromLabel === true;
       return `
-        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Opt-in capabilities. Each is off by default and safe to leave off; toggling here writes the same setting you could set by hand in <code>hive.yaml</code>. Changes take effect on the next hive restart.</p>
+        ${securityModelDatalistHtml()}
+        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Opt-in capabilities. Security-posture controls live in the Security tab; observability and quality-loop controls stay here.</p>
 
-        <div class="config-toggle">
-          <div class="config-toggle-switch ${f.ioscanEnabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="features" data-key="ioscanEnabled"></div>
-          <span class="config-toggle-label">Input/Output Scanning (ioscan) <span class="config-info">i<span class="config-tooltip">Scans untrusted external text (issue titles/bodies) for prompt-injection and secret/dangerous directives before it is injected into an agent kick. Advisory and fail-safe — it never crashes a kick.</span></span></span>
+        <div style="font-size:0.72rem;color:var(--muted);background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:10px;margin-bottom:14px">
+          Input/Output Scanning (ioscan) moved to <b>Security → Input Defense</b> so its enablement, fail mode, canaries, and classifier settings have one canonical control surface.
         </div>
 
         <div style="margin:18px 0;padding-top:14px;border-top:1px solid var(--border)">
+          <div style="font-size:0.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px">Observability</div>
           <div class="config-toggle">
             <div class="config-toggle-switch ${f.tracingEnabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="features" data-key="tracingEnabled"></div>
-            <span class="config-toggle-label">Distributed Tracing (OpenTelemetry) <span class="config-info">i<span class="config-tooltip">Exports OTLP/HTTP spans for hub/agent activity. Zero overhead when off. When on, traces export to your OTLP collector — view them in Grafana/Jaeger.</span></span></span>
+            <span class="config-toggle-label">OpenTelemetry export enabled <span class="config-info">i<span class="config-tooltip">Exports OTLP/HTTP spans for hub/agent activity. Zero overhead when off. When on, traces export to your OTLP collector — view them in Grafana/Jaeger.</span></span></span>
           </div>
-          <div class="config-field" style="margin-top:10px">
-            <label>OTLP/HTTP Endpoint <span class="config-info">i<span class="config-tooltip">Collector endpoint (e.g. https://otel-collector:4318). Leave empty to fall back to the standard OTEL_EXPORTER_OTLP_ENDPOINT env var.</span></span></label>
-            <input type="text" value="${esc(f.tracingEndpoint || '')}" placeholder="https://otel-collector:4318" onchange="markDirty('features','tracingEndpoint',this.value.trim())">
-            <p style="font-size:0.72rem;color:var(--muted);margin:4px 0 0">Traces export to your OTLP collector — view them in Grafana/Jaeger.</p>
+          <details style="margin:10px 0 0" open><summary style="cursor:pointer;color:var(--muted);font-size:0.78rem;font-weight:600">Advanced OpenTelemetry</summary>
+            <div class="config-field"><label>Endpoint <span class="config-info">i<span class="config-tooltip">Collector endpoint (e.g. https://otel-collector:4318). Leave empty to fall back to the standard OTEL_EXPORTER_OTLP_ENDPOINT env var.</span></span></label><input type="text" value="${esc(f.tracingEndpoint || '')}" placeholder="https://otel-collector:4318" onchange="markDirty('features','tracingEndpoint',this.value.trim())"></div>
+            <div class="config-field-row">
+              <div class="config-field"><label>Service name</label><input type="text" value="${esc(f.otelServiceName || '')}" placeholder="hive" onchange="markDirty('features','otelServiceName',this.value.trim())"></div>
+              <div class="config-field"><label>Sample ratio</label><input type="number" min="0" max="1" step="0.01" value="${f.tracingSampleRatio || 0}" onchange="markDirty('features','tracingSampleRatio',Number(this.value))"><span style="font-size:0.65rem;color:var(--muted)">0 means sample all.</span></div>
+            </div>
+            <div class="config-toggle"><div class="config-toggle-switch ${f.otelInsecure ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="features" data-key="otelInsecure"></div><span class="config-toggle-label">Allow insecure OTLP transport</span></div>
+            <div class="config-field"><label>Headers <span style="font-weight:400;color:var(--muted)">(write-only, one key=value per line)</span></label><textarea rows="3" style="width:100%;resize:vertical;font-family:var(--font-mono);font-size:0.74rem" placeholder="authorization=\${OTEL_EXPORTER_TOKEN}" onchange="parseOtelHeaders(this.value)"></textarea><div style="font-size:0.68rem;color:var(--muted);margin-top:4px">${f.otelHasHeaders ? 'Headers are configured; values are never echoed back.' : 'No headers configured.'} <button type="button" onclick="markDirty('features','otelHeaders',{});showToast('OTel headers will be cleared on Save','info')" style="margin-left:8px;font-size:0.68rem;padding:2px 8px;border:1px solid var(--border);background:var(--bg);color:var(--muted);border-radius:4px;cursor:pointer">Clear saved headers</button></div></div>
+          </details>
+        </div>
+
+        <div style="margin:18px 0;padding-top:14px;border-top:1px solid var(--border)">
+          <div style="font-size:0.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px">Quality loops</div>
+          <div class="config-toggle">
+            <div class="config-toggle-switch ${f.retroEnabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="features" data-key="retroEnabled"></div>
+            <span class="config-toggle-label">Retro loop enabled</span>
           </div>
+          <details style="margin:10px 0 0"><summary style="cursor:pointer;color:var(--muted);font-size:0.78rem;font-weight:600">Advanced retro</summary>
+            <div class="config-field"><label>Analysis model</label>${featureModelInput('retroAnalysisModel', f.retroAnalysisModel || '', 'leave empty for deterministic only')}</div>
+          </details>
         </div>
 
         <div style="margin:18px 0;padding-top:14px;border-top:1px solid var(--border)">

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -18317,19 +18317,58 @@ function burnAreaChart() {
       return '<div style="border:1px solid color-mix(in srgb, var(--amber) 45%, transparent);background:color-mix(in srgb, var(--amber) 10%, transparent);border-radius:8px;padding:10px 12px;margin:0 0 14px;color:var(--amber);font-size:0.76rem;line-height:1.5"><strong>Coherence warnings (non-blocking)</strong><ul style="margin:6px 0 0 18px;padding:0">' + warnings.map(w => '<li>' + esc(w) + '</li>').join('') + '</ul></div>';
     }
 
+    function securityModelDatalistHtml() {
+      const seen = new Set();
+      const options = [];
+      (KNOWN_MODELS || []).forEach(m => {
+        const v = m.value || m.label || '';
+        if (v && !seen.has(v)) { seen.add(v); options.push(v); }
+      });
+      Object.values(BACKEND_MODELS || {}).forEach(list => (list || []).forEach(m => {
+        const v = m.value || m.label || '';
+        if (v && !seen.has(v)) { seen.add(v); options.push(v); }
+      }));
+      return '<datalist id="security-model-options">' + options.map(v => '<option value="' + esc(v) + '"></option>').join('') + '</datalist>';
+    }
+
+    function securityModelInput(key, value, placeholder) {
+      return '<input type="text" list="security-model-options" value="' + esc(value || '') + '" placeholder="' + esc(placeholder || 'model id') + '" onchange="markDirty(\'security\',\'' + key + '\',this.value.trim())">';
+    }
+
+    function parseSecurityList(value) {
+      return String(value || '').split(',').map(s => s.trim()).filter(Boolean);
+    }
+
+    function parseOtelHeaders(value) {
+      const headers = {};
+      String(value || '').split('\n').forEach(line => {
+        const trimmed = line.trim();
+        if (!trimmed) return;
+        const idx = trimmed.indexOf('=');
+        if (idx <= 0) return;
+        headers[trimmed.slice(0, idx).trim()] = trimmed.slice(idx + 1).trim();
+      });
+      markDirty('security', 'otelHeaders', headers);
+    }
+
     function renderGovSecurity(sec) {
       sec = sec || {};
       const failMode = sec.ioscanFailMode || 'open';
-      const classifierToggle = Object.prototype.hasOwnProperty.call(sec, 'classifierEnabled')
-        ? `<div class="config-toggle">
-            <div class="config-toggle-switch ${sec.classifierEnabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="classifierEnabled"></div>
-            <span class="config-toggle-label">Classifier enabled <span class="config-info">i<span class="config-tooltip">Enable the optional classifier security control when this backend supports it.</span></span></span>
+      const agentNames = ((_configState.data || {}).agents || []).map(a => typeof a === 'string' ? a : (a && a.name) || '').filter(Boolean);
+      const agentList = '<datalist id="security-agent-options">' + agentNames.map(n => '<option value="' + esc(n) + '"></option>').join('') + '</datalist>';
+      const classifierAdvanced = Object.prototype.hasOwnProperty.call(sec, 'ioscanClassifier')
+        ? `<div class="config-field-row">
+            <div class="config-field"><label>Classifier model</label>${securityModelInput('ioscanClassifierModel', (sec.ioscanClassifier || {}).model || '', 'e.g. gpt-4o-mini')}</div>
+            <div class="config-field"><label>Warn threshold</label><input type="number" min="0" max="1" step="0.01" value="${(sec.ioscanClassifier || {}).warnThreshold ?? ''}" onchange="markDirty('security','ioscanClassifierWarnThreshold',Number(this.value))"></div>
+            <div class="config-field"><label>Block threshold</label><input type="number" min="0" max="1" step="0.01" value="${(sec.ioscanClassifier || {}).blockThreshold ?? ''}" onchange="markDirty('security','ioscanClassifierBlockThreshold',Number(this.value))"></div>
           </div>`
-        : '';
+        : '<p style="font-size:0.72rem;color:var(--muted);margin:8px 0 0">ioscan classifier fields are not present in this v4 backend yet; this disclosure will render them automatically when the API reports support.</p>';
       return `
+        ${securityModelDatalistHtml()}${agentList}
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:10px">Operator security controls saved through the dashboard overlay.</p>
         <div style="margin-bottom:14px">${securityPostureStripHtml()}</div>
         ${securityWarningsHtml(sec)}
+
         <div class="config-toggle">
           <div class="config-toggle-switch ${sec.ioscanEnabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="ioscanEnabled"></div>
           <span class="config-toggle-label">Input/Output scanning (ioscan) <span class="config-info">i<span class="config-tooltip">Scan untrusted issue/PR text for prompt-injection and dangerous directives before agent kicks.</span></span></span>
@@ -18345,12 +18384,17 @@ function burnAreaChart() {
           <div class="config-toggle-switch ${sec.ioscanCanaries ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="ioscanCanaries"></div>
           <span class="config-toggle-label">ioscan canaries <span class="config-info">i<span class="config-tooltip">Plant per-kick exfiltration markers and scan egress for leaks.</span></span></span>
         </div>
-        ${classifierToggle}
+        <details style="margin:10px 0 18px"><summary style="cursor:pointer;color:var(--muted);font-size:0.78rem;font-weight:600">Advanced ioscan classifier</summary>${classifierAdvanced}</details>
+
         <hr style="border-color:var(--border);margin:16px 0">
         <div class="config-toggle">
           <div class="config-toggle-switch ${sec.intentEnforce ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="intentEnforce"></div>
           <span class="config-toggle-label">Enforce intent authorization on merges</span>
         </div>
+        <details style="margin:10px 0 18px"><summary style="cursor:pointer;color:var(--muted);font-size:0.78rem;font-weight:600">Advanced intent</summary>
+          <div class="config-field"><label>Alignment model</label>${securityModelInput('intentAlignmentModel', sec.intentAlignmentModel || '', 'leave empty for default')}</div>
+        </details>
+
         <div class="config-toggle">
           <div class="config-toggle-switch ${sec.reviewRequireApproval ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="reviewRequireApproval"></div>
           <span class="config-toggle-label">Require structured review approval before merge</span>
@@ -18359,16 +18403,45 @@ function burnAreaChart() {
           <div class="config-toggle-switch ${sec.reviewFanOut ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="reviewFanOut"></div>
           <span class="config-toggle-label">Fan out review work to review-capable agents</span>
         </div>
-        <div class="config-toggle">
-          <div class="config-toggle-switch ${sec.agentSandboxEnabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="agentSandboxEnabled"></div>
-          <span class="config-toggle-label">Enable agent sandbox runner <span class="config-info">i<span class="config-tooltip">Global gate for per-agent sandbox opt-ins. Agents still opt in from their own General tab.</span></span></span>
-        </div>
+        <details style="margin:10px 0 18px"><summary style="cursor:pointer;color:var(--muted);font-size:0.78rem;font-weight:600">Advanced review gate</summary>
+          <div class="config-field-row">
+            <div class="config-field"><label>Max parallel reviews</label><input type="number" min="0" max="64" value="${sec.reviewMaxParallelReviews || 0}" onchange="markDirty('security','reviewMaxParallelReviews',Number(this.value))"><span style="font-size:0.65rem;color:var(--muted)">0 uses the default (${sec.reviewMaxParallelReviews || 5}).</span></div>
+            <div class="config-field"><label>Fixer agent</label><input type="text" list="security-agent-options" value="${esc(sec.reviewFixerAgent || '')}" placeholder="scanner" onchange="markDirty('security','reviewFixerAgent',this.value.trim())"></div>
+          </div>
+          <div class="config-field"><label>Reviewer agents <span style="font-weight:400;color:var(--muted)">(comma-separated allowlist)</span></label><input type="text" value="${esc((sec.reviewReviewerAgents || []).join(', '))}" placeholder="leave blank to auto-detect review-capable agents" onchange="markDirty('security','reviewReviewerAgents',parseSecurityList(this.value))"></div>
+          <p style="font-size:0.72rem;color:var(--muted);margin:6px 0 0">Review severity threshold is not present in this v4 backend config yet, so there is no safe field to persist.</p>
+        </details>
+
         <div style="margin-top:18px;padding-top:14px;border-top:1px solid var(--border)">
           <div style="font-size:0.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px">Quality loops</div>
           <div class="config-toggle">
             <div class="config-toggle-switch ${sec.retroEnabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="retroEnabled"></div>
             <span class="config-toggle-label">Retro loop enabled</span>
           </div>
+          <details style="margin:10px 0 0"><summary style="cursor:pointer;color:var(--muted);font-size:0.78rem;font-weight:600">Advanced retro</summary>
+            <div class="config-field"><label>Analysis model</label>${securityModelInput('retroAnalysisModel', sec.retroAnalysisModel || '', 'leave empty for deterministic only')}</div>
+          </details>
+        </div>
+
+        <div style="margin-top:18px;padding-top:14px;border-top:1px solid var(--border)">
+          <div class="config-toggle">
+            <div class="config-toggle-switch ${sec.otelEnabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="otelEnabled"></div>
+            <span class="config-toggle-label">OpenTelemetry export enabled</span>
+          </div>
+          <details style="margin:10px 0 18px"><summary style="cursor:pointer;color:var(--muted);font-size:0.78rem;font-weight:600">Advanced OpenTelemetry</summary>
+            <div class="config-field"><label>Endpoint</label><input type="text" value="${esc(sec.otelEndpoint || '')}" placeholder="https://otel-collector:4318" onchange="markDirty('security','otelEndpoint',this.value.trim())"></div>
+            <div class="config-field-row">
+              <div class="config-field"><label>Service name</label><input type="text" value="${esc(sec.otelServiceName || '')}" placeholder="hive" onchange="markDirty('security','otelServiceName',this.value.trim())"></div>
+              <div class="config-field"><label>Sample ratio</label><input type="number" min="0" max="1" step="0.01" value="${sec.otelSampleRatio || 0}" onchange="markDirty('security','otelSampleRatio',Number(this.value))"><span style="font-size:0.65rem;color:var(--muted)">0 means sample all.</span></div>
+            </div>
+            <div class="config-toggle"><div class="config-toggle-switch ${sec.otelInsecure ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="otelInsecure"></div><span class="config-toggle-label">Allow insecure OTLP transport</span></div>
+            <div class="config-field"><label>Headers <span style="font-weight:400;color:var(--muted)">(write-only, one key=value per line)</span></label><textarea rows="3" style="width:100%;resize:vertical;font-family:var(--font-mono);font-size:0.74rem" placeholder="authorization=\${OTEL_EXPORTER_TOKEN}" onchange="parseOtelHeaders(this.value)"></textarea><div style="font-size:0.68rem;color:var(--muted);margin-top:4px">${sec.otelHasHeaders ? 'Headers are configured; values are never echoed back.' : 'No headers configured.'} <button type="button" onclick="markDirty('security','otelHeaders',{});showToast('OTel headers will be cleared on Save','info')" style="margin-left:8px;font-size:0.68rem;padding:2px 8px;border:1px solid var(--border);background:var(--bg);color:var(--muted);border-radius:4px;cursor:pointer">Clear saved headers</button></div></div>
+          </details>
+        </div>
+
+        <div class="config-toggle">
+          <div class="config-toggle-switch ${sec.agentSandboxEnabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="security" data-key="agentSandboxEnabled"></div>
+          <span class="config-toggle-label">Enable agent sandbox runner <span class="config-info">i<span class="config-tooltip">Global gate for per-agent sandbox opt-ins. Agents still opt in from their own General tab.</span></span></span>
         </div>`;
     }
 

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -222,8 +222,61 @@ func BuildFrontendStatus(
 		ACMMPackAgents:  buildACMMPackAgents(cfg),
 		SystemResources: collectSystemResources(),
 		Platform:        buildPlatform(cfg),
+		Security:        buildSecurity(cfg),
 	}
 	return payload
+}
+
+// buildSecurity summarizes operator-facing security posture from effective
+// config. It is additive and secret-free, so older dashboards can ignore it.
+func buildSecurity(cfg *config.Config) *FrontendSecurity {
+	sec := &FrontendSecurity{}
+	if cfg == nil {
+		return sec
+	}
+	sec.IntentEnforced = cfg.Intent.Enforce
+	sec.IoscanEnabled = cfg.Ioscan.IsEnabled()
+	sec.IoscanFailMode = "open"
+	if cfg.Ioscan.FailClosed() {
+		sec.IoscanFailMode = "closed"
+	}
+	sec.IoscanCanaries = cfg.Ioscan.Canaries
+	sec.ReviewRequireApproval = cfg.Review.RequireApproval
+	sec.ReviewFanOut = cfg.Review.FanOut
+	sec.SandboxEnabled = cfg.AgentSandbox.Enabled
+	sec.TotalAgents = len(cfg.Agents)
+	for name, a := range cfg.Agents {
+		if a.SandboxEnabled(cfg.AgentSandbox) {
+			sec.SandboxedAgents++
+		}
+		if dashboardAgentReviewCapable(name, a, cfg.Review.ReviewerAgents) {
+			sec.ReviewCapableAgents++
+		}
+	}
+	return sec
+}
+
+func dashboardAgentReviewCapable(name string, a config.AgentConfig, allowed []string) bool {
+	if !a.Enabled || a.Paused || a.OnDemand {
+		return false
+	}
+	if len(allowed) > 0 {
+		for _, n := range allowed {
+			if strings.TrimSpace(n) == name {
+				return true
+			}
+		}
+		return false
+	}
+	fields := append([]string{name, a.Role}, a.Aliases...)
+	fields = append(fields, a.LaneKeywords...)
+	fields = append(fields, a.DetectKeywords...)
+	for _, f := range fields {
+		if strings.Contains(strings.ToLower(f), "review") {
+			return true
+		}
+	}
+	return false
 }
 
 // buildPlatform surfaces the v4 spoke capabilities (forge, mint, skills) from
@@ -407,6 +460,7 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 			BeadRole:      agentCfg.GetBeadRole(),
 			Managed:       agentCfg.Managed,
 			OnDemand:      agentCfg.OnDemand,
+			Sandboxed:     agentCfg.SandboxEnabled(cfg.AgentSandbox),
 			Session:       name,
 			State:         string(proc.State),
 			Busy:          busy,

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -243,6 +243,8 @@ func buildSecurity(cfg *config.Config) *FrontendSecurity {
 	sec.IoscanCanaries = cfg.Ioscan.Canaries
 	sec.ReviewRequireApproval = cfg.Review.RequireApproval
 	sec.ReviewFanOut = cfg.Review.FanOut
+	sec.RetroEnabled = cfg.Retro.Enabled
+	sec.OTelEnabled = cfg.EffectiveOTel().Enabled
 	sec.SandboxEnabled = cfg.AgentSandbox.Enabled
 	sec.TotalAgents = len(cfg.Agents)
 	for name, a := range cfg.Agents {

--- a/v2/pkg/intent/intent.go
+++ b/v2/pkg/intent/intent.go
@@ -73,6 +73,8 @@ var defaultGuardrailPathPatterns = []string{
 	"**/policies/**",
 	"hive.yaml",
 	"**/hive.yaml",
+	"hive.yaml.dashboard",
+	"**/hive.yaml.dashboard",
 	"OWNERS",
 	"**/OWNERS",
 	"CODEOWNERS",

--- a/v2/pkg/intent/intent_test.go
+++ b/v2/pkg/intent/intent_test.go
@@ -20,6 +20,7 @@ func TestClassify(t *testing.T) {
 		{"removed test escalates", PR{AgentAuthor: true, Files: []ChangedFile{{Filename: "tests/e2e_test.go", Status: "removed"}}}, Tier1},
 		{"guardrail workflow", PR{AgentAuthor: true, Files: []ChangedFile{{Filename: ".github/workflows/ci.yml"}}}, Tier3},
 		{"guardrail owners", PR{AgentAuthor: true, Files: []ChangedFile{{Filename: "OWNERS"}}}, Tier3},
+		{"guardrail dashboard overlay", PR{AgentAuthor: true, Files: []ChangedFile{{Filename: "hive.yaml.dashboard"}}}, Tier3},
 		{"feature label", PR{AgentAuthor: true, Title: "add widget", Labels: []string{"enhancement"}, Files: []ChangedFile{{Filename: "pkg/widget/widget.go"}}}, Tier2},
 		{"default bugfix chore", PR{AgentAuthor: true, Files: []ChangedFile{{Filename: "pkg/foo/foo.go"}}}, Tier1},
 	}

--- a/v2/pkg/pushbroker/pushbroker.go
+++ b/v2/pkg/pushbroker/pushbroker.go
@@ -27,6 +27,7 @@ var DefaultProtectedPaths = []string{
 	"bin/gh-wrapper.sh",
 	"deploy/bin/gh-wrapper.sh",
 	"policies/",
+	"hive.yaml.dashboard",
 	"OWNERS",
 	".github/OWNERS",
 }

--- a/v2/pkg/pushbroker/pushbroker_test.go
+++ b/v2/pkg/pushbroker/pushbroker_test.go
@@ -86,9 +86,9 @@ func TestBrokerPushSanitizesCredentialEnvironmentAndWorkspace(t *testing.T) {
 }
 
 func TestProtectedPathViolationsTable(t *testing.T) {
-	files := []string{"policies/guard.yaml", "OWNERS", "pkg/safe.go"}
+	files := []string{"policies/guard.yaml", "OWNERS", "hive.yaml.dashboard", "pkg/safe.go"}
 	got := ProtectedPathViolations(files, DefaultProtectedPaths)
-	if strings.Join(got, ",") != "policies/guard.yaml,OWNERS" {
+	if strings.Join(got, ",") != "policies/guard.yaml,OWNERS,hive.yaml.dashboard" {
 		t.Fatalf("got %v", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Rebased onto current `origin/v4` after #2869 merged and resolved the dashboard conflict.
- Renamed/restructured the former Access surface into the Governor Configuration → Security tab.
- Kept authorized users intact as the Security tab's top Access subsection.
- Moved v4 security-posture controls into Security subsections with one canonical control per setting.
- Kept observability/quality controls in Features and enhanced the existing OpenTelemetry entry instead of duplicating it.

## Final tab layout
### Security
- Posture summary strip at the top, also retained near the ACMM control.
- Access: existing read-only authorized-users/roles view.
- Input Defense: `ioscan.enabled`, `ioscan.fail_mode`, `ioscan.canaries`; classifier advanced fields render only when backend support exists.
- Merge Gates: `intent.enforce`, `intent.alignment_model`, `review.require_approval`, `review.fan_out`, `review.max_parallel_reviews`, `review.reviewer_agents`, `review.fixer_agent`; notes that review severity threshold is not in current config.
- Isolation: global `agent_sandbox.enabled`; per-agent opt-in remains on each agent's General tab with sandboxed badges/list indicators.
- Non-blocking coherence warnings: L6 without intent enforcement, L5+ with ioscan fail-open, review approval with no review-capable agents.

### Features
- ioscan control removed; note points operators to Security → Input Defense.
- Observability: existing OpenTelemetry entry enhanced with endpoint, service_name, insecure, sample_ratio, and write-only headers.
- Quality loops: retro enabled + analysis_model.
- Token Mint and Auto-plan remain in Features.

## Protected paths
- Added `hive.yaml.dashboard` to intent tier-3 guardrail paths and pushbroker protected paths.

## Validation
- `cd v2 && go build ./...`
- `cd v2 && go test ./pkg/dashboard/... ./pkg/intent ./pkg/pushbroker -count=1`
- `cd v2 && go vet ./pkg/dashboard/... ./pkg/intent ./pkg/pushbroker`
- `cd v2/proxy && npm test`
- Extracted dashboard `<script>` blocks and ran `node --check`.

Refs #2812, #2814, #2821, #2824, #2839, #2842, #2862
