### PR TITLE
🐛 fix(contributor): detect ready codex pane on v2 (port of #2889)

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -459,13 +459,29 @@ function recoverWedgedShell() {
   } catch (_) {}
 }
 
-function getCLIState() {
+function capturePaneText() {
   try {
-    const output = execSync(
+    return execSync(
       `tmux capture-pane -t ${TMUX_SESSION} -p 2>/dev/null`,
       { encoding: 'utf8', timeout: 15000 }
-    );
-    const text = output.toString();
+    ).toString();
+  } catch (_) {
+    return '';
+  }
+}
+
+function blockingPromptKey(text) {
+  // codex: "Do you trust the contents of this directory?" → 1. Yes, continue
+  if (/Do you trust the contents of this directory/.test(text)) return '1';
+  // codex: "✨ Update available! x -> y" → 3. Skip until next version.
+  // Deliberately not "1. Update now", which shells out to npm install -g.
+  if (/Update available!/.test(text) && /Skip until next version/.test(text)) return '3';
+  return null;
+}
+
+function getCLIState() {
+  try {
+    const text = capturePaneText();
     if (BACKEND === 'claude') {
       if (/Not logged in|Please run \/login/.test(text)) return 'needs-login';
       if (/bypass permissions|Welcome back|Try "how does|medium.*effort|@gmail\.com|@.*\.com.*Organization/.test(text)) return 'ready';
@@ -493,7 +509,13 @@ function getCLIState() {
       // that happened to end in a '>' — including partially drawn frames.
       if (/Enter your prompt, \/ for commands|Auto-approve:|Tokens left:/.test(text)) return 'ready';
     } else if (BACKEND === 'codex') {
-      if (/codex>|>\s*$|Codex CLI/.test(text)) return 'ready';
+      // Order matters: codex can leave ready-looking banner chrome behind
+      // modal prompts, so classify those prompts before matching readiness.
+      if (/Do you trust the contents of this directory/.test(text)) return 'onboarding';
+      if (/Update available!/.test(text) && /Skip until next version/.test(text)) return 'onboarding';
+      // codex renders its input marker as '›' (U+203A), not '>', and its
+      // banner reads "OpenAI Codex (vX.Y.Z)" — not the literal "Codex CLI".
+      if (/codex>|›|OpenAI Codex|Codex CLI|>\s*$/.test(text)) return 'ready';
     } else if (BACKEND === 'pi') {
       if (/pi v\d|0\.0%|auto\)|\d+\.\d+%/.test(text)) return 'ready';
     } else if (BACKEND === 'agy') {
@@ -519,8 +541,12 @@ function waitForCLI() {
         console.log('CLI ready — accepting tasks');
         resolve();
       } else if (state === 'onboarding') {
-        console.log('Auto-dismissing trust/onboarding dialog...');
-        try { execSync(`tmux send-keys -t ${TMUX_SESSION} Enter`, { timeout: 15000 }); } catch (_) {}
+        const key = blockingPromptKey(capturePaneText());
+        console.log(key ? `Auto-dismissing trust/onboarding dialog (selecting "${key}")...` : 'Auto-dismissing trust/onboarding dialog...');
+        try {
+          if (key) execSync(`tmux send-keys -t ${TMUX_SESSION} ${key} Enter`, { timeout: 15000 });
+          else execSync(`tmux send-keys -t ${TMUX_SESSION} Enter`, { timeout: 15000 });
+        } catch (_) {}
         setTimeout(check, CLI_READY_POLL_MS);
       } else if (state === 'needs-login' && !loginMessageShown) {
         loginMessageShown = true;
@@ -838,7 +864,8 @@ function classifyTmuxPane(text) {
     hasCompletionMarker = true;
     isWorking = bobRunning && BOB_SPINNER.test(text);
   } else if (BACKEND === 'codex') {
-    hasIdlePrompt = /codex>|>\s*$/.test(text);
+    // Same marker mismatch as getCLIState(): '›' (U+203A), not '>'.
+    hasIdlePrompt = /codex>|›|>\s*$/.test(text);
     hasCompletionMarker = /completed|done|finished/i.test(text);
     isWorking = /running|executing|thinking/i.test(text);
   } else if (BACKEND === 'pi') {
@@ -1373,6 +1400,7 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     progressTick,
     classifyTmuxPane,
     paneLooksBlockedOnHuman,
+    blockingPromptKey,
     PANE_STATE_WORKING,
     PANE_STATE_BLOCKED_ON_HUMAN,
     PANE_STATE_IDLE_COMPLETE,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -1004,6 +1004,78 @@ test('interactive mode still delivers via tmux send-keys (unchanged default path
   } finally { teardown(relay); }
 });
 
+
+// Verbatim capture of a genuinely READY codex pane from a running
+// ghcr.io/kubestellar/hive-contributor container. Note what it does NOT
+// contain: no "codex>", no line ending in ">", and the banner says "OpenAI
+// Codex", not "Codex CLI". The pre-fix patterns matched none of it, so this
+// pane classified as 'starting' forever.
+const CODEX_READY_PANE = [
+  'dev@codex-contributor:~/workspace$ codex --dangerously-bypass-approvals-and-sandbox',
+  '\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e',
+  '\u2502 >_ OpenAI Codex (v0.146.0)                          \u2502',
+  '\u2502 model:       gpt-5.6-luna medium   /model to change \u2502',
+  '\u2502 directory:   ~/workspace                            \u2502',
+  '\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f',
+  '  Tip: Use /rename to rename your threads for easier thread resuming.',
+  '\u203a Run /review on my current changes',
+  '  gpt-5.6-luna medium \u00b7 ~/workspace',
+  '', '', '',
+].join('\n');
+
+const CODEX_TRUST_PANE = [
+  'dev@codex-contributor:~/workspace$ codex --dangerously-bypass-approvals-and-sandbox',
+  '> You are in /home/dev/workspace',
+  '',
+  '  Do you trust the contents of this directory? Working with untrusted contents comes with higher risk of prompt injection.',
+  '',
+  '\u203a 1. Yes, continue',
+  '  2. No, quit',
+  '',
+  '  Press enter to continue',
+  '\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e',
+  '\u2502 >_ OpenAI Codex (v0.146.0)                          \u2502',
+  '\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f',
+].join('\n');
+
+const CODEX_UPDATE_PANE = [
+  'dev@codex-contributor:~/workspace$ codex --dangerously-bypass-approvals-and-sandbox',
+  '  ✨ Update available! 0.146.0 -> 0.147.0',
+  '  Release notes: https://github.com/openai/codex/releases/latest',
+  '\u203a 1. Update now (runs `npm install -g @openai/codex`)',
+  '  2. Skip',
+  '  3. Skip until next version',
+  '  Press enter to continue',
+].join('\n');
+
+test('a ready codex pane is classified ready (regression: > vs \u203a, and "OpenAI Codex" not "Codex CLI")', () => {
+  const relay = loadRelay({ backend: 'codex', cliStates: [CODEX_READY_PANE] });
+  try {
+    assert.strictEqual(relay.getCLIState(), 'ready',
+      'codex readiness was never detected, so every task was queued and handed back at timeout — the backend could not run a single task');
+  } finally { teardown(relay); }
+});
+
+test('the modal panes still win over the ready marker they also draw', () => {
+  // Both modals render '\u203a' too; modal classification runs first, so a
+  // blocked pane must NOT be reported ready by the widened pattern.
+  for (const pane of [CODEX_TRUST_PANE, CODEX_UPDATE_PANE]) {
+    const relay = loadRelay({ backend: 'codex', cliStates: [pane] });
+    try {
+      assert.strictEqual(relay.getCLIState(), 'onboarding');
+    } finally { teardown(relay); }
+  }
+});
+
+test('codex numbered startup menus get explicit safe selections', () => {
+  const relay = loadRelay({ backend: 'codex' });
+  try {
+    assert.strictEqual(relay.blockingPromptKey(CODEX_TRUST_PANE), '1');
+    assert.strictEqual(relay.blockingPromptKey(CODEX_UPDATE_PANE), '3');
+    assert.strictEqual(relay.blockingPromptKey('Do you trust this folder? (y/n)'), null);
+  } finally { teardown(relay); }
+});
+
 // ---------------------------------------------------------------------------
 
 let failed = 0;


### PR DESCRIPTION
Port of #2889 by @hanthor to v2.

This fixes interactive codex readiness detection in the v2 contributor relay by matching the real U+203A prompt marker and the version-independent `OpenAI Codex` banner. It also keeps codex trust/update modals classified before readiness and selects safe explicit menu options so the update prompt is skipped rather than triggered.

Validation:
- `node --test bin/contributor-relay.test.js` (44/44)