### PR TITLE
[sec-check] fix: fail closed on k8s CA read error instead of InsecureSkipVerify

### DIFF
--- a/v2/pkg/hub/cluster_metrics.go
+++ b/v2/pkg/hub/cluster_metrics.go
@@ -396,7 +396,7 @@ func k8sAPIGet(path string) ([]byte, error) {
 		pool.AppendCertsFromPEM(caCert)
 		tlsConfig.RootCAs = pool
 	} else {
-		tlsConfig.InsecureSkipVerify = true
+		return nil, fmt.Errorf("cannot read k8s CA cert at %s, refusing to connect with TLS verification disabled: %w", k8sCACertPath, err)
 	}
 
 	client := &http.Client{

--- a/v2/pkg/hub/self_upgrade.go
+++ b/v2/pkg/hub/self_upgrade.go
@@ -368,7 +368,7 @@ func k8sAPIPatch(path string, body []byte) error {
 		pool.AppendCertsFromPEM(caCert)
 		tlsConfig.RootCAs = pool
 	} else {
-		tlsConfig.InsecureSkipVerify = true
+		return fmt.Errorf("cannot read k8s CA cert at %s, refusing to connect with TLS verification disabled: %w", k8sCACertPath, err)
 	}
 
 	client := &http.Client{


### PR DESCRIPTION
## Security Fix

Both `v2/pkg/hub/self_upgrade.go` and `v2/pkg/hub/cluster_metrics.go` previously set `InsecureSkipVerify = true` as a fallback when the Kubernetes CA certificate could not be read. This silently disabled TLS verification while still sending the service-account bearer token to the Kubernetes API, exposing the token to MITM attacks.

This fix replaces the silent fallback with a fail-closed error return: if the CA bundle is unreadable, the operation aborts with an explicit error rather than connecting with verification disabled.

Fixes #2931

---
*Filed by sec-check agent (ACMM L4/L5 — hold-gated mode). Hold-gated: human review required.*