### PR TITLE
🔀 sync: v2 into mk (0808d)

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -13,6 +13,8 @@
 //                           the same order as HIVE_HUB
 //   AGENT_BACKEND          — CLI backend name (claude, copilot, gemini, etc.)
 //   AGENT_MODEL            — model override (optional)
+//   HIVE_AGENT_ROLE        — optional spoke agent role to claim (scanner,
+//                           quality, outreach, etc.; hub-enforced)
 //   HIVE_AGENT_SESSION     — tmux session name for the agent (default: contributor)
 
 'use strict';
@@ -37,6 +39,7 @@ if (rawHubList.length > 1 && rawTokenList.length !== rawHubList.length) {
 }
 const BACKEND = process.env.AGENT_BACKEND || 'claude';
 const MODEL = process.env.AGENT_MODEL || process.env.GOOSE_MODEL || '';
+const AGENT_ROLE = (process.env.HIVE_AGENT_ROLE || '').trim();
 const TMUX_SESSION = process.env.HIVE_AGENT_SESSION || 'contributor';
 const GH_TOKEN_CACHE = process.env.HIVE_GH_TOKEN_CACHE || (fs.existsSync('/var/run/hive-metrics')
   ? '/var/run/hive-metrics/gh-app-token.cache'
@@ -1119,6 +1122,7 @@ function handleMessage(data, hub) {
         registration_token: hub.regToken,
         cli_backend: BACKEND,
         model: MODEL,
+        role: AGENT_ROLE,
         // #2547 declare half + #2567: additive, optional self-report of runtime
         // posture and protocol version. An older hub ignores these unknown fields.
         protocol_version: RELAY_PROTOCOL_VERSION,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -263,6 +263,16 @@ test('task_assign queues rather than typing when the CLI is not ready', () => {
   } finally { teardown(relay); }
 });
 
+test('auth_response includes optional HIVE_AGENT_ROLE', () => {
+  const relay = loadRelay({ env: { HIVE_AGENT_ROLE: 'scanner' } });
+  try {
+    relay.handleMessage(JSON.stringify({ type: 'auth_challenge', seq: 1, nonce: 'n' }));
+    const auth = relay.__sent.find(m => m.type === 'auth_response');
+    assert.ok(auth, 'expected auth_response');
+    assert.strictEqual(auth.role, 'scanner');
+  } finally { teardown(relay); }
+});
+
 test('relaunchCLI() leaves cliReady false until readiness is confirmed', () => {
   const relay = loadRelay({ backend: 'copilot', cliStates: ['starting'] });
   try {

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2358,6 +2358,21 @@ func main() {
 		// fields; a fetch failure keeps each agent's baked definition. Runs before
 		// initAgentConfigDrivenSystems so downstream systems see the merged config.
 		defsrc.ApplyToConfig(context.Background(), cfg, definitionResolver, logger)
+		if err := cfg.ExpandAgentReplicas(); err != nil {
+			logger.Warn("failed to expand agent replicas after config reload", "error", err)
+		}
+		addedAgents := agentMgr.ReconcileAgents(cfg.EnabledAgents())
+		for _, added := range addedAgents {
+			if ac, ok := cfg.Agents[added]; ok && !ac.OnDemand {
+				go func(name string) {
+					logger.Info("audit: starting reconciled agent", "name", name, "trigger", "config-reload")
+					if err := agentMgr.Start(ctx, name); err != nil {
+						logger.Warn("failed to start reconciled agent", "name", name, "error", err)
+					}
+				}(added)
+			}
+		}
+		gov.UpdateAgents(cfg.EnabledAgents())
 
 		initAgentConfigDrivenSystems(cfg)
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -2411,6 +2411,70 @@ func (m *Manager) UpdateConfig(name string, cfg config.AgentConfig) error {
 	return nil
 }
 
+// ReconcileAgents makes the manager's name-keyed process table match the
+// enabled config set. New agents are added, existing agents get fresh config,
+// and removed agents have only their own hive-<name> tmux session retired.
+func (m *Manager) ReconcileAgents(configs map[string]config.AgentConfig) []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var added []string
+
+	for name, cfg := range configs {
+		if existing, ok := m.agents[name]; ok {
+			delete(m.idToName, existing.ID)
+			existing.Config = cfg
+			if cfg.ID != "" {
+				existing.ID = cfg.ID
+			} else {
+				existing.ID = name
+			}
+			m.idToName[existing.ID] = name
+			continue
+		}
+		agentID := cfg.ID
+		if agentID == "" {
+			agentID = name
+		}
+		agentUID := 0
+		tmuxSocket := ""
+		if m.uidMap != nil {
+			agentUID = m.uidMap.AllocateUID(name)
+			if agentUID > 0 {
+				tmuxSocket = "hive-" + name
+			}
+			_ = m.uidMap.Save(UIDMapPath)
+		}
+		m.agents[name] = &AgentProcess{
+			Name:         name,
+			ID:           agentID,
+			Config:       cfg,
+			State:        StateStopped,
+			UID:          agentUID,
+			Paused:       cfg.Paused,
+			OutputBuffer: NewRingBuffer(outputBufferCapacity),
+			tmuxSession:  "hive-" + name,
+			tmuxSocket:   tmuxSocket,
+		}
+		m.idToName[agentID] = name
+		added = append(added, name)
+		m.logger.Info("audit: agent added by reconcile", "name", name, "id", agentID, "uid", agentUID)
+	}
+
+	for name, existing := range m.agents {
+		if _, ok := configs[name]; ok {
+			continue
+		}
+		if existing.cancel != nil {
+			existing.cancel()
+		}
+		_ = m.tmuxCmd(existing, "kill-session", "-t", existing.tmuxSession).Run()
+		delete(m.idToName, existing.ID)
+		delete(m.agents, name)
+		m.logger.Info("audit: agent removed by reconcile", "name", name, "id", existing.ID, "session", existing.tmuxSession)
+	}
+	return added
+}
+
 func (m *Manager) RemoveAgent(name string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/v2/pkg/agent/manager_replicas_test.go
+++ b/v2/pkg/agent/manager_replicas_test.go
@@ -1,0 +1,27 @@
+package agent
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+func TestReconcileAgentsAddsReplicaWithUIDAndRemovesExtra(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{"scanner": {ID: "scanner", Enabled: true}}, slog.Default(), ProjectContext{})
+	m.uidMap = NewUIDMap()
+	m.ReconcileAgents(map[string]config.AgentConfig{
+		"scanner":   {ID: "scanner", Enabled: true, ReplicaIndex: 1, ReplicaCount: 2},
+		"scanner-2": {ID: "scanner-2", Enabled: true, ReplicaOf: "scanner", ReplicaIndex: 2, ReplicaCount: 2},
+	})
+	if _, ok := m.agents["scanner-2"]; !ok {
+		t.Fatal("scanner-2 not added")
+	}
+	if got := m.agents["scanner-2"].UID; got == 0 {
+		t.Fatal("scanner-2 UID was not allocated")
+	}
+	m.ReconcileAgents(map[string]config.AgentConfig{"scanner": {ID: "scanner", Enabled: true, ReplicaIndex: 1, ReplicaCount: 1}})
+	if _, ok := m.agents["scanner-2"]; ok {
+		t.Fatal("scanner-2 not removed")
+	}
+}

--- a/v2/pkg/config/agent_overlay.go
+++ b/v2/pkg/config/agent_overlay.go
@@ -179,6 +179,9 @@ func (c *Config) ApplyAgentDefaults(name string) {
 	if agent.ID == "" {
 		agent.ID = name
 	}
+	if agent.Replicas == 0 {
+		agent.Replicas = 1
+	}
 	if agent.BeadsDir == "" {
 		agent.BeadsDir = fmt.Sprintf("/data/beads/%s", name)
 	}

--- a/v2/pkg/config/agent_replicas_test.go
+++ b/v2/pkg/config/agent_replicas_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExpandAgentReplicasMaterializesDerivedNames(t *testing.T) {
+	cfg := &Config{Agents: map[string]AgentConfig{
+		"scanner": {ID: "scanner", Backend: "copilot", Model: "auto", Enabled: true, Replicas: 3},
+	}}
+	if err := cfg.ExpandAgentReplicas(); err != nil {
+		t.Fatalf("ExpandAgentReplicas() error = %v", err)
+	}
+	for _, name := range []string{"scanner", "scanner-2", "scanner-3"} {
+		if _, ok := cfg.Agents[name]; !ok {
+			t.Fatalf("missing materialized agent %s", name)
+		}
+	}
+	if got := cfg.Agents["scanner-2"]; got.ReplicaOf != "scanner" || got.ReplicaIndex != 2 || got.ReplicaCount != 3 || got.ID != "scanner-2" {
+		t.Fatalf("scanner-2 metadata = %+v", got)
+	}
+	if got := cfg.Agents["scanner-3"].BeadsDir; got != "/data/beads/scanner-3" {
+		t.Fatalf("scanner-3 beads dir = %q", got)
+	}
+}
+
+func TestExpandAgentReplicasRejectsCollisionsAndCap(t *testing.T) {
+	cfg := &Config{Agents: map[string]AgentConfig{
+		"scanner":   {Replicas: 2},
+		"scanner-2": {Replicas: 1},
+	}}
+	if err := cfg.ExpandAgentReplicas(); err == nil || !strings.Contains(err.Error(), "scanner-2") {
+		t.Fatalf("collision error = %v", err)
+	}
+
+	cfg = &Config{Agents: map[string]AgentConfig{"scanner": {Replicas: MaxAgentReplicas + 1}}}
+	if err := cfg.ExpandAgentReplicas(); err == nil || !strings.Contains(err.Error(), "replicas") {
+		t.Fatalf("cap error = %v", err)
+	}
+}
+
+func TestExpandAgentReplicasOneIsZeroMigration(t *testing.T) {
+	cfg := &Config{Agents: map[string]AgentConfig{"scanner": {Replicas: 1}}}
+	if err := cfg.ExpandAgentReplicas(); err != nil {
+		t.Fatalf("ExpandAgentReplicas() error = %v", err)
+	}
+	if len(cfg.Agents) != 1 {
+		t.Fatalf("len agents = %d, want 1", len(cfg.Agents))
+	}
+	if cfg.Agents["scanner"].ReplicaOf != "" || cfg.Agents["scanner"].ReplicaIndex != 1 {
+		t.Fatalf("base metadata = %+v", cfg.Agents["scanner"])
+	}
+}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -364,11 +364,15 @@ type ConnectionConfig struct {
 }
 
 type AgentConfig struct {
-	ID       string `yaml:"id" json:"id,omitempty"`
-	Backend  string `yaml:"backend" json:"backend,omitempty"`
-	Model    string `yaml:"model" json:"model,omitempty"`
-	BeadsDir string `yaml:"beads_dir" json:"beads_dir,omitempty"`
-	Enabled  bool   `yaml:"enabled" json:"enabled,omitempty"`
+	ID           string `yaml:"id" json:"id,omitempty"`
+	Backend      string `yaml:"backend" json:"backend,omitempty"`
+	Model        string `yaml:"model" json:"model,omitempty"`
+	BeadsDir     string `yaml:"beads_dir" json:"beads_dir,omitempty"`
+	Enabled      bool   `yaml:"enabled" json:"enabled,omitempty"`
+	Replicas     int    `yaml:"replicas,omitempty" json:"replicas,omitempty"`
+	ReplicaOf    string `yaml:"-" json:"replicaOf,omitempty"`
+	ReplicaIndex int    `yaml:"-" json:"replicaIndex,omitempty"`
+	ReplicaCount int    `yaml:"-" json:"replicaCount,omitempty"`
 	// Paused persists an operator pause across restarts/upgrades. Without
 	// this, every pod restart rebuilt agents un-paused (Go zero value), so
 	// an operator pause was silently undone on the next upgrade.
@@ -459,6 +463,21 @@ type AgentConfig struct {
 // Name returns the human-readable YAML key for this agent.
 func (a *AgentConfig) Name() string {
 	return a.name
+}
+
+// IsReplica reports whether this agent was materialized from another agent's
+// replicas setting rather than declared directly in YAML.
+func (a AgentConfig) IsReplica() bool { return a.ReplicaOf != "" }
+
+// BaseName returns the declared agent name whose config/prompt this agent uses.
+func (a AgentConfig) BaseName() string {
+	if a.ReplicaOf != "" {
+		return a.ReplicaOf
+	}
+	if a.name != "" {
+		return a.name
+	}
+	return a.ID
 }
 
 // HasChannel returns true if the agent has a channel of the given type.
@@ -2282,6 +2301,10 @@ func LoadWithOverrides(path, envPath string) (*Config, error) {
 		}
 	}
 
+	if err := cfg.ExpandAgentReplicas(); err != nil {
+		return nil, fmt.Errorf("expanding agent replicas: %w", err)
+	}
+
 	if err := cfg.validate(); err != nil {
 		return nil, fmt.Errorf("validating config: %w", err)
 	}
@@ -2349,6 +2372,9 @@ func LoadWithDashboardOverlay(path string) (*Config, error) {
 	cfg.MergeAgentOverrides(overlay.Agents)
 	for name := range overlay.Agents {
 		cfg.ApplyAgentDefaults(name)
+	}
+	if err := cfg.ExpandAgentReplicas(); err != nil {
+		return cfg, err
 	}
 	// Security invariant: cfg.Variables (resolver defs + the exec/http trust
 	// policy) comes ONLY from the seed loaded above — the overlay's Variables
@@ -2612,6 +2638,8 @@ func (c *Config) GitHubDefinitionAllowed(slug string) bool {
 }
 
 const (
+	MaxAgentReplicas = 5
+
 	defaultDashboardPort          = 3002
 	defaultAgentPollIntervalS     = 10
 	defaultEvalIntervalS          = 300
@@ -2679,6 +2707,9 @@ func (c *Config) applyDefaults() {
 		agent.name = name
 		if agent.ID == "" {
 			agent.ID = name
+		}
+		if agent.Replicas == 0 {
+			agent.Replicas = 1
 		}
 		if agent.BeadsDir == "" {
 			agent.BeadsDir = fmt.Sprintf("/data/beads/%s", name)
@@ -3210,6 +3241,116 @@ func validateConnections(agentName string, conns []ConnectionConfig) error {
 		}
 	}
 	return nil
+}
+
+// BaseAgentName returns the declared/base agent name for name. For ordinary
+// agents it returns name; for materialized replicas (scanner-2) it returns the
+// source agent (scanner).
+func (c *Config) BaseAgentName(name string) string {
+	if c == nil || c.Agents == nil {
+		return name
+	}
+	if ac, ok := c.Agents[name]; ok && ac.ReplicaOf != "" {
+		return ac.ReplicaOf
+	}
+	return name
+}
+
+func replicaAgentName(base string, index int) string {
+	if index <= 1 {
+		return base
+	}
+	return fmt.Sprintf("%s-%d", base, index)
+}
+
+func normalizeReplicaCount(n int) int {
+	if n == 0 {
+		return 1
+	}
+	return n
+}
+
+// ExpandAgentReplicas materializes each declared agent's replicas setting into
+// the existing name-keyed machinery: base, base-2, ..., base-N. Derived agents
+// are marked with ReplicaOf and are stripped again when the config is saved.
+func (c *Config) ExpandAgentReplicas() error {
+	if c == nil || c.Agents == nil {
+		return nil
+	}
+	baseAgents := make(map[string]AgentConfig, len(c.Agents))
+	for name, agent := range c.Agents {
+		if agent.ReplicaOf != "" {
+			continue
+		}
+		baseAgents[name] = agent
+	}
+	for name, agent := range c.Agents {
+		if agent.ReplicaOf != "" {
+			delete(c.Agents, name)
+		}
+	}
+	for name, agent := range baseAgents {
+		replicas := normalizeReplicaCount(agent.Replicas)
+		if replicas < 1 || replicas > MaxAgentReplicas {
+			return fmt.Errorf("agent %s: replicas must be between 1 and %d", name, MaxAgentReplicas)
+		}
+		for i := 2; i <= replicas; i++ {
+			derived := replicaAgentName(name, i)
+			if existing, ok := baseAgents[derived]; ok && existing.ReplicaOf == "" {
+				return fmt.Errorf("agent %s: replicas:%d would create %s, but an agent with that name already exists", name, replicas, derived)
+			}
+		}
+	}
+	for name, agent := range baseAgents {
+		replicas := normalizeReplicaCount(agent.Replicas)
+		agent.Replicas = replicas
+		agent.ReplicaOf = ""
+		agent.ReplicaIndex = 1
+		agent.ReplicaCount = replicas
+		agent.name = name
+		c.Agents[name] = agent
+		for i := 2; i <= replicas; i++ {
+			derivedName := replicaAgentName(name, i)
+			derived := agent
+			derived.name = derivedName
+			derived.ID = derivedName
+			derived.BeadsDir = fmt.Sprintf("/data/beads/%s", derivedName)
+			derived.Role = agent.Role
+			derived.ReplicaOf = name
+			derived.ReplicaIndex = i
+			derived.ReplicaCount = replicas
+			c.Agents[derivedName] = derived
+		}
+	}
+	for name, agent := range c.Agents {
+		if agent.ReplicaOf == "" {
+			continue
+		}
+		if _, ok := baseAgents[agent.ReplicaOf]; !ok {
+			delete(c.Agents, name)
+		}
+	}
+	return nil
+}
+
+// MarshalYAML persists only declared agents. Runtime-derived replicas are
+// re-created by ExpandAgentReplicas on the next load so they never collide with
+// their base agent's replicas setting after a save.
+func (c Config) MarshalYAML() (interface{}, error) {
+	type plain Config
+	out := plain(c)
+	if c.Agents != nil {
+		out.Agents = make(map[string]AgentConfig, len(c.Agents))
+		for name, agent := range c.Agents {
+			if agent.ReplicaOf != "" {
+				continue
+			}
+			agent.ReplicaIndex = 0
+			agent.ReplicaCount = 0
+			out.Agents[name] = agent
+		}
+	}
+	return out, nil
 }
 
 func (c *Config) EnabledAgents() map[string]AgentConfig {

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1982,11 +1982,17 @@ type HubConfig struct {
 	//     operators who want a wait state.
 	// A POINTER so an absent value (older on-disk config) resolves to the
 	// backward-compatible auto-accept default via IsContributeRequireExplicitAccept().
-	ContributeRequireExplicitAccept *bool               `yaml:"contribute_require_explicit_accept,omitempty"`
-	DisabledRepos                   []string            `yaml:"disabled_repos"`
-	DisabledTiers                   []string            `yaml:"disabled_tiers"`
-	TierLimits                      map[string]TierRate `yaml:"tier_limits"`
-	SnapshotIntervalMin             int                 `yaml:"snapshot_interval_min"`
+	ContributeRequireExplicitAccept *bool `yaml:"contribute_require_explicit_accept,omitempty"`
+	// ContributeDelegatableRoles is the hive-wide allow-list of spoke agent roles
+	// a contributor relay may request via HIVE_AGENT_ROLE / auth_response.role.
+	// Empty means the safe default set: scanner, quality, outreach. Privileged roles
+	// (ci-maintainer, sec-check, architect) must be explicitly listed here AND
+	// granted on the contributor profile; supervisor is never delegatable.
+	ContributeDelegatableRoles []string            `yaml:"contribute_delegatable_roles,omitempty"`
+	DisabledRepos              []string            `yaml:"disabled_repos"`
+	DisabledTiers              []string            `yaml:"disabled_tiers"`
+	TierLimits                 map[string]TierRate `yaml:"tier_limits"`
+	SnapshotIntervalMin        int                 `yaml:"snapshot_interval_min"`
 }
 
 // Contribute completion-cooldown defaults and clamp bounds. These live in the
@@ -2022,6 +2028,33 @@ func (h HubConfig) IsContributeCooldownEnabled() bool {
 // is withheld until the client accepts the assigned task.
 func (h HubConfig) IsContributeRequireExplicitAccept() bool {
 	return h.ContributeRequireExplicitAccept != nil && *h.ContributeRequireExplicitAccept
+}
+
+var defaultContributeDelegatableRoles = []string{"scanner", "quality", "outreach"}
+
+// ContributeDelegatableRoleSet resolves the hive-wide allow-list of spoke roles
+// a clanker may claim. Empty config preserves the safe v1 default; supervisor is
+// deliberately removed even if an operator lists it because it manages the fleet.
+func (h HubConfig) ContributeDelegatableRoleSet() map[string]bool {
+	roles := h.ContributeDelegatableRoles
+	if len(roles) == 0 {
+		roles = defaultContributeDelegatableRoles
+	}
+	out := make(map[string]bool, len(roles))
+	for _, role := range roles {
+		role = strings.ToLower(strings.TrimSpace(role))
+		if role == "" || role == "supervisor" {
+			continue
+		}
+		out[role] = true
+	}
+	return out
+}
+
+// IsContributeRoleDelegatable reports whether role is enabled hive-wide for
+// clanker delegation. It does not make any per-contributor or trust-tier decision.
+func (h HubConfig) IsContributeRoleDelegatable(role string) bool {
+	return h.ContributeDelegatableRoleSet()[strings.ToLower(strings.TrimSpace(role))]
 }
 
 // ContributeCooldownHoursOrDefault resolves the with-PR cooldown PERIOD in

--- a/v2/pkg/config/contribute_agent_roles_test.go
+++ b/v2/pkg/config/contribute_agent_roles_test.go
@@ -1,0 +1,33 @@
+package config
+
+import "testing"
+
+func TestContributeDelegatableRoleSet_DefaultsAndSupervisorDeny(t *testing.T) {
+	h := HubConfig{}
+	for _, role := range []string{"scanner", "quality", "outreach"} {
+		if !h.IsContributeRoleDelegatable(role) {
+			t.Fatalf("default delegatable roles should include %s", role)
+		}
+	}
+	for _, role := range []string{"ci-maintainer", "sec-check", "architect", "supervisor"} {
+		if h.IsContributeRoleDelegatable(role) {
+			t.Fatalf("default delegatable roles should not include %s", role)
+		}
+	}
+}
+
+func TestContributeDelegatableRoleSet_ExplicitAllowListStillDeniesSupervisor(t *testing.T) {
+	h := HubConfig{ContributeDelegatableRoles: []string{"ci-maintainer", " supervisor ", "SCANNER"}}
+	if !h.IsContributeRoleDelegatable("ci-maintainer") {
+		t.Fatal("explicit allow-list should enable ci-maintainer")
+	}
+	if !h.IsContributeRoleDelegatable("scanner") {
+		t.Fatal("explicit allow-list should normalize scanner")
+	}
+	if h.IsContributeRoleDelegatable("supervisor") {
+		t.Fatal("supervisor must never be delegatable, even when listed")
+	}
+	if h.IsContributeRoleDelegatable("quality") {
+		t.Fatal("non-listed role must not be enabled when explicit allow-list is set")
+	}
+}

--- a/v2/pkg/dashboard/agent_replicas_test.go
+++ b/v2/pkg/dashboard/agent_replicas_test.go
@@ -1,0 +1,41 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/agent"
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/governor"
+)
+
+func TestBuildAgentsIncludesReplicaMetadataAndBaseCadence(t *testing.T) {
+	cfg := &config.Config{
+		Agents: map[string]config.AgentConfig{
+			"scanner":   {ID: "scanner", Enabled: true, Replicas: 2, ReplicaIndex: 1, ReplicaCount: 2},
+			"scanner-2": {ID: "scanner-2", Enabled: true, ReplicaOf: "scanner", ReplicaIndex: 2, ReplicaCount: 2},
+		},
+		Governor: config.GovernorConfig{Modes: map[string]config.ModeConfig{
+			"idle": {Cadences: map[string]config.Cadence{"scanner": "10m"}},
+		}},
+	}
+	statuses := map[string]*agent.AgentProcess{
+		"scanner":   {Name: "scanner", ID: "scanner", Config: cfg.Agents["scanner"], State: agent.StateRunning},
+		"scanner-2": {Name: "scanner-2", ID: "scanner-2", Config: cfg.Agents["scanner-2"], State: agent.StateRunning},
+	}
+	agents := buildAgents(statuses, cfg, governor.State{Mode: governor.ModeIdle})
+	var replica *FrontendAgent
+	for i := range agents {
+		if agents[i].Name == "scanner-2" {
+			replica = &agents[i]
+		}
+	}
+	if replica == nil {
+		t.Fatal("scanner-2 missing")
+	}
+	if replica.ReplicaBase != "scanner" || replica.ReplicaIndex != 2 || replica.ReplicaCount != 2 {
+		t.Fatalf("replica metadata = %+v", replica)
+	}
+	if replica.Cadence != "10m" {
+		t.Fatalf("replica cadence = %q, want 10m", replica.Cadence)
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -2237,6 +2237,7 @@ func (s *Server) handleAgentConfigGet(w http.ResponseWriter, r *http.Request) {
 			"detectKeywords":   agentCfg.DetectKeywords,
 			"aliases":          agentCfg.Aliases,
 			"cavemanMode":      agentCfg.CavemanMode,
+			"replicas":         agentCfg.Replicas,
 		},
 		"cadences":       cadences,
 		"models":         models,
@@ -2721,6 +2722,11 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 			agentCfg.StaleTimeout = int(f)
 		}
 	}
+	if v, ok := body["replicas"]; ok {
+		if f, ok := v.(float64); ok {
+			agentCfg.Replicas = int(f)
+		}
+	}
 	if v, ok := body["restartStrategy"]; ok {
 		if s, ok := v.(string); ok {
 			agentCfg.RestartStrategy = sanitizeString(s)
@@ -2909,7 +2915,28 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 		}
 	}
 
+	prevAgents := make(map[string]config.AgentConfig, len(s.deps.Config.Agents))
+	for k, v := range s.deps.Config.Agents {
+		prevAgents[k] = v
+	}
 	s.deps.Config.Agents[name] = agentCfg
+	if err := s.deps.Config.ExpandAgentReplicas(); err != nil {
+		s.deps.Config.Agents = prevAgents
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	agentCfg = s.deps.Config.Agents[name]
+	addedAgents := s.deps.AgentMgr.ReconcileAgents(s.deps.Config.EnabledAgents())
+	for _, added := range addedAgents {
+		if ac, ok := s.deps.Config.Agents[added]; ok && !ac.OnDemand {
+			if err := s.deps.AgentMgr.Start(s.deps.Ctx, added); err != nil {
+				s.logger.Warn("failed to start reconciled agent", "agent", added, "error", err)
+			}
+		}
+	}
+	if s.deps.Governor != nil {
+		s.deps.Governor.UpdateAgents(s.deps.Config.EnabledAgents())
+	}
 
 	// Sync the updated config into the agent process so that status builders
 	// (which read from AgentProcess.Config, not the global config map) reflect

--- a/v2/pkg/dashboard/api_agents.go
+++ b/v2/pkg/dashboard/api_agents.go
@@ -106,8 +106,22 @@ func (s *Server) handleAgentCreate(w http.ResponseWriter, r *http.Request) {
 	s.deps.Config.Agents[body.Name] = body.Agent
 	s.deps.Config.ApplyAgentDefaults(body.Name)
 
+	if err := s.deps.Config.ExpandAgentReplicas(); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	finalCfg := s.deps.Config.Agents[body.Name]
-	s.deps.AgentMgr.AddAgent(body.Name, finalCfg)
+	addedAgents := s.deps.AgentMgr.ReconcileAgents(s.deps.Config.EnabledAgents())
+	for _, added := range addedAgents {
+		if ac, ok := s.deps.Config.Agents[added]; ok && !ac.OnDemand {
+			if err := s.deps.AgentMgr.Start(s.deps.Ctx, added); err != nil {
+				s.logger.Warn("failed to start reconciled agent", "agent", added, "error", err)
+			}
+		}
+	}
+	if s.deps.Governor != nil {
+		s.deps.Governor.UpdateAgents(s.deps.Config.EnabledAgents())
+	}
 
 	s.reInitSubsystems()
 	s.refreshAndPersist()
@@ -122,6 +136,10 @@ func (s *Server) handleAgentDelete(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		jsonError(w, "agent not found", http.StatusNotFound)
 		return
+	}
+	if agentCfg.ReplicaOf != "" {
+		name = agentCfg.ReplicaOf
+		agentCfg = s.deps.Config.Agents[name]
 	}
 
 	if !agentCfg.Managed {
@@ -138,8 +156,15 @@ func (s *Server) handleAgentDelete(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	s.deps.AgentMgr.RemoveAgent(name)
 	delete(s.deps.Config.Agents, name)
+	if err := s.deps.Config.ExpandAgentReplicas(); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.deps.AgentMgr.ReconcileAgents(s.deps.Config.EnabledAgents())
+	if s.deps.Governor != nil {
+		s.deps.Governor.UpdateAgents(s.deps.Config.EnabledAgents())
+	}
 
 	// Record the deletion durably. Removing the overlay file above is not
 	// enough on its own: ApplyPack runs on every restart and re-creates any
@@ -358,8 +383,21 @@ func (s *Server) handleAgentImport(w http.ResponseWriter, r *http.Request) {
 	s.deps.Config.Agents[name] = agentCfg
 	s.deps.Config.ApplyAgentDefaults(name)
 
-	finalCfg := s.deps.Config.Agents[name]
-	s.deps.AgentMgr.AddAgent(name, finalCfg)
+	if err := s.deps.Config.ExpandAgentReplicas(); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	addedAgents := s.deps.AgentMgr.ReconcileAgents(s.deps.Config.EnabledAgents())
+	for _, added := range addedAgents {
+		if ac, ok := s.deps.Config.Agents[added]; ok && !ac.OnDemand {
+			if err := s.deps.AgentMgr.Start(s.deps.Ctx, added); err != nil {
+				s.logger.Warn("failed to start reconciled agent", "agent", added, "error", err)
+			}
+		}
+	}
+	if s.deps.Governor != nil {
+		s.deps.Governor.UpdateAgents(s.deps.Config.EnabledAgents())
+	}
 
 	s.reInitSubsystems()
 	s.refreshAndPersist()

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -171,11 +171,15 @@ type ContributorProfile struct {
 	// never starved of work. Matching is exact on the label NAME, case-insensitive.
 	// Stored here (the existing per-contributor profile store) rather than in a new
 	// subsystem; empty/omitted for contributors who set none.
-	LabelInterests []string       `json:"label_interests,omitempty"`
-	Active         bool           `json:"active,omitempty"`
-	CurrentTask    *WSTaskAssign  `json:"current_task,omitempty"`
-	ActiveTasks    []WSTaskAssign `json:"active_tasks,omitempty"`
-	Sessions       int            `json:"sessions,omitempty"`
+	LabelInterests []string `json:"label_interests,omitempty"`
+	// AgentRoleGrants is the operator-managed per-contributor allow-list for
+	// claiming spoke agent roles that require explicit grant (for example
+	// ci-maintainer). It never changes the contributor's trust tier or credentials.
+	AgentRoleGrants []string       `json:"agent_role_grants,omitempty"`
+	Active          bool           `json:"active,omitempty"`
+	CurrentTask     *WSTaskAssign  `json:"current_task,omitempty"`
+	ActiveTasks     []WSTaskAssign `json:"active_tasks,omitempty"`
+	Sessions        int            `json:"sessions,omitempty"`
 }
 
 type ContributorRateLimits struct {

--- a/v2/pkg/dashboard/contribute_agent_roles.go
+++ b/v2/pkg/dashboard/contribute_agent_roles.go
@@ -1,0 +1,136 @@
+package dashboard
+
+import (
+	"fmt"
+	"strings"
+)
+
+var roleClaimMinTier = map[string]string{
+	"scanner":       "contributor",
+	"quality":       "contributor",
+	"outreach":      "contributor",
+	"ci-maintainer": "trusted",
+	"sec-check":     "trusted",
+	"architect":     "trusted",
+}
+
+var roleClaimNeedsGrant = map[string]bool{
+	"ci-maintainer": true,
+	"sec-check":     true,
+	"architect":     true,
+}
+
+var trustTierRank = map[string]int{
+	"newcomer":    0,
+	"advisor":     0,
+	"contributor": 1,
+	"trusted":     2,
+	"merger":      3,
+}
+
+func normalizeAgentRole(role string) string {
+	return strings.ToLower(strings.TrimSpace(role))
+}
+
+func hasAgentRoleGrant(profile *ContributorProfile, role string) bool {
+	if profile == nil {
+		return false
+	}
+	role = normalizeAgentRole(role)
+	for _, grant := range profile.AgentRoleGrants {
+		if normalizeAgentRole(grant) == role {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *ContributeWSHub) roleClaimAllowed(c *ContributorConnection, role string) (bool, string) {
+	role = normalizeAgentRole(role)
+	if role == "" {
+		return true, ""
+	}
+	if role == "supervisor" {
+		return false, "supervisor is not delegatable"
+	}
+	if c == nil || c.profile == nil {
+		return false, "missing contributor profile"
+	}
+	if h == nil || h.server == nil || h.server.deps == nil || h.server.deps.Config == nil {
+		// Unit-test and legacy no-config hubs have no work-selector config to
+		// consult. Preserve their historical "role is a display label" behavior;
+		// real hives have Config and are gated below before any role-shaped task.
+		return true, ""
+	}
+	cfg := h.server.deps.Config
+	agent, ok := cfg.Agents[role]
+	if !ok {
+		return false, fmt.Sprintf("unknown agent role %q", role)
+	}
+	if !agent.Enabled {
+		return false, fmt.Sprintf("agent role %q is disabled", role)
+	}
+	if !cfg.Hub.IsContributeRoleDelegatable(role) {
+		return false, fmt.Sprintf("agent role %q is not enabled for contributor delegation", role)
+	}
+	tier := normalizeAgentRole(c.profile.TrustTier)
+	minTier := roleClaimMinTier[role]
+	if minTier == "" {
+		minTier = "trusted"
+	}
+	if trustTierRank[tier] < trustTierRank[minTier] {
+		return false, fmt.Sprintf("trust tier %q cannot claim agent role %q", tier, role)
+	}
+	if roleClaimNeedsGrant[role] && !hasAgentRoleGrant(c.profile, role) {
+		return false, fmt.Sprintf("agent role %q requires an operator grant", role)
+	}
+	return true, ""
+}
+
+func (h *ContributeWSHub) roleKickPrompt(role string) string {
+	role = normalizeAgentRole(role)
+	if role == "" || h == nil || h.server == nil || h.server.deps == nil || h.server.deps.Scheduler == nil {
+		return ""
+	}
+	return h.server.deps.Scheduler.BuildAgentMessageFromLastActionable(role)
+}
+
+func buildRoleTaskPrompt(repoFull string, number int, title, role, agentPrompt string) string {
+	base := buildTaskPrompt(repoFull, number, title)
+	role = normalizeAgentRole(role)
+	if role == "" {
+		return base
+	}
+	if strings.TrimSpace(agentPrompt) == "" {
+		return fmt.Sprintf("[clanker-agent-role:%s]\n\nOperate as the hive spoke agent role %q for this contributor-owned task. Your credentials and permissions remain those of the contributor; do not assume any extra access from the role.\n\n%s", role, role, base)
+	}
+	return fmt.Sprintf("[clanker-agent-role:%s]\n\nA contributor is temporarily taking on the hive spoke agent role %q. Attribution remains the contributor's GitHub identity, and permissions remain the contributor tier's permissions.\n\nROLE KICK PROMPT (same template used for the spoke agent):\n%s\n\nASSIGNED CONTRIBUTOR TASK:\n%s", role, role, agentPrompt, base)
+}
+
+func (h *ContributeWSHub) issueMatchesAgentRole(role, title string, labels []string, lane string) bool {
+	role = normalizeAgentRole(role)
+	if role == "" || role == "scanner" {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(lane), role) {
+		return true
+	}
+	var keywords []string
+	if h != nil && h.server != nil && h.server.deps != nil && h.server.deps.Config != nil {
+		if agent, ok := h.server.deps.Config.Agents[role]; ok {
+			keywords = append(keywords, agent.LaneKeywords...)
+			keywords = append(keywords, agent.DetectKeywords...)
+		}
+	}
+	if len(keywords) == 0 {
+		keywords = append(keywords, role)
+	}
+	hay := strings.ToLower(title + " " + strings.Join(labels, " "))
+	for _, kw := range keywords {
+		kw = strings.ToLower(strings.TrimSpace(kw))
+		if kw != "" && strings.Contains(hay, kw) {
+			return true
+		}
+	}
+	return false
+}

--- a/v2/pkg/dashboard/contribute_agent_roles_test.go
+++ b/v2/pkg/dashboard/contribute_agent_roles_test.go
@@ -1,0 +1,149 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/scheduler"
+)
+
+func roleTestHub(t *testing.T) (*ContributeWSHub, *Server) {
+	t.Helper()
+	hub, s := covK2Hub(t)
+	cfg := s.deps.Config
+	cfg.Agents["quality"] = config.AgentConfig{Role: "quality", Enabled: true, LaneKeywords: []string{"test-coverage", "missing-tests"}}
+	cfg.Agents["scanner"] = config.AgentConfig{Role: "scanner", Enabled: true}
+	cfg.Agents["ci-maintainer"] = config.AgentConfig{Role: "ci-maintainer", Enabled: true}
+	cfg.Hub.ContributeDelegatableRoles = nil
+	s.deps.Scheduler = scheduler.New(cfg, s.logger)
+	return hub, s
+}
+
+func TestAgentRoleClaimGatingMatrix(t *testing.T) {
+	hub, _ := roleTestHub(t)
+	cases := []struct {
+		name   string
+		tier   string
+		role   string
+		grants []string
+		allow  []string
+		want   bool
+	}{
+		{name: "absent role is current behavior", tier: "newcomer", want: true},
+		{name: "newcomer cannot claim default role", tier: "newcomer", role: "scanner", want: false},
+		{name: "contributor can claim safe default role", tier: "contributor", role: "scanner", want: true},
+		{name: "trusted can claim safe default role", tier: "trusted", role: "quality", want: true},
+		{name: "privileged role disabled by default", tier: "trusted", role: "ci-maintainer", grants: []string{"ci-maintainer"}, want: false},
+		{name: "privileged role needs grant", tier: "trusted", role: "ci-maintainer", allow: []string{"ci-maintainer"}, want: false},
+		{name: "privileged role needs trusted plus grant", tier: "contributor", role: "ci-maintainer", allow: []string{"ci-maintainer"}, grants: []string{"ci-maintainer"}, want: false},
+		{name: "trusted plus grant can claim privileged role", tier: "trusted", role: "ci-maintainer", allow: []string{"ci-maintainer"}, grants: []string{"ci-maintainer"}, want: true},
+		{name: "supervisor never delegatable", tier: "merger", role: "supervisor", allow: []string{"supervisor"}, grants: []string{"supervisor"}, want: false},
+		{name: "disabled role cannot be claimed", tier: "trusted", role: "quality", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hub.server.deps.Config.Hub.ContributeDelegatableRoles = tc.allow
+			if tc.name == "disabled role cannot be claimed" {
+				agent := hub.server.deps.Config.Agents["quality"]
+				agent.Enabled = false
+				hub.server.deps.Config.Agents["quality"] = agent
+				defer func() {
+					agent.Enabled = true
+					hub.server.deps.Config.Agents["quality"] = agent
+				}()
+			}
+			conn := &ContributorConnection{
+				profile: &ContributorProfile{
+					GitHubUsername:  "alice",
+					ContributorID:   "c-alice",
+					TrustTier:       tc.tier,
+					AgentRoleGrants: tc.grants,
+				},
+				role: tc.role,
+			}
+			got, _ := hub.roleClaimAllowed(conn, tc.role)
+			if got != tc.want {
+				t.Fatalf("roleClaimAllowed(%s/%s grants=%v allow=%v) = %v, want %v",
+					tc.tier, tc.role, tc.grants, tc.allow, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAgentRoleTaskPayloadCarriesRolePromptAndFiltersLane(t *testing.T) {
+	hub, s := roleTestHub(t)
+	setStatusIssues(s,
+		map[string]any{"number": float64(1), "title": "ordinary bug", "author": "bob"},
+		map[string]any{
+			"number": float64(2),
+			"title":  "missing test coverage for API",
+			"author": "bob",
+			"labels": []any{"test-coverage"},
+			"lane":   "quality",
+		},
+	)
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "contributor"},
+		role:     "quality",
+		lastPong: time.Now(),
+	}
+	msg := hub.selectTask(conn)
+	if msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("expected task_assign, got %+v", msg)
+	}
+	if msg.Number != 2 {
+		t.Fatalf("quality role should receive quality-shaped work (#2), got #%d", msg.Number)
+	}
+	if msg.Role != "quality" {
+		t.Fatalf("task payload role = %q, want quality", msg.Role)
+	}
+	if !strings.Contains(msg.Prompt, "[clanker-agent-role:quality]") || !strings.Contains(msg.Prompt, "[agent:quality]") {
+		t.Fatalf("prompt did not carry clanker role and quality kick prompt:\n%s", msg.Prompt)
+	}
+}
+
+func TestAgentRoleDoubleClaimUsesContributorLease(t *testing.T) {
+	hub, s := roleTestHub(t)
+	setStatusIssues(s, map[string]any{
+		"number": float64(7),
+		"title":  "missing-tests regression",
+		"author": "bob",
+		"labels": []any{"missing-tests"},
+	})
+	roleConn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "role", ContributorID: "c-role", TrustTier: "contributor"},
+		role:     "quality",
+		lastPong: time.Now(),
+	}
+	plainConn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "plain", ContributorID: "c-plain", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["role"] = roleConn
+	hub.connections["plain"] = plainConn
+	hub.mu.Unlock()
+	first := hub.selectTask(roleConn)
+	if first == nil || first.Type != "task_assign" {
+		t.Fatalf("expected role clanker assignment, got %+v", first)
+	}
+	second := hub.selectTask(plainConn)
+	if second == nil || second.Type != "task_unavailable" || second.Reason != taskUnavailableNoMatchingWork {
+		t.Fatalf("same issue should be hidden by the active lease, got %+v", second)
+	}
+}
+
+func TestAgentRoleAuditEntryRecordsContributorAndRole(t *testing.T) {
+	hub, _ := roleTestHub(t)
+	hub.addActivity("alice", "picked up", "scanner", "copilot", "gpt", "contributor ran scanner task: issue myorg/repo#1")
+	entries := hub.RecentActivity()
+	if len(entries) == 0 {
+		t.Fatal("expected activity entry")
+	}
+	got := entries[len(entries)-1]
+	if got.Username != "alice" || got.Role != "scanner" || !strings.Contains(got.Task, "contributor ran scanner task") {
+		t.Fatalf("audit entry = %+v, want contributor attribution plus scanner role", got)
+	}
+}

--- a/v2/pkg/dashboard/contribute_protocol.go
+++ b/v2/pkg/dashboard/contribute_protocol.go
@@ -62,6 +62,10 @@ const (
 	// arrives in a following token_refresh — but no client change is required, since
 	// the token_refresh delivery is backward-compatible (see deliverTaskCredential).
 	capCredentialAfterAccept = "credential_after_accept"
+	// capAgentRoleClaim: the hub accepts an OPTIONAL auth_response.role request
+	// from contributor relays and, when allowed by hive config/tier/grants, shapes
+	// assignments with the matching spoke agent's prompt.
+	capAgentRoleClaim = "agent_role_claim"
 )
 
 // serverCapabilities returns the capability set this hub advertises on auth_ok.
@@ -74,6 +78,7 @@ func serverCapabilities() []string {
 		capPromptPreview,
 		capCapabilityDeclare,
 		capCredentialAfterAccept,
+		capAgentRoleClaim,
 	}
 }
 

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -257,6 +257,7 @@ type WSMessage struct {
 type WSTaskAssign struct {
 	TaskID string `json:"task_id"`
 	Kind   string `json:"kind"`
+	Role   string `json:"role,omitempty"`
 	Repo   string `json:"repo"`
 	Number int    `json:"number"`
 	Title  string `json:"title"`
@@ -1722,6 +1723,19 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
+			requestedRole := normalizeAgentRole(msg.Role)
+			probeContributor := &ContributorConnection{profile: profile}
+			if requestedRole != "" {
+				if ok, reason := h.roleClaimAllowed(probeContributor, requestedRole); !ok {
+					_ = sendJSON(conn, WSMessage{Type: "auth_failed", Reason: reason, Role: requestedRole})
+					h.logger.Warn("[contribute-ws] agent role claim rejected",
+						"username", profile.GitHubUsername, "tier", profile.TrustTier,
+						"role", requestedRole, "reason", reason)
+					conn.Close()
+					return
+				}
+			}
+
 			profile.LastActive = time.Now().UTC().Format(time.RFC3339)
 			if msg.CLIBackend != "" {
 				profile.CLIBackend = msg.CLIBackend
@@ -1732,8 +1746,8 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			if profile.AvatarURL == "" {
 				profile.AvatarURL = fmt.Sprintf("https://github.com/%s.png", profile.GitHubUsername)
 			}
-			if msg.Role != "" {
-				profile.PreferredRole = msg.Role
+			if requestedRole != "" {
+				profile.PreferredRole = requestedRole
 			}
 			_ = saveContributorProfile(profile)
 
@@ -1761,7 +1775,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				profile:      profile,
 				cliBackend:   msg.CLIBackend,
 				model:        msg.Model,
-				role:         msg.Role,
+				role:         requestedRole,
 				connectedAt:  time.Now(),
 				lastPong:     time.Now(),
 				capabilities: caps,
@@ -1793,7 +1807,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				ContributorID: profile.ContributorID,
 				TrustTier:     profile.TrustTier,
 				Permissions:   perms,
-				Role:          msg.Role,
+				Role:          requestedRole,
 				// #2567: advertise the protocol version and the server capability
 				// set so a client can learn what this deployed hub supports without
 				// probing. Additive — an existing client ignores these unknown fields.
@@ -1808,9 +1822,9 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				"username", profile.GitHubUsername,
 				"tier", profile.TrustTier,
 				"cli", msg.CLIBackend,
-				"role", msg.Role,
+				"role", requestedRole,
 			)
-			h.addActivity(profile.GitHubUsername, "joined", msg.Role, msg.CLIBackend, msg.Model, "")
+			h.addActivity(profile.GitHubUsername, "joined", requestedRole, msg.CLIBackend, msg.Model, "")
 
 			select {
 			case authDone <- contributor:
@@ -1897,6 +1911,9 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 				taskDesc := fmt.Sprintf("%s %s#%d: %s", task.Kind, task.Repo, task.Number, task.Title)
+				if task.Role != "" {
+					taskDesc = fmt.Sprintf("contributor ran %s task: %s", task.Role, taskDesc)
+				}
 				h.addActivity(contributor.profile.GitHubUsername, "picked up", contributor.role, contributor.cliBackend, contributor.model, taskDesc)
 				h.logger.Info("[contribute-ws] task assigned",
 					"username", contributor.profile.GitHubUsername,
@@ -1966,6 +1983,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					contributor.currentTask = &WSTaskAssign{
 						TaskID: msg.TaskID,
 						Kind:   msg.Kind,
+						Role:   msg.Role,
 						// #2644: canonicalise the CLIENT-supplied repo to the same
 						// repo.Full form selectTask assigned it under, so the
 						// activeIssues double-assign guard and the failure/completion
@@ -2609,6 +2627,9 @@ const (
 	// all filters (cooldown, disabled repos, allow/deny, skip-assigned, own-work),
 	// the candidate set is empty. There is simply nothing admissible to do now.
 	taskUnavailableNoMatchingWork = "no_matching_work"
+	// taskUnavailableRoleNotPermitted: the relay requested a spoke agent role, but
+	// the hive config/tier/grant policy does not allow this contributor to claim it.
+	taskUnavailableRoleNotPermitted = "agent_role_not_permitted"
 )
 
 // identityOf returns the stable key that groups a contributor's live
@@ -2805,6 +2826,18 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		// trivial and harmless (#2546).
 		return h.taskUnavailable(taskUnavailableHubNotReady)
 	}
+
+	requestedRole := ""
+	if c != nil {
+		requestedRole = normalizeAgentRole(c.role)
+	}
+	if requestedRole != "" {
+		if ok, reason := h.roleClaimAllowed(c, requestedRole); !ok {
+			h.logger.Warn("[contribute-ws] refusing task: agent role not permitted",
+				"username", identityOf(c), "role", requestedRole, "reason", reason)
+			return h.taskUnavailable(taskUnavailableRoleNotPermitted)
+		}
+	}
 	if h.server.deps != nil && h.server.deps.Config != nil && h.server.deps.Config.Hub.ContributeSuspended {
 		// #2546: the operator suspended the whole contribute queue. Previously this
 		// returned a bare nil and the contributor waited in silence, unable to tell
@@ -2986,6 +3019,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		title    string
 		url      string
 		labels   []string
+		lane     string
 		isOwn    bool
 		// interestMatch is true when the issue carries a label the contributor has
 		// opted into (#2637). It is a SOFT priority tier below own-work: matching
@@ -3070,8 +3104,12 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 			title, _ := issue["title"].(string)
 			url, _ := issue["url"].(string)
 			author, _ := issue["author"].(string)
+			lane, _ := issue["lane"].(string)
 			labels := stringSliceFromAny(issue["labels"])
 			assignees := stringSliceFromAny(issue["assignees"])
+			if requestedRole != "" && !h.issueMatchesAgentRole(requestedRole, title, labels, lane) {
+				continue
+			}
 
 			// Apply the title / author / label contribute filters. Each is a
 			// single list plus a mode (allow = only matching pass; deny = matching
@@ -3107,6 +3145,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				// task_assign can populate the Labels envelope field (kubestellar/
 				// hive#2393 item 8). They're already computed for filtering above.
 				labels: labels,
+				lane:   lane,
 				// "Own work" is the only #2390 signal available today: the
 				// candidate was authored by the connected contributor. When the
 				// username is unknown (empty), nothing is own → we keep today's
@@ -3215,6 +3254,9 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	// itself carries the #2545 workspace-clone instruction (real checkout into
 	// $HIVE_WORKSPACE_DIR rather than a fork-only --clone=false).
 	prompt := buildTaskPrompt(chosen.repoFull, chosen.number, chosen.title)
+	if requestedRole != "" {
+		prompt = buildRoleTaskPrompt(chosen.repoFull, chosen.number, chosen.title, requestedRole, h.roleKickPrompt(requestedRole))
+	}
 
 	// #2568: mint a fresh assignment generation for this task. It is stamped on the
 	// connection, shipped in task_assign below, and echoed back by the relay so a
@@ -3225,6 +3267,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	c.currentTask = &WSTaskAssign{
 		TaskID: taskID,
 		Kind:   "issue",
+		Role:   requestedRole,
 		Repo:   chosen.repoFull,
 		Number: chosen.number,
 		Title:  chosen.title,
@@ -3265,6 +3308,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		TaskID:  taskID,
 		TaskGen: gen,
 		Kind:    "issue",
+		Role:    requestedRole,
 		Repo:    chosen.repoFull,
 		Number:  chosen.number,
 		Title:   chosen.title,

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -298,6 +298,9 @@ type FrontendAgent struct {
 	Color            string `json:"color,omitempty"`
 	BeadRole         string `json:"beadRole,omitempty"`
 	Managed          bool   `json:"managed,omitempty"`
+	ReplicaBase      string `json:"replicaBase,omitempty"`
+	ReplicaIndex     int    `json:"replicaIndex,omitempty"`
+	ReplicaCount     int    `json:"replicaCount,omitempty"`
 	Session          string `json:"session"`
 	State            string `json:"state"`
 	Busy             string `json:"busy"`

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5655,9 +5655,11 @@
         }
         const indEl = agentIndicators(a.name);
         const compactCls = isAgentCompact(a.name) ? ' compact' : '';
+        const replicaBadge = (a.replicaBase && a.replicaIndex > 1) ? ` <span class="status-badge" title="Replica ${a.replicaIndex} of ${a.replicaCount} for ${esc(a.replicaBase)}">${esc(a.replicaBase)} · replica ${a.replicaIndex} of ${a.replicaCount}</span>` : '';
+        const configTarget = a.replicaBase || a.name;
         return `<div class="agent-card ${cls}${compactCls}" data-agent="${esc(a.name)}">
           <span class="working-indicator"></span>
-          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''} ${toggleBtn} <button class="compact-toggle" onclick="event.stopPropagation();toggleAgentCompact('${esc(a.name)}')" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure ${esc(a.displayName || a.name)}">⚙️</button></div>
+          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''}${replicaBadge} ${toggleBtn} <button class="compact-toggle" onclick="event.stopPropagation();toggleAgentCompact('${esc(a.name)}')" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(configTarget)}" title="Configure ${esc(a.replicaBase ? (a.replicaBase + ' (base for ' + a.name + ')') : (a.displayName || a.name))}">⚙️</button></div>
           <div class="agent-state ${isOnDemand ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}${pauseInfoIcon(a)}${(() => {
             if (a.structuredStatus === 'BLOCKED') return '<span class="status-badge blocked" title="' + esc(a.statusEvidence) + '">blocked</span>';
             if (a.structuredStatus === 'NEEDS_CONTEXT') return '<span class="status-badge needs-context" title="' + esc(a.statusEvidence) + '">needs context</span>';
@@ -13830,6 +13832,7 @@ function burnAreaChart() {
     };
     const RESTART_STRATEGIES = ['immediate', 'backoff', 'none'];
     const CAVEMAN_MODES = ['', 'lite', 'full', 'ultra', 'wenyan'];
+    const MAX_AGENT_REPLICAS = 5;
 
     function openConfigDialog(type, agentName, initialTabOverride) {
       const isCreate = type === 'agent' && !agentName;
@@ -16115,6 +16118,10 @@ function burnAreaChart() {
             <input type="number" id="cfg-agent-sort" value="${g.sortOrder || 50}" onchange="markDirty('general','sortOrder',parseInt(this.value,10))">
           </div>
           <div class="config-field">
+            <label>Replicas <span class="config-info">i<span class="config-tooltip">Run multiple isolated copies of this agent. Replica 1 keeps this name; extra replicas appear as name-2, name-3, etc. Cap ${MAX_AGENT_REPLICAS}.</span></span></label>
+            <input type="number" id="cfg-agent-replicas" min="1" max="${MAX_AGENT_REPLICAS}" value="${g.replicas || 1}" onchange="markDirty('general','replicas',Math.max(1,Math.min(MAX_AGENT_REPLICAS,parseInt(this.value,10)||1)));this.value=Math.max(1,Math.min(MAX_AGENT_REPLICAS,parseInt(this.value,10)||1))">
+          </div>
+          <div class="config-field">
             <label>Bead Role <span class="config-info">i<span class="config-tooltip">Worker agents do tasks. Supervisor monitors other agents.</span></span></label>
             <select id="cfg-agent-bead-role" onchange="markDirty('general','beadRole',this.value)">
               <option value="worker" ${(g.beadRole || 'worker') === 'worker' ? 'selected' : ''}>worker</option>
@@ -18322,6 +18329,7 @@ function burnAreaChart() {
           emoji: generalData.emoji || '',
           color: generalData.color || '#3498db',
           sort_order: generalData.sortOrder || 50,
+          replicas: generalData.replicas || 1,
           bead_role: generalData.beadRole || 'worker',
           role: generalData.role || '',
           kick_template: generalData.kickTemplate || '',
@@ -18437,6 +18445,7 @@ function burnAreaChart() {
             if (savedGeneral.emoji !== undefined) liveAgent.emoji = savedGeneral.emoji;
             if (savedGeneral.color !== undefined) liveAgent.color = savedGeneral.color;
             if (savedGeneral.sortOrder !== undefined) liveAgent.sortOrder = savedGeneral.sortOrder;
+            if (savedGeneral.replicas !== undefined) liveAgent.replicaCount = savedGeneral.replicas;
           }
         }
         _configState.dirty = {};

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -324,6 +324,9 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 			Color:         agentCfg.Color,
 			BeadRole:      agentCfg.GetBeadRole(),
 			Managed:       agentCfg.Managed,
+			ReplicaBase:   agentCfg.ReplicaOf,
+			ReplicaIndex:  agentCfg.ReplicaIndex,
+			ReplicaCount:  agentCfg.ReplicaCount,
 			OnDemand:      agentCfg.OnDemand,
 			Session:       name,
 			State:         string(proc.State),
@@ -735,6 +738,12 @@ func lookupCadenceValueForMode(agentName, modeName string, cfg *config.Config) c
 	if mode, ok := cfg.Governor.Modes[modeName]; ok {
 		if c, ok := mode.Cadences[agentName]; ok {
 			return c
+		}
+		baseName := cfg.BaseAgentName(agentName)
+		if baseName != agentName {
+			if c, ok := mode.Cadences[baseName]; ok {
+				return c
+			}
 		}
 	}
 	return ""

--- a/v2/pkg/dashboard/validation.go
+++ b/v2/pkg/dashboard/validation.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
 // ---------- validation constants ----------
@@ -69,17 +71,17 @@ var (
 
 // knownRoles is the set of valid agent roles.
 var knownRoles = map[string]bool{
-	"guide":        true,
-	"scanner":      true,
-	"supervisor":   true,
-	"quality":      true,
+	"guide":         true,
+	"scanner":       true,
+	"supervisor":    true,
+	"quality":       true,
 	"ci-maintainer": true,
-	"sec-check":    true,
-	"architect":    true,
-	"strategist":   true,
-	"outreach":     true,
-	"brainstorm":   true,
-	"worker":       true,
+	"sec-check":     true,
+	"architect":     true,
+	"strategist":    true,
+	"outreach":      true,
+	"brainstorm":    true,
+	"worker":        true,
 }
 
 // validBeadRoles is the set of valid bead roles.
@@ -176,6 +178,14 @@ func validateAgentGeneralInput(body map[string]interface{}) error {
 			n := int(f)
 			if n < 0 || n > maxSortOrder {
 				return fmt.Errorf("sortOrder must be between 0 and %d", maxSortOrder)
+			}
+		}
+	}
+	if v, ok := body["replicas"]; ok {
+		if f, ok := v.(float64); ok {
+			n := int(f)
+			if n < 1 || n > config.MaxAgentReplicas {
+				return fmt.Errorf("replicas must be between 1 and %d", config.MaxAgentReplicas)
 			}
 		}
 	}

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -241,6 +241,12 @@ func (g *Governor) UpdateConfig(cfg config.GovernorConfig) {
 	g.cfg = cfg
 }
 
+func (g *Governor) UpdateAgents(agents map[string]config.AgentConfig) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.agents = agents
+}
+
 func (g *Governor) Evaluate(queueIssues, queuePRs, queueHold, slaViolations int) []string {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -418,6 +424,10 @@ func (g *Governor) updateCadences() {
 				continue
 			}
 			entry.Interval = dur
+			if ac, ok := g.agents[agentName]; ok && ac.ReplicaIndex > 1 && ac.ReplicaCount > 1 && g.state.LastKick[agentName].IsZero() {
+				offset := time.Duration(int64(dur) * int64(ac.ReplicaIndex-1) / int64(ac.ReplicaCount))
+				g.state.LastKick[agentName] = g.now().Add(-dur + offset)
+			}
 		}
 		cadences[agentName] = entry
 	}
@@ -428,9 +438,18 @@ func (g *Governor) updateCadences() {
 // resolveCadence returns the configured cadence string for one agent in one
 // mode, falling back to the idle mode's entry when the mode defines none.
 func (g *Governor) resolveCadence(modeName, agentName string) (config.Cadence, bool) {
+	baseName := agentName
+	if ac, ok := g.agents[agentName]; ok && ac.ReplicaOf != "" {
+		baseName = ac.ReplicaOf
+	}
 	if mode, ok := g.cfg.Modes[modeName]; ok {
 		if c, ok := mode.Cadences[agentName]; ok {
 			return c, true
+		}
+		if baseName != agentName {
+			if c, ok := mode.Cadences[baseName]; ok {
+				return c, true
+			}
 		}
 	}
 	if modeName == idleModeKey {
@@ -439,6 +458,11 @@ func (g *Governor) resolveCadence(modeName, agentName string) (config.Cadence, b
 	if mode, ok := g.cfg.Modes[idleModeKey]; ok {
 		if c, ok := mode.Cadences[agentName]; ok {
 			return c, true
+		}
+		if baseName != agentName {
+			if c, ok := mode.Cadences[baseName]; ok {
+				return c, true
+			}
 		}
 	}
 	return "", false

--- a/v2/pkg/governor/governor_replicas_test.go
+++ b/v2/pkg/governor/governor_replicas_test.go
@@ -1,0 +1,31 @@
+package governor
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+func TestReplicaCadenceFallsBackToBaseAndStaggers(t *testing.T) {
+	agents := map[string]config.AgentConfig{
+		"scanner":   {Enabled: true, ReplicaIndex: 1, ReplicaCount: 2},
+		"scanner-2": {Enabled: true, ReplicaOf: "scanner", ReplicaIndex: 2, ReplicaCount: 2},
+	}
+	g := New(config.GovernorConfig{Modes: map[string]config.ModeConfig{
+		"idle": {Cadences: map[string]config.Cadence{"scanner": "10m"}},
+	}}, agents, slog.Default())
+	now := time.Date(2026, 8, 8, 9, 0, 0, 0, time.UTC)
+	g.now = func() time.Time { return now }
+	due := g.Evaluate(0, 0, 0, 0)
+	if len(due) != 1 || due[0] != "scanner" {
+		t.Fatalf("initial due = %v, want only scanner", due)
+	}
+	g.RecordKick("scanner")
+	now = now.Add(5 * time.Minute)
+	due = g.Evaluate(0, 0, 0, 0)
+	if len(due) != 1 || due[0] != "scanner-2" {
+		t.Fatalf("staggered due = %v, want only scanner-2", due)
+	}
+}

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -154,16 +154,17 @@ func (s *Scheduler) loadNamedTemplate(templateName string) string {
 
 // substituteTemplate replaces ${VAR} placeholders in a prompt template.
 func (s *Scheduler) substituteTemplate(template string, actionable *github.ActionableResult, agentName string, issues []github.Issue) string {
+	baseName := s.cfg.BaseAgentName(agentName)
 	if actionable == nil {
 		actionable = &github.ActionableResult{}
 	}
 	now := time.Now().Local()
 
 	var agentIssuesForList []github.Issue
-	if agentName == "scanner" {
+	if baseName == "scanner" {
 		agentIssuesForList = issues
 	} else {
-		agentIssuesForList = filterByLane(issues, agentName)
+		agentIssuesForList = filterByLane(issues, baseName)
 	}
 	issueList := s.formatIssueList(agentIssuesForList)
 	prList := s.formatPRList(actionable)
@@ -179,7 +180,7 @@ func (s *Scheduler) substituteTemplate(template string, actionable *github.Actio
 		displayName = ac.DisplayName
 	}
 
-	agentIssues := filterByLane(issues, agentName)
+	agentIssues := filterByLane(issues, baseName)
 	if len(agentIssues) == 0 && actionable != nil && len(actionable.Issues.Items) > 0 {
 		agentIssues = actionable.Issues.Items
 	}
@@ -316,7 +317,9 @@ func (s *Scheduler) BuildKickMessages(actionable *github.ActionableResult, agent
 			includeRepos := true
 			if agentCfg, ok := s.cfg.Agents[agentName]; ok {
 				includeRepos = agentCfg.ShouldIncludeRepos()
-			} else if agentName == "outreach" {
+			} else if agentCfg, ok := s.cfg.Agents[s.cfg.BaseAgentName(agentName)]; ok {
+				includeRepos = agentCfg.ShouldIncludeRepos()
+			} else if s.cfg.BaseAgentName(agentName) == "outreach" {
 				includeRepos = false
 			}
 			if includeRepos {
@@ -371,11 +374,12 @@ const maxIssuesPerKick = 100
 // BuildAgentMessage constructs a kick prompt for the named agent using the
 // template resolution chain (config kick_template → convention → embedded → hardcoded).
 func (s *Scheduler) BuildAgentMessage(agentName string, issues []github.Issue, actionable *github.ActionableResult) string {
+	baseName := s.cfg.BaseAgentName(agentName)
 	// 0. GitHub-sourced prompt: if the agent declares a prompt_source, resolve it
 	//    live at kick time (with allowlist gating + graceful fallback). A miss
 	//    (unset, denied, unreachable with no cache) falls through to the inline
 	//    template chain below, so a bad source never blanks or crashes a kick.
-	if agentCfg, ok := s.cfg.Agents[agentName]; ok && agentCfg.PromptSource.IsSet() {
+	if agentCfg, ok := s.cfg.Agents[baseName]; ok && agentCfg.PromptSource.IsSet() {
 		if resolver := s.gitHubPromptResolver(); resolver != nil {
 			src := promptsrc.Source{
 				Owner: agentCfg.PromptSource.Owner,
@@ -393,7 +397,7 @@ func (s *Scheduler) BuildAgentMessage(agentName string, issues []github.Issue, a
 	}
 
 	// 1. Config-driven: use kick_template field if set
-	if agentCfg, ok := s.cfg.Agents[agentName]; ok && agentCfg.KickTemplate != "" {
+	if agentCfg, ok := s.cfg.Agents[baseName]; ok && agentCfg.KickTemplate != "" {
 		if template := s.loadNamedTemplate(agentCfg.KickTemplate); template != "" {
 			s.logger.Info("using config kick_template", "agent", agentName, "template", agentCfg.KickTemplate)
 			msg := fmt.Sprintf("[agent:%s]\n\n", agentName)
@@ -406,7 +410,7 @@ func (s *Scheduler) BuildAgentMessage(agentName string, issues []github.Issue, a
 	if s.cfg.ACMMLevel != nil && *s.cfg.ACMMLevel > 0 {
 		if pack, err := config.ACMMPackByLevel(*s.cfg.ACMMLevel); err == nil {
 			for _, pa := range pack.Agents {
-				if pa.Name == agentName && pa.KickTemplate != "" {
+				if pa.Name == baseName && pa.KickTemplate != "" {
 					if template := s.loadNamedTemplate(pa.KickTemplate); template != "" {
 						s.logger.Info("using ACMM pack template", "agent", agentName, "level", *s.cfg.ACMMLevel, "template", pa.KickTemplate)
 						msg := fmt.Sprintf("[agent:%s]\n\n", agentName)
@@ -419,7 +423,7 @@ func (s *Scheduler) BuildAgentMessage(agentName string, issues []github.Issue, a
 	}
 
 	// 3. Convention: look for <agent>.md template file
-	if template := s.loadPromptTemplate(agentName); template != "" {
+	if template := s.loadPromptTemplate(baseName); template != "" {
 		s.logger.Info("using prompt template for kick", "agent", agentName)
 		msg := fmt.Sprintf("[agent:%s]\n\n", agentName)
 		msg += s.substituteTemplate(template, actionable, agentName, issues)
@@ -428,7 +432,7 @@ func (s *Scheduler) BuildAgentMessage(agentName string, issues []github.Issue, a
 
 	// 3. Legacy hardcoded fallback (removed in Phase 4 when all agents use templates)
 	s.logger.Info("no prompt template found, using hardcoded kick", "agent", agentName)
-	switch agentName {
+	switch baseName {
 	case "scanner":
 		return s.buildScannerMessage(issues, actionable)
 	case "ci-maintainer":
@@ -663,10 +667,11 @@ func (s *Scheduler) reposSection() string {
 }
 
 func (s *Scheduler) buildGenericMessage(agentName string, issues []github.Issue, actionable *github.ActionableResult) string {
+	baseName := s.cfg.BaseAgentName(agentName)
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("[agent:%s]\n", agentName))
 
-	agentIssues := filterByLane(issues, agentName)
+	agentIssues := filterByLane(issues, baseName)
 	if len(agentIssues) > 0 {
 		b.WriteString(fmt.Sprintf("Work items (%d):\n", len(agentIssues)))
 		for _, issue := range agentIssues {


### PR DESCRIPTION
Third sync round: picks up #2898 (replicated agent instances) and #2888 (clanker agent roles). Clean merge, no conflicts. Validated: go build ./..., agent + dashboard + hub tests green.