### PR TITLE
🐛 fix(contribute): ready-work queue row menu no longer clipped by scroll container

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -1099,15 +1099,11 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 .cc-q-menu-wrap{position:relative;flex-shrink:0;margin-left:auto;align-self:center}
 .cc-q-menu-btn{background:none;border:none;color:var(--cc-muted-2);cursor:pointer;font-size:1rem;line-height:1;padding:4px 6px;border-radius:6px}
 .cc-q-menu-btn:hover,.cc-q-menu-btn[aria-expanded=true]{color:var(--cc-text);background:var(--cc-border-2)}
-.cc-q-menu{position:absolute;top:100%%;right:0;z-index:40;min-width:190px;background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:10px;box-shadow:0 8px 28px rgba(1,4,9,.55);padding:6px;display:none}
+.cc-q-menu{position:fixed;top:0;left:0;right:auto;bottom:auto;z-index:10002;min-width:190px;background:var(--cc-surface);border:1px solid var(--cc-border);border-radius:10px;box-shadow:0 8px 28px rgba(1,4,9,.55);padding:6px;display:none}
 .cc-q-menu.open{display:block}
-/* Flip-up variant: for rows near the BOTTOM of the scrolling .cc-queue, the
-   default drop-down menu (top:100%%) would extend past the container's overflow
-   boundary and get clipped ("Optional hold reason" cut off). ccBindQueueMenus
-   measures on open and adds .cc-q-menu-up when there is more room above than
-   below, anchoring the menu to the button's TOP so it opens upward and stays
-   inside the visible card. */
-.cc-q-menu.cc-q-menu-up{top:auto;bottom:100%%}
+/* Fixed-positioned so the per-row menu escapes the scrolling .cc-queue overflow
+   clip; ccBindQueueMenus measures the trigger and flips/clamps inside the viewport
+   (and visible queue panel) before paint. */
 .cc-q-menu button.cc-q-act{display:flex;align-items:center;gap:8px;width:100%%;background:none;border:none;color:var(--cc-text-2);font:inherit;font-size:.82rem;text-align:left;padding:7px 9px;border-radius:6px;cursor:pointer}
 .cc-q-menu button.cc-q-act:hover{background:var(--cc-border-2);color:var(--cc-text)}
 .cc-q-menu-ic{color:var(--cc-muted-2);flex-shrink:0;width:16px;text-align:center}
@@ -2837,13 +2833,17 @@ function _wireCooldownInfo(){
   var btn=document.getElementById('cooldown-info-btn');
   var pop=document.getElementById('cooldown-info-pop');
   if(!btn||!pop)return;
+  function place(){if(!pop.hidden)ccPlaceFixedPopover(btn,pop,{fallbackWidth:300,boundary:btn.closest('.ops-card')});}
   function close(){pop.hidden=true;btn.setAttribute('aria-expanded','false');}
   btn.addEventListener('click',function(e){
     e.stopPropagation();
     var open=pop.hidden;
-    pop.hidden=!open;
-    btn.setAttribute('aria-expanded',open?'true':'false');
+    if(open){pop.hidden=false;btn.setAttribute('aria-expanded','true');place();}
+    else close();
   });
+  pop.addEventListener('click',function(e){e.stopPropagation();});
+  window.addEventListener('resize',place);
+  window.addEventListener('scroll',place,true);
   document.addEventListener('click',function(e){if(!pop.hidden&&e.target!==btn&&!pop.contains(e.target))close();});
   document.addEventListener('keydown',function(e){if(e.key==='Escape')close();});
 }
@@ -2856,17 +2856,58 @@ function _wireAffinityInfo(){
   var btn=document.getElementById('affinity-info-btn');
   var pop=document.getElementById('affinity-info-pop');
   if(!btn||!pop)return;
+  function place(){if(!pop.hidden)ccPlaceFixedPopover(btn,pop,{fallbackWidth:300,boundary:btn.closest('.ops-card')});}
   function close(){pop.hidden=true;btn.setAttribute('aria-expanded','false');}
   btn.addEventListener('click',function(e){
     e.stopPropagation();
     var open=pop.hidden;
-    pop.hidden=!open;
-    btn.setAttribute('aria-expanded',open?'true':'false');
+    if(open){pop.hidden=false;btn.setAttribute('aria-expanded','true');place();}
+    else close();
   });
+  pop.addEventListener('click',function(e){e.stopPropagation();});
+  window.addEventListener('resize',place);
+  window.addEventListener('scroll',place,true);
   document.addEventListener('click',function(e){if(!pop.hidden&&e.target!==btn&&!pop.contains(e.target))close();});
   document.addEventListener('keydown',function(e){if(e.key==='Escape')close();});
 }
 if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',_wireAffinityInfo);else _wireAffinityInfo();
+
+// ccPlaceFixedPopover places an already-visible popover/menu using viewport
+// coordinates so it is not clipped by card/queue overflow. It prefers below the
+// trigger, flips above when needed, and clamps inside the viewport plus an optional
+// boundary element (for example the visible .cc-queue panel).
+function ccPlaceFixedPopover(anchor,pop,opts){
+  opts=opts||{};
+  var edge=opts.edge||8,gap=opts.gap||8;
+  pop.style.position='fixed';
+  pop.style.left='0px';
+  pop.style.top='0px';
+  pop.style.right='auto';
+  pop.style.bottom='auto';
+  var b=anchor.getBoundingClientRect();
+  var vw=document.documentElement.clientWidth||window.innerWidth||0;
+  var vh=document.documentElement.clientHeight||window.innerHeight||0;
+  var r=pop.getBoundingClientRect();
+  var w=r.width||pop.offsetWidth||opts.fallbackWidth||320;
+  var h=r.height||pop.offsetHeight||opts.fallbackHeight||0;
+  var minTop=edge,maxBottom=vh-edge;
+  if(opts.boundary&&opts.boundary.getBoundingClientRect){
+    var cb=opts.boundary.getBoundingClientRect();
+    minTop=Math.max(minTop,cb.top+edge);
+    maxBottom=Math.min(maxBottom,cb.bottom-edge);
+  }
+  if(maxBottom<=minTop){minTop=edge;maxBottom=vh-edge;}
+  var rawLeft=(opts.align==='right')?(b.right-w):b.left;
+  var maxLeft=Math.max(edge,vw-w-edge);
+  var left=Math.min(Math.max(rawLeft,edge),maxLeft);
+  var below=maxBottom-b.bottom-gap;
+  var above=b.top-gap-minTop;
+  var top=(below>=h||below>=above)?(b.bottom+gap):(b.top-gap-h);
+  var maxTop=Math.max(minTop,maxBottom-h);
+  top=Math.min(Math.max(top,minTop),maxTop);
+  pop.style.left=left+'px';
+  pop.style.top=top+'px';
+}
 
 // _wireCustomCSSInfo toggles the compact custom-stylesheet help next to the
 // Leaderboard/Profile style picker. The element is rendered with the Me card, so
@@ -2878,25 +2919,7 @@ function _wireCustomCSSInfo(){
   btn.setAttribute('data-wired','1');
   function place(){
     if(pop.hidden)return;
-    pop.style.position='fixed';
-    pop.style.left='0px';
-    pop.style.top='0px';
-    pop.style.right='auto';
-    pop.style.bottom='auto';
-    var edge=8,gap=8;
-    var b=btn.getBoundingClientRect();
-    var vw=document.documentElement.clientWidth||window.innerWidth||0;
-    var vh=document.documentElement.clientHeight||window.innerHeight||0;
-    var r=pop.getBoundingClientRect();
-    var w=r.width||pop.offsetWidth||320;
-    var h=r.height||pop.offsetHeight||0;
-    var maxLeft=Math.max(edge,vw-w-edge);
-    var left=Math.min(Math.max(b.left,edge),maxLeft);
-    var below=vh-b.bottom-gap;
-    var above=b.top-gap;
-    var top=(below>=h||below>=above)?Math.min(b.bottom+gap,vh-h-edge):Math.max(edge,b.top-gap-h);
-    pop.style.left=left+'px';
-    pop.style.top=top+'px';
+    ccPlaceFixedPopover(btn,pop,{fallbackWidth:320});
   }
   function close(){pop.hidden=true;btn.setAttribute('aria-expanded','false');}
   btn.addEventListener('click',function(e){
@@ -4083,7 +4106,7 @@ function ccUpdateFilterNote(shown,total){
 // in the FULL ccQueue regardless of any active search filter.
 function ccCloseQueueMenus(){
   var open=document.querySelectorAll('.cc-q-menu.open');
-  for(var i=0;i<open.length;i++){open[i].classList.remove('open');open[i].classList.remove('cc-q-menu-up');}
+  for(var i=0;i<open.length;i++){open[i].classList.remove('open');}
   var btns=document.querySelectorAll('.cc-q-menu-btn[aria-expanded=true]');
   for(var j=0;j<btns.length;j++)btns[j].setAttribute('aria-expanded','false');
   // No-blink guard companion: a poll re-render that arrived while a menu was open was
@@ -4110,23 +4133,11 @@ function ccBindQueueMenus(root){
       var isOpen=menu.classList.contains('open');
       ccCloseQueueMenus();
       if(!isOpen){
-        // Decide direction BEFORE it paints so it never flashes clipped: if the
-        // menu (once shown) would extend past the bottom of the scrolling
-        // .cc-queue container, flip it to open upward. Compare the button's
-        // position to the container's viewport box, not the window, so it tracks
-        // the actual clip boundary (the queue's overflow-y:auto edge).
-        menu.classList.remove('cc-q-menu-up');
+        // Position with viewport coordinates BEFORE it paints so the menu escapes
+        // the scrolling .cc-queue overflow clip and flips/clamps when near the
+        // viewport or visible queue-panel bottom.
         menu.classList.add('open');
-        var clip=btn.closest('.cc-queue');
-        if(clip){
-          var bBot=btn.getBoundingClientRect().bottom;
-          var cBox=clip.getBoundingClientRect();
-          var menuH=menu.offsetHeight||220; // measured now that it is display:block
-          // Flip up when there isn't room below within the clip AND there is more room above.
-          if(bBot+menuH>cBox.bottom && (btn.getBoundingClientRect().top-cBox.top)>(cBox.bottom-bBot)){
-            menu.classList.add('cc-q-menu-up');
-          }
-        }
+        ccPlaceFixedPopover(btn,menu,{align:'right',gap:6,fallbackWidth:220,fallbackHeight:220,boundary:btn.closest('.cc-queue')});
         btn.setAttribute('aria-expanded','true');
       }
     });
@@ -4892,6 +4903,8 @@ function ccRenderMeQuota(){
 // ── Global menu-dismiss: click outside or Escape closes any open row menu ───────
 document.addEventListener('click',function(){ccCloseQueueMenus();});
 document.addEventListener('keydown',function(e){if(e.key==='Escape')ccCloseQueueMenus();});
+window.addEventListener('resize',function(){ccCloseQueueMenus();});
+window.addEventListener('scroll',function(){ccCloseQueueMenus();},true);
 })();
 </script>
 <script>

--- a/v2/pkg/dashboard/contribute_cooldown_explainer_test.go
+++ b/v2/pkg/dashboard/contribute_cooldown_explainer_test.go
@@ -61,6 +61,7 @@ func TestCooldownInfoButtonAndExplainer(t *testing.T) {
 		`aria-controls="cooldown-info-pop"`,
 		// The wiring that toggles the popover.
 		`function _wireCooldownInfo(`,
+		`ccPlaceFixedPopover(btn,pop,{fallbackWidth:300,boundary:btn.closest('.ops-card')});`,
 		// Explainer substance: what cooldown is + how an issue enters it.
 		`out of the ready queue`,
 		`verified PR`,

--- a/v2/pkg/dashboard/contribute_ops_queue_norefresh_test.go
+++ b/v2/pkg/dashboard/contribute_ops_queue_norefresh_test.go
@@ -81,6 +81,7 @@ func TestOwnerLabelAffinityRoster(t *testing.T) {
 		`aria-controls="affinity-info-pop"`,
 		`class="info-btn"`,
 		`function _wireAffinityInfo(`,
+		`ccPlaceFixedPopover(btn,pop,{fallbackWidth:300,boundary:btn.closest('.ops-card')});`,
 		// The explainer copy called out in the issue.
 		`Contributors subscribe to labels`,
 		`a soft hint, nothing is hidden`,

--- a/v2/pkg/dashboard/contribute_queue_menu_flip_test.go
+++ b/v2/pkg/dashboard/contribute_queue_menu_flip_test.go
@@ -5,29 +5,35 @@ import (
 	"testing"
 )
 
-// TestContributeQueueMenuFlipsUp guards the fix for the ready-work queue's per-row
-// "⋯" menu being clipped by the .cc-queue scroll container (overflow-y:auto) when a
-// row near the BOTTOM opens its menu — the operator reported the move/hold menu was
-// "behind the scroll borders" ("Optional hold reason" cut off). The fix: a
-// .cc-q-menu-up variant anchored to bottom:100%, applied by the open handler when
-// the menu would extend past the container's clip boundary.
-func TestContributeQueueMenuFlipsUp(t *testing.T) {
+// TestContributeQueueMenuUsesFixedViewportPlacement guards the fix for the
+// ready-work queue's per-row "⋯" menu being clipped by the .cc-queue scroll
+// container (overflow-y:auto) when a row near the BOTTOM opens its menu — the
+// operator reported the move/hold/move-to menu was "behind the scroll area". The
+// fix: fixed-position viewport placement shared with the custom-CSS popover, using
+// the queue panel as a boundary for flip/clamp decisions.
+func TestContributeQueueMenuUsesFixedViewportPlacement(t *testing.T) {
 	body := renderContributePage(t)
 	mustContain := []string{
-		// The flip-up CSS variant exists and anchors upward.
-		".cc-q-menu.cc-q-menu-up{top:auto;bottom:100%",
-		// The open handler measures against the scrolling .cc-queue clip box.
-		"btn.closest('.cc-queue')",
-		// ...and applies the up-variant class when there's no room below.
-		"menu.classList.add('cc-q-menu-up')",
+		// The queue menu itself escapes the scrolling clip.
+		".cc-q-menu{position:fixed",
+		// The shared helper places fixed popovers by measuring trigger geometry.
+		"function ccPlaceFixedPopover(anchor,pop,opts)",
+		"anchor.getBoundingClientRect()",
+		// The open handler clamps/flips against the visible scrolling queue panel.
+		"ccPlaceFixedPopover(btn,menu,{align:'right',gap:6",
+		"boundary:btn.closest('.cc-queue')",
+		// Scroll/resize invalidates viewport positioning and closes the open menu.
+		"window.addEventListener('resize',function(){ccCloseQueueMenus();});",
+		"window.addEventListener('scroll',function(){ccCloseQueueMenus();},true);",
 	}
 	for _, s := range mustContain {
 		if !strings.Contains(body, s) {
 			t.Errorf("contribute page missing queue-menu flip-up snippet %q", s)
 		}
 	}
-	// Closing a menu must also clear the up-variant so a reopened row isn't stuck flipped.
-	if !strings.Contains(body, "classList.remove('cc-q-menu-up')") {
-		t.Errorf("ccCloseQueueMenus must clear cc-q-menu-up on close")
+	// The old absolute-positioned flip class stayed inside the overflow clip and
+	// cannot fix the reported bug; keep it out so regressions are obvious.
+	if strings.Contains(body, "cc-q-menu-up") {
+		t.Errorf("queue menu should use fixed viewport placement, not cc-q-menu-up")
 	}
 }


### PR DESCRIPTION
## Summary
- move the ready-work queue row menu to shared fixed-position viewport placement so it escapes the scroll container
- flip/clamp against the viewport and visible queue panel; close queue menus on scroll/resize
- reuse the helper for nearby ops-card info popovers that shared the same overflow-hidden card risk

## Validation
- cd v2 && go build ./...
- cd v2 && go test ./pkg/dashboard/ -run Contribute -count=1