### PR TITLE
🔀 sync: v2 into dd (final top-up)

### DIFF
--- a/v2/deploy/k8s/dashboard-route-rbac.yaml
+++ b/v2/deploy/k8s/dashboard-route-rbac.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hive
+  namespace: hive
+  labels:
+    app.kubernetes.io/name: hive
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: hive-dashboard-route-reader
+  namespace: hive
+  labels:
+    app.kubernetes.io/name: hive
+rules:
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["list"]
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes"]
+    verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hive-dashboard-route-reader
+  namespace: hive
+  labels:
+    app.kubernetes.io/name: hive
+subjects:
+  - kind: ServiceAccount
+    name: hive
+    namespace: hive
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: hive-dashboard-route-reader

--- a/v2/deploy/k8s/deployment.yaml
+++ b/v2/deploy/k8s/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/name: hive
         app.kubernetes.io/component: controller
     spec:
+      serviceAccountName: hive
       containers:
         - name: hive
           image: hive:latest

--- a/v2/deploy/k8s/kustomization.yaml
+++ b/v2/deploy/k8s/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - configmap.yaml
   - secret.yaml
   - pvc.yaml
+  - dashboard-route-rbac.yaml
   - deployment.yaml
   - service.yaml
 

--- a/v2/pkg/hub/auth_audit.go
+++ b/v2/pkg/hub/auth_audit.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-// Auth audit: the hub periodically probes every registered spoke's
+// Auth audit: the hub periodically probes hub-fronted spokes'
 // UNAUTHENTICATED /api/status and flags any hive that answers 200 as WIDE OPEN.
 // A protected spoke redirects to login (30x) or returns 401 for an
 // unauthenticated request; a 200 means the dashboard is served to anyone with
@@ -93,6 +93,9 @@ func (s *HubServer) runAuthAudit(ctx context.Context, client *http.Client) {
 		// Only probe hives that report a real dashboard URL (heartbeating spokes).
 		base := strings.TrimRight(h.DashboardURL, "/")
 		if base == "" || strings.Contains(base, "localhost") {
+			continue
+		}
+		if !s.hubFrontedDashboardURL(base) {
 			continue
 		}
 		probed++

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -3,6 +3,8 @@ package hub
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"io"
@@ -11,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime/debug"
 	"strings"
@@ -415,14 +418,19 @@ type HeartbeatPayload struct {
 	// OKE hub. Nil means an older spoke did not report the signal, so the hub
 	// treats it as UNKNOWN rather than a failure.
 	PublicURLSelfCheck *PublicURLSelfCheck `json:"public_url_self_check,omitempty"`
-	SnapshotURL        string              `json:"snapshot_url"`
-	Owner              string              `json:"owner,omitempty"`
-	HiveType           string              `json:"hive_type,omitempty"`
-	ClusterID          string              `json:"cluster_id,omitempty"`
-	IsPublic           bool                `json:"is_public"`
-	Version            string              `json:"version"`
-	GitHash            string              `json:"git_hash"`
-	GitBranch          string              `json:"git_branch,omitempty"`
+	// RouteExists is the spoke's in-cluster confirmation that an Ingress or
+	// OpenShift Route exists for DashboardURL's host in the spoke namespace.
+	// Missing is actionable; unknown (old spoke, no RBAC, no in-cluster API) is
+	// intentionally not.
+	RouteExists *RouteExistenceCheck `json:"route_exists,omitempty"`
+	SnapshotURL string               `json:"snapshot_url"`
+	Owner       string               `json:"owner,omitempty"`
+	HiveType    string               `json:"hive_type,omitempty"`
+	ClusterID   string               `json:"cluster_id,omitempty"`
+	IsPublic    bool                 `json:"is_public"`
+	Version     string               `json:"version"`
+	GitHash     string               `json:"git_hash"`
+	GitBranch   string               `json:"git_branch,omitempty"`
 	// ImageRef is the container image this spoke's own Deployment runs, read
 	// in-cluster from the Deployment spec. GitHash says which commit the
 	// BINARY was built from; ImageRef says which TAG the deployment tracks —
@@ -598,16 +606,32 @@ const (
 	PublicURLSelfCheckUnknown = "unknown"
 
 	publicURLSelfCheckMinConsecutiveFailures = 3
+
+	RouteExistenceFound   = "found"
+	RouteExistenceMissing = "missing"
+	RouteExistenceUnknown = "unknown"
 )
 
-// PublicURLSelfCheck reports the spoke's own view of whether its public
-// dashboard URL is reachable. CheckedAt is RFC3339 UTC. HTTPStatus is set only
+// PublicURLSelfCheck reports the spoke's own view of whether its dashboard
+// listener is serving locally. CheckedAt is RFC3339 UTC. HTTPStatus is set only
 // when an HTTP response arrived; Error is a terse operator-safe cause on fail.
 type PublicURLSelfCheck struct {
 	Status     string `json:"status"`
 	CheckedAt  string `json:"checked_at,omitempty"`
 	Error      string `json:"error,omitempty"`
 	HTTPStatus int    `json:"http_status,omitempty"`
+}
+
+// RouteExistenceCheck reports whether the spoke can confirm that its namespace
+// contains an Ingress or OpenShift Route for the advertised dashboard host.
+// Unknown is deliberately non-fatal: missing RBAC, local development, or an API
+// transport error must never page as a missing route.
+type RouteExistenceCheck struct {
+	Status    string `json:"status"`
+	CheckedAt string `json:"checked_at,omitempty"`
+	Host      string `json:"host,omitempty"`
+	Kind      string `json:"kind,omitempty"`
+	Error     string `json:"error,omitempty"`
 }
 
 type StatusCollector func() *HeartbeatPayload
@@ -749,6 +773,7 @@ var (
 var (
 	publicURLSelfProbeInterval = 5 * time.Minute
 	publicURLSelfProbeTimeout  = 8 * time.Second
+	publicURLSelfProbePort     = 3002
 	publicURLSelfProbeClient   = &http.Client{
 		Timeout: publicURLSelfProbeTimeout,
 		CheckRedirect: func(*http.Request, []*http.Request) error {
@@ -762,6 +787,14 @@ var (
 		result              *PublicURLSelfCheck
 		stable              *PublicURLSelfCheck
 		consecutiveFailures int
+	}{}
+	routeExistenceProbeInterval = 5 * time.Minute
+	routeExistenceProbeTimeout  = 8 * time.Second
+	routeExistenceProbeCache    = struct {
+		sync.Mutex
+		host      string
+		nextProbe time.Time
+		result    *RouteExistenceCheck
 	}{}
 )
 
@@ -813,6 +846,7 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 	}
 	payload.Timestamp = time.Now().UTC().Format(time.RFC3339)
 	payload.PublicURLSelfCheck = publicURLSelfCheckFor(ctx, payload.DashboardURL, logger)
+	payload.RouteExists = routeExistenceCheckFor(ctx, payload.DashboardURL, logger)
 
 	filtered := payload.Leaderboard[:0]
 	for _, lb := range payload.Leaderboard {
@@ -955,10 +989,21 @@ func publicURLSelfProbe(ctx context.Context, rawURL string, client *http.Client)
 	}
 	reqCtx, cancel := context.WithTimeout(ctx, publicURLSelfProbeTimeout)
 	defer cancel()
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, rawURL, nil)
+	path := u.EscapedPath()
+	if path == "" {
+		path = "/"
+	}
+	if u.RawQuery != "" {
+		path += "?" + u.RawQuery
+	}
+	localURL := "http://127.0.0.1:" + itoa(publicURLSelfProbePort) + path
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, localURL, nil)
 	if err != nil {
 		return PublicURLSelfCheck{Status: PublicURLSelfCheckFail, CheckedAt: checkedAt, Error: "invalid dashboard URL"}
 	}
+	// Keep the public Host header while dialing the loopback listener so
+	// virtual-host routing is still exercised without depending on DNS.
+	req.Host = u.Host
 	resp, err := client.Do(req)
 	if err != nil {
 		return PublicURLSelfCheck{Status: publicURLSelfCheckStatusForError(err), CheckedAt: checkedAt, Error: terseProbeError(err)}
@@ -968,6 +1013,199 @@ func publicURLSelfProbe(ctx context.Context, rawURL string, client *http.Client)
 		return PublicURLSelfCheck{Status: PublicURLSelfCheckOK, CheckedAt: checkedAt, HTTPStatus: resp.StatusCode}
 	}
 	return PublicURLSelfCheck{Status: PublicURLSelfCheckFail, CheckedAt: checkedAt, HTTPStatus: resp.StatusCode, Error: "HTTP " + itoa(resp.StatusCode)}
+}
+
+func routeExistenceCheckFor(ctx context.Context, rawURL string, logger *slog.Logger) *RouteExistenceCheck {
+	host := dashboardHost(rawURL)
+	if host == "" {
+		return nil
+	}
+	now := time.Now()
+	routeExistenceProbeCache.Lock()
+	defer routeExistenceProbeCache.Unlock()
+	if routeExistenceProbeCache.host == host && routeExistenceProbeCache.result != nil && now.Before(routeExistenceProbeCache.nextProbe) {
+		return cloneRouteExistenceCheck(routeExistenceProbeCache.result)
+	}
+	result := routeExistenceProbe(ctx, host)
+	if result.Status == RouteExistenceMissing && logger != nil {
+		logger.Debug("dashboard route/ingress not found", "host", host)
+	} else if result.Status == RouteExistenceUnknown && logger != nil && result.Error != "" {
+		logger.Debug("dashboard route/ingress existence unknown", "host", host, "error", result.Error)
+	}
+	routeExistenceProbeCache.host = host
+	routeExistenceProbeCache.nextProbe = now.Add(routeExistenceProbeInterval)
+	routeExistenceProbeCache.result = &result
+	return cloneRouteExistenceCheck(&result)
+}
+
+func dashboardHost(rawURL string) string {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	return strings.ToLower(u.Hostname())
+}
+
+func cloneRouteExistenceCheck(in *RouteExistenceCheck) *RouteExistenceCheck {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
+var (
+	serviceAccountDir = "/var/run/secrets/kubernetes.io/serviceaccount"
+	kubernetesAPIHost = func() string { return os.Getenv("KUBERNETES_SERVICE_HOST") }
+	kubernetesAPIPort = func() string { return os.Getenv("KUBERNETES_SERVICE_PORT") }
+)
+
+func routeExistenceProbe(ctx context.Context, host string) RouteExistenceCheck {
+	checkedAt := time.Now().UTC().Format(time.RFC3339)
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return RouteExistenceCheck{Status: RouteExistenceUnknown, CheckedAt: checkedAt, Error: "empty dashboard host"}
+	}
+	cfg, err := inClusterAPIConfig()
+	if err != nil {
+		return RouteExistenceCheck{Status: RouteExistenceUnknown, CheckedAt: checkedAt, Host: host, Error: err.Error()}
+	}
+	client, err := inClusterHTTPClient(cfg)
+	if err != nil {
+		return RouteExistenceCheck{Status: RouteExistenceUnknown, CheckedAt: checkedAt, Host: host, Error: err.Error()}
+	}
+	ingFound, ingUnknown, ingErr := ingressHostExists(ctx, client, cfg, host)
+	if ingFound {
+		return RouteExistenceCheck{Status: RouteExistenceFound, CheckedAt: checkedAt, Host: host, Kind: "Ingress"}
+	}
+	routeFound, routeUnknown, routeErr := routeHostExists(ctx, client, cfg, host)
+	if routeFound {
+		return RouteExistenceCheck{Status: RouteExistenceFound, CheckedAt: checkedAt, Host: host, Kind: "Route"}
+	}
+	if ingUnknown || routeUnknown {
+		if ingErr != "" {
+			return RouteExistenceCheck{Status: RouteExistenceUnknown, CheckedAt: checkedAt, Host: host, Error: ingErr}
+		}
+		return RouteExistenceCheck{Status: RouteExistenceUnknown, CheckedAt: checkedAt, Host: host, Error: routeErr}
+	}
+	return RouteExistenceCheck{Status: RouteExistenceMissing, CheckedAt: checkedAt, Host: host, Error: "no Ingress or Route for host"}
+}
+
+type inClusterConfig struct {
+	BaseURL   string
+	Token     string
+	Namespace string
+	CAPath    string
+}
+
+func inClusterAPIConfig() (*inClusterConfig, error) {
+	host, port := strings.TrimSpace(kubernetesAPIHost()), strings.TrimSpace(kubernetesAPIPort())
+	if host == "" || port == "" {
+		return nil, errors.New("not running in a Kubernetes cluster")
+	}
+	tokenBytes, err := os.ReadFile(filepath.Join(serviceAccountDir, "token"))
+	if err != nil {
+		return nil, errors.New("serviceaccount token unavailable")
+	}
+	nsBytes, err := os.ReadFile(filepath.Join(serviceAccountDir, "namespace"))
+	if err != nil {
+		return nil, errors.New("serviceaccount namespace unavailable")
+	}
+	return &inClusterConfig{
+		BaseURL:   "https://" + host + ":" + port,
+		Token:     strings.TrimSpace(string(tokenBytes)),
+		Namespace: strings.TrimSpace(string(nsBytes)),
+		CAPath:    filepath.Join(serviceAccountDir, "ca.crt"),
+	}, nil
+}
+
+func inClusterHTTPClient(cfg *inClusterConfig) (*http.Client, error) {
+	roots, err := x509.SystemCertPool()
+	if err != nil || roots == nil {
+		roots = x509.NewCertPool()
+	}
+	if ca, err := os.ReadFile(cfg.CAPath); err == nil {
+		roots.AppendCertsFromPEM(ca)
+	}
+	return &http.Client{
+		Timeout: routeExistenceProbeTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12},
+		},
+	}, nil
+}
+
+func ingressHostExists(ctx context.Context, client *http.Client, cfg *inClusterConfig, host string) (found, unknown bool, errText string) {
+	var list struct {
+		Items []struct {
+			Spec struct {
+				Rules []struct {
+					Host string `json:"host"`
+				} `json:"rules"`
+			} `json:"spec"`
+		} `json:"items"`
+	}
+	unknown, errText = listKubernetesResource(ctx, client, cfg, "/apis/networking.k8s.io/v1/namespaces/"+url.PathEscape(cfg.Namespace)+"/ingresses", &list)
+	if unknown {
+		return false, true, errText
+	}
+	for _, item := range list.Items {
+		for _, rule := range item.Spec.Rules {
+			if strings.EqualFold(strings.TrimSpace(rule.Host), host) {
+				return true, false, ""
+			}
+		}
+	}
+	return false, false, ""
+}
+
+func routeHostExists(ctx context.Context, client *http.Client, cfg *inClusterConfig, host string) (found, unknown bool, errText string) {
+	var list struct {
+		Items []struct {
+			Spec struct {
+				Host string `json:"host"`
+			} `json:"spec"`
+		} `json:"items"`
+	}
+	unknown, errText = listKubernetesResource(ctx, client, cfg, "/apis/route.openshift.io/v1/namespaces/"+url.PathEscape(cfg.Namespace)+"/routes", &list)
+	if unknown {
+		return false, true, errText
+	}
+	for _, item := range list.Items {
+		if strings.EqualFold(strings.TrimSpace(item.Spec.Host), host) {
+			return true, false, ""
+		}
+	}
+	return false, false, ""
+}
+
+func listKubernetesResource(ctx context.Context, client *http.Client, cfg *inClusterConfig, path string, out any) (unknown bool, errText string) {
+	reqCtx, cancel := context.WithTimeout(ctx, routeExistenceProbeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, cfg.BaseURL+path, nil)
+	if err != nil {
+		return true, "invalid Kubernetes API request"
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return true, terseProbeError(err)
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		return false, ""
+	case http.StatusForbidden, http.StatusUnauthorized:
+		return true, "Kubernetes RBAC does not allow listing dashboard routes"
+	default:
+		return true, "Kubernetes API returned HTTP " + itoa(resp.StatusCode)
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxPayloadBytes)).Decode(out); err != nil {
+		return true, "could not decode Kubernetes API response"
+	}
+	return false, ""
 }
 
 func publicURLSelfCheckStatusForError(err error) string {

--- a/v2/pkg/hub/heartbeat_handler_coverage_test.go
+++ b/v2/pkg/hub/heartbeat_handler_coverage_test.go
@@ -161,7 +161,8 @@ func TestHandleHeartbeatPublicURLSelfCheckRoundTripAndOldSpokeCompatibility(t *t
 		"primary_repo":"repo",
 		"repos":["repo"],
 		"dashboard_url":"https://selfcheck.hive.kubestellar.io",
-		"public_url_self_check":{"status":"ok","checked_at":"2026-08-08T10:15:00Z","http_status":401}
+		"public_url_self_check":{"status":"ok","checked_at":"2026-08-08T10:15:00Z","http_status":401},
+		"route_exists":{"status":"found","checked_at":"2026-08-08T10:15:00Z","host":"selfcheck.hive.kubestellar.io","kind":"Ingress"}
 	}`
 	rec := postHeartbeat(t, s, body)
 	if rec.Code != http.StatusOK {
@@ -172,6 +173,9 @@ func TestHandleHeartbeatPublicURLSelfCheckRoundTripAndOldSpokeCompatibility(t *t
 	}
 	if got := s.registry.Hives[0].PublicURLSelfCheck; got.Status != PublicURLSelfCheckOK || got.HTTPStatus != http.StatusUnauthorized {
 		t.Fatalf("self-check = %+v, want ok/401", got)
+	}
+	if got := s.registry.Hives[0].RouteExists; got == nil || got.Status != RouteExistenceFound || got.Kind != "Ingress" {
+		t.Fatalf("route_exists = %+v, want found Ingress", got)
 	}
 
 	// Older spokes omit the new field. The heartbeat must still be accepted and
@@ -198,6 +202,9 @@ func TestHandleHeartbeatPublicURLSelfCheckRoundTripAndOldSpokeCompatibility(t *t
 	}
 	if old.PublicURLSelfCheck != nil {
 		t.Fatalf("old spoke should leave self-check unknown, got %+v", old.PublicURLSelfCheck)
+	}
+	if old.RouteExists != nil {
+		t.Fatalf("old spoke should leave route_exists unknown, got %+v", old.RouteExists)
 	}
 }
 

--- a/v2/pkg/hub/public_url_selfcheck_coverage_test.go
+++ b/v2/pkg/hub/public_url_selfcheck_coverage_test.go
@@ -2,8 +2,11 @@ package hub
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -19,19 +22,38 @@ func TestPublicURLSelfCheckCacheCloneAndErrors(t *testing.T) {
 	calls := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls++
+		if r.Host != "cached.example.com" {
+			t.Errorf("Host = %q, want public host", r.Host)
+		}
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer srv.Close()
 	oldClient := publicURLSelfProbeClient
+	oldPort := publicURLSelfProbePort
 	publicURLSelfProbeClient = srv.Client()
-	t.Cleanup(func() { publicURLSelfProbeClient = oldClient })
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, port, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicURLSelfProbePort, err = strconv.Atoi(port)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		publicURLSelfProbeClient = oldClient
+		publicURLSelfProbePort = oldPort
+	})
 
-	first := publicURLSelfCheckFor(context.Background(), "  "+srv.URL+"  ", nil)
+	first := publicURLSelfCheckFor(context.Background(), "  https://cached.example.com  ", nil)
 	if first == nil || first.Status != PublicURLSelfCheckOK || first.HTTPStatus != http.StatusUnauthorized {
 		t.Fatalf("first self-check = %+v", first)
 	}
 	first.Status = "mutated"
-	second := publicURLSelfCheckFor(context.Background(), srv.URL, nil)
+	second := publicURLSelfCheckFor(context.Background(), "https://cached.example.com", nil)
 	if second.Status != PublicURLSelfCheckOK || calls != 1 {
 		t.Fatalf("cached clone not used: second=%+v calls=%d", second, calls)
 	}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -143,18 +143,22 @@ type RegistryEntry struct {
 	// private-network hives may be unreachable from the public hub while alive
 	// from their own cluster. Nil means an old spoke did not report it.
 	PublicURLSelfCheck *PublicURLSelfCheck `json:"publicUrlSelfCheck,omitempty"`
-	SnapshotURL        string              `json:"snapshotUrl,omitempty"`
-	ACMMLevel          int                 `json:"acmmLevel"`
-	AgentCount         int                 `json:"agentCount"`
-	GovernorMode       string              `json:"governorMode"`
-	TotalTokens24h     int64               `json:"totalTokens24h"`
-	ActionableIssues   int                 `json:"actionableIssues"`
-	ActionablePRs      int                 `json:"actionablePRs"`
-	ContributorCount   int                 `json:"contributorCount"`
-	ActiveContributors int                 `json:"activeContributors"`
-	Owner              string              `json:"owner,omitempty"`
-	ClusterID          string              `json:"clusterId,omitempty"`
-	ClusterName        string              `json:"clusterName,omitempty"`
+	// RouteExists is the spoke's in-cluster confirmation that an Ingress or
+	// OpenShift Route exists for DashboardURL's host. Nil means an old spoke
+	// did not report it; unknown means it could not verify (for example RBAC).
+	RouteExists        *RouteExistenceCheck `json:"routeExists,omitempty"`
+	SnapshotURL        string               `json:"snapshotUrl,omitempty"`
+	ACMMLevel          int                  `json:"acmmLevel"`
+	AgentCount         int                  `json:"agentCount"`
+	GovernorMode       string               `json:"governorMode"`
+	TotalTokens24h     int64                `json:"totalTokens24h"`
+	ActionableIssues   int                  `json:"actionableIssues"`
+	ActionablePRs      int                  `json:"actionablePRs"`
+	ContributorCount   int                  `json:"contributorCount"`
+	ActiveContributors int                  `json:"activeContributors"`
+	Owner              string               `json:"owner,omitempty"`
+	ClusterID          string               `json:"clusterId,omitempty"`
+	ClusterName        string               `json:"clusterName,omitempty"`
 	// Namespace is the Kubernetes namespace this hive's spoke runs in. For a
 	// hub-provisioned (hosted) hive it is hostedNamespaceForHive(sh) —
 	// "hive-hosted-<id>" — overlaid from the authoritative SaaSHive record on
@@ -1279,6 +1283,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		InferenceAuthError: sanitizeField(payload.InferenceAuthError),
 		DashboardURL:       payload.DashboardURL,
 		PublicURLSelfCheck: sanitizePublicURLSelfCheck(payload.PublicURLSelfCheck),
+		RouteExists:        sanitizeRouteExistenceCheck(payload.RouteExists),
 		SnapshotURL:        payload.SnapshotURL,
 		ACMMLevel:          clampInt(payload.ACMMLevel, 0, 6),
 		AgentCount: func() int {
@@ -3250,6 +3255,23 @@ func sanitizePublicURLSelfCheck(in *PublicURLSelfCheck) *PublicURLSelfCheck {
 		HTTPStatus: clampInt(in.HTTPStatus, 0, 599),
 	}
 	return out
+}
+
+func sanitizeRouteExistenceCheck(in *RouteExistenceCheck) *RouteExistenceCheck {
+	if in == nil {
+		return nil
+	}
+	status := sanitizeHeartbeatField(in.Status)
+	if status != RouteExistenceFound && status != RouteExistenceMissing && status != RouteExistenceUnknown {
+		return nil
+	}
+	return &RouteExistenceCheck{
+		Status:    status,
+		CheckedAt: sanitizeHeartbeatField(in.CheckedAt),
+		Host:      sanitizeHeartbeatField(in.Host),
+		Kind:      sanitizeHeartbeatField(in.Kind),
+		Error:     sanitizeProseField(in.Error),
+	}
 }
 
 // sanitizeImageRef sanitizes a container image reference reported by a spoke.

--- a/v2/pkg/hub/url_reachability.go
+++ b/v2/pkg/hub/url_reachability.go
@@ -2,6 +2,9 @@ package hub
 
 import (
 	"net/http"
+	"net/url"
+	"os"
+	"strings"
 	"sync"
 	"time"
 )
@@ -198,16 +201,57 @@ func clusterOutage(failed, probed int) bool {
 	return float64(failed)/float64(probed) >= urlClusterOutageRatio
 }
 
+func (s *HubServer) hubFrontedDashboardURL(rawURL string) bool {
+	host := dashboardHost(rawURL)
+	if host == "" {
+		return false
+	}
+	suffix := s.hubDomainSuffix()
+	if suffix == "" {
+		return false
+	}
+	host = strings.TrimSuffix(strings.ToLower(host), ".")
+	suffix = strings.TrimPrefix(strings.TrimSuffix(strings.ToLower(suffix), "."), ".")
+	return host == suffix || strings.HasSuffix(host, "."+suffix)
+}
+
+func (s *HubServer) hubDomainSuffix() string {
+	for _, key := range []string{"HIVE_HUB_PUBLIC_URL", "HIVE_PUBLIC_URL", "HIVE_HUB_BASE_URL", "HIVE_DASHBOARD_URL", "HIVE_HUB_URL"} {
+		if suffix := domainSuffixFromBaseURL(os.Getenv(key)); suffix != "" {
+			return suffix
+		}
+	}
+	if s != nil {
+		if c, ok := s.clusters[defaultClusterID]; ok && c.Domain != "" {
+			return c.Domain
+		}
+	}
+	return ""
+}
+
+func domainSuffixFromBaseURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Hostname() == "" {
+		return ""
+	}
+	return strings.ToLower(u.Hostname())
+}
+
 // urlUnreachableAlerts builds the per-hive unreachable-URL alerts for the
 // current fleet. It is fed into evaluateAlerts' driftAlerts parameter, the
 // pre-existing seam for signals computed outside the evaluator, so this shares
 // all of the ack/dedup/first-seen machinery rather than adding a parallel one.
 //
-// A hive is critical when its spoke self-check fails, or when the hub-side
-// probe has failed repeatedly while the spoke heartbeat is stale/offline. If
-// the hub-side probe fails while heartbeats are fresh and the spoke self-check
-// is OK or unknown, the result is only informational: the URL is private from
-// the hub's vantage point, not proved dead.
+// A hive is critical when its local listener self-check fails, when the spoke
+// confirms no route/ingress exists, or when a hub-fronted URL fails from the
+// hub while the spoke heartbeat is stale/offline. If a hub-fronted probe fails
+// while heartbeats are fresh and the spoke self-check is OK or unknown, the
+// result is only informational: the URL is private from the hub's vantage
+// point, not proved dead.
 func (s *HubServer) urlUnreachableAlerts(hives []RegistryEntry, now time.Time) []Alert {
 	// A HubServer built directly by a test has no urlHealth; no probe has run,
 	// so only spoke self-check failures can be reported.
@@ -225,7 +269,7 @@ func (s *HubServer) urlUnreachableAlerts(hives []RegistryEntry, now time.Time) [
 	clusterProbed := map[string]int{}
 	clusterFailed := map[string]int{}
 	for _, h := range hives {
-		if h.DashboardURL == "" || isUnassignedPlaceholder(h.Org, h.ProvStatus) {
+		if h.DashboardURL == "" || isUnassignedPlaceholder(h.Org, h.ProvStatus) || (s != nil && !s.hubFrontedDashboardURL(h.DashboardURL)) {
 			continue
 		}
 		clusterProbed[h.ClusterID]++
@@ -253,6 +297,25 @@ func (s *HubServer) urlUnreachableAlerts(hives []RegistryEntry, now time.Time) [
 				Severity: AlertSeverityCritical,
 				Reason:   publicURLSelfCheckFailureReason(h),
 			})
+			continue
+		}
+		if routeExistenceMissing(h.RouteExists) {
+			if s.urlHealth != nil && s.urlHealth.criticalEvaluation(h.ID, true) < urlUnreachableMinAlertEvaluations {
+				continue
+			}
+			alerts = append(alerts, Alert{
+				HiveID:   h.ID,
+				HiveName: h.Name,
+				Type:     AlertTypeURLUnreachable,
+				Severity: AlertSeverityCritical,
+				Reason:   routeExistenceFailureReason(h),
+			})
+			continue
+		}
+		if !s.hubFrontedDashboardURL(h.DashboardURL) {
+			if s.urlHealth != nil {
+				s.urlHealth.criticalEvaluation(h.ID, false)
+			}
 			continue
 		}
 		n := failures[h.ID]
@@ -355,14 +418,18 @@ func publicURLSelfCheckFailed(check *PublicURLSelfCheck) bool {
 	return check != nil && check.Status == PublicURLSelfCheckFail
 }
 
+func routeExistenceMissing(check *RouteExistenceCheck) bool {
+	return check != nil && check.Status == RouteExistenceMissing
+}
+
 func publicURLSelfCheckFailureReason(h RegistryEntry) string {
-	reason := urlUnreachableReason(h.DashboardURL, 0)
+	reason := "dashboard listener failed local self-check for " + h.DashboardURL
 	check := h.PublicURLSelfCheck
 	if check == nil {
 		return reason
 	}
 	if check.HTTPStatus > 0 {
-		reason = urlUnreachableReason(h.DashboardURL, check.HTTPStatus)
+		reason = "dashboard listener returned HTTP " + itoa(check.HTTPStatus) + " for " + h.DashboardURL
 	}
 	if errText := check.Error; errText != "" {
 		reason += " (spoke self-check: " + errText + ")"
@@ -370,6 +437,17 @@ func publicURLSelfCheckFailureReason(h RegistryEntry) string {
 		reason += " (spoke self-check failed)"
 	}
 	return reason
+}
+
+func routeExistenceFailureReason(h RegistryEntry) string {
+	host := dashboardHost(h.DashboardURL)
+	if h.RouteExists != nil && h.RouteExists.Host != "" {
+		host = h.RouteExists.Host
+	}
+	if host == "" {
+		return "dashboard route/ingress does not exist"
+	}
+	return "dashboard route/ingress for " + host + " does not exist"
 }
 
 func heartbeatFreshForURLCheck(h RegistryEntry, now time.Time) bool {

--- a/v2/pkg/hub/url_reachability_test.go
+++ b/v2/pkg/hub/url_reachability_test.go
@@ -2,11 +2,15 @@ package hub
 
 import (
 	"context"
+	"encoding/pem"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -16,6 +20,15 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+func newURLHealthTestHub(domain string) *HubServer {
+	return &HubServer{
+		urlHealth: newURLHealthState(),
+		clusters: map[string]ClusterConfig{
+			defaultClusterID: {ID: defaultClusterID, Domain: domain},
+		},
+	}
 }
 
 // A 503 from a routed hostname with no backend is the exact failure that hid
@@ -49,10 +62,28 @@ func TestPublicURLSelfProbeStatusSemantics(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Host != "vanity.example.com" {
+					t.Errorf("Host = %q, want public host", r.Host)
+				}
 				w.WriteHeader(tc.code)
 			}))
 			defer srv.Close()
-			got := publicURLSelfProbe(context.Background(), srv.URL, srv.Client())
+			u, err := url.Parse(srv.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, port, err := net.SplitHostPort(u.Host)
+			if err != nil {
+				t.Fatal(err)
+			}
+			p, err := strconv.Atoi(port)
+			if err != nil {
+				t.Fatal(err)
+			}
+			oldPort := publicURLSelfProbePort
+			publicURLSelfProbePort = p
+			defer func() { publicURLSelfProbePort = oldPort }()
+			got := publicURLSelfProbe(context.Background(), "https://vanity.example.com", srv.Client())
 			if got.Status != tc.want {
 				t.Fatalf("status = %q, want %q (check=%+v)", got.Status, tc.want, got)
 			}
@@ -249,7 +280,7 @@ func TestURLUnreachableAlerts(t *testing.T) {
 	now := time.Now()
 	oldEnough := now.Add(-urlUnreachableMinAge - time.Hour).Format(time.RFC3339)
 
-	s := &HubServer{urlHealth: newURLHealthState()}
+	s := newURLHealthTestHub("example.com")
 	hives := []RegistryEntry{
 		{ID: "broken", Name: "org/broken", ClusterID: "c1", RegisteredAt: oldEnough, DashboardURL: "https://broken.example.com"},
 		{ID: "fine1", ClusterID: "c1", RegisteredAt: oldEnough, DashboardURL: "https://f1.example.com"},
@@ -275,14 +306,14 @@ func TestURLUnreachableAlerts(t *testing.T) {
 	}
 
 	// A single failure is below the threshold — a blip must never alert.
-	s2 := &HubServer{urlHealth: newURLHealthState()}
+	s2 := newURLHealthTestHub("example.com")
 	s2.urlHealth.observe("broken", urlProbeResult{Status: 503})
 	if got := s2.urlUnreachableAlerts(hives, now); len(got) != 0 {
 		t.Errorf("one failure must not alert, got %+v", got)
 	}
 
 	// Whole cluster down -> suppressed into an outage, zero per-hive alerts.
-	s3 := &HubServer{urlHealth: newURLHealthState()}
+	s3 := newURLHealthTestHub("example.com")
 	for _, h := range hives {
 		for i := 0; i < urlUnreachableMinFailures; i++ {
 			s3.urlHealth.observe(h.ID, urlProbeResult{Status: 0})
@@ -304,34 +335,41 @@ func TestURLReachabilityDecisionMatrix(t *testing.T) {
 		hubFails  bool
 		freshHB   bool
 		self      *PublicURLSelfCheck
+		route     *RouteExistenceCheck
+		dashURL   string
 		wantType  string
 		wantLevel string
 	}{
-		{"hub ok self unknown", false, true, nil, "", ""},
-		{"hub ok self ok", false, true, &PublicURLSelfCheck{Status: PublicURLSelfCheckOK}, "", ""},
-		{"hub ok self fail", false, true, &PublicURLSelfCheck{Status: PublicURLSelfCheckFail, Error: "HTTP 503", HTTPStatus: 503}, AlertTypeURLUnreachable, AlertSeverityCritical},
-		{"hub fail fresh self ok", true, true, &PublicURLSelfCheck{Status: PublicURLSelfCheckOK, HTTPStatus: 401}, AlertTypeURLPrivateNetwork, AlertSeverityInfo},
-		{"hub fail fresh self unknown", true, true, &PublicURLSelfCheck{Status: PublicURLSelfCheckUnknown, Error: "lookup failed"}, AlertTypeURLPrivateNetwork, AlertSeverityInfo},
-		{"hub fail fresh self fail", true, true, &PublicURLSelfCheck{Status: PublicURLSelfCheckFail, Error: "HTTP 503", HTTPStatus: 503}, AlertTypeURLUnreachable, AlertSeverityCritical},
-		{"hub fail stale self unknown", true, false, &PublicURLSelfCheck{Status: PublicURLSelfCheckUnknown, Error: "lookup failed"}, AlertTypeURLUnreachable, AlertSeverityCritical},
-		{"hub fail stale self ok", true, false, &PublicURLSelfCheck{Status: PublicURLSelfCheckOK, HTTPStatus: 401}, AlertTypeURLUnreachable, AlertSeverityCritical},
+		{"hub ok self unknown", false, true, nil, nil, "https://h1.example.com", "", ""},
+		{"hub ok self ok", false, true, &PublicURLSelfCheck{Status: PublicURLSelfCheckOK}, nil, "https://h1.example.com", "", ""},
+		{"hub ok self fail", false, true, &PublicURLSelfCheck{Status: PublicURLSelfCheckFail, Error: "HTTP 503", HTTPStatus: 503}, nil, "https://h1.example.com", AlertTypeURLUnreachable, AlertSeverityCritical},
+		{"route missing", false, true, &PublicURLSelfCheck{Status: PublicURLSelfCheckOK}, &RouteExistenceCheck{Status: RouteExistenceMissing, Host: "h1.example.com"}, "https://h1.example.com", AlertTypeURLUnreachable, AlertSeverityCritical},
+		{"route unknown no regression", false, true, &PublicURLSelfCheck{Status: PublicURLSelfCheckOK}, &RouteExistenceCheck{Status: RouteExistenceUnknown}, "https://h1.example.com", "", ""},
+		{"hub fail fresh self ok", true, true, &PublicURLSelfCheck{Status: PublicURLSelfCheckOK, HTTPStatus: 401}, nil, "https://h1.example.com", AlertTypeURLPrivateNetwork, AlertSeverityInfo},
+		{"hub fail fresh self unknown", true, true, &PublicURLSelfCheck{Status: PublicURLSelfCheckUnknown, Error: "lookup failed"}, nil, "https://h1.example.com", AlertTypeURLPrivateNetwork, AlertSeverityInfo},
+		{"hub fail fresh self fail", true, true, &PublicURLSelfCheck{Status: PublicURLSelfCheckFail, Error: "HTTP 503", HTTPStatus: 503}, nil, "https://h1.example.com", AlertTypeURLUnreachable, AlertSeverityCritical},
+		{"hub fail stale self unknown", true, false, &PublicURLSelfCheck{Status: PublicURLSelfCheckUnknown, Error: "lookup failed"}, nil, "https://h1.example.com", AlertTypeURLUnreachable, AlertSeverityCritical},
+		{"hub fail stale self ok", true, false, &PublicURLSelfCheck{Status: PublicURLSelfCheckOK, HTTPStatus: 401}, nil, "https://h1.example.com", AlertTypeURLUnreachable, AlertSeverityCritical},
+		{"private healthy no chip", true, true, &PublicURLSelfCheck{Status: PublicURLSelfCheckOK}, &RouteExistenceCheck{Status: RouteExistenceFound}, "https://spoke.apps.fmaas.example.net", "", ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			s := &HubServer{urlHealth: newURLHealthState()}
+			s := newURLHealthTestHub("example.com")
 			if tc.hubFails {
 				for i := 0; i < urlUnreachableMinFailures; i++ {
 					s.urlHealth.observe("h1", urlProbeResult{Status: 0})
 				}
 			}
+
 			h := RegistryEntry{
 				ID:                 "h1",
 				Name:               "org/repo",
 				ClusterID:          "c1",
 				RegisteredAt:       oldEnough,
-				DashboardURL:       "https://private.example.com",
+				DashboardURL:       tc.dashURL,
 				LastHeartbeat:      stale,
 				Online:             false,
 				PublicURLSelfCheck: tc.self,
+				RouteExists:        tc.route,
 			}
 			if tc.freshHB {
 				h.LastHeartbeat = fresh
@@ -357,11 +395,177 @@ func TestURLReachabilityDecisionMatrix(t *testing.T) {
 	}
 }
 
+func TestHubProbeDomainSuffixGating(t *testing.T) {
+	s := newURLHealthTestHub("hive.kubestellar.io")
+	if !s.hubFrontedDashboardURL("https://spoke.hive.kubestellar.io") {
+		t.Fatal("hub-fronted subdomain should be probed")
+	}
+	if s.hubFrontedDashboardURL("https://spoke.apps.fmaas-vllm-d.fmaas.res.ibm.com") {
+		t.Fatal("private/firewalled app domain must not be hub-probed")
+	}
+}
+
+func TestRouteExistenceProbeIngressRouteAndRBAC(t *testing.T) {
+	cases := []struct {
+		name        string
+		ingStatus   int
+		ingBody     string
+		routeStatus int
+		routeBody   string
+		want        string
+		wantKind    string
+	}{
+		{
+			name:      "ingress found",
+			ingStatus: http.StatusOK,
+			ingBody:   `{"items":[{"spec":{"rules":[{"host":"spoke.example.com"}]}}]}`,
+			want:      RouteExistenceFound,
+			wantKind:  "Ingress",
+		},
+		{
+			name:        "route found",
+			ingStatus:   http.StatusOK,
+			ingBody:     `{"items":[]}`,
+			routeStatus: http.StatusOK,
+			routeBody:   `{"items":[{"spec":{"host":"spoke.example.com"}}]}`,
+			want:        RouteExistenceFound,
+			wantKind:    "Route",
+		},
+		{
+			name:        "missing",
+			ingStatus:   http.StatusOK,
+			ingBody:     `{"items":[]}`,
+			routeStatus: http.StatusNotFound,
+			want:        RouteExistenceMissing,
+		},
+		{
+			name:      "no rbac unknown",
+			ingStatus: http.StatusForbidden,
+			ingBody:   `{}`,
+			want:      RouteExistenceUnknown,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+					t.Errorf("missing bearer auth")
+				}
+				switch {
+				case strings.Contains(r.URL.Path, "/ingresses"):
+					w.WriteHeader(tc.ingStatus)
+					_, _ = w.Write([]byte(tc.ingBody))
+				case strings.Contains(r.URL.Path, "/routes"):
+					status := tc.routeStatus
+					if status == 0 {
+						status = http.StatusNotFound
+					}
+					w.WriteHeader(status)
+					_, _ = w.Write([]byte(tc.routeBody))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+			dir := t.TempDir()
+			oldDir, oldHost, oldPort := serviceAccountDir, kubernetesAPIHost, kubernetesAPIPort
+			serviceAccountDir = dir
+			u, err := url.Parse(srv.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			host, port, err := net.SplitHostPort(u.Host)
+			if err != nil {
+				t.Fatal(err)
+			}
+			kubernetesAPIHost = func() string { return host }
+			kubernetesAPIPort = func() string { return port }
+			defer func() {
+				serviceAccountDir = oldDir
+				kubernetesAPIHost = oldHost
+				kubernetesAPIPort = oldPort
+			}()
+			if err := os.WriteFile(filepath.Join(dir, "token"), []byte("tok"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "namespace"), []byte("hive"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+			if err := os.WriteFile(filepath.Join(dir, "ca.crt"), certPEM, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			got := routeExistenceProbe(context.Background(), "spoke.example.com")
+			if got.Status != tc.want || got.Kind != tc.wantKind {
+				t.Fatalf("route existence = %+v, want status=%s kind=%s", got, tc.want, tc.wantKind)
+			}
+		})
+	}
+}
+
+func TestRouteExistenceCheckForCachesAndHandlesLocalDev(t *testing.T) {
+	oldDir, oldHost, oldPort := serviceAccountDir, kubernetesAPIHost, kubernetesAPIPort
+	serviceAccountDir = t.TempDir()
+	kubernetesAPIHost = func() string { return "" }
+	kubernetesAPIPort = func() string { return "" }
+	routeExistenceProbeCache.Lock()
+	routeExistenceProbeCache.host = ""
+	routeExistenceProbeCache.result = nil
+	routeExistenceProbeCache.nextProbe = time.Time{}
+	routeExistenceProbeCache.Unlock()
+	defer func() {
+		serviceAccountDir = oldDir
+		kubernetesAPIHost = oldHost
+		kubernetesAPIPort = oldPort
+		routeExistenceProbeCache.Lock()
+		routeExistenceProbeCache.host = ""
+		routeExistenceProbeCache.result = nil
+		routeExistenceProbeCache.nextProbe = time.Time{}
+		routeExistenceProbeCache.Unlock()
+	}()
+
+	if got := routeExistenceCheckFor(context.Background(), "not a url", nil); got != nil {
+		t.Fatalf("invalid dashboard URL should not report route_exists, got %+v", got)
+	}
+	first := routeExistenceCheckFor(context.Background(), "https://cached.example.com", nil)
+	if first == nil || first.Status != RouteExistenceUnknown {
+		t.Fatalf("local dev/no in-cluster API should be unknown, got %+v", first)
+	}
+	second := routeExistenceCheckFor(context.Background(), "https://cached.example.com", nil)
+	if second == nil || second.Status != RouteExistenceUnknown || second.CheckedAt != first.CheckedAt {
+		t.Fatalf("second check should be cached copy, first=%+v second=%+v", first, second)
+	}
+	if second == first {
+		t.Fatal("cached route check must be cloned, not the same pointer")
+	}
+}
+
+func TestInClusterAPIConfigMissingFiles(t *testing.T) {
+	oldDir, oldHost, oldPort := serviceAccountDir, kubernetesAPIHost, kubernetesAPIPort
+	serviceAccountDir = t.TempDir()
+	kubernetesAPIHost = func() string { return "10.0.0.1" }
+	kubernetesAPIPort = func() string { return "443" }
+	defer func() {
+		serviceAccountDir = oldDir
+		kubernetesAPIHost = oldHost
+		kubernetesAPIPort = oldPort
+	}()
+	if _, err := inClusterAPIConfig(); err == nil {
+		t.Fatal("missing token should make in-cluster config unknown")
+	}
+	if err := os.WriteFile(filepath.Join(serviceAccountDir, "token"), []byte("tok"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := inClusterAPIConfig(); err == nil {
+		t.Fatal("missing namespace should make in-cluster config unknown")
+	}
+}
+
 func TestURLUnreachableCriticalFlapSuppression(t *testing.T) {
 	now := time.Now()
 	oldEnough := now.Add(-urlUnreachableMinAge - time.Hour).Format(time.RFC3339)
 	stale := now.Add(-maxHeartbeatAge - time.Minute).UTC().Format(time.RFC3339)
-	s := &HubServer{urlHealth: newURLHealthState()}
+	s := newURLHealthTestHub("example.com")
 	for i := 0; i < urlUnreachableMinFailures; i++ {
 		s.urlHealth.observe("h1", urlProbeResult{Status: 503})
 	}
@@ -390,7 +594,7 @@ func TestURLUnreachableSuppressesUnassignedPlaceholders(t *testing.T) {
 	now := time.Now()
 	oldEnough := now.Add(-urlUnreachableMinAge - time.Hour).Format(time.RFC3339)
 	stale := now.Add(-maxHeartbeatAge - time.Minute).UTC().Format(time.RFC3339)
-	s := &HubServer{urlHealth: newURLHealthState()}
+	s := newURLHealthTestHub("example.com")
 	for i := 0; i < urlUnreachableMinFailures; i++ {
 		s.urlHealth.observe("ph", urlProbeResult{Status: 503})
 	}


### PR DESCRIPTION
Final top-up sync of origin/v2 into dd (1 commit behind: bf55352a — health listener + route-existence checks, #2890).

Merge auto-resolved cleanly. heartbeat.go and server.go now match origin/v2 exactly; dd-specific customizations in manager.go, contribute_ws.go, and scheduler.go are preserved untouched (not modified by the incoming v2 commit). go build + go vet clean.