### PR TITLE
feat(dashboard): fleet breaker — pause all agents, release restores prior state

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1331,6 +1331,16 @@ func main() {
 				_ = agentMgr.UpdateConfig(name, agentCfg)
 			}
 		}
+		// Re-establish the fleet breaker AFTER per-agent pauses are restored
+		// above: the agents it held are already back in the paused state (with
+		// PausedTrigger == fleet-breaker from their persisted pause), so this
+		// only re-attaches the breaker so a later release resumes exactly them.
+		// An engaged breaker must REMAIN engaged across restart — it does not
+		// auto-release, and it does not re-pause or resume anything here.
+		if saved.Breaker != nil && saved.Breaker.Engaged {
+			agentMgr.RestoreBreaker(true, saved.Breaker.Paused)
+			logger.Info("fleet breaker restored from state", "held", len(saved.Breaker.Paused))
+		}
 		if saved.BudgetLimit > 0 {
 			gov.SetBudgetLimit(saved.BudgetLimit)
 		}
@@ -4793,6 +4803,12 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 		IssueCosts:           issueCosts,
 		LastEval:             govState.LastEval,
 		ACMMLevel:            cfg.ACMMLevel,
+	}
+
+	// Persist the fleet breaker so an engaged kill-switch survives a restart.
+	// Only written when engaged — a never-thrown breaker adds nothing.
+	if engaged, breakerPaused := agentMgr.BreakerState(); engaged {
+		state.Breaker = &snapshot.BreakerState{Engaged: true, Paused: breakerPaused}
 	}
 
 	if err := snapshot.SaveState(path, state, logger); err != nil {

--- a/v2/pkg/agent/fleet_breaker_test.go
+++ b/v2/pkg/agent/fleet_breaker_test.go
@@ -1,0 +1,258 @@
+package agent
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// breakerTestManager builds a Manager and forces each named agent into a known
+// live state, since NewManager starts every agent StateStopped. running=true
+// puts the agent in StateRunning; paused=true puts it in StatePaused with the
+// given trigger (to simulate a prior operator pause). onDemand marks the agent
+// as OnDemand in config.
+type breakerAgentSpec struct {
+	running      bool
+	paused       bool
+	pausedByWhom string
+	onDemand     bool
+}
+
+func newBreakerTestManager(t *testing.T, specs map[string]breakerAgentSpec) *Manager {
+	t.Helper()
+	cfgs := make(map[string]config.AgentConfig, len(specs))
+	for name, s := range specs {
+		// A backend with no installed binary makes Resume's relaunch path a
+		// fast no-op (launchInTmux marks StateFailed and returns) so the test
+		// never spawns a real agent CLI. The paused-state assertions below read
+		// fields Resume sets synchronously, independent of the relaunch outcome.
+		cfgs[name] = config.AgentConfig{Backend: "no-such-backend", OnDemand: s.onDemand}
+	}
+	m := NewManager(cfgs, slog.Default(), ProjectContext{})
+	m.mu.Lock()
+	for name, s := range specs {
+		a := m.agents[name]
+		switch {
+		case s.paused:
+			a.State = StatePaused
+			a.Paused = true
+			a.Config.Paused = true
+			a.PausedTrigger = s.pausedByWhom
+		case s.running:
+			a.State = StateRunning
+			a.Paused = false
+		default:
+			a.State = StateStopped
+		}
+	}
+	m.mu.Unlock()
+	return m
+}
+
+func (m *Manager) breakerAgentPaused(name string) (paused bool, trigger string, state ProcessState) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	a := m.agents[name]
+	return a.Paused, a.PausedTrigger, a.State
+}
+
+// TestEngageBreaker_PausesRunningNonOnDemandOnly verifies engage pauses only
+// running, non-on-demand agents and SKIPS on-demand and already-paused agents,
+// never adding the skipped ones to the recorded set.
+func TestEngageBreaker_PausesRunningNonOnDemandOnly(t *testing.T) {
+	m := newBreakerTestManager(t, map[string]breakerAgentSpec{
+		"scanner":    {running: true},
+		"reviewer":   {running: true},
+		"brainstorm": {running: true, onDemand: true},               // on-demand: skip
+		"prepaused":  {paused: true, pausedByWhom: "dashboard-api"}, // prior manual pause: skip
+		"idle":       {},                                            // stopped: not running, skip
+	})
+
+	paused := m.EngageBreaker()
+
+	got := map[string]bool{}
+	for _, n := range paused {
+		got[n] = true
+	}
+	if !got["scanner"] || !got["reviewer"] {
+		t.Fatalf("expected scanner+reviewer paused, got %v", paused)
+	}
+	if got["brainstorm"] {
+		t.Error("on-demand agent must NOT be in the breaker set")
+	}
+	if got["prepaused"] {
+		t.Error("already-paused agent must NOT be in the breaker set")
+	}
+	if got["idle"] {
+		t.Error("stopped agent must NOT be in the breaker set")
+	}
+	if len(paused) != 2 {
+		t.Fatalf("expected exactly 2 paused, got %d (%v)", len(paused), paused)
+	}
+
+	// The breaker-paused agents carry the distinct trigger; the pre-paused one
+	// keeps its own trigger untouched.
+	if p, trig, st := m.breakerAgentPaused("scanner"); !p || trig != BreakerTrigger || st != StatePaused {
+		t.Errorf("scanner: paused=%v trigger=%q state=%q", p, trig, st)
+	}
+	if p, trig, _ := m.breakerAgentPaused("prepaused"); !p || trig != "dashboard-api" {
+		t.Errorf("prepaused trigger clobbered: paused=%v trigger=%q", p, trig)
+	}
+	if p, _, _ := m.breakerAgentPaused("brainstorm"); p {
+		t.Error("on-demand agent must remain un-paused")
+	}
+
+	engaged, set := m.BreakerState()
+	if !engaged {
+		t.Error("breaker should report engaged")
+	}
+	if len(set) != 2 {
+		t.Errorf("BreakerState set = %v, want 2", set)
+	}
+}
+
+// TestReleaseBreaker_ResumesOnlyBreakerSet verifies release resumes ONLY the
+// agents the breaker paused and never touches on-demand, pre-paused, or
+// operator-re-paused agents. This is the core restore invariant.
+func TestReleaseBreaker_ResumesOnlyBreakerSet(t *testing.T) {
+	m := newBreakerTestManager(t, map[string]breakerAgentSpec{
+		"scanner":    {running: true},
+		"reviewer":   {running: true},
+		"brainstorm": {running: true, onDemand: true},
+		"prepaused":  {paused: true, pausedByWhom: "dashboard-api"},
+	})
+
+	m.EngageBreaker()
+
+	// Operator re-pauses "reviewer" during the breaker window with a DIFFERENT
+	// trigger — this must NOT be auto-resumed by release.
+	if err := m.Pause("reviewer", "dashboard-api", "operator re-pause"); err != nil {
+		t.Fatalf("re-pause reviewer: %v", err)
+	}
+
+	m.ReleaseBreaker(nil)
+
+	// scanner: breaker paused it, operator never touched it → resumed.
+	if p, _, _ := m.breakerAgentPaused("scanner"); p {
+		t.Error("scanner should be resumed after release")
+	}
+	// reviewer: operator re-paused (trigger != fleet-breaker) → stays paused.
+	if p, trig, _ := m.breakerAgentPaused("reviewer"); !p || trig != "dashboard-api" {
+		t.Errorf("reviewer must stay operator-paused: paused=%v trigger=%q", p, trig)
+	}
+	// prepaused: never in the set → still paused with its own trigger.
+	if p, trig, _ := m.breakerAgentPaused("prepaused"); !p || trig != "dashboard-api" {
+		t.Errorf("prepaused must stay paused: paused=%v trigger=%q", p, trig)
+	}
+	// brainstorm: on-demand, never paused → still un-paused.
+	if p, _, _ := m.breakerAgentPaused("brainstorm"); p {
+		t.Error("on-demand brainstorm must never be paused/resumed by the breaker")
+	}
+
+	engaged, _ := m.BreakerState()
+	if engaged {
+		t.Error("breaker should report disengaged after release")
+	}
+}
+
+// TestEngageBreaker_Idempotent verifies a double-engage does not re-pause and
+// returns the same set.
+func TestEngageBreaker_Idempotent(t *testing.T) {
+	m := newBreakerTestManager(t, map[string]breakerAgentSpec{
+		"scanner":  {running: true},
+		"reviewer": {running: true},
+	})
+
+	first := m.EngageBreaker()
+	if len(first) != 2 {
+		t.Fatalf("first engage set = %v, want 2", first)
+	}
+	second := m.EngageBreaker()
+	if len(second) != 2 {
+		t.Fatalf("second engage set = %v, want 2 (idempotent)", second)
+	}
+	engaged, set := m.BreakerState()
+	if !engaged || len(set) != 2 {
+		t.Errorf("state after double-engage: engaged=%v set=%v", engaged, set)
+	}
+}
+
+// TestReleaseBreaker_Idempotent verifies a double-release (and a release with
+// no breaker engaged) is a harmless no-op.
+func TestReleaseBreaker_Idempotent(t *testing.T) {
+	m := newBreakerTestManager(t, map[string]breakerAgentSpec{
+		"scanner": {running: true},
+	})
+
+	// Release with nothing engaged: no-op, nil result.
+	if resumed := m.ReleaseBreaker(nil); resumed != nil {
+		t.Errorf("release with no breaker engaged should be nil, got %v", resumed)
+	}
+
+	m.EngageBreaker()
+	m.ReleaseBreaker(nil)
+	// Second release: breaker already disengaged → no-op.
+	if resumed := m.ReleaseBreaker(nil); resumed != nil {
+		t.Errorf("double-release should be nil, got %v", resumed)
+	}
+	if engaged, _ := m.BreakerState(); engaged {
+		t.Error("breaker should stay disengaged after double-release")
+	}
+}
+
+// TestRestoreBreaker_SurvivesReload simulates a snapshot round-trip: the
+// breaker was engaged, the process restarted, the agents restored paused with
+// the breaker trigger (as cmd/hive does), and RestoreBreaker re-attaches the
+// breaker so a later release resumes exactly them — without auto-releasing on
+// boot.
+func TestRestoreBreaker_SurvivesReload(t *testing.T) {
+	// Simulate post-restart state: scanner+reviewer restored paused BY the
+	// breaker (trigger fleet-breaker), prepaused restored paused by operator,
+	// brainstorm on-demand and running.
+	m := newBreakerTestManager(t, map[string]breakerAgentSpec{
+		"scanner":    {paused: true, pausedByWhom: BreakerTrigger},
+		"reviewer":   {paused: true, pausedByWhom: BreakerTrigger},
+		"prepaused":  {paused: true, pausedByWhom: "dashboard-api"},
+		"brainstorm": {running: true, onDemand: true},
+	})
+
+	// The snapshot recorded the breaker as engaged holding scanner+reviewer.
+	m.RestoreBreaker(true, []string{"scanner", "reviewer"})
+
+	engaged, set := m.BreakerState()
+	if !engaged {
+		t.Fatal("breaker must remain engaged after restore (no auto-release on boot)")
+	}
+	if len(set) != 2 {
+		t.Fatalf("restored set = %v, want scanner+reviewer", set)
+	}
+
+	// Boot restore must not have changed any agent's paused state.
+	for _, n := range []string{"scanner", "reviewer", "prepaused"} {
+		if p, _, _ := m.breakerAgentPaused(n); !p {
+			t.Errorf("%s should still be paused after restore", n)
+		}
+	}
+
+	// A later release resumes only the restored breaker set; prepaused stays.
+	m.ReleaseBreaker(nil)
+	if p, _, _ := m.breakerAgentPaused("scanner"); p {
+		t.Error("scanner should resume on post-restore release")
+	}
+	if p, trig, _ := m.breakerAgentPaused("prepaused"); !p || trig != "dashboard-api" {
+		t.Errorf("prepaused must stay operator-paused: paused=%v trigger=%q", p, trig)
+	}
+}
+
+// TestRestoreBreaker_DisengagedNoop verifies restoring a disengaged breaker
+// changes nothing.
+func TestRestoreBreaker_DisengagedNoop(t *testing.T) {
+	m := newBreakerTestManager(t, map[string]breakerAgentSpec{
+		"scanner": {running: true},
+	})
+	m.RestoreBreaker(false, nil)
+	if engaged, _ := m.BreakerState(); engaged {
+		t.Error("restoring a disengaged breaker must not engage it")
+	}
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -12,6 +12,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -48,6 +49,14 @@ const (
 	proxyListenPort      = 18443
 	proxyCACertPath      = "/data/proxy-ca.pem"
 )
+
+// BreakerTrigger is the distinct PausedTrigger stamped on every pause the fleet
+// breaker performs. It serves two jobs: the audit log attributes the pause to
+// the breaker, and ReleaseBreaker uses it as the guard that distinguishes a
+// pause the breaker still owns (safe to auto-resume) from one an operator
+// re-applied during the breaker window (must stay paused). Anything whose
+// current PausedTrigger != BreakerTrigger was last paused by something else.
+const BreakerTrigger = "fleet-breaker"
 
 type AgentProcess struct {
 	Name              string
@@ -212,6 +221,19 @@ type Manager struct {
 	// persistPauseCallback, when set, persists an agent's paused state to
 	// the on-disk config so it survives restarts. Nil in tests / bare setups.
 	persistPauseCallback func(name string, paused bool)
+
+	// breakerEngaged and breakerPaused hold the fleet-breaker's state, guarded
+	// by m.mu. When an operator throws the breaker, EngageBreaker pauses every
+	// running, non-on-demand agent and records the set of names it paused here.
+	// Releasing resumes ONLY that set, and only for agents whose pause is still
+	// attributable to the breaker (PausedTrigger == BreakerTrigger) — an agent
+	// an operator re-paused during the breaker window keeps its manual pause.
+	// Both fields persist into /data/hive-state.json (see cmd/hive persistState)
+	// so an engaged breaker survives the frequent pod restarts: on boot the
+	// agents restore paused from their own persisted pause, and RestoreBreaker
+	// re-associates them with the breaker so a later release resumes them.
+	breakerEngaged bool
+	breakerPaused  map[string]bool
 
 	// recordPromptCallback, when set, persists the fully-expanded prompt text
 	// delivered to an agent so owners can review it later.
@@ -5109,6 +5131,151 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 		return m.launchInTmux(ctx, agent)
 	}
 	return nil
+}
+
+// EngageBreaker throws the fleet-wide kill-switch: it pauses every agent that
+// is currently RUNNING and not OnDemand, records exactly that set, and returns
+// the names it paused. Agents that are on-demand (e.g. brainstorm) or already
+// paused (a prior operator/manual pause) are skipped entirely and never enter
+// the recorded set, so releasing the breaker later cannot un-pause them.
+//
+// Idempotent: if the breaker is already engaged, it re-pauses nothing and
+// returns the existing recorded set unchanged.
+//
+// Pausing is done by calling Pause with BreakerTrigger. Pause takes m.mu
+// itself, so this method collects the target names under m.mu, releases it,
+// then pauses each — mirroring the lock discipline the dashboard uses when it
+// pauses agents one at a time.
+func (m *Manager) EngageBreaker() (paused []string) {
+	m.mu.Lock()
+	if m.breakerEngaged {
+		existing := make([]string, 0, len(m.breakerPaused))
+		for name := range m.breakerPaused {
+			existing = append(existing, name)
+		}
+		m.mu.Unlock()
+		sort.Strings(existing)
+		return existing
+	}
+
+	targets := make([]string, 0, len(m.agents))
+	for name, agent := range m.agents {
+		if agent == nil {
+			continue
+		}
+		// Skip on-demand agents (they are meant to sit idle until summoned) and
+		// any agent that is already paused — a pause the operator owns, which
+		// the breaker must not adopt and must not later reverse.
+		if agent.Config.OnDemand {
+			continue
+		}
+		if agent.Paused || agent.State != StateRunning {
+			continue
+		}
+		targets = append(targets, name)
+	}
+
+	set := make(map[string]bool, len(targets))
+	for _, name := range targets {
+		set[name] = true
+	}
+	m.breakerEngaged = true
+	m.breakerPaused = set
+	m.mu.Unlock()
+
+	sort.Strings(targets)
+	for _, name := range targets {
+		if err := m.Pause(name, BreakerTrigger, "fleet breaker engaged"); err != nil {
+			m.logger.Warn("fleet breaker: pause failed", "agent", name, "error", err)
+		}
+	}
+	m.logger.Info("fleet breaker engaged", "paused", len(targets))
+	return targets
+}
+
+// ReleaseBreaker disengages the fleet-wide kill-switch. It resumes ONLY the
+// agents the breaker itself paused (the recorded set) and, within that set,
+// only those whose pause is STILL attributable to the breaker: current
+// PausedTrigger == BreakerTrigger and still paused. An agent an operator
+// re-paused during the breaker window has a different trigger and is left
+// paused; an on-demand agent could never enter the set in the first place.
+// Returns the names it resumed.
+func (m *Manager) ReleaseBreaker(ctx context.Context) (resumed []string) {
+	m.mu.Lock()
+	if !m.breakerEngaged {
+		m.mu.Unlock()
+		return nil
+	}
+
+	candidates := make([]string, 0, len(m.breakerPaused))
+	for name := range m.breakerPaused {
+		agent, ok := m.agents[name]
+		if !ok || agent == nil {
+			continue
+		}
+		// Only resume agents still paused BY the breaker. If the operator
+		// re-paused (trigger changed) or resumed-then-repaused during the
+		// window, leave the agent exactly as the operator left it.
+		if agent.Paused && agent.PausedTrigger == BreakerTrigger {
+			candidates = append(candidates, name)
+		}
+	}
+	m.breakerEngaged = false
+	m.breakerPaused = nil
+	m.mu.Unlock()
+
+	sort.Strings(candidates)
+	for _, name := range candidates {
+		if err := m.Resume(ctx, name, BreakerTrigger, "fleet breaker released"); err != nil {
+			m.logger.Warn("fleet breaker: resume failed", "agent", name, "error", err)
+			continue
+		}
+		resumed = append(resumed, name)
+	}
+	m.logger.Info("fleet breaker released", "resumed", len(resumed))
+	return resumed
+}
+
+// BreakerState reports whether the fleet breaker is engaged and the sorted set
+// of agent names it currently holds paused.
+func (m *Manager) BreakerState() (engaged bool, paused []string) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	engaged = m.breakerEngaged
+	paused = make([]string, 0, len(m.breakerPaused))
+	for name := range m.breakerPaused {
+		paused = append(paused, name)
+	}
+	sort.Strings(paused)
+	return engaged, paused
+}
+
+// RestoreBreaker re-establishes the breaker's in-memory state from persisted
+// snapshot data on boot. The agents themselves are restored paused via their
+// own persisted pause (with PausedTrigger == BreakerTrigger), so this only has
+// to re-mark the breaker engaged and re-record the set. It does NOT re-pause or
+// resume anything — a boot restore must never change agent state, only reattach
+// the breaker so a later ReleaseBreaker knows which agents to resume. Only
+// names still present AND still paused-by-the-breaker are re-adopted.
+func (m *Manager) RestoreBreaker(engaged bool, paused []string) {
+	if !engaged {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	set := make(map[string]bool, len(paused))
+	for _, name := range paused {
+		agent, ok := m.agents[name]
+		if !ok || agent == nil {
+			continue
+		}
+		if agent.Paused && agent.PausedTrigger == BreakerTrigger {
+			set[name] = true
+		}
+	}
+	m.breakerEngaged = true
+	m.breakerPaused = set
+	m.logger.Info("fleet breaker restored", "engaged", true, "held", len(set))
 }
 
 // SetBootstrapOverride sets a one-shot bootstrap prompt override. On the next

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -68,6 +68,9 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("POST /api/pause/{agent}", s.handlePause)
 	s.mux.HandleFunc("POST /api/resume/{agent}", s.handleResume)
 	s.mux.HandleFunc("GET /api/agent-state/{agent}", s.handleAgentState)
+	s.mux.HandleFunc("GET /api/breaker", s.handleBreakerState)
+	s.mux.HandleFunc("POST /api/breaker/engage", s.handleBreakerEngage)
+	s.mux.HandleFunc("POST /api/breaker/release", s.handleBreakerRelease)
 	s.mux.HandleFunc("POST /api/pin/{agent}/{dimension}", s.handlePin)
 	s.mux.HandleFunc("POST /api/unpin/{agent}/{dimension}", s.handleUnpin)
 	s.mux.HandleFunc("POST /api/restart/{agent}", s.handleRestart)
@@ -1280,6 +1283,64 @@ func (s *Server) handleAgentState(w http.ResponseWriter, r *http.Request) {
 		"paused":    proc.Paused,
 		"state":     pauseStateLabel(proc.Paused),
 		"procState": string(proc.State),
+	})
+}
+
+// handleBreakerState returns the current fleet-breaker state: whether it is
+// engaged and the set of agents it is holding paused. Read-only (GET), so any
+// authenticated role may call it.
+func (s *Server) handleBreakerState(w http.ResponseWriter, r *http.Request) {
+	if s.deps == nil || s.deps.AgentMgr == nil {
+		jsonError(w, "agent manager unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	engaged, agents := s.deps.AgentMgr.BreakerState()
+	jsonResponse(w, map[string]interface{}{
+		"ok":      true,
+		"engaged": engaged,
+		"agents":  agents,
+	})
+}
+
+// handleBreakerEngage throws the fleet breaker: it pauses every running,
+// non-on-demand agent and records exactly that set. Already-paused and
+// on-demand agents are left untouched (see Manager.EngageBreaker). Owner-role
+// gated via the shared roleEnforcement middleware, exactly like pause/resume.
+func (s *Server) handleBreakerEngage(w http.ResponseWriter, r *http.Request) {
+	if s.deps == nil || s.deps.AgentMgr == nil {
+		jsonError(w, "agent manager unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	paused := s.deps.AgentMgr.EngageBreaker()
+	s.auditFromRequest(r, "breaker-engage",
+		auditDetail("count", strconv.Itoa(len(paused)), "agents", strings.Join(paused, ",")), "")
+	// Persist so an engaged breaker survives a crash, not just graceful
+	// shutdown. Refresh so the dashboard reflects the newly-paused agents.
+	s.refreshAndPersist()
+	jsonResponse(w, map[string]interface{}{
+		"ok":      true,
+		"engaged": true,
+		"agents":  paused,
+	})
+}
+
+// handleBreakerRelease disengages the fleet breaker: it resumes ONLY the agents
+// the breaker paused and still owns (PausedTrigger unchanged). On-demand,
+// pre-existing, and operator-re-paused agents are never resumed (see
+// Manager.ReleaseBreaker). Owner-role gated via roleEnforcement.
+func (s *Server) handleBreakerRelease(w http.ResponseWriter, r *http.Request) {
+	if s.deps == nil || s.deps.AgentMgr == nil {
+		jsonError(w, "agent manager unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	resumed := s.deps.AgentMgr.ReleaseBreaker(s.deps.Ctx)
+	s.auditFromRequest(r, "breaker-release",
+		auditDetail("count", strconv.Itoa(len(resumed)), "agents", strings.Join(resumed, ",")), "")
+	s.refreshAndPersist()
+	jsonResponse(w, map[string]interface{}{
+		"ok":      true,
+		"engaged": false,
+		"agents":  resumed,
 	})
 }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3048,6 +3048,7 @@
     <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
       <h2 style="margin:0; cursor:pointer" class="section-label section-header-toggle" onclick="toggleSection('agents-section')"><span class="section-chevron">▼</span> Agents</h2>
       <button id="agents-compact-all-btn" onclick="event.stopPropagation();toggleAllAgentsCompact()" style="font-size:0.7rem;padding:2px 10px;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer" title="Toggle all agent cards between compact and expanded view"></button>
+      <button id="fleet-breaker-btn" onclick="event.stopPropagation();toggleFleetBreaker()" style="display:none;font-size:0.7rem;font-weight:600;padding:2px 12px;border-radius:4px;cursor:pointer;margin-left:auto" title="Fleet breaker: pause every running agent at once. Releasing restores only the agents this breaker paused — on-demand agents and any agent you paused yourself are never touched."></button>
     </div>
     <div class="section-body">
       <div class="agents" id="agents"></div>
@@ -3481,6 +3482,65 @@
       const btn = document.getElementById('agents-compact-all-btn');
       if (btn) btn.textContent = localStorage.getItem(ALL_AGENTS_COMPACT_KEY) === '1' ? '⊞ Expand All' : '⊟ Compact All';
     }
+
+    // ── Fleet breaker (kill-switch) ──
+    // A single control that pauses every running agent at once ("engage") and
+    // restores exactly the agents it paused ("release"). On-demand agents and
+    // any agent the operator paused themselves are never touched by a release —
+    // that invariant is enforced server-side (Manager.EngageBreaker/
+    // ReleaseBreaker); the UI only reflects and triggers it.
+    let _fleetBreakerEngaged = false;
+    function _renderFleetBreaker(engaged, agents) {
+      _fleetBreakerEngaged = !!engaged;
+      const btn = document.getElementById('fleet-breaker-btn');
+      if (!btn) return;
+      btn.style.display = '';
+      const count = (agents || []).length;
+      if (_fleetBreakerEngaged) {
+        btn.textContent = '▶ Release (breaker)';
+        btn.style.background = 'var(--red, #ef4444)';
+        btn.style.color = '#fff';
+        btn.style.border = '1px solid var(--red, #ef4444)';
+        btn.title = 'Fleet breaker is ENGAGED — ' + count + ' agent' + (count === 1 ? '' : 's') +
+          ' held paused. Release resumes only those; on-demand and manually-paused agents are untouched.';
+      } else {
+        btn.textContent = '⏸ Pause All (breaker)';
+        btn.style.background = 'var(--surface)';
+        btn.style.color = 'var(--muted)';
+        btn.style.border = '1px solid var(--border)';
+        btn.title = 'Fleet breaker: pause every running agent at once. Releasing restores only the agents this breaker paused — on-demand agents and any agent you paused yourself are never touched.';
+      }
+      // When engaged, make it obvious the whole fleet is held.
+      const section = document.getElementById('agents-section');
+      if (section) section.style.outline = _fleetBreakerEngaged ? '2px solid var(--red, #ef4444)' : '';
+    }
+    async function refreshFleetBreakerState() {
+      try {
+        const res = await fetch('/api/breaker');
+        const data = await res.json();
+        if (data && data.ok) _renderFleetBreaker(data.engaged, data.agents);
+      } catch (e) { /* leave last-known state on transient error */ }
+    }
+    async function toggleFleetBreaker() {
+      const engaging = !_fleetBreakerEngaged;
+      const path = engaging ? '/api/breaker/engage' : '/api/breaker/release';
+      const btn = document.getElementById('fleet-breaker-btn');
+      if (btn) btn.disabled = true;
+      try {
+        const res = await fetch(path, { method: 'POST', headers: { 'Content-Type': 'application/json' } });
+        const data = await res.json();
+        if (!data.ok) { showToast('Fleet breaker failed: ' + (data.error || 'unknown'), 'error'); return; }
+        const n = (data.agents || []).length;
+        if (engaging) showToast('Fleet breaker engaged — paused ' + n + ' agent' + (n === 1 ? '' : 's'), 'success');
+        else showToast('Fleet breaker released — resumed ' + n + ' agent' + (n === 1 ? '' : 's'), 'success');
+        _renderFleetBreaker(data.engaged, data.agents);
+      } catch (e) {
+        showToast('Fleet breaker failed: ' + e.message, 'error');
+      } finally {
+        if (btn) btn.disabled = false;
+      }
+    }
+    document.addEventListener('DOMContentLoaded', refreshFleetBreakerState);
 
     // ── Layout mode (Dark / Light) ──
     const LAYOUT_KEY = 'hive-layout-mode';
@@ -11152,6 +11212,9 @@ function burnAreaChart() {
         }
       }
       window._lastBudget = data.budget || {};
+      // Keep the fleet-breaker toggle in sync with server truth on every status
+      // refresh (another operator may have engaged it, or a restart restored it).
+      if (typeof refreshFleetBreakerState === 'function') refreshFleetBreakerState();
       updateInferenceModelsFromSSE(data.inferenceBackends);
       if (data.agents) injectAgentStyles(data.agents);
       // Display the Hive ID in header badges

--- a/v2/pkg/snapshot/state.go
+++ b/v2/pkg/snapshot/state.go
@@ -33,6 +33,17 @@ type PersistedState struct {
 	LastEval             time.Time        `json:"last_eval,omitempty"`
 	ACMMLevel            *int             `json:"acmm_level,omitempty"`
 	ConfigOverrides      *ConfigOverrides `json:"config_overrides,omitempty"`
+	Breaker              *BreakerState    `json:"breaker,omitempty"`
+}
+
+// BreakerState persists the fleet breaker so an engaged kill-switch survives
+// the frequent pod restarts. The agents it holds paused restore paused from
+// their own persisted per-agent pause; this records that the breaker owns them
+// so a later release resumes exactly that set. Absent (nil) means the breaker
+// was never engaged — the common case — and adds nothing to the state file.
+type BreakerState struct {
+	Engaged bool     `json:"engaged"`
+	Paused  []string `json:"paused,omitempty"`
 }
 
 type ConfigOverrides struct {


### PR DESCRIPTION
## Summary

Adds a fleet-wide **breaker / kill-switch** to the dashboard: one control that pauses ALL currently-running agents, and releasing it restores each agent to EXACTLY its pre-breaker state.

- **Engage:** pause every agent that is currently RUNNING and not `OnDemand`; record exactly that set.
- **Release:** un-pause ONLY the agents this breaker paused, restoring them to running.

## Restore invariants (never violated on release)

These are the guarantees a maintainer can rely on — release will **never** un-pause something the operator wants paused:

1. **On-demand agents** (`Config.OnDemand == true`, e.g. `brainstorm`) are never paused by the breaker, so they are never in the recorded set and never resumed by a release.
2. **Agents already paused BEFORE engage** (a prior operator/manual pause) are skipped entirely on engage — never adopted into the set, never auto-resumed. Their `PausedTrigger` is left untouched.
3. **Operator re-pause during the breaker window:** if an agent in the set is re-paused by an operator while the breaker is engaged, its `PausedTrigger` changes off `fleet-breaker`; release then leaves it paused. Only pauses still attributable to the breaker (`PausedTrigger == "fleet-breaker"` AND still paused) are reversed.

The mechanism: `EngageBreaker()` records the set of names it actually paused (guarded by `m.mu`); every breaker pause is stamped with the distinct trigger `fleet-breaker`. `ReleaseBreaker()` resumes a recorded name only if it is still paused AND its current trigger is still `fleet-breaker`.

## Persistence / restart

This hive restarts constantly, so the breaker's engaged flag + recorded set are persisted to `/data/hive-state.json` via the snapshot (`snapshot.BreakerState`, written in `cmd/hive` `persistState` and saved on every pause/resume + periodic save). On boot the agents restore paused from their **own** persisted pause (trigger `fleet-breaker`), and `RestoreBreaker` re-attaches the breaker **without changing any agent state**. An engaged breaker therefore REMAINS engaged across restart and does NOT auto-release; a later release resumes exactly the held set.

## Endpoints

`POST /api/breaker/engage`, `POST /api/breaker/release`, `GET /api/breaker` — registered on the same mux as pause/resume, so they inherit the identical authenticate→roleEnforcement chain (owner/read-write gated; a read-only role gets 403 on the POSTs). Each write is audited (`breaker-engage` / `breaker-release` with count + agent list).

## UI

A single prominent toggle in the Agents-panel header: **⏸ Pause All (breaker)** when disengaged, **▶ Release (breaker)** (red, with a section outline) when engaged. It reflects `GET /api/breaker` on load and after every status refresh, so it stays in sync if another operator engages it or a restart restored it.

## Tests

`v2/pkg/agent/fleet_breaker_test.go` (table-style):
- engage pauses running + non-on-demand only; SKIPS on-demand and already-paused
- release resumes ONLY the breaker set; does NOT resume on-demand, pre-paused, or operator-re-paused agents (`TestReleaseBreaker_ResumesOnlyBreakerSet`)
- engaged state survives a simulated reload (`TestRestoreBreaker_SurvivesReload`)
- idempotent double-engage / double-release

Does not change existing single-agent pause/resume, the login-detector auto-pause, on-demand semantics, or anything in the hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)