### PR TITLE
[sec-check] fix: pin Nous git clone to commit SHA to prevent mutable-branch supply chain injection

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -215,7 +215,14 @@ ARG PLUK_VERSION=0.8.0
 RUN npm install -g @kubestellar/pluk@${PLUK_VERSION} && npm cache clean --force
 RUN mkdir -p /var/run/pluk/logs /var/run/pluk/commands && \
     chmod 1777 /var/run/pluk/logs /var/run/pluk/commands
-RUN (which git && git clone -b feat/cli-agent-mode https://github.com/clubanderson/agentic-strategy-evolution /opt/nous && \
+# Nous framework: pinned to a specific commit SHA to prevent supply-chain
+# injection via a push to the mutable branch ref. Update NOUS_COMMIT
+# deliberately when pulling upstream changes, after reviewing the diff at
+# that SHA. feat/cli-agent-mode HEAD verified 2026-08-08.
+ARG NOUS_COMMIT=8de28905b87474b870c56e1ecbd3c970532683b8
+RUN (which git && \
+    git clone https://github.com/clubanderson/agentic-strategy-evolution /opt/nous && \
+    git -C /opt/nous checkout "${NOUS_COMMIT}" && \
     python3 -m venv /opt/nous/venv && \
     /opt/nous/venv/bin/pip install --no-cache-dir -e /opt/nous 2>&1) || \
     echo "WARN: Nous install failed — run_campaign.py may not work"


### PR DESCRIPTION
## Security Fix

Pins the Nous framework `git clone` in `v2/Dockerfile` to a specific commit SHA instead of the mutable branch name `feat/cli-agent-mode`.

### Why this is dangerous

The current Dockerfile clones an external personal repository at a floating branch reference:

```dockerfile
RUN git clone -b feat/cli-agent-mode https://github.com/clubanderson/agentic-strategy-evolution /opt/nous
```

Any push to `feat/cli-agent-mode` on `clubanderson/agentic-strategy-evolution` instantly affects the next image build — without any change to the Dockerfile. A compromised GitHub account or a malicious commit to that branch could inject arbitrary Python code that is then `pip install -e`'d and executed inside the production hive container.

### What this PR does

Adds `ARG NOUS_COMMIT=8de28905b87474b870c56e1ecbd3c970532683b8` and replaces the mutable branch clone with:

```dockerfile
git clone https://github.com/clubanderson/agentic-strategy-evolution /opt/nous && \
git -C /opt/nous checkout "${NOUS_COMMIT}"
```

The pinned SHA (`8de28905`) is the verified HEAD of `feat/cli-agent-mode` as of 2026-08-08. Future upstream updates require a deliberate, reviewable bump of `NOUS_COMMIT`.

Fixes #2905

---
*Filed by sec-check agent (ACMM L4/L5 — hold-gated mode). Hold-gated: human review required.*