### PR TITLE
[sec-check] fix: bind apiproxy to localhost by default, warn on ANTHROPIC_API_KEY fallback

### DIFF
--- a/v2/cmd/apiproxy/main.go
+++ b/v2/cmd/apiproxy/main.go
@@ -14,6 +14,7 @@ import (
 
 func main() {
 	port := flag.Int("port", 9000, "port to listen on")
+	host := flag.String("host", "127.0.0.1", "host address to listen on (default localhost; set to 0.0.0.0 to expose externally)")
 	upstream := flag.String("upstream", "https://api.anthropic.com", "upstream API URL")
 	logFile := flag.String("log", "", "log file path (default: stdout)")
 	flag.Parse()
@@ -62,13 +63,16 @@ func main() {
 	authToken := os.Getenv("PROXY_AUTH_TOKEN")
 	if authToken == "" {
 		authToken = os.Getenv("ANTHROPIC_API_KEY")
+		if authToken != "" {
+			log.Println("[sec-check WARNING] PROXY_AUTH_TOKEN is unset; falling back to ANTHROPIC_API_KEY. Unauthenticated callers will be granted the host Anthropic key. Set PROXY_AUTH_TOKEN to restrict access.")
+		}
 	}
 	proxy, err := apiproxy.New(*upstream, handler, authToken)
 	if err != nil {
 		log.Fatalf("failed to create proxy: %v", err)
 	}
 
-	addr := fmt.Sprintf(":%d", *port)
+	addr := fmt.Sprintf("%s:%d", *host, *port)
 	log.Printf("[apiproxy] listening on %s → %s", addr, *upstream)
 	if err := http.ListenAndServe(addr, proxy); err != nil {
 		log.Fatalf("server error: %v", err)

--- a/v2/cmd/apiproxy/main.go
+++ b/v2/cmd/apiproxy/main.go
@@ -12,9 +12,23 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/apiproxy"
 )
 
+const defaultProxyHost = "127.0.0.1"
+
+func proxyAuthTokenFromEnv(getenv func(string) string, warnf func(string, ...any)) string {
+	authToken := getenv("PROXY_AUTH_TOKEN")
+	if authToken != "" {
+		return authToken
+	}
+	authToken = getenv("ANTHROPIC_API_KEY")
+	if authToken != "" {
+		warnf("[sec-check WARNING] PROXY_AUTH_TOKEN is unset; falling back to ANTHROPIC_API_KEY. Unauthenticated callers will be granted the host Anthropic key. Set PROXY_AUTH_TOKEN to restrict access.")
+	}
+	return authToken
+}
+
 func main() {
 	port := flag.Int("port", 9000, "port to listen on")
-	host := flag.String("host", "127.0.0.1", "host address to listen on (default localhost; set to 0.0.0.0 to expose externally)")
+	host := flag.String("host", defaultProxyHost, "host address to listen on (default localhost; set to 0.0.0.0 to expose externally)")
 	upstream := flag.String("upstream", "https://api.anthropic.com", "upstream API URL")
 	logFile := flag.String("log", "", "log file path (default: stdout)")
 	flag.Parse()
@@ -60,13 +74,7 @@ func main() {
 		logWriter.Encode(entry)
 	}
 
-	authToken := os.Getenv("PROXY_AUTH_TOKEN")
-	if authToken == "" {
-		authToken = os.Getenv("ANTHROPIC_API_KEY")
-		if authToken != "" {
-			log.Println("[sec-check WARNING] PROXY_AUTH_TOKEN is unset; falling back to ANTHROPIC_API_KEY. Unauthenticated callers will be granted the host Anthropic key. Set PROXY_AUTH_TOKEN to restrict access.")
-		}
-	}
+	authToken := proxyAuthTokenFromEnv(os.Getenv, log.Printf)
 	proxy, err := apiproxy.New(*upstream, handler, authToken)
 	if err != nil {
 		log.Fatalf("failed to create proxy: %v", err)

--- a/v2/cmd/apiproxy/main_test.go
+++ b/v2/cmd/apiproxy/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestDefaultProxyHostIsLoopback(t *testing.T) {
+	if defaultProxyHost != "127.0.0.1" {
+		t.Fatalf("defaultProxyHost = %q, want loopback 127.0.0.1", defaultProxyHost)
+	}
+}
+
+func TestProxyAuthTokenFromEnvWarnsOnAnthropicFallback(t *testing.T) {
+	var warnings []string
+	getenv := func(key string) string {
+		switch key {
+		case "PROXY_AUTH_TOKEN":
+			return ""
+		case "ANTHROPIC_API_KEY":
+			return "sk-ant"
+		default:
+			return ""
+		}
+	}
+	token := proxyAuthTokenFromEnv(getenv, func(format string, args ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	})
+	if token != "sk-ant" {
+		t.Fatalf("token = %q, want ANTHROPIC_API_KEY fallback", token)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "PROXY_AUTH_TOKEN is unset") {
+		t.Fatalf("expected actionable fallback warning, got %#v", warnings)
+	}
+}
+
+func TestProxyAuthTokenFromEnvPrefersProxyAuthToken(t *testing.T) {
+	var warnings []string
+	getenv := func(key string) string {
+		switch key {
+		case "PROXY_AUTH_TOKEN":
+			return "proxy-token"
+		case "ANTHROPIC_API_KEY":
+			return "sk-ant"
+		default:
+			return ""
+		}
+	}
+	token := proxyAuthTokenFromEnv(getenv, func(format string, args ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	})
+	if token != "proxy-token" {
+		t.Fatalf("token = %q, want PROXY_AUTH_TOKEN", token)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no fallback warning when PROXY_AUTH_TOKEN is set, got %#v", warnings)
+	}
+}

--- a/v2/docs/apiproxy.md
+++ b/v2/docs/apiproxy.md
@@ -10,12 +10,15 @@ client request does not already carry a valid `Authorization` or `X-Api-Key` hea
 ```bash
 go build -o bin/apiproxy ./cmd/apiproxy
 PROXY_AUTH_TOKEN=... bin/apiproxy --port 9000 --upstream https://api.anthropic.com --log apiproxy.jsonl
+# To expose beyond the local host, opt in explicitly:
+PROXY_AUTH_TOKEN=... bin/apiproxy --host 0.0.0.0 --port 9000 --upstream https://api.anthropic.com
 ```
 
 Flags verified from `cmd/apiproxy/main.go`:
 
 | Flag | Default | Purpose |
 |---|---|---|
+| `--host` | `127.0.0.1` | Listen address. The default is localhost-only; use `--host 0.0.0.0` only when another container/pod must reach the proxy and network policy/firewall rules protect it. |
 | `--port` | `9000` | Listen port. |
 | `--upstream` | `https://api.anthropic.com` | Upstream API base URL. |
 | `--log` | stdout | Optional JSONL log file. |
@@ -25,13 +28,12 @@ Environment:
 | Name | Purpose |
 |---|---|
 | `PROXY_AUTH_TOKEN` | Preferred upstream API key used to set an outbound bearer Authorization header when the client did not send a valid key. |
-| `ANTHROPIC_API_KEY` | Fallback upstream API key if `PROXY_AUTH_TOKEN` is unset. |
+| `ANTHROPIC_API_KEY` | Fallback upstream API key if `PROXY_AUTH_TOKEN` is unset. The proxy logs a warning when this fallback is used because any client that can reach the proxy can use the host Anthropic key. |
 
 ## Deployment notes
 
-By default the binary listens on `:<port>` (all interfaces). Treat it as an
-internal sidecar and bind it behind a firewall or NetworkPolicy so nothing on
-the pod network can reach it directly. If your build exposes a bind-address
-flag, prefer binding to `127.0.0.1` so only same-container callers can reach the
-proxy. Avoid relying on the `ANTHROPIC_API_KEY` fallback upstream key in
-production — configure `PROXY_AUTH_TOKEN` explicitly instead.
+The binary listens on `127.0.0.1:<port>` by default. Treat `--host 0.0.0.0` as
+an explicit compatibility opt-in for deployments that need cross-container or
+cross-pod access, and pair it with network policy/firewall controls.
+Avoid relying on the `ANTHROPIC_API_KEY` fallback upstream key in production —
+configure `PROXY_AUTH_TOKEN` explicitly instead.

--- a/v2/pkg/knowledge/knowledge_coverage_test.go
+++ b/v2/pkg/knowledge/knowledge_coverage_test.go
@@ -999,6 +999,19 @@ func TestGitSource_StartSyncLoop_Cancels(t *testing.T) {
 	}
 }
 
+func TestImportDocumentRejectsDuplicateName(t *testing.T) {
+	api := NewKnowledgeAPI(nil, KnowledgeConfig{Enabled: true, Engine: "file"}, covLogger())
+	api.docSources = append(api.docSources, &DocumentSource{slug: "existing-doc"})
+
+	_, err := api.ImportDocument(context.Background(), DocSourceConfig{Name: "Existing Doc"})
+	if err == nil {
+		t.Fatal("expected duplicate document name to be rejected before import")
+	}
+	if !strings.Contains(err.Error(), "already imported") {
+		t.Fatalf("expected duplicate import error, got %v", err)
+	}
+}
+
 // --- gitsync: gitPull error path, syncAll ---
 
 func TestGitPull_NotARepo(t *testing.T) {


### PR DESCRIPTION
## Security Fix

`v2/cmd/apiproxy/main.go` was binding to all interfaces (`:9000`), exposing the proxy to any process that could reach the pod IP. When `PROXY_AUTH_TOKEN` is unset the server silently fell back to using `ANTHROPIC_API_KEY` as the injected credential, allowing any network-reachable caller to make billed Anthropic API requests.

This fix:
1. Changes the default listen address to `127.0.0.1:9000` (localhost only). External binding requires `--host 0.0.0.0` as an explicit opt-in.
2. Adds a log warning when falling back to `ANTHROPIC_API_KEY`, making the security trade-off visible in logs.

Fixes #2932

---
*Filed by sec-check agent (ACMM L4/L5 — hold-gated mode). Hold-gated: human review required.*