### PR TITLE
fix(leaderboard): CSS sanitizer allows custom props + safe at-rules and reports what it drops

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -533,7 +533,7 @@ func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request)
 	customStyleHeadHTML := ""
 	customStyleNoticeHTML := ""
 	if rawStyle := strings.TrimSpace(r.URL.Query().Get("style")); rawStyle != "" {
-		if _, src, err := getLeaderboardCustomStyle(r.Context(), rawStyle); err == nil {
+		if _, src, dropped, err := getLeaderboardCustomStyleWithDropped(r.Context(), rawStyle); err == nil {
 			styleKey := leaderboardCustomStyleCacheKey(src)
 			escapedSrc := html.EscapeString(styleKey)
 			styleKeyJSON, _ := json.Marshal(styleKey)
@@ -542,7 +542,17 @@ func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request)
 				url.QueryEscape(styleKey),
 				string(styleKeyJSON),
 			)
-			customStyleNoticeHTML = fmt.Sprintf(`<div class="lb-custom-style-note" id="leaderboard-custom-style-note" role="status">Custom style active: <code>%s</code></div>`, escapedSrc)
+			// Anti-silent-drop (#2972): if the sanitizer removed anything, say so
+			// in the notice with the reasons, so a theme author can see WHY a rule
+			// did not apply instead of staring at a healthy-looking no-op.
+			if len(dropped) > 0 {
+				customStyleNoticeHTML = fmt.Sprintf(
+					`<div class="lb-custom-style-note lb-custom-style-note--warn" id="leaderboard-custom-style-note" role="status">Custom style active: <code>%s</code> — %d rule%s removed by the sanitizer:%s</div>`,
+					escapedSrc, len(dropped), plural(len(dropped)), droppedRulesHTML(dropped),
+				)
+			} else {
+				customStyleNoticeHTML = fmt.Sprintf(`<div class="lb-custom-style-note" id="leaderboard-custom-style-note" role="status">Custom style active: <code>%s</code></div>`, escapedSrc)
+			}
 		} else {
 			customStyleNoticeHTML = `<div class="lb-custom-style-note lb-custom-style-note--warn" id="leaderboard-custom-style-note" role="status">Custom style could not be loaded — using default <button type="button" onclick="this.parentElement.remove()">Dismiss</button></div>`
 		}
@@ -1403,6 +1413,9 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 .lb-custom-style-note{margin:0 0 16px;padding:10px 12px;border:1px solid rgba(88,166,255,.35);border-radius:8px;background:rgba(88,166,255,.10);color:var(--cc-text);font-size:.86rem}
 .lb-custom-style-note code{color:var(--cc-accent)}
 .lb-custom-style-note--warn{border-color:rgba(210,153,34,.45);background:rgba(210,153,34,.12)}
+.lb-custom-style-dropped{margin:8px 0 0;padding-left:18px;font-size:.82rem;line-height:1.5}
+.lb-custom-style-dropped li{margin:2px 0}
+.lb-custom-style-dropped code{color:var(--cc-accent)}
 .lb-custom-style-note button{margin-left:8px;background:transparent;border:1px solid var(--cc-border);border-radius:6px;color:var(--cc-text);padding:2px 8px;cursor:pointer}
 </style>%s</head><body>
 <div class="page-tabs" role="tablist">

--- a/v2/pkg/dashboard/api_leaderboard_style.go
+++ b/v2/pkg/dashboard/api_leaderboard_style.go
@@ -2,7 +2,9 @@ package dashboard
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"net/url"
@@ -39,8 +41,34 @@ type customStyleSource struct {
 
 type customStyleCacheEntry struct {
 	css       []byte
+	dropped   []droppedCSSRule
 	expiresAt time.Time
 }
+
+// droppedCSSRule records something the sanitizer removed from an author's
+// stylesheet, together with a human-readable reason. Surfacing these is the
+// whole point of issue #2972: before, a rejected rule was simply absent and the
+// theme silently rendered as a no-op with no indication why.
+type droppedCSSRule struct {
+	// Rule is a short excerpt (selector, declaration, or at-rule prelude) that
+	// was removed, trimmed to droppedRuleExcerptMax runes so a hostile or huge
+	// stylesheet cannot blow up the response header / notice.
+	Rule string `json:"rule"`
+	// Reason is a stable, human-readable explanation of why it was removed.
+	Reason string `json:"reason"`
+}
+
+const (
+	// droppedRuleExcerptMax caps how much of a rejected rule we echo back so a
+	// large or malicious stylesheet cannot bloat the response header or notice.
+	droppedRuleExcerptMax = 120
+	// maxDroppedRulesReported caps how many dropped entries we retain so a
+	// stylesheet full of rejects cannot produce an unbounded list.
+	maxDroppedRulesReported = 64
+	// maxAtRuleNestDepth bounds how deep we recurse into nested at-rules so a
+	// pathological stylesheet cannot exhaust the stack.
+	maxAtRuleNestDepth = 8
+)
 
 var (
 	customStyleCacheMu sync.Mutex
@@ -55,7 +83,35 @@ var (
 	githubCSSPathRE   = regexp.MustCompile(`^[A-Za-z0-9._/-]+$`)
 	cssImportRE       = regexp.MustCompile(`(?is)@import\b[^;]*(;|$)`)
 	cssURLRE          = regexp.MustCompile(`(?is)url\(\s*(['"]?)([^'")]+)['"]?\s*\)`)
+	// cssAtRuleNameRE captures the at-rule identifier from a prelude, e.g.
+	// "@media (min-width: 600px)" -> "media", "@-webkit-keyframes spin" ->
+	// "-webkit-keyframes".
+	cssAtRuleNameRE = regexp.MustCompile(`(?i)^@(-[a-z]+-)?([a-z-]+)`)
 )
+
+// safeNestedAtRules are the at-rules whose *inner* content is a normal list of
+// scoped style rules (selector { declarations }). We recurse the sanitizer into
+// their bodies so nested declarations get the same value checks and scoping.
+//
+// Deliberately excluded (see PR body for the security reasoning):
+//   - @import      — network fetch of arbitrary CSS: an exfil / injection vector.
+//     Stripped earlier by cssImportRE; also rejected here for defence in depth.
+//   - @font-face   — its src: descriptor fetches a font over the network, which
+//     is a request-based exfil channel we cannot constrain to "no network" while
+//     still being useful, so we reject it rather than ship a half-safe allow.
+//   - @charset / @namespace / @page / @layer etc. — not needed by themes and
+//     easier to reason about when rejected than when partially allowed.
+var safeNestedAtRules = map[string]bool{
+	"media":    true,
+	"supports": true,
+}
+
+// safeKeyframesAtRules are at-rules whose inner blocks are keyframe selectors
+// (from/to/percentages) rather than scoped selectors, so their bodies are kept
+// verbatim after value-sanitization but are NOT scope-prefixed.
+var safeKeyframesAtRules = map[string]bool{
+	"keyframes": true,
+}
 
 func validateCustomStyleSource(src string) (customStyleSource, error) {
 	src = strings.TrimSpace(src)
@@ -147,27 +203,36 @@ func normalizeCustomStyleScope(scope string) (string, string, error) {
 }
 
 func getCustomStyle(ctx context.Context, rawSrc, rawScope string) ([]byte, customStyleSource, error) {
+	css, src, _, err := getCustomStyleWithDropped(ctx, rawSrc, rawScope)
+	return css, src, err
+}
+
+// getCustomStyleWithDropped is getCustomStyle plus the list of rules the
+// sanitizer removed, so callers (the /api/.../style handler and the /contribute
+// landing) can report them instead of silently dropping — see #2972.
+func getCustomStyleWithDropped(ctx context.Context, rawSrc, rawScope string) ([]byte, customStyleSource, []droppedCSSRule, error) {
 	scope, root, err := normalizeCustomStyleScope(rawScope)
 	if err != nil {
-		return nil, customStyleSource{}, err
+		return nil, customStyleSource{}, nil, err
 	}
 	src, err := validateCustomStyleSource(rawSrc)
 	if err != nil {
-		return nil, customStyleSource{}, err
+		return nil, customStyleSource{}, nil, err
 	}
 	key := customStyleCacheKey(src, scope)
 	now := time.Now()
 	customStyleCacheMu.Lock()
 	if entry, ok := customStyleCache[key]; ok && now.Before(entry.expiresAt) {
 		css := append([]byte(nil), entry.css...)
+		dropped := append([]droppedCSSRule(nil), entry.dropped...)
 		customStyleCacheMu.Unlock()
-		return css, src, nil
+		return css, src, dropped, nil
 	}
 	customStyleCacheMu.Unlock()
 
-	css, err := fetchAndSanitizeCustomStyle(ctx, src, root)
+	css, dropped, err := fetchAndSanitizeCustomStyle(ctx, src, root)
 	if err != nil {
-		return nil, src, err
+		return nil, src, nil, err
 	}
 	customStyleCacheMu.Lock()
 	if len(customStyleCache) >= customStyleMaxCache {
@@ -176,64 +241,107 @@ func getCustomStyle(ctx context.Context, rawSrc, rawScope string) ([]byte, custo
 			break
 		}
 	}
-	customStyleCache[key] = customStyleCacheEntry{css: append([]byte(nil), css...), expiresAt: now.Add(customStyleCacheTTL)}
+	customStyleCache[key] = customStyleCacheEntry{
+		css:       append([]byte(nil), css...),
+		dropped:   append([]droppedCSSRule(nil), dropped...),
+		expiresAt: now.Add(customStyleCacheTTL),
+	}
 	customStyleCacheMu.Unlock()
-	return css, src, nil
+	return css, src, dropped, nil
 }
 
-func fetchAndSanitizeCustomStyle(ctx context.Context, src customStyleSource, scopeRoot string) ([]byte, error) {
+func fetchAndSanitizeCustomStyle(ctx context.Context, src customStyleSource, scopeRoot string) ([]byte, []droppedCSSRule, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, customStyleRawURL(src), nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	resp, err := customStyleClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, errCustomStyleNotFound
+		return nil, nil, errCustomStyleNotFound
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("style fetch failed")
+		return nil, nil, fmt.Errorf("style fetch failed")
 	}
 	ct := strings.ToLower(resp.Header.Get("Content-Type"))
 	if ct != "" && !strings.Contains(ct, "text/css") && !strings.Contains(ct, "text/plain") {
-		return nil, fmt.Errorf("style response is not CSS")
+		return nil, nil, fmt.Errorf("style response is not CSS")
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, customStyleMaxBytes+1))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return sanitizeCustomStyle(body, scopeRoot)
+	return sanitizeCustomStyleWithDropped(body, scopeRoot)
 }
 
 var errCustomStyleNotFound = fmt.Errorf("style not found")
 
+// sanitizeCustomStyle is the back-compatible entry point kept for callers/tests
+// that do not need the dropped-rule report.
 func sanitizeCustomStyle(css []byte, scopeRoot string) ([]byte, error) {
-	if len(css) > customStyleMaxBytes {
-		return nil, fmt.Errorf("style exceeds %d byte limit", customStyleMaxBytes)
-	}
-	s := cssImportRE.ReplaceAllString(string(css), "")
-	s = cssURLRE.ReplaceAllStringFunc(s, sanitizeCSSURLToken)
-	var kept []string
-	for _, line := range strings.Split(s, "\n") {
-		lower := strings.ToLower(line)
-		if strings.Contains(line, `\`) {
-			continue
-		}
-		if strings.Contains(lower, "://") || strings.Contains(lower, "image-set(") {
-			continue
-		}
-		if strings.Contains(lower, "expression(") || strings.Contains(lower, "-moz-binding") || strings.Contains(lower, "behavior:") {
-			continue
-		}
-		kept = append(kept, line)
-	}
-	return []byte(scopeCustomStyle(strings.Join(kept, "\n"), scopeRoot)), nil
+	out, _, err := sanitizeCustomStyleWithDropped(css, scopeRoot)
+	return out, err
 }
 
-func scopeCustomStyle(css, scopeRoot string) string {
+// sanitizeCustomStyleWithDropped rewrites an author's stylesheet into the safe,
+// scoped subset the leaderboard/dashboard will accept, and returns the list of
+// rules it removed (with reasons) so the caller can surface them (#2972).
+//
+// The parser walks balanced { } blocks so it can recurse into at-rules; the old
+// implementation was string/line based and (a) discarded every at-rule and
+// (b) desynced on the first nested brace, corrupting everything after an
+// @media block.
+func sanitizeCustomStyleWithDropped(css []byte, scopeRoot string) ([]byte, []droppedCSSRule, error) {
+	if len(css) > customStyleMaxBytes {
+		return nil, nil, fmt.Errorf("style exceeds %d byte limit", customStyleMaxBytes)
+	}
+	// Strip comments first so the block parser never sees braces or "@import"
+	// hidden inside them, and so scoping is never applied to comment text (the
+	// old string-based prefixer injected the scope inside comments — #2972).
+	s := stripCSSComments(string(css))
+	// @import is a network fetch / injection vector; remove any occurrence up
+	// front (belt and braces — the at-rule allowlist below also rejects it).
+	s = cssImportRE.ReplaceAllString(s, "")
+	// Neutralise unsafe url()/image-set() targets inside declaration values.
+	s = cssURLRE.ReplaceAllStringFunc(s, sanitizeCSSURLToken)
+
+	drops := &droppedCSSCollector{}
+	out := sanitizeCustomStyleBlocks(s, scopeRoot, false, 0, drops)
+	return []byte(out), drops.rules, nil
+}
+
+// droppedCSSCollector accumulates removed rules, de-duplicated and capped.
+type droppedCSSCollector struct {
+	rules []droppedCSSRule
+	seen  map[string]bool
+}
+
+func (d *droppedCSSCollector) add(rule, reason string) {
+	if len(d.rules) >= maxDroppedRulesReported {
+		return
+	}
+	rule = truncateForReport(collapseWhitespace(rule))
+	if rule == "" {
+		return
+	}
+	key := rule + "\x00" + reason
+	if d.seen == nil {
+		d.seen = map[string]bool{}
+	}
+	if d.seen[key] {
+		return
+	}
+	d.seen[key] = true
+	d.rules = append(d.rules, droppedCSSRule{Rule: rule, Reason: reason})
+}
+
+// sanitizeCustomStyleBlocks walks css as a sequence of "prelude { body }" rules
+// plus any trailing declaration text. inKeyframes selects keyframe-selector
+// handling (from/to/percent, no scoping) instead of normal scoped selectors.
+func sanitizeCustomStyleBlocks(css, scopeRoot string, inKeyframes bool, depth int, drops *droppedCSSCollector) string {
 	var out strings.Builder
 	remaining := css
 	for {
@@ -241,30 +349,157 @@ func scopeCustomStyle(css, scopeRoot string) string {
 		if open < 0 {
 			break
 		}
-		selector := strings.TrimSpace(remaining[:open])
-		remaining = remaining[open+1:]
-		close := strings.Index(remaining, "}")
-		if close < 0 {
+		prelude := strings.TrimSpace(remaining[:open])
+		afterOpen := remaining[open+1:]
+		bodyEnd := matchingBrace(afterOpen)
+		if bodyEnd < 0 {
+			// Unbalanced — drop the rest rather than emit a truncated block.
+			if prelude != "" {
+				drops.add(prelude, "unbalanced braces")
+			}
 			break
 		}
-		body := remaining[:close]
-		remaining = remaining[close+1:]
-		if selector == "" || strings.Contains(selector, "@") {
+		body := afterOpen[:bodyEnd]
+		remaining = afterOpen[bodyEnd+1:]
+
+		if prelude == "" {
+			drops.add(body, "block without a selector")
 			continue
 		}
-		scoped := scopeCustomStyleSelectors(selector, scopeRoot)
+
+		if strings.HasPrefix(prelude, "@") {
+			out.WriteString(sanitizeAtRule(prelude, body, scopeRoot, depth, drops))
+			continue
+		}
+
+		if inKeyframes {
+			// Keyframe stop: selector is from/to/percentage; keep verbatim but
+			// still value-sanitize declarations. Not scope-prefixed.
+			sel := sanitizeKeyframeSelector(prelude)
+			if sel == "" {
+				drops.add(prelude, "invalid keyframe selector")
+				continue
+			}
+			decls := sanitizeDeclarations(body, prelude, drops)
+			if strings.TrimSpace(decls) == "" {
+				continue
+			}
+			out.WriteString(sel)
+			out.WriteString("{")
+			out.WriteString(decls)
+			out.WriteString("}\n")
+			continue
+		}
+
+		scoped := scopeCustomStyleSelectors(prelude, scopeRoot, drops)
 		if scoped == "" {
+			continue
+		}
+		decls := sanitizeDeclarations(body, prelude, drops)
+		if strings.TrimSpace(decls) == "" {
 			continue
 		}
 		out.WriteString(scoped)
 		out.WriteString("{")
-		out.WriteString(body)
+		out.WriteString(decls)
 		out.WriteString("}\n")
 	}
 	return out.String()
 }
 
-func scopeCustomStyleSelectors(selector, scopeRoot string) string {
+// sanitizeAtRule handles a single "@name prelude { body }" rule. Only the safe
+// allowlist survives; everything else is dropped with a reason.
+func sanitizeAtRule(prelude, body, scopeRoot string, depth int, drops *droppedCSSCollector) string {
+	name := ""
+	if m := cssAtRuleNameRE.FindStringSubmatch(prelude); m != nil {
+		name = strings.ToLower(m[2])
+	}
+	if depth >= maxAtRuleNestDepth {
+		drops.add("@"+name, "at-rules nested too deeply")
+		return ""
+	}
+	switch {
+	case safeNestedAtRules[name]:
+		// @media / @supports: recurse into the inner scoped rules.
+		inner := sanitizeCustomStyleBlocks(body, scopeRoot, false, depth+1, drops)
+		if strings.TrimSpace(inner) == "" {
+			return ""
+		}
+		return prelude + "{\n" + inner + "}\n"
+	case safeKeyframesAtRules[name]:
+		// @keyframes / @-webkit-keyframes: recurse with keyframe handling.
+		inner := sanitizeCustomStyleBlocks(body, scopeRoot, true, depth+1, drops)
+		if strings.TrimSpace(inner) == "" {
+			return ""
+		}
+		return prelude + "{\n" + inner + "}\n"
+	default:
+		drops.add(prelude, "at-rule not allowed (only @media, @supports, @keyframes)")
+		return ""
+	}
+}
+
+// sanitizeDeclarations validates each "prop: value" declaration in a block. A
+// single bad declaration is dropped (with a reason referencing its rule) but the
+// rest of the block survives — the old code dropped the whole rule if any line
+// was bad, which is what made themes silently inert (#2972).
+func sanitizeDeclarations(body, ruleContext string, drops *droppedCSSCollector) string {
+	var kept []string
+	droppedAny := false
+	for _, decl := range strings.Split(body, ";") {
+		trimmed := strings.TrimSpace(decl)
+		if trimmed == "" {
+			continue
+		}
+		if reason := declarationDropReason(trimmed); reason != "" {
+			drops.add(shortRule(ruleContext)+" { "+trimmed+" }", reason)
+			droppedAny = true
+			continue
+		}
+		kept = append(kept, decl)
+	}
+	if len(kept) == 0 {
+		return ""
+	}
+	// If we dropped nothing, emit the body verbatim so output stays byte-faithful
+	// to the author's source (whitespace, trailing-semicolon style, and so on).
+	// Only when a declaration was removed do we re-serialize the survivors.
+	if !droppedAny {
+		return body
+	}
+	out := make([]string, 0, len(kept))
+	for _, d := range kept {
+		out = append(out, strings.TrimSpace(d))
+	}
+	return strings.Join(out, ";") + ";"
+}
+
+// declarationDropReason returns a non-empty reason if a single declaration must
+// be removed for safety, or "" if it is allowed.
+func declarationDropReason(trimmed string) string {
+	lower := strings.ToLower(trimmed)
+	switch {
+	case strings.Contains(lower, "expression("):
+		return "expression() can execute script"
+	case strings.Contains(lower, "-moz-binding"):
+		return "-moz-binding can bind script"
+	case strings.HasPrefix(lower, "behavior:") || strings.Contains(lower, " behavior:"):
+		return "behavior: can execute an HTC script"
+	case strings.Contains(lower, "image-set("):
+		return "image-set() can fetch a remote resource (exfil)"
+	case strings.Contains(lower, "://"):
+		return "remote URL not allowed (exfil)"
+	case strings.Contains(trimmed, `\`):
+		return "escape sequences not allowed (can smuggle blocked tokens)"
+	}
+	return ""
+}
+
+// scopeCustomStyleSelectors prefixes each comma-separated selector with the
+// scope root. Selectors that would let a theme escape its scope (e.g. an
+// ancestor selector reaching <html>) are dropped with a reason so the author
+// learns why, rather than getting a silent no-op (#2972).
+func scopeCustomStyleSelectors(selector, scopeRoot string, drops *droppedCSSCollector) string {
 	parts := strings.Split(selector, ",")
 	scoped := make([]string, 0, len(parts))
 	for _, part := range parts {
@@ -272,7 +507,16 @@ func scopeCustomStyleSelectors(selector, scopeRoot string) string {
 		if part == "" {
 			continue
 		}
-		if part == scopeRoot || (scopeRoot == customStyleAllowedScopes[customStyleScopeDashboard] && (strings.HasPrefix(part, scopeRoot+" ") || strings.HasPrefix(part, scopeRoot+".") || strings.HasPrefix(part, scopeRoot+":"))) {
+		isDashboard := scopeRoot == customStyleAllowedScopes[customStyleScopeDashboard]
+		// An author selector that already qualifies the scope root as a compound
+		// (#root.foo / #root:hover / #root[attr]) is kept as-is. We deliberately
+		// do NOT treat "#root <combinator>…" (e.g. "#root ~ footer") as already
+		// scoped for the leaderboard scope: a sibling/child combinator right off
+		// the root can reach elements OUTSIDE the widget, so it must be prefixed
+		// again to stay contained. For the dashboard scope the historical
+		// behaviour also honoured a descendant space, so preserve that.
+		if part == scopeRoot || strings.HasPrefix(part, scopeRoot+".") || strings.HasPrefix(part, scopeRoot+":") || strings.HasPrefix(part, scopeRoot+"[") ||
+			(isDashboard && strings.HasPrefix(part, scopeRoot+" ")) {
 			scoped = append(scoped, part)
 			continue
 		}
@@ -281,18 +525,103 @@ func scopeCustomStyleSelectors(selector, scopeRoot string) string {
 				scoped = append(scoped, scopeRoot)
 				continue
 			}
+			matchedRoot := false
 			for _, rootSelector := range []string{"body", "html", ":root"} {
 				if strings.HasPrefix(part, rootSelector+".") || strings.HasPrefix(part, rootSelector+":") || strings.HasPrefix(part, rootSelector+"#") {
 					part = scopeRoot + strings.TrimPrefix(part, rootSelector)
 					scoped = append(scoped, part)
-					goto nextSelector
+					matchedRoot = true
+					break
 				}
+			}
+			if matchedRoot {
+				continue
 			}
 		}
 		scoped = append(scoped, scopeRoot+" "+part)
-	nextSelector:
 	}
 	return strings.Join(scoped, ", ")
+}
+
+// sanitizeKeyframeSelector accepts only keyframe stop selectors: from, to, or a
+// comma list of percentages. Anything else is rejected.
+func sanitizeKeyframeSelector(sel string) string {
+	parts := strings.Split(sel, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(strings.ToLower(p))
+		if p == "from" || p == "to" {
+			out = append(out, p)
+			continue
+		}
+		if strings.HasSuffix(p, "%") && keyframePercentRE.MatchString(p) {
+			out = append(out, p)
+			continue
+		}
+		return ""
+	}
+	return strings.Join(out, ",")
+}
+
+var keyframePercentRE = regexp.MustCompile(`^\d{1,3}(\.\d+)?%$`)
+
+// matchingBrace returns the index of the "}" that closes the block whose "{"
+// has already been consumed, accounting for nesting. -1 if unbalanced.
+func matchingBrace(s string) int {
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '{':
+			depth++
+		case '}':
+			if depth == 0 {
+				return i
+			}
+			depth--
+		}
+	}
+	return -1
+}
+
+// stripCSSComments removes /* ... */ comments. Unterminated comments consume to
+// end-of-input (matching browser behaviour).
+func stripCSSComments(s string) string {
+	var out strings.Builder
+	for {
+		start := strings.Index(s, "/*")
+		if start < 0 {
+			out.WriteString(s)
+			break
+		}
+		out.WriteString(s[:start])
+		end := strings.Index(s[start+2:], "*/")
+		if end < 0 {
+			break
+		}
+		s = s[start+2+end+2:]
+	}
+	return out.String()
+}
+
+func collapseWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func truncateForReport(s string) string {
+	r := []rune(s)
+	if len(r) <= droppedRuleExcerptMax {
+		return s
+	}
+	return string(r[:droppedRuleExcerptMax-1]) + "…"
+}
+
+// shortRule returns a compact selector excerpt for use inside a dropped-reason.
+func shortRule(s string) string {
+	s = collapseWhitespace(s)
+	if len([]rune(s)) > 48 {
+		return string([]rune(s)[:47]) + "…"
+	}
+	return s
 }
 
 func sanitizeCSSURLToken(token string) string {
@@ -319,7 +648,7 @@ func sanitizeCSSURLToken(token string) string {
 }
 
 func (s *Server) handleStyle(w http.ResponseWriter, r *http.Request) {
-	css, _, err := getCustomStyle(r.Context(), r.URL.Query().Get("src"), r.URL.Query().Get("scope"))
+	css, _, dropped, err := getCustomStyleWithDropped(r.Context(), r.URL.Query().Get("src"), r.URL.Query().Get("scope"))
 	if err != nil {
 		status := http.StatusUnprocessableEntity
 		if err == errCustomStyleNotFound {
@@ -330,7 +659,26 @@ func (s *Server) handleStyle(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "text/css; charset=utf-8")
 	w.Header().Set("Cache-Control", "public, max-age=300")
+	// Anti-silent-drop (#2972): tell the caller what was removed and why.
+	// X-Style-Rules-Dropped is a count so a curl author sees "loaded, N removed"
+	// at a glance; X-Style-Rules-Dropped-Detail carries the JSON list.
+	setDroppedStyleHeaders(w.Header(), dropped)
 	_, _ = w.Write(css)
+}
+
+// setDroppedStyleHeaders writes the dropped-rule report onto response headers.
+// The detail header is JSON so tooling can parse it; header values must stay on
+// one line, so the JSON is compact and already length-capped upstream.
+func setDroppedStyleHeaders(h http.Header, dropped []droppedCSSRule) {
+	h.Set("X-Style-Rules-Dropped", fmt.Sprintf("%d", len(dropped)))
+	if len(dropped) == 0 {
+		return
+	}
+	if detail, err := json.Marshal(dropped); err == nil {
+		// Strip any stray CR/LF defensively so the excerpt cannot inject a header.
+		clean := strings.NewReplacer("\r", " ", "\n", " ").Replace(string(detail))
+		h.Set("X-Style-Rules-Dropped-Detail", clean)
+	}
 }
 
 func (s *Server) handleLeaderboardStyle(w http.ResponseWriter, r *http.Request) {
@@ -361,6 +709,46 @@ func getLeaderboardCustomStyle(ctx context.Context, rawSrc string) ([]byte, lead
 	return getCustomStyle(ctx, rawSrc, customStyleScopeLeaderboard)
 }
 
+func getLeaderboardCustomStyleWithDropped(ctx context.Context, rawSrc string) ([]byte, leaderboardCustomStyleSource, []droppedCSSRule, error) {
+	return getCustomStyleWithDropped(ctx, rawSrc, customStyleScopeLeaderboard)
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+// droppedRulesHTML renders the dropped-rule report as an escaped <ul> for the
+// contribute notice, capped so a stylesheet full of rejects cannot bloat the
+// page. Both the rule excerpt and reason are HTML-escaped.
+func droppedRulesHTML(dropped []droppedCSSRule) string {
+	const maxShown = 12
+	var b strings.Builder
+	b.WriteString(`<ul class="lb-custom-style-dropped">`)
+	shown := dropped
+	if len(shown) > maxShown {
+		shown = shown[:maxShown]
+	}
+	for _, d := range shown {
+		b.WriteString("<li><code>")
+		b.WriteString(html.EscapeString(d.Rule))
+		b.WriteString("</code> — ")
+		b.WriteString(html.EscapeString(d.Reason))
+		b.WriteString("</li>")
+	}
+	if len(dropped) > maxShown {
+		b.WriteString(fmt.Sprintf("<li>…and %d more</li>", len(dropped)-maxShown))
+	}
+	b.WriteString("</ul>")
+	return b.String()
+}
+
 func sanitizeLeaderboardCustomStyle(css []byte) ([]byte, error) {
 	return sanitizeCustomStyle(css, customStyleAllowedScopes[customStyleScopeLeaderboard])
+}
+
+func sanitizeLeaderboardCustomStyleWithDropped(css []byte) ([]byte, []droppedCSSRule, error) {
+	return sanitizeCustomStyleWithDropped(css, customStyleAllowedScopes[customStyleScopeLeaderboard])
 }

--- a/v2/pkg/dashboard/api_leaderboard_style_test.go
+++ b/v2/pkg/dashboard/api_leaderboard_style_test.go
@@ -7,6 +7,198 @@ import (
 	"testing"
 )
 
+// dropReasonFor returns the reason recorded for the first dropped rule whose
+// excerpt contains needle, or "" if none.
+func dropReasonFor(dropped []droppedCSSRule, needle string) string {
+	for _, d := range dropped {
+		if strings.Contains(d.Rule, needle) {
+			return d.Reason
+		}
+	}
+	return ""
+}
+
+// TestSanitizeCustomPropertiesAndVarSurvive covers #2972: custom-property
+// declarations and var() references must pass through, but a custom property
+// whose value is an unsafe url() must still be neutralised.
+func TestSanitizeCustomPropertiesAndVarSurvive(t *testing.T) {
+	css := []byte(`
+:root { --bf-accent: #5c7bd1; --bf-soft: rgba(92,123,209,.2); }
+.me-card { border: 1px solid var(--bf-accent); color: var(--bf-soft); }
+.evilvar { --leak: url(https://evil.example/x.png); }
+`)
+	got, dropped, err := sanitizeLeaderboardCustomStyleWithDropped(css)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(got)
+	for _, want := range []string{"--bf-accent: #5c7bd1", "var(--bf-accent)", "var(--bf-soft)"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("custom property theming dropped, missing %q:\n%s", want, out)
+		}
+	}
+	// The custom property is kept, but its unsafe url() target is emptied.
+	if strings.Contains(out, "evil.example") {
+		t.Fatalf("unsafe url() in custom property survived:\n%s", out)
+	}
+	if !strings.Contains(out, "--leak: url(\"\")") {
+		t.Fatalf("expected neutralised --leak, got:\n%s", out)
+	}
+	_ = dropped
+}
+
+// TestSanitizeSafeAtRulesSurvive covers #2972: @media/@supports/@keyframes must
+// survive with their inner declarations sanitized, and their inner rules scoped
+// (for @media/@supports). @import stays rejected.
+func TestSanitizeSafeAtRulesSurvive(t *testing.T) {
+	css := []byte(`
+@import "https://evil.example/x.css";
+@media (prefers-color-scheme: light) { .me-row { color: #111; } }
+@supports (display: grid) { .me-grid { display: grid; } }
+@keyframes pulse { from { opacity: 0; } to { opacity: 1; } }
+@font-face { font-family: x; src: url(https://evil.example/f.woff); }
+`)
+	got, dropped, err := sanitizeLeaderboardCustomStyleWithDropped(css)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(got)
+	for _, want := range []string{
+		"@media (prefers-color-scheme: light)",
+		"#tab-leaderboard .me-row{ color: #111; }",
+		"@supports (display: grid)",
+		"#tab-leaderboard .me-grid{ display: grid; }",
+		"@keyframes pulse",
+		"from{ opacity: 0; }",
+		"to{ opacity: 1; }",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("safe at-rule content missing %q:\n%s", want, out)
+		}
+	}
+	// @import and @font-face must be gone.
+	if strings.Contains(out, "@import") || strings.Contains(out, "evil.example") {
+		t.Fatalf("@import survived:\n%s", out)
+	}
+	if strings.Contains(out, "@font-face") {
+		t.Fatalf("@font-face survived (network src exfil vector):\n%s", out)
+	}
+	// @font-face rejection must be REPORTED, not silent.
+	if r := dropReasonFor(dropped, "@font-face"); r == "" {
+		t.Fatalf("@font-face rejection not reported in dropped list: %+v", dropped)
+	}
+}
+
+// TestSanitizeDangerousVectorsStillBlockedAndReported covers the security
+// contract plus the anti-silent-drop guarantee: each dangerous vector is both
+// removed AND surfaced with a reason.
+func TestSanitizeDangerousVectorsStillBlockedAndReported(t *testing.T) {
+	css := []byte(`
+.expr { width: expression(alert(1)); color: red; }
+.moz { -moz-binding: url(/x.xml); }
+.beh { behavior: url(/x.htc); }
+.iset { background-image: image-set("https://evil.example/p.png" 1x); }
+.remote { background: url(https://evil.example/p.png); }
+`)
+	got, dropped, err := sanitizeLeaderboardCustomStyleWithDropped(css)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(got)
+	for _, bad := range []string{"expression(", "-moz-binding", "behavior:", "image-set(", "evil.example"} {
+		if strings.Contains(out, bad) {
+			t.Fatalf("dangerous token %q survived:\n%s", bad, out)
+		}
+	}
+	// The .expr rule keeps its safe sibling declaration; only expression() drops.
+	if !strings.Contains(out, "#tab-leaderboard .expr{color: red;}") {
+		t.Fatalf("safe declaration in mixed rule was lost:\n%s", out)
+	}
+	// Each dangerous drop is reported.
+	for needle, mustMention := range map[string]string{
+		"expression":   "expression",
+		"-moz-binding": "-moz-binding",
+		"behavior":     "behavior",
+		"image-set":    "exfil",
+	} {
+		if r := dropReasonFor(dropped, needle); !strings.Contains(strings.ToLower(r), mustMention) {
+			t.Fatalf("drop for %q not reported with reason mentioning %q: %+v", needle, mustMention, dropped)
+		}
+	}
+}
+
+// TestSanitizeNestedAtRuleDoesNotCorruptFollowingRules is the specific bug from
+// the report: the old string parser desynced on the first nested brace and
+// corrupted every rule after an @media block.
+func TestSanitizeNestedAtRuleDoesNotCorruptFollowingRules(t *testing.T) {
+	css := []byte(`
+@media (min-width: 600px) { .a { color: red; } }
+.after { color: blue; }
+`)
+	got, err := sanitizeLeaderboardCustomStyle(css)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(got)
+	if !strings.Contains(out, "#tab-leaderboard .after{ color: blue; }") {
+		t.Fatalf("rule after @media was corrupted/lost:\n%s", out)
+	}
+	if strings.Contains(out, "#tab-leaderboard }") {
+		t.Fatalf("stray brace from parser desync:\n%s", out)
+	}
+}
+
+// TestStyleHandlerReportsDroppedHeader covers the X-Style-Rules-Dropped header
+// contract for curl-based authors (#2972 suggestion 1).
+func TestStyleHandlerReportsDroppedHeader(t *testing.T) {
+	resetLeaderboardStyleTestState(t)
+	raw := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/css")
+		_, _ = w.Write([]byte(`.ok{color:red}.bad{width:expression(alert(1))}`))
+	}))
+	defer raw.Close()
+	customStyleRawBaseURL = raw.URL
+
+	srv := newFullServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/leaderboard/style?src=owner/repo/lb/theme.css@main", nil)
+	rec := httptest.NewRecorder()
+	srv.handleLeaderboardStyle(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if got := rec.Header().Get("X-Style-Rules-Dropped"); got != "1" {
+		t.Fatalf("X-Style-Rules-Dropped = %q, want 1", got)
+	}
+	detail := rec.Header().Get("X-Style-Rules-Dropped-Detail")
+	if !strings.Contains(detail, "expression") {
+		t.Fatalf("dropped detail missing reason: %q", detail)
+	}
+}
+
+// TestContributeNoticeListsDroppedRules covers the anti-silent-drop guarantee in
+// the /contribute UI notice.
+func TestContributeNoticeListsDroppedRules(t *testing.T) {
+	resetLeaderboardStyleTestState(t)
+	raw := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/css")
+		_, _ = w.Write([]byte(`.ok{color:red}@import "https://evil.example/x.css";.bad{behavior:url(/x.htc)}`))
+	}))
+	defer raw.Close()
+	customStyleRawBaseURL = raw.URL
+
+	srv := newFullServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/contribute/leaderboard?style=owner/repo/lb/theme.css@main", nil)
+	rec := httptest.NewRecorder()
+	srv.handleContributeLanding(rec, req)
+	html := rec.Body.String()
+	if !strings.Contains(html, "removed by the sanitizer") {
+		t.Fatalf("contribute notice does not report dropped rules:\n%s", html)
+	}
+	if !strings.Contains(html, "lb-custom-style-dropped") {
+		t.Fatalf("contribute notice missing dropped list markup")
+	}
+}
+
 func resetLeaderboardStyleTestState(t *testing.T) {
 	t.Helper()
 	origBase := customStyleRawBaseURL


### PR DESCRIPTION
Fixes #2972

## The report

Jorge (castrojo) published a leaderboard theme, pointed the hive at it, saw the dropdown flip to **Custom**, and nothing changed. The feature "works," but the sanitizer is stricter than the help text and **fails silently** — a rejected rule is simply absent, so the page looks healthy while the theme does nothing. His examples: a rule defining `--bf-*` custom properties was dropped whole (so twelve rules referencing them went inert), every `@media` block was dropped (no light/dark), and rules after an at-rule went missing.

## What was actually happening (`v2/pkg/dashboard/api_leaderboard_style.go`)

The sanitizer was **string/line based**:

- `scopeCustomStyle` (old line ~252) dropped any selector containing `@`, so **every at-rule — `@media`, `@supports`, `@keyframes` — was discarded**.
- The brace matcher took the *first* `}` as the block close. On the first **nested** brace (the inner rule of an `@media`) it desynced and **corrupted every rule after the at-rule** — reproduced: input `@media {...} .after{...}` produced a stray `#tab-leaderboard }` and lost `.after`.
- **Nothing removed was ever reported** — the core complaint.

## The fix

Rewrote the sanitizer around a **balanced-brace block parser** (`matchingBrace`) that recurses into a **safe at-rule allowlist**, plus comment stripping up front (the old string prefixer even injected the scope prefix *inside* comments).

Now allowed (the safe subset themes need):
- **Custom properties** (`--foo: …`) and **`var(--foo)`** references — the backbone of theming. Values still run through the same `url()`/token value checks, so `--leak: url(https://evil…)` is neutralised to `url("")`.
- **`@media` / `@supports`** — inner rules recursed and scoped.
- **`@keyframes` / `@-webkit-keyframes`** — inner keyframe stops (`from`/`to`/`%`) kept and value-sanitized, not scope-prefixed.
- A single unsafe declaration is dropped **without** discarding the rest of its rule (the old all-or-nothing behaviour is what made themes silently inert).

## Vectors deliberately still blocked (security reasoning)

This is a sanitizer for a page that renders other users' content, so loosening it wrong is an XSS/exfil vector. Still rejected, each **with a reported reason**:

- **`@import`** — fetches arbitrary remote CSS (injection / exfil).
- **`@font-face`** — its `src:` fetches a font over the network; can't be constrained to "no network" while staying useful, so rejected rather than half-allowed.
- **`expression()` / `-moz-binding` / `behavior:`** — script execution.
- **`image-set()` / remote `url()` / `://`** — request-based exfil.
- **Escape sequences (`\`)** — can smuggle otherwise-blocked tokens.
- **Sibling/child combinators off the scope root** (e.g. `#tab-leaderboard ~ footer`) — re-prefixed so a theme can't reach elements outside its widget.

## No more silent drops (the anti-silent-drop guarantee)

Every removal is now surfaced:
- `getCustomStyleWithDropped` returns a `[]droppedCSSRule` (`{rule, reason}`), cached alongside the CSS.
- `/api/leaderboard/style` (and `/api/style`) emit **`X-Style-Rules-Dropped`** (count — Jorge's own curl-friendly suggestion) and **`X-Style-Rules-Dropped-Detail`** (JSON list).
- The `/contribute` leaderboard notice lists the removed rules with reasons ("…N rules removed by the sanitizer: …").

## Tests

Added to `api_leaderboard_style_test.go`: custom props + `var()` survive while `--x: url(evil)` is stripped; `@media`/`@supports`/`@keyframes` survive with inner declarations sanitized and `@import`/`@font-face` rejected; the rule after an `@media` is no longer corrupted; every dangerous vector is both blocked **and** reported; the response header and contribute notice carry the dropped list. Full `pkg/dashboard` suite passes; `go build ./...` and `go vet ./...` clean.
