### PR TITLE
🐛 fix(contributor): detect a ready codex pane (› marker, real banner text)

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -544,7 +544,16 @@ function getCLIState() {
       // "1. Yes, continue / 2. No, quit" list, where it is swallowed.
       if (/Do you trust the contents of this directory/.test(text)) return 'onboarding';
       if (/Update available!/.test(text) && /Skip until next version/.test(text)) return 'onboarding';
-      if (/codex>|>\s*$|Codex CLI/.test(text)) return 'ready';
+      // codex renders its input marker as '›' (U+203A), not '>', and its
+      // banner reads "OpenAI Codex (vX.Y.Z)" — never the literal "Codex CLI".
+      // The three original patterns therefore matched NOTHING a real codex
+      // pane ever contains, so readiness was never detected: every task was
+      // queued and then handed back at CLI_READY_TIMEOUT_MS, and an
+      // interactive codex contributor could not run a single task. Matching
+      // the marker and the real banner is what makes the backend usable.
+      // Safe against the modals above: those are classified first and return
+      // 'onboarding', so a menu that also draws '›' never reaches here.
+      if (/codex>|›|OpenAI Codex|Codex CLI|>\s*$/.test(text)) return 'ready';
     } else if (BACKEND === 'pi') {
       if (/pi v\d|0\.0%|auto\)|\d+\.\d+%/.test(text)) return 'ready';
     } else if (BACKEND === 'agy') {
@@ -941,7 +950,8 @@ function classifyTmuxPane(text) {
     hasCompletionMarker = true;
     isWorking = bobRunning && BOB_SPINNER.test(text);
   } else if (BACKEND === 'codex') {
-    hasIdlePrompt = /codex>|>\s*$/.test(text);
+    // Same marker mismatch as getCLIState(): '›' (U+203A), not '>'.
+    hasIdlePrompt = /codex>|›|>\s*$/.test(text);
     hasCompletionMarker = /completed|done|finished/i.test(text);
     isWorking = /running|executing|thinking/i.test(text);
   } else if (BACKEND === 'pi') {

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -1344,6 +1344,43 @@ test('a currentTask with no recorded hub still reaches the hub (regression: synt
   } finally { teardown(relay); }
 });
 
+// Verbatim capture of a genuinely READY codex pane from a running
+// ghcr.io/kubestellar/hive-contributor container. Note what it does NOT
+// contain: no "codex>", no line ending in ">", and the banner says "OpenAI
+// Codex", not "Codex CLI". The pre-fix patterns matched none of it, so this
+// pane classified as 'starting' forever.
+const CODEX_READY_PANE = [
+  'dev@codex-contributor:~/workspace$ codex --dangerously-bypass-approvals-and-sandbox',
+  '\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e',
+  '\u2502 >_ OpenAI Codex (v0.146.0)                          \u2502',
+  '\u2502 model:       gpt-5.6-luna medium   /model to change \u2502',
+  '\u2502 directory:   ~/workspace                            \u2502',
+  '\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f',
+  '  Tip: Use /rename to rename your threads for easier thread resuming.',
+  '\u203a Run /review on my current changes',
+  '  gpt-5.6-luna medium \u00b7 ~/workspace',
+  '', '', '',
+].join('\n');
+
+test('a ready codex pane is classified ready (regression: > vs \u203a, and "OpenAI Codex" not "Codex CLI")', () => {
+  const relay = loadRelay({ backend: 'codex', paneText: CODEX_READY_PANE });
+  try {
+    assert.strictEqual(relay.getCLIState(), 'ready',
+      'codex readiness was never detected, so every task was queued and handed back at timeout — the backend could not run a single task');
+  } finally { teardown(relay); }
+});
+
+test('the modal panes still win over the ready marker they also draw', () => {
+  // Both modals render '\u203a' too; modal classification runs first, so a
+  // blocked pane must NOT be reported ready by the widened pattern.
+  for (const pane of [CODEX_TRUST_PANE, CODEX_UPDATE_PANE]) {
+    const relay = loadRelay({ backend: 'codex', paneText: pane });
+    try {
+      assert.strictEqual(relay.getCLIState(), 'onboarding');
+    } finally { teardown(relay); }
+  }
+});
+
 // ---------------------------------------------------------------------------
 
 let failed = 0;


### PR DESCRIPTION
## The bug

An interactive **codex** contributor never runs a task. Not "sometimes fails" — never runs one at all.

```js
if (/codex>|>\s*$|Codex CLI/.test(text)) return 'ready';
```

Checked against a live pane from `ghcr.io/kubestellar/hive-contributor:latest`, all three alternatives miss:

| pattern | reality |
|---|---|
| `codex>` | codex never renders this |
| `/>\s*$/` | codex's input marker is **`›` (U+203A)**, not `>` |
| `Codex CLI` | the banner reads **"OpenAI Codex (v0.146.0)"** |

So `getCLIState()` returns `'starting'` forever. `tmuxSendKeys()` queues every assigned task waiting for `cliReady`, which never becomes true. Before #2849 the task sat there silently; with #2849 it's handed back at `CLI_READY_TIMEOUT_MS`. Either way codex does no work.

Measured on a running container, same image, three backends:

```
codex : "CLI ready" x0,  prompts delivered 0,  queued-never-sent 1
claude: "CLI ready" x1,  prompts delivered ≥1
agy   : "CLI ready" x1,  prompts delivered ≥1
```

The exact pane that classified as `starting`:

```
╭─────────────────────────────────────────────────────╮
│ >_ OpenAI Codex (v0.146.0)                          │
│ model:       gpt-5.6-luna medium   /model to change │
│ directory:   ~/workspace                            │
╰─────────────────────────────────────────────────────╯
  Tip: Use /rename to rename your threads for easier thread resuming.
› Run /review on my current changes
  gpt-5.6-luna medium · ~/workspace
```

(The `>_` inside the banner is followed by `_`, so `/>\s*$/` doesn't match it either.)

## The fix

Match the marker and banner codex actually prints, in `getCLIState()` and in `checkTmuxIdle()`, which carried the same `>` assumption.

**This does not weaken the modal guards.** Both modals draw `›` as well, but they're classified first and return `'onboarding'`, so a blocked pane still never reads as ready. Added a test asserting precisely that for the trust menu and the update nudge — that ordering is the thing most likely to break in future edits.

## Testing

`node bin/contributor-relay.test.js` — **58/58**, 2 new. Pane fixtures are verbatim captures, not hand-written approximations, since hand-written ones are exactly what would have hidden this (they'd have included a plausible-looking `codex>`).

Verified live: after bind-mounting this over the stock relay, the same container logged `CLI ready — accepting tasks` for the first time.

Follows #2849 (which makes the resulting stall recoverable) and #2845 (the trust prompt). Targeting `v4` since that's where those landed and what the published image tracks — happy to retarget to `v2` if you'd prefer it there too.