### PR TITLE
✨ feat(agents): run multiple replicas of the same agent (replicas: N)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2358,6 +2358,21 @@ func main() {
 		// fields; a fetch failure keeps each agent's baked definition. Runs before
 		// initAgentConfigDrivenSystems so downstream systems see the merged config.
 		defsrc.ApplyToConfig(context.Background(), cfg, definitionResolver, logger)
+		if err := cfg.ExpandAgentReplicas(); err != nil {
+			logger.Warn("failed to expand agent replicas after config reload", "error", err)
+		}
+		addedAgents := agentMgr.ReconcileAgents(cfg.EnabledAgents())
+		for _, added := range addedAgents {
+			if ac, ok := cfg.Agents[added]; ok && !ac.OnDemand {
+				go func(name string) {
+					logger.Info("audit: starting reconciled agent", "name", name, "trigger", "config-reload")
+					if err := agentMgr.Start(ctx, name); err != nil {
+						logger.Warn("failed to start reconciled agent", "name", name, "error", err)
+					}
+				}(added)
+			}
+		}
+		gov.UpdateAgents(cfg.EnabledAgents())
 
 		initAgentConfigDrivenSystems(cfg)
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -2411,6 +2411,70 @@ func (m *Manager) UpdateConfig(name string, cfg config.AgentConfig) error {
 	return nil
 }
 
+// ReconcileAgents makes the manager's name-keyed process table match the
+// enabled config set. New agents are added, existing agents get fresh config,
+// and removed agents have only their own hive-<name> tmux session retired.
+func (m *Manager) ReconcileAgents(configs map[string]config.AgentConfig) []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var added []string
+
+	for name, cfg := range configs {
+		if existing, ok := m.agents[name]; ok {
+			delete(m.idToName, existing.ID)
+			existing.Config = cfg
+			if cfg.ID != "" {
+				existing.ID = cfg.ID
+			} else {
+				existing.ID = name
+			}
+			m.idToName[existing.ID] = name
+			continue
+		}
+		agentID := cfg.ID
+		if agentID == "" {
+			agentID = name
+		}
+		agentUID := 0
+		tmuxSocket := ""
+		if m.uidMap != nil {
+			agentUID = m.uidMap.AllocateUID(name)
+			if agentUID > 0 {
+				tmuxSocket = "hive-" + name
+			}
+			_ = m.uidMap.Save(UIDMapPath)
+		}
+		m.agents[name] = &AgentProcess{
+			Name:         name,
+			ID:           agentID,
+			Config:       cfg,
+			State:        StateStopped,
+			UID:          agentUID,
+			Paused:       cfg.Paused,
+			OutputBuffer: NewRingBuffer(outputBufferCapacity),
+			tmuxSession:  "hive-" + name,
+			tmuxSocket:   tmuxSocket,
+		}
+		m.idToName[agentID] = name
+		added = append(added, name)
+		m.logger.Info("audit: agent added by reconcile", "name", name, "id", agentID, "uid", agentUID)
+	}
+
+	for name, existing := range m.agents {
+		if _, ok := configs[name]; ok {
+			continue
+		}
+		if existing.cancel != nil {
+			existing.cancel()
+		}
+		_ = m.tmuxCmd(existing, "kill-session", "-t", existing.tmuxSession).Run()
+		delete(m.idToName, existing.ID)
+		delete(m.agents, name)
+		m.logger.Info("audit: agent removed by reconcile", "name", name, "id", existing.ID, "session", existing.tmuxSession)
+	}
+	return added
+}
+
 func (m *Manager) RemoveAgent(name string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/v2/pkg/agent/manager_replicas_test.go
+++ b/v2/pkg/agent/manager_replicas_test.go
@@ -1,0 +1,27 @@
+package agent
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+func TestReconcileAgentsAddsReplicaWithUIDAndRemovesExtra(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{"scanner": {ID: "scanner", Enabled: true}}, slog.Default(), ProjectContext{})
+	m.uidMap = NewUIDMap()
+	m.ReconcileAgents(map[string]config.AgentConfig{
+		"scanner":   {ID: "scanner", Enabled: true, ReplicaIndex: 1, ReplicaCount: 2},
+		"scanner-2": {ID: "scanner-2", Enabled: true, ReplicaOf: "scanner", ReplicaIndex: 2, ReplicaCount: 2},
+	})
+	if _, ok := m.agents["scanner-2"]; !ok {
+		t.Fatal("scanner-2 not added")
+	}
+	if got := m.agents["scanner-2"].UID; got == 0 {
+		t.Fatal("scanner-2 UID was not allocated")
+	}
+	m.ReconcileAgents(map[string]config.AgentConfig{"scanner": {ID: "scanner", Enabled: true, ReplicaIndex: 1, ReplicaCount: 1}})
+	if _, ok := m.agents["scanner-2"]; ok {
+		t.Fatal("scanner-2 not removed")
+	}
+}

--- a/v2/pkg/config/agent_overlay.go
+++ b/v2/pkg/config/agent_overlay.go
@@ -179,6 +179,9 @@ func (c *Config) ApplyAgentDefaults(name string) {
 	if agent.ID == "" {
 		agent.ID = name
 	}
+	if agent.Replicas == 0 {
+		agent.Replicas = 1
+	}
 	if agent.BeadsDir == "" {
 		agent.BeadsDir = fmt.Sprintf("/data/beads/%s", name)
 	}

--- a/v2/pkg/config/agent_replicas_test.go
+++ b/v2/pkg/config/agent_replicas_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExpandAgentReplicasMaterializesDerivedNames(t *testing.T) {
+	cfg := &Config{Agents: map[string]AgentConfig{
+		"scanner": {ID: "scanner", Backend: "copilot", Model: "auto", Enabled: true, Replicas: 3},
+	}}
+	if err := cfg.ExpandAgentReplicas(); err != nil {
+		t.Fatalf("ExpandAgentReplicas() error = %v", err)
+	}
+	for _, name := range []string{"scanner", "scanner-2", "scanner-3"} {
+		if _, ok := cfg.Agents[name]; !ok {
+			t.Fatalf("missing materialized agent %s", name)
+		}
+	}
+	if got := cfg.Agents["scanner-2"]; got.ReplicaOf != "scanner" || got.ReplicaIndex != 2 || got.ReplicaCount != 3 || got.ID != "scanner-2" {
+		t.Fatalf("scanner-2 metadata = %+v", got)
+	}
+	if got := cfg.Agents["scanner-3"].BeadsDir; got != "/data/beads/scanner-3" {
+		t.Fatalf("scanner-3 beads dir = %q", got)
+	}
+}
+
+func TestExpandAgentReplicasRejectsCollisionsAndCap(t *testing.T) {
+	cfg := &Config{Agents: map[string]AgentConfig{
+		"scanner":   {Replicas: 2},
+		"scanner-2": {Replicas: 1},
+	}}
+	if err := cfg.ExpandAgentReplicas(); err == nil || !strings.Contains(err.Error(), "scanner-2") {
+		t.Fatalf("collision error = %v", err)
+	}
+
+	cfg = &Config{Agents: map[string]AgentConfig{"scanner": {Replicas: MaxAgentReplicas + 1}}}
+	if err := cfg.ExpandAgentReplicas(); err == nil || !strings.Contains(err.Error(), "replicas") {
+		t.Fatalf("cap error = %v", err)
+	}
+}
+
+func TestExpandAgentReplicasOneIsZeroMigration(t *testing.T) {
+	cfg := &Config{Agents: map[string]AgentConfig{"scanner": {Replicas: 1}}}
+	if err := cfg.ExpandAgentReplicas(); err != nil {
+		t.Fatalf("ExpandAgentReplicas() error = %v", err)
+	}
+	if len(cfg.Agents) != 1 {
+		t.Fatalf("len agents = %d, want 1", len(cfg.Agents))
+	}
+	if cfg.Agents["scanner"].ReplicaOf != "" || cfg.Agents["scanner"].ReplicaIndex != 1 {
+		t.Fatalf("base metadata = %+v", cfg.Agents["scanner"])
+	}
+}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -364,11 +364,15 @@ type ConnectionConfig struct {
 }
 
 type AgentConfig struct {
-	ID       string `yaml:"id" json:"id,omitempty"`
-	Backend  string `yaml:"backend" json:"backend,omitempty"`
-	Model    string `yaml:"model" json:"model,omitempty"`
-	BeadsDir string `yaml:"beads_dir" json:"beads_dir,omitempty"`
-	Enabled  bool   `yaml:"enabled" json:"enabled,omitempty"`
+	ID           string `yaml:"id" json:"id,omitempty"`
+	Backend      string `yaml:"backend" json:"backend,omitempty"`
+	Model        string `yaml:"model" json:"model,omitempty"`
+	BeadsDir     string `yaml:"beads_dir" json:"beads_dir,omitempty"`
+	Enabled      bool   `yaml:"enabled" json:"enabled,omitempty"`
+	Replicas     int    `yaml:"replicas,omitempty" json:"replicas,omitempty"`
+	ReplicaOf    string `yaml:"-" json:"replicaOf,omitempty"`
+	ReplicaIndex int    `yaml:"-" json:"replicaIndex,omitempty"`
+	ReplicaCount int    `yaml:"-" json:"replicaCount,omitempty"`
 	// Paused persists an operator pause across restarts/upgrades. Without
 	// this, every pod restart rebuilt agents un-paused (Go zero value), so
 	// an operator pause was silently undone on the next upgrade.
@@ -459,6 +463,21 @@ type AgentConfig struct {
 // Name returns the human-readable YAML key for this agent.
 func (a *AgentConfig) Name() string {
 	return a.name
+}
+
+// IsReplica reports whether this agent was materialized from another agent's
+// replicas setting rather than declared directly in YAML.
+func (a AgentConfig) IsReplica() bool { return a.ReplicaOf != "" }
+
+// BaseName returns the declared agent name whose config/prompt this agent uses.
+func (a AgentConfig) BaseName() string {
+	if a.ReplicaOf != "" {
+		return a.ReplicaOf
+	}
+	if a.name != "" {
+		return a.name
+	}
+	return a.ID
 }
 
 // HasChannel returns true if the agent has a channel of the given type.
@@ -2282,6 +2301,10 @@ func LoadWithOverrides(path, envPath string) (*Config, error) {
 		}
 	}
 
+	if err := cfg.ExpandAgentReplicas(); err != nil {
+		return nil, fmt.Errorf("expanding agent replicas: %w", err)
+	}
+
 	if err := cfg.validate(); err != nil {
 		return nil, fmt.Errorf("validating config: %w", err)
 	}
@@ -2349,6 +2372,9 @@ func LoadWithDashboardOverlay(path string) (*Config, error) {
 	cfg.MergeAgentOverrides(overlay.Agents)
 	for name := range overlay.Agents {
 		cfg.ApplyAgentDefaults(name)
+	}
+	if err := cfg.ExpandAgentReplicas(); err != nil {
+		return cfg, err
 	}
 	// Security invariant: cfg.Variables (resolver defs + the exec/http trust
 	// policy) comes ONLY from the seed loaded above — the overlay's Variables
@@ -2612,6 +2638,8 @@ func (c *Config) GitHubDefinitionAllowed(slug string) bool {
 }
 
 const (
+	MaxAgentReplicas = 5
+
 	defaultDashboardPort          = 3002
 	defaultAgentPollIntervalS     = 10
 	defaultEvalIntervalS          = 300
@@ -2679,6 +2707,9 @@ func (c *Config) applyDefaults() {
 		agent.name = name
 		if agent.ID == "" {
 			agent.ID = name
+		}
+		if agent.Replicas == 0 {
+			agent.Replicas = 1
 		}
 		if agent.BeadsDir == "" {
 			agent.BeadsDir = fmt.Sprintf("/data/beads/%s", name)
@@ -3210,6 +3241,116 @@ func validateConnections(agentName string, conns []ConnectionConfig) error {
 		}
 	}
 	return nil
+}
+
+// BaseAgentName returns the declared/base agent name for name. For ordinary
+// agents it returns name; for materialized replicas (scanner-2) it returns the
+// source agent (scanner).
+func (c *Config) BaseAgentName(name string) string {
+	if c == nil || c.Agents == nil {
+		return name
+	}
+	if ac, ok := c.Agents[name]; ok && ac.ReplicaOf != "" {
+		return ac.ReplicaOf
+	}
+	return name
+}
+
+func replicaAgentName(base string, index int) string {
+	if index <= 1 {
+		return base
+	}
+	return fmt.Sprintf("%s-%d", base, index)
+}
+
+func normalizeReplicaCount(n int) int {
+	if n == 0 {
+		return 1
+	}
+	return n
+}
+
+// ExpandAgentReplicas materializes each declared agent's replicas setting into
+// the existing name-keyed machinery: base, base-2, ..., base-N. Derived agents
+// are marked with ReplicaOf and are stripped again when the config is saved.
+func (c *Config) ExpandAgentReplicas() error {
+	if c == nil || c.Agents == nil {
+		return nil
+	}
+	baseAgents := make(map[string]AgentConfig, len(c.Agents))
+	for name, agent := range c.Agents {
+		if agent.ReplicaOf != "" {
+			continue
+		}
+		baseAgents[name] = agent
+	}
+	for name, agent := range c.Agents {
+		if agent.ReplicaOf != "" {
+			delete(c.Agents, name)
+		}
+	}
+	for name, agent := range baseAgents {
+		replicas := normalizeReplicaCount(agent.Replicas)
+		if replicas < 1 || replicas > MaxAgentReplicas {
+			return fmt.Errorf("agent %s: replicas must be between 1 and %d", name, MaxAgentReplicas)
+		}
+		for i := 2; i <= replicas; i++ {
+			derived := replicaAgentName(name, i)
+			if existing, ok := baseAgents[derived]; ok && existing.ReplicaOf == "" {
+				return fmt.Errorf("agent %s: replicas:%d would create %s, but an agent with that name already exists", name, replicas, derived)
+			}
+		}
+	}
+	for name, agent := range baseAgents {
+		replicas := normalizeReplicaCount(agent.Replicas)
+		agent.Replicas = replicas
+		agent.ReplicaOf = ""
+		agent.ReplicaIndex = 1
+		agent.ReplicaCount = replicas
+		agent.name = name
+		c.Agents[name] = agent
+		for i := 2; i <= replicas; i++ {
+			derivedName := replicaAgentName(name, i)
+			derived := agent
+			derived.name = derivedName
+			derived.ID = derivedName
+			derived.BeadsDir = fmt.Sprintf("/data/beads/%s", derivedName)
+			derived.Role = agent.Role
+			derived.ReplicaOf = name
+			derived.ReplicaIndex = i
+			derived.ReplicaCount = replicas
+			c.Agents[derivedName] = derived
+		}
+	}
+	for name, agent := range c.Agents {
+		if agent.ReplicaOf == "" {
+			continue
+		}
+		if _, ok := baseAgents[agent.ReplicaOf]; !ok {
+			delete(c.Agents, name)
+		}
+	}
+	return nil
+}
+
+// MarshalYAML persists only declared agents. Runtime-derived replicas are
+// re-created by ExpandAgentReplicas on the next load so they never collide with
+// their base agent's replicas setting after a save.
+func (c Config) MarshalYAML() (interface{}, error) {
+	type plain Config
+	out := plain(c)
+	if c.Agents != nil {
+		out.Agents = make(map[string]AgentConfig, len(c.Agents))
+		for name, agent := range c.Agents {
+			if agent.ReplicaOf != "" {
+				continue
+			}
+			agent.ReplicaIndex = 0
+			agent.ReplicaCount = 0
+			out.Agents[name] = agent
+		}
+	}
+	return out, nil
 }
 
 func (c *Config) EnabledAgents() map[string]AgentConfig {

--- a/v2/pkg/dashboard/agent_replicas_test.go
+++ b/v2/pkg/dashboard/agent_replicas_test.go
@@ -1,0 +1,41 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/agent"
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/governor"
+)
+
+func TestBuildAgentsIncludesReplicaMetadataAndBaseCadence(t *testing.T) {
+	cfg := &config.Config{
+		Agents: map[string]config.AgentConfig{
+			"scanner":   {ID: "scanner", Enabled: true, Replicas: 2, ReplicaIndex: 1, ReplicaCount: 2},
+			"scanner-2": {ID: "scanner-2", Enabled: true, ReplicaOf: "scanner", ReplicaIndex: 2, ReplicaCount: 2},
+		},
+		Governor: config.GovernorConfig{Modes: map[string]config.ModeConfig{
+			"idle": {Cadences: map[string]config.Cadence{"scanner": "10m"}},
+		}},
+	}
+	statuses := map[string]*agent.AgentProcess{
+		"scanner":   {Name: "scanner", ID: "scanner", Config: cfg.Agents["scanner"], State: agent.StateRunning},
+		"scanner-2": {Name: "scanner-2", ID: "scanner-2", Config: cfg.Agents["scanner-2"], State: agent.StateRunning},
+	}
+	agents := buildAgents(statuses, cfg, governor.State{Mode: governor.ModeIdle})
+	var replica *FrontendAgent
+	for i := range agents {
+		if agents[i].Name == "scanner-2" {
+			replica = &agents[i]
+		}
+	}
+	if replica == nil {
+		t.Fatal("scanner-2 missing")
+	}
+	if replica.ReplicaBase != "scanner" || replica.ReplicaIndex != 2 || replica.ReplicaCount != 2 {
+		t.Fatalf("replica metadata = %+v", replica)
+	}
+	if replica.Cadence != "10m" {
+		t.Fatalf("replica cadence = %q, want 10m", replica.Cadence)
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -2237,6 +2237,7 @@ func (s *Server) handleAgentConfigGet(w http.ResponseWriter, r *http.Request) {
 			"detectKeywords":   agentCfg.DetectKeywords,
 			"aliases":          agentCfg.Aliases,
 			"cavemanMode":      agentCfg.CavemanMode,
+			"replicas":         agentCfg.Replicas,
 		},
 		"cadences":       cadences,
 		"models":         models,
@@ -2721,6 +2722,11 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 			agentCfg.StaleTimeout = int(f)
 		}
 	}
+	if v, ok := body["replicas"]; ok {
+		if f, ok := v.(float64); ok {
+			agentCfg.Replicas = int(f)
+		}
+	}
 	if v, ok := body["restartStrategy"]; ok {
 		if s, ok := v.(string); ok {
 			agentCfg.RestartStrategy = sanitizeString(s)
@@ -2909,7 +2915,28 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 		}
 	}
 
+	prevAgents := make(map[string]config.AgentConfig, len(s.deps.Config.Agents))
+	for k, v := range s.deps.Config.Agents {
+		prevAgents[k] = v
+	}
 	s.deps.Config.Agents[name] = agentCfg
+	if err := s.deps.Config.ExpandAgentReplicas(); err != nil {
+		s.deps.Config.Agents = prevAgents
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	agentCfg = s.deps.Config.Agents[name]
+	addedAgents := s.deps.AgentMgr.ReconcileAgents(s.deps.Config.EnabledAgents())
+	for _, added := range addedAgents {
+		if ac, ok := s.deps.Config.Agents[added]; ok && !ac.OnDemand {
+			if err := s.deps.AgentMgr.Start(s.deps.Ctx, added); err != nil {
+				s.logger.Warn("failed to start reconciled agent", "agent", added, "error", err)
+			}
+		}
+	}
+	if s.deps.Governor != nil {
+		s.deps.Governor.UpdateAgents(s.deps.Config.EnabledAgents())
+	}
 
 	// Sync the updated config into the agent process so that status builders
 	// (which read from AgentProcess.Config, not the global config map) reflect

--- a/v2/pkg/dashboard/api_agents.go
+++ b/v2/pkg/dashboard/api_agents.go
@@ -106,8 +106,22 @@ func (s *Server) handleAgentCreate(w http.ResponseWriter, r *http.Request) {
 	s.deps.Config.Agents[body.Name] = body.Agent
 	s.deps.Config.ApplyAgentDefaults(body.Name)
 
+	if err := s.deps.Config.ExpandAgentReplicas(); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	finalCfg := s.deps.Config.Agents[body.Name]
-	s.deps.AgentMgr.AddAgent(body.Name, finalCfg)
+	addedAgents := s.deps.AgentMgr.ReconcileAgents(s.deps.Config.EnabledAgents())
+	for _, added := range addedAgents {
+		if ac, ok := s.deps.Config.Agents[added]; ok && !ac.OnDemand {
+			if err := s.deps.AgentMgr.Start(s.deps.Ctx, added); err != nil {
+				s.logger.Warn("failed to start reconciled agent", "agent", added, "error", err)
+			}
+		}
+	}
+	if s.deps.Governor != nil {
+		s.deps.Governor.UpdateAgents(s.deps.Config.EnabledAgents())
+	}
 
 	s.reInitSubsystems()
 	s.refreshAndPersist()
@@ -122,6 +136,10 @@ func (s *Server) handleAgentDelete(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		jsonError(w, "agent not found", http.StatusNotFound)
 		return
+	}
+	if agentCfg.ReplicaOf != "" {
+		name = agentCfg.ReplicaOf
+		agentCfg = s.deps.Config.Agents[name]
 	}
 
 	if !agentCfg.Managed {
@@ -138,8 +156,15 @@ func (s *Server) handleAgentDelete(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	s.deps.AgentMgr.RemoveAgent(name)
 	delete(s.deps.Config.Agents, name)
+	if err := s.deps.Config.ExpandAgentReplicas(); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.deps.AgentMgr.ReconcileAgents(s.deps.Config.EnabledAgents())
+	if s.deps.Governor != nil {
+		s.deps.Governor.UpdateAgents(s.deps.Config.EnabledAgents())
+	}
 
 	// Record the deletion durably. Removing the overlay file above is not
 	// enough on its own: ApplyPack runs on every restart and re-creates any
@@ -358,8 +383,21 @@ func (s *Server) handleAgentImport(w http.ResponseWriter, r *http.Request) {
 	s.deps.Config.Agents[name] = agentCfg
 	s.deps.Config.ApplyAgentDefaults(name)
 
-	finalCfg := s.deps.Config.Agents[name]
-	s.deps.AgentMgr.AddAgent(name, finalCfg)
+	if err := s.deps.Config.ExpandAgentReplicas(); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	addedAgents := s.deps.AgentMgr.ReconcileAgents(s.deps.Config.EnabledAgents())
+	for _, added := range addedAgents {
+		if ac, ok := s.deps.Config.Agents[added]; ok && !ac.OnDemand {
+			if err := s.deps.AgentMgr.Start(s.deps.Ctx, added); err != nil {
+				s.logger.Warn("failed to start reconciled agent", "agent", added, "error", err)
+			}
+		}
+	}
+	if s.deps.Governor != nil {
+		s.deps.Governor.UpdateAgents(s.deps.Config.EnabledAgents())
+	}
 
 	s.reInitSubsystems()
 	s.refreshAndPersist()

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -298,6 +298,9 @@ type FrontendAgent struct {
 	Color            string `json:"color,omitempty"`
 	BeadRole         string `json:"beadRole,omitempty"`
 	Managed          bool   `json:"managed,omitempty"`
+	ReplicaBase      string `json:"replicaBase,omitempty"`
+	ReplicaIndex     int    `json:"replicaIndex,omitempty"`
+	ReplicaCount     int    `json:"replicaCount,omitempty"`
 	Session          string `json:"session"`
 	State            string `json:"state"`
 	Busy             string `json:"busy"`

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5655,9 +5655,11 @@
         }
         const indEl = agentIndicators(a.name);
         const compactCls = isAgentCompact(a.name) ? ' compact' : '';
+        const replicaBadge = (a.replicaBase && a.replicaIndex > 1) ? ` <span class="status-badge" title="Replica ${a.replicaIndex} of ${a.replicaCount} for ${esc(a.replicaBase)}">${esc(a.replicaBase)} · replica ${a.replicaIndex} of ${a.replicaCount}</span>` : '';
+        const configTarget = a.replicaBase || a.name;
         return `<div class="agent-card ${cls}${compactCls}" data-agent="${esc(a.name)}">
           <span class="working-indicator"></span>
-          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''} ${toggleBtn} <button class="compact-toggle" onclick="event.stopPropagation();toggleAgentCompact('${esc(a.name)}')" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure ${esc(a.displayName || a.name)}">⚙️</button></div>
+          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''}${replicaBadge} ${toggleBtn} <button class="compact-toggle" onclick="event.stopPropagation();toggleAgentCompact('${esc(a.name)}')" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(configTarget)}" title="Configure ${esc(a.replicaBase ? (a.replicaBase + ' (base for ' + a.name + ')') : (a.displayName || a.name))}">⚙️</button></div>
           <div class="agent-state ${isOnDemand ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}${pauseInfoIcon(a)}${(() => {
             if (a.structuredStatus === 'BLOCKED') return '<span class="status-badge blocked" title="' + esc(a.statusEvidence) + '">blocked</span>';
             if (a.structuredStatus === 'NEEDS_CONTEXT') return '<span class="status-badge needs-context" title="' + esc(a.statusEvidence) + '">needs context</span>';
@@ -13830,6 +13832,7 @@ function burnAreaChart() {
     };
     const RESTART_STRATEGIES = ['immediate', 'backoff', 'none'];
     const CAVEMAN_MODES = ['', 'lite', 'full', 'ultra', 'wenyan'];
+    const MAX_AGENT_REPLICAS = 5;
 
     function openConfigDialog(type, agentName, initialTabOverride) {
       const isCreate = type === 'agent' && !agentName;
@@ -16115,6 +16118,10 @@ function burnAreaChart() {
             <input type="number" id="cfg-agent-sort" value="${g.sortOrder || 50}" onchange="markDirty('general','sortOrder',parseInt(this.value,10))">
           </div>
           <div class="config-field">
+            <label>Replicas <span class="config-info">i<span class="config-tooltip">Run multiple isolated copies of this agent. Replica 1 keeps this name; extra replicas appear as name-2, name-3, etc. Cap ${MAX_AGENT_REPLICAS}.</span></span></label>
+            <input type="number" id="cfg-agent-replicas" min="1" max="${MAX_AGENT_REPLICAS}" value="${g.replicas || 1}" onchange="markDirty('general','replicas',Math.max(1,Math.min(MAX_AGENT_REPLICAS,parseInt(this.value,10)||1)));this.value=Math.max(1,Math.min(MAX_AGENT_REPLICAS,parseInt(this.value,10)||1))">
+          </div>
+          <div class="config-field">
             <label>Bead Role <span class="config-info">i<span class="config-tooltip">Worker agents do tasks. Supervisor monitors other agents.</span></span></label>
             <select id="cfg-agent-bead-role" onchange="markDirty('general','beadRole',this.value)">
               <option value="worker" ${(g.beadRole || 'worker') === 'worker' ? 'selected' : ''}>worker</option>
@@ -18322,6 +18329,7 @@ function burnAreaChart() {
           emoji: generalData.emoji || '',
           color: generalData.color || '#3498db',
           sort_order: generalData.sortOrder || 50,
+          replicas: generalData.replicas || 1,
           bead_role: generalData.beadRole || 'worker',
           role: generalData.role || '',
           kick_template: generalData.kickTemplate || '',
@@ -18437,6 +18445,7 @@ function burnAreaChart() {
             if (savedGeneral.emoji !== undefined) liveAgent.emoji = savedGeneral.emoji;
             if (savedGeneral.color !== undefined) liveAgent.color = savedGeneral.color;
             if (savedGeneral.sortOrder !== undefined) liveAgent.sortOrder = savedGeneral.sortOrder;
+            if (savedGeneral.replicas !== undefined) liveAgent.replicaCount = savedGeneral.replicas;
           }
         }
         _configState.dirty = {};

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -324,6 +324,9 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 			Color:         agentCfg.Color,
 			BeadRole:      agentCfg.GetBeadRole(),
 			Managed:       agentCfg.Managed,
+			ReplicaBase:   agentCfg.ReplicaOf,
+			ReplicaIndex:  agentCfg.ReplicaIndex,
+			ReplicaCount:  agentCfg.ReplicaCount,
 			OnDemand:      agentCfg.OnDemand,
 			Session:       name,
 			State:         string(proc.State),
@@ -735,6 +738,12 @@ func lookupCadenceValueForMode(agentName, modeName string, cfg *config.Config) c
 	if mode, ok := cfg.Governor.Modes[modeName]; ok {
 		if c, ok := mode.Cadences[agentName]; ok {
 			return c
+		}
+		baseName := cfg.BaseAgentName(agentName)
+		if baseName != agentName {
+			if c, ok := mode.Cadences[baseName]; ok {
+				return c
+			}
 		}
 	}
 	return ""

--- a/v2/pkg/dashboard/validation.go
+++ b/v2/pkg/dashboard/validation.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
 // ---------- validation constants ----------
@@ -69,17 +71,17 @@ var (
 
 // knownRoles is the set of valid agent roles.
 var knownRoles = map[string]bool{
-	"guide":        true,
-	"scanner":      true,
-	"supervisor":   true,
-	"quality":      true,
+	"guide":         true,
+	"scanner":       true,
+	"supervisor":    true,
+	"quality":       true,
 	"ci-maintainer": true,
-	"sec-check":    true,
-	"architect":    true,
-	"strategist":   true,
-	"outreach":     true,
-	"brainstorm":   true,
-	"worker":       true,
+	"sec-check":     true,
+	"architect":     true,
+	"strategist":    true,
+	"outreach":      true,
+	"brainstorm":    true,
+	"worker":        true,
 }
 
 // validBeadRoles is the set of valid bead roles.
@@ -176,6 +178,14 @@ func validateAgentGeneralInput(body map[string]interface{}) error {
 			n := int(f)
 			if n < 0 || n > maxSortOrder {
 				return fmt.Errorf("sortOrder must be between 0 and %d", maxSortOrder)
+			}
+		}
+	}
+	if v, ok := body["replicas"]; ok {
+		if f, ok := v.(float64); ok {
+			n := int(f)
+			if n < 1 || n > config.MaxAgentReplicas {
+				return fmt.Errorf("replicas must be between 1 and %d", config.MaxAgentReplicas)
 			}
 		}
 	}

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -241,6 +241,12 @@ func (g *Governor) UpdateConfig(cfg config.GovernorConfig) {
 	g.cfg = cfg
 }
 
+func (g *Governor) UpdateAgents(agents map[string]config.AgentConfig) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.agents = agents
+}
+
 func (g *Governor) Evaluate(queueIssues, queuePRs, queueHold, slaViolations int) []string {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -418,6 +424,10 @@ func (g *Governor) updateCadences() {
 				continue
 			}
 			entry.Interval = dur
+			if ac, ok := g.agents[agentName]; ok && ac.ReplicaIndex > 1 && ac.ReplicaCount > 1 && g.state.LastKick[agentName].IsZero() {
+				offset := time.Duration(int64(dur) * int64(ac.ReplicaIndex-1) / int64(ac.ReplicaCount))
+				g.state.LastKick[agentName] = g.now().Add(-dur + offset)
+			}
 		}
 		cadences[agentName] = entry
 	}
@@ -428,9 +438,18 @@ func (g *Governor) updateCadences() {
 // resolveCadence returns the configured cadence string for one agent in one
 // mode, falling back to the idle mode's entry when the mode defines none.
 func (g *Governor) resolveCadence(modeName, agentName string) (config.Cadence, bool) {
+	baseName := agentName
+	if ac, ok := g.agents[agentName]; ok && ac.ReplicaOf != "" {
+		baseName = ac.ReplicaOf
+	}
 	if mode, ok := g.cfg.Modes[modeName]; ok {
 		if c, ok := mode.Cadences[agentName]; ok {
 			return c, true
+		}
+		if baseName != agentName {
+			if c, ok := mode.Cadences[baseName]; ok {
+				return c, true
+			}
 		}
 	}
 	if modeName == idleModeKey {
@@ -439,6 +458,11 @@ func (g *Governor) resolveCadence(modeName, agentName string) (config.Cadence, b
 	if mode, ok := g.cfg.Modes[idleModeKey]; ok {
 		if c, ok := mode.Cadences[agentName]; ok {
 			return c, true
+		}
+		if baseName != agentName {
+			if c, ok := mode.Cadences[baseName]; ok {
+				return c, true
+			}
 		}
 	}
 	return "", false

--- a/v2/pkg/governor/governor_replicas_test.go
+++ b/v2/pkg/governor/governor_replicas_test.go
@@ -1,0 +1,31 @@
+package governor
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+func TestReplicaCadenceFallsBackToBaseAndStaggers(t *testing.T) {
+	agents := map[string]config.AgentConfig{
+		"scanner":   {Enabled: true, ReplicaIndex: 1, ReplicaCount: 2},
+		"scanner-2": {Enabled: true, ReplicaOf: "scanner", ReplicaIndex: 2, ReplicaCount: 2},
+	}
+	g := New(config.GovernorConfig{Modes: map[string]config.ModeConfig{
+		"idle": {Cadences: map[string]config.Cadence{"scanner": "10m"}},
+	}}, agents, slog.Default())
+	now := time.Date(2026, 8, 8, 9, 0, 0, 0, time.UTC)
+	g.now = func() time.Time { return now }
+	due := g.Evaluate(0, 0, 0, 0)
+	if len(due) != 1 || due[0] != "scanner" {
+		t.Fatalf("initial due = %v, want only scanner", due)
+	}
+	g.RecordKick("scanner")
+	now = now.Add(5 * time.Minute)
+	due = g.Evaluate(0, 0, 0, 0)
+	if len(due) != 1 || due[0] != "scanner-2" {
+		t.Fatalf("staggered due = %v, want only scanner-2", due)
+	}
+}

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -154,16 +154,17 @@ func (s *Scheduler) loadNamedTemplate(templateName string) string {
 
 // substituteTemplate replaces ${VAR} placeholders in a prompt template.
 func (s *Scheduler) substituteTemplate(template string, actionable *github.ActionableResult, agentName string, issues []github.Issue) string {
+	baseName := s.cfg.BaseAgentName(agentName)
 	if actionable == nil {
 		actionable = &github.ActionableResult{}
 	}
 	now := time.Now().Local()
 
 	var agentIssuesForList []github.Issue
-	if agentName == "scanner" {
+	if baseName == "scanner" {
 		agentIssuesForList = issues
 	} else {
-		agentIssuesForList = filterByLane(issues, agentName)
+		agentIssuesForList = filterByLane(issues, baseName)
 	}
 	issueList := s.formatIssueList(agentIssuesForList)
 	prList := s.formatPRList(actionable)
@@ -179,7 +180,7 @@ func (s *Scheduler) substituteTemplate(template string, actionable *github.Actio
 		displayName = ac.DisplayName
 	}
 
-	agentIssues := filterByLane(issues, agentName)
+	agentIssues := filterByLane(issues, baseName)
 	if len(agentIssues) == 0 && actionable != nil && len(actionable.Issues.Items) > 0 {
 		agentIssues = actionable.Issues.Items
 	}
@@ -316,7 +317,9 @@ func (s *Scheduler) BuildKickMessages(actionable *github.ActionableResult, agent
 			includeRepos := true
 			if agentCfg, ok := s.cfg.Agents[agentName]; ok {
 				includeRepos = agentCfg.ShouldIncludeRepos()
-			} else if agentName == "outreach" {
+			} else if agentCfg, ok := s.cfg.Agents[s.cfg.BaseAgentName(agentName)]; ok {
+				includeRepos = agentCfg.ShouldIncludeRepos()
+			} else if s.cfg.BaseAgentName(agentName) == "outreach" {
 				includeRepos = false
 			}
 			if includeRepos {
@@ -371,11 +374,12 @@ const maxIssuesPerKick = 100
 // BuildAgentMessage constructs a kick prompt for the named agent using the
 // template resolution chain (config kick_template → convention → embedded → hardcoded).
 func (s *Scheduler) BuildAgentMessage(agentName string, issues []github.Issue, actionable *github.ActionableResult) string {
+	baseName := s.cfg.BaseAgentName(agentName)
 	// 0. GitHub-sourced prompt: if the agent declares a prompt_source, resolve it
 	//    live at kick time (with allowlist gating + graceful fallback). A miss
 	//    (unset, denied, unreachable with no cache) falls through to the inline
 	//    template chain below, so a bad source never blanks or crashes a kick.
-	if agentCfg, ok := s.cfg.Agents[agentName]; ok && agentCfg.PromptSource.IsSet() {
+	if agentCfg, ok := s.cfg.Agents[baseName]; ok && agentCfg.PromptSource.IsSet() {
 		if resolver := s.gitHubPromptResolver(); resolver != nil {
 			src := promptsrc.Source{
 				Owner: agentCfg.PromptSource.Owner,
@@ -393,7 +397,7 @@ func (s *Scheduler) BuildAgentMessage(agentName string, issues []github.Issue, a
 	}
 
 	// 1. Config-driven: use kick_template field if set
-	if agentCfg, ok := s.cfg.Agents[agentName]; ok && agentCfg.KickTemplate != "" {
+	if agentCfg, ok := s.cfg.Agents[baseName]; ok && agentCfg.KickTemplate != "" {
 		if template := s.loadNamedTemplate(agentCfg.KickTemplate); template != "" {
 			s.logger.Info("using config kick_template", "agent", agentName, "template", agentCfg.KickTemplate)
 			msg := fmt.Sprintf("[agent:%s]\n\n", agentName)
@@ -406,7 +410,7 @@ func (s *Scheduler) BuildAgentMessage(agentName string, issues []github.Issue, a
 	if s.cfg.ACMMLevel != nil && *s.cfg.ACMMLevel > 0 {
 		if pack, err := config.ACMMPackByLevel(*s.cfg.ACMMLevel); err == nil {
 			for _, pa := range pack.Agents {
-				if pa.Name == agentName && pa.KickTemplate != "" {
+				if pa.Name == baseName && pa.KickTemplate != "" {
 					if template := s.loadNamedTemplate(pa.KickTemplate); template != "" {
 						s.logger.Info("using ACMM pack template", "agent", agentName, "level", *s.cfg.ACMMLevel, "template", pa.KickTemplate)
 						msg := fmt.Sprintf("[agent:%s]\n\n", agentName)
@@ -419,7 +423,7 @@ func (s *Scheduler) BuildAgentMessage(agentName string, issues []github.Issue, a
 	}
 
 	// 3. Convention: look for <agent>.md template file
-	if template := s.loadPromptTemplate(agentName); template != "" {
+	if template := s.loadPromptTemplate(baseName); template != "" {
 		s.logger.Info("using prompt template for kick", "agent", agentName)
 		msg := fmt.Sprintf("[agent:%s]\n\n", agentName)
 		msg += s.substituteTemplate(template, actionable, agentName, issues)
@@ -428,7 +432,7 @@ func (s *Scheduler) BuildAgentMessage(agentName string, issues []github.Issue, a
 
 	// 3. Legacy hardcoded fallback (removed in Phase 4 when all agents use templates)
 	s.logger.Info("no prompt template found, using hardcoded kick", "agent", agentName)
-	switch agentName {
+	switch baseName {
 	case "scanner":
 		return s.buildScannerMessage(issues, actionable)
 	case "ci-maintainer":
@@ -663,10 +667,11 @@ func (s *Scheduler) reposSection() string {
 }
 
 func (s *Scheduler) buildGenericMessage(agentName string, issues []github.Issue, actionable *github.ActionableResult) string {
+	baseName := s.cfg.BaseAgentName(agentName)
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("[agent:%s]\n", agentName))
 
-	agentIssues := filterByLane(issues, agentName)
+	agentIssues := filterByLane(issues, baseName)
 	if len(agentIssues) > 0 {
 		b.WriteString(fmt.Sprintf("Work items (%d):\n", len(agentIssues)))
 		for _, issue := range agentIssues {


### PR DESCRIPTION
## Summary
- Add per-agent `replicas: N` (default 1, cap 5) and expand configured agents into derived names: `scanner`, `scanner-2`, ... with collision validation.
- Keep existing name-keyed machinery by giving every replica its own agent name/ID, tmux session (`hive-<name>`), beads/work dirs, UID-map entry, dashboard card, audit and token accounting bucket.
- Add base-name resolution so replicas fall back to the base agent prompt/cadence/templates while still being kicked and tracked under their derived name.
- Reconcile live replica changes: increasing replicas creates/starts new sessions; decreasing replicas retires only the removed `hive-<name>` sessions via the manager lifecycle.
- Add dashboard/API support for a Replicas field plus replica badges (for example `scanner · replica 2 of 3`).

## Work distribution boundary
Replicas intentionally do not add a new distributed lock in v1. They get staggered governor kicks (interval offset by replica index/count) and continue to rely on the existing issue/bead/assignment conventions in the agent prompts and GitHub workflow to avoid duplicate work. Each replica is a full agent from the budget perspective, so per-agent token budgets/costs apply per derived name and fleet cost scales with the replica count.

## Validation
- `go build ./...`
- `go vet ./...`
- `go test ./pkg/config/ ./pkg/agent/ ./pkg/dashboard/ -count=1`
- `go test ./pkg/governor/ -count=1`