### PR TITLE
🐛 fix(github): automerge sweep must not treat pending CI as green

### DIFF
--- a/v2/pkg/github/automerge_sweep.go
+++ b/v2/pkg/github/automerge_sweep.go
@@ -211,13 +211,39 @@ func parseHiveQueueReview(body string) string {
 	return matches[1]
 }
 
+// commitGreen reports whether every non-meta commit status and check run on
+// the head SHA has actually succeeded. Pending is NOT green: the sweep runs
+// every minute and a queue action usually lands seconds after the PR opens,
+// so treating in-flight CI as green would squash the PR before its first CI
+// run finishes — mergeable_state cannot catch that, because "unstable"
+// (non-required checks outstanding) deliberately maps to MergeableYes and
+// managed repos generally have no branch protection making any check
+// required. Meta gates (tide, netlify previews, ...) are excluded on both
+// surfaces — tide in particular posts a commit status that stays "pending"
+// forever on Prow-managed repos and must never wedge the queue.
 func (c *Client) commitGreen(ctx context.Context, owner, repo, sha string) (bool, string, error) {
-	status, _, err := c.client.Repositories.GetCombinedStatus(ctx, owner, repo, sha, &gh.ListOptions{PerPage: 100})
-	if err != nil {
-		return false, "status-check", err
-	}
-	if status.GetTotalCount() > 0 && (status.GetState() == "failure" || status.GetState() == "error") {
-		return false, "status-" + status.GetState(), nil
+	statusOpts := &gh.ListOptions{PerPage: 100}
+	for {
+		status, resp, err := c.client.Repositories.GetCombinedStatus(ctx, owner, repo, sha, statusOpts)
+		if err != nil {
+			return false, "status-check", err
+		}
+		for _, s := range status.Statuses {
+			if isMetaCheck(s.GetContext()) {
+				continue
+			}
+			switch s.GetState() {
+			case "success":
+			case "pending":
+				return false, "status-pending", nil
+			default: // "failure", "error"
+				return false, "status-" + s.GetState(), nil
+			}
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		statusOpts.Page = resp.NextPage
 	}
 
 	opts := &gh.ListCheckRunsOptions{ListOptions: gh.ListOptions{PerPage: 100}}
@@ -231,7 +257,7 @@ func (c *Client) commitGreen(ctx context.Context, owner, repo, sha string) (bool
 				continue
 			}
 			if cr.GetStatus() != "completed" {
-				continue
+				return false, "check-pending", nil
 			}
 			switch cr.GetConclusion() {
 			case "success", "neutral", "skipped":

--- a/v2/pkg/github/automerge_sweep_test.go
+++ b/v2/pkg/github/automerge_sweep_test.go
@@ -161,30 +161,42 @@ func TestAutoMergeSweepHelpersAndNilClient(t *testing.T) {
 }
 
 func TestCommitGreenStatusAndCheckBranches(t *testing.T) {
+	type status struct{ context, state string }
+	type check struct{ name, status, conclusion string }
 	tests := []struct {
-		name            string
-		statusState     string
-		statusTotal     int
-		checkStatus     string
-		checkConclusion string
-		wantGreen       bool
-		wantReason      string
+		name       string
+		statuses   []status
+		checks     []check
+		wantGreen  bool
+		wantReason string
 	}{
-		{name: "failure status blocks", statusState: "failure", statusTotal: 1, wantReason: "status-failure"},
-		{name: "pending status with no red checks relies on mergeable", statusState: "pending", statusTotal: 1, checkStatus: "queued", wantGreen: true},
-		{name: "check failure blocks", statusState: "success", statusTotal: 1, checkStatus: "completed", checkConclusion: "failure", wantReason: "check-failure"},
-		{name: "no statuses or checks is green after mergeable gate", statusState: "pending", statusTotal: 0, wantGreen: true},
+		{name: "failure status blocks", statuses: []status{{"ci/build", "failure"}}, wantReason: "status-failure"},
+		{name: "error status blocks", statuses: []status{{"ci/build", "error"}}, wantReason: "status-error"},
+		{name: "pending status blocks until CI completes", statuses: []status{{"ci/build", "pending"}}, wantReason: "status-pending"},
+		{name: "in-progress check blocks until CI completes", statuses: []status{{"ci/build", "success"}}, checks: []check{{"build", "in_progress", ""}}, wantReason: "check-pending"},
+		{name: "queued check blocks until CI completes", checks: []check{{"build", "queued", ""}}, wantReason: "check-pending"},
+		{name: "check failure blocks", statuses: []status{{"ci/build", "success"}}, checks: []check{{"build", "completed", "failure"}}, wantReason: "check-failure"},
+		{name: "pending meta status and check are ignored", statuses: []status{{"tide", "pending"}, {"ci/build", "success"}}, checks: []check{{"tide", "in_progress", ""}, {"build", "completed", "success"}}, wantGreen: true},
+		{name: "no statuses or checks is green after mergeable gate", wantGreen: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch {
 				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha/status":
-					json.NewEncoder(w).Encode(map[string]any{"state": tt.statusState, "total_count": tt.statusTotal})
+					statuses := []map[string]string{}
+					combined := "success"
+					for _, s := range tt.statuses {
+						statuses = append(statuses, map[string]string{"context": s.context, "state": s.state})
+						if s.state != "success" {
+							combined = s.state
+						}
+					}
+					json.NewEncoder(w).Encode(map[string]any{"state": combined, "total_count": len(statuses), "statuses": statuses})
 				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha/check-runs":
 					runs := []map[string]string{}
-					if tt.checkStatus != "" {
-						runs = append(runs, map[string]string{"name": "build", "status": tt.checkStatus, "conclusion": tt.checkConclusion})
+					for _, c := range tt.checks {
+						runs = append(runs, map[string]string{"name": c.name, "status": c.status, "conclusion": c.conclusion})
 					}
 					json.NewEncoder(w).Encode(map[string]any{"total_count": len(runs), "check_runs": runs})
 				default:
@@ -282,7 +294,7 @@ func TestTrySweepQueuedPRMissingHeadAndMergeNotApplied(t *testing.T) {
 				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7/reviews":
 					json.NewEncoder(w).Encode([]map[string]any{{"state": "COMMENTED", "body": "noise"}, {"state": "APPROVED", "body": "Approved by @bob for Hive auto-merge on green CI."}})
 				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/status":
-					json.NewEncoder(w).Encode(map[string]any{"state": "success", "total_count": 1})
+					json.NewEncoder(w).Encode(map[string]any{"state": "success", "total_count": 1, "statuses": []map[string]string{{"context": "ci/build", "state": "success"}}})
 				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/check-runs":
 					json.NewEncoder(w).Encode(map[string]any{"total_count": 1, "check_runs": []map[string]string{{"name": "build", "status": "completed", "conclusion": "success"}}})
 				case r.Method == http.MethodPut && r.URL.Path == "/repos/acme/widget/pulls/7/merge":
@@ -317,7 +329,7 @@ func TestTrySweepQueuedPRMergeError(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7/reviews":
 			json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": "Approved by @bob for Hive auto-merge on green CI."}})
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/status":
-			json.NewEncoder(w).Encode(map[string]any{"state": "success", "total_count": 1})
+			json.NewEncoder(w).Encode(map[string]any{"state": "success", "total_count": 1, "statuses": []map[string]string{{"context": "ci/build", "state": "success"}}})
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/check-runs":
 			json.NewEncoder(w).Encode(map[string]any{"total_count": 1, "check_runs": []map[string]string{{"name": "build", "status": "completed", "conclusion": "success"}}})
 		case r.Method == http.MethodPut && r.URL.Path == "/repos/acme/widget/pulls/7/merge":
@@ -439,8 +451,11 @@ func newAutoMergeSweepAPI(t *testing.T, expectedLabel string, prs []sweepPR, mer
 		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/repos/acme/widget/commits/") && strings.HasSuffix(r.URL.Path, "/status"):
 			number := shaNumber(t, r.URL.Path)
 			pr := byNumber[number]
-			total := 1
-			json.NewEncoder(w).Encode(map[string]any{"state": pr.statusState, "total_count": total})
+			json.NewEncoder(w).Encode(map[string]any{
+				"state":       pr.statusState,
+				"total_count": 1,
+				"statuses":    []map[string]string{{"context": "ci/build", "state": pr.statusState}},
+			})
 		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/repos/acme/widget/commits/") && strings.HasSuffix(r.URL.Path, "/check-runs"):
 			number := shaNumber(t, r.URL.Path)
 			pr := byNumber[number]


### PR DESCRIPTION
Follow-up to #2840 / #2858.

## Why

#2858 gave the merger-queue label its consumer, but the sweep's CI gate has a hole that defeats the feature's stated contract ("auto-merge on **green** CI"):

- `commitGreen` skipped check runs whose status was not `completed` (`queued`/`in_progress` → `continue`), so in-flight CI counted as green.
- The combined commit status was only rejected on `failure`/`error`; a `pending` combined state passed.

A queue action usually lands seconds after the PR opens, while CI is still running — and the sweep runs every minute. So in the common case the PR is squashed before its first CI run finishes.

The existing test at `TestCommitGreenStatusAndCheckBranches` named this behavior "pending status ... relies on mergeable", but `mergeableFromState` cannot catch it: `unstable` (non-required checks outstanding) deliberately maps to `MergeableYes` per the standing ignore-non-required-checks policy, and managed repos generally have no branch protection making any check required. Nothing gated on in-flight CI at all.

## What

`commitGreen` now walks **per-context** commit statuses and check runs:

- any non-meta `pending` status or `queued`/`in_progress` check run blocks the merge with skip reason `status-pending`/`check-pending` — the sweep simply retries on its next pass once CI completes;
- meta gates (`tide`, netlify previews, ...) are filtered on **both** surfaces via the existing `isMetaCheck`, so tide's perpetually-pending commit status on Prow-managed repos cannot wedge the queue;
- per-context iteration also stops a red **meta** status from vetoing an otherwise green SHA through the combined state, and the statuses list is now paginated like the check runs already were.

The distinct `*-pending` skip reasons let operators tell "waiting for CI" from "CI failed" in the sweep logs.

## Tests

- `TestCommitGreenStatusAndCheckBranches` reworked to per-context fixtures; the pending case now expects a block, plus new cases: `error` status, `queued`/`in_progress` check runs, and pending meta status+check being ignored.
- Sweep API harness and the standalone fixtures now serve realistic `statuses` arrays.

`go build ./...` and `go vet` pass locally; CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)