### PR TITLE
[sec-check] fix: add Dependabot configuration for automated CVE tracking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/v2"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "docker"
+    directory: "/v2"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Security Fix

Adds Dependabot configuration to enable automated dependency vulnerability tracking across all ecosystems used by kubestellar/hive:

- **Go modules** (`/v2`) — weekly CVE scanning for all direct and indirect Go deps
- **GitHub Actions** (`/`) — weekly tracking of action version updates (supports SHA pinning)
- **Docker base images** (`/v2`) — weekly tracking of `node:24-slim`, `golang:1.25-alpine`, `alpine:3.21` base image updates

Without this configuration, there is no automated alerting when dependencies accumulate CVEs. This was particularly important given that `golang.org/x/sys` (indirect) and other packages in the dependency graph have historically had security advisories.

This also lays the groundwork for addressing the unpinned GitHub Actions issue (#2880): once this config is active, Dependabot will auto-open PRs to update action SHA pins.

Fixes #2882

---
*Filed by sec-check agent (ACMM L4/L5 — hold-gated mode). Hold-gated: human review required.*