### PR TITLE
✨ feat(contribute): clankers can take on spoke agent roles (scanner, ci-maintainer, …)

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -13,6 +13,8 @@
 //                           the same order as HIVE_HUB
 //   AGENT_BACKEND          — CLI backend name (claude, copilot, gemini, etc.)
 //   AGENT_MODEL            — model override (optional)
+//   HIVE_AGENT_ROLE        — optional spoke agent role to claim (scanner,
+//                           quality, outreach, etc.; hub-enforced)
 //   HIVE_AGENT_SESSION     — tmux session name for the agent (default: contributor)
 
 'use strict';
@@ -37,6 +39,7 @@ if (rawHubList.length > 1 && rawTokenList.length !== rawHubList.length) {
 }
 const BACKEND = process.env.AGENT_BACKEND || 'claude';
 const MODEL = process.env.AGENT_MODEL || process.env.GOOSE_MODEL || '';
+const AGENT_ROLE = (process.env.HIVE_AGENT_ROLE || '').trim();
 const TMUX_SESSION = process.env.HIVE_AGENT_SESSION || 'contributor';
 const GH_TOKEN_CACHE = process.env.HIVE_GH_TOKEN_CACHE || (fs.existsSync('/var/run/hive-metrics')
   ? '/var/run/hive-metrics/gh-app-token.cache'
@@ -1119,6 +1122,7 @@ function handleMessage(data, hub) {
         registration_token: hub.regToken,
         cli_backend: BACKEND,
         model: MODEL,
+        role: AGENT_ROLE,
         // #2547 declare half + #2567: additive, optional self-report of runtime
         // posture and protocol version. An older hub ignores these unknown fields.
         protocol_version: RELAY_PROTOCOL_VERSION,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -263,6 +263,16 @@ test('task_assign queues rather than typing when the CLI is not ready', () => {
   } finally { teardown(relay); }
 });
 
+test('auth_response includes optional HIVE_AGENT_ROLE', () => {
+  const relay = loadRelay({ env: { HIVE_AGENT_ROLE: 'scanner' } });
+  try {
+    relay.handleMessage(JSON.stringify({ type: 'auth_challenge', seq: 1, nonce: 'n' }));
+    const auth = relay.__sent.find(m => m.type === 'auth_response');
+    assert.ok(auth, 'expected auth_response');
+    assert.strictEqual(auth.role, 'scanner');
+  } finally { teardown(relay); }
+});
+
 test('relaunchCLI() leaves cliReady false until readiness is confirmed', () => {
   const relay = loadRelay({ backend: 'copilot', cliStates: ['starting'] });
   try {

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1982,11 +1982,17 @@ type HubConfig struct {
 	//     operators who want a wait state.
 	// A POINTER so an absent value (older on-disk config) resolves to the
 	// backward-compatible auto-accept default via IsContributeRequireExplicitAccept().
-	ContributeRequireExplicitAccept *bool               `yaml:"contribute_require_explicit_accept,omitempty"`
-	DisabledRepos                   []string            `yaml:"disabled_repos"`
-	DisabledTiers                   []string            `yaml:"disabled_tiers"`
-	TierLimits                      map[string]TierRate `yaml:"tier_limits"`
-	SnapshotIntervalMin             int                 `yaml:"snapshot_interval_min"`
+	ContributeRequireExplicitAccept *bool `yaml:"contribute_require_explicit_accept,omitempty"`
+	// ContributeDelegatableRoles is the hive-wide allow-list of spoke agent roles
+	// a contributor relay may request via HIVE_AGENT_ROLE / auth_response.role.
+	// Empty means the safe default set: scanner, quality, outreach. Privileged roles
+	// (ci-maintainer, sec-check, architect) must be explicitly listed here AND
+	// granted on the contributor profile; supervisor is never delegatable.
+	ContributeDelegatableRoles []string            `yaml:"contribute_delegatable_roles,omitempty"`
+	DisabledRepos              []string            `yaml:"disabled_repos"`
+	DisabledTiers              []string            `yaml:"disabled_tiers"`
+	TierLimits                 map[string]TierRate `yaml:"tier_limits"`
+	SnapshotIntervalMin        int                 `yaml:"snapshot_interval_min"`
 }
 
 // Contribute completion-cooldown defaults and clamp bounds. These live in the
@@ -2022,6 +2028,33 @@ func (h HubConfig) IsContributeCooldownEnabled() bool {
 // is withheld until the client accepts the assigned task.
 func (h HubConfig) IsContributeRequireExplicitAccept() bool {
 	return h.ContributeRequireExplicitAccept != nil && *h.ContributeRequireExplicitAccept
+}
+
+var defaultContributeDelegatableRoles = []string{"scanner", "quality", "outreach"}
+
+// ContributeDelegatableRoleSet resolves the hive-wide allow-list of spoke roles
+// a clanker may claim. Empty config preserves the safe v1 default; supervisor is
+// deliberately removed even if an operator lists it because it manages the fleet.
+func (h HubConfig) ContributeDelegatableRoleSet() map[string]bool {
+	roles := h.ContributeDelegatableRoles
+	if len(roles) == 0 {
+		roles = defaultContributeDelegatableRoles
+	}
+	out := make(map[string]bool, len(roles))
+	for _, role := range roles {
+		role = strings.ToLower(strings.TrimSpace(role))
+		if role == "" || role == "supervisor" {
+			continue
+		}
+		out[role] = true
+	}
+	return out
+}
+
+// IsContributeRoleDelegatable reports whether role is enabled hive-wide for
+// clanker delegation. It does not make any per-contributor or trust-tier decision.
+func (h HubConfig) IsContributeRoleDelegatable(role string) bool {
+	return h.ContributeDelegatableRoleSet()[strings.ToLower(strings.TrimSpace(role))]
 }
 
 // ContributeCooldownHoursOrDefault resolves the with-PR cooldown PERIOD in

--- a/v2/pkg/config/contribute_agent_roles_test.go
+++ b/v2/pkg/config/contribute_agent_roles_test.go
@@ -1,0 +1,33 @@
+package config
+
+import "testing"
+
+func TestContributeDelegatableRoleSet_DefaultsAndSupervisorDeny(t *testing.T) {
+	h := HubConfig{}
+	for _, role := range []string{"scanner", "quality", "outreach"} {
+		if !h.IsContributeRoleDelegatable(role) {
+			t.Fatalf("default delegatable roles should include %s", role)
+		}
+	}
+	for _, role := range []string{"ci-maintainer", "sec-check", "architect", "supervisor"} {
+		if h.IsContributeRoleDelegatable(role) {
+			t.Fatalf("default delegatable roles should not include %s", role)
+		}
+	}
+}
+
+func TestContributeDelegatableRoleSet_ExplicitAllowListStillDeniesSupervisor(t *testing.T) {
+	h := HubConfig{ContributeDelegatableRoles: []string{"ci-maintainer", " supervisor ", "SCANNER"}}
+	if !h.IsContributeRoleDelegatable("ci-maintainer") {
+		t.Fatal("explicit allow-list should enable ci-maintainer")
+	}
+	if !h.IsContributeRoleDelegatable("scanner") {
+		t.Fatal("explicit allow-list should normalize scanner")
+	}
+	if h.IsContributeRoleDelegatable("supervisor") {
+		t.Fatal("supervisor must never be delegatable, even when listed")
+	}
+	if h.IsContributeRoleDelegatable("quality") {
+		t.Fatal("non-listed role must not be enabled when explicit allow-list is set")
+	}
+}

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -171,11 +171,15 @@ type ContributorProfile struct {
 	// never starved of work. Matching is exact on the label NAME, case-insensitive.
 	// Stored here (the existing per-contributor profile store) rather than in a new
 	// subsystem; empty/omitted for contributors who set none.
-	LabelInterests []string       `json:"label_interests,omitempty"`
-	Active         bool           `json:"active,omitempty"`
-	CurrentTask    *WSTaskAssign  `json:"current_task,omitempty"`
-	ActiveTasks    []WSTaskAssign `json:"active_tasks,omitempty"`
-	Sessions       int            `json:"sessions,omitempty"`
+	LabelInterests []string `json:"label_interests,omitempty"`
+	// AgentRoleGrants is the operator-managed per-contributor allow-list for
+	// claiming spoke agent roles that require explicit grant (for example
+	// ci-maintainer). It never changes the contributor's trust tier or credentials.
+	AgentRoleGrants []string       `json:"agent_role_grants,omitempty"`
+	Active          bool           `json:"active,omitempty"`
+	CurrentTask     *WSTaskAssign  `json:"current_task,omitempty"`
+	ActiveTasks     []WSTaskAssign `json:"active_tasks,omitempty"`
+	Sessions        int            `json:"sessions,omitempty"`
 }
 
 type ContributorRateLimits struct {

--- a/v2/pkg/dashboard/contribute_agent_roles.go
+++ b/v2/pkg/dashboard/contribute_agent_roles.go
@@ -1,0 +1,136 @@
+package dashboard
+
+import (
+	"fmt"
+	"strings"
+)
+
+var roleClaimMinTier = map[string]string{
+	"scanner":       "contributor",
+	"quality":       "contributor",
+	"outreach":      "contributor",
+	"ci-maintainer": "trusted",
+	"sec-check":     "trusted",
+	"architect":     "trusted",
+}
+
+var roleClaimNeedsGrant = map[string]bool{
+	"ci-maintainer": true,
+	"sec-check":     true,
+	"architect":     true,
+}
+
+var trustTierRank = map[string]int{
+	"newcomer":    0,
+	"advisor":     0,
+	"contributor": 1,
+	"trusted":     2,
+	"merger":      3,
+}
+
+func normalizeAgentRole(role string) string {
+	return strings.ToLower(strings.TrimSpace(role))
+}
+
+func hasAgentRoleGrant(profile *ContributorProfile, role string) bool {
+	if profile == nil {
+		return false
+	}
+	role = normalizeAgentRole(role)
+	for _, grant := range profile.AgentRoleGrants {
+		if normalizeAgentRole(grant) == role {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *ContributeWSHub) roleClaimAllowed(c *ContributorConnection, role string) (bool, string) {
+	role = normalizeAgentRole(role)
+	if role == "" {
+		return true, ""
+	}
+	if role == "supervisor" {
+		return false, "supervisor is not delegatable"
+	}
+	if c == nil || c.profile == nil {
+		return false, "missing contributor profile"
+	}
+	if h == nil || h.server == nil || h.server.deps == nil || h.server.deps.Config == nil {
+		// Unit-test and legacy no-config hubs have no work-selector config to
+		// consult. Preserve their historical "role is a display label" behavior;
+		// real hives have Config and are gated below before any role-shaped task.
+		return true, ""
+	}
+	cfg := h.server.deps.Config
+	agent, ok := cfg.Agents[role]
+	if !ok {
+		return false, fmt.Sprintf("unknown agent role %q", role)
+	}
+	if !agent.Enabled {
+		return false, fmt.Sprintf("agent role %q is disabled", role)
+	}
+	if !cfg.Hub.IsContributeRoleDelegatable(role) {
+		return false, fmt.Sprintf("agent role %q is not enabled for contributor delegation", role)
+	}
+	tier := normalizeAgentRole(c.profile.TrustTier)
+	minTier := roleClaimMinTier[role]
+	if minTier == "" {
+		minTier = "trusted"
+	}
+	if trustTierRank[tier] < trustTierRank[minTier] {
+		return false, fmt.Sprintf("trust tier %q cannot claim agent role %q", tier, role)
+	}
+	if roleClaimNeedsGrant[role] && !hasAgentRoleGrant(c.profile, role) {
+		return false, fmt.Sprintf("agent role %q requires an operator grant", role)
+	}
+	return true, ""
+}
+
+func (h *ContributeWSHub) roleKickPrompt(role string) string {
+	role = normalizeAgentRole(role)
+	if role == "" || h == nil || h.server == nil || h.server.deps == nil || h.server.deps.Scheduler == nil {
+		return ""
+	}
+	return h.server.deps.Scheduler.BuildAgentMessageFromLastActionable(role)
+}
+
+func buildRoleTaskPrompt(repoFull string, number int, title, role, agentPrompt string) string {
+	base := buildTaskPrompt(repoFull, number, title)
+	role = normalizeAgentRole(role)
+	if role == "" {
+		return base
+	}
+	if strings.TrimSpace(agentPrompt) == "" {
+		return fmt.Sprintf("[clanker-agent-role:%s]\n\nOperate as the hive spoke agent role %q for this contributor-owned task. Your credentials and permissions remain those of the contributor; do not assume any extra access from the role.\n\n%s", role, role, base)
+	}
+	return fmt.Sprintf("[clanker-agent-role:%s]\n\nA contributor is temporarily taking on the hive spoke agent role %q. Attribution remains the contributor's GitHub identity, and permissions remain the contributor tier's permissions.\n\nROLE KICK PROMPT (same template used for the spoke agent):\n%s\n\nASSIGNED CONTRIBUTOR TASK:\n%s", role, role, agentPrompt, base)
+}
+
+func (h *ContributeWSHub) issueMatchesAgentRole(role, title string, labels []string, lane string) bool {
+	role = normalizeAgentRole(role)
+	if role == "" || role == "scanner" {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(lane), role) {
+		return true
+	}
+	var keywords []string
+	if h != nil && h.server != nil && h.server.deps != nil && h.server.deps.Config != nil {
+		if agent, ok := h.server.deps.Config.Agents[role]; ok {
+			keywords = append(keywords, agent.LaneKeywords...)
+			keywords = append(keywords, agent.DetectKeywords...)
+		}
+	}
+	if len(keywords) == 0 {
+		keywords = append(keywords, role)
+	}
+	hay := strings.ToLower(title + " " + strings.Join(labels, " "))
+	for _, kw := range keywords {
+		kw = strings.ToLower(strings.TrimSpace(kw))
+		if kw != "" && strings.Contains(hay, kw) {
+			return true
+		}
+	}
+	return false
+}

--- a/v2/pkg/dashboard/contribute_agent_roles_test.go
+++ b/v2/pkg/dashboard/contribute_agent_roles_test.go
@@ -1,0 +1,149 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/scheduler"
+)
+
+func roleTestHub(t *testing.T) (*ContributeWSHub, *Server) {
+	t.Helper()
+	hub, s := covK2Hub(t)
+	cfg := s.deps.Config
+	cfg.Agents["quality"] = config.AgentConfig{Role: "quality", Enabled: true, LaneKeywords: []string{"test-coverage", "missing-tests"}}
+	cfg.Agents["scanner"] = config.AgentConfig{Role: "scanner", Enabled: true}
+	cfg.Agents["ci-maintainer"] = config.AgentConfig{Role: "ci-maintainer", Enabled: true}
+	cfg.Hub.ContributeDelegatableRoles = nil
+	s.deps.Scheduler = scheduler.New(cfg, s.logger)
+	return hub, s
+}
+
+func TestAgentRoleClaimGatingMatrix(t *testing.T) {
+	hub, _ := roleTestHub(t)
+	cases := []struct {
+		name   string
+		tier   string
+		role   string
+		grants []string
+		allow  []string
+		want   bool
+	}{
+		{name: "absent role is current behavior", tier: "newcomer", want: true},
+		{name: "newcomer cannot claim default role", tier: "newcomer", role: "scanner", want: false},
+		{name: "contributor can claim safe default role", tier: "contributor", role: "scanner", want: true},
+		{name: "trusted can claim safe default role", tier: "trusted", role: "quality", want: true},
+		{name: "privileged role disabled by default", tier: "trusted", role: "ci-maintainer", grants: []string{"ci-maintainer"}, want: false},
+		{name: "privileged role needs grant", tier: "trusted", role: "ci-maintainer", allow: []string{"ci-maintainer"}, want: false},
+		{name: "privileged role needs trusted plus grant", tier: "contributor", role: "ci-maintainer", allow: []string{"ci-maintainer"}, grants: []string{"ci-maintainer"}, want: false},
+		{name: "trusted plus grant can claim privileged role", tier: "trusted", role: "ci-maintainer", allow: []string{"ci-maintainer"}, grants: []string{"ci-maintainer"}, want: true},
+		{name: "supervisor never delegatable", tier: "merger", role: "supervisor", allow: []string{"supervisor"}, grants: []string{"supervisor"}, want: false},
+		{name: "disabled role cannot be claimed", tier: "trusted", role: "quality", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hub.server.deps.Config.Hub.ContributeDelegatableRoles = tc.allow
+			if tc.name == "disabled role cannot be claimed" {
+				agent := hub.server.deps.Config.Agents["quality"]
+				agent.Enabled = false
+				hub.server.deps.Config.Agents["quality"] = agent
+				defer func() {
+					agent.Enabled = true
+					hub.server.deps.Config.Agents["quality"] = agent
+				}()
+			}
+			conn := &ContributorConnection{
+				profile: &ContributorProfile{
+					GitHubUsername:  "alice",
+					ContributorID:   "c-alice",
+					TrustTier:       tc.tier,
+					AgentRoleGrants: tc.grants,
+				},
+				role: tc.role,
+			}
+			got, _ := hub.roleClaimAllowed(conn, tc.role)
+			if got != tc.want {
+				t.Fatalf("roleClaimAllowed(%s/%s grants=%v allow=%v) = %v, want %v",
+					tc.tier, tc.role, tc.grants, tc.allow, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAgentRoleTaskPayloadCarriesRolePromptAndFiltersLane(t *testing.T) {
+	hub, s := roleTestHub(t)
+	setStatusIssues(s,
+		map[string]any{"number": float64(1), "title": "ordinary bug", "author": "bob"},
+		map[string]any{
+			"number": float64(2),
+			"title":  "missing test coverage for API",
+			"author": "bob",
+			"labels": []any{"test-coverage"},
+			"lane":   "quality",
+		},
+	)
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "contributor"},
+		role:     "quality",
+		lastPong: time.Now(),
+	}
+	msg := hub.selectTask(conn)
+	if msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("expected task_assign, got %+v", msg)
+	}
+	if msg.Number != 2 {
+		t.Fatalf("quality role should receive quality-shaped work (#2), got #%d", msg.Number)
+	}
+	if msg.Role != "quality" {
+		t.Fatalf("task payload role = %q, want quality", msg.Role)
+	}
+	if !strings.Contains(msg.Prompt, "[clanker-agent-role:quality]") || !strings.Contains(msg.Prompt, "[agent:quality]") {
+		t.Fatalf("prompt did not carry clanker role and quality kick prompt:\n%s", msg.Prompt)
+	}
+}
+
+func TestAgentRoleDoubleClaimUsesContributorLease(t *testing.T) {
+	hub, s := roleTestHub(t)
+	setStatusIssues(s, map[string]any{
+		"number": float64(7),
+		"title":  "missing-tests regression",
+		"author": "bob",
+		"labels": []any{"missing-tests"},
+	})
+	roleConn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "role", ContributorID: "c-role", TrustTier: "contributor"},
+		role:     "quality",
+		lastPong: time.Now(),
+	}
+	plainConn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "plain", ContributorID: "c-plain", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["role"] = roleConn
+	hub.connections["plain"] = plainConn
+	hub.mu.Unlock()
+	first := hub.selectTask(roleConn)
+	if first == nil || first.Type != "task_assign" {
+		t.Fatalf("expected role clanker assignment, got %+v", first)
+	}
+	second := hub.selectTask(plainConn)
+	if second == nil || second.Type != "task_unavailable" || second.Reason != taskUnavailableNoMatchingWork {
+		t.Fatalf("same issue should be hidden by the active lease, got %+v", second)
+	}
+}
+
+func TestAgentRoleAuditEntryRecordsContributorAndRole(t *testing.T) {
+	hub, _ := roleTestHub(t)
+	hub.addActivity("alice", "picked up", "scanner", "copilot", "gpt", "contributor ran scanner task: issue myorg/repo#1")
+	entries := hub.RecentActivity()
+	if len(entries) == 0 {
+		t.Fatal("expected activity entry")
+	}
+	got := entries[len(entries)-1]
+	if got.Username != "alice" || got.Role != "scanner" || !strings.Contains(got.Task, "contributor ran scanner task") {
+		t.Fatalf("audit entry = %+v, want contributor attribution plus scanner role", got)
+	}
+}

--- a/v2/pkg/dashboard/contribute_protocol.go
+++ b/v2/pkg/dashboard/contribute_protocol.go
@@ -62,6 +62,10 @@ const (
 	// arrives in a following token_refresh — but no client change is required, since
 	// the token_refresh delivery is backward-compatible (see deliverTaskCredential).
 	capCredentialAfterAccept = "credential_after_accept"
+	// capAgentRoleClaim: the hub accepts an OPTIONAL auth_response.role request
+	// from contributor relays and, when allowed by hive config/tier/grants, shapes
+	// assignments with the matching spoke agent's prompt.
+	capAgentRoleClaim = "agent_role_claim"
 )
 
 // serverCapabilities returns the capability set this hub advertises on auth_ok.
@@ -74,6 +78,7 @@ func serverCapabilities() []string {
 		capPromptPreview,
 		capCapabilityDeclare,
 		capCredentialAfterAccept,
+		capAgentRoleClaim,
 	}
 }
 

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -257,6 +257,7 @@ type WSMessage struct {
 type WSTaskAssign struct {
 	TaskID string `json:"task_id"`
 	Kind   string `json:"kind"`
+	Role   string `json:"role,omitempty"`
 	Repo   string `json:"repo"`
 	Number int    `json:"number"`
 	Title  string `json:"title"`
@@ -1722,6 +1723,19 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
+			requestedRole := normalizeAgentRole(msg.Role)
+			probeContributor := &ContributorConnection{profile: profile}
+			if requestedRole != "" {
+				if ok, reason := h.roleClaimAllowed(probeContributor, requestedRole); !ok {
+					_ = sendJSON(conn, WSMessage{Type: "auth_failed", Reason: reason, Role: requestedRole})
+					h.logger.Warn("[contribute-ws] agent role claim rejected",
+						"username", profile.GitHubUsername, "tier", profile.TrustTier,
+						"role", requestedRole, "reason", reason)
+					conn.Close()
+					return
+				}
+			}
+
 			profile.LastActive = time.Now().UTC().Format(time.RFC3339)
 			if msg.CLIBackend != "" {
 				profile.CLIBackend = msg.CLIBackend
@@ -1732,8 +1746,8 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			if profile.AvatarURL == "" {
 				profile.AvatarURL = fmt.Sprintf("https://github.com/%s.png", profile.GitHubUsername)
 			}
-			if msg.Role != "" {
-				profile.PreferredRole = msg.Role
+			if requestedRole != "" {
+				profile.PreferredRole = requestedRole
 			}
 			_ = saveContributorProfile(profile)
 
@@ -1761,7 +1775,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				profile:      profile,
 				cliBackend:   msg.CLIBackend,
 				model:        msg.Model,
-				role:         msg.Role,
+				role:         requestedRole,
 				connectedAt:  time.Now(),
 				lastPong:     time.Now(),
 				capabilities: caps,
@@ -1793,7 +1807,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				ContributorID: profile.ContributorID,
 				TrustTier:     profile.TrustTier,
 				Permissions:   perms,
-				Role:          msg.Role,
+				Role:          requestedRole,
 				// #2567: advertise the protocol version and the server capability
 				// set so a client can learn what this deployed hub supports without
 				// probing. Additive — an existing client ignores these unknown fields.
@@ -1808,9 +1822,9 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				"username", profile.GitHubUsername,
 				"tier", profile.TrustTier,
 				"cli", msg.CLIBackend,
-				"role", msg.Role,
+				"role", requestedRole,
 			)
-			h.addActivity(profile.GitHubUsername, "joined", msg.Role, msg.CLIBackend, msg.Model, "")
+			h.addActivity(profile.GitHubUsername, "joined", requestedRole, msg.CLIBackend, msg.Model, "")
 
 			select {
 			case authDone <- contributor:
@@ -1897,6 +1911,9 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 				taskDesc := fmt.Sprintf("%s %s#%d: %s", task.Kind, task.Repo, task.Number, task.Title)
+				if task.Role != "" {
+					taskDesc = fmt.Sprintf("contributor ran %s task: %s", task.Role, taskDesc)
+				}
 				h.addActivity(contributor.profile.GitHubUsername, "picked up", contributor.role, contributor.cliBackend, contributor.model, taskDesc)
 				h.logger.Info("[contribute-ws] task assigned",
 					"username", contributor.profile.GitHubUsername,
@@ -1966,6 +1983,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					contributor.currentTask = &WSTaskAssign{
 						TaskID: msg.TaskID,
 						Kind:   msg.Kind,
+						Role:   msg.Role,
 						// #2644: canonicalise the CLIENT-supplied repo to the same
 						// repo.Full form selectTask assigned it under, so the
 						// activeIssues double-assign guard and the failure/completion
@@ -2609,6 +2627,9 @@ const (
 	// all filters (cooldown, disabled repos, allow/deny, skip-assigned, own-work),
 	// the candidate set is empty. There is simply nothing admissible to do now.
 	taskUnavailableNoMatchingWork = "no_matching_work"
+	// taskUnavailableRoleNotPermitted: the relay requested a spoke agent role, but
+	// the hive config/tier/grant policy does not allow this contributor to claim it.
+	taskUnavailableRoleNotPermitted = "agent_role_not_permitted"
 )
 
 // identityOf returns the stable key that groups a contributor's live
@@ -2805,6 +2826,18 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		// trivial and harmless (#2546).
 		return h.taskUnavailable(taskUnavailableHubNotReady)
 	}
+
+	requestedRole := ""
+	if c != nil {
+		requestedRole = normalizeAgentRole(c.role)
+	}
+	if requestedRole != "" {
+		if ok, reason := h.roleClaimAllowed(c, requestedRole); !ok {
+			h.logger.Warn("[contribute-ws] refusing task: agent role not permitted",
+				"username", identityOf(c), "role", requestedRole, "reason", reason)
+			return h.taskUnavailable(taskUnavailableRoleNotPermitted)
+		}
+	}
 	if h.server.deps != nil && h.server.deps.Config != nil && h.server.deps.Config.Hub.ContributeSuspended {
 		// #2546: the operator suspended the whole contribute queue. Previously this
 		// returned a bare nil and the contributor waited in silence, unable to tell
@@ -2986,6 +3019,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		title    string
 		url      string
 		labels   []string
+		lane     string
 		isOwn    bool
 		// interestMatch is true when the issue carries a label the contributor has
 		// opted into (#2637). It is a SOFT priority tier below own-work: matching
@@ -3070,8 +3104,12 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 			title, _ := issue["title"].(string)
 			url, _ := issue["url"].(string)
 			author, _ := issue["author"].(string)
+			lane, _ := issue["lane"].(string)
 			labels := stringSliceFromAny(issue["labels"])
 			assignees := stringSliceFromAny(issue["assignees"])
+			if requestedRole != "" && !h.issueMatchesAgentRole(requestedRole, title, labels, lane) {
+				continue
+			}
 
 			// Apply the title / author / label contribute filters. Each is a
 			// single list plus a mode (allow = only matching pass; deny = matching
@@ -3107,6 +3145,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				// task_assign can populate the Labels envelope field (kubestellar/
 				// hive#2393 item 8). They're already computed for filtering above.
 				labels: labels,
+				lane:   lane,
 				// "Own work" is the only #2390 signal available today: the
 				// candidate was authored by the connected contributor. When the
 				// username is unknown (empty), nothing is own → we keep today's
@@ -3215,6 +3254,9 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	// itself carries the #2545 workspace-clone instruction (real checkout into
 	// $HIVE_WORKSPACE_DIR rather than a fork-only --clone=false).
 	prompt := buildTaskPrompt(chosen.repoFull, chosen.number, chosen.title)
+	if requestedRole != "" {
+		prompt = buildRoleTaskPrompt(chosen.repoFull, chosen.number, chosen.title, requestedRole, h.roleKickPrompt(requestedRole))
+	}
 
 	// #2568: mint a fresh assignment generation for this task. It is stamped on the
 	// connection, shipped in task_assign below, and echoed back by the relay so a
@@ -3225,6 +3267,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	c.currentTask = &WSTaskAssign{
 		TaskID: taskID,
 		Kind:   "issue",
+		Role:   requestedRole,
 		Repo:   chosen.repoFull,
 		Number: chosen.number,
 		Title:  chosen.title,
@@ -3265,6 +3308,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		TaskID:  taskID,
 		TaskGen: gen,
 		Kind:    "issue",
+		Role:    requestedRole,
 		Repo:    chosen.repoFull,
 		Number:  chosen.number,
 		Title:   chosen.title,


### PR DESCRIPTION
## Summary
- Adds optional contributor relay role opt-in via HIVE_AGENT_ROLE / auth_response.role.
- Gates role claims in the hive: hive-wide allow-list defaults to scanner, quality, outreach; supervisor is never delegatable; ci-maintainer/sec-check/architect require explicit allow-list plus per-contributor grant and trusted+ tier.
- Shapes role-clanker assignments with the spoke agent kick prompt and role-specific issue filtering while keeping contributor attribution and contributor-tier credentials.
- Reuses the existing contributor task lease/currentTask guard so role clankers and regular clankers cannot double-claim the same issue.

## Design decisions
### Opt-in
A relay may set HIVE_AGENT_ROLE=scanner (single role in v1). The role is surfaced in auth_response.role and echoed on auth_ok/task_assign.

### Gating matrix
| Role class | Hive allow-list | Min tier | Per-contributor grant | Notes |
| --- | --- | --- | --- | --- |
| scanner / quality / outreach | Default enabled unless overridden | contributor+ | no | disabled agent configs are rejected |
| ci-maintainer / sec-check / architect | explicit hub.contribute_delegatable_roles | trusted+ | yes | push-capable / privileged roles need operator approval |
| supervisor | never | n/a | n/a | manages the fleet and cannot be delegated |
| no role | n/a | existing behavior | n/a | backward compatible |

Role selection never widens credentials: scoped tokens are still minted from the contributor's trust tier, and advisory/read-only tiers remain constrained by their tier.

### Task shaping
Role assignments include the same spoke agent kick prompt (via Scheduler.BuildAgentMessageFromLastActionable) plus the concrete contributor issue prompt. Role filtering uses lane/agent keywords where available; scanner keeps the broad scanner queue.

### No double-work
The role assignment commits to the same ContributorConnection.currentTask lease as normal /contribute work. The existing active issue guard and lease expiry/revoke paths therefore prevent a role clanker and another clanker from taking the same issue.

### Attribution + audit
Activity remains attributed to the contributor GitHub identity and includes the claimed role/task text (for example, contributor ran scanner task). Dashboard agent cards are not treated as in-spoke agent runs.

## Tests
- go build ./...
- go vet ./...
- go test ./pkg/dashboard/ ./pkg/hub/ ./pkg/config/ -count=1
- node --test bin/contributor-relay.test.js